### PR TITLE
server: plumb contexts to various ops

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -242,7 +242,10 @@ func NewDistSender(cfg *DistSenderConfig, g *gossip.Gossip) *DistSender {
 // retry logic here; this is not an issue since the lookup performs a
 // single inconsistent read only.
 func (ds *DistSender) RangeLookup(
-	key roachpb.RKey, desc *roachpb.RangeDescriptor, useReverseScan bool,
+	ctx context.Context,
+	key roachpb.RKey,
+	desc *roachpb.RangeDescriptor,
+	useReverseScan bool,
 ) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, *roachpb.Error) {
 	ba := roachpb.BatchRequest{}
 	ba.ReadConsistency = roachpb.INCONSISTENT
@@ -257,10 +260,7 @@ func (ds *DistSender) RangeLookup(
 	})
 	replicas := newReplicaSlice(ds.gossip, desc)
 	replicas.Shuffle()
-	// TODO(tschottdorf): Ideally we would use the trace of the request which
-	// caused this lookup.
-	_ = context.TODO()
-	br, err := ds.sendRPC(ds.Ctx, desc.RangeID, replicas, ba)
+	br, err := ds.sendRPC(ctx, desc.RangeID, replicas, ba)
 	if err != nil {
 		return nil, nil, roachpb.NewError(err)
 	}

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -375,11 +375,16 @@ func TestSendRPCOrder(t *testing.T) {
 
 type MockRangeDescriptorDB func(roachpb.RKey, bool) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, *roachpb.Error)
 
-func (mdb MockRangeDescriptorDB) RangeLookup(key roachpb.RKey, _ *roachpb.RangeDescriptor, useReverseScan bool) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, *roachpb.Error) {
+func (mdb MockRangeDescriptorDB) RangeLookup(
+	_ context.Context,
+	key roachpb.RKey,
+	_ *roachpb.RangeDescriptor,
+	useReverseScan bool,
+) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, *roachpb.Error) {
 	return mdb(stripMeta(key), useReverseScan)
 }
 func (mdb MockRangeDescriptorDB) FirstRange() (*roachpb.RangeDescriptor, error) {
-	rs, _, err := mdb.RangeLookup(nil, nil, false /* useReverseScan */)
+	rs, _, err := mdb.RangeLookup(context.Background(), nil, nil, false /* useReverseScan */)
 	if err != nil || len(rs) == 0 {
 		return nil, err.GoError()
 	}

--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -60,7 +60,10 @@ type RangeDescriptorDB interface {
 	// which contain the given key (possibly from intents), and the second holds
 	// prefetched adjacent descriptors.
 	RangeLookup(
-		key roachpb.RKey, desc *roachpb.RangeDescriptor, useReverseScan bool,
+		ctx context.Context,
+		key roachpb.RKey,
+		desc *roachpb.RangeDescriptor,
+		useReverseScan bool,
 	) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, *roachpb.Error)
 	// FirstRange returns the descriptor for the first Range. This is the
 	// Range containing all \x00\x00meta1 entries.
@@ -432,7 +435,9 @@ func (rdc *rangeDescriptorCache) performRangeLookup(
 			return nil, nil, err
 		}
 	}
-	descs, prefetched, pErr := rdc.db.RangeLookup(metadataKey, desc, useReverseScan)
+	// Tag inner operations.
+	ctx = log.WithLogTag(ctx, "range-lookup", nil)
+	descs, prefetched, pErr := rdc.db.RangeLookup(ctx, metadataKey, desc, useReverseScan)
 	return descs, prefetched, pErr.GoError()
 }
 

--- a/kv/range_cache_test.go
+++ b/kv/range_cache_test.go
@@ -107,7 +107,12 @@ func (db *testDescriptorDB) FirstRange() (*roachpb.RangeDescriptor, error) {
 	return nil, nil
 }
 
