### PR TITLE
sql: Add pg_type table to pg_catalog

### DIFF
--- a/pkg/sql/pgtypes.go
+++ b/pkg/sql/pgtypes.go
@@ -1,0 +1,67 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nathan VanBenschoten (nvanbenschoten@gmail.com)
+
+package sql
+
+import (
+	"reflect"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/lib/pq/oid"
+)
+
+var oidToDatum = map[oid.Oid]parser.Type{
+	oid.T_bool:        parser.TypeBool,
+	oid.T_bytea:       parser.TypeBytes,
+	oid.T_date:        parser.TypeDate,
+	oid.T_float4:      parser.TypeFloat,
+	oid.T_float8:      parser.TypeFloat,
+	oid.T_int2:        parser.TypeInt,
+	oid.T_int4:        parser.TypeInt,
+	oid.T_int8:        parser.TypeInt,
+	oid.T_interval:    parser.TypeInterval,
+	oid.T_numeric:     parser.TypeDecimal,
+	oid.T_text:        parser.TypeString,
+	oid.T_timestamp:   parser.TypeTimestamp,
+	oid.T_timestamptz: parser.TypeTimestampTZ,
+	oid.T_varchar:     parser.TypeString,
+}
+
+var datumToOid = map[reflect.Type]oid.Oid{
+	reflect.TypeOf(parser.TypeBool):        oid.T_bool,
+	reflect.TypeOf(parser.TypeBytes):       oid.T_bytea,
+	reflect.TypeOf(parser.TypeDate):        oid.T_date,
+	reflect.TypeOf(parser.TypeFloat):       oid.T_float8,
+	reflect.TypeOf(parser.TypeInt):         oid.T_int8,
+	reflect.TypeOf(parser.TypeInterval):    oid.T_interval,
+	reflect.TypeOf(parser.TypeDecimal):     oid.T_numeric,
+	reflect.TypeOf(parser.TypeString):      oid.T_text,
+	reflect.TypeOf(parser.TypeTimestamp):   oid.T_timestamp,
+	reflect.TypeOf(parser.TypeTimestampTZ): oid.T_timestamptz,
+}
+
+// OidToDatum maps Postgres object IDs to CockroachDB types.
+func OidToDatum(oid oid.Oid) (parser.Type, bool) {
+	t, ok := oidToDatum[oid]
+	return t, ok
+}
+
+// DatumToOid maps CockroachDB types to Postgres object IDs, using reflection
+// to support unhashable types.
+func DatumToOid(typ parser.Type) (oid.Oid, bool) {
+	oid, ok := datumToOid[reflect.TypeOf(typ)]
+	return oid, ok
+}

