### PR TITLE
sqlbase: move all system table descriptions to sqlbase

### DIFF
--- a/server/node.go
+++ b/server/node.go
@@ -161,22 +161,7 @@ func allocateStoreIDs(nodeID roachpb.NodeID, inc int64, db *client.DB) (roachpb.
 // GetBootstrapSchema returns the schema which will be used to bootstrap a new
 // server.
 func GetBootstrapSchema() sqlbase.MetadataSchema {
-	schema := sqlbase.MakeMetadataSchema()
-	AddEventLogToMetadataSchema(&schema)
-	sql.AddEventLogToMetadataSchema(&schema)
-	return schema
-}
-
-// AddEventLogToMetadataSchema adds the range event log table to the supplied
-// MetadataSchema.
-func AddEventLogToMetadataSchema(schema *sqlbase.MetadataSchema) {
-	desc := sql.CreateTableDescriptor(
-		keys.RangeEventTableID,
-		keys.SystemDatabaseID,
-		storage.RangeEventTableSchema,
-		sqlbase.NewDefaultPrivilegeDescriptor(),
-	)
-	schema.AddDescriptor(keys.SystemDatabaseID, &desc)
+	return sqlbase.MakeMetadataSchema()
 }
 
 // bootstrapCluster bootstraps a multiple stores using the provided

--- a/sql/event_log.go
+++ b/sql/event_log.go
@@ -22,8 +22,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/internal/client"
-	"github.com/cockroachdb/cockroach/keys"
-	"github.com/cockroachdb/cockroach/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/pkg/errors"
@@ -61,30 +59,6 @@ const (
 	// after being offline.
 	EventLogNodeRestart EventLogType = "node_restart"
 )
-
-// eventTableSchema describes the schema of the event log table.
-const eventTableSchema = `
-CREATE TABLE system.eventlog (
-  timestamp    TIMESTAMP  NOT NULL,
-  eventType    STRING     NOT NULL,
-  targetID     INT        NOT NULL,
-  reportingID  INT        NOT NULL,
-  info         STRING,
-  uniqueID     BYTES      DEFAULT experimental_unique_bytes(),
-  PRIMARY KEY (timestamp, uniqueID)
-);`
-
-// AddEventLogToMetadataSchema adds the event log table to the supplied
-// MetadataSchema.
-func AddEventLogToMetadataSchema(schema *sqlbase.MetadataSchema) {
-	desc := CreateTableDescriptor(
-		keys.EventLogTableID,
-		keys.SystemDatabaseID,
-		eventTableSchema,
-		sqlbase.NewDefaultPrivilegeDescriptor(),
-	)
-	schema.AddDescriptor(keys.SystemDatabaseID, &desc)
-}
 
 // An EventLogger exposes methods used to record events to the event table.
 type EventLogger struct {

--- a/sql/sqlbase/metadata.go
+++ b/sql/sqlbase/metadata.go
@@ -94,6 +94,12 @@ func (ms *MetadataSchema) AddDescriptor(parentID ID, desc DescriptorProto) {
 	if id := desc.GetID(); id > keys.MaxReservedDescID {
 		panic(fmt.Sprintf("invalid reserved table ID: %d > %d", id, keys.MaxReservedDescID))
 	}
+	for _, d := range ms.descs {
+		if d.desc.GetID() == desc.GetID() {
+			log.Errorf(context.TODO(), "adding descriptor with duplicate ID: %v", desc)
+			return
+		}
+	}
 	ms.descs = append(ms.descs, metadataDescriptor{parentID, desc})
 }
 
@@ -115,18 +121,6 @@ func (ms MetadataSchema) SystemDescriptorCount() int {
 // tests.
 func (ms MetadataSchema) SystemConfigDescriptorCount() int {
 	return ms.configs
-}
-
-// MaxTableID returns the highest table ID of any system table. This value is
-// needed to automate certain tests.
-func (ms MetadataSchema) MaxTableID() ID {
-	var maxID ID
-	for _, tbl := range ms.descs {
-		if maxID < tbl.desc.GetID() {
-			maxID = tbl.desc.GetID()
-		}
-	}
-	return maxID
 }
 
 // GetInitialValues returns the set of initial K/V values which should be added to

--- a/storage/log.go
+++ b/storage/log.go
@@ -48,21 +48,6 @@ const (
 	RangeEventLogRemove RangeEventLogType = "remove"
 )
 
-// RangeEventTableSchema defines the schema of the event log table. It is
-// currently envisioned as a wide table; many different event types can be
-// recorded to the table.
-const RangeEventTableSchema = `
-CREATE TABLE system.rangelog (
-  timestamp     TIMESTAMP  NOT NULL,
-  rangeID       INT        NOT NULL,
-  storeID       INT        NOT NULL,
-  eventType     STRING     NOT NULL,
-  otherRangeID  INT,
-  info          STRING,
-  uniqueID      INT        DEFAULT unique_rowid(),
-  PRIMARY KEY (timestamp, uniqueID)
-);`
-
 type rangeLogEvent struct {
 	timestamp    time.Time
 	rangeID      roachpb.RangeID


### PR DESCRIPTION
There were two system tables (RangeEventLogTable, EventLogTable)
that were described outside of sqlbase. This change moves
them to sqlbase together with the other system tables.

Some table descriptors are described as literals in system.go. A
followup PR will eliminate the need to use table descriptor literals
for system tables.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9277)

<!-- Reviewable:end -->
