### PR TITLE
cli: enhance the `sql` CLI utility and fix long-standing bugs.

### DIFF
--- a/cli/interactive_tests/test_client_side_checking.tcl
+++ b/cli/interactive_tests/test_client_side_checking.tcl
@@ -1,0 +1,73 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_server $argv
+
+spawn $argv sql
+eexpect root@
+
+# Check that syntax errors are handled client-side when running interactive.
+send "begin;\r"
+eexpect BEGIN
+eexpect root@
+
+send "select 3+;\r"
+eexpect "statement not sent"
+eexpect root@
+
+send "select 1;\r"
+eexpect "1 row"
+eexpect root@
+
+send "commit;\r"
+eexpect COMMIT
+eexpect root@
+
+# Check that the user can force server-side handling.
+send "\\unset check_syntax\r"
+eexpect root@
+
+send "begin;\r"
+eexpect BEGIN
+
+send "select 3+;\r"
+eexpect "pq: syntax error"
+eexpect root@
+
+send "select 1;\r"
+eexpect "current transaction is aborted"
+eexpect root@
+
+send "commit;\r"
+eexpect "ROLLBACK"
+eexpect root@
+
+send "\003"
+eexpect eof
+
+# Check that syntax errors are handled server-side by default when running non-interactive.
+spawn /bin/bash
+send "PS1=':''/# '\r"
+eexpect ":/# "
+
+send "(echo '\\unset errexit'; echo 'begin;'; echo 'select 1+;'; echo 'select 1;') | $argv sql\r"
+eexpect "syntax error"
+eexpect "current transaction is aborted"
+eexpect ":/# "
+send "echo \$?\r"
+eexpect "1\r\n:/# "
+
+send "(echo '\\unset errexit'; echo '\\set check_syntax'; echo 'begin;'; echo 'select 1+;'; echo 'select 1;'; echo 'commit;') | $argv sql\r"
+eexpect "syntax error"
+eexpect "1 row"
+eexpect "COMMIT"
+eexpect ":/# "
+send "echo \$?\r"
+eexpect "0\r\n:/# "
+
+send "exit 0\r"
+eexpect eof
+
+stop_server $argv
+

--- a/cli/interactive_tests/test_error_handling.tcl
+++ b/cli/interactive_tests/test_error_handling.tcl
@@ -1,0 +1,46 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_server $argv
+
+spawn /bin/bash
+send "PS1=':''/# '\r"
+eexpect ":/# "
+
+# Check that by default, an error prevents subsequent statements from running.
+send "(echo 'select foo;'; echo 'select 1;') | $argv sql\r"
+eexpect "pq: column name \"foo\" not found\r\nError: pq: column name"
+eexpect ":/# "
+send "echo \$?\r"
+eexpect "1\r\n:/# "
+
+# Check that a user can request to continue upon failures.
+send "(echo '\\unset errexit'; echo 'select foo;'; echo 'select 1;') | $argv sql\r"
+eexpect "pq: column name \"foo\" not found"
+eexpect "1 row"
+eexpect ":/# "
+send "echo \$?\r"
+eexpect "0\r\n:/# "
+
+send "$argv sql\r"
+eexpect "root@"
+
+# Check that by default, an error does not cause an interactive failure.
+send "select foo;\r"
+eexpect "pq: column name"
+eexpect "root@"
+
+# Check that the user can ask for errors to terminate the interactive client.
+send "\\set errexit\r"
+eexpect "root@"
+send "select foo;\r"
+eexpect "Error: pq: column name"
+eexpect ":/# "
+send "echo \$?\r"
+eexpect "1\r\n:/# "
+
+send "exit 0\r"
+eexpect eof
+
+stop_server $argv

--- a/cli/interactive_tests/test_example_data.tcl
+++ b/cli/interactive_tests/test_example_data.tcl
@@ -34,6 +34,7 @@ eexpect "42"
 eexpect "1 row"
 eexpect ":/# "
 
+# Clean up.
 send "exit 0\r"
 eexpect eof
 

--- a/cli/interactive_tests/test_history.tcl
+++ b/cli/interactive_tests/test_history.tcl
@@ -14,7 +14,7 @@ eexpect root@
 
 # Test that last line can be recalled with arrow-up
 send "\033\[A"
