### PR TITLE
Revert "build: fix `make check` on failure"

### DIFF
--- a/build/check-style.sh
+++ b/build/check-style.sh
@@ -177,28 +177,21 @@ runcheck() {
   # We need to set these options again due to the `parallel` magic.
   set -euo pipefail
 
-  # These variables really ought to be local, but then they are not bound
-  # when the trap below fires.
-  start=$(date +%s)
-  name="$1"
+  local name="$1"
   shift
-
-  function footer() {
-    local status=$?
-    local end=$(date +%s)
-    local runtime=$((end-start))
-    if [ $status -eq 0 ]; then
-      echo "--- PASS: $name ($runtime.00s)"
-    else
-      echo "--- FAIL: $name ($runtime.00s)"
-      echo "$output"
-    fi
-    return $status
-  }
-  trap footer EXIT
-
   echo "=== RUN $name"
+  local start=$(date +%s)
   output=$(eval "$name")
+  local status=$?
+  local end=$(date +%s)
+  local runtime=$((end-start))
+  if [ $status -eq 0 ]; then
+    echo "--- PASS: $name ($runtime.00s)"
+  else
+    echo "--- FAIL: $name ($runtime.00s)"
+    echo "$output"
+  fi
+  return $status
 }
 
 exit_status=0


### PR DESCRIPTION
This reverts commit e2d54badbb89c89a4aea856be94b58ff74967d8f.

The commit didn't seem to do much sense. The trap was being overriden,
which caused output from failing tests to not be displayed. Also there's a return value in the trap that seems wrong.
Also it's unclear to me and Tamir what the intent was exactly. All tests
seem to run even on failures before the test too, both on the serial and
on the parallel execution path.
@tschottdorf please do whatever you were trying to do again :)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9824)

<!-- Reviewable:end -->
