### PR TITLE
sql: improve performance of schema change operations

### DIFF
--- a/sql/schema_changer.go
+++ b/sql/schema_changer.go
@@ -65,7 +65,6 @@ func (sc *SchemaChanger) truncateAndDropTable(
 	lease *sqlbase.TableDescriptor_SchemaChangeLease,
 	tableDesc *sqlbase.TableDescriptor,
 ) error {
-
 	l, err := sc.ExtendLease(*lease)
 	if err != nil {
 		return err

--- a/sql/truncate.go
+++ b/sql/truncate.go
@@ -19,14 +19,20 @@ package sql
 import (
 	"math"
 
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/privilege"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
-	"github.com/pkg/errors"
-	"golang.org/x/net/context"
+	"github.com/cockroachdb/cockroach/util/log"
 )
+
+// TableTruncateChunkSize is the maximum number of keys deleted per chunk
+// during a table truncation.
+const TableTruncateChunkSize = IndexTruncateChunkSize
 
 // Truncate deletes all rows from a table.
 // Privileges: DROP on table.
@@ -112,19 +118,18 @@ func truncateTable(tableDesc *sqlbase.TableDescriptor, txn *client.Txn) error {
 	return err
 }
 
-// TableTruncateChunkSize is the size of a chunk during a table
-// truncation/drop operation. The chunk can be interpreted as the number of
-// keys or table rows to be deleted.
-const TableTruncateChunkSize = 1000
-
 // truncateTableInChunks truncates the data of a table in chunks. It deletes a
 // range of data for the table, which includes the PK and all indexes.
 func truncateTableInChunks(
 	ctx context.Context, tableDesc *sqlbase.TableDescriptor, db *client.DB,
 ) error {
+	const chunkSize = TableTruncateChunkSize
 	var resume roachpb.Span
-	for done := false; !done; {
+	for row, done := 0, false; !done; row += chunkSize {
 		resumeAt := resume
+		if log.V(2) {
+			log.Infof(ctx, "table %s truncate at row: %d, span: %s", tableDesc.Name, row, resume)
+		}
 		if err := db.Txn(ctx, func(txn *client.Txn) error {
 			rd, err := makeRowDeleter(txn, tableDesc, nil, nil, false)
 			if err != nil {
@@ -134,7 +139,7 @@ func truncateTableInChunks(
 			if err := td.init(txn); err != nil {
 				return err
 			}
-			resume, err = td.deleteAllRows(txn.Context, resumeAt, TableTruncateChunkSize)
+			resume, err = td.deleteAllRows(txn.Context, resumeAt, chunkSize)
 			return err
 		}); err != nil {
 			return err


### PR DESCRIPTION
This change improves performance by scanning fewer keys
and eliminating obvious redundant operations.

Adjusted the chunking constants to be more appropriate.
A schema change is still affecting the throughput of OLTP
operations.

Added context to various function calls, and log to traces where
appropriate.
#9149

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9798)

<!-- Reviewable:end -->
