### PR TITLE
Add Time Series Maintenance Queue

### DIFF
--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -92,6 +92,13 @@ func (s *Store) ForceRaftLogScanAndProcess() {
 	forceScanAndProcess(s, s.raftLogQueue.baseQueue)
 }
 
+// ForceTimeSeriesMaintenanceQueueProcess iterates over all ranges, enqueuing
+// any that need time series maintenance, then processes the time series
+// maintenance queue.
+func (s *Store) ForceTimeSeriesMaintenanceQueueProcess() {
+	forceScanAndProcess(s, s.tsMaintenanceQueue.baseQueue)
+}
+
 // GetDeadReplicas exports s.deadReplicas for tests.
 func (s *Store) GetDeadReplicas() roachpb.StoreDeadReplicas {
 	return s.deadReplicas()

--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -209,6 +209,15 @@ var (
 	metaSplitQueueProcessingNanos = metric.Metadata{Name: "queue.split.processingnanos",
 		Help: "Nanoseconds spent processing replicas in the split queue"}
 
+	metaTimeSeriesMaintenanceQueueSuccesses = metric.Metadata{Name: "queue.tsmaintenance.process.success",
+		Help: "Number of replicas successfully processed by the time series maintenance queue"}
+	metaTimeSeriesMaintenanceQueueFailures = metric.Metadata{Name: "queue.tsmaintenance.process.failure",
+		Help: "Number of replicas which failed processing in the time series maintenance queue"}
+	metaTimeSeriesMaintenanceQueuePending = metric.Metadata{Name: "queue.tsmaintenance.pending",
+		Help: "Number of pending replicas in the time series maintenance queue"}
+	metaTimeSeriesMaintenanceQueueProcessingNanos = metric.Metadata{Name: "queue.tsmaintenance.processingnanos",
+		Help: "Nanoseconds spent processing replicas in the time series maintenance queue"}
+
 	// GCInfo cumulative totals.
 	metaGCNumKeysAffected = metric.Metadata{Name: "queue.gc.info.numkeysaffected",
 		Help: "Number of keys with GC'able data"}
@@ -348,31 +357,35 @@ type StoreMetrics struct {
 	RaftEnqueuedPending *metric.Gauge
 
 	// Replica queue metrics.
-	GCQueueSuccesses                *metric.Counter
-	GCQueueFailures                 *metric.Counter
-	GCQueuePending                  *metric.Gauge
-	GCQueueProcessingNanos          *metric.Counter
-	RaftLogQueueSuccesses           *metric.Counter
-	RaftLogQueueFailures            *metric.Counter
-	RaftLogQueuePending             *metric.Gauge
-	RaftLogQueueProcessingNanos     *metric.Counter
-	ConsistencyQueueSuccesses       *metric.Counter
-	ConsistencyQueueFailures        *metric.Counter
-	ConsistencyQueuePending         *metric.Gauge
-	ConsistencyQueueProcessingNanos *metric.Counter
-	ReplicaGCQueueSuccesses         *metric.Counter
-	ReplicaGCQueueFailures          *metric.Counter
-	ReplicaGCQueuePending           *metric.Gauge
-	ReplicaGCQueueProcessingNanos   *metric.Counter
-	ReplicateQueueSuccesses         *metric.Counter
-	ReplicateQueueFailures          *metric.Counter
-	ReplicateQueuePending           *metric.Gauge
-	ReplicateQueueProcessingNanos   *metric.Counter
-	ReplicateQueuePurgatory         *metric.Gauge
-	SplitQueueSuccesses             *metric.Counter
-	SplitQueueFailures              *metric.Counter
-	SplitQueuePending               *metric.Gauge
-	SplitQueueProcessingNanos       *metric.Counter
+	GCQueueSuccesses                          *metric.Counter
+	GCQueueFailures                           *metric.Counter
+	GCQueuePending                            *metric.Gauge
+	GCQueueProcessingNanos                    *metric.Counter
+	RaftLogQueueSuccesses                     *metric.Counter
+	RaftLogQueueFailures                      *metric.Counter
+	RaftLogQueuePending                       *metric.Gauge
+	RaftLogQueueProcessingNanos               *metric.Counter
+	ConsistencyQueueSuccesses                 *metric.Counter
+	ConsistencyQueueFailures                  *metric.Counter
+	ConsistencyQueuePending                   *metric.Gauge
+	ConsistencyQueueProcessingNanos           *metric.Counter
+	ReplicaGCQueueSuccesses                   *metric.Counter
+	ReplicaGCQueueFailures                    *metric.Counter
+	ReplicaGCQueuePending                     *metric.Gauge
+	ReplicaGCQueueProcessingNanos             *metric.Counter
+	ReplicateQueueSuccesses                   *metric.Counter
+	ReplicateQueueFailures                    *metric.Counter
+	ReplicateQueuePending                     *metric.Gauge
+	ReplicateQueueProcessingNanos             *metric.Counter
+	ReplicateQueuePurgatory                   *metric.Gauge
+	SplitQueueSuccesses                       *metric.Counter
+	SplitQueueFailures                        *metric.Counter
+	SplitQueuePending                         *metric.Gauge
+	SplitQueueProcessingNanos                 *metric.Counter
+	TimeSeriesMaintenanceQueueSuccesses       *metric.Counter
+	TimeSeriesMaintenanceQueueFailures        *metric.Counter
+	TimeSeriesMaintenanceQueuePending         *metric.Gauge
+	TimeSeriesMaintenanceQueueProcessingNanos *metric.Counter
 
 	// GCInfo cumulative totals.
 	GCNumKeysAffected            *metric.Counter
@@ -492,31 +505,35 @@ func newStoreMetrics(sampleInterval time.Duration) *StoreMetrics {
 		RaftEnqueuedPending: metric.NewGauge(metaRaftEnqueuedPending),
 
 		// Replica queue metrics.
-		GCQueueSuccesses:                metric.NewCounter(metaGCQueueSuccesses),
-		GCQueueFailures:                 metric.NewCounter(metaGCQueueFailures),
-		GCQueuePending:                  metric.NewGauge(metaGCQueuePending),
-		GCQueueProcessingNanos:          metric.NewCounter(metaGCQueueProcessingNanos),
-		RaftLogQueueSuccesses:           metric.NewCounter(metaRaftLogQueueSuccesses),
-		RaftLogQueueFailures:            metric.NewCounter(metaRaftLogQueueFailures),
-		RaftLogQueuePending:             metric.NewGauge(metaRaftLogQueuePending),
-		RaftLogQueueProcessingNanos:     metric.NewCounter(metaRaftLogQueueProcessingNanos),
-		ConsistencyQueueSuccesses:       metric.NewCounter(metaConsistencyQueueSuccesses),
-		ConsistencyQueueFailures:        metric.NewCounter(metaConsistencyQueueFailures),
-		ConsistencyQueuePending:         metric.NewGauge(metaConsistencyQueuePending),
-		ConsistencyQueueProcessingNanos: metric.NewCounter(metaConsistencyQueueProcessingNanos),
-		ReplicaGCQueueSuccesses:         metric.NewCounter(metaReplicaGCQueueSuccesses),
-		ReplicaGCQueueFailures:          metric.NewCounter(metaReplicaGCQueueFailures),
-		ReplicaGCQueuePending:           metric.NewGauge(metaReplicaGCQueuePending),
-		ReplicaGCQueueProcessingNanos:   metric.NewCounter(metaReplicaGCQueueProcessingNanos),
-		ReplicateQueueSuccesses:         metric.NewCounter(metaReplicateQueueSuccesses),
-		ReplicateQueueFailures:          metric.NewCounter(metaReplicateQueueFailures),
-		ReplicateQueuePending:           metric.NewGauge(metaReplicateQueuePending),
-		ReplicateQueueProcessingNanos:   metric.NewCounter(metaReplicateQueueProcessingNanos),
-		ReplicateQueuePurgatory:         metric.NewGauge(metaReplicateQueuePurgatory),
-		SplitQueueSuccesses:             metric.NewCounter(metaSplitQueueSuccesses),
-		SplitQueueFailures:              metric.NewCounter(metaSplitQueueFailures),
-		SplitQueuePending:               metric.NewGauge(metaSplitQueuePending),
-		SplitQueueProcessingNanos:       metric.NewCounter(metaSplitQueueProcessingNanos),
+		GCQueueSuccesses:                          metric.NewCounter(metaGCQueueSuccesses),
+		GCQueueFailures:                           metric.NewCounter(metaGCQueueFailures),
+		GCQueuePending:                            metric.NewGauge(metaGCQueuePending),
+		GCQueueProcessingNanos:                    metric.NewCounter(metaGCQueueProcessingNanos),
+		RaftLogQueueSuccesses:                     metric.NewCounter(metaRaftLogQueueSuccesses),
+		RaftLogQueueFailures:                      metric.NewCounter(metaRaftLogQueueFailures),
+		RaftLogQueuePending:                       metric.NewGauge(metaRaftLogQueuePending),
+		RaftLogQueueProcessingNanos:               metric.NewCounter(metaRaftLogQueueProcessingNanos),
+		ConsistencyQueueSuccesses:                 metric.NewCounter(metaConsistencyQueueSuccesses),
+		ConsistencyQueueFailures:                  metric.NewCounter(metaConsistencyQueueFailures),
+		ConsistencyQueuePending:                   metric.NewGauge(metaConsistencyQueuePending),
+		ConsistencyQueueProcessingNanos:           metric.NewCounter(metaConsistencyQueueProcessingNanos),
+		ReplicaGCQueueSuccesses:                   metric.NewCounter(metaReplicaGCQueueSuccesses),
+		ReplicaGCQueueFailures:                    metric.NewCounter(metaReplicaGCQueueFailures),
+		ReplicaGCQueuePending:                     metric.NewGauge(metaReplicaGCQueuePending),
+		ReplicaGCQueueProcessingNanos:             metric.NewCounter(metaReplicaGCQueueProcessingNanos),
+		ReplicateQueueSuccesses:                   metric.NewCounter(metaReplicateQueueSuccesses),
+		ReplicateQueueFailures:                    metric.NewCounter(metaReplicateQueueFailures),
+		ReplicateQueuePending:                     metric.NewGauge(metaReplicateQueuePending),
+		ReplicateQueueProcessingNanos:             metric.NewCounter(metaReplicateQueueProcessingNanos),
+		ReplicateQueuePurgatory:                   metric.NewGauge(metaReplicateQueuePurgatory),
+		SplitQueueSuccesses:                       metric.NewCounter(metaSplitQueueSuccesses),
+		SplitQueueFailures:                        metric.NewCounter(metaSplitQueueFailures),
+		SplitQueuePending:                         metric.NewGauge(metaSplitQueuePending),
+		SplitQueueProcessingNanos:                 metric.NewCounter(metaSplitQueueProcessingNanos),
+		TimeSeriesMaintenanceQueueSuccesses:       metric.NewCounter(metaTimeSeriesMaintenanceQueueFailures),
+		TimeSeriesMaintenanceQueueFailures:        metric.NewCounter(metaTimeSeriesMaintenanceQueueSuccesses),
+		TimeSeriesMaintenanceQueuePending:         metric.NewGauge(metaTimeSeriesMaintenanceQueuePending),
+		TimeSeriesMaintenanceQueueProcessingNanos: metric.NewCounter(metaTimeSeriesMaintenanceQueueProcessingNanos),
 
 		// GCInfo cumulative totals.
 		GCNumKeysAffected:            metric.NewCounter(metaGCNumKeysAffected),

--- a/pkg/storage/ts_maintenance_queue.go
+++ b/pkg/storage/ts_maintenance_queue.go
@@ -17,12 +17,21 @@
 package storage
 
 import (
+	"time"
+
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
+
+const (
+	timeSeriesMaintenanceQueueTimerDuration = time.Second
+	timeSeriesMaintenanceQueueMaxSize       = 100
 )
 
 // TimeSeriesDataStore is an interface defined in the storage package that can
@@ -32,6 +41,86 @@ import (
 type TimeSeriesDataStore interface {
 	ContainsTimeSeries(roachpb.RKey, roachpb.RKey) bool
 	PruneTimeSeries(
-		context.Context, engine.Engine, roachpb.RKey, roachpb.RKey, *client.DB, hlc.Timestamp,
+		context.Context, engine.Reader, roachpb.RKey, roachpb.RKey, *client.DB, hlc.Timestamp,
 	) error
+}
+
+// timeSeriesMaintenanceQueue identifies replicas that contain time series
+// data and performs necessary data maintenance on the time series located in
+// the replica. Currently, maintenance involves pruning time series data older
+// than a certain threshold.
+//
+// Logic for time series maintenance is implemented in a higher level time
+// series package; this queue uses the TimeSeriesDataStore interface to call
+// into that logic.
+//
+// Once a replica is selected for processing, data changes are executed against
+// the cluster using a KV client; changes are not restricted to the data in the
+// replica being processed. These tasks could therefore be performed without a
+// replica queue; however, a replica queue has been chosen to initiate this task
+// for a few reasons:
+// * The queue naturally distributes the workload across the cluster in
+// proportion to the number of ranges containing time series data.
+// * Access to the local replica is a convenient way to discover the names of
+// time series stored on the cluster; the names are required in order to
+// effectively prune time series without expensive distributed scans.
+//
+// Data changes executed by this queue are idempotent; it is explicitly safe
+// for multiple nodes to attempt to prune the same time series concurrently.
+// In this situation, each node would compute the same delete range based on
+// the current timestamp; the first will succeed, all others will become
+// a no-op.
+type timeSeriesMaintenanceQueue struct {
+	*baseQueue
+	tsData TimeSeriesDataStore
+	db     *client.DB
+}
+
+// newTimeSeriesMaintenanceQueue returns a new instance of
+// timeSeriesMaintenanceQueue.
+func newTimeSeriesMaintenanceQueue(
+	store *Store, db *client.DB, g *gossip.Gossip, tsData TimeSeriesDataStore,
+) *timeSeriesMaintenanceQueue {
+	tsmq := &timeSeriesMaintenanceQueue{
+		tsData: tsData,
+		db:     db,
+	}
+	tsmq.baseQueue = newBaseQueue(
+		store.Ctx(), "timeSeriesMaintenance", tsmq, store, g,
+		queueConfig{
+			maxSize:              timeSeriesMaintenanceQueueMaxSize,
+			needsLease:           true,
+			acceptsUnsplitRanges: true,
+			successes:            store.metrics.TimeSeriesMaintenanceQueueSuccesses,
+			failures:             store.metrics.TimeSeriesMaintenanceQueueFailures,
+			pending:              store.metrics.TimeSeriesMaintenanceQueuePending,
+			processingNanos:      store.metrics.TimeSeriesMaintenanceQueueProcessingNanos,
+		},
+	)
+
+	return tsmq
+}
+
+func (tsmq *timeSeriesMaintenanceQueue) shouldQueue(
+	_ hlc.Timestamp, repl *Replica, _ config.SystemConfig,
+) (shouldQ bool, priority float64) {
+	desc := repl.Desc()
+	return tsmq.tsData.ContainsTimeSeries(desc.StartKey, desc.EndKey), 0
+}
+
+func (tsmq *timeSeriesMaintenanceQueue) process(
+	ctx context.Context, now hlc.Timestamp, repl *Replica, sysCfg config.SystemConfig,
+) error {
+	desc := repl.Desc()
+	snap := repl.store.Engine().NewSnapshot()
+	defer snap.Close()
+	return tsmq.tsData.PruneTimeSeries(ctx, snap, desc.StartKey, desc.EndKey, tsmq.db, now)
+}
+
+func (tsmq *timeSeriesMaintenanceQueue) timer() time.Duration {
+	return timeSeriesMaintenanceQueueTimerDuration
+}
+
+func (tsmq *timeSeriesMaintenanceQueue) purgatoryChan() <-chan struct{} {
+	return nil
 }

--- a/pkg/storage/ts_maintenance_queue_test.go
+++ b/pkg/storage/ts_maintenance_queue_test.go
@@ -1,0 +1,245 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Matt Tracy (matt@cockroachlabs.com)
+
+package storage_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/ts"
+	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/kr/pretty"
+)
+
+type modelTimeSeriesDataStore struct {
+	syncutil.Mutex
+	t                  testing.TB
+	containsCalled     int
+	pruneCalled        int
+	pruneSeenStartKeys map[string]struct{}
+	pruneSeenEndKeys   map[string]struct{}
+}
+
+func (m *modelTimeSeriesDataStore) ContainsTimeSeries(start, end roachpb.RKey) bool {
+	if !start.Less(end) {
+		m.t.Fatalf("ContainsTimeSeries passed start key %v which is not less than end key %v", start, end)
+	}
+	m.Lock()
+	defer m.Unlock()
+	m.containsCalled++
+	return true
+}
+
+func (m *modelTimeSeriesDataStore) PruneTimeSeries(
+	ctx context.Context,
+	snapshot engine.Reader,
+	start, end roachpb.RKey,
+	db *client.DB,
+	now hlc.Timestamp,
+) error {
+	if snapshot == nil {
+		m.t.Fatal("PruneTimeSeries was passed a nil snapshot")
+	}
+	if db == nil {
+		m.t.Fatal("PruneTimeSeries was passed a nil client.DB")
+	}
+	if !start.Less(end) {
+		m.t.Fatalf("PruneTimeSeries passed start key %v which is not less than end key %v", start, end)
+	}
+
+	m.Lock()
+	defer m.Unlock()
+	m.pruneCalled++
+	m.pruneSeenStartKeys[start.String()] = struct{}{}
+	m.pruneSeenEndKeys[end.String()] = struct{}{}
+	return nil
+}
+
+// TestTimeSeriesMaintenanceQueue verifies shouldQueue and process method
+// pass the correct data to the store's TimeSeriesData
+func TestTimeSeriesMaintenanceQueue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	model := &modelTimeSeriesDataStore{
+		t:                  t,
+		pruneSeenStartKeys: make(map[string]struct{}),
+		pruneSeenEndKeys:   make(map[string]struct{}),
+	}
+
+	cfg := storage.TestStoreConfig()
+	cfg.TimeSeriesDataStore = model
+	cfg.TestingKnobs.DisableScanner = true
+	cfg.TestingKnobs.DisableSplitQueue = true
+
+	store, stopper, _ := createTestStoreWithConfig(t, cfg)
+	defer stopper.Stop()
+
+	// Generate several splits.
+	splitKeys := []roachpb.Key{roachpb.Key("c"), roachpb.Key("b"), roachpb.Key("a")}
+	for _, k := range splitKeys {
+		rng := store.LookupReplica(roachpb.RKey(k), nil)
+		args := adminSplitArgs(k, k)
+		if _, pErr := client.SendWrappedWith(store, nil, roachpb.Header{
+			RangeID: rng.RangeID,
+		}, &args); pErr != nil {
+			t.Fatal(pErr)
+		}
+	}
+
+	// Generate a list of start/end keys the model should have been passed by
+	// the queue. This consists of all split keys, with KeyMin as an additional
+	// start and KeyMax as an additional end.
+	expectedStartKeys := make(map[string]struct{})
+	expectedEndKeys := make(map[string]struct{})
+	expectedStartKeys[roachpb.KeyMin.String()] = struct{}{}
+	expectedEndKeys[roachpb.KeyMax.String()] = struct{}{}
+	for _, expected := range splitKeys {
+		expectedStartKeys[expected.String()] = struct{}{}
+		expectedEndKeys[expected.String()] = struct{}{}
+	}
+
+	// Wait for splits to complete and system config to be available.
+	util.SucceedsSoon(t, func() error {
+		if a, e := store.ReplicaCount(), len(expectedEndKeys); a != e {
+			return fmt.Errorf("expected %d replicas in store; found %d", a, e)
+		}
+		if _, ok := store.Gossip().GetSystemConfig(); !ok {
+			return fmt.Errorf("system config not yet available")
+		}
+		return nil
+	})
+
+	// Force replica scan to run, which will populate the model.
+	store.ForceTimeSeriesMaintenanceQueueProcess()
+
+	// Wait for processing to complete.
+	util.SucceedsSoon(t, func() error {
+		model.Lock()
+		defer model.Unlock()
+		if a, e := model.containsCalled, len(expectedStartKeys); a != e {
+			return fmt.Errorf("ContainsTimeSeries called %d times; expected %d", a, e)
+		}
+		if a, e := model.pruneCalled, len(expectedStartKeys); a != e {
+			return fmt.Errorf("PruneTimeSeries called %d times; expected %d", a, e)
+		}
+		return nil
+	})
+
+	model.Lock()
+	defer model.Unlock()
+	if a, e := model.pruneSeenStartKeys, expectedStartKeys; !reflect.DeepEqual(a, e) {
+		t.Errorf("start keys seen by PruneTimeSeries did not match expectation: %s", pretty.Diff(a, e))
+	}
+	if a, e := model.pruneSeenEndKeys, expectedEndKeys; !reflect.DeepEqual(a, e) {
+		t.Errorf("end keys seen by PruneTimeSeries did not match expectation: %s", pretty.Diff(a, e))
+	}
+}
+
+// TestTimeSeriesMaintenanceQueueServer verifies that the time series
+// maintenance queue runs correctly on a test server.
+func TestTimeSeriesMaintenanceQueueServer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop()
+	tsrv := s.(*server.TestServer)
+	tsdb := tsrv.TsDB()
+
+	// Populate time series data into the server. One time series, with one
+	// datapoint at the current time and one datapoint older than the pruning
+	// threshold. Datapoint timestamps are set to the midpoint of sample duration
+	// periods; this simplifies verification.
+	seriesName := "test.metric"
+	now := tsrv.Clock().PhysicalNow()
+	pastThreshold := now - (ts.Resolution10s.PruneThreshold() * 2)
+	sampleDuration := ts.Resolution10s.SampleDuration()
+	datapoints := []tspb.TimeSeriesDatapoint{
+		{
+			TimestampNanos: pastThreshold - pastThreshold%sampleDuration + sampleDuration/2,
+			Value:          200.0,
+		},
+		{
+			TimestampNanos: now - now%sampleDuration + sampleDuration/2,
+			Value:          100.0,
+		},
+	}
+	if err := tsdb.StoreData(context.TODO(), ts.Resolution10s, []tspb.TimeSeriesData{
+		{
+			Name:       seriesName,
+			Source:     "source1",
+			Datapoints: datapoints,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// getDatapoints queries all datapoints in the series from the beginning
+	// of time to a point in the near future.
+	getDatapoints := func() ([]tspb.TimeSeriesDatapoint, error) {
+		dps, _, err := tsdb.Query(
+			context.TODO(),
+			tspb.Query{Name: seriesName},
+			ts.Resolution10s,
+			ts.Resolution10s.SampleDuration(),
+			0,
+			now+ts.Resolution10s.SlabDuration(),
+		)
+		return dps, err
+	}
+
+	// Verify the datapoints are all present.
+	actualDatapoints, err := getDatapoints()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a, e := actualDatapoints, datapoints; !reflect.DeepEqual(a, e) {
+		t.Fatalf("got datapoints %v, expected %v, diff: %s", a, e, pretty.Diff(a, e))
+	}
+
+	// Force pruning.
+	storeID := roachpb.StoreID(1)
+	store, err := tsrv.Stores().GetStore(roachpb.StoreID(1))
+	if err != nil {
+		t.Fatalf("error retrieving store %d: %s", storeID, err)
+	}
+	store.ForceTimeSeriesMaintenanceQueueProcess()
+
+	// Verify the older datapoint has been pruned.
+	util.SucceedsSoon(t, func() error {
+		actualDatapoints, err = getDatapoints()
+		if err != nil {
+			return err
+		}
+		if a, e := actualDatapoints, datapoints[1:]; !reflect.DeepEqual(a, e) {
+			return fmt.Errorf("got datapoints %v, expected %v, diff: %s", a, e, pretty.Diff(a, e))
+		}
+		return nil
+	})
+}

--- a/pkg/ts/pruning_test.go
+++ b/pkg/ts/pruning_test.go
@@ -200,7 +200,9 @@ func TestFindTimeSeries(t *testing.T) {
 			},
 		},
 	} {
-		actual, err := findTimeSeries(e, tcase.start, tcase.end)
+		snap := e.NewSnapshot()
+		actual, err := findTimeSeries(snap, tcase.start, tcase.end)
+		snap.Close()
 		if err != nil {
 			t.Fatalf("case %d: unexpected error %q", i, err)
 		}

--- a/pkg/ts/resolution.go
+++ b/pkg/ts/resolution.go
@@ -86,7 +86,18 @@ func (r Resolution) SampleDuration() int64 {
 func (r Resolution) SlabDuration() int64 {
 	duration, ok := slabDurationByResolution[r]
 	if !ok {
-		panic(fmt.Sprintf("no key duration found for resolution value %v", r))
+		panic(fmt.Sprintf("no slab duration found for resolution value %v", r))
 	}
 	return duration
+}
+
+// PruneThreshold returns the pruning threshold duration for this resolution,
+// expressed in nanoseconds. This duration determines how old time series data
+// must be before it is eligible for pruning.
+func (r Resolution) PruneThreshold() int64 {
+	threshold, ok := pruneThresholdByResolution[r]
+	if !ok {
+		panic(fmt.Sprintf("no prune threshold found for resolution value %v", r))
+	}
+	return threshold
 }


### PR DESCRIPTION
Adds a new storage queue, the "Time Series Maintenance Queue", which
periodically initiates the pruning of time series data. This queue primarily
utilizes the previously developed pruning utilities in the time series package.

Commit includes two tests that verify that the queue works correctly; one test
that verifies that the queue passes the correct information to the time series
pruning functions, and another that starts a test server and directly verifies
that time series data is pruned by the queue.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9959)

<!-- Reviewable:end -->
