### PR TITLE
tracing: use the updated opentracing infrastructure

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -74,7 +74,7 @@ github.com/kkaneda/returncheck bf081fa7155e3a27df1f056a49d50685edfa5b1b
 github.com/kr/pretty 737b74a46c4bf788349f72cb256fed10aea4d0ac
 github.com/kr/text 7cafcd837844e784b526369c9bce262804aebc60
 github.com/lib/pq 80f8150043c80fb52dee6bc863a709cdac7ec8f8
-github.com/lightstep/lightstep-tracer-go f3c66066ce6023ad1bd721cfbd9fbd6292eb08cc
+github.com/lightstep/lightstep-tracer-go 8d59645adbb3c85f28ae340a055a9349cdd99fe7
 github.com/mattn/go-isatty 66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8
 github.com/mattn/go-runewidth d6bea18f789704b5f83375793155289da36a3c7f
 github.com/mattn/goveralls f4d273b02ce1b4e48acf3662b717aa987bfc4118
@@ -85,8 +85,8 @@ github.com/montanaflynn/stats 60dcacf48f43d6dd654d0ed94120ff5806c5ca5c
 github.com/olekukonko/tablewriter daf2955e742cf123959884fdff4685aa79b63135
 github.com/opencontainers/runc ae7a92e352116f38bce3f7cb3aa2bc590a7e3f65
 github.com/opennota/check 5b00aacd5639507d2b039245a278ec9f5505509f
-github.com/opentracing/basictracer-go c7c0202a8a77f658aeb2193a27b6c0cfcc821038
-github.com/opentracing/opentracing-go 855519783f479520497c6b3445611b05fc42f009
+github.com/opentracing/basictracer-go 6dea169035b81f39f8f157256225ba02ca7104ab
+github.com/opentracing/opentracing-go 30dda9350627161ff15581c0bdc504e32ec9a536
 github.com/pborman/uuid c55201b036063326c5b1b89ccfe45a184973d073
 github.com/peterbourgon/g2s 5767a0b2078638d14800683fd0fe425604883f63
 github.com/petermattis/goid ba001f8780f3bf978180f390ad7b5bac39fbf70a

