### PR TITLE
storage: Disable coalesced heartbeats by default

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2451,7 +2451,7 @@ func (r *Replica) maybeCoalesceHeartbeat(
 	toReplica, fromReplica roachpb.ReplicaDescriptor,
 	quiesce bool,
 ) bool {
-	if !enableCoalescedHeartbeats {
+	if !r.store.cfg.EnableCoalescedHeartbeats {
 		return false
 	}
 	var hbMap map[roachpb.StoreIdent][]RaftHeartbeat


### PR DESCRIPTION
Coalesced heartbeats is a new feature, which should be disabled by
default until it is sufficiently battle tested and stable. However, enable it
in tests, as well as if the COCKROACH_ENABLE_COALESCED_HEARTBEATS
environment variable is set to true.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10179)

<!-- Reviewable:end -->
