### PR TITLE
kv: Hack around GRPC context leak

### DIFF
--- a/kv/transport.go
+++ b/kv/transport.go
@@ -178,7 +178,15 @@ func (gt *grpcTransport) SendNext(done chan<- BatchCall) {
 	}
 
 	go func() {
-		reply, err := client.client.Batch(gt.opts.ctx, &client.args)
+		// HACK: GRPC leaks if client calls are made with a context which
+		// is cancelable but doesn't actually get canceled. Insulate this
+		// call from our outer context, which may last for the lifetime of
+		// a client session.
+		// TODO(bdarnell): remove after https://github.com/grpc/grpc-go/issues/888
+		// is fixed.
+		ctx, cancel := context.WithCancel(gt.opts.ctx)
+		defer cancel()
+		reply, err := client.client.Batch(ctx, &client.args)
 		if reply != nil {
 			for i := range reply.Responses {
 				if err := reply.Responses[i].GetInner().Verify(client.args.Requests[i].GetInner()); err != nil {


### PR DESCRIPTION
I believe this will prevent the leak described in
https://github.com/grpc/grpc-go/issues/888

This gives us a workaround we can deploy while waiting on upstream, if we want to. We can see whether this fixes all or part of #9252.

@cockroachdb/stability

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9258)

<!-- Reviewable:end -->
