### PR TITLE
sql: rename strptime/strftime with an experimental prefix

### DIFF
--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -578,7 +578,7 @@ var Builtins = map[string][]Builtin{
 
 	// Timestamp/Date functions.
 
-	"strftime": {
+	"experimental_strftime": {
 		Builtin{
 			Types:      ArgTypes{TypeTimestamp, TypeString},
 			ReturnType: TypeString,
@@ -620,7 +620,7 @@ var Builtins = map[string][]Builtin{
 		},
 	},
 
-	"strptime": {
+	"experimental_strptime": {
 		Builtin{
 			Types:      ArgTypes{TypeString, TypeString},
 			ReturnType: TypeTimestampTZ,

--- a/sql/parser/eval_test.go
+++ b/sql/parser/eval_test.go
@@ -530,13 +530,13 @@ func TestEval(t *testing.T) {
 		{`extract_duration(millisecond from '20s30ms40µs'::interval)`, `20030`},
 		{`extract_duration(microsecond from '12345ns'::interval)`, `12`},
 		// Time and date conversion
-		{`strftime('2016-09-28'::date, '%d@%Y/%m')`, `'28@2016/09'`},
-		{`strftime('2010-01-10 12:13:14.123456+00:00'::timestamp, '%a %A %w %d %b %B %m %y %Y %H %I %p %M %S %f %z %Z %j %U %W %c %x %X %%')`,
+		{`experimental_strftime('2016-09-28'::date, '%d@%Y/%m')`, `'28@2016/09'`},
+		{`experimental_strftime('2010-01-10 12:13:14.123456+00:00'::timestamp, '%a %A %w %d %b %B %m %y %Y %H %I %p %M %S %f %z %Z %j %U %W %c %x %X %%')`,
 			`'Sun Sunday 0 10 Jan January 01 10 2010 12 12 PM 13 14 123456 +0000 UTC 010 02 01 Sun Jan 10 12:13:14 2010 01/10/10 12:13:14 %'`},
-		{`strftime('2010-01-10 12:13:14.123456+00:00'::timestamptz, '%a %A %w %d %b %B %m %y %Y %H %I %p %M %S %f %z %Z %j %U %W %c %x %X %%')`,
+		{`experimental_strftime('2010-01-10 12:13:14.123456+00:00'::timestamptz, '%a %A %w %d %b %B %m %y %Y %H %I %p %M %S %f %z %Z %j %U %W %c %x %X %%')`,
 			`'Sun Sunday 0 10 Jan January 01 10 2010 12 12 PM 13 14 123456 +0000 UTC 010 02 01 Sun Jan 10 12:13:14 2010 01/10/10 12:13:14 %'`},
-		{`strptime('%d %Y %B', '03 2006 December')`, `2006-12-03 00:00:00+00:00`},
-		{`strptime('%y %m %d %z %M %S %H', '06 12 21 -0400 05 33 14')`, `2006-12-21 18:05:33+00:00`},
+		{`experimental_strptime('%d %Y %B', '03 2006 December')`, `2006-12-03 00:00:00+00:00`},
+		{`experimental_strptime('%y %m %d %z %M %S %H', '06 12 21 -0400 05 33 14')`, `2006-12-21 18:05:33+00:00`},
 		// TODO(nvanbenschoten) introduce a shorthand type annotation notation.
 		// {`123!int + 1`, `124`},
 		// {`123!float + 1`, `124.0`},


### PR DESCRIPTION
@mjibson has come up with arguments why we may want to change the
interface of these SQL functions. Renaming to `experimental_*` for now
until that discussion is resolved.

cc @dt

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9786)

<!-- Reviewable:end -->
