### PR TITLE
gceworker: fix autoshutdown when not using the worker after create/start

### DIFF
--- a/scripts/autoshutdown.cron.sh
+++ b/scripts/autoshutdown.cron.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# This script is intended to be called periodical. If it doesn't detect remote
+# sessions in a given number of consecutive runs, a shutdown is initiated.
+#
+# To disable auto-shutdown: `sudo touch /.active`
+
+set -euxo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <num_periods>"
+  exit 1
+fi
+
+MAX_COUNT="$1"
+
+if ! [ "$MAX_COUNT" -gt 0 -a "$MAX_COUNT" -lt 10000 ]; then
+  echo "Invalid argument '$MAX_COUNT'"
+  exit 1
+fi
+
+# We maintain the count of how many consecutive iterations of this script did
+# NOT detect a remote session. Once we exceed MAX_COUNT, we shut down.
+# We use /dev/shm which is not persistent over reboots.
+FILE=/dev/shm/autoshutdown-count
+COUNT=0
+
+if [ -f /.active ] || w -hs | grep -q pts; then
+  # Auto-shutdown is disabled (via /.active) or there is a remote session.
+  echo 0 > $FILE
+  exit 0
+fi
+
+if [ -f $FILE ]; then
+  COUNT=$(cat $FILE)
+fi
+
+COUNT=$((COUNT+1))
+
+if [ $COUNT -le $MAX_COUNT ]; then
+  echo $COUNT > $FILE
+else
+  /sbin/shutdown -h
+fi


### PR DESCRIPTION
The autoshutdown crontab script "kicks in" the first time it sees a remote
session, so autoshutdown doesn't work if we just create or start a worker and
then forget about it. The method we are using also has some flakiness around
`/etc/nologin`.

Replacing with a script that simply keeps track of a count in a file in
`/dev/shm` (which is not persistent over reboots).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9382)

<!-- Reviewable:end -->
