### PR TITLE
storage: tick the logical clock for quiescent ranges

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -44,7 +44,7 @@ github.com/cockroachdb/pq 40c6b2414c76cdb84aacc955f79dc844e48ad0c0
 github.com/cockroachdb/stress 029c9348806514969d1109a6ae36e521af411ca7
 github.com/cockroachdb/yacc 7c99dfd2164a5d23c3f495ffc2e0b72b6379d066
 github.com/codahale/hdrhistogram f8ad88b59a584afeee9d334eff879b104439117b
-github.com/coreos/etcd 656167d760543d442eae62f0c8c4f92c05f59508
+github.com/coreos/etcd 143e2f27fc20f0cf5c29ad432b7526ef5adc9899
 github.com/cpuguy83/go-md2man 2724a9c9051aa62e9cca11304e7dd518e9e41599
 github.com/davecgh/go-spew 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
 github.com/docker/distribution c9fd26e9efe2c7405d7072ad181844275977b5e3

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1987,6 +1987,26 @@ func (r *Replica) tickRaftMuLocked() (bool, error) {
 		return false, nil
 	}
 	if r.mu.quiescent {
+		// While a replica is quiesced we still advance its logical clock. This is
+		// necessary to avoid a scenario where the leader quiesces and a follower
+		// does not. The follower calls an election but the election fails because
+		// the leader and other follower believe that no time in the current term
+		// has passed. The Raft group is then in a state where one member has a
+		// term that is advanced which will then cause subsequent heartbeats from
+		// the existing leader to be rejected in a way that the leader will step
+		// down. This situation is caused by an interaction between quiescence and
+		// the Raft CheckQuorum feature which relies on the logical clock ticking
+		// at roughly the same rate on all members of the group.
+		//
+		// By ticking the logical clock (incrementing an integer) we avoid this
+		// situation. If one of the followers does not quiesce it will call an
+		// election but the election will succeed. Note that while we expect such
+		// elections from quiesced followers to be extremely rare, it is very
+		// difficult to completely eliminate them so we want to minimize the
+		// disruption when they do occur.
+		//
+		// For more details, see #9372.
+		r.mu.internalRaftGroup.TickQuiesced()
 		return false, nil
 	}
 	if r.maybeQuiesceLocked() {


### PR DESCRIPTION
Fixes #9372.

I see this being done in addition to #9383. See the commentary on #9372 for details. I'm sending this out for discussion and would add more commentary to this PR if we decide to move ahead with it. This PR relies on the following patch to `github.com/coreos/etcd/raft/rawnode.go`:

``` diff
diff --git a/raft/rawnode.go b/raft/rawnode.go
index 54c5000..e916483 100644
--- a/raft/rawnode.go
+++ b/raft/rawnode.go
@@ -120,6 +120,12 @@ func (rn *RawNode) Tick() {
        rn.raft.tick()
 }

+// TickClock advances the internal logical clock by a single tick without
+// performing any other processing.
+func (rn *RawNode) TickClock() {
+       rn.raft.electionElapsed++
+}
+
 // Campaign causes this RawNode to transition to candidate state.
 func (rn *RawNode) Campaign() error {
        return rn.raft.Step(pb.Message{
```

Cc @cockroachdb/stability

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9407)

<!-- Reviewable:end -->
