### PR TITLE
sql: implement strptime/strftime.

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -103,6 +103,8 @@ github.com/stretchr/testify 976c720a22c8eb4eb6a0b4348ad85ad12491a506
 github.com/tebeka/go2xunit cb8eb3dedfac9cf4cb1f2d8988f3390f2d0cf2e7
 github.com/termie/go-shutil bcacb06fecaeec8dc42af03c87c6949f4a05c74c
 github.com/wadey/gocovmerge b5bfa59ec0adc420475f97f89b58045c721d761c
+github.com/jeffjen/datefmt 6688647cfa0439b86e09b097cac96ed328d5fa34
+github.com/leekchan/timeutil 28917288c48df3d2c1cfe468c273e0b2adda0aa5
 golang.org/x/crypto 484eb34681af59703e639b971bc307019182c41f
 golang.org/x/net 0f2be02c5ddfa7c7936000ad519b04c6c795eab3
 golang.org/x/oauth2 3c3a985cb79f52a3190fbc056984415ca6763d01

--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -563,6 +563,64 @@ var Builtins = map[string][]Builtin{
 
 	// Timestamp/Date functions.
 
+	"strftime": {
+		Builtin{
+			Types:      ArgTypes{TypeTimestamp, TypeString},
+			ReturnType: TypeString,
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
+				fromTime := args[0].(*DTimestamp).Time
+				format := string(*args[1].(*DString))
+				t, err := timeutil.Strftime(fromTime, format)
+				if err != nil {
+					return nil, err
+				}
+				return NewDString(t), nil
+			},
+		},
+		Builtin{
+			Types:      ArgTypes{TypeDate, TypeString},
+			ReturnType: TypeString,
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
+				fromTime := time.Unix(int64(*args[0].(*DDate))*secondsInDay, 0).UTC()
+				format := string(*args[1].(*DString))
+				t, err := timeutil.Strftime(fromTime, format)
+				if err != nil {
+					return nil, err
+				}
+				return NewDString(t), nil
+			},
+		},
+		Builtin{
+			Types:      ArgTypes{TypeTimestampTZ, TypeString},
+			ReturnType: TypeString,
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
+				fromTime := args[0].(*DTimestampTZ).Time
+				format := string(*args[1].(*DString))
+				t, err := timeutil.Strftime(fromTime, format)
+				if err != nil {
+					return nil, err
+				}
+				return NewDString(t), nil
+			},
+		},
+	},
+
+	"strptime": {
+		Builtin{
+			Types:      ArgTypes{TypeString, TypeString},
+			ReturnType: TypeTimestampTZ,
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
+				format := string(*args[0].(*DString))
+				toParse := string(*args[1].(*DString))
+				t, err := timeutil.Strptime(toParse, format)
+				if err != nil {
+					return nil, err
+				}
+				return MakeDTimestampTZ(t.UTC(), time.Microsecond), nil
+			},
+		},
+	},
+
 	"age": {
 		Builtin{
 			Types:      ArgTypes{TypeTimestamp},

--- a/sql/parser/eval_test.go
+++ b/sql/parser/eval_test.go
@@ -509,6 +509,14 @@ func TestEval(t *testing.T) {
 		{`extract_duration(second from '10m20s30ms'::interval)`, `620`},
 		{`extract_duration(millisecond from '20s30ms40µs'::interval)`, `20030`},
 		{`extract_duration(microsecond from '12345ns'::interval)`, `12`},
+		// Time and date conversion
+		{`strftime('2016-09-28'::date, '%d@%Y/%m')`, `'28@2016/09'`},
+		{`strftime('2010-01-10 12:13:14.123456+00:00'::timestamp, '%a %A %w %d %b %B %m %y %Y %H %I %p %M %S %f %z %Z %j %U %W %c %x %X %%')`,
+			`'Sun Sunday 0 10 Jan January 01 10 2010 12 12 PM 13 14 123456 +0000 UTC 010 02 01 Sun Jan 10 12:13:14 2010 01/10/10 12:13:14 %'`},
+		{`strftime('2010-01-10 12:13:14.123456+00:00'::timestamptz, '%a %A %w %d %b %B %m %y %Y %H %I %p %M %S %f %z %Z %j %U %W %c %x %X %%')`,
+			`'Sun Sunday 0 10 Jan January 01 10 2010 12 12 PM 13 14 123456 +0000 UTC 010 02 01 Sun Jan 10 12:13:14 2010 01/10/10 12:13:14 %'`},
+		{`strptime('%d %Y %B', '03 2006 December')`, `2006-12-03 00:00:00+00:00`},
+		{`strptime('%y %m %d %z %M %S %H', '06 12 21 -0400 05 33 14')`, `2006-12-21 18:05:33+00:00`},
 		// TODO(nvanbenschoten) introduce a shorthand type annotation notation.
 		// {`123!int + 1`, `124`},
 		// {`123!float + 1`, `124.0`},

--- a/util/timeutil/conv.go
+++ b/util/timeutil/conv.go
@@ -1,0 +1,37 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package timeutil
+
+import (
+	"time"
+
+	"github.com/jeffjen/datefmt"
+	"github.com/leekchan/timeutil"
+)
+
+// Strftime converts a time to a string using some C-style format.
+func Strftime(time time.Time, fmt string) (string, error) {
+	return timeutil.Strftime(&time, fmt), nil
+}
+
+// Strptime converts a string to a time using some C-style format.
+func Strptime(time, fmt string) (time.Time, error) {
+	// TODO(knz) The `datefmt` package uses C's `strptime` which doesn't
+	// know about microseconds. We may want to change to an
+	// implementation that does this better.
+	return datefmt.Strptime(fmt, time)
+}

--- a/util/timeutil/conv_test.go
+++ b/util/timeutil/conv_test.go
@@ -1,0 +1,75 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package timeutil
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTimeConversion(t *testing.T) {
+	tests := []struct {
+		start     string
+		format    string
+		tm        string
+		revformat string
+		reverse   string
+	}{
+		{`2006-10-12`, `%Y-%m-%d`, `2006-10-12T00:00:00Z`, ``, ``},
+		{`10/12/06`, `%m/%d/%y`, `2006-10-12T00:00:00Z`, ``, ``},
+		{`20061012 01:03:02`, `%Y%m%d %H:%S:%M`, `2006-10-12T01:02:03Z`, ``, ``},
+		{`2018 10 4`, `%Y %W %w`, `2018-03-08T00:00:00Z`, ``, ``},
+		{`2018 10 4`, `%Y %U %w`, `2018-03-15T00:00:00Z`, ``, ``},
+		{`2016 100 PM 11`, `%Y %j %p %I`, `2016-04-09T23:00:00Z`, ``, ``},
+		{`Wed Oct 05 2016`, `%a %b %d %Y`, `2016-10-05T00:00:00Z`, ``, ``},
+		{`Wednesday October 05 2016`, `%A %B %d %Y`, `2016-10-05T00:00:00Z`, ``, ``},
+	}
+
+	for _, test := range tests {
+		tm, err := Strptime(test.start, test.format)
+		if err != nil {
+			t.Errorf("strptime(%q, %q): %v", test.start, test.format, err)
+			continue
+		}
+		tm = tm.UTC()
+
+		tmS := tm.Format(time.RFC3339Nano)
+		if tmS != test.tm {
+			t.Errorf("strptime(%q, %q): got %q, expected %q", test.start, test.format, tmS, test.tm)
+			continue
+		}
+
+		revfmt := test.format
+		if test.revformat != "" {
+			revfmt = test.revformat
+		}
+
+		ref := test.start
+		if test.reverse != "" {
+			ref = test.reverse
+		}
+
+		revS, err := Strftime(tm, revfmt)
+		if err != nil {
+			t.Errorf("strftime(%q, %q): %v", tm, revfmt, err)
+			continue
+		}
+		if ref != revS {
+			t.Errorf("strftime(%q, %q): got %q, expected %q", tm, revfmt, revS, ref)
+		}
+	}
+}


### PR DESCRIPTION
This implements strftime using a Go native library and strptime using
the C library (There is no Go library for strptime yet).

We probably want to restrict the format strings that we want to
advertise in docs to a subset of those recognized by the implementation. I'd
suggest the following:

```
%Y year YYYY
%y year YY
%m month MM
%d day DD
%H hour HH
%M minutes MM
%S seconds SS
%w weekday 0-6
%W week 0-53 starting with monday
%U week 0-53 starting with sunday
%I hour 1-12
%p AM/PM
%a weekday name
%A weekday name (full)
%b month name
%B month name (full)
%j day of year
```

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9762)

<!-- Reviewable:end -->
