### PR TITLE
CONTRIBUTING: require git worktree support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
   - A C++ compiler that supports C++11. Note that GCC prior to 6.0 doesn't
   work due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48891.
   - A Go environment with a 64-bit version of Go 1.7.
-  - Git 1.8+
+  - Git 2.5+
   - Bash
 
 2.  Get the CockroachDB code:

--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,9 @@ ifneq ($(SKIP_BOOTSTRAP),1)
 
 # If we're in a git worktree, the git hooks directory may not be in our root,
 # so we ask git for the location.
+#
+# Note that this command requires git 2.5+; earlier versions produce opaque
+# errors.
 GITHOOKSDIR := $(shell git rev-parse --git-path hooks)
 GITHOOKS := $(subst githooks/,$(GITHOOKSDIR)/,$(wildcard githooks/*))
 $(GITHOOKSDIR)/%: githooks/%


### PR DESCRIPTION
2f568cb added git worktree awareness to the Makefile by invoking
`git rev-parse --git-path hooks` is invoked. This invocation is not
understood by git versions predating worktree support.

We could potentially make the Makefile invocation more resilient to
older git versions, but it doesn't seem worth it.

@cockroachdb/stability

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9172)

<!-- Reviewable:end -->
