### PR TITLE
storage: format uninitialized replicas more tersely

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -190,6 +190,9 @@ func (d *atomicRangeDesc) load() *roachpb.RangeDescriptor {
 // using a lock, the copy might be inconsistent.
 func (d *atomicRangeDesc) String() string {
 	inconsistentDesc := d.load()
+	if !inconsistentDesc.IsInitialized() {
+		return fmt.Sprintf("%d{-}", inconsistentDesc.RangeID)
+	}
 	return fmt.Sprintf("%d{%s-%s}",
 		inconsistentDesc.RangeID, inconsistentDesc.StartKey, inconsistentDesc.EndKey)
 }
@@ -490,7 +493,7 @@ func (r *Replica) newReplicaInner(
 // require a lock and its output may not be atomic with other ongoing work in
 // the replica. This is done to prevent deadlocks in logging sites.
 func (r *Replica) String() string {
-	return fmt.Sprintf("%s %s", r.store, &r.rangeDesc)
+	return fmt.Sprintf("[n%d,s%d,r%s]", r.store.Ident.NodeID, r.store.Ident.StoreID, &r.rangeDesc)
 }
 
 // Destroy clears pending command queue by sending each pending

--- a/storage/store.go
+++ b/storage/store.go
@@ -668,7 +668,7 @@ func NewStore(ctx StoreContext, eng engine.Engine, nodeDesc *roachpb.NodeDescrip
 
 // String formats a store for debug output.
 func (s *Store) String() string {
-	return fmt.Sprintf("store=%d:%d", s.Ident.NodeID, s.Ident.StoreID)
+	return fmt.Sprintf("[n%d,s%d]", s.Ident.NodeID, s.Ident.StoreID)
 }
 
 // Ctx returns the base context for the store.


### PR DESCRIPTION
This changes the range reported for an uninitialized Replica from
`{/Min-/Min}` to `{-}` which is more visually obvious in logs.

Make Store.String() and Replica.String() match the format of the log
tags used on Store.Ctx() and Replica.ctx. This is useful in the short
term to make our logs more consistent while we're still propagating the
contexts everywhere.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9061)

<!-- Reviewable:end -->
