### PR TITLE
sql: implement parse errors as errors instead of panics.

### DIFF
--- a/sql/parser/parse.go
+++ b/sql/parser/parse.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/util"
 	"github.com/pkg/errors"
 )
 
@@ -68,15 +67,6 @@ type Parser struct {
 
 // Parse parses the sql and returns a list of statements.
 func (p *Parser) Parse(sql string, syntax Syntax) (stmts StatementList, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			// Panic on anything except unimplemented errors.
-			if _, ok := r.(util.UnimplementedWithIssueError); !ok && r != errUnimplemented {
-				panic(r)
-			}
-			err = r.(error)
-		}
-	}()
 	p.scanner.init(sql, syntax)
 	if p.parserImpl.Parse(&p.scanner) != 0 {
 		return nil, errors.New(p.scanner.lastError)

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -7,26 +7,27 @@ import __yyfmt__ "fmt"
 
 //line sql.y:20
 import (
+	"fmt"
+
 	"go/constant"
 	"go/token"
 
-	"github.com/pkg/errors"
-
 	"github.com/cockroachdb/cockroach/sql/privilege"
-	"github.com/cockroachdb/cockroach/util"
 )
 
-var errUnimplemented = errors.New("unimplemented")
-
-func unimplemented() {
-	panic(errUnimplemented)
+func unimplemented(sqllex sqlLexer) int {
+	sqllex.Error("unimplemented")
+	return 1
 }
 
-func unimplementedWithIssue(issue int) {
-	panic(util.UnimplementedWithIssueErrorf(issue, ""))
+func unimplementedWithIssue(sqllex sqlLexer, issue int) int {
+	sqllex.Error(fmt.Sprintf("unimplemented "+
+		"(see issue https://github.com/cockroachdb/cockroach/issues/%d)",
+		issue))
+	return 1
 }
 
-//line sql.y:44
+//line sql.y:45
 
 // sqlSymUnion represents a union of types, providing accessor methods
 // to retrieve the underlying type stored in the union's empty interface.
@@ -270,7 +271,7 @@ func (u *sqlSymUnion) window() Window {
 	return u.val.(Window)
 }
 
-//line sql.y:288
+//line sql.y:289
 type sqlSymType struct {
 	yys   int
 	id    int
@@ -882,7 +883,7 @@ const sqlEofCode = 1
 const sqlErrCode = 2
 const sqlInitialStackSize = 16
 
-//line sql.y:4845
+//line sql.y:4846
 
 //line yacctab:1
 var sqlExca = [...]int{
@@ -5093,13 +5094,13 @@ sqldefault:
 
 	case 1:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:699
+		//line sql.y:700
 		{
 			sqllex.(*Scanner).stmts = sqlDollar[1].union.stmts()
 		}
 	case 2:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:705
+		//line sql.y:706
 		{
 			if sqlDollar[3].union.stmt() != nil {
 				sqlVAL.union.val = append(sqlDollar[1].union.stmts(), sqlDollar[3].union.stmt())
@@ -5107,7 +5108,7 @@ sqldefault:
 		}
 	case 3:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:711
+		//line sql.y:712
 		{
 			if sqlDollar[1].union.stmt() != nil {
 				sqlVAL.union.val = []Statement{sqlDollar[1].union.stmt()}
@@ -5117,91 +5118,91 @@ sqldefault:
 		}
 	case 19:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:736
+		//line sql.y:737
 		{
 			sqlVAL.union.val = sqlDollar[1].union.slct()
 		}
 	case 27:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:747
+		//line sql.y:748
 		{
 			sqlVAL.union.val = Statement(nil)
 		}
 	case 28:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:753
+		//line sql.y:754
 		{
 			sqlVAL.union.val = &AlterTable{Table: sqlDollar[3].union.normalizableTableName(), IfExists: false, Cmds: sqlDollar[4].union.alterTableCmds()}
 		}
 	case 29:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:757
+		//line sql.y:758
 		{
 			sqlVAL.union.val = &AlterTable{Table: sqlDollar[5].union.normalizableTableName(), IfExists: true, Cmds: sqlDollar[6].union.alterTableCmds()}
 		}
 	case 30:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:763
+		//line sql.y:764
 		{
 			sqlVAL.union.val = AlterTableCmds{sqlDollar[1].union.alterTableCmd()}
 		}
 	case 31:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:767
+		//line sql.y:768
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.alterTableCmds(), sqlDollar[3].union.alterTableCmd())
 		}
 	case 32:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:774
+		//line sql.y:775
 		{
 			sqlVAL.union.val = &AlterTableAddColumn{columnKeyword: false, IfNotExists: false, ColumnDef: sqlDollar[2].union.colDef()}
 		}
 	case 33:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:779
+		//line sql.y:780
 		{
 			sqlVAL.union.val = &AlterTableAddColumn{columnKeyword: false, IfNotExists: true, ColumnDef: sqlDollar[5].union.colDef()}
 		}
 	case 34:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:784
+		//line sql.y:785
 		{
 			sqlVAL.union.val = &AlterTableAddColumn{columnKeyword: true, IfNotExists: false, ColumnDef: sqlDollar[3].union.colDef()}
 		}
 	case 35:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:789
+		//line sql.y:790
 		{
 			sqlVAL.union.val = &AlterTableAddColumn{columnKeyword: true, IfNotExists: true, ColumnDef: sqlDollar[6].union.colDef()}
 		}
 	case 36:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:794
+		//line sql.y:795
 		{
 			sqlVAL.union.val = &AlterTableSetDefault{columnKeyword: sqlDollar[2].union.bool(), Column: Name(sqlDollar[3].str), Default: sqlDollar[4].union.expr()}
 		}
 	case 37:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:799
+		//line sql.y:800
 		{
 			sqlVAL.union.val = &AlterTableDropNotNull{columnKeyword: sqlDollar[2].union.bool(), Column: Name(sqlDollar[3].str)}
 		}
 	case 38:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:803
+		//line sql.y:804
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 39:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:806
+		//line sql.y:807
 		{
 			sqlVAL.union.val = &AlterTableDropColumn{columnKeyword: sqlDollar[2].union.bool(), IfExists: true, Column: Name(sqlDollar[5].str)}
 		}
 	case 40:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:811
+		//line sql.y:812
 		{
 			sqlVAL.union.val = &AlterTableDropColumn{
 				columnKeyword: sqlDollar[2].union.bool(),
@@ -5212,13 +5213,13 @@ sqldefault:
 		}
 	case 41:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:821
+		//line sql.y:822
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 42:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:824
+		//line sql.y:825
 		{
 			sqlVAL.union.val = &AlterTableAddConstraint{
 				ConstraintDef:      sqlDollar[2].union.constraintDef(),
@@ -5227,13 +5228,13 @@ sqldefault:
 		}
 	case 43:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:831
+		//line sql.y:832
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 44:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:834
+		//line sql.y:835
 		{
 			sqlVAL.union.val = &AlterTableValidateConstraint{
 				Constraint: Name(sqlDollar[3].str),
@@ -5241,7 +5242,7 @@ sqldefault:
 		}
 	case 45:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:841
+		//line sql.y:842
 		{
 			sqlVAL.union.val = &AlterTableDropConstraint{
 				IfExists:     true,
@@ -5251,7 +5252,7 @@ sqldefault:
 		}
 	case 46:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:850
+		//line sql.y:851
 		{
 			sqlVAL.union.val = &AlterTableDropConstraint{
 				IfExists:     false,
@@ -5261,107 +5262,107 @@ sqldefault:
 		}
 	case 47:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:860
+		//line sql.y:861
 		{
 			sqlVAL.union.val = sqlDollar[3].union.expr()
 		}
 	case 48:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:864
+		//line sql.y:865
 		{
 			sqlVAL.union.val = nil
 		}
 	case 49:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:870
+		//line sql.y:871
 		{
 			sqlVAL.union.val = DropCascade
 		}
 	case 50:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:874
+		//line sql.y:875
 		{
 			sqlVAL.union.val = DropRestrict
 		}
 	case 51:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:878
+		//line sql.y:879
 		{
 			sqlVAL.union.val = DropDefault
 		}
 	case 52:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:884
+		//line sql.y:885
 		{
 			sqlVAL.union.val = ValidationSkip
 		}
 	case 53:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:888
+		//line sql.y:889
 		{
 			sqlVAL.union.val = ValidationDefault
 		}
 	case 54:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:893
+		//line sql.y:894
 		{
-			unimplementedWithIssue(2473)
+			return unimplementedWithIssue(sqllex, 2473)
 		}
 	case 55:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:894
+		//line sql.y:895
 		{
 		}
 	case 56:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:897
+		//line sql.y:898
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 57:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:898
+		//line sql.y:899
 		{
 		}
 	case 58:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:902
+		//line sql.y:903
 		{
 			sqlVAL.union.val = &CopyFrom{Table: sqlDollar[2].union.normalizableTableName(), Stdin: true}
 		}
 	case 59:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:906
+		//line sql.y:907
 		{
 			sqlVAL.union.val = &CopyFrom{Table: sqlDollar[2].union.normalizableTableName(), Stdin: true}
 		}
 	case 60:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:910
+		//line sql.y:911
 		{
 			sqlVAL.union.val = &CopyFrom{Table: sqlDollar[2].union.normalizableTableName(), Columns: sqlDollar[4].union.unresolvedNames(), Stdin: true}
 		}
 	case 66:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:925
+		//line sql.y:926
 		{
 			sqlVAL.union.val = &Delete{Table: sqlDollar[4].union.tblExpr(), Where: newWhere(astWhere, sqlDollar[5].union.expr()), Returning: sqlDollar[6].union.retExprs()}
 		}
 	case 67:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:932
+		//line sql.y:933
 		{
 			sqlVAL.union.val = &DropDatabase{Name: Name(sqlDollar[3].str), IfExists: false}
 		}
 	case 68:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:936
+		//line sql.y:937
 		{
 			sqlVAL.union.val = &DropDatabase{Name: Name(sqlDollar[5].str), IfExists: true}
 		}
 	case 69:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:940
+		//line sql.y:941
 		{
 			sqlVAL.union.val = &DropIndex{
 				IndexList:    sqlDollar[3].union.tableWithIdxList(),
@@ -5371,7 +5372,7 @@ sqldefault:
 		}
 	case 70:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:948
+		//line sql.y:949
 		{
 			sqlVAL.union.val = &DropIndex{
 				IndexList:    sqlDollar[5].union.tableWithIdxList(),
@@ -5381,102 +5382,102 @@ sqldefault:
 		}
 	case 71:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:956
+		//line sql.y:957
 		{
 			sqlVAL.union.val = &DropTable{Names: sqlDollar[3].union.tableNameReferences(), IfExists: false, DropBehavior: sqlDollar[4].union.dropBehavior()}
 		}
 	case 72:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:960
+		//line sql.y:961
 		{
 			sqlVAL.union.val = &DropTable{Names: sqlDollar[5].union.tableNameReferences(), IfExists: true, DropBehavior: sqlDollar[6].union.dropBehavior()}
 		}
 	case 73:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:964
+		//line sql.y:965
 		{
 			sqlVAL.union.val = &DropView{Names: sqlDollar[3].union.tableNameReferences(), IfExists: false, DropBehavior: sqlDollar[4].union.dropBehavior()}
 		}
 	case 74:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:968
+		//line sql.y:969
 		{
 			sqlVAL.union.val = &DropView{Names: sqlDollar[5].union.tableNameReferences(), IfExists: true, DropBehavior: sqlDollar[6].union.dropBehavior()}
 		}
 	case 75:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:974
+		//line sql.y:975
 		{
 			sqlVAL.union.val = TableNameReferences{sqlDollar[1].union.unresolvedName()}
 		}
 	case 76:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:978
+		//line sql.y:979
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.tableNameReferences(), sqlDollar[3].union.unresolvedName())
 		}
 	case 77:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:984
+		//line sql.y:985
 		{
 			sqlVAL.union.val = UnresolvedName{Name(sqlDollar[1].str)}
 		}
 	case 78:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:988
+		//line sql.y:989
 		{
 			sqlVAL.union.val = append(UnresolvedName{Name(sqlDollar[1].str)}, sqlDollar[2].union.unresolvedName()...)
 		}
 	case 79:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:994
+		//line sql.y:995
 		{
 			sqlVAL.union.val = UnresolvedName{Name(sqlDollar[2].str)}
 		}
 	case 80:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:998
+		//line sql.y:999
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.unresolvedName(), Name(sqlDollar[3].str))
 		}
 	case 81:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1005
+		//line sql.y:1006
 		{
 			sqlVAL.union.val = &Explain{Statement: sqlDollar[2].union.stmt()}
 		}
 	case 82:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1009
+		//line sql.y:1010
 		{
 			sqlVAL.union.val = &Explain{Options: sqlDollar[3].union.strs(), Statement: sqlDollar[5].union.stmt()}
 		}
 	case 83:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1015
+		//line sql.y:1016
 		{
 			sqlVAL.union.val = sqlDollar[1].union.slct()
 		}
 	case 90:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1024
+		//line sql.y:1025
 		{ /* SKIP DOC */
 		}
 	case 91:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1028
+		//line sql.y:1029
 		{
 			sqlVAL.union.val = []string{sqlDollar[1].str}
 		}
 	case 92:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1032
+		//line sql.y:1033
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.strs(), sqlDollar[3].str)
 		}
 	case 94:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1042
+		//line sql.y:1043
 		{
 			sqlVAL.union.val = &Prepare{
 				Name:      Name(sqlDollar[2].str),
@@ -5486,25 +5487,25 @@ sqldefault:
 		}
 	case 95:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1052
+		//line sql.y:1053
 		{
 			sqlVAL.union.val = sqlDollar[2].union.colTypes()
 		}
 	case 96:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1056
+		//line sql.y:1057
 		{
 			sqlVAL.union.val = []ColumnType(nil)
 		}
 	case 97:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1062
+		//line sql.y:1063
 		{
 			sqlVAL.union.val = sqlDollar[1].union.slct()
 		}
 	case 101:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1072
+		//line sql.y:1073
 		{
 			sqlVAL.union.val = &Execute{
 				Name:   Name(sqlDollar[2].str),
@@ -5513,19 +5514,19 @@ sqldefault:
 		}
 	case 102:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1083
+		//line sql.y:1084
 		{
 			sqlVAL.union.val = sqlDollar[2].union.exprs()
 		}
 	case 103:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1087
+		//line sql.y:1088
 		{
 			sqlVAL.union.val = Exprs(nil)
 		}
 	case 104:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1094
+		//line sql.y:1095
 		{
 			sqlVAL.union.val = &Deallocate{
 				Name: Name(sqlDollar[2].str),
@@ -5533,7 +5534,7 @@ sqldefault:
 		}
 	case 105:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1100
+		//line sql.y:1101
 		{
 			sqlVAL.union.val = &Deallocate{
 				Name: Name(sqlDollar[3].str),
@@ -5541,335 +5542,335 @@ sqldefault:
 		}
 	case 106:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1106
+		//line sql.y:1107
 		{
 			sqlVAL.union.val = &Deallocate{}
 		}
 	case 107:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1110
+		//line sql.y:1111
 		{
 			sqlVAL.union.val = &Deallocate{}
 		}
 	case 108:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1117
+		//line sql.y:1118
 		{
 			sqlVAL.union.val = &Grant{Privileges: sqlDollar[2].union.privilegeList(), Grantees: sqlDollar[6].union.nameList(), Targets: sqlDollar[4].union.targetList()}
 		}
 	case 109:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1124
+		//line sql.y:1125
 		{
 			sqlVAL.union.val = &Revoke{Privileges: sqlDollar[2].union.privilegeList(), Grantees: sqlDollar[6].union.nameList(), Targets: sqlDollar[4].union.targetList()}
 		}
 	case 110:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1131
+		//line sql.y:1132
 		{
 			sqlVAL.union.val = TargetList{Tables: sqlDollar[1].union.tablePatterns()}
 		}
 	case 111:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1135
+		//line sql.y:1136
 		{
 			sqlVAL.union.val = TargetList{Tables: sqlDollar[2].union.tablePatterns()}
 		}
 	case 112:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1139
+		//line sql.y:1140
 		{
 			sqlVAL.union.val = TargetList{Databases: sqlDollar[2].union.nameList()}
 		}
 	case 113:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1146
+		//line sql.y:1147
 		{
 			sqlVAL.union.val = privilege.List{privilege.ALL}
 		}
 	case 114:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1149
+		//line sql.y:1150
 		{
 		}
 	case 115:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1153
+		//line sql.y:1154
 		{
 			sqlVAL.union.val = privilege.List{sqlDollar[1].union.privilegeType()}
 		}
 	case 116:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1157
+		//line sql.y:1158
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.privilegeList(), sqlDollar[3].union.privilegeType())
 		}
 	case 117:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1164
+		//line sql.y:1165
 		{
 			sqlVAL.union.val = privilege.CREATE
 		}
 	case 118:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1168
+		//line sql.y:1169
 		{
 			sqlVAL.union.val = privilege.DROP
 		}
 	case 119:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1172
+		//line sql.y:1173
 		{
 			sqlVAL.union.val = privilege.GRANT
 		}
 	case 120:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1176
+		//line sql.y:1177
 		{
 			sqlVAL.union.val = privilege.SELECT
 		}
 	case 121:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1180
+		//line sql.y:1181
 		{
 			sqlVAL.union.val = privilege.INSERT
 		}
 	case 122:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1184
+		//line sql.y:1185
 		{
 			sqlVAL.union.val = privilege.DELETE
 		}
 	case 123:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1188
+		//line sql.y:1189
 		{
 			sqlVAL.union.val = privilege.UPDATE
 		}
 	case 124:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1196
+		//line sql.y:1197
 		{
 			sqlVAL.union.val = NameList{Name(sqlDollar[1].str)}
 		}
 	case 125:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1200
+		//line sql.y:1201
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.nameList(), Name(sqlDollar[3].str))
 		}
 	case 126:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1208
+		//line sql.y:1209
 		{
 			sqlVAL.union.val = sqlDollar[2].union.stmt()
 		}
 	case 127:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1212
+		//line sql.y:1213
 		{
 			sqlVAL.union.val = sqlDollar[3].union.stmt()
 		}
 	case 128:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1216
+		//line sql.y:1217
 		{
 			sqlVAL.union.val = &SetDefaultIsolation{Isolation: sqlDollar[6].union.isoLevel()}
 		}
 	case 129:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1220
+		//line sql.y:1221
 		{
 			sqlVAL.union.val = sqlDollar[3].union.stmt()
 		}
 	case 130:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1223
+		//line sql.y:1224
 		{ /* SKIP DOC */
 		}
 	case 131:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1229
+		//line sql.y:1230
 		{
 			sqlVAL.union.val = &Set{Values: sqlDollar[4].union.exprs()}
 		}
 	case 132:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1235
+		//line sql.y:1236
 		{
 			sqlVAL.union.val = sqlDollar[2].union.stmt()
 		}
 	case 134:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1242
+		//line sql.y:1243
 		{
 			sqlVAL.union.val = &SetTransaction{Isolation: sqlDollar[1].union.isoLevel(), UserPriority: UnspecifiedUserPriority}
 		}
 	case 135:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1246
+		//line sql.y:1247
 		{
 			sqlVAL.union.val = &SetTransaction{Isolation: UnspecifiedIsolation, UserPriority: sqlDollar[1].union.userPriority()}
 		}
 	case 136:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1250
+		//line sql.y:1251
 		{
 			sqlVAL.union.val = &SetTransaction{Isolation: sqlDollar[1].union.isoLevel(), UserPriority: sqlDollar[3].union.userPriority()}
 		}
 	case 137:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1254
+		//line sql.y:1255
 		{
 			sqlVAL.union.val = &SetTransaction{Isolation: sqlDollar[3].union.isoLevel(), UserPriority: sqlDollar[1].union.userPriority()}
 		}
 	case 138:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1261
+		//line sql.y:1262
 		{
 			sqlVAL.union.val = sqlDollar[2].union.userPriority()
 		}
 	case 139:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1267
+		//line sql.y:1268
 		{
 			sqlVAL.union.val = &Set{Name: sqlDollar[1].union.unresolvedName(), Values: sqlDollar[3].union.exprs()}
 		}
 	case 140:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1271
+		//line sql.y:1272
 		{
 			sqlVAL.union.val = &Set{Name: sqlDollar[1].union.unresolvedName(), Values: sqlDollar[3].union.exprs()}
 		}
 	case 141:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1275
+		//line sql.y:1276
 		{
 			sqlVAL.union.val = &Set{Name: sqlDollar[1].union.unresolvedName()}
 		}
 	case 142:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1279
+		//line sql.y:1280
 		{
 			sqlVAL.union.val = &Set{Name: sqlDollar[1].union.unresolvedName()}
 		}
 	case 144:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1286
+		//line sql.y:1287
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 145:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1289
+		//line sql.y:1290
 		{
 			sqlVAL.union.val = &SetTimeZone{Value: sqlDollar[3].union.expr()}
 		}
 	case 146:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1292
+		//line sql.y:1293
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 148:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1299
+		//line sql.y:1300
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr()}
 		}
 	case 149:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1303
+		//line sql.y:1304
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.exprs(), sqlDollar[3].union.expr())
 		}
 	case 152:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1311
+		//line sql.y:1312
 		{
 			sqlVAL.union.val = Placeholder{Name: sqlDollar[1].str}
 		}
 	case 153:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1317
+		//line sql.y:1318
 		{
 			sqlVAL.union.val = SnapshotIsolation
 		}
 	case 154:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1321
+		//line sql.y:1322
 		{
 			sqlVAL.union.val = SnapshotIsolation
 		}
 	case 155:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1325
+		//line sql.y:1326
 		{
 			sqlVAL.union.val = SnapshotIsolation
 		}
 	case 156:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1329
+		//line sql.y:1330
 		{
 			sqlVAL.union.val = SerializableIsolation
 		}
 	case 157:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1333
+		//line sql.y:1334
 		{
 			sqlVAL.union.val = SerializableIsolation
 		}
 	case 158:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1339
+		//line sql.y:1340
 		{
 			sqlVAL.union.val = Low
 		}
 	case 159:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1343
+		//line sql.y:1344
 		{
 			sqlVAL.union.val = Normal
 		}
 	case 160:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1347
+		//line sql.y:1348
 		{
 			sqlVAL.union.val = High
 		}
 	case 161:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1353
+		//line sql.y:1354
 		{
 			sqlVAL.union.val = MakeDBool(true)
 		}
 	case 162:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1357
+		//line sql.y:1358
 		{
 			sqlVAL.union.val = MakeDBool(false)
 		}
 	case 163:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1361
+		//line sql.y:1362
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
 	case 165:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1376
+		//line sql.y:1377
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
 	case 166:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1380
+		//line sql.y:1381
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
 	case 167:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1384
+		//line sql.y:1385
 		{
 			d, err := ParseDInterval(sqlDollar[2].str)
 			if err != nil {
@@ -5880,253 +5881,253 @@ sqldefault:
 		}
 	case 169:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1394
+		//line sql.y:1395
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
 	case 170:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1398
+		//line sql.y:1399
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
 	case 171:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1403
+		//line sql.y:1404
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 172:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1404
+		//line sql.y:1405
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 173:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1405
+		//line sql.y:1406
 		{
 		}
 	case 174:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1409
+		//line sql.y:1410
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
 	case 175:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1413
+		//line sql.y:1414
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
 	case 176:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1419
+		//line sql.y:1420
 		{
 			sqlVAL.union.val = &Show{Name: sqlDollar[2].str}
 		}
 	case 177:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1423
+		//line sql.y:1424
 		{
 			sqlVAL.union.val = &Show{Name: sqlDollar[2].str}
 		}
 	case 178:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1427
+		//line sql.y:1428
 		{
 			sqlVAL.union.val = &ShowColumns{Table: sqlDollar[4].union.normalizableTableName()}
 		}
 	case 179:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1431
+		//line sql.y:1432
 		{
 			sqlVAL.union.val = &ShowDatabases{}
 		}
 	case 180:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1435
+		//line sql.y:1436
 		{
 			sqlVAL.union.val = &ShowGrants{Targets: sqlDollar[3].union.targetListPtr(), Grantees: sqlDollar[4].union.nameList()}
 		}
 	case 181:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1439
+		//line sql.y:1440
 		{
 			sqlVAL.union.val = &ShowIndex{Table: sqlDollar[4].union.normalizableTableName()}
 		}
 	case 182:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1443
+		//line sql.y:1444
 		{
 			sqlVAL.union.val = &ShowIndex{Table: sqlDollar[4].union.normalizableTableName()}
 		}
 	case 183:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1447
+		//line sql.y:1448
 		{
 			sqlVAL.union.val = &ShowConstraints{Table: sqlDollar[4].union.normalizableTableName()}
 		}
 	case 184:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1451
+		//line sql.y:1452
 		{
 			sqlVAL.union.val = &ShowConstraints{Table: sqlDollar[4].union.normalizableTableName()}
 		}
 	case 185:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1455
+		//line sql.y:1456
 		{
 			sqlVAL.union.val = &ShowIndex{Table: sqlDollar[4].union.normalizableTableName()}
 		}
 	case 186:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1459
+		//line sql.y:1460
 		{
 			sqlVAL.union.val = &ShowTables{Database: Name(sqlDollar[4].str)}
 		}
 	case 187:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1463
+		//line sql.y:1464
 		{
 			sqlVAL.union.val = &ShowTables{}
 		}
 	case 188:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1467
+		//line sql.y:1468
 		{
 			sqlVAL.union.val = &Show{Name: "TIME ZONE"}
 		}
 	case 189:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1471
+		//line sql.y:1472
 		{
 			sqlVAL.union.val = &Show{Name: "TRANSACTION ISOLATION LEVEL"}
 		}
 	case 190:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1475
+		//line sql.y:1476
 		{
 			sqlVAL.union.val = &Show{Name: "TRANSACTION PRIORITY"}
 		}
 	case 191:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1479
+		//line sql.y:1480
 		{
 			sqlVAL.union.val = Statement(nil)
 		}
 	case 192:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1483
+		//line sql.y:1484
 		{
 			sqlVAL.union.val = &ShowCreateTable{Table: sqlDollar[4].union.normalizableTableName()}
 		}
 	case 193:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1487
+		//line sql.y:1488
 		{
 			sqlVAL.union.val = &ShowCreateView{View: sqlDollar[4].union.normalizableTableName()}
 		}
 	case 194:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1493
+		//line sql.y:1494
 		{
 			sqlVAL.union.val = &Help{Name: Name(sqlDollar[2].str)}
 		}
 	case 195:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1499
+		//line sql.y:1500
 		{
 			tmp := sqlDollar[2].union.targetList()
 			sqlVAL.union.val = &tmp
 		}
 	case 196:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1504
+		//line sql.y:1505
 		{
 			sqlVAL.union.val = (*TargetList)(nil)
 		}
 	case 197:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1510
+		//line sql.y:1511
 		{
 			sqlVAL.union.val = sqlDollar[2].union.nameList()
 		}
 	case 198:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1514
+		//line sql.y:1515
 		{
 			sqlVAL.union.val = NameList(nil)
 		}
 	case 199:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1520
+		//line sql.y:1521
 		{
 			sqlVAL.union.val = &Split{Table: sqlDollar[3].union.normalizableTableName(), Exprs: sqlDollar[7].union.exprs()}
 		}
 	case 200:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1524
+		//line sql.y:1525
 		{
 			sqlVAL.union.val = &Split{Index: sqlDollar[3].union.tableWithIdx(), Exprs: sqlDollar[7].union.exprs()}
 		}
 	case 201:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:1531
+		//line sql.y:1532
 		{
 			sqlVAL.union.val = &CreateTable{Table: sqlDollar[3].union.normalizableTableName(), IfNotExists: false, Interleave: sqlDollar[7].union.interleave(), Defs: sqlDollar[5].union.tblDefs(), AsSource: nil, AsColumnNames: nil}
 		}
 	case 202:
 		sqlDollar = sqlS[sqlpt-10 : sqlpt+1]
-		//line sql.y:1535
+		//line sql.y:1536
 		{
 			sqlVAL.union.val = &CreateTable{Table: sqlDollar[6].union.normalizableTableName(), IfNotExists: true, Interleave: sqlDollar[10].union.interleave(), Defs: sqlDollar[8].union.tblDefs(), AsSource: nil, AsColumnNames: nil}
 		}
 	case 203:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1541
+		//line sql.y:1542
 		{
 			sqlVAL.union.val = &CreateTable{Table: sqlDollar[3].union.normalizableTableName(), IfNotExists: false, Interleave: nil, Defs: nil, AsSource: sqlDollar[6].union.slct(), AsColumnNames: sqlDollar[4].union.nameList()}
 		}
 	case 204:
 		sqlDollar = sqlS[sqlpt-9 : sqlpt+1]
-		//line sql.y:1545
+		//line sql.y:1546
 		{
 			sqlVAL.union.val = &CreateTable{Table: sqlDollar[6].union.normalizableTableName(), IfNotExists: true, Interleave: nil, Defs: nil, AsSource: sqlDollar[9].union.slct(), AsColumnNames: sqlDollar[7].union.nameList()}
 		}
 	case 206:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1552
+		//line sql.y:1553
 		{
 			sqlVAL.union.val = TableDefs(nil)
 		}
 	case 207:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1558
+		//line sql.y:1559
 		{
 			sqlVAL.union.val = TableDefs{sqlDollar[1].union.tblDef()}
 		}
 	case 208:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1562
+		//line sql.y:1563
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.tblDefs(), sqlDollar[3].union.tblDef())
 		}
 	case 209:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1568
+		//line sql.y:1569
 		{
 			sqlVAL.union.val = sqlDollar[1].union.colDef()
 		}
 	case 212:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1574
+		//line sql.y:1575
 		{
 			sqlVAL.union.val = sqlDollar[1].union.constraintDef()
 		}
 	case 213:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1580
+		//line sql.y:1581
 		{
 			sqlVAL.union.val = &InterleaveDef{
 				Parent:       NormalizableTableName{UnresolvedName{Name(sqlDollar[4].str)}},
@@ -6136,33 +6137,33 @@ sqldefault:
 		}
 	case 214:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1588
+		//line sql.y:1589
 		{
 			sqlVAL.union.val = (*InterleaveDef)(nil)
 		}
 	case 215:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1595
+		//line sql.y:1596
 		{
 			/* SKIP DOC */
 			sqlVAL.union.val = DropCascade
 		}
 	case 216:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1599
+		//line sql.y:1600
 		{
 			/* SKIP DOC */
 			sqlVAL.union.val = DropRestrict
 		}
 	case 217:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1603
+		//line sql.y:1604
 		{
 			sqlVAL.union.val = DropDefault
 		}
 	case 218:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1609
+		//line sql.y:1610
 		{
 			tableDef, err := newColumnTableDef(Name(sqlDollar[1].str), sqlDollar[2].union.colType(), sqlDollar[3].union.colQuals())
 			if err != nil {
@@ -6173,91 +6174,91 @@ sqldefault:
 		}
 	case 219:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1620
+		//line sql.y:1621
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.colQuals(), sqlDollar[2].union.colQual())
 		}
 	case 220:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1624
+		//line sql.y:1625
 		{
 			sqlVAL.union.val = []NamedColumnQualification(nil)
 		}
 	case 221:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1630
+		//line sql.y:1631
 		{
 			sqlVAL.union.val = NamedColumnQualification{Name: Name(sqlDollar[2].str), Qualification: sqlDollar[3].union.colQualElem()}
 		}
 	case 222:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1634
+		//line sql.y:1635
 		{
 			sqlVAL.union.val = NamedColumnQualification{Qualification: sqlDollar[1].union.colQualElem()}
 		}
 	case 223:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1637
+		//line sql.y:1638
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 224:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1639
+		//line sql.y:1640
 		{
 			sqlVAL.union.val = NamedColumnQualification{Qualification: &ColumnFamilyConstraint{Family: Name(sqlDollar[2].str)}}
 		}
 	case 225:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1643
+		//line sql.y:1644
 		{
 			sqlVAL.union.val = NamedColumnQualification{Qualification: &ColumnFamilyConstraint{Family: Name(sqlDollar[3].str), Create: true}}
 		}
 	case 226:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1647
+		//line sql.y:1648
 		{
 			sqlVAL.union.val = NamedColumnQualification{Qualification: &ColumnFamilyConstraint{Family: Name(sqlDollar[6].str), Create: true, IfNotExists: true}}
 		}
 	case 227:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1665
+		//line sql.y:1666
 		{
 			sqlVAL.union.val = NotNullConstraint{}
 		}
 	case 228:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1669
+		//line sql.y:1670
 		{
 			sqlVAL.union.val = NullConstraint{}
 		}
 	case 229:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1673
+		//line sql.y:1674
 		{
 			sqlVAL.union.val = UniqueConstraint{}
 		}
 	case 230:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1677
+		//line sql.y:1678
 		{
 			sqlVAL.union.val = PrimaryKeyConstraint{}
 		}
 	case 231:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1681
+		//line sql.y:1682
 		{
 			sqlVAL.union.val = &ColumnCheckConstraint{Expr: sqlDollar[3].union.expr()}
 		}
 	case 232:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1685
+		//line sql.y:1686
 		{
 			sqlVAL.union.val = &ColumnDefault{Expr: sqlDollar[2].union.expr()}
 		}
 	case 233:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1689
+		//line sql.y:1690
 		{
 			sqlVAL.union.val = &ColumnFKConstraint{
 				Table: sqlDollar[2].union.normalizableTableName(),
@@ -6266,7 +6267,7 @@ sqldefault:
 		}
 	case 234:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:1698
+		//line sql.y:1699
 		{
 			sqlVAL.union.val = &IndexTableDef{
 				Name:       Name(sqlDollar[2].str),
@@ -6277,7 +6278,7 @@ sqldefault:
 		}
 	case 235:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1707
+		//line sql.y:1708
 		{
 			sqlVAL.union.val = &UniqueConstraintTableDef{
 				IndexTableDef: IndexTableDef{
@@ -6290,7 +6291,7 @@ sqldefault:
 		}
 	case 236:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1720
+		//line sql.y:1721
 		{
 			sqlVAL.union.val = &FamilyTableDef{
 				Name:    Name(sqlDollar[2].str),
@@ -6299,20 +6300,20 @@ sqldefault:
 		}
 	case 237:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1732
+		//line sql.y:1733
 		{
 			sqlVAL.union.val = sqlDollar[3].union.constraintDef()
 			sqlVAL.union.val.(ConstraintTableDef).setName(Name(sqlDollar[2].str))
 		}
 	case 238:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1737
+		//line sql.y:1738
 		{
 			sqlVAL.union.val = sqlDollar[1].union.constraintDef()
 		}
 	case 239:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1743
+		//line sql.y:1744
 		{
 			sqlVAL.union.val = &CheckConstraintTableDef{
 				Expr: sqlDollar[3].union.expr(),
@@ -6320,7 +6321,7 @@ sqldefault:
 		}
 	case 240:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1749
+		//line sql.y:1750
 		{
 			sqlVAL.union.val = &UniqueConstraintTableDef{
 				IndexTableDef: IndexTableDef{
@@ -6332,7 +6333,7 @@ sqldefault:
 		}
 	case 241:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1759
+		//line sql.y:1760
 		{
 			sqlVAL.union.val = &UniqueConstraintTableDef{
 				IndexTableDef: IndexTableDef{
@@ -6343,7 +6344,7 @@ sqldefault:
 		}
 	case 242:
 		sqlDollar = sqlS[sqlpt-10 : sqlpt+1]
-		//line sql.y:1769
+		//line sql.y:1770
 		{
 			sqlVAL.union.val = &ForeignKeyConstraintTableDef{
 				Table:    sqlDollar[7].union.normalizableTableName(),
@@ -6353,149 +6354,149 @@ sqldefault:
 		}
 	case 245:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1792
+		//line sql.y:1793
 		{
 			sqlVAL.union.val = sqlDollar[3].union.nameList()
 		}
 	case 246:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1796
+		//line sql.y:1797
 		{
 			sqlVAL.union.val = NameList(nil)
 		}
 	case 247:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1802
+		//line sql.y:1803
 		{
 			sqlVAL.union.val = sqlDollar[2].union.nameList()
 		}
 	case 248:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1806
+		//line sql.y:1807
 		{
 			sqlVAL.union.val = NameList(nil)
 		}
 	case 249:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1811
+		//line sql.y:1812
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 250:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1812
+		//line sql.y:1813
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 251:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1813
+		//line sql.y:1814
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 252:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1814
+		//line sql.y:1815
 		{
 		}
 	case 253:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1821
+		//line sql.y:1822
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 254:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1822
+		//line sql.y:1823
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 255:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1823
+		//line sql.y:1824
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 256:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1824
+		//line sql.y:1825
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 257:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1825
+		//line sql.y:1826
 		{
 		}
 	case 258:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1828
+		//line sql.y:1829
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 259:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1831
+		//line sql.y:1832
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 260:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1834
+		//line sql.y:1835
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 261:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1835
+		//line sql.y:1836
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 262:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1836
+		//line sql.y:1837
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 263:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1837
+		//line sql.y:1838
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 264:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1838
+		//line sql.y:1839
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 265:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1842
+		//line sql.y:1843
 		{
 			sqlVAL.union.val = sqlDollar[1].union.numVal()
 		}
 	case 266:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1846
+		//line sql.y:1847
 		{
 			sqlVAL.union.val = &NumVal{Value: constant.UnaryOp(token.SUB, sqlDollar[2].union.numVal().Value, 0)}
 		}
 	case 267:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1850
+		//line sql.y:1851
 		{
 			sqlVAL.union.val = sqlDollar[1].union.numVal()
 		}
 	case 268:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1857
+		//line sql.y:1858
 		{
 			sqlVAL.union.val = &Truncate{Tables: sqlDollar[3].union.tableNameReferences(), DropBehavior: sqlDollar[4].union.dropBehavior()}
 		}
 	case 269:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1864
+		//line sql.y:1865
 		{
 			sqlVAL.union.val = &CreateView{
 				Name:        sqlDollar[3].union.normalizableTableName(),
@@ -6505,7 +6506,7 @@ sqldefault:
 		}
 	case 270:
 		sqlDollar = sqlS[sqlpt-11 : sqlpt+1]
-		//line sql.y:1877
+		//line sql.y:1878
 		{
 			sqlVAL.union.val = &CreateIndex{
 				Name:       Name(sqlDollar[4].str),
@@ -6518,7 +6519,7 @@ sqldefault:
 		}
 	case 271:
 		sqlDollar = sqlS[sqlpt-14 : sqlpt+1]
-		//line sql.y:1888
+		//line sql.y:1889
 		{
 			sqlVAL.union.val = &CreateIndex{
 				Name:        Name(sqlDollar[7].str),
@@ -6532,202 +6533,202 @@ sqldefault:
 		}
 	case 272:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1902
+		//line sql.y:1903
 		{
 			sqlVAL.union.val = true
 		}
 	case 273:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1906
+		//line sql.y:1907
 		{
 			sqlVAL.union.val = false
 		}
 	case 274:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1912
+		//line sql.y:1913
 		{
 			sqlVAL.union.val = IndexElemList{sqlDollar[1].union.idxElem()}
 		}
 	case 275:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1916
+		//line sql.y:1917
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.idxElems(), sqlDollar[3].union.idxElem())
 		}
 	case 276:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1925
+		//line sql.y:1926
 		{
 			sqlVAL.union.val = IndexElem{Column: Name(sqlDollar[1].str), Direction: sqlDollar[3].union.dir()}
 		}
 	case 277:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1928
+		//line sql.y:1929
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 278:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1929
+		//line sql.y:1930
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 279:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1932
+		//line sql.y:1933
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 280:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1933
+		//line sql.y:1934
 		{
 		}
 	case 281:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1937
+		//line sql.y:1938
 		{
 			sqlVAL.union.val = Ascending
 		}
 	case 282:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1941
+		//line sql.y:1942
 		{
 			sqlVAL.union.val = Descending
 		}
 	case 283:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1945
+		//line sql.y:1946
 		{
 			sqlVAL.union.val = DefaultDirection
 		}
 	case 284:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1952
+		//line sql.y:1953
 		{
 			sqlVAL.union.val = &RenameDatabase{Name: Name(sqlDollar[3].str), NewName: Name(sqlDollar[6].str)}
 		}
 	case 285:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1956
+		//line sql.y:1957
 		{
 			sqlVAL.union.val = &RenameTable{Name: sqlDollar[3].union.normalizableTableName(), NewName: sqlDollar[6].union.normalizableTableName(), IfExists: false, IsView: false}
 		}
 	case 286:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1960
+		//line sql.y:1961
 		{
 			sqlVAL.union.val = &RenameTable{Name: sqlDollar[5].union.normalizableTableName(), NewName: sqlDollar[8].union.normalizableTableName(), IfExists: true, IsView: false}
 		}
 	case 287:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1964
+		//line sql.y:1965
 		{
 			sqlVAL.union.val = &RenameTable{Name: sqlDollar[3].union.normalizableTableName(), NewName: sqlDollar[6].union.normalizableTableName(), IfExists: false, IsView: true}
 		}
 	case 288:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1968
+		//line sql.y:1969
 		{
 			sqlVAL.union.val = &RenameTable{Name: sqlDollar[5].union.normalizableTableName(), NewName: sqlDollar[8].union.normalizableTableName(), IfExists: true, IsView: true}
 		}
 	case 289:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1972
+		//line sql.y:1973
 		{
 			sqlVAL.union.val = &RenameIndex{Index: sqlDollar[3].union.tableWithIdx(), NewName: Name(sqlDollar[6].str), IfExists: false}
 		}
 	case 290:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1976
+		//line sql.y:1977
 		{
 			sqlVAL.union.val = &RenameIndex{Index: sqlDollar[5].union.tableWithIdx(), NewName: Name(sqlDollar[8].str), IfExists: true}
 		}
 	case 291:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1980
+		//line sql.y:1981
 		{
 			sqlVAL.union.val = &RenameColumn{Table: sqlDollar[3].union.normalizableTableName(), Name: Name(sqlDollar[6].str), NewName: Name(sqlDollar[8].str), IfExists: false}
 		}
 	case 292:
 		sqlDollar = sqlS[sqlpt-10 : sqlpt+1]
-		//line sql.y:1984
+		//line sql.y:1985
 		{
 			sqlVAL.union.val = &RenameColumn{Table: sqlDollar[5].union.normalizableTableName(), Name: Name(sqlDollar[8].str), NewName: Name(sqlDollar[10].str), IfExists: true}
 		}
 	case 293:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1988
+		//line sql.y:1989
 		{
 			sqlVAL.union.val = Statement(nil)
 		}
 	case 294:
 		sqlDollar = sqlS[sqlpt-10 : sqlpt+1]
-		//line sql.y:1992
+		//line sql.y:1993
 		{
 			sqlVAL.union.val = Statement(nil)
 		}
 	case 295:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1998
+		//line sql.y:1999
 		{
 			sqlVAL.union.val = true
 		}
 	case 296:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2002
+		//line sql.y:2003
 		{
 			sqlVAL.union.val = false
 		}
 	case 297:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2007
+		//line sql.y:2008
 		{
 		}
 	case 298:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2008
+		//line sql.y:2009
 		{
 		}
 	case 299:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2012
+		//line sql.y:2013
 		{
 			sqlVAL.union.val = &ReleaseSavepoint{Savepoint: sqlDollar[2].str}
 		}
 	case 300:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2018
+		//line sql.y:2019
 		{
 			sqlVAL.union.val = &Savepoint{Name: sqlDollar[2].str}
 		}
 	case 301:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2025
+		//line sql.y:2026
 		{
 			sqlVAL.union.val = sqlDollar[3].union.stmt()
 		}
 	case 302:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2029
+		//line sql.y:2030
 		{
 			sqlVAL.union.val = sqlDollar[3].union.stmt()
 		}
 	case 303:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2033
+		//line sql.y:2034
 		{
 			sqlVAL.union.val = &CommitTransaction{}
 		}
 	case 304:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2037
+		//line sql.y:2038
 		{
 			sqlVAL.union.val = &CommitTransaction{}
 		}
 	case 305:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2041
+		//line sql.y:2042
 		{
 			if sqlDollar[2].str != "" {
 				sqlVAL.union.val = &RollbackToSavepoint{Savepoint: sqlDollar[2].str}
@@ -6737,113 +6738,113 @@ sqldefault:
 		}
 	case 306:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2050
+		//line sql.y:2051
 		{
 		}
 	case 307:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2051
+		//line sql.y:2052
 		{
 		}
 	case 308:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2055
+		//line sql.y:2056
 		{
 			sqlVAL.str = ""
 		}
 	case 309:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2059
+		//line sql.y:2060
 		{
 			sqlVAL.str = sqlDollar[3].str
 		}
 	case 310:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2063
+		//line sql.y:2064
 		{
 			sqlVAL.str = sqlDollar[2].str
 		}
 	case 311:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2067
+		//line sql.y:2068
 		{
 			sqlVAL.str = ""
 		}
 	case 312:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2073
+		//line sql.y:2074
 		{
 			sqlVAL.str = sqlDollar[2].str
 		}
 	case 313:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2077
+		//line sql.y:2078
 		{
 			sqlVAL.str = sqlDollar[1].str
 		}
 	case 314:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2083
+		//line sql.y:2084
 		{
 			sqlVAL.union.val = &BeginTransaction{Isolation: sqlDollar[1].union.isoLevel(), UserPriority: UnspecifiedUserPriority}
 		}
 	case 315:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2087
+		//line sql.y:2088
 		{
 			sqlVAL.union.val = &BeginTransaction{Isolation: UnspecifiedIsolation, UserPriority: sqlDollar[1].union.userPriority()}
 		}
 	case 316:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2091
+		//line sql.y:2092
 		{
 			sqlVAL.union.val = &BeginTransaction{Isolation: sqlDollar[1].union.isoLevel(), UserPriority: sqlDollar[3].union.userPriority()}
 		}
 	case 317:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2095
+		//line sql.y:2096
 		{
 			sqlVAL.union.val = &BeginTransaction{Isolation: sqlDollar[3].union.isoLevel(), UserPriority: sqlDollar[1].union.userPriority()}
 		}
 	case 318:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2099
+		//line sql.y:2100
 		{
 			sqlVAL.union.val = &BeginTransaction{Isolation: UnspecifiedIsolation, UserPriority: UnspecifiedUserPriority}
 		}
 	case 319:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2105
+		//line sql.y:2106
 		{
 			sqlVAL.union.val = sqlDollar[3].union.isoLevel()
 		}
 	case 320:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2111
+		//line sql.y:2112
 		{
 			sqlVAL.union.val = &CreateDatabase{Name: Name(sqlDollar[3].str), Encoding: sqlDollar[4].union.strVal()}
 		}
 	case 321:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:2115
+		//line sql.y:2116
 		{
 			sqlVAL.union.val = &CreateDatabase{IfNotExists: true, Name: Name(sqlDollar[6].str), Encoding: sqlDollar[7].union.strVal()}
 		}
 	case 322:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2121
+		//line sql.y:2122
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[3].str}
 		}
 	case 323:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2124
+		//line sql.y:2125
 		{
 			sqlVAL.union.val = (*StrVal)(nil)
 		}
 	case 324:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2134
+		//line sql.y:2135
 		{
 			sqlVAL.union.val = sqlDollar[5].union.stmt()
 			sqlVAL.union.val.(*Insert).Table = sqlDollar[4].union.tblExpr()
@@ -6851,7 +6852,7 @@ sqldefault:
 		}
 	case 325:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2140
+		//line sql.y:2141
 		{
 			sqlVAL.union.val = sqlDollar[5].union.stmt()
 			sqlVAL.union.val.(*Insert).Table = sqlDollar[4].union.tblExpr()
@@ -6859,13 +6860,13 @@ sqldefault:
 		}
 	case 326:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:2145
+		//line sql.y:2146
 		{
-			unimplementedWithIssue(6637)
+			return unimplementedWithIssue(sqllex, 6637)
 		}
 	case 327:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2147
+		//line sql.y:2148
 		{
 			sqlVAL.union.val = sqlDollar[5].union.stmt()
 			sqlVAL.union.val.(*Insert).Table = sqlDollar[4].union.tblExpr()
@@ -6873,187 +6874,187 @@ sqldefault:
 		}
 	case 328:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:2152
+		//line sql.y:2153
 		{
-			unimplementedWithIssue(6637)
+			return unimplementedWithIssue(sqllex, 6637)
 		}
 	case 329:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2160
+		//line sql.y:2161
 		{
 			sqlVAL.union.val = sqlDollar[1].union.newNormalizableTableName()
 		}
 	case 330:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2164
+		//line sql.y:2165
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[1].union.newNormalizableTableName(), As: AliasClause{Alias: Name(sqlDollar[3].str)}}
 		}
 	case 331:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2170
+		//line sql.y:2171
 		{
 			sqlVAL.union.val = &Insert{Rows: sqlDollar[1].union.slct()}
 		}
 	case 332:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2174
+		//line sql.y:2175
 		{
 			sqlVAL.union.val = &Insert{Columns: sqlDollar[2].union.unresolvedNames(), Rows: sqlDollar[4].union.slct()}
 		}
 	case 333:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2178
+		//line sql.y:2179
 		{
 			sqlVAL.union.val = &Insert{Rows: &Select{}}
 		}
 	case 334:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:2184
+		//line sql.y:2185
 		{
 			sqlVAL.union.val = &OnConflict{Columns: sqlDollar[3].union.nameList(), Exprs: sqlDollar[7].union.updateExprs(), Where: newWhere(astWhere, sqlDollar[8].union.expr())}
 		}
 	case 335:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2188
+		//line sql.y:2189
 		{
 			sqlVAL.union.val = &OnConflict{Columns: sqlDollar[3].union.nameList(), DoNothing: true}
 		}
 	case 336:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2194
+		//line sql.y:2195
 		{
 			// TODO(dan): Support the where_clause.
 			sqlVAL.union.val = sqlDollar[2].union.nameList()
 		}
 	case 337:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2198
+		//line sql.y:2199
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 338:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2200
+		//line sql.y:2201
 		{
 			sqlVAL.union.val = NameList(nil)
 		}
 	case 339:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2206
+		//line sql.y:2207
 		{
 			sqlVAL.union.val = sqlDollar[2].union.selExprs()
 		}
 	case 340:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2210
+		//line sql.y:2211
 		{
 			sqlVAL.union.val = SelectExprs(nil)
 		}
 	case 341:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:2217
+		//line sql.y:2218
 		{
 			sqlVAL.union.val = &Update{Table: sqlDollar[3].union.tblExpr(), Exprs: sqlDollar[5].union.updateExprs(), Where: newWhere(astWhere, sqlDollar[7].union.expr()), Returning: sqlDollar[8].union.retExprs()}
 		}
 	case 342:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2223
+		//line sql.y:2224
 		{
-			unimplementedWithIssue(7841)
+			return unimplementedWithIssue(sqllex, 7841)
 		}
 	case 343:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2224
+		//line sql.y:2225
 		{
 		}
 	case 344:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2228
+		//line sql.y:2229
 		{
 			sqlVAL.union.val = UpdateExprs{sqlDollar[1].union.updateExpr()}
 		}
 	case 345:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2232
+		//line sql.y:2233
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.updateExprs(), sqlDollar[3].union.updateExpr())
 		}
 	case 348:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2242
+		//line sql.y:2243
 		{
 			sqlVAL.union.val = &UpdateExpr{Names: UnresolvedNames{sqlDollar[1].union.unresolvedName()}, Expr: sqlDollar[3].union.expr()}
 		}
 	case 349:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2254
+		//line sql.y:2255
 		{
 			sqlVAL.union.val = &UpdateExpr{Tuple: true, Names: sqlDollar[2].union.unresolvedNames(), Expr: &Tuple{Exprs: sqlDollar[5].union.exprs()}}
 		}
 	case 350:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2258
+		//line sql.y:2259
 		{
 			sqlVAL.union.val = &UpdateExpr{Tuple: true, Names: sqlDollar[2].union.unresolvedNames(), Expr: &Subquery{Select: sqlDollar[5].union.selectStmt()}}
 		}
 	case 352:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2302
+		//line sql.y:2303
 		{
 			sqlVAL.union.val = &Select{Select: sqlDollar[1].union.selectStmt()}
 		}
 	case 353:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2308
+		//line sql.y:2309
 		{
 			sqlVAL.union.val = &ParenSelect{Select: sqlDollar[2].union.slct()}
 		}
 	case 354:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2312
+		//line sql.y:2313
 		{
 			sqlVAL.union.val = &ParenSelect{Select: &Select{Select: sqlDollar[2].union.selectStmt()}}
 		}
 	case 355:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2327
+		//line sql.y:2328
 		{
 			sqlVAL.union.val = &Select{Select: sqlDollar[1].union.selectStmt()}
 		}
 	case 356:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2331
+		//line sql.y:2332
 		{
 			sqlVAL.union.val = &Select{Select: sqlDollar[1].union.selectStmt(), OrderBy: sqlDollar[2].union.orderBy()}
 		}
 	case 357:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2335
+		//line sql.y:2336
 		{
 			sqlVAL.union.val = &Select{Select: sqlDollar[1].union.selectStmt(), OrderBy: sqlDollar[2].union.orderBy(), Limit: sqlDollar[3].union.limit()}
 		}
 	case 358:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2339
+		//line sql.y:2340
 		{
 			sqlVAL.union.val = &Select{Select: sqlDollar[2].union.selectStmt()}
 		}
 	case 359:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2343
+		//line sql.y:2344
 		{
 			sqlVAL.union.val = &Select{Select: sqlDollar[2].union.selectStmt(), OrderBy: sqlDollar[3].union.orderBy()}
 		}
 	case 360:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2347
+		//line sql.y:2348
 		{
 			sqlVAL.union.val = &Select{Select: sqlDollar[2].union.selectStmt(), OrderBy: sqlDollar[3].union.orderBy(), Limit: sqlDollar[4].union.limit()}
 		}
 	case 363:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:2381
+		//line sql.y:2382
 		{
 			sqlVAL.union.val = &SelectClause{
 				Exprs:   sqlDollar[3].union.selExprs(),
@@ -7066,7 +7067,7 @@ sqldefault:
 		}
 	case 364:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:2394
+		//line sql.y:2395
 		{
 			sqlVAL.union.val = &SelectClause{
 				Distinct: sqlDollar[2].union.bool(),
@@ -7080,7 +7081,7 @@ sqldefault:
 		}
 	case 366:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2407
+		//line sql.y:2408
 		{
 			sqlVAL.union.val = &SelectClause{
 				Exprs:       SelectExprs{starSelectExpr()},
@@ -7090,7 +7091,7 @@ sqldefault:
 		}
 	case 367:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2415
+		//line sql.y:2416
 		{
 			sqlVAL.union.val = &UnionClause{
 				Type:  UnionOp,
@@ -7101,7 +7102,7 @@ sqldefault:
 		}
 	case 368:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2424
+		//line sql.y:2425
 		{
 			sqlVAL.union.val = &UnionClause{
 				Type:  IntersectOp,
@@ -7112,7 +7113,7 @@ sqldefault:
 		}
 	case 369:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2433
+		//line sql.y:2434
 		{
 			sqlVAL.union.val = &UnionClause{
 				Type:  ExceptOp,
@@ -7123,134 +7124,134 @@ sqldefault:
 		}
 	case 370:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2451
+		//line sql.y:2452
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 371:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2452
+		//line sql.y:2453
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 372:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2453
+		//line sql.y:2454
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 373:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2456
+		//line sql.y:2457
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 374:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2457
+		//line sql.y:2458
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 375:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2460
+		//line sql.y:2461
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 376:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2463
+		//line sql.y:2464
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 377:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2464
+		//line sql.y:2465
 		{
 		}
 	case 378:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2467
+		//line sql.y:2468
 		{
 		}
 	case 379:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2468
+		//line sql.y:2469
 		{
 		}
 	case 380:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2472
+		//line sql.y:2473
 		{
 			sqlVAL.union.val = true
 		}
 	case 381:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2476
+		//line sql.y:2477
 		{
 			sqlVAL.union.val = false
 		}
 	case 382:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2480
+		//line sql.y:2481
 		{
 			sqlVAL.union.val = false
 		}
 	case 383:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2486
+		//line sql.y:2487
 		{
 			sqlVAL.union.val = true
 		}
 	case 384:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2491
+		//line sql.y:2492
 		{
 		}
 	case 385:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2492
+		//line sql.y:2493
 		{
 		}
 	case 386:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2496
+		//line sql.y:2497
 		{
 			sqlVAL.union.val = sqlDollar[1].union.orderBy()
 		}
 	case 387:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2500
+		//line sql.y:2501
 		{
 			sqlVAL.union.val = OrderBy(nil)
 		}
 	case 388:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2506
+		//line sql.y:2507
 		{
 			sqlVAL.union.val = OrderBy(sqlDollar[3].union.orders())
 		}
 	case 389:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2512
+		//line sql.y:2513
 		{
 			sqlVAL.union.val = []*Order{sqlDollar[1].union.order()}
 		}
 	case 390:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2516
+		//line sql.y:2517
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.orders(), sqlDollar[3].union.order())
 		}
 	case 391:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2522
+		//line sql.y:2523
 		{
 			sqlVAL.union.val = &Order{Expr: sqlDollar[1].union.expr(), Direction: sqlDollar[2].union.dir()}
 		}
 	case 392:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2530
+		//line sql.y:2531
 		{
 			if sqlDollar[1].union.limit() == nil {
 				sqlVAL.union.val = sqlDollar[2].union.limit()
@@ -7261,7 +7262,7 @@ sqldefault:
 		}
 	case 393:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2539
+		//line sql.y:2540
 		{
 			sqlVAL.union.val = sqlDollar[1].union.limit()
 			if sqlDollar[2].union.limit() != nil {
@@ -7270,7 +7271,7 @@ sqldefault:
 		}
 	case 396:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2550
+		//line sql.y:2551
 		{
 			if sqlDollar[2].union.expr() == nil {
 				sqlVAL.union.val = (*Limit)(nil)
@@ -7280,65 +7281,65 @@ sqldefault:
 		}
 	case 397:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2563
+		//line sql.y:2564
 		{
 			sqlVAL.union.val = &Limit{Offset: sqlDollar[2].union.expr()}
 		}
 	case 398:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2570
+		//line sql.y:2571
 		{
 			sqlVAL.union.val = &Limit{Offset: sqlDollar[2].union.expr()}
 		}
 	case 400:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2577
+		//line sql.y:2578
 		{
 			sqlVAL.union.val = Expr(nil)
 		}
 	case 401:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2591
+		//line sql.y:2592
 		{
 		}
 	case 402:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2592
+		//line sql.y:2593
 		{
 		}
 	case 403:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2618
+		//line sql.y:2619
 		{
 			sqlVAL.union.val = GroupBy(sqlDollar[3].union.exprs())
 		}
 	case 404:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2622
+		//line sql.y:2623
 		{
 			sqlVAL.union.val = GroupBy(nil)
 		}
 	case 405:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2628
+		//line sql.y:2629
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 406:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2632
+		//line sql.y:2633
 		{
 			sqlVAL.union.val = Expr(nil)
 		}
 	case 407:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2638
+		//line sql.y:2639
 		{
 			sqlVAL.union.val = &ValuesClause{[]*Tuple{{Exprs: sqlDollar[2].union.exprs()}}}
 		}
 	case 408:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2642
+		//line sql.y:2643
 		{
 			valNode := sqlDollar[1].union.selectStmt().(*ValuesClause)
 			valNode.Tuples = append(valNode.Tuples, &Tuple{Exprs: sqlDollar[3].union.exprs()})
@@ -7346,49 +7347,49 @@ sqldefault:
 		}
 	case 409:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2654
+		//line sql.y:2655
 		{
 			sqlVAL.union.val = &From{Tables: sqlDollar[2].union.tblExprs(), AsOf: sqlDollar[3].union.asOfClause()}
 		}
 	case 410:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2658
+		//line sql.y:2659
 		{
 			sqlVAL.union.val = &From{}
 		}
 	case 411:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2664
+		//line sql.y:2665
 		{
 			sqlVAL.union.val = TableExprs{sqlDollar[1].union.tblExpr()}
 		}
 	case 412:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2668
+		//line sql.y:2669
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.tblExprs(), sqlDollar[3].union.tblExpr())
 		}
 	case 413:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2674
+		//line sql.y:2675
 		{
 			sqlVAL.union.val = &IndexHints{Index: Name(sqlDollar[3].str)}
 		}
 	case 414:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2679
+		//line sql.y:2680
 		{
 			sqlVAL.union.val = &IndexHints{NoIndexJoin: true}
 		}
 	case 415:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2685
+		//line sql.y:2686
 		{
 			sqlVAL.union.val = sqlDollar[1].union.indexHints()
 		}
 	case 416:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2690
+		//line sql.y:2691
 		{
 			a := sqlDollar[1].union.indexHints()
 			b := sqlDollar[3].union.indexHints()
@@ -7408,322 +7409,322 @@ sqldefault:
 		}
 	case 417:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2710
+		//line sql.y:2711
 		{
 			sqlVAL.union.val = &IndexHints{Index: Name(sqlDollar[2].str)}
 		}
 	case 418:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2714
+		//line sql.y:2715
 		{
 			sqlVAL.union.val = sqlDollar[3].union.indexHints()
 		}
 	case 419:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2718
+		//line sql.y:2719
 		{
 			sqlVAL.union.val = (*IndexHints)(nil)
 		}
 	case 420:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2725
+		//line sql.y:2726
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[1].union.newNormalizableTableName(), Hints: sqlDollar[2].union.indexHints(), As: sqlDollar[3].union.aliasClause()}
 		}
 	case 421:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2729
+		//line sql.y:2730
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: &Subquery{Select: sqlDollar[1].union.selectStmt()}, As: sqlDollar[2].union.aliasClause()}
 		}
 	case 422:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2733
+		//line sql.y:2734
 		{
 			sqlVAL.union.val = sqlDollar[1].union.tblExpr()
 		}
 	case 423:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2737
+		//line sql.y:2738
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[2].union.tblExpr(), As: sqlDollar[4].union.aliasClause()}
 		}
 	case 424:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2757
+		//line sql.y:2758
 		{
 			sqlVAL.union.val = &ParenTableExpr{Expr: sqlDollar[2].union.tblExpr()}
 		}
 	case 425:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2761
+		//line sql.y:2762
 		{
 			sqlVAL.union.val = &JoinTableExpr{Join: astCrossJoin, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[4].union.tblExpr()}
 		}
 	case 426:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2765
+		//line sql.y:2766
 		{
 			sqlVAL.union.val = &JoinTableExpr{Join: sqlDollar[2].str, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[4].union.tblExpr(), Cond: sqlDollar[5].union.joinCond()}
 		}
 	case 427:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2769
+		//line sql.y:2770
 		{
 			sqlVAL.union.val = &JoinTableExpr{Join: astJoin, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[3].union.tblExpr(), Cond: sqlDollar[4].union.joinCond()}
 		}
 	case 428:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2773
+		//line sql.y:2774
 		{
 			sqlVAL.union.val = &JoinTableExpr{Join: sqlDollar[3].str, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[5].union.tblExpr(), Cond: NaturalJoinCond{}}
 		}
 	case 429:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2777
+		//line sql.y:2778
 		{
 			sqlVAL.union.val = &JoinTableExpr{Join: astJoin, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[4].union.tblExpr(), Cond: NaturalJoinCond{}}
 		}
 	case 430:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2783
+		//line sql.y:2784
 		{
 			sqlVAL.union.val = AliasClause{Alias: Name(sqlDollar[2].str), Cols: sqlDollar[4].union.nameList()}
 		}
 	case 431:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2787
+		//line sql.y:2788
 		{
 			sqlVAL.union.val = AliasClause{Alias: Name(sqlDollar[2].str)}
 		}
 	case 432:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2791
+		//line sql.y:2792
 		{
 			sqlVAL.union.val = AliasClause{Alias: Name(sqlDollar[1].str), Cols: sqlDollar[3].union.nameList()}
 		}
 	case 433:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2795
+		//line sql.y:2796
 		{
 			sqlVAL.union.val = AliasClause{Alias: Name(sqlDollar[1].str)}
 		}
 	case 435:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2802
+		//line sql.y:2803
 		{
 			sqlVAL.union.val = AliasClause{}
 		}
 	case 436:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2808
+		//line sql.y:2809
 		{
 			sqlVAL.union.val = AsOfClause{Expr: &StrVal{s: sqlDollar[5].str}}
 		}
 	case 437:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2812
+		//line sql.y:2813
 		{
 			sqlVAL.union.val = AsOfClause{}
 		}
 	case 438:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2818
+		//line sql.y:2819
 		{
 			sqlVAL.str = astFullJoin
 		}
 	case 439:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2822
+		//line sql.y:2823
 		{
 			sqlVAL.str = astLeftJoin
 		}
 	case 440:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2826
+		//line sql.y:2827
 		{
 			sqlVAL.str = astRightJoin
 		}
 	case 441:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2830
+		//line sql.y:2831
 		{
 			sqlVAL.str = astInnerJoin
 		}
 	case 442:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2836
+		//line sql.y:2837
 		{
 		}
 	case 443:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2837
+		//line sql.y:2838
 		{
 		}
 	case 444:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2848
+		//line sql.y:2849
 		{
 			sqlVAL.union.val = &UsingJoinCond{Cols: sqlDollar[3].union.nameList()}
 		}
 	case 445:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2852
+		//line sql.y:2853
 		{
 			sqlVAL.union.val = &OnJoinCond{Expr: sqlDollar[2].union.expr()}
 		}
 	case 446:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2858
+		//line sql.y:2859
 		{
 			sqlVAL.union.val = sqlDollar[1].union.unresolvedName()
 		}
 	case 447:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2862
+		//line sql.y:2863
 		{
 			sqlVAL.union.val = sqlDollar[1].union.unresolvedName()
 		}
 	case 448:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2866
+		//line sql.y:2867
 		{
 			sqlVAL.union.val = sqlDollar[2].union.unresolvedName()
 		}
 	case 449:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2870
+		//line sql.y:2871
 		{
 			sqlVAL.union.val = sqlDollar[3].union.unresolvedName()
 		}
 	case 450:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2876
+		//line sql.y:2877
 		{
 			sqlVAL.union.val = TableNameReferences{sqlDollar[1].union.unresolvedName()}
 		}
 	case 451:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2880
+		//line sql.y:2881
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.tableNameReferences(), sqlDollar[3].union.unresolvedName())
 		}
 	case 452:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2893
+		//line sql.y:2894
 		{
 			sqlVAL.union.val = sqlDollar[1].union.newNormalizableTableName()
 		}
 	case 453:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2897
+		//line sql.y:2898
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[1].union.newNormalizableTableName(), As: AliasClause{Alias: Name(sqlDollar[2].str)}}
 		}
 	case 454:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2901
+		//line sql.y:2902
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[1].union.newNormalizableTableName(), As: AliasClause{Alias: Name(sqlDollar[3].str)}}
 		}
 	case 455:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2907
+		//line sql.y:2908
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 456:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2911
+		//line sql.y:2912
 		{
 			sqlVAL.union.val = Expr(nil)
 		}
 	case 457:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2923
+		//line sql.y:2924
 		{
 			sqlVAL.union.val = sqlDollar[1].union.colType()
 		}
 	case 458:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2927
+		//line sql.y:2928
 		{
-			unimplementedWithIssue(2115)
+			return unimplementedWithIssue(sqllex, 2115)
 		}
 	case 459:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2928
+		//line sql.y:2929
 		{
-			unimplementedWithIssue(2115)
+			return unimplementedWithIssue(sqllex, 2115)
 		}
 	case 460:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2931
+		//line sql.y:2932
 		{
-			unimplementedWithIssue(2115)
+			return unimplementedWithIssue(sqllex, 2115)
 		}
 	case 461:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2932
+		//line sql.y:2933
 		{
-			unimplementedWithIssue(2115)
+			return unimplementedWithIssue(sqllex, 2115)
 		}
 	case 462:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2933
+		//line sql.y:2934
 		{
 		}
 	case 468:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2941
+		//line sql.y:2942
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 469:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2943
+		//line sql.y:2944
 		{
 			sqlVAL.union.val = bytesColTypeBlob
 		}
 	case 470:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2947
+		//line sql.y:2948
 		{
 			sqlVAL.union.val = bytesColTypeBytes
 		}
 	case 471:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2951
+		//line sql.y:2952
 		{
 			sqlVAL.union.val = bytesColTypeBytea
 		}
 	case 472:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2955
+		//line sql.y:2956
 		{
 			sqlVAL.union.val = stringColTypeText
 		}
 	case 473:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2959
+		//line sql.y:2960
 		{
 			sqlVAL.union.val = intColTypeSerial
 		}
 	case 474:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2963
+		//line sql.y:2964
 		{
 			sqlVAL.union.val = intColTypeSmallSerial
 		}
 	case 475:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2967
+		//line sql.y:2968
 		{
 			sqlVAL.union.val = intColTypeBigSerial
 		}
 	case 480:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2988
+		//line sql.y:2989
 		{
 			prec, err := sqlDollar[2].union.numVal().asInt64()
 			if err != nil {
@@ -7734,7 +7735,7 @@ sqldefault:
 		}
 	case 481:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2997
+		//line sql.y:2998
 		{
 			prec, err := sqlDollar[2].union.numVal().asInt64()
 			if err != nil {
@@ -7750,55 +7751,55 @@ sqldefault:
 		}
 	case 482:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3011
+		//line sql.y:3012
 		{
 			sqlVAL.union.val = nil
 		}
 	case 483:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3018
+		//line sql.y:3019
 		{
 			sqlVAL.union.val = intColTypeInt
 		}
 	case 484:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3022
+		//line sql.y:3023
 		{
 			sqlVAL.union.val = intColTypeInt8
 		}
 	case 485:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3026
+		//line sql.y:3027
 		{
 			sqlVAL.union.val = intColTypeInt64
 		}
 	case 486:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3030
+		//line sql.y:3031
 		{
 			sqlVAL.union.val = intColTypeInteger
 		}
 	case 487:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3034
+		//line sql.y:3035
 		{
 			sqlVAL.union.val = intColTypeSmallInt
 		}
 	case 488:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3038
+		//line sql.y:3039
 		{
 			sqlVAL.union.val = intColTypeBigInt
 		}
 	case 489:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3042
+		//line sql.y:3043
 		{
 			sqlVAL.union.val = floatColTypeReal
 		}
 	case 490:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3046
+		//line sql.y:3047
 		{
 			prec, err := sqlDollar[2].union.numVal().asInt64()
 			if err != nil {
@@ -7809,13 +7810,13 @@ sqldefault:
 		}
 	case 491:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3055
+		//line sql.y:3056
 		{
 			sqlVAL.union.val = floatColTypeDouble
 		}
 	case 492:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3059
+		//line sql.y:3060
 		{
 			sqlVAL.union.val = sqlDollar[2].union.colType()
 			if sqlVAL.union.val == nil {
@@ -7826,7 +7827,7 @@ sqldefault:
 		}
 	case 493:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3068
+		//line sql.y:3069
 		{
 			sqlVAL.union.val = sqlDollar[2].union.colType()
 			if sqlVAL.union.val == nil {
@@ -7837,7 +7838,7 @@ sqldefault:
 		}
 	case 494:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3077
+		//line sql.y:3078
 		{
 			sqlVAL.union.val = sqlDollar[2].union.colType()
 			if sqlVAL.union.val == nil {
@@ -7848,31 +7849,31 @@ sqldefault:
 		}
 	case 495:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3086
+		//line sql.y:3087
 		{
 			sqlVAL.union.val = boolColTypeBoolean
 		}
 	case 496:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3090
+		//line sql.y:3091
 		{
 			sqlVAL.union.val = boolColTypeBool
 		}
 	case 497:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3096
+		//line sql.y:3097
 		{
 			sqlVAL.union.val = sqlDollar[2].union.numVal()
 		}
 	case 498:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3100
+		//line sql.y:3101
 		{
 			sqlVAL.union.val = &NumVal{Value: constant.MakeInt64(0)}
 		}
 	case 503:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3118
+		//line sql.y:3119
 		{
 			n, err := sqlDollar[4].union.numVal().asInt64()
 			if err != nil {
@@ -7888,13 +7889,13 @@ sqldefault:
 		}
 	case 504:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3134
+		//line sql.y:3135
 		{
 			sqlVAL.union.val = intColTypeBit
 		}
 	case 509:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3150
+		//line sql.y:3151
 		{
 			n, err := sqlDollar[3].union.numVal().asInt64()
 			if err != nil {
@@ -7910,796 +7911,796 @@ sqldefault:
 		}
 	case 510:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3166
+		//line sql.y:3167
 		{
 			sqlVAL.union.val = sqlDollar[1].union.colType()
 		}
 	case 511:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3172
+		//line sql.y:3173
 		{
 			sqlVAL.union.val = stringColTypeChar
 		}
 	case 512:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3176
+		//line sql.y:3177
 		{
 			sqlVAL.union.val = stringColTypeChar
 		}
 	case 513:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3180
+		//line sql.y:3181
 		{
 			sqlVAL.union.val = stringColTypeVarChar
 		}
 	case 514:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3184
+		//line sql.y:3185
 		{
 			sqlVAL.union.val = stringColTypeString
 		}
 	case 515:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3189
+		//line sql.y:3190
 		{
 		}
 	case 516:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3190
+		//line sql.y:3191
 		{
 		}
 	case 517:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3195
+		//line sql.y:3196
 		{
 			sqlVAL.union.val = dateColTypeDate
 		}
 	case 518:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3199
+		//line sql.y:3200
 		{
 			sqlVAL.union.val = timestampColTypeTimestamp
 		}
 	case 519:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3203
+		//line sql.y:3204
 		{
 			sqlVAL.union.val = timestampColTypeTimestamp
 		}
 	case 520:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3207
+		//line sql.y:3208
 		{
 			sqlVAL.union.val = timestampTzColTypeTimestampWithTZ
 		}
 	case 521:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3211
+		//line sql.y:3212
 		{
 			sqlVAL.union.val = timestampTzColTypeTimestampWithTZ
 		}
 	case 522:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3216
+		//line sql.y:3217
 		{
 			sqlVAL.union.val = intervalColTypeInterval
 		}
 	case 523:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3221
+		//line sql.y:3222
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 524:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3222
+		//line sql.y:3223
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 525:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3223
+		//line sql.y:3224
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 526:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3224
+		//line sql.y:3225
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 527:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3225
+		//line sql.y:3226
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 528:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3226
+		//line sql.y:3227
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 529:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3227
+		//line sql.y:3228
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 530:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3228
+		//line sql.y:3229
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 531:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3229
+		//line sql.y:3230
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 532:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3230
+		//line sql.y:3231
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 533:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3231
+		//line sql.y:3232
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 534:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3232
+		//line sql.y:3233
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 535:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3233
+		//line sql.y:3234
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 536:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3234
+		//line sql.y:3235
 		{
 		}
 	case 537:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3237
+		//line sql.y:3238
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 538:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3238
+		//line sql.y:3239
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 540:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3262
+		//line sql.y:3263
 		{
 			sqlVAL.union.val = &CastExpr{Expr: sqlDollar[1].union.expr(), Type: sqlDollar[3].union.colType(), syntaxMode: castShort}
 		}
 	case 541:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3266
+		//line sql.y:3267
 		{
 			sqlVAL.union.val = &AnnotateTypeExpr{Expr: sqlDollar[1].union.expr(), Type: sqlDollar[3].union.colType(), syntaxMode: annotateShort}
 		}
 	case 542:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3269
+		//line sql.y:3270
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 543:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3270
+		//line sql.y:3271
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 544:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3279
+		//line sql.y:3280
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryPlus, Expr: sqlDollar[2].union.expr()}
 		}
 	case 545:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3283
+		//line sql.y:3284
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryMinus, Expr: sqlDollar[2].union.expr()}
 		}
 	case 546:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3287
+		//line sql.y:3288
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryComplement, Expr: sqlDollar[2].union.expr()}
 		}
 	case 547:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3291
+		//line sql.y:3292
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Plus, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 548:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3295
+		//line sql.y:3296
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Minus, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 549:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3299
+		//line sql.y:3300
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Mult, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 550:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3303
+		//line sql.y:3304
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Div, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 551:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3307
+		//line sql.y:3308
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: FloorDiv, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 552:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3311
+		//line sql.y:3312
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Mod, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 553:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3315
+		//line sql.y:3316
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 554:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3319
+		//line sql.y:3320
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 555:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3323
+		//line sql.y:3324
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitand, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 556:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3327
+		//line sql.y:3328
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 557:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3331
+		//line sql.y:3332
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: LT, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 558:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3335
+		//line sql.y:3336
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: GT, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 559:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3339
+		//line sql.y:3340
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: EQ, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 560:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3343
+		//line sql.y:3344
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Concat, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 561:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3347
+		//line sql.y:3348
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: LShift, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 562:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3351
+		//line sql.y:3352
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: RShift, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 563:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3355
+		//line sql.y:3356
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: LE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 564:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3359
+		//line sql.y:3360
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: GE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 565:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3363
+		//line sql.y:3364
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 566:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3367
+		//line sql.y:3368
 		{
 			sqlVAL.union.val = &AndExpr{Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 567:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3371
+		//line sql.y:3372
 		{
 			sqlVAL.union.val = &OrExpr{Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 568:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3375
+		//line sql.y:3376
 		{
 			sqlVAL.union.val = &NotExpr{Expr: sqlDollar[2].union.expr()}
 		}
 	case 569:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3379
+		//line sql.y:3380
 		{
 			sqlVAL.union.val = &NotExpr{Expr: sqlDollar[2].union.expr()}
 		}
 	case 570:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3383
+		//line sql.y:3384
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Like, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 571:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3387
+		//line sql.y:3388
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NotLike, Left: sqlDollar[1].union.expr(), Right: sqlDollar[4].union.expr()}
 		}
 	case 572:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3391
+		//line sql.y:3392
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: ILike, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 573:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3395
+		//line sql.y:3396
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NotILike, Left: sqlDollar[1].union.expr(), Right: sqlDollar[4].union.expr()}
 		}
 	case 574:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3399
+		//line sql.y:3400
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: SimilarTo, Left: sqlDollar[1].union.expr(), Right: sqlDollar[4].union.expr()}
 		}
 	case 575:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3403
+		//line sql.y:3404
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NotSimilarTo, Left: sqlDollar[1].union.expr(), Right: sqlDollar[5].union.expr()}
 		}
 	case 576:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3407
