### PR TITLE
storage: Support deferred cancellation in the CommandQueue

### DIFF
--- a/pkg/storage/command_queue.go
+++ b/pkg/storage/command_queue.go
@@ -32,18 +32,20 @@ import (
 // executing commands. New commands affecting keys or key ranges must
 // wait on already-executing commands which overlap their key range.
 //
-// Before executing, a command invokes getWait() to acquire a slice of
-// channels belonging to overlapping commands which are already
-// running. Each channel is waited on by the caller for confirmation
-// that all overlapping, pending commands have completed and the
-// pending command can proceed.
+// Before executing, a command invokes getPrereqs() to acquire a slice of
+// references to overlapping commands that are already in the command queue.
+// After determining its prerequisite commands, the command is added to the
+// queue via add(). getPrereqs() and add() accept a parameter indicating whether
+// the command is read-only. Read-only commands don't need to wait on other
+// read-only commands, so the commands returned via getPrereqs() don't include
+// read-only on read-only overlapping commands as an optimization. Both getPrereqs()
+// and add() must see an atomic view of the command queue, so in a concurrent setting,
+// their execution must be synchronized under the same lock.
 //
-// After waiting, a command is added to the queue's already-executing
-// set via add(). add accepts a parameter indicating whether the
-// command is read-only. Read-only commands don't need to wait on other
-// read-only commands, so the channels returned via getWait() don't
-// include read-only on read-only overlapping commands as an
-// optimization.
+// After determining prerequisite commands and adding the new command to the
+// command queue, the new command must wait on each prerequisite command's
+// pending channel for confirmation that all overlapping commands have completed
+// and that the new command can proceed.
 //
 // Once commands complete, remove() is invoked to remove the executing
 // command and close its channel, possibly signaling waiting commands
@@ -55,8 +57,8 @@ type CommandQueue struct {
 	reads       interval.Tree
 	writes      interval.Tree
 	idAlloc     int64
-	wRg, rwRg   interval.RangeGroup // avoids allocating in getWait
-	oHeap       overlapHeap         // avoids allocating in getWait
+	wRg, rwRg   interval.RangeGroup // avoids allocating in getPrereqs
+	oHeap       overlapHeap         // avoids allocating in getPrereqs
 	overlaps    []*cmd              // avoids allocating in getOverlaps
 
 	coveringOptimization bool // if true, use covering span optimization
@@ -75,10 +77,14 @@ type cmd struct {
 	key       interval.Range
 	readOnly  bool
 	timestamp hlc.Timestamp
-	expanded  bool          // have the children been added
-	buffered  bool          // is this cmd buffered in readsBuffer
+
+	buffered bool // is this cmd buffered in readsBuffer
+	expanded bool // have the children been added
+	children []cmd
+
+	prereqs   []*cmd
 	pending   chan struct{} // closed when complete
-	children  []cmd
+	cancelled bool
 }
 
 // ID implements interval.Interface.
@@ -212,20 +218,22 @@ func (cq *CommandQueue) expand(c *cmd, isInserted bool) bool {
 	return true
 }
 
-// getWait returns a slice of the pending channels of executing
-// commands which overlap the specified key ranges. The caller
-// should then invoke add() to add the keys to the command queue and
-// then wait for confirmation that all gating commands have completed
-// or failed. readOnly is true if the requester is a read-only
-// command; false for read-write. The provided timestamp, if non-zero,
-// is used to allow reads to proceed if they are at earlier timestamps
-// than pending writes, and writes to proceed if they are at later
-// timestamps than pending reads.
-func (cq *CommandQueue) getWait(
+// getPrereqs returns a slice of the prerequisite commands which overlap the
+// specified key ranges. The caller should invoke add() to add the keys to the
+// command queue and then wait for confirmation that all gating commands have
+// completed or failed by waiting for each of their pending channels to close.
+//
+// readOnly is true if the requester is a read-only command; false for read-write.
+// The provided timestamp, if non-zero, is used to allow reads to proceed if they
+// are at earlier timestamps than pending writes, and writes to proceed if they are
+// at later timestamps than pending reads.
+func (cq *CommandQueue) getPrereqs(
 	readOnly bool, timestamp hlc.Timestamp, spans []roachpb.Span,
-) (chans []<-chan struct{}) {
+) (prereqs []*cmd) {
 	prepareSpans(spans)
 
+	// Loop over all spans. This cannot be a for-range loop, because the
+	// loop counter may be adjusted within the loop.
 	for i := 0; i < len(spans); i++ {
 		span := spans[i]
 		if span.EndKey == nil {
@@ -253,17 +261,16 @@ func (cq *CommandQueue) getWait(
 
 		// Sort overlapping commands by command ID and iterate from latest to earliest,
 		// adding the commands' ranges to the RangeGroup to determine gating keyspace
-		// command dependencies. Because all commands are given WaitGroup dependencies
-		// to the most recent commands that they are dependent on, and because of the
-		// causality provided by the strictly increasing command ID allocation, this
-		// approach will construct a DAG-like dependency graph between WaitGroups with
-		// overlapping keys. This comes as an alternative to creating explicit WaitGroups
+		// command dependencies. Because all commands are given dependencies to the most
+		// recent commands that they are dependent on, and because of the causality provided
+		// by the strictly increasing command ID allocation, this approach will construct
+		// a DAG-like dependency graph between returned prerequisite commands with
+		// overlapping keys. This comes as an alternative to returning explicit prerequisite
 		// dependencies to all gating commands for each new command, which could result
 		// in an exponential dependency explosion.
 		//
 		// For example, consider the following 5 write commands, each with key ranges
-		// represented on the x axis and WaitGroup dependencies represented by vertical
-		// lines:
+		// represented on the x axis and dependencies represented by vertical lines:
 		//
 		// cmd 1:   --------------
 		//           |      |
@@ -278,9 +285,28 @@ func (cq *CommandQueue) getWait(
 		// Instead of having each command establish explicit dependencies on all previous
 		// overlapping commands, each command only needs to establish explicit dependencies
 		// on the set of overlapping commands closest to the new command that together span
-		// the new command's overlapped range. Following this strategy, the other dependencies
+		// the new command's key range. Following this strategy, the other dependencies
 		// will be implicitly enforced, which reduces memory utilization and synchronization
 		// costs.
+		//
+		// This approach is improved further by noting that dependencies on overlapping
+		// commands (even those that cover additional portions of the new command) that are
+		// transitive dependencies of commands that we have already established a dependency
+		// on can be safely ignored. This is safe because dependencies will be transitively
+		// enforced. Following this strategy, all command dependencies will be enforced
+		// without the need for the majority of dependencies to be held explicitly, which
+		// reduces memory utilization and synchronization costs. All together, the final
+		// dependency graph will look something like:
+		//
+		// cmd 1:   --------------
+		//                  |
+		// cmd 2:       -------------
+		//                |
+		// cmd 3:    -------
+		//                |
+		// cmd 4:         -------
+		//                   |
+		// cmd 5:         -------
 		//
 		// The exception are existing reads: since reads don't wait for each other, an incoming
 		// write must wait for reads even when they are covered by a "later" read (since that
@@ -353,7 +379,7 @@ func (cq *CommandQueue) getWait(
 					if cmd.pending == nil {
 						cmd.pending = make(chan struct{})
 					}
-					chans = append(chans, cmd.pending)
+					prereqs = append(prereqs, cmd)
 				}
 			} else {
 				if cmdHasTimestamp {
@@ -385,7 +411,7 @@ func (cq *CommandQueue) getWait(
 					if cmd.pending == nil {
 						cmd.pending = make(chan struct{})
 					}
-					chans = append(chans, cmd.pending)
+					prereqs = append(prereqs, cmd)
 				}
 
 				// The current command is a write, so add it to the write RangeGroup.
@@ -406,11 +432,11 @@ func (cq *CommandQueue) getWait(
 		cq.wRg.Clear()
 		cq.rwRg.Clear()
 	}
-	return chans
+	return prereqs
 }
 
 // getOverlaps returns a slice of values which overlap the specified
-// interval. The slice is only valid until the next call to GetOverlaps.
+// interval. The slice is only valid until the next call to getOverlaps.
 func (cq *CommandQueue) getOverlaps(
 	readOnly bool, timestamp hlc.Timestamp, rng interval.Range,
 ) []*cmd {
@@ -454,8 +480,7 @@ func (cq *CommandQueue) getOverlaps(
 	return overlaps
 }
 
-// overlapHeap is a max-heap of cache.Overlaps, sorting the elements
-// in decreasing Value.(*cmd).id order.
+// overlapHeap is a max-heap ordered by cmd.id.
 type overlapHeap []*cmd
 
 func (o overlapHeap) Len() int { return len(o) }
@@ -489,19 +514,17 @@ func (o *overlapHeap) PopOverlap() *cmd {
 	return x.(*cmd)
 }
 
-// add adds commands to the queue which affect the specified key ranges. Ranges
-// without an end key affect only the start key. The returned interface is the
-// key for the command queue and must be re-supplied on subsequent invocation
-// of remove().
+// add adds commands to the queue which affect the specified key ranges with the provided
+// prerequisites, determined by getPrereqs(). Ranges without an end key affect only the
+// start key. The returned command must be re-supplied on subsequent invocation of remove().
 //
 // Either all supplied spans must be range-global or range-local. Failure to
 // obey with this restriction results in a fatal error.
 //
 // Returns a nil `cmd` when no spans are given.
-//
-// add should be invoked after waiting on already-executing, overlapping
-// commands via the WaitGroup initialized through getWait().
-func (cq *CommandQueue) add(readOnly bool, timestamp hlc.Timestamp, spans []roachpb.Span) *cmd {
+func (cq *CommandQueue) add(
+	readOnly bool, timestamp hlc.Timestamp, prereqs []*cmd, spans []roachpb.Span,
+) *cmd {
 	if len(spans) == 0 {
 		return nil
 	}
@@ -543,8 +566,9 @@ func (cq *CommandQueue) add(readOnly bool, timestamp hlc.Timestamp, spans []roac
 	cmd.key = coveringSpan.AsRange()
 	cmd.readOnly = readOnly
 	cmd.timestamp = timestamp
-	cmd.expanded = false
+	cmd.prereqs = prereqs
 
+	cmd.expanded = false
 	if len(spans) > 1 {
 		// Populate the covering entry's children.
 		cmd.children = cmds[1:]

--- a/pkg/storage/command_queue_test.go
+++ b/pkg/storage/command_queue_test.go
@@ -27,40 +27,37 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
-func getWait(
-	cq *CommandQueue, from, to roachpb.Key, readOnly bool, ts hlc.Timestamp,
-) []<-chan struct{} {
-	return cq.getWait(readOnly, ts, []roachpb.Span{{Key: from, EndKey: to}})
+var zeroTS = hlc.Timestamp{}
+
+func getPrereqs(cq *CommandQueue, from, to roachpb.Key, readOnly bool) []*cmd {
+	return cq.getPrereqs(readOnly, zeroTS, []roachpb.Span{{Key: from, EndKey: to}})
 }
 
-func add(cq *CommandQueue, from, to roachpb.Key, readOnly bool, ts hlc.Timestamp) *cmd {
-	return cq.add(readOnly, ts, []roachpb.Span{{Key: from, EndKey: to}})
+func add(cq *CommandQueue, from, to roachpb.Key, readOnly bool, prereqs []*cmd) *cmd {
+	return cq.add(readOnly, zeroTS, prereqs, []roachpb.Span{{Key: from, EndKey: to}})
 }
 
-func getWaitAndAdd(
-	cq *CommandQueue, from, to roachpb.Key, readOnly bool, ts hlc.Timestamp,
-) ([]<-chan struct{}, *cmd) {
-	return getWait(cq, from, to, readOnly, ts), add(cq, from, to, readOnly, ts)
+func getPrereqsAndAdd(cq *CommandQueue, from, to roachpb.Key, readOnly bool) ([]*cmd, *cmd) {
+	prereqs := getPrereqs(cq, from, to, readOnly)
+	return prereqs, add(cq, from, to, readOnly, prereqs)
 }
 
-func waitCmdDone(chans []<-chan struct{}) {
-	for _, ch := range chans {
-		<-ch
+func waitCmdDone(prereqs []*cmd) {
+	for _, prereq := range prereqs {
+		<-prereq.pending
 	}
 }
 
-var zeroTS = hlc.Timestamp{}
-
-// testCmdDone waits for the cmdDone channel to be closed for at most
-// the specified wait duration. Returns true if the command finished in
+// testCmdDone waits for the prereqs' pending channels to be closed for at
+// most the specified wait duration. Returns true if the command finished in
 // the allotted time, false otherwise.
-func testCmdDone(chans []<-chan struct{}, wait time.Duration) bool {
+func testCmdDone(prereqs []*cmd, wait time.Duration) bool {
 	t := time.After(wait)
-	for _, ch := range chans {
+	for _, prereq := range prereqs {
 		select {
 		case <-t:
 			return false
-		case <-ch:
+		case <-prereq.pending:
 		}
 	}
 	return true
@@ -68,14 +65,14 @@ func testCmdDone(chans []<-chan struct{}, wait time.Duration) bool {
 
 // checkCmdDoesNotFinish makes sure that the command waiting on the provided channels
 // does not finish, returning false if this assertion fails.
-func checkCmdDoesNotFinish(t *testing.T, chans []<-chan struct{}) bool {
-	return !testCmdDone(chans, 3*time.Millisecond)
+func checkCmdDoesNotFinish(prereqs []*cmd) bool {
+	return !testCmdDone(prereqs, 3*time.Millisecond)
 }
 
 // checkCmdFinishes makes sure that the command waiting on the provided channels
 // finishes, returning false if this assertion fails.
-func checkCmdFinishes(t *testing.T, chans []<-chan struct{}) bool {
-	return testCmdDone(chans, 15*time.Millisecond)
+func checkCmdFinishes(prereqs []*cmd) bool {
+	return testCmdDone(prereqs, 15*time.Millisecond)
 }
 
 func TestCommandQueue(t *testing.T) {
@@ -83,17 +80,17 @@ func TestCommandQueue(t *testing.T) {
 	cq := NewCommandQueue(true)
 
 	// Try a command with no overlapping already-running commands.
-	waitCmdDone(getWait(cq, roachpb.Key("a"), nil, false, zeroTS))
-	waitCmdDone(getWait(cq, roachpb.Key("a"), roachpb.Key("b"), false, zeroTS))
+	waitCmdDone(getPrereqs(cq, roachpb.Key("a"), nil, false))
+	waitCmdDone(getPrereqs(cq, roachpb.Key("a"), roachpb.Key("b"), false))
 
 	// Add a command and verify dependency on it.
-	wk := add(cq, roachpb.Key("a"), nil, false, zeroTS)
-	chans := getWait(cq, roachpb.Key("a"), nil, false, zeroTS)
-	if !checkCmdDoesNotFinish(t, chans) {
+	cmd1 := add(cq, roachpb.Key("a"), nil, false, nil)
+	prereqs := getPrereqs(cq, roachpb.Key("a"), nil, false)
+	if !checkCmdDoesNotFinish(prereqs) {
 		t.Fatal("command should not finish with command outstanding")
 	}
-	cq.remove(wk)
-	if !checkCmdFinishes(t, chans) {
+	cq.remove(cmd1)
+	if !checkCmdFinishes(prereqs) {
 		t.Fatal("command should finish with no commands outstanding")
 	}
 }
@@ -107,32 +104,32 @@ func TestCommandQueueWriteWaitForNonAdjacentRead(t *testing.T) {
 	cq := NewCommandQueue(true)
 	key := roachpb.Key("a")
 	// Add a read-only command.
-	wk1 := add(cq, key, nil, true, zeroTS)
+	cmd1 := add(cq, key, nil, true, nil)
 	// Add another one on top.
-	wk2 := add(cq, key, nil, true, zeroTS)
+	cmd2 := add(cq, key, nil, true, nil)
 
 	// A write should have to wait for **both** reads, not only the second
 	// one.
-	chans := getWait(cq, key, nil, false /* !readOnly */, zeroTS)
+	prereqs := getPrereqs(cq, key, nil, false /* !readOnly */)
 
 	// Certainly blocks now.
-	if !checkCmdDoesNotFinish(t, chans) {
+	if !checkCmdDoesNotFinish(prereqs) {
 		t.Fatal("command should not finish with command outstanding")
 	}
 
 	// The second read returns, but the first one remains.
-	cq.remove(wk2)
+	cq.remove(cmd2)
 
 	// Should still block. This being broken is why this test exists.
-	if !checkCmdDoesNotFinish(t, chans) {
+	if !checkCmdDoesNotFinish(prereqs) {
 		t.Fatal("command should not finish with command outstanding")
 	}
 
 	// First read returns.
-	cq.remove(wk1)
+	cq.remove(cmd1)
 
 	// Now it goes through.
-	if !checkCmdFinishes(t, chans) {
+	if !checkCmdFinishes(prereqs) {
 		t.Fatal("command should finish with no commands outstanding")
 	}
 }
@@ -141,16 +138,16 @@ func TestCommandQueueNoWaitOnReadOnly(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	cq := NewCommandQueue(true)
 	// Add a read-only command.
-	chans1, wk := getWaitAndAdd(cq, roachpb.Key("a"), nil, true, zeroTS)
+	prereqs1, cmd1 := getPrereqsAndAdd(cq, roachpb.Key("a"), nil, true)
 	// Verify no wait on another read-only command.
-	waitCmdDone(chans1)
+	waitCmdDone(prereqs1)
 	// Verify wait with a read-write command.
-	chans2 := getWait(cq, roachpb.Key("a"), nil, false, zeroTS)
-	if !checkCmdDoesNotFinish(t, chans2) {
+	prereqs2 := getPrereqs(cq, roachpb.Key("a"), nil, false)
+	if !checkCmdDoesNotFinish(prereqs2) {
 		t.Fatal("command should not finish with command outstanding")
 	}
-	cq.remove(wk)
-	if !checkCmdFinishes(t, chans2) {
+	cq.remove(cmd1)
+	if !checkCmdFinishes(prereqs2) {
 		t.Fatal("command should finish with no commands outstanding")
 	}
 }
@@ -160,20 +157,20 @@ func TestCommandQueueMultipleExecutingCommands(t *testing.T) {
 	cq := NewCommandQueue(true)
 
 	// Add multiple commands and add a command which overlaps them all.
-	wk1 := add(cq, roachpb.Key("a"), nil, false, zeroTS)
-	wk2 := add(cq, roachpb.Key("b"), roachpb.Key("c"), false, zeroTS)
-	wk3 := add(cq, roachpb.Key("0"), roachpb.Key("d"), false, zeroTS)
-	chans := getWait(cq, roachpb.Key("a"), roachpb.Key("cc"), false, zeroTS)
-	cq.remove(wk1)
-	if !checkCmdDoesNotFinish(t, chans) {
+	cmd1 := add(cq, roachpb.Key("a"), nil, false, nil)
+	cmd2 := add(cq, roachpb.Key("b"), roachpb.Key("c"), false, nil)
+	cmd3 := add(cq, roachpb.Key("0"), roachpb.Key("d"), false, nil)
+	prereqs := getPrereqs(cq, roachpb.Key("a"), roachpb.Key("cc"), false)
+	cq.remove(cmd1)
+	if !checkCmdDoesNotFinish(prereqs) {
 		t.Fatal("command should not finish with two commands outstanding")
 	}
-	cq.remove(wk2)
-	if !checkCmdDoesNotFinish(t, chans) {
+	cq.remove(cmd2)
+	if !checkCmdDoesNotFinish(prereqs) {
 		t.Fatal("command should not finish with one command outstanding")
 	}
-	cq.remove(wk3)
-	if !checkCmdFinishes(t, chans) {
+	cq.remove(cmd3)
+	if !checkCmdFinishes(prereqs) {
 		t.Fatal("command should finish with no commands outstanding")
 	}
 }
@@ -183,29 +180,29 @@ func TestCommandQueueMultiplePendingCommands(t *testing.T) {
 	cq := NewCommandQueue(true)
 
 	// Add a command which will overlap all commands.
-	wk0 := add(cq, roachpb.Key("a"), roachpb.Key("d"), false, zeroTS)
-	chans1, wk1 := getWaitAndAdd(cq, roachpb.Key("a"), roachpb.Key("b").Next(), false, zeroTS)
-	chans2 := getWait(cq, roachpb.Key("b"), nil, false, zeroTS)
-	chans3 := getWait(cq, roachpb.Key("c"), nil, false, zeroTS)
+	wk0 := add(cq, roachpb.Key("a"), roachpb.Key("d"), false, nil)
+	prereqs1, cmd1 := getPrereqsAndAdd(cq, roachpb.Key("a"), roachpb.Key("b").Next(), false)
+	prereqs2 := getPrereqs(cq, roachpb.Key("b"), nil, false)
+	prereqs3 := getPrereqs(cq, roachpb.Key("c"), nil, false)
 
-	for i, chans := range [][]<-chan struct{}{chans1, chans2, chans3} {
-		if !checkCmdDoesNotFinish(t, chans) {
+	for i, prereqs := range [][]*cmd{prereqs1, prereqs2, prereqs3} {
+		if !checkCmdDoesNotFinish(prereqs) {
 			t.Fatalf("command %d should not finish with command 0 outstanding", i+1)
 		}
 	}
 
 	cq.remove(wk0)
-	if !checkCmdFinishes(t, chans1) {
+	if !checkCmdFinishes(prereqs1) {
 		t.Fatal("command 1 should finish")
 	}
-	if !checkCmdFinishes(t, chans3) {
+	if !checkCmdFinishes(prereqs3) {
 		t.Fatal("command 3 should finish")
 	}
-	if !checkCmdDoesNotFinish(t, chans2) {
+	if !checkCmdDoesNotFinish(prereqs2) {
 		t.Fatal("command 2 should remain outstanding")
 	}
-	cq.remove(wk1)
-	if !checkCmdFinishes(t, chans2) {
+	cq.remove(cmd1)
+	if !checkCmdFinishes(prereqs2) {
 		t.Fatal("command 2 should finish with no commands outstanding")
 	}
 }
@@ -215,37 +212,37 @@ func TestCommandQueueRemove(t *testing.T) {
 	cq := NewCommandQueue(true)
 
 	// Add multiple commands and commands which access each.
-	wk1 := add(cq, roachpb.Key("a"), nil, false, zeroTS)
-	wk2 := add(cq, roachpb.Key("b"), nil, false, zeroTS)
-	chans1 := getWait(cq, roachpb.Key("a"), nil, false, zeroTS)
-	chans2 := getWait(cq, roachpb.Key("b"), nil, false, zeroTS)
+	cmd1 := add(cq, roachpb.Key("a"), nil, false, nil)
+	cmd2 := add(cq, roachpb.Key("b"), nil, false, nil)
+	prereqs1 := getPrereqs(cq, roachpb.Key("a"), nil, false)
+	prereqs2 := getPrereqs(cq, roachpb.Key("b"), nil, false)
 
 	// Remove the commands from the queue and verify both commands are signaled.
-	cq.remove(wk1)
-	cq.remove(wk2)
+	cq.remove(cmd1)
+	cq.remove(cmd2)
 
-	for i, chans := range [][]<-chan struct{}{chans1, chans2} {
-		if !checkCmdFinishes(t, chans) {
+	for i, prereqs := range [][]*cmd{prereqs1, prereqs2} {
+		if !checkCmdFinishes(prereqs) {
 			t.Fatalf("command %d should finish with clearing queue", i+1)
 		}
 	}
 }
 
 // TestCommandQueueExclusiveEnd verifies that an end key is treated as
-// an exclusive end when GetWait calculates overlapping commands. Test
-// it by calling GetWait with a command whose start key is equal to
+// an exclusive end when GetPrereqs calculates overlapping commands. Test
+// it by calling GetPrereqs with a command whose start key is equal to
 // the end key of a previous command.
 func TestCommandQueueExclusiveEnd(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	cq := NewCommandQueue(true)
-	add(cq, roachpb.Key("a"), roachpb.Key("b"), false, zeroTS)
+	add(cq, roachpb.Key("a"), roachpb.Key("b"), false, nil)
 
 	// Verify no wait on the second writer command on "b" since
 	// it does not overlap with the first command on ["a", "b").
-	waitCmdDone(getWait(cq, roachpb.Key("b"), nil, false, zeroTS))
+	waitCmdDone(getPrereqs(cq, roachpb.Key("b"), nil, false))
 }
 
-// TestCommandQueueSelfOverlap makes sure that GetWait adds all of the
+// TestCommandQueueSelfOverlap makes sure that GetPrereqs adds all of the
 // key ranges simultaneously. If that weren't the case, all but the first
 // span would wind up waiting on overlapping previous spans, resulting
 // in deadlock.
@@ -253,36 +250,36 @@ func TestCommandQueueSelfOverlap(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	cq := NewCommandQueue(true)
 	a := roachpb.Key("a")
-	k := add(cq, a, roachpb.Key("b"), false, zeroTS)
-	chans := cq.getWait(false, zeroTS, []roachpb.Span{{Key: a}, {Key: a}, {Key: a}})
-	cq.remove(k)
-	waitCmdDone(chans)
+	cmd := add(cq, a, roachpb.Key("b"), false, nil)
+	prereqs := cq.getPrereqs(false, zeroTS, []roachpb.Span{{Key: a}, {Key: a}, {Key: a}})
+	cq.remove(cmd)
+	waitCmdDone(prereqs)
 }
 
 func TestCommandQueueCoveringOptimization(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	cq := NewCommandQueue(true)
 
-	a := roachpb.Span{Key: roachpb.Key("a")}
-	b := roachpb.Span{Key: roachpb.Key("b")}
-	c := roachpb.Span{Key: roachpb.Key("c")}
+	a := roachpb.Key("a")
+	b := roachpb.Key("b")
+	c := roachpb.Key("c")
 
 	{
 		// Test adding a covering entry and then not expanding it.
-		wk := cq.add(false, zeroTS, []roachpb.Span{a, b})
+		cmd := add(cq, a, b, false, nil)
 		if n := cq.treeSize(); n != 1 {
 			t.Fatalf("expected a single covering span, but got %d", n)
 		}
-		waitCmdDone(cq.getWait(false, zeroTS, []roachpb.Span{c}))
-		cq.remove(wk)
+		waitCmdDone(getPrereqs(cq, c, nil, false))
+		cq.remove(cmd)
 	}
 
 	{
 		// Test adding a covering entry and expanding it.
-		wk := cq.add(false, zeroTS, []roachpb.Span{a, b})
-		chans := cq.getWait(false, zeroTS, []roachpb.Span{a})
-		cq.remove(wk)
-		waitCmdDone(chans)
+		cmd := add(cq, a, b, false, nil)
+		prereqs := getPrereqs(cq, a, nil, false)
+		cq.remove(cmd)
+		waitCmdDone(prereqs)
 	}
 }
 
@@ -295,7 +292,7 @@ func TestCommandQueueWithoutCoveringOptimization(t *testing.T) {
 	c := roachpb.Span{Key: roachpb.Key("c")}
 
 	{
-		cmd := cq.add(false, zeroTS, []roachpb.Span{a, b})
+		cmd := cq.add(false, zeroTS, nil, []roachpb.Span{a, b})
 		if !cmd.expanded {
 			t.Errorf("expected non-expanded command, not %+v", cmd)
 		}
@@ -309,7 +306,7 @@ func TestCommandQueueWithoutCoveringOptimization(t *testing.T) {
 	}
 
 	{
-		cmd := cq.add(false, zeroTS, []roachpb.Span{c})
+		cmd := cq.add(false, zeroTS, nil, []roachpb.Span{c})
 		if cmd.expanded {
 			t.Errorf("expected unexpanded command, not %+v", cmd)
 		}
@@ -362,17 +359,17 @@ func TestCommandQueueIssue6495(t *testing.T) {
 		mkSpan("\xbb\x89\x8a\x8a\x89", "\xbb\x89\x8a\x8a\x89\x00"),
 	}
 
-	cq.getWait(false, zeroTS, spans1998)
-	cmd1998 := cq.add(false, zeroTS, spans1998)
+	cq.getPrereqs(false, zeroTS, spans1998)
+	cmd1998 := cq.add(false, zeroTS, nil, spans1998)
 
-	cq.getWait(true, zeroTS, spans1999)
-	cmd1999 := cq.add(true, zeroTS, spans1999)
+	cq.getPrereqs(true, zeroTS, spans1999)
+	cmd1999 := cq.add(true, zeroTS, nil, spans1999)
 
-	cq.getWait(true, zeroTS, spans2002)
-	cq.add(true, zeroTS, spans2002)
+	cq.getPrereqs(true, zeroTS, spans2002)
+	cq.add(true, zeroTS, nil, spans2002)
 
-	cq.getWait(false, zeroTS, spans2003)
-	cq.add(false, zeroTS, spans2003)
+	cq.getPrereqs(false, zeroTS, spans2003)
+	cq.add(false, zeroTS, nil, spans2003)
 
 	cq.remove(cmd1998)
 	cq.remove(cmd1999)
@@ -407,73 +404,75 @@ func TestCommandQueueTimestamps(t *testing.T) {
 		mkSpan("e", "g"),
 	}
 
-	cmd1 := cq.add(true, makeTS(1, 0), spans1)
+	cmd1 := cq.add(true, makeTS(1, 0), nil, spans1)
 
-	if w := cq.getWait(true, makeTS(2, 0), spans2); w != nil {
-		t.Errorf("expected nil wait slice; got %+v", w)
+	pre2 := cq.getPrereqs(true, makeTS(2, 0), spans2)
+	if pre2 != nil {
+		t.Errorf("expected nil prereq slice; got %+v", pre2)
 	}
-	cmd2 := cq.add(false, makeTS(2, 0), spans2)
+	cmd2 := cq.add(false, makeTS(2, 0), pre2, spans2)
 
-	if w := cq.getWait(true, makeTS(3, 0), spans3); w != nil {
-		t.Errorf("expected nil wait slice; got %+v", w)
+	pre3 := cq.getPrereqs(true, makeTS(3, 0), spans3)
+	if pre3 != nil {
+		t.Errorf("expected nil prereq slice; got %+v", pre3)
 	}
-	cmd3 := cq.add(false, makeTS(3, 0), spans3)
+	cmd3 := cq.add(false, makeTS(3, 0), pre3, spans3)
 
-	// spans4 should wait on spans3.children[1].pending.
-	w := cq.getWait(true, makeTS(4, 0), spans4)
-	expW := []<-chan struct{}{cmd3.children[1].pending}
-	if !reflect.DeepEqual(w, expW) {
-		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	// spans4 should wait on spans3.children[1].
+	pre4 := cq.getPrereqs(true, makeTS(4, 0), spans4)
+	expPre := []*cmd{&cmd3.children[1]}
+	if !reflect.DeepEqual(expPre, pre4) {
+		t.Errorf("expected prereq commands %+v; got %+v", expPre, pre4)
 	}
-	cmd4 := cq.add(true, makeTS(4, 0), spans4)
+	cmd4 := cq.add(true, makeTS(4, 0), pre4, spans4)
 
 	// Verify that an earlier writer for whole span waits on all commands.
-	w = cq.getWait(false, makeTS(0, 1), []roachpb.Span{mkSpan("a", "g")})
-	allW := []<-chan struct{}{
-		cmd4.pending,
-		// Skip cmd3.children[1].pending here because it's a dependency.
-		cmd3.children[0].pending,
-		cmd2.pending,
-		cmd1.children[1].pending,
-		cmd1.children[0].pending,
+	pre5 := cq.getPrereqs(false, makeTS(0, 1), []roachpb.Span{mkSpan("a", "g")})
+	allCmds := []*cmd{
+		cmd4,
+		// Skip cmd3.children[1] here because it's a dependency.
+		&cmd3.children[0],
+		cmd2,
+		&cmd1.children[1],
+		&cmd1.children[0],
 	}
-	expW = allW
-	if !reflect.DeepEqual(expW, w) {
-		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	expPre = allCmds
+	if !reflect.DeepEqual(expPre, pre5) {
+		t.Errorf("expected prereq commands %+v; got %+v", expPre, pre5)
 	}
 
 	// Verify that a later writer for whole span. At the same
 	// timestamp, we wait on the latest read.
-	expW = []<-chan struct{}{cmd4.pending, cmd3.children[0].pending, cmd2.pending}
-	if w := cq.getWait(false, makeTS(4, 0), []roachpb.Span{mkSpan("a", "g")}); !reflect.DeepEqual(expW, w) {
-		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	expPre = []*cmd{cmd4, &cmd3.children[0], cmd2}
+	if pre := cq.getPrereqs(false, makeTS(4, 0), []roachpb.Span{mkSpan("a", "g")}); !reflect.DeepEqual(expPre, pre) {
+		t.Errorf("expected prereq commands %+v; got %+v", expPre, pre)
 	}
 	// At +1 logical tick, we skip the latest read and instead
 	// read the overlapped write just beneath the latest read.
-	expW = []<-chan struct{}{cmd3.children[1].pending, cmd3.children[0].pending, cmd2.pending}
-	if w := cq.getWait(false, makeTS(4, 1), []roachpb.Span{mkSpan("a", "g")}); !reflect.DeepEqual(expW, w) {
-		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	expPre = []*cmd{&cmd3.children[1], &cmd3.children[0], cmd2}
+	if pre := cq.getPrereqs(false, makeTS(4, 1), []roachpb.Span{mkSpan("a", "g")}); !reflect.DeepEqual(expPre, pre) {
+		t.Errorf("expected prereq commands %+v; got %+v", expPre, pre)
 	}
 
 	// Verify an earlier reader for whole span doesn't wait.
-	if w := cq.getWait(true, makeTS(0, 1), []roachpb.Span{mkSpan("a", "g")}); w != nil {
-		t.Errorf("expected nil wait slice; got %+v", w)
+	if pre := cq.getPrereqs(true, makeTS(0, 1), []roachpb.Span{mkSpan("a", "g")}); pre != nil {
+		t.Errorf("expected nil prereq command; got %+v", pre)
 	}
 
 	// Verify a later reader for whole span waits on both writers.
-	expW = []<-chan struct{}{cmd3.children[1].pending, cmd3.children[0].pending, cmd2.pending}
-	if w := cq.getWait(true, makeTS(4, 0), []roachpb.Span{mkSpan("a", "g")}); !reflect.DeepEqual(expW, w) {
-		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	expPre = []*cmd{&cmd3.children[1], &cmd3.children[0], cmd2}
+	if pre := cq.getPrereqs(true, makeTS(4, 0), []roachpb.Span{mkSpan("a", "g")}); !reflect.DeepEqual(expPre, pre) {
+		t.Errorf("expected prereq commands %+v; got %+v", expPre, pre)
 	}
 
 	// Verify that if no timestamp is specified, we always wait (on writers and readers!).
-	expW = allW
-	if w := cq.getWait(false, hlc.Timestamp{}, []roachpb.Span{mkSpan("a", "g")}); !reflect.DeepEqual(expW, w) {
-		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	expPre = allCmds
+	if pre := cq.getPrereqs(false, hlc.Timestamp{}, []roachpb.Span{mkSpan("a", "g")}); !reflect.DeepEqual(expPre, pre) {
+		t.Errorf("expected prereq commands %+v; got %+v", expPre, pre)
 	}
-	expW = []<-chan struct{}{cmd3.children[1].pending, cmd3.children[0].pending, cmd2.pending}
-	if w := cq.getWait(true, hlc.Timestamp{}, []roachpb.Span{mkSpan("a", "g")}); !reflect.DeepEqual(expW, w) {
-		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	expPre = []*cmd{&cmd3.children[1], &cmd3.children[0], cmd2}
+	if pre := cq.getPrereqs(true, hlc.Timestamp{}, []roachpb.Span{mkSpan("a", "g")}); !reflect.DeepEqual(expPre, pre) {
+		t.Errorf("expected prereq commands %+v; got %+v", expPre, pre)
 	}
 }
 
@@ -500,13 +499,13 @@ func TestCommandQueueEnclosed(t *testing.T) {
 		mkSpan("a", ""),
 	}
 
-	cmd1 := cq.add(true, makeTS(2, 0), spans1)
-	cmd2 := cq.add(false, makeTS(3, 0), spans2)
+	cmd1 := cq.add(true, makeTS(2, 0), nil, spans1)
+	cmd2 := cq.add(false, makeTS(3, 0), nil, spans2)
 
-	w := cq.getWait(false, makeTS(1, 0), spansCandidate)
-	expW := []<-chan struct{}{cmd2.pending, cmd1.pending}
-	if !reflect.DeepEqual(w, expW) {
-		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	pre := cq.getPrereqs(false, makeTS(1, 0), spansCandidate)
+	expPre := []*cmd{cmd2, cmd1}
+	if !reflect.DeepEqual(expPre, pre) {
+		t.Errorf("expected prereq commands %+v; got %+v", expPre, pre)
 	}
 }
 
@@ -530,42 +529,42 @@ func TestCommandQueueTimestampsEmpty(t *testing.T) {
 		mkSpan("h", ""),
 	}
 
-	cmd1 := cq.add(true, hlc.Timestamp{}, spansR)
-	cmd2 := cq.add(false, hlc.Timestamp{}, spansW)
-	cmd3 := cq.add(true, makeTS(1, 0), spansRTS)
-	cmd4 := cq.add(false, makeTS(1, 0), spansWTS)
+	cmd1 := cq.add(true, zeroTS, nil, spansR)
+	cmd2 := cq.add(false, zeroTS, nil, spansW)
+	cmd3 := cq.add(true, makeTS(1, 0), nil, spansRTS)
+	cmd4 := cq.add(false, makeTS(1, 0), nil, spansWTS)
 
 	// A writer will depend on both zero-timestamp spans.
-	w := cq.getWait(false, makeTS(1, 0), []roachpb.Span{mkSpan("a", "f")})
-	expW := []<-chan struct{}{cmd2.pending, cmd1.pending}
-	if !reflect.DeepEqual(w, expW) {
-		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	pre := cq.getPrereqs(false, makeTS(1, 0), []roachpb.Span{mkSpan("a", "f")})
+	expPre := []*cmd{cmd2, cmd1}
+	if !reflect.DeepEqual(expPre, pre) {
+		t.Errorf("expected prereq commands %+v; got %+v", expPre, pre)
 	}
 
 	// A reader will depend on the write span.
-	w = cq.getWait(true, makeTS(1, 0), []roachpb.Span{mkSpan("a", "f")})
-	expW = []<-chan struct{}{cmd2.pending}
-	if !reflect.DeepEqual(w, expW) {
-		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	pre = cq.getPrereqs(true, makeTS(1, 0), []roachpb.Span{mkSpan("a", "f")})
+	expPre = []*cmd{cmd2}
+	if !reflect.DeepEqual(expPre, pre) {
+		t.Errorf("expected prereq commands %+v; got %+v", expPre, pre)
 	}
 
 	// A zero-timestamp writer will depend on both ts=1 spans.
-	w = cq.getWait(false, hlc.Timestamp{}, []roachpb.Span{mkSpan("g", "i")})
-	expW = []<-chan struct{}{cmd4.pending, cmd3.pending}
-	if !reflect.DeepEqual(w, expW) {
-		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	pre = cq.getPrereqs(false, hlc.Timestamp{}, []roachpb.Span{mkSpan("g", "i")})
+	expPre = []*cmd{cmd4, cmd3}
+	if !reflect.DeepEqual(expPre, pre) {
+		t.Errorf("expected prereq commands %+v; got %+v", expPre, pre)
 	}
 
 	// A zero-timestamp reader will depend on the write span.
-	w = cq.getWait(true, hlc.Timestamp{}, []roachpb.Span{mkSpan("g", "i")})
-	expW = []<-chan struct{}{cmd4.pending}
-	if !reflect.DeepEqual(w, expW) {
-		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	pre = cq.getPrereqs(true, hlc.Timestamp{}, []roachpb.Span{mkSpan("g", "i")})
+	expPre = []*cmd{cmd4}
+	if !reflect.DeepEqual(expPre, pre) {
+		t.Errorf("expected prereq commands %+v; got %+v", expPre, pre)
 	}
 }
 
-func BenchmarkCommandQueueGetWaitAllReadOnly(b *testing.B) {
-	// Test read-only getWait performance for various number of command queue
+func BenchmarkCommandQueueGetPrereqsAllReadOnly(b *testing.B) {
+	// Test read-only getPrereqs performance for various number of command queue
 	// entries. See #13627 where a previous implementation of
 	// CommandQueue.getOverlaps had O(n) performance in this setup. Since reads
 	// do not wait on other reads, expected performance is O(1).
@@ -577,12 +576,12 @@ func BenchmarkCommandQueueGetWaitAllReadOnly(b *testing.B) {
 				EndKey: roachpb.Key("aaaaaaaaab"),
 			}}
 			for i := 0; i < size; i++ {
-				cq.add(true, zeroTS, spans)
+				cq.add(true, zeroTS, nil, spans)
 			}
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_ = cq.getWait(true, zeroTS, spans)
+				_ = cq.getPrereqs(true, zeroTS, spans)
 			}
 		})
 	}
@@ -611,8 +610,8 @@ func BenchmarkCommandQueueReadWriteMix(b *testing.B) {
 					}}
 					var cmd *cmd
 					readOnly := j%(readsPerWrite+1) != 0
-					_ = cq.getWait(readOnly, zeroTS, spans)
-					cmd = cq.add(readOnly, zeroTS, spans)
+					prereqs := cq.getPrereqs(readOnly, zeroTS, spans)
+					cmd = cq.add(readOnly, zeroTS, prereqs, spans)
 					if len(liveCmdQueue) == cap(liveCmdQueue) {
 						cq.remove(<-liveCmdQueue)
 					}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -2327,7 +2327,7 @@ func TestReplicaCommandQueueCancellation(t *testing.T) {
 	// Wait until both commands are in the command queue.
 	testutils.SucceedsSoon(t, func() error {
 		tc.repl.cmdQMu.Lock()
-		chans := tc.repl.cmdQMu.global.getWait(false, hlc.Timestamp{}, []roachpb.Span{{Key: key1}, {Key: key2}})
+		chans := tc.repl.cmdQMu.queues[spanGlobal].getWait(false, hlc.Timestamp{}, []roachpb.Span{{Key: key1}, {Key: key2}})
 		tc.repl.cmdQMu.Unlock()
 		if a, e := len(chans), 2; a < e {
 			return errors.Errorf("%d of %d commands in the command queue", a, e)
@@ -6362,7 +6362,7 @@ func TestReplicaTryAbandon(t *testing.T) {
 	func() {
 		tc.repl.cmdQMu.Lock()
 		defer tc.repl.cmdQMu.Unlock()
-		if s := tc.repl.cmdQMu.global.String(); s == "" {
+		if s := tc.repl.cmdQMu.queues[spanGlobal].String(); s == "" {
 			t.Fatal("expected non-empty command queue")
 		}
 	}()
@@ -6378,7 +6378,7 @@ func TestReplicaTryAbandon(t *testing.T) {
 	testutils.SucceedsSoon(t, func() error {
 		tc.repl.cmdQMu.Lock()
 		defer tc.repl.cmdQMu.Unlock()
-		if s := tc.repl.cmdQMu.global.String(); s != "" {
+		if s := tc.repl.cmdQMu.queues[spanGlobal].String(); s != "" {
 			return errors.Errorf("expected empty command queue, but found\n%s", s)
 		}
 		return nil

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -2255,21 +2256,171 @@ func TestReplicaCommandQueueInconsistent(t *testing.T) {
 	// Success.
 }
 
+type cancellationTestInstruction struct {
+	span   roachpb.Span
+	cancel bool
+}
+
 // TestReplicaCommandQueueCancellation verifies that commands which are
-// waiting on the command queue do not execute if their context is cancelled.
+// waiting on the command queue do not execute or deadlock if their context
+// is cancelled, and that commands dependent on cancelled commands execute
+// correctly.
 func TestReplicaCommandQueueCancellation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	// Intercept commands with matching command IDs and block them.
-	blockingStart := make(chan struct{})
+
+	keyA := roachpb.Key("a")
+	keyB := roachpb.Key("b")
+	keyC := roachpb.Key("c")
+	keyD := roachpb.Key("d")
+	keyE := roachpb.Key("e")
+	keyF := roachpb.Key("e")
+
+	makeSpan := func(start, end roachpb.Key) roachpb.Span {
+		return roachpb.Span{Key: start, EndKey: end.Next()}
+	}
+	spanAB := makeSpan(keyA, keyB)
+	spanAC := makeSpan(keyA, keyC)
+	spanAF := makeSpan(keyA, keyF)
+	spanBE := makeSpan(keyB, keyE)
+	spanCD := makeSpan(keyC, keyD)
+	spanDF := makeSpan(keyD, keyF)
+	spanEF := makeSpan(keyE, keyF)
+
+	testCases := []struct {
+		name   string
+		instrs []cancellationTestInstruction
+	}{
+		//  -----      -----     -----      xxxxx
+		//    |    ->    |    &    |    ->    |    etc.
+		//  -----      xxxxx     -----      -----
+		{name: "SingleDependency", instrs: []cancellationTestInstruction{
+			{span: spanAF},
+			{span: spanAF},
+		}},
+		//  --------      xxxxxxxx      --------      xxxxxxxx     --------      --------
+		//   |    |   ->   |    |    &   |    |   ->   |    |   &   |    |   ->   |    |   etc.
+		//  ---  ---      ---  ---      ---  ---      xxx  xxx     ---  ---      xxx  xxx
+		{name: "MultipleDependencies", instrs: []cancellationTestInstruction{
+			{span: spanAF},
+			{span: spanAC},
+			{span: spanDF},
+		}},
+		//  -----      -----       -----      xxxxx       -----      xxxxx
+		//    |          |           |          |           |          |
+		//  -----  ->  xxxxx   &   -----  ->  xxxxx   &   -----  ->  xxxxx  etc.
+		//    |          |           |          |           |          |
+		//  -----      -----       -----      -----       -----      xxxxx
+		{name: "DependencyChain", instrs: []cancellationTestInstruction{
+			{span: spanAF},
+			{span: spanAF},
+			{span: spanAF},
+		}},
+		//  ---     ---      ---     ---     ---     ---      xxx     xxx
+		//   |       |        |       |       |       |        |       |
+		//  -----------  ->  xxxxxxxxxxx  &  -----------  ->  -----------  etc.
+		//       |                |               |                |
+		//      ---              ---             ---              xxx
+		{name: "SplitDependencyChain", instrs: []cancellationTestInstruction{
+			{span: spanAB},
+			{span: spanEF},
+			{span: spanAF},
+			{span: spanCD},
+		}},
+		//  -------------      -------------     -------------      -------------
+		//            |                  |                 |                  |
+		//          -----              -----             -----              xxxxx
+		//           |     ->           |     &           |     ->           |     etc.
+		//    ---------          xxxxxxxxx         ---------          ---------
+		//     |                  |                 |                  |
+		//  -----              -----             -----              xxxxx
+		{name: "NonOverlappingDependencyChain", instrs: []cancellationTestInstruction{
+			{span: spanAF},
+			{span: spanDF},
+			{span: spanBE},
+			{span: spanAC},
+		}},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Run every permutation of command cancellation as a separate subtest
+			// for the current instruction configuration.
+			var permuteTestInstrs func(pre, post []cancellationTestInstruction)
+			permuteTestInstrs = func(pre, post []cancellationTestInstruction) {
+				if len(post) == 0 {
+					// Create a name for this permutation.
+					// C = cancel
+					// R = run
+					var permName bytes.Buffer
+					for _, instr := range pre {
+						if instr.cancel {
+							permName.WriteByte('C')
+						} else {
+							permName.WriteByte('R')
+						}
+					}
+
+					t.Run(permName.String(), func(t *testing.T) {
+						testReplicaCommandQueueCancellationInstrs(t, pre)
+					})
+					return
+				}
+
+				instr := post[0]
+				rest := post[1:]
+				instr.cancel = false
+				permuteTestInstrs(append(pre, instr), rest)
+				instr.cancel = true
+				permuteTestInstrs(append(pre, instr), rest)
+			}
+			permuteTestInstrs(nil, tc.instrs)
+		})
+	}
+}
+
+// TestReplicaCommandQueueCancellationRandom verifies that commands in a
+// random dependency graph which are waiting on the command queue do not
+// execute or deadlock if their context is cancelled, and that commands
+// dependent on cancelled commands execute correctly.
+func TestReplicaCommandQueueCancellationRandom(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	rng, seed := randutil.NewPseudoRand()
+	randKey := func() roachpb.Key {
+		return roachpb.Key(randutil.RandBytes(rng, 1))
+	}
+	randBool := func() bool {
+		return rng.Int31n(2) == 0
+	}
+	t.Logf("running with seed %d", seed)
+
+	const trials = 25
+	for i := 0; i < trials; i++ {
+		commandCount := randutil.RandIntInRange(rng, 0, 25)
+		instructions := make([]cancellationTestInstruction, commandCount)
+		for j := range instructions {
+			startKey := randKey()
+			endKey := randKey()
+			if startKey.Compare(endKey) >= 0 {
+				endKey = startKey.Next()
+			}
+			instructions[j] = cancellationTestInstruction{
+				span:   roachpb.Span{Key: startKey, EndKey: endKey},
+				cancel: randBool(),
+			}
+		}
+		testReplicaCommandQueueCancellationInstrs(t, instructions)
+	}
+}
+
+func testReplicaCommandQueueCancellationInstrs(t *testing.T, instrs []cancellationTestInstruction) {
+	// Intercept DeleteRangeRequests and block them.
 	blockingDone := make(chan struct{})
 
 	tc := testContext{}
 	tsc := TestStoreConfig(nil)
 	tsc.TestingKnobs.TestingEvalFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
-			if filterArgs.Hdr.UserPriority == 42 {
-				log.Infof(context.Background(), "starting to block %s", filterArgs.Req)
-				blockingStart <- struct{}{}
+			if _, ok := filterArgs.Req.(*roachpb.DeleteRangeRequest); ok {
 				<-blockingDone
 			}
 			return nil
@@ -2278,22 +2429,17 @@ func TestReplicaCommandQueueCancellation(t *testing.T) {
 	defer stopper.Stop(context.TODO())
 	tc.StartWithStoreConfig(t, stopper, tsc)
 
-	defer close(blockingDone) // make sure teardown can happen
-
-	startBlockingCmd := func(ctx context.Context, keys ...roachpb.Key) <-chan *roachpb.Error {
+	// startBlockingCmd will create a goroutine to send a read-write request
+	// over the given span. It returns a channel that will be given the result
+	// of the request when it completes.
+	startBlockingCmd := func(ctx context.Context, span roachpb.Span) <-chan *roachpb.Error {
 		done := make(chan *roachpb.Error)
 
 		if err := stopper.RunAsyncTask(context.Background(), "test", func(_ context.Context) {
-			ba := roachpb.BatchRequest{
-				Header: roachpb.Header{
-					UserPriority: 42,
-				},
-			}
-			for _, key := range keys {
-				args := putArgs(key, nil)
-				ba.Add(&args)
-			}
-
+			ba := roachpb.BatchRequest{}
+			ba.Add(&roachpb.DeleteRangeRequest{
+				Span: span,
+			})
 			_, pErr := tc.Sender().Send(ctx, ba)
 			done <- pErr
 		}); err != nil {
@@ -2303,49 +2449,87 @@ func TestReplicaCommandQueueCancellation(t *testing.T) {
 		return done
 	}
 
-	key1 := roachpb.Key("one")
-	key2 := roachpb.Key("two")
+	// We always add an initial instruction that will block all commands to
+	// prevent leading cancelled commands from immediately executing. This is
+	// used to build up a dependency configuration in the CommandQueue before
+	// cancelling some instructions and releasing the gate (the blockingDone chan)
+	// to let the others through.
+	initial := cancellationTestInstruction{
+		span:   roachpb.Span{Key: keys.SystemMax, EndKey: keys.TableDataMin},
+		cancel: false,
+	}
+	instrs = append([]cancellationTestInstruction{initial}, instrs...)
 
-	// Wait until the command queue is blocked.
-	cmd1Done := startBlockingCmd(context.Background(), key1)
-	<-blockingStart
+	type cancellation struct {
+		cancel context.CancelFunc
+		done   <-chan *roachpb.Error
+	}
+	var cancellations []cancellation
+	var completions []<-chan *roachpb.Error
 
-	// Start a command that is already cancelled. It will return immediately.
-	{
+	for i, instruction := range instrs {
+		if !instruction.span.Overlaps(initial.span) {
+			t.Fatalf("all instruction spans should overlap the initial span; found %v",
+				instruction.span)
+		}
+
+		// Send a command for the instruction with a new context.
 		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-		done := startBlockingCmd(ctx, key1, key2)
-		if pErr := <-done; !testutils.IsPError(pErr, context.Canceled.Error()) {
-			t.Fatalf("unexpected error %v", pErr)
+		cmdDone := startBlockingCmd(ctx, instruction.span)
+
+		// Wait until the new command is in the command queue.
+		testutils.SucceedsSoon(t, func() error {
+			tc.repl.cmdQMu.Lock()
+			l := tc.repl.cmdQMu.queues[spanGlobal].treeSize()
+			tc.repl.cmdQMu.Unlock()
+			if e := i + 1; l != e {
+				return errors.Errorf("%d of %d commands in the command queue", l, e)
+			}
+			return nil
+		})
+
+		// Maintain a handle to check when the command completes, as well as
+		// a cancellation function for commands that should be cancelled.
+		if instruction.cancel {
+			cancellations = append(cancellations, cancellation{
+				cancel: cancel,
+				done:   cmdDone,
+			})
+		} else {
+			completions = append(completions, cmdDone)
 		}
 	}
 
-	// Start a third command which will wait for the first.
-	ctx, cancel := context.WithCancel(context.Background())
-	cmd3Done := startBlockingCmd(ctx, key1, key2)
+	// Cancel all commands that should be cancelled, in a non-deterministic order.
+	perm := rand.Perm(len(cancellations))
+	for _, idx := range perm {
+		cancellation := cancellations[idx]
+		cancellation.cancel()
 
-	// Wait until both commands are in the command queue.
-	testutils.SucceedsSoon(t, func() error {
-		tc.repl.cmdQMu.Lock()
-		chans := tc.repl.cmdQMu.queues[spanGlobal].getWait(false, hlc.Timestamp{}, []roachpb.Span{{Key: key1}, {Key: key2}})
-		tc.repl.cmdQMu.Unlock()
-		if a, e := len(chans), 2; a < e {
-			return errors.Errorf("%d of %d commands in the command queue", a, e)
+		// If this deadlocks, the command has unexpectedly begun executing and was
+		// trapped in the command filter. Indeed, the absence of such a deadlock is
+		// what's being tested here.
+		if pErr := <-cancellation.done; !testutils.IsPError(pErr, context.Canceled.Error()) {
+			t.Fatal(pErr)
 		}
-		return nil
-	})
-
-	// Cancel the third command; it will finish even though it is still
-	// blocked by the command queue.
-	cancel()
-	if pErr := <-cmd3Done; !testutils.IsPError(pErr, context.Canceled.Error()) {
-		t.Fatal(pErr)
 	}
 
-	// Now unblock the first command to allow the test to clean up.
-	blockingDone <- struct{}{}
-	if pErr := <-cmd1Done; pErr != nil {
-		t.Fatal(pErr)
+	// Release all remaining commands and allow them to complete, this time in-order.
+	// If this deadlocks, it is a sign that a dependency on a cancelled command was
+	// not correctly handled.
+	close(blockingDone)
+	for _, done := range completions {
+		if pErr := <-done; pErr != nil {
+			t.Fatal(pErr)
+		}
+	}
+
+	// Assert that the command queue is empty and that both successful and cancelled
+	// commands were cleaned up.
+	tc.repl.cmdQMu.Lock()
+	defer tc.repl.cmdQMu.Unlock()
+	if l := tc.repl.cmdQMu.queues[spanGlobal].treeSize(); l != 0 {
+		t.Fatalf("expected command queue to be empty, found %d remaining commands", l)
 	}
 }
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -4094,21 +4094,21 @@ func (s *Store) updateCommandQueueGauges() error {
 	newStoreReplicaVisitor(s).Visit(func(rep *Replica) bool {
 		rep.cmdQMu.Lock()
 
-		writes := rep.cmdQMu.global.localMetrics.writeCommands
-		writes += rep.cmdQMu.local.localMetrics.writeCommands
+		writes := rep.cmdQMu.queues[spanGlobal].localMetrics.writeCommands
+		writes += rep.cmdQMu.queues[spanLocal].localMetrics.writeCommands
 
-		reads := rep.cmdQMu.global.localMetrics.readCommands
-		reads += rep.cmdQMu.local.localMetrics.readCommands
+		reads := rep.cmdQMu.queues[spanGlobal].localMetrics.readCommands
+		reads += rep.cmdQMu.queues[spanLocal].localMetrics.readCommands
 
-		treeSize := int64(rep.cmdQMu.global.treeSize())
-		treeSize += int64(rep.cmdQMu.local.treeSize())
+		treeSize := int64(rep.cmdQMu.queues[spanGlobal].treeSize())
+		treeSize += int64(rep.cmdQMu.queues[spanLocal].treeSize())
 
-		maxOverlaps := rep.cmdQMu.global.localMetrics.maxOverlapsSeen
-		if locMax := rep.cmdQMu.local.localMetrics.maxOverlapsSeen; locMax > maxOverlaps {
+		maxOverlaps := rep.cmdQMu.queues[spanGlobal].localMetrics.maxOverlapsSeen
+		if locMax := rep.cmdQMu.queues[spanLocal].localMetrics.maxOverlapsSeen; locMax > maxOverlaps {
 			maxOverlaps = locMax
 		}
-		rep.cmdQMu.global.localMetrics.maxOverlapsSeen = 0
-		rep.cmdQMu.local.localMetrics.maxOverlapsSeen = 0
+		rep.cmdQMu.queues[spanGlobal].localMetrics.maxOverlapsSeen = 0
+		rep.cmdQMu.queues[spanLocal].localMetrics.maxOverlapsSeen = 0
 		rep.cmdQMu.Unlock()
 
 		cqSize := writes + reads


### PR DESCRIPTION
Fixes #9237.

Previously when a command was cancelled while in the `CommandQueue` due to
a `Context` cancellation, we would spawn a goroutine to block until all
prerequisite commands completed. This change allows us to avoid the
extra goroutine by offloading the cleanup work to the abandoned commands'
dependents.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9448)

<!-- Reviewable:end -->
