### PR TITLE
cli: UX improvements to the sql CLI

### DIFF
--- a/cli/interactive_tests/test_history.tcl
+++ b/cli/interactive_tests/test_history.tcl
@@ -25,7 +25,7 @@ eexpect root@
 send "foo;\r"
 eexpect "syntax error"
 eexpect root@
-send "\022SEL"
+send "\022sel"
 eexpect "SELECT 1;"
 
 # Test that recalled previous line can be executed
@@ -49,10 +49,17 @@ send "\004"
 eexpect eof
 
 # Test that history is preserved across runs
-spawn /cockroach/cockroach sql
+spawn $argv sql
 eexpect root@
 send "\033\[A"
 eexpect "SELECT 1;"
+
+# Test that the client cannot terminate with Ctrl+C while
+# cursor is on recalled line
+send "\003"
+send "\rselect 1;\r"
+eexpect "1 row"
+eexpect root@
 
 # Finally terminate with Ctrl+C
 send "\003"

--- a/cli/interactive_tests/test_multiline_statements.tcl
+++ b/cli/interactive_tests/test_multiline_statements.tcl
@@ -32,6 +32,14 @@ eexpect "root@"
 send "\033\[A"
 eexpect "SELECT 1, 2, 3;"
 
+# Test that Ctrl+C after the first line merely cancels the statement and presents the prompt.
+send "\r"
+eexpect root@
+send "SELECT\r"
+eexpect " ->"
+send "\003"
+eexpect root@
+
 send "\003"
 eexpect eof
 


### PR DESCRIPTION
- enable case-insensitive search through the history. This way
  statements normalized to uppercase can be searched lowercase.
- ensure that Ctrl+C only terminates the prompt when entered
  at the beginning of a fresh statement. Otherwise it merely
  cancels the statement and presents the prompt anew.

cc @bdarnell

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9704)

<!-- Reviewable:end -->
