### PR TITLE
sql: don't limit batches with unordered spans

### DIFF
--- a/roachpb/api.pb.go
+++ b/roachpb/api.pb.go
@@ -1297,6 +1297,12 @@ type Header struct {
 	// by span requests in the batch. Span requests are requests like
 	// Scan, ReverseScan, and DelRange. If two requests touch the
 	// same key it is double counted.
+	//
+	// If a batch limit is used with Scan requests, the spans for the requests
+	// must be non-overlapping and in increasing order.
+	//
+	// If a batch limit is used with ReverseScan requests, the spans for the
+	// requests must be non-overlapping and in decreasing order.
 	MaxSpanRequestKeys int64 `protobuf:"varint,8,opt,name=max_span_request_keys,json=maxSpanRequestKeys" json:"max_span_request_keys"`
 	// if set, all of the spans in the batch are distinct. Note that the
 	// calculation of distinct spans does not include intents in an

--- a/roachpb/api.proto
+++ b/roachpb/api.proto
@@ -803,6 +803,12 @@ message Header {
   // by span requests in the batch. Span requests are requests like
   // Scan, ReverseScan, and DelRange. If two requests touch the
   // same key it is double counted.
+  //
+  // If a batch limit is used with Scan requests, the spans for the requests
+  // must be non-overlapping and in increasing order.
+  //
+  // If a batch limit is used with ReverseScan requests, the spans for the
+  // requests must be non-overlapping and in decreasing order.
   optional int64 max_span_request_keys = 8 [(gogoproto.nullable) = false];
   // if set, all of the spans in the batch are distinct. Note that the
   // calculation of distinct spans does not include intents in an

--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -313,8 +313,8 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 		if err != nil {
 			return err
 		}
-		// StartScan uses 0 as a sentinal for the default limit of entries scanned.
-		if err := rf.StartScan(txn, roachpb.Spans{sp}, 0); err != nil {
+		err = rf.StartScan(txn, roachpb.Spans{sp}, true /* limit batches */, 0 /* no limit hint */)
+		if err != nil {
 			return err
 		}
 

--- a/sql/distsql/joinreader.go
+++ b/sql/distsql/joinreader.go
@@ -128,7 +128,7 @@ func (jr *joinReader) mainLoop() error {
 			})
 		}
 
-		err := jr.fetcher.StartScan(jr.flowCtx.txn, spans, 0)
+		err := jr.fetcher.StartScan(jr.flowCtx.txn, spans, false /* no batch limits */, 0)
 		if err != nil {
 			log.Errorf(jr.ctx, "scan error: %s", err)
 			return err

--- a/sql/distsql/tablereader.go
+++ b/sql/distsql/tablereader.go
@@ -225,7 +225,9 @@ func (tr *tableReader) Run(wg *sync.WaitGroup) {
 		defer log.Infof(tr.ctx, "exiting")
 	}
 
-	if err := tr.fetcher.StartScan(tr.flowCtx.txn, tr.spans, tr.getLimitHint()); err != nil {
+	if err := tr.fetcher.StartScan(
+		tr.flowCtx.txn, tr.spans, true /* limit batches */, tr.getLimitHint(),
+	); err != nil {
 		log.Errorf(tr.ctx, "scan error: %s", err)
 		tr.output.Close(err)
 		return

--- a/sql/fk.go
+++ b/sql/fk.go
@@ -294,7 +294,7 @@ func (f baseFKHelper) check(values parser.DTuple) (parser.DTuple, error) {
 		key = roachpb.Key(f.searchPrefix)
 	}
 	spans := roachpb.Spans{roachpb.Span{Key: key, EndKey: key.PrefixEnd()}}
-	if err := f.rf.StartScan(f.txn, spans, 1); err != nil {
+	if err := f.rf.StartScan(f.txn, spans, true /* limit batches */, 1); err != nil {
 		return nil, err
 	}
 	return f.rf.NextRow()

--- a/sql/join.go
+++ b/sql/join.go
@@ -52,11 +52,12 @@ func (p *planner) makeIndexJoin(origScan *scanNode, exactPrefix int) (resultPlan
 	// at a starting point to build the new indexScan node.
 	indexScan = origScan
 
-	// Create a new table scan node with the primary index.
+	// Create a new scanNode that will be used with the primary index.
 	table := p.Scan()
 	table.desc = origScan.desc
 	table.initDescDefaults(publicColumns)
 	table.initOrdering(0)
+	table.disableBatchLimit()
 
 	colIDtoRowIndex := map[sqlbase.ColumnID]int{}
 	for _, colID := range table.desc.PrimaryIndex.ColumnIDs {

--- a/sql/sqlbase/rowfetcher.go
+++ b/sql/sqlbase/rowfetcher.go
@@ -152,7 +152,9 @@ func (rf *RowFetcher) Init(
 
 // StartScan initializes and starts the key-value scan. Can be used multiple
 // times.
-func (rf *RowFetcher) StartScan(txn *client.Txn, spans roachpb.Spans, limitHint int64) error {
+func (rf *RowFetcher) StartScan(
+	txn *client.Txn, spans roachpb.Spans, limitBatches bool, limitHint int64,
+) error {
 	if len(spans) == 0 {
 		// If no spans were specified retrieve all of the keys that start with our
 		// index key prefix.
@@ -177,10 +179,14 @@ func (rf *RowFetcher) StartScan(txn *client.Txn, spans roachpb.Spans, limitHint 
 		firstBatchLimit++
 	}
 
-	rf.kvFetcher = makeKVFetcher(txn, spans, rf.reverse, firstBatchLimit)
+	var err error
+	rf.kvFetcher, err = makeKVFetcher(txn, spans, rf.reverse, limitBatches, firstBatchLimit)
+	if err != nil {
+		return err
+	}
 
 	// Retrieve the first key.
-	_, err := rf.NextKey()
+	_, err = rf.NextKey()
 	return err
 }
 

--- a/sql/tablewriter.go
+++ b/sql/tablewriter.go
@@ -439,7 +439,8 @@ func (tu *tableUpserter) fetchExisting(ctx context.Context) ([]parser.DTuple, er
 		return make([]parser.DTuple, len(primaryKeys)), nil
 	}
 
-	if err := tu.fetcher.StartScan(tu.txn, pkSpans, int64(len(pkSpans))); err != nil {
+	// We don't limit batches here because the spans are unordered.
+	if err := tu.fetcher.StartScan(tu.txn, pkSpans, false /* no batch limits */, 0); err != nil {
 		return nil, err
 	}
 
@@ -647,7 +648,7 @@ func (td *tableDeleter) deleteAllRowsScan(
 	if err != nil {
 		return resume, err
 	}
-	if err := rf.StartScan(td.txn, roachpb.Spans{resume}, 0); err != nil {
+	if err := rf.StartScan(td.txn, roachpb.Spans{resume}, true /* limit batches */, 0); err != nil {
 		return resume, err
 	}
 
@@ -739,7 +740,7 @@ func (td *tableDeleter) deleteIndexScan(
 	if err != nil {
 		return resume, err
 	}
-	if err := rf.StartScan(td.txn, roachpb.Spans{resume}, 0); err != nil {
+	if err := rf.StartScan(td.txn, roachpb.Spans{resume}, true /* limit batches */, 0); err != nil {
 		return resume, err
 	}
 

--- a/sql/testdata/select_index_span_ranges
+++ b/sql/testdata/select_index_span_ranges
@@ -1,0 +1,65 @@
+# This test verifies that we correctly perform an index join when the KV
+# batches span ranges. This is testing that SQL disables batch limits for index
+# join; otherwise it can get out of order results from KV that it can't handle.
+
+kv-batch-size 10
+
+statement ok
+CREATE TABLE t (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  d INT,
+  FAMILY (a),
+  FAMILY (b),
+  FAMILY (c),
+  FAMILY (d),
+  INDEX c (c)
+)
+
+statement ok
+INSERT INTO t VALUES
+(1, 0, 99, 0),
+(2, 0, 80, 0),
+(3, 0, 90, 0),
+(4, 0, 10, 0),
+(5, 0, 20, 0),
+(6, 0, 85, 0),
+(7, 0, 91, 0),
+(8, 0, 12, 0),
+(9, 0, 91, 0),
+(10, 0, 11, 0),
+(11, 0, 12, 0),
+(12, 0, 88, 0),
+(13, 0, 13, 0)
+
+# Split the table across multiple ranges.
+statement ok
+ALTER TABLE t SPLIT AT (2)
+
+statement ok
+ALTER TABLE t SPLIT AT (3)
+
+statement ok
+ALTER TABLE t SPLIT AT (5)
+
+statement ok
+ALTER TABLE t SPLIT AT (8)
+
+query ITT
+EXPLAIN SELECT * FROM t WHERE (c >= 80) ORDER BY c
+----
+0  index-join
+1  scan        t@c /80-
+1  scan        t@primary
+
+query IIII
+SELECT * FROM t WHERE (c >= 80) ORDER BY c
+----
+2   0  80  0
+6   0  85  0
+12  0  88  0
+3   0  90  0
+7   0  91  0
+9   0  91  0
+1   0  99  0


### PR DESCRIPTION
KV doesn't provide the semantics SQL expects when batches are limited and have
unordered spans. This occurs only during index join. Don't limit batches in this
case - they are already effectively limited by the batching inside indexJoin (we
only request 100 rows at a time).

Improve the error checking in kvfetcher: we verify the spans are ordered if
there is a limit. Also we make the resume span check more strict - once we see a
resume span, we shouldn't see any more results for the resulting spans.

This also turned up errors for UPSERT; disabled batch limits in that case as
well.

Fixes #9095.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9099)

<!-- Reviewable:end -->
