### PR TITLE
acceptance/cli: accept 'connection reset' as alternate connection failure

### DIFF
--- a/cli/interactive_tests/test_reconnect.tcl
+++ b/cli/interactive_tests/test_reconnect.tcl
@@ -20,7 +20,11 @@ eexpect root@
 
 send "select 1;\r"
 eexpect "opening new connection"
-eexpect "connection refused"
+expect {
+    "connection refused" {}
+    "connection reset by peer" {}
+    timeout {exit 1}
+}
 eexpect root@
 
 # Check that the client automatically reconnects when the server goes up again.


### PR DESCRIPTION
Fixes #9696.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9701)

<!-- Reviewable:end -->
