### PR TITLE
sql: Add initial support for window functions

### DIFF
--- a/sql/create.go
+++ b/sql/create.go
@@ -1032,8 +1032,8 @@ func makeCheckConstraint(
 	}
 
 	var p parser.Parser
-	if p.AggregateInExpr(expr) {
-		return nil, fmt.Errorf("aggregate functions are not allowed in CHECK expressions")
+	if err := p.AssertNoAggregationOrWindowing(expr, "CHECK expressions"); err != nil {
+		return nil, err
 	}
 
 	if err := sqlbase.SanitizeVarFreeExpr(expr, parser.TypeBool, "CHECK"); err != nil {

--- a/sql/limit.go
+++ b/sql/limit.go
@@ -59,8 +59,8 @@ func (p *planner) Limit(n *parser.Limit) (*limitNode, error) {
 
 	for _, datum := range data {
 		if datum.src != nil {
-			if p.parser.AggregateInExpr(datum.src) {
-				return nil, fmt.Errorf("aggregate functions are not allowed in %s", datum.name)
+			if err := p.parser.AssertNoAggregationOrWindowing(datum.src, datum.name); err != nil {
+				return nil, err
 			}
 
 			normalized, err := p.analyzeExpr(datum.src, nil, nil, parser.TypeInt, true, datum.name)

--- a/sql/parser/normalize.go
+++ b/sql/parser/normalize.go
@@ -629,7 +629,7 @@ func (v *isConstVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 
 		switch t := expr.(type) {
 		case *FuncExpr:
-			if t.fn.impure {
+			if t.IsImpure() {
 				v.isConst = false
 				return false, expr
 			}

--- a/sql/parser/normalize_test.go
+++ b/sql/parser/normalize_test.go
@@ -111,6 +111,7 @@ func TestNormalizeExpr(t *testing.T) {
 		{`a/2=1`, `a = 2`},
 		{`1=a/2`, `a = 2`},
 		{`s=lower('FOO')`, `s = 'foo'`},
+		{`s=lower('FOO') OVER ()`, `s = lower('FOO') OVER ()`},
 		{`lower(s)='foo'`, `lower(s) = 'foo'`},
 		{`random()`, `random()`},
 		{`9223372036854775808`, `9223372036854775808`},

--- a/sql/parser/parse.go
+++ b/sql/parser/parse.go
@@ -59,10 +59,11 @@ const (
 // Parser wraps a scanner, parser and other utilities present in the parser
 // package.
 type Parser struct {
-	scanner            Scanner
-	parserImpl         sqlParserImpl
-	normalizeVisitor   normalizeVisitor
-	isAggregateVisitor IsAggregateVisitor
+	scanner               Scanner
+	parserImpl            sqlParserImpl
+	normalizeVisitor      normalizeVisitor
+	isAggregateVisitor    IsAggregateVisitor
+	containsWindowVisitor ContainsWindowVisitor
 }
 
 // Parse parses the sql and returns a list of statements.

--- a/sql/parser/parse_test.go
+++ b/sql/parser/parse_test.go
@@ -392,6 +392,22 @@ func TestParse(t *testing.T) {
 
 		{`SELECT a FROM t HAVING a = b`},
 
+		{`SELECT a FROM t WINDOW w AS ()`},
+		{`SELECT a FROM t WINDOW w AS (w2)`},
+		{`SELECT a FROM t WINDOW w AS (PARTITION BY b)`},
+		{`SELECT a FROM t WINDOW w AS (PARTITION BY b, 1 + 2)`},
+		{`SELECT a FROM t WINDOW w AS (ORDER BY c)`},
+		{`SELECT a FROM t WINDOW w AS (ORDER BY c, 1 + 2)`},
+		{`SELECT a FROM t WINDOW w AS (PARTITION BY b ORDER BY c)`},
+
+		{`SELECT avg(1) OVER w FROM t`},
+		{`SELECT avg(1) OVER () FROM t`},
+		{`SELECT avg(1) OVER (w) FROM t`},
+		{`SELECT avg(1) OVER (PARTITION BY b) FROM t`},
+		{`SELECT avg(1) OVER (ORDER BY c) FROM t`},
+		{`SELECT avg(1) OVER (PARTITION BY b ORDER BY c) FROM t`},
+		{`SELECT avg(1) OVER (w PARTITION BY b ORDER BY c) FROM t`},
+
 		{`SELECT a FROM t UNION SELECT 1 FROM t`},
 		{`SELECT a FROM t UNION SELECT 1 FROM t UNION SELECT 1 FROM t`},
 		{`SELECT a FROM t UNION ALL SELECT 1 FROM t`},

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -290,8 +290,14 @@ func (u *sqlSymUnion) dropBehavior() DropBehavior {
 func (u *sqlSymUnion) interleave() *InterleaveDef {
 	return u.val.(*InterleaveDef)
 }
+func (u *sqlSymUnion) windowDef() *WindowDef {
+	return u.val.(*WindowDef)
+}
+func (u *sqlSymUnion) window() Window {
+	return u.val.(Window)
+}
 
-//line sql.y:309
+//line sql.y:315
 type sqlSymType struct {
 	yys   int
 	id    int
@@ -897,7 +903,7 @@ const sqlEofCode = 1
 const sqlErrCode = 2
 const sqlInitialStackSize = 16
 
-//line sql.y:4736
+//line sql.y:4789
 
 //line yacctab:1
 var sqlExca = [...]int{
@@ -1464,8 +1470,8 @@ var sqlAct = [...]int{
 	69, 1136, 1548, 1024, 1023, 63, 1286, 69, 69, 69,
 	1025, 680, 58, 1650, 1504, 1581, 1582, 1564, 59, 1270,
 	1561, 302, 303, 264, 1026, 888, 308, 71, 71, 1687,
-	783, 259, 702, 702, 788, 422, 1656, 242, 1812, 71,
-	71, 1335, 69, 71, 1738, 1545, 1720, 1597, 1620, 745,
+	783, 259, 702, 702, 788, 422, 1812, 242, 1656, 71,
+	71, 1335, 69, 71, 1720, 1545, 1738, 1597, 1620, 745,
 	1602, 745, 71, 71, 1614, 1613, 1555, 1615, 1601, 1614,
 	1613, 1617, 1615, 1140, 893, 32, 267, 1611, 1618, 725,
 	482, 283, 1566, 745, 283, 283, 283, 283, 283, 796,
@@ -3958,8 +3964,8 @@ var sqlPgo = [...]int{
 	1529, 136, 126, 17, 1527, 106, 1526, 87, 1523, 0,
 	107, 101, 1521, 121, 69, 1519, 1517, 1510, 1502, 24,
 	2, 10, 6, 7, 4, 30, 29, 1500, 1497, 123,
-	84, 1495, 142, 1494, 1493, 33, 1476, 1474, 15, 1471,
-	13, 1468, 11, 1, 1466, 133, 1465, 88, 1464, 1358,
+	84, 1495, 142, 1494, 1493, 1476, 33, 1474, 15, 1471,
+	13, 1468, 1466, 11, 1, 133, 1465, 88, 1464, 1358,
 	1461, 137, 1459, 1456, 1402, 79,
 }
 var sqlR1 = [...]int{
@@ -4031,9 +4037,9 @@ var sqlR1 = [...]int{
 	216, 216, 216, 216, 216, 216, 216, 216, 216, 216,
 	216, 216, 216, 216, 216, 216, 216, 216, 216, 216,
 	216, 216, 216, 216, 216, 216, 223, 223, 224, 224,
-	225, 225, 226, 226, 228, 229, 229, 229, 230, 234,
-	234, 227, 227, 231, 231, 231, 232, 232, 233, 233,
-	233, 233, 233, 147, 147, 147, 148, 148, 149, 83,
+	226, 226, 227, 227, 228, 229, 229, 229, 230, 231,
+	231, 225, 225, 232, 232, 232, 233, 233, 234, 234,
+	234, 234, 234, 147, 147, 147, 148, 148, 149, 83,
 	83, 144, 144, 143, 143, 143, 146, 146, 100, 187,
 	187, 187, 187, 187, 187, 187, 101, 101, 108, 102,
 	102, 103, 103, 103, 103, 103, 103, 139, 140, 104,
@@ -4346,18 +4352,18 @@ var sqlChk = [...]int{
 	-48, -55, -48, -48, 300, 300, -48, -85, -117, 299,
 	176, -24, -95, 284, 298, 298, 300, 126, -72, -160,
 	-48, -218, 299, -215, -216, -53, 299, -73, -63, -24,
-	-72, 176, -225, 273, -135, -83, 239, -161, -161, -98,
+	-72, 176, -226, 273, -135, -83, 239, -161, -161, -98,
 	263, 176, 142, -161, -134, -133, 111, 165, 299, -73,
 	-157, 26, 26, -135, -144, 300, -135, -135, 300, -135,
-	5, -135, 300, 300, 300, -135, -234, -48, -135, 300,
+	5, -135, 300, 300, 300, -135, -231, -48, -135, 300,
 	300, 300, -140, 113, 89, 173, 299, -135, 300, 300,
-	303, 300, 300, 300, -225, -126, -48, -81, -48, 103,
+	303, 300, 300, 300, -226, -126, -48, -81, -48, 103,
 	123, 169, 143, 299, -136, -55, -125, -242, 65, 236,
 	300, 300, 169, 169, -135, -170, -43, -43, 247, 247,
 	90, -73, 62, -91, -34, 299, 186, 300, 303, -54,
 	-89, 54, -54, -135, 299, -72, 300, 300, 300, -55,
-	-226, -228, -48, 244, -98, 299, -135, -161, 303, 306,
-	284, -73, 300, -135, -135, 300, 300, -70, -227, 188,
+	-227, -228, -48, 244, -98, 299, -135, -161, 303, 306,
+	284, -73, 300, -135, -135, 300, 300, -70, -225, 188,
 	300, -136, 113, 299, -144, 300, -135, -209, -49, 167,
 	-135, -50, 299, -65, 299, 201, -42, 54, -48, -48,
 	260, 168, 300, -48, -48, -125, -160, -39, -81, -39,
@@ -4365,13 +4371,13 @@ var sqlChk = [...]int{
 	-133, -193, 300, 300, -70, 43, -136, -144, 300, 300,
 	98, 300, -212, 157, -48, -73, -55, -37, 263, -81,
 	222, -128, 299, -65, -54, -70, -125, -65, -72, -228,
-	-230, 300, -231, 196, 212, -83, 300, 103, -210, -213,
+	-230, 300, -232, 196, 212, -83, 300, 103, -210, -213,
 	-211, 176, 114, 187, 225, 300, 300, -68, 299, -135,
-	-86, -73, -39, 300, -65, 300, 300, -232, -233, 35,
-	255, 69, -135, -232, -48, -211, 176, -213, 176, 260,
-	87, -212, -73, -128, 300, -125, -233, 191, 109, 211,
+	-86, -73, -39, 300, -65, 300, 300, -233, -234, 35,
+	255, 69, -135, -233, -48, -211, 176, -213, 176, 260,
+	87, -212, -73, -128, 300, -125, -234, 191, 109, 211,
 	191, 109, -214, 164, 205, 46, 222, -214, -210, 300,
-	-44, 46, 205, -65, 26, 20, 169, 84, -233,
+	-44, 46, 205, -65, 26, 20, 169, 84, -234,
 }
 var sqlDef = [...]int{
 
@@ -4957,13 +4963,13 @@ sqldefault:
 
 	case 1:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:715
+		//line sql.y:722
 		{
 			sqllex.(*Scanner).stmts = sqlDollar[1].union.stmts()
 		}
 	case 2:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:721
+		//line sql.y:728
 		{
 			if sqlDollar[3].union.stmt() != nil {
 				sqlVAL.union.val = append(sqlDollar[1].union.stmts(), sqlDollar[3].union.stmt())
@@ -4971,7 +4977,7 @@ sqldefault:
 		}
 	case 3:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:727
+		//line sql.y:734
 		{
 			if sqlDollar[1].union.stmt() != nil {
 				sqlVAL.union.val = []Statement{sqlDollar[1].union.stmt()}
@@ -4981,91 +4987,91 @@ sqldefault:
 		}
 	case 18:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:751
+		//line sql.y:758
 		{
 			sqlVAL.union.val = sqlDollar[1].union.slct()
 		}
 	case 26:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:762
+		//line sql.y:769
 		{
 			sqlVAL.union.val = Statement(nil)
 		}
 	case 27:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:768
+		//line sql.y:775
 		{
 			sqlVAL.union.val = &AlterTable{Table: sqlDollar[3].union.normalizableTableName(), IfExists: false, Cmds: sqlDollar[4].union.alterTableCmds()}
 		}
 	case 28:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:772
+		//line sql.y:779
 		{
 			sqlVAL.union.val = &AlterTable{Table: sqlDollar[5].union.normalizableTableName(), IfExists: true, Cmds: sqlDollar[6].union.alterTableCmds()}
 		}
 	case 29:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:778
+		//line sql.y:785
 		{
 			sqlVAL.union.val = AlterTableCmds{sqlDollar[1].union.alterTableCmd()}
 		}
 	case 30:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:782
+		//line sql.y:789
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.alterTableCmds(), sqlDollar[3].union.alterTableCmd())
 		}
 	case 31:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:789
+		//line sql.y:796
 		{
 			sqlVAL.union.val = &AlterTableAddColumn{columnKeyword: false, IfNotExists: false, ColumnDef: sqlDollar[2].union.colDef()}
 		}
 	case 32:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:794
+		//line sql.y:801
 		{
 			sqlVAL.union.val = &AlterTableAddColumn{columnKeyword: false, IfNotExists: true, ColumnDef: sqlDollar[5].union.colDef()}
 		}
 	case 33:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:799
+		//line sql.y:806
 		{
 			sqlVAL.union.val = &AlterTableAddColumn{columnKeyword: true, IfNotExists: false, ColumnDef: sqlDollar[3].union.colDef()}
 		}
 	case 34:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:804
+		//line sql.y:811
 		{
 			sqlVAL.union.val = &AlterTableAddColumn{columnKeyword: true, IfNotExists: true, ColumnDef: sqlDollar[6].union.colDef()}
 		}
 	case 35:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:809
+		//line sql.y:816
 		{
 			sqlVAL.union.val = &AlterTableSetDefault{columnKeyword: sqlDollar[2].union.bool(), Column: Name(sqlDollar[3].str), Default: sqlDollar[4].union.expr()}
 		}
 	case 36:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:814
+		//line sql.y:821
 		{
 			sqlVAL.union.val = &AlterTableDropNotNull{columnKeyword: sqlDollar[2].union.bool(), Column: Name(sqlDollar[3].str)}
 		}
 	case 37:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:818
+		//line sql.y:825
 		{
 			unimplemented()
 		}
 	case 38:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:821
+		//line sql.y:828
 		{
 			sqlVAL.union.val = &AlterTableDropColumn{columnKeyword: sqlDollar[2].union.bool(), IfExists: true, Column: Name(sqlDollar[5].str)}
 		}
 	case 39:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:826
+		//line sql.y:833
 		{
 			sqlVAL.union.val = &AlterTableDropColumn{
 				columnKeyword: sqlDollar[2].union.bool(),
@@ -5076,31 +5082,31 @@ sqldefault:
 		}
 	case 40:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:836
+		//line sql.y:843
 		{
 			unimplemented()
 		}
 	case 41:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:839
+		//line sql.y:846
 		{
 			sqlVAL.union.val = &AlterTableAddConstraint{ConstraintDef: sqlDollar[2].union.constraintDef()}
 		}
 	case 42:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:843
+		//line sql.y:850
 		{
 			unimplemented()
 		}
 	case 43:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:845
+		//line sql.y:852
 		{
 			unimplemented()
 		}
 	case 44:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:848
+		//line sql.y:855
 		{
 			sqlVAL.union.val = &AlterTableDropConstraint{
 				IfExists:     true,
@@ -5110,7 +5116,7 @@ sqldefault:
 		}
 	case 45:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:857
+		//line sql.y:864
 		{
 			sqlVAL.union.val = &AlterTableDropConstraint{
 				IfExists:     false,
@@ -5120,95 +5126,95 @@ sqldefault:
 		}
 	case 46:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:867
+		//line sql.y:874
 		{
 			sqlVAL.union.val = sqlDollar[3].union.expr()
 		}
 	case 47:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:871
+		//line sql.y:878
 		{
 			sqlVAL.union.val = nil
 		}
 	case 48:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:877
+		//line sql.y:884
 		{
 			sqlVAL.union.val = DropCascade
 		}
 	case 49:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:881
+		//line sql.y:888
 		{
 			sqlVAL.union.val = DropRestrict
 		}
 	case 50:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:885
+		//line sql.y:892
 		{
 			sqlVAL.union.val = DropDefault
 		}
 	case 51:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:890
+		//line sql.y:897
 		{
 			unimplementedWithIssue(2473)
 		}
 	case 52:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:891
+		//line sql.y:898
 		{
 		}
 	case 53:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:894
+		//line sql.y:901
 		{
 			unimplemented()
 		}
 	case 54:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:895
+		//line sql.y:902
 		{
 		}
 	case 55:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:899
+		//line sql.y:906
 		{
 			sqlVAL.union.val = &CopyFrom{Table: sqlDollar[2].union.normalizableTableName(), Stdin: true}
 		}
 	case 56:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:903
+		//line sql.y:910
 		{
 			sqlVAL.union.val = &CopyFrom{Table: sqlDollar[2].union.normalizableTableName(), Stdin: true}
 		}
 	case 57:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:907
+		//line sql.y:914
 		{
 			sqlVAL.union.val = &CopyFrom{Table: sqlDollar[2].union.normalizableTableName(), Columns: sqlDollar[4].union.unresolvedNames(), Stdin: true}
 		}
 	case 62:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:921
+		//line sql.y:928
 		{
 			sqlVAL.union.val = &Delete{Table: sqlDollar[4].union.tblExpr(), Where: newWhere(astWhere, sqlDollar[5].union.expr()), Returning: sqlDollar[6].union.retExprs()}
 		}
 	case 63:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:928
+		//line sql.y:935
 		{
 			sqlVAL.union.val = &DropDatabase{Name: Name(sqlDollar[3].str), IfExists: false}
 		}
 	case 64:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:932
+		//line sql.y:939
 		{
 			sqlVAL.union.val = &DropDatabase{Name: Name(sqlDollar[5].str), IfExists: true}
 		}
 	case 65:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:936
+		//line sql.y:943
 		{
 			sqlVAL.union.val = &DropIndex{
 				IndexList:    sqlDollar[3].union.tableWithIdxList(),
@@ -5218,7 +5224,7 @@ sqldefault:
 		}
 	case 66:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:944
+		//line sql.y:951
 		{
 			sqlVAL.union.val = &DropIndex{
 				IndexList:    sqlDollar[5].union.tableWithIdxList(),
@@ -5228,90 +5234,90 @@ sqldefault:
 		}
 	case 67:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:952
+		//line sql.y:959
 		{
 			sqlVAL.union.val = &DropTable{Names: sqlDollar[3].union.tableNameReferences(), IfExists: false, DropBehavior: sqlDollar[4].union.dropBehavior()}
 		}
 	case 68:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:956
+		//line sql.y:963
 		{
 			sqlVAL.union.val = &DropTable{Names: sqlDollar[5].union.tableNameReferences(), IfExists: true, DropBehavior: sqlDollar[6].union.dropBehavior()}
 		}
 	case 69:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:962
+		//line sql.y:969
 		{
 			sqlVAL.union.val = TableNameReferences{sqlDollar[1].union.unresolvedName()}
 		}
 	case 70:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:966
+		//line sql.y:973
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.tableNameReferences(), sqlDollar[3].union.unresolvedName())
 		}
 	case 71:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:972
+		//line sql.y:979
 		{
 			sqlVAL.union.val = UnresolvedName{Name(sqlDollar[1].str)}
 		}
 	case 72:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:976
+		//line sql.y:983
 		{
 			sqlVAL.union.val = append(UnresolvedName{Name(sqlDollar[1].str)}, sqlDollar[2].union.unresolvedName()...)
 		}
 	case 73:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:982
+		//line sql.y:989
 		{
 			sqlVAL.union.val = UnresolvedName{Name(sqlDollar[2].str)}
 		}
 	case 74:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:986
+		//line sql.y:993
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.unresolvedName(), Name(sqlDollar[3].str))
 		}
 	case 75:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:993
+		//line sql.y:1000
 		{
 			sqlVAL.union.val = &Explain{Statement: sqlDollar[2].union.stmt()}
 		}
 	case 76:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:997
+		//line sql.y:1004
 		{
 			sqlVAL.union.val = &Explain{Options: sqlDollar[3].union.strs(), Statement: sqlDollar[5].union.stmt()}
 		}
 	case 77:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1003
+		//line sql.y:1010
 		{
 			sqlVAL.union.val = sqlDollar[1].union.slct()
 		}
 	case 84:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1012
+		//line sql.y:1019
 		{ /* SKIP DOC */
 		}
 	case 85:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1016
+		//line sql.y:1023
 		{
 			sqlVAL.union.val = []string{sqlDollar[1].str}
 		}
 	case 86:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1020
+		//line sql.y:1027
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.strs(), sqlDollar[3].str)
 		}
 	case 88:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1030
+		//line sql.y:1037
 		{
 			sqlVAL.union.val = &Prepare{
 				Name:      Name(sqlDollar[2].str),
@@ -5321,25 +5327,25 @@ sqldefault:
 		}
 	case 89:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1040
+		//line sql.y:1047
 		{
 			sqlVAL.union.val = sqlDollar[2].union.colTypes()
 		}
 	case 90:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1044
+		//line sql.y:1051
 		{
 			sqlVAL.union.val = []ColumnType(nil)
 		}
 	case 91:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1050
+		//line sql.y:1057
 		{
 			sqlVAL.union.val = sqlDollar[1].union.slct()
 		}
 	case 95:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1060
+		//line sql.y:1067
 		{
 			sqlVAL.union.val = &Execute{
 				Name:   Name(sqlDollar[2].str),
@@ -5348,19 +5354,19 @@ sqldefault:
 		}
 	case 96:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1071
+		//line sql.y:1078
 		{
 			sqlVAL.union.val = sqlDollar[2].union.exprs()
 		}
 	case 97:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1075
+		//line sql.y:1082
 		{
 			sqlVAL.union.val = Exprs(nil)
 		}
 	case 98:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1082
+		//line sql.y:1089
 		{
 			sqlVAL.union.val = &Deallocate{
 				Name: Name(sqlDollar[2].str),
@@ -5368,7 +5374,7 @@ sqldefault:
 		}
 	case 99:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1088
+		//line sql.y:1095
 		{
 			sqlVAL.union.val = &Deallocate{
 				Name: Name(sqlDollar[3].str),
@@ -5376,335 +5382,335 @@ sqldefault:
 		}
 	case 100:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1094
+		//line sql.y:1101
 		{
 			sqlVAL.union.val = &Deallocate{}
 		}
 	case 101:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1098
+		//line sql.y:1105
 		{
 			sqlVAL.union.val = &Deallocate{}
 		}
 	case 102:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1105
+		//line sql.y:1112
 		{
 			sqlVAL.union.val = &Grant{Privileges: sqlDollar[2].union.privilegeList(), Grantees: sqlDollar[6].union.nameList(), Targets: sqlDollar[4].union.targetList()}
 		}
 	case 103:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1112
+		//line sql.y:1119
 		{
 			sqlVAL.union.val = &Revoke{Privileges: sqlDollar[2].union.privilegeList(), Grantees: sqlDollar[6].union.nameList(), Targets: sqlDollar[4].union.targetList()}
 		}
 	case 104:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1119
+		//line sql.y:1126
 		{
 			sqlVAL.union.val = TargetList{Tables: sqlDollar[1].union.tablePatterns()}
 		}
 	case 105:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1123
+		//line sql.y:1130
 		{
 			sqlVAL.union.val = TargetList{Tables: sqlDollar[2].union.tablePatterns()}
 		}
 	case 106:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1127
+		//line sql.y:1134
 		{
 			sqlVAL.union.val = TargetList{Databases: sqlDollar[2].union.nameList()}
 		}
 	case 107:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1134
+		//line sql.y:1141
 		{
 			sqlVAL.union.val = privilege.List{privilege.ALL}
 		}
 	case 108:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1137
+		//line sql.y:1144
 		{
 		}
 	case 109:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1141
+		//line sql.y:1148
 		{
 			sqlVAL.union.val = privilege.List{sqlDollar[1].union.privilegeType()}
 		}
 	case 110:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1145
+		//line sql.y:1152
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.privilegeList(), sqlDollar[3].union.privilegeType())
 		}
 	case 111:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1152
+		//line sql.y:1159
 		{
 			sqlVAL.union.val = privilege.CREATE
 		}
 	case 112:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1156
+		//line sql.y:1163
 		{
 			sqlVAL.union.val = privilege.DROP
 		}
 	case 113:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1160
+		//line sql.y:1167
 		{
 			sqlVAL.union.val = privilege.GRANT
 		}
 	case 114:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1164
+		//line sql.y:1171
 		{
 			sqlVAL.union.val = privilege.SELECT
 		}
 	case 115:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1168
+		//line sql.y:1175
 		{
 			sqlVAL.union.val = privilege.INSERT
 		}
 	case 116:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1172
+		//line sql.y:1179
 		{
 			sqlVAL.union.val = privilege.DELETE
 		}
 	case 117:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1176
+		//line sql.y:1183
 		{
 			sqlVAL.union.val = privilege.UPDATE
 		}
 	case 118:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1184
+		//line sql.y:1191
 		{
 			sqlVAL.union.val = NameList{Name(sqlDollar[1].str)}
 		}
 	case 119:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1188
+		//line sql.y:1195
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.nameList(), Name(sqlDollar[3].str))
 		}
 	case 120:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1196
+		//line sql.y:1203
 		{
 			sqlVAL.union.val = sqlDollar[2].union.stmt()
 		}
 	case 121:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1200
+		//line sql.y:1207
 		{
 			sqlVAL.union.val = sqlDollar[3].union.stmt()
 		}
 	case 122:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1204
+		//line sql.y:1211
 		{
 			sqlVAL.union.val = &SetDefaultIsolation{Isolation: sqlDollar[6].union.isoLevel()}
 		}
 	case 123:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1208
+		//line sql.y:1215
 		{
 			sqlVAL.union.val = sqlDollar[3].union.stmt()
 		}
 	case 124:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1211
+		//line sql.y:1218
 		{ /* SKIP DOC */
 		}
 	case 125:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1217
+		//line sql.y:1224
 		{
 			sqlVAL.union.val = &Set{Values: sqlDollar[4].union.exprs()}
 		}
 	case 126:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1223
+		//line sql.y:1230
 		{
 			sqlVAL.union.val = sqlDollar[2].union.stmt()
 		}
 	case 128:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1230
+		//line sql.y:1237
 		{
 			sqlVAL.union.val = &SetTransaction{Isolation: sqlDollar[1].union.isoLevel(), UserPriority: UnspecifiedUserPriority}
 		}
 	case 129:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1234
+		//line sql.y:1241
 		{
 			sqlVAL.union.val = &SetTransaction{Isolation: UnspecifiedIsolation, UserPriority: sqlDollar[1].union.userPriority()}
 		}
 	case 130:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1238
+		//line sql.y:1245
 		{
 			sqlVAL.union.val = &SetTransaction{Isolation: sqlDollar[1].union.isoLevel(), UserPriority: sqlDollar[3].union.userPriority()}
 		}
 	case 131:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1242
+		//line sql.y:1249
 		{
 			sqlVAL.union.val = &SetTransaction{Isolation: sqlDollar[3].union.isoLevel(), UserPriority: sqlDollar[1].union.userPriority()}
 		}
 	case 132:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1249
+		//line sql.y:1256
 		{
 			sqlVAL.union.val = sqlDollar[2].union.userPriority()
 		}
 	case 133:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1255
+		//line sql.y:1262
 		{
 			sqlVAL.union.val = &Set{Name: sqlDollar[1].union.unresolvedName(), Values: sqlDollar[3].union.exprs()}
 		}
 	case 134:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1259
+		//line sql.y:1266
 		{
 			sqlVAL.union.val = &Set{Name: sqlDollar[1].union.unresolvedName(), Values: sqlDollar[3].union.exprs()}
 		}
 	case 135:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1263
+		//line sql.y:1270
 		{
 			sqlVAL.union.val = &Set{Name: sqlDollar[1].union.unresolvedName()}
 		}
 	case 136:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1267
+		//line sql.y:1274
 		{
 			sqlVAL.union.val = &Set{Name: sqlDollar[1].union.unresolvedName()}
 		}
 	case 138:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1274
+		//line sql.y:1281
 		{
 			unimplemented()
 		}
 	case 139:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1277
+		//line sql.y:1284
 		{
 			sqlVAL.union.val = &SetTimeZone{Value: sqlDollar[3].union.expr()}
 		}
 	case 140:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1280
+		//line sql.y:1287
 		{
 			unimplemented()
 		}
 	case 142:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1287
+		//line sql.y:1294
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr()}
 		}
 	case 143:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1291
+		//line sql.y:1298
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.exprs(), sqlDollar[3].union.expr())
 		}
 	case 146:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1299
+		//line sql.y:1306
 		{
 			sqlVAL.union.val = Placeholder{Name: sqlDollar[1].str}
 		}
 	case 147:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1305
+		//line sql.y:1312
 		{
 			sqlVAL.union.val = SnapshotIsolation
 		}
 	case 148:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1309
+		//line sql.y:1316
 		{
 			sqlVAL.union.val = SnapshotIsolation
 		}
 	case 149:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1313
+		//line sql.y:1320
 		{
 			sqlVAL.union.val = SnapshotIsolation
 		}
 	case 150:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1317
+		//line sql.y:1324
 		{
 			sqlVAL.union.val = SerializableIsolation
 		}
 	case 151:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1321
+		//line sql.y:1328
 		{
 			sqlVAL.union.val = SerializableIsolation
 		}
 	case 152:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1327
+		//line sql.y:1334
 		{
 			sqlVAL.union.val = Low
 		}
 	case 153:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1331
+		//line sql.y:1338
 		{
 			sqlVAL.union.val = Normal
 		}
 	case 154:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1335
+		//line sql.y:1342
 		{
 			sqlVAL.union.val = High
 		}
 	case 155:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1341
+		//line sql.y:1348
 		{
 			sqlVAL.union.val = MakeDBool(true)
 		}
 	case 156:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1345
+		//line sql.y:1352
 		{
 			sqlVAL.union.val = MakeDBool(false)
 		}
 	case 157:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1349
+		//line sql.y:1356
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
 	case 159:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1364
+		//line sql.y:1371
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
 	case 160:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1368
+		//line sql.y:1375
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
 	case 161:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1372
+		//line sql.y:1379
 		{
 			d, err := ParseDInterval(sqlDollar[2].str)
 			if err != nil {
@@ -5715,241 +5721,241 @@ sqldefault:
 		}
 	case 163:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1382
+		//line sql.y:1389
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
 	case 164:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1386
+		//line sql.y:1393
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
 	case 165:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1391
+		//line sql.y:1398
 		{
 			unimplemented()
 		}
 	case 166:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1392
+		//line sql.y:1399
 		{
 			unimplemented()
 		}
 	case 167:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1393
+		//line sql.y:1400
 		{
 		}
 	case 168:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1397
+		//line sql.y:1404
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
 	case 169:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1401
+		//line sql.y:1408
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
 	case 170:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1407
+		//line sql.y:1414
 		{
 			sqlVAL.union.val = &Show{Name: sqlDollar[2].str}
 		}
 	case 171:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1411
+		//line sql.y:1418
 		{
 			sqlVAL.union.val = &Show{Name: sqlDollar[2].str}
 		}
 	case 172:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1415
+		//line sql.y:1422
 		{
 			sqlVAL.union.val = &ShowColumns{Table: sqlDollar[4].union.normalizableTableName()}
 		}
 	case 173:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1419
+		//line sql.y:1426
 		{
 			sqlVAL.union.val = &ShowDatabases{}
 		}
 	case 174:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1423
+		//line sql.y:1430
 		{
 			sqlVAL.union.val = &ShowGrants{Targets: sqlDollar[3].union.targetListPtr(), Grantees: sqlDollar[4].union.nameList()}
 		}
 	case 175:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1427
+		//line sql.y:1434
 		{
 			sqlVAL.union.val = &ShowIndex{Table: sqlDollar[4].union.normalizableTableName()}
 		}
 	case 176:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1431
+		//line sql.y:1438
 		{
 			sqlVAL.union.val = &ShowIndex{Table: sqlDollar[4].union.normalizableTableName()}
 		}
 	case 177:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1435
+		//line sql.y:1442
 		{
 			sqlVAL.union.val = &ShowConstraints{Table: sqlDollar[4].union.normalizableTableName()}
 		}
 	case 178:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1439
+		//line sql.y:1446
 		{
 			sqlVAL.union.val = &ShowConstraints{Table: sqlDollar[4].union.normalizableTableName()}
 		}
 	case 179:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1443
+		//line sql.y:1450
 		{
 			sqlVAL.union.val = &ShowIndex{Table: sqlDollar[4].union.normalizableTableName()}
 		}
 	case 180:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1447
+		//line sql.y:1454
 		{
 			sqlVAL.union.val = &ShowTables{Database: Name(sqlDollar[4].str)}
 		}
 	case 181:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1451
+		//line sql.y:1458
 		{
 			sqlVAL.union.val = &ShowTables{}
 		}
 	case 182:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1455
+		//line sql.y:1462
 		{
 			sqlVAL.union.val = &Show{Name: "TIME ZONE"}
 		}
 	case 183:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1459
+		//line sql.y:1466
 		{
 			sqlVAL.union.val = &Show{Name: "TRANSACTION ISOLATION LEVEL"}
 		}
 	case 184:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1463
+		//line sql.y:1470
 		{
 			sqlVAL.union.val = &Show{Name: "TRANSACTION PRIORITY"}
 		}
 	case 185:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1467
+		//line sql.y:1474
 		{
 			sqlVAL.union.val = Statement(nil)
 		}
 	case 186:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1471
+		//line sql.y:1478
 		{
 			sqlVAL.union.val = &ShowCreateTable{Table: sqlDollar[4].union.normalizableTableName()}
 		}
 	case 187:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1477
+		//line sql.y:1484
 		{
 			tmp := sqlDollar[2].union.targetList()
 			sqlVAL.union.val = &tmp
 		}
 	case 188:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1482
+		//line sql.y:1489
 		{
 			sqlVAL.union.val = (*TargetList)(nil)
 		}
 	case 189:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1488
+		//line sql.y:1495
 		{
 			sqlVAL.union.val = sqlDollar[2].union.nameList()
 		}
 	case 190:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1492
+		//line sql.y:1499
 		{
 			sqlVAL.union.val = NameList(nil)
 		}
 	case 191:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1498
+		//line sql.y:1505
 		{
 			sqlVAL.union.val = &Split{Table: sqlDollar[3].union.normalizableTableName(), Exprs: sqlDollar[7].union.exprs()}
 		}
 	case 192:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1502
+		//line sql.y:1509
 		{
 			sqlVAL.union.val = &Split{Index: sqlDollar[3].union.tableWithIdx(), Exprs: sqlDollar[7].union.exprs()}
 		}
 	case 193:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:1509
+		//line sql.y:1516
 		{
 			sqlVAL.union.val = &CreateTable{Table: sqlDollar[3].union.normalizableTableName(), IfNotExists: false, Interleave: sqlDollar[7].union.interleave(), Defs: sqlDollar[5].union.tblDefs(), AsSource: nil}
 		}
 	case 194:
 		sqlDollar = sqlS[sqlpt-10 : sqlpt+1]
-		//line sql.y:1513
+		//line sql.y:1520
 		{
 			sqlVAL.union.val = &CreateTable{Table: sqlDollar[6].union.normalizableTableName(), IfNotExists: true, Interleave: sqlDollar[10].union.interleave(), Defs: sqlDollar[8].union.tblDefs(), AsSource: nil}
 		}
 	case 195:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1519
+		//line sql.y:1526
 		{
 			sqlVAL.union.val = &CreateTable{Table: sqlDollar[3].union.normalizableTableName(), IfNotExists: false, Interleave: nil, Defs: nil, AsSource: sqlDollar[5].union.slct()}
 		}
 	case 196:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1523
+		//line sql.y:1530
 		{
 			sqlVAL.union.val = &CreateTable{Table: sqlDollar[6].union.normalizableTableName(), IfNotExists: true, Interleave: nil, Defs: nil, AsSource: sqlDollar[8].union.slct()}
 		}
 	case 198:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1530
+		//line sql.y:1537
 		{
 			sqlVAL.union.val = TableDefs(nil)
 		}
 	case 199:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1536
+		//line sql.y:1543
 		{
 			sqlVAL.union.val = TableDefs{sqlDollar[1].union.tblDef()}
 		}
 	case 200:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1540
+		//line sql.y:1547
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.tblDefs(), sqlDollar[3].union.tblDef())
 		}
 	case 201:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1546
+		//line sql.y:1553
 		{
 			sqlVAL.union.val = sqlDollar[1].union.colDef()
 		}
 	case 204:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1552
+		//line sql.y:1559
 		{
 			sqlVAL.union.val = sqlDollar[1].union.constraintDef()
 		}
 	case 205:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1558
+		//line sql.y:1565
 		{
 			sqlVAL.union.val = &InterleaveDef{
 				Parent:       NormalizableTableName{UnresolvedName{Name(sqlDollar[4].str)}},
@@ -5959,123 +5965,123 @@ sqldefault:
 		}
 	case 206:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1566
+		//line sql.y:1573
 		{
 			sqlVAL.union.val = (*InterleaveDef)(nil)
 		}
 	case 207:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1573
+		//line sql.y:1580
 		{
 			/* SKIP DOC */
 			sqlVAL.union.val = DropCascade
 		}
 	case 208:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1577
+		//line sql.y:1584
 		{
 			/* SKIP DOC */
 			sqlVAL.union.val = DropRestrict
 		}
 	case 209:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1581
+		//line sql.y:1588
 		{
 			sqlVAL.union.val = DropDefault
 		}
 	case 210:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1587
+		//line sql.y:1594
 		{
 			sqlVAL.union.val = newColumnTableDef(Name(sqlDollar[1].str), sqlDollar[2].union.colType(), sqlDollar[3].union.colQuals())
 		}
 	case 211:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1593
+		//line sql.y:1600
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.colQuals(), sqlDollar[2].union.colQual())
 		}
 	case 212:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1597
+		//line sql.y:1604
 		{
 			sqlVAL.union.val = []NamedColumnQualification(nil)
 		}
 	case 213:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1603
+		//line sql.y:1610
 		{
 			sqlVAL.union.val = NamedColumnQualification{Name: Name(sqlDollar[2].str), Qualification: sqlDollar[3].union.colQualElem()}
 		}
 	case 214:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1607
+		//line sql.y:1614
 		{
 			sqlVAL.union.val = NamedColumnQualification{Qualification: sqlDollar[1].union.colQualElem()}
 		}
 	case 215:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1610
+		//line sql.y:1617
 		{
 			unimplemented()
 		}
 	case 216:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1612
+		//line sql.y:1619
 		{
 			sqlVAL.union.val = NamedColumnQualification{Qualification: &ColumnFamilyConstraint{Family: Name(sqlDollar[2].str)}}
 		}
 	case 217:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1616
+		//line sql.y:1623
 		{
 			sqlVAL.union.val = NamedColumnQualification{Qualification: &ColumnFamilyConstraint{Family: Name(sqlDollar[3].str), Create: true}}
 		}
 	case 218:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1620
+		//line sql.y:1627
 		{
 			sqlVAL.union.val = NamedColumnQualification{Qualification: &ColumnFamilyConstraint{Family: Name(sqlDollar[6].str), Create: true, IfNotExists: true}}
 		}
 	case 219:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1638
+		//line sql.y:1645
 		{
 			sqlVAL.union.val = NotNullConstraint{}
 		}
 	case 220:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1642
+		//line sql.y:1649
 		{
 			sqlVAL.union.val = NullConstraint{}
 		}
 	case 221:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1646
+		//line sql.y:1653
 		{
 			sqlVAL.union.val = UniqueConstraint{}
 		}
 	case 222:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1650
+		//line sql.y:1657
 		{
 			sqlVAL.union.val = PrimaryKeyConstraint{}
 		}
 	case 223:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1654
+		//line sql.y:1661
 		{
 			sqlVAL.union.val = &ColumnCheckConstraint{Expr: sqlDollar[3].union.expr()}
 		}
 	case 224:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1658
+		//line sql.y:1665
 		{
 			sqlVAL.union.val = &ColumnDefault{Expr: sqlDollar[2].union.expr()}
 		}
 	case 225:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1662
+		//line sql.y:1669
 		{
 			sqlVAL.union.val = &ColumnFKConstraint{
 				Table: sqlDollar[2].union.normalizableTableName(),
@@ -6084,7 +6090,7 @@ sqldefault:
 		}
 	case 226:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:1671
+		//line sql.y:1678
 		{
 			sqlVAL.union.val = &IndexTableDef{
 				Name:       Name(sqlDollar[2].str),
@@ -6095,7 +6101,7 @@ sqldefault:
 		}
 	case 227:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1680
+		//line sql.y:1687
 		{
 			sqlVAL.union.val = &UniqueConstraintTableDef{
 				IndexTableDef: IndexTableDef{
@@ -6108,7 +6114,7 @@ sqldefault:
 		}
 	case 228:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1693
+		//line sql.y:1700
 		{
 			sqlVAL.union.val = &FamilyTableDef{
 				Name:    Name(sqlDollar[2].str),
@@ -6117,20 +6123,20 @@ sqldefault:
 		}
 	case 229:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1705
+		//line sql.y:1712
 		{
 			sqlVAL.union.val = sqlDollar[3].union.constraintDef()
 			sqlVAL.union.val.(ConstraintTableDef).setName(Name(sqlDollar[2].str))
 		}
 	case 230:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1710
+		//line sql.y:1717
 		{
 			sqlVAL.union.val = sqlDollar[1].union.constraintDef()
 		}
 	case 231:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1716
+		//line sql.y:1723
 		{
 			sqlVAL.union.val = &CheckConstraintTableDef{
 				Expr: sqlDollar[3].union.expr(),
@@ -6138,7 +6144,7 @@ sqldefault:
 		}
 	case 232:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1722
+		//line sql.y:1729
 		{
 			sqlVAL.union.val = &UniqueConstraintTableDef{
 				IndexTableDef: IndexTableDef{
@@ -6150,7 +6156,7 @@ sqldefault:
 		}
 	case 233:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1732
+		//line sql.y:1739
 		{
 			sqlVAL.union.val = &UniqueConstraintTableDef{
 				IndexTableDef: IndexTableDef{
@@ -6161,7 +6167,7 @@ sqldefault:
 		}
 	case 234:
 		sqlDollar = sqlS[sqlpt-10 : sqlpt+1]
-		//line sql.y:1742
+		//line sql.y:1749
 		{
 			sqlVAL.union.val = &ForeignKeyConstraintTableDef{
 				Table:    sqlDollar[7].union.normalizableTableName(),
@@ -6171,149 +6177,149 @@ sqldefault:
 		}
 	case 237:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1765
+		//line sql.y:1772
 		{
 			sqlVAL.union.val = sqlDollar[3].union.nameList()
 		}
 	case 238:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1769
+		//line sql.y:1776
 		{
 			sqlVAL.union.val = NameList(nil)
 		}
 	case 239:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1775
+		//line sql.y:1782
 		{
 			sqlVAL.union.val = sqlDollar[2].union.nameList()
 		}
 	case 240:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1779
+		//line sql.y:1786
 		{
 			sqlVAL.union.val = NameList(nil)
 		}
 	case 241:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1784
+		//line sql.y:1791
 		{
 			unimplemented()
 		}
 	case 242:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1785
+		//line sql.y:1792
 		{
 			unimplemented()
 		}
 	case 243:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1786
+		//line sql.y:1793
 		{
 			unimplemented()
 		}
 	case 244:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1787
+		//line sql.y:1794
 		{
 		}
 	case 245:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1794
+		//line sql.y:1801
 		{
 			unimplemented()
 		}
 	case 246:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1795
+		//line sql.y:1802
 		{
 			unimplemented()
 		}
 	case 247:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1796
+		//line sql.y:1803
 		{
 			unimplemented()
 		}
 	case 248:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1797
+		//line sql.y:1804
 		{
 			unimplemented()
 		}
 	case 249:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1798
+		//line sql.y:1805
 		{
 		}
 	case 250:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1801
+		//line sql.y:1808
 		{
 			unimplemented()
 		}
 	case 251:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1804
+		//line sql.y:1811
 		{
 			unimplemented()
 		}
 	case 252:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1807
+		//line sql.y:1814
 		{
 			unimplemented()
 		}
 	case 253:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1808
+		//line sql.y:1815
 		{
 			unimplemented()
 		}
 	case 254:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1809
+		//line sql.y:1816
 		{
 			unimplemented()
 		}
 	case 255:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1810
+		//line sql.y:1817
 		{
 			unimplemented()
 		}
 	case 256:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1811
+		//line sql.y:1818
 		{
 			unimplemented()
 		}
 	case 257:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1815
+		//line sql.y:1822
 		{
 			sqlVAL.union.val = sqlDollar[1].union.numVal()
 		}
 	case 258:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1819
+		//line sql.y:1826
 		{
 			sqlVAL.union.val = &NumVal{Value: constant.UnaryOp(token.SUB, sqlDollar[2].union.numVal().Value, 0)}
 		}
 	case 259:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1823
+		//line sql.y:1830
 		{
 			sqlVAL.union.val = sqlDollar[1].union.numVal()
 		}
 	case 260:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1830
+		//line sql.y:1837
 		{
 			sqlVAL.union.val = &Truncate{Tables: sqlDollar[3].union.tableNameReferences(), DropBehavior: sqlDollar[4].union.dropBehavior()}
 		}
 	case 261:
 		sqlDollar = sqlS[sqlpt-11 : sqlpt+1]
-		//line sql.y:1837
+		//line sql.y:1844
 		{
 			sqlVAL.union.val = &CreateIndex{
 				Name:       Name(sqlDollar[4].str),
@@ -6326,7 +6332,7 @@ sqldefault:
 		}
 	case 262:
 		sqlDollar = sqlS[sqlpt-14 : sqlpt+1]
-		//line sql.y:1848
+		//line sql.y:1855
 		{
 			sqlVAL.union.val = &CreateIndex{
 				Name:        Name(sqlDollar[7].str),
@@ -6340,190 +6346,190 @@ sqldefault:
 		}
 	case 263:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1862
+		//line sql.y:1869
 		{
 			sqlVAL.union.val = true
 		}
 	case 264:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1866
+		//line sql.y:1873
 		{
 			sqlVAL.union.val = false
 		}
 	case 265:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1872
+		//line sql.y:1879
 		{
 			sqlVAL.union.val = IndexElemList{sqlDollar[1].union.idxElem()}
 		}
 	case 266:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1876
+		//line sql.y:1883
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.idxElems(), sqlDollar[3].union.idxElem())
 		}
 	case 267:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1885
+		//line sql.y:1892
 		{
 			sqlVAL.union.val = IndexElem{Column: Name(sqlDollar[1].str), Direction: sqlDollar[3].union.dir()}
 		}
 	case 268:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1888
+		//line sql.y:1895
 		{
 			unimplemented()
 		}
 	case 269:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1889
+		//line sql.y:1896
 		{
 			unimplemented()
 		}
 	case 270:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1892
+		//line sql.y:1899
 		{
 			unimplemented()
 		}
 	case 271:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1893
+		//line sql.y:1900
 		{
 		}
 	case 272:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1897
+		//line sql.y:1904
 		{
 			sqlVAL.union.val = Ascending
 		}
 	case 273:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1901
+		//line sql.y:1908
 		{
 			sqlVAL.union.val = Descending
 		}
 	case 274:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1905
+		//line sql.y:1912
 		{
 			sqlVAL.union.val = DefaultDirection
 		}
 	case 275:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1912
+		//line sql.y:1919
 		{
 			sqlVAL.union.val = &RenameDatabase{Name: Name(sqlDollar[3].str), NewName: Name(sqlDollar[6].str)}
 		}
 	case 276:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1916
+		//line sql.y:1923
 		{
 			sqlVAL.union.val = &RenameTable{Name: sqlDollar[3].union.normalizableTableName(), NewName: sqlDollar[6].union.normalizableTableName(), IfExists: false}
 		}
 	case 277:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1920
+		//line sql.y:1927
 		{
 			sqlVAL.union.val = &RenameTable{Name: sqlDollar[5].union.normalizableTableName(), NewName: sqlDollar[8].union.normalizableTableName(), IfExists: true}
 		}
 	case 278:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1924
+		//line sql.y:1931
 		{
 			sqlVAL.union.val = &RenameIndex{Index: sqlDollar[3].union.tableWithIdx(), NewName: Name(sqlDollar[6].str), IfExists: false}
 		}
 	case 279:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1928
+		//line sql.y:1935
 		{
 			sqlVAL.union.val = &RenameIndex{Index: sqlDollar[5].union.tableWithIdx(), NewName: Name(sqlDollar[8].str), IfExists: true}
 		}
 	case 280:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1932
+		//line sql.y:1939
 		{
 			sqlVAL.union.val = &RenameColumn{Table: sqlDollar[3].union.normalizableTableName(), Name: Name(sqlDollar[6].str), NewName: Name(sqlDollar[8].str), IfExists: false}
 		}
 	case 281:
 		sqlDollar = sqlS[sqlpt-10 : sqlpt+1]
-		//line sql.y:1936
+		//line sql.y:1943
 		{
 			sqlVAL.union.val = &RenameColumn{Table: sqlDollar[5].union.normalizableTableName(), Name: Name(sqlDollar[8].str), NewName: Name(sqlDollar[10].str), IfExists: true}
 		}
 	case 282:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1940
+		//line sql.y:1947
 		{
 			sqlVAL.union.val = Statement(nil)
 		}
 	case 283:
 		sqlDollar = sqlS[sqlpt-10 : sqlpt+1]
-		//line sql.y:1944
+		//line sql.y:1951
 		{
 			sqlVAL.union.val = Statement(nil)
 		}
 	case 284:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1950
+		//line sql.y:1957
 		{
 			sqlVAL.union.val = true
 		}
 	case 285:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1954
+		//line sql.y:1961
 		{
 			sqlVAL.union.val = false
 		}
 	case 286:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1959
+		//line sql.y:1966
 		{
 		}
 	case 287:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1960
+		//line sql.y:1967
 		{
 		}
 	case 288:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1964
+		//line sql.y:1971
 		{
 			sqlVAL.union.val = &ReleaseSavepoint{Savepoint: sqlDollar[2].str}
 		}
 	case 289:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1970
+		//line sql.y:1977
 		{
 			sqlVAL.union.val = &Savepoint{Name: sqlDollar[2].str}
 		}
 	case 290:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1977
+		//line sql.y:1984
 		{
 			sqlVAL.union.val = sqlDollar[3].union.stmt()
 		}
 	case 291:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1981
+		//line sql.y:1988
 		{
 			sqlVAL.union.val = sqlDollar[3].union.stmt()
 		}
 	case 292:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1985
+		//line sql.y:1992
 		{
 			sqlVAL.union.val = &CommitTransaction{}
 		}
 	case 293:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1989
+		//line sql.y:1996
 		{
 			sqlVAL.union.val = &CommitTransaction{}
 		}
 	case 294:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1993
+		//line sql.y:2000
 		{
 			if sqlDollar[2].str != "" {
 				sqlVAL.union.val = &RollbackToSavepoint{Savepoint: sqlDollar[2].str}
@@ -6533,113 +6539,113 @@ sqldefault:
 		}
 	case 295:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2002
+		//line sql.y:2009
 		{
 		}
 	case 296:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2003
+		//line sql.y:2010
 		{
 		}
 	case 297:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2007
+		//line sql.y:2014
 		{
 			sqlVAL.str = ""
 		}
 	case 298:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2011
+		//line sql.y:2018
 		{
 			sqlVAL.str = sqlDollar[3].str
 		}
 	case 299:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2015
+		//line sql.y:2022
 		{
 			sqlVAL.str = sqlDollar[2].str
 		}
 	case 300:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2019
+		//line sql.y:2026
 		{
 			sqlVAL.str = ""
 		}
 	case 301:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2025
+		//line sql.y:2032
 		{
 			sqlVAL.str = sqlDollar[2].str
 		}
 	case 302:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2029
+		//line sql.y:2036
 		{
 			sqlVAL.str = sqlDollar[1].str
 		}
 	case 303:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2035
+		//line sql.y:2042
 		{
 			sqlVAL.union.val = &BeginTransaction{Isolation: sqlDollar[1].union.isoLevel(), UserPriority: UnspecifiedUserPriority}
 		}
 	case 304:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2039
+		//line sql.y:2046
 		{
 			sqlVAL.union.val = &BeginTransaction{Isolation: UnspecifiedIsolation, UserPriority: sqlDollar[1].union.userPriority()}
 		}
 	case 305:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2043
+		//line sql.y:2050
 		{
 			sqlVAL.union.val = &BeginTransaction{Isolation: sqlDollar[1].union.isoLevel(), UserPriority: sqlDollar[3].union.userPriority()}
 		}
 	case 306:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2047
+		//line sql.y:2054
 		{
 			sqlVAL.union.val = &BeginTransaction{Isolation: sqlDollar[3].union.isoLevel(), UserPriority: sqlDollar[1].union.userPriority()}
 		}
 	case 307:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2051
+		//line sql.y:2058
 		{
 			sqlVAL.union.val = &BeginTransaction{Isolation: UnspecifiedIsolation, UserPriority: UnspecifiedUserPriority}
 		}
 	case 308:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2057
+		//line sql.y:2064
 		{
 			sqlVAL.union.val = sqlDollar[3].union.isoLevel()
 		}
 	case 309:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2063
+		//line sql.y:2070
 		{
 			sqlVAL.union.val = &CreateDatabase{Name: Name(sqlDollar[3].str), Encoding: sqlDollar[4].union.strVal()}
 		}
 	case 310:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:2067
+		//line sql.y:2074
 		{
 			sqlVAL.union.val = &CreateDatabase{IfNotExists: true, Name: Name(sqlDollar[6].str), Encoding: sqlDollar[7].union.strVal()}
 		}
 	case 311:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2073
+		//line sql.y:2080
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[3].str}
 		}
 	case 312:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2076
+		//line sql.y:2083
 		{
 			sqlVAL.union.val = (*StrVal)(nil)
 		}
 	case 313:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2086
+		//line sql.y:2093
 		{
 			sqlVAL.union.val = sqlDollar[5].union.stmt()
 			sqlVAL.union.val.(*Insert).Table = sqlDollar[4].union.tblExpr()
@@ -6647,7 +6653,7 @@ sqldefault:
 		}
 	case 314:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2092
+		//line sql.y:2099
 		{
 			sqlVAL.union.val = sqlDollar[5].union.stmt()
 			sqlVAL.union.val.(*Insert).Table = sqlDollar[4].union.tblExpr()
@@ -6655,13 +6661,13 @@ sqldefault:
 		}
 	case 315:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:2097
+		//line sql.y:2104
 		{
 			unimplementedWithIssue(6637)
 		}
 	case 316:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2099
+		//line sql.y:2106
 		{
 			sqlVAL.union.val = sqlDollar[5].union.stmt()
 			sqlVAL.union.val.(*Insert).Table = sqlDollar[4].union.tblExpr()
@@ -6669,187 +6675,187 @@ sqldefault:
 		}
 	case 317:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:2104
+		//line sql.y:2111
 		{
 			unimplementedWithIssue(6637)
 		}
 	case 318:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2112
+		//line sql.y:2119
 		{
 			sqlVAL.union.val = sqlDollar[1].union.newNormalizableTableName()
 		}
 	case 319:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2116
+		//line sql.y:2123
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[1].union.newNormalizableTableName(), As: AliasClause{Alias: Name(sqlDollar[3].str)}}
 		}
 	case 320:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2122
+		//line sql.y:2129
 		{
 			sqlVAL.union.val = &Insert{Rows: sqlDollar[1].union.slct()}
 		}
 	case 321:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2126
+		//line sql.y:2133
 		{
 			sqlVAL.union.val = &Insert{Columns: sqlDollar[2].union.unresolvedNames(), Rows: sqlDollar[4].union.slct()}
 		}
 	case 322:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2130
+		//line sql.y:2137
 		{
 			sqlVAL.union.val = &Insert{Rows: &Select{}}
 		}
 	case 323:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:2136
+		//line sql.y:2143
 		{
 			sqlVAL.union.val = &OnConflict{Columns: sqlDollar[3].union.nameList(), Exprs: sqlDollar[7].union.updateExprs(), Where: newWhere(astWhere, sqlDollar[8].union.expr())}
 		}
 	case 324:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2140
+		//line sql.y:2147
 		{
 			sqlVAL.union.val = &OnConflict{Columns: sqlDollar[3].union.nameList(), DoNothing: true}
 		}
 	case 325:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2146
+		//line sql.y:2153
 		{
 			// TODO(dan): Support the where_clause.
 			sqlVAL.union.val = sqlDollar[2].union.nameList()
 		}
 	case 326:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2150
+		//line sql.y:2157
 		{
 			unimplemented()
 		}
 	case 327:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2152
+		//line sql.y:2159
 		{
 			sqlVAL.union.val = NameList(nil)
 		}
 	case 328:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2158
+		//line sql.y:2165
 		{
 			sqlVAL.union.val = sqlDollar[2].union.selExprs()
 		}
 	case 329:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2162
+		//line sql.y:2169
 		{
 			sqlVAL.union.val = SelectExprs(nil)
 		}
 	case 330:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:2169
+		//line sql.y:2176
 		{
 			sqlVAL.union.val = &Update{Table: sqlDollar[3].union.tblExpr(), Exprs: sqlDollar[5].union.updateExprs(), Where: newWhere(astWhere, sqlDollar[7].union.expr()), Returning: sqlDollar[8].union.retExprs()}
 		}
 	case 331:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2175
+		//line sql.y:2182
 		{
 			unimplementedWithIssue(7841)
 		}
 	case 332:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2176
+		//line sql.y:2183
 		{
 		}
 	case 333:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2180
+		//line sql.y:2187
 		{
 			sqlVAL.union.val = UpdateExprs{sqlDollar[1].union.updateExpr()}
 		}
 	case 334:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2184
+		//line sql.y:2191
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.updateExprs(), sqlDollar[3].union.updateExpr())
 		}
 	case 337:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2194
+		//line sql.y:2201
 		{
 			sqlVAL.union.val = &UpdateExpr{Names: UnresolvedNames{sqlDollar[1].union.unresolvedName()}, Expr: sqlDollar[3].union.expr()}
 		}
 	case 338:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2206
+		//line sql.y:2213
 		{
 			sqlVAL.union.val = &UpdateExpr{Tuple: true, Names: sqlDollar[2].union.unresolvedNames(), Expr: &Tuple{Exprs: sqlDollar[5].union.exprs()}}
 		}
 	case 339:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2210
+		//line sql.y:2217
 		{
 			sqlVAL.union.val = &UpdateExpr{Tuple: true, Names: sqlDollar[2].union.unresolvedNames(), Expr: &Subquery{Select: sqlDollar[5].union.selectStmt()}}
 		}
 	case 341:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2254
+		//line sql.y:2261
 		{
 			sqlVAL.union.val = &Select{Select: sqlDollar[1].union.selectStmt()}
 		}
 	case 342:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2260
+		//line sql.y:2267
 		{
 			sqlVAL.union.val = &ParenSelect{Select: sqlDollar[2].union.slct()}
 		}
 	case 343:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2264
+		//line sql.y:2271
 		{
 			sqlVAL.union.val = &ParenSelect{Select: &Select{Select: sqlDollar[2].union.selectStmt()}}
 		}
 	case 344:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2279
+		//line sql.y:2286
 		{
 			sqlVAL.union.val = &Select{Select: sqlDollar[1].union.selectStmt()}
 		}
 	case 345:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2283
+		//line sql.y:2290
 		{
 			sqlVAL.union.val = &Select{Select: sqlDollar[1].union.selectStmt(), OrderBy: sqlDollar[2].union.orderBy()}
 		}
 	case 346:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2287
+		//line sql.y:2294
 		{
 			sqlVAL.union.val = &Select{Select: sqlDollar[1].union.selectStmt(), OrderBy: sqlDollar[2].union.orderBy(), Limit: sqlDollar[3].union.limit()}
 		}
 	case 347:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2291
+		//line sql.y:2298
 		{
 			sqlVAL.union.val = &Select{Select: sqlDollar[2].union.selectStmt()}
 		}
 	case 348:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2295
+		//line sql.y:2302
 		{
 			sqlVAL.union.val = &Select{Select: sqlDollar[2].union.selectStmt(), OrderBy: sqlDollar[3].union.orderBy()}
 		}
 	case 349:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2299
+		//line sql.y:2306
 		{
 			sqlVAL.union.val = &Select{Select: sqlDollar[2].union.selectStmt(), OrderBy: sqlDollar[3].union.orderBy(), Limit: sqlDollar[4].union.limit()}
 		}
 	case 352:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:2333
+		//line sql.y:2340
 		{
 			sqlVAL.union.val = &SelectClause{
 				Exprs:   sqlDollar[3].union.selExprs(),
@@ -6857,11 +6863,12 @@ sqldefault:
 				Where:   newWhere(astWhere, sqlDollar[5].union.expr()),
 				GroupBy: sqlDollar[6].union.groupBy(),
 				Having:  newWhere(astHaving, sqlDollar[7].union.expr()),
+				Window:  sqlDollar[8].union.window(),
 			}
 		}
 	case 353:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:2345
+		//line sql.y:2353
 		{
 			sqlVAL.union.val = &SelectClause{
 				Distinct: sqlDollar[2].union.bool(),
@@ -6870,11 +6877,12 @@ sqldefault:
 				Where:    newWhere(astWhere, sqlDollar[5].union.expr()),
 				GroupBy:  sqlDollar[6].union.groupBy(),
 				Having:   newWhere(astHaving, sqlDollar[7].union.expr()),
+				Window:   sqlDollar[8].union.window(),
 			}
 		}
 	case 355:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2357
+		//line sql.y:2366
 		{
 			sqlVAL.union.val = &SelectClause{
 				Exprs:       SelectExprs{starSelectExpr()},
@@ -6884,7 +6892,7 @@ sqldefault:
 		}
 	case 356:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2365
+		//line sql.y:2374
 		{
 			sqlVAL.union.val = &UnionClause{
 				Type:  UnionOp,
@@ -6895,7 +6903,7 @@ sqldefault:
 		}
 	case 357:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2374
+		//line sql.y:2383
 		{
 			sqlVAL.union.val = &UnionClause{
 				Type:  IntersectOp,
@@ -6906,7 +6914,7 @@ sqldefault:
 		}
 	case 358:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2383
+		//line sql.y:2392
 		{
 			sqlVAL.union.val = &UnionClause{
 				Type:  ExceptOp,
@@ -6917,134 +6925,134 @@ sqldefault:
 		}
 	case 359:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2401
+		//line sql.y:2410
 		{
 			unimplemented()
 		}
 	case 360:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2402
+		//line sql.y:2411
 		{
 			unimplemented()
 		}
 	case 361:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2403
+		//line sql.y:2412
 		{
 			unimplemented()
 		}
 	case 362:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2406
+		//line sql.y:2415
 		{
 			unimplemented()
 		}
 	case 363:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2407
+		//line sql.y:2416
 		{
 			unimplemented()
 		}
 	case 364:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2410
+		//line sql.y:2419
 		{
 			unimplemented()
 		}
 	case 365:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2413
+		//line sql.y:2422
 		{
 			unimplemented()
 		}
 	case 366:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2414
+		//line sql.y:2423
 		{
 		}
 	case 367:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2417
+		//line sql.y:2426
 		{
 		}
 	case 368:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2418
+		//line sql.y:2427
 		{
 		}
 	case 369:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2422
+		//line sql.y:2431
 		{
 			sqlVAL.union.val = true
 		}
 	case 370:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2426
+		//line sql.y:2435
 		{
 			sqlVAL.union.val = false
 		}
 	case 371:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2430
+		//line sql.y:2439
 		{
 			sqlVAL.union.val = false
 		}
 	case 372:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2436
+		//line sql.y:2445
 		{
 			sqlVAL.union.val = true
 		}
 	case 373:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2441
+		//line sql.y:2450
 		{
 		}
 	case 374:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2442
+		//line sql.y:2451
 		{
 		}
 	case 375:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2446
+		//line sql.y:2455
 		{
 			sqlVAL.union.val = sqlDollar[1].union.orderBy()
 		}
 	case 376:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2450
+		//line sql.y:2459
 		{
 			sqlVAL.union.val = OrderBy(nil)
 		}
 	case 377:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2456
+		//line sql.y:2465
 		{
 			sqlVAL.union.val = OrderBy(sqlDollar[3].union.orders())
 		}
 	case 378:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2462
+		//line sql.y:2471
 		{
 			sqlVAL.union.val = []*Order{sqlDollar[1].union.order()}
 		}
 	case 379:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2466
+		//line sql.y:2475
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.orders(), sqlDollar[3].union.order())
 		}
 	case 380:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2472
+		//line sql.y:2481
 		{
 			sqlVAL.union.val = &Order{Expr: sqlDollar[1].union.expr(), Direction: sqlDollar[2].union.dir()}
 		}
 	case 381:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2480
+		//line sql.y:2489
 		{
 			if sqlDollar[1].union.limit() == nil {
 				sqlVAL.union.val = sqlDollar[2].union.limit()
@@ -7055,7 +7063,7 @@ sqldefault:
 		}
 	case 382:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2489
+		//line sql.y:2498
 		{
 			sqlVAL.union.val = sqlDollar[1].union.limit()
 			if sqlDollar[2].union.limit() != nil {
@@ -7064,7 +7072,7 @@ sqldefault:
 		}
 	case 385:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2500
+		//line sql.y:2509
 		{
 			if sqlDollar[2].union.expr() == nil {
 				sqlVAL.union.val = (*Limit)(nil)
@@ -7074,65 +7082,65 @@ sqldefault:
 		}
 	case 386:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2513
+		//line sql.y:2522
 		{
 			sqlVAL.union.val = &Limit{Offset: sqlDollar[2].union.expr()}
 		}
 	case 387:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2520
+		//line sql.y:2529
 		{
 			sqlVAL.union.val = &Limit{Offset: sqlDollar[2].union.expr()}
 		}
 	case 389:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2527
+		//line sql.y:2536
 		{
 			sqlVAL.union.val = Expr(nil)
 		}
 	case 390:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2541
+		//line sql.y:2550
 		{
 		}
 	case 391:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2542
+		//line sql.y:2551
 		{
 		}
 	case 392:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2568
+		//line sql.y:2577
 		{
 			sqlVAL.union.val = GroupBy(sqlDollar[3].union.exprs())
 		}
 	case 393:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2572
+		//line sql.y:2581
 		{
 			sqlVAL.union.val = GroupBy(nil)
 		}
 	case 394:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2578
+		//line sql.y:2587
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 395:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2582
+		//line sql.y:2591
 		{
 			sqlVAL.union.val = Expr(nil)
 		}
 	case 396:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2588
+		//line sql.y:2597
 		{
 			sqlVAL.union.val = &ValuesClause{[]*Tuple{{Exprs: sqlDollar[2].union.exprs()}}}
 		}
 	case 397:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2592
+		//line sql.y:2601
 		{
 			valNode := sqlDollar[1].union.selectStmt().(*ValuesClause)
 			valNode.Tuples = append(valNode.Tuples, &Tuple{Exprs: sqlDollar[3].union.exprs()})
@@ -7140,49 +7148,49 @@ sqldefault:
 		}
 	case 398:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2604
+		//line sql.y:2613
 		{
 			sqlVAL.union.val = &From{Tables: sqlDollar[2].union.tblExprs(), AsOf: sqlDollar[3].union.asOfClause()}
 		}
 	case 399:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2608
+		//line sql.y:2617
 		{
 			sqlVAL.union.val = &From{}
 		}
 	case 400:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2614
+		//line sql.y:2623
 		{
 			sqlVAL.union.val = TableExprs{sqlDollar[1].union.tblExpr()}
 		}
 	case 401:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2618
+		//line sql.y:2627
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.tblExprs(), sqlDollar[3].union.tblExpr())
 		}
 	case 402:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2624
+		//line sql.y:2633
 		{
 			sqlVAL.union.val = &IndexHints{Index: Name(sqlDollar[3].str)}
 		}
 	case 403:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2629
+		//line sql.y:2638
 		{
 			sqlVAL.union.val = &IndexHints{NoIndexJoin: true}
 		}
 	case 404:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2635
+		//line sql.y:2644
 		{
 			sqlVAL.union.val = sqlDollar[1].union.indexHints()
 		}
 	case 405:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2640
+		//line sql.y:2649
 		{
 			a := sqlDollar[1].union.indexHints()
 			b := sqlDollar[3].union.indexHints()
@@ -7202,322 +7210,322 @@ sqldefault:
 		}
 	case 406:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2660
+		//line sql.y:2669
 		{
 			sqlVAL.union.val = &IndexHints{Index: Name(sqlDollar[2].str)}
 		}
 	case 407:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2664
+		//line sql.y:2673
 		{
 			sqlVAL.union.val = sqlDollar[3].union.indexHints()
 		}
 	case 408:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2668
+		//line sql.y:2677
 		{
 			sqlVAL.union.val = (*IndexHints)(nil)
 		}
 	case 409:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2675
+		//line sql.y:2684
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[1].union.newNormalizableTableName(), Hints: sqlDollar[2].union.indexHints(), As: sqlDollar[3].union.aliasClause()}
 		}
 	case 410:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2679
+		//line sql.y:2688
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: &Subquery{Select: sqlDollar[1].union.selectStmt()}, As: sqlDollar[2].union.aliasClause()}
 		}
 	case 411:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2683
+		//line sql.y:2692
 		{
 			sqlVAL.union.val = sqlDollar[1].union.tblExpr()
 		}
 	case 412:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2687
+		//line sql.y:2696
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[2].union.tblExpr(), As: sqlDollar[4].union.aliasClause()}
 		}
 	case 413:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2707
+		//line sql.y:2716
 		{
 			sqlVAL.union.val = &ParenTableExpr{Expr: sqlDollar[2].union.tblExpr()}
 		}
 	case 414:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2711
+		//line sql.y:2720
 		{
 			sqlVAL.union.val = &JoinTableExpr{Join: astCrossJoin, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[4].union.tblExpr()}
 		}
 	case 415:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2715
+		//line sql.y:2724
 		{
 			sqlVAL.union.val = &JoinTableExpr{Join: sqlDollar[2].str, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[4].union.tblExpr(), Cond: sqlDollar[5].union.joinCond()}
 		}
 	case 416:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2719
+		//line sql.y:2728
 		{
 			sqlVAL.union.val = &JoinTableExpr{Join: astJoin, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[3].union.tblExpr(), Cond: sqlDollar[4].union.joinCond()}
 		}
 	case 417:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2723
+		//line sql.y:2732
 		{
 			sqlVAL.union.val = &JoinTableExpr{Join: sqlDollar[3].str, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[5].union.tblExpr(), Cond: NaturalJoinCond{}}
 		}
 	case 418:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2727
+		//line sql.y:2736
 		{
 			sqlVAL.union.val = &JoinTableExpr{Join: astJoin, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[4].union.tblExpr(), Cond: NaturalJoinCond{}}
 		}
 	case 419:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2733
+		//line sql.y:2742
 		{
 			sqlVAL.union.val = AliasClause{Alias: Name(sqlDollar[2].str), Cols: sqlDollar[4].union.nameList()}
 		}
 	case 420:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2737
+		//line sql.y:2746
 		{
 			sqlVAL.union.val = AliasClause{Alias: Name(sqlDollar[2].str)}
 		}
 	case 421:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2741
+		//line sql.y:2750
 		{
 			sqlVAL.union.val = AliasClause{Alias: Name(sqlDollar[1].str), Cols: sqlDollar[3].union.nameList()}
 		}
 	case 422:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2745
+		//line sql.y:2754
 		{
 			sqlVAL.union.val = AliasClause{Alias: Name(sqlDollar[1].str)}
 		}
 	case 424:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2752
+		//line sql.y:2761
 		{
 			sqlVAL.union.val = AliasClause{}
 		}
 	case 425:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2758
+		//line sql.y:2767
 		{
 			sqlVAL.union.val = AsOfClause{Expr: &StrVal{s: sqlDollar[5].str}}
 		}
 	case 426:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2762
+		//line sql.y:2771
 		{
 			sqlVAL.union.val = AsOfClause{}
 		}
 	case 427:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2768
+		//line sql.y:2777
 		{
 			sqlVAL.str = astFullJoin
 		}
 	case 428:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2772
+		//line sql.y:2781
 		{
 			sqlVAL.str = astLeftJoin
 		}
 	case 429:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2776
+		//line sql.y:2785
 		{
 			sqlVAL.str = astRightJoin
 		}
 	case 430:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2780
+		//line sql.y:2789
 		{
 			sqlVAL.str = astInnerJoin
 		}
 	case 431:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2786
+		//line sql.y:2795
 		{
 		}
 	case 432:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2787
+		//line sql.y:2796
 		{
 		}
 	case 433:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2798
+		//line sql.y:2807
 		{
 			sqlVAL.union.val = &UsingJoinCond{Cols: sqlDollar[3].union.nameList()}
 		}
 	case 434:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2802
+		//line sql.y:2811
 		{
 			sqlVAL.union.val = &OnJoinCond{Expr: sqlDollar[2].union.expr()}
 		}
 	case 435:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2808
+		//line sql.y:2817
 		{
 			sqlVAL.union.val = sqlDollar[1].union.unresolvedName()
 		}
 	case 436:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2812
+		//line sql.y:2821
 		{
 			sqlVAL.union.val = sqlDollar[1].union.unresolvedName()
 		}
 	case 437:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2816
+		//line sql.y:2825
 		{
 			sqlVAL.union.val = sqlDollar[2].union.unresolvedName()
 		}
 	case 438:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2820
+		//line sql.y:2829
 		{
 			sqlVAL.union.val = sqlDollar[3].union.unresolvedName()
 		}
 	case 439:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2826
+		//line sql.y:2835
 		{
 			sqlVAL.union.val = TableNameReferences{sqlDollar[1].union.unresolvedName()}
 		}
 	case 440:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2830
+		//line sql.y:2839
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.tableNameReferences(), sqlDollar[3].union.unresolvedName())
 		}
 	case 441:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2843
+		//line sql.y:2852
 		{
 			sqlVAL.union.val = sqlDollar[1].union.newNormalizableTableName()
 		}
 	case 442:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2847
+		//line sql.y:2856
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[1].union.newNormalizableTableName(), As: AliasClause{Alias: Name(sqlDollar[2].str)}}
 		}
 	case 443:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2851
+		//line sql.y:2860
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[1].union.newNormalizableTableName(), As: AliasClause{Alias: Name(sqlDollar[3].str)}}
 		}
 	case 444:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2857
+		//line sql.y:2866
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 445:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2861
+		//line sql.y:2870
 		{
 			sqlVAL.union.val = Expr(nil)
 		}
 	case 446:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2873
+		//line sql.y:2882
 		{
 			sqlVAL.union.val = sqlDollar[1].union.colType()
 		}
 	case 447:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2877
+		//line sql.y:2886
 		{
 			unimplementedWithIssue(2115)
 		}
 	case 448:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2878
+		//line sql.y:2887
 		{
 			unimplementedWithIssue(2115)
 		}
 	case 449:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2881
+		//line sql.y:2890
 		{
 			unimplementedWithIssue(2115)
 		}
 	case 450:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2882
+		//line sql.y:2891
 		{
 			unimplementedWithIssue(2115)
 		}
 	case 451:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2883
+		//line sql.y:2892
 		{
 		}
 	case 457:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2891
+		//line sql.y:2900
 		{
 			unimplemented()
 		}
 	case 458:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2893
+		//line sql.y:2902
 		{
 			sqlVAL.union.val = bytesColTypeBlob
 		}
 	case 459:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2897
+		//line sql.y:2906
 		{
 			sqlVAL.union.val = bytesColTypeBytes
 		}
 	case 460:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2901
+		//line sql.y:2910
 		{
 			sqlVAL.union.val = bytesColTypeBytea
 		}
 	case 461:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2905
+		//line sql.y:2914
 		{
 			sqlVAL.union.val = stringColTypeText
 		}
 	case 462:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2909
+		//line sql.y:2918
 		{
 			sqlVAL.union.val = intColTypeSerial
 		}
 	case 463:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2913
+		//line sql.y:2922
 		{
 			sqlVAL.union.val = intColTypeSmallSerial
 		}
 	case 464:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2917
+		//line sql.y:2926
 		{
 			sqlVAL.union.val = intColTypeBigSerial
 		}
 	case 469:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2938
+		//line sql.y:2947
 		{
 			prec, err := sqlDollar[2].union.numVal().asInt64()
 			if err != nil {
@@ -7528,7 +7536,7 @@ sqldefault:
 		}
 	case 470:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2947
+		//line sql.y:2956
 		{
 			prec, err := sqlDollar[2].union.numVal().asInt64()
 			if err != nil {
@@ -7544,55 +7552,55 @@ sqldefault:
 		}
 	case 471:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2961
+		//line sql.y:2970
 		{
 			sqlVAL.union.val = nil
 		}
 	case 472:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2968
+		//line sql.y:2977
 		{
 			sqlVAL.union.val = intColTypeInt
 		}
 	case 473:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2972
+		//line sql.y:2981
 		{
 			sqlVAL.union.val = intColTypeInt8
 		}
 	case 474:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2976
+		//line sql.y:2985
 		{
 			sqlVAL.union.val = intColTypeInt64
 		}
 	case 475:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2980
+		//line sql.y:2989
 		{
 			sqlVAL.union.val = intColTypeInteger
 		}
 	case 476:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2984
+		//line sql.y:2993
 		{
 			sqlVAL.union.val = intColTypeSmallInt
 		}
 	case 477:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2988
+		//line sql.y:2997
 		{
 			sqlVAL.union.val = intColTypeBigInt
 		}
 	case 478:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2992
+		//line sql.y:3001
 		{
 			sqlVAL.union.val = floatColTypeReal
 		}
 	case 479:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2996
+		//line sql.y:3005
 		{
 			prec, err := sqlDollar[2].union.numVal().asInt64()
 			if err != nil {
@@ -7603,13 +7611,13 @@ sqldefault:
 		}
 	case 480:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3005
+		//line sql.y:3014
 		{
 			sqlVAL.union.val = floatColTypeDouble
 		}
 	case 481:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3009
+		//line sql.y:3018
 		{
 			sqlVAL.union.val = sqlDollar[2].union.colType()
 			if sqlVAL.union.val == nil {
@@ -7620,7 +7628,7 @@ sqldefault:
 		}
 	case 482:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3018
+		//line sql.y:3027
 		{
 			sqlVAL.union.val = sqlDollar[2].union.colType()
 			if sqlVAL.union.val == nil {
@@ -7631,7 +7639,7 @@ sqldefault:
 		}
 	case 483:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3027
+		//line sql.y:3036
 		{
 			sqlVAL.union.val = sqlDollar[2].union.colType()
 			if sqlVAL.union.val == nil {
@@ -7642,31 +7650,31 @@ sqldefault:
 		}
 	case 484:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3036
+		//line sql.y:3045
 		{
 			sqlVAL.union.val = boolColTypeBoolean
 		}
 	case 485:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3040
+		//line sql.y:3049
 		{
 			sqlVAL.union.val = boolColTypeBool
 		}
 	case 486:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3046
+		//line sql.y:3055
 		{
 			sqlVAL.union.val = sqlDollar[2].union.numVal()
 		}
 	case 487:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3050
+		//line sql.y:3059
 		{
 			sqlVAL.union.val = &NumVal{Value: constant.MakeInt64(0)}
 		}
 	case 492:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3068
+		//line sql.y:3077
 		{
 			n, err := sqlDollar[4].union.numVal().asInt64()
 			if err != nil {
@@ -7682,13 +7690,13 @@ sqldefault:
 		}
 	case 493:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3084
+		//line sql.y:3093
 		{
 			sqlVAL.union.val = intColTypeBit
 		}
 	case 498:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3100
+		//line sql.y:3109
 		{
 			n, err := sqlDollar[3].union.numVal().asInt64()
 			if err != nil {
@@ -7704,1698 +7712,1704 @@ sqldefault:
 		}
 	case 499:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3116
+		//line sql.y:3125
 		{
 			sqlVAL.union.val = sqlDollar[1].union.colType()
 		}
 	case 500:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3122
+		//line sql.y:3131
 		{
 			sqlVAL.union.val = stringColTypeChar
 		}
 	case 501:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3126
+		//line sql.y:3135
 		{
 			sqlVAL.union.val = stringColTypeChar
 		}
 	case 502:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3130
+		//line sql.y:3139
 		{
 			sqlVAL.union.val = stringColTypeVarChar
 		}
 	case 503:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3134
+		//line sql.y:3143
 		{
 			sqlVAL.union.val = stringColTypeString
 		}
 	case 504:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3139
+		//line sql.y:3148
 		{
 		}
 	case 505:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3140
+		//line sql.y:3149
 		{
 		}
 	case 506:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3145
+		//line sql.y:3154
 		{
 			sqlVAL.union.val = dateColTypeDate
 		}
 	case 507:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3149
+		//line sql.y:3158
 		{
 			sqlVAL.union.val = timestampColTypeTimestamp
 		}
 	case 508:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3153
+		//line sql.y:3162
 		{
 			sqlVAL.union.val = timestampColTypeTimestamp
 		}
 	case 509:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3157
+		//line sql.y:3166
 		{
 			sqlVAL.union.val = timestampTzColTypeTimestampWithTZ
 		}
 	case 510:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3161
+		//line sql.y:3170
 		{
 			sqlVAL.union.val = timestampTzColTypeTimestampWithTZ
 		}
 	case 511:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3166
+		//line sql.y:3175
 		{
 			sqlVAL.union.val = intervalColTypeInterval
 		}
 	case 512:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3171
+		//line sql.y:3180
 		{
 			unimplemented()
 		}
 	case 513:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3172
+		//line sql.y:3181
 		{
 			unimplemented()
 		}
 	case 514:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3173
+		//line sql.y:3182
 		{
 			unimplemented()
 		}
 	case 515:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3174
+		//line sql.y:3183
 		{
 			unimplemented()
 		}
 	case 516:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3175
+		//line sql.y:3184
 		{
 			unimplemented()
 		}
 	case 517:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3176
+		//line sql.y:3185
 		{
 			unimplemented()
 		}
 	case 518:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3177
+		//line sql.y:3186
 		{
 			unimplemented()
 		}
 	case 519:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3178
+		//line sql.y:3187
 		{
 			unimplemented()
 		}
 	case 520:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3179
+		//line sql.y:3188
 		{
 			unimplemented()
 		}
 	case 521:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3180
+		//line sql.y:3189
 		{
 			unimplemented()
 		}
 	case 522:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3181
+		//line sql.y:3190
 		{
 			unimplemented()
 		}
 	case 523:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3182
+		//line sql.y:3191
 		{
 			unimplemented()
 		}
 	case 524:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3183
+		//line sql.y:3192
 		{
 			unimplemented()
 		}
 	case 525:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3184
+		//line sql.y:3193
 		{
 		}
 	case 526:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3187
+		//line sql.y:3196
 		{
 			unimplemented()
 		}
 	case 527:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3188
+		//line sql.y:3197
 		{
 			unimplemented()
 		}
 	case 529:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3212
+		//line sql.y:3221
 		{
 			sqlVAL.union.val = &CastExpr{Expr: sqlDollar[1].union.expr(), Type: sqlDollar[3].union.colType()}
 		}
 	case 530:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3216
+		//line sql.y:3225
 		{
 			sqlVAL.union.val = &AnnotateTypeExpr{Expr: sqlDollar[1].union.expr(), Type: sqlDollar[3].union.colType()}
 		}
 	case 531:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3219
+		//line sql.y:3228
 		{
 			unimplemented()
 		}
 	case 532:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3220
+		//line sql.y:3229
 		{
 			unimplemented()
 		}
 	case 533:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3229
+		//line sql.y:3238
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryPlus, Expr: sqlDollar[2].union.expr()}
 		}
 	case 534:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3233
+		//line sql.y:3242
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryMinus, Expr: sqlDollar[2].union.expr()}
 		}
 	case 535:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3237
+		//line sql.y:3246
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryComplement, Expr: sqlDollar[2].union.expr()}
 		}
 	case 536:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3241
+		//line sql.y:3250
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Plus, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 537:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3245
+		//line sql.y:3254
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Minus, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 538:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3249
+		//line sql.y:3258
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Mult, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 539:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3253
+		//line sql.y:3262
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Div, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 540:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3257
+		//line sql.y:3266
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: FloorDiv, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 541:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3261
+		//line sql.y:3270
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Mod, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 542:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3265
+		//line sql.y:3274
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 543:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3269
+		//line sql.y:3278
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 544:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3273
+		//line sql.y:3282
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitand, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 545:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3277
+		//line sql.y:3286
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 546:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3281
+		//line sql.y:3290
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: LT, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 547:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3285
+		//line sql.y:3294
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: GT, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 548:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3289
+		//line sql.y:3298
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: EQ, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 549:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3293
+		//line sql.y:3302
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Concat, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 550:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3297
+		//line sql.y:3306
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: LShift, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 551:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3301
+		//line sql.y:3310
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: RShift, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 552:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3305
+		//line sql.y:3314
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: LE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 553:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3309
+		//line sql.y:3318
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: GE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 554:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3313
+		//line sql.y:3322
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 555:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3317
+		//line sql.y:3326
 		{
 			sqlVAL.union.val = &AndExpr{Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 556:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3321
+		//line sql.y:3330
 		{
 			sqlVAL.union.val = &OrExpr{Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 557:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3325
+		//line sql.y:3334
 		{
 			sqlVAL.union.val = &NotExpr{Expr: sqlDollar[2].union.expr()}
 		}
 	case 558:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3329
+		//line sql.y:3338
 		{
 			sqlVAL.union.val = &NotExpr{Expr: sqlDollar[2].union.expr()}
 		}
 	case 559:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3333
+		//line sql.y:3342
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Like, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 560:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3337
+		//line sql.y:3346
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NotLike, Left: sqlDollar[1].union.expr(), Right: sqlDollar[4].union.expr()}
 		}
 	case 561:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3341
+		//line sql.y:3350
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: ILike, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 562:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3345
+		//line sql.y:3354
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NotILike, Left: sqlDollar[1].union.expr(), Right: sqlDollar[4].union.expr()}
 		}
 	case 563:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3349
+		//line sql.y:3358
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: SimilarTo, Left: sqlDollar[1].union.expr(), Right: sqlDollar[4].union.expr()}
 		}
 	case 564:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3353
+		//line sql.y:3362
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NotSimilarTo, Left: sqlDollar[1].union.expr(), Right: sqlDollar[5].union.expr()}
 		}
 	case 565:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3357
+		//line sql.y:3366
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: RegMatch, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 566:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3361
+		//line sql.y:3370
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NotRegMatch, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 567:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3365
+		//line sql.y:3374
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: RegIMatch, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 568:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3369
+		//line sql.y:3378
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NotRegIMatch, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 569:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3373
+		//line sql.y:3382
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: DNull}
 		}
 	case 570:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3377
+		//line sql.y:3386
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: DNull}
 		}
 	case 571:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3380
+		//line sql.y:3389
 		{
 			unimplemented()
 		}
 	case 572:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3382
+		//line sql.y:3391
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: MakeDBool(true)}
 		}
 	case 573:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3386
+		//line sql.y:3395
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: MakeDBool(true)}
 		}
 	case 574:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3390
