### PR TITLE
sql: adjust advertised and tested support for strptime specifiers

### DIFF
--- a/sql/parser/eval_test.go
+++ b/sql/parser/eval_test.go
@@ -536,7 +536,7 @@ func TestEval(t *testing.T) {
 		{`experimental_strftime('2010-01-10 12:13:14.123456+00:00'::timestamptz, '%a %A %w %d %b %B %m %y %Y %H %I %p %M %S %f %z %Z %j %U %W %c %x %X %%')`,
 			`'Sun Sunday 0 10 Jan January 01 10 2010 12 12 PM 13 14 123456 +0000 UTC 010 02 01 Sun Jan 10 12:13:14 2010 01/10/10 12:13:14 %'`},
 		{`experimental_strptime('%d %Y %B', '03 2006 December')`, `2006-12-03 00:00:00+00:00`},
-		{`experimental_strptime('%y %m %d %z %M %S %H', '06 12 21 -0400 05 33 14')`, `2006-12-21 18:05:33+00:00`},
+		{`experimental_strptime('%y %m %d %M %S %H', '06 12 21 05 33 14')`, `2006-12-21 14:05:33+00:00`},
 		// TODO(nvanbenschoten) introduce a shorthand type annotation notation.
 		// {`123!int + 1`, `124`},
 		// {`123!float + 1`, `124.0`},

--- a/util/timeutil/conv_test.go
+++ b/util/timeutil/conv_test.go
@@ -34,11 +34,15 @@ func TestTimeConversion(t *testing.T) {
 		{`20061012 01:03:02`, `%Y%m%d %H:%S:%M`, `2006-10-12T01:02:03Z`, ``, ``},
 		{`2018 10 4`, `%Y %W %w`, `2018-03-08T00:00:00Z`, ``, ``},
 		{`2018 10 4`, `%Y %U %w`, `2018-03-15T00:00:00Z`, ``, ``},
-		// %j cannot be used reliably to parse a date from text; so test
-		// it only for rendering.
-		{`20161012 PM 11`, `%Y%m%d %p %I`, `2016-10-12T23:00:00Z`, `%j`, `286`},
+		// On BSD variants (OS X, FreeBSD), %p cannot be parsed before
+		// hour specifiers, so be sure that they appear in this order.
+		{`20161012 11 PM`, `%Y%m%d %I %p`, `2016-10-12T23:00:00Z`, ``, ``},
 		{`Wed Oct 05 2016`, `%a %b %d %Y`, `2016-10-05T00:00:00Z`, ``, ``},
 		{`Wednesday October 05 2016`, `%A %B %d %Y`, `2016-10-05T00:00:00Z`, ``, ``},
+		// %j and %z cannot be used reliably to parse a date from text (%z
+		// is non-standard; %j does not work on some platforms, including
+		// OSX); so test it only for rendering.
+		{`2016-10-12 010203`, `%Y-%m-%d %H%M%S`, `2016-10-12T01:02:03Z`, `%j %z`, `286 +0000`},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Format %z is only supported by strftime in POSIX, not strptime.

Format %j should be supported by both but happens to be only supported
for strftime properly on OSX.

Adjust the tests accordingly.

Fixes #9768.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9789)

<!-- Reviewable:end -->
