### PR TITLE
kv: remove SendOptions.Timeout

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -368,9 +368,8 @@ func (ds *DistSender) sendRPC(
 
 	// Set RPC opts with stipulation that one of N RPCs must succeed.
 	rpcOpts := SendOptions{
+		ctx:              ctx,
 		SendNextTimeout:  ds.sendNextTimeout,
-		Timeout:          base.NetworkTimeout,
-		Context:          ctx,
 		transportFactory: ds.transportFactory,
 	}
 	tracing.AnnotateTrace()
@@ -1047,7 +1046,7 @@ func (ds *DistSender) sendToReplicas(
 			sendNextTimer.Read = true
 			// On successive RPC timeouts, send to additional replicas if available.
 			if !transport.IsExhausted() {
-				log.Trace(opts.Context, "timeout, trying next peer")
+				log.Trace(opts.ctx, "timeout, trying next peer")
 				pending++
 				transport.SendNext(done)
 			}
@@ -1057,9 +1056,9 @@ func (ds *DistSender) sendToReplicas(
 			err := call.Err
 			if err == nil {
 				if log.V(2) {
-					log.Infof(opts.Context, "RPC reply: %+v", call.Reply)
+					log.Infof(opts.ctx, "RPC reply: %+v", call.Reply)
 				} else if log.V(1) && call.Reply.Error != nil {
-					log.Infof(opts.Context, "application error: %s", call.Reply.Error)
+					log.Infof(opts.ctx, "application error: %s", call.Reply.Error)
 				}
 
 				if !ds.handlePerReplicaError(rangeID, call.Reply.Error) {
@@ -1075,12 +1074,12 @@ func (ds *DistSender) sendToReplicas(
 				// information than a RangeNotFound).
 				err = call.Reply.Error.GoError()
 			} else if log.V(1) {
-				log.Warningf(opts.Context, "RPC error: %s", err)
+				log.Warningf(opts.ctx, "RPC error: %s", err)
 			}
 
 			// Send to additional replicas if available.
 			if !transport.IsExhausted() {
-				log.Tracef(opts.Context, "error, trying next peer: %s", err)
+				log.Tracef(opts.ctx, "error, trying next peer: %s", err)
 				pending++
 				transport.SendNext(done)
 			}

--- a/testutils/error.go
+++ b/testutils/error.go
@@ -55,7 +55,7 @@ func IsPError(pErr *roachpb.Error, re string) bool {
 // that show a connection issue or an issue with the node itself. This can
 // occur when a node is restarting or is unstable in some other way.
 func IsSQLRetryError(err error) bool {
-	return IsError(err, "(connection reset by peer|connection refused|failed to send RPC|EOF|context deadline exceeded)")
+	return IsError(err, "(connection reset by peer|connection refused|failed to send RPC|EOF)")
 }
 
 // Caller returns filename and line number info for the specified stack


### PR DESCRIPTION
This option seems to do more harm than good, often prematurely
terminating still-healthy RPCs.

Fixes #9070.
Fixes #9076.
Fixes #9217.

Updates #9209.

Removes `kv.TestClientNotReady` which is a long-antiquated test, and
long ago stopped testing anything meaningful. In its current
incarnation, it was testing DistSender's handling of byzantine nodes
which would accept connections and then fail to respond to RPCs; that
doesn't seem worth adapting.

Also, this removes "context deadline exceeded" as an acceptable error
in various tests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9234)

<!-- Reviewable:end -->
