### PR TITLE
sql: tag log messages issued from the internal executor.

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -523,7 +523,7 @@ func (sc *SchemaChanger) backfillIndexesChunk(
 		// many transactions is fine because the schema change is in the
 		// correct state to handle intermediate OLTP commands which delete
 		// and add values during the scan.
-		planner := makePlanner()
+		planner := makePlanner("backfill")
 		planner.setTxn(txn)
 		scan := planner.Scan()
 		scan.desc = *tableDesc

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -116,7 +116,7 @@ VALUES(
 		args[4] = string(infoBytes)
 	}
 
-	rows, err := ev.ExecuteStatementInTransaction(txn, insertEventTableStmt, args...)
+	rows, err := ev.ExecuteStatementInTransaction("log-event", txn, insertEventTableStmt, args...)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/group_test.go
+++ b/pkg/sql/group_test.go
@@ -46,7 +46,7 @@ func TestDesiredAggregateOrder(t *testing.T) {
 		{`(COUNT(a), MIN(a))`, nil},
 		{`(MIN(a+1))`, nil},
 	}
-	p := makePlanner()
+	p := makePlanner("test")
 	for _, d := range testData {
 		sel := makeSelectNode(t)
 		expr := parseAndNormalizeExpr(t, d.expr, sel)

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -39,9 +39,9 @@ var _ sqlutil.InternalExecutor = InternalExecutor{}
 // ExecuteStatementInTransaction executes the supplied SQL statement as part of
 // the supplied transaction. Statements are currently executed as the root user.
 func (ie InternalExecutor) ExecuteStatementInTransaction(
-	txn *client.Txn, statement string, qargs ...interface{},
+	opName string, txn *client.Txn, statement string, qargs ...interface{},
 ) (int, error) {
-	p := makeInternalPlanner(txn, security.RootUser)
+	p := makeInternalPlanner(opName, txn, security.RootUser)
 	p.leaseMgr = ie.LeaseManager
 	return p.exec(statement, qargs...)
 }
@@ -51,7 +51,7 @@ func (ie InternalExecutor) GetTableSpan(
 	user string, txn *client.Txn, dbName, tableName string,
 ) (roachpb.Span, error) {
 	// Lookup the table ID.
-	p := makeInternalPlanner(txn, user)
+	p := makeInternalPlanner("get-table-span", txn, user)
 	p.leaseMgr = ie.LeaseManager
 
 	tn := parser.TableName{DatabaseName: parser.Name(dbName), TableName: parser.Name(tableName)}

--- a/pkg/sql/select_name_resolution_test.go
+++ b/pkg/sql/select_name_resolution_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func testInitDummySelectNode(desc *sqlbase.TableDescriptor) *selectNode {
-	p := makePlanner()
+	p := makePlanner("test")
 	scan := &scanNode{p: p}
 	scan.desc = *desc
 	scan.initDescDefaults(publicColumns)

--- a/pkg/sql/sqlutil/internal_executor.go
+++ b/pkg/sql/sqlutil/internal_executor.go
@@ -26,5 +26,5 @@ type InternalExecutor interface {
 	// ExecuteStatementInTransaction executes the supplied SQL statement as part of
 	// the supplied transaction. Statements are currently executed as the root user.
 	ExecuteStatementInTransaction(
-		txn *client.Txn, statement string, params ...interface{}) (int, error)
+		opName string, txn *client.Txn, statement string, params ...interface{}) (int, error)
 }

--- a/pkg/sql/values_test.go
+++ b/pkg/sql/values_test.go
@@ -36,7 +36,7 @@ import (
 func TestValues(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	p := makePlanner()
+	p := makePlanner("test")
 	p.session.mon.StartMonitor()
 	defer p.session.mon.StopMonitor(context.Background())
 

--- a/pkg/storage/log.go
+++ b/pkg/storage/log.go
@@ -105,7 +105,7 @@ VALUES(
 		s.metrics.RangeRemoves.Inc(1)
 	}
 
-	rows, err := s.cfg.SQLExecutor.ExecuteStatementInTransaction(txn, insertEventTableStmt, args...)
+	rows, err := s.cfg.SQLExecutor.ExecuteStatementInTransaction("log-range-event", txn, insertEventTableStmt, args...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Prior to this patch, uses of SQL for "internal" purposes (DB logs,
lease activity etc) was anonymous with regard to logging and it would
have been hard to distinguish which log message was caused by which
internal activity -- as opposed to client activities which are tagged
by the remote address already.

This patch enhances the situation by providing different logging tags
for the various internal uses of SQL.

(this is a part of #9259 extracted for easier reviewing and discussion)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10024)

<!-- Reviewable:end -->