+		//line sql.y:3399
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: MakeDBool(false)}
 		}
 	case 575:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3394
+		//line sql.y:3403
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: MakeDBool(false)}
 		}
 	case 576:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3398
+		//line sql.y:3407
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: DNull}
 		}
 	case 577:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3402
+		//line sql.y:3411
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: DNull}
 		}
 	case 578:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3406
+		//line sql.y:3415
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsDistinctFrom, Left: sqlDollar[1].union.expr(), Right: sqlDollar[5].union.expr()}
 		}
 	case 579:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3410
+		//line sql.y:3419
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNotDistinctFrom, Left: sqlDollar[1].union.expr(), Right: sqlDollar[6].union.expr()}
 		}
 	case 580:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3414
+		//line sql.y:3423
 		{
 			sqlVAL.union.val = &IsOfTypeExpr{Expr: sqlDollar[1].union.expr(), Types: sqlDollar[5].union.colTypes()}
 		}
 	case 581:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:3418
+		//line sql.y:3427
 		{
 			sqlVAL.union.val = &IsOfTypeExpr{Not: true, Expr: sqlDollar[1].union.expr(), Types: sqlDollar[6].union.colTypes()}
 		}
 	case 582:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3422
+		//line sql.y:3431
 		{
 			sqlVAL.union.val = &RangeCond{Left: sqlDollar[1].union.expr(), From: sqlDollar[4].union.expr(), To: sqlDollar[6].union.expr()}
 		}
 	case 583:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:3426
