### PR TITLE
server, storage: remove Open() from the Engine interface

### DIFF
--- a/pkg/base/store_spec.go
+++ b/pkg/base/store_spec.go
@@ -25,6 +25,7 @@ import (
 	"unicode"
 
 	"github.com/dustin/go-humanize"
+	"github.com/spf13/pflag"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -220,6 +221,8 @@ type StoreSpecList struct {
 	Specs   []StoreSpec
 	updated bool // updated is used to determine if specs only contain the default value.
 }
+
+var _ pflag.Value = &StoreSpecList{}
 
 // String returns a string representation of all the StoreSpecs. This is part
 // of pflag's value interface.

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -71,17 +71,17 @@ func openStore(cmd *cobra.Command, dir string, stopper *stop.Stopper) (*engine.R
 	if err != nil {
 		return nil, err
 	}
-	db := engine.NewRocksDB(
+	db, err := engine.NewRocksDB(
 		roachpb.Attributes{},
 		dir,
 		cache,
 		0,
 		maxOpenFiles,
-		stopper,
 	)
-	if err := db.Open(); err != nil {
+	if err != nil {
 		return nil, err
 	}
+	stopper.AddCloser(db)
 	return db, nil
 }
 

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -303,10 +303,10 @@ func runStart(_ *cobra.Command, args []string) error {
 	stopper := initBacktrace(logDir)
 	log.Event(startCtx, "initialized profiles")
 
-	if err := serverCfg.InitStores(); err != nil {
+	engines, err := serverCfg.CreateEngines()
+	if err != nil {
 		return fmt.Errorf("failed to initialize stores: %s", err)
 	}
-	engines := server.Engines(serverCfg.Engines)
 	defer engines.Close()
 
 	if err := serverCfg.InitNode(); err != nil {
@@ -317,7 +317,7 @@ func runStart(_ *cobra.Command, args []string) error {
 	if envVarsUsed := envutil.GetEnvVarsUsed(); len(envVarsUsed) > 0 {
 		log.Infof(startCtx, "using local environment variables: %s", strings.Join(envVarsUsed, ", "))
 	}
-	s, err := server.NewServer(serverCfg, stopper)
+	s, err := server.NewServer(serverCfg, engines, stopper)
 	if err != nil {
 		return fmt.Errorf("failed to start Cockroach server: %s", err)
 	}

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -33,16 +33,17 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"google.golang.org/grpc"
-
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
-	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -51,10 +52,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/pkg/errors"
-
-	"github.com/spf13/cobra"
 )
 
 var errMissingParams = errors.New("missing or invalid parameters")
@@ -237,39 +234,6 @@ func initBlockProfile() {
 	runtime.SetBlockProfileRate(int(d))
 }
 
-func initCheckpointing(engines []engine.Engine) {
-	checkpointInterval := envutil.EnvOrDefaultDuration("COCKROACH_CHECKPOINT_INTERVAL", -1)
-	if checkpointInterval < 0 {
-		return
-	}
-	if min := 10 * time.Second; checkpointInterval < min {
-		log.Infof(context.TODO(), "fixing excessively short checkpointing interval: %s -> %s",
-			checkpointInterval, min)
-		checkpointInterval = min
-	}
-
-	go func() {
-		t := time.NewTicker(checkpointInterval)
-		defer t.Stop()
-
-		for {
-			<-t.C
-
-			const format = "2006-01-02T15_04_05"
-			dir := timeutil.Now().Format(format)
-			start := timeutil.Now()
-			for _, e := range engines {
-				// Note that when dir is relative (as it is here) it is appended to the
-				// engine's data directory.
-				if err := e.Checkpoint(dir); err != nil {
-					log.Warning(context.TODO(), err)
-				}
-			}
-			log.Infof(context.TODO(), "created checkpoint %s: %.1fms", dir, timeutil.Since(start).Seconds()*1000)
-		}
-	}()
-}
-
 // ErrorCode is the value to be used by main() as exit code in case of
 // error. For most errors 1 is appropriate, but a signal termination
 // can change this.
@@ -366,8 +330,6 @@ func runStart(_ *cobra.Command, args []string) error {
 	if !envutil.EnvOrDefaultBool("COCKROACH_SKIP_UPDATE_CHECK", false) {
 		s.PeriodicallyCheckForUpdates()
 	}
-
-	initCheckpointing(serverCfg.Engines)
 
 	pgURL, err := serverCfg.PGURL(connUser)
 	if err != nil {

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -303,12 +303,6 @@ func runStart(_ *cobra.Command, args []string) error {
 	stopper := initBacktrace(logDir)
 	log.Event(startCtx, "initialized profiles")
 
-	engines, err := serverCfg.CreateEngines()
-	if err != nil {
-		return fmt.Errorf("failed to initialize stores: %s", err)
-	}
-	defer engines.Close()
-
 	if err := serverCfg.InitNode(); err != nil {
 		return fmt.Errorf("failed to initialize node: %s", err)
 	}
@@ -317,12 +311,10 @@ func runStart(_ *cobra.Command, args []string) error {
 	if envVarsUsed := envutil.GetEnvVarsUsed(); len(envVarsUsed) > 0 {
 		log.Infof(startCtx, "using local environment variables: %s", strings.Join(envVarsUsed, ", "))
 	}
-	s, err := server.NewServer(serverCfg, engines, stopper)
+	s, err := server.NewServer(serverCfg, stopper)
 	if err != nil {
 		return fmt.Errorf("failed to start Cockroach server: %s", err)
 	}
-	// The server took ownership of the engines.
-	engines = nil
 
 	if err := s.Start(startCtx); err != nil {
 		return fmt.Errorf("cockroach server exited with error: %s", err)

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -303,9 +303,11 @@ func runStart(_ *cobra.Command, args []string) error {
 	stopper := initBacktrace(logDir)
 	log.Event(startCtx, "initialized profiles")
 
-	if err := serverCfg.InitStores(stopper); err != nil {
+	if err := serverCfg.InitStores(); err != nil {
 		return fmt.Errorf("failed to initialize stores: %s", err)
 	}
+	engines := server.Engines(serverCfg.Engines)
+	defer engines.Close()
 
 	if err := serverCfg.InitNode(); err != nil {
 		return fmt.Errorf("failed to initialize node: %s", err)
@@ -319,6 +321,8 @@ func runStart(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to start Cockroach server: %s", err)
 	}
+	// The server took ownership of the engines.
+	engines = nil
 
 	if err := s.Start(startCtx); err != nil {
 		return fmt.Errorf("cockroach server exited with error: %s", err)

--- a/pkg/kv/dist_sender_server_test.go
+++ b/pkg/kv/dist_sender_server_test.go
@@ -64,7 +64,7 @@ func TestRangeLookupWithOpenTransaction(t *testing.T) {
 	now := s.Clock().Now()
 	txn := roachpb.NewTransaction("txn", roachpb.Key("foobar"), 0, enginepb.SERIALIZABLE, now, 0)
 	if err := engine.MVCCPutProto(
-		context.Background(), s.(*server.TestServer).Cfg.Engines[0],
+		context.Background(), s.(*server.TestServer).Engines()[0],
 		nil, key, now, txn, &roachpb.RangeDescriptor{}); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -366,7 +366,7 @@ func (cfg *Config) CreateEngines() (Engines, error) {
 	defer engines.Close()
 
 	if cfg.enginesCreated {
-		return nil, errors.Errorf("engines already created")
+		return Engines{}, errors.Errorf("engines already created")
 	}
 	cfg.enginesCreated = true
 
@@ -381,7 +381,7 @@ func (cfg *Config) CreateEngines() (Engines, error) {
 	}
 	openFileLimitPerStore, err := setOpenFileLimit(physicalStores)
 	if err != nil {
-		return nil, err
+		return Engines{}, err
 	}
 
 	skipSizeCheck := cfg.TestingKnobs.Store != nil &&
@@ -392,12 +392,12 @@ func (cfg *Config) CreateEngines() (Engines, error) {
 			if spec.SizePercent > 0 {
 				sysMem, err := GetTotalMemory()
 				if err != nil {
-					return nil, errors.Errorf("could not retrieve system memory")
+					return Engines{}, errors.Errorf("could not retrieve system memory")
 				}
 				sizeInBytes = int64(float64(sysMem) * spec.SizePercent / 100)
 			}
 			if sizeInBytes != 0 && !skipSizeCheck && sizeInBytes < base.MinimumStoreSize {
-				return nil, errors.Errorf("%f%% of memory is only %s bytes, which is below the minimum requirement of %s",
+				return Engines{}, errors.Errorf("%f%% of memory is only %s bytes, which is below the minimum requirement of %s",
 					spec.SizePercent, humanizeutil.IBytes(sizeInBytes), humanizeutil.IBytes(base.MinimumStoreSize))
 			}
 			engines = append(engines, engine.NewInMem(spec.Attributes, sizeInBytes))
@@ -405,12 +405,12 @@ func (cfg *Config) CreateEngines() (Engines, error) {
 			if spec.SizePercent > 0 {
 				fileSystemUsage := gosigar.FileSystemUsage{}
 				if err := fileSystemUsage.Get(spec.Path); err != nil {
-					return nil, err
+					return Engines{}, err
 				}
 				sizeInBytes = int64(float64(fileSystemUsage.Total) * spec.SizePercent / 100)
 			}
 			if sizeInBytes != 0 && !skipSizeCheck && sizeInBytes < base.MinimumStoreSize {
-				return nil, errors.Errorf("%f%% of %s's total free space is only %s bytes, which is below the minimum requirement of %s",
+				return Engines{}, errors.Errorf("%f%% of %s's total free space is only %s bytes, which is below the minimum requirement of %s",
 					spec.SizePercent, spec.Path, humanizeutil.IBytes(sizeInBytes), humanizeutil.IBytes(base.MinimumStoreSize))
 			}
 
@@ -422,7 +422,7 @@ func (cfg *Config) CreateEngines() (Engines, error) {
 				openFileLimitPerStore,
 			)
 			if err != nil {
-				return nil, err
+				return Engines{}, err
 			}
 			engines = append(engines, eng)
 		}

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -36,9 +36,11 @@ func TestParseInitNodeAttributes(t *testing.T) {
 	cfg.Stores = base.StoreSpecList{Specs: []base.StoreSpec{{InMemory: true, SizeInBytes: base.MinimumStoreSize * 100}}}
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	if err := cfg.InitStores(stopper); err != nil {
+	if err := cfg.InitStores(); err != nil {
 		t.Fatalf("Failed to initialize stores: %s", err)
 	}
+	engines := Engines(cfg.Engines)
+	defer engines.Close()
 	if err := cfg.InitNode(); err != nil {
 		t.Fatalf("Failed to initialize node: %s", err)
 	}
@@ -57,9 +59,11 @@ func TestParseJoinUsingAddrs(t *testing.T) {
 	cfg.Stores = base.StoreSpecList{Specs: []base.StoreSpec{{InMemory: true, SizeInBytes: base.MinimumStoreSize * 100}}}
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	if err := cfg.InitStores(stopper); err != nil {
+	if err := cfg.InitStores(); err != nil {
 		t.Fatalf("Failed to initialize stores: %s", err)
 	}
+	engines := Engines(cfg.Engines)
+	defer engines.Close()
 	if err := cfg.InitNode(); err != nil {
 		t.Fatalf("Failed to initialize node: %s", err)
 	}

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/gossip/resolver"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
 func TestParseInitNodeAttributes(t *testing.T) {
@@ -34,12 +33,10 @@ func TestParseInitNodeAttributes(t *testing.T) {
 	cfg := MakeConfig()
 	cfg.Attrs = "attr1=val1::attr2=val2"
 	cfg.Stores = base.StoreSpecList{Specs: []base.StoreSpec{{InMemory: true, SizeInBytes: base.MinimumStoreSize * 100}}}
-	stopper := stop.NewStopper()
-	defer stopper.Stop()
-	if err := cfg.InitStores(); err != nil {
+	engines, err := cfg.CreateEngines()
+	if err != nil {
 		t.Fatalf("Failed to initialize stores: %s", err)
 	}
-	engines := Engines(cfg.Engines)
 	defer engines.Close()
 	if err := cfg.InitNode(); err != nil {
 		t.Fatalf("Failed to initialize node: %s", err)
@@ -57,12 +54,10 @@ func TestParseJoinUsingAddrs(t *testing.T) {
 	cfg := MakeConfig()
 	cfg.JoinList = []string{"localhost:12345,,localhost:23456", "localhost:34567"}
 	cfg.Stores = base.StoreSpecList{Specs: []base.StoreSpec{{InMemory: true, SizeInBytes: base.MinimumStoreSize * 100}}}
-	stopper := stop.NewStopper()
-	defer stopper.Stop()
-	if err := cfg.InitStores(); err != nil {
+	engines, err := cfg.CreateEngines()
+	if err != nil {
 		t.Fatalf("Failed to initialize stores: %s", err)
 	}
-	engines := Engines(cfg.Engines)
 	defer engines.Close()
 	if err := cfg.InitNode(); err != nil {
 		t.Fatalf("Failed to initialize node: %s", err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -148,13 +148,13 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	// components.
 	ctx = tracing.WithTracer(ctx, s.cfg.AmbientCtx.Tracer)
 
-	if cfg.Insecure {
+	if s.cfg.Insecure {
 		log.Warning(ctx, "running in insecure mode, this is strongly discouraged. See --insecure.")
 	}
 
 	s.clock.SetMaxOffset(cfg.MaxOffset)
 
-	s.rpcContext = rpc.NewContext(s.cfg.AmbientCtx, cfg.Config, s.clock, s.stopper)
+	s.rpcContext = rpc.NewContext(s.cfg.AmbientCtx, s.cfg.Config, s.clock, s.stopper)
 	s.rpcContext.HeartbeatCB = func() {
 		if err := s.rpcContext.RemoteClocks.VerifyClockOffset(); err != nil {
 			log.Fatal(ctx, err)
@@ -177,7 +177,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		s.gossip,
 		s.clock,
 		s.rpcContext,
-		cfg.TimeUntilStoreDead,
+		s.cfg.TimeUntilStoreDead,
 		s.stopper,
 	)
 
@@ -208,7 +208,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		s.cfg.AmbientCtx,
 		s.distSender,
 		s.clock,
-		cfg.Linearizable,
+		s.cfg.Linearizable,
 		s.stopper,
 		txnMetrics,
 	)
@@ -217,7 +217,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	// Use the range lease expiration and renewal durations as the node
 	// liveness expiration and heartbeat interval.
 	active, renewal := storage.RangeLeaseDurations(
-		storage.RaftElectionTimeout(cfg.RaftTickInterval, cfg.RaftElectionTimeoutTicks))
+		storage.RaftElectionTimeout(s.cfg.RaftTickInterval, s.cfg.RaftElectionTimeoutTicks))
 	s.nodeLiveness = storage.NewNodeLiveness(
 		s.cfg.AmbientCtx, s.clock, s.db, s.gossip, active, renewal,
 	)
@@ -233,7 +233,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	// Set up Lease Manager
 	var lmKnobs sql.LeaseManagerTestingKnobs
 	if cfg.TestingKnobs.SQLLeaseManager != nil {
-		lmKnobs = *cfg.TestingKnobs.SQLLeaseManager.(*sql.LeaseManagerTestingKnobs)
+		lmKnobs = *s.cfg.TestingKnobs.SQLLeaseManager.(*sql.LeaseManagerTestingKnobs)
 	}
 	s.leaseMgr = sql.NewLeaseManager(&s.nodeIDContainer, *s.db, s.clock, lmKnobs, s.stopper)
 	s.leaseMgr.RefreshLeases(s.stopper, s.db, s.gossip)
@@ -259,14 +259,14 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		DistSQLSrv:            s.distSQLServer,
 		MetricsSampleInterval: s.cfg.MetricsSampleInterval,
 	}
-	if cfg.TestingKnobs.SQLExecutor != nil {
-		execCfg.TestingKnobs = cfg.TestingKnobs.SQLExecutor.(*sql.ExecutorTestingKnobs)
+	if s.cfg.TestingKnobs.SQLExecutor != nil {
+		execCfg.TestingKnobs = s.cfg.TestingKnobs.SQLExecutor.(*sql.ExecutorTestingKnobs)
 	} else {
 		execCfg.TestingKnobs = &sql.ExecutorTestingKnobs{}
 	}
-	if cfg.TestingKnobs.SQLSchemaChanger != nil {
+	if s.cfg.TestingKnobs.SQLSchemaChanger != nil {
 		execCfg.SchemaChangerTestingKnobs =
-			cfg.TestingKnobs.SQLSchemaChanger.(*sql.SchemaChangerTestingKnobs)
+			s.cfg.TestingKnobs.SQLSchemaChanger.(*sql.SchemaChangerTestingKnobs)
 	} else {
 		execCfg.SchemaChangerTestingKnobs = &sql.SchemaChangerTestingKnobs{}
 	}
@@ -305,8 +305,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		RangeLeaseRenewalDuration: renewal,
 		TimeSeriesDataStore:       s.tsDB,
 	}
-	if cfg.TestingKnobs.Store != nil {
-		storeCfg.TestingKnobs = *cfg.TestingKnobs.Store.(*storage.StoreTestingKnobs)
+	if s.cfg.TestingKnobs.Store != nil {
+		storeCfg.TestingKnobs = *s.cfg.TestingKnobs.Store.(*storage.StoreTestingKnobs)
 	}
 
 	s.recorder = status.NewMetricsRecorder(s.clock)
@@ -327,6 +327,10 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	for _, gw := range []grpcGatewayServer{&s.admin, s.status, &s.tsServer} {
 		gw.RegisterService(s.grpc)
 	}
+
+	// Take ownership of the engines.
+	engines := Engines(s.cfg.Engines)
+	stopper.AddCloser(&engines)
 
 	return s, nil
 }

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -256,14 +257,13 @@ func (ts *TestServer) Start(params base.TestServerArgs) error {
 		return err
 	}
 
-	if err := ts.Cfg.InitStores(); err != nil {
+	engines, err := ts.Cfg.CreateEngines()
+	if err != nil {
 		return err
 	}
-	engines := Engines(ts.Cfg.Engines)
 	defer engines.Close()
 
-	var err error
-	ts.Server, err = NewServer(*ts.Cfg, params.Stopper)
+	ts.Server, err = NewServer(*ts.Cfg, engines, params.Stopper)
 	if err != nil {
 		return err
 	}
@@ -329,6 +329,11 @@ func WaitForInitialSplits(db *client.DB) error {
 // Stores returns the collection of stores from this TestServer's node.
 func (ts *TestServer) Stores() *storage.Stores {
 	return ts.node.stores
+}
+
+// Engines returns the TestServer's engines.
+func (ts *TestServer) Engines() []engine.Engine {
+	return ts.engines
 }
 
 // ServingAddr returns the server's address. Should be used by clients.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -36,7 +36,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -137,6 +136,30 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 		cfg.AdvertiseAddr = util.TestAddr.String()
 		cfg.HTTPAddr = util.TestAddr.String()
 	}
+
+	// Ensure we have the correct number of engines. Add in-memory ones where
+	// needed. There must be at least one store/engine.
+	if len(params.StoreSpecs) == 0 {
+		params.StoreSpecs = []base.StoreSpec{base.DefaultTestStoreSpec}
+	}
+	// Validate the store specs.
+	for _, storeSpec := range params.StoreSpecs {
+		if storeSpec.InMemory {
+			if storeSpec.SizePercent > 0 {
+				panic(fmt.Sprintf("test server does not yet support in memory stores based on percentage of total memory: %s", storeSpec))
+			}
+		} else {
+			// TODO(bram): This will require some cleanup of on disk files.
+			panic(fmt.Sprintf("test server does not yet support on disk stores: %s", storeSpec))
+		}
+	}
+	// Copy over the store specs.
+	cfg.Stores = base.StoreSpecList{Specs: params.StoreSpecs}
+	if cfg.TestingKnobs.Store == nil {
+		cfg.TestingKnobs.Store = &storage.StoreTestingKnobs{}
+	}
+	cfg.TestingKnobs.Store.(*storage.StoreTestingKnobs).SkipMinSizeCheck = true
+
 	return cfg
 }
 
@@ -233,22 +256,8 @@ func (ts *TestServer) Start(params base.TestServerArgs) error {
 		return err
 	}
 
-	// Ensure we have the correct number of engines. Add in-memory ones where
-	// needed. There must be at least one store/engine.
-	if len(params.StoreSpecs) == 0 {
-		params.StoreSpecs = []base.StoreSpec{base.DefaultTestStoreSpec}
-	}
-	for _, storeSpec := range params.StoreSpecs {
-		if storeSpec.InMemory {
-			if storeSpec.SizePercent > 0 {
-				panic(fmt.Sprintf("test server does not yet support in memory stores based on percentage of total memory: %s", storeSpec))
-			}
-			ts.Cfg.Engines = append(ts.Cfg.Engines,
-				engine.NewInMem(roachpb.Attributes{}, storeSpec.SizeInBytes))
-		} else {
-			// TODO(bram): This will require some cleanup of on disk files.
-			panic(fmt.Sprintf("test server does not yet support on disk stores: %s", storeSpec))
-		}
+	if err := ts.Cfg.InitStores(); err != nil {
+		return err
 	}
 	engines := Engines(ts.Cfg.Engines)
 	defer engines.Close()

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -243,22 +243,24 @@ func (ts *TestServer) Start(params base.TestServerArgs) error {
 			if storeSpec.SizePercent > 0 {
 				panic(fmt.Sprintf("test server does not yet support in memory stores based on percentage of total memory: %s", storeSpec))
 			}
-			ts.Cfg.Engines = append(ts.Cfg.Engines, engine.NewInMem(
-				roachpb.Attributes{},
-				storeSpec.SizeInBytes,
-				params.Stopper,
-			))
+			ts.Cfg.Engines = append(ts.Cfg.Engines,
+				engine.NewInMem(roachpb.Attributes{}, storeSpec.SizeInBytes))
 		} else {
 			// TODO(bram): This will require some cleanup of on disk files.
 			panic(fmt.Sprintf("test server does not yet support on disk stores: %s", storeSpec))
 		}
 	}
+	engines := Engines(ts.Cfg.Engines)
+	defer engines.Close()
 
 	var err error
 	ts.Server, err = NewServer(*ts.Cfg, params.Stopper)
 	if err != nil {
 		return err
 	}
+	// The server took ownership of the engines.
+	engines = nil
+
 	// Our context must be shared with our server.
 	ts.Cfg = &ts.Server.cfg
 

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -257,18 +257,11 @@ func (ts *TestServer) Start(params base.TestServerArgs) error {
 		return err
 	}
 
-	engines, err := ts.Cfg.CreateEngines()
+	var err error
+	ts.Server, err = NewServer(*ts.Cfg, params.Stopper)
 	if err != nil {
 		return err
 	}
-	defer engines.Close()
-
-	ts.Server, err = NewServer(*ts.Cfg, engines, params.Stopper)
-	if err != nil {
-		return err
-	}
-	// The server took ownership of the engines.
-	engines = nil
 
 	// Our context must be shared with our server.
 	ts.Cfg = &ts.Server.cfg

--- a/pkg/storage/abort_cache_test.go
+++ b/pkg/storage/abort_cache_test.go
@@ -61,7 +61,9 @@ func init() {
 func createTestAbortCache(
 	t *testing.T, rangeID roachpb.RangeID, stopper *stop.Stopper,
 ) (*AbortCache, engine.Engine) {
-	return NewAbortCache(rangeID), engine.NewInMem(roachpb.Attributes{}, 1<<20, stopper)
+	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	stopper.AddCloser(eng)
+	return NewAbortCache(rangeID), eng
 }
 
 // TestAbortCachePutGetClearData tests basic get & put functionality as well as

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -77,7 +77,8 @@ func TestStoreRecoverFromEngine(t *testing.T) {
 	clock := hlc.NewClock(manual.UnixNano)
 	engineStopper := stop.NewStopper()
 	defer engineStopper.Stop()
-	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20, engineStopper)
+	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	engineStopper.AddCloser(eng)
 	var rangeID2 roachpb.RangeID
 
 	get := func(store *storage.Store, rangeID roachpb.RangeID, key roachpb.Key) int64 {
@@ -167,7 +168,8 @@ func TestStoreRecoverWithErrors(t *testing.T) {
 	clock := hlc.NewClock(manual.UnixNano)
 	engineStopper := stop.NewStopper()
 	defer engineStopper.Stop()
-	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20, engineStopper)
+	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	engineStopper.AddCloser(eng)
 
 	numIncrements := 0
 

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -214,8 +214,10 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 			}
 			return nil
 		}
+	eng := engine.NewInMem(roachpb.Attributes{}, 10<<20)
+	stopper.AddCloser(eng)
 	store := createTestStoreWithEngine(t,
-		engine.NewInMem(roachpb.Attributes{}, 10<<20, stopper),
+		eng,
 		clock,
 		true,
 		cfg,

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -91,8 +91,10 @@ func createTestStoreWithConfig(
 ) (*storage.Store, *stop.Stopper, *hlc.ManualClock) {
 	stopper := stop.NewStopper()
 	manual := hlc.NewManualClock(123)
+	eng := engine.NewInMem(roachpb.Attributes{}, 10<<20)
+	stopper.AddCloser(eng)
 	store := createTestStoreWithEngine(t,
-		engine.NewInMem(roachpb.Attributes{}, 10<<20, stopper),
+		eng,
 		hlc.NewClock(manual.UnixNano),
 		true,
 		storeCfg,
@@ -648,7 +650,8 @@ func (m *multiTestContext) addStore(idx int) {
 	} else {
 		engineStopper := stop.NewStopper()
 		m.engineStoppers = append(m.engineStoppers, engineStopper)
-		eng = engine.NewInMem(roachpb.Attributes{}, 1<<20, engineStopper)
+		eng = engine.NewInMem(roachpb.Attributes{}, 1<<20)
+		engineStopper.AddCloser(eng)
 		m.engines = append(m.engines, eng)
 		needBootstrap = true
 	}

--- a/pkg/storage/engine/batch_test.go
+++ b/pkg/storage/engine/batch_test.go
@@ -52,7 +52,8 @@ func mvccKey(k interface{}) MVCCKey {
 func testBatchBasics(t *testing.T, commit func(e Engine, b Batch) error) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	e := NewInMem(roachpb.Attributes{}, 1<<20, stopper)
+	e := NewInMem(roachpb.Attributes{}, 1<<20)
+	stopper.AddCloser(e)
 
 	b := e.NewBatch()
 	defer b.Close()
@@ -231,7 +232,8 @@ func TestBatchGet(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	e := NewInMem(roachpb.Attributes{}, 1<<20, stopper)
+	e := NewInMem(roachpb.Attributes{}, 1<<20)
+	stopper.AddCloser(e)
 
 	b := e.NewBatch()
 	defer b.Close()
@@ -285,7 +287,8 @@ func TestBatchMerge(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	e := NewInMem(roachpb.Attributes{}, 1<<20, stopper)
+	e := NewInMem(roachpb.Attributes{}, 1<<20)
+	stopper.AddCloser(e)
 
 	b := e.NewBatch()
 	defer b.Close()
@@ -342,7 +345,8 @@ func TestBatchProto(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	e := NewInMem(roachpb.Attributes{}, 1<<20, stopper)
+	e := NewInMem(roachpb.Attributes{}, 1<<20)
+	stopper.AddCloser(e)
 
 	b := e.NewBatch()
 	defer b.Close()
@@ -389,7 +393,8 @@ func TestBatchScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	e := NewInMem(roachpb.Attributes{}, 1<<20, stopper)
+	e := NewInMem(roachpb.Attributes{}, 1<<20)
+	stopper.AddCloser(e)
 
 	b := e.NewBatch()
 	defer b.Close()
@@ -482,7 +487,8 @@ func TestBatchScanWithDelete(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	e := NewInMem(roachpb.Attributes{}, 1<<20, stopper)
+	e := NewInMem(roachpb.Attributes{}, 1<<20)
+	stopper.AddCloser(e)
 
 	b := e.NewBatch()
 	defer b.Close()
@@ -510,7 +516,8 @@ func TestBatchScanMaxWithDeleted(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	e := NewInMem(roachpb.Attributes{}, 1<<20, stopper)
+	e := NewInMem(roachpb.Attributes{}, 1<<20)
+	stopper.AddCloser(e)
 
 	b := e.NewBatch()
 	defer b.Close()
@@ -544,7 +551,8 @@ func TestBatchConcurrency(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	e := NewInMem(roachpb.Attributes{}, 1<<20, stopper)
+	e := NewInMem(roachpb.Attributes{}, 1<<20)
+	stopper.AddCloser(e)
 
 	b := e.NewBatch()
 	defer b.Close()
@@ -579,7 +587,8 @@ func TestBatchBuilder(t *testing.T) {
 
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	e := NewInMem(roachpb.Attributes{}, 1<<20, stopper)
+	e := NewInMem(roachpb.Attributes{}, 1<<20)
+	stopper.AddCloser(e)
 
 	batch := e.NewBatch().(*rocksDBBatch)
 	// Ensure that, even though we reach into the batch's internals with
@@ -627,7 +636,8 @@ func TestBatchBuilderStress(t *testing.T) {
 
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	e := NewInMem(roachpb.Attributes{}, 1<<20, stopper)
+	e := NewInMem(roachpb.Attributes{}, 1<<20)
+	stopper.AddCloser(e)
 
 	rng, _ := randutil.NewPseudoRand()
 
@@ -692,7 +702,8 @@ func TestBatchDistinct(t *testing.T) {
 
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	e := NewInMem(roachpb.Attributes{}, 1<<20, stopper)
+	e := NewInMem(roachpb.Attributes{}, 1<<20)
+	stopper.AddCloser(e)
 
 	if err := e.Put(mvccKey("b"), []byte("b")); err != nil {
 		t.Fatal(err)
@@ -763,7 +774,8 @@ func TestBatchDistinctPanics(t *testing.T) {
 
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	e := NewInMem(roachpb.Attributes{}, 1<<20, stopper)
+	e := NewInMem(roachpb.Attributes{}, 1<<20)
+	stopper.AddCloser(e)
 
 	batch := e.NewBatch()
 	defer batch.Close()

--- a/pkg/storage/engine/bench_rocksdb_test.go
+++ b/pkg/storage/engine/bench_rocksdb_test.go
@@ -27,23 +27,25 @@ import (
 
 func setupMVCCRocksDB(b testing.TB, loc string) (Engine, *stop.Stopper) {
 	stopper := stop.NewStopper()
-	rocksdb := NewRocksDB(
+	rocksdb, err := NewRocksDB(
 		roachpb.Attributes{},
 		loc,
 		RocksDBCache{},
 		0,
 		DefaultMaxOpenFiles,
-		stopper,
 	)
-	if err := rocksdb.Open(); err != nil {
+	if err != nil {
 		b.Fatalf("could not create new rocksdb db instance at %s: %v", loc, err)
 	}
+	stopper.AddCloser(rocksdb)
 	return rocksdb, stopper
 }
 
 func setupMVCCInMemRocksDB(_ testing.TB, loc string) (Engine, *stop.Stopper) {
 	stopper := stop.NewStopper()
-	return NewInMem(roachpb.Attributes{}, testCacheSize, stopper), stopper
+	eng := NewInMem(roachpb.Attributes{}, testCacheSize)
+	stopper.AddCloser(eng)
+	return eng, stopper
 }
 
 // Read benchmarks. All of them run with on-disk data.

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -160,10 +160,6 @@ type Engine interface {
 	ReadWriter
 	// Attrs returns the engine/store attributes.
 	Attrs() roachpb.Attributes
-	// Checkpoint creates a point-in-time snapshot of the on-disk state of the
-	// key/value store, hard-linking and copying files into the specified
-	// directory.
-	Checkpoint(dir string) error
 	// Capacity returns capacity details for the engine's available storage.
 	Capacity() (roachpb.StoreCapacity, error)
 	// Flush causes the engine to write all in-memory data to disk

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -177,8 +177,6 @@ type Engine interface {
 	// by invoking Close(). Note that snapshots must not be used after the
 	// original engine has been stopped.
 	NewSnapshot() Reader
-	// Open initializes the engine.
-	Open() error
 }
 
 // Batch is the interface for batch specific operations.

--- a/pkg/storage/engine/engine_test.go
+++ b/pkg/storage/engine/engine_test.go
@@ -60,7 +60,8 @@ var (
 func runWithAllEngines(test func(e Engine, t *testing.T), t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	inMem := NewInMem(inMemAttrs, testCacheSize, stopper)
+	inMem := NewInMem(inMemAttrs, testCacheSize)
+	stopper.AddCloser(inMem)
 	test(inMem, t)
 }
 

--- a/pkg/storage/engine/in_mem.go
+++ b/pkg/storage/engine/in_mem.go
@@ -16,10 +16,7 @@
 
 package engine
 
-import (
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/util/stop"
-)
+import "github.com/cockroachdb/cockroach/pkg/roachpb"
 
 // InMem wraps RocksDB and configures it for in-memory only storage.
 type InMem struct {
@@ -27,17 +24,19 @@ type InMem struct {
 }
 
 // NewInMem allocates and returns a new, opened InMem engine.
-func NewInMem(attrs roachpb.Attributes, cacheSize int64, stopper *stop.Stopper) InMem {
+// The caller must call the engine's Close method when the engine is no longer
+// needed.
+func NewInMem(attrs roachpb.Attributes, cacheSize int64) InMem {
 	cache := NewRocksDBCache(cacheSize)
 	// The cache starts out with a refcount of one, and creating the engine
 	// from it adds another refcount, at which point we release one of them.
 	defer cache.Release()
-	db := InMem{
-		RocksDB: newMemRocksDB(attrs, cache, 512<<20 /* 512 MB */, stopper),
-	}
-	if err := db.Open(); err != nil {
+
+	rdb, err := newMemRocksDB(attrs, cache, 512<<20 /* 512 MB */)
+	if err != nil {
 		panic(err)
 	}
+	db := InMem{RocksDB: rdb}
 	return db
 }
 

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -552,20 +552,6 @@ func (r *RocksDB) Flush() error {
 	return statusToError(C.DBFlush(r.rdb))
 }
 
-// Checkpoint creates a point-in-time snapshot of the on-disk state.
-func (r *RocksDB) Checkpoint(dir string) error {
-	if len(r.dir) == 0 {
-		return errors.Errorf("unable to checkpoint in-memory rocksdb instance")
-	}
-	if len(dir) == 0 {
-		return errors.Errorf("empty checkpoint directory")
-	}
-	if !filepath.IsAbs(dir) {
-		dir = filepath.Join(r.dir, dir)
-	}
-	return statusToError(C.DBCheckpoint(r.rdb, goToCSlice([]byte(dir))))
-}
-
 // NewIterator returns an iterator over this rocksdb engine.
 func (r *RocksDB) NewIterator(prefix bool) Iterator {
 	return newRocksDBIterator(r.rdb, prefix, r)

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -47,7 +47,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -271,46 +270,49 @@ type RocksDB struct {
 	cache        RocksDBCache       // Shared cache.
 	maxSize      int64              // Used for calculating rebalancing and free space.
 	maxOpenFiles int                // The maximum number of open files this instance will use.
-	stopper      *stop.Stopper
-	deallocated  chan struct{} // Closed when the underlying handle is deallocated.
+	deallocated  chan struct{}      // Closed when the underlying handle is deallocated.
 }
 
 var _ Engine = &RocksDB{}
 
 // NewRocksDB allocates and returns a new RocksDB object.
+// This creates options and opens the database. If the database
+// doesn't yet exist at the specified directory, one is initialized
+// from scratch.
+// The caller must call the engine's Close method when the engine is no longer
+// needed.
 func NewRocksDB(
-	attrs roachpb.Attributes,
-	dir string,
-	cache RocksDBCache,
-	maxSize int64,
-	maxOpenFiles int,
-	stopper *stop.Stopper,
-) *RocksDB {
+	attrs roachpb.Attributes, dir string, cache RocksDBCache, maxSize int64, maxOpenFiles int,
+) (*RocksDB, error) {
 	if dir == "" {
 		panic("dir must be non-empty")
 	}
-	return &RocksDB{
+	r := &RocksDB{
 		attrs:        attrs,
 		dir:          dir,
 		cache:        cache.ref(),
 		maxSize:      maxSize,
 		maxOpenFiles: maxOpenFiles,
-		stopper:      stopper,
 		deallocated:  make(chan struct{}),
 	}
+	if err := r.open(); err != nil {
+		return nil, err
+	}
+	return r, nil
 }
 
-func newMemRocksDB(
-	attrs roachpb.Attributes, cache RocksDBCache, maxSize int64, stopper *stop.Stopper,
-) *RocksDB {
-	return &RocksDB{
+func newMemRocksDB(attrs roachpb.Attributes, cache RocksDBCache, maxSize int64) (*RocksDB, error) {
+	r := &RocksDB{
 		attrs: attrs,
 		// dir: empty dir == "mem" RocksDB instance.
 		cache:       cache.ref(),
 		maxSize:     maxSize,
-		stopper:     stopper,
 		deallocated: make(chan struct{}),
 	}
+	if err := r.open(); err != nil {
+		return nil, err
+	}
+	return r, nil
 }
 
 // String formatter.
@@ -318,18 +320,7 @@ func (r *RocksDB) String() string {
 	return fmt.Sprintf("%s=%s", r.attrs.Attrs, r.dir)
 }
 
-// Open creates options and opens the database. If the database
-// doesn't yet exist at the specified directory, one is initialized
-// from scratch. The RocksDB Open and Close methods are reference
-// counted such that subsequent Open calls to an already opened
-// RocksDB instance only bump the reference count. The RocksDB is only
-// closed when a sufficient number of Close calls are performed to
-// bring the reference count down to 0.
-func (r *RocksDB) Open() error {
-	if r.rdb != nil {
-		return nil
-	}
-
+func (r *RocksDB) open() error {
 	var ver storageVersion
 	if len(r.dir) != 0 {
 		log.Infof(context.TODO(), "opening rocksdb instance at %q", r.dir)
@@ -381,7 +372,6 @@ func (r *RocksDB) Open() error {
 	go func() {
 		<-r.deallocated
 	}()
-	r.stopper.AddCloser(r)
 	return nil
 }
 
@@ -1454,8 +1444,6 @@ type RocksDBSstFileReader struct {
 // MakeRocksDBSstFileReader creates a RocksDBSstFileReader that uses a scratch
 // directory which is cleaned up by `Close`.
 func MakeRocksDBSstFileReader() (RocksDBSstFileReader, error) {
-	stopper := stop.NewStopper()
-
 	dir, err := ioutil.TempDir("", "RocksDBSstFileReader")
 	if err != nil {
 		return RocksDBSstFileReader{}, err
@@ -1464,9 +1452,9 @@ func MakeRocksDBSstFileReader() (RocksDBSstFileReader, error) {
 	// TODO(dan): I pulled all these magic numbers out of nowhere. Make them
 	// less magic.
 	cache := NewRocksDBCache(1 << 20)
-	rocksDB := NewRocksDB(
-		roachpb.Attributes{}, dir, cache, 512<<20, DefaultMaxOpenFiles, stopper)
-	if err := rocksDB.Open(); err != nil {
+	rocksDB, err := NewRocksDB(
+		roachpb.Attributes{}, dir, cache, 512<<20, DefaultMaxOpenFiles)
+	if err != nil {
 		return RocksDBSstFileReader{}, err
 	}
 	return RocksDBSstFileReader{dir, rocksDB}, nil

--- a/pkg/storage/engine/rocksdb/db.cc
+++ b/pkg/storage/engine/rocksdb/db.cc
@@ -1537,16 +1537,6 @@ DBStatus DBCompact(DBEngine* db) {
   return ToDBStatus(db->rep->CompactRange(rocksdb::CompactRangeOptions(), NULL, NULL));
 }
 
-DBStatus DBCheckpoint(DBEngine* db, DBSlice dir) {
-  rocksdb::Checkpoint* cp = nullptr;
-  rocksdb::Status status = rocksdb::Checkpoint::Create(db->rep, &cp);
-  if (!status.ok()) {
-    return ToDBStatus(status);
-  }
-  std::unique_ptr<rocksdb::Checkpoint> cp_deleter(cp);
-  return ToDBStatus(cp->CreateCheckpoint(ToString(dir)));
-}
-
 DBStatus DBImpl::Put(DBKey key, DBSlice value) {
   rocksdb::WriteOptions options;
   return ToDBStatus(rep->Put(options, EncodeKey(key), ToSlice(value)));

--- a/pkg/storage/engine/rocksdb/db.h
+++ b/pkg/storage/engine/rocksdb/db.h
@@ -99,11 +99,6 @@ DBStatus DBFlush(DBEngine* db);
 // Forces an immediate compaction over all keys.
 DBStatus DBCompact(DBEngine* db);
 
-// Checkpoint creates a point-in-time snapshot of the database,
-// hard-linking sstable files and copying the manifest and other
-// files.
-DBStatus DBCheckpoint(DBEngine* db, DBSlice dir);
-
 // Sets the database entry for "key" to "value".
 DBStatus DBPut(DBEngine* db, DBKey key, DBSlice value);
 

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -23,7 +23,6 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"strconv"
 	"sync"
@@ -239,86 +238,6 @@ func openRocksDBWithVersion(t *testing.T, hasVersionFile bool, ver Version) erro
 		stopper,
 	)
 	return rocksdb.Open()
-}
-
-func TestCheckpoint(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	dir, err := ioutil.TempDir("", "testing")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatal(err)
-		}
-	}()
-
-	var expectedKeys []string
-	func() {
-		stopper := stop.NewStopper()
-		defer stopper.Stop()
-
-		db := NewRocksDB(
-			roachpb.Attributes{},
-			dir,
-			RocksDBCache{},
-			0,
-			DefaultMaxOpenFiles,
-			stopper,
-		)
-		if err := db.Open(); err != nil {
-			t.Fatal(err)
-		}
-
-		// Add 20 keys, creating a checkpoint after the 10th key is added.
-		for i := 0; i < 20; i++ {
-			if i == 10 {
-				if err := db.Checkpoint("checkpoint"); err != nil {
-					t.Fatal(err)
-				}
-			}
-			s := fmt.Sprintf("%02d", i)
-			if err := db.Put(mvccKey(s), []byte(s)); err != nil {
-				t.Fatal(err)
-			}
-			if i < 10 {
-				expectedKeys = append(expectedKeys, s)
-			}
-		}
-	}()
-
-	func() {
-		stopper := stop.NewStopper()
-		defer stopper.Stop()
-
-		dir = filepath.Join(dir, "checkpoint")
-		db := NewRocksDB(
-			roachpb.Attributes{},
-			dir,
-			RocksDBCache{},
-			0,
-			DefaultMaxOpenFiles,
-			stopper,
-		)
-		if err := db.Open(); err != nil {
-			t.Fatal(err)
-		}
-
-		// The checkpoint should only contain the first 10 keys.
-		var keys []string
-		err := db.Iterate(NilKey, MVCCKeyMax, func(kv MVCCKeyValue) (bool, error) {
-			keys = append(keys, string(kv.Key.Key))
-			return false, nil
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if !reflect.DeepEqual(expectedKeys, keys) {
-			t.Fatalf("expected %s, but got %s", expectedKeys, keys)
-		}
-	}()
 }
 
 func TestSSTableInfosString(t *testing.T) {

--- a/pkg/storage/migration_test.go
+++ b/pkg/storage/migration_test.go
@@ -33,7 +33,8 @@ func TestMigrate7310And6991(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	eng := engine.NewInMem(roachpb.Attributes{}, 1<<10, stopper)
+	eng := engine.NewInMem(roachpb.Attributes{}, 1<<10)
+	stopper.AddCloser(eng)
 
 	desc := *testRangeDescriptor()
 

--- a/pkg/storage/replica_state_test.go
+++ b/pkg/storage/replica_state_test.go
@@ -35,7 +35,8 @@ func TestSynthesizeHardState(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20, stopper)
+	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	stopper.AddCloser(eng)
 
 	tHS := raftpb.HardState{Term: 2, Vote: 3, Commit: 4}
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -157,7 +157,8 @@ func (tc *testContext) StartWithStoreConfig(t testing.TB, cfg StoreConfig) {
 		tc.clock = hlc.NewClock(tc.manualClock.UnixNano)
 	}
 	if tc.engine == nil {
-		tc.engine = engine.NewInMem(roachpb.Attributes{Attrs: []string{"dc1", "mem"}}, 1<<20, tc.stopper)
+		tc.engine = engine.NewInMem(roachpb.Attributes{Attrs: []string{"dc1", "mem"}}, 1<<20)
+		tc.stopper.AddCloser(tc.engine)
 	}
 	if tc.transport == nil {
 		tc.transport = NewDummyRaftTransport()

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -650,6 +650,9 @@ type StoreTestingKnobs struct {
 	// NumKeysEvaluatedForRangeIntentResolution is set by the stores to the
 	// number of keys evaluated for range intent resolution.
 	NumKeysEvaluatedForRangeIntentResolution *int64
+	// SkipMinSizeCheck, if set, makes the store creation process skip the check
+	// for a minimum size.
+	SkipMinSizeCheck bool
 }
 
 var _ base.ModuleTestingKnobs = &StoreTestingKnobs{}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -165,7 +165,8 @@ func createTestStoreWithoutStart(
 		TestTimeUntilStoreDeadOff,
 		stopper,
 	)
-	eng := engine.NewInMem(roachpb.Attributes{}, 10<<20, stopper)
+	eng := engine.NewInMem(roachpb.Attributes{}, 10<<20)
+	stopper.AddCloser(eng)
 	cfg.Transport = NewDummyRaftTransport()
 	sender := &testSender{}
 	cfg.DB = client.NewDB(sender)
@@ -224,7 +225,8 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	cfg.Clock = hlc.NewClock(manual.UnixNano)
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20, stopper)
+	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	stopper.AddCloser(eng)
 	cfg.Transport = NewDummyRaftTransport()
 	store := NewStore(cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
 
@@ -285,7 +287,8 @@ func TestBootstrapOfNonEmptyStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20, stopper)
+	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	stopper.AddCloser(eng)
 
 	// Put some random garbage into the engine.
 	if err := eng.Put(engine.MakeMVCCMetadataKey(roachpb.Key("foo")), []byte("bar")); err != nil {
@@ -2545,9 +2548,8 @@ func (sp *fakeStorePool) updateRemoteCapacityEstimate(
 // various exceptional conditions and new capacity estimates.
 func TestSendSnapshotThrottling(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	stopper := stop.NewStopper()
-	defer stopper.Stop()
-	e := engine.NewInMem(roachpb.Attributes{}, 1<<10, stopper)
+	e := engine.NewInMem(roachpb.Attributes{}, 1<<10)
+	defer e.Close()
 
 	ctx := context.Background()
 	header := SnapshotRequest_Header{CanDecline: true}

--- a/pkg/storage/stores_test.go
+++ b/pkg/storage/stores_test.go
@@ -147,7 +147,8 @@ func TestStoresLookupReplica(t *testing.T) {
 		{3, roachpb.RKey("x"), roachpb.RKey("z")},
 	}
 	for i, rng := range ranges {
-		e[i] = engine.NewInMem(roachpb.Attributes{}, 1<<20, stopper)
+		e[i] = engine.NewInMem(roachpb.Attributes{}, 1<<20)
+		stopper.AddCloser(e[i])
 		cfg.Transport = NewDummyRaftTransport()
 		s[i] = NewStore(cfg, e[i], &roachpb.NodeDescriptor{NodeID: 1})
 		s[i].Ident.StoreID = rng.storeID
@@ -238,7 +239,9 @@ func createStores(count int, t *testing.T) (*hlc.ManualClock, []*Store, *Stores,
 	stores := []*Store{}
 	for i := 0; i < 2; i++ {
 		cfg.Transport = NewDummyRaftTransport()
-		s := NewStore(cfg, engine.NewInMem(roachpb.Attributes{}, 1<<20, stopper), &roachpb.NodeDescriptor{NodeID: 1})
+		eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+		stopper.AddCloser(eng)
+		s := NewStore(cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
 		storeIDAlloc++
 		s.Ident.StoreID = storeIDAlloc
 		stores = append(stores, s)

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -97,7 +97,8 @@ func (ltc *LocalTestCluster) Start(t util.Tester, baseCtx *base.Config, initSend
 	rpcContext := rpc.NewContext(ambient, baseCtx, ltc.Clock, ltc.Stopper)
 	server := rpc.NewServer(rpcContext) // never started
 	ltc.Gossip = gossip.New(ambient, nc, rpcContext, server, nil, ltc.Stopper, metric.NewRegistry())
-	ltc.Eng = engine.NewInMem(roachpb.Attributes{}, 50<<20, ltc.Stopper)
+	ltc.Eng = engine.NewInMem(roachpb.Attributes{}, 50<<20)
+	ltc.Stopper.AddCloser(ltc.Eng)
 
 	ltc.Stores = storage.NewStores(ambient, ltc.Clock)
 


### PR DESCRIPTION
This is a series of refactorings whose main points are to remove the distinction between creating and opening an Engine, and then moving the creation of the Engines inside `Server.Start()`.
They were done for #9504, which needs to read from the engines inside `Server.Start()`, before the engines used to be `Open()ed`.

CC @BramGruneir for r3, @RaduBerinde for r2 which moves `noCopy` to a central location.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9845)

<!-- Reviewable:end -->
