### PR TITLE
storage: deflake TestRangeQuiescence (again)

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2648,10 +2648,8 @@ func TestRangeQuiescence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	sc := storage.TestStoreConfig()
-	sc.RaftTickInterval = 10 * time.Millisecond
-	sc.RaftHeartbeatIntervalTicks = 2
-	sc.RaftElectionTimeoutTicks = 10
 	sc.TestingKnobs.DisableScanner = true
+	sc.TestingKnobs.DisablePeriodicGossips = true
 	mtc := multiTestContext{storeConfig: &sc}
 	mtc.Start(t, 3)
 	defer mtc.Stop()


### PR DESCRIPTION
The previous Raft tick and election timeout settings were too low and
would cause spurious elections preventing quiescence when running
`stressrace`. Now we use the default settings which quadruples the time
of the test from 200ms to 800ms, but remove the flakiness.

Fixes #9471

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9986)

<!-- Reviewable:end -->
