### PR TITLE
sql: add command-line flag for specifying a password

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -803,7 +803,7 @@ func Example_user() {
 	c.Run("user ls")
 	c.Run("user ls --pretty")
 	c.Run("user ls --pretty=false")
-	c.Run("user set foo --password=bar")
+	c.Run("user set foo --set-password=bar")
 	// Don't use get, since the output of hashedPassword is random.
 	// c.Run("user get foo")
 	c.Run("user ls --pretty")
@@ -823,7 +823,7 @@ func Example_user() {
 	// user ls --pretty=false
 	// 0 rows
 	// username
-	// user set foo --password=bar
+	// user set foo --set-password=bar
 	// INSERT 1
 	// user ls --pretty
 	// +----------+

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -238,12 +238,18 @@ server to listen on an external address in insecure mode.`,
 		Description: `Define the maximum number of results that will be retrieved.`,
 	}
 
+	SetPassword = FlagInfo{
+		Name: "set-password",
+		Description: `
+The created user's password. If provided, disables prompting. Pass '-' to
+provide the password on standard input.`,
+	}
+
 	Password = FlagInfo{
 		Name:   "password",
 		EnvVar: "COCKROACH_PASSWORD",
 		Description: `
-The created user's password. If provided, disables prompting. Pass '-' to
-provide the password on standard input.`,
+The user's password which is used to connect to CockroachDB.`,
 	}
 
 	CACert = FlagInfo{

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -41,7 +41,7 @@ import (
 
 var maxResults int64
 
-var connURL, connUser, connHost, connPort, advertiseHost string
+var connURL, connUser, connPassword, connHost, connPort, advertiseHost string
 var httpHost, httpPort, connDBName, zoneConfig string
 var zoneDisableReplication bool
 var startBackground bool
@@ -316,7 +316,7 @@ func init() {
 		intFlag(f, &keySize, cliflags.KeySize, defaultKeySize)
 	}
 
-	stringFlag(setUserCmd.Flags(), &password, cliflags.Password, "")
+	stringFlag(setUserCmd.Flags(), &setPassword, cliflags.SetPassword, "")
 
 	clientCmds := []*cobra.Command{
 		sqlShellCmd, quitCmd, freezeClusterCmd, dumpCmd, /* startCmd is covered above */
@@ -373,6 +373,7 @@ func init() {
 		stringFlag(f, &connURL, cliflags.URL, "")
 
 		stringFlag(f, &connUser, cliflags.User, security.RootUser)
+		stringFlag(f, &connPassword, cliflags.Password, "")
 		stringFlag(f, &connPort, cliflags.ClientPort, base.DefaultPort)
 		stringFlag(f, &connDBName, cliflags.Database, "")
 	}

--- a/pkg/cli/user.go
+++ b/pkg/cli/user.go
@@ -28,7 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 )
 
-var password string
+var setPassword string
 
 // A getUserCmd command displays the config for the specified username.
 var getUserCmd = &cobra.Command{
@@ -124,7 +124,7 @@ func runSetUser(cmd *cobra.Command, args []string) error {
 	}
 	var err error
 	var hashed []byte
-	switch password {
+	switch setPassword {
 	case "":
 		hashed, err = security.PromptForPasswordAndHash()
 		if err != nil {
@@ -149,7 +149,7 @@ func runSetUser(cmd *cobra.Command, args []string) error {
 			}
 		}
 	default:
-		hashed, err = security.HashPassword(password)
+		hashed, err = security.HashPassword(setPassword)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #9880. @asubiotto, I add a flag `--user-password` to specify the user's password to connect to CockroacDB.

please help me review if I done it right, thanks.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10175)

<!-- Reviewable:end -->
