### PR TITLE
sql: DFloat.Compare sorts NaN before non-NaN

### DIFF
--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -335,7 +335,17 @@ func (d *DFloat) Compare(other Datum) int {
 	if *d > *v {
 		return 1
 	}
-	return 0
+	// NaN sorts before non-NaN (#10109).
+	if *d == *v {
+		return 0
+	}
+	if math.IsNaN(float64(*d)) {
+		if math.IsNaN(float64(*v)) {
+			return 0
+		}
+		return -1
+	}
+	return 1
 }
 
 // HasPrev implements the Datum interface.

--- a/pkg/sql/parser/datum_test.go
+++ b/pkg/sql/parser/datum_test.go
@@ -1,0 +1,43 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: David Eisenstat (eisen@cockroachlabs.com)
+
+package parser
+
+import (
+	"math"
+	"testing"
+)
+
+func TestDFloatCompare(t *testing.T) {
+	values := []Datum{DNull}
+	for _, x := range []float64{math.NaN(), math.Inf(-1), -1, 0, 1, math.Inf(1)} {
+		values = append(values, NewDFloat(DFloat(x)))
+	}
+	for i, x := range values {
+		for j, y := range values {
+			expected := 0
+			if i < j {
+				expected = -1
+			} else if i > j {
+				expected = 1
+			}
+			got := x.Compare(y)
+			if got != expected {
+				t.Errorf("comparing DFloats %s and %s: expected %d, got %d", x, y, expected, got)
+			}
+		}
+	}
+}

--- a/pkg/sql/testdata/order_by
+++ b/pkg/sql/testdata/order_by
@@ -390,3 +390,17 @@ query ITT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, c, a
 ----
 0 scan abcd@abc /1/4-/1/5
+
+statement ok
+CREATE TABLE nan (id INT PRIMARY KEY, x REAL);
+
+statement ok
+INSERT INTO nan VALUES (1, 0/0), (2, -1), (3, 1), (4, 0/0);
+
+query R
+SELECT x FROM nan ORDER BY x;
+----
+NaN
+NaN
+-1
+1


### PR DESCRIPTION
See #10109 for context -- `DFloat.Compare` currently does not uphold its
contract. This change fixes that and aligns it with the encoded `DFloat`
ordering.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10112)

<!-- Reviewable:end -->
