### PR TITLE
scripts: fwd agent when setting up gceworker

### DIFF
--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -22,7 +22,7 @@ case ${1-} in
     sleep 20 # avoid SSH timeout on copy-files
 
     gcloud compute copy-files "$(dirname "${0}")" "${name}:scripts"
-    gcloud compute ssh "${name}" "GOVERSION=${GOVERSION} ./scripts/bootstrap-debian.sh"
+    gcloud compute ssh "${name}" --ssh-flag="-A" --command="GOVERSION=${GOVERSION} ./scripts/bootstrap-debian.sh"
     # Install automatic shutdown after ten minutes of operation without a
     # logged in user. To disable this, `sudo touch /.active`.
     # This is much more intricate than it looks. A few complications which
@@ -50,7 +50,7 @@ case ${1-} in
     ;;
     ssh)
     shift
-    gcloud compute ssh "${name}" "$@"
+    gcloud compute ssh "${name}" --ssh-flag="-A" -- "$@"
     ;;
     *)
     echo "$0: unknown command: ${1-}, use one of create, start, stop, destroy, or ssh"


### PR DESCRIPTION
From the man pages of ssh and ssh-agent:

> The idea is that the agent is run in the user's local PC, laptop, or terminal.
> Authentication data need not be stored on any other machine, and authentication
> passphrases never go over the network. However, the connection to the agent is
> forwarded over SSH remote logins, and the user can thus use the privileges given
> by the identities anywhere in the network in a secure way.
> 
> The `-A` flag to SSH enables forwarding of the authentication agent connection.
> This can also be specified on a per-host basis in a configuration file. Agent
> forwarding should be enabled with caution. Users with the ability to bypass file
> permissions on the remote host (for the agent's UNIX-domain socket) can access
> the local agent through the forwarded connection. An attacker cannot obtain key
> material from the agent, however they can perform operations on the keys that
> enable them to authenticate using the identities loaded into the agent.

Thus enabling agent forwarding means that git operations performed on the GCE
worker using remotes via the SSH transport protocol can use keys the user has
locally in their agent.

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8965)

<!-- Reviewable:end -->
