### PR TITLE
sql: skip flaky TestReacquireLeaseOnRestart

### DIFF
--- a/sql/txn_restart_test.go
+++ b/sql/txn_restart_test.go
@@ -1110,6 +1110,7 @@ func TestNonRetryableErrorOnCommit(t *testing.T) {
 // the clock, so that the transaction timestamp exceeds the deadline of the EndTransactionRequest.
 func TestReacquireLeaseOnRestart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("#9774")
 
 	var cmdFilters CommandFilters
 	cmdFilters.AppendFilter(checkEndTransactionTrigger, true)


### PR DESCRIPTION
This test changes the MaxOffset of a running node instead of starting one with
the desired clock offset. I suspect that that node is in fact pinging itself
and finds that it doesn't advertise the clock offset it has configured, but
I have not checked that.

Skipping this test since it's _extremely_ flaky, but the fix should not be
too hard.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9775)

<!-- Reviewable:end -->
