### PR TITLE
glide.yaml: update grpc

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 1e0821f7c814849f40cf53d5e518335aad23fc69f58b3bc97b730d2a658b7ae2
-updated: 2016-12-13T11:56:12.606527563-05:00
+hash: c7659df3c8e53d7ca9210b38bfea490c45476d6cd028c876d6e20b257fcf139c
+updated: 2016-12-13T13:32:44.183863499-05:00
 imports:
 - name: cloud.google.com/go
   version: 9d965e63e8cceb1b5d7977a202f0fcb8866d6525
@@ -118,7 +118,7 @@ imports:
   subpackages:
   - oleutil
 - name: github.com/gogo/protobuf
-  version: ccdc7fbcb4cd13f34b76d7262805e58316faaaf4
+  version: 06ec6c31ff1bac6ed4e205a547a3d72934813ef3
   subpackages:
   - gogoproto
   - jsonpb
@@ -165,7 +165,7 @@ imports:
 - name: github.com/google/btree
   version: 0c3044bc8bada22db67b93f5760fe3f05d6a5c25
 - name: github.com/google/go-github
-  version: 939928b912496ed4fbeb6e4beb2467b4fa540af7
+  version: 466070b0580728e63bd1a415e0019639e55d7148
   subpackages:
   - github
 - name: github.com/google/go-querystring
@@ -392,7 +392,7 @@ imports:
   - socket
   - urlfetch
 - name: google.golang.org/grpc
-  version: 79b7c349179cdd6efd8bac4a1ce7f01b98c16e9b
+  version: 777daa17ff9b5daef1cfdf915088a2ada3332bf0
   subpackages:
   - codes
   - credentials

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,10 +1,5 @@
 package: github.com/cockroachdb/cockroach
 import:
-# TODO(tamird): remove when we upgrade.
-- package: github.com/gogo/protobuf
-  version: ccdc7fbcb4cd13f34b76d7262805e58316faaaf4
-- package: google.golang.org/grpc
-  version: 79b7c349179cdd6efd8bac4a1ce7f01b98c16e9b
 # TODO(tamird): remove when we upgrade to 4.3.1 or beyond.
 - package: github.com/cockroachdb/c-jemalloc
   version: 42e6a32cd7a4dff9c70d80323681d46d046181ef

--- a/pkg/gossip/gossip.pb.go
+++ b/pkg/gossip/gossip.pb.go
@@ -148,7 +148,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for Gossip service
 
@@ -243,7 +243,7 @@ var _Gossip_serviceDesc = grpc.ServiceDesc{
 			ClientStreams: true,
 		},
 	},
-	Metadata: fileDescriptorGossip,
+	Metadata: "cockroach/pkg/gossip/gossip.proto",
 }
 
 func (m *BootstrapInfo) Marshal() (dAtA []byte, err error) {

--- a/pkg/roachpb/api.pb.go
+++ b/pkg/roachpb/api.pb.go
@@ -1481,7 +1481,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for Internal service
 
@@ -1544,7 +1544,7 @@ var _Internal_serviceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: fileDescriptorApi,
+	Metadata: "cockroach/pkg/roachpb/api.proto",
 }
 
 // Client API for External service
@@ -1608,7 +1608,7 @@ var _External_serviceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: fileDescriptorApi,
+	Metadata: "cockroach/pkg/roachpb/api.proto",
 }
 
 func (m *RangeInfo) Marshal() (dAtA []byte, err error) {

--- a/pkg/rpc/heartbeat.pb.go
+++ b/pkg/rpc/heartbeat.pb.go
@@ -100,7 +100,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for Heartbeat service
 
@@ -163,7 +163,7 @@ var _Heartbeat_serviceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: fileDescriptorHeartbeat,
+	Metadata: "cockroach/pkg/rpc/heartbeat.proto",
 }
 
 func (m *RemoteOffset) Marshal() (dAtA []byte, err error) {

--- a/pkg/server/serverpb/admin.pb.go
+++ b/pkg/server/serverpb/admin.pb.go
@@ -682,7 +682,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for Admin service
 
@@ -1235,7 +1235,7 @@ var _Admin_serviceDesc = grpc.ServiceDesc{
 			ServerStreams: true,
 		},
 	},
