### PR TITLE
log: AmbientContext helper for annotating contexts

### DIFF
--- a/pkg/util/log/ambient_context.go
+++ b/pkg/util/log/ambient_context.go
@@ -1,0 +1,128 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde
+
+package log
+
+import (
+	opentracing "github.com/opentracing/opentracing-go"
+	otlog "github.com/opentracing/opentracing-go/log"
+	"golang.org/x/net/context"
+	"golang.org/x/net/trace"
+)
+
+// AmbientContext is a helper type used to "annotate" context.Contexts with log
+// tags and a Tracer or EventLog.
+//
+// Example:
+//
+//   ac := AmbientContext{Tracer: tracing.NewTracer()}
+//   ac.AddLogTag("n", 1)
+//
+//   // on an operation with context ctx
+//   ctx = ac.AnnotateCtx(ctx)
+//   ...
+//
+//   // start a background operation
+//   ctx, span := ac.AnnotateCtxWithSpan(context.Background(), "some-op")
+//   defer span.Finish()
+//   ...
+type AmbientContext struct {
+	// Tracer is used to open spans (see AnnotateCtxWithSpan).
+	Tracer opentracing.Tracer
+
+	// EventLog will be embedded into contexts that don't already have an event
+	// log or an open span (if not nil).
+	EventLog trace.EventLog
+
+	tags *logTag
+}
+
+func (ac *AmbientContext) addTag(field otlog.Field) {
+	ac.tags = &logTag{Field: field, parent: ac.tags}
+}
+
+// AddLogTag adds a tag; see WithLogTag.
+func (ac *AmbientContext) AddLogTag(name string, value interface{}) {
+	ac.addTag(otlog.Object(name, value))
+}
+
+// AddLogTagInt adds an integer tag; see WithLogTagInt.
+func (ac *AmbientContext) AddLogTagInt(name string, value int) {
+	ac.addTag(otlog.Int(name, value))
+}
+
+// AddLogTagInt64 adds an integer tag; see WithLogTagInt64.
+func (ac *AmbientContext) AddLogTagInt64(name string, value int64) {
+	ac.addTag(otlog.Int64(name, value))
+}
+
+// AddLogTagStr adds a string tag; see WithLogTagStr.
+func (ac *AmbientContext) AddLogTagStr(name string, value string) {
+	ac.addTag(otlog.String(name, value))
+}
+
+// AnnotateCtx annotates a given context with the information in AmbientContext:
+//  - the EventLog is embedded in the context if the context doesn't already
+//    have en event log or an open trace.
+//  - the log tags in AmbientContext are added (if ctx doesn't already have them).
+//
+// For background operations, context.Background() should be passed; however, in
+// that case it is strongly recommended to open a span if possible (using
+// AnnotateCtxWithSpan).
+func (ac *AmbientContext) AnnotateCtx(ctx context.Context) context.Context {
+	// TODO(radu): We could keep a cached context based off of
+	// context.Background() to avoid allocations in that case.
+	if ac.EventLog != nil && opentracing.SpanFromContext(ctx) == nil && eventLogFromCtx(ctx) == nil {
+		ctx = withEventLogInternal(ctx, ac.EventLog)
+	}
+	if ac.tags != nil {
+		ctx = copyTagChain(ctx, ac.tags)
+	}
+	return ctx
+}
+
+// AnnotateCtxWithSpan annotates the given context with the information in
+// AmbientContext (see AnnotateCtx) and opens a span.
+//
+// If the given context has a span, the new span is a child of that span.
+// Otherwise, the Tracer in AmbientContext is used to create a new root span.
+//
+// The caller is responsible for closing the span (via Span.Finish).
+func (ac *AmbientContext) AnnotateCtxWithSpan(
+	ctx context.Context, opName string,
+) (context.Context, opentracing.Span) {
+	if ac.tags != nil {
+		ctx = copyTagChain(ctx, ac.tags)
+	}
+
+	var span opentracing.Span
+	if parentSpan := opentracing.SpanFromContext(ctx); parentSpan != nil {
+		tracer := parentSpan.Tracer()
+		span = tracer.StartSpan(opName, opentracing.ChildOf(parentSpan.Context()))
+	} else {
+		if ac.Tracer == nil {
+			panic("no tracer in AmbientContext for root span")
+		}
+		span = ac.Tracer.StartSpan(opName)
+	}
+	return opentracing.ContextWithSpan(ctx, span), span
+}
+
+// TODO(radu): remove once they start getting used.
+var _ = AmbientContext{}.Tracer
+var _ = (*AmbientContext).AddLogTagInt
+var _ = (*AmbientContext).AddLogTagInt64
+var _ = (*AmbientContext).AddLogTagStr

