### PR TITLE
storage: fix WaitGroup race in CheckConsistency()

### DIFF
--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1806,6 +1806,7 @@ func (r *Replica) CheckConsistency(
 		if replica == localReplica {
 			continue
 		}
+		wg.Add(1)
 		replica := replica // per-iteration copy
 		if err := r.store.Stopper().RunAsyncTask(func() {
 			defer wg.Done()
@@ -1856,9 +1857,8 @@ func (r *Replica) CheckConsistency(
 			log.Errorf(ctx, buf.String())
 		}); err != nil {
 			log.Error(ctx, errors.Wrap(err, "could not run async CollectChecksum"))
-			continue
+			wg.Done()
 		}
-		wg.Add(1)
 	}
 	wg.Wait()
 


### PR DESCRIPTION
Previously, the async task could call Done() before the parent task
calls Add(1). Resolves #9330.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9337)

<!-- Reviewable:end -->
