### PR TITLE
[do no merge] sql/parser: allow manually ranking overloads

### DIFF
--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -84,6 +84,15 @@ type Builtin struct {
 	Types      typeList
 	ReturnType Datum
 
+	// When multiple overloads are eligible based on types even after all of of
+	// the heuristics to pick one have been used, if one of the overloads is a
+	// Builtin with the `preferredOverload` flag set to true it can be selected
+	// rather than returning a no-such-method error.
+	// This should generally be avoided -- avoiding introducing ambiguous
+	// overloads in the first place is a much better solution -- and only done
+	// after consultation with @knz @nvanbenschoten.
+	preferredOverload bool
+
 	// Set to true when a function potentially returns a different value
 	// when called in the same statement with the same parameters.
 	// e.g.: random(), clock_timestamp(). Some functions like now()

--- a/sql/parser/overload.go
+++ b/sql/parser/overload.go
@@ -469,5 +469,11 @@ func typeCheckOverloadedExprs(
 	if err := defaultTypeCheck(len(overloads) > 0); err != nil {
 		return nil, nil, err
 	}
+
+	for _, c := range overloads {
+		if c, ok := c.(Builtin); ok && c.preferredOverload {
+			return typedExprs, c, nil
+		}
+	}
 	return typedExprs, nil, nil
 }


### PR DESCRIPTION
adds a `preferredOverload` flag to `Builtin`s.

If multiple overloads of a `Builtin` are compatible
with the argument and desired (if any) types, after
_all_ the existing heuristics have tried and
failed to pick one overload, if an overload has the
preferredOverload flag set, it may be chosen rather
than giving up (and reporting no matching signature).

In most cases of ambiguous overloads, failing to
resolve and requiring the user to explicitly choose
a type is safest, but in some rare cases, introducing
ambiguity might be a deterrent to adding an otherwise
useful overload. Being able to add additional overloads
without breaking existing queries, by resolving the 
introduced ambiguity with an explicit ranking, could 
mitigate that.

For example, a usage of this might be to have two
overloads of `now()`, returning the both session
zone aware and unaware timestamp types: when the 
`desired` type is either timestamp or timestamptz,
it is clear which to pick, but a `select now();`
would fail.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9637)

<!-- Reviewable:end -->
