### PR TITLE
storage: fix crash in TestLeaseConcurrent

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1627,8 +1627,7 @@ func makeIDKey() storagebase.CmdIDKey {
 //   which case the other returned values are zero.
 func (r *Replica) proposeRaftCommand(
 	ctx context.Context, ba roachpb.BatchRequest,
-) (
-	chan roachpb.ResponseWithError, func() bool, error) {
+) (chan roachpb.ResponseWithError, func() bool, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.mu.destroyed != nil {

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -1620,14 +1620,18 @@ func TestLeaseConcurrent(t *testing.T) {
 				}
 				go func() {
 					wg.Wait()
+					tc.rng.mu.Lock()
+					defer tc.rng.mu.Unlock()
 					if withError {
+						// When we complete the command, we have to remove it from the map;
+						// otherwise its context (and tracing span) may be used after the
+						// client cleaned up.
+						delete(tc.rng.mu.pendingCmds, cmd.idKey)
 						cmd.done <- roachpb.ResponseWithError{
 							Err: roachpb.NewErrorf(origMsg),
 						}
 						return
 					}
-					tc.rng.mu.Lock()
-					defer tc.rng.mu.Unlock()
 					if err := defaultProposeRaftCommandLocked(tc.rng, cmd); err != nil {
 						panic(err) // unlikely, so punt on proper handling
 					}


### PR DESCRIPTION
Fixes #9575.

@tschottdorf @petermattis I am not very familar with this code, I hope I'm not missing something.
I verified the raft spans show up in a local cluster, but I don't know how to trigger any of the special conditions in the code..

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9578)

<!-- Reviewable:end -->
