### PR TITLE
storage: compact printing of key ranges

### DIFF
--- a/keys/printer_test.go
+++ b/keys/printer_test.go
@@ -177,3 +177,33 @@ func TestPrettyPrint(t *testing.T) {
 		}
 	}
 }
+
+func TestPrettyPrintRange(t *testing.T) {
+	tableKey := makeKey(MakeTablePrefix(61), encoding.EncodeVarintAscending(nil, 4))
+	tableKey2 := makeKey(MakeTablePrefix(61), encoding.EncodeVarintAscending(nil, 500))
+
+	testCases := []struct {
+		start, end roachpb.Key
+		maxChars   int
+		expected   string
+	}{
+		{MinKey, tableKey, 8, "/{M…-T…}"},
+		{MinKey, tableKey, 15, "/{Min-Tabl…}"},
+		{MinKey, tableKey, 20, "/{Min-Table/6…}"},
+		{MinKey, tableKey, 25, "/{Min-Table/61/4}"},
+		{tableKey, tableKey2, 8, "/Table/…"},
+		{tableKey, tableKey2, 15, "/Table/61/…"},
+		{tableKey, tableKey2, 20, "/Table/61/{4-500}"},
+		{tableKey, MaxKey, 10, "/{Ta…-Max}"},
+		{tableKey, MaxKey, 20, "/{Table/6…-Max}"},
+		{tableKey, MaxKey, 25, "/{Table/61/4-Max}"},
+	}
+
+	for i, tc := range testCases {
+		var buf bytes.Buffer
+		PrettyPrintRange(&buf, tc.start, tc.end, tc.maxChars)
+		if str := buf.String(); str != tc.expected {
+			t.Errorf("%d: expected \"%s\", got \"%s\"", i, tc.expected, str)
+		}
+	}
+}

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -177,30 +177,30 @@ type replicaChecksum struct {
 	snapshot *roachpb.RaftSnapshotData
 }
 
