### PR TITLE
kv: use args.Summary() in DistSender event

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -971,7 +971,7 @@ func (ds *DistSender) sendToReplicas(
 
 	// Send the first request.
 	pending := 1
-	log.VEventf(2, opts.ctx, "sending RPC for batch: %s", args)
+	log.VEventf(2, opts.ctx, "sending RPC for batch: %s", args.Summary())
 	transport.SendNext(done)
 
 	// Wait for completions. This loop will retry operations that fail


### PR DESCRIPTION
Not only does BatchRequest.Summary() display more concisely, it is quite
a bit faster than BatchRequest.String(), providing a 4% speed-up in
block_writer tests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/9998)

<!-- Reviewable:end -->
