### PR TITLE
storage: move ReplicaCorruption to Store

### DIFF
--- a/storage/replica_state.go
+++ b/storage/replica_state.go
@@ -381,10 +381,14 @@ func loadReplicaDestroyedError(
 // setReplicaDestroyedError sets an error indicating that the replica has been
 // destroyed.
 func setReplicaDestroyedError(
-	ctx context.Context, eng engine.ReadWriter, rangeID roachpb.RangeID, err *roachpb.Error,
+	ctx context.Context,
+	eng engine.ReadWriter,
+	rangeID roachpb.RangeID,
+	cErr *roachpb.Error,
 ) error {
 	return engine.MVCCPutProto(ctx, eng, nil,
-		keys.RangeReplicaDestroyedErrorKey(rangeID), hlc.ZeroTimestamp, nil /* txn */, err)
+		keys.RangeReplicaDestroyedErrorKey(rangeID),
+		hlc.ZeroTimestamp, nil /* txn */, cErr)
 }
 
 func loadHardState(

--- a/storage/store.go
+++ b/storage/store.go
@@ -2364,6 +2364,44 @@ func (s *Store) HandleRaftRequest(
 	return nil
 }
 
+// maybeSetCorrupt is used for proper handling of failing replicas. Such
+// a failure is indicated by a call to maybeSetCorrupt with
+// a ReplicaCorruptionError. The returned boolean is the new corruption status
+// of the Replica, i.e. true if the replica was corrupted as a result of the
+// observed error.
+//
+// TODO(tschottdorf): when marking a Replica corrupt, must subtract its stats
+// from r.store.metrics. Errors which happen between committing a batch and
+// sending a stats delta from the store are going to be particularly tricky and
+// the best bet is to not have any of those. @bdarnell remarks: Corruption
+// errors should be rare so we may want the store to just recompute its stats
+// in the background when one occurs.
+func (s *Store) maybeSetCorrupt(
+	ctx context.Context, r *Replica, processErr error,
+) bool {
+	cErr, ok := processErr.(*roachpb.ReplicaCorruptionError)
+	if !ok {
+		return false
+	}
+
+	log.Errorf(ctx, "stalling replica due to: %s", cErr.ErrorMsg)
+
+	// Try to persist the destroyed error message. If the underlying store is
+	// corrupted the error won't be processed and a panic will occur.
+	if err := setReplicaDestroyedError(ctx, r.store.Engine(), r.RangeID, roachpb.NewError(cErr)); err != nil {
+		// TODO(tschottdorf): this may not be the best course of action as the
+		// initial reason for the corruption is likely a failure of the
+		// underlying storage.
+		log.Fatalf(ctx, "unable to persist corruption: %s", err)
+	}
+
+	r.mu.Lock()
+	r.mu.corrupted = true // TODO(tschottdorf): remove this field
+	r.mu.destroyed = cErr
+	r.mu.Unlock()
+	return true
+}
+
 func (s *Store) processRaftRequest(
 	ctx context.Context, req *RaftMessageRequest, inSnap IncomingSnapshot,
 ) (pErr *roachpb.Error) {
@@ -2603,6 +2641,7 @@ func (s *Store) processRaftRequest(
 		// Force the replica to deal with this snapshot right now.
 		if err := r.handleRaftReadyRaftMuLocked(inSnap); err != nil {
 			// mimic the behavior in processRaft.
+			// TODO(tschottdorf): handle corruption in this path.
 			panic(err)
 		}
 		removePlaceholder = false
@@ -2798,13 +2837,14 @@ func (s *Store) processRequestQueue(rangeID roachpb.RangeID) {
 func (s *Store) processReady(rangeID roachpb.RangeID) {
 	start := timeutil.Now()
 
-	s.mu.Lock()
-	r, ok := s.mu.replicas[rangeID]
-	s.mu.Unlock()
+	r, err := s.GetReplica(rangeID)
+	if err != nil {
+		return // TODO(bdarnell)
+	}
 
-	if ok {
+	if corrupt := s.maybeSetCorrupt(s.Ctx(), r, func() error {
 		if err := r.handleRaftReady(IncomingSnapshot{}); err != nil {
-			panic(err) // TODO(bdarnell)
+			return err
 		}
 		elapsed := timeutil.Since(start)
 		s.metrics.RaftWorkingDurationNanos.Inc(elapsed.Nanoseconds())
@@ -2826,6 +2866,12 @@ func (s *Store) processReady(rangeID roachpb.RangeID) {
 				atomic.AddInt32(&s.counts.droppedPlaceholders, 1)
 			}
 		}
+		return nil
+	}()); corrupt {
+		return
+	} else if err != nil {
+		// TODO(bdarnell)
+		panic(err)
 	}
 }
 

--- a/storage/stores.go
+++ b/storage/stores.go
@@ -235,7 +235,7 @@ func (ls *Stores) LookupReplica(
 
 		if repDescFound {
 			// We already found the range; this should never happen outside of tests.
-			err := errors.Errorf("range %+v exists on additional store: %+v", replica, store)
+			err := errors.Errorf("replica %+v exists on additional store: %+v", replica.Desc(), store)
 			return 0, roachpb.ReplicaDescriptor{}, err
 		}
 


### PR DESCRIPTION
Also lets a lot of test senders go through Store (which was
prompted by TestReplicaCorruption).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9633)

<!-- Reviewable:end -->
