### PR TITLE
sql: Persist DB names to view descriptors with new Format flag

### DIFF
--- a/pkg/sql/parser/format.go
+++ b/pkg/sql/parser/format.go
@@ -24,6 +24,10 @@ import (
 type fmtFlags struct {
 	showTypes        bool
 	showTableAliases bool
+	// tableNameNormalizer will be called on all NormalizableTableNames if it is
+	// non-nil. Its results will be used if they are non-nil, or ignored if they
+	// are nil.
+	tableNameNormalizer func(*NormalizableTableName) *TableName
 }
 
 // FmtFlags enables conditional formatting in the pretty-printer.
@@ -41,6 +45,12 @@ var FmtQualify FmtFlags = &fmtFlags{showTableAliases: true}
 // FmtShowTypes instructs the pretty-printer to
 // annotate expressions with their resolved types.
 var FmtShowTypes FmtFlags = &fmtFlags{showTypes: true}
+
+// FmtNormalizeTableNames returns FmtFlags that instructs the pretty-printer
+// to normalize all table names using the provided function.
+func FmtNormalizeTableNames(fn func(*NormalizableTableName) *TableName) FmtFlags {
+	return &fmtFlags{tableNameNormalizer: fn}
+}
 
 // NodeFormatter is implemented by nodes that can be pretty-printed.
 type NodeFormatter interface {

--- a/pkg/sql/parser/table_name.go
+++ b/pkg/sql/parser/table_name.go
@@ -38,7 +38,13 @@ type NormalizableTableName struct {
 
 // Format implements the NodeFormatter interface.
 func (nt NormalizableTableName) Format(buf *bytes.Buffer, f FmtFlags) {
-	nt.TableNameReference.Format(buf, f)
+	tnr := nt.TableNameReference
+	if f.tableNameNormalizer != nil {
+		if tn := f.tableNameNormalizer(&nt); tn != nil {
+			tnr = tn
+		}
+	}
+	tnr.Format(buf, f)
 }
 func (nt NormalizableTableName) String() string { return AsString(nt) }
 
@@ -105,7 +111,7 @@ type TableName struct {
 
 // Format implements the NodeFormatter interface.
 func (t *TableName) Format(buf *bytes.Buffer, f FmtFlags) {
-	if !t.dbNameOriginallyOmitted {
+	if !t.dbNameOriginallyOmitted || f.tableNameNormalizer != nil {
 		FormatNode(buf, f, t.DatabaseName)
 		buf.WriteByte('.')
 	}

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -187,15 +187,15 @@ func TestShowCreateView(t *testing.T) {
 	}
 
 	tests := []string{
-		`CREATE VIEW %s AS SELECT * FROM t`,
 		`CREATE VIEW %s AS SELECT * FROM d.t`,
-		`CREATE VIEW %s AS SELECT i, s, t FROM t`,
-		`CREATE VIEW %s AS SELECT t.i, t.s, t.t FROM t`,
-		`CREATE VIEW %s AS SELECT foo.i, foo.s, foo.t FROM t AS foo WHERE foo.i > 3`,
-		`CREATE VIEW %s AS SELECT COUNT(*) FROM t`,
-		`CREATE VIEW %s AS SELECT s, COUNT(*) FROM t GROUP BY s HAVING COUNT(*) > 3`,
-		`CREATE VIEW %s (a, b, c, d) AS SELECT * FROM t`,
-		`CREATE VIEW %s (a, b) AS SELECT i, v FROM t`,
+		`CREATE VIEW %s AS SELECT * FROM d.t`,
+		`CREATE VIEW %s AS SELECT i, s, t FROM d.t`,
+		`CREATE VIEW %s AS SELECT t.i, t.s, t.t FROM d.t`,
+		`CREATE VIEW %s AS SELECT foo.i, foo.s, foo.t FROM d.t AS foo WHERE foo.i > 3`,
+		`CREATE VIEW %s AS SELECT COUNT(*) FROM d.t`,
+		`CREATE VIEW %s AS SELECT s, COUNT(*) FROM d.t GROUP BY s HAVING COUNT(*) > 3`,
+		`CREATE VIEW %s (a, b, c, d) AS SELECT * FROM d.t`,
+		`CREATE VIEW %s (a, b) AS SELECT i, v FROM d.t`,
 	}
 	for i, test := range tests {
 		name := fmt.Sprintf("T%d", i)

--- a/pkg/sql/testdata/views
+++ b/pkg/sql/testdata/views
@@ -78,20 +78,69 @@ SELECT * FROM v1 AS v1 INNER JOIN v2 AS v2 ON v1.a = v2.x;
 2 98 2 98
 3 97 3 97
 
+statement ok
+CREATE DATABASE test2;
+
+statement ok
+SET DATABASE = test2;
+
+query II colnames
+SELECT * FROM test.v1;
+----
+a b
+1 99
+2 98
+3 97
+
+query II colnames
+SELECT * FROM test.v2;
+----
+x y
+1 99
+2 98
+3 97
+
+query II colnames
+SELECT * FROM test.v6;
+----
+x y
+1 99
+2 98
+3 97
+
+statement ok
+CREATE VIEW v1 AS SELECT * FROM test.v2;
+
+statement ok
+SET DATABASE = test;
+
+query II colnames
+SELECT * FROM test2.v1
+----
+x y
+1 99
+2 98
+3 97
+
 query TT
 SHOW CREATE VIEW v1;
 ----
-v1 CREATE VIEW v1 AS SELECT * FROM t
+v1 CREATE VIEW v1 AS SELECT * FROM test.t
 
 query TT
 SHOW CREATE VIEW v2;
 ----
-v2 CREATE VIEW v2 (x, y) AS SELECT * FROM t
+v2 CREATE VIEW v2 (x, y) AS SELECT * FROM test.t
 
 query TT
 SHOW CREATE VIEW v6;
 ----
-v6 CREATE VIEW v6 (x, y) AS SELECT * FROM v1
+v6 CREATE VIEW v6 (x, y) AS SELECT * FROM test.v1
+
+query TT
+SHOW CREATE VIEW test2.v1;
+----
+test2.v1 CREATE VIEW "test2.v1" AS SELECT * FROM test.v2
 
 statement error pgcode 42809 "v1" is not a table
 DROP TABLE v1;
@@ -101,6 +150,13 @@ DROP VIEW t;
 
 statement error view "v6" depends on view "v1"
 DROP VIEW v1;
+
+# TODO(a-robinson): Need to improve this error message once #9988 is in.
+statement error view "v1" depends on view "v2"
+DROP VIEW v2;
+
+statement ok
+DROP VIEW test2.v1;
 
 statement ok
 DROP VIEW v6;


### PR DESCRIPTION
We don't have to go this way, but as explained in the comment thread on https://github.com/cockroachdb/cockroach/issues/9921#issuecomment-254009800, this was enough easier than trying to adapt Walk that I thought it was worth putting together as a proof of concept, at the very least.

@knz

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10009)

<!-- Reviewable:end -->
