### PR TITLE
Makefile: support selecting style tests with env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,11 @@ STATIC :=
 PKG          := ./pkg/...
 TAGS         :=
 TESTS        := .
+# STYLE_TESTS can be set in the environment to restrict the tests run
+# during `make check`. For example, to skip the slower TestGoImports
+# subtest, use:
+#   export STYLE_TESTS='Test([^G]|.[^o]|..[^i]|...[^m])'
+STYLE_TESTS  ?= $(TESTS)
 TESTTIMEOUT  := 2m
 RACETIMEOUT  := 10m
 BENCHTIMEOUT := 5m
@@ -163,7 +168,7 @@ dupl:
 .PHONY: check
 check: TAGS += check
 check:
-	$(GO) test ./build -v -tags '$(TAGS)' -run 'TestStyle/$(TESTS)'
+	$(GO) test ./build -v -tags '$(TAGS)' -run 'TestStyle/$(STYLE_TESTS)'
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
To skip TestGoimports, you can now add this to your env:

``` bash
  export STYLE_TESTS='Test([^G]|.[^o]|..[^i]|...[^m])'
```

The existing support for `make check TESTS=xx` continues to work if you don't
have the var set. You can override it using `make check STYLE_TESTS=xx` (which
unlike the existing command should work for `make` as well).

I will send out a PSA when this goes in.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9974)

<!-- Reviewable:end -->
