### PR TITLE
storage: absorb RaftCommand into ReplicatedProposalData

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -424,12 +424,12 @@ func tryRaftLogEntry(kv engine.MVCCKeyValue) (string, error) {
 	if ent.Type == raftpb.EntryNormal {
 		if len(ent.Data) > 0 {
 			_, cmdData := storage.DecodeRaftCommand(ent.Data)
-			var cmd storagebase.RaftCommand
+			var cmd storagebase.ReplicatedProposalData
 			if err := cmd.Unmarshal(cmdData); err != nil {
 				return "", err
 			}
 			ent.Data = nil
-			return fmt.Sprintf("%s by %v\n%s\n%s\n", &ent, cmd.OriginReplica, &cmd.Cmd, &cmd), nil
+			return fmt.Sprintf("%s by %v\n%s\n%s\n", &ent, cmd.OriginReplica, cmd.Cmd, &cmd), nil
 		}
 		return fmt.Sprintf("%s: EMPTY\n", &ent), nil
 	} else if ent.Type == raftpb.EntryConfChange {
@@ -441,7 +441,7 @@ func tryRaftLogEntry(kv engine.MVCCKeyValue) (string, error) {
 		if err := ctx.Unmarshal(cc.Context); err != nil {
 			return "", err
 		}
-		var cmd storagebase.RaftCommand
+		var cmd storagebase.ReplicatedProposalData
 		if err := cmd.Unmarshal(ctx.Payload); err != nil {
 			return "", err
 		}

--- a/pkg/roachpb/string_test.go
+++ b/pkg/roachpb/string_test.go
@@ -62,7 +62,9 @@ func TestTransactionString(t *testing.T) {
 	var txnEmpty roachpb.Transaction
 	_ = txnEmpty.String() // prevent regression of NPE
 
-	var cmd storagebase.RaftCommand
+	cmd := storagebase.ReplicatedProposalData{
+		Cmd: &roachpb.BatchRequest{},
+	}
 	cmd.Cmd.Txn = &txn
 	if actStr, idStr := fmt.Sprintf("%s", &cmd), txn.ID.String(); !strings.Contains(actStr, idStr) {
 		t.Fatalf("expected to find '%s' in '%s'", idStr, actStr)

--- a/pkg/storage/raft.go
+++ b/pkg/storage/raft.go
@@ -184,7 +184,7 @@ func raftEntryFormatter(data []byte) string {
 		// large snapshot entries.
 		return fmt.Sprintf("[%x] [%d]", commandID, len(data))
 	}
-	var cmd storagebase.RaftCommand
+	var cmd storagebase.ReplicatedProposalData
 	if err := proto.Unmarshal(encodedCmd, &cmd); err != nil {
 		return fmt.Sprintf("[error parsing entry: %s]", err)
 	}

--- a/pkg/storage/raft.pb.go
+++ b/pkg/storage/raft.pb.go
@@ -203,7 +203,7 @@ func (*SnapshotResponse) Descriptor() ([]byte, []int) { return fileDescriptorRaf
 type ConfChangeContext struct {
 	CommandID string `protobuf:"bytes,1,opt,name=command_id,json=commandId" json:"command_id"`
 	// Payload is the application-level command (i.e. an encoded
-	// storagebase.RaftCommand).
+	// storagebase.ReplicatedProposalData).
 	Payload []byte `protobuf:"bytes,2,opt,name=payload" json:"payload,omitempty"`
 	// Replica contains full details about the replica being added or removed.
 	Replica cockroach_roachpb.ReplicaDescriptor `protobuf:"bytes,3,opt,name=replica" json:"replica"`

--- a/pkg/storage/raft.proto
+++ b/pkg/storage/raft.proto
@@ -149,7 +149,7 @@ message ConfChangeContext {
       (gogoproto.customname) = "CommandID"];
 
   // Payload is the application-level command (i.e. an encoded
-  // storagebase.RaftCommand).
+  // storagebase.ReplicatedProposalData).
   optional bytes payload = 2;
 
   // Replica contains full details about the replica being added or removed.

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1717,10 +1717,10 @@ func (r *Replica) evaluateProposal(
 	// since evaluating a proposal is expensive (at least under proposer-
 	// evaluated KV).
 	var pd ProposalData
-	pd.RaftCommand = &storagebase.RaftCommand{
+	pd.ReplicatedProposalData = storagebase.ReplicatedProposalData{
 		RangeID:       r.RangeID,
 		OriginReplica: replica,
-		Cmd:           ba,
+		Cmd:           &ba,
 	}
 	pd.ctx = ctx
 	pd.idKey = idKey
@@ -1736,13 +1736,13 @@ func (r *Replica) insertProposalLocked(pd *ProposalData) {
 	if r.mu.lastAssignedLeaseIndex < r.mu.state.LeaseAppliedIndex {
 		r.mu.lastAssignedLeaseIndex = r.mu.state.LeaseAppliedIndex
 	}
-	if !pd.RaftCommand.Cmd.IsLeaseRequest() {
+	if !pd.Cmd.IsLeaseRequest() {
 		r.mu.lastAssignedLeaseIndex++
 	}
-	pd.RaftCommand.MaxLeaseIndex = r.mu.lastAssignedLeaseIndex
+	pd.MaxLeaseIndex = r.mu.lastAssignedLeaseIndex
 	if log.V(4) {
 		log.Infof(pd.ctx, "submitting proposal %x: maxLeaseIndex=%d",
-			pd.idKey, pd.RaftCommand.MaxLeaseIndex)
+			pd.idKey, pd.MaxLeaseIndex)
 	}
 
 	if _, ok := r.mu.proposals[pd.idKey]; ok {
@@ -1837,26 +1837,26 @@ func (r *Replica) isSoloReplicaLocked() bool {
 }
 
 func defaultSubmitProposalLocked(r *Replica, p *ProposalData) error {
-	if p.RaftCommand.Cmd.Timestamp == hlc.ZeroTimestamp {
+	if p.Cmd.Timestamp == hlc.ZeroTimestamp {
 		return errors.Errorf("can't propose Raft command with zero timestamp")
 	}
 
 	ctx := r.AnnotateCtx(context.TODO())
 
-	data, err := protoutil.Marshal(p.RaftCommand)
+	data, err := protoutil.Marshal(&p.ReplicatedProposalData)
 	if err != nil {
 		return err
 	}
 	defer r.store.enqueueRaftUpdateCheck(r.RangeID)
 
-	if union, ok := p.RaftCommand.Cmd.GetArg(roachpb.EndTransaction); ok {
+	if union, ok := p.Cmd.GetArg(roachpb.EndTransaction); ok {
 		ict := union.(*roachpb.EndTransactionRequest).InternalCommitTrigger
 		if crt := ict.GetChangeReplicasTrigger(); crt != nil {
 			// EndTransactionRequest with a ChangeReplicasTrigger is special
 			// because raft needs to understand it; it cannot simply be an
 			// opaque command.
 			log.Infof(ctx, "proposing %s %+v for range %d: %+v",
-				crt.ChangeType, crt.Replica, p.RaftCommand.RangeID, crt.UpdatedReplicas)
+				crt.ChangeType, crt.Replica, p.RangeID, crt.UpdatedReplicas)
 
 			confChangeCtx := ConfChangeContext{
 				CommandID: string(p.idKey),
@@ -2115,7 +2115,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(inSnap IncomingSnapshot) error {
 		case raftpb.EntryNormal:
 
 			var commandID storagebase.CmdIDKey
-			var command storagebase.RaftCommand
+			var command storagebase.ReplicatedProposalData
 
 			// Process committed entries. etcd raft occasionally adds a nil entry
 			// (our own commands are never empty). This happens in two situations:
@@ -2153,7 +2153,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(inSnap IncomingSnapshot) error {
 			if err := ccCtx.Unmarshal(cc.Context); err != nil {
 				return err
 			}
-			var command storagebase.RaftCommand
+			var command storagebase.ReplicatedProposalData
 			if err := command.Unmarshal(ccCtx.Payload); err != nil {
 				return err
 			}
@@ -2439,7 +2439,7 @@ type pendingCmdSlice []*ProposalData
 func (s pendingCmdSlice) Len() int      { return len(s) }
 func (s pendingCmdSlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s pendingCmdSlice) Less(i, j int) bool {
-	return s[i].RaftCommand.MaxLeaseIndex < s[j].RaftCommand.MaxLeaseIndex
+	return s[i].MaxLeaseIndex < s[j].MaxLeaseIndex
 }
 
 //go:generate stringer -type refreshRaftReason
@@ -2473,7 +2473,7 @@ func (r *Replica) refreshProposalsLocked(refreshAtDelta int, reason refreshRaftR
 	numShouldRetry := 0
 	var reproposals pendingCmdSlice
 	for idKey, p := range r.mu.proposals {
-		if p.RaftCommand.MaxLeaseIndex > maxMustRetryCommandIndex {
+		if p.MaxLeaseIndex > maxMustRetryCommandIndex {
 			if p.proposedAtTicks > refreshAtTicks {
 				// The command was proposed too recently, don't bother reproprosing
 				// it yet. Note that if refreshAtDelta is 0, refreshAtTicks will be
@@ -2727,7 +2727,10 @@ func (r *Replica) reportSnapshotStatus(to uint64, snapErr error) {
 // which will apply as a no-op (without accessing raftCmd, via an error),
 // updating only the applied index.
 func (r *Replica) processRaftCommand(
-	ctx context.Context, idKey storagebase.CmdIDKey, index uint64, raftCmd storagebase.RaftCommand,
+	ctx context.Context,
+	idKey storagebase.CmdIDKey,
+	index uint64,
+	raftCmd storagebase.ReplicatedProposalData,
 ) (pErr *roachpb.Error) {
 	if index == 0 {
 		log.Fatalf(ctx, "processRaftCommand requires a non-zero index")
@@ -2838,10 +2841,10 @@ func (r *Replica) processRaftCommand(
 	}
 	r.mu.Unlock()
 
-	if splitMergeUnlock := r.maybeAcquireSplitMergeLock(raftCmd.Cmd); splitMergeUnlock != nil {
-		defer func() {
-			splitMergeUnlock(pErr)
-		}()
+	// TODO(tschottdorf): not all commands have a BatchRequest (for example,
+	// empty appends). Be more careful with this in proposer-eval'ed KV.
+	if raftCmd.Cmd == nil {
+		raftCmd.Cmd = &roachpb.BatchRequest{}
 	}
 
 	// applyRaftCommand will return "expected" errors, but may also indicate
@@ -2851,10 +2854,17 @@ func (r *Replica) processRaftCommand(
 		log.VEventf(ctx, 1, "applying command with forced error: %s", forcedErr)
 	} else {
 		log.Event(ctx, "applying command")
+
+		if splitMergeUnlock := r.maybeAcquireSplitMergeLock(*raftCmd.Cmd); splitMergeUnlock != nil {
+			defer func() {
+				splitMergeUnlock(pErr)
+			}()
+		}
+
 	}
 	var response proposalResult
 	{
-		pd := r.applyRaftCommand(ctx, idKey, index, leaseIndex, raftCmd.Cmd, forcedErr)
+		pd := r.applyRaftCommand(ctx, idKey, index, leaseIndex, *raftCmd.Cmd, forcedErr)
 		pd.Err = r.maybeSetCorrupt(ctx, pd.Err)
 
 		// TODO(tschottdorf): this field should be zeroed earlier.

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -711,8 +711,8 @@ const (
 	raftCommandNoSplitMask = raftCommandNoSplitBit - 1
 )
 
-// encode a command ID, an encoded storagebase.RaftCommand, and whether the
-// command contains a split.
+// encode a command ID, an encoded storagebase.ReplicatedProposalData, and
+// whether the command contains a split.
 func encodeRaftCommand(commandID storagebase.CmdIDKey, command []byte) []byte {
 	if len(commandID) != raftCommandIDLen {
 		panic(fmt.Sprintf("invalid command ID length; %d != %d", len(commandID), raftCommandIDLen))

--- a/pkg/storage/storagebase/proposer_kv.pb.go
+++ b/pkg/storage/storagebase/proposer_kv.pb.go
@@ -10,7 +10,6 @@
 		cockroach/pkg/storage/storagebase/state.proto
 
 	It has these top-level messages:
-		RaftCommand
 		Split
 		Merge
 		ReplicatedProposalData
@@ -42,12 +41,49 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 
-// A RaftCommand is a command which can be serialized and sent via
-// raft.
-type RaftCommand struct {
+// Split is emitted when a Replica commits a split trigger. It signals that the
+// Replica has prepared the on-disk state for both the left and right hand
+// sides of the split, and that the left hand side Replica should be updated as
+// well as the right hand side created.
+type Split struct {
+	cockroach_roachpb1.SplitTrigger `protobuf:"bytes,1,opt,name=trigger,embedded=trigger" json:"trigger"`
+	// RHSDelta holds the statistics for what was written to what is now the
+	// right-hand side of the split during the batch which executed it.
+	// The on-disk state of the right-hand side is already correct, but the
+	// Store must learn about this delta to update its counters appropriately.
+	RHSDelta cockroach_storage_engine_enginepb.MVCCStats `protobuf:"bytes,2,opt,name=rhs_delta,json=rhsDelta" json:"rhs_delta"`
+}
+
+func (m *Split) Reset()                    { *m = Split{} }
+func (m *Split) String() string            { return proto.CompactTextString(m) }
+func (*Split) ProtoMessage()               {}
+func (*Split) Descriptor() ([]byte, []int) { return fileDescriptorProposerKv, []int{0} }
+
+// Merge is emitted by a Replica which commits a transaction with
+// a MergeTrigger (i.e. absorbs its right neighbor).
+type Merge struct {
+	cockroach_roachpb1.MergeTrigger `protobuf:"bytes,1,opt,name=trigger,embedded=trigger" json:"trigger"`
+}
+
+func (m *Merge) Reset()                    { *m = Merge{} }
+func (m *Merge) String() string            { return proto.CompactTextString(m) }
+func (*Merge) ProtoMessage()               {}
+func (*Merge) Descriptor() ([]byte, []int) { return fileDescriptorProposerKv, []int{1} }
+
+// ReplicaProposalData is the structured information which together with
+// a RocksDB WriteBatch constitutes the proposal payload in proposer-evaluated
+// KV. For the majority of proposals, we expect ReplicatedProposalData to be
+// trivial; only changes to the metadata state (splits, merges, rebalances,
+// leases, log truncation, ...) of the Replica or certain special commands must
+// sideline information here based on which all Replicas must take action.
+//
+// TODO(tschottdorf): We may need to add a lease identifier to allow the
+// followers to reliably produce errors for proposals which apply after a
+// lease change.
+type ReplicatedProposalData struct {
 	RangeID       github_com_cockroachdb_cockroach_pkg_roachpb.RangeID `protobuf:"varint,1,opt,name=range_id,json=rangeId,casttype=github.com/cockroachdb/cockroach/pkg/roachpb.RangeID" json:"range_id"`
 	OriginReplica cockroach_roachpb.ReplicaDescriptor                  `protobuf:"bytes,2,opt,name=origin_replica,json=originReplica" json:"origin_replica"`
-	Cmd           cockroach_roachpb3.BatchRequest                      `protobuf:"bytes,3,opt,name=cmd" json:"cmd"`
+	Cmd           *cockroach_roachpb3.BatchRequest                     `protobuf:"bytes,3,opt,name=cmd" json:"cmd,omitempty"`
 	// When the command is applied, its result is an error if the lease log
 	// counter has already reached (or exceeded) max_lease_index.
 	//
@@ -75,120 +111,29 @@ type RaftCommand struct {
 	// updated accordingly. Managing retry of proposals becomes trickier as
 	// well as that uproots whatever ordering was originally envisioned.
 	MaxLeaseIndex uint64 `protobuf:"varint,4,opt,name=max_lease_index,json=maxLeaseIndex" json:"max_lease_index"`
-}
-
-func (m *RaftCommand) Reset()                    { *m = RaftCommand{} }
-func (m *RaftCommand) String() string            { return proto.CompactTextString(m) }
-func (*RaftCommand) ProtoMessage()               {}
-func (*RaftCommand) Descriptor() ([]byte, []int) { return fileDescriptorProposerKv, []int{0} }
-
-// Split is emitted when a Replica commits a split trigger. It signals that the
-// Replica has prepared the on-disk state for both the left and right hand
-// sides of the split, and that the left hand side Replica should be updated as
-// well as the right hand side created.
-type Split struct {
-	cockroach_roachpb1.SplitTrigger `protobuf:"bytes,1,opt,name=trigger,embedded=trigger" json:"trigger"`
-	// RHSDelta holds the statistics for what was written to what is now the
-	// right-hand side of the split during the batch which executed it.
-	// The on-disk state of the right-hand side is already correct, but the
-	// Store must learn about this delta to update its counters appropriately.
-	RHSDelta cockroach_storage_engine_enginepb.MVCCStats `protobuf:"bytes,2,opt,name=rhs_delta,json=rhsDelta" json:"rhs_delta"`
-}
-
-func (m *Split) Reset()                    { *m = Split{} }
-func (m *Split) String() string            { return proto.CompactTextString(m) }
-func (*Split) ProtoMessage()               {}
-func (*Split) Descriptor() ([]byte, []int) { return fileDescriptorProposerKv, []int{1} }
-
-// Merge is emitted by a Replica which commits a transaction with
-// a MergeTrigger (i.e. absorbs its right neighbor).
-type Merge struct {
-	cockroach_roachpb1.MergeTrigger `protobuf:"bytes,1,opt,name=trigger,embedded=trigger" json:"trigger"`
-}
-
-func (m *Merge) Reset()                    { *m = Merge{} }
-func (m *Merge) String() string            { return proto.CompactTextString(m) }
-func (*Merge) ProtoMessage()               {}
-func (*Merge) Descriptor() ([]byte, []int) { return fileDescriptorProposerKv, []int{2} }
-
-// ReplicaProposalData is the structured information which together with
-// a RocksDB WriteBatch constitutes the proposal payload in proposer-evaluated
-// KV. For the majority of proposals, we expect ReplicatedProposalData to be
-// trivial; only changes to the metadata state (splits, merges, rebalances,
-// leases, log truncation, ...) of the Replica or certain special commands must
-// sideline information here based on which all Replicas must take action.
-//
-// TODO(tschottdorf): We may need to add a lease identifier to allow the
-// followers to reliably produce errors for proposals which apply after a
-// lease change.
-type ReplicatedProposalData struct {
 	// Whether to block concurrent readers while processing the proposal data.
-	BlockReads bool `protobuf:"varint,1,opt,name=block_reads,json=blockReads" json:"block_reads"`
+	BlockReads bool `protobuf:"varint,10001,opt,name=block_reads,json=blockReads" json:"block_reads"`
 	// Updates to the Replica's ReplicaState. By convention and as outlined on
 	// the comment on the ReplicaState message, this field is sparsely populated
 	// and any field set overwrites the corresponding field in the state, perhaps
 	// which additional side effects (for instance on a descriptor update).
-	State ReplicaState `protobuf:"bytes,2,opt,name=state" json:"state"`
-	Split *Split       `protobuf:"bytes,3,opt,name=split" json:"split,omitempty"`
-	Merge *Merge       `protobuf:"bytes,4,opt,name=merge" json:"merge,omitempty"`
+	State ReplicaState `protobuf:"bytes,10002,opt,name=state" json:"state"`
+	Split *Split       `protobuf:"bytes,10003,opt,name=split" json:"split,omitempty"`
+	Merge *Merge       `protobuf:"bytes,10004,opt,name=merge" json:"merge,omitempty"`
 	// TODO(tschottdorf): trim this down; we shouldn't need the whole request.
-	ComputeChecksum *cockroach_roachpb3.ComputeChecksumRequest `protobuf:"bytes,5,opt,name=compute_checksum,json=computeChecksum" json:"compute_checksum,omitempty"`
-	// Deprecated once proposer-evaluated-kv is in place: the Raft command which
-	// executes on all Replicas.
-	RaftCommand *RaftCommand `protobuf:"bytes,999,opt,name=raft_command,json=raftCommand" json:"raft_command,omitempty"`
+	ComputeChecksum *cockroach_roachpb3.ComputeChecksumRequest `protobuf:"bytes,10005,opt,name=compute_checksum,json=computeChecksum" json:"compute_checksum,omitempty"`
 }
 
 func (m *ReplicatedProposalData) Reset()                    { *m = ReplicatedProposalData{} }
 func (m *ReplicatedProposalData) String() string            { return proto.CompactTextString(m) }
 func (*ReplicatedProposalData) ProtoMessage()               {}
-func (*ReplicatedProposalData) Descriptor() ([]byte, []int) { return fileDescriptorProposerKv, []int{3} }
+func (*ReplicatedProposalData) Descriptor() ([]byte, []int) { return fileDescriptorProposerKv, []int{2} }
 
 func init() {
-	proto.RegisterType((*RaftCommand)(nil), "cockroach.storage.storagebase.RaftCommand")
 	proto.RegisterType((*Split)(nil), "cockroach.storage.storagebase.Split")
 	proto.RegisterType((*Merge)(nil), "cockroach.storage.storagebase.Merge")
 	proto.RegisterType((*ReplicatedProposalData)(nil), "cockroach.storage.storagebase.ReplicatedProposalData")
 }
-func (m *RaftCommand) Marshal() (data []byte, err error) {
-	size := m.Size()
-	data = make([]byte, size)
-	n, err := m.MarshalTo(data)
-	if err != nil {
-		return nil, err
-	}
-	return data[:n], nil
-}
-
-func (m *RaftCommand) MarshalTo(data []byte) (int, error) {
-	var i int
-	_ = i
-	var l int
-	_ = l
-	data[i] = 0x8
-	i++
-	i = encodeVarintProposerKv(data, i, uint64(m.RangeID))
-	data[i] = 0x12
-	i++
-	i = encodeVarintProposerKv(data, i, uint64(m.OriginReplica.Size()))
-	n1, err := m.OriginReplica.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n1
-	data[i] = 0x1a
-	i++
-	i = encodeVarintProposerKv(data, i, uint64(m.Cmd.Size()))
-	n2, err := m.Cmd.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n2
-	data[i] = 0x20
-	i++
-	i = encodeVarintProposerKv(data, i, uint64(m.MaxLeaseIndex))
-	return i, nil
-}
-
 func (m *Split) Marshal() (data []byte, err error) {
 	size := m.Size()
 	data = make([]byte, size)
@@ -207,19 +152,19 @@ func (m *Split) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintProposerKv(data, i, uint64(m.SplitTrigger.Size()))
-	n3, err := m.SplitTrigger.MarshalTo(data[i:])
+	n1, err := m.SplitTrigger.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n3
+	i += n1
 	data[i] = 0x12
 	i++
 	i = encodeVarintProposerKv(data, i, uint64(m.RHSDelta.Size()))
-	n4, err := m.RHSDelta.MarshalTo(data[i:])
+	n2, err := m.RHSDelta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n4
+	i += n2
 	return i, nil
 }
 
@@ -241,11 +186,11 @@ func (m *Merge) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintProposerKv(data, i, uint64(m.MergeTrigger.Size()))
-	n5, err := m.MergeTrigger.MarshalTo(data[i:])
+	n3, err := m.MergeTrigger.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n5
+	i += n3
 	return i, nil
 }
 
@@ -266,13 +211,45 @@ func (m *ReplicatedProposalData) MarshalTo(data []byte) (int, error) {
 	_ = l
 	data[i] = 0x8
 	i++
+	i = encodeVarintProposerKv(data, i, uint64(m.RangeID))
+	data[i] = 0x12
+	i++
+	i = encodeVarintProposerKv(data, i, uint64(m.OriginReplica.Size()))
+	n4, err := m.OriginReplica.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n4
+	if m.Cmd != nil {
+		data[i] = 0x1a
+		i++
+		i = encodeVarintProposerKv(data, i, uint64(m.Cmd.Size()))
+		n5, err := m.Cmd.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n5
+	}
+	data[i] = 0x20
+	i++
+	i = encodeVarintProposerKv(data, i, uint64(m.MaxLeaseIndex))
+	data[i] = 0x88
+	i++
+	data[i] = 0xf1
+	i++
+	data[i] = 0x4
+	i++
 	if m.BlockReads {
 		data[i] = 1
 	} else {
 		data[i] = 0
 	}
 	i++
-	data[i] = 0x12
+	data[i] = 0x92
+	i++
+	data[i] = 0xf1
+	i++
+	data[i] = 0x4
 	i++
 	i = encodeVarintProposerKv(data, i, uint64(m.State.Size()))
 	n6, err := m.State.MarshalTo(data[i:])
@@ -281,7 +258,11 @@ func (m *ReplicatedProposalData) MarshalTo(data []byte) (int, error) {
 	}
 	i += n6
 	if m.Split != nil {
-		data[i] = 0x1a
+		data[i] = 0x9a
+		i++
+		data[i] = 0xf1
+		i++
+		data[i] = 0x4
 		i++
 		i = encodeVarintProposerKv(data, i, uint64(m.Split.Size()))
 		n7, err := m.Split.MarshalTo(data[i:])
@@ -291,7 +272,11 @@ func (m *ReplicatedProposalData) MarshalTo(data []byte) (int, error) {
 		i += n7
 	}
 	if m.Merge != nil {
-		data[i] = 0x22
+		data[i] = 0xa2
+		i++
+		data[i] = 0xf1
+		i++
+		data[i] = 0x4
 		i++
 		i = encodeVarintProposerKv(data, i, uint64(m.Merge.Size()))
 		n8, err := m.Merge.MarshalTo(data[i:])
@@ -301,7 +286,11 @@ func (m *ReplicatedProposalData) MarshalTo(data []byte) (int, error) {
 		i += n8
 	}
 	if m.ComputeChecksum != nil {
-		data[i] = 0x2a
+		data[i] = 0xaa
+		i++
+		data[i] = 0xf1
+		i++
+		data[i] = 0x4
 		i++
 		i = encodeVarintProposerKv(data, i, uint64(m.ComputeChecksum.Size()))
 		n9, err := m.ComputeChecksum.MarshalTo(data[i:])
@@ -309,18 +298,6 @@ func (m *ReplicatedProposalData) MarshalTo(data []byte) (int, error) {
 			return 0, err
 		}
 		i += n9
-	}
-	if m.RaftCommand != nil {
-		data[i] = 0xba
-		i++
-		data[i] = 0x3e
-		i++
-		i = encodeVarintProposerKv(data, i, uint64(m.RaftCommand.Size()))
-		n10, err := m.RaftCommand.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n10
 	}
 	return i, nil
 }
@@ -352,18 +329,6 @@ func encodeVarintProposerKv(data []byte, offset int, v uint64) int {
 	data[offset] = uint8(v)
 	return offset + 1
 }
-func (m *RaftCommand) Size() (n int) {
-	var l int
-	_ = l
-	n += 1 + sovProposerKv(uint64(m.RangeID))
-	l = m.OriginReplica.Size()
-	n += 1 + l + sovProposerKv(uint64(l))
-	l = m.Cmd.Size()
-	n += 1 + l + sovProposerKv(uint64(l))
-	n += 1 + sovProposerKv(uint64(m.MaxLeaseIndex))
-	return n
-}
-
 func (m *Split) Size() (n int) {
 	var l int
 	_ = l
@@ -385,24 +350,28 @@ func (m *Merge) Size() (n int) {
 func (m *ReplicatedProposalData) Size() (n int) {
 	var l int
 	_ = l
-	n += 2
-	l = m.State.Size()
+	n += 1 + sovProposerKv(uint64(m.RangeID))
+	l = m.OriginReplica.Size()
 	n += 1 + l + sovProposerKv(uint64(l))
+	if m.Cmd != nil {
+		l = m.Cmd.Size()
+		n += 1 + l + sovProposerKv(uint64(l))
+	}
+	n += 1 + sovProposerKv(uint64(m.MaxLeaseIndex))
+	n += 4
+	l = m.State.Size()
+	n += 3 + l + sovProposerKv(uint64(l))
 	if m.Split != nil {
 		l = m.Split.Size()
-		n += 1 + l + sovProposerKv(uint64(l))
+		n += 3 + l + sovProposerKv(uint64(l))
 	}
 	if m.Merge != nil {
 		l = m.Merge.Size()
-		n += 1 + l + sovProposerKv(uint64(l))
+		n += 3 + l + sovProposerKv(uint64(l))
 	}
 	if m.ComputeChecksum != nil {
 		l = m.ComputeChecksum.Size()
-		n += 1 + l + sovProposerKv(uint64(l))
-	}
-	if m.RaftCommand != nil {
-		l = m.RaftCommand.Size()
-		n += 2 + l + sovProposerKv(uint64(l))
+		n += 3 + l + sovProposerKv(uint64(l))
 	}
 	return n
 }
@@ -419,154 +388,6 @@ func sovProposerKv(x uint64) (n int) {
 }
 func sozProposerKv(x uint64) (n int) {
 	return sovProposerKv(uint64((x << 1) ^ uint64((int64(x) >> 63))))
-}
-func (m *RaftCommand) Unmarshal(data []byte) error {
-	l := len(data)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowProposerKv
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := data[iNdEx]
-			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: RaftCommand: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: RaftCommand: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 1:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field RangeID", wireType)
-			}
-			m.RangeID = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowProposerKv
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				m.RangeID |= (github_com_cockroachdb_cockroach_pkg_roachpb.RangeID(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-		case 2:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field OriginReplica", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowProposerKv
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthProposerKv
-			}
-			postIndex := iNdEx + msglen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if err := m.OriginReplica.Unmarshal(data[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
-		case 3:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Cmd", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowProposerKv
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthProposerKv
-			}
-			postIndex := iNdEx + msglen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if err := m.Cmd.Unmarshal(data[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
-		case 4:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field MaxLeaseIndex", wireType)
-			}
-			m.MaxLeaseIndex = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowProposerKv
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				m.MaxLeaseIndex |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-		default:
-			iNdEx = preIndex
-			skippy, err := skipProposerKv(data[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if skippy < 0 {
-				return ErrInvalidLengthProposerKv
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
 }
 func (m *Split) Unmarshal(data []byte) error {
 	l := len(data)
@@ -789,6 +610,107 @@ func (m *ReplicatedProposalData) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RangeID", wireType)
+			}
+			m.RangeID = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowProposerKv
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				m.RangeID |= (github_com_cockroachdb_cockroach_pkg_roachpb.RangeID(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field OriginReplica", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowProposerKv
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthProposerKv
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.OriginReplica.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Cmd", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowProposerKv
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthProposerKv
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Cmd == nil {
+				m.Cmd = &cockroach_roachpb3.BatchRequest{}
+			}
+			if err := m.Cmd.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MaxLeaseIndex", wireType)
+			}
+			m.MaxLeaseIndex = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowProposerKv
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				m.MaxLeaseIndex |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 10001:
+			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field BlockReads", wireType)
 			}
 			var v int
@@ -807,7 +729,7 @@ func (m *ReplicatedProposalData) Unmarshal(data []byte) error {
 				}
 			}
 			m.BlockReads = bool(v != 0)
-		case 2:
+		case 10002:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field State", wireType)
 			}
@@ -837,7 +759,7 @@ func (m *ReplicatedProposalData) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 3:
+		case 10003:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Split", wireType)
 			}
@@ -870,7 +792,7 @@ func (m *ReplicatedProposalData) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 4:
+		case 10004:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Merge", wireType)
 			}
@@ -903,7 +825,7 @@ func (m *ReplicatedProposalData) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 5:
+		case 10005:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field ComputeChecksum", wireType)
 			}
@@ -933,39 +855,6 @@ func (m *ReplicatedProposalData) Unmarshal(data []byte) error {
 				m.ComputeChecksum = &cockroach_roachpb3.ComputeChecksumRequest{}
 			}
 			if err := m.ComputeChecksum.Unmarshal(data[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
-		case 999:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field RaftCommand", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowProposerKv
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthProposerKv
-			}
-			postIndex := iNdEx + msglen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if m.RaftCommand == nil {
-				m.RaftCommand = &RaftCommand{}
-			}
-			if err := m.RaftCommand.Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -1100,44 +989,42 @@ func init() {
 }
 
 var fileDescriptorProposerKv = []byte{
-	// 620 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0x8c, 0x53, 0x41, 0x6b, 0xd4, 0x40,
-	0x14, 0x6e, 0xba, 0x5d, 0x76, 0x9d, 0x55, 0x5b, 0x06, 0x91, 0xa5, 0xe0, 0x66, 0x59, 0x5a, 0xa8,
-	0x5a, 0x13, 0x51, 0x41, 0xf0, 0x98, 0x2c, 0xd4, 0x42, 0x2b, 0x3a, 0x2d, 0x1e, 0xf4, 0x10, 0x26,
-	0x93, 0x69, 0x12, 0x36, 0xc9, 0xc4, 0x99, 0xd9, 0xd2, 0x9f, 0xe1, 0xaf, 0x10, 0xc4, 0x3f, 0xd2,
-	0x63, 0x8f, 0x9e, 0x16, 0x5d, 0x0f, 0xfe, 0x07, 0x4f, 0x32, 0x93, 0x49, 0xbb, 0xc5, 0xe8, 0x7a,
-	0xca, 0x64, 0xde, 0xf7, 0x7d, 0xf3, 0xde, 0xf7, 0xde, 0x03, 0x4f, 0x09, 0x23, 0x13, 0xce, 0x30,
-	0x49, 0xdc, 0x72, 0x12, 0xbb, 0x42, 0x32, 0x8e, 0x63, 0x5a, 0x7f, 0x43, 0x2c, 0xa8, 0x5b, 0x72,
-	0x56, 0x32, 0x41, 0x79, 0x30, 0x39, 0x75, 0x4a, 0xce, 0x24, 0x83, 0xf7, 0x2e, 0x49, 0x8e, 0x01,
-	0x3a, 0x0b, 0x84, 0x4d, 0xfb, 0xba, 0xa6, 0x3e, 0x95, 0xa1, 0x8b, 0xcb, 0xb4, 0xe2, 0x6f, 0x0e,
-	0x9b, 0x01, 0x11, 0x96, 0xd8, 0x20, 0xb6, 0x9a, 0x11, 0x39, 0x95, 0x78, 0x01, 0xf5, 0xb8, 0x39,
-	0x79, 0x5a, 0xc4, 0x69, 0x51, 0x7f, 0x14, 0xeb, 0x94, 0x10, 0xc3, 0x78, 0xb4, 0xbc, 0x5c, 0x21,
-	0xb1, 0xa4, 0x06, 0x7e, 0x27, 0x66, 0x31, 0xd3, 0x47, 0x57, 0x9d, 0xaa, 0xdb, 0xd1, 0x97, 0x55,
-	0xd0, 0x43, 0xf8, 0x44, 0xfa, 0x2c, 0xcf, 0x71, 0x11, 0xc1, 0x10, 0x74, 0x39, 0x2e, 0x62, 0x1a,
-	0xa4, 0x51, 0xdf, 0x1a, 0x5a, 0x3b, 0x2d, 0x6f, 0xef, 0x7c, 0x66, 0xaf, 0xcc, 0x67, 0x76, 0x07,
-	0xa9, 0xfb, 0xfd, 0xf1, 0xaf, 0x99, 0xfd, 0x2c, 0x4e, 0x65, 0x32, 0x0d, 0x1d, 0xc2, 0x72, 0xf7,
-	0x32, 0x89, 0x28, 0x74, 0x1b, 0x0b, 0x75, 0x0c, 0x0f, 0x75, 0xb4, 0xf0, 0x7e, 0x04, 0xdf, 0x80,
-	0xdb, 0x8c, 0xa7, 0x71, 0x5a, 0x04, 0x9c, 0x96, 0x59, 0x4a, 0x70, 0x7f, 0x75, 0x68, 0xed, 0xf4,
-	0x9e, 0x6c, 0x39, 0x57, 0xbd, 0xb8, 0x24, 0x57, 0x88, 0x31, 0x15, 0x84, 0xa7, 0xa5, 0x64, 0xdc,
-	0x5b, 0x53, 0xf9, 0xa0, 0x5b, 0x95, 0x82, 0x09, 0xc3, 0xe7, 0xa0, 0x45, 0xf2, 0xa8, 0xdf, 0xd2,
-	0x3a, 0x76, 0x83, 0x8e, 0x87, 0x25, 0x49, 0x10, 0xfd, 0x30, 0xa5, 0x42, 0x1a, 0x09, 0xc5, 0x80,
-	0xbb, 0x60, 0x3d, 0xc7, 0x67, 0x41, 0x46, 0xb1, 0xa0, 0x41, 0x5a, 0x44, 0xf4, 0xac, 0xbf, 0x36,
-	0xb4, 0x76, 0xd6, 0xea, 0x67, 0x72, 0x7c, 0x76, 0xa0, 0x62, 0xfb, 0x2a, 0x34, 0xfa, 0x6c, 0x81,
-	0xf6, 0x51, 0x99, 0xa5, 0x12, 0xfa, 0xa0, 0x23, 0x79, 0x1a, 0xc7, 0x94, 0x6b, 0x9b, 0x9a, 0x1f,
-	0xd5, 0xd0, 0xe3, 0x0a, 0xe6, 0x75, 0x95, 0xe0, 0xc5, 0xcc, 0xb6, 0x50, 0xcd, 0x84, 0xef, 0xc1,
-	0x0d, 0x9e, 0x88, 0x20, 0xa2, 0x99, 0xac, 0x3d, 0xd8, 0x75, 0xfe, 0x9c, 0xc7, 0xaa, 0xf9, 0x4e,
-	0x3d, 0x03, 0xce, 0xe1, 0x5b, 0xdf, 0x3f, 0x92, 0x58, 0x0a, 0x6f, 0xc3, 0xf4, 0xa6, 0x8b, 0x5e,
-	0x1e, 0x8d, 0x95, 0x0a, 0xea, 0xf2, 0x44, 0xe8, 0xd3, 0xe8, 0x00, 0xb4, 0x0f, 0x29, 0x8f, 0xe9,
-	0xff, 0xa5, 0xaa, 0xa1, 0x7f, 0x4f, 0x75, 0xf4, 0xa9, 0x05, 0xee, 0x1a, 0xb3, 0x25, 0x8d, 0x5e,
-	0xeb, 0x35, 0xc2, 0xd9, 0x18, 0x4b, 0x0c, 0xb7, 0x41, 0x2f, 0xcc, 0x18, 0x99, 0x04, 0x9c, 0xe2,
-	0x48, 0xe8, 0x37, 0xba, 0xc6, 0x3e, 0xa0, 0x03, 0x48, 0xdd, 0xc3, 0x3d, 0xd0, 0xd6, 0xe3, 0x68,
-	0x0a, 0x7d, 0xe8, 0xfc, 0x73, 0xf1, 0xea, 0xc6, 0xab, 0x3a, 0xa9, 0x51, 0xab, 0xf8, 0xf0, 0x05,
-	0x68, 0x0b, 0x65, 0xac, 0xe9, 0xf6, 0xd6, 0x12, 0x21, 0xdd, 0x04, 0x54, 0x51, 0x14, 0x37, 0x57,
-	0x95, 0xea, 0x26, 0x2f, 0xe7, 0x6a, 0x57, 0x50, 0x45, 0x81, 0xc7, 0x60, 0x83, 0xb0, 0xbc, 0x9c,
-	0x4a, 0x1a, 0x90, 0x84, 0x92, 0x89, 0x98, 0xe6, 0xfd, 0xb6, 0x96, 0xb9, 0xdf, 0x60, 0xa8, 0x5f,
-	0x41, 0x7d, 0x83, 0x34, 0xa3, 0x87, 0xd6, 0xc9, 0xf5, 0x7b, 0xf8, 0x0a, 0xdc, 0xe4, 0xf8, 0x44,
-	0x06, 0xa4, 0x5a, 0xc0, 0xfe, 0xcf, 0x8e, 0x96, 0x7c, 0xb0, 0xcc, 0x9e, 0xab, 0x9d, 0x45, 0x3d,
-	0x7e, 0xf5, 0xe3, 0x6d, 0x9f, 0x7f, 0x1f, 0xac, 0x9c, 0xcf, 0x07, 0xd6, 0xc5, 0x7c, 0x60, 0x7d,
-	0x9d, 0x0f, 0xac, 0x6f, 0xf3, 0x81, 0xf5, 0xf1, 0xc7, 0x60, 0xe5, 0x5d, 0x6f, 0x81, 0xff, 0x3b,
-	0x00, 0x00, 0xff, 0xff, 0x79, 0xd3, 0x7f, 0x4f, 0x2c, 0x05, 0x00, 0x00,
+	// 588 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0x8c, 0x53, 0x4d, 0x6f, 0xd3, 0x30,
+	0x18, 0x5e, 0x58, 0xab, 0x15, 0x57, 0xb0, 0x29, 0x42, 0x28, 0x9a, 0x44, 0x52, 0x55, 0x03, 0x15,
+	0x31, 0x12, 0xbe, 0x6e, 0xdc, 0xd2, 0x4a, 0xac, 0xd2, 0x56, 0x81, 0x0b, 0x1c, 0xe0, 0x10, 0x39,
+	0x8e, 0x95, 0x44, 0x4d, 0xea, 0x60, 0xbb, 0x53, 0x7f, 0x06, 0x9f, 0x3f, 0x82, 0x7f, 0xd2, 0xe3,
+	0x8e, 0x9c, 0x2a, 0x28, 0x3f, 0x81, 0x1b, 0x27, 0x64, 0xc7, 0x19, 0x9d, 0x96, 0xc1, 0x4e, 0x7e,
+	0xe5, 0xf7, 0x79, 0x1e, 0x3f, 0xef, 0x9b, 0x27, 0xe0, 0x31, 0xa6, 0x78, 0xc2, 0x28, 0xc2, 0x89,
+	0x57, 0x4c, 0x62, 0x8f, 0x0b, 0xca, 0x50, 0x4c, 0xaa, 0x33, 0x44, 0x9c, 0x78, 0x05, 0xa3, 0x05,
+	0xe5, 0x84, 0x05, 0x93, 0x63, 0xb7, 0x60, 0x54, 0x50, 0xf3, 0xd6, 0x29, 0xc9, 0xd5, 0x40, 0x77,
+	0x8d, 0xb0, 0xeb, 0x9c, 0xd5, 0x54, 0x55, 0x11, 0x7a, 0xa8, 0x48, 0x4b, 0xfe, 0x6e, 0xa7, 0x1e,
+	0x10, 0x21, 0x81, 0x34, 0x62, 0xaf, 0x1e, 0x91, 0x13, 0x81, 0xd6, 0x50, 0x0f, 0xea, 0xcd, 0x93,
+	0x69, 0x9c, 0x4e, 0xab, 0x43, 0xb2, 0x8e, 0x31, 0xd6, 0x8c, 0xfb, 0xff, 0x1f, 0x97, 0x0b, 0x24,
+	0x88, 0x86, 0xdf, 0x88, 0x69, 0x4c, 0x55, 0xe9, 0xc9, 0xaa, 0xbc, 0xed, 0x7e, 0x35, 0x40, 0x73,
+	0x5c, 0x64, 0xa9, 0x30, 0xfb, 0x60, 0x4b, 0xb0, 0x34, 0x8e, 0x09, 0xb3, 0x8c, 0x8e, 0xd1, 0x6b,
+	0x3f, 0x72, 0xdc, 0xbf, 0xab, 0xd1, 0xa6, 0x5d, 0x05, 0x7d, 0x59, 0xc2, 0xfc, 0xd6, 0x62, 0xe9,
+	0x6c, 0x9c, 0x2c, 0x1d, 0x03, 0x56, 0x4c, 0xf3, 0x2d, 0xb8, 0xca, 0x12, 0x1e, 0x44, 0x24, 0x13,
+	0xc8, 0xba, 0xa2, 0x64, 0xf6, 0xdd, 0xf3, 0x1b, 0x2e, 0xc7, 0x71, 0xab, 0xa9, 0xdc, 0xa3, 0xd7,
+	0xfd, 0xfe, 0x58, 0x20, 0xc1, 0xfd, 0x1d, 0xa9, 0xb9, 0x5a, 0x3a, 0x2d, 0x78, 0x30, 0x1e, 0x48,
+	0x15, 0xd8, 0x62, 0x09, 0x57, 0x55, 0xf7, 0x10, 0x34, 0x8f, 0x08, 0x8b, 0xc9, 0xe5, 0xac, 0x2a,
+	0xe8, 0xc5, 0x56, 0xbb, 0xbf, 0x1a, 0xe0, 0x26, 0x24, 0x45, 0x96, 0x62, 0x24, 0x48, 0xf4, 0x5c,
+	0x05, 0x03, 0x65, 0x03, 0x24, 0x90, 0x19, 0x82, 0x16, 0x43, 0xd3, 0x98, 0x04, 0x69, 0xa4, 0x1e,
+	0xd8, 0xf4, 0x9f, 0x69, 0x5b, 0x5b, 0x50, 0xde, 0x0f, 0x07, 0xbf, 0x97, 0xce, 0x93, 0x38, 0x15,
+	0xc9, 0x2c, 0x74, 0x31, 0xcd, 0xbd, 0xd3, 0xd7, 0xa3, 0xd0, 0xab, 0xfd, 0xda, 0xae, 0xe6, 0xc1,
+	0x2d, 0x25, 0x3c, 0x8c, 0xcc, 0x17, 0xe0, 0x3a, 0x65, 0x69, 0x9c, 0x4e, 0x03, 0x56, 0x9a, 0xd0,
+	0xeb, 0xda, 0xab, 0x19, 0x45, 0xdb, 0x1c, 0x10, 0x8e, 0x59, 0x5a, 0x08, 0xca, 0xfc, 0x86, 0xf4,
+	0x03, 0xaf, 0x95, 0x0a, 0xba, 0x6d, 0x3e, 0x04, 0x9b, 0x38, 0x8f, 0xac, 0xcd, 0x0b, 0x57, 0xe2,
+	0x23, 0x81, 0x13, 0x48, 0xde, 0xcd, 0x08, 0x17, 0x50, 0x62, 0xcd, 0x7d, 0xb0, 0x9d, 0xa3, 0x79,
+	0x90, 0x11, 0xc4, 0x49, 0x90, 0x4e, 0x23, 0x32, 0xb7, 0x1a, 0x1d, 0xa3, 0xd7, 0xa8, 0x1e, 0xc8,
+	0xd1, 0xfc, 0x50, 0xf6, 0x86, 0xb2, 0x65, 0xde, 0x01, 0xed, 0x30, 0xa3, 0x78, 0x12, 0x30, 0x82,
+	0x22, 0x6e, 0x7d, 0x18, 0x75, 0x8c, 0x5e, 0x4b, 0x43, 0x81, 0xea, 0x40, 0xd9, 0x30, 0x0f, 0x40,
+	0x53, 0x25, 0xcf, 0xfa, 0x38, 0x52, 0x5e, 0xee, 0xb9, 0xff, 0xfc, 0xc9, 0xaa, 0xf9, 0x64, 0x02,
+	0x88, 0x96, 0x2b, 0x05, 0xcc, 0xa7, 0xa0, 0xc9, 0x65, 0xe4, 0xac, 0x4f, 0xa3, 0x73, 0xdb, 0xa9,
+	0x53, 0x52, 0xf9, 0x84, 0x25, 0x47, 0x92, 0x73, 0x19, 0x02, 0xeb, 0xf3, 0xe5, 0xc8, 0x2a, 0x31,
+	0xb0, 0xe4, 0x98, 0xaf, 0xc0, 0x0e, 0xa6, 0x79, 0x31, 0x13, 0x24, 0xc0, 0x09, 0xc1, 0x13, 0x3e,
+	0xcb, 0xad, 0x2f, 0xa5, 0xce, 0xdd, 0x9a, 0xd5, 0xf6, 0x4b, 0x6c, 0x5f, 0x43, 0xab, 0x25, 0x6f,
+	0xe3, 0xb3, 0xf7, 0xfe, 0xed, 0xc5, 0x0f, 0x7b, 0x63, 0xb1, 0xb2, 0x8d, 0x93, 0x95, 0x6d, 0x7c,
+	0x5b, 0xd9, 0xc6, 0xf7, 0x95, 0x6d, 0xbc, 0xff, 0x69, 0x6f, 0xbc, 0x69, 0xaf, 0x59, 0xf9, 0x13,
+	0x00, 0x00, 0xff, 0xff, 0x8d, 0x30, 0x06, 0x4f, 0xcb, 0x04, 0x00, 0x00,
 }

--- a/pkg/storage/storagebase/proposer_kv.proto
+++ b/pkg/storage/storagebase/proposer_kv.proto
@@ -24,45 +24,6 @@ import "cockroach/pkg/storage/storagebase/state.proto";
 
 import "gogoproto/gogo.proto";
 
-// A RaftCommand is a command which can be serialized and sent via
-// raft.
-message RaftCommand {
-  optional int64 range_id = 1 [(gogoproto.nullable) = false,
-      (gogoproto.customname) = "RangeID",
-      (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID"];
-  optional roachpb.ReplicaDescriptor origin_replica = 2 [(gogoproto.nullable) = false];
-  optional roachpb.BatchRequest cmd = 3 [(gogoproto.nullable) = false];
-  // When the command is applied, its result is an error if the lease log
-  // counter has already reached (or exceeded) max_lease_index.
-  //
-  // The lease index is a replay protection mechanism. Similar to the Raft
-  // applied index, it is strictly increasing, but may have gaps. A command
-  // will only apply successfully if its max_lease_index has not been surpassed
-  // by the Range's applied lease index (in which case the command may need
-  // to be retried, that is, regenerated with a higher max_lease_index).
-  // When the command applies, the new lease index will increase to
-  // max_lease_index (so a potential later replay will fail).
-  //
-  // This mechanism was introduced as a simpler alternative to using the Raft
-  // applied index, which is fraught with complexity due to the need to predict
-  // exactly the log position at which a command will apply, even when the Raft
-  // leader is not colocated with the lease holder (which usually proposes all
-  // commands).
-  //
-  // Pinning the lease-index to the assigned slot (as opposed to allowing gaps
-  // as we do now) is an interesting venue to explore from the standpoint of
-  // parallelization: One could hope to enforce command ordering in that way
-  // (without recourse to a higher-level locking primitive such as the command
-  // queue). This is a hard problem: First of all, managing the pending
-  // commands gets more involved; a command must not be removed if others have
-  // been added after it, and on removal, the assignment counters must be
-  // updated accordingly. Managing retry of proposals becomes trickier as
-  // well as that uproots whatever ordering was originally envisioned.
-  optional uint64 max_lease_index = 4 [(gogoproto.nullable) = false];
-}
-
-
-
 // Split is emitted when a Replica commits a split trigger. It signals that the
 // Replica has prepared the on-disk state for both the left and right hand
 // sides of the split, and that the left hand side Replica should be updated as
@@ -93,20 +54,61 @@ message Merge {
 // followers to reliably produce errors for proposals which apply after a
 // lease change.
 message ReplicatedProposalData {
+  // ======================================
+  // Beginning of what was formerly RaftCommand.
+  // ======================================
+
+  optional int64 range_id = 1 [(gogoproto.nullable) = false,
+      (gogoproto.customname) = "RangeID",
+      (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID"];
+  optional roachpb.ReplicaDescriptor origin_replica = 2 [(gogoproto.nullable) = false];
+  optional roachpb.BatchRequest cmd = 3;
+  // When the command is applied, its result is an error if the lease log
+  // counter has already reached (or exceeded) max_lease_index.
+  //
+  // The lease index is a replay protection mechanism. Similar to the Raft
+  // applied index, it is strictly increasing, but may have gaps. A command
+  // will only apply successfully if its max_lease_index has not been surpassed
+  // by the Range's applied lease index (in which case the command may need
+  // to be retried, that is, regenerated with a higher max_lease_index).
+  // When the command applies, the new lease index will increase to
+  // max_lease_index (so a potential later replay will fail).
+  //
+  // This mechanism was introduced as a simpler alternative to using the Raft
+  // applied index, which is fraught with complexity due to the need to predict
+  // exactly the log position at which a command will apply, even when the Raft
+  // leader is not colocated with the lease holder (which usually proposes all
+  // commands).
+  //
+  // Pinning the lease-index to the assigned slot (as opposed to allowing gaps
+  // as we do now) is an interesting venue to explore from the standpoint of
+  // parallelization: One could hope to enforce command ordering in that way
+  // (without recourse to a higher-level locking primitive such as the command
+  // queue). This is a hard problem: First of all, managing the pending
+  // commands gets more involved; a command must not be removed if others have
+  // been added after it, and on removal, the assignment counters must be
+  // updated accordingly. Managing retry of proposals becomes trickier as
+  // well as that uproots whatever ordering was originally envisioned.
+  optional uint64 max_lease_index = 4 [(gogoproto.nullable) = false];
+
+  // ======================================
+  // End of what was formerly RaftCommand and beginning of proposer-evaluated
+  // KV protos. These are not stable. While general proto compatibility rules
+  // apply, these are intentionally kept at high tag numbers for now so that
+  // a stabilized version can be inserted at low tag numbers in the future.
+  // ======================================
+
   // Whether to block concurrent readers while processing the proposal data.
-  optional bool block_reads = 1 [(gogoproto.nullable) = false];
+  optional bool block_reads = 10001 [(gogoproto.nullable) = false];
   // Updates to the Replica's ReplicaState. By convention and as outlined on
   // the comment on the ReplicaState message, this field is sparsely populated
   // and any field set overwrites the corresponding field in the state, perhaps
   // which additional side effects (for instance on a descriptor update).
-  optional storage.storagebase.ReplicaState state = 2 [(gogoproto.nullable) = false];
-  optional Split split = 3;
-  optional Merge merge = 4;
+  optional storage.storagebase.ReplicaState state = 10002 [(gogoproto.nullable) = false];
+  optional Split split = 10003;
+  optional Merge merge = 10004;
   // TODO(tschottdorf): trim this down; we shouldn't need the whole request.
-  optional roachpb.ComputeChecksumRequest compute_checksum = 5;
-  // TODO(tschottdorf): add the WriteBatch.
+  optional roachpb.ComputeChecksumRequest compute_checksum = 10005;
 
-  // Deprecated once proposer-evaluated-kv is in place: the Raft command which
-  // executes on all Replicas.
-  optional RaftCommand raft_command = 999;
+  // TODO(tschottdorf): add the WriteBatch here.
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1638,8 +1638,8 @@ func (s *Store) NewRangeDescriptor(
 	return desc, nil
 }
 
-// splitTriggerPostCommit is the part of the split trigger which coordinates
-// the actual split with the Store. Requires that Replica.raftMu is held.
+// splitPostApply is the part of the split trigger which coordinates the actual
+// split with the Store. Requires that Replica.raftMu is held.
 //
 // TODO(tschottdorf): Want to merge this with SplitRange, but some legacy
 // testing code calls SplitRange directly.
@@ -1720,7 +1720,7 @@ func (s *Store) SplitRange(origRng, newRng *Replica) error {
 	defer s.mu.Unlock()
 	if exRng, ok := s.mu.uninitReplicas[newDesc.RangeID]; ok {
 		// If we have an uninitialized replica of the new range we require pointer
-		// equivalence with newRng. See Store.splitTriggerPostCommit()
+		// equivalence with newRng. See Store.splitTriggerPostApply().
 		if exRng != newRng {
 			ctx := s.AnnotateCtx(context.TODO())
 			log.Fatalf(ctx, "found unexpected uninitialized replica: %s vs %s", exRng, newRng)


### PR DESCRIPTION
Remove the `storagebase.RaftCommand` proto by moving its fields onto
`ReplicatedProposalData` while preserving the tag numbers. Use that message
instead of `RaftCommand` throughout, including on the wire (since the tag
numbers were preserved, this does not require any special handling).

This in preparation for a follow-up change which adds an experimental switch to
use proposer-evaluated KV (#6166).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10200)

<!-- Reviewable:end -->
