### PR TITLE
storage: Limit replica reservations to 1

### DIFF
--- a/storage/reservation.go
+++ b/storage/reservation.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// defaultMaxReservations is the number of concurrent reservations allowed.
-	defaultMaxReservations = 5
+	defaultMaxReservations = 1
 	// defaultMaxReservedBytes is the total number of bytes that can be
 	// reserved, by all active reservations, at any time.
 	defaultMaxReservedBytes = 250 << 20 // 250 MiB

--- a/storage/reservation_test.go
+++ b/storage/reservation_test.go
@@ -77,7 +77,7 @@ func bookieQueueLen(b *bookie) int {
 // correctly.
 func TestBookieReserve(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	stopper, _, b := createTestBookie(time.Hour, defaultMaxReservations, defaultMaxReservedBytes)
+	stopper, _, b := createTestBookie(time.Hour, 5, defaultMaxReservedBytes)
 	defer stopper.Stop()
 
 	testCases := []struct {


### PR DESCRIPTION
We already limit snapshot generation to 1 at a time, so it makes sense
to have the same limit for the receiving side (which is more expensive).

Fixes #8973

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8974)

<!-- Reviewable:end -->
