### PR TITLE
Revert "Revert "kv: Set default SendNextTimeout to a reasonable value""

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -42,10 +42,7 @@ import (
 const (
 	// TODO(bdarnell): make SendNextTimeout configurable.
 	// https://github.com/cockroachdb/cockroach/issues/6719
-	//
-	// Temporarily increased from 500ms to 10s; see
-	// https://github.com/cockroachdb/cockroach/issues/6750
-	defaultSendNextTimeout = 10 * time.Second
+	defaultSendNextTimeout = 500 * time.Millisecond
 	defaultClientTimeout   = 10 * time.Second
 
 	// The default maximum number of ranges to return from a range


### PR DESCRIPTION
This reverts commit 3869b40333c3446a1af1c16563fdb7419e7dce29.

Some related races have been fixed in 9c72e42 and subsequent changes,
making it likely that this is worth trying again.

Closes #6750.

@cockroachdb/stability 

I think we might want to bake this out of band before merging, particularly on Rho.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9239)

<!-- Reviewable:end -->
