### PR TITLE
storage: mark MergeRequests as "non KV"

### DIFF
--- a/roachpb/api.go
+++ b/roachpb/api.go
@@ -791,8 +791,12 @@ func (*RangeLookupRequest) flags() int        { return isRead }
 func (*ResolveIntentRequest) flags() int      { return isWrite }
 func (*ResolveIntentRangeRequest) flags() int { return isWrite | isRange }
 func (*NoopRequest) flags() int               { return isRead } // slightly special
-func (*MergeRequest) flags() int              { return isWrite }
 func (*TruncateLogRequest) flags() int        { return isWrite | isNonKV }
+
+// MergeRequests are considered "non KV" because they do not need to be gated
+// by the command queue (reordering is ok) and they operate on non-MVCC data so
+// the timestamp cache is also unnecessary.
+func (*MergeRequest) flags() int { return isWrite | isNonKV }
 
 func (*RequestLeaseRequest) flags() int {
 	return isWrite | isAlone | isNonKV | skipLeaseCheck

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -132,10 +132,15 @@ func (ba *BatchRequest) IsSingleRequest() bool {
 	return len(ba.Requests) == 1
 }
 
-// IsSingleNonKVRequest returns true iff the batch contains a single
-// request, and that request has the non-KV flag set.
-func (ba *BatchRequest) IsSingleNonKVRequest() bool {
-	return ba.IsSingleRequest() && ba.hasFlag(isNonKV)
+// IsNonKV returns true iff all of the requests in the batch have the non-KV
+// flag set.
+func (ba *BatchRequest) IsNonKV() bool {
+	for _, union := range ba.Requests {
+		if (union.GetInner().flags() & isNonKV) == 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // IsSingleSkipLeaseCheckRequest returns true iff the batch contains a single

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1430,7 +1430,7 @@ func (r *Replica) addReadOnlyCmd(
 	}
 
 	var endCmdsFunc func(*roachpb.BatchResponse, *roachpb.Error) *roachpb.Error
-	if !ba.IsSingleNonKVRequest() {
+	if !ba.IsNonKV() {
 		// Add the read to the command queue to gate subsequent
 		// overlapping commands until this command completes.
 		log.Event(ctx, "command queue")
@@ -1502,7 +1502,7 @@ func (r *Replica) assert5725(ba roachpb.BatchRequest) {
 func (r *Replica) addWriteCmd(
 	ctx context.Context, ba roachpb.BatchRequest,
 ) (br *roachpb.BatchResponse, pErr *roachpb.Error) {
-	isNonKV := ba.IsSingleNonKVRequest()
+	isNonKV := ba.IsNonKV()
 	if !isNonKV {
 		// Add the write to the command queue to gate subsequent overlapping
 		// commands until this command completes. Note that this must be


### PR DESCRIPTION
Mark MergeRequests as "non KV" so that the skip the command queue and
timestamp cache. Merge requests can be reordered without issue obviating
the need for the command queue. Since there is no MVCC for merge requests
the timestamp cache isn't necessary. In simple local testing the command
queue processing was sometimes taking single-digits of milliseconds.

See #9818

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9889)

<!-- Reviewable:end -->