+		//line sql.y:3435
 		{
 			sqlVAL.union.val = &RangeCond{Not: true, Left: sqlDollar[1].union.expr(), From: sqlDollar[5].union.expr(), To: sqlDollar[7].union.expr()}
 		}
 	case 584:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3430
+		//line sql.y:3439
 		{
 			sqlVAL.union.val = &RangeCond{Left: sqlDollar[1].union.expr(), From: sqlDollar[4].union.expr(), To: sqlDollar[6].union.expr()}
 		}
 	case 585:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:3434
+		//line sql.y:3443
 		{
 			sqlVAL.union.val = &RangeCond{Not: true, Left: sqlDollar[1].union.expr(), From: sqlDollar[5].union.expr(), To: sqlDollar[7].union.expr()}
 		}
 	case 586:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3438
+		//line sql.y:3447
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: In, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 587:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3442
+		//line sql.y:3451
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NotIn, Left: sqlDollar[1].union.expr(), Right: sqlDollar[4].union.expr()}
 		}
 	case 589:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3459
+		//line sql.y:3468
 		{
 			sqlVAL.union.val = &CastExpr{Expr: sqlDollar[1].union.expr(), Type: sqlDollar[3].union.colType()}
 		}
 	case 590:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3463
+		//line sql.y:3472
 		{
 			sqlVAL.union.val = &AnnotateTypeExpr{Expr: sqlDollar[1].union.expr(), Type: sqlDollar[3].union.colType()}
 		}
 	case 591:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3467