+		//line sql.y:3408
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: RegMatch, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 577:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3411
+		//line sql.y:3412
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NotRegMatch, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 578:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3415
+		//line sql.y:3416
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: RegIMatch, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 579:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3419
+		//line sql.y:3420
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NotRegIMatch, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 580:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3423
+		//line sql.y:3424
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: DNull}
 		}
 	case 581:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3427
+		//line sql.y:3428
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: DNull}
 		}
 	case 582:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3430
+		//line sql.y:3431
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 583:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3432
+		//line sql.y:3433
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: MakeDBool(true)}
 		}
 	case 584:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3436
+		//line sql.y:3437
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: MakeDBool(true)}
 		}
 	case 585:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3440
+		//line sql.y:3441
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: MakeDBool(false)}
 		}
 	case 586:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3444
+		//line sql.y:3445
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: MakeDBool(false)}
 		}
 	case 587:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3448
+		//line sql.y:3449
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: DNull}
 		}
 	case 588:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3452
+		//line sql.y:3453
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: DNull}
 		}
 	case 589:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3456
+		//line sql.y:3457
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsDistinctFrom, Left: sqlDollar[1].union.expr(), Right: sqlDollar[5].union.expr()}
 		}
 	case 590:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3460
+		//line sql.y:3461
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNotDistinctFrom, Left: sqlDollar[1].union.expr(), Right: sqlDollar[6].union.expr()}
 		}
 	case 591:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3464
