### PR TITLE
sql: Reject aggregations and window fns in GROUP BY ordinal exprs

### DIFF
--- a/sql/testdata/aggregate
+++ b/sql/testdata/aggregate
@@ -82,6 +82,9 @@ SELECT COUNT(*), k FROM kv GROUP BY 2
 query error aggregate functions are not allowed in GROUP BY
 SELECT * FROM kv GROUP BY v, COUNT(DISTINCT w)
 
+query error aggregate functions are not allowed in GROUP BY
+SELECT COUNT(DISTINCT w) FROM kv GROUP BY 1
+
 query error aggregate functions are not allowed in RETURNING
 INSERT INTO kv (k, v) VALUES (99, 100) RETURNING sum(v)
 

--- a/sql/testdata/window
+++ b/sql/testdata/window
@@ -22,6 +22,9 @@ INSERT INTO kv VALUES
 query error window functions are not allowed in GROUP BY
 SELECT * FROM kv GROUP BY v, COUNT(w) OVER ()
 
+query error window functions are not allowed in GROUP BY
+SELECT COUNT(w) OVER () FROM kv GROUP BY 1
+
 query error window functions are not allowed in RETURNING
 INSERT INTO kv (k, v) VALUES (99, 100) RETURNING sum(v) OVER ()
 


### PR DESCRIPTION
Fixes #9626.

Previously we were asserting that aggregate functions were not in GROUP
BY expressions before we replaced column indices with their respective
expressions.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9629)

<!-- Reviewable:end -->
