### PR TITLE
sql: improve error handling for SET TIME ZONE

### DIFF
--- a/sql/set.go
+++ b/sql/set.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 // Set sets session variables.
@@ -142,10 +143,7 @@ func (p *planner) SetTimeZone(n *parser.SetTimeZone) (planNode, error) {
 	switch v := d.(type) {
 	case *parser.DString:
 		location := string(*v)
-		if location == "DEFAULT" || location == "LOCAL" {
-			location = "UTC"
-		}
-		loc, err := time.LoadLocation(location)
+		loc, err := timeutil.LoadLocation(location)
 		if err != nil {
 			return nil, fmt.Errorf("cannot find time zone %q: %v", location, err)
 		}

--- a/sql/testdata/datetime
+++ b/sql/testdata/datetime
@@ -483,8 +483,41 @@ SELECT '2015-08-24 23:45:45.53453-05:00'::timestamptz
 ----
 2015-08-24 23:45:45.53453 -0500 -0500
 
-statement error cannot find time zone "foobar":.*
+statement error cannot find time zone "foobar": timezone data cannot be found
 SET TIME ZONE 'foobar'
+
+statement ok
+SET TIME ZONE default
+
+query T
+SELECT '2015-08-24 21:45:45.53453'::timestamptz
+----
+2015-08-24 21:45:45.53453 +0000 +0000
+
+statement ok
+SET TIME ZONE local
+
+query T
+SELECT '2015-08-24 21:45:45.53453'::timestamptz
+----
+2015-08-24 21:45:45.53453 +0000 +0000
+
+statement ok
+SET TIME ZONE 'DEFAULT'
+
+query T
+SELECT '2015-08-24 21:45:45.53453'::timestamptz
+----
+2015-08-24 21:45:45.53453 +0000 +0000
+
+statement ok
+SET TIME ZONE ''
+
+query T
+SELECT '2015-08-24 21:45:45.53453'::timestamptz
+----
+2015-08-24 21:45:45.53453 +0000 +0000
+
 
 statement ok
 SET TIME ZONE INTERVAL '-7h'

--- a/util/timeutil/zoneinfo.go
+++ b/util/timeutil/zoneinfo.go
@@ -1,0 +1,47 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package timeutil
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+var errTZDataNotFound = errors.New("timezone data cannot be found")
+
+// LoadLocation returns the time.Location with the given name.
+// The name is taken to be a location name corresponding to a file
+// in the IANA Time Zone database, such as "America/New_York".
+//
+// We do not use Go's time.LoadLocation() directly because:
+// 1) it maps "Local" to the local time zone, whereas we want UTC.
+// 2) when a tz is not found, it reports some garbage message
+// related to zoneinfo.zip, which we don't ship, instead
+// of a more useful message like "the tz file with such name
+// is not present in one of the standard tz locations".
+func LoadLocation(name string) (*time.Location, error) {
+	switch strings.ToLower(name) {
+	case "local", "default":
+		name = "UTC"
+	}
+	l, err := time.LoadLocation(name)
+	if err != nil && strings.Contains(err.Error(), "zoneinfo.zip") {
+		err = errTZDataNotFound
+	}
+	return l, err
+}


### PR DESCRIPTION
Prior to this patch a failure to find the data for a time zone would
report some lookup error relative to a file called
`zoneinfo.zip`. This is misleading because 1) the lookup code in the
Go library actually first tries to find TZ data in the system-wide
standard locations (/usr/share/zoneinfo etc) and 2) we don't ship this
zip file anyway.

Also the normalization for the special names "default" and "local" was
done case-insensitively.

This patch addresses these two issues.

Fixes #9560.

cc @jseldess.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9597)

<!-- Reviewable:end -->
