### PR TITLE
sql: fix EXPLAIN for VALUES with expressions containing sub-queries.

### DIFF
--- a/sql/testdata/values
+++ b/sql/testdata/values
@@ -17,3 +17,17 @@ VALUES (1), (1), (2), (3) ORDER BY 1 DESC LIMIT 3
 
 query error column z does not exist
 VALUES (1), (1), (2), (3) ORDER BY z
+
+# subqueries can be evaluated in VALUES
+query I
+VALUES ((SELECT 1)), ((SELECT 2))
+----
+1
+2
+
+# the subquery's plan must be visible in EXPLAIN
+query ITT
+EXPLAIN VALUES (1), ((SELECT 2))
+----
+0 values 1 column
+1 empty  -

--- a/sql/values.go
+++ b/sql/values.go
@@ -278,7 +278,15 @@ func (n *valuesNode) ExplainPlan(_ bool) (name, description string, children []p
 	name = "values"
 	description = fmt.Sprintf("%d column%s",
 		len(n.columns), util.Pluralize(int64(len(n.columns))))
-	return name, description, nil
+
+	var subplans []planNode
+	for _, tuple := range n.tuples {
+		for _, expr := range tuple {
+			subplans = n.p.collectSubqueryPlans(expr, subplans)
+		}
+	}
+
+	return name, description, subplans
 }
 
 func (n *valuesNode) ExplainTypes(regTypes func(string, string)) {


### PR DESCRIPTION
Fixes an oversight. Found with help from @mjibson.

Matt you can review this but foremost I invite you to populate your ExplainPlan for SPLIT AS (and possibly ExplainTypes) taking some inspiration from this.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8970)

<!-- Reviewable:end -->
