### PR TITLE
Revert "util/tracing: use GPRC for lightstep reporting"

### DIFF
--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -218,7 +218,6 @@ var newTracer = func() opentracing.Tracer {
 		lsTr := lightstep.NewTracer(lightstep.Options{
 			AccessToken:    lightstepToken,
 			MaxLogsPerSpan: maxLogsPerSpan,
-			UseGRPC:        true,
 		})
 		if lightstepOnly {
 			return lsTr


### PR DESCRIPTION
This reverts commit 0abeb5a48dcde340ca14bd09789857792b58455c.

Lightstep doesn't actually work for me with that commit (it keeps timing out
trying to connect). My guess is that the server side is not set up yet.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10121)

<!-- Reviewable:end -->
