### PR TITLE
storage: fix TestNodeRestart

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -2287,7 +2287,7 @@ func (s *Store) processRaftRequest(
 			panic(fmt.Sprintf("unexpected quiesce: %+v", req))
 		}
 		status := r.RaftStatus()
-		if status.Term == req.Message.Term && status.Commit == req.Message.Commit {
+		if status != nil && status.Term == req.Message.Term && status.Commit == req.Message.Commit {
 			r.setQuiescent(true)
 			return
 		}


### PR DESCRIPTION
Fix a nil pointer dereference: an inflight quiesce message might be
received by a newly started node which hasn't yet initialized its raft
group.

Fixes #9341.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9342)

<!-- Reviewable:end -->
