### PR TITLE
build: speed up go generate: don't run ui tests

### DIFF
--- a/ui/Makefile
+++ b/ui/Makefile
@@ -56,6 +56,11 @@ GOBINDATA_TARGET = embedded.go
 .PHONY: all
 all: lint test $(GOBINDATA_TARGET)
 
+# Running `go generate` will call this target. Update this if you add new
+# generated files.
+.PHONY: generate
+generate: $(GOBINDATA_TARGET)
+
 # TODO(tamird): is there a way to not repeat this here? It's already in protobuf.mk
 app/js/protos.js generated/protos.json generated/protos.d.ts: $(addprefix $(REPO_ROOT)/, $(sort $(shell cd $(REPO_ROOT) && git ls-files --exclude-standard --cached --others -- '*.proto')))
 	$(MAKE) -C $(ORG_ROOT) -f cockroach/build/protobuf.mk

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -18,4 +18,4 @@
 // stylesheets.
 package ui
 
-//go:generate make
+//go:generate make generate


### PR DESCRIPTION
Previously, go generate would not only generate all of the protobufs and
embedded.go, but also run the ui linters and tests. This is pretty slow
and not really relevant to go generate.

Now, go generate only generates files. CI has been updated to run the ui
tests if necessary.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9639)

<!-- Reviewable:end -->
