### PR TITLE
all: change some context.Background()s to TODO()

### DIFF
--- a/internal/client/sender.go
+++ b/internal/client/sender.go
@@ -47,7 +47,7 @@ func SendWrappedWith(
 	sender Sender, ctx context.Context, h roachpb.Header, args roachpb.Request,
 ) (roachpb.Response, *roachpb.Error) {
 	if ctx == nil {
-		ctx = context.Background()
+		ctx = context.TODO()
 	}
 	ba := roachpb.BatchRequest{}
 	ba.Header = h

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -376,7 +376,7 @@ func (ds *DistSender) CountRanges(rs roachpb.RSpan) (int64, error) {
 	var count int64
 	for {
 		desc, needAnother, _, err := ds.getDescriptors(
-			context.Background(), rs, nil, false /*useReverseScan*/)
+			context.TODO(), rs, nil, false /*useReverseScan*/)
 		if err != nil {
 			return -1, err
 		}

--- a/kv/transport.go
+++ b/kv/transport.go
@@ -254,7 +254,7 @@ func (s *senderTransport) SendNext(done chan<- BatchCall) {
 	s.called = true
 	sp := s.tracer.StartSpan("node")
 	defer sp.Finish()
-	ctx := opentracing.ContextWithSpan(context.Background(), sp)
+	ctx := opentracing.ContextWithSpan(context.TODO(), sp)
 	log.Event(ctx, s.args.String())
 	br, pErr := s.sender.Send(ctx, s.args)
 	if br == nil {

--- a/kv/transport_race.go
+++ b/kv/transport_race.go
@@ -65,7 +65,7 @@ func grpcTransportFactory(
 			defer func() {
 				atomic.StoreInt32(&running, 0)
 				log.Infof(
-					context.Background(),
+					context.TODO(),
 					"transport race promotion: ran %d iterations on up to %d requests",
 					iters, curIdx+1,
 				)

--- a/rpc/context.go
+++ b/rpc/context.go
@@ -346,7 +346,7 @@ func (ctx *Context) runHeartbeat(cc *grpc.ClientConn, remoteAddr string) error {
 func (ctx *Context) heartbeat(
 	heartbeatClient HeartbeatClient, request PingRequest,
 ) (*PingResponse, error) {
-	goCtx, cancel := context.WithTimeout(context.Background(), ctx.HeartbeatTimeout)
+	goCtx, cancel := context.WithTimeout(context.TODO(), ctx.HeartbeatTimeout)
 	defer cancel()
 	// NB: We want the request to fail-fast (the default), otherwise we won't be
 	// notified of transport failures.

--- a/server/admin.go
+++ b/server/admin.go
@@ -979,7 +979,7 @@ func (s *adminServer) waitForStoreFrozen(
 					return err
 				}
 				client := storage.NewFreezeClient(conn)
-				resp, err = client.PollFrozen(context.Background(),
+				resp, err = client.PollFrozen(context.TODO(),
 					&storage.PollFrozenRequest{
 						StoreRequestHeader: storage.StoreRequestHeader{
 							NodeID:  nodeID,
@@ -994,7 +994,7 @@ func (s *adminServer) waitForStoreFrozen(
 			// Run a limited, non-blocking task. That means the task simply
 			// won't run if the semaphore is full (or the node is draining).
 			// Both are handled by the surrounding retry loop.
-			if err := s.server.stopper.RunLimitedAsyncTask(context.Background(), sem,
+			if err := s.server.stopper.RunLimitedAsyncTask(context.TODO(), sem,
 				func(_ context.Context) {
 					if err := action(); err != nil {
 						sendErr(err)

--- a/sql/planner.go
+++ b/sql/planner.go
@@ -76,7 +76,7 @@ type planner struct {
 func makePlanner() *planner {
 	// init with an empty session. We can't leave this nil because too much code
 	// looks in the session for the current database.
-	return &planner{session: &Session{Location: time.UTC, context: context.Background()}}
+	return &planner{session: &Session{Location: time.UTC, context: context.TODO()}}
 }
 
 // queryRunner abstracts the services provided by a planner object

--- a/sql/session.go
+++ b/sql/session.go
@@ -363,7 +363,7 @@ func (ts *txnState) finishSQLTxn() {
 		(traceSQLFor7881 && sampledFor7881) {
 		dump := tracing.FormatRawSpans(ts.CollectedSpans)
 		if len(dump) > 0 {
-			log.Infof(context.Background(), "SQL trace:\n%s", dump)
+			log.Infof(context.TODO(), "SQL trace:\n%s", dump)
 		}
 	}
 }

--- a/util/stop/stopper.go
+++ b/util/stop/stopper.go
@@ -259,7 +259,7 @@ func (s *Stopper) RunLimitedAsyncTask(
 	case <-s.ShouldQuiesce():
 		return errUnavailable
 	default:
-		log.Infof(context.Background(), "stopper throttling task from %s:%d due to semaphore", file, line)
+		log.Infof(context.TODO(), "stopper throttling task from %s:%d due to semaphore", file, line)
 		// Retry the select without the default.
 		select {
 		case sem <- struct{}{}:
@@ -350,7 +350,7 @@ func (s *Stopper) Stop() {
 	defer s.Recover()
 	defer unregister(s)
 
-	log.Info(context.Background(), "stop has been called, stopping or quiescing all running tasks")
+	log.Info(context.TODO(), "stop has been called, stopping or quiescing all running tasks")
 	// Don't bother doing stuff cleanly if we're panicking, that would likely
 	// block. Instead, best effort only. This cleans up the stack traces,
 	// avoids stalls and helps some tests in `./cli` finish cleanly (where
@@ -422,7 +422,7 @@ func (s *Stopper) Quiesce() {
 		close(s.quiescer)
 	}
 	for s.mu.numTasks > 0 {
-		log.Infof(context.Background(), "quiescing; tasks left:\n%s", s.runningTasksLocked())
+		log.Infof(context.TODO(), "quiescing; tasks left:\n%s", s.runningTasksLocked())
 		// Unlock s.mu, wait for the signal, and lock s.mu.
 		s.mu.quiesce.Wait()
 	}


### PR DESCRIPTION
Going forward, `context.Bacgkround()` will only be used when it is the right
thing to do (actual background processes, cli). Any cases where we just don't
have a context should use TODO. See #9807 for more discussion.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9874)

<!-- Reviewable:end -->
