### PR TITLE
sql: Return pg error codes for db/table already exists errors

### DIFF
--- a/sql/create.go
+++ b/sql/create.go
@@ -350,7 +350,7 @@ func (n *createTableNode) Start() error {
 		if n.n.IfNotExists {
 			return nil
 		}
-		return descriptorAlreadyExistsErr{&desc, tKey.Name()}
+		return sqlbase.NewRelationAlreadyExistsError(tKey.Name())
 	} else if err != nil {
 		return err
 	}

--- a/sql/descriptor.go
+++ b/sql/descriptor.go
@@ -121,7 +121,14 @@ func (p *planner) createDescriptor(
 			return false, nil
 		}
 		// Key exists, but we don't want it to: error out.
-		return false, descriptorAlreadyExistsErr{descriptor, plainKey.Name()}
+		switch descriptor.TypeName() {
+		case "database":
+			return false, sqlbase.NewDatabaseAlreadyExistsError(plainKey.Name())
+		case "table", "view":
+			return false, sqlbase.NewRelationAlreadyExistsError(plainKey.Name())
+		default:
+			return false, descriptorAlreadyExistsErr{descriptor, plainKey.Name()}
+		}
 	} else if err != nil {
 		return false, err
 	}

--- a/sql/pgwire/pgerror/codes.go
+++ b/sql/pgwire/pgerror/codes.go
@@ -210,7 +210,7 @@ const (
 	CodeDuplicateFunctionError                  = "42723"
 	CodeDuplicatePreparedStatementError         = "42P05"
 	CodeDuplicateSchemaError                    = "42P06"
-	CodeDuplicateTableError                     = "42P07"
+	CodeDuplicateRelationError                  = "42P07"
 	CodeDuplicateAliasError                     = "42712"
 	CodeDuplicateObjectError                    = "42710"
 	CodeAmbiguousColumnError                    = "42702"

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -697,7 +697,7 @@ func TestPGPreparedExec(t *testing.T) {
 			"CREATE TABLE d.t (i INT, s STRING, d INT)",
 			[]preparedExecTest{
 				baseTest,
-				baseTest.Error(`pq: table "t" already exists`),
+				baseTest.Error(`pq: relation "t" already exists`),
 			},
 		},
 		{

--- a/sql/rename_test.go
+++ b/sql/rename_test.go
@@ -212,7 +212,7 @@ CREATE TABLE test.t (a INT PRIMARY KEY);
 	// name is not deleted from the database until the async schema changer checks
 	// that there's no more leases on the old version).
 	if _, err := db.Exec("CREATE TABLE test.t (a INT PRIMARY KEY)"); !testutils.IsError(
-		err, `table "t" already exists`) {
+		err, `relation "t" already exists`) {
 		t.Fatal(err)
 	}
 

--- a/sql/sqlbase/errors.go
+++ b/sql/sqlbase/errors.go
@@ -268,6 +268,56 @@ func (e *ErrUndefinedDatabase) SrcContext() SrcCtx {
 	return e.ctx
 }
 
+// NewDatabaseAlreadyExistsError creates a new ErrDatabaseAlreadyExists.
+func NewDatabaseAlreadyExistsError(name string) error {
+	return &ErrDatabaseAlreadyExists{ctx: MakeSrcCtx(1), name: name}
+}
+
+// ErrDatabaseAlreadyExists represents a missing database error.
+type ErrDatabaseAlreadyExists struct {
+	ctx  SrcCtx
+	name string
+}
+
+func (e *ErrDatabaseAlreadyExists) Error() string {
+	return fmt.Sprintf("database %q already exists", e.name)
+}
+
+// Code implements the ErrorWithPGCode interface.
+func (*ErrDatabaseAlreadyExists) Code() string {
+	return pgerror.CodeDuplicateDatabaseError
+}
+
+// SrcContext implements the ErrorWithPGCode interface.
+func (e *ErrDatabaseAlreadyExists) SrcContext() SrcCtx {
+	return e.ctx
+}
+
+// NewRelationAlreadyExistsError creates a new ErrRelationAlreadyExists.
+func NewRelationAlreadyExistsError(name string) error {
+	return &ErrRelationAlreadyExists{ctx: MakeSrcCtx(1), name: name}
+}
+
+// ErrRelationAlreadyExists represents a missing database error.
+type ErrRelationAlreadyExists struct {
+	ctx  SrcCtx
+	name string
+}
+
+func (e *ErrRelationAlreadyExists) Error() string {
+	return fmt.Sprintf("relation %q already exists", e.name)
+}
+
+// Code implements the ErrorWithPGCode interface.
+func (*ErrRelationAlreadyExists) Code() string {
+	return pgerror.CodeDuplicateRelationError
+}
+
+// SrcContext implements the ErrorWithPGCode interface.
+func (e *ErrRelationAlreadyExists) SrcContext() SrcCtx {
+	return e.ctx
+}
+
 // IsIntegrityConstraintError returns true if the error is some kind of SQL
 // constraint violation.
 func IsIntegrityConstraintError(err error) bool {

--- a/sql/testdata/database
+++ b/sql/testdata/database
@@ -1,7 +1,7 @@
 statement ok
 CREATE DATABASE a
 
-statement error database "a" already exists
+statement error pgcode 42P04 database "a" already exists
 CREATE DATABASE a
 
 statement ok

--- a/sql/testdata/set
+++ b/sql/testdata/set
@@ -43,7 +43,7 @@ statement error no database specified
 SHOW TABLES
 
 # SET statement succeeds, CREATE TABLE fails.
-statement error table \"bar\" already exists
+statement error pgcode 42P07 relation \"bar\" already exists
 SET DATABASE = foo; CREATE TABLE bar (k INT PRIMARY KEY)
 
 query T colnames

--- a/sql/testdata/table
+++ b/sql/testdata/table
@@ -10,7 +10,7 @@ CREATE TABLE test."" (id INT PRIMARY KEY)
 statement ok
 CREATE TABLE test.a (id INT PRIMARY KEY)
 
-statement error table "a" already exists
+statement error pgcode 42P07 relation "a" already exists
 CREATE TABLE test.a (id INT PRIMARY KEY)
 
 statement ok
@@ -19,7 +19,7 @@ SET DATABASE = test
 statement error empty table name
 CREATE TABLE "" (id INT PRIMARY KEY)
 
-statement error table "a" already exists
+statement error pgcode 42P07 relation "a" already exists
 CREATE TABLE a (id INT PRIMARY KEY)
 
 statement error duplicate column name: "id"


### PR DESCRIPTION
Ran into this while working on tests for views. This allows us to match the postgres error codes and returned by postgres for DB/relation already exists errors.

It also switches the error message from `table "foo" already exists` to `relation "foo" already exists` to maintain correctness when both tables and views are in play. We could return the exact type of the conflicting descriptor with a bit more work in descriptor.go, if you'd prefer.

Postgres returns a `relation "foo" already exists` error for all table/view conflicts.
MySQL returns a `Table 'foo' already exists` error even when the relation involved is actually a view.

@knz

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9235)

<!-- Reviewable:end -->
