### PR TITLE
scripts: use a more modern distribution

### DIFF
--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -15,7 +15,7 @@ case ${1-} in
            --machine-type "custom-32-32768" \
            --network "default" \
            --maintenance-policy "MIGRATE" \
-           --image "/debian-cloud/debian-8-jessie-v20160803" \
+           --image "/ubuntu-os-cloud/ubuntu-1604-xenial-v20160830" \
            --boot-disk-size "100" \
            --boot-disk-type "pd-ssd" \
            --boot-disk-device-name "${name}"


### PR DESCRIPTION
The previously used Debian image used an ancient version of git not compatible
with the tricks we pull in our Makefile.

cc @tamird

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9147)

<!-- Reviewable:end -->
