### PR TITLE
RFCs: Mark schema gossip RFC as complete

### DIFF
--- a/docs/RFCS/schema_gossip.md
+++ b/docs/RFCS/schema_gossip.md
@@ -1,6 +1,6 @@
-- Feature Name: schema_distribution
-- Status: unstarted
-- Start Date: TBD
+- Feature Name: schema_gossip
+- Status: completed
+- Start Date: 2015-07-20
 - RFC PR: [#1743](https://github.com/cockroachdb/cockroach/pull/1743)
 - Cockroach Issue:
 

--- a/docs/RFCS/table_descriptor_lease.md
+++ b/docs/RFCS/table_descriptor_lease.md
@@ -19,7 +19,7 @@ latency.
 
 Table descriptors are currently distributed to every node in the
 cluster via gossipping of the system config (see
-[schema_distribution](https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/schema_gossip.md)). Unfortunately,
+[schema_gossip](https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/schema_gossip.md)). Unfortunately,
 it is not safe to use these gossipped table descriptors in almost any
 circumstance. Consider the statements:
 


### PR DESCRIPTION
Also clean up its feature name to be the same as its file name.

It looks like this was implemented long ago and just never marked as done, but it's not at all clear to an uninformed reader, especially since it doesn't link to any tracking issues.

@vivekmenezes

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9787)

<!-- Reviewable:end -->
