### PR TITLE
sql: Log statements to event log earlier

### DIFF
--- a/sql/executor.go
+++ b/sql/executor.go
@@ -881,6 +881,9 @@ func (e *Executor) execStmtInOpenTxn(
 	planMaker.evalCtx.SetTxnTimestamp(txnState.sqlTimestamp)
 	planMaker.evalCtx.SetStmtTimestamp(e.cfg.Clock.PhysicalTime())
 
+	session := planMaker.session
+	log.Event(session.context, stmt.String())
+
 	// TODO(cdo): Figure out how to not double count on retries.
 	e.updateStmtCounts(stmt)
 	switch s := stmt.(type) {
@@ -979,9 +982,6 @@ func (e *Executor) execStmtInOpenTxn(
 		}
 		return Result{PGTag: s.StatementTag()}, nil
 	}
-
-	session := planMaker.session
-	log.Event(session.context, stmt.String())
 
 	result, err := e.execStmt(stmt, planMaker, implicitTxn /* autoCommit */)
 	if err != nil {


### PR DESCRIPTION
This ensures that all statements get logged, particularly COMMIT and
ROLLBACK, which were handled with an early return before the previous
location of the logging statement.

@cockroachdb/stability

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9520)

<!-- Reviewable:end -->
