### PR TITLE
sql: switch to our forked yacc to prevent NTYPES error

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -2,6 +2,7 @@ cmd github.com/client9/misspell/cmd/misspell
 cmd github.com/cockroachdb/c-protobuf/cmd/protoc
 cmd github.com/cockroachdb/cockroach/cmd/protoc-gen-gogoroach
 cmd github.com/cockroachdb/stress
+cmd github.com/cockroachdb/yacc
 cmd github.com/golang/lint/golint
 cmd github.com/gordonklaus/ineffassign
 cmd github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
@@ -41,6 +42,7 @@ github.com/cockroachdb/cmux b64f5908f4945f4b11ed4a0a9d3cc1e23350866d
 github.com/cockroachdb/cockroach-go 2e4a60d41697eebb308b1def89f0abaf1c056137
 github.com/cockroachdb/pq 40c6b2414c76cdb84aacc955f79dc844e48ad0c0
 github.com/cockroachdb/stress 029c9348806514969d1109a6ae36e521af411ca7
+github.com/cockroachdb/yacc 7c99dfd2164a5d23c3f495ffc2e0b72b6379d066
 github.com/codahale/hdrhistogram f8ad88b59a584afeee9d334eff879b104439117b
 github.com/coreos/etcd 48f4a7d037ca8fd276fff09ef068074193b24dfa
 github.com/cpuguy83/go-md2man 2724a9c9051aa62e9cca11304e7dd518e9e41599

--- a/acceptance/run.sh
+++ b/acceptance/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+set -euo pipefail
 
 source $(dirname $0)/../build/init-docker.sh
 $(dirname $0)/../build/builder.sh make install GOFLAGS='-tags clockoffset'

--- a/build/build-docker-deploy.sh
+++ b/build/build-docker-deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Build a statically linked Cockroach binary
 #
 # Author: Peter Mattis (peter@cockroachlabs.com)

--- a/build/build-race-binaries.sh
+++ b/build/build-race-binaries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Build cockroach binary with race detection enabled.
 
 set -euo pipefail

--- a/build/build-static-binaries.sh
+++ b/build/build-static-binaries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Build various statically linked binaries.
 
 set -euo pipefail

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+set -euo pipefail
 
 image="cockroachdb/builder"
 

--- a/build/check-style.sh
+++ b/build/check-style.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/build/check-style.sh
+++ b/build/check-style.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+set -euo pipefail
 
 export PKG=${PKG:-./...}
 

--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eux
 

--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eux
+set -euxo pipefail
 
 CIRCLE_NODE_INDEX="${CIRCLE_NODE_INDEX-0}"
 CIRCLE_NODE_TOTAL="${CIRCLE_NODE_TOTAL-1}"

--- a/build/circle-local.sh
+++ b/build/circle-local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/build/circle-local.sh
+++ b/build/circle-local.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 $(dirname $0)/circle-deps.sh
 $(dirname $0)/circle-test.sh

--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/build/deplicense.sh
+++ b/build/deplicense.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-#
+
+set -euo pipefail
+
 # Output the license info for the current directory's dependencies.
 #
 # The output is sorted by package name:
 #   <package-repo-root> <license info>
-
-set -e
 
 dirs=()
 function visit() {

--- a/build/init-docker.sh
+++ b/build/init-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/build/init-docker.sh
+++ b/build/init-docker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+set -euo pipefail
 
 # Verify that Docker is installed.
 DOCKER="docker"

--- a/build/push-docker-deploy.sh
+++ b/build/push-docker-deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eux
 

--- a/build/push-docker-deploy.sh
+++ b/build/push-docker-deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eux
+set -euxo pipefail
 
 $(dirname $0)/build-docker-deploy.sh
 

--- a/build/push-one-binary.sh
+++ b/build/push-one-binary.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
+
+set -euxo pipefail
+
 # This file uses `bash` and not `sh` due to the `time` builtin (the external
 # `time` is not available on CircleCI).
-
-set -eu
 
 BUCKET_NAME="cockroach"
 LATEST_SUFFIX=".LATEST"

--- a/build/push-release-tarball.sh
+++ b/build/push-release-tarball.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
+
+set -euxo pipefail
+
 # This file uses `bash` and not `sh` due to the `time` builtin (the external
 # `time` is not available on CircleCI).
-
-set -eu
 
 BUCKET_NAME="binaries.cockroachdb.com"
 

--- a/build/upload-coverage.sh
+++ b/build/upload-coverage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -z "$COVERALLS_TOKEN" ]; then
   echo "FAIL: Missing or empty COVERALLS_TOKEN."

--- a/build/upload-coverage.sh
+++ b/build/upload-coverage.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 if [ -z "$COVERALLS_TOKEN" ]; then
   echo "FAIL: Missing or empty COVERALLS_TOKEN."
   exit 1

--- a/cloud/aws/benchmarks/benchmarks.sh
+++ b/cloud/aws/benchmarks/benchmarks.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
+
+set -euxo pipefail
+
 # The caller should download the static-tests and extract them into the
 # local directory.
-
-set -x
 
 TEST_FLAGS="-test.bench=.* -test.benchmem -test.run=NONE -test.count=10"
 LOG_DIR="logs"

--- a/cloud/aws/benchmarks/benchmarks.sh
+++ b/cloud/aws/benchmarks/benchmarks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # The caller should download the static-tests and extract them into the
 # local directory.
 