--- a/pkg/sql/pgwire/binary_test.go
+++ b/pkg/sql/pgwire/binary_test.go
@@ -25,11 +25,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -59,7 +59,7 @@ func testBinaryDatumType(t *testing.T, typ string, datumConstructor func(val str
 		buf.wrapped.Reset()
 
 		d := datumConstructor(test.In)
-		oid := datumToOid[reflect.TypeOf(d.ResolvedType())]
+		oid, _ := sql.DatumToOid(d.ResolvedType())
 		func() {
 			defer func() {
 				if r := recover(); r != nil {

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -398,38 +397,6 @@ func pgBinaryToDate(i int32) *parser.DDate {
 	daysSinceEpoch := pgEpochJDateFromUnix + i
 	return parser.NewDDate(parser.DDate(daysSinceEpoch))
 }
-
-var (
-	oidToDatum = map[oid.Oid]parser.Type{
-		oid.T_bool:        parser.TypeBool,
-		oid.T_bytea:       parser.TypeBytes,
-		oid.T_date:        parser.TypeDate,
-		oid.T_float4:      parser.TypeFloat,
-		oid.T_float8:      parser.TypeFloat,
-		oid.T_int2:        parser.TypeInt,
-		oid.T_int4:        parser.TypeInt,
-		oid.T_int8:        parser.TypeInt,
-		oid.T_interval:    parser.TypeInterval,
-		oid.T_numeric:     parser.TypeDecimal,
-		oid.T_text:        parser.TypeString,
-		oid.T_timestamp:   parser.TypeTimestamp,
-		oid.T_timestamptz: parser.TypeTimestampTZ,
-		oid.T_varchar:     parser.TypeString,
-	}
-	// Using reflection to support unhashable types.
-	datumToOid = map[reflect.Type]oid.Oid{
-		reflect.TypeOf(parser.TypeBool):        oid.T_bool,
-		reflect.TypeOf(parser.TypeBytes):       oid.T_bytea,
-		reflect.TypeOf(parser.TypeDate):        oid.T_date,
-		reflect.TypeOf(parser.TypeFloat):       oid.T_float8,
-		reflect.TypeOf(parser.TypeInt):         oid.T_int8,
-		reflect.TypeOf(parser.TypeInterval):    oid.T_interval,
-		reflect.TypeOf(parser.TypeDecimal):     oid.T_numeric,
-		reflect.TypeOf(parser.TypeString):      oid.T_text,
-		reflect.TypeOf(parser.TypeTimestamp):   oid.T_timestamp,
-		reflect.TypeOf(parser.TypeTimestampTZ): oid.T_timestamptz,
-	}
-)
 
 // decodeOidDatum decodes bytes with specified Oid and format code into
 // a datum.

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -21,7 +21,6 @@ import (
 	"bufio"
 	"fmt"
 	"net"
-	"reflect"
 	"strconv"
 
 	"github.com/lib/pq/oid"
@@ -366,7 +365,7 @@ func (c *v3Conn) handleParse(ctx context.Context, buf *readBuffer) error {
 		if t == 0 {
 			continue
 		}
-		v, ok := oidToDatum[t]
+		v, ok := sql.OidToDatum(t)
 		if !ok {
 			return c.sendInternalError(fmt.Sprintf("unknown oid type: %v", t))
 		}
@@ -401,7 +400,7 @@ func (c *v3Conn) handleParse(ctx context.Context, buf *readBuffer) error {
 		if inTypes[i] != 0 {
 			continue
 		}
-		id, ok := datumToOid[reflect.TypeOf(t)]
+		id, ok := sql.DatumToOid(t)
 		if !ok {
 			return c.sendInternalError(fmt.Sprintf("unknown datum type: %s", t))
 		}

--- a/pkg/sql/testdata/information_schema
+++ b/pkg/sql/testdata/information_schema
@@ -349,6 +349,7 @@ pg_constraint
 pg_indexes
 pg_namespace
 pg_tables
+pg_type
 descriptor
 eventlog
 lease
@@ -371,6 +372,7 @@ table_constraints
 schemata
 schema_privileges
 rangelog
+pg_type
 pg_tables
 pg_namespace
 pg_indexes
@@ -400,6 +402,7 @@ def            pg_catalog          pg_constraint      SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1
+def            pg_catalog          pg_type            SYSTEM VIEW  1
 def            system              descriptor         BASE TABLE   1
 def            system              eventlog           BASE TABLE   1
 def            system              lease              BASE TABLE   1
@@ -438,6 +441,7 @@ def            pg_catalog          pg_constraint      SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1
+def            pg_catalog          pg_type            SYSTEM VIEW  1
 
 user root
 
@@ -465,6 +469,7 @@ def            pg_catalog          pg_constraint      SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1
+def            pg_catalog          pg_type            SYSTEM VIEW  1
 
 user root
 

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -51,6 +51,7 @@ pg_constraint
 pg_indexes
 pg_namespace
 pg_tables
+pg_type
 
 query TT colnames
 SHOW CREATE TABLE pg_catalog.pg_namespace
@@ -238,26 +239,26 @@ JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'constraint_db'
 ----
-attrelid    relname       attname  atttypid    attstattarget  attlen  attnum  attndims  attcacheoff
-2265044713  t1            p        647854976   0              8       1       0         -1
-2265044713  t1            a        2581589785  0              8       2       0         -1
-2265044713  t1            b        2581589785  0              8       3       0         -1
-2265044713  t1            c        2581589785  0              8       4       0         -1
-1759889455  primary       p        647854976   0              8       1       0         -1
-1759889452  t1_a_key      a        2581589785  0              8       1       0         -1
-1759889453  index_key     b        2581589785  0              8       1       0         -1
-1759889453  index_key     c        2581589785  0              8       2       0         -1
-2030599329  t2            t1_ID    2581589785  0              8       1       0         -1
-559702612   t2_t1_ID_idx  t1_ID    2581589785  0              8       1       0         -1
-2064007441  t3            a        2581589785  0              8       1       0         -1
-2064007441  t3            b        2581589785  0              8       2       0         -1
-2064007441  t3            c        3583390041  0              -1      3       0         -1
-4171047644  t3_a_b_idx    a        2581589785  0              8       1       0         -1
-4171047644  t3_a_b_idx    b        2581589785  0              8       2       0         -1
-2332993830  v1            p        647854976   0              8       1       0         -1
-2332993830  v1            a        2581589785  0              8       2       0         -1
-2332993830  v1            b        2581589785  0              8       3       0         -1
-2332993830  v1            c        2581589785  0              8       4       0         -1
+attrelid    relname       attname  atttypid  attstattarget  attlen  attnum  attndims  attcacheoff
+2265044713  t1            p        701       0              8       1       0         -1
+2265044713  t1            a        20        0              8       2       0         -1
+2265044713  t1            b        20        0              8       3       0         -1
+2265044713  t1            c        20        0              8       4       0         -1
+1759889455  primary       p        701       0              8       1       0         -1
+1759889452  t1_a_key      a        20        0              8       1       0         -1
+1759889453  index_key     b        20        0              8       1       0         -1
+1759889453  index_key     c        20        0              8       2       0         -1
+2030599329  t2            t1_ID    20        0              8       1       0         -1
+559702612   t2_t1_ID_idx  t1_ID    20        0              8       1       0         -1
+2064007441  t3            a        20        0              8       1       0         -1
+2064007441  t3            b        20        0              8       2       0         -1
+2064007441  t3            c        25        0              -1      3       0         -1
+4171047644  t3_a_b_idx    a        20        0              8       1       0         -1
+4171047644  t3_a_b_idx    b        20        0              8       2       0         -1
+2332993830  v1            p        701       0              8       1       0         -1
+2332993830  v1            a        20        0              8       2       0         -1
+2332993830  v1            b        20        0              8       3       0         -1
+2332993830  v1            c        20        0              8       4       0         -1
 
 query TTIBTTBB colnames
 SELECT c.relname, attname, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef
@@ -473,3 +474,110 @@ ORDER BY con.oid
 conname  confkey  conpfeqop  conppeqop  conffeqop  conexclop  conbin  consrc
 fk       {2}      NULL       NULL       NULL       NULL       NULL    NULL
 fk       {3,4}    NULL       NULL       NULL       NULL       NULL    NULL
+
+## pg_catalog.pg_type
+
+query ITIIIBT colnames
+SELECT oid, typname, typnamespace, typowner, typlen, typbyval, typtype
+FROM pg_catalog.pg_type
+ORDER BY oid
+----
+oid   typname      typnamespace  typowner  typlen  typbyval  typtype
+16    bool         NULL          NULL      1       true      b
+17    bytes        NULL          NULL      -1      false     b
+20    int          NULL          NULL      8       true      b
+21    int          NULL          NULL      8       true      b
+23    int          NULL          NULL      8       true      b
+25    string       NULL          NULL      -1      false     b
+700   float        NULL          NULL      8       true      b
+701   float        NULL          NULL      8       true      b
+1043  string       NULL          NULL      -1      false     b
+1082  date         NULL          NULL      8       true      b
+1114  timestamp    NULL          NULL      24      true      b
+1184  timestamptz  NULL          NULL      24      true      b
+1186  interval     NULL          NULL      24      true      b
+1700  decimal      NULL          NULL      -1      false     b
+
+query ITTBBTIII colnames
+SELECT oid, typname, typcategory, typispreferred, typisdefined, typdelim, typrelid, typelem, typarray
+FROM pg_catalog.pg_type
+ORDER BY oid
+----
+oid   typname      typcategory  typispreferred  typisdefined  typdelim  typrelid  typelem  typarray
+16    bool         B            false           true          ,         0         0        0
+17    bytes        U            false           true          ,         0         0        0
+20    int          N            false           true          ,         0         0        0
+21    int          N            false           true          ,         0         0        0
+23    int          N            false           true          ,         0         0        0
+25    string       S            false           true          ,         0         0        0
+700   float        N            false           true          ,         0         0        0
+701   float        N            false           true          ,         0         0        0
+1043  string       S            false           true          ,         0         0        0
+1082  date         D            false           true          ,         0         0        0
+1114  timestamp    D            false           true          ,         0         0        0
+1184  timestamptz  D            false           true          ,         0         0        0
+1186  interval     T            false           true          ,         0         0        0
+1700  decimal      N            false           true          ,         0         0        0
+
+query ITIIIIIII colnames
+SELECT oid, typname, typinput, typoutput, typreceive, typsend, typmodin, typmodout, typanalyze
+FROM pg_catalog.pg_type
+ORDER BY oid
+----
+oid   typname      typinput  typoutput  typreceive  typsend  typmodin  typmodout  typanalyze
+16    bool         0         0          0           0        0         0          0
+17    bytes        0         0          0           0        0         0          0
+20    int          0         0          0           0        0         0          0
+21    int          0         0          0           0        0         0          0
+23    int          0         0          0           0        0         0          0
+25    string       0         0          0           0        0         0          0
+700   float        0         0          0           0        0         0          0
+701   float        0         0          0           0        0         0          0
+1043  string       0         0          0           0        0         0          0
+1082  date         0         0          0           0        0         0          0
+1114  timestamp    0         0          0           0        0         0          0
+1184  timestamptz  0         0          0           0        0         0          0
+1186  interval     0         0          0           0        0         0          0
+1700  decimal      0         0          0           0        0         0          0
+
+query ITTTBII colnames
+SELECT oid, typname, typalign, typstorage, typnotnull, typbasetype, typtypmod
+FROM pg_catalog.pg_type
+ORDER BY oid
+----
+oid   typname      typalign  typstorage  typnotnull  typbasetype  typtypmod
+16    bool         NULL      NULL        false       0            -1
+17    bytes        NULL      NULL        false       0            -1
+20    int          NULL      NULL        false       0            -1
+21    int          NULL      NULL        false       0            -1
+23    int          NULL      NULL        false       0            -1
+25    string       NULL      NULL        false       0            -1
+700   float        NULL      NULL        false       0            -1
+701   float        NULL      NULL        false       0            -1
+1043  string       NULL      NULL        false       0            -1
+1082  date         NULL      NULL        false       0            -1
+1114  timestamp    NULL      NULL        false       0            -1
+1184  timestamptz  NULL      NULL        false       0            -1
+1186  interval     NULL      NULL        false       0            -1
+1700  decimal      NULL      NULL        false       0            -1
+
+query ITIITTT colnames
+SELECT oid, typname, typndims, typcollation, typdefaultbin, typdefault, typacl
+FROM pg_catalog.pg_type
+ORDER BY oid
+----
+oid   typname      typndims  typcollation  typdefaultbin  typdefault  typacl
+16    bool         0         0             NULL           NULL        NULL
+17    bytes        0         0             NULL           NULL        NULL
+20    int          0         0             NULL           NULL        NULL
+21    int          0         0             NULL           NULL        NULL
+23    int          0         0             NULL           NULL        NULL
+25    string       0         0             NULL           NULL        NULL
+700   float        0         0             NULL           NULL        NULL
+701   float        0         0             NULL           NULL        NULL
+1043  string       0         0             NULL           NULL        NULL
+1082  date         0         0             NULL           NULL        NULL
+1114  timestamp    0         0             NULL           NULL        NULL
+1184  timestamptz  0         0             NULL           NULL        NULL
+1186  interval     0         0             NULL           NULL        NULL
+1700  decimal      0         0             NULL           NULL        NULL


### PR DESCRIPTION
Fixes #10072.

The `pg_type` table stores information about data types.

cc. @jordanlewis

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10209)

<!-- Reviewable:end -->
