### PR TITLE
client: clean up the txnSender mess

### DIFF
--- a/internal/client/txn.go
+++ b/internal/client/txn.go
@@ -33,66 +33,10 @@ import (
 	"github.com/cockroachdb/cockroach/util/tracing"
 )
 
-// txnSender implements the Sender interface and is used to keep the Send
-// method out of the Txn method set.
-type txnSender Txn
-
-// Send updates the transaction on error. Depending on the error type, the
-// transaction might be replaced by a new one.
-func (ts *txnSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-	// Send call through wrapped sender.
-	ba.Txn = &ts.Proto
-	// For testing purposes, ts.UserPriority can be a negative value (see
-	// MakePriority).
-	if ts.UserPriority != 0 {
-		ba.UserPriority = ts.UserPriority
-	}
-
-	br, pErr := ts.wrapped.Send(ts.Context, ba)
-	if br != nil && br.Error != nil {
-		panic(roachpb.ErrorUnexpectedlySet(ts.wrapped, br))
-	}
-
-	if br != nil {
-		for _, encSp := range br.CollectedSpans {
-			var newSp basictracer.RawSpan
-			if err := tracing.DecodeRawSpan(encSp, &newSp); err != nil {
-				return nil, roachpb.NewError(err)
-			}
-			ts.CollectedSpans = append(ts.CollectedSpans, newSp)
-		}
-	}
-	// Only successful requests can carry an updated Txn in their response
-	// header. Any error (e.g. a restart) can have a Txn attached to them as
-	// well; those update our local state in the same way for the next attempt.
-	// The exception is if our transaction was aborted and needs to restart
-	// from scratch, in which case we do just that.
-	if pErr == nil {
-		ts.Proto.Update(br.Txn)
-		return br, nil
-	} else if _, ok := pErr.GetDetail().(*roachpb.TransactionAbortedError); ok {
-		// On Abort, reset the transaction so we start anew on restart.
-		ts.Proto = roachpb.Transaction{
-			TxnMeta: enginepb.TxnMeta{
-				Isolation: ts.Proto.Isolation,
-			},
-			Name: ts.Proto.Name,
-		}
-		// Acts as a minimum priority on restart.
-		if pErr.GetTxn() != nil {
-			ts.Proto.Priority = pErr.GetTxn().Priority
-		}
-	} else if pErr.TransactionRestart != roachpb.TransactionRestart_NONE {
-		ts.Proto.Update(pErr.GetTxn())
-	}
-	return nil, pErr
-}
-
 // Txn is an in-progress distributed database transaction. A Txn is not safe for
 // concurrent use by multiple goroutines.
 type Txn struct {
 	db             DB
-	wrapped        Sender
 	Proto          roachpb.Transaction
 	UserPriority   roachpb.UserPriority
 	Context        context.Context // must not be nil
@@ -109,13 +53,10 @@ type Txn struct {
 
 // NewTxn returns a new txn.
 func NewTxn(ctx context.Context, db DB) *Txn {
-	txn := &Txn{
+	return &Txn{
 		db:      db,
-		wrapped: db.sender,
 		Context: ctx,
 	}
-	txn.db.sender = (*txnSender)(txn)
-	return txn
 }
 
 // IsFinalized returns true if this Txn has been finalized and should therefore
@@ -588,6 +529,72 @@ func (txn *Txn) Exec(
 	return err
 }
 
+// sendInternal sends the batch and updates the transaction on error. Depending
+// on the error type, the transaction might be replaced by a new one.
+func (txn *Txn) sendInternal(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+	if len(ba.Requests) == 0 {
+		return nil, nil
+	}
+	if pErr := txn.db.prepareToSend(&ba); pErr != nil {
+		return nil, pErr
+	}
+
+	// Send call through the DB's sender.
+	ba.Txn = &txn.Proto
+	// For testing purposes, txn.UserPriority can be a negative value (see
+	// MakePriority).
+	if txn.UserPriority != 0 {
+		ba.UserPriority = txn.UserPriority
+	}
+
+	// TODO(radu): when db.send supports a context, we can just use that (and
+	// remove the prepareToSend call above).
+	br, pErr := txn.db.sender.Send(txn.Context, ba)
+	if br != nil && br.Error != nil {
+		panic(roachpb.ErrorUnexpectedlySet(txn.db.sender, br))
+	}
+
+	if br != nil {
+		for _, encSp := range br.CollectedSpans {
+			var newSp basictracer.RawSpan
+			if err := tracing.DecodeRawSpan(encSp, &newSp); err != nil {
+				return nil, roachpb.NewError(err)
+			}
+			txn.CollectedSpans = append(txn.CollectedSpans, newSp)
+		}
+	}
+	// Only successful requests can carry an updated Txn in their response
+	// header. Any error (e.g. a restart) can have a Txn attached to them as
+	// well; those update our local state in the same way for the next attempt.
+	// The exception is if our transaction was aborted and needs to restart
+	// from scratch, in which case we do just that.
+	if pErr == nil {
+		txn.Proto.Update(br.Txn)
+		return br, nil
+	}
+
+	if log.V(1) {
+		log.Infof(txn.Context, "failed batch: %s", pErr)
+	}
+
+	if _, ok := pErr.GetDetail().(*roachpb.TransactionAbortedError); ok {
+		// On Abort, reset the transaction so we start anew on restart.
+		txn.Proto = roachpb.Transaction{
+			TxnMeta: enginepb.TxnMeta{
+				Isolation: txn.Proto.Isolation,
+			},
+			Name: txn.Proto.Name,
+		}
+		// Acts as a minimum priority on restart.
+		if pErr.GetTxn() != nil {
+			txn.Proto.Priority = pErr.GetTxn().Priority
+		}
+	} else if pErr.TransactionRestart != roachpb.TransactionRestart_NONE {
+		txn.Proto.Update(pErr.GetTxn())
+	}
+	return nil, pErr
+}
+
 // send runs the specified calls synchronously in a single batch and
 // returns any errors. If the transaction is read-only or has already
 // been successfully committed or aborted, a potential trailing
@@ -666,7 +673,7 @@ func (txn *Txn) send(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.
 		ba.Requests = ba.Requests[:lastIndex]
 	}
 
-	br, pErr := txn.db.send(ba)
+	br, pErr := txn.sendInternal(ba)
 	if elideEndTxn && pErr == nil {
 		// Check that read only transactions do not violate their deadline. This can NOT
 		// happen since the txn deadline is normally updated when it is about to expire

--- a/internal/client/txn_test.go
+++ b/internal/client/txn_test.go
@@ -163,7 +163,7 @@ func TestTxnRequestTxnTimestamp(t *testing.T) {
 	txn := NewTxn(context.Background(), *db)
 
 	for testIdx = range testCases {
-		if _, pErr := txn.db.sender.Send(context.Background(), ba); pErr != nil {
+		if _, pErr := txn.sendInternal(ba); pErr != nil {
 			t.Fatal(pErr)
 		}
 	}
@@ -177,7 +177,7 @@ func TestTxnResetTxnOnAbort(t *testing.T) {
 	}, nil))
 
 	txn := NewTxn(context.Background(), *db)
-	_, pErr := txn.db.sender.Send(context.Background(), testPut())
+	_, pErr := txn.sendInternal(testPut())
 	if _, ok := pErr.GetDetail().(*roachpb.TransactionAbortedError); !ok {
 		t.Fatalf("expected TransactionAbortedError, got %v", pErr)
 	}
@@ -757,7 +757,7 @@ func TestSetPriority(t *testing.T) {
 	if err := txn.SetUserPriority(expected); err != nil {
 		t.Fatal(err)
 	}
-	if _, pErr := txn.db.sender.Send(context.Background(), roachpb.BatchRequest{}); pErr != nil {
+	if _, pErr := txn.sendInternal(roachpb.BatchRequest{}); pErr != nil {
 		t.Fatal(pErr)
 	}
 
@@ -765,7 +765,7 @@ func TestSetPriority(t *testing.T) {
 	expected = roachpb.UserPriority(-13)
 	txn = NewTxn(context.Background(), *db)
 	txn.InternalSetPriority(13)
-	if _, pErr := txn.db.sender.Send(context.Background(), roachpb.BatchRequest{}); pErr != nil {
+	if _, pErr := txn.sendInternal(roachpb.BatchRequest{}); pErr != nil {
 		t.Fatal(pErr)
 	}
 }


### PR DESCRIPTION
This is a rough description of the current nightmare in Txn: NewTxn takes a db;
it remembers the db's original Sender in txn.wrapped, and then it highjacks
`db.sender`, setting it to txnSender. txnSender is a Sender implementation
which uses the saved (wrapped) sender internally (it also ignores the provided
context).

All this mind bending stuff is there for the sole purpose of reusing the code
in `db.send()` which does very little stuff before calling to db.sender.

Cleaning all this stuff up. We keep DB as is, and use a `sendInternal` function
instead of `db.send`. Factoring out the little stuff that `db.send()` does into
`db.prepareToSend()` so we can reuse it. This will be folded back into
`db.send()` once it supports a context.

This is against `master` because we will do more context plumbing work in this code.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9248)

<!-- Reviewable:end -->
