### PR TITLE
storage: Skip flaky TestProactiveRaftLogTruncate 

### DIFF
--- a/storage/raft_log_queue_test.go
+++ b/storage/raft_log_queue_test.go
@@ -206,6 +206,8 @@ func TestGetTruncatableIndexes(t *testing.T) {
 // log even when replica scanning is disabled.
 func TestProactiveRaftLogTruncate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("#9772")
+
 	store, _, stopper := createTestStore(t)
 	defer stopper.Stop()
 


### PR DESCRIPTION
Its sibling TestGetTruncatableIndexes is also skipped.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9773)

<!-- Reviewable:end -->
