### PR TITLE
storage: add metrics for replica queues

### DIFF
--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -102,6 +102,10 @@ func newGCQueue(store *Store, gossip *gossip.Gossip) *gcQueue {
 		maxSize:              gcQueueMaxSize,
 		needsLease:           true,
 		acceptsUnsplitRanges: false,
+		successes:            store.metrics.GCQueueSuccesses,
+		failures:             store.metrics.GCQueueFailures,
+		pending:              store.metrics.GCQueuePending,
+		processingNanos:      store.metrics.GCQueueProcessingNanos,
 	})
 	return gcq
 }

--- a/storage/metrics.go
+++ b/storage/metrics.go
@@ -150,6 +150,58 @@ var (
 
 	metaRaftEnqueuedPending = metric.Metadata{Name: "raft.enqueued.pending",
 		Help: "Number of pending outgoing messages in the Raft Transport queue"}
+
+	// Replica queue metrics.
+	metaGCQueueSuccesses = metric.Metadata{Name: "queue.gc.process.success",
+		Help: "Number of replicas successfully processed by the GC queue"}
+	metaGCQueueFailures = metric.Metadata{Name: "queue.gc.process.failure",
+		Help: "Number of replicas which failed processing in the GC queue"}
+	metaGCQueuePending = metric.Metadata{Name: "queue.gc.pending",
+		Help: "Number of pending replicas in the GC queue"}
+	metaGCQueueProcessingNanos = metric.Metadata{Name: "queue.gc.processingnanos",
+		Help: "Nanoseconds spent processing replicas in the GC queue"}
+	metaRaftLogQueueSuccesses = metric.Metadata{Name: "queue.raftlog.process.success",
+		Help: "Number of replicas successfully processed by the raft log queue"}
+	metaRaftLogQueueFailures = metric.Metadata{Name: "queue.raftlog.process.failure",
+		Help: "Number of replicas which failed processing in the raft log queue"}
+	metaRaftLogQueuePending = metric.Metadata{Name: "queue.raftlog.pending",
+		Help: "Number of pending replicas in the raft log queue"}
+	metaRaftLogQueueProcessingNanos = metric.Metadata{Name: "queue.raftlog.processingnanos",
+		Help: "Nanoseconds spent processing replicas in the raft log queue"}
+	metaConsistencyQueueSuccesses = metric.Metadata{Name: "queue.consistency.process.success",
+		Help: "Number of replicas successfully processed by the consistency checker queue"}
+	metaConsistencyQueueFailures = metric.Metadata{Name: "queue.consistency.process.failure",
+		Help: "Number of replicas which failed processing in the consistency checker queue"}
+	metaConsistencyQueuePending = metric.Metadata{Name: "queue.consistency.pending",
+		Help: "Number of pending replicas in the consistency checker queue"}
+	metaConsistencyQueueProcessingNanos = metric.Metadata{Name: "queue.consistency.processingnanos",
+		Help: "Nanoseconds spent processing replicas in the consistency checker queue"}
+	metaReplicaGCQueueSuccesses = metric.Metadata{Name: "queue.replicagc.process.success",
+		Help: "Number of replicas successfully processed by the replica GC queue"}
+	metaReplicaGCQueueFailures = metric.Metadata{Name: "queue.replicagc.process.failure",
+		Help: "Number of replicas which failed processing in the replica GC queue"}
+	metaReplicaGCQueuePending = metric.Metadata{Name: "queue.replicagc.pending",
+		Help: "Number of pending replicas in the replica GC queue"}
+	metaReplicaGCQueueProcessingNanos = metric.Metadata{Name: "queue.replicagc.processingnanos",
+		Help: "Nanoseconds spent processing replicas in the replica GC queue"}
+	metaReplicateQueueSuccesses = metric.Metadata{Name: "queue.replicate.process.success",
+		Help: "Number of replicas successfully processed by the replicate queue"}
+	metaReplicateQueueFailures = metric.Metadata{Name: "queue.replicate.process.failure",
+		Help: "Number of replicas which failed processing in the replicate queue"}
+	metaReplicateQueuePending = metric.Metadata{Name: "queue.replicate.pending",
+		Help: "Number of pending replicas in the replicate queue"}
+	metaReplicateQueueProcessingNanos = metric.Metadata{Name: "queue.replicate.processingnanos",
+		Help: "Nanoseconds spent processing replicas in the replicate queue"}
+	metaReplicateQueuePurgatory = metric.Metadata{Name: "queue.replicate.purgatory",
+		Help: "Number of replicas in the replicate queue's purgatory, awaiting allocation options"}
+	metaSplitQueueSuccesses = metric.Metadata{Name: "queue.split.process.success",
+		Help: "Number of replicas successfully processed by the split queue"}
+	metaSplitQueueFailures = metric.Metadata{Name: "queue.split.process.failure",
+		Help: "Number of replicas which failed processing in the split queue"}
+	metaSplitQueuePending = metric.Metadata{Name: "queue.split.pending",
+		Help: "Number of pending replicas in the split queue"}
+	metaSplitQueueProcessingNanos = metric.Metadata{Name: "queue.split.processingnanos",
+		Help: "Nanoseconds spent processing replicas in the split queue"}
 )
 
 // StoreMetrics is the set of metrics for a given store.
