### PR TITLE
storage: add COCKROACH_SCHEDULER_CONCURRENCY

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -91,7 +91,8 @@ var changeTypeInternalToRaft = map[roachpb.ReplicaChangeType]raftpb.ConfChangeTy
 	roachpb.REMOVE_REPLICA: raftpb.ConfChangeRemoveNode,
 }
 
-var storeSchedulerConcurrency = 2 * runtime.NumCPU()
+var storeSchedulerConcurrency = envutil.EnvOrDefaultInt(
+	"COCKROACH_SCHEDULER_CONCURRENCY", 2*runtime.NumCPU())
 
 // TestStoreContext has some fields initialized with values relevant in tests.
 func TestStoreContext() StoreContext {


### PR DESCRIPTION
Allow storeSchedulerConcurrency to be set set from the
COCKROACH_SCHEDULER_CONCURRENCY env var.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9451)

<!-- Reviewable:end -->
