### PR TITLE
sql: populate the valuesNode for virtual tables during query execution

### DIFF
--- a/sql/data_source.go
+++ b/sql/data_source.go
@@ -199,18 +199,19 @@ func (p *planner) getVirtualDataSource(tn *parser.TableName) (planDataSource, bo
 		return planDataSource{}, false, err
 	}
 	if virtual.desc != nil {
-		v, err := virtual.getValuesNode(p)
-		if err != nil {
-			return planDataSource{}, false, err
-		}
-
+		columns, constructor := virtual.getPlanInfo()
 		sourceName := parser.TableName{
 			TableName:    parser.Name(virtual.desc.Name),
 			DatabaseName: tn.DatabaseName,
 		}
 		return planDataSource{
-			info: newSourceInfoForSingleTable(sourceName, v.Columns()),
-			plan: v,
+			info: newSourceInfoForSingleTable(sourceName, columns),
+			plan: &delayedValuesNode{
+				p:           p,
+				name:        sourceName.String(),
+				columns:     columns,
+				constructor: constructor,
+			},
 		}, true, nil
 	}
 	return planDataSource{}, false, nil

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -212,6 +212,7 @@ var _ planNode = &dropViewNode{}
 var _ planNode = &alterTableNode{}
 var _ planNode = &joinNode{}
 var _ planNode = &distSQLNode{}
+var _ planNode = &delayedValuesNode{}
 
 // makePlan implements the Planner interface.
 func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, error) {

--- a/sql/testdata/pg_catalog
+++ b/sql/testdata/pg_catalog
@@ -24,6 +24,11 @@ CREATE DATABASE pg_catalog
 statement ok
 DROP DATABASE other_db
 
+# the following query checks that the planDataSource instantiated from
+# a virtual table in the FROM clause is properly deallocated even when
+# query preparation causes an error. #9853
+query error unknown function
+SELECT * FROM pg_catalog.pg_class c WHERE nonexistent_function()
 
 # Verify pg_catalog can be used like a normal database.
 

--- a/sql/values.go
+++ b/sql/values.go
@@ -318,3 +318,53 @@ func (n *valuesNode) ExplainTypes(regTypes func(string, string)) {
 }
 
 func (*valuesNode) SetLimitHint(_ int64, _ bool) {}
+
+// delayedValuesNode wraps a valuesNode in cases where the valuesNode
+// must be populated during query execution (as opposed to planNode
+// construction) for resource tracking purposes.
+type delayedValuesNode struct {
+	p           *planner
+	name        string
+	columns     ResultColumns
+	constructor valuesNodeConstructor
+	plan        *valuesNode
+}
+
+func (d *delayedValuesNode) SetLimitHint(_ int64, _ bool) {}
+func (d *delayedValuesNode) expandPlan() error {
+	v, err := d.constructor(d.p)
+	if err != nil {
+		return err
+	}
+	if err := v.expandPlan(); err != nil {
+		v.Close()
+		return err
+	}
+	d.plan = v
+	return nil
+}
+
+func (d *delayedValuesNode) Close() {
+	if d.plan != nil {
+		d.plan.Close()
+		d.plan = nil
+	}
+}
+
+func (d *delayedValuesNode) ExplainPlan(
+	verbose bool,
+) (name, description string, children []planNode) {
+	if d.plan != nil {
+		children = []planNode{d.plan}
+	}
+	return "virtual table", d.name, children
+}
+
+func (d *delayedValuesNode) ExplainTypes(rt func(string, string)) {}
+func (d *delayedValuesNode) Columns() ResultColumns               { return d.columns }
+func (d *delayedValuesNode) Ordering() orderingInfo               { return orderingInfo{} }
+func (d *delayedValuesNode) MarkDebug(_ explainMode)              {}
+func (d *delayedValuesNode) Start() error                         { return d.plan.Start() }
+func (d *delayedValuesNode) Next() (bool, error)                  { return d.plan.Next() }
+func (d *delayedValuesNode) Values() parser.DTuple                { return d.plan.Values() }
+func (d *delayedValuesNode) DebugValues() debugValues             { return d.plan.DebugValues() }

--- a/sql/virtual_schema.go
+++ b/sql/virtual_schema.go
@@ -94,9 +94,13 @@ type virtualTableEntry struct {
 	desc     *sqlbase.TableDescriptor
 }
 
-// getValuesNode returns a new valuesNode for the virtual table using the
-// provided planner.
-func (e virtualTableEntry) getValuesNode(p *planner) (*valuesNode, error) {
+type valuesNodeConstructor func(p *planner) (*valuesNode, error)
+
+// getPlanInfo returns the column metadata and a constructor for a new
+// valuesNode for the virtual table. We use deferred construction here
+// so as to avoid populating a RowContainer during query preparation,
+// where we can't guarantee it will be Close()d in case of error.
+func (e virtualTableEntry) getPlanInfo() (ResultColumns, valuesNodeConstructor) {
 	var columns ResultColumns
 	for _, col := range e.desc.Columns {
 		columns = append(columns, ResultColumn{
@@ -104,26 +108,31 @@ func (e virtualTableEntry) getValuesNode(p *planner) (*valuesNode, error) {
 			Typ:  col.Type.ToDatumType(),
 		})
 	}
-	v := p.newContainerValuesNode(columns, 0)
 
-	err := e.tableDef.populate(p, func(datums ...parser.Datum) error {
-		if r, c := len(datums), len(v.columns); r != c {
-			panic(fmt.Sprintf("datum row count and column count differ: %d vs %d", r, c))
-		}
-		for i, col := range v.columns {
-			datum := datums[i]
-			if !(datum == parser.DNull || datum.TypeEqual(col.Typ)) {
-				panic(fmt.Sprintf("datum column %q expected to be type %s; found type %s",
-					col.Name, col.Typ.Type(), datum.Type()))
+	constructor := func(p *planner) (*valuesNode, error) {
+		v := p.newContainerValuesNode(columns, 0)
+
+		err := e.tableDef.populate(p, func(datums ...parser.Datum) error {
+			if r, c := len(datums), len(v.columns); r != c {
+				panic(fmt.Sprintf("datum row count and column count differ: %d vs %d", r, c))
 			}
+			for i, col := range v.columns {
+				datum := datums[i]
+				if !(datum == parser.DNull || datum.TypeEqual(col.Typ)) {
+					panic(fmt.Sprintf("datum column %q expected to be type %s; found type %s",
+						col.Name, col.Typ.Type(), datum.Type()))
+				}
+			}
+			return v.rows.AddRow(datums)
+		})
+		if err != nil {
+			v.Close()
+			return nil, err
 		}
-		return v.rows.AddRow(datums)
-	})
-	if err != nil {
-		v.Close()
-		return nil, err
+		return v, nil
 	}
-	return v, nil
+
+	return columns, constructor
 }
 
 func (vs *virtualSchemaHolder) init(p *planner) error {


### PR DESCRIPTION
Prior to this patch, the valuesNode for virtual tables was populated
as soon as the data source was analyzed from a FROM clause, and not
released properly from the memory monitor in case the analysis of the
rest of the query failed.

This patch fixes the issue by delaying the initialization of the
valuesNode until the planNode is expanded.

Fixes #9853.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9864)

<!-- Reviewable:end -->
