### PR TITLE
storage: better tracing for refurbished and reproposed Raft commands

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -2280,6 +2280,7 @@ func (r *Replica) refreshPendingCmdsLocked(reason refreshRaftReason, refreshAtDe
 		}
 		delete(r.mu.pendingCmds, idKey)
 		// The command can be refurbished.
+		log.Eventf(p.ctx, "refurbishing command %x; %s", p.idKey, reason)
 		if pErr := r.refurbishPendingCmdLocked(p); pErr != nil {
 			p.done <- roachpb.ResponseWithError{Err: pErr}
 		}
@@ -2299,6 +2300,7 @@ func (r *Replica) refreshPendingCmdsLocked(reason refreshRaftReason, refreshAtDe
 	// the right place. Reproposing in order is definitely required, however.
 	sort.Sort(reproposals)
 	for _, p := range reproposals {
+		log.Eventf(p.ctx, "reproposing command %x; %s", p.idKey, reason)
 		if err := r.proposePendingCmdLocked(p); err != nil {
 			return err
 		}
@@ -2530,10 +2532,10 @@ func (r *Replica) processRaftCommand(
 		// properties like key range are undefined).
 		forcedErr = roachpb.NewErrorf("no-op on empty Raft entry")
 	} else if isLeaseError() {
-		if log.V(1) {
-			log.Warningf(r.ctx, "command proposed from replica %+v (lease at %v): %s",
-				raftCmd.OriginReplica, r.mu.state.Lease.Replica, raftCmd.Cmd)
-		}
+		log.VEventf(
+			1, ctx, "command proposed from replica %+v (lease at %v): %s",
+			raftCmd.OriginReplica, r.mu.state.Lease.Replica, raftCmd.Cmd,
+		)
 		forcedErr = roachpb.NewError(newNotLeaseHolderError(
 			r.mu.state.Lease, raftCmd.OriginReplica.StoreID, r.mu.state.Desc))
 	} else if raftCmd.Cmd.IsLeaseRequest() {
@@ -2558,8 +2560,9 @@ func (r *Replica) processRaftCommand(
 		// The command is trying to apply at a past log position. That's
 		// unfortunate and hopefully rare; we will refurbish on the proposer.
 		// Note that in this situation, the leaseIndex does not advance.
-		forcedErr = roachpb.NewErrorf("command observed at lease index %d, "+
-			"but required < %d", leaseIndex, raftCmd.MaxLeaseIndex)
+		forcedErr = roachpb.NewErrorf(
+			"command observed at lease index %d, but required < %d", leaseIndex, raftCmd.MaxLeaseIndex,
+		)
 
 		if cmd != nil {
 			// Only refurbish when no earlier incarnation of this command has
@@ -2570,10 +2573,10 @@ func (r *Replica) processRaftCommand(
 			// Note that we keep the context to avoid hiding these internal
 			// cycles from traces.
 			if localMaxLeaseIndex := cmd.raftCmd.MaxLeaseIndex; localMaxLeaseIndex <= raftCmd.MaxLeaseIndex {
-				if log.V(1) {
-					log.Infof(r.ctx, "refurbishing command for <= %d observed at %d",
-						raftCmd.MaxLeaseIndex, leaseIndex)
-				}
+				log.VEventf(
+					1, ctx, "refurbishing command %x; <= %d observed at %d", cmd.idKey,
+					raftCmd.MaxLeaseIndex, leaseIndex,
+				)
 
 				if pErr := r.refurbishPendingCmdLocked(cmd); pErr == nil {
 					cmd.done = make(chan roachpb.ResponseWithError, 1)
@@ -2581,7 +2584,7 @@ func (r *Replica) processRaftCommand(
 					// We could try to send the error to the client instead,
 					// but to avoid even the appearance of Replica divergence,
 					// let's not.
-					log.Warningf(r.ctx, "unable to refurbish: %s", pErr)
+					log.Warningf(ctx, "unable to refurbish: %s", pErr)
 				}
 			} else {
 				// The refurbishment is already in flight, so we better get cmd back
@@ -2604,14 +2607,14 @@ func (r *Replica) processRaftCommand(
 		}()
 	}
 
-	log.Event(ctx, "applying batch")
 	// applyRaftCommand will return "expected" errors, but may also indicate
 	// replica corruption (as of now, signaled by a replicaCorruptionError).
 	// We feed its return through maybeSetCorrupt to act when that happens.
-	if log.V(1) && forcedErr != nil {
-		log.Infof(r.ctx, "applying command with forced error: %v", forcedErr)
+	if forcedErr != nil {
+		log.VEventf(1, ctx, "applying command with forced error: %s", forcedErr)
+	} else {
+		log.Event(ctx, "applying command")
 	}
-
 	br, propResult, pErr := r.applyRaftCommand(idKey, ctx, index, leaseIndex,
 		raftCmd.OriginReplica, raftCmd.Cmd, forcedErr)
 	pErr = r.maybeSetCorrupt(ctx, pErr)
@@ -2643,8 +2646,8 @@ func (r *Replica) processRaftCommand(
 	if cmd != nil {
 		cmd.done <- roachpb.ResponseWithError{Reply: br, Err: pErr}
 		close(cmd.done)
-	} else if pErr != nil && log.V(1) {
-		log.Errorf(r.ctx, "error executing raft command: %s", pErr)
+	} else if pErr != nil {
+		log.VEventf(1, ctx, "error executing raft command: %s", pErr)
 	}
 
 	return pErr


### PR DESCRIPTION
Improved tracing in `refurbishPendingCmdLocked`, `proposeRaftCommand`, and at
the call sites of `refreshPendingCmdsLocked`.

Fixes #9537.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9568)

<!-- Reviewable:end -->