+		//line sql.y:3476
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryPlus, Expr: sqlDollar[2].union.expr()}
 		}
 	case 592:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3471
+		//line sql.y:3480
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryMinus, Expr: sqlDollar[2].union.expr()}
 		}
 	case 593:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3475
+		//line sql.y:3484
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryComplement, Expr: sqlDollar[2].union.expr()}
 		}
 	case 594:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3479
+		//line sql.y:3488
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Plus, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 595:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3483
+		//line sql.y:3492
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Minus, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 596:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3487
+		//line sql.y:3496
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Mult, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 597:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3491
+		//line sql.y:3500
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Div, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 598:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3495
+		//line sql.y:3504
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: FloorDiv, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 599:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3499
+		//line sql.y:3508
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Mod, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 600:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3503
+		//line sql.y:3512
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 601:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3507
+		//line sql.y:3516
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 602:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3511
+		//line sql.y:3520
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitand, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 603:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3515
+		//line sql.y:3524
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 604:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3519
+		//line sql.y:3528
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: LT, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 605:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3523
+		//line sql.y:3532
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: GT, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 606:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3527
+		//line sql.y:3536
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: EQ, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 607:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3531
+		//line sql.y:3540
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Concat, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 608:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3535
+		//line sql.y:3544
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: LShift, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 609:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3539
+		//line sql.y:3548
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: RShift, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 610:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3543
+		//line sql.y:3552
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: LE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 611:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3547
+		//line sql.y:3556
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: GE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 612:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3551
+		//line sql.y:3560
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 613:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3555
+		//line sql.y:3564
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsDistinctFrom, Left: sqlDollar[1].union.expr(), Right: sqlDollar[5].union.expr()}
 		}
 	case 614:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3559
