### PR TITLE
acceptance: clean up logging

### DIFF
--- a/build/teamcity-acceptance.sh
+++ b/build/teamcity-acceptance.sh
@@ -4,4 +4,4 @@ build/builder.sh make build
 build/builder.sh make install
 build/builder.sh go test -v -c -tags acceptance ./pkg/acceptance
 cd pkg/acceptance
-../../acceptance.test -nodes 3 -l artifacts/acceptance -test.v -test.timeout 10m 2>&1 | go-test-teamcity
+../../acceptance.test -nodes 3 -l ../../artifacts/acceptance -test.v -test.timeout 10m 2>&1 | go-test-teamcity


### PR DESCRIPTION
Do not create log directories unless asked to.
On TeamCity, put the logs in the artifacts directory (this got lost
during the `pkg` transition). Noticed during triage of #10056.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10180)

<!-- Reviewable:end -->
