### PR TITLE
storage: correctly gc locally-anchored transactions

### DIFF
--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -788,7 +788,7 @@ func intersectSpan(
 	}
 	if bytes.Compare(span.Key, keys.LocalRangeMax) < 0 {
 		if bytes.Compare(span.EndKey, keys.LocalRangeMax) >= 0 {
-			panic("a local intent range may not have a non-local portion")
+			log.Fatalf(context.Background(), "a local intent range may not have a non-local portion: %s", span)
 		}
 		if containsKeyRange(desc, span.Key, span.EndKey) {
 			return &span, nil


### PR DESCRIPTION
The previous way of computing the key range for the GCRequest was incorrectly
making the assumption that `(roachpb.Key).Next` respected ordering on the
corresponding addressing-resolved keys.

This lead to intents on RangeDescriptors not being resolved during range splits
and perhaps rebalances, as observed in #8978.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9036)

<!-- Reviewable:end -->
