### PR TITLE
storage: allow consistency checks on frozen ranges

### DIFF
--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -61,6 +61,18 @@ func (ba *BatchRequest) UpdateTxn(otherTxn *Transaction) {
 	ba.Txn = &clonedTxn
 }
 
+// IsConsistencyRelated returns whether the batch consists of a single
+// ComputeChecksum or VerifyChecksum or CheckConsistency request.
+func (ba *BatchRequest) IsConsistencyRelated() bool {
+	if !ba.IsSingleRequest() {
+		return false
+	}
+	_, ok1 := ba.GetArg(ComputeChecksum)
+	_, ok2 := ba.GetArg(VerifyChecksum)
+	_, ok3 := ba.GetArg(CheckConsistency)
+	return ok1 || ok2 || ok3
+}
+
 // IsFreeze returns whether the batch consists of a single ChangeFrozen request.
 func (ba *BatchRequest) IsFreeze() bool {
 	if !ba.IsSingleRequest() {

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -2220,9 +2220,9 @@ func (r *Replica) applyRaftCommand(
 
 	r.mu.Lock()
 	oldIndex := r.mu.state.RaftAppliedIndex
-	// When frozen, the Range only applies freeze-related requests. Overrides
-	// any forcedError.
-	if mayApply := !r.mu.state.Frozen || ba.IsFreeze(); !mayApply {
+	// When frozen, the Range only applies freeze- and consistency-related
+	// requests. Overrides any forcedError.
+	if mayApply := !r.mu.state.Frozen || ba.IsFreeze() || ba.IsConsistencyRelated(); !mayApply {
 		forcedError = roachpb.NewError(roachpb.NewRangeFrozenError(*r.mu.state.Desc))
 	}
 	r.mu.Unlock()


### PR DESCRIPTION
This seems useful in its own right, but the immediate motivation is for
testing the revised consistency checker without interference from
unrelated Raft commands (PR forthcoming).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9138)

<!-- Reviewable:end -->
