### PR TITLE
sql: implement a CONCAT_AGG built-in function.

### DIFF
--- a/sql/parser/aggregate_builtins.go
+++ b/sql/parser/aggregate_builtins.go
@@ -15,6 +15,7 @@
 package parser
 
 import (
+	"bytes"
 	"fmt"
 	"math"
 	"strings"
@@ -83,6 +84,14 @@ var aggregates = map[string][]Builtin{
 
 	"bool_or": {
 		makeAggBuiltin(TypeBool, TypeBool, newBoolOrAggregate),
+	},
+
+	"concat_agg": {
+		// TODO(knz) When CockroachDB supports STRING_AGG, CONCAT_AGG(X)
+		// should be substituted to STRING_AGG(X, '') and executed as
+		// such (no need for a separate implementation).
+		makeAggBuiltin(TypeString, TypeString, newStringConcatAggregate),
+		makeAggBuiltin(TypeBytes, TypeBytes, newBytesConcatAggregate),
 	},
 
 	"count": countImpls(),
@@ -219,6 +228,45 @@ func (a *avgAggregate) Result() Datum {
 	default:
 		panic(fmt.Sprintf("unexpected SUM result type: %s", t.Type()))
 	}
+}
+
+type concatAggregate struct {
+	forBytes   bool
+	sawNonNull bool
+	result     bytes.Buffer
+}
+
+func newBytesConcatAggregate() AggregateFunc {
+	return &concatAggregate{forBytes: true}
+}
+func newStringConcatAggregate() AggregateFunc {
+	return &concatAggregate{}
+}
+
+func (a *concatAggregate) Add(datum Datum) {
+	if datum == DNull {
+		return
+	}
+	a.sawNonNull = true
+	var arg string
+	if a.forBytes {
+		arg = string(*datum.(*DBytes))
+	} else {
+		arg = string(*datum.(*DString))
+	}
+	a.result.WriteString(arg)
+}
+
+func (a *concatAggregate) Result() Datum {
+	if !a.sawNonNull {
+		return DNull
+	}
+	if a.forBytes {
+		res := DBytes(a.result.String())
+		return &res
+	}
+	res := DString(a.result.String())
+	return &res
 }
 
 type boolAndAggregate struct {

--- a/sql/testdata/aggregate
+++ b/sql/testdata/aggregate
@@ -715,6 +715,11 @@ SELECT BOOL_AND(b), BOOL_OR(b) FROM bools
 ----
 false false
 
+query T
+SELECT CONCAT_AGG(s) FROM (SELECT s FROM kv ORDER BY k)
+----
+aabbA
+
 # Tests for the single-row optimization.
 statement OK
 CREATE TABLE ab (

--- a/sql/testdata/window
+++ b/sql/testdata/window
@@ -273,6 +273,16 @@ SELECT avg(d) OVER (PARTITION BY v, v, v, v, v, v, v, v, v, v) FROM kv WHERE k =
 ----
 8.0000000000000000
 
+query IT
+SELECT k, concat_agg(s) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1   bab
+3   Aa
+5   NULL
+6   bab
+7   b
+8   A
+
 query IB
 SELECT k, bool_and(b) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
 ----


### PR DESCRIPTION
This is until we support aggregates with secondary arguments, which is
needed to implement the more general function `STRING_AGG` (
https://www.postgresql.org/docs/9.2/static/functions-aggregate.html ).

`string_agg()` can be met half way with `ltrim(concat_agg(col||delim),
delim)`.

(Implemented while investigating the registration cluster)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9690)

<!-- Reviewable:end -->
