### PR TITLE
kube: Decrease number of replicas, bind http-host to 0.0.0.0

### DIFF
--- a/cloud/kubernetes/README.md
+++ b/cloud/kubernetes/README.md
@@ -130,7 +130,7 @@ database and ensuring the other replicas have all data that was written.
 Simply patch the PetSet by running
 
 ```shell
-kubectl patch petset cockroachdb -p '{"spec":{"replicas":6}}'
+kubectl patch petset cockroachdb -p '{"spec":{"replicas":4}}'
 ```
 
 Note that you may need to create a new persistent volume claim first. If you

--- a/cloud/kubernetes/cockroachdb-petset.yaml
+++ b/cloud/kubernetes/cockroachdb-petset.yaml
@@ -52,7 +52,7 @@ metadata:
   name: cockroachdb
 spec:
   serviceName: "cockroachdb"
-  replicas: 5
+  replicas: 3
   template:
     metadata:
       labels:
@@ -93,7 +93,7 @@ spec:
           - |
             # The use of qualified `hostname -f` is crucial:
             # Other nodes aren't able to look up the unqualified hostname.
-            CRARGS=("start" "--logtostderr" "--insecure" "--host" "$(hostname -f)")
+            CRARGS=("start" "--logtostderr" "--insecure" "--host" "$(hostname -f)" "--http-host" "0.0.0.0")
             # TODO(tschottdorf): really want to use an init container to do
             # the bootstrapping. The idea is that the container would know
             # whether it's on the first node and could check whether there's

--- a/cloud/kubernetes/minikube.sh
+++ b/cloud/kubernetes/minikube.sh
@@ -9,7 +9,7 @@ kubectl delete petsets,pods,persistentvolumes,persistentvolumeclaims,services -l
 # claims here manually even though that sounds counter-intuitive. For details
 # see https://github.com/kubernetes/contrib/pull/1295#issuecomment-230180894.
 # Note that we make an extra volume here so you can manually test scale-up.
-for i in $(seq 0 5); do
+for i in $(seq 0 3); do
   cat <<EOF | kubectl create -f -
 kind: PersistentVolume
 apiVersion: v1


### PR DESCRIPTION
Decrease the number of replicas such that we aren't creating more
replicas than there are nodes in a default kubernetes cluster.

Bind the admin UI to 0.0.0.0 so that port-forwarding works.

@tschottdorf @jseldess

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9784)

<!-- Reviewable:end -->
