### PR TITLE
server: Fix Flaky TestStatusSummaries

### DIFF
--- a/base/test_server_args.go
+++ b/base/test_server_args.go
@@ -62,6 +62,9 @@ type TestServerArgs struct {
 	// Stopper can be used to stop the server. If not set, a stopper will be
 	// constructed and it can be gotten through TestServerInterface.Stopper().
 	Stopper *stop.Stopper
+
+	// If set, the recording of events to the event log tables is disabled.
+	DisableEventLog bool
 }
 
 // TestClusterArgs contains the parameters one can set when creating a test

--- a/server/context.go
+++ b/server/context.go
@@ -60,6 +60,7 @@ const (
 	defaultTimeUntilStoreDead       = 5 * time.Minute
 	defaultStorePath                = "cockroach-data"
 	defaultReservationsEnabled      = true
+	defaultEventLogEnabled          = true
 
 	minimumNetworkFileDescriptors     = 256
 	recommendedNetworkFileDescriptors = 5000
@@ -165,6 +166,12 @@ type Context struct {
 	// Ctx is the base context.Context for the server. If nil,
 	// context.Background() will be used.
 	Ctx context.Context
+
+	// EventLogEnabled is a switch which enables recording into cockroach's SQL
+	// event log tables. These tables record transactional events about changes
+	// to cluster metadata, such as DDL statements and range rebalancing
+	// actions.
+	EventLogEnabled bool
 }
 
 // GetTotalMemory returns either the total system memory or if possible the
@@ -337,6 +344,7 @@ func MakeContext() Context {
 		MetricsSampleInterval:    defaultMetricsSampleInterval,
 		TimeUntilStoreDead:       defaultTimeUntilStoreDead,
 		ReservationsEnabled:      defaultReservationsEnabled,
+		EventLogEnabled:          defaultEventLogEnabled,
 		Stores: StoreSpecList{
 			Specs: []StoreSpec{{Path: defaultStorePath}},
 		},

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -441,12 +441,13 @@ func compareNodeStatus(t *testing.T, ts *TestServer, expectedNodeStatus *status.
 // both the Node and stores within the node.
 func TestStatusSummaries(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#8844")
 
 	// ========================================
 	// Start test server and wait for full initialization.
 	// ========================================
-	srv, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	srv, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+		DisableEventLog: true,
+	})
 	defer srv.Stopper().Stop()
 	ts := srv.(*TestServer)
 

--- a/server/server.go
+++ b/server/server.go
@@ -260,7 +260,7 @@ func NewServer(srvCtx Context, stopper *stop.Stopper) (*Server, error) {
 		SQLExecutor: sql.InternalExecutor{
 			LeaseManager: s.leaseMgr,
 		},
-		LogRangeEvents: true,
+		LogRangeEvents: s.ctx.EventLogEnabled,
 		AllocatorOptions: storage.AllocatorOptions{
 			AllowRebalance: true,
 		},

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -118,6 +118,9 @@ func makeTestContextFromParams(params base.TestServerArgs) Context {
 	if params.SSLCertKey != "" {
 		ctx.SSLCertKey = params.SSLCertKey
 	}
+	if params.DisableEventLog {
+		ctx.EventLogEnabled = false
+	}
 	ctx.JoinList = []string{params.JoinAddr}
 	return ctx
 }


### PR DESCRIPTION
Fixes a flake in TestStatusSummaries by disabling the SQL event log during the
test. The Event Log for "Node Join" is recorded on its own goroutine (which
retries indefinitely until it succeeds); this would occasionally overlap with
the status summary generation in a way that threw off the measurement
expectations.

Fixes #8844

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9303)

<!-- Reviewable:end -->