+		//line sql.y:3568
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNotDistinctFrom, Left: sqlDollar[1].union.expr(), Right: sqlDollar[6].union.expr()}
 		}
 	case 615:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3563
+		//line sql.y:3572
 		{
 			sqlVAL.union.val = &IsOfTypeExpr{Expr: sqlDollar[1].union.expr(), Types: sqlDollar[5].union.colTypes()}
 		}
 	case 616:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:3567
+		//line sql.y:3576
 		{
 			sqlVAL.union.val = &IsOfTypeExpr{Not: true, Expr: sqlDollar[1].union.expr(), Types: sqlDollar[6].union.colTypes()}
 		}
 	case 617:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3579
+		//line sql.y:3588
 		{
 			sqlVAL.union.val = sqlDollar[1].union.unresolvedName()
 		}
 	case 619:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3584
+		//line sql.y:3593
 		{
 			sqlVAL.union.val = Placeholder{Name: sqlDollar[1].str}
 		}
 	case 620:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3588
+		//line sql.y:3597
 		{
 			sqlVAL.union.val = &ParenExpr{Expr: sqlDollar[2].union.expr()}
 		}
 	case 623:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3594
+		//line sql.y:3603
 		{
 			sqlVAL.union.val = &Subquery{Select: sqlDollar[1].union.selectStmt()}
 		}
 	case 624:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3598
+		//line sql.y:3607
 		{
 			sqlVAL.union.val = &Subquery{Select: sqlDollar[1].union.selectStmt()}
 		}
 	case 625:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3602
+		//line sql.y:3611
 		{
 			sqlVAL.union.val = &ExistsExpr{Subquery: &Subquery{Select: sqlDollar[2].union.selectStmt()}}
 		}
 	case 626:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3608
+		//line sql.y:3617
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 627:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3612
+		//line sql.y:3621
 		{
 			sqlVAL.union.val = sqlDollar[1].union.expr()
 		}
 	case 628:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3616
+		//line sql.y:3625
 		{
 			sqlVAL.union.val = sqlDollar[1].union.expr()
 		}
 	case 629:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3624
+		//line sql.y:3633
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.normalizableFunctionName()}
 		}
 	case 630:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3628
+		//line sql.y:3637
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.normalizableFunctionName(), Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 631:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3631
+		//line sql.y:3640
 		{
 			unimplemented()
 		}
 	case 632:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:3632
+		//line sql.y:3641
 		{
 			unimplemented()
 		}
 	case 633:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3634
+		//line sql.y:3643
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.normalizableFunctionName(), Type: All, Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 634:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3638
+		//line sql.y:3647
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.normalizableFunctionName(), Type: Distinct, Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 635:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3642
+		//line sql.y:3651
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.normalizableFunctionName(), Exprs: Exprs{StarExpr()}}
 		}
 	case 636:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3655
+		//line sql.y:3664
 		{
-			sqlVAL.union.val = sqlDollar[1].union.expr()
+			f := sqlDollar[1].union.expr().(*FuncExpr)
+			f.WindowDef = sqlDollar[4].union.windowDef()
+			sqlVAL.union.val = f
 		}
 	case 637:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3659
+		//line sql.y:3670
 		{
 			sqlVAL.union.val = sqlDollar[1].union.expr()
 		}
 	case 638:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3668
+		//line sql.y:3679
 		{
 			unimplemented()
 		}
 	case 639:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3669
+		//line sql.y:3680
 		{
 			unimplemented()
 		}
 	case 640:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3673
+		//line sql.y:3684
 		{
 			unimplemented()
 		}
 	case 641:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3675
+		//line sql.y:3686
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName(sqlDollar[1].str)}
 		}
 	case 642:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3679
+		//line sql.y:3690
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName(sqlDollar[1].str)}
 		}
 	case 643:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3683
+		//line sql.y:3694
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName(sqlDollar[1].str)}
 		}
 	case 644:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3687
+		//line sql.y:3698
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName(sqlDollar[1].str)}
 		}
 	case 645:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3690
+		//line sql.y:3701
 		{
 			unimplemented()
 		}
 	case 646:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3691
+		//line sql.y:3702
 		{
 			unimplemented()
 		}
 	case 647:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3692
+		//line sql.y:3703
 		{
 			unimplemented()
 		}
 	case 648:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3693
+		//line sql.y:3704
 		{
 			unimplemented()
 		}
 	case 649:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3695
+		//line sql.y:3706
 		{
 			sqlVAL.union.val = &CastExpr{Expr: sqlDollar[3].union.expr(), Type: sqlDollar[5].union.colType()}
 		}
 	case 650:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3699
+		//line sql.y:3710
 		{
 			sqlVAL.union.val = &AnnotateTypeExpr{Expr: sqlDollar[3].union.expr(), Type: sqlDollar[5].union.colType()}
 		}
 	case 651:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3703
+		//line sql.y:3714
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName(sqlDollar[1].str), Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 652:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3707
+		//line sql.y:3718
 		{
 			sqlVAL.union.val = &OverlayExpr{FuncExpr{Name: WrapQualifiedFunctionName(sqlDollar[1].str), Exprs: sqlDollar[3].union.exprs()}}
 		}
 	case 653:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3711
+		//line sql.y:3722
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName("STRPOS"), Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 654:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3715
+		//line sql.y:3726
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName(sqlDollar[1].str), Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 655:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3718
+		//line sql.y:3729
 		{
 			unimplemented()
 		}
 	case 656:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3720
+		//line sql.y:3731
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName("BTRIM"), Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 657:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3724
+		//line sql.y:3735
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName("LTRIM"), Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 658:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3728
+		//line sql.y:3739
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName("RTRIM"), Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 659:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3732
+		//line sql.y:3743
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName("BTRIM"), Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 660:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:3736
+		//line sql.y:3747
 		{
 			sqlVAL.union.val = &IfExpr{Cond: sqlDollar[3].union.expr(), True: sqlDollar[5].union.expr(), Else: sqlDollar[7].union.expr()}
 		}
 	case 661:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3740
+		//line sql.y:3751
 		{
 			sqlVAL.union.val = &NullIfExpr{Expr1: sqlDollar[3].union.expr(), Expr2: sqlDollar[5].union.expr()}
 		}
 	case 662:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3744
+		//line sql.y:3755
 		{
 			sqlVAL.union.val = &CoalesceExpr{Name: "IFNULL", Exprs: Exprs{sqlDollar[3].union.expr(), sqlDollar[5].union.expr()}}
 		}
 	case 663:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3748
