### PR TITLE
storage: use time-tracking mutex

### DIFF
--- a/build/check-style.sh
+++ b/build/check-style.sh
@@ -11,7 +11,7 @@ TestCopyrightHeaders() {
 
 TestTimeutil() {
   echo "checking for time.Now and time.Since calls (use timeutil instead)"
-  ! git grep -nE 'time\.(Now|Since)' -- '*.go' | grep -vE '^util/(log|timeutil)/\w+\.go\b'
+  ! git grep -nE 'time\.(Now|Since)' -- '*.go' | grep -vE '^util/(log|syncutil|timeutil)/\w+\.go\b'
 }
 
 TestEnvutil() {

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -82,6 +82,9 @@ const (
 	optimizePutThreshold = 10
 
 	replicaChangeTxnName = "change-replica"
+
+	defaultReplicaRaftMuWarnThreshold = 500 * time.Millisecond
+	defaultReplicaMuWarnThreshold     = 500 * time.Millisecond
 )
 
 // This flag controls whether Transaction entries are automatically gc'ed
@@ -241,11 +244,15 @@ type Replica struct {
 	// raftMu protects Raft processing the replica.
 	//
 	// Locking notes: Replica.raftMu < Replica.mu
-	raftMu syncutil.Mutex
+	//
+	// TODO(peter): evaluate runtime overhead the timed mutex.
+	raftMu syncutil.TimedMutex
 
 	mu struct {
 		// Protects all fields in the mu struct.
-		syncutil.Mutex
+		//
+		// TODO(peter): evaluate runtime overhead the timed mutex.
+		syncutil.TimedMutex
 		// Has the replica been destroyed.
 		destroyed error
 		// Corrupted persistently (across process restarts) indicates whether the
@@ -477,6 +484,9 @@ func newReplica(rangeID roachpb.RangeID, store *Store) *Replica {
 		store:      store,
 		abortCache: NewAbortCache(rangeID),
 	}
+	// TODO(radu): we can do better than store.Ctx() here.
+	r.raftMu = syncutil.MakeTimedMutex(store.Ctx(), defaultReplicaRaftMuWarnThreshold)
+	r.mu.TimedMutex = syncutil.MakeTimedMutex(store.Ctx(), defaultReplicaMuWarnThreshold)
 	r.mu.outSnapDone = initialOutSnapDone
 	return r
 }
@@ -2802,7 +2812,7 @@ func (r *Replica) applyRaftCommand(
 		log.Fatalf(ctx, "setting mvcc stats in a batch should never fail: %s", err)
 	}
 
-	// TODO(petermattis): We did not close the writer in an earlier version of
+	// TODO(peter): We did not close the writer in an earlier version of
 	// the code, which went undetected even though we used the batch after
 	// (though only to commit it). We should add an assertion to prevent that in
 	// the future.

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -57,6 +57,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/protoutil"
 	"github.com/cockroachdb/cockroach/util/stop"
+	"github.com/cockroachdb/cockroach/util/syncutil"
 	"github.com/cockroachdb/cockroach/util/uuid"
 )
 
@@ -362,6 +363,7 @@ func TestReplicaContains(t *testing.T) {
 
 	// This test really only needs a hollow shell of a Replica.
 	r := &Replica{}
+	r.mu.TimedMutex = syncutil.MakeTimedMutex(context.Background(), time.Hour)
 	r.mu.state.Desc = desc
 	r.rangeStr.store(desc)
 

--- a/storage/scanner_test.go
+++ b/storage/scanner_test.go
@@ -57,6 +57,7 @@ func newTestRangeSet(count int, t *testing.T) *testRangeSet {
 		rng := &Replica{
 			RangeID: desc.RangeID,
 		}
+		rng.mu.TimedMutex = syncutil.MakeTimedMutex(context.Background(), time.Hour)
 		rng.mu.state.Stats = enginepb.MVCCStats{
 			KeyBytes:  1,
 			ValBytes:  2,

--- a/storage/store.go
+++ b/storage/store.go
@@ -85,6 +85,8 @@ const (
 	// replicaRequestQueueSize specifies the maximum number of requests to queue
 	// for a replica.
 	replicaRequestQueueSize = 100
+
+	defaultStoreMutexWarnThreshold = 100 * time.Millisecond
 )
 
 var changeTypeInternalToRaft = map[roachpb.ReplicaChangeType]raftpb.ConfChangeType{
@@ -410,7 +412,8 @@ type Store struct {
 	// modified by a concurrent HandleRaftRequest. (#4476)
 
 	mu struct {
-		syncutil.Mutex // Protects all variables in the mu struct.
+		// TODO(peter): evaluate runtime overhead of the timed mutex.
+		syncutil.TimedMutex // Protects all variables in the mu struct.
 		// Map of replicas by Range ID. This includes `uninitReplicas`.
 		replicas       map[roachpb.RangeID]*Replica
 		replicasByKey  *btree.BTree                 // btree keyed by ranges end keys.
@@ -636,11 +639,13 @@ func NewStore(ctx StoreContext, eng engine.Engine, nodeDesc *roachpb.NodeDescrip
 		nodeDesc:  nodeDesc,
 		metrics:   newStoreMetrics(),
 	}
+
 	s.intentResolver = newIntentResolver(s)
 	s.raftEntryCache = newRaftEntryCache(ctx.RaftEntryCacheSize)
 	s.drainLeases.Store(false)
 	s.scheduler = newRaftScheduler(ctx.Ctx, s, storeSchedulerConcurrency)
 
+	s.mu.TimedMutex = syncutil.MakeTimedMutex(s.Ctx(), defaultStoreMutexWarnThreshold)
 	s.mu.Lock()
 	s.mu.replicas = map[roachpb.RangeID]*Replica{}
 	s.mu.replicaPlaceholders = map[roachpb.RangeID]*ReplicaPlaceholder{}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/protoutil"
 	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/stop"
+	"github.com/cockroachdb/cockroach/util/syncutil"
 	"github.com/cockroachdb/cockroach/util/uuid"
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
@@ -686,6 +687,7 @@ func TestProcessRangeDescriptorUpdate(t *testing.T) {
 		store:      store,
 		abortCache: NewAbortCache(desc.RangeID),
 	}
+	r.mu.TimedMutex = syncutil.MakeTimedMutex(context.Background(), time.Hour)
 	if err := r.init(desc, store.Clock(), 0); err != nil {
 		t.Fatal(err)
 	}

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -20,8 +20,16 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/cockroachdb/cockroach/util/syncutil"
+
 	"golang.org/x/net/context"
 )
+
+func init() {
+	// Make sure that if syncutil.TimedMutex is used, any warnings are printed
+	// using this package.
+	syncutil.SetLogger(Warningf)
+}
 
 const httpLogLevelPrefix = "/debug/vmodule/"
 

--- a/util/syncutil/timedmutex.go
+++ b/util/syncutil/timedmutex.go
@@ -1,0 +1,87 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package syncutil
+
+import (
+	"fmt"
+	"os"
+	"runtime/debug"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+var opts struct {
+	mu  Mutex
+	log func(context.Context, string, ...interface{})
+}
+
+// SetLogger changes the function which will be used by TimedMutex when
+// warning about an above-threshold invocation.
+func SetLogger(fn func(context.Context, string, ...interface{})) {
+	opts.mu.Lock()
+	defer opts.mu.Unlock()
+	opts.log = fn
+}
+
+// TimedMutex is a mutex which dumps a stack trace whenever a lock is unlocked
+// after being held for longer than the supplied duration, which must be
+// strictly positive.
+type TimedMutex struct {
+	mu       *Mutex    // intentionally pointer to make zero value unusable
+	lockedAt time.Time // protected by mu
+
+	// Non-mutable fields.
+	ctx       context.Context
+	threshold time.Duration
+}
+
+// MakeTimedMutex creates a TimedMutex which warns when an Unlock happens more
+// than warnDuration after the corresponding lock. It will use the supplied
+// context for the warning message; see SetLogger().
+func MakeTimedMutex(ctx context.Context, warnDuration time.Duration) TimedMutex {
+	if warnDuration <= 0 {
+		panic("duration must be positive")
+	}
+	return TimedMutex{ctx: ctx, threshold: warnDuration, mu: &Mutex{}}
+}
+
+// Lock implements sync.Locker
+func (tm *TimedMutex) Lock() {
+	tm.mu.Lock()
+	tm.lockedAt = time.Now()
+}
+
+// Unlock implements sync.Locker
+func (tm *TimedMutex) Unlock() {
+	lockedAt := tm.lockedAt
+	tm.mu.Unlock()
+
+	if heldFor := time.Since(lockedAt); heldFor >= tm.threshold {
+		opts.mu.Lock()
+		log := opts.log
+		opts.mu.Unlock()
+
+		if log == nil {
+			log = func(_ context.Context, msg string, args ...interface{}) {
+				fmt.Fprintf(os.Stderr, msg, args...)
+			}
+		}
+		log(
+			tm.ctx, "mutex held for %s (>%s):\n%s",
+			heldFor, tm.threshold, debug.Stack(),
+		)
+	}
+}

--- a/util/syncutil/timedmutex_test.go
+++ b/util/syncutil/timedmutex_test.go
@@ -1,0 +1,57 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package syncutil_test // because of log import
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	_ "github.com/cockroachdb/cockroach/util/log" // for flags
+	"github.com/cockroachdb/cockroach/util/syncutil"
+
+	"golang.org/x/net/context"
+)
+
+func TestTimedMutex(t *testing.T) {
+	var msgs []string
+	syncutil.SetLogger(func(ctx context.Context, innerMsg string, args ...interface{}) {
+		msgs = append(msgs, innerMsg)
+	})
+
+	{
+		// Should fire.
+		tm := syncutil.MakeTimedMutex(context.Background(), time.Nanosecond)
+		tm.Lock()
+		time.Sleep(2 * time.Nanosecond)
+		tm.Unlock()
+
+		if len(msgs) != 1 {
+			t.Fatalf("mutex did not warn: %+v", msgs)
+		}
+	}
+
+	{
+		tm := syncutil.MakeTimedMutex(context.Background(), time.Duration(math.MaxInt64))
+		tm.Lock()
+		// Avoid staticcheck complaining about empty critical section.
+		time.Sleep(time.Nanosecond)
+		tm.Unlock()
+
+		if len(msgs) != 1 {
+			t.Fatalf("mutex warned erroneously: %+v", msgs[1:])
+		}
+	}
+}


### PR DESCRIPTION
See #9543.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9638)

<!-- Reviewable:end -->
