### PR TITLE
log: allow setting `vmodule` on-the-fly

### DIFF
--- a/server/debug.go
+++ b/server/debug.go
@@ -120,6 +120,12 @@ table tr td {
 <a href="./pprof/goroutine?debug=1">goroutine</a> (<a href="./pprof/goroutine?debug=2">all</a>)<br />
 </td>
 </tr>
+<tr>
+<td>change vmodule</td>
+<td>
+get /debug/vmodule/<your_vmodule_here><br />For example, <code>*=1</code> or <code>raft=3,storage=2</code>. Empty string disables vmodule logging.
+</td>
+</tr>
 </table>
 </body></html>
 `)

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -16,9 +16,27 @@
 
 package log
 
-import "golang.org/x/net/context"
+import (
+	"fmt"
+	"net/http"
+
+	"golang.org/x/net/context"
+)
+
+const httpLogLevelPrefix = "/debug/vmodule/"
+
+func handleVModule(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	spec := r.RequestURI[len(httpLogLevelPrefix):]
+	if err := logging.vmodule.Set(spec); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+	Infof(context.Background(), "vmodule changed to: %s", spec)
+	fmt.Fprint(w, "ok: "+spec)
+}
 
 func init() {
+	http.Handle(httpLogLevelPrefix, http.HandlerFunc(handleVModule))
 	copyStandardLogTo("INFO")
 }
 


### PR DESCRIPTION
Issue a GET request to /debug/vmodule/<vmodule_spec> to use this feature.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8948)

<!-- Reviewable:end -->
