### PR TITLE
storage: improve store visitor

### DIFF
--- a/storage/helpers_test.go
+++ b/storage/helpers_test.go
@@ -51,7 +51,7 @@ func (s *Store) ComputeMVCCStats() (enginepb.MVCCStats, error) {
 	var totalStats enginepb.MVCCStats
 	var err error
 
-	visitor := newStoreRangeSet(s)
+	visitor := newStoreReplicaVisitor(s)
 	now := s.Clock().PhysicalNow()
 	visitor.Visit(func(r *Replica) bool {
 		var stats enginepb.MVCCStats
@@ -66,7 +66,7 @@ func (s *Store) ComputeMVCCStats() (enginepb.MVCCStats, error) {
 }
 
 func forceScanAndProcess(s *Store, q *baseQueue) {
-	newStoreRangeSet(s).Visit(func(repl *Replica) bool {
+	newStoreReplicaVisitor(s).Visit(func(repl *Replica) bool {
 		q.MaybeAdd(repl, s.cfg.Clock.Now())
 		return true
 	})


### PR DESCRIPTION
The previous code was using the Store btree to visit the Replicas in
a particular order. It turns out that order was never necessary (and perhaps
even counter-productive).

More importantly, since the btree version needed to lock each Replica mutex
while also holding the Store lock, Store.mu was as contended as the worst
Replica.mu, which is disastrous. The new code simply copies the Replicas
out from under the Store lock without invoking any methods on them, which
should completely avoid that problem.

Prompted by #9749, which showcased the above problem.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9771)

<!-- Reviewable:end -->
