### PR TITLE
sql: Add initial support for the pg_catalog database

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -611,9 +611,10 @@ func Example_sql() {
 	// x	y
 	// 42	69
 	// sql --execute=show databases
-	// 3 rows
+	// 4 rows
 	// Database
 	// information_schema
+	// pg_catalog
 	// system
 	// t
 	// sql -e explain select 3

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -241,16 +241,13 @@ func TestAdminAPIDatabases(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// We should have three databases:
-	// - system database
-	// - information_schema
-	// - newly created test database
-	if a, e := len(resp.Databases), 3; a != e {
+	expectedDBs := []string{"information_schema", "pg_catalog", "system", testdb}
+	if a, e := len(resp.Databases), len(expectedDBs); a != e {
 		t.Fatalf("length of result %d != expected %d", a, e)
 	}
 
 	sort.Strings(resp.Databases)
-	for i, e := range []string{"information_schema", "system", testdb} {
+	for i, e := range expectedDBs {
 		if a := resp.Databases[i]; a != e {
 			t.Fatalf("database name %s != expected %s", a, e)
 		}

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -159,7 +159,7 @@ type Executor struct {
 	nodeID         roachpb.NodeID
 	cfg            ExecutorConfig
 	reCache        *parser.RegexpCache
-	virtualSchemas virtualSchemaMap
+	virtualSchemas virtualSchemaHolder
 
 	// Transient stats.
 	Latency       metric.Histograms

--- a/sql/information_schema.go
+++ b/sql/information_schema.go
@@ -532,6 +532,23 @@ func forEachTableDesc(
 	return nil
 }
 
+func forEachIndexInTable(
+	table *sqlbase.TableDescriptor,
+	fn func(*sqlbase.IndexDescriptor) error,
+) error {
+	if table.IsPhysicalTable() {
+		if err := fn(&table.PrimaryIndex); err != nil {
+			return err
+		}
+	}
+	for i := range table.Indexes {
+		if err := fn(&table.Indexes[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func userCanSeeDatabase(db *sqlbase.DatabaseDescriptor, user string) bool {
 	return userCanSeeDescriptor(db, user)
 }

--- a/sql/information_schema.go
+++ b/sql/information_schema.go
@@ -101,12 +101,9 @@ CREATE TABLE information_schema.columns (
 			func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
 				// Table descriptors already holds columns in-order.
 				visible := 0
-				for _, column := range table.Columns {
-					if column.Hidden {
-						continue
-					}
+				return forEachColumnInTable(table, func(column *sqlbase.ColumnDescriptor) error {
 					visible++
-					if err := addRow(
+					return addRow(
 						defString,                                    // table_catalog
 						parser.NewDString(db.Name),                   // table_schema
 						parser.NewDString(table.Name),                // table_name
@@ -120,11 +117,8 @@ CREATE TABLE information_schema.columns (
 						numericPrecision(column.Type),                // numeric_precision
 						numericScale(column.Type),                    // numeric_scale
 						datetimePrecision(column.Type),               // datetime_precision
-					); err != nil {
-						return err
-					}
-				}
-				return nil
+					)
+				})
 			},
 		)
 	},
@@ -544,6 +538,40 @@ func forEachIndexInTable(
 	for i := range table.Indexes {
 		if err := fn(&table.Indexes[i]); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func forEachColumnInTable(
+	table *sqlbase.TableDescriptor,
+	fn func(*sqlbase.ColumnDescriptor) error,
+) error {
+	// Table descriptors already hold columns in-order.
+	for i := range table.Columns {
+		if !table.Columns[i].Hidden {
+			if err := fn(&table.Columns[i]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func forEachColumnInIndex(
+	table *sqlbase.TableDescriptor,
+	index *sqlbase.IndexDescriptor,
+	fn func(*sqlbase.ColumnDescriptor) error,
+) error {
+	colMap := make(map[sqlbase.ColumnID]*sqlbase.ColumnDescriptor, len(table.Columns))
+	for i, column := range table.Columns {
+		colMap[column.ID] = &table.Columns[i]
+	}
+	for _, columnID := range index.ColumnIDs {
+		if column := colMap[columnID]; !column.Hidden {
+			if err := fn(column); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/sql/information_schema.go
+++ b/sql/information_schema.go
@@ -434,7 +434,7 @@ func forEachDatabaseDesc(
 	}
 
 	// Handle virtual schemas.
-	for _, schema := range p.virtualSchemas() {
+	for _, schema := range p.virtualSchemas().entries {
 		dbDescs = append(dbDescs, schema.desc)
 	}
 
@@ -494,7 +494,7 @@ func forEachTableDesc(
 	}
 
 	// Handle virtual schemas.
-	for dbName, schema := range p.virtualSchemas() {
+	for dbName, schema := range p.virtualSchemas().entries {
 		dbTables := make(map[string]*sqlbase.TableDescriptor, len(schema.tables))
 		for tableName, entry := range schema.tables {
 			dbTables[tableName] = entry.desc

--- a/sql/pg_catalog.go
+++ b/sql/pg_catalog.go
@@ -1,0 +1,23 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nathan VanBenschoten (nvanbenschoten@gmail.com)
+
+package sql
+
+// pgCatalog contains a set of system tables mirroring PostgreSQL's pg_catalog schema.
+var pgCatalog = virtualSchema{
+	name:   "pg_catalog",
+	tables: []virtualSchemaTable{},
+}

--- a/sql/pg_catalog.go
+++ b/sql/pg_catalog.go
@@ -16,8 +16,97 @@
 
 package sql
 
+import (
+	"encoding/binary"
+	"hash"
+	"hash/fnv"
+
+	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/sql/sqlbase"
+)
+
 // pgCatalog contains a set of system tables mirroring PostgreSQL's pg_catalog schema.
 var pgCatalog = virtualSchema{
-	name:   "pg_catalog",
-	tables: []virtualSchemaTable{},
+	name: "pg_catalog",
+	tables: []virtualSchemaTable{
+		pgCatalogNamespaceTable,
+	},
+}
+
+var pgCatalogNamespaceTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE pg_catalog.pg_namespace (
+	oid INT,
+	nspname STRING NOT NULL DEFAULT '',
+	nspowner INT,
+	aclitem STRING
+);
+`,
+	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+		h := makeOidHasher()
+		return forEachDatabaseDesc(p, func(db *sqlbase.DatabaseDescriptor) error {
+			return addRow(
+				h.DBOid(db),                // oid
+				parser.NewDString(db.Name), // nspname
+				parser.DNull,               // nspowner
+				parser.DNull,               // aclitem
+			)
+		})
+	},
+}
+
+// oidHasher provides a consistent hashing mechanism for object identifiers in
+// pg_catalog tables, allowing for reliable joins across tables.
+type oidHasher struct {
+	h hash.Hash32
+}
+
+func makeOidHasher() oidHasher {
+	return oidHasher{h: fnv.New32()}
+}
+
+func (h oidHasher) writeStr(s string) {
+	if _, err := h.h.Write([]byte(s)); err != nil {
+		panic(err)
+	}
+}
+
+func (h oidHasher) writeUInt8(i uint8) {
+	if err := binary.Write(h.h, binary.BigEndian, i); err != nil {
+		panic(err)
+	}
+}
+
+func (h oidHasher) writeUInt32(i uint32) {
+	if err := binary.Write(h.h, binary.BigEndian, i); err != nil {
+		panic(err)
+	}
+}
+
+type oidTypeTag uint8
+
+const (
+	_ oidTypeTag = iota
+	databaseTypeTag
+)
+
+func (h oidHasher) writeTypeTag(tag oidTypeTag) {
+	h.writeUInt8(uint8(tag))
+}
+
+func (h oidHasher) getOid() *parser.DInt {
+	i := h.h.Sum32()
+	h.h.Reset()
+	return parser.NewDInt(parser.DInt(i))
+}
+
+func (h oidHasher) writeDB(db *sqlbase.DatabaseDescriptor) {
+	h.writeUInt32(uint32(db.ID))
+	h.writeStr(db.Name)
+}
+
+func (h oidHasher) DBOid(db *sqlbase.DatabaseDescriptor) *parser.DInt {
+	h.writeTypeTag(databaseTypeTag)
+	h.writeDB(db)
+	return h.getOid()
 }

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -404,7 +404,7 @@ func TestPGPreparedQuery(t *testing.T) {
 				Results("hashedPassword", "BYTES", true, gosql.NullBool{}),
 		},
 		"SHOW DATABASES": {
-			baseTest.Results("information_schema").Results("d").Results("system"),
+			baseTest.Results("information_schema").Results("pg_catalog").Results("d").Results("system"),
 		},
 		"SHOW GRANTS ON system.users": {
 			baseTest.Results("users", security.RootUser, "DELETE,GRANT,INSERT,SELECT,UPDATE"),

--- a/sql/planner.go
+++ b/sql/planner.go
@@ -324,9 +324,9 @@ func (p *planner) fillFKTableMap(m tableLookupsByID) error {
 	return nil
 }
 
-func (p *planner) virtualSchemas() virtualSchemaMap {
+func (p *planner) virtualSchemas() *virtualSchemaHolder {
 	if p.session.executor == nil {
 		return nil
 	}
-	return p.session.executor.virtualSchemas
+	return &p.session.executor.virtualSchemas
 }

--- a/sql/show.go
+++ b/sql/show.go
@@ -260,7 +260,7 @@ func (p *planner) ShowDatabases(n *parser.ShowDatabases) (planNode, error) {
 		return nil, err
 	}
 	v := p.newContainerValuesNode(ResultColumns{{Name: "Database", Typ: parser.TypeString}}, 0)
-	for db := range p.virtualSchemas() {
+	for _, db := range p.virtualSchemas().orderedNames {
 		if err := v.rows.AddRow(parser.DTuple{parser.NewDString(db)}); err != nil {
 			v.rows.Close()
 			return nil, err

--- a/sql/testdata/database
+++ b/sql/testdata/database
@@ -15,6 +15,7 @@ SHOW DATABASES
 ----
 Database
 information_schema
+pg_catalog
 a
 system
 test
@@ -35,6 +36,7 @@ query T
 SHOW DATABASES
 ----
 information_schema
+pg_catalog
 a
 b
 c
@@ -74,6 +76,7 @@ SHOW DATABASES
 ----
 Database
 information_schema
+pg_catalog
 a
 c
 system

--- a/sql/testdata/drop_database
+++ b/sql/testdata/drop_database
@@ -5,6 +5,7 @@ query T
 SHOW DATABASES
 ----
 information_schema
+pg_catalog
 foo-bar
 system
 test
@@ -16,6 +17,7 @@ query T
 SHOW DATABASES
 ----
 information_schema
+pg_catalog
 system
 test
 
@@ -26,6 +28,7 @@ query T
 SHOW DATABASES
 ----
 information_schema
+pg_catalog
 foo bar
 system
 test
@@ -37,5 +40,6 @@ query T
 SHOW DATABASES
 ----
 information_schema
+pg_catalog
 system
 test

--- a/sql/testdata/information_schema
+++ b/sql/testdata/information_schema
@@ -158,7 +158,7 @@ Table  User  Privileges
 query TTTTI colnames
 SELECT table_catalog, table_schema, table_name, column_name, ordinal_position
 FROM information_schema.columns
-WHERE table_schema != 'information_schema'
+WHERE table_schema != 'information_schema' AND table_schema != 'pg_catalog'
 ----
 table_catalog  table_schema        table_name  column_name               ordinal_position
 def            system              descriptor  id                        1
@@ -334,6 +334,7 @@ table_privileges
 tables
 abc
 xyz
+pg_namespace
 descriptor
 eventlog
 lease
@@ -356,6 +357,7 @@ table_constraints
 schemata
 schema_privileges
 rangelog
+pg_namespace
 namespace
 
 query TTTTI colnames
@@ -371,6 +373,7 @@ def            information_schema  table_privileges   SYSTEM VIEW  1
 def            information_schema  tables             SYSTEM VIEW  1
 def            other_db            abc                VIEW         1
 def            other_db            xyz                BASE TABLE   1
+def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            system              descriptor         BASE TABLE   1
 def            system              eventlog           BASE TABLE   1
 def            system              lease              BASE TABLE   1
@@ -402,6 +405,7 @@ def            information_schema  schemata           SYSTEM VIEW  1
 def            information_schema  table_constraints  SYSTEM VIEW  1
 def            information_schema  table_privileges   SYSTEM VIEW  1
 def            information_schema  tables             SYSTEM VIEW  1
+def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 
 user root
 
@@ -422,6 +426,7 @@ def            information_schema  table_constraints  SYSTEM VIEW  1
 def            information_schema  table_privileges   SYSTEM VIEW  1
 def            information_schema  tables             SYSTEM VIEW  1
 def            other_db            xyz                BASE TABLE   5
+def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 
 user root
 

--- a/sql/testdata/information_schema
+++ b/sql/testdata/information_schema
@@ -334,6 +334,7 @@ table_privileges
 tables
 abc
 xyz
+pg_attrdef
 pg_attribute
 pg_class
 pg_namespace
@@ -364,6 +365,7 @@ pg_tables
 pg_namespace
 pg_class
 pg_attribute
+pg_attrdef
 namespace
 
 query TTTTI colnames
@@ -379,6 +381,7 @@ def            information_schema  table_privileges   SYSTEM VIEW  1
 def            information_schema  tables             SYSTEM VIEW  1
 def            other_db            abc                VIEW         1
 def            other_db            xyz                BASE TABLE   1
+def            pg_catalog          pg_attrdef         SYSTEM VIEW  1
 def            pg_catalog          pg_attribute       SYSTEM VIEW  1
 def            pg_catalog          pg_class           SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
@@ -414,6 +417,7 @@ def            information_schema  schemata           SYSTEM VIEW  1
 def            information_schema  table_constraints  SYSTEM VIEW  1
 def            information_schema  table_privileges   SYSTEM VIEW  1
 def            information_schema  tables             SYSTEM VIEW  1
+def            pg_catalog          pg_attrdef         SYSTEM VIEW  1
 def            pg_catalog          pg_attribute       SYSTEM VIEW  1
 def            pg_catalog          pg_class           SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
@@ -438,6 +442,7 @@ def            information_schema  table_constraints  SYSTEM VIEW  1
 def            information_schema  table_privileges   SYSTEM VIEW  1
 def            information_schema  tables             SYSTEM VIEW  1
 def            other_db            xyz                BASE TABLE   5
+def            pg_catalog          pg_attrdef         SYSTEM VIEW  1
 def            pg_catalog          pg_attribute       SYSTEM VIEW  1
 def            pg_catalog          pg_class           SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1

--- a/sql/testdata/information_schema
+++ b/sql/testdata/information_schema
@@ -334,6 +334,7 @@ table_privileges
 tables
 abc
 xyz
+pg_class
 pg_namespace
 pg_tables
 descriptor
@@ -360,6 +361,7 @@ schema_privileges
 rangelog
 pg_tables
 pg_namespace
+pg_class
 namespace
 
 query TTTTI colnames
@@ -375,6 +377,7 @@ def            information_schema  table_privileges   SYSTEM VIEW  1
 def            information_schema  tables             SYSTEM VIEW  1
 def            other_db            abc                VIEW         1
 def            other_db            xyz                BASE TABLE   1
+def            pg_catalog          pg_class           SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1
 def            system              descriptor         BASE TABLE   1
@@ -408,6 +411,7 @@ def            information_schema  schemata           SYSTEM VIEW  1
 def            information_schema  table_constraints  SYSTEM VIEW  1
 def            information_schema  table_privileges   SYSTEM VIEW  1
 def            information_schema  tables             SYSTEM VIEW  1
+def            pg_catalog          pg_class           SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1
 
@@ -430,6 +434,7 @@ def            information_schema  table_constraints  SYSTEM VIEW  1
 def            information_schema  table_privileges   SYSTEM VIEW  1
 def            information_schema  tables             SYSTEM VIEW  1
 def            other_db            xyz                BASE TABLE   5
+def            pg_catalog          pg_class           SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1
 

--- a/sql/testdata/information_schema
+++ b/sql/testdata/information_schema
@@ -97,6 +97,7 @@ query T
 SHOW DATABASES
 ----
 information_schema
+pg_catalog
 system
 test
 
@@ -290,6 +291,7 @@ SELECT * FROM information_schema.schemata
 ----
 CATALOG_NAME  SCHEMA_NAME         DEFAULT_CHARACTER_SET_NAME  SQL_PATH
 def           information_schema  NULL                        NULL
+def           pg_catalog          NULL                        NULL
 def           system              NULL                        NULL
 def           test                NULL                        NULL
 
@@ -302,6 +304,7 @@ SELECT * FROM information_schema.schemata
 CATALOG_NAME  SCHEMA_NAME         DEFAULT_CHARACTER_SET_NAME  SQL_PATH
 def           information_schema  NULL                        NULL
 def           other_db            NULL                        NULL
+def           pg_catalog          NULL                        NULL
 def           system              NULL                        NULL
 def           test                NULL                        NULL
 

--- a/sql/testdata/information_schema
+++ b/sql/testdata/information_schema
@@ -334,6 +334,7 @@ table_privileges
 tables
 abc
 xyz
+pg_attribute
 pg_class
 pg_namespace
 pg_tables
@@ -362,6 +363,7 @@ rangelog
 pg_tables
 pg_namespace
 pg_class
+pg_attribute
 namespace
 
 query TTTTI colnames
@@ -377,6 +379,7 @@ def            information_schema  table_privileges   SYSTEM VIEW  1
 def            information_schema  tables             SYSTEM VIEW  1
 def            other_db            abc                VIEW         1
 def            other_db            xyz                BASE TABLE   1
+def            pg_catalog          pg_attribute       SYSTEM VIEW  1
 def            pg_catalog          pg_class           SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1
@@ -411,6 +414,7 @@ def            information_schema  schemata           SYSTEM VIEW  1
 def            information_schema  table_constraints  SYSTEM VIEW  1
 def            information_schema  table_privileges   SYSTEM VIEW  1
 def            information_schema  tables             SYSTEM VIEW  1
+def            pg_catalog          pg_attribute       SYSTEM VIEW  1
 def            pg_catalog          pg_class           SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1
@@ -434,6 +438,7 @@ def            information_schema  table_constraints  SYSTEM VIEW  1
 def            information_schema  table_privileges   SYSTEM VIEW  1
 def            information_schema  tables             SYSTEM VIEW  1
 def            other_db            xyz                BASE TABLE   5
+def            pg_catalog          pg_attribute       SYSTEM VIEW  1
 def            pg_catalog          pg_class           SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1

--- a/sql/testdata/information_schema
+++ b/sql/testdata/information_schema
@@ -335,6 +335,7 @@ tables
 abc
 xyz
 pg_namespace
+pg_tables
 descriptor
 eventlog
 lease
@@ -357,6 +358,7 @@ table_constraints
 schemata
 schema_privileges
 rangelog
+pg_tables
 pg_namespace
 namespace
 
@@ -374,6 +376,7 @@ def            information_schema  tables             SYSTEM VIEW  1
 def            other_db            abc                VIEW         1
 def            other_db            xyz                BASE TABLE   1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
+def            pg_catalog          pg_tables          SYSTEM VIEW  1
 def            system              descriptor         BASE TABLE   1
 def            system              eventlog           BASE TABLE   1
 def            system              lease              BASE TABLE   1
@@ -406,6 +409,7 @@ def            information_schema  table_constraints  SYSTEM VIEW  1
 def            information_schema  table_privileges   SYSTEM VIEW  1
 def            information_schema  tables             SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
+def            pg_catalog          pg_tables          SYSTEM VIEW  1
 
 user root
 
@@ -427,6 +431,7 @@ def            information_schema  table_privileges   SYSTEM VIEW  1
 def            information_schema  tables             SYSTEM VIEW  1
 def            other_db            xyz                BASE TABLE   5
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
+def            pg_catalog          pg_tables          SYSTEM VIEW  1
 
 user root
 

--- a/sql/testdata/pg_catalog
+++ b/sql/testdata/pg_catalog
@@ -39,6 +39,7 @@ SET DATABASE = test
 query T
 SHOW TABLES FROM pg_catalog
 ----
+pg_attrdef
 pg_attribute
 pg_class
 pg_namespace
@@ -307,3 +308,16 @@ v1            p        false         true        0            NULL    NULL      
 v1            a        false         true        0            NULL    NULL        NULL
 v1            b        false         true        0            NULL    NULL        NULL
 v1            c        false         true        0            NULL    NULL        NULL
+
+## pg_catalog.pg_attrdef
+
+query ITIITT colnames
+SELECT ad.oid, c.relname, adrelid, adnum, adbin, adsrc
+FROM pg_catalog.pg_attrdef ad
+JOIN pg_catalog.pg_class c ON ad.adrelid = c.oid
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE n.nspname = 'constraint_db'
+----
+oid         relname  adrelid     adnum  adbin  adsrc
+1889966686  t1       2265044713  4      12     12
+390509283   t3       2064007441  3      'FOO'  'FOO'

--- a/sql/testdata/pg_catalog
+++ b/sql/testdata/pg_catalog
@@ -1,0 +1,41 @@
+# Verify pg_catalog database handles mutation statements correctly.
+
+query error user root does not have DROP privilege on database pg_catalog
+ALTER DATABASE pg_catalog RENAME TO not_pg_catalog
+
+statement error user root does not have CREATE privilege on database pg_catalog
+CREATE TABLE pg_catalog.t (x INT)
+
+query error user root does not have DROP privilege on database pg_catalog
+DROP DATABASE pg_catalog
+
+
+# Verify other databases can't be called "pg_catalog".
+
+statement ok
+CREATE DATABASE other_db
+
+statement error the new database name "pg_catalog" already exists
+ALTER DATABASE other_db RENAME TO pg_catalog
+
+statement error database "pg_catalog" already exists
+CREATE DATABASE pg_catalog
+
+statement ok
+DROP DATABASE other_db
+
+
+# Verify pg_catalog can be used like a normal database.
+
+statement ok
+SET DATABASE = pg_catalog
+
+statement ok
+SET DATABASE = test
+
+
+# Verify pg_catalog handles reflection correctly.
+
+query T
+SHOW TABLES FROM pg_catalog
+----

--- a/sql/testdata/pg_catalog
+++ b/sql/testdata/pg_catalog
@@ -39,6 +39,7 @@ SET DATABASE = test
 query T
 SHOW TABLES FROM pg_catalog
 ----
+pg_class
 pg_namespace
 pg_tables
 
@@ -109,6 +110,9 @@ CREATE TABLE constraint_db.t3 (
     INDEX (a, b)
 )
 
+statement ok
+CREATE VIEW constraint_db.v1 AS SELECT * FROM constraint_db.t1;
+
 ## pg_catalog.pg_namespace
 
 query ITIT colnames
@@ -138,3 +142,81 @@ tablename          hasindexes
 table_constraints  false
 table_privileges   false
 tables             false
+
+## pg_catalog.pg_class
+
+query ITIIIIII colnames
+SELECT c.oid, relname, relnamespace, reltype, relowner, relam, relfilenode, reltablespace
+FROM pg_catalog.pg_class c 
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE n.nspname = 'constraint_db'
+----
+oid         relname       relnamespace  reltype  relowner  relam  relfilenode  reltablespace
+2265044713  t1            3061586988    0        NULL      NULL   0            0
+1759889455  primary       3061586988    0        NULL      NULL   0            0
+1759889452  t1_a_key      3061586988    0        NULL      NULL   0            0
+1759889453  index_key     3061586988    0        NULL      NULL   0            0
+2030599329  t2            3061586988    0        NULL      NULL   0            0
+559702615   primary       3061586988    0        NULL      NULL   0            0
+559702612   t2_t1_ID_idx  3061586988    0        NULL      NULL   0            0
+2064007441  t3            3061586988    0        NULL      NULL   0            0
+4171047647  primary       3061586988    0        NULL      NULL   0            0
+4171047644  t3_a_b_idx    3061586988    0        NULL      NULL   0            0
+2332993830  v1            3061586988    0        NULL      NULL   0            0
+
+query TIRIIBB colnames
+SELECT relname, relpages, reltuples, relallvisible, reltoastrelid, relhasindex, relisshared
+FROM pg_catalog.pg_class c 
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE n.nspname = 'constraint_db'
+----
+relname       relpages  reltuples  relallvisible  reltoastrelid  relhasindex  relisshared
+t1            NULL      NULL       0              0              true         false
+primary       NULL      NULL       0              0              false        false
+t1_a_key      NULL      NULL       0              0              false        false
+index_key     NULL      NULL       0              0              false        false
+t2            NULL      NULL       0              0              true         false
+primary       NULL      NULL       0              0              false        false
+t2_t1_ID_idx  NULL      NULL       0              0              false        false
+t3            NULL      NULL       0              0              true         false
+primary       NULL      NULL       0              0              false        false
+t3_a_b_idx    NULL      NULL       0              0              false        false
+v1            NULL      NULL       0              0              false        false
+
+query TBTIIBB colnames
+SELECT relname, relistemp, relkind, relnatts, relchecks, relhasoids, relhaspkey
+FROM pg_catalog.pg_class c 
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE n.nspname = 'constraint_db'
+----
+relname       relistemp  relkind  relnatts  relchecks  relhasoids  relhaspkey
+t1            false      r        4         0          false       true
+primary       false      i        1         0          false       false
+t1_a_key      false      i        1         0          false       false
+index_key     false      i        2         0          false       false
+t2            false      r        2         0          false       true
+primary       false      i        1         0          false       false
+t2_t1_ID_idx  false      i        1         0          false       false
+t3            false      r        4         1          false       true
+primary       false      i        1         0          false       false
+t3_a_b_idx    false      i        2         0          false       false
+v1            false      v        4         0          false       false
+
+query TBBBITT colnames
+SELECT relname, relhasrules, relhastriggers, relhassubclass, relfrozenxid, relacl, reloptions
+FROM pg_catalog.pg_class c 
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE n.nspname = 'constraint_db'
+----
+relname       relhasrules  relhastriggers  relhassubclass  relfrozenxid  relacl  reloptions
+t1            false        false           false           0             NULL    NULL
+primary       false        false           false           0             NULL    NULL
+t1_a_key      false        false           false           0             NULL    NULL
+index_key     false        false           false           0             NULL    NULL
+t2            false        false           false           0             NULL    NULL
+primary       false        false           false           0             NULL    NULL
+t2_t1_ID_idx  false        false           false           0             NULL    NULL
+t3            false        false           false           0             NULL    NULL
+primary       false        false           false           0             NULL    NULL
+t3_a_b_idx    false        false           false           0             NULL    NULL
+v1            false        false           false           0             NULL    NULL

--- a/sql/testdata/pg_catalog
+++ b/sql/testdata/pg_catalog
@@ -39,6 +39,7 @@ SET DATABASE = test
 query T
 SHOW TABLES FROM pg_catalog
 ----
+pg_attribute
 pg_class
 pg_namespace
 pg_tables
@@ -220,3 +221,89 @@ t3            false        false           false           0             NULL   
 primary       false        false           false           0             NULL    NULL
 t3_a_b_idx    false        false           false           0             NULL    NULL
 v1            false        false           false           0             NULL    NULL
+
+## pg_catalog.pg_attribute
+
+query ITTIIIIII colnames
+SELECT attrelid, c.relname, attname, atttypid, attstattarget, attlen, attnum, attndims, attcacheoff
+FROM pg_catalog.pg_attribute a
+JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE n.nspname = 'constraint_db'
+----
+attrelid    relname       attname  atttypid    attstattarget  attlen  attnum  attndims  attcacheoff
+2265044713  t1            p        290627148   0              8       1       0         -1
+2265044713  t1            a        739628165   0              8       2       0         -1
+2265044713  t1            b        739628165   0              8       3       0         -1
+2265044713  t1            c        739628165   0              8       4       0         -1
+1759889455  primary       p        290627148   0              8       1       0         -1
+1759889452  t1_a_key      a        739628165   0              8       1       0         -1
+1759889453  index_key     b        739628165   0              8       1       0         -1
+1759889453  index_key     c        739628165   0              8       2       0         -1
+2030599329  t2            t1_ID    739628165   0              8       1       0         -1
+559702612   t2_t1_ID_idx  t1_ID    739628165   0              8       1       0         -1
+2064007441  t3            a        739628165   0              8       1       0         -1
+2064007441  t3            b        739628165   0              8       2       0         -1
+2064007441  t3            c        4126817477  0              -1      3       0         -1
+4171047644  t3_a_b_idx    a        739628165   0              8       1       0         -1
+4171047644  t3_a_b_idx    b        739628165   0              8       2       0         -1
+2332993830  v1            p        290627148   0              8       1       0         -1
+2332993830  v1            a        739628165   0              8       2       0         -1
+2332993830  v1            b        739628165   0              8       3       0         -1
+2332993830  v1            c        739628165   0              8       4       0         -1
+
+query TTIBTTBB colnames
+SELECT c.relname, attname, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef
+FROM pg_catalog.pg_attribute a
+JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE n.nspname = 'constraint_db'
+----
+relname       attname  atttypmod  attbyval  attstorage  attalign  attnotnull  atthasdef
+t1            p        -1         NULL      NULL        NULL      true        false
+t1            a        -1         NULL      NULL        NULL      false       false
+t1            b        -1         NULL      NULL        NULL      false       false
+t1            c        -1         NULL      NULL        NULL      false       true
+primary       p        -1         NULL      NULL        NULL      true        false
+t1_a_key      a        -1         NULL      NULL        NULL      false       false
+index_key     b        -1         NULL      NULL        NULL      false       false
+index_key     c        -1         NULL      NULL        NULL      false       true
+t2            t1_ID    -1         NULL      NULL        NULL      false       false
+t2_t1_ID_idx  t1_ID    -1         NULL      NULL        NULL      false       false
+t3            a        -1         NULL      NULL        NULL      false       false
+t3            b        -1         NULL      NULL        NULL      false       false
+t3            c        -1         NULL      NULL        NULL      false       true
+t3_a_b_idx    a        -1         NULL      NULL        NULL      false       false
+t3_a_b_idx    b        -1         NULL      NULL        NULL      false       false
+v1            p        -1         NULL      NULL        NULL      true        false
+v1            a        -1         NULL      NULL        NULL      true        false
+v1            b        -1         NULL      NULL        NULL      true        false
+v1            c        -1         NULL      NULL        NULL      true        false
+
+query TTBBITTT colnames
+SELECT c.relname, attname, attisdropped, attislocal, attinhcount, attacl, attoptions, attfdwoptions
+FROM pg_catalog.pg_attribute a
+JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE n.nspname = 'constraint_db'
+----
+relname       attname  attisdropped  attislocal  attinhcount  attacl  attoptions  attfdwoptions
+t1            p        false         true        0            NULL    NULL        NULL
+t1            a        false         true        0            NULL    NULL        NULL
+t1            b        false         true        0            NULL    NULL        NULL
+t1            c        false         true        0            NULL    NULL        NULL
+primary       p        false         true        0            NULL    NULL        NULL
+t1_a_key      a        false         true        0            NULL    NULL        NULL
+index_key     b        false         true        0            NULL    NULL        NULL
+index_key     c        false         true        0            NULL    NULL        NULL
+t2            t1_ID    false         true        0            NULL    NULL        NULL
+t2_t1_ID_idx  t1_ID    false         true        0            NULL    NULL        NULL
+t3            a        false         true        0            NULL    NULL        NULL
+t3            b        false         true        0            NULL    NULL        NULL
+t3            c        false         true        0            NULL    NULL        NULL
+t3_a_b_idx    a        false         true        0            NULL    NULL        NULL
+t3_a_b_idx    b        false         true        0            NULL    NULL        NULL
+v1            p        false         true        0            NULL    NULL        NULL
+v1            a        false         true        0            NULL    NULL        NULL
+v1            b        false         true        0            NULL    NULL        NULL
+v1            c        false         true        0            NULL    NULL        NULL

--- a/sql/testdata/pg_catalog
+++ b/sql/testdata/pg_catalog
@@ -40,6 +40,7 @@ query T
 SHOW TABLES FROM pg_catalog
 ----
 pg_namespace
+pg_tables
 
 query TT colnames
 SHOW CREATE TABLE pg_catalog.pg_namespace
@@ -119,3 +120,21 @@ oid         nspname             nspowner  aclitem
 3178318485  pg_catalog          NULL      NULL
 1793492844  system              NULL      NULL
 2091240128  test                NULL      NULL
+
+## pg_catalog.pg_tables
+
+query TTTTBBBB colnames
+SELECT * FROM pg_catalog.pg_tables WHERE schemaname = 'constraint_db'
+----
+schemaname     tablename  tableowner  tablespace  hasindexes  hasrules  hastriggers  rowsecurity
+constraint_db  t1         NULL        NULL        true        false     false        false
+constraint_db  t2         NULL        NULL        true        false     false        false
+constraint_db  t3         NULL        NULL        true        false     false        false
+
+query TB colnames
+SELECT tablename, hasindexes FROM pg_catalog.pg_tables WHERE schemaname = 'information_schema' AND tablename LIKE '%table%'
+----
+tablename          hasindexes
+table_constraints  false
+table_privileges   false
+tables             false

--- a/sql/testdata/pg_catalog
+++ b/sql/testdata/pg_catalog
@@ -39,3 +39,83 @@ SET DATABASE = test
 query T
 SHOW TABLES FROM pg_catalog
 ----
+pg_namespace
+
+query TT colnames
+SHOW CREATE TABLE pg_catalog.pg_namespace
+----
+Table                  CreateTable
+pg_catalog.pg_namespace  CREATE TABLE "pg_catalog.pg_namespace" (
+                           oid INT NULL,
+                           nspname STRING NOT NULL DEFAULT '',
+                           nspowner INT NULL,
+                           aclitem STRING NULL
+                       )
+
+query TTBT colnames
+SHOW COLUMNS FROM pg_catalog.pg_namespace
+----
+Field     Type    Null  Default
+oid       INT     true   NULL
+nspname   STRING  false  ''
+nspowner  INT     true   NULL
+aclitem   STRING  true   NULL
+
+query TTTTTTT colnames
+SHOW INDEXES FROM pg_catalog.pg_namespace
+----
+Table  Name  Unique  Seq  Column  Direction  Storing
+
+query TTTTT colnames
+SHOW CONSTRAINTS FROM pg_catalog.pg_namespace
+----
+Table         Name     Type  Column(s)  Details
+pg_namespace  PRIMARY  KEY   NULL         NULL
+
+query TTT colnames
+SHOW GRANTS ON pg_catalog.pg_namespace
+----
+Table  User  Privileges
+
+
+# Verify selecting from pg_catalog.
+
+statement ok
+CREATE DATABASE constraint_db
+
+statement ok
+CREATE TABLE constraint_db.t1 (
+  p FLOAT PRIMARY KEY,
+  a INT UNIQUE,
+  b INT,
+  c INT DEFAULT 12,
+  UNIQUE INDEX index_key(b, c)
+)
+
+statement ok
+CREATE TABLE constraint_db.t2 (
+    t1_ID INT,
+    CONSTRAINT fk FOREIGN KEY (t1_ID) REFERENCES constraint_db.t1(a),
+    INDEX (t1_ID)
+)
+
+statement ok
+CREATE TABLE constraint_db.t3 (
+    a INT,
+    b INT CHECK (b > 11),
+    c STRING DEFAULT 'FOO',
+    CONSTRAINT fk FOREIGN KEY (a, b) REFERENCES constraint_db.t1(b, c),
+    INDEX (a, b)
+)
+
+## pg_catalog.pg_namespace
+
+query ITIT colnames
+SELECT * FROM pg_catalog.pg_namespace
+----
+oid         nspname             nspowner  aclitem
+3061586988  constraint_db       NULL      NULL
+3816276882  information_schema  NULL      NULL
+3178318485  pg_catalog          NULL      NULL
+1793492844  system              NULL      NULL
+2091240128  test                NULL      NULL

--- a/sql/testdata/rename_database
+++ b/sql/testdata/rename_database
@@ -2,6 +2,7 @@ query T
 SHOW DATABASES
 ----
 information_schema
+pg_catalog
 system
 test
 
@@ -41,6 +42,7 @@ query T
 SHOW DATABASES
 ----
 information_schema
+pg_catalog
 system
 u
 
@@ -88,6 +90,7 @@ query T
 SHOW DATABASES
 ----
 information_schema
+pg_catalog
 system
 t
 u

--- a/sql/testdata/system
+++ b/sql/testdata/system
@@ -2,6 +2,7 @@ query T
 SHOW DATABASES
 ----
 information_schema
+pg_catalog
 system
 test
 

--- a/sql/virtual_schema.go
+++ b/sql/virtual_schema.go
@@ -53,19 +53,23 @@ type virtualSchemaTable struct {
 // add that object to this slice.
 var virtualSchemas = []virtualSchema{
 	informationSchema,
+	pgCatalog,
 }
 
 //
 // SQL-layer interface to work with virtual schemas.
 //
 
-// virtualSchemaMap is a type used to provide convenient access to virtual
-// database and table descriptors. virtualSchemaMap, virtualSchemaEntry,
+// virtualSchemaHolder is a type used to provide convenient access to virtual
+// database and table descriptors. virtualSchemaHolder, virtualSchemaEntry,
 // and virtualTableEntry make up the generated data structure which the
 // virtualSchemas slice is mapped to. Because of this, they should not be
 // created directly, but instead will be populated in a post-startup hook
 // on an Executor.
-type virtualSchemaMap map[string]virtualSchemaEntry
+type virtualSchemaHolder struct {
+	entries      map[string]virtualSchemaEntry
+	orderedNames []string
+}
 
 type virtualSchemaEntry struct {
 	desc              *sqlbase.DatabaseDescriptor
@@ -115,9 +119,12 @@ func (e virtualTableEntry) getValuesNode(p *planner) (*valuesNode, error) {
 	return v, nil
 }
 
-func (vsm *virtualSchemaMap) init(p *planner) error {
-	*vsm = make(map[string]virtualSchemaEntry, len(virtualSchemas))
-	for _, schema := range virtualSchemas {
+func (vs *virtualSchemaHolder) init(p *planner) error {
+	*vs = virtualSchemaHolder{
+		entries:      make(map[string]virtualSchemaEntry, len(virtualSchemas)),
+		orderedNames: make([]string, len(virtualSchemas)),
+	}
+	for i, schema := range virtualSchemas {
 		dbName := schema.name
 		dbDesc := initVirtualDatabaseDesc(dbName)
 		tables := make(map[string]virtualTableEntry, len(schema.tables))
@@ -134,12 +141,14 @@ func (vsm *virtualSchemaMap) init(p *planner) error {
 			orderedTableNames = append(orderedTableNames, tableDesc.Name)
 		}
 		sort.Strings(orderedTableNames)
-		(*vsm)[dbName] = virtualSchemaEntry{
+		vs.entries[dbName] = virtualSchemaEntry{
 			desc:              dbDesc,
 			tables:            tables,
 			orderedTableNames: orderedTableNames,
 		}
+		vs.orderedNames[i] = dbName
 	}
+	sort.Strings(vs.orderedNames)
 	return nil
 }
 
@@ -168,23 +177,26 @@ func initVirtualTableDesc(p *planner, t virtualSchemaTable) (sqlbase.TableDescri
 }
 
 // getVirtualSchemaEntry retrieves a virtual schema entry given a database name.
-func (vsm virtualSchemaMap) getVirtualSchemaEntry(name string) (virtualSchemaEntry, bool) {
-	e, ok := vsm[name]
+func (vs *virtualSchemaHolder) getVirtualSchemaEntry(name string) (virtualSchemaEntry, bool) {
+	if vs == nil {
+		return virtualSchemaEntry{}, false
+	}
+	e, ok := vs.entries[name]
 	return e, ok
 }
 
 // getVirtualDatabaseDesc checks if the provided name matches a virtual database,
 // and if so, returns that database's descriptor.
-func (vsm virtualSchemaMap) getVirtualDatabaseDesc(name string) *sqlbase.DatabaseDescriptor {
-	if e, ok := vsm.getVirtualSchemaEntry(name); ok {
+func (vs *virtualSchemaHolder) getVirtualDatabaseDesc(name string) *sqlbase.DatabaseDescriptor {
+	if e, ok := vs.getVirtualSchemaEntry(name); ok {
 		return e.desc
 	}
 	return nil
 }
 
 // isVirtualDatabase checks if the provided name corresponds to a virtual database.
-func (vsm virtualSchemaMap) isVirtualDatabase(name string) bool {
-	_, ok := vsm.getVirtualSchemaEntry(name)
+func (vs *virtualSchemaHolder) isVirtualDatabase(name string) bool {
+	_, ok := vs.getVirtualSchemaEntry(name)
 	return ok
 }
 
@@ -198,8 +210,8 @@ func (e *Executor) IsVirtualDatabase(name string) bool {
 // pair. The function will return the table's virtual table entry if the name matches
 // a specific table. It will return an error if the name references a virtual database
 // but the table is non-existent.
-func (vsm virtualSchemaMap) getVirtualTableEntry(tn *parser.TableName) (virtualTableEntry, error) {
-	if db, ok := vsm.getVirtualSchemaEntry(tn.Database()); ok {
+func (vs *virtualSchemaHolder) getVirtualTableEntry(tn *parser.TableName) (virtualTableEntry, error) {
+	if db, ok := vs.getVirtualSchemaEntry(tn.Database()); ok {
 		if t, ok := db.tables[sqlbase.NormalizeName(tn.TableName)]; ok {
 			return t, nil
 		}
@@ -210,8 +222,8 @@ func (vsm virtualSchemaMap) getVirtualTableEntry(tn *parser.TableName) (virtualT
 
 // getVirtualTableDesc checks if the provided name matches a virtual database/table
 // pair, and returns its descriptor if it does.
-func (vsm virtualSchemaMap) getVirtualTableDesc(tn *parser.TableName) (*sqlbase.TableDescriptor, error) {
-	t, err := vsm.getVirtualTableEntry(tn)
+func (vs *virtualSchemaHolder) getVirtualTableDesc(tn *parser.TableName) (*sqlbase.TableDescriptor, error) {
+	t, err := vs.getVirtualTableEntry(tn)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
See #5194.

This change adds initial support for the `pg_catalog` database, along with the following five tables:
- `pg_namespace`
- `pg_tables`
- `pg_class`
- `pg_attribute`
- `pg_attrdef`

`pg_catalog` is highly normalized, meaning that to query for any substantial information, multiple joins are often necessary. This is facilitated (per the `pg_catalog` spec) through the inclusion of an `oid` (object identifier) column on most tables. To support consistent object identifiers across joins and across queries, this change introduces an `oidHasher` type, which is used throughout the `pg_catalog` population code to deterministically hash objects to `oid` columns.

After this change, there are eight remaining tables (some of which can be left unpopulated) that are needed to support popular ORMs like Hibernate and ActiveRecord. Many ORMs will also need `pg_catalog` to be added to a "schema search path", as discussed in the [information schema RFC](https://github.com/cockroachdb/cockroach/blob/develop/docs/RFCS/information_schema.md#schema-search-path-extension-only-needed-for-pg_catalog-support).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9565)

<!-- Reviewable:end -->
