### PR TITLE
util/timeutil: fix the strptime test.

### DIFF
--- a/util/timeutil/conv_test.go
+++ b/util/timeutil/conv_test.go
@@ -34,7 +34,9 @@ func TestTimeConversion(t *testing.T) {
 		{`20061012 01:03:02`, `%Y%m%d %H:%S:%M`, `2006-10-12T01:02:03Z`, ``, ``},
 		{`2018 10 4`, `%Y %W %w`, `2018-03-08T00:00:00Z`, ``, ``},
 		{`2018 10 4`, `%Y %U %w`, `2018-03-15T00:00:00Z`, ``, ``},
-		{`2016 100 PM 11`, `%Y %j %p %I`, `2016-04-09T23:00:00Z`, ``, ``},
+		// %j cannot be used reliably to parse a date from text; so test
+		// it only for rendering.
+		{`20161012 PM 11`, `%Y%m%d %p %I`, `2016-10-12T23:00:00Z`, `%j`, `286`},
 		{`Wed Oct 05 2016`, `%a %b %d %Y`, `2016-10-05T00:00:00Z`, ``, ``},
 		{`Wednesday October 05 2016`, `%A %B %d %Y`, `2016-10-05T00:00:00Z`, ``, ``},
 	}


### PR DESCRIPTION
Parsing a date from the year number (%Y) and the day number in that
year (%j) is actually not reliably supported. So avoid requiring that
it works in tests.

Fixes #9768.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9777)

<!-- Reviewable:end -->
