### PR TITLE
acceptance: fix hostnames for Terraform tests

### DIFF
--- a/pkg/acceptance/terraform_test.go
+++ b/pkg/acceptance/terraform_test.go
@@ -86,3 +86,10 @@ func TestFiveNodesAndWriters(t *testing.T) {
 		}
 	}
 }
+
+func TestRandomNameMeetsTerraformRules(t *testing.T) {
+	prefix := "testprefix-" + getRandomName()
+	if !prefixRE.MatchString(prefix) {
+		t.Fatalf("generated prefix '%s' doesn't match Terraform-enforced regex %s", prefix, prefixRE)
+	}
+}

--- a/pkg/acceptance/util_test.go
+++ b/pkg/acceptance/util_test.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -150,6 +151,14 @@ func runTests(m *testing.M) {
 //   '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)', invalid
 var prefixRE = regexp.MustCompile("^(?:[a-z](?:[-a-z0-9]{0,45}[a-z0-9])?)$")
 
+// getRandomName generates a random, human-readable name to ease identification
+// of different test resources.
+func getRandomName() string {
+	// Remove characters that aren't allowed in hostnames for machines allocated
+	// by Terraform.
+	return strings.Replace(namesgenerator.GetRandomName(0), "_", "", -1)
+}
+
 func farmer(t *testing.T, prefix string) *terrafarm.Farmer {
 	SkipUnlessRemote(t)
 
@@ -202,7 +211,7 @@ func farmer(t *testing.T, prefix string) *terrafarm.Farmer {
 			name += "-"
 		}
 
-		name += namesgenerator.GetRandomName(0)
+		name += getRandomName()
 
 		// Rudimentary collision control.
 		for i := 0; ; i++ {


### PR DESCRIPTION
 Terraform has specific rules for hostnames, one of which disallows
underscores. Unfortunately, Docker's `namesgenerator` uses underscores.
This change removes those underscores and adds a test to avoid
generating invalid hostnames in the future.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10082)

<!-- Reviewable:end -->
