### PR TITLE
sql: add internal search path for SELECT queries

### DIFF
--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -225,9 +225,18 @@ func (p *planner) getDataSource(
 	switch t := src.(type) {
 	case *parser.NormalizableTableName:
 		// Usual case: a table.
-		tn, err := t.NormalizeWithDatabaseName(p.session.Database)
+		tn, err := t.Normalize()
 		if err != nil {
 			return planDataSource{}, err
+		}
+		if tn.DatabaseName == "" {
+			database, err := p.databaseFromSearchPath(tn)
+			if err != nil {
+				return planDataSource{}, err
+			}
+			if err := tn.QualifyWithDatabase(database); err != nil {
+				return planDataSource{}, err
+			}
 		}
 
 		// Is this perhaps a name for a virtual table?

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -58,7 +58,13 @@ const keyFor7881Sample = "found#7881"
 // Session contains the state of a SQL client connection.
 // Create instances using NewSession().
 type Session struct {
-	Database    string
+	Database string
+	// SearchPath is a list of databases that will be searched for a table name
+	// before the database. Currently, this is used only for SELECTs.
+	//
+	// NOTE: If we allow the user to set this, we'll need to handle the case where
+	// the session database or pg_catalog are in this path.
+	SearchPath  []string
 	User        string
 	Syntax      int32
 	DistSQLMode distSQLExecMode
@@ -135,10 +141,11 @@ func NewSession(ctx context.Context, args SessionArgs, e *Executor, remote net.A
 		panic("Session's context must have a tracer in it")
 	}
 	s := &Session{
-		Database: args.Database,
-		User:     args.User,
-		Location: time.UTC,
-		executor: e,
+		Database:   args.Database,
+		SearchPath: []string{"pg_catalog"},
+		User:       args.User,
+		Location:   time.UTC,
+		executor:   e,
 	}
 	cfg, cache := e.getSystemConfig()
 	s.planner = planner{

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -131,6 +131,9 @@ var _ SchemaAccessor = &planner{}
 func (p *planner) getTableOrViewDesc(tn *parser.TableName) (*sqlbase.TableDescriptor, error) {
 	virtual, err := p.virtualSchemas().getVirtualTableDesc(tn)
 	if err != nil || virtual != nil {
+		if _, ok := err.(*sqlbase.ErrUndefinedTable); ok {
+			return nil, nil
+		}
 		return virtual, err
 	}
 
@@ -487,4 +490,30 @@ func (p *planner) expandTableGlob(pattern parser.TablePattern) (parser.TableName
 		return nil, err
 	}
 	return tableNames, nil
+}
+
+// databaseFromSearchPath returns the first database in the session's SearchPath
+// that contains the specified table. If the table can't be found, we return the
+// session database.
+func (p *planner) databaseFromSearchPath(tn *parser.TableName) (string, error) {
+	t := *tn
+	for _, database := range p.session.SearchPath {
+		t.DatabaseName = parser.Name(database)
+		desc, err := p.getTableOrViewDesc(&t)
+		if err != nil {
+			if _, ok := err.(*sqlbase.ErrUndefinedDatabase); ok {
+				// Keep iterating through search path if a database in the search path
+				// doesn't exist.
+				continue
+			}
+			return "", err
+		}
+		if desc != nil {
+			// The table or view exists in this database, so return it.
+			return t.Database(), nil
+		}
+	}
+	// If we couldn't find the table or view in the search path, default to the
+	// database set by the user.
+	return p.session.Database, nil
 }

--- a/pkg/sql/testdata/select_search_path
+++ b/pkg/sql/testdata/select_search_path
@@ -1,0 +1,119 @@
+# Test that pg_catalog tables are accessible without qualifying table/view
+# names.
+
+query I
+SELECT COUNT(DISTINCT(1)) FROM pg_attrdef
+----
+1
+
+query I
+SELECT COUNT(DISTINCT(1)) FROM pg_attribute
+----
+1
+
+query I
+SELECT COUNT(DISTINCT(1)) FROM pg_class
+----
+1
+
+query I
+SELECT COUNT(DISTINCT(1)) FROM pg_namespace
+----
+1
+
+query I
+SELECT COUNT(DISTINCT(1)) FROM pg_tables
+----
+1
+
+
+statement ok
+CREATE DATABASE t1
+
+statement ok
+CREATE TABLE t1.numbers (n INTEGER)
+
+statement ok
+CREATE DATABASE t2
+
+statement ok
+CREATE TABLE t2.words (w TEXT)
+
+# Test that we can query with unqualified table names from t1 and pg_catalog
+# (but not t2) when t1 is the session database.
+
+statement ok
+SET DATABASE = t1
+
+query I
+SELECT COUNT(*) FROM numbers
+----
+0
+
+query error pq: table "words" does not exist
+SELECT COUNT(*) FROM words
+
+query I
+SELECT COUNT(DISTINCT(1)) FROM pg_attrdef
+----
+1
+
+query I
+SELECT COUNT(DISTINCT(1)) FROM pg_attribute
+----
+1
+
+query I
+SELECT COUNT(DISTINCT(1)) FROM pg_class
+----
+1
+
+query I
+SELECT COUNT(DISTINCT(1)) FROM pg_namespace
+----
+1
+
+query I
+SELECT COUNT(DISTINCT(1)) FROM pg_tables
+----
+1
+
+# Test that we can query with unqualified table names from t2 and pg_catalog
+# (but not t1) when t2 is the session database.
+
+statement ok
+SET DATABASE = t2
+
+query error pq: table "numbers" does not exist
+SELECT COUNT(*) FROM numbers
+
+query I
+SELECT COUNT(*) FROM words
+----
+0
+
+query I
+SELECT COUNT(DISTINCT(1)) FROM pg_attrdef
+----
+1
+
+query I
+SELECT COUNT(DISTINCT(1)) FROM pg_attribute
+----
+1
+
+query I
+SELECT COUNT(DISTINCT(1)) FROM pg_class
+----
+1
+
+query I
+SELECT COUNT(DISTINCT(1)) FROM pg_namespace
+----
+1
+
+query I
+SELECT COUNT(DISTINCT(1)) FROM pg_tables
+----
+1
+


### PR DESCRIPTION
ORMs often query `pg_catalog` tables using unqualified table names. For example, `SELECT * FROM pg_attribute`. This change adds a search path (like Postgres's `search_path`) to the SQL session, which is an ordered list of databases to search for an unqualified table name. Currently, this is used only for SELECT queries, which is what the major ORMs seem to need.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9927)

<!-- Reviewable:end -->
