### PR TITLE
[WIP] storage: remove Store.uninitRaftMu

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -2551,7 +2551,8 @@ func TestRaftBlockedReplica(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer rep.RaftUnlock(rep.RaftLock())
+	rep.RaftLock()
+	defer rep.RaftUnlock()
 
 	// Verify that we're still ticking the non-blocked replica.
 	ticks := mtc.stores[0].Metrics().RaftTicks.Count

--- a/storage/helpers_test.go
+++ b/storage/helpers_test.go
@@ -158,12 +158,12 @@ func (s *Store) ManualReplicaGC(repl *Replica) error {
 	return s.gcQueue.process(s.Ctx(), s.Clock().Now(), repl, cfg)
 }
 
-func (r *Replica) RaftLock() bool {
-	return r.raftLock()
+func (r *Replica) RaftLock() {
+	r.raftMu.Lock()
 }
 
-func (r *Replica) RaftUnlock(uninitRaftLocked bool) {
-	r.raftUnlock(uninitRaftLocked)
+func (r *Replica) RaftUnlock() {
+	r.raftMu.Unlock()
 }
 
 // GetLastIndex is the same function as LastIndex but it does not require

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -238,22 +238,10 @@ type Replica struct {
 	// All updates to state.Desc should be duplicated here.
 	rangeStr atomicDescString
 
-	// raftMu protects Raft processing the replica. Note that Raft processing for
-	// uninitialized replicas is also protected by Store.uninitRaftMu, but that
-	// detail is encapsulated in Replica.raft{Lock,Unlock}() which should be used
-	// for acquiring and releasing raftMu.
+	// raftMu protects Raft processing the replica.
 	//
-	// Locking notes: Replica.raftMu < Store.uninitRaftMu < Replica.mu
-	raftMu struct {
-		syncutil.Mutex
-		// Is the Replica initialized or not? This mirrors the value returned by
-		// Replica.IsInitialized() (which is protected by Replica.mu). It is also
-		// mostly consistent with the presence of the replica in
-		// Store.mu.uninitReplicas, though there are tiny time windows when
-		// inconsistencies could occur due to using different locks to update the
-		// values.
-		initialized bool
-	}
+	// Locking notes: Replica.raftMu < Replica.mu
+	raftMu syncutil.Mutex
 
 	mu struct {
 		// Protects all fields in the mu struct.
@@ -505,11 +493,6 @@ func NewReplica(
 	if err := r.init(desc, store.Clock(), replicaID); err != nil {
 		return nil, err
 	}
-	// Safe to do without holding raftMu because nothing has a reference to the
-	// new Replica yet. We can't perform this initialization in
-	// Replica.initLocked() because that method is sometimes called without
-	// Replica.raftMu held (see splitTriggerPostCommit).
-	r.raftMu.initialized = r.IsInitialized()
 
 	r.maybeGossipSystemConfig()
 	return r, nil
@@ -909,8 +892,6 @@ func (r *Replica) setDescWithoutProcessUpdate(desc *roachpb.RangeDescriptor) {
 
 	r.rangeStr.store(desc)
 	r.mu.state.Desc = desc
-
-	r.raftMu.initialized = r.isInitializedLocked()
 }
 
 // GetReplicaDescriptor returns the replica for this range from the range
@@ -1701,7 +1682,6 @@ func defaultProposeRaftCommandLocked(r *Replica, p *pendingCmd) error {
 	}
 	defer r.store.enqueueRaftUpdateCheck(r.RangeID)
 
-	var hasSplit bool
 	if union, ok := p.raftCmd.Cmd.GetArg(roachpb.EndTransaction); ok {
 		ict := union.(*roachpb.EndTransactionRequest).InternalCommitTrigger
 		if crt := ict.GetChangeReplicasTrigger(); crt != nil {
@@ -1733,8 +1713,6 @@ func defaultProposeRaftCommandLocked(r *Replica, p *pendingCmd) error {
 					})
 			})
 		}
-
-		hasSplit = ict.GetSplitTrigger() != nil
 	}
 
 	return r.withRaftGroupLocked(true, func(raftGroup *raft.RawNode) (bool, error) {
@@ -1745,7 +1723,7 @@ func defaultProposeRaftCommandLocked(r *Replica, p *pendingCmd) error {
 		// were quiesced.
 		r.unquiesceLocked()
 		return false, /* !unquiesceAndWakeLeader */
-			raftGroup.Propose(encodeRaftCommand(string(p.idKey), data, hasSplit))
+			raftGroup.Propose(encodeRaftCommand(string(p.idKey), data))
 	})
 }
 
@@ -1786,43 +1764,19 @@ func (r *Replica) unquiesceAndWakeLeaderLocked() {
 	}
 }
 
-// Lock the replica for Raft processing.
-func (r *Replica) raftLock() (uninitRaftLocked bool) {
-	r.raftMu.Lock()
-	if r.raftMu.initialized {
-		return false
-	}
-	r.store.uninitRaftMu.Lock()
-	return true
-}
-
-// Unlock the replica for Raft processing.
-func (r *Replica) raftUnlock(uninitRaftLocked bool) {
-	if uninitRaftLocked {
-		r.store.uninitRaftMu.Unlock()
-	}
-	r.raftMu.Unlock()
-}
-
 // handleRaftReady processes a raft.Ready containing entries and messages that
 // are ready to read, be saved to stable storage, committed or sent to other
 // peers. It takes a non-empty IncomingSnapshot to indicate that it is
 // about to process a snapshot.
 func (r *Replica) handleRaftReady(inSnap IncomingSnapshot) error {
-	uninitRaftLocked := r.raftLock()
-	// We overwrite uninitRaftLocked below (in case a raft command contains a
-	// split), which requires using a separate closure to capture
-	// uninitRaftLocked rather than having it evaluated at the point of the defer
-	// statement.
-	defer func() {
-		r.raftUnlock(uninitRaftLocked)
-	}()
-	return r.handleRaftReadyRaftMuLocked(&uninitRaftLocked, inSnap)
+	r.raftMu.Lock()
+	defer r.raftMu.Unlock()
+	return r.handleRaftReadyRaftMuLocked(inSnap)
 }
 
 // handleRaftReadyLocked is the same as handleRaftReady but requires that the
 // replica be locked for raft processing via r.raftLock.
-func (r *Replica) handleRaftReadyRaftMuLocked(uninitRaftLocked *bool, inSnap IncomingSnapshot) error {
+func (r *Replica) handleRaftReadyRaftMuLocked(inSnap IncomingSnapshot) error {
 	ctx := r.ctx
 	var hasReady bool
 	var rd raft.Ready
@@ -1913,27 +1867,6 @@ func (r *Replica) handleRaftReadyRaftMuLocked(uninitRaftLocked *bool, inSnap Inc
 			refreshReason = reasonSnapshotApplied
 		}
 		// TODO(bdarnell): update coalesced heartbeat mapping with snapshot info.
-	}
-
-	if !*uninitRaftLocked {
-		// Block processing of uninitialized replicas if any of the committed
-		// entries contains a split. We need to grab Store.uninitRaftMu before
-		// creating the batch (more precisely, before reading from the batch) in
-		// order to provide proper synchronization with uninitialized replicas. If
-		// we locked uninitRaftMu after reading from the batch (i.e. in
-		// Replica.splitTrigger) we could be reading stale data that a concurrent
-		// operation (on an uninitialized Replica) is updating.
-		for _, e := range rd.CommittedEntries {
-			if e.Type != raftpb.EntryNormal {
-				// Only normal entries can contain splits.
-				continue
-			}
-			if raftCommandHasSplit(e.Data) {
-				r.store.uninitRaftMu.Lock()
-				*uninitRaftLocked = true
-				break
-			}
-		}
 	}
 
 	batch := r.store.Engine().NewBatch()
@@ -2076,7 +2009,8 @@ func (r *Replica) handleRaftReadyRaftMuLocked(uninitRaftLocked *bool, inSnap Inc
 // tick the Raft group, returning any error and true if the raft group exists
 // and false otherwise.
 func (r *Replica) tick() (bool, error) {
-	defer r.raftUnlock(r.raftLock())
+	r.raftMu.Lock()
+	defer r.raftMu.Unlock()
 	return r.tickRaftMuLocked()
 }
 
@@ -2498,7 +2432,8 @@ func (r *Replica) sendRaftMessageRequest(req *RaftMessageRequest) bool {
 }
 
 func (r *Replica) reportSnapshotStatus(to uint64, snapErr error) {
-	defer r.raftUnlock(r.raftLock())
+	r.raftMu.Lock()
+	defer r.raftMu.Unlock()
 
 	snapStatus := raft.SnapshotFinish
 	if snapErr != nil {
@@ -2542,7 +2477,7 @@ func (r *Replica) refurbishPendingCmdLocked(cmd *pendingCmd) *roachpb.Error {
 // updating only the applied index.
 func (r *Replica) processRaftCommand(
 	idKey storagebase.CmdIDKey, index uint64, raftCmd roachpb.RaftCommand,
-) *roachpb.Error {
+) (pErr *roachpb.Error) {
 	if index == 0 {
 		log.Fatalf(r.ctx, "processRaftCommand requires a non-zero index")
 	}
@@ -2664,6 +2599,12 @@ func (r *Replica) processRaftCommand(
 	}
 	r.mu.Unlock()
 
+	if splitMergeUnlock := r.maybeAcquireSplitMergeLock(raftCmd.Cmd); splitMergeUnlock != nil {
+		defer func() {
+			splitMergeUnlock(pErr)
+		}()
+	}
+
 	log.Event(ctx, "applying batch")
 	// applyRaftCommand will return "expected" errors, but may also indicate
 	// replica corruption (as of now, signaled by a replicaCorruptionError).
@@ -2708,6 +2649,78 @@ func (r *Replica) processRaftCommand(
 	}
 
 	return pErr
+}
+
+func (r *Replica) maybeAcquireSplitMergeLock(ba roachpb.BatchRequest) func(pErr *roachpb.Error) {
+	arg, ok := ba.GetArg(roachpb.EndTransaction)
+	if !ok {
+		return nil
+	}
+	ict := arg.(*roachpb.EndTransactionRequest).InternalCommitTrigger
+	if split := ict.GetSplitTrigger(); split != nil {
+		return r.acquireSplitLock(split)
+	}
+	if merge := ict.GetMergeTrigger(); merge != nil {
+		return r.acquireMergeLock(merge)
+	}
+	return nil
+}
+
+func (r *Replica) acquireSplitLock(split *roachpb.SplitTrigger) func(pErr *roachpb.Error) {
+	rightRng, created, err := r.store.getOrCreateReplica(split.RightDesc.RangeID, 0, nil)
+	if err != nil {
+		return nil
+	}
+
+	// It would be nice to assert that rightRng is not initialized
+	// here. Unfortunately, due to reproposals and retries we might be executing
+	// a reproposal for a split trigger that was already executed via a
+	// retry. The reproposed command will not succeed (the transaction has
+	// already committed).
+	//
+	// TODO(peter): It might be okay to return an error here, but it is more
+	// conservative to hit the exact same error paths that we would hit for other
+	// commands that have reproposals interacting with retries (i.e. we don't
+	// treat splits differently).
+
+	return func(pErr *roachpb.Error) {
+		if pErr != nil && created && !rightRng.IsInitialized() {
+			// An error occurred during processing of the split and the RHS is still
+			// uninitialized. Mark the RHS destroyed and remove it from the replica's
+			// map as it is likely detritus. One reason this can occur is when
+			// concurrent splits on the same key are executed. Only one of the splits
+			// will succeed while the other will allocate a range ID, but fail to
+			// commit.
+			//
+			// We condition this removal on whether the RHS was newly created in
+			// order to be conservative. If a Raft message had created the Replica
+			// then presumably it was alive for some reason other than a concurrent
+			// split and shouldn't be destroyed.
+			rightRng.mu.Lock()
+			rightRng.mu.destroyed = errors.Errorf("%s: failed to initialize", rightRng)
+			rightRng.mu.Unlock()
+			r.store.mu.Lock()
+			delete(r.store.mu.replicas, rightRng.RangeID)
+			delete(r.store.mu.replicaQueues, rightRng.RangeID)
+			delete(r.store.mu.uninitReplicas, rightRng.RangeID)
+			r.store.mu.Unlock()
+		}
+		rightRng.raftMu.Unlock()
+	}
+}
+
+func (r *Replica) acquireMergeLock(merge *roachpb.MergeTrigger) func(pErr *roachpb.Error) {
+	rightRng, err := r.store.GetReplica(merge.RightDesc.RangeID)
+	if err != nil {
+		log.Fatalf(r.ctx, "unable to find merge RHS replica: %s", err)
+	}
+
+	// TODO(peter,tschottdorf): This is necessary but likely not sufficient. The
+	// right hand side of the merge can still race on reads. See #8630.
+	rightRng.raftMu.Lock()
+	return func(_ *roachpb.Error) {
+		rightRng.raftMu.Unlock()
+	}
 }
 
 // applyRaftCommand applies a raft command from the replicated log to the

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -2884,21 +2884,6 @@ func (r *Replica) mergeTrigger(
 		return nil, errors.Errorf("RHS range ID must be provided: %d", rightRangeID)
 	}
 
-	{
-		// TODO(peter,tschottdorf): This is necessary but likely not
-		// sufficient. The right hand side of the merge can still race on
-		// reads. See #8630.
-		//
-		// TODO(peter): We need to hold the subsumed range's raftMu until the
-		// Store.MergeRange is invoked. Currently we release it when this method
-		// returns which isn't correct.
-		subsumedRng, err := r.store.GetReplica(rightRangeID)
-		if err != nil {
-			panic(err)
-		}
-		defer subsumedRng.raftUnlock(subsumedRng.raftLock())
-	}
-
 	// Compute stats for premerged range, including current transaction.
 	var mergedMS = r.GetMVCCStats()
 	mergedMS.Add(*ms)

--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -704,33 +704,23 @@ const (
 	// The prescribed length for each command ID.
 	raftCommandIDLen                = 8
 	raftCommandEncodingVersion byte = 0
-	raftCommandNoSplitBit           = 1 << 7
-	raftCommandNoSplitMask          = raftCommandNoSplitBit - 1
+	// The no-split bit is now unused, but we still apply the mask to the first
+	// byte of the command for backward compatibility.
+	raftCommandNoSplitBit  = 1 << 7
+	raftCommandNoSplitMask = raftCommandNoSplitBit - 1
 )
 
 // encode a command ID, an encoded roachpb.RaftCommand, and whether the command
-// contains a split. The hasSplit parameter indicates whether the command
-// contains an EndTransaction containing a split trigger. We store this info in
-// the first byte of the encoded data so that we can quickly determine whether
-// a raft command contains a split before decoding the command. Splits require
-// additional synchronization which must be obtained before the command is
-// decoded. See Replica.handleRaftReady.
-func encodeRaftCommand(commandID string, command []byte, hasSplit bool) []byte {
+// contains a split.
+func encodeRaftCommand(commandID string, command []byte) []byte {
 	if len(commandID) != raftCommandIDLen {
 		log.Fatalf(context.TODO(), "invalid command ID length; %d != %d", len(commandID), raftCommandIDLen)
 	}
 	x := make([]byte, 1, 1+raftCommandIDLen+len(command))
 	x[0] = raftCommandEncodingVersion
-	if !hasSplit {
-		x[0] |= raftCommandNoSplitBit
-	}
 	x = append(x, []byte(commandID)...)
 	x = append(x, command...)
 	return x
-}
-
-func raftCommandHasSplit(data []byte) bool {
-	return len(data) > 0 && (data[0]&raftCommandNoSplitBit) == 0
 }
 
 // DecodeRaftCommand splits a raftpb.Entry.Data into its commandID and

--- a/storage/replica_raftstorage_test.go
+++ b/storage/replica_raftstorage_test.go
@@ -97,33 +97,3 @@ func TestSkipLargeReplicaSnapshot(t *testing.T) {
 		)
 	}
 }
-
-func TestRaftCommandHasSplit(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	testCases := []struct {
-		encoded  []byte
-		hasSplit bool
-	}{
-		{nil, false},
-		{encodeRaftCommand("abcdefgh", nil, false), false},
-		{encodeRaftCommand("abcdefgh", nil, true), true},
-	}
-	for _, c := range testCases {
-		if v := raftCommandHasSplit(c.encoded); c.hasSplit != v {
-			t.Fatalf("expected hasSplit=%t, but found hasSplit=%t", c.hasSplit, v)
-		}
-		if len(c.encoded) > 0 {
-			if c.hasSplit {
-				// For backward compatibility, the hasSplit indication is encoded as a
-				// "no split" value of 0 in the first byte of the encoded raft command.
-				if raftCommandEncodingVersion != c.encoded[0] {
-					t.Fatalf("expected %x, but found %x", raftCommandEncodingVersion, c.encoded[0])
-				}
-			} else {
-				if e := raftCommandEncodingVersion | raftCommandNoSplitBit; e != c.encoded[0] {
-					t.Fatalf("expected %x, but found %x", e, c.encoded[0])
-				}
-			}
-		}
-	}
-}

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -6047,7 +6047,8 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 	// test is ticking the replica manually and doesn't want the store to be
 	// doing so concurrently.
 	r := tc.rng
-	defer r.raftUnlock(r.raftLock())
+	r.raftMu.Lock()
+	defer r.raftMu.Unlock()
 
 	repDesc, err := r.GetReplicaDescriptor()
 	if err != nil {

--- a/storage/store.go
+++ b/storage/store.go
@@ -325,11 +325,11 @@ type Store struct {
 	drainLeases atomic.Value
 
 	// Locking notes: To avoid deadlocks, the following lock order must be
-	// obeyed: Replica.raftMu < Store.uninitRaftMu < Replica.readOnlyCmdMu <
-	// Store.mu.Mutex < Replica.mu.Mutex < Store.scheduler.mu. (It is not
-	// required to acquire every lock in sequence, but when multiple locks are
-	// held at the same time, it is incorrect to acquire a lock with "lesser"
-	// value in this sequence after one with "greater" value)
+	// obeyed: Replica.raftMu < < Replica.readOnlyCmdMu < Store.mu.Mutex <
+	// Replica.mu.Mutex < Store.scheduler.mu. (It is not required to acquire
+	// every lock in sequence, but when multiple locks are held at the same time,
+	// it is incorrect to acquire a lock with "lesser" value in this sequence
+	// after one with "greater" value)
 	//
 	// Methods of Store with a "Locked" suffix require that
 	// Store.mu.Mutex be held. Other locking requirements are indicated
@@ -359,10 +359,10 @@ type Store struct {
 	//
 	// Detailed description of the locks:
 	//
-	// * Replica.raftMu/Store.uninitRaftMu: Held while any raft messages are
-	//   being processed (including handleRaftReady and HandleRaftRequest) or
-	//   while the set of Replicas in the Store is being changed (which may
-	//   happen outside of raft via the replica GC queue).
+	// * Replica.raftMu: Held while any raft messages are being processed
+	//   (including handleRaftReady and HandleRaftRequest) or while the set of
+	//   Replicas in the Store is being changed (which may happen outside of raft
+	//   via the replica GC queue).
 	//
 	// * Replica.readOnlyCmdMu (RWMutex): Held in read mode while any
 	//   read-only command is in progress on the replica; held in write
@@ -378,8 +378,7 @@ type Store struct {
 	//   released briefly at the start of each request; metadata operations like
 	//   splits acquire it again to update the map. Even though these lock
 	//   acquisitions do not make up a single critical section, it is safe thanks
-	//   to Replica.raftMu/Store.uninitRaftMu which prevents any concurrent
-	//   modifications.
+	//   to Replica.raftMu which prevents any concurrent modifications.
 	//
 	// * Replica.mu: Protects the Replica's in-memory state. Acquired
 	//   and released briefly as needed (note that while the lock is
@@ -395,30 +394,20 @@ type Store struct {
 	//   state. Callbacks from the scheduler are performed while not holding this
 	//   mutex in order to observe the above ordering constraints.
 	//
-	// Splits (and merges, but they're not finished and so will not be
-	// discussed here) deserve special consideration: they operate on
-	// two ranges. Naively, this is fine because the right-hand range is
-	// brand new, but an uninitialized version may have been created by
-	// a raft message before we process the split (see commentary on
-	// Replica.splitTrigger). We currently make this safe by processing
-	// all uninitialized replicas serially before starting any
-	// initialized replicas which can run in parallel.
+	// Splits (and merges, but they're not finished and so will not be discussed
+	// here) deserve special consideration: they operate on two ranges. Naively,
+	// this is fine because the right-hand range is brand new, but an
+	// uninitialized version may have been created by a raft message before we
+	// process the split (see commentary on Replica.splitTrigger). We make this
+	// safe by locking the right-hand range for the duration of the Raft command
+	// containing the split/merge trigger.
 	//
 	// Note that because we acquire and release Store.mu and Replica.mu
 	// repeatedly rather than holding a lock for an entire request, we are
 	// actually relying on higher-level locks to ensure that things don't change
 	// out from under us. In particular, handleRaftReady accesses the replicaID
-	// more than once, and we rely on Replica.raftMu/Store.uninitRaftMu to ensure
-	// that this is not modified by a concurrent HandleRaftRequest. (#4476)
-
-	// uninitRaftMu protects Raft processing for uninitialized replicas. We need
-	// to serialize processing of uninitialized replicas because we do not know
-	// what range of keys such replicas cover. Uninitialized replicas might
-	// conflict with either initialized replicas (which can create new replicas
-	// via splits) or other uninitialized replicas (by applying snapshots).
-	//
-	// Locking notes: Replica.raftMu < Store.uninitRaftMu < Replica.mu
-	uninitRaftMu syncutil.Mutex
+	// more than once, and we rely on Replica.raftMu to ensure that this is not
+	// modified by a concurrent HandleRaftRequest. (#4476)
 
 	mu struct {
 		syncutil.Mutex // Protects all variables in the mu struct.
@@ -1474,41 +1463,15 @@ func splitTriggerPostCommit(
 	split *roachpb.SplitTrigger,
 	r *Replica,
 ) {
-	// There might be an uninitialized replica for the right hand side of the
-	// split. If there is, we want to use that *Replica because another goroutine
-	// might already have a reference to it but is waiting for Store.uninitRaftMu
-	// (which this goroutine holds).
-	r.store.mu.Lock()
-	rightRng, ok := r.store.mu.uninitReplicas[split.RightDesc.RangeID]
-	r.store.mu.Unlock()
-
-	// Create (or re-initialize) the new Replica representing the right side of
-	// the split. Our error handling options at this point are very limited, but
-	// we need to do this after our batch has committed.
-	var err error
-	if ok {
-		// This is safe because any other goroutine which has a pointer to rightRng
-		// cannot be performing raft processing on it since this goroutine holds
-		// Store.uninitRaftMu.
-		//
-		// TODO(peter): We can't lock rightRng.raftMu here because another
-		// goroutine may already hold that lock. But that goroutine will be waiting
-		// on Store.uninitRaftMu which we hold, so we're safe to proceed. This
-		// subtlety will go away when Store.uninitRaftMu goes away.
-		err = rightRng.init(&split.RightDesc, r.store.Clock(), 0)
-	} else {
-		rightRng, err = NewReplica(&split.RightDesc, r.store, 0)
-	}
+	// The right hand side of the split was already created (and its raftMu
+	// acquired) in Replica.acquireSplitLock. It must be present here.
+	rightRng, err := r.store.GetReplica(split.RightDesc.RangeID)
 	if err != nil {
-		panic(err)
+		log.Fatalf(ctx, "unable to find RHS replica: %s", err)
 	}
-
-	// We do not grab rightRng.raftMu here because some other goroutine might
-	// already be holding it (if there was an existing uninitialized
-	// replica). This is safe because that goroutine will be waiting for
-	// Store.uninitRaftMu which we hold. Another goroutine cannot discover an
-	// initialized version of rightRng until we install it with Store.SplitRange
-	// which marks it initialized while holding Store.mu.
+	if err := rightRng.init(&split.RightDesc, r.store.Clock(), 0); err != nil {
+		log.Fatal(ctx, err)
+	}
 
 	// Copy the timestamp cache into the RHS range.
 	r.mu.Lock()
@@ -1608,8 +1571,8 @@ func splitTriggerPostCommit(
 }
 
 // SplitRange shortens the original range to accommodate the new range. The new
-// range is added to the ranges map and the replicasByKey
-// btree. origRng.raftMu, newRng.raftMu and Store.uninitRaftMu must be held.
+// range is added to the ranges map and the replicasByKey btree. origRng.raftMu
+// and newRng.raftMu must be held.
 //
 // This is only called from the split trigger in the context of the execution
 // of a Raft command.
@@ -1795,7 +1758,8 @@ func (s *Store) addReplicaToRangeMapLocked(rng *Replica) error {
 // then. If `destroy` is true, all data belonging to the replica will be
 // deleted. In either case a tombstone record will be written.
 func (s *Store) RemoveReplica(rep *Replica, origDesc roachpb.RangeDescriptor, destroy bool) error {
-	defer rep.raftUnlock(rep.raftLock())
+	rep.raftMu.Lock()
+	defer rep.raftMu.Unlock()
 	return s.removeReplicaImpl(rep, origDesc, destroy)
 }
 
@@ -2404,12 +2368,12 @@ func (s *Store) processRaftRequest(
 	inSnap IncomingSnapshot,
 ) (pErr *roachpb.Error) {
 	// Lazily create the replica.
-	r, uninitRaftLocked, err := s.getOrCreateReplica(
-		req.RangeID, req.ToReplica.ReplicaID, req.FromReplica)
+	r, _, err := s.getOrCreateReplica(
+		req.RangeID, req.ToReplica.ReplicaID, &req.FromReplica)
 	if err != nil {
 		return roachpb.NewError(err)
 	}
-	defer r.raftUnlock(uninitRaftLocked)
+	defer r.raftMu.Unlock()
 	r.setLastReplicaDescriptors(req)
 
 	if req.Quiesce {
@@ -2425,7 +2389,7 @@ func (s *Store) processRaftRequest(
 
 	// Check to see if a snapshot can be applied. Snapshots can always be applied
 	// to initialized replicas. Note that if we add a placeholder we need to
-	// already be holding Store.uninitRaftMu in order to prevent concurrent
+	// already be holding Replica.raftMu in order to prevent concurrent
 	// raft-ready processing of uninitialized replicas.
 	var addedPlaceholder bool
 	var removePlaceholder bool
@@ -2637,7 +2601,7 @@ func (s *Store) processRaftRequest(
 		removePlaceholder = false
 	} else {
 		// Force the replica to deal with this snapshot right now.
-		if err := r.handleRaftReadyRaftMuLocked(&uninitRaftLocked, inSnap); err != nil {
+		if err := r.handleRaftReadyRaftMuLocked(inSnap); err != nil {
 			// mimic the behavior in processRaft.
 			panic(err)
 		}
@@ -2958,10 +2922,10 @@ var errRetry = errors.New("retry: orphaned replica")
 func (s *Store) getOrCreateReplica(
 	rangeID roachpb.RangeID,
 	replicaID roachpb.ReplicaID,
-	creatingReplica roachpb.ReplicaDescriptor,
-) (_ *Replica, uninitRaftLocked bool, _ error) {
+	creatingReplica *roachpb.ReplicaDescriptor,
+) (_ *Replica, created bool, _ error) {
 	for {
-		r, uninitRaftLocked, err := s.tryGetOrCreateReplica(
+		r, created, err := s.tryGetOrCreateReplica(
 			rangeID, replicaID, creatingReplica)
 		if err == errRetry {
 			continue
@@ -2969,7 +2933,7 @@ func (s *Store) getOrCreateReplica(
 		if err != nil {
 			return nil, false, err
 		}
-		return r, uninitRaftLocked, err
+		return r, created, err
 	}
 }
 
@@ -2982,38 +2946,40 @@ func (s *Store) getOrCreateReplica(
 func (s *Store) tryGetOrCreateReplica(
 	rangeID roachpb.RangeID,
 	replicaID roachpb.ReplicaID,
-	creatingReplica roachpb.ReplicaDescriptor,
-) (_ *Replica, uninitRaftLocked bool, _ error) {
+	creatingReplica *roachpb.ReplicaDescriptor,
+) (_ *Replica, created bool, _ error) {
 	// The common case: look up an existing (initialized) replica.
 	s.mu.Lock()
 	r, ok := s.mu.replicas[rangeID]
 	s.mu.Unlock()
 	if ok {
-		// Drop messages that come from a node that we believe was once a member of
-		// the group but has been removed.
-		desc := r.Desc()
-		_, found := desc.GetReplicaDescriptorByID(creatingReplica.ReplicaID)
-		// It's not a current member of the group. Is it from the past?
-		if !found && creatingReplica.ReplicaID < desc.NextReplicaID {
-			return nil, false, &roachpb.ReplicaTooOldError{}
+		if creatingReplica != nil {
+			// Drop messages that come from a node that we believe was once a member of
+			// the group but has been removed.
+			desc := r.Desc()
+			_, found := desc.GetReplicaDescriptorByID(creatingReplica.ReplicaID)
+			// It's not a current member of the group. Is it from the past?
+			if !found && creatingReplica.ReplicaID < desc.NextReplicaID {
+				return nil, false, &roachpb.ReplicaTooOldError{}
+			}
 		}
 
-		uninitRaftUnlocked := r.raftLock()
+		r.raftMu.Lock()
 		r.mu.Lock()
 		destroyed, corrupted := r.mu.destroyed, r.mu.corrupted
 		r.mu.Unlock()
 		if destroyed != nil {
-			r.raftUnlock(uninitRaftLocked)
+			r.raftMu.Unlock()
 			if corrupted {
 				return nil, false, destroyed
 			}
 			return nil, false, errRetry
 		}
 		if err := r.setReplicaID(replicaID); err != nil {
-			r.raftUnlock(uninitRaftLocked)
+			r.raftMu.Unlock()
 			return nil, false, err
 		}
-		return r, uninitRaftUnlocked, nil
+		return r, false, nil
 	}
 
 	// No replica currently exists, so we'll try to create one. Before creating
@@ -3029,14 +2995,10 @@ func (s *Store) tryGetOrCreateReplica(
 		}
 	}
 
-	// Create a new replica and lock it for raft processing. This will lock
-	// Replica.raftMu and Store.uninitRaftMu because the newly created replica is
-	// uninitialized.
+	// Create a new replica and lock it for raft processing.
 	r = newReplica(rangeID, s)
-	r.creatingReplica = &creatingReplica
-	if !r.raftLock() {
-		log.Fatalf(s.Ctx(), "uninitRaftLocked must be true")
-	}
+	r.creatingReplica = creatingReplica
+	r.raftMu.Lock()
 
 	// Install the replica in the store's replica map. The replica is in an
 	// inconsistent state, but nobody will be accessing it while we hold its
@@ -3053,7 +3015,7 @@ func (s *Store) tryGetOrCreateReplica(
 	if s.addReplicaToRangeMapLocked(r) != nil {
 		r.mu.Unlock()
 		s.mu.Unlock()
-		r.raftUnlock(true)
+		r.raftMu.Unlock()
 		return nil, false, errRetry
 	}
 	s.mu.uninitReplicas[r.RangeID] = r
@@ -3074,7 +3036,7 @@ func (s *Store) tryGetOrCreateReplica(
 		delete(s.mu.replicaQueues, rangeID)
 		delete(s.mu.uninitReplicas, rangeID)
 		s.mu.Unlock()
-		r.raftUnlock(true)
+		r.raftMu.Unlock()
 		return nil, false, err
 	}
 	r.mu.Unlock()


### PR DESCRIPTION
Rework locking during splits and merges so that we acquire the RHS
replica's raftMu and hold it for the lifetime of the Raft command
containing the split/merge trigger.

Fixes #9128.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9459)

<!-- Reviewable:end -->
