### PR TITLE
ui: fix vscode type-checking and autocomplete

### DIFF
--- a/ui/Makefile
+++ b/ui/Makefile
@@ -100,7 +100,7 @@ npm.installed: package.json npm-shrinkwrap.json
 	npm install --no-progress
 	touch $@
 
-typings.installed: generated/protos.d.ts typings.json npm.installed
+typings.installed: generated/protos.d.ts typings.json npm.installed jspm.installed
 	typings install
 	typings prune
 	touch $@

--- a/ui/README.md
+++ b/ui/README.md
@@ -20,6 +20,14 @@ with the environment variable `COCKROACH_DEBUG_UI` set to a truthy value, e.g.
 [strconv.ParseBool](https://godoc.org/strconv#ParseBool) will work) and
 navigating to the web console.
 
+### Visual Studio Code
+
+To get autocomplete and type-checking working in Visual Studio Code, you may
+need to manually configure your typescript version. Typescript 2 is already
+installed by npm, but you'll need to configure your project/workspace to point
+to it. See
+https://code.visualstudio.com/docs/languages/typescript#_using-newer-typescript-versions.
+
 ## Modification
 
 As mentioned above, be sure to run the CockroachDB server in UI debug mode

--- a/ui/npm-shrinkwrap.json
+++ b/ui/npm-shrinkwrap.json
@@ -2411,7 +2411,7 @@
       "version": "0.0.6"
     },
     "typescript": {
-      "version": "1.8.7"
+      "version": "2.0.2"
     },
     "typings": {
       "version": "1.3.3",
@@ -2435,6 +2435,9 @@
         },
         "repeating": {
           "version": "2.0.1"
+        },
+        "typescript": {
+          "version": "1.8.7"
         }
       }
     },

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,6 +13,7 @@
     "stylint": "^1.3.10",
     "stylus": "^0.54.5",
     "tslint": "^3.11.0",
+    "typescript": "^2.0.2",
     "typings": "^1.0.4"
   },
   "jspm": {

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "allowJs": true,
+    "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "forceConsistentCasingInFileNames": true,

--- a/ui/typings.json
+++ b/ui/typings.json
@@ -17,12 +17,15 @@
     "d3": "registry:npm/d3#3.0.0+20160723033700",
     "enzyme": "registry:npm/enzyme#2.2.0+20160322031343",
     "lodash": "registry:npm/lodash#4.0.0+20160723033700",
+    "moment": "file:jspm_packages/npm/moment@2.14.1/moment.d.ts",
     "nvd3": "registry:npm/nvd3#1.8.3+20160711175044",
     "protos-builders": "file:app/js/protos.d.ts",
     "react-paginate": "file:local_typings/react-paginate.d.ts",
     "react-router": "registry:npm/react-router#2.4.0+20160811060709",
     "react-router-redux": "registry:npm/react-router-redux#4.0.0+20160602212457",
+    "redux": "file:jspm_packages/npm/redux@3.6.0/index.d.ts",
     "redux-thunk": "registry:npm/redux-thunk#2.0.0+20160525185520",
+    "reselect": "file:jspm_packages/npm/reselect@2.5.3/src/reselect.d.ts",
     "sinon": "registry:npm/sinon#1.16.0+20160723033700"
   }
 }


### PR DESCRIPTION
This is #9158 without the files bit.
# 

This modifies tsconfig.json and typings.json so that the options
work better with vscode.

Specifically, the following needs to be true for vscode to work:
- typescript 2+ has to be installed
- vscode has to be configured to use typescript 2+
- dependencies that carry their own typings (moment, reselect, redux)
  are shimmed into typings.json because vscode can't resolve included
  typings
- tsconfig.allowSyntheticDefaultImports must be set to true; this is
  the default when module is set to system, but that is unsupported in
  vscode

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9219)

<!-- Reviewable:end -->
