### PR TITLE
cli: Make clear in startup logs if any env vars were used

### DIFF
--- a/cli/debug.go
+++ b/cli/debug.go
@@ -679,7 +679,7 @@ var debugEnvCmd = &cobra.Command{
 Output environment variables that influence configuration.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		env := envutil.GetEnvReport()
+		env := envutil.GetEnvReport(false)
 		fmt.Print(env)
 	},
 }

--- a/cli/start.go
+++ b/cli/start.go
@@ -360,6 +360,9 @@ func runStart(_ *cobra.Command, args []string) error {
 	}
 
 	log.Info(startCtx, "starting cockroach node")
+	if envVarsUsed := envutil.GetEnvReport(true); envVarsUsed != "" {
+		log.Infof(startCtx, "using local environment variables:\n%s", envVarsUsed)
+	}
 	s, err := server.NewServer(serverCtx, stopper)
 	if err != nil {
 		return fmt.Errorf("failed to start Cockroach server: %s", err)

--- a/util/envutil/env.go
+++ b/util/envutil/env.go
@@ -97,7 +97,7 @@ func ClearEnvCache() {
 
 // GetEnvReport dumps all configuration variables that may have been
 // used and their value.
-func GetEnvReport() string {
+func GetEnvReport(presentOnly bool) string {
 	envVarRegistry.mu.Lock()
 	defer envVarRegistry.mu.Unlock()
 
@@ -105,7 +105,7 @@ func GetEnvReport() string {
 	for k, v := range envVarRegistry.cache {
 		if v.present {
 			fmt.Fprintf(&b, "%s = %s # %s\n", k, v.value, v.consumer)
-		} else {
+		} else if !presentOnly {
 			fmt.Fprintf(&b, "# %s is not set (read from %s)\n", k, v.consumer)
 		}
 	}


### PR DESCRIPTION
Help make situations like #8876 easier to debug

@tschottdorf

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9069)

<!-- Reviewable:end -->
