### PR TITLE
	storage: fix incorrect LookupRange error causing TestSplitSnapshotRace_SplitWins flakiness

### DIFF
--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -394,6 +394,9 @@ func (t *multiTestContextKVTransport) SendNext(done chan<- kv.BatchCall) {
 	// the multi test context, so we can derive the index for stoppers
 	// and senders by subtracting 1 from the node ID.
 	nodeIndex := int(rep.NodeID) - 1
+	if log.V(1) {
+		log.Infof(context.TODO(), "SendNext nodeIndex=%d", nodeIndex)
+	}
 
 	// This method crosses store boundaries: it is possible that the
 	// destination store is stopped while the source is still running.

--- a/storage/stores.go
+++ b/storage/stores.go
@@ -192,44 +192,55 @@ func (ls *Stores) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.B
 // if not found.
 // If end is nil, a replica containing start is looked up.
 // This is only for testing usage; performance doesn't matter.
-func (ls *Stores) LookupReplica(start, end roachpb.RKey) (rangeID roachpb.RangeID, repDesc roachpb.ReplicaDescriptor, err error) {
+func (ls *Stores) LookupReplica(
+	start, end roachpb.RKey,
+) (roachpb.RangeID, roachpb.ReplicaDescriptor, error) {
 	ls.mu.RLock()
 	defer ls.mu.RUnlock()
-	var rng *Replica
-	var partialDesc *roachpb.RangeDescriptor
+	var rangeID roachpb.RangeID
+	var repDesc roachpb.ReplicaDescriptor
 	var repDescFound bool
 	for _, store := range ls.storeMap {
-		rng = store.LookupReplica(start, end)
-		if rng == nil {
-			if tmpRng := store.LookupReplica(start, nil); tmpRng != nil {
-				partialDesc = tmpRng.Desc()
-				log.Warningf(context.TODO(), "range not contained in one range: [%s,%s), but have [%s,%s)",
-					start, end, partialDesc.StartKey, partialDesc.EndKey)
-				break
-			}
+		replica := store.LookupReplica(start, nil)
+		if replica == nil {
 			continue
 		}
-		if !repDescFound {
-			rangeID = rng.RangeID
-			repDesc, err = rng.GetReplicaDescriptor()
-			if err != nil {
-				if _, ok := err.(*roachpb.RangeNotFoundError); !ok {
-					return 0, roachpb.ReplicaDescriptor{}, err
-				}
-			} else {
-				repDescFound = true
-			}
-			continue
+
+		// Verify that the descriptor contains the entire range.
+		if desc := replica.Desc(); !desc.ContainsKeyRange(start, end) {
+			log.Warningf(context.TODO(), "range not contained in one range: [%s,%s), but have [%s,%s)",
+				start, end, desc.StartKey, desc.EndKey)
+			err := roachpb.NewRangeKeyMismatchError(start.AsRawKey(), end.AsRawKey(), desc)
+			return 0, roachpb.ReplicaDescriptor{}, err
 		}
-		// Should never happen outside of tests.
-		return 0, roachpb.ReplicaDescriptor{}, errors.Errorf(
-			"range %+v exists on additional store: %+v", rng, store,
-		)
+
+		rangeID = replica.RangeID
+
+		var err error
+		repDesc, err = replica.GetReplicaDescriptor()
+		if err != nil {
+			if _, ok := err.(*roachpb.RangeNotFoundError); ok {
+				// We are not holding a lock across this block; the replica could have
+				// been removed from the range (via down-replication) between the
+				// LookupReplica and the GetReplicaDescriptor calls. In this case just
+				// ignore this replica.
+				continue
+			}
+			return 0, roachpb.ReplicaDescriptor{}, err
+		}
+
+		if repDescFound {
+			// We already found the range; this should never happen outside of tests.
+			err := errors.Errorf("range %+v exists on additional store: %+v", replica, store)
+			return 0, roachpb.ReplicaDescriptor{}, err
+		}
+
+		repDescFound = true
 	}
 	if !repDescFound {
-		err = roachpb.NewRangeKeyMismatchError(start.AsRawKey(), end.AsRawKey(), partialDesc)
+		return 0, roachpb.ReplicaDescriptor{}, roachpb.NewRangeNotFoundError(0)
 	}
-	return rangeID, repDesc, err
+	return rangeID, repDesc, nil
 }
 
 // FirstRange implements the RangeDescriptorDB interface. It returns the

--- a/storage/stores_test.go
+++ b/storage/stores_test.go
@@ -197,6 +197,11 @@ func TestStoresLookupReplica(t *testing.T) {
 			end:        nil,
 			expStoreID: s[1].Ident.StoreID,
 		},
+		{
+			start:    roachpb.RKey("z1"),
+			end:      roachpb.RKey("z2"),
+			expError: "range 0 was not found",
+		},
 	}
 	for testIdx, tc := range testCases {
 		_, r, err := ls.LookupReplica(tc.start, tc.end)

--- a/storage/stores_test.go
+++ b/storage/stores_test.go
@@ -167,28 +167,48 @@ func TestStoresLookupReplica(t *testing.T) {
 		ls.AddStore(s[i])
 	}
 
-	if _, r, err := ls.LookupReplica(roachpb.RKey("a"), roachpb.RKey("c")); err != nil {
-		t.Error(err)
-	} else if r.StoreID != s[0].Ident.StoreID {
-		t.Errorf("expected store %d; got %d", s[0].Ident.StoreID, r.StoreID)
+	testCases := []struct {
+		start, end roachpb.RKey
+		expStoreID roachpb.StoreID
+		expError   string
+	}{
+		{
+			start:      roachpb.RKey("a"),
+			end:        roachpb.RKey("c"),
+			expStoreID: s[0].Ident.StoreID,
+		},
+		{
+			start:      roachpb.RKey("b"),
+			end:        nil,
+			expStoreID: s[0].Ident.StoreID,
+		},
+		{
+			start:    roachpb.RKey("b"),
+			end:      roachpb.RKey("d"),
+			expError: "outside of bounds of range",
+		},
+		{
+			start:      roachpb.RKey("x"),
+			end:        roachpb.RKey("z"),
+			expStoreID: s[1].Ident.StoreID,
+		},
+		{
+			start:      roachpb.RKey("y"),
+			end:        nil,
+			expStoreID: s[1].Ident.StoreID,
+		},
 	}
-	if _, r, err := ls.LookupReplica(roachpb.RKey("b"), nil); err != nil {
-		t.Error(err)
-	} else if r.StoreID != s[0].Ident.StoreID {
-		t.Errorf("expected store %d; got %d", s[0].Ident.StoreID, r.StoreID)
-	}
-	if _, _, err := ls.LookupReplica(roachpb.RKey("b"), roachpb.RKey("d")); !testutils.IsError(err, "outside of bounds of range") {
-		t.Errorf("got unexpected error %v", err)
-	}
-	if _, r, err := ls.LookupReplica(roachpb.RKey("x"), roachpb.RKey("z")); err != nil {
-		t.Error(err)
-	} else if r.StoreID != s[1].Ident.StoreID {
-		t.Errorf("expected store %d; got %d", s[1].Ident.StoreID, r.StoreID)
-	}
-	if _, r, err := ls.LookupReplica(roachpb.RKey("y"), nil); err != nil {
-		t.Error(err)
-	} else if r.StoreID != s[1].Ident.StoreID {
-		t.Errorf("expected store %d; got %d", s[1].Ident.StoreID, r.StoreID)
+	for testIdx, tc := range testCases {
+		_, r, err := ls.LookupReplica(tc.start, tc.end)
+		if tc.expError != "" {
+			if !testutils.IsError(err, tc.expError) {
+				t.Errorf("%d: got error %v (expected %s)", testIdx, err, tc.expError)
+			}
+		} else if err != nil {
+			t.Errorf("%d: %s", testIdx, err)
+		} else if r.StoreID != tc.expStoreID {
+			t.Errorf("%d: expected store %d; got %d", testIdx, tc.expStoreID, r.StoreID)
+		}
 	}
 
 	if desc, err := ls.FirstRange(); err != nil {


### PR DESCRIPTION
The test occasionally times out under `stressrace`. The culprit is a condition
where the first replica doesn't find the range and incorrectly returns
RangeKeyMismatchError. The request is not retried on other replicas, but is then
retried endlessly by dist_sender.

The fix is to return a `RangeNotFound` in this case. Rewriting the code in the
function a bit to make it more readable.

Fixes #8868.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8988)

<!-- Reviewable:end -->
