### PR TITLE
cli: Include unreplicated data in `debug range-data`

### DIFF
--- a/cli/cliflags/flags.go
+++ b/cli/cliflags/flags.go
@@ -349,4 +349,9 @@ defined in terms of multiples of this value.`,
 		Name:        "undo",
 		Description: `Attempt to undo an earlier attempt to freeze the cluster.`,
 	}
+
+	Replicated = FlagInfo{
+		Name:        "replicated",
+		Description: "Restrict scan to replicated data.",
+	}
 )

--- a/cli/context.go
+++ b/cli/context.go
@@ -144,4 +144,5 @@ type debugContext struct {
 	startKey, endKey engine.MVCCKey
 	values           bool
 	sizes            bool
+	replicated       bool
 }

--- a/cli/debug.go
+++ b/cli/debug.go
@@ -152,8 +152,9 @@ var debugRangeDataCmd = &cobra.Command{
 	Use:   "range-data [directory] range-id",
 	Short: "dump all the data in a range",
 	Long: `
-Pretty-prints all keys and values in a range. This includes all data covered
-by the consistency checker.
+Pretty-prints all keys and values in a range. By default, includes unreplicated
+state like the raft HardState. With --replicated, only includes data covered by
+ the consistency checker.
 `,
 	RunE: runDebugRangeData,
 }
@@ -181,7 +182,7 @@ func runDebugRangeData(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	iter := storage.NewReplicaDataIterator(&desc, db, true)
+	iter := storage.NewReplicaDataIterator(&desc, db, debugCtx.replicated)
 	for ; iter.Valid(); iter.Next() {
 		if _, err := printKeyValue(engine.MVCCKeyValue{
 			Key:   iter.Key(),

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -51,8 +51,9 @@ var baseCtx = serverCtx.Context
 var cliCtx = cliContext{Context: baseCtx}
 var sqlCtx = sqlContext{cliContext: &cliCtx}
 var debugCtx = debugContext{
-	startKey: engine.NilKey,
-	endKey:   engine.MVCCKeyMax,
+	startKey:   engine.NilKey,
+	endKey:     engine.MVCCKeyMax,
+	replicated: false,
 }
 
 var cacheSize *bytesValue
@@ -404,6 +405,9 @@ func init() {
 		varFlag(f, (*mvccKey)(&debugCtx.endKey), cliflags.To)
 		boolFlag(f, &debugCtx.values, cliflags.Values, false)
 		boolFlag(f, &debugCtx.sizes, cliflags.Sizes, false)
+
+		f = debugRangeDataCmd.Flags()
+		boolFlag(f, &debugCtx.replicated, cliflags.Replicated, false)
 	}
 
 	boolFlag(versionCmd.Flags(), &versionIncludesDeps, cliflags.Deps, false)


### PR DESCRIPTION
Add flag --replicated to limit the scan to replicated data.

Used to investigate #9037.

Cc @cockroachdb/stability

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9167)

<!-- Reviewable:end -->
