### PR TITLE
cli: Print more info to stdout when starting a node

### DIFF
--- a/cli/start.go
+++ b/cli/start.go
@@ -394,9 +394,19 @@ func runStart(_ *cobra.Command, args []string) error {
 	for i, spec := range serverCtx.Stores.Specs {
 		fmt.Fprintf(tw, "store[%d]:\t%s\n", i, spec)
 	}
-	for i, address := range serverCtx.JoinList {
-		fmt.Fprintf(tw, "join[%d]:\t%s\n", i, address)
+	initialBoot := s.InitialBoot()
+	nodeID := s.NodeID()
+	if initialBoot {
+		if nodeID == server.FirstNodeID {
+			fmt.Fprintf(tw, "status:\tinitialized new cluster\n")
+		} else {
+			fmt.Fprintf(tw, "status:\tinitialized new node, joined pre-existing cluster\n")
+		}
+	} else {
+		fmt.Fprintf(tw, "status:\trestarted pre-existing node\n")
 	}
+	fmt.Fprintf(tw, "clusterID:\t%s\n", s.ClusterID())
+	fmt.Fprintf(tw, "nodeID:\t%d\n", nodeID)
 	if err := tw.Flush(); err != nil {
 		return err
 	}

--- a/server/node.go
+++ b/server/node.go
@@ -63,6 +63,9 @@ const (
 	// publishStatusInterval is the interval for publishing periodic statistics
 	// from stores to the internal event feed.
 	publishStatusInterval = 10 * time.Second
+
+	// FirstNodeID is the node ID of the first node in a new cluster.
+	FirstNodeID = 1
 )
 
 // Metric names.
@@ -199,13 +202,13 @@ func bootstrapCluster(engines []engine.Engine, txnMetrics kv.TxnMetrics) (uuid.U
 	for i, eng := range engines {
 		sIdent := roachpb.StoreIdent{
 			ClusterID: clusterID,
-			NodeID:    1,
+			NodeID:    FirstNodeID,
 			StoreID:   roachpb.StoreID(i + 1),
 		}
 
 		// The bootstrapping store will not connect to other nodes so its
 		// StoreConfig doesn't really matter.
-		s := storage.NewStore(ctx, eng, &roachpb.NodeDescriptor{NodeID: 1})
+		s := storage.NewStore(ctx, eng, &roachpb.NodeDescriptor{NodeID: FirstNodeID})
 
 		// Verify the store isn't already part of a cluster.
 		if s.Ident.ClusterID != *uuid.EmptyUUID {

--- a/server/server.go
+++ b/server/server.go
@@ -60,6 +60,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/sdnotify"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/tracing"
+	"github.com/cockroachdb/cockroach/util/uuid"
 )
 
 var (
@@ -296,6 +297,22 @@ func NewServer(srvCtx Context, stopper *stop.Stopper) (*Server, error) {
 // Ctx returns the base context for the server.
 func (s *Server) Ctx() context.Context {
 	return s.ctx.Ctx
+}
+
+// ClusterID returns the ID of the cluster this server is a part of.
+func (s *Server) ClusterID() uuid.UUID {
+	return s.node.ClusterID
+}
+
+// NodeID returns the ID of this node within its cluster.
+func (s *Server) NodeID() roachpb.NodeID {
+	return s.node.Descriptor.NodeID
+}
+
+// InitialBoot returns whether this is the first time the node has booted.
+// Only intended to help print debugging info during server startup.
+func (s *Server) InitialBoot() bool {
+	return s.node.initialBoot
 }
 
 // grpcGatewayServer represents a grpc service with HTTP endpoints through GRPC


### PR DESCRIPTION
As mentioned in https://github.com/cockroachdb/cockroach/issues/8650#issuecomment-244426880, I could use a little more explanation around the intended behavior when trying to join a cluster when a local store already exists, but otherwise this provides a little useful more info to stdout when starting a node.

Closes #8650

@mberhault @sploiselle

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9066)

<!-- Reviewable:end -->
