### PR TITLE
storage: rename StoreContext to StoreConfig

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -252,7 +252,7 @@ func NewServer(srvCtx Context, stopper *stop.Stopper) (*Server, error) {
 	s.registry.AddMetricStruct(s.pgServer.Metrics())
 
 	// TODO(bdarnell): make StoreConfig configurable.
-	nCtx := storage.StoreContext{
+	storeCfg := storage.StoreConfig{
 		Ctx:                            s.Ctx(),
 		Clock:                          s.clock,
 		DB:                             s.db,
@@ -274,7 +274,7 @@ func NewServer(srvCtx Context, stopper *stop.Stopper) (*Server, error) {
 		Locality: srvCtx.Locality,
 	}
 	if srvCtx.TestingKnobs.Store != nil {
-		nCtx.TestingKnobs = *srvCtx.TestingKnobs.Store.(*storage.StoreTestingKnobs)
+		storeCfg.TestingKnobs = *srvCtx.TestingKnobs.Store.(*storage.StoreTestingKnobs)
 	}
 
 	s.recorder = status.NewMetricsRecorder(s.clock)
@@ -283,7 +283,7 @@ func NewServer(srvCtx Context, stopper *stop.Stopper) (*Server, error) {
 	s.runtime = status.MakeRuntimeStatSampler(s.clock)
 	s.registry.AddMetricStruct(s.runtime)
 
-	s.node = NewNode(nCtx, s.recorder, s.registry, s.stopper, txnMetrics, sql.MakeEventLogger(s.leaseMgr))
+	s.node = NewNode(storeCfg, s.recorder, s.registry, s.stopper, txnMetrics, sql.MakeEventLogger(s.leaseMgr))
 	roachpb.RegisterInternalServer(s.grpc, s.node)
 	storage.RegisterConsistencyServer(s.grpc, s.node.storesServer)
 	storage.RegisterFreezeServer(s.grpc, s.node.storesServer)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -212,7 +212,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	tds := kv.NewTxnCoordSender(ctx, ds, s.Clock(), ts.Ctx.Linearizable,
 		ts.stopper, kv.MakeTxnMetrics())
 
-	if err := ts.node.ctx.DB.AdminSplit(context.TODO(), "m"); err != nil {
+	if err := ts.node.storeCfg.DB.AdminSplit(context.TODO(), "m"); err != nil {
 		t.Fatal(err)
 	}
 	writes := []roachpb.Key{roachpb.Key("a"), roachpb.Key("z")}
@@ -311,7 +311,7 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 			ts.stopper, kv.MakeTxnMetrics())
 
 		for _, sk := range tc.splitKeys {
-			if err := ts.node.ctx.DB.AdminSplit(context.TODO(), sk); err != nil {
+			if err := ts.node.storeCfg.DB.AdminSplit(context.TODO(), sk); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/storage/client_bench_test.go
+++ b/storage/client_bench_test.go
@@ -26,9 +26,9 @@ import (
 
 func BenchmarkReplicaSnapshot(b *testing.B) {
 	defer tracing.Disable()()
-	sCtx := TestStoreContext()
-	sCtx.TestingKnobs.DisableSplitQueue = true
-	store, _, stopper := createTestStoreWithContext(b, &sCtx)
+	storeCfg := TestStoreConfig()
+	storeCfg.TestingKnobs.DisableSplitQueue = true
+	store, _, stopper := createTestStoreWithContext(b, &storeCfg)
 	defer stopper.Stop()
 	// We want to manually control the size of the raft log.
 	store.SetRaftLogQueueActive(false)

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -67,9 +67,9 @@ func createSplitRanges(
 // TestStoreRangeMergeTwoEmptyRanges tries to merge two empty ranges together.
 func TestStoreRangeMergeTwoEmptyRanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sCtx := storage.TestStoreContext()
-	sCtx.TestingKnobs.DisableSplitQueue = true
-	store, stopper, _ := createTestStoreWithContext(t, sCtx)
+	storeCfg := storage.TestStoreConfig()
+	storeCfg.TestingKnobs.DisableSplitQueue = true
+	store, stopper, _ := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 
 	if _, _, err := createSplitRanges(store); err != nil {
@@ -96,9 +96,9 @@ func TestStoreRangeMergeTwoEmptyRanges(t *testing.T) {
 // subsumed range is cleaned up on merge.
 func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sCtx := storage.TestStoreContext()
-	sCtx.TestingKnobs.DisableSplitQueue = true
-	store, stopper, _ := createTestStoreWithContext(t, sCtx)
+	storeCfg := storage.TestStoreConfig()
+	storeCfg.TestingKnobs.DisableSplitQueue = true
+	store, stopper, _ := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 
 	scan := func(f func(roachpb.KeyValue) (bool, error)) {
@@ -175,9 +175,9 @@ func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 // each containing data.
 func TestStoreRangeMergeWithData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sCtx := storage.TestStoreContext()
-	sCtx.TestingKnobs.DisableSplitQueue = true
-	store, stopper, _ := createTestStoreWithContext(t, sCtx)
+	storeCfg := storage.TestStoreConfig()
+	storeCfg.TestingKnobs.DisableSplitQueue = true
+	store, stopper, _ := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 
 	content := roachpb.Key("testing!")
@@ -303,9 +303,9 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 // fails.
 func TestStoreRangeMergeLastRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sCtx := storage.TestStoreContext()
-	sCtx.TestingKnobs.DisableSplitQueue = true
-	store, stopper, _ := createTestStoreWithContext(t, sCtx)
+	storeCfg := storage.TestStoreConfig()
+	storeCfg.TestingKnobs.DisableSplitQueue = true
+	store, stopper, _ := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 
 	// Merge last range.
@@ -370,9 +370,9 @@ func TestStoreRangeMergeNonCollocated(t *testing.T) {
 // range has stats consistent with recomputations.
 func TestStoreRangeMergeStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sCtx := storage.TestStoreContext()
-	sCtx.TestingKnobs.DisableSplitQueue = true
-	store, stopper, manual := createTestStoreWithContext(t, sCtx)
+	storeCfg := storage.TestStoreConfig()
+	storeCfg.TestingKnobs.DisableSplitQueue = true
+	store, stopper, manual := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 
 	// Split the range.
@@ -429,9 +429,9 @@ func TestStoreRangeMergeStats(t *testing.T) {
 
 func BenchmarkStoreRangeMerge(b *testing.B) {
 	defer tracing.Disable()()
-	sCtx := storage.TestStoreContext()
-	sCtx.TestingKnobs.DisableSplitQueue = true
-	store, stopper, _ := createTestStoreWithContext(b, sCtx)
+	storeCfg := storage.TestStoreConfig()
+	storeCfg.TestingKnobs.DisableSplitQueue = true
+	store, stopper, _ := createTestStoreWithConfig(b, storeCfg)
 	defer stopper.Stop()
 
 	// Perform initial split of ranges.

--- a/storage/client_raft_log_queue_test.go
+++ b/storage/client_raft_log_queue_test.go
@@ -46,10 +46,10 @@ func TestRaftLogQueue(t *testing.T) {
 
 	// Turn off raft elections so the raft leader won't change out from under
 	// us in this test.
-	sc := storage.TestStoreContext()
+	sc := storage.TestStoreConfig()
 	sc.RaftTickInterval = time.Hour * 24
 	sc.RaftElectionTimeoutTicks = 1000000
-	mtc.storeContext = &sc
+	mtc.storeConfig = &sc
 
 	mtc.Start(t, 3)
 	defer mtc.Stop()

--- a/storage/client_replica_gc_test.go
+++ b/storage/client_replica_gc_test.go
@@ -45,9 +45,9 @@ func TestReplicaGCQueueDropReplicaDirect(t *testing.T) {
 	// no GC will take place since the consistent RangeLookup hits the first
 	// Node. We use the TestingCommandFilter to make sure that the second Node
 	// waits for the first.
-	ctx := storage.TestStoreContext()
-	mtc.storeContext = &ctx
-	mtc.storeContext.TestingKnobs.TestingCommandFilter =
+	cfg := storage.TestStoreConfig()
+	mtc.storeConfig = &cfg
+	mtc.storeConfig.TestingKnobs.TestingCommandFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			et, ok := filterArgs.Req.(*roachpb.EndTransactionRequest)
 			if !ok || filterArgs.Sid != 2 {

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -93,9 +93,9 @@ func TestStoreRangeSplitAtIllegalKeys(t *testing.T) {
 // UserTableDataMin and still gossip the SystemConfig properly.
 func TestStoreRangeSplitAtTablePrefix(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sCtx := storage.TestStoreContext()
-	sCtx.TestingKnobs.DisableSplitQueue = true
-	store, stopper, _ := createTestStoreWithContext(t, sCtx)
+	storeCfg := storage.TestStoreConfig()
+	storeCfg.TestingKnobs.DisableSplitQueue = true
+	store, stopper, _ := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 
 	key := keys.MakeRowSentinelKey(append([]byte(nil), keys.UserTableDataMin...))
@@ -145,9 +145,9 @@ func TestStoreRangeSplitAtTablePrefix(t *testing.T) {
 // a table row will cause a split at a boundary between rows.
 func TestStoreRangeSplitInsideRow(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sCtx := storage.TestStoreContext()
-	sCtx.TestingKnobs.DisableSplitQueue = true
-	store, stopper, _ := createTestStoreWithContext(t, sCtx)
+	storeCfg := storage.TestStoreConfig()
+	storeCfg.TestingKnobs.DisableSplitQueue = true
+	store, stopper, _ := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 
 	// Manually create some the column keys corresponding to the table:
@@ -198,9 +198,9 @@ func TestStoreRangeSplitInsideRow(t *testing.T) {
 // that all intents are cleared and the transaction record cleaned up.
 func TestStoreRangeSplitIntents(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sCtx := storage.TestStoreContext()
-	sCtx.TestingKnobs.DisableSplitQueue = true
-	store, stopper, _ := createTestStoreWithContext(t, sCtx)
+	storeCfg := storage.TestStoreConfig()
+	storeCfg.TestingKnobs.DisableSplitQueue = true
+	store, stopper, _ := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 
 	// First, write some values left and right of the proposed split key.
@@ -251,9 +251,9 @@ func TestStoreRangeSplitIntents(t *testing.T) {
 // to split at the start of the newly split range.
 func TestStoreRangeSplitAtRangeBounds(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sCtx := storage.TestStoreContext()
-	sCtx.TestingKnobs.DisableSplitQueue = true
-	store, stopper, _ := createTestStoreWithContext(t, sCtx)
+	storeCfg := storage.TestStoreConfig()
+	storeCfg.TestingKnobs.DisableSplitQueue = true
+	store, stopper, _ := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 
 	args := adminSplitArgs(roachpb.KeyMin, []byte("a"))
@@ -276,9 +276,9 @@ func TestStoreRangeSplitAtRangeBounds(t *testing.T) {
 // because the split key is invalid after the first split succeeds.
 func TestStoreRangeSplitConcurrent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sCtx := storage.TestStoreContext()
-	sCtx.TestingKnobs.DisableSplitQueue = true
-	store, stopper, _ := createTestStoreWithContext(t, sCtx)
+	storeCfg := storage.TestStoreConfig()
+	storeCfg.TestingKnobs.DisableSplitQueue = true
+	store, stopper, _ := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 
 	splitKey := roachpb.Key("a")
@@ -335,9 +335,9 @@ func TestStoreRangeSplitConcurrent(t *testing.T) {
 // can't be replayed.
 func TestStoreRangeSplitIdempotency(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sCtx := storage.TestStoreContext()
-	sCtx.TestingKnobs.DisableSplitQueue = true
-	store, stopper, _ := createTestStoreWithContext(t, sCtx)
+	storeCfg := storage.TestStoreConfig()
+	storeCfg.TestingKnobs.DisableSplitQueue = true
+	store, stopper, _ := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 	rangeID := roachpb.RangeID(1)
 	splitKey := roachpb.Key("m")
@@ -482,9 +482,9 @@ func TestStoreRangeSplitIdempotency(t *testing.T) {
 // the pre-split.
 func TestStoreRangeSplitStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sCtx := storage.TestStoreContext()
-	sCtx.TestingKnobs.DisableSplitQueue = true
-	store, stopper, manual := createTestStoreWithContext(t, sCtx)
+	storeCfg := storage.TestStoreConfig()
+	storeCfg.TestingKnobs.DisableSplitQueue = true
+	store, stopper, manual := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 
 	// Split the range after the last table data key.
@@ -589,9 +589,9 @@ func TestStoreRangeSplitStats(t *testing.T) {
 // requests' impact on MVCCStats are only estimated. See updateStatsOnMerge.
 func TestStoreRangeSplitStatsWithMerges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sCtx := storage.TestStoreContext()
-	sCtx.TestingKnobs.DisableSplitQueue = true
-	store, stopper, manual := createTestStoreWithContext(t, sCtx)
+	storeCfg := storage.TestStoreConfig()
+	storeCfg.TestingKnobs.DisableSplitQueue = true
+	store, stopper, manual := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 
 	// Split the range after the last table data key.
@@ -1087,9 +1087,9 @@ func TestStoreSplitTimestampCacheReadRace(t *testing.T) {
 
 	getContinues := make(chan struct{})
 	var getStarted sync.WaitGroup
-	sCtx := storage.TestStoreContext()
-	sCtx.TestingKnobs.DisableSplitQueue = true
-	sCtx.TestingKnobs.TestingCommandFilter =
+	storeCfg := storage.TestStoreConfig()
+	storeCfg.TestingKnobs.DisableSplitQueue = true
+	storeCfg.TestingKnobs.TestingCommandFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if et, ok := filterArgs.Req.(*roachpb.EndTransactionRequest); ok {
 				st := et.InternalCommitTrigger.GetSplitTrigger()
@@ -1104,7 +1104,7 @@ func TestStoreSplitTimestampCacheReadRace(t *testing.T) {
 			}
 			return nil
 		}
-	store, stopper, _ := createTestStoreWithContext(t, sCtx)
+	store, stopper, _ := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 
 	now := store.Clock().Now()
@@ -1318,12 +1318,12 @@ func TestStoreSplitTimestampCacheDifferentLeaseHolder(t *testing.T) {
 func TestStoreRangeSplitRaceUninitializedRHS(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	mtc := &multiTestContext{}
-	storeCtx := storage.TestStoreContext()
+	storeCfg := storage.TestStoreConfig()
 	// An aggressive tick interval lets groups communicate more and thus
 	// triggers test failures much more reliably. We can't go too aggressive
 	// or race tests never make any progress.
-	storeCtx.RaftTickInterval = 50 * time.Millisecond
-	storeCtx.RaftElectionTimeoutTicks = 2
+	storeCfg.RaftTickInterval = 50 * time.Millisecond
+	storeCfg.RaftElectionTimeoutTicks = 2
 	currentTrigger := make(chan *roachpb.SplitTrigger, 1)
 	var seen struct {
 		syncutil.Mutex
@@ -1331,7 +1331,7 @@ func TestStoreRangeSplitRaceUninitializedRHS(t *testing.T) {
 	}
 	seen.sids = make(map[storagebase.CmdIDKey][2]bool)
 
-	storeCtx.TestingKnobs.TestingCommandFilter = func(args storagebase.FilterArgs) *roachpb.Error {
+	storeCfg.TestingKnobs.TestingCommandFilter = func(args storagebase.FilterArgs) *roachpb.Error {
 		et, ok := args.Req.(*roachpb.EndTransactionRequest)
 		if !ok || et.InternalCommitTrigger == nil {
 			return nil
@@ -1365,7 +1365,7 @@ func TestStoreRangeSplitRaceUninitializedRHS(t *testing.T) {
 		return nil
 	}
 
-	mtc.storeContext = &storeCtx
+	mtc.storeConfig = &storeCfg
 	mtc.Start(t, 2)
 	defer mtc.Stop()
 
@@ -1447,10 +1447,10 @@ func TestStoreRangeSplitRaceUninitializedRHS(t *testing.T) {
 // elects a leader without waiting for an election timeout.
 func TestLeaderAfterSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	storeContext := storage.TestStoreContext()
-	storeContext.RaftElectionTimeoutTicks = 1000000
+	storeConfig := storage.TestStoreConfig()
+	storeConfig.RaftElectionTimeoutTicks = 1000000
 	mtc := &multiTestContext{
-		storeContext: &storeContext,
+		storeConfig: &storeConfig,
 	}
 	mtc.Start(t, 3)
 	defer mtc.Stop()
@@ -1479,9 +1479,9 @@ func TestLeaderAfterSplit(t *testing.T) {
 
 func BenchmarkStoreRangeSplit(b *testing.B) {
 	defer tracing.Disable()()
-	sCtx := storage.TestStoreContext()
-	sCtx.TestingKnobs.DisableSplitQueue = true
-	store, stopper, _ := createTestStoreWithContext(b, sCtx)
+	storeCfg := storage.TestStoreConfig()
+	storeCfg.TestingKnobs.DisableSplitQueue = true
+	store, stopper, _ := createTestStoreWithConfig(b, storeCfg)
 	defer stopper.Stop()
 
 	// Perform initial split of ranges.
@@ -1615,9 +1615,9 @@ func TestStoreSplitBeginTxnPushMetaIntentRace(t *testing.T) {
 
 	wroteMeta2 := make(chan struct{}, 1)
 
-	sCtx := storage.TestStoreContext()
-	sCtx.TestingKnobs.DisableSplitQueue = true
-	sCtx.TestingKnobs.TestingCommandFilter = func(filterArgs storagebase.FilterArgs) *roachpb.Error {
+	storeCfg := storage.TestStoreConfig()
+	storeCfg.TestingKnobs.DisableSplitQueue = true
+	storeCfg.TestingKnobs.TestingCommandFilter = func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 		startMu.Lock()
 		start := startMu.time
 		startMu.Unlock()
@@ -1644,7 +1644,7 @@ func TestStoreSplitBeginTxnPushMetaIntentRace(t *testing.T) {
 		}
 		return nil
 	}
-	store, stopper, manual := createTestStoreWithContext(t, sCtx)
+	store, stopper, manual := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 
 	// Advance the clock past the transaction cleanup expiration.

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -432,7 +432,7 @@ func TestGCQueueTransactionTable(t *testing.T) {
 	resolved := map[string][]roachpb.Span{}
 
 	tc := testContext{}
-	tsc := TestStoreContext()
+	tsc := TestStoreConfig()
 	tsc.TestingKnobs.TestingCommandFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if resArgs, ok := filterArgs.Req.(*roachpb.ResolveIntentRequest); ok {
@@ -449,7 +449,7 @@ func TestGCQueueTransactionTable(t *testing.T) {
 			}
 			return nil
 		}
-	tc.StartWithStoreContext(t, tsc)
+	tc.StartWithStoreConfig(t, tsc)
 	defer tc.Stop()
 	tc.manualClock.Set(int64(now))
 

--- a/storage/helpers_test.go
+++ b/storage/helpers_test.go
@@ -55,11 +55,11 @@ func (s *Store) ComputeMVCCStats() (enginepb.MVCCStats, error) {
 
 func forceScanAndProcess(s *Store, q *baseQueue) {
 	newStoreRangeSet(s).Visit(func(repl *Replica) bool {
-		q.MaybeAdd(repl, s.ctx.Clock.Now())
+		q.MaybeAdd(repl, s.cfg.Clock.Now())
 		return true
 	})
 
-	q.DrainQueue(s.ctx.Clock)
+	q.DrainQueue(s.cfg.Clock)
 }
 
 // ForceReplicationScanAndProcess iterates over all ranges and
@@ -91,7 +91,7 @@ func (s *Store) LeaseExpiration(clock *hlc.Clock) int64 {
 	// Due to lease extensions, the remaining interval can be longer than just
 	// the sum of the offset (=length of stasis period) and the active
 	// duration, but definitely not by 2x.
-	return 2 * int64(s.ctx.rangeLeaseActiveDuration+clock.MaxOffset())
+	return 2 * int64(s.cfg.rangeLeaseActiveDuration+clock.MaxOffset())
 }
 
 // LogReplicaChangeTest adds a fake replica change event to the log for the

--- a/storage/id_alloc_test.go
+++ b/storage/id_alloc_test.go
@@ -43,7 +43,7 @@ func TestIDAllocator(t *testing.T) {
 	store, _, stopper := createTestStore(t)
 	defer stopper.Stop()
 	allocd := make(chan int, 100)
-	idAlloc, err := newIDAllocator(context.TODO(), keys.RangeIDGenerator, store.ctx.DB, 2, 10, stopper)
+	idAlloc, err := newIDAllocator(context.TODO(), keys.RangeIDGenerator, store.cfg.DB, 2, 10, stopper)
 	if err != nil {
 		t.Errorf("failed to create idAllocator: %v", err)
 	}
@@ -91,14 +91,14 @@ func TestIDAllocatorNegativeValue(t *testing.T) {
 	defer stopper.Stop()
 
 	// Increment our key to a negative value.
-	newValue, err := engine.MVCCIncrement(context.Background(), store.Engine(), nil, keys.RangeIDGenerator, store.ctx.Clock.Now(), nil, -1024)
+	newValue, err := engine.MVCCIncrement(context.Background(), store.Engine(), nil, keys.RangeIDGenerator, store.cfg.Clock.Now(), nil, -1024)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if newValue != -1024 {
 		t.Errorf("expected new value to be -1024; got %d", newValue)
 	}
-	idAlloc, err := newIDAllocator(context.TODO(), keys.RangeIDGenerator, store.ctx.DB, 2, 10, stopper)
+	idAlloc, err := newIDAllocator(context.TODO(), keys.RangeIDGenerator, store.cfg.DB, 2, 10, stopper)
 	if err != nil {
 		t.Errorf("failed to create IDAllocator: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 	allocd := make(chan int, 10)
 
 	// Firstly create a valid IDAllocator to get some ID.
-	idAlloc, err := newIDAllocator(context.TODO(), keys.RangeIDGenerator, store.ctx.DB, 2, 10, stopper)
+	idAlloc, err := newIDAllocator(context.TODO(), keys.RangeIDGenerator, store.cfg.DB, 2, 10, stopper)
 	if err != nil {
 		t.Errorf("failed to create IDAllocator: %v", err)
 	}
@@ -222,7 +222,7 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 func TestAllocateWithStopper(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	store, _, stopper := createTestStore(t)
-	idAlloc, err := newIDAllocator(context.TODO(), keys.RangeIDGenerator, store.ctx.DB, 2, 10, stopper)
+	idAlloc, err := newIDAllocator(context.TODO(), keys.RangeIDGenerator, store.cfg.DB, 2, 10, stopper)
 	if err != nil {
 		log.Fatal(context.Background(), err)
 	}

--- a/storage/log.go
+++ b/storage/log.go
@@ -105,7 +105,7 @@ VALUES(
 		s.metrics.RangeRemoves.Inc(1)
 	}
 
-	rows, err := s.ctx.SQLExecutor.ExecuteStatementInTransaction(txn, insertEventTableStmt, args...)
+	rows, err := s.cfg.SQLExecutor.ExecuteStatementInTransaction(txn, insertEventTableStmt, args...)
 	if err != nil {
 		return err
 	}
@@ -121,7 +121,7 @@ VALUES(
 // TODO(mrtracy): There are several different reasons that a replica split
 // could occur, and that information should be logged.
 func (s *Store) logSplit(txn *client.Txn, updatedDesc, newDesc roachpb.RangeDescriptor) error {
-	if !s.ctx.LogRangeEvents {
+	if !s.cfg.LogRangeEvents {
 		return nil
 	}
 	info := struct {
@@ -153,7 +153,7 @@ func (s *Store) logChange(
 	replica roachpb.ReplicaDescriptor,
 	desc roachpb.RangeDescriptor,
 ) error {
-	if !s.ctx.LogRangeEvents {
+	if !s.cfg.LogRangeEvents {
 		return nil
 	}
 

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -281,9 +281,9 @@ func TestBaseQueueAdd(t *testing.T) {
 // processed according to the timer function.
 func TestBaseQueueProcess(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	tsc := TestStoreContext()
+	tsc := TestStoreConfig()
 	tc := testContext{}
-	tc.StartWithStoreContext(t, tsc)
+	tc.StartWithStoreConfig(t, tsc)
 	defer tc.Stop()
 
 	// Remove replica for range 1 since it encompasses the entire keyspace.
@@ -442,14 +442,14 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 		},
 	}
 
-	bq := makeTestBaseQueue("test", testQueue, s, s.ctx.Gossip, queueConfig{maxSize: 2})
-	bq.Start(s.ctx.Clock, stopper)
+	bq := makeTestBaseQueue("test", testQueue, s, s.cfg.Gossip, queueConfig{maxSize: 2})
+	bq.Start(s.cfg.Clock, stopper)
 
 	// Check our config.
 	var sysCfg config.SystemConfig
 	util.SucceedsSoon(t, func() error {
 		var ok bool
-		sysCfg, ok = s.ctx.Gossip.GetSystemConfig()
+		sysCfg, ok = s.cfg.Gossip.GetSystemConfig()
 		if !ok {
 			return errors.New("system config not yet present")
 		}
@@ -530,9 +530,9 @@ func (*testError) purgatoryErrorMarker() {
 // the purgatory channel causes the replicas to be reprocessed.
 func TestBaseQueuePurgatory(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	tsc := TestStoreContext()
+	tsc := TestStoreConfig()
 	tc := testContext{}
-	tc.StartWithStoreContext(t, tsc)
+	tc.StartWithStoreConfig(t, tsc)
 	defer tc.Stop()
 
 	testQueue := &testQueueImpl{

--- a/storage/replica_data_iter_test.go
+++ b/storage/replica_data_iter_test.go
@@ -138,14 +138,14 @@ func TestReplicaDataIteratorEmptyRange(t *testing.T) {
 // it verifies the pre and post ranges still contain the expected data.
 func TestReplicaDataIterator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	ctx := TestStoreContext()
+	cfg := TestStoreConfig()
 	// Disable Raft processing for this test as it mucks with low-level details
 	// of replica storage in an unsafe way.
-	ctx.TestingKnobs.DisableProcessRaft = true
+	cfg.TestingKnobs.DisableProcessRaft = true
 	tc := testContext{
 		bootstrapMode: bootstrapRangeOnly,
 	}
-	tc.StartWithStoreContext(t, ctx)
+	tc.StartWithStoreConfig(t, cfg)
 	defer tc.Stop()
 
 	// See notes in EmptyRange test method for adjustment to descriptor.

--- a/storage/replica_raftstorage_test.go
+++ b/storage/replica_raftstorage_test.go
@@ -57,9 +57,9 @@ func fillTestRange(t testing.TB, rep *Replica, size int64) {
 
 func TestSkipLargeReplicaSnapshot(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sCtx := TestStoreContext()
-	sCtx.TestingKnobs.DisableSplitQueue = true
-	store, _, stopper := createTestStoreWithContext(t, &sCtx)
+	storeCfg := TestStoreConfig()
+	storeCfg.TestingKnobs.DisableSplitQueue = true
+	store, _, stopper := createTestStoreWithContext(t, &storeCfg)
 	defer stopper.Stop()
 
 	const snapSize = 1 << 20 // 1 MiB

--- a/storage/replica_range_lease.go
+++ b/storage/replica_range_lease.go
@@ -95,7 +95,7 @@ func (p *pendingLeaseRequest) InitOrJoinRequest(
 	// No request in progress. Let's propose a Lease command asynchronously.
 	// TODO(tschottdorf): get duration from configuration, either as a
 	// config flag or, later, dynamically adjusted.
-	startStasis := timestamp.Add(int64(replica.store.ctx.rangeLeaseActiveDuration), 0)
+	startStasis := timestamp.Add(int64(replica.store.cfg.rangeLeaseActiveDuration), 0)
 	expiration := startStasis.Add(int64(replica.store.Clock().MaxOffset()), 0)
 	reqSpan := roachpb.Span{
 		Key: startKey,

--- a/storage/stores_test.go
+++ b/storage/stores_test.go
@@ -131,10 +131,10 @@ func TestStoresLookupReplica(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	ctx := TestStoreContext()
+	cfg := TestStoreConfig()
 	manualClock := hlc.NewManualClock(0)
-	ctx.Clock = hlc.NewClock(manualClock.UnixNano)
-	ls := NewStores(context.TODO(), ctx.Clock)
+	cfg.Clock = hlc.NewClock(manualClock.UnixNano)
+	ls := NewStores(context.TODO(), cfg.Clock)
 
 	// Create two new stores with ranges we care about.
 	var e [2]engine.Engine
@@ -149,8 +149,8 @@ func TestStoresLookupReplica(t *testing.T) {
 	}
 	for i, rng := range ranges {
 		e[i] = engine.NewInMem(roachpb.Attributes{}, 1<<20, stopper)
-		ctx.Transport = NewDummyRaftTransport()
-		s[i] = NewStore(ctx, e[i], &roachpb.NodeDescriptor{NodeID: 1})
+		cfg.Transport = NewDummyRaftTransport()
+		s[i] = NewStore(cfg, e[i], &roachpb.NodeDescriptor{NodeID: 1})
 		s[i].Ident.StoreID = rng.storeID
 
 		d[i] = &roachpb.RangeDescriptor{
@@ -230,16 +230,16 @@ var storeIDAlloc roachpb.StoreID
 // createStores creates a slice of count stores.
 func createStores(count int, t *testing.T) (*hlc.ManualClock, []*Store, *Stores, *stop.Stopper) {
 	stopper := stop.NewStopper()
-	ctx := TestStoreContext()
+	cfg := TestStoreConfig()
 	manualClock := hlc.NewManualClock(0)
-	ctx.Clock = hlc.NewClock(manualClock.UnixNano)
-	ls := NewStores(context.TODO(), ctx.Clock)
+	cfg.Clock = hlc.NewClock(manualClock.UnixNano)
+	ls := NewStores(context.TODO(), cfg.Clock)
 
 	// Create two stores with ranges we care about.
 	stores := []*Store{}
 	for i := 0; i < 2; i++ {
-		ctx.Transport = NewDummyRaftTransport()
-		s := NewStore(ctx, engine.NewInMem(roachpb.Attributes{}, 1<<20, stopper), &roachpb.NodeDescriptor{NodeID: 1})
+		cfg.Transport = NewDummyRaftTransport()
+		s := NewStore(cfg, engine.NewInMem(roachpb.Attributes{}, 1<<20, stopper), &roachpb.NodeDescriptor{NodeID: 1})
 		storeIDAlloc++
 		s.Ident.StoreID = storeIDAlloc
 		stores = append(stores, s)

--- a/testutils/localtestcluster/local_test_cluster.go
+++ b/testutils/localtestcluster/local_test_cluster.go
@@ -107,16 +107,16 @@ func (ltc *LocalTestCluster) Start(t util.Tester, baseCtx *base.Context, initSen
 	}
 	ltc.DB = client.NewDBWithContext(ltc.Sender, *ltc.DBContext)
 	transport := storage.NewDummyRaftTransport()
-	ctx := storage.TestStoreContext()
+	cfg := storage.TestStoreConfig()
 	if ltc.RangeRetryOptions != nil {
-		ctx.RangeRetryOptions = *ltc.RangeRetryOptions
+		cfg.RangeRetryOptions = *ltc.RangeRetryOptions
 	}
-	ctx.Ctx = tracing.WithTracer(clusterCtx, tracer)
-	ctx.Clock = ltc.Clock
-	ctx.DB = ltc.DB
-	ctx.Gossip = ltc.Gossip
-	ctx.Transport = transport
-	ltc.Store = storage.NewStore(ctx, ltc.Eng, nodeDesc)
+	cfg.Ctx = tracing.WithTracer(clusterCtx, tracer)
+	cfg.Clock = ltc.Clock
+	cfg.DB = ltc.DB
+	cfg.Gossip = ltc.Gossip
+	cfg.Transport = transport
+	ltc.Store = storage.NewStore(cfg, ltc.Eng, nodeDesc)
 	if err := ltc.Store.Bootstrap(roachpb.StoreIdent{NodeID: nodeID, StoreID: 1}, ltc.Stopper); err != nil {
 		t.Fatalf("unable to start local test cluster: %s", err)
 	}


### PR DESCRIPTION
Also renaming all related names (variables, members) accordingly.

This is a revival of #8478.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9699)

<!-- Reviewable:end -->
