### PR TITLE
storage/engine: micro-optimizations for MVCCMerge

### DIFF
--- a/storage/engine/bench_rocksdb_test.go
+++ b/storage/engine/bench_rocksdb_test.go
@@ -247,6 +247,10 @@ func BenchmarkMVCCBatch100000Put10_RocksDB(b *testing.B) {
 	runMVCCBatchPut(setupMVCCInMemRocksDB, 10, 100000, b)
 }
 
+func BenchmarkMVCCBatchTimeSeries282_RocksDB(b *testing.B) {
+	runMVCCBatchTimeSeries(setupMVCCInMemRocksDB, 282, b)
+}
+
 // DeleteRange benchmarks below (using on-disk data).
 
 func BenchmarkMVCCDeleteRange1Version8Bytes_RocksDB(b *testing.B) {


### PR DESCRIPTION
Added a benchmark which mimics the periodic writing of timeseries
values.

```
name                              old time/op  new time/op  delta
MVCCBatchTimeSeries282_RocksDB-8   323µs ± 2%   297µs ± 3%  -7.89%  (p=0.000 n=20+20)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9862)

<!-- Reviewable:end -->
