### PR TITLE
kube: exec the cockroachdb process so signals are handled properly

### DIFF
--- a/cloud/kubernetes/cockroachdb-petset.yaml
+++ b/cloud/kubernetes/cockroachdb-petset.yaml
@@ -113,7 +113,7 @@ spec:
             then
               CRARGS+=("--join" "cockroachdb")
             fi
-            /cockroach/cockroach ${CRARGS[*]}
+            exec /cockroach/cockroach ${CRARGS[*]}
       # No pre-stop hook is required, a SIGTERM plus some time is all that's
       # needed for graceful shutdown of a node.
       terminationGracePeriodSeconds: 60


### PR DESCRIPTION
As suggested by a comment on our recent blog post: http://disq.us/p/1cq0c5k

And similar to what we recently did for our docker image: https://github.com/cockroachdb/cockroach/pull/9495

@tschottdorf

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9918)

<!-- Reviewable:end -->
