### PR TITLE
storage: remove placeholders immediately after Replica.handleRaftReady

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1652,10 +1652,8 @@ func (r *Replica) handleRaftReady() error {
 			r.store.mu.Lock()
 			defer r.store.mu.Unlock()
 
-			if _, exists := r.store.mu.replicaPlaceholders[r.RangeID]; exists {
-				if err := r.store.removePlaceholderLocked(r.RangeID); err != nil {
-					return errors.Wrapf(err, "could not remove placeholder before applySnapshot")
-				}
+			if r.store.removePlaceholderLocked(r.RangeID) {
+				atomic.AddInt32(&r.store.counts.filledPlaceholders, 1)
 			}
 			if err := r.store.processRangeDescriptorUpdateLocked(r); err != nil {
 				return errors.Wrapf(err, "could not processRangeDescriptorUpdate after applySnapshot")

--- a/storage/store.go
+++ b/storage/store.go
@@ -414,6 +414,16 @@ type Store struct {
 		syncutil.Mutex
 		value map[roachpb.RangeID]struct{}
 	}
+
+	counts struct {
+		// Number of placeholders removed due to error.
+		removedPlaceholders int32
+		// Number of placeholders successfully filled by a snapshot.
+		filledPlaceholders int32
+		// Number of placeholders removed due to a snapshot that was dropped by
+		// raft.
+		droppedPlaceholders int32
+	}
 }
 
 var _ client.Sender = &Store{}
@@ -1654,29 +1664,37 @@ func (s *Store) addPlaceholderLocked(placeholder *ReplicaPlaceholder) error {
 	return nil
 }
 
-func (s *Store) removePlaceholderLocked(rngID roachpb.RangeID) error {
+// removePlaceholder removes a placeholder for the specified range if it
+// exists, returning true if a placeholder was present and removed and false
+// otherwise.
+func (s *Store) removePlaceholder(rngID roachpb.RangeID) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.removePlaceholderLocked(rngID)
+}
+
+func (s *Store) removePlaceholderLocked(rngID roachpb.RangeID) bool {
 	rng, ok := s.mu.replicaPlaceholders[rngID]
 	if !ok {
-		return errors.Errorf("%v: cannot remove placeholder for RangeID %v; Placeholder doesn't exist", s, rngID)
+		return false
 	}
-	if exRng := s.mu.replicasByKey.Delete(rng); exRng != nil {
-		switch exRng.(type) {
-		case *Replica:
-			return errors.Errorf("%v: expected placeholder for RangeID: %v, got Replica", s, rngID)
-		case *ReplicaPlaceholder:
-			delete(s.mu.replicaPlaceholders, rngID)
-			return nil
-		}
+	switch exRng := s.mu.replicasByKey.Delete(rng).(type) {
+	case *ReplicaPlaceholder:
+		delete(s.mu.replicaPlaceholders, rngID)
+		return true
+	case nil:
+		log.Fatalf(context.TODO(), "%s range=%d: placeholder not found", s, rngID)
+	default:
+		log.Fatalf(context.TODO(), "%s range=%d: expected placeholder, got %T", s, rngID, exRng)
 	}
-	return errors.Errorf("placeholder %v was not in replicasByKey BTree", rngID)
+	return false // appease the compiler
 }
 
 // addReplicaToRangeMapLocked adds the replica to the replicas map.
 // addReplicaToRangeMapLocked requires that the store lock is held.
 func (s *Store) addReplicaToRangeMapLocked(rng *Replica) error {
 	if _, ok := s.mu.replicas[rng.RangeID]; ok {
-		return errors.Errorf("%s: range for ID %d already exists in replicasByKey btree", s,
-			rng.RangeID)
+		return errors.Errorf("%s: replica already exists", rng)
 	}
 	s.mu.replicas[rng.RangeID] = rng
 	return nil
@@ -1707,6 +1725,7 @@ func (s *Store) removeReplicaImpl(rep *Replica, origDesc roachpb.RangeDescriptor
 	defer s.mu.Unlock()
 
 	delete(s.mu.replicas, rep.RangeID)
+	delete(s.mu.replicaPlaceholders, rep.RangeID)
 	if s.mu.replicasByKey.Delete(rep) == nil {
 		return errors.Errorf("couldn't find range in replicasByKey btree")
 	}
@@ -2174,7 +2193,10 @@ func (s *Store) maybeUpdateTransaction(txn *roachpb.Transaction, now hlc.Timesta
 
 // HandleRaftRequest dispatches a raft message to the appropriate Replica. It
 // requires that s.processRaftMu and s.mu are not held.
-func (s *Store) HandleRaftRequest(ctx context.Context, req *RaftMessageRequest) *roachpb.Error {
+func (s *Store) HandleRaftRequest(
+	ctx context.Context,
+	req *RaftMessageRequest,
+) (pErr *roachpb.Error) {
 	s.processRaftMu.Lock()
 	defer s.processRaftMu.Unlock()
 
@@ -2200,9 +2222,10 @@ func (s *Store) HandleRaftRequest(ctx context.Context, req *RaftMessageRequest) 
 		}
 	}
 
-	addedPlaceholder := false
-
 	s.metrics.raftRcvdMessages[req.Message.Type].Inc(1)
+
+	var addedPlaceholder bool
+	var removePlaceholder bool
 
 	switch req.Message.Type {
 	case raftpb.MsgSnap:
@@ -2222,6 +2245,10 @@ func (s *Store) HandleRaftRequest(ctx context.Context, req *RaftMessageRequest) 
 			}
 
 			if placeholder != nil {
+				// NB: The placeholder added here is either removed below after a
+				// preemptive snapshot is applied or after the next call to
+				// Replica.handleRaftReady. Note that we can only get here if the
+				// replica doesn't exist or is uninitialized.
 				if err := s.addPlaceholderLocked(placeholder); err != nil {
 					log.Fatal(ctx, errors.Wrapf(err, "%s: could not add vetted placeholder %s", s, placeholder))
 				}
@@ -2232,16 +2259,26 @@ func (s *Store) HandleRaftRequest(ctx context.Context, req *RaftMessageRequest) 
 			return nil
 		}
 
+		if addedPlaceholder {
+			// If we added a placeholder remove it before we return unless some other
+			// part of the code takes ownership of the removal (indicated by setting
+			// removePlaceholder to false).
+			removePlaceholder = true
+			defer func() {
+				if removePlaceholder {
+					if s.removePlaceholder(req.RangeID) {
+						atomic.AddInt32(&s.counts.removedPlaceholders, 1)
+					}
+				}
+			}()
+		}
+
 	case raftpb.MsgHeartbeat:
 		// TODO(bdarnell): handle coalesced heartbeats.
 	}
 
-	s.mu.Lock()
 	// Lazily create the replica.
-	r, err := s.getOrCreateReplicaLocked(req.RangeID, req.ToReplica.ReplicaID, req.FromReplica)
-	// TODO(bdarnell): is it safe to release the store lock here?
-	// It deadlocks to hold s.Mutex while calling raftGroup.Step.
-	s.mu.Unlock()
+	r, err := s.getOrCreateReplica(req.RangeID, req.ToReplica.ReplicaID, req.FromReplica)
 	if err != nil {
 		return roachpb.NewError(err)
 	}
@@ -2253,6 +2290,29 @@ func (s *Store) HandleRaftRequest(ctx context.Context, req *RaftMessageRequest) 
 			// members of the raft group (i.e. replicas with an ID of 0). This
 			// is the only operation that can be performed before it is part of
 			// the raft group.
+
+			defer func() {
+				s.mu.Lock()
+				defer s.mu.Unlock()
+
+				// We need to remove the placeholder regardless of whether the snapshot
+				// applied successfully or not.
+				if addedPlaceholder {
+					// Clear the replica placeholder; we are about to swap it with a real replica.
+					if !s.removePlaceholderLocked(req.RangeID) {
+						log.Fatalf(ctx, "%s: could not remove placeholder after preemptive snapshot", r)
+					}
+					atomic.AddInt32(&s.counts.filledPlaceholders, 1)
+					removePlaceholder = false
+				}
+
+				if pErr == nil {
+					// If the snapshot succeeded, process the range descriptor update.
+					if err := s.processRangeDescriptorUpdateLocked(r); err != nil {
+						pErr = roachpb.NewError(err)
+					}
+				}
+			}()
 
 			// Requiring that the Term is set in a message makes sure that we
 			// get all of Raft's internal safety checks (it confuses messages
@@ -2346,19 +2406,8 @@ func (s *Store) HandleRaftRequest(ctx context.Context, req *RaftMessageRequest) 
 				return roachpb.NewError(err)
 			}
 
-			s.mu.Lock()
-			defer s.mu.Unlock()
-			if addedPlaceholder {
-				// Clear the replica placeholder; we are about to swap it with a real replica.
-				if err := s.removePlaceholderLocked(req.RangeID); err != nil {
-					return roachpb.NewError(err)
-				}
-			}
-
-			if err := s.processRangeDescriptorUpdateLocked(r); err != nil {
-				return roachpb.NewError(err)
-			}
-
+			// NB: See the defer at the start of this block for the removal of the
+			// placeholder and processing of the range descriptor update.
 			return nil
 
 			// At this point, the Replica has data but no ReplicaID. We hope
@@ -2367,8 +2416,8 @@ func (s *Store) HandleRaftRequest(ctx context.Context, req *RaftMessageRequest) 
 			// happen, at some point the Replica GC queue will have to grab it.
 		}
 		// We disallow non-snapshot messages to replica ID 0. Note that
-		// getOrCreateReplicaLocked disallows moving the replica ID backward, so
-		// the only way we can get here is if the replica did not previously exist.
+		// getOrCreateReplica disallows moving the replica ID backward, so the only
+		// way we can get here is if the replica did not previously exist.
 		if log.V(1) {
 			log.Infof(s.Ctx(), "refusing incoming Raft message %s for range %d from %+v to %+v",
 				req.Message.Type, req.RangeID, req.FromReplica, req.ToReplica)
@@ -2384,6 +2433,9 @@ func (s *Store) HandleRaftRequest(ctx context.Context, req *RaftMessageRequest) 
 	}
 
 	s.enqueueRaftUpdateCheck(req.RangeID)
+	// If a placeholder was added it is now owned by the replica and will be
+	// removed after the next call to Replica.handleRaftReady().
+	removePlaceholder = false
 	return nil
 }
 
@@ -2512,6 +2564,14 @@ func (s *Store) processRaft() {
 					panic(err) // TODO(bdarnell)
 				}
 				maybeWarnDuration(start, r, "handle raft ready")
+				// Only an uninitialized replica can have a placeholder since, by
+				// definition, an initialized replica will be present in the
+				// replicasByKey map. While the replica will usually consume the
+				// placeholder itself, that isn't guaranteed and so this invocation
+				// here is crucial (i.e. don't remove it).
+				if s.removePlaceholder(r.RangeID) {
+					atomic.AddInt32(&s.counts.droppedPlaceholders, 1)
+				}
 			}
 
 			var wg sync.WaitGroup
@@ -2528,11 +2588,6 @@ func (s *Store) processRaft() {
 				}
 			}
 			wg.Wait()
