### PR TITLE
storage: fix TestTxnObeysLeaseExpiration

### DIFF
--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -800,12 +800,6 @@ func (tc *TxnCoordSender) updateState(
 	}
 
 	switch t := pErr.GetDetail().(type) {
-	case *roachpb.TransactionStatusError:
-		// Likely already committed or more obscure errors such as epoch or
-		// timestamp regressions; consider txn dead.
-		if txn := pErr.GetTxn(); txn != nil {
-			defer tc.cleanupTxnLocked(ctx, *txn)
-		}
 	case *roachpb.OpRequiresTxnError:
 		panic("OpRequiresTxnError must not happen at this level")
 	case *roachpb.ReadWithinUncertaintyIntervalError:
@@ -840,16 +834,12 @@ func (tc *TxnCoordSender) updateState(
 	case nil:
 		// Nothing to do here, avoid the default case.
 	default:
-		// Do not clean up the transaction here since the client might still
-		// want to continue the transaction. For example, a client might
-		// continue its transaction after receiving ConditionFailedError, which
-		// can come from a unique index violation.
-		//
-		// TODO(bdarnell): Is this valid? Unless there is a single CPut in
-		// the batch, it is difficult to be able to continue after a
-		// ConditionFailedError because it is unclear which parts of the
-		// batch had succeeded on other ranges before one range hit the
-		// failed condition. It may be better to clean up the transaction here.
+		// Do not clean up the transaction since we're leaving cancellation of
+		// the transaction up to the client. For example, on seeing an error,
+		// like TransactionStatusError or ConditionFailedError, the client
+		// will call Txn.CleanupOnError() which will cleanup the transaction
+		// and its intents. Therefore leave the transaction in the PENDING
+		// state and do not call cleanTxnLocked().
 	}
 
 	txnID := *newTxn.ID

--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -464,7 +464,11 @@ func TestTxnCoordSenderEndTxn(t *testing.T) {
 				}
 			case 1:
 				// Past deadline.
-				assertTransactionAbortedError(t, err)
+				if statusError, ok := err.(*roachpb.TransactionStatusError); !ok {
+					t.Fatalf("expected TransactionStatusError but got %T: %s", err, err)
+				} else if expected := "transaction deadline exceeded"; statusError.Msg != expected {
+					t.Fatalf("expected %s, got %s", expected, statusError.Msg)
+				}
 			case 2:
 				// Equal deadline.
 				if err != nil {

--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"sync"
 	"testing"
-	"time"
 
 	"golang.org/x/net/context"
 
@@ -38,7 +37,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -586,20 +584,18 @@ CREATE TABLE test.t(a INT PRIMARY KEY);
 	}
 }
 
-// TestTxnObeysLeaseExpiration tests that a transaction is aborted when it tries
-// to use a table descriptor with an expired lease.
+// TestTxnObeysLeaseExpiration tests that a transaction is aborted when it
+// uses a table descriptor with an expired lease.
 func TestTxnObeysLeaseExpiration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("TODO(vivek): #7031")
-	// Set the lease duration such that it expires quickly.
-	savedLeaseDuration, savedMinLeaseDuration := csql.LeaseDuration, csql.MinLeaseDuration
-	defer func() {
-		csql.LeaseDuration, csql.MinLeaseDuration = savedLeaseDuration, savedMinLeaseDuration
-	}()
-	csql.MinLeaseDuration = 100 * time.Millisecond
-	csql.LeaseDuration = 2 * csql.MinLeaseDuration
-
 	params, _ := createTestServerParams()
+	params.Knobs = base.TestingKnobs{
+		SQLLeaseManager: &csql.LeaseManagerTestingKnobs{
+			LeaseStoreTestingKnobs: csql.LeaseStoreTestingKnobs{
+				CanUseExpiredLeases: true,
+			},
+		},
+	}
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop()
 	leaseManager := s.LeaseManager().(*csql.LeaseManager)
@@ -612,39 +608,24 @@ INSERT INTO t.kv VALUES ('a', 'b');
 		t.Fatal(err)
 	}
 
-	// Run a number of sql operations and expire the lease they acquire.
-	runCommandAndExpireLease(t, leaseManager, s.Clock(), sqlDB, `INSERT INTO t.kv VALUES ('c', 'd')`)
-	runCommandAndExpireLease(t, leaseManager, s.Clock(), sqlDB, `UPDATE t.kv SET v = 'd' WHERE k = 'a'`)
-	runCommandAndExpireLease(t, leaseManager, s.Clock(), sqlDB, `DELETE FROM t.kv WHERE k = 'a'`)
-	runCommandAndExpireLease(t, leaseManager, s.Clock(), sqlDB, `TRUNCATE TABLE t.kv`)
-}
+	// The above INSERT has acquired a lease on the table; expire the lease.
+	// This lease while expired will still be used by the SQL commands below
+	// because CanUseExpiredLeases is set. The SQL commands will set the
+	// transaction deadline to the lease expiration time (in the past), and
+	// the transaction will eventually fail with a deadline exceeded error.
+	leaseManager.ExpireLeases(s.Clock())
 
