### PR TITLE
testcluster: always wait for full replication

### DIFF
--- a/testutils/testcluster/testcluster.go
+++ b/testutils/testcluster/testcluster.go
@@ -177,6 +177,12 @@ func StartTestCluster(t testing.TB, nodes int, args base.TestClusterArgs) *TestC
 	tc.stopper.AddCloser(stop.CloserFn(tc.stopServers))
 
 	tc.waitForStores(t)
+
+	// TODO(tamird): consider removing this when #8081 is addressed.
+	if err := tc.WaitForFullReplication(); err != nil {
+		t.Fatal(err)
+	}
+
 	return tc
 }
 


### PR DESCRIPTION
This makes it considerably less likely that database creation will cause
replication to stall in our benchmarks.

The underlying cause remains unknown.

Updates #8081.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9624)

<!-- Reviewable:end -->
