### PR TITLE
Fix index-out-of-range panic in Time Series Query

### DIFF
--- a/ts/query.go
+++ b/ts/query.go
@@ -515,6 +515,11 @@ func (db *DB) Query(query tspb.Query, r Resolution, startNanos, endNanos int64) 
 	// unionIterator at each offset encountered. If the query is requesting a
 	// derivative, a rate of change is recorded instead of the actual values.
 	iters.init()
+	if !iters.isValid() {
+		// We have no data to return.
+		return nil, sources, nil
+	}
+
 	var last tspb.TimeSeriesDatapoint
 	if isDerivative {
 		last = tspb.TimeSeriesDatapoint{

--- a/ts/query_test.go
+++ b/ts/query_test.go
@@ -317,6 +317,13 @@ func (tm *testModel) assertQuery(
 		}
 	}
 
+	// Verify that expected sources match actual sources.
+	sort.Strings(expectedSources)
+	sort.Strings(actualSources)
+	if !reflect.DeepEqual(actualSources, expectedSources) {
+		tm.t.Error(errors.Errorf("actual source list: %v, expected: %v", actualSources, expectedSources))
+	}
+
 	// Iterate over data in all dataSpans and construct expected datapoints.
 	var startOffset int32
 	isDerivative := q.GetDerivative() != tspb.TimeSeriesQueryDerivative_NONE
@@ -333,6 +340,12 @@ func (tm *testModel) assertQuery(
 	}
 
 	iters.init()
+	if !iters.isValid() {
+		if a, e := 0, len(expectedDatapoints); a != e {
+			tm.t.Error(errors.Errorf("query had zero datapoints, expected: %v", expectedDatapoints))
+		}
+		return
+	}
 	currentVal := func() tspb.TimeSeriesDatapoint {
 		var value float64
 		switch q.GetSourceAggregator() {
@@ -380,11 +393,6 @@ func (tm *testModel) assertQuery(
 		iters.advance()
 	}
 
-	sort.Strings(expectedSources)
-	sort.Strings(actualSources)
-	if !reflect.DeepEqual(actualSources, expectedSources) {
-		tm.t.Error(errors.Errorf("actual source list: %v, expected: %v", actualSources, expectedSources))
-	}
 	if !reflect.DeepEqual(actualDatapoints, expectedDatapoints) {
 		tm.t.Error(errors.Errorf("actual datapoints: %v, expected: %v", actualDatapoints, expectedDatapoints))
 	}
@@ -457,8 +465,37 @@ func TestQuery(t *testing.T) {
 	// Test with everything specified.
 	tm.assertQuery("test.multimetric", nil, tspb.TimeSeriesQueryAggregator_MIN.Enum(), tspb.TimeSeriesQueryAggregator_MAX.Enum(),
 		tspb.TimeSeriesQueryDerivative_NON_NEGATIVE_DERIVATIVE.Enum(), resolution1ns, 0, 90, 8, 2)
-	// Test query that returns no data.
-	tm.assertQuery("nodata", nil, nil, nil, nil, resolution1ns, 0, 90, 0, 0)
+
+	// Test queries that return no data. Check with every
+	// aggregator/downsampler/derivative combination. This situation is
+	// particularly prone to nil panics (parts of the query system will not have
+	// data).
+	aggs := []tspb.TimeSeriesQueryAggregator{
+		tspb.TimeSeriesQueryAggregator_MIN, tspb.TimeSeriesQueryAggregator_MAX,
+		tspb.TimeSeriesQueryAggregator_AVG, tspb.TimeSeriesQueryAggregator_SUM,
+	}
+	derivs := []tspb.TimeSeriesQueryDerivative{
+		tspb.TimeSeriesQueryDerivative_NONE, tspb.TimeSeriesQueryDerivative_DERIVATIVE,
+		tspb.TimeSeriesQueryDerivative_NON_NEGATIVE_DERIVATIVE,
+	}
+	for _, downsampler := range aggs {
+		for _, agg := range aggs {
+			for _, deriv := range derivs {
+				tm.assertQuery(
+					"nodata",
+					nil,
+					downsampler.Enum(),
+					agg.Enum(),
+					deriv.Enum(),
+					resolution1ns,
+					0,
+					90,
+					0,
+					0,
+				)
+			}
+		}
+	}
 
 	// Verify querying specific sources, thus excluding other available sources
 	// in the same time period.


### PR DESCRIPTION
A panic was possible in the time series query system under certain conditions:
- A query finds no matching data on the server
- That query is a derivative query

This commit eliminates that possibility by exiting earlier if no data is found.
Also adds a test which exercises all aggregator/downsampler/derivative
combinations in the no-data case; this new test was able to trigger the panic,
and has verified that it is no longer present.

Fixes #8289

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9038)

<!-- Reviewable:end -->
