### PR TITLE
Makefile: stop rebuilding on `make check`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,11 +161,9 @@ dupl:
 	| dupl -files $(DUPLFLAGS)
 
 .PHONY: check
+check: TAGS += check
 check:
-	# compile everything; go vet sometimes reports incorrect errors if
-	# the build artifacts are stale.
-	$(GO) test -i -tags '$(TAGS)' ./pkg/...
-	$(GO) test ./build -v -tags check -run 'TestStyle/$(TESTS)'
+	$(GO) test ./build -v -tags '$(TAGS)' -run 'TestStyle/$(TESTS)'
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
The upstream badness appears to be fixed, though I only tested limited
cases.

Fixes #9919.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9948)

<!-- Reviewable:end -->
