### PR TITLE
sql: put session events in eventlog

### DIFF
--- a/sql/executor.go
+++ b/sql/executor.go
@@ -980,34 +980,31 @@ func (e *Executor) execStmtInOpenTxn(
 		return Result{PGTag: s.StatementTag()}, nil
 	}
 
-	if txnState.tr != nil {
-		txnState.tr.LazyLog(stmt, true /* sensitive */)
-	}
+	session := planMaker.session
+	log.Event(session.context, stmt.String())
 
 	result, err := e.execStmt(stmt, planMaker, implicitTxn /* autoCommit */)
 	if err != nil {
 		if traceSQL {
-			log.Tracef(txnState.txn.Context, "ERROR: %v", err)
+			log.ErrEventf(txnState.txn.Context, "ERROR: %v", err)
 		}
-		if txnState.tr != nil {
-			txnState.tr.LazyPrintf("ERROR: %v", err)
-		}
+		log.ErrEventf(session.context, "ERROR: %v", err)
 		txnState.updateStateAndCleanupOnErr(err, e)
-		result = Result{Err: err}
-	} else if txnState.tr != nil {
-		tResult := &traceResult{tag: result.PGTag, count: -1}
-		switch result.Type {
-		case parser.RowsAffected:
-			tResult.count = result.RowsAffected
-		case parser.Rows:
-			tResult.count = len(result.Rows)
-		}
-		txnState.tr.LazyLog(tResult, false)
-		if traceSQL {
-			log.Tracef(txnState.txn.Context, "%s done", tResult)
-		}
+		return Result{Err: err}, err
 	}
-	return result, err
+
+	tResult := &traceResult{tag: result.PGTag, count: -1}
+	switch result.Type {
+	case parser.RowsAffected:
+		tResult.count = result.RowsAffected
+	case parser.Rows:
+		tResult.count = len(result.Rows)
+	}
+	if traceSQL {
+		log.Eventf(txnState.txn.Context, "%s done", tResult)
+	}
+	log.Event(session.context, tResult.String())
+	return result, nil
 }
 
 // Clean up after trying to execute a transactional statement while not in a SQL

--- a/util/log/trace.go
+++ b/util/log/trace.go
@@ -54,6 +54,11 @@ func WithEventLog(ctx context.Context, family, title string) context.Context {
 	return withEventLogInternal(ctx, trace.NewEventLog(family, title))
 }
 
+// WithNoEventLog creates a context which no longer has an embedded event log.
+func WithNoEventLog(ctx context.Context) context.Context {
+	return withEventLogInternal(ctx, nil)
+}
+
 func eventLogFromCtx(ctx context.Context) *ctxEventLog {
 	if val := ctx.Value(ctxEventLogKey{}); val != nil {
 		return val.(*ctxEventLog)

--- a/util/log/trace_test.go
+++ b/util/log/trace_test.go
@@ -152,6 +152,9 @@ func TestEventLog(t *testing.T) {
 	Info(ctxWithEventLog, "log")
 	Errorf(ctxWithEventLog, "errlog%d", 1)
 
+	// Events to child contexts without the event log should be no-ops.
+	Event(WithNoEventLog(ctxWithEventLog), "should-not-show-up")
+
 	// Events to parent context should still be no-ops.
 	Event(ctx, "should-not-show-up")
 


### PR DESCRIPTION
SQL has a per-session "debug/request" trace which can be very long-lived.
Replacing it with an EventLog (which shows up under "debug/events").

This is a cherry-pick from `develop`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9262)

<!-- Reviewable:end -->
