### PR TITLE
cli: add interactive tests

### DIFF
--- a/acceptance/cli_test.go
+++ b/acceptance/cli_test.go
@@ -1,0 +1,69 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package acceptance
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+const testGlob = "../cli/interactive_tests/test*.tcl"
+const containerPath = "/go/src/github.com/cockroachdb/cockroach/cli/interactive_tests"
+
+var cmdBase = []string{
+	"/usr/bin/env",
+	"COCKROACH_SKIP_UPDATE_CHECK=1",
+	"PGHOST=localhost",
+	"PGPORT=",
+	"/usr/bin/expect",
+}
+
+func TestDockerCli(t *testing.T) {
+	paths, err := filepath.Glob(testGlob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(paths) == 0 {
+		t.Fatalf("no testfiles found (%v)", testGlob)
+	}
+
+	verbose := testing.Verbose() || log.V(1)
+	for _, p := range paths {
+		testFile := filepath.Base(p)
+		testPath := filepath.Join(containerPath, testFile)
+		if verbose {
+			fmt.Printf("--- test: %s\n", testFile)
+		}
+
+		cmd := cmdBase
+		if verbose {
+			cmd = append(cmd, "-d")
+		}
+		cmd = append(cmd, "-f", testPath, "/cockroach")
+
+		if err := testDocker(t, 0, "cli_test", cmd); err != nil {
+			fmt.Printf("--- %s FAIL\n", testFile)
+			t.Fatal(err)
+		}
+		if verbose {
+			fmt.Printf("--- %s SUCCESS\n", testFile)
+		}
+	}
+}

--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -398,7 +398,7 @@ func testDockerSuccess(t *testing.T, name string, cmd []string) {
 
 const (
 	// NB: postgresTestTag is grepped for in circle-deps.sh, so don't rename it.
-	postgresTestTag = "20160906-1541"
+	postgresTestTag = "20160913-0941"
 	// Iterating against a locally built version of the docker image can be done
 	// by changing postgresTestImage to the hash of the container.
 	postgresTestImage = "cockroachdb/postgres-test:" + postgresTestTag

--- a/cli/interactive_tests/common.tcl
+++ b/cli/interactive_tests/common.tcl
@@ -1,0 +1,38 @@
+# We are sending vt100 terminal sequences below, so inform readline
+# accordingly.
+set env(TERM) vt100
+
+# Keep the history in a test location, so as to not override the
+# developer's own history file.
+set histfile ".cockroachdb_history_test"
+set ::env(COCKROACH_SQL_CLI_HISTORY) $histfile
+system "rm -f $histfile"
+
+# Everything in this test should be fast. Don't be tolerant for long
+# waits.
+set timeout 1
+
+# When run via Docker the enclosing terminal has 0 columns and 0 rows,
+# and this confuses readline. Ensure sane defaults here.
+set stty_init "cols 80 rows 25"
+
+# Convenience wrapper function, which ensures that all expects are
+# mandatory (i.e. with a mandatory fail if the expected output doesn't
+# show up fast).
+proc eexpect {text} {
+    expect {
+	$text {}
+	timeout {exit 1}
+    }
+}
+
+# Convenience functions to start/shutdown the server.
+# Preserves the invariant that the server's PID is saved
+# in `server_pid`.
+proc start_server {argv} {
+    system "$argv start & echo \$! >server_pid"
+    sleep 1
+}
+proc stop_server {argv} {
+    system "set -e; if kill -CONT `cat server_pid`; then $argv quit  || true & sleep 1; kill -9 `cat server_pid` || true; else $argv quit || true; fi"
+}

--- a/cli/interactive_tests/test_example_data.tcl
+++ b/cli/interactive_tests/test_example_data.tcl
@@ -1,0 +1,42 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_server $argv
+
+set timeout 5
+
+spawn /bin/bash
+send "PS1=':''/# '\r"
+eexpect ":/# "
+
+# Check that the startrek example can be loaded in the db.
+send "$argv gen example-data startrek | $argv sql\r"
+eexpect ":/# "
+send "echo \$?\r"
+eexpect "0\r\n:/# "
+
+# Check that the startrek example is loaded.
+send "$argv sql -e 'SELECT COUNT(*) FROM startrek.quotes'\r"
+eexpect "COUNT"
+eexpect "200"
+eexpect "1 row"
+eexpect ":/# "
+
+# Check that the intro example can be loaded in the db.
+send "$argv gen example-data intro | $argv sql\r"
+eexpect ":/# "
+send "echo \$?\r"
+eexpect "0\r\n:/# "
+
+# Check that the startrek example is loaded.
+send "$argv sql -e 'SELECT COUNT(*) FROM intro.mytable'\r"
+eexpect "COUNT"
+eexpect "42"
+eexpect "1 row"
+eexpect ":/# "
+
+send "exit 0\r"
+eexpect eof
+
+stop_server $argv

--- a/cli/interactive_tests/test_history.tcl
+++ b/cli/interactive_tests/test_history.tcl
@@ -1,0 +1,61 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_server $argv
+
+spawn $argv sql
+eexpect root@
+
+# Ensure the connection is up and working.
+send "select 1;\r"
+eexpect "1 row"
+eexpect root@
+
+# Test that last line can be recalled with arrow-up
+send "\033\[A"
+eexpect "select 1;"
+
+# Test that recalled last line can be executed
+send "\r"
+eexpect "1 row"
+eexpect root@
+
+# Test that we can recall a previous line with Ctrl+R
+send "foo;\r"
+eexpect "syntax error"
+eexpect root@
+send "\022sel"
+eexpect "select 1;"
+
+# Test that recalled previous line can be executed
+send "\r"
+eexpect "1 row"
+eexpect root@
+
+# Test that last recalled line becomes top of history
+send "\033\[A"
+eexpect "select 1;"
+
+# Test that client cannot terminate with Ctrl+D while cursor
+# is on recalled line
+send "\004"
+send "\r"
+eexpect "1 row"
+eexpect root@
+
+# Test that Ctrl+D does terminate client on empty line
+send "\004"
+eexpect eof
+
+# Test that history is preserved across runs
+spawn ./cockroach sql
+eexpect root@
+send "\033\[A"
+eexpect "select 1;"
+
+# Finally terminate with Ctrl+C
+send "\003"
+eexpect eof
+
+stop_server $argv

--- a/cli/interactive_tests/test_last_statement.tcl
+++ b/cli/interactive_tests/test_last_statement.tcl
@@ -1,0 +1,71 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_server $argv
+
+spawn /bin/bash
+send "PS1=':''/# '\r"
+eexpect ":/# "
+
+send "$argv sql\r"
+eexpect root@
+
+# Check that an error in the last statement is propagated to the shell.
+send "select ++;\r"
+eexpect "syntax error"
+eexpect root@
+send "\\q\r"
+eexpect ":/# "
+send "echo hello \$?\r"
+eexpect "hello 1"
+eexpect ":/# "
+
+# Check that an incomplete last statement in interactive mode is not
+# executed.
+send "$argv sql\r"
+eexpect root@
+send "drop database if exists t; create database t; create table t.foo(x int);\r"
+eexpect "CREATE TABLE"
+eexpect root@
+send "insert into t.foo(x) values (42)\r"
+eexpect " ->"
+send "\004"
+eexpect ":/# "
+
+send "$argv sql\r"
+eexpect root@
+send "select * from t.foo;\r"
+eexpect "0 rows"
+eexpect root@
+send "\\q\r"
+eexpect ":/# "
+
+# Check that an incomplete last statement in non-interactive mode
+# is not executed, and fails with a warning. #8838
+send "echo 'insert into t.foo(x) values (42)' | $argv sql\r"
+eexpect "missing semicolon at end of statement"
+eexpect ":/# "
+
+send "echo 'select * from t.foo;' | $argv sql\r"
+eexpect "0 rows"
+eexpect ":/# "
+
+# Check that a complete last statement terminated with a semicolon
+# just before EOF and without a newline is properly executed. #7328
+send "printf 'insert into t.foo(x) values(42);' | $argv sql\r"
+eexpect "INSERT"
+eexpect ":/# "
+send "echo 'select * from t.foo;' | $argv sql\r"
+eexpect "1 row"
+eexpect ":/# "
+
+# Check that a final comment does not cause an error message. #9243
+send "printf 'select 1;\\n-- final comment' | $argv sql\r"
+eexpect "1 row\r\n1\r\n1\r\n:/# "
+
+# Finally terminate with Ctrl+C
+send "exit\r"
+eexpect eof
+
+stop_server $argv

--- a/cli/interactive_tests/test_local_cmds.tcl
+++ b/cli/interactive_tests/test_local_cmds.tcl
@@ -1,0 +1,70 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_server $argv
+
+spawn $argv sql
+eexpect root@
+
+# Check that \? prints the help text.
+send "\\?\r"
+eexpect "You are using"
+eexpect "More documentation"
+eexpect root@
+
+# Check that \! invokes external commands.
+send "\\! echo -n he; echo llo\r"
+eexpect "hello"
+eexpect "root@"
+
+# Check that \q terminates the client.
+send "\\q\r"
+eexpect eof
+spawn $argv sql
+eexpect root@
+
+# Check that \| reads statements.
+send "\\| echo 'select '; echo '38 + 4;'\r"
+eexpect 42
+eexpect "1 row"
+eexpect root@
+
+# Check that \| does not execute upon encountering an error.
+send "\\| echo 'create database dontcreate;'; exit 1\r"
+eexpect "error in external command"
+eexpect root@
+send "drop database dontcreate;\r"
+eexpect "database * does not exist"
+eexpect root@
+
+# Check that a buit-in command in between tokens of a statement is
+# passed-through.
+send "select\r"
+eexpect " ->"
+
+send "\\h\r"
+eexpect " ->"
+
+send "1;\r"
+eexpect "pq: syntax error*\\h"
+eexpect root@
+
+# Check that a built-in command in the middle of a token (eg a string)
+# is passed-through.
+send "select 'hello\r"
+eexpect " ->"
+send "\\h\r"
+eexpect " ->"
+send "world';\r"
+eexpect "hello"
+eexpect "\\h"
+eexpect "world"
+eexpect "1 row"
+eexpect root@
+
+# Finally terminate with Ctrl+C.
+send "\003"
+eexpect eof
+
+stop_server $argv

--- a/cli/interactive_tests/test_pretty.tcl
+++ b/cli/interactive_tests/test_pretty.tcl
@@ -1,0 +1,47 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_server $argv
+
+spawn /bin/bash
+send "PS1='\\h:''/# '\r"
+eexpect ":/# "
+
+# Check table ASCII art with and without --pretty. (#7268)
+
+# Check that tables are pretty-printed when input is not a terminal
+# but --pretty is specified.
+send "echo 'select 1;' | $argv sql --pretty\r"
+eexpect "+-*+\r\n*\r\n+-*+\r\n*1 row"
+eexpect ":/# "
+
+# Check that tables are not pretty-printed when input is not a terminal
+# and --pretty is not speciifed.
+send "echo begin; echo 'select 1;' | $argv sql\r"
+eexpect "begin\r\n1 row\r\n1\r\n1\r\n"
+
+# Check that tables are pretty-printed when input is a terminal
+# and --pretty is not specified.
+send "$argv sql\r"
+eexpect root@
+send "select 1;\r"
+eexpect "+-*+\r\n*\r\n+-*+\r\n*1 row"
+send "\\q\r"
+eexpect ":/# "
+
+# Check that tables are not pretty-printed when input is a terminal
+# and --pretty=false is specified.
+send "$argv sql --pretty=false\r"
+eexpect root@
+send "select 42; select 1;\r"
+eexpect "42\r\n1 row\r\n1\r\n1\r\n"
+eexpect root@
+send "\\q\r"
+
+eexpect ":/# "
+send "exit\r"
+eexpect eof
+
+stop_server $argv
+

--- a/cli/interactive_tests/test_reconnect.tcl
+++ b/cli/interactive_tests/test_reconnect.tcl
@@ -1,0 +1,47 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_server $argv
+
+spawn $argv sql
+eexpect root@
+
+send "select 1;\r"
+eexpect "1 row"
+eexpect root@
+
+# Check that the client properly detects the server went down.
+stop_server $argv
+
+send "select 1;\r"
+eexpect "bad connection"
+eexpect root@
+
+send "select 1;\r"
+eexpect "connection refused"
+eexpect root@
+
+# Check that the client automatically reconnects when the server goes up again.
+start_server $argv
+
+send "select 1;\r"
+eexpect "1 row"
+eexpect root@
+
+# Check that the client picks up when the server was restarted.
+stop_server $argv
+start_server $argv
+
+send "select 1;\r"
+eexpect "bad connection"
+eexpect root@
+
+send "select 1;\r"
+eexpect "1 row"
+eexpect root@
+
+send "\\q\r"
+eexpect eof
+
+stop_server $argv

--- a/cli/interactive_tests/test_server_sig.tcl
+++ b/cli/interactive_tests/test_server_sig.tcl
@@ -1,0 +1,58 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+set timeout 15
+
+spawn /bin/bash
+send "PS1='\\h:''/# '\r"
+eexpect ":/# "
+
+# Check that the server shuts down upon receiving SIGTERM.
+send "$argv start & echo $! >server_pid; fg\r"
+eexpect "initialized"
+
+system "kill `cat server_pid`"
+eexpect "initiating graceful shutdown"
+eexpect "shutdown completed"
+eexpect ":/# "
+
+# SIGTERM finishes with exit code 0. (#9051)
+send "echo \$?\r"
+eexpect "0\r\n"
+eexpect ":/# "
+
+# Check that the server shuts down upon receiving Ctrl+C.
+send "$argv start & echo $! >server_pid; fg\r"
+eexpect "restarted"
+
+send "\003"
+eexpect "initiating graceful shutdown"
+eexpect "shutdown completed"
+eexpect ":/# "
+
+# Ctrl+C finishes with exit code 1. (#9051)
+send "echo \$?\r"
+eexpect "1\r\n"
+eexpect ":/# "
+
+# Check that the server shuts down fast upon receiving Ctrl+C twice.
+set timeout 1
+send "$argv start & echo $! >server_pid; fg\r"
+eexpect "restarted"
+
+send "\003"
+eexpect "initiating graceful shutdown"
+send "\003"
+eexpect "hard shutdown"
+eexpect ":/# "
+
+# Ctrl+C twice finishes with exit code 130. (#9051)
+send "echo \$?\r"
+eexpect "130\r\n"
+eexpect ":/# "
+
+send "exit\r"
+eexpect eof
+
+stop_server $argv

--- a/cli/sql.go
+++ b/cli/sql.go
@@ -240,6 +240,8 @@ func preparePrompts(dbURL string) (fullPrompt string, continuePrompt string) {
 	return fullPrompt, continuePrompt
 }
 
+var cmdHistFile = envutil.EnvOrDefaultString("COCKROACH_SQL_CLI_HISTORY", ".cockroachdb_history")
+
 // runInteractive runs the SQL client interactively, presenting
 // a prompt to the user for each statement.
 func runInteractive(conn *sqlConn, config *readline.Config) (exitErr error) {
@@ -262,7 +264,7 @@ func runInteractive(conn *sqlConn, config *readline.Config) (exitErr error) {
 				log.Info(context.TODO(), "cannot load or save the command-line history")
 			}
 		} else {
-			histFile := filepath.Join(userAcct.HomeDir, ".cockroachdb_history")
+			histFile := filepath.Join(userAcct.HomeDir, cmdHistFile)
 			cfg := ins.Config.Clone()
 			cfg.HistoryFile = histFile
 			ins.SetConfig(cfg)


### PR DESCRIPTION
This is using the venerable but trustworthy program `expect` see https://en.wikipedia.org/wiki/Expect.

This can address all the tests that exercise the experience of the user running commands from a terminal, like for example readline handling in the SQL CLI. We can also use it to check that the server reacts properly to signals, which would provide a proper test for #9051. 

Note that it is not trivial to rewrite an `expect` replacement in Go since such a test program would need to (portably) allocate a pseudo-tty, set up its parameters and manage the processes under test. In comparison writing expect scripts is relatively trivial and very maintainable.

I am taking suggestions (cc @tamird, @bdarnell ) as to how to launch `expect` from our current test infrastructure. Should I create a new Go test that invokes `expect` as an external command and checks its exit code?

Fixes #7334.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9087)

<!-- Reviewable:end -->
