### PR TITLE
storage: instrument eager ReplicaGC

### DIFF
--- a/storage/migration.go
+++ b/storage/migration.go
@@ -62,6 +62,7 @@ func migrate7310And6991(ctx context.Context, batch engine.ReadWriter, desc roach
 	// don't have a snapshot here, so we could wind up lowering the commit
 	// index (which would error out and fatal us).
 	if hs.Commit == 0 {
+		log.Warningf(ctx, "migration: synthesized HardState for %+v", desc)
 		if err := synthesizeHardState(ctx, batch, state, hs); err != nil {
 			return errors.Wrap(err, "could not migrate HardState")
 		}

--- a/storage/store.go
+++ b/storage/store.go
@@ -838,6 +838,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 				// the replica before shutting down. Destroy the replica now
 				// to avoid creating a new replica without a valid replica ID
 				// (which is necessary to have a non-nil raft group)
+				log.Infof(ctx, "eagerly destroying local data: %+v", desc)
 				return false, s.destroyReplicaData(&desc)
 			}
 			if !desc.IsInitialized() {


### PR DESCRIPTION
We have been seeing long startup times which disappear spontaneously. During a
restart of the beta cluster, the following goroutine was observed, which suggests
that we were spending a lot of time GCing replicas on startup.

```
engine              ??:0                     _Cfunc_DBIterNext(#324, #323, 0, 0, 0, 0, 0, 0, 0)
engine              rocksdb.go:1135          (*rocksDBIterator).Next(#235)
storage             replica_data_iter.go:104 (*ReplicaDataIterator).Next(#316)
storage             store.go:1748            (*Store).destroyReplicaData(#109, #317, 0, 0)
storage             store.go:841             (*Store).Start.func2(0x101b, #300, 0x36, 0x40, #301, 0x36, 0x40, #315, 0x3, 0x4, ...)
storage             store.go:734             IterateRangeDescriptors.func1(#306, 0x40, 0x41, #307, 0x92, 0x92, #341, 0, 0x186c, 0x4000, ...)
engine              mvcc.go:1593             MVCCIterate(#329, #68, #47, #81, #232, 0x9, 0x10, #233, 0xb, 0x10, ...)
storage             store.go:738             IterateRangeDescriptors(#330, #196, #47, #81, #195, #179, #110)
storage             store.go:867             (*Store).Start(#109, #330, #196, #179, #185, 0x1)
server              node.go:405              (*Node).initStores(#78, #330, #196, #98, 0x1, 0x1, #179, 0, #55)
server              node.go:330              (*Node).start(#78, #330, #196, #42, #129, #98, 0x1, 0x1, 0, 0, ...)
server              server.go:431            (*Server).Start(#5, #330, #196, #95, 0x1)
cli                 start.go:368             runStart(#34, #178, 0, 0x9, 0, 0)
cobra               command.go:599           (*Command).execute(#34, #177, 0x9, 0x9, #34, #177)
cobra               command.go:689           (*Command).ExecuteC(#33, #70, #343, #72)
cobra               command.go:648           (*Command).Execute(#33, #71, #343)
cli                 cli.go:96                Run(#64, 0xa, 0xa, 0, 0)
main                main.go:37               main()
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8985)

<!-- Reviewable:end -->
