### PR TITLE
scripts: allow varying Go version in gceworker

### DIFF
--- a/scripts/bootstrap-debian.sh
+++ b/scripts/bootstrap-debian.sh
@@ -3,9 +3,9 @@
 # On a (recent enough) Debian/Ubuntu system, bootstraps a source Go install
 # (with improved parallel build patches) and the cockroach repo.
 
-set -euo pipefail
+set -euxo pipefail
 
-GOVERSION="1.7"
+GOVERSION="${GOVERSION-1.7}"
 
 cd "$(dirname "${0}")"
 
@@ -15,7 +15,7 @@ mkdir -p ~/go-bootstrap
 curl "https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz" | tar -C ~/go-bootstrap -xvz --strip=1
 curl "https://storage.googleapis.com/golang/go${GOVERSION}.src.tar.gz" | tar -C ~ -xvz
 
-patch -p1 -d ../go < parallelbuilds-go1.7.patch
+patch -p1 -d ../go < "parallelbuilds-go${GOVERSION}.patch"
 
 (cd ~/go/src && GOROOT_BOOTSTRAP=~/go-bootstrap ./make.bash)
 

--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -4,8 +4,9 @@ set -euxo pipefail
 
 export CLOUDSDK_CORE_PROJECT=${CLOUDSDK_CORE_PROJECT-${GOOGLE_PROJECT-cockroach-$(id -un)}}
 export CLOUDSDK_COMPUTE_ZONE=${GCEWORKER_ZONE-${CLOUDSDK_COMPUTE_ZONE-us-east1-b}}
+GOVERSION=${GOVERSION-1.7}
 
-name=${GCEWORKER_NAME-gceworker}
+name=${GCEWORKER_NAME-gceworker$(echo "${GOVERSION}" | tr -d '.')}
 
 cd "$(dirname "${0}")"
 
@@ -13,7 +14,7 @@ case ${1-} in
     create)
     gcloud compute instances \
            create "${name}" \
-           --machine-type "custom-32-65536" \
+           --machine-type "custom-32-32768" \
            --network "default" \
            --maintenance-policy "MIGRATE" \
            --image "/debian-cloud/debian-8-jessie-v20160803" \
@@ -23,7 +24,7 @@ case ${1-} in
     sleep 20 # avoid SSH timeout on copy-files
 
     gcloud compute copy-files . "${name}:scripts"
-    gcloud compute ssh "${name}" ./scripts/bootstrap-debian.sh
+    gcloud compute ssh "${name}" "GOVERSION=${GOVERSION} ./scripts/bootstrap-debian.sh"
     # Install automatic shutdown after ten minutes of operation without a
     # logged in user. To disable this, `sudo touch /.active`.
     # This is much more intricate than it looks. A few complications which

