### PR TITLE
*: skip flaky tests only optionally

### DIFF
--- a/build/teamcity-acceptance.sh
+++ b/build/teamcity-acceptance.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -euxo pipefail
+
+
 build/builder.sh make build
 build/builder.sh make install
 build/builder.sh go test -v -c -tags acceptance ./pkg/acceptance
 cd pkg/acceptance
-../../acceptance.test -nodes 3 -l ../../artifacts/acceptance -test.v -test.timeout 10m 2>&1 | go-test-teamcity
+COCKROACH_SKIP_FLAKY_TESTS=true ../../acceptance.test -nodes 3 -l ../../artifacts/acceptance -test.v -test.timeout 10m 2>&1 | go-test-teamcity

--- a/build/teamcity-stress.sh
+++ b/build/teamcity-stress.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 mkdir artifacts
 
 exit_status=0
-build/builder.sh make stress PKG="$PKG" GOFLAGS="${GOFLAGS-}" TAGS="${TAGS-}" TESTTIMEOUT=0 TESTFLAGS='-test.v' STRESSFLAGS='-maxtime 15m -maxfails 1 -stderr' 2>&1 | tee artifacts/stress.log || exit_status=$?
+build/builder.sh make stress PKG="$PKG" GOFLAGS="${GOFLAGS-}" TAGS="${TAGS-}" TESTTIMEOUT=0 TESTFLAGS='-test.v' COCKROACH_SKIP_FLAKY_TESTS=true STRESSFLAGS='-maxtime 15m -maxfails 1 -stderr' 2>&1 | tee artifacts/stress.log || exit_status=$?
 
 if [ $exit_status -ne 0 ]; then
   build/builder.sh env GITHUB_API_TOKEN="$GITHUB_API_TOKEN" BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" post-github < artifacts/stress.log

--- a/build/teamcity-test.sh
+++ b/build/teamcity-test.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 set -euxo pipefail
-build/builder.sh make test TESTFLAGS='-v' 2>&1 | go-test-teamcity
+
+build/builder.sh make test TESTFLAGS='-v' COCKROACH_SKIP_FLAKY_TESTS=true 2>&1 | go-test-teamcity

--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 set -euxo pipefail
-build/builder.sh make testrace TESTFLAGS='-v' 2>&1 | go-test-teamcity
+
+build/builder.sh make testrace TESTFLAGS='-v' COCKROACH_SKIP_FLAKY_TESTS=true 2>&1 | go-test-teamcity

--- a/pkg/acceptance/chaos_test.go
+++ b/pkg/acceptance/chaos_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/flaky"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -309,7 +310,7 @@ func waitClientsStop(num int, state *testState, stallDuration time.Duration) {
 // being killed and restarted continuously. The test doesn't measure write
 // performance, but cluster recovery.
 func TestClusterRecovery(t *testing.T) {
-	t.Skip("Skipped due to flakiness until we can investigate #8538 further.")
+	flaky.Register(t, 8538)
 	runTestOnConfigs(t, testClusterRecoveryInner)
 }
 

--- a/pkg/acceptance/cli_test.go
+++ b/pkg/acceptance/cli_test.go
@@ -35,7 +35,8 @@ var cmdBase = []string{
 
 func TestDockerCLI(t *testing.T) {
 	if err := testDockerOneShot(t, "cli_test", []string{"stat", cluster.CockroachBinaryInContainer}); err != nil {
-		t.Skipf(`TODO(dt): No binary in one-shot container, see #6086: %s`, err)
+		// See #6086.
+		t.Skipf("no binary in one-shot container: %s", err)
 	}
 
 	paths, err := filepath.Glob(testGlob)

--- a/pkg/acceptance/finagle_test.go
+++ b/pkg/acceptance/finagle_test.go
@@ -14,11 +14,15 @@
 
 package acceptance
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/flaky"
+)
 
 // This runs the `finagle-postgres` tests from the upstream project.
 func TestDockerFinagle(t *testing.T) {
-	t.Skip("#8332. Upstream has a 2s timeout, disabled until we run tests somewhere more consistent.")
+	flaky.Register(t, 8332, "upstream has a 2s timeout")
 	testDockerSuccess(t, "finagle", []string{"/bin/sh", "-c", finagle})
 }
 

--- a/pkg/acceptance/freeze_test.go
+++ b/pkg/acceptance/freeze_test.go
@@ -33,11 +33,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/flaky"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 func TestFreezeCluster(t *testing.T) {
-	t.Skip("#7957")
+	flaky.Register(t, 7957)
 	runTestOnConfigs(t, testFreezeClusterInner)
 }
 

