### PR TITLE
sql: Add pg_indexes table to pg_catalog

### DIFF
--- a/pkg/sql/parser/create.go
+++ b/pkg/sql/parser/create.go
@@ -107,7 +107,7 @@ func (node *CreateIndex) Format(buf *bytes.Buffer, f FmtFlags) {
 	fmt.Fprintf(buf, "ON %s (", node.Table)
 	FormatNode(buf, f, node.Columns)
 	buf.WriteByte(')')
-	if node.Storing != nil {
+	if len(node.Storing) > 0 {
 		buf.WriteString(" STORING (")
 		FormatNode(buf, f, node.Storing)
 		buf.WriteByte(')')

--- a/pkg/sql/testdata/information_schema
+++ b/pkg/sql/testdata/information_schema
@@ -346,6 +346,7 @@ xyz
 pg_attrdef
 pg_attribute
 pg_class
+pg_indexes
 pg_namespace
 pg_tables
 descriptor
@@ -372,6 +373,7 @@ schema_privileges
 rangelog
 pg_tables
 pg_namespace
+pg_indexes
 pg_class
 pg_attribute
 pg_attrdef
@@ -393,6 +395,7 @@ def            other_db            xyz                BASE TABLE   2
 def            pg_catalog          pg_attrdef         SYSTEM VIEW  1
 def            pg_catalog          pg_attribute       SYSTEM VIEW  1
 def            pg_catalog          pg_class           SYSTEM VIEW  1
+def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1
 def            system              descriptor         BASE TABLE   1
@@ -429,6 +432,7 @@ def            information_schema  tables             SYSTEM VIEW  1
 def            pg_catalog          pg_attrdef         SYSTEM VIEW  1
 def            pg_catalog          pg_attribute       SYSTEM VIEW  1
 def            pg_catalog          pg_class           SYSTEM VIEW  1
+def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1
 
@@ -454,6 +458,7 @@ def            other_db            xyz                BASE TABLE   6
 def            pg_catalog          pg_attrdef         SYSTEM VIEW  1
 def            pg_catalog          pg_attribute       SYSTEM VIEW  1
 def            pg_catalog          pg_class           SYSTEM VIEW  1
+def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1
 

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -47,6 +47,7 @@ SHOW TABLES FROM pg_catalog
 pg_attrdef
 pg_attribute
 pg_class
+pg_indexes
 pg_namespace
 pg_tables
 
@@ -114,7 +115,7 @@ CREATE TABLE constraint_db.t3 (
     b INT CHECK (b > 11),
     c STRING DEFAULT 'FOO',
     CONSTRAINT fk FOREIGN KEY (a, b) REFERENCES constraint_db.t1(b, c),
-    INDEX (a, b)
+    INDEX (a, b DESC) STORING (c)
 )
 
 statement ok
@@ -326,3 +327,33 @@ WHERE n.nspname = 'constraint_db'
 oid         relname  adrelid     adnum  adbin  adsrc
 1889966686  t1       2265044713  4      12     12
 390509283   t3       2064007441  3      'FOO'  'FOO'
+
+## pg_catalog.pg_indexes
+
+query TTTT colnames
+SELECT schemaname, tablename, indexname, tablespace
+FROM pg_catalog.pg_indexes
+WHERE schemaname = 'constraint_db'
+----
+schemaname     tablename  indexname     tablespace
+constraint_db  t1         primary       NULL
+constraint_db  t1         t1_a_key      NULL
+constraint_db  t1         index_key     NULL
+constraint_db  t2         primary       NULL
+constraint_db  t2         t2_t1_ID_idx  NULL
+constraint_db  t3         primary       NULL
+constraint_db  t3         t3_a_b_idx    NULL
+
+query TTT colnames
+SELECT tablename, indexname, indexdef
+FROM pg_catalog.pg_indexes
+WHERE schemaname = 'constraint_db'
+----
+tablename  indexname     indexdef
+t1         primary       CREATE UNIQUE INDEX "primary" ON constraint_db.t1 (p ASC)
+t1         t1_a_key      CREATE UNIQUE INDEX t1_a_key ON constraint_db.t1 (a ASC)
+t1         index_key     CREATE UNIQUE INDEX index_key ON constraint_db.t1 (b ASC, c ASC)
+t2         primary       CREATE UNIQUE INDEX "primary" ON constraint_db.t2 (rowid ASC)
+t2         t2_t1_ID_idx  CREATE INDEX t2_t1_ID_idx ON constraint_db.t2 (t1_ID ASC)
+t3         primary       CREATE UNIQUE INDEX "primary" ON constraint_db.t3 (rowid ASC)
+t3         t3_a_b_idx    CREATE INDEX t3_a_b_idx ON constraint_db.t3 (a ASC, b DESC) STORING (c)


### PR DESCRIPTION
The `pg_indexes` table provides access to useful information about each
index in the database.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9869)

<!-- Reviewable:end -->
