### PR TITLE
tracing: set txnID in the sql Span and propagate it

### DIFF
--- a/util/tracing/tracer.go
+++ b/util/tracing/tracer.go
@@ -50,6 +50,10 @@ func JoinOrNew(tr opentracing.Tracer, carrier *Span, opName string) (opentracing
 		switch err {
 		case nil:
 			sp := tr.StartSpan(opName, opentracing.FollowsFrom(wireContext))
+
+			// Copy baggage items to tags so they show up in the Lightstep UI.
+			sp.Context().ForeachBaggageItem(func(k, v string) bool { sp.SetTag(k, v); return true })
+
 			sp.LogEvent(opName)
 			return sp, nil
 		case opentracing.ErrSpanContextNotFound:


### PR DESCRIPTION
We set the txnID as a tag and baggage item in the sql span. The baggage item
makes it over the wire, where we copy it to a tag. We need to set the tags in
addition to the baggage items because only the tags show up in the Lightstep UI.

This is not the final word on this. We may find a more generic way to do this,
like putting the `txnID` in the context and automatically setting span tags
based on log tags. But this change should help debugging for the time being,
and it will give us a better idea of the requirements.

This enables searching for the trace of a given txn in Lighstep.

Sample: https://app.lightstep.com/radutest/trace?span_guid=3aff1e7809d8cd78&at_micros=1474036500598764#span-3aff1e7809d8cd78

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9425)

<!-- Reviewable:end -->
