### PR TITLE
server: Don't pass context into background worker

### DIFF
--- a/server/node.go
+++ b/server/node.go
@@ -356,7 +356,7 @@ func (n *Node) start(
 	n.startedAt = n.ctx.Clock.Now().WallTime
 
 	n.startComputePeriodicMetrics(n.stopper)
-	n.startGossip(ctx, n.stopper)
+	n.startGossip(n.stopper)
 
 	// Record node started event.
 	n.recordJoinEvent()
@@ -577,8 +577,9 @@ func (n *Node) connectGossip() {
 
 // startGossip loops on a periodic ticker to gossip node-related
 // information. Starts a goroutine to loop until the node is closed.
-func (n *Node) startGossip(ctx context.Context, stopper *stop.Stopper) {
+func (n *Node) startGossip(stopper *stop.Stopper) {
 	stopper.RunWorker(func() {
+		ctx := n.Ctx()
 		// This should always return immediately and acts as a sanity check that we
 		// don't try to gossip before we're connected.
 		select {


### PR DESCRIPTION
node.start is called with a short-lived context used for tracing the
startup processes. Background processes need their own detached
contexts. See also #8734 which applied the same idea to the storage
package.

Fixes #8732

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9453)

<!-- Reviewable:end -->
