### PR TITLE
sql: Prevent the usage of star expansions in view queries

### DIFF
--- a/pkg/sql/select.go
+++ b/pkg/sql/select.go
@@ -61,6 +61,10 @@ type selectNode struct {
 	render  []parser.TypedExpr
 	columns ResultColumns
 
+	// A piece of metadata to indicate whether a star expression was expanded
+	// during rendering.
+	isStar bool
+
 	// The number of initial columns - before adding any internal render
 	// targets for grouping, filtering or ordering. The original columns
 	// are columns[:numOriginalCols], the internally added ones are
@@ -574,6 +578,7 @@ func (s *selectNode) addRender(target parser.SelectExpr, desiredType parser.Type
 	} else if isStar {
 		s.columns = append(s.columns, cols...)
 		s.render = append(s.render, typedExprs...)
+		s.isStar = true
 		return nil
 	}
 

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -187,14 +187,13 @@ func TestShowCreateView(t *testing.T) {
 	}
 
 	tests := []string{
-		`CREATE VIEW %s AS SELECT * FROM d.t`,
-		`CREATE VIEW %s AS SELECT * FROM d.t`,
+		`CREATE VIEW %s AS SELECT i, s, v, t FROM d.t`,
 		`CREATE VIEW %s AS SELECT i, s, t FROM d.t`,
 		`CREATE VIEW %s AS SELECT t.i, t.s, t.t FROM d.t`,
 		`CREATE VIEW %s AS SELECT foo.i, foo.s, foo.t FROM d.t AS foo WHERE foo.i > 3`,
 		`CREATE VIEW %s AS SELECT COUNT(*) FROM d.t`,
 		`CREATE VIEW %s AS SELECT s, COUNT(*) FROM d.t GROUP BY s HAVING COUNT(*) > 3`,
-		`CREATE VIEW %s (a, b, c, d) AS SELECT * FROM d.t`,
+		`CREATE VIEW %s (a, b, c, d) AS SELECT i, s, v, t FROM d.t`,
 		`CREATE VIEW %s (a, b) AS SELECT i, v FROM d.t`,
 	}
 	for i, test := range tests {

--- a/pkg/sql/testdata/alter_table
+++ b/pkg/sql/testdata/alter_table
@@ -508,7 +508,7 @@ ALTER INDEX nonexistent@noindex SPLIT AT (42)
 user root
 
 statement ok
-CREATE VIEW privsview AS SELECT * FROM privs
+CREATE VIEW privsview AS SELECT a,b,c FROM privs
 
 statement error pgcode 42809 "privsview" is not a table
 ALTER TABLE privsview ADD d INT

--- a/pkg/sql/testdata/create_index
+++ b/pkg/sql/testdata/create_index
@@ -97,7 +97,7 @@ statement error pgcode 42P01 table "foo" does not exist
 CREATE INDEX fail ON foo (b DESC)
 
 statement ok
-CREATE VIEW v AS SELECT * FROM t
+CREATE VIEW v AS SELECT a,b FROM t
 
 statement error pgcode 42809 "v" is not a table
 CREATE INDEX failview ON v (b DESC)

--- a/pkg/sql/testdata/delete
+++ b/pkg/sql/testdata/delete
@@ -27,7 +27,7 @@ SELECT * FROM kv
 7 8
 
 statement ok
-CREATE VIEW kview AS SELECT * FROM kv
+CREATE VIEW kview AS SELECT k,v FROM kv
 
 query II
 SELECT * FROM kview

--- a/pkg/sql/testdata/drop_database
+++ b/pkg/sql/testdata/drop_database
@@ -57,19 +57,19 @@ statement OK
 CREATE TABLE d2.t1 (k STRING PRIMARY KEY, v STRING)
 
 statement ok
-CREATE VIEW d1.v1 AS SELECT * FROM d1.t1
+CREATE VIEW d1.v1 AS SELECT k,v FROM d1.t1
 
 statement ok
-CREATE VIEW d1.v2 AS SELECT * FROM d1.v1
+CREATE VIEW d1.v2 AS SELECT k,v FROM d1.v1
 
 statement ok
-CREATE VIEW d2.v1 AS SELECT * FROM d2.t1
+CREATE VIEW d2.v1 AS SELECT k,v FROM d2.t1
 
 statement ok
-CREATE VIEW d2.v2 AS SELECT * FROM d1.t1
+CREATE VIEW d2.v2 AS SELECT k,v FROM d1.t1
 
 statement ok
-CREATE VIEW d2.v3 AS SELECT * FROM d1.v2
+CREATE VIEW d2.v3 AS SELECT k,v FROM d1.v2
 
 statement ok
 CREATE VIEW d2.v4 AS SELECT COUNT(*) FROM d1.t1 as x JOIN d2.t1 as y ON x.k = y.k

--- a/pkg/sql/testdata/drop_index
+++ b/pkg/sql/testdata/drop_index
@@ -111,7 +111,7 @@ users primary true   1   id     ASC       false
 users foo     false  1   name   ASC       false
 
 statement ok
-CREATE VIEW v2 AS SELECT * FROM v
+CREATE VIEW v2 AS SELECT name FROM v
 
 query T
 SHOW TABLES

--- a/pkg/sql/testdata/drop_view
+++ b/pkg/sql/testdata/drop_view
@@ -5,10 +5,10 @@ statement ok
 INSERT INTO a VALUES ('a', '1'), ('b', '2'), ('c', '3')
 
 statement ok
-CREATE VIEW b AS SELECT * from a
+CREATE VIEW b AS SELECT k,v from a
 
 statement ok
-CREATE VIEW c AS SELECT * from b
+CREATE VIEW c AS SELECT k,v from b
 
 query T
 SHOW TABLES FROM test
@@ -27,7 +27,7 @@ statement error cannot drop view "b" because it is depended on by view "test.c"
 DROP VIEW b
 
 statement ok
-CREATE VIEW d AS SELECT * FROM a
+CREATE VIEW d AS SELECT k,v FROM a
 
 statement ok
 CREATE VIEW diamond AS SELECT COUNT(*) FROM b AS b JOIN d AS d ON b.k = d.k
@@ -58,13 +58,13 @@ DROP VIEW d
 user root
 
 statement ok
-CREATE VIEW testuser1 AS SELECT * FROM a
+CREATE VIEW testuser1 AS SELECT k,v FROM a
 
 statement ok
-CREATE VIEW testuser2 AS SELECT * FROM testuser1
+CREATE VIEW testuser2 AS SELECT k,v FROM testuser1
 
 statement ok
-CREATE VIEW testuser3 AS SELECT * FROM testuser2
+CREATE VIEW testuser3 AS SELECT k,v FROM testuser2
 
 statement ok
 GRANT ALL ON testuser1 to testuser
@@ -156,7 +156,7 @@ statement ok
 CREATE VIEW x AS VALUES (1, 2), (3, 4)
 
 statement ok
-CREATE VIEW y AS SELECT * FROM x
+CREATE VIEW y AS SELECT column1, column2 FROM x
 
 statement error cannot drop view "x" because it is depended on by view "test.y"
 DROP VIEW x
@@ -168,7 +168,7 @@ statement ok
 CREATE VIEW x AS VALUES (1, 2), (3, 4)
 
 statement ok
-CREATE VIEW y AS SELECT * FROM x
+CREATE VIEW y AS SELECT column1, column2 FROM x
 
 statement error cannot drop view "x" because it is depended on by view "test.y"
 DROP VIEW x

--- a/pkg/sql/testdata/grant_table
+++ b/pkg/sql/testdata/grant_table
@@ -106,7 +106,7 @@ SHOW GRANTS ON t FOR readwrite, "test-user"
 # The same as above, but on a view
 
 statement ok
-CREATE VIEW v as SELECT * FROM t
+CREATE VIEW v as SELECT id FROM t
 
 query TTT colnames
 SHOW GRANTS ON v

--- a/pkg/sql/testdata/information_schema
+++ b/pkg/sql/testdata/information_schema
@@ -329,7 +329,7 @@ statement ok
 CREATE TABLE other_db.xyz (i INT)
 
 statement ok
-CREATE VIEW other_db.abc AS SELECT * from other_db.xyz
+CREATE VIEW other_db.abc AS SELECT i from other_db.xyz
 
 query T
 SELECT table_name FROM information_schema.tables
@@ -627,7 +627,7 @@ statement ok
 CREATE TABLE other_db.xyz (i INT)
 
 statement ok
-CREATE VIEW other_db.abc AS SELECT * from other_db.xyz
+CREATE VIEW other_db.abc AS SELECT i from other_db.xyz
 
 query TTTTTTTT colnames
 SELECT * FROM information_schema.table_privileges WHERE TABLE_SCHEMA = 'other_db'

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -119,7 +119,7 @@ CREATE TABLE constraint_db.t3 (
 )
 
 statement ok
-CREATE VIEW constraint_db.v1 AS SELECT * FROM constraint_db.t1;
+CREATE VIEW constraint_db.v1 AS SELECT p,a,b,c FROM constraint_db.t1;
 
 ## pg_catalog.pg_namespace
 

--- a/pkg/sql/testdata/rename_database
+++ b/pkg/sql/testdata/rename_database
@@ -101,7 +101,7 @@ user root
 # both for views in that database and for views in a different database.
 
 statement ok
-CREATE VIEW t.v AS SELECT * FROM u.kv
+CREATE VIEW t.v AS SELECT k,v FROM u.kv
 
 query T
 SHOW TABLES FROM u
@@ -118,7 +118,7 @@ statement ok
 ALTER DATABASE u RENAME TO v
 
 statement ok
-CREATE VIEW v.v AS SELECT * FROM v.kv
+CREATE VIEW v.v AS SELECT k,v FROM v.kv
 
 statement error cannot rename database because table "kv" is depended on by view "v.v"
 ALTER DATABASE v RENAME TO u

--- a/pkg/sql/testdata/rename_table
+++ b/pkg/sql/testdata/rename_table
@@ -146,7 +146,7 @@ SELECT * FROM test2.t2
 5 25
 
 statement ok
-CREATE VIEW test2.v1 AS SELECT * FROM test2.t2
+CREATE VIEW test2.v1 AS SELECT c1,c2 FROM test2.t2
 
 statement error pgcode 42809 "test2.v1" is not a table
 ALTER TABLE test2.v1 RENAME TO test2.v2

--- a/pkg/sql/testdata/rename_view
+++ b/pkg/sql/testdata/rename_view
@@ -14,7 +14,7 @@ statement ok
 INSERT INTO kv VALUES (1, 2), (3, 4)
 
 statement ok
-CREATE VIEW v as SELECT * FROM kv;
+CREATE VIEW v as SELECT k,v FROM kv;
 
 query II
 SELECT * FROM v
@@ -77,7 +77,7 @@ statement ok
 INSERT INTO t VALUES (4, 16), (5, 25)
 
 statement ok
-CREATE VIEW v as SELECT * from t
+CREATE VIEW v as SELECT c1,c2 from t
 
 statement error pgcode 42P07 relation "new_v" already exists
 ALTER VIEW v RENAME TO new_v

--- a/pkg/sql/testdata/truncate
+++ b/pkg/sql/testdata/truncate
@@ -16,7 +16,7 @@ SELECT * FROM kv
 7 8
 
 statement ok
-CREATE VIEW kview AS SELECT * FROM kv
+CREATE VIEW kview AS SELECT k,v FROM kv
 
 query II
 SELECT * FROM kview

--- a/pkg/sql/testdata/update
+++ b/pkg/sql/testdata/update
@@ -45,7 +45,7 @@ statement error compound types not supported yet: "k\.v"
 UPDATE kv SET k.v = 9
 
 statement ok
-CREATE VIEW kview as SELECT * from kv
+CREATE VIEW kview as SELECT k,v from kv
 
 query II
 SELECT * FROM kview

--- a/pkg/sql/testdata/views
+++ b/pkg/sql/testdata/views
@@ -5,28 +5,28 @@ statement ok
 INSERT INTO t VALUES (1, 99), (2, 98), (3, 97)
 
 statement ok
-CREATE VIEW v1 AS select * from t
+CREATE VIEW v1 AS select a, b from t
 
 statement error pgcode 42P07 relation \"v1\" already exists
-CREATE VIEW v1 AS select * from t
+CREATE VIEW v1 AS select a, b from t
 
 statement error pgcode 42P07 relation \"t\" already exists
-CREATE VIEW t AS select * from t
+CREATE VIEW t AS select a, b from t
 
 statement ok
-CREATE VIEW v2 (x, y) AS select * from t;
+CREATE VIEW v2 (x, y) AS select a, b from t;
 
 statement error pgcode 42601 CREATE VIEW specifies 1 column name, but data source has 2 columns
-CREATE VIEW v3 (x) AS select * from t;
+CREATE VIEW v3 (x) AS select a, b from t;
 
 statement error pgcode 42601 CREATE VIEW specifies 3 column names, but data source has 2 columns
-CREATE VIEW v4 (x, y, z) AS select * from t;
+CREATE VIEW v4 (x, y, z) AS select a, b from t;
 
 statement error pgcode 42P01 table "dne" does not exist
-CREATE VIEW v5 AS select * from dne;
+CREATE VIEW v5 AS select a, b from dne;
 
 statement ok
-CREATE VIEW v6 (x, y) AS select * from v1;
+CREATE VIEW v6 (x, y) AS select a, b from v1;
 
 query II colnames
 SELECT * FROM v1;
@@ -109,7 +109,7 @@ x y
 3 97
 
 statement ok
-CREATE VIEW v1 AS SELECT * FROM test.v2;
+CREATE VIEW v1 AS SELECT x, y FROM test.v2;
 
 statement ok
 SET DATABASE = test;
@@ -125,22 +125,22 @@ x y
 query TT
 SHOW CREATE VIEW v1;
 ----
-v1 CREATE VIEW v1 AS SELECT * FROM test.t
+v1 CREATE VIEW v1 AS SELECT a, b FROM test.t
 
 query TT
 SHOW CREATE VIEW v2;
 ----
-v2 CREATE VIEW v2 (x, y) AS SELECT * FROM test.t
+v2 CREATE VIEW v2 (x, y) AS SELECT a, b FROM test.t
 
 query TT
 SHOW CREATE VIEW v6;
 ----
-v6 CREATE VIEW v6 (x, y) AS SELECT * FROM test.v1
+v6 CREATE VIEW v6 (x, y) AS SELECT a, b FROM test.v1
 
 query TT
 SHOW CREATE VIEW test2.v1;
 ----
-test2.v1 CREATE VIEW "test2.v1" AS SELECT * FROM test.v2
+test2.v1 CREATE VIEW "test2.v1" AS SELECT x, y FROM test.v2
 
 statement error pgcode 42809 "v1" is not a table
 DROP TABLE v1;
@@ -168,6 +168,75 @@ DROP VIEW v1;
 
 statement error pgcode 42P01 view "v1" does not exist
 DROP VIEW v1;
+
+# Verify correct rejection of star expressions
+# TODO(a-robinson): Support star expressions as soon as we can (#10028)
+
+statement error views do not currently support \* expressions
+create view s1 AS SELECT * FROM t
+
+statement error views do not currently support \* expressions
+create view s1 AS SELECT t.* FROM t
+
+statement error views do not currently support \* expressions
+create view s1 AS SELECT alias.* FROM t AS alias
+
+statement error views do not currently support \* expressions
+create view s1 AS TABLE t
+
+statement error views do not currently support \* expressions
+create view s1 AS SELECT a FROM (SELECT * FROM t)
+
+statement error views do not currently support \* expressions
+create view s1 AS SELECT a FROM t WHERE NOT a IN (SELECT a FROM (SELECT * FROM t))
+
+statement error views do not currently support \* expressions
+create view s1 AS SELECT a FROM t GROUP BY a HAVING a IN (SELECT a FROM (SELECT * FROM t))
+
+statement error views do not currently support \* expressions
+create view s1 AS SELECT t1.*, t2.a FROM t AS t1 JOIN t AS t2 ON t1.a = t2.a
+
+statement error views do not currently support \* expressions
+create view s1 AS SELECT t1.a, t2.* FROM t AS t1 JOIN t AS t2 ON t1.a = t2.a
+
+statement error views do not currently support \* expressions
+create view s1 AS SELECT t1.*, t2.* FROM t AS t1 JOIN t AS t2 ON t1.a = t2.a
+
+statement error views do not currently support \* expressions
+create view s1 AS SELECT * FROM t AS t1 JOIN t AS t2 ON t1.a = t2.a
+
+statement error views do not currently support \* expressions
+create view s1 AS SELECT t1.a, t2.a FROM (SELECT * FROM t) AS t1 JOIN t AS t2 ON t1.a = t2.a
+
+statement error views do not currently support \* expressions
+create view s1 AS SELECT t1.a, t2.a FROM t AS t1 JOIN (SELECT * FROM t) AS t2 ON t1.a = t2.a
+
+statement error views do not currently support \* expressions
+create view s1 AS SELECT t1.a, t2.a FROM t AS t1 JOIN t AS t2 ON t1.a IN (SELECT a FROM (SELECT * FROM t))
+
+statement ok
+create view s1 AS SELECT COUNT(*) FROM t
+
+statement ok
+create view s2 AS SELECT a FROM t WHERE a IN (SELECT COUNT(*) FROM t)
+
+statement ok
+create view s3 AS SELECT a, COUNT(*) FROM t GROUP BY a
+
+statement ok
+create view s4 AS SELECT a, COUNT(*) FROM t GROUP BY a HAVING a > (SELECT COUNT(*) FROM t)
+
+statement ok
+DROP VIEW s4;
+
+statement ok
+DROP VIEW s3;
+
+statement ok
+DROP VIEW s2;
+
+statement ok
+DROP VIEW s1;
 
 statement ok
 DROP TABLE t;


### PR DESCRIPTION
And clean up all the tests that relied on them in the process.

See #10028 for context

@dt

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10099)

<!-- Reviewable:end -->
