### PR TITLE
sql: slow down schema change backfill

### DIFF
--- a/sql/drop.go
+++ b/sql/drop.go
@@ -729,9 +729,12 @@ func (p *planner) dropViewImpl(tableDesc *sqlbase.TableDescriptor) error {
 // can even eliminate the need to use a transaction for each chunk at a later
 // stage if it proves inefficient).
 func truncateAndDropTable(
-	ctx context.Context, tableDesc *sqlbase.TableDescriptor, db *client.DB,
+	ctx context.Context,
+	tableDesc *sqlbase.TableDescriptor,
+	db *client.DB,
+	testingKnobs *ExecutorTestingKnobs,
 ) error {
-	if err := truncateTableInChunks(ctx, tableDesc, db); err != nil {
+	if err := truncateTableInChunks(ctx, tableDesc, db, testingKnobs); err != nil {
 		return err
 	}
 

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -278,6 +278,10 @@ type ExecutorTestingKnobs struct {
 	// StatementFilter; otherwise, the statement commits immediately after
 	// execution so there'll be nothing left to abort by the time the filter runs.
 	DisableAutoCommit bool
+
+	// DisableSchemaChangeBackfillBackoff turns off the backoff between schema
+	// change backfill incremental updates.
+	DisableSchemaChangeBackfillBackoff bool
 }
 
 // NewExecutor creates an Executor and registers a callback on the

--- a/sql/schema_changer_test.go
+++ b/sql/schema_changer_test.go
@@ -538,7 +538,6 @@ func runSchemaChangeWithOperations(
 // that run simultaneously.
 func TestRaceWithBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-
 	var backfillNotification chan bool
 	params, _ := createTestServerParams()
 	// Disable asynchronous schema change execution to allow synchronous path
@@ -553,6 +552,7 @@ func TestRaceWithBackfill(t *testing.T) {
 				}
 				return nil
 			},
+			DisableSchemaChangeBackfillBackoff: true,
 		},
 		SQLSchemaChangeManager: &csql.SchemaChangeManagerTestingKnobs{
 			AsyncSchemaChangerExecNotification: schemaChangeManagerDisabled,
@@ -791,7 +791,6 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 // Test schema change purge failure doesn't leave DB in a bad state.
 func TestSchemaChangePurgeFailure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-
 	params, _ := createTestServerParams()
 	// Disable the async schema changer.
 	var enableAsyncSchemaChanges uint32
@@ -807,6 +806,7 @@ func TestSchemaChangePurgeFailure(t *testing.T) {
 				}
 				return nil
 			},
+			DisableSchemaChangeBackfillBackoff: true,
 		},
 		SQLSchemaChangeManager: &csql.SchemaChangeManagerTestingKnobs{
 			AsyncSchemaChangerExecNotification: func() error {
@@ -924,6 +924,7 @@ func TestSchemaChangeReverseMutations(t *testing.T) {
 			SyncSchemaChangersFilter: func(tscc csql.TestingSchemaChangerCollection) {
 				tscc.ClearSchemaChangers()
 			},
+			DisableSchemaChangeBackfillBackoff: true,
 		},
 		SQLSchemaChangeManager: &csql.SchemaChangeManagerTestingKnobs{
 			AsyncSchemaChangerExecNotification: func() error {

--- a/sql/session.go
+++ b/sql/session.go
@@ -453,10 +453,7 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 			} else if done {
 				break
 			}
-			if err := sc.exec(
-				e.cfg.TestingKnobs.SchemaChangersStartBackfillNotification,
-				e.cfg.TestingKnobs.SyncSchemaChangersRenameOldNameNotInUseNotification,
-			); err != nil {
+			if err := sc.exec(e.cfg.TestingKnobs); err != nil {
 				if isSchemaChangeRetryError(err) {
 					// Try again
 					continue


### PR DESCRIPTION
I'll be a lot happier about schema changes after we merge this!

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9617)

<!-- Reviewable:end -->
