### PR TITLE
storage: optimize handling of applied index MVCC stats

### DIFF
--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -906,7 +906,9 @@ func MVCCPut(
 // MVCCBlindPut is a fast-path of MVCCPut. See the MVCCPut comments for details
 // of the semantics. MVCCBlindPut skips retrieving the existing metadata for
 // the key requiring the caller to guarantee no versions for the key currently
-// exist.
+// exist in order for stats to be updated properly. If a previous version of
+// the key does exist it is up to the caller to properly account for their
+// existence in updating the stats.
 func MVCCBlindPut(
 	ctx context.Context,
 	engine Writer,


### PR DESCRIPTION
RaftAppliedIndexKey and LeaseAppliedIndexKey are overwritten on every write
operation, but the MVCC stats for these keys is inconsequential. Rather
than using MVCCPut to write these keys, we now using MVCCBlindPut and
manually compute their stat contributions by remembering their previous
size. This gives a 5% boost to single-node block_writer performance.

Fixes #9306

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9993)

<!-- Reviewable:end -->
