### PR TITLE
storage: Add metrics for tracking CommandQueue health

### DIFF
--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -38,6 +38,25 @@ var (
 	metaLeaseHolderCount = metric.Metadata{Name: "replicas.leaseholders"}
 	metaQuiescentCount   = metric.Metadata{Name: "replicas.quiescent"}
 
+	// Replica CommandQueue metrics. Max size metrics track the maximum value
+	// seen for all replicas during a single replica scan.
+	metaMaxCommandQueueSize = metric.Metadata{Name: "replicas.commandqueue.maxsize",
+		Help: "Largest number of commands in any CommandQueue"}
+	metaMaxCommandQueueWriteCount = metric.Metadata{Name: "replicas.commandqueue.maxwritecount",
+		Help: "Largest number of read-write commands in any CommandQueue"}
+	metaMaxCommandQueueReadCount = metric.Metadata{Name: "replicas.commandqueue.maxreadcount",
+		Help: "Largest number of read-only commands in any CommandQueue"}
+	metaMaxCommandQueueTreeSize = metric.Metadata{Name: "replicas.commandqueue.maxtreesize",
+		Help: "Largest number of intervals in any CommandQueue's interval tree"}
+	metaMaxCommandQueueOverlaps = metric.Metadata{Name: "replicas.commandqueue.maxoverlaps",
+		Help: "Largest number of overlapping commands seen when adding to any CommandQueue"}
+	metaCombinedCommandQueueSize = metric.Metadata{Name: "replicas.commandqueue.combinedqueuesize",
+		Help: "Number of commands in all CommandQueues combined"}
+	metaCombinedCommandWriteCount = metric.Metadata{Name: "replicas.commandqueue.combinedwritecount",
+		Help: "Number of read-write commands in all CommandQueues combined"}
+	metaCombinedCommandReadCount = metric.Metadata{Name: "replicas.commandqueue.combinedreadcount",
+		Help: "Number of read-only commands in all CommandQueues combined"}
+
 	// Range metrics.
 	metaAvailableRangeCount = metric.Metadata{Name: "ranges.available"}
 
@@ -268,6 +287,16 @@ type StoreMetrics struct {
 	LeaseHolderCount              *metric.Gauge
 	QuiescentCount                *metric.Gauge
 
+	// Replica CommandQueue metrics.
+	MaxCommandQueueSize       *metric.Gauge
+	MaxCommandQueueWriteCount *metric.Gauge
+	MaxCommandQueueReadCount  *metric.Gauge
+	MaxCommandQueueTreeSize   *metric.Gauge
+	MaxCommandQueueOverlaps   *metric.Gauge
+	CombinedCommandQueueSize  *metric.Gauge
+	CombinedCommandWriteCount *metric.Gauge
+	CombinedCommandReadCount  *metric.Gauge
+
 	// Range metrics.
 	AvailableRangeCount *metric.Gauge
 
@@ -427,6 +456,16 @@ func newStoreMetrics(sampleInterval time.Duration) *StoreMetrics {
 		RaftLeaderNotLeaseHolderCount: metric.NewGauge(metaRaftLeaderNotLeaseHolderCount),
 		LeaseHolderCount:              metric.NewGauge(metaLeaseHolderCount),
 		QuiescentCount:                metric.NewGauge(metaQuiescentCount),
+
+		// Replica CommandQueue metrics.
+		MaxCommandQueueSize:       metric.NewGauge(metaMaxCommandQueueSize),
+		MaxCommandQueueWriteCount: metric.NewGauge(metaMaxCommandQueueWriteCount),
+		MaxCommandQueueReadCount:  metric.NewGauge(metaMaxCommandQueueReadCount),
+		MaxCommandQueueTreeSize:   metric.NewGauge(metaMaxCommandQueueTreeSize),
+		MaxCommandQueueOverlaps:   metric.NewGauge(metaMaxCommandQueueOverlaps),
+		CombinedCommandQueueSize:  metric.NewGauge(metaCombinedCommandQueueSize),
+		CombinedCommandWriteCount: metric.NewGauge(metaCombinedCommandWriteCount),
+		CombinedCommandReadCount:  metric.NewGauge(metaCombinedCommandReadCount),
 
 		// Range metrics.
 		AvailableRangeCount: metric.NewGauge(metaAvailableRangeCount),

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3311,6 +3311,64 @@ func (s *Store) updateReplicationGauges() error {
 	return nil
 }
 
+// updateCommandQueueGauges updates a number of simple statistics for
+// the CommandQueues of each replica in this store.
+func (s *Store) updateCommandQueueGauges() error {
+	var (
+		maxCommandQueueSize       int64
+		maxCommandQueueWriteCount int64
+		maxCommandQueueReadCount  int64
+		maxCommandQueueTreeSize   int64
+		maxCommandQueueOverlaps   int64
+		combinedCommandQueueSize  int64
+		combinedCommandWriteCount int64
+		combinedCommandReadCount  int64
+	)
+	newStoreReplicaVisitor(s).Visit(func(rep *Replica) bool {
+		rep.mu.Lock()
+		writes := rep.mu.cmdQ.localMetrics.writeCommands
+		reads := rep.mu.cmdQ.localMetrics.readCommands
+		treeSize := int64(rep.mu.cmdQ.treeSize())
+
+		maxOverlaps := rep.mu.cmdQ.localMetrics.maxOverlapsSeen
+		rep.mu.cmdQ.localMetrics.maxOverlapsSeen = 0
+		rep.mu.Unlock()
+
+		cqSize := writes + reads
+		if cqSize > maxCommandQueueSize {
+			maxCommandQueueSize = cqSize
+		}
+		if writes > maxCommandQueueWriteCount {
+			maxCommandQueueWriteCount = writes
+		}
+		if reads > maxCommandQueueReadCount {
+			maxCommandQueueReadCount = reads
+		}
+		if treeSize > maxCommandQueueTreeSize {
+			maxCommandQueueTreeSize = treeSize
+		}
+		if maxOverlaps > maxCommandQueueOverlaps {
+			maxCommandQueueOverlaps = maxOverlaps
+		}
+
+		combinedCommandQueueSize += cqSize
+		combinedCommandWriteCount += writes
+		combinedCommandReadCount += reads
+		return true // more
+	})
+
+	s.metrics.MaxCommandQueueSize.Update(maxCommandQueueSize)
+	s.metrics.MaxCommandQueueWriteCount.Update(maxCommandQueueWriteCount)
+	s.metrics.MaxCommandQueueReadCount.Update(maxCommandQueueReadCount)
+	s.metrics.MaxCommandQueueTreeSize.Update(maxCommandQueueTreeSize)
+	s.metrics.MaxCommandQueueOverlaps.Update(maxCommandQueueOverlaps)
+	s.metrics.CombinedCommandQueueSize.Update(combinedCommandQueueSize)
+	s.metrics.CombinedCommandWriteCount.Update(combinedCommandWriteCount)
+	s.metrics.CombinedCommandReadCount.Update(combinedCommandReadCount)
+
+	return nil
+}
+
 // ComputeMetrics immediately computes the current value of store metrics which
 // cannot be computed incrementally. This method should be invoked periodically
 // by a higher-level system which records store metrics.
@@ -3320,6 +3378,10 @@ func (s *Store) ComputeMetrics(tick int) error {
 	}
 
 	if err := s.updateReplicationGauges(); err != nil {
+		return err
+	}
+
+	if err := s.updateCommandQueueGauges(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Related to #9797.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10067)

<!-- Reviewable:end -->
