### PR TITLE
acceptance: deflake TestDockerReadWriteForwardReferenceVersion

### DIFF
--- a/acceptance/reference_test.go
+++ b/acceptance/reference_test.go
@@ -110,7 +110,8 @@ $bin sql -d old -e "SELECT i, b, s, d, f, v, extract(epoch FROM t) FROM testing_
 $bin sql -d old -e "SELECT i, b, s, d, f, v, extract(epoch FROM t) FROM testing_new" >> old.everything
 # diff returns non-zero if different. With set -e above, that would exit here.
 diff new.everything old.everything
-$bin quit && wait
+$bin quit || true
+wait
 `
 	runReadWriteReferenceTest(t, `bidirectional-reference-version`, backwardReferenceTest)
 }
@@ -127,7 +128,8 @@ $bin start & &> out
 until $bin sql -e "SELECT 1"; do sleep 1; done
 # grep returns non-zero if it didn't match anything. With set -e above, that would exit here.
 $bin sql -d old -e "SELECT i, b, s, d, f, v, extract(epoch FROM t) FROM testing_new" 2>&1 | grep "is encoded using using version 2, but this client only supports version 1"
-$bin quit && wait
+$bin quit || true
+wait
 `
 	runReadWriteReferenceTest(t, `forward-reference-version`, backwardReferenceTest)
 }


### PR DESCRIPTION
The last call to `./cockroach quit` can fail on the reference version. It's
intentionally an old beta, which means we can't change the quit code, so make
the script resilient to quit failing. If this happens again, we may have to try
quitting in a loop.

Closes #8893.

(Merging to master because that's where the test flaked.)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9001)

<!-- Reviewable:end -->
