### PR TITLE
storage: skipping TestGetTruncatableIndexes due to flakiness

### DIFF
--- a/storage/raft_log_queue_test.go
+++ b/storage/raft_log_queue_test.go
@@ -109,6 +109,7 @@ func TestComputeTruncatableIndex(t *testing.T) {
 // removed.
 func TestGetTruncatableIndexes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("#9445 Skipped due to flakiness")
 	store, _, stopper := createTestStore(t)
 	defer stopper.Stop()
 	if _, err := store.GetReplica(0); err == nil {


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9706)

<!-- Reviewable:end -->
