### PR TITLE
cli: Only print env var names on startup, not values

### DIFF
--- a/cli/debug.go
+++ b/cli/debug.go
@@ -679,7 +679,7 @@ var debugEnvCmd = &cobra.Command{
 Output environment variables that influence configuration.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		env := envutil.GetEnvReport(false)
+		env := envutil.GetEnvReport()
 		fmt.Print(env)
 	},
 }

--- a/cli/start.go
+++ b/cli/start.go
@@ -360,8 +360,8 @@ func runStart(_ *cobra.Command, args []string) error {
 	}
 
 	log.Info(startCtx, "starting cockroach node")
-	if envVarsUsed := envutil.GetEnvReport(true); envVarsUsed != "" {
-		log.Infof(startCtx, "using local environment variables:\n%s", envVarsUsed)
+	if envVarsUsed := envutil.GetEnvVarsUsed(); len(envVarsUsed) > 0 {
+		log.Infof(startCtx, "using local environment variables: %s", strings.Join(envVarsUsed, ", "))
 	}
 	s, err := server.NewServer(serverCtx, stopper)
 	if err != nil {

--- a/util/envutil/env.go
+++ b/util/envutil/env.go
@@ -97,7 +97,7 @@ func ClearEnvCache() {
 
 // GetEnvReport dumps all configuration variables that may have been
 // used and their value.
-func GetEnvReport(presentOnly bool) string {
+func GetEnvReport() string {
 	envVarRegistry.mu.Lock()
 	defer envVarRegistry.mu.Unlock()
 
@@ -105,11 +105,26 @@ func GetEnvReport(presentOnly bool) string {
 	for k, v := range envVarRegistry.cache {
 		if v.present {
 			fmt.Fprintf(&b, "%s = %s # %s\n", k, v.value, v.consumer)
-		} else if !presentOnly {
+		} else {
 			fmt.Fprintf(&b, "# %s is not set (read from %s)\n", k, v.consumer)
 		}
 	}
 	return b.String()
+}
+
+// GetEnvVarsUsed returns the names of all environment variables that
+// may have been used.
+func GetEnvVarsUsed() []string {
+	envVarRegistry.mu.Lock()
+	defer envVarRegistry.mu.Unlock()
+
+	var vars []string
+	for k, v := range envVarRegistry.cache {
+		if v.present {
+			vars = append(vars, k)
+		}
+	}
+	return vars
 }
 
 // GetShellCommand returns a complete command to run with a prefix of the command line.


### PR DESCRIPTION
The values could sometimes contain sensitive information.

Partially undoes #9069. Fixes #9136

@tschottdorf

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9141)

<!-- Reviewable:end -->
