### PR TITLE
distsql: basic flow scheduler

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -602,6 +602,8 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 	sql.NewSchemaChangeManager(testingKnobs, *s.db, s.gossip, s.leaseMgr).Start(s.stopper)
 
+	s.distSQLServer.Start()
+
 	log.Infof(ctx, "starting %s server at %s", s.cfg.HTTPRequestScheme(), unresolvedHTTPAddr)
 	log.Infof(ctx, "starting grpc/postgres server at %s", unresolvedListenAddr)
 	log.Infof(ctx, "advertising CockroachDB node at %s", unresolvedAdvertAddr)

--- a/pkg/sql/dist_sql_node.go
+++ b/pkg/sql/dist_sql_node.go
@@ -120,7 +120,7 @@ func (n *distSQLNode) Next() (bool, error) {
 		if n.syncMode {
 			n.flow.RunSync()
 		} else {
-			n.flow.Start()
+			n.flow.Start(func() {})
 		}
 		n.flowStarted = true
 	}

--- a/pkg/sql/distsql/flow.go
+++ b/pkg/sql/distsql/flow.go
@@ -64,16 +64,27 @@ const (
 type Flow struct {
 	FlowCtx
 
-	flowRegistry       *flowRegistry
+	flowRegistry *flowRegistry
+	processors   []processor
+	outboxes     []*outbox
+	// simpleFlowConsumer is a special outbox which instead of sending rows to
+	// another host, returns them directly (as a result to a SetupSimpleFlow RPC,
+	// or to the local host).
 	simpleFlowConsumer RowReceiver
-	waitGroup          sync.WaitGroup
-	processors         []processor
-	outboxes           []*outbox
 
-	// inboundStreams are streams that receive data from other hosts, through
-	// the FlowStream API.
-	inboundStreams map[StreamID]RowReceiver
-	localStreams   map[StreamID]RowReceiver
+	localStreams map[StreamID]RowReceiver
+
+	// inboundStreams are streams that receive data from other hosts; this map
+	// is to be passed to flowRegistry.RegisterFlow.
+	inboundStreams map[StreamID]*inboundStreamInfo
+
+	// waitGroup is used to wait for async components of the flow:
+	//  - processors
+	//  - inbound streams
+	//  - outboxes
+	waitGroup sync.WaitGroup
+
+	doneFn func()
 
 	status flowStatus
 }
@@ -83,12 +94,13 @@ func newFlow(flowCtx FlowCtx, flowReg *flowRegistry, simpleFlowConsumer RowRecei
 		panic("flow context has no span")
 	}
 	flowCtx.Context = log.WithLogTagStr(flowCtx.Context, "f", flowCtx.id.Short())
-	return &Flow{
+	f := &Flow{
 		FlowCtx:            flowCtx,
 		flowRegistry:       flowReg,
 		simpleFlowConsumer: simpleFlowConsumer,
-		status:             FlowNotStarted,
 	}
+	f.status = FlowNotStarted
+	return f
 }
 
 // setupInboundStream adds a stream to the stream map (inboundStreams or
@@ -103,12 +115,12 @@ func (f *Flow) setupInboundStream(spec StreamEndpointSpec, receiver RowReceiver)
 			return errors.Errorf("inbound stream %d has multiple consumers", sid)
 		}
 		if f.inboundStreams == nil {
-			f.inboundStreams = make(map[StreamID]RowReceiver)
+			f.inboundStreams = make(map[StreamID]*inboundStreamInfo)
 		}
 		if log.V(2) {
 			log.Infof(f.FlowCtx.Context, "set up inbound stream %d", sid)
 		}
