### PR TITLE
gossip: deflake TestGossipOrphanedStallDetection

### DIFF
--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -281,6 +281,7 @@ func TestGossipOrphanedStallDetection(t *testing.T) {
 
 	peerNodeID := peer.GetNodeID()
 	peerAddr := peer.GetNodeAddr()
+	peerAddrStr := peerAddr.String()
 
 	local.startClient(peerAddr, peerNodeID)
 
@@ -290,7 +291,16 @@ func TestGossipOrphanedStallDetection(t *testing.T) {
 				return nil
 			}
 		}
-		return errors.Errorf("%d not yet connected", peerNodeID)
+		return errors.Errorf("node %d not yet connected", peerNodeID)
+	})
+
+	util.SucceedsSoon(t, func() error {
+		for _, resolver := range local.GetResolvers() {
+			if resolver.Addr() == peerAddrStr {
+				return nil
+			}
+		}
+		return errors.Errorf("node %d descriptor not yet available", peerNodeID)
 	})
 
 	local.bootstrap()
@@ -301,7 +311,7 @@ func TestGossipOrphanedStallDetection(t *testing.T) {
 	util.SucceedsSoon(t, func() error {
 		for _, peerID := range local.Outgoing() {
 			if peerID == peerNodeID {
-				return errors.Errorf("%d still connected", peerNodeID)
+				return errors.Errorf("node %d still connected", peerNodeID)
 			}
 		}
 		return nil
@@ -317,6 +327,6 @@ func TestGossipOrphanedStallDetection(t *testing.T) {
 				return nil
 			}
 		}
-		return errors.Errorf("%d not yet connected", peerNodeID)
+		return errors.Errorf("node %d not yet connected", peerNodeID)
 	})
 }


### PR DESCRIPTION
Wait until the remote has gossiped its node descriptor before shutting
it down. Previously, the test could kill the connection before the
remote's address could be discovered via incoming gossip.

Closes #8972.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9194)

<!-- Reviewable:end -->
