### PR TITLE
storage: do not eagerly GC replicas at startup

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -2201,10 +2201,11 @@ func TestLeaderRemoveSelf(t *testing.T) {
 func TestRemoveRangeWithoutGC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	mtc := startMultiTestContext(t, 2)
+	sc := storage.TestStoreContext()
+	sc.TestingKnobs.DisableScanner = true
+	mtc := multiTestContext{storeContext: &sc}
+	mtc.Start(t, 2)
 	defer mtc.Stop()
-	// Disable the GC queue and move the range from store 0 to 1.
-	mtc.stores[0].SetReplicaGCQueueActive(false)
 	const rangeID roachpb.RangeID = 1
 	mtc.replicateRange(rangeID, 1)
 	mtc.unreplicateRange(rangeID, 0)
@@ -2238,25 +2239,22 @@ func TestRemoveRangeWithoutGC(t *testing.T) {
 	// can continue to use its last known replica ID.
 	mtc.stopStore(0)
 	mtc.restartStore(0)
-	// Turn off the GC queue to ensure that the replica is deleted at
-	// startup instead of by the scanner. This is not 100% guaranteed
-	// since the scanner could have already run at this point, but it
-	// should be enough to prevent us from accidentally relying on the
-	// scanner.
-	mtc.stores[0].SetReplicaGCQueueActive(false)
 
-	// The Replica object is not recreated.
-	if _, err := mtc.stores[0].GetReplica(rangeID); err == nil {
-		t.Fatalf("expected replica to be missing")
-	}
+	util.SucceedsSoon(t, func() error {
+		// The Replica object should be removed.
+		if _, err := mtc.stores[0].GetReplica(rangeID); err == nil {
+			return errors.Errorf("expected replica to be missing")
+		}
 
-	// And the data is no longer on disk.
-	if ok, err := engine.MVCCGetProto(context.Background(), mtc.stores[0].Engine(), descKey,
-		mtc.stores[0].Clock().Now(), true, nil, &desc); err != nil {
-		t.Fatal(err)
-	} else if ok {
-		t.Fatal("expected range descriptor to be absent")
-	}
+		// And the data should no longer be on disk.
+		if ok, err := engine.MVCCGetProto(context.Background(), mtc.stores[0].Engine(), descKey,
+			mtc.stores[0].Clock().Now(), true, nil, &desc); err != nil {
+			return err
+		} else if ok {
+			return errors.Errorf("expected range descriptor to be absent")
+		}
+		return nil
+	})
 }
 
 // TestCheckConsistencyMultiStore creates a Db with three stores ]

--- a/storage/store.go
+++ b/storage/store.go
@@ -824,31 +824,40 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	// due to a split crashing halfway will simply be resolved on the
 	// next split attempt. They can otherwise be ignored.
 	s.mu.Lock()
+
+	// TODO(peter): While we have to iterate to find the replica descriptors
+	// serially, we can perform the migrations and replica creation
+	// concurrently. Note that while we can perform this initialization
+	// concurrently, all of the initialization must be performed before we start
+	// listening for Raft messages and starting the process Raft loop.
 	err = IterateRangeDescriptors(ctx, s.engine,
 		func(desc roachpb.RangeDescriptor) (bool, error) {
-			if _, ok := desc.GetReplicaDescriptor(s.StoreID()); !ok {
-				// We are no longer a member of the range, but we didn't GC
-				// the replica before shutting down. Destroy the replica now
-				// to avoid creating a new replica without a valid replica ID
-				// (which is necessary to have a non-nil raft group)
-				log.Infof(ctx, "eagerly destroying local data: %+v", desc)
-				return false, s.destroyReplicaData(&desc)
-			}
 			if !desc.IsInitialized() {
 				return false, errors.Errorf("found uninitialized RangeDescriptor: %+v", desc)
 			}
 			s.migrate(ctx, desc)
 
-			rng, err := NewReplica(&desc, s, 0)
+			rep, err := NewReplica(&desc, s, 0)
 			if err != nil {
 				return false, err
 			}
-			if err = s.addReplicaInternalLocked(rng); err != nil {
+			if err = s.addReplicaInternalLocked(rep); err != nil {
 				return false, err
 			}
 			// Add this range and its stats to our counter.
 			s.metrics.ReplicaCount.Inc(1)
-			s.metrics.addMVCCStats(rng.GetMVCCStats())
+			s.metrics.addMVCCStats(rep.GetMVCCStats())
+
+			if _, ok := desc.GetReplicaDescriptor(s.StoreID()); !ok {
+				// We are no longer a member of the range, but we didn't GC the replica
+				// before shutting down. Add the replica to the GC queue.
+				if added, err := s.replicaGCQueue.Add(rep, replicaGCPriorityRemoved); err != nil {
+					log.Errorf(ctx, "%s: unable to add replica to GC queue: %s", rep, err)
+				} else if added {
+					log.Infof(ctx, "%s: added to replica GC queue", rep)
+				}
+			}
+
 			// Note that we do not create raft groups at this time; they will be created
 			// on-demand the first time they are needed. This helps reduce the amount of
 			// election-related traffic in a cold start.


### PR DESCRIPTION
Add removed replicas to the replica GC queue at startup so that they
will get destroyed in the background.

Fixes #8993.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9020)

<!-- Reviewable:end -->
