### PR TITLE
storage: debug logs for replicateQueue and replicaScanner

### DIFF
--- a/storage/allocator.go
+++ b/storage/allocator.go
@@ -58,6 +58,17 @@ const (
 	AllocatorRemoveDead
 )
 
+var allocatorActionNames = map[AllocatorAction]string{
+	AllocatorNoop:       "noop",
+	AllocatorRemove:     "remove",
+	AllocatorAdd:        "add",
+	AllocatorRemoveDead: "remove dead",
+}
+
+func (a AllocatorAction) String() string {
+	return allocatorActionNames[a]
+}
+
 // allocatorError indicates a retryable error condition which sends replicas
 // being processed through the replicate_queue into purgatory so that they
 // can be retried quickly as soon as new stores come online, or additional

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -109,6 +109,9 @@ func (rq *replicateQueue) shouldQueue(
 
 	action, priority := rq.allocator.ComputeAction(zone, desc)
 	if action != AllocatorNoop {
+		if log.V(2) {
+			log.Infof(rq.ctx, "%s repair needed (%s), enqueuing", repl, action)
+		}
 		return true, priority
 	}
 	// See if there is a rebalancing opportunity present.
@@ -118,6 +121,13 @@ func (rq *replicateQueue) shouldQueue(
 	}
 	target := rq.allocator.RebalanceTarget(
 		zone.Constraints, desc.Replicas, leaseStoreID)
+	if log.V(2) {
+		if target != nil {
+			log.Infof(rq.ctx, "%s rebalance target found, enqueuing", repl)
+		} else {
+			log.Infof(rq.ctx, "%s no rebalance target found, not enqueuing", repl)
+		}
+	}
 	return target != nil, 0
 }
 

--- a/storage/scanner.go
+++ b/storage/scanner.go
@@ -213,6 +213,9 @@ func (rs *replicaScanner) waitAndProcess(
 				return false
 			}
 
+			if log.V(2) {
+				log.Infof(rs.ctx, "replica scanner processing %s", repl)
+			}
 			for _, q := range rs.queues {
 				q.MaybeAdd(repl, clock.Now())
 			}


### PR DESCRIPTION
While debugging #9736 (dormant ranges in TestRebalance_3To5Small), it
was apparent that the replica queue and scanner are relative black boxes
for our logs. These log messages were useful for looking into #9736 and
should be more generally useful.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9751)

<!-- Reviewable:end -->
