### PR TITLE
master -> develop

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -42,7 +42,7 @@ github.com/cockroachdb/cockroach-go 2e4a60d41697eebb308b1def89f0abaf1c056137
 github.com/cockroachdb/pq 40c6b2414c76cdb84aacc955f79dc844e48ad0c0
 github.com/cockroachdb/stress 029c9348806514969d1109a6ae36e521af411ca7
 github.com/codahale/hdrhistogram f8ad88b59a584afeee9d334eff879b104439117b
-github.com/coreos/etcd fb64c8ccfeb9408b80c3f657a52ec6cad2fdb3f8
+github.com/coreos/etcd 48f4a7d037ca8fd276fff09ef068074193b24dfa
 github.com/cpuguy83/go-md2man 2724a9c9051aa62e9cca11304e7dd518e9e41599
 github.com/davecgh/go-spew 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
 github.com/docker/distribution c9fd26e9efe2c7405d7072ad181844275977b5e3

--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -109,7 +109,7 @@ golang.org/x/sys a646d33e2ee3172a661fc09bca23bb4889a41bc8
 golang.org/x/text 2910a502d2bf9e43193af9d68ca516529614eed3
 golang.org/x/tools 0e9f43fcb67267967af8c15d7dc54b373e341d20
 google.golang.org/appengine e951d3868b377b14f4e60efa3a301532ee3c1ebf
-google.golang.org/grpc b7aa4e95cbb5ec9d07c52a7541ce178ef9626316
+google.golang.org/grpc 79b7c349179cdd6efd8bac4a1ce7f01b98c16e9b
 gopkg.in/check.v1 4f90aeace3a26ad7021961c297b22c42160c7b25
 gopkg.in/inf.v0 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 gopkg.in/yaml.v1 9f9df34309c04878acc86042b16630b0f696e1de

--- a/build/cockroach.rb
+++ b/build/cockroach.rb
@@ -4,8 +4,8 @@ class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
   url "https://github.com/cockroachdb/cockroach.git",
-      :tag => "beta-20160728",
-      :revision => "844e419503ab060aa091c40a7126cb6766fb6621"
+      :tag => "beta-20160829",
+      :revision => "ce2bc501f35e5a0d5707fd11d88ca28224aa34b9"
   head "https://github.com/cockroachdb/cockroach.git"
 
   depends_on "go" => :build

