### PR TITLE
server, storage, sql, gossip: use a shared NodeIDContainer

### DIFF
--- a/pkg/base/node_id.go
+++ b/pkg/base/node_id.go
@@ -1,0 +1,72 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package base
+
+import (
+	"strconv"
+	"sync/atomic"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// NodeIDContainer is used to share a single roachpb.NodeID instance between
+// multiple layers. It allows setting and getting the value. Once a value is
+// set, the value cannot change.
+type NodeIDContainer struct {
+	noCopy util.NoCopy
+
+	// nodeID is atomically updated under the mutex; it can be read atomically
+	// without the mutex.
+	nodeID int32
+}
+
+// String returns the node ID, or "?" if it is unset.
+func (n *NodeIDContainer) String() string {
+	val := n.Get()
+	if val == 0 {
+		return "?"
+	}
+	return strconv.Itoa(int(val))
+}
+
+// Get returns the current node ID; 0 if it is unset.
+func (n *NodeIDContainer) Get() roachpb.NodeID {
+	return roachpb.NodeID(atomic.LoadInt32(&n.nodeID))
+}
+
+// Set sets the current node ID. If it is already set, the value must match.
+func (n *NodeIDContainer) Set(ctx context.Context, val roachpb.NodeID) {
+	if val <= 0 {
+		log.Fatalf(ctx, "trying to set invalid NodeID: %d", val)
+	}
+	oldVal := atomic.SwapInt32(&n.nodeID, int32(val))
+	if oldVal == 0 {
+		log.Infof(ctx, "NodeID set to %d", val)
+	} else if oldVal != int32(val) {
+		log.Fatalf(ctx, "different NodeIDs set: %d, then %d", oldVal, val)
+	}
+}
+
+// Reset changes the NodeID regardless of the old value. Can only be used from
+// testing code.
+func (n *NodeIDContainer) Reset(_ util.Tester, val roachpb.NodeID) {
+	atomic.StoreInt32(&n.nodeID, int32(val))
+}

--- a/pkg/base/node_id_test.go
+++ b/pkg/base/node_id_test.go
@@ -1,0 +1,55 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package base_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"golang.org/x/net/context"
+)
+
+func TestNodeIDContainer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	n := &base.NodeIDContainer{}
+
+	if val := n.Get(); val != 0 {
+		t.Errorf("initial value should be 0, not %d", val)
+	}
+	if str := n.String(); str != "?" {
+		t.Errorf("initial string should be ?, not %s", str)
+	}
+
+	for i := 0; i < 2; i++ {
+		n.Set(context.TODO(), 5)
+		if val := n.Get(); val != 5 {
+			t.Errorf("value should be 5, not %d", val)
+		}
+		if str := n.String(); str != "5" {
+			t.Errorf("string should be 5, not %s", str)
+		}
+	}
+
+	n.Reset(t, 6)
+	if val := n.Get(); val != 6 {
+		t.Errorf("value should be 6, not %d", val)
+	}
+	if str := n.String(); str != "6" {
+		t.Errorf("string should be 6, not %s", str)
+	}
+}

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1037,7 +1037,7 @@ func checkNodeStatus(t *testing.T, c cliTest, output string, start time.Time) {
 		t.Fatalf("%s", err)
 	}
 
