### PR TITLE
sql: basic ARRAY support + CURRENT_SCHEMAS()

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1323,6 +1323,7 @@ func checkResultType(typ parser.Type) error {
 	case parser.TypeTimestamp:
 	case parser.TypeTimestampTZ:
 	case parser.TypeInterval:
+	case parser.TypeArray:
 	case parser.TypePlaceholder:
 		return errors.Errorf("could not determine data type of %s", typ)
 	default:

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -900,6 +900,32 @@ var Builtins = map[string][]Builtin{
 		}),
 	},
 
+	// For now, schemas are the same as databases. So, current_schemas returns the
+	// current database (if one has been set by the user) and, if the passed in
+	// parameter is true, the session's database search path.
+	"current_schemas": {
+		Builtin{
+			Types:      ArgTypes{TypeBool},
+			ReturnType: TypeArray,
+			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
+				if args[0] == DNull {
+					return DNull, nil
+				}
+				var schemas DArray
+				showImplicitSchemas := args[0].(*DBool)
+				if showImplicitSchemas == DBoolTrue {
+					for _, p := range ctx.SearchPath {
+						schemas = append(schemas, NewDString(p))
+					}
+				}
+				if len(ctx.Database) != 0 {
+					schemas = append(schemas, NewDString(ctx.Database))
+				}
+				return &schemas, nil
+			},
+		},
+	},
+
 	"degrees": {
 		floatBuiltin1(func(x float64) (Datum, error) {
 			return NewDFloat(DFloat(180.0 * x / math.Pi)), nil

--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -1340,6 +1340,143 @@ func (d dNull) Size() uintptr {
 	return unsafe.Sizeof(d)
 }
 
+// DArray is the array Datum. Currently, all arrays are text arrays. Any Datum
+// inserted into a DArray are treated as text during serialization. This is
+// probably sufficient to provide basic ORM (ActiveRecord) support, but we'll
+// need to support different array types (e.g. int[]) when we implement
+// persistent storage and other features of arrays.
+type DArray []Datum
+
+// ResolvedType implements the TypedExpr interface.
+func (d *DArray) ResolvedType() Type {
+	return TypeArray
+}
+
+// Compare implements the Datum interface.
+func (d *DArray) Compare(other Datum) int {
+	if other == DNull {
+		// NULL is less than any non-NULL value.
+		return 1
+	}
+	v, ok := other.(*DArray)
+	if !ok {
+		panic(makeUnsupportedComparisonMessage(d, other))
+	}
+	n := len(*d)
+	if n > len(*v) {
+		n = len(*v)
+	}
+	for i := 0; i < n; i++ {
+		c := (*d)[i].Compare((*v)[i])
+		if c != 0 {
+			return c
+		}
+	}
+	if len(*d) < len(*v) {
+		return -1
+	}
+	if len(*d) > len(*v) {
+		return 1
+	}
+	return 0
+}
+
+// HasPrev implements the Datum interface.
+func (d *DArray) HasPrev() bool {
+	for i := len(*d) - 1; i >= 0; i-- {
+		if (*d)[i].HasPrev() {
+			return true
+		}
+	}
+	return false
+}
+
+// Prev implements the Datum interface.
+func (d *DArray) Prev() Datum {
+	n := make(DArray, len(*d))
+	copy(n, *d)
+	for i := len(n) - 1; i >= 0; i-- {
+		if n[i].HasPrev() {
+			n[i] = n[i].Prev()
+			return &n
+		}
+	}
+	panic(fmt.Errorf("Prev() cannot be computed on a tuple whose datum does not support it"))
+}
+
+// HasNext implements the Datum interface.
+func (d *DArray) HasNext() bool {
+	for i := len(*d) - 1; i >= 0; i-- {
+		if (*d)[i].HasNext() {
+			return true
+		}
+	}
+	return false
+}
+
+// Next implements the Datum interface.
+func (d *DArray) Next() Datum {
+	n := make(DArray, len(*d))
+	copy(n, *d)
+	for i := len(n) - 1; i >= 0; i-- {
+		if n[i].HasNext() {
+			n[i] = n[i].Next()
+			return &n
+		}
+	}
+	panic(fmt.Errorf("Next() cannot be computed on a tuple whose datum does not support it"))
+}
+
+// IsMax implements the Datum interface.
+func (*DArray) IsMax() bool {
+	// Unimplemented for DArray. Seems possible to provide an implementation
+	// which called IsMax for each of the elements, but currently this isn't
+	// needed.
+	return false
+}
+
+// IsMin implements the Datum interface.
+func (*DArray) IsMin() bool {
+	// Unimplemented for DArray. Seems possible to provide an implementation
+	// which called IsMin for each of the elements, but currently this isn't
+	// needed.
+	return false
+}
+
+// Format implements the NodeFormatter interface.
+func (d *DArray) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteByte('{')
+	for i, v := range *d {
+		if i > 0 {
+			buf.WriteString(",")
+		}
+		FormatNode(buf, f, v)
+	}
+	buf.WriteByte('}')
+}
+
+func (d *DArray) Len() int {
+	return len(*d)
+}
+
+func (d *DArray) Less(i, j int) bool {
+	return (*d)[i].Compare((*d)[j]) < 0
+}
+
+func (d *DArray) Swap(i, j int) {
+	(*d)[i], (*d)[j] = (*d)[j], (*d)[i]
+}
+
+// Size implements the Datum interface.
+func (d *DArray) Size() uintptr {
+	sz := unsafe.Sizeof(*d)
+	for _, e := range *d {
+		dsz := e.Size()
+		sz += dsz
+	}
+	return sz
+}
+
 // Temporary workaround for #3633, allowing comparisons between
 // heterogeneous types.
 // TODO(nvanbenschoten) Now that typing is improved, can we get rid of this?

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -2278,6 +2278,11 @@ func (t *DTuple) Eval(_ *EvalContext) (Datum, error) {
 }
 
 // Eval implements the TypedExpr interface.
+func (t *DArray) Eval(_ *EvalContext) (Datum, error) {
+	return t, nil
+}
+
+// Eval implements the TypedExpr interface.
 func (node *Placeholder) Eval(_ *EvalContext) (Datum, error) {
 	return nil, fmt.Errorf("no value provided for placeholder: $%s", node.Name)
 }

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -1458,6 +1458,11 @@ type EvalContext struct {
 	clusterTimestamp hlc.Timestamp
 	// Location references the *Location on the current Session.
 	Location **time.Location
+	// Database is the database in the current Session.
+	Database string
+	// SearchPath is the search path for databases used when encountering an
+	// unqualified table name.
+	SearchPath []string
 
 	ReCache *RegexpCache
 	tmpDec  inf.Dec

--- a/pkg/sql/parser/expr.go
+++ b/pkg/sql/parser/expr.go
@@ -1063,6 +1063,7 @@ func (node *DString) String() string          { return AsString(node) }
 func (node *DTimestamp) String() string       { return AsString(node) }
 func (node *DTimestampTZ) String() string     { return AsString(node) }
 func (node *DTuple) String() string           { return AsString(node) }
+func (node *DArray) String() string           { return AsString(node) }
 func (node *ExistsExpr) String() string       { return AsString(node) }
 func (node Exprs) String() string             { return AsString(node) }
 func (node *FuncExpr) String() string         { return AsString(node) }

--- a/pkg/sql/parser/type.go
+++ b/pkg/sql/parser/type.go
@@ -77,6 +77,8 @@ var (
 	// TypePlaceholder is the type family of a placeholder. CANNOT be compared
 	// with ==.
 	TypePlaceholder Type = TPlaceholder{}
+	// TypeArray is the type family of a DArray. Can be compared with ==.
+	TypeArray Type = tArray{TypeString}
 )
 
 // Do not instantiate the tXxx types elsewhere. The variables above are intended
@@ -232,3 +234,24 @@ func (TPlaceholder) FamilyEqual(other Type) bool {
 
 // Size implements the Type interface.
 func (t TPlaceholder) Size() (uintptr, bool) { panic("TPlaceholder.Size() is undefined") }
+
+// TArray is the type of a DArray. For now, this only supports arrays of
+// strings.
+type tArray struct{ Typ Type }
+
+func (a tArray) String() string { return a.Typ.String() + "[]" }
+
+// Equal implements the Type interface.
+func (tArray) Equal(other Type) bool {
+	return other == TypeArray
+}
+
+// FamilyEqual implements the Type interface.
+func (tArray) FamilyEqual(other Type) bool {
+	return other == TypeArray
+}
+
+// Size implements the Type interface.
+func (tArray) Size() (uintptr, bool) {
+	return unsafe.Sizeof(DString("")), variableSize
+}

--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -635,6 +635,10 @@ func (d *DTuple) TypeCheck(_ *SemaContext, desired Type) (TypedExpr, error) { re
 
 // TypeCheck implements the Expr interface. It is implemented as an idempotent
 // identity function for Datum.
+func (d *DArray) TypeCheck(_ *SemaContext, desired Type) (TypedExpr, error) { return d, nil }
+
+// TypeCheck implements the Expr interface. It is implemented as an idempotent
+// identity function for Datum.
 func (d dNull) TypeCheck(_ *SemaContext, desired Type) (TypedExpr, error) { return d, nil }
 
 func typeCheckAndRequireBoolean(ctx *SemaContext, expr Expr, op string) (TypedExpr, error) {

--- a/pkg/sql/parser/walk.go
+++ b/pkg/sql/parser/walk.go
@@ -422,6 +422,9 @@ func (expr *DTimestampTZ) Walk(_ Visitor) Expr { return expr }
 // Walk implements the Expr interface.
 func (expr *DTuple) Walk(_ Visitor) Expr { return expr }
 
+// Walk implements the Expr interface.
+func (expr *DArray) Walk(_ Visitor) Expr { return expr }
+
 // WalkExpr traverses the nodes in an expression.
 //
 // NOTE: Do not count on the WalkStmt/WalkExpr machinery to visit all

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -103,6 +103,8 @@ func pgTypeForParserType(t parser.Type) pgType {
 		return pgType{oid.T_timestamptz, 8}
 	case parser.TypeInterval:
 		return pgType{oid.T_interval, 8}
+	case parser.TypeArray:
+		return pgType{oid.T__text, -1}
 	default:
 		panic(fmt.Sprintf("unsupported type %s", t))
 	}
@@ -175,6 +177,18 @@ func (b *writeBuffer) writeTextDatum(d parser.Datum, sessionLoc *time.Location) 
 
 	case *parser.DInterval:
 		b.writeLengthPrefixedString(v.String())
+
+	case *parser.DArray:
+		var tb bytes.Buffer
+		tb.WriteString("{")
+		for i, d := range *v {
+			if i > 0 {
+				tb.WriteString(",")
+			}
+			tb.WriteString(d.String())
+		}
+		tb.WriteString("}")
+		b.writeLengthPrefixedString(tb.String())
 
 	default:
 		b.setError(errors.Errorf("unsupported type %T", d))

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -218,6 +218,8 @@ func (p *planner) resetForBatch(e *Executor) {
 	p.resetContexts()
 	p.evalCtx.NodeID = e.cfg.NodeID.Get()
 	p.evalCtx.ReCache = e.reCache
+	p.evalCtx.Database = p.session.Database
+	p.evalCtx.SearchPath = append([]string(nil), p.session.SearchPath...)
 }
 
 // query initializes a planNode from a SQL statement string.  This

--- a/pkg/sql/set.go
+++ b/pkg/sql/set.go
@@ -64,6 +64,7 @@ func (p *planner) Set(n *parser.Set) (planNode, error) {
 			}
 		}
 		p.session.Database = dbName
+		p.evalCtx.Database = dbName
 
 	case `SYNTAX`:
 		s, err := p.getStringVal(name, typedValues)

--- a/pkg/sql/testdata/builtin_function
+++ b/pkg/sql/testdata/builtin_function
@@ -1119,3 +1119,22 @@ SELECT nonexistent.* IS NOT TRUE
 
 query error cannot use "foo.\*" in this context
 SELECT foo.* IS NOT TRUE FROM (VALUES (1)) AS foo(x)
+
+query T
+SELECT CURRENT_SCHEMAS(true)
+----
+{'pg_catalog','test'}
+
+query T
+SELECT CURRENT_SCHEMAS(false)
+----
+{'test'}
+
+query error pq: unknown signature for CURRENT_SCHEMAS: CURRENT_SCHEMAS()
+SELECT CURRENT_SCHEMAS()
+
+query T
+SELECT CURRENT_SCHEMAS(NULL::bool)
+----
+NULL
+


### PR DESCRIPTION
This is to progress further with ActiveRecord initialization. I haven't actually tested this against ActiveRecord, because to do that I need @nvanbenschoten's  `pg_catalog` changes, which haven't been merged). However, I've tested that `psql` can successfully display the result of `SELECT CURRENT_SCHEMAS(true|false)`, and I've added a SQL logic test.

This is out for early feedback.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9604)

<!-- Reviewable:end -->
