### PR TITLE
sql: use subtests for parallel_test

### DIFF
--- a/pkg/sql/logic_test.go
+++ b/pkg/sql/logic_test.go
@@ -1093,7 +1093,7 @@ func TestLogic(t *testing.T) {
 		defer l.printErrorSummary()
 	}
 	for _, path := range paths {
-		t.Run(path, func(t *testing.T) {
+		t.Run(filepath.Base(path), func(t *testing.T) {
 			// the `t` given to this anonymous function may be different
 			// from the t above, so re-bind it to `l` for the duration of
 			// the test.

--- a/pkg/sql/parallel_test.go
+++ b/pkg/sql/parallel_test.go
@@ -139,8 +139,7 @@ func (t *parallelTest) run(dir string) {
 	}
 
 	if spec.SkipReason != "" {
-		log.Warningf(t.ctx, "Skipping test %s: %s", dir, spec.SkipReason)
-		return
+		t.Skip(spec.SkipReason)
 	}
 
 	log.Infof(t.ctx, "Running test %s", dir)
@@ -251,10 +250,12 @@ func TestParallel(t *testing.T) {
 		t.Fatalf("No testfiles found (glob: %s)", glob)
 	}
 	total := 0
-	for _, p := range paths {
-		pt := parallelTest{T: t, ctx: context.Background()}
-		pt.run(p)
-		total++
+	for _, path := range paths {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			pt := parallelTest{T: t, ctx: context.Background()}
+			pt.run(path)
+			total++
+		})
 	}
 	log.Infof(context.Background(), "%d parallel tests passed", total)
 }


### PR DESCRIPTION
CC @tschottdorf 
We should integrate this with `flaky.Register` as well. Maybe by searching for a `#<number>` in the reason string, or by adding a `skip_issue` field in the test config.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10227)

<!-- Reviewable:end -->
