### PR TITLE
storage: deflake TestGossipFirstRange

### DIFF
--- a/storage/gossip_test.go
+++ b/storage/gossip_test.go
@@ -42,7 +42,7 @@ func TestGossipFirstRange(t *testing.T) {
 
 	errors := make(chan error)
 	descs := make(chan *roachpb.RangeDescriptor)
-	tc.Servers[0].Gossip().RegisterCallback(gossip.KeyFirstRangeDescriptor,
+	unregister := tc.Servers[0].Gossip().RegisterCallback(gossip.KeyFirstRangeDescriptor,
 		func(_ string, content roachpb.Value) {
 			var desc roachpb.RangeDescriptor
 			if err := content.GetProto(&desc); err != nil {
@@ -50,7 +50,13 @@ func TestGossipFirstRange(t *testing.T) {
 			} else {
 				descs <- &desc
 			}
-		})
+		},
+	)
+	// Unregister the callback before attempting to stop the stopper to prevent
+	// deadlock. This is still flaky in theory since a callback can fire between
+	// the last read from the channels and this unregister, but testing has
+	// shown this solution to be sufficiently robust for now.
+	defer unregister()
 
 	// Wait for the specified descriptor to be gossiped for the first range. We
 	// loop because the timing of replica addition and lease transfer can cause


### PR DESCRIPTION
The channel used in this test is unbuffered, so it was possible for an
"extra" gossip callback to fire while the test is shutting down. This
commit unregisters the gossip callback before the test exits.

Fixes #9746.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9747)

<!-- Reviewable:end -->
