### PR TITLE
cmd/zerosum: fix range stats calculation

### DIFF
--- a/cmd/zerosum/main.go
+++ b/cmd/zerosum/main.go
@@ -353,7 +353,7 @@ func (z *zeroSum) verify(d time.Duration) {
 func (z *zeroSum) rangeInfo() (int, []int) {
 	replicas := make([]int, len(z.nodes))
 	client := z.clients[z.randNode(rand.Intn)]
-	rows, err := client.Scan(keys.Meta2Prefix, keys.Meta2KeyMax, 0)
+	rows, err := client.Scan(keys.Meta2Prefix, keys.Meta2Prefix.PrefixEnd(), 0)
 	if err != nil {
 		z.maybeLogError(err)
 		return -1, replicas


### PR DESCRIPTION
Using Meta2KeyMax as the end key was causing us to miss the last range.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9110)

<!-- Reviewable:end -->
