### PR TITLE
storage: streaming snapshots improvements

### DIFF
--- a/rpc/context.go
+++ b/rpc/context.go
@@ -48,7 +48,11 @@ const (
 // service.
 func NewServer(ctx *Context) *grpc.Server {
 	opts := []grpc.ServerOption{
-		grpc.MaxMsgSize(math.MaxInt32), // TODO(peter,tamird): need tests before lowering
+		// The limiting factor for lowering the max message size is the fact
+		// that a single large kv can be sent over the network in one message.
+		// Our maximum kv size is unlimited, so we need this to be very large.
+		// TODO(peter,tamird): need tests before lowering
+		grpc.MaxMsgSize(math.MaxInt32),
 	}
 	if !ctx.Insecure {
 		tlsConfig, err := ctx.GetServerTLSConfig()

--- a/storage/engine/batch.go
+++ b/storage/engine/batch.go
@@ -81,16 +81,22 @@ func (b *rocksDBBatchBuilder) maybeInit() {
 // the builder may be used to construct another batch, but the returned []byte
 // is only valid until the next builder method is called.
 func (b *rocksDBBatchBuilder) Finish() []byte {
+	repr := b.getRepr()
+	b.repr = b.repr[:headerSize]
+	b.count = 0
+	return repr
+}
+
+// getRepr constructs the batch representation and returns it.
+func (b *rocksDBBatchBuilder) getRepr() []byte {
+	b.maybeInit()
 	buf := b.repr[8:headerSize]
 	v := uint32(b.count)
 	buf[0] = byte(v)
 	buf[1] = byte(v >> 8)
 	buf[2] = byte(v >> 16)
 	buf[3] = byte(v >> 24)
-	repr := b.repr
-	b.repr = b.repr[:headerSize]
-	b.count = 0
-	return repr
+	return b.repr
 }
 
 func (b *rocksDBBatchBuilder) grow(n int) {

--- a/storage/engine/batch_test.go
+++ b/storage/engine/batch_test.go
@@ -582,6 +582,10 @@ func TestBatchBuilder(t *testing.T) {
 	e := NewInMem(roachpb.Attributes{}, 1<<20, stopper)
 
 	batch := e.NewBatch().(*rocksDBBatch)
+	// Ensure that, even though we reach into the batch's internals with
+	// dbPut etc, asking for the batch's Repr will get data from C++ and
+	// not its unused builder.
+	batch.flushes++
 	defer batch.Close()
 
 	builder := &rocksDBBatchBuilder{}
@@ -632,6 +636,10 @@ func TestBatchBuilderStress(t *testing.T) {
 
 		func() {
 			batch := e.NewBatch().(*rocksDBBatch)
+			// Ensure that, even though we reach into the batch's internals with
+			// dbPut etc, asking for the batch's Repr will get data from C++ and
+			// not its unused builder.
+			batch.flushes++
 			defer batch.Close()
 
 			builder := &rocksDBBatchBuilder{}

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -917,6 +917,7 @@ func (r *rocksDBBatch) ApplyBatchRepr(repr []byte) error {
 	if r.distinctOpen {
 		panic("distinct batch open")
 	}
+	r.flushMutations()
 	return dbApplyBatchRepr(r.batch, repr)
 }
 

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -1005,6 +1005,10 @@ func (r *rocksDBBatch) Commit() error {
 }
 
 func (r *rocksDBBatch) Repr() []byte {
+	if r.flushes == 0 {
+		// We've never flushed to C++. Return the mutations only.
+		return r.builder.getRepr()
+	}
 	r.flushMutations()
 	return cSliceToGoBytes(C.DBBatchRepr(r.batch))
 }

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -2005,7 +2005,7 @@ func (r *Replica) sendRaftMessage(msg raftpb.Message) {
 		}
 		if *msgUUID != snap.SnapUUID {
 			log.Fatalf(r.ctx, "programming error: snapshot message from Raft.Ready %s doesn't match outgoing snapshot UUID %s.",
-				*msgUUID, snap.SnapUUID)
+				msgUUID.Short(), snap.SnapUUID.Short())
 		}
 		// Asynchronously stream the snapshot to the recipient.
 		if err := r.store.Stopper().RunTask(func() {

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -3001,7 +3001,7 @@ func (r *Replica) ChangeReplicas(
 			)
 		}
 
-		if err := r.setPendingSnapshotIndex(snap.Snapshot.Metadata.Index); err != nil {
+		if err := r.setPendingSnapshotIndex(snap.RaftSnap.Metadata.Index); err != nil {
 			return err
 		}
 
@@ -3015,8 +3015,8 @@ func (r *Replica) ChangeReplicas(
 					Type:     raftpb.MsgSnap,
 					To:       0, // special cased ReplicaID for preemptive snapshots
 					From:     uint64(fromRepDesc.ReplicaID),
-					Term:     snap.Snapshot.Metadata.Term,
-					Snapshot: snap.Snapshot,
+					Term:     snap.RaftSnap.Metadata.Term,
+					Snapshot: snap.RaftSnap,
 				},
 			},
 			// TODO(jordan) set this accurately

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -6463,7 +6463,6 @@ func TestReserveAndApplySnapshot(t *testing.T) {
 		SnapUUID:        snap.SnapUUID,
 		RangeDescriptor: *firstRng.Desc(),
 		Batches:         [][]byte{b.Repr()},
-		LogEntries:      snap.LogEntries,
 	},
 		snap.Snapshot, raftpb.HardState{}); err != nil {
 		t.Fatal(err)

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -6464,7 +6464,7 @@ func TestReserveAndApplySnapshot(t *testing.T) {
 		RangeDescriptor: *firstRng.Desc(),
 		Batches:         [][]byte{b.Repr()},
 	},
-		snap.Snapshot, raftpb.HardState{}); err != nil {
+		snap.RaftSnap, raftpb.HardState{}); err != nil {
 		t.Fatal(err)
 	}
 	checkReservations(t, 0)

--- a/storage/store.go
+++ b/storage/store.go
@@ -2599,13 +2599,13 @@ func sendSnapshot(
 
 	rangeID := header.RangeDescriptor.RangeID
 
-	truncState, err := loadTruncatedState(stream.Context(), snap.Snap, rangeID)
+	truncState, err := loadTruncatedState(stream.Context(), snap.EngineSnap, rangeID)
 	if err != nil {
 		return err
 	}
 	firstIndex := truncState.Index + 1
 
-	endIndex := snap.Snapshot.Metadata.Index + 1
+	endIndex := snap.RaftSnap.Metadata.Index + 1
 	logEntries := make([][]byte, 0, endIndex-firstIndex)
 
 	scanFunc := func(kv roachpb.KeyValue) (bool, error) {
@@ -2616,7 +2616,7 @@ func sendSnapshot(
 		return false, err
 	}
 
-	if err := iterateEntries(stream.Context(), snap.Snap, rangeID, firstIndex, endIndex, scanFunc); err != nil {
+	if err := iterateEntries(stream.Context(), snap.EngineSnap, rangeID, firstIndex, endIndex, scanFunc); err != nil {
 		return err
 	}
 	if err := stream.Send(&SnapshotRequest{LogEntries: logEntries, Final: true}); err != nil {

--- a/storage/store.go
+++ b/storage/store.go
@@ -2597,11 +2597,33 @@ func sendSnapshot(
 		}
 	}
 
-	if err := stream.Send(&SnapshotRequest{LogEntries: snap.LogEntries, Final: true}); err != nil {
+	rangeID := header.RangeDescriptor.RangeID
+
+	truncState, err := loadTruncatedState(stream.Context(), snap.Snap, rangeID)
+	if err != nil {
+		return err
+	}
+	firstIndex := truncState.Index + 1
+
+	endIndex := snap.Snapshot.Metadata.Index + 1
+	logEntries := make([][]byte, 0, endIndex-firstIndex)
+
+	scanFunc := func(kv roachpb.KeyValue) (bool, error) {
+		bytes, err := kv.Value.GetBytes()
+		if err == nil {
+			logEntries = append(logEntries, bytes)
+		}
+		return false, err
+	}
+
+	if err := iterateEntries(stream.Context(), snap.Snap, rangeID, firstIndex, endIndex, scanFunc); err != nil {
+		return err
+	}
+	if err := stream.Send(&SnapshotRequest{LogEntries: logEntries, Final: true}); err != nil {
 		return err
 	}
 	log.Infof(stream.Context(), "streamed snapshot: kv pairs: %d, log entries: %d",
-		n, len(snap.LogEntries))
+		n, len(logEntries))
 
 	resp, err = stream.Recv()
 	if err != nil {

--- a/storage/store.go
+++ b/storage/store.go
@@ -2557,8 +2557,8 @@ func sendSnapshot(
 	// unreplicated keys from the snapshot.
 	unreplicatedPrefix := keys.MakeRangeIDUnreplicatedPrefix(header.RangeDescriptor.RangeID)
 	var alloc bufalloc.ByteAllocator
-	// TODO(jordan) make this configurable.
-	batchSize := 50
+	// TODO(jordan) make this configurable. For now, 1MB.
+	const batchSize = 1 << 20
 	n := 0
 	var b engine.Batch
 	for ; snap.Iter.Valid(); snap.Iter.Next() {
@@ -2581,11 +2581,14 @@ func sendSnapshot(
 			return err
 		}
 
-		if n%batchSize == 0 {
+		if len(b.Repr()) >= batchSize {
 			if err := sendBatch(stream, b); err != nil {
 				return err
 			}
 			b = nil
+			// We no longer need the keys and values in the batch we just sent,
+			// so reset alloc and allow them to be garbage collected.
+			alloc = bufalloc.ByteAllocator{}
 		}
 	}
 	if b != nil {


### PR DESCRIPTION
This pull request contains several commits that respond to post-merge comments
on #8726.

```
Changes:

   storage: distinct batches for snapshot logs

   This commit re-introduces the use of distinct batches to snapshot
   application for clearing the range.

   rocksDBBatch.ApplyBatchRepr also had a small bug - it didn't flush
   mutations before applying the repr. That's corrected now.

  storage: streaming snap miscellaneous improvements

   - Rename OutgoingSnap.{Snap,Snapshot} to {EngineSnap,RaftSnap} for
    clarity
   - Use uuid.Short() to log Snapshot uuids.

   storage: get snapshot log entries lazily

   When sending a streaming snapshot, delay getting the raft log entries from
   the rocksdb snapshot until we need them.

   storage: streaming snaps chunked by size in bytes

   Previously, snapshots were chunked based on the number of entries in a
   batch. Now they are chunked based on the size in bytes of the batch.

   storage/engine: improve batch.Repr()

   If the batch has never been flushed, we can just return the mutations as a
   Repr without having to flush to C++ and read bytes back.
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8958)

<!-- Reviewable:end -->
