### PR TITLE
cli/sql: do not normalize the string sent to the server.

### DIFF
--- a/cli/sql.go
+++ b/cli/sql.go
@@ -412,6 +412,7 @@ func runInteractive(conn *sqlConn, config *readline.Config) (exitErr error) {
 		// the user then stop processing if the `errexit` option is set.
 		// Otherwise, pretty-print the resulting AST to populate the
 		// history.
+		normalizedStmt := fullStmt
 		if doCheck, _ := options["check_syntax"]; doCheck {
 			var parser parser.Parser
 			stmts, err := parser.Parse(fullStmt, syntax)
@@ -423,7 +424,7 @@ func runInteractive(conn *sqlConn, config *readline.Config) (exitErr error) {
 				}
 				skipStmt = true
 			} else if normalizeHistory, _ := options["normalize_history"]; normalizeHistory {
-				fullStmt = stmts.String() + ";"
+				normalizedStmt = stmts.String() + ";"
 			}
 		}
 
@@ -431,7 +432,7 @@ func runInteractive(conn *sqlConn, config *readline.Config) (exitErr error) {
 			// We save the history between each statement, This enables
 			// reusing history in another SQL shell without closing the
 			// current shell.
-			addHistory(ins, fullStmt)
+			addHistory(ins, normalizedStmt)
 		}
 
 		if skipStmt {


### PR DESCRIPTION
Prior to this patch, if client-side syntax checking and normalization
was enabled (the default in interactive mode), the string sent
to the server was the string after normalization: the normalized
string was used both for the history and sent to the server.

This would become an issue with an upcoming feature that allows
configuring user passwords using SQL statements: the password
must not appear in the history but it must be sent to the server.

This patch preemptively supports this upcoming feature by ensuring
that even when a normalized string is saved to the history, the user
input is sent as-is to the server.

Supports #9794.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9866)

<!-- Reviewable:end -->
