### PR TITLE
cli: Add advertise-host flag to start command

### DIFF
--- a/base/context.go
+++ b/base/context.go
@@ -87,8 +87,13 @@ type Context struct {
 	// the server is running or the user passed in client calls.
 	User string
 
-	// Addr is the server's public address.
+	// Addr is the address the server is listening on.
 	Addr string
+
+	// AdvertiseAddr is the address advertised by the server to other nodes
+	// in the cluster. It should be reachable by all other nodes and should
+	// route to an interface that Addr is listening on.
+	AdvertiseAddr string
 
 	// HTTPAddr is server's public HTTP address.
 	//
@@ -113,6 +118,7 @@ func (ctx *Context) InitDefaults() {
 	ctx.Insecure = defaultInsecure
 	ctx.User = defaultUser
 	ctx.Addr = defaultAddr
+	ctx.AdvertiseAddr = ctx.Addr
 	ctx.HTTPAddr = defaultHTTPAddr
 }
 
@@ -169,7 +175,7 @@ func (ctx *Context) PGURL(user string) (*url.URL, error) {
 	return &url.URL{
 		Scheme:   "postgresql",
 		User:     url.User(user),
-		Host:     ctx.Addr,
+		Host:     ctx.AdvertiseAddr,
 		RawQuery: options.Encode(),
 	}, nil
 }

--- a/cli/cliflags/flags.go
+++ b/cli/cliflags/flags.go
@@ -155,14 +155,21 @@ An unspecified type means ip address or dns. Type is one of:
 	ServerHost = FlagInfo{
 		Name: "host",
 		Description: `
-The address to listen on. The node will also advertise itself using this
-hostname; it must resolve from other nodes in the cluster.`,
+The hostname to listen on. The node will also advertise itself using this
+hostname if advertise-host is not specified.`,
 	}
 
 	ServerPort = FlagInfo{
 		Name:        "port",
 		Shorthand:   "p",
 		Description: `The port to bind to.`,
+	}
+
+	AdvertiseHost = FlagInfo{
+		Name: "advertise-host",
+		Description: `
+The hostname to advertise to other CockroachDB nodes for intra-cluster
+communication; it must resolve from other nodes in the cluster.`,
 	}
 
 	ServerHTTPPort = FlagInfo{

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -42,7 +42,7 @@ import (
 var maxResults int64
 
 var connURL string
-var connUser, connHost, connPort, httpPort, httpAddr, connDBName, zoneConfig string
+var connUser, connHost, connPort, advertiseHost, httpPort, httpAddr, connDBName, zoneConfig string
 var startBackground bool
 var undoFreezeCluster bool
 
@@ -290,6 +290,7 @@ func init() {
 		// Server flags.
 		stringFlag(f, &connHost, cliflags.ServerHost, "")
 		stringFlag(f, &connPort, cliflags.ServerPort, base.DefaultPort)
+		stringFlag(f, &advertiseHost, cliflags.AdvertiseHost, "")
 		stringFlag(f, &httpPort, cliflags.ServerHTTPPort, base.DefaultHTTPPort)
 		stringFlag(f, &httpAddr, cliflags.ServerHTTPAddr, "")
 		stringFlag(f, &serverCtx.Attrs, cliflags.Attrs, serverCtx.Attrs)
@@ -429,5 +430,9 @@ func extraFlagInit() {
 	if httpAddr == "" {
 		httpAddr = connHost
 	}
+	if advertiseHost == "" {
+		advertiseHost = connHost
+	}
+	serverCtx.AdvertiseAddr = net.JoinHostPort(advertiseHost, connPort)
 	serverCtx.HTTPAddr = net.JoinHostPort(httpAddr, httpPort)
 }

--- a/cli/start.go
+++ b/cli/start.go
@@ -132,6 +132,7 @@ func initInsecure() error {
 		}
 	} else {
 		serverCtx.Addr = net.JoinHostPort("localhost", connPort)
+		serverCtx.AdvertiseAddr = serverCtx.Addr
 		serverCtx.HTTPAddr = net.JoinHostPort("localhost", httpPort)
 	}
 	return nil
@@ -480,7 +481,7 @@ func getGRPCConn() (*grpc.ClientConn, *stop.Stopper, error) {
 	stopper := stop.NewStopper()
 	rpcContext := rpc.NewContext(context.TODO(), serverCtx.Context, hlc.NewClock(hlc.UnixNano),
 		stopper)
-	conn, err := rpcContext.GRPCDial(serverCtx.Addr)
+	conn, err := rpcContext.GRPCDial(serverCtx.AdvertiseAddr)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cli/start_test.go
+++ b/cli/start_test.go
@@ -44,6 +44,13 @@ func TestInitInsecure(t *testing.T) {
 		{[]string{"--host", "192.168.1.1"}, true,
 			`specify --insecure to listen on external address 192\.168\.1\.1`},
 		{[]string{"--insecure", "--host", "192.168.1.1"}, true, ""},
+		{[]string{"--host", "localhost", "--advertise-host", "192.168.1.1"}, true, ""},
+		{[]string{"--host", "127.0.0.1", "--advertise-host", "192.168.1.1"}, true, ""},
+		{[]string{"--host", "::1", "--advertise-host", "192.168.1.1"}, true, ""},
+		{[]string{"--insecure", "--host", "192.168.1.1", "--advertise-host", "192.168.1.1"}, true, ""},
+		{[]string{"--insecure", "--host", "192.168.1.1", "--advertise-host", "192.168.2.2"}, true, ""},
+		// Clear out the flags when done to avoid affecting other tests that rely on the flag state.
+		{[]string{"--host", "", "--advertise-host", ""}, true, ""},
 	}
 	for i, c := range testCases {
 		// Reset the context and insecure flag for every test case.

--- a/server/server.go
+++ b/server/server.go
@@ -104,8 +104,8 @@ type Server struct {
 
 // NewServer creates a Server from a server.Context.
 func NewServer(srvCtx Context, stopper *stop.Stopper) (*Server, error) {
-	if _, err := net.ResolveTCPAddr("tcp", srvCtx.Addr); err != nil {
-		return nil, errors.Errorf("unable to resolve RPC address %q: %v", srvCtx.Addr, err)
+	if _, err := net.ResolveTCPAddr("tcp", srvCtx.AdvertiseAddr); err != nil {
+		return nil, errors.Errorf("unable to resolve RPC address %q: %v", srvCtx.AdvertiseAddr, err)
 	}
 
 	if srvCtx.Ctx == nil {
@@ -354,11 +354,17 @@ func (s *Server) Start(ctx context.Context) error {
 		return err
 	}
 	log.Eventf(ctx, "listening on port %s", s.ctx.Addr)
-	unresolvedAddr, err := officialAddr(s.ctx.Addr, ln.Addr())
+	unresolvedListenAddr, err := officialAddr(s.ctx.Addr, ln.Addr())
 	if err != nil {
 		return err
 	}
-	s.ctx.Addr = unresolvedAddr.String()
+	s.ctx.Addr = unresolvedListenAddr.String()
+	unresolvedAdvertAddr, err := officialAddr(s.ctx.AdvertiseAddr, ln.Addr())
+	if err != nil {
+		return err
+	}
+	s.ctx.AdvertiseAddr = unresolvedAdvertAddr.String()
+
 	s.rpcContext.SetLocalInternalServer(s.node)
 
 	m := cmux.New(ln)
@@ -452,10 +458,11 @@ func (s *Server) Start(ctx context.Context) error {
 	// apply it for all web endpoints.
 	s.mux.HandleFunc(debugEndpoint, http.HandlerFunc(handleDebug))
 
-	s.gossip.Start(unresolvedAddr)
+	s.gossip.Start(unresolvedAdvertAddr)
 	log.Event(ctx, "started gossip")
 
-	if err := s.node.start(ctx, unresolvedAddr, s.ctx.Engines, s.ctx.NodeAttributes); err != nil {
+	err = s.node.start(ctx, unresolvedAdvertAddr, s.ctx.Engines, s.ctx.NodeAttributes)
+	if err != nil {
 		return err
 	}
 	log.Event(ctx, "started node")
@@ -487,7 +494,8 @@ func (s *Server) Start(ctx context.Context) error {
 	sql.NewSchemaChangeManager(testingKnobs, *s.db, s.gossip, s.leaseMgr).Start(s.stopper)
 
 	log.Infof(s.Ctx(), "starting %s server at %s", s.ctx.HTTPRequestScheme(), unresolvedHTTPAddr)
-	log.Infof(s.Ctx(), "starting grpc/postgres server at %s", unresolvedAddr)
+	log.Infof(s.Ctx(), "starting grpc/postgres server at %s", unresolvedListenAddr)
+	log.Infof(s.Ctx(), "advertising CockroachDB node at %s", unresolvedAdvertAddr)
 	if len(s.ctx.SocketFile) != 0 {
 		log.Infof(s.Ctx(), "starting postgres server at unix:%s", s.ctx.SocketFile)
 	}

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -82,6 +82,7 @@ func makeTestContext() Context {
 	// makeTestContextFromParams). Call TestServer.ServingAddr() for the
 	// full address (including bound port).
 	ctx.Addr = util.TestAddr.String()
+	ctx.AdvertiseAddr = util.TestAddr.String()
 	ctx.HTTPAddr = util.TestAddr.String()
 	// Set standard user for intra-cluster traffic.
 	ctx.User = security.NodeUser
@@ -128,9 +129,11 @@ func makeTestContextFromParams(params base.TestServerArgs) Context {
 		// to prevent issues that can occur when running a test under
 		// stress.
 		ctx.Addr = util.IsolatedTestAddr.String()
+		ctx.AdvertiseAddr = util.IsolatedTestAddr.String()
 		ctx.HTTPAddr = util.IsolatedTestAddr.String()
 	} else {
 		ctx.Addr = util.TestAddr.String()
+		ctx.AdvertiseAddr = util.TestAddr.String()
 		ctx.HTTPAddr = util.TestAddr.String()
 	}
 	return ctx
@@ -307,7 +310,7 @@ func (ts *TestServer) Stores() *storage.Stores {
 
 // ServingAddr returns the server's address. Should be used by clients.
 func (ts *TestServer) ServingAddr() string {
-	return ts.ctx.Addr
+	return ts.ctx.AdvertiseAddr
 }
 
 // ServingHost returns the host portion of the rpc server's address.


### PR DESCRIPTION
Enables overriding the interface(s) that the server is listening on
for the purposes of picking an address to advertise via the gossip
network.

Could reasonably be expanded with advertise-port if anyone hits a case
where port forwarding causes issues (could potentially happen in some
docker deployments).

For what it's worth, it's a little weird that we have `--host` and
`--port` to contrast with `--http-addr` and `--http-port`. Should we
try to phase out `--http-addr` and replace it with `--http-host`?

Fixes #1008

@tamird @sploiselle

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9503)

<!-- Reviewable:end -->
