### PR TITLE
master -> develop

### DIFF
--- a/acceptance/cluster/cluster.go
+++ b/acceptance/cluster/cluster.go
@@ -20,6 +20,8 @@ import (
 	"net"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/util/stop"
@@ -70,7 +72,8 @@ func Consistent(t *testing.T, c Cluster) {
 	defer kvStopper.Stop()
 	// Set withDiff to false because any failure results in a second consistency check
 	// being called with withDiff=true.
-	if pErr := kvClient.CheckConsistency(keys.LocalMax, keys.MaxKey, false /* withDiff*/); pErr != nil {
-		t.Fatal(pErr)
+	if err := kvClient.CheckConsistency(context.TODO(), keys.LocalMax,
+		keys.MaxKey, false /* withDiff*/); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/acceptance/cluster/cluster.go
+++ b/acceptance/cluster/cluster.go
@@ -20,6 +20,8 @@ import (
 	"net"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/util/stop"
@@ -72,7 +74,8 @@ func Consistent(t *testing.T, c Cluster) {
 	defer kvStopper.Stop()
 	// Set withDiff to false because any failure results in a second consistency check
 	// being called with withDiff=true.
-	if pErr := kvClient.CheckConsistency(keys.LocalMax, keys.MaxKey, false /* withDiff*/); pErr != nil {
-		t.Fatal(pErr)
+	if err := kvClient.CheckConsistency(context.TODO(), keys.LocalMax,
+		keys.MaxKey, false /* withDiff*/); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/acceptance/freeze_test.go
+++ b/acceptance/freeze_test.go
@@ -160,7 +160,7 @@ func testFreezeClusterInner(t *testing.T, c cluster.Cluster, cfg cluster.TestCon
 		db, dbStopper := c.NewClient(t, 0)
 		defer dbStopper.Stop()
 
-		if _, err := db.Scan(keys.LocalMax, roachpb.KeyMax, 0); err != nil {
+		if _, err := db.Scan(context.TODO(), keys.LocalMax, roachpb.KeyMax, 0); err != nil {
 			t.Fatal(err)
 		}
 		return nil

--- a/acceptance/gossip_peerings_test.go
+++ b/acceptance/gossip_peerings_test.go
@@ -191,7 +191,7 @@ func testGossipRestartInner(t *testing.T, c cluster.Cluster, cfg cluster.TestCon
 		for i := 0; i < num; i++ {
 			db, dbStopper := c.NewClient(t, i)
 			if i == 0 {
-				if err := db.Del("count"); err != nil {
+				if err := db.Del(context.Background(), "count"); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/acceptance/put_test.go
+++ b/acceptance/put_test.go
@@ -52,7 +52,7 @@ func testPutInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig) {
 			for timeutil.Now().Before(deadline) {
 				k := atomic.AddInt64(&count, 1)
 				v := value[:r.Intn(len(value))]
-				if err := db.Put(fmt.Sprintf("%08d", k), v); err != nil {
+				if err := db.Put(context.TODO(), fmt.Sprintf("%08d", k), v); err != nil {
 					errs <- err
 					return
 				}

--- a/acceptance/replication_test.go
+++ b/acceptance/replication_test.go
@@ -33,7 +33,7 @@ import (
 
 func countRangeReplicas(db *client.DB) (int, error) {
 	desc := &roachpb.RangeDescriptor{}
-	if err := db.GetProto(keys.RangeDescriptorKey(roachpb.RKeyMin), desc); err != nil {
+	if err := db.GetProto(context.TODO(), keys.RangeDescriptorKey(roachpb.RKeyMin), desc); err != nil {
 		return 0, err
 	}
 	return len(desc.Replicas), nil

--- a/acceptance/single_key_test.go
+++ b/acceptance/single_key_test.go
@@ -119,7 +119,7 @@ func testSingleKeyInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig)
 	}
 
 	// Verify the resulting value stored at the key is what we expect.
-	r, err := initDB.Get(key)
+	r, err := initDB.Get(context.TODO(), key)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/acceptance/single_key_test.go
+++ b/acceptance/single_key_test.go
@@ -45,7 +45,7 @@ func testSingleKeyInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig)
 	const key = "test-key"
 	initDB, initDBStopper := c.NewClient(t, 0)
 	defer initDBStopper.Stop()
-	if err := initDB.Put(key, 0); err != nil {
+	if err := initDB.Put(context.TODO(), key, 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -119,7 +119,7 @@ func testSingleKeyInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig)
 	}
 
 	// Verify the resulting value stored at the key is what we expect.
-	r, err := initDB.Get(key)
+	r, err := initDB.Get(context.TODO(), key)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/acceptance/single_key_test.go
+++ b/acceptance/single_key_test.go
@@ -45,7 +45,7 @@ func testSingleKeyInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig)
 	const key = "test-key"
 	initDB, initDBStopper := c.NewClient(t, 0)
 	defer initDBStopper.Stop()
-	if err := initDB.Put(key, 0); err != nil {
+	if err := initDB.Put(context.TODO(), key, 0); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cli/kv.go
+++ b/cli/kv.go
@@ -203,7 +203,7 @@ func runInc(cmd *cobra.Command, args []string) {
 	}
 
 	key := roachpb.Key(unquoteArg(args[0], true /* disallow system keys */))
-	if r, err := kvDB.Inc(key, int64(amount)); err != nil {
+	if r, err := kvDB.Inc(context.TODO(), key, int64(amount)); err != nil {
 		panicf("increment failed: %s", err)
 	} else {
 		fmt.Printf("%d\n", r.ValueInt())

--- a/cli/kv.go
+++ b/cli/kv.go
@@ -298,7 +298,7 @@ func runScan(cmd *cobra.Command, args []string) {
 	kvDB, stopper := makeDBClient()
 	defer stopper.Stop()
 
-	rows, err := kvDB.Scan(startKey, endKey, maxResults)
+	rows, err := kvDB.Scan(context.Background(), startKey, endKey, maxResults)
 	if err != nil {
 		panicf("scan failed: %s", err)
 	}
@@ -329,7 +329,7 @@ func runReverseScan(cmd *cobra.Command, args []string) {
 	kvDB, stopper := makeDBClient()
 	defer stopper.Stop()
 
-	rows, err := kvDB.ReverseScan(startKey, endKey, maxResults)
+	rows, err := kvDB.ReverseScan(context.TODO(), startKey, endKey, maxResults)
 	if err != nil {
 		panicf("reverse scan failed: %s", err)
 	}

--- a/cli/kv.go
+++ b/cli/kv.go
@@ -159,9 +159,9 @@ func runCPut(cmd *cobra.Command, args []string) {
 	value := unquoteArg(args[1], false)
 	var err error
 	if len(args) == 3 {
-		err = kvDB.CPut(key, value, unquoteArg(args[2], false))
+		err = kvDB.CPut(context.Background(), key, value, unquoteArg(args[2], false))
 	} else {
-		err = kvDB.CPut(key, value, nil)
+		err = kvDB.CPut(context.Background(), key, value, nil)
 	}
 
 	if err != nil {

--- a/cli/kv.go
+++ b/cli/kv.go
@@ -85,7 +85,7 @@ func runGet(cmd *cobra.Command, args []string) {
 	defer stopper.Stop()
 
 	key := roachpb.Key(unquoteArg(args[0], false))
-	r, err := kvDB.Get(key)
+	r, err := kvDB.Get(context.Background(), key)
 	if err != nil {
 		panicf("get failed: %s", err)
 	}

--- a/cli/kv.go
+++ b/cli/kv.go
@@ -266,6 +266,7 @@ func runDelRange(cmd *cobra.Command, args []string) {
 	defer stopper.Stop()
 
 	if err := kvDB.DelRange(
+		context.TODO(),
 		unquoteArg(args[0], true /* disallow system keys */),
 		unquoteArg(args[1], true /* disallow system keys */),
 	); err != nil {

--- a/cli/kv.go
+++ b/cli/kv.go
@@ -85,7 +85,7 @@ func runGet(cmd *cobra.Command, args []string) {
 	defer stopper.Stop()
 
 	key := roachpb.Key(unquoteArg(args[0], false))
-	r, err := kvDB.Get(key)
+	r, err := kvDB.Get(context.Background(), key)
 	if err != nil {
 		panicf("get failed: %s", err)
 	}
@@ -159,9 +159,9 @@ func runCPut(cmd *cobra.Command, args []string) {
 	value := unquoteArg(args[1], false)
 	var err error
 	if len(args) == 3 {
-		err = kvDB.CPut(key, value, unquoteArg(args[2], false))
+		err = kvDB.CPut(context.Background(), key, value, unquoteArg(args[2], false))
 	} else {
-		err = kvDB.CPut(key, value, nil)
+		err = kvDB.CPut(context.Background(), key, value, nil)
 	}
 
 	if err != nil {
@@ -203,7 +203,7 @@ func runInc(cmd *cobra.Command, args []string) {
 	}
 
 	key := roachpb.Key(unquoteArg(args[0], true /* disallow system keys */))
-	if r, err := kvDB.Inc(key, int64(amount)); err != nil {
+	if r, err := kvDB.Inc(context.TODO(), key, int64(amount)); err != nil {
 		panicf("increment failed: %s", err)
 	} else {
 		fmt.Printf("%d\n", r.ValueInt())
@@ -266,6 +266,7 @@ func runDelRange(cmd *cobra.Command, args []string) {
 	defer stopper.Stop()
 
 	if err := kvDB.DelRange(
+		context.TODO(),
 		unquoteArg(args[0], true /* disallow system keys */),
 		unquoteArg(args[1], true /* disallow system keys */),
 	); err != nil {
@@ -298,7 +299,7 @@ func runScan(cmd *cobra.Command, args []string) {
 	kvDB, stopper := makeDBClient()
 	defer stopper.Stop()
 
-	rows, err := kvDB.Scan(startKey, endKey, maxResults)
+	rows, err := kvDB.Scan(context.Background(), startKey, endKey, maxResults)
 	if err != nil {
 		panicf("scan failed: %s", err)
 	}
@@ -329,7 +330,7 @@ func runReverseScan(cmd *cobra.Command, args []string) {
 	kvDB, stopper := makeDBClient()
 	defer stopper.Stop()
 
-	rows, err := kvDB.ReverseScan(startKey, endKey, maxResults)
+	rows, err := kvDB.ReverseScan(context.TODO(), startKey, endKey, maxResults)
 	if err != nil {
 		panicf("reverse scan failed: %s", err)
 	}

--- a/cli/range.go
+++ b/cli/range.go
@@ -100,7 +100,7 @@ func runSplitRange(cmd *cobra.Command, args []string) {
 	key := roachpb.Key(args[0])
 	kvDB, stopper := makeDBClient()
 	defer stopper.Stop()
-	if err := kvDB.AdminSplit(key); err != nil {
+	if err := kvDB.AdminSplit(context.Background(), key); err != nil {
 		panicf("split failed: %s\n", err)
 	}
 }

--- a/cli/range.go
+++ b/cli/range.go
@@ -19,6 +19,8 @@ package cli
 import (
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 
@@ -58,7 +60,7 @@ func runLsRanges(cmd *cobra.Command, args []string) {
 
 	kvDB, stopper := makeDBClient()
 	defer stopper.Stop()
-	rows, err := kvDB.Scan(startKey, endKey, maxResults)
+	rows, err := kvDB.Scan(context.Background(), startKey, endKey, maxResults)
 	if err != nil {
 		panicf("scan failed: %s\n", err)
 	}
@@ -98,7 +100,7 @@ func runSplitRange(cmd *cobra.Command, args []string) {
 	key := roachpb.Key(args[0])
 	kvDB, stopper := makeDBClient()
 	defer stopper.Stop()
-	if err := kvDB.AdminSplit(key); err != nil {
+	if err := kvDB.AdminSplit(context.Background(), key); err != nil {
 		panicf("split failed: %s\n", err)
 	}
 }

--- a/cli/range.go
+++ b/cli/range.go
@@ -19,6 +19,8 @@ package cli
 import (
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 
@@ -58,7 +60,7 @@ func runLsRanges(cmd *cobra.Command, args []string) {
 
 	kvDB, stopper := makeDBClient()
 	defer stopper.Stop()
-	rows, err := kvDB.Scan(startKey, endKey, maxResults)
+	rows, err := kvDB.Scan(context.Background(), startKey, endKey, maxResults)
 	if err != nil {
 		panicf("scan failed: %s\n", err)
 	}

--- a/cmd/zerosum/cluster.go
+++ b/cmd/zerosum/cluster.go
@@ -181,7 +181,7 @@ func (c *cluster) waitForFullReplication() {
 
 func (c *cluster) isReplicated() (bool, string) {
 	db := c.clients[0]
-	rows, err := db.Scan(keys.Meta2Prefix, keys.Meta2Prefix.PrefixEnd(), 100000)
+	rows, err := db.Scan(context.Background(), keys.Meta2Prefix, keys.Meta2Prefix.PrefixEnd(), 100000)
 	if err != nil {
 		log.Fatalf(context.Background(), "scan failed: %s\n", err)
 	}
@@ -211,7 +211,7 @@ func (c *cluster) isReplicated() (bool, string) {
 }
 
 func (c *cluster) split(nodeIdx int, splitKey roachpb.Key) error {
-	return c.clients[nodeIdx].AdminSplit(splitKey)
+	return c.clients[nodeIdx].AdminSplit(context.Background(), splitKey)
 }
 
 func (c *cluster) transferLease(nodeIdx int, r *rand.Rand, key roachpb.Key) (bool, error) {
@@ -230,7 +230,7 @@ func (c *cluster) transferLease(nodeIdx int, r *rand.Rand, key roachpb.Key) (boo
 			break
 		}
 	}
-	if err := c.clients[nodeIdx].AdminTransferLease(key, target); err != nil {
+	if err := c.clients[nodeIdx].AdminTransferLease(context.Background(), key, target); err != nil {
 		return false, errors.Errorf("%s: transfer lease: %s", key, err)
 	}
 	return true, nil

--- a/cmd/zerosum/cluster.go
+++ b/cmd/zerosum/cluster.go
@@ -211,7 +211,7 @@ func (c *cluster) isReplicated() (bool, string) {
 }
 
 func (c *cluster) split(nodeIdx int, splitKey roachpb.Key) error {
-	return c.clients[nodeIdx].AdminSplit(splitKey)
+	return c.clients[nodeIdx].AdminSplit(context.Background(), splitKey)
 }
 
 func (c *cluster) transferLease(nodeIdx int, r *rand.Rand, key roachpb.Key) (bool, error) {
@@ -230,7 +230,7 @@ func (c *cluster) transferLease(nodeIdx int, r *rand.Rand, key roachpb.Key) (boo
 			break
 		}
 	}
-	if err := c.clients[nodeIdx].AdminTransferLease(key, target); err != nil {
+	if err := c.clients[nodeIdx].AdminTransferLease(context.Background(), key, target); err != nil {
 		return false, errors.Errorf("%s: transfer lease: %s", key, err)
 	}
 	return true, nil

--- a/cmd/zerosum/cluster.go
+++ b/cmd/zerosum/cluster.go
@@ -181,7 +181,7 @@ func (c *cluster) waitForFullReplication() {
 
 func (c *cluster) isReplicated() (bool, string) {
 	db := c.clients[0]
-	rows, err := db.Scan(keys.Meta2Prefix, keys.Meta2Prefix.PrefixEnd(), 100000)
+	rows, err := db.Scan(context.Background(), keys.Meta2Prefix, keys.Meta2Prefix.PrefixEnd(), 100000)
 	if err != nil {
 		log.Fatalf(context.Background(), "scan failed: %s\n", err)
 	}

--- a/cmd/zerosum/main.go
+++ b/cmd/zerosum/main.go
@@ -356,7 +356,7 @@ func (z *zeroSum) verify(d time.Duration) {
 func (z *zeroSum) rangeInfo() (int, []int) {
 	replicas := make([]int, len(z.nodes))
 	client := z.clients[z.randNode(rand.Intn)]
-	rows, err := client.Scan(keys.Meta2Prefix, keys.Meta2Prefix.PrefixEnd(), 0)
+	rows, err := client.Scan(context.Background(), keys.Meta2Prefix, keys.Meta2Prefix.PrefixEnd(), 0)
 	if err != nil {
 		z.maybeLogError(err)
 		return -1, replicas

--- a/cmd/zerosum/main.go
+++ b/cmd/zerosum/main.go
@@ -321,7 +321,7 @@ func (z *zeroSum) check(d time.Duration) {
 		time.Sleep(d)
 
 		client := z.clients[z.randNode(rand.Intn)]
-		if err := client.CheckConsistency(keys.LocalMax, keys.MaxKey, false); err != nil {
+		if err := client.CheckConsistency(context.Background(), keys.LocalMax, keys.MaxKey, false); err != nil {
 			z.maybeLogError(err)
 		}
 	}
@@ -356,7 +356,7 @@ func (z *zeroSum) verify(d time.Duration) {
 func (z *zeroSum) rangeInfo() (int, []int) {
 	replicas := make([]int, len(z.nodes))
 	client := z.clients[z.randNode(rand.Intn)]
-	rows, err := client.Scan(keys.Meta2Prefix, keys.Meta2Prefix.PrefixEnd(), 0)
+	rows, err := client.Scan(context.Background(), keys.Meta2Prefix, keys.Meta2Prefix.PrefixEnd(), 0)
 	if err != nil {
 		z.maybeLogError(err)
 		return -1, replicas

--- a/cmd/zerosum/main.go
+++ b/cmd/zerosum/main.go
@@ -322,7 +322,7 @@ func (z *zeroSum) check(d time.Duration) {
 		time.Sleep(d)
 
 		client := z.clients[z.randNode(rand.Intn)]
-		if err := client.CheckConsistency(keys.LocalMax, keys.MaxKey, false); err != nil {
+		if err := client.CheckConsistency(context.Background(), keys.LocalMax, keys.MaxKey, false); err != nil {
 			z.maybeLogError(err)
 		}
 	}
@@ -357,7 +357,7 @@ func (z *zeroSum) verify(d time.Duration) {
 func (z *zeroSum) rangeInfo() (int, []int) {
 	replicas := make([]int, len(z.nodes))
 	client := z.clients[z.randNode(rand.Intn)]
-	rows, err := client.Scan(keys.Meta2Prefix, keys.Meta2Prefix.PrefixEnd(), 0)
+	rows, err := client.Scan(context.Background(), keys.Meta2Prefix, keys.Meta2Prefix.PrefixEnd(), 0)
 	if err != nil {
 		z.maybeLogError(err)
 		return -1, replicas

--- a/cmd/zerosum/main.go
+++ b/cmd/zerosum/main.go
@@ -321,7 +321,7 @@ func (z *zeroSum) check(d time.Duration) {
 		time.Sleep(d)
 
 		client := z.clients[z.randNode(rand.Intn)]
-		if err := client.CheckConsistency(keys.LocalMax, keys.MaxKey, false); err != nil {
+		if err := client.CheckConsistency(context.Background(), keys.LocalMax, keys.MaxKey, false); err != nil {
 			z.maybeLogError(err)
 		}
 	}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -250,7 +250,7 @@ func TestClientRetryNonTxn(t *testing.T) {
 					if _, ok := test.args.(*roachpb.GetRequest); ok {
 						_, err = db.Get(context.TODO(), key)
 					} else {
-						err = db.Put(key, "value")
+						err = db.Put(context.TODO(), key, "value")
 					}
 					doneCall <- errors.Wrapf(
 						err, "%d: expected success on non-txn call to %s",
@@ -385,7 +385,7 @@ func TestClientGetAndPutProto(t *testing.T) {
 	}
 
 	key := roachpb.Key(testUser + "/zone-config")
-	if err := db.Put(key, &zoneConfig); err != nil {
+	if err := db.Put(context.TODO(), key, &zoneConfig); err != nil {
 		t.Fatalf("unable to put proto: %s", err)
 	}
 
@@ -407,7 +407,7 @@ func TestClientGetAndPut(t *testing.T) {
 	db := createTestClient(t, s.Stopper(), s.ServingAddr())
 
 	value := []byte("value")
-	if err := db.Put(testUser+"/key", value); err != nil {
+	if err := db.Put(context.TODO(), testUser+"/key", value); err != nil {
 		t.Fatalf("unable to put value: %s", err)
 	}
 	gr, err := db.Get(context.TODO(), testUser+"/key")
@@ -429,7 +429,7 @@ func TestClientPutInline(t *testing.T) {
 	db := createTestClient(t, s.Stopper(), s.ServingAddr())
 
 	value := []byte("value")
-	if err := db.PutInline(testUser+"/key", value); err != nil {
+	if err := db.PutInline(context.TODO(), testUser+"/key", value); err != nil {
 		t.Fatalf("unable to put value: %s", err)
 	}
 	gr, err := db.Get(context.TODO(), testUser+"/key")
@@ -455,7 +455,7 @@ func TestClientEmptyValues(t *testing.T) {
 	defer s.Stopper().Stop()
 	db := createTestClient(t, s.Stopper(), s.ServingAddr())
 
-	if err := db.Put(testUser+"/a", []byte{}); err != nil {
+	if err := db.Put(context.TODO(), testUser+"/a", []byte{}); err != nil {
 		t.Error(err)
 	}
 	if gr, err := db.Get(context.TODO(), testUser+"/a"); err != nil {
@@ -610,7 +610,7 @@ func TestClientBatch(t *testing.T) {
 	// Induce a non-transactional failure.
 	{
 		key := roachpb.Key("conditionalPut")
-		if err := db.Put(key, "hello"); err != nil {
+		if err := db.Put(context.TODO(), key, "hello"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -635,7 +635,7 @@ func TestClientBatch(t *testing.T) {
 	// Induce a transactional failure.
 	{
 		key := roachpb.Key("conditionalPut")
-		if err := db.Put(key, "hello"); err != nil {
+		if err := db.Put(context.TODO(), key, "hello"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -787,7 +787,7 @@ func TestClientPermissions(t *testing.T) {
 	value := []byte("value")
 	const matchErr = "is not allowed"
 	for tcNum, tc := range testCases {
-		err := tc.client.Put(tc.path, value)
+		err := tc.client.Put(context.TODO(), tc.path, value)
 		if (err == nil) != tc.allowed || (!tc.allowed && !testutils.IsError(err, matchErr)) {
 			t.Errorf("#%d: expected allowed=%t, got err=%v", tcNum, tc.allowed, err)
 		}
@@ -861,7 +861,7 @@ func TestReadOnlyTxnObeysDeadline(t *testing.T) {
 	defer s.Stopper().Stop()
 	db := createTestClient(t, s.Stopper(), s.ServingAddr())
 
-	if err := db.Put("k", "v"); err != nil {
+	if err := db.Put(context.TODO(), "k", "v"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -743,7 +743,7 @@ func TestConcurrentIncrements(t *testing.T) {
 	// Convenience loop: Crank up this number for testing this
 	// more often. It'll increase test duration though.
 	for k := 0; k < 5; k++ {
-		if err := db.DelRange(testUser+"/value-0", testUser+"/value-1x"); err != nil {
+		if err := db.DelRange(context.TODO(), testUser+"/value-0", testUser+"/value-1x"); err != nil {
 			t.Fatalf("%d: unable to clean up: %s", k, err)
 		}
 		concurrentIncrements(db, t)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -464,7 +464,7 @@ func TestClientEmptyValues(t *testing.T) {
 		t.Errorf("expected non-nil empty byte slice; got %q", bytes)
 	}
 
-	if _, err := db.Inc(testUser+"/b", 0); err != nil {
+	if _, err := db.Inc(context.TODO(), testUser+"/b", 0); err != nil {
 		t.Error(err)
 	}
 	if gr, err := db.Get(context.TODO(), testUser+"/b"); err != nil {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -248,7 +248,7 @@ func TestClientRetryNonTxn(t *testing.T) {
 				go func() {
 					var err error
 					if _, ok := test.args.(*roachpb.GetRequest); ok {
-						_, err = db.Get(key)
+						_, err = db.Get(context.TODO(), key)
 					} else {
 						err = db.Put(key, "value")
 					}
@@ -285,7 +285,7 @@ func TestClientRetryNonTxn(t *testing.T) {
 		}
 
 		// Get the current value to verify whether the txn happened first.
-		gr, err := db.Get(key)
+		gr, err := db.Get(context.TODO(), key)
 		if err != nil {
 			t.Fatalf("%d: expected success getting %q: %s", i, key, err)
 		}
@@ -330,7 +330,7 @@ func TestClientRunTransaction(t *testing.T) {
 				return err
 			}
 			// Attempt to read outside of txn.
-			if gr, err := db.Get(key); err != nil {
+			if gr, err := db.Get(context.TODO(), key); err != nil {
 				return err
 			} else if gr.Value != nil {
 				return errors.Errorf("expected nil value; got %+v", gr.Value)
@@ -354,7 +354,7 @@ func TestClientRunTransaction(t *testing.T) {
 		}
 
 		// Verify the value is now visible on commit == true, and not visible otherwise.
-		gr, err := db.Get(key)
+		gr, err := db.Get(context.TODO(), key)
 		if commit {
 			if err != nil || gr.Value == nil || !bytes.Equal(gr.ValueBytes(), value) {
 				t.Errorf("expected success reading value: %+v, %s", gr.Value, err)
@@ -390,7 +390,7 @@ func TestClientGetAndPutProto(t *testing.T) {
 	}
 
 	var readZoneConfig config.ZoneConfig
-	if err := db.GetProto(key, &readZoneConfig); err != nil {
+	if err := db.GetProto(context.TODO(), key, &readZoneConfig); err != nil {
 		t.Fatalf("unable to get proto: %s", err)
 	}
 	if !proto.Equal(&zoneConfig, &readZoneConfig) {
@@ -410,7 +410,7 @@ func TestClientGetAndPut(t *testing.T) {
 	if err := db.Put(testUser+"/key", value); err != nil {
 		t.Fatalf("unable to put value: %s", err)
 	}
-	gr, err := db.Get(testUser + "/key")
+	gr, err := db.Get(context.TODO(), testUser+"/key")
 	if err != nil {
 		t.Fatalf("unable to get value: %s", err)
 	}
@@ -432,7 +432,7 @@ func TestClientPutInline(t *testing.T) {
 	if err := db.PutInline(testUser+"/key", value); err != nil {
 		t.Fatalf("unable to put value: %s", err)
 	}
-	gr, err := db.Get(testUser + "/key")
+	gr, err := db.Get(context.TODO(), testUser+"/key")
 	if err != nil {
 		t.Fatalf("unable to get value: %s", err)
 	}
@@ -458,7 +458,7 @@ func TestClientEmptyValues(t *testing.T) {
 	if err := db.Put(testUser+"/a", []byte{}); err != nil {
 		t.Error(err)
 	}
-	if gr, err := db.Get(testUser + "/a"); err != nil {
+	if gr, err := db.Get(context.TODO(), testUser+"/a"); err != nil {
 		t.Error(err)
 	} else if bytes := gr.ValueBytes(); bytes == nil || len(bytes) != 0 {
 		t.Errorf("expected non-nil empty byte slice; got %q", bytes)
@@ -467,7 +467,7 @@ func TestClientEmptyValues(t *testing.T) {
 	if _, err := db.Inc(testUser+"/b", 0); err != nil {
 		t.Error(err)
 	}
-	if gr, err := db.Get(testUser + "/b"); err != nil {
+	if gr, err := db.Get(context.TODO(), testUser+"/b"); err != nil {
 		t.Error(err)
 	} else if gr.Value == nil {
 		t.Errorf("expected non-nil integer")
@@ -714,7 +714,7 @@ func concurrentIncrements(db *client.DB, t *testing.T) {
 	results := []int64(nil)
 	for i := 0; i < 2; i++ {
 		readKey := []byte(fmt.Sprintf(testUser+"/value-%d", i))
-		gr, err := db.Get(readKey)
+		gr, err := db.Get(context.TODO(), readKey)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -791,7 +791,7 @@ func TestClientPermissions(t *testing.T) {
 		if (err == nil) != tc.allowed || (!tc.allowed && !testutils.IsError(err, matchErr)) {
 			t.Errorf("#%d: expected allowed=%t, got err=%v", tcNum, tc.allowed, err)
 		}
-		_, err = tc.client.Get(tc.path)
+		_, err = tc.client.Get(context.TODO(), tc.path)
 		if (err == nil) != tc.allowed || (!tc.allowed && !testutils.IsError(err, matchErr)) {
 			t.Errorf("#%d: expected allowed=%t, got err=%v", tcNum, tc.allowed, err)
 		}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -248,9 +248,9 @@ func TestClientRetryNonTxn(t *testing.T) {
 				go func() {
 					var err error
 					if _, ok := test.args.(*roachpb.GetRequest); ok {
-						_, err = db.Get(key)
+						_, err = db.Get(context.TODO(), key)
 					} else {
-						err = db.Put(key, "value")
+						err = db.Put(context.TODO(), key, "value")
 					}
 					doneCall <- errors.Wrapf(
 						err, "%d: expected success on non-txn call to %s",
@@ -285,7 +285,7 @@ func TestClientRetryNonTxn(t *testing.T) {
 		}
 
 		// Get the current value to verify whether the txn happened first.
-		gr, err := db.Get(key)
+		gr, err := db.Get(context.TODO(), key)
 		if err != nil {
 			t.Fatalf("%d: expected success getting %q: %s", i, key, err)
 		}
@@ -330,7 +330,7 @@ func TestClientRunTransaction(t *testing.T) {
 				return err
 			}
 			// Attempt to read outside of txn.
-			if gr, err := db.Get(key); err != nil {
+			if gr, err := db.Get(context.TODO(), key); err != nil {
 				return err
 			} else if gr.Value != nil {
 				return errors.Errorf("expected nil value; got %+v", gr.Value)
@@ -354,7 +354,7 @@ func TestClientRunTransaction(t *testing.T) {
 		}
 
 		// Verify the value is now visible on commit == true, and not visible otherwise.
-		gr, err := db.Get(key)
+		gr, err := db.Get(context.TODO(), key)
 		if commit {
 			if err != nil || gr.Value == nil || !bytes.Equal(gr.ValueBytes(), value) {
 				t.Errorf("expected success reading value: %+v, %s", gr.Value, err)
@@ -383,12 +383,12 @@ func TestClientGetAndPutProto(t *testing.T) {
 	}
 
 	key := roachpb.Key(testUser + "/zone-config")
-	if err := db.Put(key, &zoneConfig); err != nil {
+	if err := db.Put(context.TODO(), key, &zoneConfig); err != nil {
 		t.Fatalf("unable to put proto: %s", err)
 	}
 
 	var readZoneConfig config.ZoneConfig
-	if err := db.GetProto(key, &readZoneConfig); err != nil {
+	if err := db.GetProto(context.TODO(), key, &readZoneConfig); err != nil {
 		t.Fatalf("unable to get proto: %s", err)
 	}
 	if !proto.Equal(&zoneConfig, &readZoneConfig) {
@@ -405,10 +405,10 @@ func TestClientGetAndPut(t *testing.T) {
 	db := createTestClient(t, s.Stopper(), s.ServingAddr())
 
 	value := []byte("value")
-	if err := db.Put(testUser+"/key", value); err != nil {
+	if err := db.Put(context.TODO(), testUser+"/key", value); err != nil {
 		t.Fatalf("unable to put value: %s", err)
 	}
-	gr, err := db.Get(testUser + "/key")
+	gr, err := db.Get(context.TODO(), testUser+"/key")
 	if err != nil {
 		t.Fatalf("unable to get value: %s", err)
 	}
@@ -427,10 +427,10 @@ func TestClientPutInline(t *testing.T) {
 	db := createTestClient(t, s.Stopper(), s.ServingAddr())
 
 	value := []byte("value")
-	if err := db.PutInline(testUser+"/key", value); err != nil {
+	if err := db.PutInline(context.TODO(), testUser+"/key", value); err != nil {
 		t.Fatalf("unable to put value: %s", err)
 	}
-	gr, err := db.Get(testUser + "/key")
+	gr, err := db.Get(context.TODO(), testUser+"/key")
 	if err != nil {
 		t.Fatalf("unable to get value: %s", err)
 	}
@@ -453,19 +453,19 @@ func TestClientEmptyValues(t *testing.T) {
 	defer s.Stopper().Stop()
 	db := createTestClient(t, s.Stopper(), s.ServingAddr())
 
-	if err := db.Put(testUser+"/a", []byte{}); err != nil {
+	if err := db.Put(context.TODO(), testUser+"/a", []byte{}); err != nil {
 		t.Error(err)
 	}
-	if gr, err := db.Get(testUser + "/a"); err != nil {
+	if gr, err := db.Get(context.TODO(), testUser+"/a"); err != nil {
 		t.Error(err)
 	} else if bytes := gr.ValueBytes(); bytes == nil || len(bytes) != 0 {
 		t.Errorf("expected non-nil empty byte slice; got %q", bytes)
 	}
 
-	if _, err := db.Inc(testUser+"/b", 0); err != nil {
+	if _, err := db.Inc(context.TODO(), testUser+"/b", 0); err != nil {
 		t.Error(err)
 	}
-	if gr, err := db.Get(testUser + "/b"); err != nil {
+	if gr, err := db.Get(context.TODO(), testUser+"/b"); err != nil {
 		t.Error(err)
 	} else if gr.Value == nil {
 		t.Errorf("expected non-nil integer")
@@ -608,7 +608,7 @@ func TestClientBatch(t *testing.T) {
 	// Induce a non-transactional failure.
 	{
 		key := roachpb.Key("conditionalPut")
-		if err := db.Put(key, "hello"); err != nil {
+		if err := db.Put(context.TODO(), key, "hello"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -633,7 +633,7 @@ func TestClientBatch(t *testing.T) {
 	// Induce a transactional failure.
 	{
 		key := roachpb.Key("conditionalPut")
-		if err := db.Put(key, "hello"); err != nil {
+		if err := db.Put(context.TODO(), key, "hello"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -712,7 +712,7 @@ func concurrentIncrements(db *client.DB, t *testing.T) {
 	results := []int64(nil)
 	for i := 0; i < 2; i++ {
 		readKey := []byte(fmt.Sprintf(testUser+"/value-%d", i))
-		gr, err := db.Get(readKey)
+		gr, err := db.Get(context.TODO(), readKey)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -741,7 +741,7 @@ func TestConcurrentIncrements(t *testing.T) {
 	// Convenience loop: Crank up this number for testing this
 	// more often. It'll increase test duration though.
 	for k := 0; k < 5; k++ {
-		if err := db.DelRange(testUser+"/value-0", testUser+"/value-1x"); err != nil {
+		if err := db.DelRange(context.TODO(), testUser+"/value-0", testUser+"/value-1x"); err != nil {
 			t.Fatalf("%d: unable to clean up: %s", k, err)
 		}
 		concurrentIncrements(db, t)
@@ -785,11 +785,11 @@ func TestClientPermissions(t *testing.T) {
 	value := []byte("value")
 	const matchErr = "is not allowed"
 	for tcNum, tc := range testCases {
-		err := tc.client.Put(tc.path, value)
+		err := tc.client.Put(context.TODO(), tc.path, value)
 		if (err == nil) != tc.allowed || (!tc.allowed && !testutils.IsError(err, matchErr)) {
 			t.Errorf("#%d: expected allowed=%t, got err=%v", tcNum, tc.allowed, err)
 		}
-		_, err = tc.client.Get(tc.path)
+		_, err = tc.client.Get(context.TODO(), tc.path)
 		if (err == nil) != tc.allowed || (!tc.allowed && !testutils.IsError(err, matchErr)) {
 			t.Errorf("#%d: expected allowed=%t, got err=%v", tcNum, tc.allowed, err)
 		}
@@ -859,7 +859,7 @@ func TestReadOnlyTxnObeysDeadline(t *testing.T) {
 	defer s.Stopper().Stop()
 	db := createTestClient(t, s.Stopper(), s.ServingAddr())
 
-	if err := db.Put("k", "v"); err != nil {
+	if err := db.Put(context.TODO(), "k", "v"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/client/db.go
+++ b/internal/client/db.go
@@ -256,10 +256,10 @@ func (db *DB) PutInline(ctx context.Context, key, value interface{}) error {
 //
 // key can be either a byte slice or a string. value can be any key type, a
 // proto.Message or any Go primitive type (bool, int, etc).
-func (db *DB) CPut(key, value, expValue interface{}) error {
+func (db *DB) CPut(ctx context.Context, key, value, expValue interface{}) error {
 	b := &Batch{}
 	b.CPut(key, value, expValue)
-	return getOneErr(db.Run(context.TODO(), b), b)
+	return getOneErr(db.Run(ctx, b), b)
 }
 
 // InitPut sets the first value for a key to value. An error is reported if a
@@ -268,10 +268,10 @@ func (db *DB) CPut(key, value, expValue interface{}) error {
 // key can be either a byte slice or a string. value can be any key type, a
 // proto.Message or any Go primitive type (bool, int, etc). It is illegal to
 // set value to nil.
-func (db *DB) InitPut(key, value interface{}) error {
+func (db *DB) InitPut(ctx context.Context, key, value interface{}) error {
 	b := &Batch{}
 	b.InitPut(key, value)
-	return getOneErr(db.Run(context.TODO(), b), b)
+	return getOneErr(db.Run(ctx, b), b)
 }
 
 // Inc increments the integer value at key. If the key does not exist it will

--- a/internal/client/db.go
+++ b/internal/client/db.go
@@ -208,18 +208,18 @@ func NewDBWithContext(sender Sender, ctx DBContext) *DB {
 //   // string(r.Key) == "a"
 //
 // key can be either a byte slice or a string.
-func (db *DB) Get(key interface{}) (KeyValue, error) {
+func (db *DB) Get(ctx context.Context, key interface{}) (KeyValue, error) {
 	b := &Batch{}
 	b.Get(key)
-	return getOneRow(db.Run(context.TODO(), b), b)
+	return getOneRow(db.Run(ctx, b), b)
 }
 
 // GetProto retrieves the value for a key and decodes the result as a proto
 // message.
 //
 // key can be either a byte slice or a string.
-func (db *DB) GetProto(key interface{}, msg proto.Message) error {
-	r, err := db.Get(key)
+func (db *DB) GetProto(ctx context.Context, key interface{}, msg proto.Message) error {
+	r, err := db.Get(ctx, key)
 	if err != nil {
 		return err
 	}

--- a/internal/client/db.go
+++ b/internal/client/db.go
@@ -230,10 +230,10 @@ func (db *DB) GetProto(ctx context.Context, key interface{}, msg proto.Message) 
 //
 // key can be either a byte slice or a string. value can be any key type, a
 // proto.Message or any Go primitive type (bool, int, etc).
-func (db *DB) Put(key, value interface{}) error {
+func (db *DB) Put(ctx context.Context, key, value interface{}) error {
 	b := &Batch{}
 	b.Put(key, value)
-	return getOneErr(db.Run(context.TODO(), b), b)
+	return getOneErr(db.Run(ctx, b), b)
 }
 
 // PutInline sets the value for a key, but does not maintain
@@ -243,10 +243,10 @@ func (db *DB) Put(key, value interface{}) error {
 //
 // key can be either a byte slice or a string. value can be any key type, a
 // proto.Message or any Go primitive type (bool, int, etc).
-func (db *DB) PutInline(key, value interface{}) error {
+func (db *DB) PutInline(ctx context.Context, key, value interface{}) error {
 	b := &Batch{}
 	b.PutInline(key, value)
-	return getOneErr(db.Run(context.TODO(), b), b)
+	return getOneErr(db.Run(ctx, b), b)
 }
 
 // CPut conditionally sets the value for a key if the existing value is equal

--- a/internal/client/db.go
+++ b/internal/client/db.go
@@ -286,6 +286,7 @@ func (db *DB) Inc(ctx context.Context, key interface{}, value int64) (KeyValue, 
 }
 
 func (db *DB) scan(
+	ctx context.Context,
 	begin, end interface{},
 	maxRows int64,
 	isReverse bool,
@@ -301,7 +302,7 @@ func (db *DB) scan(
 	} else {
 		b.ReverseScan(begin, end)
 	}
-	r, err := getOneResult(db.Run(context.TODO(), b), b)
+	r, err := getOneResult(db.Run(ctx, b), b)
 	return r.Rows, err
 }
 
@@ -311,8 +312,8 @@ func (db *DB) scan(
 // The returned []KeyValue will contain up to maxRows elements.
 //
 // key can be either a byte slice or a string.
-func (db *DB) Scan(begin, end interface{}, maxRows int64) ([]KeyValue, error) {
-	return db.scan(begin, end, maxRows, false, roachpb.CONSISTENT)
+func (db *DB) Scan(ctx context.Context, begin, end interface{}, maxRows int64) ([]KeyValue, error) {
+	return db.scan(ctx, begin, end, maxRows, false, roachpb.CONSISTENT)
 }
 
 // ReverseScan retrieves the rows between begin (inclusive) and end (exclusive)
@@ -321,8 +322,10 @@ func (db *DB) Scan(begin, end interface{}, maxRows int64) ([]KeyValue, error) {
 // The returned []KeyValue will contain up to maxRows elements.
 //
 // key can be either a byte slice or a string.
-func (db *DB) ReverseScan(begin, end interface{}, maxRows int64) ([]KeyValue, error) {
-	return db.scan(begin, end, maxRows, true, roachpb.CONSISTENT)
+func (db *DB) ReverseScan(
+	ctx context.Context, begin, end interface{}, maxRows int64,
+) ([]KeyValue, error) {
+	return db.scan(ctx, begin, end, maxRows, true, roachpb.CONSISTENT)
 }
 
 // Del deletes one or more keys.

--- a/internal/client/db.go
+++ b/internal/client/db.go
@@ -354,19 +354,19 @@ func (db *DB) DelRange(ctx context.Context, begin, end interface{}) error {
 // and the subsequent range will no longer exist.
 //
 // key can be either a byte slice or a string.
-func (db *DB) AdminMerge(key interface{}) error {
+func (db *DB) AdminMerge(ctx context.Context, key interface{}) error {
 	b := &Batch{}
 	b.adminMerge(key)
-	return getOneErr(db.Run(context.TODO(), b), b)
+	return getOneErr(db.Run(ctx, b), b)
 }
 
 // AdminSplit splits the range at splitkey.
 //
 // key can be either a byte slice or a string.
-func (db *DB) AdminSplit(splitKey interface{}) error {
+func (db *DB) AdminSplit(ctx context.Context, splitKey interface{}) error {
 	b := &Batch{}
 	b.adminSplit(splitKey)
-	return getOneErr(db.Run(context.TODO(), b), b)
+	return getOneErr(db.Run(ctx, b), b)
 }
 
 // AdminTransferLease transfers the lease for the range containing key to the
@@ -379,19 +379,19 @@ func (db *DB) AdminSplit(splitKey interface{}) error {
 // applied the new lease, but that's about it. It's not guaranteed that the new
 // lease holder has applied it (so it might not know immediately that it is the
 // new lease holder).
-func (db *DB) AdminTransferLease(key interface{}, target roachpb.StoreID) error {
+func (db *DB) AdminTransferLease(ctx context.Context, key interface{}, target roachpb.StoreID) error {
 	b := &Batch{}
 	b.adminTransferLease(key, target)
-	return getOneErr(db.Run(context.TODO(), b), b)
+	return getOneErr(db.Run(ctx, b), b)
 }
 
 // CheckConsistency runs a consistency check on all the ranges containing
 // the key span. It logs a diff of all the keys that are inconsistent
 // when withDiff is set to true.
-func (db *DB) CheckConsistency(begin, end interface{}, withDiff bool) error {
+func (db *DB) CheckConsistency(ctx context.Context, begin, end interface{}, withDiff bool) error {
 	b := &Batch{}
 	b.CheckConsistency(begin, end, withDiff)
-	return getOneErr(db.Run(context.TODO(), b), b)
+	return getOneErr(db.Run(ctx, b), b)
 }
 
 // sendAndFill is a helper which sends the given batch and fills its results,

--- a/internal/client/db.go
+++ b/internal/client/db.go
@@ -331,10 +331,10 @@ func (db *DB) ReverseScan(
 // Del deletes one or more keys.
 //
 // key can be either a byte slice or a string.
-func (db *DB) Del(keys ...interface{}) error {
+func (db *DB) Del(ctx context.Context, keys ...interface{}) error {
 	b := &Batch{}
 	b.Del(keys...)
-	return getOneErr(db.Run(context.TODO(), b), b)
+	return getOneErr(db.Run(ctx, b), b)
 }
 
 // DelRange deletes the rows between begin (inclusive) and end (exclusive).
@@ -342,10 +342,10 @@ func (db *DB) Del(keys ...interface{}) error {
 // TODO(pmattis): Perhaps the result should return which rows were deleted.
 //
 // key can be either a byte slice or a string.
-func (db *DB) DelRange(begin, end interface{}) error {
+func (db *DB) DelRange(ctx context.Context, begin, end interface{}) error {
 	b := &Batch{}
 	b.DelRange(begin, end, false)
-	return getOneErr(db.Run(context.TODO(), b), b)
+	return getOneErr(db.Run(ctx, b), b)
 }
 
 // AdminMerge merges the range containing key and the subsequent

--- a/internal/client/db.go
+++ b/internal/client/db.go
@@ -279,10 +279,10 @@ func (db *DB) InitPut(ctx context.Context, key, value interface{}) error {
 // key exists but was set using Put or CPut an error will be returned.
 //
 // key can be either a byte slice or a string.
-func (db *DB) Inc(key interface{}, value int64) (KeyValue, error) {
+func (db *DB) Inc(ctx context.Context, key interface{}, value int64) (KeyValue, error) {
 	b := &Batch{}
 	b.Inc(key, value)
-	return getOneRow(db.Run(context.TODO(), b), b)
+	return getOneRow(db.Run(ctx, b), b)
 }
 
 func (db *DB) scan(

--- a/internal/client/db_test.go
+++ b/internal/client/db_test.go
@@ -81,7 +81,7 @@ func TestDB_Get(t *testing.T) {
 	s, db := setup(t)
 	defer s.Stopper().Stop()
 
-	result, err := db.Get("aa")
+	result, err := db.Get(context.TODO(), "aa")
 	if err != nil {
 		panic(err)
 	}
@@ -92,11 +92,12 @@ func TestDB_Put(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t)
 	defer s.Stopper().Stop()
+	ctx := context.TODO()
 
-	if err := db.Put("aa", "1"); err != nil {
+	if err := db.Put(context.TODO(), "aa", "1"); err != nil {
 		panic(err)
 	}
-	result, err := db.Get("aa")
+	result, err := db.Get(ctx, "aa")
 	if err != nil {
 		panic(err)
 	}
@@ -107,41 +108,42 @@ func TestDB_CPut(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t)
 	defer s.Stopper().Stop()
+	ctx := context.TODO()
 
-	if err := db.Put("aa", "1"); err != nil {
+	if err := db.Put(ctx, "aa", "1"); err != nil {
 		panic(err)
 	}
-	if err := db.CPut("aa", "2", "1"); err != nil {
+	if err := db.CPut(ctx, "aa", "2", "1"); err != nil {
 		panic(err)
 	}
-	result, err := db.Get("aa")
+	result, err := db.Get(ctx, "aa")
 	if err != nil {
 		panic(err)
 	}
 	checkResult(t, []byte("2"), result.ValueBytes())
 
-	if err = db.CPut("aa", "3", "1"); err == nil {
+	if err = db.CPut(ctx, "aa", "3", "1"); err == nil {
 		panic("expected error from conditional put")
 	}
-	result, err = db.Get("aa")
+	result, err = db.Get(ctx, "aa")
 	if err != nil {
 		panic(err)
 	}
 	checkResult(t, []byte("2"), result.ValueBytes())
 
-	if err = db.CPut("bb", "4", "1"); err == nil {
+	if err = db.CPut(ctx, "bb", "4", "1"); err == nil {
 		panic("expected error from conditional put")
 	}
-	result, err = db.Get("bb")
+	result, err = db.Get(ctx, "bb")
 	if err != nil {
 		panic(err)
 	}
 	checkResult(t, []byte(""), result.ValueBytes())
 
-	if err = db.CPut("bb", "4", nil); err != nil {
+	if err = db.CPut(ctx, "bb", "4", nil); err != nil {
 		panic(err)
 	}
-	result, err = db.Get("bb")
+	result, err = db.Get(ctx, "bb")
 	if err != nil {
 		panic(err)
 	}
@@ -152,17 +154,18 @@ func TestDB_InitPut(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t)
 	defer s.Stopper().Stop()
+	ctx := context.TODO()
 
-	if err := db.InitPut("aa", "1"); err != nil {
+	if err := db.InitPut(ctx, "aa", "1"); err != nil {
 		panic(err)
 	}
-	if err := db.InitPut("aa", "1"); err != nil {
+	if err := db.InitPut(ctx, "aa", "1"); err != nil {
 		panic(err)
 	}
-	if err := db.InitPut("aa", "2"); err == nil {
+	if err := db.InitPut(ctx, "aa", "2"); err == nil {
 		panic("expected error from init put")
 	}
-	result, err := db.Get("aa")
+	result, err := db.Get(ctx, "aa")
 	if err != nil {
 		panic(err)
 	}
@@ -173,11 +176,12 @@ func TestDB_Inc(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t)
 	defer s.Stopper().Stop()
+	ctx := context.TODO()
 
-	if _, err := db.Inc("aa", 100); err != nil {
+	if _, err := db.Inc(ctx, "aa", 100); err != nil {
 		panic(err)
 	}
-	result, err := db.Get("aa")
+	result, err := db.Get(ctx, "aa")
 	if err != nil {
 		panic(err)
 	}
@@ -215,7 +219,7 @@ func TestDB_Scan(t *testing.T) {
 	if err := db.Run(context.TODO(), b); err != nil {
 		panic(err)
 	}
-	rows, err := db.Scan("a", "b", 100)
+	rows, err := db.Scan(context.TODO(), "a", "b", 100)
 	if err != nil {
 		panic(err)
 	}
@@ -240,7 +244,7 @@ func TestDB_ReverseScan(t *testing.T) {
 	if err := db.Run(context.TODO(), b); err != nil {
 		panic(err)
 	}
-	rows, err := db.ReverseScan("ab", "c", 100)
+	rows, err := db.ReverseScan(context.TODO(), "ab", "c", 100)
 	if err != nil {
 		panic(err)
 	}
@@ -265,10 +269,10 @@ func TestDB_Del(t *testing.T) {
 	if err := db.Run(context.TODO(), b); err != nil {
 		panic(err)
 	}
-	if err := db.Del("ab"); err != nil {
+	if err := db.Del(context.TODO(), "ab"); err != nil {
 		panic(err)
 	}
-	rows, err := db.Scan("a", "b", 100)
+	rows, err := db.Scan(context.TODO(), "a", "b", 100)
 	if err != nil {
 		panic(err)
 	}
@@ -312,11 +316,12 @@ func TestDB_Put_insecure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, db := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
 	defer s.Stopper().Stop()
+	ctx := context.TODO()
 
-	if err := db.Put("aa", "1"); err != nil {
+	if err := db.Put(context.TODO(), "aa", "1"); err != nil {
 		panic(err)
 	}
-	result, err := db.Get("aa")
+	result, err := db.Get(ctx, "aa")
 	if err != nil {
 		panic(err)
 	}

--- a/internal/client/db_test.go
+++ b/internal/client/db_test.go
@@ -219,7 +219,7 @@ func TestDB_Scan(t *testing.T) {
 	if err := db.Run(context.TODO(), b); err != nil {
 		panic(err)
 	}
-	rows, err := db.Scan("a", "b", 100)
+	rows, err := db.Scan(context.TODO(), "a", "b", 100)
 	if err != nil {
 		panic(err)
 	}
@@ -244,7 +244,7 @@ func TestDB_ReverseScan(t *testing.T) {
 	if err := db.Run(context.TODO(), b); err != nil {
 		panic(err)
 	}
-	rows, err := db.ReverseScan("ab", "c", 100)
+	rows, err := db.ReverseScan(context.TODO(), "ab", "c", 100)
 	if err != nil {
 		panic(err)
 	}
@@ -272,7 +272,7 @@ func TestDB_Del(t *testing.T) {
 	if err := db.Del("ab"); err != nil {
 		panic(err)
 	}
-	rows, err := db.Scan("a", "b", 100)
+	rows, err := db.Scan(context.TODO(), "a", "b", 100)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/client/db_test.go
+++ b/internal/client/db_test.go
@@ -94,7 +94,7 @@ func TestDB_Put(t *testing.T) {
 	defer s.Stopper().Stop()
 	ctx := context.TODO()
 
-	if err := db.Put("aa", "1"); err != nil {
+	if err := db.Put(context.TODO(), "aa", "1"); err != nil {
 		panic(err)
 	}
 	result, err := db.Get(ctx, "aa")
@@ -110,7 +110,7 @@ func TestDB_CPut(t *testing.T) {
 	defer s.Stopper().Stop()
 	ctx := context.TODO()
 
-	if err := db.Put("aa", "1"); err != nil {
+	if err := db.Put(context.TODO(), "aa", "1"); err != nil {
 		panic(err)
 	}
 	if err := db.CPut("aa", "2", "1"); err != nil {
@@ -318,7 +318,7 @@ func TestDB_Put_insecure(t *testing.T) {
 	defer s.Stopper().Stop()
 	ctx := context.TODO()
 
-	if err := db.Put("aa", "1"); err != nil {
+	if err := db.Put(context.TODO(), "aa", "1"); err != nil {
 		panic(err)
 	}
 	result, err := db.Get(ctx, "aa")

--- a/internal/client/db_test.go
+++ b/internal/client/db_test.go
@@ -81,7 +81,7 @@ func TestDB_Get(t *testing.T) {
 	s, db := setup(t)
 	defer s.Stopper().Stop()
 
-	result, err := db.Get("aa")
+	result, err := db.Get(context.TODO(), "aa")
 	if err != nil {
 		panic(err)
 	}
@@ -92,11 +92,12 @@ func TestDB_Put(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t)
 	defer s.Stopper().Stop()
+	ctx := context.TODO()
 
 	if err := db.Put("aa", "1"); err != nil {
 		panic(err)
 	}
-	result, err := db.Get("aa")
+	result, err := db.Get(ctx, "aa")
 	if err != nil {
 		panic(err)
 	}
@@ -107,6 +108,7 @@ func TestDB_CPut(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t)
 	defer s.Stopper().Stop()
+	ctx := context.TODO()
 
 	if err := db.Put("aa", "1"); err != nil {
 		panic(err)
@@ -114,7 +116,7 @@ func TestDB_CPut(t *testing.T) {
 	if err := db.CPut("aa", "2", "1"); err != nil {
 		panic(err)
 	}
-	result, err := db.Get("aa")
+	result, err := db.Get(ctx, "aa")
 	if err != nil {
 		panic(err)
 	}
@@ -123,7 +125,7 @@ func TestDB_CPut(t *testing.T) {
 	if err = db.CPut("aa", "3", "1"); err == nil {
 		panic("expected error from conditional put")
 	}
-	result, err = db.Get("aa")
+	result, err = db.Get(ctx, "aa")
 	if err != nil {
 		panic(err)
 	}
@@ -132,7 +134,7 @@ func TestDB_CPut(t *testing.T) {
 	if err = db.CPut("bb", "4", "1"); err == nil {
 		panic("expected error from conditional put")
 	}
-	result, err = db.Get("bb")
+	result, err = db.Get(ctx, "bb")
 	if err != nil {
 		panic(err)
 	}
@@ -141,7 +143,7 @@ func TestDB_CPut(t *testing.T) {
 	if err = db.CPut("bb", "4", nil); err != nil {
 		panic(err)
 	}
-	result, err = db.Get("bb")
+	result, err = db.Get(ctx, "bb")
 	if err != nil {
 		panic(err)
 	}
@@ -152,6 +154,7 @@ func TestDB_InitPut(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t)
 	defer s.Stopper().Stop()
+	ctx := context.TODO()
 
 	if err := db.InitPut("aa", "1"); err != nil {
 		panic(err)
@@ -162,7 +165,7 @@ func TestDB_InitPut(t *testing.T) {
 	if err := db.InitPut("aa", "2"); err == nil {
 		panic("expected error from init put")
 	}
-	result, err := db.Get("aa")
+	result, err := db.Get(ctx, "aa")
 	if err != nil {
 		panic(err)
 	}
@@ -173,11 +176,12 @@ func TestDB_Inc(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t)
 	defer s.Stopper().Stop()
+	ctx := context.TODO()
 
 	if _, err := db.Inc("aa", 100); err != nil {
 		panic(err)
 	}
-	result, err := db.Get("aa")
+	result, err := db.Get(ctx, "aa")
 	if err != nil {
 		panic(err)
 	}
@@ -312,11 +316,12 @@ func TestDB_Put_insecure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, db := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
 	defer s.Stopper().Stop()
+	ctx := context.TODO()
 
 	if err := db.Put("aa", "1"); err != nil {
 		panic(err)
 	}
-	result, err := db.Get("aa")
+	result, err := db.Get(ctx, "aa")
 	if err != nil {
 		panic(err)
 	}

--- a/internal/client/db_test.go
+++ b/internal/client/db_test.go
@@ -110,10 +110,10 @@ func TestDB_CPut(t *testing.T) {
 	defer s.Stopper().Stop()
 	ctx := context.TODO()
 
-	if err := db.Put(context.TODO(), "aa", "1"); err != nil {
+	if err := db.Put(ctx, "aa", "1"); err != nil {
 		panic(err)
 	}
-	if err := db.CPut("aa", "2", "1"); err != nil {
+	if err := db.CPut(ctx, "aa", "2", "1"); err != nil {
 		panic(err)
 	}
 	result, err := db.Get(ctx, "aa")
@@ -122,7 +122,7 @@ func TestDB_CPut(t *testing.T) {
 	}
 	checkResult(t, []byte("2"), result.ValueBytes())
 
-	if err = db.CPut("aa", "3", "1"); err == nil {
+	if err = db.CPut(ctx, "aa", "3", "1"); err == nil {
 		panic("expected error from conditional put")
 	}
 	result, err = db.Get(ctx, "aa")
@@ -131,7 +131,7 @@ func TestDB_CPut(t *testing.T) {
 	}
 	checkResult(t, []byte("2"), result.ValueBytes())
 
-	if err = db.CPut("bb", "4", "1"); err == nil {
+	if err = db.CPut(ctx, "bb", "4", "1"); err == nil {
 		panic("expected error from conditional put")
 	}
 	result, err = db.Get(ctx, "bb")
@@ -140,7 +140,7 @@ func TestDB_CPut(t *testing.T) {
 	}
 	checkResult(t, []byte(""), result.ValueBytes())
 
-	if err = db.CPut("bb", "4", nil); err != nil {
+	if err = db.CPut(ctx, "bb", "4", nil); err != nil {
 		panic(err)
 	}
 	result, err = db.Get(ctx, "bb")
@@ -156,13 +156,13 @@ func TestDB_InitPut(t *testing.T) {
 	defer s.Stopper().Stop()
 	ctx := context.TODO()
 
-	if err := db.InitPut("aa", "1"); err != nil {
+	if err := db.InitPut(ctx, "aa", "1"); err != nil {
 		panic(err)
 	}
-	if err := db.InitPut("aa", "1"); err != nil {
+	if err := db.InitPut(ctx, "aa", "1"); err != nil {
 		panic(err)
 	}
-	if err := db.InitPut("aa", "2"); err == nil {
+	if err := db.InitPut(ctx, "aa", "2"); err == nil {
 		panic("expected error from init put")
 	}
 	result, err := db.Get(ctx, "aa")

--- a/internal/client/db_test.go
+++ b/internal/client/db_test.go
@@ -269,7 +269,7 @@ func TestDB_Del(t *testing.T) {
 	if err := db.Run(context.TODO(), b); err != nil {
 		panic(err)
 	}
-	if err := db.Del("ab"); err != nil {
+	if err := db.Del(context.TODO(), "ab"); err != nil {
 		panic(err)
 	}
 	rows, err := db.Scan(context.TODO(), "a", "b", 100)

--- a/internal/client/db_test.go
+++ b/internal/client/db_test.go
@@ -178,7 +178,7 @@ func TestDB_Inc(t *testing.T) {
 	defer s.Stopper().Stop()
 	ctx := context.TODO()
 
-	if _, err := db.Inc("aa", 100); err != nil {
+	if _, err := db.Inc(ctx, "aa", 100); err != nil {
 		panic(err)
 	}
 	result, err := db.Get(ctx, "aa")

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -93,7 +93,7 @@ func TestKVDBCoverage(t *testing.T) {
 	}
 
 	// Increment.
-	if ir, pErr := db.Inc("i", 10); pErr != nil {
+	if ir, pErr := db.Inc(ctx, "i", 10); pErr != nil {
 		t.Fatal(pErr)
 	} else if ir.ValueInt() != 10 {
 		t.Errorf("expected increment new value of %d; got %d", 10, ir.ValueInt())

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -81,7 +81,7 @@ func TestKVDBCoverage(t *testing.T) {
 	}
 
 	// Conditional put should succeed, changing value1 to value2.
-	if pErr := db.CPut(key, value2, value1); pErr != nil {
+	if pErr := db.CPut(context.TODO(), key, value2, value1); pErr != nil {
 		t.Fatal(pErr)
 	}
 

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -124,7 +124,7 @@ func TestKVDBCoverage(t *testing.T) {
 			t.Fatal(pErr)
 		}
 	}
-	if rows, pErr := db.Scan("a", "d", 0); pErr != nil {
+	if rows, pErr := db.Scan(context.TODO(), "a", "d", 0); pErr != nil {
 		t.Fatal(pErr)
 	} else if len(rows) != len(keyValues) {
 		t.Fatalf("expected %d rows in scan; got %d", len(keyValues), len(rows))
@@ -141,7 +141,7 @@ func TestKVDBCoverage(t *testing.T) {
 	}
 
 	// Test reverse scan.
-	if rows, pErr := db.ReverseScan("a", "d", 0); pErr != nil {
+	if rows, pErr := db.ReverseScan(context.TODO(), "a", "d", 0); pErr != nil {
 		t.Fatal(pErr)
 	} else if len(rows) != len(keyValues) {
 		t.Fatalf("expected %d rows in scan; got %d", len(keyValues), len(rows))

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -60,6 +60,7 @@ func TestKVDBCoverage(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop()
+	ctx := context.TODO()
 
 	db := createTestClient(t, s.Stopper(), s.ServingAddr())
 	key := roachpb.Key("a")
@@ -73,7 +74,7 @@ func TestKVDBCoverage(t *testing.T) {
 	}
 
 	// Verify put.
-	if gr, pErr := db.Get(key); pErr != nil {
+	if gr, pErr := db.Get(ctx, key); pErr != nil {
 		t.Fatal(pErr)
 	} else if !gr.Exists() {
 		t.Error("expected key to exist")
@@ -85,7 +86,7 @@ func TestKVDBCoverage(t *testing.T) {
 	}
 
 	// Verify get by looking up conditional put value.
-	if gr, pErr := db.Get(key); pErr != nil {
+	if gr, pErr := db.Get(ctx, key); pErr != nil {
 		t.Fatal(pErr)
 	} else if !bytes.Equal(gr.ValueBytes(), value2) {
 		t.Errorf("expected get to return %q; got %q", value2, gr.ValueBytes())
@@ -102,7 +103,7 @@ func TestKVDBCoverage(t *testing.T) {
 	if pErr := db.Del(key); pErr != nil {
 		t.Fatal(pErr)
 	}
-	if gr, pErr := db.Get(key); pErr != nil {
+	if gr, pErr := db.Get(ctx, key); pErr != nil {
 		t.Fatal(pErr)
 	} else if gr.Exists() {
 		t.Error("expected key to not exist after delete")
@@ -224,7 +225,7 @@ func TestKVDBTransaction(t *testing.T) {
 		}
 
 		// Attempt to read outside of txn.
-		if gr, err := db.Get(key); err != nil {
+		if gr, err := db.Get(context.TODO(), key); err != nil {
 			t.Fatal(err)
 		} else if gr.Exists() {
 			t.Errorf("expected nil value; got %+v", gr.Value)
@@ -243,7 +244,7 @@ func TestKVDBTransaction(t *testing.T) {
 	}
 
 	// Verify the value is now visible after commit.
-	if gr, err := db.Get(key); err != nil {
+	if gr, err := db.Get(context.TODO(), key); err != nil {
 		t.Errorf("expected success reading value; got %s", err)
 	} else if !gr.Exists() || !bytes.Equal(gr.ValueBytes(), value) {
 		t.Errorf("expected value %q; got %q", value, gr.ValueBytes())

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -69,7 +69,7 @@ func TestKVDBCoverage(t *testing.T) {
 	value3 := []byte("value3")
 
 	// Put first value at key.
-	if pErr := db.Put(key, value1); pErr != nil {
+	if pErr := db.Put(context.TODO(), key, value1); pErr != nil {
 		t.Fatal(pErr)
 	}
 
@@ -120,7 +120,7 @@ func TestKVDBCoverage(t *testing.T) {
 		if pErr != nil {
 			t.Fatal(pErr)
 		}
-		if pErr := db.Put(kv.Key, valueBytes); pErr != nil {
+		if pErr := db.Put(context.TODO(), kv.Key, valueBytes); pErr != nil {
 			t.Fatal(pErr)
 		}
 	}

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -100,7 +100,7 @@ func TestKVDBCoverage(t *testing.T) {
 	}
 
 	// Delete conditional put value.
-	if pErr := db.Del(key); pErr != nil {
+	if pErr := db.Del(ctx, key); pErr != nil {
 		t.Fatal(pErr)
 	}
 	if gr, pErr := db.Get(ctx, key); pErr != nil {
@@ -157,7 +157,7 @@ func TestKVDBCoverage(t *testing.T) {
 		}
 	}
 
-	if pErr := db.DelRange("a", "c"); pErr != nil {
+	if pErr := db.DelRange(context.TODO(), "a", "c"); pErr != nil {
 		t.Fatal(pErr)
 	}
 }

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -217,7 +217,7 @@ func TestMultiRangeBoundedBatchScan(t *testing.T) {
 
 	db := setupMultipleRanges(t, s, "a", "b", "c", "d", "e", "f")
 	for _, key := range []string{"a1", "a2", "a3", "b1", "b2", "c1", "c2", "d1", "f1", "f2", "f3"} {
-		if err := db.Put(key, "value"); err != nil {
+		if err := db.Put(ctx, key, "value"); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -288,7 +288,7 @@ func TestMultiRangeBoundedBatchReverseScan(t *testing.T) {
 
 	db := setupMultipleRanges(t, s, "a", "b", "c", "d", "e", "f")
 	for _, key := range []string{"a1", "a2", "a3", "b1", "b2", "c1", "c2", "d1", "f1", "f2", "f3"} {
-		if err := db.Put(key, "value"); err != nil {
+		if err := db.Put(ctx, key, "value"); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -361,7 +361,7 @@ func TestMultiRangeBoundedBatchScanUnsortedOrder(t *testing.T) {
 
 	db := setupMultipleRanges(t, s, "a", "b", "c", "d", "e", "f")
 	for _, key := range []string{"a1", "a2", "a3", "b1", "b2", "b3", "b4", "b5", "c1", "c2", "d1", "f1", "f2", "f3"} {
-		if err := db.Put(key, "value"); err != nil {
+		if err := db.Put(context.TODO(), key, "value"); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -395,7 +395,7 @@ func TestMultiRangeBoundedBatchScanSortedOverlapping(t *testing.T) {
 
 	db := setupMultipleRanges(t, s, "a", "b", "c", "d", "e", "f")
 	for _, key := range []string{"a1", "a2", "a3", "b1", "b2", "c1", "c2", "d1", "f1", "f2", "f3"} {
-		if err := db.Put(key, "value"); err != nil {
+		if err := db.Put(context.TODO(), key, "value"); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -471,7 +471,7 @@ func TestMultiRangeBoundedBatchDelRange(t *testing.T) {
 	for bound := 1; bound <= 20; bound++ {
 		// Initialize all keys.
 		for _, key := range []string{"a1", "a2", "a3", "b1", "b2", "c1", "c2", "d1", "f1", "f2", "f3", "g1", "g2", "h1"} {
-			if err := db.Put(key, "value"); err != nil {
+			if err := db.Put(context.TODO(), key, "value"); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -522,7 +522,7 @@ func TestMultiRangeBoundedBatchDelRangeBoundary(t *testing.T) {
 	db := setupMultipleRanges(t, s, "a", "b")
 	// Check that a
 	for _, key := range []string{"a1", "a2", "a3", "b1", "b2"} {
-		if err := db.Put(key, "value"); err != nil {
+		if err := db.Put(context.TODO(), key, "value"); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -576,7 +576,7 @@ func TestMultiRangeBoundedBatchDelRangeOverlappingKeys(t *testing.T) {
 
 	for bound := 1; bound <= 20; bound++ {
 		for _, key := range []string{"a1", "a2", "a3", "b1", "b2", "b3", "c1", "c2", "d1", "f1", "f2", "f3"} {
-			if err := db.Put(key, "value"); err != nil {
+			if err := db.Put(context.TODO(), key, "value"); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -663,7 +663,7 @@ func TestMultiRangeScanReverseScanDeleteResolve(t *testing.T) {
 
 	// Write keys before, at, and after the split key.
 	for _, key := range []string{"a", "b", "c"} {
-		if err := db.Put(key, "value"); err != nil {
+		if err := db.Put(context.TODO(), key, "value"); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -793,7 +793,7 @@ func initReverseScanTestEnv(s serverutils.TestServerInterface, t *testing.T) *cl
 	}
 	// Write keys before, at, and after the split key.
 	for _, key := range []string{"a", "b", "c", "d", "e", "f", "g", "h"} {
-		if err := db.Put(key, "value"); err != nil {
+		if err := db.Put(context.TODO(), key, "value"); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -911,7 +911,7 @@ func TestBadRequest(t *testing.T) {
 	db := createTestClient(t, s.Stopper(), s.ServingAddr())
 
 	// Write key "a".
-	if err := db.Put("a", "value"); err != nil {
+	if err := db.Put(context.TODO(), "a", "value"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1001,7 +1001,7 @@ func TestPropagateTxnOnError(t *testing.T) {
 
 	// Set the initial value on the target key "b".
 	origVal := "val"
-	if err := db.Put(targetKey, origVal); err != nil {
+	if err := db.Put(context.TODO(), targetKey, origVal); err != nil {
 		t.Fatal(err)
 	}
 

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -76,7 +76,7 @@ func TestRangeLookupWithOpenTransaction(t *testing.T) {
 	// intent error. If it did, it would go into a deadloop attempting
 	// to push the transaction, which in turn requires another range
 	// lookup, etc, ad nauseam.
-	if _, err := db.Get("a"); err != nil {
+	if _, err := db.Get(context.TODO(), "a"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -92,7 +92,7 @@ func setupMultipleRanges(
 
 	// Split the keyspace at the given keys.
 	for _, key := range splitAt {
-		if err := db.AdminSplit(key); err != nil {
+		if err := db.AdminSplit(context.TODO(), key); err != nil {
 			// Don't leak server goroutines.
 			t.Fatal(err)
 		}
@@ -787,7 +787,7 @@ func initReverseScanTestEnv(s serverutils.TestServerInterface, t *testing.T) *cl
 	// ["", "b"),["b", "e") ,["e", "g") and ["g", "\xff\xff").
 	for _, key := range []string{"b", "e", "g"} {
 		// Split the keyspace at the given key.
-		if err := db.AdminSplit(key); err != nil {
+		if err := db.AdminSplit(context.TODO(), key); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -883,7 +883,7 @@ func TestReverseScanWithSplitAndMerge(t *testing.T) {
 
 	// Case 1: An encounter with a range split.
 	// Split the range ["b", "e") at "c".
-	if err := db.AdminSplit("c"); err != nil {
+	if err := db.AdminSplit(context.TODO(), "c"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -896,7 +896,7 @@ func TestReverseScanWithSplitAndMerge(t *testing.T) {
 
 	// Case 2: encounter with range merge .
 	// Merge the range ["e", "g") and ["g", "\xff\xff") .
-	if err := db.AdminMerge("e"); err != nil {
+	if err := db.AdminMerge(context.TODO(), "e"); err != nil {
 		t.Fatal(err)
 	}
 	if rows, err := db.ReverseScan(context.TODO(), "d", "g", 0); err != nil {

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -668,14 +668,14 @@ func TestMultiRangeScanReverseScanDeleteResolve(t *testing.T) {
 		}
 	}
 	// Scan to retrieve the keys just written.
-	if rows, err := db.Scan("a", "q", 0); err != nil {
+	if rows, err := db.Scan(context.TODO(), "a", "q", 0); err != nil {
 		t.Fatalf("unexpected error on Scan: %s", err)
 	} else if l := len(rows); l != 3 {
 		t.Errorf("expected 3 rows; got %d", l)
 	}
 
 	// Scan in reverse order to retrieve the keys just written.
-	if rows, err := db.ReverseScan("a", "q", 0); err != nil {
+	if rows, err := db.ReverseScan(context.TODO(), "a", "q", 0); err != nil {
 		t.Fatalf("unexpected error on ReverseScan: %s", err)
 	} else if l := len(rows); l != 3 {
 		t.Errorf("expected 3 rows; got %d", l)
@@ -692,14 +692,14 @@ func TestMultiRangeScanReverseScanDeleteResolve(t *testing.T) {
 	}
 
 	// Scan consistently to make sure the intents are gone.
-	if rows, err := db.Scan("a", "q", 0); err != nil {
+	if rows, err := db.Scan(context.TODO(), "a", "q", 0); err != nil {
 		t.Fatalf("unexpected error on Scan: %s", err)
 	} else if l := len(rows); l != 0 {
 		t.Errorf("expected 0 rows; got %d", l)
 	}
 
 	// ReverseScan consistently to make sure the intents are gone.
-	if rows, err := db.ReverseScan("a", "q", 0); err != nil {
+	if rows, err := db.ReverseScan(context.TODO(), "a", "q", 0); err != nil {
 		t.Fatalf("unexpected error on ReverseScan: %s", err)
 	} else if l := len(rows); l != 0 {
 		t.Errorf("expected 0 rows; got %d", l)
@@ -807,28 +807,29 @@ func TestSingleRangeReverseScan(t *testing.T) {
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop()
 	db := initReverseScanTestEnv(s, t)
+	ctx := context.TODO()
 
 	// Case 1: Request.EndKey is in the middle of the range.
-	if rows, err := db.ReverseScan("b", "d", 0); err != nil {
+	if rows, err := db.ReverseScan(ctx, "b", "d", 0); err != nil {
 		t.Fatalf("unexpected error on ReverseScan: %s", err)
 	} else if l := len(rows); l != 2 {
 		t.Errorf("expected 2 rows; got %d", l)
 	}
-	if rows, err := db.ReverseScan("b", "d", 1); err != nil {
+	if rows, err := db.ReverseScan(ctx, "b", "d", 1); err != nil {
 		t.Fatalf("unexpected error on ReverseScan: %s", err)
 	} else if l := len(rows); l != 1 {
 		t.Errorf("expected 1 rows; got %d", l)
 	}
 
 	// Case 2: Request.EndKey is equal to the EndKey of the range.
-	if rows, pErr := db.ReverseScan("e", "g", 0); pErr != nil {
+	if rows, pErr := db.ReverseScan(ctx, "e", "g", 0); pErr != nil {
 		t.Fatalf("unexpected error on ReverseScan: %s", pErr)
 	} else if l := len(rows); l != 2 {
 		t.Errorf("expected 2 rows; got %d", l)
 	}
 	// Case 3: Test roachpb.TableDataMin. Expected to return "g" and "h".
 	wanted := 2
-	if rows, pErr := db.ReverseScan("g", keys.TableDataMin, 0); pErr != nil {
+	if rows, pErr := db.ReverseScan(ctx, "g", keys.TableDataMin, 0); pErr != nil {
 		t.Fatalf("unexpected error on ReverseScan: %s", pErr)
 	} else if l := len(rows); l != wanted {
 		t.Errorf("expected %d rows; got %d", wanted, l)
@@ -837,7 +838,7 @@ func TestSingleRangeReverseScan(t *testing.T) {
 	// This span covers the system DB keys. Note sql.GetInitialSystemValues
 	// returns one key before keys.SystemMax, but our scan is including one key
 	// (\xffa) created for the test.
-	if rows, pErr := db.ReverseScan(keys.SystemMax, "b", 0); pErr != nil {
+	if rows, pErr := db.ReverseScan(ctx, keys.SystemMax, "b", 0); pErr != nil {
 		t.Fatalf("unexpected error on ReverseScan: %s", pErr)
 	} else if l := len(rows); l != 1 {
 		t.Errorf("expected 1 row; got %d", l)
@@ -851,20 +852,21 @@ func TestMultiRangeReverseScan(t *testing.T) {
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop()
 	db := initReverseScanTestEnv(s, t)
+	ctx := context.TODO()
 
 	// Case 1: Request.EndKey is in the middle of the range.
-	if rows, pErr := db.ReverseScan("a", "d", 0); pErr != nil {
+	if rows, pErr := db.ReverseScan(ctx, "a", "d", 0); pErr != nil {
 		t.Fatalf("unexpected error on ReverseScan: %s", pErr)
 	} else if l := len(rows); l != 3 {
 		t.Errorf("expected 3 rows; got %d", l)
 	}
-	if rows, pErr := db.ReverseScan("a", "d", 2); pErr != nil {
+	if rows, pErr := db.ReverseScan(ctx, "a", "d", 2); pErr != nil {
 		t.Fatalf("unexpected error on ReverseScan: %s", pErr)
 	} else if l := len(rows); l != 2 {
 		t.Errorf("expected 2 rows; got %d", l)
 	}
 	// Case 2: Request.EndKey is equal to the EndKey of the range.
-	if rows, pErr := db.ReverseScan("d", "g", 0); pErr != nil {
+	if rows, pErr := db.ReverseScan(ctx, "d", "g", 0); pErr != nil {
 		t.Fatalf("unexpected error on ReverseScan: %s", pErr)
 	} else if l := len(rows); l != 3 {
 		t.Errorf("expected 3 rows; got %d", l)
@@ -886,7 +888,7 @@ func TestReverseScanWithSplitAndMerge(t *testing.T) {
 	}
 
 	// The ReverseScan will run into a stale descriptor.
-	if rows, err := db.ReverseScan("a", "d", 0); err != nil {
+	if rows, err := db.ReverseScan(context.TODO(), "a", "d", 0); err != nil {
 		t.Fatalf("unexpected error on ReverseScan: %s", err)
 	} else if l := len(rows); l != 3 {
 		t.Errorf("expected 3 rows; got %d", l)
@@ -897,7 +899,7 @@ func TestReverseScanWithSplitAndMerge(t *testing.T) {
 	if err := db.AdminMerge("e"); err != nil {
 		t.Fatal(err)
 	}
-	if rows, err := db.ReverseScan("d", "g", 0); err != nil {
+	if rows, err := db.ReverseScan(context.TODO(), "d", "g", 0); err != nil {
 		t.Fatalf("unexpected error on ReverseScan: %s", err)
 	} else if l := len(rows); l != 3 {
 		t.Errorf("expected 3 rows; got %d", l)
@@ -909,17 +911,18 @@ func TestBadRequest(t *testing.T) {
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop()
 	db := createTestClient(t, s.Stopper(), s.ServingAddr())
+	ctx := context.TODO()
 
 	// Write key "a".
-	if err := db.Put(context.TODO(), "a", "value"); err != nil {
+	if err := db.Put(ctx, "a", "value"); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := db.Scan("a", "a", 0); !testutils.IsError(err, "truncation resulted in empty batch") {
+	if _, err := db.Scan(ctx, "a", "a", 0); !testutils.IsError(err, "truncation resulted in empty batch") {
 		t.Fatalf("unexpected error on scan with startkey == endkey: %v", err)
 	}
 
-	if _, err := db.ReverseScan("a", "a", 0); !testutils.IsError(err, "truncation resulted in empty batch") {
+	if _, err := db.ReverseScan(ctx, "a", "a", 0); !testutils.IsError(err, "truncation resulted in empty batch") {
 		t.Fatalf("unexpected error on reverse scan with startkey == endkey: %v", err)
 	}
 

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -926,11 +926,11 @@ func TestBadRequest(t *testing.T) {
 		t.Fatalf("unexpected error on reverse scan with startkey == endkey: %v", err)
 	}
 
-	if err := db.DelRange("x", "a"); !testutils.IsError(err, "truncation resulted in empty batch") {
+	if err := db.DelRange(ctx, "x", "a"); !testutils.IsError(err, "truncation resulted in empty batch") {
 		t.Fatalf("unexpected error on deletion on [x, a): %v", err)
 	}
 
-	if err := db.DelRange("", "z"); !testutils.IsError(err, "must be greater than LocalMax") {
+	if err := db.DelRange(ctx, "", "z"); !testutils.IsError(err, "must be greater than LocalMax") {
 		t.Fatalf("unexpected error on deletion on [KeyMin, z): %v", err)
 	}
 }

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -191,7 +191,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 	// Check that we split 5 times in allotted time.
 	util.SucceedsSoon(t, func() error {
 		// Scan the txn records.
-		rows, err := s.DB.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
+		rows, err := s.DB.Scan(context.TODO(), keys.Meta2Prefix, keys.MetaMax, 0)
 		if err != nil {
 			return errors.Errorf("failed to scan meta2 keys: %s", err)
 		}

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -102,7 +102,7 @@ func TestRangeSplitMeta(t *testing.T) {
 	// Execute the consecutive splits.
 	for _, splitKey := range splitKeys {
 		log.Infof(context.Background(), "starting split at key %q...", splitKey)
-		if err := s.DB.AdminSplit(roachpb.Key(splitKey)); err != nil {
+		if err := s.DB.AdminSplit(context.TODO(), roachpb.Key(splitKey)); err != nil {
 			t.Fatal(err)
 		}
 		log.Infof(context.Background(), "split at key %q complete", splitKey)
@@ -147,7 +147,7 @@ func TestRangeSplitsWithConcurrentTxns(t *testing.T) {
 			<-txnChannel
 		}
 		log.Infof(context.Background(), "starting split at key %q...", splitKey)
-		if pErr := s.DB.AdminSplit(splitKey); pErr != nil {
+		if pErr := s.DB.AdminSplit(context.TODO(), splitKey); pErr != nil {
 			t.Error(pErr)
 		}
 		log.Infof(context.Background(), "split at key %q complete", splitKey)
@@ -227,14 +227,14 @@ func TestRangeSplitsWithSameKeyTwice(t *testing.T) {
 
 	splitKey := roachpb.Key("aa")
 	log.Infof(context.Background(), "starting split at key %q...", splitKey)
-	if err := s.DB.AdminSplit(splitKey); err != nil {
+	if err := s.DB.AdminSplit(context.TODO(), splitKey); err != nil {
 		t.Fatal(err)
 	}
 	log.Infof(context.Background(), "split at key %q first time complete", splitKey)
 	ch := make(chan error)
 	go func() {
 		// should return error other than infinite loop
-		ch <- s.DB.AdminSplit(splitKey)
+		ch <- s.DB.AdminSplit(context.TODO(), splitKey)
 	}()
 
 	if err := <-ch; err == nil {

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -102,7 +102,7 @@ func TestRangeSplitMeta(t *testing.T) {
 	// Execute the consecutive splits.
 	for _, splitKey := range splitKeys {
 		log.Infof(context.Background(), "starting split at key %q...", splitKey)
-		if err := s.DB.AdminSplit(roachpb.Key(splitKey)); err != nil {
+		if err := s.DB.AdminSplit(context.TODO(), roachpb.Key(splitKey)); err != nil {
 			t.Fatal(err)
 		}
 		log.Infof(context.Background(), "split at key %q complete", splitKey)
@@ -147,7 +147,7 @@ func TestRangeSplitsWithConcurrentTxns(t *testing.T) {
 			<-txnChannel
 		}
 		log.Infof(context.Background(), "starting split at key %q...", splitKey)
-		if pErr := s.DB.AdminSplit(splitKey); pErr != nil {
+		if pErr := s.DB.AdminSplit(context.TODO(), splitKey); pErr != nil {
 			t.Error(pErr)
 		}
 		log.Infof(context.Background(), "split at key %q complete", splitKey)
@@ -191,7 +191,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 	// Check that we split 5 times in allotted time.
 	util.SucceedsSoon(t, func() error {
 		// Scan the txn records.
-		rows, err := s.DB.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
+		rows, err := s.DB.Scan(context.TODO(), keys.Meta2Prefix, keys.MetaMax, 0)
 		if err != nil {
 			return errors.Errorf("failed to scan meta2 keys: %s", err)
 		}
@@ -227,14 +227,14 @@ func TestRangeSplitsWithSameKeyTwice(t *testing.T) {
 
 	splitKey := roachpb.Key("aa")
 	log.Infof(context.Background(), "starting split at key %q...", splitKey)
-	if err := s.DB.AdminSplit(splitKey); err != nil {
+	if err := s.DB.AdminSplit(context.TODO(), splitKey); err != nil {
 		t.Fatal(err)
 	}
 	log.Infof(context.Background(), "split at key %q first time complete", splitKey)
 	ch := make(chan error)
 	go func() {
 		// should return error other than infinite loop
-		ch <- s.DB.AdminSplit(splitKey)
+		ch <- s.DB.AdminSplit(context.TODO(), splitKey)
 	}()
 
 	if err := <-ch; err == nil {

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -1341,7 +1341,7 @@ func TestTxnRestartCount(t *testing.T) {
 
 	// Outside of the transaction, read the same key as was read within the transaction. This
 	// means that future attempts to write will increase the timestamp.
-	if _, err := db.Get(key); err != nil {
+	if _, err := db.Get(context.TODO(), key); err != nil {
 		t.Fatal(err)
 	}
 

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -64,7 +64,7 @@ func TestTxnDBBasics(t *testing.T) {
 			}
 
 			// Attempt to read outside of txn.
-			if gr, err := s.DB.Get(key); err != nil {
+			if gr, err := s.DB.Get(context.TODO(), key); err != nil {
 				return err
 			} else if gr.Exists() {
 				return errors.Errorf("expected nil value; got %v", gr.Value)
@@ -90,7 +90,7 @@ func TestTxnDBBasics(t *testing.T) {
 		}
 
 		// Verify the value is now visible on commit == true, and not visible otherwise.
-		gr, err := s.DB.Get(key)
+		gr, err := s.DB.Get(context.TODO(), key)
 		if commit {
 			if err != nil || !gr.Exists() || !bytes.Equal(gr.ValueBytes(), value) {
 				t.Errorf("expected success reading value: %+v, %s", gr.ValueBytes(), err)
@@ -271,7 +271,7 @@ func TestSnapshotIsolationLostUpdate(t *testing.T) {
 	}
 
 	// Verify final value.
-	gr, err := s.DB.Get(key)
+	gr, err := s.DB.Get(context.TODO(), key)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -531,12 +531,12 @@ func TestTxnTimestampRegression(t *testing.T) {
 		}
 
 		// Attempt to read outside of txn (this will push timestamp of transaction).
-		if _, err := s.DB.Get(keyA); err != nil {
+		if _, err := s.DB.Get(context.TODO(), keyA); err != nil {
 			return err
 		}
 
 		// Now, read again outside of txn to warmup timestamp cache with higher timestamp.
-		if _, err := s.DB.Get(keyB); err != nil {
+		if _, err := s.DB.Get(context.TODO(), keyB); err != nil {
 			return err
 		}
 
@@ -756,11 +756,11 @@ func TestTxnRestartedSerializableTimestampRegression(t *testing.T) {
 	// Wait until txnA finishes put(a).
 	<-ch
 	// Attempt to get keyA, which will push txnA.
-	if _, err := s.DB.Get(keyA); err != nil {
+	if _, err := s.DB.Get(context.TODO(), keyA); err != nil {
 		t.Fatal(err)
 	}
 	// Do a read at keyB to cause txnA to forward timestamp.
-	if _, err := s.DB.Get(keyB); err != nil {
+	if _, err := s.DB.Get(context.TODO(), keyB); err != nil {
 		t.Fatal(err)
 	}
 	// Notify txnA to commit.

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -64,7 +64,7 @@ func TestTxnDBBasics(t *testing.T) {
 			}
 
 			// Attempt to read outside of txn.
-			if gr, err := s.DB.Get(key); err != nil {
+			if gr, err := s.DB.Get(context.TODO(), key); err != nil {
 				return err
 			} else if gr.Exists() {
 				return errors.Errorf("expected nil value; got %v", gr.Value)
@@ -90,7 +90,7 @@ func TestTxnDBBasics(t *testing.T) {
 		}
 
 		// Verify the value is now visible on commit == true, and not visible otherwise.
-		gr, err := s.DB.Get(key)
+		gr, err := s.DB.Get(context.TODO(), key)
 		if commit {
 			if err != nil || !gr.Exists() || !bytes.Equal(gr.ValueBytes(), value) {
 				t.Errorf("expected success reading value: %+v, %s", gr.ValueBytes(), err)
@@ -271,7 +271,7 @@ func TestSnapshotIsolationLostUpdate(t *testing.T) {
 	}
 
 	// Verify final value.
-	gr, err := s.DB.Get(key)
+	gr, err := s.DB.Get(context.TODO(), key)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -531,12 +531,12 @@ func TestTxnTimestampRegression(t *testing.T) {
 		}
 
 		// Attempt to read outside of txn (this will push timestamp of transaction).
-		if _, err := s.DB.Get(keyA); err != nil {
+		if _, err := s.DB.Get(context.TODO(), keyA); err != nil {
 			return err
 		}
 
 		// Now, read again outside of txn to warmup timestamp cache with higher timestamp.
-		if _, err := s.DB.Get(keyB); err != nil {
+		if _, err := s.DB.Get(context.TODO(), keyB); err != nil {
 			return err
 		}
 
@@ -676,14 +676,14 @@ func TestTxnRepeatGetWithRangeSplit(t *testing.T) {
 		}
 		s.Manual.Set(time.Second.Nanoseconds())
 		// Split range by keyB.
-		if err := s.DB.AdminSplit(splitKey); err != nil {
+		if err := s.DB.AdminSplit(context.TODO(), splitKey); err != nil {
 			t.Fatal(err)
 		}
 		// Wait till split complete.
 		// Check that we split 1 times in allotted time.
 		util.SucceedsSoon(t, func() error {
 			// Scan the meta records.
-			rows, serr := s.DB.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
+			rows, serr := s.DB.Scan(context.TODO(), keys.Meta2Prefix, keys.MetaMax, 0)
 			if serr != nil {
 				t.Fatalf("failed to scan meta2 keys: %s", serr)
 			}
@@ -756,11 +756,11 @@ func TestTxnRestartedSerializableTimestampRegression(t *testing.T) {
 	// Wait until txnA finishes put(a).
 	<-ch
 	// Attempt to get keyA, which will push txnA.
-	if _, err := s.DB.Get(keyA); err != nil {
+	if _, err := s.DB.Get(context.TODO(), keyA); err != nil {
 		t.Fatal(err)
 	}
 	// Do a read at keyB to cause txnA to forward timestamp.
-	if _, err := s.DB.Get(keyB); err != nil {
+	if _, err := s.DB.Get(context.TODO(), keyB); err != nil {
 		t.Fatal(err)
 	}
 	// Notify txnA to commit.

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -676,7 +676,7 @@ func TestTxnRepeatGetWithRangeSplit(t *testing.T) {
 		}
 		s.Manual.Set(time.Second.Nanoseconds())
 		// Split range by keyB.
-		if err := s.DB.AdminSplit(splitKey); err != nil {
+		if err := s.DB.AdminSplit(context.TODO(), splitKey); err != nil {
 			t.Fatal(err)
 		}
 		// Wait till split complete.

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -683,7 +683,7 @@ func TestTxnRepeatGetWithRangeSplit(t *testing.T) {
 		// Check that we split 1 times in allotted time.
 		util.SucceedsSoon(t, func() error {
 			// Scan the meta records.
-			rows, serr := s.DB.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
+			rows, serr := s.DB.Scan(context.TODO(), keys.Meta2Prefix, keys.MetaMax, 0)
 			if serr != nil {
 				t.Fatalf("failed to scan meta2 keys: %s", serr)
 			}

--- a/server/admin.go
+++ b/server/admin.go
@@ -527,7 +527,7 @@ func (s *adminServer) TableStats(ctx context.Context, req *serverpb.TableStatsRe
 
 	// Get current range descriptors for table. This is done by scanning over
 	// meta2 keys for the range.
-	rangeDescKVs, err := s.server.db.Scan(keys.RangeMetaKey(startKey), keys.RangeMetaKey(endKey), 0)
+	rangeDescKVs, err := s.server.db.Scan(ctx, keys.RangeMetaKey(startKey), keys.RangeMetaKey(endKey), 0)
 	if err != nil {
 		return nil, s.serverError(err)
 	}

--- a/server/admin.go
+++ b/server/admin.go
@@ -487,7 +487,7 @@ func (s *adminServer) TableStats(ctx context.Context, req *serverpb.TableStatsRe
 
 	// Get current range descriptors for table. This is done by scanning over
 	// meta2 keys for the range.
-	rangeDescKVs, err := s.server.db.Scan(keys.RangeMetaKey(startKey), keys.RangeMetaKey(endKey), 0)
+	rangeDescKVs, err := s.server.db.Scan(ctx, keys.RangeMetaKey(startKey), keys.RangeMetaKey(endKey), 0)
 	if err != nil {
 		return nil, s.serverError(err)
 	}

--- a/server/intent_test.go
+++ b/server/intent_test.go
@@ -119,7 +119,7 @@ func TestIntentResolution(t *testing.T) {
 				Knobs: base.TestingKnobs{Store: &storeKnobs}})
 			defer s.Stopper().Stop()
 			// Split the Range. This should not have any asynchronous intents.
-			if err := kvDB.AdminSplit(splitKey); err != nil {
+			if err := kvDB.AdminSplit(context.TODO(), splitKey); err != nil {
 				t.Fatal(err)
 			}
 
@@ -158,7 +158,7 @@ func TestIntentResolution(t *testing.T) {
 			// Use Raft to make it likely that any straddling intent
 			// resolutions have come in. Don't touch existing data; that could
 			// generate unexpected intent resolutions.
-			if _, err := kvDB.Scan("z\x00", "z\x00\x00", 0); err != nil {
+			if _, err := kvDB.Scan(context.TODO(), "z\x00", "z\x00\x00", 0); err != nil {
 				t.Fatal(err)
 			}
 		}()

--- a/server/intent_test.go
+++ b/server/intent_test.go
@@ -158,7 +158,7 @@ func TestIntentResolution(t *testing.T) {
 			// Use Raft to make it likely that any straddling intent
 			// resolutions have come in. Don't touch existing data; that could
 			// generate unexpected intent resolutions.
-			if _, err := kvDB.Scan("z\x00", "z\x00\x00", 0); err != nil {
+			if _, err := kvDB.Scan(context.TODO(), "z\x00", "z\x00\x00", 0); err != nil {
 				t.Fatal(err)
 			}
 		}()

--- a/server/intent_test.go
+++ b/server/intent_test.go
@@ -119,7 +119,7 @@ func TestIntentResolution(t *testing.T) {
 				Knobs: base.TestingKnobs{Store: &storeKnobs}})
 			defer s.Stopper().Stop()
 			// Split the Range. This should not have any asynchronous intents.
-			if err := kvDB.AdminSplit(splitKey); err != nil {
+			if err := kvDB.AdminSplit(context.TODO(), splitKey); err != nil {
 				t.Fatal(err)
 			}
 

--- a/server/node.go
+++ b/server/node.go
@@ -137,7 +137,7 @@ type Node struct {
 // allocateNodeID increments the node id generator key to allocate
 // a new, unique node id.
 func allocateNodeID(db *client.DB) (roachpb.NodeID, error) {
-	r, err := db.Inc(keys.NodeIDGenerator, 1)
+	r, err := db.Inc(context.TODO(), keys.NodeIDGenerator, 1)
 	if err != nil {
 		return 0, errors.Errorf("unable to allocate node ID: %s", err)
 	}
@@ -148,7 +148,7 @@ func allocateNodeID(db *client.DB) (roachpb.NodeID, error) {
 // specified node to allocate "inc" new, unique store ids. The
 // first ID in a contiguous range is returned on success.
 func allocateStoreIDs(nodeID roachpb.NodeID, inc int64, db *client.DB) (roachpb.StoreID, error) {
-	r, err := db.Inc(keys.StoreIDGenerator, inc)
+	r, err := db.Inc(context.TODO(), keys.StoreIDGenerator, inc)
 	if err != nil {
 		return 0, errors.Errorf("unable to allocate %d store IDs for node %d: %s", inc, nodeID, err)
 	}

--- a/server/node.go
+++ b/server/node.go
@@ -140,7 +140,7 @@ type Node struct {
 // allocateNodeID increments the node id generator key to allocate
 // a new, unique node id.
 func allocateNodeID(db *client.DB) (roachpb.NodeID, error) {
-	r, err := db.Inc(keys.NodeIDGenerator, 1)
+	r, err := db.Inc(context.TODO(), keys.NodeIDGenerator, 1)
 	if err != nil {
 		return 0, errors.Errorf("unable to allocate node ID: %s", err)
 	}
@@ -151,7 +151,7 @@ func allocateNodeID(db *client.DB) (roachpb.NodeID, error) {
 // specified node to allocate "inc" new, unique store ids. The
 // first ID in a contiguous range is returned on success.
 func allocateStoreIDs(nodeID roachpb.NodeID, inc int64, db *client.DB) (roachpb.StoreID, error) {
-	r, err := db.Inc(keys.StoreIDGenerator, inc)
+	r, err := db.Inc(context.TODO(), keys.StoreIDGenerator, inc)
 	if err != nil {
 		return 0, errors.Errorf("unable to allocate %d store IDs for node %d: %s", inc, nodeID, err)
 	}
@@ -691,7 +691,7 @@ func (n *Node) writeSummaries() error {
 			// node status, writing one of these every 10s will generate
 			// more versions than will easily fit into a range over the
 			// course of a day.
-			if err = n.ctx.DB.PutInline(key, nodeStatus); err != nil {
+			if err = n.ctx.DB.PutInline(n.Ctx(), key, nodeStatus); err != nil {
 				return
 			}
 			if log.V(2) {

--- a/server/node.go
+++ b/server/node.go
@@ -137,7 +137,7 @@ type Node struct {
 // allocateNodeID increments the node id generator key to allocate
 // a new, unique node id.
 func allocateNodeID(db *client.DB) (roachpb.NodeID, error) {
-	r, err := db.Inc(keys.NodeIDGenerator, 1)
+	r, err := db.Inc(context.TODO(), keys.NodeIDGenerator, 1)
 	if err != nil {
 		return 0, errors.Errorf("unable to allocate node ID: %s", err)
 	}
@@ -148,7 +148,7 @@ func allocateNodeID(db *client.DB) (roachpb.NodeID, error) {
 // specified node to allocate "inc" new, unique store ids. The
 // first ID in a contiguous range is returned on success.
 func allocateStoreIDs(nodeID roachpb.NodeID, inc int64, db *client.DB) (roachpb.StoreID, error) {
-	r, err := db.Inc(keys.StoreIDGenerator, inc)
+	r, err := db.Inc(context.TODO(), keys.StoreIDGenerator, inc)
 	if err != nil {
 		return 0, errors.Errorf("unable to allocate %d store IDs for node %d: %s", inc, nodeID, err)
 	}
@@ -703,7 +703,7 @@ func (n *Node) writeSummaries() error {
 			// node status, writing one of these every 10s will generate
 			// more versions than will easily fit into a range over the
 			// course of a day.
-			if err = n.ctx.DB.PutInline(key, nodeStatus); err != nil {
+			if err = n.ctx.DB.PutInline(n.Ctx(), key, nodeStatus); err != nil {
 				return
 			}
 			if log.V(2) {

--- a/server/node.go
+++ b/server/node.go
@@ -703,7 +703,7 @@ func (n *Node) writeSummaries() error {
 			// node status, writing one of these every 10s will generate
 			// more versions than will easily fit into a range over the
 			// course of a day.
-			if err = n.ctx.DB.PutInline(key, nodeStatus); err != nil {
+			if err = n.ctx.DB.PutInline(n.Ctx(), key, nodeStatus); err != nil {
 				return
 			}
 			if log.V(2) {

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -450,6 +450,7 @@ func TestStatusSummaries(t *testing.T) {
 	})
 	defer srv.Stopper().Stop()
 	ts := srv.(*TestServer)
+	ctx := context.TODO()
 
 	// Retrieve the first store from the Node.
 	s, err := ts.node.stores.GetStore(roachpb.StoreID(1))
@@ -552,10 +553,10 @@ func TestStatusSummaries(t *testing.T) {
 	rightKey := "c"
 
 	// Write some values left and right of the proposed split key.
-	if err := ts.db.Put(leftKey, content); err != nil {
+	if err := ts.db.Put(ctx, leftKey, content); err != nil {
 		t.Fatal(err)
 	}
-	if err := ts.db.Put(rightKey, content); err != nil {
+	if err := ts.db.Put(ctx, rightKey, content); err != nil {
 		t.Fatal(err)
 	}
 
@@ -588,10 +589,10 @@ func TestStatusSummaries(t *testing.T) {
 
 	// Write on both sides of the split to ensure that the raft machinery
 	// is running.
-	if err := ts.db.Put(leftKey, content); err != nil {
+	if err := ts.db.Put(ctx, leftKey, content); err != nil {
 		t.Fatal(err)
 	}
-	if err := ts.db.Put(rightKey, content); err != nil {
+	if err := ts.db.Put(ctx, rightKey, content); err != nil {
 		t.Fatal(err)
 	}
 

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -331,7 +331,7 @@ func compareNodeStatus(t *testing.T, ts *TestServer, expectedNodeStatus *status.
 	// ========================================
 	nodeStatusKey := keys.NodeStatusKey(int32(ts.node.Descriptor.NodeID))
 	nodeStatus := &status.NodeStatus{}
-	if err := ts.db.GetProto(nodeStatusKey, nodeStatus); err != nil {
+	if err := ts.db.GetProto(context.TODO(), nodeStatusKey, nodeStatus); err != nil {
 		t.Fatalf("%d: failure getting node status: %s", testNumber, err)
 	}
 
@@ -450,6 +450,7 @@ func TestStatusSummaries(t *testing.T) {
 	})
 	defer srv.Stopper().Stop()
 	ts := srv.(*TestServer)
+	ctx := context.TODO()
 
 	// Retrieve the first store from the Node.
 	s, err := ts.node.stores.GetStore(roachpb.StoreID(1))
@@ -463,7 +464,7 @@ func TestStatusSummaries(t *testing.T) {
 	leftKey := "a"
 
 	// Scan over all keys to "wake up" all replicas (force a lease holder election).
-	if _, err := kvDB.Scan(keys.MetaMax, keys.MaxKey, 0); err != nil {
+	if _, err := kvDB.Scan(context.TODO(), keys.MetaMax, keys.MaxKey, 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -552,10 +553,10 @@ func TestStatusSummaries(t *testing.T) {
 	rightKey := "c"
 
 	// Write some values left and right of the proposed split key.
-	if err := ts.db.Put(leftKey, content); err != nil {
+	if err := ts.db.Put(ctx, leftKey, content); err != nil {
 		t.Fatal(err)
 	}
-	if err := ts.db.Put(rightKey, content); err != nil {
+	if err := ts.db.Put(ctx, rightKey, content); err != nil {
 		t.Fatal(err)
 	}
 
@@ -582,16 +583,16 @@ func TestStatusSummaries(t *testing.T) {
 	// ========================================
 
 	// Split the range.
-	if err := ts.db.AdminSplit(splitKey); err != nil {
+	if err := ts.db.AdminSplit(context.TODO(), splitKey); err != nil {
 		t.Fatal(err)
 	}
 
 	// Write on both sides of the split to ensure that the raft machinery
 	// is running.
-	if err := ts.db.Put(leftKey, content); err != nil {
+	if err := ts.db.Put(ctx, leftKey, content); err != nil {
 		t.Fatal(err)
 	}
-	if err := ts.db.Put(rightKey, content); err != nil {
+	if err := ts.db.Put(ctx, rightKey, content); err != nil {
 		t.Fatal(err)
 	}
 

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -331,7 +331,7 @@ func compareNodeStatus(t *testing.T, ts *TestServer, expectedNodeStatus *status.
 	// ========================================
 	nodeStatusKey := keys.NodeStatusKey(int32(ts.node.Descriptor.NodeID))
 	nodeStatus := &status.NodeStatus{}
-	if err := ts.db.GetProto(nodeStatusKey, nodeStatus); err != nil {
+	if err := ts.db.GetProto(context.TODO(), nodeStatusKey, nodeStatus); err != nil {
 		t.Fatalf("%d: failure getting node status: %s", testNumber, err)
 	}
 

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -583,7 +583,7 @@ func TestStatusSummaries(t *testing.T) {
 	// ========================================
 
 	// Split the range.
-	if err := ts.db.AdminSplit(splitKey); err != nil {
+	if err := ts.db.AdminSplit(context.TODO(), splitKey); err != nil {
 		t.Fatal(err)
 	}
 

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -464,7 +464,7 @@ func TestStatusSummaries(t *testing.T) {
 	leftKey := "a"
 
 	// Scan over all keys to "wake up" all replicas (force a lease holder election).
-	if _, err := kvDB.Scan(keys.MetaMax, keys.MaxKey, 0); err != nil {
+	if _, err := kvDB.Scan(context.TODO(), keys.MetaMax, keys.MaxKey, 0); err != nil {
 		t.Fatal(err)
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -372,6 +372,7 @@ func TestSystemConfigGossip(t *testing.T) {
 	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop()
 	ts := s.(*TestServer)
+	ctx := context.TODO()
 
 	key := sqlbase.MakeDescMetadataKey(keys.MaxReservedDescID)
 	valAt := func(i int) *sqlbase.DatabaseDescriptor {
@@ -390,12 +391,12 @@ func TestSystemConfigGossip(t *testing.T) {
 	}
 
 	// Try a plain KV write first.
-	if err := kvDB.Put(key, valAt(0)); err != nil {
+	if err := kvDB.Put(ctx, key, valAt(0)); err != nil {
 		t.Fatal(err)
 	}
 
 	// Now do it as part of a transaction, but without the trigger set.
-	if err := kvDB.Txn(context.TODO(), func(txn *client.Txn) error {
+	if err := kvDB.Txn(ctx, func(txn *client.Txn) error {
 		return txn.Put(key, valAt(1))
 	}); err != nil {
 		t.Fatal(err)
@@ -416,7 +417,7 @@ func TestSystemConfigGossip(t *testing.T) {
 	}
 
 	// This time mark the transaction as having a Gossip trigger.
-	if err := kvDB.Txn(context.TODO(), func(txn *client.Txn) error {
+	if err := kvDB.Txn(ctx, func(txn *client.Txn) error {
 		txn.SetSystemConfigTrigger()
 		return txn.Put(key, valAt(2))
 	}); err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -212,7 +212,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	tds := kv.NewTxnCoordSender(ctx, ds, s.Clock(), ts.Ctx.Linearizable,
 		ts.stopper, kv.MakeTxnMetrics())
 
-	if err := ts.node.ctx.DB.AdminSplit("m"); err != nil {
+	if err := ts.node.ctx.DB.AdminSplit(context.TODO(), "m"); err != nil {
 		t.Fatal(err)
 	}
 	writes := []roachpb.Key{roachpb.Key("a"), roachpb.Key("z")}
@@ -311,7 +311,7 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 			ts.stopper, kv.MakeTxnMetrics())
 
 		for _, sk := range tc.splitKeys {
-			if err := ts.node.ctx.DB.AdminSplit(sk); err != nil {
+			if err := ts.node.ctx.DB.AdminSplit(context.TODO(), sk); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -350,6 +350,7 @@ func TestSystemConfigGossip(t *testing.T) {
 	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop()
 	ts := s.(*TestServer)
+	ctx := context.TODO()
 
 	key := sqlbase.MakeDescMetadataKey(keys.MaxReservedDescID)
 	valAt := func(i int) *sqlbase.DatabaseDescriptor {
@@ -368,12 +369,12 @@ func TestSystemConfigGossip(t *testing.T) {
 	}
 
 	// Try a plain KV write first.
-	if err := kvDB.Put(key, valAt(0)); err != nil {
+	if err := kvDB.Put(ctx, key, valAt(0)); err != nil {
 		t.Fatal(err)
 	}
 
 	// Now do it as part of a transaction, but without the trigger set.
-	if err := kvDB.Txn(context.TODO(), func(txn *client.Txn) error {
+	if err := kvDB.Txn(ctx, func(txn *client.Txn) error {
 		return txn.Put(key, valAt(1))
 	}); err != nil {
 		t.Fatal(err)
@@ -394,7 +395,7 @@ func TestSystemConfigGossip(t *testing.T) {
 	}
 
 	// This time mark the transaction as having a Gossip trigger.
-	if err := kvDB.Txn(context.TODO(), func(txn *client.Txn) error {
+	if err := kvDB.Txn(ctx, func(txn *client.Txn) error {
 		txn.SetSystemConfigTrigger()
 		return txn.Put(key, valAt(2))
 	}); err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -234,7 +234,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	tds := kv.NewTxnCoordSender(ctx, ds, s.Clock(), ts.Ctx.Linearizable,
 		ts.stopper, kv.MakeTxnMetrics())
 
-	if err := ts.node.ctx.DB.AdminSplit("m"); err != nil {
+	if err := ts.node.ctx.DB.AdminSplit(context.TODO(), "m"); err != nil {
 		t.Fatal(err)
 	}
 	writes := []roachpb.Key{roachpb.Key("a"), roachpb.Key("z")}
@@ -333,7 +333,7 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 			ts.stopper, kv.MakeTxnMetrics())
 
 		for _, sk := range tc.splitKeys {
-			if err := ts.node.ctx.DB.AdminSplit(sk); err != nil {
+			if err := ts.node.ctx.DB.AdminSplit(context.TODO(), sk); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -488,7 +488,7 @@ func TestRangesResponse(t *testing.T) {
 	defer ts.Stopper().Stop()
 
 	// Perform a scan to ensure that all the raft groups are initialized.
-	if _, err := ts.(*TestServer).db.Scan(keys.LocalMax, roachpb.KeyMax, 0); err != nil {
+	if _, err := ts.(*TestServer).db.Scan(context.TODO(), keys.LocalMax, roachpb.KeyMax, 0); err != nil {
 		t.Fatal(err)
 	}
 

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -226,7 +226,7 @@ func startServer(t *testing.T) serverutils.TestServerInterface {
 
 	// Make sure the range is spun up with an arbitrary read command. We do not
 	// expect a specific response.
-	if _, err := kvDB.Get("a"); err != nil {
+	if _, err := kvDB.Get(context.TODO(), "a"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -452,7 +452,7 @@ func TestMetricsRecording(t *testing.T) {
 	checkTimeSeriesKey := func(now int64, keyName string) error {
 		key := ts.MakeDataKey(keyName, "", ts.Resolution10s, now)
 		data := roachpb.InternalTimeSeriesData{}
-		return kvDB.GetProto(key, &data)
+		return kvDB.GetProto(context.TODO(), key, &data)
 	}
 
 	// Verify that metrics for the current timestamp are recorded. This should

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -226,7 +226,7 @@ func startServer(t *testing.T) serverutils.TestServerInterface {
 
 	// Make sure the range is spun up with an arbitrary read command. We do not
 	// expect a specific response.
-	if _, err := kvDB.Get("a"); err != nil {
+	if _, err := kvDB.Get(context.TODO(), "a"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -452,7 +452,7 @@ func TestMetricsRecording(t *testing.T) {
 	checkTimeSeriesKey := func(now int64, keyName string) error {
 		key := ts.MakeDataKey(keyName, "", ts.Resolution10s, now)
 		data := roachpb.InternalTimeSeriesData{}
-		return kvDB.GetProto(key, &data)
+		return kvDB.GetProto(context.TODO(), key, &data)
 	}
 
 	// Verify that metrics for the current timestamp are recorded. This should
@@ -488,7 +488,7 @@ func TestRangesResponse(t *testing.T) {
 	defer ts.Stopper().Stop()
 
 	// Perform a scan to ensure that all the raft groups are initialized.
-	if _, err := ts.(*TestServer).db.Scan(keys.LocalMax, roachpb.KeyMax, 0); err != nil {
+	if _, err := ts.(*TestServer).db.Scan(context.TODO(), keys.LocalMax, roachpb.KeyMax, 0); err != nil {
 		t.Fatal(err)
 	}
 

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -163,7 +163,7 @@ func startServer(t *testing.T) *TestServer {
 
 	// Make sure the range is spun up with an arbitrary read command. We do not
 	// expect a specific response.
-	if _, err := kvDB.Get("a"); err != nil {
+	if _, err := kvDB.Get(context.TODO(), "a"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -379,7 +379,7 @@ func TestMetricsRecording(t *testing.T) {
 	checkTimeSeriesKey := func(now int64, keyName string) error {
 		key := ts.MakeDataKey(keyName, "", ts.Resolution10s, now)
 		data := roachpb.InternalTimeSeriesData{}
-		return kvDB.GetProto(key, &data)
+		return kvDB.GetProto(context.TODO(), key, &data)
 	}
 
 	// Verify that metrics for the current timestamp are recorded. This should
@@ -415,7 +415,7 @@ func TestRangesResponse(t *testing.T) {
 	defer ts.Stopper().Stop()
 
 	// Perform a scan to ensure that all the raft groups are initialized.
-	if _, err := ts.db.Scan(keys.LocalMax, roachpb.KeyMax, 0); err != nil {
+	if _, err := ts.db.Scan(context.TODO(), keys.LocalMax, roachpb.KeyMax, 0); err != nil {
 		t.Fatal(err)
 	}
 

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -278,7 +278,7 @@ func WaitForInitialSplits(db *client.DB) error {
 	expectedRanges := ExpectedInitialRangeCount()
 	return util.RetryForDuration(initialSplitsTimeout, func() error {
 		// Scan all keys in the Meta2Prefix; we only need a count.
-		rows, err := db.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
+		rows, err := db.Scan(context.TODO(), keys.Meta2Prefix, keys.MetaMax, 0)
 		if err != nil {
 			return err
 		}

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -290,7 +290,7 @@ func WaitForInitialSplits(db *client.DB) error {
 	expectedRanges := ExpectedInitialRangeCount()
 	return util.RetryForDuration(initialSplitsTimeout, func() error {
 		// Scan all keys in the Meta2Prefix; we only need a count.
-		rows, err := db.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
+		rows, err := db.Scan(context.TODO(), keys.Meta2Prefix, keys.MetaMax, 0)
 		if err != nil {
 			return err
 		}

--- a/server/updates.go
+++ b/server/updates.go
@@ -160,8 +160,8 @@ func (s *Server) maybeRunPeriodicCheck(op string, key roachpb.Key, f func()) tim
 
 	f()
 
-	if err := s.db.Put(key, timeutil.Now().Add(updateCheckFrequency)); err != nil {
-		log.Infof(context.TODO(), "Error updating %s time: %v", op, err)
+	if err := s.db.Put(s.Ctx(), key, timeutil.Now().Add(updateCheckFrequency)); err != nil {
+		log.Infof(s.Ctx(), "Error updating %s time: %v", op, err)
 	}
 	return updateCheckFrequency
 }

--- a/server/updates.go
+++ b/server/updates.go
@@ -140,7 +140,7 @@ func (s *Server) maybeRunPeriodicCheck(op string, key roachpb.Key, f func()) tim
 		}
 
 		nextRetry := whenToCheck.Add(updateCheckRetryFrequency)
-		if err := s.db.CPut(key, nextRetry, whenToCheck); err != nil {
+		if err := s.db.CPut(s.Ctx(), key, nextRetry, whenToCheck); err != nil {
 			if log.V(2) {
 				log.Infof(s.Ctx(), "Could not set next version check time (maybe another node checked?): %v", err)
 			}
@@ -150,7 +150,7 @@ func (s *Server) maybeRunPeriodicCheck(op string, key roachpb.Key, f func()) tim
 		log.Infof(s.Ctx(), "No previous %s time.", op)
 		nextRetry := timeutil.Now().Add(updateCheckRetryFrequency)
 		// CPut with `nil` prev value to assert that no other node has checked.
-		if err := s.db.CPut(key, nextRetry, nil); err != nil {
+		if err := s.db.CPut(s.Ctx(), key, nextRetry, nil); err != nil {
 			if log.V(2) {
 				log.Infof(s.Ctx(), "Could not set %s time (maybe another node checked?): %v", op, err)
 			}

--- a/server/updates.go
+++ b/server/updates.go
@@ -121,9 +121,9 @@ func (s *Server) maybeCheckForUpdates() time.Duration {
 // Returns how long until `f` should be run next (i.e. when this method should
 // be called again).
 func (s *Server) maybeRunPeriodicCheck(op string, key roachpb.Key, f func()) time.Duration {
-	resp, err := s.db.Get(key)
+	resp, err := s.db.Get(s.Ctx(), key)
 	if err != nil {
-		log.Infof(context.TODO(), "Error reading %s time: %v", op, err)
+		log.Infof(s.Ctx(), "Error reading %s time: %v", op, err)
 		return updateCheckRetryFrequency
 	}
 
@@ -133,7 +133,7 @@ func (s *Server) maybeRunPeriodicCheck(op string, key roachpb.Key, f func()) tim
 	if resp.Exists() {
 		whenToCheck, pErr := resp.Value.GetTime()
 		if pErr != nil {
-			log.Warningf(context.TODO(), "Error decoding %s time: %v", op, err)
+			log.Warningf(s.Ctx(), "Error decoding %s time: %v", op, err)
 			return updateCheckRetryFrequency
 		} else if delay := whenToCheck.Sub(timeutil.Now()); delay > 0 {
 			return delay
@@ -142,17 +142,17 @@ func (s *Server) maybeRunPeriodicCheck(op string, key roachpb.Key, f func()) tim
 		nextRetry := whenToCheck.Add(updateCheckRetryFrequency)
 		if err := s.db.CPut(key, nextRetry, whenToCheck); err != nil {
 			if log.V(2) {
-				log.Infof(context.TODO(), "Could not set next version check time (maybe another node checked?): %v", err)
+				log.Infof(s.Ctx(), "Could not set next version check time (maybe another node checked?): %v", err)
 			}
 			return updateCheckRetryFrequency
 		}
 	} else {
-		log.Infof(context.TODO(), "No previous %s time.", op)
+		log.Infof(s.Ctx(), "No previous %s time.", op)
 		nextRetry := timeutil.Now().Add(updateCheckRetryFrequency)
 		// CPut with `nil` prev value to assert that no other node has checked.
 		if err := s.db.CPut(key, nextRetry, nil); err != nil {
 			if log.V(2) {
-				log.Infof(context.TODO(), "Could not set %s time (maybe another node checked?): %v", op, err)
+				log.Infof(s.Ctx(), "Could not set %s time (maybe another node checked?): %v", op, err)
 			}
 			return updateCheckRetryFrequency
 		}

--- a/sql/create_test.go
+++ b/sql/create_test.go
@@ -91,7 +91,7 @@ func TestDatabaseDescriptor(t *testing.T) {
 	}
 
 	// Remove the junk; allow database creation to proceed.
-	if err := kvDB.Del(dbDescKey); err != nil {
+	if err := kvDB.Del(ctx, dbDescKey); err != nil {
 		t.Fatal(err)
 	}
 

--- a/sql/create_test.go
+++ b/sql/create_test.go
@@ -19,6 +19,8 @@ package sql_test
 import (
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/server"
@@ -33,12 +35,13 @@ func TestDatabaseDescriptor(t *testing.T) {
 	params, _ := createTestServerParams()
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop()
+	ctx := context.TODO()
 
 	expectedCounter := int64(keys.MaxReservedDescID + 1)
 
 	// Test values before creating the database.
 	// descriptor ID counter.
-	if ir, err := kvDB.Get(keys.DescIDGenerator); err != nil {
+	if ir, err := kvDB.Get(ctx, keys.DescIDGenerator); err != nil {
 		t.Fatal(err)
 	} else if actual := ir.ValueInt(); actual != expectedCounter {
 		t.Fatalf("expected descriptor ID == %d, got %d", expectedCounter, actual)
@@ -46,7 +49,7 @@ func TestDatabaseDescriptor(t *testing.T) {
 
 	// Database name.
 	nameKey := sqlbase.MakeNameMetadataKey(keys.RootNamespaceID, "test")
-	if gr, err := kvDB.Get(nameKey); err != nil {
+	if gr, err := kvDB.Get(ctx, nameKey); err != nil {
 		t.Fatal(err)
 	} else if gr.Exists() {
 		t.Fatal("expected non-existing key")
@@ -72,7 +75,7 @@ func TestDatabaseDescriptor(t *testing.T) {
 		t.Fatalf("unexpected error %v", err)
 	}
 
-	if ir, err := kvDB.Get(keys.DescIDGenerator); err != nil {
+	if ir, err := kvDB.Get(ctx, keys.DescIDGenerator); err != nil {
 		t.Fatal(err)
 	} else if actual := ir.ValueInt(); actual != expectedCounter {
 		t.Fatalf("expected descriptor ID == %d, got %d", expectedCounter, actual)
@@ -99,21 +102,21 @@ func TestDatabaseDescriptor(t *testing.T) {
 
 	// Check keys again.
 	// descriptor ID counter.
-	if ir, err := kvDB.Get(keys.DescIDGenerator); err != nil {
+	if ir, err := kvDB.Get(ctx, keys.DescIDGenerator); err != nil {
 		t.Fatal(err)
 	} else if actual := ir.ValueInt(); actual != expectedCounter {
 		t.Fatalf("expected descriptor ID == %d, got %d", expectedCounter, actual)
 	}
 
 	// Database name.
-	if gr, err := kvDB.Get(nameKey); err != nil {
+	if gr, err := kvDB.Get(ctx, nameKey); err != nil {
 		t.Fatal(err)
 	} else if !gr.Exists() {
 		t.Fatal("key is missing")
 	}
 
 	// database descriptor.
-	if gr, err := kvDB.Get(dbDescKey); err != nil {
+	if gr, err := kvDB.Get(ctx, dbDescKey); err != nil {
 		t.Fatal(err)
 	} else if !gr.Exists() {
 		t.Fatal("key is missing")
@@ -126,21 +129,21 @@ func TestDatabaseDescriptor(t *testing.T) {
 
 	// Check keys again.
 	// descriptor ID counter.
-	if ir, err := kvDB.Get(keys.DescIDGenerator); err != nil {
+	if ir, err := kvDB.Get(ctx, keys.DescIDGenerator); err != nil {
 		t.Fatal(err)
 	} else if actual := ir.ValueInt(); actual != expectedCounter {
 		t.Fatalf("expected descriptor ID == %d, got %d", expectedCounter, actual)
 	}
 
 	// Database name.
-	if gr, err := kvDB.Get(nameKey); err != nil {
+	if gr, err := kvDB.Get(ctx, nameKey); err != nil {
 		t.Fatal(err)
 	} else if !gr.Exists() {
 		t.Fatal("key is missing")
 	}
 
 	// database descriptor.
-	if gr, err := kvDB.Get(dbDescKey); err != nil {
+	if gr, err := kvDB.Get(ctx, dbDescKey); err != nil {
 		t.Fatal(err)
 	} else if !gr.Exists() {
 		t.Fatal("key is missing")

--- a/sql/create_test.go
+++ b/sql/create_test.go
@@ -66,7 +66,7 @@ func TestDatabaseDescriptor(t *testing.T) {
 			},
 		},
 	}
-	if err := kvDB.CPut(dbDescKey, dbDesc, nil); err != nil {
+	if err := kvDB.CPut(ctx, dbDescKey, dbDesc, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/sql/create_test.go
+++ b/sql/create_test.go
@@ -19,6 +19,8 @@ package sql_test
 import (
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/server"
@@ -33,12 +35,13 @@ func TestDatabaseDescriptor(t *testing.T) {
 	params, _ := createTestServerParams()
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop()
+	ctx := context.TODO()
 
 	expectedCounter := int64(keys.MaxReservedDescID + 1)
 
 	// Test values before creating the database.
 	// descriptor ID counter.
-	if ir, err := kvDB.Get(keys.DescIDGenerator); err != nil {
+	if ir, err := kvDB.Get(ctx, keys.DescIDGenerator); err != nil {
 		t.Fatal(err)
 	} else if actual := ir.ValueInt(); actual != expectedCounter {
 		t.Fatalf("expected descriptor ID == %d, got %d", expectedCounter, actual)
@@ -46,7 +49,7 @@ func TestDatabaseDescriptor(t *testing.T) {
 
 	// Database name.
 	nameKey := sqlbase.MakeNameMetadataKey(keys.RootNamespaceID, "test")
-	if gr, err := kvDB.Get(nameKey); err != nil {
+	if gr, err := kvDB.Get(ctx, nameKey); err != nil {
 		t.Fatal(err)
 	} else if gr.Exists() {
 		t.Fatal("expected non-existing key")
@@ -63,7 +66,7 @@ func TestDatabaseDescriptor(t *testing.T) {
 			},
 		},
 	}
-	if err := kvDB.CPut(dbDescKey, dbDesc, nil); err != nil {
+	if err := kvDB.CPut(ctx, dbDescKey, dbDesc, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -72,14 +75,14 @@ func TestDatabaseDescriptor(t *testing.T) {
 		t.Fatalf("unexpected error %v", err)
 	}
 
-	if ir, err := kvDB.Get(keys.DescIDGenerator); err != nil {
+	if ir, err := kvDB.Get(ctx, keys.DescIDGenerator); err != nil {
 		t.Fatal(err)
 	} else if actual := ir.ValueInt(); actual != expectedCounter {
 		t.Fatalf("expected descriptor ID == %d, got %d", expectedCounter, actual)
 	}
 
 	start := roachpb.Key(keys.MakeTablePrefix(uint32(keys.NamespaceTableID)))
-	if kvs, err := kvDB.Scan(start, start.PrefixEnd(), 0); err != nil {
+	if kvs, err := kvDB.Scan(ctx, start, start.PrefixEnd(), 0); err != nil {
 		t.Fatal(err)
 	} else {
 		if a, e := len(kvs), server.GetBootstrapSchema().SystemDescriptorCount(); a != e {
@@ -88,7 +91,7 @@ func TestDatabaseDescriptor(t *testing.T) {
 	}
 
 	// Remove the junk; allow database creation to proceed.
-	if err := kvDB.Del(dbDescKey); err != nil {
+	if err := kvDB.Del(ctx, dbDescKey); err != nil {
 		t.Fatal(err)
 	}
 
@@ -99,21 +102,21 @@ func TestDatabaseDescriptor(t *testing.T) {
 
 	// Check keys again.
 	// descriptor ID counter.
-	if ir, err := kvDB.Get(keys.DescIDGenerator); err != nil {
+	if ir, err := kvDB.Get(ctx, keys.DescIDGenerator); err != nil {
 		t.Fatal(err)
 	} else if actual := ir.ValueInt(); actual != expectedCounter {
 		t.Fatalf("expected descriptor ID == %d, got %d", expectedCounter, actual)
 	}
 
 	// Database name.
-	if gr, err := kvDB.Get(nameKey); err != nil {
+	if gr, err := kvDB.Get(ctx, nameKey); err != nil {
 		t.Fatal(err)
 	} else if !gr.Exists() {
 		t.Fatal("key is missing")
 	}
 
 	// database descriptor.
-	if gr, err := kvDB.Get(dbDescKey); err != nil {
+	if gr, err := kvDB.Get(ctx, dbDescKey); err != nil {
 		t.Fatal(err)
 	} else if !gr.Exists() {
 		t.Fatal("key is missing")
@@ -126,21 +129,21 @@ func TestDatabaseDescriptor(t *testing.T) {
 
 	// Check keys again.
 	// descriptor ID counter.
-	if ir, err := kvDB.Get(keys.DescIDGenerator); err != nil {
+	if ir, err := kvDB.Get(ctx, keys.DescIDGenerator); err != nil {
 		t.Fatal(err)
 	} else if actual := ir.ValueInt(); actual != expectedCounter {
 		t.Fatalf("expected descriptor ID == %d, got %d", expectedCounter, actual)
 	}
 
 	// Database name.
-	if gr, err := kvDB.Get(nameKey); err != nil {
+	if gr, err := kvDB.Get(ctx, nameKey); err != nil {
 		t.Fatal(err)
 	} else if !gr.Exists() {
 		t.Fatal("key is missing")
 	}
 
 	// database descriptor.
-	if gr, err := kvDB.Get(dbDescKey); err != nil {
+	if gr, err := kvDB.Get(ctx, dbDescKey); err != nil {
 		t.Fatal(err)
 	} else if !gr.Exists() {
 		t.Fatal("key is missing")

--- a/sql/create_test.go
+++ b/sql/create_test.go
@@ -82,7 +82,7 @@ func TestDatabaseDescriptor(t *testing.T) {
 	}
 
 	start := roachpb.Key(keys.MakeTablePrefix(uint32(keys.NamespaceTableID)))
-	if kvs, err := kvDB.Scan(start, start.PrefixEnd(), 0); err != nil {
+	if kvs, err := kvDB.Scan(ctx, start, start.PrefixEnd(), 0); err != nil {
 		t.Fatal(err)
 	} else {
 		if a, e := len(kvs), server.GetBootstrapSchema().SystemDescriptorCount(); a != e {

--- a/sql/descriptor_mutation_test.go
+++ b/sql/descriptor_mutation_test.go
@@ -22,6 +22,8 @@ import (
 	"math/rand"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/keys"
@@ -131,6 +133,7 @@ func (mt mutationTest) makeMutationsActive() {
 		mt.Fatal(err)
 	}
 	if err := mt.kvDB.Put(
+		context.TODO(),
 		sqlbase.MakeDescMetadataKey(mt.tableDesc.ID),
 		sqlbase.WrapDescriptor(mt.tableDesc),
 	); err != nil {
@@ -181,6 +184,7 @@ func (mt mutationTest) writeMutation(m sqlbase.DescriptorMutation) {
 		mt.Fatal(err)
 	}
 	if err := mt.kvDB.Put(
+		context.TODO(),
 		sqlbase.MakeDescMetadataKey(mt.tableDesc.ID),
 		sqlbase.WrapDescriptor(mt.tableDesc),
 	); err != nil {
@@ -974,6 +978,7 @@ func TestAddingFKs(t *testing.T) {
 	ordersDesc.State = sqlbase.TableDescriptor_ADD
 	ordersDesc.Version++
 	if err := kvDB.Put(
+		context.TODO(),
 		sqlbase.MakeDescMetadataKey(ordersDesc.ID),
 		sqlbase.WrapDescriptor(ordersDesc),
 	); err != nil {

--- a/sql/descriptor_mutation_test.go
+++ b/sql/descriptor_mutation_test.go
@@ -22,6 +22,8 @@ import (
 	"math/rand"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/keys"
@@ -103,7 +105,7 @@ func (mt mutationTest) checkTableSize(e int) {
 	tablePrefix := keys.MakeTablePrefix(uint32(mt.tableDesc.ID))
 	tableStartKey := roachpb.Key(tablePrefix)
 	tableEndKey := tableStartKey.PrefixEnd()
-	if kvs, err := mt.kvDB.Scan(tableStartKey, tableEndKey, 0); err != nil {
+	if kvs, err := mt.kvDB.Scan(context.TODO(), tableStartKey, tableEndKey, 0); err != nil {
 		mt.Error(err)
 	} else if len(kvs) != e {
 		mt.Errorf("expected %d key value pairs, but got %d", e, len(kvs))
@@ -131,6 +133,7 @@ func (mt mutationTest) makeMutationsActive() {
 		mt.Fatal(err)
 	}
 	if err := mt.kvDB.Put(
+		context.TODO(),
 		sqlbase.MakeDescMetadataKey(mt.tableDesc.ID),
 		sqlbase.WrapDescriptor(mt.tableDesc),
 	); err != nil {
@@ -181,6 +184,7 @@ func (mt mutationTest) writeMutation(m sqlbase.DescriptorMutation) {
 		mt.Fatal(err)
 	}
 	if err := mt.kvDB.Put(
+		context.TODO(),
 		sqlbase.MakeDescMetadataKey(mt.tableDesc.ID),
 		sqlbase.WrapDescriptor(mt.tableDesc),
 	); err != nil {
@@ -974,6 +978,7 @@ func TestAddingFKs(t *testing.T) {
 	ordersDesc.State = sqlbase.TableDescriptor_ADD
 	ordersDesc.Version++
 	if err := kvDB.Put(
+		context.TODO(),
 		sqlbase.MakeDescMetadataKey(ordersDesc.ID),
 		sqlbase.WrapDescriptor(ordersDesc),
 	); err != nil {

--- a/sql/descriptor_mutation_test.go
+++ b/sql/descriptor_mutation_test.go
@@ -105,7 +105,7 @@ func (mt mutationTest) checkTableSize(e int) {
 	tablePrefix := keys.MakeTablePrefix(uint32(mt.tableDesc.ID))
 	tableStartKey := roachpb.Key(tablePrefix)
 	tableEndKey := tableStartKey.PrefixEnd()
-	if kvs, err := mt.kvDB.Scan(tableStartKey, tableEndKey, 0); err != nil {
+	if kvs, err := mt.kvDB.Scan(context.TODO(), tableStartKey, tableEndKey, 0); err != nil {
 		mt.Error(err)
 	} else if len(kvs) != e {
 		mt.Errorf("expected %d key value pairs, but got %d", e, len(kvs))

--- a/sql/drop_test.go
+++ b/sql/drop_test.go
@@ -19,6 +19,8 @@ package sql_test
 import (
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -34,6 +36,7 @@ func TestDropDatabase(t *testing.T) {
 	params, _ := createTestServerParams()
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop()
+	ctx := context.TODO()
 
 	// Fix the column families so the key counts below don't change if the
 	// family heuristics are updated.
@@ -46,7 +49,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	}
 
 	dbNameKey := sqlbase.MakeNameMetadataKey(keys.RootNamespaceID, "t")
-	r, err := kvDB.Get(dbNameKey)
+	r, err := kvDB.Get(ctx, dbNameKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,13 +58,13 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	}
 	dbDescKey := sqlbase.MakeDescMetadataKey(sqlbase.ID(r.ValueInt()))
 	desc := &sqlbase.Descriptor{}
-	if err := kvDB.GetProto(dbDescKey, desc); err != nil {
+	if err := kvDB.GetProto(ctx, dbDescKey, desc); err != nil {
 		t.Fatal(err)
 	}
 	dbDesc := desc.GetDatabase()
 
 	tbNameKey := sqlbase.MakeNameMetadataKey(dbDesc.ID, "kv")
-	gr, err := kvDB.Get(tbNameKey)
+	gr, err := kvDB.Get(ctx, tbNameKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +72,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 		t.Fatalf(`table "kv" does not exist`)
 	}
 	tbDescKey := sqlbase.MakeDescMetadataKey(sqlbase.ID(gr.ValueInt()))
-	if err := kvDB.GetProto(tbDescKey, desc); err != nil {
+	if err := kvDB.GetProto(ctx, tbDescKey, desc); err != nil {
 		t.Fatal(err)
 	}
 	tbDesc := desc.GetTable()
@@ -89,12 +92,12 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 
 	tbZoneKey := sqlbase.MakeZoneKey(tbDesc.ID)
 	dbZoneKey := sqlbase.MakeZoneKey(dbDesc.ID)
-	if gr, err := kvDB.Get(tbZoneKey); err != nil {
+	if gr, err := kvDB.Get(ctx, tbZoneKey); err != nil {
 		t.Fatal(err)
 	} else if !gr.Exists() {
 		t.Fatalf("table zone config entry not found")
 	}
-	if gr, err := kvDB.Get(dbZoneKey); err != nil {
+	if gr, err := kvDB.Get(ctx, dbZoneKey); err != nil {
 		t.Fatal(err)
 	} else if !gr.Exists() {
 		t.Fatalf("database zone config entry not found")
@@ -103,7 +106,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	tablePrefix := keys.MakeTablePrefix(uint32(tbDesc.ID))
 	tableStartKey := roachpb.Key(tablePrefix)
 	tableEndKey := tableStartKey.PrefixEnd()
-	if kvs, err := kvDB.Scan(tableStartKey, tableEndKey, 0); err != nil {
+	if kvs, err := kvDB.Scan(ctx, tableStartKey, tableEndKey, 0); err != nil {
 		t.Fatal(err)
 	} else if l := 6; len(kvs) != l {
 		t.Fatalf("expected %d key value pairs, but got %d", l, len(kvs))
@@ -113,43 +116,43 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 		t.Fatal(err)
 	}
 
-	if kvs, err := kvDB.Scan(tableStartKey, tableEndKey, 0); err != nil {
+	if kvs, err := kvDB.Scan(ctx, tableStartKey, tableEndKey, 0); err != nil {
 		t.Fatal(err)
 	} else if l := 0; len(kvs) != l {
 		t.Fatalf("expected %d key value pairs, but got %d", l, len(kvs))
 	}
 
-	if gr, err := kvDB.Get(tbDescKey); err != nil {
+	if gr, err := kvDB.Get(ctx, tbDescKey); err != nil {
 		t.Fatal(err)
 	} else if gr.Exists() {
 		t.Fatalf("table descriptor still exists after database is dropped: %q", tbDescKey)
 	}
 
-	if gr, err := kvDB.Get(tbNameKey); err != nil {
+	if gr, err := kvDB.Get(ctx, tbNameKey); err != nil {
 		t.Fatal(err)
 	} else if gr.Exists() {
 		t.Fatalf("table descriptor key still exists after database is dropped")
 	}
 
-	if gr, err := kvDB.Get(dbDescKey); err != nil {
+	if gr, err := kvDB.Get(ctx, dbDescKey); err != nil {
 		t.Fatal(err)
 	} else if gr.Exists() {
 		t.Fatalf("database descriptor still exists after database is dropped")
 	}
 
-	if gr, err := kvDB.Get(dbNameKey); err != nil {
+	if gr, err := kvDB.Get(ctx, dbNameKey); err != nil {
 		t.Fatal(err)
 	} else if gr.Exists() {
 		t.Fatalf("database descriptor key still exists after database is dropped")
 	}
 
-	if gr, err := kvDB.Get(tbZoneKey); err != nil {
+	if gr, err := kvDB.Get(ctx, tbZoneKey); err != nil {
 		t.Fatal(err)
 	} else if gr.Exists() {
 		t.Fatalf("table zone config entry still exists after the database is dropped")
 	}
 
-	if gr, err := kvDB.Get(dbZoneKey); err != nil {
+	if gr, err := kvDB.Get(ctx, dbZoneKey); err != nil {
 		t.Fatal(err)
 	} else if gr.Exists() {
 		t.Fatalf("database zone config entry still exists after the database is dropped")
@@ -184,7 +187,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 
 	indexStartKey := roachpb.Key(indexPrefix)
 	indexEndKey := indexStartKey.PrefixEnd()
-	if kvs, err := kvDB.Scan(indexStartKey, indexEndKey, 0); err != nil {
+	if kvs, err := kvDB.Scan(context.TODO(), indexStartKey, indexEndKey, 0); err != nil {
 		t.Fatal(err)
 	} else if l := 3; len(kvs) != l {
 		t.Fatalf("expected %d key value pairs, but got %d", l, len(kvs))
@@ -194,7 +197,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 		t.Fatal(err)
 	}
 
-	if kvs, err := kvDB.Scan(indexStartKey, indexEndKey, 0); err != nil {
+	if kvs, err := kvDB.Scan(context.TODO(), indexStartKey, indexEndKey, 0); err != nil {
 		t.Fatal(err)
 	} else if l := 0; len(kvs) != l {
 		t.Fatalf("expected %d key value pairs, but got %d", l, len(kvs))
@@ -215,6 +218,7 @@ func TestDropTable(t *testing.T) {
 	params, _ := createTestServerParams()
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop()
+	ctx := context.TODO()
 
 	// Fix the column families so the key counts below don't change if the
 	// family heuristics are updated.
@@ -228,7 +232,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "kv")
 	nameKey := sqlbase.MakeNameMetadataKey(keys.MaxReservedDescID+1, "kv")
-	gr, err := kvDB.Get(nameKey)
+	gr, err := kvDB.Get(ctx, nameKey)
 
 	if err != nil {
 		t.Fatal(err)
@@ -251,7 +255,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	}
 
 	zoneKey := sqlbase.MakeZoneKey(tableDesc.ID)
-	if gr, err := kvDB.Get(zoneKey); err != nil {
+	if gr, err := kvDB.Get(ctx, zoneKey); err != nil {
 		t.Fatal(err)
 	} else if !gr.Exists() {
 		t.Fatalf("zone config entry not found")
@@ -260,7 +264,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	tablePrefix := keys.MakeTablePrefix(uint32(tableDesc.ID))
 	tableStartKey := roachpb.Key(tablePrefix)
 	tableEndKey := tableStartKey.PrefixEnd()
-	if kvs, err := kvDB.Scan(tableStartKey, tableEndKey, 0); err != nil {
+	if kvs, err := kvDB.Scan(ctx, tableStartKey, tableEndKey, 0); err != nil {
 		t.Fatal(err)
 	} else if l := 6; len(kvs) != l {
 		t.Fatalf("expected %d key value pairs, but got %d", l, len(kvs))
@@ -276,25 +280,25 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 		t.Fatalf("different error than expected: %v", err)
 	}
 
-	if kvs, err := kvDB.Scan(tableStartKey, tableEndKey, 0); err != nil {
+	if kvs, err := kvDB.Scan(ctx, tableStartKey, tableEndKey, 0); err != nil {
 		t.Fatal(err)
 	} else if l := 0; len(kvs) != l {
 		t.Fatalf("expected %d key value pairs, but got %d", l, len(kvs))
 	}
 
-	if gr, err := kvDB.Get(descKey); err != nil {
+	if gr, err := kvDB.Get(ctx, descKey); err != nil {
 		t.Fatal(err)
 	} else if gr.Exists() {
 		t.Fatalf("table descriptor still exists after the table is dropped")
 	}
 
-	if gr, err := kvDB.Get(nameKey); err != nil {
+	if gr, err := kvDB.Get(ctx, nameKey); err != nil {
 		t.Fatal(err)
 	} else if gr.Exists() {
 		t.Fatalf("table namekey still exists after the table is dropped")
 	}
 
-	if gr, err := kvDB.Get(zoneKey); err != nil {
+	if gr, err := kvDB.Get(ctx, zoneKey); err != nil {
 		t.Fatal(err)
 	} else if gr.Exists() {
 		t.Fatalf("zone config entry still exists after the table is dropped")

--- a/sql/drop_test.go
+++ b/sql/drop_test.go
@@ -106,7 +106,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	tablePrefix := keys.MakeTablePrefix(uint32(tbDesc.ID))
 	tableStartKey := roachpb.Key(tablePrefix)
 	tableEndKey := tableStartKey.PrefixEnd()
-	if kvs, err := kvDB.Scan(tableStartKey, tableEndKey, 0); err != nil {
+	if kvs, err := kvDB.Scan(ctx, tableStartKey, tableEndKey, 0); err != nil {
 		t.Fatal(err)
 	} else if l := 6; len(kvs) != l {
 		t.Fatalf("expected %d key value pairs, but got %d", l, len(kvs))
@@ -116,7 +116,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 		t.Fatal(err)
 	}
 
-	if kvs, err := kvDB.Scan(tableStartKey, tableEndKey, 0); err != nil {
+	if kvs, err := kvDB.Scan(ctx, tableStartKey, tableEndKey, 0); err != nil {
 		t.Fatal(err)
 	} else if l := 0; len(kvs) != l {
 		t.Fatalf("expected %d key value pairs, but got %d", l, len(kvs))
@@ -187,7 +187,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 
 	indexStartKey := roachpb.Key(indexPrefix)
 	indexEndKey := indexStartKey.PrefixEnd()
-	if kvs, err := kvDB.Scan(indexStartKey, indexEndKey, 0); err != nil {
+	if kvs, err := kvDB.Scan(context.TODO(), indexStartKey, indexEndKey, 0); err != nil {
 		t.Fatal(err)
 	} else if l := 3; len(kvs) != l {
 		t.Fatalf("expected %d key value pairs, but got %d", l, len(kvs))
@@ -197,7 +197,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 		t.Fatal(err)
 	}
 
-	if kvs, err := kvDB.Scan(indexStartKey, indexEndKey, 0); err != nil {
+	if kvs, err := kvDB.Scan(context.TODO(), indexStartKey, indexEndKey, 0); err != nil {
 		t.Fatal(err)
 	} else if l := 0; len(kvs) != l {
 		t.Fatalf("expected %d key value pairs, but got %d", l, len(kvs))
@@ -264,7 +264,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	tablePrefix := keys.MakeTablePrefix(uint32(tableDesc.ID))
 	tableStartKey := roachpb.Key(tablePrefix)
 	tableEndKey := tableStartKey.PrefixEnd()
-	if kvs, err := kvDB.Scan(tableStartKey, tableEndKey, 0); err != nil {
+	if kvs, err := kvDB.Scan(ctx, tableStartKey, tableEndKey, 0); err != nil {
 		t.Fatal(err)
 	} else if l := 6; len(kvs) != l {
 		t.Fatalf("expected %d key value pairs, but got %d", l, len(kvs))
@@ -280,7 +280,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 		t.Fatalf("different error than expected: %v", err)
 	}
 
-	if kvs, err := kvDB.Scan(tableStartKey, tableEndKey, 0); err != nil {
+	if kvs, err := kvDB.Scan(ctx, tableStartKey, tableEndKey, 0); err != nil {
 		t.Fatal(err)
 	} else if l := 0; len(kvs) != l {
 		t.Fatalf("expected %d key value pairs, but got %d", l, len(kvs))

--- a/sql/lease.go
+++ b/sql/lease.go
@@ -248,7 +248,7 @@ func (s LeaseStore) waitForOneVersion(tableID sqlbase.ID, retryOpts retry.Option
 		// Get the current version of the table descriptor non-transactionally.
 		//
 		// TODO(pmattis): Do an inconsistent read here?
-		if err := s.db.GetProto(descKey, desc); err != nil {
+		if err := s.db.GetProto(context.TODO(), descKey, desc); err != nil {
 			return 0, err
 		}
 		tableDesc = desc.GetTable()

--- a/sql/lease.go
+++ b/sql/lease.go
@@ -247,7 +247,7 @@ func (s LeaseStore) waitForOneVersion(tableID sqlbase.ID, retryOpts retry.Option
 		// Get the current version of the table descriptor non-transactionally.
 		//
 		// TODO(pmattis): Do an inconsistent read here?
-		if err := s.db.GetProto(descKey, desc); err != nil {
+		if err := s.db.GetProto(context.TODO(), descKey, desc); err != nil {
 			return 0, err
 		}
 		tableDesc = desc.GetTable()

--- a/sql/poc_test.go
+++ b/sql/poc_test.go
@@ -34,7 +34,7 @@ func TestPOC(t *testing.T) {
 	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop()
 
-	err := kvDB.Put("testkey", "testval")
+	err := kvDB.Put(context.TODO(), "testkey", "testval")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sql/poc_test.go
+++ b/sql/poc_test.go
@@ -19,6 +19,8 @@ package sql
 import (
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -36,7 +38,7 @@ func TestPOC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	kv, err := kvDB.Get("testkey")
+	kv, err := kvDB.Get(context.TODO(), "testkey")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sql/poc_test.go
+++ b/sql/poc_test.go
@@ -19,6 +19,8 @@ package sql
 import (
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -32,11 +34,11 @@ func TestPOC(t *testing.T) {
 	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop()
 
-	err := kvDB.Put("testkey", "testval")
+	err := kvDB.Put(context.TODO(), "testkey", "testval")
 	if err != nil {
 		t.Fatal(err)
 	}
-	kv, err := kvDB.Get("testkey")
+	kv, err := kvDB.Get(context.TODO(), "testkey")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sql/rename_test.go
+++ b/sql/rename_test.go
@@ -20,6 +20,8 @@ package sql
 import (
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/keys"
@@ -57,7 +59,7 @@ func TestRenameTable(t *testing.T) {
 	// Check the table descriptor.
 	desc := &sqlbase.Descriptor{}
 	tableDescKey := sqlbase.MakeDescMetadataKey(sqlbase.ID(tableCounter))
-	if err := kvDB.GetProto(tableDescKey, desc); err != nil {
+	if err := kvDB.GetProto(context.TODO(), tableDescKey, desc); err != nil {
 		t.Fatal(err)
 	}
 	tableDesc := desc.GetTable()
@@ -82,7 +84,7 @@ func TestRenameTable(t *testing.T) {
 	}
 
 	// Check the table descriptor again.
-	if err := kvDB.GetProto(tableDescKey, desc); err != nil {
+	if err := kvDB.GetProto(context.TODO(), tableDescKey, desc); err != nil {
 		t.Fatal(err)
 	}
 	tableDesc = desc.GetTable()

--- a/sql/schema_changer_test.go
+++ b/sql/schema_changer_test.go
@@ -522,7 +522,7 @@ func runSchemaChangeWithOperations(
 	// change operations.
 	tablePrefix := roachpb.Key(keys.MakeTablePrefix(uint32(tableDesc.ID)))
 	tableEnd := tablePrefix.PrefixEnd()
-	if kvs, err := kvDB.Scan(tablePrefix, tableEnd, 0); err != nil {
+	if kvs, err := kvDB.Scan(context.TODO(), tablePrefix, tableEnd, 0); err != nil {
 		t.Fatal(err)
 	} else if e := keyMultiple * (maxValue + numInserts + 1); len(kvs) != e {
 		t.Fatalf("expected %d key value pairs, but got %d", e, len(kvs))
@@ -585,7 +585,7 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 	tableEnd := tablePrefix.PrefixEnd()
 	// number of keys == 3 * number of rows; 2 column families and 1 index entry
 	// for each row.
-	if kvs, err := kvDB.Scan(tablePrefix, tableEnd, 0); err != nil {
+	if kvs, err := kvDB.Scan(context.TODO(), tablePrefix, tableEnd, 0); err != nil {
 		t.Fatal(err)
 	} else if e := 3 * (maxValue + 1); len(kvs) != e {
 		t.Fatalf("expected %d key value pairs, but got %d", e, len(kvs))
@@ -703,7 +703,7 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 	wg.Wait()
 
 	// Ensure that the table data has been deleted.
-	if kvs, err := kvDB.Scan(tablePrefix, tableEnd, 0); err != nil {
+	if kvs, err := kvDB.Scan(context.TODO(), tablePrefix, tableEnd, 0); err != nil {
 		t.Fatal(err)
 	} else if len(kvs) != 0 {
 		t.Fatalf("expected %d key value pairs, but got %d", 0, len(kvs))
@@ -884,7 +884,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	numGarbageValues := csql.IndexBackfillChunkSize
 	tablePrefix := roachpb.Key(keys.MakeTablePrefix(uint32(tableDesc.ID)))
 	tableEnd := tablePrefix.PrefixEnd()
-	if kvs, err := kvDB.Scan(tablePrefix, tableEnd, 0); err != nil {
+	if kvs, err := kvDB.Scan(context.TODO(), tablePrefix, tableEnd, 0); err != nil {
 		t.Fatal(err)
 	} else if e := 1*(maxValue+2) + numGarbageValues; len(kvs) != e {
 		t.Fatalf("expected %d key value pairs, but got %d", e, len(kvs))
@@ -904,7 +904,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 
 	// No garbage left behind.
 	numGarbageValues = 0
-	if kvs, err := kvDB.Scan(tablePrefix, tableEnd, 0); err != nil {
+	if kvs, err := kvDB.Scan(context.TODO(), tablePrefix, tableEnd, 0); err != nil {
 		t.Fatal(err)
 	} else if e := 1*(maxValue+2) + numGarbageValues; len(kvs) != e {
 		t.Fatalf("expected %d key value pairs, but got %d", e, len(kvs))
@@ -1089,7 +1089,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	// Check that the number of k-v pairs is accurate.
 	tablePrefix := roachpb.Key(keys.MakeTablePrefix(uint32(tableDesc.ID)))
 	tableEnd := tablePrefix.PrefixEnd()
-	if kvs, err := kvDB.Scan(tablePrefix, tableEnd, 0); err != nil {
+	if kvs, err := kvDB.Scan(context.TODO(), tablePrefix, tableEnd, 0); err != nil {
 		t.Fatal(err)
 	} else if e := 2 * (maxValue + 1); len(kvs) != e {
 		t.Fatalf("expected %d key value pairs, but got %d", e, len(kvs))

--- a/sql/schema_changer_test.go
+++ b/sql/schema_changer_test.go
@@ -209,6 +209,7 @@ INSERT INTO t.test VALUES ('a', 'b'), ('c', 'd');
 	expectedVersion++
 	tableDesc.UpVersion = true
 	if err := kvDB.Put(
+		context.TODO(),
 		sqlbase.MakeDescMetadataKey(tableDesc.ID),
 		sqlbase.WrapDescriptor(tableDesc),
 	); err != nil {
@@ -276,6 +277,7 @@ INSERT INTO t.test VALUES ('a', 'b'), ('c', 'd');
 		tableDesc.Mutations[0].Direction = direction
 		expectedVersion++
 		if err := kvDB.Put(
+			context.TODO(),
 			sqlbase.MakeDescMetadataKey(tableDesc.ID),
 			sqlbase.WrapDescriptor(tableDesc),
 		); err != nil {
@@ -520,7 +522,7 @@ func runSchemaChangeWithOperations(
 	// change operations.
 	tablePrefix := roachpb.Key(keys.MakeTablePrefix(uint32(tableDesc.ID)))
 	tableEnd := tablePrefix.PrefixEnd()
-	if kvs, err := kvDB.Scan(tablePrefix, tableEnd, 0); err != nil {
+	if kvs, err := kvDB.Scan(context.TODO(), tablePrefix, tableEnd, 0); err != nil {
 		t.Fatal(err)
 	} else if e := keyMultiple * (maxValue + numInserts + 1); len(kvs) != e {
 		t.Fatalf("expected %d key value pairs, but got %d", e, len(kvs))
@@ -583,7 +585,7 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 	tableEnd := tablePrefix.PrefixEnd()
 	// number of keys == 3 * number of rows; 2 column families and 1 index entry
 	// for each row.
-	if kvs, err := kvDB.Scan(tablePrefix, tableEnd, 0); err != nil {
+	if kvs, err := kvDB.Scan(context.TODO(), tablePrefix, tableEnd, 0); err != nil {
 		t.Fatal(err)
 	} else if e := 3 * (maxValue + 1); len(kvs) != e {
 		t.Fatalf("expected %d key value pairs, but got %d", e, len(kvs))
@@ -701,7 +703,7 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 	wg.Wait()
 
 	// Ensure that the table data has been deleted.
-	if kvs, err := kvDB.Scan(tablePrefix, tableEnd, 0); err != nil {
+	if kvs, err := kvDB.Scan(context.TODO(), tablePrefix, tableEnd, 0); err != nil {
 		t.Fatal(err)
 	} else if len(kvs) != 0 {
 		t.Fatalf("expected %d key value pairs, but got %d", 0, len(kvs))
@@ -882,7 +884,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	numGarbageValues := csql.IndexBackfillChunkSize
 	tablePrefix := roachpb.Key(keys.MakeTablePrefix(uint32(tableDesc.ID)))
 	tableEnd := tablePrefix.PrefixEnd()
-	if kvs, err := kvDB.Scan(tablePrefix, tableEnd, 0); err != nil {
+	if kvs, err := kvDB.Scan(context.TODO(), tablePrefix, tableEnd, 0); err != nil {
 		t.Fatal(err)
 	} else if e := 1*(maxValue+2) + numGarbageValues; len(kvs) != e {
 		t.Fatalf("expected %d key value pairs, but got %d", e, len(kvs))
@@ -902,7 +904,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 
 	// No garbage left behind.
 	numGarbageValues = 0
-	if kvs, err := kvDB.Scan(tablePrefix, tableEnd, 0); err != nil {
+	if kvs, err := kvDB.Scan(context.TODO(), tablePrefix, tableEnd, 0); err != nil {
 		t.Fatal(err)
 	} else if e := 1*(maxValue+2) + numGarbageValues; len(kvs) != e {
 		t.Fatalf("expected %d key value pairs, but got %d", e, len(kvs))
@@ -1087,7 +1089,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	// Check that the number of k-v pairs is accurate.
 	tablePrefix := roachpb.Key(keys.MakeTablePrefix(uint32(tableDesc.ID)))
 	tableEnd := tablePrefix.PrefixEnd()
-	if kvs, err := kvDB.Scan(tablePrefix, tableEnd, 0); err != nil {
+	if kvs, err := kvDB.Scan(context.TODO(), tablePrefix, tableEnd, 0); err != nil {
 		t.Fatal(err)
 	} else if e := 2 * (maxValue + 1); len(kvs) != e {
 		t.Fatalf("expected %d key value pairs, but got %d", e, len(kvs))

--- a/sql/schema_changer_test.go
+++ b/sql/schema_changer_test.go
@@ -209,6 +209,7 @@ INSERT INTO t.test VALUES ('a', 'b'), ('c', 'd');
 	expectedVersion++
 	tableDesc.UpVersion = true
 	if err := kvDB.Put(
+		context.TODO(),
 		sqlbase.MakeDescMetadataKey(tableDesc.ID),
 		sqlbase.WrapDescriptor(tableDesc),
 	); err != nil {
@@ -276,6 +277,7 @@ INSERT INTO t.test VALUES ('a', 'b'), ('c', 'd');
 		tableDesc.Mutations[0].Direction = direction
 		expectedVersion++
 		if err := kvDB.Put(
+			context.TODO(),
 			sqlbase.MakeDescMetadataKey(tableDesc.ID),
 			sqlbase.WrapDescriptor(tableDesc),
 		); err != nil {

--- a/sql/split.go
+++ b/sql/split.go
@@ -19,6 +19,8 @@ package sql
 import (
 	"strings"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/privilege"
@@ -136,7 +138,7 @@ func (n *splitNode) Start() error {
 	// TODO(radu): we should find a way to prevent this error, like waiting for
 	// whatever condition we need to wait.
 	for r := retry.Start(retry.Options{MaxRetries: maxSplitRetries}); ; {
-		err := n.p.execCfg.DB.AdminSplit(n.key)
+		err := n.p.execCfg.DB.AdminSplit(context.TODO(), n.key)
 		if err != nil &&
 			strings.Contains(err.Error(), storage.ErrMsgConflictUpdatingRangeDesc) &&
 			r.Next() {

--- a/sql/split_test.go
+++ b/sql/split_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -33,7 +35,7 @@ import (
 
 // getRangeKeys returns the end keys of all ranges.
 func getRangeKeys(db *client.DB) ([]roachpb.Key, error) {
-	rows, err := db.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
+	rows, err := db.Scan(context.TODO(), keys.Meta2Prefix, keys.MetaMax, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/sqlbase/structured_test.go
+++ b/sql/sqlbase/structured_test.go
@@ -801,7 +801,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			if err := v.SetProto(desc); err != nil {
 				t.Fatal(err)
 			}
-			if err := kvDB.Put(MakeDescMetadataKey(referencedDesc.ID), &v); err != nil {
+			if err := kvDB.Put(context.TODO(), MakeDescMetadataKey(referencedDesc.ID), &v); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/sql/sqlbase/structured_test.go
+++ b/sql/sqlbase/structured_test.go
@@ -801,7 +801,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			if err := v.SetProto(desc); err != nil {
 				t.Fatal(err)
 			}
-			if err := kvDB.Put(MakeDescMetadataKey(referencedDesc.ID), &v); err != nil {
+			if err := kvDB.Put(context.TODO(), MakeDescMetadataKey(referencedDesc.ID), &v); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -812,7 +812,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			t.Errorf("%d: expected \"%s\", but found \"%s\"", i, test.err, err.Error())
 		}
 		for _, referencedDesc := range test.referenced {
-			if err := kvDB.Del(MakeDescMetadataKey(referencedDesc.ID)); err != nil {
+			if err := kvDB.Del(context.TODO(), MakeDescMetadataKey(referencedDesc.ID)); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/sql/sqlbase/structured_test.go
+++ b/sql/sqlbase/structured_test.go
@@ -812,7 +812,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			t.Errorf("%d: expected \"%s\", but found \"%s\"", i, test.err, err.Error())
 		}
 		for _, referencedDesc := range test.referenced {
-			if err := kvDB.Del(MakeDescMetadataKey(referencedDesc.ID)); err != nil {
+			if err := kvDB.Del(context.TODO(), MakeDescMetadataKey(referencedDesc.ID)); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/sql/sqlbase/testutils.go
+++ b/sql/sqlbase/testutils.go
@@ -23,6 +23,8 @@ import (
 	"math/rand"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/sql/parser"
@@ -35,7 +37,7 @@ import (
 // GetTableDescriptor retrieves a table descriptor directly from the KV layer.
 func GetTableDescriptor(kvDB *client.DB, database string, table string) *TableDescriptor {
 	dbNameKey := MakeNameMetadataKey(keys.RootNamespaceID, database)
-	gr, err := kvDB.Get(dbNameKey)
+	gr, err := kvDB.Get(context.TODO(), dbNameKey)
 	if err != nil {
 		panic(err)
 	}
@@ -45,7 +47,7 @@ func GetTableDescriptor(kvDB *client.DB, database string, table string) *TableDe
 	dbDescID := ID(gr.ValueInt())
 
 	tableNameKey := MakeNameMetadataKey(dbDescID, table)
-	gr, err = kvDB.Get(tableNameKey)
+	gr, err = kvDB.Get(context.TODO(), tableNameKey)
 	if err != nil {
 		panic(err)
 	}
@@ -55,7 +57,7 @@ func GetTableDescriptor(kvDB *client.DB, database string, table string) *TableDe
 
 	descKey := MakeDescMetadataKey(ID(gr.ValueInt()))
 	desc := &Descriptor{}
-	if err := kvDB.GetProto(descKey, desc); err != nil {
+	if err := kvDB.GetProto(context.TODO(), descKey, desc); err != nil {
 		panic("proto missing")
 	}
 	return desc.GetTable()

--- a/sql/sqlbase/testutils.go
+++ b/sql/sqlbase/testutils.go
@@ -22,6 +22,8 @@ import (
 	"math/rand"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/sql/parser"
@@ -34,7 +36,7 @@ import (
 // GetTableDescriptor retrieves a table descriptor directly from the KV layer.
 func GetTableDescriptor(kvDB *client.DB, database string, table string) *TableDescriptor {
 	dbNameKey := MakeNameMetadataKey(keys.RootNamespaceID, database)
-	gr, err := kvDB.Get(dbNameKey)
+	gr, err := kvDB.Get(context.TODO(), dbNameKey)
 	if err != nil {
 		panic(err)
 	}
@@ -44,7 +46,7 @@ func GetTableDescriptor(kvDB *client.DB, database string, table string) *TableDe
 	dbDescID := ID(gr.ValueInt())
 
 	tableNameKey := MakeNameMetadataKey(dbDescID, table)
-	gr, err = kvDB.Get(tableNameKey)
+	gr, err = kvDB.Get(context.TODO(), tableNameKey)
 	if err != nil {
 		panic(err)
 	}
@@ -54,7 +56,7 @@ func GetTableDescriptor(kvDB *client.DB, database string, table string) *TableDe
 
 	descKey := MakeDescMetadataKey(ID(gr.ValueInt()))
 	desc := &Descriptor{}
-	if err := kvDB.GetProto(descKey, desc); err != nil {
+	if err := kvDB.GetProto(context.TODO(), descKey, desc); err != nil {
 		panic("proto missing")
 	}
 	return desc.GetTable()

--- a/storage/client_metrics_test.go
+++ b/storage/client_metrics_test.go
@@ -207,7 +207,7 @@ func TestStoreMetrics(t *testing.T) {
 
 	// Add some data to the "right" range.
 	dataKey := []byte("z")
-	if _, err := mtc.dbs[0].Inc(dataKey, 5); err != nil {
+	if _, err := mtc.dbs[0].Inc(context.TODO(), dataKey, 5); err != nil {
 		t.Fatal(err)
 	}
 	mtc.waitForValues(roachpb.Key("z"), []int64{5, 5, 5})

--- a/storage/client_replica_test.go
+++ b/storage/client_replica_test.go
@@ -227,7 +227,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 
 	// Put an initial value.
 	initVal := []byte("initVal")
-	err := store.DB().Put(key, initVal)
+	err := store.DB().Put(context.TODO(), key, initVal)
 	if err != nil {
 		t.Fatalf("failed to put: %s", err)
 	}

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -161,10 +161,10 @@ func TestStoreRangeSplitInsideRow(t *testing.T) {
 	col2Key := keys.MakeFamilyKey(append([]byte(nil), rowKey...), 2)
 
 	// We don't care about the value, so just store any old thing.
-	if err := store.DB().Put(col1Key, "column 1"); err != nil {
+	if err := store.DB().Put(context.TODO(), col1Key, "column 1"); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.DB().Put(col2Key, "column 2"); err != nil {
+	if err := store.DB().Put(context.TODO(), col2Key, "column 2"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/protoutil"
 	"github.com/cockroachdb/cockroach/util/randutil"
+	"github.com/cockroachdb/cockroach/util/syncutil"
 	"github.com/cockroachdb/cockroach/util/timeutil"
 	"github.com/cockroachdb/cockroach/util/tracing"
 	"github.com/coreos/etcd/raft/raftpb"
@@ -159,10 +160,10 @@ func TestStoreRangeSplitInsideRow(t *testing.T) {
 	col2Key := keys.MakeFamilyKey(append([]byte(nil), rowKey...), 2)
 
 	// We don't care about the value, so just store any old thing.
-	if err := store.DB().Put(col1Key, "column 1"); err != nil {
+	if err := store.DB().Put(context.TODO(), col1Key, "column 1"); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.DB().Put(col2Key, "column 2"); err != nil {
+	if err := store.DB().Put(context.TODO(), col2Key, "column 2"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -837,7 +838,7 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 		expKeys = append(expKeys, testutils.MakeKey(keys.Meta2Prefix, roachpb.RKeyMax))
 
 		util.SucceedsSoonDepth(1, t, func() error {
-			rows, err := store.DB().Scan(keys.Meta2Prefix, keys.MetaMax, 0)
+			rows, err := store.DB().Scan(context.TODO(), keys.Meta2Prefix, keys.MetaMax, 0)
 			if err != nil {
 				return err
 			}
@@ -1223,7 +1224,7 @@ func TestStoreSplitTimestampCacheDifferentLeaseHolder(t *testing.T) {
 
 	// Another client comes along at a higher timestamp, touching everything on
 	// the right of the (soon-to-be) split key.
-	if _, err := db.Scan(splitKey, rightKey, 0); err != nil {
+	if _, err := db.Scan(ctx, splitKey, rightKey, 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1588,27 +1589,28 @@ func TestStoreSplitBeginTxnPushMetaIntentRace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	splitKey := roachpb.RKey("a")
 
-	sCtx := storage.TestStoreContext()
-	sCtx.TestingKnobs.DisableSplitQueue = true
-	store, stopper, manual := createTestStoreWithContext(t, sCtx)
-	defer stopper.Stop()
-
-	// Advance the clock past the transaction cleanup expiration.
-	manual.Increment(storage.GetGCQueueTxnCleanupThreshold().Nanoseconds() + 1)
-
-	// First, create a split after addressing records.
-	args := adminSplitArgs(roachpb.KeyMin, keys.SystemPrefix)
-	if _, pErr := client.SendWrapped(rg1(store), nil, &args); pErr != nil {
-		t.Fatal(pErr)
+	var startMu struct {
+		syncutil.Mutex
+		time time.Time
 	}
 
-	startTime := timeutil.Now()
 	wroteMeta2 := make(chan struct{}, 1)
-	store.TestingKnobs().TestingCommandFilter = func(filterArgs storagebase.FilterArgs) *roachpb.Error {
+
+	sCtx := storage.TestStoreContext()
+	sCtx.TestingKnobs.DisableSplitQueue = true
+	sCtx.TestingKnobs.TestingCommandFilter = func(filterArgs storagebase.FilterArgs) *roachpb.Error {
+		startMu.Lock()
+		start := startMu.time
+		startMu.Unlock()
+
+		if start.IsZero() {
+			return nil
+		}
+
 		if _, ok := filterArgs.Req.(*roachpb.BeginTransactionRequest); ok {
 			// Return a node unavailable error for BeginTransaction request
 			// in the event we haven't waited 20ms.
-			if timeutil.Since(startTime) < 20*time.Millisecond {
+			if timeutil.Since(start) < 20*time.Millisecond {
 				return roachpb.NewError(&roachpb.NodeUnavailableError{})
 			}
 			if log.V(1) {
@@ -1623,6 +1625,22 @@ func TestStoreSplitBeginTxnPushMetaIntentRace(t *testing.T) {
 		}
 		return nil
 	}
+	store, stopper, manual := createTestStoreWithContext(t, sCtx)
+	defer stopper.Stop()
+
+	// Advance the clock past the transaction cleanup expiration.
+	manual.Increment(storage.GetGCQueueTxnCleanupThreshold().Nanoseconds() + 1)
+
+	// First, create a split after addressing records.
+	args := adminSplitArgs(roachpb.KeyMin, keys.SystemPrefix)
+	if _, pErr := client.SendWrapped(rg1(store), nil, &args); pErr != nil {
+		t.Fatal(pErr)
+	}
+
+	// Begin blocking BeginTransaction calls and signaling meta2 writes.
+	startMu.Lock()
+	startMu.time = timeutil.Now()
+	startMu.Unlock()
 
 	// Initiate split at splitKey in a goroutine.
 	doneSplit := make(chan *roachpb.Error, 1)

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -161,10 +161,10 @@ func TestStoreRangeSplitInsideRow(t *testing.T) {
 	col2Key := keys.MakeFamilyKey(append([]byte(nil), rowKey...), 2)
 
 	// We don't care about the value, so just store any old thing.
-	if err := store.DB().Put(col1Key, "column 1"); err != nil {
+	if err := store.DB().Put(context.TODO(), col1Key, "column 1"); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.DB().Put(col2Key, "column 2"); err != nil {
+	if err := store.DB().Put(context.TODO(), col2Key, "column 2"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -843,7 +843,7 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 		expKeys = append(expKeys, testutils.MakeKey(keys.Meta2Prefix, roachpb.RKeyMax))
 
 		util.SucceedsSoonDepth(1, t, func() error {
-			rows, err := store.DB().Scan(keys.Meta2Prefix, keys.MetaMax, 0)
+			rows, err := store.DB().Scan(context.TODO(), keys.Meta2Prefix, keys.MetaMax, 0)
 			if err != nil {
 				return err
 			}
@@ -1230,7 +1230,7 @@ func TestStoreSplitTimestampCacheDifferentLeaseHolder(t *testing.T) {
 
 	// Another client comes along at a higher timestamp, touching everything on
 	// the right of the (soon-to-be) split key.
-	if _, err := db.Scan(splitKey, rightKey, 0); err != nil {
+	if _, err := db.Scan(ctx, splitKey, rightKey, 0); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -843,7 +843,7 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 		expKeys = append(expKeys, testutils.MakeKey(keys.Meta2Prefix, roachpb.RKeyMax))
 
 		util.SucceedsSoonDepth(1, t, func() error {
-			rows, err := store.DB().Scan(keys.Meta2Prefix, keys.MetaMax, 0)
+			rows, err := store.DB().Scan(context.TODO(), keys.Meta2Prefix, keys.MetaMax, 0)
 			if err != nil {
 				return err
 			}
@@ -1230,7 +1230,7 @@ func TestStoreSplitTimestampCacheDifferentLeaseHolder(t *testing.T) {
 
 	// Another client comes along at a higher timestamp, touching everything on
 	// the right of the (soon-to-be) split key.
-	if _, err := db.Scan(splitKey, rightKey, 0); err != nil {
+	if _, err := db.Scan(ctx, splitKey, rightKey, 0); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/client_status_test.go
+++ b/storage/client_status_test.go
@@ -19,6 +19,8 @@ package storage_test
 import (
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util"
@@ -57,7 +59,7 @@ func TestComputeStatsForKeySpan(t *testing.T) {
 	// Create some keys across the ranges.
 	incKeys := []string{"b", "bb", "bbb", "d", "dd", "h"}
 	for _, k := range incKeys {
-		if _, err := mtc.dbs[0].Inc([]byte(k), 5); err != nil {
+		if _, err := mtc.dbs[0].Inc(context.TODO(), []byte(k), 5); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/storage/client_status_test.go
+++ b/storage/client_status_test.go
@@ -17,8 +17,9 @@
 package storage_test
 
 import (
-	"context"
 	"testing"
+
+	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/roachpb"

--- a/storage/client_status_test.go
+++ b/storage/client_status_test.go
@@ -17,6 +17,7 @@
 package storage_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/internal/client"
@@ -57,7 +58,7 @@ func TestComputeStatsForKeySpan(t *testing.T) {
 	// Create some keys across the ranges.
 	incKeys := []string{"b", "bb", "bbb", "d", "dd", "h"}
 	for _, k := range incKeys {
-		if _, err := mtc.dbs[0].Inc([]byte(k), 5); err != nil {
+		if _, err := mtc.dbs[0].Inc(context.TODO(), []byte(k), 5); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -864,7 +864,7 @@ func (m *multiTestContext) replicateRange(rangeID roachpb.RangeID, dests ...int)
 		// raft leader is guaranteed to have the updated version, but followers are
 		// not.
 		var desc roachpb.RangeDescriptor
-		if err := m.dbs[0].GetProto(keys.RangeDescriptorKey(startKey), &desc); err != nil {
+		if err := m.dbs[0].GetProto(context.TODO(), keys.RangeDescriptorKey(startKey), &desc); err != nil {
 			m.t.Fatal(err)
 		}
 
@@ -911,7 +911,7 @@ func (m *multiTestContext) unreplicateRange(rangeID roachpb.RangeID, dest int) {
 	startKey := m.findStartKeyLocked(rangeID)
 
 	var desc roachpb.RangeDescriptor
-	if err := m.dbs[0].GetProto(keys.RangeDescriptorKey(startKey), &desc); err != nil {
+	if err := m.dbs[0].GetProto(context.TODO(), keys.RangeDescriptorKey(startKey), &desc); err != nil {
 		m.t.Fatal(err)
 	}
 

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -812,7 +812,7 @@ func (m *multiTestContext) replicateRange(rangeID roachpb.RangeID, dests ...int)
 		// raft leader is guaranteed to have the updated version, but followers are
 		// not.
 		var desc roachpb.RangeDescriptor
-		if err := m.dbs[0].GetProto(keys.RangeDescriptorKey(startKey), &desc); err != nil {
+		if err := m.dbs[0].GetProto(context.TODO(), keys.RangeDescriptorKey(startKey), &desc); err != nil {
 			m.t.Fatal(err)
 		}
 
@@ -859,7 +859,7 @@ func (m *multiTestContext) unreplicateRange(rangeID roachpb.RangeID, dest int) {
 	startKey := m.findStartKeyLocked(rangeID)
 
 	var desc roachpb.RangeDescriptor
-	if err := m.dbs[0].GetProto(keys.RangeDescriptorKey(startKey), &desc); err != nil {
+	if err := m.dbs[0].GetProto(context.TODO(), keys.RangeDescriptorKey(startKey), &desc); err != nil {
 		m.t.Fatal(err)
 	}
 

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -313,7 +313,11 @@ func (gcq *gcQueue) process(
 		return err
 	}
 
+	// We have the "luxury" of having two relevant contexts here: One which
+	// goes to the queue's EventLog and one which goes to tracing for this
+	// operation.
 	log.Infof(gcq.ctx, "completed with stats %+v", info)
+	log.Tracef(ctx, "completed with stats %+v", info)
 
 	var ba roachpb.BatchRequest
 	var gcArgs roachpb.GCRequest
@@ -332,6 +336,7 @@ func (gcq *gcQueue) process(
 	ba.Timestamp = now
 	ba.Add(&gcArgs)
 	if _, pErr := repl.Send(ctx, ba); pErr != nil {
+		log.ErrEvent(ctx, pErr.String())
 		return pErr.GoError()
 	}
 	return nil

--- a/storage/id_alloc.go
+++ b/storage/id_alloc.go
@@ -95,7 +95,7 @@ func (ia *idAllocator) start() {
 				for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
 					idKey := ia.idKey.Load().(roachpb.Key)
 					if err := ia.stopper.RunTask(func() {
-						res, err = ia.db.Inc(idKey, int64(ia.blockSize))
+						res, err = ia.db.Inc(context.TODO(), idKey, int64(ia.blockSize))
 					}); err != nil {
 						log.Warning(context.TODO(), err)
 						return

--- a/storage/log_test.go
+++ b/storage/log_test.go
@@ -60,7 +60,7 @@ func TestLogSplits(t *testing.T) {
 	}
 
 	// Generate an explicit split event.
-	if err := kvDB.AdminSplit("splitkey"); err != nil {
+	if err := kvDB.AdminSplit(context.TODO(), "splitkey"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/log_test.go
+++ b/storage/log_test.go
@@ -138,7 +138,7 @@ func TestLogRebalances(t *testing.T) {
 	// Use a client to get the RangeDescriptor for the first range. We will use
 	// this range's information to log fake rebalance events.
 	desc := &roachpb.RangeDescriptor{}
-	if err := db.GetProto(keys.RangeDescriptorKey(roachpb.RKeyMin), desc); err != nil {
+	if err := db.GetProto(context.TODO(), keys.RangeDescriptorKey(roachpb.RKeyMin), desc); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/log_test.go
+++ b/storage/log_test.go
@@ -60,7 +60,7 @@ func TestLogSplits(t *testing.T) {
 	}
 
 	// Generate an explicit split event.
-	if err := kvDB.AdminSplit("splitkey"); err != nil {
+	if err := kvDB.AdminSplit(context.TODO(), "splitkey"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -138,7 +138,7 @@ func TestLogRebalances(t *testing.T) {
 	// Use a client to get the RangeDescriptor for the first range. We will use
 	// this range's information to log fake rebalance events.
 	desc := &roachpb.RangeDescriptor{}
-	if err := db.GetProto(keys.RangeDescriptorKey(roachpb.RKeyMin), desc); err != nil {
+	if err := db.GetProto(context.TODO(), keys.RangeDescriptorKey(roachpb.RKeyMin), desc); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1931,8 +1931,7 @@ func (r *Replica) CheckConsistency(
 			if bytes.Compare(key, keys.LocalMax) < 0 {
 				key = keys.LocalMax
 			}
-			if err := r.store.db.CheckConsistency(
-				key, endKey, true /* withDiff */); err != nil {
+			if err := r.store.db.CheckConsistency(ctx, key, endKey, true /* withDiff */); err != nil {
 				log.Error(ctx, errors.Wrap(err, "could not rerun consistency check"))
 			}
 		}); err != nil {

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1910,8 +1910,7 @@ func (r *Replica) CheckConsistency(
 			if bytes.Compare(key, keys.LocalMax) < 0 {
 				key = keys.LocalMax
 			}
-			if err := r.store.db.CheckConsistency(
-				key, endKey, true /* withDiff */); err != nil {
+			if err := r.store.db.CheckConsistency(ctx, key, endKey, true /* withDiff */); err != nil {
 				log.Error(ctx, errors.Wrap(err, "could not rerun consistency check"))
 			}
 		}); err != nil {

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -3431,7 +3431,7 @@ func TestEndTransactionDirectGCFailure(t *testing.T) {
 	util.SucceedsSoon(t, func() error {
 		if atomic.LoadInt64(&count) == 0 {
 			return errors.Errorf("intent resolution not attempted yet")
-		} else if err := tc.store.DB().Put("panama", "banana"); err != nil {
+		} else if err := tc.store.DB().Put(context.TODO(), "panama", "banana"); err != nil {
 			return err
 		}
 		return nil

--- a/storage/replica_trigger.go
+++ b/storage/replica_trigger.go
@@ -19,6 +19,8 @@ package storage
 import (
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/util/hlc"
@@ -26,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/util/timeutil"
 	"github.com/coreos/etcd/raft"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // postCommitSplit is emitted when a Replica commits a split trigger and

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -98,7 +98,7 @@ func (sq *splitQueue) process(
 	if len(splitKeys) > 0 {
 		log.Infof(ctx, "splitting at keys %v", splitKeys)
 		for _, splitKey := range splitKeys {
-			if err := sq.db.AdminSplit(splitKey.AsRawKey()); err != nil {
+			if err := sq.db.AdminSplit(ctx, splitKey.AsRawKey()); err != nil {
 				return errors.Errorf("unable to split %s at key %q: %s", r, splitKey, err)
 			}
 		}

--- a/testutils/testcluster/testcluster.go
+++ b/testutils/testcluster/testcluster.go
@@ -402,7 +402,8 @@ func (tc *TestCluster) RemoveReplicas(
 func (tc *TestCluster) TransferRangeLease(
 	rangeDesc *roachpb.RangeDescriptor, dest ReplicationTarget,
 ) error {
-	err := tc.Servers[0].DB().AdminTransferLease(rangeDesc.StartKey.AsRawKey(), dest.StoreID)
+	err := tc.Servers[0].DB().AdminTransferLease(context.TODO(),
+		rangeDesc.StartKey.AsRawKey(), dest.StoreID)
 	if err != nil {
 		return errors.Wrapf(err, "%q: transfer lease unexpected error", rangeDesc.StartKey)
 	}

--- a/testutils/testcluster/testcluster.go
+++ b/testutils/testcluster/testcluster.go
@@ -269,7 +269,7 @@ func (tc *TestCluster) SplitRange(
 
 	leftRangeDesc := new(roachpb.RangeDescriptor)
 	rightRangeDesc := new(roachpb.RangeDescriptor)
-	if err := tc.Servers[0].DB().GetProto(
+	if err := tc.Servers[0].DB().GetProto(context.TODO(),
 		keys.RangeDescriptorKey(origRangeDesc.StartKey), leftRangeDesc); err != nil {
 		return nil, nil, errors.Wrap(err, "could not look up left-hand side descriptor")
 	}
@@ -277,7 +277,7 @@ func (tc *TestCluster) SplitRange(
 	// adjusted slightly so we don't split in the middle of SQL rows). Update it
 	// to the real point.
 	splitRKey = leftRangeDesc.EndKey
-	if err := tc.Servers[0].DB().GetProto(
+	if err := tc.Servers[0].DB().GetProto(context.TODO(),
 		keys.RangeDescriptorKey(splitRKey), rightRangeDesc); err != nil {
 		return nil, nil, errors.Wrap(err, "could not look up right-hand side descriptor")
 	}
@@ -314,7 +314,7 @@ func (tc *TestCluster) changeReplicas(
 		// the previous ChangeReplicas call. By the time ChangeReplicas returns the
 		// raft leader is guaranteed to have the updated version, but followers are
 		// not.
-		if err := tc.Servers[0].DB().GetProto(
+		if err := tc.Servers[0].DB().GetProto(context.TODO(),
 			keys.RangeDescriptorKey(startKey), rangeDesc); err != nil {
 			return nil, err
 		}
@@ -340,7 +340,7 @@ func (tc *TestCluster) changeReplicas(
 			return nil, err
 		}
 	}
-	if err := tc.Servers[0].DB().GetProto(
+	if err := tc.Servers[0].DB().GetProto(context.TODO(),
 		keys.RangeDescriptorKey(startKey), rangeDesc); err != nil {
 		return nil, err
 	}
@@ -402,7 +402,8 @@ func (tc *TestCluster) RemoveReplicas(
 func (tc *TestCluster) TransferRangeLease(
 	rangeDesc *roachpb.RangeDescriptor, dest ReplicationTarget,
 ) error {
-	err := tc.Servers[0].DB().AdminTransferLease(rangeDesc.StartKey.AsRawKey(), dest.StoreID)
+	err := tc.Servers[0].DB().AdminTransferLease(context.TODO(),
+		rangeDesc.StartKey.AsRawKey(), dest.StoreID)
 	if err != nil {
 		return errors.Wrapf(err, "%q: transfer lease unexpected error", rangeDesc.StartKey)
 	}

--- a/testutils/testcluster/testcluster.go
+++ b/testutils/testcluster/testcluster.go
@@ -262,7 +262,7 @@ func (tc *TestCluster) SplitRange(
 
 	leftRangeDesc := new(roachpb.RangeDescriptor)
 	rightRangeDesc := new(roachpb.RangeDescriptor)
-	if err := tc.Servers[0].DB().GetProto(
+	if err := tc.Servers[0].DB().GetProto(context.TODO(),
 		keys.RangeDescriptorKey(origRangeDesc.StartKey), leftRangeDesc); err != nil {
 		return nil, nil, errors.Wrap(err, "could not look up left-hand side descriptor")
 	}
@@ -270,7 +270,7 @@ func (tc *TestCluster) SplitRange(
 	// adjusted slightly so we don't split in the middle of SQL rows). Update it
 	// to the real point.
 	splitRKey = leftRangeDesc.EndKey
-	if err := tc.Servers[0].DB().GetProto(
+	if err := tc.Servers[0].DB().GetProto(context.TODO(),
 		keys.RangeDescriptorKey(splitRKey), rightRangeDesc); err != nil {
 		return nil, nil, errors.Wrap(err, "could not look up right-hand side descriptor")
 	}
@@ -307,7 +307,7 @@ func (tc *TestCluster) changeReplicas(
 		// the previous ChangeReplicas call. By the time ChangeReplicas returns the
 		// raft leader is guaranteed to have the updated version, but followers are
 		// not.
-		if err := tc.Servers[0].DB().GetProto(
+		if err := tc.Servers[0].DB().GetProto(context.TODO(),
 			keys.RangeDescriptorKey(startKey), rangeDesc); err != nil {
 			return nil, err
 		}
@@ -333,7 +333,7 @@ func (tc *TestCluster) changeReplicas(
 			return nil, err
 		}
 	}
-	if err := tc.Servers[0].DB().GetProto(
+	if err := tc.Servers[0].DB().GetProto(context.TODO(),
 		keys.RangeDescriptorKey(startKey), rangeDesc); err != nil {
 		return nil, err
 	}
@@ -395,7 +395,8 @@ func (tc *TestCluster) RemoveReplicas(
 func (tc *TestCluster) TransferRangeLease(
 	rangeDesc *roachpb.RangeDescriptor, dest ReplicationTarget,
 ) error {
-	err := tc.Servers[0].DB().AdminTransferLease(rangeDesc.StartKey.AsRawKey(), dest.StoreID)
+	err := tc.Servers[0].DB().AdminTransferLease(context.TODO(),
+		rangeDesc.StartKey.AsRawKey(), dest.StoreID)
 	if err != nil {
 		return errors.Wrapf(err, "%q: transfer lease unexpected error", rangeDesc.StartKey)
 	}

--- a/testutils/testcluster/testcluster.go
+++ b/testutils/testcluster/testcluster.go
@@ -269,7 +269,7 @@ func (tc *TestCluster) SplitRange(
 
 	leftRangeDesc := new(roachpb.RangeDescriptor)
 	rightRangeDesc := new(roachpb.RangeDescriptor)
-	if err := tc.Servers[0].DB().GetProto(
+	if err := tc.Servers[0].DB().GetProto(context.TODO(),
 		keys.RangeDescriptorKey(origRangeDesc.StartKey), leftRangeDesc); err != nil {
 		return nil, nil, errors.Wrap(err, "could not look up left-hand side descriptor")
 	}
@@ -277,7 +277,7 @@ func (tc *TestCluster) SplitRange(
 	// adjusted slightly so we don't split in the middle of SQL rows). Update it
 	// to the real point.
 	splitRKey = leftRangeDesc.EndKey
-	if err := tc.Servers[0].DB().GetProto(
+	if err := tc.Servers[0].DB().GetProto(context.TODO(),
 		keys.RangeDescriptorKey(splitRKey), rightRangeDesc); err != nil {
 		return nil, nil, errors.Wrap(err, "could not look up right-hand side descriptor")
 	}
@@ -314,7 +314,7 @@ func (tc *TestCluster) changeReplicas(
 		// the previous ChangeReplicas call. By the time ChangeReplicas returns the
 		// raft leader is guaranteed to have the updated version, but followers are
 		// not.
-		if err := tc.Servers[0].DB().GetProto(
+		if err := tc.Servers[0].DB().GetProto(context.TODO(),
 			keys.RangeDescriptorKey(startKey), rangeDesc); err != nil {
 			return nil, err
 		}
@@ -340,7 +340,7 @@ func (tc *TestCluster) changeReplicas(
 			return nil, err
 		}
 	}
-	if err := tc.Servers[0].DB().GetProto(
+	if err := tc.Servers[0].DB().GetProto(context.TODO(),
 		keys.RangeDescriptorKey(startKey), rangeDesc); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixed a few trivial conflicts related to #9283.

``` diff
diff --cc server/status_test.go
index 8be3b96,71f5c21..ec435e6
--- a/server/status_test.go
+++ b/server/status_test.go
@@@ -415,7 -488,7 +415,7 @@@ func TestRangesResponse(t *testing.T) 
    defer ts.Stopper().Stop()

    // Perform a scan to ensure that all the raft groups are initialized.
-   if _, err := ts.db.Scan(keys.LocalMax, roachpb.KeyMax, 0); err != nil {
 -  if _, err := ts.(*TestServer).db.Scan(context.TODO(), keys.LocalMax, roachpb.KeyMax, 0); err != nil {
++  if _, err := ts.db.Scan(context.TODO(), keys.LocalMax, roachpb.KeyMax, 0); err != nil {
        t.Fatal(err)
    }

diff --cc sql/drop_test.go
index 5495a9b,0c45f91..b3115e7
--- a/sql/drop_test.go
+++ b/sql/drop_test.go
@@@ -17,16 -17,13 +17,18 @@@
  package sql_test

  import (
 +  "bytes"
 +  gosql "database/sql"
 +  "fmt"
    "testing"

+   "golang.org/x/net/context"
+ 
    "github.com/cockroachdb/cockroach/config"
 +  "github.com/cockroachdb/cockroach/internal/client"
    "github.com/cockroachdb/cockroach/keys"
    "github.com/cockroachdb/cockroach/roachpb"
 +  "github.com/cockroachdb/cockroach/sql"
    "github.com/cockroachdb/cockroach/sql/sqlbase"
    "github.com/cockroachdb/cockroach/testutils"
    "github.com/cockroachdb/cockroach/testutils/serverutils"
@@@ -161,21 -159,17 +164,21 @@@ INSERT INTO t.kv VALUES ('c', 'e'), ('a
    }
  }

 -func TestDropIndex(t *testing.T) {
 -  defer leaktest.AfterTest(t)()
 -  params, _ := createTestServerParams()
 -  s, sqlDB, kvDB := serverutils.StartServer(t, params)
 -  defer s.Stopper().Stop()
 +func checkKeyCount(t *testing.T, kvDB *client.DB, prefix roachpb.Key, numKeys int) {
-   if kvs, err := kvDB.Scan(prefix, prefix.PrefixEnd(), 0); err != nil {
++  if kvs, err := kvDB.Scan(context.TODO(), prefix, prefix.PrefixEnd(), 0); err != nil {
 +      t.Fatal(err)
 +  } else if l := numKeys; len(kvs) != l {
 +      t.Fatalf("expected %d key value pairs, but got %d", l, len(kvs))
 +  }
 +}

 +func createKVTable(t *testing.T, sqlDB *gosql.DB, numRows int) {
 +  // Fix the column families so the key counts don't change if the family
 +  // heuristics are updated.
    if _, err := sqlDB.Exec(`
  CREATE DATABASE t;
 -CREATE TABLE t.kv (k CHAR PRIMARY KEY, v CHAR);
 +CREATE TABLE t.kv (k INT PRIMARY KEY, v INT, FAMILY (k), FAMILY (v));
  CREATE INDEX foo on t.kv (v);
 -INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
  `); err != nil {
        t.Fatal(err)
    }
@@@ -296,9 -218,17 +299,10 @@@ func TestDropTable(t *testing.T) 
    params, _ := createTestServerParams()
    s, sqlDB, kvDB := serverutils.StartServer(t, params)
    defer s.Stopper().Stop()
+   ctx := context.TODO()

 -  // Fix the column families so the key counts below don't change if the
 -  // family heuristics are updated.
 -  if _, err := sqlDB.Exec(`
 -CREATE DATABASE t;
 -CREATE TABLE t.kv (k CHAR PRIMARY KEY, v CHAR, FAMILY (k), FAMILY (v));
 -INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 -`); err != nil {
 -      t.Fatal(err)
 -  }
 +  numRows := 2*sql.TableTruncateChunkSize + 1
 +  createKVTable(t, sqlDB, numRows)

    tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "kv")
    nameKey := sqlbase.MakeNameMetadataKey(keys.MaxReservedDescID+1, "kv")
@@@ -345,7 -280,13 +349,7 @@@
        t.Fatalf("different error than expected: %v", err)
    }

-   if gr, err := kvDB.Get(descKey); err != nil {
 -  if kvs, err := kvDB.Scan(ctx, tableStartKey, tableEndKey, 0); err != nil {
 -      t.Fatal(err)
 -  } else if l := 0; len(kvs) != l {
 -      t.Fatalf("expected %d key value pairs, but got %d", l, len(kvs))
 -  }
 -
+   if gr, err := kvDB.Get(ctx, descKey); err != nil {
        t.Fatal(err)
    } else if gr.Exists() {
        t.Fatalf("table descriptor still exists after the table is dropped")
diff --cc sql/split.go
index 78a318a,0000000..16064f4
mode 100644,000000..100644
--- a/sql/split.go
+++ b/sql/split.go
@@@ -1,201 -1,0 +1,203 @@@
 +// Copyright 2016 The Cockroach Authors.
 +//
 +// Licensed under the Apache License, Version 2.0 (the "License");
 +// you may not use this file except in compliance with the License.
 +// You may obtain a copy of the License at
 +//
 +//     http://www.apache.org/licenses/LICENSE-2.0
 +//
 +// Unless required by applicable law or agreed to in writing, software
 +// distributed under the License is distributed on an "AS IS" BASIS,
 +// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 +// implied. See the License for the specific language governing
 +// permissions and limitations under the License.
 +//
 +// Author: Matt Jibson
 +
 +package sql
 +
 +import (
 +  "strings"
 +
++  "golang.org/x/net/context"
++
 +  "github.com/cockroachdb/cockroach/keys"
 +  "github.com/cockroachdb/cockroach/sql/parser"
 +  "github.com/cockroachdb/cockroach/sql/privilege"
 +  "github.com/cockroachdb/cockroach/sql/sqlbase"
 +  "github.com/cockroachdb/cockroach/storage"
 +  "github.com/cockroachdb/cockroach/util/retry"
 +  "github.com/pkg/errors"
 +)
 +
 +const maxSplitRetries = 4
 +
 +// Split executes a KV split.
 +// Privileges: INSERT on table.
 +func (p *planner) Split(n *parser.Split) (planNode, error) {
 +  var tableName parser.NormalizableTableName
 +  if n.Index == nil {
 +      tableName = n.Table
 +  } else {
 +      tableName = n.Index.Table
 +  }
 +
 +  // Check that the table exists and that the user has permission.
 +  tn, err := tableName.NormalizeWithDatabaseName(p.session.Database)
 +  if err != nil {
 +      return nil, err
 +  }
 +  tableDesc, err := p.getTableDesc(tn)
 +  if err != nil {
 +      return nil, err
 +  }
 +  if tableDesc == nil {
 +      return nil, sqlbase.NewUndefinedTableError(tn.String())
 +  }
 +  if err := p.checkPrivilege(tableDesc, privilege.INSERT); err != nil {
 +      return nil, err
 +  }
 +
 +  // Determine which index to use.
 +  var index sqlbase.IndexDescriptor
 +  if n.Index == nil {
 +      index = tableDesc.PrimaryIndex
 +  } else {
 +      normIdxName := sqlbase.NormalizeName(n.Index.Index)
 +      status, i, err := tableDesc.FindIndexByNormalizedName(normIdxName)
 +      if err != nil {
 +          return nil, err
 +      }
 +      if status != sqlbase.DescriptorActive {
 +          return nil, errors.Errorf("unknown index %s", normIdxName)
 +      }
 +      index = tableDesc.Indexes[i]
 +  }
 +
 +  // Determine how to use the remaining argument expressions.
 +  if len(index.ColumnIDs) != len(n.Exprs) {
 +      return nil, errors.Errorf("expected %d expressions, got %d", len(index.ColumnIDs), len(n.Exprs))
 +  }
 +  typedExprs := make([]parser.TypedExpr, len(n.Exprs))
 +  for i, expr := range n.Exprs {
 +      c, err := tableDesc.FindColumnByID(index.ColumnIDs[i])
 +      if err != nil {
 +          return nil, err
 +      }
 +      desired := c.Type.ToDatumType()
 +      typedExpr, err := p.analyzeExpr(expr, nil, nil, desired, true, "SPLIT AT")
 +      if err != nil {
 +          return nil, err
 +      }
 +      typedExprs[i] = typedExpr
 +  }
 +
 +  return &splitNode{
 +      p:         p,
 +      tableDesc: tableDesc,
 +      index:     index,
 +      exprs:     typedExprs,
 +  }, nil
 +}
 +
 +type splitNode struct {
 +  p         *planner
 +  tableDesc *sqlbase.TableDescriptor
 +  index     sqlbase.IndexDescriptor
 +  exprs     []parser.TypedExpr
 +  key       []byte
 +}
 +
 +func (n *splitNode) Start() error {
 +  values := make([]parser.Datum, len(n.exprs))
 +  colMap := make(map[sqlbase.ColumnID]int)
 +  for i, e := range n.exprs {
 +      if err := n.p.startSubqueryPlans(e); err != nil {
 +          return err
 +      }
 +      val, err := e.Eval(&n.p.evalCtx)
 +      if err != nil {
 +          return err
 +      }
 +      values[i] = val
 +      c, err := n.tableDesc.FindColumnByID(n.index.ColumnIDs[i])
 +      if err != nil {
 +          return err
 +      }
 +      colMap[c.ID] = i
 +  }
 +  prefix := sqlbase.MakeIndexKeyPrefix(n.tableDesc, n.index.ID)
 +  key, _, err := sqlbase.EncodeIndexKey(n.tableDesc, &n.index, colMap, values, prefix)
 +  if err != nil {
 +      return err
 +  }
 +  n.key = keys.MakeRowSentinelKey(key)
 +
 +  // We retry a few times if we hit a "conflict updating range descriptors"
 +  // error; this can happen if we try to split right after table creation.
 +  // TODO(radu): we should find a way to prevent this error, like waiting for
 +  // whatever condition we need to wait.
 +  for r := retry.Start(retry.Options{MaxRetries: maxSplitRetries}); ; {
-       err := n.p.execCfg.DB.AdminSplit(n.key)
++      err := n.p.execCfg.DB.AdminSplit(context.TODO(), n.key)
 +      if err != nil &&
 +          strings.Contains(err.Error(), storage.ErrMsgConflictUpdatingRangeDesc) &&
 +          r.Next() {
 +          continue
 +      }
 +      return err
 +  }
 +}
 +
 +func (n *splitNode) expandPlan() error {
 +  for _, e := range n.exprs {
 +      if err := n.p.expandSubqueryPlans(e); err != nil {
 +          return err
 +      }
 +  }
 +  return nil
 +}
 +
 +func (n *splitNode) Next() (bool, error) {
 +  return n.key != nil, nil
 +}
 +
 +func (n *splitNode) Values() parser.DTuple {
 +  k := n.key
 +  n.key = nil
 +  return parser.DTuple{
 +      parser.NewDBytes(parser.DBytes(k)),
 +      parser.NewDString(keys.PrettyPrint(k)),
 +  }
 +}
 +
 +func (*splitNode) Columns() ResultColumns {
 +  return ResultColumns{
 +      {
 +          Name: "key",
 +          Typ:  parser.TypeBytes,
 +      },
 +      {
 +          Name: "pretty",
 +          Typ:  parser.TypeString,
 +      },
 +  }
 +}
 +
 +func (*splitNode) Close()                              {}
 +func (*splitNode) Ordering() orderingInfo              { return orderingInfo{} }
 +func (*splitNode) ExplainTypes(_ func(string, string)) {}
 +func (*splitNode) SetLimitHint(_ int64, _ bool)        {}
 +func (*splitNode) MarkDebug(_ explainMode)             {}
 +
 +func (*splitNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
 +  return "empty", "-", nil
 +}
 +
 +func (n *splitNode) DebugValues() debugValues {
 +  return debugValues{
 +      rowIdx: 0,
 +      key:    "",
 +      value:  parser.DNull.String(),
 +      output: debugValueRow,
 +  }
 +}
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9408)

<!-- Reviewable:end -->