-	nodeID := c.Gossip().GetNodeID()
+	nodeID := c.Gossip().NodeID.Get()
 	nodeIDStr := strconv.FormatInt(int64(nodeID), 10)
 	if a, e := fields[0], nodeIDStr; a != e {
 		t.Errorf("node id (%s) != expected (%s)", a, e)

--- a/pkg/cmd/gossipsim/main.go
+++ b/pkg/cmd/gossipsim/main.go
@@ -167,8 +167,8 @@ func outputDotFile(
 		node := simNode.Gossip
 		incoming := node.Incoming()
 		for _, iNode := range incoming {
-			e := edge{dest: node.GetNodeID()}
-			key := fmt.Sprintf("%d:%d", iNode, node.GetNodeID())
+			e := edge{dest: node.NodeID.Get()}
+			key := fmt.Sprintf("%d:%d", iNode, node.NodeID.Get())
 			if _, ok := edgeSet[key]; !ok {
 				e.added = true
 				quiescent = false
@@ -207,7 +207,7 @@ func outputDotFile(
 			infoKey := otherNode.Addr().String()
 			// GetInfo returns an error if the info is missing.
 			if info, err := node.GetInfo(infoKey); err != nil {
-				missing = append(missing, otherNode.Gossip.GetNodeID())
+				missing = append(missing, otherNode.Gossip.NodeID.Get())
 				quiescent = false
 			} else {
 				_, val, err := encoding.DecodeUint64Ascending(info)
@@ -217,7 +217,7 @@ func outputDotFile(
 				totalAge += int64(cycle) - int64(val)
 			}
 		}
-		log.Infof(context.TODO(), "node %d: missing infos for nodes %s", node.GetNodeID(), missing)
+		log.Infof(context.TODO(), "node %d: missing infos for nodes %s", node.NodeID.Get(), missing)
 
 		var sentinelAge int64
 		// GetInfo returns an error if the info is missing.
@@ -244,8 +244,8 @@ func outputDotFile(
 				(maxDotFontSize-minDotFontSize))/float64(maxIncoming)))
 		}
 		fmt.Fprintf(f, "\t%s [%sfontsize=%d,label=\"{%s|AA=%s, MH=%d, SA=%d}\"]\n",
-			node.GetNodeID(), nodeColor, fontSize, node.GetNodeID(), age, node.MaxHops(), sentinelAge)
-		outgoing := outgoingMap[node.GetNodeID()]
+			node.NodeID.Get(), nodeColor, fontSize, node.NodeID.Get(), age, node.MaxHops(), sentinelAge)
+		outgoing := outgoingMap[node.NodeID.Get()]
 		for _, e := range outgoing {
 			destSimNode, ok := network.GetNodeFromID(e.dest)
 			if !ok {
@@ -258,9 +258,9 @@ func outputDotFile(
 			} else if e.deleted {
 				style = " [color=red,style=dotted]"
 			}
-			fmt.Fprintf(f, "\t%s -> %s%s\n", node.GetNodeID(), dest.GetNodeID(), style)
+			fmt.Fprintf(f, "\t%s -> %s%s\n", node.NodeID.Get(), dest.NodeID.Get(), style)
 			if !e.deleted {
-				edgeSet[fmt.Sprintf("%d:%d", node.GetNodeID(), e.dest)] = e
+				edgeSet[fmt.Sprintf("%d:%d", node.NodeID.Get(), e.dest)] = e
 			}
 		}
 	}

--- a/pkg/gossip/client.go
+++ b/pkg/gossip/client.go
@@ -188,15 +188,9 @@ func (c *client) sendGossip(g *Gossip, stream Gossip_GossipClient) error {
 		if log.V(1) {
 			ctx := c.AnnotateCtx(stream.Context())
 			if c.peerID != 0 {
-				log.Infof(
-					ctx, "node %d: sending %s to node %d (%s)",
-					g.mu.is.NodeID, extractKeys(args.Delta), c.peerID, c.addr,
-				)
+				log.Infof(ctx, "sending %s to node %d (%s)", extractKeys(args.Delta), c.peerID, c.addr)
 			} else {
-				log.Infof(
-					ctx, "node %d: sending %s to %s",
-					g.mu.is.NodeID, extractKeys(args.Delta), c.addr,
-				)
+				log.Infof(ctx, "sending %s to %s", extractKeys(args.Delta), c.addr)
 			}
 		}
 
@@ -224,11 +218,11 @@ func (c *client) handleResponse(ctx context.Context, g *Gossip, reply *Response)
 	if reply.Delta != nil {
 		freshCount, err := g.mu.is.combine(reply.Delta, reply.NodeID)
 		if err != nil {
-			log.Warningf(ctx, "node %d: failed to fully combine delta from node %d: %s", g.mu.is.NodeID, reply.NodeID, err)
+			log.Warningf(ctx, "failed to fully combine delta from node %d: %s", reply.NodeID, err)
 		}
 		if infoCount := len(reply.Delta); infoCount > 0 {
 			if log.V(1) {
-				log.Infof(ctx, "node %d: received %s from node %d (%d fresh)", g.mu.is.NodeID, extractKeys(reply.Delta), reply.NodeID, freshCount)
+				log.Infof(ctx, "received %s from node %d (%d fresh)", extractKeys(reply.Delta), reply.NodeID, freshCount)
 			}
 		}
 		g.maybeTightenLocked()

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -70,6 +70,7 @@ import (
 	"github.com/pkg/errors"
 	circuit "github.com/rubyist/circuitbreaker"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip/resolver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -196,8 +197,12 @@ type Gossip struct {
 }
 
 // New creates an instance of a gossip node.
+// The higher level manages the NodeIDContainer instance (which can be shared by
+// various server components). The ambient context is expected to already
+// contain the node ID.
 func New(
 	ambient log.AmbientContext,
+	nodeID *base.NodeIDContainer,
 	rpcContext *rpc.Context,
 	grpcServer *grpc.Server,
 	resolvers []resolver.Resolver,
@@ -206,7 +211,7 @@ func New(
 ) *Gossip {
 	ambient.SetEventLog("gossip", "gossip")
 	g := &Gossip{
-		server:            newServer(ambient, stopper, registry),
+		server:            newServer(ambient, nodeID, stopper, registry),
 		Connected:         make(chan struct{}),
 		rpcContext:        rpcContext,
 		outgoing:          makeNodeSet(minPeers, metric.NewGauge(MetaConnectionsOutgoingGauge)),
@@ -220,9 +225,7 @@ func New(
 		resolverAddrs:     map[util.UnresolvedAddr]resolver.Resolver{},
 		bootstrapAddrs:    map[util.UnresolvedAddr]struct{}{},
 	}
-	stopper.AddCloser(stop.CloserFn(func() {
-		g.server.AmbientContext.FinishEventLog()
-	}))
+	stopper.AddCloser(stop.CloserFn(g.server.AmbientContext.FinishEventLog))
 
 	registry.AddMetric(g.outgoing.gauge)
 	g.clientsMu.breakers = map[string]*circuit.Breaker{}
@@ -245,36 +248,29 @@ func New(
 	return g
 }
 
+// NewTest is a simplified wrapper around New that creates the NodeIDContainer
+// internally. Used for testing.
+func NewTest(
+	nodeID roachpb.NodeID,
+	rpcContext *rpc.Context,
+	grpcServer *grpc.Server,
+	resolvers []resolver.Resolver,
+	stopper *stop.Stopper,
+	registry *metric.Registry,
+) *Gossip {
+	n := &base.NodeIDContainer{}
+	var ac log.AmbientContext
+	ac.AddLogTag("n", n)
+	gossip := New(ac, n, rpcContext, grpcServer, resolvers, stopper, registry)
+	if nodeID != 0 {
+		n.Set(context.TODO(), nodeID)
+	}
+	return gossip
+}
+
 // GetNodeMetrics returns the gossip node metrics.
 func (g *Gossip) GetNodeMetrics() *Metrics {
 	return g.server.GetNodeMetrics()
-}
-
-// GetNodeID returns the instance's saved node ID.
-func (g *Gossip) GetNodeID() roachpb.NodeID {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	return g.mu.is.NodeID
-}
-
-// SetNodeID sets the infostore's node ID.
-func (g *Gossip) SetNodeID(nodeID roachpb.NodeID) {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	if g.mu.is.NodeID != 0 && g.mu.is.NodeID != nodeID {
-		panic(fmt.Sprintf("different node IDs were set for the same gossip instance (%d, %d)", g.mu.is.NodeID, nodeID))
-	}
-	g.mu.is.NodeID = nodeID
-	ctx := g.AnnotateCtx(context.TODO())
-	log.Infof(ctx, "NodeID set to %d", nodeID)
-}
-
-// ResetNodeID resets the infostore's node ID.
-// NOTE: use only from unittests.
-func (g *Gossip) ResetNodeID(nodeID roachpb.NodeID) {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	g.mu.is.NodeID = nodeID
 }
 
 // SetNodeDescriptor adds the node descriptor to the gossip network
@@ -906,7 +902,7 @@ func (g *Gossip) bootstrap() {
 				if !haveClients || !haveSentinel {
 					// Try to get another bootstrap address from the resolvers.
 					if addr := g.getNextBootstrapAddress(); addr != nil {
-						g.startClient(addr, g.mu.is.NodeID)
+						g.startClient(addr, g.NodeID.Get())
 					} else {
 						bootstrapAddrs := make([]string, 0, len(g.bootstrapping))
 						for addr := range g.bootstrapping {
@@ -1027,7 +1023,7 @@ func (g *Gossip) tightenNetwork(distantNodeID roachpb.NodeID) {
 		} else {
 			log.Infof(ctx, "starting client to distant node %d to tighten network graph", distantNodeID)
 			log.Eventf(ctx, "tightening network with new client to %s", nodeAddr)
-			g.startClient(nodeAddr, g.mu.is.NodeID)
+			g.startClient(nodeAddr, g.NodeID.Get())
 		}
 	}
 }
@@ -1039,7 +1035,7 @@ func (g *Gossip) doDisconnected(c *client) {
 
 	// If the client was disconnected with a forwarding address, connect now.
 	if c.forwardAddr != nil {
-		g.startClient(c.forwardAddr, g.mu.is.NodeID)
+		g.startClient(c.forwardAddr, g.NodeID.Get())
 	}
 	g.maybeSignalStatusChangeLocked()
 }

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1023,11 +1023,9 @@ func (g *Gossip) tightenNetwork(distantNodeID roachpb.NodeID) {
 	if g.outgoing.hasSpace() {
 		ctx := g.AnnotateCtx(context.TODO())
 		if nodeAddr, err := g.getNodeIDAddressLocked(distantNodeID); err != nil {
-			log.Errorf(ctx, "node %d: unable to get address for node %d: %s",
-				g.mu.is.NodeID, distantNodeID, err)
+			log.Errorf(ctx, "unable to get address for node %d: %s", distantNodeID, err)
 		} else {
-			log.Infof(ctx, "node %d: starting client to distant node %d to tighten network graph",
-				g.mu.is.NodeID, distantNodeID)
+			log.Infof(ctx, "starting client to distant node %d to tighten network graph", distantNodeID)
 			log.Eventf(ctx, "tightening network with new client to %s", nodeAddr)
 			g.startClient(nodeAddr, g.mu.is.NodeID)
 		}

--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -312,7 +312,7 @@ func (ds *DistSender) getNodeDescriptor() *roachpb.NodeDescriptor {
 		return nil
 	}
 
-	ownNodeID := ds.gossip.GetNodeID()
+	ownNodeID := ds.gossip.NodeID.Get()
 	if ownNodeID > 0 {
 		// TODO(tschottdorf): Consider instead adding the NodeID of the
 		// coordinator to the header, so we can get this from incoming

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -337,7 +337,7 @@ func TestSendRPCOrder(t *testing.T) {
 					Attrs: tc.attrs,
 				},
 			}
-			g.ResetNodeID(nd.NodeID)
+			g.NodeID.Reset(t, nd.NodeID)
 			if err := g.SetNodeDescriptor(nd); err != nil {
 				t.Fatal(err)
 			}
@@ -407,7 +407,7 @@ func TestOwnNodeCertain(t *testing.T) {
 		NodeID:  expNodeID,
 		Address: util.MakeUnresolvedAddr("tcp", "foobar:1234"),
 	}
-	g.ResetNodeID(nd.NodeID)
+	g.NodeID.Reset(t, nd.NodeID)
 	if err := g.SetNodeDescriptor(nd); err != nil {
 		t.Fatal(err)
 	}
@@ -584,9 +584,8 @@ func makeGossip(t *testing.T, stopper *stop.Stopper) *gossip.Gossip {
 	rpcContext := rpc.NewContext(log.AmbientContext{}, &base.Config{Insecure: true}, nil, stopper)
 	server := rpc.NewServer(rpcContext)
 
-	g := gossip.New(log.AmbientContext{}, rpcContext, server, nil, stopper, metric.NewRegistry())
 	const nodeID = 1
-	g.SetNodeID(nodeID)
+	g := gossip.NewTest(nodeID, rpcContext, server, nil, stopper, metric.NewRegistry())
 	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{
 		NodeID:  nodeID,
 		Address: util.MakeUnresolvedAddr("tcp", "neverused:9999"),
@@ -1018,7 +1017,7 @@ func TestGetNodeDescriptor(t *testing.T) {
 
 	g := makeGossip(t, stopper)
 	ds := NewDistSender(&DistSenderConfig{}, g)
-	g.ResetNodeID(5)
+	g.NodeID.Reset(t, 5)
 	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{NodeID: 5}); err != nil {
 		t.Fatal(err)
 	}
@@ -1883,7 +1882,7 @@ func TestSlowLeaseHolderRetry(t *testing.T) {
 	}
 
 	for _, node := range n.Nodes {
-		nodeID := node.Gossip.GetNodeID()
+		nodeID := node.Gossip.NodeID.Get()
 
 		metaRangeDescriptor.Replicas = append(metaRangeDescriptor.Replicas, roachpb.ReplicaDescriptor{NodeID: nodeID})
 		rangeDescriptor.Replicas = append(rangeDescriptor.Replicas, roachpb.ReplicaDescriptor{NodeID: nodeID})

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -373,11 +373,11 @@ func TestPriorityRatchetOnAbortOrPush(t *testing.T) {
 // uncertainty, which interferes with the tests. The feature is disabled simply
 // by poisoning the gossip NodeID; this may break other functionality which
 // is usually not relevant in uncertainty tests.
-func disableOwnNodeCertain(tc *localtestcluster.LocalTestCluster) {
+func disableOwnNodeCertain(t *testing.T, tc *localtestcluster.LocalTestCluster) {
 	distSender := tc.Sender.(*TxnCoordSender).wrapped.(*DistSender)
 	desc := distSender.getNodeDescriptor()
 	desc.NodeID = 999
-	distSender.gossip.ResetNodeID(desc.NodeID)
+	distSender.gossip.NodeID.Reset(t, desc.NodeID)
 	if err := distSender.gossip.SetNodeDescriptor(desc); err != nil {
 		panic(err)
 	}
@@ -389,7 +389,7 @@ func disableOwnNodeCertain(tc *localtestcluster.LocalTestCluster) {
 func TestUncertaintyRestart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _ := createTestDB(t)
-	disableOwnNodeCertain(s)
+	disableOwnNodeCertain(t, s)
 	defer s.Stop()
 	const maxOffset = 250 * time.Millisecond
 	s.Clock.SetMaxOffset(maxOffset)
@@ -439,7 +439,7 @@ func TestUncertaintyRestart(t *testing.T) {
 func TestUncertaintyMaxTimestampForwarding(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _ := createTestDB(t)
-	disableOwnNodeCertain(s)
+	disableOwnNodeCertain(t, s)
 	defer s.Stop()
 	// Large offset so that any value in the future is an uncertain read.
 	// Also makes sure that the values we write in the future below don't

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -314,8 +314,8 @@ func (n *Node) initNodeID(id roachpb.NodeID) {
 		if id == 0 {
 			log.Fatal(ctxWithSpan, "new node allocated illegal ID 0")
 		}
-		n.storeCfg.Gossip.SetNodeID(id)
 		span.Finish()
+		n.storeCfg.Gossip.NodeID.Set(ctx, id)
 	} else {
 		log.Infof(ctx, "node ID %d initialized", id)
 	}

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -122,7 +122,7 @@ func (s *statusServer) RegisterGateway(
 func (s *statusServer) parseNodeID(nodeIDParam string) (roachpb.NodeID, bool, error) {
 	// No parameter provided or set to local.
 	if len(nodeIDParam) == 0 || localRE.MatchString(nodeIDParam) {
-		return s.gossip.GetNodeID(), true, nil
+		return s.gossip.NodeID.Get(), true, nil
 	}
 
 	id, err := strconv.ParseInt(nodeIDParam, 10, 64)
@@ -130,7 +130,7 @@ func (s *statusServer) parseNodeID(nodeIDParam string) (roachpb.NodeID, bool, er
 		return 0, false, fmt.Errorf("node id could not be parsed: %s", err)
 	}
 	nodeID := roachpb.NodeID(id)
-	return nodeID, nodeID == s.gossip.GetNodeID(), nil
+	return nodeID, nodeID == s.gossip.NodeID.Get(), nil
 }
 
 func (s *statusServer) dialNode(nodeID roachpb.NodeID) (serverpb.StatusClient, error) {
@@ -177,10 +177,10 @@ func (s *statusServer) Details(
 	}
 	if local {
 		resp := &serverpb.DetailsResponse{
-			NodeID:    s.gossip.GetNodeID(),
+			NodeID:    s.gossip.NodeID.Get(),
 			BuildInfo: build.GetInfo(),
 		}
-		if addr, err := s.gossip.GetNodeIDAddress(s.gossip.GetNodeID()); err == nil {
+		if addr, err := s.gossip.GetNodeIDAddress(s.gossip.NodeID.Get()); err == nil {
 			resp.Address = *addr
 		}
 		return resp, nil

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -85,7 +85,7 @@ func TestStatusJson(t *testing.T) {
 	defer s.Stopper().Stop()
 	ts := s.(*TestServer)
 
-	nodeID := ts.Gossip().GetNodeID()
+	nodeID := ts.Gossip().NodeID.Get()
 	addr, err := ts.Gossip().GetNodeIDAddress(nodeID)
 	if err != nil {
 		t.Fatal(err)
@@ -406,7 +406,7 @@ func TestMetricsEndpoint(t *testing.T) {
 	s := startServer(t)
 	defer s.Stopper().Stop()
 
-	if _, err := getText(s, s.AdminURL()+statusPrefix+"metrics/"+s.Gossip().GetNodeID().String()); err != nil {
+	if _, err := getText(s, s.AdminURL()+statusPrefix+"metrics/"+s.Gossip().NodeID.String()); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -159,7 +158,6 @@ type ResultColumns []ResultColumn
 // An Executor executes SQL statements.
 // Executor is thread-safe.
 type Executor struct {
-	nodeID         roachpb.NodeID
 	cfg            ExecutorConfig
 	reCache        *parser.RegexpCache
 	virtualSchemas virtualSchemaHolder
@@ -197,6 +195,7 @@ type Executor struct {
 // a Executor; the rest will have sane defaults set if omitted.
 type ExecutorConfig struct {
 	AmbientCtx   log.AmbientContext
+	NodeID       *base.NodeIDContainer
 	DB           *client.DB
 	Gossip       *gossip.Gossip
 	LeaseManager *LeaseManager
@@ -306,13 +305,6 @@ func NewDummyExecutor() *Executor {
 // AnnotateCtx is a convenience wrapper; see AmbientContext.
 func (e *Executor) AnnotateCtx(ctx context.Context) context.Context {
 	return e.cfg.AmbientCtx.AnnotateCtx(ctx)
-}
-
-// SetNodeID sets the node ID for the SQL server. This method must be called
-// before actually using the Executor.
-func (e *Executor) SetNodeID(nodeID roachpb.NodeID) {
-	e.nodeID = nodeID
-	e.cfg.LeaseManager.nodeID = uint32(nodeID)
 }
 
 // updateSystemConfig is called whenever the system config gossip entry is updated.

--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	csql "github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -169,8 +170,10 @@ func (t *leaseTest) mustPublish(nodeID uint32, descID sqlbase.ID) {
 func (t *leaseTest) node(nodeID uint32) *csql.LeaseManager {
 	mgr := t.nodes[nodeID]
 	if mgr == nil {
+		nc := &base.NodeIDContainer{}
+		nc.Set(context.TODO(), roachpb.NodeID(nodeID))
 		mgr = csql.NewLeaseManager(
-			nodeID, *t.kvDB,
+			nc, *t.kvDB,
 			t.server.Clock(),
 			t.leaseManagerTestingKnobs,
 			t.server.Stopper(),

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -216,7 +216,7 @@ func (p *planner) resetForBatch(e *Executor) {
 	p.databaseCache = cache
 	p.session.TxnState.schemaChangers.curGroupNum++
 	p.resetContexts()
-	p.evalCtx.NodeID = e.nodeID
+	p.evalCtx.NodeID = e.cfg.NodeID.Get()
 	p.evalCtx.ReCache = e.reCache
 }
 

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -744,7 +744,7 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 					log.Info(context.TODO(), "received a new config")
 				}
 				schemaChanger := SchemaChanger{
-					nodeID:       roachpb.NodeID(s.leaseMgr.nodeID),
+					nodeID:       s.leaseMgr.nodeID.Get(),
 					db:           s.db,
 					leaseMgr:     s.leaseMgr,
 					testingKnobs: s.testingKnobs,

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -170,7 +170,7 @@ func TestSchemaChangeProcess(t *testing.T) {
 	var id = sqlbase.ID(keys.MaxReservedDescID + 2)
 	var node = roachpb.NodeID(2)
 	stopper := stop.NewStopper()
-	leaseMgr := csql.NewLeaseManager(0, *kvDB, hlc.NewClock(hlc.UnixNano), csql.LeaseManagerTestingKnobs{}, stopper)
+	leaseMgr := csql.NewLeaseManager(&base.NodeIDContainer{}, *kvDB, hlc.NewClock(hlc.UnixNano), csql.LeaseManagerTestingKnobs{}, stopper)
 	defer stopper.Stop()
 	changer := csql.NewSchemaChangerForTesting(id, 0, node, *kvDB, leaseMgr)
 

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -1171,8 +1171,7 @@ func TestReacquireLeaseOnRestart(t *testing.T) {
 					txn := args.Hdr.Txn
 					txn.ResetObservedTimestamps()
 					now := s.Clock().Now()
-					txn.UpdateObservedTimestamp(
-						s.(*server.TestServer).Gossip().GetNodeID(), now)
+					txn.UpdateObservedTimestamp(s.(*server.TestServer).Gossip().NodeID.Get(), now)
 					return roachpb.NewErrorWithTxn(roachpb.NewReadWithinUncertaintyIntervalError(now, now), txn)
 				}
 			}

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -1163,9 +1163,7 @@ func Example_rebalancing() {
 	// randomly adding / removing stores and adding bytes.
 	rpcContext := rpc.NewContext(log.AmbientContext{}, &base.Config{Insecure: true}, nil, stopper)
 	server := rpc.NewServer(rpcContext) // never started
-	g := gossip.New(log.AmbientContext{}, rpcContext, server, nil, stopper, metric.NewRegistry())
-	// Have to call g.SetNodeID before call g.AddInfo
-	g.SetNodeID(roachpb.NodeID(1))
+	g := gossip.NewTest(1, rpcContext, server, nil, stopper, metric.NewRegistry())
 	sp := NewStorePool(
 		log.AmbientContext{},
 		g,

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -162,7 +162,7 @@ func (nl *NodeLiveness) ManualHeartbeat() error {
 // method does a conditional put on the node liveness record, and if
 // successful, stores the updated liveness record in the nodes map.
 func (nl *NodeLiveness) heartbeat(ctx context.Context) error {
-	nodeID := nl.gossip.GetNodeID()
+	nodeID := nl.gossip.NodeID.Get()
 
 	var newLiveness Liveness
 	var oldLiveness *Liveness
@@ -209,7 +209,7 @@ func (nl *NodeLiveness) heartbeat(ctx context.Context) error {
 func (nl *NodeLiveness) Self() (Liveness, error) {
 	nl.mu.Lock()
 	defer nl.mu.Unlock()
-	return nl.getLivenessLocked(nl.gossip.GetNodeID())
+	return nl.getLivenessLocked(nl.gossip.NodeID.Get())
 }
 
 // GetLiveness returns the liveness record for the specified nodeID.

--- a/pkg/storage/raft_transport_test.go
+++ b/pkg/storage/raft_transport_test.go
@@ -105,9 +105,9 @@ func newRaftTransportTestContext(t testing.TB) *raftTransportTestContext {
 		log.AmbientContext{}, testutils.NewNodeTestBaseContext(), nil, rttc.stopper,
 	)
 	server := rpc.NewServer(rttc.nodeRPCContext) // never started
-	rttc.gossip = gossip.New(
-		log.AmbientContext{}, rttc.nodeRPCContext, server, nil, rttc.stopper, metric.NewRegistry())
-	rttc.gossip.SetNodeID(1)
+	rttc.gossip = gossip.NewTest(
+		1, rttc.nodeRPCContext, server, nil, rttc.stopper, metric.NewRegistry(),
+	)
 	return rttc
 }
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -148,9 +148,7 @@ func (tc *testContext) StartWithStoreConfig(t testing.TB, cfg StoreConfig) {
 	if tc.gossip == nil {
 		rpcContext := rpc.NewContext(cfg.AmbientCtx, &base.Config{Insecure: true}, nil, tc.stopper)
 		server := rpc.NewServer(rpcContext) // never started
-		tc.gossip = gossip.New(
-			cfg.AmbientCtx, rpcContext, server, nil, tc.stopper, metric.NewRegistry())
-		tc.gossip.SetNodeID(1)
+		tc.gossip = gossip.NewTest(1, rpcContext, server, nil, tc.stopper, metric.NewRegistry())
 	}
 	if tc.manualClock == nil {
 		tc.manualClock = hlc.NewManualClock(0)

--- a/pkg/storage/simulation/cluster.go
+++ b/pkg/storage/simulation/cluster.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math"
 	"math/rand"
 	"sort"
 	"text/tabwriter"
@@ -78,10 +79,9 @@ func createCluster(
 	clock := hlc.NewClock(hlc.UnixNano)
 	rpcContext := rpc.NewContext(log.AmbientContext{}, &base.Config{Insecure: true}, clock, stopper)
 	server := rpc.NewServer(rpcContext)
-	g := gossip.New(log.AmbientContext{}, rpcContext, server, nil, stopper, metric.NewRegistry())
-	// NodeID is required for Gossip, so set it to -1 for the cluster Gossip
-	// instance to prevent conflicts with real NodeIDs.
-	g.SetNodeID(-1)
+	// We set the node ID to MaxInt32 for the cluster Gossip instance to prevent
+	// conflicts with real node IDs.
+	g := gossip.NewTest(math.MaxInt32, rpcContext, server, nil, stopper, metric.NewRegistry())
 	storePool := storage.NewStorePool(
 		log.AmbientContext{},
 		g,

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -935,7 +935,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	}
 	// Always set gossip NodeID before gossiping any info.
 	if s.cfg.Gossip != nil {
-		s.cfg.Gossip.SetNodeID(s.Ident.NodeID)
+		s.cfg.Gossip.NodeID.Set(ctx, s.Ident.NodeID)
 	}
 
 	// Set the store ID for logging.

--- a/pkg/storage/store_pool_test.go
+++ b/pkg/storage/store_pool_test.go
@@ -63,9 +63,7 @@ func createTestStorePool(
 	clock := hlc.NewClock(mc.UnixNano)
 	rpcContext := rpc.NewContext(log.AmbientContext{}, &base.Config{Insecure: true}, clock, stopper)
 	server := rpc.NewServer(rpcContext) // never started
-	g := gossip.New(log.AmbientContext{}, rpcContext, server, nil, stopper, metric.NewRegistry())
-	// Have to call g.SetNodeID before call g.AddInfo
-	g.SetNodeID(roachpb.NodeID(1))
+	g := gossip.NewTest(1, rpcContext, server, nil, stopper, metric.NewRegistry())
 	storePool := NewStorePool(
 		log.AmbientContext{},
 		g,

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -154,8 +154,7 @@ func createTestStoreWithoutStart(
 
 	rpcContext := rpc.NewContext(log.AmbientContext{}, &base.Config{Insecure: true}, nil, stopper)
 	server := rpc.NewServer(rpcContext) // never started
-	cfg.Gossip = gossip.New(log.AmbientContext{}, rpcContext, server, nil, stopper, metric.NewRegistry())
-	cfg.Gossip.SetNodeID(1)
+	cfg.Gossip = gossip.NewTest(1, rpcContext, server, nil, stopper, metric.NewRegistry())
 	manual := hlc.NewManualClock(0)
 	cfg.Clock = hlc.NewClock(manual.UnixNano)
 	cfg.StorePool = NewStorePool(
@@ -178,8 +177,6 @@ func createTestStoreWithoutStart(
 	if err := store.BootstrapRange(nil); err != nil {
 		t.Fatal(err)
 	}
-	// Have to call g.SetNodeID before call g.AddInfo
-	store.Gossip().SetNodeID(roachpb.NodeID(1))
 	return store, manual, stopper
 }
 

--- a/pkg/util/log/log_context.go
+++ b/pkg/util/log/log_context.go
@@ -17,10 +17,6 @@
 package log
 
 import (
-	"math"
-	"strconv"
-	"sync/atomic"
-
 	otlog "github.com/opentracing/opentracing-go/log"
 
 	"golang.org/x/net/context"
@@ -162,26 +158,4 @@ func WithLogTagsFromCtx(ctx, fromCtx context.Context) context.Context {
 		return copyTagChain(ctx, bottomTag)
 	}
 	return ctx
-}
-
-// DynamicIntValue is a helper type that allows using a "dynamic" int32 value
-// for a log tag.
-type DynamicIntValue struct {
-	value int64
-}
-
-// DynamicIntValueUnknown can be used with Set; it makes the value "?".
-const DynamicIntValueUnknown = math.MinInt64
-
-func (dv *DynamicIntValue) String() string {
-	val := atomic.LoadInt64(&dv.value)
-	if val == math.MinInt64 {
-		return "?"
-	}
-	return strconv.FormatInt(val, 10)
-}
-
-// Set changes the value returned by String().
-func (dv *DynamicIntValue) Set(newVal int64) {
-	atomic.StoreInt64(&dv.value, newVal)
 }


### PR DESCRIPTION
This series of changes consolidates different copies of the node ID:
- in gossip
- in server, for the node ID tag
- in sql executor and lease manager

In addition, all gossip tests now include the nodeID tag in gossip's ambient context.

Fixes #9344.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10165)

<!-- Reviewable:end -->
