### PR TITLE
ui: add a simple proxy server

### DIFF
--- a/pkg/ui/README.md
+++ b/pkg/ui/README.md
@@ -54,6 +54,25 @@ The UI also supports live reload in debug mode. To take advantage of this, run
 `make livereload` from this directory - the UI will automatically reload files
 as you modify them, taking advantage of TypeScript's incremental compilation.
 
+## Proxying
+
+When prototyping changes to the CockroachDB Admin UI, it is desirable to see
+those changes with data from an existing cluster without the headache of having
+to redeploy a cluster. This is useful for rapidly visualizing local development
+changes against a consistent and realistic dataset.
+
+We have created a simple NodeJS reverse-proxy server to accomplish this; this
+server proxies all requests for web resources (javascript, HTML, CSS) to a local
+CockroachDB server, while proxying all requests for actual data to a remote
+CockroachDB server.
+
+To use this server, navigate to the `ui/proxy` directory and run `npm install`.
+Then run:
+`./proxy.js <existing-instance-ui-url> --local <development-instance-ui-url>`
+and navigate to `http://localhost:3000` to access the UI.
+
+Run `./proxy.js --help` for detailed information.
+
 ## Dependencies
 
 Our web console is compiled using a collection of tools that depends on

--- a/pkg/ui/proxy/package.json
+++ b/pkg/ui/proxy/package.json
@@ -1,0 +1,8 @@
+{
+  "main": "proxy.js",
+  "dependencies": {
+    "express": "^4.14.0",
+    "http-proxy": "^1.15.1",
+    "yargs": "^6.2.0"
+  }
+}

--- a/pkg/ui/proxy/proxy.js
+++ b/pkg/ui/proxy/proxy.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+// Simple proxy server that serves the UI from one Cockroach instance and
+// proxies requests to another Cockroach instance.
+
+var express = require('express');
+var app      = express();
+var httpProxy = require('http-proxy');
+var apiProxy = httpProxy.createProxyServer({secure:false});
+
+var argv = require('yargs')
+  .usage('Usage: $0 <remote-cockroach-ui-url> [options]')
+  .demand(1)
+  .default('local', 'http://localhost:8080', 'Cockroach instance UI URL to serve UI files from')
+  .default('port', 3000, 'The port to run this proxy server on')
+  .example(`$0 https://myroach:8080`, 'Serve UI resources (HTML, JS, CSS) from localhost:8080, while serving API data requests from https://myroach:8080')
+  .help('h')
+  .alias('h', 'help')
+  .alias('p', 'port')
+  .alias('l', 'local')
+  .argv;
+
+var local = argv.local,
+  remote = argv._[0],
+  port = argv.port;
+
+console.log(`Proxying requests from ${local} to ${remote} at http://localhost:${port}`);
+
+app.all("/_admin/v1*", function(req, res) {
+  apiProxy.web(req, res, {target: remote});
+});
+
+app.all("/_status*", function(req, res) {
+  apiProxy.web(req, res, {target: remote});
+});
+
+app.all("/ts/*", function(req, res) {
+  apiProxy.web(req, res, {target: remote});
+});
+
+app.all("/*", function(req, res) {
+  apiProxy.web(req, res, {target: local});
+});
+
+app.listen(port);
+
+// Catch-all error handler
+apiProxy.on('error', function (err, req, res) {
+  console.error(err);
+  res.status(500);
+  res.send({ error: err });
+});


### PR DESCRIPTION
This proxy server allows a developer to point a local Cockroach UI
to an existing Cockroach instance.

Made with the assistance of @mrtracy

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9858)

<!-- Reviewable:end -->
