### PR TITLE
scripts: correctly source go bash config

### DIFF
--- a/scripts/bootstrap-debian.sh
+++ b/scripts/bootstrap-debian.sh
@@ -20,7 +20,7 @@ patch -p1 -d ../go < "parallelbuilds-go${GOVERSION}.patch"
 (cd ~/go/src && GOROOT_BOOTSTRAP=~/go-bootstrap ./make.bash)
 
 echo 'export GOPATH=${HOME}; export PATH=${HOME}/go/bin:${GOPATH}/bin:${PATH}' >> ~/.bashrc_go
-echo '. .bashrc_go' >> ~/.bashrc
+echo '. ~/.bashrc_go' >> ~/.bashrc
 
 . ~/.bashrc_go
 

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -490,9 +490,9 @@ func TestApplyCmdLeaseError(t *testing.T) {
 		StoreID:   2,
 		ReplicaID: 2,
 	}
-	rngDesc := tc.rng.Desc()
+	rngDesc := *tc.rng.Desc()
 	rngDesc.Replicas = append(rngDesc.Replicas, secondReplica)
-	tc.rng.setDescWithoutProcessUpdate(rngDesc)
+	tc.rng.setDescWithoutProcessUpdate(&rngDesc)
 
 	pArgs := putArgs(roachpb.Key("a"), []byte("asd"))
 


### PR DESCRIPTION
Previously would do the wrong thing if a shell was started anywhere
other than $HOME.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9035)

<!-- Reviewable:end -->