+		//line sql.y:3465
 		{
 			sqlVAL.union.val = &IsOfTypeExpr{Expr: sqlDollar[1].union.expr(), Types: sqlDollar[5].union.colTypes()}
 		}
 	case 592:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:3468
+		//line sql.y:3469
 		{
 			sqlVAL.union.val = &IsOfTypeExpr{Not: true, Expr: sqlDollar[1].union.expr(), Types: sqlDollar[6].union.colTypes()}
 		}
 	case 593:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3472
+		//line sql.y:3473
 		{
 			sqlVAL.union.val = &RangeCond{Left: sqlDollar[1].union.expr(), From: sqlDollar[4].union.expr(), To: sqlDollar[6].union.expr()}
 		}
 	case 594:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:3476
+		//line sql.y:3477
 		{
 			sqlVAL.union.val = &RangeCond{Not: true, Left: sqlDollar[1].union.expr(), From: sqlDollar[5].union.expr(), To: sqlDollar[7].union.expr()}
 		}
 	case 595:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3480
+		//line sql.y:3481
 		{
 			sqlVAL.union.val = &RangeCond{Left: sqlDollar[1].union.expr(), From: sqlDollar[4].union.expr(), To: sqlDollar[6].union.expr()}
 		}
 	case 596:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:3484
