### PR TITLE
sql/parser: Adding note about Walk's intentionally limited scope

### DIFF
--- a/pkg/sql/parser/walk.go
+++ b/pkg/sql/parser/walk.go
@@ -412,6 +412,11 @@ func (expr *DTuple) Walk(_ Visitor) Expr { return expr }
 func (expr *DPlaceholder) Walk(_ Visitor) Expr { return expr }
 
 // WalkExpr traverses the nodes in an expression.
+//
+// NOTE: Do not count on the WalkStmt/WalkExpr machinery to visit all
+// expressions contained in a query. Only a sub-set of all expressions are
+// found by WalkStmt and subsequently traversed. See the comment below on
+// WalkStmt for details.
 func WalkExpr(v Visitor, expr Expr) (newExpr Expr, changed bool) {
 	recurse, newExpr := v.VisitPre(expr)
 
@@ -791,6 +796,11 @@ var _ WalkableStmt = &ValuesClause{}
 // WalkStmt walks the entire parsed stmt calling WalkExpr on each
 // expression, and replacing each expression with the one returned
 // by WalkExpr.
+//
+// NOTE: Beware that WalkStmt does not necessarily traverse all parts of a
+// statement by itself. For example, it will not walk into Subquery nodes
+// within a FROM clause or into a JoinCond. Walk's logic is pretty
+// interdependent with the logic for constructing a query plan.
 func WalkStmt(v Visitor, stmt Statement) (newStmt Statement, changed bool) {
 	walkable, ok := stmt.(WalkableStmt)
 	if !ok {


### PR DESCRIPTION
Hopefully this will be helpful to the next new person that looks into
using it for something that it wasn't built for.

@knz

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10026)

<!-- Reviewable:end -->
