### PR TITLE
gossip: fix occasional unittest failure, improve logging

### DIFF
--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -162,7 +162,7 @@ func (n *Network) GetNodeFromID(nodeID roachpb.NodeID) (*Node, bool) {
 func (n *Network) SimulateNetwork(simCallback func(cycle int, network *Network) bool) {
 	n.Start()
 	nodes := n.Nodes
-	for cycle := 1; simCallback(cycle, n); cycle++ {
+	for cycle := 1; ; cycle++ {
 		// Node 0 gossips sentinel & cluster ID every cycle.
 		if err := nodes[0].Gossip.AddInfo(
 			gossip.KeySentinel,
@@ -188,6 +188,11 @@ func (n *Network) SimulateNetwork(simCallback func(cycle int, network *Network) 
 				log.Fatal(context.TODO(), err)
 			}
 			node.Gossip.SimulationCycle()
+		}
+		// If the simCallback returns false, we're done with the
+		// simulation; exit the loop.
+		if !simCallback(cycle, n) {
+			break
 		}
 		time.Sleep(5 * time.Millisecond)
 	}


### PR DESCRIPTION
Issue was that sometimes the network would become fully connected
the first time through the sim loop, before the sentinel could
be gossiped, so no cleanup would ever occur. We now guarantee at
least one iteration of the sim loop.

Fixes #9155

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9249)

<!-- Reviewable:end -->
