### PR TITLE
util/uuid: remove Equal

### DIFF
--- a/acceptance/event_log_test.go
+++ b/acceptance/event_log_test.go
@@ -86,12 +86,12 @@ func testEventLogInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig) 
 			}
 
 			// Verify cluster ID is recorded, and is the same for all nodes.
-			if uuid.Equal(info.ClusterID, *uuid.EmptyUUID) {
+			if (info.ClusterID == uuid.UUID{}) {
 				t.Fatalf("Node join recorded nil cluster id, info: %v", info)
 			}
-			if uuid.Equal(clusterID, *uuid.EmptyUUID) {
+			if (clusterID == uuid.UUID{}) {
 				clusterID = info.ClusterID
-			} else if !uuid.Equal(clusterID, info.ClusterID) {
+			} else if clusterID != info.ClusterID {
 				t.Fatalf(
 					"Node join recorded different cluster ID than earlier node. Expected %s, got %s. Info: %v",
 					clusterID, info.ClusterID, info)
@@ -156,7 +156,7 @@ func testEventLogInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig) 
 			}
 
 			// Verify cluster ID is recorded, and is the same for all nodes.
-			if !uuid.Equal(confirmedClusterID, info.ClusterID) {
+			if confirmedClusterID != info.ClusterID {
 				t.Fatalf(
 					"Node restart recorded different cluster ID than earlier join. Expected %s, got %s. Info: %v",
 					confirmedClusterID, info.ClusterID, info)

--- a/server/admin.go
+++ b/server/admin.go
@@ -770,7 +770,7 @@ func (s *adminServer) GetUIData(ctx context.Context, req *serverpb.GetUIDataRequ
 // Cluster returns cluster metadata.
 func (s *adminServer) Cluster(_ context.Context, req *serverpb.ClusterRequest) (*serverpb.ClusterResponse, error) {
 	clusterID := s.server.node.ClusterID
-	if uuid.Equal(clusterID, *uuid.EmptyUUID) {
+	if clusterID == *uuid.EmptyUUID {
 		return nil, grpc.Errorf(codes.Unavailable, "cluster ID not yet available")
 	}
 	return &serverpb.ClusterResponse{ClusterID: clusterID.String()}, nil

--- a/util/uuid/uuid.go
+++ b/util/uuid/uuid.go
@@ -114,8 +114,3 @@ func FromString(input string) (*UUID, error) {
 	u, err := uuid.FromString(input)
 	return &UUID{u}, err
 }
-
-// Equal delegates to "github.com/satori/go.uuid".Equal.
-func Equal(u1, u2 UUID) bool {
-	return uuid.Equal(u1.UUID, u2.UUID)
-}


### PR DESCRIPTION
We already use these structures as map keys, which requires them to be
struct-comparable; no sense in having two ways to skin the same cat.

From the graveyard.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9146)

<!-- Reviewable:end -->
