### PR TITLE
sql: retry on split failures during SPLIT AT

### DIFF
--- a/cmd/zerosum/main.go
+++ b/cmd/zerosum/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach-go/crdb"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/syncutil"
@@ -223,7 +224,7 @@ func (z *zeroSum) monkey(tableID uint32, d time.Duration) {
 		case 0:
 			if err := z.split(z.randNode(r.Intn), key); err != nil {
 				if strings.Contains(err.Error(), "range is already split at key") ||
-					strings.Contains(err.Error(), "conflict updating range descriptors") {
+					strings.Contains(err.Error(), storage.ErrMsgConflictUpdatingRangeDesc) {
 					continue
 				}
 				z.maybeLogError(err)

--- a/sql/split_at_test.go
+++ b/sql/split_at_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/testutils/sqlutils"
-	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
@@ -115,19 +114,10 @@ func TestSplitAt(t *testing.T) {
 		},
 	}
 
-	for i, tt := range tests {
+	for _, tt := range tests {
 		var key roachpb.Key
 		var pretty string
-		var err error
-		if i == 0 {
-			// After the CREATE TABLE, a SPLIT will sometimes fail with "conflict updating
-			// range descriptors". So the first test can retry a few times.
-			util.SucceedsSoon(t, func() error {
-				return db.QueryRow(tt.in, tt.args...).Scan(&key, &pretty)
-			})
-		} else {
-			err = db.QueryRow(tt.in, tt.args...).Scan(&key, &pretty)
-		}
+		err := db.QueryRow(tt.in, tt.args...).Scan(&key, &pretty)
 		if err != nil && tt.error == "" {
 			t.Fatalf("%s: unexpected error: %s", tt.in, err)
 		} else if tt.error != "" && err == nil {

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -300,7 +300,7 @@ func TestStoreRangeSplitConcurrent(t *testing.T) {
 			// concurrently, the range is already split at the specified key or the
 			// split key is outside of the bounds for the range.
 			expected := strings.Join([]string{
-				"conflict updating range descriptors",
+				storage.ErrMsgConflictUpdatingRangeDesc,
 				"range is already split at key",
 				"key range .* outside of bounds of range",
 			}, "|")

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -49,6 +49,11 @@ import (
 
 var errTransactionUnsupported = errors.New("not supported within a transaction")
 
+// ErrMsgConflictUpdatingRangeDesc is an error message that is returned by
+// AdminSplit when it conflicts with some other process that updates range
+// descriptors.
+const ErrMsgConflictUpdatingRangeDesc = "conflict updating range descriptors"
+
 // executeCmd switches over the method and multiplexes to execute the appropriate storage API
 // command. It returns the response, an error, and a post commit trigger which
 // may be actionable even in the case of an error.
@@ -2211,7 +2216,7 @@ func (r *Replica) AdminSplit(
 		}
 		if err := txn.Run(b); err != nil {
 			if _, ok := err.(*roachpb.ConditionFailedError); ok {
-				return errors.Errorf("conflict updating range descriptors")
+				return errors.New(ErrMsgConflictUpdatingRangeDesc)
 			}
 			return err
 		}


### PR DESCRIPTION
Ran testdata/select_index_span_ranges and TestSplitAt under `make stress` with
maxSplitRetries=2 and saw no failures. Setting to 4 for good measure.

Fixes #9120.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9125)

<!-- Reviewable:end -->
