### PR TITLE
ui: Fix ReactPaginate import

### DIFF
--- a/ui/app/containers/raftRanges.tsx
+++ b/ui/app/containers/raftRanges.tsx
@@ -1,6 +1,6 @@
 import _ from "lodash";
 import * as React from "react";
-import * as ReactPaginate from "react-paginate";
+import ReactPaginate from "react-paginate";
 import { Link } from "react-router";
 import { connect } from "react-redux";
 

--- a/ui/local_typings/react-paginate.d.ts
+++ b/ui/local_typings/react-paginate.d.ts
@@ -1,2 +1,2 @@
-let noTypeInfoYet: any;
+declare const noTypeInfoYet: {(_: any): any};
 export = noTypeInfoYet;


### PR DESCRIPTION
The recent change to compile modules as SystemJS modules unintentionally broke
the raft debug page, because the import statement for ReactPaginate was not
correct. This was not discovered by compilation because the ReactPaginate module
does not have a type definition, and is treated as `any`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8996)

<!-- Reviewable:end -->
