### PR TITLE
build: Print out the check error(s) when goimports or misspell fails

### DIFF
--- a/build/check-style.sh
+++ b/build/check-style.sh
@@ -45,7 +45,9 @@ TestMissingLeakTest() {
 }
 
 TestMisspell() {
-  ! git ls-files | xargs misspell | read
+  misspellings=$(git ls-files | xargs misspell)
+  echo "${misspellings}"
+  [[ -z "${misspellings}" ]]
 }
 
 TestTabsInShellScripts() {
@@ -129,7 +131,9 @@ TestGofmtSimplify() {
 }
 
 TestGoimports() {
-  ! goimports -l . | read
+  badimports=$(goimports -l .)
+  echo "${badimports}"
+  [[ -z "${badimports}" ]]
 }
 
 TestUnconvert() {


### PR DESCRIPTION
It's perhaps less elegant, but I'd rather have a little less elegance
than have to rerun the individual goimports or misspell command
outside of the script to see why it failed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9079)

<!-- Reviewable:end -->
