### PR TITLE
server, storage/engine: update recommended and default file descriptors

### DIFF
--- a/server/context.go
+++ b/server/context.go
@@ -239,8 +239,8 @@ func GetTotalMemory() (int64, error) {
 // the soft and hard limits respectively.
 func setOpenFileLimit(physicalStoreCount int) (int, error) {
 	minimumOpenFileLimit := uint64(physicalStoreCount*engine.MinimumMaxOpenFiles + minimumNetworkFileDescriptors)
-	networkConstrainedFileLimit := uint64(physicalStoreCount*engine.DefaultMaxOpenFiles + minimumNetworkFileDescriptors)
-	recommendedOpenFileLimit := uint64(physicalStoreCount*engine.DefaultMaxOpenFiles + recommendedNetworkFileDescriptors)
+	networkConstrainedFileLimit := uint64(physicalStoreCount*engine.RecommendedMaxOpenFiles + minimumNetworkFileDescriptors)
+	recommendedOpenFileLimit := uint64(physicalStoreCount*engine.RecommendedMaxOpenFiles + recommendedNetworkFileDescriptors)
 	// TODO(bram): Test this out on windows.
 	var rLimit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit); err != nil {

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -67,10 +67,14 @@ const (
 
 	// DefaultMaxOpenFiles is the default value for rocksDB's max_open_files
 	// option.
-	DefaultMaxOpenFiles = 5000
+	DefaultMaxOpenFiles = -1
+	// RecommendedMaxOpenFiles is the recommended value for rocksDB's
+	// max_open_files option. If more file descriptors are available than the
+	// recommended number, than the default value is used.
+	RecommendedMaxOpenFiles = 10000
 	// MinimumMaxOpenFiles is The minimum value that rocksDB's max_open_files
 	// option can be set to.
-	MinimumMaxOpenFiles = 256
+	MinimumMaxOpenFiles = 2000
 )
 
 func init() {


### PR DESCRIPTION
This sets the default value for rocksdb's max_open_files to -1 which is now
recommend by rocksDB from version 4.9 onward.
Also, this ups the minimum number to 2000 from 256 and the recommended to 10000
from 5000.

@jseldess this will require some updates to the docs.

@petermattis, you mentioned that we need approximately 1 file descriptor per 100MB of storage.  If that's the case, than we need 10 for 1GB and 10k for 1TB.  4TB drives are not uncommon these days and requiring 40K+ fd will require a good amount of work on some operating systems.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9679)

<!-- Reviewable:end -->
