### PR TITLE
sql: split parser.Datum into Type and Datum

### DIFF
--- a/pkg/sql/analyze.go
+++ b/pkg/sql/analyze.go
@@ -387,10 +387,10 @@ func simplifyOneAndExpr(left, right parser.TypedExpr) (parser.TypedExpr, parser.
 	// to prefer a comparison between a column value and a datum of the same
 	// type is that it makes index constraint construction easier.
 	either := lcmp
-	if !ldatum.TypeEqual(rdatum) {
+	if !ldatum.ResolvedType().Equal(rdatum.ResolvedType()) {
 		switch ta := lcmpLeft.(type) {
 		case *parser.IndexedVar:
-			if ta.ReturnType().TypeEqual(rdatum) {
+			if ta.ResolvedType().Equal(rdatum.ResolvedType()) {
 				either = rcmp
 			}
 		}
@@ -922,10 +922,10 @@ func simplifyOneOrExpr(left, right parser.TypedExpr) (parser.TypedExpr, parser.T
 	// to prefer a comparison between a column value and a datum of the same
 	// type is that it makes index constraint construction easier.
 	either := lcmp
-	if !ldatum.TypeEqual(rdatum) {
+	if !ldatum.ResolvedType().Equal(rdatum.ResolvedType()) {
 		switch ta := lcmpLeft.(type) {
 		case *parser.IndexedVar:
-			if ta.ReturnType().TypeEqual(rdatum) {
+			if ta.ResolvedType().Equal(rdatum.ResolvedType()) {
 				either = rcmp
 			}
 		}
@@ -1605,7 +1605,7 @@ func (p *planner) analyzeExpr(
 	raw parser.Expr,
 	sources multiSourceInfo,
 	ivarHelper parser.IndexedVarHelper,
-	expectedType parser.Datum,
+	expectedType parser.Type,
 	requireType bool,
 	typingContext string,
 ) (parser.TypedExpr, error) {

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -91,8 +91,8 @@ func (c *checkHelper) IndexedVarEval(idx int, ctx *parser.EvalContext) (parser.D
 	return c.curSourceRow[idx].Eval(ctx)
 }
 
-// IndexedVarReturnType implements the parser.IndexedVarContainer interface.
-func (c *checkHelper) IndexedVarReturnType(idx int) parser.Datum {
+// IndexedVarResolvedType implements the parser.IndexedVarContainer interface.
+func (c *checkHelper) IndexedVarResolvedType(idx int) parser.Type {
 	return c.sourceInfo.sourceColumns[idx].Typ
 }
 

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -198,53 +198,53 @@ func (n *copyNode) addRow(line []byte) error {
 			continue
 		}
 		var d parser.Datum
-		switch t := n.resultColumns[i].Typ.(type) {
-		case *parser.DBool:
+		switch t := n.resultColumns[i].Typ; t {
+		case parser.TypeBool:
 			d, err = parser.ParseDBool(s)
-		case *parser.DBytes:
+		case parser.TypeBytes:
 			s, err = decodeCopy(s)
 			d = parser.NewDBytes(parser.DBytes(s))
-		case *parser.DDate:
+		case parser.TypeDate:
 			s, err = decodeCopy(s)
 			if err != nil {
 				break
 			}
 			d, err = parser.ParseDDate(s, n.p.session.Location)
-		case *parser.DDecimal:
+		case parser.TypeDecimal:
 			d, err = parser.ParseDDecimal(s)
-		case *parser.DFloat:
+		case parser.TypeFloat:
 			d, err = parser.ParseDFloat(s)
-		case *parser.DInt:
+		case parser.TypeInt:
 			d, err = parser.ParseDInt(s)
-		case *parser.DInterval:
+		case parser.TypeInterval:
 			s, err = decodeCopy(s)
 			if err != nil {
 				break
 			}
 			d, err = parser.ParseDInterval(s)
-		case *parser.DString:
+		case parser.TypeString:
 			s, err = decodeCopy(s)
 			d = parser.NewDString(s)
-		case *parser.DTimestamp:
+		case parser.TypeTimestamp:
 			s, err = decodeCopy(s)
 			if err != nil {
 				break
 			}
 			d, err = parser.ParseDTimestamp(s, time.Microsecond)
-		case *parser.DTimestampTZ:
+		case parser.TypeTimestampTZ:
 			s, err = decodeCopy(s)
 			if err != nil {
 				break
 			}
 			d, err = parser.ParseDTimestampTZ(s, n.p.session.Location, time.Microsecond)
 		default:
-			return fmt.Errorf("unknown type %s (%T)", t.Type(), t)
+			return fmt.Errorf("unknown type %s", t)
 		}
 		if err != nil {
 			return err
 		}
 
-		sz, _ := d.Size()
+		sz := d.Size()
 		if err := acc.Grow(int64(sz)); err != nil {
 			return err
 		}

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -258,7 +258,7 @@ func (p *planner) CreateView(n *parser.CreateView) (planNode, error) {
 	// depends on, make sure we use the most recent versions of table
 	// descriptors rather than the copies in the lease cache.
 	p.avoidCachedDescriptors = true
-	sourcePlan, err := p.Select(n.AsSource, []parser.Datum{}, false)
+	sourcePlan, err := p.Select(n.AsSource, []parser.Type{}, false)
 	if err != nil {
 		return nil, err
 	}
@@ -399,7 +399,7 @@ func (p *planner) CreateTable(n *parser.CreateTable) (planNode, error) {
 		// to populate the new table descriptor in Start() below. We
 		// instantiate the sourcePlan as early as here so that EXPLAIN has
 		// something useful to show about CREATE TABLE .. AS ...
-		sourcePlan, err = p.Select(n.AsSource, []parser.Datum{}, false)
+		sourcePlan, err = p.Select(n.AsSource, []parser.Type{}, false)
 		if err != nil {
 			return nil, err
 		}
@@ -546,7 +546,7 @@ func (n *createTableNode) Start() error {
 		n.sourcePlan.Close()
 		n.sourcePlan = nil
 
-		desiredTypesFromSelect := make([]parser.Datum, len(resultColumns))
+		desiredTypesFromSelect := make([]parser.Type, len(resultColumns))
 		for i, col := range resultColumns {
 			desiredTypesFromSelect[i] = col.Typ
 		}
@@ -1153,6 +1153,44 @@ func (p *planner) makeTableDesc(
 	return desc, desc.AllocateIDs()
 }
 
+// dummyColumnItem is used in makeCheckConstraint to construct an expression
+// that can be both type-checked and examined for variable expressions.
+type dummyColumnItem struct {
+	typ parser.Type
+}
+
+// String implements the Stringer interface.
+func (d dummyColumnItem) String() string {
+	return fmt.Sprintf("<%s>", d.typ)
+}
+
+// Format implements the NodeFormatter interface.
+func (d dummyColumnItem) Format(buf *bytes.Buffer, _ parser.FmtFlags) {
+	buf.WriteString(d.String())
+}
+
+// Walk implements the Expr interface.
+func (d dummyColumnItem) Walk(_ parser.Visitor) parser.Expr {
+	return d
+}
+
+// TypeCheck implements the Expr interface.
+func (d dummyColumnItem) TypeCheck(
+	_ *parser.SemaContext, desired parser.Type,
+) (parser.TypedExpr, error) {
+	return d, nil
+}
+
+// Eval implements the TypedExpr interface.
+func (dummyColumnItem) Eval(_ *parser.EvalContext) (parser.Datum, error) {
+	panic("dummyColumnItem.Eval() is undefined")
+}
+
+// ResolvedType implements the TypedExpr interface.
+func (d dummyColumnItem) ResolvedType() parser.Type {
+	return d.typ
+}
+
 func makeCheckConstraint(
 	desc sqlbase.TableDescriptor, d *parser.CheckConstraintTableDef, inuseNames map[string]struct{},
 ) (*sqlbase.TableDescriptor_CheckConstraint, error) {
@@ -1198,8 +1236,8 @@ func makeCheckConstraint(
 			nameBuf.WriteByte('_')
 			nameBuf.WriteString(col.Name)
 		}
-		// Convert to a dummy datum of the correct type.
-		return nil, false, col.Type.ToDatumType()
+		// Convert to a dummy node of the correct type.
+		return nil, false, dummyColumnItem{col.Type.ToDatumType()}
 	}
 
 	expr, err := parser.SimpleVisit(d.Expr, preFn)

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -424,7 +424,7 @@ func (src *dataSourceInfo) expandStar(
 		col := src.sourceColumns[idx]
 		if !col.hidden {
 			ivar := ivarHelper.IndexedVar(idx)
-			columns = append(columns, ResultColumn{Name: col.Name, Typ: ivar.ReturnType()})
+			columns = append(columns, ResultColumn{Name: col.Name, Typ: ivar.ResolvedType()})
 			exprs = append(exprs, ivar)
 		}
 	}

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -47,7 +47,7 @@ type deleteNode struct {
 //   Notes: postgres requires DELETE. Also requires SELECT for "USING" and "WHERE" with tables.
 //          mysql requires DELETE. Also requires SELECT if a table is used in the "WHERE" clause.
 func (p *planner) Delete(
-	n *parser.Delete, desiredTypes []parser.Datum, autoCommit bool,
+	n *parser.Delete, desiredTypes []parser.Type, autoCommit bool,
 ) (planNode, error) {
 	tn, err := p.getAliasedTableName(n.Table)
 	if err != nil {

--- a/pkg/sql/distsql/expr.go
+++ b/pkg/sql/distsql/expr.go
@@ -36,7 +36,7 @@ type valArgsConvert struct {
 }
 
 func (v *valArgsConvert) VisitPre(expr parser.Expr) (recurse bool, newExpr parser.Expr) {
-	if val, ok := expr.(parser.Placeholder); ok {
+	if val, ok := expr.(*parser.Placeholder); ok {
 		idx, err := strconv.Atoi(val.Name)
 		if err != nil || idx < 0 || idx >= v.h.NumVars() {
 			v.err = errors.Errorf("invalid variable index %s", val.Name)
@@ -104,8 +104,8 @@ func (eh *exprHelper) String() string {
 // exprHelper implements parser.IndexedVarContainer.
 var _ parser.IndexedVarContainer = &exprHelper{}
 
-// IndexedVarReturnType is part of the parser.IndexedVarContainer interface.
-func (eh *exprHelper) IndexedVarReturnType(idx int) parser.Datum {
+// IndexedVarResolvedType is part of the parser.IndexedVarContainer interface.
+func (eh *exprHelper) IndexedVarResolvedType(idx int) parser.Type {
 	return eh.types[idx].ToDatumType()
 }
 

--- a/pkg/sql/distsql/expr_test.go
+++ b/pkg/sql/distsql/expr_test.go
@@ -27,7 +27,7 @@ import (
 
 type testVarContainer struct{}
 
-func (d testVarContainer) IndexedVarReturnType(idx int) parser.Datum {
+func (d testVarContainer) IndexedVarResolvedType(idx int) parser.Type {
 	return parser.TypeInt
 }
 

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -195,7 +195,7 @@ func formatColumns(cols ResultColumns, printTypes bool) string {
 		}
 		if printTypes {
 			buf.WriteByte(' ')
-			buf.WriteString(rCol.Typ.Type())
+			buf.WriteString(rCol.Typ.String())
 		}
 	}
 	buf.WriteByte(')')

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -641,7 +641,7 @@ func (a *aggregateFuncHolder) String() string { return parser.AsString(a) }
 func (a *aggregateFuncHolder) Walk(v parser.Visitor) parser.Expr { return a }
 
 func (a *aggregateFuncHolder) TypeCheck(
-	_ *parser.SemaContext, desired parser.Datum,
+	_ *parser.SemaContext, desired parser.Type,
 ) (parser.TypedExpr, error) {
 	return a, nil
 }
@@ -657,6 +657,6 @@ func (a *aggregateFuncHolder) Eval(ctx *parser.EvalContext) (parser.Datum, error
 	return datum, nil
 }
 
-func (a *aggregateFuncHolder) ReturnType() parser.Datum {
-	return a.expr.ReturnType()
+func (a *aggregateFuncHolder) ResolvedType() parser.Type {
+	return a.expr.ResolvedType()
 }

--- a/pkg/sql/index_selection.go
+++ b/pkg/sql/index_selection.go
@@ -1332,7 +1332,7 @@ func (oic orIndexConstraints) exactPrefix() int {
 		// Compare the exact values of this constraint, keep the matching
 		// prefix.
 		for i, d := range datums {
-			if !(d.TypeEqual(iDatums[i]) && d.Compare(iDatums[i]) == 0) {
+			if !(d.ResolvedType().Equal(iDatums[i].ResolvedType()) && d.Compare(iDatums[i]) == 0) {
 				datums = datums[:i]
 				break
 			}

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -51,7 +51,7 @@ type insertNode struct {
 //   Notes: postgres requires INSERT. No "on duplicate key update" option.
 //          mysql requires INSERT. Also requires UPDATE on "ON DUPLICATE KEY UPDATE".
 func (p *planner) Insert(
-	n *parser.Insert, desiredTypes []parser.Datum, autoCommit bool,
+	n *parser.Insert, desiredTypes []parser.Type, autoCommit bool,
 ) (planNode, error) {
 	tn, err := p.getAliasedTableName(n.Table)
 	if err != nil {
@@ -130,7 +130,7 @@ func (p *planner) Insert(
 	}
 
 	// Analyze the expressions for column information and typing.
-	desiredTypesFromSelect := make([]parser.Datum, len(cols))
+	desiredTypesFromSelect := make([]parser.Type, len(cols))
 	for i, col := range cols {
 		desiredTypesFromSelect[i] = col.Type.ToDatumType()
 	}

--- a/pkg/sql/parser/aggregate_builtins.go
+++ b/pkg/sql/parser/aggregate_builtins.go
@@ -119,7 +119,7 @@ var Aggregates = map[string][]Builtin{
 	},
 }
 
-func makeAggBuiltin(in, ret Datum, f func() AggregateFunc) Builtin {
+func makeAggBuiltin(in, ret Type, f func() AggregateFunc) Builtin {
 	return Builtin{
 		// See the comment about aggregate functions in the definitions
 		// of the Builtins array above.
@@ -134,7 +134,7 @@ func makeAggBuiltin(in, ret Datum, f func() AggregateFunc) Builtin {
 	}
 }
 
-func makeAggBuiltins(f func() AggregateFunc, types ...Datum) []Builtin {
+func makeAggBuiltins(f func() AggregateFunc, types ...Type) []Builtin {
 	ret := make([]Builtin, len(types))
 	for i := range types {
 		ret[i] = makeAggBuiltin(types[i], types[i], f)
@@ -227,7 +227,7 @@ func (a *avgAggregate) Result() Datum {
 		t.QuoRound(&t.Dec, count, decimal.Precision, inf.RoundHalfUp)
 		return t
 	default:
-		panic(fmt.Sprintf("unexpected SUM result type: %s", t.Type()))
+		panic(fmt.Sprintf("unexpected SUM result type: %s", t))
 	}
 }
 
@@ -656,7 +656,7 @@ func (a *stddevAggregate) Result() Datum {
 		decimal.Sqrt(&t.Dec, &t.Dec, decimal.Precision)
 		return t
 	}
-	panic(fmt.Sprintf("unexpected variance result type: %s", variance.Type()))
+	panic(fmt.Sprintf("unexpected variance result type: %s", variance.ResolvedType()))
 }
 
 var _ Visitor = &IsAggregateVisitor{}

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -82,7 +82,7 @@ const (
 // Builtin is a built-in function.
 type Builtin struct {
 	Types      typeList
-	ReturnType Datum
+	ReturnType Type
 
 	// When multiple overloads are eligible based on types even after all of of
 	// the heuristics to pick one have been used, if one of the overloads is a
@@ -111,7 +111,7 @@ func (b Builtin) params() typeList {
 	return b.Types
 }
 
-func (b Builtin) returnType() Datum {
+func (b Builtin) returnType() Type {
 	return b.ReturnType
 }
 
@@ -119,7 +119,7 @@ func (b Builtin) preferred() bool {
 	return b.preferredOverload
 }
 
-func categorizeType(t Datum) string {
+func categorizeType(t Type) string {
 	switch t {
 	case TypeDate, TypeInterval, TypeTimestamp, TypeTimestampTZ:
 		return categoryDateAndTime
@@ -128,7 +128,7 @@ func categorizeType(t Datum) string {
 	case TypeString, TypeBytes:
 		return categoryString
 	default:
-		return strings.ToUpper(t.Type())
+		return strings.ToUpper(t.String())
 	}
 }
 
@@ -151,7 +151,7 @@ func (b Builtin) Signature() string {
 	if b.ReturnType == nil {
 		return "<T>... -> <T>" // Special-case for LEAST and GREATEST.
 	}
-	return fmt.Sprintf("(%s) -> %s", b.Types.String(), b.ReturnType.Type())
+	return fmt.Sprintf("(%s) -> %s", b.Types.String(), b.ReturnType)
 }
 
 // Builtins contains the built-in functions indexed by name.
@@ -216,7 +216,7 @@ var Builtins = map[string][]Builtin{
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				dstr, ok := args[0].(*DString)
 				if !ok {
-					return DNull, fmt.Errorf("unknown signature for concat_ws: concat_ws(%s, ...)", args[0].Type())
+					return DNull, fmt.Errorf("unknown signature for concat_ws: concat_ws(%s, ...)", args[0])
 				}
 				sep := string(*dstr)
 				var ss []string
@@ -1290,7 +1290,7 @@ func decimalBuiltin2(f func(*inf.Dec, *inf.Dec) (Datum, error)) Builtin {
 	}
 }
 
-func stringBuiltin1(f func(string) (Datum, error), returnType Datum) Builtin {
+func stringBuiltin1(f func(string) (Datum, error), returnType Type) Builtin {
 	return Builtin{
 		Types:      ArgTypes{TypeString},
 		ReturnType: returnType,
@@ -1300,7 +1300,7 @@ func stringBuiltin1(f func(string) (Datum, error), returnType Datum) Builtin {
 	}
 }
 
-func stringBuiltin2(f func(string, string) (Datum, error), returnType Datum) Builtin {
+func stringBuiltin2(f func(string, string) (Datum, error), returnType Type) Builtin {
 	return Builtin{
 		Types:      ArgTypes{TypeString, TypeString},
 		ReturnType: returnType,
@@ -1312,7 +1312,7 @@ func stringBuiltin2(f func(string, string) (Datum, error), returnType Datum) Bui
 }
 
 func stringBuiltin3(
-	a, b, c string, f func(string, string, string) (Datum, error), returnType Datum, info string,
+	a, b, c string, f func(string, string, string) (Datum, error), returnType Type, info string,
 ) Builtin {
 	return Builtin{
 		Types:      NamedArgTypes{{a, TypeString}, {b, TypeString}, {c, TypeString}},
@@ -1324,7 +1324,7 @@ func stringBuiltin3(
 	}
 }
 
-func bytesBuiltin1(f func(string) (Datum, error), returnType Datum) Builtin {
+func bytesBuiltin1(f func(string) (Datum, error), returnType Type) Builtin {
 	return Builtin{
 		Types:      ArgTypes{TypeBytes},
 		ReturnType: returnType,

--- a/pkg/sql/parser/col_types.go
+++ b/pkg/sql/parser/col_types.go
@@ -257,26 +257,26 @@ func (node *BytesColType) String() string       { return AsString(node) }
 // DatumTypeToColumnType produces a SQL column type equivalent to the
 // given Datum type. Used to generate CastExpr nodes during
 // normalization.
-func DatumTypeToColumnType(d Datum) (ColumnType, error) {
-	switch d.(type) {
-	case *DInt:
+func DatumTypeToColumnType(t Type) (ColumnType, error) {
+	switch t {
+	case TypeInt:
 		return intColTypeInt, nil
-	case *DFloat:
+	case TypeFloat:
 		return floatColTypeFloat, nil
-	case *DDecimal:
+	case TypeDecimal:
 		return decimalColTypeDecimal, nil
-	case *DTimestamp:
+	case TypeTimestamp:
 		return timestampColTypeTimestamp, nil
-	case *DTimestampTZ:
+	case TypeTimestampTZ:
 		return timestampTzColTypeTimestampWithTZ, nil
-	case *DInterval:
+	case TypeInterval:
 		return intervalColTypeInterval, nil
-	case *DDate:
+	case TypeDate:
 		return dateColTypeDate, nil
-	case *DString:
+	case TypeString:
 		return stringColTypeString, nil
-	case *DBytes:
+	case TypeBytes:
 		return bytesColTypeBytes, nil
 	}
-	return nil, errors.Errorf("internal error: unknown Datum type %T", d)
+	return nil, errors.Errorf("internal error: unknown Datum type %s", t)
 }

--- a/pkg/sql/parser/constant_test.go
+++ b/pkg/sql/parser/constant_test.go
@@ -40,7 +40,7 @@ func TestNumericConstantVerifyAndResolveAvailableTypes(t *testing.T) {
 
 	testCases := []struct {
 		str   string
-		avail []Datum
+		avail []Type
 	}{
 		{"1", wantInt},
 		{"0", wantInt},
@@ -79,12 +79,12 @@ func TestNumericConstantVerifyAndResolveAvailableTypes(t *testing.T) {
 		for _, availType := range avail {
 			if res, err := c.ResolveAsType(&SemaContext{}, availType); err != nil {
 				t.Errorf("%d: expected resolving %v as available type %s would succeed, found %v",
-					i, c.Value.ExactString(), availType.Type(), err)
+					i, c.Value.ExactString(), availType, err)
 			} else {
 				resErr := func(parsed, resolved interface{}) {
 					t.Errorf("%d: expected resolving %v as available type %s would produce a Datum"+
 						" with the value %v, found %v",
-						i, c, availType.Type(), parsed, resolved)
+						i, c, availType, parsed, resolved)
 				}
 				switch typ := res.(type) {
 				case *DInt:
@@ -144,7 +144,7 @@ func TestStringConstantVerifyAvailableTypes(t *testing.T) {
 
 	testCases := []struct {
 		c     *StrVal
-		avail []Datum
+		avail []Type
 	}{
 		{&StrVal{s: "abc 世界", bytesEsc: false}, wantStringButCanBeAll},
 		{&StrVal{s: "2010-09-28", bytesEsc: false}, wantStringButCanBeAll},
@@ -174,7 +174,7 @@ func TestStringConstantVerifyAvailableTypes(t *testing.T) {
 					// throw a failure.
 					t.Errorf("%d: expected resolving %v as available type %s would either succeed"+
 						" or throw a parsing error, found %v",
-						i, test.c, availType.Type(), err)
+						i, test.c, availType, err)
 				}
 			}
 		}
@@ -280,7 +280,7 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 
 		// Make sure it can be resolved as each of those types or throws a parsing error.
 		for _, availType := range test.c.AvailableTypes() {
-			typeName := availType.Type()
+			typeName := availType.String()
 			res, err := test.c.ResolveAsType(&SemaContext{}, availType)
 			if err != nil {
 				if !strings.Contains(err.Error(), "could not parse") {
@@ -288,7 +288,7 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 					// parseable types will be verified. Any other error should throw a failure.
 					t.Errorf("%d: expected resolving %v as available type %s would either succeed"+
 						" or throw a parsing error, found %v",
-						i, test.c, availType.Type(), err)
+						i, test.c, typeName, err)
 				}
 				continue
 			}

--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -49,16 +49,9 @@ var (
 	DNull Datum = dNull{}
 )
 
-// A Datum holds either a bool, int64, float64, string or []Datum.
+// Datum represents a SQL value.
 type Datum interface {
 	TypedExpr
-	// Type returns the (user-friendly) name of the type.
-	Type() string
-	// TypeEqual determines if the receiver and the other Datum have the same
-	// type or not. This method should be used for asserting the type of all
-	// Datum, with the exception of DNull, where it is safe/encouraged to perform
-	// a direct equivalence check.
-	TypeEqual(other Datum) bool
 	// Compare returns -1 if the receiver is less than other, 0 if receiver is
 	// equal to other and +1 if receiver is greater than other.
 	// TODO(nvanbenschoten) Should we look into merging this with cmpOps?
@@ -86,10 +79,12 @@ type Datum interface {
 	// type can hold.
 	IsMin() bool
 
-	// Size returns a lower bound on the Datum's size, in bytes.  The
-	// second return value indicates whether the size is dependent on
-	// the particular value.
-	Size() (uintptr, bool)
+	// Size returns a lower bound on the total size of the receiver in bytes,
+	// including memory that is pointed at (even if shared between Datum
+	// instances) but excluding allocation overhead.
+	//
+	// It holds for every Datum d that d.Size() >= d.ResolvedType().Size().
+	Size() uintptr
 }
 
 // DBool is the boolean Datum.
@@ -104,14 +99,23 @@ func MakeDBool(d DBool) *DBool {
 	return DBoolFalse
 }
 
-// makeParseError returns a parse error using the provided string and type name.
-// An optional error can be provided, which will be appended to the end of the error string.
-func makeParseError(s, typ string, err error) error {
+// makeParseError returns a parse error using the provided string and type. An
+// optional error can be provided, which will be appended to the end of the
+// error string.
+func makeParseError(s string, typ Type, err error) error {
 	var suffix string
 	if err != nil {
 		suffix = fmt.Sprintf(": %v", err)
 	}
 	return fmt.Errorf("could not parse '%s' as type %s%s", s, typ, suffix)
+}
+
+func makeUnsupportedComparisonMessage(d1, d2 Datum) string {
+	return fmt.Sprintf("unsupported comparison: %s to %s", d1.ResolvedType(), d2.ResolvedType())
+}
+
+func makeUnsupportedMethodMessage(d Datum, methodName string) string {
+	return fmt.Sprintf("%s.%s not supported", d.ResolvedType(), methodName)
 }
 
 // ParseDBool parses and returns the *DBool Datum value represented by the provided
@@ -121,7 +125,7 @@ func ParseDBool(s string) (*DBool, error) {
 	// spec. Is that ok?
 	b, err := strconv.ParseBool(s)
 	if err != nil {
-		return nil, makeParseError(s, TypeBool.Type(), err)
+		return nil, makeParseError(s, TypeBool, err)
 	}
 	return MakeDBool(DBool(b)), nil
 }
@@ -134,23 +138,12 @@ func GetBool(d Datum) (DBool, error) {
 	if d == DNull {
 		return DBool(false), nil
 	}
-	return false, fmt.Errorf("cannot convert %s to type %s", d.Type(), TypeBool.Type())
+	return false, fmt.Errorf("cannot convert %s to type %s", d.ResolvedType(), TypeBool)
 }
 
-// ReturnType implements the TypedExpr interface.
-func (*DBool) ReturnType() Datum {
+// ResolvedType implements the TypedExpr interface.
+func (*DBool) ResolvedType() Type {
 	return TypeBool
-}
-
-// Type implements the Datum interface.
-func (*DBool) Type() string {
-	return "bool"
-}
-
-// TypeEqual implements the Datum interface.
-func (d *DBool) TypeEqual(other Datum) bool {
-	_, ok := other.(*DBool)
-	return ok
 }
 
 // Compare implements the Datum interface.
@@ -161,7 +154,7 @@ func (d *DBool) Compare(other Datum) int {
 	}
 	v, ok := other.(*DBool)
 	if !ok {
-		panic(fmt.Sprintf("unsupported comparison: %s to %s", d.Type(), other.Type()))
+		panic(makeUnsupportedComparisonMessage(d, other))
 	}
 	if !*d && *v {
 		return -1
@@ -208,8 +201,8 @@ func (d *DBool) Format(buf *bytes.Buffer, f FmtFlags) {
 }
 
 // Size implements the Datum interface.
-func (d *DBool) Size() (uintptr, bool) {
-	return unsafe.Sizeof(*d), false
+func (d *DBool) Size() uintptr {
+	return unsafe.Sizeof(*d)
 }
 
 // DInt is the int Datum.
@@ -225,25 +218,14 @@ func NewDInt(d DInt) *DInt {
 func ParseDInt(s string) (*DInt, error) {
 	i, err := strconv.ParseInt(s, 0, 64)
 	if err != nil {
-		return nil, makeParseError(s, TypeInt.Type(), err)
+		return nil, makeParseError(s, TypeInt, err)
 	}
 	return NewDInt(DInt(i)), nil
 }
 
-// ReturnType implements the TypedExpr interface.
-func (*DInt) ReturnType() Datum {
+// ResolvedType implements the TypedExpr interface.
+func (*DInt) ResolvedType() Type {
 	return TypeInt
-}
-
-// Type implements the Datum interface.
-func (*DInt) Type() string {
-	return "int"
-}
-
-// TypeEqual implements the Datum interface.
-func (d *DInt) TypeEqual(other Datum) bool {
-	_, ok := other.(*DInt)
-	return ok
 }
 
 // Compare implements the Datum interface.
@@ -256,7 +238,7 @@ func (d *DInt) Compare(other Datum) int {
 	if !ok {
 		cmp, ok := mixedTypeCompare(d, other)
 		if !ok {
-			panic(fmt.Sprintf("unsupported comparison: %s to %s", d.Type(), other.Type()))
+			panic(makeUnsupportedComparisonMessage(d, other))
 		}
 		return cmp
 	}
@@ -305,8 +287,8 @@ func (d *DInt) Format(buf *bytes.Buffer, f FmtFlags) {
 }
 
 // Size implements the Datum interface.
-func (d *DInt) Size() (uintptr, bool) {
-	return unsafe.Sizeof(*d), false
+func (d *DInt) Size() uintptr {
+	return unsafe.Sizeof(*d)
 }
 
 // DFloat is the float Datum.
@@ -323,25 +305,14 @@ func NewDFloat(d DFloat) *DFloat {
 func ParseDFloat(s string) (*DFloat, error) {
 	f, err := strconv.ParseFloat(s, 64)
 	if err != nil {
-		return nil, makeParseError(s, TypeFloat.Type(), err)
+		return nil, makeParseError(s, TypeFloat, err)
 	}
 	return NewDFloat(DFloat(f)), nil
 }
 
-// ReturnType implements the TypedExpr interface.
-func (*DFloat) ReturnType() Datum {
+// ResolvedType implements the TypedExpr interface.
+func (*DFloat) ResolvedType() Type {
 	return TypeFloat
-}
-
-// Type implements the Datum interface.
-func (*DFloat) Type() string {
-	return "float"
-}
-
-// TypeEqual implements the Datum interface.
-func (d *DFloat) TypeEqual(other Datum) bool {
-	_, ok := other.(*DFloat)
-	return ok
 }
 
 // Compare implements the Datum interface.
@@ -354,7 +325,7 @@ func (d *DFloat) Compare(other Datum) int {
 	if !ok {
 		cmp, ok := mixedTypeCompare(d, other)
 		if !ok {
-			panic(fmt.Sprintf("unsupported comparison: %s to %s", d.Type(), other.Type()))
+			panic(makeUnsupportedComparisonMessage(d, other))
 		}
 		return cmp
 	}
@@ -411,8 +382,8 @@ func (d *DFloat) Format(buf *bytes.Buffer, f FmtFlags) {
 }
 
 // Size implements the Datum interface.
-func (d *DFloat) Size() (uintptr, bool) {
-	return unsafe.Sizeof(*d), false
+func (d *DFloat) Size() uintptr {
+	return unsafe.Sizeof(*d)
 }
 
 // DDecimal is the decimal Datum.
@@ -425,25 +396,14 @@ type DDecimal struct {
 func ParseDDecimal(s string) (*DDecimal, error) {
 	dd := &DDecimal{}
 	if _, ok := dd.SetString(s); !ok {
-		return nil, makeParseError(s, TypeDecimal.Type(), nil)
+		return nil, makeParseError(s, TypeDecimal, nil)
 	}
 	return dd, nil
 }
 
-// ReturnType implements the TypedExpr interface.
-func (d *DDecimal) ReturnType() Datum {
+// ResolvedType implements the TypedExpr interface.
+func (*DDecimal) ResolvedType() Type {
 	return TypeDecimal
-}
-
-// Type implements the Datum interface.
-func (*DDecimal) Type() string {
-	return "decimal"
-}
-
-// TypeEqual implements the Datum interface.
-func (d *DDecimal) TypeEqual(other Datum) bool {
-	_, ok := other.(*DDecimal)
-	return ok
 }
 
 // Compare implements the Datum interface.
@@ -456,7 +416,7 @@ func (d *DDecimal) Compare(other Datum) int {
 	if !ok {
 		cmp, ok := mixedTypeCompare(d, other)
 		if !ok {
-			panic(fmt.Sprintf("unsupported comparison: %s to %s", d.Type(), other.Type()))
+			panic(makeUnsupportedComparisonMessage(d, other))
 		}
 		return cmp
 	}
@@ -470,7 +430,7 @@ func (*DDecimal) HasPrev() bool {
 
 // Prev implements the Datum interface.
 func (d *DDecimal) Prev() Datum {
-	panic(d.Type() + ".Prev() not supported")
+	panic(makeUnsupportedMethodMessage(d, "Prev"))
 }
 
 // HasNext implements the Datum interface.
@@ -480,7 +440,7 @@ func (*DDecimal) HasNext() bool {
 
 // Next implements the Datum interface.
 func (d *DDecimal) Next() Datum {
-	panic(d.Type() + ".Next() not supported")
+	panic(makeUnsupportedMethodMessage(d, "Next"))
 }
 
 // IsMax implements the Datum interface.
@@ -499,9 +459,9 @@ func (d *DDecimal) Format(buf *bytes.Buffer, f FmtFlags) {
 }
 
 // Size implements the Datum interface.
-func (d *DDecimal) Size() (uintptr, bool) {
+func (d *DDecimal) Size() uintptr {
 	intVal := d.Dec.UnscaledBig()
-	return unsafe.Sizeof(*d) + unsafe.Sizeof(*intVal) + uintptr(cap(intVal.Bits()))*unsafe.Sizeof(big.Word(0)), true
+	return unsafe.Sizeof(*d) + uintptr(cap(intVal.Bits()))*unsafe.Sizeof(big.Word(0))
 }
 
 // DString is the string Datum.
@@ -514,20 +474,9 @@ func NewDString(d string) *DString {
 	return &r
 }
 
-// ReturnType implements the TypedExpr interface.
-func (*DString) ReturnType() Datum {
+// ResolvedType implements the TypedExpr interface.
+func (*DString) ResolvedType() Type {
 	return TypeString
-}
-
-// Type implements the Datum interface.
-func (*DString) Type() string {
-	return "string"
-}
-
-// TypeEqual implements the Datum interface.
-func (d *DString) TypeEqual(other Datum) bool {
-	_, ok := other.(*DString)
-	return ok
 }
 
 // Compare implements the Datum interface.
@@ -538,7 +487,7 @@ func (d *DString) Compare(other Datum) int {
 	}
 	v, ok := other.(*DString)
 	if !ok {
-		panic(fmt.Sprintf("unsupported comparison: %s to %s", d.Type(), other.Type()))
+		panic(makeUnsupportedComparisonMessage(d, other))
 	}
 	if *d < *v {
 		return -1
@@ -556,7 +505,7 @@ func (*DString) HasPrev() bool {
 
 // Prev implements the Datum interface.
 func (d *DString) Prev() Datum {
-	panic(d.Type() + ".Prev() not supported")
+	panic(makeUnsupportedMethodMessage(d, "Prev"))
 }
 
 // HasNext implements the Datum interface.
@@ -585,8 +534,8 @@ func (d *DString) Format(buf *bytes.Buffer, f FmtFlags) {
 }
 
 // Size implements the Datum interface.
-func (d *DString) Size() (uintptr, bool) {
-	return unsafe.Sizeof(*d) + uintptr(len(*d)), true
+func (d *DString) Size() uintptr {
+	return unsafe.Sizeof(*d) + uintptr(len(*d))
 }
 
 // DBytes is the bytes Datum. The underlying type is a string because we want
@@ -599,20 +548,9 @@ func NewDBytes(d DBytes) *DBytes {
 	return &d
 }
 
-// ReturnType implements the TypedExpr interface.
-func (d *DBytes) ReturnType() Datum {
+// ResolvedType implements the TypedExpr interface.
+func (*DBytes) ResolvedType() Type {
 	return TypeBytes
-}
-
-// Type implements the Datum interface.
-func (*DBytes) Type() string {
-	return "bytes"
-}
-
-// TypeEqual implements the Datum interface.
-func (d *DBytes) TypeEqual(other Datum) bool {
-	_, ok := other.(*DBytes)
-	return ok
 }
 
 // Compare implements the Datum interface.
@@ -623,7 +561,7 @@ func (d *DBytes) Compare(other Datum) int {
 	}
 	v, ok := other.(*DBytes)
 	if !ok {
-		panic(fmt.Sprintf("unsupported comparison: %s to %s", d.Type(), other.Type()))
+		panic(makeUnsupportedComparisonMessage(d, other))
 	}
 	if *d < *v {
 		return -1
@@ -641,7 +579,7 @@ func (*DBytes) HasPrev() bool {
 
 // Prev implements the Datum interface.
 func (d *DBytes) Prev() Datum {
-	panic(d.Type() + ".Prev() not supported")
+	panic(makeUnsupportedMethodMessage(d, "Prev"))
 }
 
 // HasNext implements the Datum interface.
@@ -670,8 +608,8 @@ func (d *DBytes) Format(buf *bytes.Buffer, f FmtFlags) {
 }
 
 // Size implements the Datum interface.
-func (d *DBytes) Size() (uintptr, bool) {
-	return unsafe.Sizeof(*d) + uintptr(len(*d)), true
+func (d *DBytes) Size() uintptr {
+	return unsafe.Sizeof(*d) + uintptr(len(*d))
 }
 
 // DDate is the date Datum represented as the number of days after
@@ -722,23 +660,12 @@ func ParseDDate(s string, loc *time.Location) (*DDate, error) {
 		}
 	}
 
-	return nil, makeParseError(s, TypeDate.Type(), nil)
+	return nil, makeParseError(s, TypeDate, nil)
 }
 
-// ReturnType implements the TypedExpr interface.
-func (*DDate) ReturnType() Datum {
+// ResolvedType implements the TypedExpr interface.
+func (*DDate) ResolvedType() Type {
 	return TypeDate
-}
-
-// Type implements the Datum interface.
-func (*DDate) Type() string {
-	return "date"
-}
-
-// TypeEqual implements the Datum interface.
-func (d *DDate) TypeEqual(other Datum) bool {
-	_, ok := other.(*DDate)
-	return ok
 }
 
 // Compare implements the Datum interface.
@@ -749,7 +676,7 @@ func (d *DDate) Compare(other Datum) int {
 	}
 	v, ok := other.(*DDate)
 	if !ok {
-		panic(fmt.Sprintf("unsupported comparison: %s to %s", d.Type(), other.Type()))
+		panic(makeUnsupportedComparisonMessage(d, other))
 	}
 	if *d < *v {
 		return -1
@@ -796,8 +723,8 @@ func (d *DDate) Format(buf *bytes.Buffer, f FmtFlags) {
 }
 
 // Size implements the Datum interface.
-func (d *DDate) Size() (uintptr, bool) {
-	return unsafe.Sizeof(*d), false
+func (d *DDate) Size() uintptr {
+	return unsafe.Sizeof(*d)
 }
 
 // DTimestamp is the timestamp Datum.
@@ -836,12 +763,12 @@ func parseTimestampInLocation(s string, loc *time.Location) (time.Time, error) {
 	for _, format := range timeFormats {
 		if t, err := time.ParseInLocation(format, s, loc); err == nil {
 			if err := checkForMissingZone(t, loc); err != nil {
-				return time.Time{}, makeParseError(s, TypeTimestamp.Type(), err)
+				return time.Time{}, makeParseError(s, TypeTimestamp, err)
 			}
 			return t, nil
 		}
 	}
-	return time.Time{}, makeParseError(s, TypeTimestamp.Type(), nil)
+	return time.Time{}, makeParseError(s, TypeTimestamp, nil)
 }
 
 // Unfortunately Go is very strict when parsing abbreviated zone names -- with
@@ -879,20 +806,9 @@ func ParseDTimestamp(s string, precision time.Duration) (*DTimestamp, error) {
 	return MakeDTimestamp(t, precision), nil
 }
 
-// ReturnType implements the TypedExpr interface.
-func (*DTimestamp) ReturnType() Datum {
+// ResolvedType implements the TypedExpr interface.
+func (*DTimestamp) ResolvedType() Type {
 	return TypeTimestamp
-}
-
-// Type implements the Datum interface.
-func (*DTimestamp) Type() string {
-	return "timestamp"
-}
-
-// TypeEqual implements the Datum interface.
-func (d *DTimestamp) TypeEqual(other Datum) bool {
-	_, ok := other.(*DTimestamp)
-	return ok
 }
 
 // Compare implements the Datum interface.
@@ -903,7 +819,7 @@ func (d *DTimestamp) Compare(other Datum) int {
 	}
 	v, ok := other.(*DTimestamp)
 	if !ok {
-		panic(fmt.Sprintf("unsupported comparison: %s to %s", d.Type(), other.Type()))
+		panic(makeUnsupportedComparisonMessage(d, other))
 	}
 	if d.Before(v.Time) {
 		return -1
@@ -952,8 +868,8 @@ func (d *DTimestamp) Format(buf *bytes.Buffer, f FmtFlags) {
 }
 
 // Size implements the Datum interface.
-func (d *DTimestamp) Size() (uintptr, bool) {
-	return unsafe.Sizeof(*d), false
+func (d *DTimestamp) Size() uintptr {
+	return unsafe.Sizeof(*d)
 }
 
 // DTimestampTZ is the timestamp Datum that is rendered with session offset.
@@ -978,20 +894,9 @@ func ParseDTimestampTZ(
 	return MakeDTimestampTZ(t, precision), nil
 }
 
-// ReturnType implements the TypedExpr interface.
-func (*DTimestampTZ) ReturnType() Datum {
+// ResolvedType implements the TypedExpr interface.
+func (*DTimestampTZ) ResolvedType() Type {
 	return TypeTimestampTZ
-}
-
-// Type implements the Datum interface.
-func (d *DTimestampTZ) Type() string {
-	return "timestamptz"
-}
-
-// TypeEqual implements the Datum interface.
-func (d *DTimestampTZ) TypeEqual(other Datum) bool {
-	_, ok := other.(*DTimestampTZ)
-	return ok
 }
 
 // Compare implements the Datum interface.
@@ -1002,7 +907,7 @@ func (d *DTimestampTZ) Compare(other Datum) int {
 	}
 	v, ok := other.(*DTimestampTZ)
 	if !ok {
-		panic(fmt.Sprintf("unsupported comparison: %s to %s", d.Type(), other.Type()))
+		panic(makeUnsupportedComparisonMessage(d, other))
 	}
 	if d.Before(v.Time) {
 		return -1
@@ -1051,8 +956,8 @@ func (d *DTimestampTZ) Format(buf *bytes.Buffer, f FmtFlags) {
 }
 
 // Size implements the Datum interface.
-func (d *DTimestampTZ) Size() (uintptr, bool) {
-	return unsafe.Sizeof(*d), false
+func (d *DTimestampTZ) Size() uintptr {
+	return unsafe.Sizeof(*d)
 }
 
 // DInterval is the interval Datum.
@@ -1071,7 +976,7 @@ func ParseDInterval(s string) (*DInterval, error) {
 
 	// If it's a blank string, exit early.
 	if len(s) == 0 {
-		return nil, makeParseError(s, TypeInterval.Type(), nil)
+		return nil, makeParseError(s, TypeInterval, nil)
 	}
 
 	if s[0] == 'P' {
@@ -1079,7 +984,7 @@ func ParseDInterval(s string) (*DInterval, error) {
 		// interval.
 		dur, err := iso8601ToDuration(s)
 		if err != nil {
-			return nil, makeParseError(s, TypeInterval.Type(), err)
+			return nil, makeParseError(s, TypeInterval, err)
 		}
 		return &DInterval{Duration: dur}, nil
 	} else if strings.ContainsRune(s, ' ') {
@@ -1087,7 +992,7 @@ func ParseDInterval(s string) (*DInterval, error) {
 		// as neither iso8601 nor golang permit spaces.
 		dur, err := postgresToDuration(s)
 		if err != nil {
-			return nil, makeParseError(s, TypeInterval.Type(), err)
+			return nil, makeParseError(s, TypeInterval, err)
 		}
 		return &DInterval{Duration: dur}, nil
 	} else if strings.ContainsRune(s, ':') {
@@ -1110,10 +1015,10 @@ func ParseDInterval(s string) (*DInterval, error) {
 		case 3:
 			dur, err = time.ParseDuration(parts[0] + "h" + parts[1] + "m" + parts[2] + "s")
 		default:
-			return nil, makeParseError(s, TypeInterval.Type(), fmt.Errorf("unknown format"))
+			return nil, makeParseError(s, TypeInterval, fmt.Errorf("unknown format"))
 		}
 		if err != nil {
-			return nil, makeParseError(s, TypeInterval.Type(), err)
+			return nil, makeParseError(s, TypeInterval, err)
 		}
 		return &DInterval{Duration: duration.Duration{Nanos: dur.Nanoseconds()}}, nil
 	}
@@ -1125,25 +1030,14 @@ func ParseDInterval(s string) (*DInterval, error) {
 	// Fallback to golang durations.
 	dur, err := time.ParseDuration(s)
 	if err != nil {
-		return nil, makeParseError(s, TypeInterval.Type(), err)
+		return nil, makeParseError(s, TypeInterval, err)
 	}
 	return &DInterval{Duration: duration.Duration{Nanos: dur.Nanoseconds()}}, nil
 }
 
-// ReturnType implements the TypedExpr interface.
-func (d *DInterval) ReturnType() Datum {
+// ResolvedType implements the TypedExpr interface.
+func (*DInterval) ResolvedType() Type {
 	return TypeInterval
-}
-
-// Type implements the Datum interface.
-func (*DInterval) Type() string {
-	return "interval"
-}
-
-// TypeEqual implements the Datum interface.
-func (d *DInterval) TypeEqual(other Datum) bool {
-	_, ok := other.(*DInterval)
-	return ok
 }
 
 // Compare implements the Datum interface.
@@ -1154,7 +1048,7 @@ func (d *DInterval) Compare(other Datum) int {
 	}
 	v, ok := other.(*DInterval)
 	if !ok {
-		panic(fmt.Sprintf("unsupported comparison: %s to %s", d.Type(), other.Type()))
+		panic(makeUnsupportedComparisonMessage(d, other))
 	}
 	return d.Duration.Compare(v.Duration)
 }
@@ -1166,7 +1060,7 @@ func (*DInterval) HasPrev() bool {
 
 // Prev implements the Datum interface.
 func (d *DInterval) Prev() Datum {
-	panic(d.Type() + ".Prev() not supported")
+	panic(makeUnsupportedMethodMessage(d, "Prev"))
 }
 
 // HasNext implements the Datum interface.
@@ -1176,7 +1070,7 @@ func (*DInterval) HasNext() bool {
 
 // Next implements the Datum interface.
 func (d *DInterval) Next() Datum {
-	panic(d.Type() + ".Next() not supported")
+	panic(makeUnsupportedMethodMessage(d, "Next"))
 }
 
 // IsMax implements the Datum interface.
@@ -1199,38 +1093,20 @@ func (d *DInterval) Format(buf *bytes.Buffer, f FmtFlags) {
 }
 
 // Size implements the Datum interface.
-func (d *DInterval) Size() (uintptr, bool) {
-	return unsafe.Sizeof(*d), false
+func (d *DInterval) Size() uintptr {
+	return unsafe.Sizeof(*d)
 }
 
 // DTuple is the tuple Datum.
 type DTuple []Datum
 
-// ReturnType implements the TypedExpr interface.
-func (d *DTuple) ReturnType() Datum {
-	return d
-}
-
-// Type implements the Datum interface.
-func (*DTuple) Type() string {
-	return "tuple"
-}
-
-// TypeEqual implements the Datum interface.
-func (d *DTuple) TypeEqual(other Datum) bool {
-	t, ok := other.(*DTuple)
-	if !ok {
-		return false
+// ResolvedType implements the TypedExpr interface.
+func (d *DTuple) ResolvedType() Type {
+	typ := make(TTuple, len(*d))
+	for i, v := range *d {
+		typ[i] = v.ResolvedType()
 	}
-	if len(*d) != len(*t) {
-		return false
-	}
-	for i := 0; i < len(*d); i++ {
-		if !(*d)[i].TypeEqual((*t)[i]) {
-			return false
-		}
-	}
-	return true
+	return typ
 }
 
 // Compare implements the Datum interface.
@@ -1241,7 +1117,7 @@ func (d *DTuple) Compare(other Datum) int {
 	}
 	v, ok := other.(*DTuple)
 	if !ok {
-		panic(fmt.Sprintf("unsupported comparison: %s to %s", d.Type(), other.Type()))
+		panic(makeUnsupportedComparisonMessage(d, other))
 	}
 	n := len(*d)
 	if n > len(*v) {
@@ -1369,13 +1245,13 @@ func (d *DTuple) makeUnique() {
 }
 
 // Size implements the Datum interface.
-func (d *DTuple) Size() (uintptr, bool) {
+func (d *DTuple) Size() uintptr {
 	sz := unsafe.Sizeof(*d)
 	for _, e := range *d {
-		dsz, _ := e.Size()
+		dsz := e.Size()
 		sz += dsz
 	}
-	return sz, true
+	return sz
 }
 
 // SortedDifference finds the elements of d which are not in other,
@@ -1401,20 +1277,9 @@ func (d *DTuple) SortedDifference(other *DTuple) *DTuple {
 
 type dNull struct{}
 
-// ReturnType implements the TypedExpr interface.
-func (dNull) ReturnType() Datum {
-	return DNull
-}
-
-// Type implements the Datum interface.
-func (d dNull) Type() string {
-	return "NULL"
-}
-
-// TypeEqual implements the Datum interface.
-func (d dNull) TypeEqual(other Datum) bool {
-	_, ok := other.(dNull)
-	return ok
+// ResolvedType implements the TypedExpr interface.
+func (dNull) ResolvedType() Type {
+	return TypeNull
 }
 
 // Compare implements the Datum interface.
@@ -1432,7 +1297,7 @@ func (dNull) HasPrev() bool {
 
 // Prev implements the Datum interface.
 func (d dNull) Prev() Datum {
-	panic(d.Type() + ".Prev not supported")
+	panic(makeUnsupportedMethodMessage(d, "Prev"))
 }
 
 // HasNext implements the Datum interface.
@@ -1442,7 +1307,7 @@ func (dNull) HasNext() bool {
 
 // Next implements the Datum interface.
 func (d dNull) Next() Datum {
-	panic(d.Type() + ".Next not supported")
+	panic(makeUnsupportedMethodMessage(d, "Next"))
 }
 
 // IsMax implements the Datum interface.
@@ -1461,97 +1326,18 @@ func (dNull) Format(buf *bytes.Buffer, f FmtFlags) {
 }
 
 // Size implements the Datum interface.
-func (d dNull) Size() (uintptr, bool) {
-	return unsafe.Sizeof(d), false
-}
-
-var _ VariableExpr = &DPlaceholder{}
-
-// DPlaceholder is the named placeholder Datum.
-type DPlaceholder struct {
-	name string
-	pmap *PlaceholderInfo
-}
-
-// Name gives access to the placeholder's name to other packages.
-func (d *DPlaceholder) Name() string {
-	return d.name
-}
-
-// ReturnType implements the TypedExpr interface.
-func (d *DPlaceholder) ReturnType() Datum {
-	if typ, ok := d.pmap.Type(d.name); ok {
-		return typ
-	}
-	return d
-}
-
-// Variable implements the VariableExpr interface.
-func (*DPlaceholder) Variable() {}
-
-// Type implements the Datum interface.
-func (*DPlaceholder) Type() string {
-	return "placeholder"
-}
-
-// TypeEqual implements the Datum interface.
-func (d *DPlaceholder) TypeEqual(other Datum) bool {
-	_, ok := other.(*DPlaceholder)
-	return ok
-}
-
-// Compare implements the Datum interface.
-func (d *DPlaceholder) Compare(other Datum) int {
-	panic(d.Type() + ".Compare not supported")
-}
-
-// HasPrev implements the Datum interface.
-func (*DPlaceholder) HasPrev() bool {
-	return false
-}
-
-// Prev implements the Datum interface.
-func (d *DPlaceholder) Prev() Datum {
-	panic(d.Type() + ".Prev not supported")
-}
-
-// HasNext implements the Datum interface.
-func (*DPlaceholder) HasNext() bool {
-	return false
-}
-
-// Next implements the Datum interface.
-func (d *DPlaceholder) Next() Datum {
-	panic(d.Type() + ".Next not supported")
-}
-
-// IsMax implements the Datum interface.
-func (*DPlaceholder) IsMax() bool {
-	return true
-}
-
-// IsMin implements the Datum interface.
-func (*DPlaceholder) IsMin() bool {
-	return true
-}
-
-// Format implements the NodeFormatter interface.
-func (d *DPlaceholder) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteByte('$')
-	buf.WriteString(d.name)
-}
-
-// Size implements the Datum interface.
-func (d *DPlaceholder) Size() (uintptr, bool) {
-	return unsafe.Sizeof(*d) + uintptr(len(d.name)), true
+func (d dNull) Size() uintptr {
+	return unsafe.Sizeof(d)
 }
 
 // Temporary workaround for #3633, allowing comparisons between
 // heterogeneous types.
 // TODO(nvanbenschoten) Now that typing is improved, can we get rid of this?
 func mixedTypeCompare(l, r Datum) (int, bool) {
+	ltype := l.ResolvedType()
+	rtype := r.ResolvedType()
 	// Check equality.
-	eqOp, ok := CmpOps[EQ].lookupImpl(l, r)
+	eqOp, ok := CmpOps[EQ].lookupImpl(ltype, rtype)
 	if !ok {
 		return 0, false
 	}
@@ -1565,7 +1351,7 @@ func mixedTypeCompare(l, r Datum) (int, bool) {
 	}
 
 	// Check less than.
-	ltOp, ok := CmpOps[LT].lookupImpl(l, r)
+	ltOp, ok := CmpOps[LT].lookupImpl(ltype, rtype)
 	if !ok {
 		return 0, false
 	}

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -50,8 +50,8 @@ const secondsInDay = 24 * 60 * 60
 
 // UnaryOp is a unary operator.
 type UnaryOp struct {
-	Typ        Datum
-	ReturnType Datum
+	Typ        Type
+	ReturnType Type
 	fn         func(*EvalContext, Datum) (Datum, error)
 	types      typeList
 }
@@ -60,7 +60,7 @@ func (op UnaryOp) params() typeList {
 	return op.types
 }
 
-func (op UnaryOp) returnType() Datum {
+func (op UnaryOp) returnType() Type {
 	return op.ReturnType
 }
 
@@ -146,9 +146,9 @@ var UnaryOps = map[UnaryOperator]unaryOpOverload{
 
 // BinOp is a binary operator.
 type BinOp struct {
-	LeftType   Datum
-	RightType  Datum
-	ReturnType Datum
+	LeftType   Type
+	RightType  Type
+	ReturnType Type
 	fn         func(*EvalContext, Datum, Datum) (Datum, error)
 	types      typeList
 }
@@ -157,11 +157,11 @@ func (op BinOp) params() typeList {
 	return op.types
 }
 
-func (op BinOp) matchParams(l, r Datum) bool {
+func (op BinOp) matchParams(l, r Type) bool {
 	return op.params().matchAt(l, 0) && op.params().matchAt(r, 1)
 }
 
-func (op BinOp) returnType() Datum {
+func (op BinOp) returnType() Type {
 	return op.ReturnType
 }
 
@@ -181,7 +181,7 @@ func init() {
 // binOpOverload is an overloaded set of binary operator implementations.
 type binOpOverload []BinOp
 
-func (o binOpOverload) lookupImpl(left, right Datum) (BinOp, bool) {
+func (o binOpOverload) lookupImpl(left, right Type) (BinOp, bool) {
 	for _, fn := range o {
 		if fn.matchParams(left, right) {
 			return fn, true
@@ -830,8 +830,8 @@ func init() {
 
 // CmpOp is a comparison operator.
 type CmpOp struct {
-	LeftType  Datum
-	RightType Datum
+	LeftType  Type
+	RightType Type
 	fn        func(*EvalContext, Datum, Datum) (DBool, error)
 	types     typeList
 }
@@ -840,11 +840,11 @@ func (op CmpOp) params() typeList {
 	return op.types
 }
 
-func (op CmpOp) matchParams(l, r Datum) bool {
+func (op CmpOp) matchParams(l, r Type) bool {
 	return op.params().matchAt(l, 0) && op.params().matchAt(r, 1)
 }
 
-func (op CmpOp) returnType() Datum {
+func (op CmpOp) returnType() Type {
 	return TypeBool
 }
 
@@ -864,7 +864,7 @@ func init() {
 // cmpOpOverload is an overloaded set of comparison operator implementations.
 type cmpOpOverload []CmpOp
 
-func (o cmpOpOverload) lookupImpl(left, right Datum) (CmpOp, bool) {
+func (o cmpOpOverload) lookupImpl(left, right Type) (CmpOp, bool) {
 	for _, fn := range o {
 		if fn.matchParams(left, right) {
 			return fn, true
@@ -1403,9 +1403,9 @@ func cmpTuple(ldatum, rdatum Datum) (int, error) {
 	return 0, nil
 }
 
-func makeEvalTupleIn(d Datum) CmpOp {
+func makeEvalTupleIn(typ Type) CmpOp {
 	return CmpOp{
-		LeftType:  d,
+		LeftType:  typ,
 		RightType: TypeTuple,
 		fn: func(_ *EvalContext, arg, values Datum) (DBool, error) {
 			if arg == DNull {
@@ -1885,7 +1885,7 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("invalid cast: %s -> %s", d.Type(), expr.Type)
+	return nil, fmt.Errorf("invalid cast: %s -> %s", d.ResolvedType(), expr.Type)
 }
 
 // Eval implements the TypedExpr interface.
@@ -1962,7 +1962,7 @@ func (expr *FuncExpr) Eval(ctx *EvalContext) (Datum, error) {
 		args = append(args, arg)
 	}
 
-	if !expr.fn.Types.match(ArgTypes(args)) {
+	if !expr.fn.Types.match(ArgTypes(args.ResolvedType().(TTuple))) {
 		// The argument types no longer match the memoized function. This happens
 		// when a non-NULL argument becomes NULL and the function does not support
 		// NULL arguments. For example, "SELECT LOWER(col) FROM TABLE" where col is
@@ -2278,22 +2278,21 @@ func (t *DTuple) Eval(_ *EvalContext) (Datum, error) {
 }
 
 // Eval implements the TypedExpr interface.
-func (t *DPlaceholder) Eval(_ *EvalContext) (Datum, error) {
-	return t, fmt.Errorf("no value provided for placeholder: $%s", t.name)
+func (node *Placeholder) Eval(_ *EvalContext) (Datum, error) {
+	return nil, fmt.Errorf("no value provided for placeholder: $%s", node.Name)
 }
 
 func evalComparison(ctx *EvalContext, op ComparisonOperator, left, right Datum) (Datum, error) {
 	if left == DNull || right == DNull {
 		return DNull, nil
 	}
-
-	if fn, ok := CmpOps[op].lookupImpl(left, right); ok {
+	ltype := left.ResolvedType()
+	rtype := right.ResolvedType()
+	if fn, ok := CmpOps[op].lookupImpl(ltype, rtype); ok {
 		v, err := fn.fn(ctx, left, right)
 		return MakeDBool(v), err
 	}
-
-	return nil, fmt.Errorf("unsupported comparison operator: <%s> %s <%s>",
-		left.Type(), op, right.Type())
+	return nil, fmt.Errorf("unsupported comparison operator: <%s> %s <%s>", ltype, op, rtype)
 }
 
 // foldComparisonExpr folds a given comparison operation and its expressions
@@ -2538,7 +2537,7 @@ func anchorPattern(pattern string, caseInsensitive bool) string {
 // FindEqualComparisonFunction looks up an overload of the "=" operator
 // for a given pair of input operand types.
 func FindEqualComparisonFunction(
-	leftType, rightType Datum,
+	leftType, rightType Type,
 ) (func(*EvalContext, Datum, Datum) (DBool, error), bool) {
 	fn, found := CmpOps[EQ].lookupImpl(leftType, rightType)
 	if found {

--- a/pkg/sql/parser/expr.go
+++ b/pkg/sql/parser/expr.go
@@ -38,7 +38,7 @@ type Expr interface {
 	// The ctx parameter defines the context in which to perform type checking.
 	// The desired parameter hints the desired type that the method's caller wants from
 	// the resulting TypedExpr.
-	TypeCheck(ctx *SemaContext, desired Datum) (TypedExpr, error)
+	TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, error)
 }
 
 // TypedExpr represents a well-typed expression.
@@ -55,9 +55,9 @@ type TypedExpr interface {
 	// appropriate WalkExpr. For example, Placeholder should be replace
 	// by the argument passed from the client.
 	Eval(*EvalContext) (Datum, error)
-	// ReturnType provides the type of the TypedExpr, which is the type of Datum that
-	// the TypedExpr will return when evaluated.
-	ReturnType() Datum
+	// ResolvedType provides the type of the TypedExpr, which is the type of Datum
+	// that the TypedExpr will return when evaluated.
+	ResolvedType() Type
 }
 
 // VariableExpr is an Expr that may change per row. It is used to
@@ -101,10 +101,10 @@ func exprFmtWithParen(buf *bytes.Buffer, f FmtFlags, e Expr) {
 // typeAnnotation is an embeddable struct to provide a TypedExpr with a dynamic
 // type annotation.
 type typeAnnotation struct {
-	typ Datum
+	typ Type
 }
 
-func (ta typeAnnotation) ReturnType() Datum {
+func (ta typeAnnotation) ResolvedType() Type {
 	ta.assertTyped()
 	return ta.typ
 }
@@ -335,7 +335,7 @@ func (node *ComparisonExpr) memoizeFn() {
 		return
 	}
 	fOp, fLeft, fRight, _, _ := foldComparisonExpr(node.Operator, node.Left, node.Right)
-	leftRet, rightRet := fLeft.(TypedExpr).ReturnType(), fRight.(TypedExpr).ReturnType()
+	leftRet, rightRet := fLeft.(TypedExpr).ResolvedType(), fRight.(TypedExpr).ResolvedType()
 	fn, ok := CmpOps[fOp].lookupImpl(leftRet, rightRet)
 	if !ok {
 		panic(fmt.Sprintf("lookup for ComparisonExpr %s's CmpOp failed",
@@ -361,26 +361,26 @@ func (node *ComparisonExpr) IsMixedTypeComparison() bool {
 	case In, NotIn:
 		tuple := *node.Right.(*DTuple)
 		for _, expr := range tuple {
-			if !sameTypeExprs(node.TypedLeft(), expr.(TypedExpr)) {
+			if !sameTypeOrNull(node.TypedLeft(), expr.(TypedExpr)) {
 				return true
 			}
 		}
 		return false
 	default:
-		return !sameTypeExprs(node.TypedLeft(), node.TypedRight())
+		return !sameTypeOrNull(node.TypedLeft(), node.TypedRight())
 	}
 }
 
-func sameTypeExprs(left, right TypedExpr) bool {
-	leftType := left.ReturnType()
-	if leftType == DNull {
+func sameTypeOrNull(left, right TypedExpr) bool {
+	leftType := left.ResolvedType()
+	if leftType == TypeNull {
 		return true
 	}
-	rightType := right.ReturnType()
-	if rightType == DNull {
+	rightType := right.ResolvedType()
+	if rightType == TypeNull {
 		return true
 	}
-	return leftType.TypeEqual(rightType)
+	return leftType.Equal(rightType)
 }
 
 // RangeCond represents a BETWEEN or a NOT BETWEEN expression.
@@ -542,23 +542,38 @@ func (node DefaultVal) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString("DEFAULT")
 }
 
-// ReturnType implements the TypedExpr interface.
-func (DefaultVal) ReturnType() Datum { return nil }
+// ResolvedType implements the TypedExpr interface.
+func (DefaultVal) ResolvedType() Type { return nil }
 
-var _ VariableExpr = Placeholder{}
+var _ VariableExpr = &Placeholder{}
 
 // Placeholder represents a named placeholder.
 type Placeholder struct {
 	Name string
+
+	typeAnnotation
+}
+
+// NewPlaceholder allocates a Placeholder.
+func NewPlaceholder(name string) *Placeholder {
+	return &Placeholder{Name: name}
 }
 
 // Variable implements the VariableExpr interface.
-func (Placeholder) Variable() {}
+func (*Placeholder) Variable() {}
 
 // Format implements the NodeFormatter interface.
-func (node Placeholder) Format(buf *bytes.Buffer, f FmtFlags) {
+func (node *Placeholder) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteByte('$')
 	buf.WriteString(node.Name)
+}
+
+// ResolvedType implements the TypedExpr interface.
+func (node *Placeholder) ResolvedType() Type {
+	if node.typ == nil {
+		node.typ = &TPlaceholder{Name: node.Name}
+	}
+	return node.typ
 }
 
 // Tuple represents a parenthesized list of expressions.
@@ -566,7 +581,7 @@ type Tuple struct {
 	Exprs Exprs
 
 	row   bool // indicates whether or not the tuple should be textually represented as a row.
-	types DTuple
+	types TTuple
 }
 
 // Format implements the NodeFormatter interface.
@@ -579,9 +594,9 @@ func (node *Tuple) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteByte(')')
 }
 
-// ReturnType implements the TypedExpr interface.
-func (node *Tuple) ReturnType() Datum {
-	return &node.types
+// ResolvedType implements the TypedExpr interface.
+func (node *Tuple) ResolvedType() Type {
+	return node.types
 }
 
 // Array represents an array constructor.
@@ -637,9 +652,9 @@ func (node *Subquery) Format(buf *bytes.Buffer, f FmtFlags) {
 	FormatNode(buf, f, node.Select)
 }
 
-// ReturnType implements the TypedExpr interface.
-func (node *Subquery) ReturnType() Datum {
-	return DNull
+// ResolvedType implements the TypedExpr interface.
+func (*Subquery) ResolvedType() Type {
+	return TypeNull
 }
 
 // BinaryOperator represents a binary operator.
@@ -705,7 +720,7 @@ func (node *BinaryExpr) TypedRight() TypedExpr {
 func (*BinaryExpr) operatorExpr() {}
 
 func (node *BinaryExpr) memoizeFn() {
-	leftRet, rightRet := node.Left.(TypedExpr).ReturnType(), node.Right.(TypedExpr).ReturnType()
+	leftRet, rightRet := node.Left.(TypedExpr).ResolvedType(), node.Right.(TypedExpr).ResolvedType()
 	fn, ok := BinOps[node.Operator].lookupImpl(leftRet, rightRet)
 	if !ok {
 		panic(fmt.Sprintf("lookup for BinaryExpr %s's BinOp failed",
@@ -718,7 +733,7 @@ func (node *BinaryExpr) memoizeFn() {
 // if the pair of arguments have a valid implementation for the given
 // BinaryOperator.
 func newBinExprIfValidOverload(op BinaryOperator, left TypedExpr, right TypedExpr) *BinaryExpr {
-	leftRet, rightRet := left.ReturnType(), right.ReturnType()
+	leftRet, rightRet := left.ResolvedType(), right.ResolvedType()
 	fn, ok := BinOps[op].lookupImpl(leftRet, rightRet)
 	if ok {
 		expr := &BinaryExpr{
@@ -940,22 +955,22 @@ func (node *CastExpr) Format(buf *bytes.Buffer, f FmtFlags) {
 }
 
 var (
-	boolCastTypes = []Datum{DNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString}
-	intCastTypes  = []Datum{DNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString,
+	boolCastTypes = []Type{TypeNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString}
+	intCastTypes  = []Type{TypeNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString,
 		TypeTimestamp, TypeTimestampTZ, TypeDate, TypeInterval}
-	floatCastTypes = []Datum{DNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString,
+	floatCastTypes = []Type{TypeNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString,
 		TypeTimestamp, TypeTimestampTZ, TypeDate, TypeInterval}
-	decimalCastTypes = []Datum{DNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString,
+	decimalCastTypes = []Type{TypeNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString,
 		TypeTimestamp, TypeTimestampTZ, TypeDate, TypeInterval}
-	stringCastTypes = []Datum{DNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString,
+	stringCastTypes = []Type{TypeNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString,
 		TypeBytes, TypeTimestamp, TypeTimestampTZ, TypeInterval, TypeDate}
-	bytesCastTypes     = []Datum{DNull, TypeString, TypeBytes}
-	dateCastTypes      = []Datum{DNull, TypeString, TypeDate, TypeTimestamp, TypeTimestampTZ, TypeInt}
-	timestampCastTypes = []Datum{DNull, TypeString, TypeDate, TypeTimestamp, TypeTimestampTZ, TypeInt}
-	intervalCastTypes  = []Datum{DNull, TypeString, TypeInt, TypeInterval}
+	bytesCastTypes     = []Type{TypeNull, TypeString, TypeBytes}
+	dateCastTypes      = []Type{TypeNull, TypeString, TypeDate, TypeTimestamp, TypeTimestampTZ, TypeInt}
+	timestampCastTypes = []Type{TypeNull, TypeString, TypeDate, TypeTimestamp, TypeTimestampTZ, TypeInt}
+	intervalCastTypes  = []Type{TypeNull, TypeString, TypeInt, TypeInterval}
 )
 
-func colTypeToTypeAndValidArgTypes(t ColumnType) (Datum, []Datum) {
+func colTypeToTypeAndValidArgTypes(t ColumnType) (Type, []Type) {
 	switch t.(type) {
 	case *BoolColType:
 		return TypeBool, boolCastTypes
@@ -981,7 +996,7 @@ func colTypeToTypeAndValidArgTypes(t ColumnType) (Datum, []Datum) {
 	return nil, nil
 }
 
-func (node *CastExpr) castTypeAndValidArgTypes() (Datum, []Datum) {
+func (node *CastExpr) castTypeAndValidArgTypes() (Type, []Type) {
 	return colTypeToTypeAndValidArgTypes(node.Type)
 }
 
@@ -1022,7 +1037,7 @@ func (node *AnnotateTypeExpr) TypedInnerExpr() TypedExpr {
 	return node.Expr.(TypedExpr)
 }
 
-func (node *AnnotateTypeExpr) annotationType() Datum {
+func (node *AnnotateTypeExpr) annotationType() Type {
 	typ, _ := colTypeToTypeAndValidArgTypes(node.Type)
 	return typ
 }
@@ -1048,7 +1063,6 @@ func (node *DString) String() string          { return AsString(node) }
 func (node *DTimestamp) String() string       { return AsString(node) }
 func (node *DTimestampTZ) String() string     { return AsString(node) }
 func (node *DTuple) String() string           { return AsString(node) }
-func (node *DPlaceholder) String() string     { return AsString(node) }
 func (node *ExistsExpr) String() string       { return AsString(node) }
 func (node Exprs) String() string             { return AsString(node) }
 func (node *FuncExpr) String() string         { return AsString(node) }
@@ -1068,6 +1082,6 @@ func (node *Tuple) String() string            { return AsString(node) }
 func (node *AnnotateTypeExpr) String() string { return AsString(node) }
 func (node *UnaryExpr) String() string        { return AsString(node) }
 func (node DefaultVal) String() string        { return AsString(node) }
-func (node Placeholder) String() string       { return AsString(node) }
+func (node *Placeholder) String() string      { return AsString(node) }
 func (node dNull) String() string             { return AsString(node) }
 func (list NameList) String() string          { return AsString(list) }

--- a/pkg/sql/parser/expr_test.go
+++ b/pkg/sql/parser/expr_test.go
@@ -103,7 +103,7 @@ func TestNormalizeNameInExpr(t *testing.T) {
 // TestExprString verifies that converting an expression to a string and back
 // doesn't change the (normalized) expression.
 func TestExprString(t *testing.T) {
-	defer mockNameTypes(map[string]Datum{
+	defer mockNameTypes(map[string]Type{
 		"a": TypeBool,
 		"b": TypeBool,
 		"c": TypeBool,

--- a/pkg/sql/parser/format.go
+++ b/pkg/sql/parser/format.go
@@ -67,14 +67,14 @@ func FormatNode(buf *bytes.Buffer, f FmtFlags, n NodeFormatter) {
 			buf.WriteByte('(')
 			n.Format(buf, f)
 			buf.WriteString(")[")
-			if rt := te.ReturnType(); rt == nil {
+			if rt := te.ResolvedType(); rt == nil {
 				// An attempt is made to pretty-print an expression that was
 				// not assigned a type yet. This should not happen, so we make
 				// it clear in the output this needs to be investigated
 				// further.
 				buf.WriteString(fmt.Sprintf("??? %v", te))
 			} else {
-				buf.WriteString(rt.Type())
+				buf.WriteString(rt.String())
 			}
 			buf.WriteByte(']')
 			return

--- a/pkg/sql/parser/indexed_vars.go
+++ b/pkg/sql/parser/indexed_vars.go
@@ -25,7 +25,7 @@ import (
 // String for IndexedVars.
 type IndexedVarContainer interface {
 	IndexedVarEval(idx int, ctx *EvalContext) (Datum, error)
-	IndexedVarReturnType(idx int) Datum
+	IndexedVarResolvedType(idx int) Type
 	IndexedVarFormat(buf *bytes.Buffer, f FmtFlags, idx int)
 }
 
@@ -49,7 +49,7 @@ func (v *IndexedVar) Walk(_ Visitor) Expr {
 }
 
 // TypeCheck is part of the Expr interface.
-func (v *IndexedVar) TypeCheck(_ *SemaContext, desired Datum) (TypedExpr, error) {
+func (v *IndexedVar) TypeCheck(_ *SemaContext, desired Type) (TypedExpr, error) {
 	return v, nil
 }
 
@@ -58,9 +58,9 @@ func (v *IndexedVar) Eval(ctx *EvalContext) (Datum, error) {
 	return v.container.IndexedVarEval(v.Idx, ctx)
 }
 
-// ReturnType is part of the TypedExpr interface.
-func (v *IndexedVar) ReturnType() Datum {
-	return v.container.IndexedVarReturnType(v.Idx)
+// ResolvedType is part of the TypedExpr interface.
+func (v *IndexedVar) ResolvedType() Type {
+	return v.container.IndexedVarResolvedType(v.Idx)
 }
 
 // Format implements the NodeFormatter interface.

--- a/pkg/sql/parser/indexed_vars_test.go
+++ b/pkg/sql/parser/indexed_vars_test.go
@@ -28,8 +28,8 @@ func (d testVarContainer) IndexedVarEval(idx int, ctx *EvalContext) (Datum, erro
 	return d[idx].Eval(ctx)
 }
 
-func (d testVarContainer) IndexedVarReturnType(idx int) Datum {
-	return d[idx].ReturnType()
+func (d testVarContainer) IndexedVarResolvedType(idx int) Type {
+	return d[idx].ResolvedType()
 }
 
 func (d testVarContainer) IndexedVarFormat(buf *bytes.Buffer, _ FmtFlags, idx int) {
@@ -71,11 +71,11 @@ func TestIndexedVars(t *testing.T) {
 		t.Errorf("invalid expression string '%s', expected '%s'", str, expectedStr)
 	}
 
-	d := typedExpr.ReturnType()
-	if !d.TypeEqual(TypeInt) {
-		t.Errorf("invalid expression type %s", d.Type())
+	typ := typedExpr.ResolvedType()
+	if !typ.Equal(TypeInt) {
+		t.Errorf("invalid expression type %s", typ)
 	}
-	d, err = typedExpr.Eval(&EvalContext{})
+	d, err := typedExpr.Eval(&EvalContext{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/parser/normalize.go
+++ b/pkg/sql/parser/normalize.go
@@ -95,7 +95,7 @@ func (expr *UnaryExpr) normalize(v *normalizeVisitor) TypedExpr {
 		return val
 	case UnaryMinus:
 		// -0 -> 0 (except for float which has negative zero)
-		if !val.ReturnType().TypeEqual(TypeFloat) && IsNumericZero(val) {
+		if val.ResolvedType() != TypeFloat && IsNumericZero(val) {
 			return val
 		}
 		switch b := val.(type) {
@@ -124,7 +124,7 @@ func (expr *UnaryExpr) normalize(v *normalizeVisitor) TypedExpr {
 func (expr *BinaryExpr) normalize(v *normalizeVisitor) TypedExpr {
 	left := expr.TypedLeft()
 	right := expr.TypedRight()
-	expectedType := expr.ReturnType()
+	expectedType := expr.ResolvedType()
 
 	if left == DNull || right == DNull {
 		return DNull
@@ -721,8 +721,8 @@ func IsNumericOne(expr TypedExpr) bool {
 
 // ReType ensures that the given numeric expression evaluates
 // to the requested type, inserting a cast if necessary.
-func ReType(expr TypedExpr, wantedType Datum) (TypedExpr, error) {
-	if expr.ReturnType().TypeEqual(wantedType) {
+func ReType(expr TypedExpr, wantedType Type) (TypedExpr, error) {
+	if expr.ResolvedType().Equal(wantedType) {
 		return expr, nil
 	}
 	reqType, err := DatumTypeToColumnType(wantedType)

--- a/pkg/sql/parser/normalize_test.go
+++ b/pkg/sql/parser/normalize_test.go
@@ -19,7 +19,7 @@ package parser
 import "testing"
 
 func TestNormalizeExpr(t *testing.T) {
-	defer mockNameTypes(map[string]Datum{
+	defer mockNameTypes(map[string]Type{
 		"a": TypeInt,
 		"b": TypeInt,
 		"c": TypeInt,

--- a/pkg/sql/parser/overload.go
+++ b/pkg/sql/parser/overload.go
@@ -25,7 +25,7 @@ import (
 // access to the parameter type list  and the return type of the implementation.
 type overloadImpl interface {
 	params() typeList
-	returnType() Datum
+	returnType() Type
 	// allows manually resolving preference between multiple compatible overloads
 	preferred() bool
 }
@@ -35,12 +35,12 @@ type typeList interface {
 	// match checks if all types in the typeList match the corresponding elements in types.
 	match(types ArgTypes) bool
 	// matchAt checks if the parameter type at index i of the typeList matches type typ.
-	matchAt(typ Datum, i int) bool
+	matchAt(typ Type, i int) bool
 	// matchLen checks that the typeList can support l parameters.
 	matchLen(l int) bool
 	// getAt returns the type at the given index in the typeList, or nil if the typeList
 	// cannot have a parameter at index i.
-	getAt(i int) Datum
+	getAt(i int) Type
 	// human readable signature
 	String() string
 }
@@ -53,7 +53,7 @@ var _ typeList = SingleType{}
 
 // ArgTypes is a typeList implementation that accepts a specific number of
 // argument types.
-type ArgTypes []Datum
+type ArgTypes []Type
 
 func (a ArgTypes) match(types ArgTypes) bool {
 	if len(types) != len(a) {
@@ -67,34 +67,25 @@ func (a ArgTypes) match(types ArgTypes) bool {
 	return true
 }
 
-func (a ArgTypes) matchAt(typ Datum, i int) bool {
-	if i >= len(a) {
-		return false
-	}
-	if _, ok := typ.(*DTuple); ok {
-		typ = TypeTuple
-	}
-	return a[i].TypeEqual(typ)
+func (a ArgTypes) matchAt(typ Type, i int) bool {
+	return i < len(a) && a[i].FamilyEqual(typ)
 }
 
 func (a ArgTypes) matchLen(l int) bool {
 	return len(a) == l
 }
 
-func (a ArgTypes) getAt(i int) Datum {
+func (a ArgTypes) getAt(i int) Type {
 	return a[i]
 }
 
 func (a ArgTypes) String() string {
 	var s bytes.Buffer
-	first := true
-	for i := range a {
-		if first {
-			first = false
-		} else {
+	for i, typ := range a {
+		if i > 0 {
 			s.WriteString(", ")
 		}
-		s.WriteString(a[i].Type())
+		s.WriteString(typ.String())
 	}
 	return s.String()
 }
@@ -104,7 +95,7 @@ func (a ArgTypes) String() string {
 // human-readable signature.
 type NamedArgTypes []struct {
 	Name string
-	Typ  Datum
+	Typ  Type
 }
 
 func (a NamedArgTypes) match(types ArgTypes) bool {
@@ -119,21 +110,15 @@ func (a NamedArgTypes) match(types ArgTypes) bool {
 	return true
 }
 
-func (a NamedArgTypes) matchAt(typ Datum, i int) bool {
-	if i >= len(a) {
-		return false
-	}
-	if _, ok := typ.(*DTuple); ok {
-		typ = TypeTuple
-	}
-	return a[i].Typ.TypeEqual(typ)
+func (a NamedArgTypes) matchAt(typ Type, i int) bool {
+	return i < len(a) && a[i].Typ.FamilyEqual(typ)
 }
 
 func (a NamedArgTypes) matchLen(l int) bool {
 	return len(a) == l
 }
 
-func (a NamedArgTypes) getAt(i int) Datum {
+func (a NamedArgTypes) getAt(i int) Type {
 	return a[i].Typ
 }
 
@@ -145,7 +130,7 @@ func (a NamedArgTypes) String() string {
 		}
 		s.WriteString(arg.Name)
 		s.WriteString(": ")
-		s.WriteString(arg.Typ.Type())
+		s.WriteString(arg.Typ.String())
 	}
 	return s.String()
 }
@@ -157,7 +142,7 @@ func (AnyType) match(types ArgTypes) bool {
 	return true
 }
 
-func (AnyType) matchAt(typ Datum, i int) bool {
+func (AnyType) matchAt(typ Type, i int) bool {
 	return true
 }
 
@@ -165,7 +150,7 @@ func (AnyType) matchLen(l int) bool {
 	return true
 }
 
-func (AnyType) getAt(i int) Datum {
+func (AnyType) getAt(i int) Type {
 	panic("getAt called on AnyType")
 }
 
@@ -177,7 +162,7 @@ func (AnyType) String() string {
 // arguments and matches when each argument is either NULL or of the type
 // typ.
 type VariadicType struct {
-	Typ Datum
+	Typ Type
 }
 
 func (v VariadicType) match(types ArgTypes) bool {
@@ -189,27 +174,27 @@ func (v VariadicType) match(types ArgTypes) bool {
 	return true
 }
 
-func (v VariadicType) matchAt(typ Datum, i int) bool {
-	return typ == DNull || typ.TypeEqual(v.Typ)
+func (v VariadicType) matchAt(typ Type, i int) bool {
+	return typ == TypeNull || typ.Equal(v.Typ)
 }
 
 func (v VariadicType) matchLen(l int) bool {
 	return true
 }
 
-func (v VariadicType) getAt(i int) Datum {
+func (v VariadicType) getAt(i int) Type {
 	return v.Typ
 }
 
 func (v VariadicType) String() string {
-	return v.Typ.Type() + "..."
+	return fmt.Sprintf("%s...", v.Typ)
 }
 
 // SingleType is a typeList implementation which accepts a single
 // argument of type typ. It is logically identical to an ArgTypes
 // implementation with length 1, but avoids the slice allocation.
 type SingleType struct {
-	Typ Datum
+	Typ Type
 }
 
 func (s SingleType) match(types ArgTypes) bool {
@@ -219,18 +204,18 @@ func (s SingleType) match(types ArgTypes) bool {
 	return s.matchAt(types[0], 0)
 }
 
-func (s SingleType) matchAt(typ Datum, i int) bool {
+func (s SingleType) matchAt(typ Type, i int) bool {
 	if i != 0 {
 		return false
 	}
-	return typ.TypeEqual(s.Typ)
+	return typ.Equal(s.Typ)
 }
 
 func (s SingleType) matchLen(l int) bool {
 	return l == 1
 }
 
-func (s SingleType) getAt(i int) Datum {
+func (s SingleType) getAt(i int) Type {
 	if i != 0 {
 		return nil
 	}
@@ -238,7 +223,7 @@ func (s SingleType) getAt(i int) Datum {
 }
 
 func (s SingleType) String() string {
-	return s.Typ.Type()
+	return s.Typ.String()
 }
 
 // typeCheckOverloadedExprs determines the correct overload to use for the given set of
@@ -246,7 +231,7 @@ func (s SingleType) String() string {
 // parameters after being type checked, along with the chosen overloadImpl. If an overloaded
 // function implementation could not be determined, the overloadImpl return value will be nil.
 func typeCheckOverloadedExprs(
-	ctx *SemaContext, desired Datum, overloads []overloadImpl, exprs ...Expr,
+	ctx *SemaContext, desired Type, overloads []overloadImpl, exprs ...Expr,
 ) ([]TypedExpr, overloadImpl, error) {
 	// Special-case the AnyType overload. We determine its return type by checking that
 	// all parameters have the same type.
@@ -300,10 +285,7 @@ func typeCheckOverloadedExprs(
 				return err
 			}
 			// If we dont want to error on args, avoid type checking them without a desired type.
-			typedExprs[expr.i] = &DPlaceholder{
-				name: StripParens(expr.e).(Placeholder).Name,
-				pmap: ctx.Placeholders,
-			}
+			typedExprs[expr.i] = StripParens(expr.e).(*Placeholder)
 		}
 		return nil
 	}
@@ -366,7 +348,7 @@ func typeCheckOverloadedExprs(
 		}
 		typedExprs[expr.i] = typ
 		filterOverloads(func(o overloadImpl) bool {
-			return o.params().matchAt(typ.ReturnType(), expr.i)
+			return o.params().matchAt(typ.ResolvedType(), expr.i)
 		})
 	}
 
@@ -388,9 +370,8 @@ func typeCheckOverloadedExprs(
 				typ, err := expr.e.TypeCheck(ctx, des)
 				if err != nil {
 					return true, nil, fmt.Errorf("error type checking constant value: %v", err)
-				} else if des != nil && !typ.ReturnType().TypeEqual(des) {
-					panic(fmt.Errorf("desired constant value type %s but set type %s",
-						des.Type(), typ.ReturnType().Type()))
+				} else if des != nil && !typ.ResolvedType().Equal(des) {
+					panic(fmt.Errorf("desired constant value type %s but set type %s", des, typ.ResolvedType()))
 				}
 				typedExprs[expr.i] = typ
 			}
@@ -419,25 +400,25 @@ func typeCheckOverloadedExprs(
 	// The first heuristic is to prefer candidates that return the desired type.
 	if desired != nil {
 		filterOverloads(func(o overloadImpl) bool {
-			return o.returnType().TypeEqual(desired)
+			return o.returnType().Equal(desired)
 		})
 		if ok, fn, err := checkReturn(); ok {
 			return typedExprs, fn, err
 		}
 	}
 
-	var homogeneousTyp Datum
+	var homogeneousTyp Type
 	if len(resolvableExprs) > 0 {
-		homogeneousTyp = typedExprs[resolvableExprs[0].i].ReturnType()
+		homogeneousTyp = typedExprs[resolvableExprs[0].i].ResolvedType()
 		for _, resExprs := range resolvableExprs[1:] {
-			if !homogeneousTyp.TypeEqual(typedExprs[resExprs.i].ReturnType()) {
+			if !homogeneousTyp.Equal(typedExprs[resExprs.i].ResolvedType()) {
 				homogeneousTyp = nil
 				break
 			}
 		}
 	}
 
-	var bestConstType Datum
+	var bestConstType Type
 	if len(constExprs) > 0 {
 		before := overloads
 
@@ -455,7 +436,7 @@ func typeCheckOverloadedExprs(
 			if all {
 				for _, expr := range constExprs {
 					filterOverloads(func(o overloadImpl) bool {
-						return o.params().getAt(expr.i).TypeEqual(homogeneousTyp)
+						return o.params().getAt(expr.i).Equal(homogeneousTyp)
 					})
 				}
 			}
@@ -474,7 +455,7 @@ func typeCheckOverloadedExprs(
 			natural := naturalConstantType(expr.e.(Constant))
 			if natural != nil {
 				filterOverloads(func(o overloadImpl) bool {
-					return o.params().getAt(expr.i).TypeEqual(natural)
+					return o.params().getAt(expr.i).Equal(natural)
 				})
 			}
 		}
@@ -491,14 +472,14 @@ func typeCheckOverloadedExprs(
 		bestConstType = commonNumericConstantType(constExprs)
 		for _, expr := range constExprs {
 			filterOverloads(func(o overloadImpl) bool {
-				return o.params().getAt(expr.i).TypeEqual(bestConstType)
+				return o.params().getAt(expr.i).Equal(bestConstType)
 			})
 		}
 		if ok, fn, err := checkReturn(); ok {
 			return typedExprs, fn, err
 		}
 		if homogeneousTyp != nil {
-			if !homogeneousTyp.TypeEqual(bestConstType) {
+			if !homogeneousTyp.Equal(bestConstType) {
 				homogeneousTyp = nil
 			}
 		} else {
@@ -512,7 +493,7 @@ func typeCheckOverloadedExprs(
 	if homogeneousTyp != nil && len(placeholderExprs) > 0 {
 		for _, expr := range placeholderExprs {
 			filterOverloads(func(o overloadImpl) bool {
-				return o.params().getAt(expr.i).TypeEqual(homogeneousTyp)
+				return o.params().getAt(expr.i).Equal(homogeneousTyp)
 			})
 		}
 		if ok, fn, err := checkReturn(); ok {

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -76,7 +76,7 @@ func (p *Parser) Parse(sql string, syntax Syntax) (stmts StatementList, err erro
 
 // NoTypePreference can be provided to TypeCheck's desired type parameter to indicate that
 // the caller of the function has no preference on the type of the resulting TypedExpr.
-var NoTypePreference = Datum(nil)
+var NoTypePreference = Type(nil)
 
 // TypeCheck performs type checking on the provided expression tree, returning
 // the new typed expression tree, which additionally permits evaluation and type
@@ -86,7 +86,7 @@ var NoTypePreference = Datum(nil)
 // their inferred types in the provided context. The optional desired parameter can
 // be used to hint the desired type for the root of the resulting typed expression
 // tree.
-func TypeCheck(expr Expr, ctx *SemaContext, desired Datum) (TypedExpr, error) {
+func TypeCheck(expr Expr, ctx *SemaContext, desired Type) (TypedExpr, error) {
 	expr, err := foldConstantLiterals(expr)
 	if err != nil {
 		return nil, err
@@ -98,14 +98,13 @@ func TypeCheck(expr Expr, ctx *SemaContext, desired Datum) (TypedExpr, error) {
 // an identical manner to TypeCheck. It then asserts that the resulting TypedExpr
 // has the provided return type, returning both the typed expression and an error
 // if it does not.
-func TypeCheckAndRequire(expr Expr, ctx *SemaContext, required Datum, op string) (TypedExpr, error) {
+func TypeCheckAndRequire(expr Expr, ctx *SemaContext, required Type, op string) (TypedExpr, error) {
 	typedExpr, err := TypeCheck(expr, ctx, required)
 	if err != nil {
 		return nil, err
 	}
-	if typ := typedExpr.ReturnType(); !(typ.TypeEqual(required) || typ == DNull) {
-		return typedExpr, fmt.Errorf("argument of %s must be type %s, not type %s",
-			op, required.Type(), typ.Type())
+	if typ := typedExpr.ResolvedType(); !(typ.Equal(required) || typ == TypeNull) {
+		return typedExpr, fmt.Errorf("argument of %s must be type %s, not type %s", op, required, typ)
 	}
 	return typedExpr, nil
 }

--- a/pkg/sql/parser/placeholders.go
+++ b/pkg/sql/parser/placeholders.go
@@ -19,7 +19,7 @@ package parser
 import "fmt"
 
 // PlaceholderTypes relates placeholder names to their resolved type.
-type PlaceholderTypes map[string]Datum
+type PlaceholderTypes map[string]Type
 
 // QueryArguments relates placeholder names to their provided query argument.
 type QueryArguments map[string]Datum
@@ -55,7 +55,7 @@ func (p *PlaceholderInfo) Assign(src *PlaceholderInfo) {
 
 // Type returns the known type of a placeholder.
 // Returns false in the 2nd value if the placeholder is not typed.
-func (p *PlaceholderInfo) Type(name string) (Datum, bool) {
+func (p *PlaceholderInfo) Type(name string) (Type, bool) {
 	if t, ok := p.Types[name]; ok {
 		return t, true
 	}
@@ -80,15 +80,15 @@ func (p *PlaceholderInfo) SetValue(name string, val Datum) {
 	p.Values[name] = val
 	if _, ok := p.Types[name]; !ok {
 		// No type yet, infer from value
-		p.Types[name] = val.ReturnType()
+		p.Types[name] = val.ResolvedType()
 	}
 }
 
 // SetType assignes a known type to a placeholder.
 // Reports an error if another type was previously assigned.
-func (p *PlaceholderInfo) SetType(name string, typ Datum) error {
-	if t, ok := p.Types[name]; ok && !typ.TypeEqual(t) {
-		return fmt.Errorf("placeholder %s already has type %s, cannot assign %s", name, t.Type(), typ.Type())
+func (p *PlaceholderInfo) SetType(name string, typ Type) error {
+	if t, ok := p.Types[name]; ok && !typ.Equal(t) {
+		return fmt.Errorf("placeholder %s already has type %s, cannot assign %s", name, t, typ)
 	}
 	p.Types[name] = typ
 	return nil
@@ -113,7 +113,7 @@ func (p *PlaceholderInfo) SetTypes(src PlaceholderTypes) {
 // expression or a placeholder expression within nested parentheses, and if so,
 // whether the placeholder's type remains unset in the PlaceholderInfo.
 func (p *PlaceholderInfo) IsUnresolvedPlaceholder(expr Expr) bool {
-	if t, ok := StripParens(expr).(Placeholder); ok {
+	if t, ok := StripParens(expr).(*Placeholder); ok {
 		_, res := p.Types[t.Name]
 		return !res
 	}

--- a/pkg/sql/parser/sql.go
+++ b/pkg/sql/parser/sql.go
@@ -5838,7 +5838,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:1329
 		{
-			sqlVAL.union.val = Placeholder{Name: sqlDollar[1].str}
+			sqlVAL.union.val = NewPlaceholder(sqlDollar[1].str)
 		}
 	case 156:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
@@ -8662,7 +8662,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:3652
 		{
-			sqlVAL.union.val = Placeholder{Name: sqlDollar[1].str}
+			sqlVAL.union.val = NewPlaceholder(sqlDollar[1].str)
 		}
 	case 634:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1327,7 +1327,7 @@ var_value:
 | numeric_only
 | PLACEHOLDER
   {
-    $$.val = Placeholder{Name: $1}
+    $$.val = NewPlaceholder($1)
   }
 
 iso_level:
@@ -3652,7 +3652,7 @@ c_expr:
 | a_expr_const
 | PLACEHOLDER
   {
-    $$.val = Placeholder{Name: $1}
+    $$.val = NewPlaceholder($1)
   }
 | '(' a_expr ')'
   {

--- a/pkg/sql/parser/star_datum.go
+++ b/pkg/sql/parser/star_datum.go
@@ -48,16 +48,18 @@ func (s *StarDatum) String() string { return AsString(s) }
 func (s *StarDatum) Walk(v Visitor) Expr { return s }
 
 // TypeCheck implements the Expr interface.
-func (s *StarDatum) TypeCheck(_ *SemaContext, _ Datum) (TypedExpr, error) {
+func (s *StarDatum) TypeCheck(_ *SemaContext, _ Type) (TypedExpr, error) {
 	return s, nil
 }
 
+var constDInt = DInt(0)
+
 // Eval implements the TypedExpr interface.
 func (*StarDatum) Eval(ctx *EvalContext) (Datum, error) {
-	return TypeInt.Eval(ctx)
+	return &constDInt, nil
 }
 
-// ReturnType implements the TypedExpr interface.
-func (*StarDatum) ReturnType() Datum {
-	return TypeInt.ReturnType()
+// ResolvedType implements the TypedExpr interface.
+func (*StarDatum) ResolvedType() Type {
+	return TypeInt
 }

--- a/pkg/sql/parser/type.go
+++ b/pkg/sql/parser/type.go
@@ -1,0 +1,234 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tamir Duberstein (tamird@gmail.com)
+
+package parser
+
+import (
+	"bytes"
+	"fmt"
+	"unsafe"
+)
+
+// Type represents a SQL type.
+type Type interface {
+	fmt.Stringer
+	// Equal returns whether the receiver and the other type are the same. Prefer
+	// == for determining equality with a TypeXxx constant except TypeTuple and
+	// TypePlaceholder.
+	Equal(other Type) bool
+	// FamilyEqual returns whether the receiver and the other type have the same
+	// constructor.
+	FamilyEqual(other Type) bool
+
+	// Size returns a lower bound on the total size of a Datum whose type is the
+	// receiver in bytes, including memory that is pointed at (even if shared
+	// between Datum instances) but excluding allocation overhead.
+	//
+	// The second argument indicates whether data of this type have different
+	// sizes.
+	//
+	// It holds for every Datum d that d.Size() >= d.ResolvedType().Size().
+	Size() (uintptr, bool)
+}
+
+const (
+	fixedSize    = false
+	variableSize = true
+)
+
+var (
+	// TypeNull is the type of a DNull. Can be compared with ==.
+	TypeNull Type = tNull{}
+	// TypeBool is the type of a DBool. Can be compared with ==.
+	TypeBool Type = tBool{}
+	// TypeInt is the type of a DInt. Can be compared with ==.
+	TypeInt Type = tInt{}
+	// TypeFloat is the type of a DFloat. Can be compared with ==.
+	TypeFloat Type = tFloat{}
+	// TypeDecimal is the type of a DDecimal. Can be compared with ==.
+	TypeDecimal Type = tDecimal{}
+	// TypeString is the type of a DString. Can be compared with ==.
+	TypeString Type = tString{}
+	// TypeBytes is the type of a DBytes. Can be compared with ==.
+	TypeBytes Type = tBytes{}
+	// TypeDate is the type of a DDate. Can be compared with ==.
+	TypeDate Type = tDate{}
+	// TypeTimestamp is the type of a DTimestamp. Can be compared with ==.
+	TypeTimestamp Type = tTimestamp{}
+	// TypeTimestampTZ is the type of a DTimestampTZ. Can be compared with ==.
+	TypeTimestampTZ Type = tTimestampTZ{}
+	// TypeInterval is the type of a DInterval. Can be compared with ==.
+	TypeInterval Type = tInterval{}
+	// TypeTuple is the type family of a DTuple. CANNOT be compared with ==.
+	TypeTuple Type = TTuple(nil)
+	// TypePlaceholder is the type family of a placeholder. CANNOT be compared
+	// with ==.
+	TypePlaceholder Type = TPlaceholder{}
+)
+
+// Do not instantiate the tXxx types elsewhere. The variables above are intended
+// to be singletons.
+type tNull struct{}
+
+func (tNull) String() string              { return "NULL" }
+func (tNull) Equal(other Type) bool       { return other == TypeNull }
+func (tNull) FamilyEqual(other Type) bool { return other == TypeNull }
+func (tNull) Size() (uintptr, bool)       { return unsafe.Sizeof(dNull{}), fixedSize }
+
+type tBool struct{}
+
+func (tBool) String() string              { return "bool" }
+func (tBool) Equal(other Type) bool       { return other == TypeBool }
+func (tBool) FamilyEqual(other Type) bool { return other == TypeBool }
+func (tBool) Size() (uintptr, bool)       { return unsafe.Sizeof(DBool(false)), fixedSize }
+
+type tInt struct{}
+
+func (tInt) String() string              { return "int" }
+func (tInt) Equal(other Type) bool       { return other == TypeInt }
+func (tInt) FamilyEqual(other Type) bool { return other == TypeInt }
+func (tInt) Size() (uintptr, bool)       { return unsafe.Sizeof(DInt(0)), fixedSize }
+
+type tFloat struct{}
+
+func (tFloat) String() string              { return "float" }
+func (tFloat) Equal(other Type) bool       { return other == TypeFloat }
+func (tFloat) FamilyEqual(other Type) bool { return other == TypeFloat }
+func (tFloat) Size() (uintptr, bool)       { return unsafe.Sizeof(DFloat(0.0)), fixedSize }
+
+type tDecimal struct{}
+
+func (tDecimal) String() string              { return "decimal" }
+func (tDecimal) Equal(other Type) bool       { return other == TypeDecimal }
+func (tDecimal) FamilyEqual(other Type) bool { return other == TypeDecimal }
+func (tDecimal) Size() (uintptr, bool)       { return unsafe.Sizeof(DDecimal{}), variableSize }
+
+type tString struct{}
+
+func (tString) String() string              { return "string" }
+func (tString) Equal(other Type) bool       { return other == TypeString }
+func (tString) FamilyEqual(other Type) bool { return other == TypeString }
+func (tString) Size() (uintptr, bool)       { return unsafe.Sizeof(DString("")), variableSize }
+
+type tBytes struct{}
+
+func (tBytes) String() string              { return "bytes" }
+func (tBytes) Equal(other Type) bool       { return other == TypeBytes }
+func (tBytes) FamilyEqual(other Type) bool { return other == TypeBytes }
+func (tBytes) Size() (uintptr, bool)       { return unsafe.Sizeof(DBytes("")), variableSize }
+
+type tDate struct{}
+
+func (tDate) String() string              { return "date" }
+func (tDate) Equal(other Type) bool       { return other == TypeDate }
+func (tDate) FamilyEqual(other Type) bool { return other == TypeDate }
+func (tDate) Size() (uintptr, bool)       { return unsafe.Sizeof(DDate(0)), fixedSize }
+
+type tTimestamp struct{}
+
+func (tTimestamp) String() string              { return "timestamp" }
+func (tTimestamp) Equal(other Type) bool       { return other == TypeTimestamp }
+func (tTimestamp) FamilyEqual(other Type) bool { return other == TypeTimestamp }
+func (tTimestamp) Size() (uintptr, bool)       { return unsafe.Sizeof(DTimestamp{}), fixedSize }
+
+type tTimestampTZ struct{}
+
+func (tTimestampTZ) String() string              { return "timestamptz" }
+func (tTimestampTZ) Equal(other Type) bool       { return other == TypeTimestampTZ }
+func (tTimestampTZ) FamilyEqual(other Type) bool { return other == TypeTimestampTZ }
+func (tTimestampTZ) Size() (uintptr, bool)       { return unsafe.Sizeof(DTimestampTZ{}), fixedSize }
+
+type tInterval struct{}
+
+func (tInterval) String() string              { return "interval" }
+func (tInterval) Equal(other Type) bool       { return other == TypeInterval }
+func (tInterval) FamilyEqual(other Type) bool { return other == TypeInterval }
+func (tInterval) Size() (uintptr, bool)       { return unsafe.Sizeof(DInterval{}), fixedSize }
+
+// TTuple is the type of a DTuple.
+type TTuple []Type
+
+// String implements the fmt.Stringer interface.
+func (t TTuple) String() string {
+	var buf bytes.Buffer
+	buf.WriteString("tuple")
+	if t != nil {
+		buf.WriteByte('{')
+		for i, typ := range t {
+			if i != 0 {
+				buf.WriteString(", ")
+			}
+			buf.WriteString(typ.String())
+		}
+		buf.WriteByte('}')
+	}
+	return buf.String()
+}
+
+// Equal implements the Type interface.
+func (t TTuple) Equal(other Type) bool {
+	u, ok := other.(TTuple)
+	if !ok || len(t) != len(u) {
+		return false
+	}
+	for i, typ := range t {
+		if !typ.Equal(u[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// FamilyEqual implements the Type interface.
+func (TTuple) FamilyEqual(other Type) bool {
+	_, ok := other.(TTuple)
+	return ok
+}
+
+// Size implements the Type interface.
+func (t TTuple) Size() (uintptr, bool) {
+	sz := uintptr(0)
+	variable := false
+	for _, typ := range t {
+		typsz, typvariable := typ.Size()
+		sz += typsz
+		variable = variable || typvariable
+	}
+	return sz, variable
+}
+
+// TPlaceholder is the type of a placeholder.
+type TPlaceholder struct {
+	Name string
+}
+
+// String implements the fmt.Stringer interface.
+func (t TPlaceholder) String() string { return fmt.Sprintf("placeholder{%s}", t.Name) }
+
+// Equal implements the Type interface.
+func (t TPlaceholder) Equal(other Type) bool {
+	u, ok := other.(*TPlaceholder)
+	return ok && t.Name == u.Name
+}
+
+// FamilyEqual implements the Type interface.
+func (TPlaceholder) FamilyEqual(other Type) bool {
+	_, ok := other.(*TPlaceholder)
+	return ok
+}
+
+// Size implements the Type interface.
+func (t TPlaceholder) Size() (uintptr, bool) { panic("TPlaceholder.Size() is undefined") }

--- a/pkg/sql/parser/type_check_test.go
+++ b/pkg/sql/parser/type_check_test.go
@@ -180,7 +180,7 @@ func ddecimal(f float64) copyableExpr {
 }
 func placeholder(name string) copyableExpr {
 	return func() Expr {
-		return Placeholder{name}
+		return NewPlaceholder(name)
 	}
 }
 func tuple(exprs ...copyableExpr) copyableExpr {
@@ -188,9 +188,8 @@ func tuple(exprs ...copyableExpr) copyableExpr {
 		return &Tuple{Exprs: buildExprs(exprs)}
 	}
 }
-func dtuple(datums ...Datum) *DTuple {
-	dt := DTuple(datums)
-	return &dt
+func ttuple(types ...Type) TTuple {
+	return TTuple(types)
 }
 
 func forEachPerm(exprs []copyableExpr, i int, fn func([]copyableExpr)) {
@@ -214,10 +213,10 @@ func clonePlaceholderTypes(args PlaceholderTypes) PlaceholderTypes {
 
 type sameTypedExprsTestCase struct {
 	ptypes  PlaceholderTypes
-	desired Datum
+	desired Type
 	exprs   []copyableExpr
 
-	expectedType   Datum
+	expectedType   Type
 	expectedPTypes PlaceholderTypes
 }
 
@@ -232,8 +231,9 @@ func attemptTypeCheckSameTypedExprs(t *testing.T, idx int, test sameTypedExprsTe
 		if err != nil {
 			t.Errorf("%d: unexpected error returned from typeCheckSameTypedExprs: %v", idx, err)
 		} else {
-			if !typ.TypeEqual(test.expectedType) {
-				t.Errorf("%d: expected type %s:%s when type checking %s:%s, found %s", idx, test.expectedType, test.expectedType.Type(), buildExprs(exprs), typ, typ.Type())
+			if !typ.Equal(test.expectedType) {
+				t.Errorf("%d: expected type %s when type checking %s, found %s",
+					idx, test.expectedType, buildExprs(exprs), typ)
 			}
 			if !reflect.DeepEqual(ctx.Placeholders.Types, test.expectedPTypes) {
 				t.Errorf("%d: expected placeholder types %v after typeCheckSameTypedExprs for %v, found %v", idx, test.expectedPTypes, buildExprs(exprs), ctx.Placeholders.Types)
@@ -271,8 +271,8 @@ func TestTypeCheckSameTypedExprs(t *testing.T) {
 		{nil, nil, exprs(intConst("1"), placeholder("a")), TypeInt, mapPTypesInt},
 		{nil, nil, exprs(decConst("1.1"), placeholder("a")), TypeDecimal, mapPTypesDecimal},
 		// Verify dealing with Null.
-		{nil, nil, exprs(dnull), DNull, nil},
-		{nil, nil, exprs(dnull, dnull), DNull, nil},
+		{nil, nil, exprs(dnull), TypeNull, nil},
+		{nil, nil, exprs(dnull, dnull), TypeNull, nil},
 		{nil, nil, exprs(dnull, intConst("1")), TypeInt, nil},
 		{nil, nil, exprs(dnull, decConst("1.1")), TypeDecimal, nil},
 		{nil, nil, exprs(dnull, dint(1)), TypeInt, nil},
@@ -304,31 +304,31 @@ func TestTypeCheckSameTypedExprs(t *testing.T) {
 func TestTypeCheckSameTypedTupleExprs(t *testing.T) {
 	for i, d := range []sameTypedExprsTestCase{
 		// // Constants.
-		{nil, nil, exprs(tuple(intConst("1"))), dtuple(TypeInt), nil},
-		{nil, nil, exprs(tuple(intConst("1"), intConst("1"))), dtuple(TypeInt, TypeInt), nil},
-		{nil, nil, exprs(tuple(intConst("1")), tuple(intConst("1"))), dtuple(TypeInt), nil},
-		{nil, nil, exprs(tuple(intConst("1")), tuple(decConst("1.0"))), dtuple(TypeDecimal), nil},
-		{nil, nil, exprs(tuple(intConst("1")), tuple(decConst("1.1"))), dtuple(TypeDecimal), nil},
+		{nil, nil, exprs(tuple(intConst("1"))), ttuple(TypeInt), nil},
+		{nil, nil, exprs(tuple(intConst("1"), intConst("1"))), ttuple(TypeInt, TypeInt), nil},
+		{nil, nil, exprs(tuple(intConst("1")), tuple(intConst("1"))), ttuple(TypeInt), nil},
+		{nil, nil, exprs(tuple(intConst("1")), tuple(decConst("1.0"))), ttuple(TypeDecimal), nil},
+		{nil, nil, exprs(tuple(intConst("1")), tuple(decConst("1.1"))), ttuple(TypeDecimal), nil},
 		// Resolved exprs.
-		{nil, nil, exprs(tuple(dint(1)), tuple(dint(1))), dtuple(TypeInt), nil},
-		{nil, nil, exprs(tuple(dint(1), ddecimal(1)), tuple(dint(1), ddecimal(1))), dtuple(TypeInt, TypeDecimal), nil},
+		{nil, nil, exprs(tuple(dint(1)), tuple(dint(1))), ttuple(TypeInt), nil},
+		{nil, nil, exprs(tuple(dint(1), ddecimal(1)), tuple(dint(1), ddecimal(1))), ttuple(TypeInt, TypeDecimal), nil},
 		// Mixing constants and resolved exprs.
-		{nil, nil, exprs(tuple(dint(1), decConst("1.1")), tuple(intConst("1"), ddecimal(1))), dtuple(TypeInt, TypeDecimal), nil},
-		{nil, nil, exprs(tuple(dint(1), decConst("1.0")), tuple(intConst("1"), dint(1))), dtuple(TypeInt, TypeInt), nil},
+		{nil, nil, exprs(tuple(dint(1), decConst("1.1")), tuple(intConst("1"), ddecimal(1))), ttuple(TypeInt, TypeDecimal), nil},
+		{nil, nil, exprs(tuple(dint(1), decConst("1.0")), tuple(intConst("1"), dint(1))), ttuple(TypeInt, TypeInt), nil},
 		// Mixing resolved placeholders with constants and resolved exprs.
-		{mapPTypesDecimal, nil, exprs(tuple(ddecimal(1), intConst("1")), tuple(placeholder("a"), placeholder("a"))), dtuple(TypeDecimal, TypeDecimal), mapPTypesDecimal},
-		{mapPTypesDecimalAndDecimal, nil, exprs(tuple(placeholder("b"), intConst("1")), tuple(placeholder("a"), placeholder("a"))), dtuple(TypeDecimal, TypeDecimal), mapPTypesDecimalAndDecimal},
-		{mapPTypesIntAndDecimal, nil, exprs(tuple(intConst("1"), intConst("1")), tuple(placeholder("a"), placeholder("b"))), dtuple(TypeInt, TypeDecimal), mapPTypesIntAndDecimal},
+		{mapPTypesDecimal, nil, exprs(tuple(ddecimal(1), intConst("1")), tuple(placeholder("a"), placeholder("a"))), ttuple(TypeDecimal, TypeDecimal), mapPTypesDecimal},
+		{mapPTypesDecimalAndDecimal, nil, exprs(tuple(placeholder("b"), intConst("1")), tuple(placeholder("a"), placeholder("a"))), ttuple(TypeDecimal, TypeDecimal), mapPTypesDecimalAndDecimal},
+		{mapPTypesIntAndDecimal, nil, exprs(tuple(intConst("1"), intConst("1")), tuple(placeholder("a"), placeholder("b"))), ttuple(TypeInt, TypeDecimal), mapPTypesIntAndDecimal},
 		// Mixing unresolved placeholders with constants and resolved exprs.
-		{nil, nil, exprs(tuple(ddecimal(1), intConst("1")), tuple(placeholder("a"), placeholder("a"))), dtuple(TypeDecimal, TypeDecimal), mapPTypesDecimal},
-		{nil, nil, exprs(tuple(intConst("1"), intConst("1")), tuple(placeholder("a"), placeholder("b"))), dtuple(TypeInt, TypeInt), mapPTypesIntAndInt},
+		{nil, nil, exprs(tuple(ddecimal(1), intConst("1")), tuple(placeholder("a"), placeholder("a"))), ttuple(TypeDecimal, TypeDecimal), mapPTypesDecimal},
+		{nil, nil, exprs(tuple(intConst("1"), intConst("1")), tuple(placeholder("a"), placeholder("b"))), ttuple(TypeInt, TypeInt), mapPTypesIntAndInt},
 		// Verify dealing with Null.
-		{nil, nil, exprs(tuple(intConst("1"), dnull), tuple(dnull, decConst("1"))), dtuple(TypeInt, TypeDecimal), nil},
-		{nil, nil, exprs(tuple(dint(1), dnull), tuple(dnull, ddecimal(1))), dtuple(TypeInt, TypeDecimal), nil},
+		{nil, nil, exprs(tuple(intConst("1"), dnull), tuple(dnull, decConst("1"))), ttuple(TypeInt, TypeDecimal), nil},
+		{nil, nil, exprs(tuple(dint(1), dnull), tuple(dnull, ddecimal(1))), ttuple(TypeInt, TypeDecimal), nil},
 		// Verify desired type when possible.
-		{nil, dtuple(TypeInt, TypeDecimal), exprs(tuple(intConst("1"), intConst("1")), tuple(intConst("1"), intConst("1"))), dtuple(TypeInt, TypeDecimal), nil},
+		{nil, ttuple(TypeInt, TypeDecimal), exprs(tuple(intConst("1"), intConst("1")), tuple(intConst("1"), intConst("1"))), ttuple(TypeInt, TypeDecimal), nil},
 		// Verify desired type when possible with unresolved constants.
-		{nil, dtuple(TypeInt, TypeDecimal), exprs(tuple(placeholder("a"), intConst("1")), tuple(intConst("1"), placeholder("b"))), dtuple(TypeInt, TypeDecimal), mapPTypesIntAndDecimal},
+		{nil, ttuple(TypeInt, TypeDecimal), exprs(tuple(placeholder("a"), intConst("1")), tuple(intConst("1"), placeholder("b"))), ttuple(TypeInt, TypeDecimal), mapPTypesIntAndDecimal},
 	} {
 		attemptTypeCheckSameTypedExprs(t, i, d)
 	}
@@ -343,7 +343,7 @@ func TestTypeCheckSameTypedExprsError(t *testing.T) {
 
 	testData := []struct {
 		ptypes  PlaceholderTypes
-		desired Datum
+		desired Type
 		exprs   []copyableExpr
 
 		expectedErr string
@@ -372,10 +372,10 @@ func TestTypeCheckSameTypedExprsError(t *testing.T) {
 	}
 }
 
-func cast(p Placeholder, typ ColumnType) Expr {
+func cast(p *Placeholder, typ ColumnType) Expr {
 	return &CastExpr{Expr: p, Type: typ}
 }
-func annot(p Placeholder, typ ColumnType) Expr {
+func annot(p *Placeholder, typ ColumnType) Expr {
 	return &AnnotateTypeExpr{Expr: p, Type: typ}
 }
 
@@ -390,152 +390,152 @@ func TestProcessPlaceholderAnnotations(t *testing.T) {
 	}{
 		{
 			PlaceholderTypes{},
-			[]Expr{Placeholder{"a"}},
+			[]Expr{NewPlaceholder("a")},
 			PlaceholderTypes{},
 		},
 		{
 			PlaceholderTypes{},
-			[]Expr{Placeholder{"a"}, Placeholder{"b"}},
+			[]Expr{NewPlaceholder("a"), NewPlaceholder("b")},
 			PlaceholderTypes{},
 		},
 		{
 			PlaceholderTypes{"b": TypeBool},
-			[]Expr{Placeholder{"a"}, Placeholder{"b"}},
+			[]Expr{NewPlaceholder("a"), NewPlaceholder("b")},
 			PlaceholderTypes{"b": TypeBool},
 		},
 		{
 			PlaceholderTypes{"c": TypeFloat},
-			[]Expr{Placeholder{"a"}, Placeholder{"b"}},
+			[]Expr{NewPlaceholder("a"), NewPlaceholder("b")},
 			PlaceholderTypes{"c": TypeFloat},
 		},
 		{
 			PlaceholderTypes{},
 			[]Expr{
-				cast(Placeholder{"a"}, intType),
-				cast(Placeholder{"a"}, boolType),
+				cast(NewPlaceholder("a"), intType),
+				cast(NewPlaceholder("a"), boolType),
 			},
 			PlaceholderTypes{},
 		},
 		{
 			PlaceholderTypes{"a": TypeFloat},
 			[]Expr{
-				cast(Placeholder{"a"}, intType),
-				cast(Placeholder{"a"}, boolType),
+				cast(NewPlaceholder("a"), intType),
+				cast(NewPlaceholder("a"), boolType),
 			},
 			PlaceholderTypes{"a": TypeFloat},
 		},
 		{
 			PlaceholderTypes{},
 			[]Expr{
-				cast(Placeholder{"a"}, intType),
-				cast(Placeholder{"b"}, boolType),
+				cast(NewPlaceholder("a"), intType),
+				cast(NewPlaceholder("b"), boolType),
 			},
 			PlaceholderTypes{"a": TypeInt, "b": TypeBool},
 		},
 		{
 			PlaceholderTypes{},
 			[]Expr{
-				annot(Placeholder{"a"}, intType),
-				annot(Placeholder{"b"}, boolType),
+				annot(NewPlaceholder("a"), intType),
+				annot(NewPlaceholder("b"), boolType),
 			},
 			PlaceholderTypes{"a": TypeInt, "b": TypeBool},
 		},
 		{
 			PlaceholderTypes{"b": TypeBool},
 			[]Expr{
-				annot(Placeholder{"a"}, intType),
+				annot(NewPlaceholder("a"), intType),
 			},
 			PlaceholderTypes{"a": TypeInt, "b": TypeBool},
 		},
 		{
 			PlaceholderTypes{},
 			[]Expr{
-				cast(Placeholder{"a"}, intType),
-				cast(Placeholder{"b"}, boolType),
-				cast(Placeholder{"a"}, intType),
-				cast(Placeholder{"b"}, intType),
+				cast(NewPlaceholder("a"), intType),
+				cast(NewPlaceholder("b"), boolType),
+				cast(NewPlaceholder("a"), intType),
+				cast(NewPlaceholder("b"), intType),
 			},
 			PlaceholderTypes{"a": TypeInt},
 		},
 		{
 			PlaceholderTypes{},
 			[]Expr{
-				cast(Placeholder{"a"}, intType),
-				annot(Placeholder{"b"}, boolType),
-				cast(Placeholder{"a"}, intType),
-				cast(Placeholder{"b"}, intType),
+				cast(NewPlaceholder("a"), intType),
+				annot(NewPlaceholder("b"), boolType),
+				cast(NewPlaceholder("a"), intType),
+				cast(NewPlaceholder("b"), intType),
 			},
 			PlaceholderTypes{"a": TypeInt, "b": TypeBool},
 		},
 		{
 			PlaceholderTypes{},
 			[]Expr{
-				cast(Placeholder{"a"}, intType),
-				cast(Placeholder{"b"}, boolType),
-				Placeholder{"a"},
+				cast(NewPlaceholder("a"), intType),
+				cast(NewPlaceholder("b"), boolType),
+				NewPlaceholder("a"),
 			},
 			PlaceholderTypes{"b": TypeBool},
 		},
 		{
 			PlaceholderTypes{},
 			[]Expr{
-				Placeholder{"a"},
-				cast(Placeholder{"a"}, intType),
-				cast(Placeholder{"b"}, boolType),
+				NewPlaceholder("a"),
+				cast(NewPlaceholder("a"), intType),
+				cast(NewPlaceholder("b"), boolType),
 			},
 			PlaceholderTypes{"b": TypeBool},
 		},
 		{
 			PlaceholderTypes{},
 			[]Expr{
-				annot(Placeholder{"a"}, intType),
-				annot(Placeholder{"b"}, boolType),
-				Placeholder{"a"},
+				annot(NewPlaceholder("a"), intType),
+				annot(NewPlaceholder("b"), boolType),
+				NewPlaceholder("a"),
 			},
 			PlaceholderTypes{"a": TypeInt, "b": TypeBool},
 		},
 		{
 			PlaceholderTypes{},
 			[]Expr{
-				Placeholder{"a"},
-				annot(Placeholder{"a"}, intType),
-				annot(Placeholder{"b"}, boolType),
+				NewPlaceholder("a"),
+				annot(NewPlaceholder("a"), intType),
+				annot(NewPlaceholder("b"), boolType),
 			},
 			PlaceholderTypes{"a": TypeInt, "b": TypeBool},
 		},
 		{
 			PlaceholderTypes{"a": TypeFloat, "b": TypeBool},
 			[]Expr{
-				Placeholder{"a"},
-				cast(Placeholder{"a"}, intType),
-				cast(Placeholder{"b"}, boolType),
+				NewPlaceholder("a"),
+				cast(NewPlaceholder("a"), intType),
+				cast(NewPlaceholder("b"), boolType),
 			},
 			PlaceholderTypes{"a": TypeFloat, "b": TypeBool},
 		},
 		{
 			PlaceholderTypes{"a": TypeFloat, "b": TypeFloat},
 			[]Expr{
-				Placeholder{"a"},
-				cast(Placeholder{"a"}, intType),
-				cast(Placeholder{"b"}, boolType),
+				NewPlaceholder("a"),
+				cast(NewPlaceholder("a"), intType),
+				cast(NewPlaceholder("b"), boolType),
 			},
 			PlaceholderTypes{"a": TypeFloat, "b": TypeFloat},
 		},
 		{
 			PlaceholderTypes{},
 			[]Expr{
-				cast(Placeholder{"a"}, intType),
-				annot(Placeholder{"a"}, intType),
-				cast(Placeholder{"a"}, intType),
+				cast(NewPlaceholder("a"), intType),
+				annot(NewPlaceholder("a"), intType),
+				cast(NewPlaceholder("a"), intType),
 			},
 			PlaceholderTypes{"a": TypeInt},
 		},
 		{
 			PlaceholderTypes{},
 			[]Expr{
-				cast(Placeholder{"a"}, intType),
-				annot(Placeholder{"a"}, boolType),
-				cast(Placeholder{"a"}, intType),
+				cast(NewPlaceholder("a"), intType),
+				annot(NewPlaceholder("a"), boolType),
+				cast(NewPlaceholder("a"), intType),
 			},
 			PlaceholderTypes{"a": TypeBool},
 		},
@@ -563,49 +563,49 @@ func TestProcessPlaceholderAnnotationsError(t *testing.T) {
 		{
 			PlaceholderTypes{},
 			[]Expr{
-				annot(Placeholder{"a"}, floatType),
-				annot(Placeholder{"a"}, intType),
+				annot(NewPlaceholder("a"), floatType),
+				annot(NewPlaceholder("a"), intType),
 			},
 			"multiple conflicting type annotations around a",
 		},
 		{
 			PlaceholderTypes{},
 			[]Expr{
-				annot(Placeholder{"a"}, floatType),
-				cast(Placeholder{"a"}, floatType),
-				cast(Placeholder{"b"}, floatType),
-				annot(Placeholder{"a"}, intType),
+				annot(NewPlaceholder("a"), floatType),
+				cast(NewPlaceholder("a"), floatType),
+				cast(NewPlaceholder("b"), floatType),
+				annot(NewPlaceholder("a"), intType),
 			},
 			"multiple conflicting type annotations around a",
 		},
 		{
 			PlaceholderTypes{"a": TypeFloat},
 			[]Expr{
-				annot(Placeholder{"a"}, intType),
+				annot(NewPlaceholder("a"), intType),
 			},
 			"type annotation around a that conflicts with previously inferred type float",
 		},
 		{
 			PlaceholderTypes{"a": TypeFloat},
 			[]Expr{
-				cast(Placeholder{"a"}, intType),
-				annot(Placeholder{"a"}, intType),
+				cast(NewPlaceholder("a"), intType),
+				annot(NewPlaceholder("a"), intType),
 			},
 			"type annotation around a that conflicts with previously inferred type float",
 		},
 		{
 			PlaceholderTypes{"a": TypeFloat},
 			[]Expr{
-				annot(Placeholder{"a"}, floatType),
-				annot(Placeholder{"a"}, intType),
+				annot(NewPlaceholder("a"), floatType),
+				annot(NewPlaceholder("a"), intType),
 			},
 			"type annotation around a that conflicts with previously inferred type float",
 		},
 		{
 			PlaceholderTypes{"a": TypeFloat},
 			[]Expr{
-				annot(Placeholder{"a"}, intType),
-				annot(Placeholder{"a"}, floatType),
+				annot(NewPlaceholder("a"), intType),
+				annot(NewPlaceholder("a"), floatType),
 			},
 			"type annotation around a that conflicts with previously inferred type float",
 		},

--- a/pkg/sql/parser/var_name.go
+++ b/pkg/sql/parser/var_name.go
@@ -88,16 +88,16 @@ var singletonStarName VarName = UnqualifiedStar{}
 // StarExpr is a convenience function that represents an unqualified "*".
 func StarExpr() VarName { return singletonStarName }
 
-// ReturnType implements the TypedExpr interface.
-func (UnqualifiedStar) ReturnType() Datum {
+// ResolvedType implements the TypedExpr interface.
+func (UnqualifiedStar) ResolvedType() Type {
 	panic("unqualified stars ought to be replaced before this point")
 }
 
 // Variable implements the VariableExpr interface.
 func (UnqualifiedStar) Variable() {}
 
-// ReturnType implements the TypedExpr interface.
-func (UnresolvedName) ReturnType() Datum {
+// ResolvedType implements the TypedExpr interface.
+func (UnresolvedName) ResolvedType() Type {
 	panic("unresolved names ought to be replaced before this point")
 }
 
@@ -132,8 +132,8 @@ func (a *AllColumnsSelector) NormalizeVarName() (VarName, error) { return a, nil
 // VariableExpr interface is used.
 func (a *AllColumnsSelector) Variable() {}
 
-// ReturnType implements the TypedExpr interface.
-func (*AllColumnsSelector) ReturnType() Datum {
+// ResolvedType implements the TypedExpr interface.
+func (*AllColumnsSelector) ResolvedType() Type {
 	panic("all-columns selectors ought to be replaced before this point")
 }
 
@@ -182,8 +182,8 @@ func (c *ColumnItem) Column() string {
 // VariableExpr interface is used.
 func (c *ColumnItem) Variable() {}
 
-// ReturnType implements the TypedExpr interface.
-func (c *ColumnItem) ReturnType() Datum {
+// ResolvedType implements the TypedExpr interface.
+func (c *ColumnItem) ResolvedType() Type {
 	if presetTypesForTesting == nil {
 		return nil
 	}

--- a/pkg/sql/parser/walk.go
+++ b/pkg/sql/parser/walk.go
@@ -370,7 +370,7 @@ func (expr *NumVal) Walk(_ Visitor) Expr { return expr }
 func (expr *StrVal) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
-func (expr Placeholder) Walk(_ Visitor) Expr { return expr }
+func (expr *Placeholder) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
 func (expr *DBool) Walk(_ Visitor) Expr { return expr }
@@ -407,9 +407,6 @@ func (expr *DTimestampTZ) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
 func (expr *DTuple) Walk(_ Visitor) Expr { return expr }
-
-// Walk implements the Expr interface.
-func (expr *DPlaceholder) Walk(_ Visitor) Expr { return expr }
 
 // WalkExpr traverses the nodes in an expression.
 //

--- a/pkg/sql/parser/window_builtins.go
+++ b/pkg/sql/parser/window_builtins.go
@@ -126,39 +126,39 @@ var windows = map[string][]Builtin{
 		makeWindowBuiltin(ArgTypes{TypeInt}, TypeInt, newNtileWindow),
 	},
 	"lag": mergeBuiltinSlices(
-		collectWindowBuiltins(func(t Datum) Builtin {
+		collectWindowBuiltins(func(t Type) Builtin {
 			return makeWindowBuiltin(ArgTypes{t}, t, makeLeadLagWindowConstructor(false, false, false))
 		}, anyElementTypes...),
-		collectWindowBuiltins(func(t Datum) Builtin {
+		collectWindowBuiltins(func(t Type) Builtin {
 			return makeWindowBuiltin(ArgTypes{t, TypeInt}, t, makeLeadLagWindowConstructor(false, true, false))
 		}, anyElementTypes...),
-		collectWindowBuiltins(func(t Datum) Builtin {
+		collectWindowBuiltins(func(t Type) Builtin {
 			return makeWindowBuiltin(ArgTypes{t, TypeInt, t}, t, makeLeadLagWindowConstructor(false, true, true))
 		}, anyElementTypes...),
 	),
 	"lead": mergeBuiltinSlices(
-		collectWindowBuiltins(func(t Datum) Builtin {
+		collectWindowBuiltins(func(t Type) Builtin {
 			return makeWindowBuiltin(ArgTypes{t}, t, makeLeadLagWindowConstructor(true, false, false))
 		}, anyElementTypes...),
-		collectWindowBuiltins(func(t Datum) Builtin {
+		collectWindowBuiltins(func(t Type) Builtin {
 			return makeWindowBuiltin(ArgTypes{t, TypeInt}, t, makeLeadLagWindowConstructor(true, true, false))
 		}, anyElementTypes...),
-		collectWindowBuiltins(func(t Datum) Builtin {
+		collectWindowBuiltins(func(t Type) Builtin {
 			return makeWindowBuiltin(ArgTypes{t, TypeInt, t}, t, makeLeadLagWindowConstructor(true, true, true))
 		}, anyElementTypes...),
 	),
-	"first_value": collectWindowBuiltins(func(t Datum) Builtin {
+	"first_value": collectWindowBuiltins(func(t Type) Builtin {
 		return makeWindowBuiltin(ArgTypes{t}, t, newFirstValueWindow)
 	}, anyElementTypes...),
-	"last_value": collectWindowBuiltins(func(t Datum) Builtin {
+	"last_value": collectWindowBuiltins(func(t Type) Builtin {
 		return makeWindowBuiltin(ArgTypes{t}, t, newLastValueWindow)
 	}, anyElementTypes...),
-	"nth_value": collectWindowBuiltins(func(t Datum) Builtin {
+	"nth_value": collectWindowBuiltins(func(t Type) Builtin {
 		return makeWindowBuiltin(ArgTypes{t, TypeInt}, t, newNthValueWindow)
 	}, anyElementTypes...),
 }
 
-var anyElementTypes = []Datum{
+var anyElementTypes = []Type{
 	TypeBool,
 	TypeInt,
 	TypeFloat,
@@ -171,7 +171,7 @@ var anyElementTypes = []Datum{
 	TypeTuple,
 }
 
-func makeWindowBuiltin(in ArgTypes, ret Datum, f func() WindowFunc) Builtin {
+func makeWindowBuiltin(in ArgTypes, ret Type, f func() WindowFunc) Builtin {
 	return Builtin{
 		impure:     true,
 		class:      WindowClass,
@@ -181,7 +181,7 @@ func makeWindowBuiltin(in ArgTypes, ret Datum, f func() WindowFunc) Builtin {
 	}
 }
 
-func collectWindowBuiltins(f func(Datum) Builtin, types ...Datum) []Builtin {
+func collectWindowBuiltins(f func(Type) Builtin, types ...Type) []Builtin {
 	r := make([]Builtin, len(types))
 	for i := range types {
 		r[i] = f(types[i])

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -417,7 +417,7 @@ CREATE TABLE pg_catalog.pg_tables (
 	},
 }
 
-func typLen(typ parser.Datum) parser.Datum {
+func typLen(typ parser.Type) parser.Datum {
 	if sz, variable := typ.Size(); !variable {
 		return parser.NewDInt(parser.DInt(sz))
 	}
@@ -492,8 +492,8 @@ func (h oidHasher) writeColumn(column *sqlbase.ColumnDescriptor) {
 	h.writeStr(column.Name)
 }
 
-func (h oidHasher) writeType(typ parser.Datum) {
-	h.writeStr(typ.Type())
+func (h oidHasher) writeType(typ parser.Type) {
+	h.writeStr(typ.String())
 }
 
 func (h oidHasher) DBOid(db *sqlbase.DatabaseDescriptor) *parser.DInt {
@@ -531,7 +531,7 @@ func (h oidHasher) ColumnOid(
 	return h.getOid()
 }
 
-func (h oidHasher) TypeOid(typ parser.Datum) *parser.DInt {
+func (h oidHasher) TypeOid(typ parser.Type) *parser.DInt {
 	h.writeTypeTag(typeTypeTag)
 	h.writeType(typ)
 	return h.getOid()

--- a/pkg/sql/pgwire/binary_test.go
+++ b/pkg/sql/pgwire/binary_test.go
@@ -59,7 +59,7 @@ func testBinaryDatumType(t *testing.T, typ string, datumConstructor func(val str
 		buf.wrapped.Reset()
 
 		d := datumConstructor(test.In)
-		oid := datumToOid[reflect.TypeOf(d)]
+		oid := datumToOid[reflect.TypeOf(d.ResolvedType())]
 		func() {
 			defer func() {
 				if r := recover(); r != nil {

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -79,43 +79,32 @@ type pgNumeric struct {
 	sign                    pgNumericSign
 }
 
-func typeForDatum(d parser.Datum) pgType {
-	if d == parser.DNull {
+func pgTypeForParserType(t parser.Type) pgType {
+	switch t {
+	case parser.TypeNull:
 		return pgType{oid: oid.T_unknown}
-	}
-	switch d.(type) {
-	case *parser.DBool:
+	case parser.TypeBool:
 		return pgType{oid.T_bool, 1}
-
-	case *parser.DBytes:
+	case parser.TypeBytes:
 		return pgType{oid.T_bytea, -1}
-
-	case *parser.DInt:
+	case parser.TypeInt:
 		return pgType{oid.T_int8, 8}
-
-	case *parser.DFloat:
+	case parser.TypeFloat:
 		return pgType{oid.T_float8, 8}
-
-	case *parser.DDecimal:
+	case parser.TypeDecimal:
 		return pgType{oid.T_numeric, -1}
-
-	case *parser.DString:
+	case parser.TypeString:
 		return pgType{oid.T_text, -1}
-
-	case *parser.DDate:
+	case parser.TypeDate:
 		return pgType{oid.T_date, 8}
-
-	case *parser.DTimestamp:
+	case parser.TypeTimestamp:
 		return pgType{oid.T_timestamp, 8}
-
-	case *parser.DTimestampTZ:
+	case parser.TypeTimestampTZ:
 		return pgType{oid.T_timestamptz, 8}
-
-	case *parser.DInterval:
+	case parser.TypeInterval:
 		return pgType{oid.T_interval, 8}
-
 	default:
-		panic(fmt.Sprintf("unsupported type %T", d))
+		panic(fmt.Sprintf("unsupported type %s", t))
 	}
 }
 
@@ -397,7 +386,7 @@ func pgBinaryToDate(i int32) *parser.DDate {
 }
 
 var (
-	oidToDatum = map[oid.Oid]parser.Datum{
+	oidToDatum = map[oid.Oid]parser.Type{
 		oid.T_bool:        parser.TypeBool,
 		oid.T_bytea:       parser.TypeBytes,
 		oid.T_date:        parser.TypeDate,

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -402,7 +402,7 @@ func (c *v3Conn) handleParse(ctx context.Context, buf *readBuffer) error {
 		}
 		id, ok := datumToOid[reflect.TypeOf(t)]
 		if !ok {
-			return c.sendInternalError(fmt.Sprintf("unknown datum type: %s", t.Type()))
+			return c.sendInternalError(fmt.Sprintf("unknown datum type: %s", t))
 		}
 		inTypes[i] = id
 	}
@@ -830,7 +830,7 @@ func (c *v3Conn) sendRowDescription(columns []sql.ResultColumn, formatCodes []fo
 		}
 		c.writeBuf.writeTerminatedString(column.Name)
 
-		typ := typeForDatum(column.Typ)
+		typ := pgTypeForParserType(column.Typ)
 		c.writeBuf.putInt32(0) // Table OID (optional).
 		c.writeBuf.putInt16(0) // Column attribute ID (optional).
 		c.writeBuf.putInt32(int32(typ.oid))

--- a/pkg/sql/pgwire_test.go
+++ b/pkg/sql/pgwire_test.go
@@ -266,7 +266,7 @@ func TestPGPrepareFail(t *testing.T) {
 		"SELECT CASE WHEN TRUE THEN $1 ELSE $2 END": "pq: could not determine data type of placeholder $1",
 		"SELECT $1 > 0 AND NOT $1":                  "pq: incompatible NOT argument type: int",
 		"CREATE TABLE $1 (id INT)":                  "pq: syntax error at or near \"1\"\nCREATE TABLE $1 (id INT)\n             ^\n",
-		"UPDATE d.t SET s = i + $1":                 "pq: unsupported binary operator: <int> + <placeholder> (desired <string>)",
+		"UPDATE d.t SET s = i + $1":                 "pq: unsupported binary operator: <int> + <placeholder{1}> (desired <string>)",
 		"SELECT $0 > 0":                             "pq: invalid placeholder name: $0",
 		"SELECT $2 > 0":                             "pq: could not determine data type of placeholder $1",
 		"SELECT 3 + CASE (4) WHEN 4 THEN $1 END":    "pq: could not determine data type of placeholder $1",

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -34,7 +34,7 @@ type planMaker interface {
 	//
 	// This method should not be used directly; instead prefer makePlan()
 	// or prepare() below.
-	newPlan(stmt parser.Statement, desiredTypes []parser.Datum, autoCommit bool) (planNode, error)
+	newPlan(stmt parser.Statement, desiredTypes []parser.Type, autoCommit bool) (planNode, error)
 
 	// makePlan prepares the query plan for a single SQL statement.  it
 	// calls newPlan() then expandPlan() on the result.  Execution must
@@ -229,7 +229,7 @@ func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, er
 // newPlan constructs a planNode from a statement. This is used
 // recursively by the various node constructors.
 func (p *planner) newPlan(
-	stmt parser.Statement, desiredTypes []parser.Datum, autoCommit bool,
+	stmt parser.Statement, desiredTypes []parser.Type, autoCommit bool,
 ) (planNode, error) {
 	tracing.AnnotateTrace()
 

--- a/pkg/sql/returning.go
+++ b/pkg/sql/returning.go
@@ -48,7 +48,7 @@ type returningHelper struct {
 // insert/update node.
 func (p *planner) newReturningHelper(
 	r parser.ReturningExprs,
-	desiredTypes []parser.Datum,
+	desiredTypes []parser.Type,
 	alias string,
 	tablecols []sqlbase.ColumnDescriptor,
 ) (*returningHelper, error) {
@@ -99,7 +99,7 @@ func (p *planner) newReturningHelper(
 			return nil, err
 		}
 		rh.exprs = append(rh.exprs, typedExpr)
-		rh.columns = append(rh.columns, ResultColumn{Name: outputName, Typ: typedExpr.ReturnType()})
+		rh.columns = append(rh.columns, ResultColumn{Name: outputName, Typ: typedExpr.ResolvedType()})
 	}
 	return rh, nil
 }
@@ -146,8 +146,8 @@ func (rh *returningHelper) IndexedVarEval(idx int, ctx *parser.EvalContext) (par
 	return rh.curSourceRow[idx].Eval(ctx)
 }
 
-// IndexedVarReturnType implements the parser.IndexedVarContainer interface.
-func (rh *returningHelper) IndexedVarReturnType(idx int) parser.Datum {
+// IndexedVarResolvedType implements the parser.IndexedVarContainer interface.
+func (rh *returningHelper) IndexedVarResolvedType(idx int) parser.Type {
 	return rh.source.sourceColumns[idx].Typ
 }
 

--- a/pkg/sql/row_container.go
+++ b/pkg/sql/row_container.go
@@ -96,8 +96,7 @@ func (c *RowContainer) Close() {
 func (c *RowContainer) rowSize(row parser.DTuple) int64 {
 	rsz := c.fixedColsSize
 	for _, i := range c.varSizedColumns {
-		sz, _ := row[i].Size()
-		rsz += int64(sz)
+		rsz += int64(row[i].Size())
 	}
 	return rsz
 }

--- a/pkg/sql/rsg_test.go
+++ b/pkg/sql/rsg_test.go
@@ -112,38 +112,38 @@ func TestRandomSyntaxFunctions(t *testing.T) {
 		case parser.ArgTypes:
 			for _, typ := range ft {
 				var v interface{}
-				switch typ.(type) {
-				case *parser.DInt:
+				switch typ {
+				case parser.TypeInt:
 					i := r.Int63()
 					i -= r.Int63()
 					v = i
-				case *parser.DFloat, *parser.DDecimal:
+				case parser.TypeFloat, parser.TypeDecimal:
 					v = r.Float64()
-				case *parser.DString:
+				case parser.TypeString:
 					v = `'string'`
-				case *parser.DBytes:
+				case parser.TypeBytes:
 					v = `b'bytes'`
-				case *parser.DTimestamp, *parser.DTimestampTZ:
+				case parser.TypeTimestamp, parser.TypeTimestampTZ:
 					t := time.Unix(0, r.Int63())
 					v = fmt.Sprintf(`'%s'`, t.Format(time.RFC3339Nano))
-				case *parser.DBool:
+				case parser.TypeBool:
 					if r.Intn(2) == 0 {
 						v = "false"
 					} else {
 						v = "true"
 					}
-				case *parser.DDate:
+				case parser.TypeDate:
 					i := r.Int63()
 					i -= r.Int63()
 					d := parser.NewDDate(parser.DDate(i))
 					v = fmt.Sprintf(`'%s'`, d)
-				case *parser.DInterval:
+				case parser.TypeInterval:
 					d := duration.Duration{Nanos: r.Int63()}
 					v = fmt.Sprintf(`'%s'`, &parser.DInterval{Duration: d})
-				case *parser.DTuple:
+				case parser.TypeTuple:
 					v = "NULL"
 				default:
-					panic(fmt.Errorf("unknown arg type: %T", typ))
+					panic(fmt.Errorf("unknown arg type: %s", typ))
 				}
 				args = append(args, fmt.Sprint(v))
 			}

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -377,8 +377,8 @@ func (n *scanNode) IndexedVarEval(idx int, ctx *parser.EvalContext) (parser.Datu
 	return n.row[idx].Eval(ctx)
 }
 
-func (n *scanNode) IndexedVarReturnType(idx int) parser.Datum {
-	return n.resultColumns[idx].Typ.ReturnType()
+func (n *scanNode) IndexedVarResolvedType(idx int) parser.Type {
+	return n.resultColumns[idx].Typ
 }
 
 func (n *scanNode) IndexedVarFormat(buf *bytes.Buffer, _ parser.FmtFlags, idx int) {

--- a/pkg/sql/set.go
+++ b/pkg/sql/set.go
@@ -113,7 +113,7 @@ func (p *planner) getStringVal(name string, values []parser.TypedExpr) (string, 
 	s, ok := val.(*parser.DString)
 	if !ok {
 		return "", fmt.Errorf("%s: requires a single string value: %s is a %s",
-			name, values[0], val.Type())
+			name, values[0], val.ResolvedType())
 	}
 	return string(*s), nil
 }

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -318,7 +318,7 @@ func (p *planner) ShowCreateView(n *parser.ShowCreateView) (planNode, error) {
 			if !ok {
 				return nil, errors.Errorf("failed to parse underlying query from view %q as a select", tn)
 			}
-			sourcePlan, err := p.Select(sel, []parser.Datum{}, false)
+			sourcePlan, err := p.Select(sel, []parser.Type{}, false)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/sqlbase/encoded_datum.go
+++ b/pkg/sql/sqlbase/encoded_datum.go
@@ -105,9 +105,9 @@ func (ed *EncDatum) SetDatum(typ ColumnType_Kind, d parser.Datum) {
 	if d == nil {
 		panic("nil datum given")
 	}
-	if d != parser.DNull && !typ.ToDatumType().TypeEqual(d) {
+	if d != parser.DNull && !typ.ToDatumType().Equal(d.ResolvedType()) {
 		panic(fmt.Sprintf("invalid datum type given: %s, expected %s",
-			d.Type(), typ.ToDatumType().Type()))
+			d.ResolvedType(), typ.ToDatumType()))
 	}
 	ed.Type = typ
 	ed.encoded = nil
@@ -227,10 +227,10 @@ func (r EncDatumRow) String() string {
 
 // DatumToEncDatum converts a parser.Datum to an EncDatum.
 func DatumToEncDatum(datum parser.Datum) (EncDatum, error) {
-	dType, ok := ColumnType_Kind_value[strings.ToUpper(datum.Type())]
+	dType, ok := ColumnType_Kind_value[strings.ToUpper(datum.ResolvedType().String())]
 	if !ok {
 		return EncDatum{}, errors.Errorf(
-			"Unknown type %s, could not convert to EncDatum", datum.Type())
+			"Unknown type %s, could not convert to EncDatum", datum.ResolvedType())
 	}
 	return EncDatum{
 		Type:  (ColumnType_Kind)(dType),

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -75,9 +75,9 @@ type RowFetcher struct {
 	// -- Fields updated during a scan --
 
 	kvFetcher        kvFetcher
-	keyValTypes      []parser.Datum // the index key value types for the current row
+	keyValTypes      []parser.Type  // the index key value types for the current row
 	keyVals          []parser.Datum // the index key values for the current row
-	implicitValTypes []parser.Datum // the implicit value types for unique indexes
+	implicitValTypes []parser.Type  // the implicit value types for unique indexes
 	implicitVals     []parser.Datum // the implicit values for unique indexes
 	indexKey         []byte         // the index key of the current row
 	row              parser.DTuple

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1604,9 +1604,9 @@ func (c *ColumnType) NumericScale() (int32, bool) {
 	return 0, false
 }
 
-// ToDatumType converts the ColumnType_Kind to the correct type Datum, or
-// nil if there is no correspondence.
-func (k ColumnType_Kind) ToDatumType() parser.Datum {
+// ToDatumType converts the ColumnType_Kind to the correct type, or nil if there
+// is no correspondence.
+func (k ColumnType_Kind) ToDatumType() parser.Type {
 	switch k {
 	case ColumnType_BOOL:
 		return parser.TypeBool
@@ -1632,9 +1632,9 @@ func (k ColumnType_Kind) ToDatumType() parser.Datum {
 	return nil
 }
 
-// ToDatumType converts the ColumnType to the correct type Datum, or
-// nil if there is no correspondence.
-func (c *ColumnType) ToDatumType() parser.Datum {
+// ToDatumType converts the ColumnType to the correct type, or nil if there is
+// no correspondence.
+func (c *ColumnType) ToDatumType() parser.Type {
 	return c.Kind.ToDatumType()
 }
 

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -28,7 +28,7 @@ import (
 // in the expression tree from the point type checking occurs to
 // the point the query starts execution / evaluation.
 type subquery struct {
-	typ            parser.Datum
+	typ            parser.Type
 	subquery       *parser.Subquery
 	execMode       subqueryExecMode
 	wantNormalized bool
@@ -81,7 +81,7 @@ func (s *subquery) Walk(v parser.Visitor) parser.Expr {
 
 func (s *subquery) Variable() {}
 
-func (s *subquery) TypeCheck(_ *parser.SemaContext, desired parser.Datum) (parser.TypedExpr, error) {
+func (s *subquery) TypeCheck(_ *parser.SemaContext, desired parser.Type) (parser.TypedExpr, error) {
 	// TODO(knz): if/when type checking can be extracted from the
 	// newPlan recursion, we can propagate the desired type to the
 	// sub-query. For now, the type is simply derived during the subquery node
@@ -93,7 +93,7 @@ func (s *subquery) TypeCheck(_ *parser.SemaContext, desired parser.Datum) (parse
 	return s, nil
 }
 
-func (s *subquery) ReturnType() parser.Datum { return s.typ }
+func (s *subquery) ResolvedType() parser.Type { return s.typ }
 
 func (s *subquery) Eval(_ *parser.EvalContext) (parser.Datum, error) {
 	if s.err != nil {
@@ -367,11 +367,11 @@ func (v *subqueryVisitor) VisitPre(expr parser.Expr) (recurse bool, newExpr pars
 			// a single value against a tuple.
 			result.typ = cols[0].Typ
 		} else {
-			colTypes := make(parser.DTuple, wantedNumColumns)
+			colTypes := make(parser.TTuple, wantedNumColumns)
 			for i, col := range cols {
 				colTypes[i] = col.Typ
 			}
-			result.typ = &colTypes
+			result.typ = colTypes
 		}
 	}
 

--- a/pkg/sql/table_join.go
+++ b/pkg/sql/table_join.go
@@ -154,8 +154,8 @@ func (p *onPredicate) IndexedVarEval(idx int, ctx *parser.EvalContext) (parser.D
 	return p.curRow[idx].Eval(ctx)
 }
 
-// IndexedVarReturnType implements the parser.IndexedVarContainer interface.
-func (p *onPredicate) IndexedVarReturnType(idx int) parser.Datum {
+// IndexedVarResolvedType implements the parser.IndexedVarContainer interface.
+func (p *onPredicate) IndexedVarResolvedType(idx int) parser.Type {
 	return p.info.sourceColumns[idx].Typ
 }
 
@@ -306,7 +306,7 @@ func (p *usingPredicate) prepareRow(result, leftRow, rightRow parser.DTuple) {
 // pickUsingColumn searches for a column whose name matches colName.
 // The column index and type are returned if found, otherwise an error
 // is reported.
-func pickUsingColumn(cols ResultColumns, colName string, context string) (int, parser.Datum, error) {
+func pickUsingColumn(cols ResultColumns, colName string, context string) (int, parser.Type, error) {
 	idx := invalidColIdx
 	for j, col := range cols {
 		if col.hidden {
@@ -372,7 +372,8 @@ func (p *planner) makeUsingPredicate(
 		// Memoize the comparison function.
 		fn, found := parser.FindEqualComparisonFunction(leftType, rightType)
 		if !found {
-			return nil, nil, fmt.Errorf("JOIN/USING types %s and %s for column %s cannot be matched", leftType.Type(), rightType.Type(), colName)
+			return nil, nil, fmt.Errorf("JOIN/USING types %s and %s for column %s cannot be matched",
+				leftType, rightType, colName)
 		}
 		cmpOps[i] = fn
 

--- a/pkg/sql/testdata/aggregate
+++ b/pkg/sql/testdata/aggregate
@@ -469,7 +469,7 @@ SELECT AVG(a) FROM abc
 query error unknown signature for AVG: AVG\(bool\)
 SELECT AVG(c) FROM abc
 
-query error unknown signature for AVG: AVG\(tuple\)
+query error unknown signature for AVG: AVG\(tuple{string, bool}\)
 SELECT AVG((a,c)) FROM abc
 
 query error unknown signature for SUM: SUM\(string\)
@@ -478,7 +478,7 @@ SELECT SUM(a) FROM abc
 query error unknown signature for SUM: SUM\(bool\)
 SELECT SUM(c) FROM abc
 
-query error unknown signature for SUM: SUM\(tuple\)
+query error unknown signature for SUM: SUM\(tuple{string, bool}\)
 SELECT SUM((a,c)) FROM abc
 
 statement ok

--- a/pkg/sql/testdata/subquery
+++ b/pkg/sql/testdata/subquery
@@ -86,7 +86,7 @@ SELECT * FROM abc WHERE a = 7
 ----
 7 8 9
 
-statement error value type tuple doesn't match type INT of column "a"
+statement error value type tuple{int, int, int} doesn't match type INT of column "a"
 INSERT INTO abc VALUES ((SELECT (10, 11, 12)))
 
 statement error subquery must return only one column, found 3
@@ -119,7 +119,7 @@ SELECT * FROM xyz
 7 8 10
 10 11 12
 
-statement error value type tuple doesn't match type INT of column "z"
+statement error value type tuple{int, int} doesn't match type INT of column "z"
 UPDATE xyz SET z = (SELECT (10, 11)) WHERE x = 7
 
 statement error subquery must return 2 columns, found 1

--- a/pkg/sql/union.go
+++ b/pkg/sql/union.go
@@ -26,7 +26,7 @@ import (
 
 // UnionClause constructs a planNode from a UNION/INTERSECT/EXCEPT expression.
 func (p *planner) UnionClause(
-	n *parser.UnionClause, desiredTypes []parser.Datum, autoCommit bool,
+	n *parser.UnionClause, desiredTypes []parser.Type, autoCommit bool,
 ) (planNode, error) {
 	var emitAll = false
 	var emit unionNodeEmit
@@ -73,8 +73,8 @@ func (p *planner) UnionClause(
 		// TODO(dan): This currently checks whether the types are exactly the same,
 		// but Postgres is more lenient:
 		// http://www.postgresql.org/docs/9.5/static/typeconv-union-case.html.
-		if !l.Typ.TypeEqual(r.Typ) {
-			return nil, fmt.Errorf("%v types %s and %s cannot be matched", n.Type, l.Typ.Type(), r.Typ.Type())
+		if !l.Typ.Equal(r.Typ) {
+			return nil, fmt.Errorf("%v types %s and %s cannot be matched", n.Type, l.Typ, r.Typ)
 		}
 		if l.hidden != r.hidden {
 			return nil, fmt.Errorf("%v types cannot be matched", n.Type)

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -59,8 +59,8 @@ func (uh *upsertHelper) IndexedVarEval(idx int, ctx *parser.EvalContext) (parser
 	return uh.curSourceRow[idx].Eval(ctx)
 }
 
-// IndexedVarReturnType implements the parser.IndexedVarContainer interface.
-func (uh *upsertHelper) IndexedVarReturnType(idx int) parser.Datum {
+// IndexedVarResolvedType implements the parser.IndexedVarContainer interface.
+func (uh *upsertHelper) IndexedVarResolvedType(idx int) parser.Type {
 	numSourceColumns := len(uh.sourceInfo.sourceColumns)
 	if idx >= numSourceColumns {
 		return uh.excludedSourceInfo.sourceColumns[idx-numSourceColumns].Typ

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -36,7 +36,7 @@ type valuesNode struct {
 	tuples   [][]parser.TypedExpr
 	rows     *RowContainer
 
-	desiredTypes []parser.Datum // This can be removed when we only type check once.
+	desiredTypes []parser.Type // This can be removed when we only type check once.
 
 	nextRow       int           // The index of the next row.
 	invertSorting bool          // Inverts the sorting predicate.
@@ -52,7 +52,7 @@ func (p *planner) newContainerValuesNode(columns ResultColumns, capacity int) *v
 }
 
 func (p *planner) ValuesClause(
-	n *parser.ValuesClause, desiredTypes []parser.Datum,
+	n *parser.ValuesClause, desiredTypes []parser.Type,
 ) (planNode, error) {
 	v := &valuesNode{
 		p:            p,
@@ -93,13 +93,13 @@ func (p *planner) ValuesClause(
 				return nil, err
 			}
 
-			typ := typedExpr.ReturnType()
+			typ := typedExpr.ResolvedType()
 			if num == 0 {
 				v.columns = append(v.columns, ResultColumn{Name: "column" + strconv.Itoa(i+1), Typ: typ})
-			} else if v.columns[i].Typ == parser.DNull {
+			} else if v.columns[i].Typ == parser.TypeNull {
 				v.columns[i].Typ = typ
-			} else if typ != parser.DNull && !typ.TypeEqual(v.columns[i].Typ) {
-				return nil, fmt.Errorf("VALUES list type mismatch, %s for %s", typ.Type(), v.columns[i].Typ.Type())
+			} else if typ != parser.TypeNull && !typ.Equal(v.columns[i].Typ) {
+				return nil, fmt.Errorf("VALUES list type mismatch, %s for %s", typ, v.columns[i].Typ)
 			}
 
 			tupleRow[i] = typedExpr

--- a/pkg/sql/values_test.go
+++ b/pkg/sql/values_test.go
@@ -160,7 +160,7 @@ func TestGolangQueryArgs(t *testing.T) {
 		expectedType reflect.Type
 	}{
 		// Null type.
-		{nil, reflect.TypeOf(parser.DNull)},
+		{nil, reflect.TypeOf(parser.TypeNull)},
 
 		// Bool type.
 		{true, reflect.TypeOf(parser.TypeBool)},

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -116,9 +116,9 @@ func (e virtualTableEntry) getPlanInfo() (ResultColumns, nodeConstructor) {
 			}
 			for i, col := range v.columns {
 				datum := datums[i]
-				if !(datum == parser.DNull || datum.TypeEqual(col.Typ)) {
+				if !(datum == parser.DNull || datum.ResolvedType().Equal(col.Typ)) {
 					panic(fmt.Sprintf("datum column %q expected to be type %s; found type %s",
-						col.Name, col.Typ.Type(), datum.Type()))
+						col.Name, col.Typ, datum.ResolvedType()))
 				}
 			}
 			return v.rows.AddRow(datums)

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -112,7 +112,7 @@ func (p *planner) window(n *parser.SelectClause, s *selectNode) (*windowNode, er
 					s.render = append(s.render, arg)
 					s.columns = append(s.columns, ResultColumn{
 						Name: arg.String(),
-						Typ:  arg.ReturnType(),
+						Typ:  arg.ResolvedType(),
 					})
 				}
 			}
@@ -548,7 +548,7 @@ func (n *windowNode) computeWindows() error {
 					}
 
 					// This may overestimate, because WindowFuncs may perform internal caching.
-					sz, _ := res.Size()
+					sz := res.Size()
 					if err := acc.Grow(int64(sz)); err != nil {
 						return err
 					}
@@ -802,7 +802,7 @@ func (w *windowFuncHolder) String() string { return parser.AsString(w) }
 func (w *windowFuncHolder) Walk(v parser.Visitor) parser.Expr { return w }
 
 func (w *windowFuncHolder) TypeCheck(
-	_ *parser.SemaContext, desired parser.Datum,
+	_ *parser.SemaContext, desired parser.Type,
 ) (parser.TypedExpr, error) {
 	return w, nil
 }
@@ -814,6 +814,6 @@ func (w *windowFuncHolder) Eval(ctx *parser.EvalContext) (parser.Datum, error) {
 	return w.window.windowValues[w.window.curRowIdx][w.funcIdx].Eval(ctx)
 }
 
-func (w *windowFuncHolder) ReturnType() parser.Datum {
-	return w.expr.ReturnType()
+func (w *windowFuncHolder) ResolvedType() parser.Type {
+	return w.expr.ResolvedType()
 }


### PR DESCRIPTION
Currently we use Datum to represent both types and values, with naming
conventions that indicate the intended use. Having separate types is
clearer and will aid future changes to the type system.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9912)

<!-- Reviewable:end -->
