### PR TITLE
kv: fix a warning log in dist_sender

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -691,7 +691,8 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 					seq = ba.Txn.Sequence
 				}
 
-				if numAttempts%magicLogCurAttempt == 0 || seq%magicLogCurAttempt == 0 {
+				// seq + 1 so that we don't log on the first attempt.
+				if numAttempts%magicLogCurAttempt == 0 || (seq+1)%magicLogCurAttempt == 0 {
 					// Log a message if a request appears to get stuck for a long
 					// time or, potentially, forever. See #8975.
 					// The local counter captures this loop here; the Sequence number
@@ -699,7 +700,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 					// incremented every time this method is called).
 					log.Warningf(
 						ctx,
-						"%d retries for an RPC at sequence %d, last error was: %s, remaining key ranges %s: %s",
+						"%d retries for an RPC at sequence %d, last error was: %s, remaining key ranges %q: %s",
 						numAttempts, seq, pErr, rs, ba,
 					)
 				}


### PR DESCRIPTION
A new warning was added that was meant to print only after the first
attempt. It was mistakenly being printed on the first attempt.

Additionally, it was printing a key with %s which lead to non-unicode
characters in the test log. Now it prints with %q.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9067)

<!-- Reviewable:end -->
