### PR TITLE
docs: Create 5 kube replicas, not 6

### DIFF
--- a/cloud/kubernetes/cockroachdb-petset.yaml
+++ b/cloud/kubernetes/cockroachdb-petset.yaml
@@ -54,7 +54,7 @@ metadata:
   name: cockroachdb
 spec:
   serviceName: "cockroachdb"
-  replicas: 6
+  replicas: 5
   template:
     metadata:
       labels:


### PR DESCRIPTION
This was a mistake I made in copying things over from our example in the kubnernetes repository. The idea is to start with 5 and then scale up to 6, as described in https://www.cockroachlabs.com/docs/orchestrate-cockroachdb-with-kubernetes.html

@jseldess

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9427)

<!-- Reviewable:end -->
