### PR TITLE
Fix multi-store metrics.

### DIFF
--- a/util/metric/prometheus_exporter.go
+++ b/util/metric/prometheus_exporter.go
@@ -1,0 +1,95 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package metric
+
+import (
+	"io"
+
+	"github.com/gogo/protobuf/proto"
+	prometheusgo "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+)
+
+// PrometheusExporter contains a map of metric families (a metric with multiple labels).
+// It initializes each metric family once and reuses it for each prometheus scrape.
+// It is NOT thread-safe.
+// TODO(marc): we should really keep out metric objects here so we can avoid creating
+// new prometheus.Metric every time we are scraped.
+// see: https://github.com/cockroachdb/cockroach/issues/9326
+//  pe := MakePrometheusExporter()
+//  pe.AddMetricsFromRegistry(nodeRegistry)
+//  pe.AddMetricsFromRegistry(storeOneRegistry)
+//  ...
+//  pe.AddMetricsFromRegistry(storeNRegistry)
+//  pe.Export(w)
+type PrometheusExporter struct {
+	families map[string]*prometheusgo.MetricFamily
+}
+
+// MakePrometheusExporter returns an initialized prometheus exporter.
+func MakePrometheusExporter() PrometheusExporter {
+	return PrometheusExporter{families: map[string]*prometheusgo.MetricFamily{}}
+}
+
+// find the family for the passed-in metric, or create and return it if not found.
+func (pm *PrometheusExporter) findOrCreateFamily(prom PrometheusExportable) *prometheusgo.MetricFamily {
+	familyName := exportedName(prom.GetName())
+	if family, ok := pm.families[familyName]; ok {
+		return family
+	}
+
+	family := &prometheusgo.MetricFamily{
+		Name: proto.String(familyName),
+		Help: proto.String(prom.GetHelp()),
+		Type: prom.GetType(),
+	}
+
+	pm.families[familyName] = family
+	return family
+}
+
+// AddMetricsFromRegistry takes a registry and adds all metrics to the metric family map.
+// It creates a new family if needed.
+func (pm *PrometheusExporter) AddMetricsFromRegistry(registry *Registry) {
+	labels := registry.getLabels()
+	for _, metric := range registry.tracked {
+		metric.Inspect(func(v interface{}) {
+			if prom, ok := v.(PrometheusExportable); ok {
+				m := prom.ToPrometheusMetric()
+				// Set registry and metric labels.
+				m.Label = append(labels, prom.GetLabels()...)
+
+				family := pm.findOrCreateFamily(prom)
+				family.Metric = append(family.Metric, m)
+			}
+		})
+	}
+}
+
+// Export writes all metrics in the families map to the iowriter in
+// prometheus' text format. It removes individual metrics from the families
+// as it goes, readying the families for another found of registry additions.
+func (pm *PrometheusExporter) Export(w io.Writer) error {
+	for _, family := range pm.families {
+		if _, err := expfmt.MetricFamilyToText(w, family); err != nil {
+			return err
+		}
+		// Clear metrics for reuse.
+		family.Metric = []*prometheusgo.Metric{}
+	}
+	return nil
+}

--- a/util/metric/prometheus_exporter_test.go
+++ b/util/metric/prometheus_exporter_test.go
@@ -1,0 +1,90 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package metric
+
+import "testing"
+
+func TestPrometheusExporter(t *testing.T) {
+	r1, r2 := NewRegistry(), NewRegistry()
+	// r2 has a registry-level label, r1 does not.
+	r2.AddLabel("registry", "two")
+
+	r1.AddMetric(NewGauge(Metadata{Name: "one.gauge"}))
+	r2.AddMetric(NewGauge(Metadata{Name: "two.gauge"}))
+
+	c1Meta := Metadata{Name: "shared.counter"}
+	c1Meta.AddLabel("counter", "one")
+	c2Meta := Metadata{Name: "shared.counter"}
+	c2Meta.AddLabel("counter", "two")
+
+	r1.AddMetric(NewCounter(c1Meta))
+	r2.AddMetric(NewCounter(c2Meta))
+
+	pe := MakePrometheusExporter()
+	pe.AddMetricsFromRegistry(r1)
+	pe.AddMetricsFromRegistry(r2)
+
+	type metricLabels map[string]string
+	type family struct {
+		// List of metric. The order depends on the order of "AddMetricsFromRegistry".
+		// Each entry is a list of labels for the metric at that index,  "registry labels" followed by
+		// "metric labels" in the order they were added.
+		metrics []metricLabels
+	}
+
+	expected := map[string]family{
+		"one_gauge": {[]metricLabels{
+			{},
+		}},
+		"two_gauge": {[]metricLabels{
+			{"registry": "two"},
+		}},
+		"shared_counter": {[]metricLabels{
+			{"counter": "one"},
+			{"counter": "two", "registry": "two"},
+		}},
+	}
+
+	if lenExpected, lenExporter := len(expected), len(pe.families); lenExpected != lenExporter {
+		t.Errorf("wrong number of families, expected %d, got %d", lenExpected, lenExporter)
+	}
+
+	for name, fam := range expected {
+		fam2, ok := pe.families[name]
+		if !ok {
+			t.Errorf("exporter does not have metric family named %s", name)
+		}
+		if lenExpected, lenExporter := len(fam.metrics), len(fam2.GetMetric()); lenExpected != lenExporter {
+			t.Errorf("wrong number of metrics for family %s, expected %d, got %d", name, lenExpected, lenExporter)
+		}
+		for i, met := range fam2.GetMetric() {
+			expectedLabels := fam.metrics[i]
+			if lenExpected, lenExporter := len(expectedLabels), len(met.Label); lenExpected != lenExporter {
+				t.Errorf("wrong number of labels for metric %d in family %s, expected %d, got %d",
+					i, name, lenExpected, lenExporter)
+			}
+			for _, l := range met.Label {
+				if val, ok := expectedLabels[l.GetName()]; !ok {
+					t.Errorf("unexpected label name %s for metric %d in family %s", l.GetName(), i, name)
+				} else if val != l.GetValue() {
+					t.Errorf("label %s for metric %d in family %s has value %s, expected %s",
+						l.GetName(), i, name, l.GetValue(), val)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #9302

Metrics with the same name but different labels need to be exported
together (ie: there must be a single HELP and TYPE line for a given
metric). This means that we need to combine metrics with the same name,
most of which are currently the store-level metrics.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9322)

<!-- Reviewable:end -->