--- a/pkg/acceptance/partition_test.go
+++ b/pkg/acceptance/partition_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
+	"github.com/cockroachdb/cockroach/pkg/util/flaky"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -49,7 +50,7 @@ func TestPartitionNemesis(t *testing.T) {
 }
 
 func TestPartitionBank(t *testing.T) {
-	t.Skip("#7978")
+	flaky.Register(t, 7978)
 	SkipUnlessPrivileged(t)
 	runTestOnConfigs(t, testBankWithNemesis(BidirectionalPartitionNemesis))
 }

--- a/pkg/acceptance/reference_test.go
+++ b/pkg/acceptance/reference_test.go
@@ -25,7 +25,8 @@ import (
 
 func runReferenceTestWithScript(t *testing.T, script string) {
 	if err := testDockerOneShot(t, "reference", []string{"stat", cluster.CockroachBinaryInContainer}); err != nil {
-		t.Skipf(`TODO(dt): No binary in one-shot container, see #6086: %s`, err)
+		// See #6086.
+		t.Skipf("no binary in one-shot container: %s", err)
 	}
 
 	if err := testDockerOneShot(t, "reference", []string{"/bin/bash", "-c", script}); err != nil {

--- a/pkg/acceptance/repair_test.go
+++ b/pkg/acceptance/repair_test.go
@@ -20,13 +20,18 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/acceptance/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/flaky"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
 // RepairTest kills and starts new nodes systematically to ensure we do
 // indeed repair the cluster.
 func TestRepair(t *testing.T) {
-	t.Skip("TODO(bram): skip this test until failures are investigated - #6798, #6700, #6277, #6209, #5672")
+	flaky.Register(t, 6798)
+	flaky.Register(t, 6700)
+	flaky.Register(t, 6277)
+	flaky.Register(t, 6209)
+	flaky.Register(t, 5672)
 	runTestOnConfigs(t, testRepairInner)
 }
 

--- a/pkg/internal/rsg/yacc/parse_test.go
+++ b/pkg/internal/rsg/yacc/parse_test.go
@@ -29,8 +29,6 @@ import (
 const sqlYPath = "../../../sql/parser/sql.y"
 
 func TestLex(t *testing.T) {
-	t.Skip("broken on CircleCI")
-
 	b, err := ioutil.ReadFile(sqlYPath)
 	if err != nil {
 		t.Fatal(err)
@@ -49,8 +47,6 @@ Loop:
 }
 
 func TestParse(t *testing.T) {
-	t.Skip("broken on CircleCI")
-
 	b, err := ioutil.ReadFile(sqlYPath)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/server/admin_cluster_test.go
+++ b/pkg/server/admin_cluster_test.go
@@ -26,12 +26,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/flaky"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 func TestAdminAPITableStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#8890")
+	flaky.Register(t, 8890)
 
 	const nodeCount = 3
 	tc := testcluster.StartTestCluster(t, nodeCount, base.TestClusterArgs{

--- a/pkg/sql/copy_in_test.go
+++ b/pkg/sql/copy_in_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/flaky"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/lib/pq"
 )
@@ -291,7 +292,8 @@ func TestCopyError(t *testing.T) {
 func TestCopyOne(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	t.Skip("https://github.com/lib/pq/issues/494")
+	t.Skip("since it was marked as flaky due to race detector warnings, this test has completely rotted and now times out")
+	flaky.Register(t, 0, "https://github.com/lib/pq/issues/494")
 
 	params, _ := createTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
@@ -325,7 +327,8 @@ func TestCopyOne(t *testing.T) {
 func TestCopyInProgress(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	t.Skip("https://github.com/lib/pq/issues/494")
+	t.Skip("since it was marked as flaky due to race detector warnings, this test has completely rotted and now times out")
+	flaky.Register(t, 0, "https://github.com/lib/pq/issues/494")
 
 	params, _ := createTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)

--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/flaky"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -589,7 +590,7 @@ CREATE TABLE test.t(a INT PRIMARY KEY);
 // to use a table descriptor with an expired lease.
 func TestTxnObeysLeaseExpiration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("TODO(vivek): #7031")
+	flaky.Register(t, 7031)
 	// Set the lease duration such that it expires quickly.
 	savedLeaseDuration, savedMinLeaseDuration := csql.LeaseDuration, csql.MinLeaseDuration
 	defer func() {

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
+	"github.com/cockroachdb/cockroach/pkg/util/flaky"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -1123,7 +1124,7 @@ func TestNonRetryableErrorOnCommit(t *testing.T) {
 // the clock, so that the transaction timestamp exceeds the deadline of the EndTransactionRequest.
 func TestReacquireLeaseOnRestart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#9774")
+	flaky.Register(t, 9774)
 
 	var cmdFilters CommandFilters
 	cmdFilters.AppendFilter(checkEndTransactionTrigger, true)

--- a/pkg/storage/client_metrics_test.go
+++ b/pkg/storage/client_metrics_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/flaky"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/pkg/errors"
@@ -148,8 +149,8 @@ func verifyRocksDBStats(t *testing.T, s *storage.Store) {
 		{m.RdbBlockCacheMisses, 0},
 		{m.RdbBlockCacheUsage, 0},
 		{m.RdbBlockCachePinnedUsage, 0},
-		{m.RdbBloomFilterPrefixChecked, 20},
-		{m.RdbBloomFilterPrefixUseful, 20},
+		{m.RdbBloomFilterPrefixChecked, 0}, // see #10085
+		{m.RdbBloomFilterPrefixUseful, 0},  // see #10085
 		{m.RdbMemtableHits, 0},
 		{m.RdbMemtableMisses, 0},
 		{m.RdbMemtableTotalSize, 5000},
@@ -166,7 +167,7 @@ func verifyRocksDBStats(t *testing.T, s *storage.Store) {
 
 func TestStoreMetrics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("TODO(mrtracy): #9204")
+	flaky.Register(t, 9204)
 
 	mtc := startMultiTestContext(t, 3)
 	defer mtc.Stop()

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/flaky"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -2081,7 +2082,9 @@ func TestReplicateRemovedNodeDisruptiveElection(t *testing.T) {
 	// The change to error reporting means that we can no longer trap
 	// transport errors separately from error messages and send them to
 	// errChan.
-	t.Skip("TODO(bdarnell): flaky (#8308), and needs update for change to raft transport error reporting")
+	t.Skip("needs update for change to raft transport error reporting")
+	// It's also flaky.
+	flaky.Register(t, 8308)
 
 	mtc := startMultiTestContext(t, 4)
 	defer mtc.Stop()

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/flaky"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -1024,7 +1025,7 @@ func TestSplitSnapshotRace_SplitWins(t *testing.T) {
 // so it still has a conflicting range.
 func TestSplitSnapshotRace_SnapshotWins(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#8416")
+	flaky.Register(t, 8416)
 	runSetupSplitSnapshotRace(t, func(mtc *multiTestContext, leftKey, rightKey roachpb.Key) {
 		// Bring the right range up first.
 		for i := 3; i <= 5; i++ {

--- a/pkg/storage/node_liveness_test.go
+++ b/pkg/storage/node_liveness_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/flaky"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
@@ -59,7 +60,7 @@ func stopNodeLivenessHeartbeats(mtc *multiTestContext) {
 
 func TestNodeLiveness(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#9973")
+	flaky.Register(t, 9973)
 	mtc := startMultiTestContext(t, 3)
 	defer mtc.Stop()
 

--- a/pkg/storage/raft_log_queue_test.go
+++ b/pkg/storage/raft_log_queue_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/flaky"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/coreos/etcd/raft"
 	"github.com/pkg/errors"
@@ -220,7 +221,7 @@ func TestGetTruncatableIndexes(t *testing.T) {
 // log even when replica scanning is disabled.
 func TestProactiveRaftLogTruncate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#9772")
+	flaky.Register(t, 9772)
 
 	store, _, stopper := createTestStore(t)
 	defer stopper.Stop()

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
+	"github.com/cockroachdb/cockroach/pkg/util/flaky"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -5970,7 +5971,7 @@ func TestReplicaCancelRaftCommandProgress(t *testing.T) {
 // in these commands applying at the computed indexes.
 func TestReplicaBurstPendingCommandsAndRepropose(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("TODO(bdarnell): https://github.com/cockroachdb/cockroach/issues/8422")
+	flaky.Register(t, 8422)
 	var tc testContext
 	tc.Start(t)
 	defer tc.Stop()

--- a/pkg/util/flaky/flaky.go
+++ b/pkg/util/flaky/flaky.go
@@ -1,0 +1,64 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package flaky
+
+import (
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// Skipper is a narrow subset of testing.TB required for Register().
+type Skipper interface {
+	Skip(...interface{})
+}
+
+const envVarName = "COCKROACH_SKIP_FLAKY_TESTS"
+
+var skipFlakyTests = envutil.EnvOrDefaultBool(envVarName, false)
+
+// Register should be called from tests which are deemed flaky, causing them to
+// be skipped whenever COCKROACH_SKIP_FLAKY_TESTS is set to a truthy value. The
+// parameters are typically the *testing.T, a cockroachdb/cockroach issue
+// number, and optionally comments on the test's flakyness. A zero issue number
+// can be passed when no issue is available.
+func Register(t Skipper, issueNumber int, comments ...string) {
+	var reason string
+	if len(comments) > 0 {
+		reason = strings.Join(comments, "\n") + "; "
+	}
+	var invoke func(...interface{})
+	if skipFlakyTests {
+		invoke = t.Skip
+	} else {
+		ctx := context.Background()
+		invoke = func(args ...interface{}) {
+			log.Warning(ctx, args...)
+		}
+	}
+	issue := "no issue filed"
+	if issueNumber > 0 {
+		issue = "https://github.com/cockroachdb/cockroach/issues/" + strconv.Itoa(issueNumber)
+	}
+	var addendum string
+	if !skipFlakyTests {
+		addendum = " (consider " + envVarName + "=true)"
+	}
+	invoke("test is flaky: " + reason + issue + addendum)
+}


### PR DESCRIPTION
Using `t.Skip{f,}` as the weapon of choice for flaky tests is not a good
solution as tests which never run tend to rot and wind up not only flaky, but
completely broken (see #10141).

On the other hand, _not_ skipping flaky tests is also doomed to fail since the
toll on developers is too high.

Introduce an alternative which skips tests based on the environment variable
`COCKROACH_SKIP_FLAKY_TESTS` whenever `flaky.Register(<issue_num>, <reason>)`
is called, along with a simple lint to avoid accidental use of `t.Skip{,f}`.
With the environment variable set to a truthy value, the test is skipped with
an informative message. Otherwise, a similarly informative message is logged as
a `Warning`, but the test continues to run.

Change existing `Skip{f,}`s to use this method, fixing up some tests in the
process and documenting completely broken ones (through an extra `Skip`).

Change the TeamCity build scripts to set `COCKROACH_SKIP_FLAKY_TESTS=true`.

The intention is that henceforth, we can more liberally mark tests as flaky and
still not have them rot as they still run occasionally, though unsatisfyingly
mostly on developer's machines. There's also a small upshot to stress testing:
there's no need to unskip a test which is to be stressed.

NB: Using a command-line parameter was considered, but the need to have that
flag registered with every package made it the less palatable option.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10197)

<!-- Reviewable:end -->
