### PR TITLE
Better docker image, make cockroach pid=1 in container

### DIFF
--- a/build/deploy/cockroach.sh
+++ b/build/deploy/cockroach.sh
@@ -4,7 +4,7 @@ set -eu
 
 if [ "${1-}" = "shell" ]; then
   shift
-  /bin/sh "$@"
+  exec /bin/sh "$@"
 else
-  /cockroach/cockroach "$@"
+  exec /cockroach/cockroach "$@"
 fi


### PR DESCRIPTION
Recently, I have built some docker images following the [Best practices by docker](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/). An important tips is using the exec Bash command so that the final running application becomes the container’s PID 1. This allows the application to receive any Unix signals sent to the container.

Without exec, processes in container:

``` shell
root@6dde80f808c8:/cockroach# ps -ef
UID        PID  PPID  C STIME TTY          TIME CMD
root         1     0  0 08:14 ?        00:00:00 /bin/sh /cockroach/cockroach.sh start
root         7     1  0 08:14 ?        00:00:00 /cockroach/cockroach start
root        22     0  0 08:15 ?        00:00:00 /bin/bash --login
root        31    22  0 08:15 ?        00:00:00 ps -ef
```

With exec, processes in container:

``` shell
root@9435173a3f10:/cockroach# ps -ef
UID        PID  PPID  C STIME TTY          TIME CMD
root         1     0  1 08:25 ?        00:00:00 /cockroach/cockroach start
root        19     0  1 08:25 ?        00:00:00 /bin/bash --login
root        28    19  0 08:26 ?        00:00:00 ps -ef
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9495)

<!-- Reviewable:end -->
