### PR TITLE
gceworker: fix autoshutdown when not using the worker after create/start

### DIFF
--- a/scripts/crontab.autoshutdown
+++ b/scripts/crontab.autoshutdown
@@ -1,0 +1,19 @@
+# This is a crontab file that (when installed as root) auto shuts down a host
+# if no remote session is detected for 10 minutes.
+#
+# To disable auto-shutdown, `sudo touch /.active`
+#
+# Also, when installing this crontab for the first time it will go into effect
+# only after a reboot or when a remote session is detected. To make it go into
+# effect right away, run `/sbin/shutdown --no-wall -h +10`
+
+
+# As long as we detect a remote session, we (re)schedule a shutdown in 10
+# minutes. Scheduling a shutdown cancels any previous shutdown.
+#
+# Once a shutdown is close enough, ssh logins are not allowed any more; hence we
+# preventively remove the /etc/nologin file.
+#
+# Note: this is invoked via `sh -c`, and so no `bash` features must be used.
+* * * * * rm -f /etc/nologin; (test -f /.active && /sbin/shutdown -c --no-wall || w -hs | grep -q pts && /sbin/shutdown --no-wall -h +10) >> /root/idle.log 2>&1
+@reboot test -f /.active || /sbin/shutdown --no-wall -h +10

--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -23,17 +23,10 @@ case ${1-} in
 
     gcloud compute copy-files "$(dirname "${0}")" "${name}:scripts"
     gcloud compute ssh "${name}" --ssh-flag="-A" --command="GOVERSION=${GOVERSION} ./scripts/bootstrap-debian.sh"
+
     # Install automatic shutdown after ten minutes of operation without a
     # logged in user. To disable this, `sudo touch /.active`.
-    # This is much more intricate than it looks. A few complications which
-    # are addressed in these few commands:
-    # - Once a shutdown is close enough, ssh logins are not allowed any more;
-    #   hence we preventively remove the /etc/nologin file.
-    # - calling shutdown with a later date cancels the previous shutdown, so
-    #   we keep scheduling shutdowns in the future while users are logged in.
-    # - This is invoked via `sh -c`, and so no `bash` features must be used.
-    gcloud compute ssh "${name}" \
-      "echo '* * * * * rm -f /etc/nologin; (test -f /.active && /sbin/shutdown -c --no-wall || w -hs | grep -q pts && /sbin/shutdown --no-wall -h +10) >> /root/idle.log 2>&1' | sudo crontab -"
+    gcloud compute ssh "${name}" --command="sudo crontab scripts/crontab.autoshutdown; sudo /sbin/shutdown --no-wall -h +10 2>/dev/null"
 
     ;;
     start)


### PR DESCRIPTION
The autoshutdown crontab script "kicks in" the first time it sees a remote
session, so autoshutdown doesn't work if we just create or start a worker and
then forget about it.

To fix this we schedule a shutdown on `create` and on `@reboot`. Also moving the
crontab to a separate file which is easier to read and comment.

Auto shutdown seems to work after create/start. I will test it some more before merging.

It still has some rough edges. The nologin thing can still block you out for up to a minute, and if you log in, `rm /.active`, and log out right away, the shutdown probably won't kick in..

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9381)

<!-- Reviewable:end -->
