### PR TITLE
server: fix heartbeat span

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -207,7 +207,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	// liveness expiration and heartbeat interval.
 	active, renewal := storage.RangeLeaseDurations(
 		storage.RaftElectionTimeout(cfg.RaftTickInterval, cfg.RaftElectionTimeoutTicks))
-	s.nodeLiveness = storage.NewNodeLiveness(s.clock, s.db, s.gossip, active, renewal)
+	s.nodeLiveness = storage.NewNodeLiveness(
+		s.cfg.AmbientCtx, s.clock, s.db, s.gossip, active, renewal,
+	)
 	s.registry.AddMetricStruct(s.nodeLiveness.Metrics())
 
 	s.raftTransport = storage.NewRaftTransport(


### PR DESCRIPTION
A recent change incorrectly created a child span under "server start" and used
that for the entire heartbeat worker. Fixing to use an AmbientCtx, and starting
a separate span for each heartbeat.

Fixes #10123.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10126)

<!-- Reviewable:end -->