--- a/gossip/client.go
+++ b/gossip/client.go
@@ -236,9 +236,9 @@ func (c *client) handleResponse(g *Gossip, reply *Response) error {
 	// matches an incoming or the client is connecting to itself.
 	if g.mu.is.NodeID == c.peerID {
 		return errors.Errorf("stopping outgoing client to node %d (%s); loopback connection", c.peerID, c.addr)
-	} else if g.hasIncomingLocked(c.peerID) && g.mu.is.NodeID < c.peerID {
+	} else if g.hasIncomingLocked(c.peerID) && g.mu.is.NodeID > c.peerID {
 		// To avoid mutual shutdown, we only shutdown our client if our
-		// node ID is less than the peer's.
+		// node ID is higher than the peer's.
 		return errors.Errorf("stopping outgoing client to node %d (%s); already have incoming", c.peerID, c.addr)
 	}
 

--- a/gossip/client.go
+++ b/gossip/client.go
@@ -19,6 +19,7 @@ package gossip
 import (
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -80,8 +81,19 @@ func (c *client) start(
 ) {
 	stopper.RunWorker(func() {
 		ctx, cancel := context.WithCancel(context.TODO())
-		defer cancel()
+		var wg sync.WaitGroup
 		defer func() {
+			// This closes the outgoing stream, causing any attempt to send or
+			// receive to return an error.
+			//
+			// Note: it is still possible for incoming gossip to be processed after
+			// this point.
+			cancel()
+
+			// The stream is closed, but there may still be some incoming gossip
+			// being processed. Wait until that is complete to avoid racing the
+			// client's removal against the discovery of its remote's node ID.
+			wg.Wait()
 			disconnected <- c
 		}()
 
@@ -109,7 +121,7 @@ func (c *client) start(
 
 		// Start gossiping.
 		log.Infof(ctx, "node %d: started gossip client to %s", nodeID, c.addr)
-		if err := c.gossip(ctx, g, stream, stopper); err != nil {
+		if err := c.gossip(ctx, g, stream, stopper, &wg); err != nil {
 			if !grpcutil.IsClosedConnection(err) {
 				g.mu.Lock()
 				peerID := c.peerID
@@ -248,7 +260,7 @@ func (c *client) handleResponse(g *Gossip, reply *Response) error {
 // gossip loops, sending deltas of the infostore and receiving deltas
 // in turn. If an alternate is proposed on response, the client addr
 // is modified and method returns for forwarding by caller.
-func (c *client) gossip(ctx context.Context, g *Gossip, stream Gossip_GossipClient, stopper *stop.Stopper) error {
+func (c *client) gossip(ctx context.Context, g *Gossip, stream Gossip_GossipClient, stopper *stop.Stopper, wg *sync.WaitGroup) error {
 	sendGossipChan := make(chan struct{}, 1)
 
 	// Register a callback for gossip updates.
@@ -262,7 +274,12 @@ func (c *client) gossip(ctx context.Context, g *Gossip, stream Gossip_GossipClie
 	defer g.RegisterCallback(".*", updateCallback)()
 
 	errCh := make(chan error, 1)
+	// This wait group is used to allow the caller to wait until gossip
+	// processing is terminated.
+	wg.Add(1)
 	stopper.RunWorker(func() {
+		defer wg.Done()
+
 		errCh <- func() error {
 			for {
 				reply, err := stream.Recv()

--- a/gossip/client_test.go
+++ b/gossip/client_test.go
@@ -333,7 +333,7 @@ func TestClientDisconnectRedundant(t *testing.T) {
 		// Check which of the clients is connected to the other.
 		ok1 := local.findClient(func(c *client) bool { return c.addr.String() == rAddr.String() }) != nil
 		ok2 := remote.findClient(func(c *client) bool { return c.addr.String() == lAddr.String() }) != nil
-		// We expect node 1 to disconnect; if both are still connected,
+		// We expect node 2 to disconnect; if both are still connected,
 		// it's possible that node 1 gossiped before node 2 connected, in
 		// which case we have to gossip from node 1 to trigger the
 		// disconnect redundant client code.
@@ -341,7 +341,7 @@ func TestClientDisconnectRedundant(t *testing.T) {
 			if err := local.AddInfo("local-key", nil, time.Second); err != nil {
 				t.Fatal(err)
 			}
-		} else if !ok1 && ok2 && verifyServerMaps(local, 1) && verifyServerMaps(remote, 0) {
+		} else if ok1 && !ok2 && verifyServerMaps(local, 0) && verifyServerMaps(remote, 1) {
 			return nil
 		}
 		return errors.New("local client to remote not yet closed as redundant")

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -590,8 +590,9 @@ func (*BatchRequest) GetUser() string {
 // Store, a sequence counter less than or equal to the last observed one incurs
 // a transaction restart (if the request is transactional).
 func (ba *BatchRequest) SetNewRequest() {
-	if ba.Txn == nil {
-		return
+	if ba.Txn != nil {
+		txn := *ba.Txn
+		txn.Sequence++
+		ba.Txn = &txn
 	}
-	ba.Txn.Sequence++
 }

--- a/scripts/bootstrap-debian.sh
+++ b/scripts/bootstrap-debian.sh
@@ -3,9 +3,9 @@
 # On a (recent enough) Debian/Ubuntu system, bootstraps a source Go install
 # (with improved parallel build patches) and the cockroach repo.
 
-set -euo pipefail
+set -euxo pipefail
 
-GOVERSION="1.7"
+GOVERSION="${GOVERSION-1.7}"
 
 cd "$(dirname "${0}")"
 
@@ -15,7 +15,7 @@ mkdir -p ~/go-bootstrap
 curl "https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz" | tar -C ~/go-bootstrap -xvz --strip=1
 curl "https://storage.googleapis.com/golang/go${GOVERSION}.src.tar.gz" | tar -C ~ -xvz
 
-patch -p1 -d ../go < parallelbuilds-go1.7.patch
+patch -p1 -d ../go < "parallelbuilds-go${GOVERSION}.patch"
 
 (cd ~/go/src && GOROOT_BOOTSTRAP=~/go-bootstrap ./make.bash)
 

--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -3,9 +3,9 @@
 set -euxo pipefail
 
 export CLOUDSDK_CORE_PROJECT=${CLOUDSDK_CORE_PROJECT-${GOOGLE_PROJECT-cockroach-$(id -un)}}
-export CLOUDSDK_COMPUTE_ZONE=${GCESLAVE_ZONE-${CLOUDSDK_COMPUTE_ZONE-us-east1-b}}
+export CLOUDSDK_COMPUTE_ZONE=${GCEWORKER_ZONE-${CLOUDSDK_COMPUTE_ZONE-us-east1-b}}
 
-name=${GCESLAVE_NAME-gceslave}
+name=${GCEWORKER_NAME-gceworker}
 
 cd "$(dirname "${0}")"
 

--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -4,8 +4,9 @@ set -euxo pipefail
 
 export CLOUDSDK_CORE_PROJECT=${CLOUDSDK_CORE_PROJECT-${GOOGLE_PROJECT-cockroach-$(id -un)}}
 export CLOUDSDK_COMPUTE_ZONE=${GCEWORKER_ZONE-${CLOUDSDK_COMPUTE_ZONE-us-east1-b}}
+GOVERSION=${GOVERSION-1.7}
 
-name=${GCEWORKER_NAME-gceworker}
+name=${GCEWORKER_NAME-gceworker$(echo "${GOVERSION}" | tr -d '.')}
 
 cd "$(dirname "${0}")"
 
@@ -13,7 +14,7 @@ case ${1-} in
     create)
     gcloud compute instances \
            create "${name}" \
-           --machine-type "custom-32-65536" \
+           --machine-type "custom-32-32768" \
            --network "default" \
            --maintenance-policy "MIGRATE" \
            --image "/debian-cloud/debian-8-jessie-v20160803" \
@@ -23,7 +24,7 @@ case ${1-} in
     sleep 20 # avoid SSH timeout on copy-files
 
     gcloud compute copy-files . "${name}:scripts"
-    gcloud compute ssh "${name}" ./scripts/bootstrap-debian.sh
+    gcloud compute ssh "${name}" "GOVERSION=${GOVERSION} ./scripts/bootstrap-debian.sh"
     # Install automatic shutdown after ten minutes of operation without a
     # logged in user. To disable this, `sudo touch /.active`.
     # This is much more intricate than it looks. A few complications which

--- a/scripts/parallelbuilds-go1.6.patch
+++ b/scripts/parallelbuilds-go1.6.patch
@@ -1,0 +1,125 @@
+diff --git a/src/cmd/go/build.go b/src/cmd/go/build.go
+index f2a2a60..53c962c 100644
+--- a/src/cmd/go/build.go
++++ b/src/cmd/go/build.go
+@@ -694,6 +694,8 @@ type builder struct {
+ 	exec      sync.Mutex
+ 	readySema chan bool
+ 	ready     actionQueue
++
++	tasks chan func()
+ }
+ 
+ // An action represents a single action in the action graph.
+@@ -1236,6 +1238,7 @@ func (b *builder) do(root *action) {
+ 	}
+ 
+ 	b.readySema = make(chan bool, len(all))
++	b.tasks = make(chan func(), buildP)
+ 
+ 	// Initialize per-action execution state.
+ 	for _, a := range all {
+@@ -1312,6 +1315,8 @@ func (b *builder) do(root *action) {
+ 					a := b.ready.pop()
+ 					b.exec.Unlock()
+ 					handle(a)
++				case task := <-b.tasks:
++					task()
+ 				case <-interrupted:
+ 					setExitStatus(1)
+ 					return
+@@ -3141,12 +3146,16 @@ func (b *builder) cgo(p *Package, cgoExe, obj string, pcCFLAGS, pcLDFLAGS, cgofi
+ 		staticLibs = []string{"-Wl,--start-group", "-lmingwex", "-lmingw32", "-Wl,--end-group"}
+ 	}
+ 
++	var tasks []func()
++	var results chan error
++
+ 	cflags := stringList(cgoCPPFLAGS, cgoCFLAGS)
+ 	for _, cfile := range cfiles {
++		cfile := cfile
+ 		ofile := obj + cfile[:len(cfile)-1] + "o"
+-		if err := b.gcc(p, ofile, cflags, obj+cfile); err != nil {
+-			return nil, nil, err
+-		}
++		tasks = append(tasks, func() {
++			results <- b.gcc(p, ofile, cflags, obj+cfile)
++		})
+ 		linkobj = append(linkobj, ofile)
+ 		if !strings.HasSuffix(ofile, "_cgo_main.o") {
+ 			outObj = append(outObj, ofile)
+@@ -3154,35 +3163,65 @@ func (b *builder) cgo(p *Package, cgoExe, obj string, pcCFLAGS, pcLDFLAGS, cgofi
+ 	}
+ 
+ 	for _, file := range gccfiles {
++		file := file
+ 		ofile := obj + cgoRe.ReplaceAllString(file[:len(file)-1], "_") + "o"
+-		if err := b.gcc(p, ofile, cflags, file); err != nil {
+-			return nil, nil, err
+-		}
++		tasks = append(tasks, func() {
++			results <- b.gcc(p, ofile, cflags, file)
++		})
+ 		linkobj = append(linkobj, ofile)
+ 		outObj = append(outObj, ofile)
+ 	}
+ 
+ 	cxxflags := stringList(cgoCPPFLAGS, cgoCXXFLAGS)
+ 	for _, file := range gxxfiles {
++		file := file
+ 		// Append .o to the file, just in case the pkg has file.c and file.cpp
+ 		ofile := obj + cgoRe.ReplaceAllString(file, "_") + ".o"
+-		if err := b.gxx(p, ofile, cxxflags, file); err != nil {
+-			return nil, nil, err
+-		}
++		tasks = append(tasks, func() {
++			results <- b.gxx(p, ofile, cxxflags, file)
++		})
+ 		linkobj = append(linkobj, ofile)
+ 		outObj = append(outObj, ofile)
+ 	}
+ 
+ 	for _, file := range mfiles {
++		file := file
+ 		// Append .o to the file, just in case the pkg has file.c and file.m
+ 		ofile := obj + cgoRe.ReplaceAllString(file, "_") + ".o"
+-		if err := b.gcc(p, ofile, cflags, file); err != nil {
+-			return nil, nil, err
+-		}
++		tasks = append(tasks, func() {
++			results <- b.gcc(p, ofile, cflags, file)
++		})
+ 		linkobj = append(linkobj, ofile)
+ 		outObj = append(outObj, ofile)
+ 	}
+ 
++	// Give the results channel enough capacity so that sending the
++	// result is guaranteed not to block.
++	results = make(chan error, len(tasks))
++
++	// Feed the tasks into the b.tasks channel on a separate goroutine
++	// because the b.tasks channel's limited capacity might cause
++	// sending the task to block.
++	go func() {
++		for _, task := range tasks {
++			b.tasks <- task
++		}
++	}()
++
++	// Loop until we've received results from all of our tasks or an
++	// error occurs.
++	for count := 0; count < len(tasks); {
++		select {
++		case err := <-results:
++			if err != nil {
++				return nil, nil, err
++			}
++			count++
++		case task := <-b.tasks:
++			task()
++		}
++	}
++
+ 	linkobj = append(linkobj, p.SysoFiles...)
+ 	dynobj := obj + "_cgo_.o"
+ 	pie := (goarch == "arm" && goos == "linux") || goos == "android"


### PR DESCRIPTION
``` diff
commit 860b83b5ea2c92fb8e45f884a4ddf5435c3e303e
Merge: 4500007 280679f
Author: Tamir Duberstein <tamird@gmail.com>
Date:   Tue Aug 30 12:21:48 2016 -0400

    Merge branch 'master' into develop

diff --cc GLOCKFILE
index 75daea8,fa26ae0..29b5f72
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@@ -42,13 -41,12 +42,13 @@@ github.com/cockroachdb/cmux b64f5908f49
  github.com/cockroachdb/cockroach-go 2e4a60d41697eebb308b1def89f0abaf1c056137
  github.com/cockroachdb/pq 40c6b2414c76cdb84aacc955f79dc844e48ad0c0
  github.com/cockroachdb/stress 029c9348806514969d1109a6ae36e521af411ca7
 +github.com/cockroachdb/yacc 7c99dfd2164a5d23c3f495ffc2e0b72b6379d066
  github.com/codahale/hdrhistogram f8ad88b59a584afeee9d334eff879b104439117b
- github.com/coreos/etcd fb64c8ccfeb9408b80c3f657a52ec6cad2fdb3f8
+ github.com/coreos/etcd 48f4a7d037ca8fd276fff09ef068074193b24dfa
  github.com/cpuguy83/go-md2man 2724a9c9051aa62e9cca11304e7dd518e9e41599
 -github.com/davecgh/go-spew 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
 -github.com/docker/distribution c9fd26e9efe2c7405d7072ad181844275977b5e3
 -github.com/docker/engine-api 3ae7fcd11e45c53108b006544fa7fbf2fd9df1bf
 +github.com/davecgh/go-spew 6cf5744a041a0022271cefed95ba843f6d87fd51
 +github.com/docker/distribution c810308d1bf3051521dd63cc1cdda03be9f11327
 +github.com/docker/engine-api 94a8f8f29307ab291abad6c6f2182d67089aae5d
  github.com/docker/go-connections 0bad1a3951398f88ef4dd75fdb42af374430be89
  github.com/docker/go-units eb879ae3e2b84e2a142af415b679ddeda47ec71c
  github.com/dustin/go-humanize 2fcb5204cdc65b4bec9fd0a87606bb0d0e3c54e8
@@@ -107,13 -106,13 +107,13 @@@ golang.org/x/crypto 1ce41b6ca7dccc03377
  golang.org/x/net 07b51741c1d6423d4a6abab1c49940ec09cb1aaf
  golang.org/x/oauth2 4784bb855e56a530f1ce5d788959359ed6cb4a16
  golang.org/x/sys a646d33e2ee3172a661fc09bca23bb4889a41bc8
 -golang.org/x/text 2910a502d2bf9e43193af9d68ca516529614eed3
 -golang.org/x/tools 0e9f43fcb67267967af8c15d7dc54b373e341d20
 +golang.org/x/text d69c40b4be55797923cec7457fac7a244d91a9b6
 +golang.org/x/tools 08b1e0510c4cfc628a52f0ce641d027b4b2cebe0
  google.golang.org/appengine e951d3868b377b14f4e60efa3a301532ee3c1ebf
- google.golang.org/grpc b7aa4e95cbb5ec9d07c52a7541ce178ef9626316
+ google.golang.org/grpc 79b7c349179cdd6efd8bac4a1ce7f01b98c16e9b
  gopkg.in/check.v1 4f90aeace3a26ad7021961c297b22c42160c7b25
  gopkg.in/inf.v0 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 -gopkg.in/yaml.v1 9f9df34309c04878acc86042b16630b0f696e1de
 +gopkg.in/yaml.v2 e4d366fc3c7938e2958e662b4258c7a89e1f0e3e
  honnef.co/go/lint a730e73f0085f274d67b586a1d587fd6e42e6708
  honnef.co/go/simple aa6f9e72ec86009fdfc110b52e2c769d48d5a904
  honnef.co/go/staticcheck 02337b3080e043d43781e1a0d129df14848f9507
diff --cc gossip/client.go
index b0d4193,c597a6b..874755a
--- a/gossip/client.go
+++ b/gossip/client.go
@@@ -81,9 -80,20 +82,20 @@@ func (c *client) start
    breaker *circuit.Breaker,
  ) {
    stopper.RunWorker(func() {
 -      ctx, cancel := context.WithCancel(context.TODO())
 +      ctx, cancel := context.WithCancel(c.ctx)
-       defer cancel()
+       var wg sync.WaitGroup
        defer func() {
+           // This closes the outgoing stream, causing any attempt to send or
+           // receive to return an error.
+           //
+           // Note: it is still possible for incoming gossip to be processed after
+           // this point.
+           cancel()
+ 
+           // The stream is closed, but there may still be some incoming gossip
+           // being processed. Wait until that is complete to avoid racing the
+           // client's removal against the discovery of its remote's node ID.
+           wg.Wait()
            disconnected <- c
        }()


```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8950)

<!-- Reviewable:end -->
