### PR TITLE
storage: rework raftScheduler worker notification

### DIFF
--- a/storage/metrics.go
+++ b/storage/metrics.go
@@ -243,6 +243,8 @@ var (
 		Help: "Duration of Replica Raft mutex critical sections"}
 	metaMuStoreNanos = metric.Metadata{Name: "mutex.storenanos",
 		Help: "Duration of Store mutex critical sections"}
+	metaMuSchedulerNanos = metric.Metadata{Name: "mutex.schedulernanos",
+		Help: "Duration of Raft Scheduler mutex critical sections"}
 )
 
 // StoreMetrics is the set of metrics for a given store.
@@ -386,9 +388,10 @@ type StoreMetrics struct {
 	GCResolveSuccess             *metric.Counter
 
 	// Mutex timing information.
-	MuStoreNanos   *metric.Histogram
-	MuRaftNanos    *metric.Histogram
-	MuReplicaNanos *metric.Histogram
+	MuStoreNanos     *metric.Histogram
+	MuSchedulerNanos *metric.Histogram
+	MuRaftNanos      *metric.Histogram
+	MuReplicaNanos   *metric.Histogram
 
 	// Stats for efficient merges.
 	mu struct {
@@ -545,6 +548,10 @@ func newStoreMetrics() *StoreMetrics {
 		),
 		MuStoreNanos: metric.NewHistogram(
 			metaMuStoreNanos, time.Minute,
+			time.Second.Nanoseconds(), 1,
+		),
+		MuSchedulerNanos: metric.NewHistogram(
+			metaMuSchedulerNanos, time.Minute,
 			time.Second.Nanoseconds(), 1,
 		),
 	}

--- a/storage/scheduler_test.go
+++ b/storage/scheduler_test.go
@@ -194,7 +194,7 @@ func TestSchedulerLoop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	p := newTestProcessor()
-	s := newRaftScheduler(context.Background(), p, 1)
+	s := newRaftScheduler(context.Background(), nil, p, 1)
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	s.Start(stopper)
@@ -215,7 +215,7 @@ func TestSchedulerBuffering(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	p := newTestProcessor()
-	s := newRaftScheduler(context.Background(), p, 1)
+	s := newRaftScheduler(context.Background(), nil, p, 1)
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	s.Start(stopper)

--- a/storage/store.go
+++ b/storage/store.go
@@ -2331,9 +2331,9 @@ func (s *Store) HandleRaftRequest(
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	q := s.mu.replicaQueues[req.RangeID]
 	if len(q) >= replicaRequestQueueSize {
+		s.mu.Unlock()
 		// TODO(peter): Return an error indicating the request was dropped. Note
 		// that dropping the request is safe. Raft will retry.
 		s.metrics.RaftRcvdMsgDropped.Inc(1)
@@ -2343,6 +2343,7 @@ func (s *Store) HandleRaftRequest(
 		req:        req,
 		respStream: respStream,
 	})
+	s.mu.Unlock()
 
 	s.scheduler.EnqueueRaftRequest(req.RangeID)
 	return nil

--- a/storage/store.go
+++ b/storage/store.go
@@ -650,7 +650,7 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 	s.intentResolver = newIntentResolver(s)
 	s.raftEntryCache = newRaftEntryCache(cfg.RaftEntryCacheSize)
 	s.drainLeases.Store(false)
-	s.scheduler = newRaftScheduler(cfg.Ctx, s, storeSchedulerConcurrency)
+	s.scheduler = newRaftScheduler(cfg.Ctx, s.metrics, s, storeSchedulerConcurrency)
 
 	storeMuLogger := syncutil.ThresholdLogger(
 		s.Ctx(),

--- a/ui/app/containers/nodeGraphs.tsx
+++ b/ui/app/containers/nodeGraphs.tsx
@@ -281,6 +281,10 @@ export default class extends React.Component<IInjectedProps, {}> {
                         aggregateMax downsampleMax />
               </Axis>
               <Axis format={ (n: number) => d3.format(".1f")(NanoToMilli(n)) } label="Milliseconds">
+                <Metric name="cr.store.mutex.schedulernanos-max" title="SchedulerMu"
+                        aggregateMax downsampleMax />
+              </Axis>
+              <Axis format={ (n: number) => d3.format(".1f")(NanoToMilli(n)) } label="Milliseconds">
                 <Metric name="cr.store.mutex.replicananos-max" title="ReplicaMu"
                         aggregateMax downsampleMax />
               </Axis>


### PR DESCRIPTION
Use a sync.Cond instead of a buffered channel. Buffered channels have
internal overhead for maintaining the buffer even when the elements are
empty. And the buffer wasn't necessary as the raftScheduler work is
already buffered on the internal queue. Lastly, signaling a sync.Cond is
significantly faster than selecting and sending on a buffered channel.

Release Store.mu before calling raftScheduler.EnqueueRaftRequest.

See #9749

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9831)

<!-- Reviewable:end -->
