### PR TITLE
sql: tag the logging context with 'internal' for the internal executor.

### DIFF
--- a/sql/session.go
+++ b/sql/session.go
@@ -91,11 +91,11 @@ func NewSession(ctx context.Context, args SessionArgs, e *Executor, remote net.A
 	}
 	s.PreparedStatements = makePreparedStatements(s)
 	s.PreparedPortals = makePreparedPortals(s)
-	remoteStr := ""
+	remoteStr := "<internal>"
 	if remote != nil {
 		remoteStr = remote.String()
-		ctx = log.WithLogTag(ctx, "client=", remoteStr)
 	}
+	ctx = log.WithLogTagStr(ctx, "client=", remoteStr)
 
 	// Set up an EventLog for session events.
 	ctx = log.WithEventLog(ctx, fmt.Sprintf("sql [%s]", args.User), remoteStr)


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9133)

<!-- Reviewable:end -->
