### PR TITLE
sql: Fix window functions with column references above windowing

### DIFF
--- a/pkg/sql/row_container.go
+++ b/pkg/sql/row_container.go
@@ -30,8 +30,9 @@ import (
 // TODO(knz): this does not currently track the amount of memory used
 // for the outer array of DTuple references.
 type RowContainer struct {
-	p    *planner
-	rows []parser.DTuple
+	p       *planner
+	rows    []parser.DTuple
+	numCols int
 
 	// fixedColsSize is the sum of widths of fixed-width columns in a
 	// single row.
@@ -68,6 +69,7 @@ func (p *planner) NewRowContainer(h ResultColumns, rowCapacity int) *RowContaine
 	res := &RowContainer{
 		p:               p,
 		rows:            make([]parser.DTuple, 0, rowCapacity),
+		numCols:         nCols,
 		varSizedColumns: make([]int, 0, nCols),
 		memAcc:          p.session.OpenAccount(),
 	}
@@ -114,6 +116,11 @@ func (c *RowContainer) AddRow(row parser.DTuple) error {
 // Len reports the number of rows currently held in this RowContainer.
 func (c *RowContainer) Len() int {
 	return len(c.rows)
+}
+
+// NumCols reports the number of columns held in this RowContainer.
+func (c *RowContainer) NumCols() int {
+	return c.numCols
 }
 
 // At accesses a row at a specific index.

--- a/pkg/sql/testdata/window
+++ b/pkg/sql/testdata/window
@@ -344,6 +344,16 @@ SELECT k, min(d) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
 8  3
 
 query IR
+SELECT k, pow(max(d) OVER (PARTITION BY v), k::DECIMAL) FROM kv ORDER BY 1
+----
+1  7.9000000000000000
+3  512.0000000000000000
+5  -3408200705601.0000000000000000
+6  243087.4555210000000000
+7  1920390.8986159000000000
+8  16777216.0000000000000000
+
+query IR
 SELECT k, max(d) OVER (PARTITION BY v) FROM kv ORDER BY 1
 ----
 1  7.9
@@ -497,6 +507,25 @@ EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY 
 3  render/filter  render 6                                       (100)[int]
 4  scan           result                                         (k int, v int, w int, f float, d decimal, s string, b bool)
 
+query ITTT
+EXPLAIN (TYPES) SELECT k, k + stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
+----
+0  select         result                                           (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)
+1  sort           result                                           (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)
+2  window         result                                           (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal, "variance(d) OVER (PARTITION BY v, 100)" decimal)
+2  window         render k + stddev(d) OVER (PARTITION BY v, 'a')  ((k)[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]
+2  window         render variance(d) OVER (PARTITION BY v, 100)    (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]
+3  render/filter  result                                           (k int, d decimal, d decimal, v int, "'a'" string, v int, "100" int, k int)
+3  render/filter  render 0                                         (k)[int]
+3  render/filter  render 1                                         (d)[decimal]
+3  render/filter  render 2                                         (d)[decimal]
+3  render/filter  render 3                                         (v)[int]
+3  render/filter  render 4                                         ('a')[string]
+3  render/filter  render 5                                         (v)[int]
+3  render/filter  render 6                                         (100)[int]
+3  render/filter  render 7                                         (k)[int]
+4  scan           result                                           (k int, v int, w int, f float, d decimal, s string, b bool)
+
 statement OK
 INSERT INTO kv VALUES
 (9, 2, 9, .1, DEFAULT, DEFAULT, DEFAULT),
@@ -541,6 +570,19 @@ SELECT k, v, w, row_number() OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
 9   2     9  4
 10  4     9  3
 11  NULL  9  2
+
+query IIII
+SELECT k, v, w, v - w + 2 + row_number() OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
+----
+1   2     3  3
+3   4     5  3
+5   NULL  5  NULL
+6   2     3  4
+7   2     2  3
+8   4     2  5
+9   2     9  -1
+10  4     9  0
+11  NULL  9  NULL
 
 query II
 SELECT k, rank() OVER () FROM kv ORDER BY 1

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -80,14 +80,19 @@ func (p *planner) window(n *parser.SelectClause, s *selectNode) (*windowNode, er
 	if err := window.extractWindowFunctions(s); err != nil {
 		return nil, err
 	}
-	renderCols := len(s.columns)
+	renderCols := s.columns
 
 	if err := window.constructWindowDefinitions(n, s); err != nil {
 		return nil, err
 	}
+	windowDefCols := s.columns[len(renderCols):]
 
-	window.wrappedRenderVals = p.NewRowContainer(s.columns[:renderCols], 0)
-	window.wrappedWindowDefVals = p.NewRowContainer(s.columns[renderCols:], 0)
+	window.replaceIndexedVars(s)
+	indexedVarCols := s.columns[len(renderCols)+len(windowDefCols):]
+
+	window.wrappedRenderVals = p.NewRowContainer(renderCols, 0)
+	window.wrappedWindowDefVals = p.NewRowContainer(windowDefCols, 0)
+	window.wrappedIndexedVarVals = p.NewRowContainer(indexedVarCols, 0)
 	window.windowsAcc = p.session.OpenAccount()
 
 	return window, nil
@@ -243,6 +248,60 @@ func constructWindowDef(
 	return def, nil
 }
 
+// Once the extractWindowFunctions has been run over each render, the remaining
+// expressions will all be "above" the windowing level, with windowFuncHolders standing
+// in as terminal expressions for each window function. This means that we can compute
+// the results of each window function for each row, and then continue evaluating the
+// windowRenders with each window function's respective result for that row.
+//
+// There is one complication here: IndexedVars above the windowing level need to be
+// fixed. Because window function evaluation requires completion of any wrapped plan
+// nodes, if we did nothing here, all IndexedVars would be pointing to their values in
+// the last row of the underlying selectNode. Clearly, we cannot use the selectNode as
+// the IndexedVarContainer for IndexedVars above the windowing level. To work around
+// this, we perform four steps:
+// 1. We add renders for each column referenced by an IndexedVar above the windowing
+//    level.
+// 2. We replace each IndexedVar with a new IndexedVar that uses the windowNode as
+//    an IndexedVarContainer.
+// 3. We buffer all of the column values from the newly added renders while computing
+//    window function results.
+// 4. When evaluating windowRenders for each row that contain these new IndexedVars,
+//    the windowNode provides the buffered column value for that row through its
+//    IndexedVarContainer interface.
+func (n *windowNode) replaceIndexedVars(s *selectNode) {
+	ivarHelper := parser.MakeIndexedVarHelper(n, s.ivarHelper.NumVars())
+	n.ivarIdxMap = make(map[int]int)
+	n.ivarSourceInfo = s.sourceInfo
+
+	varIdx := 0
+	for i, render := range n.windowRender {
+		if render == nil {
+			continue
+		}
+		replaceIdxVars := func(expr parser.VariableExpr) (ok bool, newExpr parser.VariableExpr) {
+			iv, ok := expr.(*parser.IndexedVar)
+			if !ok {
+				return true, expr
+			}
+			if _, ok := n.ivarIdxMap[iv.Idx]; !ok {
+				// We add a new render to the wrapped selectNode for each new IndexedVar we
+				// see. We also register this mapping in the ivarIdxMap.
+				s.render = append(s.render, iv)
+				s.columns = append(s.columns, ResultColumn{
+					Name: iv.String(),
+					Typ:  iv.ResolvedType(),
+				})
+
+				n.ivarIdxMap[iv.Idx] = varIdx
+				varIdx++
+			}
+			return true, ivarHelper.IndexedVar(iv.Idx)
+		}
+		n.windowRender[i] = exprConvertVars(render, replaceIdxVars)
+	}
+}
+
 // A windowNode implements the planNode interface and handles windowing logic.
 // It "wraps" a planNode which is used to retrieve the un-windowed results.
 type windowNode struct {
@@ -251,7 +310,8 @@ type windowNode struct {
 	// The "wrapped" node (which returns un-windowed results).
 	plan planNode
 
-	// The values returned by the wrapped nodes will be split into two groups:
+	// The values returned by the wrapped nodes will be split into three RowContainer
+	// groups that are separated for clarity, but have the same lifetime:
 	// - wrappedRenderVals: these values are either passed directly as rendered values of the
 	//     windowNode if their corresponding expressions were not wrapped in window functions,
 	//     or used as arguments to window functions to eventually create rendered values for
@@ -260,8 +320,14 @@ type windowNode struct {
 	// - wrappedWindowDefVals: these values are used to partition and order window function
 	//     applications, and were added to the wrapped node from window definitions.
 	//     (see constructWindowDefinitions)
-	wrappedRenderVals    *RowContainer
-	wrappedWindowDefVals *RowContainer
+	// - wrappedIndexedVarVals: these values are used to buffer the IndexedVar values
+	//     for each row. Unlike the selectNode, which can stream values for each IndexedVar,
+	//     we need to buffer all values here while we compute window function results. We
+	//     then index into these values in IndexedVarContainer.IndexedVarEval.
+	//     (see replaceIndexedVars)
+	wrappedRenderVals     *RowContainer
+	wrappedWindowDefVals  *RowContainer
+	wrappedIndexedVarVals *RowContainer
 
 	// A sparse array holding renders specific to this windowNode. This will contain
 	// nil entries for renders that do not contain window functions, and which therefore
@@ -277,6 +343,10 @@ type windowNode struct {
 	funcs        []*windowFuncHolder
 	windowValues [][]parser.Datum
 	curRowIdx    int
+
+	// ivarIdxMap maps selectNode ivarIdx values to windowNode ivarIdx values.
+	ivarIdxMap     map[int]int
+	ivarSourceInfo multiSourceInfo
 
 	windowsAcc WrappableMemoryAccount
 
@@ -365,18 +435,24 @@ func (n *windowNode) Next() (bool, error) {
 			return true, nil
 		}
 
-		// Make a copy of the provided values and split into wrappedRenderVals and
-		// wrappedRenderVals.
+		// Make a copy of the provided values and split into wrappedRenderVals,
+		// wrappedRenderVals, and wrappedIndexedVarVals.
 		values := n.plan.Values()
 		valuesCopy := make(parser.DTuple, len(values))
 		copy(valuesCopy, values)
 
-		wrappedRenderVals := valuesCopy[:n.wrappedRenderVals.NumCols()]
-		if err := n.wrappedRenderVals.AddRow(wrappedRenderVals); err != nil {
+		renderEnd := n.wrappedRenderVals.NumCols()
+		windowDefEnd := renderEnd + n.wrappedWindowDefVals.NumCols()
+		renderVals := valuesCopy[:renderEnd]
+		if err := n.wrappedRenderVals.AddRow(renderVals); err != nil {
 			return false, err
 		}
-		wrappedWindowDefVals := valuesCopy[n.wrappedRenderVals.NumCols():]
-		if err := n.wrappedWindowDefVals.AddRow(wrappedWindowDefVals); err != nil {
+		windowDefVals := valuesCopy[renderEnd:windowDefEnd]
+		if err := n.wrappedWindowDefVals.AddRow(windowDefVals); err != nil {
+			return false, err
+		}
+		indexedVarVals := valuesCopy[windowDefEnd:]
+		if err := n.wrappedIndexedVarVals.AddRow(indexedVarVals); err != nil {
 			return false, err
 		}
 
@@ -664,6 +740,8 @@ func (n *windowNode) populateValues() error {
 	// accounts.
 	n.wrappedRenderVals.Close()
 	n.wrappedRenderVals = nil
+	n.wrappedIndexedVarVals.Close()
+	n.wrappedIndexedVarVals = nil
 	n.windowValues = nil
 	acc.Close()
 
@@ -708,6 +786,10 @@ func (n *windowNode) Close() {
 	if n.wrappedWindowDefVals != nil {
 		n.wrappedWindowDefVals.Close()
 		n.wrappedWindowDefVals = nil
+	}
+	if n.wrappedIndexedVarVals != nil {
+		n.wrappedIndexedVarVals.Close()
+		n.wrappedIndexedVarVals = nil
 	}
 	if n.windowValues != nil {
 		n.windowValues = nil
@@ -859,4 +941,19 @@ func (w *windowFuncHolder) Eval(ctx *parser.EvalContext) (parser.Datum, error) {
 
 func (w *windowFuncHolder) ResolvedType() parser.Type {
 	return w.expr.ResolvedType()
+}
+
+// IndexedVarEval implements the parser.IndexedVarContainer interface.
+func (n *windowNode) IndexedVarEval(idx int, ctx *parser.EvalContext) (parser.Datum, error) {
+	return n.wrappedIndexedVarVals.At(n.curRowIdx)[n.ivarIdxMap[idx]].Eval(ctx)
+}
+
+// IndexedVarResolvedType implements the parser.IndexedVarContainer interface.
+func (n *windowNode) IndexedVarResolvedType(idx int) parser.Type {
+	return n.ivarSourceInfo[0].sourceColumns[idx].Typ
+}
+
+// IndexedVarString implements the parser.IndexedVarContainer interface.
+func (n *windowNode) IndexedVarFormat(buf *bytes.Buffer, f parser.FmtFlags, idx int) {
+	n.ivarSourceInfo[0].FormatVar(buf, f, idx)
 }


### PR DESCRIPTION
Given a legal query like `SELECT a + rank() OVER () FROM x`, we would
previously return an incorrect value for all but the last row processed
by the underlying `selectNode`. The problem was that `a` would be replaced
by an `IndexedVar`, and when the `a + rank() OVER()` was evaluated for each
row (after reading in all rows), `a` would always have the same value.
This was because `selectNode` (which is the `IndexesVar's`
`IndexedVarContainer`) never changes its `curSourceRow` once it has
completed processing.

The solution was to walk the expressions in `windowNode's` constructor
after the `extractWindowFuncsVisitor` has been run and replace all
`IndexedVars` above the windowing layer with new `IndexedVars` that
point to `windowNode` as their `IndexedVarContainer`.

This was requested by @andreimatei, who is already recklessly abusing
window functions.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10186)

<!-- Reviewable:end -->
