### PR TITLE
acceptance+cloud: fix for Terraform 0.7.4

### DIFF
--- a/acceptance/terraform/main.tf
+++ b/acceptance/terraform/main.tf
@@ -40,7 +40,7 @@ resource "google_compute_instance" "cockroach" {
 
   connection {
     user = "ubuntu"
-    key_file = "~/.ssh/${var.key_name}"
+    private_key = "${file(format("~/.ssh/%s", var.key_name))}"
   }
 
   service_account {
@@ -70,7 +70,7 @@ resource "null_resource" "cockroach-runner" {
 
   connection {
     user = "ubuntu"
-    key_file = "~/.ssh/${var.key_name}"
+    private_key = "${file(format("~/.ssh/%s", var.key_name))}"
     host = "${element(google_compute_instance.cockroach.*.network_interface.0.access_config.0.assigned_nat_ip, count.index)}"
   }
 

--- a/cloud/aws/README.md
+++ b/cloud/aws/README.md
@@ -39,7 +39,7 @@ To see the actions expected to be performed by terraform, use `plan` instead of 
 #### Create a cockroach cluster with 3 nodes
 
 ```
-$ terraform apply --var=num_instances=3
+$ terraform apply --var=num_instances=\"3\"
 
 Outputs:
   example_block_writer =

--- a/cloud/aws/examples.tf
+++ b/cloud/aws/examples.tf
@@ -27,7 +27,7 @@ resource "aws_instance" "example_block_writer" {
 
   connection {
     user = "ubuntu"
-    key_file = "~/.ssh/${var.key_name}.pem"
+    private_key = "${file(format("~/.ssh/%s.pem", var.key_name))}"
   }
 
   provisioner "file" {

--- a/cloud/aws/main.tf
+++ b/cloud/aws/main.tf
@@ -35,7 +35,7 @@ resource "null_resource" "cockroach-runner" {
   count = "${var.num_instances}"
   connection {
     user = "ubuntu"
-    key_file = "~/.ssh/${var.key_name}.pem"
+    private_key = "${file(format("~/.ssh/%s.pem", var.key_name))}"
     host = "${element(aws_instance.cockroach.*.public_ip, count.index)}"
   }
 

--- a/cloud/gce/README.md
+++ b/cloud/gce/README.md
@@ -43,7 +43,7 @@ The following variables can be modified if necessary:
 #### Create a cockroach cluster with 3 nodes
 
 ```
-$ terraform apply --var=num_instances=3
+$ terraform apply --var=num_instances=\"3\"
 
 
 Outputs:

--- a/cloud/gce/examples.tf
+++ b/cloud/gce/examples.tf
@@ -38,7 +38,7 @@ resource "google_compute_instance" "example_block_writer" {
 
   connection {
     user = "ubuntu"
-    key_file = "~/.ssh/${var.key_name}"
+    private_key = "${file(format("~/.ssh/%s", var.key_name))}"
   }
 
   service_account {

--- a/cloud/gce/main.tf
+++ b/cloud/gce/main.tf
@@ -27,7 +27,7 @@ resource "google_compute_instance" "cockroach" {
 
   connection {
     user = "ubuntu"
-    key_file = "~/.ssh/${var.key_name}"
+    private_key = "${file(format("~/.ssh/%s", var.key_name))}"
   }
 
   service_account {
@@ -55,7 +55,7 @@ resource "null_resource" "cockroach-runner" {
 
   connection {
     user = "ubuntu"
-    key_file = "~/.ssh/${var.key_name}"
+    private_key = "${file(format("~/.ssh/%s", var.key_name))}"
     host = "${element(google_compute_instance.cockroach.*.network_interface.0.access_config.0.assigned_nat_ip, count.index)}"
   }
 


### PR DESCRIPTION
Fix incompatibility with Terraform 0.7.4. The preferred way of
specifying private keys has changed, with no mention in the 0.7.*
upgrade guide. Tested with Terraform 0.7.3 (builder image version)
and 0.7.4 (latest released version).

See hashicorp/terraform#8963 for details.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9615)

<!-- Reviewable:end -->
