### PR TITLE
acceptance+cloud: fix Terraform 0.7.0+ breakage

### DIFF
--- a/acceptance/terrafarm/farmer.go
+++ b/acceptance/terrafarm/farmer.go
@@ -112,7 +112,7 @@ func (f *Farmer) Add(nodes int) error {
 	}
 
 	for v, val := range f.AddVars {
-		args = append(args, fmt.Sprintf("-var=%s=%s", v, val))
+		args = append(args, fmt.Sprintf(`-var=%s="%s"`, v, val))
 	}
 
 	if nodes == 0 {

--- a/acceptance/terrafarm/run.go
+++ b/acceptance/terrafarm/run.go
@@ -81,7 +81,7 @@ func (f *Farmer) appendDefaults(args []string) []string {
 		"-no-color",
 		"-var=key_name="+f.KeyName,
 		"-state="+f.StateFile,
-		"-var=prefix="+f.Prefix)
+		`-var=prefix="`+f.Prefix+`"`)
 }
 
 func (f *Farmer) apply(args ...string) error {

--- a/acceptance/terraform/main.tf
+++ b/acceptance/terraform/main.tf
@@ -49,12 +49,13 @@ resource "google_compute_instance" "cockroach" {
 }
 
 data "template_file" "supervisor" {
+  count = "${var.num_instances}"
   template = "${file("supervisor.conf.tpl")}"
   vars {
     stores = "${var.stores}"
     cockroach_port = "${var.sql_port}"
     # The value of the --join flag must be empty for the first node,
-    # and a running node for all others. We built a list of addresses
+    # and a running node for all others. We build a list of addresses
     # shifted by one (first element is empty), then take the value at index "instance.index".
     join_address = "${element(concat(split(",", ""), google_compute_instance.cockroach.*.network_interface.0.access_config.0.assigned_nat_ip), count.index)}"
     cockroach_flags = "${var.cockroach_flags}"

--- a/cloud/aws/main.tf
+++ b/cloud/aws/main.tf
@@ -15,6 +15,7 @@ resource "aws_instance" "cockroach" {
 }
 
 data "template_file" "supervisor" {
+  count = "${var.num_instances}"
   template = "${file("supervisor.conf.tpl")}"
   vars {
     stores = "${var.stores}"

--- a/cloud/gce/main.tf
+++ b/cloud/gce/main.tf
@@ -36,6 +36,7 @@ resource "google_compute_instance" "cockroach" {
 }
 
 data "template_file" "supervisor" {
+  count = "${var.num_instances}"
   template = "${file("supervisor.conf.tpl")}"
   vars {
     stores = "${var.stores}"


### PR DESCRIPTION
**terrafarm: always quote Terraform values**
When setting Terraform variables, Farmer was only quoting the values of
two variables.  Now, we quote all values. This resolves the issue where
passed in TESTFLAGS (e.g. `-tf.cockroach-binary`) were being silently
ignored when passed into Terraform because of some unexpected behavior
when using implicitly typed Terraform values with Terraform functions
such as `coalesce`.

For example, when specifying `-tf.cockroach-binary`, Farmer passes
`-var=cockroach_binary=foo` to Terraform. `main.tf` does this to figure
out which `cockroach` binary to copy to the new nodes:

```
coalesce(cockroach_binary, ...)
```

`coalesce` is supposed to return the first non-empty string passed to
it. When `cockroach_binary` is an unquoted string, `coalesce` is
silently ignores the non-empty value for `cockroach_binary`.

**acceptance/terraform+cloud: fix cluster join**
6f59f86 fixed some Terraform warnings but broke the process of new
nodes joining the cluster. It was creating `supervisor.conf` files with
empty `--join` parameters for `cockroach`.

Changing the `template_file` Terraform `resource` to `data` seems to
have the side effect of not implicitly generating the `count` variable.
So, `template_file.join_address` was being set to "", which causes all
created nodes to start a new cluster.

Future Free Friday project: see if there's a viable subset of Terraform to
reimplement for our tests

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9232)

<!-- Reviewable:end -->
