### PR TITLE
ts: plumb contexts

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -280,7 +280,7 @@ func NewServer(srvCtx Context, stopper *stop.Stopper) (*Server, error) {
 	storage.RegisterStoresServer(s.grpc, s.node.storesServer)
 
 	s.tsDB = ts.NewDB(s.db)
-	s.tsServer = ts.MakeServer(s.tsDB)
+	s.tsServer = ts.MakeServer(s.Ctx(), s.tsDB)
 
 	s.admin = makeAdminServer(s)
 	s.status = newStatusServer(s.db, s.gossip, s.recorder, s.ctx.Context, s.rpcContext, s.node.stores)
@@ -470,7 +470,7 @@ func (s *Server) Start(ctx context.Context) error {
 	s.startSampleEnvironment(s.ctx.MetricsSampleInterval)
 
 	// Begin recording time series data collected by the status monitor.
-	s.tsDB.PollSource(s.recorder, s.ctx.MetricsSampleInterval, ts.Resolution10s, s.stopper)
+	s.tsDB.PollSource(s.Ctx(), s.recorder, s.ctx.MetricsSampleInterval, ts.Resolution10s, s.stopper)
 
 	// Begin recording status summaries.
 	s.node.startWriteSummaries(s.ctx.MetricsSampleInterval)

--- a/ts/db_test.go
+++ b/ts/db_test.go
@@ -203,7 +203,7 @@ func (tm *testModel) storeInModel(r Resolution, data tspb.TimeSeriesData) {
 // in both the model and the system under test.
 func (tm *testModel) storeTimeSeriesData(r Resolution, data []tspb.TimeSeriesData) {
 	// Store data in the system under test.
-	if err := tm.DB.StoreData(r, data); err != nil {
+	if err := tm.DB.StoreData(context.TODO(), r, data); err != nil {
 		tm.t.Fatalf("error storing time series data: %s", err.Error())
 	}
 
@@ -360,7 +360,7 @@ func TestPollSource(t *testing.T) {
 		},
 	}
 
-	tm.DB.PollSource(&testSource, time.Millisecond, Resolution10s, testSource.stopper)
+	tm.DB.PollSource(context.TODO(), &testSource, time.Millisecond, Resolution10s, testSource.stopper)
 	<-testSource.stopper.IsStopped()
 	if a, e := testSource.calledCount, 2; a != e {
 		t.Errorf("testSource was called %d times, expected %d", a, e)

--- a/ts/query.go
+++ b/ts/query.go
@@ -423,7 +423,9 @@ func (is unionIterator) min() float64 {
 // returned datapoint will represent the sum of datapoints from all sources at
 // the same time. The returned string slices contains a list of all sources for
 // the metric which were aggregated to produce the result.
-func (db *DB) Query(query tspb.Query, r Resolution, startNanos, endNanos int64) ([]tspb.TimeSeriesDatapoint, []string, error) {
+func (db *DB) Query(
+	ctx context.Context, query tspb.Query, r Resolution, startNanos, endNanos int64,
+) ([]tspb.TimeSeriesDatapoint, []string, error) {
 	// Normalize startNanos and endNanos the nearest SampleDuration boundary.
 	startNanos -= startNanos % r.SampleDuration()
 
@@ -437,7 +439,7 @@ func (db *DB) Query(query tspb.Query, r Resolution, startNanos, endNanos int64) 
 		b := &client.Batch{}
 		b.Scan(startKey, endKey)
 
-		if err := db.db.Run(context.TODO(), b); err != nil {
+		if err := db.db.Run(ctx, b); err != nil {
 			return nil, nil, err
 		}
 		rows = b.Results[0].Rows
@@ -454,7 +456,7 @@ func (db *DB) Query(query tspb.Query, r Resolution, startNanos, endNanos int64) 
 				b.Get(key)
 			}
 		}
-		err := db.db.Run(context.TODO(), b)
+		err := db.db.Run(ctx, b)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/ts/query_test.go
+++ b/ts/query_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/ts/tspb"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -257,7 +259,7 @@ func (tm *testModel) assertQuery(
 		Derivative:       derivative,
 		Sources:          sources,
 	}
-	actualDatapoints, actualSources, err := tm.DB.Query(q, r, start, end)
+	actualDatapoints, actualSources, err := tm.DB.Query(context.TODO(), q, r, start, end)
 	if err != nil {
 		tm.t.Fatal(err)
 	}

--- a/ts/server.go
+++ b/ts/server.go
@@ -17,11 +17,14 @@
 package ts
 
 import (
-	"github.com/cockroachdb/cockroach/ts/tspb"
-	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"golang.org/x/net/context"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+
+	"github.com/cockroachdb/cockroach/ts/tspb"
+	"github.com/cockroachdb/cockroach/util/log"
+	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 )
 
 const (
@@ -32,14 +35,17 @@ const (
 
 // Server handles incoming external requests related to time series data.
 type Server struct {
-	db *DB
+	ctx context.Context
+	db  *DB
 }
 
 // MakeServer instantiates a new Server which services requests with data from
 // the supplied DB.
-func MakeServer(db *DB) Server {
+func MakeServer(ctx context.Context, db *DB) Server {
+	ctx = log.WithLogTag(ctx, "ts-srv", nil)
 	return Server{
-		db: db,
+		ctx: ctx,
+		db:  db,
 	}
 }
 
@@ -58,9 +64,16 @@ func (s *Server) RegisterGateway(
 	return tspb.RegisterTimeSeriesHandler(ctx, mux, conn)
 }
 
+// logContext applies the log tags from the Server's context to the given
+// context.
+func (s *Server) logContext(ctx context.Context) context.Context {
+	return log.WithLogTagsFromCtx(ctx, s.ctx)
+}
+
 // Query is an endpoint that returns data for one or more metrics over a
 // specific time span.
 func (s *Server) Query(ctx context.Context, request *tspb.TimeSeriesQueryRequest) (*tspb.TimeSeriesQueryResponse, error) {
+	ctx = s.logContext(ctx)
 	if len(request.Queries) == 0 {
 		return nil, grpc.Errorf(codes.InvalidArgument, "Queries cannot be empty")
 	}
@@ -69,7 +82,7 @@ func (s *Server) Query(ctx context.Context, request *tspb.TimeSeriesQueryRequest
 		Results: make([]tspb.TimeSeriesQueryResponse_Result, 0, len(request.Queries)),
 	}
 	for _, query := range request.Queries {
-		datapoints, sources, err := s.db.Query(query, Resolution10s, request.StartNanos, request.EndNanos)
+		datapoints, sources, err := s.db.Query(ctx, query, Resolution10s, request.StartNanos, request.EndNanos)
 		if err != nil {
 			return nil, grpc.Errorf(codes.Internal, err.Error())
 		}

--- a/ts/server_test.go
+++ b/ts/server_test.go
@@ -39,7 +39,7 @@ func TestQuery(t *testing.T) {
 
 	// Populate data directly.
 	tsdb := tsrv.TsDB()
-	if err := tsdb.StoreData(ts.Resolution10s, []tspb.TimeSeriesData{
+	if err := tsdb.StoreData(context.TODO(), ts.Resolution10s, []tspb.TimeSeriesData{
 		{
 			Name:   "test.metric",
 			Source: "source1",


### PR DESCRIPTION
The batches ran by `ts` now get contexts; this fixes the lack of node tags on
these operations. In addition they are also marked with a `ts-srv` or
`ts-poll` tag.

Plus: Don't duplicate tags when using WithLogTagsFromCtx.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9275)

<!-- Reviewable:end -->
