### PR TITLE
[DO NOT MERGE] server: attach tracer to the timeseries context

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -533,8 +533,8 @@ func (s *Server) Start(ctx context.Context) error {
 
 	// Begin recording time series data collected by the status monitor.
 	s.tsDB.PollSource(
-		s.AnnotateCtx(context.Background()), s.recorder,
-		s.cfg.MetricsSampleInterval, ts.Resolution10s, s.stopper,
+		tracing.WithTracer(s.AnnotateCtx(context.Background()), s.cfg.AmbientCtx.Tracer),
+		s.recorder, s.cfg.MetricsSampleInterval, ts.Resolution10s, s.stopper,
 	)
 
 	// Begin recording status summaries.


### PR DESCRIPTION
I doubt this is the correct way to do this, but something seems off
here. Perhaps Server.AnnotateCtx should attach the tracer.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9984)

<!-- Reviewable:end -->
