### PR TITLE
kv: resolve intents from a DelRange using a minimal span

### DIFF
--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -746,7 +746,10 @@ func (r *Replica) resolveLocalIntents(
 			}
 			if inSpan != nil {
 				intent.Span = *inSpan
-				_, err := engine.MVCCResolveWriteIntentRangeUsingIter(ctx, batch, iterAndBuf, ms, intent, math.MaxInt64)
+				num, err := engine.MVCCResolveWriteIntentRangeUsingIter(ctx, batch, iterAndBuf, ms, intent, math.MaxInt64)
+				if r.store.ctx.TestingKnobs.NumKeysEvaluatedForRangeIntentResolution != nil {
+					atomic.AddInt64(r.store.ctx.TestingKnobs.NumKeysEvaluatedForRangeIntentResolution, num)
+				}
 				return err
 			}
 			return nil

--- a/storage/store.go
+++ b/storage/store.go
@@ -569,6 +569,9 @@ type StoreTestingKnobs struct {
 	// process ranges that need to be split, for use in tests that use
 	// the replication queue but disable the split queue.
 	ReplicateQueueAcceptsUnsplit bool
+	// NumKeysEvaluatedForRangeIntentResolution is set by the stores to the
+	// number of keys evaluated for range intent resolution.
+	NumKeysEvaluatedForRangeIntentResolution *int64
 }
 
 var _ base.ModuleTestingKnobs = &StoreTestingKnobs{}


### PR DESCRIPTION
We were originally using the span passed into DelRange to resolve
intents, even when the DelRange was limited using MaxSpanRequestKeys.
As a result, after a DelRange() over a large span was committed, the
intent resolution would attempt to resolve all the keys in the span
even when only a few were deleted.

Now, when the MaxSpanRequestKeys limit is hit intent resolution will only
traverse the keys that were deleted.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9419)

<!-- Reviewable:end -->
