### PR TITLE
tracing: return spans instead of cleanup functions

### DIFF
--- a/sql/distsql/joinreader.go
+++ b/sql/distsql/joinreader.go
@@ -98,8 +98,8 @@ func (jr *joinReader) mainLoop() error {
 	var alloc sqlbase.DatumAlloc
 	spans := make(roachpb.Spans, 0, joinReaderBatchSize)
 
-	ctx, closeSpan := tracing.ChildSpan(jr.ctx, "join reader")
-	defer closeSpan()
+	ctx, span := tracing.ChildSpan(jr.ctx, "join reader")
+	defer tracing.FinishSpan(span)
 
 	log.VEventf(1, ctx, "starting (filter: %s)", jr.filter)
 	if log.V(1) {

--- a/sql/distsql/sorter.go
+++ b/sql/distsql/sorter.go
@@ -57,8 +57,8 @@ func (s *sorter) Run(wg *sync.WaitGroup) {
 		defer wg.Done()
 	}
 
-	ctx, closeSpan := tracing.ChildSpan(s.ctx, "sorter")
-	defer closeSpan()
+	ctx, span := tracing.ChildSpan(s.ctx, "sorter")
+	defer tracing.FinishSpan(span)
 
 	if log.V(2) {
 		log.Infof(ctx, "starting sorter run")

--- a/sql/distsql/tablereader.go
+++ b/sql/distsql/tablereader.go
@@ -99,8 +99,8 @@ func (tr *tableReader) Run(wg *sync.WaitGroup) {
 		defer wg.Done()
 	}
 
-	ctx, closeSpan := tracing.ChildSpan(tr.ctx, "table reader")
-	defer closeSpan()
+	ctx, span := tracing.ChildSpan(tr.ctx, "table reader")
+	defer tracing.FinishSpan(span)
 
 	log.VEventf(1, ctx, "starting (filter: %s)", tr.filter)
 	if log.V(1) {

--- a/util/stop/stopper.go
+++ b/util/stop/stopper.go
@@ -229,13 +229,13 @@ func (s *Stopper) RunAsyncTask(ctx context.Context, f func(context.Context)) err
 		return errUnavailable
 	}
 
-	ctx, doneFn := tracing.ForkCtxSpan(ctx, fmt.Sprintf("%s:%d", file, line))
+	ctx, span := tracing.ForkCtxSpan(ctx, fmt.Sprintf("%s:%d", file, line))
 
 	// Call f.
 	go func() {
 		defer s.Recover()
 		defer s.runPostlude(key)
-		defer doneFn()
+		defer tracing.FinishSpan(span)
 		f(ctx)
 	}()
 	return nil
@@ -273,13 +273,13 @@ func (s *Stopper) RunLimitedAsyncTask(
 		return errUnavailable
 	}
 
-	ctx, doneFn := tracing.ForkCtxSpan(ctx, fmt.Sprintf("%s:%d", file, line))
+	ctx, span := tracing.ForkCtxSpan(ctx, fmt.Sprintf("%s:%d", file, line))
 
 	go func() {
 		defer s.Recover()
 		defer s.runPostlude(key)
 		defer func() { <-sem }()
-		defer doneFn()
+		defer tracing.FinishSpan(span)
 		f(ctx)
 	}()
 	return nil

--- a/util/tracing/tracer.go
+++ b/util/tracing/tracer.go
@@ -107,37 +107,47 @@ func NewTracerAndSpanFor7881(
 	return sp, tr, err
 }
 
+// FinishSpan closes the given span (if not nil). It is a convenience wrapper
+// for span.Finish() which tolerates nil spans.
+func FinishSpan(span opentracing.Span) {
+	if span != nil {
+		span.Finish()
+	}
+}
+
 // ForkCtxSpan checks if ctx has a Span open; if it does, it creates a new Span
 // that follows from the original Span. This allows the resulting context to be
 // used in an async task that might outlive the original operation.
 //
-// Returns the new context and a function that closes the span.
-func ForkCtxSpan(ctx context.Context, opName string) (context.Context, func()) {
+// Returns the new context and the new span (if any). The span should be
+// closed via FinishSpan.
+func ForkCtxSpan(ctx context.Context, opName string) (context.Context, opentracing.Span) {
 	if span := opentracing.SpanFromContext(ctx); span != nil {
 		if span.BaggageItem(Snowball) == "1" {
 			// If we are doing snowball tracing, the span might outlive the snowball
 			// tracer (calling the record function when it is no longer legal to do
 			// so). Return a context with no span in this case.
-			return opentracing.ContextWithSpan(ctx, nil), func() {}
+			return opentracing.ContextWithSpan(ctx, nil), nil
 		}
 		tr := span.Tracer()
 		newSpan := tr.StartSpan(opName, opentracing.FollowsFrom(span.Context()))
-		return opentracing.ContextWithSpan(ctx, newSpan), func() { newSpan.Finish() }
+		return opentracing.ContextWithSpan(ctx, newSpan), newSpan
 	}
-	return ctx, func() {}
+	return ctx, nil
 }
 
 // ChildSpan opens a span as a child of the current span in the context (if
 // there is one).
 //
-// Returns the new context and a function that closes the span.
-func ChildSpan(ctx context.Context, opName string) (context.Context, func()) {
+// Returns the new context and the new span (if any). The span should be
+// closed via FinishSpan.
+func ChildSpan(ctx context.Context, opName string) (context.Context, opentracing.Span) {
 	span := opentracing.SpanFromContext(ctx)
 	if span == nil {
-		return ctx, func() {}
+		return ctx, nil
 	}
 	newSpan := span.Tracer().StartSpan(opName, opentracing.ChildOf(span.Context()))
-	return opentracing.ContextWithSpan(ctx, newSpan), func() { newSpan.Finish() }
+	return opentracing.ContextWithSpan(ctx, newSpan), newSpan
 }
 
 // basicTracerOptions initializes options for basictracer.


### PR DESCRIPTION
The functions that create child spans now return a (possibly `nil`) `Span` which
can be closed using `FinishSpan()`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9728)

<!-- Reviewable:end -->