+		//line sql.y:3485
 		{
 			sqlVAL.union.val = &RangeCond{Not: true, Left: sqlDollar[1].union.expr(), From: sqlDollar[5].union.expr(), To: sqlDollar[7].union.expr()}
 		}
 	case 597:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3488
+		//line sql.y:3489
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: In, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 598:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3492
+		//line sql.y:3493
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NotIn, Left: sqlDollar[1].union.expr(), Right: sqlDollar[4].union.expr()}
 		}
 	case 600:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3509
+		//line sql.y:3510
 		{
 			sqlVAL.union.val = &CastExpr{Expr: sqlDollar[1].union.expr(), Type: sqlDollar[3].union.colType(), syntaxMode: castShort}
 		}
 	case 601:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3513
+		//line sql.y:3514
 		{
 			sqlVAL.union.val = &AnnotateTypeExpr{Expr: sqlDollar[1].union.expr(), Type: sqlDollar[3].union.colType(), syntaxMode: annotateShort}
 		}
 	case 602:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3517
+		//line sql.y:3518
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryPlus, Expr: sqlDollar[2].union.expr()}
 		}
 	case 603:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3521
+		//line sql.y:3522
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryMinus, Expr: sqlDollar[2].union.expr()}
 		}
 	case 604:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3525
