### PR TITLE
storage: Protect CommandQueue with its own mutex

### DIFF
--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -272,6 +272,8 @@ var (
 
 	metaMuReplicaNanos = metric.Metadata{Name: "mutex.replicananos",
 		Help: "Duration of Replica mutex critical sections"}
+	metaMuCommandQueueNanos = metric.Metadata{Name: "mutex.commandqueuenanos",
+		Help: "Duration of Command Queue mutex critical sections"}
 	metaMuRaftNanos = metric.Metadata{Name: "mutex.raftnanos",
 		Help: "Duration of Replica Raft mutex critical sections"}
 	metaMuStoreNanos = metric.Metadata{Name: "mutex.storenanos",
@@ -438,10 +440,11 @@ type StoreMetrics struct {
 	GCResolveSuccess             *metric.Counter
 
 	// Mutex timing information.
-	MuStoreNanos     *metric.Histogram
-	MuSchedulerNanos *metric.Histogram
-	MuRaftNanos      *metric.Histogram
-	MuReplicaNanos   *metric.Histogram
+	MuStoreNanos        *metric.Histogram
+	MuSchedulerNanos    *metric.Histogram
+	MuRaftNanos         *metric.Histogram
+	MuReplicaNanos      *metric.Histogram
+	MuCommandQueueNanos *metric.Histogram
 
 	// Stats for efficient merges.
 	mu struct {
@@ -608,6 +611,10 @@ func newStoreMetrics(sampleInterval time.Duration) *StoreMetrics {
 		// at the moment.
 		MuReplicaNanos: metric.NewHistogram(
 			metaMuReplicaNanos, sampleInterval,
+			time.Second.Nanoseconds(), 1,
+		),
+		MuCommandQueueNanos: metric.NewHistogram(
+			metaMuCommandQueueNanos, sampleInterval,
 			time.Second.Nanoseconds(), 1,
 		),
 		MuRaftNanos: metric.NewHistogram(

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -248,6 +248,15 @@ type Replica struct {
 	// TODO(peter): evaluate runtime overhead the timed mutex.
 	raftMu syncutil.TimedMutex
 
+	cmdQMu struct {
+		// Protects all fields in the cmdQMu struct.
+		//
+		// Locking notes: Replica.mu < Replica.cmdQMu
+		syncutil.TimedMutex
+		// Enforces at most one command is running per key(s).
+		q *CommandQueue
+	}
+
 	mu struct {
 		// Protects all fields in the mu struct.
 		//
@@ -267,8 +276,6 @@ type Replica struct {
 		state storagebase.ReplicaState
 		// Counter used for assigning lease indexes for proposals.
 		lastAssignedLeaseIndex uint64
-		// Enforces at most one command is running per key(s).
-		cmdQ *CommandQueue
 		// Last index persisted to the raft log (not necessarily committed).
 		lastIndex uint64
 		// The raft log index of a pending preemptive snapshot. Used to prohibit
@@ -526,6 +533,18 @@ func newReplica(rangeID roachpb.RangeID, store *Store) *Replica {
 	)
 	r.mu.TimedMutex = syncutil.MakeTimedMutex(replicaMuLogger)
 	r.mu.outSnapDone = initialOutSnapDone
+
+	cmdQMuLogger := syncutil.ThresholdLogger(
+		r.AnnotateCtx(context.Background()),
+		defaultReplicaMuWarnThreshold,
+		func(ctx context.Context, msg string, args ...interface{}) {
+			log.Warningf(ctx, "cmdQMu: "+msg, args...)
+		},
+		func(t time.Duration) {
+			r.store.metrics.MuCommandQueueNanos.RecordValue(t.Nanoseconds())
+		},
+	)
+	r.cmdQMu.TimedMutex = syncutil.MakeTimedMutex(cmdQMuLogger)
 	return r
 }
 
@@ -566,7 +585,10 @@ func (r *Replica) initLocked(
 		return errors.Errorf("replicaID must be 0 when creating an initialized replica")
 	}
 
-	r.mu.cmdQ = NewCommandQueue()
+	r.cmdQMu.Lock()
+	r.cmdQMu.q = NewCommandQueue()
+	r.cmdQMu.Unlock()
+
 	r.mu.tsCache = newTimestampCache(clock)
 	r.mu.proposals = map[storagebase.CmdIDKey]*ProposalData{}
 	r.mu.checksums = map[uuid.UUID]replicaChecksum{}
@@ -1163,10 +1185,10 @@ func (r *Replica) beginCmds(
 		for i, union := range ba.Requests {
 			spans[i] = union.GetInner().Header()
 		}
-		r.mu.Lock()
-		chans := r.mu.cmdQ.getWait(readOnly, spans...)
-		cmd = r.mu.cmdQ.add(readOnly, spans...)
-		r.mu.Unlock()
+		r.cmdQMu.Lock()
+		chans := r.cmdQMu.q.getWait(readOnly, spans...)
+		cmd = r.cmdQMu.q.add(readOnly, spans...)
+		r.cmdQMu.Unlock()
 
 		beforeWait := timeutil.Now()
 		ctxDone := ctx.Done()
@@ -1190,9 +1212,9 @@ func (r *Replica) beginCmds(
 					for _, ch := range chans {
 						<-ch
 					}
-					r.mu.Lock()
-					r.mu.cmdQ.remove(cmd)
-					r.mu.Unlock()
+					r.cmdQMu.Lock()
+					r.cmdQMu.q.remove(cmd)
+					r.cmdQMu.Unlock()
 				}()
 				return nil, err
 			}
@@ -1231,9 +1253,6 @@ func (r *Replica) beginCmds(
 func (r *Replica) endCmds(
 	cmd *cmd, ba *roachpb.BatchRequest, br *roachpb.BatchResponse, pErr *roachpb.Error,
 ) (rErr *roachpb.Error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
 	// Only update the timestamp cache if the command succeeded and is
 	// marked as affecting the cache. Inconsistent reads are excluded.
 	if pErr == nil && ba.ReadConsistency != roachpb.INCONSISTENT {
@@ -1262,9 +1281,14 @@ func (r *Replica) endCmds(
 			}
 		}
 
+		r.mu.Lock()
 		r.mu.tsCache.AddRequest(cr)
+		r.mu.Unlock()
 	}
-	r.mu.cmdQ.remove(cmd)
+
+	r.cmdQMu.Lock()
+	r.cmdQMu.q.remove(cmd)
+	r.cmdQMu.Unlock()
 	return pErr
 }
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -373,6 +373,7 @@ func TestReplicaContains(t *testing.T) {
 	// This test really only needs a hollow shell of a Replica.
 	r := &Replica{}
 	r.mu.TimedMutex = syncutil.MakeTimedMutex(defaultMuLogger)
+	r.cmdQMu.TimedMutex = syncutil.MakeTimedMutex(defaultMuLogger)
 	r.mu.state.Desc = desc
 	r.rangeStr.store(0, desc)
 
@@ -2020,9 +2021,9 @@ func TestReplicaCommandQueueCancellation(t *testing.T) {
 
 	// Wait until both commands are in the command queue.
 	util.SucceedsSoon(t, func() error {
-		tc.rng.mu.Lock()
-		chans := tc.rng.mu.cmdQ.getWait(false, roachpb.Span{Key: key1}, roachpb.Span{Key: key2})
-		tc.rng.mu.Unlock()
+		tc.rng.cmdQMu.Lock()
+		chans := tc.rng.cmdQMu.q.getWait(false, roachpb.Span{Key: key1}, roachpb.Span{Key: key2})
+		tc.rng.cmdQMu.Unlock()
 		if a, e := len(chans), 2; a < e {
 			return errors.Errorf("%d of %d commands in the command queue", a, e)
 		}

--- a/pkg/storage/scanner_test.go
+++ b/pkg/storage/scanner_test.go
@@ -58,6 +58,7 @@ func newTestRangeSet(count int, t *testing.T) *testRangeSet {
 			RangeID: desc.RangeID,
 		}
 		rng.mu.TimedMutex = syncutil.MakeTimedMutex(defaultMuLogger)
+		rng.cmdQMu.TimedMutex = syncutil.MakeTimedMutex(defaultMuLogger)
 		rng.mu.state.Stats = enginepb.MVCCStats{
 			KeyBytes:  1,
 			ValBytes:  2,

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3535,14 +3535,14 @@ func (s *Store) updateCommandQueueGauges() error {
 		combinedCommandReadCount  int64
 	)
 	newStoreReplicaVisitor(s).Visit(func(rep *Replica) bool {
-		rep.mu.Lock()
-		writes := rep.mu.cmdQ.localMetrics.writeCommands
-		reads := rep.mu.cmdQ.localMetrics.readCommands
-		treeSize := int64(rep.mu.cmdQ.treeSize())
+		rep.cmdQMu.Lock()
+		writes := rep.cmdQMu.q.localMetrics.writeCommands
+		reads := rep.cmdQMu.q.localMetrics.readCommands
+		treeSize := int64(rep.cmdQMu.q.treeSize())
 
-		maxOverlaps := rep.mu.cmdQ.localMetrics.maxOverlapsSeen
-		rep.mu.cmdQ.localMetrics.maxOverlapsSeen = 0
-		rep.mu.Unlock()
+		maxOverlaps := rep.cmdQMu.q.localMetrics.maxOverlapsSeen
+		rep.cmdQMu.q.localMetrics.maxOverlapsSeen = 0
+		rep.cmdQMu.Unlock()
 
 		cqSize := writes + reads
 		if cqSize > maxCommandQueueSize {

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -676,6 +676,7 @@ func TestProcessRangeDescriptorUpdate(t *testing.T) {
 		abortCache: NewAbortCache(desc.RangeID),
 	}
 	r.mu.TimedMutex = syncutil.MakeTimedMutex(defaultMuLogger)
+	r.cmdQMu.TimedMutex = syncutil.MakeTimedMutex(defaultMuLogger)
 	if err := r.init(desc, store.Clock(), 0); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Opening this primarily to discuss, as I haven’t been able to get any tangible insight into actual performance implications (yet). Intuitively I would think that in the case of [heavy lock contention](https://github.com/cockroachdb/cockroach/issues/9749), decoupling synchronization of components that do not need to interact atomically would help. 

The change shows that it is safe to give the `CommandQueue` its own Mutex. This is important because we saw cases where once the `CommandQueue` gets backed up enough, operations on it can take multiple seconds. Specifically, these operations include anything that deals with the queue's interval tree, where overhead grows linearly with the number of overlapping commands. These operations previously blocked the replica mutex, meaning that they were a part of preventing current commands from completing. This in turn resulted in the command queue getting even more clogged up.

In the past we've tried to unify mutexes, as it makes concurrency a lot easier to reason about and reduces a lot of complexity. However, with something as self contained as the `CommandQueue`, it seems like a clear win to split its mutex off.

@tschottdorf @petermattis @andreimatei

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10068)

<!-- Reviewable:end -->
