### PR TITLE
storage: concurrent destruction of replica data

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -573,7 +573,32 @@ func (r *Replica) Destroy(origDesc roachpb.RangeDescriptor, destroyData bool) er
 	if !destroyData {
 		return nil
 	}
-	return r.store.destroyReplicaData(desc)
+	return r.destroyDataRaftMuLocked()
+}
+
+// destroyData deletes all data associated with a replica, leaving a
+// tombstone. Requires that Replica.raftMu is held.
+func (r *Replica) destroyDataRaftMuLocked() error {
+	desc := r.Desc()
+	iter := NewReplicaDataIterator(desc, r.store.Engine(), false /* !replicatedOnly */)
+	defer iter.Close()
+	batch := r.store.Engine().NewBatch()
+	defer batch.Close()
+	for ; iter.Valid(); iter.Next() {
+		_ = batch.Clear(iter.Key())
+	}
+
+	// Save a tombstone. The range cannot be re-replicated onto this
+	// node without having a replica ID of at least desc.NextReplicaID.
+	tombstoneKey := keys.RaftTombstoneKey(desc.RangeID)
+	tombstone := &roachpb.RaftTombstone{
+		NextReplicaID: desc.NextReplicaID,
+	}
+	if err := engine.MVCCPutProto(context.Background(), batch, nil, tombstoneKey, hlc.ZeroTimestamp, nil, tombstone); err != nil {
+		return err
+	}
+
+	return batch.Commit()
 }
 
 func (r *Replica) setReplicaID(replicaID roachpb.ReplicaID) error {

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -2764,6 +2764,10 @@ func (r *Replica) mergeTrigger(
 		// TODO(peter,tschottdorf): This is necessary but likely not
 		// sufficient. The right hand side of the merge can still race on
 		// reads. See #8630.
+		//
+		// TODO(peter): We need to hold the subsumed range's raftMu until the
+		// Store.MergeRange is invoked. Currently we release it when this method
+		// returns which isn't correct.
 		subsumedRng, err := r.store.GetReplica(rightRangeID)
 		if err != nil {
 			panic(err)

--- a/storage/store.go
+++ b/storage/store.go
@@ -1760,62 +1760,53 @@ func (s *Store) removeReplicaImpl(rep *Replica, origDesc roachpb.RangeDescriptor
 		return errors.Errorf("cannot remove replica %s; replica ID has changed (%s >= %s)",
 			rep, repDesc.ReplicaID, origDesc.NextReplicaID)
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
 
+	s.mu.Lock()
 	if _, ok := s.mu.replicas[rep.RangeID]; !ok {
+		s.mu.Unlock()
 		return errors.New("replica not found")
 	}
-
-	delete(s.mu.replicas, rep.RangeID)
-	delete(s.mu.replicaPlaceholders, rep.RangeID)
-	delete(s.mu.replicaQueues, rep.RangeID)
-	delete(s.mu.uninitReplicas, rep.RangeID)
-	if s.mu.replicasByKey.Delete(rep) == nil {
+	if s.getOverlappingKeyRangeLocked(desc) != rep {
 		// This is a fatal error because returning at this point will
 		// leave the Store in an inconsistent state (we've already deleted
 		// from s.mu.replicas), and uninitialized replicas shouldn't make
 		// it this far anyway. This method will need some changes when we
 		// introduce GC of uninitialized replicas.
+		//
+		// TODO(peter): The above comment is out of date: we could return an error
+		// here but are not doing so yet in the name of conservatism.
+		s.mu.Unlock()
 		log.Fatalf(context.TODO(), "replica %s found by id but not by key", rep)
 	}
-	s.scanner.RemoveReplica(rep)
-	s.consistencyScanner.RemoveReplica(rep)
-
 	// Adjust stats before calling Destroy. This can be called before or after
 	// Destroy, but this configuration helps avoid races in stat verification
 	// tests.
 	s.metrics.subtractMVCCStats(rep.GetMVCCStats())
 	s.metrics.ReplicaCount.Dec(1)
+	s.mu.Unlock()
 
-	// TODO(bdarnell): Destroying the on-disk data is fairly expensive to do
-	// under store.Mutex, but doing it outside the lock is tricky due to the risk
-	// that a replica gets recreated by an incoming raft message.
-	return rep.Destroy(origDesc, destroyData)
-}
-
-// destroyReplicaData deletes all data associated with a replica, leaving a tombstone.
-// If a Replica object exists, use Replica.Destroy instead of this method.
-func (s *Store) destroyReplicaData(desc *roachpb.RangeDescriptor) error {
-	iter := NewReplicaDataIterator(desc, s.Engine(), false /* !replicatedOnly */)
-	defer iter.Close()
-	batch := s.Engine().NewBatch()
-	defer batch.Close()
-	for ; iter.Valid(); iter.Next() {
-		_ = batch.Clear(iter.Key())
-	}
-
-	// Save a tombstone. The range cannot be re-replicated onto this
-	// node without having a replica ID of at least desc.NextReplicaID.
-	tombstoneKey := keys.RaftTombstoneKey(desc.RangeID)
-	tombstone := &roachpb.RaftTombstone{
-		NextReplicaID: desc.NextReplicaID,
-	}
-	if err := engine.MVCCPutProto(context.Background(), batch, nil, tombstoneKey, hlc.ZeroTimestamp, nil, tombstone); err != nil {
+	// Mark the replica as destroyed and (optionally) destroy the on-disk data
+	// while not holding Store.mu. This is safe because we're holding
+	// Replica.raftMu and the replica is present in Store.mu.replicasByKey
+	// (preventing any concurrent access to the replica's key range).
+	if err := rep.Destroy(origDesc, destroyData); err != nil {
 		return err
 	}
 
-	return batch.Commit()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.mu.replicas, rep.RangeID)
+	delete(s.mu.replicaPlaceholders, rep.RangeID)
+	delete(s.mu.replicaQueues, rep.RangeID)
+	delete(s.mu.uninitReplicas, rep.RangeID)
+	if s.mu.replicasByKey.Delete(rep) == nil {
+		// We already checked that our replica was present in replicasByKey
+		// above. Nothing should have been able to change that.
+		log.Fatalf(context.TODO(), "replica %s found by id but not by key", rep)
+	}
+	s.scanner.RemoveReplica(rep)
+	s.consistencyScanner.RemoveReplica(rep)
+	return nil
 }
 
 // processRangeDescriptorUpdate should be called whenever a replica's range


### PR DESCRIPTION
Previously, replicas were marked as destroyed on their on disk data
deleted while holding Store.mu. This acted as a concurrency bottleneck
and also locked out other replica processing. With placeholders and the
per-Replica raft locks, holding Store.mu is no longer necessary to
destroy a replica.

Fixes #9244.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9299)

<!-- Reviewable:end -->
