### PR TITLE
master -> develop

### DIFF
--- a/cli/start.go
+++ b/cli/start.go
@@ -334,7 +334,7 @@ func runStart(_ *cobra.Command, args []string) error {
 	if err := os.MkdirAll(logDir, 0755); err != nil {
 		return err
 	}
-	log.Tracef(startCtx, "created log directory %s", logDir)
+	log.Eventf(startCtx, "created log directory %s", logDir)
 
 	// We log build information to stdout (for the short summary), but also
 	// to stderr to coincide with the full logs.
@@ -349,7 +349,7 @@ func runStart(_ *cobra.Command, args []string) error {
 	serverCtx.User = security.NodeUser
 
 	stopper := initBacktrace(logDir)
-	log.Trace(startCtx, "initialized profiles")
+	log.Event(startCtx, "initialized profiles")
 
 	if err := serverCtx.InitStores(stopper); err != nil {
 		return fmt.Errorf("failed to initialize stores: %s", err)

--- a/cli/start.go
+++ b/cli/start.go
@@ -339,7 +339,7 @@ func runStart(_ *cobra.Command, args []string) error {
 	if err := os.MkdirAll(logDir, 0755); err != nil {
 		return err
 	}
-	log.Tracef(startCtx, "created log directory %s", logDir)
+	log.Eventf(startCtx, "created log directory %s", logDir)
 
 	// We log build information to stdout (for the short summary), but also
 	// to stderr to coincide with the full logs.
@@ -354,7 +354,7 @@ func runStart(_ *cobra.Command, args []string) error {
 	serverCtx.User = security.NodeUser
 
 	stopper := initBacktrace(logDir)
-	log.Trace(startCtx, "initialized profiles")
+	log.Event(startCtx, "initialized profiles")
 
 	if err := serverCtx.InitStores(stopper); err != nil {
 		return fmt.Errorf("failed to initialize stores: %s", err)

--- a/internal/client/txn.go
+++ b/internal/client/txn.go
@@ -392,7 +392,7 @@ func (txn *Txn) GetDeadline() *hlc.Timestamp {
 // The txn's status is set to ABORTED in case of error. txn is
 // considered finalized and cannot be used to send any more commands.
 func (txn *Txn) Rollback() error {
-	log.VTracef(2, txn.Context, "rolling back transaction")
+	log.VEventf(2, txn.Context, "rolling back transaction")
 	err := txn.sendEndTxnReq(false /* commit */, nil)
 	txn.finalized = true
 	return err
@@ -512,7 +512,7 @@ func (txn *Txn) Exec(
 		if err == nil && opt.AutoCommit && txn.Proto.Status == roachpb.PENDING {
 			// fn succeeded, but didn't commit.
 			err = txn.Commit()
-			log.Tracef(txn.Context, "client.Txn did AutoCommit. err: %v\ntxn: %+v", err, txn.Proto)
+			log.Eventf(txn.Context, "client.Txn did AutoCommit. err: %v\ntxn: %+v", err, txn.Proto)
 			if err != nil {
 				if _, retryable := err.(*roachpb.RetryableTxnError); !retryable {
 					// We can't retry, so let the caller know we tried to
@@ -539,7 +539,7 @@ func (txn *Txn) Exec(
 				r.Reset()
 			}
 		}
-		log.VTracef(2, txn.Context, "automatically retrying transaction: %s because of error: %s",
+		log.VEventf(2, txn.Context, "automatically retrying transaction: %s because of error: %s",
 			txn.DebugName(), err)
 	}
 

--- a/internal/client/txn.go
+++ b/internal/client/txn.go
@@ -392,7 +392,7 @@ func (txn *Txn) GetDeadline() *hlc.Timestamp {
 // The txn's status is set to ABORTED in case of error. txn is
 // considered finalized and cannot be used to send any more commands.
 func (txn *Txn) Rollback() error {
-	log.VTracef(2, txn.Context, "rolling back transaction")
+	log.VEventf(2, txn.Context, "rolling back transaction")
 	err := txn.sendEndTxnReq(false /* commit */, nil)
 	txn.finalized = true
 	return err
@@ -518,7 +518,7 @@ func (txn *Txn) Exec(
 		if err == nil && opt.AutoCommit && txn.Proto.Status == roachpb.PENDING {
 			// fn succeeded, but didn't commit.
 			err = txn.Commit()
-			log.Tracef(txn.Context, "client.Txn did AutoCommit. err: %v\ntxn: %+v", err, txn.Proto)
+			log.Eventf(txn.Context, "client.Txn did AutoCommit. err: %v\ntxn: %+v", err, txn.Proto)
 			if err != nil {
 				if _, retryable := err.(*roachpb.RetryableTxnError); !retryable {
 					// We can't retry, so let the caller know we tried to
@@ -545,7 +545,7 @@ func (txn *Txn) Exec(
 				r.Reset()
 			}
 		}
-		log.VTracef(2, txn.Context, "automatically retrying transaction: %s because of error: %s",
+		log.VEventf(2, txn.Context, "automatically retrying transaction: %s because of error: %s",
 			txn.DebugName(), err)
 	}
 

--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -238,9 +238,9 @@ func (et *evictionToken) EvictAndReplace(ctx context.Context, newDescs ...roachp
 		if err == nil {
 			if len(newDescs) > 0 {
 				err = et.doReplace(newDescs...)
-				log.Tracef(ctx, "evicting cached range descriptor with %d replacements", len(newDescs))
+				log.Eventf(ctx, "evicting cached range descriptor with %d replacements", len(newDescs))
 			} else {
-				log.Trace(ctx, "evicting cached range descriptor")
+				log.Event(ctx, "evicting cached range descriptor")
 			}
 		}
 	})
@@ -304,7 +304,7 @@ func (rdc *rangeDescriptorCache) lookupRangeDescriptorInternal(
 		returnToken := rdc.makeEvictionToken(desc, func() error {
 			return rdc.evictCachedRangeDescriptorLocked(key, desc, useReverseScan)
 		})
-		log.Trace(ctx, "looked up range descriptor from cache")
+		log.Event(ctx, "looked up range descriptor from cache")
 		return desc, returnToken, nil
 	}
 
@@ -326,7 +326,7 @@ func (rdc *rangeDescriptorCache) lookupRangeDescriptorInternal(
 		doneWg()
 
 		res = <-resC
-		log.Trace(ctx, "looked up range descriptor with shared request")
+		log.Event(ctx, "looked up range descriptor with shared request")
 	} else {
 		rdc.lookupRequests.inflight[requestKey] = req
 		rdc.lookupRequests.Unlock()
@@ -392,7 +392,7 @@ func (rdc *rangeDescriptorCache) lookupRangeDescriptorInternal(
 		delete(rdc.lookupRequests.inflight, requestKey)
 		rdc.lookupRequests.Unlock()
 		rdc.rangeCache.Unlock()
-		log.Trace(ctx, "looked up range descriptor")
+		log.Event(ctx, "looked up range descriptor")
 	}
 
 	// It rarely may be possible that we got grouped in with the wrong

--- a/kv/transport.go
+++ b/kv/transport.go
@@ -258,7 +258,7 @@ func (s *senderTransport) SendNext(done chan<- BatchCall) {
 	sp := s.tracer.StartSpan("node")
 	defer sp.Finish()
 	ctx := opentracing.ContextWithSpan(context.Background(), sp)
-	log.Trace(ctx, s.args.String())
+	log.Event(ctx, s.args.String())
 	br, pErr := s.sender.Send(ctx, s.args)
 	if br == nil {
 		br = &roachpb.BatchResponse{}
@@ -268,7 +268,7 @@ func (s *senderTransport) SendNext(done chan<- BatchCall) {
 	}
 	br.Error = pErr
 	if pErr != nil {
-		log.Trace(ctx, "error: "+pErr.String())
+		log.Event(ctx, "error: "+pErr.String())
 	}
 	done <- BatchCall{Reply: br}
 }

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -378,7 +378,7 @@ func (tc *TxnCoordSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*r
 
 		if hasET && log.V(1) {
 			for _, intent := range et.IntentSpans {
-				log.Tracef(ctx, "intent: [%s,%s)", intent.Key, intent.EndKey)
+				log.Eventf(ctx, "intent: [%s,%s)", intent.Key, intent.EndKey)
 			}
 		}
 	}
@@ -396,7 +396,7 @@ func (tc *TxnCoordSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*r
 		}
 
 		if pErr = tc.updateState(startNS, ctx, ba, br, pErr); pErr != nil {
-			log.Tracef(ctx, "error: %s", pErr)
+			log.Eventf(ctx, "error: %s", pErr)
 			return nil, pErr
 		}
 	}
@@ -456,7 +456,7 @@ func (tc *TxnCoordSender) maybeRejectClientLocked(
 	// continue.
 	switch {
 	case !ok:
-		log.VTracef(2, ctx, "rejecting unknown txn: %s", txn.ID)
+		log.VEventf(2, ctx, "rejecting unknown txn: %s", txn.ID)
 		// TODO(spencerkimball): Could add coordinator node ID to the
 		// transaction session so that we can definitively return the right
 		// error between these possible errors. Or update the code to make an
@@ -535,7 +535,7 @@ func (tc *TxnCoordSender) maybeBeginTxn(ba *roachpb.BatchRequest) error {
 // is updated and the heartbeat goroutine signaled to clean up the transaction
 // gracefully.
 func (tc *TxnCoordSender) cleanupTxnLocked(ctx context.Context, txn roachpb.Transaction) {
-	log.Trace(ctx, "coordinator stops")
+	log.Event(ctx, "coordinator stops")
 	txnMeta, ok := tc.txns[*txn.ID]
 	// The heartbeat might've already removed the record. Or we may have already
 	// closed txnEnd but we are racing with the heartbeat cleanup.
@@ -718,7 +718,7 @@ func (tc *TxnCoordSender) heartbeat(ctx context.Context, txnID uuid.UUID) bool {
 	hb.Key = txn.Key
 	ba.Add(hb)
 
-	log.Trace(ctx, "heartbeat")
+	log.Event(ctx, "heartbeat")
 	br, pErr := tc.wrapped.Send(ctx, ba)
 
 	// Correctness mandates that when we can't heartbeat the transaction, we
@@ -871,7 +871,7 @@ func (tc *TxnCoordSender) updateState(
 			// we expect it to be committed/aborted at some point in the
 			// future.
 			if _, isEnding := ba.GetArg(roachpb.EndTransaction); pErr != nil || !isEnding {
-				log.Trace(ctx, "coordinator spawns")
+				log.Event(ctx, "coordinator spawns")
 				txnMeta = &txnMetadata{
 					txn:              newTxn,
 					keys:             keys,

--- a/server/node.go
+++ b/server/node.go
@@ -405,7 +405,7 @@ func (n *Node) initStores(
 	}
 	for _, e := range engines {
 		s := storage.NewStore(n.ctx, e, &n.Descriptor)
-		log.Tracef(ctx, "created store for engine: %s", e)
+		log.Eventf(ctx, "created store for engine: %s", e)
 		// Initialize each store in turn, handling un-bootstrapped errors by
 		// adding the store to the bootstraps list.
 		if err := s.Start(ctx, stopper); err != nil {
@@ -446,7 +446,7 @@ func (n *Node) initStores(
 	if err := n.validateStores(); err != nil {
 		return err
 	}
-	log.Trace(ctx, "validated stores")
+	log.Event(ctx, "validated stores")
 
 	// Set the stores map as the gossip persistent storage, so that
 	// gossip can bootstrap using the most recently persisted set of
@@ -458,14 +458,14 @@ func (n *Node) initStores(
 	// Connect gossip before starting bootstrap. For new nodes, connecting
 	// to the gossip network is necessary to get the cluster ID.
 	n.connectGossip()
-	log.Trace(ctx, "connected to gossip")
+	log.Event(ctx, "connected to gossip")
 
 	// If no NodeID has been assigned yet, allocate a new node ID by
 	// supplying 0 to initNodeID.
 	if n.Descriptor.NodeID == 0 {
 		n.initNodeID(0)
 		n.initialBoot = true
-		log.Tracef(ctx, "allocated node ID %d", n.Descriptor.NodeID)
+		log.Eventf(ctx, "allocated node ID %d", n.Descriptor.NodeID)
 	}
 
 	// Bootstrap any uninitialized stores asynchronously.
@@ -828,14 +828,14 @@ func (n *Node) Batch(
 		}
 		defer sp.Finish()
 		traceCtx := opentracing.ContextWithSpan(ctx, sp)
-		log.Tracef(traceCtx, "node "+strconv.Itoa(int(n.Descriptor.NodeID))) // could save allocs here.
+		log.Eventf(traceCtx, "node "+strconv.Itoa(int(n.Descriptor.NodeID))) // could save allocs here.
 
 		tStart := timeutil.Now()
 		var pErr *roachpb.Error
 		br, pErr = n.stores.Send(traceCtx, *args)
 		if pErr != nil {
 			br = &roachpb.BatchResponse{}
-			log.Tracef(traceCtx, "error: %T", pErr.GetDetail())
+			log.Eventf(traceCtx, "error: %T", pErr.GetDetail())
 		}
 		if br.Error != nil {
 			panic(roachpb.ErrorUnexpectedlySet(n.stores, br))

--- a/server/node.go
+++ b/server/node.go
@@ -393,7 +393,7 @@ func (n *Node) initStores(
 	}
 	for _, e := range engines {
 		s := storage.NewStore(n.ctx, e, &n.Descriptor)
-		log.Tracef(ctx, "created store for engine: %s", e)
+		log.Eventf(ctx, "created store for engine: %s", e)
 		// Initialize each store in turn, handling un-bootstrapped errors by
 		// adding the store to the bootstraps list.
 		if err := s.Start(ctx, stopper); err != nil {
@@ -434,7 +434,7 @@ func (n *Node) initStores(
 	if err := n.validateStores(); err != nil {
 		return err
 	}
-	log.Trace(ctx, "validated stores")
+	log.Event(ctx, "validated stores")
 
 	// Set the stores map as the gossip persistent storage, so that
 	// gossip can bootstrap using the most recently persisted set of
@@ -446,14 +446,14 @@ func (n *Node) initStores(
 	// Connect gossip before starting bootstrap. For new nodes, connecting
 	// to the gossip network is necessary to get the cluster ID.
 	n.connectGossip()
-	log.Trace(ctx, "connected to gossip")
+	log.Event(ctx, "connected to gossip")
 
 	// If no NodeID has been assigned yet, allocate a new node ID by
 	// supplying 0 to initNodeID.
 	if n.Descriptor.NodeID == 0 {
 		n.initNodeID(0)
 		n.initialBoot = true
-		log.Tracef(ctx, "allocated node ID %d", n.Descriptor.NodeID)
+		log.Eventf(ctx, "allocated node ID %d", n.Descriptor.NodeID)
 	}
 
 	// Bootstrap any uninitialized stores asynchronously.
@@ -816,14 +816,14 @@ func (n *Node) Batch(
 		}
 		defer sp.Finish()
 		traceCtx := opentracing.ContextWithSpan(ctx, sp)
-		log.Tracef(traceCtx, "node "+strconv.Itoa(int(n.Descriptor.NodeID))) // could save allocs here.
+		log.Eventf(traceCtx, "node "+strconv.Itoa(int(n.Descriptor.NodeID))) // could save allocs here.
 
 		tStart := timeutil.Now()
 		var pErr *roachpb.Error
 		br, pErr = n.stores.Send(traceCtx, *args)
 		if pErr != nil {
 			br = &roachpb.BatchResponse{}
-			log.Tracef(traceCtx, "error: %T", pErr.GetDetail())
+			log.Eventf(traceCtx, "error: %T", pErr.GetDetail())
 		}
 		if br.Error != nil {
 			panic(roachpb.ErrorUnexpectedlySet(n.stores, br))

--- a/server/server.go
+++ b/server/server.go
@@ -372,7 +372,7 @@ func (s *Server) Start(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	log.Tracef(ctx, "listening on port %s", s.ctx.Addr)
+	log.Eventf(ctx, "listening on port %s", s.ctx.Addr)
 	unresolvedAddr, err := officialAddr(s.ctx.Addr, ln.Addr())
 	if err != nil {
 		return err
@@ -472,12 +472,12 @@ func (s *Server) Start(ctx context.Context) error {
 	s.mux.HandleFunc(debugEndpoint, http.HandlerFunc(handleDebug))
 
 	s.gossip.Start(unresolvedAddr)
-	log.Trace(ctx, "started gossip")
+	log.Event(ctx, "started gossip")
 
 	if err := s.node.start(ctx, unresolvedAddr, s.ctx.Engines, s.ctx.NodeAttributes); err != nil {
 		return err
 	}
-	log.Trace(ctx, "started node")
+	log.Event(ctx, "started node")
 
 	// Set the NodeID in the base context (which was inherited by the
 	// various components of the server).
@@ -514,7 +514,7 @@ func (s *Server) Start(ctx context.Context) error {
 	s.stopper.RunWorker(func() {
 		netutil.FatalIfUnexpected(m.Serve())
 	})
-	log.Trace(ctx, "accepting connections")
+	log.Event(ctx, "accepting connections")
 
 	// Initialize grpc-gateway mux and context.
 	jsonpb := &util.JSONPb{
@@ -576,12 +576,12 @@ func (s *Server) Start(ctx context.Context) error {
 	s.mux.Handle(statusPrefix, gwMux)
 	s.mux.Handle("/health", gwMux)
 	s.mux.Handle(statusVars, http.HandlerFunc(s.status.handleVars))
-	log.Trace(ctx, "added http endpoints")
+	log.Event(ctx, "added http endpoints")
 
 	if err := sdnotify.Ready(); err != nil {
 		log.Errorf(s.Ctx(), "failed to signal readiness using systemd protocol: %s", err)
 	}
-	log.Trace(ctx, "server ready")
+	log.Event(ctx, "server ready")
 
 	return nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -353,7 +353,7 @@ func (s *Server) Start(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	log.Tracef(ctx, "listening on port %s", s.ctx.Addr)
+	log.Eventf(ctx, "listening on port %s", s.ctx.Addr)
 	unresolvedAddr, err := officialAddr(s.ctx.Addr, ln.Addr())
 	if err != nil {
 		return err
@@ -453,12 +453,12 @@ func (s *Server) Start(ctx context.Context) error {
 	s.mux.HandleFunc(debugEndpoint, http.HandlerFunc(handleDebug))
 
 	s.gossip.Start(unresolvedAddr)
-	log.Trace(ctx, "started gossip")
+	log.Event(ctx, "started gossip")
 
 	if err := s.node.start(ctx, unresolvedAddr, s.ctx.Engines, s.ctx.NodeAttributes); err != nil {
 		return err
 	}
-	log.Trace(ctx, "started node")
+	log.Event(ctx, "started node")
 
 	// Set the NodeID in the base context (which was inherited by the
 	// various components of the server).
@@ -495,7 +495,7 @@ func (s *Server) Start(ctx context.Context) error {
 	s.stopper.RunWorker(func() {
 		netutil.FatalIfUnexpected(m.Serve())
 	})
-	log.Trace(ctx, "accepting connections")
+	log.Event(ctx, "accepting connections")
 
 	// Initialize grpc-gateway mux and context.
 	jsonpb := &util.JSONPb{
@@ -556,12 +556,12 @@ func (s *Server) Start(ctx context.Context) error {
 	s.mux.Handle(ts.URLPrefix, gwMux)
 	s.mux.Handle(statusPrefix, s.status)
 	s.mux.Handle(healthEndpoint, s.status)
-	log.Trace(ctx, "added http endpoints")
+	log.Event(ctx, "added http endpoints")
 
 	if err := sdnotify.Ready(); err != nil {
 		log.Errorf(s.Ctx(), "failed to signal readiness using systemd protocol: %s", err)
 	}
-	log.Trace(ctx, "server ready")
+	log.Event(ctx, "server ready")
 
 	return nil
 }

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -334,7 +334,7 @@ func (e *Executor) Prepare(
 	if log.V(2) {
 		log.Infof(session.Ctx(), "preparing: %s", query)
 	} else if traceSQL {
-		log.Tracef(session.Ctx(), "preparing: %s", query)
+		log.Eventf(session.Ctx(), "preparing: %s", query)
 	}
 	stmt, err := parser.ParseOne(query, parser.Syntax(session.Syntax))
 	if err != nil {
@@ -546,7 +546,7 @@ func (e *Executor) execRequest(session *Session, sql string) StatementResults {
 			if aErr, ok := err.(*client.AutoCommitError); ok {
 				// TODO(andrei): Until #7881 fixed.
 				{
-					log.Tracef(session.Ctx(), "executor got AutoCommitError: %s\n"+
+					log.Eventf(session.Ctx(), "executor got AutoCommitError: %s\n"+
 						"txn: %+v\nexecOpt.AutoRetry %t, execOpt.AutoCommit:%t, stmts %+v, remaining %+v",
 						aErr, txnState.txn.Proto, execOpt.AutoRetry, execOpt.AutoCommit, stmts,
 						remainingStmts)
@@ -716,7 +716,7 @@ func (e *Executor) execStmtsInCurrentTxn(
 
 	for i, stmt := range stmts {
 		ctx := planMaker.session.Ctx()
-		log.VTracef(2, ctx, "executing %d/%d: %s", i+1, len(stmts), stmt)
+		log.VEventf(2, ctx, "executing %d/%d: %s", i+1, len(stmts), stmt)
 		txnState.schemaChangers.curStatementIdx = i
 
 		var stmtStrBefore string

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -367,7 +367,7 @@ func (e *Executor) Prepare(
 	if log.V(2) {
 		log.Infof(session.Ctx(), "preparing: %s", query)
 	} else if traceSQL {
-		log.Tracef(session.Ctx(), "preparing: %s", query)
+		log.Eventf(session.Ctx(), "preparing: %s", query)
 	}
 	stmt, err := parser.ParseOne(query, parser.Syntax(session.Syntax))
 	if err != nil {
@@ -611,7 +611,7 @@ func (e *Executor) execRequest(session *Session, sql string, copymsg copyMsg) St
 			if aErr, ok := err.(*client.AutoCommitError); ok {
 				// TODO(andrei): Until #7881 fixed.
 				{
-					log.Tracef(session.Ctx(), "executor got AutoCommitError: %s\n"+
+					log.Eventf(session.Ctx(), "executor got AutoCommitError: %s\n"+
 						"txn: %+v\nexecOpt.AutoRetry %t, execOpt.AutoCommit:%t, stmts %+v, remaining %+v",
 						aErr, txnState.txn.Proto, execOpt.AutoRetry, execOpt.AutoCommit, stmts,
 						remainingStmts)
@@ -781,7 +781,7 @@ func (e *Executor) execStmtsInCurrentTxn(
 
 	for i, stmt := range stmts {
 		ctx := planMaker.session.Ctx()
-		log.VTracef(2, ctx, "executing %d/%d: %s", i+1, len(stmts), stmt)
+		log.VEventf(2, ctx, "executing %d/%d: %s", i+1, len(stmts), stmt)
 		txnState.schemaChangers.curStatementIdx = i
 
 		var stmtStrBefore string

--- a/sql/txn_restart_test.go
+++ b/sql/txn_restart_test.go
@@ -366,7 +366,7 @@ func (ta *TxnAborter) statementFilter(stmt string, res *sql.Result) {
 	if ri != nil {
 		ri.execCount++
 		if ri.restartCount == 0 {
-			log.VTracef(1, context.TODO(), "TxnAborter sees satisfied statement %q", stmt)
+			log.VEventf(1, context.TODO(), "TxnAborter sees satisfied statement %q", stmt)
 			ri.satisfied = true
 		}
 		if ri.restartCount > 0 && res.Err == nil {

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -317,7 +317,7 @@ func (gcq *gcQueue) process(
 	// goes to the queue's EventLog and one which goes to tracing for this
 	// operation.
 	log.Infof(gcq.ctx, "completed with stats %+v", info)
-	log.Tracef(ctx, "completed with stats %+v", info)
+	log.Eventf(ctx, "completed with stats %+v", info)
 
 	var ba roachpb.BatchRequest
 	var gcArgs roachpb.GCRequest

--- a/storage/intent_resolver.go
+++ b/storage/intent_resolver.go
@@ -173,7 +173,7 @@ func (ir *intentResolver) maybePushTransactions(
 		}
 	}
 
-	log.Trace(ctx, "pushing transaction")
+	log.Event(ctx, "pushing transaction")
 
 	// Split intents into those we need to push and those which are good to
 	// resolve.
@@ -403,7 +403,7 @@ func (ir *intentResolver) resolveIntents(ctx context.Context,
 	// We're doing async stuff below; those need new traces.
 	ctx, cleanup := tracing.EnsureContext(ctx, ir.store.Tracer())
 	defer cleanup()
-	log.Tracef(ctx, "resolving intents [wait=%t]", wait)
+	log.Eventf(ctx, "resolving intents [wait=%t]", wait)
 
 	var reqs []roachpb.Request
 	for i := range intents {

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -493,7 +493,7 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) error {
 	ctx = repl.logContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, bq.processTimeout)
 	defer cancel()
-	log.Tracef(ctx, "processing replica")
+	log.Eventf(ctx, "processing replica")
 
 	// If the queue requires a replica to have the range lease in
 	// order to be processed, check whether this replica has range lease
@@ -507,7 +507,7 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) error {
 			}
 			return errors.Wrapf(err.GoError(), "%s: could not obtain lease", repl)
 		}
-		log.Trace(ctx, "got range lease")
+		log.Event(ctx, "got range lease")
 	}
 
 	log.VEventf(3, bq.ctx, "processing")
@@ -516,7 +516,7 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) error {
 		return err
 	}
 	log.VEventf(2, bq.ctx, "done: %s", timeutil.Since(start))
-	log.Trace(ctx, "done")
+	log.Event(ctx, "done")
 	return nil
 }
 

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -492,7 +492,7 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) error {
 	ctx = repl.logContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, bq.processTimeout)
 	defer cancel()
-	log.Tracef(ctx, "processing replica")
+	log.Eventf(ctx, "processing replica")
 
 	// If the queue requires a replica to have the range lease in
 	// order to be processed, check whether this replica has range lease
@@ -506,7 +506,7 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) error {
 			}
 			return errors.Wrapf(err.GoError(), "%s: could not obtain lease", repl)
 		}
-		log.Trace(ctx, "got range lease")
+		log.Event(ctx, "got range lease")
 	}
 
 	log.VEventf(3, bq.ctx, "processing")
@@ -515,7 +515,7 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) error {
 		return err
 	}
 	log.VEventf(2, bq.ctx, "done: %s", timeutil.Since(start))
-	log.Trace(ctx, "done")
+	log.Event(ctx, "done")
 	return nil
 }
 

--- a/storage/raft_log_queue.go
+++ b/storage/raft_log_queue.go
@@ -200,7 +200,7 @@ func (rlq *raftLogQueue) process(
 
 	// Can and should the raft logs be truncated?
 	if truncatableIndexes >= RaftLogQueueStaleThreshold {
-		log.VTracef(1, ctx, "truncating raft log %d-%d",
+		log.VEventf(1, ctx, "truncating raft log %d-%d",
 			oldestIndex-truncatableIndexes, oldestIndex)
 		b := &client.Batch{}
 		b.AddRawRequest(&roachpb.TruncateLogRequest{

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -52,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/protoutil"
 	"github.com/cockroachdb/cockroach/util/syncutil"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 	"github.com/cockroachdb/cockroach/util/tracing"
 	"github.com/cockroachdb/cockroach/util/uuid"
 )
@@ -1153,7 +1154,12 @@ func (r *Replica) beginCmds(ctx context.Context, ba *roachpb.BatchRequest) (func
 		cmd = r.mu.cmdQ.add(readOnly, spans...)
 		r.mu.Unlock()
 
+		beforeWait := timeutil.Now()
 		ctxDone := ctx.Done()
+		numChans := len(chans)
+		if numChans > 0 {
+			log.Tracef(ctx, "waiting for %d overlapping requests", len(chans))
+		}
 		for _, ch := range chans {
 			select {
 			case <-ch:
@@ -1161,7 +1167,7 @@ func (r *Replica) beginCmds(ctx context.Context, ba *roachpb.BatchRequest) (func
 				err := ctx.Err()
 				errStr := fmt.Sprintf("%s while in command queue: %s", err, ba)
 				log.Warning(ctx, errStr)
-				log.Trace(ctx, errStr)
+				log.ErrEvent(ctx, errStr)
 				go func() {
 					// The command is moot, so we don't need to bother executing.
 					// However, the command queue assumes that commands don't drop
@@ -1176,6 +1182,9 @@ func (r *Replica) beginCmds(ctx context.Context, ba *roachpb.BatchRequest) (func
 				}()
 				return nil, err
 			}
+		}
+		if numChans > 0 {
+			log.Tracef(ctx, "waited %s for overlapping requests", timeutil.Since(beforeWait))
 		}
 	} else {
 		log.Trace(ctx, "operation accepts inconsistent results")
@@ -1418,6 +1427,7 @@ func (r *Replica) addReadOnlyCmd(ctx context.Context, ba roachpb.BatchRequest) (
 		}
 	}
 
+	log.Trace(ctx, "waiting for read lock")
 	r.readOnlyCmdMu.RLock()
 	defer r.readOnlyCmdMu.RUnlock()
 
@@ -1443,7 +1453,13 @@ func (r *Replica) addReadOnlyCmd(ctx context.Context, ba roachpb.BatchRequest) (
 		pErr = r.checkIfTxnAborted(ctx, r.store.Engine(), *ba.Txn)
 	}
 	if trigger != nil && len(trigger.intents) > 0 {
+		log.Tracef(ctx, "submitting %d intents to asynchronous processing", len(trigger.intents))
 		r.store.intentResolver.processIntentsAsync(r, trigger.intents)
+	}
+	if pErr != nil {
+		log.ErrEvent(ctx, pErr.String())
+	} else {
+		log.Trace(ctx, "read completed")
 	}
 	return br, pErr
 }

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -52,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/protoutil"
 	"github.com/cockroachdb/cockroach/util/syncutil"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 	"github.com/cockroachdb/cockroach/util/tracing"
 	"github.com/cockroachdb/cockroach/util/uuid"
 )
@@ -793,7 +794,7 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) *roachpb.Error {
 				// Return a nil chan to signal that we have a valid lease.
 				return nil, nil
 			}
-			log.Tracef(ctx, "request range lease (attempt #%d)", attempt)
+			log.Eventf(ctx, "request range lease (attempt #%d)", attempt)
 
 			// No active lease: Request renewal if a renewal is not already pending.
 			return r.requestLeaseLocked(timestamp), nil
@@ -1060,13 +1061,13 @@ func (r *Replica) Send(
 	// Differentiate between admin, read-only and write.
 	var pErr *roachpb.Error
 	if ba.IsWrite() {
-		log.Trace(ctx, "read-write path")
+		log.Event(ctx, "read-write path")
 		br, pErr = r.addWriteCmd(ctx, ba)
 	} else if ba.IsReadOnly() {
-		log.Trace(ctx, "read-only path")
+		log.Event(ctx, "read-only path")
 		br, pErr = r.addReadOnlyCmd(ctx, ba)
 	} else if ba.IsAdmin() {
-		log.Trace(ctx, "admin path")
+		log.Event(ctx, "admin path")
 		br, pErr = r.addAdminCmd(ctx, ba)
 	} else if len(ba.Requests) == 0 {
 		// empty batch; shouldn't happen (we could handle it, but it hints
@@ -1082,7 +1083,7 @@ func (r *Replica) Send(
 		pErr = roachpb.NewError(roachpb.NewRangeNotFoundError(r.RangeID))
 	}
 	if pErr != nil {
-		log.Tracef(ctx, "replica.Send got error: %s", pErr)
+		log.Eventf(ctx, "replica.Send got error: %s", pErr)
 	}
 	return br, pErr
 }
@@ -1153,7 +1154,12 @@ func (r *Replica) beginCmds(ctx context.Context, ba *roachpb.BatchRequest) (func
 		cmd = r.mu.cmdQ.add(readOnly, spans...)
 		r.mu.Unlock()
 
+		beforeWait := timeutil.Now()
 		ctxDone := ctx.Done()
+		numChans := len(chans)
+		if numChans > 0 {
+			log.Eventf(ctx, "waiting for %d overlapping requests", len(chans))
+		}
 		for _, ch := range chans {
 			select {
 			case <-ch:
@@ -1161,7 +1167,7 @@ func (r *Replica) beginCmds(ctx context.Context, ba *roachpb.BatchRequest) (func
 				err := ctx.Err()
 				errStr := fmt.Sprintf("%s while in command queue: %s", err, ba)
 				log.Warning(ctx, errStr)
-				log.Trace(ctx, errStr)
+				log.ErrEvent(ctx, errStr)
 				go func() {
 					// The command is moot, so we don't need to bother executing.
 					// However, the command queue assumes that commands don't drop
@@ -1177,8 +1183,11 @@ func (r *Replica) beginCmds(ctx context.Context, ba *roachpb.BatchRequest) (func
 				return nil, err
 			}
 		}
+		if numChans > 0 {
+			log.Eventf(ctx, "waited %s for overlapping requests", timeutil.Since(beforeWait))
+		}
 	} else {
-		log.Trace(ctx, "operation accepts inconsistent results")
+		log.Event(ctx, "operation accepts inconsistent results")
 	}
 
 	// Update the incoming timestamp if unset. Wait until after any
@@ -1404,7 +1413,7 @@ func (r *Replica) addReadOnlyCmd(ctx context.Context, ba roachpb.BatchRequest) (
 	if !ba.IsSingleNonKVRequest() {
 		// Add the read to the command queue to gate subsequent
 		// overlapping commands until this command completes.
-		log.Trace(ctx, "command queue")
+		log.Event(ctx, "command queue")
 		var err error
 		endCmdsFunc, err = r.beginCmds(ctx, &ba)
 		if err != nil {
@@ -1418,6 +1427,7 @@ func (r *Replica) addReadOnlyCmd(ctx context.Context, ba roachpb.BatchRequest) (
 		}
 	}
 
+	log.Event(ctx, "waiting for read lock")
 	r.readOnlyCmdMu.RLock()
 	defer r.readOnlyCmdMu.RUnlock()
 
@@ -1443,7 +1453,13 @@ func (r *Replica) addReadOnlyCmd(ctx context.Context, ba roachpb.BatchRequest) (
 		pErr = r.checkIfTxnAborted(ctx, r.store.Engine(), *ba.Txn)
 	}
 	if trigger != nil && len(trigger.intents) > 0 {
+		log.Eventf(ctx, "submitting %d intents to asynchronous processing", len(trigger.intents))
 		r.store.intentResolver.processIntentsAsync(r, trigger.intents)
+	}
+	if pErr != nil {
+		log.ErrEvent(ctx, pErr.String())
+	} else {
+		log.Event(ctx, "read completed")
 	}
 	return br, pErr
 }
@@ -1473,7 +1489,7 @@ func (r *Replica) addWriteCmd(
 		// done before getting the max timestamp for the key(s), as
 		// timestamp cache is only updated after preceding commands have
 		// been run to successful completion.
-		log.Trace(ctx, "command queue")
+		log.Event(ctx, "command queue")
 		endCmdsFunc, err := r.beginCmds(ctx, &ba)
 		if err != nil {
 			return nil, roachpb.NewError(err)
@@ -1512,7 +1528,7 @@ func (r *Replica) addWriteCmd(
 		}
 	}
 
-	log.Trace(ctx, "raft")
+	log.Event(ctx, "raft")
 
 	ch, tryAbandon, err := r.proposeRaftCommand(ctx, ba)
 
@@ -2447,7 +2463,7 @@ func (r *Replica) processRaftCommand(
 	}
 	r.mu.Unlock()
 
-	log.Trace(ctx, "applying batch")
+	log.Event(ctx, "applying batch")
 	// applyRaftCommand will return "expected" errors, but may also indicate
 	// replica corruption (as of now, signaled by a replicaCorruptionError).
 	// We feed its return through maybeSetCorrupt to act when that happens.
@@ -3080,7 +3096,7 @@ func (r *Replica) gossipFirstRangeLocked(ctx context.Context) {
 	if r.store.Gossip() == nil {
 		return
 	}
-	log.Trace(ctx, "gossiping sentinel and first range")
+	log.Event(ctx, "gossiping sentinel and first range")
 	if log.V(1) {
 		log.Infof(ctx, "gossiping sentinel from store %d, range %d", r.store.StoreID(), r.RangeID)
 	}

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -915,7 +915,7 @@ func (r *Replica) RangeLookup(
 	h roachpb.Header,
 	args roachpb.RangeLookupRequest,
 ) (roachpb.RangeLookupResponse, *PostCommitTrigger, error) {
-	log.Trace(ctx, "RangeLookup")
+	log.Event(ctx, "RangeLookup")
 	var reply roachpb.RangeLookupResponse
 	ts := h.Timestamp // all we're going to use from the header.
 	key, err := keys.Addr(args.Key)
@@ -2248,7 +2248,7 @@ func (r *Replica) AdminSplit(
 	// Determine split key if not provided with args. This scan is
 	// allowed to be relatively slow because admin commands don't block
 	// other commands.
-	log.Trace(ctx, "split begins")
+	log.Event(ctx, "split begins")
 	var splitKey roachpb.RKey
 	{
 		foundSplitKey := args.SplitKey
@@ -2289,7 +2289,7 @@ func (r *Replica) AdminSplit(
 	if desc.StartKey.Equal(splitKey) || desc.EndKey.Equal(splitKey) {
 		return reply, roachpb.NewErrorf("range is already split at key %s", splitKey)
 	}
-	log.Trace(ctx, "found split key")
+	log.Event(ctx, "found split key")
 
 	// Create right hand side range descriptor with the newly-allocated Range ID.
 	rightDesc, err := r.store.NewRangeDescriptor(splitKey, desc.EndKey, desc.Replicas)
@@ -2304,8 +2304,8 @@ func (r *Replica) AdminSplit(
 	log.Infof(ctx, "initiating a split of this range at key %s", splitKey)
 
 	if err := r.store.DB().Txn(context.TODO(), func(txn *client.Txn) error {
-		log.Trace(ctx, "split closure begins")
-		defer log.Trace(ctx, "split closure ends")
+		log.Event(ctx, "split closure begins")
+		defer log.Event(ctx, "split closure ends")
 		// Update existing range descriptor for left hand side of
 		// split. Note that we mutate the descriptor for the left hand
 		// side of the split first to locate the txn record there.
@@ -2322,7 +2322,7 @@ func (r *Replica) AdminSplit(
 			// This prevents cases where splits are aborted early due to
 			// conflicts with meta intents before the txn record has been
 			// written (see #9265).
-			log.Trace(ctx, "updating left descriptor")
+			log.Event(ctx, "updating left descriptor")
 			if err := txn.Run(b); err != nil {
 				if _, ok := err.(*roachpb.ConditionFailedError); ok {
 					return errors.New(ErrMsgConflictUpdatingRangeDesc)
@@ -2366,7 +2366,7 @@ func (r *Replica) AdminSplit(
 		})
 
 		// Commit txn with final batch (RHS desc and meta).
-		log.Trace(ctx, "commit txn with batch containing RHS descriptor and meta records")
+		log.Event(ctx, "commit txn with batch containing RHS descriptor and meta records")
 		if err := txn.Run(b); err != nil {
 			if _, ok := err.(*roachpb.ConditionFailedError); ok {
 				return errors.New(ErrMsgConflictUpdatingRangeDesc)
@@ -2569,7 +2569,7 @@ func (r *Replica) splitTrigger(
 	if err != nil {
 		return enginepb.MVCCStats{}, nil, errors.Wrap(err, "unable to compute stats for LHS range after split")
 	}
-	log.Trace(ctx, "computed stats for left hand side range")
+	log.Event(ctx, "computed stats for left hand side range")
 
 	// Copy the last replica GC timestamp. This value is unreplicated,
 	// which is why the MVCC stats are set to nil on calls to
@@ -2588,7 +2588,7 @@ func (r *Replica) splitTrigger(
 		// TODO(tschottdorf): ReplicaCorruptionError.
 		return enginepb.MVCCStats{}, nil, errors.Wrap(err, "unable to copy abort cache to RHS split range")
 	}
-	log.Tracef(ctx, "copied abort cache (%d entries)", seqCount)
+	log.Eventf(ctx, "copied abort cache (%d entries)", seqCount)
 
 	// Initialize the right-hand lease to be the same as the left-hand lease.
 	// This looks like an innocuous performance improvement, but it's more than
@@ -2778,7 +2778,7 @@ func (r *Replica) AdminMerge(
 	}
 
 	if err := r.store.DB().Txn(context.TODO(), func(txn *client.Txn) error {
-		log.Trace(ctx, "merge closure begins")
+		log.Event(ctx, "merge closure begins")
 		// Update the range descriptor for the receiving range.
 		{
 			b := txn.NewBatch()
@@ -2788,7 +2788,7 @@ func (r *Replica) AdminMerge(
 			}
 			// Commit this batch on its own to ensure that the transaction record
 			// is created in the right place (our triggers rely on this).
-			log.Trace(ctx, "updating left descriptor")
+			log.Event(ctx, "updating left descriptor")
 			if err := txn.Run(b); err != nil {
 				return err
 			}
@@ -2834,7 +2834,7 @@ func (r *Replica) AdminMerge(
 				},
 			},
 		})
-		log.Trace(ctx, "attempting commit")
+		log.Event(ctx, "attempting commit")
 		return txn.Run(b)
 	}); err != nil {
 		return reply, roachpb.NewErrorf("merge of range into %d failed: %s", origLeftDesc.RangeID, err)
@@ -3110,7 +3110,7 @@ func (r *Replica) ChangeReplicas(
 			return errors.Errorf("%s: unable to add replica %v which is already present", r, repDesc)
 		}
 
-		log.Trace(ctx, "requesting reservation")
+		log.Event(ctx, "requesting reservation")
 		// Before we try to add a new replica, we first need to secure a
 		// reservation for the replica on the receiving store.
 		if err := r.store.allocator.storePool.reserve(
@@ -3121,7 +3121,7 @@ func (r *Replica) ChangeReplicas(
 		); err != nil {
 			return errors.Wrapf(err, "%s: change replicas failed", r)
 		}
-		log.Trace(ctx, "reservation granted")
+		log.Event(ctx, "reservation granted")
 
 		// Prohibit premature raft log truncation. We set the pending index to 1
 		// here until we determine what it is below. This removes a small window of
@@ -3149,7 +3149,7 @@ func (r *Replica) ChangeReplicas(
 		// negate the benefits of pre-emptive snapshots, but that is a recoverable
 		// degradation, not a catastrophic failure.
 		snap, err := r.GetSnapshot(ctx)
-		log.Trace(ctx, "generated snapshot")
+		log.Event(ctx, "generated snapshot")
 		if err != nil {
 			return errors.Wrapf(err, "%s: change replicas failed", r)
 		}
@@ -3202,7 +3202,7 @@ func (r *Replica) ChangeReplicas(
 	descKey := keys.RangeDescriptorKey(desc.StartKey)
 
 	if err := r.store.DB().Txn(ctx, func(txn *client.Txn) error {
-		log.Trace(ctx, "attempting txn")
+		log.Event(ctx, "attempting txn")
 		txn.Proto.Name = replicaChangeTxnName
 		// TODO(tschottdorf): oldDesc is used for sanity checks related to #7224.
 		// Remove when that has been solved. The failure mode is likely based on
@@ -3256,7 +3256,7 @@ func (r *Replica) ChangeReplicas(
 			},
 		})
 		if err := txn.Run(b); err != nil {
-			log.Trace(ctx, err.Error())
+			log.Event(ctx, err.Error())
 			return err
 		}
 
@@ -3268,10 +3268,10 @@ func (r *Replica) ChangeReplicas(
 		}
 		return nil
 	}); err != nil {
-		log.Trace(ctx, err.Error())
+		log.Event(ctx, err.Error())
 		return errors.Wrapf(err, "change replicas of range %d failed", rangeID)
 	}
-	log.Trace(ctx, "txn complete")
+	log.Event(ctx, "txn complete")
 	return nil
 }
 

--- a/storage/replica_gc_queue.go
+++ b/storage/replica_gc_queue.go
@@ -179,7 +179,7 @@ func (q *replicaGCQueue) process(
 	replyDesc := reply.Ranges[0]
 	if _, currentMember := replyDesc.GetReplicaDescriptor(rng.store.StoreID()); !currentMember {
 		// We are no longer a member of this range; clean up our local data.
-		log.VTracef(1, ctx, "destroying local data")
+		log.VEventf(1, ctx, "destroying local data")
 		if err := rng.store.RemoveReplica(rng, replyDesc, true); err != nil {
 			return err
 		}
@@ -188,7 +188,7 @@ func (q *replicaGCQueue) process(
 		// away. But currentMember is true, so we are still a member of the
 		// subsuming range. Shut down raft processing for the former range
 		// and delete any remaining metadata, but do not delete the data.
-		log.VTracef(1, ctx, "removing merged range")
+		log.VEventf(1, ctx, "removing merged range")
 		if err := rng.store.RemoveReplica(rng, replyDesc, false); err != nil {
 			return err
 		}
@@ -203,7 +203,7 @@ func (q *replicaGCQueue) process(
 		// but also on how good a job the queue does at inspecting every
 		// Replica (see #8111) when inactive ones can be starved by
 		// event-driven additions.
-		log.Trace(ctx, "not gc'able")
+		log.Event(ctx, "not gc'able")
 		if err := rng.setLastReplicaGCTimestamp(now); err != nil {
 			return err
 		}

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -139,7 +139,7 @@ func (rq *replicateQueue) process(
 
 	switch action {
 	case AllocatorAdd:
-		log.Trace(ctx, "adding a new replica")
+		log.Event(ctx, "adding a new replica")
 		newStore, err := rq.allocator.AllocateTarget(zone.ReplicaAttrs[0], desc.Replicas, true)
 		if err != nil {
 			return err
@@ -149,19 +149,19 @@ func (rq *replicateQueue) process(
 			StoreID: newStore.StoreID,
 		}
 
-		log.VTracef(1, ctx, "adding replica to %+v due to under-replication", newReplica)
+		log.VEventf(1, ctx, "adding replica to %+v due to under-replication", newReplica)
 		if err = repl.ChangeReplicas(ctx, roachpb.ADD_REPLICA, newReplica, desc); err != nil {
 			return err
 		}
 	case AllocatorRemove:
-		log.Trace(ctx, "removing a replica")
+		log.Event(ctx, "removing a replica")
 		// We require the lease in order to process replicas, so
 		// repl.store.StoreID() corresponds to the lease-holder's store ID.
 		removeReplica, err := rq.allocator.RemoveTarget(desc.Replicas, repl.store.StoreID())
 		if err != nil {
 			return err
 		}
-		log.VTracef(1, ctx, "removing replica %+v due to over-replication", removeReplica)
+		log.VEventf(1, ctx, "removing replica %+v due to over-replication", removeReplica)
 		if err = repl.ChangeReplicas(ctx, roachpb.REMOVE_REPLICA, removeReplica, desc); err != nil {
 			return err
 		}
@@ -170,7 +170,7 @@ func (rq *replicateQueue) process(
 			return nil
 		}
 	case AllocatorRemoveDead:
-		log.Trace(ctx, "removing a dead replica")
+		log.Event(ctx, "removing a dead replica")
 		if len(deadReplicas) == 0 {
 			if log.V(1) {
 				log.Warningf(ctx, "Range of replica %s was identified as having dead replicas, but no dead replicas were found.", repl)
@@ -178,12 +178,12 @@ func (rq *replicateQueue) process(
 			break
 		}
 		deadReplica := deadReplicas[0]
-		log.VTracef(1, ctx, "removing dead replica %+v from store", deadReplica)
+		log.VEventf(1, ctx, "removing dead replica %+v from store", deadReplica)
 		if err = repl.ChangeReplicas(ctx, roachpb.REMOVE_REPLICA, deadReplica, desc); err != nil {
 			return err
 		}
 	case AllocatorNoop:
-		log.Trace(ctx, "considering a rebalance")
+		log.Event(ctx, "considering a rebalance")
 		// The Noop case will result if this replica was queued in order to
 		// rebalance. Attempt to find a rebalancing target.
 		//
@@ -192,7 +192,7 @@ func (rq *replicateQueue) process(
 		rebalanceStore := rq.allocator.RebalanceTarget(
 			zone.ReplicaAttrs[0], desc.Replicas, repl.store.StoreID())
 		if rebalanceStore == nil {
-			log.VTracef(1, ctx, "no suitable rebalance target")
+			log.VEventf(1, ctx, "no suitable rebalance target")
 			// No action was necessary and no rebalance target was found. Return
 			// without re-queuing this replica.
 			return nil
@@ -201,7 +201,7 @@ func (rq *replicateQueue) process(
 			NodeID:  rebalanceStore.Node.NodeID,
 			StoreID: rebalanceStore.StoreID,
 		}
-		log.VTracef(1, ctx, "rebalancing to %+v", rebalanceReplica)
+		log.VEventf(1, ctx, "rebalancing to %+v", rebalanceReplica)
 		if err = repl.ChangeReplicas(ctx, roachpb.ADD_REPLICA, rebalanceReplica, desc); err != nil {
 			return err
 		}

--- a/storage/store.go
+++ b/storage/store.go
@@ -750,7 +750,7 @@ func (s *Store) IsStarted() bool {
 func IterateRangeDescriptors(ctx context.Context,
 	eng engine.Reader, fn func(desc roachpb.RangeDescriptor) (bool, error),
 ) error {
-	log.Trace(ctx, "beginning range descriptor iteration")
+	log.Event(ctx, "beginning range descriptor iteration")
 	// Iterator over all range-local key-based data.
 	start := keys.RangeDescriptorKey(roachpb.RKeyMin)
 	end := keys.RangeDescriptorKey(roachpb.RKeyMax)
@@ -779,7 +779,7 @@ func IterateRangeDescriptors(ctx context.Context,
 
 	_, err := engine.MVCCIterate(context.Background(), eng, start, end, hlc.MaxTimestamp, false /* !consistent */, nil, /* txn */
 		false /* !reverse */, kvToDesc)
-	log.Tracef(ctx, "iterated over %d keys to find %d range descriptors (by suffix: %v)",
+	log.Eventf(ctx, "iterated over %d keys to find %d range descriptors (by suffix: %v)",
 		allCount, matchCount, bySuffix)
 	return err
 }
@@ -822,7 +822,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 			return &NotBootstrappedError{}
 		}
 	}
-	log.Trace(ctx, "read store identity")
+	log.Event(ctx, "read store identity")
 
 	// If the nodeID is 0, it has not be assigned yet.
 	if s.nodeDesc.NodeID != 0 && s.Ident.NodeID != s.nodeDesc.NodeID {
@@ -959,9 +959,9 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	// loop figure it out.
 	select {
 	case <-doneUnfreezing:
-		log.Trace(ctx, "finished unfreezing")
+		log.Event(ctx, "finished unfreezing")
 	case <-time.After(10 * time.Second):
-		log.Trace(ctx, "gave up waiting for unfreezing; continuing in background")
+		log.Event(ctx, "gave up waiting for unfreezing; continuing in background")
 	}
 
 	// Gossip is only ever nil while bootstrapping a cluster and
@@ -1015,7 +1015,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		if err = s.ComputeMetrics(-1); err != nil {
 			log.Infof(ctx, "%s: failed initial metrics computation: %s", s, err)
 		}
-		log.Trace(ctx, "computed initial metrics")
+		log.Event(ctx, "computed initial metrics")
 	}
 
 	// Set the started flag (for unittests).
@@ -1523,7 +1523,7 @@ func splitTriggerPostCommit(
 	r.mu.tsCache.MergeInto(rightRng.mu.tsCache, true /* clear */)
 	rightRng.mu.Unlock()
 	r.mu.Unlock()
-	log.Trace(ctx, "copied timestamp cache")
+	log.Event(ctx, "copied timestamp cache")
 
 	// Add the RHS replica to the store. This step atomically updates
 	// the EndKey of the LHS replica and also adds the RHS replica
@@ -2112,9 +2112,9 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (br *roachpb.
 	}
 
 	if log.V(1) {
-		log.Tracef(ctx, "executing %s", ba)
+		log.Eventf(ctx, "executing %s", ba)
 	} else {
-		log.Tracef(ctx, "executing %d requests", len(ba.Requests))
+		log.Eventf(ctx, "executing %d requests", len(ba.Requests))
 	}
 	// Backoff and retry loop for handling errors. Backoff times are measured
 	// in the Trace.
@@ -2123,7 +2123,7 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (br *roachpb.
 	next := func(r *retry.Retry) bool {
 		if r.CurrentAttempt() > 0 {
 			ba.SetNewRequest()
-			log.Trace(ctx, "backoff")
+			log.Event(ctx, "backoff")
 		}
 		return r.Next()
 	}
@@ -2198,7 +2198,7 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (br *roachpb.
 			pErr.Index = index
 		}
 
-		log.Tracef(ctx, "error: %T", pErr.GetDetail())
+		log.Eventf(ctx, "error: %T", pErr.GetDetail())
 		switch t := pErr.GetDetail().(type) {
 		case *roachpb.WriteIntentError:
 			// If write intent error is resolved, exit retry/backoff loop to
@@ -2231,7 +2231,7 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (br *roachpb.
 	// By default, retries are indefinite. However, some unittests set a
 	// maximum retry count; return txn retry error for transactional cases
 	// and the original error otherwise.
-	log.Trace(ctx, "store retry limit exceeded") // good to check for if tests fail
+	log.Event(ctx, "store retry limit exceeded") // good to check for if tests fail
 	if ba.Txn != nil {
 		pErr = roachpb.NewErrorWithTxn(roachpb.NewTransactionRetryError(), ba.Txn)
 	}

--- a/storage/store.go
+++ b/storage/store.go
@@ -749,7 +749,7 @@ func (s *Store) IsStarted() bool {
 func IterateRangeDescriptors(ctx context.Context,
 	eng engine.Reader, fn func(desc roachpb.RangeDescriptor) (bool, error),
 ) error {
-	log.Trace(ctx, "beginning range descriptor iteration")
+	log.Event(ctx, "beginning range descriptor iteration")
 	// Iterator over all range-local key-based data.
 	start := keys.RangeDescriptorKey(roachpb.RKeyMin)
 	end := keys.RangeDescriptorKey(roachpb.RKeyMax)
@@ -778,7 +778,7 @@ func IterateRangeDescriptors(ctx context.Context,
 
 	_, err := engine.MVCCIterate(context.Background(), eng, start, end, hlc.MaxTimestamp, false /* !consistent */, nil, /* txn */
 		false /* !reverse */, kvToDesc)
-	log.Tracef(ctx, "iterated over %d keys to find %d range descriptors (by suffix: %v)",
+	log.Eventf(ctx, "iterated over %d keys to find %d range descriptors (by suffix: %v)",
 		allCount, matchCount, bySuffix)
 	return err
 }
@@ -821,7 +821,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 			return &NotBootstrappedError{}
 		}
 	}
-	log.Trace(ctx, "read store identity")
+	log.Event(ctx, "read store identity")
 
 	// If the nodeID is 0, it has not be assigned yet.
 	if s.nodeDesc.NodeID != 0 && s.Ident.NodeID != s.nodeDesc.NodeID {
@@ -958,9 +958,9 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	// loop figure it out.
 	select {
 	case <-doneUnfreezing:
-		log.Trace(ctx, "finished unfreezing")
+		log.Event(ctx, "finished unfreezing")
 	case <-time.After(10 * time.Second):
-		log.Trace(ctx, "gave up waiting for unfreezing; continuing in background")
+		log.Event(ctx, "gave up waiting for unfreezing; continuing in background")
 	}
 
 	// Gossip is only ever nil while bootstrapping a cluster and
@@ -1014,7 +1014,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		if err = s.ComputeMetrics(-1); err != nil {
 			log.Infof(ctx, "%s: failed initial metrics computation: %s", s, err)
 		}
-		log.Trace(ctx, "computed initial metrics")
+		log.Event(ctx, "computed initial metrics")
 	}
 
 	// Set the started flag (for unittests).
@@ -1522,7 +1522,7 @@ func splitTriggerPostCommit(
 	r.mu.tsCache.MergeInto(rightRng.mu.tsCache, true /* clear */)
 	rightRng.mu.Unlock()
 	r.mu.Unlock()
-	log.Trace(ctx, "copied timestamp cache")
+	log.Event(ctx, "copied timestamp cache")
 
 	// Add the RHS replica to the store. This step atomically updates
 	// the EndKey of the LHS replica and also adds the RHS replica
@@ -2111,9 +2111,9 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (br *roachpb.
 	}
 
 	if log.V(1) {
-		log.Tracef(ctx, "executing %s", ba)
+		log.Eventf(ctx, "executing %s", ba)
 	} else {
-		log.Tracef(ctx, "executing %d requests", len(ba.Requests))
+		log.Eventf(ctx, "executing %d requests", len(ba.Requests))
 	}
 	// Backoff and retry loop for handling errors. Backoff times are measured
 	// in the Trace.
@@ -2122,7 +2122,7 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (br *roachpb.
 	next := func(r *retry.Retry) bool {
 		if r.CurrentAttempt() > 0 {
 			ba.SetNewRequest()
-			log.Trace(ctx, "backoff")
+			log.Event(ctx, "backoff")
 		}
 		return r.Next()
 	}
@@ -2197,7 +2197,7 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (br *roachpb.
 			pErr.Index = index
 		}
 
-		log.Tracef(ctx, "error: %T", pErr.GetDetail())
+		log.Eventf(ctx, "error: %T", pErr.GetDetail())
 		switch t := pErr.GetDetail().(type) {
 		case *roachpb.WriteIntentError:
 			// If write intent error is resolved, exit retry/backoff loop to
@@ -2230,7 +2230,7 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (br *roachpb.
 	// By default, retries are indefinite. However, some unittests set a
 	// maximum retry count; return txn retry error for transactional cases
 	// and the original error otherwise.
-	log.Trace(ctx, "store retry limit exceeded") // good to check for if tests fail
+	log.Event(ctx, "store retry limit exceeded") // good to check for if tests fail
 	if ba.Txn != nil {
 		pErr = roachpb.NewErrorWithTxn(roachpb.NewTransactionRetryError(), ba.Txn)
 	}

--- a/storage/stores.go
+++ b/storage/stores.go
@@ -173,7 +173,7 @@ func (ls *Stores) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.B
 			// The uncertainty window is [OrigTimestamp, maxTS), so if that window
 			// is empty, there won't be any uncertainty restarts.
 			if !ba.Txn.OrigTimestamp.Less(maxTS) {
-				log.Trace(ctx, "read has no clock uncertainty")
+				log.Event(ctx, "read has no clock uncertainty")
 			}
 			shallowTxn.MaxTimestamp.Backward(maxTS)
 			ba.Txn = &shallowTxn

--- a/util/log/trace.go
+++ b/util/log/trace.go
@@ -194,23 +194,3 @@ func VEventf(level level, ctx context.Context, format string, args ...interface{
 		eventInternal(ctx, false /*isErr*/, true /*withTags*/, format, args...)
 	}
 }
-
-// Trace is a DEPRECATED alias for Event.
-func Trace(ctx context.Context, msg string) {
-	Event(ctx, msg)
-}
-
-// Tracef is a DEPRECATED alias for Eventf.
-func Tracef(ctx context.Context, format string, args ...interface{}) {
-	Eventf(ctx, format, args...)
-}
-
-// VTracef is a DEPRECATED alias for VEventf.
-func VTracef(level level, ctx context.Context, format string, args ...interface{}) {
-	if VDepth(level, 1) {
-		// Log to INFO (which also logs an event).
-		logDepth(ctx, 1, InfoLog, format, args)
-	} else {
-		eventInternal(ctx, false /*isErr*/, true /*withTags*/, format, args...)
-	}
-}

--- a/util/log/trace.go
+++ b/util/log/trace.go
@@ -194,23 +194,3 @@ func VEventf(level level, ctx context.Context, format string, args ...interface{
 		eventInternal(ctx, false /*isErr*/, true /*withTags*/, format, args...)
 	}
 }
-
-// Trace is a DEPRECATED alias for Event.
-func Trace(ctx context.Context, msg string) {
-	Event(ctx, msg)
-}
-
-// Tracef is a DEPRECATED alias for Eventf.
-func Tracef(ctx context.Context, format string, args ...interface{}) {
-	Eventf(ctx, format, args...)
-}
-
-// VTracef is a DEPRECATED alias for VEventf.
-func VTracef(level level, ctx context.Context, format string, args ...interface{}) {
-	if VDepth(level, 1) {
-		// Log to INFO (which also logs an event).
-		logDepth(ctx, 1, Severity_INFO, format, args)
-	} else {
-		eventInternal(ctx, false /*isErr*/, true /*withTags*/, format, args...)
-	}
-}


### PR DESCRIPTION
Mostly #9410 with a couple of other callsites fixed up.

``` diff
diff --cc server/server.go
index beb14f4,2e59b98..731a7b8
--- a/server/server.go
+++ b/server/server.go
@@@ -571,12 -552,11 +571,12 @@@ func (s *Server) Start(ctx context.Cont

    // TODO(marc): when cookie-based authentication exists,
    // apply it for all web endpoints.
 -  s.mux.Handle(adminEndpoint, gwMux)
 +  s.mux.Handle(adminPrefix, gwMux)
    s.mux.Handle(ts.URLPrefix, gwMux)
 -  s.mux.Handle(statusPrefix, s.status)
 -  s.mux.Handle(healthEndpoint, s.status)
 +  s.mux.Handle(statusPrefix, gwMux)
 +  s.mux.Handle("/health", gwMux)
 +  s.mux.Handle(statusVars, http.HandlerFunc(s.status.handleVars))
-   log.Trace(ctx, "added http endpoints")
+   log.Event(ctx, "added http endpoints")

    if err := sdnotify.Ready(); err != nil {
        log.Errorf(s.Ctx(), "failed to signal readiness using systemd protocol: %s", err)
diff --cc sql/txn_restart_test.go
index b25bc2a,c132682..711c3f0
--- a/sql/txn_restart_test.go
+++ b/sql/txn_restart_test.go
@@@ -161,292 -185,28 +161,292 @@@ func checkRestarts(t *testing.T, magicV
                file, line, key, count)
        }
    }
 -  for key, count := range magicVals.endTxnRestartCounts {
 -      if count != 0 {
 -          file, line, _ := caller.Lookup(1)
 -          t.Errorf("%s:%d: txn writing \"%s\" still has to be aborted %d times",
 -              file, line, key, count)
 +  if t.Failed() {
 +      t.Fatalf("checking error injection failed")
 +  }
 +}
 +
 +// TxnAborter can be used to listen for transactions running particular
 +// SQL statements; the trapped transactions will be aborted.
 +// The TxnAborter needs to be hooked up to a Server's
 +// Knobs.StatementFilter, so that the Aborter sees what statements are being
 +// executed. This is done by calling HookupToExecutor(), which returns a
 +// stuitable ExecutorTestingKnobs.
 +// A statement can be registered for abortion (meaning, the statement's
 +// transaction will be TransactionAborted) with QueueStmtForAbortion(). When the
 +// Aborter sees that statement, it will run a higher priority transaction that
 +// tramples the data, so the original transaction will get a TransactionAborted
 +// error when it tries to commit.
 +//
 +// Note that transaction cannot be aborted using an injected error, since we
 +// want the pusher to clean up the intents of the pushee.
 +//
 +// The aborter only works with INSERT statements operating on the table t.test
 +// defined as:
 +//    CREATE DATABASE t; CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);`)
 +// The TxnAborter runs transactions deleting the row for the `k` that the
 +// trapped transactions were writing to.
 +//
 +// Be sure to set DisableAutoCommit on the ExecutorTestingKnobs, otherwise
 +// implicit transactions won't have a chance to be aborted.
 +// The TxnAborter should only be used in tests that set
 +// server.Context.TestingKnobs.ExecutorTestingKnobs.FixTxnPriority = true.
 +//
 +// Example usage:
 +//
 +//    func TestTxnAutoRetry(t *testing.T) {
 +//        defer leaktest.AfterTest(t)()
 +//        aborter := MakeTxnAborter()
 +//        defer aborter.Close(t)
 +//        params, cmdFilters := createTestServerParams()
 +//        executorKnobs := sql.ExecutorTestingKnobs{
 +//            FixTxnPriority: true,
 +//            // We're going to abort txns using a TxnAborter, and that's
 +//            // incompatible with AutoCommit.
 +//            DisableAutoCommit: true,
 +//        }
 +//        params.Knobs.SQLExecutor = aborter.HookupToExecutor(executorKnobs)
 +//        s, sqlDB, _ := serverutils.StartServer(t, params)
 +//        defer s.Stopper().Stop()
 +//        aborter.InitConn(t, s)
 +//
 +//    sqlDB.Exec(`
 +//        CREATE DATABASE t; CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);`)
 +//        sentinelInsert := "INSERT INTO t.test(k, v) VALUES (0, 'sentinel')"
 +//        aborter.QueueStmtForAbortion(t,
 +//                    sentinelInsert, 1 /* restartCount */, true /* willBeRetriedIbid */)
 +//        sqlDB.Exec(sentinelInsert)
 +//    ...
 +type TxnAborter struct {
 +  mu           syncutil.Mutex
 +  stmtsToAbort map[string]*restartInfo
 +  db           *gosql.DB
 +  cleanupDB    func()
 +}
 +
 +type restartInfo struct {
 +  // The numberic value being inserted in col 'k'.
 +  key int
 +  // The remaining number of times to abort the txn.
 +  restartCount   int
 +  satisfied      bool
 +  checkSatisfied bool
 +  // The number of times the statement as been executed.
 +  execCount int
 +}
 +
 +func MakeTxnAborter() *TxnAborter {
 +  return &TxnAborter{
 +      stmtsToAbort: make(map[string]*restartInfo),
 +  }
 +}
 +
 +// Close releases resources used by the TxnAborter and verifies that all
 +// the statements were aborted the intended number of times.
 +func (ta *TxnAborter) Close(t testing.TB) {
 +  if ta.db != nil {
 +      ta.db.Close()
 +      ta.cleanupDB()
 +      if r := recover(); r != nil {
 +          // Don't `verify()` if the test is panicking down (presumably because of a
 +          // Fatal or a timeout).
 +          panic(r)
 +      } else {
 +          ta.verify(t)
        }
    }
 -  if len(magicVals.txnsToFail) > 0 {
 -      file, line, _ := caller.Lookup(1)
 -      t.Errorf("%s:%d: txns still to be failed: %v", file, line, magicVals.txnsToFail)
 +}
 +
 +// InitConn opens a connection pool that the Aborter will use internally.
 +func (ta *TxnAborter) InitConn(t testing.TB, s serverutils.TestServerInterface) {
 +  // Open a second connection pool, to be used by aborts.
 +  // This is needed because the main conn pool is going to be restricted to one
 +  // connection.
 +  // TODO(andrei): remove this if we ever move to using libpq conns directly.
 +  // See TODOs around on SetMaxOpenConns.
 +  pgURL, cleanupDB := sqlutils.PGUrl(
 +      t, s.ServingAddr(), security.RootUser, "SecondConnPool")
 +  db, err := gosql.Open("postgres", pgURL.String())
 +  if err != nil {
 +      cleanupDB()
 +      t.Fatalf("error opening aborter connection: %s", err)
    }
 -  if t.Failed() {
 -      t.Fatalf("checking error injection failed")
 +  ta.db = db
 +  ta.cleanupDB = cleanupDB
 +}
 +
 +// QueueStmtForAbortion registers a statement whose transaction will be aborted.
 +//
 +// stmt needs to be the statement, literally as the parser will convert it back
 +// to a string.
 +// restartCount specifies how many times a txn running this statement will be
 +// aborted.
 +// willBeRetriedIbid should be set if the statement will be retried by the test
 +// (as an identical statement). This allows the TxnAborter to assert, on
 +// Close(), that the statement has been retried the intended number of times by
 +// the end of the test (besides asserting that an error was injected the right
 +// number of times. So, the Aborter can be used to check that the retry
 +// machinery has done its job. The Aborter will consider the statement to have
 +// been retried correctly if the statement has been executed at least once after
 +// the Aborter is done injecting errors because of it. So normally we'd expect
 +// this statement to executed RestartCount + 1 times, but we allow it to be
 +// retried more times because the statement's txn might also retried because of
 +// other statements.
 +//
 +// Calling QueueStmtForAbortion repeatedly with the same stmt is allowed, and
 +// each call checks that the previous one was satisfied.
 +func (ta *TxnAborter) QueueStmtForAbortion(
 +  t testing.TB, stmt string, restartCount int, willBeRetriedIbid bool,
 +) {
 +  ta.mu.Lock()
 +  defer ta.mu.Unlock()
 +  ri := ta.stmtsToAbort[stmt]
 +  if ri != nil {
 +      // If we're overwriting a statement that was already queued, verify that it
 +      // was satisfied.
 +      if err := ta.checkStmtSatisfied(stmt); err != nil {
 +          t.Errorf("%s: %s", testutils.Caller(1), err)
 +      }
 +  }
 +  // Extract the "key" - the value of the first col, which will be trampled on.
 +  re := regexp.MustCompile(`VALUES.*\((\d),`)
 +  matches := re.FindStringSubmatch(stmt)
 +  if matches == nil {
 +      t.Fatalf("bad statement: key col not found")
 +  }
 +  key, err := strconv.Atoi(matches[1])
 +  if err != nil {
 +      t.Fatalf("bad statement: key col is not a number")
 +  }
 +  ta.stmtsToAbort[stmt] = &restartInfo{
 +      key:            key,
 +      restartCount:   restartCount,
 +      satisfied:      false,
 +      checkSatisfied: willBeRetriedIbid,
 +  }
 +}
 +
 +// GetExecCount returns the number of times a statement has been seen.
 +// You probably don't want to call this while the TxnAborter might be in
 +// the process of aborting the txn containing stmt, as the result will not be
 +// deterministic.
 +func (ta *TxnAborter) GetExecCount(stmt string) (int, bool) {
 +  ta.mu.Lock()
 +  defer ta.mu.Unlock()
 +  ri, ok := ta.stmtsToAbort[stmt]
 +  if ok {
 +      return ri.execCount, ok
 +  } else {
 +      return 0, ok
 +  }
 +}
 +
 +// HookupToExecutor returns a modified ExecutorTestingKnobs with the
 +// StatementFilter hooked up to the TxnAborter.
 +func (ta *TxnAborter) HookupToExecutor(
 +  knobs sql.ExecutorTestingKnobs,
 +) base.ModuleTestingKnobs {
 +  if !knobs.FixTxnPriority || !knobs.DisableAutoCommit {
 +      panic("TxnAborter can only be installed when " +
 +          "FixTxnPriority and DisableAutoCommit are both specified")
 +  }
 +  if knobs.StatementFilter != nil {
 +      panic("a StatementFilter is already installed")
    }
 +  knobs.StatementFilter = ta.statementFilter
 +  return &knobs
  }

 -// TestTxnRestart tests the logic in the sql executor for automatically retrying
 -// txns in case of retriable errors.
 -func TestTxnRestart(t *testing.T) {
 +// statementFilter should be invoked for each SQL statement being executed.
 +// It's meant to be hooked up to an Executor by HookupToExecutor().
 +func (ta *TxnAborter) statementFilter(stmt string, res *sql.Result) {
 +  ta.mu.Lock()
 +  ri := ta.stmtsToAbort[stmt]
 +  shouldAbort := false
 +  if ri != nil {
 +      ri.execCount++
 +      if ri.restartCount == 0 {
-           log.VTracef(1, context.TODO(), "TxnAborter sees satisfied statement %q", stmt)
++          log.VEventf(1, context.TODO(), "TxnAborter sees satisfied statement %q", stmt)
 +          ri.satisfied = true
 +      }
 +      if ri.restartCount > 0 && res.Err == nil {
 +          log.Infof(context.TODO(), "TxnAborter aborting txn for statement %q", stmt)
 +          ri.restartCount--
 +          shouldAbort = true
 +      }
 +  }
 +  ta.mu.Unlock()
 +  if shouldAbort {
 +      err := ta.abortTxn(ri.key)
 +      if err != nil {
 +          res.Err = errors.Wrap(err, "TxnAborter failed to abort")
 +      }
 +  }
 +}
 +
 +// abortTxn writes to a key and as a side effect aborts a txn that had an intent
 +// on that key.
 +func (ta *TxnAborter) abortTxn(key int) error {
 +  var err error
 +  var tx *gosql.Tx
 +  tx, err = ta.db.Begin()
 +  if err != nil {
 +      return err
 +  }
 +  if _, err := tx.Exec("SET TRANSACTION PRIORITY HIGH"); err != nil {
 +      return err
 +  }
 +  if _, err := tx.Exec("DELETE FROM t.test WHERE k = $1", key); err != nil {
 +      return err
 +  }
 +  if err = tx.Commit(); err != nil {
 +      return err
 +  }
 +  return nil
 +}
 +
 +func (ta *TxnAborter) verify(t testing.TB) {
 +  ta.mu.Lock()
 +  defer ta.mu.Unlock()
 +  for stmt := range ta.stmtsToAbort {
 +      if err := ta.checkStmtSatisfied(stmt); err != nil {
 +          t.Error(err)
 +      }
 +  }
 +}
 +
 +func (ta *TxnAborter) checkStmtSatisfied(stmt string) error {
 +  ri := ta.stmtsToAbort[stmt]
 +  if ri == nil {
 +      return errors.Errorf("checkStmtSatisfied called for missing statement %q", stmt)
 +  }
 +  if ri.restartCount != 0 {
 +      return errors.Errorf("Statement %q still needs to be aborted %d times.",
 +          stmt, ri.restartCount)
 +  } else {
 +      if ri.checkSatisfied && !ri.satisfied {
 +          return errors.Errorf("Statement %q was not retried after its txn was aborted "+
 +              "the last time.", stmt)
 +      }
 +  }
 +  return nil
 +}
 +
 +// Test the logic in the sql executor for automatically retrying txns in case of
 +// retriable errors.
 +func TestTxnAutoRetry(t *testing.T) {
    defer leaktest.AfterTest(t)()

 +  aborter := MakeTxnAborter()
 +  defer aborter.Close(t)
    params, cmdFilters := createTestServerParams()
 +  executorKnobs := sql.ExecutorTestingKnobs{
 +      FixTxnPriority: true,
 +      // We're going to abort txns using a TxnAborter, and that's incompatible
 +      // with AutoCommit.
 +      DisableAutoCommit: true,
 +  }
 +  params.Knobs.SQLExecutor = aborter.HookupToExecutor(executorKnobs)
    // Disable one phase commits because they cannot be restarted.
    params.Knobs.Store.(*storage.StoreTestingKnobs).DisableOnePhaseCommits = true
    s, sqlDB, _ := serverutils.StartServer(t, params)
diff --cc storage/replica_command.go
index a2d9fbb,36221dc..f85673b
--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@@ -2322,10 -2343,10 +2322,10 @@@ func (r *Replica) AdminSplit
            // This prevents cases where splits are aborted early due to
            // conflicts with meta intents before the txn record has been
            // written (see #9265).
-           log.Trace(ctx, "updating left descriptor")
+           log.Event(ctx, "updating left descriptor")
            if err := txn.Run(b); err != nil {
                if _, ok := err.(*roachpb.ConditionFailedError); ok {
 -                  return errors.Errorf("conflict updating range descriptors")
 +                  return errors.New(ErrMsgConflictUpdatingRangeDesc)
                }
                return err
            }
@@@ -2366,10 -2387,10 +2366,10 @@@
        })

        // Commit txn with final batch (RHS desc and meta).
-       log.Trace(ctx, "commit txn with batch containing RHS descriptor and meta records")
+       log.Event(ctx, "commit txn with batch containing RHS descriptor and meta records")
        if err := txn.Run(b); err != nil {
            if _, ok := err.(*roachpb.ConditionFailedError); ok {
 -              return errors.Errorf("conflict updating range descriptors")
 +              return errors.New(ErrMsgConflictUpdatingRangeDesc)
            }
            return err
        }
diff --cc storage/replicate_queue.go
index 2beff9e,e114775..ced146f
--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@@ -139,8 -139,8 +139,8 @@@ func (rq *replicateQueue) process

    switch action {
    case AllocatorAdd:
-       log.Trace(ctx, "adding a new replica")
+       log.Event(ctx, "adding a new replica")
 -      newStore, err := rq.allocator.AllocateTarget(zone.ReplicaAttrs[0], desc.Replicas, true)
 +      newStore, err := rq.allocator.AllocateTarget(zone.Constraints, desc.Replicas, true)
        if err != nil {
            return err
        }
@@@ -190,9 -190,9 +190,9 @@@
        // We require the lease in order to process replicas, so
        // repl.store.StoreID() corresponds to the lease-holder's store ID.
        rebalanceStore := rq.allocator.RebalanceTarget(
 -          zone.ReplicaAttrs[0], desc.Replicas, repl.store.StoreID())
 +          zone.Constraints, desc.Replicas, repl.store.StoreID())
        if rebalanceStore == nil {
-           log.VTracef(1, ctx, "no suitable rebalance target")
+           log.VEventf(1, ctx, "no suitable rebalance target")
            // No action was necessary and no rebalance target was found. Return
            // without re-queuing this replica.
            return nil
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9417)

<!-- Reviewable:end -->
