### PR TITLE
log: fix VTrace to consider the verbosity of the caller module

### DIFF
--- a/util/log/trace.go
+++ b/util/log/trace.go
@@ -47,7 +47,7 @@ func Tracef(ctx context.Context, format string, args ...interface{}) {
 // active trace) or logs to the trace alone depending on whether the specified
 // verbosity level is active.
 func VTrace(level level, ctx context.Context, msg string) {
-	if V(level) {
+	if VDepth(level, 1) {
 		Info(ctx, msg)
 	} else {
 		Trace(ctx, msg)
@@ -60,7 +60,7 @@ var _ = VTrace // TODO(peter): silence unused error, remove when used
 // active trace) or logs to the trace alone depending on whether the specified
 // verbosity level is active.
 func VTracef(level level, ctx context.Context, format string, args ...interface{}) {
-	if V(level) {
+	if VDepth(level, 1) {
 		Infof(ctx, format, args...)
 	} else {
 		Tracef(ctx, format, args...)


### PR DESCRIPTION
It was broken when --vmodule was set (so the caller had a different
verbosity than the "log" module itself).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9000)

<!-- Reviewable:end -->
