### PR TITLE
sql: Normalize virtual schema database names

### DIFF
--- a/sql/testdata/information_schema
+++ b/sql/testdata/information_schema
@@ -295,6 +295,15 @@ def           pg_catalog          NULL                        NULL
 def           system              NULL                        NULL
 def           test                NULL                        NULL
 
+query TTTT colnames
+SELECT * FROM INFormaTION_SCHEMa.schemata
+----
+CATALOG_NAME  SCHEMA_NAME         DEFAULT_CHARACTER_SET_NAME  SQL_PATH
+def           information_schema  NULL                        NULL
+def           pg_catalog          NULL                        NULL
+def           system              NULL                        NULL
+def           test                NULL                        NULL
+
 statement ok
 CREATE DATABASE other_db
 

--- a/sql/virtual_schema.go
+++ b/sql/virtual_schema.go
@@ -213,7 +213,7 @@ func (e *Executor) IsVirtualDatabase(name string) bool {
 func (vs *virtualSchemaHolder) getVirtualTableEntry(
 	tn *parser.TableName,
 ) (virtualTableEntry, error) {
-	if db, ok := vs.getVirtualSchemaEntry(tn.Database()); ok {
+	if db, ok := vs.getVirtualSchemaEntry(sqlbase.NormalizeName(tn.DatabaseName)); ok {
 		if t, ok := db.tables[sqlbase.NormalizeName(tn.TableName)]; ok {
 			return t, nil
 		}


### PR DESCRIPTION
Previously, the database names were never normalized, so selecting from
`INFORMATION_SCHEMA.<table_name>` would not work.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9743)

<!-- Reviewable:end -->
