### PR TITLE
acceptance: fix interactive cli test flakiness.

### DIFF
--- a/cli/interactive_tests/common.tcl
+++ b/cli/interactive_tests/common.tcl
@@ -10,7 +10,7 @@ system "rm -f $histfile"
 
 # Everything in this test should be fast. Don't be tolerant for long
 # waits.
-set timeout 1
+set timeout 30
 
 # When run via Docker the enclosing terminal has 0 columns and 0 rows,
 # and this confuses readline. Ensure sane defaults here.

--- a/cli/interactive_tests/test_example_data.tcl
+++ b/cli/interactive_tests/test_example_data.tcl
@@ -4,8 +4,6 @@ source [file join [file dirname $argv0] common.tcl]
 
 start_server $argv
 
-set timeout 5
-
 spawn /bin/bash
 send "PS1=':''/# '\r"
 eexpect ":/# "

--- a/cli/interactive_tests/test_server_sig.tcl
+++ b/cli/interactive_tests/test_server_sig.tcl
@@ -2,8 +2,6 @@
 
 source [file join [file dirname $argv0] common.tcl]
 
-set timeout 15
-
 spawn /bin/bash
 send "PS1='\\h:''/# '\r"
 eexpect ":/# "
@@ -37,7 +35,6 @@ eexpect "1\r\n"
 eexpect ":/# "
 
 # Check that the server shuts down fast upon receiving Ctrl+C twice.
-set timeout 1
 send "$argv start & echo $! >server_pid; fg\r"
 eexpect "restarted"
 

--- a/cli/start.go
+++ b/cli/start.go
@@ -307,6 +307,11 @@ func runStart(_ *cobra.Command, args []string) error {
 		return rerunBackground()
 	}
 
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, os.Interrupt)
+	// TODO(spencer): move this behind a build tag.
+	signal.Notify(signalCh, syscall.SIGTERM, syscall.SIGQUIT)
+
 	tracer := tracing.NewTracer()
 	startCtx := tracing.WithTracer(context.Background(), tracer)
 	sp := tracer.StartSpan("server start")
@@ -419,11 +424,6 @@ func runStart(_ *cobra.Command, args []string) error {
 	if err := tw.Flush(); err != nil {
 		return err
 	}
-
-	signalCh := make(chan os.Signal, 1)
-	signal.Notify(signalCh, os.Interrupt)
-	// TODO(spencer): move this behind a build tag.
-	signal.Notify(signalCh, syscall.SIGTERM, syscall.SIGQUIT)
 
 	var returnErr error
 


### PR DESCRIPTION
Found in e.g. https://teamcity.cockroachdb.com/viewLog.html?buildId=25078&buildTypeId=Cockroach_UnitTests_Acceptance&tab=buildLog

Sometimes the server restart or queries just takes very long (more than 5-10 seconds). Change the timeout to be 30s always.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9614)

<!-- Reviewable:end -->