-type atomicRangeDesc struct {
-	descPtr unsafe.Pointer
+type atomicDescString struct {
+	strPtr unsafe.Pointer
 }
 
-func (d *atomicRangeDesc) store(desc *roachpb.RangeDescriptor) {
-	atomic.StorePointer(&d.descPtr, unsafe.Pointer(desc))
-}
+// store atomically updates d.strPtr with the string representation of desc.
+func (d *atomicDescString) store(desc *roachpb.RangeDescriptor) {
+	const maxRangeChars = 30
+	var str string
+	if !desc.IsInitialized() {
+		str = fmt.Sprintf("%d:{-}", desc.RangeID)
+	} else {
+		var buf bytes.Buffer
+		fmt.Fprintf(&buf, "%d:", desc.RangeID)
+		keys.PrettyPrintRange(&buf, roachpb.Key(desc.StartKey), roachpb.Key(desc.EndKey), maxRangeChars)
+		str = buf.String()
+	}
 
-func (d *atomicRangeDesc) load() *roachpb.RangeDescriptor {
-	return (*roachpb.RangeDescriptor)(atomic.LoadPointer(&d.descPtr))
+	atomic.StorePointer(&d.strPtr, unsafe.Pointer(&str))
 }
 
 // String returns the string representation of the range; since we are not
 // using a lock, the copy might be inconsistent.
-func (d *atomicRangeDesc) String() string {
-	inconsistentDesc := d.load()
-	if !inconsistentDesc.IsInitialized() {
-		return fmt.Sprintf("%d{-}", inconsistentDesc.RangeID)
-	}
-	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "%d:", inconsistentDesc.RangeID)
-	keys.PrettyPrintRange(&buf, roachpb.Key(inconsistentDesc.StartKey),
-		roachpb.Key(inconsistentDesc.EndKey), 30)
-	return buf.String()
+func (d *atomicDescString) String() string {
+	return *(*string)(atomic.LoadPointer(&d.strPtr))
 }
 
 // A Replica is a contiguous keyspace with writes managed via an
@@ -233,10 +233,10 @@ type Replica struct {
 	// RWMutex.
 	readOnlyCmdMu syncutil.RWMutex
 
-	// rangeDesc is a *RangeDescriptor that can be atomically read from in
-	// replica.Desc() without needing to acquire the replica.mu lock. All
-	// updates to state.Desc should be duplicated here
-	rangeDesc atomicRangeDesc
+	// rangeStr is a string representation of a RangeDescriptor that cam be
+	// atomically read and updated without needing to acquire the replica.mu lock.
+	// All updates to state.Desc should be duplicated here.
+	rangeStr atomicDescString
 
 	// raftMu protects Raft processing the replica. Note that Raft processing for
 	// uninitialized replicas is also protected by Store.uninitRaftMu, but that
@@ -538,15 +538,15 @@ func (r *Replica) initLocked(
 	if r.mu.state, err = loadState(ctx, r.store.Engine(), desc); err != nil {
 		return err
 	}
-	r.rangeDesc.store(r.mu.state.Desc)
+	r.rangeStr.store(r.mu.state.Desc)
 
 	r.mu.lastIndex, err = loadLastIndex(ctx, r.store.Engine(), r.RangeID)
 	if err != nil {
 		return err
 	}
 
-	// Add replica log tags - the value is rangeDesc.String().
-	ctx = log.WithLogTag(ctx, "r", &r.rangeDesc)
+	// Add replica log tags - the value is rangeStr.String().
+	ctx = log.WithLogTag(ctx, "r", &r.rangeStr)
 	r.ctx = ctx
 
 	pErr, err := loadReplicaDestroyedError(ctx, r.store.Engine(), r.RangeID)
@@ -586,7 +586,7 @@ func (r *Replica) logContext(ctx context.Context) context.Context {
 // require a lock and its output may not be atomic with other ongoing work in
 // the replica. This is done to prevent deadlocks in logging sites.
 func (r *Replica) String() string {
-	return fmt.Sprintf("[n%d,s%d,r%s]", r.store.Ident.NodeID, r.store.Ident.StoreID, &r.rangeDesc)
+	return fmt.Sprintf("[n%d,s%d,r%s]", r.store.Ident.NodeID, r.store.Ident.StoreID, &r.rangeStr)
 }
 
 // Destroy clears pending command queue by sending each pending
@@ -897,9 +897,7 @@ func (r *Replica) setDescWithoutProcessUpdate(desc *roachpb.RangeDescriptor) {
 			r.mu.state.Desc, desc)
 	}
 
-	// NB: If we used rangeDesc for anything but informational purposes, the
-	// order here would be crucial.
-	r.rangeDesc.store(desc)
+	r.rangeStr.store(desc)
 	r.mu.state.Desc = desc
 
 	r.raftMu.initialized = r.isInitializedLocked()
@@ -1062,7 +1060,7 @@ func (r *Replica) Send(
 		return nil, roachpb.NewError(err)
 	}
 	// Add the range log tag.
-	ctx = log.WithLogTag(ctx, "r", &r.rangeDesc)
+	ctx = log.WithLogTag(ctx, "r", &r.rangeStr)
 	ctx, cleanup := tracing.EnsureContext(ctx, r.store.Tracer())
 	defer cleanup()
 

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -196,8 +196,11 @@ func (d *atomicRangeDesc) String() string {
 	if !inconsistentDesc.IsInitialized() {
 		return fmt.Sprintf("%d{-}", inconsistentDesc.RangeID)
 	}
-	return fmt.Sprintf("%d{%s-%s}",
-		inconsistentDesc.RangeID, inconsistentDesc.StartKey, inconsistentDesc.EndKey)
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d:", inconsistentDesc.RangeID)
+	keys.PrettyPrintRange(&buf, roachpb.Key(inconsistentDesc.StartKey),
+		roachpb.Key(inconsistentDesc.EndKey), 30)
+	return buf.String()
 }
 
 // A Replica is a contiguous keyspace with writes managed via an

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -362,7 +362,7 @@ func TestReplicaContains(t *testing.T) {
 	// This test really only needs a hollow shell of a Replica.
 	r := &Replica{}
 	r.mu.state.Desc = desc
-	r.rangeDesc.store(desc)
+	r.rangeStr.store(desc)
 
 	if statsKey := keys.RangeStatsKey(desc.RangeID); !r.ContainsKey(statsKey) {
 		t.Errorf("expected range to contain range stats key %q", statsKey)


### PR DESCRIPTION
The range tags can be very long and distracting. This change adds a pretty print
function for ranges which limits the number of characters printed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9431)

<!-- Reviewable:end -->
