### PR TITLE
storage: define streaming snapshots in terms of shared code

### DIFF
--- a/acceptance/event_log_test.go
+++ b/acceptance/event_log_test.go
@@ -86,12 +86,12 @@ func testEventLogInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig) 
 			}
 
 			// Verify cluster ID is recorded, and is the same for all nodes.
-			if uuid.Equal(info.ClusterID, *uuid.EmptyUUID) {
+			if (info.ClusterID == uuid.UUID{}) {
 				t.Fatalf("Node join recorded nil cluster id, info: %v", info)
 			}
-			if uuid.Equal(clusterID, *uuid.EmptyUUID) {
+			if (clusterID == uuid.UUID{}) {
 				clusterID = info.ClusterID
-			} else if !uuid.Equal(clusterID, info.ClusterID) {
+			} else if clusterID != info.ClusterID {
 				t.Fatalf(
 					"Node join recorded different cluster ID than earlier node. Expected %s, got %s. Info: %v",
 					clusterID, info.ClusterID, info)
@@ -156,7 +156,7 @@ func testEventLogInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig) 
 			}
 
 			// Verify cluster ID is recorded, and is the same for all nodes.
-			if !uuid.Equal(confirmedClusterID, info.ClusterID) {
+			if confirmedClusterID != info.ClusterID {
 				t.Fatalf(
 					"Node restart recorded different cluster ID than earlier join. Expected %s, got %s. Info: %v",
 					confirmedClusterID, info.ClusterID, info)

--- a/internal/client/txn.go
+++ b/internal/client/txn.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/tracing"
-	"github.com/cockroachdb/cockroach/util/uuid"
 )
 
 // txnSender implements the Sender interface and is used to keep the Send
@@ -578,13 +577,8 @@ func (txn *Txn) Exec(
 		} else {
 			// Make sure the txn record that err carries is for this txn.
 			// If it's not, we terminate the "retryable" character of the error.
-			if txn.Proto.ID != nil {
-				if retErr.TxnID == nil {
-					return errors.New(retErr.Error())
-				}
-				if !uuid.Equal(*retErr.TxnID, *txn.Proto.ID) {
-					return errors.New(retErr.Error())
-				}
+			if txn.Proto.ID != nil && (retErr.TxnID == nil || *retErr.TxnID != *txn.Proto.ID) {
+				return errors.New(retErr.Error())
 			}
 
 			if !retErr.Backoff {

--- a/server/admin.go
+++ b/server/admin.go
@@ -769,7 +769,7 @@ func (s *adminServer) GetUIData(ctx context.Context, req *serverpb.GetUIDataRequ
 // Cluster returns cluster metadata.
 func (s *adminServer) Cluster(_ context.Context, req *serverpb.ClusterRequest) (*serverpb.ClusterResponse, error) {
 	clusterID := s.server.node.ClusterID
-	if uuid.Equal(clusterID, *uuid.EmptyUUID) {
+	if clusterID == *uuid.EmptyUUID {
 		return nil, grpc.Errorf(codes.Unavailable, "cluster ID not yet available")
 	}
 	return &serverpb.ClusterResponse{ClusterID: clusterID.String()}, nil

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1647,7 +1647,7 @@ func (r *Replica) isRaftLeaderLocked() bool {
 
 // handleRaftReady processes the Ready() messages on the replica if there are any. It takes a
 // non-nil IncomingSnapshot pointer to indicate that it is about to process a snapshot.
-func (r *Replica) handleRaftReady(inSnap *IncomingSnapshot) error {
+func (r *Replica) handleRaftReady(inSnap IncomingSnapshot) error {
 	ctx := r.ctx
 	var hasReady bool
 	var rd raft.Ready
@@ -1697,11 +1697,11 @@ func (r *Replica) handleRaftReady(inSnap *IncomingSnapshot) error {
 		if err != nil {
 			return errors.Wrap(err, "invalid snapshot id")
 		}
-		if inSnap == nil || *snapUUID != inSnap.SnapUUID {
+		if *snapUUID != inSnap.SnapUUID {
 			log.Fatalf(ctx, "programming error: a snapshot application was attempted outside of the streaming snapshot codepath")
 		}
 
-		if err := r.applySnapshot(ctx, *inSnap, rd.Snapshot, rd.HardState); err != nil {
+		if err := r.applySnapshot(ctx, inSnap, rd.Snapshot, rd.HardState); err != nil {
 			return err
 		}
 

--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -426,6 +426,10 @@ type IncomingSnapshot struct {
 	Batches [][]byte
 	// The Raft log entries for this snapshot.
 	LogEntries [][]byte
+
+	// If true, indicates that a placeholder for this snapshot needs to be
+	// removed once it is applied.
+	addedPlaceholder bool
 }
 
 // Close this OutgoingSnapshot, freeing associated resources.

--- a/util/uuid/uuid.go
+++ b/util/uuid/uuid.go
@@ -114,8 +114,3 @@ func FromString(input string) (*UUID, error) {
 	u, err := uuid.FromString(input)
 	return &UUID{u}, err
 }
-
-// Equal delegates to "github.com/satori/go.uuid".Equal.
-func Equal(u1, u2 UUID) bool {
-	return uuid.Equal(u1.UUID, u2.UUID)
-}


### PR DESCRIPTION
Reduces duplication between normal raft processing and streaming
snapshot application.

With @jordanlewis.

My hope is that this will reduce the pain of merging #8956 and #8941.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9065)

<!-- Reviewable:end -->