--- a/cloud/aws/download_binary.sh
+++ b/cloud/aws/download_binary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script takes the name of a binary and downloads it from S3.
 # It takes the repo_name/binary_name and an optional sha.
 # If the sha is not specified, the latest binary is downloaded.

--- a/cloud/aws/download_binary.sh
+++ b/cloud/aws/download_binary.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+set -euxo pipefail
+
 # This script takes the name of a binary and downloads it from S3.
 # It takes the repo_name/binary_name and an optional sha.
 # If the sha is not specified, the latest binary is downloaded.
@@ -29,7 +32,6 @@
 # }
 # ...
 # <<<
-set -ex
 
 BUCKET_NAME="cockroach"
 LATEST_SUFFIX=".LATEST"

--- a/cloud/aws/stress/stress.sh
+++ b/cloud/aws/stress/stress.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # The caller should download the static-tests and extract them into the
 # local directory.
 

--- a/cloud/aws/stress/stress.sh
+++ b/cloud/aws/stress/stress.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
+
+set -euxo pipefail
+
 # The caller should download the static-tests and extract them into the
 # local directory.
-
-set -x
 
 LOG_DIR="logs"
 MAX_RUNS=0

--- a/cloud/gce/benchmarks/benchmarks.sh
+++ b/cloud/gce/benchmarks/benchmarks.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
+
+set -euxo pipefail
+
 # The caller should download the static-tests and extract them into the
 # local directory.
-
-set -x
 
 TEST_FLAGS="-test.bench=.* -test.benchmem -test.run=NONE -test.count=10"
 LOG_DIR="logs"

--- a/cloud/gce/benchmarks/benchmarks.sh
+++ b/cloud/gce/benchmarks/benchmarks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # The caller should download the static-tests and extract them into the
 # local directory.
 

--- a/cloud/gce/download_binary.sh
+++ b/cloud/gce/download_binary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script takes the name of a binary and downloads it from S3.
 # It takes the repo_name/binary_name and an optional sha.
 # If the sha is not specified, the latest binary is downloaded.

--- a/cloud/gce/download_binary.sh
+++ b/cloud/gce/download_binary.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+set -euxo pipefail
+
 # This script takes the name of a binary and downloads it from S3.
 # It takes the repo_name/binary_name and an optional sha.
 # If the sha is not specified, the latest binary is downloaded.
@@ -29,7 +32,6 @@
 # }
 # ...
 # <<<
-set -ex
 
 BUCKET_NAME="cockroach"
 LATEST_SUFFIX=".LATEST"

--- a/cloud/gce/stress/stress.sh
+++ b/cloud/gce/stress/stress.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # The caller should download the static-tests and extract them into the
 # local directory.
 

--- a/cloud/gce/stress/stress.sh
+++ b/cloud/gce/stress/stress.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
+
+set -euxo pipefail
+
 # The caller should download the static-tests and extract them into the
 # local directory.
-
-set -x
 
 LOG_DIR="logs"
 MAX_RUNS=0

--- a/sql/parser/sql_union.sh
+++ b/sql/parser/sql_union.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/sql/parser/sql_union.sh
+++ b/sql/parser/sql_union.sh
@@ -10,7 +10,8 @@ set -euo pipefail
 # to union type accessors in the Go code within rules, as the YACC
 # compiler does not type check Go code.
 function type_check() {
-    ! go tool yacc -o /dev/null -p sql sql.y | grep -F 'conflicts'
+    ret=$(go tool yacc -o /dev/null -p sql sql.y)
+    ! echo "$ret" | grep -F 'conflicts'
 }
 
 # This step performs the actual compilation from the sql.y syntax to
@@ -42,7 +43,8 @@ function compile() {
 
     # Compile this new "unionized" syntax file through YACC, this time writing
     # the output to sql.go.
-    ! go tool yacc -o sql.go -p sql sql.y | grep -F 'conflicts'
+    ret=$(go tool yacc -o sql.go -p sql sql.y)
+    ! echo "$ret" | grep -F 'conflicts'
 
     # Overwrite the migrated syntax file with the original syntax file.
     mv sql.y.tmp sql.y

--- a/sql/parser/sql_union.sh
+++ b/sql/parser/sql_union.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+set -euo pipefail
 
 # This step runs sql.y through the YACC compiler directly without
 # performing any type/token declaration modifications, throwing out

--- a/sql/parser/sql_union.sh
+++ b/sql/parser/sql_union.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+YACC="../../../../../../bin/yacc"
+
 # This step runs sql.y through the YACC compiler directly without
 # performing any type/token declaration modifications, throwing out
 # the result on a successful compilation. This allows the YACC compiler
@@ -10,7 +12,7 @@ set -euo pipefail
 # to union type accessors in the Go code within rules, as the YACC
 # compiler does not type check Go code.
 function type_check() {
-    ret=$(go tool yacc -o /dev/null -p sql sql.y)
+    ret=$($YACC -o /dev/null -p sql sql.y)
     ! echo "$ret" | grep -F 'conflicts'
 }
 
@@ -43,7 +45,7 @@ function compile() {
 
     # Compile this new "unionized" syntax file through YACC, this time writing
     # the output to sql.go.
-    ret=$(go tool yacc -o sql.go -p sql sql.y)
+    ret=$($YACC -o sql.go -p sql sql.y)
     ! echo "$ret" | grep -F 'conflicts'
 
     # Overwrite the migrated syntax file with the original syntax file.


### PR DESCRIPTION
Makes a bunch of scripts stricter while I'm here.

This prevents a silent `go generate` failure in `sql/parser`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8957)

<!-- Reviewable:end -->