--- a/pkg/util/log/ambient_context_test.go
+++ b/pkg/util/log/ambient_context_test.go
@@ -1,0 +1,87 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde
+
+package log
+
+import (
+	"testing"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	"golang.org/x/net/context"
+)
+
+func TestAnnotateCtxTags(t *testing.T) {
+	ac := AmbientContext{}
+	ac.AddLogTag("a", 1)
+	ac.AddLogTag("b", 2)
+
+	ctx := ac.AnnotateCtx(context.Background())
+	if exp, val := "[a1,b2] test", makeMessage(ctx, "test", nil); val != exp {
+		t.Errorf("expected '%s', got '%s'", exp, val)
+	}
+
+	ctx = context.Background()
+	ctx = WithLogTag(ctx, "a", 10)
+	ctx = WithLogTag(ctx, "aa", nil)
+	ctx = ac.AnnotateCtx(ctx)
+
+	if exp, val := "[a10,aa,b2] test", makeMessage(ctx, "test", nil); val != exp {
+		t.Errorf("expected '%s', got '%s'", exp, val)
+	}
+}
+
+func TestAnnotateCtxSpan(t *testing.T) {
+	var traceEv events
+	tracer := testingTracer(&traceEv)
+
+	ac := AmbientContext{}
+	ac.EventLog = &testingEventLog{}
+	ac.AddLogTag("ambient", nil)
+
+	// Annotate a context that has an open span.
+
+	sp1 := tracer.StartSpan("root")
+	ctx1 := opentracing.ContextWithSpan(context.Background(), sp1)
+	Event(ctx1, "a")
+
+	ctx2, sp2 := ac.AnnotateCtxWithSpan(ctx1, "child")
+	Event(ctx2, "b")
+
+	Event(ctx1, "c")
+	sp2.Finish()
+	sp1.Finish()
+
+	if expected := (events{
+		"root:start", "root:a", "child:start", "child:[ambient] b", "root:c", "child:finish",
+		"root:finish",
+	}); !compareTraces(expected, traceEv) {
+		t.Errorf("expected events '%s', got '%v'", expected, traceEv)
+	}
+
+	// Annotate a context that has no span.
+
+	traceEv = nil
+	ac.Tracer = tracer
+	ctx, sp := ac.AnnotateCtxWithSpan(context.Background(), "s")
+	Event(ctx, "a")
+	sp.Finish()
+
+	if expected := (events{
+		"s:start", "s:[ambient] a", "s:finish",
+	}); !compareTraces(expected, traceEv) {
+		t.Errorf("expected events '%s', got '%v'", expected, traceEv)
+	}
+}

--- a/pkg/util/log/log_context_test.go
+++ b/pkg/util/log/log_context_test.go
@@ -63,7 +63,7 @@ func TestLogContext(t *testing.T) {
 
 	for i, tc := range testCases {
 		if value := makeMessage(tc.ctx, "test", nil); value != tc.expected {
-			t.Errorf("Test case %d failed: expected '%s', got '%s'", i, tc.expected, value)
+			t.Errorf("test case %d failed: expected '%s', got '%s'", i, tc.expected, value)
 		}
 	}
 }
@@ -129,7 +129,7 @@ func TestWithLogTagsFromCtx(t *testing.T) {
 
 	for i, tc := range testCases {
 		if value := makeMessage(tc.ctx, "test", nil); value != tc.expected {
-			t.Errorf("Test case %d failed: expected '%s', got '%s'", i, tc.expected, value)
+			t.Errorf("test case %d failed: expected '%s', got '%s'", i, tc.expected, value)
 		}
 	}
 }


### PR DESCRIPTION
This helper will be stored in various server components and will replace the
"background" contexts we use directly. See #9807 for more information.

Posting this before actually changing anything else to nail down the details before modifying too much code.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9893)

<!-- Reviewable:end -->
