### PR TITLE
storage: Don't enqueue uninitialized replicas

### DIFF
--- a/storage/queue.go
+++ b/storage/queue.go
@@ -107,10 +107,12 @@ func isExpectedQueueError(err error) bool {
 type queueImpl interface {
 	// shouldQueue accepts current time, a replica, and the system config
 	// and returns whether it should be queued and if so, at what priority.
+	// The Replica is guaranteed to be initialized.
 	shouldQueue(hlc.Timestamp, *Replica, config.SystemConfig) (shouldQueue bool, priority float64)
 
 	// process accepts current time, a replica, and the system config
-	// and executes queue-specific work on it.
+	// and executes queue-specific work on it. The Replica is guaranteed
+	// to be initialized.
 	process(context.Context, hlc.Timestamp, *Replica, config.SystemConfig) error
 
 	// timer returns a duration to wait between processing the next item
@@ -281,6 +283,10 @@ func (bq *baseQueue) MaybeAdd(repl *Replica, now hlc.Timestamp) {
 		return
 	}
 
+	if !repl.IsInitialized() {
+		return
+	}
+
 	if !cfgOk {
 		log.VEvent(1, bq.ctx, "no system config available. skipping")
 		return
@@ -324,6 +330,12 @@ func (bq *baseQueue) addInternal(repl *Replica, should bool, priority float64) (
 	if bq.mu.disabled {
 		log.Event(bq.ctx, "queue disabled")
 		return false, errQueueDisabled
+	}
+
+	if !repl.IsInitialized() {
+		// We checked this above in MaybeAdd(), but we need to check it
+		// again for Add().
+		return false, errors.New("replica not initialized")
 	}
 
 	// If the replica is currently in purgatory, don't re-add it.

--- a/storage/store.go
+++ b/storage/store.go
@@ -1706,9 +1706,18 @@ func (s *Store) removeReplicaImpl(rep *Replica, origDesc roachpb.RangeDescriptor
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if _, ok := s.mu.replicas[rep.RangeID]; !ok {
+		return errors.New("replica not found")
+	}
+
 	delete(s.mu.replicas, rep.RangeID)
 	if s.mu.replicasByKey.Delete(rep) == nil {
-		return errors.Errorf("couldn't find range in replicasByKey btree")
+		// This is a fatal error because returning at this point will
+		// leave the Store in an inconsistent state (we've already deleted
+		// from s.mu.replicas), and uninitialized replicas shouldn't make
+		// it this far anyway. This method will need some changes when we
+		// introduce GC of uninitialized replicas.
+		log.Fatalf(context.TODO(), "replica %s found by id but not by key", rep)
 	}
 	s.scanner.RemoveReplica(rep)
 	s.consistencyScanner.RemoveReplica(rep)


### PR DESCRIPTION
None of the queues can do anything useful with uninitialized
replicas (they could be GC'd, but the replica GC queue currently
requires the range to have keys), so filter out uninitialized replicas
in baseQueue.

Make it a fatal error if a replica is in Store.mu.replicas but not
Store.mu.replicasByKey, which is one of the observable symptoms of
attempts to GC an uninitialized replica.

Updates #8944

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9021)

<!-- Reviewable:end -->
