### PR TITLE
docs: new minimum git version for building from source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
   - A C++ compiler that supports C++11. Note that GCC prior to 6.0 doesn't
   work due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48891.
   - A Go environment with a 64-bit version of Go 1.7.
-  - Git 1.8+
+  - Git 2.5+
   - Bash
 
 2.  Get the CockroachDB code:


### PR DESCRIPTION
In response to https://github.com/cockroachdb/cockroach/pull/9072, this PR updates the minimum Git version for building from source.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9205)

<!-- Reviewable:end -->
