### PR TITLE
storage: add Replica.checkBatchRange

### DIFF
--- a/roachpb/api.go
+++ b/roachpb/api.go
@@ -812,7 +812,7 @@ func (*TransferLeaseRequest) flags() int {
 	// holder.
 	return isWrite | isAlone | isNonKV | skipLeaseCheck
 }
-func (*ComputeChecksumRequest) flags() int          { return isWrite | isNonKV }
+func (*ComputeChecksumRequest) flags() int          { return isWrite | isNonKV | isRange }
 func (*DeprecatedVerifyChecksumRequest) flags() int { return isWrite }
 func (*CheckConsistencyRequest) flags() int         { return isAdmin | isRange }
 func (*ChangeFrozenRequest) flags() int             { return isWrite | isRange | isNonKV }

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1122,26 +1122,32 @@ func (r *Replica) Send(
 	return br, pErr
 }
 
-func (r *Replica) checkCmdHeader(header roachpb.Span) error {
-	if !r.ContainsKeyRange(header.Key, header.EndKey) {
-		mismatchErr := roachpb.NewRangeKeyMismatchError(header.Key, header.EndKey, r.Desc())
-		// Try to suggest the correct range on a key mismatch error where
-		// even the start key of the request went to the wrong range.
-		if !r.ContainsKey(header.Key) {
-			if keyAddr, err := keys.Addr(header.Key); err == nil {
-				if repl := r.store.LookupReplica(keyAddr, nil); repl != nil {
-					// Only return the correct range descriptor as a hint
-					// if we know the current lease holder for that range, which
-					// indicates that our knowledge is not stale.
-					if lease, _ := repl.getLease(); lease != nil && lease.Covers(r.store.Clock().Now()) {
-						mismatchErr.SuggestedRange = repl.Desc()
-					}
-				}
+func (r *Replica) checkBatchRange(ba roachpb.BatchRequest) error {
+	rspan, err := keys.Range(ba)
+	if err != nil {
+		return err
+	}
+
+	desc := r.Desc()
+	if desc.ContainsKeyRange(rspan.Key, rspan.EndKey) {
+		return nil
+	}
+
+	mismatchErr := roachpb.NewRangeKeyMismatchError(
+		rspan.Key.AsRawKey(), rspan.EndKey.AsRawKey(), desc)
+	// Try to suggest the correct range on a key mismatch error where
+	// even the start key of the request went to the wrong range.
+	if !desc.ContainsKey(rspan.Key) {
+		if repl := r.store.LookupReplica(rspan.Key, nil); repl != nil {
+			// Only return the correct range descriptor as a hint
+			// if we know the current lease holder for that range, which
+			// indicates that our knowledge is not stale.
+			if lease, _ := repl.getLease(); lease != nil && lease.Covers(r.store.Clock().Now()) {
+				mismatchErr.SuggestedRange = repl.Desc()
 			}
 		}
-		return mismatchErr
 	}
-	return nil
+	return mismatchErr
 }
 
 // checkBatchRequest verifies BatchRequest validity requirements. In
@@ -1392,12 +1398,12 @@ func (r *Replica) addAdminCmd(
 	if len(ba.Requests) != 1 {
 		return nil, roachpb.NewErrorf("only single-element admin batches allowed")
 	}
-	args := ba.Requests[0].GetInner()
 
-	if err := r.checkCmdHeader(args.Header()); err != nil {
+	if err := r.checkBatchRange(ba); err != nil {
 		return nil, roachpb.NewErrorWithTxn(err, ba.Txn)
 	}
 
+	args := ba.Requests[0].GetInner()
 	if sp := opentracing.SpanFromContext(ctx); sp != nil {
 		sp.SetOperationName(reflect.TypeOf(args).String())
 	}
@@ -3156,7 +3162,6 @@ func (r *Replica) executeBatch(
 	ba roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *PostCommitTrigger, *roachpb.Error) {
 	br := ba.CreateReply()
-	var trigger *PostCommitTrigger
 
 	r.mu.Lock()
 	threshold := r.mu.state.GCThreshold
@@ -3177,6 +3182,11 @@ func (r *Replica) executeBatch(
 		optimizePuts(batch, ba.Requests, ba.Header.DistinctSpans)
 	}
 
+	if err := r.checkBatchRange(ba); err != nil {
+		return nil, nil, roachpb.NewErrorWithTxn(err, ba.Header.Txn)
+	}
+
+	var trigger *PostCommitTrigger
 	for index, union := range ba.Requests {
 		// Execute the command.
 		args := union.GetInner()

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -79,10 +79,6 @@ func (r *Replica) executeCmd(
 		return nil, nil
 	}
 
-	if err := r.checkCmdHeader(args.Header()); err != nil {
-		return nil, roachpb.NewErrorWithTxn(err, h.Txn)
-	}
-
 	// If a unittest filter was installed, check for an injected error; otherwise, continue.
 	if filter := r.store.cfg.TestingKnobs.TestingCommandFilter; filter != nil {
 		filterArgs := storagebase.FilterArgs{Ctx: ctx, CmdID: raftCmdID, Index: index,


### PR DESCRIPTION
Replace the per-request usage of Replica.checkCmdHeader with a per-batch
call to Replica.checkBatchRange. This avoids lots of Replica.mu lock
manipulation in batches with large numbers of requests.

name                 old time/op  new time/op  delta
KVInsert10000_SQL-8   113ms ± 2%   110ms ± 3%  -2.13%  (p=0.013 n=9+10)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9848)

<!-- Reviewable:end -->
