### PR TITLE
storage,kv: small logging improvements

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -456,6 +456,7 @@ func (tc *TxnCoordSender) maybeRejectClientLocked(
 	// continue.
 	switch {
 	case !ok:
+		log.VTracef(2, ctx, "rejecting unknown txn: %s", txn.ID)
 		// TODO(spencerkimball): Could add coordinator node ID to the
 		// transaction session so that we can definitively return the right
 		// error between these possible errors. Or update the code to make an

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -145,6 +145,7 @@ func (ba *BatchRequest) GetArg(method Method) (Request, bool) {
 
 func (br *BatchResponse) String() string {
 	var str []string
+	str = append(str, fmt.Sprintf("(err: %v)", br.Error))
 	for _, union := range br.Responses {
 		str = append(str, fmt.Sprintf("%T", union.GetInner()))
 	}
@@ -558,6 +559,9 @@ func (ba BatchRequest) Split(canSplitET bool) [][]RequestUnion {
 // See #2198.
 func (ba BatchRequest) String() string {
 	var str []string
+	if ba.Txn != nil {
+		str = append(str, fmt.Sprintf("[txn: %s]", ba.Txn.ID.Short()))
+	}
 	for count, arg := range ba.Requests {
 		// Limit the strings to provide just a summary. Without this limit
 		// a log message with a BatchRequest can be very long.

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1377,7 +1377,9 @@ func (r *Replica) PushTxn(
 		if !pusherWins {
 			s = "failed to push"
 		}
-		log.Infof(ctx, "%s "+s+" %s: %s", args.PusherTxn.ID.Short(), reply.PusheeTxn.ID.Short(), reason)
+		log.Infof(ctx, "%s "+s+" %s: %s (pushee last active: %s)",
+			args.PusherTxn.ID.Short(), reply.PusheeTxn.ID.Short(), reason,
+			reply.PusheeTxn.LastActive())
 	}
 
 	if !pusherWins {


### PR DESCRIPTION
- biggest one is including the txn id in `Batch{Request,Response}` strings

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9294)

<!-- Reviewable:end -->
