### PR TITLE
sql: SHOW TABLES marks a dropped table with a " (dropped)" suffix

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -369,7 +369,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 			return err
 		}
 		// Short circuit the backfill if the table has been deleted.
-		if tableDesc.Deleted() {
+		if tableDesc.Dropped() {
 			done = true
 			return nil
 		}
@@ -513,7 +513,7 @@ func (sc *SchemaChanger) truncateIndexes(
 					return err
 				}
 				// Short circuit the truncation if the table has been deleted.
-				if tableDesc.Deleted() {
+				if tableDesc.Dropped() {
 					done = true
 					return nil
 				}
@@ -604,7 +604,7 @@ func (sc *SchemaChanger) backfillIndexesChunk(
 			return err
 		}
 		// Short circuit the backfill if the table has been deleted.
-		if tableDesc.Deleted() {
+		if tableDesc.Dropped() {
 			done = true
 			return nil
 		}

--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -887,7 +887,7 @@ func verifyDropTableMetadata(
 	if desc == nil {
 		return errors.Errorf("%s %d missing", objType, tableID)
 	}
-	if desc.Deleted() {
+	if desc.Dropped() {
 		return nil
 	}
 	return errors.Errorf("expected %s %d to be marked as deleted", objType, tableID)
@@ -910,7 +910,7 @@ func (p *planner) dropViewImpl(
 		}
 		// The dependency is also being deleted, so we don't have to remove the
 		// references.
-		if dependencyDesc.Deleted() {
+		if dependencyDesc.Dropped() {
 			continue
 		}
 		dependencyDesc.DependedOnBy = removeMatchingReferences(dependencyDesc.DependedOnBy, viewDesc.ID)

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -499,11 +499,11 @@ CREATE TABLE test.t(a INT PRIMARY KEY);
 	if !rows.Next() {
 		t.Fatal("table invisible through SHOW TABLES")
 	}
-	var val []byte
+	var val string
 	if err := rows.Scan(&val); err != nil {
 		t.Errorf("row scan failed: %s", err)
 	}
-	if string(val) != "t (dropped)" {
+	if val != "t (dropped)" {
 		t.Fatalf("table = %s", val)
 	}
 

--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -454,7 +454,7 @@ CREATE TABLE test.t(a INT PRIMARY KEY);
 	// try to acquire at a bogus version to make sure we don't get back a lease we
 	// already had.
 	_, err = t.acquire(1, tableDesc.ID, tableDesc.Version+1)
-	if !testutils.IsError(err, "table is being deleted") {
+	if !testutils.IsError(err, "table is being dropped") {
 		t.Fatalf("got a different error than expected: %v", err)
 	}
 }
@@ -470,7 +470,7 @@ func isDeleted(tableID sqlbase.ID, cfg config.SystemConfig) bool {
 		panic("unable to unmarshal table descriptor")
 	}
 	table := descriptor.GetTable()
-	return table.Deleted()
+	return table.Dropped()
 }
 
 func acquire(
@@ -580,7 +580,7 @@ CREATE TABLE test.t(a INT PRIMARY KEY);
 	}
 	// Now we shouldn't be able to acquire any more.
 	_, err = acquire(s.(*server.TestServer), tableDesc.ID, 0)
-	if !testutils.IsError(err, "table is being deleted") {
+	if !testutils.IsError(err, "table is being dropped") {
 		t.Fatalf("got a different error than expected: %v", err)
 	}
 }

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -222,7 +222,7 @@ func (sc SchemaChanger) exec() error {
 	}
 	table := desc.GetTable()
 
-	if table.Deleted() {
+	if table.Dropped() {
 		lease, err = sc.ExtendLease(lease)
 		if err != nil {
 			return err
@@ -781,7 +781,7 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 						// A schema change execution might fail soon after
 						// unsetting UpVersion, and we still want to process
 						// outstanding mutations. Similar with a table marked for deletion.
-						if table.UpVersion || table.Deleted() || table.Adding() ||
+						if table.UpVersion || table.Dropped() || table.Adding() ||
 							table.Renamed() || len(table.Mutations) > 0 {
 							if log.V(2) {
 								log.Infof(context.TODO(), "%s: queue up pending schema change; table: %d, version: %d",

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -664,9 +664,9 @@ func (p *planner) ShowTables(n *parser.ShowTables) (planNode, error) {
 			v := p.newContainerValuesNode(columns, len(tableNames))
 			for _, name := range tableNames {
 				tableName := name.Table()
-				// Check to see if the table has been deleted.
+				// Check to see if the table has been dropped.
 				if _, err := p.mustGetTableOrViewDesc(&name); err != nil {
-					if err == errTableDeleted {
+					if err == errTableDropped {
 						tableName += " (dropped)"
 					} else {
 						return nil, err

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1504,7 +1504,7 @@ func (desc *TableDescriptor) SetUpVersion() error {
 		// has been deleted. This will block new mutations from being queued on the
 		// table; it'd be misleading to allow them to be queued, since the
 		// respective schema change will never run.
-		return fmt.Errorf("table %q has been deleted", desc.Name)
+		return fmt.Errorf("table %q is being dropped", desc.Name)
 	}
 	desc.UpVersion = true
 	return nil

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1482,8 +1482,8 @@ func (desc *TableDescriptor) FinalizeMutation() (MutationID, error) {
 	return mutationID, nil
 }
 
-// Deleted returns true if the table is being deleted.
-func (desc *TableDescriptor) Deleted() bool {
+// Dropped returns true if the table is being dropped.
+func (desc *TableDescriptor) Dropped() bool {
 	return desc.State == TableDescriptor_DROP
 }
 
@@ -1499,7 +1499,7 @@ func (desc *TableDescriptor) Renamed() bool {
 
 // SetUpVersion sets the up_version marker on the table descriptor (see the proto
 func (desc *TableDescriptor) SetUpVersion() error {
-	if desc.Deleted() {
+	if desc.Dropped() {
 		// We don't allow the version to be incremented any more once a table
 		// has been deleted. This will block new mutations from being queued on the
 		// table; it'd be misleading to allow them to be queued, since the

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -222,13 +222,13 @@ func (p *planner) mustGetViewDesc(tn *parser.TableName) (*sqlbase.TableDescripto
 	return desc, nil
 }
 
-var errTableDeleted = errors.New("table is being deleted")
+var errTableDropped = errors.New("table is being dropped")
 var errTableAdding = errors.New("table is being added")
 
 func filterTableState(tableDesc *sqlbase.TableDescriptor) error {
 	switch {
-	case tableDesc.Deleted():
-		return errTableDeleted
+	case tableDesc.Dropped():
+		return errTableDropped
 	case tableDesc.Adding():
 		return errTableAdding
 	case tableDesc.State != sqlbase.TableDescriptor_PUBLIC:


### PR DESCRIPTION
fixes #9318

Added another commit that renames table deleted to table dropped for #9493

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10063)

<!-- Reviewable:end -->