-	Metadata: fileDescriptorAdmin,
+	Metadata: "cockroach/pkg/server/serverpb/admin.proto",
 }
 
 func (m *DatabasesRequest) Marshal() (dAtA []byte, err error) {

--- a/pkg/server/serverpb/status.pb.go
+++ b/pkg/server/serverpb/status.pb.go
@@ -383,7 +383,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for Status service
 
@@ -819,7 +819,7 @@ var _Status_serviceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: fileDescriptorStatus,
+	Metadata: "cockroach/pkg/server/serverpb/status.proto",
 }
 
 func (m *DetailsRequest) Marshal() (dAtA []byte, err error) {

--- a/pkg/sql/distsql/api.pb.go
+++ b/pkg/sql/distsql/api.pb.go
@@ -103,7 +103,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for DistSQL service
 
@@ -310,7 +310,7 @@ var _DistSQL_serviceDesc = grpc.ServiceDesc{
 			ClientStreams: true,
 		},
 	},
-	Metadata: fileDescriptorApi,
+	Metadata: "cockroach/pkg/sql/distsql/api.proto",
 }
 
 func (m *SetupFlowRequest) Marshal() (dAtA []byte, err error) {

--- a/pkg/storage/api.pb.go
+++ b/pkg/storage/api.pb.go
@@ -130,7 +130,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for Freeze service
 
@@ -193,7 +193,7 @@ var _Freeze_serviceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: fileDescriptorApi,
+	Metadata: "cockroach/pkg/storage/api.proto",
 }
 
 // Client API for Consistency service
@@ -257,7 +257,7 @@ var _Consistency_serviceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: fileDescriptorApi,
+	Metadata: "cockroach/pkg/storage/api.proto",
 }
 
 func (m *StoreRequestHeader) Marshal() (dAtA []byte, err error) {

--- a/pkg/storage/raft.pb.go
+++ b/pkg/storage/raft.pb.go
@@ -238,7 +238,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for MultiRaft service
 
@@ -398,7 +398,7 @@ var _MultiRaft_serviceDesc = grpc.ServiceDesc{
 			ClientStreams: true,
 		},
 	},
-	Metadata: fileDescriptorRaft,
+	Metadata: "cockroach/pkg/storage/raft.proto",
 }
 
 func (m *RaftHeartbeat) Marshal() (dAtA []byte, err error) {

--- a/pkg/ts/tspb/timeseries.pb.go
+++ b/pkg/ts/tspb/timeseries.pb.go
@@ -305,7 +305,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for TimeSeries service
 
@@ -370,7 +370,7 @@ var _TimeSeries_serviceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: fileDescriptorTimeseries,
+	Metadata: "cockroach/pkg/ts/tspb/timeseries.proto",
 }
 
 func (m *TimeSeriesDatapoint) Marshal() (dAtA []byte, err error) {


### PR DESCRIPTION
This update includes 118 commits.

https://github.com/grpc/grpc-go/compare/79b7c34...777daa1

Interesting PRs:

- Client side interceptors:
  grpc/grpc-go#867
- Stricter error handling:
  grpc/grpc-go#876
- More robust cancellation:
  grpc/grpc-go#882
- Fix context leak:
  grpc/grpc-go#891
- Client load balancing:
  grpc/grpc-go#899
- Fix quota miscounting:
  grpc/grpc-go#947

Also updates gogo/protobuf to pick up
gogo/protobuf@8d70fb3 which is required due
to the `grpc.SupportPackageIsVersion` mechanism.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9697)

<!-- Reviewable:end -->