+		//line sql.y:3526
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryComplement, Expr: sqlDollar[2].union.expr()}
 		}
 	case 605:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3529
+		//line sql.y:3530
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Plus, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 606:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3533
+		//line sql.y:3534
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Minus, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 607:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3537
+		//line sql.y:3538
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Mult, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 608:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3541
+		//line sql.y:3542
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Div, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 609:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3545
+		//line sql.y:3546
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: FloorDiv, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 610:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3549
+		//line sql.y:3550
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Mod, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 611:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3553
+		//line sql.y:3554
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 612:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3557
+		//line sql.y:3558
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 613:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3561
+		//line sql.y:3562
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitand, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 614:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3565
+		//line sql.y:3566
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 615:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3569
+		//line sql.y:3570
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: LT, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 616:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3573
+		//line sql.y:3574
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: GT, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 617:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3577
+		//line sql.y:3578
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: EQ, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 618:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3581
+		//line sql.y:3582
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Concat, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 619:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3585
+		//line sql.y:3586
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: LShift, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 620:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3589
+		//line sql.y:3590
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: RShift, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 621:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3593
+		//line sql.y:3594
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: LE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 622:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3597
+		//line sql.y:3598
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: GE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 623:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3601
+		//line sql.y:3602
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 624:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3605
+		//line sql.y:3606
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsDistinctFrom, Left: sqlDollar[1].union.expr(), Right: sqlDollar[5].union.expr()}
 		}
 	case 625:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3609
