### PR TITLE
storage/engine: Fix rocksdb assertions

### DIFF
--- a/storage/engine/engine_test.go
+++ b/storage/engine/engine_test.go
@@ -274,6 +274,7 @@ func TestEngineBatch(t *testing.T) {
 			expectedValue := get(engine, key)
 			// Run the whole thing as a batch and compare.
 			b := engine.NewBatch()
+			defer b.Close()
 			if err := b.Clear(key); err != nil {
 				t.Fatal(err)
 			}

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -57,7 +57,9 @@ import (
 import "C"
 
 const (
-	minMemtableBudget = 1 << 20  // 1 MB
+	// Small values for minMemtableBudget trigger assertions in debug
+	// builds of rocksdb.
+	minMemtableBudget = 10 << 20 // 10 MB
 	defaultBlockSize  = 32 << 10 // 32KB (rocksdb default is 4KB)
 
 	// DefaultMaxOpenFiles is the default value for rocksDB's max_open_files

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -64,6 +64,7 @@ func TestBatchIterReadOwnWrite(t *testing.T) {
 	defer stopper.Stop()
 
 	b := db.NewBatch()
+	defer b.Close()
 
 	k := MakeMVCCMetadataKey(testKey1)
 
@@ -131,6 +132,7 @@ func TestBatchPrefixIter(t *testing.T) {
 	defer stopper.Stop()
 
 	b := db.NewBatch()
+	defer b.Close()
 
 	// Set up a batch with: delete("a"), put("b"). We'll then prefix seek for "b"
 	// which should succeed and then prefix seek for "a" which should fail. Note

--- a/storage/store.go
+++ b/storage/store.go
@@ -764,6 +764,7 @@ func IterateRangeDescriptors(ctx context.Context,
 
 func (s *Store) migrate(ctx context.Context, desc roachpb.RangeDescriptor) {
 	batch := s.engine.NewBatch()
+	defer batch.Close()
 	if err := migrate7310And6991(ctx, batch, desc); err != nil {
 		log.Fatal(ctx, errors.Wrap(err, "during migration"))
 	}
@@ -1296,6 +1297,7 @@ func (s *Store) BootstrapRange(initialValues []roachpb.KeyValue) error {
 		return err
 	}
 	batch := s.engine.NewBatch()
+	defer batch.Close()
 	ms := &enginepb.MVCCStats{}
 	now := s.ctx.Clock.Now()
 	ctx := context.Background()


### PR DESCRIPTION
Our tests currently fail with debug builds of rocksdb because of additional assertions enabled in this mode. With these changes our tests pass with debug builds of rocksdb 4.8.

See #9168 

@cockroachdb/stability

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9179)

<!-- Reviewable:end -->
