### PR TITLE
sql: use 3 node cluster in backup/restore tests

### DIFF
--- a/sql/backup_test.go
+++ b/sql/backup_test.go
@@ -200,7 +200,7 @@ func setupReplicationAndLeases(
 	}
 }
 
-func TestBackupRestore(t *testing.T) {
+func TestBackupRestoreOnce(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 	// TODO(dan): Actually invalidate the descriptor cache and delete this line.
@@ -209,11 +209,7 @@ func TestBackupRestore(t *testing.T) {
 	dir, cleanupFn := testingTempDir(t, 1)
 	defer cleanupFn()
 
-	// TODO(dan): Increase this clusterSize to 3. It works if the test timeout
-	// is raised and with a util.SucceedsSoon wrapped around Backup, Restore,
-	// and every sql Exec, but it seems like we should be fixing the underlying
-	// issues.
-	const clusterSize = 1
+	const clusterSize = 3
 	const count = 1000
 
 	{
@@ -324,11 +320,7 @@ func TestBackupRestoreBank(t *testing.T) {
 	baseDir, cleanupFn := testingTempDir(t, 1)
 	defer cleanupFn()
 
-	// TODO(dan): Increase this clusterSize to 3. It works if the test timeout
-	// is raised and with a util.SucceedsSoon wrapped around Backup, Restore,
-	// and every sql Exec, but it seems like we should be fixing the underlying
-	// issues.
-	const clusterSize = 1
+	const clusterSize = 3
 	const numAccounts = 10
 	const backupRestoreIterations = 10
 


### PR DESCRIPTION
Looks like the recent stability work has resolved whatever issues I was seeing
before.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9717)

<!-- Reviewable:end -->
