### PR TITLE
sql: Fix bug preventing renaming of primary key columns

### DIFF
--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1232,6 +1232,7 @@ func (desc *TableDescriptor) RenameColumnNormalized(colID ColumnID, newColName s
 			}
 		}
 	}
+	renameColumnInIndex(&desc.PrimaryIndex)
 	for i := range desc.Indexes {
 		renameColumnInIndex(&desc.Indexes[i])
 	}

--- a/pkg/sql/testdata/rename_column
+++ b/pkg/sql/testdata/rename_column
@@ -1,10 +1,10 @@
 statement ok
 CREATE TABLE users (
-  id    INT PRIMARY KEY,
+  uid    INT PRIMARY KEY,
   name  VARCHAR NOT NULL,
   title VARCHAR,
   INDEX foo (name),
-  UNIQUE INDEX bar (id, name)
+  UNIQUE INDEX bar (uid, name)
 )
 
 statement ok
@@ -13,7 +13,7 @@ INSERT INTO users VALUES (1, 'tom', 'cat'),(2, 'jerry', 'rat')
 query ITT colnames
 SELECT * FROM users
 ----
-id name  title
+uid name  title
 1  tom   cat
 2  jerry rat
 
@@ -31,6 +31,9 @@ ALTER TABLE uses RENAME COLUMN title TO species
 
 statement ok
 ALTER TABLE IF EXISTS uses RENAME COLUMN title TO species
+
+statement ok
+ALTER TABLE users RENAME COLUMN uid TO id
 
 statement ok
 ALTER TABLE users RENAME COLUMN title TO species


### PR DESCRIPTION
It looks like this has been broken since RENAME COLUMN was first introduced back in #2158.

It's possible that this should just be replaced by desc.AllNonDropIndexes(), but I'm not confident whether the behavior difference in the handling of Mutations between that and the current code is significant. Thoughts?

Fixes #9987

@paperstreet because he was unfortunate enough to be the last person to move this code around

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10018)

<!-- Reviewable:end -->
