### PR TITLE
master -> develop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,8 +194,11 @@ include .go-version
 
 ifneq ($(SKIP_BOOTSTRAP),1)
 
-GITHOOKS := $(subst githooks/,.git/hooks/,$(wildcard githooks/*))
-.git/hooks/%: githooks/%
+# If we're in a git worktree, the git hooks directory may not be in our root,
+# so we ask git for the location.
+GITHOOKSDIR := $(shell git rev-parse --git-path hooks)
+GITHOOKS := $(subst githooks/,$(GITHOOKSDIR)/,$(wildcard githooks/*))
+$(GITHOOKSDIR)/%: githooks/%
 	@echo installing $<
 	@rm -f $@
 	@mkdir -p $(dir $@)

--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/log/logflags"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/syncutil"
 	"github.com/cockroachdb/cockroach/util/timeutil"
@@ -459,6 +460,12 @@ func (l *LocalCluster) startNode(node *testNode) {
 		"--host=" + node.nodeStr,
 		"--alsologtostderr=INFO",
 		"--verbosity=1",
+	}
+
+	// Forward the vmodule flag to the nodes.
+	vmoduleFlag := flag.Lookup(logflags.VModuleName)
+	if vmoduleFlag.Value.String() != "" {
+		cmd = append(cmd, fmt.Sprintf("--%s=%s", vmoduleFlag.Name, vmoduleFlag.Value.String()))
 	}
 
 	for _, store := range node.stores {

--- a/acceptance/terrafarm/farmer.go
+++ b/acceptance/terrafarm/farmer.go
@@ -92,7 +92,7 @@ func (f *Farmer) NumNodes() int {
 func (f *Farmer) Add(nodes int) error {
 	nodes += f.NumNodes()
 	args := []string{
-		fmt.Sprintf("-var=num_instances=%d", nodes),
+		fmt.Sprintf("-var=num_instances=\"%d\"", nodes),
 		fmt.Sprintf("-var=stores=%s", f.Stores),
 	}
 

--- a/acceptance/terraform/nodectl
+++ b/acceptance/terraform/nodectl
@@ -19,6 +19,9 @@ if [ $# -ne 2 ]; then
     usage
 fi
 
+# ~/.config/gcloud may be erroneously owned by root, so fix that.
+sudo chown -R ${USER} "${HOME}/.config/gcloud"
+
 # CockroachDB nodes are named blah-cockroach-[0-9]*, so extract the final
 # numeric part.
 gcs_url="$2"

--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -228,7 +228,7 @@ func farmer(t *testing.T, prefix string) *terrafarm.Farmer {
 		Cwd:         *flagCwd,
 		LogDir:      logDir,
 		KeyName:     *flagKeyName,
-		Stores:      stores,
+		Stores:      strconv.Quote(stores),
 		Prefix:      name,
 		StateFile:   name + ".tfstate",
 		AddVars:     terraformVars,

--- a/build/build-docker-deploy.sh
+++ b/build/build-docker-deploy.sh
@@ -17,6 +17,7 @@ if [ "${1-}" = "docker" ]; then
     time make STATIC=1 release
 
     check_static cockroach
+    strip -S cockroach
 
     mv cockroach build/deploy/cockroach
 

--- a/cli/debug.go
+++ b/cli/debug.go
@@ -679,7 +679,7 @@ var debugEnvCmd = &cobra.Command{
 Output environment variables that influence configuration.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		env := envutil.GetEnvReport()
+		env := envutil.GetEnvReport(false)
 		fmt.Print(env)
 	},
 }

--- a/cli/node.go
+++ b/cli/node.go
@@ -89,7 +89,7 @@ var nodesColumnHeaders = []string{
 	"system_bytes",
 	"replicas_leaders",
 	"replicas_leaseholders",
-	"ranges_availalbe",
+	"ranges_available",
 }
 
 var statusNodeCmd = &cobra.Command{

--- a/cli/node.go
+++ b/cli/node.go
@@ -87,9 +87,9 @@ var nodesColumnHeaders = []string{
 	"value_bytes",
 	"intent_bytes",
 	"system_bytes",
-	"leader_ranges",
-	"repl_ranges", // Using abbreviations to avoid excessively wide output.
-	"avail_ranges",
+	"replicas_leaders",
+	"replicas_leaseholders",
+	"ranges_availalbe",
 }
 
 var statusNodeCmd = &cobra.Command{
@@ -176,8 +176,8 @@ func nodeStatusesToRows(statuses []status.NodeStatus) [][]string {
 			strconv.FormatInt(int64(metricVals["valbytes"]), 10),
 			strconv.FormatInt(int64(metricVals["intentbytes"]), 10),
 			strconv.FormatInt(int64(metricVals["sysbytes"]), 10),
-			strconv.FormatInt(int64(metricVals["ranges.leader"]), 10),
-			strconv.FormatInt(int64(metricVals["ranges.replicated"]), 10),
+			strconv.FormatInt(int64(metricVals["replicas.leaders"]), 10),
+			strconv.FormatInt(int64(metricVals["replicas.leaseholders"]), 10),
 			strconv.FormatInt(int64(metricVals["ranges.available"]), 10),
 		})
 	}

--- a/cli/start.go
+++ b/cli/start.go
@@ -360,6 +360,9 @@ func runStart(_ *cobra.Command, args []string) error {
 	}
 
 	log.Info(startCtx, "starting cockroach node")
+	if envVarsUsed := envutil.GetEnvReport(true); envVarsUsed != "" {
+		log.Infof(startCtx, "using local environment variables:\n%s", envVarsUsed)
+	}
 	s, err := server.NewServer(serverCtx, stopper)
 	if err != nil {
 		return fmt.Errorf("failed to start Cockroach server: %s", err)

--- a/cmd/zerosum/main.go
+++ b/cmd/zerosum/main.go
@@ -353,7 +353,7 @@ func (z *zeroSum) verify(d time.Duration) {
 func (z *zeroSum) rangeInfo() (int, []int) {
 	replicas := make([]int, len(z.nodes))
 	client := z.clients[z.randNode(rand.Intn)]
-	rows, err := client.Scan(keys.Meta2Prefix, keys.Meta2KeyMax, 0)
+	rows, err := client.Scan(keys.Meta2Prefix, keys.Meta2Prefix.PrefixEnd(), 0)
 	if err != nil {
 		z.maybeLogError(err)
 		return -1, replicas

--- a/docs/RFCS/type_annotations.md
+++ b/docs/RFCS/type_annotations.md
@@ -1,0 +1,252 @@
+- Feature Name: SQL Type Annotations
+- Status: completed
+- Start Date: 2016-05-25
+- Authors: Nathan, knz
+- RFC PR: #6895
+- Cockroach Issue: #6189
+
+
+# Summary
+
+This RFC proposes to add a new "type annotation" syntax to our SQL dialect
+(referred to as CockroachSQL from now on). This was originally proposed as
+part of the Summer typing system, but is being split up separately because
+it is purely an extension which was not necessary for the immediate
+correctness of the type system.
+
+# Motivation
+
+In order to clarify the typing rules during the design of the Summer
+type system and to exercise the proposed system, we found it was useful
+to "force" certain expressions to be of a certain type.
+
+Unfortunately, the SQL cast expression (`CAST(... AS ...)` or
+`...::...`) is not appropriate for this, because although it
+guarantees a type to the surrounding expression it does not constrain
+its argument. For example `sign(1.2)::int` does not disambiguate which
+overload of `sign` to use.
+
+Therefore we propose the following SQL extension, which was not
+required for the correctness of the Summer typing system but offers 
+opportunities to better exercise it in tests. The extension also gives
+users of our SQL dialect more control over the type inference decisions
+of the type system.
+
+The need for this type of extension was also implicitly
+present/expressed in the alternate proposals Rick and Morty.
+
+# Detailed design
+
+The extension is a new "type annotation" expression node.
+
+### Operator Syntax
+
+We define the following SQL syntax: `E ::: T`, where `E` is a sub-expression
+and `T` is a type. We chose this syntax because it does not collide (visually
+or logically) with other SQL syntax, and because it draws parallels to the
+cast operator syntax.
+
+For example: `1:::int` or `1 ::: int`.
+
+The meaning of this at a first order approximation is "interpret the
+expression on the left using the type on the right".
+
+### Keyword Syntax
+
+In addition, we define the keyword syntax: `ANNOTATE_TYPE(E, T)`, where `E`
+is a sub-expression and `T` is a type. We chose this syntax because it draws
+parallels to the cast keyword syntax, without requiring special client handling.
+We could have opted for an `ANNOTATE_TYPE(E AS T)` syntax, which would have been
+more similar to the cast keyword syntax, but would not be usable by ORMs or other
+SQL client abstraction layers because it would not look like a function call.
+
+For example: `ANNOTATE_TYPE(1, int)`.
+
+### Type Annotations vs. Type Casts
+
+As expressed above, type annotations and type casts play different roles.
+The primary purpose of a type cast is to take a given expression of type
+`T1` and map it during evaluation to a type `T2`. This cast can be used to
+work around disjoint types between a sub-expression and its parent context,
+but it has no effect on typing of the sub-expression itself. In practice 
+with the Summer type system, this means that during type checking, a 
+`CastExpr` will throw away any recursively passed `desiredType`, and will 
+propagate down `NoPreference` to its sub-expressions.
+
+On the other hand, type annotations have no runtime effect (as implied by
+the term "annotation"). Instead, the annotation only has an effect during
+semantic analysis. The annotation will do what it can to type its sub-expression
+as its annotation type, and then assert that the sub-expression does get typed
+as this type, throwing an error if not. In a "bottom-up" type system, the 
+only thing an annotation like this could do is assert after its sub-expression's
+type has been resolved that it matches its annotation type. However, in a
+bi-directional typing system like Summer, the annotation can be more effective
+by also "desiring" its annotation type from its children. In effect, this means
+that the sub-expression will become the desired type if possible.
+
+Examples
+
+```sql
+    SELECT 1.2
+        -> no preference for the return type of `1.2`
+        -> numeric constant without a preference defaults to DECIMAL
+        -> the expression returns a DECIMAL
+    SELECT 1.2::float
+        -> no preference for the return type of CAST(... as FLOAT)
+        -> no preference for the return type of `1.2`
+        -> numeric constant without a preference defaults to DECIMAL
+        -> CastExpr returns a FLOAT instead, which it will cast during evaluation
+        -> the expression returns a FLOAT
+    SELECT 1.2::string
+        -> no preference for the return type of CAST(... as STRING)
+        -> no preference for the return type of `1.2`
+        -> numeric constant without a preference defaults to DECIMAL
+        -> CastExpr returns a STRING instead, which it will cast (format) during evaluation
+        -> the expression returns a STRING
+    SELECT 1.2:::float
+        -> no preference for the return type of `... ::: FLOAT`
+        -> FLOAT preference passed for the return type of `1.2`
+        -> numeric constant contains FLOAT in its "resolvable type set", so it resolves
+           itself as a FLOAT
+        -> the type annotation correctly asserts that its sub-expression returns a FLOAT
+        -> the type assertion itself returns a float, and does nothing during evaluation
+        -> the expression returns a FLOAT
+    SELECT 1.2:::string
+        -> no preference for the return type of `... ::: STRING`
+        -> STRING preference passed for the return type of `1.2`
+        -> numeric constant does not contains STRING in its "resolvable type set", so it 
+           resolves itself to the default type of DECIMAL instead
+        -> the type annotation throws an error when asserting that its sub-expression 
+           returns a STRING, type checking fails
+
+    SELECT sign(1.2)
+        -> no preference for the return type of `sign`
+        -> no preference for the return type of `1.2`
+        -> `1.2` defaults to a DECIMAL
+        -> overload resolution chooses the DECIMAL implementation
+        -> the expression returns a DECIMAL
+    SELECT sign(1.2)::float
+        -> no preference for the return type of CAST(... as FLOAT)
+        -> no preference for the return type of `sign`
+        -> no preference for the return type of `1.2`
+        -> `1.2` defaults to a DECIMAL
+        -> overload resolution chooses the DECIMAL implementation
+        -> CastExpr returns a FLOAT instead, which it will cast during evaluation
+        -> the expression returns a FLOAT
+    SELECT sign(1.2)::string
+        -> no preference for the return type of CAST(... as STRING)
+        -> no preference for the return type of `sign`
+        -> no preference for the return type of `1.2`
+        -> `1.2` defaults to a DECIMAL
+        -> overload resolution chooses the DECIMAL implementation
+        -> CastExpr returns a STRING instead, which it will cast (format) during evaluation
+        -> the expression returns a STRING
+    SELECT sign(1.2):::float
+        -> no preference for the return type of `... ::: FLOAT`
+        -> FLOAT preference passed for the return type of `sign`
+        -> FLOAT used in overload resolution to determine float overload and
+           to resolve the numeric constant as a float
+        -> the type annotation correctly asserts that its sub-expression returns a FLOAT
+        -> the type assertion itself returns a float, and does nothing during evaluation
+        -> the expression returns a FLOAT
+    SELECT sign(1.2):::string
+        -> no preference for the return type of `... ::: STRING`
+        -> STRING preference passed for the return type of `sign`
+        -> STRING ignore in overload resolution because no overloads return a STRING,
+           so DECIMAL implementation is defaulted to
+        -> the type annotation throws an error when asserting that its sub-expression 
+           returns a STRING, type checking fails
+```
+
+Note that in the above examples, adding a type annotation onto the top
+of a SELECT clause has an almost identical effect on type checking as 
+INSERTing into a column with the annotation type.
+
+### Interaction with Placeholders
+
+The initial Summer RFC defined a set of rules for determining the type of
+placeholders based on type casts and type annotations. The proposed rules
+are:
+
+- if any given placeholder appears as immediate argument of an
+  explicit annotation, then assign that type to the placeholder (and
+  reject conflicting annotations after the 1st).
+
+- otherwise (no direct annotations on a placeholder), if all
+  occurrences of a placeholder appear as immediate argument
+  to a cast expression then:
+
+  - if all the cast(s) are homogeneous,
+    then assign the placeholder the type indicated by the cast.
+
+  - otherwise, assign the type "string" to the placeholder.
+
+- for anything else, defer to type checking to determine the placeholder type.
+
+Examples:
+
+```sql
+   SELECT $1:::float, $1::string
+       -> $1 ::: float, execution will perform explicit cast float->string
+   SELECT $1:::float, $1:::string
+       -> error: conflicting types
+   SELECT $1::float, $1::float
+       -> $1 ::: float
+   SELECT $1::float, $1::string
+       -> $1 ::: string, execution will perform explicit cast $1 -> float
+   SELECT $1:::float, $1
+       -> $1 ::: float
+   SELECT $1::float, $1
+       -> nothing done during 1st pass, type checking will resolve
+```
+
+(Note that this rule does not interfere with the separate rule,
+customary in SQL interpreters, that the client may choose to disregard
+the stated type of a placeholder during execute and instead pass the
+value as a string. The query executor must then convert the string to
+the type for the placeholder that was determined during type checking.
+For example if a client prepares `select $1:::int + 2` and passes "123" (a string),
+the executor must convert "123" to 123 (an int) before running the query. The
+annotation expression is a type assertion, not conversion, at run-time.)
+
+This set of rules has already been partially implemented in the 
+`parser.placeholderAnnotationVisitor`, which is used through
+`parser.ProcessPlaceholderAnnotations`.
+
+### Implementation Plan
+
+A `TypeAnnotationExpr` or `AnnotationExpr` will be created in the `parser`
+package. It's implementation will mirror that of the `ParenExpr`, except
+in its `TypeCheck` method, where it will call `typeCheckAndRequire` on
+its sub-expression with its annotation type. The expression could also
+make a similar type assertion in its `Eval` method, but this shouldn't
+be necessary.
+
+The `ProcessPlaceholderAnnotations` will need to be adjusted to adopt the
+rules listed above for interactions between casts and annotions. This is
+already stubbed out.
+
+# Drawbacks
+
+Type annotations will be a Cockroach specific language extension to SQL.
+In general, we have tried to avoid language extensions, as they limit
+portability of SQL statements and create a higher learning curve for
+moving to Cockroach. However, we concluded that this was ok, because 
+these annotations are fully opt-in, and are not a requirement of the 
+dialect.
+
+# Alternatives
+
+None. This is strictly an isolated extension.
+
+# Unresolved questions
+
+### EXPLAIN(TYPES)
+
+An initial proof of concept implementation of type annotations made it
+clear that `EXPLAIN(TYPES)` in conjunction with type annotations results
+in a fairly verbose output. It might make sense to make type annotations 
+"invisible" in the output of `EXPLAIN(TYPES)`, as they are annotations 
+for the type system, as opposed to expressions which affect evaluation.
+Furthermore, if the annotation passes type checking, its child will already
+have the same type, so including it in the output is unnecessary.

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -683,18 +683,26 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 		var numAttempts int
 		for r := retry.StartWithCtx(ctx, ds.rpcRetryOptions); r.Next(); {
 			numAttempts++
-			const magicLogCurAttempt = 20
-			if (numAttempts%magicLogCurAttempt == 0) || (ba.Txn != nil && (ba.Txn.Sequence%magicLogCurAttempt == 0)) {
-				// Log a message if a request appears to get stuck for a long
-				// time or, potentially, forever. See #8975.
-				// The local counter captures this loop here; the Sequence number
-				// should capture anything higher up (as it needs to be
-				// incremented every time this method is called).
-				log.Warningf(
-					ctx,
-					"%d retries for an RPC at sequence %d, last error was: %s, remaining key ranges %s: %s",
-					numAttempts, ba.Txn.Sequence, pErr, rs, ba,
-				)
+			{
+				const magicLogCurAttempt = 20
+
+				var seq int32
+				if ba.Txn != nil {
+					seq = ba.Txn.Sequence
+				}
+
+				if numAttempts%magicLogCurAttempt == 0 || seq%magicLogCurAttempt == 0 {
+					// Log a message if a request appears to get stuck for a long
+					// time or, potentially, forever. See #8975.
+					// The local counter captures this loop here; the Sequence number
+					// should capture anything higher up (as it needs to be
+					// incremented every time this method is called).
+					log.Warningf(
+						ctx,
+						"%d retries for an RPC at sequence %d, last error was: %s, remaining key ranges %s: %s",
+						numAttempts, seq, pErr, rs, ba,
+					)
+				}
 			}
 			// Get range descriptor (or, when spanning range, descriptors). Our
 			// error handling below may clear them on certain errors, so we

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -691,7 +691,8 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 					seq = ba.Txn.Sequence
 				}
 
-				if numAttempts%magicLogCurAttempt == 0 || seq%magicLogCurAttempt == 0 {
+				// seq + 1 so that we don't log on the first attempt.
+				if numAttempts%magicLogCurAttempt == 0 || (seq+1)%magicLogCurAttempt == 0 {
 					// Log a message if a request appears to get stuck for a long
 					// time or, potentially, forever. See #8975.
 					// The local counter captures this loop here; the Sequence number
@@ -699,7 +700,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 					// incremented every time this method is called).
 					log.Warningf(
 						ctx,
-						"%d retries for an RPC at sequence %d, last error was: %s, remaining key ranges %s: %s",
+						"%d retries for an RPC at sequence %d, last error was: %s, remaining key ranges %q: %s",
 						numAttempts, seq, pErr, rs, ba,
 					)
 				}

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -680,7 +680,22 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 		var needAnother bool
 		var pErr *roachpb.Error
 		var finished bool
+		var numAttempts int
 		for r := retry.StartWithCtx(ctx, ds.rpcRetryOptions); r.Next(); {
+			numAttempts++
+			const magicLogCurAttempt = 20
+			if (numAttempts%magicLogCurAttempt == 0) || (ba.Txn != nil && (ba.Txn.Sequence%magicLogCurAttempt == 0)) {
+				// Log a message if a request appears to get stuck for a long
+				// time or, potentially, forever. See #8975.
+				// The local counter captures this loop here; the Sequence number
+				// should capture anything higher up (as it needs to be
+				// incremented every time this method is called).
+				log.Warningf(
+					ctx,
+					"%d retries for an RPC at sequence %d, last error was: %s, remaining key ranges %s: %s",
+					numAttempts, ba.Txn.Sequence, pErr, rs, ba,
+				)
+			}
 			// Get range descriptor (or, when spanning range, descriptors). Our
 			// error handling below may clear them on certain errors, so we
 			// refresh (likely from the cache) on every retry.

--- a/rpc/context.go
+++ b/rpc/context.go
@@ -37,6 +37,15 @@ import (
 	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
+func init() {
+	// Disable GRPC tracing. This retains a subset of messages for
+	// display on /debug/requests, which is very expensive for
+	// snapshots. Until we can be more selective about what is retained
+	// in traces, we must disable tracing entirely.
+	// https://github.com/grpc/grpc-go/issues/695
+	grpc.EnableTracing = false
+}
+
 const (
 	defaultHeartbeatInterval = 3 * time.Second
 	// The coefficient by which the maximum offset is multiplied to determine the

--- a/scripts/bootstrap-debian.sh
+++ b/scripts/bootstrap-debian.sh
@@ -20,7 +20,7 @@ patch -p1 -d ../go < "parallelbuilds-go${GOVERSION}.patch"
 (cd ~/go/src && GOROOT_BOOTSTRAP=~/go-bootstrap ./make.bash)
 
 echo 'export GOPATH=${HOME}; export PATH=${HOME}/go/bin:${GOPATH}/bin:${PATH}' >> ~/.bashrc_go
-echo '. .bashrc_go' >> ~/.bashrc
+echo '. ~/.bashrc_go' >> ~/.bashrc
 
 . ~/.bashrc_go
 

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -418,7 +418,7 @@ func compareNodeStatus(t *testing.T, ts *TestServer, expectedNodeStatus *status.
 		compareMetricMaps(actualStores[key].Metrics, expectedStores[key].Metrics,
 			[]string{
 				"replicas",
-				"ranges.replicated",
+				"replicas.leaseholders",
 			},
 			[]string{
 				"livebytes",
@@ -503,14 +503,14 @@ func TestStatusSummaries(t *testing.T) {
 		stat := status.StoreStatus{
 			Desc: *desc,
 			Metrics: map[string]float64{
-				"replicas":          float64(expectedReplicas),
-				"ranges.replicated": float64(expectedReplicas),
-				"livebytes":         0,
-				"keybytes":          0,
-				"valbytes":          0,
-				"livecount":         0,
-				"keycount":          0,
-				"valcount":          0,
+				"replicas":              float64(expectedReplicas),
+				"replicas.leaseholders": float64(expectedReplicas),
+				"livebytes":             0,
+				"keybytes":              0,
+				"valbytes":              0,
+				"livecount":             0,
+				"keycount":              0,
+				"valcount":              0,
 			},
 		}
 		expectedNodeStatus.StoreStatuses = append(expectedNodeStatus.StoreStatuses, stat)
@@ -599,9 +599,9 @@ func TestStatusSummaries(t *testing.T) {
 	// Increment metrics on the first store.
 	store1 = expectedStoreStatuses[roachpb.StoreID(1)].Metrics
 	store1["replicas"]++
-	store1["ranges.leader"]++
+	store1["replicas.leaders"]++
+	store1["replicas.leaseholders"]++
 	store1["ranges.available"]++
-	store1["ranges.replicated"]++
 
 	forceWriteStatus()
 	expectedNodeStatus = compareNodeStatus(t, ts, expectedNodeStatus, 3)

--- a/server/status/recorder_test.go
+++ b/server/status/recorder_test.go
@@ -211,8 +211,8 @@ func TestMetricsRecorder(t *testing.T) {
 
 		// Stats needed for store summaries.
 		{"ranges", "counter", 1},
-		{"ranges.leader", "gauge", 1},
-		{"ranges.replicated", "gauge", 1},
+		{"replicas.leaders", "gauge", 1},
+		{"replicas.leaseholders", "gauge", 1},
 		{"ranges.available", "gauge", 1},
 	}
 

--- a/sql/create.go
+++ b/sql/create.go
@@ -334,7 +334,7 @@ func (n *createTableNode) Start() error {
 
 	id, err := n.p.generateUniqueDescID()
 	if err != nil {
-		return nil
+		return err
 	}
 	desc.SetID(id)
 

--- a/sql/parser/normalize.go
+++ b/sql/parser/normalize.go
@@ -474,8 +474,8 @@ func (expr *OrExpr) normalize(v *normalizeVisitor) TypedExpr {
 
 func (expr *ParenExpr) normalize(v *normalizeVisitor) TypedExpr {
 	newExpr := expr.TypedInnerExpr()
-	if normalizeable, ok := newExpr.(normalizableExpr); ok {
-		newExpr = normalizeable.normalize(v)
+	if normalizable, ok := newExpr.(normalizableExpr); ok {
+		newExpr = normalizable.normalize(v)
 		if v.err != nil {
 			return expr
 		}
@@ -571,8 +571,8 @@ func (v *normalizeVisitor) VisitPost(expr Expr) Expr {
 	}
 
 	// Normalize expressions that know how to normalize themselves.
-	if normalizeable, ok := expr.(normalizableExpr); ok {
-		expr = normalizeable.normalize(v)
+	if normalizable, ok := expr.(normalizableExpr); ok {
+		expr = normalizable.normalize(v)
 		if v.err != nil {
 			return expr
 		}

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -37,7 +37,7 @@ func unimplementedWithIssue(issue int) {
 // By using an empty interface, we lose the type checking previously provided
 // by yacc and the Go compiler when dealing with union values. Instead, runtime
 // type assertions must be relied upon in the methods below, and as such, the
-// parser should be thoroughly tested whenever new sytax is added.
+// parser should be thoroughly tested whenever new syntax is added.
 //
 // It is important to note that when assigning values to sqlSymUnion.val, all
 // nil values should be typed so that they are stored as nil instances in the

--- a/sql/parser/sql.y
+++ b/sql/parser/sql.y
@@ -50,7 +50,7 @@ func unimplementedWithIssue(issue int) {
 // By using an empty interface, we lose the type checking previously provided
 // by yacc and the Go compiler when dealing with union values. Instead, runtime
 // type assertions must be relied upon in the methods below, and as such, the
-// parser should be thoroughly tested whenever new sytax is added.
+// parser should be thoroughly tested whenever new syntax is added.
 //
 // It is important to note that when assigning values to sqlSymUnion.val, all
 // nil values should be typed so that they are stored as nil instances in the

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -2201,10 +2201,11 @@ func TestLeaderRemoveSelf(t *testing.T) {
 func TestRemoveRangeWithoutGC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	mtc := startMultiTestContext(t, 2)
+	sc := storage.TestStoreContext()
+	sc.TestingKnobs.DisableScanner = true
+	mtc := multiTestContext{storeContext: &sc}
+	mtc.Start(t, 2)
 	defer mtc.Stop()
-	// Disable the GC queue and move the range from store 0 to 1.
-	mtc.stores[0].SetReplicaGCQueueActive(false)
 	const rangeID roachpb.RangeID = 1
 	mtc.replicateRange(rangeID, 1)
 	mtc.unreplicateRange(rangeID, 0)
@@ -2238,25 +2239,22 @@ func TestRemoveRangeWithoutGC(t *testing.T) {
 	// can continue to use its last known replica ID.
 	mtc.stopStore(0)
 	mtc.restartStore(0)
-	// Turn off the GC queue to ensure that the replica is deleted at
-	// startup instead of by the scanner. This is not 100% guaranteed
-	// since the scanner could have already run at this point, but it
-	// should be enough to prevent us from accidentally relying on the
-	// scanner.
-	mtc.stores[0].SetReplicaGCQueueActive(false)
 
-	// The Replica object is not recreated.
-	if _, err := mtc.stores[0].GetReplica(rangeID); err == nil {
-		t.Fatalf("expected replica to be missing")
-	}
+	util.SucceedsSoon(t, func() error {
+		// The Replica object should be removed.
+		if _, err := mtc.stores[0].GetReplica(rangeID); err == nil {
+			return errors.Errorf("expected replica to be missing")
+		}
 
-	// And the data is no longer on disk.
-	if ok, err := engine.MVCCGetProto(context.Background(), mtc.stores[0].Engine(), descKey,
-		mtc.stores[0].Clock().Now(), true, nil, &desc); err != nil {
-		t.Fatal(err)
-	} else if ok {
-		t.Fatal("expected range descriptor to be absent")
-	}
+		// And the data should no longer be on disk.
+		if ok, err := engine.MVCCGetProto(context.Background(), mtc.stores[0].Engine(), descKey,
+			mtc.stores[0].Clock().Now(), true, nil, &desc); err != nil {
+			return err
+		} else if ok {
+			return errors.Errorf("expected range descriptor to be absent")
+		}
+		return nil
+	})
 }
 
 // TestCheckConsistencyMultiStore creates a Db with three stores ]

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -107,10 +107,12 @@ func isExpectedQueueError(err error) bool {
 type queueImpl interface {
 	// shouldQueue accepts current time, a replica, and the system config
 	// and returns whether it should be queued and if so, at what priority.
+	// The Replica is guaranteed to be initialized.
 	shouldQueue(hlc.Timestamp, *Replica, config.SystemConfig) (shouldQueue bool, priority float64)
 
 	// process accepts current time, a replica, and the system config
-	// and executes queue-specific work on it.
+	// and executes queue-specific work on it. The Replica is guaranteed
+	// to be initialized.
 	process(context.Context, hlc.Timestamp, *Replica, config.SystemConfig) error
 
 	// timer returns a duration to wait between processing the next item
@@ -281,6 +283,10 @@ func (bq *baseQueue) MaybeAdd(repl *Replica, now hlc.Timestamp) {
 		return
 	}
 
+	if !repl.IsInitialized() {
+		return
+	}
+
 	if !cfgOk {
 		log.VEvent(1, bq.ctx, "no system config available. skipping")
 		return
@@ -324,6 +330,12 @@ func (bq *baseQueue) addInternal(repl *Replica, should bool, priority float64) (
 	if bq.mu.disabled {
 		log.Event(bq.ctx, "queue disabled")
 		return false, errQueueDisabled
+	}
+
+	if !repl.IsInitialized() {
+		// We checked this above in MaybeAdd(), but we need to check it
+		// again for Add().
+		return false, errors.New("replica not initialized")
 	}
 
 	// If the replica is currently in purgatory, don't re-add it.

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1652,10 +1652,8 @@ func (r *Replica) handleRaftReady() error {
 			r.store.mu.Lock()
 			defer r.store.mu.Unlock()
 
-			if _, exists := r.store.mu.replicaPlaceholders[r.RangeID]; exists {
-				if err := r.store.removePlaceholderLocked(r.RangeID); err != nil {
-					return errors.Wrapf(err, "could not remove placeholder before applySnapshot")
-				}
+			if r.store.removePlaceholderLocked(r.RangeID) {
+				atomic.AddInt32(&r.store.counts.filledPlaceholders, 1)
 			}
 			if err := r.store.processRangeDescriptorUpdateLocked(r); err != nil {
 				return errors.Wrapf(err, "could not processRangeDescriptorUpdate after applySnapshot")

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -190,6 +190,9 @@ func (d *atomicRangeDesc) load() *roachpb.RangeDescriptor {
 // using a lock, the copy might be inconsistent.
 func (d *atomicRangeDesc) String() string {
 	inconsistentDesc := d.load()
+	if !inconsistentDesc.IsInitialized() {
+		return fmt.Sprintf("%d{-}", inconsistentDesc.RangeID)
+	}
 	return fmt.Sprintf("%d{%s-%s}",
 		inconsistentDesc.RangeID, inconsistentDesc.StartKey, inconsistentDesc.EndKey)
 }
@@ -490,7 +493,7 @@ func (r *Replica) newReplicaInner(
 // require a lock and its output may not be atomic with other ongoing work in
 // the replica. This is done to prevent deadlocks in logging sites.
 func (r *Replica) String() string {
-	return fmt.Sprintf("%s %s", r.store, &r.rangeDesc)
+	return fmt.Sprintf("[n%d,s%d,r%s]", r.store.Ident.NodeID, r.store.Ident.StoreID, &r.rangeDesc)
 }
 
 // Destroy clears pending command queue by sending each pending

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -495,15 +495,15 @@ func (r *Replica) String() string {
 
 // Destroy clears pending command queue by sending each pending
 // command an error and cleans up all data associated with this range.
-func (r *Replica) Destroy(origDesc roachpb.RangeDescriptor) error {
+func (r *Replica) Destroy(origDesc roachpb.RangeDescriptor, destroyData bool) error {
 	desc := r.Desc()
 	if repDesc, ok := desc.GetReplicaDescriptor(r.store.StoreID()); ok && repDesc.ReplicaID >= origDesc.NextReplicaID {
 		return errors.Errorf("cannot destroy replica %s; replica ID has changed (%s >= %s)",
 			r, repDesc.ReplicaID, origDesc.NextReplicaID)
 	}
 
-	// Clear the pending command queue.
 	r.mu.Lock()
+	// Clear the pending command queue.
 	for _, p := range r.mu.pendingCmds {
 		p.done <- roachpb.ResponseWithError{
 			Reply: &roachpb.BatchResponse{},
@@ -517,6 +517,9 @@ func (r *Replica) Destroy(origDesc roachpb.RangeDescriptor) error {
 		r.mu.replicaID, r.RangeID)
 	r.mu.Unlock()
 
+	if !destroyData {
+		return nil
+	}
 	return r.store.destroyReplicaData(desc)
 }
 

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -182,7 +182,7 @@ func (r *Replica) executeCmd(
 	reply.SetHeader(header)
 
 	if log.V(2) {
-		log.Infof(ctx, "executed %s command %+v: %+v, err=%s", args.Method(), args, reply, err)
+		log.Infof(ctx, "executed %s command %+v: %+v, err=%v", args.Method(), args, reply, err)
 	}
 
 	// Create a roachpb.Error by initializing txn from the request/response header.

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -788,7 +788,7 @@ func intersectSpan(
 	}
 	if bytes.Compare(span.Key, keys.LocalRangeMax) < 0 {
 		if bytes.Compare(span.EndKey, keys.LocalRangeMax) >= 0 {
-			panic("a local intent range may not have a non-local portion")
+			log.Fatalf(context.Background(), "a local intent range may not have a non-local portion: %s", span)
 		}
 		if containsKeyRange(desc, span.Key, span.EndKey) {
 			return &span, nil

--- a/storage/replica_data_iter_test.go
+++ b/storage/replica_data_iter_test.go
@@ -205,7 +205,7 @@ func TestReplicaDataIterator(t *testing.T) {
 	}
 
 	// Destroy range and verify that its data has been completely cleared.
-	if err := tc.rng.Destroy(*tc.rng.Desc()); err != nil {
+	if err := tc.rng.Destroy(*tc.rng.Desc(), true); err != nil {
 		t.Fatal(err)
 	}
 	iter = NewReplicaDataIterator(tc.rng.Desc(), tc.rng.store.Engine(), false /* !replicatedOnly */)

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -6207,9 +6207,8 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 		r.mu.Lock()
 		ticks := r.mu.ticks
 		r.mu.Unlock()
-		var info tickInfo
 		for ; (ticks % electionTicks) != 0; ticks++ {
-			if err := r.tick(&info); err != nil {
+			if _, err := r.tick(); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -6239,8 +6238,7 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 		r.mu.Unlock()
 
 		// Tick raft.
-		var info tickInfo
-		if err := r.tick(&info); err != nil {
+		if _, err := r.tick(); err != nil {
 			t.Fatal(err)
 		}
 

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -490,9 +490,9 @@ func TestApplyCmdLeaseError(t *testing.T) {
 		StoreID:   2,
 		ReplicaID: 2,
 	}
-	rngDesc := tc.rng.Desc()
+	rngDesc := *tc.rng.Desc()
 	rngDesc.Replicas = append(rngDesc.Replicas, secondReplica)
-	tc.rng.setDescWithoutProcessUpdate(rngDesc)
+	tc.rng.setDescWithoutProcessUpdate(&rngDesc)
 
 	pArgs := putArgs(roachpb.Key("a"), []byte("asd"))
 

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -878,7 +878,7 @@ func TestReplicaTSCacheLowWaterOnLease(t *testing.T) {
 	// test cases that do not test anything.
 	baseLowWater := baseRTS.WallTime
 
-	newLowWater := now.Add(50, 0).WallTime + baseLowWater
+	newLowWater := now.WallTime + baseLowWater + int64(maxClockOffset)
 
 	testCases := []struct {
 		storeID     roachpb.StoreID
@@ -903,7 +903,8 @@ func TestReplicaTSCacheLowWaterOnLease(t *testing.T) {
 			expErr: "overlaps previous"},
 		// The other store tries again, this time without the overlap.
 		{storeID: tc.store.StoreID() + 1,
-			start: now.Add(31, 0), expiration: now.Add(50, 0)},
+			start: now.Add(31, 0), expiration: now.Add(50, 0),
+			expLowWater: newLowWater},
 		// Lease is regranted to this replica. Store clock moves forward avoid
 		// influencing the result.
 		{storeID: tc.store.StoreID(),

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -5082,12 +5082,12 @@ func TestReplicaDestroy(t *testing.T) {
 	if err := rep.setDesc(newDesc); err != nil {
 		t.Fatal(err)
 	}
-	if err := rep.Destroy(*origDesc); !testutils.IsError(err, "replica ID has changed") {
+	if err := rep.Destroy(*origDesc, true); !testutils.IsError(err, "replica ID has changed") {
 		t.Fatalf("expected error 'replica ID has changed' but got %v", err)
 	}
 
 	// Now try a fresh descriptor and succeed.
-	if err := rep.Destroy(*rep.Desc()); err != nil {
+	if err := rep.Destroy(*rep.Desc(), true); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/storage/replica_trigger.go
+++ b/storage/replica_trigger.go
@@ -463,7 +463,7 @@ func (r *Replica) handleTrigger(
 	}
 
 	if trigger.addToReplicaGCQueue {
-		if _, err := r.store.replicaGCQueue.Add(r, 1.0); err != nil {
+		if _, err := r.store.replicaGCQueue.Add(r, replicaGCPriorityRemoved); err != nil {
 			// Log the error; the range should still be GC'd eventually.
 			log.Errorf(ctx, "unable to add to GC queue: %s", err)
 		}

--- a/storage/reservation.go
+++ b/storage/reservation.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// defaultMaxReservations is the number of concurrent reservations allowed.
-	defaultMaxReservations = 5
+	defaultMaxReservations = 1
 	// defaultMaxReservedBytes is the total number of bytes that can be
 	// reserved, by all active reservations, at any time.
 	defaultMaxReservedBytes = 250 << 20 // 250 MiB

--- a/storage/reservation_test.go
+++ b/storage/reservation_test.go
@@ -77,7 +77,7 @@ func bookieQueueLen(b *bookie) int {
 // correctly.
 func TestBookieReserve(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	stopper, _, b := createTestBookie(time.Hour, defaultMaxReservations, defaultMaxReservedBytes)
+	stopper, _, b := createTestBookie(time.Hour, 5, defaultMaxReservedBytes)
 	defer stopper.Stop()
 
 	testCases := []struct {

--- a/storage/store.go
+++ b/storage/store.go
@@ -414,6 +414,16 @@ type Store struct {
 		syncutil.Mutex
 		value map[roachpb.RangeID]struct{}
 	}
+
+	counts struct {
+		// Number of placeholders removed due to error.
+		removedPlaceholders int32
+		// Number of placeholders successfully filled by a snapshot.
+		filledPlaceholders int32
+		// Number of placeholders removed due to a snapshot that was dropped by
+		// raft.
+		droppedPlaceholders int32
+	}
 }
 
 var _ client.Sender = &Store{}
@@ -1654,29 +1664,37 @@ func (s *Store) addPlaceholderLocked(placeholder *ReplicaPlaceholder) error {
 	return nil
 }
 
-func (s *Store) removePlaceholderLocked(rngID roachpb.RangeID) error {
+// removePlaceholder removes a placeholder for the specified range if it
+// exists, returning true if a placeholder was present and removed and false
+// otherwise.
+func (s *Store) removePlaceholder(rngID roachpb.RangeID) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.removePlaceholderLocked(rngID)
+}
+
+func (s *Store) removePlaceholderLocked(rngID roachpb.RangeID) bool {
 	rng, ok := s.mu.replicaPlaceholders[rngID]
 	if !ok {
-		return errors.Errorf("%v: cannot remove placeholder for RangeID %v; Placeholder doesn't exist", s, rngID)
+		return false
 	}
-	if exRng := s.mu.replicasByKey.Delete(rng); exRng != nil {
-		switch exRng.(type) {
-		case *Replica:
-			return errors.Errorf("%v: expected placeholder for RangeID: %v, got Replica", s, rngID)
-		case *ReplicaPlaceholder:
-			delete(s.mu.replicaPlaceholders, rngID)
-			return nil
-		}
+	switch exRng := s.mu.replicasByKey.Delete(rng).(type) {
+	case *ReplicaPlaceholder:
+		delete(s.mu.replicaPlaceholders, rngID)
+		return true
+	case nil:
+		log.Fatalf(context.TODO(), "%s range=%d: placeholder not found", s, rngID)
+	default:
+		log.Fatalf(context.TODO(), "%s range=%d: expected placeholder, got %T", s, rngID, exRng)
 	}
-	return errors.Errorf("placeholder %v was not in replicasByKey BTree", rngID)
+	return false // appease the compiler
 }
 
 // addReplicaToRangeMapLocked adds the replica to the replicas map.
 // addReplicaToRangeMapLocked requires that the store lock is held.
 func (s *Store) addReplicaToRangeMapLocked(rng *Replica) error {
 	if _, ok := s.mu.replicas[rng.RangeID]; ok {
-		return errors.Errorf("%s: range for ID %d already exists in replicasByKey btree", s,
-			rng.RangeID)
+		return errors.Errorf("%s: replica already exists", rng)
 	}
 	s.mu.replicas[rng.RangeID] = rng
 	return nil
@@ -1707,6 +1725,7 @@ func (s *Store) removeReplicaImpl(rep *Replica, origDesc roachpb.RangeDescriptor
 	defer s.mu.Unlock()
 
 	delete(s.mu.replicas, rep.RangeID)
+	delete(s.mu.replicaPlaceholders, rep.RangeID)
 	if s.mu.replicasByKey.Delete(rep) == nil {
 		return errors.Errorf("couldn't find range in replicasByKey btree")
 	}
@@ -2174,7 +2193,10 @@ func (s *Store) maybeUpdateTransaction(txn *roachpb.Transaction, now hlc.Timesta
 
 // HandleRaftRequest dispatches a raft message to the appropriate Replica. It
 // requires that s.processRaftMu and s.mu are not held.
-func (s *Store) HandleRaftRequest(ctx context.Context, req *RaftMessageRequest) *roachpb.Error {
+func (s *Store) HandleRaftRequest(
+	ctx context.Context,
+	req *RaftMessageRequest,
+) (pErr *roachpb.Error) {
 	s.processRaftMu.Lock()
 	defer s.processRaftMu.Unlock()
 
@@ -2200,9 +2222,10 @@ func (s *Store) HandleRaftRequest(ctx context.Context, req *RaftMessageRequest) 
 		}
 	}
 
-	addedPlaceholder := false
-
 	s.metrics.raftRcvdMessages[req.Message.Type].Inc(1)
+
+	var addedPlaceholder bool
+	var removePlaceholder bool
 
 	switch req.Message.Type {
 	case raftpb.MsgSnap:
@@ -2222,6 +2245,10 @@ func (s *Store) HandleRaftRequest(ctx context.Context, req *RaftMessageRequest) 
 			}
 
 			if placeholder != nil {
+				// NB: The placeholder added here is either removed below after a
+				// preemptive snapshot is applied or after the next call to
+				// Replica.handleRaftReady. Note that we can only get here if the
+				// replica doesn't exist or is uninitialized.
 				if err := s.addPlaceholderLocked(placeholder); err != nil {
 					log.Fatal(ctx, errors.Wrapf(err, "%s: could not add vetted placeholder %s", s, placeholder))
 				}
@@ -2232,16 +2259,26 @@ func (s *Store) HandleRaftRequest(ctx context.Context, req *RaftMessageRequest) 
 			return nil
 		}
 
+		if addedPlaceholder {
+			// If we added a placeholder remove it before we return unless some other
+			// part of the code takes ownership of the removal (indicated by setting
+			// removePlaceholder to false).
+			removePlaceholder = true
+			defer func() {
+				if removePlaceholder {
+					if s.removePlaceholder(req.RangeID) {
+						atomic.AddInt32(&s.counts.removedPlaceholders, 1)
+					}
+				}
+			}()
+		}
+
 	case raftpb.MsgHeartbeat:
 		// TODO(bdarnell): handle coalesced heartbeats.
 	}
 
-	s.mu.Lock()
 	// Lazily create the replica.
-	r, err := s.getOrCreateReplicaLocked(req.RangeID, req.ToReplica.ReplicaID, req.FromReplica)
-	// TODO(bdarnell): is it safe to release the store lock here?
-	// It deadlocks to hold s.Mutex while calling raftGroup.Step.
-	s.mu.Unlock()
+	r, err := s.getOrCreateReplica(req.RangeID, req.ToReplica.ReplicaID, req.FromReplica)
 	if err != nil {
 		return roachpb.NewError(err)
 	}
@@ -2253,6 +2290,29 @@ func (s *Store) HandleRaftRequest(ctx context.Context, req *RaftMessageRequest) 
 			// members of the raft group (i.e. replicas with an ID of 0). This
 			// is the only operation that can be performed before it is part of
 			// the raft group.
+
+			defer func() {
+				s.mu.Lock()
+				defer s.mu.Unlock()
+
+				// We need to remove the placeholder regardless of whether the snapshot
+				// applied successfully or not.
+				if addedPlaceholder {
+					// Clear the replica placeholder; we are about to swap it with a real replica.
+					if !s.removePlaceholderLocked(req.RangeID) {
+						log.Fatalf(ctx, "%s: could not remove placeholder after preemptive snapshot", r)
+					}
+					atomic.AddInt32(&s.counts.filledPlaceholders, 1)
+					removePlaceholder = false
+				}
+
+				if pErr == nil {
+					// If the snapshot succeeded, process the range descriptor update.
+					if err := s.processRangeDescriptorUpdateLocked(r); err != nil {
+						pErr = roachpb.NewError(err)
+					}
+				}
+			}()
 
 			// Requiring that the Term is set in a message makes sure that we
 			// get all of Raft's internal safety checks (it confuses messages
@@ -2346,19 +2406,8 @@ func (s *Store) HandleRaftRequest(ctx context.Context, req *RaftMessageRequest) 
 				return roachpb.NewError(err)
 			}
 
-			s.mu.Lock()
-			defer s.mu.Unlock()
-			if addedPlaceholder {
-				// Clear the replica placeholder; we are about to swap it with a real replica.
-				if err := s.removePlaceholderLocked(req.RangeID); err != nil {
-					return roachpb.NewError(err)
-				}
-			}
-
-			if err := s.processRangeDescriptorUpdateLocked(r); err != nil {
-				return roachpb.NewError(err)
-			}
-
+			// NB: See the defer at the start of this block for the removal of the
+			// placeholder and processing of the range descriptor update.
 			return nil
 
 			// At this point, the Replica has data but no ReplicaID. We hope
@@ -2367,8 +2416,8 @@ func (s *Store) HandleRaftRequest(ctx context.Context, req *RaftMessageRequest) 
 			// happen, at some point the Replica GC queue will have to grab it.
 		}
 		// We disallow non-snapshot messages to replica ID 0. Note that
-		// getOrCreateReplicaLocked disallows moving the replica ID backward, so
-		// the only way we can get here is if the replica did not previously exist.
+		// getOrCreateReplica disallows moving the replica ID backward, so the only
+		// way we can get here is if the replica did not previously exist.
 		if log.V(1) {
 			log.Infof(s.Ctx(), "refusing incoming Raft message %s for range %d from %+v to %+v",
 				req.Message.Type, req.RangeID, req.FromReplica, req.ToReplica)
@@ -2384,6 +2433,9 @@ func (s *Store) HandleRaftRequest(ctx context.Context, req *RaftMessageRequest) 
 	}
 
 	s.enqueueRaftUpdateCheck(req.RangeID)
+	// If a placeholder was added it is now owned by the replica and will be
+	// removed after the next call to Replica.handleRaftReady().
+	removePlaceholder = false
 	return nil
 }
 
@@ -2512,6 +2564,14 @@ func (s *Store) processRaft() {
 					panic(err) // TODO(bdarnell)
 				}
 				maybeWarnDuration(start, r, "handle raft ready")
+				// Only an uninitialized replica can have a placeholder since, by
+				// definition, an initialized replica will be present in the
+				// replicasByKey map. While the replica will usually consume the
+				// placeholder itself, that isn't guaranteed and so this invocation
+				// here is crucial (i.e. don't remove it).
+				if s.removePlaceholder(r.RangeID) {
+					atomic.AddInt32(&s.counts.droppedPlaceholders, 1)
+				}
 			}
 
 			var wg sync.WaitGroup
@@ -2528,11 +2588,6 @@ func (s *Store) processRaft() {
 				}
 			}
 			wg.Wait()
-			// After a round of readys, if a placeholder hasn't been removed
-			// by the handleRaftReady, this means that the Raft group rejected
-			// the snapshot. Now that we have called handleRaftReady on all
-			// replicas, clear all remaining placeholders.
-			s.clearAllPlaceholders()
 			s.processRaftMu.Unlock()
 
 			s.metrics.RaftWorkingDurationNanos.Inc(timeutil.Since(workingStart).Nanoseconds())
@@ -2611,22 +2666,17 @@ func (s *Store) processRaft() {
 	})
 }
 
-func (s *Store) clearAllPlaceholders() {
+// getOrCreateReplica returns a replica for the given RangeID, creating an
+// uninitialized replica if necessary. The caller must not hold the store's
+// lock.
+func (s *Store) getOrCreateReplica(
+	rangeID roachpb.RangeID,
+	replicaID roachpb.ReplicaID,
+	creatingReplica roachpb.ReplicaDescriptor,
+) (*Replica, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	for rngID, res := range s.mu.replicaPlaceholders {
-		if s.mu.replicasByKey.Delete(res) == nil {
-			log.Fatalf(s.Ctx(), "%s: expected to find placeholder %s in replicasByKey", s, res)
-		}
-		delete(s.mu.replicaPlaceholders, rngID)
-	}
-}
-
-// getOrCreateReplicaLocked returns a replica for the given RangeID,
-// creating an uninitialized replica if necessary. The caller must
-// hold the store's lock.
-func (s *Store) getOrCreateReplicaLocked(rangeID roachpb.RangeID, replicaID roachpb.ReplicaID, creatingReplica roachpb.ReplicaDescriptor) (*Replica, error) {
 	r, ok := s.mu.replicas[rangeID]
 	if ok {
 		if err := r.setReplicaID(replicaID); err != nil {

--- a/storage/store.go
+++ b/storage/store.go
@@ -2636,31 +2636,16 @@ func (s *Store) processRaft() {
 				s.processRaftMu.Lock()
 				s.mu.Lock()
 				pendingReplicas = pendingReplicas[:0]
-				var raftLeaders, rangeLeaseHolders, rangeLeaseHoldersWithoutRaftLeadership int64
 
-				var info tickInfo
 				for id, r := range s.mu.replicas {
-					if err := r.tick(&info); err != nil {
+					if exists, err := r.tick(); err != nil {
 						log.Error(s.Ctx(), err)
-					} else if info.Exists {
+					} else if exists {
 						pendingReplicas = append(pendingReplicas, id)
-					}
-					if info.IsRangeLeaseHolder && !info.IsRaftLeader {
-						rangeLeaseHoldersWithoutRaftLeadership++
-					}
-					if info.IsRaftLeader {
-						raftLeaders++
-					}
-					if info.IsRangeLeaseHolder {
-						rangeLeaseHolders++
 					}
 				}
 
 				s.mu.Unlock()
-
-				s.metrics.RaftLeaders.Update(raftLeaders)
-				s.metrics.RangeLeaseHolders.Update(rangeLeaseHolders)
-				s.metrics.RangeLeaseHoldersWithoutRaftLeadership.Update(rangeLeaseHoldersWithoutRaftLeadership)
 				s.metrics.RaftTicks.Inc(1)
 
 				// Enqueue all pending ranges for readiness checks. Note that we could
@@ -2798,9 +2783,14 @@ func (s *Store) updateReplicationGauges() error {
 		return errors.Errorf("%s: system config not yet available", s)
 	}
 
-	var leaderRangeCount, replicatedRangeCount, replicationPendingRangeCount, availableRangeCount int64
+	var raftLeaderCount, leaseHolderCount, raftLeaderNotLeaseHolderCount, availableRangeCount,
+		replicaAllocatorNoopCount,
+		replicaAllocatorAddCount,
+		replicaAllocatorRemoveCount,
+		replicaAllocatorRemoveDeadCount int64
 
 	timestamp := s.ctx.Clock.Now()
+
 	s.mu.Lock()
 	for _, rng := range s.mu.replicas {
 		desc := rng.Desc()
@@ -2809,23 +2799,33 @@ func (s *Store) updateReplicationGauges() error {
 			log.Error(s.Ctx(), err)
 			continue
 		}
-		raftStatus := rng.RaftStatus()
 
+		rng.mu.Lock()
+		raftStatus := rng.raftStatusLocked()
+		lease := rng.mu.state.Lease
+		rng.mu.Unlock()
+
+		leaseCovers := lease.Covers(timestamp)
+		leaseOwned := lease.OwnedBy(s.Ident.StoreID)
+
+		// To avoid double counting, most stats are only counted on the raft
+		// leader. The lease holder count is the exception, which is counted by
+		// all replicas.
 		if raftStatus != nil && raftStatus.SoftState.RaftState == raft.StateLeader {
-			leaderRangeCount++
-			// TODO(bram): #4564 Compare attributes of the stores so we can
-			// track ranges that have enough replicas but still need to be
-			// migrated onto nodes with the desired attributes.
-			if len(raftStatus.Progress) >= len(zoneConfig.ReplicaAttrs) {
-				replicatedRangeCount++
-			}
+			raftLeaderCount++
 
-			// If any replica holds the range lease, the range is available.
-			if lease, _ := rng.getLease(); lease.Covers(timestamp) {
+			if leaseCovers {
+				// If any replica holds the range lease, the range is available.
 				availableRangeCount++
+
+				if leaseOwned {
+					leaseHolderCount++
+				} else {
+					raftLeaderNotLeaseHolderCount++
+				}
 			} else {
-				// If there is no range lease, then as long as more than 50%
-				// of the replicas are current then it is available.
+				// If there is no range lease, then as long as a majority of
+				// the replicas are current then it is available.
 				current := 0
 				for _, progress := range raftStatus.Progress {
 					if progress.Match == raftStatus.Applied {
@@ -2839,17 +2839,32 @@ func (s *Store) updateReplicationGauges() error {
 				}
 			}
 
-			if action, _ := s.allocator.ComputeAction(zoneConfig, desc); action != AllocatorNoop {
-				replicationPendingRangeCount++
+			switch action, _ := s.allocator.ComputeAction(zoneConfig, desc); action {
+			case AllocatorNoop:
+				replicaAllocatorNoopCount++
+			case AllocatorAdd:
+				replicaAllocatorAddCount++
+			case AllocatorRemove:
+				replicaAllocatorRemoveCount++
+			case AllocatorRemoveDead:
+				replicaAllocatorRemoveDeadCount++
 			}
+		} else if leaseCovers && leaseOwned {
+			leaseHolderCount++
 		}
 	}
 	s.mu.Unlock()
 
-	s.metrics.LeaderRangeCount.Update(leaderRangeCount)
-	s.metrics.ReplicatedRangeCount.Update(replicatedRangeCount)
-	s.metrics.ReplicationPendingRangeCount.Update(replicationPendingRangeCount)
+	s.metrics.RaftLeaderCount.Update(raftLeaderCount)
+	s.metrics.RaftLeaderNotLeaseHolderCount.Update(raftLeaderNotLeaseHolderCount)
+	s.metrics.LeaseHolderCount.Update(leaseHolderCount)
+
 	s.metrics.AvailableRangeCount.Update(availableRangeCount)
+
+	s.metrics.ReplicaAllocatorNoopCount.Update(replicaAllocatorNoopCount)
+	s.metrics.ReplicaAllocatorRemoveCount.Update(replicaAllocatorRemoveCount)
+	s.metrics.ReplicaAllocatorAddCount.Update(replicaAllocatorAddCount)
+	s.metrics.ReplicaAllocatorRemoveDeadCount.Update(replicaAllocatorRemoveDeadCount)
 
 	return nil
 }

--- a/storage/store.go
+++ b/storage/store.go
@@ -668,7 +668,7 @@ func NewStore(ctx StoreContext, eng engine.Engine, nodeDesc *roachpb.NodeDescrip
 
 // String formats a store for debug output.
 func (s *Store) String() string {
-	return fmt.Sprintf("store=%d:%d", s.Ident.NodeID, s.Ident.StoreID)
+	return fmt.Sprintf("[n%d,s%d]", s.Ident.NodeID, s.Ident.StoreID)
 }
 
 // Ctx returns the base context for the store.

--- a/storage/store.go
+++ b/storage/store.go
@@ -824,31 +824,40 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	// due to a split crashing halfway will simply be resolved on the
 	// next split attempt. They can otherwise be ignored.
 	s.mu.Lock()
+
+	// TODO(peter): While we have to iterate to find the replica descriptors
+	// serially, we can perform the migrations and replica creation
+	// concurrently. Note that while we can perform this initialization
+	// concurrently, all of the initialization must be performed before we start
+	// listening for Raft messages and starting the process Raft loop.
 	err = IterateRangeDescriptors(ctx, s.engine,
 		func(desc roachpb.RangeDescriptor) (bool, error) {
-			if _, ok := desc.GetReplicaDescriptor(s.StoreID()); !ok {
-				// We are no longer a member of the range, but we didn't GC
-				// the replica before shutting down. Destroy the replica now
-				// to avoid creating a new replica without a valid replica ID
-				// (which is necessary to have a non-nil raft group)
-				log.Infof(ctx, "eagerly destroying local data: %+v", desc)
-				return false, s.destroyReplicaData(&desc)
-			}
 			if !desc.IsInitialized() {
 				return false, errors.Errorf("found uninitialized RangeDescriptor: %+v", desc)
 			}
 			s.migrate(ctx, desc)
 
-			rng, err := NewReplica(&desc, s, 0)
+			rep, err := NewReplica(&desc, s, 0)
 			if err != nil {
 				return false, err
 			}
-			if err = s.addReplicaInternalLocked(rng); err != nil {
+			if err = s.addReplicaInternalLocked(rep); err != nil {
 				return false, err
 			}
 			// Add this range and its stats to our counter.
 			s.metrics.ReplicaCount.Inc(1)
-			s.metrics.addMVCCStats(rng.GetMVCCStats())
+			s.metrics.addMVCCStats(rep.GetMVCCStats())
+
+			if _, ok := desc.GetReplicaDescriptor(s.StoreID()); !ok {
+				// We are no longer a member of the range, but we didn't GC the replica
+				// before shutting down. Add the replica to the GC queue.
+				if added, err := s.replicaGCQueue.Add(rep, replicaGCPriorityRemoved); err != nil {
+					log.Errorf(ctx, "%s: unable to add replica to GC queue: %s", rep, err)
+				} else if added {
+					log.Infof(ctx, "%s: added to replica GC queue", rep)
+				}
+			}
+
 			// Note that we do not create raft groups at this time; they will be created
 			// on-demand the first time they are needed. This helps reduce the amount of
 			// election-related traffic in a cold start.

--- a/storage/store.go
+++ b/storage/store.go
@@ -2399,7 +2399,7 @@ func (s *Store) HandleRaftResponse(ctx context.Context, resp *RaftMessageRespons
 			rep, ok := s.mu.replicas[resp.RangeID]
 			s.mu.Unlock()
 			if ok {
-				if added, err := s.replicaGCQueue.Add(rep, 1.0); err != nil {
+				if added, err := s.replicaGCQueue.Add(rep, replicaGCPriorityRemoved); err != nil {
 					log.Errorf(ctx, "%s: unable to add replica %d to GC queue: %s", rep, resp.ToReplica, err)
 				} else if added {
 					log.Infof(ctx, "%s: replica %s too old, added to replica GC queue", rep, resp.ToReplica)

--- a/storage/store.go
+++ b/storage/store.go
@@ -1706,9 +1706,18 @@ func (s *Store) removeReplicaImpl(rep *Replica, origDesc roachpb.RangeDescriptor
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if _, ok := s.mu.replicas[rep.RangeID]; !ok {
+		return errors.New("replica not found")
+	}
+
 	delete(s.mu.replicas, rep.RangeID)
 	if s.mu.replicasByKey.Delete(rep) == nil {
-		return errors.Errorf("couldn't find range in replicasByKey btree")
+		// This is a fatal error because returning at this point will
+		// leave the Store in an inconsistent state (we've already deleted
+		// from s.mu.replicas), and uninitialized replicas shouldn't make
+		// it this far anyway. This method will need some changes when we
+		// introduce GC of uninitialized replicas.
+		log.Fatalf(context.TODO(), "replica %s found by id but not by key", rep)
 	}
 	s.scanner.RemoveReplica(rep)
 	s.consistencyScanner.RemoveReplica(rep)

--- a/storage/store.go
+++ b/storage/store.go
@@ -1871,7 +1871,7 @@ func (s *Store) Metrics() *StoreMetrics {
 func (s *Store) MVCCStats() enginepb.MVCCStats {
 	s.metrics.mu.Lock()
 	defer s.metrics.mu.Unlock()
-	return s.metrics.stats
+	return s.metrics.mu.stats
 }
 
 // Descriptor returns a StoreDescriptor including current store

--- a/storage/store_metrics.go
+++ b/storage/store_metrics.go
@@ -241,8 +241,10 @@ type StoreMetrics struct {
 	RangeLeaseHoldersWithoutRaftLeadership *metric.Gauge
 
 	// Stats for efficient merges.
-	mu    syncutil.Mutex
-	stats enginepb.MVCCStats
+	mu struct {
+		syncutil.Mutex
+		stats enginepb.MVCCStats
+	}
 }
 
 func newStoreMetrics() *StoreMetrics {
@@ -345,19 +347,19 @@ func newStoreMetrics() *StoreMetrics {
 // snapshot of these gauges in the registry might mix the values of two
 // subsequent updates.
 func (sm *StoreMetrics) updateMVCCGaugesLocked() {
-	sm.LiveBytes.Update(sm.stats.LiveBytes)
-	sm.KeyBytes.Update(sm.stats.KeyBytes)
-	sm.ValBytes.Update(sm.stats.ValBytes)
-	sm.IntentBytes.Update(sm.stats.IntentBytes)
-	sm.LiveCount.Update(sm.stats.LiveCount)
-	sm.KeyCount.Update(sm.stats.KeyCount)
-	sm.ValCount.Update(sm.stats.ValCount)
-	sm.IntentCount.Update(sm.stats.IntentCount)
-	sm.IntentAge.Update(sm.stats.IntentAge)
-	sm.GcBytesAge.Update(sm.stats.GCBytesAge)
-	sm.LastUpdateNanos.Update(sm.stats.LastUpdateNanos)
-	sm.SysBytes.Update(sm.stats.SysBytes)
-	sm.SysCount.Update(sm.stats.SysCount)
+	sm.LiveBytes.Update(sm.mu.stats.LiveBytes)
+	sm.KeyBytes.Update(sm.mu.stats.KeyBytes)
+	sm.ValBytes.Update(sm.mu.stats.ValBytes)
+	sm.IntentBytes.Update(sm.mu.stats.IntentBytes)
+	sm.LiveCount.Update(sm.mu.stats.LiveCount)
+	sm.KeyCount.Update(sm.mu.stats.KeyCount)
+	sm.ValCount.Update(sm.mu.stats.ValCount)
+	sm.IntentCount.Update(sm.mu.stats.IntentCount)
+	sm.IntentAge.Update(sm.mu.stats.IntentAge)
+	sm.GcBytesAge.Update(sm.mu.stats.GCBytesAge)
+	sm.LastUpdateNanos.Update(sm.mu.stats.LastUpdateNanos)
+	sm.SysBytes.Update(sm.mu.stats.SysBytes)
+	sm.SysCount.Update(sm.mu.stats.SysCount)
 }
 
 func (sm *StoreMetrics) updateCapacityGauges(capacity roachpb.StoreCapacity) {
@@ -379,14 +381,14 @@ func (sm *StoreMetrics) updateReplicationGauges(leaders, replicated, pending, av
 func (sm *StoreMetrics) addMVCCStats(stats enginepb.MVCCStats) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
-	sm.stats.Add(stats)
+	sm.mu.stats.Add(stats)
 	sm.updateMVCCGaugesLocked()
 }
 
 func (sm *StoreMetrics) subtractMVCCStats(stats enginepb.MVCCStats) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
-	sm.stats.Subtract(stats)
+	sm.mu.stats.Subtract(stats)
 	sm.updateMVCCGaugesLocked()
 }
 

--- a/storage/store_metrics.go
+++ b/storage/store_metrics.go
@@ -17,7 +17,6 @@
 package storage
 
 import (
-	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/util/metric"
@@ -360,22 +359,6 @@ func (sm *StoreMetrics) updateMVCCGaugesLocked() {
 	sm.LastUpdateNanos.Update(sm.mu.stats.LastUpdateNanos)
 	sm.SysBytes.Update(sm.mu.stats.SysBytes)
 	sm.SysCount.Update(sm.mu.stats.SysCount)
-}
-
-func (sm *StoreMetrics) updateCapacityGauges(capacity roachpb.StoreCapacity) {
-	sm.mu.Lock()
-	defer sm.mu.Unlock()
-	sm.Capacity.Update(capacity.Capacity)
-	sm.Available.Update(capacity.Available)
-}
-
-func (sm *StoreMetrics) updateReplicationGauges(leaders, replicated, pending, available int64) {
-	sm.mu.Lock()
-	defer sm.mu.Unlock()
-	sm.LeaderRangeCount.Update(leaders)
-	sm.ReplicatedRangeCount.Update(replicated)
-	sm.ReplicationPendingRangeCount.Update(pending)
-	sm.AvailableRangeCount.Update(available)
 }
 
 func (sm *StoreMetrics) addMVCCStats(stats enginepb.MVCCStats) {

--- a/storage/store_metrics.go
+++ b/storage/store_metrics.go
@@ -31,7 +31,7 @@ var (
 	metaRaftLeaderCount               = metric.Metadata{Name: "replicas.leaders"}
 	metaRaftLeaderNotLeaseHolderCount = metric.Metadata{
 		Name: "replicas.leaders_not_leaseholders",
-		Help: "Total number of Replicas on this store that are Raft leaders but not Range lease holders.",
+		Help: "Total number of Replicas that are Raft leaders whose Range lease is held by another store.",
 	}
 	metaLeaseHolderCount = metric.Metadata{Name: "replicas.leaseholders"}
 

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/uuid"
 	"github.com/coreos/etcd/raft"
+	"github.com/coreos/etcd/raft/raftpb"
 	"github.com/pkg/errors"
 )
 
@@ -2201,8 +2202,8 @@ func TestStoreRangePlaceholders(t *testing.T) {
 	}
 
 	// Test that simple deletion works.
-	if err := s.removePlaceholderLocked(placeholder1.rangeDesc.RangeID); err != nil {
-		t.Fatalf("could not remove placeholder that was present, got %s", err)
+	if !s.removePlaceholderLocked(placeholder1.rangeDesc.RangeID) {
+		t.Fatalf("could not remove placeholder that was present")
 	}
 
 	// Test cannot double insert the same placeholder.
@@ -2214,11 +2215,11 @@ func TestStoreRangePlaceholders(t *testing.T) {
 	}
 
 	// Test cannot double delete a placeholder.
-	if err := s.removePlaceholderLocked(placeholder1.rangeDesc.RangeID); err != nil {
-		t.Fatalf("could not remove placeholder that was present, got %s", err)
+	if !s.removePlaceholderLocked(placeholder1.rangeDesc.RangeID) {
+		t.Fatalf("could not remove placeholder that was present")
 	}
-	if err := s.removePlaceholderLocked(placeholder1.rangeDesc.RangeID); !testutils.IsError(err, "cannot remove placeholder for RangeID \\d+; Placeholder doesn't exist") {
-		t.Fatalf("could not remove placeholder that was present, got %v", err)
+	if s.removePlaceholderLocked(placeholder1.rangeDesc.RangeID) {
+		t.Fatalf("successfully removed placeholder that was not present")
 	}
 
 	// This placeholder overlaps with an existing replica.
@@ -2236,7 +2237,152 @@ func TestStoreRangePlaceholders(t *testing.T) {
 	}
 
 	// Test that Placeholder deletion doesn't delete replicas.
-	if err := s.removePlaceholderLocked(repID); !testutils.IsError(err, "cannot remove placeholder for RangeID \\d+; Placeholder doesn't exist") {
-		t.Fatalf("should not be able to process removeReplicaPlaceholder for a RangeID where a Replica exists, got: %v", err)
+	if s.removePlaceholderLocked(repID) {
+		t.Fatalf("should not be able to process removeReplicaPlaceholder for a RangeID where a Replica exists")
+	}
+}
+
+// Test that we remove snapshot placeholders on error conditions.
+func TestStoreRemovePlaceholderOnError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	tc := testContext{}
+	tc.Start(t)
+	defer tc.Stop()
+	s := tc.store
+	ctx := context.Background()
+
+	// Clobber the existing range so we can test nonoverlapping placeholders.
+	rng1, err := s.GetReplica(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RemoveReplica(rng1, *rng1.Desc(), true); err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate a minimal fake snapshot.
+	snapData := &roachpb.RaftSnapshotData{
+		RangeDescriptor: *rng1.Desc(),
+	}
+	data, err := protoutil.Marshal(snapData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wrap the snapshot in a minimal request. The request will error because the
+	// replica tombstone for the range requires that a new replica have an ID
+	// greater than 1.
+	req := &RaftMessageRequest{
+		RangeID: 1,
+		ToReplica: roachpb.ReplicaDescriptor{
+			NodeID:    1,
+			StoreID:   1,
+			ReplicaID: 1,
+		},
+		FromReplica: roachpb.ReplicaDescriptor{
+			NodeID:    2,
+			StoreID:   2,
+			ReplicaID: 2,
+		},
+		Message: raftpb.Message{
+			Type: raftpb.MsgSnap,
+			Snapshot: raftpb.Snapshot{
+				Data: data,
+			},
+		},
+	}
+	const expected = "raft group deleted"
+	if err := s.HandleRaftRequest(ctx, req); !testutils.IsError(errors.Errorf("%s", err), expected) {
+		t.Fatalf("expected %s, but found %v", expected, err)
+	}
+
+	s.mu.Lock()
+	numPlaceholders := len(s.mu.replicaPlaceholders)
+	s.mu.Unlock()
+
+	if numPlaceholders != 0 {
+		t.Fatalf("expected 0 placeholders, but found %d", numPlaceholders)
+	}
+	if n := atomic.LoadInt32(&s.counts.removedPlaceholders); n != 1 {
+		t.Fatalf("expected 1 removed placeholder, but found %d", n)
+	}
+}
+
+// Test that we remove snapshot placeholders when raft ignores the
+// snapshot. This is testing the removal of placeholder after handleRaftReady
+// processing for an unitialized Replica.
+func TestStoreRemovePlaceholderOnRaftIgnored(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	tc := testContext{}
+	tc.Start(t)
+	defer tc.Stop()
+	s := tc.store
+	ctx := context.Background()
+
+	// Clobber the existing range so we can test nonoverlapping placeholders.
+	rng1, err := s.GetReplica(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RemoveReplica(rng1, *rng1.Desc(), true); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := writeInitialState(ctx, s.Engine(), enginepb.MVCCStats{}, *rng1.Desc()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate a minimal fake snapshot.
+	snapData := &roachpb.RaftSnapshotData{
+		RangeDescriptor: *rng1.Desc(),
+	}
+	data, err := protoutil.Marshal(snapData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wrap the snapshot in a minimal request. The request will be dropped
+	// because the Raft log index and term are less than the hard state written
+	// above.
+	req := &RaftMessageRequest{
+		RangeID: 1,
+		ToReplica: roachpb.ReplicaDescriptor{
+			NodeID:    1,
+			StoreID:   1,
+			ReplicaID: 2,
+		},
+		FromReplica: roachpb.ReplicaDescriptor{
+			NodeID:    2,
+			StoreID:   2,
+			ReplicaID: 2,
+		},
+		Message: raftpb.Message{
+			Type: raftpb.MsgSnap,
+			Snapshot: raftpb.Snapshot{
+				Data: data,
+				Metadata: raftpb.SnapshotMetadata{
+					Index: 1,
+					Term:  1,
+				},
+			},
+		},
+	}
+	if err := s.HandleRaftRequest(ctx, req); err != nil {
+		t.Fatal(err)
+	}
+
+	util.SucceedsSoon(t, func() error {
+		s.mu.Lock()
+		numPlaceholders := len(s.mu.replicaPlaceholders)
+		s.mu.Unlock()
+
+		if numPlaceholders == 0 {
+			return nil
+		}
+		return errors.Errorf("expected 0 placeholders, but found %d", numPlaceholders)
+	})
+
+	if n := atomic.LoadInt32(&s.counts.droppedPlaceholders); n != 1 {
+		t.Fatalf("expected 1 dropped placeholder, but found %d", n)
 	}
 }

--- a/storage/timestamp_cache.go
+++ b/storage/timestamp_cache.go
@@ -141,7 +141,6 @@ func newTimestampCache(clock *hlc.Clock) *timestampCache {
 	tc := &timestampCache{
 		rCache:                cache.NewIntervalCache(cache.Config{Policy: cache.CacheFIFO}),
 		wCache:                cache.NewIntervalCache(cache.Config{Policy: cache.CacheFIFO}),
-		requests:              btree.New(btreeDegree),
 		evictionSizeThreshold: defaultEvictionSizeThreshold,
 	}
 	tc.Clear(clock)
@@ -153,6 +152,7 @@ func newTimestampCache(clock *hlc.Clock) *timestampCache {
 // Clear clears the cache and resets the low water mark to the
 // current time plus the maximum clock offset.
 func (tc *timestampCache) Clear(clock *hlc.Clock) {
+	tc.requests = btree.New(btreeDegree)
 	tc.rCache.Clear()
 	tc.wCache.Clear()
 	tc.lowWater = clock.Now()

--- a/testutils/testcluster/testcluster.go
+++ b/testutils/testcluster/testcluster.go
@@ -479,7 +479,7 @@ func (tc *TestCluster) WaitForFullReplication() error {
 				if err := s.ComputeMetrics(0); err != nil {
 					return err
 				}
-				if s.Metrics().ReplicationPendingRangeCount.Value() > 0 {
+				if s.Metrics().ReplicaAllocatorAddCount.Value() > 0 {
 					notReplicated = true
 				}
 				return nil

--- a/ts/query.go
+++ b/ts/query.go
@@ -515,6 +515,11 @@ func (db *DB) Query(query tspb.Query, r Resolution, startNanos, endNanos int64) 
 	// unionIterator at each offset encountered. If the query is requesting a
 	// derivative, a rate of change is recorded instead of the actual values.
 	iters.init()
+	if !iters.isValid() {
+		// We have no data to return.
+		return nil, sources, nil
+	}
+
 	var last tspb.TimeSeriesDatapoint
 	if isDerivative {
 		last = tspb.TimeSeriesDatapoint{

--- a/ts/query_test.go
+++ b/ts/query_test.go
@@ -317,6 +317,13 @@ func (tm *testModel) assertQuery(
 		}
 	}
 
+	// Verify that expected sources match actual sources.
+	sort.Strings(expectedSources)
+	sort.Strings(actualSources)
+	if !reflect.DeepEqual(actualSources, expectedSources) {
+		tm.t.Error(errors.Errorf("actual source list: %v, expected: %v", actualSources, expectedSources))
+	}
+
 	// Iterate over data in all dataSpans and construct expected datapoints.
 	var startOffset int32
 	isDerivative := q.GetDerivative() != tspb.TimeSeriesQueryDerivative_NONE
@@ -333,6 +340,12 @@ func (tm *testModel) assertQuery(
 	}
 
 	iters.init()
+	if !iters.isValid() {
+		if a, e := 0, len(expectedDatapoints); a != e {
+			tm.t.Error(errors.Errorf("query had zero datapoints, expected: %v", expectedDatapoints))
+		}
+		return
+	}
 	currentVal := func() tspb.TimeSeriesDatapoint {
 		var value float64
 		switch q.GetSourceAggregator() {
@@ -380,11 +393,6 @@ func (tm *testModel) assertQuery(
 		iters.advance()
 	}
 
-	sort.Strings(expectedSources)
-	sort.Strings(actualSources)
-	if !reflect.DeepEqual(actualSources, expectedSources) {
-		tm.t.Error(errors.Errorf("actual source list: %v, expected: %v", actualSources, expectedSources))
-	}
 	if !reflect.DeepEqual(actualDatapoints, expectedDatapoints) {
 		tm.t.Error(errors.Errorf("actual datapoints: %v, expected: %v", actualDatapoints, expectedDatapoints))
 	}
@@ -457,8 +465,37 @@ func TestQuery(t *testing.T) {
 	// Test with everything specified.
 	tm.assertQuery("test.multimetric", nil, tspb.TimeSeriesQueryAggregator_MIN.Enum(), tspb.TimeSeriesQueryAggregator_MAX.Enum(),
 		tspb.TimeSeriesQueryDerivative_NON_NEGATIVE_DERIVATIVE.Enum(), resolution1ns, 0, 90, 8, 2)
-	// Test query that returns no data.
-	tm.assertQuery("nodata", nil, nil, nil, nil, resolution1ns, 0, 90, 0, 0)
+
+	// Test queries that return no data. Check with every
+	// aggregator/downsampler/derivative combination. This situation is
+	// particularly prone to nil panics (parts of the query system will not have
+	// data).
+	aggs := []tspb.TimeSeriesQueryAggregator{
+		tspb.TimeSeriesQueryAggregator_MIN, tspb.TimeSeriesQueryAggregator_MAX,
+		tspb.TimeSeriesQueryAggregator_AVG, tspb.TimeSeriesQueryAggregator_SUM,
+	}
+	derivs := []tspb.TimeSeriesQueryDerivative{
+		tspb.TimeSeriesQueryDerivative_NONE, tspb.TimeSeriesQueryDerivative_DERIVATIVE,
+		tspb.TimeSeriesQueryDerivative_NON_NEGATIVE_DERIVATIVE,
+	}
+	for _, downsampler := range aggs {
+		for _, agg := range aggs {
+			for _, deriv := range derivs {
+				tm.assertQuery(
+					"nodata",
+					nil,
+					downsampler.Enum(),
+					agg.Enum(),
+					deriv.Enum(),
+					resolution1ns,
+					0,
+					90,
+					0,
+					0,
+				)
+			}
+		}
+	}
 
 	// Verify querying specific sources, thus excluding other available sources
 	// in the same time period.

--- a/ui/app/containers/nodeGraphs.tsx
+++ b/ui/app/containers/nodeGraphs.tsx
@@ -240,11 +240,11 @@ export default class extends React.Component<IInjectedProps, {}> {
               </Axis>
             </LineGraph>
 
-            <LineGraph title="Raft Leaders and LeaseHolders" sources={sources}>
+            <LineGraph title="Replicas: Raft leaders and Range Lease holders" sources={sources}>
               <Axis format={ d3.format(".1f") }>
-                <Metric name="cr.store.raft.leaders" title="Ranges on this Store that are Raft Leaders" />
-                <Metric name="cr.store.range.leaseholders" title="Ranges on this Store that are Raft LeaseHolders" />
-                <Metric name="cr.store.range.leaseholders.without.leadership" title="Ranges on this Store that are Raft LeaseHolders but aren't Raft Leaders" />
+                <Metric name="cr.store.replicas.leaders" title="Leaders" />
+                <Metric name="cr.store.replicas.leaseholders" title="Lease Holders" />
+                <Metric name="cr.store.replicas.leaders_not_leaseholders" title="Leaders w/o Lease" />
               </Axis>
             </LineGraph>
 

--- a/ui/app/containers/nodeOverview.tsx
+++ b/ui/app/containers/nodeOverview.tsx
@@ -76,14 +76,14 @@ class NodeOverview extends React.Component<NodeOverviewProps, {}> {
                         title="Total Replicas"
                         valueFn={(metrics) => metrics.get(MetricConstants.replicas).toString()} />
               <TableRow data={node}
-                        title="Leader Ranges"
-                        valueFn={(metrics) => metrics.get(MetricConstants.leaderRanges).toString()} />
+                        title="Raft Leaders"
+                        valueFn={(metrics) => metrics.get(MetricConstants.raftLeaders).toString()} />
               <TableRow data={node}
                         title="Available"
-                        valueFn={(metrics) => Percentage(metrics.get(MetricConstants.availableRanges), metrics.get(MetricConstants.leaderRanges))} />
+                        valueFn={(metrics) => Percentage(metrics.get(MetricConstants.availableRanges), metrics.get(MetricConstants.raftLeaders))} />
               <TableRow data={node}
                         title="Fully Replicated"
-                        valueFn={(metrics) => Percentage(metrics.get(MetricConstants.replicatedRanges), metrics.get(MetricConstants.leaderRanges))} />
+                        valueFn={(metrics) => Percentage(metrics.get(MetricConstants.replicatedRanges), metrics.get(MetricConstants.raftLeaders))} />
               <TableRow data={node}
                         title="Available Capacity"
                         valueFn={(metrics) => Bytes(metrics.get(MetricConstants.availableCapacity))} />

--- a/ui/app/util/proto.ts
+++ b/ui/app/util/proto.ts
@@ -37,32 +37,33 @@ export function RollupStoreMetrics(ns: NodeStatus): void {
  */
 export namespace MetricConstants {
   // Store level metrics.
-  export var replicas: string = "replicas";
-  export var leaderRanges: string = "ranges.leader";
-  export var replicatedRanges: string = "ranges.replicated";
-  export var availableRanges: string = "ranges.available";
-  export var liveBytes: string = "livebytes";
-  export var keyBytes: string = "keybytes";
-  export var valBytes: string = "valbytes";
-  export var intentBytes: string = "intentbytes";
-  export var liveCount: string = "livecount";
-  export var keyCount: string = "keycount";
-  export var valCount: string = "valcount";
-  export var intentCount: string = "intentcount";
-  export var intentAge: string = "intentage";
-  export var gcBytesAge: string = "gcbytesage";
-  export var lastUpdateNano: string = "lastupdatenanos";
-  export var capacity: string = "capacity";
-  export var availableCapacity: string = "capacity.available";
-  export var sysBytes: string = "sysbytes";
-  export var sysCount: string = "syscount";
+  export const replicas: string = "replicas";
+  export const raftLeaders: string = "replicas.leaders";
+  export const leaseHolders: string = "replicas.leaseholders";
+  export const availableRanges: string = "ranges.available";
+  export const replicatedRanges: string  = "ranges.allocator.noop";
+  export const liveBytes: string = "livebytes";
+  export const keyBytes: string = "keybytes";
+  export const valBytes: string = "valbytes";
+  export const intentBytes: string = "intentbytes";
+  export const liveCount: string = "livecount";
+  export const keyCount: string = "keycount";
+  export const valCount: string = "valcount";
+  export const intentCount: string = "intentcount";
+  export const intentAge: string = "intentage";
+  export const gcBytesAge: string = "gcbytesage";
+  export const lastUpdateNano: string = "lastupdatenanos";
+  export const capacity: string = "capacity";
+  export const availableCapacity: string = "capacity.available";
+  export const sysBytes: string = "sysbytes";
+  export const sysCount: string = "syscount";
 
   // Node level metrics.
-  export var userCPUPercent: string = "sys.cpu.user.percent";
-  export var sysCPUPercent: string = "sys.cpu.sys.percent";
-  export var allocBytes: string = "sys.go.allocbytes";
-  export var sqlConns: string = "sql.conns";
-  export var rss: string = "sys.rss";
+  export const userCPUPercent: string = "sys.cpu.user.percent";
+  export const sysCPUPercent: string = "sys.cpu.sys.percent";
+  export const allocBytes: string = "sys.go.allocbytes";
+  export const sqlConns: string = "sql.conns";
+  export const rss: string = "sys.rss";
 }
 
 /**

--- a/util/envutil/env.go
+++ b/util/envutil/env.go
@@ -97,7 +97,7 @@ func ClearEnvCache() {
 
 // GetEnvReport dumps all configuration variables that may have been
 // used and their value.
-func GetEnvReport() string {
+func GetEnvReport(presentOnly bool) string {
 	envVarRegistry.mu.Lock()
 	defer envVarRegistry.mu.Unlock()
 
@@ -105,7 +105,7 @@ func GetEnvReport() string {
 	for k, v := range envVarRegistry.cache {
 		if v.present {
 			fmt.Fprintf(&b, "%s = %s # %s\n", k, v.value, v.consumer)
-		} else {
+		} else if !presentOnly {
 			fmt.Fprintf(&b, "# %s is not set (read from %s)\n", k, v.consumer)
 		}
 	}


### PR DESCRIPTION
`git diff -w --patience`:

``` diff
commit a35586fb5e37c6b459f42287968e1911e1e7a0ed
Merge: d63b41e 9e38b02
Author: Tamir Duberstein <tamird@gmail.com>
Date:   Tue Sep 6 09:59:34 2016 -0400

    Merge branch 'master' into develop

diff --cc acceptance/cluster/localcluster.go
index f4ef640,e45959c..3bea7a2
--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@@ -44,8 -44,10 +44,9 @@@ import 
    roachClient "github.com/cockroachdb/cockroach/internal/client"
    "github.com/cockroachdb/cockroach/rpc"
    "github.com/cockroachdb/cockroach/security"
 -  "github.com/cockroachdb/cockroach/server"
    "github.com/cockroachdb/cockroach/util"
    "github.com/cockroachdb/cockroach/util/log"
+   "github.com/cockroachdb/cockroach/util/log/logflags"
    "github.com/cockroachdb/cockroach/util/stop"
    "github.com/cockroachdb/cockroach/util/syncutil"
    "github.com/cockroachdb/cockroach/util/timeutil"
@@@ -460,8 -462,14 +461,14 @@@ func (l *LocalCluster) startNode(node *
        "--verbosity=1",
    }

+   // Forward the vmodule flag to the nodes.
+   vmoduleFlag := flag.Lookup(logflags.VModuleName)
+   if vmoduleFlag.Value.String() != "" {
+       cmd = append(cmd, fmt.Sprintf("--%s=%s", vmoduleFlag.Name, vmoduleFlag.Value.String()))
+   }
+ 
    for _, store := range node.stores {
 -      storeSpec := server.StoreSpec{
 +      storeSpec := base.StoreSpec{
            Path:        store.dataStr,
            SizeInBytes: int64(store.config.MaxRanges) * maxRangeBytes,
        }
diff --cc sql/create.go
index 53db146,7e3c581..ac2b309
--- a/sql/create.go
+++ b/sql/create.go
@@@ -387,9 -332,9 +387,9 @@@ func (n *createTableNode) Start() erro
        }
    }

 -  id, err := n.p.generateUniqueDescID()
 +  id, err := generateUniqueDescID(n.p.txn)
    if err != nil {
-       return nil
+       return err
    }
    desc.SetID(id)

diff --cc sql/parser/sql.go
index 0a6259f,30ba034..e0c2053
Binary files differ
diff --cc storage/replica.go
index a201370,02ff918..15a3a04
--- a/storage/replica.go
+++ b/storage/replica.go
@@@ -1624,26 -1582,8 +1628,8 @@@ func defaultProposeRaftCommandLocked(r 
    })
  }

- func (r *Replica) isRangeLeaseHolderLocked() bool {
-   lease := r.mu.state.Lease
-   if lease == nil {
-       return false
-   }
-   timestamp := r.store.Clock().Now()
-   if lease.Covers(timestamp) {
-       if lease.OwnedBy(r.store.Ident.StoreID) {
-           return true
-       }
-   }
-   return false
- }
- 
- func (r *Replica) isRaftLeaderLocked() bool {
-   return r.mu.leaderID == r.mu.replicaID
- }
- 
  func (r *Replica) handleRaftReady() error {
 -  ctx := r.ctx
 +  ctx := context.TODO()
    var hasReady bool
    var rd raft.Ready
    r.mu.Lock()
diff --cc storage/store.go
index a6f656d,58068e0..e08ef82
--- a/storage/store.go
+++ b/storage/store.go
@@@ -2369,10 -2434,10 +2437,10 @@@ func (s *Store) HandleRaftRequest
            // happen, at some point the Replica GC queue will have to grab it.
        }
        // We disallow non-snapshot messages to replica ID 0. Note that
-       // getOrCreateReplicaLocked disallows moving the replica ID backward, so
-       // the only way we can get here is if the replica did not previously exist.
+       // getOrCreateReplica disallows moving the replica ID backward, so the only
+       // way we can get here is if the replica did not previously exist.
        if log.V(1) {
 -          log.Infof(s.Ctx(), "refusing incoming Raft message %s for range %d from %+v to %+v",
 +          log.Infof(ctx, "refusing incoming Raft message %s for range %d from %+v to %+v",
                req.Message.Type, req.RangeID, req.FromReplica, req.ToReplica)
        }
        return roachpb.NewErrorf("cannot recreate replica that is not a member of its range (StoreID %s not found in range %d)",
diff --cc ts/query.go
index 7511a78,cb1b13b..c8eb42e
--- a/ts/query.go
+++ b/ts/query.go
@@@ -795,10 -512,14 +795,15 @@@ func (db *DB) Query
    }

    // Iterate over all requested offsets, recording a value from the
 -  // unionIterator at each offset encountered. If the query is requesting a
 -  // derivative, a rate of change is recorded instead of the actual values.
 +  // aggregatingIterator at each offset encountered. If the query is
 +  // requesting a derivative, a rate of change is recorded instead of the
 +  // actual values.
    iters.init()
+   if !iters.isValid() {
+       // We have no data to return.
+       return nil, sources, nil
+   }
+ 
    var last tspb.TimeSeriesDatapoint
    if isDerivative {
        last = tspb.TimeSeriesDatapoint{
diff --cc ts/query_test.go
index 3cbd854,93aaae9..c961654
--- a/ts/query_test.go
+++ b/ts/query_test.go
@@@ -830,21 -452,50 +838,51 @@@ func TestQuery(t *testing.T) 
    tm.assertModelCorrect()

    // Test default query: avg downsampler, sum aggregator, no derivative.
 -  tm.assertQuery("test.multimetric", nil, nil, nil, nil, resolution1ns, 0, 90, 8, 2)
 +  tm.assertQuery("test.multimetric", nil, nil, nil, nil, resolution1ns, 1, 0, 90, 8, 2)
    // Test with aggregator specified.
    tm.assertQuery("test.multimetric", nil, tspb.TimeSeriesQueryAggregator_MAX.Enum(), nil, nil,
 -      resolution1ns, 0, 90, 8, 2)
 +      resolution1ns, 1, 0, 90, 8, 2)
    // Test with aggregator and downsampler.
    tm.assertQuery("test.multimetric", nil, tspb.TimeSeriesQueryAggregator_MAX.Enum(), tspb.TimeSeriesQueryAggregator_AVG.Enum(), nil,
 -      resolution1ns, 0, 90, 8, 2)
 +      resolution1ns, 1, 0, 90, 8, 2)
    // Test with derivative specified.
    tm.assertQuery("test.multimetric", nil, tspb.TimeSeriesQueryAggregator_AVG.Enum(), nil,
 -      tspb.TimeSeriesQueryDerivative_DERIVATIVE.Enum(), resolution1ns, 0, 90, 8, 2)
 +      tspb.TimeSeriesQueryDerivative_DERIVATIVE.Enum(), resolution1ns, 1, 0, 90, 8, 2)
    // Test with everything specified.
    tm.assertQuery("test.multimetric", nil, tspb.TimeSeriesQueryAggregator_MIN.Enum(), tspb.TimeSeriesQueryAggregator_MAX.Enum(),
 -      tspb.TimeSeriesQueryDerivative_NON_NEGATIVE_DERIVATIVE.Enum(), resolution1ns, 0, 90, 8, 2)
 +      tspb.TimeSeriesQueryDerivative_NON_NEGATIVE_DERIVATIVE.Enum(), resolution1ns, 1, 0, 90, 8, 2)
-   // Test query that returns no data.
-   tm.assertQuery("nodata", nil, nil, nil, nil, resolution1ns, 1, 0, 90, 0, 0)
+ 
+   // Test queries that return no data. Check with every
+   // aggregator/downsampler/derivative combination. This situation is
+   // particularly prone to nil panics (parts of the query system will not have
+   // data).
+   aggs := []tspb.TimeSeriesQueryAggregator{
+       tspb.TimeSeriesQueryAggregator_MIN, tspb.TimeSeriesQueryAggregator_MAX,
+       tspb.TimeSeriesQueryAggregator_AVG, tspb.TimeSeriesQueryAggregator_SUM,
+   }
+   derivs := []tspb.TimeSeriesQueryDerivative{
+       tspb.TimeSeriesQueryDerivative_NONE, tspb.TimeSeriesQueryDerivative_DERIVATIVE,
+       tspb.TimeSeriesQueryDerivative_NON_NEGATIVE_DERIVATIVE,
+   }
+   for _, downsampler := range aggs {
+       for _, agg := range aggs {
+           for _, deriv := range derivs {
+               tm.assertQuery(
+                   "nodata",
+                   nil,
+                   downsampler.Enum(),
+                   agg.Enum(),
+                   deriv.Enum(),
+                   resolution1ns,
++                  1,
+                   0,
+                   90,
+                   0,
+                   0,
+               )
+           }
+       }
+   }

    // Verify querying specific sources, thus excluding other available sources
    // in the same time period.
diff --cc ui/embedded.go
index cb141a0,513f3d0..859b508
Binary files differ

```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9121)

<!-- Reviewable:end -->
