### PR TITLE
Makefile: Decrease required Git version back down to 1.8+

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
   - A C++ compiler that supports C++11. Note that GCC prior to 6.0 doesn't
     work due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48891
   - A Go environment with a 64-bit version of Go 1.7.1
-  - Git 2.5+
+  - Git 1.8+
   - Bash
 
 2.  Get the CockroachDB code:

--- a/Makefile
+++ b/Makefile
@@ -197,9 +197,8 @@ ifneq ($(SKIP_BOOTSTRAP),1)
 # If we're in a git worktree, the git hooks directory may not be in our root,
 # so we ask git for the location.
 #
-# Note that this command requires git 2.5+; earlier versions produce opaque
-# errors.
-GITHOOKSDIR := $(shell git rev-parse --git-path hooks)
+# Note that `git rev-parse --git-path hooks` requires git 2.5+.
+GITHOOKSDIR := $(shell test -d .git && echo '.git/hooks' || git rev-parse —git-path hooks)
 GITHOOKS := $(subst githooks/,$(GITHOOKSDIR)/,$(wildcard githooks/*))
 $(GITHOOKSDIR)/%: githooks/%
 	@echo installing $<


### PR DESCRIPTION
This is important because Debian linuxes do not have Git 2.5+ in their
default package manager, so its a hassle to get.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9325)

<!-- Reviewable:end -->
