### PR TITLE
storage: Deflake TestAcceptsUnsplitRanges again

### DIFF
--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -530,6 +530,7 @@ func (m *multiTestContext) makeContext(i int) storage.StoreContext {
 	ctx.Gossip = m.gossips[i]
 	ctx.StorePool = m.storePools[i]
 	ctx.TestingKnobs.DisableSplitQueue = true
+	ctx.TestingKnobs.ReplicateQueueAcceptsUnsplit = true
 	return ctx
 }
 

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -331,10 +331,10 @@ func (bq *baseQueue) requiresSplit(cfg config.SystemConfig, repl *Replica) bool 
 	if bq.acceptsUnsplitRanges {
 		return false
 	}
-	// If there's no store (as is the case in some narrow unit tests), or if
-	// the store's split queue is disabled, the "required" split will never
-	// come. In that case, pretend we don't require the split.
-	if store := repl.store; store == nil || store.splitQueue.Disabled() {
+	// If there's no store (as is the case in some narrow unit tests),
+	// the "required" split will never come. In that case, pretend we
+	// don't require the split.
+	if store := repl.store; store == nil {
 		return false
 	}
 	desc := repl.Desc()

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -58,7 +58,7 @@ func newReplicateQueue(store *Store, g *gossip.Gossip, allocator Allocator, cloc
 	rq.baseQueue = makeBaseQueue("replicate", rq, store, g, queueConfig{
 		maxSize:              replicateQueueMaxSize,
 		needsLease:           true,
-		acceptsUnsplitRanges: false,
+		acceptsUnsplitRanges: store.TestingKnobs().ReplicateQueueAcceptsUnsplit,
 		successes:            store.metrics.ReplicateQueueSuccesses,
 		failures:             store.metrics.ReplicateQueueFailures,
 		pending:              store.metrics.ReplicateQueuePending,

--- a/storage/store.go
+++ b/storage/store.go
@@ -583,6 +583,10 @@ type StoreTestingKnobs struct {
 	DisableRefreshReasonTicks bool
 	// DisableProcessRaft disables the process raft loop.
 	DisableProcessRaft bool
+	// ReplicateQueueAcceptsUnsplit allows the replication queue to
+	// process ranges that need to be split, for use in tests that use
+	// the replication queue but disable the split queue.
+	ReplicateQueueAcceptsUnsplit bool
 }
 
 var _ base.ModuleTestingKnobs = &StoreTestingKnobs{}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -172,6 +172,9 @@ func createTestStore(t testing.TB) (*Store, *hlc.ManualClock, *stop.Stopper) {
 	// so just disable the scanner for all tests that use this function
 	// instead of figuring out exactly which tests need it.
 	ctx.TestingKnobs.DisableScanner = true
+	// The scanner affects background operations; we must also disable
+	// the split queue separately to cover event-driven splits.
+	ctx.TestingKnobs.DisableSplitQueue = true
 	return createTestStoreWithContext(t, &ctx)
 }
 


### PR DESCRIPTION
Fixes #9229 (correctly, this time)

Disabling the scanner is not enough; we must also disable the split queue to prevent event-driven splits. However, this interacts poorly with an older hack that simply ignores the "accepts unsplit" requirement when the split queue is disabled, so that had to be removed first.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9480)

<!-- Reviewable:end -->
