### PR TITLE
build: add teamcity's acceptance 'custom script' to a checked-in file

### DIFF
--- a/build/teamcity-acceptance.sh
+++ b/build/teamcity-acceptance.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+build/builder.sh make build
+build/builder.sh make install
+build/builder.sh go test -v -c -tags acceptance ./acceptance
+cd acceptance
+../acceptance.test -nodes 3 -l artifacts/acceptance -test.v -test.timeout 10m --verbosity=1 --vmodule=monitor=2 2>&1 | go-test-teamcity


### PR DESCRIPTION
moves this logic under version control and where a PR that moves e.g. the acceptance pkg can atomically change the pkg and the test invocation

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9849)

<!-- Reviewable:end -->
