### PR TITLE
 storage: add test to verify replicasByKey behavior

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -1180,8 +1180,7 @@ func (s *Store) GetReplica(rangeID roachpb.RangeID) (*Replica, error) {
 	return s.getReplicaLocked(rangeID)
 }
 
-// getReplicaLocked fetches a replica by RangeID. The store's lock must be held
-// in read or read/write mode.
+// getReplicaLocked fetches a replica by RangeID. The store's lock must be held.
 func (s *Store) getReplicaLocked(rangeID roachpb.RangeID) (*Replica, error) {
 	if rng, ok := s.mu.replicas[rangeID]; ok {
 		return rng, nil
@@ -1804,8 +1803,11 @@ func (s *Store) destroyReplicaData(desc *roachpb.RangeDescriptor) error {
 	return batch.Commit()
 }
 
-// processRangeDescriptorUpdate is called whenever a range's
-// descriptor is updated.
+// processRangeDescriptorUpdate should be called whenever a replica's range
+// descriptor is updated, to update the store's maps of its ranges to match
+// the updated descriptor. Since the latter update requires acquiring the store
+// lock (which cannot always safely be done by replicas), this function call
+// should be deferred until it is safe to acquire the store lock.
 func (s *Store) processRangeDescriptorUpdate(rng *Replica) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
When a store accepts a snapshot for a range that split or otherwise
changed its descriptor, it should update its internal state. Fixes
#8946.

WIP as the test is scaffolded but nonfunctional. I would appreciate 
any feedback on how to make that test work.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8954)

<!-- Reviewable:end -->
