### PR TITLE
cli: better errors

### DIFF
--- a/pkg/cli/backup.go
+++ b/pkg/cli/backup.go
@@ -50,7 +50,10 @@ func runBackup(cmd *cobra.Command, args []string) error {
 	base := args[0]
 
 	ctx := context.Background()
-	kvDB, stopper := makeDBClient()
+	kvDB, stopper, err := makeDBClient()
+	if err != nil {
+		return err
+	}
 	defer stopper.Stop()
 
 	desc, err := sql.Backup(ctx, *kvDB, base, hlc.NewClock(hlc.UnixNano).Now())
@@ -66,7 +69,7 @@ var backupCmd = &cobra.Command{
 	Use:   "backup [options] <basepath>",
 	Short: "backup all SQL tables",
 	Long:  "Exports a consistent snapshot of all SQL tables to storage.",
-	RunE:  runBackup,
+	RunE:  maybeDecorateGRPCError(runBackup),
 }
 
 func runRestore(cmd *cobra.Command, args []string) error {
@@ -76,7 +79,10 @@ func runRestore(cmd *cobra.Command, args []string) error {
 	base := args[0]
 
 	ctx := context.Background()
-	kvDB, stopper := makeDBClient()
+	kvDB, stopper, err := makeDBClient()
+	if err != nil {
+		return err
+	}
 	defer stopper.Stop()
 
 	tableName := parser.TableName{
@@ -99,5 +105,5 @@ var restoreCmd = &cobra.Command{
 	Use:   "restore [options] <basepath>",
 	Short: "restore SQL tables from a backup",
 	Long:  "Imports one or all SQL tables, restoring them to a previously snapshotted state.",
-	RunE:  runRestore,
+	RunE:  maybeDecorateGRPCError(runRestore),
 }

--- a/pkg/cli/cert.go
+++ b/pkg/cli/cert.go
@@ -17,10 +17,8 @@
 package cli
 
 import (
-	"fmt"
-
 	"github.com/cockroachdb/cockroach/pkg/security"
-
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -37,20 +35,16 @@ var createCACertCmd = &cobra.Command{
 Generates CA certificate and key, writing them to --ca-cert and --ca-key.
 `,
 	SilenceUsage: true,
-	RunE:         runCreateCACert,
+	RunE:         maybeDecorateGRPCError(runCreateCACert),
 }
 
 // runCreateCACert generates key pair and CA certificate and writes them
 // to their corresponding files.
 func runCreateCACert(cmd *cobra.Command, args []string) error {
 	if len(baseCfg.SSLCA) == 0 || len(baseCfg.SSLCAKey) == 0 {
-		mustUsage(cmd)
 		return errMissingParams
 	}
-	if err := security.RunCreateCACert(baseCfg.SSLCA, baseCfg.SSLCAKey, keySize); err != nil {
-		return fmt.Errorf("failed to generate CA certificate: %s", err)
-	}
-	return nil
+	return errors.Wrap(security.RunCreateCACert(baseCfg.SSLCA, baseCfg.SSLCAKey, keySize), "failed to generate CA certificate")
 }
 
 // A createNodeCert command generates a node certificate and stores it
@@ -64,7 +58,7 @@ Generates node certificate and keys for a given node, writing them to
 At least one host should be passed in (either IP address or dns name).
 `,
 	SilenceUsage: true,
-	RunE:         runCreateNodeCert,
+	RunE:         maybeDecorateGRPCError(runCreateNodeCert),
 }
 
 // runCreateNodeCert generates key pair and CA certificate and writes them
@@ -72,14 +66,12 @@ At least one host should be passed in (either IP address or dns name).
 func runCreateNodeCert(cmd *cobra.Command, args []string) error {
 	if len(baseCfg.SSLCA) == 0 || len(baseCfg.SSLCAKey) == 0 ||
 		len(baseCfg.SSLCert) == 0 || len(baseCfg.SSLCertKey) == 0 {
-		mustUsage(cmd)
 		return errMissingParams
 	}
-	if err := security.RunCreateNodeCert(baseCfg.SSLCA, baseCfg.SSLCAKey,
-		baseCfg.SSLCert, baseCfg.SSLCertKey, keySize, args); err != nil {
-		return fmt.Errorf("failed to generate node certificate: %s", err)
-	}
-	return nil
+	return errors.Wrap(security.RunCreateNodeCert(baseCfg.SSLCA, baseCfg.SSLCAKey,
+		baseCfg.SSLCert, baseCfg.SSLCertKey, keySize, args),
+		"failed to generate node certificate",
+	)
 }
 
 // A createClientCert command generates a client certificate and stores it
@@ -93,27 +85,24 @@ Generates a client certificate and key, writing them to --cert and --key.
 The certs directory should contain a CA cert and key.
 `,
 	SilenceUsage: true,
-	RunE:         runCreateClientCert,
+	RunE:         maybeDecorateGRPCError(runCreateClientCert),
 }
 
 // runCreateClientCert generates key pair and CA certificate and writes them
 // to their corresponding files.
 func runCreateClientCert(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
-		mustUsage(cmd)
-		return errMissingParams
+		return cmd.Usage()
 	}
 	if len(baseCfg.SSLCA) == 0 || len(baseCfg.SSLCAKey) == 0 ||
 		len(baseCfg.SSLCert) == 0 || len(baseCfg.SSLCertKey) == 0 {
-		mustUsage(cmd)
 		return errMissingParams
 	}
 
-	if err := security.RunCreateClientCert(baseCfg.SSLCA, baseCfg.SSLCAKey,
-		baseCfg.SSLCert, baseCfg.SSLCertKey, keySize, args[0]); err != nil {
-		return fmt.Errorf("failed to generate clent certificate: %s", err)
-	}
-	return nil
+	return errors.Wrap(security.RunCreateClientCert(baseCfg.SSLCA, baseCfg.SSLCAKey,
+		baseCfg.SSLCert, baseCfg.SSLCertKey, keySize, args[0]),
+		"failed to generate clent certificate",
+	)
 }
 
 var certCmds = []*cobra.Command{
@@ -125,8 +114,8 @@ var certCmds = []*cobra.Command{
 var certCmd = &cobra.Command{
 	Use:   "cert",
 	Short: "create ca, node, and client certs",
-	Run: func(cmd *cobra.Command, args []string) {
-		mustUsage(cmd)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Usage()
 	},
 }
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -94,9 +94,3 @@ func Run(args []string) error {
 	cockroachCmd.SetArgs(args)
 	return cockroachCmd.Execute()
 }
-
-func mustUsage(cmd *cobra.Command) {
-	if err := cmd.Usage(); err != nil {
-		panic(err)
-	}
-}

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -265,7 +265,7 @@ func Example_basic() {
 	// "b"	"2"
 	// 2 result(s)
 	// debug kv inc c b
-	// invalid increment: b: strconv.ParseInt: parsing "b": invalid syntax
+	// invalid increment: strconv.ParseInt: parsing "b": invalid syntax
 }
 
 func Example_quoted() {

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -116,7 +116,11 @@ func (k *mvccKey) Set(value string) error {
 
 	switch typ {
 	case raw:
-		*k = mvccKey(engine.MakeMVCCMetadataKey(roachpb.Key(unquoteArg(keyStr, false))))
+		unquoted, err := unquoteArg(keyStr, false)
+		if err != nil {
+			return err
+		}
+		*k = mvccKey(engine.MakeMVCCMetadataKey(roachpb.Key(unquoted)))
 	case human:
 		key, err := keys.UglyPrint(keyStr)
 		if err != nil {

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -49,7 +49,7 @@ var debugKeysCmd = &cobra.Command{
 	Long: `
 Pretty-prints all keys in a store.
 `,
-	RunE: runDebugKeys,
+	RunE: maybeDecorateGRPCError(runDebugKeys),
 }
 
 func parseRangeID(arg string) (roachpb.RangeID, error) {
@@ -140,11 +140,7 @@ func runDebugKeys(cmd *cobra.Command, args []string) error {
 		printer = printKeyValue
 	}
 
-	if err := db.Iterate(debugCtx.startKey, debugCtx.endKey, printer); err != nil {
-		return err
-	}
-
-	return nil
+	return db.Iterate(debugCtx.startKey, debugCtx.endKey, printer)
 }
 
 var debugRangeDataCmd = &cobra.Command{
@@ -155,7 +151,7 @@ Pretty-prints all keys and values in a range. By default, includes unreplicated
 state like the raft HardState. With --replicated, only includes data covered by
  the consistency checker.
 `,
-	RunE: runDebugRangeData,
+	RunE: maybeDecorateGRPCError(runDebugRangeData),
 }
 
 func runDebugRangeData(cmd *cobra.Command, args []string) error {
@@ -199,7 +195,7 @@ var debugRangeDescriptorsCmd = &cobra.Command{
 	Long: `
 Prints all range descriptors in a store with a history of changes.
 `,
-	RunE: runDebugRangeDescriptors,
+	RunE: maybeDecorateGRPCError(runDebugRangeDescriptors),
 }
 
 func descStr(desc roachpb.RangeDescriptor) string {
@@ -416,7 +412,7 @@ var debugRaftLogCmd = &cobra.Command{
 	Long: `
 Prints all log entries in a store for the given range.
 `,
-	RunE: runDebugRaftLog,
+	RunE: maybeDecorateGRPCError(runDebugRaftLog),
 }
 
 func tryRaftLogEntry(kv engine.MVCCKeyValue) (string, error) {
@@ -499,7 +495,7 @@ ranges individually.
 
 Uses a hard-coded GC policy with a 24 hour TTL for old versions.
 `,
-	RunE: runDebugGCCmd,
+	RunE: maybeDecorateGRPCError(runDebugGCCmd),
 }
 
 func runDebugGCCmd(cmd *cobra.Command, args []string) error {
@@ -578,7 +574,7 @@ Perform local consistency checks of a single store.
 Capable of detecting the following errors:
 * Raft logs that are inconsistent with their metadata
 `,
-	RunE: runDebugCheckStoreCmd,
+	RunE: maybeDecorateGRPCError(runDebugCheckStoreCmd),
 }
 
 type replicaCheckInfo struct {
@@ -690,7 +686,7 @@ var debugCompactCmd = &cobra.Command{
 	Long: `
 Compact the sstables in a store.
 `,
-	RunE: runDebugCompact,
+	RunE: maybeDecorateGRPCError(runDebugCompact),
 }
 
 func runDebugCompact(cmd *cobra.Command, args []string) error {
@@ -733,7 +729,7 @@ total files and 14 files that are 129 MiB in size.
 The suffixes K, M, G and T are used for terseness to represent KiB, MiB, GiB
 and TiB.
 `,
-	RunE: runDebugSSTables,
+	RunE: maybeDecorateGRPCError(runDebugSSTables),
 }
 
 func runDebugSSTables(cmd *cobra.Command, args []string) error {
@@ -781,7 +777,7 @@ var debugCmd = &cobra.Command{
 These commands are useful for extracting data from the data files of a
 process that has failed and cannot restart.
 `,
-	Run: func(cmd *cobra.Command, args []string) {
-		mustUsage(cmd)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Usage()
 	},
 }

--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -37,14 +37,13 @@ var dumpCmd = &cobra.Command{
 	Long: `
 Dump SQL tables of a cockroach database.
 `,
-	RunE:         runDump,
+	RunE:         maybeDecorateGRPCError(runDump),
 	SilenceUsage: true,
 }
 
 func runDump(cmd *cobra.Command, args []string) error {
 	if len(args) != 2 {
-		mustUsage(cmd)
-		return errMissingParams
+		return cmd.Usage()
 	}
 
 	conn, err := makeSQLClient()

--- a/pkg/cli/error.go
+++ b/pkg/cli/error.go
@@ -1,0 +1,46 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cli
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+type cmdFn func(*cobra.Command, []string) error
+
+func maybeDecorateGRPCError(wrapped cmdFn) cmdFn {
+	return func(cmd *cobra.Command, args []string) error {
+		err := wrapped(cmd, args)
+
+		if unwrappedErr := errors.Cause(err); unwrappedErr == nil || !grpcutil.IsClosedConnection(unwrappedErr) {
+			return err // intentionally return original to keep wrapping
+		}
+
+		errCode := grpc.Code(err)
+		errMsg := grpc.ErrorDesc(err)
+
+		format := `unable to connect or connection lost.
+
+Please check the address and credentials such as certificates (if attempting to
+communicate with a secure cluster).
+
+(error code %d: %s)`
+
+		return errors.Errorf(format, errCode, errMsg)
+	}
+}

--- a/pkg/cli/examples.go
+++ b/pkg/cli/examples.go
@@ -33,13 +33,12 @@ Available examples:
   quotes from the eponymous TV show.
 - intro: a database containing a single table with a hidden message.
 `,
-	RunE: runGenExamplesCmd,
+	RunE: maybeDecorateGRPCError(runGenExamplesCmd),
 }
 
 func runGenExamplesCmd(cmd *cobra.Command, args []string) error {
 	if len(args) > 1 {
-		mustUsage(cmd)
-		return errMissingParams
+		return cmd.Usage()
 	}
 
 	example := "startrek"

--- a/pkg/cli/gen.go
+++ b/pkg/cli/gen.go
@@ -37,7 +37,7 @@ By default, this places man pages into the "man/man1" directory under the curren
 Use "--path=PATH" to override the output directory. For example, to install man pages globally on
 many Unix-like systems, use "--path=/usr/local/share/man/man1".
 `,
-	RunE: runGenManCmd,
+	RunE: maybeDecorateGRPCError(runGenManCmd),
 }
 
 func runGenManCmd(cmd *cobra.Command, args []string) error {
@@ -88,7 +88,7 @@ override the file location.
 Note that for the generated file to work on OS X, you'll need to install Homebrew's bash-completion
 package (or an equivalent) and follow the post-install instructions.
 `,
-	RunE: runGenAutocompleteCmd,
+	RunE: maybeDecorateGRPCError(runGenAutocompleteCmd),
 }
 
 func runGenAutocompleteCmd(cmd *cobra.Command, args []string) error {
@@ -103,8 +103,8 @@ var genCmd = &cobra.Command{
 	Use:   "gen [command]",
 	Short: "generate auxiliary files",
 	Long:  "Generate manpages, example shell settings, example databases, etc.",
-	Run: func(cmd *cobra.Command, args []string) {
-		mustUsage(cmd)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Usage()
 	},
 }
 

--- a/pkg/cli/kv.go
+++ b/pkg/cli/kv.go
@@ -24,6 +24,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -35,7 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
-func makeDBClient() (*client.DB, *stop.Stopper) {
+func makeDBClient() (*client.DB, *stop.Stopper, error) {
 	stopper := stop.NewStopper()
 	cfg := &base.Config{
 		User:       security.NodeUser,
@@ -44,25 +45,26 @@ func makeDBClient() (*client.DB, *stop.Stopper) {
 		SSLCertKey: baseCfg.SSLCertKey,
 		Insecure:   baseCfg.Insecure,
 	}
+
 	sender, err := client.NewSender(rpc.NewContext(context.TODO(), cfg, nil, stopper), baseCfg.Addr)
 	if err != nil {
 		stopper.Stop()
-		panicf("failed to initialize KV client: %s", err)
+		return nil, nil, errors.Wrap(err, "failed to initialize KV client")
 	}
-	return client.NewDB(sender), stopper
+	return client.NewDB(sender), stopper, nil
 }
 
 // unquoteArg unquotes the provided argument using Go double-quoted
 // string literal rules.
-func unquoteArg(arg string, disallowSystem bool) string {
+func unquoteArg(arg string, disallowSystem bool) (string, error) {
 	s, err := strconv.Unquote(`"` + arg + `"`)
 	if err != nil {
-		panicf("invalid argument %q: %s", arg, err)
+		return "", errors.Wrapf(err, "invalid argument %q", arg)
 	}
 	if disallowSystem && strings.HasPrefix(s, "\x00") {
-		panicf("cannot specify system key %q", s)
+		return "", errors.Errorf("cannot specify system key %q", s)
 	}
-	return s
+	return s, nil
 }
 
 // A getCmd gets the value for the specified key.
@@ -73,26 +75,33 @@ var getCmd = &cobra.Command{
 Fetches and displays the value for <key>.
 `,
 	SilenceUsage: true,
-	RunE:         panicGuard(runGet),
+	RunE:         maybeDecorateGRPCError(runGet),
 }
 
-func runGet(cmd *cobra.Command, args []string) {
+func runGet(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
-		mustUsage(cmd)
-		return
+		return cmd.Usage()
 	}
-	kvDB, stopper := makeDBClient()
+	kvDB, stopper, err := makeDBClient()
+	if err != nil {
+		return err
+	}
 	defer stopper.Stop()
 
-	key := roachpb.Key(unquoteArg(args[0], false))
+	unquoted, err := unquoteArg(args[0], false)
+	if err != nil {
+		return err
+	}
+	key := roachpb.Key(unquoted)
 	r, err := kvDB.Get(context.Background(), key)
 	if err != nil {
-		panicf("get failed: %s", err)
+		return err
 	}
 	if !r.Exists() {
-		panicf("%s not found", key)
+		return errors.Errorf("%s not found", key)
 	}
 	fmt.Printf("%s\n", r.PrettyValue())
+	return nil
 }
 
 // A putCmd sets the value for one or more keys.
@@ -106,29 +115,34 @@ in pairs on the command line.
 WARNING: Modifying system or table keys can corrupt your cluster.
 `,
 	SilenceUsage: true,
-	RunE:         panicGuard(runPut),
+	RunE:         maybeDecorateGRPCError(runPut),
 }
 
-func runPut(cmd *cobra.Command, args []string) {
+func runPut(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 || len(args)%2 == 1 {
-		mustUsage(cmd)
-		return
+		return cmd.Usage()
 	}
 
 	b := &client.Batch{}
 	for i := 0; i < len(args); i += 2 {
-		b.Put(
-			unquoteArg(args[i], true /* disallow system keys */),
-			unquoteArg(args[i+1], false),
-		)
+		k, err := unquoteArg(args[i], true /* disallow system keys */)
+		if err != nil {
+			return err
+		}
+		v, err := unquoteArg(args[i+1], false)
+		if err != nil {
+			return err
+		}
+		b.Put(k, v)
 	}
 
-	kvDB, stopper := makeDBClient()
+	kvDB, stopper, err := makeDBClient()
+	if err != nil {
+		return err
+	}
 	defer stopper.Stop()
 
-	if err := kvDB.Run(context.Background(), b); err != nil {
-		panicf("put failed: %s", err)
-	}
+	return kvDB.Run(context.Background(), b)
 }
 
 // A cPutCmd conditionally sets a value for a key.
@@ -143,30 +157,36 @@ pass nil for expValue. The expValue defaults to 1 if not specified.
 WARNING: Modifying system or table keys can corrupt your cluster.
 `,
 	SilenceUsage: true,
-	RunE:         panicGuard(runCPut),
+	RunE:         maybeDecorateGRPCError(runCPut),
 }
 
-func runCPut(cmd *cobra.Command, args []string) {
+func runCPut(cmd *cobra.Command, args []string) error {
 	if len(args) != 2 && len(args) != 3 {
-		mustUsage(cmd)
-		return
+		return cmd.Usage()
 	}
 
-	kvDB, stopper := makeDBClient()
+	kvDB, stopper, err := makeDBClient()
+	if err != nil {
+		return err
+	}
 	defer stopper.Stop()
 
-	key := unquoteArg(args[0], true /* disallow system keys */)
-	value := unquoteArg(args[1], false)
-	var err error
-	if len(args) == 3 {
-		err = kvDB.CPut(context.Background(), key, value, unquoteArg(args[2], false))
-	} else {
-		err = kvDB.CPut(context.Background(), key, value, nil)
-	}
-
+	key, err := unquoteArg(args[0], true /* disallow system keys */)
 	if err != nil {
-		panicf("conditional put failed: %s", err)
+		return err
 	}
+	value, err := unquoteArg(args[1], false)
+	if err != nil {
+		return err
+	}
+	if len(args) == 3 {
+		existing, err := unquoteArg(args[2], false)
+		if err != nil {
+			return err
+		}
+		return kvDB.CPut(context.Background(), key, value, existing)
+	}
+	return kvDB.CPut(context.Background(), key, value, nil)
 }
 
 // A incCmd command increments the value for a key.
@@ -182,32 +202,39 @@ flags.
 WARNING: Modifying system or table keys can corrupt your cluster.
 `,
 	SilenceUsage: true,
-	RunE:         panicGuard(runInc),
+	RunE:         maybeDecorateGRPCError(runInc),
 }
 
-func runInc(cmd *cobra.Command, args []string) {
-	if len(args) > 2 {
-		mustUsage(cmd)
-		return
+func runInc(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 || len(args) > 2 {
+		return cmd.Usage()
 	}
 
-	kvDB, stopper := makeDBClient()
+	kvDB, stopper, err := makeDBClient()
+	if err != nil {
+		return err
+	}
 	defer stopper.Stop()
 
 	amount := 1
-	if len(args) >= 2 {
+	if len(args) == 2 {
 		var err error
 		if amount, err = strconv.Atoi(args[1]); err != nil {
-			panicf("invalid increment: %s: %s", args[1], err)
+			return errors.Wrap(err, "invalid increment")
 		}
 	}
 
-	key := roachpb.Key(unquoteArg(args[0], true /* disallow system keys */))
-	if r, err := kvDB.Inc(context.TODO(), key, int64(amount)); err != nil {
-		panicf("increment failed: %s", err)
-	} else {
-		fmt.Printf("%d\n", r.ValueInt())
+	unquoted, err := unquoteArg(args[0], true /* disallow system keys */)
+	if err != nil {
+		return err
 	}
+	key := roachpb.Key(unquoted)
+	r, err := kvDB.Inc(context.TODO(), key, int64(amount))
+	if err != nil {
+		return errors.Wrap(err, "increment failed")
+	}
+	fmt.Printf("%d\n", r.ValueInt())
+	return nil
 }
 
 // A delCmd deletes the values of one or more keys.
@@ -220,26 +247,30 @@ Deletes the values of one or more keys.
 WARNING: Modifying system or table keys can corrupt your cluster.
 `,
 	SilenceUsage: true,
-	RunE:         panicGuard(runDel),
+	RunE:         maybeDecorateGRPCError(runDel),
 }
 
-func runDel(cmd *cobra.Command, args []string) {
+func runDel(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		mustUsage(cmd)
-		return
+		return cmd.Usage()
 	}
 
 	b := &client.Batch{}
 	for _, arg := range args {
-		b.Del(unquoteArg(arg, true /* disallow system keys */))
+		key, err := unquoteArg(arg, true /* disallow system keys */)
+		if err != nil {
+			return err
+		}
+		b.Del(key)
 	}
 
-	kvDB, stopper := makeDBClient()
+	kvDB, stopper, err := makeDBClient()
+	if err != nil {
+		return err
+	}
 	defer stopper.Stop()
 
-	if err := kvDB.Run(context.Background(), b); err != nil {
-		panicf("delete failed: %s", err)
-	}
+	return kvDB.Run(context.Background(), b)
 }
 
 // A delRangeCmd deletes the values for a range of keys.
@@ -253,25 +284,32 @@ Deletes the values for the range of keys [startKey, endKey).
 WARNING: Modifying system or table keys can corrupt your cluster.
 `,
 	SilenceUsage: true,
-	RunE:         panicGuard(runDelRange),
+	RunE:         maybeDecorateGRPCError(runDelRange),
 }
 
-func runDelRange(cmd *cobra.Command, args []string) {
+func runDelRange(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		mustUsage(cmd)
-		return
+		return cmd.Usage()
 	}
 
-	kvDB, stopper := makeDBClient()
+	kvDB, stopper, err := makeDBClient()
+	if err != nil {
+		return err
+	}
 	defer stopper.Stop()
 
-	if err := kvDB.DelRange(
-		context.TODO(),
-		unquoteArg(args[0], true /* disallow system keys */),
-		unquoteArg(args[1], true /* disallow system keys */),
-	); err != nil {
-		panicf("delrange failed: %s", err)
+	uqFrom, err := unquoteArg(args[0], true /* disallow system keys */)
+	if err != nil {
+		return err
 	}
+	uqTo, err := unquoteArg(args[1], true /* disallow system keys */)
+	if err != nil {
+		return err
+	}
+
+	return kvDB.DelRange(
+		context.TODO(), roachpb.Key(uqFrom), roachpb.Key(uqTo),
+	)
 }
 
 // A scanCmd fetches the key/value pairs for a specified
@@ -286,24 +324,30 @@ is specified then all (non-system) key/value pairs are retrieved. If no
 are retrieved.
 `,
 	SilenceUsage: true,
-	RunE:         panicGuard(runScan),
+	RunE:         maybeDecorateGRPCError(runScan),
 }
 
-func runScan(cmd *cobra.Command, args []string) {
+func runScan(cmd *cobra.Command, args []string) error {
 	if len(args) > 2 {
-		mustUsage(cmd)
-		return
+		return cmd.Usage()
 	}
-	startKey, endKey := initScanArgs(args)
+	startKey, endKey, err := initScanArgs(args)
+	if err != nil {
+		return err
+	}
 
-	kvDB, stopper := makeDBClient()
+	kvDB, stopper, err := makeDBClient()
+	if err != nil {
+		return err
+	}
 	defer stopper.Stop()
 
 	rows, err := kvDB.Scan(context.Background(), startKey, endKey, maxResults)
 	if err != nil {
-		panicf("scan failed: %s", err)
+		return err
 	}
 	showResult(rows)
+	return nil
 }
 
 // A reverseScanCmd fetches the key/value pairs for a specified
@@ -318,40 +362,54 @@ is specified then all (non-system) key/value pairs are retrieved. If no
 are retrieved.
 `,
 	SilenceUsage: true,
-	RunE:         panicGuard(runReverseScan),
+	RunE:         maybeDecorateGRPCError(runReverseScan),
 }
 
-func runReverseScan(cmd *cobra.Command, args []string) {
+func runReverseScan(cmd *cobra.Command, args []string) error {
 	if len(args) > 2 {
-		mustUsage(cmd)
-		return
+		return cmd.Usage()
 	}
-	startKey, endKey := initScanArgs(args)
-	kvDB, stopper := makeDBClient()
+	startKey, endKey, err := initScanArgs(args)
+	if err != nil {
+		return err
+	}
+	kvDB, stopper, err := makeDBClient()
+	if err != nil {
+		return err
+	}
 	defer stopper.Stop()
 
 	rows, err := kvDB.ReverseScan(context.TODO(), startKey, endKey, maxResults)
 	if err != nil {
-		panicf("reverse scan failed: %s", err)
+		return err
 	}
 	showResult(rows)
+	return nil
 }
 
-func initScanArgs(args []string) (startKey, endKey roachpb.Key) {
+func initScanArgs(args []string) (startKey, endKey roachpb.Key, _ error) {
 	if len(args) >= 1 {
-		startKey = roachpb.Key(unquoteArg(args[0], false))
+		unquoted, err := unquoteArg(args[0], false)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "invalid start key")
+		}
+		startKey = roachpb.Key(unquoted)
 	} else {
 		// Start with the first key after the system key range.
 		startKey = keys.UserDataSpan.Key
 	}
 	if len(args) >= 2 {
-		endKey = roachpb.Key(unquoteArg(args[1], false))
+		unquoted, err := unquoteArg(args[1], false)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "invalid end key")
+		}
+		endKey = roachpb.Key(unquoted)
 	} else {
 		// Exclude table data keys by default. The user can explicitly request them
 		// by passing \xff\xff for the end key.
 		endKey = keys.UserDataSpan.EndKey
 	}
-	return startKey, endKey
+	return startKey, endKey, nil
 }
 
 func showResult(rows []client.KeyValue) {
@@ -385,8 +443,8 @@ Special characters in keys or values should be specified according to
 the double-quoted Go string literal rules (see
 https://golang.org/ref/spec#String_literals).
 `,
-	Run: func(cmd *cobra.Command, args []string) {
-		mustUsage(cmd)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Usage()
 	},
 }
 

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -46,12 +46,12 @@ var lsNodesCmd = &cobra.Command{
 	commands.
 	`,
 	SilenceUsage: true,
-	RunE:         runLsNodes,
+	RunE:         maybeDecorateGRPCError(runLsNodes),
 }
 
 func runLsNodes(cmd *cobra.Command, args []string) error {
 	if len(args) != 0 {
-		mustUsage(cmd)
+		return cmd.Usage()
 	}
 
 	c, stopper, err := getStatusClient()
@@ -100,7 +100,7 @@ var statusNodeCmd = &cobra.Command{
 	is specified, this will display the status for all nodes in the cluster.
 	`,
 	SilenceUsage: true,
-	RunE:         runStatusNode,
+	RunE:         maybeDecorateGRPCError(runStatusNode),
 }
 
 func runStatusNode(cmd *cobra.Command, args []string) error {
@@ -137,7 +137,6 @@ func runStatusNode(cmd *cobra.Command, args []string) error {
 		nodeStatuses = []status.NodeStatus{*nodeStatus}
 
 	default:
-		mustUsage(cmd)
 		return errors.Errorf("expected no arguments or a single node ID")
 	}
 
@@ -194,8 +193,8 @@ var nodeCmd = &cobra.Command{
 	Use:   "node [command]",
 	Short: "list nodes and show their status",
 	Long:  "List nodes and show their status.",
-	Run: func(cmd *cobra.Command, args []string) {
-		mustUsage(cmd)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Usage()
 	},
 }
 

--- a/pkg/cli/range.go
+++ b/pkg/cli/range.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -35,13 +35,12 @@ var lsRangesCmd = &cobra.Command{
 Lists the ranges in a cluster.
 `,
 	SilenceUsage: true,
-	RunE:         panicGuard(runLsRanges),
+	RunE:         maybeDecorateGRPCError(runLsRanges),
 }
 
-func runLsRanges(cmd *cobra.Command, args []string) {
+func runLsRanges(cmd *cobra.Command, args []string) error {
 	if len(args) > 1 {
-		mustUsage(cmd)
-		return
+		return cmd.Usage()
 	}
 
 	var startKey roachpb.Key
@@ -58,18 +57,21 @@ func runLsRanges(cmd *cobra.Command, args []string) {
 	}
 	endKey := keys.Meta2Prefix.PrefixEnd()
 
-	kvDB, stopper := makeDBClient()
+	kvDB, stopper, err := makeDBClient()
+	if err != nil {
+		return err
+	}
 	defer stopper.Stop()
+
 	rows, err := kvDB.Scan(context.Background(), startKey, endKey, maxResults)
 	if err != nil {
-		panicf("scan failed: %s\n", err)
+		return err
 	}
 
 	for _, row := range rows {
 		desc := &roachpb.RangeDescriptor{}
 		if err := row.ValueProto(desc); err != nil {
-			panicf("%s: unable to unmarshal range descriptor\n", row.Key)
-			continue
+			return errors.Wrapf(err, "unable to unmarshal range descriptor at %s", row.Key)
 		}
 		fmt.Printf("%s-%s [%d]\n", desc.StartKey, desc.EndKey, desc.RangeID)
 		for i, replica := range desc.Replicas {
@@ -78,6 +80,7 @@ func runLsRanges(cmd *cobra.Command, args []string) {
 		}
 	}
 	fmt.Printf("%d result(s)\n", len(rows))
+	return nil
 }
 
 // A splitRangeCmd command splits a range.
@@ -88,21 +91,22 @@ var splitRangeCmd = &cobra.Command{
 Splits the range containing <key> at <key>.
 `,
 	SilenceUsage: true,
-	RunE:         panicGuard(runSplitRange),
+	RunE:         maybeDecorateGRPCError(runSplitRange),
 }
 
-func runSplitRange(cmd *cobra.Command, args []string) {
+func runSplitRange(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
-		mustUsage(cmd)
-		return
+		return cmd.Usage()
 	}
 
 	key := roachpb.Key(args[0])
-	kvDB, stopper := makeDBClient()
-	defer stopper.Stop()
-	if err := kvDB.AdminSplit(context.Background(), key); err != nil {
-		panicf("split failed: %s\n", err)
+
+	kvDB, stopper, err := makeDBClient()
+	if err != nil {
+		return err
 	}
+	defer stopper.Stop()
+	return errors.Wrap(kvDB.AdminSplit(context.Background(), key), "split failed")
 }
 
 var rangeCmds = []*cobra.Command{
@@ -113,8 +117,8 @@ var rangeCmds = []*cobra.Command{
 var rangeCmd = &cobra.Command{
 	Use:   "range",
 	Short: "list and split ranges",
-	Run: func(cmd *cobra.Command, args []string) {
-		mustUsage(cmd)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Usage()
 	},
 }
 

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -50,7 +50,7 @@ var sqlShellCmd = &cobra.Command{
 	Long: `
 Open a sql shell running against a cockroach database.
 `,
-	RunE:         runTerm,
+	RunE:         maybeDecorateGRPCError(runTerm),
 	SilenceUsage: true,
 }
 
@@ -489,8 +489,7 @@ func runStatements(conn *sqlConn, stmts []string, pretty bool) error {
 
 func runTerm(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
-		mustUsage(cmd)
-		return errMissingParams
+		return cmd.Usage()
 	}
 
 	conn, err := makeSQLClient()

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -18,7 +18,6 @@
 package cli
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -53,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
 
 	"github.com/spf13/cobra"
 )
@@ -63,29 +63,6 @@ var errMissingParams = errors.New("missing or invalid parameters")
 // This will be non-nil when jemalloc is linked in with profiling enabled.
 // The function takes a filename to write the profile to.
 var jemallocHeapDump func(string) error
-
-// panicGuard wraps an errorless command into one wrapping panics into errors.
-// This simplifies error handling for many commands for which more elaborate
-// error handling isn't needed and would otherwise bloat the code.
-//
-// Deprecated: When introducing a new cobra.Command, simply return an error.
-func panicGuard(cmdFn func(*cobra.Command, []string)) func(*cobra.Command, []string) error {
-	return func(c *cobra.Command, args []string) (err error) {
-		defer func() {
-			if r := recover(); r != nil {
-				err = fmt.Errorf("%v", r)
-			}
-		}()
-		cmdFn(c, args)
-		return nil
-	}
-}
-
-// panicf is only to be used when wrapped through panicGuard, since the
-// stack trace doesn't matter then.
-func panicf(format string, args ...interface{}) {
-	panic(fmt.Sprintf(format, args...))
-}
 
 // startCmd starts a node by initializing the stores and joining
 // the cluster.
@@ -103,7 +80,7 @@ uninitialized, specify the --join flag to point to any healthy node
 `,
 	Example:      `  cockroach start --insecure --store=attrs=ssd,path=/mnt/ssd1 [--join=host:port,[host:port]]`,
 	SilenceUsage: true,
-	RunE:         runStart,
+	RunE:         maybeDecorateGRPCError(runStart),
 }
 
 func setDefaultCacheSize(ctx *server.Config) {
@@ -551,36 +528,72 @@ will be ignored by the server. When all extant requests have been
 completed, the server exits.
 `,
 	SilenceUsage: true,
-	RunE:         runQuit,
+	RunE:         maybeDecorateGRPCError(runQuit),
 }
 
-// doShutdown attempts to trigger server shutdown. The string return
-// value, if non-empty, indicates a reason why the state may be
-// uncertain and thus that it may make sense to retry the shutdown.
-func doShutdown(c serverpb.AdminClient, ctx context.Context, onModes []int32) (string, error) {
-	stream, err := c.Drain(ctx, &serverpb.DrainRequest{
-		On:       onModes,
-		Shutdown: true,
-	})
-	if err != nil {
-		return "", err
-	}
-	_, err = stream.Recv()
-	if err == nil {
-		for {
-			if _, err := stream.Recv(); !grpcutil.IsClosedConnection(err) {
-				return "", err
-			}
-			break
+// doShutdown attempts to trigger a server shutdown. When given an empty
+// onModes slice, it's a hard shutdown.
+func doShutdown(c serverpb.AdminClient, ctx context.Context, onModes []int32) error {
+	// This is kind of hairy, but should work well in practice. We want to
+	// distinguish between the case in which we can't even connect to the
+	// server (in which case we don't want our caller to try to come back with
+	// a hard retry) and the case in which an attempt to shut down fails (times
+	// out, or perhaps drops the connection while waiting). To that end, we
+	// first run a noop DrainRequest. If that fails, we give up. Otherwise, we
+	// wait for the "real" request to give us a response and then continue
+	// reading until the connection drops (which then counts as a success, for
+	// the connection dropping is likely the result of the Stopper having
+	// reached the final stages of shutdown).
+	for i, modes := range [][]int32{nil, onModes} {
+		stream, err := c.Drain(ctx, &serverpb.DrainRequest{
+			On:       modes,
+			Shutdown: i > 0,
+		})
+		if err != nil {
+			return err
 		}
-		fmt.Println("ok")
-		return "", nil
+		// Only signal the caller to try again with a hard shutdown if we're
+		// not already trying to do that, and if the initial connection attempt
+		// (without shutdown) has succeeded.
+		tryHard := i > 0 && len(onModes) > 0
+		var hasResp bool
+		for {
+			if _, err := stream.Recv(); err != nil {
+				if hasResp && grpcutil.IsClosedConnection(err) {
+					// We're trying to shut down, and we already got a response
+					// and now the connection is closed. This means we shut
+					// down successfully.
+					return nil
+				}
+				if tryHard {
+					// Either we hadn't seen a response yet (in which case it's
+					// likely that our connection broke while waiting for the
+					// shutdown to happen); try again (and harder).
+					return errTryHardShutdown{err}
+				}
+				// Case in which we don't even know whether the server is
+				// running. No point in trying again.
+				return err
+			}
+			if i == 0 {
+				// Our liveness probe succeeded.
+				break
+			}
+			hasResp = true
+		}
 	}
-	return fmt.Sprintf("%v", err), nil
+	return nil
 }
+
+type errTryHardShutdown struct{ error }
 
 // runQuit accesses the quit shutdown path.
-func runQuit(_ *cobra.Command, _ []string) error {
+func runQuit(_ *cobra.Command, _ []string) (err error) {
+	defer func() {
+		if err == nil {
+			fmt.Println("ok")
+		}
+	}()
 	onModes := make([]int32, len(server.GracefulDrainModes))
 	for i, m := range server.GracefulDrainModes {
 		onModes[i] = int32(m)
@@ -594,21 +607,20 @@ func runQuit(_ *cobra.Command, _ []string) error {
 
 	ctx := stopperContext(stopper)
 
-	retry, err := doShutdown(c, ctx, onModes)
-	if err != nil {
-		return err
-	}
-	if retry != "" {
-		fmt.Fprintf(os.Stderr, "graceful shutdown failed, proceeding with hard shutdown: %s\n", retry)
-
-		// Not passing drain modes tells the server to not bother and go
-		// straight to shutdown.
-		_, err := doShutdown(c, ctx, nil)
-		if err != nil {
-			return fmt.Errorf("hard shutdown failed: %v", err)
+	if err := doShutdown(c, ctx, onModes); err != nil {
+		if _, ok := err.(*errTryHardShutdown); ok {
+			fmt.Fprintf(
+				os.Stderr, "graceful shutdown failed: %s\nproceeding with hard shutdown\n", err,
+			)
+		} else {
+			return err
 		}
+	} else {
+		return nil
 	}
-	return nil
+	// Not passing drain modes tells the server to not bother and go
+	// straight to shutdown.
+	return errors.Wrap(doShutdown(c, ctx, nil), "hard shutdown failed")
 }
 
 // freezeClusterCmd command issues a cluster-wide freeze.
@@ -623,7 +635,7 @@ restarted. A failed or incomplete invocation of this command can be rolled back
 using the --undo flag, or by restarting all the nodes in the cluster.
 `,
 	SilenceUsage: true,
-	RunE:         runFreezeCluster,
+	RunE:         maybeDecorateGRPCError(runFreezeCluster),
 }
 
 func runFreezeCluster(_ *cobra.Command, _ []string) error {

--- a/pkg/cli/zone.go
+++ b/pkg/cli/zone.go
@@ -209,15 +209,14 @@ Fetches and displays the zone configuration for the specified database or
 table.
 `,
 	SilenceUsage: true,
-	RunE:         runGetZone,
+	RunE:         maybeDecorateGRPCError(runGetZone),
 }
 
 // runGetZone retrieves the zone config for a given object id,
 // and if present, outputs its YAML representation.
 func runGetZone(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
-		mustUsage(cmd)
-		return nil
+		return cmd.Usage()
 	}
 
 	names, err := parseZoneName(args[0])
@@ -272,13 +271,12 @@ var lsZonesCmd = &cobra.Command{
 List zone configs.
 `,
 	SilenceUsage: true,
-	RunE:         runLsZones,
+	RunE:         maybeDecorateGRPCError(runLsZones),
 }
 
 func runLsZones(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
-		mustUsage(cmd)
-		return nil
+		return cmd.Usage()
 	}
 	conn, err := makeSQLClient()
 	if err != nil {
@@ -347,13 +345,12 @@ var rmZoneCmd = &cobra.Command{
 Remove an existing zone config for the specified database or table.
 `,
 	SilenceUsage: true,
-	RunE:         runRmZone,
+	RunE:         maybeDecorateGRPCError(runRmZone),
 }
 
 func runRmZone(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
-		mustUsage(cmd)
-		return nil
+		return cmd.Usage()
 	}
 
 	names, err := parseZoneName(args[0])
@@ -418,7 +415,7 @@ Note that the specified zone config is merged with the existing zone config for
 the database or table.
 `,
 	SilenceUsage: true,
-	RunE:         runSetZone,
+	RunE:         maybeDecorateGRPCError(runSetZone),
 }
 
 func readZoneConfig() (conf []byte, err error) {
@@ -444,8 +441,7 @@ func readZoneConfig() (conf []byte, err error) {
 // in the system.zones table.
 func runSetZone(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
-		mustUsage(cmd)
-		return nil
+		return cmd.Usage()
 	}
 
 	conn, err := makeSQLClient()
@@ -527,8 +523,8 @@ var zoneCmds = []*cobra.Command{
 var zoneCmd = &cobra.Command{
 	Use:   "zone",
 	Short: "get, set, list and remove zones",
-	Run: func(cmd *cobra.Command, args []string) {
-		mustUsage(cmd)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Usage()
 	},
 }
 

--- a/pkg/internal/client/rpc_sender.go
+++ b/pkg/internal/client/rpc_sender.go
@@ -18,7 +18,6 @@ package client
 
 import (
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
@@ -44,7 +43,7 @@ func NewSender(ctx *rpc.Context, target string) (Sender, error) {
 func (s sender) Send(
 	ctx context.Context, ba roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
-	br, err := s.Batch(ctx, &ba, grpc.FailFast(false))
+	br, err := s.Batch(ctx, &ba)
 	if err != nil {
 		return nil, roachpb.NewError(errors.Wrap(err, "roachpb.Batch RPC failed"))
 	}

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -882,10 +882,12 @@ func (s *adminServer) Drain(req *serverpb.DrainRequest, stream serverpb.Admin_Dr
 		return err
 	}
 
-	if req.Shutdown {
-		s.server.grpc.Stop()
-		go s.server.stopper.Stop()
+	if !req.Shutdown {
+		return nil
 	}
+
+	s.server.grpc.Stop()
+	go s.server.stopper.Stop()
 
 	ctx := stream.Context()
 

--- a/pkg/util/grpcutil/grpc_util.go
+++ b/pkg/util/grpcutil/grpc_util.go
@@ -19,17 +19,20 @@ package grpcutil
 import (
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/util/netutil"
+	"github.com/pkg/errors"
+
 	"golang.org/x/net/context"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/transport"
-
-	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 )
 
-// IsClosedConnection returns true if err is an error produced by gRPC on closed connections.
+// IsClosedConnection returns true if err's Cause is an error produced by gRPC
+// on closed connections.
 func IsClosedConnection(err error) bool {
+	err = errors.Cause(err)
 	if err == context.Canceled ||
 		grpc.Code(err) == codes.Canceled ||
 		grpc.Code(err) == codes.Unavailable ||


### PR DESCRIPTION
Removed `panicGuard` and `mustUsage` and introduced proper error handling,
cleaning up some cruft along the way. However, the primary goal was exposing
better errors to clients. To this end, GRPC errors are now special-cased
and print a legible error. For example,

```
$ ./cockroach node ls # node is not even running
Error: unable to connect or connection lost.

Please check the address and credentials such as certificates (if attempting to
communicate with a secure cluster).

(error code 14: grpc: the connection is unavailable)
Failed running "node"
```

In particular, I removed the `failfast=false` toggle in RPCSender, which (at
least for the cli debug commands, where it is used) would have calls hang
forever, even if the server wasn't even running or the certificates not
specified.

Updated `grpcutil.IsConnectionClosed()` to operate on the `errors.Cause` of
an error.

Reworked `runQuit`:

```
./cockroach quit --host gamma.gce.cockroachdb.com # host alive, but secure
Error: unable to connect or connection lost.

Please check the address and credentials such as certificates (if attempting to
communicate with a secure cluster).

(error code 13: transport is closing)
Failed running "quit"

$ ./cockroach quit # host not running
Error: unable to connect or connection lost.

Please check the address and credentials such as certificates (if attempting to
communicate with a secure cluster).

(error code 14: grpc: the connection is unavailable)
Failed running "quit"

$  $ ./cockroach quit # node running
ok
```

Fixes #9151.
Fixes #9153.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9917)

<!-- Reviewable:end -->
