### PR TITLE
distsql: disallow copy of exprHelper

### DIFF
--- a/build/check-style.sh
+++ b/build/check-style.sh
@@ -159,7 +159,7 @@ TestUnconvert() {
 }
 
 TestUnused() {
-  ! unused -reflect=false -exported ./... | grep -vE 'sql/(pgwire/pgerror/codes.go|(parser/yacc(par|tab)))'
+  ! unused -reflect=false -exported ./... | grep -vE 'sql/(pgwire/pgerror/codes.go|parser/yacc(par|tab))|(field|type) noCopy '
 }
 
 TestStaticcheck() {

--- a/sql/distsql/expr.go
+++ b/sql/distsql/expr.go
@@ -77,6 +77,8 @@ func processExpression(exprSpec Expression, h *parser.IndexedVarHelper) (parser.
 // exprHelper implements the common logic around evaluating an expression that
 // depends on a set of values.
 type exprHelper struct {
+	noCopy noCopy
+
 	expr parser.TypedExpr
 	// vars is used to generate IndexedVars that are "backed" by
 	// the values in `row`.
@@ -89,7 +91,7 @@ type exprHelper struct {
 	datumAlloc sqlbase.DatumAlloc
 }
 
-func (eh exprHelper) String() string {
+func (eh *exprHelper) String() string {
 	if eh.expr == nil {
 		return "none"
 	}
@@ -138,3 +140,13 @@ func (eh *exprHelper) evalFilter(row sqlbase.EncDatumRow) (bool, error) {
 	eh.row = row
 	return sqlbase.RunFilter(eh.expr, eh.evalCtx)
 }
+
+// noCopy may be embedded into structs which must not be copied
+// after the first use.
+//
+// See https://github.com/golang/go/issues/8005#issuecomment-190753527
+// for details.
+type noCopy struct{}
+
+// Lock is a no-op used by -copylocks checker from `go vet`.
+func (*noCopy) Lock() {}

--- a/sql/distsql/joinreader.go
+++ b/sql/distsql/joinreader.go
@@ -101,7 +101,7 @@ func (jr *joinReader) mainLoop() error {
 	ctx, closeSpan := tracing.ChildSpan(jr.ctx, "join reader")
 	defer closeSpan()
 
-	log.VEventf(1, ctx, "starting (filter: %s)", jr.filter)
+	log.VEventf(1, ctx, "starting (filter: %s)", &jr.filter)
 	if log.V(1) {
 		defer log.Infof(ctx, "exiting")
 	}

--- a/sql/distsql/tablereader.go
+++ b/sql/distsql/tablereader.go
@@ -102,7 +102,7 @@ func (tr *tableReader) Run(wg *sync.WaitGroup) {
 	ctx, closeSpan := tracing.ChildSpan(tr.ctx, "table reader")
 	defer closeSpan()
 
-	log.VEventf(1, ctx, "starting (filter: %s)", tr.filter)
+	log.VEventf(1, ctx, "starting (filter: %s)", &tr.filter)
 	if log.V(1) {
 		defer log.Infof(ctx, "exiting")
 	}


### PR DESCRIPTION
The `exprHelper` was not designed to be copied (the `IndexedVarHelper` refer to
it by address). Disallow this using the `noCopy` struct, as used in the standard
library.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9737)

<!-- Reviewable:end -->
