### PR TITLE
sql: Walk now walks subexpressions in window definition

### DIFF
--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -315,6 +315,16 @@ func (expr *FuncExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, erro
 			expr.Name, expr.Name, strings.Join(typeNames, ", "), desStr)
 	}
 
+	if expr.WindowDef != nil {
+		for i, partition := range expr.WindowDef.Partitions {
+			typedPartition, err := partition.TypeCheck(ctx, NoTypePreference)
+			if err != nil {
+				return nil, err
+			}
+			expr.WindowDef.Partitions[i] = typedPartition
+		}
+	}
+
 	builtin := fn.(Builtin)
 	if expr.IsWindowFunctionApplication() {
 		// Make sure the window function application is of either a built-in window

--- a/pkg/sql/parser/walk.go
+++ b/pkg/sql/parser/walk.go
@@ -135,7 +135,7 @@ func (expr *AnnotateTypeExpr) Walk(v Visitor) Expr {
 // CopyNode makes a copy of this Expr without recursing in any child Exprs.
 func (expr *CoalesceExpr) CopyNode() *CoalesceExpr {
 	exprCopy := *expr
-	exprCopy.Exprs = Exprs(append([]Expr(nil), exprCopy.Exprs...))
+	exprCopy.Exprs = append(Exprs(nil), exprCopy.Exprs...)
 	return &exprCopy
 }
 
@@ -181,9 +181,9 @@ func (expr *ExistsExpr) Walk(v Visitor) Expr {
 // CopyNode makes a copy of this Expr without recursing in any child Exprs.
 func (expr *FuncExpr) CopyNode() *FuncExpr {
 	exprCopy := *expr
-	exprCopy.Exprs = Exprs(append([]Expr(nil), exprCopy.Exprs...))
+	exprCopy.Exprs = append(Exprs(nil), exprCopy.Exprs...)
 	if windowDef := exprCopy.WindowDef; windowDef != nil {
-		windowDef.Partitions = Exprs(append([]Expr(nil), windowDef.Partitions...))
+		windowDef.Partitions = append(Exprs(nil), windowDef.Partitions...)
 	}
 	return &exprCopy
 }
@@ -463,7 +463,7 @@ func (stmt *Delete) CopyNode() *Delete {
 		wCopy := *stmt.Where
 		stmtCopy.Where = &wCopy
 	}
-	stmtCopy.Returning = ReturningExprs(append([]SelectExpr(nil), stmt.Returning...))
+	stmtCopy.Returning = append(ReturningExprs(nil), stmt.Returning...)
 	return &stmtCopy
 }
 
@@ -509,7 +509,7 @@ func (stmt *Explain) WalkStmt(v Visitor) Statement {
 // CopyNode makes a copy of this Expr without recursing in any child Exprs.
 func (stmt *Insert) CopyNode() *Insert {
 	stmtCopy := *stmt
-	stmtCopy.Returning = ReturningExprs(append([]SelectExpr(nil), stmt.Returning...))
+	stmtCopy.Returning = append(ReturningExprs(nil), stmt.Returning...)
 	return &stmtCopy
 }
 
@@ -612,16 +612,16 @@ func (stmt *Select) WalkStmt(v Visitor) Statement {
 // CopyNode makes a copy of this Expr without recursing in any child Exprs.
 func (stmt *SelectClause) CopyNode() *SelectClause {
 	stmtCopy := *stmt
-	stmtCopy.Exprs = SelectExprs(append([]SelectExpr(nil), stmt.Exprs...))
+	stmtCopy.Exprs = append(SelectExprs(nil), stmt.Exprs...)
 	stmtCopy.From = &From{
-		Tables: TableExprs(append([]TableExpr(nil), stmt.From.Tables...)),
+		Tables: append(TableExprs(nil), stmt.From.Tables...),
 		AsOf:   stmt.From.AsOf,
 	}
 	if stmt.Where != nil {
 		wCopy := *stmt.Where
 		stmtCopy.Where = &wCopy
 	}
-	stmtCopy.GroupBy = GroupBy(append([]Expr(nil), stmt.GroupBy...))
+	stmtCopy.GroupBy = append(GroupBy(nil), stmt.GroupBy...)
 	if stmt.Having != nil {
 		hCopy := *stmt.Having
 		stmtCopy.Having = &hCopy
@@ -709,7 +709,7 @@ func (stmt *SelectClause) WalkStmt(v Visitor) Statement {
 // CopyNode makes a copy of this Expr without recursing in any child Exprs.
 func (stmt *Set) CopyNode() *Set {
 	stmtCopy := *stmt
-	stmtCopy.Values = Exprs(append([]Expr(nil), stmt.Values...))
+	stmtCopy.Values = append(Exprs(nil), stmt.Values...)
 	return &stmtCopy
 }
 
@@ -731,7 +731,7 @@ func (stmt *Set) WalkStmt(v Visitor) Statement {
 // CopyNode makes a copy of this Expr without recursing in any child Exprs.
 func (stmt *Update) CopyNode() *Update {
 	stmtCopy := *stmt
-	stmtCopy.Exprs = UpdateExprs(make([]*UpdateExpr, len(stmt.Exprs)))
+	stmtCopy.Exprs = make(UpdateExprs, len(stmt.Exprs))
 	for i, e := range stmt.Exprs {
 		eCopy := *e
 		stmtCopy.Exprs[i] = &eCopy
@@ -740,7 +740,7 @@ func (stmt *Update) CopyNode() *Update {
 		wCopy := *stmt.Where
 		stmtCopy.Where = &wCopy
 	}
-	stmtCopy.Returning = ReturningExprs(append([]SelectExpr(nil), stmt.Returning...))
+	stmtCopy.Returning = append(ReturningExprs(nil), stmt.Returning...)
 	return &stmtCopy
 }
 

--- a/pkg/sql/select_name_resolution.go
+++ b/pkg/sql/select_name_resolution.go
@@ -116,7 +116,7 @@ func (v *nameResolutionVisitor) VisitPre(expr parser.Expr) (recurse bool, newNod
 
 			t = t.CopyNode()
 			t.Exprs[0] = parser.StarDatumInstance
-			return false, t
+			return true, t
 		}
 		return true, t
 

--- a/pkg/sql/testdata/window
+++ b/pkg/sql/testdata/window
@@ -479,6 +479,24 @@ EXPLAIN (TYPES) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) 
 3  render/filter  render 4                   (v)[int]
 4  scan           result                     (k int, v int, w int, f float, d decimal, s string, b bool)
 
+query ITTT
+EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
+----
+0  select         result                                         (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)
+1  sort           result                                         (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)
+2  window         result                                         (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal, "variance(d) OVER (PARTITION BY v, 100)" decimal)
+2  window         render stddev(d) OVER (PARTITION BY v, 'a')    (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
+2  window         render variance(d) OVER (PARTITION BY v, 100)  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]
+3  render/filter  result                                         (k int, d decimal, d decimal, v int, "'a'" string, v int, "100" int)
+3  render/filter  render 0                                       (k)[int]
+3  render/filter  render 1                                       (d)[decimal]
+3  render/filter  render 2                                       (d)[decimal]
+3  render/filter  render 3                                       (v)[int]
+3  render/filter  render 4                                       ('a')[string]
+3  render/filter  render 5                                       (v)[int]
+3  render/filter  render 6                                       (100)[int]
+4  scan           result                                         (k int, v int, w int, f float, d decimal, s string, b bool)
+
 statement OK
 INSERT INTO kv VALUES
 (9, 2, 9, .1, DEFAULT, DEFAULT, DEFAULT),


### PR DESCRIPTION
I realized this was missing while reviewing #10146.

This fixes `EXPLAIN (TYPES)` for Window functions with `PARTITION BY`
expressions. Previously this was working because we would move all subexpressions
from the `windowDef` into individual renders on a `selectNode`, which meant that type
checking wasn't strictly necessary. However, for EXPLAIN (TYPES) to work, this is needed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10161)

<!-- Reviewable:end -->
