### PR TITLE
storage: load RHS previous hard state from engine on split

### DIFF
--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -2564,17 +2564,34 @@ func (r *Replica) splitTrigger(
 			return enginepb.MVCCStats{}, nil, errors.Wrap(err, "unable to account for enginepb.MVCCStats's own stats impact")
 		}
 
-		// TODO(tschottdorf): Writing the initial state is subtle since this
-		// also seeds the Raft group. We are writing to the right hand side's
-		// Raft group state in this batch. Between committing and telling the
-		// Store, we could race with an uninitialized version of our new
-		// Replica which might have been created by an incoming message from
-		// another node which already processed the split. We rely on
-		// synchronization provided at the Store level to avoid this. See #7860
-		// and for history #7600. Note also that it is crucial that
-		// writeInitialState *absorbs* an existing HardState (which might
-		// contain a cast vote).
-		rightMS, err = writeInitialState(ctx, batch, rightMS, split.RightDesc)
+		// Writing the initial state is subtle since this also seeds the Raft
+		// group. We are writing to the right hand side's Raft group state in this
+		// batch so we need to synchronize with anything else that could be
+		// touching that replica's Raft state. Specifically, we want to prohibit an
+		// uninitialized Replica from receiving a message for the right hand side
+		// range and performing raft processing. This is achieved by serializing
+		// execution of uninitialized Replicas in Store.processRaft and ensuring
+		// that no uninitialized Replica is being processed while an initialized
+		// one (like the one currently being split) is being processed.
+		//
+		// Note also that it is crucial that writeInitialState *absorbs* an
+		// existing HardState (which might contain a cast vote). We load the
+		// existing HardState from the underlying engine instead of the batch
+		// because batch reads are from a snapshot taken at the point in time when
+		// the first read was performed on the batch. This last requirement is not
+		// currently needed due to the uninitialized Replica synchronization
+		// mentioned above, but future work will relax that synchronization, moving
+		// it from before the point that batch was created to this method. We want
+		// to see any writes to the hard state that were performed between the
+		// creation of the batch and that synchronization point. The only drawback
+		// to not reading from the batch is that we won't see any writes to the
+		// right hand side's hard state that were previously made in the batch
+		// (which should be impossible).
+		oldHS, err := loadHardState(ctx, r.store.Engine(), split.RightDesc.RangeID)
+		if err != nil {
+			return enginepb.MVCCStats{}, nil, errors.Wrap(err, "unable to load hard state")
+		}
+		rightMS, err = writeInitialState(ctx, batch, rightMS, split.RightDesc, oldHS)
 		if err != nil {
 			return enginepb.MVCCStats{}, nil, errors.Wrap(err, "unable to write initial state")
 		}

--- a/storage/replica_state.go
+++ b/storage/replica_state.go
@@ -425,7 +425,11 @@ func synthesizeHardState(
 // The supplied MVCCStats are used for the Stats field after adjusting for
 // persisting the state itself, and the updated stats are returned.
 func writeInitialState(
-	ctx context.Context, eng engine.ReadWriter, ms enginepb.MVCCStats, desc roachpb.RangeDescriptor,
+	ctx context.Context,
+	eng engine.ReadWriter,
+	ms enginepb.MVCCStats,
+	desc roachpb.RangeDescriptor,
+	oldHS raftpb.HardState,
 ) (enginepb.MVCCStats, error) {
 	var s storagebase.ReplicaState
 
@@ -440,11 +444,6 @@ func writeInitialState(
 	s.Stats = ms
 
 	newMS, err := saveState(ctx, eng, s)
-	if err != nil {
-		return enginepb.MVCCStats{}, err
-	}
-
-	oldHS, err := loadHardState(ctx, eng, desc.RangeID)
 	if err != nil {
 		return enginepb.MVCCStats{}, err
 	}

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -205,6 +205,7 @@ func (tc *testContext) StartWithStoreContext(t testing.TB, ctx StoreContext) {
 				tc.store.Engine(),
 				enginepb.MVCCStats{},
 				*testDesc,
+				raftpb.HardState{},
 			); err != nil {
 				t.Fatal(err)
 			}

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -654,9 +654,9 @@ func TestReplicaNotLeaseHolderError(t *testing.T) {
 		StoreID:   2,
 		ReplicaID: 2,
 	}
-	rngDesc := tc.rng.Desc()
+	rngDesc := *tc.rng.Desc()
 	rngDesc.Replicas = append(rngDesc.Replicas, secondReplica)
-	tc.rng.setDescWithoutProcessUpdate(rngDesc)
+	tc.rng.setDescWithoutProcessUpdate(&rngDesc)
 
 	tc.manualClock.Set(leaseExpiry(tc.rng))
 	now := tc.clock.Now()

--- a/storage/store.go
+++ b/storage/store.go
@@ -1347,7 +1347,7 @@ func (s *Store) BootstrapRange(initialValues []roachpb.KeyValue) error {
 		return err
 	}
 
-	updatedMS, err := writeInitialState(ctx, batch, *ms, *desc)
+	updatedMS, err := writeInitialState(ctx, batch, *ms, *desc, raftpb.HardState{})
 	if err != nil {
 		return err
 	}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -985,7 +985,8 @@ func splitTestRange(store *Store, key, splitKey roachpb.RKey, t *testing.T) *Rep
 	}
 	// Minimal amount of work to keep this deprecated machinery working: Write
 	// some required Raft keys.
-	if _, err := writeInitialState(context.Background(), store.engine, enginepb.MVCCStats{}, *desc); err != nil {
+	if _, err := writeInitialState(context.Background(), store.engine,
+		enginepb.MVCCStats{}, *desc, raftpb.HardState{}); err != nil {
 		t.Fatal(err)
 	}
 	newRng, err := NewReplica(desc, store, 0)
@@ -2328,7 +2329,8 @@ func TestStoreRemovePlaceholderOnRaftIgnored(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := writeInitialState(ctx, s.Engine(), enginepb.MVCCStats{}, *rng1.Desc()); err != nil {
+	if _, err := writeInitialState(ctx, s.Engine(),
+		enginepb.MVCCStats{}, *rng1.Desc(), raftpb.HardState{}); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
When creating the new Raft state for the right hand side of a split,
load any existing hard state from the engine and not the batch. The
batch reads are from a snapshot taken at the point in time when the
first batch read was performed. This is currently safe due to the
serialization of uninitialized replica processing, but future
changes (see #8941) want to loosen those restrictions and only lock out
writes to the right hand side after the batch has been created.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9088)

<!-- Reviewable:end -->
