### PR TITLE
sql: Fix crash when partitioning empty windows

### DIFF
--- a/sql/testdata/window
+++ b/sql/testdata/window
@@ -257,6 +257,19 @@ SELECT (avg(d) OVER (PARTITION BY v ORDER BY w) + avg(d) OVER (PARTITION BY w OR
    8.4500000000000000
   15.8000000000000000
 
+query R
+SELECT avg(d) OVER (PARTITION BY v) FROM kv WHERE FALSE ORDER BY 1
+----
+
+query R
+SELECT avg(d) OVER (PARTITION BY v, v, v, v, v, v, v, v, v, v) FROM kv WHERE FALSE ORDER BY 1
+----
+
+query R
+SELECT avg(d) OVER (PARTITION BY v, v, v, v, v, v, v, v, v, v) FROM kv WHERE k = 3 ORDER BY 1
+----
+8.0000000000000000
+
 query IB
 SELECT k, bool_and(b) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
 ----

--- a/sql/window.go
+++ b/sql/window.go
@@ -405,6 +405,10 @@ type peerGroupChecker interface {
 // 2D-slice for each window function in n.funcs.
 func (n *windowNode) computeWindows() error {
 	rowCount := n.wrappedValues.Len()
+	if rowCount == 0 {
+		return nil
+	}
+
 	windowCount := len(n.funcs)
 	acc := n.windowsAcc.W(n.planner.session)
 


### PR DESCRIPTION
Previously we were accidentally using the `rowCount` instead of the
`columnCount` as a maximum scratch space for window partition values,
which would cause a crash when there were more partition columns than
rows. While switching this to the `columnCount` would work for now, it's
safer to dynamically grow this slice as needed to avoid issues if we
ever coalesce identical partition renders together. This should also
result in a tighter bound on this scratch space size.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9413)

<!-- Reviewable:end -->
