### PR TITLE
ui: stop excessive metrics queries

### DIFF
--- a/ui/app/redux/metrics.spec.ts
+++ b/ui/app/redux/metrics.spec.ts
@@ -123,7 +123,6 @@ describe("metrics reducer", function() {
       assert.lengthOf(_.keys(state.queries), 1);
       assert.equal(state.queries[componentID].data, response);
       assert.equal(state.queries[componentID].request, request);
-      assert.isUndefined(state.queries[componentID].nextRequest);
       assert.isUndefined(state.queries[componentID].error);
     });
 

--- a/ui/app/redux/metrics.ts
+++ b/ui/app/redux/metrics.ts
@@ -83,7 +83,6 @@ function metricsQueryReducer(state: MetricsQuery, action: Action) {
         state = _.clone(state);
         state.data = response.data.response;
         state.request = response.data.request;
-        state.nextRequest = undefined;
         state.error = undefined;
       }
       return state;


### PR DESCRIPTION
When the nextRequest was cleared after a metrics query was
received, this caused refreshMetricsIfStale in
metricsDataProvider.tsx to refresh the query. There's no real need
to clear the nextRequest since it will never match any future
requests, so I have stopped clearing it for now.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9692)

<!-- Reviewable:end -->