+		//line sql.y:3610
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNotDistinctFrom, Left: sqlDollar[1].union.expr(), Right: sqlDollar[6].union.expr()}
 		}
 	case 626:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3613
+		//line sql.y:3614
 		{
 			sqlVAL.union.val = &IsOfTypeExpr{Expr: sqlDollar[1].union.expr(), Types: sqlDollar[5].union.colTypes()}
 		}
 	case 627:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:3617
+		//line sql.y:3618
 		{
 			sqlVAL.union.val = &IsOfTypeExpr{Not: true, Expr: sqlDollar[1].union.expr(), Types: sqlDollar[6].union.colTypes()}
 		}
 	case 628:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3629
+		//line sql.y:3630
 		{
 			sqlVAL.union.val = sqlDollar[1].union.unresolvedName()
 		}
 	case 630:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3634
+		//line sql.y:3635
 		{
 			sqlVAL.union.val = Placeholder{Name: sqlDollar[1].str}
 		}
 	case 631:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3638
+		//line sql.y:3639
 		{
 			sqlVAL.union.val = &ParenExpr{Expr: sqlDollar[2].union.expr()}
 		}
 	case 634:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3644
+		//line sql.y:3645
 		{
 			sqlVAL.union.val = &Subquery{Select: sqlDollar[1].union.selectStmt()}
 		}
 	case 635:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3648
+		//line sql.y:3649
 		{
 			sqlVAL.union.val = &Subquery{Select: sqlDollar[1].union.selectStmt()}
 		}
 	case 636:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3652
+		//line sql.y:3653
 		{
 			sqlVAL.union.val = &ExistsExpr{Subquery: &Subquery{Select: sqlDollar[2].union.selectStmt()}}
 		}
 	case 637:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3658
+		//line sql.y:3659
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 638:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3662
+		//line sql.y:3663
 		{
 			sqlVAL.union.val = sqlDollar[1].union.expr()
 		}
 	case 639:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3666
+		//line sql.y:3667
 		{
 			sqlVAL.union.val = sqlDollar[1].union.expr()
 		}
 	case 640:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3674
+		//line sql.y:3675
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.normalizableFunctionName()}
 		}
 	case 641:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3678
+		//line sql.y:3679
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.normalizableFunctionName(), Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 642:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3681
+		//line sql.y:3682
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 643:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:3682
+		//line sql.y:3683
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 644:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3684
+		//line sql.y:3685
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.normalizableFunctionName(), Type: All, Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 645:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3688
+		//line sql.y:3689
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.normalizableFunctionName(), Type: Distinct, Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 646:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3692
+		//line sql.y:3693
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.normalizableFunctionName(), Exprs: Exprs{StarExpr()}}
 		}
 	case 647:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3705
+		//line sql.y:3706
 		{
 			f := sqlDollar[1].union.expr().(*FuncExpr)
 			f.WindowDef = sqlDollar[4].union.windowDef()
@@ -8707,233 +8708,233 @@ sqldefault:
 		}
 	case 648:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3711
+		//line sql.y:3712
 		{
 			sqlVAL.union.val = sqlDollar[1].union.expr()
 		}
 	case 649:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3720
+		//line sql.y:3721
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 650:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3721
+		//line sql.y:3722
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 651:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3725
+		//line sql.y:3726
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 652:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3727
+		//line sql.y:3728
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName(sqlDollar[1].str)}
 		}
 	case 653:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3731
+		//line sql.y:3732
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName(sqlDollar[1].str)}
 		}
 	case 654:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3735
+		//line sql.y:3736
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName(sqlDollar[1].str)}
 		}
 	case 655:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3739
+		//line sql.y:3740
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName(sqlDollar[1].str)}
 		}
 	case 656:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3742
+		//line sql.y:3743
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 657:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3743
+		//line sql.y:3744
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 658:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3744
+		//line sql.y:3745
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 659:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3745
+		//line sql.y:3746
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 660:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3747
+		//line sql.y:3748
 		{
 			sqlVAL.union.val = &CastExpr{Expr: sqlDollar[3].union.expr(), Type: sqlDollar[5].union.colType(), syntaxMode: castExplicit}
 		}
 	case 661:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3751
+		//line sql.y:3752
 		{
 			sqlVAL.union.val = &AnnotateTypeExpr{Expr: sqlDollar[3].union.expr(), Type: sqlDollar[5].union.colType(), syntaxMode: annotateExplicit}
 		}
 	case 662:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3755
+		//line sql.y:3756
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName(sqlDollar[1].str), Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 663:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3759
+		//line sql.y:3760
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName(sqlDollar[1].str), Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 664:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3763
+		//line sql.y:3764
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName(sqlDollar[1].str), Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 665:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3767
+		//line sql.y:3768
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName("STRPOS"), Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 666:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3771
+		//line sql.y:3772
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName(sqlDollar[1].str), Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 667:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3774
+		//line sql.y:3775
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 668:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3776
+		//line sql.y:3777
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName("BTRIM"), Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 669:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3780
+		//line sql.y:3781
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName("LTRIM"), Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 670:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3784
+		//line sql.y:3785
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName("RTRIM"), Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 671:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3788
+		//line sql.y:3789
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName("BTRIM"), Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 672:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:3792
+		//line sql.y:3793
 		{
 			sqlVAL.union.val = &IfExpr{Cond: sqlDollar[3].union.expr(), True: sqlDollar[5].union.expr(), Else: sqlDollar[7].union.expr()}
 		}
 	case 673:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3796
+		//line sql.y:3797
 		{
 			sqlVAL.union.val = &NullIfExpr{Expr1: sqlDollar[3].union.expr(), Expr2: sqlDollar[5].union.expr()}
 		}
 	case 674:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3800
+		//line sql.y:3801
 		{
 			sqlVAL.union.val = &CoalesceExpr{Name: "IFNULL", Exprs: Exprs{sqlDollar[3].union.expr(), sqlDollar[5].union.expr()}}
 		}
 	case 675:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3804
+		//line sql.y:3805
 		{
 			sqlVAL.union.val = &CoalesceExpr{Name: "COALESCE", Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 676:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3808
+		//line sql.y:3809
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName(sqlDollar[1].str), Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 677:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3812
+		//line sql.y:3813
 		{
 			sqlVAL.union.val = &FuncExpr{Name: WrapQualifiedFunctionName(sqlDollar[1].str), Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 678:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3818
+		//line sql.y:3819
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 679:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3819
+		//line sql.y:3820
 		{
 		}
 	case 680:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3822
+		//line sql.y:3823
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 681:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3823
+		//line sql.y:3824
 		{
 		}
 	case 682:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3828
+		//line sql.y:3829
 		{
 			sqlVAL.union.val = sqlDollar[2].union.window()
 		}
 	case 683:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3832
+		//line sql.y:3833
 		{
 			sqlVAL.union.val = Window(nil)
 		}
 	case 684:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3838
+		//line sql.y:3839
 		{
 			sqlVAL.union.val = Window{sqlDollar[1].union.windowDef()}
 		}
 	case 685:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3842
+		//line sql.y:3843
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.window(), sqlDollar[3].union.windowDef())
 		}
 	case 686:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3848
+		//line sql.y:3849
 		{
 			n := sqlDollar[3].union.windowDef()
 			n.Name = Name(sqlDollar[1].str)
@@ -8941,25 +8942,25 @@ sqldefault:
 		}
 	case 687:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3856
+		//line sql.y:3857
 		{
 			sqlVAL.union.val = sqlDollar[2].union.windowDef()
 		}
 	case 688:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3860
+		//line sql.y:3861
 		{
 			sqlVAL.union.val = &WindowDef{Name: Name(sqlDollar[2].str)}
 		}
 	case 689:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3864
+		//line sql.y:3865
 		{
 			sqlVAL.union.val = (*WindowDef)(nil)
 		}
 	case 690:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3871
+		//line sql.y:3872
 		{
 			sqlVAL.union.val = &WindowDef{
 				RefName:    Name(sqlDollar[2].str),
@@ -8969,663 +8970,663 @@ sqldefault:
 		}
 	case 692:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3890
+		//line sql.y:3891
 		{
 			sqlVAL.str = ""
 		}
 	case 693:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3896
+		//line sql.y:3897
 		{
 			sqlVAL.union.val = sqlDollar[3].union.exprs()
 		}
 	case 694:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3900
+		//line sql.y:3901
 		{
 			sqlVAL.union.val = Exprs(nil)
 		}
 	case 695:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3910
+		//line sql.y:3911
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 696:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3911
+		//line sql.y:3912
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 697:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3912
+		//line sql.y:3913
 		{
 		}
 	case 698:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3915
+		//line sql.y:3916
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 699:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3916
+		//line sql.y:3917
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 700:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3922
+		//line sql.y:3923
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 701:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3923
+		//line sql.y:3924
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 702:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3924
+		//line sql.y:3925
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 703:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3925
+		//line sql.y:3926
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 704:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3926
+		//line sql.y:3927
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 705:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3937
+		//line sql.y:3938
 		{
 			sqlVAL.union.val = &Tuple{Exprs: sqlDollar[3].union.exprs(), row: true}
 		}
 	case 706:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3941
+		//line sql.y:3942
 		{
 			sqlVAL.union.val = &Tuple{Exprs: nil, row: true}
 		}
 	case 707:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3945
+		//line sql.y:3946
 		{
 			sqlVAL.union.val = &Tuple{Exprs: append(sqlDollar[2].union.exprs(), sqlDollar[4].union.expr())}
 		}
 	case 708:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3951
+		//line sql.y:3952
 		{
 			sqlVAL.union.val = &Tuple{Exprs: sqlDollar[3].union.exprs(), row: true}
 		}
 	case 709:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3955
+		//line sql.y:3956
 		{
 			sqlVAL.union.val = &Tuple{Exprs: nil, row: true}
 		}
 	case 710:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3961
+		//line sql.y:3962
 		{
 			sqlVAL.union.val = &Tuple{Exprs: append(sqlDollar[2].union.exprs(), sqlDollar[4].union.expr())}
 		}
 	case 711:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4004
+		//line sql.y:4005
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr()}
 		}
 	case 712:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4008
+		//line sql.y:4009
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.exprs(), sqlDollar[3].union.expr())
 		}
 	case 713:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4014
+		//line sql.y:4015
 		{
 			sqlVAL.union.val = []ColumnType{sqlDollar[1].union.colType()}
 		}
 	case 714:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4018
+		//line sql.y:4019
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.colTypes(), sqlDollar[3].union.colType())
 		}
 	case 715:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4024
+		//line sql.y:4025
 		{
 			sqlVAL.union.val = &Array{sqlDollar[2].union.exprs()}
 		}
 	case 716:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4028
+		//line sql.y:4029
 		{
 			sqlVAL.union.val = &Array{sqlDollar[2].union.exprs()}
 		}
 	case 717:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4032
+		//line sql.y:4033
 		{
 			sqlVAL.union.val = &Array{nil}
 		}
 	case 718:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4038
+		//line sql.y:4039
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr()}
 		}
 	case 719:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4042
+		//line sql.y:4043
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.exprs(), sqlDollar[3].union.expr())
 		}
 	case 720:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4048
+		//line sql.y:4049
 		{
 			sqlVAL.union.val = Exprs{&StrVal{s: sqlDollar[1].str}, sqlDollar[3].union.expr()}
 		}
 	case 721:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4052
+		//line sql.y:4053
 		{
 			sqlVAL.union.val = sqlDollar[1].union.exprs()
 		}
 	case 729:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:4074
+		//line sql.y:4075
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[2].union.expr(), sqlDollar[3].union.expr(), sqlDollar[4].union.expr()}
 		}
 	case 730:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4078
+		//line sql.y:4079
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[2].union.expr(), sqlDollar[3].union.expr()}
 		}
 	case 731:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4082
+		//line sql.y:4083
 		{
 			sqlVAL.union.val = sqlDollar[1].union.exprs()
 		}
 	case 732:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4088
+		//line sql.y:4089
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 733:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4095
+		//line sql.y:4096
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[3].union.expr(), sqlDollar[1].union.expr()}
 		}
 	case 734:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:4099
+		//line sql.y:4100
 		{
 			sqlVAL.union.val = Exprs(nil)
 		}
 	case 735:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4116
+		//line sql.y:4117
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[2].union.expr(), sqlDollar[3].union.expr()}
 		}
 	case 736:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4120
+		//line sql.y:4121
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[3].union.expr(), sqlDollar[2].union.expr()}
 		}
 	case 737:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4124
+		//line sql.y:4125
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[2].union.expr()}
 		}
 	case 738:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4128
+		//line sql.y:4129
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), NewDInt(1), sqlDollar[2].union.expr()}
 		}
 	case 739:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4132
+		//line sql.y:4133
 		{
 			sqlVAL.union.val = sqlDollar[1].union.exprs()
 		}
 	case 740:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:4136
+		//line sql.y:4137
 		{
 			sqlVAL.union.val = Exprs(nil)
 		}
 	case 741:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4142
+		//line sql.y:4143
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 742:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4148
+		//line sql.y:4149
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 743:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4154
+		//line sql.y:4155
 		{
 			sqlVAL.union.val = append(sqlDollar[3].union.exprs(), sqlDollar[1].union.expr())
 		}
 	case 744:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4158
+		//line sql.y:4159
 		{
 			sqlVAL.union.val = sqlDollar[2].union.exprs()
 		}
 	case 745:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4162
+		//line sql.y:4163
 		{
 			sqlVAL.union.val = sqlDollar[1].union.exprs()
 		}
 	case 746:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4168
+		//line sql.y:4169
 		{
 			sqlVAL.union.val = &Subquery{Select: sqlDollar[1].union.selectStmt()}
 		}
 	case 747:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4172
+		//line sql.y:4173
 		{
 			sqlVAL.union.val = &Tuple{Exprs: sqlDollar[2].union.exprs()}
 		}
 	case 748:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:4183
+		//line sql.y:4184
 		{
 			sqlVAL.union.val = &CaseExpr{Expr: sqlDollar[2].union.expr(), Whens: sqlDollar[3].union.whens(), Else: sqlDollar[4].union.expr()}
 		}
 	case 749:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4190
+		//line sql.y:4191
 		{
 			sqlVAL.union.val = []*When{sqlDollar[1].union.when()}
 		}
 	case 750:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4194
+		//line sql.y:4195
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.whens(), sqlDollar[2].union.when())
 		}
 	case 751:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:4200
+		//line sql.y:4201
 		{
 			sqlVAL.union.val = &When{Cond: sqlDollar[2].union.expr(), Val: sqlDollar[4].union.expr()}
 		}
 	case 752:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4206
+		//line sql.y:4207
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 753:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:4210
+		//line sql.y:4211
 		{
 			sqlVAL.union.val = Expr(nil)
 		}
 	case 755:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:4217
+		//line sql.y:4218
 		{
 			sqlVAL.union.val = Expr(nil)
 		}
 	case 756:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4223
+		//line sql.y:4224
 		{
 			sqlVAL.union.val = sqlDollar[1].union.namePart()
 		}
 	case 757:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4227
+		//line sql.y:4228
 		{
 			sqlVAL.union.val = sqlDollar[1].union.namePart()
 		}
 	case 758:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4231
+		//line sql.y:4232
 		{
 			sqlVAL.union.val = &ArraySubscript{Begin: sqlDollar[2].union.expr()}
 		}
 	case 759:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:4235
+		//line sql.y:4236
 		{
 			sqlVAL.union.val = &ArraySubscript{Begin: sqlDollar[2].union.expr(), End: sqlDollar[4].union.expr()}
 		}
 	case 760:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4241
+		//line sql.y:4242
 		{
 			sqlVAL.union.val = Name(sqlDollar[2].str)
 		}
 	case 761:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4247
+		//line sql.y:4248
 		{
 			sqlVAL.union.val = UnqualifiedStar{}
 		}
 	case 762:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4253
+		//line sql.y:4254
 		{
 			sqlVAL.union.val = UnresolvedName{sqlDollar[1].union.namePart()}
 		}
 	case 763:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4257
