### PR TITLE
gossip: Don't use %s to format an array of resolvers.

### DIFF
--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -227,7 +227,11 @@ func New(
 
 	registry.AddMetric(g.outgoing.gauge)
 	g.clientsMu.breakers = map[string]*circuit.Breaker{}
-	log.Infof(g.ctx, "initial resolvers: %s", resolvers)
+	resolverAddrs := make([]string, len(resolvers))
+	for i, resolver := range resolvers {
+		resolverAddrs[i] = resolver.Addr()
+	}
+	log.Infof(g.ctx, "initial resolvers: %v", resolverAddrs)
 	g.SetResolvers(resolvers)
 
 	g.mu.Lock()


### PR DESCRIPTION
This is showing up in our startup logs:
I160923 16:01:12.144308 1 gossip/gossip.go:230  [n?] initial resolvers: [%!s(*resolver.socketResolver=&{tcp cockroachdb:26257})]

@tamird

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9514)

<!-- Reviewable:end -->
