### PR TITLE
storage: avoid a race in command cancellation

### DIFF
--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -2008,16 +2008,16 @@ func TestReplicaCommandQueueCancellation(t *testing.T) {
 		return nil
 	})
 
-	// Finish the previous command.
-	blockingDone <- struct{}{}
-	if pErr := <-cmd1Done; pErr != nil {
-		t.Fatal(pErr)
-	}
-
 	// If this deadlocks, the command has unexpectedly begun executing and was
 	// trapped in the command filter. Indeed, the absence of such a deadlock is
 	// what's being tested here.
 	if pErr := <-cmd2Done; !testutils.IsPError(pErr, context.Canceled.Error()) {
+		t.Fatal(pErr)
+	}
+
+	// Finish the previous command, allowing the test to shut down.
+	blockingDone <- struct{}{}
+	if pErr := <-cmd1Done; pErr != nil {
 		t.Fatal(pErr)
 	}
 }


### PR DESCRIPTION
It was previously possible for an expired command to execute if the
completion of its dependencies raced with the cancellation of its
context.

This change explicitly prioritizes cancellation over execution in such
cases.

Fixes #8986.

@cockroachdb/stability

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9177)

<!-- Reviewable:end -->
