### PR TITLE
build: bump etcd raft

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -44,7 +44,7 @@ github.com/cockroachdb/pq 40c6b2414c76cdb84aacc955f79dc844e48ad0c0
 github.com/cockroachdb/stress 029c9348806514969d1109a6ae36e521af411ca7
 github.com/cockroachdb/yacc 7c99dfd2164a5d23c3f495ffc2e0b72b6379d066
 github.com/codahale/hdrhistogram f8ad88b59a584afeee9d334eff879b104439117b
-github.com/coreos/etcd 48f4a7d037ca8fd276fff09ef068074193b24dfa
+github.com/coreos/etcd 656167d760543d442eae62f0c8c4f92c05f59508
 github.com/cpuguy83/go-md2man 2724a9c9051aa62e9cca11304e7dd518e9e41599
 github.com/davecgh/go-spew 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
 github.com/docker/distribution c9fd26e9efe2c7405d7072ad181844275977b5e3


### PR DESCRIPTION
Picks up 2 changes I made to etcd/raft to reduce per-raft group memory
usage.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9193)

<!-- Reviewable:end -->
