### PR TITLE
style: remove GoImports test

### DIFF
--- a/build/style_test.go
+++ b/build/style_test.go
@@ -400,30 +400,6 @@ func TestStyle(t *testing.T) {
 		}
 	})
 
-	t.Run("TestGoimports", func(t *testing.T) {
-		t.Parallel()
-		cmd, stderr, filter, err := dirCmd(pkg.Dir, "goimports", "-l", ".")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if err := cmd.Start(); err != nil {
-			t.Fatal(err)
-		}
-
-		if err := stream.ForEach(filter, func(s string) {
-			t.Error(s)
-		}); err != nil {
-			t.Error(err)
-		}
-
-		if err := cmd.Wait(); err != nil {
-			if out := stderr.String(); len(out) > 0 {
-				t.Fatalf("err=%s, stderr=%s", err, out)
-			}
-		}
-	})
-
 	t.Run("TestCrlfmt", func(t *testing.T) {
 		t.Parallel()
 		cmd, stderr, filter, err := dirCmd(pkg.Dir, "crlfmt", "-ignore", `\.pb(\.gw)?\.go`, "-tab", "2", ".")


### PR DESCRIPTION
The GoImports test is slow and doesn't bring much to the table, given that we
run `gofmt` and the compiler should complain about incorrect imports.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9989)

<!-- Reviewable:end -->
