### PR TITLE
sql: don't try to rollback the kv txn when in state CommitWait

### DIFF
--- a/pkg/sql/session_test.go
+++ b/pkg/sql/session_test.go
@@ -1,0 +1,177 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Andrei Matei (andreimatei1@gmail.com)
+
+package sql_test
+
+import (
+	"database/sql/driver"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/lib/pq"
+)
+
+// Test that a connection closed abruptly while a SQL txn is in progress results
+// in that txn being rolled back.
+func TestSessionFinishRollsBackTxn(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	aborter := NewTxnAborter()
+	defer aborter.Close(t)
+	params, _ := createTestServerParams()
+	params.Knobs.SQLExecutor = aborter.executorKnobs()
+	s, mainDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop()
+	{
+		pgURL, cleanup := sqlutils.PGUrl(
+			t, s.ServingAddr(), security.RootUser, "TestSessionFinishRollsBackTxn")
+		defer cleanup()
+		if err := aborter.Init(pgURL); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := mainDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	// We're going to test the rollback of transactions left in various states
+	// when the connection closes abruptly.
+	// For the state CommitWait, there's no actual rollback we can test for (since
+	// the kv-level transaction has already been committed). But we still
+	// exercise this state to check that the server doesn't crash (which used to
+	// happen - #9879).
+	tests := []sql.TxnStateEnum{sql.Open, sql.RestartWait, sql.CommitWait}
+	for _, state := range tests {
+		t.Run(state.String(), func(t *testing.T) {
+			// Create a low-level lib/pq connection so we can close it at will.
+			pgURL, cleanupDB := sqlutils.PGUrl(
+				t, s.ServingAddr(), security.RootUser, state.String())
+			defer cleanupDB()
+			conn, err := pq.Open(pgURL.String())
+			if err != nil {
+				t.Fatal(err)
+			}
+			connClosed := false
+			defer func() {
+				if connClosed {
+					return
+				}
+				if err := conn.Close(); err != nil {
+					t.Fatal(err)
+				}
+			}()
+
+			txn, err := conn.Begin()
+			if err != nil {
+				t.Fatal(err)
+			}
+			tx := txn.(driver.Execer)
+			if _, err := tx.Exec("SET TRANSACTION PRIORITY NORMAL", nil); err != nil {
+				t.Fatal(err)
+			}
+
+			if state == sql.RestartWait || state == sql.CommitWait {
+				if _, err := tx.Exec("SAVEPOINT cockroach_restart", nil); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			insertStmt := "INSERT INTO t.test(k, v) VALUES (1, 'a')"
+			if state == sql.RestartWait {
+				// To get a txn in RestartWait, we'll use an aborter.
+				if err := aborter.QueueStmtForAbortion(
+					insertStmt, 1 /* restartCount */, false /* willBeRetriedIbid */); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if _, err := tx.Exec(insertStmt, nil); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := aborter.VerifyAndClear(); err != nil {
+				t.Fatal(err)
+			}
+
+			if state == sql.RestartWait || state == sql.CommitWait {
+				_, err := tx.Exec("RELEASE SAVEPOINT cockroach_restart", nil)
+				if state == sql.CommitWait {
+					if err != nil {
+						t.Fatal(err)
+					}
+				} else if !testutils.IsError(err, "pq: restart transaction:.*") {
+					t.Fatal(err)
+				}
+			}
+
+			// Abruptly close the connection.
+			connClosed = true
+			if err := conn.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			// Check that the txn we had above was rolled back. We do this by reading
+			// after the preceding txn and checking that we don't get an error and
+			// that we haven't been blocked by intents (we can't exactly test that we
+			// haven't been blocked but we assert that the query didn't take too
+			// long).
+			// We do the read in an explicit txn so that automatic retries don't hide
+			// any errors.
+			// TODO(andrei): Figure out a better way to test for non-blocking.
+			// Use a trace when the client-side tracing story gets good enough.
+			txCheck, err := mainDB.Begin()
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Run check at low priority so we don't push the previous transaction and
+			// fool ourselves into thinking it had been rolled back.
+			if _, err := txCheck.Exec("SET TRANSACTION PRIORITY LOW"); err != nil {
+				t.Fatal(err)
+			}
+			ts := timeutil.Now()
+			var count int
+			if err := txCheck.QueryRow("SELECT COUNT(1) FROM t.test").Scan(&count); err != nil {
+				t.Fatal(err)
+			}
+			// CommitWait actually committed, so we'll need to clean up.
+			if state != sql.CommitWait {
+				if count != 0 {
+					t.Fatalf("expected no rows, got: %d", count)
+				}
+			} else {
+				if _, err := txCheck.Exec("DELETE FROM t.test"); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := txCheck.Commit(); err != nil {
+				t.Fatal(err)
+			}
+			if d := timeutil.Since(ts); d > time.Second {
+				t.Fatalf("Looks like the checking tx was unexpectedly blocked. "+
+					"It took %s to commit.", d)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
When the SQL txn is in state CommitWait and the session is abruptly
terminated, we don't have a KV txn to rollback. This was leading to a
crash.

fixes #9879

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9961)

<!-- Reviewable:end -->
