### PR TITLE
storage: fix TestStoreRangeCorruptionChangeReplicas

### DIFF
--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -45,6 +45,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
+const firstRange = roachpb.RangeID(1)
+const noStore = roachpb.StoreID(-1)
+
 var simpleZoneConfig = config.ZoneConfig{
 	NumReplicas: 1,
 	Constraints: config.Constraints{
@@ -212,7 +215,12 @@ func TestAllocatorSimpleRetrieval(t *testing.T) {
 	stopper, g, _, a, _ := createTestAllocator()
 	defer stopper.Stop()
 	gossiputil.NewStoreGossiper(g).GossipStores(singleStore, t)
-	result, err := a.AllocateTarget(simpleZoneConfig.Constraints, []roachpb.ReplicaDescriptor{}, false)
+	result, err := a.AllocateTarget(
+		simpleZoneConfig.Constraints,
+		[]roachpb.ReplicaDescriptor{},
+		firstRange,
+		false,
+	)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %v", err)
 	}
@@ -221,11 +229,48 @@ func TestAllocatorSimpleRetrieval(t *testing.T) {
 	}
 }
 
+// TestAllocatorCorruptReplica ensures that the allocator never attempts to
+// allocate a new replica on top of a dead (corrupt) one.
+func TestAllocatorCorruptReplica(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	stopper, g, sp, a, _ := createTestAllocator()
+	defer stopper.Stop()
+	gossiputil.NewStoreGossiper(g).GossipStores(sameDCStores, t)
+	const store1ID = roachpb.StoreID(1)
+
+	// Set store 1 to have a dead replica in the store pool.
+	sp.mu.Lock()
+	sp.mu.storeDetails[store1ID].deadReplicas[firstRange] =
+		[]roachpb.ReplicaDescriptor{{
+			NodeID:  roachpb.NodeID(1),
+			StoreID: store1ID,
+		}}
+	sp.mu.Unlock()
+
+	result, err := a.AllocateTarget(
+		simpleZoneConfig.Constraints,
+		[]roachpb.ReplicaDescriptor{},
+		firstRange,
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Node.NodeID != 2 || result.StoreID != 2 {
+		t.Errorf("expected NodeID 2 and StoreID 2: %+v", result)
+	}
+}
+
 func TestAllocatorNoAvailableDisks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper, _, _, a, _ := createTestAllocator()
 	defer stopper.Stop()
-	result, err := a.AllocateTarget(simpleZoneConfig.Constraints, []roachpb.ReplicaDescriptor{}, false)
+	result, err := a.AllocateTarget(
+		simpleZoneConfig.Constraints,
+		[]roachpb.ReplicaDescriptor{},
+		firstRange,
+		false,
+	)
 	if result != nil {
 		t.Errorf("expected nil result: %+v", result)
 	}
@@ -239,14 +284,24 @@ func TestAllocatorTwoDatacenters(t *testing.T) {
 	stopper, g, _, a, _ := createTestAllocator()
 	defer stopper.Stop()
 	gossiputil.NewStoreGossiper(g).GossipStores(multiDCStores, t)
-	result1, err := a.AllocateTarget(multiDCConfig.Constraints, []roachpb.ReplicaDescriptor{}, false)
+	result1, err := a.AllocateTarget(
+		multiDCConfig.Constraints,
+		[]roachpb.ReplicaDescriptor{},
+		firstRange,
+		false,
+	)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %v", err)
 	}
-	result2, err := a.AllocateTarget(multiDCConfig.Constraints, []roachpb.ReplicaDescriptor{{
-		NodeID:  result1.Node.NodeID,
-		StoreID: result1.StoreID,
-	}}, false)
+	result2, err := a.AllocateTarget(
+		multiDCConfig.Constraints,
+		[]roachpb.ReplicaDescriptor{{
+			NodeID:  result1.Node.NodeID,
+			StoreID: result1.StoreID,
+		}},
+		firstRange,
+		false,
+	)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %v", err)
 	}
@@ -256,16 +311,21 @@ func TestAllocatorTwoDatacenters(t *testing.T) {
 		t.Errorf("Expected nodes %+v: %+v vs %+v", expected, result1.Node, result2.Node)
 	}
 	// Verify that no result is forthcoming if we already have a replica.
-	result3, err := a.AllocateTarget(multiDCConfig.Constraints, []roachpb.ReplicaDescriptor{
-		{
-			NodeID:  result1.Node.NodeID,
-			StoreID: result1.StoreID,
+	result3, err := a.AllocateTarget(
+		multiDCConfig.Constraints,
+		[]roachpb.ReplicaDescriptor{
+			{
+				NodeID:  result1.Node.NodeID,
+				StoreID: result1.StoreID,
+			},
+			{
+				NodeID:  result2.Node.NodeID,
+				StoreID: result2.StoreID,
+			},
 		},
-		{
-			NodeID:  result2.Node.NodeID,
-			StoreID: result2.StoreID,
-		},
-	}, false)
+		firstRange,
+		false,
+	)
 	if err == nil {
 		t.Errorf("expected error on allocation without available stores: %+v", result3)
 	}
@@ -288,7 +348,10 @@ func TestAllocatorExistingReplica(t *testing.T) {
 				NodeID:  2,
 				StoreID: 2,
 			},
-		}, false)
+		},
+		firstRange,
+		false,
+	)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %v", err)
 	}