--- a/scripts/parallelbuilds-go1.6.patch
+++ b/scripts/parallelbuilds-go1.6.patch
@@ -1,0 +1,125 @@
+diff --git a/src/cmd/go/build.go b/src/cmd/go/build.go
+index f2a2a60..53c962c 100644
+--- a/src/cmd/go/build.go
++++ b/src/cmd/go/build.go
+@@ -694,6 +694,8 @@ type builder struct {
+ 	exec      sync.Mutex
+ 	readySema chan bool
+ 	ready     actionQueue
++
++	tasks chan func()
+ }
+ 
+ // An action represents a single action in the action graph.
+@@ -1236,6 +1238,7 @@ func (b *builder) do(root *action) {
+ 	}
+ 
+ 	b.readySema = make(chan bool, len(all))
++	b.tasks = make(chan func(), buildP)
+ 
+ 	// Initialize per-action execution state.
+ 	for _, a := range all {
+@@ -1312,6 +1315,8 @@ func (b *builder) do(root *action) {
+ 					a := b.ready.pop()
+ 					b.exec.Unlock()
+ 					handle(a)
++				case task := <-b.tasks:
++					task()
+ 				case <-interrupted:
+ 					setExitStatus(1)
+ 					return
+@@ -3141,12 +3146,16 @@ func (b *builder) cgo(p *Package, cgoExe, obj string, pcCFLAGS, pcLDFLAGS, cgofi
+ 		staticLibs = []string{"-Wl,--start-group", "-lmingwex", "-lmingw32", "-Wl,--end-group"}
+ 	}
+ 
++	var tasks []func()
++	var results chan error
++
+ 	cflags := stringList(cgoCPPFLAGS, cgoCFLAGS)
+ 	for _, cfile := range cfiles {
++		cfile := cfile
+ 		ofile := obj + cfile[:len(cfile)-1] + "o"
+-		if err := b.gcc(p, ofile, cflags, obj+cfile); err != nil {
+-			return nil, nil, err
+-		}
++		tasks = append(tasks, func() {
++			results <- b.gcc(p, ofile, cflags, obj+cfile)
++		})
+ 		linkobj = append(linkobj, ofile)
+ 		if !strings.HasSuffix(ofile, "_cgo_main.o") {
+ 			outObj = append(outObj, ofile)
+@@ -3154,35 +3163,65 @@ func (b *builder) cgo(p *Package, cgoExe, obj string, pcCFLAGS, pcLDFLAGS, cgofi
+ 	}
+ 
+ 	for _, file := range gccfiles {
++		file := file
+ 		ofile := obj + cgoRe.ReplaceAllString(file[:len(file)-1], "_") + "o"
+-		if err := b.gcc(p, ofile, cflags, file); err != nil {
+-			return nil, nil, err
+-		}
++		tasks = append(tasks, func() {
++			results <- b.gcc(p, ofile, cflags, file)
++		})
+ 		linkobj = append(linkobj, ofile)
+ 		outObj = append(outObj, ofile)
+ 	}
+ 
+ 	cxxflags := stringList(cgoCPPFLAGS, cgoCXXFLAGS)
+ 	for _, file := range gxxfiles {
++		file := file
+ 		// Append .o to the file, just in case the pkg has file.c and file.cpp
+ 		ofile := obj + cgoRe.ReplaceAllString(file, "_") + ".o"
+-		if err := b.gxx(p, ofile, cxxflags, file); err != nil {
+-			return nil, nil, err
+-		}
++		tasks = append(tasks, func() {
++			results <- b.gxx(p, ofile, cxxflags, file)
++		})
+ 		linkobj = append(linkobj, ofile)
+ 		outObj = append(outObj, ofile)
+ 	}
+ 
+ 	for _, file := range mfiles {
++		file := file
+ 		// Append .o to the file, just in case the pkg has file.c and file.m
+ 		ofile := obj + cgoRe.ReplaceAllString(file, "_") + ".o"
+-		if err := b.gcc(p, ofile, cflags, file); err != nil {
+-			return nil, nil, err
+-		}
++		tasks = append(tasks, func() {
++			results <- b.gcc(p, ofile, cflags, file)
++		})
+ 		linkobj = append(linkobj, ofile)
+ 		outObj = append(outObj, ofile)
+ 	}
+ 
++	// Give the results channel enough capacity so that sending the
++	// result is guaranteed not to block.
++	results = make(chan error, len(tasks))
++
++	// Feed the tasks into the b.tasks channel on a separate goroutine
++	// because the b.tasks channel's limited capacity might cause
++	// sending the task to block.
++	go func() {
++		for _, task := range tasks {
++			b.tasks <- task
++		}
++	}()
++
++	// Loop until we've received results from all of our tasks or an
++	// error occurs.
++	for count := 0; count < len(tasks); {
++		select {
++		case err := <-results:
++			if err != nil {
++				return nil, nil, err
++			}
++			count++
++		case task := <-b.tasks:
++			task()
++		}
++	}
++
+ 	linkobj = append(linkobj, p.SysoFiles...)
+ 	dynobj := obj + "_cgo_.o"
+ 	pie := (goarch == "arm" && goos == "linux") || goos == "android"


### PR DESCRIPTION
Supports only 1.6 and 1.7.

Multi-version support was easy enough and is going to be useful when
- playing with Backtrace right now (no 1.7 support)
- comparing Go versions (think benchmarking)

Note that we lint against using all but one Go version at a time, but
that check is easy enough to circumvent.

Also reduced the memory assigned to 32GiB (from 64GiB), added `set -x`
to the bootstrap script and added the Go version to the default machine
name (easy enough to preserve the current behavior with
export GCEWORKER_NAME=gceworker).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8935)

<!-- Reviewable:end -->