-func runCommandAndExpireLease(
-	t *testing.T, leaseManager *csql.LeaseManager, clock *hlc.Clock, sqlDB *gosql.DB, sql string,
-) {
-	// Run a transaction that lets its table lease expire.
-	txn, err := sqlDB.Begin()
-	if err != nil {
-		t.Fatal(err)
+	testCases := []string{
+		`INSERT INTO t.kv VALUES ('c', 'd')`,
+		`UPDATE t.kv SET v = 'd' WHERE k = 'a'`,
+		`DELETE FROM t.kv WHERE k = 'a'`,
+		`TRUNCATE TABLE t.kv`,
 	}
-	// Use snapshot isolation so that the transaction is pushed without being
-	// restarted.
-	if _, err := txn.Exec("SET TRANSACTION ISOLATION LEVEL SNAPSHOT"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := txn.Exec(sql); err != nil {
-		t.Fatal(err)
-	}
-
-	leaseManager.ExpireLeases(clock)
-
-	// Run another transaction that pushes the above transaction.
-	if _, err := sqlDB.Query("SELECT * FROM t.kv"); err != nil {
-		t.Fatal(err)
-	}
-
-	// Commit and see the aborted txn.
-	if err := txn.Commit(); !testutils.IsError(err, "pq: restart transaction: txn aborted") {
-		t.Fatalf("%s, err = %v", sql, err)
+	for _, testCase := range testCases {
+		t.Run(testCase, func(t *testing.T) {
+			if _, err := sqlDB.Exec(testCase); !testutils.IsError(err, "pq: transaction deadline exceeded") {
+				t.Fatal(err)
+			}
+		})
 	}
 }

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -398,6 +398,8 @@ func (ts *txnState) updateStateAndCleanupOnErr(err error, e *Executor) {
 	if _, ok := err.(*roachpb.RetryableTxnError); !ok || !ts.willBeRetried() {
 		// We can't or don't want to retry this txn, so the txn is over.
 		e.TxnAbortCount.Inc(1)
+		// This call rolls back a PENDING transaction and cleans up all its
+		// intents.
 		ts.txn.CleanupOnError(err)
 		ts.resetStateAndTxn(Aborted)
 	} else {

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -589,16 +589,14 @@ func (r *Replica) EndTransaction(
 	reply.Txn.Timestamp.Forward(h.Txn.Timestamp)
 
 	if isEndTransactionExceedingDeadline(reply.Txn.Timestamp, args) {
-		reply.Txn.Status = roachpb.ABORTED
-		// FIXME(#3037):
-		// If the deadline has lapsed, return all the intents for
-		// resolution. Unfortunately, since we're (a) returning an error,
-		// and (b) not able to write on error (see #1989), we can't write
-		// ABORTED into the master transaction record, which remains
-		// PENDING, and that's pretty bad.
-		return reply,
-			intentsToProposalData(roachpb.AsIntents(args.IntentSpans, reply.Txn), &args),
-			roachpb.NewTransactionAbortedError()
+		// If the deadline has lapsed return an error and rely on the client
+		// issuing a Rollback() that aborts the transaction and cleans up
+		// intents. Unfortunately, we're returning an error and unable to
+		// write on error (see #1989): we can't write ABORTED into the master
+		// transaction record which remains PENDING, and thus rely on the
+		// client to issue a Rollback() for cleanup.
+		return reply, ProposalData{}, roachpb.NewTransactionStatusError(
+			"transaction deadline exceeded")
 	}
 
 	// Set transaction status to COMMITTED or ABORTED as per the

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -2446,8 +2446,10 @@ func TestEndTransactionDeadline(t *testing.T) {
 				}
 			case 1:
 				// Past deadline.
-				if _, ok := pErr.GetDetail().(*roachpb.TransactionAbortedError); !ok {
-					t.Errorf("expected TransactionAbortedError but got %T: %s", pErr, pErr)
+				if statusError, ok := pErr.GetDetail().(*roachpb.TransactionStatusError); !ok {
+					t.Errorf("expected TransactionStatusError but got %T: %s", pErr, pErr)
+				} else if e := "transaction deadline exceeded"; statusError.Msg != e {
+					t.Errorf("expected %s, got %s", e, statusError.Msg)
 				}
 			case 2:
 				// Equal deadline.
@@ -2573,8 +2575,10 @@ func TestEndTransactionDeadline_1PC(t *testing.T) {
 	ba.Header = etH
 	ba.Add(&bt, &put, &et)
 	_, pErr := tc.Sender().Send(context.Background(), ba)
-	if _, ok := pErr.GetDetail().(*roachpb.TransactionAbortedError); !ok {
-		t.Errorf("expected TransactionAbortedError but got %T: %s", pErr, pErr)
+	if statusError, ok := pErr.GetDetail().(*roachpb.TransactionStatusError); !ok {
+		t.Errorf("expected TransactionStatusError but got %T: %s", pErr, pErr)
+	} else if e := "transaction deadline exceeded"; statusError.Msg != e {
+		t.Errorf("expected %s, got %s", e, statusError.Msg)
 	}
 }
 


### PR DESCRIPTION
Return an error with the transaction in the PENDING state
when a transaction doesn't meet its deadline. This allows
the client to issue a Rollback() that cleans up the transaction
intents. This mechanism is a bit unreliable because if the client
fails before issuing a Rollback(), the transaction remains pending
with the intents alive. But it is deemed to be a good solution for
the deadline exceeds case, which is a rare event. A rare failure
followed by a rare client failure will result in intents lying
around until the transaction record itself expires.

fixes #7031

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9906)

<!-- Reviewable:end -->
