### PR TITLE
sql: implement pg_catalog.pg_proc

### DIFF
--- a/docs/RFCS/information_schema.md
+++ b/docs/RFCS/information_schema.md
@@ -116,7 +116,7 @@ detailed discussion on `pg_catalog` until the implementation of `information_sch
 
 ### Standards Considerations
 
-It is advised that we take a similar approach to MySQL in it's representation of
+It is advised that we take a similar approach to MySQL in its representation of
 `information_schema`. The `information_schema` table structure will follow the ANSI/ISO
 SQL:2003 standard Part 11 Schemata. The intent is approximate compliance with SQL:2003 core
 feature F021 Basic information schema.

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -147,11 +147,18 @@ func (b Builtin) Category() string {
 	return ""
 }
 
-// Signature returns a human-readable signature
+// Class returns the FunctionClass of this builtin.
+func (b Builtin) Class() FunctionClass {
+	return b.class
+}
+
+// Impure returns false if this builtin is a pure function of its inputs.
+func (b Builtin) Impure() bool {
+	return b.impure
+}
+
+// Signature returns a human-readable signature.
 func (b Builtin) Signature() string {
-	if b.ReturnType == nil {
-		return "<T>... -> <T>" // Special-case for LEAST and GREATEST.
-	}
 	return fmt.Sprintf("(%s) -> %s", b.Types.String(), b.ReturnType)
 }
 
@@ -578,7 +585,7 @@ var Builtins = map[string][]Builtin{
 	"greatest": {
 		Builtin{
 			Types:      AnyType{},
-			ReturnType: nil, // No explicit return type because AnyType parameters.
+			ReturnType: TypeAny,
 			category:   categoryComparison,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return pickFromTuple(ctx, true /* greatest */, args)
@@ -589,7 +596,7 @@ var Builtins = map[string][]Builtin{
 	"least": {
 		Builtin{
 			Types:      AnyType{},
-			ReturnType: nil, // No explicit return type because AnyType parameters.
+			ReturnType: TypeAny,
 			category:   categoryComparison,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return pickFromTuple(ctx, false /* !greatest */, args)

--- a/pkg/sql/parser/overload.go
+++ b/pkg/sql/parser/overload.go
@@ -41,7 +41,11 @@ type typeList interface {
 	// getAt returns the type at the given index in the typeList, or nil if the typeList
 	// cannot have a parameter at index i.
 	getAt(i int) Type
-	// human readable signature
+	// Length returns the number of types in the list
+	Length() int
+	// Types returns a realized copy of the list. variadic lists return a list of size one.
+	Types() []Type
+	// String returns a human readable signature
 	String() string
 }
 
@@ -77,6 +81,16 @@ func (a ArgTypes) matchLen(l int) bool {
 
 func (a ArgTypes) getAt(i int) Type {
 	return a[i]
+}
+
+// Length implements the typeList interface.
+func (a ArgTypes) Length() int {
+	return len(a)
+}
+
+// Types implements the typeList interface.
+func (a ArgTypes) Types() []Type {
+	return a
 }
 
 func (a ArgTypes) String() string {
@@ -122,6 +136,21 @@ func (a NamedArgTypes) getAt(i int) Type {
 	return a[i].Typ
 }
 
+// Length implements the typeList interface.
+func (a NamedArgTypes) Length() int {
+	return len(a)
+}
+
+// Types implements the typeList interface.
+func (a NamedArgTypes) Types() []Type {
+	n := len(a)
+	ret := make([]Type, n, n)
+	for i, s := range a {
+		ret[i] = s.Typ
+	}
+	return ret
+}
+
 func (a NamedArgTypes) String() string {
 	var s bytes.Buffer
 	for i, arg := range a {
@@ -154,8 +183,18 @@ func (AnyType) getAt(i int) Type {
 	panic("getAt called on AnyType")
 }
 
+// Length implements the typeList interface.
+func (a AnyType) Length() int {
+	return 1
+}
+
+// Types implements the typeList interface.
+func (a AnyType) Types() []Type {
+	return []Type{TypeAny}
+}
+
 func (AnyType) String() string {
-	return "*"
+	return "anyelement..."
 }
 
 // VariadicType is a typeList implementation which accepts any number of
@@ -184,6 +223,16 @@ func (v VariadicType) matchLen(l int) bool {
 
 func (v VariadicType) getAt(i int) Type {
 	return v.Typ
+}
+
+// Length implements the typeList interface.
+func (v VariadicType) Length() int {
+	return 1
+}
+
+// Types implements the typeList interface.
+func (v VariadicType) Types() []Type {
+	return []Type{v.Typ}
 }
 
 func (v VariadicType) String() string {
@@ -220,6 +269,16 @@ func (s SingleType) getAt(i int) Type {
 		return nil
 	}
 	return s.Typ
+}
+
+// Length implements the typeList interface.
+func (s SingleType) Length() int {
+	return 1
+}
+
+// Types implements the typeList interface.
+func (s SingleType) Types() []Type {
+	return []Type{s.Typ}
 }
 
 func (s SingleType) String() string {

--- a/pkg/sql/parser/type.go
+++ b/pkg/sql/parser/type.go
@@ -79,6 +79,8 @@ var (
 	TypePlaceholder Type = TPlaceholder{}
 	// TypeArray is the type family of a DArray. Can be compared with ==.
 	TypeArray Type = tArray{TypeString}
+	// TypeAny can be any type. Can be compared with ==.
+	TypeAny Type = tAny{}
 )
 
 // Do not instantiate the tXxx types elsewhere. The variables above are intended
@@ -255,3 +257,10 @@ func (tArray) FamilyEqual(other Type) bool {
 func (tArray) Size() (uintptr, bool) {
 	return unsafe.Sizeof(DString("")), variableSize
 }
+
+type tAny struct{}
+
+func (tAny) String() string              { return "anyelement" }
+func (tAny) Equal(other Type) bool       { return other == TypeAny }
+func (tAny) FamilyEqual(other Type) bool { return other == TypeAny }
+func (tAny) Size() (uintptr, bool)       { return unsafe.Sizeof(DString("")), variableSize }

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -24,9 +24,12 @@ import (
 	"hash/fnv"
 	"reflect"
 	"strconv"
+	"strings"
+	"unicode"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/lib/pq/oid"
 	"github.com/pkg/errors"
 )
 
@@ -36,11 +39,13 @@ var (
 	negOneVal = parser.NewDInt(-1)
 )
 
+const pgCatalogName = "pg_catalog"
+
 // pgCatalog contains a set of system tables mirroring PostgreSQL's pg_catalog schema.
 // This code attempts to comply as closely as possible to the system catalogs documented
 // in https://www.postgresql.org/docs/9.6/static/catalogs.html.
 var pgCatalog = virtualSchema{
-	name: "pg_catalog",
+	name: pgCatalogName,
 	tables: []virtualSchemaTable{
 		pgCatalogAttrDefTable,
 		pgCatalogAttributeTable,
@@ -49,6 +54,7 @@ var pgCatalog = virtualSchema{
 		pgCatalogDatabaseTable,
 		pgCatalogIndexesTable,
 		pgCatalogNamespaceTable,
+		pgCatalogProcTable,
 		pgCatalogTablesTable,
 		pgCatalogTypeTable,
 		pgCatalogViewsTable,
@@ -594,6 +600,161 @@ CREATE TABLE pg_catalog.pg_namespace (
 	},
 }
 
+var (
+	proArgModeInOut    = parser.NewDString("b")
+	proArgModeIn       = parser.NewDString("i")
+	proArgModeOut      = parser.NewDString("o")
+	proArgModeTable    = parser.NewDString("t")
+	proArgModeVariadic = parser.NewDString("v")
+
+	// Avoid unused warning for constants.
+	_ = proArgModeInOut
+	_ = proArgModeIn
+	_ = proArgModeOut
+	_ = proArgModeTable
+)
+
+func datumToOidOrPanic(typ parser.Type, builtin parser.Builtin) oid.Oid {
+	oid, ok := DatumToOid(typ)
+	if !ok {
+		panic(fmt.Sprintf("programmer error: could not find referenced type %v on builtin %v",
+			typ, builtin))
+	}
+	return oid
+}
+
+// See: https://www.postgresql.org/docs/9.6/static/catalog-pg-proc.html
+var pgCatalogProcTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE pg_catalog.pg_proc (
+	oid INT,
+	proname STRING,
+	pronamespace INT,
+	proowner INT,
+	prolang INT,
+	procost FLOAT,
+	prorows FLOAT,
+	provariadic INT,
+	protransform STRING,
+	proisagg BOOL,
+	proiswindow BOOL,
+	prosecdef BOOL,
+	proleakproof BOOL,
+	proisstrict BOOL,
+	proretset BOOL,
+	provolatile CHAR,
+	proparallel CHAR,
+	pronargs INT,
+	pronargdefaults INT,
+	prorettype INT,
+	proargtypes STRING,
+	proallargtypes STRING,
+	proargmodes STRING,
+	proargnames STRING,
+	proargdefaults STRING,
+	protrftypes STRING,
+	prosrc STRING,
+	probin STRING,
+	proconfig STRING,
+	proacl STRING
+);
+`,
+	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+		h := makeOidHasher()
+		dbDesc, err := p.getDatabaseDesc(pgCatalogName)
+		dbOid := h.DBOid(dbDesc)
+		if err != nil {
+			return err
+		}
+		for name, builtins := range parser.Builtins {
+			// parser.Builtins contains duplicate uppercase and lowercase keys.
+			// Only return the lowercase ones for compatibility with postgres.
+			var first rune
+			for _, c := range name {
+				first = c
+				break
+			}
+			if unicode.IsUpper(first) {
+				continue
+			}
+			for _, builtin := range builtins {
+				dName := parser.NewDString(name)
+				isAggregate := builtin.Class() == parser.AggregateClass
+				isWindow := builtin.Class() == parser.WindowClass
+
+				var retType parser.Datum
+				if builtin.ReturnType != nil {
+					oid := datumToOidOrPanic(builtin.ReturnType, builtin)
+					retType = parser.NewDInt(parser.DInt(oid))
+				}
+
+				argTypes := builtin.Types
+				dArgTypes := make([]string, len(argTypes.Types()))
+				for i, argType := range argTypes.Types() {
+					dArgType := datumToOidOrPanic(argType, builtin)
+					dArgTypes[i] = strconv.Itoa(int(dArgType))
+				}
+				dArgTypeString := strings.Join(dArgTypes, ", ")
+
+				var argmodes parser.Datum
+				var variadicType *parser.DInt
+				switch argTypes.(type) {
+				case parser.VariadicType:
+					argmodes = proArgModeVariadic
+					argType := argTypes.Types()[0]
+					oid := datumToOidOrPanic(argType, builtin)
+					variadicType = parser.NewDInt(parser.DInt(oid))
+				case parser.AnyType:
+					argmodes = proArgModeVariadic
+					argType := parser.TypeAny
+					oid := datumToOidOrPanic(argType, builtin)
+					variadicType = parser.NewDInt(parser.DInt(oid))
+
+				default:
+					argmodes = parser.DNull
+					variadicType = oidZero
+				}
+				err := addRow(
+					h.BuiltinOid(name, &builtin), // oid
+					dName,                                             // proname
+					dbOid,                                             // pronamespace
+					parser.DNull,                                      // proowner
+					oidZero,                                           // prolang
+					parser.DNull,                                      // procost
+					parser.DNull,                                      // prorows
+					variadicType,                                      // provariadic
+					parser.DNull,                                      // protransform
+					parser.MakeDBool(parser.DBool(isAggregate)),       // proisagg
+					parser.MakeDBool(parser.DBool(isWindow)),          // proiswindow
+					parser.MakeDBool(false),                           // prosecdef
+					parser.MakeDBool(parser.DBool(!builtin.Impure())), // proleakproof
+					parser.MakeDBool(false),                           // proisstrict
+					parser.MakeDBool(false),                           // proretset
+					parser.DNull,                                      // provolatile
+					parser.DNull,                                      // proparallel
+					parser.NewDInt(parser.DInt(builtin.Types.Length())), // pronargs
+					parser.NewDInt(parser.DInt(0)),                      // pronargdefaults
+					retType, // prorettype
+					parser.NewDString(dArgTypeString), // proargtypes
+					parser.DNull,                      // proallargtypes
+					argmodes,                          // proargmodes
+					parser.DNull,                      // proargnames
+					parser.DNull,                      // proargdefaults
+					parser.DNull,                      // protrftypes
+					dName,                             // prosrc
+					parser.DNull,                      // probin
+					parser.DNull,                      // proconfig
+					parser.DNull,                      // proacl
+				)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	},
+}
+
 // See: https://www.postgresql.org/docs/9.6/static/view-pg-tables.html.
 var pgCatalogTablesTable = virtualSchemaTable{
 	schema: `
@@ -828,6 +989,8 @@ func typByVal(typ parser.Type) parser.Datum {
 
 // This mapping should be kept sync with PG's categorization.
 var datumToTypeCategory = map[reflect.Type]*parser.DString{
+	reflect.TypeOf(parser.TypeAny):         typCategoryPseudo,
+	reflect.TypeOf(parser.TypeArray):       typCategoryArray,
 	reflect.TypeOf(parser.TypeBool):        typCategoryBoolean,
 	reflect.TypeOf(parser.TypeBytes):       typCategoryUserDefined,
 	reflect.TypeOf(parser.TypeDate):        typCategoryDateTime,
@@ -838,6 +1001,7 @@ var datumToTypeCategory = map[reflect.Type]*parser.DString{
 	reflect.TypeOf(parser.TypeString):      typCategoryString,
 	reflect.TypeOf(parser.TypeTimestamp):   typCategoryDateTime,
 	reflect.TypeOf(parser.TypeTimestampTZ): typCategoryDateTime,
+	reflect.TypeOf(parser.TypeTuple):       typCategoryPseudo,
 }
 
 func typCategory(typ parser.Type) parser.Datum {
@@ -938,6 +1102,7 @@ const (
 	fkConstraintTypeTag
 	pKeyConstraintTypeTag
 	uniqueConstraintTypeTag
+	functionTypeTag
 )
 
 func (h oidHasher) writeTypeTag(tag oidTypeTag) {
@@ -1054,5 +1219,12 @@ func (h oidHasher) UniqueConstraintOid(
 	h.writeDB(db)
 	h.writeTable(table)
 	h.writeIndex(index)
+	return h.getOid()
+}
+
+func (h oidHasher) BuiltinOid(name string, builtin *parser.Builtin) *parser.DInt {
+	h.writeTypeTag(functionTypeTag)
+	h.writeStr(name)
+	h.writeStr(builtin.Types.String())
 	return h.getOid()
 }

--- a/pkg/sql/pgtypes.go
+++ b/pkg/sql/pgtypes.go
@@ -24,6 +24,7 @@ import (
 )
 
 var oidToDatum = map[oid.Oid]parser.Type{
+	oid.T_anyelement:  parser.TypeAny,
 	oid.T_bool:        parser.TypeBool,
 	oid.T_bytea:       parser.TypeBytes,
 	oid.T_date:        parser.TypeDate,
@@ -35,12 +36,16 @@ var oidToDatum = map[oid.Oid]parser.Type{
 	oid.T_interval:    parser.TypeInterval,
 	oid.T_numeric:     parser.TypeDecimal,
 	oid.T_text:        parser.TypeString,
+	oid.T__text:       parser.TypeArray,
 	oid.T_timestamp:   parser.TypeTimestamp,
 	oid.T_timestamptz: parser.TypeTimestampTZ,
 	oid.T_varchar:     parser.TypeString,
 }
 
 var datumToOid = map[reflect.Type]oid.Oid{
+	reflect.TypeOf(parser.TypeAny): oid.T_anyelement,
+	// Currently, only text arrays are supported.
+	reflect.TypeOf(parser.TypeArray):       oid.T__text,
 	reflect.TypeOf(parser.TypeBool):        oid.T_bool,
 	reflect.TypeOf(parser.TypeBytes):       oid.T_bytea,
 	reflect.TypeOf(parser.TypeDate):        oid.T_date,
@@ -51,6 +56,7 @@ var datumToOid = map[reflect.Type]oid.Oid{
 	reflect.TypeOf(parser.TypeString):      oid.T_text,
 	reflect.TypeOf(parser.TypeTimestamp):   oid.T_timestamp,
 	reflect.TypeOf(parser.TypeTimestampTZ): oid.T_timestamptz,
+	reflect.TypeOf(parser.TypeTuple):       oid.T_record,
 }
 
 // OidToDatum maps Postgres object IDs to CockroachDB types.

--- a/pkg/sql/pgwire_test.go
+++ b/pkg/sql/pgwire_test.go
@@ -422,7 +422,7 @@ func TestPGPreparedQuery(t *testing.T) {
 			baseTest.Results("UTC"),
 		},
 		"HELP LEAST": {
-			baseTest.Results("least", "<T>... -> <T>", "Comparison", ""),
+			baseTest.Results("least", "(anyelement...) -> anyelement", "Comparison", ""),
 		},
 		"SELECT (SELECT 1+$1)": {
 			baseTest.SetArgs(1).Results(2),

--- a/pkg/sql/testdata/help
+++ b/pkg/sql/testdata/help
@@ -13,4 +13,4 @@ query TTTT colnames
 HELP LEAST
 ----
 Function    Signature                           Category            Details
-least       <T>... -> <T>                       Comparison
+least       (anyelement...) -> anyelement       Comparison

--- a/pkg/sql/testdata/information_schema
+++ b/pkg/sql/testdata/information_schema
@@ -351,6 +351,7 @@ pg_constraint
 pg_database
 pg_indexes
 pg_namespace
+pg_proc
 pg_tables
 pg_type
 pg_views
@@ -380,6 +381,7 @@ rangelog
 pg_views
 pg_type
 pg_tables
+pg_proc
 pg_namespace
 pg_indexes
 pg_database
@@ -410,6 +412,7 @@ def            pg_catalog          pg_constraint      SYSTEM VIEW  1
 def            pg_catalog          pg_database        SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
+def            pg_catalog          pg_proc            SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1
 def            pg_catalog          pg_type            SYSTEM VIEW  1
 def            pg_catalog          pg_views           SYSTEM VIEW  1
@@ -452,6 +455,7 @@ def            pg_catalog          pg_constraint      SYSTEM VIEW  1
 def            pg_catalog          pg_database        SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
+def            pg_catalog          pg_proc            SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1
 def            pg_catalog          pg_type            SYSTEM VIEW  1
 def            pg_catalog          pg_views           SYSTEM VIEW  1
@@ -483,6 +487,7 @@ def            pg_catalog          pg_constraint      SYSTEM VIEW  1
 def            pg_catalog          pg_database        SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
+def            pg_catalog          pg_proc            SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1
 def            pg_catalog          pg_type            SYSTEM VIEW  1
 def            pg_catalog          pg_views           SYSTEM VIEW  1

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -51,6 +51,7 @@ pg_constraint
 pg_database
 pg_indexes
 pg_namespace
+pg_proc
 pg_tables
 pg_type
 pg_views
@@ -501,12 +502,14 @@ oid   typname      typnamespace  typowner  typlen  typbyval  typtype
 25    string       NULL          NULL      -1      false     b
 700   float        NULL          NULL      8       true      b
 701   float        NULL          NULL      8       true      b
+1009  string[]     NULL          NULL      -1      false     b
 1043  string       NULL          NULL      -1      false     b
 1082  date         NULL          NULL      8       true      b
 1114  timestamp    NULL          NULL      24      true      b
 1184  timestamptz  NULL          NULL      24      true      b
 1186  interval     NULL          NULL      24      true      b
 1700  decimal      NULL          NULL      -1      false     b
+2283  anyelement   NULL          NULL      -1      false     b
 
 query ITTBBTIII colnames
 SELECT oid, typname, typcategory, typispreferred, typisdefined, typdelim, typrelid, typelem, typarray
@@ -522,12 +525,14 @@ oid   typname      typcategory  typispreferred  typisdefined  typdelim  typrelid
 25    string       S            false           true          ,         0         0        0
 700   float        N            false           true          ,         0         0        0
 701   float        N            false           true          ,         0         0        0
+1009  string[]     A            false           true          ,         0         0        0
 1043  string       S            false           true          ,         0         0        0
 1082  date         D            false           true          ,         0         0        0
 1114  timestamp    D            false           true          ,         0         0        0
 1184  timestamptz  D            false           true          ,         0         0        0
 1186  interval     T            false           true          ,         0         0        0
 1700  decimal      N            false           true          ,         0         0        0
+2283  anyelement   P            false           true          ,         0         0        0
 
 query ITIIIIIII colnames
 SELECT oid, typname, typinput, typoutput, typreceive, typsend, typmodin, typmodout, typanalyze
@@ -543,12 +548,14 @@ oid   typname      typinput  typoutput  typreceive  typsend  typmodin  typmodout
 25    string       0         0          0           0        0         0          0
 700   float        0         0          0           0        0         0          0
 701   float        0         0          0           0        0         0          0
+1009  string[]     0         0          0           0        0         0          0
 1043  string       0         0          0           0        0         0          0
 1082  date         0         0          0           0        0         0          0
 1114  timestamp    0         0          0           0        0         0          0
 1184  timestamptz  0         0          0           0        0         0          0
 1186  interval     0         0          0           0        0         0          0
 1700  decimal      0         0          0           0        0         0          0
+2283  anyelement   0         0          0           0        0         0          0
 
 query ITTTBII colnames
 SELECT oid, typname, typalign, typstorage, typnotnull, typbasetype, typtypmod
@@ -564,12 +571,14 @@ oid   typname      typalign  typstorage  typnotnull  typbasetype  typtypmod
 25    string       NULL      NULL        false       0            -1
 700   float        NULL      NULL        false       0            -1
 701   float        NULL      NULL        false       0            -1
+1009  string[]     NULL      NULL        false       0            -1
 1043  string       NULL      NULL        false       0            -1
 1082  date         NULL      NULL        false       0            -1
 1114  timestamp    NULL      NULL        false       0            -1
 1184  timestamptz  NULL      NULL        false       0            -1
 1186  interval     NULL      NULL        false       0            -1
 1700  decimal      NULL      NULL        false       0            -1
+2283  anyelement   NULL      NULL        false       0            -1
 
 query ITIITTT colnames
 SELECT oid, typname, typndims, typcollation, typdefaultbin, typdefault, typacl
@@ -585,12 +594,14 @@ oid   typname      typndims  typcollation  typdefaultbin  typdefault  typacl
 25    string       0         0             NULL           NULL        NULL
 700   float        0         0             NULL           NULL        NULL
 701   float        0         0             NULL           NULL        NULL
+1009  string[]     0         0             NULL           NULL        NULL
 1043  string       0         0             NULL           NULL        NULL
 1082  date         0         0             NULL           NULL        NULL
 1114  timestamp    0         0             NULL           NULL        NULL
 1184  timestamptz  0         0             NULL           NULL        NULL
 1186  interval     0         0             NULL           NULL        NULL
 1700  decimal      0         0             NULL           NULL        NULL
+2283  anyelement   0         0             NULL           NULL        NULL
 
 ## pg_catalog.pg_database
 
@@ -617,3 +628,68 @@ oid         datname             datconnlimit  datlastsysoid  datfrozenxid  datmi
 3061586988  constraint_db       -1            NULL           NULL          NULL        NULL           NULL
 3178318485  pg_catalog          -1            NULL           NULL          NULL        NULL           NULL
 3816276882  information_schema  -1            NULL           NULL          NULL        NULL           NULL
+
+## pg_catalog.pg_proc
+
+query TITITTI colnames
+SELECT proname, pronamespace, proowner, prolang, procost, prorows, provariadic
+FROM pg_catalog.pg_proc
+WHERE proname='substring';
+----
+proname    pronamespace  proowner  prolang  procost  prorows  provariadic
+substring  3178318485    NULL      0        NULL     NULL     0
+substring  3178318485    NULL      0        NULL     NULL     0
+substring  3178318485    NULL      0        NULL     NULL     0
+substring  3178318485    NULL      0        NULL     NULL     0
+
+query TTBBBB colnames
+SELECT proname, protransform, proisagg, proiswindow, prosecdef, proleakproof
+FROM pg_catalog.pg_proc
+WHERE proname='substring';
+----
+proname    protransform  proisagg  proiswindow  prosecdef  proleakproof
+substring  NULL          false     false        false      true
+substring  NULL          false     false        false      true
+substring  NULL          false     false        false      true
+substring  NULL          false     false        false      true
+
+query TBBTT colnames
+SELECT proname, proisstrict, proretset, provolatile, proparallel
+FROM pg_catalog.pg_proc
+WHERE proname='substring';
+----
+proname    proisstrict  proretset  provolatile  proparallel
+substring  false        false      NULL         NULL
+substring  false        false      NULL         NULL
+substring  false        false      NULL         NULL
+substring  false        false      NULL         NULL
+
+query TIIITTTT colnames
+SELECT proname, pronargs, pronargdefaults, prorettype, proargtypes, proallargtypes, proargmodes, proargdefaults
+FROM pg_catalog.pg_proc
+WHERE proname='substring';
+----
+proname    pronargs  pronargdefaults  prorettype  proargtypes  proallargtypes  proargmodes  proargdefaults
+substring  2         0                25          25, 20       NULL            NULL         NULL
+substring  3         0                25          25, 20, 20   NULL            NULL         NULL
+substring  2         0                25          25, 25       NULL            NULL         NULL
+substring  3         0                25          25, 25, 25   NULL            NULL         NULL
+
+query TTTTTT colnames
+SELECT proname, protrftypes, prosrc, probin, proconfig, proacl
+FROM pg_catalog.pg_proc
+WHERE proname='substring';
+----
+proname    protrftypes  prosrc     probin  proconfig  proacl
+substring  NULL         substring  NULL    NULL       NULL
+substring  NULL         substring  NULL    NULL       NULL
+substring  NULL         substring  NULL    NULL       NULL
+substring  NULL         substring  NULL    NULL       NULL
+
+query TIIITT colnames
+SELECT proname, provariadic, pronargs, prorettype, proargtypes, proargmodes
+FROM pg_catalog.pg_proc
+WHERE proname='least'
+----
+proname  provariadic  pronargs  prorettype  proargtypes  proargmodes
+least    2283         1         2283        2283         v


### PR DESCRIPTION
`pg_catalog.pg_proc` is a virtual table that contains information on builtin functions.

Several of the columns have been left unimplemented. Please take note of the unimplemented columns - it's possible that we need to add better placeholders or implementations for those. We also don't support `ARRAY`s sufficiently to use them for the array type columns in `pg_proc`.

Introduce `parser.TypeAny`, corresponding to a postgres `anyelement` type, and use this instead of NULL for the return type of `least` and `greatest`.


Fixes #10075.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10217)

<!-- Reviewable:end -->
