### PR TITLE
sql: properly reject string literals containing invalid UTF-8 sequences.

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -654,11 +654,14 @@ func Example_sql_escape() {
 	// sql -e insert into t.t values (e'\xdc\x88\x38\x35', 'UTF8 string with RTL char')
 	// INSERT 1
 	// sql -e insert into t.t values (e'\xc3\x28', 'non-UTF8 string')
-	// INSERT 1
+	// pq: invalid UTF-8 byte sequence
+	// insert into t.t values (e'\xc3\x28', 'non-UTF8 string')
+	//                         ^
+	//
 	// sql -e insert into t.t values (e'a\tb\tc\n12\t123123213\t12313', 'tabs')
 	// INSERT 1
 	// sql -e select * from t.t
-	// 10 rows
+	// 9 rows
 	// s	d
 	// foo	printable ASCII
 	// "\"foo"	printable ASCII with quotes
@@ -668,7 +671,6 @@ func Example_sql_escape() {
 	// "\u00f1"	printable UTF8 using escapes
 	// "\x01"	non-printable UTF8 string
 	// "\u070885"	UTF8 string with RTL char
-	// "\xc3("	non-UTF8 string
 	// "a\tb\tc\n12\t123123213\t12313"	tabs
 	// sql -e create table t.u ("""foo" int, "\foo" int, "foo
 	// bar" int, "κόσμε" int, "܈85" int)
@@ -701,11 +703,10 @@ func Example_sql_escape() {
 	// | ñ                              | printable UTF8 using escapes   |
 	// | "\x01"                         | non-printable UTF8 string      |
 	// | ܈85                            | UTF8 string with RTL char      |
-	// | "\xc3("                        | non-UTF8 string                |
 	// | a   b         c␤               | tabs                           |
 	// | 12  123123213 12313            |                                |
 	// +--------------------------------+--------------------------------+
-	// (10 rows)
+	// (9 rows)
 	// sql --pretty -e show columns from t.u
 	// +----------+------+-------+----------------+
 	// |  Field   | Type | Null  |    Default     |

--- a/cli/dump_test.go
+++ b/cli/dump_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/spf13/pflag"
 	"gopkg.in/inf.v0"
@@ -241,9 +242,17 @@ func TestDumpRandom(t *testing.T) {
 			n := time.Duration(rnd.Int63()).String()
 			o := rnd.Intn(2) == 1
 			e := strings.TrimRight(inf.NewDec(rnd.Int63(), inf.Scale(rnd.Int31n(20)-10)).String(), ".0")
-			s := make([]byte, rnd.Intn(500))
-			if _, err := rnd.Read(s); err != nil {
+			sr := make([]byte, rnd.Intn(500))
+			if _, err := rnd.Read(sr); err != nil {
 				t.Fatal(err)
+			}
+			s := make([]byte, 0, len(sr))
+			for _, b := range sr {
+				r := rune(b)
+				if !utf8.ValidRune(r) {
+					continue
+				}
+				s = append(s, []byte(string(r))...)
 			}
 			b := make([]byte, rnd.Intn(500))
 			if _, err := rnd.Read(b); err != nil {

--- a/sql/analyze_test.go
+++ b/sql/analyze_test.go
@@ -41,6 +41,7 @@ func testTableDesc() *sqlbase.TableDescriptor {
 			{Name: "h", Type: sqlbase.ColumnType{Kind: sqlbase.ColumnType_FLOAT}},
 			{Name: "i", Type: sqlbase.ColumnType{Kind: sqlbase.ColumnType_STRING}},
 			{Name: "j", Type: sqlbase.ColumnType{Kind: sqlbase.ColumnType_INT}},
+			{Name: "k", Type: sqlbase.ColumnType{Kind: sqlbase.ColumnType_BYTES}},
 		},
 		PrimaryIndex: sqlbase.IndexDescriptor{
 			Name: "primary", Unique: true, ColumnNames: []string{"a"},

--- a/sql/index_selection_test.go
+++ b/sql/index_selection_test.go
@@ -521,11 +521,11 @@ func TestMakeSpans(t *testing.T) {
 			`/7/3/0-/7/3/1 /7/2/0-/7/2/1 /7/1/0-/7/1/1`},
 		// Test different directions for te columns inside a tuple.
 		{`(a,b,j) IN ((1,2,3), (4,5,6))`, `a-,b,j-`, `/4/5/6-/4/5/5 /1/2/3-/1/2/2`},
-		{`i = E'\xff'`, `i`, `/"\xff"-/"\xff\x00"`},
+		{`k = b'\xff'`, `k`, `/"\xff"-/"\xff\x00"`},
 		// Test that limits on bytes work correctly: when encoding a descending limit for bytes,
 		// we need to go outside the bytes encoding.
 		// "\xaa" is encoded as [bytesDescMarker, ^0xaa, <term escape sequence>]
-		{`i = E'\xaa'`, `i-`,
+		{`k = b'\xaa'`, `k-`,
 			fmt.Sprintf("raw:%c%c\xff\xfe-%c%c\xff\xff",
 				encoding.BytesDescMarker, ^byte(0xaa), encoding.BytesDescMarker, ^byte(0xaa))},
 

--- a/sql/parser/eval_test.go
+++ b/sql/parser/eval_test.go
@@ -617,8 +617,6 @@ func TestEvalError(t *testing.T) {
 		{`ANNOTATE_TYPE(ANNOTATE_TYPE(1, int), decimal)`,
 			`incompatible type assertion for ANNOTATE_TYPE(1, INT) as decimal, found type: int`},
 		{`b'\xff\xfe\xfd'::string`, `invalid utf8: "\xff\xfe\xfd"`},
-		{`'' LIKE ` + string([]byte{0x27, 0xc2, 0x30, 0x7a, 0xd5, 0x25, 0x30, 0x27}),
-			`LIKE regexp compilation failed: error parsing regexp: invalid UTF-8: .*`},
 		// TODO(pmattis): Check for overflow.
 		// {`~0 + 1`, `0`},
 	}

--- a/sql/parser/scan.go
+++ b/sql/parser/scan.go
@@ -29,6 +29,7 @@ import (
 
 const eof = -1
 const errUnterminated = "unterminated string"
+const errInvalidUTF8 = "invalid UTF-8 byte sequence"
 const errInvalidHexNumeric = "invalid hexadecimal numeric literal"
 const singleQuote = '\''
 
@@ -197,21 +198,21 @@ func (s *Scanner) scan(lval *sqlSymType) {
 
 	case s.identQuote:
 		// "[^"]"
-		if s.scanString(lval, s.identQuote, false) {
+		if s.scanString(lval, s.identQuote, false, true) {
 			lval.id = IDENT
 		}
 		return
 
 	case singleQuote:
 		// '[^']'
-		if s.scanString(lval, ch, s.syntax == Modern) {
+		if s.scanString(lval, ch, s.syntax == Modern, true) {
 			lval.id = SCONST
 		}
 		return
 
 	case s.stringQuote:
 		// '[^']'
-		if s.scanString(lval, s.stringQuote, s.syntax == Modern) {
+		if s.scanString(lval, s.stringQuote, s.syntax == Modern, true) {
 			lval.id = SCONST
 		}
 		return
@@ -221,7 +222,7 @@ func (s *Scanner) scan(lval *sqlSymType) {
 		if t := s.peek(); t == singleQuote || t == s.stringQuote {
 			// [bB]'[^']'
 			s.pos++
-			if s.scanString(lval, t, true) {
+			if s.scanString(lval, t, true, false) {
 				lval.id = BCONST
 			}
 			return
@@ -230,7 +231,7 @@ func (s *Scanner) scan(lval *sqlSymType) {
 			if t := s.peekN(1); t == singleQuote || t == s.stringQuote {
 				// [rRbB]'[^']'
 				s.pos += 2
-				if s.scanString(lval, t, false) {
+				if s.scanString(lval, t, false, false) {
 					lval.id = BCONST
 				}
 				return
@@ -245,7 +246,7 @@ func (s *Scanner) scan(lval *sqlSymType) {
 			if t := s.peek(); t == singleQuote || t == s.stringQuote {
 				// [rR]'[^']'
 				s.pos++
-				if s.scanString(lval, t, false) {
+				if s.scanString(lval, t, false, true) {
 					lval.id = SCONST
 				}
 				return
@@ -254,7 +255,7 @@ func (s *Scanner) scan(lval *sqlSymType) {
 				if t := s.peekN(1); t == singleQuote || t == s.stringQuote {
 					// [bBrR]'[^']'
 					s.pos += 2
-					if s.scanString(lval, t, false) {
+					if s.scanString(lval, t, false, false) {
 						lval.id = BCONST
 					}
 					return
@@ -269,7 +270,7 @@ func (s *Scanner) scan(lval *sqlSymType) {
 		if t := s.peek(); t == singleQuote || t == s.stringQuote {
 			// [eE]'[^']'
 			s.pos++
-			if s.scanString(lval, t, true) {
+			if s.scanString(lval, t, true, true) {
 				lval.id = SCONST
 			}
 			return
@@ -282,13 +283,18 @@ func (s *Scanner) scan(lval *sqlSymType) {
 		if t := s.peek(); t == singleQuote || t == s.stringQuote {
 			// [xX]'[a-f0-9]'
 			s.pos++
-			if s.scanString(lval, t, false) {
+			if s.scanString(lval, t, false, false) {
 				stringBytes, err := hex.DecodeString(lval.str)
 				if err != nil {
 					// Either the string has an odd number of characters or contains one or
 					// more invalid bytes.
 					lval.id = ERROR
 					lval.str = "invalid hexadecimal string literal"
+					return
+				}
+				if !utf8.Valid(stringBytes) {
+					lval.id = ERROR
+					lval.str = errInvalidUTF8
 					return
 				}
 				lval.id = SCONST
@@ -662,7 +668,7 @@ func (s *Scanner) scanPlaceholder(lval *sqlSymType) {
 	lval.id = PLACEHOLDER
 }
 
-func (s *Scanner) scanString(lval *sqlSymType, ch int, allowEscapes bool) bool {
+func (s *Scanner) scanString(lval *sqlSymType, ch int, allowEscapes, requireUTF8 bool) bool {
 	var buf []byte
 	var runeTmp [utf8.UTFMax]byte
 	start := s.pos
@@ -776,6 +782,12 @@ outer:
 			lval.str = errUnterminated
 			return false
 		}
+	}
+
+	if requireUTF8 && !utf8.Valid(buf) {
+		lval.id = ERROR
+		lval.str = errInvalidUTF8
+		return false
 	}
 
 	lval.str = string(buf)

--- a/sql/parser/scan_test.go
+++ b/sql/parser/scan_test.go
@@ -79,6 +79,8 @@ func TestScanner(t *testing.T) {
 		{`'a'`, []int{SCONST}},
 		{`b'a'`, []int{BCONST}},
 		{`B'a'`, []int{BCONST}},
+		{`b'\xff'`, []int{BCONST}},
+		{`B'\xff'`, []int{BCONST}},
 		{`e'a'`, []int{SCONST}},
 		{`E'a'`, []int{SCONST}},
 		{`NOT`, []int{NOT}},
@@ -91,8 +93,8 @@ func TestScanner(t *testing.T) {
 		{`WITH ORDINALITY`, []int{WITH_LA, ORDINALITY}},
 		{`1`, []int{ICONST}},
 		{`0xa`, []int{ICONST}},
-		{`x'ba'`, []int{SCONST}},
-		{`X'ba'`, []int{SCONST}},
+		{`x'2F'`, []int{SCONST}},
+		{`X'2F'`, []int{SCONST}},
 		{`1.0`, []int{FCONST}},
 		{`1.0e1`, []int{FCONST}},
 		{`1e+1`, []int{FCONST}},
@@ -111,7 +113,7 @@ func TestScanner(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(d.expected, tokens) {
-			t.Errorf("%d: expected %d, but found %d", i, d.expected, tokens)
+			t.Errorf("%d: %q: expected %d, but found %d", i, d.sql, d.expected, tokens)
 		}
 	}
 }
@@ -327,6 +329,7 @@ func TestScanString(t *testing.T) {
 		{`e'\009'`, `invalid syntax`},
 		{`e'\101'`, `A`},
 		{`e'\101B'`, `AB`},
+		{`e'\xff'`, `invalid UTF-8 byte sequence`},
 		{`e'\u1'`, `invalid syntax`},
 		{`e'\U123'`, `invalid syntax`},
 		{`e'\u0041'`, `A`},
@@ -343,6 +346,7 @@ world'`, `hello
 world`},
 		{`x'666f6f'`, `foo`},
 		{`X'626172'`, `bar`},
+		{`X'FF'`, `invalid UTF-8 byte sequence`},
 	}
 	for _, d := range testData {
 		s := MakeScanner(d.sql, Traditional)
@@ -366,6 +370,8 @@ func TestScanStringModern(t *testing.T) {
 		{`B'\x41'`, `A`},
 		{`e"\x41"`, `A`},
 		{`E'\x41'`, `A`},
+		{`e"\xff"`, `invalid UTF-8 byte sequence`},
+		{`E'\xff'`, `invalid UTF-8 byte sequence`},
 		// Disable escapes with raw strings.
 		{`r"\x41"`, `\x41`},
 		{`R'\x41'`, `\x41`},


### PR DESCRIPTION
Fixes #9059.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9094)

<!-- Reviewable:end -->