+		//line sql.y:4258
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.unresolvedName(), sqlDollar[2].union.namePart())
 		}
 	case 764:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4262
+		//line sql.y:4263
 		{
 		}
 	case 765:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:4263
+		//line sql.y:4264
 		{
 		}
 	case 767:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4272
+		//line sql.y:4273
 		{
 			sqlVAL.union.val = DefaultVal{}
 		}
 	case 768:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4278
+		//line sql.y:4279
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr()}
 		}
 	case 769:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4282
+		//line sql.y:4283
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.exprs(), sqlDollar[3].union.expr())
 		}
 	case 770:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4291
+		//line sql.y:4292
 		{
 			sqlVAL.union.val = sqlDollar[2].union.exprs()
 		}
 	case 771:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4297
+		//line sql.y:4298
 		{
 			sqlVAL.union.val = SelectExprs{sqlDollar[1].union.selExpr()}
 		}
 	case 772:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4301
+		//line sql.y:4302
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.selExprs(), sqlDollar[3].union.selExpr())
 		}
 	case 773:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4307
+		//line sql.y:4308
 		{
 			sqlVAL.union.val = SelectExpr{Expr: sqlDollar[1].union.expr(), As: Name(sqlDollar[3].str)}
 		}
 	case 774:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4316
+		//line sql.y:4317
 		{
 			sqlVAL.union.val = SelectExpr{Expr: sqlDollar[1].union.expr(), As: Name(sqlDollar[2].str)}
 		}
 	case 775:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4320
+		//line sql.y:4321
 		{
 			sqlVAL.union.val = SelectExpr{Expr: sqlDollar[1].union.expr()}
 		}
 	case 776:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4324
+		//line sql.y:4325
 		{
 			sqlVAL.union.val = starSelectExpr()
 		}
 	case 777:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4332
+		//line sql.y:4333
 		{
 			sqlVAL.union.val = UnresolvedNames{sqlDollar[1].union.unresolvedName()}
 		}
 	case 778:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4336
+		//line sql.y:4337
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.unresolvedNames(), sqlDollar[3].union.unresolvedName())
 		}
 	case 779:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4342
+		//line sql.y:4343
 		{
 			sqlVAL.union.val = TableNameWithIndexList{sqlDollar[1].union.tableWithIdx()}
 		}
 	case 780:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4346
+		//line sql.y:4347
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.tableWithIdxList(), sqlDollar[3].union.tableWithIdx())
 		}
 	case 781:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4352
+		//line sql.y:4353
 		{
 			sqlVAL.union.val = TablePatterns{sqlDollar[1].union.unresolvedName()}
 		}
 	case 782:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4356
+		//line sql.y:4357
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.tablePatterns(), sqlDollar[3].union.unresolvedName())
 		}
 	case 783:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4367
+		//line sql.y:4368
 		{
 			sqlVAL.union.val = UnresolvedName{Name(sqlDollar[1].str)}
 		}
 	case 784:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4371
+		//line sql.y:4372
 		{
 			sqlVAL.union.val = append(UnresolvedName{Name(sqlDollar[1].str)}, sqlDollar[2].union.unresolvedName()...)
 		}
 	case 785:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4377
+		//line sql.y:4378
 		{
 			sqlVAL.union.val = &TableNameWithIndex{Table: sqlDollar[1].union.normalizableTableName(), Index: Name(sqlDollar[3].str)}
 		}
 	case 786:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4388
+		//line sql.y:4389
 		{
 			sqlVAL.union.val = UnresolvedName{Name(sqlDollar[1].str)}
 		}
 	case 787:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4392
+		//line sql.y:4393
 		{
 			sqlVAL.union.val = UnresolvedName{UnqualifiedStar{}}
 		}
 	case 788:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4396
+		//line sql.y:4397
 		{
 			sqlVAL.union.val = UnresolvedName{Name(sqlDollar[1].str), sqlDollar[2].union.namePart()}
 		}
 	case 789:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4400
+		//line sql.y:4401
 		{
 			sqlVAL.union.val = UnresolvedName{Name(sqlDollar[1].str), sqlDollar[2].union.namePart()}
 		}
 	case 790:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4406
+		//line sql.y:4407
 		{
 			sqlVAL.union.val = NameList{Name(sqlDollar[1].str)}
 		}
 	case 791:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4410
+		//line sql.y:4411
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.nameList(), Name(sqlDollar[3].str))
 		}
 	case 792:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4416
+		//line sql.y:4417
 		{
 			sqlVAL.union.val = sqlDollar[2].union.nameList()
 		}
 	case 793:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:4419
+		//line sql.y:4420
 		{
 		}
 	case 794:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4429
+		//line sql.y:4430
 		{
 			sqlVAL.union.val = UnresolvedName{Name(sqlDollar[1].str)}
 		}
 	case 795:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4433
+		//line sql.y:4434
 		{
 			sqlVAL.union.val = append(UnresolvedName{Name(sqlDollar[1].str)}, sqlDollar[2].union.unresolvedName()...)
 		}
 	case 796:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4440
+		//line sql.y:4441
 		{
 			sqlVAL.union.val = sqlDollar[1].union.numVal()
 		}
 	case 797:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4444
+		//line sql.y:4445
 		{
 			sqlVAL.union.val = sqlDollar[1].union.numVal()
 		}
 	case 798:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4448
+		//line sql.y:4449
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
 	case 799:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4452
+		//line sql.y:4453
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str, bytesEsc: true}
 		}
 	case 800:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:4455
+		//line sql.y:4456
 		{
-			unimplemented()
+			return unimplemented(sqllex)
 		}
 	case 801:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4457
+		//line sql.y:4458
 		{
 			sqlVAL.union.val = &CastExpr{Expr: &StrVal{s: sqlDollar[2].str}, Type: sqlDollar[1].union.colType(), syntaxMode: castPrefix}
 		}
 	case 802:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4461
+		//line sql.y:4462
 		{
 			sqlVAL.union.val = &CastExpr{Expr: &StrVal{s: sqlDollar[2].str}, Type: sqlDollar[1].union.colType(), syntaxMode: castPrefix}
 		}
 	case 803:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:4465
+		//line sql.y:4466
 		{
 			sqlVAL.union.val = &CastExpr{Expr: &StrVal{s: sqlDollar[5].str}, Type: sqlDollar[1].union.colType(), syntaxMode: castPrefixParens}
 		}
 	case 804:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4469
+		//line sql.y:4470
 		{
 			sqlVAL.union.val = MakeDBool(true)
 		}
 	case 805:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4473
+		//line sql.y:4474
 		{
 			sqlVAL.union.val = MakeDBool(false)
 		}
 	case 806:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4477
+		//line sql.y:4478
 		{
 			sqlVAL.union.val = DNull
 		}
 	case 808:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4484
+		//line sql.y:4485
 		{
 			sqlVAL.union.val = sqlDollar[2].union.numVal()
 		}
 	case 809:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4488
+		//line sql.y:4489
 		{
 			sqlVAL.union.val = &NumVal{Value: constant.UnaryOp(token.SUB, sqlDollar[2].union.numVal().Value, 0)}
 		}
 	case 814:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:4510
+		//line sql.y:4511
 		{
 			sqlVAL.str = ""
 		}
 	case 815:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4516
+		//line sql.y:4517
 		{
 			sqlVAL.str = sqlDollar[2].str
 		}
 	case 816:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:4520
+		//line sql.y:4521
 		{
 			sqlVAL.str = ""
 		}

--- a/sql/parser/sql.y
+++ b/sql/parser/sql.y
@@ -20,23 +20,24 @@
 package parser
 
 import (
+    "fmt"
+
     "go/constant"
     "go/token"
 
-    "github.com/pkg/errors"
-
     "github.com/cockroachdb/cockroach/sql/privilege"
-    "github.com/cockroachdb/cockroach/util"
 )
 
-var errUnimplemented = errors.New("unimplemented")
-
-func unimplemented() {
-    panic(errUnimplemented)
+func unimplemented(sqllex sqlLexer) int {
+    sqllex.Error("unimplemented")
+    return 1
 }
 
-func unimplementedWithIssue(issue int) {
-    panic(util.UnimplementedWithIssueErrorf(issue, ""))
+func unimplementedWithIssue(sqllex sqlLexer, issue int) int {
+    sqllex.Error(fmt.Sprintf("unimplemented "+
+			     "(see issue https://github.com/cockroachdb/cockroach/issues/%d)",
+			     issue))
+    return 1
 }
 %}
 
@@ -800,7 +801,7 @@ alter_table_cmd:
     $$.val = &AlterTableDropNotNull{columnKeyword: $2.bool(), Column: Name($3)}
   }
   // ALTER TABLE <name> ALTER [COLUMN] <colname> SET NOT NULL
-| ALTER opt_column name SET NOT NULL { unimplemented() }
+| ALTER opt_column name SET NOT NULL { return unimplemented(sqllex) }
   // ALTER TABLE <name> DROP [COLUMN] IF EXISTS <colname> [RESTRICT|CASCADE]
 | DROP opt_column IF EXISTS name opt_drop_behavior
   {
@@ -818,7 +819,7 @@ alter_table_cmd:
   }
   // ALTER TABLE <name> ALTER [COLUMN] <colname> [SET DATA] TYPE <typename>
   //     [ USING <expression> ]
-| ALTER opt_column name opt_set_data TYPE typename opt_collate_clause alter_using { unimplemented() }
+| ALTER opt_column name opt_set_data TYPE typename opt_collate_clause alter_using { return unimplemented(sqllex) }
   // ALTER TABLE <name> ADD CONSTRAINT ...
 | ADD table_constraint opt_validate_behavior
   {
@@ -828,7 +829,7 @@ alter_table_cmd:
     }
   }
   // ALTER TABLE <name> ALTER CONSTRAINT ...
-| ALTER CONSTRAINT name { unimplemented() }
+| ALTER CONSTRAINT name { return unimplemented(sqllex) }
   // ALTER TABLE <name> VALIDATE CONSTRAINT ...
 | VALIDATE CONSTRAINT name
   {
@@ -890,11 +891,11 @@ opt_validate_behavior:
   }
 
 opt_collate_clause:
-  COLLATE any_name { unimplementedWithIssue(2473) }
+  COLLATE any_name { return unimplementedWithIssue(sqllex, 2473) }
 | /* EMPTY */ {}
 
 alter_using:
-  USING a_expr { unimplemented() }
+  USING a_expr { return unimplemented(sqllex) }
 | /* EMPTY */ {}
 
 copy_from_stmt:
@@ -1076,7 +1077,7 @@ execute_stmt:
     }
   }
   // CREATE TABLE <name> AS EXECUTE <plan_name> [(params, ...)]
-// | CREATE opt_temp TABLE create_as_target AS EXECUTE name execute_param_clause opt_with_data { unimplemented() }
+// | CREATE opt_temp TABLE create_as_target AS EXECUTE name execute_param_clause opt_with_data { return unimplemented(sqllex) }
 
 execute_param_clause:
   '(' expr_list ')'
@@ -1283,13 +1284,13 @@ generic_set:
 set_rest_more:
   // Generic SET syntaxes:
   generic_set
-| var_name FROM CURRENT { unimplemented() }
+| var_name FROM CURRENT { return unimplemented(sqllex) }
   // Special syntaxes mandated by SQL standard:
 | TIME ZONE zone_value
   {
     $$.val = &SetTimeZone{Value: $3.expr()}
   }
-| NAMES opt_encoding { unimplemented() }
+| NAMES opt_encoding { return unimplemented(sqllex) }
 
 var_name:
   any_name
@@ -1400,8 +1401,8 @@ zone_value:
   }
 
 opt_encoding:
-  SCONST { unimplemented() }
-| DEFAULT { unimplemented() }
+  SCONST { return unimplemented(sqllex) }
+| DEFAULT { return unimplemented(sqllex) }
 | /* EMPTY */ {}
 
 non_reserved_word_or_sconst:
@@ -1636,7 +1637,7 @@ col_qualification:
   {
     $$.val = NamedColumnQualification{Qualification: $1.colQualElem()}
   }
-| COLLATE any_name { unimplemented() }
+| COLLATE any_name { return unimplemented(sqllex) }
 | FAMILY name
   {
     $$.val = NamedColumnQualification{Qualification: &ColumnFamilyConstraint{Family: Name($2)}}
@@ -1810,9 +1811,9 @@ opt_column_list:
   }
 
 key_match:
-  MATCH FULL { unimplemented() }
-| MATCH PARTIAL { unimplemented() }
-| MATCH SIMPLE { unimplemented() }
+  MATCH FULL { return unimplemented(sqllex) }
+| MATCH PARTIAL { return unimplemented(sqllex) }
+| MATCH SIMPLE { return unimplemented(sqllex) }
 | /* EMPTY */ {}
 
 // We combine the update and delete actions into one value temporarily for
@@ -1820,24 +1821,24 @@ key_match:
 // production. update is in the left 8 bits, delete in the right. Note that
 // NOACTION is the default.
 key_actions:
-  key_update { unimplemented() }
-| key_delete { unimplemented() }
-| key_update key_delete { unimplemented() }
-| key_delete key_update { unimplemented() }
+  key_update { return unimplemented(sqllex) }
+| key_delete { return unimplemented(sqllex) }
+| key_update key_delete { return unimplemented(sqllex) }
+| key_delete key_update { return unimplemented(sqllex) }
 | /* EMPTY */ {}
 
 key_update:
-  ON UPDATE key_action { unimplemented() }
+  ON UPDATE key_action { return unimplemented(sqllex) }
 
 key_delete:
-  ON DELETE key_action { unimplemented() }
+  ON DELETE key_action { return unimplemented(sqllex) }
 
 key_action:
-  NO ACTION { unimplemented() }
-| RESTRICT { unimplemented() }
-| CASCADE { unimplemented() }
-| SET NULL { unimplemented() }
-| SET DEFAULT { unimplemented() }
+  NO ACTION { return unimplemented(sqllex) }
+| RESTRICT { return unimplemented(sqllex) }
+| CASCADE { return unimplemented(sqllex) }
+| SET NULL { return unimplemented(sqllex) }
+| SET DEFAULT { return unimplemented(sqllex) }
 
 numeric_only:
   FCONST
@@ -1927,11 +1928,11 @@ index_elem:
   {
     $$.val = IndexElem{Column: Name($1), Direction: $3.dir()}
   }
-| func_expr_windowless opt_collate opt_asc_desc { unimplemented() }
-| '(' a_expr ')' opt_collate opt_asc_desc { unimplemented() }
+| func_expr_windowless opt_collate opt_asc_desc { return unimplemented(sqllex) }
+| '(' a_expr ')' opt_collate opt_asc_desc { return unimplemented(sqllex) }
 
 opt_collate:
-  COLLATE any_name { unimplemented() }
+  COLLATE any_name { return unimplemented(sqllex) }
 | /* EMPTY */ {}
 
 opt_asc_desc:
@@ -2144,14 +2145,14 @@ insert_stmt:
     $$.val.(*Insert).Table = $4.tblExpr()
     $$.val.(*Insert).OnConflict = $6.onConflict()
   }
-| opt_with_clause INSERT INTO insert_target insert_rest on_conflict RETURNING target_list { unimplementedWithIssue(6637) }
+| opt_with_clause INSERT INTO insert_target insert_rest on_conflict RETURNING target_list { return unimplementedWithIssue(sqllex, 6637) }
 | opt_with_clause UPSERT INTO insert_target insert_rest
   {
     $$.val = $5.stmt()
     $$.val.(*Insert).Table = $4.tblExpr()
     $$.val.(*Insert).OnConflict = &OnConflict{}
   }
-| opt_with_clause UPSERT INTO insert_target insert_rest RETURNING target_list { unimplementedWithIssue(6637) }
+| opt_with_clause UPSERT INTO insert_target insert_rest RETURNING target_list { return unimplementedWithIssue(sqllex, 6637) }
 
 // Can't easily make AS optional here, because VALUES in insert_rest would have
 // a shift/reduce conflict with VALUES as an optional alias. We could easily
@@ -2197,7 +2198,7 @@ opt_conf_expr:
     // TODO(dan): Support the where_clause.
     $$.val = $2.nameList()
   }