+		//line sql.y:3759
 		{
 			sqlVAL.union.val = &CoalesceExpr{Name: "COALESCE", Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 664:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3752
+		//line sql.y:3763
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName(sqlDollar[1].str), Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 665:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3756
+		//line sql.y:3767
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName(sqlDollar[1].str), Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 666:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3762
+		//line sql.y:3773
 		{
 			unimplemented()
 		}
 	case 667:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3763
+		//line sql.y:3774
 		{
 		}
 	case 668:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3766
+		//line sql.y:3777
 		{
 			unimplemented()
 		}
 	case 669:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3767
+		//line sql.y:3778
 		{
 		}
 	case 670:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3771
+		//line sql.y:3783
 		{
-			unimplemented()
+			sqlVAL.union.val = sqlDollar[2].union.window()
 		}
 	case 671:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3772
+		//line sql.y:3787
 		{
+			sqlVAL.union.val = Window(nil)
 		}
 	case 672:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3775
+		//line sql.y:3793
 		{
-			unimplemented()
+			sqlVAL.union.val = Window{sqlDollar[1].union.windowDef()}
 		}
 	case 673:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3776
+		//line sql.y:3797
 		{
-			unimplemented()
+			sqlVAL.union.val = append(sqlDollar[1].union.window(), sqlDollar[3].union.windowDef())
 		}
 	case 674:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3779
+		//line sql.y:3803
 		{
-			unimplemented()
+			n := sqlDollar[3].union.windowDef()
+			n.Name = Name(sqlDollar[1].str)
+			sqlVAL.union.val = n
 		}
 	case 675:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3782
+		//line sql.y:3811
 		{
-			unimplemented()
+			sqlVAL.union.val = sqlDollar[2].union.windowDef()
 		}
 	case 676:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3783
+		//line sql.y:3815
 		{
-			unimplemented()
+			sqlVAL.union.val = &WindowDef{Name: Name(sqlDollar[2].str)}
 		}
 	case 677:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3784
+		//line sql.y:3819
 		{
+			sqlVAL.union.val = (*WindowDef)(nil)
 		}
 	case 678:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3788
+		//line sql.y:3826
 		{
-			unimplemented()
-		}
-	case 679:
-		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3799
-		{
-			unimplemented()
+			sqlVAL.union.val = &WindowDef{
+				RefName:    Name(sqlDollar[2].str),
+				Partitions: sqlDollar[3].union.exprs(),
+				OrderBy:    sqlDollar[4].union.orderBy(),
+			}
 		}
 	case 680:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3800
+		//line sql.y:3845
 		{
+			sqlVAL.str = ""
 		}
 	case 681:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3803
+		//line sql.y:3851
 		{
-			unimplemented()
+			sqlVAL.union.val = sqlDollar[3].union.exprs()
 		}
 	case 682:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3804
+		//line sql.y:3855
 		{
+			sqlVAL.union.val = Exprs(nil)
 		}
 	case 683:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3812
+		//line sql.y:3865
 		{
 			unimplemented()
 		}
 	case 684:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3813
+		//line sql.y:3866
 		{
 			unimplemented()
 		}
 	case 685:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3814
+		//line sql.y:3867
 		{
 		}
 	case 686:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3817
+		//line sql.y:3870
 		{
 			unimplemented()
 		}
 	case 687:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3818
+		//line sql.y:3871
 		{
 			unimplemented()
 		}
 	case 688:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3824
+		//line sql.y:3877
 		{
 			unimplemented()
 		}
 	case 689:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3825
+		//line sql.y:3878
 		{
 			unimplemented()
 		}
 	case 690:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3826
+		//line sql.y:3879
 		{
 			unimplemented()
 		}
 	case 691:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3827
+		//line sql.y:3880
 		{
 			unimplemented()
 		}
 	case 692:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3828
+		//line sql.y:3881
 		{
 			unimplemented()
 		}
 	case 693:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3839
+		//line sql.y:3892
 		{
 			sqlVAL.union.val = &Tuple{Exprs: sqlDollar[3].union.exprs(), row: true}
 		}
 	case 694:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3843
+		//line sql.y:3896
 		{
 			sqlVAL.union.val = &Tuple{Exprs: nil, row: true}
 		}
 	case 695:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3847
+		//line sql.y:3900
 		{
 			sqlVAL.union.val = &Tuple{Exprs: append(sqlDollar[2].union.exprs(), sqlDollar[4].union.expr())}
 		}
 	case 696:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3853
+		//line sql.y:3906
 		{
 			sqlVAL.union.val = &Tuple{Exprs: sqlDollar[3].union.exprs(), row: true}
 		}
 	case 697:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3857
+		//line sql.y:3910
 		{
 			sqlVAL.union.val = &Tuple{Exprs: nil, row: true}
 		}
 	case 698:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3863
+		//line sql.y:3916
 		{
 			sqlVAL.union.val = &Tuple{Exprs: append(sqlDollar[2].union.exprs(), sqlDollar[4].union.expr())}
 		}
 	case 699:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3906
+		//line sql.y:3959
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr()}
 		}
 	case 700:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3910
+		//line sql.y:3963
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.exprs(), sqlDollar[3].union.expr())
 		}
 	case 701:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3916
+		//line sql.y:3969
 		{
 			sqlVAL.union.val = []ColumnType{sqlDollar[1].union.colType()}
 		}
 	case 702:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3920
+		//line sql.y:3973
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.colTypes(), sqlDollar[3].union.colType())
 		}
 	case 703:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3926
+		//line sql.y:3979
 		{
 			sqlVAL.union.val = &Array{sqlDollar[2].union.exprs()}
 		}
 	case 704:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3930
+		//line sql.y:3983
 		{
 			sqlVAL.union.val = &Array{sqlDollar[2].union.exprs()}
 		}
 	case 705:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3934
+		//line sql.y:3987
 		{
 			sqlVAL.union.val = &Array{nil}
 		}
 	case 706:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3940
+		//line sql.y:3993
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr()}
 		}
 	case 707:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3944
+		//line sql.y:3997
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.exprs(), sqlDollar[3].union.expr())
 		}
 	case 708:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3950
+		//line sql.y:4003
 		{
 			sqlVAL.union.val = Exprs{&StrVal{s: sqlDollar[1].str}, sqlDollar[3].union.expr()}
 		}
 	case 716:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3972
+		//line sql.y:4025
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[2].union.expr(), sqlDollar[3].union.expr(), sqlDollar[4].union.expr()}
 		}
 	case 717:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3976
+		//line sql.y:4029
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[2].union.expr(), sqlDollar[3].union.expr()}
 		}
 	case 718:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3982
+		//line sql.y:4035
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 719:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3989
+		//line sql.y:4042
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[3].union.expr(), sqlDollar[1].union.expr()}
 		}
 	case 720:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3993
+		//line sql.y:4046
 		{
 			sqlVAL.union.val = Exprs(nil)
 		}
 	case 721:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4010
+		//line sql.y:4063
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[2].union.expr(), sqlDollar[3].union.expr()}
 		}
 	case 722:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4014
+		//line sql.y:4067
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[3].union.expr(), sqlDollar[2].union.expr()}
 		}
 	case 723:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4018
+		//line sql.y:4071
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[2].union.expr()}
 		}
 	case 724:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4022
+		//line sql.y:4075
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), NewDInt(1), sqlDollar[2].union.expr()}
 		}
 	case 725:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4026
+		//line sql.y:4079
 		{
 			sqlVAL.union.val = sqlDollar[1].union.exprs()
 		}
 	case 726:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:4030
+		//line sql.y:4083
 		{
 			sqlVAL.union.val = Exprs(nil)
 		}
 	case 727:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4036
+		//line sql.y:4089
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 728:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4042
+		//line sql.y:4095
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 729:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4048
+		//line sql.y:4101
 		{
 			sqlVAL.union.val = append(sqlDollar[3].union.exprs(), sqlDollar[1].union.expr())
 		}
 	case 730:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4052
+		//line sql.y:4105
 		{
 			sqlVAL.union.val = sqlDollar[2].union.exprs()
 		}
 	case 731:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4056
+		//line sql.y:4109
 		{
 			sqlVAL.union.val = sqlDollar[1].union.exprs()
 		}
 	case 732:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4062
+		//line sql.y:4115
 		{
 			sqlVAL.union.val = &Subquery{Select: sqlDollar[1].union.selectStmt()}
 		}
 	case 733:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4066
+		//line sql.y:4119
 		{
 			sqlVAL.union.val = &Tuple{Exprs: sqlDollar[2].union.exprs()}
 		}
 	case 734:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:4077
+		//line sql.y:4130
 		{
 			sqlVAL.union.val = &CaseExpr{Expr: sqlDollar[2].union.expr(), Whens: sqlDollar[3].union.whens(), Else: sqlDollar[4].union.expr()}
 		}
 	case 735:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4084
+		//line sql.y:4137
 		{
 			sqlVAL.union.val = []*When{sqlDollar[1].union.when()}
 		}
 	case 736:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4088
+		//line sql.y:4141
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.whens(), sqlDollar[2].union.when())
 		}
 	case 737:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:4094
+		//line sql.y:4147
 		{
 			sqlVAL.union.val = &When{Cond: sqlDollar[2].union.expr(), Val: sqlDollar[4].union.expr()}
 		}
 	case 738:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4100
+		//line sql.y:4153
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 739:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:4104
+		//line sql.y:4157
 		{
 			sqlVAL.union.val = Expr(nil)
 		}
 	case 741:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:4111
+		//line sql.y:4164
 		{
 			sqlVAL.union.val = Expr(nil)
 		}
 	case 742:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4117
+		//line sql.y:4170
 		{
 			sqlVAL.union.val = sqlDollar[1].union.namePart()
 		}
 	case 743:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4121
+		//line sql.y:4174
 		{
 			sqlVAL.union.val = sqlDollar[1].union.namePart()
 		}
 	case 744:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4125
+		//line sql.y:4178
 		{
 			sqlVAL.union.val = &ArraySubscript{Begin: sqlDollar[2].union.expr()}
 		}
 	case 745:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:4129
+		//line sql.y:4182
 		{
 			sqlVAL.union.val = &ArraySubscript{Begin: sqlDollar[2].union.expr(), End: sqlDollar[4].union.expr()}
 		}
 	case 746:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4135
+		//line sql.y:4188
 		{
 			sqlVAL.union.val = Name(sqlDollar[2].str)
 		}
 	case 747:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4141
+		//line sql.y:4194
 		{
 			sqlVAL.union.val = UnqualifiedStar{}
 		}
 	case 748:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4147
+		//line sql.y:4200
 		{
 			sqlVAL.union.val = UnresolvedName{sqlDollar[1].union.namePart()}
 		}
 	case 749:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4151
+		//line sql.y:4204
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.unresolvedName(), sqlDollar[2].union.namePart())
 		}
 	case 750:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4156
+		//line sql.y:4209
 		{
 		}
 	case 751:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:4157
+		//line sql.y:4210
 		{
 		}
 	case 753:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4166
+		//line sql.y:4219
 		{
 			sqlVAL.union.val = DefaultVal{}
 		}
 	case 754:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4172
+		//line sql.y:4225
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr()}
 		}
 	case 755:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4176
+		//line sql.y:4229
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.exprs(), sqlDollar[3].union.expr())
 		}
 	case 756:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4185
+		//line sql.y:4238
 		{
 			sqlVAL.union.val = sqlDollar[2].union.exprs()
 		}
 	case 757:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4191
+		//line sql.y:4244
 		{
 			sqlVAL.union.val = SelectExprs{sqlDollar[1].union.selExpr()}
 		}
 	case 758:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4195
+		//line sql.y:4248
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.selExprs(), sqlDollar[3].union.selExpr())
 		}
 	case 759:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4201
+		//line sql.y:4254
 		{
 			sqlVAL.union.val = SelectExpr{Expr: sqlDollar[1].union.expr(), As: Name(sqlDollar[3].str)}
 		}
 	case 760:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4210
+		//line sql.y:4263
 		{
 			sqlVAL.union.val = SelectExpr{Expr: sqlDollar[1].union.expr(), As: Name(sqlDollar[2].str)}
 		}
 	case 761:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4214
+		//line sql.y:4267
 		{
 			sqlVAL.union.val = SelectExpr{Expr: sqlDollar[1].union.expr()}
 		}
 	case 762:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4218
+		//line sql.y:4271
 		{
 			sqlVAL.union.val = starSelectExpr()
 		}
 	case 763:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4226
+		//line sql.y:4279
 		{
 			sqlVAL.union.val = UnresolvedNames{sqlDollar[1].union.unresolvedName()}
 		}
 	case 764:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4230
+		//line sql.y:4283
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.unresolvedNames(), sqlDollar[3].union.unresolvedName())
 		}
 	case 765:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4236
+		//line sql.y:4289
 		{
 			sqlVAL.union.val = TableNameWithIndexList{sqlDollar[1].union.tableWithIdx()}
 		}
 	case 766:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4240
+		//line sql.y:4293
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.tableWithIdxList(), sqlDollar[3].union.tableWithIdx())
 		}
 	case 767:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4246
+		//line sql.y:4299
 		{
 			sqlVAL.union.val = TablePatterns{sqlDollar[1].union.unresolvedName()}
 		}
 	case 768:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4250
+		//line sql.y:4303
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.tablePatterns(), sqlDollar[3].union.unresolvedName())
 		}
 	case 769:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4261
+		//line sql.y:4314
 		{
 			sqlVAL.union.val = UnresolvedName{Name(sqlDollar[1].str)}
 		}
 	case 770:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4265
+		//line sql.y:4318
 		{
 			sqlVAL.union.val = append(UnresolvedName{Name(sqlDollar[1].str)}, sqlDollar[2].union.unresolvedName()...)
 		}
 	case 771:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4271
+		//line sql.y:4324
 		{
 			sqlVAL.union.val = &TableNameWithIndex{Table: sqlDollar[1].union.normalizableTableName(), Index: Name(sqlDollar[3].str)}
 		}
 	case 772:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4282
+		//line sql.y:4335
 		{
 			sqlVAL.union.val = UnresolvedName{Name(sqlDollar[1].str)}
 		}
 	case 773:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4286
+		//line sql.y:4339
 		{
 			sqlVAL.union.val = UnresolvedName{UnqualifiedStar{}}
 		}
 	case 774:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4290
+		//line sql.y:4343
 		{
 			sqlVAL.union.val = UnresolvedName{Name(sqlDollar[1].str), sqlDollar[2].union.namePart()}
 		}
 	case 775:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4294
+		//line sql.y:4347
 		{
 			sqlVAL.union.val = UnresolvedName{Name(sqlDollar[1].str), sqlDollar[2].union.namePart()}
 		}
 	case 776:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4300
+		//line sql.y:4353
 		{
 			sqlVAL.union.val = NameList{Name(sqlDollar[1].str)}
 		}
 	case 777:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4304
+		//line sql.y:4357
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.nameList(), Name(sqlDollar[3].str))
 		}
 	case 778:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4310
+		//line sql.y:4363
 		{
 			sqlVAL.union.val = sqlDollar[2].union.nameList()
 		}
 	case 779:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:4313
+		//line sql.y:4366
 		{
 		}
 	case 780:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4323
+		//line sql.y:4376
 		{
 			sqlVAL.union.val = UnresolvedName{Name(sqlDollar[1].str)}
 		}
 	case 781:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4327
+		//line sql.y:4380
 		{
 			sqlVAL.union.val = append(UnresolvedName{Name(sqlDollar[1].str)}, sqlDollar[2].union.unresolvedName()...)
 		}
 	case 782:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4334
+		//line sql.y:4387
 		{
 			sqlVAL.union.val = sqlDollar[1].union.numVal()
 		}
 	case 783:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4338
+		//line sql.y:4391
 		{
 			sqlVAL.union.val = sqlDollar[1].union.numVal()
 		}
 	case 784:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4342
+		//line sql.y:4395
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
 	case 785:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4346
+		//line sql.y:4399
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str, bytesEsc: true}
 		}
 	case 786:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:4349
+		//line sql.y:4402
 		{
 			unimplemented()
 		}
 	case 787:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4351
+		//line sql.y:4404
 		{
 			sqlVAL.union.val = &CastExpr{Expr: &StrVal{s: sqlDollar[2].str}, Type: sqlDollar[1].union.colType()}
 		}
 	case 788:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4355
+		//line sql.y:4408
 		{
 			sqlVAL.union.val = &CastExpr{Expr: &StrVal{s: sqlDollar[2].str}, Type: sqlDollar[1].union.colType()}
 		}
 	case 789:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:4359
+		//line sql.y:4412
 		{
 			sqlVAL.union.val = &CastExpr{Expr: &StrVal{s: sqlDollar[5].str}, Type: sqlDollar[1].union.colType()}
 		}
 	case 790:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4363
+		//line sql.y:4416
 		{
 			sqlVAL.union.val = MakeDBool(true)
 		}
 	case 791:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4367
+		//line sql.y:4420
 		{
 			sqlVAL.union.val = MakeDBool(false)
 		}
 	case 792:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4371
+		//line sql.y:4424
 		{
 			sqlVAL.union.val = DNull
 		}
 	case 794:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4378
+		//line sql.y:4431
 		{
 			sqlVAL.union.val = sqlDollar[2].union.numVal()
 		}
 	case 795:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4382
+		//line sql.y:4435
 		{
 			sqlVAL.union.val = &NumVal{Value: constant.UnaryOp(token.SUB, sqlDollar[2].union.numVal().Value, 0)}
 		}
 	case 800:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:4404
+		//line sql.y:4457
 		{
 			sqlVAL.str = ""
 		}
 	case 801:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4410
+		//line sql.y:4463
 		{
 			sqlVAL.str = sqlDollar[2].str
 		}
 	case 802:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:4414
+		//line sql.y:4467
 		{
 			sqlVAL.str = ""
 		}

--- a/sql/parser/window.go
+++ b/sql/parser/window.go
@@ -1,0 +1,69 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nathan VanBenschoten (nvanbenschoten@gmail.com)
+
+package parser
+
+var _ Visitor = &ContainsWindowVisitor{}
+
+// ContainsWindowVisitor checks if walked expressions contain window functions.
+type ContainsWindowVisitor struct {
+	sawWindow bool
+}
+
+// VisitPre satisfies the Visitor interface.
+func (v *ContainsWindowVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
+	switch t := expr.(type) {
+	case *FuncExpr:
+		if t.IsWindowFunction() {
+			v.sawWindow = true
+			return false, expr
+		}
+	case *Subquery:
+		return false, expr
+	}
+	return true, expr
+}
+
+// VisitPost satisfies the Visitor interface.
+func (*ContainsWindowVisitor) VisitPost(expr Expr) Expr { return expr }
+
+// ContainsWindowFunc determines if an Expr contains a window function.
+func (v *ContainsWindowVisitor) ContainsWindowFunc(expr Expr) bool {
+	if expr != nil {
+		WalkExprConst(v, expr)
+		ret := v.sawWindow
+		v.sawWindow = false
+		return ret
+	}
+	return false
+}
+
+// WindowFuncInExpr determines if an Expr contains a window function, using
+// the Parser's embedded visitor.
+func (p *Parser) WindowFuncInExpr(expr Expr) bool {
+	return p.containsWindowVisitor.ContainsWindowFunc(expr)
+}
+
+// WindowFuncInExprs determines if any of the provided TypedExpr contains a
+// window function, using the Parser's embedded visitor.
+func (p *Parser) WindowFuncInExprs(exprs []TypedExpr) bool {
+	for _, expr := range exprs {
+		if p.WindowFuncInExpr(expr) {
+			return true
+		}
+	}
+	return false
+}

--- a/sql/returning.go
+++ b/sql/returning.go
@@ -17,8 +17,6 @@
 package sql
 
 import (
-	"fmt"
-
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
 )
