### PR TITLE
Makefile: better support for multiple checkouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,8 +194,11 @@ include .go-version
 
 ifneq ($(SKIP_BOOTSTRAP),1)
 
-GITHOOKS := $(subst githooks/,.git/hooks/,$(wildcard githooks/*))
-.git/hooks/%: githooks/%
+# If we're in a git worktree, the git hooks directory may not be in our root,
+# so we ask git for the location.
+GITHOOKSDIR := $(shell git rev-parse --git-path hooks)
+GITHOOKS := $(subst githooks/,$(GITHOOKSDIR)/,$(wildcard githooks/*))
+$(GITHOOKSDIR)/%: githooks/%
 	@echo installing $<
 	@rm -f $@
 	@mkdir -p $(dir $@)


### PR DESCRIPTION
Use `$(git rev-parse --git-path)` instead of hardcoding `.git`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9072)

<!-- Reviewable:end -->
