### PR TITLE
acceptance: fix allocator tests

### DIFF
--- a/acceptance/terraform/nodectl
+++ b/acceptance/terraform/nodectl
@@ -19,6 +19,9 @@ if [ $# -ne 2 ]; then
     usage
 fi
 
+# ~/.config/gcloud may be erroneously owned by root, so fix that.
+sudo chown -R ${USER} "${HOME}/.config/gcloud"
+
 # CockroachDB nodes are named blah-cockroach-[0-9]*, so extract the final
 # numeric part.
 gcs_url="$2"


### PR DESCRIPTION
`nodectl`, which uploads and downloads archived stores,  was failing to
invoke `gsutil`, because recently, `~/.config/gcloud` started being
owned by root upon instance creation for some reason.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9028)

<!-- Reviewable:end -->
