### PR TITLE
acceptance: fix Terraform acceptance tests

### DIFF
--- a/pkg/acceptance/terraform/main.tf
+++ b/pkg/acceptance/terraform/main.tf
@@ -75,7 +75,7 @@ resource "null_resource" "cockroach-runner" {
   }
 
   provisioner "file" {
-    source = "../../cloud/gce/download_binary.sh"
+    source = "../../../cloud/gce/download_binary.sh"
     destination = "/home/ubuntu/download_binary.sh"
   }
 


### PR DESCRIPTION
Everything moved to pkg, which broke the copying of `download_binary.sh`
to CockroachDB nodes.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9949)

<!-- Reviewable:end -->
