### PR TITLE
storage: fix deadlock in coalesced heartbeats

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -1450,6 +1450,60 @@ func TestRaftHeartbeats(t *testing.T) {
 	}
 }
 
+// TestReportUnreachableHeartbeats tests that if a single transport fails,
+// coalesced heartbeats are not stalled out entirely.
+func TestReportUnreachableHeartbeats(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	mtc := startMultiTestContext(t, 3)
+	defer mtc.Stop()
+
+	// Replicate the range onto all three stores
+	mtc.replicateRange(1, 1, 2)
+
+	// Send a single increment to ensure the range is up.
+	key := roachpb.Key("a")
+	incArgs := incrementArgs(key, 2)
+	if _, err := client.SendWrapped(context.Background(),
+		mtc.distSenders[0], &incArgs); err != nil {
+		t.Fatal(err)
+	}
+	mtc.waitForValues(key, []int64{2, 2, 2})
+
+	leaderIdx := -1
+	for i, store := range mtc.stores {
+		if store.RaftStatus(1).SoftState.RaftState == raft.StateLeader {
+			leaderIdx = i
+			break
+		}
+	}
+	initialTerm := mtc.stores[leaderIdx].RaftStatus(1).Term
+	// Choose a follower index that is guaranteed to not be the leader
+	followerIdx := len(mtc.stores) + 1 - leaderIdx
+
+	// Shut down a raft transport via the circuit breaker, and wait for two
+	// election timeouts to trigger an election if reportUnreachable broke
+	// heartbeat transmission to the other store.
+	cb := mtc.transports[0].GetCircuitBreaker(roachpb.NodeID(followerIdx))
+	cb.Break()
+
+	ticksToWait := 2 * mtc.makeStoreConfig(0).RaftElectionTimeoutTicks
+	ticks := mtc.stores[leaderIdx].Metrics().RaftTicks.Count
+	for targetTicks := ticks() + int64(ticksToWait); ticks() < targetTicks; {
+		time.Sleep(time.Millisecond)
+	}
+
+	// Ensure that the leadership has not changed, to confirm that heartbeats
+	// are sent to the store with a functioning transport.
+	status := mtc.stores[leaderIdx].RaftStatus(1)
+	if status.SoftState.RaftState != raft.StateLeader {
+		t.Errorf("expected node %d to be leader after sleeping but was %s", leaderIdx, status.SoftState.RaftState)
+	}
+	if status.Term != initialTerm {
+		t.Errorf("while sleeping, term changed from %d to %d", initialTerm, status.Term)
+	}
+}
+
 // TestReplicateAfterSplit verifies that a new replica whose start key
 // is not KeyMin replicating to a fresh store can apply snapshots correctly.
 func TestReplicateAfterSplit(t *testing.T) {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -374,6 +374,11 @@ type Replica struct {
 		// The pending outgoing snapshot if there is one.
 		outSnap OutgoingSnapshot
 	}
+
+	unreachablesMu struct {
+		syncutil.Mutex
+		remotes map[roachpb.ReplicaID]struct{}
+	}
 }
 
 // KeyRange is an interface type for the replicasByKey BTree, to compare
@@ -2198,6 +2203,15 @@ func (r *Replica) tickRaftMuLocked() (bool, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	r.unreachablesMu.Lock()
+	remotes := r.unreachablesMu.remotes
+	r.unreachablesMu.remotes = nil
+	r.unreachablesMu.Unlock()
+
+	for remoteReplica := range remotes {
+		r.mu.internalRaftGroup.ReportUnreachable(uint64(remoteReplica))
+	}
+
 	// If the raft group is uninitialized, do not initialize raft groups on
 	// tick.
 	if r.mu.internalRaftGroup == nil {
@@ -2659,12 +2673,15 @@ func (r *Replica) sendRaftMessage(ctx context.Context, msg raftpb.Message) {
 	}
 }
 
-// reportUnreachable reports the remote replica as unreachable to the internal
-// raft group.
-func (r *Replica) reportUnreachable(remoteReplica roachpb.ReplicaID) {
-	r.raftMu.Lock()
-	defer r.raftMu.Unlock()
-	r.mu.internalRaftGroup.ReportUnreachable(uint64(remoteReplica))
+// addUnreachableRemoteReplica adds the given remote ReplicaID to be reported
+// as unreachable on the next tick.
+func (r *Replica) addUnreachableRemoteReplica(remoteReplica roachpb.ReplicaID) {
+	r.unreachablesMu.Lock()
+	if r.unreachablesMu.remotes == nil {
+		r.unreachablesMu.remotes = make(map[roachpb.ReplicaID]struct{})
+	}
+	r.unreachablesMu.remotes[remoteReplica] = struct{}{}
+	r.unreachablesMu.Unlock()
 }
 
 // sendRaftMessageRequest sends a raft message, returning false if the message


### PR DESCRIPTION
The `Replica.ReportUnreachable()` code path held `r.raftMu`, and was
called by the heartbeat coalescing goroutine. If `r.raftMu` was
unavailable, this held up all heartbeat traffic. Change reporting
unreachable remote replicas to add to a per-Replica slice of
unreachable remotes, and have the actual reporting happen on
`Replica.tick()`. Closes #10206.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10214)

<!-- Reviewable:end -->
