### PR TITLE
storage/engine: bump the memtable budget from 32 MB to 128 MB

### DIFF
--- a/cli/debug.go
+++ b/cli/debug.go
@@ -74,7 +74,6 @@ func openStore(cmd *cobra.Command, dir string, stopper *stop.Stopper) (*engine.R
 		roachpb.Attributes{},
 		dir,
 		cache,
-		10<<20,
 		0,
 		maxOpenFiles,
 		stopper,

--- a/server/context.go
+++ b/server/context.go
@@ -43,16 +43,9 @@ import (
 
 // Context defaults.
 const (
-	defaultCGroupMemPath = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
-	defaultMaxOffset     = 250 * time.Millisecond
-	defaultCacheSize     = 512 << 20 // 512 MB
-	// defaultMemtableBudget controls how much memory can be used for memory
-	// tables. The way we initialize RocksDB, 100% (32 MB) of this setting can be
-	// used for memory tables and each memory table will be 25% of the size (8
-	// MB). This corresponds to the default RocksDB memtable size. Note that
-	// larger values do not necessarily improve performance, so benchmark any
-	// changes to this value.
-	defaultMemtableBudget           = 32 << 20 // 32 MB
+	defaultCGroupMemPath            = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+	defaultMaxOffset                = 250 * time.Millisecond
+	defaultCacheSize                = 512 << 20 // 512 MB
 	defaultScanInterval             = 10 * time.Minute
 	defaultConsistencyCheckInterval = 24 * time.Hour
 	defaultScanMaxIdleTime          = 5 * time.Second
@@ -92,11 +85,6 @@ type Context struct {
 	// CacheSize is the amount of memory in bytes to use for caching data.
 	// The value is split evenly between the stores if there are more than one.
 	CacheSize int64
-
-	// MemtableBudget is the amount of memory, per store, in bytes to use for
-	// the memory table.
-	// This value is no longer settable by the end user.
-	MemtableBudget int64
 
 	// Parsed values.
 
@@ -340,7 +328,6 @@ func MakeContext() Context {
 		Context:                  new(base.Context),
 		MaxOffset:                defaultMaxOffset,
 		CacheSize:                defaultCacheSize,
-		MemtableBudget:           defaultMemtableBudget,
 		ScanInterval:             defaultScanInterval,
 		ScanMaxIdleTime:          defaultScanMaxIdleTime,
 		ConsistencyCheckInterval: defaultConsistencyCheckInterval,
@@ -405,7 +392,6 @@ func (ctx *Context) InitStores(stopper *stop.Stopper) error {
 					spec.Attributes,
 					spec.Path,
 					cache,
-					ctx.MemtableBudget,
 					sizeInBytes,
 					openFileLimitPerStore,
 					stopper,

--- a/storage/engine/bench_rocksdb_test.go
+++ b/storage/engine/bench_rocksdb_test.go
@@ -26,13 +26,11 @@ import (
 )
 
 func setupMVCCRocksDB(b testing.TB, loc string) (Engine, *stop.Stopper) {
-	const memtableBudget = 512 << 20 // 512 MB
 	stopper := stop.NewStopper()
 	rocksdb := NewRocksDB(
 		roachpb.Attributes{},
 		loc,
 		RocksDBCache{},
-		memtableBudget,
 		0,
 		DefaultMaxOpenFiles,
 		stopper,

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -60,10 +60,7 @@ import (
 import "C"
 
 const (
-	// Small values for minMemtableBudget trigger assertions in debug
-	// builds of rocksdb.
-	minMemtableBudget = 10 << 20 // 10 MB
-	defaultBlockSize  = 32 << 10 // 32KB (rocksdb default is 4KB)
+	defaultBlockSize = 32 << 10 // 32KB (rocksdb default is 4KB)
 
 	// DefaultMaxOpenFiles is the default value for rocksDB's max_open_files
 	// option.
@@ -268,15 +265,14 @@ func (c RocksDBCache) Release() {
 
 // RocksDB is a wrapper around a RocksDB database instance.
 type RocksDB struct {
-	rdb            *C.DBEngine
-	attrs          roachpb.Attributes // Attributes for this engine
-	dir            string             // The data directory
-	cache          RocksDBCache       // Shared cache.
-	memtableBudget int64              // Memory to use for the memory table.
-	maxSize        int64              // Used for calculating rebalancing and free space.
-	maxOpenFiles   int                // The maximum number of open files this instance will use.
-	stopper        *stop.Stopper
-	deallocated    chan struct{} // Closed when the underlying handle is deallocated.
+	rdb          *C.DBEngine
+	attrs        roachpb.Attributes // Attributes for this engine
+	dir          string             // The data directory
+	cache        RocksDBCache       // Shared cache.
+	maxSize      int64              // Used for calculating rebalancing and free space.
+	maxOpenFiles int                // The maximum number of open files this instance will use.
+	stopper      *stop.Stopper
+	deallocated  chan struct{} // Closed when the underlying handle is deallocated.
 }
 
 var _ Engine = &RocksDB{}
@@ -286,7 +282,7 @@ func NewRocksDB(
 	attrs roachpb.Attributes,
 	dir string,
 	cache RocksDBCache,
-	memtableBudget, maxSize int64,
+	maxSize int64,
 	maxOpenFiles int,
 	stopper *stop.Stopper,
 ) *RocksDB {
@@ -294,28 +290,26 @@ func NewRocksDB(
 		panic("dir must be non-empty")
 	}
 	return &RocksDB{
-		attrs:          attrs,
-		dir:            dir,
-		cache:          cache.ref(),
-		memtableBudget: memtableBudget,
-		maxSize:        maxSize,
-		maxOpenFiles:   maxOpenFiles,
-		stopper:        stopper,
-		deallocated:    make(chan struct{}),
+		attrs:        attrs,
+		dir:          dir,
+		cache:        cache.ref(),
+		maxSize:      maxSize,
+		maxOpenFiles: maxOpenFiles,
+		stopper:      stopper,
+		deallocated:  make(chan struct{}),
 	}
 }
 
 func newMemRocksDB(
-	attrs roachpb.Attributes, cache RocksDBCache, memtableBudget int64, stopper *stop.Stopper,
+	attrs roachpb.Attributes, cache RocksDBCache, maxSize int64, stopper *stop.Stopper,
 ) *RocksDB {
 	return &RocksDB{
 		attrs: attrs,
 		// dir: empty dir == "mem" RocksDB instance.
-		cache:          cache.ref(),
-		memtableBudget: memtableBudget,
-		maxSize:        memtableBudget,
-		stopper:        stopper,
-		deallocated:    make(chan struct{}),
+		cache:       cache.ref(),
+		maxSize:     maxSize,
+		stopper:     stopper,
+		deallocated: make(chan struct{}),
 	}
 }
 
@@ -334,11 +328,6 @@ func (r *RocksDB) String() string {
 func (r *RocksDB) Open() error {
 	if r.rdb != nil {
 		return nil
-	}
-
-	if r.memtableBudget < minMemtableBudget {
-		return errors.Errorf("memtable budget must be at least %s: %s",
-			humanize.IBytes(minMemtableBudget), humanizeutil.IBytes(r.memtableBudget))
 	}
 
 	var ver storageVersion
@@ -369,7 +358,6 @@ func (r *RocksDB) Open() error {
 	status := C.DBOpen(&r.rdb, goToCSlice([]byte(r.dir)),
 		C.DBOptions{
 			cache:           r.cache.cache,
-			memtable_budget: C.uint64_t(r.memtableBudget),
 			block_size:      C.uint64_t(blockSize),
 			wal_ttl_seconds: C.uint64_t(walTTL),
 			allow_os_buffer: C.bool(true),
@@ -1491,7 +1479,7 @@ func MakeRocksDBSstFileReader() (RocksDBSstFileReader, error) {
 	// less magic.
 	cache := NewRocksDBCache(1 << 20)
 	rocksDB := NewRocksDB(
-		roachpb.Attributes{}, dir, cache, 512<<20, 512<<20, DefaultMaxOpenFiles, stopper)
+		roachpb.Attributes{}, dir, cache, 512<<20, DefaultMaxOpenFiles, stopper)
 	if err := rocksDB.Open(); err != nil {
 		return RocksDBSstFileReader{}, err
 	}

--- a/storage/engine/rocksdb/db.cc
+++ b/storage/engine/rocksdb/db.cc
@@ -1418,8 +1418,9 @@ DBStatus DBOpen(DBEngine **db, DBSlice dir, DBOptions db_opts) {
   options.table_factory.reset(rocksdb::NewBlockBasedTableFactory(table_options));
   options.max_open_files = db_opts.max_open_files;
 
+  const uint64_t memtable_budget = 32 << 20; // 32 MB
   options.max_write_buffer_number = 4;
-  options.write_buffer_size = db_opts.memtable_budget / options.max_write_buffer_number;
+  options.write_buffer_size = memtable_budget / options.max_write_buffer_number;
   options.level0_file_num_compaction_trigger = 1;
   options.level0_slowdown_writes_trigger = 16;
   options.level0_stop_writes_trigger = 17;

--- a/storage/engine/rocksdb/db.cc
+++ b/storage/engine/rocksdb/db.cc
@@ -1423,8 +1423,11 @@ DBStatus DBOpen(DBEngine **db, DBSlice dir, DBOptions db_opts) {
   options.level0_file_num_compaction_trigger = 1;
   options.level0_slowdown_writes_trigger = 16;
   options.level0_stop_writes_trigger = 17;
-  // Merge two memtables when flushing to L0.
-  options.min_write_buffer_number_to_merge = 2;
+  // Flush write buffers to L0 as soon as they are full. A higher
+  // value could be beneficial if there are duplicate records in each
+  // of the individual write buffers, but perf testing hasn't shown
+  // any benefit so far.
+  options.min_write_buffer_number_to_merge = 1;
   // Enable dynamic level sizing which reduces both size and write
   // amplification. This causes RocksDB to pick the target size of
   // each level dynamically.

--- a/storage/engine/rocksdb/db.h
+++ b/storage/engine/rocksdb/db.h
@@ -61,7 +61,6 @@ typedef struct DBIterator DBIterator;
 // DBOptions contains local database options.
 typedef struct {
   DBCache *cache;
-  uint64_t memtable_budget;
   uint64_t block_size;
   uint64_t wal_ttl_seconds;
   bool allow_os_buffer;

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -39,24 +39,6 @@ import (
 
 const testCacheSize = 1 << 30 // 1 GB
 
-func TestMinMemtableBudget(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	rocksdb := NewRocksDB(
-		roachpb.Attributes{},
-		".",
-		RocksDBCache{},
-		0,
-		0,
-		DefaultMaxOpenFiles,
-		stop.NewStopper(),
-	)
-	const expected = "memtable budget must be at least"
-	if err := rocksdb.Open(); !testutils.IsError(err, expected) {
-		t.Fatalf("expected %s, but got %v", expected, err)
-	}
-}
-
 func TestBatchIterReadOwnWrite(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -249,7 +231,6 @@ func openRocksDBWithVersion(t *testing.T, hasVersionFile bool, ver Version) erro
 		roachpb.Attributes{},
 		dir,
 		RocksDBCache{},
-		minMemtableBudget,
 		0,
 		DefaultMaxOpenFiles,
 		stopper,
@@ -279,7 +260,6 @@ func TestCheckpoint(t *testing.T) {
 			roachpb.Attributes{},
 			dir,
 			RocksDBCache{},
-			minMemtableBudget,
 			0,
 			DefaultMaxOpenFiles,
 			stopper,
@@ -314,7 +294,6 @@ func TestCheckpoint(t *testing.T) {
 			roachpb.Attributes{},
 			dir,
 			RocksDBCache{},
-			minMemtableBudget,
 			0,
 			DefaultMaxOpenFiles,
 			stopper,


### PR DESCRIPTION
This should alleviate write stalls when deleting a range.

See #9663

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9668)

<!-- Reviewable:end -->
