### PR TITLE
util/caller: strip pkg/ prefixes

### DIFF
--- a/pkg/util/caller/resolver.go
+++ b/pkg/util/caller/resolver.go
@@ -46,7 +46,7 @@ type CallResolver struct {
 
 var reStripNothing = regexp.MustCompile(`^$`)
 
-// defaultRE strips src/github.com/organization/project/module/submodule/file.go
+// defaultRE strips src/github.com/org/project/(pkg/)module/submodule/file.go
 // down to module/submodule/file.go. It falls back to stripping nothing when
 // it's unable to look up its own location via runtime.Caller().
 var defaultRE = func() *regexp.Regexp {
@@ -66,8 +66,8 @@ var defaultRE = func() *regexp.Regexp {
 		path = filepath.Dir(filepath.Clean(path))
 	}
 	qSep := regexp.QuoteMeta(sep)
-	// Part of the regexp that matches `/github.com/username/reponame/`.
-	pkgStrip := qSep + strings.Repeat(strings.Join([]string{"[^", "]+", ""}, qSep), 3) + "(.*)"
+	// Part of the regexp that matches `/github.com/username/reponame/(pkg/)`.
+	pkgStrip := qSep + strings.Repeat(strings.Join([]string{"[^", "]+", ""}, qSep), 3) + "(?:pkg/)?(.*)"
 	if !strings.Contains(path, sep) {
 		// This is again the unusual case above. The actual callsites will have
 		// a "real" caller, so now we don't exactly know what to strip; going

--- a/pkg/util/caller/resolver_test.go
+++ b/pkg/util/caller/resolver_test.go
@@ -54,7 +54,7 @@ func TestDefaultCallResolver(t *testing.T) {
 			t.Fatalf("unexpected caller reported: %s", fun)
 		}
 
-		if file != filepath.Join("pkg", "util", "caller", "resolver_test.go") {
+		if file != filepath.Join("util", "caller", "resolver_test.go") {
 			t.Fatalf("wrong file '%s'", file)
 		}
 	}


### PR DESCRIPTION
Fixes #9930

Downside is that this means path/to/file.go:123 is going to be missing pkg and thus not clickable
in an iTerm session in the root.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9932)

<!-- Reviewable:end -->
