### PR TITLE
sql: change current_date() to return the date in UTC

### DIFF
--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -586,7 +586,7 @@ var Builtins = map[string][]Builtin{
 			ReturnType: TypeDate,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				t := ctx.GetTxnTimestamp(time.Microsecond).Time
-				return NewDDateFromTime(t, ctx.GetLocation()), nil
+				return NewDDateFromTime(t, time.UTC), nil
 			},
 		},
 	},

--- a/sql/testdata/datetime
+++ b/sql/testdata/datetime
@@ -127,7 +127,7 @@ SELECT now() - timestamp '2015-06-13' > interval '100h'
 true
 
 query B
-SELECT now()::timestamptz - current_date()::timestamptz < interval '24h10s'
+SELECT now() - current_date()::timestamp < interval '24h10s'
 ----
 true
 


### PR DESCRIPTION
This is to bring it in line with current_timestamp() and now()
that return the timestamp in UTC.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9586)

<!-- Reviewable:end -->
