### PR TITLE
sql: Finalize support for builtin window functions

### DIFF
--- a/sql/testdata/window
+++ b/sql/testdata/window
@@ -777,3 +777,340 @@ SELECT k, v, w, ntile(6) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
 9   2     9  4
 10  4     9  3
 11  NULL  9  2
+
+query II
+SELECT k, lag(9) OVER () FROM kv ORDER BY 1
+----
+1   NULL
+3   9
+5   9
+6   9
+7   9
+8   9
+9   9
+10  9
+11  9
+
+query II
+SELECT k, lead(9) OVER () FROM kv ORDER BY 1
+----
+1   9
+3   9
+5   9
+6   9
+7   9
+8   9
+9   9
+10  9
+11  NULL
+
+query II
+SELECT k, lag(k) OVER () FROM kv ORDER BY 1
+----
+1   NULL
+3   1
+5   3
+6   5
+7   6
+8   7
+9   8
+10  9
+11  10
+
+query II
+SELECT k, lag(k) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1   7
+3   8
+5   NULL
+6   1
+7   NULL
+8   NULL
+9   6
+10  3
+11  5
+
+query II
+SELECT k, lead(k) OVER () FROM kv ORDER BY 1
+----
+1   3
+3   5
+5   6
+6   7
+7   8
+8   9
+9   10
+10  11
+11  NULL
+
+query II
+SELECT k, lead(k) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1   6
+3   10
+5   11
+6   9
+7   1
+8   3
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, lag(k, 3) OVER () FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   1
+7   3
+8   5
+9   6
+10  7
+11  8
+
+query II
+SELECT k, lag(k, 3) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   NULL
+7   NULL
+8   NULL
+9   7
+10  NULL
+11  NULL
+
+query II
+SELECT k, lead(k, 3) OVER () FROM kv ORDER BY 1
+----
+1   6
+3   7
+5   8
+6   9
+7   10
+8   11
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, lead(k, 3) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   NULL
+7   9
+8   NULL
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, lag(k, -5) OVER () FROM kv ORDER BY 1
+----
+1   8
+3   9
+5   10
+6   11
+7   NULL
+8   NULL
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, lead(k, -5) OVER () FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   NULL
+7   NULL
+8   1
+9   3
+10  5
+11  6
+
+query II
+SELECT k, lag(k, 0) OVER () FROM kv ORDER BY 1
+----
+1   1
+3   3
+5   5
+6   6
+7   7
+8   8
+9   9
+10  10
+11  11
+
+query II
+SELECT k, lead(k, 0) OVER () FROM kv ORDER BY 1
+----
+1   1
+3   3
+5   5
+6   6
+7   7
+8   8
+9   9
+10  10
+11  11
+
+query II
+SELECT k, lag(k, NULL::INT) OVER () FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   NULL
+7   NULL
+8   NULL
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, lead(k, NULL::INT) OVER () FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   NULL
+7   NULL
+8   NULL
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, lag(k, w) OVER () FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   1
+7   5
+8   6
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, lag(k, w) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   NULL
+7   NULL
+8   NULL
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, lead(k, w) OVER () FROM kv ORDER BY 1
+----
+1   6
+3   9
+5   10
+6   9
+7   9
+8   10
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, lead(k, w) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   NULL
+7   6
+8   10
+9   NULL
+10  NULL
+11  NULL
+
+query error unknown signature for lag: lag\(int, int, string\)
+SELECT k, lag(k, 1, 'FOO') OVER () FROM kv ORDER BY 1
+
+query error unknown signature for lead: lead\(int, int, string\)
+SELECT k, lead(k, 1, 'FOO') OVER () FROM kv ORDER BY 1
+
+query error unknown signature for lag: lag\(int, int, string\)
+SELECT k, lag(k, 1, s) OVER () FROM kv ORDER BY 1
+
+query error unknown signature for lead: lead\(int, int, string\)
+SELECT k, lead(k, 1, s) OVER () FROM kv ORDER BY 1
+
+query II
+SELECT k, lag(k, 3, -99) OVER () FROM kv ORDER BY 1
+----
+1   -99
+3   -99
+5   -99
+6   1
+7   3
+8   5
+9   6
+10  7
+11  8
+
+query II
+SELECT k, lead(k, 3, -99) OVER () FROM kv ORDER BY 1
+----
+1   6
+3   7
+5   8
+6   9
+7   10
+8   11
+9   -99
+10  -99
+11  -99
+
+query II
+SELECT k, lag(k, 3, v) OVER () FROM kv ORDER BY 1
+----
+1   2
+3   4
+5   NULL
+6   1
+7   3
+8   5
+9   6
+10  7
+11  8
+
+query II
+SELECT k, lead(k, 3, v) OVER () FROM kv ORDER BY 1
+----
+1   6
+3   7
+5   8
+6   9
+7   10
+8   11
+9   2
+10  4
+11  NULL
+
+query II
+SELECT k, (lag(k, 5, w) OVER w + lead(k, 3, v) OVER w) FROM kv WINDOW w AS () ORDER BY 1
+----
+1   9
+3   12
+5   13
+6   12
+7   12
+8   12
+9   5
+10  9
+11  NULL

