### PR TITLE
rpc: Disable GRPC tracing (again)

### DIFF
--- a/rpc/context.go
+++ b/rpc/context.go
@@ -37,6 +37,15 @@ import (
 	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
+func init() {
+	// Disable GRPC tracing. This retains a subset of messages for
+	// display on /debug/requests, which is very expensive for
+	// snapshots. Until we can be more selective about what is retained
+	// in traces, we must disable tracing entirely.
+	// https://github.com/grpc/grpc-go/issues/695
+	grpc.EnableTracing = false
+}
+
 const (
 	defaultHeartbeatInterval = 3 * time.Second
 	// The coefficient by which the maximum offset is multiplied to determine the


### PR DESCRIPTION
This retains a subset of messages for display on /debug/requests, which
is very expensive for snapshots. Until we can be more selective about
what is retained in traces, we must disable tracing entirely.

See grpc/grpc-go#695

This is why we see so many snapshots in memory (and the occasional OOM) in the beta and gamma clusters.

@cockroachdb/stability

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9113)

<!-- Reviewable:end -->