-func (db *testDescriptorDB) RangeLookup(key roachpb.RKey, _ *roachpb.RangeDescriptor, useReverseScan bool) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, *roachpb.Error) {
+func (db *testDescriptorDB) RangeLookup(
+	_ context.Context,
+	key roachpb.RKey,
+	_ *roachpb.RangeDescriptor,
+	useReverseScan bool,
+) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, *roachpb.Error) {
 	<-db.pauseChan
 	atomic.AddInt64(&db.lookupCount, 1)
 	return db.getDescriptors(stripMeta(key), useReverseScan)

--- a/server/server.go
+++ b/server/server.go
@@ -284,7 +284,7 @@ func NewServer(srvCtx Context, stopper *stop.Stopper) (*Server, error) {
 	s.tsServer = ts.MakeServer(s.Ctx(), s.tsDB)
 
 	s.admin = makeAdminServer(s)
-	s.status = newStatusServer(s.db, s.gossip, s.recorder, s.ctx.Context, s.rpcContext, s.node.stores)
+	s.status = newStatusServer(s.Ctx(), s.db, s.gossip, s.recorder, s.rpcContext, s.node.stores)
 	for _, gw := range []grpcGatewayServer{&s.admin, s.status, &s.tsServer} {
 		gw.RegisterService(s.grpc)
 	}

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -324,7 +324,7 @@ func (ts *TestServer) ServingPort() (string, error) {
 
 // WriteSummaries implements TestServerInterface.
 func (ts *TestServer) WriteSummaries() error {
-	return ts.node.writeSummaries()
+	return ts.node.writeSummaries(context.TODO())
 }
 
 // AdminURL implements TestServerInterface.

--- a/server/updates.go
+++ b/server/updates.go
@@ -120,10 +120,15 @@ func (s *Server) maybeCheckForUpdates() time.Duration {
 // executes the timestamp is set to the next execution time.
 // Returns how long until `f` should be run next (i.e. when this method should
 // be called again).
-func (s *Server) maybeRunPeriodicCheck(op string, key roachpb.Key, f func()) time.Duration {
-	resp, err := s.db.Get(s.Ctx(), key)
+func (s *Server) maybeRunPeriodicCheck(
+	op string, key roachpb.Key, f func(context.Context),
+) time.Duration {
+	// Add the op name to the log context.
+	ctx := log.WithLogTag(s.Ctx(), op, nil)
+
+	resp, err := s.db.Get(ctx, key)
 	if err != nil {
-		log.Infof(s.Ctx(), "Error reading %s time: %v", op, err)
+		log.Infof(ctx, "error reading time: %s", err)
 		return updateCheckRetryFrequency
 	}
 
@@ -133,40 +138,40 @@ func (s *Server) maybeRunPeriodicCheck(op string, key roachpb.Key, f func()) tim
 	if resp.Exists() {
 		whenToCheck, pErr := resp.Value.GetTime()
 		if pErr != nil {
-			log.Warningf(s.Ctx(), "Error decoding %s time: %v", op, err)
+			log.Warningf(ctx, "error decoding time: %s", err)
 			return updateCheckRetryFrequency
 		} else if delay := whenToCheck.Sub(timeutil.Now()); delay > 0 {
 			return delay
 		}
 
 		nextRetry := whenToCheck.Add(updateCheckRetryFrequency)
-		if err := s.db.CPut(s.Ctx(), key, nextRetry, whenToCheck); err != nil {
+		if err := s.db.CPut(ctx, key, nextRetry, whenToCheck); err != nil {
 			if log.V(2) {
-				log.Infof(s.Ctx(), "Could not set next version check time (maybe another node checked?): %v", err)
+				log.Infof(ctx, "could not set next version check time (maybe another node checked?): %s", err)
 			}
 			return updateCheckRetryFrequency
 		}
 	} else {
-		log.Infof(s.Ctx(), "No previous %s time.", op)
+		log.Infof(ctx, "No previous %s time.", op)
 		nextRetry := timeutil.Now().Add(updateCheckRetryFrequency)
 		// CPut with `nil` prev value to assert that no other node has checked.
-		if err := s.db.CPut(s.Ctx(), key, nextRetry, nil); err != nil {
+		if err := s.db.CPut(ctx, key, nextRetry, nil); err != nil {
 			if log.V(2) {
-				log.Infof(s.Ctx(), "Could not set %s time (maybe another node checked?): %v", op, err)
+				log.Infof(ctx, "Could not set %s time (maybe another node checked?): %v", op, err)
 			}
 			return updateCheckRetryFrequency
 		}
 	}
 
-	f()
+	f(ctx)
 
-	if err := s.db.Put(s.Ctx(), key, timeutil.Now().Add(updateCheckFrequency)); err != nil {
-		log.Infof(s.Ctx(), "Error updating %s time: %v", op, err)
+	if err := s.db.Put(ctx, key, timeutil.Now().Add(updateCheckFrequency)); err != nil {
+		log.Infof(ctx, "Error updating %s time: %v", op, err)
 	}
 	return updateCheckFrequency
 }
 
-func (s *Server) checkForUpdates() {
+func (s *Server) checkForUpdates(ctx context.Context) {
 	q := updatesURL.Query()
 	q.Set("version", build.GetInfo().Tag)
 	q.Set("uuid", s.node.ClusterID.String())
@@ -177,7 +182,7 @@ func (s *Server) checkForUpdates() {
 		// This is probably going to be relatively common in production
 		// environments where network access is usually curtailed.
 		if log.V(2) {
-			log.Warning(context.TODO(), "Failed to check for updates: ", err)
+			log.Warning(ctx, "Failed to check for updates: ", err)
 		}
 		return
 	}
@@ -185,7 +190,7 @@ func (s *Server) checkForUpdates() {
 
 	if res.StatusCode != http.StatusOK {
 		b, err := ioutil.ReadAll(res.Body)
-		log.Warningf(context.TODO(), "Failed to check for updates: status: %s, body: %s, error: %v",
+		log.Warningf(ctx, "Failed to check for updates: status: %s, body: %s, error: %v",
 			res.Status, b, err)
 		return
 	}
@@ -197,22 +202,21 @@ func (s *Server) checkForUpdates() {
 
 	err = decoder.Decode(&r)
 	if err != nil && err != io.EOF {
-		log.Warning(context.TODO(), "Error decoding updates info: ", err)
+		log.Warning(ctx, "Error decoding updates info: ", err)
 		return
 	}
 
 	for _, v := range r.Details {
-		log.Infof(context.TODO(), "A new version is available: %s, details: %s", v.Version, v.Details)
+		log.Infof(ctx, "A new version is available: %s, details: %s", v.Version, v.Details)
 	}
 }
 
 func (s *Server) usageReportingEnabled() bool {
 	// Grab the optin value from the database.
-	ctx := context.TODO()
 	req := &serverpb.GetUIDataRequest{Keys: []string{optinKey}}
-	resp, err := s.admin.GetUIData(ctx, req)
+	resp, err := s.admin.GetUIData(s.Ctx(), req)
 	if err != nil {
-		log.Warning(ctx, err)
+		log.Warning(s.Ctx(), err)
 		return false
 	}
 
@@ -223,7 +227,7 @@ func (s *Server) usageReportingEnabled() bool {
 	}
 	optin, err := strconv.ParseBool(string(val.Value))
 	if err != nil {
-		log.Warningf(ctx, "could not parse optin value (%q): %v", val.Value, err)
+		log.Warningf(s.Ctx(), "could not parse optin value (%q): %v", val.Value, err)
 		return false
 	}
 	return optin
@@ -238,7 +242,8 @@ func (s *Server) maybeReportUsage(running time.Duration) time.Duration {
 	if !s.usageReportingEnabled() {
 		return updateCheckFrequency
 	}
-	return s.maybeRunPeriodicCheck("metrics reporting", keys.NodeLastUsageReportKey(int32(s.node.Descriptor.NodeID)), s.reportUsage)
+	return s.maybeRunPeriodicCheck("metrics reporting",
+		keys.NodeLastUsageReportKey(int32(s.node.Descriptor.NodeID)), s.reportUsage)
 }
 
 func (s *Server) getReportingInfo() reportingInfo {
@@ -261,10 +266,10 @@ func (s *Server) getReportingInfo() reportingInfo {
 	return reportingInfo{summary, stores}
 }
 
-func (s *Server) reportUsage() {
+func (s *Server) reportUsage(ctx context.Context) {
 	b := new(bytes.Buffer)
 	if err := json.NewEncoder(b).Encode(s.getReportingInfo()); err != nil {
-		log.Warning(context.TODO(), err)
+		log.Warning(ctx, err)
 		return
 	}
 
@@ -277,13 +282,13 @@ func (s *Server) reportUsage() {
 	if err != nil && log.V(2) {
 		// This is probably going to be relatively common in production
 		// environments where network access is usually curtailed.
-		log.Warning(context.TODO(), "Failed to report node usage metrics: ", err)
+		log.Warning(ctx, "Failed to report node usage metrics: ", err)
 		return
 	}
 
 	if res.StatusCode != http.StatusOK {
 		b, err := ioutil.ReadAll(res.Body)
-		log.Warningf(context.TODO(), "Failed to report node usage metrics: status: %s, body: %s, "+
+		log.Warningf(ctx, "Failed to report node usage metrics: status: %s, body: %s, "+
 			"error: %v", res.Status, b, err)
 	}
 }

--- a/server/updates_test.go
+++ b/server/updates_test.go
@@ -22,6 +22,8 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/build"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -57,7 +59,7 @@ func TestCheckVersion(t *testing.T) {
 	defer stubURL(&updatesURL, u)()
 
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	s.(*TestServer).checkForUpdates()
+	s.(*TestServer).checkForUpdates(context.TODO())
 	recorder.Close()
 	s.Stopper().Stop()
 
@@ -104,7 +106,7 @@ func TestReportUsage(t *testing.T) {
 	}
 
 	node := ts.node.recorder.GetStatusSummary()
-	ts.reportUsage()
+	ts.reportUsage(context.TODO())
 
 	ts.Stopper().Stop() // stopper will wait for the update/report loop to finish too.
 	recorder.Close()

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -509,12 +509,15 @@ func (m *multiTestContext) FirstRange() (*roachpb.RangeDescriptor, error) {
 // RangeLookup implements the RangeDescriptorDB interface. It looks up the
 // descriptors for the given (meta) key.
 func (m *multiTestContext) RangeLookup(
-	key roachpb.RKey, desc *roachpb.RangeDescriptor, useReverseScan bool,
+	ctx context.Context,
+	key roachpb.RKey,
+	desc *roachpb.RangeDescriptor,
+	useReverseScan bool,
 ) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, *roachpb.Error) {
 	// DistSender's RangeLookup function will work correctly, as long as
 	// multiTestContext's FirstRange() method returns the correct descriptor for the
 	// first range.
-	return m.distSenders[0].RangeLookup(key, desc, useReverseScan)
+	return m.distSenders[0].RangeLookup(ctx, key, desc, useReverseScan)
 }
 
 func (m *multiTestContext) makeContext(i int) storage.StoreContext {

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -498,7 +498,9 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) error {
 
 	sp := repl.store.Tracer().StartSpan(bq.name)
 	defer sp.Finish()
-	ctx := opentracing.ContextWithSpan(context.Background(), sp)
+	// Putting a span in ctx means that events will no longer go to the event log.
+	// Use bq.ctx for events that are intended for the event log.
+	ctx := opentracing.ContextWithSpan(bq.ctx, sp)
 	ctx = repl.logContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, bq.processTimeout)
 	defer cancel()


### PR DESCRIPTION
Plumbing contexts to various server ops (status, summaries, ID allocation, range cache, queue) so it is visible in the traces/logs where the operation is coming from.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9463)

<!-- Reviewable:end -->
