### PR TITLE
storage: disable quiescence by default

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -2011,7 +2011,7 @@ func (r *Replica) tickRaftMuLocked() (bool, error) {
 	return true, nil
 }
 
-var enableQuiescence = envutil.EnvOrDefaultBool("COCKROACH_ENABLE_QUIESCENCE", true)
+var enableQuiescence = envutil.EnvOrDefaultBool("COCKROACH_ENABLE_QUIESCENCE", false)
 
 // maybeQuiesceLocked checks to see if the replica is quiescable and initiates
 // quiescence if it is. Returns true if the replica has been quiesced and false


### PR DESCRIPTION
It seems to be causing performance problems on gamma. Disabling by
default until we get those figured out.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9354)

<!-- Reviewable:end -->
