### PR TITLE
Move check for mixed cluster IDs

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -2825,19 +2825,6 @@ func (r *Replica) maybeGossipFirstRange() *roachpb.Error {
 	if !r.IsFirstRange() {
 		return nil
 	}
-
-	// When multiple nodes are initialized with overlapping Gossip addresses, they all
-	// will attempt to gossip their cluster ID. This is a fairly obvious misconfiguration,
-	// so we error out below.
-	if uuidBytes, err := r.store.Gossip().GetInfo(gossip.KeyClusterID); err == nil {
-		if gossipClusterID, err := uuid.FromBytes(uuidBytes); err == nil {
-			if *gossipClusterID != r.store.ClusterID() {
-				log.Fatalf(r.ctx, "store %d belongs to cluster %s, but attempted to join cluster %s via gossip",
-					r.store.StoreID(), r.store.ClusterID(), gossipClusterID)
-			}
-		}
-	}
-
 	// Gossip the cluster ID from all replicas of the first range; there
 	// is no expiration on the cluster ID.
 	if log.V(1) {


### PR DESCRIPTION
@bdarnell，please see #9271 and  help me review that If I have done it right.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9286)

<!-- Reviewable:end -->
