### PR TITLE
all: remove Trace/Tracef/VTracef

### DIFF
--- a/cli/start.go
+++ b/cli/start.go
@@ -334,7 +334,7 @@ func runStart(_ *cobra.Command, args []string) error {
 	if err := os.MkdirAll(logDir, 0755); err != nil {
 		return err
 	}
-	log.Tracef(startCtx, "created log directory %s", logDir)
+	log.Eventf(startCtx, "created log directory %s", logDir)
 
 	// We log build information to stdout (for the short summary), but also
 	// to stderr to coincide with the full logs.
@@ -349,7 +349,7 @@ func runStart(_ *cobra.Command, args []string) error {
 	serverCtx.User = security.NodeUser
 
 	stopper := initBacktrace(logDir)
-	log.Trace(startCtx, "initialized profiles")
+	log.Event(startCtx, "initialized profiles")
 
 	if err := serverCtx.InitStores(stopper); err != nil {
 		return fmt.Errorf("failed to initialize stores: %s", err)

--- a/internal/client/txn.go
+++ b/internal/client/txn.go
@@ -392,7 +392,7 @@ func (txn *Txn) GetDeadline() *hlc.Timestamp {
 // The txn's status is set to ABORTED in case of error. txn is
 // considered finalized and cannot be used to send any more commands.
 func (txn *Txn) Rollback() error {
-	log.VTracef(2, txn.Context, "rolling back transaction")
+	log.VEventf(2, txn.Context, "rolling back transaction")
 	err := txn.sendEndTxnReq(false /* commit */, nil)
 	txn.finalized = true
 	return err
@@ -512,7 +512,7 @@ func (txn *Txn) Exec(
 		if err == nil && opt.AutoCommit && txn.Proto.Status == roachpb.PENDING {
 			// fn succeeded, but didn't commit.
 			err = txn.Commit()
-			log.Tracef(txn.Context, "client.Txn did AutoCommit. err: %v\ntxn: %+v", err, txn.Proto)
+			log.Eventf(txn.Context, "client.Txn did AutoCommit. err: %v\ntxn: %+v", err, txn.Proto)
 			if err != nil {
 				if _, retryable := err.(*roachpb.RetryableTxnError); !retryable {
 					// We can't retry, so let the caller know we tried to
@@ -539,7 +539,7 @@ func (txn *Txn) Exec(
 				r.Reset()
 			}
 		}
-		log.VTracef(2, txn.Context, "automatically retrying transaction: %s because of error: %s",
+		log.VEventf(2, txn.Context, "automatically retrying transaction: %s because of error: %s",
 			txn.DebugName(), err)
 	}
 

--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -238,9 +238,9 @@ func (et *evictionToken) EvictAndReplace(ctx context.Context, newDescs ...roachp
 		if err == nil {
 			if len(newDescs) > 0 {
 				err = et.doReplace(newDescs...)
-				log.Tracef(ctx, "evicting cached range descriptor with %d replacements", len(newDescs))
+				log.Eventf(ctx, "evicting cached range descriptor with %d replacements", len(newDescs))
 			} else {
-				log.Trace(ctx, "evicting cached range descriptor")
+				log.Event(ctx, "evicting cached range descriptor")
 			}
 		}
 	})
@@ -304,7 +304,7 @@ func (rdc *rangeDescriptorCache) lookupRangeDescriptorInternal(
 		returnToken := rdc.makeEvictionToken(desc, func() error {
 			return rdc.evictCachedRangeDescriptorLocked(key, desc, useReverseScan)
 		})
-		log.Trace(ctx, "looked up range descriptor from cache")
+		log.Event(ctx, "looked up range descriptor from cache")
 		return desc, returnToken, nil
 	}
 
@@ -326,7 +326,7 @@ func (rdc *rangeDescriptorCache) lookupRangeDescriptorInternal(
 		doneWg()
 
 		res = <-resC
-		log.Trace(ctx, "looked up range descriptor with shared request")
+		log.Event(ctx, "looked up range descriptor with shared request")
 	} else {
 		rdc.lookupRequests.inflight[requestKey] = req
 		rdc.lookupRequests.Unlock()
@@ -392,7 +392,7 @@ func (rdc *rangeDescriptorCache) lookupRangeDescriptorInternal(
 		delete(rdc.lookupRequests.inflight, requestKey)
 		rdc.lookupRequests.Unlock()
 		rdc.rangeCache.Unlock()
-		log.Trace(ctx, "looked up range descriptor")
+		log.Event(ctx, "looked up range descriptor")
 	}
 
 	// It rarely may be possible that we got grouped in with the wrong

--- a/kv/transport.go
+++ b/kv/transport.go
@@ -258,7 +258,7 @@ func (s *senderTransport) SendNext(done chan<- BatchCall) {
 	sp := s.tracer.StartSpan("node")
 	defer sp.Finish()
 	ctx := opentracing.ContextWithSpan(context.Background(), sp)
-	log.Trace(ctx, s.args.String())
+	log.Event(ctx, s.args.String())
 	br, pErr := s.sender.Send(ctx, s.args)
 	if br == nil {
 		br = &roachpb.BatchResponse{}
@@ -268,7 +268,7 @@ func (s *senderTransport) SendNext(done chan<- BatchCall) {
 	}
 	br.Error = pErr
 	if pErr != nil {
-		log.Trace(ctx, "error: "+pErr.String())
+		log.Event(ctx, "error: "+pErr.String())
 	}
 	done <- BatchCall{Reply: br}
 }

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -378,7 +378,7 @@ func (tc *TxnCoordSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*r
 
 		if hasET && log.V(1) {
 			for _, intent := range et.IntentSpans {
-				log.Tracef(ctx, "intent: [%s,%s)", intent.Key, intent.EndKey)
+				log.Eventf(ctx, "intent: [%s,%s)", intent.Key, intent.EndKey)
 			}
 		}
 	}
@@ -396,7 +396,7 @@ func (tc *TxnCoordSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*r
 		}
 
 		if pErr = tc.updateState(startNS, ctx, ba, br, pErr); pErr != nil {
-			log.Tracef(ctx, "error: %s", pErr)
+			log.Eventf(ctx, "error: %s", pErr)
 			return nil, pErr
 		}
 	}
@@ -456,7 +456,7 @@ func (tc *TxnCoordSender) maybeRejectClientLocked(
 	// continue.
 	switch {
 	case !ok:
-		log.VTracef(2, ctx, "rejecting unknown txn: %s", txn.ID)
+		log.VEventf(2, ctx, "rejecting unknown txn: %s", txn.ID)
 		// TODO(spencerkimball): Could add coordinator node ID to the
 		// transaction session so that we can definitively return the right
 		// error between these possible errors. Or update the code to make an
@@ -535,7 +535,7 @@ func (tc *TxnCoordSender) maybeBeginTxn(ba *roachpb.BatchRequest) error {
 // is updated and the heartbeat goroutine signaled to clean up the transaction
 // gracefully.
 func (tc *TxnCoordSender) cleanupTxnLocked(ctx context.Context, txn roachpb.Transaction) {
-	log.Trace(ctx, "coordinator stops")
+	log.Event(ctx, "coordinator stops")
 	txnMeta, ok := tc.txns[*txn.ID]
 	// The heartbeat might've already removed the record. Or we may have already
 	// closed txnEnd but we are racing with the heartbeat cleanup.
@@ -718,7 +718,7 @@ func (tc *TxnCoordSender) heartbeat(ctx context.Context, txnID uuid.UUID) bool {
 	hb.Key = txn.Key
 	ba.Add(hb)
 
-	log.Trace(ctx, "heartbeat")
+	log.Event(ctx, "heartbeat")
 	br, pErr := tc.wrapped.Send(ctx, ba)
 
 	// Correctness mandates that when we can't heartbeat the transaction, we
@@ -871,7 +871,7 @@ func (tc *TxnCoordSender) updateState(
 			// we expect it to be committed/aborted at some point in the
 			// future.
 			if _, isEnding := ba.GetArg(roachpb.EndTransaction); pErr != nil || !isEnding {
-				log.Trace(ctx, "coordinator spawns")
+				log.Event(ctx, "coordinator spawns")
 				txnMeta = &txnMetadata{
 					txn:              newTxn,
 					keys:             keys,

--- a/server/node.go
+++ b/server/node.go
@@ -405,7 +405,7 @@ func (n *Node) initStores(
 	}
 	for _, e := range engines {
 		s := storage.NewStore(n.ctx, e, &n.Descriptor)
-		log.Tracef(ctx, "created store for engine: %s", e)
+		log.Eventf(ctx, "created store for engine: %s", e)
 		// Initialize each store in turn, handling un-bootstrapped errors by
 		// adding the store to the bootstraps list.
 		if err := s.Start(ctx, stopper); err != nil {
@@ -446,7 +446,7 @@ func (n *Node) initStores(
 	if err := n.validateStores(); err != nil {
 		return err
 	}
-	log.Trace(ctx, "validated stores")
+	log.Event(ctx, "validated stores")
 
 	// Set the stores map as the gossip persistent storage, so that
 	// gossip can bootstrap using the most recently persisted set of
@@ -458,14 +458,14 @@ func (n *Node) initStores(
 	// Connect gossip before starting bootstrap. For new nodes, connecting
 	// to the gossip network is necessary to get the cluster ID.
 	n.connectGossip()
-	log.Trace(ctx, "connected to gossip")
+	log.Event(ctx, "connected to gossip")
 
 	// If no NodeID has been assigned yet, allocate a new node ID by
 	// supplying 0 to initNodeID.
 	if n.Descriptor.NodeID == 0 {
 		n.initNodeID(0)
 		n.initialBoot = true
-		log.Tracef(ctx, "allocated node ID %d", n.Descriptor.NodeID)
+		log.Eventf(ctx, "allocated node ID %d", n.Descriptor.NodeID)
 	}
 
 	// Bootstrap any uninitialized stores asynchronously.
@@ -828,14 +828,14 @@ func (n *Node) Batch(
 		}
 		defer sp.Finish()
 		traceCtx := opentracing.ContextWithSpan(ctx, sp)
-		log.Tracef(traceCtx, "node "+strconv.Itoa(int(n.Descriptor.NodeID))) // could save allocs here.
+		log.Eventf(traceCtx, "node "+strconv.Itoa(int(n.Descriptor.NodeID))) // could save allocs here.
 
 		tStart := timeutil.Now()
 		var pErr *roachpb.Error
 		br, pErr = n.stores.Send(traceCtx, *args)
 		if pErr != nil {
 			br = &roachpb.BatchResponse{}
-			log.Tracef(traceCtx, "error: %T", pErr.GetDetail())
+			log.Eventf(traceCtx, "error: %T", pErr.GetDetail())
 		}
 		if br.Error != nil {
 			panic(roachpb.ErrorUnexpectedlySet(n.stores, br))

--- a/server/server.go
+++ b/server/server.go
@@ -353,7 +353,7 @@ func (s *Server) Start(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	log.Tracef(ctx, "listening on port %s", s.ctx.Addr)
+	log.Eventf(ctx, "listening on port %s", s.ctx.Addr)
 	unresolvedAddr, err := officialAddr(s.ctx.Addr, ln.Addr())
 	if err != nil {
 		return err
@@ -453,12 +453,12 @@ func (s *Server) Start(ctx context.Context) error {
 	s.mux.HandleFunc(debugEndpoint, http.HandlerFunc(handleDebug))
 
 	s.gossip.Start(unresolvedAddr)
-	log.Trace(ctx, "started gossip")
+	log.Event(ctx, "started gossip")
 
 	if err := s.node.start(ctx, unresolvedAddr, s.ctx.Engines, s.ctx.NodeAttributes); err != nil {
 		return err
 	}
-	log.Trace(ctx, "started node")
+	log.Event(ctx, "started node")
 
 	// Set the NodeID in the base context (which was inherited by the
 	// various components of the server).
@@ -495,7 +495,7 @@ func (s *Server) Start(ctx context.Context) error {
 	s.stopper.RunWorker(func() {
 		netutil.FatalIfUnexpected(m.Serve())
 	})
-	log.Trace(ctx, "accepting connections")
+	log.Event(ctx, "accepting connections")
 
 	// Initialize grpc-gateway mux and context.
 	jsonpb := &util.JSONPb{
@@ -556,12 +556,12 @@ func (s *Server) Start(ctx context.Context) error {
 	s.mux.Handle(ts.URLPrefix, gwMux)
 	s.mux.Handle(statusPrefix, s.status)
 	s.mux.Handle(healthEndpoint, s.status)
-	log.Trace(ctx, "added http endpoints")
+	log.Event(ctx, "added http endpoints")
 
 	if err := sdnotify.Ready(); err != nil {
 		log.Errorf(s.Ctx(), "failed to signal readiness using systemd protocol: %s", err)
 	}
-	log.Trace(ctx, "server ready")
+	log.Event(ctx, "server ready")
 
 	return nil
 }

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -334,7 +334,7 @@ func (e *Executor) Prepare(
 	if log.V(2) {
 		log.Infof(session.Ctx(), "preparing: %s", query)
 	} else if traceSQL {
-		log.Tracef(session.Ctx(), "preparing: %s", query)
+		log.Eventf(session.Ctx(), "preparing: %s", query)
 	}
 	stmt, err := parser.ParseOne(query, parser.Syntax(session.Syntax))
 	if err != nil {
@@ -546,7 +546,7 @@ func (e *Executor) execRequest(session *Session, sql string) StatementResults {
 			if aErr, ok := err.(*client.AutoCommitError); ok {
 				// TODO(andrei): Until #7881 fixed.
 				{
-					log.Tracef(session.Ctx(), "executor got AutoCommitError: %s\n"+
+					log.Eventf(session.Ctx(), "executor got AutoCommitError: %s\n"+
 						"txn: %+v\nexecOpt.AutoRetry %t, execOpt.AutoCommit:%t, stmts %+v, remaining %+v",
 						aErr, txnState.txn.Proto, execOpt.AutoRetry, execOpt.AutoCommit, stmts,
 						remainingStmts)
@@ -716,7 +716,7 @@ func (e *Executor) execStmtsInCurrentTxn(
 
 	for i, stmt := range stmts {
 		ctx := planMaker.session.Ctx()
-		log.VTracef(2, ctx, "executing %d/%d: %s", i+1, len(stmts), stmt)
+		log.VEventf(2, ctx, "executing %d/%d: %s", i+1, len(stmts), stmt)
 		txnState.schemaChangers.curStatementIdx = i
 
 		var stmtStrBefore string

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -317,7 +317,7 @@ func (gcq *gcQueue) process(
 	// goes to the queue's EventLog and one which goes to tracing for this
 	// operation.
 	log.Infof(gcq.ctx, "completed with stats %+v", info)
-	log.Tracef(ctx, "completed with stats %+v", info)
+	log.Eventf(ctx, "completed with stats %+v", info)
 
 	var ba roachpb.BatchRequest
 	var gcArgs roachpb.GCRequest

--- a/storage/intent_resolver.go
+++ b/storage/intent_resolver.go
@@ -173,7 +173,7 @@ func (ir *intentResolver) maybePushTransactions(
 		}
 	}
 
-	log.Trace(ctx, "pushing transaction")
+	log.Event(ctx, "pushing transaction")
 
 	// Split intents into those we need to push and those which are good to
 	// resolve.
@@ -403,7 +403,7 @@ func (ir *intentResolver) resolveIntents(ctx context.Context,
 	// We're doing async stuff below; those need new traces.
 	ctx, cleanup := tracing.EnsureContext(ctx, ir.store.Tracer())
 	defer cleanup()
-	log.Tracef(ctx, "resolving intents [wait=%t]", wait)
+	log.Eventf(ctx, "resolving intents [wait=%t]", wait)
 
 	var reqs []roachpb.Request
 	for i := range intents {

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -492,7 +492,7 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) error {
 	ctx = repl.logContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, bq.processTimeout)
 	defer cancel()
-	log.Tracef(ctx, "processing replica")
+	log.Eventf(ctx, "processing replica")
 
 	// If the queue requires a replica to have the range lease in
 	// order to be processed, check whether this replica has range lease
@@ -506,7 +506,7 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) error {
 			}
 			return errors.Wrapf(err.GoError(), "%s: could not obtain lease", repl)
 		}
-		log.Trace(ctx, "got range lease")
+		log.Event(ctx, "got range lease")
 	}
 
 	log.VEventf(3, bq.ctx, "processing")
@@ -515,7 +515,7 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) error {
 		return err
 	}
 	log.VEventf(2, bq.ctx, "done: %s", timeutil.Since(start))
-	log.Trace(ctx, "done")
+	log.Event(ctx, "done")
 	return nil
 }
 

--- a/storage/raft_log_queue.go
+++ b/storage/raft_log_queue.go
@@ -200,7 +200,7 @@ func (rlq *raftLogQueue) process(
 
 	// Can and should the raft logs be truncated?
 	if truncatableIndexes >= RaftLogQueueStaleThreshold {
-		log.VTracef(1, ctx, "truncating raft log %d-%d",
+		log.VEventf(1, ctx, "truncating raft log %d-%d",
 			oldestIndex-truncatableIndexes, oldestIndex)
 		b := &client.Batch{}
 		b.AddRawRequest(&roachpb.TruncateLogRequest{

--- a/storage/replica_gc_queue.go
+++ b/storage/replica_gc_queue.go
@@ -179,7 +179,7 @@ func (q *replicaGCQueue) process(
 	replyDesc := reply.Ranges[0]
 	if _, currentMember := replyDesc.GetReplicaDescriptor(rng.store.StoreID()); !currentMember {
 		// We are no longer a member of this range; clean up our local data.
-		log.VTracef(1, ctx, "destroying local data")
+		log.VEventf(1, ctx, "destroying local data")
 		if err := rng.store.RemoveReplica(rng, replyDesc, true); err != nil {
 			return err
 		}
@@ -188,7 +188,7 @@ func (q *replicaGCQueue) process(
 		// away. But currentMember is true, so we are still a member of the
 		// subsuming range. Shut down raft processing for the former range
 		// and delete any remaining metadata, but do not delete the data.
-		log.VTracef(1, ctx, "removing merged range")
+		log.VEventf(1, ctx, "removing merged range")
 		if err := rng.store.RemoveReplica(rng, replyDesc, false); err != nil {
 			return err
 		}
@@ -203,7 +203,7 @@ func (q *replicaGCQueue) process(
 		// but also on how good a job the queue does at inspecting every
 		// Replica (see #8111) when inactive ones can be starved by
 		// event-driven additions.
-		log.Trace(ctx, "not gc'able")
+		log.Event(ctx, "not gc'able")
 		if err := rng.setLastReplicaGCTimestamp(now); err != nil {
 			return err
 		}

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -139,7 +139,7 @@ func (rq *replicateQueue) process(
 
 	switch action {
 	case AllocatorAdd:
-		log.Trace(ctx, "adding a new replica")
+		log.Event(ctx, "adding a new replica")
 		newStore, err := rq.allocator.AllocateTarget(zone.ReplicaAttrs[0], desc.Replicas, true)
 		if err != nil {
 			return err
@@ -149,19 +149,19 @@ func (rq *replicateQueue) process(
 			StoreID: newStore.StoreID,
 		}
 
-		log.VTracef(1, ctx, "adding replica to %+v due to under-replication", newReplica)
+		log.VEventf(1, ctx, "adding replica to %+v due to under-replication", newReplica)
 		if err = repl.ChangeReplicas(ctx, roachpb.ADD_REPLICA, newReplica, desc); err != nil {
 			return err
 		}
 	case AllocatorRemove:
-		log.Trace(ctx, "removing a replica")
+		log.Event(ctx, "removing a replica")
 		// We require the lease in order to process replicas, so
 		// repl.store.StoreID() corresponds to the lease-holder's store ID.
 		removeReplica, err := rq.allocator.RemoveTarget(desc.Replicas, repl.store.StoreID())
 		if err != nil {
 			return err
 		}
-		log.VTracef(1, ctx, "removing replica %+v due to over-replication", removeReplica)
+		log.VEventf(1, ctx, "removing replica %+v due to over-replication", removeReplica)
 		if err = repl.ChangeReplicas(ctx, roachpb.REMOVE_REPLICA, removeReplica, desc); err != nil {
 			return err
 		}
@@ -170,7 +170,7 @@ func (rq *replicateQueue) process(
 			return nil
 		}
 	case AllocatorRemoveDead:
-		log.Trace(ctx, "removing a dead replica")
+		log.Event(ctx, "removing a dead replica")
 		if len(deadReplicas) == 0 {
 			if log.V(1) {
 				log.Warningf(ctx, "Range of replica %s was identified as having dead replicas, but no dead replicas were found.", repl)
@@ -178,12 +178,12 @@ func (rq *replicateQueue) process(
 			break
 		}
 		deadReplica := deadReplicas[0]
-		log.VTracef(1, ctx, "removing dead replica %+v from store", deadReplica)
+		log.VEventf(1, ctx, "removing dead replica %+v from store", deadReplica)
 		if err = repl.ChangeReplicas(ctx, roachpb.REMOVE_REPLICA, deadReplica, desc); err != nil {
 			return err
 		}
 	case AllocatorNoop:
-		log.Trace(ctx, "considering a rebalance")
+		log.Event(ctx, "considering a rebalance")
 		// The Noop case will result if this replica was queued in order to
 		// rebalance. Attempt to find a rebalancing target.
 		//
@@ -192,7 +192,7 @@ func (rq *replicateQueue) process(
 		rebalanceStore := rq.allocator.RebalanceTarget(
 			zone.ReplicaAttrs[0], desc.Replicas, repl.store.StoreID())
 		if rebalanceStore == nil {
-			log.VTracef(1, ctx, "no suitable rebalance target")
+			log.VEventf(1, ctx, "no suitable rebalance target")
 			// No action was necessary and no rebalance target was found. Return
 			// without re-queuing this replica.
 			return nil
@@ -201,7 +201,7 @@ func (rq *replicateQueue) process(
 			NodeID:  rebalanceStore.Node.NodeID,
 			StoreID: rebalanceStore.StoreID,
 		}
-		log.VTracef(1, ctx, "rebalancing to %+v", rebalanceReplica)
+		log.VEventf(1, ctx, "rebalancing to %+v", rebalanceReplica)
 		if err = repl.ChangeReplicas(ctx, roachpb.ADD_REPLICA, rebalanceReplica, desc); err != nil {
 			return err
 		}

--- a/storage/store.go
+++ b/storage/store.go
@@ -750,7 +750,7 @@ func (s *Store) IsStarted() bool {
 func IterateRangeDescriptors(ctx context.Context,
 	eng engine.Reader, fn func(desc roachpb.RangeDescriptor) (bool, error),
 ) error {
-	log.Trace(ctx, "beginning range descriptor iteration")
+	log.Event(ctx, "beginning range descriptor iteration")
 	// Iterator over all range-local key-based data.
 	start := keys.RangeDescriptorKey(roachpb.RKeyMin)
 	end := keys.RangeDescriptorKey(roachpb.RKeyMax)
@@ -779,7 +779,7 @@ func IterateRangeDescriptors(ctx context.Context,
 
 	_, err := engine.MVCCIterate(context.Background(), eng, start, end, hlc.MaxTimestamp, false /* !consistent */, nil, /* txn */
 		false /* !reverse */, kvToDesc)
-	log.Tracef(ctx, "iterated over %d keys to find %d range descriptors (by suffix: %v)",
+	log.Eventf(ctx, "iterated over %d keys to find %d range descriptors (by suffix: %v)",
 		allCount, matchCount, bySuffix)
 	return err
 }
@@ -822,7 +822,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 			return &NotBootstrappedError{}
 		}
 	}
-	log.Trace(ctx, "read store identity")
+	log.Event(ctx, "read store identity")
 
 	// If the nodeID is 0, it has not be assigned yet.
 	if s.nodeDesc.NodeID != 0 && s.Ident.NodeID != s.nodeDesc.NodeID {
@@ -959,9 +959,9 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	// loop figure it out.
 	select {
 	case <-doneUnfreezing:
-		log.Trace(ctx, "finished unfreezing")
+		log.Event(ctx, "finished unfreezing")
 	case <-time.After(10 * time.Second):
-		log.Trace(ctx, "gave up waiting for unfreezing; continuing in background")
+		log.Event(ctx, "gave up waiting for unfreezing; continuing in background")
 	}
 
 	// Gossip is only ever nil while bootstrapping a cluster and
@@ -1015,7 +1015,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		if err = s.ComputeMetrics(-1); err != nil {
 			log.Infof(ctx, "%s: failed initial metrics computation: %s", s, err)
 		}
-		log.Trace(ctx, "computed initial metrics")
+		log.Event(ctx, "computed initial metrics")
 	}
 
 	// Set the started flag (for unittests).
@@ -1523,7 +1523,7 @@ func splitTriggerPostCommit(
 	r.mu.tsCache.MergeInto(rightRng.mu.tsCache, true /* clear */)
 	rightRng.mu.Unlock()
 	r.mu.Unlock()
-	log.Trace(ctx, "copied timestamp cache")
+	log.Event(ctx, "copied timestamp cache")
 
 	// Add the RHS replica to the store. This step atomically updates
 	// the EndKey of the LHS replica and also adds the RHS replica
@@ -2112,9 +2112,9 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (br *roachpb.
 	}
 
 	if log.V(1) {
-		log.Tracef(ctx, "executing %s", ba)
+		log.Eventf(ctx, "executing %s", ba)
 	} else {
-		log.Tracef(ctx, "executing %d requests", len(ba.Requests))
+		log.Eventf(ctx, "executing %d requests", len(ba.Requests))
 	}
 	// Backoff and retry loop for handling errors. Backoff times are measured
 	// in the Trace.
@@ -2123,7 +2123,7 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (br *roachpb.
 	next := func(r *retry.Retry) bool {
 		if r.CurrentAttempt() > 0 {
 			ba.SetNewRequest()
-			log.Trace(ctx, "backoff")
+			log.Event(ctx, "backoff")
 		}
 		return r.Next()
 	}
@@ -2198,7 +2198,7 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (br *roachpb.
 			pErr.Index = index
 		}
 
-		log.Tracef(ctx, "error: %T", pErr.GetDetail())
+		log.Eventf(ctx, "error: %T", pErr.GetDetail())
 		switch t := pErr.GetDetail().(type) {
 		case *roachpb.WriteIntentError:
 			// If write intent error is resolved, exit retry/backoff loop to
@@ -2231,7 +2231,7 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (br *roachpb.
 	// By default, retries are indefinite. However, some unittests set a
 	// maximum retry count; return txn retry error for transactional cases
 	// and the original error otherwise.
-	log.Trace(ctx, "store retry limit exceeded") // good to check for if tests fail
+	log.Event(ctx, "store retry limit exceeded") // good to check for if tests fail
 	if ba.Txn != nil {
 		pErr = roachpb.NewErrorWithTxn(roachpb.NewTransactionRetryError(), ba.Txn)
 	}

--- a/storage/stores.go
+++ b/storage/stores.go
@@ -173,7 +173,7 @@ func (ls *Stores) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.B
 			// The uncertainty window is [OrigTimestamp, maxTS), so if that window
 			// is empty, there won't be any uncertainty restarts.
 			if !ba.Txn.OrigTimestamp.Less(maxTS) {
-				log.Trace(ctx, "read has no clock uncertainty")
+				log.Event(ctx, "read has no clock uncertainty")
 			}
 			shallowTxn.MaxTimestamp.Backward(maxTS)
 			ba.Txn = &shallowTxn

--- a/util/log/trace.go
+++ b/util/log/trace.go
@@ -194,23 +194,3 @@ func VEventf(level level, ctx context.Context, format string, args ...interface{
 		eventInternal(ctx, false /*isErr*/, true /*withTags*/, format, args...)
 	}
 }
-
-// Trace is a DEPRECATED alias for Event.
-func Trace(ctx context.Context, msg string) {
-	Event(ctx, msg)
-}
-
-// Tracef is a DEPRECATED alias for Eventf.
-func Tracef(ctx context.Context, format string, args ...interface{}) {
-	Eventf(ctx, format, args...)
-}
-
-// VTracef is a DEPRECATED alias for VEventf.
-func VTracef(level level, ctx context.Context, format string, args ...interface{}) {
-	if VDepth(level, 1) {
-		// Log to INFO (which also logs an event).
-		logDepth(ctx, 1, InfoLog, format, args)
-	} else {
-		eventInternal(ctx, false /*isErr*/, true /*withTags*/, format, args...)
-	}
-}


### PR DESCRIPTION
The `Trace*` functions have been deprecated in favor of the more aptly named
`Event*`. The callsites were not updated to avoid conflict during merges; but
there have been quite a few instances of confusion around this so it is time to
do it.

The change is purely mechanical. I plan to merge this into develop right after it goes into `master` and fix any remaining callsites there.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9410)

<!-- Reviewable:end -->
