### PR TITLE
storage: always mark removed replicas as destroyed

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -495,15 +495,15 @@ func (r *Replica) String() string {
 
 // Destroy clears pending command queue by sending each pending
 // command an error and cleans up all data associated with this range.
-func (r *Replica) Destroy(origDesc roachpb.RangeDescriptor) error {
+func (r *Replica) Destroy(origDesc roachpb.RangeDescriptor, destroyData bool) error {
 	desc := r.Desc()
 	if repDesc, ok := desc.GetReplicaDescriptor(r.store.StoreID()); ok && repDesc.ReplicaID >= origDesc.NextReplicaID {
 		return errors.Errorf("cannot destroy replica %s; replica ID has changed (%s >= %s)",
 			r, repDesc.ReplicaID, origDesc.NextReplicaID)
 	}
 
-	// Clear the pending command queue.
 	r.mu.Lock()
+	// Clear the pending command queue.
 	for _, p := range r.mu.pendingCmds {
 		p.done <- roachpb.ResponseWithError{
 			Reply: &roachpb.BatchResponse{},
@@ -517,6 +517,9 @@ func (r *Replica) Destroy(origDesc roachpb.RangeDescriptor) error {
 		r.mu.replicaID, r.RangeID)
 	r.mu.Unlock()
 
+	if !destroyData {
+		return nil
+	}
 	return r.store.destroyReplicaData(desc)
 }
 

--- a/storage/replica_data_iter_test.go
+++ b/storage/replica_data_iter_test.go
@@ -205,7 +205,7 @@ func TestReplicaDataIterator(t *testing.T) {
 	}
 
 	// Destroy range and verify that its data has been completely cleared.
-	if err := tc.rng.Destroy(*tc.rng.Desc()); err != nil {
+	if err := tc.rng.Destroy(*tc.rng.Desc(), true); err != nil {
 		t.Fatal(err)
 	}
 	iter = NewReplicaDataIterator(tc.rng.Desc(), tc.rng.store.Engine(), false /* !replicatedOnly */)

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -5082,12 +5082,12 @@ func TestReplicaDestroy(t *testing.T) {
 	if err := rep.setDesc(newDesc); err != nil {
 		t.Fatal(err)
 	}
-	if err := rep.Destroy(*origDesc); !testutils.IsError(err, "replica ID has changed") {
+	if err := rep.Destroy(*origDesc, true); !testutils.IsError(err, "replica ID has changed") {
 		t.Fatalf("expected error 'replica ID has changed' but got %v", err)
 	}
 
 	// Now try a fresh descriptor and succeed.
-	if err := rep.Destroy(*rep.Desc()); err != nil {
+	if err := rep.Destroy(*rep.Desc(), true); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Always call Replica.Destroy() on removed replicas ensuring
Replica.mu.destroyed is set.

Extracted from #8941.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9062)

<!-- Reviewable:end -->
