### PR TITLE
cli: allow setting --key with env var COCKROACH_KEY.

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -256,6 +256,7 @@ provide the password on standard input.`,
 
 	Key = FlagInfo{
 		Name:        "key",
+		EnvVar:      "COCKROACH_KEY",
 		Description: `Path to the key protecting --cert. Needed in secure mode.`,
 	}
 


### PR DESCRIPTION
Fixes #9202.

Must have been an oversight, because the env var was already referenced by `acceptance/cluster/localcluster.go`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10092)

<!-- Reviewable:end -->
