### PR TITLE
sql: Do SELECT privilege checks on views, not their underlying query

### DIFF
--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -61,6 +61,10 @@ type planner struct {
 	// It's used in layers below the executor to modify the behavior of SELECT.
 	avoidCachedDescriptors bool
 
+	// If set, the planner should skip checking for the SELECT privilege when
+	// initializing plans to read from a table. This should be used with care.
+	skipSelectPrivilegeChecks bool
+
 	// If set, contains the in progress COPY FROM columns.
 	copyFrom *copyNode
 

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -268,8 +268,10 @@ func (n *scanNode) initTable(
 ) error {
 	n.desc = *desc
 
-	if err := p.checkPrivilege(&n.desc, privilege.SELECT); err != nil {
-		return err
+	if !p.skipSelectPrivilegeChecks {
+		if err := p.checkPrivilege(&n.desc, privilege.SELECT); err != nil {
+			return err
+		}
 	}
 
 	if indexHints != nil && indexHints.Index != "" {

--- a/pkg/sql/testdata/views
+++ b/pkg/sql/testdata/views
@@ -142,6 +142,72 @@ SHOW CREATE VIEW test2.v1;
 ----
 test2.v1 CREATE VIEW "test2.v1" AS SELECT x, y FROM test.v2
 
+statement ok
+GRANT SELECT ON t TO testuser;
+
+user testuser
+
+query II
+SELECT * FROM t;
+----
+1 99
+2 98
+3 97
+
+query error user testuser does not have SELECT privilege on view v1
+SELECT * FROM v1;
+
+query error user testuser does not have SELECT privilege on view v6
+SELECT * FROM v6;
+
+user root
+
+statement ok
+REVOKE SELECT ON t FROM testuser;
+
+statement ok
+GRANT SELECT ON v1 TO testuser;
+
+user testuser
+
+query error user testuser does not have SELECT privilege on table t
+SELECT * FROM t;
+
+query II
+SELECT * FROM v1;
+----
+1 99
+2 98
+3 97
+
+query error user testuser does not have SELECT privilege on view v6
+SELECT * FROM v6;
+
+user root
+
+statement ok
+REVOKE SELECT ON v1 FROM testuser;
+
+statement ok
+GRANT SELECT ON v6 TO testuser;
+
+user testuser
+
+query error user testuser does not have SELECT privilege on table t
+SELECT * FROM t;
+
+query error user testuser does not have SELECT privilege on view v1
+SELECT * FROM v1;
+
+query II
+SELECT * FROM v6;
+----
+1 99
+2 98
+3 97
+
+user root
+
 statement error pgcode 42809 "v1" is not a table
 DROP TABLE v1;
 


### PR DESCRIPTION
Sticking this into the planner and setting it before/after constructing the subquery plan feels really hacky (I hope we aren't going to add concurrency to the plan construction process anytime soon!). Hopefully I'm missing something, but I don't see a cleaner way to get the information passed down given the current design of the code. Any other suggestions?

Thanks @jseldess for doing a thorough job with the docs and reminding me about this!
#2971

@dt

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10097)

<!-- Reviewable:end -->