-| ON CONSTRAINT name { unimplemented() }
+| ON CONSTRAINT name { return unimplemented(sqllex) }
 | /* EMPTY */
   {
     $$.val = NameList(nil)
@@ -2222,7 +2223,7 @@ update_stmt:
 
 // Mark this as unimplemented until the normal from_clause is supported here.
 update_from_clause:
-  FROM from_list { unimplementedWithIssue(7841) }
+  FROM from_list { return unimplementedWithIssue(sqllex, 7841) }
 | /* EMPTY */ {}
 
 set_clause_list:
@@ -2450,19 +2451,19 @@ simple_select:
 //
 // Recognizing WITH_LA here allows a CTE to be named TIME or ORDINALITY.
 with_clause:
-WITH cte_list { unimplemented() }
-| WITH_LA cte_list { unimplemented() }
-| WITH RECURSIVE cte_list { unimplemented() }
+WITH cte_list { return unimplemented(sqllex) }
+| WITH_LA cte_list { return unimplemented(sqllex) }
+| WITH RECURSIVE cte_list { return unimplemented(sqllex) }
 
 cte_list:
-  common_table_expr { unimplemented() }
-| cte_list ',' common_table_expr { unimplemented() }
+  common_table_expr { return unimplemented(sqllex) }
+| cte_list ',' common_table_expr { return unimplemented(sqllex) }
 
 common_table_expr:
-  name opt_name_list AS '(' preparable_stmt ')' { unimplemented() }
+  name opt_name_list AS '(' preparable_stmt ')' { return unimplemented(sqllex) }
 
 opt_with_clause:
-  with_clause { unimplemented() }
+  with_clause { return unimplemented(sqllex) }
 | /* EMPTY */ {}
 
 opt_table:
@@ -2558,7 +2559,7 @@ limit_clause:
   }
 // SQL:2008 syntax
 // TODO(pmattis): Should we support this?
-// | FETCH first_or_next opt_select_fetch_first_value row_or_rows ONLY { unimplemented() }
+// | FETCH first_or_next opt_select_fetch_first_value row_or_rows ONLY { return unimplemented(sqllex) }
 
 offset_clause:
   OFFSET a_expr
@@ -2584,8 +2585,8 @@ select_limit_value:
 // problems with the trailing ROW/ROWS key words. SQL only calls for constants,
 // so we allow the rest only with parentheses. If omitted, default to 1.
 // opt_select_fetch_first_value:
-//   signed_iconst { unimplemented() }
-// | '(' a_expr ')' { unimplemented() }
+//   signed_iconst { return unimplemented(sqllex) }
+// | '(' a_expr ')' { return unimplemented(sqllex) }
 // | /* EMPTY */ {}
 
 // noise words
@@ -2594,8 +2595,8 @@ row_or_rows:
 | ROWS {}
 
 // first_or_next:
-//   FIRST { unimplemented() }
-// | NEXT { unimplemented() }
+//   FIRST { return unimplemented(sqllex) }
+// | NEXT { return unimplemented(sqllex) }
 
 // This syntax for group_clause tries to follow the spec quite closely.
 // However, the spec allows only column references, not expressions,
@@ -2926,12 +2927,12 @@ typename:
     $$.val = $1.colType()
   }
   // SQL standard syntax, currently only one-dimensional
-| simple_typename ARRAY '[' ICONST ']' { unimplementedWithIssue(2115) }
-| simple_typename ARRAY { unimplementedWithIssue(2115) }
+| simple_typename ARRAY '[' ICONST ']' { return unimplementedWithIssue(sqllex, 2115) }
+| simple_typename ARRAY { return unimplementedWithIssue(sqllex, 2115) }
 
 opt_array_bounds:
-  opt_array_bounds '[' ']' { unimplementedWithIssue(2115) }
-| opt_array_bounds '[' ICONST ']' { unimplementedWithIssue(2115) }
+  opt_array_bounds '[' ']' { return unimplementedWithIssue(sqllex, 2115) }
+| opt_array_bounds '[' ICONST ']' { return unimplementedWithIssue(sqllex, 2115) }
 | /* EMPTY */ {}
 
 simple_typename:
@@ -2940,7 +2941,7 @@ simple_typename:
 | character
 | const_datetime
 | const_interval opt_interval // TODO(pmattis): Support opt_interval?
-| const_interval '(' ICONST ')' { unimplemented() }
+| const_interval '(' ICONST ')' { return unimplemented(sqllex) }
 | BLOB
   {
     $$.val = bytesColTypeBlob
@@ -3220,24 +3221,24 @@ const_interval:
   }
 
 opt_interval:
-  YEAR { unimplemented() }
-| MONTH { unimplemented() }
-| DAY { unimplemented() }
-| HOUR { unimplemented() }
-| MINUTE { unimplemented() }
-| interval_second { unimplemented() }
-| YEAR TO MONTH { unimplemented() }
-| DAY TO HOUR { unimplemented() }
-| DAY TO MINUTE { unimplemented() }
-| DAY TO interval_second { unimplemented() }
-| HOUR TO MINUTE { unimplemented() }
-| HOUR TO interval_second { unimplemented() }
-| MINUTE TO interval_second { unimplemented() }
+  YEAR { return unimplemented(sqllex) }
+| MONTH { return unimplemented(sqllex) }
+| DAY { return unimplemented(sqllex) }
+| HOUR { return unimplemented(sqllex) }
+| MINUTE { return unimplemented(sqllex) }
+| interval_second { return unimplemented(sqllex) }
+| YEAR TO MONTH { return unimplemented(sqllex) }
+| DAY TO HOUR { return unimplemented(sqllex) }
+| DAY TO MINUTE { return unimplemented(sqllex) }
+| DAY TO interval_second { return unimplemented(sqllex) }
+| HOUR TO MINUTE { return unimplemented(sqllex) }
+| HOUR TO interval_second { return unimplemented(sqllex) }
+| MINUTE TO interval_second { return unimplemented(sqllex) }
 | /* EMPTY */ {}
 
 interval_second:
-  SECOND { unimplemented() }
-| SECOND '(' ICONST ')' { unimplemented() }
+  SECOND { return unimplemented(sqllex) }
+| SECOND '(' ICONST ')' { return unimplemented(sqllex) }
 
 // General expressions. This is the heart of the expression syntax.
 //
@@ -3268,8 +3269,8 @@ a_expr:
   {
     $$.val = &AnnotateTypeExpr{Expr: $1.expr(), Type: $3.colType(), syntaxMode: annotateShort}
   }
-| a_expr COLLATE any_name { unimplemented() }
-| a_expr AT TIME ZONE a_expr %prec AT { unimplemented() }
+| a_expr COLLATE any_name { return unimplemented(sqllex) }
+| a_expr AT TIME ZONE a_expr %prec AT { return unimplemented(sqllex) }
   // These operators must be called out explicitly in order to make use of
   // bison's automatic operator-precedence handling. All other operator names
   // are handled by the generic productions using "OP", below; and all those
@@ -3429,7 +3430,7 @@ a_expr:
   {
     $$.val = &ComparisonExpr{Operator: IsNot, Left: $1.expr(), Right: DNull}
   }
-| row OVERLAPS row { unimplemented() }
+| row OVERLAPS row { return unimplemented(sqllex) }
 | a_expr IS TRUE %prec IS
   {
     $$.val = &ComparisonExpr{Operator: Is, Left: $1.expr(), Right: MakeDBool(true)}
@@ -3494,9 +3495,9 @@ a_expr:
   {
     $$.val = &ComparisonExpr{Operator: NotIn, Left: $1.expr(), Right: $4.expr()}
   }
-// | a_expr subquery_op sub_type select_with_parens %prec CONCAT { unimplemented() }
-// | a_expr subquery_op sub_type '(' a_expr ')' %prec CONCAT { unimplemented() }
-// | UNIQUE select_with_parens { unimplemented() }
+// | a_expr subquery_op sub_type select_with_parens %prec CONCAT { return unimplemented(sqllex) }
+// | a_expr subquery_op sub_type '(' a_expr ')' %prec CONCAT { return unimplemented(sqllex) }
+// | UNIQUE select_with_parens { return unimplemented(sqllex) }
 
 // Restricted expressions
 //
@@ -3655,7 +3656,7 @@ c_expr:
     $$.val = &ExistsExpr{Subquery: &Subquery{Select: $2.selectStmt()}}
   }
 // TODO(pmattis): Support this notation?
-// | ARRAY select_with_parens { unimplemented() }
+// | ARRAY select_with_parens { return unimplemented(sqllex) }
 | ARRAY array_expr
   {
     $$.val = $2.expr()
@@ -3669,7 +3670,7 @@ c_expr:
     $$.val = $1.expr()
   }
 // TODO(pmattis): Support this notation?
-// | GROUPING '(' expr_list ')' { unimplemented() }
+// | GROUPING '(' expr_list ')' { return unimplemented(sqllex) }
 
 func_application:
   func_name '(' ')'
@@ -3680,8 +3681,8 @@ func_application:
   {
     $$.val = &FuncExpr{Name: $1.normalizableFunctionName(), Exprs: $3.exprs()}
   }
-| func_name '(' VARIADIC a_expr opt_sort_clause ')' { unimplemented() }
-| func_name '(' expr_list ',' VARIADIC a_expr opt_sort_clause ')' { unimplemented() }
+| func_name '(' VARIADIC a_expr opt_sort_clause ')' { return unimplemented(sqllex) }
+| func_name '(' expr_list ',' VARIADIC a_expr opt_sort_clause ')' { return unimplemented(sqllex) }
 | func_name '(' ALL expr_list opt_sort_clause ')'
   {
     $$.val = &FuncExpr{Name: $1.normalizableFunctionName(), Type: All, Exprs: $4.exprs()}
@@ -3719,12 +3720,12 @@ func_expr:
 // expressions are not allowed, where needed to disambiguate the grammar
 // (e.g. in CREATE INDEX).
 func_expr_windowless:
-  func_application { unimplemented() }
-| func_expr_common_subexpr { unimplemented() }
+  func_application { return unimplemented(sqllex) }
+| func_expr_common_subexpr { return unimplemented(sqllex) }
 
 // Special expressions that are considered to be functions.
 func_expr_common_subexpr:
-  COLLATION FOR '(' a_expr ')' { unimplemented() }
+  COLLATION FOR '(' a_expr ')' { return unimplemented(sqllex) }
 | CURRENT_DATE
   {
     $$.val = &FuncExpr{Name: WrapQualifiedFunctionName($1)}
@@ -3741,10 +3742,10 @@ func_expr_common_subexpr:
   {
     $$.val = &FuncExpr{Name: WrapQualifiedFunctionName($1)}
   }
-| CURRENT_ROLE { unimplemented() }
-| CURRENT_USER { unimplemented() }
-| SESSION_USER { unimplemented() }
-| USER { unimplemented() }
+| CURRENT_ROLE { return unimplemented(sqllex) }
+| CURRENT_USER { return unimplemented(sqllex) }
+| SESSION_USER { return unimplemented(sqllex) }
+| USER { return unimplemented(sqllex) }
 | CAST '(' a_expr AS typename ')'
   {
     $$.val = &CastExpr{Expr: $3.expr(), Type: $5.colType(), syntaxMode: castExplicit}
@@ -3773,7 +3774,7 @@ func_expr_common_subexpr:
   {
     $$.val = &FuncExpr{Name: WrapQualifiedFunctionName($1), Exprs: $3.exprs()}
   }
-| TREAT '(' a_expr AS typename ')' { unimplemented() }
+| TREAT '(' a_expr AS typename ')' { return unimplemented(sqllex) }
 | TRIM '(' BOTH trim_list ')'
   {
     $$.val = &FuncExpr{Name: WrapQualifiedFunctionName("BTRIM"), Exprs: $4.exprs()}
@@ -3817,11 +3818,11 @@ func_expr_common_subexpr:
 
 // Aggregate decoration clauses
 within_group_clause:
-WITHIN GROUP '(' sort_clause ')' { unimplemented() }
+WITHIN GROUP '(' sort_clause ')' { return unimplemented(sqllex) }
 | /* EMPTY */ {}
 
 filter_clause:
-  FILTER '(' WHERE a_expr ')' { unimplemented() }
+  FILTER '(' WHERE a_expr ')' { return unimplemented(sqllex) }
 | /* EMPTY */ {}
 
 // Window Definitions
@@ -3909,23 +3910,23 @@ opt_partition_clause:
 // This is only a subset of the full SQL:2008 frame_clause grammar. We don't
 // support <window frame exclusion> yet.
 opt_frame_clause:
-  RANGE frame_extent { unimplemented() }
-| ROWS frame_extent { unimplemented() }
+  RANGE frame_extent { return unimplemented(sqllex) }
+| ROWS frame_extent { return unimplemented(sqllex) }
 | /* EMPTY */ {}
 
 frame_extent:
-  frame_bound { unimplemented() }
-| BETWEEN frame_bound AND frame_bound { unimplemented() }
+  frame_bound { return unimplemented(sqllex) }
+| BETWEEN frame_bound AND frame_bound { return unimplemented(sqllex) }
 
 // This is used for both frame start and frame end, with output set up on the
 // assumption it's frame start; the frame_extent productions must reject
 // invalid cases.
 frame_bound:
-  UNBOUNDED PRECEDING { unimplemented() }
-| UNBOUNDED FOLLOWING { unimplemented() }
-| CURRENT ROW { unimplemented() }
-| a_expr PRECEDING { unimplemented() }
-| a_expr FOLLOWING { unimplemented() }
+  UNBOUNDED PRECEDING { return unimplemented(sqllex) }
+| UNBOUNDED FOLLOWING { return unimplemented(sqllex) }
+| CURRENT ROW { return unimplemented(sqllex) }
+| a_expr PRECEDING { return unimplemented(sqllex) }
+| a_expr FOLLOWING { return unimplemented(sqllex) }
 
 // Supporting nonterminals for expressions.
 
@@ -3965,34 +3966,34 @@ implicit_row:
   }
 
 // sub_type:
-//   ANY { unimplemented() }
-// | SOME { unimplemented() }
-// | ALL { unimplemented() }
+//   ANY { return unimplemented(sqllex) }
+// | SOME { return unimplemented(sqllex) }
+// | ALL { return unimplemented(sqllex) }
 
 // math_op:
-//   '+' { unimplemented() }
-// | '-' { unimplemented() }
-// | '*' { unimplemented() }
-// | '/' { unimplemented() }
-// | '%' { unimplemented() }
-// | '&' { unimplemented() }
-// | '|' { unimplemented() }
-// | '^' { unimplemented() }
-// | '#' { unimplemented() }
-// | '<' { unimplemented() }
-// | '>' { unimplemented() }
-// | '=' { unimplemented() }
-// | CONCAT { unimplemented() }
-// | LESS_EQUALS { unimplemented() }
-// | GREATER_EQUALS { unimplemented() }
-// | NOT_EQUALS { unimplemented() }
+//   '+' { return unimplemented(sqllex) }
+// | '-' { return unimplemented(sqllex) }
+// | '*' { return unimplemented(sqllex) }
+// | '/' { return unimplemented(sqllex) }
+// | '%' { return unimplemented(sqllex) }
+// | '&' { return unimplemented(sqllex) }
+// | '|' { return unimplemented(sqllex) }
+// | '^' { return unimplemented(sqllex) }
+// | '#' { return unimplemented(sqllex) }
+// | '<' { return unimplemented(sqllex) }
+// | '>' { return unimplemented(sqllex) }
+// | '=' { return unimplemented(sqllex) }
+// | CONCAT { return unimplemented(sqllex) }
+// | LESS_EQUALS { return unimplemented(sqllex) }
+// | GREATER_EQUALS { return unimplemented(sqllex) }
+// | NOT_EQUALS { return unimplemented(sqllex) }
 
 // subquery_op:
-//   math_op { unimplemented() }
-// | LIKE { unimplemented() }
-// | NOT_LA LIKE { unimplemented() }
-// | ILIKE { unimplemented() }
-// | NOT_LA ILIKE { unimplemented() }
+//   math_op { return unimplemented(sqllex) }
+// | LIKE { return unimplemented(sqllex) }
+// | NOT_LA LIKE { return unimplemented(sqllex) }
+// | ILIKE { return unimplemented(sqllex) }
+// | NOT_LA ILIKE { return unimplemented(sqllex) }
   // cannot put SIMILAR TO here, because SIMILAR TO is a hack.
   // the regular expression is preprocessed by a function (similar_escape),
   // and the ~ operator for posix regular expressions is used.
@@ -4454,7 +4455,7 @@ a_expr_const:
   {
     $$.val = &StrVal{s: $1, bytesEsc: true}
   }
-| func_name '(' expr_list opt_sort_clause ')' SCONST { unimplemented() }
+| func_name '(' expr_list opt_sort_clause ')' SCONST { return unimplemented(sqllex) }
 | const_typename SCONST
   {
     $$.val = &CastExpr{Expr: &StrVal{s: $2}, Type: $1.colType(), syntaxMode: castPrefix}


### PR DESCRIPTION
Prior to this patch the SQL parser (generated by go-yacc) would use
panic() as a primitive form of exception and the panic would be caught
in the immediate caller to the yacc-generated `Parse` function.

This patch capitalizes on the fact that yacc uses LALR with a single
function iterating through the token string, and uses Go's `return`
directly to signal errors to `Parse`'s caller.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9887)

<!-- Reviewable:end -->
