### PR TITLE
cli: fix the doc for 'zone set' and add a new flag --disable-replication

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -167,6 +167,8 @@ func captureOutput(f func()) (out string, err error) {
 
 func (c cliTest) RunWithArgs(a []string) {
 	sqlCtx.execStmts = nil
+	zoneConfig = ""
+	zoneDisableReplication = false
 
 	var args []string
 	args = append(args, a[0])
@@ -497,6 +499,8 @@ func Example_zone() {
 	c.Run("zone rm .default")
 	c.Run("zone set .default --file=./testdata/zone_range_max_bytes.yaml")
 	c.Run("zone get system")
+	c.Run("zone set .default --disable-replication")
+	c.Run("zone get system")
 
 	// Output:
 	// zone ls
@@ -526,7 +530,7 @@ func Example_zone() {
 	// range_max_bytes: 134217728
 	// gc:
 	//   ttlseconds: 86400
-	// num_replicas: 1
+	// num_replicas: 3
 	// constraints: [us-east-1a, ssd]
 	// zone get system
 	// system
@@ -534,7 +538,7 @@ func Example_zone() {
 	// range_max_bytes: 134217728
 	// gc:
 	//   ttlseconds: 86400
-	// num_replicas: 1
+	// num_replicas: 3
 	// constraints: [us-east-1a, ssd]
 	// zone rm system
 	// DELETE 1
@@ -543,6 +547,21 @@ func Example_zone() {
 	// zone rm .default
 	// unable to remove .default
 	// zone set .default --file=./testdata/zone_range_max_bytes.yaml
+	// range_min_bytes: 1048576
+	// range_max_bytes: 134217728
+	// gc:
+	//   ttlseconds: 86400
+	// num_replicas: 3
+	// constraints: []
+	// zone get system
+	// .default
+	// range_min_bytes: 1048576
+	// range_max_bytes: 134217728
+	// gc:
+	//   ttlseconds: 86400
+	// num_replicas: 3
+	// constraints: []
+	// zone set .default --disable-replication
 	// range_min_bytes: 1048576
 	// range_max_bytes: 134217728
 	// gc:

--- a/cli/cliflags/flags.go
+++ b/cli/cliflags/flags.go
@@ -74,6 +74,13 @@ tiers and order must be the same on all nodes.  For example:
 File to read the zone configuration from. Specify "-" to read from standard input.`,
 	}
 
+	ZoneDisableReplication = FlagInfo{
+		Name: "disable-replication",
+		Description: `
+Disable replication in the zone by setting the desired replica count to 1.
+Equivalent to setting 'num_replicas: 1' via -f.`,
+	}
+
 	Background = FlagInfo{
 		Name: "background",
 		Description: `

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -43,6 +43,7 @@ var maxResults int64
 
 var connURL string
 var connUser, connHost, connPort, httpPort, httpAddr, connDBName, zoneConfig string
+var zoneDisableReplication bool
 var startBackground bool
 var undoFreezeCluster bool
 
@@ -364,7 +365,9 @@ func init() {
 		boolFlag(f, &cliCtx.prettyFmt, cliflags.Pretty, isInteractive)
 	}
 
-	stringFlag(setZoneCmd.Flags(), &zoneConfig, cliflags.ZoneConfig, "")
+	zf := setZoneCmd.Flags()
+	stringFlag(zf, &zoneConfig, cliflags.ZoneConfig, "")
+	boolFlag(zf, &zoneDisableReplication, cliflags.ZoneDisableReplication, false)
 
 	varFlag(sqlShellCmd.Flags(), &sqlCtx.execStmts, cliflags.Execute)
 

--- a/cli/testdata/zone_range_max_bytes.yaml
+++ b/cli/testdata/zone_range_max_bytes.yaml
@@ -1,1 +1,2 @@
 range_max_bytes: 134217728
+num_replicas: 3


### PR DESCRIPTION
The help text for `zone set` was outdated since
c19f31b2d47c6b80c59eae8a0cea6d981a8d71a9.
This patch addresses this.

In addition `zone set` now also supports a new flag
`--disable-replication` which is equivalent to passing a file
containing `num_replicas: 1` via -f.

Fixes #9251.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9253)

<!-- Reviewable:end -->
