### PR TITLE
storage: add replica log tag to queue context

### DIFF
--- a/storage/raft_log_queue.go
+++ b/storage/raft_log_queue.go
@@ -200,10 +200,8 @@ func (rlq *raftLogQueue) process(
 
 	// Can and should the raft logs be truncated?
 	if truncatableIndexes >= RaftLogQueueStaleThreshold {
-		if log.V(1) {
-			log.Infof(ctx, "%s: truncating raft log %d-%d",
-				r, oldestIndex-truncatableIndexes, oldestIndex)
-		}
+		log.VTracef(1, ctx, "truncating raft log %d-%d",
+			oldestIndex-truncatableIndexes, oldestIndex)
 		b := &client.Batch{}
 		b.AddRawRequest(&roachpb.TruncateLogRequest{
 			Span:    roachpb.Span{Key: r.Desc().StartKey.AsRawKey()},

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -530,6 +530,14 @@ func (r *Replica) initLocked(
 	return nil
 }
 
+// logContext adds the node, store and replica log tags to a context. Used to
+// personalize an operation context with this Replica's identity.
+func (r *Replica) logContext(ctx context.Context) context.Context {
+	// Copy the log tags from the base context. This allows us to opaquely set the
+	// log tags that were passed by the upper layers.
+	return log.WithLogTagsFromCtx(ctx, r.ctx)
+}
+
 // String returns the string representation of the replica using an
 // inconsistent copy of the range descriptor. Therefore, String does not
 // require a lock and its output may not be atomic with other ongoing work in

--- a/storage/replica_gc_queue.go
+++ b/storage/replica_gc_queue.go
@@ -179,10 +179,7 @@ func (q *replicaGCQueue) process(
 	replyDesc := reply.Ranges[0]
 	if _, currentMember := replyDesc.GetReplicaDescriptor(rng.store.StoreID()); !currentMember {
 		// We are no longer a member of this range; clean up our local data.
-		if log.V(1) {
-			log.Infof(ctx, "destroying local data from range %d", desc.RangeID)
-		}
-		log.Trace(ctx, "destroying local data")
+		log.VTracef(1, ctx, "destroying local data")
 		if err := rng.store.RemoveReplica(rng, replyDesc, true); err != nil {
 			return err
 		}
@@ -191,10 +188,7 @@ func (q *replicaGCQueue) process(
 		// away. But currentMember is true, so we are still a member of the
 		// subsuming range. Shut down raft processing for the former range
 		// and delete any remaining metadata, but do not delete the data.
-		if log.V(1) {
-			log.Infof(ctx, "removing merged range %d", desc.RangeID)
-		}
-		log.Trace(ctx, "removing merged range")
+		log.VTracef(1, ctx, "removing merged range")
 		if err := rng.store.RemoveReplica(rng, replyDesc, false); err != nil {
 			return err
 		}

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -149,7 +149,7 @@ func (rq *replicateQueue) process(
 			StoreID: newStore.StoreID,
 		}
 
-		log.VTracef(1, ctx, "%s: adding replica to %+v due to under-replication", repl, newReplica)
+		log.VTracef(1, ctx, "adding replica to %+v due to under-replication", newReplica)
 		if err = repl.ChangeReplicas(ctx, roachpb.ADD_REPLICA, newReplica, desc); err != nil {
 			return err
 		}
@@ -161,7 +161,7 @@ func (rq *replicateQueue) process(
 		if err != nil {
 			return err
 		}
-		log.VTracef(1, ctx, "%s: removing replica %+v due to over-replication", repl, removeReplica)
+		log.VTracef(1, ctx, "removing replica %+v due to over-replication", removeReplica)
 		if err = repl.ChangeReplicas(ctx, roachpb.REMOVE_REPLICA, removeReplica, desc); err != nil {
 			return err
 		}
@@ -178,7 +178,7 @@ func (rq *replicateQueue) process(
 			break
 		}
 		deadReplica := deadReplicas[0]
-		log.VTracef(1, ctx, "%s: removing dead replica %+v from store", repl, deadReplica)
+		log.VTracef(1, ctx, "removing dead replica %+v from store", deadReplica)
 		if err = repl.ChangeReplicas(ctx, roachpb.REMOVE_REPLICA, deadReplica, desc); err != nil {
 			return err
 		}
@@ -192,7 +192,7 @@ func (rq *replicateQueue) process(
 		rebalanceStore := rq.allocator.RebalanceTarget(
 			zone.ReplicaAttrs[0], desc.Replicas, repl.store.StoreID())
 		if rebalanceStore == nil {
-			log.VTracef(1, ctx, "%s: no suitable rebalance target", repl)
+			log.VTracef(1, ctx, "no suitable rebalance target")
 			// No action was necessary and no rebalance target was found. Return
 			// without re-queuing this replica.
 			return nil
@@ -201,7 +201,7 @@ func (rq *replicateQueue) process(
 			NodeID:  rebalanceStore.Node.NodeID,
 			StoreID: rebalanceStore.StoreID,
 		}
-		log.VTracef(1, ctx, "%s: rebalancing to %+v", repl, rebalanceReplica)
+		log.VTracef(1, ctx, "rebalancing to %+v", rebalanceReplica)
 		if err = repl.ChangeReplicas(ctx, roachpb.ADD_REPLICA, rebalanceReplica, desc); err != nil {
 			return err
 		}

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -96,7 +96,7 @@ func (sq *splitQueue) process(
 	desc := rng.Desc()
 	splitKeys := sysCfg.ComputeSplitKeys(desc.StartKey, desc.EndKey)
 	if len(splitKeys) > 0 {
-		log.Infof(ctx, "splitting %s at keys %v", rng, splitKeys)
+		log.Infof(ctx, "splitting at keys %v", splitKeys)
 		for _, splitKey := range splitKeys {
 			if err := sq.db.AdminSplit(splitKey.AsRawKey()); err != nil {
 				return errors.Errorf("unable to split %s at key %q: %s", rng, splitKey, err)
@@ -113,7 +113,7 @@ func (sq *splitQueue) process(
 	size := rng.GetMVCCStats().Total()
 	// FIXME: why is this implementation not the same as the one above?
 	if float64(size)/float64(zone.RangeMaxBytes) > 1 {
-		log.Infof(ctx, "splitting %s size=%d max=%d", rng, size, zone.RangeMaxBytes)
+		log.Infof(ctx, "splitting size=%d max=%d", size, zone.RangeMaxBytes)
 		if _, pErr := client.SendWrappedWith(rng, ctx, roachpb.Header{
 			Timestamp: now,
 		}, &roachpb.AdminSplitRequest{


### PR DESCRIPTION
Add the replica log tag to the context passed to queue.process. Fixed up
a bunch of log messages in the process to removing the resulting
redundant information.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9223)

<!-- Reviewable:end -->
