### PR TITLE
cli/sql: invite the user to enter transactions over multiple lines.

### DIFF
--- a/pkg/cli/interactive_tests/test_client_side_checking.tcl
+++ b/pkg/cli/interactive_tests/test_client_side_checking.tcl
@@ -8,12 +8,12 @@ spawn $argv sql
 eexpect root@
 
 # Check that syntax errors are handled client-side when running interactive.
-send "begin;\r"
+send "begin;\r\r"
 eexpect BEGIN
 eexpect root@
 
 send "select 3+;\r"
-eexpect "statement not sent"
+eexpect "statement ignored"
 eexpect root@
 
 send "select 1;\r"

--- a/pkg/cli/interactive_tests/test_multiline_statements.tcl
+++ b/pkg/cli/interactive_tests/test_multiline_statements.tcl
@@ -24,6 +24,12 @@ send "select 1,\r"
 eexpect " ->"
 send "2, 3\r"
 eexpect " ->"
+
+# Test that \show does what it says.
+send "\\show\r"
+eexpect "select 1,\r\n2, 3\r\n*->"
+
+# Test finishing the multi-line statement.
 send ";\r"
 eexpect "1 row"
 eexpect "root@"
@@ -38,6 +44,30 @@ eexpect root@
 send "SELECT\r"
 eexpect " ->"
 send "\003"
+eexpect root@
+
+# Test that BEGIN .. without COMMIT begins a multi-line statement.
+send "BEGIN; SELECT 1;\r"
+eexpect " ->"
+
+# Test that \show does what it says.
+send "\\show\r"
+eexpect "BEGIN*;\r\nSELECT 1;\r\n*->"
+
+# Test that a COMMIT is detected properly.
+send "COMMIT;\r"
+eexpect "1 row"
+eexpect "root@"
+
+# Test that an invalid statement inside a multi-line txn doesn't go to the
+# server.
+send "BEGIN;\r"
+eexpect " ->"
+send "SELEC T1;\r"
+eexpect "invalid syntax"
+eexpect " ->"
+send "SELECT 1; COMMIT;\r"
+eexpect "1 row"
 eexpect root@
 
 send "\003"

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -18,6 +18,7 @@ package cli
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -54,32 +55,115 @@ Open a sql shell running against a cockroach database.
 	SilenceUsage: true,
 }
 
