### PR TITLE
build: fixed coverage regression introduced in #8957

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,10 @@ coverage:
 	$(GO) test -v $(GOFLAGS) -i $(PKG)
 	$(GO) test $(GOFLAGS) -cover -run "$(TESTS)" $(PKG) $(TESTFLAGS)
 
+.PHONY: upload-coverage
+upload-coverage:
+	@build/upload-coverage.sh
+
 # "make stress PKG=./storage TESTS=TestBlah" will build the given test
 # and run it in a loop (the PKG argument is required; if TESTS is not
 # given all tests in the package will be run).
@@ -211,10 +215,6 @@ $(GLOCK):
 .bootstrap: $(GITHOOKS) $(GLOCK) GLOCKFILE
 	@unset GIT_WORK_TREE; $(GLOCK) sync github.com/cockroachdb/cockroach
 	touch $@
-
-.PHONY: upload-coverage
-upload-coverage:
-	@build/upload-coverage.sh
 
 include .bootstrap
 

--- a/build/upload-coverage.sh
+++ b/build/upload-coverage.sh
@@ -60,7 +60,7 @@ for pkg in $(go list ./...); do
   # tests.
   f="${coverage_dir}/$(echo $pkg | tr / -).cover"
   touch $f
-  time ${builder} make coverage \
+  time make coverage \
     PKG="$pkg" \
     TESTFLAGS="-v -coverprofile=$f -covermode=$coverage_mode -coverpkg=$coverpkg" | \
     tee "${outdir}/coverage.log"

--- a/build/upload-coverage.sh
+++ b/build/upload-coverage.sh
@@ -28,8 +28,9 @@ coverage_mode=count
 # iterative_coverpkg fetches all test deps and main deps, filters them, and
 # converts them into a comma separated list stored in $coverpkg.
 iterative_coverpkg() {
-  imports="$1"
-  old_line_count="-1"
+  local imports="$1"
+  local old_line_count="-1"
+  local line_count=""
   while [ "$old_line_count" != "$line_count" ]; do
     old_line_count=$line_count
     imports+=$'\n'$(go list  -f '{{join .Imports "\n"}}


### PR DESCRIPTION
@tamird @jordanlewis 
#8957 `set -euo pipefail` caused the upload-coverage script to fail.

https://teamcity.cockroachdb.com/viewLog.html?buildId=16669&buildTypeId=Cockroach_Coverage_Coverage&tab=buildLog

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8989)

<!-- Reviewable:end -->
