### PR TITLE
storage: deflake TestSkipLargeReplicaSnapshot

### DIFF
--- a/storage/replica_raftstorage_test.go
+++ b/storage/replica_raftstorage_test.go
@@ -59,13 +59,14 @@ func TestSkipLargeReplicaSnapshot(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	storeCfg := TestStoreConfig()
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, _, stopper := createTestStoreWithContext(t, &storeCfg)
-	defer stopper.Stop()
 
 	const snapSize = 1 << 20 // 1 MiB
 	cfg := config.DefaultZoneConfig()
 	cfg.RangeMaxBytes = snapSize
 	defer config.TestingSetDefaultZoneConfig(cfg)()
+
+	store, _, stopper := createTestStoreWithContext(t, &storeCfg)
+	defer stopper.Stop()
 
 	rep, err := store.GetReplica(rangeID)
 	if err != nil {


### PR DESCRIPTION
This test was flaky. Fixed by moving the pre-test setting of max replica
size in the zone configuration before we actually create the store.

Fixes #9711 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9750)

<!-- Reviewable:end -->
