### PR TITLE
storage/engine: extract arch depenant const into own files

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -74,6 +74,9 @@ var (
 
 // Server is the cockroach server node.
 type Server struct {
+	// Must align to 8-bytes for atomic int64 updates.
+	nodeLogTagVal log.DynamicIntValue
+
 	ctx            Context
 	mux            *http.ServeMux
 	clock          *hlc.Clock
@@ -99,8 +102,6 @@ type Server struct {
 	stopper        *stop.Stopper
 	sqlExecutor    *sql.Executor
 	leaseMgr       *sql.LeaseManager
-
-	nodeLogTagVal log.DynamicIntValue
 }
 
 // NewServer creates a Server from a server.Context.

--- a/storage/engine/rocksdb_32bit.go
+++ b/storage/engine/rocksdb_32bit.go
@@ -1,0 +1,22 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+// +build 386 amd64p32 arm armbe  mips mipsle mips64p32 mips64p32le ppc sparc
+
+package engine
+
+const (
+	maxArrayLen = 1<<31 - 1
+)

--- a/storage/engine/rocksdb_64bit.go
+++ b/storage/engine/rocksdb_64bit.go
@@ -1,0 +1,22 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+// +build amd64 arm64 arm64be ppc64 ppc64le mips64 mips64le s390x sparc64
+
+package engine
+
+const (
+	maxArrayLen = 1<<50 - 1
+)


### PR DESCRIPTION
While crdb supports only amd64 at this time, it is useful for
experimenting on other archs to have the consts pulled out into
their own files so no code changes are needed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9491)

<!-- Reviewable:end -->
