### PR TITLE
distsql: implement router by mirror

### DIFF
--- a/sql/distsql/base.go
+++ b/sql/distsql/base.go
@@ -31,7 +31,7 @@ type RowReceiver interface {
 	// PushRow sends a row to this receiver. May block.
 	// Returns true if the row was sent, or false if the receiver does not need
 	// any more rows. In all cases, Close() still needs to be called.
-	// The sender must not use the row anymore after calling this function.
+	// The sender must not modify the row after calling this function.
 	PushRow(row sqlbase.EncDatumRow) bool
 	// Close is called when we have no more rows; it causes the RowReceiver to
 	// process all rows and clean up. If err is not null, the error is sent to
@@ -44,6 +44,7 @@ type RowReceiver interface {
 type RowSource interface {
 	// NextRow retrieves the next row. Returns a nil row if there are no more
 	// rows. Depending on the implementation, it may block.
+	// The caller must not modify the received row.
 	NextRow() (sqlbase.EncDatumRow, error)
 }
 

--- a/sql/distsql/routers.go
+++ b/sql/distsql/routers.go
@@ -13,6 +13,7 @@
 // permissions and limitations under the License.
 //
 // Author: Radu Berinde (radu@cockroachlabs.com)
+// Author: Irfan Sharif (irfansharif@cockroachlabs.com)
 //
 // Routers are used by processors to direct outgoing rows to (potentially)
 // multiple streams; see docs/RFCS/distributed_sql.md
@@ -40,34 +41,75 @@ func makeRouter(spec *OutputRouterSpec, streams []RowReceiver) (
 	switch spec.Type {
 	case OutputRouterSpec_BY_HASH:
 		return makeHashRouter(spec.HashColumns, streams)
+	case OutputRouterSpec_MIRROR:
+		return makeMirrorRouter(streams)
 	default:
 		return nil, errors.Errorf("router type %s not supported", spec.Type)
 	}
 }
 
-type hashRouter struct {
-	hashCols []uint32
-
+type routerBase struct {
 	streams []RowReceiver
+	err     error
+}
 
-	buffer []byte
-	err    error
+type mirrorRouter struct {
+	routerBase
+}
 
-	alloc sqlbase.DatumAlloc
+type hashRouter struct {
+	routerBase
+
+	hashCols []uint32
+	buffer   []byte
+	alloc    sqlbase.DatumAlloc
 }
 
 var _ RowReceiver = &hashRouter{}
+var _ RowReceiver = &mirrorRouter{}
 
 var crc32Table = crc32.MakeTable(crc32.Castagnoli)
+
+func makeMirrorRouter(streams []RowReceiver) (*mirrorRouter, error) {
+	return &mirrorRouter{
+		routerBase: routerBase{streams: streams},
+	}, nil
+}
 
 func makeHashRouter(hashCols []uint32, streams []RowReceiver) (*hashRouter, error) {
 	if len(hashCols) == 0 {
 		return nil, errors.Errorf("no hash columns for BY_HASH router")
 	}
 	return &hashRouter{
-		hashCols: hashCols,
-		streams:  streams,
+		routerBase: routerBase{streams: streams},
+		hashCols:   hashCols,
 	}, nil
+}
+
+// Close is part of the RowReceiver interface.
+func (rb *routerBase) Close(err error) {
+	if rb.err != nil {
+		// Any error we ran into takes precedence.
+		err = rb.err
+	}
+	for _, s := range rb.streams {
+		s.Close(err)
+	}
+}
+
+// PushRow is part of the RowReceiver interface.
+func (mr *mirrorRouter) PushRow(row sqlbase.EncDatumRow) bool {
+	if mr.err != nil {
+		return false
+	}
+
+	// Each row is sent to all the output streams, returning false here if a
+	// stream in particular does not need more rows or if none of them do seems
+	// unnecessary.
+	for _, s := range mr.streams {
+		s.PushRow(row)
+	}
+	return true
 }
 
 // PushRow is part of the RowReceiver interface.
@@ -101,15 +143,4 @@ func (hr *hashRouter) PushRow(row sqlbase.EncDatumRow) bool {
 	// limited benefit.
 	_ = hr.streams[streamIdx].PushRow(row)
 	return true
-}
-
-// Close is part of the RowReceiver interface.
-func (hr *hashRouter) Close(err error) {
-	if hr.err != nil {
-		// Any error we ran into takes precedence.
-		err = hr.err
-	}
-	for _, s := range hr.streams {
-		s.Close(err)
-	}
 }

--- a/sql/distsql/routers_test.go
+++ b/sql/distsql/routers_test.go
@@ -13,6 +13,7 @@
 // permissions and limitations under the License.
 //
 // Author: Radu Berinde (radu@cockroachlabs.com)
+// Author: Irfan Sharif (irfansharif@cockroachlabs.com)
 
 package distsql
 
@@ -32,14 +33,7 @@ func TestHashRouter(t *testing.T) {
 
 	// Generate tables of possible values for each column; we have fewer possible
 	// values than rows to guarantee many occurrences of each value.
-	vals := make([][]sqlbase.EncDatum, numCols)
-	for i := 0; i < numCols; i++ {
-		typ := sqlbase.RandColumnType(rng)
-		vals[i] = make([]sqlbase.EncDatum, numRows/10)
-		for j := range vals[i] {
-			vals[i][j].SetDatum(typ, sqlbase.RandDatum(rng, typ, true))
-		}
-	}
+	vals := sqlbase.RandEncDatumSlices(rng, numCols, numRows/10)
 
 	testCases := []struct {
 		hashColumns []uint32
@@ -107,6 +101,77 @@ func TestHashRouter(t *testing.T) {
 							t.Errorf("rows %s and %s in different buckets", row, row2)
 						}
 					}
+				}
+			}
+		}
+	}
+}
+
+func TestMirrorRouter(t *testing.T) {
+	const numCols = 6
+	const numRows = 20
+
+	rng, _ := randutil.NewPseudoRand()
+	alloc := &sqlbase.DatumAlloc{}
+
+	vals := sqlbase.RandEncDatumSlices(rng, numCols, numRows)
+
+	for numBuckets := 1; numBuckets <= 3; numBuckets++ {
+		bufs := make([]*RowBuffer, numBuckets)
+		recvs := make([]RowReceiver, numBuckets)
+		for i := 0; i < numBuckets; i++ {
+			bufs[i] = &RowBuffer{}
+			recvs[i] = bufs[i]
+		}
+		mr, err := makeMirrorRouter(recvs)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for i := 0; i < numRows; i++ {
+			row := make(sqlbase.EncDatumRow, numCols)
+			for j := 0; j < numCols; j++ {
+				row[j] = vals[j][rng.Intn(len(vals[j]))]
+			}
+			ok := mr.PushRow(row)
+			if !ok {
+				t.Fatalf("PushRow returned false")
+			}
+		}
+		mr.Close(nil)
+
+		// Verify each row is sent to each of the output streams.
+		for bIdx, b := range bufs {
+			if len(b.rows) != len(bufs[0].rows) {
+				t.Errorf("buckets %d and %d have different number of rows", 0, bIdx)
+			}
+			if !b.closed {
+				t.Errorf("bucket not closed")
+			}
+			if b.err != nil {
+				t.Error(b.err)
+			}
+			if bIdx == 0 {
+				continue
+			}
+
+			// Verify that the i-th row is the same across all buffers.
+			for i, row := range b.rows {
+				row2 := bufs[0].rows[i]
+
+				equal := true
+				for j, c := range row {
+					cmp, err := c.Compare(alloc, &row2[j])
+					if err != nil {
+						t.Fatal(err)
+					}
+					if cmp != 0 {
+						equal = false
+						break
+					}
+				}
+				if !equal {
+					t.Errorf("rows %s and %s found in one bucket and not the other", row, row2)
 				}
 			}
 		}

--- a/sql/sqlbase/testutils.go
+++ b/sql/sqlbase/testutils.go
@@ -14,6 +14,7 @@
 //
 // Author: Andrei Matei (andreimatei1@gmail.com)
 // Author: Radu Berinde (radu@cockroachlabs.com)
+// Author: Irfan Sharif (irfansharif@cockroachlabs.com)
 
 package sqlbase
 
@@ -122,4 +123,25 @@ func RandEncDatum(rng *rand.Rand) EncDatum {
 	var ed EncDatum
 	ed.SetDatum(typ, datum)
 	return ed
+}
+
+// RandEncDatumSlice generates a slice of random EncDatum values of the same random
+// type.
+func RandEncDatumSlice(rng *rand.Rand, numVals int) []EncDatum {
+	typ := RandColumnType(rng)
+	vals := make([]EncDatum, numVals)
+	for i := range vals {
+		vals[i].SetDatum(typ, RandDatum(rng, typ, true))
+	}
+	return vals
+}
+
+// RandEncDatumSlices generates EncDatum slices, each slice with values of the same
+// random type.
+func RandEncDatumSlices(rng *rand.Rand, numSets, numValsPerSet int) [][]EncDatum {
+	vals := make([][]EncDatum, numSets)
+	for i := range vals {
+		vals[i] = RandEncDatumSlice(rng, numValsPerSet)
+	}
+	return vals
 }


### PR DESCRIPTION
Implementation of MIRROR router, distributes rows to multiple streams so
all rows end up in all streams.

Part of #7588

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9039)

<!-- Reviewable:end -->