-eexpect "select 1;"
+eexpect "SELECT 1;"
 
 # Test that recalled last line can be executed
 send "\r"
@@ -25,8 +25,8 @@ eexpect root@
 send "foo;\r"
 eexpect "syntax error"
 eexpect root@
-send "\022sel"
-eexpect "select 1;"
+send "\022SEL"
+eexpect "SELECT 1;"
 
 # Test that recalled previous line can be executed
 send "\r"
@@ -35,7 +35,7 @@ eexpect root@
 
 # Test that last recalled line becomes top of history
 send "\033\[A"
-eexpect "select 1;"
+eexpect "SELECT 1;"
 
 # Test that client cannot terminate with Ctrl+D while cursor
 # is on recalled line
@@ -52,7 +52,7 @@ eexpect eof
 spawn ./cockroach sql
 eexpect root@
 send "\033\[A"
-eexpect "select 1;"
+eexpect "SELECT 1;"
 
 # Finally terminate with Ctrl+C
 send "\003"

--- a/cli/interactive_tests/test_local_cmds.tcl
+++ b/cli/interactive_tests/test_local_cmds.tcl
@@ -47,7 +47,7 @@ send "\\h\r"
 eexpect " ->"
 
 send "1;\r"
-eexpect "pq: syntax error*\\h"
+eexpect "syntax error*\\h"
 eexpect root@
 
 # Check that a built-in command in the middle of a token (eg a string)

--- a/cli/interactive_tests/test_multiline_statements.tcl
+++ b/cli/interactive_tests/test_multiline_statements.tcl
@@ -1,0 +1,38 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_server $argv
+
+spawn $argv sql
+eexpect root@
+
+# Test that a multi-line entry can be recalled escaped.
+send "select 'foo\r"
+eexpect " ->"
+send "bar';\r"
+eexpect "1 row"
+eexpect "root@"
+
+# Send up-arrow.
+send "\033\[A"
+eexpect "SELECT e'foo\\\\nbar';"
+send "\r"
+eexpect "root@"
+
+send "select 1,\r"
+eexpect " ->"
+send "2, 3\r"
+eexpect " ->"
+send ";\r"
+eexpect "1 row"
+eexpect "root@"
+
+# Send up-arrow.
+send "\033\[A"
+eexpect "SELECT 1, 2, 3;"
+
+send "\003"
+eexpect eof
+
+stop_server $argv


### PR DESCRIPTION
This patch introduces a few features to enhance UX:
- client-side syntax checking. By default in interactive shells, the
  client will check the syntax locally and the statement is not sent
  to the server at all if an error is detected. This feature ensures
  that a user who enters by mistake a statement containing a syntax
  error during a transaction does not cause the transaction to abort
  and force the user to start over.
  
  This feature is disabled by default in non-interactive shells.
- for statements with valid syntax, the statement is pretty-printed
  before it is added to the interactive history. This exposes users to
  the "canonical syntax" of their input, which may increase SQL
  literacy of beginners over time. For example:
  
  `select * from intro.mytable where l%2=0;`
  
  becomes:
  
  `SELECT * FROM intro.mytable WHERE (l % 2) = 0;`
- consistent error handling. When running non-interactively, the shell
  will stop reading further lines of input upon the first error
  encountered. This makes the handling of errors across lines
  consistent with the handling of errors when multiple statements are
  present on the same line.
  
  This feature is disabled by default in interactive shells.

In addition to these user-visible features, a couple other features
are added to make the above more configurable:
- the SQL shell now accepts two built-in commands `\set` and `\unset`
  to set client-side variables/options. `\set` without argument lists
  the options set by default.
- two client-side options are now supported:
  - `errexit` (named after the bash option of the same name): set by
    default when non-interactive, unset when interactive. Causes the
    shell to exit upon encountering an error.
  - `check_syntax`: set by default when interactive, unset when
    non-interactive. Causes the shell to validate syntax locally.

Fixes #9502.
(between other things)

@andreimatei this provides a useful temporary workaround for the handling of multi-line statements in the history.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9610)

<!-- Reviewable:end -->
