### PR TITLE
storage: include replicaID in replica log tag

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -373,7 +373,7 @@ func TestReplicaContains(t *testing.T) {
 	r := &Replica{}
 	r.mu.TimedMutex = syncutil.MakeTimedMutex(defaultMuLogger)
 	r.mu.state.Desc = desc
-	r.rangeStr.store(desc)
+	r.rangeStr.store(0, desc)
 
 	if statsKey := keys.RangeStatsKey(desc.RangeID); !r.ContainsKey(statsKey) {
 		t.Errorf("expected range to contain range stats key %q", statsKey)


### PR DESCRIPTION
Log tag format is now r`rangeID/replicaID:{keyStart-keyEnd}`.

Example:

```
I161013 16:38:42.810964 23890 storage/replica_command.go:2354  [s1,r4/1:/{Table/13-Max}] initiating a split of this range at key /Table/14 [r5]
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9967)

<!-- Reviewable:end -->
