### PR TITLE
storage/engine/rocksdb: set cache_index_and_filter_blocks to true

### DIFF
--- a/pkg/storage/engine/rocksdb/db.cc
+++ b/pkg/storage/engine/rocksdb/db.cc
@@ -1395,6 +1395,8 @@ DBStatus DBOpen(DBEngine **db, DBSlice dir, DBOptions db_opts) {
   // Increasing block_size decreases memory usage at the cost of
   // increased read amplification.
   table_options.block_size = db_opts.block_size;
+  table_options.cache_index_and_filter_blocks = true;
+  table_options.pin_l0_filter_and_index_blocks_in_cache = true;
 
   // Use the rocksdb options builder to configure the base options
   // using our memtable budget.


### PR DESCRIPTION
Set BlockBasedTableOptions::cache_index_and_filter_blocks to true so
that index and filter blocks are placed in the block-cache on
demand (and available for eviction) rather than being loaded and pinned
in memory when a table is opened. This is a modest (few percent)
performance hit in small `block_writer` tests, but prevents excessive
memory usage on clusters which have a large amount of index and filter
data.

See #10050

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10051)

<!-- Reviewable:end -->
