### PR TITLE
storage: set RangeNotFoundError when Replica deleted

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -618,8 +618,7 @@ func (r *Replica) Destroy(origDesc roachpb.RangeDescriptor, destroyData bool) er
 	// Clear the map.
 	r.mu.pendingCmds = map[storagebase.CmdIDKey]*pendingCmd{}
 	r.mu.internalRaftGroup = nil
-	r.mu.destroyed = errors.Errorf("replica %d (range %d) was garbage collected",
-		r.mu.replicaID, r.RangeID)
+	r.mu.destroyed = roachpb.NewRangeNotFoundError(r.RangeID)
 	r.mu.Unlock()
 
 	if !destroyData {

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -493,9 +493,18 @@ func TestStoreRemoveReplicaDestroy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	const expected = "replica .* was garbage collected"
-	if _, _, err := rng1.proposeRaftCommand(context.Background(), roachpb.BatchRequest{}); !testutils.IsError(err, expected) {
-		t.Fatalf("expected error %s, but got %v", expected, err)
+	rng1.mu.Lock()
+	expErr := rng1.mu.destroyed
+	rng1.mu.Unlock()
+
+	if expErr == nil {
+		t.Fatal("replica was not marked as destroyed")
+	}
+
+	if _, _, err := rng1.proposeRaftCommand(
+		context.Background(), roachpb.BatchRequest{},
+	); err != expErr {
+		t.Fatalf("expected error %s, but got %v", expErr, err)
 	}
 }
 


### PR DESCRIPTION
the previous unstructured error would occasionally bubble up to the caller (and
this would also happen in production). Instead, return a RangeNotFoundError.

This would occur in

```
make stress PKG=./storage TESTS=TestStoreRangeDownReplicate \
    STRESSFLAGS='-p 100 -stderr -maxfails 1 -regex "was garbage coll"'
    TESTTIMEOUT=30s<Paste>
```

after <2min.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9732)

<!-- Reviewable:end -->
