### PR TITLE
util/encoding: Replace byte iteration with bytes.IndexByte in findDecimalTerminator

### DIFF
--- a/pkg/util/encoding/decimal.go
+++ b/pkg/util/encoding/decimal.go
@@ -21,6 +21,7 @@
 package encoding
 
 import (
+	"bytes"
 	"fmt"
 	"math"
 	"math/big"
@@ -385,13 +386,8 @@ func makeDecimalFromMandE(negative bool, e int, m []byte, tmp []byte) *inf.Dec {
 
 // findDecimalTerminator finds the decimalTerminator in the given slice.
 func findDecimalTerminator(buf []byte) (int, error) {
-	// TODO(nvanbenschoten): bytes.IndexByte is inefficient for small slices. This is
-	// apparently fixed in go1.7. For now, we manually search for the terminator.
-	// idx := bytes.IndexByte(r, decimalTerminator)
-	for i, b := range buf {
-		if b == decimalTerminator {
-			return i, nil
-		}
+	if idx := bytes.IndexByte(buf, decimalTerminator); idx != -1 {
+		return idx, nil
 	}
 	return -1, errors.Errorf("did not find terminator %#x in buffer %#x", decimalTerminator, buf)
 }


### PR DESCRIPTION
This addresses a TODO that was waiting on Go 1.7.

The only benchmark this seemed to move was `PeekLengthDecimal`, which
got a nice 14% speed bump:

```
name                 old time/op    new time/op    delta
PeekLengthDecimal-4    48.4ns ± 1%    41.6ns ± 1%  -14.09%  (p=0.000 n=10+9)

name                 old alloc/op   new alloc/op   delta
PeekLengthDecimal-4    0.00B ±NaN%    0.00B ±NaN%     ~     (all samples are equal)

name                 old allocs/op  new allocs/op  delta
PeekLengthDecimal-4     0.00 ±NaN%     0.00 ±NaN%     ~     (all samples are equal)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10035)

<!-- Reviewable:end -->
