### PR TITLE
storage: narrow Replica.mu locking in Replica.TruncateLog

### DIFF
--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1532,8 +1532,6 @@ func (r *Replica) TruncateLog(
 	h roachpb.Header,
 	args roachpb.TruncateLogRequest,
 ) (roachpb.TruncateLogResponse, *PostCommitTrigger, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
 	var reply roachpb.TruncateLogResponse
 
 	// After a merge, it's possible that this request was sent to the wrong
@@ -1573,7 +1571,9 @@ func (r *Replica) TruncateLog(
 		hlc.ZeroTimestamp, nil /* txn */, false /* returnKeys */); err != nil {
 		return reply, nil, err
 	}
+	r.mu.Lock()
 	raftLogSize := r.mu.raftLogSize + diff.SysBytes
+	r.mu.Unlock()
 	// Check raftLogSize since it isn't persisted between server restarts.
 	if raftLogSize < 0 {
 		raftLogSize = 0


### PR DESCRIPTION
It was unnecessary to hold Replica.mu for the duration of
Replica.TruncateLog as it is only protected access to
Replica.mu.raftLogSize.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9840)

<!-- Reviewable:end -->
