### PR TITLE
storage/engine/rocksdb: disable whole_key_filtering

### DIFF
--- a/pkg/storage/engine/rocksdb/db.cc
+++ b/pkg/storage/engine/rocksdb/db.cc
@@ -1395,6 +1395,10 @@ DBStatus DBOpen(DBEngine **db, DBSlice dir, DBOptions db_opts) {
   // Increasing block_size decreases memory usage at the cost of
   // increased read amplification.
   table_options.block_size = db_opts.block_size;
+  // Disable whole_key_filtering which adds a bloom filter entry for
+  // the "whole key", doubling the size of our bloom filters. This is
+  // used to speed up Get operations which we don't use.
+  table_options.whole_key_filtering = false;
 
   // Use the rocksdb options builder to configure the base options
   // using our memtable budget.


### PR DESCRIPTION
Disable BlockBasedTableOptions::whole_key_filtering which adds a bloom
filter entry for the entire key. This option doubles the size of our
bloom filters, but is only used to speed up Gets which we don't use.

See #10050

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10060)

<!-- Reviewable:end -->
