### PR TITLE
storage: handle concurrent outgoing snapshots per Replica

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -1525,12 +1525,15 @@ func TestRangeDescriptorSnapshotRace(t *testing.T) {
 					t.Fatal("failed to look up min range")
 				} else if _, err := rng.GetSnapshot(context.Background()); err != nil {
 					t.Fatalf("failed to snapshot min range: %s", err)
+				} else {
+					rng.CloseOutSnap()
 				}
-
 				if rng := mtc.stores[0].LookupReplica(roachpb.RKey("Z"), nil); rng == nil {
 					t.Fatal("failed to look up max range")
 				} else if _, err := rng.GetSnapshot(context.Background()); err != nil {
 					t.Fatalf("failed to snapshot max range: %s", err)
+				} else {
+					rng.CloseOutSnap()
 				}
 			}
 		}

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -619,6 +619,64 @@ func TestSnapshotAfterTruncation(t *testing.T) {
 	mtc.waitForValues(key, []int64{incAB, incAB, incAB})
 }
 
+// TestConcurrentRaftSnapshots tests that snapshots still work correctly when
+// Raft requests multiple non-preemptive snapshots at the same time. This
+// situation occurs when two replicas need snapshots at the same time.
+func TestConcurrentRaftSnapshots(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	mtc := startMultiTestContext(t, 5)
+	defer mtc.Stop()
+	rng, err := mtc.stores[0].GetReplica(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key := roachpb.Key("a")
+	incA := int64(5)
+	incB := int64(7)
+	incAB := incA + incB
+
+	// Set up a key to replicate across the cluster. We're going to modify this
+	// key and truncate the raft logs from that command after killing one of the
+	// nodes to check that it gets the new value after it comes up.
+	incArgs := incrementArgs(key, incA)
+	if _, err := client.SendWrapped(rg1(mtc.stores[0]), nil, &incArgs); err != nil {
+		t.Fatal(err)
+	}
+
+	mtc.replicateRange(1, 1, 2, 3, 4)
+	mtc.waitForValues(key, []int64{incA, incA, incA, incA, incA})
+
+	// Now kill store 1, increment the key on the other stores and truncate
+	// their logs to make sure that when store 1 comes back up it will require a
+	// non-preemptive snapshot from Raft.
+	mtc.stopStore(1)
+	mtc.stopStore(2)
+
+	incArgs = incrementArgs(key, incB)
+	if _, err := client.SendWrapped(rg1(mtc.stores[0]), nil, &incArgs); err != nil {
+		t.Fatal(err)
+	}
+
+	mtc.waitForValues(key, []int64{incAB, incA, incA, incAB, incAB})
+
+	index, err := rng.GetLastIndex()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Truncate the log at index+1 (log entries < N are removed, so this
+	// includes the increment).
+	truncArgs := truncateLogArgs(index+1, 1)
+	if _, err := client.SendWrapped(rg1(mtc.stores[0]), nil, &truncArgs); err != nil {
+		t.Fatal(err)
+	}
+	mtc.restartStore(1)
+	mtc.restartStore(2)
+
+	mtc.waitForValues(key, []int64{incAB, incAB, incAB, incAB, incAB})
+}
+
 // Test various mechanism for refreshing pending commands.
 func TestRefreshPendingCommands(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/storage/raft_transport.go
+++ b/storage/raft_transport.go
@@ -562,7 +562,7 @@ func (t *RaftTransport) SendAsync(req *RaftMessageRequest) bool {
 func (t *RaftTransport) SendSnapshot(
 	ctx context.Context,
 	header SnapshotRequest_Header,
-	snap OutgoingSnapshot,
+	snap *OutgoingSnapshot,
 	newBatch func() engine.Batch,
 ) error {
 	nodeID := header.RaftMessageRequest.ToReplica.NodeID

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -2983,7 +2983,7 @@ func (r *Replica) ChangeReplicas(
 		// negate the benefits of pre-emptive snapshots, but that is a recoverable
 		// degradation, not a catastrophic failure.
 		snap, err := r.GetSnapshot(ctx)
-		defer snap.Close()
+		defer r.CloseOutSnap()
 		log.Trace(ctx, "generated snapshot")
 		if err != nil {
 			return errors.Wrapf(err, "change replicas of range %d failed", rangeID)

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -5729,78 +5729,10 @@ func TestDiffRange(t *testing.T) {
 	}
 }
 
-func TestAsyncSnapshot(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	tsc := TestStoreContext()
-	tsc.BlockingSnapshotDuration = 0
-	tc := testContext{}
-	tc.StartWithStoreContext(t, tsc)
-	defer tc.Stop()
-
-	// Lock the replica manually instead of going through GetSnapshot()
-	// because we want to test the underlying async functionality.
-	tc.rng.mu.Lock()
-	_, err := tc.rng.Snapshot()
-	tc.rng.mu.Unlock()
-
-	// In async operation, the first call never succeeds.
-	if err != raft.ErrSnapshotTemporarilyUnavailable {
-		t.Fatalf("expected ErrSnapshotTemporarilyUnavailable, got %s", err)
-	}
-
-	// It will eventually succeed.
-	util.SucceedsSoon(t, func() error {
-		tc.rng.mu.Lock()
-		snap, err := tc.rng.Snapshot()
-		tc.rng.mu.Unlock()
-		if err != nil {
-			return err
-		}
-		if len(snap.Data) == 0 {
-			return errors.Errorf("snapshot is empty")
-		}
-		return nil
-	})
-}
-
-func TestAsyncSnapshotMaxAge(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	tsc := TestStoreContext()
-	tsc.BlockingSnapshotDuration = 0
-	tsc.AsyncSnapshotMaxAge = time.Millisecond
-	tc := testContext{}
-	tc.StartWithStoreContext(t, tsc)
-	defer tc.Stop()
-
-	// Lock the replica manually instead of going through GetSnapshot()
-	// because we want to test the underlying async functionality.
-	tc.rng.mu.Lock()
-	_, err := tc.rng.Snapshot()
-	tc.rng.mu.Unlock()
-
-	// In async operation, the first call never succeeds.
-	if err != raft.ErrSnapshotTemporarilyUnavailable {
-		t.Fatalf("expected ErrSnapshotTemporarilyUnavailable, got %s", err)
-	}
-
-	// Wait for the snapshot to be generated and abandoned.
-	time.Sleep(100 * time.Millisecond)
-	tc.rng.mu.Lock()
-	defer tc.rng.mu.Unlock()
-	// The channel was closed without producing a result.
-	snap, ok := <-tc.rng.mu.snapshotChan
-	if ok {
-		t.Fatalf("expected channel to be closed but got result: %v", snap)
-	}
-}
-
 func TestSyncSnapshot(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	tsc := TestStoreContext()
-	tsc.BlockingSnapshotDuration = time.Second
 	tc := testContext{}
 	tc.StartWithStoreContext(t, tsc)
 	defer tc.Stop()
@@ -6419,7 +6351,7 @@ func TestReserveAndApplySnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer snap.Close()
+	defer firstRng.CloseOutSnap()
 
 	tc.store.metrics.Available.Update(tc.store.bookie.maxReservedBytes)
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -100,7 +100,6 @@ func TestStoreContext() StoreContext {
 		ScanInterval:                   10 * time.Minute,
 		ConsistencyCheckInterval:       10 * time.Minute,
 		ConsistencyCheckPanicOnFailure: true,
-		BlockingSnapshotDuration:       100 * time.Millisecond,
 	}
 }
 
@@ -480,13 +479,6 @@ type StoreContext struct {
 	// If LogRangeEvents is true, major changes to ranges will be logged into
 	// the range event log.
 	LogRangeEvents bool
-
-	// BlockingSnapshotDuration is the amount of time Replica.Snapshot
-	// will wait before switching to asynchronous mode. Zero is a good
-	// choice for production but non-zero values can speed up tests.
-	// (This only blocks on the first attempt; it will not block a
-	// second time if the generation is still in progress).
-	BlockingSnapshotDuration time.Duration
 
 	// AsyncSnapshotMaxAge is the maximum amount of time that an
 	// asynchronous snapshot will be held while waiting for raft to pick
@@ -2534,7 +2526,7 @@ func (s *Store) HandleRaftResponse(ctx context.Context, resp *RaftMessageRespons
 func sendSnapshot(
 	stream MultiRaft_RaftSnapshotClient,
 	header SnapshotRequest_Header,
-	snap OutgoingSnapshot,
+	snap *OutgoingSnapshot,
 	newBatch func() engine.Batch,
 ) error {
 


### PR DESCRIPTION
Previously, streaming snapshots was broken in the case of a 5-replica range. If 2 of the 5 replicas came up from being dead at the same time, two raft-initiated snapshots would be requested at the same time for the same range.

This case is now handled. Only one snapshot is processed at once. A previously failing test is added that verifies that this situation doesn't break things.

Additionally, remove `r.mu.snapshotChan` - this asynchronous machinery isn't necessary now that the heavy lifting for snapshots happens during streaming, outside of the actual `SnapshotWithContext` method.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9073)

<!-- Reviewable:end -->
