### PR TITLE
sql: test refactor

### DIFF
--- a/pkg/sql/as_of_test.go
+++ b/pkg/sql/as_of_test.go
@@ -239,7 +239,9 @@ func TestAsOfRetry(t *testing.T) {
 			switch req := args.Req.(type) {
 			case *roachpb.ScanRequest:
 				for key, count := range magicVals.restartCounts {
-					checkCorrectTxn(string(req.Key), magicVals, args.Hdr.Txn)
+					if err := checkCorrectTxn(string(req.Key), magicVals, args.Hdr.Txn); err != nil {
+						return roachpb.NewError(err)
+					}
 					if count > 0 && bytes.Contains(req.Key, []byte(key)) {
 						magicVals.restartCounts[key]--
 						err := roachpb.NewTransactionRetryError()

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -213,7 +213,7 @@ func (*ExecutorTestingKnobs) ModuleTestingKnobs() {}
 
 // StatementFilter is the type of callback that
 // ExecutorTestingKnobs.StatementFilter takes.
-type StatementFilter func(stms string, res *Result)
+type StatementFilter func(context.Context, string, *Result)
 
 // ExecutorTestingKnobs is part of the context used to control parts of the
 // system during testing.
@@ -798,8 +798,8 @@ func (e *Executor) execStmtsInCurrentTxn(
 			}
 		}
 		res.Err = convertToErrWithPGCode(res.Err)
-		if e.cfg.TestingKnobs.StatementFilter != nil {
-			e.cfg.TestingKnobs.StatementFilter(stmt.String(), &res)
+		if filter := e.cfg.TestingKnobs.StatementFilter; filter != nil {
+			filter(ctx, stmt.String(), &res)
 		}
 		results = append(results, res)
 		if err != nil {

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -20,11 +20,14 @@ import (
 	"bytes"
 	gosql "database/sql"
 	"fmt"
+	"net/url"
 	"regexp"
 	"strconv"
 	"sync/atomic"
 	"testing"
 
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -43,8 +46,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/lib/pq"
-	"github.com/pkg/errors"
 )
 
 type failureRecord struct {
@@ -77,31 +78,29 @@ func createFilterVals(restartCounts map[string]int, abortCounts map[string]int) 
 
 // checkCorrectTxn checks that the current txn is the correct one, according to
 // the way the previous txn that tried to write value failed.
-func checkCorrectTxn(value string, magicVals *filterVals, txn *roachpb.Transaction) {
+func checkCorrectTxn(value string, magicVals *filterVals, txn *roachpb.Transaction) error {
 	failureRec, found := magicVals.failedValues[value]
 	if !found {
-		return
+		return nil
 	}
 	switch failureRec.err.(type) {
 	case *roachpb.TransactionAbortedError:
 		// The previous txn should have been aborted, so check that we're running
 		// in a new one.
 		if failureRec.txn.Equal(txn) {
-			panic(fmt.Sprintf("new transaction for value \"%s\" is the same "+
-				"as the old one", value))
+			return errors.Errorf(`new transaction for value "%s" is the same as the old one`, value)
 		}
 	default:
 		// The previous txn should have been restarted, so we should be running in
 		// the same one.
 		if !failureRec.txn.Equal(txn) {
-			// panic and not t.Fatal because this runs on a different goroutine
-			panic(fmt.Sprintf("new transaction for value \"%s\" (%s) "+
-				"is not the same as the old one (%s)", value,
-				txn, failureRec.txn))
+			return errors.Errorf(`new transaction for value "%s" (%s) is not the same as the old one (%s)`, value, txn, failureRec.txn)
 		}
 	}
 	// Don't check this value in subsequent transactions.
 	delete(magicVals.failedValues, value)
+
+	return nil
 }
 
 func injectErrors(req roachpb.Request, hdr roachpb.Header, magicVals *filterVals) error {
@@ -111,7 +110,9 @@ func injectErrors(req roachpb.Request, hdr roachpb.Header, magicVals *filterVals
 	switch req := req.(type) {
 	case *roachpb.ConditionalPutRequest:
 		for key, count := range magicVals.restartCounts {
-			checkCorrectTxn(string(req.Value.RawBytes), magicVals, hdr.Txn)
+			if err := checkCorrectTxn(string(req.Value.RawBytes), magicVals, hdr.Txn); err != nil {
+				return err
+			}
 			if count > 0 && bytes.Contains(req.Value.RawBytes, []byte(key)) {
 				magicVals.restartCounts[key]--
 				err := roachpb.NewReadWithinUncertaintyIntervalError(
@@ -122,7 +123,9 @@ func injectErrors(req roachpb.Request, hdr roachpb.Header, magicVals *filterVals
 			}
 		}
 		for key, count := range magicVals.abortCounts {
-			checkCorrectTxn(string(req.Value.RawBytes), magicVals, hdr.Txn)
+			if err := checkCorrectTxn(string(req.Value.RawBytes), magicVals, hdr.Txn); err != nil {
+				return err
+			}
 			if count > 0 && bytes.Contains(req.Value.RawBytes, []byte(key)) {
 				magicVals.abortCounts[key]--
 				err := roachpb.NewTransactionAbortedError()
@@ -177,7 +180,7 @@ func checkRestarts(t *testing.T, magicVals *filterVals) {
 //
 // The aborter only works with INSERT statements operating on the table t.test
 // defined as:
-//    CREATE DATABASE t; CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);`)
+//	`CREATE DATABASE t; CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT)`
 // The TxnAborter runs transactions deleting the row for the `k` that the
 // trapped transactions were writing to.
 //
@@ -189,91 +192,76 @@ func checkRestarts(t *testing.T, magicVals *filterVals) {
 // Example usage:
 //
 //	func TestTxnAutoRetry(t *testing.T) {
-// 		defer leaktest.AfterTest(t)()
-//	 	aborter := MakeTxnAborter()
-// 		defer aborter.Close(t)
+//		defer leaktest.AfterTest(t)()
+//		aborter := NewTxnAborter()
+//		defer aborter.Close(t)
 //		params, cmdFilters := createTestServerParams()
-//		executorKnobs := sql.ExecutorTestingKnobs{
-//			FixTxnPriority: true,
-//			// We're going to abort txns using a TxnAborter, and that's
-//			// incompatible with AutoCommit.
-//			DisableAutoCommit: true,
-//		}
-//		params.Knobs.SQLExecutor = aborter.HookupToExecutor(executorKnobs)
+//		params.Knobs.SQLExecutor = aborter.executorKnobs()
 //		s, sqlDB, _ := serverutils.StartServer(t, params)
 //		defer s.Stopper().Stop()
-//		aborter.InitConn(t, s)
+//		{
+//			pgURL, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), security.RootUser, "TestTxnAutoRetry")
+//			defer cleanup()
+//			if err := aborter.Init(pgURL); err != nil {
+//				t.Fatal(err)
+//			}
+//		}
 //
-//  	sqlDB.Exec(`
-//    	CREATE DATABASE t; CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);`)
-//		sentinelInsert := "INSERT INTO t.test(k, v) VALUES (0, 'sentinel')"
-//		aborter.QueueStmtForAbortion(t,
-//					sentinelInsert, 1 /* restartCount */, true /* willBeRetriedIbid */)
+//		sqlDB.Exec(`CREATE DATABASE t; CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT)`)
+//		const sentinelInsert = "INSERT INTO t.test(k, v) VALUES (0, 'sentinel')"
+//		if err := aborter.QueueStmtForAbortion(
+//			sentinelInsert, 1 /* abortCount */, true /* willBeRetriedIbid */,
+//		); err != nil {
+//			t.Fatal(err)
+//		}
 //		sqlDB.Exec(sentinelInsert)
 //	...
 type TxnAborter struct {
-	mu           syncutil.Mutex
-	stmtsToAbort map[string]*restartInfo
-	db           *gosql.DB
-	cleanupDB    func()
+	mu struct {
+		syncutil.Mutex
+		stmtsToAbort map[string]*restartInfo
+	}
+	// A second connection pool, to be used by aborts.
+	// This is needed because the main conn pool is going to be restricted to one
+	// connection.
+	// TODO(andrei): remove this if we ever move to using libpq conns directly.
+	// See TODOs around on SetMaxOpenConns.
+	abortDB *gosql.DB
 }
 
 type restartInfo struct {
 	// The numberic value being inserted in col 'k'.
 	key int
 	// The remaining number of times to abort the txn.
-	restartCount   int
+	abortCount     int
 	satisfied      bool
 	checkSatisfied bool
 	// The number of times the statement as been executed.
 	execCount int
 }
 
-func MakeTxnAborter() *TxnAborter {
-	return &TxnAborter{
-		stmtsToAbort: make(map[string]*restartInfo),
-	}
+func NewTxnAborter() *TxnAborter {
+	ta := new(TxnAborter)
+	ta.mu.stmtsToAbort = make(map[string]*restartInfo)
+	return ta
 }
 
-// Close releases resources used by the TxnAborter and verifies that all
-// the statements were aborted the intended number of times.
-func (ta *TxnAborter) Close(t testing.TB) {
-	if ta.db != nil {
-		ta.db.Close()
-		ta.cleanupDB()
-		if r := recover(); r != nil {
-			// Don't `verify()` if the test is panicking down (presumably because of a
-			// Fatal or a timeout).
-			panic(r)
-		} else {
-			ta.verify(t)
-		}
-	}
-}
-
-// InitConn opens a connection pool that the Aborter will use internally.
-func (ta *TxnAborter) InitConn(t testing.TB, s serverutils.TestServerInterface) {
-	// Open a second connection pool, to be used by aborts.
-	// This is needed because the main conn pool is going to be restricted to one
-	// connection.
-	// TODO(andrei): remove this if we ever move to using libpq conns directly.
-	// See TODOs around on SetMaxOpenConns.
-	pgURL, cleanupDB := sqlutils.PGUrl(
-		t, s.ServingAddr(), security.RootUser, "SecondConnPool")
-	db, err := gosql.Open("postgres", pgURL.String())
+func (ta *TxnAborter) Init(pgURL url.URL) error {
+	abortDB, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
-		cleanupDB()
-		t.Fatalf("error opening aborter connection: %s", err)
+		return err
 	}
-	ta.db = db
-	ta.cleanupDB = cleanupDB
+	ta.abortDB = abortDB
+	return nil
 }
+
+var valuesRE = regexp.MustCompile(`VALUES.*\((\d),`)
 
 // QueueStmtForAbortion registers a statement whose transaction will be aborted.
 //
 // stmt needs to be the statement, literally as the parser will convert it back
 // to a string.
-// restartCount specifies how many times a txn running this statement will be
+// abortCount specifies how many times a txn running this statement will be
 // aborted.
 // willBeRetriedIbid should be set if the statement will be retried by the test
 // (as an identical statement). This allows the TxnAborter to assert, on
@@ -290,33 +278,33 @@ func (ta *TxnAborter) InitConn(t testing.TB, s serverutils.TestServerInterface) 
 // Calling QueueStmtForAbortion repeatedly with the same stmt is allowed, and
 // each call checks that the previous one was satisfied.
 func (ta *TxnAborter) QueueStmtForAbortion(
-	t testing.TB, stmt string, restartCount int, willBeRetriedIbid bool,
-) {
+	stmt string, abortCount int, willBeRetriedIbid bool,
+) error {
 	ta.mu.Lock()
 	defer ta.mu.Unlock()
-	ri := ta.stmtsToAbort[stmt]
-	if ri != nil {
-		// If we're overwriting a statement that was already queued, verify that it
-		// was satisfied.
-		if err := ta.checkStmtSatisfied(stmt); err != nil {
-			t.Errorf("%s: %s", testutils.Caller(1), err)
+	if ri, ok := ta.mu.stmtsToAbort[stmt]; ok {
+		// If we're overwriting a statement that was already queued, verify it
+		// first.
+		if err := ri.Verify(); err != nil {
+			return errors.Wrapf(err, `statement "%s" error`, stmt)
 		}
 	}
 	// Extract the "key" - the value of the first col, which will be trampled on.
-	re := regexp.MustCompile(`VALUES.*\((\d),`)
-	matches := re.FindStringSubmatch(stmt)
-	if matches == nil {
-		t.Fatalf("bad statement: key col not found")
-	}
-	key, err := strconv.Atoi(matches[1])
-	if err != nil {
-		t.Fatalf("bad statement: key col is not a number")
-	}
-	ta.stmtsToAbort[stmt] = &restartInfo{
-		key:            key,
-		restartCount:   restartCount,
-		satisfied:      false,
-		checkSatisfied: willBeRetriedIbid,
+	switch matches := valuesRE.FindStringSubmatch(stmt); len(matches) {
+	case 0, 1:
+		return errors.Errorf(`bad statement "%s": key col not found`, stmt)
+	default:
+		key, err := strconv.Atoi(matches[1])
+		if err != nil {
+			return errors.Wrapf(err, `bad statement "%s"`, stmt)
+		}
+		ta.mu.stmtsToAbort[stmt] = &restartInfo{
+			key:            key,
+			abortCount:     abortCount,
+			satisfied:      false,
+			checkSatisfied: willBeRetriedIbid,
+		}
+		return nil
 	}
 }
 
@@ -327,61 +315,51 @@ func (ta *TxnAborter) QueueStmtForAbortion(
 func (ta *TxnAborter) GetExecCount(stmt string) (int, bool) {
 	ta.mu.Lock()
 	defer ta.mu.Unlock()
-	ri, ok := ta.stmtsToAbort[stmt]
-	if ok {
-		return ri.execCount, ok
-	} else {
-		return 0, ok
+	if ri, ok := ta.mu.stmtsToAbort[stmt]; ok {
+		return ri.execCount, true
 	}
+	return 0, false
 }
 
-// HookupToExecutor returns a modified ExecutorTestingKnobs with the
-// StatementFilter hooked up to the TxnAborter.
-func (ta *TxnAborter) HookupToExecutor(knobs sql.ExecutorTestingKnobs) base.ModuleTestingKnobs {
-	if !knobs.FixTxnPriority || !knobs.DisableAutoCommit {
-		panic("TxnAborter can only be installed when " +
-			"FixTxnPriority and DisableAutoCommit are both specified")
-	}
-	if knobs.StatementFilter != nil {
-		panic("a StatementFilter is already installed")
-	}
-	knobs.StatementFilter = ta.statementFilter
-	return &knobs
-}
-
-// statementFilter should be invoked for each SQL statement being executed.
-// It's meant to be hooked up to an Executor by HookupToExecutor().
-func (ta *TxnAborter) statementFilter(stmt string, res *sql.Result) {
+func (ta *TxnAborter) statementFilter(ctx context.Context, stmt string, res *sql.Result) {
 	ta.mu.Lock()
-	ri := ta.stmtsToAbort[stmt]
+	ri, ok := ta.mu.stmtsToAbort[stmt]
 	shouldAbort := false
-	if ri != nil {
+	if ok {
 		ri.execCount++
-		if ri.restartCount == 0 {
-			log.VEventf(1, context.TODO(), "TxnAborter sees satisfied statement %q", stmt)
+		if ri.abortCount == 0 {
+			log.VEventf(1, ctx, "TxnAborter sees satisfied statement %q", stmt)
 			ri.satisfied = true
 		}
-		if ri.restartCount > 0 && res.Err == nil {
-			log.Infof(context.TODO(), "TxnAborter aborting txn for statement %q", stmt)
-			ri.restartCount--
+		if ri.abortCount > 0 && res.Err == nil {
+			log.Infof(ctx, "TxnAborter aborting txn for statement %q", stmt)
+			ri.abortCount--
 			shouldAbort = true
 		}
 	}
 	ta.mu.Unlock()
 	if shouldAbort {
-		err := ta.abortTxn(ri.key)
-		if err != nil {
+		if err := ta.abortTxn(ri.key); err != nil {
 			res.Err = errors.Wrap(err, "TxnAborter failed to abort")
 		}
+	}
+}
+
+// executorKnobs are the bridge between the TxnAborter and the sql.Executor.
+func (ta *TxnAborter) executorKnobs() base.ModuleTestingKnobs {
+	return &sql.ExecutorTestingKnobs{
+		FixTxnPriority: true,
+		// We're going to abort txns using a TxnAborter, and that's incompatible
+		// with AutoCommit.
+		DisableAutoCommit: true,
+		StatementFilter:   ta.statementFilter,
 	}
 }
 
 // abortTxn writes to a key and as a side effect aborts a txn that had an intent
 // on that key.
 func (ta *TxnAborter) abortTxn(key int) error {
-	var err error
-	var tx *gosql.Tx
-	tx, err = ta.db.Begin()
+	tx, err := ta.abortDB.Begin()
 	if err != nil {
 		return err
 	}
@@ -397,29 +375,24 @@ func (ta *TxnAborter) abortTxn(key int) error {
 	return nil
 }
 
-func (ta *TxnAborter) verify(t testing.TB) {
+func (ta *TxnAborter) Close(t testing.TB) {
+	ta.abortDB.Close()
+
 	ta.mu.Lock()
 	defer ta.mu.Unlock()
-	for stmt := range ta.stmtsToAbort {
-		if err := ta.checkStmtSatisfied(stmt); err != nil {
-			t.Error(err)
+	for stmt, ri := range ta.mu.stmtsToAbort {
+		if err := ri.Verify(); err != nil {
+			t.Error(errors.Wrapf(err, `statement "%s" error`, stmt))
 		}
 	}
 }
 
-func (ta *TxnAborter) checkStmtSatisfied(stmt string) error {
-	ri := ta.stmtsToAbort[stmt]
-	if ri == nil {
-		return errors.Errorf("checkStmtSatisfied called for missing statement %q", stmt)
+func (ri *restartInfo) Verify() error {
+	if ri.abortCount != 0 {
+		return errors.Errorf("%d additional aborts expected", ri.abortCount)
 	}
-	if ri.restartCount != 0 {
-		return errors.Errorf("Statement %q still needs to be aborted %d times.",
-			stmt, ri.restartCount)
-	} else {
-		if ri.checkSatisfied && !ri.satisfied {
-			return errors.Errorf("Statement %q was not retried after its txn was aborted "+
-				"the last time.", stmt)
-		}
+	if ri.checkSatisfied && !ri.satisfied {
+		return errors.New("previous abort did not result in a retry")
 	}
 	return nil
 }
@@ -429,21 +402,21 @@ func (ta *TxnAborter) checkStmtSatisfied(stmt string) error {
 func TestTxnAutoRetry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	aborter := MakeTxnAborter()
+	aborter := NewTxnAborter()
 	defer aborter.Close(t)
 	params, cmdFilters := createTestServerParams()
-	executorKnobs := sql.ExecutorTestingKnobs{
-		FixTxnPriority: true,
-		// We're going to abort txns using a TxnAborter, and that's incompatible
-		// with AutoCommit.
-		DisableAutoCommit: true,
-	}
-	params.Knobs.SQLExecutor = aborter.HookupToExecutor(executorKnobs)
+	params.Knobs.SQLExecutor = aborter.executorKnobs()
 	// Disable one phase commits because they cannot be restarted.
 	params.Knobs.Store.(*storage.StoreTestingKnobs).DisableOnePhaseCommits = true
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop()
-	aborter.InitConn(t, s)
+	{
+		pgURL, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), security.RootUser, "TestTxnAutoRetry")
+		defer cleanup()
+		if err := aborter.Init(pgURL); err != nil {
+			t.Fatal(err)
+		}
+	}
 
 	// Make sure all the commands we send in this test are sent over the same connection.
 	// This is a bit of a hack; in Go you're not supposed to have connection state
@@ -483,18 +456,26 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT, t DECIMAL);
 			return nil
 		}, false)
 
-	aborter.QueueStmtForAbortion(t,
-		"INSERT INTO t.test(k, v, t) VALUES (1, 'boulanger', cluster_logical_timestamp())",
-		2 /* restartCount */, true /* willBeRetriedIbid */)
-	aborter.QueueStmtForAbortion(t,
-		"INSERT INTO t.test(k, v, t) VALUES (2, 'dromedary', cluster_logical_timestamp())",
-		2 /* restartCount */, true /* willBeRetriedIbid */)
-	aborter.QueueStmtForAbortion(t,
-		"INSERT INTO t.test(k, v, t) VALUES (3, 'fajita', cluster_logical_timestamp())",
-		2 /* restartCount */, true /* willBeRetriedIbid */)
-	aborter.QueueStmtForAbortion(t,
-		"INSERT INTO t.test(k, v, t) VALUES (4, 'hooly', cluster_logical_timestamp())",
-		2 /* restartCount */, true /* willBeRetriedIbid */)
+	if err := aborter.QueueStmtForAbortion(
+		"INSERT INTO t.test(k, v, t) VALUES (1, 'boulanger', cluster_logical_timestamp())", 2 /* abortCount */, true, /* willBeRetriedIbid */
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := aborter.QueueStmtForAbortion(
+		"INSERT INTO t.test(k, v, t) VALUES (2, 'dromedary', cluster_logical_timestamp())", 2 /* abortCount */, true, /* willBeRetriedIbid */
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := aborter.QueueStmtForAbortion(
+		"INSERT INTO t.test(k, v, t) VALUES (3, 'fajita', cluster_logical_timestamp())", 2 /* abortCount */, true, /* willBeRetriedIbid */
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := aborter.QueueStmtForAbortion(
+		"INSERT INTO t.test(k, v, t) VALUES (4, 'hooly', cluster_logical_timestamp())", 2 /* abortCount */, true, /* willBeRetriedIbid */
+	); err != nil {
+		t.Fatal(err)
+	}
 
 	// Test that implicit txns - txns for which we see all the statements and prefixes
 	// of txns (statements batched together with the BEGIN stmt) - are retried.
@@ -517,7 +498,7 @@ INSERT INTO t.test(k, v, t) VALUES (6, 'laureal', cluster_logical_timestamp());
 
 	checkRestarts(t, magicVals)
 
-	if _, err := sqlDB.Exec("END;"); err != nil {
+	if _, err := sqlDB.Exec("END"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -567,25 +548,28 @@ BEGIN;
 func TestAbortedTxnOnlyRetriedOnce(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	aborter := MakeTxnAborter()
+	aborter := NewTxnAborter()
 	defer aborter.Close(t)
 	params, _ := createTestServerParams()
-	executorKnobs := sql.ExecutorTestingKnobs{
-		FixTxnPriority: true,
-		// We're going to abort txns using a TxnAborter, and that's incompatible
-		// with AutoCommit.
-		DisableAutoCommit: true,
-	}
-	params.Knobs.SQLExecutor = aborter.HookupToExecutor(executorKnobs)
+	params.Knobs.SQLExecutor = aborter.executorKnobs()
 	// Disable one phase commits because they cannot be restarted.
 	params.Knobs.Store.(*storage.StoreTestingKnobs).DisableOnePhaseCommits = true
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop()
-	aborter.InitConn(t, s)
+	{
+		pgURL, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), security.RootUser, "TestAbortedTxnOnlyRetriedOnce")
+		defer cleanup()
+		if err := aborter.Init(pgURL); err != nil {
+			t.Fatal(err)
+		}
+	}
 
-	insertStmt := "INSERT INTO t.test(k, v) VALUES (1, 'boulanger')"
-	aborter.QueueStmtForAbortion(t, insertStmt,
-		1 /* restartCount */, true /* willBeRetriedIbid */)
+	const insertStmt = "INSERT INTO t.test(k, v) VALUES (1, 'boulanger')"
+	if err := aborter.QueueStmtForAbortion(
+		insertStmt, 1 /* abortCount */, true, /* willBeRetriedIbid */
+	); err != nil {
+		t.Fatal(err)
+	}
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
@@ -640,7 +624,7 @@ func exec(t *testing.T, sqlDB *gosql.DB, rs rollbackStrategy, fn func(*gosql.Tx)
 		t.Fatal(err)
 	}
 	if _, err := tx.Exec(
-		"SAVEPOINT cockroach_restart; SET TRANSACTION PRIORITY LOW;"); err != nil {
+		"SAVEPOINT cockroach_restart; SET TRANSACTION PRIORITY LOW"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -671,22 +655,21 @@ func runTestTxn(
 ) bool {
 	retriesNeeded :=
 		(magicVals.restartCounts["boulanger"] + magicVals.abortCounts["boulanger"]) > 0
-	var err error
 	if retriesNeeded {
-		_, err = tx.Exec("INSERT INTO t.test(k, v) VALUES (1, 'boulanger')")
+		_, err := tx.Exec("INSERT INTO t.test(k, v) VALUES (1, 'boulanger')")
 		if !testutils.IsError(err, expectedErr) {
-			t.Fatalf("expected to fail here. err: %v", err)
+			t.Fatalf("unexpected error: %v", err)
 		}
 		return isRetryableErr(err)
 	}
 	// Now the INSERT should succeed.
-	_, err = tx.Exec(fmt.Sprintf(
-		"DELETE FROM t.test WHERE true; %s;", sentinelInsert))
-	if err != nil {
+	if _, err := tx.Exec(
+		"DELETE FROM t.test WHERE true;" + sentinelInsert,
+	); err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = tx.Exec("RELEASE SAVEPOINT cockroach_restart")
+	_, err := tx.Exec("RELEASE SAVEPOINT cockroach_restart")
 	return isRetryableErr(err)
 }
 
@@ -696,19 +679,19 @@ func runTestTxn(
 func TestTxnUserRestart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	aborter := MakeTxnAborter()
+	aborter := NewTxnAborter()
 	defer aborter.Close(t)
 	params, cmdFilters := createTestServerParams()
-	executorKnobs := sql.ExecutorTestingKnobs{
-		FixTxnPriority: true,
-		// We're going to abort txns using a TxnAborter, and that's incompatible
-		// with AutoCommit.
-		DisableAutoCommit: true,
-	}
-	params.Knobs.SQLExecutor = aborter.HookupToExecutor(executorKnobs)
+	params.Knobs.SQLExecutor = aborter.executorKnobs()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop()
-	aborter.InitConn(t, s)
+	{
+		pgURL, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), security.RootUser, "TestTxnUserRestart")
+		defer cleanup()
+		if err := aborter.Init(pgURL); err != nil {
+			t.Fatal(err)
+		}
+	}
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
@@ -747,9 +730,12 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
 				}, false)
 
 			// Also inject an error at RELEASE time, besides the error injected by magicVals.
-			sentinelInsert := "INSERT INTO t.test(k, v) VALUES (0, 'sentinel')"
-			aborter.QueueStmtForAbortion(t,
-				sentinelInsert, 1 /* restartCount */, true /* willBeRetriedIbid */)
+			const sentinelInsert = "INSERT INTO t.test(k, v) VALUES (0, 'sentinel')"
+			if err := aborter.QueueStmtForAbortion(
+				sentinelInsert, 1 /* abortCount */, true, /* willBeRetriedIbid */
+			); err != nil {
+				t.Fatal(err)
+			}
 
 			commitCount := s.MustGetSQLCounter(sql.MetaTxnCommit.Name)
 			// This is the magic. Run the txn closure until all the retries are exhausted.
@@ -807,17 +793,15 @@ CREATE DATABASE t; CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
 		t.Fatal(err)
 	}
 	if _, err := tx.Exec(
-		"SAVEPOINT cockroach_restart; RELEASE cockroach_restart;"); err != nil {
+		"SAVEPOINT cockroach_restart; RELEASE cockroach_restart"); err != nil {
 		t.Fatal(err)
 	}
-	_, err = tx.Exec("INSERT INTO t.test(k, v) VALUES (0, 'sentinel');")
-	if !testutils.IsError(err, "current transaction is committed") {
-		t.Fatal(err)
+	if _, err := tx.Exec("INSERT INTO t.test(k, v) VALUES (0, 'sentinel')"); !testutils.IsError(err, "current transaction is committed") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 	// Rollback should respond with a COMMIT command tag.
-	err = tx.Rollback()
-	if !testutils.IsError(err, "unexpected command tag COMMIT") {
-		t.Fatal(err)
+	if err := tx.Rollback(); !testutils.IsError(err, "unexpected command tag COMMIT") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -828,19 +812,19 @@ CREATE DATABASE t; CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
 func TestErrorOnCommitFinalizesTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	aborter := MakeTxnAborter()
+	aborter := NewTxnAborter()
 	defer aborter.Close(t)
 	params, _ := createTestServerParams()
-	executorKnobs := sql.ExecutorTestingKnobs{
-		FixTxnPriority: true,
-		// We're going to abort txns using a TxnAborter, and that's incompatible
-		// with AutoCommit.
-		DisableAutoCommit: true,
-	}
-	params.Knobs.SQLExecutor = aborter.HookupToExecutor(executorKnobs)
+	params.Knobs.SQLExecutor = aborter.executorKnobs()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop()
-	aborter.InitConn(t, s)
+	{
+		pgURL, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), security.RootUser, "TestErrorOnCommitFinalizesTxn")
+		defer cleanup()
+		if err := aborter.Init(pgURL); err != nil {
+			t.Fatal(err)
+		}
+	}
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t; CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
@@ -864,14 +848,17 @@ CREATE DATABASE t; CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
 		{true},
 	}
 	for _, tc := range testCases {
-		insertStmt := "INSERT INTO t.test(k, v) VALUES (0, 'boulanger')"
-		aborter.QueueStmtForAbortion(t, insertStmt,
-			1 /* restartCount */, false /* willBeRetriedIbid */)
-		if _, err := sqlDB.Exec("BEGIN;"); err != nil {
+		const insertStmt = "INSERT INTO t.test(k, v) VALUES (0, 'boulanger')"
+		if err := aborter.QueueStmtForAbortion(
+			insertStmt, 1 /* abortCount */, false, /* willBeRetriedIbid */
+		); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := sqlDB.Exec("BEGIN"); err != nil {
 			t.Fatal(err)
 		}
 		if tc.retryIntent {
-			if _, err := sqlDB.Exec("SAVEPOINT cockroach_restart;"); err != nil {
+			if _, err := sqlDB.Exec("SAVEPOINT cockroach_restart"); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -917,12 +904,12 @@ func TestRollbackToSavepointStatement(t *testing.T) {
 	// ROLLBACK TO SAVEPOINT without a transaction
 	_, err := sqlDB.Exec("ROLLBACK TO SAVEPOINT cockroach_restart")
 	if !testutils.IsError(err, "the transaction is not in a retriable state") {
-		t.Fatalf("expected to fail here. err: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	// ROLLBACK TO SAVEPOINT with a wrong name
 	_, err = sqlDB.Exec("ROLLBACK TO SAVEPOINT foo")
 	if !testutils.IsError(err, "SAVEPOINT not supported except for COCKROACH_RESTART") {
-		t.Fatalf("expected to fail here. err: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// ROLLBACK TO SAVEPOINT in a non-retriable transaction
@@ -933,13 +920,13 @@ func TestRollbackToSavepointStatement(t *testing.T) {
 	if _, err := tx.Exec("SAVEPOINT cockroach_restart"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err = tx.Exec("BOGUS SQL STATEMENT"); err == nil {
-		t.Fatalf("expected to fail here. err: %v", err)
+	if _, err := tx.Exec("BOGUS SQL STATEMENT"); !testutils.IsError(err, `syntax error at or near "BOGUS"`) {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	_, err = tx.Exec("ROLLBACK TO SAVEPOINT cockroach_restart")
-	if !testutils.IsError(err,
-		"SAVEPOINT COCKROACH_RESTART has not been used or a non-retriable error was encountered") {
-		t.Fatalf("expected to fail here. err: %v", err)
+	if _, err := tx.Exec("ROLLBACK TO SAVEPOINT cockroach_restart"); !testutils.IsError(
+		err, "SAVEPOINT COCKROACH_RESTART has not been used or a non-retriable error was encountered",
+	) {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -967,12 +954,11 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
 	if _, err := tx.Exec("SAVEPOINT cockroach_restart"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err = tx.Exec("INSERT INTO t.test (k, v) VALUES (0, 'test')"); err != nil {
+	if _, err := tx.Exec("INSERT INTO t.test (k, v) VALUES (0, 'test')"); err != nil {
 		t.Fatal(err)
 	}
-	_, err = tx.Exec("INSERT INTO t.test (k, v) VALUES (0, 'test');")
-	if !testutils.IsError(err, "duplicate key value") {
-		t.Errorf("expected duplicate key error. Got: %v", err)
+	if _, err := tx.Exec("INSERT INTO t.test (k, v) VALUES (0, 'test')"); !testutils.IsError(err, "duplicate key value") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 	if _, err := tx.Exec("ROLLBACK TO SAVEPOINT cockroach_restart"); !testutils.IsError(
 		err, "current transaction is aborted, commands ignored until end of "+
@@ -990,19 +976,19 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
 func TestRollbackInRestartWait(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	aborter := MakeTxnAborter()
+	aborter := NewTxnAborter()
 	defer aborter.Close(t)
 	params, _ := createTestServerParams()
-	executorKnobs := sql.ExecutorTestingKnobs{
-		FixTxnPriority: true,
-		// We're going to abort txns using a TxnAborter, and that's incompatible
-		// with AutoCommit.
-		DisableAutoCommit: true,
-	}
-	params.Knobs.SQLExecutor = aborter.HookupToExecutor(executorKnobs)
+	params.Knobs.SQLExecutor = aborter.executorKnobs()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop()
-	aborter.InitConn(t, s)
+	{
+		pgURL, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), security.RootUser, "TestRollbackInRestartWait")
+		defer cleanup()
+		if err := aborter.Init(pgURL); err != nil {
+			t.Fatal(err)
+		}
+	}
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
@@ -1012,9 +998,12 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
 	}
 
 	// Set up error injection that causes retries.
-	insertStmt := "INSERT INTO t.test(k, v) VALUES (0, 'boulanger')"
-	aborter.QueueStmtForAbortion(t, insertStmt,
-		1 /* restartCount */, false /* willBeRetriedIbid */)
+	const insertStmt = "INSERT INTO t.test(k, v) VALUES (0, 'boulanger')"
+	if err := aborter.QueueStmtForAbortion(
+		insertStmt, 1 /* abortCount */, false, /* willBeRetriedIbid */
+	); err != nil {
+		t.Fatal(err)
+	}
 
 	tx, err := sqlDB.Begin()
 	if err != nil {
@@ -1095,7 +1084,7 @@ func TestNonRetryableErrorOnCommit(t *testing.T) {
 		}, false)
 	defer cleanupFilter()
 
-	if _, err := sqlDB.Exec("CREATE DATABASE t;"); !testutils.IsError(err, "pq: testError") {
+	if _, err := sqlDB.Exec("CREATE DATABASE t"); !testutils.IsError(err, "pq: testError") {
 		t.Errorf("unexpected error %v", err)
 	}
 	if !hitError {


### PR DESCRIPTION
- Better emitted errors by moving `t.{Error,Fatal}{,f}` out of helpers
- Various golint fixes (not sure why these are not picked up by CI)
- Convert panics to errors
- DRY TxnAborter -> sql.ExecutorTestingKnobs plumbing
- Slim down TxnAborter.Close by moving logic to callers + defers

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9882)

<!-- Reviewable:end -->
