### PR TITLE
storage: deflake TestRangeQuiescence

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -2635,7 +2635,7 @@ func TestRangeQuiescence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	sc := storage.TestStoreConfig()
-	sc.RaftTickInterval = 1 * time.Millisecond
+	sc.RaftTickInterval = 10 * time.Millisecond
 	sc.RaftHeartbeatIntervalTicks = 2
 	sc.RaftElectionTimeoutTicks = 10
 	sc.TestingKnobs.DisableScanner = true


### PR DESCRIPTION
The previous 1ms Raft tick interval could sometimes lead to spurious
elections. Bump the raft tick interval to 10ms avoids that problem under
"stress".

Fixes #9471

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9908)

<!-- Reviewable:end -->
