### PR TITLE
scripts: fix gceworker for go 1.7.1

### DIFF
--- a/scripts/bootstrap-debian.sh
+++ b/scripts/bootstrap-debian.sh
@@ -15,7 +15,9 @@ mkdir -p ~/go-bootstrap
 curl "https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz" | tar -C ~/go-bootstrap -xvz --strip=1
 curl "https://storage.googleapis.com/golang/go${GOVERSION}.src.tar.gz" | tar -C ~ -xvz
 
-patch -p1 -d ../go < "parallelbuilds-go${GOVERSION}.patch"
+# Apply the patch for the "major" go version (e.g. 1.6, 1.7).
+GOPATCHVER=$(echo ${GOVERSION} | grep -o "^[0-9]\+\.[0-9]\+")
+patch -p1 -d ../go < "parallelbuilds-go${GOPATCHVER}.patch"
 
 (cd ~/go/src && GOROOT_BOOTSTRAP=~/go-bootstrap ./make.bash)
 


### PR DESCRIPTION
The script was trying to install `parallelbuilds-go1.7.1.patch`. Fixing to
extract only the first two numbers from the version.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9348)

<!-- Reviewable:end -->
