### PR TITLE
kubernetes: Don't tolerate unready endpoints in petset config

### DIFF
--- a/cloud/kubernetes/cockroachdb-petset.yaml
+++ b/cloud/kubernetes/cockroachdb-petset.yaml
@@ -24,8 +24,6 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    # Make sure DNS is resolvable during initialization.
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
     # Enable automatic monitoring of all instances when Prometheus is running in the cluster.
     prometheus.io/scrape: "true"
     prometheus.io/path: "_status/vars"


### PR DESCRIPTION
The annotation was only included in the initial config due to
cargo-culting, and has the potential to break node startup if it
resolves its own address to gossip to.

@tschottdorf

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9623)

<!-- Reviewable:end -->