@@ -338,7 +401,12 @@ func TestAllocatorRelaxConstraints(t *testing.T) {
 			existing = append(existing, roachpb.ReplicaDescriptor{NodeID: roachpb.NodeID(id), StoreID: roachpb.StoreID(id)})
 		}
 		constraints := config.Constraints{Constraints: test.required}
-		result, err := a.AllocateTarget(constraints, existing, test.relaxConstraints)
+		result, err := a.AllocateTarget(
+			constraints,
+			existing,
+			firstRange,
+			test.relaxConstraints,
+		)
 		if haveErr := (err != nil); haveErr != test.expErr {
 			t.Errorf("%d: expected error %t; got %t: %s", i, test.expErr, haveErr, err)
 		} else if err == nil && roachpb.StoreID(test.expID) != result.StoreID {
@@ -400,7 +468,12 @@ func TestAllocatorRebalance(t *testing.T) {
 
 	// Every rebalance target must be either stores 1 or 2.
 	for i := 0; i < 10; i++ {
-		result := a.RebalanceTarget(config.Constraints{}, []roachpb.ReplicaDescriptor{{StoreID: 3}}, 0)
+		result := a.RebalanceTarget(
+			config.Constraints{},
+			[]roachpb.ReplicaDescriptor{{StoreID: 3}},
+			noStore,
+			firstRange,
+		)
 		if result == nil {
 			t.Fatal("nil result")
 		}
@@ -416,7 +489,11 @@ func TestAllocatorRebalance(t *testing.T) {
 		if !ok {
 			t.Fatalf("%d: unable to get store %d descriptor", i, store.StoreID)
 		}
-		sl, _, _ := a.storePool.getStoreList(config.Constraints{}, true)
+		sl, _, _ := a.storePool.getStoreList(
+			config.Constraints{},
+			firstRange,
+			true,
+		)
 		result := a.shouldRebalance(desc, sl)
 		if expResult := (i >= 2); expResult != result {
 			t.Errorf("%d: expected rebalance %t; got %t", i, expResult, result)
@@ -523,7 +600,11 @@ func TestAllocatorRebalanceThrashing(t *testing.T) {
 
 		// Ensure gossiped store descriptor changes have propagated.
 		util.SucceedsSoon(t, func() error {
-			sl, _, _ := a.storePool.getStoreList(config.Constraints{}, true)
+			sl, _, _ := a.storePool.getStoreList(
+				config.Constraints{},
+				firstRange,
+				true,
+			)
 			for j, s := range sl.stores {
 				if a, e := s.Capacity.RangeCount, tc[j].rangeCount; a != e {
 					return errors.Errorf("tc %d: range count for %d = %d != expected %d", i, j, a, e)
@@ -531,7 +612,11 @@ func TestAllocatorRebalanceThrashing(t *testing.T) {
 			}
 			return nil
 		})
-		sl, _, _ := a.storePool.getStoreList(config.Constraints{}, true)
+		sl, _, _ := a.storePool.getStoreList(
+			config.Constraints{},
+			firstRange,
+			true,
+		)
 
 		// Verify shouldRebalance returns the expected value.
 		for j, store := range stores {
@@ -581,7 +666,12 @@ func TestAllocatorRebalanceByCount(t *testing.T) {
 
 	// Every rebalance target must be store 4 (or nil for case of missing the only option).
 	for i := 0; i < 10; i++ {
-		result := a.RebalanceTarget(config.Constraints{}, []roachpb.ReplicaDescriptor{{StoreID: 1}}, 0)
+		result := a.RebalanceTarget(
+			config.Constraints{},
+			[]roachpb.ReplicaDescriptor{{StoreID: stores[0].StoreID}},
+			stores[0].StoreID,
+			firstRange,
+		)
 		if result != nil && result.StoreID != 4 {
 			t.Errorf("expected store 4; got %d", result.StoreID)
 		}
@@ -594,7 +684,11 @@ func TestAllocatorRebalanceByCount(t *testing.T) {
 		if !ok {
 			t.Fatalf("%d: unable to get store %d descriptor", i, store.StoreID)
 		}
-		sl, _, _ := a.storePool.getStoreList(config.Constraints{}, true)
+		sl, _, _ := a.storePool.getStoreList(
+			config.Constraints{},
+			firstRange,
+			true,
+		)
 		result := a.shouldRebalance(desc, sl)
 		if expResult := (i < 3); expResult != result {
 			t.Errorf("%d: expected rebalance %t; got %t", i, expResult, result)
@@ -1100,7 +1194,9 @@ func TestAllocatorThrottled(t *testing.T) {
 	_, err := a.AllocateTarget(
 		simpleZoneConfig.Constraints,
 		[]roachpb.ReplicaDescriptor{},
-		false)
+		firstRange,
+		false,
+	)
 	if _, ok := err.(purgatoryError); !ok {
 		t.Fatalf("expected a purgatory error, got: %v", err)
 	}
@@ -1110,7 +1206,9 @@ func TestAllocatorThrottled(t *testing.T) {
 	result, err := a.AllocateTarget(
 		simpleZoneConfig.Constraints,
 		[]roachpb.ReplicaDescriptor{},
-		false)
+		firstRange,
+		false,
+	)
 	if err != nil {
 		t.Fatalf("unable to perform allocation: %v", err)
 	}
@@ -1130,7 +1228,9 @@ func TestAllocatorThrottled(t *testing.T) {
 	_, err = a.AllocateTarget(
 		simpleZoneConfig.Constraints,
 		[]roachpb.ReplicaDescriptor{},
-		false)
+		firstRange,
+		false,
+	)
 	if _, ok := err.(purgatoryError); ok {
 		t.Fatalf("expected a non purgatory error, got: %v", err)
 	}
@@ -1210,7 +1310,9 @@ func Example_rebalancing() {
 			target := alloc.RebalanceTarget(
 				config.Constraints{},
 				[]roachpb.ReplicaDescriptor{{NodeID: ts.Node.NodeID, StoreID: ts.StoreID}},
-				-1)
+				noStore,
+				firstRange,
+			)
 			if target != nil {
 				testStores[j].rebalance(&testStores[int(target.StoreID)], alloc.randGen.Int63n(1<<20))
 			}

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -802,10 +802,8 @@ func TestStoreRangeUpReplicate(t *testing.T) {
 
 // TestStoreRangeCorruptionChangeReplicas verifies that the replication queue
 // will notice corrupted replicas and replace them.
-// TODO(bram): #8664 There's some flakiness in this test when stressed.
 func TestStoreRangeCorruptionChangeReplicas(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skipf("#8664: flaky")
 
 	const numReplicas = 3
 	const extraStores = 3
@@ -837,7 +835,6 @@ func TestStoreRangeCorruptionChangeReplicas(t *testing.T) {
 	mtc.Start(t, numReplicas+extraStores)
 	defer mtc.Stop()
 	mtc.initGossipNetwork()
-
 	store0 := mtc.stores[0]
 
 	for i := 0; i < extraStores; i++ {
@@ -879,6 +876,7 @@ func TestStoreRangeCorruptionChangeReplicas(t *testing.T) {
 		if _, err := client.SendWrapped(context.Background(), rg1(store0), &args); err != nil {
 			t.Fatal(err)
 		}
+
 		// Wait until maybeSetCorrupt has been called. This isn't called immediately
 		// since the put command has quorum with the other good node.
 		util.SucceedsSoon(t, func() error {

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -405,6 +405,7 @@ func (m *multiTestContext) initGossipNetwork() {
 		for i := 0; i < len(m.stores); i++ {
 			_, alive, _ := m.storePools[i].GetStoreList(
 				config.Constraints{},
+				roachpb.RangeID(0),
 				/* deterministic */ false,
 			)
 			if alive != len(m.stores) {

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -201,9 +201,9 @@ func (r *Replica) GetTimestampCacheLowWater() hlc.Timestamp {
 
 // GetStoreList is the same function as GetStoreList exposed for tests only.
 func (sp *StorePool) GetStoreList(
-	constraints config.Constraints, deterministic bool,
+	constraints config.Constraints, rangeID roachpb.RangeID, deterministic bool,
 ) (StoreList, int, int) {
-	return sp.getStoreList(constraints, deterministic)
+	return sp.getStoreList(constraints, rangeID, deterministic)
 }
 
 // IsQuiescent returns whether the replica is quiescent or not.

--- a/pkg/storage/simulation/range.go
+++ b/pkg/storage/simulation/range.go
@@ -114,7 +114,12 @@ func (r *Range) splitRange(originalRange *Range) {
 // getAllocateTarget queries the allocator for the store that would be the best
 // candidate to take on a new replica.
 func (r *Range) getAllocateTarget() (roachpb.StoreID, error) {
-	newStore, err := r.allocator.AllocateTarget(r.zone.Constraints, r.desc.Replicas, true)
+	newStore, err := r.allocator.AllocateTarget(
+		r.zone.Constraints,
+		r.desc.Replicas,
+		r.desc.RangeID,
+		true,
+	)
 	if err != nil {
 		return 0, err
 	}
@@ -137,7 +142,12 @@ func (r *Range) getRemoveTarget() (roachpb.StoreID, error) {
 // candidate to add a replica for rebalancing. Returns true only if a target is
 // found.
 func (r *Range) getRebalanceTarget(storeID roachpb.StoreID) (roachpb.StoreID, bool) {
-	rebalanceTarget := r.allocator.RebalanceTarget(r.zone.Constraints, r.desc.Replicas, storeID)
+	rebalanceTarget := r.allocator.RebalanceTarget(
+		r.zone.Constraints,
+		r.desc.Replicas,
+		storeID,
+		r.desc.RangeID,
+	)
 	if rebalanceTarget == nil {
 		return 0, false
 	}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2031,30 +2031,37 @@ func (s *Store) Descriptor() (*roachpb.StoreDescriptor, error) {
 	}, nil
 }
 
+// deadReplicas returns a list of all the dead replicas on the store.
 func (s *Store) deadReplicas() roachpb.StoreDeadReplicas {
-	sid := s.StoreID()
+	// We can't use a storeReplicaVisitor here as it skips destroyed replicas.
+	// Similar to in the storeReplicaVisitor, make a copy of the current
+	// replicas to iterate over so we don't have to hold the store lock during
+	// processing.
+	// TODO(bram): does this need to visit all the stores? Could we just use the
+	// store pool to locate any dead replicas on this store directly?
+	s.mu.Lock()
+	replicas := make([]*Replica, 0, len(s.mu.replicas))
+	for _, repl := range s.mu.replicas {
+		replicas = append(replicas, repl)
+	}
+	s.mu.Unlock()
 
 	var deadReplicas []roachpb.ReplicaIdent
-	newStoreReplicaVisitor(s).Visit(func(r *Replica) bool {
+	for _, r := range replicas {
 		r.mu.Lock()
 		destroyed := r.mu.destroyed
+		desc := r.mu.state.Desc
 		r.mu.Unlock()
-		desc := r.Desc()
-		replicaDesc, ok := desc.GetReplicaDescriptor(sid)
+		replicaDesc, ok := desc.GetReplicaDescriptor(s.Ident.StoreID)
 		if ok && destroyed != nil {
 			deadReplicas = append(deadReplicas, roachpb.ReplicaIdent{
 				RangeID: desc.RangeID,
-				Replica: roachpb.ReplicaDescriptor{
-					NodeID:    s.Ident.NodeID,
-					StoreID:   sid,
-					ReplicaID: replicaDesc.ReplicaID,
-				},
+				Replica: replicaDesc,
 			})
 		}
-		return true // more
-	})
+	}
 	return roachpb.StoreDeadReplicas{
-		StoreID:  s.StoreID(),
+		StoreID:  s.Ident.StoreID,
 		Replicas: deadReplicas,
 	}
 }


### PR DESCRIPTION
2 commits:
1. fixes storepool.deadReplicas()
2. ensures that storeList won't assign a new replica to replace a currently dead(corrupt) one on a store

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10141)

<!-- Reviewable:end -->
