### PR TITLE
sqltest: tidy backup/restore tests

### DIFF
--- a/sql/backup.go
+++ b/sql/backup.go
@@ -45,7 +45,8 @@ const (
 	backupDescriptorName = "BACKUP"
 )
 
-func allRangeDescriptors(txn *client.Txn) ([]roachpb.RangeDescriptor, error) {
+// AllRangeDescriptors fetches all meta2 RangeDescriptor using the given txn.
+func AllRangeDescriptors(txn *client.Txn) ([]roachpb.RangeDescriptor, error) {
 	// TODO(dan): Iterate with some batch size.
 	rows, err := txn.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
 	if err != nil {
@@ -110,7 +111,7 @@ func Backup(
 			var err error
 			setTxnTimestamps(txn, endTime)
 
-			rangeDescs, err = allRangeDescriptors(txn)
+			rangeDescs, err = AllRangeDescriptors(txn)
 			if err != nil {
 				return err
 			}

--- a/testutils/sqlutils/sql_runner.go
+++ b/testutils/sqlutils/sql_runner.go
@@ -63,3 +63,21 @@ func (sr *SQLRunner) Query(query string, args ...interface{}) *gosql.Rows {
 	}
 	return r
 }
+
+// Row is a wrapper around gosql.Row that kills the test on error.
+type Row struct {
+	testing.TB
+	row *gosql.Row
+}
+
+// Scan is a wrapper around (*gosql.Row).Scan that kills the test on error.
+func (r *Row) Scan(dest ...interface{}) {
+	if err := r.row.Scan(dest...); err != nil {
+		r.Fatalf("error scanning '%v': %s", r.row, err)
+	}
+}
+
+// QueryRow is a wrapper around gosql.QueryRow that kills the test on error.
+func (sr *SQLRunner) QueryRow(query string, args ...interface{}) *Row {
+	return &Row{sr.TB, sr.DB.QueryRow(query, args...)}
+}


### PR DESCRIPTION
This commit lays groundwork for replacing the use of sql INSERT and Backup in
the Restore benchmark, which makes the setup take too long. Instead of going
through sql, the output of bankDataInsertStmts will be fed into the upcoming
sql->kv transform and then ingested.

Also converts the benchmarks to subtests, reduces duplication in test setup,
deletes an unnecessary test assertion, and uses testutils.SQLRunner for sql
queries.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9812)

<!-- Reviewable:end -->
