### PR TITLE
sql: create table fails silently instead of retrying

### DIFF
--- a/sql/create.go
+++ b/sql/create.go
@@ -334,7 +334,7 @@ func (n *createTableNode) Start() error {
 
 	id, err := n.p.generateUniqueDescID()
 	if err != nil {
-		return nil
+		return err
 	}
 	desc.SetID(id)
 


### PR DESCRIPTION
While trying to resurrect #6277, I found that table creation was failing
silently.

I'll work on adding a direct test for it later. I found that TestRepair can
fail still with other reasons. I just wanted to get this fix in right away.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9011)

<!-- Reviewable:end -->
