### PR TITLE
roachpb: fix coverage build

### DIFF
--- a/roachpb/batch_test.go
+++ b/roachpb/batch_test.go
@@ -102,19 +102,6 @@ func TestBatchRequestGetArg(t *testing.T) {
 	}
 }
 
-func TestBatchRequestString(t *testing.T) {
-	br := BatchRequest{}
-	for i := 0; i < 100; i++ {
-		br.Requests = append(br.Requests, RequestUnion{Get: &GetRequest{}})
-	}
-	br.Requests = append(br.Requests, RequestUnion{EndTransaction: &EndTransactionRequest{}})
-
-	e := `Get ["",""), Get ["",""), Get ["",""), Get ["",""), Get ["",""), Get ["",""), Get ["",""), Get ["",""), Get ["",""), Get ["",""), Get ["",""), Get ["",""), Get ["",""), Get ["",""), Get ["",""), Get ["",""), Get ["",""), Get ["",""), Get ["",""), Get ["",""), ... 76 skipped ..., Get ["",""), Get ["",""), Get ["",""), Get ["",""), EndTransaction ["","")`
-	if e != br.String() {
-		t.Fatalf("e = %s, v = %s", e, br.String())
-	}
-}
-
 func TestBatchRequestSummary(t *testing.T) {
 	// The Summary function is generated automatically, so the tests don't need to
 	// be exhaustive.

--- a/roachpb/data_test.go
+++ b/roachpb/data_test.go
@@ -18,12 +18,10 @@ package roachpb
 
 import (
 	"bytes"
-	"fmt"
 	"math"
 	"math/rand"
 	"reflect"
 	"sort"
-	"strings"
 	"testing"
 	"time"
 
@@ -210,15 +208,6 @@ func TestIsPrev(t *testing.T) {
 	}
 }
 
-func TestKeyString(t *testing.T) {
-	if Key("hello").String() != `"hello"` {
-		t.Errorf("expected key to display pretty version: %s", Key("hello"))
-	}
-	if RKeyMax.String() != `"\xff\xff"` {
-		t.Errorf("expected key max to display pretty version: %s", RKeyMax)
-	}
-}
-
 func TestValueChecksumEmpty(t *testing.T) {
 	k := []byte("key")
 	v := Value{}
@@ -360,44 +349,6 @@ func TestTxnIDEqual(t *testing.T) {
 		if eq := TxnIDEqual(test.a, test.b); eq != test.expEqual {
 			t.Errorf("%d: expected %q == %q: %t; got %t", i, test.a, test.b, test.expEqual, eq)
 		}
-	}
-}
-
-func TestTransactionString(t *testing.T) {
-	txnID, err := uuid.FromBytes([]byte("ת\x0f^\xe4-Fؽ\xf7\x16\xe4\xf9\xbe^\xbe"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	ts1 := makeTS(10, 11)
-	txn := Transaction{
-		TxnMeta: enginepb.TxnMeta{
-			Isolation: enginepb.SERIALIZABLE,
-			Key:       Key("foo"),
-			ID:        txnID,
-			Epoch:     2,
-			Timestamp: makeTS(20, 21),
-			Priority:  957356782,
-		},
-		Name:          "name",
-		Status:        COMMITTED,
-		LastHeartbeat: &ts1,
-		OrigTimestamp: makeTS(30, 31),
-		MaxTimestamp:  makeTS(40, 41),
-	}
-	expStr := `"name" id=d7aa0f5e key="foo" rw=false pri=44.58039917 iso=SERIALIZABLE stat=COMMITTED ` +
-		`epo=2 ts=0.000000020,21 orig=0.000000030,31 max=0.000000040,41 wto=false rop=false`
-
-	if str := txn.String(); str != expStr {
-		t.Errorf("expected txn %s; got %s", expStr, str)
-	}
-
-	var txnEmpty Transaction
-	_ = txnEmpty.String() // prevent regression of NPE
-
-	var cmd RaftCommand
-	cmd.Cmd.Txn = &txn
-	if actStr, idStr := fmt.Sprintf("%s", &cmd), txn.ID.String(); !strings.Contains(actStr, idStr) {
-		t.Fatalf("expected to find '%s' in '%s'", idStr, actStr)
 	}
 }
 

--- a/roachpb/string_test.go
+++ b/roachpb/string_test.go
@@ -1,0 +1,82 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tamir Duberstein (tamird@gmail.com)
+
+package roachpb_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	// Hook up the pretty printer.
+	_ "github.com/cockroachdb/cockroach/keys"
+	"github.com/cockroachdb/cockroach/roachpb"
+
+	"github.com/cockroachdb/cockroach/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/util/hlc"
+	"github.com/cockroachdb/cockroach/util/uuid"
+)
+
+func TestTransactionString(t *testing.T) {
+	txnID, err := uuid.FromBytes([]byte("ת\x0f^\xe4-Fؽ\xf7\x16\xe4\xf9\xbe^\xbe"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts1 := hlc.Timestamp{WallTime: 10, Logical: 11}
+	txn := roachpb.Transaction{
+		TxnMeta: enginepb.TxnMeta{
+			Isolation: enginepb.SERIALIZABLE,
+			Key:       roachpb.Key("foo"),
+			ID:        txnID,
+			Epoch:     2,
+			Timestamp: hlc.Timestamp{WallTime: 20, Logical: 21},
+			Priority:  957356782,
+		},
+		Name:          "name",
+		Status:        roachpb.COMMITTED,
+		LastHeartbeat: &ts1,
+		OrigTimestamp: hlc.Timestamp{WallTime: 30, Logical: 31},
+		MaxTimestamp:  hlc.Timestamp{WallTime: 40, Logical: 41},
+	}
+	expStr := `"name" id=d7aa0f5e key="foo" rw=false pri=44.58039917 iso=SERIALIZABLE stat=COMMITTED ` +
+		`epo=2 ts=0.000000020,21 orig=0.000000030,31 max=0.000000040,41 wto=false rop=false`
+
+	if str := txn.String(); str != expStr {
+		t.Errorf("expected txn %s; got %s", expStr, str)
+	}
+
+	var txnEmpty roachpb.Transaction
+	_ = txnEmpty.String() // prevent regression of NPE
+
+	var cmd roachpb.RaftCommand
+	cmd.Cmd.Txn = &txn
+	if actStr, idStr := fmt.Sprintf("%s", &cmd), txn.ID.String(); !strings.Contains(actStr, idStr) {
+		t.Fatalf("expected to find '%s' in '%s'", idStr, actStr)
+	}
+}
+
+func TestBatchRequestString(t *testing.T) {
+	br := roachpb.BatchRequest{}
+	for i := 0; i < 100; i++ {
+		br.Requests = append(br.Requests, roachpb.RequestUnion{Get: &roachpb.GetRequest{}})
+	}
+	br.Requests = append(br.Requests, roachpb.RequestUnion{EndTransaction: &roachpb.EndTransactionRequest{}})
+
+	e := `Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), ... 76 skipped ..., Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), EndTransaction [/Min,/Min)`
+	if e != br.String() {
+		t.Fatalf("e = %s, v = %s", e, br.String())
+	}
+}


### PR DESCRIPTION
Moves all String tests to a new file that lines in roachpb_test so that
it can import keys and enjoy the magic of the pretty printer.

This fixes the coverage build which links things in an unusual way.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9792)

<!-- Reviewable:end -->