--- a/sql/trace.go
+++ b/sql/trace.go
@@ -112,7 +112,7 @@ func (n *explainTraceNode) Next() (bool, error) {
 		if len(n.txn.CollectedSpans) == 0 {
 			if !n.exhausted {
 				n.txn.CollectedSpans = append(n.txn.CollectedSpans, basictracer.RawSpan{
-					Logs: []opentracing.LogData{{Timestamp: n.lastTS}},
+					Logs: []opentracing.LogRecord{{Timestamp: n.lastTS}},
 				})
 			}
 			basePos = n.lastPos + 1
@@ -135,12 +135,26 @@ func (n *explainTraceNode) Next() (bool, error) {
 				if i > 0 {
 					duration = fmt.Sprintf("%.3fms", entry.Timestamp.Sub(n.lastTS).Seconds()*1000)
 				}
+				// Extract the message of the event, which is either in an "event" or
+				// "error" field.
+				var msg string
+				for _, f := range entry.Fields {
+					key := f.Key()
+					if key == "event" {
+						msg = fmt.Sprint(f.Value())
+						break
+					}
+					if key == "error" {
+						msg = fmt.Sprint("error:", f.Value())
+						break
+					}
+				}
 				cols := append(parser.DTuple{
 					parser.NewDString(commulativeDuration),
 					parser.NewDString(duration),
 					parser.NewDInt(parser.DInt(basePos + i)),
 					parser.NewDString(sp.Operation),
-					parser.NewDString(entry.Event),
+					parser.NewDString(msg),
 				}, vals.AsRow()...)
 
 				// Timestamp is added for sorting, but will be removed after sort.

--- a/util/log/trace.go
+++ b/util/log/trace.go
@@ -120,6 +120,7 @@ func eventInternal(ctx context.Context, isErr, withTags bool, format string, arg
 		}
 
 		if sp != nil {
+			// TODO(radu): use sp.LogFields with "event" or "error" key.
 			sp.LogEvent(msg)
 			if isErr {
 				// TODO(radu): figure out a way to signal that this is an error. We

--- a/util/tracing/tee_tracer.go
+++ b/util/tracing/tee_tracer.go
@@ -21,6 +21,7 @@ import (
 
 	basictracer "github.com/opentracing/basictracer-go"
 	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
 )
 
 // TeeTracer is an opentracing.Tracer that sends events to multiple Tracers.
@@ -174,6 +175,20 @@ func (ts *TeeSpan) SetTag(key string, value interface{}) opentracing.Span {
 		sp.SetTag(key, value)
 	}
 	return ts
+}
+
+// LogFields is part of the opentracing.Span interface.
+func (ts *TeeSpan) LogFields(fields ...log.Field) {
+	for _, sp := range ts.spans {
+		sp.LogFields(fields...)
+	}
+}
+
+// LogKV is part of the opentracing.Span interface.
+func (ts *TeeSpan) LogKV(alternatingKeyValues ...interface{}) {
+	for _, sp := range ts.spans {
+		sp.LogKV(alternatingKeyValues...)
+	}
 }
 
 // LogEvent is part of the opentracing.Span interface.

--- a/util/tracing/tee_tracer_test.go
+++ b/util/tracing/tee_tracer_test.go
@@ -41,7 +41,7 @@ func TestTeeTracer(t *testing.T) {
 	tr := NewTeeTracer(t1, t2)
 
 	span := tr.StartSpan("x")
-	span.LogEventWithPayload("event", "payload")
+	span.LogKV("k1", "v1", "k2", "v2")
 	span.SetTag("tag", "value")
 	span.SetBaggageItem("baggage", "baggage-value")
 	assert.Equal(t, "baggage-value", span.BaggageItem("baggage"))
@@ -67,13 +67,13 @@ func TestTeeTracer(t *testing.T) {
 
 		assert.Equal(t, "x", spans[0].Operation)
 		assert.Equal(t, opentracing.Tags{"tag": "value"}, spans[0].Tags)
-		assert.Equal(t, "event", spans[0].Logs[0].Event)
-		assert.Equal(t, "payload", spans[0].Logs[0].Payload)
+		assert.Equal(t, "k1:v1", spans[0].Logs[0].Fields[0].String())
+		assert.Equal(t, "k2:v2", spans[0].Logs[0].Fields[1].String())
 		assert.Equal(t, 1, len(spans[0].Context.Baggage))
 
 		assert.Equal(t, "y", spans[1].Operation)
 		assert.Equal(t, opentracing.Tags(nil), spans[1].Tags)
-		assert.Equal(t, "event2", spans[1].Logs[0].Event)
+		assert.Equal(t, "event:event2", spans[1].Logs[0].Fields[0].String())
 		assert.Equal(t, 1, len(spans[1].Context.Baggage))
 	}
 }

--- a/util/tracing/tracer_test.go
+++ b/util/tracing/tracer_test.go
@@ -1,0 +1,75 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package tracing
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/util/timeutil"
+	basictracer "github.com/opentracing/basictracer-go"
+	opentracing "github.com/opentracing/opentracing-go"
+	otlog "github.com/opentracing/opentracing-go/log"
+)
+
+func TestEncodeDecodeRawSpan(t *testing.T) {
+	s := basictracer.RawSpan{
+		Context: basictracer.SpanContext{
+			TraceID: 1,
+			SpanID:  2,
+			Sampled: true,
+			Baggage: make(map[string]string),
+		},
+		ParentSpanID: 13,
+		Operation:    "testop",
+		Start:        timeutil.Now(),
+		Duration:     15 * time.Millisecond,
+		Tags:         make(map[string]interface{}),
+		Logs: []opentracing.LogRecord{
+			{
+				Timestamp: timeutil.Now().Add(2 * time.Millisecond),
+			},
+			{
+				Timestamp: timeutil.Now().Add(5 * time.Millisecond),
+				Fields: []otlog.Field{
+					otlog.Int("f1", 3),
+					otlog.String("f2", "f2Val"),
+				},
+			},
+		},
+	}
+	s.Context.Baggage["bag"] = "bagVal"
+	s.Tags["tag"] = 5
+
+	enc, err := EncodeRawSpan(&s, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var d basictracer.RawSpan
+	if err = DecodeRawSpan(enc, &d); err != nil {
+		t.Fatal(err)
+	}
+	// We cannot use DeepEqual because we encode all log fields as strings. So
+	// e.g. the "f1" field above is now a string, not an int. The string
+	// representations must match though.
+	sStr := fmt.Sprint(s)
+	dStr := fmt.Sprint(d)
+	if sStr != dStr {
+		t.Errorf("initial span: '%s', after encode/decode: '%s'", sStr, dStr)
+	}
+}


### PR DESCRIPTION
Recently opentracing added a new `LogFields`/`LogKV` interface. The updated
basictracer implementation breaks our code, most importantly the `RawSpan`
serialization and deserialization (for snowball tracing). This change makes the
necessary updates.

We also switch to using the new API. For now we use it in a trivial way because
Lightstep was not yet updated to show all the KVs. Once it is we can use it in
a more advanced way, like using the special "error" key for errors and setting
context log tags as KVs.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9599)

<!-- Reviewable:end -->
