### PR TITLE
storage: clear the timestamp cache when we're not the lease holder

### DIFF
--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -878,7 +878,7 @@ func TestReplicaTSCacheLowWaterOnLease(t *testing.T) {
 	// test cases that do not test anything.
 	baseLowWater := baseRTS.WallTime
 
-	newLowWater := now.Add(50, 0).WallTime + baseLowWater
+	newLowWater := now.WallTime + baseLowWater + int64(maxClockOffset)
 
 	testCases := []struct {
 		storeID     roachpb.StoreID
@@ -903,7 +903,8 @@ func TestReplicaTSCacheLowWaterOnLease(t *testing.T) {
 			expErr: "overlaps previous"},
 		// The other store tries again, this time without the overlap.
 		{storeID: tc.store.StoreID() + 1,
-			start: now.Add(31, 0), expiration: now.Add(50, 0)},
+			start: now.Add(31, 0), expiration: now.Add(50, 0),
+			expLowWater: newLowWater},
 		// Lease is regranted to this replica. Store clock moves forward avoid
 		// influencing the result.
 		{storeID: tc.store.StoreID(),

--- a/storage/timestamp_cache.go
+++ b/storage/timestamp_cache.go
@@ -141,7 +141,6 @@ func newTimestampCache(clock *hlc.Clock) *timestampCache {
 	tc := &timestampCache{
 		rCache:                cache.NewIntervalCache(cache.Config{Policy: cache.CacheFIFO}),
 		wCache:                cache.NewIntervalCache(cache.Config{Policy: cache.CacheFIFO}),
-		requests:              btree.New(btreeDegree),
 		evictionSizeThreshold: defaultEvictionSizeThreshold,
 	}
 	tc.Clear(clock)
@@ -153,6 +152,7 @@ func newTimestampCache(clock *hlc.Clock) *timestampCache {
 // Clear clears the cache and resets the low water mark to the
 // current time plus the maximum clock offset.
 func (tc *timestampCache) Clear(clock *hlc.Clock) {
+	tc.requests = btree.New(btreeDegree)
 	tc.rCache.Clear()
 	tc.wCache.Clear()
 	tc.lowWater = clock.Now()


### PR DESCRIPTION
Fixes #9101.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9102)

<!-- Reviewable:end -->
