### PR TITLE
sql: preserve the syntax of casts and type annotations when pretty-printing

### DIFF
--- a/sql/parser/normalize_test.go
+++ b/sql/parser/normalize_test.go
@@ -122,8 +122,8 @@ func TestNormalizeExpr(t *testing.T) {
 		{`ANNOTATE_TYPE(1, float)`, `1.0`},
 		// TODO(nvanbenschoten) introduce a shorthand type annotation notation.
 		// {`1!float`, `1.0`},
-		{`IF((true AND a < 0), (0 + a)::decimal, 2 / (1 - 1))`, `IF(a < 0, CAST(a AS DECIMAL), 2 / 0)`},
-		{`IF((true OR a < 0), (0 + a)::decimal, 2 / (1 - 1))`, `CAST(a AS DECIMAL)`},
+		{`IF((true AND a < 0), (0 + a)::decimal, 2 / (1 - 1))`, `IF(a < 0, a::DECIMAL, 2 / 0)`},
+		{`IF((true OR a < 0), (0 + a)::decimal, 2 / (1 - 1))`, `a::DECIMAL`},
 		{`COALESCE(NULL, (NULL < 3), a = 2 - 1, d)`, `COALESCE(a = 1, d)`},
 		{`COALESCE(NULL, a)`, `a`},
 	}

