### PR TITLE
storage: improve logging context in SendSnapshot

### DIFF
--- a/storage/raft_transport.go
+++ b/storage/raft_transport.go
@@ -626,8 +626,9 @@ func (t *RaftTransport) SendSnapshot(
 			breaker.Fail()
 		}
 	}()
-	return sendSnapshot(snapshotClientWithBreaker{
-		MultiRaft_RaftSnapshotClient: stream,
-		breaker: breaker,
-	}, header, snap, newBatch)
+	return sendSnapshot(ctx,
+		snapshotClientWithBreaker{
+			MultiRaft_RaftSnapshotClient: stream,
+			breaker: breaker,
+		}, header, snap, newBatch)
 }


### PR DESCRIPTION
Improves a context in streaming snapshot logs. The stream context isn't as useful in debugging as the context from the relevant RaftTransport.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9855)

<!-- Reviewable:end -->
