### PR TITLE
Add git hook for crlfmt

### DIFF
--- a/build/check-style.sh
+++ b/build/check-style.sh
@@ -167,7 +167,13 @@ TestStaticcheck() {
 }
 
 TestCrlfmt() {
-  crlfmt -ignore 'pb.*.go' -tab 2 .
+  local cmd='crlfmt -ignore \.pb.*\.go -tab 2'
+  local status=0
+  ${cmd} . || status=$?
+  if [ $status -ne 0 ]; then
+    echo -e "run the following command:\n${cmd} -w .; git add -p"
+  fi
+  return $status
 }
 
 # Run all the tests, wrapped in a similar output format to "go test"

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+TESTS=TestCrlfmt ./build/check-style.sh


### PR DESCRIPTION
This hook fails unless the formatting is correct, giving instructions on what
command to run to fix it.

The alternative is to silently rewrite the code, which I don't support as I
am of the opinion that the VCS should not silently alter files. Besides, the
editor wouldn't find out (or would, interrupting the user with questions
about reloading). However, this can be discussed in the PR introducing this
commit.

It's fairly hard to make a hook do "the right thing". As written, this one
will not know what's being committed or what is staged. For example, it's
easy to satisfy the hook by reformatting the files but not committing them.
We could add the same hook for pre-push, but there are other situations which
are tricky.

I'm not convinced that making crlfmt an enforced lint is going to be easy
or worth the time. Perhaps the right move is to automatically reformat the
code periodically without human intervention, but I can see how opponents
to that idea would be hard to find. It does however have the advantage of
avoiding discussion in PRs much to the same effect, but at the same time
does not mean every type of editor needs to be provided with support for
auto-invoking crlfmt, and there is no burden on developers or outside
contributors. Thus, there might be merit to this idea.

In any case, the status quo is bad: We enforce crlfmt, but do not help
use it automatically. That's a waste of developer time and CI cycles.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9809)

<!-- Reviewable:end -->