-// options store the client-side options that a user of the sql cli
-// can configure with \set and \unset.
-// TODO(knz) For now these are booleans but eventually we may need
-// to support arbitrary strings.
-var options = map[string]bool{
-	// The following defaults apply for the interactive shell.
-	// These defaults are overridden for non-interactive shells below.
+// cliState defines the current state of the CLI during
+// command-line processing.
+type cliState struct {
+	conn *sqlConn
+	ins  *readline.Instance
 
+	// Options
+	//
 	// Determines whether to stop the client upon encountering an error.
-	"errexit": false,
-
+	errExit bool
 	// Determines whether to perform client-side syntax checking.
-	"check_syntax": true,
-
+	checkSyntax bool
 	// Determines whether to store normalized syntax in the shell history
 	// when check_syntax is set.
 	// TODO(knz) this can possibly be set back to false by default when
 	// the upstream readline library handles multi-line history entries
 	// properly.
-	"normalize_history": true,
+	normalizeHistory bool
+	// The prompt at the beginning of a multi-line entry.
+	fullPrompt string
+	// The prompt on a continuation line in a multi-line entry.
+	continuePrompt string
+
+	// State
+	//
+	// lastInputLine is the last valid line obtained from readline.
+	lastInputLine string
+	// atEOF indicates whether the last call to readline signaled EOF on input.
+	atEOF bool
+
+	// partialLines is the array of lines accumulated so far in a
+	// multi-line entry. When syntax checking is enabled, partialLines
+	// also gets rewritten so that all statements parsed successfully so
+	// far have their own, single entry in partialLines (i.e. statements
+	// spanning multiple lines are grouped together in one partialLines
+	// entry).
+	partialLines []string
+
+	// partialStmtsLen represents the number of semicolon-separated
+	// statements in `partialLines` parsed successfully so far. It grows
+	// larger than zero whenever 1) syntax checking is enabled and 2)
+	// multi-statement (as opposed to multi-line) entry starts,
+	// i.e. when the shell decides to continue inputting statements even
+	// after a full statement followed by a semicolon was read
+	// successfully. This is currently used for multi-line transaction
+	// editing.
+	partialStmtsLen int
+
+	// concatLines is the concatenation of partialLines, computed during
+	// doCheckStatement and then reused in doRunStatement().
+	concatLines string
+
+	// querySyntax determines whether to query the current syntax mode
+	// from the server before starting to read the next line of input.
+	querySyntax bool
+	// syntax determines the current syntax to use for scanning and parsing
+	// new lines of input.
+	syntax parser.Syntax
+
+	// exitErr defines the error to report to the user upon termination.
+	// This can carry over from one line of input to another. For
+	// example in the interactive shell, a statement causing a SQL
+	// error, followed by lines of whitespace or SQL comments, followed
+	// by Ctrl+D, causes the shell to terminate with an error --
+	// reporting the status of the last valid SQL statement executed.
+	exitErr error
 }
 
+// cliStateEnum drives the CLI state machine in runInteractive().
+type cliStateEnum int
+
 const (
-	cliNextLine     = 0 // Done with this line, ask for another line.
-	cliExit         = 1 // User requested to exit.
-	cliProcessQuery = 2 // Regular query to send to the server.
+	cliStart cliStateEnum = iota
+	cliStop
+
+	// Querying the server for the current syntax prior to starting
+	// input.
+	cliQuerySyntax
+
+	// Just before reading the first line of a potentially multi-line
+	// statement.
+	cliStartLine
+
+	// Just before reading the 2nd line or after in a multi-line
+	// statement.
+	cliContinueLine
+
+	// Actually reading the input and checking for input errors.
+	cliReadLine
+
+	// Determine to do with the newly input line.
+	cliDecidePath
+
+	// Process the first line of a (possibly multi-line) entry.
+	cliProcessFirstLine
+
+	// Check and handle for client-side commands.
+	cliHandleCliCmd
+
+	// Concatenate the inputs so far, discard entry made only of whitespace
+	// and/or comments, and check for semicolons.
+	cliPrepareStatementLine
+
+	// Perform syntax validation if enabled with check_syntax,
+	// and possibly trigger entry for multi-line transactions.
+	cliCheckStatement
+
+	// Actually run the SQL buffered so far.
+	cliRunStatement
 )
 
 // printCliHelp prints a short inline help about the CLI.
@@ -90,6 +174,7 @@ Type: \q to exit (Ctrl+C/Ctrl+D also supported)
   \| CMD            run an external command and run its output as SQL statements.
   \set [NAME]       set a client-side flag or (without argument) print the current settings.
   \unset NAME       unset a flag.
+  \show             during a multi-line statement or transaction, show the SQL entered so far.
   \? or "help"      print this help.
 
 More documentation about our SQL dialect is available online:
@@ -100,110 +185,94 @@ http://www.cockroachlabs.com/docs/
 
 // addHistory persists a line of input to the readline history
 // file.
-func addHistory(ins *readline.Instance, line string) {
+func (c *cliState) addHistory(line string) {
+	if !isInteractive {
+		return
+	}
+
 	// ins.SaveHistory will push command into memory and try to
 	// persist to disk (if ins's config.HistoryFile is set).  err can
 	// be not nil only if it got a IO error while trying to persist.
-	if err := ins.SaveHistory(line); err != nil {
+	if err := c.ins.SaveHistory(line); err != nil {
 		log.Warningf(context.TODO(), "cannot save command-line history: %s", err)
 		log.Info(context.TODO(), "command-line history will not be saved in this session")
-		cfg := ins.Config.Clone()
+		cfg := c.ins.Config.Clone()
 		cfg.HistoryFile = ""
-		ins.SetConfig(cfg)
+		c.ins.SetConfig(cfg)
 	}
+}
+
+func (c *cliState) invalidSyntax(
+	nextState cliStateEnum, format string, args ...interface{},
+) cliStateEnum {
+	fmt.Fprint(osStderr, "invalid syntax: ")
+	fmt.Fprintf(osStderr, format, args...)
+	fmt.Fprintln(osStderr)
+	c.exitErr = errInvalidSyntax
+	return nextState
+}
+
+func (c *cliState) invalidOption(nextState cliStateEnum, opt string) cliStateEnum {
+	fmt.Fprintf(osStderr, "option not recognized: %s\n", opt)
+	return nextState
+}
+
+func (c *cliState) invalidOptionChange(nextState cliStateEnum, opt string) cliStateEnum {
+	fmt.Fprintf(osStderr, "cannot change option during multi-line editing: %s\n", opt)
+	return nextState
 }
 
 // handleSet supports the \set client-side command.
-func handleSet(args []string) {
-	if len(args) > 1 {
-		fmt.Fprintf(osStderr, "Invalid command: \\set %s. Try \\? for help.\n", strings.Join(args, " "))
-		return
+func (c *cliState) handleSet(args []string, nextState, errState cliStateEnum) cliStateEnum {
+	if len(args) != 1 {
+		return c.invalidSyntax(errState, `\set %s. Try \? for help.`, strings.Join(args, " "))
 	}
-	if len(args) == 0 {
-		for k, v := range options {
-			fmt.Printf("%s = %v\n", strings.ToUpper(k), v)
-		}
-		return
-	}
-
 	opt := strings.ToLower(args[0])
-	options[opt] = true
+	switch opt {
+	case `errexit`:
+		c.errExit = true
+	case `check_syntax`:
+		if len(c.partialLines) > 0 {
+			return c.invalidOptionChange(errState, opt)
+		}
+		c.checkSyntax = true
+	case `normalize_history`:
+		if len(c.partialLines) > 0 {
+			return c.invalidOptionChange(errState, opt)
+		}
+		c.normalizeHistory = true
+	default:
+		return c.invalidOption(errState, opt)
+	}
+	return nextState
 }
 
 // handleUnset supports the \unset client-side command.
-func handleUnset(args []string) {
+func (c *cliState) handleUnset(args []string, nextState, errState cliStateEnum) cliStateEnum {
 	if len(args) != 1 {
-		fmt.Fprintf(osStderr, "Invalid command: \\unset %s. Try \\? for help.\n", strings.Join(args, " "))
-		return
+		return c.invalidSyntax(errState, `\unset %s. Try \? for help.`, strings.Join(args, " "))
 	}
 	opt := strings.ToLower(args[0])
-	options[opt] = false
+	switch opt {
+	case `errexit`:
+		c.errExit = false
+	case `check_syntax`:
+		if len(c.partialLines) > 0 {
+			return c.invalidOptionChange(errState, opt)
+		}
+		c.checkSyntax = false
+	case `normalize_history`:
+		if len(c.partialLines) > 0 {
+			return c.invalidOptionChange(errState, opt)
+		}
+		c.normalizeHistory = false
+	default:
+		return c.invalidOption(errState, opt)
+	}
+	return nextState
 }
 
-// handleInputLine looks at a single line of text entered
-// by the user at the prompt and decides what to do: either
-// run a client-side command, print some help or continue with
-// a regular query.
-func handleInputLine(
-	ins *readline.Instance, stmt *[]string, line string, syntax parser.Syntax,
-) (status int, hasSet, isEmpty, endsWithSemi bool) {
-	if len(*stmt) == 0 {
-		// Special case: first line of multi-line statement.
-		// In this case ignore empty lines, and recognize "help" specially.
-		switch line {
-		case "":
-			return cliNextLine, false, true, false
-		case "help":
-			printCliHelp()
-			return cliNextLine, false, true, false
-		}
-
-		if len(line) > 0 && line[0] == '\\' {
-			// Client-side commands: process locally.
-
-			addHistory(ins, line)
-
-			cmd := strings.Fields(line)
-			switch cmd[0] {
-			case `\q`:
-				return cliExit, false, true, false
-			case `\!`:
-				return runSyscmd(line), false, true, false
-			case `\|`:
-				status = pipeSyscmd(stmt, line)
-				isEmpty, endsWithSemi, hasSet = isEndOfStatement(syntax, stmt)
-				return status, hasSet, isEmpty, endsWithSemi
-			case `\`, `\?`:
-				printCliHelp()
-			case `\set`:
-				handleSet(cmd[1:])
-			case `\unset`:
-				handleUnset(cmd[1:])
-			default:
-				fmt.Fprintf(osStderr, "Invalid command: %s. Try \\? for help.\n", line)
-			}
-
-			if strings.HasPrefix(line, `\d`) {
-				// Unrecognized command for now, but we want to be helpful.
-				fmt.Fprint(osStderr, "Suggestion: use the SQL SHOW statement to inspect your schema.\n")
-			}
-
-			return cliNextLine, false, true, false
-		}
-	}
-
-	*stmt = append(*stmt, line)
-	isEmpty, isEnd, hasSet := isEndOfStatement(syntax, stmt)
-	if isEmpty || isEnd {
-		status = cliProcessQuery
-	} else {
-		status = cliNextLine
-	}
-	return status, hasSet, isEmpty, isEnd
-}
-
-func isEndOfStatement(syntax parser.Syntax, stmt *[]string) (isEmpty, isEnd, hasSet bool) {
-	fullStmt := strings.Join(*stmt, "\n")
+func isEndOfStatement(fullStmt string, syntax parser.Syntax) (isEmpty, isEnd, hasSet bool) {
 	sc := parser.MakeScanner(fullStmt, syntax)
 	isEmpty = true
 	var last int
@@ -235,40 +304,46 @@ func execSyscmd(command string) (string, error) {
 	return out.String(), nil
 }
 
+var errInvalidSyntax = errors.New("invalid syntax")
+
 // runSyscmd runs system commands on the interactive CLI.
-func runSyscmd(line string) int {
-	command := line[2:]
+func (c *cliState) runSyscmd(line string, nextState, errState cliStateEnum) cliStateEnum {
+	command := strings.Trim(line[2:], " \r\n\t\f")
 	if command == "" {
 		fmt.Fprintf(osStderr, "Usage:\n  \\! [command]\n")
-		return cliNextLine
+		c.exitErr = errInvalidSyntax
+		return errState
 	}
 
 	cmdOut, err := execSyscmd(command)
 	if err != nil {
 		fmt.Fprintf(osStderr, "command failed: %s\n", err)
-		return cliNextLine
+		c.exitErr = err
+		return errState
 	}
 
 	fmt.Print(cmdOut)
-	return cliNextLine
+	return nextState
 }
 
 // pipeSyscmd executes system commands and pipe the output into the current SQL.
-func pipeSyscmd(stmt *[]string, line string) int {
-	command := line[2:]
+func (c *cliState) pipeSyscmd(line string, nextState, errState cliStateEnum) cliStateEnum {
+	command := strings.Trim(line[2:], " \n\r\t\f")
 	if command == "" {
 		fmt.Fprintf(osStderr, "Usage:\n  \\| [command]\n")
-		return cliNextLine
+		c.exitErr = errInvalidSyntax
+		return errState
 	}
 
 	cmdOut, err := execSyscmd(command)
 	if err != nil {
 		fmt.Fprintf(osStderr, "command failed: %s\n", err)
-		return cliNextLine
+		c.exitErr = err
+		return errState
 	}
 
-	*stmt = append(*stmt, cmdOut)
-	return cliProcessQuery
+	c.lastInputLine = cmdOut
+	return nextState
 }
 
 // preparePrompts computes a full and short prompt for the interactive
@@ -295,20 +370,33 @@ func preparePrompts(dbURL string) (fullPrompt string, continuePrompt string) {
 	return fullPrompt, continuePrompt
 }
 
+// endsWithIncompleteTxn returns true if and only if its
+// argument ends with an incomplete transaction prefix (BEGIN without
+// ROLLBACK/COMMIT).
+func endsWithIncompleteTxn(stmts parser.StatementList) bool {
+	txnStarted := false
+	for _, stmt := range stmts {
+		switch stmt.(type) {
+		case *parser.BeginTransaction:
+			txnStarted = true
+		case *parser.CommitTransaction, *parser.RollbackTransaction:
+			txnStarted = false
+		}
+	}
+	return txnStarted
+}
+
 var cmdHistFile = envutil.EnvOrDefaultString("COCKROACH_SQL_CLI_HISTORY", ".cockroachdb_history")
 
-// runInteractive runs the SQL client interactively, presenting
-// a prompt to the user for each statement.
-func runInteractive(conn *sqlConn, config *readline.Config) (exitErr error) {
-	fullPrompt, continuePrompt := preparePrompts(conn.url)
-
-	ins, err := readline.NewEx(config)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = ins.Close() }()
+func (c *cliState) doStart(nextState cliStateEnum) cliStateEnum {
+	// Common initialization.
+	c.syntax = parser.Traditional
+	c.querySyntax = true
+	c.partialLines = []string{}
 
 	if isInteractive {
+		c.fullPrompt, c.continuePrompt = preparePrompts(c.conn.url)
+
 		// We only enable history management when the terminal is actually
 		// interactive. This saves on memory when e.g. piping a large SQL
 		// script through the command-line client.
@@ -320,146 +408,27 @@ func runInteractive(conn *sqlConn, config *readline.Config) (exitErr error) {
 			}
 		} else {
 			histFile := filepath.Join(userAcct.HomeDir, cmdHistFile)
-			cfg := ins.Config.Clone()
+			cfg := c.ins.Config.Clone()
 			cfg.HistoryFile = histFile
 			cfg.HistorySearchFold = true
-			ins.SetConfig(cfg)
+			c.ins.SetConfig(cfg)
 		}
+
+		// The user only gets to see the info screen on interactive session.
 		fmt.Print(infoMessage)
+
+		c.checkSyntax = true
+		c.normalizeHistory = true
+		c.errExit = false
 	} else {
 		// When running non-interactive, by default we want errors to stop
 		// further processing and all syntax checking to be done
 		// server-side.
-		options["errexit"] = true
-		options["check_syntax"] = false
+		c.errExit = true
+		c.checkSyntax = false
 	}
 
-	var stmt []string
-	syntax := parser.Traditional
-
-	for isFinished := false; !isFinished; {
-		if isInteractive {
-			thisPrompt := fullPrompt
-			if len(stmt) > 0 {
-				thisPrompt = continuePrompt
-			}
-			ins.SetPrompt(thisPrompt)
-		}
-
-		l, err := ins.Readline()
-
-		if isInteractive && err == readline.ErrInterrupt && (len(stmt) > 0 || l != "") {
-			// In interactive mode, Ctrl+C after the beginning of a
-			// statement cancels the current statement entirely; only Ctrl+C
-			// at the beginning of a new statement terminates the shell.
-			stmt = stmt[:0]
-			continue
-		}
-		if !isInteractive && err == io.EOF {
-			// In non-interactive mode, we want EOF to finish the last statement.
-			err = nil
-			isFinished = true
-		}
-		if err == readline.ErrInterrupt || err == io.EOF {
-			break
-		} else if err != nil {
-			fmt.Fprintf(osStderr, "input error: %s\n", err)
-			return err
-		}
-
-		// Check if this is a request for help or a client-side command.
-		// If so, process it directly and skip query processing below.
-		status, hasSet, isEmpty, endsWithSemi := handleInputLine(ins, &stmt, l, syntax)
-		if status == cliExit {
-			break
-		}
-		if isEmpty || (status == cliNextLine && !isFinished) {
-			// Ask for more input unless we reached EOF.
-			continue
-		}
-		if isFinished && len(stmt) == 0 {
-			// Exit if we reached EOF and the currently built-up statement is empty.
-			break
-		}
-
-		// We join the statements back together with newlines in case
-		// there is a significant newline inside a string literal.
-		fullStmt := strings.TrimRight(strings.Join(stmt, "\n"), " \n\t\f")
-
-		// Ensure the statement is terminated with a semicolon. This
-		// catches cases where the last line before EOF was not terminated
-		// properly.
-		if len(fullStmt) > 0 && !endsWithSemi {
-			if strings.TrimSpace(fullStmt) == "" {
-				// Only whitespace. Nothing to do really.
-				continue
-			}
-
-			// That was the last line of input but some statement bits
-			// were accumulated. Report an error.
-			fmt.Fprintf(osStderr, "missing semicolon at end of statement: %q\n", fullStmt)
-			return fmt.Errorf("last statement was not executed")
-		}
-
-		// Clear the saved statement.
-		stmt = stmt[:0]
-
-		skipStmt := false
-		exitIfErr, _ := options["errexit"]
-
-		// If client-side syntax checking is enabled, parse the statement
-		// before sending it to the server. If it fails to parse, inform
-		// the user then stop processing if the `errexit` option is set.
-		// Otherwise, pretty-print the resulting AST to populate the
-		// history.
-		normalizedStmt := fullStmt
-		if doCheck, _ := options["check_syntax"]; doCheck {
-			var parser parser.Parser
-			stmts, err := parser.Parse(fullStmt, syntax)
-			if err != nil {
-				fmt.Fprintf(osStderr, "statement not sent to server: %v", err)
-				exitErr = err
-				if exitIfErr {
-					break
-				}
-				skipStmt = true
-			} else if normalizeHistory, _ := options["normalize_history"]; normalizeHistory {
-				normalizedStmt = stmts.String() + ";"
-			}
-		}
-
-		if isInteractive {
-			// We save the history between each statement, This enables
-			// reusing history in another SQL shell without closing the
-			// current shell.
-			addHistory(ins, normalizedStmt)
-		}
-
-		if skipStmt {
-			// If a syntax error was detected client-side, don't try to go
-			// to the server and simply try again.
-			continue
-		}
-
-		if exitErr = runQueryAndFormatResults(conn, os.Stdout, makeQuery(fullStmt), cliCtx.prettyFmt); exitErr != nil {
-			fmt.Fprintln(osStderr, exitErr)
-		}
-
-		if exitErr != nil && exitIfErr {
-			break
-		}
-
-		if hasSet {
-			newSyntax, err := getSyntax(conn)
-			if err != nil {
-				fmt.Fprintf(osStderr, "could not get session syntax: %s", err)
-			} else {
-				syntax = newSyntax
-			}
-		}
-	}
-
-	return exitErr
+	return nextState
 }
 
 func getSyntax(conn *sqlConn) (parser.Syntax, error) {
@@ -474,6 +443,381 @@ func getSyntax(conn *sqlConn) (parser.Syntax, error) {
 		return parser.Modern, nil
 	}
 	return 0, fmt.Errorf("unknown syntax: %s", rows[0][0])
+}
+
+func (c *cliState) doQuerySyntax(nextState cliStateEnum) cliStateEnum {
+	if !c.querySyntax {
+		return nextState
+	}
+
+	newSyntax, err := getSyntax(c.conn)
+	if err != nil {
+		fmt.Fprintf(osStderr, "warning: could not get session syntax: %s\n", err)
+		// For now this is just a warning.
+	} else {
+		c.syntax = newSyntax
+	}
+	return nextState
+}
+
+func (c *cliState) doStartLine(nextState cliStateEnum) cliStateEnum {
+	// Clear the input buffer.
+	c.atEOF = false
+	c.querySyntax = false
+	c.partialLines = c.partialLines[:0]
+	c.partialStmtsLen = 0
+
+	if isInteractive {
+		c.ins.SetPrompt(c.fullPrompt)
+	}
+
+	return nextState
+}
+
+func (c *cliState) doContinueLine(nextState cliStateEnum) cliStateEnum {
+	c.atEOF = false
+
+	if isInteractive {
+		c.ins.SetPrompt(c.continuePrompt)
+	}
+
+	return nextState
+}
+
+// doReadline reads a line of input and check the input status.  If
+// input was successful it populates c.lastInputLine.  Otherwise
+// c.exitErr is set in some cases and an error/retry state is returned.
+func (c *cliState) doReadLine(nextState cliStateEnum) cliStateEnum {
+	l, err := c.ins.Readline()
+
+	switch err {
+	case nil:
+		// Good to go.
+
+	case readline.ErrInterrupt:
+		if !isInteractive {
+			// Ctrl+C terminates non-interactive shells in all cases.
+			c.exitErr = err
+			return cliStop
+		}
+
+		if l != "" {
+			// Ctrl+C after the beginning of a line cancels the current
+			// line.
+			return cliReadLine
+		}
+
+		if len(c.partialLines) > 0 {
+			// Ctrl+C at the beginning of a line in a multi-line statement
+			// cancels the multi-line statement.
+			return cliStartLine
+		}
+
+		// Otherwise, also terminate with an interrupt error.
+		c.exitErr = err
+		return cliStop
+
+	case io.EOF:
+		c.atEOF = true
+
+		if isInteractive {
+			// In interactive mode, EOF terminates.
+			// exitErr is left to be whatever has set it previously.
+			return cliStop
+		}
+
+		// Non-interactive: if no partial statement, EOF terminates.
+		// exitErr is left to be whatever has set it previously.
+		if len(c.partialLines) == 0 {
+			return cliStop
+		}
+
+		// Otherwise, give the shell a chance to process the last input line.
+
+	default:
+		// Other errors terminate the shell.
+		fmt.Fprintf(osStderr, "input error: %s\n", err)
+		c.exitErr = err
+		return cliStop
+	}
+
+	c.lastInputLine = l
+	return nextState
+}
+
+func (c *cliState) doProcessFirstLine(startState, nextState cliStateEnum) cliStateEnum {
+	// Special case: first line of multi-line statement.
+	// In this case ignore empty lines, and recognize "help" specially.
+	switch c.lastInputLine {
+	case "":
+		// Ignore empty lines, just continue reading.
+		return startState
+
+	case "help", "quit", "exit":
+		printCliHelp()
+		return startState
+	}
+
+	return nextState
+}
+
+func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnum {
+	if len(c.lastInputLine) == 0 || c.lastInputLine[0] != '\\' {
+		return nextState
+	}
+
+	errState := loopState
+	if c.errExit {
+		// If exiterr is set, an error in a client-side command also
+		// terminates the shell.
+		errState = cliStop
+	}
+
+	// This is a client-side command. Whatever happens, we are not going
+	// to handle it as a statement, so save the history.
+	c.addHistory(c.lastInputLine)
+
+	cmd := strings.Fields(c.lastInputLine)
+	switch cmd[0] {
+	case `\q`, `\quit`, `\exit`:
+		return cliStop
+
+	case `\`, `\?`, `\help`:
+		printCliHelp()
+
+	case `\set`:
+		return c.handleSet(cmd[1:], loopState, errState)
+
+	case `\unset`:
+		return c.handleUnset(cmd[1:], loopState, errState)
+
+	case `\!`:
+		return c.runSyscmd(c.lastInputLine, loopState, errState)
+
+	case `\show`:
+		if len(c.partialLines) == 0 {
+			fmt.Fprintf(osStderr, "No input so far. Did you mean SHOW?\n")
+		} else {
+			for _, s := range c.partialLines {
+				fmt.Println(s)
+			}
+		}
+
+	case `\|`:
+		return c.pipeSyscmd(c.lastInputLine, nextState, errState)
+
+	default:
+		if strings.HasPrefix(cmd[0], `\d`) {
+			// Unrecognized command for now, but we want to be helpful.
+			fmt.Fprint(osStderr, "Suggestion: use the SQL SHOW statement to inspect your schema.\n")
+		}
+		return c.invalidSyntax(errState, `%s. Try \? for help.`, c.lastInputLine)
+	}
+
+	return loopState
+}
+
+func (c *cliState) doPrepareStatementLine(
+	startState, contState, checkState, execState cliStateEnum,
+) cliStateEnum {
+	c.partialLines = append(c.partialLines, c.lastInputLine)
+
+	// We join the statements back together with newlines in case
+	// there is a significant newline inside a string literal.
+	c.concatLines = strings.Trim(strings.Join(c.partialLines, "\n"), " \r\n\t\f")
+
+	if c.concatLines == "" {
+		// Only whitespace.
+		return startState
+	}
+
+	isEmpty, endsWithSemi, hasSet := isEndOfStatement(c.concatLines, c.syntax)
+	if c.partialStmtsLen == 0 && isEmpty {
+		// More whitespace, or comments. Still nothing to do. However
+		// if the syntax was non-trivial to arrive here,
+		// keep it for history.
+		if c.lastInputLine != "" {
+			c.addHistory(c.lastInputLine)
+		}
+		return startState
+	}
+
+	c.querySyntax = hasSet
+
+	if c.atEOF {
+		// Definitely no more input expected.
+		if !endsWithSemi {
+			fmt.Fprintf(osStderr, "missing semicolon at end of statement: %s\n", c.concatLines)
+			c.exitErr = fmt.Errorf("last statement was not executed: %s", c.concatLines)
+			return cliStop
+		}
+	}
+
+	if !endsWithSemi {
+		return contState
+	}
+
+	if !c.checkSyntax {
+		// If syntax checking is not enabled, put the raw statement into
+		// history, then go and run it.
+		c.addHistory(c.concatLines)
+		return execState
+	}
+
+	return checkState
+}
+
+func (c *cliState) doCheckStatement(startState, contState, execState cliStateEnum) cliStateEnum {
+	// From here on, client-side syntax checking is enabled.
+	var parser parser.Parser
+	parsedStmts, err := parser.Parse(c.concatLines, c.syntax)
+	if err != nil {
+		_ = c.invalidSyntax(0, "statement ignored: %v", err)
+
+		// Even on failure, add the last (erroneous) lines as-is to the
+		// history, so that the user can recall them later to fix them.
+		for i := c.partialStmtsLen; i < len(c.partialLines); i++ {
+			c.addHistory(c.partialLines[i])
+		}
+
+		// Stop here if exiterr is set.
+		if c.errExit {
+			return cliStop
+		}
+
+		// Otherwise, remove the erroneous lines from the buffered input,
+		// then try again.
+		c.partialLines = c.partialLines[:c.partialStmtsLen]
+		if len(c.partialLines) == 0 {
+			return startState
+		}
+		return contState
+	}
+
+	if !isInteractive {
+		return execState
+	}
+
+	if c.normalizeHistory {
+		// Add statements, not lines, to the history.
+		for i := c.partialStmtsLen; i < len(parsedStmts); i++ {
+			c.addHistory(parsedStmts[i].String() + ";")
+		}
+	} else {
+		// Add the last lines received to the history.
+		for i := c.partialStmtsLen; i < len(c.partialLines); i++ {
+			c.addHistory(c.partialLines[i])
+		}
+	}
+
+	// Replace the last entered lines by the last entered statements.
+	c.partialLines = c.partialLines[:c.partialStmtsLen]
+	for i := c.partialStmtsLen; i < len(parsedStmts); i++ {
+		c.partialLines = append(c.partialLines, parsedStmts[i].String()+";")
+	}
+
+	nextState := execState
+
+	// In interactive mode, we make some additional effort to help the user:
+	// if the entry so far is starting an incomplete transaction, push
+	// the user to enter input over multiple lines.
+	if endsWithIncompleteTxn(parsedStmts) && c.lastInputLine != "" {
+		if c.partialStmtsLen == 0 {
+			fmt.Fprintln(osStderr, "Now adding input for a multi-line SQL transaction client-side.\n"+
+				"Press Enter two times to send the SQL text collected so far to the server, or Ctrl+C to cancel.")
+		}
+
+		nextState = contState
+	}
+
+	c.partialStmtsLen = len(parsedStmts)
+
+	return nextState
+}
+
+func (c *cliState) doRunStatement(nextState cliStateEnum) cliStateEnum {
+	c.exitErr = runQueryAndFormatResults(c.conn, os.Stdout, makeQuery(c.concatLines), cliCtx.prettyFmt)
+	if c.exitErr != nil {
+		fmt.Fprintln(osStderr, c.exitErr)
+		if c.errExit {
+			return cliStop
+		}
+	}
+	return nextState
+}
+
+func (c *cliState) doDecidePath() cliStateEnum {
+	if len(c.partialLines) == 0 {
+		return cliProcessFirstLine
+	} else if isInteractive {
+		// In interactive mode, we allow client-side commands to be
+		// issued on intermediate lines.
+		return cliHandleCliCmd
+	}
+	// Neither interactive nor at start, continue with processing.
+	return cliPrepareStatementLine
+}
+
+// runInteractive runs the SQL client interactively, presenting
+// a prompt to the user for each statement.
+func runInteractive(conn *sqlConn, config *readline.Config) (exitErr error) {
+	c := cliState{conn: conn}
+
+	state := cliStart
+	for {
+		if state == cliStop {
+			break
+		}
+		switch state {
+		case cliStart:
+			// The readline initialization is not placed in
+			// the doStart() method because of the defer.
+			c.ins, c.exitErr = readline.NewEx(config)
+			if c.exitErr != nil {
+				return c.exitErr
+			}
+			defer func() { _ = c.ins.Close() }()
+
+			state = c.doStart(cliQuerySyntax)
+
+		case cliQuerySyntax:
+			state = c.doQuerySyntax(cliStartLine)
+
+		case cliStartLine:
+			state = c.doStartLine(cliReadLine)
+
+		case cliContinueLine:
+			state = c.doContinueLine(cliReadLine)
+
+		case cliReadLine:
+			state = c.doReadLine(cliDecidePath)
+
+		case cliDecidePath:
+			state = c.doDecidePath()
+
+		case cliProcessFirstLine:
+			state = c.doProcessFirstLine(cliReadLine, cliHandleCliCmd)
+
+		case cliHandleCliCmd:
+			state = c.doHandleCliCmd(cliReadLine, cliPrepareStatementLine)
+
+		case cliPrepareStatementLine:
+			state = c.doPrepareStatementLine(
+				cliStartLine, cliContinueLine, cliCheckStatement, cliRunStatement,
+			)
+
+		case cliCheckStatement:
+			state = c.doCheckStatement(cliStartLine, cliContinueLine, cliRunStatement)
+
+		case cliRunStatement:
+			state = c.doRunStatement(cliQuerySyntax)
+
+		default:
+			panic(fmt.Sprintf("unknown state: %d", state))
+		}
+	}
+
+	return c.exitErr
 }
 
 // runOneStatement executes one statement and terminates

--- a/pkg/cli/sql_test.go
+++ b/pkg/cli/sql_test.go
@@ -177,7 +177,7 @@ func TestIsEndOfStatement(t *testing.T) {
 		if syntax == 0 {
 			syntax = parser.Traditional
 		}
-		isEmpty, isEnd, hasSet := isEndOfStatement(syntax, &[]string{test.in})
+		isEmpty, isEnd, hasSet := isEndOfStatement(test.in, syntax)
 		if isEmpty != test.isEmpty {
 			t.Errorf("%q: isEmpty expected %v, got %v", test.in, test.isEmpty, isEmpty)
 		}


### PR DESCRIPTION
This patch introduces several features and fixes a bug.
- New feature: when a user starts a transaction interactively, the
  shell now prompts the user to edit the entirety of the transaction
  locally before the SQL is sent to the server. This invites the user
  to avoid long-running transactions. The user can override this
  behavior by pressing "Enter" two times (this forces the SQL
  collected so far to go to the server).
- New feature: when the user is editing a multi-line statement (either
  a statement not yet terminated by a semicolon, or additional
  statements in a multi-line transaction), a new client-side "\show"
  command prints out the SQL code collected so far.
- Bug fix: when wrong SQL that spans multiple lines is added, the
  shell history is now populated by the individual lines of the
  erroneous statement, as opposed to a single history entry containing
  newline characters.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10187)

<!-- Reviewable:end -->
