### PR TITLE
acceptance: Unskip TestEventLog

### DIFF
--- a/acceptance/event_log_test.go
+++ b/acceptance/event_log_test.go
@@ -33,7 +33,6 @@ import (
 // TestEventLog verifies that "node joined" and "node restart" events are
 // recorded whenever a node starts and contacts the cluster.
 func TestEventLog(t *testing.T) {
-	t.Skip("flaky: #8562")
 	runTestOnConfigs(t, testEventLogInner)
 }
 


### PR DESCRIPTION
TestEventLog is currently being skipped due to #8706 and #8562 (the latter has
been closed). It has proven difficult to replicate this flake locally or in team
city; we are going to re-enable the test until we obtain another failure (which
will have the per-node logs needed to diagnose the issue: see #8706 for more
details).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9195)

<!-- Reviewable:end -->
