### PR TITLE
sql/parser: sanity check builtin functions for length overflow

### DIFF
--- a/sql/parser/aggregate_builtins.go
+++ b/sql/parser/aggregate_builtins.go
@@ -181,7 +181,7 @@ func (a *identAggregate) Result() Datum {
 
 type avgAggregate struct {
 	agg   AggregateFunc
-	count int
+	count int64
 }
 
 func newIntAvgAggregate() AggregateFunc {
@@ -273,7 +273,7 @@ func (a *boolOrAggregate) Result() Datum {
 }
 
 type countAggregate struct {
-	count int
+	count int64
 }
 
 func newCountAggregate() AggregateFunc {
@@ -496,7 +496,7 @@ func (a *intVarianceAggregate) Result() Datum {
 }
 
 type floatVarianceAggregate struct {
-	count   int
+	count   int64
 	mean    float64
 	sqrDiff float64
 }

--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -22,7 +22,6 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -34,6 +33,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/pkg/errors"
 	"gopkg.in/inf.v0"
 
 	"github.com/cockroachdb/cockroach/build"
@@ -50,6 +50,7 @@ var (
 	errAbsOfMinInt64    = errors.New("abs of min integer value (-9223372036854775808) not defined")
 	errRoundTooLow      = errors.New("rounding would extend value by more than 2000 decimal digits")
 	errArgTooBig        = errors.New("argument value is too large")
+	errArgTooSmall      = errors.New("argument value is too small")
 	errSqrtOfNegNumber  = errors.New("cannot take square root of a negative number")
 	errLogOfNegNumber   = errors.New("cannot take logarithm of a negative number")
 	errLogOfZero        = errors.New("cannot take logarithm of zero")
@@ -131,6 +132,21 @@ func (b Builtin) Category() string {
 		return categorizeType(b.ReturnType)
 	}
 	return ""
+}
+
+// argToInt converts a *DInt stored in a Datum into an int type. It checks to
+// ensure it fits within a 32-bit integer. At the moment this should typically
+// only be used indexing into fields or field lengths. Field lengths have
+// a practical limit that is far below an Int32 value.
+func argToInt(d Datum) (int, error) {
+	a := d.(*DInt)
+	if *a > math.MaxInt32 {
+		return 0, errArgTooBig
+	}
+	if *a < math.MinInt32 {
+		return 0, errArgTooSmall
+	}
+	return int(*a), nil
 }
 
 // Builtins contains the built-in functions indexed by name.
@@ -217,7 +233,10 @@ var Builtins = map[string][]Builtin{
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				text := string(*args[0].(*DString))
 				sep := string(*args[1].(*DString))
-				field := int(*args[2].(*DInt))
+				field, err := argToInt(args[2])
+				if err != nil {
+					return DNull, errors.Wrap(err, "field position")
+				}
 
 				if field <= 0 {
 					return DNull, fmt.Errorf("field position %d must be greater than zero", field)
@@ -238,7 +257,10 @@ var Builtins = map[string][]Builtin{
 			ReturnType: TypeString,
 			fn: func(_ *EvalContext, args DTuple) (_ Datum, err error) {
 				s := string(*args[0].(*DString))
-				count := int(*args[1].(*DInt))
+				count, err := argToInt(args[1])
+				if err != nil {
+					return DNull, errors.Wrap(err, "field count")
+				}
 				if count < 0 {
 					count = 0
 				}
@@ -301,7 +323,10 @@ var Builtins = map[string][]Builtin{
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				s := string(*args[0].(*DString))
 				to := string(*args[1].(*DString))
-				pos := int(*args[2].(*DInt))
+				pos, err := argToInt(args[2])
+				if err != nil {
+					return DNull, errors.Wrap(err, "field position")
+				}
 				size := utf8.RuneCountInString(to)
 				return overlay(s, to, pos, size)
 			},
@@ -312,8 +337,14 @@ var Builtins = map[string][]Builtin{
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				s := string(*args[0].(*DString))
 				to := string(*args[1].(*DString))
-				pos := int(*args[2].(*DInt))
-				size := int(*args[3].(*DInt))
+				pos, err := argToInt(args[2])
+				if err != nil {
+					return DNull, errors.Wrap(err, "field position")
+				}
+				size, err := argToInt(args[3])
+				if err != nil {
+					return DNull, errors.Wrap(err, "field size")
+				}
 				return overlay(s, to, pos, size)
 			},
 		},
@@ -433,7 +464,10 @@ var Builtins = map[string][]Builtin{
 			ReturnType: TypeBytes,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				bytes := []byte(*args[0].(*DBytes))
-				n := int(*args[1].(*DInt))
+				n, err := argToInt(args[1])
+				if err != nil {
+					return DNull, errors.Wrap(err, "field n")
+				}
 
 				if n < -len(bytes) {
 					n = 0
@@ -450,7 +484,10 @@ var Builtins = map[string][]Builtin{
 			ReturnType: TypeString,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				runes := []rune(string(*args[0].(*DString)))
-				n := int(*args[1].(*DInt))
+				n, err := argToInt(args[1])
+				if err != nil {
+					return DNull, errors.Wrap(err, "field n")
+				}
 
 				if n < -len(runes) {
 					n = 0
@@ -470,7 +507,10 @@ var Builtins = map[string][]Builtin{
 			ReturnType: TypeBytes,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				bytes := []byte(*args[0].(*DBytes))
-				n := int(*args[1].(*DInt))
+				n, err := argToInt(args[1])
+				if err != nil {
+					return DNull, errors.Wrap(err, "field n")
+				}
 
 				if n < -len(bytes) {
 					n = 0
@@ -487,7 +527,10 @@ var Builtins = map[string][]Builtin{
 			ReturnType: TypeString,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				runes := []rune(string(*args[0].(*DString)))
-				n := int(*args[1].(*DInt))
+				n, err := argToInt(args[1])
+				if err != nil {
+					return DNull, errors.Wrap(err, "field n")
+				}
 
 				if n < -len(runes) {
 					n = 0
@@ -979,8 +1022,11 @@ var substringImpls = []Builtin{
 		ReturnType: TypeString,
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			runes := []rune(string(*args[0].(*DString)))
-			// SQL strings are 1-indexed.
-			start := int(*args[1].(*DInt)) - 1
+			start, err := argToInt(args[1])
+			if err != nil {
+				return DNull, errors.Wrap(err, "field start")
+			}
+			start-- // SQL strings are 1-indexed.
 
 			if start < 0 {
 				start = 0
@@ -996,9 +1042,15 @@ var substringImpls = []Builtin{
 		ReturnType: TypeString,
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			runes := []rune(string(*args[0].(*DString)))
-			// SQL strings are 1-indexed.
-			start := int(*args[1].(*DInt)) - 1
-			length := int(*args[2].(*DInt))
+			start, err := argToInt(args[1])
+			if err != nil {
+				return DNull, errors.Wrap(err, "field start")
+			}
+			length, err := argToInt(args[2])
+			if err != nil {
+				return DNull, errors.Wrap(err, "field length")
+			}
+			start-- // SQL strings are 1-indexed.
 
 			if length < 0 {
 				return DNull, fmt.Errorf("negative substring length %d not allowed", length)

--- a/sql/parser/window_builtins.go
+++ b/sql/parser/window_builtins.go
@@ -266,7 +266,7 @@ func (w *rankWindow) Compute(wf WindowFrame) (Datum, error) {
 
 // denseRankWindow computes the rank of the current row without gaps (it counts peer groups).
 type denseRankWindow struct {
-	denseRank int
+	denseRank int64
 	peerRes   *DInt
 }
 
@@ -329,9 +329,9 @@ func (w *cumulativeDistWindow) Compute(wf WindowFrame) (Datum, error) {
 // the partition as equally as possible.
 type ntileWindow struct {
 	ntile          *DInt // current result
-	curBucketCount int   // row number of current bucket
-	boundary       int   // how many rows should be in the bucket
-	remainder      int   // (total rows) % (bucket num)
+	curBucketCount int64 // row number of current bucket
+	boundary       int64 // how many rows should be in the bucket
+	remainder      int64 // (total rows) % (bucket num)
 }
 
 func newNtileWindow() WindowFunc {
@@ -343,15 +343,14 @@ var errInvalidArgumentForNtile = errors.Errorf("argument of ntile must be greate
 func (w *ntileWindow) Compute(wf WindowFrame) (Datum, error) {
 	if w.ntile == nil {
 		// If this is the first call to ntileWindow.Compute, set up the buckets.
-		total := wf.rowCount()
+		total := int64(wf.rowCount())
 
 		arg := wf.args()[0]
 		if arg == DNull {
 			// per spec: If argument is the null value, then the result is the null value.
 			return DNull, nil
 		}
-
-		nbuckets := int(*arg.(*DInt))
+		nbuckets := int64(*arg.(*DInt))
 		if nbuckets <= 0 {
 			// per spec: If argument is less than or equal to 0, then an error is returned.
 			return nil, errInvalidArgumentForNtile
@@ -374,7 +373,7 @@ func (w *ntileWindow) Compute(wf WindowFrame) (Datum, error) {
 	w.curBucketCount++
 	if w.boundary < w.curBucketCount {
 		// Move to next ntile bucket.
-		if w.remainder != 0 && int(*w.ntile) == w.remainder {
+		if w.remainder != 0 && int64(*w.ntile) == w.remainder {
 			w.remainder = 0
 			w.boundary--
 		}


### PR DESCRIPTION
On 32-bit systems there is a cast from 64-bit int to a 32-bit int
which could cause data correctness issues on large values. Check
for larger values before casting to an int. Also change counter
fields from ints to int64s to be explicit about size.

Updates #8179

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9549)

<!-- Reviewable:end -->
