### PR TITLE
sql: tag log messages with the remote address.

### DIFF
--- a/sql/session.go
+++ b/sql/session.go
@@ -94,6 +94,7 @@ func NewSession(ctx context.Context, args SessionArgs, e *Executor, remote net.A
 	remoteStr := ""
 	if remote != nil {
 		remoteStr = remote.String()
+		ctx = log.WithLogTag(ctx, "client=", remoteStr)
 	}
 
 	// Set up an EventLog for session events.


### PR DESCRIPTION
This is necessary to identify log messages from different sessions.

Prior to this patch:

```
I160903 11:08:40.991041 179 sql/executor.go:739  [n1] executing 1/1: SELECT * FROM t.f
```

With this patch:

```
I160903 11:10:52.971758 169 sql/executor.go:739  [n1,remote=127.0.0.1:48566] executing 1/1: SELECT * FROM t.f
```

Log messages caused by queries by an internal executor are not
affected (they don't have a remote address).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9085)

<!-- Reviewable:end -->
