### PR TITLE
[wip] stability: return errors from (*Replica).{raftM,m,readOnlyCmdM}u

### DIFF
--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -141,7 +141,7 @@ func TestGCQueueShouldQueue(t *testing.T) {
 		func() {
 			// Hold lock throughout to reduce chance of random commands
 			// leading to inconsistent state.
-			tc.rng.mu.Lock()
+			tc.rng.mu.Wrapped().Lock()
 			defer tc.rng.mu.Unlock()
 			if err := setMVCCStats(context.Background(), tc.rng.store.Engine(), tc.rng.RangeID, ms); err != nil {
 				t.Fatal(err)

--- a/storage/helpers_test.go
+++ b/storage/helpers_test.go
@@ -149,8 +149,8 @@ func (s *Store) EnqueueRaftUpdateCheck(rangeID roachpb.RangeID) {
 // GetLastIndex is the same function as LastIndex but it does not require
 // that the replica lock is held.
 func (r *Replica) GetLastIndex() (uint64, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.Wrapped().Lock()
+	defer r.mu.Wrapped().Unlock()
 	return r.LastIndex()
 }
 
@@ -161,7 +161,7 @@ func (r *Replica) GetLease() (*roachpb.Lease, *roachpb.Lease) {
 
 // GetTimestampCacheLowWater returns the timestamp cache low water mark.
 func (r *Replica) GetTimestampCacheLowWater() hlc.Timestamp {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.Wrapped().Lock()
+	defer r.mu.Wrapped().Unlock()
 	return r.mu.tsCache.lowWater
 }

--- a/storage/raft_log_queue.go
+++ b/storage/raft_log_queue.go
@@ -83,7 +83,9 @@ func getTruncatableIndexes(r *Replica) (uint64, uint64, error) {
 		return 0, 0, nil
 	}
 
-	r.mu.Lock()
+	if err := r.mu.Lock(); err != nil {
+		return 0, 0, err
+	}
 	raftLogSize := r.mu.raftLogSize
 	// We target the raft log size at the size of the replicated data. When
 	// writing to a replica, it is common for the raft log to become larger than

--- a/storage/raft_log_queue_test.go
+++ b/storage/raft_log_queue_test.go
@@ -133,9 +133,9 @@ func TestGetTruncatableIndexes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r.mu.Lock()
+	r.mu.Wrapped().Lock()
 	firstIndex, err := r.FirstIndex()
-	r.mu.Unlock()
+	r.mu.Wrapped().Unlock()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,9 +168,9 @@ func TestGetTruncatableIndexes(t *testing.T) {
 	// before ForceRaftLogScanAndProcess but is still working on it.
 	stopper.Quiesce()
 
-	r.mu.Lock()
+	r.mu.Wrapped().Lock()
 	newFirstIndex, err := r.FirstIndex()
-	r.mu.Unlock()
+	r.mu.Wrapped().Unlock()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -213,9 +213,9 @@ func TestProactiveRaftLogTruncate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r.mu.Lock()
+	r.mu.Wrapped().Lock()
 	oldFirstIndex, err := r.FirstIndex()
-	r.mu.Unlock()
+	r.mu.Wrapped().Unlock()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -233,9 +233,9 @@ func TestProactiveRaftLogTruncate(t *testing.T) {
 	// Wait for any asynchronous tasks to finish.
 	stopper.Quiesce()
 
-	r.mu.Lock()
+	r.mu.Wrapped().Lock()
 	newFirstIndex, err := r.FirstIndex()
-	r.mu.Unlock()
+	r.mu.Wrapped().Unlock()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/replica_raftstorage_test.go
+++ b/storage/replica_raftstorage_test.go
@@ -47,9 +47,9 @@ func fillTestRange(t testing.TB, rep *Replica, size int64) {
 			t.Fatal(pErr)
 		}
 	}
-	rep.mu.Lock()
+	rep.mu.Wrapped().Lock()
 	after := rep.mu.state.Stats.Total()
-	rep.mu.Unlock()
+	rep.mu.Wrapped().Unlock()
 	if after < size {
 		t.Fatalf("range not full after filling: wrote %d, but range at %d", size, after)
 	}
@@ -86,7 +86,7 @@ func TestSkipLargeReplicaSnapshot(t *testing.T) {
 	fillTestRange(t, rep, snapSize*2)
 
 	if _, err := rep.Snapshot(); err != raft.ErrSnapshotTemporarilyUnavailable {
-		rep.mu.Lock()
+		rep.mu.Wrapped().Lock()
 		after := rep.mu.state.Stats.Total()
 		rep.mu.Unlock()
 		t.Fatalf(

--- a/storage/split_queue_test.go
+++ b/storage/split_queue_test.go
@@ -85,7 +85,7 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 		func() {
 			// Hold lock throughout to reduce chance of random commands leading
 			// to inconsistent state.
-			tc.rng.mu.Lock()
+			tc.rng.mu.MustLock()
 			defer tc.rng.mu.Unlock()
 			ms := enginepb.MVCCStats{KeyBytes: test.bytes}
 			if err := setMVCCStats(context.Background(), tc.rng.store.Engine(), tc.rng.RangeID, ms); err != nil {

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -379,7 +379,7 @@ func TestReplicasByKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rep.mu.Lock()
+	rep.mu.MustLock()
 	rep.mu.state.Desc.EndKey = roachpb.RKey("e")
 	rep.mu.Unlock()
 
@@ -680,10 +680,10 @@ func TestProcessRangeDescriptorUpdate(t *testing.T) {
 	}
 
 	// Initialize the range with start and end keys.
-	r.mu.Lock()
+	r.mu.Wrapped().Lock()
 	r.mu.state.Desc.StartKey = roachpb.RKey("b")
 	r.mu.state.Desc.EndKey = roachpb.RKey("d")
-	r.mu.Unlock()
+	r.mu.Wrapped().Unlock()
 
 	if err := store.processRangeDescriptorUpdateLocked(r); err != nil {
 		t.Errorf("expected processRangeDescriptorUpdate on a replica that's not in the uninit map to silently succeed, got %v", err)
@@ -2022,7 +2022,7 @@ func TestStoreChangeFrozen(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		repl.mu.Lock()
+		repl.mu.Wrapped().Lock()
 		frozen := repl.mu.state.Frozen
 		repl.mu.Unlock()
 		pFrozen, err := loadFrozenStatus(context.Background(), store.Engine(), 1)
@@ -2161,7 +2161,7 @@ func TestStoreGCThreshold(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		repl.mu.Lock()
+		repl.mu.Wrapped().Lock()
 		gcThreshold := repl.mu.state.GCThreshold
 		repl.mu.Unlock()
 		pgcThreshold, err := loadGCThreshold(context.Background(), store.Engine(), 1)

--- a/util/syncutil/mutex_error.go
+++ b/util/syncutil/mutex_error.go
@@ -1,0 +1,147 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package syncutil
+
+func init() {
+	// Silence TestUnused.
+	var rw RWMutexWithError
+	_ = rw.Wrapped()
+	_ = rw.Destroyed()
+	rw.Destroy(nil)
+	var w MutexWithError
+	w.Destroy(nil)
+}
+
+// RWMutexWithError .
+type RWMutexWithError struct {
+	internalMutex RWMutex
+	destroyed     error
+}
+
+// Wrapped .
+func (mu *RWMutexWithError) Wrapped() *RWMutex {
+	return &mu.internalMutex
+}
+
+// Destroy .
+func (mu *RWMutexWithError) Destroy(err error) {
+	mu.internalMutex.Lock()
+	defer mu.internalMutex.Unlock()
+	mu.DestroyLocked(err)
+}
+
+// DestroyLocked .
+func (mu *RWMutexWithError) DestroyLocked(err error) {
+	mu.destroyed = err
+}
+
+// Destroyed .
+func (mu *RWMutexWithError) Destroyed() error {
+	mu.internalMutex.Lock()
+	defer mu.internalMutex.Unlock()
+	return mu.DestroyedLocked()
+}
+
+// DestroyedLocked .
+func (mu *RWMutexWithError) DestroyedLocked() error {
+	return mu.destroyed
+}
+
+// RLock .
+func (mu *RWMutexWithError) RLock() error {
+	mu.internalMutex.RLock()
+	if mu.destroyed != nil {
+		mu.internalMutex.RUnlock()
+		return mu.destroyed
+	}
+	return nil
+}
+
+// RUnlock .
+func (mu *RWMutexWithError) RUnlock() {
+	mu.internalMutex.RUnlock()
+}
+
+// Lock .
+func (mu *RWMutexWithError) Lock() error {
+	mu.internalMutex.Lock()
+	if mu.destroyed != nil {
+		mu.internalMutex.Unlock()
+		return mu.destroyed
+	}
+	return nil
+}
+
+// Unlock .
+func (mu *RWMutexWithError) Unlock() {
+	mu.internalMutex.Unlock()
+}
+
+// MutexWithError .
+type MutexWithError struct {
+	internalMutex Mutex
+	destroyed     error
+}
+
+// Destroyed .
+func (mu *MutexWithError) Destroyed() error {
+	mu.internalMutex.Lock()
+	defer mu.internalMutex.Unlock()
+	return mu.DestroyedLocked()
+}
+
+// DestroyedLocked .
+func (mu *MutexWithError) DestroyedLocked() error {
+	return mu.destroyed
+}
+
+// Wrapped .
+func (mu *MutexWithError) Wrapped() *Mutex {
+	return &mu.internalMutex
+}
+
+// Destroy .
+func (mu *MutexWithError) Destroy(err error) {
+	mu.internalMutex.Lock()
+	defer mu.internalMutex.Unlock()
+	mu.DestroyLocked(err)
+}
+
+// DestroyLocked .
+func (mu *MutexWithError) DestroyLocked(err error) {
+	mu.destroyed = err
+}
+
+// MustLock .
+func (mu *MutexWithError) MustLock() {
+	if err := mu.Lock(); err != nil {
+		panic(err)
+	}
+}
+
+// Lock .
+func (mu *MutexWithError) Lock() error {
+	mu.internalMutex.Lock()
+	if mu.destroyed != nil {
+		mu.internalMutex.Unlock()
+		return mu.destroyed
+	}
+	return nil
+}
+
+// Unlock .
+func (mu *MutexWithError) Unlock() {
+	mu.internalMutex.Unlock()
+}


### PR DESCRIPTION
This is out for early review. I recommend focusing on `(*Replica).Destroy()` and `util/syncutil/mutex_error.go` as well as the changes in the `*Replica` struct itself.
Most of the changes in this PR are due to `(*Replica).mu`, which we lock a lot and checked for races very rarely.
## 

This forces explicit error handling every time one of these mutexes is
acquired; see #8630.
Where code previously read

``` go
r.mu.Lock()
if r.mu.destroyed != nil { // almost never checked in practice
}
// [...]
r.mu.Unlock()
```

it will now have the following canonical options:

``` go
if err := r.mu.Lock(); err != nil {
    return err
}
// [...] (only when Replica not destroyed)
r.mu.Unlock()
```

``` go
if err := r.mu.Lock(); err != nil {
    // Acknowledge fact that Replica is destroyed, but proceed anyway.
    r.mu.Wrapped().Lock()
}
// [...] (unconditionally, and protected by lock)
r.mu.Unlock()
```

The idea here is that errors will have to be handled one way or the other.

`(*Replica).Destroy()` now destroys all of the aforementioned mutexes. This
should significantly reduce the chance of races, though it also returns errors
in many new locations which will likely cause a few new panics to crop up in
practice (indicating previous races which went unnoticed).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9190)

<!-- Reviewable:end -->
