### PR TITLE
storage: deflake TestReplicaLazyLoad

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -2205,6 +2205,7 @@ func TestReplicaLazyLoad(t *testing.T) {
 	sc := storage.TestStoreConfig()
 	sc.RaftTickInterval = time.Millisecond
 	sc.TestingKnobs.DisableScanner = true
+	sc.TestingKnobs.DisablePeriodicGossips = true
 	mtc := multiTestContext{storeConfig: &sc}
 	mtc.Start(t, 1)
 	defer mtc.Stop()


### PR DESCRIPTION
Add a new StoreTestingKnobs.DisablePeriodicGossips to disable the
periodic first range gossip which was waking up the range 1 replica
shortly after a store started.

Fixes #9904

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9909)

<!-- Reviewable:end -->
