### PR TITLE
server,storage: eager campaign after cluster bootstrap

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1360,12 +1360,16 @@ func (s *Store) Bootstrap(ident roachpb.StoreIdent, stopper *stop.Stopper) error
 		return err
 	}
 
-	// If we're bootstrapping the store we can campaign idle replicas
-	// immediately. This primarily affects tests.
+	s.NotifyBootstrapped()
+	return nil
+}
+
+// NotifyBootstrapped tells the store that it was bootstrapped and allows idle
+// replicas to campaign immediately. This primarily affects tests.
+func (s *Store) NotifyBootstrapped() {
 	s.idleReplicaElectionTime.Lock()
 	s.idleReplicaElectionTime.at = s.Clock().PhysicalTime()
 	s.idleReplicaElectionTime.Unlock()
-	return nil
 }
 
 // GetReplica fetches a replica by Range ID. Returns an error if no replica is found.


### PR DESCRIPTION
Extend the change in #9550 to allow eagerly campaigning replicas after
startup to include clusters created via TestCluster.

Fixes #10160

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10162)

<!-- Reviewable:end -->