-			// After a round of readys, if a placeholder hasn't been removed
-			// by the handleRaftReady, this means that the Raft group rejected
-			// the snapshot. Now that we have called handleRaftReady on all
-			// replicas, clear all remaining placeholders.
-			s.clearAllPlaceholders()
 			s.processRaftMu.Unlock()
 
 			s.metrics.RaftWorkingDurationNanos.Inc(timeutil.Since(workingStart).Nanoseconds())
@@ -2611,22 +2666,17 @@ func (s *Store) processRaft() {
 	})
 }
 
-func (s *Store) clearAllPlaceholders() {
+// getOrCreateReplica returns a replica for the given RangeID, creating an
+// uninitialized replica if necessary. The caller must not hold the store's
+// lock.
+func (s *Store) getOrCreateReplica(
+	rangeID roachpb.RangeID,
+	replicaID roachpb.ReplicaID,
+	creatingReplica roachpb.ReplicaDescriptor,
+) (*Replica, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	for rngID, res := range s.mu.replicaPlaceholders {
-		if s.mu.replicasByKey.Delete(res) == nil {
-			log.Fatalf(s.Ctx(), "%s: expected to find placeholder %s in replicasByKey", s, res)
-		}
-		delete(s.mu.replicaPlaceholders, rngID)
-	}
-}
-
-// getOrCreateReplicaLocked returns a replica for the given RangeID,
-// creating an uninitialized replica if necessary. The caller must
-// hold the store's lock.
-func (s *Store) getOrCreateReplicaLocked(rangeID roachpb.RangeID, replicaID roachpb.ReplicaID, creatingReplica roachpb.ReplicaDescriptor) (*Replica, error) {
 	r, ok := s.mu.replicas[rangeID]
 	if ok {
 		if err := r.setReplicaID(replicaID); err != nil {

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/uuid"
 	"github.com/coreos/etcd/raft"
+	"github.com/coreos/etcd/raft/raftpb"
 	"github.com/pkg/errors"
 )
 
@@ -2201,8 +2202,8 @@ func TestStoreRangePlaceholders(t *testing.T) {
 	}
 
 	// Test that simple deletion works.
-	if err := s.removePlaceholderLocked(placeholder1.rangeDesc.RangeID); err != nil {
-		t.Fatalf("could not remove placeholder that was present, got %s", err)
+	if !s.removePlaceholderLocked(placeholder1.rangeDesc.RangeID) {
+		t.Fatalf("could not remove placeholder that was present")
 	}
 
 	// Test cannot double insert the same placeholder.
@@ -2214,11 +2215,11 @@ func TestStoreRangePlaceholders(t *testing.T) {
 	}
 
 	// Test cannot double delete a placeholder.
-	if err := s.removePlaceholderLocked(placeholder1.rangeDesc.RangeID); err != nil {
-		t.Fatalf("could not remove placeholder that was present, got %s", err)
+	if !s.removePlaceholderLocked(placeholder1.rangeDesc.RangeID) {
+		t.Fatalf("could not remove placeholder that was present")
 	}
-	if err := s.removePlaceholderLocked(placeholder1.rangeDesc.RangeID); !testutils.IsError(err, "cannot remove placeholder for RangeID \\d+; Placeholder doesn't exist") {
-		t.Fatalf("could not remove placeholder that was present, got %v", err)
+	if s.removePlaceholderLocked(placeholder1.rangeDesc.RangeID) {
+		t.Fatalf("successfully removed placeholder that was not present")
 	}
 
 	// This placeholder overlaps with an existing replica.
@@ -2236,7 +2237,152 @@ func TestStoreRangePlaceholders(t *testing.T) {
 	}
 
 	// Test that Placeholder deletion doesn't delete replicas.
-	if err := s.removePlaceholderLocked(repID); !testutils.IsError(err, "cannot remove placeholder for RangeID \\d+; Placeholder doesn't exist") {
-		t.Fatalf("should not be able to process removeReplicaPlaceholder for a RangeID where a Replica exists, got: %v", err)
+	if s.removePlaceholderLocked(repID) {
+		t.Fatalf("should not be able to process removeReplicaPlaceholder for a RangeID where a Replica exists")
+	}
+}
+
+// Test that we remove snapshot placeholders on error conditions.
+func TestStoreRemovePlaceholderOnError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	tc := testContext{}
+	tc.Start(t)
+	defer tc.Stop()
+	s := tc.store
+	ctx := context.Background()
+
+	// Clobber the existing range so we can test nonoverlapping placeholders.
+	rng1, err := s.GetReplica(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RemoveReplica(rng1, *rng1.Desc(), true); err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate a minimal fake snapshot.
+	snapData := &roachpb.RaftSnapshotData{
+		RangeDescriptor: *rng1.Desc(),
+	}
+	data, err := protoutil.Marshal(snapData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wrap the snapshot in a minimal request. The request will error because the
+	// replica tombstone for the range requires that a new replica have an ID
+	// greater than 1.
+	req := &RaftMessageRequest{
+		RangeID: 1,
+		ToReplica: roachpb.ReplicaDescriptor{
+			NodeID:    1,
+			StoreID:   1,
+			ReplicaID: 1,
+		},
+		FromReplica: roachpb.ReplicaDescriptor{
+			NodeID:    2,
+			StoreID:   2,
+			ReplicaID: 2,
+		},
+		Message: raftpb.Message{
+			Type: raftpb.MsgSnap,
+			Snapshot: raftpb.Snapshot{
+				Data: data,
+			},
+		},
+	}
+	const expected = "raft group deleted"
+	if err := s.HandleRaftRequest(ctx, req); !testutils.IsError(errors.Errorf("%s", err), expected) {
+		t.Fatalf("expected %s, but found %v", expected, err)
+	}
+
+	s.mu.Lock()
+	numPlaceholders := len(s.mu.replicaPlaceholders)
+	s.mu.Unlock()
+
+	if numPlaceholders != 0 {
+		t.Fatalf("expected 0 placeholders, but found %d", numPlaceholders)
+	}
+	if n := atomic.LoadInt32(&s.counts.removedPlaceholders); n != 1 {
+		t.Fatalf("expected 1 removed placeholder, but found %d", n)
+	}
+}
+
+// Test that we remove snapshot placeholders when raft ignores the
+// snapshot. This is testing the removal of placeholder after handleRaftReady
+// processing for an unitialized Replica.
+func TestStoreRemovePlaceholderOnRaftIgnored(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	tc := testContext{}
+	tc.Start(t)
+	defer tc.Stop()
+	s := tc.store
+	ctx := context.Background()
+
+	// Clobber the existing range so we can test nonoverlapping placeholders.
+	rng1, err := s.GetReplica(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RemoveReplica(rng1, *rng1.Desc(), true); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := writeInitialState(ctx, s.Engine(), enginepb.MVCCStats{}, *rng1.Desc()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate a minimal fake snapshot.
+	snapData := &roachpb.RaftSnapshotData{
+		RangeDescriptor: *rng1.Desc(),
+	}
+	data, err := protoutil.Marshal(snapData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wrap the snapshot in a minimal request. The request will be dropped
+	// because the Raft log index and term are less than the hard state written
+	// above.
+	req := &RaftMessageRequest{
+		RangeID: 1,
+		ToReplica: roachpb.ReplicaDescriptor{
+			NodeID:    1,
+			StoreID:   1,
+			ReplicaID: 2,
+		},
+		FromReplica: roachpb.ReplicaDescriptor{
+			NodeID:    2,
+			StoreID:   2,
+			ReplicaID: 2,
+		},
+		Message: raftpb.Message{
+			Type: raftpb.MsgSnap,
+			Snapshot: raftpb.Snapshot{
+				Data: data,
+				Metadata: raftpb.SnapshotMetadata{
+					Index: 1,
+					Term:  1,
+				},
+			},
+		},
+	}
+	if err := s.HandleRaftRequest(ctx, req); err != nil {
+		t.Fatal(err)
+	}
+
+	util.SucceedsSoon(t, func() error {
+		s.mu.Lock()
+		numPlaceholders := len(s.mu.replicaPlaceholders)
+		s.mu.Unlock()
+
+		if numPlaceholders == 0 {
+			return nil
+		}
+		return errors.Errorf("expected 0 placeholders, but found %d", numPlaceholders)
+	})
+
+	if n := atomic.LoadInt32(&s.counts.droppedPlaceholders); n != 1 {
+		t.Fatalf("expected 1 dropped placeholder, but found %d", n)
 	}
 }


### PR DESCRIPTION
This meshes better with per-Replica raft locking where
Store.processRaftMu will not be present to protect the placeholder
during application of a preemptive snapshot.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8956)

<!-- Reviewable:end -->
