### PR TITLE
pkg: fix escaping of pass through flags

### DIFF
--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -exuo pipefail
 build/builder.sh make check 2>&1 | go-test-teamcity
+build/builder.sh make gotestdashi 2>&1
 build/builder.sh go generate ./... 2>&1
 build/builder.sh /bin/bash -c '! git status --porcelain | read || (git status; git diff -a; exit 1)' 2>&1
 

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -12,6 +12,5 @@ DIRS=$(filter-out Makefile,$(wildcard *))
 
 .PHONY: $(DIRS)
 .DEFAULT $(DIRS):
-	@make -C .. $(MAKECMDGOALS) \
-	  $(patsubst PKG=%,PKG=./pkg/%,$(filter PKG=%,$(MAKEFLAGS))) \
-	  $(filter-out PKG=%,$(MAKEFLAGS))
+	@$(MAKE) -C .. $(MAKECMDGOALS) \
+	  $(patsubst PKG=%,PKG=./pkg/%,$(filter PKG=%,$(MAKEFLAGS)))


### PR DESCRIPTION
There was no reason to pass MAKEFLAGS explicitly as the MAKEFLAGS
variable is implicitly used to pass through options to recursive
invocations of make. Passing MAKEFLAGS explicitly also ruined escaping
of any argument containing spaces or special shell
characters (e.g. `|`).

Fixes #9977

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9978)

<!-- Reviewable:end -->
