### PR TITLE
storage: use range context for raft logs

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -369,7 +369,7 @@ func (r *Replica) withRaftGroupLocked(f func(r *raft.RawNode) error) error {
 			uint64(r.mu.replicaID),
 			r.mu.state.RaftAppliedIndex,
 			r.store.ctx,
-			&raftLogger{stringer: r},
+			&raftLogger{ctx: r.ctx},
 		), nil)
 		if err != nil {
 			return err
@@ -1606,7 +1606,7 @@ func (r *Replica) handleRaftReady() error {
 		return nil
 	}
 
-	logRaftReady(ctx, r, rd)
+	logRaftReady(ctx, rd)
 
 	refreshReason := noReason
 	if rd.SoftState != nil && leaderID != roachpb.ReplicaID(rd.SoftState.Lead) {

--- a/storage/store.go
+++ b/storage/store.go
@@ -2398,7 +2398,7 @@ func (s *Store) HandleRaftRequest(
 					// crashing potential for any choice of dummy value below.
 					appliedIndex,
 					r.store.ctx,
-					&raftLogger{stringer: r},
+					&raftLogger{ctx: r.ctx},
 				), nil)
 			if err != nil {
 				return roachpb.NewError(err)


### PR DESCRIPTION
Setting up the raft logger to use the range context. We no longer need to plumb
the range as a Stringer (that information is in the log tags).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9143)

<!-- Reviewable:end -->