-		f.inboundStreams[sid] = receiver
+		f.inboundStreams[sid] = &inboundStreamInfo{receiver: receiver, waitGroup: &f.waitGroup}
 		return nil
 	}
 	if _, found := f.localStreams[sid]; found {
@@ -295,26 +307,20 @@ func (f *Flow) setupFlow(spec *FlowSpec) error {
 	return nil
 }
 
-func (f *Flow) getInboundStream(sid StreamID) (RowReceiver, error) {
-	// TODO(radu): detect if we connect to a stream multiple times.
-	recv, ok := f.inboundStreams[sid]
-	if !ok {
-		return nil, errors.Errorf("no inbound stream %d for flow %s", sid, f.id)
-	}
-	return recv, nil
-}
-
 // Start starts the flow (each processor runs in their own goroutine).
-func (f *Flow) Start() {
+func (f *Flow) Start(doneFn func()) {
+	f.doneFn = doneFn
 	log.VEventf(
 		f.Context, 1, "starting (%d processors, %d outboxes)", len(f.outboxes), len(f.processors),
 	)
 	f.status = FlowRunning
-	f.flowRegistry.RegisterFlow(f.id, f)
+	f.flowRegistry.RegisterFlow(f.id, f, f.inboundStreams)
+	f.waitGroup.Add(len(f.inboundStreams))
+	f.waitGroup.Add(len(f.outboxes))
+	f.waitGroup.Add(len(f.processors))
 	for _, o := range f.outboxes {
 		o.start(&f.waitGroup)
 	}
-	f.waitGroup.Add(len(f.processors))
 	for _, p := range f.processors {
 		go p.Run(&f.waitGroup)
 	}
@@ -340,6 +346,8 @@ func (f *Flow) Cleanup() {
 		f.flowRegistry.UnregisterFlow(f.id)
 	}
 	f.status = FlowFinished
+	f.doneFn()
+	f.doneFn = nil
 }
 
 // RunSync runs the processors in the flow in order (serially), in the same

--- a/pkg/sql/distsql/flow_registry_test.go
+++ b/pkg/sql/distsql/flow_registry_test.go
@@ -48,7 +48,7 @@ func TestFlowRegistry(t *testing.T) {
 		t.Error("looked up unregistered flow")
 	}
 
-	reg.RegisterFlow(id1, f1)
+	reg.RegisterFlow(id1, f1, nil)
 
 	if f := reg.LookupFlow(id1, 0); f != f1 {
 		t.Error("couldn't lookup previously registered flow")
@@ -64,7 +64,7 @@ func TestFlowRegistry(t *testing.T) {
 
 	go func() {
 		time.Sleep(jiffy)
-		reg.RegisterFlow(id1, f1)
+		reg.RegisterFlow(id1, f1, nil)
 	}()
 
 	if f := reg.LookupFlow(id1, 10*jiffy); f != f1 {
@@ -95,7 +95,7 @@ func TestFlowRegistry(t *testing.T) {
 	}()
 
 	time.Sleep(jiffy)
-	reg.RegisterFlow(id2, f2)
+	reg.RegisterFlow(id2, f2, nil)
 	wg.Wait()
 
 	// -- Multiple lookups, with the first one failing. --
@@ -120,6 +120,6 @@ func TestFlowRegistry(t *testing.T) {
 	}()
 
 	wg1.Wait()
-	reg.RegisterFlow(id3, f3)
+	reg.RegisterFlow(id3, f3, nil)
 	wg2.Wait()
 }

--- a/pkg/sql/distsql/flow_scheduler.go
+++ b/pkg/sql/distsql/flow_scheduler.go
@@ -1,0 +1,119 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package distsql
+
+import (
+	"container/list"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+const maxRunningFlows = 500
+const flowDoneChanSize = 8
+
+// flowScheduler manages running flows and decides when to queue and when to
+// start flows. The main interface it presents is ScheduleFlows, which passes a
+// flow to be run.
+type flowScheduler struct {
+	log.AmbientContext
+	stopper    *stop.Stopper
+	flowDoneCh chan *Flow
+
+	mu struct {
+		syncutil.Mutex
+		numRunning int
+		queue      *list.List
+	}
+}
+
+func newFlowScheduler(ambient log.AmbientContext, stopper *stop.Stopper) *flowScheduler {
+	fs := &flowScheduler{
+		AmbientContext: ambient,
+		stopper:        stopper,
+		flowDoneCh:     make(chan *Flow, flowDoneChanSize),
+	}
+	fs.mu.queue = list.New()
+	return fs
+}
+
+func (fs *flowScheduler) canRunFlow(_ *Flow) bool {
+	// TODO(radu): we will have more complex resource accounting (like memory).
+	// For now we just limit the number of concurrent flows.
+	return fs.mu.numRunning < maxRunningFlows
+}
+
+// runFlowNow starts the given flow; does not wait for the flow to complete.
+func (fs *flowScheduler) runFlowNow(f *Flow) {
+	fs.mu.numRunning++
+	f.Start(func() { fs.flowDoneCh <- f })
+	// TODO(radu): we could replace the WaitGroup with a structure that keeps a
+	// refcount and automatically runs Cleanup() when the count reaches 0.
+	go func() {
+		f.Wait()
+		f.Cleanup()
+	}()
+}
+
+// ScheduleFlow is the main interface of the flow scheduler: it runs or enqueues
+// the given flow.
+func (fs *flowScheduler) ScheduleFlow(f *Flow) error {
+	return fs.stopper.RunTask(func() {
+		fs.mu.Lock()
+		defer fs.mu.Unlock()
+
+		if fs.canRunFlow(f) {
+			fs.runFlowNow(f)
+		} else {
+			fs.mu.queue.PushBack(f)
+		}
+	})
+}
+
+// Start launches the main loop of the scheduler.
+func (fs *flowScheduler) Start() {
+	fs.stopper.RunWorker(func() {
+		stopped := false
+		fs.mu.Lock()
+		defer fs.mu.Unlock()
+
+		for {
+			if stopped && fs.mu.numRunning == 0 {
+				// TODO(radu): somehow error out the flows that are still in the queue.
+				return
+			}
+			fs.mu.Unlock()
+			select {
+			case <-fs.flowDoneCh:
+				fs.mu.Lock()
+				fs.mu.numRunning--
+				if !stopped {
+					if frElem := fs.mu.queue.Front(); frElem != nil {
+						f := frElem.Value.(*Flow)
+						fs.mu.queue.Remove(frElem)
+						fs.runFlowNow(f)
+					}
+				}
+
+			case <-fs.stopper.ShouldStop():
+				fs.mu.Lock()
+				stopped = true
+			}
+		}
+	})
+}

--- a/pkg/sql/distsql/outbox.go
+++ b/pkg/sql/distsql/outbox.go
@@ -198,7 +198,6 @@ func (m *outbox) run() {
 }
 
 func (m *outbox) start(wg *sync.WaitGroup) {
-	wg.Add(1)
 	m.wg = wg
 	m.RowChannel.Init()
 	go m.run()


### PR DESCRIPTION
Implementing a very basic flow scheduler. Currently it limits the number of
flows run in parallel.

This change also adds a mechanism to time out flows that never get inbound
connections to their streams, and correctly accounts for the inbound streams in
the flow waitgroup (fixes #9985).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10201)

<!-- Reviewable:end -->