@@ -249,6 +301,33 @@ type StoreMetrics struct {
 
 	RaftEnqueuedPending *metric.Gauge
 
+	// Replica queue metrics.
+	GCQueueSuccesses                *metric.Counter
+	GCQueueFailures                 *metric.Counter
+	GCQueuePending                  *metric.Gauge
+	GCQueueProcessingNanos          *metric.Counter
+	RaftLogQueueSuccesses           *metric.Counter
+	RaftLogQueueFailures            *metric.Counter
+	RaftLogQueuePending             *metric.Gauge
+	RaftLogQueueProcessingNanos     *metric.Counter
+	ConsistencyQueueSuccesses       *metric.Counter
+	ConsistencyQueueFailures        *metric.Counter
+	ConsistencyQueuePending         *metric.Gauge
+	ConsistencyQueueProcessingNanos *metric.Counter
+	ReplicaGCQueueSuccesses         *metric.Counter
+	ReplicaGCQueueFailures          *metric.Counter
+	ReplicaGCQueuePending           *metric.Gauge
+	ReplicaGCQueueProcessingNanos   *metric.Counter
+	ReplicateQueueSuccesses         *metric.Counter
+	ReplicateQueueFailures          *metric.Counter
+	ReplicateQueuePending           *metric.Gauge
+	ReplicateQueueProcessingNanos   *metric.Counter
+	ReplicateQueuePurgatory         *metric.Gauge
+	SplitQueueSuccesses             *metric.Counter
+	SplitQueueFailures              *metric.Counter
+	SplitQueuePending               *metric.Gauge
+	SplitQueueProcessingNanos       *metric.Counter
+
 	// Stats for efficient merges.
 	mu struct {
 		syncutil.Mutex
@@ -343,6 +422,33 @@ func newStoreMetrics() *StoreMetrics {
 		raftRcvdMessages:          make(map[raftpb.MessageType]*metric.Counter, len(raftpb.MessageType_name)),
 
 		RaftEnqueuedPending: metric.NewGauge(metaRaftEnqueuedPending),
+
+		// Replica queue metrics.
+		GCQueueSuccesses:                metric.NewCounter(metaGCQueueSuccesses),
+		GCQueueFailures:                 metric.NewCounter(metaGCQueueFailures),
+		GCQueuePending:                  metric.NewGauge(metaGCQueuePending),
+		GCQueueProcessingNanos:          metric.NewCounter(metaGCQueueProcessingNanos),
+		RaftLogQueueSuccesses:           metric.NewCounter(metaRaftLogQueueSuccesses),
+		RaftLogQueueFailures:            metric.NewCounter(metaRaftLogQueueFailures),
+		RaftLogQueuePending:             metric.NewGauge(metaRaftLogQueuePending),
+		RaftLogQueueProcessingNanos:     metric.NewCounter(metaRaftLogQueueProcessingNanos),
+		ConsistencyQueueSuccesses:       metric.NewCounter(metaConsistencyQueueSuccesses),
+		ConsistencyQueueFailures:        metric.NewCounter(metaConsistencyQueueFailures),
+		ConsistencyQueuePending:         metric.NewGauge(metaConsistencyQueuePending),
+		ConsistencyQueueProcessingNanos: metric.NewCounter(metaConsistencyQueueProcessingNanos),
+		ReplicaGCQueueSuccesses:         metric.NewCounter(metaReplicaGCQueueSuccesses),
+		ReplicaGCQueueFailures:          metric.NewCounter(metaReplicaGCQueueFailures),
+		ReplicaGCQueuePending:           metric.NewGauge(metaReplicaGCQueuePending),
+		ReplicaGCQueueProcessingNanos:   metric.NewCounter(metaReplicaGCQueueProcessingNanos),
+		ReplicateQueueSuccesses:         metric.NewCounter(metaReplicateQueueSuccesses),
+		ReplicateQueueFailures:          metric.NewCounter(metaReplicateQueueFailures),
+		ReplicateQueuePending:           metric.NewGauge(metaReplicateQueuePending),
+		ReplicateQueueProcessingNanos:   metric.NewCounter(metaReplicateQueueProcessingNanos),
+		ReplicateQueuePurgatory:         metric.NewGauge(metaReplicateQueuePurgatory),
+		SplitQueueSuccesses:             metric.NewCounter(metaSplitQueueSuccesses),
+		SplitQueueFailures:              metric.NewCounter(metaSplitQueueFailures),
+		SplitQueuePending:               metric.NewGauge(metaSplitQueuePending),
+		SplitQueueProcessingNanos:       metric.NewCounter(metaSplitQueueProcessingNanos),
 	}
 
 	sm.raftRcvdMessages[raftpb.MsgProp] = sm.RaftRcvdMsgProp

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/syncutil"
 	"github.com/cockroachdb/cockroach/util/timeutil"
@@ -147,6 +148,16 @@ type queueConfig struct {
 	acceptsUnsplitRanges bool
 	// processTimeout is the timeout for processing a replica.
 	processTimeout time.Duration
+	// successes is a counter of replicas processed successfully.
+	successes *metric.Counter
+	// failures is a counter of replicas which failed processing.
+	failures *metric.Counter
+	// pending is a gauge measuring current replica count pending.
+	pending *metric.Gauge
+	// processingNanos is a counter measuring total nanoseconds spent processing replicas.
+	processingNanos *metric.Counter
+	// purgatory is a gauge measuring current replica count in purgatory.
+	purgatory *metric.Gauge
 }
 
 // baseQueue is the base implementation of the replicaQueue interface.
@@ -373,8 +384,7 @@ func (bq *baseQueue) addInternal(repl *Replica, should bool, priority float64) (
 
 	log.VEventf(3, bq.ctx, "%s: adding: priority=%0.3f", repl, priority)
 	item = &replicaItem{value: repl.RangeID, priority: priority}
-	heap.Push(&bq.mu.priorityQ, item)
-	bq.mu.replicas[repl.RangeID] = item
+	bq.add(item)
 
 	// If adding this replica has pushed the queue past its maximum size,
 	// remove the lowest priority element.
@@ -511,11 +521,15 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) error {
 
 	log.VEventf(3, bq.ctx, "processing")
 	start := timeutil.Now()
-	if err := bq.impl.process(ctx, clock.Now(), repl, cfg); err != nil {
+	err := bq.impl.process(ctx, clock.Now(), repl, cfg)
+	duration := timeutil.Since(start)
+	bq.processingNanos.Inc(duration.Nanoseconds())
+	if err != nil {
 		return err
 	}
-	log.VEventf(2, bq.ctx, "done: %s", timeutil.Since(start))
+	log.VEventf(2, bq.ctx, "done: %s", duration)
 	log.Event(ctx, "done")
+	bq.successes.Inc(1)
 	return nil
 }
 
@@ -526,6 +540,10 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) error {
 // mechanism for signaling re-processing of replicas held in
 // purgatory.
 func (bq *baseQueue) maybeAddToPurgatory(repl *Replica, err error, clock *hlc.Clock, stopper *stop.Stopper) {
+	// Increment failures metric here to capture all error returns from
+	// process().
+	bq.failures.Inc(1)
+
 	// Check whether the failure is a purgatory error and whether the queue supports it.
 	if _, ok := err.(purgatoryError); !ok || bq.impl.purgatoryChan() == nil {
 		log.Errorf(bq.ctx, "on %s: %s", repl, err)
@@ -543,6 +561,10 @@ func (bq *baseQueue) maybeAddToPurgatory(repl *Replica, err error, clock *hlc.Cl
 
 	item := &replicaItem{value: repl.RangeID}
 	bq.mu.replicas[repl.RangeID] = item
+
+	defer func() {
+		bq.purgatory.Update(int64(len(bq.mu.purgatory)))
+	}()
 
 	// If purgatory already exists, just add to the map and we're done.
 	if bq.mu.purgatory != nil {
@@ -620,6 +642,7 @@ func (bq *baseQueue) pop() *Replica {
 		return nil
 	}
 	item := heap.Pop(&bq.mu.priorityQ).(*replicaItem)
+	bq.pending.Update(int64(bq.mu.priorityQ.Len()))
 	delete(bq.mu.replicas, item.value)
 	bq.mu.Unlock()
 
@@ -631,13 +654,22 @@ func (bq *baseQueue) pop() *Replica {
 	return repl
 }
 
+// add adds an element to the priority queue. Caller must hold mutex.
+func (bq *baseQueue) add(item *replicaItem) {
+	heap.Push(&bq.mu.priorityQ, item)
+	bq.pending.Update(int64(bq.mu.priorityQ.Len()))
+	bq.mu.replicas[item.value] = item
+}
+
 // remove removes an element from purgatory (if it's experienced an
 // error) or from the priority queue by index. Caller must hold mutex.
 func (bq *baseQueue) remove(item *replicaItem) {
 	if _, ok := bq.mu.purgatory[item.value]; ok {
 		delete(bq.mu.purgatory, item.value)
+		bq.purgatory.Update(int64(len(bq.mu.purgatory)))
 	} else {
 		heap.Remove(&bq.mu.priorityQ, item.index)
+		bq.pending.Update(int64(bq.mu.priorityQ.Len()))
 	}
 	delete(bq.mu.replicas, item.value)
 }
@@ -649,6 +681,7 @@ func (bq *baseQueue) DrainQueue(clock *hlc.Clock) {
 	repl := bq.pop()
 	for repl != nil {
 		if err := bq.processReplica(repl, clock); err != nil {
+			bq.failures.Inc(1)
 			log.Errorf(bq.ctx, "failed processing replica %s: %s", repl, err)
 		}
 		repl = bq.pop()

--- a/storage/raft_log_queue.go
+++ b/storage/raft_log_queue.go
@@ -60,6 +60,10 @@ func newRaftLogQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *raftLo
 		maxSize:              raftLogQueueMaxSize,
 		needsLease:           false,
 		acceptsUnsplitRanges: true,
+		successes:            store.metrics.RaftLogQueueSuccesses,
+		failures:             store.metrics.RaftLogQueueFailures,
+		pending:              store.metrics.RaftLogQueuePending,
+		processingNanos:      store.metrics.RaftLogQueueProcessingNanos,
 	})
 	return rlq
 }

--- a/storage/replica_consistency_queue.go
+++ b/storage/replica_consistency_queue.go
@@ -43,6 +43,10 @@ func newReplicaConsistencyQueue(store *Store, gossip *gossip.Gossip) *replicaCon
 		maxSize:              replicaConsistencyQueueSize,
 		needsLease:           true,
 		acceptsUnsplitRanges: true,
+		successes:            store.metrics.ConsistencyQueueSuccesses,
+		failures:             store.metrics.ConsistencyQueueFailures,
+		pending:              store.metrics.ConsistencyQueuePending,
+		processingNanos:      store.metrics.ConsistencyQueueProcessingNanos,
 	})
 	return rcq
 }

--- a/storage/replica_gc_queue.go
+++ b/storage/replica_gc_queue.go
@@ -78,6 +78,10 @@ func newReplicaGCQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *repl
 		maxSize:              replicaGCQueueMaxSize,
 		needsLease:           false,
 		acceptsUnsplitRanges: true,
+		successes:            store.metrics.ReplicaGCQueueSuccesses,
+		failures:             store.metrics.ReplicaGCQueueFailures,
+		pending:              store.metrics.ReplicaGCQueuePending,
+		processingNanos:      store.metrics.ReplicaGCQueueProcessingNanos,
 	})
 	return q
 }

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -59,6 +59,11 @@ func newReplicateQueue(store *Store, g *gossip.Gossip, allocator Allocator, cloc
 		maxSize:              replicateQueueMaxSize,
 		needsLease:           true,
 		acceptsUnsplitRanges: false,
+		successes:            store.metrics.ReplicateQueueSuccesses,
+		failures:             store.metrics.ReplicateQueueFailures,
+		pending:              store.metrics.ReplicateQueuePending,
+		processingNanos:      store.metrics.ReplicateQueueProcessingNanos,
+		purgatory:            store.metrics.ReplicateQueuePurgatory,
 	})
 
 	if g != nil { // gossip is nil for some unittests

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -53,6 +53,10 @@ func newSplitQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *splitQue
 		maxSize:              splitQueueMaxSize,
 		needsLease:           true,
 		acceptsUnsplitRanges: true,
+		successes:            store.metrics.SplitQueueSuccesses,
+		failures:             store.metrics.SplitQueueFailures,
+		pending:              store.metrics.SplitQueuePending,
+		processingNanos:      store.metrics.SplitQueueProcessingNanos,
 	})
 	return sq
 }


### PR DESCRIPTION
In particular: total counts for successfully processed and process
failures, current length of pending queue, total nanoseconds of
replica processing time, and length of purgatory queue.

Fixes #9272

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9398)

<!-- Reviewable:end -->
