### PR TITLE
status: avoid holding mutex over network i/o

### DIFF
--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -78,7 +78,10 @@ type storeMetrics interface {
 // store hosted by the node. There are slight differences in the way these are
 // recorded, and they are thus kept separate.
 type MetricsRecorder struct {
-	mu struct {
+	// prometheusExporter merges metrics into families and generates the
+	// prometheus text format.
+	prometheusExporter metric.PrometheusExporter
+	mu                 struct {
 		syncutil.Mutex
 		// nodeRegistry contains, as subregistries, the multiple component-specific
 		// registries which are recorded as "node level" metrics.
@@ -92,10 +95,6 @@ type MetricsRecorder struct {
 		storeRegistries map[roachpb.StoreID]*metric.Registry
 		clock           *hlc.Clock
 		stores          map[roachpb.StoreID]storeMetrics
-
-		// prometheusExporter merges metrics into families and generates the
-		// prometheus text format.
-		prometheusExporter metric.PrometheusExporter
 
 		// Counts to help optimize slice allocation.
 		lastDataCount        int
@@ -111,7 +110,7 @@ func NewMetricsRecorder(clock *hlc.Clock) *MetricsRecorder {
 	mr := &MetricsRecorder{}
 	mr.mu.storeRegistries = make(map[roachpb.StoreID]*metric.Registry)
 	mr.mu.stores = make(map[roachpb.StoreID]storeMetrics)
-	mr.mu.prometheusExporter = metric.MakePrometheusExporter()
+	mr.prometheusExporter = metric.MakePrometheusExporter()
 	mr.mu.clock = clock
 	return mr
 }
@@ -180,11 +179,11 @@ func (mr *MetricsRecorder) PrintAsText(w io.Writer) error {
 		return nil
 	}
 
-	mr.mu.prometheusExporter.AddMetricsFromRegistry(mr.mu.nodeRegistry)
+	mr.prometheusExporter.AddMetricsFromRegistry(mr.mu.nodeRegistry)
 	for _, reg := range mr.mu.storeRegistries {
-		mr.mu.prometheusExporter.AddMetricsFromRegistry(reg)
+		mr.prometheusExporter.AddMetricsFromRegistry(reg)
 	}
-	return mr.mu.prometheusExporter.Export(w)
+	return mr.prometheusExporter.Export(w)
 }
 
 // GetTimeSeriesData serializes registered metrics for consumption by

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -179,11 +179,11 @@ func (mr *MetricsRecorder) PrintAsText(w io.Writer) error {
 		return nil
 	}
 
-	mr.prometheusExporter.AddMetricsFromRegistry(mr.mu.nodeRegistry)
+	mr.prometheusExporter.ScrapeRegistry(mr.mu.nodeRegistry)
 	for _, reg := range mr.mu.storeRegistries {
-		mr.prometheusExporter.AddMetricsFromRegistry(reg)
+		mr.prometheusExporter.ScrapeRegistry(reg)
 	}
-	return mr.prometheusExporter.Export(w)
+	return mr.prometheusExporter.PrintAsText(w)
 }
 
 // GetTimeSeriesData serializes registered metrics for consumption by

--- a/pkg/util/metric/metric.go
+++ b/pkg/util/metric/metric.go
@@ -68,6 +68,8 @@ type PrometheusExportable interface {
 	GetLabels() []*prometheusgo.LabelPair
 	// ToPrometheusMetric returns a filled-in prometheus metric of the right type
 	// for the given metric. It does not fill in labels.
+	// The implementation must return thread-safe data to the caller, i.e.
+	// usually a copy of internal state.
 	ToPrometheusMetric() *prometheusgo.Metric
 }
 

--- a/pkg/util/metric/prometheus_exporter.go
+++ b/pkg/util/metric/prometheus_exporter.go
@@ -64,9 +64,11 @@ func (pm *PrometheusExporter) findOrCreateFamily(
 	return family
 }
 
-// AddMetricsFromRegistry takes a registry and adds all metrics to the metric family map.
-// It creates a new family if needed.
-func (pm *PrometheusExporter) AddMetricsFromRegistry(registry *Registry) {
+// ScrapeRegistry scrapes all metrics contained in the registry to the metric
+// family map, holding on only to the scraped data (which is no longer
+// connected to the registry and metrics within) when returning from the the
+// call. It creates new families as needed.
+func (pm *PrometheusExporter) ScrapeRegistry(registry *Registry) {
 	labels := registry.getLabels()
 	for _, metric := range registry.tracked {
 		metric.Inspect(func(v interface{}) {
@@ -82,10 +84,10 @@ func (pm *PrometheusExporter) AddMetricsFromRegistry(registry *Registry) {
 	}
 }
 
-// Export writes all metrics in the families map to the iowriter in
+// PrintAsText writes all metrics in the families map to the io.Writer in
 // prometheus' text format. It removes individual metrics from the families
 // as it goes, readying the families for another found of registry additions.
-func (pm *PrometheusExporter) Export(w io.Writer) error {
+func (pm *PrometheusExporter) PrintAsText(w io.Writer) error {
 	for _, family := range pm.families {
 		if _, err := expfmt.MetricFamilyToText(w, family); err != nil {
 			return err

--- a/pkg/util/metric/prometheus_exporter_test.go
+++ b/pkg/util/metric/prometheus_exporter_test.go
@@ -35,8 +35,8 @@ func TestPrometheusExporter(t *testing.T) {
 	r2.AddMetric(NewCounter(c2Meta))
 
 	pe := MakePrometheusExporter()
-	pe.AddMetricsFromRegistry(r1)
-	pe.AddMetricsFromRegistry(r2)
+	pe.ScrapeRegistry(r1)
+	pe.ScrapeRegistry(r2)
 
 	type metricLabels map[string]string
 	type family struct {


### PR DESCRIPTION
The writer passed to `(*MetricsRecorder).PrintAsText` may not consume
quickly
(after all, it is usually a TCP/IP connection) and when it doesn't, the
resulting deadlock brought the server to its knees.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10228)

<!-- Reviewable:end -->
