### PR TITLE
metrics: idiomatic histograms

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -109,7 +109,7 @@ type TxnMetrics struct {
 	Commits    metric.Rates
 	Commits1PC metric.Rates // Commits which finished in a single phase
 	Abandons   metric.Rates
-	Durations  metric.Histograms
+	Durations  *metric.Histogram
 
 	// Restarts is the number of times we had to restart the transaction.
 	Restarts *metric.Histogram
@@ -215,8 +215,8 @@ func (tc *TxnCoordSender) startStats() {
 			// Take a snapshot of metrics. There's some chance of skew, since the snapshots are
 			// not done atomically, but that should be fine for these debug stats.
 			metrics := tc.metrics
-			durations := metrics.Durations[scale].Current()
-			restarts := metrics.Restarts.Current()
+			durations := metrics.Durations.Windowed()
+			restarts := metrics.Restarts.Windowed()
 			commitRate := metrics.Commits.Rates[scale].Value()
 			commit1PCRate := metrics.Commits1PC.Rates[scale].Value()
 			abortRate := metrics.Aborts.Rates[scale].Value()

--- a/server/node.go
+++ b/server/node.go
@@ -84,7 +84,7 @@ var errNeedsBootstrap = errors.New("node has no initialized stores and no instru
 var errCannotJoinSelf = errors.New("an uninitialized node cannot specify its own address to join a cluster")
 
 type nodeMetrics struct {
-	Latency metric.Histograms
+	Latency *metric.Histogram
 	Success metric.Rates
 	Err     metric.Rates
 }

--- a/server/status/recorder_test.go
+++ b/server/status/recorder_test.go
@@ -290,14 +290,12 @@ func TestMetricsRecorder(t *testing.T) {
 				}
 			case "latency":
 				l := metric.NewLatency(metric.Metadata{Name: reg.prefix + data.name})
-				reg.reg.AddMetricGroup(l)
+				reg.reg.AddMetric(l)
 				l.RecordValue(data.val)
 				// Latency is simply three histograms (at different resolution
 				// time scales).
-				for _, scale := range metric.DefaultTimeScales {
-					for _, q := range recordHistogramQuantiles {
-						addExpected(reg.prefix, data.name+sep+scale.Name()+q.suffix, reg.source, 100, data.val, reg.isNode)
-					}
+				for _, q := range recordHistogramQuantiles {
+					addExpected(reg.prefix, data.name+q.suffix, reg.source, 100, data.val, reg.isNode)
 				}
 			}
 		}
@@ -350,7 +348,7 @@ func TestMetricsRecorder(t *testing.T) {
 
 	nodeSummary := recorder.GetStatusSummary()
 	if nodeSummary == nil {
-		t.Fatalf("recorder did not return nodeSummary.")
+		t.Fatalf("recorder did not return nodeSummary")
 	}
 
 	sort.Sort(byStoreDescID(nodeSummary.StoreStatuses))

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -162,7 +162,7 @@ type Executor struct {
 	virtualSchemas virtualSchemaHolder
 
 	// Transient stats.
-	Latency       metric.Histograms
+	Latency       *metric.Histogram
 	SelectCount   *metric.Counter
 	TxnBeginCount *metric.Counter
 

--- a/ui/app/containers/clusterOverview.tsx
+++ b/ui/app/containers/clusterOverview.tsx
@@ -83,13 +83,13 @@ class ClusterMain extends React.Component<ClusterMainProps, {}> {
                                Percentiles are first calculated on each node.
                                For each percentile, the maximum latency across all nodes is then shown.`}>
             <Axis format={ (n: number) => d3.format(".1f")(NanoToMilli(n)) } label="Milliseconds">
-              <Metric name="cr.node.exec.latency-1m-max" title="Max Latency"
+              <Metric name="cr.node.exec.latency-max" title="Max Latency"
                       aggregateMax downsampleMax />
-              <Metric name="cr.node.exec.latency-1m-p99" title="99th percentile latency"
+              <Metric name="cr.node.exec.latency-p99" title="99th percentile latency"
                       aggregateMax downsampleMax />
-              <Metric name="cr.node.exec.latency-1m-p90" title="90th percentile latency"
+              <Metric name="cr.node.exec.latency-p90" title="90th percentile latency"
                       aggregateMax downsampleMax />
-              <Metric name="cr.node.exec.latency-1m-p50" title="50th percentile latency"
+              <Metric name="cr.node.exec.latency-p50" title="50th percentile latency"
                       aggregateMax downsampleMax />
             </Axis>
           </LineGraph>

--- a/ui/app/containers/nodeGraphs.tsx
+++ b/ui/app/containers/nodeGraphs.tsx
@@ -58,13 +58,13 @@ export default class extends React.Component<IInjectedProps, {}> {
                                  For each percentile, the maximum latency across all nodes is then shown.`}
                        sources={sources}>
               <Axis format={ (n: number) => d3.format(".1f")(NanoToMilli(n)) } label="Milliseconds">
-                <Metric name="cr.node.exec.latency-1m-max" title="Max Latency"
+                <Metric name="cr.node.exec.latency-max" title="Max Latency"
                         aggregateMax downsampleMax />
-                <Metric name="cr.node.exec.latency-1m-p99" title="99th percentile latency"
+                <Metric name="cr.node.exec.latency-p99" title="99th percentile latency"
                         aggregateMax downsampleMax />
-                <Metric name="cr.node.exec.latency-1m-p90" title="90th percentile latency"
+                <Metric name="cr.node.exec.latency-p90" title="90th percentile latency"
                         aggregateMax downsampleMax />
-                <Metric name="cr.node.exec.latency-1m-p50" title="50th percentile latency"
+                <Metric name="cr.node.exec.latency-p50" title="50th percentile latency"
                         aggregateMax downsampleMax />
               </Axis>
             </LineGraph>

--- a/util/metric/metric.go
+++ b/util/metric/metric.go
@@ -31,7 +31,16 @@ import (
 	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
-const histWrapNum = 4 // number of histograms to keep in rolling window
+const (
+	// MaxLatency is the maximum value tracked in latency histograms. Higher
+	// values will be recorded as this value instead.
+	MaxLatency = 10 * time.Second
+
+	// Data will leave windowed histograms after approximately this duration.
+	latencyRotationInterval = 20 * time.Second
+	// The number of histograms to keep in rolling window.
+	histWrapNum = 2
+)
 
 // Iterable provides a method for synchronized access to interior objects.
 type Iterable interface {
@@ -99,7 +108,6 @@ var _ Iterable = &Rate{}
 var _ json.Marshaler = &Gauge{}
 var _ json.Marshaler = &GaugeFloat64{}
 var _ json.Marshaler = &Counter{}
-var _ json.Marshaler = &Histogram{}
 var _ json.Marshaler = &Rate{}
 var _ json.Marshaler = &Registry{}
 
@@ -113,7 +121,6 @@ type periodic interface {
 	tick()
 }
 
-var _ periodic = &Histogram{}
 var _ periodic = &Rate{}
 
 var now = timeutil.Now
@@ -128,107 +135,153 @@ func TestingSetNow(f func() time.Time) func() {
 	}
 }
 
+// TODO(tschottdorf): remove this method when
+// https://github.com/codahale/hdrhistogram/pull/22 is merged and the
+// dependency bumped.
+func cloneHistogram(in *hdrhistogram.Histogram) *hdrhistogram.Histogram {
+	out := in.Export()
+	out.Counts = append([]int64(nil), out.Counts...)
+	return hdrhistogram.Import(out)
+}
+
 func maybeTick(m periodic) {
 	for m.nextTick().Before(now()) {
 		m.tick()
 	}
 }
 
-// A Histogram is a wrapper around an hdrhistogram.WindowedHistogram.
+// A Histogram collects observed values by keeping bucketed counts. For
+// convenience, internally two sets of buckets are kept: A cumulative set (i.e.
+// data is never evicted) and a windowed set (which keeps only recently
+// collected samples).
+//
+// Top-level methods generally apply to the cumulative buckets; the windowed
+// variant is exposed through the Windowed method.
 type Histogram struct {
 	Metadata
 	maxVal int64
-
-	mu       syncutil.Mutex
-	windowed *hdrhistogram.WindowedHistogram
-	nextT    time.Time
-	duration time.Duration
-}
-
-// NewHistogram creates a new windowed HDRHistogram with the given parameters.
-// Data is kept in the active window for approximately the given duration.
-// See the documentation for hdrhistogram.WindowedHistogram for details.
-func NewHistogram(metadata Metadata, duration time.Duration, maxVal int64, sigFigs int) *Histogram {
-	return &Histogram{
-		Metadata: metadata,
-		maxVal:   maxVal,
-		nextT:    now(),
-		duration: duration,
-		windowed: hdrhistogram.NewWindowed(histWrapNum, 0, maxVal, sigFigs),
+	mu     struct {
+		syncutil.Mutex
+		cumulative *hdrhistogram.Histogram
+		sliding    *slidingHistogram
 	}
 }
 
-// GetType returns the prometheus type enum for this metric.
-func (h *Histogram) GetType() *prometheusgo.MetricType {
-	return prometheusgo.MetricType_SUMMARY.Enum()
+// NewHistogram initializes a given Histogram. The contained windowed histogram
+// rotates every 'duration'; both the windowed and the cumulative histogram
+// track nonnegative values up to 'maxVal' with 'sigFigs' decimal points of
+// precision.
+func NewHistogram(metadata Metadata, duration time.Duration, maxVal int64, sigFigs int) *Histogram {
+	dHist := newSlidingHistogram(duration, maxVal, sigFigs)
+	h := &Histogram{
+		Metadata: metadata,
+		maxVal:   maxVal,
+	}
+	h.mu.cumulative = hdrhistogram.New(0, maxVal, sigFigs)
+	h.mu.sliding = dHist
+	return h
 }
 
-func (h *Histogram) tick() {
-	h.nextT = h.nextT.Add(h.duration / histWrapNum)
-	h.windowed.Rotate()
+// NewLatency is a convenience function which returns a histograms with
+// suitable defaults for latency tracking. Values are expressed in ns,
+// are truncated into the interval [0, MaxLatency] and are recorded
+// with one digit of precision (i.e. errors of <10ms at 100ms, <6s at 60s).
+func NewLatency(metadata Metadata) *Histogram {
+	return NewHistogram(
+		metadata, latencyRotationInterval, MaxLatency.Nanoseconds(), 1,
+	)
 }
 
-func (h *Histogram) nextTick() time.Time {
-	return h.nextT
+// Windowed returns a copy of the current windowed histogram data.
+func (h *Histogram) Windowed() *hdrhistogram.Histogram {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return cloneHistogram(h.mu.sliding.Current())
 }
 
-// MarshalJSON outputs to JSON.
-func (h *Histogram) MarshalJSON() ([]byte, error) {
-	return json.Marshal(h.Current().CumulativeDistribution())
+// Snapshot returns a copy of the cumulative (i.e. all-time samples) histogram
+// data.
+func (h *Histogram) Snapshot() *hdrhistogram.Histogram {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return cloneHistogram(h.mu.cumulative)
 }
 
-// RecordValue adds the given value to the histogram, truncating if necessary.
+// RecordValue adds the given value to the histogram. Recording a value in
+// excess of the configured maximum value for that histogram results in
+// recording the maximum value instead.
 func (h *Histogram) RecordValue(v int64) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	maybeTick(h)
-	for h.windowed.Current.RecordValue(v) != nil {
-		v = h.maxVal
+
+	if h.mu.sliding.RecordValue(v) != nil {
+		_ = h.mu.sliding.RecordValue(h.maxVal)
+	}
+	if h.mu.cumulative.RecordValue(v) != nil {
+		_ = h.mu.cumulative.RecordValue(h.maxVal)
 	}
 }
 
-// Current returns a copy of the data currently in the window.
-func (h *Histogram) Current() *hdrhistogram.Histogram {
+// TotalCount returns the (cumulative) number of samples.
+func (h *Histogram) TotalCount() int64 {
 	h.mu.Lock()
-	maybeTick(h)
-	export := h.windowed.Merge().Export()
-	// Make a deep copy of export.Counts, because (*hdrhistogram.Histogram).Export() does
-	// a shallow copy of the histogram counts, which leads to data races when multiple goroutines
-	// call this method.
-	// TODO(cdo): Remove this when I've gotten a chance to submit a PR for the proper fix
-	// to hdrhistogram.
-	export.Counts = append([]int64(nil), export.Counts...)
-	h.mu.Unlock()
-	return hdrhistogram.Import(export)
+	defer h.mu.Unlock()
+	return h.mu.cumulative.TotalCount()
+}
+
+// Min returns the minimum.
+func (h *Histogram) Min() int64 {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.mu.cumulative.Min()
 }
 
 // Inspect calls the closure with the empty string and the receiver.
 func (h *Histogram) Inspect(f func(interface{})) {
 	h.mu.Lock()
-	maybeTick(h)
+	maybeTick(h.mu.sliding)
 	h.mu.Unlock()
 	f(h)
 }
 
+// GetType returns the prometheus type enum for this metric.
+func (h *Histogram) GetType() *prometheusgo.MetricType {
+	return prometheusgo.MetricType_HISTOGRAM.Enum()
+}
+
 // ToPrometheusMetric returns a filled-in prometheus metric of the right type.
 func (h *Histogram) ToPrometheusMetric() *prometheusgo.Metric {
-	// TODO(mjibson): change to a Histogram once bucket counts are reasonable
-	sum := &prometheusgo.Summary{}
+	hist := &prometheusgo.Histogram{}
 
 	h.mu.Lock()
-	maybeTick(h)
-	merged := h.windowed.Merge()
-	for _, b := range merged.CumulativeDistribution() {
-		sum.Quantile = append(sum.Quantile, &prometheusgo.Quantile{
-			Quantile: proto.Float64(b.Quantile),
-			Value:    proto.Float64(float64(b.ValueAt)),
+	maybeTick(h.mu.sliding)
+	bars := h.mu.cumulative.Distribution()
+	hist.Bucket = make([]*prometheusgo.Bucket, 0, len(bars))
+
+	var cumCount uint64
+	var sum float64
+	for _, bar := range bars {
+		if bar.Count == 0 {
+			// No need to expose trivial buckets.
+			continue
+		}
+		upperBound := float64(bar.To)
+		sum += upperBound * float64(bar.Count)
+
+		cumCount += uint64(bar.Count)
+		curCumCount := cumCount // need a new alloc thanks to bad proto code
+
+		hist.Bucket = append(hist.Bucket, &prometheusgo.Bucket{
+			CumulativeCount: &curCumCount,
+			UpperBound:      &upperBound,
 		})
 	}
-	sum.SampleCount = proto.Uint64(uint64(merged.TotalCount()))
+	hist.SampleCount = &cumCount
+	hist.SampleSum = &sum // can do better here; we approximate in the loop
 	h.mu.Unlock()
 
 	return &prometheusgo.Metric{
-		Summary: sum,
+		Histogram: hist,
 	}
 }
 
@@ -379,7 +432,9 @@ func (e *Rate) Add(v float64) {
 }
 
 // Inspect calls the given closure with the empty string and the Rate's current
-// value. TODO(mrtracy): Fix this to pass the Rate object itself to 'f', to
+// value.
+//
+// TODO(mrtracy): Fix this to pass the Rate object itself to 'f', to
 // match the 'visitor' behavior as the other metric types (currently, it passes
 // the current value of the Rate as a float64.)
 func (e *Rate) Inspect(f func(interface{})) {

--- a/util/metric/registry_test.go
+++ b/util/metric/registry_test.go
@@ -96,8 +96,7 @@ func TestRegistry(t *testing.T) {
 	r.AddMetric(topRate)
 
 	r.AddMetricGroup(NewRates(Metadata{Name: "top.rates"}))
-	r.AddMetric(NewHistogram(Metadata{Name: "top.hist"}, time.Minute, 1000, 3))
-	r.AddMetricGroup(NewLatency(Metadata{Name: "top.latency"}))
+	r.AddMetric(NewHistogram(Metadata{Name: "top.histogram"}, time.Minute, 1000, 3))
 
 	r.AddMetric(NewGauge(Metadata{Name: "bottom.gauge"}))
 	r.AddMetricGroup(NewRates(Metadata{Name: "bottom.rates"}))
@@ -107,7 +106,6 @@ func TestRegistry(t *testing.T) {
 		StructCounter   *Counter
 		StructHistogram *Histogram
 		StructRate      *Rate
-		StructLatency   Histograms
 		StructRates     Rates
 		// A few extra ones: either not exported, or not metric objects.
 		privateStructGauge   *Gauge
@@ -121,7 +119,6 @@ func TestRegistry(t *testing.T) {
 		StructCounter:        NewCounter(Metadata{Name: "struct.counter"}),
 		StructHistogram:      NewHistogram(Metadata{Name: "struct.histogram"}, time.Minute, 1000, 3),
 		StructRate:           NewRate(Metadata{Name: "struct.rate"}, time.Minute),
-		StructLatency:        NewLatency(Metadata{Name: "struct.latency"}),
 		StructRates:          NewRates(Metadata{Name: "struct.rates"}),
 		privateStructGauge:   NewGauge(Metadata{Name: "struct.private-gauge"}),
 		privateStructGauge64: NewGaugeFloat64(Metadata{Name: "struct.private-gauge64"}),
@@ -137,10 +134,7 @@ func TestRegistry(t *testing.T) {
 		"top.rates-1m":       {},
 		"top.rates-10m":      {},
 		"top.rates-1h":       {},
-		"top.hist":           {},
-		"top.latency-1m":     {},
-		"top.latency-10m":    {},
-		"top.latency-1h":     {},
+		"top.histogram":      {},
 		"top.gauge":          {},
 		"top.floatgauge":     {},
 		"top.counter":        {},
@@ -154,9 +148,6 @@ func TestRegistry(t *testing.T) {
 		"struct.counter":     {},
 		"struct.histogram":   {},
 		"struct.rate":        {},
-		"struct.latency-1m":  {},
-		"struct.latency-10m": {},
-		"struct.latency-1h":  {},
 		"struct.rates-count": {},
 		"struct.rates-1m":    {},
 		"struct.rates-10m":   {},
@@ -180,7 +171,7 @@ func TestRegistry(t *testing.T) {
 	if g := r.getGauge("bad"); g != nil {
 		t.Errorf("getGauge returned non-nil %v, expected nil", g)
 	}
-	if g := r.getGauge("top.hist"); g != nil {
+	if g := r.getGauge("top.histogram"); g != nil {
 		t.Errorf("getGauge returned non-nil %v of type %T when requesting non-gauge, expected nil", g, g)
 	}
 
@@ -190,7 +181,7 @@ func TestRegistry(t *testing.T) {
 	if c := r.getCounter("bad"); c != nil {
 		t.Errorf("getCounter returned non-nil %v, expected nil", c)
 	}
-	if c := r.getCounter("top.hist"); c != nil {
+	if c := r.getCounter("top.histogram"); c != nil {
 		t.Errorf("getCounter returned non-nil %v of type %T when requesting non-counter, expected nil", c, c)
 	}
 
@@ -200,7 +191,7 @@ func TestRegistry(t *testing.T) {
 	if r := r.getRate("bad"); r != nil {
 		t.Errorf("getRate returned non-nil %v, expected nil", r)
 	}
-	if r := r.getRate("top.hist"); r != nil {
+	if r := r.getRate("top.histogram"); r != nil {
 		t.Errorf("getRate returned non-nil %v of type %T when requesting non-rate, expected nil", r, r)
 	}
 }

--- a/util/metric/sliding_histogram.go
+++ b/util/metric/sliding_histogram.go
@@ -1,0 +1,62 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package metric
+
+import (
+	"time"
+
+	"github.com/codahale/hdrhistogram"
+)
+
+var _ periodic = &slidingHistogram{}
+
+// A deprecatedWindowedHistogram is a wrapper around an
+// hdrhistogram.WindowedHistogram. The caller must enforce proper
+// synchronization.
+type slidingHistogram struct {
+	windowed *hdrhistogram.WindowedHistogram
+	nextT    time.Time
+	duration time.Duration
+}
+
+// newSlidingHistogram creates a new windowed HDRHistogram with the given
+// parameters. Data is kept in the active window for approximately the given
+// duration. See the documentation for hdrhistogram.WindowedHistogram for
+// details.
+func newSlidingHistogram(duration time.Duration, maxVal int64, sigFigs int) *slidingHistogram {
+	return &slidingHistogram{
+		nextT:    now(),
+		duration: duration,
+		windowed: hdrhistogram.NewWindowed(histWrapNum, 0, maxVal, sigFigs),
+	}
+}
+
+func (h *slidingHistogram) tick() {
+	h.nextT = h.nextT.Add(h.duration / histWrapNum)
+	h.windowed.Rotate()
+}
+
+func (h *slidingHistogram) nextTick() time.Time {
+	return h.nextT
+}
+
+func (h *slidingHistogram) Current() *hdrhistogram.Histogram {
+	maybeTick(h)
+	return cloneHistogram(h.windowed.Merge())
+}
+
+func (h *slidingHistogram) RecordValue(v int64) error {
+	return h.windowed.Current.RecordValue(v)
+}


### PR DESCRIPTION
Reworked our usage of histograms. The primary objective was exposing "sane"
histograms to prometheus; prior to this change we exposed ever-changing
streaming quantiles of windowed histograms, which is completely worthless.

To support our in-house time series (which cannot ingest general histograms)
and for "casual" users of histogram information (TxnCoordSender), support for
windowed histograms remains.

In effect, our Histogram type now wraps two internal histograms:
- a "real" histogram which keeps totals and is scraped by prometheus
- a windowed histogram (in turn composed of several subhistograms through which
  it rotates) which is scraped by time series.

This should work reasonably well with the caveat that we cannot sum our
internal time series histograms and expect mathematically meaningful results,
which is avoided for the most part as histogram source aggregation typically
grabs the maximum value observed, which _is_ valid. The notable exception are
rollups, which are not implemented yet but will end up averaging out the same
quantile at different times, giving meaningless results. That latter
restriction seems unimportant in practice given that roll-ups also downsample
dramatically, so the additional loss of fidelity is likely not a concern as
long as we document it appropriately.

Existing tooling was simplified to keep less "useless" histograms. For example,
we were keeping multiple durations of sliding windows for each time series,
but this wasn't used. Now we record only one at a reasonably high resolution
to time series (and prometheus doesn't use the windowed histograms at all).

Similar treatment is possible for "rates" which is another unidiomatic
construct introduced by me back in the day and should be completely removable
(in a future PR).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9810)

<!-- Reviewable:end -->
