### PR TITLE
sql: implement CASCADE for TRUNCATE

### DIFF
--- a/sql/testdata/fk
+++ b/sql/testdata/fk
@@ -122,12 +122,6 @@ INSERT INTO scans (scanned) VALUES ('867072000006'), ('missing'), ('885155001450
 statement error foreign key violation: values \['867072000006'\] in columns \[upc\] referenced in table "scans"
 DELETE FROM products WHERE sku = 'VP-W9QH-W44L'
 
-statement error foreign key violation: non-empty
-TRUNCATE products
-
-statement error CASCADE not yet supported: foreign key violation
-TRUNCATE products CASCADE
-
 # Blanking a field nobody cares about is fine.
 statement ok
 UPDATE products SET vendor = '' WHERE sku = '780'
@@ -174,7 +168,7 @@ statement error foreign key violation: values \['885155001450'\] in columns \[up
 UPDATE products SET upc = 'blah' WHERE sku = '780'
 
 statement ok
-TRUNCATE orders
+TRUNCATE orders, reviews
 
 # Changing now non-referenced and secondary field is fine.
 statement ok
@@ -187,14 +181,24 @@ UPDATE products SET sku = '780', upc = 'blah' WHERE sku = '750'
 statement error foreign key violation: values \['885155001450'\] in columns \[upc\] referenced in table "scans"
 DELETE FROM products WHERE sku = '750'
 
-statement error foreign key violation: non-empty columns \[upc\] referenced in table "scans"
+statement error "products" is referenced by foreign key from table "orders"
 TRUNCATE products
 
-statement ok
-TRUNCATE scans
+query I
+SELECT COUNT(*) FROM scans
+----
+4
 
 statement ok
-TRUNCATE products
+TRUNCATE products CASCADE
+
+query I
+SELECT COUNT(*) FROM scans
+----
+0
+
+statement ok
+TRUNCATE scans, products, orders, reviews
 
 query TTTTT colnames
 SHOW CONSTRAINTS FROM orders


### PR DESCRIPTION
Also switches non-cascade behavior to match pg: truncate fails unless referencing table is also explicitly truncated, _even if it is empty_.
Previously, we actually read the referencing table, similar to how a DELETE is checked.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9240)

<!-- Reviewable:end -->
