### PR TITLE
sql, storage: misc spelling fixes

### DIFF
--- a/sql/lease.go
+++ b/sql/lease.go
@@ -234,7 +234,7 @@ func (s LeaseStore) Release(lease *LeaseState) error {
 // waitForOneVersion returns once there are no unexpired leases on the
 // previous version of the table descriptor. It returns the current version.
 // After returning there can only be versions of the descriptor >= to the
-// returned verson. Lease acquisition (see acquire()) maintains the
+// returned version. Lease acquisition (see acquire()) maintains the
 // invariant that no new leases for desc.Version-1 will be granted once
 // desc.Version exists.
 func (s LeaseStore) waitForOneVersion(tableID sqlbase.ID, retryOpts retry.Options) (
@@ -1028,7 +1028,7 @@ func (m *LeaseManager) AcquireByName(
 		// RENAME had a lease on the old name, and then tries to use the new name
 		// after the RENAME statement.
 		//
-		// How do we dissambiguate between the a) and b)? We get a fresh lease on
+		// How do we disambiguate between the a) and b)? We get a fresh lease on
 		// the descriptor, as required by b), and then we'll know if we're trying to
 		// resolve the current or the old name.
 

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -38,9 +38,9 @@ type Iterator interface {
 	// SeekReverse advances the iterator to the first key in the engine which
 	// is <= the provided key.
 	SeekReverse(key MVCCKey)
-	// Valid returns true if the iterator is currently valid. An
-	// iterator which hasn't been seeked or has gone past the end of the
-	// key range is invalid.
+	// Valid returns true if the iterator is currently valid. An iterator that
+	// hasn't had Seek called on it or has gone past the end of the key range
+	// is invalid.
 	Valid() bool
 	// Next advances the iterator to the next key/value in the
 	// iteration. After this call, Valid() will be true if the

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -1440,7 +1440,7 @@ type RocksDBSstFileReader struct {
 	rocksDB *RocksDB
 }
 
-// MakeRocksDBSstFileReader creates a RocksDBSstFileReader that uses a scrach
+// MakeRocksDBSstFileReader creates a RocksDBSstFileReader that uses a scratch
 // directory which is cleaned up by `Close`.
 func MakeRocksDBSstFileReader() (RocksDBSstFileReader, error) {
 	stopper := stop.NewStopper()


### PR DESCRIPTION
follow up from #8980

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8982)

<!-- Reviewable:end -->
