### PR TITLE
acceptance: allow use of GOOGLE_CREDENTIALS

### DIFF
--- a/pkg/acceptance/terraform/main.tf
+++ b/pkg/acceptance/terraform/main.tf
@@ -1,6 +1,5 @@
 provider "google" {
   region = "${var.gce_region}"
-  credentials = ""
 }
 
 resource "google_compute_instance" "cockroach" {


### PR DESCRIPTION
Previously, the remote acceptance tests that use terraform would not accept
credentials passed in via `GOOGLE_CREDENTIALS`. They would only work when run
on a GCE instance with default credentials. Removing this line from the
terraform configuration allows for either method.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10203)

<!-- Reviewable:end -->
