### PR TITLE
gossip,testcluster: Use more loopback IP addresses in tests

### DIFF
--- a/gossip/client_test.go
+++ b/gossip/client_test.go
@@ -41,7 +41,7 @@ import (
 
 // startGossip creates and starts a gossip instance.
 func startGossip(nodeID roachpb.NodeID, stopper *stop.Stopper, t *testing.T, registry *metric.Registry) *Gossip {
-	return startGossipAtAddr(nodeID, util.TestAddr, stopper, t, registry)
+	return startGossipAtAddr(nodeID, util.IsolatedTestAddr, stopper, t, registry)
 }
 
 func startGossipAtAddr(nodeID roachpb.NodeID, addr net.Addr, stopper *stop.Stopper, t *testing.T, registry *metric.Registry) *Gossip {
@@ -109,7 +109,7 @@ func startFakeServerGossips(t *testing.T) (*Gossip, *fakeGossipServer, *stop.Sto
 
 	lserver := rpc.NewServer(lRPCContext)
 	local := New(context.TODO(), lRPCContext, lserver, nil, stopper, metric.NewRegistry())
-	lln, err := netutil.ListenAndServeGRPC(stopper, lserver, util.TestAddr)
+	lln, err := netutil.ListenAndServeGRPC(stopper, lserver, util.IsolatedTestAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +118,7 @@ func startFakeServerGossips(t *testing.T) (*Gossip, *fakeGossipServer, *stop.Sto
 	rRPCContext := rpc.NewContext(context.TODO(), &base.Context{Insecure: true}, nil, stopper)
 
 	rserver := rpc.NewServer(rRPCContext)
-	rln, err := netutil.ListenAndServeGRPC(stopper, rserver, util.TestAddr)
+	rln, err := netutil.ListenAndServeGRPC(stopper, rserver, util.IsolatedTestAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -399,7 +399,7 @@ func TestClientRegisterWithInitNodeID(t *testing.T) {
 		RPCContext := rpc.NewContext(context.TODO(), &base.Context{Insecure: true}, nil, stopper)
 
 		server := rpc.NewServer(RPCContext)
-		ln, err := netutil.ListenAndServeGRPC(stopper, server, util.TestAddr)
+		ln, err := netutil.ListenAndServeGRPC(stopper, server, util.IsolatedTestAddr)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -78,10 +78,11 @@ func makeTestContext() Context {
 	ctx.SSLCertKey = filepath.Join(security.EmbeddedCertsDir, security.EmbeddedNodeKey)
 
 	// Addr defaults to localhost with port set at time of call to
-	// Start() to an available port.
-	// Call TestServer.ServingAddr() for the full address (including bound port).
-	ctx.Addr = "127.0.0.1:0"
-	ctx.HTTPAddr = "127.0.0.1:0"
+	// Start() to an available port. May be overridden later (as in
+	// makeTestContextFromParams). Call TestServer.ServingAddr() for the
+	// full address (including bound port).
+	ctx.Addr = util.TestAddr.String()
+	ctx.HTTPAddr = util.TestAddr.String()
 	// Set standard user for intra-cluster traffic.
 	ctx.User = security.NodeUser
 
@@ -122,6 +123,16 @@ func makeTestContextFromParams(params base.TestServerArgs) Context {
 		ctx.EventLogEnabled = false
 	}
 	ctx.JoinList = []string{params.JoinAddr}
+	if ctx.Insecure {
+		// Whenever we can (i.e. in insecure mode), use IsolatedTestAddr
+		// to prevent issues that can occur when running a test under
+		// stress.
+		ctx.Addr = util.IsolatedTestAddr.String()
+		ctx.HTTPAddr = util.IsolatedTestAddr.String()
+	} else {
+		ctx.Addr = util.TestAddr.String()
+		ctx.HTTPAddr = util.TestAddr.String()
+	}
 	return ctx
 }
 

--- a/testutils/testcluster/testcluster_test.go
+++ b/testutils/testcluster/testcluster_test.go
@@ -182,7 +182,15 @@ func TestWaitForFullReplication(t *testing.T) {
 func TestStopServer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	tc := StartTestCluster(t, 3, base.TestClusterArgs{ReplicationMode: base.ReplicationAuto})
+	// Use insecure mode so our servers listen on util.IsolatedTestAddr
+	// and they fail cleanly instead of interfering with other tests.
+	// See https://github.com/cockroachdb/cockroach/issues/9256
+	tc := StartTestCluster(t, 3, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Insecure: true,
+		},
+		ReplicationMode: base.ReplicationAuto,
+	})
 	defer tc.Stopper().Stop()
 	if err := tc.WaitForFullReplication(); err != nil {
 		t.Fatal(err)

--- a/util/testaddr_default.go
+++ b/util/testaddr_default.go
@@ -1,0 +1,24 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Ben Darnell
+
+// +build !linux
+
+package util
+
+func init() {
+	IsolatedTestAddr = TestAddr
+}

--- a/util/testaddr_random.go
+++ b/util/testaddr_random.go
@@ -1,0 +1,36 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Ben Darnell
+
+// +build linux
+
+package util
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/util/randutil"
+)
+
+func init() {
+	r, _ := randutil.NewPseudoRand()
+	// 127.255.255.255 is special (broadcast), so choose values less
+	// than 255.
+	a := r.Intn(255)
+	b := r.Intn(255)
+	c := r.Intn(255)
+	IsolatedTestAddr = NewUnresolvedAddr("tcp", fmt.Sprintf("127.%d.%d.%d:0", a, b, c))
+}

--- a/util/unresolved_addr.go
+++ b/util/unresolved_addr.go
@@ -21,9 +21,27 @@ import (
 	"net"
 )
 
-// TestAddr is an address to use for test servers. Listening on port 0 causes
-// the kernel to allocate an unused port.
+// TestAddr is an address to use for test servers. Listening on port 0
+// causes the kernel to allocate an unused port.
 var TestAddr = NewUnresolvedAddr("tcp", "127.0.0.1:0")
+
+// IsolatedTestAddr is initialized in testaddr_*.go
+
+// IsolatedTestAddr is an address to use for tests that need extra
+// isolation by using more addresses than 127.0.0.1 (support for this
+// is platform-specific and only enabled on Linux). Both TestAddr and
+// IsolatedTestAddr guarantee that the chosen port is not in use when
+// allocated, but IsolatedTestAddr draws from a larger pool of
+// addresses so that when tests are run in a tight loop the system is
+// less likely to run out of available ports or give a port to one
+// test immediately after it was closed by another.
+//
+// IsolatedTestAddr should be used for tests that open and close a
+// large number of sockets, or tests which stop a server and rely on
+// seeing a "connection refused" error afterwards. It cannot be used
+// with tests that operate in secure mode since our test certificates
+// are only valid for 127.0.0.1.
+var IsolatedTestAddr *UnresolvedAddr
 
 // MakeUnresolvedAddr populates an UnresolvedAddr from a network and raw
 // address string.


### PR DESCRIPTION
This mitigates issues seen when running the gossip and testcluster tests
under stress. It cannot be turned on by default because it breaks
certificate validation, so it is only used for the specific tests that
have seen issues.

Fixes #9016
Fixes #9256

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9457)

<!-- Reviewable:end -->
