### PR TITLE
storage, server: no more timestamp arithmetic in leases in and timestamp cache

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -60,6 +60,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/cockroachdb/cockroach/pkg/util/sdnotify"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
@@ -379,6 +380,8 @@ type grpcGatewayServer interface {
 func (s *Server) Start(ctx context.Context) error {
 	ctx = s.AnnotateCtx(ctx)
 
+	startTime := timeutil.Now()
+
 	tlsConfig, err := s.cfg.GetServerTLSConfig()
 	if err != nil {
 		return err
@@ -539,6 +542,19 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 	s.stopper.AddCloser(&s.engines)
 
+	anyStoreBootstrapped := false
+	for _, e := range s.engines {
+		if _, err := storage.ReadStoreIdent(ctx, e); err != nil {
+			// NotBootstrappedError is expected.
+			if _, ok := err.(*storage.NotBootstrappedError); !ok {
+				return err
+			}
+		} else {
+			anyStoreBootstrapped = true
+			break
+		}
+	}
+
 	err = s.node.start(
 		ctx,
 		unresolvedAdvertAddr,
@@ -582,9 +598,31 @@ func (s *Server) Start(ctx context.Context) error {
 		log.Infof(ctx, "starting postgres server at unix:%s", s.cfg.SocketFile)
 	}
 
-	s.stopper.RunWorker(func() {
-		netutil.FatalIfUnexpected(m.Serve())
-	})
+	{
+		// We might have to sleep a bit to protect against this node producing
+		// non-monotonic timestamps. Before restarting, its clock might have been
+		// driven by other nodes' fast clocks, but when we restarted, we lost all this
+		// information. For example, a client might have written a value at a
+		// timestamp that's in the future of the restarted node's clock, and if we
+		// don't do something, the same client's read would not return it.
+		// So, we wait up to MaxOffset. We assume we couldn't have served timestamps
+		// more than MaxOffset in the future.
+		//
+		// As an optimization for tests, we don't sleep if all the stores are brand
+		// new. In this case, the node will not serve anything anyway until it
+		// synchronizes with other nodes.
+		if anyStoreBootstrapped {
+			sleepDuration := s.clock.MaxOffset() - timeutil.Since(startTime)
+			if sleepDuration > 0 {
+				log.Infof(ctx, "sleeping for %s to guarantee HLC monotonicity", sleepDuration)
+				time.Sleep(sleepDuration)
+			}
+		}
+		s.stopper.RunWorker(func() {
+			netutil.FatalIfUnexpected(m.Serve())
+		})
+	}
+
 	log.Event(ctx, "accepting connections")
 
 	// Initialize grpc-gateway mux and context.

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -74,6 +74,44 @@ func TestHealth(t *testing.T) {
 	}
 }
 
+// TestServerStartClock tests that a server's clock is not pushed out of thin
+// air. This used to happen - the simple act of starting was causing a server's
+// clock to be pushed because we were introducing bogus future timestamps into
+// our system.
+func TestServerStartClock(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Set a high max-offset so that, if the server's clock is pushed by
+	// MaxOffset, we don't hide that under the latency of the Start operation
+	// which would allow the physical clock to catch up to the pushed one.
+	params := base.TestServerArgs{
+		MaxOffset: time.Second,
+	}
+	s, _, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop()
+
+	// Run a command so that we are sure to touch the timestamp cache. This is
+	// actually not needed because other commands run during server
+	// initialization, but we cannot guarantee that's going to stay that way.
+	get := &roachpb.GetRequest{
+		Span: roachpb.Span{Key: roachpb.Key("a")},
+	}
+	if _, err := client.SendWrapped(
+		context.Background(), s.KVClient().(*client.DB).GetSender(), get,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	now := s.Clock().Now()
+	// We rely on s.Clock() having been initialized from hlc.UnixNano(), which is a
+	// bit fragile.
+	physicalNow := hlc.UnixNano()
+	serverClockWasPushed := (now.Logical > 0) || (now.WallTime > physicalNow)
+	if serverClockWasPushed {
+		t.Fatalf("time: server %s vs actual %d", now, physicalNow)
+	}
+}
+
 // TestPlainHTTPServer verifies that we can serve plain http and talk to it.
 // This is controlled by -cert=""
 func TestPlainHTTPServer(t *testing.T) {

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -114,19 +114,6 @@ func TestRejectFutureCommand(t *testing.T) {
 	mtc.Start(t, 1)
 	defer mtc.Stop()
 
-	// First do a write. The first write will advance the clock by MaxOffset
-	// because of the read cache's low water mark.
-	getArgs := putArgs([]byte("b"), []byte("b"))
-	if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), &getArgs); err != nil {
-		t.Fatal(err)
-	}
-	if now := clock.Now(); now.WallTime != int64(maxOffset) {
-		t.Fatalf("expected clock to advance to 100ms; got %s", now)
-	}
-	// The logical clock has advanced past the physical clock; increment
-	// the "physical" clock to catch up.
-	manual.Increment(int64(maxOffset))
-
 	startTime := manual.UnixNano()
 
 	// Commands with a future timestamp that is within the MaxOffset
@@ -138,8 +125,8 @@ func TestRejectFutureCommand(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if now := clock.Now(); now.WallTime != int64(190*time.Millisecond) {
-		t.Fatalf("expected clock to advance to 190ms; got %s", now)
+	if now := clock.Now(); now.WallTime != int64(90*time.Millisecond) {
+		t.Fatalf("expected clock to advance to 90ms; got %s", now)
 	}
 
 	// Once the accumulated offset reaches MaxOffset, commands will be rejected.
@@ -149,9 +136,9 @@ func TestRejectFutureCommand(t *testing.T) {
 		t.Fatalf("expected clock offset error but got nil")
 	}
 
-	// The clock remained at 190ms and the final command was not executed.
-	if now := clock.Now(); now.WallTime != int64(190*time.Millisecond) {
-		t.Errorf("expected clock to advance to 190ms; got %s", now)
+	// The clock remained at 90ms and the final command was not executed.
+	if now := clock.Now(); now.WallTime != int64(90*time.Millisecond) {
+		t.Errorf("expected clock to stay at 90ms; got %s", now)
 	}
 	val, _, err := engine.MVCCGet(context.Background(), mtc.engines[0], roachpb.Key("a"), clock.Now(), true, nil)
 	if err != nil {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1345,7 +1345,7 @@ func (r *Replica) applyTimestampCache(ba *roachpb.BatchRequest) *roachpb.Error {
 					return roachpb.NewError(roachpb.NewTransactionReplayError())
 				} else if !wTS.Less(ba.Txn.Timestamp) {
 					// This is a crucial bit of code. The timestamp cache is
-					// reset with the current time + max offset as the low water
+					// reset with the current time as the low-water
 					// mark, so if this replica recently obtained the lease,
 					// this case will be true for new txns, even if they're not
 					// a replay. We move the timestamp forward and return retry.

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -2977,10 +2977,6 @@ func (r *Replica) mergeTrigger(
 	mergedMS.Subtract(r.GetMVCCStats())
 	*ms = mergedMS
 
-	r.mu.Lock()
-	r.mu.tsCache.Clear(r.store.Clock())
-	r.mu.Unlock()
-
 	var pd ProposalData
 	pd.BlockReads = true
 	pd.ReplicatedProposalData.Merge = &storagebase.Merge{

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -307,7 +307,7 @@ func (r *Replica) leasePostApply(
 		// lease holder. Note that we'll call SetLowWater when we next acquire
 		// the lease.
 		r.mu.Lock()
-		r.mu.tsCache.Clear(r.store.Clock())
+		r.mu.tsCache.Clear(r.store.Clock().Now())
 		r.mu.Unlock()
 	}
 
@@ -410,11 +410,7 @@ func (r *Replica) handleProposalData(
 	}
 
 	if pd.Merge != nil {
-		r.mu.Lock()
-		r.mu.tsCache.Clear(r.store.Clock())
-		r.mu.Unlock()
-
-		if err := r.store.MergeRange(r, pd.Merge.LeftDesc.EndKey,
+		if err := r.store.MergeRange(ctx, r, pd.Merge.LeftDesc.EndKey,
 			pd.Merge.RightDesc.RangeID,
 		); err != nil {
 			// Our in-memory state has diverged from the on-disk state.

--- a/pkg/storage/replica_range_lease.go
+++ b/pkg/storage/replica_range_lease.go
@@ -285,10 +285,6 @@ func (r *Replica) AdminTransferLease(target roachpb.StoreID) error {
 		}
 		// No extension in progress; start a transfer.
 		nextLeaseBegin := r.store.Clock().Now()
-		// Don't transfer immediately after a node restart since we might have
-		// served higher timestamps before the restart.
-		nextLeaseBegin.Forward(
-			hlc.ZeroTimestamp.Add(r.store.startedAt+int64(r.store.Clock().MaxOffset()), 0))
 		transfer := r.mu.pendingLeaseRequest.InitOrJoinRequest(
 			r, nextLeaseHolder, nextLeaseBegin,
 			desc.StartKey.AsRawKey(), true /* transfer */)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -916,6 +916,21 @@ func (s *Store) migrate(ctx context.Context, desc roachpb.RangeDescriptor) {
 	}
 }
 
+// ReadStoreIdent reads the StoreIdent from the store.
+// It returns *NotBootstrappedError if the ident is missing (meaning that the
+// store needs to be bootstrapped).
+func ReadStoreIdent(ctx context.Context, eng engine.Engine) (roachpb.StoreIdent, error) {
+	var ident roachpb.StoreIdent
+	ok, err := engine.MVCCGetProto(
+		ctx, eng, keys.StoreIdentKey(), hlc.ZeroTimestamp, true, nil, &ident)
+	if err != nil {
+		return roachpb.StoreIdent{}, err
+	} else if !ok {
+		return roachpb.StoreIdent{}, &NotBootstrappedError{}
+	}
+	return ident, err
+}
+
 // Start the engine, set the GC and read the StoreIdent.
 func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	s.stopper = stopper
@@ -932,12 +947,11 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	// the store has already been initialized.
 	if s.Ident.NodeID == 0 {
 		// Read store ident and return a not-bootstrapped error if necessary.
-		ok, err := engine.MVCCGetProto(ctx, s.engine, keys.StoreIdentKey(), hlc.ZeroTimestamp, true, nil, &s.Ident)
+		ident, err := ReadStoreIdent(ctx, s.engine)
 		if err != nil {
 			return err
-		} else if !ok {
-			return &NotBootstrappedError{}
 		}
+		s.Ident = ident
 	}
 	log.Event(ctx, "read store identity")
 
@@ -1350,18 +1364,18 @@ func (s *Store) Bootstrap(ident roachpb.StoreIdent, stopper *stop.Stopper) error
 		return errors.Errorf("store %s: unable to access: %s", s.engine, err)
 	} else if len(kvs) > 0 {
 		// See if this is an already-bootstrapped store.
-		if ok, err := engine.MVCCGetProto(
-			ctx, s.engine, keys.StoreIdentKey(), hlc.ZeroTimestamp, true, nil, &s.Ident,
-		); err != nil {
-			return errors.Errorf("store %s is non-empty but cluster ID could not be determined: %s", s.engine, err)
-		} else if ok {
-			return errors.Errorf("store %s already belongs to cockroach cluster %s", s.engine, s.Ident.ClusterID)
+		ident, err := ReadStoreIdent(ctx, s.engine)
+		if err != nil {
+			return errors.Wrapf(err, "unable to read ident of non-empty store %s "+
+				"during bootstrap:", s.engine)
 		}
+		s.Ident = ident
 		keyVals := []string{}
 		for _, kv := range kvs {
 			keyVals = append(keyVals, fmt.Sprintf("%s: %q", kv.Key, kv.Value))
 		}
-		return errors.Errorf("store %s is non-empty but does not contain store metadata (first %d key/values: %s)", s.engine, len(keyVals), keyVals)
+		return errors.Errorf("can't bootstap non-empty store %s (clusterID: %d, first %d key/values: %s)",
+			s.engine, s.Ident.ClusterID, len(keyVals), keyVals)
 	}
 	err = engine.MVCCPutProto(ctx, s.engine, nil,
 		keys.StoreIdentKey(), hlc.ZeroTimestamp, nil, &s.Ident)

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -244,10 +244,8 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	if err := eng.Flush(); err != nil {
 		t.Fatal(err)
 	}
-	if value, _, err := engine.MVCCGet(context.Background(), eng, keys.StoreIdentKey(), hlc.ZeroTimestamp, true, nil); err != nil {
-		t.Fatal(err)
-	} else if value == nil {
-		t.Fatalf("unable to read store ident")
+	if _, err := ReadStoreIdent(context.Background(), eng); err != nil {
+		t.Fatalf("unable to read store ident: %s", err)
 	}
 
 	// Try to get 1st range--non-existent.


### PR DESCRIPTION
- Wait on server startup instead of starting leases in the future. 
- storage: don't use the clock max offset when clearing the timestamp cache

cc @cockroachdb/stability , @petermattis

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9504)

<!-- Reviewable:end -->
