### PR TITLE
storage: deflake TestConcurrentRaftSnapshots

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -626,10 +626,10 @@ func (sc *StoreConfig) Valid() bool {
 		sc.Ctx != nil && sc.Ctx.Done() == nil && tracing.TracerFromCtx(sc.Ctx) != nil
 }
 
-// setDefaults initializes unset fields in StoreConfig to values
+// SetDefaults initializes unset fields in StoreConfig to values
 // suitable for use on a local network.
 // TODO(tschottdorf) see if this ought to be configurable via flags.
-func (sc *StoreConfig) setDefaults() {
+func (sc *StoreConfig) SetDefaults() {
 	if (sc.RangeRetryOptions == retry.Options{}) {
 		sc.RangeRetryOptions = base.DefaultRetryOptions()
 	}
@@ -663,7 +663,7 @@ func (sc *StoreConfig) setDefaults() {
 // NewStore returns a new instance of a store.
 func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescriptor) *Store {
 	// TODO(tschottdorf) find better place to set these defaults.
-	cfg.setDefaults()
+	cfg.SetDefaults()
 
 	if !cfg.Valid() {
 		panic(fmt.Sprintf("invalid store configuration: %+v", &cfg))


### PR DESCRIPTION
Don't expireLeases if a store is stopped as doing so causes unexpected
lease transfers in tests.

Rework multiTestContext.addStore so that it respects the configured
RaftElectionTimeoutTicks instead of always using the defaults.

Fixes #9903

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9905)

<!-- Reviewable:end -->
