### PR TITLE
client: add context to DB.Run()

### DIFF
--- a/cli/kv.go
+++ b/cli/kv.go
@@ -126,7 +126,7 @@ func runPut(cmd *cobra.Command, args []string) {
 	kvDB, stopper := makeDBClient()
 	defer stopper.Stop()
 
-	if err := kvDB.Run(b); err != nil {
+	if err := kvDB.Run(context.Background(), b); err != nil {
 		panicf("put failed: %s", err)
 	}
 }
@@ -237,7 +237,7 @@ func runDel(cmd *cobra.Command, args []string) {
 	kvDB, stopper := makeDBClient()
 	defer stopper.Stop()
 
-	if err := kvDB.Run(b); err != nil {
+	if err := kvDB.Run(context.Background(), b); err != nil {
 		panicf("delete failed: %s", err)
 	}
 }

--- a/internal/client/db.go
+++ b/internal/client/db.go
@@ -211,7 +211,7 @@ func NewDBWithContext(sender Sender, ctx DBContext) *DB {
 func (db *DB) Get(key interface{}) (KeyValue, error) {
 	b := &Batch{}
 	b.Get(key)
-	return runOneRow(db, b)
+	return getOneRow(db.Run(b), b)
 }
 
 // GetProto retrieves the value for a key and decodes the result as a proto
@@ -233,8 +233,7 @@ func (db *DB) GetProto(key interface{}, msg proto.Message) error {
 func (db *DB) Put(key, value interface{}) error {
 	b := &Batch{}
 	b.Put(key, value)
-	_, err := runOneResult(db, b)
-	return err
+	return getOneErr(db.Run(b), b)
 }
 
 // PutInline sets the value for a key, but does not maintain
@@ -247,8 +246,7 @@ func (db *DB) Put(key, value interface{}) error {
 func (db *DB) PutInline(key, value interface{}) error {
 	b := &Batch{}
 	b.PutInline(key, value)
-	_, err := runOneResult(db, b)
-	return err
+	return getOneErr(db.Run(b), b)
 }
 
 // CPut conditionally sets the value for a key if the existing value is equal
@@ -261,8 +259,7 @@ func (db *DB) PutInline(key, value interface{}) error {
 func (db *DB) CPut(key, value, expValue interface{}) error {
 	b := &Batch{}
 	b.CPut(key, value, expValue)
-	_, err := runOneResult(db, b)
-	return err
+	return getOneErr(db.Run(b), b)
 }
 
 // InitPut sets the first value for a key to value. An error is reported if a
@@ -274,8 +271,7 @@ func (db *DB) CPut(key, value, expValue interface{}) error {
 func (db *DB) InitPut(key, value interface{}) error {
 	b := &Batch{}
 	b.InitPut(key, value)
-	_, err := runOneResult(db, b)
-	return err
+	return getOneErr(db.Run(b), b)
 }
 
 // Inc increments the integer value at key. If the key does not exist it will
@@ -286,7 +282,7 @@ func (db *DB) InitPut(key, value interface{}) error {
 func (db *DB) Inc(key interface{}, value int64) (KeyValue, error) {
 	b := &Batch{}
 	b.Inc(key, value)
-	return runOneRow(db, b)
+	return getOneRow(db.Run(b), b)
 }
 
 func (db *DB) scan(
@@ -305,7 +301,7 @@ func (db *DB) scan(
 	} else {
 		b.ReverseScan(begin, end)
 	}
-	r, err := runOneResult(db, b)
+	r, err := getOneResult(db.Run(b), b)
 	return r.Rows, err
 }
 
@@ -335,8 +331,7 @@ func (db *DB) ReverseScan(begin, end interface{}, maxRows int64) ([]KeyValue, er
 func (db *DB) Del(keys ...interface{}) error {
 	b := &Batch{}
 	b.Del(keys...)
-	_, err := runOneResult(db, b)
-	return err
+	return getOneErr(db.Run(b), b)
 }
 
 // DelRange deletes the rows between begin (inclusive) and end (exclusive).
@@ -347,8 +342,7 @@ func (db *DB) Del(keys ...interface{}) error {
 func (db *DB) DelRange(begin, end interface{}) error {
 	b := &Batch{}
 	b.DelRange(begin, end, false)
-	_, err := runOneResult(db, b)
-	return err
+	return getOneErr(db.Run(b), b)
 }
 
 // AdminMerge merges the range containing key and the subsequent
@@ -360,8 +354,7 @@ func (db *DB) DelRange(begin, end interface{}) error {
 func (db *DB) AdminMerge(key interface{}) error {
 	b := &Batch{}
 	b.adminMerge(key)
-	_, err := runOneResult(db, b)
-	return err
+	return getOneErr(db.Run(b), b)
 }
 
 // AdminSplit splits the range at splitkey.
@@ -370,8 +363,7 @@ func (db *DB) AdminMerge(key interface{}) error {
 func (db *DB) AdminSplit(splitKey interface{}) error {
 	b := &Batch{}
 	b.adminSplit(splitKey)
-	_, err := runOneResult(db, b)
-	return err
+	return getOneErr(db.Run(b), b)
 }
 
 // AdminTransferLease transfers the lease for the range containing key to the
@@ -382,8 +374,7 @@ func (db *DB) AdminSplit(splitKey interface{}) error {
 func (db *DB) AdminTransferLease(key interface{}, target roachpb.StoreID) error {
 	b := &Batch{}
 	b.adminTransferLease(key, target)
-	_, err := runOneResult(db, b)
-	return err
+	return getOneErr(db.Run(b), b)
 }
 
 // CheckConsistency runs a consistency check on all the ranges containing
@@ -392,8 +383,7 @@ func (db *DB) AdminTransferLease(key interface{}, target roachpb.StoreID) error 
 func (db *DB) CheckConsistency(begin, end interface{}, withDiff bool) error {
 	b := &Batch{}
 	b.CheckConsistency(begin, end, withDiff)
-	_, err := runOneResult(db, b)
-	return err
+	return getOneErr(db.Run(b), b)
 }
 
 // sendAndFill is a helper which sends the given batch and fills its results,
@@ -427,7 +417,17 @@ func sendAndFill(
 	return nil
 }
 
-// Run implements Runner.Run(). See comments there.
+// Run executes the operations queued up within a batch. Before executing any
+// of the operations the batch is first checked to see if there were any errors
+// during its construction (e.g. failure to marshal a proto message).
+//
+// The operations within a batch are run in parallel and the order is
+// non-deterministic. It is an unspecified behavior to modify and retrieve the
+// same key within a batch.
+//
+// Upon completion, Batch.Results will contain the results for each
+// operation. The order of the results matches the order the operations were
+// added to the batch.
 func (db *DB) Run(b *Batch) error {
 	if err := b.prepare(); err != nil {
 		return err
@@ -504,38 +504,35 @@ func (db *DB) send(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Er
 	return br, nil
 }
 
-// Runner only exports the Run method on a batch of operations.
-type Runner interface {
-	// Run executes the operations queued up within a batch. Before executing any
-	// of the operations the batch is first checked to see if there were any errors
-	// during its construction (e.g. failure to marshal a proto message).
-	//
-	// The operations within a batch are run in parallel and the order is
-	// non-deterministic. It is an unspecified behavior to modify and retrieve the
-	// same key within a batch.
-	//
-	// Upon completion, Batch.Results will contain the results for each
-	// operation. The order of the results matches the order the operations were
-	// added to the batch.
-	Run(b *Batch) error
+// getOneErr returns the error for a single-request Batch that was run.
+// runErr is the error returned by Run, b is the Batch that was passed to Run.
+func getOneErr(runErr error, b *Batch) error {
+	if runErr != nil && len(b.Results) > 0 {
+		return b.Results[0].Err
+	}
+	return runErr
 }
 
-func runOneResult(r Runner, b *Batch) (Result, error) {
-	if err := r.Run(b); err != nil {
+// getOneResult returns the result for a single-request Batch that was run.
+// runErr is the error returned by Run, b is the Batch that was passed to Run.
+func getOneResult(runErr error, b *Batch) (Result, error) {
+	if runErr != nil {
 		if len(b.Results) > 0 {
 			return b.Results[0], b.Results[0].Err
 		}
-		return Result{Err: err}, err
+		return Result{Err: runErr}, runErr
 	}
 	res := b.Results[0]
 	if res.Err != nil {
-		panic("r.Run() succeeded even through the result has an error")
+		panic("run succeeded even through the result has an error")
 	}
 	return res, nil
 }
 
-func runOneRow(r Runner, b *Batch) (KeyValue, error) {
-	res, err := runOneResult(r, b)
+// getOneRow returns the first row for a single-request Batch that was run.
+// runErr is the error returned by Run, b is the Batch that was passed to Run.
+func getOneRow(runErr error, b *Batch) (KeyValue, error) {
+	res, err := getOneResult(runErr, b)
 	if err != nil {
 		return KeyValue{}, err
 	}

--- a/internal/client/db_test.go
+++ b/internal/client/db_test.go
@@ -192,7 +192,7 @@ func TestBatch(t *testing.T) {
 	b := &client.Batch{}
 	b.Get("aa")
 	b.Put("bb", "2")
-	if err := db.Run(b); err != nil {
+	if err := db.Run(context.TODO(), b); err != nil {
 		panic(err)
 	}
 
@@ -212,7 +212,7 @@ func TestDB_Scan(t *testing.T) {
 	b.Put("aa", "1")
 	b.Put("ab", "2")
 	b.Put("bb", "3")
-	if err := db.Run(b); err != nil {
+	if err := db.Run(context.TODO(), b); err != nil {
 		panic(err)
 	}
 	rows, err := db.Scan("a", "b", 100)
@@ -237,7 +237,7 @@ func TestDB_ReverseScan(t *testing.T) {
 	b.Put("aa", "1")
 	b.Put("ab", "2")
 	b.Put("bb", "3")
-	if err := db.Run(b); err != nil {
+	if err := db.Run(context.TODO(), b); err != nil {
 		panic(err)
 	}
 	rows, err := db.ReverseScan("ab", "c", 100)
@@ -262,7 +262,7 @@ func TestDB_Del(t *testing.T) {
 	b.Put("aa", "1")
 	b.Put("ab", "2")
 	b.Put("ac", "3")
-	if err := db.Run(b); err != nil {
+	if err := db.Run(context.TODO(), b); err != nil {
 		panic(err)
 	}
 	if err := db.Del("ab"); err != nil {
@@ -298,7 +298,7 @@ func TestTxn_Commit(t *testing.T) {
 	b := &client.Batch{}
 	b.Get("aa")
 	b.Get("ab")
-	if err := db.Run(b); err != nil {
+	if err := db.Run(context.TODO(), b); err != nil {
 		panic(err)
 	}
 	expected := map[string][]byte{

--- a/internal/client/txn.go
+++ b/internal/client/txn.go
@@ -163,7 +163,7 @@ func (txn *Txn) NewBatch() *Batch {
 func (txn *Txn) Get(key interface{}) (KeyValue, error) {
 	b := txn.NewBatch()
 	b.Get(key)
-	return runOneRow(txn, b)
+	return getOneRow(txn.Run(b), b)
 }
 
 // GetProto retrieves the value for a key and decodes the result as a proto
@@ -185,8 +185,7 @@ func (txn *Txn) GetProto(key interface{}, msg proto.Message) error {
 func (txn *Txn) Put(key, value interface{}) error {
 	b := txn.NewBatch()
 	b.Put(key, value)
-	_, err := runOneResult(txn, b)
-	return err
+	return getOneErr(txn.Run(b), b)
 }
 
 // CPut conditionally sets the value for a key if the existing value is equal
@@ -199,8 +198,7 @@ func (txn *Txn) Put(key, value interface{}) error {
 func (txn *Txn) CPut(key, value, expValue interface{}) error {
 	b := txn.NewBatch()
 	b.CPut(key, value, expValue)
-	_, err := runOneResult(txn, b)
-	return err
+	return getOneErr(txn.Run(b), b)
 }
 
 // InitPut sets the first value for a key to value. An error is reported if a
@@ -212,8 +210,7 @@ func (txn *Txn) CPut(key, value, expValue interface{}) error {
 func (txn *Txn) InitPut(key, value interface{}) error {
 	b := txn.NewBatch()
 	b.InitPut(key, value)
-	_, err := runOneResult(txn, b)
-	return err
+	return getOneErr(txn.Run(b), b)
 }
 
 // Inc increments the integer value at key. If the key does not exist it will
@@ -227,7 +224,7 @@ func (txn *Txn) InitPut(key, value interface{}) error {
 func (txn *Txn) Inc(key interface{}, value int64) (KeyValue, error) {
 	b := txn.NewBatch()
 	b.Inc(key, value)
-	return runOneRow(txn, b)
+	return getOneRow(txn.Run(b), b)
 }
 
 func (txn *Txn) scan(begin, end interface{}, maxRows int64, isReverse bool) ([]KeyValue, error) {
@@ -240,7 +237,7 @@ func (txn *Txn) scan(begin, end interface{}, maxRows int64, isReverse bool) ([]K
 	} else {
 		b.ReverseScan(begin, end)
 	}
-	r, err := runOneResult(txn, b)
+	r, err := getOneResult(txn.Run(b), b)
 	return r.Rows, err
 }
 
@@ -276,8 +273,7 @@ var _ = (*Txn)(nil).ReverseScan
 func (txn *Txn) Del(keys ...interface{}) error {
 	b := txn.NewBatch()
 	b.Del(keys...)
-	_, err := runOneResult(txn, b)
-	return err
+	return getOneErr(txn.Run(b), b)
 }
 
 // DelRange deletes the rows between begin (inclusive) and end (exclusive).
@@ -289,11 +285,20 @@ func (txn *Txn) Del(keys ...interface{}) error {
 func (txn *Txn) DelRange(begin, end interface{}) error {
 	b := txn.NewBatch()
 	b.DelRange(begin, end, false)
-	_, err := runOneResult(txn, b)
-	return err
+	return getOneErr(txn.Run(b), b)
 }
 
-// Run implements Runner.Run(). See comments there.
+// Run executes the operations queued up within a batch. Before executing any
+// of the operations the batch is first checked to see if there were any errors
+// during its construction (e.g. failure to marshal a proto message).
+//
+// The operations within a batch are run in parallel and the order is
+// non-deterministic. It is an unspecified behavior to modify and retrieve the
+// same key within a batch.
+//
+// Upon completion, Batch.Results will contain the results for each
+// operation. The order of the results matches the order the operations were
+// added to the batch.
 func (txn *Txn) Run(b *Batch) error {
 	tracing.AnnotateTrace()
 	defer tracing.AnnotateTrace()

--- a/internal/client/txn_test.go
+++ b/internal/client/txn_test.go
@@ -339,7 +339,7 @@ func TestBeginTransactionErrorIndex(t *testing.T) {
 	_ = db.Txn(context.TODO(), func(txn *Txn) error {
 		b := txn.NewBatch()
 		b.Put("a", "b")
-		_, err := runOneResult(txn, b)
+		err := getOneErr(txn.Run(b), b)
 		pErr := b.MustPErr()
 		// Verify that the original error type is preserved, but the error index is unset.
 		if _, ok := pErr.GetDetail().(*roachpb.WriteIntentError); !ok {

--- a/internal/client/txn_test.go
+++ b/internal/client/txn_test.go
@@ -814,7 +814,7 @@ func TestBatchMixRawRequest(t *testing.T) {
 	b := &Batch{}
 	b.AddRawRequest(&roachpb.EndTransactionRequest{})
 	b.Put("x", "y")
-	if err := db.Run(b); !testutils.IsError(err, "non-raw operations") {
+	if err := db.Run(context.TODO(), b); !testutils.IsError(err, "non-raw operations") {
 		t.Fatal(err)
 	}
 }

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -195,7 +195,7 @@ func TestKVDBInternalMethods(t *testing.T) {
 		}
 		b := &client.Batch{}
 		b.AddRawRequest(args)
-		err := db.Run(b)
+		err := db.Run(context.TODO(), b)
 		if !testutils.IsError(err, "contains an internal request|contains commit trigger") {
 			t.Errorf("%d: unexpected error for %s: %v", i, args.Method(), err)
 		}
@@ -262,7 +262,7 @@ func TestAuthentication(t *testing.T) {
 	// Create a node user client and call Run() on it which lets us build our own
 	// request, specifying the user.
 	db1 := createTestClientForUser(t, s.Stopper(), s.ServingAddr(), security.NodeUser)
-	if err := db1.Run(b1); err != nil {
+	if err := db1.Run(context.TODO(), b1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -272,7 +272,7 @@ func TestAuthentication(t *testing.T) {
 	// Try again, but this time with certs for a non-node user (even the root
 	// user has no KV permissions).
 	db2 := createTestClientForUser(t, s.Stopper(), s.ServingAddr(), security.RootUser)
-	if err := db2.Run(b2); !testutils.IsError(err, "is not allowed") {
+	if err := db2.Run(context.TODO(), b2); !testutils.IsError(err, "is not allowed") {
 		t.Fatal(err)
 	}
 }

--- a/server/admin.go
+++ b/server/admin.go
@@ -988,7 +988,7 @@ func (s *adminServer) ClusterFreeze(
 		b := &client.Batch{}
 		fa := roachpb.NewChangeFrozen(from, to, req.Freeze, build.GetInfo().Tag)
 		b.AddRawRequest(fa)
-		if err := s.server.db.Run(b); err != nil {
+		if err := s.server.db.Run(context.TODO(), b); err != nil {
 			return nil, err
 		}
 		fr := b.RawResponse().Responses[0].GetInner().(*roachpb.ChangeFrozenResponse)

--- a/server/status.go
+++ b/server/status.go
@@ -482,7 +482,7 @@ func (s *statusServer) Nodes(ctx context.Context, req *serverpb.NodesRequest) (*
 
 	b := &client.Batch{}
 	b.Scan(startKey, endKey)
-	if err := s.db.Run(b); err != nil {
+	if err := s.db.Run(context.TODO(), b); err != nil {
 		log.Error(ctx, err)
 		return nil, grpc.Errorf(codes.Internal, err.Error())
 	}
@@ -510,7 +510,7 @@ func (s *statusServer) Node(ctx context.Context, req *serverpb.NodeRequest) (*st
 	key := keys.NodeStatusKey(int32(nodeID))
 	b := &client.Batch{}
 	b.Get(key)
-	if err := s.db.Run(b); err != nil {
+	if err := s.db.Run(context.TODO(), b); err != nil {
 		log.Error(ctx, err)
 		return nil, grpc.Errorf(codes.Internal, err.Error())
 	}

--- a/storage/addressing_test.go
+++ b/storage/addressing_test.go
@@ -137,7 +137,7 @@ func TestUpdateRangeAddressing(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		if err := store.DB().Run(b); err != nil {
+		if err := store.DB().Run(context.TODO(), b); err != nil {
 			t.Fatal(err)
 		}
 		// Scan meta keys directly from engine.

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -891,7 +891,7 @@ func getRangeMetadata(key roachpb.RKey, mtc *multiTestContext, t *testing.T) roa
 		MaxRanges: 1,
 	})
 	var reply *roachpb.RangeLookupResponse
-	if err := mtc.dbs[0].Run(b); err != nil {
+	if err := mtc.dbs[0].Run(context.TODO(), b); err != nil {
 		t.Fatalf("error getting range metadata: %s", err)
 	} else {
 		reply = b.RawResponse().Responses[0].GetInner().(*roachpb.RangeLookupResponse)

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -577,9 +577,7 @@ func (*gcQueue) purgatoryChan() <-chan struct{} {
 
 // pushTxn attempts to abort the txn via push. The wait group is signaled on
 // completion.
-func pushTxn(db *client.DB, now hlc.Timestamp, txn *roachpb.Transaction,
-	typ roachpb.PushTxnType) {
-
+func pushTxn(db *client.DB, now hlc.Timestamp, txn *roachpb.Transaction, typ roachpb.PushTxnType) {
 	// Attempt to push the transaction which created the intent.
 	pushArgs := &roachpb.PushTxnRequest{
 		Span: roachpb.Span{
@@ -592,7 +590,7 @@ func pushTxn(db *client.DB, now hlc.Timestamp, txn *roachpb.Transaction,
 	}
 	b := &client.Batch{}
 	b.AddRawRequest(pushArgs)
-	if err := db.Run(b); err != nil {
+	if err := db.Run(context.TODO(), b); err != nil {
 		log.Warningf(context.TODO(), "push of txn %s failed: %s", txn, err)
 		return
 	}

--- a/storage/raft_log_queue.go
+++ b/storage/raft_log_queue.go
@@ -208,7 +208,7 @@ func (rlq *raftLogQueue) process(
 			Index:   oldestIndex,
 			RangeID: r.RangeID,
 		})
-		return rlq.db.Run(b)
+		return rlq.db.Run(ctx, b)
 	}
 	return nil
 }

--- a/storage/replica_gc_queue.go
+++ b/storage/replica_gc_queue.go
@@ -166,7 +166,7 @@ func (q *replicaGCQueue) process(
 		},
 		MaxRanges: 1,
 	})
-	if err := q.db.Run(b); err != nil {
+	if err := q.db.Run(ctx, b); err != nil {
 		return err
 	}
 	br := b.RawResponse()

--- a/storage/store.go
+++ b/storage/store.go
@@ -2201,7 +2201,7 @@ func (s *Store) maybeUpdateTransaction(txn *roachpb.Transaction, now hlc.Timesta
 		PusheeTxn: txn.TxnMeta,
 		PushType:  roachpb.PUSH_QUERY,
 	})
-	if err := s.db.Run(b); err != nil {
+	if err := s.db.Run(context.TODO(), b); err != nil {
 		// TODO(tschottdorf):
 		// We shouldn't catch an error here (unless it's from the abort cache, in
 		// which case we would not get the crucial information that we've been

--- a/ts/db.go
+++ b/ts/db.go
@@ -140,5 +140,5 @@ func (db *DB) StoreData(r Resolution, data []tspb.TimeSeriesData) error {
 		})
 	}
 
-	return db.db.Run(b)
+	return db.db.Run(context.TODO(), b)
 }

--- a/ts/query.go
+++ b/ts/query.go
@@ -22,6 +22,8 @@ import (
 	"sort"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/ts/tspb"
@@ -435,7 +437,7 @@ func (db *DB) Query(query tspb.Query, r Resolution, startNanos, endNanos int64) 
 		b := &client.Batch{}
 		b.Scan(startKey, endKey)
 
-		if err := db.db.Run(b); err != nil {
+		if err := db.db.Run(context.TODO(), b); err != nil {
 			return nil, nil, err
 		}
 		rows = b.Results[0].Rows
@@ -452,7 +454,7 @@ func (db *DB) Query(query tspb.Query, r Resolution, startNanos, endNanos int64) 
 				b.Get(key)
 			}
 		}
-		err := db.db.Run(b)
+		err := db.db.Run(context.TODO(), b)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
The main driver for this is to plumb contexts for the timeseries requests.

I am adding ctx to all interfaces in DB (Get, Put, Inc, etc) but that will be a separate change - it will need some coordination around merging to `develop`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9260)

<!-- Reviewable:end -->
