### PR TITLE
GLOCKFILE: Update crlfmt version, vim-crlfmt support.

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -42,7 +42,7 @@ github.com/cockroachdb/c-rocksdb b5ca031b93fde49bfa2ba99aba423136aebf3c06
 github.com/cockroachdb/c-snappy d4e7b428fe7fc09e93573df3448567a62df8c9fa
 github.com/cockroachdb/cmux b64f5908f4945f4b11ed4a0a9d3cc1e23350866d
 github.com/cockroachdb/cockroach-go 31611c0501c812f437d4861d87d117053967c955
-github.com/cockroachdb/crlfmt 652c0df7fb3088f7b761fbaa36ab8f50b8fb9ed4
+github.com/cockroachdb/crlfmt f4be2332630e8f33c3262c0d5f0d13d733c8bedf
 github.com/cockroachdb/pq 44a6473ebbc26e3af09fe57bbdf761475c2c9f7c
 github.com/cockroachdb/stress 029c9348806514969d1109a6ae36e521af411ca7
 github.com/codahale/hdrhistogram 3a0bb77429bd3a61596f5e8a3172445844342120


### PR DESCRIPTION
Pulls in latest changes from https://github.com/cockroachdb/crlfmt/pull/7, should add support for [vim-crlfmt](https://github.com/irfansharif/vim-crlfmt).

cc @tamird

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10132)

<!-- Reviewable:end -->