@@ -50,8 +48,8 @@ func (p *planner) makeReturningHelper(
 	}
 
 	for _, e := range r {
-		if p.parser.AggregateInExpr(e.Expr) {
-			return rh, fmt.Errorf("aggregate functions are not allowed in RETURNING")
+		if err := p.parser.AssertNoAggregationOrWindowing(e.Expr, "RETURNING"); err != nil {
+			return rh, err
 		}
 	}
 

--- a/sql/sqlbase/table.go
+++ b/sql/sqlbase/table.go
@@ -141,8 +141,8 @@ func MakeColumnDefDescs(d *parser.ColumnTableDef) (*ColumnDescriptor, *IndexDesc
 			return nil, nil, err
 		}
 		var p parser.Parser
-		if p.AggregateInExpr(d.DefaultExpr.Expr) {
-			return nil, nil, fmt.Errorf("Aggregate functions are not allowed in DEFAULT expressions")
+		if err := p.AssertNoAggregationOrWindowing(d.DefaultExpr.Expr, "DEFAULT expressions"); err != nil {
+			return nil, nil, err
 		}
 		s := d.DefaultExpr.Expr.String()
 		col.DefaultExpr = &s

--- a/sql/testdata/check_constraints
+++ b/sql/testdata/check_constraints
@@ -82,6 +82,10 @@ INSERT INTO calls_func VALUES (-5)
 statement error aggregate functions are not allowed in CHECK expressions
 CREATE TABLE bad (a INT CHECK(SUM(a) > 1))
 
+# Window function calls in CHECK are not ok.
+statement error window functions are not allowed in CHECK expressions
+CREATE TABLE bad (a INT CHECK(SUM(a) OVER () > 1))
+
 # fail on bad check types
 statement error pq: unsupported binary operator: <bool> - <bool>
 CREATE TABLE t4 (a INT CHECK (false - true))

--- a/sql/testdata/default
+++ b/sql/testdata/default
@@ -11,8 +11,12 @@ statement error DEFAULT expression .* may not contain variable sub-expressions
 CREATE TABLE t (a INT PRIMARY KEY DEFAULT b)
 
 # Aggregate function calls in CHECK are not ok.
-statement error Aggregate functions are not allowed in DEFAULT expressions
+statement error aggregate functions are not allowed in DEFAULT expressions
 CREATE TABLE bad (a INT DEFAULT COUNT(1))
+
+# Window function calls in CHECK are not ok.
+statement error window functions are not allowed in DEFAULT expressions
+CREATE TABLE bad (a INT DEFAULT COUNT(1) OVER ())
 
 statement ok
 CREATE TABLE t (

--- a/sql/testdata/window
+++ b/sql/testdata/window
@@ -1,0 +1,418 @@
+statement ok
+CREATE TABLE kv (
+  -- don't add column "a"
+  k INT PRIMARY KEY,
+  v INT,
+  w INT,
+  f FLOAT,
+  d DECIMAL,
+  s STRING,
+  b BOOL
+)
+
+statement OK
+INSERT INTO kv VALUES
+(1, 2, 3, 1.0, 1, 'a', true),
+(3, 4, 5, 2, 8, 'a', true),
+(5, NULL, 5, 9.9, -321, NULL, false),
+(6, 2, 3, 4.4, 4.4, 'b', true),
+(7, 2, 2, 6, 7.9, 'b', true),
+(8, 4, 2, 3, 3, 'A', false)
+
+query error window functions are not allowed in GROUP BY
+SELECT * FROM kv GROUP BY v, COUNT(w) OVER ()
+
+query error window functions are not allowed in RETURNING
+INSERT INTO kv (k, v) VALUES (99, 100) RETURNING sum(v) OVER ()
+
+query error window functions are not allowed in LIMIT
+SELECT SUM(v) FROM kv GROUP BY k LIMIT SUM(v) OVER ()
+
+query error window functions are not allowed in OFFSET
+SELECT SUM(v) FROM kv GROUP BY k LIMIT 1 OFFSET SUM(v) OVER ()
+
+query error window functions are not allowed in VALUES
+INSERT INTO kv (k, v) VALUES (99, COUNT(1) OVER ())
+
+query error window functions are not allowed in WHERE
+SELECT k FROM kv WHERE AVG(k) OVER () > 1
+
+query R
+SELECT avg(k) OVER () FROM kv ORDER BY 1
+----
+5.0000000000000000
+5.0000000000000000
+5.0000000000000000
+5.0000000000000000
+5.0000000000000000
+5.0000000000000000
+
+query R
+SELECT avg(k) OVER (PARTITION BY v) FROM kv ORDER BY 1
+----
+4.6666666666666667
+4.6666666666666667
+4.6666666666666667
+5.0000000000000000
+5.5000000000000000
+5.5000000000000000
+
+query R
+SELECT avg(k) OVER (ORDER BY w) FROM kv ORDER BY 1
+----
+5.0000000000000000
+5.0000000000000000
+5.5000000000000000
+5.5000000000000000
+7.5000000000000000
+7.5000000000000000
+
+query R
+SELECT avg(k) OVER (ORDER BY w DESC) FROM kv ORDER BY 1
+----
+3.7500000000000000
+3.7500000000000000
+4.0000000000000000
+4.0000000000000000
+5.0000000000000000
+5.0000000000000000
+
+query R
+SELECT avg(k) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+4.6666666666666667
+4.6666666666666667
+5.0000000000000000
+5.5000000000000000
+7.0000000000000000
+8.0000000000000000
+
+query R
+SELECT avg(k) OVER w FROM kv WINDOW w AS (PARTITION BY v ORDER BY w) ORDER BY 1
+----
+4.6666666666666667
+4.6666666666666667
+5.0000000000000000
+5.5000000000000000
+7.0000000000000000
+8.0000000000000000
+
+query R
+SELECT avg(k) OVER (w) FROM kv WINDOW w AS (PARTITION BY v ORDER BY w) ORDER BY 1
+----
+4.6666666666666667
+4.6666666666666667
+5.0000000000000000
+5.5000000000000000
+7.0000000000000000
+8.0000000000000000
+
+query R
+SELECT avg(k) OVER (w ORDER BY w) FROM kv WINDOW w AS (PARTITION BY v) ORDER BY 1
+----
+4.6666666666666667
+4.6666666666666667
+5.0000000000000000
+5.5000000000000000
+7.0000000000000000
+8.0000000000000000
+
+query IIIRRTBR colnames
+SELECT *, avg(k) OVER (w ORDER BY w) FROM kv WINDOW w AS (PARTITION BY v) ORDER BY 1
+----
+k  v     w  f    d     s     b      avg(k) OVER (w ORDER BY w)
+1  2     3  1    1     a     true   4.6666666666666667
+3  4     5  2    8     a     true   5.5000000000000000
+5  NULL  5  9.9  -321  NULL  false  5.0000000000000000
+6  2     3  4.4  4.4   b     true   4.6666666666666667
+7  2     2  6    7.9   b     true   7.0000000000000000
+8  4     2  3    3     A     false  8.0000000000000000
+
+query IIIRRTBR colnames
+SELECT *, avg(k) OVER w FROM kv WINDOW w AS (PARTITION BY v ORDER BY w) ORDER BY avg(k) OVER w, k
+----
+k  v     w  f    d     s     b      avg(k) OVER w
+1  2     3  1    1     a     true   4.6666666666666667
+6  2     3  4.4  4.4   b     true   4.6666666666666667
+5  NULL  5  9.9  -321  NULL  false  5.0000000000000000
+3  4     5  2    8     a     true   5.5000000000000000
+7  2     2  6    7.9   b     true   7.0000000000000000
+8  4     2  3    3     A     false  8.0000000000000000
+
+query IIIRRTB colnames
+SELECT * FROM kv WINDOW w AS (PARTITION BY v ORDER BY w) ORDER BY avg(k) OVER w DESC, k
+----
+k  v     w  f    d     s     b
+8  4     2  3    3     A     false
+7  2     2  6    7.9   b     true
+3  4     5  2    8     a     true
+5  NULL  5  9.9  -321  NULL  false
+1  2     3  1    1     a     true
+6  2     3  4.4  4.4   b     true
+
+query error window "w" is already defined
+SELECT avg(k) OVER w FROM kv WINDOW w AS (), w AS ()
+
+query error window "x" does not exist
+SELECT avg(k) OVER x FROM kv WINDOW w AS ()
+
+query error window "x" does not exist
+SELECT avg(k) OVER (x) FROM kv WINDOW w AS ()
+
+query error cannot override PARTITION BY clause of window "w"
+SELECT avg(k) OVER (w PARTITION BY v) FROM kv WINDOW w AS ()
+
+query error cannot override PARTITION BY clause of window "w"
+SELECT avg(k) OVER (w PARTITION BY v) FROM kv WINDOW w AS (PARTITION BY v)
+
+query error cannot override ORDER BY clause of window "w"
+SELECT avg(k) OVER (w ORDER BY v) FROM kv WINDOW w AS (ORDER BY v)
+
+query error column name "a" not found
+SELECT avg(k) OVER (PARTITION BY a) FROM kv
+
+query error column name "a" not found
+SELECT avg(k) OVER (ORDER BY a) FROM kv
+
+query error aggregate function calls cannot contain window function call avg
+SELECT avg(avg(k) OVER ()) FROM kv ORDER BY 1
+
+query R
+SELECT avg(avg(k)) OVER () FROM kv ORDER BY 1
+----
+5.0000000000000000
+
+query error OVER specified, but now is not a window function nor an aggregate function
+SELECT now() OVER () FROM kv ORDER BY 1
+
+query error window function calls cannot be nested under avg
+SELECT avg(avg(k) OVER ()) OVER () FROM kv ORDER BY 1
+
+query error OVER specified, but round is not a window function nor an aggregate function
+SELECT round(avg(k) OVER ()) OVER () FROM kv ORDER BY 1
+
+query R
+SELECT round(avg(k) OVER (PARTITION BY v ORDER BY w)) FROM kv ORDER BY 1
+----
+5
+5
+5
+6
+7
+8
+
+query R
+SELECT avg(f) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+2.5
+3
+3.8000000000000003
+3.8000000000000003
+6
+9.9
+
+query R
+SELECT avg(d) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+-321.0000000000000000
+   3.0000000000000000
+   4.4333333333333333
+   4.4333333333333333
+   5.5000000000000000
+   7.9000000000000000
+
+query IB
+SELECT k, bool_and(b) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1  true
+3  false
+5  false
+6  true
+7  true
+8  false
+
+query IB
+SELECT k, bool_or(b) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1  true
+3  true
+5  false
+6  true
+7  true
+8  false
+
+query II
+SELECT k, count(d) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1  3
+3  2
+5  1
+6  3
+7  1
+8  1
+
+query II
+SELECT k, count(*) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1  3
+3  2
+5  1
+6  3
+7  1
+8  1
+
+query IR
+SELECT k, max(d) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1  7.9
+3  8
+5  -321
+6  7.9
+7  7.9
+8  3
+
+query IR
+SELECT k, min(d) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1  1
+3  3
+5  -321
+6  1
+7  7.9
+8  3
+
+query IR
+SELECT k, max(d) OVER (PARTITION BY v) FROM kv ORDER BY 1
+----
+1  7.9
+3  8
+5  -321
+6  7.9
+7  7.9
+8  8
+
+query IR
+SELECT k, sum(d) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1  13.3
+3  11
+5  -321
+6  13.3
+7  7.9
+8  3
+
+query IR
+SELECT k, variance(d) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1  11.9033333333333333
+3  12.5000000000000000
+5  NULL
+6  11.9033333333333333
+7  NULL
+8  NULL
+
+query IR
+SELECT k, stddev(d) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1  3.4501207708330057
+3  3.5355339059327376
+5  NULL
+6  3.4501207708330057
+7  NULL
+8  NULL
+
+query IR
+SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
+----
+5  NULL
+1  3.4501207708330057
+6  3.4501207708330057
+7  3.4501207708330057
+3  3.5355339059327376
+8  3.5355339059327376
+
+query IRIR
+SELECT * FROM (SELECT k, d, v, stddev(d) OVER (PARTITION BY v) FROM kv) sub ORDER BY variance(d) OVER (PARTITION BY v), k
+----
+5  -321  NULL  NULL
+1  1     2     3.4501207708330057
+6  4.4   2     3.4501207708330057
+7  7.9   2     3.4501207708330057
+3  8     4     3.5355339059327376
+8  3     4     3.5355339059327376
+
+query IR
+SELECT k, max(stddev) OVER (ORDER BY d) FROM (SELECT k, d, stddev(d) OVER (PARTITION BY v) as stddev FROM kv) sub ORDER BY 2, k
+----
+5  NULL
+1  3.4501207708330057
+3  3.5355339059327376
+6  3.5355339059327376
+7  3.5355339059327376
+8  3.5355339059327376
+
+query IR
+SELECT k, max(stddev) OVER (ORDER BY d DESC) FROM (SELECT k, d, stddev(d) OVER (PARTITION BY v) as stddev FROM kv) sub ORDER BY 2, k
+----
+1  3.5355339059327376
+3  3.5355339059327376
+5  3.5355339059327376
+6  3.5355339059327376
+7  3.5355339059327376
+8  3.5355339059327376
+
+query ITT
+EXPLAIN SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
+----
+0  sort    +"variance(d) OVER w",+k
+1  window  stddev(d) OVER w, variance(d) OVER w
+2  scan    kv@primary -
+
+query ITTT
+EXPLAIN (DEBUG) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
+----
+0  /kv/primary/1/v  /2                                            PARTIAL
+0  /kv/primary/1/d  1                                             PARTIAL
+0  /kv/primary/1/s  'a'                                           BUFFERED
+1  /kv/primary/3/v  /4                                            PARTIAL
+1  /kv/primary/3/d  8                                             PARTIAL
+1  /kv/primary/3/s  'a'                                           BUFFERED
+2  /kv/primary/5    NULL                                          PARTIAL
+2  /kv/primary/5/d  -321                                          BUFFERED
+3  /kv/primary/6/v  /2                                            PARTIAL
+3  /kv/primary/6/d  4.4                                           PARTIAL
+3  /kv/primary/6/s  'b'                                           BUFFERED
+4  /kv/primary/7/v  /2                                            PARTIAL
+4  /kv/primary/7/d  7.9                                           PARTIAL
+4  /kv/primary/7/s  'b'                                           BUFFERED
+5  /kv/primary/8/v  /4                                            PARTIAL
+5  /kv/primary/8/d  3                                             PARTIAL
+5  /kv/primary/8/s  'A'                                           BUFFERED
+0  0                (1, 3.4501207708330057, 11.9033333333333334)  BUFFERED
+1  1                (3, 3.5355339059327376, 12.5000000000000000)  BUFFERED
+2  2                (5, NULL, NULL)                               BUFFERED
+3  3                (6, 3.4501207708330057, 11.9033333333333334)  BUFFERED
+4  4                (7, 3.4501207708330057, 11.9033333333333334)  BUFFERED
+5  5                (8, 3.5355339059327376, 12.5000000000000000)  BUFFERED
+0  0                (5, NULL, NULL)                               ROW
+1  1                (1, 3.4501207708330057, 11.9033333333333334)  ROW
+2  2                (6, 3.4501207708330057, 11.9033333333333334)  ROW
+3  3                (7, 3.4501207708330057, 11.9033333333333334)  ROW
+4  4                (3, 3.5355339059327376, 12.5000000000000000)  ROW
+5  5                (8, 3.5355339059327376, 12.5000000000000000)  ROW
+
+query ITTT
+EXPLAIN (TYPES) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
+----
+0  select         result                     (k int, "stddev(d) OVER w" decimal)
+1  sort           result                     (k int, "stddev(d) OVER w" decimal)
+2  window         result                     (k int, "stddev(d) OVER w" decimal, "variance(d) OVER w" decimal)
+2  window         render stddev(d) OVER w    (stddev((d)[decimal]) OVER w)[decimal]
+2  window         render variance(d) OVER w  (variance((d)[decimal]) OVER w)[decimal]
+3  render/filter  result                     (k int, d decimal, d decimal, v int, v int)
+3  render/filter  render 0                   (k)[int]
+3  render/filter  render 1                   (d)[decimal]
+3  render/filter  render 2                   (d)[decimal]
+3  render/filter  render 3                   (v)[int]
+3  render/filter  render 4                   (v)[int]
+4  scan           result                     (k int, v int, w int, f float, d decimal, s string, b bool)

--- a/sql/values.go
+++ b/sql/values.go
@@ -70,8 +70,8 @@ func (p *planner) ValuesClause(n *parser.ValuesClause, desiredTypes []parser.Dat
 		tupleBuf = tupleBuf[numCols:]
 
 		for i, expr := range tuple.Exprs {
-			if p.parser.AggregateInExpr(expr) {
-				return nil, fmt.Errorf("aggregate functions are not allowed in VALUES")
+			if err := p.parser.AssertNoAggregationOrWindowing(expr, "VALUES"); err != nil {
+				return nil, err
 			}
 
 			desired := parser.NoTypePreference

--- a/sql/window.go
+++ b/sql/window.go
@@ -1,0 +1,744 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nathan VanBenschoten (nvanbenschoten@gmail.com)
+
+package sql
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+
+	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/util/encoding"
+	"github.com/pkg/errors"
+)
+
+// window constructs a windowNode according to window function applications. This may
+// adjust the render targets in the selectNode as necessary. The use of window functions
+// will run with a space complexity of O(NW) (N = number of rows, W = number of windows)
+// and a time complexity of O(NW) (no ordering), O(W*NlogN) (with ordering), and
+// O(W*N^2) (with constant or variable sized window-frames, which are not yet supported).
+//
+// This code uses the following terminology throughout:
+// - window:
+//     the optionally-ordered subset of data over which calculations are made, defined by
+//     the window definition for a given window function application.
+// - built-in window functions:
+//     a set of built-in functions that can only be used in the context of a window
+//     through a window function application, using window function syntax.
+//     Ex. row_number(), rank(), dense_rank()
+// - window function application:
+//     the act of applying a built-in window function or built-in aggregation function
+//     over a specific window. The application performs a calculation across a set of
+//     table rows that are somehow related to the current row. Unlike regular aggregate
+//     functions, window function application does not cause rows to become grouped into
+//     a single output row — the rows retain their separate identities.
+// - window definition:
+//     the defined window to apply a window function over, which is stated in a window
+//     function application's OVER clause.
+//     Ex. SELECT avg(x) OVER (w PARTITION BY z) FROM y
+//                            ^^^^^^^^^^^^^^^^^^
+// - named window specification:
+//     a named window provided at the end of a SELECT clause in the WINDOW clause that
+//     can be referenced by the window definition of of one or more window function
+//     applications. This window can be used directly as a window definition, or can be
+//     overridden in a window definition.
+//     Ex. used directly: SELECT avg(x) OVER w FROM y WINDOW w AS (ORDER BY z)
+//                                                           ^^^^^^^^^^^^^^^^^
+//     Ex. overridden: SELECT avg(x) OVER (w PARTITION BY z) FROM y WINDOW w AS (ORDER BY z)
+//                                                                         ^^^^^^^^^^^^^^^^^
+func (p *planner) window(n *parser.SelectClause, s *selectNode) (*windowNode, error) {
+	// Determine if a window function is being applied. We use the selectNode's
+	// renders to determine this because window functions may be added to the
+	// selectNode by an ORDER BY clause.
+	// For instance: SELECT x FROM y ORDER BY avg(x) OVER ().
+	if containsWindowFn := p.parser.WindowFuncInExprs(s.render); !containsWindowFn {
+		return nil, nil
+	}
+
+	window := &windowNode{
+		planner:      p,
+		values:       valuesNode{columns: s.columns},
+		windowRender: make([]parser.TypedExpr, len(s.render)),
+	}
+
+	visitor := extractWindowFuncsVisitor{
+		n:              window,
+		aggregatesSeen: make(map[*parser.FuncExpr]struct{}),
+	}
+
+	// Loop over the render expressions and extract any window functions. While looping
+	// over the renders, each window function will be replaced by a separate render for
+	// each of its (possibly 0) arguments in the selectNode.
+	oldRenders := s.render
+	oldColumns := s.columns
+	s.render = make([]parser.TypedExpr, 0, len(oldRenders))
+	s.columns = make([]ResultColumn, 0, len(oldColumns))
+	for i := range oldRenders {
+		// Add all window function applications found in oldRenders[i] to window.funcs.
+		typedExpr, numFuncsAdded, err := visitor.extract(oldRenders[i])
+		if err != nil {
+			return nil, err
+		}
+		if numFuncsAdded == 0 {
+			// No window functions in render.
+			s.render = append(s.render, oldRenders[i])
+			s.columns = append(s.columns, oldColumns[i])
+		} else {
+			// One or more window functions in render. Create a new render in
+			// selectNode for each window function argument.
+			window.windowRender[i] = typedExpr
+			prevWindowCount := len(window.funcs) - numFuncsAdded
+			for i, funcHolder := range window.funcs[prevWindowCount:] {
+				funcHolder.funcIdx = prevWindowCount + i
+				funcHolder.subRenderCol = len(s.render)
+				arg := funcHolder.arg
+				s.render = append(s.render, arg)
+				s.columns = append(s.columns, ResultColumn{
+					Name: arg.String(),
+					Typ:  arg.ReturnType(),
+				})
+			}
+		}
+	}
+
+	if err := window.constructWindowDefinitions(n, s); err != nil {
+		return nil, err
+	}
+	return window, nil
+}
+
+// constructWindowDefinitions creates window definitions for each window
+// function application by combining specific window definition from a
+// given window function application with referenced window specifications
+// on the SelectClause.
+func (n *windowNode) constructWindowDefinitions(sc *parser.SelectClause, s *selectNode) error {
+	// Process each named window specification on the select clause.
+	namedWindowSpecs := make(map[string]*parser.WindowDef, len(sc.Window))
+	for _, windowDef := range sc.Window {
+		name := sqlbase.NormalizeName(windowDef.Name)
+		if _, ok := namedWindowSpecs[name]; ok {
+			return errors.Errorf("window %q is already defined", name)
+		}
+		namedWindowSpecs[name] = windowDef
+	}
+
+	// Construct window definitions for each window function application.
+	for _, windowFn := range n.funcs {
+		windowDef, err := constructWindowDef(*windowFn.expr.WindowDef, namedWindowSpecs)
+		if err != nil {
+			return err
+		}
+
+		// TODO(nvanbenschoten) below we add renders to the selectNode for each
+		// partition and order expression. We should handle cases where the expression
+		// is already referenced by the query like sortNode does.
+
+		// Validate PARTITION BY clause.
+		for _, partition := range windowDef.Partitions {
+			windowFn.partitionIdxs = append(windowFn.partitionIdxs, len(s.render))
+			if err := s.addRender(parser.SelectExpr{Expr: partition}, nil); err != nil {
+				return err
+			}
+		}
+
+		// Validate ORDER BY clause.
+		for _, orderBy := range windowDef.OrderBy {
+			direction := encoding.Ascending
+			if orderBy.Direction == parser.Descending {
+				direction = encoding.Descending
+			}
+			ordering := sqlbase.ColumnOrderInfo{
+				ColIdx:    len(s.render),
+				Direction: direction,
+			}
+			windowFn.columnOrdering = append(windowFn.columnOrdering, ordering)
+			if err := s.addRender(parser.SelectExpr{Expr: orderBy.Expr}, nil); err != nil {
+				return err
+			}
+		}
+
+		windowFn.windowDef = windowDef
+	}
+	return nil
+}
+
+// constructWindowDef constructs a WindowDef using the provided WindowDef value and the
+// set of named window specifications on the current SELECT clause. If the provided
+// WindowDef does not reference a named window spec, then it will simply be returned without
+// modification. If the provided WindowDef does reference a named window spec, then the
+// referenced spec will be overridden with any extra clauses from the WindowDef and returned.
+func constructWindowDef(
+	def parser.WindowDef,
+	namedWindowSpecs map[string]*parser.WindowDef,
+) (parser.WindowDef, error) {
+	modifyRef := false
+	var refName string
+	switch {
+	case def.RefName != "":
+		// SELECT rank() OVER (w) FROM t WINDOW w as (...)
+		// We copy the referenced window specification, and modify it if necessary.
+		refName = sqlbase.NormalizeName(def.RefName)
+		modifyRef = true
+	case def.Name != "":
+		// SELECT rank() OVER w FROM t WINDOW w as (...)
+		// We use the referenced window specification directly, without modification.
+		refName = sqlbase.NormalizeName(def.Name)
+	}
+	if refName == "" {
+		return def, nil
+	}
+
+	referencedSpec, ok := namedWindowSpecs[refName]
+	if !ok {
+		return def, errors.Errorf("window %q does not exist", refName)
+	}
+	if !modifyRef {
+		return *referencedSpec, nil
+	}
+
+	// referencedSpec.Partitions is always used.
+	if def.Partitions != nil {
+		return def, errors.Errorf("cannot override PARTITION BY clause of window %q", refName)
+	}
+	def.Partitions = referencedSpec.Partitions
+
+	// referencedSpec.OrderBy is used if set.
+	if referencedSpec.OrderBy != nil {
+		if def.OrderBy != nil {
+			return def, errors.Errorf("cannot override ORDER BY clause of window %q", refName)
+		}
+		def.OrderBy = referencedSpec.OrderBy
+	}
+	return def, nil
+}
+
+// A windowNode implements the planNode interface and handles windowing logic.
+// It "wraps" a planNode which is used to retrieve the un-windowed results.
+type windowNode struct {
+	planner *planner
+
+	// The "wrapped" node (which returns un-windowed results).
+	plan          planNode
+	wrappedValues []parser.DTuple
+
+	// A sparse array holding renders specific to this windowNode. This will contain
+	// nil entries for renders that do not contain window functions, and which therefore
+	// can be propagated directly from the "wrapped" node.
+	windowRender []parser.TypedExpr
+
+	// The populated values for this windowNode.
+	values    valuesNode
+	populated bool
+
+	// The window functions handled by this windowNode. computeWindows will populate
+	// an entire column in windowValues for each windowFuncHolder, in order.
+	funcs        []*windowFuncHolder
+	windowValues [][]parser.Datum
+	curRowIdx    int
+
+	explain explainMode
+}
+
+func (n *windowNode) Columns() []ResultColumn {
+	return n.values.Columns()
+}
+
+func (n *windowNode) Ordering() orderingInfo {
+	// Window partitions are returned un-ordered.
+	return orderingInfo{}
+}
+
+func (n *windowNode) Values() parser.DTuple {
+	return n.values.Values()
+}
+
+func (n *windowNode) MarkDebug(mode explainMode) {
+	if mode != explainDebug {
+		panic(fmt.Sprintf("unknown debug mode %d", mode))
+	}
+	n.explain = mode
+	n.plan.MarkDebug(mode)
+}
+
+func (n *windowNode) DebugValues() debugValues {
+	if n.populated {
+		return n.values.DebugValues()
+	}
+
+	// We are emitting a "buffered" row.
+	vals := n.plan.DebugValues()
+	if vals.output == debugValueRow {
+		vals.output = debugValueBuffered
+	}
+	return vals
+}
+
+func (n *windowNode) expandPlan() error {
+	// We do not need to recurse into the child node here; selectTopNode
+	// does this for us.
+
+	for _, e := range n.windowRender {
+		if err := n.planner.expandSubqueryPlans(e); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (n *windowNode) Start() error {
+	if err := n.plan.Start(); err != nil {
+		return err
+	}
+
+	for _, e := range n.windowRender {
+		if err := n.planner.startSubqueryPlans(e); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (n *windowNode) Next() (bool, error) {
+	for !n.populated {
+		next, err := n.plan.Next()
+		if err != nil {
+			return false, err
+		}
+		if !next {
+			n.populated = true
+			if err := n.computeWindows(); err != nil {
+				return false, err
+			}
+			if err := n.populateValues(); err != nil {
+				return false, err
+			}
+			break
+		}
+		if n.explain == explainDebug && n.plan.DebugValues().output != debugValueRow {
+			// Pass through non-row debug values.
+			return true, nil
+		}
+
+		// Add a copy of the row to wrappedValues.
+		values := n.plan.Values()
+		valuesCopy := make(parser.DTuple, len(values))
+		copy(valuesCopy, values)
+		n.wrappedValues = append(n.wrappedValues, valuesCopy)
+
+		if n.explain == explainDebug {
+			// Emit a "buffered" row.
+			return true, nil
+		}
+	}
+
+	return n.values.Next()
+}
+
+type partitionEntry struct {
+	idx   int
+	datum parser.DTuple
+}
+
+type partitionSorter struct {
+	rows     []partitionEntry
+	ordering sqlbase.ColumnOrdering
+}
+
+// partitionSorter implements the sort.Interface interface.
+func (n *partitionSorter) Len() int           { return len(n.rows) }
+func (n *partitionSorter) Swap(i, j int)      { n.rows[i], n.rows[j] = n.rows[j], n.rows[i] }
+func (n *partitionSorter) Less(i, j int) bool { return n.Compare(i, j) < 0 }
+
+// partitionSorter implements the peerGroupChecker interface.
+func (n *partitionSorter) InSameGroup(i, j int) bool { return n.Compare(i, j) == 0 }
+
+func (n *partitionSorter) Compare(i, j int) int {
+	ra, rb := n.rows[i].datum, n.rows[j].datum
+	for _, o := range n.ordering {
+		da := ra[o.ColIdx]
+		db := rb[o.ColIdx]
+		if c := da.Compare(db); c != 0 {
+			if o.Direction != encoding.Ascending {
+				return -c
+			}
+			return c
+		}
+	}
+	return 0
+}
+
+type allPeers struct{}
+
+// allPeers implements the peerGroupChecker interface.
+func (allPeers) InSameGroup(i, j int) bool { return true }
+
+// peerGroupChecker can check if a pair of row indexes within a partition are
+// in the same peer group.
+type peerGroupChecker interface {
+	InSameGroup(i, j int) bool
+}
+
+// computeWindows populates n.windowValues, adding a column of values to the
+// 2D-slice for each window function in n.funcs.
+func (n *windowNode) computeWindows() error {
+	rowCount := len(n.wrappedValues)
+	n.windowValues = make([][]parser.Datum, rowCount)
+
+	windowCount := len(n.funcs)
+	windowAlloc := make([]parser.Datum, rowCount*windowCount)
+	for i := range n.windowValues {
+		n.windowValues[i] = windowAlloc[i*windowCount : (i+1)*windowCount]
+	}
+
+	var scratch []byte
+	scratchDatum := make(parser.DTuple, 0, rowCount)
+	for windowIdx, windowFn := range n.funcs {
+		partitions := make(map[string][]partitionEntry)
+		scratchDatum = scratchDatum[:len(windowFn.partitionIdxs)]
+
+		// Partition rows into separate partitions based on hash values of the
+		// window function's PARTITION BY attribute.
+		//
+		// TODO(nvanbenschoten) Window functions with the same window definition
+		// can share partition and sorting work.
+		// See Cao et al. [http://vldb.org/pvldb/vol5/p1244_yucao_vldb2012.pdf]
+		for rowI, row := range n.wrappedValues {
+			entry := partitionEntry{idx: rowI, datum: row}
+			if len(windowFn.partitionIdxs) == 0 {
+				// If no partition indexes are included for the window function, all
+				// rows are added to the same partition.
+				if rowI == 0 {
+					partitions[""] = make([]partitionEntry, len(n.wrappedValues))
+				}
+				partitions[""][rowI] = entry
+			} else {
+				// If the window function has partition indexes, we hash the values of each
+				// of these indexes for each row, and partition based on this hashed value.
+				for i, idx := range windowFn.partitionIdxs {
+					scratchDatum[i] = row[idx]
+				}
+
+				encoded, err := sqlbase.EncodeDTuple(scratch, scratchDatum)
+				if err != nil {
+					return err
+				}
+
+				partitions[string(encoded)] = append(partitions[string(encoded)], entry)
+				scratch = encoded[:0]
+			}
+		}
+
+		// For each partition, perform necessary sorting based on the window function's
+		// ORDER BY attribute. After this, perform the window function computation for
+		// each tuple and save the result in n.windowValues.
+		//
+		// TODO(nvanbenschoten)
+		// - Investigate inter- and intra-partition parallelism
+		// - Investigate more efficient aggregation techniques
+		//   * Removable Cumulative
+		//   * Segment Tree
+		// See Leis et al. [http://www.vldb.org/pvldb/vol8/p1058-leis.pdf]
+		for _, partition := range partitions {
+			// TODO(nvanbenschoten) Handle framing here. Right now we only handle the default
+			// framing option of RANGE UNBOUNDED PRECEDING. With ORDER BY, this sets the frame
+			// to be all rows from the partition start up through the current row's last ORDER BY
+			// peer. Without ORDER BY, all rows of the partition are included in the window frame,
+			// since all rows become peers of the current row. Once we add better framing support,
+			// we should flesh this logic out more.
+			//
+			// TODO(nvanbenschoten) Handle built-in window functions in addtition to
+			// aggregate functions.
+			agg := windowFn.expr.GetAggregateConstructor()()
+
+			// Since we only support two types of window frames (see TODO above), we only
+			// need two possible types of peerGroupChecker's to help determine peer groups
+			// for given tuples.
+			var peerGrouper peerGroupChecker
+			if windowFn.columnOrdering != nil {
+				// If an ORDER BY clause is provided, order the partition and use the
+				// sorter as our peerGroupChecker.
+				sorter := &partitionSorter{rows: partition, ordering: windowFn.columnOrdering}
+				// The sort needs to be deterministic because multiple window functions with
+				// syntactically equivalent ORDER BY clauses in their window definitions
+				// need to be guaranteed to be evaluated in the same order, even if the
+				// ORDER BY *does not* uniquely determine an ordering. In the future, this
+				// could be guaranteed by only performing a single pass over a sorted partition
+				// for functions with syntactically equivalent PARTITION BY and ORDER BY clauses.
+				sort.Sort(sorter)
+				peerGrouper = sorter
+			} else {
+				// If no ORDER BY clause is provided, all rows in the partition are peers.
+				peerGrouper = allPeers{}
+			}
+
+			// Iterate over peer groups within partition.
+			rowIdx := 0
+			for rowIdx < len(partition) {
+				// Compute the size of a peer group while accumulating in aggregate.
+				peerGroupSize := 0
+				for ; rowIdx < len(partition); rowIdx++ {
+					if peerGroupSize > 0 {
+						if !peerGrouper.InSameGroup(rowIdx-1, rowIdx) {
+							break
+						}
+					}
+					row := partition[rowIdx]
+					agg.Add(row.datum[windowFn.subRenderCol])
+					peerGroupSize++
+				}
+
+				// Set aggregate result for entire peer group.
+				res := agg.Result()
+				for ; peerGroupSize > 0; peerGroupSize-- {
+					row := partition[rowIdx-peerGroupSize]
+					n.windowValues[row.idx][windowIdx] = res
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// populateValues populates n.values with final datum values after computing
+// window result values in n.windowValues.
+func (n *windowNode) populateValues() error {
+	rowCount := len(n.wrappedValues)
+	n.values.rows = make([]parser.DTuple, rowCount)
+
+	rowWidth := len(n.windowRender)
+	rowsAlloc := make(parser.DTuple, rowCount*rowWidth)
+	for i := range n.values.rows {
+		curRow := rowsAlloc[i*rowWidth : (i+1)*rowWidth]
+		n.values.rows[i] = curRow
+
+		n.curRowIdx = i // Point all windowFuncHolders to the correct row values.
+		curColIdx := 0
+		curFnIdx := 0
+		for j := range n.values.rows[i] {
+			if curWindowRender := n.windowRender[j]; curWindowRender == nil {
+				// If the windowRender at this index is nil, propagate the datum
+				// directly from the wrapped planNode. It wasn't changed by windowNode.
+				curRow[j] = n.wrappedValues[i][curColIdx]
+				curColIdx++
+			} else {
+				// If the windowRender is not nil, ignore 0 or more columns from the wrapped
+				// planNode. These were used as arguments to window functions all beneath
+				// a single windowRender.
+				// SELECT rank() over () from t; -> ignore 0 from wrapped values
+				// SELECT (avg(a) over () + avg(b) over ()) from t; -> ignore 2 from wrapped values
+				for ; curFnIdx < len(n.funcs); curFnIdx++ {
+					if n.funcs[curFnIdx].subRenderCol != curColIdx {
+						break
+					}
+					curColIdx++
+				}
+				// Instead, we evaluate the current window render, which depends on at least
+				// one window function, at the given row.
+				res, err := curWindowRender.Eval(&n.planner.evalCtx)
+				if err != nil {
+					return err
+				}
+				curRow[j] = res
+			}
+		}
+	}
+
+	return nil
+}
+
+func (n *windowNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
+	name = "window"
+	var buf bytes.Buffer
+	for i, f := range n.funcs {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		f.Format(&buf, parser.FmtSimple)
+	}
+
+	subplans := []planNode{n.plan}
+	for _, e := range n.windowRender {
+		subplans = n.planner.collectSubqueryPlans(e, subplans)
+	}
+	return name, buf.String(), subplans
+}
+
+func (n *windowNode) ExplainTypes(regTypes func(string, string)) {
+	cols := n.Columns()
+	for i, rexpr := range n.windowRender {
+		if rexpr != nil {
+			regTypes(fmt.Sprintf("render %s", cols[i].Name),
+				parser.AsStringWithFlags(rexpr, parser.FmtShowTypes))
+		}
+	}
+}
+
+func (*windowNode) SetLimitHint(_ int64, _ bool) {}
+
+// wrap the supplied planNode with the windowNode if windowing is required.
+func (n *windowNode) wrap(plan planNode) planNode {
+	if n == nil {
+		return plan
+	}
+	n.plan = plan
+	return n
+}
+
+type extractWindowFuncsVisitor struct {
+	n *windowNode
+
+	// Avoids allocations.
+	subWindowVisitor parser.ContainsWindowVisitor
+
+	// Persisted visitor state.
+	aggregatesSeen map[*parser.FuncExpr]struct{}
+	windowFnCount  int
+	err            error
+}
+
+var _ parser.Visitor = &extractWindowFuncsVisitor{}
+
+func (v *extractWindowFuncsVisitor) VisitPre(expr parser.Expr) (recurse bool, newExpr parser.Expr) {
+	if v.err != nil {
+		return false, expr
+	}
+
+	switch t := expr.(type) {
+	case *parser.FuncExpr:
+		switch {
+		case t.IsWindowFunction():
+			// Check if a parent node above this window function is an aggregate.
+			if len(v.aggregatesSeen) > 0 {
+				v.err = errors.Errorf("aggregate function calls cannot contain window function "+
+					"call %s", t.Name)
+				return false, expr
+			}
+
+			// Make sure the window function application is of either a built-in window
+			// function or of a built-in aggregate function.
+			if t.GetWindowConstructor() == nil && t.GetAggregateConstructor() == nil {
+				v.err = fmt.Errorf("OVER specified, but %s is not a window function nor an "+
+					"aggregate function", t.Name)
+				return false, expr
+			}
+
+			// TODO(nvanbenschoten) Once we support built-in window functions instead of
+			// just aggregates over a window, we'll need to support a variable number of
+			// arguments.
+			argExpr := t.Exprs[0].(parser.TypedExpr)
+
+			// Make sure this window function does not contain another window function.
+			if v.subWindowVisitor.ContainsWindowFunc(argExpr) {
+				v.err = fmt.Errorf("window function calls cannot be nested under %s", t.Name)
+				return false, expr
+			}
+
+			f := &windowFuncHolder{
+				expr:   t,
+				arg:    argExpr,
+				window: v.n,
+			}
+			v.windowFnCount++
+			v.n.funcs = append(v.n.funcs, f)
+			return false, f
+		case t.GetAggregateConstructor() != nil:
+			// If we see an aggregation that is not used in a window function, we save it
+			// in the visitor's seen aggregate set. The aggregate function will remain in
+			// this set until the recursion into its children is complete.
+			v.aggregatesSeen[t] = struct{}{}
+		}
+	}
+	return true, expr
+}
+
+func (v *extractWindowFuncsVisitor) VisitPost(expr parser.Expr) parser.Expr {
+	if fn, ok := expr.(*parser.FuncExpr); ok {
+		delete(v.aggregatesSeen, fn)
+	}
+	return expr
+}
+
+// Extract windowFuncHolders from exprs that use window functions and check if they are valid.
+// It will return the new expression tree, along with the number of window functions seen and
+// added to v.n.funcs.
+// A window function is valid if:
+// - it is not contained in an aggregate function
+// - it does not contain another window function
+// - it is either the application of a built-in window function
+//   or of a built-in aggregate function
+//
+// For example:
+// Invalid: `SELECT AVG(AVG(k) OVER ()) FROM kv`
+// - The avg aggregate wraps the window function.
+// Valid:      `SELECT AVG(k) OVER () FROM kv`
+// Also valid: `SELECT AVG(AVG(k)) OVER () FROM kv`
+// - Window functions can wrap aggregates.
+// Invalid:    `SELECT NOW() OVER () FROM kv`
+// - NOW() is not an aggregate or a window function.
+func (v extractWindowFuncsVisitor) extract(typedExpr parser.TypedExpr) (parser.TypedExpr, int, error) {
+	expr, _ := parser.WalkExpr(&v, typedExpr)
+	if v.err != nil {
+		return nil, 0, v.err
+	}
+	return expr.(parser.TypedExpr), v.windowFnCount, nil
+}
+
+var _ parser.TypedExpr = &windowFuncHolder{}
+var _ parser.VariableExpr = &windowFuncHolder{}
+
+type windowFuncHolder struct {
+	window *windowNode
+
+	expr *parser.FuncExpr
+	arg  parser.TypedExpr
+
+	funcIdx      int // index of the windowFuncHolder in window.funcs
+	subRenderCol int // column of the windowFuncHolder in window.wrappedValues
+
+	windowDef      parser.WindowDef
+	partitionIdxs  []int
+	columnOrdering sqlbase.ColumnOrdering
+}
+
+func (*windowFuncHolder) Variable() {}
+
+func (w *windowFuncHolder) Format(buf *bytes.Buffer, f parser.FmtFlags) {
+	w.expr.Format(buf, f)
+}
+
+func (w *windowFuncHolder) String() string { return parser.AsString(w) }
+
+func (w *windowFuncHolder) Walk(v parser.Visitor) parser.Expr { return w }
+
+func (w *windowFuncHolder) TypeCheck(_ *parser.SemaContext, desired parser.Datum) (parser.TypedExpr, error) {
+	return w, nil
+}
+
+func (w *windowFuncHolder) Eval(ctx *parser.EvalContext) (parser.Datum, error) {
+	// Index into the windowValues computed in windowNode.computeWindows
+	// to determine the Datum value to return. Evaluating this datum
+	// is almost certainly the identity.
+	return w.window.windowValues[w.window.curRowIdx][w.funcIdx].Eval(ctx)
+}
+
+func (w *windowFuncHolder) ReturnType() parser.Datum {
+	return w.expr.ReturnType()
+}


### PR DESCRIPTION
Closes #2475.

This change adds support for a subset of all window function
functionality. Window functions can be run over either pre-existing
aggregate builtins or a set of window function-only builtins. The change
only supports running window functions over aggregation functions for now.
It fully supports the `PARTITION BY` and `ORDER BY` clauses, but does not
yet support frame clause for window definitions.

Future related work:
- Support window frame clause
- Add built-in window functions
- Improve partitioning/sorting/aggregating efficiency (see referenced
  papers in TODOs)
- Improve inter- and intra-partition parallelism
- Avoid adding unnecessary extra renders to selectNode
- Support `WITHIN GROUP` and `FILTER` clauses

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8928)

<!-- Reviewable:end -->
