### PR TITLE
storage: wait for gossip connection before gossiping stores

### DIFF
--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -363,6 +363,7 @@ func (m *multiTestContext) Stop() {
 func (m *multiTestContext) gossipStores() {
 	timestamps := make(map[string]int64)
 	for i := 0; i < len(m.stores); i++ {
+		<-m.gossips[i].Connected
 		if err := m.stores[i].GossipStore(context.Background()); err != nil {
 			m.t.Fatal(err)
 		}


### PR DESCRIPTION
c2d55bd added a panic in `(*Store).GossipStore` which was being
triggered by test code refactored in 05de822.

Fixes #9685.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9693)

<!-- Reviewable:end -->