--- a/sql/parser/parse_test.go
+++ b/sql/parser/parse_test.go
@@ -327,6 +327,19 @@ func TestParse(t *testing.T) {
 		{`SELECT 'a' FROM t@{NO_INDEX_JOIN}`},
 		{`SELECT 'a' FROM t@{FORCE_INDEX=bar,NO_INDEX_JOIN}`},
 
+		{`SELECT '1':::INT`},
+
+		{`SELECT '1'::INT`},
+		{`SELECT BOOL 'foo'`},
+		{`SELECT INT 'foo'`},
+		{`SELECT REAL 'foo'`},
+		{`SELECT DECIMAL 'foo'`},
+		{`SELECT DATE 'foo'`},
+		{`SELECT TIMESTAMP 'foo'`},
+		{`SELECT TIMESTAMP WITH TIME ZONE 'foo'`},
+		{`SELECT INTERVAL 'foo'`},
+		{`SELECT CHAR 'foo'`},
+
 		{`SELECT 'a' AS "12345"`},
 		{`SELECT 'a' AS clnm`},
 
@@ -585,17 +598,8 @@ func TestParse2(t *testing.T) {
 			`CREATE TABLE a (b INT, CONSTRAINT foo UNIQUE (b) INTERLEAVE IN PARENT c (d))`},
 		{`CREATE INDEX ON a (b) COVERING (c)`, `CREATE INDEX ON a (b) STORING (c)`},
 
-		{`SELECT BOOL 'foo'`, `SELECT CAST('foo' AS BOOL)`},
-		{`SELECT INT 'foo'`, `SELECT CAST('foo' AS INT)`},
-		{`SELECT REAL 'foo'`, `SELECT CAST('foo' AS REAL)`},
-		{`SELECT DECIMAL 'foo'`, `SELECT CAST('foo' AS DECIMAL)`},
-		{`SELECT DATE 'foo'`, `SELECT CAST('foo' AS DATE)`},
-		{`SELECT TIMESTAMP 'foo'`, `SELECT CAST('foo' AS TIMESTAMP)`},
-		{`SELECT TIMESTAMP WITHOUT TIME ZONE 'foo'`, `SELECT CAST('foo' AS TIMESTAMP)`},
+		{`SELECT TIMESTAMP WITHOUT TIME ZONE 'foo'`, `SELECT TIMESTAMP 'foo'`},
 		{`SELECT CAST('foo' AS TIMESTAMP WITHOUT TIME ZONE)`, `SELECT CAST('foo' AS TIMESTAMP)`},
-		{`SELECT TIMESTAMP WITH TIME ZONE 'foo'`, `SELECT CAST('foo' AS TIMESTAMP WITH TIME ZONE)`},
-		{`SELECT INTERVAL 'foo'`, `SELECT CAST('foo' AS INTERVAL)`},
-		{`SELECT CHAR 'foo'`, `SELECT CAST('foo' AS CHAR)`},
 
 		{`SELECT 'a' FROM t@{FORCE_INDEX=bar}`, `SELECT 'a' FROM t@bar`},
 		{`SELECT 'a' FROM t@{NO_INDEX_JOIN,FORCE_INDEX=bar}`,
@@ -684,12 +688,6 @@ func TestParse2(t *testing.T) {
 		// We allow OFFSET before LIMIT, but always output LIMIT first.
 		{`SELECT a FROM t OFFSET a LIMIT b`,
 			`SELECT a FROM t LIMIT b OFFSET a`},
-		// Shorthand type cast.
-		{`SELECT '1'::INT`,
-			`SELECT CAST('1' AS INT)`},
-		// Shorthand type annotation.
-		{`SELECT '1':::INT`,
-			`SELECT ANNOTATE_TYPE('1', INT)`},
 		// Double negation. See #1800.
 		{`SELECT *,-/* comment */-5`,
 			`SELECT *, - (- 5)`},

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -8056,13 +8056,13 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
 		//line sql.y:3275
 		{
-			sqlVAL.union.val = &CastExpr{Expr: sqlDollar[1].union.expr(), Type: sqlDollar[3].union.colType()}
+			sqlVAL.union.val = &CastExpr{Expr: sqlDollar[1].union.expr(), Type: sqlDollar[3].union.colType(), syntaxMode: castShort}
 		}
 	case 538:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
 		//line sql.y:3279
 		{
-			sqlVAL.union.val = &AnnotateTypeExpr{Expr: sqlDollar[1].union.expr(), Type: sqlDollar[3].union.colType()}
+			sqlVAL.union.val = &AnnotateTypeExpr{Expr: sqlDollar[1].union.expr(), Type: sqlDollar[3].union.colType(), syntaxMode: annotateShort}
 		}
 	case 539:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
@@ -8410,13 +8410,13 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
 		//line sql.y:3522
 		{
-			sqlVAL.union.val = &CastExpr{Expr: sqlDollar[1].union.expr(), Type: sqlDollar[3].union.colType()}
+			sqlVAL.union.val = &CastExpr{Expr: sqlDollar[1].union.expr(), Type: sqlDollar[3].union.colType(), syntaxMode: castShort}
 		}
 	case 598:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
 		//line sql.y:3526
 		{
-			sqlVAL.union.val = &AnnotateTypeExpr{Expr: sqlDollar[1].union.expr(), Type: sqlDollar[3].union.colType()}
+			sqlVAL.union.val = &AnnotateTypeExpr{Expr: sqlDollar[1].union.expr(), Type: sqlDollar[3].union.colType(), syntaxMode: annotateShort}
 		}
 	case 599:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
@@ -8754,13 +8754,13 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
 		//line sql.y:3760
 		{
-			sqlVAL.union.val = &CastExpr{Expr: sqlDollar[3].union.expr(), Type: sqlDollar[5].union.colType()}
+			sqlVAL.union.val = &CastExpr{Expr: sqlDollar[3].union.expr(), Type: sqlDollar[5].union.colType(), syntaxMode: castExplicit}
 		}
 	case 658:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
 		//line sql.y:3764
 		{
-			sqlVAL.union.val = &AnnotateTypeExpr{Expr: sqlDollar[3].union.expr(), Type: sqlDollar[5].union.colType()}
+			sqlVAL.union.val = &AnnotateTypeExpr{Expr: sqlDollar[3].union.expr(), Type: sqlDollar[5].union.colType(), syntaxMode: annotateExplicit}
 		}
 	case 659:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
@@ -9540,19 +9540,19 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
 		//line sql.y:4470
 		{
-			sqlVAL.union.val = &CastExpr{Expr: &StrVal{s: sqlDollar[2].str}, Type: sqlDollar[1].union.colType()}
+			sqlVAL.union.val = &CastExpr{Expr: &StrVal{s: sqlDollar[2].str}, Type: sqlDollar[1].union.colType(), syntaxMode: castPrefix}
 		}
 	case 799:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
 		//line sql.y:4474
 		{
-			sqlVAL.union.val = &CastExpr{Expr: &StrVal{s: sqlDollar[2].str}, Type: sqlDollar[1].union.colType()}
+			sqlVAL.union.val = &CastExpr{Expr: &StrVal{s: sqlDollar[2].str}, Type: sqlDollar[1].union.colType(), syntaxMode: castPrefix}
 		}
 	case 800:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
 		//line sql.y:4478
 		{
-			sqlVAL.union.val = &CastExpr{Expr: &StrVal{s: sqlDollar[5].str}, Type: sqlDollar[1].union.colType()}
+			sqlVAL.union.val = &CastExpr{Expr: &StrVal{s: sqlDollar[5].str}, Type: sqlDollar[1].union.colType(), syntaxMode: castPrefixParens}
 		}
 	case 801:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]

--- a/sql/parser/sql.y
+++ b/sql/parser/sql.y
@@ -3275,11 +3275,11 @@ a_expr:
   c_expr
 | a_expr TYPECAST typename
   {
-    $$.val = &CastExpr{Expr: $1.expr(), Type: $3.colType()}
+    $$.val = &CastExpr{Expr: $1.expr(), Type: $3.colType(), syntaxMode: castShort}
   }
 | a_expr TYPEANNOTATE typename
   {
-    $$.val = &AnnotateTypeExpr{Expr: $1.expr(), Type: $3.colType()}
+    $$.val = &AnnotateTypeExpr{Expr: $1.expr(), Type: $3.colType(), syntaxMode: annotateShort}
   }
 | a_expr COLLATE any_name { unimplemented() }
 | a_expr AT TIME ZONE a_expr %prec AT { unimplemented() }
@@ -3522,11 +3522,11 @@ b_expr:
   c_expr
 | b_expr TYPECAST typename
   {
-    $$.val = &CastExpr{Expr: $1.expr(), Type: $3.colType()}
+    $$.val = &CastExpr{Expr: $1.expr(), Type: $3.colType(), syntaxMode: castShort}
   }
 | b_expr TYPEANNOTATE typename
   {
-    $$.val = &AnnotateTypeExpr{Expr: $1.expr(), Type: $3.colType()}
+    $$.val = &AnnotateTypeExpr{Expr: $1.expr(), Type: $3.colType(), syntaxMode: annotateShort}
   }
 | '+' b_expr %prec UMINUS
   {
@@ -3760,11 +3760,11 @@ func_expr_common_subexpr:
 | USER { unimplemented() }
 | CAST '(' a_expr AS typename ')'
   {
-    $$.val = &CastExpr{Expr: $3.expr(), Type: $5.colType()}
+    $$.val = &CastExpr{Expr: $3.expr(), Type: $5.colType(), syntaxMode: castExplicit}
   }
 | ANNOTATE_TYPE '(' a_expr ',' typename ')'
   {
-    $$.val = &AnnotateTypeExpr{Expr: $3.expr(), Type: $5.colType()}
+    $$.val = &AnnotateTypeExpr{Expr: $3.expr(), Type: $5.colType(), syntaxMode: annotateExplicit}
   }
 | EXTRACT '(' extract_list ')'
   {
@@ -4470,15 +4470,15 @@ a_expr_const:
 | func_name '(' expr_list opt_sort_clause ')' SCONST { unimplemented() }
 | const_typename SCONST
   {
-    $$.val = &CastExpr{Expr: &StrVal{s: $2}, Type: $1.colType()}
+    $$.val = &CastExpr{Expr: &StrVal{s: $2}, Type: $1.colType(), syntaxMode: castPrefix}
   }
 | const_interval SCONST opt_interval
   {
-    $$.val = &CastExpr{Expr: &StrVal{s: $2}, Type: $1.colType()}
+    $$.val = &CastExpr{Expr: &StrVal{s: $2}, Type: $1.colType(), syntaxMode: castPrefix}
   }
 | const_interval '(' ICONST ')' SCONST
   {
-    $$.val = &CastExpr{Expr: &StrVal{s: $5}, Type: $1.colType()}
+    $$.val = &CastExpr{Expr: &StrVal{s: $5}, Type: $1.colType(), syntaxMode: castPrefixParens}
   }
 | TRUE
   {


### PR DESCRIPTION
This beautifies the output of EXPLAIN (slightly)
But foremost condenses the history when cli-side checking is enabled.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9739)

<!-- Reviewable:end -->
