### PR TITLE
style: function call wrapping

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -56,6 +56,54 @@ short and related arguments (e.g. `start, end int64`) should either go on the sa
 or the type should be repeated on each line -- no argument should appear by itself
 on a line with no type (confusing and brittle when edited).
 
+### Wrapping Function Calls
+
+When wrapping function calls that do not fit on one line, put the arguments on a
+separate line, with the closing `)` on a separate line:
+
+```go
+    someFunc(
+       arg1, arg2, arg3,
+    )
+```
+
+If this still doesn't fit, put each argument on a separate line:
+
+```go
+    someFunc(
+       arg1,
+       arg2,
+       arg3,
+    )
+```
+
+This form should also be used if one of the arguments is a multi-line expression:
+
+```go
+   someFunc(
+     arg1,
+     arg2{
+       field1: val1,
+       field2: val2,
+     },
+   )
+```
+
+A complex example:
+```go
+  if err := txn.Exec(
+    client.TxnExecOptions{AutoRetry: false, AutoCommit: true},
+    func(txn *client.Txn, _ *client.TxnExecOptions) error {
+      // Set deadline to sometime in the past.
+      txn.UpdateDeadlineMaybe(hlc.Timestamp{WallTime: timeutil.Now().Add(-time.Second).UnixNano()})
+      _, err := txn.Get("k")
+      return err
+    },
+  ); !testutils.IsError(err, "txn aborted") {
+    t.Fatal(err)
+  }
+```
+                          }
 ### fmt Verbs
 
 Prefer the most specific verb for your use. In other words, prefer to avoid %v

--- a/STYLE.md
+++ b/STYLE.md
@@ -58,6 +58,9 @@ on a line with no type (confusing and brittle when edited).
 
 ### Wrapping Function Calls
 
+Note: the guidelines in this section are suggestions; they are not required and
+they should not be demanded in code reviews.
+
 When wrapping function calls that do not fit on one line, put the arguments on a
 separate line, with the closing `)` on a separate line:
 
@@ -106,9 +109,9 @@ A complex example:
                           }
 ### fmt Verbs
 
-Prefer the most specific verb for your use. In other words, prefer to avoid %v
-when possible. However, %v is to be used when formatting bindings which might
-be nil and which do not already handle nil formatting. Notably, nil errors
-formatted as %s will render as "%!s(<nil>)" while nil errors formatted as %v
-will render as "<nil>". Therefore, prefer %v when formatting errors which are
-not known to be non-nil.
+Prefer the most specific verb for your use. In other words, prefer to avoid `%v`
+when possible. However, `%v` is to be used when formatting bindings which might
+be `nil` and which do not already handle `nil` formatting. Notably, `nil` errors
+formatted as `%s` will render as `%!s(<nil>)` while `nil` errors formatted as `%v`
+will render as `<nil>`. Therefore, prefer `%v` when formatting errors which are
+not known to be non-`nil`.


### PR DESCRIPTION
Updates #9678.

Bikeshed away! Apart from having a consistent style, my only preference is for something that can be automatically enforced via `crlfmt` (if possible).

CC @paperstreet @dt @tamird @petermattis @bdarnell

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9687)

<!-- Reviewable:end -->
