### PR TITLE
cli: Remove deprecated http-addr flag

### DIFF
--- a/cli/cliflags/flags.go
+++ b/cli/cliflags/flags.go
@@ -200,12 +200,6 @@ communication; it must resolve from other nodes in the cluster.`,
 		Description: `The port to bind to for HTTP requests.`,
 	}
 
-	// TODO(#9516): Remove this.
-	ServerHTTPAddr = FlagInfo{
-		Name:        "http-addr",
-		Description: `DEPRECATED: Use http-host instead.`,
-	}
-
 	Socket = FlagInfo{
 		Name:   "socket",
 		EnvVar: "COCKROACH_SOCKET",

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -42,7 +42,7 @@ import (
 var maxResults int64
 
 var connURL, connUser, connHost, connPort, advertiseHost string
-var httpHost, httpPort, httpAddr, connDBName, zoneConfig string
+var httpHost, httpPort, connDBName, zoneConfig string
 var zoneDisableReplication bool
 var startBackground bool
 var undoFreezeCluster bool
@@ -294,7 +294,6 @@ func init() {
 		stringFlag(f, &advertiseHost, cliflags.AdvertiseHost, "")
 		stringFlag(f, &httpHost, cliflags.ServerHTTPHost, "")
 		stringFlag(f, &httpPort, cliflags.ServerHTTPPort, base.DefaultHTTPPort)
-		stringFlag(f, &httpAddr, cliflags.ServerHTTPAddr, "")
 		stringFlag(f, &serverCtx.Attrs, cliflags.Attrs, serverCtx.Attrs)
 		varFlag(f, &serverCtx.Locality, cliflags.Locality)
 
@@ -438,14 +437,8 @@ func extraFlagInit() {
 	}
 	serverCtx.AdvertiseAddr = net.JoinHostPort(advertiseHost, connPort)
 
-	// Temporarily support both httpHost and httpAddr, preferring httpHost.
-	// TODO(#9516): Remove httpAddr.
 	if httpHost == "" {
-		if httpAddr != "" {
-			httpHost = httpAddr
-		} else {
-			httpHost = connHost
-		}
+		httpHost = connHost
 	}
 	serverCtx.HTTPAddr = net.JoinHostPort(httpHost, httpPort)
 }

--- a/cli/flags_test.go
+++ b/cli/flags_test.go
@@ -109,21 +109,11 @@ func TestHttpHostFlagValue(t *testing.T) {
 		// confirm IPv6 works too
 		{[]string{"start", "--" + cliflags.ServerHTTPHost.Name, "::1"}, "[::1]:" + base.DefaultHTTPPort},
 		{[]string{"start", "--" + cliflags.ServerHTTPHost.Name, "2622:6221:e663:4922:fc2b:788b:fadd:7b48"}, "[2622:6221:e663:4922:fc2b:788b:fadd:7b48]:" + base.DefaultHTTPPort},
-		// confirm that http-addr still works
-		{[]string{"start", "--" + cliflags.ServerHTTPAddr.Name, "127.0.0.1"}, "127.0.0.1:" + base.DefaultHTTPPort},
-		{[]string{"start", "--" + cliflags.ServerHTTPAddr.Name, "192.168.0.111"}, "192.168.0.111:" + base.DefaultHTTPPort},
-		{[]string{"start", "--" + cliflags.ServerHTTPAddr.Name, "my.host.name"}, "my.host.name:" + base.DefaultHTTPPort},
-		{[]string{"start", "--" + cliflags.ServerHTTPAddr.Name, "myhostname"}, "myhostname:" + base.DefaultHTTPPort},
-		{[]string{"start", "--" + cliflags.ServerHTTPAddr.Name, "::1"}, "[::1]:" + base.DefaultHTTPPort},
-		{[]string{"start", "--" + cliflags.ServerHTTPAddr.Name, "2622:6221:e663:4922:fc2b:788b:fadd:7b48"}, "[2622:6221:e663:4922:fc2b:788b:fadd:7b48]:" + base.DefaultHTTPPort},
-		// confirm that http-host is preferred over http-addr
-		{[]string{"start", "--" + cliflags.ServerHTTPHost.Name, "127.0.0.1", "--" + cliflags.ServerHTTPAddr.Name, "192.168.0.111"}, "127.0.0.1:" + base.DefaultHTTPPort},
 	}
 
 	for i, td := range testData {
-		// Ensure each test case starts with empty package-level variables
+		// Ensure each test case starts with an empty package-level variable.
 		httpHost = ""
-		httpAddr = ""
 
 		if err := f.Parse(td.args); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
The Sept 29 release included the new http-host flag which replaces this, and it appears as though @jseldess updated the docs in https://github.com/cockroachdb/docs/pull/701

Fixes #9516

@tamird

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9725)

<!-- Reviewable:end -->