--- a/sql/testdata/window
+++ b/sql/testdata/window
@@ -1114,3 +1114,294 @@ SELECT k, (lag(k, 5, w) OVER w + lead(k, 3, v) OVER w) FROM kv WINDOW w AS () OR
 9   5
 10  9
 11  NULL
+
+query II
+SELECT k, first_value(NULL::INT) OVER () FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   NULL
+7   NULL
+8   NULL
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, first_value(1) OVER () FROM kv ORDER BY 1
+----
+1   1
+3   1
+5   1
+6   1
+7   1
+8   1
+9   1
+10  1
+11  1
+
+query IR
+SELECT k, first_value(199.9 * 23.3) OVER () FROM kv ORDER BY 1
+----
+1   4657.6700000000000000
+3   4657.6700000000000000
+5   4657.6700000000000000
+6   4657.6700000000000000
+7   4657.6700000000000000
+8   4657.6700000000000000
+9   4657.6700000000000000
+10  4657.6700000000000000
+11  4657.6700000000000000
+
+query II
+SELECT k, first_value(v) OVER () FROM kv ORDER BY 1
+----
+1   2
+3   2
+5   2
+6   2
+7   2
+8   2
+9   2
+10  2
+11  2
+
+query IIII
+SELECT k, v, w, first_value(w) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1   2     3  2
+3   4     5  2
+5   NULL  5  5
+6   2     3  2
+7   2     2  2
+8   4     2  2
+9   2     9  2
+10  4     9  2
+11  NULL  9  5
+
+query IIII
+SELECT k, v, w, first_value(w) OVER (PARTITION BY v ORDER BY w DESC) FROM kv ORDER BY 1
+----
+1   2     3  9
+3   4     5  9
+5   NULL  5  9
+6   2     3  9
+7   2     2  9
+8   4     2  9
+9   2     9  9
+10  4     9  9
+11  NULL  9  9
+
+query II
+SELECT k, last_value(NULL::INT) OVER () FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   NULL
+7   NULL
+8   NULL
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, last_value(1) OVER () FROM kv ORDER BY 1
+----
+1   1
+3   1
+5   1
+6   1
+7   1
+8   1
+9   1
+10  1
+11  1
+
+query IR
+SELECT k, last_value(199.9 * 23.3) OVER () FROM kv ORDER BY 1
+----
+1   4657.6700000000000000
+3   4657.6700000000000000
+5   4657.6700000000000000
+6   4657.6700000000000000
+7   4657.6700000000000000
+8   4657.6700000000000000
+9   4657.6700000000000000
+10  4657.6700000000000000
+11  4657.6700000000000000
+
+query II
+SELECT k, last_value(v) OVER () FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   NULL
+7   NULL
+8   NULL
+9   NULL
+10  NULL
+11  NULL
+
+query IIII
+SELECT k, v, w, last_value(w) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1   2     3  3
+3   4     5  5
+5   NULL  5  5
+6   2     3  3
+7   2     2  2
+8   4     2  2
+9   2     9  9
+10  4     9  9
+11  NULL  9  9
+
+query IIII
+SELECT k, v, w, last_value(w) OVER (PARTITION BY v ORDER BY w DESC) FROM kv ORDER BY 1
+----
+1   2     3  3
+3   4     5  5
+5   NULL  5  5
+6   2     3  3
+7   2     2  2
+8   4     2  2
+9   2     9  9
+10  4     9  9
+11  NULL  9  9
+
+query error unknown signature for nth_value: nth_value\(int, string\)
+SELECT k, nth_value(v, 'FOO') OVER () FROM kv ORDER BY 1
+
+query error argument of nth_value must be greater than zero
+SELECT k, nth_value(v, -99) OVER () FROM kv ORDER BY 1
+
+query error argument of nth_value must be greater than zero
+SELECT k, nth_value(v, 0) OVER () FROM kv ORDER BY 1
+
+query II
+SELECT k, nth_value(NULL::INT, 5) OVER () FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   NULL
+7   NULL
+8   NULL
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, nth_value(1, 3) OVER () FROM kv ORDER BY 1
+----
+1   1
+3   1
+5   1
+6   1
+7   1
+8   1
+9   1
+10  1
+11  1
+
+query II
+SELECT k, nth_value(1, 33) OVER () FROM kv ORDER BY 1
+----
+1   NULL
+3   NULL
+5   NULL
+6   NULL
+7   NULL
+8   NULL
+9   NULL
+10  NULL
+11  NULL
+
+query IR
+SELECT k, nth_value(199.9 * 23.3, 7) OVER () FROM kv ORDER BY 1
+----
+1   4657.6700000000000000
+3   4657.6700000000000000
+5   4657.6700000000000000
+6   4657.6700000000000000
+7   4657.6700000000000000
+8   4657.6700000000000000
+9   4657.6700000000000000
+10  4657.6700000000000000
+11  4657.6700000000000000
+
+query II
+SELECT k, nth_value(v, 8) OVER () FROM kv ORDER BY 1
+----
+1   4
+3   4
+5   4
+6   4
+7   4
+8   4
+9   4
+10  4
+11  4
+
+query IIII
+SELECT k, v, w, nth_value(w, 2) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1   2     3  3
+3   4     5  5
+5   NULL  5  NULL
+6   2     3  3
+7   2     2  NULL
+8   4     2  NULL
+9   2     9  3
+10  4     9  5
+11  NULL  9  9
+
+query IIII
+SELECT k, v, w, nth_value(w, 2) OVER (PARTITION BY v ORDER BY w DESC) FROM kv ORDER BY 1
+----
+1   2     3  3
+3   4     5  5
+5   NULL  5  5
+6   2     3  3
+7   2     2  3
+8   4     2  5
+9   2     9  NULL
+10  4     9  NULL
+11  NULL  9  NULL
+
+query II
+SELECT k, nth_value(v, k) OVER () FROM kv ORDER BY 1
+----
+1   2
+3   NULL
+5   2
+6   4
+7   2
+8   4
+9   NULL
+10  NULL
+11  NULL
+
+query II
+SELECT k, nth_value(v, v) OVER () FROM kv ORDER BY 1
+----
+1   4
+3   2
+5   NULL
+6   4
+7   4
+8   2
+9   4
+10  2
+11  NULL
+
+statement ok
+INSERT INTO kv VALUES (12, -1, DEFAULT, DEFAULT, DEFAULT, DEFAULT)
+
+query error argument of nth_value must be greater than zero
+SELECT k, nth_value(v, v) OVER () FROM kv ORDER BY 1
+
+statement ok
+DELETE FROM kv WHERE k = 12


### PR DESCRIPTION
This change adds support for the following builtin window functions:
- lead(e)
- lag(e)
- first_value(e)
- last_value(e)
- nth_value(e, n)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9352)

<!-- Reviewable:end -->
