### PR TITLE
storage: persist fully nontrival ReplicaState

### DIFF
--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -2642,44 +2642,6 @@ func (r *Replica) splitTrigger(
 	}
 	log.Eventf(ctx, "copied abort cache (%d entries)", seqCount)
 
-	// Initialize the right-hand lease to be the same as the left-hand lease.
-	// This looks like an innocuous performance improvement, but it's more than
-	// that - it ensures that we properly initialize the timestamp cache, which
-	// is only populated on the lease holder, from that of the original Range.
-	// We found out about a regression here the hard way in #7899. Prior to
-	// this block, the following could happen:
-	// - a client reads key 'd', leaving an entry in the timestamp cache on the
-	//   lease holder of [a,e) at the time, node one.
-	// - the range [a,e) splits at key 'c'. [c,e) starts out without a lease.
-	// - the replicas of [a,e) on nodes one and two both process the split
-	//   trigger and thus copy their timestamp caches to the new right-hand side
-	//   Replica. However, only node one's timestamp cache contains information
-	//   about the read of key 'd' in the first place.
-	// - node two becomes the lease holder for [c,e). Its timestamp cache does
-	//   know about the read at 'd' which happened at the beginning.
-	// - node two can illegally propose a write to 'd' at a lower timestamp.
-	{
-		leftLease, err := loadLease(ctx, r.store.Engine(), r.RangeID)
-		if err != nil {
-			return enginepb.MVCCStats{}, ProposalData{}, errors.Wrap(err, "unable to load lease")
-		}
-
-		replica, found := split.RightDesc.GetReplicaDescriptor(leftLease.Replica.StoreID)
-		if !found {
-			return enginepb.MVCCStats{}, ProposalData{}, errors.Errorf(
-				"pre-split lease holder %+v not found in post-split descriptor %+v",
-				leftLease.Replica, split.RightDesc,
-			)
-		}
-		rightLease := leftLease
-		rightLease.Replica = replica
-		if err := setLease(
-			ctx, batch, &bothDeltaMS, split.RightDesc.RangeID, rightLease,
-		); err != nil {
-			return enginepb.MVCCStats{}, ProposalData{}, errors.Wrap(err, "unable to seed right-hand side lease")
-		}
-	}
-
 	// Compute (absolute) stats for RHS range.
 	var rightMS enginepb.MVCCStats
 	if origBothMS.ContainsEstimates || bothDeltaMS.ContainsEstimates {
@@ -2754,7 +2716,46 @@ func (r *Replica) splitTrigger(
 		if err != nil {
 			return enginepb.MVCCStats{}, ProposalData{}, errors.Wrap(err, "unable to load hard state")
 		}
-		rightMS, err = writeInitialState(ctx, batch, rightMS, split.RightDesc, oldHS)
+		// Initialize the right-hand lease to be the same as the left-hand lease.
+		// This looks like an innocuous performance improvement, but it's more than
+		// that - it ensures that we properly initialize the timestamp cache, which
+		// is only populated on the lease holder, from that of the original Range.
+		// We found out about a regression here the hard way in #7899. Prior to
+		// this block, the following could happen:
+		// - a client reads key 'd', leaving an entry in the timestamp cache on the
+		//   lease holder of [a,e) at the time, node one.
+		// - the range [a,e) splits at key 'c'. [c,e) starts out without a lease.
+		// - the replicas of [a,e) on nodes one and two both process the split
+		//   trigger and thus copy their timestamp caches to the new right-hand side
+		//   Replica. However, only node one's timestamp cache contains information
+		//   about the read of key 'd' in the first place.
+		// - node two becomes the lease holder for [c,e). Its timestamp cache does
+		//   not know about the read at 'd' which happened at the beginning.
+		// - node two can illegally propose a write to 'd' at a lower timestamp.
+		//
+		// TODO(tschottdorf): why would this use r.store.Engine() and not the
+		// batch?
+		leftLease, err := loadLease(ctx, r.store.Engine(), r.RangeID)
+		if err != nil {
+			return enginepb.MVCCStats{}, ProposalData{}, errors.Wrap(err, "unable to load lease")
+		}
+		if (leftLease == nil || *leftLease == roachpb.Lease{}) {
+			log.Fatalf(ctx, "LHS of split has no lease")
+		}
+
+		replica, found := split.RightDesc.GetReplicaDescriptor(leftLease.Replica.StoreID)
+		if !found {
+			return enginepb.MVCCStats{}, ProposalData{}, errors.Errorf(
+				"pre-split lease holder %+v not found in post-split descriptor %+v",
+				leftLease.Replica, split.RightDesc,
+			)
+		}
+		rightLease := leftLease
+		rightLease.Replica = replica
+
+		rightMS, err = writeInitialState(
+			ctx, batch, rightMS, split.RightDesc, oldHS, rightLease,
+		)
 		if err != nil {
 			return enginepb.MVCCStats{}, ProposalData{}, errors.Wrap(err, "unable to write initial state")
 		}

--- a/pkg/storage/replica_data_iter_test.go
+++ b/pkg/storage/replica_data_iter_test.go
@@ -74,6 +74,7 @@ func createRangeData(t *testing.T, r *Replica) []engine.MVCCKey {
 		{keys.RangeLastGCKey(r.RangeID), ts0},
 		{keys.RaftAppliedIndexKey(r.RangeID), ts0},
 		{keys.RaftTruncatedStateKey(r.RangeID), ts0},
+		{keys.RangeLeaseKey(r.RangeID), ts0},
 		{keys.LeaseAppliedIndexKey(r.RangeID), ts0},
 		{keys.RangeStatsKey(r.RangeID), ts0},
 		{keys.RangeTxnSpanGCThresholdKey(r.RangeID), ts0},

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -209,6 +209,7 @@ func (tc *testContext) StartWithStoreConfig(t testing.TB, cfg StoreConfig) {
 				enginepb.MVCCStats{},
 				*testDesc,
 				raftpb.HardState{},
+				&roachpb.Lease{},
 			); err != nil {
 				t.Fatal(err)
 			}
@@ -4277,10 +4278,10 @@ func TestReplicaStatsComputation(t *testing.T) {
 	defer tc.Stop()
 
 	baseStats := initialStats()
-	// Add in the contribution for the range lease request.
+	// The initial stats contain an empty lease, but there will be an initial
+	// nontrivial lease requested with the first write below.
 	baseStats.Add(enginepb.MVCCStats{
-		SysCount: 1,
-		SysBytes: 62,
+		SysBytes: 8,
 	})
 
 	// Put a value.

--- a/pkg/storage/stats_test.go
+++ b/pkg/storage/stats_test.go
@@ -32,8 +32,8 @@ import (
 // writeInitialState().
 func initialStats() enginepb.MVCCStats {
 	return enginepb.MVCCStats{
-		SysBytes: 183,
-		SysCount: 6,
+		SysBytes: 237,
+		SysCount: 7,
 	}
 }
 func TestRangeStatsEmpty(t *testing.T) {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1483,7 +1483,7 @@ func (s *Store) BootstrapRange(initialValues []roachpb.KeyValue) error {
 		return err
 	}
 
-	updatedMS, err := writeInitialState(ctx, batch, *ms, *desc, raftpb.HardState{})
+	updatedMS, err := writeInitialState(ctx, batch, *ms, *desc, raftpb.HardState{}, &roachpb.Lease{})
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -145,6 +145,13 @@ func createTestStoreWithoutStart(
 	stopper := stop.NewStopper()
 	// Setup fake zone config handler.
 	config.TestingSetupZoneConfigHook(stopper)
+
+	defer func() {
+		if t.Failed() {
+			stopper.Stop()
+		}
+	}()
+
 	rpcContext := rpc.NewContext(context.TODO(), &base.Config{Insecure: true}, nil, stopper)
 	server := rpc.NewServer(rpcContext) // never started
 	cfg.Gossip = gossip.New(context.TODO(), rpcContext, server, nil, stopper, metric.NewRegistry())
@@ -1033,8 +1040,10 @@ func splitTestRange(store *Store, key, splitKey roachpb.RKey, t *testing.T) *Rep
 	}
 	// Minimal amount of work to keep this deprecated machinery working: Write
 	// some required Raft keys.
-	if _, err := writeInitialState(context.Background(), store.engine,
-		enginepb.MVCCStats{}, *desc, raftpb.HardState{}); err != nil {
+	if _, err := writeInitialState(
+		context.Background(), store.engine, enginepb.MVCCStats{}, *desc,
+		raftpb.HardState{}, &roachpb.Lease{},
+	); err != nil {
 		t.Fatal(err)
 	}
 	newRng, err := NewReplica(desc, store, 0)
@@ -2390,8 +2399,10 @@ func TestStoreRemovePlaceholderOnRaftIgnored(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := writeInitialState(ctx, s.Engine(),
-		enginepb.MVCCStats{}, *rng1.Desc(), raftpb.HardState{}); err != nil {
+	if _, err := writeInitialState(
+		ctx, s.Engine(), enginepb.MVCCStats{}, *rng1.Desc(),
+		raftpb.HardState{}, &roachpb.Lease{},
+	); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Previously, there was some ambiguity about what parts of a Range were
actually written. For example, a nil lease and a zero-value lease were
both allowed and treated equally (in fact, Lease was the only field lacking
the treatment).

Proposer-evaluated KV will use the same container, ReplicaState, to transmit
changes to the state. This makes it worthwhile to be somewhat stricter here.
For example, FrozenStatus is now an enum whose zero value we never want to see
persisted to disk, and consequently we don't ever want to synthesize it from
disk. We don't (or at least shouldn't), but now we assert similarly for all
fields.

There are mild migration concerns here for clusters which are running with
#9883, but that PR will not be part of a release until 2016-10-20.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9970)

<!-- Reviewable:end -->
