### PR TITLE
sql/parser: Verify that AggregateFuncs deep copy Datums on Result

### DIFF
--- a/sql/parser/aggregate_builtins.go
+++ b/sql/parser/aggregate_builtins.go
@@ -35,7 +35,12 @@ func init() {
 
 // AggregateFunc accumulates the result of a some function of a Datum.
 type AggregateFunc interface {
+	// Add accumulates the passed datum into the AggregateFunc.
 	Add(Datum)
+
+	// Result returns the current value of the accumulation. This value
+	// will be a deep copy of any AggregateFunc internal state, so that
+	// it will not be mutated by additional calls to Add.
 	Result() Datum
 }
 
@@ -443,10 +448,13 @@ func (a *intSumAggregate) Result() Datum {
 	if !a.seenNonNull {
 		return DNull
 	}
-	if !a.large {
-		a.decSum.SetUnscaled(a.intSum)
+	dd := &DDecimal{}
+	if a.large {
+		dd.Set(&a.decSum.Dec)
+	} else {
+		dd.SetUnscaled(a.intSum)
 	}
-	return &a.decSum
+	return dd
 }
 
 type decimalSumAggregate struct {


### PR DESCRIPTION
Requested as a separate PR from #8928.

This makes sure that all `Datum`s returned from the `Result` method of
`AggregateFunc` implementations are deep copies of any internal state.
This is necessary to allow for ordered window functions that will
incrementally call `Result` on an aggregate, and expect each resultant
`Datum` to be a separate deep copy and not modified during future
accumulation.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9089)

<!-- Reviewable:end -->
