### PR TITLE
storage: separate command queue for system keys

### DIFF
--- a/pkg/storage/command_queue.go
+++ b/pkg/storage/command_queue.go
@@ -20,8 +20,12 @@ import (
 	"container/heap"
 	"fmt"
 
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // A CommandQueue maintains an interval tree of keys or key ranges for
@@ -52,6 +56,8 @@ type CommandQueue struct {
 	wRg, rwRg interval.RangeGroup // avoids allocating in GetWait
 	oHeap     overlapHeap         // avoids allocating in GetWait
 	overlaps  []*cmd              // avoids allocating in getOverlaps
+
+	coveringOptimization bool // if true, use covering span optimization
 
 	// Used to temporarily store metrics local to a single CommandQueue. These
 	// will periodically be processed by the Store.
@@ -94,12 +100,22 @@ func (c *cmd) cmdCount() int {
 	return len(c.children)
 }
 
-// NewCommandQueue returns a new command queue.
-func NewCommandQueue() *CommandQueue {
+// NewCommandQueue returns a new command queue. The boolean specifies whether
+// to enable the covering span optimization. With this optimization, whenever
+// a command consisting of multiple spans is added, a covering span is computed
+// and only that covering span inserted. The individual spans are inserted
+// (i.e. the covering span expanded) only when required by a later overlapping
+// command, the hope being that that occurs infrequently, and that in the
+// common case savings are made due to the reduced number of spans active in
+// the tree.
+// As such, the optimization makes sense for workloads in which commands
+// typically contain many spans, but are spatially disjoint.
+func NewCommandQueue(coveringOptimization bool) *CommandQueue {
 	cq := &CommandQueue{
-		tree: interval.Tree{Overlapper: interval.Range.OverlapExclusive},
-		wRg:  interval.NewRangeTree(),
-		rwRg: interval.NewRangeTree(),
+		tree:                 interval.Tree{Overlapper: interval.Range.OverlapExclusive},
+		wRg:                  interval.NewRangeTree(),
+		rwRg:                 interval.NewRangeTree(),
+		coveringOptimization: coveringOptimization,
 	}
 	return cq
 }
@@ -115,6 +131,28 @@ func prepareSpans(spans ...roachpb.Span) {
 			spans[i] = span
 		}
 	}
+}
+
+// expand replaces the command with its children, returning true if work was
+// done in the process. The boolean parameter must be true if the covering span
+// was previously inserted into the tree.
+func (cq *CommandQueue) expand(c *cmd, isInserted bool) bool {
+	if c.expanded || len(c.children) == 0 {
+		return false
+	}
+	c.expanded = true
+	if isInserted {
+		if err := cq.tree.Delete(c, false /* !fast */); err != nil {
+			panic(err)
+		}
+	}
+	for i := range c.children {
+		child := &c.children[i]
+		if err := cq.tree.Insert(child, false /* !fast */); err != nil {
+			panic(err)
+		}
+	}
+	return true
 }
 
 // GetWait returns a slice of the pending channels of executing commands which
@@ -147,20 +185,8 @@ func (cq *CommandQueue) getWait(readOnly bool, spans ...roachpb.Span) (chans []<
 		// entries. If we encounter a covering entry, we remove it from the
 		// interval tree and add all of its children.
 		restart := false
-		for _, cmd := range overlaps {
-			if !cmd.expanded && len(cmd.children) != 0 {
-				restart = true
-				cmd.expanded = true
-				if err := cq.tree.Delete(cmd, false /* !fast */); err != nil {
-					panic(err)
-				}
-				for i := range cmd.children {
-					child := &cmd.children[i]
-					if err := cq.tree.Insert(child, false /* !fast */); err != nil {
-						panic(err)
-					}
-				}
-			}
+		for _, c := range overlaps {
+			restart = restart || cq.expand(c, true /* isInserted */)
 		}
 		if restart {
 			i--
@@ -376,9 +402,17 @@ func (o *overlapHeap) PopOverlap() *cmd {
 // key for the command queue and must be re-supplied on subsequent invocation
 // of remove().
 //
+// Either all supplied spans must be range-global or range-local. Failure to
+// obey with this restriction results in a fatal error.
+//
+// Returns a nil `cmd` when no spans are given.
+//
 // add should be invoked after waiting on already-executing, overlapping
 // commands via the WaitGroup initialized through getWait().
 func (cq *CommandQueue) add(readOnly bool, spans ...roachpb.Span) *cmd {
+	if len(spans) == 0 {
+		return nil
+	}
 	prepareSpans(spans...)
 
 	// Compute the min and max key that covers all of the spans.
@@ -393,15 +427,21 @@ func (cq *CommandQueue) add(readOnly bool, spans ...roachpb.Span) *cmd {
 		}
 	}
 
+	if keys.IsLocal(minKey) != keys.IsLocal(maxKey) {
+		log.Fatalf(
+			context.TODO(),
+			"mixed range-global and range-local keys: %s and %s",
+			minKey, maxKey,
+		)
+	}
+
 	numCmds := 1
 	if len(spans) > 1 {
 		numCmds += len(spans)
 	}
 	cmds := make([]cmd, numCmds)
 
-	// Create the covering entry. Note that this may have an "illegal" key range
-	// spanning from range-local to range-global, but that's acceptable here as
-	// long as we're careful in the future.
+	// Create the covering entry.
 	cmd := &cmds[0]
 	cmd.id = cq.nextID()
 	cmd.key = interval.Range{
@@ -432,8 +472,12 @@ func (cq *CommandQueue) add(readOnly bool, spans ...roachpb.Span) *cmd {
 		cq.localMetrics.writeCommands += int64(cmd.cmdCount())
 	}
 
-	if err := cq.tree.Insert(cmd, false /* !fast */); err != nil {
-		panic(err)
+	if cq.coveringOptimization || len(spans) == 1 {
+		if err := cq.tree.Insert(cmd, false /* !fast */); err != nil {
+			panic(err)
+		}
+	} else {
+		cq.expand(cmd, false /* !isInserted */)
 	}
 	return cmd
 }
@@ -442,6 +486,8 @@ func (cq *CommandQueue) add(readOnly bool, spans ...roachpb.Span) *cmd {
 // specified key has completed and should be removed. Any pending
 // commands waiting on this command will be signaled if this is the
 // only command upon which they are still waiting.
+//
+// Removing a `nil` cmd is a no-op.
 func (cq *CommandQueue) remove(cmd *cmd) {
 	if cmd == nil {
 		return

--- a/pkg/storage/command_queue_test.go
+++ b/pkg/storage/command_queue_test.go
@@ -71,7 +71,7 @@ func checkCmdFinishes(t *testing.T, chans []<-chan struct{}) bool {
 
 func TestCommandQueue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	cq := NewCommandQueue()
+	cq := NewCommandQueue(true)
 
 	// Try a command with no overlapping already-running commands.
 	waitCmdDone(getWait(cq, roachpb.Key("a"), nil, false))
@@ -95,7 +95,7 @@ func TestCommandQueue(t *testing.T) {
 // would wind up waiting only for one of the two readers under it.
 func TestCommandQueueWriteWaitForNonAdjacentRead(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	cq := NewCommandQueue()
+	cq := NewCommandQueue(true)
 	key := roachpb.Key("a")
 	// Add a read-only command.
 	wk1 := add(cq, key, nil, true)
@@ -130,7 +130,7 @@ func TestCommandQueueWriteWaitForNonAdjacentRead(t *testing.T) {
 
 func TestCommandQueueNoWaitOnReadOnly(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	cq := NewCommandQueue()
+	cq := NewCommandQueue(true)
 	// Add a read-only command.
 	chans1, wk := getWaitAndAdd(cq, roachpb.Key("a"), nil, true)
 	// Verify no wait on another read-only command.
@@ -148,7 +148,7 @@ func TestCommandQueueNoWaitOnReadOnly(t *testing.T) {
 
 func TestCommandQueueMultipleExecutingCommands(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	cq := NewCommandQueue()
+	cq := NewCommandQueue(true)
 
 	// Add multiple commands and add a command which overlaps them all.
 	wk1 := add(cq, roachpb.Key("a"), nil, false)
@@ -171,7 +171,7 @@ func TestCommandQueueMultipleExecutingCommands(t *testing.T) {
 
 func TestCommandQueueMultiplePendingCommands(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	cq := NewCommandQueue()
+	cq := NewCommandQueue(true)
 
 	// Add a command which will overlap all commands.
 	wk0 := add(cq, roachpb.Key("a"), roachpb.Key("d"), false)
@@ -203,7 +203,7 @@ func TestCommandQueueMultiplePendingCommands(t *testing.T) {
 
 func TestCommandQueueRemove(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	cq := NewCommandQueue()
+	cq := NewCommandQueue(true)
 
 	// Add multiple commands and commands which access each.
 	wk1 := add(cq, roachpb.Key("a"), nil, false)
@@ -228,7 +228,7 @@ func TestCommandQueueRemove(t *testing.T) {
 // the end key of a previous command.
 func TestCommandQueueExclusiveEnd(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	cq := NewCommandQueue()
+	cq := NewCommandQueue(true)
 	add(cq, roachpb.Key("a"), roachpb.Key("b"), false)
 
 	// Verify no wait on the second writer command on "b" since
@@ -242,7 +242,7 @@ func TestCommandQueueExclusiveEnd(t *testing.T) {
 // in deadlock.
 func TestCommandQueueSelfOverlap(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	cq := NewCommandQueue()
+	cq := NewCommandQueue(true)
 	a := roachpb.Key("a")
 	k := add(cq, a, roachpb.Key("b"), false)
 	chans := cq.getWait(false, []roachpb.Span{{Key: a}, {Key: a}, {Key: a}}...)
@@ -250,9 +250,9 @@ func TestCommandQueueSelfOverlap(t *testing.T) {
 	waitCmdDone(chans)
 }
 
-func TestCommandQueueCovering(t *testing.T) {
+func TestCommandQueueCoveringOptimization(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	cq := NewCommandQueue()
+	cq := NewCommandQueue(true)
 
 	a := roachpb.Span{Key: roachpb.Key("a")}
 	b := roachpb.Span{Key: roachpb.Key("b")}
@@ -261,6 +261,9 @@ func TestCommandQueueCovering(t *testing.T) {
 	{
 		// Test adding a covering entry and then not expanding it.
 		wk := cq.add(false, a, b)
+		if n := cq.tree.Len(); n != 1 {
+			t.Fatalf("expected a single covering span, but got %d", n)
+		}
 		waitCmdDone(cq.getWait(false, c))
 		cq.remove(wk)
 	}
@@ -274,11 +277,48 @@ func TestCommandQueueCovering(t *testing.T) {
 	}
 }
 
+func TestCommandQueueWithoutCoveringOptimization(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	cq := NewCommandQueue(false /* !coveringOptimization */)
+
+	a := roachpb.Span{Key: roachpb.Key("a")}
+	b := roachpb.Span{Key: roachpb.Key("b")}
+	c := roachpb.Span{Key: roachpb.Key("c")}
+
+	{
+		cmd := cq.add(false, a, b)
+		if !cmd.expanded {
+			t.Errorf("expected non-expanded command, not %+v", cmd)
+		}
+		if exp, act := 2, len(cmd.children); exp != act {
+			t.Errorf("expected %d children in command, got %d: %+v", exp, act, cmd)
+		}
+		if exp, act := 2, cq.tree.Len(); act != exp {
+			t.Errorf("expected %d spans in tree, got %d", exp, act)
+		}
+		cq.remove(cmd)
+	}
+
+	{
+		cmd := cq.add(false, c)
+		if cmd.expanded {
+			t.Errorf("expected unexpanded command, not %+v", cmd)
+		}
+		if len(cmd.children) != 0 {
+			t.Errorf("expected no children in command %+v", cmd)
+		}
+		if act, exp := cq.tree.Len(), 1; act != exp {
+			t.Errorf("expected %d spans in tree, got %d", exp, act)
+		}
+		cq.remove(cmd)
+	}
+}
+
 // Reconstruct a set of commands that tickled a bug in interval.Tree. See
 // https://github.com/cockroachdb/cockroach/issues/6495 for details.
 func TestCommandQueueIssue6495(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	cq := NewCommandQueue()
+	cq := NewCommandQueue(true)
 	cq.idAlloc = 1997
 
 	mkSpan := func(start, end string) roachpb.Span {

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -2022,7 +2022,7 @@ func TestReplicaCommandQueueCancellation(t *testing.T) {
 	// Wait until both commands are in the command queue.
 	util.SucceedsSoon(t, func() error {
 		tc.rng.cmdQMu.Lock()
-		chans := tc.rng.cmdQMu.q.getWait(false, roachpb.Span{Key: key1}, roachpb.Span{Key: key2})
+		chans := tc.rng.cmdQMu.global.getWait(false, roachpb.Span{Key: key1}, roachpb.Span{Key: key2})
 		tc.rng.cmdQMu.Unlock()
 		if a, e := len(chans), 2; a < e {
 			return errors.Errorf("%d of %d commands in the command queue", a, e)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3599,12 +3599,22 @@ func (s *Store) updateCommandQueueGauges() error {
 	)
 	newStoreReplicaVisitor(s).Visit(func(rep *Replica) bool {
 		rep.cmdQMu.Lock()
-		writes := rep.cmdQMu.q.localMetrics.writeCommands
-		reads := rep.cmdQMu.q.localMetrics.readCommands
-		treeSize := int64(rep.cmdQMu.q.treeSize())
 
-		maxOverlaps := rep.cmdQMu.q.localMetrics.maxOverlapsSeen
-		rep.cmdQMu.q.localMetrics.maxOverlapsSeen = 0
+		writes := rep.cmdQMu.global.localMetrics.writeCommands
+		writes += rep.cmdQMu.local.localMetrics.writeCommands
+
+		reads := rep.cmdQMu.global.localMetrics.readCommands
+		reads += rep.cmdQMu.local.localMetrics.readCommands
+
+		treeSize := int64(rep.cmdQMu.global.treeSize())
+		treeSize += int64(rep.cmdQMu.local.treeSize())
+
+		maxOverlaps := rep.cmdQMu.global.localMetrics.maxOverlapsSeen
+		if locMax := rep.cmdQMu.local.localMetrics.maxOverlapsSeen; locMax > maxOverlaps {
+			maxOverlaps = locMax
+		}
+		rep.cmdQMu.global.localMetrics.maxOverlapsSeen = 0
+		rep.cmdQMu.local.localMetrics.maxOverlapsSeen = 0
 		rep.cmdQMu.Unlock()
 
 		cqSize := writes + reads


### PR DESCRIPTION
In preparation for #10084 (which will properly account for access to internal
keys in the context of proposer-evaluated KV), split the command queue into a
portion which holds "regular" (=global) reads and writes (such as a key written
to during a SQL insert) and the remainder (=local, though that terminology is
overripe for an overhaul) such as transactional writes to a RangeDescriptor.

The command queue optimizes for certain access patterns by inserting first a
coagulated root span. This optimization would perform poorly when performed
on batches mixing both types of Spans, and it makes no sense for the workload
expected on the "local" portion (where there is high contention with read only
requests and the set of keys touched is small and discrete) and was thus turned
off.

The impact of this is currently negligible, but once the interdependence
between commands is properly accounted for, the "local" command queue will
see a few read-only spans for the majority of spans and its performance will
be of interest, making it a likely target for follow-up optimizations (or
outright specialization) as discussed in #10084.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10173)

<!-- Reviewable:end -->
