### PR TITLE
storage: handle duplicate BeginTransaction

### DIFF
--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -450,8 +450,10 @@ func (r *Replica) BeginTransaction(
 				// this command's txn and rewrite the record.
 				reply.Txn.Update(&txn)
 			} else {
-				return reply, roachpb.NewTransactionStatusError(
-					fmt.Sprintf("BeginTransaction can't overwrite %s", txn))
+				// Our txn record already exists. This is either a client error, sending
+				// a duplicate BeginTransaction, or it's an artefact of DistSender
+				// re-sending a batch. Assume the latter and ask the client to restart.
+				return reply, roachpb.NewTransactionRetryError()
 			}
 
 		case roachpb.COMMITTED:


### PR DESCRIPTION
On seeing a dupe, instead of returning an internal error that's not
handled anywhere, return a TxnRestartError, so the client retries.

Fixes #9233

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9305)

<!-- Reviewable:end -->
