### PR TITLE
kv: avoid NPE caused by log line

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -683,18 +683,26 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 		var numAttempts int
 		for r := retry.StartWithCtx(ctx, ds.rpcRetryOptions); r.Next(); {
 			numAttempts++
-			const magicLogCurAttempt = 20
-			if (numAttempts%magicLogCurAttempt == 0) || (ba.Txn != nil && (ba.Txn.Sequence%magicLogCurAttempt == 0)) {
-				// Log a message if a request appears to get stuck for a long
-				// time or, potentially, forever. See #8975.
-				// The local counter captures this loop here; the Sequence number
-				// should capture anything higher up (as it needs to be
-				// incremented every time this method is called).
-				log.Warningf(
-					ctx,
-					"%d retries for an RPC at sequence %d, last error was: %s, remaining key ranges %s: %s",
-					numAttempts, ba.Txn.Sequence, pErr, rs, ba,
-				)
+			{
+				const magicLogCurAttempt = 20
+
+				var seq int32
+				if ba.Txn != nil {
+					seq = ba.Txn.Sequence
+				}
+
+				if numAttempts%magicLogCurAttempt == 0 || seq%magicLogCurAttempt == 0 {
+					// Log a message if a request appears to get stuck for a long
+					// time or, potentially, forever. See #8975.
+					// The local counter captures this loop here; the Sequence number
+					// should capture anything higher up (as it needs to be
+					// incremented every time this method is called).
+					log.Warningf(
+						ctx,
+						"%d retries for an RPC at sequence %d, last error was: %s, remaining key ranges %s: %s",
+						numAttempts, seq, pErr, rs, ba,
+					)
+				}
 			}
 			// Get range descriptor (or, when spanning range, descriptors). Our
 			// error handling below may clear them on certain errors, so we


### PR DESCRIPTION
spurious access to `ba.Txn.Sequence` when `ba.Txn` could be nil.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9040)

<!-- Reviewable:end -->
