### PR TITLE
storage: persist proposed lease transfers to disk

### DIFF
--- a/base/test_server_args.go
+++ b/base/test_server_args.go
@@ -19,6 +19,7 @@ package base
 import (
 	"time"
 
+	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util/stop"
 )
 
@@ -76,9 +77,10 @@ type TestServerArgs struct {
 // cluster. It contains a TestServerArgs instance which will be copied over to
 // every server.
 //
-// The zero value means "full replication".
+// The zero value means "ReplicationAuto".
 type TestClusterArgs struct {
-	// ServerArgs will be copied to each constituent TestServer.
+	// ServerArgs will be copied to each constituent TestServer. Used for all the
+	// servers not overridden in ServerArgsPerNode.
 	ServerArgs TestServerArgs
 	// ReplicationMode controls how replication is to be done in the cluster.
 	ReplicationMode TestClusterReplicationMode
@@ -112,3 +114,9 @@ const (
 	// replication through the TestServer.
 	ReplicationManual
 )
+
+// ReplicationTarget identifies a node/store pair.
+type ReplicationTarget struct {
+	NodeID  roachpb.NodeID
+	StoreID roachpb.StoreID
+}

--- a/keys/constants.go
+++ b/keys/constants.go
@@ -102,18 +102,20 @@ var (
 	// abort cache protects a transaction from re-reading its own intents
 	// after it's been aborted.
 	LocalAbortCacheSuffix = []byte("abc-")
-	// localRangeFrozenStatusSuffix is the suffix for a frozen status.
+	// LocalRangeFrozenStatusSuffix is the suffix for a frozen status.
 	LocalRangeFrozenStatusSuffix = []byte("fzn-")
 	// localRangeLastGCSuffix is the suffix for the last GC.
 	LocalRangeLastGCSuffix = []byte("lgc-")
-	// LocalRaftAppliedIndexSuffix is the suffix for the raft applied index.
+	// localRaftAppliedIndexSuffix is the suffix for the raft applied index.
 	LocalRaftAppliedIndexSuffix = []byte("rfta")
-	// localRaftTombstoneSuffix is the suffix for the raft tombstone.
+	// LocalRaftTombstoneSuffix is the suffix for the raft tombstone.
 	LocalRaftTombstoneSuffix = []byte("rftb")
-	// localRaftTruncatedStateSuffix is the suffix for the RaftTruncatedState.
+	// LocalRaftTruncatedStateSuffix is the suffix for the RaftTruncatedState.
 	LocalRaftTruncatedStateSuffix = []byte("rftt")
-	// localRangeLeaseSuffix is the suffix for a range lease.
+	// LocalRangeLeaseSuffix is the suffix for a range lease.
 	LocalRangeLeaseSuffix = []byte("rll-")
+	// LocalNextLeaseSuffix is the suffix for a range's "next lease".
+	LocalNextLeaseSuffix = []byte("rnl-")
 	// LocalLeaseAppliedIndexSuffix is the suffix for the applied lease index.
 	LocalLeaseAppliedIndexSuffix = []byte("rlla")
 	// localRangeStatsSuffix is the suffix for range statistics.

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -189,6 +189,12 @@ func RangeLeaseKey(rangeID roachpb.RangeID) roachpb.Key {
 	return MakeRangeIDReplicatedKey(rangeID, LocalRangeLeaseSuffix, nil)
 }
 
+// ReplicaNextLeaseKey returns a system-local key for info on the last lease
+// that was proposed, but not yet applied, by the local replica.
+func ReplicaNextLeaseKey(rangeID roachpb.RangeID) roachpb.Key {
+	return MakeRangeIDUnreplicatedKey(rangeID, LocalNextLeaseSuffix, nil)
+}
+
 // RangeStatsKey returns the key for accessing the MVCCStats struct
 // for the specified Range ID.
 func RangeStatsKey(rangeID roachpb.RangeID) roachpb.Key {

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -1209,11 +1209,11 @@ func TestRequestToUninitializedRange(t *testing.T) {
 
 	// HACK: remove the second store from the node to generate a
 	// non-retryable error when we try to talk to it.
-	store2, err := s.Stores().GetStore(2)
+	ts, err := s.Stores().GetStore(2)
 	if err != nil {
 		t.Fatal(err)
 	}
-	s.Stores().RemoveStore(store2)
+	s.Stores().GetStores().(*storage.Stores).RemoveStore(ts.(*storage.Store))
 
 	// Create the uninitialized range by sending an isolated raft
 	// message to the first store.
@@ -1251,7 +1251,7 @@ func TestRequestToUninitializedRange(t *testing.T) {
 		t.Fatal(err)
 	}
 	util.SucceedsSoon(t, func() error {
-		if replica, err := store1.GetReplica(rangeID); err != nil {
+		if replica, err := store1.(*storage.Store).GetReplica(rangeID); err != nil {
 			return errors.Errorf("failed to look up replica: %s", err)
 		} else if replica.IsInitialized() {
 			return errors.Errorf("expected replica to be uninitialized")

--- a/sql/backup_test.go
+++ b/sql/backup_test.go
@@ -200,7 +200,7 @@ func backupRestoreTestSetup(
 		sqlDB.Exec(split)
 	}
 
-	targets := make([]testcluster.ReplicationTarget, backupRestoreClusterSize-1)
+	targets := make([]base.ReplicationTarget, backupRestoreClusterSize-1)
 	for i := 1; i < backupRestoreClusterSize; i++ {
 		targets[i-1] = tc.Target(i)
 	}

--- a/storage/client_replica_test.go
+++ b/storage/client_replica_test.go
@@ -713,7 +713,7 @@ func TestLeaseExtensionNotBlockedByRead(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		_, repDesc, err := s.Stores().LookupReplica(rKey, nil)
+		_, repDesc, err := s.Stores().(server.TestStores).LookupReplica(rKey, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -875,10 +875,11 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 
 // runSetupSplitSnapshotRace engineers a situation in which a range has
 // been split but node 3 hasn't processed it yet. There is a race
-// depending on whether node 3 learns of the split from its left or
-// right side. When this function returns most of the nodes will be
-// stopped, and depending on the order in which they are restarted, we
-// can arrange for both possible outcomes of the race.
+// on this follower node  between learning about the split through the regular
+// way (applying the split command on the lhs range) and receiving a snapshot
+// from the rhs. When this function returns most of the nodes will be stopped,
+// and depending on the order in which they are restarted, we can arrange for
+// both possible outcomes of the race.
 //
 // Range 1 is the system keyspace, located on node 0.
 //

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -441,12 +441,12 @@ func MVCCSetRangeStats(
 	return MVCCPutProto(ctx, engine, nil, keys.RangeStatsKey(rangeID), hlc.ZeroTimestamp, nil, ms)
 }
 
-// MVCCGetProto fetches the value at the specified key and unmarshals
-// it using a protobuf decoder. Returns true on success or false if
-// the key was not found. In the event of a WriteIntentError when
-// consistent=false, we return the error and the decoded result; for
-// all other errors (or when consistent=true) the decoded value is
-// invalid.
+// MVCCGetProto fetches the value at the specified key and unmarshals it using a
+// protobuf decoder. Returns true on success or false if the key was not found
+// (in which case `msg` is not modified).
+// In the event of a WriteIntentError when consistent=false, we return the error
+// and the decoded result; for all other errors (or when consistent=true) the
+// decoded value is invalid.
 func MVCCGetProto(
 	ctx context.Context,
 	engine Reader,
@@ -476,7 +476,7 @@ func MVCCGetProto(
 func MVCCPutProto(
 	ctx context.Context,
 	engine ReadWriter,
-	ms *enginepb.MVCCStats,
+	ms *enginepb.MVCCStats, // can be nil is the key is unreplicated and doesn't affect stats
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
 	txn *roachpb.Transaction,

--- a/storage/log_test.go
+++ b/storage/log_test.go
@@ -117,7 +117,8 @@ func TestLogSplits(t *testing.T) {
 	// StoreID 1 is present on the testserver. If this assumption changes in the
 	// future, *any* store will work, but a new method will need to be added to
 	// Stores (or a creative usage of VisitStores could suffice).
-	store, pErr := s.(*server.TestServer).Stores().GetStore(roachpb.StoreID(1))
+	testStore, pErr := s.(*server.TestServer).Stores().GetStore(roachpb.StoreID(1))
+	store := testStore.(*storage.Store)
 	if pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -146,7 +147,8 @@ func TestLogRebalances(t *testing.T) {
 	// StoreID 1 is present on the testserver. If this assumption changes in the
 	// future, *any* store will work, but a new method will need to be added to
 	// Stores (or a creative usage of VisitStores could suffice).
-	store, err := s.(*server.TestServer).Stores().GetStore(roachpb.StoreID(1))
+	testStore, err := s.(*server.TestServer).Stores().GetStore(roachpb.StoreID(1))
+	store := testStore.(*storage.Store)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/main_test.go
+++ b/storage/main_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/util/randutil"
 )
 
@@ -41,6 +42,7 @@ var verifyBelowRaftProtos bool
 func TestMain(m *testing.M) {
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 
 	// Create a set of all protos we believe to be marshalled downstream of raft.
 	// After the tests are run, we'll subtract the encountered protos from this

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -282,7 +282,7 @@ type Replica struct {
 		// process have been truncated.
 		raftLogSize int64
 		// pendingLeaseRequest is used to coalesce RequestLease requests.
-		pendingLeaseRequest pendingLeaseRequest
+		pendingLeaseRequest *pendingLeaseRequest
 		// Max bytes before split.
 		maxBytes int64
 		// pendingCmds stores the Raft in-flight commands which
@@ -579,6 +579,11 @@ func (r *Replica) initLocked(
 	}
 	r.rangeStr.store(r.mu.state.Desc)
 
+	r.mu.pendingLeaseRequest, err = newPendingLeaseRequest(r.ctx, r)
+	if err != nil {
+		return err
+	}
+
 	r.mu.lastIndex, err = loadLastIndex(r.ctx, r.store.Engine(), r.RangeID)
 	if err != nil {
 		return err
@@ -764,7 +769,7 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) *roachpb.Error {
 	// lease holder. Returns also on context.Done() (timeout or cancellation).
 	for attempt := 1; ; attempt++ {
 		timestamp := r.store.Clock().Now()
-		llChan, pErr := func() (<-chan *roachpb.Error, *roachpb.Error) {
+		loeChan, pErr := func() (<-chan leaseOrErr, *roachpb.Error) {
 			r.mu.Lock()
 			defer r.mu.Unlock()
 			lease := r.mu.state.Lease
@@ -800,7 +805,7 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) *roachpb.Error {
 					// a lease extension. We don't need to wait for that extension
 					// to go through and simply ignore the returned channel (which
 					// is buffered).
-					_ = r.requestLeaseLocked(timestamp)
+					_ = r.requestLeaseLocked(ctx, timestamp)
 				}
 				// Return a nil chan to signal that we have a valid lease.
 				return nil, nil
@@ -808,33 +813,33 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) *roachpb.Error {
 			log.Eventf(ctx, "request range lease (attempt #%d)", attempt)
 
 			// No active lease: Request renewal if a renewal is not already pending.
-			return r.requestLeaseLocked(timestamp), nil
+			return r.requestLeaseLocked(ctx, timestamp), nil
 		}()
 		if pErr != nil {
 			return pErr
 		}
-		if llChan == nil {
+		if loeChan == nil {
 			// We own a covering lease.
 			return nil
 		}
 
 		// Wait for the range lease to finish, or the context to expire.
 		select {
-		case pErr := <-llChan:
-			if pErr != nil {
+		case loe := <-loeChan:
+			if loe.pErr != nil {
 				// Getting a LeaseRejectedError back means someone else got there
 				// first, or the lease request was somehow invalid due to a
 				// concurrent change. Convert the error to a NotLeaseHolderError.
-				if _, ok := pErr.GetDetail().(*roachpb.LeaseRejectedError); ok {
+				if _, ok := loe.pErr.GetDetail().(*roachpb.LeaseRejectedError); ok {
 					lease, _ := r.getLease()
 					if !lease.Covers(r.store.Clock().Now()) {
 						lease = nil
 					}
 					return roachpb.NewError(newNotLeaseHolderError(lease, r.store.StoreID(), r.Desc()))
 				}
-				return pErr
+				return loe.pErr
 			}
-			log.Event(ctx, "lease acquisition succeeded")
+			log.Eventf(ctx, "a new lease has been applied: %s", loe.lease)
 			continue
 		case <-ctx.Done():
 			log.ErrEventf(ctx, "lease acquisition failed: %s", ctx.Err())
@@ -1391,7 +1396,7 @@ func (r *Replica) addAdminCmd(
 		reply, pErr = r.AdminMerge(ctx, *tArgs, r.Desc())
 		resp = &reply
 	case *roachpb.AdminTransferLeaseRequest:
-		pErr = roachpb.NewError(r.AdminTransferLease(tArgs.Target))
+		pErr = roachpb.NewError(r.AdminTransferLease(ctx, tArgs.Target))
 		resp = &roachpb.AdminTransferLeaseResponse{}
 	case *roachpb.CheckConsistencyRequest:
 		var reply roachpb.CheckConsistencyResponse

--- a/storage/replica_range_lease.go
+++ b/storage/replica_range_lease.go
@@ -24,32 +24,166 @@ import (
 
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util/hlc"
-	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/protoutil"
+	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 )
 
-// pendingLeaseRequest coalesces RequestLease requests and lets callers
-// join an in-progress one and wait for the result.
-// The actual execution of the RequestLease Raft request is delegated to a
-// replica.
+// pendingLeaseRequest coalesces RequestLease requests and lets callers initiate
+// a lease request (extension or transfer) or join an in-progress one and wait
+// for the result.
+// pendingLeaseRequest deals with persisting the state of transferred leases to
+// disk and restoring it on node restart.
+// The actual execution of the RequestLease Raft request is delegated to the
+// parent replica.
+//
+// The pendingLeaseRequest deals with the trickiness of concurrent lease
+// requests and races thereof by making rather weak guarantees: a client can
+// propose a new lease and block until some new lease is applied, but there's no
+// guaranteed that the applied lease is the proposed one. However, this struct
+// also serializes proposals coming from the current replica (and assumes that,
+// while there's a valid lease, only the lease holder will propose new leases),
+// so cases where a waiter is notified of a different lease than the one it was
+// waiting on should be rare - node restarts and races of proposals close to a
+// lease's expiration time.
+// Guarantees on error are stronger: if an error is reported back to a waiting
+// client, that error is guaranteed to be related to the lease it proposed. But
+// the usual caveats apply: an error doesn't necessarily mean that the command
+// hasn't applied / will not apply successfully.
+//
+// Waiters are woken when peningLeaseRequest.SignalLeaseApplied is called from
+// the commit trigger of a transaction that has applied a new lease.
+//
 // Methods are not thread-safe; a pendingLeaseRequest is logically part of
 // a replica, so replica.mu should be used to synchronize all calls.
 type pendingLeaseRequest struct {
-	// Slice of channels to send on after lease acquisition.
-	// If empty, then no request is in progress.
-	llChans []chan *roachpb.Error
+	replica *Replica
 	// nextLease is the pending RequestLease request, if any. It can be used to
 	// figure out if we're in the process of extending our own lease, or
 	// transferring it to another replica.
 	nextLease roachpb.Lease
+	// Slice of channels to send on after lease acquisition.
+	// If empty, then no request is in progress.
+	waiters []chan leaseOrErr
+}
+
+func newPendingLeaseRequest(
+	ctx context.Context, replica *Replica,
+) (*pendingLeaseRequest, error) {
+	// Load the nextLease from disk.
+	nextLease, err := loadNextLease(ctx, replica.store.Engine(), replica.RangeID)
+	if err != nil {
+		return nil, err
+	}
+	// A bit of magic here: if, upon a restart, nextLease is found to be an
+	// extension, then we ignore it. The important thing to restore after a
+	// restart is a lease transfer (so, when we proposed the transfer, we promised
+	// not to use the existing lease any more). If we were to restore an extension
+	// too, we would likely block new attempts to extend the lease.
+	if isExtension := nextLease.Replica.ReplicaID == replica.mu.replicaID; isExtension {
+		nextLease = roachpb.Lease{}
+	}
+	return &pendingLeaseRequest{
+		replica:   replica,
+		nextLease: nextLease,
+		waiters:   nil,
+	}, nil
+}
+
+// leaseOrErr represents the result a waiter gets after a lease has been
+// applied. It will have either a new lease that recently applied, or an error.
+// If it's an error, it is what replica.Send() got when it proposed the specific
+// lease the waiter was waiting on.
+type leaseOrErr struct {
+	pErr  *roachpb.Error
+	lease roachpb.Lease
+}
+
+// SignalLeaseApplied signals all the waiters either that a lease has just been
+// applied, or that the proposal for a lease has failed.
+func (p *pendingLeaseRequest) SignalLeaseApplied(
+	ctx context.Context, lease roachpb.Lease, pErr *roachpb.Error,
+) {
+	if pErr == nil {
+		p.notifyWaiters(leaseOrErr{lease: lease})
+		p.WipeNextLease(ctx)
+	} else {
+		// We need to protect against spurious result errors by checking which lease
+		// request this signal corresponds too. It might not correspond to the
+		// request the current waiters are waiting on, since a signal delivering a
+		// success can race with a signal signaling an error for the same request.
+		// Also, an error can in theory lose a race with a successful application of
+		// a lease proposed by another node.
+		if !proto.Equal(&lease, &p.nextLease) {
+			return
+		}
+		p.notifyWaiters(leaseOrErr{pErr: pErr})
+		// In case of an error, we can wipe our state, but only if we were trying to
+		// extend the lease. The idea is that, if we were trying to extend the
+		// lease, we want to allow others to try again. If, on the other hand, we
+		// were trying to transfer the lease, then we'd still in principle want to
+		// allow others to try again, but, since there's still a chance this
+		// transfer will succeed in the future (proposing a command can return an
+		// error even if the command applies successfully), we can't just wipe the
+		// state: we still need to be in "transfer" mode and not allow the current
+		// lease to be used for serving.
+		if isExtension := lease.Replica.ReplicaID == p.replica.mu.replicaID; isExtension {
+			p.WipeNextLease(ctx)
+		}
+	}
+}
+
+// WipeNextLease clears the "nextLease" state, in memory and on disk. Calling
+// InitOrJoinRequest() after this returns will propose a new lease request.
+func (p *pendingLeaseRequest) WipeNextLease(ctx context.Context) {
+	if len(p.waiters) != 0 {
+		panic("wiping state but someone's waiting for a result")
+	}
+	err := setNextLease(
+		ctx, p.replica.store.engine, p.replica.RangeID, roachpb.Lease{})
+	if err != nil {
+		// TODO(andrei): What should we do for such replica corruption errors?
+		panic(errors.Wrapf(err, "failed to persist lease to disk"))
+	}
+	p.nextLease = roachpb.Lease{}
+}
+
+// getWaitChan returns a channel that will be signaled the next time the replica
+// applies a lease (the lease the caller has just proposed, or a completely
+// different one).
+func (p *pendingLeaseRequest) getWaitChan(ctx context.Context) chan leaseOrErr {
+	// Add myself to the waiters.
+	myCh := make(chan leaseOrErr, 1)
+	p.waiters = append(p.waiters, myCh)
+	return myCh
+}
+
+// notifyWaiters sends a notification to the current batch of waiters. It then
+// clears the list of waiters. Callers should also call WipeNextLease atomically
+// (wrt InitOrJoinRequest() calls) after calling this if they don't want future
+// clients to continue to wait for the same lease the current epoch's waiters
+// were blocked on.
+func (p *pendingLeaseRequest) notifyWaiters(loe leaseOrErr) {
+	for i, ch := range p.waiters {
+		// Don't send the same pErr object twice; this can lead to races. We could
+		// clone every time but it's more efficient to send pErr itself to one of
+		// the channels (the last one; if we send it earlier the race can still
+		// happen).
+		if loe.pErr == nil || i == len(p.waiters)-1 {
+			ch <- loe
+		} else {
+			loeClone := loe
+			loeClone.pErr = protoutil.Clone(loe.pErr).(*roachpb.Error)
+			ch <- loeClone
+		}
+	}
+	p.waiters = nil
 }
 
 // RequestPending returns the pending Lease, if one is in progress.
 // The second return val is true if a lease request is pending.
 func (p *pendingLeaseRequest) RequestPending() (roachpb.Lease, bool) {
-	pending := len(p.llChans) > 0
-	if pending {
+	if p.nextLease.Replica.ReplicaID != 0 {
 		return p.nextLease, true
 	}
 	return roachpb.Lease{}, false
@@ -62,9 +196,9 @@ func (p *pendingLeaseRequest) RequestPending() (roachpb.Lease, bool) {
 // naming another replica as lease holder.
 //
 // replica is used to schedule and execute async work (proposing a RequestLease
-// command). replica.mu is locked when delivering results, so calls from the
-// replica happen either before or after a result for a pending request has
-// happened.
+// command). replica.mu is locked when delivering results, so calls to
+// InitOrJoinRequest happen either before or after a previous lease request had
+// finished.
 //
 // transfer needs to be set if the request represents a lease transfer (as
 // opposed to an extension, or acquiring the lease when none is held).
@@ -73,105 +207,96 @@ func (p *pendingLeaseRequest) RequestPending() (roachpb.Lease, bool) {
 // of replica.store.Stopper().ShouldQuiesce(), care will be needed for cancelling
 // the Raft command, similar to replica.addWriteCmd.
 func (p *pendingLeaseRequest) InitOrJoinRequest(
-	replica *Replica,
+	ctx context.Context,
 	nextLeaseHolder roachpb.ReplicaDescriptor,
 	timestamp hlc.Timestamp,
 	startKey roachpb.Key,
 	transfer bool,
-) <-chan *roachpb.Error {
-	if nextLease, ok := p.RequestPending(); ok {
-		if nextLease.Replica.ReplicaID == nextLeaseHolder.ReplicaID {
-			// Join a pending request asking for the same replica to become lease
-			// holder.
-			return p.JoinRequest()
+) <-chan leaseOrErr {
+	if _, ok := p.RequestPending(); !ok {
+		// No request in progress. Let's propose a Lease command asynchronously.
+		// Sanity check that there's no waiters. We should become the first waiter.
+		if len(p.waiters) != 0 {
+			panic("no lease request in progress, but someone's waiting for a result")
 		}
-		llChan := make(chan *roachpb.Error, 1)
-		// We can't join the request in progress.
-		llChan <- roachpb.NewErrorf("request for different replica in progress "+
-			"(requesting: %+v, in progress: %+v)",
-			nextLeaseHolder.ReplicaID, nextLease.Replica.ReplicaID)
-		return llChan
-	}
-	llChan := make(chan *roachpb.Error, 1)
-	// No request in progress. Let's propose a Lease command asynchronously.
-	// TODO(tschottdorf): get duration from configuration, either as a
-	// config flag or, later, dynamically adjusted.
-	startStasis := timestamp.Add(int64(replica.store.cfg.rangeLeaseActiveDuration), 0)
-	expiration := startStasis.Add(int64(replica.store.Clock().MaxOffset()), 0)
-	reqSpan := roachpb.Span{
-		Key: startKey,
-	}
-	var leaseReq roachpb.Request
-	reqLease := roachpb.Lease{
-		Start:       timestamp,
-		StartStasis: startStasis,
-		Expiration:  expiration,
-		Replica:     nextLeaseHolder,
-	}
-	if transfer {
-		leaseReq = &roachpb.TransferLeaseRequest{
-			Span:  reqSpan,
-			Lease: reqLease,
+		startStasis := timestamp.Add(int64(p.replica.store.cfg.rangeLeaseActiveDuration), 0)
+		expiration := startStasis.Add(int64(p.replica.store.Clock().MaxOffset()), 0)
+		reqSpan := roachpb.Span{
+			Key: startKey,
 		}
-	} else {
-		leaseReq = &roachpb.RequestLeaseRequest{
-			Span:  reqSpan,
-			Lease: reqLease,
+		var leaseReq roachpb.Request
+		reqLease := roachpb.Lease{
+			Start:       timestamp,
+			StartStasis: startStasis,
+			Expiration:  expiration,
+			Replica:     nextLeaseHolder,
 		}
-	}
-	if replica.store.Stopper().RunAsyncTask(replica.ctx, func(ctx context.Context) {
-		// Propose a RequestLease command and wait for it to apply.
-		ba := roachpb.BatchRequest{}
-		ba.Timestamp = replica.store.Clock().Now()
-		ba.RangeID = replica.RangeID
-		ba.Add(leaseReq)
-		if log.V(2) {
-			log.Infof(ctx, "sending lease request %v", leaseReq)
-		}
-		_, pErr := replica.Send(ctx, ba)
-
-		// Send result of lease to all waiter channels.
-		replica.mu.Lock()
-		defer replica.mu.Unlock()
-		for i, llChan := range p.llChans {
-			// Don't send the same pErr object twice; this can lead to races. We could
-			// clone every time but it's more efficient to send pErr itself to one of
-			// the channels (the last one; if we send it earlier the race can still
-			// happen).
-			if i == len(p.llChans)-1 {
-				llChan <- pErr
-			} else {
-				llChan <- protoutil.Clone(pErr).(*roachpb.Error) // works with `nil`
+		if transfer {
+			leaseReq = &roachpb.TransferLeaseRequest{
+				Span:  reqSpan,
+				Lease: reqLease,
+			}
+		} else {
+			leaseReq = &roachpb.RequestLeaseRequest{
+				Span:  reqSpan,
+				Lease: reqLease,
 			}
 		}
-		p.llChans = p.llChans[:0]
-		p.nextLease = roachpb.Lease{}
-	}) != nil {
-		// We failed to start the asynchronous task. Send a blank NotLeaseHolderError
-		// back to indicate that we have no idea who the range lease holder might
-		// be; we've withdrawn from active duty.
-		llChan <- roachpb.NewError(
-			newNotLeaseHolderError(nil, replica.store.StoreID(), replica.mu.state.Desc))
-		return llChan
-	}
-	p.llChans = append(p.llChans, llChan)
-	p.nextLease = reqLease
-	return llChan
-}
 
-// JoinRequest adds one more waiter to the currently pending request.
-// It is the caller's responsibility to ensure that there is a pending request,
-// and that the request is compatible with whatever the caller is currently
-// wanting to do (i.e. the request is naming the intended node as the next
-// lease holder).
-func (p *pendingLeaseRequest) JoinRequest() <-chan *roachpb.Error {
-	llChan := make(chan *roachpb.Error, 1)
-	if len(p.llChans) == 0 {
-		llChan <- roachpb.NewErrorf("no request in progress")
-		return llChan
+		// Save state in-memory and on-disk.
+		err := setNextLease(
+			ctx, p.replica.store.engine, p.replica.RangeID, reqLease)
+		if err != nil {
+			// NOTE(andrei): We could return an error to the caller here since we
+			// haven't sent the request yet, but we can't similarly handle the same
+			// kind of corruption error in GetWaitChan(), so we just panic here too
+			// for symmetry.
+			panic(errors.Wrapf(err, "failed to persist lease to disk"))
+		}
+		p.nextLease = reqLease
+
+		if p.replica.store.Stopper().RunAsyncTask(p.replica.store.Ctx(), func(ctx context.Context) {
+			// Propose a RequestLease command and wait for it to apply.
+			ba := roachpb.BatchRequest{}
+			ba.Timestamp = p.replica.store.Clock().Now()
+			ba.RangeID = p.replica.RangeID
+			ba.Add(leaseReq)
+			_, pErr := p.replica.Send(ctx, ba)
+			if pErr != nil {
+				// If the request failed, signal the waiters. If it succeeded, they'll
+				// be signaled by the commit trigger that applies the new lease.
+				p.replica.mu.Lock()
+				p.SignalLeaseApplied(ctx, p.nextLease, pErr)
+				p.replica.mu.Unlock()
+			}
+		}) != nil {
+			p.WipeNextLease(ctx)
+			errCh := make(chan leaseOrErr, 1)
+			// We failed to start the asynchronous task. Send a blank NotLeaseHolderError
+			// back to indicate that we have no idea who the range lease holder might
+			// be; we've withdrawn from active duty.
+			rangeDesc := p.replica.mu.state.Desc
+			errCh <- leaseOrErr{pErr: roachpb.NewError(
+				newNotLeaseHolderError(nil, p.replica.store.StoreID(), rangeDesc))}
+			return errCh
+		}
+		// Add ourselves as a waiter.
+		retCh := p.getWaitChan(ctx)
+		return retCh
 	}
-	p.llChans = append(p.llChans, llChan)
-	return llChan
+
+	// A lease request is in progress. If it's for the same target, join it.
+	if p.nextLease.Replica.ReplicaID == nextLeaseHolder.ReplicaID {
+		// Join a pending request asking for the same replica to become lease
+		// holder.
+		return p.getWaitChan(ctx)
+	}
+	errChan := make(chan leaseOrErr, 1)
+	errChan <- leaseOrErr{pErr: roachpb.NewErrorf(
+		"request for different replica in progress "+
+			"(requesting: %+v, in progress: %+v)",
+		nextLeaseHolder.ReplicaID, p.nextLease.Replica.ReplicaID)}
+	return errChan
 }
 
 // TransferInProgress returns the next lease, if the replica is in the process
@@ -180,6 +305,10 @@ func (p *pendingLeaseRequest) JoinRequest() <-chan *roachpb.Error {
 //
 // It is assumed that the replica owning this pendingLeaseRequest owns the
 // LeaderLease.
+//
+// Note that the pendingLeaseRequest, and hence this method, is unaware of any
+// transfer that might have been in progress before a restart. The caller must
+// check for that separately.
 //
 // replicaID is the ID of the parent replica.
 func (p *pendingLeaseRequest) TransferInProgress(replicaID roachpb.ReplicaID) (roachpb.Lease, bool) {
@@ -195,33 +324,37 @@ func (p *pendingLeaseRequest) TransferInProgress(replicaID roachpb.ReplicaID) (r
 // requestLeaseLocked executes a request to obtain or extend a lease
 // asynchronously and returns a channel on which the result will be posted. If
 // there's already a request in progress, we join in waiting for the results of
-// that request. Unless an error is returned, the obtained lease will be valid
-// for a time interval containing the requested timestamp.
+// that request. The returned channel is signaled once a new lease has been
+// applied; there's no guarantee that that lease is owned by the current replica
+// or that it covers the requested timestamp. Callers are expected to test the
+// resulting lease and possibly retry.
 // If a transfer is in progress, a NotLeaderError directing to the recipient is
 // sent on the returned chan.
-func (r *Replica) requestLeaseLocked(timestamp hlc.Timestamp) <-chan *roachpb.Error {
+func (r *Replica) requestLeaseLocked(
+	ctx context.Context, timestamp hlc.Timestamp,
+) <-chan leaseOrErr {
 	// Propose a Raft command to get a lease for this replica.
 	repDesc, err := r.getReplicaDescriptorLocked()
 	if err != nil {
-		llChan := make(chan *roachpb.Error, 1)
-		llChan <- roachpb.NewError(err)
-		return llChan
+		errChan := make(chan leaseOrErr, 1)
+		errChan <- leaseOrErr{pErr: roachpb.NewError(err)}
+		return errChan
 	}
 	if transferLease, ok := r.mu.pendingLeaseRequest.TransferInProgress(
-		repDesc.ReplicaID); ok {
-		llChan := make(chan *roachpb.Error, 1)
-		llChan <- roachpb.NewError(
-			newNotLeaseHolderError(&transferLease, r.store.StoreID(), r.mu.state.Desc))
-		return llChan
+		r.mu.replicaID); ok {
+		errChan := make(chan leaseOrErr, 1)
+		errChan <- leaseOrErr{pErr: roachpb.NewError(
+			newNotLeaseHolderError(&transferLease, r.store.StoreID(), r.mu.state.Desc))}
+		return errChan
 	}
 	if r.store.IsDrainingLeases() {
 		// We've retired from active duty.
-		llChan := make(chan *roachpb.Error, 1)
-		llChan <- roachpb.NewError(newNotLeaseHolderError(nil, r.store.StoreID(), r.mu.state.Desc))
-		return llChan
+		errChan := make(chan leaseOrErr, 1)
+		errChan <- leaseOrErr{pErr: roachpb.NewError(newNotLeaseHolderError(nil, r.store.StoreID(), r.mu.state.Desc))}
+		return errChan
 	}
 	return r.mu.pendingLeaseRequest.InitOrJoinRequest(
-		r, repDesc, timestamp, r.mu.state.Desc.StartKey.AsRawKey(), false /* transfer */)
+		ctx, repDesc, timestamp, r.mu.state.Desc.StartKey.AsRawKey(), false /* transfer */)
 }
 
 // AdminTransferLease transfers the LeaderLease to another replica. Only the
@@ -233,22 +366,23 @@ func (r *Replica) requestLeaseLocked(timestamp hlc.Timestamp) <-chan *roachpb.Er
 // even serve reads or propose commands with timestamps lower than the start of
 // the new lease because it could lead to read your own write violations (see
 // comments on the stasis period in the Lease proto). We could, in principle,
-// serve reads more than the maximum clock offset in the past.
+// serve reads more than the maximum clock offset in the past. After a transfer
+// is initiated, Replica.mu.pendingLeaseRequest.TransferInProgress() will start
+// returning true.
 //
 // The method waits for any in-progress lease extension to be done, and it also
 // blocks until the transfer is done. If a transfer is already in progress,
 // this method joins in waiting for it to complete if it's transferring to the
 // same replica. Otherwise, a NotLeaderError is returned.
-//
-// TODO(andrei): figure out how to persist the "not serving" state across node
-// restarts.
-func (r *Replica) AdminTransferLease(target roachpb.StoreID) error {
+func (r *Replica) AdminTransferLease(
+	ctx context.Context, target roachpb.StoreID,
+) error {
 	// initTransferHelper inits a transfer if no extension is in progress.
 	// It returns a channel for waiting for the result of a pending
 	// extension (if any is in progress) and a channel for waiting for the
 	// transfer (if it was successfully initiated).
 	var nextLeaseHolder roachpb.ReplicaDescriptor
-	initTransferHelper := func() (<-chan *roachpb.Error, <-chan *roachpb.Error, error) {
+	initTransferHelper := func() (<-chan leaseOrErr, <-chan leaseOrErr, error) {
 		r.mu.Lock()
 		defer r.mu.Unlock()
 
@@ -276,7 +410,11 @@ func (r *Replica) AdminTransferLease(target roachpb.StoreID) error {
 			if nextLease.Replica == repDesc {
 				// There's an extension in progress. Let's wait for it to succeed and
 				// try again.
-				return r.mu.pendingLeaseRequest.JoinRequest(), nil, nil
+				return r.mu.pendingLeaseRequest.InitOrJoinRequest(
+					ctx, nextLease.Replica,
+					// the rest of the arguments don't matter; we know we're joining a
+					// request, not initiating one.
+					nextLease.Start, desc.StartKey.AsRawKey(), false /* transfer */), nil, nil
 			}
 			// Another transfer is in progress, and it's not transferring to the
 			// same replica we'd like.
@@ -289,7 +427,7 @@ func (r *Replica) AdminTransferLease(target roachpb.StoreID) error {
 		nextLeaseBegin.Forward(
 			hlc.ZeroTimestamp.Add(r.store.startedAt+int64(r.store.Clock().MaxOffset()), 0))
 		transfer := r.mu.pendingLeaseRequest.InitOrJoinRequest(
-			r, nextLeaseHolder, nextLeaseBegin,
+			ctx, nextLeaseHolder, nextLeaseBegin,
 			desc.StartKey.AsRawKey(), true /* transfer */)
 		return nil, transfer, nil
 	}
@@ -307,7 +445,18 @@ func (r *Replica) AdminTransferLease(target roachpb.StoreID) error {
 				// The target is us and we're the lease holder.
 				return nil
 			}
-			return (<-transfer).GoError()
+			loe := <-transfer
+			if loe.pErr != nil {
+				return (<-transfer).pErr.GoError()
+			}
+			if loe.lease.Replica.StoreID != target {
+				// The lease was transferred somewhere else.
+				r.mu.Lock()
+				rangeDesc := r.mu.state.Desc
+				r.mu.Unlock()
+				return newNotLeaseHolderError(&loe.lease, r.store.StoreID(), rangeDesc)
+			}
+			return nil
 		}
 		// Wait for the in-progress extension without holding the mutex.
 		if r.store.TestingKnobs().LeaseTransferBlockedOnExtensionEvent != nil {

--- a/storage/replica_trigger.go
+++ b/storage/replica_trigger.go
@@ -285,6 +285,9 @@ func (r *Replica) leasePostCommitTrigger(
 		// periodic check should happen.
 		r.maybeTransferRaftLeadership(ctx, replicaID, trigger.lease.Replica.ReplicaID)
 	}
+	r.mu.Lock()
+	r.mu.pendingLeaseRequest.SignalLeaseApplied(ctx, *trigger.lease, nil /* pErr */)
+	r.mu.Unlock()
 }
 
 // maybeTransferRaftLeadership attempts to transfer the leadership away from

--- a/storage/stats_test.go
+++ b/storage/stats_test.go
@@ -20,9 +20,6 @@ import (
 	"reflect"
 	"testing"
 
-	"golang.org/x/net/context"
-
-	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
@@ -47,35 +44,5 @@ func TestRangeStatsEmpty(t *testing.T) {
 	ms := tc.rng.GetMVCCStats()
 	if exp := initialStats(); !reflect.DeepEqual(ms, exp) {
 		t.Errorf("expected stats %+v; got %+v", exp, ms)
-	}
-}
-
-func TestRangeStatsInit(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	tc := testContext{}
-	tc.Start(t)
-	defer tc.Stop()
-	ms := enginepb.MVCCStats{
-		LiveBytes:       1,
-		KeyBytes:        2,
-		ValBytes:        3,
-		IntentBytes:     4,
-		LiveCount:       5,
-		KeyCount:        6,
-		ValCount:        7,
-		IntentCount:     8,
-		IntentAge:       9,
-		GCBytesAge:      10,
-		LastUpdateNanos: 11,
-	}
-	if err := engine.MVCCSetRangeStats(context.Background(), tc.engine, 1, &ms); err != nil {
-		t.Fatal(err)
-	}
-	loadMS, err := loadMVCCStats(context.Background(), tc.engine, tc.rng.RangeID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(ms, loadMS) {
-		t.Errorf("mvcc stats mismatch %+v != %+v", ms, loadMS)
 	}
 }

--- a/storage/store.go
+++ b/storage/store.go
@@ -1459,7 +1459,7 @@ func (s *Store) StoreID() roachpb.StoreID { return s.Ident.StoreID }
 // Clock accessor.
 func (s *Store) Clock() *hlc.Clock { return s.cfg.Clock }
 
-// Engine accessor.
+// Engine accessor. Part of TestStoreInterface.
 func (s *Store) Engine() engine.Engine { return s.engine }
 
 // DB accessor.

--- a/testutils/serverutils/test_server_shim.go
+++ b/testutils/serverutils/test_server_shim.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/stop"
+	"github.com/cockroachdb/cockroach/util/testserverutils"
 )
 
 // TestServerInterface defines test server functionality that tests need; it is
@@ -94,6 +95,13 @@ type TestServerInterface interface {
 	// WriteSummaries records summaries of time-series data, which is required for
 	// any tests that query server stats.
 	WriteSummaries() error
+
+	// GetFirstStoreID is a utility function returning the StoreID of the first
+	// store on this node.
+	GetFirstStoreID() roachpb.StoreID
+
+	// Stores returns the collection of stores from this TestServer's node.
+	Stores() testserverutils.TestStoresInterface
 }
 
 // TestServerFactory encompasses the actual implementation of the shim

--- a/testutils/testcluster/testcluster.go
+++ b/testutils/testcluster/testcluster.go
@@ -231,7 +231,7 @@ func (tc *TestCluster) waitForStores(t testing.TB) {
 	}
 }
 
-// LookupRange returns the descriptor of the range containing key.
+// LookupRange is part of TestClusterInterface.
 func (tc *TestCluster) LookupRange(key roachpb.Key) (roachpb.RangeDescriptor, error) {
 	return serverutils.LookupRange(tc.Servers[0].DistSender(), key)
 }
@@ -287,23 +287,17 @@ func (tc *TestCluster) SplitRange(
 	return leftRangeDesc, rightRangeDesc, nil
 }
 
-// ReplicationTarget identifies a node/store pair.
-type ReplicationTarget struct {
-	NodeID  roachpb.NodeID
-	StoreID roachpb.StoreID
-}
-
-// Target returns a ReplicationTarget for the specified server.
-func (tc *TestCluster) Target(serverIdx int) ReplicationTarget {
+// Target is part of TestClusterInterface.
+func (tc *TestCluster) Target(serverIdx int) base.ReplicationTarget {
 	s := tc.Servers[serverIdx]
-	return ReplicationTarget{
+	return base.ReplicationTarget{
 		NodeID:  s.GetNode().Descriptor.NodeID,
 		StoreID: s.GetFirstStoreID(),
 	}
 }
 
 func (tc *TestCluster) changeReplicas(
-	action roachpb.ReplicaChangeType, startKey roachpb.RKey, targets ...ReplicationTarget,
+	action roachpb.ReplicaChangeType, startKey roachpb.RKey, targets ...base.ReplicationTarget,
 ) (*roachpb.RangeDescriptor, error) {
 	rangeDesc := &roachpb.RangeDescriptor{}
 
@@ -348,13 +342,9 @@ func (tc *TestCluster) changeReplicas(
 	return rangeDesc, nil
 }
 
-// AddReplicas adds replicas for a range on a set of stores.
-// It's illegal to have multiple replicas of the same range on stores of a single
-// node.
-// The method blocks until a snapshot of the range has been copied to all the
-// new replicas and the new replicas become part of the Raft group.
+// AddReplicas is part of TestClusterInterface.
 func (tc *TestCluster) AddReplicas(
-	startKey roachpb.Key, targets ...ReplicationTarget,
+	startKey roachpb.Key, targets ...base.ReplicationTarget,
 ) (*roachpb.RangeDescriptor, error) {
 	rKey := keys.MustAddr(startKey)
 	rangeDesc, err := tc.changeReplicas(
@@ -387,21 +377,14 @@ func (tc *TestCluster) AddReplicas(
 
 // RemoveReplicas removes one or more replicas from a range.
 func (tc *TestCluster) RemoveReplicas(
-	startKey roachpb.Key, targets ...ReplicationTarget,
+	startKey roachpb.Key, targets ...base.ReplicationTarget,
 ) (*roachpb.RangeDescriptor, error) {
 	return tc.changeReplicas(roachpb.REMOVE_REPLICA, keys.MustAddr(startKey), targets...)
 }
 
-// TransferRangeLease transfers the lease for a range from whoever has it to
-// a particular store. That store must already have a replica of the range. If
-// that replica already has the (active) lease, this method is a no-op.
-//
-// When this method returns, it's guaranteed that the old lease holder has
-// applied the new lease, but that's about it. It's not guaranteed that the new
-// lease holder has applied it (so it might not know immediately that it is the
-// new lease holder).
+// TransferRangeLease is part of TestClusterInterface.
 func (tc *TestCluster) TransferRangeLease(
-	rangeDesc *roachpb.RangeDescriptor, dest ReplicationTarget,
+	rangeDesc *roachpb.RangeDescriptor, dest base.ReplicationTarget,
 ) error {
 	err := tc.Servers[0].DB().AdminTransferLease(context.TODO(),
 		rangeDesc.StartKey.AsRawKey(), dest.StoreID)
@@ -415,7 +398,7 @@ func (tc *TestCluster) TransferRangeLease(
 // without verifying if the lease is still active. Instead, it returns a time-
 // stamp taken off the queried node's clock.
 func (tc *TestCluster) FindRangeLease(
-	rangeDesc *roachpb.RangeDescriptor, hint *ReplicationTarget,
+	rangeDesc *roachpb.RangeDescriptor, hint *base.ReplicationTarget,
 ) (_ *roachpb.Lease, now hlc.Timestamp, _ error) {
 	if hint != nil {
 		var ok bool
@@ -424,7 +407,7 @@ func (tc *TestCluster) FindRangeLease(
 				"bad hint: %+v; store doesn't have a replica of the range", hint)
 		}
 	} else {
-		hint = &ReplicationTarget{
+		hint = &base.ReplicationTarget{
 			NodeID:  rangeDesc.Replicas[0].NodeID,
 			StoreID: rangeDesc.Replicas[0].StoreID}
 	}
@@ -471,28 +454,28 @@ func (tc *TestCluster) FindRangeLease(
 // different hints can yield different results. The one server that's guaranteed
 // to have applied the transfer is the previous lease holder.
 func (tc *TestCluster) FindRangeLeaseHolder(
-	rangeDesc *roachpb.RangeDescriptor, hint *ReplicationTarget,
-) (ReplicationTarget, error) {
+	rangeDesc *roachpb.RangeDescriptor, hint *base.ReplicationTarget,
+) (base.ReplicationTarget, error) {
 	lease, now, err := tc.FindRangeLease(rangeDesc, hint)
 	if err != nil {
-		return ReplicationTarget{}, err
+		return base.ReplicationTarget{}, err
 	}
 	if lease == nil || !lease.Covers(now) {
-		return ReplicationTarget{}, errors.New("no active lease")
+		return base.ReplicationTarget{}, errors.New("no active lease")
 	}
 	replicaDesc := lease.Replica
-	return ReplicationTarget{NodeID: replicaDesc.NodeID, StoreID: replicaDesc.StoreID}, nil
+	return base.ReplicationTarget{NodeID: replicaDesc.NodeID, StoreID: replicaDesc.StoreID}, nil
 }
 
 // findMemberStore returns the store containing a given replica.
 func (tc *TestCluster) findMemberStore(storeID roachpb.StoreID) (*storage.Store, error) {
-	for _, server := range tc.Servers {
-		if server.Stores().HasStore(storeID) {
-			store, err := server.Stores().GetStore(storeID)
+	for _, s := range tc.Servers {
+		if s.Stores().(server.TestStores).HasStore(storeID) {
+			store, err := s.Stores().GetStore(storeID)
 			if err != nil {
 				return nil, err
 			}
-			return store, nil
+			return store.(*storage.Store), nil
 		}
 	}
 	return nil, errors.Errorf("store not found")
@@ -511,7 +494,7 @@ func (tc *TestCluster) WaitForFullReplication() error {
 	for r := retry.Start(opts); r.Next() && notReplicated; {
 		notReplicated = false
 		for _, s := range tc.Servers {
-			err := s.Stores().VisitStores(func(s *storage.Store) error {
+			err := s.Stores().(server.TestStores).VisitStores(func(s *storage.Store) error {
 				if err := s.ComputeMetrics(0); err != nil {
 					return err
 				}

--- a/testutils/testcluster/testcluster.go
+++ b/testutils/testcluster/testcluster.go
@@ -123,31 +123,40 @@ func StartTestCluster(t testing.TB, nodes int, args base.TestClusterArgs) *TestC
 	if nodes < 1 {
 		t.Fatal("invalid cluster size: ", nodes)
 	}
-	if args.ServerArgs.JoinAddr != "" {
-		t.Fatal("can't specify a join addr when starting a cluster")
-	}
-	if args.ServerArgs.Stopper != nil {
-		t.Fatal("can't set individual server stoppers when starting a cluster")
-	}
-	storeKnobs := args.ServerArgs.Knobs.Store
-	if storeKnobs != nil &&
-		(storeKnobs.(*storage.StoreTestingKnobs).DisableSplitQueue ||
-			storeKnobs.(*storage.StoreTestingKnobs).DisableReplicateQueue) {
-		t.Fatal("can't disable an individual server's queues when starting a cluster; " +
-			"the cluster controls replication")
-	}
 
-	switch args.ReplicationMode {
-	case base.ReplicationAuto:
-	case base.ReplicationManual:
-		if args.ServerArgs.Knobs.Store == nil {
-			args.ServerArgs.Knobs.Store = &storage.StoreTestingKnobs{}
+	// Sanity-check and massage all ServerArgs to work for a cluster.
+	var allArgs []*base.TestServerArgs
+	allArgs = append(allArgs, &args.ServerArgs)
+	for _, sargs := range args.ServerArgsPerNode {
+		allArgs = append(allArgs, &sargs)
+	}
+	for _, sargs := range allArgs {
+		if sargs.JoinAddr != "" {
+			t.Fatal("can't specify a join addr when starting a cluster")
 		}
-		storeKnobs := args.ServerArgs.Knobs.Store.(*storage.StoreTestingKnobs)
-		storeKnobs.DisableSplitQueue = true
-		storeKnobs.DisableReplicateQueue = true
-	default:
-		t.Fatal("unexpected replication mode")
+		if sargs.Stopper != nil {
+			t.Fatal("can't set individual server stoppers when starting a cluster")
+		}
+		storeKnobs := sargs.Knobs.Store
+		if storeKnobs != nil &&
+			(storeKnobs.(*storage.StoreTestingKnobs).DisableSplitQueue ||
+				storeKnobs.(*storage.StoreTestingKnobs).DisableReplicateQueue) {
+			t.Fatal("can't disable an individual server's queues when starting a cluster; " +
+				"the cluster controls replication")
+		}
+
+		switch args.ReplicationMode {
+		case base.ReplicationAuto:
+		case base.ReplicationManual:
+			if sargs.Knobs.Store == nil {
+				sargs.Knobs.Store = &storage.StoreTestingKnobs{}
+			}
+			storeKnobs := sargs.Knobs.Store.(*storage.StoreTestingKnobs)
+			storeKnobs.DisableSplitQueue = true
+			storeKnobs.DisableReplicateQueue = true
+		default:
+			t.Fatal("unexpected replication mode")
+		}
 	}
 
 	tc := &TestCluster{}

--- a/testutils/testcluster/testcluster_test.go
+++ b/testutils/testcluster/testcluster_test.go
@@ -101,7 +101,7 @@ func TestManualReplication(t *testing.T) {
 	// Transfer the lease to node 1.
 	leaseHolder, err := tc.FindRangeLeaseHolder(
 		tableRangeDesc,
-		&ReplicationTarget{
+		&base.ReplicationTarget{
 			NodeID:  tc.Servers[0].GetNode().Descriptor.NodeID,
 			StoreID: tc.Servers[0].GetFirstStoreID(),
 		})
@@ -123,7 +123,7 @@ func TestManualReplication(t *testing.T) {
 	// new lease.
 	leaseHolder, err = tc.FindRangeLeaseHolder(
 		tableRangeDesc,
-		&ReplicationTarget{
+		&base.ReplicationTarget{
 			NodeID:  tc.Servers[0].GetNode().Descriptor.NodeID,
 			StoreID: tc.Servers[0].GetFirstStoreID(),
 		})

--- a/util/testserverutils/testserver_utils.go
+++ b/util/testserverutils/testserver_utils.go
@@ -1,0 +1,41 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Andrei Matei (andreimatei1@gmail.com)
+
+package testserverutils
+
+import (
+	"github.com/cockroachdb/cockroach/internal/client"
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/storage/engine"
+)
+
+// TestStoresInterface is implemented by server.TestStores.
+// It embeds a Stores and give convenient access to tests that can't depend on
+// storage.
+type TestStoresInterface interface {
+	client.Sender
+	GetStore(roachpb.StoreID) (TestStoreInterface, error)
+	// GetStores returns the storage.Stores instance.
+	GetStores() interface{}
+}
+
+// TestStoreInterface is implemented by *storage.Store.
+type TestStoreInterface interface {
+	// Engine accessor.
+	// NB: This introduces a dependency on engine. That package is low-level enough
+	// that it seems unlikely that a util or one of its clients can't depend on it.
+	Engine() engine.Engine
+}


### PR DESCRIPTION
... so we don't use those leases after a restart

fixes #7996

cc @cockroachdb/stability @petermattis

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9523)

<!-- Reviewable:end -->
