### PR TITLE
sql: fix TestRaceWithBackfill

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -126,6 +126,13 @@ func convertBackfillError(tableDesc *sqlbase.TableDescriptor, b *client.Batch) e
 	return convertBatchError(tableDesc, b)
 }
 
+func (sc *SchemaChanger) getChunkSize(chunkSize int64) int64 {
+	if sc.testingKnobs.BackfillChunkSize > 0 {
+		return sc.testingKnobs.BackfillChunkSize
+	}
+	return chunkSize
+}
+
 // runBackfill runs the backfill for the schema changer.
 func (sc *SchemaChanger) runBackfill(lease *sqlbase.TableDescriptor_SchemaChangeLease) error {
 	l, err := sc.ExtendLease(*lease)
@@ -142,56 +149,53 @@ func (sc *SchemaChanger) runBackfill(lease *sqlbase.TableDescriptor_SchemaChange
 	var addedIndexDescs []sqlbase.IndexDescriptor
 	// Indexes within the Mutations slice for checkpointing.
 	mutationSentinel := -1
-	columnMutationIdx, addedIndexMutationIdx, droppedIndexMutationIdx :=
-		mutationSentinel, mutationSentinel, mutationSentinel
+	var columnMutationIdx, addedIndexMutationIdx, droppedIndexMutationIdx int
 
+	var tableDesc *sqlbase.TableDescriptor
 	if err := sc.db.Txn(context.TODO(), func(txn *client.Txn) error {
-		tableDesc, err := sqlbase.GetTableDescFromID(txn, sc.tableID)
-		if err != nil {
-			return err
-		}
-
-		for i, m := range tableDesc.Mutations {
-			if m.MutationID != sc.mutationID {
-				break
-			}
-			switch m.Direction {
-			case sqlbase.DescriptorMutation_ADD:
-				switch t := m.Descriptor_.(type) {
-				case *sqlbase.DescriptorMutation_Column:
-					addedColumnDescs = append(addedColumnDescs, *t.Column)
-					if columnMutationIdx == mutationSentinel {
-						columnMutationIdx = i
-					}
-				case *sqlbase.DescriptorMutation_Index:
-					addedIndexDescs = append(addedIndexDescs, *t.Index)
-					if addedIndexMutationIdx == mutationSentinel {
-						addedIndexMutationIdx = i
-					}
-				default:
-					return errors.Errorf("unsupported mutation: %+v", m)
-				}
-
-			case sqlbase.DescriptorMutation_DROP:
-				switch t := m.Descriptor_.(type) {
-				case *sqlbase.DescriptorMutation_Column:
-					droppedColumnDescs = append(droppedColumnDescs, *t.Column)
-					if columnMutationIdx == mutationSentinel {
-						columnMutationIdx = i
-					}
-				case *sqlbase.DescriptorMutation_Index:
-					droppedIndexDescs = append(droppedIndexDescs, *t.Index)
-					if droppedIndexMutationIdx == mutationSentinel {
-						droppedIndexMutationIdx = i
-					}
-				default:
-					return errors.Errorf("unsupported mutation: %+v", m)
-				}
-			}
-		}
-		return nil
+		tableDesc, err = sqlbase.GetTableDescFromID(txn, sc.tableID)
+		return err
 	}); err != nil {
 		return err
+	}
+
+	for i, m := range tableDesc.Mutations {
+		if m.MutationID != sc.mutationID {
+			break
+		}
+		switch m.Direction {
+		case sqlbase.DescriptorMutation_ADD:
+			switch t := m.Descriptor_.(type) {
+			case *sqlbase.DescriptorMutation_Column:
+				addedColumnDescs = append(addedColumnDescs, *t.Column)
+				if columnMutationIdx == mutationSentinel {
+					columnMutationIdx = i
+				}
+			case *sqlbase.DescriptorMutation_Index:
+				addedIndexDescs = append(addedIndexDescs, *t.Index)
+				if addedIndexMutationIdx == mutationSentinel {
+					addedIndexMutationIdx = i
+				}
+			default:
+				return errors.Errorf("unsupported mutation: %+v", m)
+			}
+
+		case sqlbase.DescriptorMutation_DROP:
+			switch t := m.Descriptor_.(type) {
+			case *sqlbase.DescriptorMutation_Column:
+				droppedColumnDescs = append(droppedColumnDescs, *t.Column)
+				if columnMutationIdx == mutationSentinel {
+					columnMutationIdx = i
+				}
+			case *sqlbase.DescriptorMutation_Index:
+				droppedIndexDescs = append(droppedIndexDescs, *t.Index)
+				if droppedIndexMutationIdx == mutationSentinel {
+					droppedIndexMutationIdx = i
+				}
+			default:
+				return errors.Errorf("unsupported mutation: %+v", m)
+			}
+		}
 	}
 
 	// First drop indexes, then add/drop columns, and only then add indexes.
@@ -304,7 +308,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 		}
 
 		// Run through the entire table key space adding and deleting columns.
-		const chunkSize = ColumnTruncateAndBackfillChunkSize
+		chunkSize := sc.getChunkSize(ColumnTruncateAndBackfillChunkSize)
 		// Evaluate default values.
 		updateCols := append(added, dropped...)
 		updateValues := make(parser.DTuple, len(updateCols))
@@ -350,6 +354,9 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 	return nil
 }
 
+// truncateAndBackfillColumnsChunk returns the next-key, done and an error.
+// next-key and done are invalid if error != nil. next-key is invalid if done
+// is true.
 func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 	added []sqlbase.ColumnDescriptor,
 	dropped []sqlbase.ColumnDescriptor,
@@ -364,20 +371,22 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 	done := false
 	var nextKey roachpb.Key
 	err := sc.db.Txn(context.TODO(), func(txn *client.Txn) error {
+		if sc.testingKnobs.RunBeforeBackfillChunk != nil {
+			if err := sc.testingKnobs.RunBeforeBackfillChunk(sp); err != nil {
+				return err
+			}
+		}
+		if sc.testingKnobs.RunAfterBackfillChunk != nil {
+			defer sc.testingKnobs.RunAfterBackfillChunk()
+		}
+
 		tableDesc, err := sqlbase.GetTableDescFromID(txn, sc.tableID)
 		if err != nil {
 			return err
 		}
 		// Short circuit the backfill if the table has been deleted.
-		if tableDesc.Dropped() {
-			done = true
+		if done = tableDesc.Dropped(); done {
 			return nil
-		}
-
-		if sc.testingKnobs.RunBeforeBackfillChunk != nil {
-			if err := sc.testingKnobs.RunBeforeBackfillChunk(sp); err != nil {
-				return err
-			}
 		}
 
 		updateCols := append(added, dropped...)
@@ -465,8 +474,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 		if err := txn.Run(writeBatch); err != nil {
 			return convertBackfillError(tableDesc, writeBatch)
 		}
-		if i < chunkSize {
-			done = true
+		if done = i < chunkSize; done {
 			return nil
 		}
 		curIndexKey, _, err := sqlbase.EncodeIndexKey(
@@ -490,7 +498,10 @@ func (sc *SchemaChanger) truncateIndexes(
 	dropped []sqlbase.IndexDescriptor,
 	mutationIdx int,
 ) error {
-	const chunkSize = IndexTruncateChunkSize
+	chunkSize := sc.getChunkSize(IndexTruncateChunkSize)
+	if sc.testingKnobs.BackfillChunkSize > 0 {
+		chunkSize = sc.testingKnobs.BackfillChunkSize
+	}
 	for _, desc := range dropped {
 		var resume roachpb.Span
 		lastCheckpoint := timeutil.Now()
@@ -508,20 +519,22 @@ func (sc *SchemaChanger) truncateIndexes(
 					sc.tableID, sc.mutationID, row, resume)
 			}
 			if err := sc.db.Txn(context.TODO(), func(txn *client.Txn) error {
+				if sc.testingKnobs.RunBeforeBackfillChunk != nil {
+					if err := sc.testingKnobs.RunBeforeBackfillChunk(resume); err != nil {
+						return err
+					}
+				}
+				if sc.testingKnobs.RunAfterBackfillChunk != nil {
+					defer sc.testingKnobs.RunAfterBackfillChunk()
+				}
+
 				tableDesc, err := sqlbase.GetTableDescFromID(txn, sc.tableID)
 				if err != nil {
 					return err
 				}
 				// Short circuit the truncation if the table has been deleted.
-				if tableDesc.Dropped() {
-					done = true
+				if done = tableDesc.Dropped(); done {
 					return nil
-				}
-
-				if sc.testingKnobs.RunBeforeBackfillChunk != nil {
-					if err := sc.testingKnobs.RunBeforeBackfillChunk(resume); err != nil {
-						return err
-					}
 				}
 
 				rd, err := makeRowDeleter(txn, tableDesc, nil, nil, false)
@@ -567,7 +580,7 @@ func (sc *SchemaChanger) backfillIndexes(
 	}
 
 	// Backfill the index entries for all the rows.
-	const chunkSize = IndexBackfillChunkSize
+	chunkSize := sc.getChunkSize(IndexBackfillChunkSize)
 	lastCheckpoint := timeutil.Now()
 	for row, done := int64(0), false; !done; row += chunkSize {
 		// First extend the schema change lease.
@@ -588,6 +601,8 @@ func (sc *SchemaChanger) backfillIndexes(
 	return nil
 }
 
+// backfillIndexesChunk returns the next-key, done and an error. next-key and
+// done are invalid if error != nil. next-key is invalid if done is true.
 func (sc *SchemaChanger) backfillIndexesChunk(
 	added []sqlbase.IndexDescriptor,
 	sp roachpb.Span,
@@ -599,20 +614,22 @@ func (sc *SchemaChanger) backfillIndexesChunk(
 	done := false
 	secondaryIndexEntries := make([]sqlbase.IndexEntry, len(added))
 	err := sc.db.Txn(context.TODO(), func(txn *client.Txn) error {
+		if sc.testingKnobs.RunBeforeBackfillChunk != nil {
+			if err := sc.testingKnobs.RunBeforeBackfillChunk(sp); err != nil {
+				return err
+			}
+		}
+		if sc.testingKnobs.RunAfterBackfillChunk != nil {
+			defer sc.testingKnobs.RunAfterBackfillChunk()
+		}
+
 		tableDesc, err := sqlbase.GetTableDescFromID(txn, sc.tableID)
 		if err != nil {
 			return err
 		}
 		// Short circuit the backfill if the table has been deleted.
-		if tableDesc.Dropped() {
-			done = true
+		if done = tableDesc.Dropped(); done {
 			return nil
-		}
-
-		if sc.testingKnobs.RunBeforeBackfillChunk != nil {
-			if err := sc.testingKnobs.RunBeforeBackfillChunk(sp); err != nil {
-				return err
-			}
 		}
 
 		// Get the next set of rows.
@@ -677,8 +694,7 @@ func (sc *SchemaChanger) backfillIndexesChunk(
 			return convertBackfillError(tableDesc, b)
 		}
 		// Have we processed all the table rows?
-		if numRows < chunkSize {
-			done = true
+		if done = numRows < chunkSize; done {
 			return nil
 		}
 		// Keep track of the next key.

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -652,8 +652,16 @@ type SchemaChangerTestingKnobs struct {
 	// RunBeforeBackfillChunk is called before executing each chunk of a
 	// backfill during a schema change operation. It is called with the
 	// current span and returns an error which eventually is returned to the
-	// caller of SchemaChanger.exec().
+	// caller of SchemaChanger.exec(). It is called at the start of the
+	// backfill function passed into the transaction executing the chunk.
 	RunBeforeBackfillChunk func(sp roachpb.Span) error
+
+	// RunAfterBackfillChunk is called after executing each chunk of a
+	// backfill during a schema change operation. It is called just before
+	// returning from the backfill function passed into the transaction
+	// executing the chunk. It is always called even when the backfill
+	// function returns an error, or if the table has already been dropped.
+	RunAfterBackfillChunk func()
 
 	// RenameOldNameNotInUseNotification is called during a rename schema
 	// change, after all leases on the version of the descriptor with the old
@@ -672,6 +680,9 @@ type SchemaChangerTestingKnobs struct {
 	// WriteCheckpointInterval is the interval after which a checkpoint is
 	// written.
 	WriteCheckpointInterval time.Duration
+
+	// BackfillChunkSize is to be used for all backfill chunked operations.
+	BackfillChunkSize int64
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -20,6 +20,7 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"math/rand"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -706,6 +707,184 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 		t.Fatal(err)
 	} else if len(kvs) != 0 {
 		t.Fatalf("expected %d key value pairs, but got %d", 0, len(kvs))
+	}
+}
+
+// Test aborting a schema change backfill transaction and check that the
+// backfill is completed correctly. The backfill transaction is aborted at a
+// time when it thinks it has processed all the rows of the table. Later,
+// before the transaction is retried, the table is populated with more rows
+// that a backfill chunk, requiring the backfill to forget that it is at the
+// end of its processing and needs to continue on to process two more chunks
+// of data.
+func TestAbortSchemaChangeBackfill(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var backfillNotification, commandsDone chan struct{}
+	var dontAbortBackfill uint32
+	params, _ := createTestServerParams()
+	const maxValue = 100
+	backfillCount := int64(0)
+	retriedBackfill := int64(0)
+	var retriedSpan roachpb.Span
+
+	// Disable asynchronous schema change execution to allow synchronous path
+	// to trigger start of backfill notification.
+	params.Knobs = base.TestingKnobs{
+		SQLExecutor: &csql.ExecutorTestingKnobs{
+			// Fix the priority to guarantee that a high priority transaction
+			// pushes a lower priority one.
+			FixTxnPriority: true,
+		},
+		SQLSchemaChanger: &csql.SchemaChangerTestingKnobs{
+			RunBeforeBackfillChunk: func(sp roachpb.Span) error {
+				switch atomic.LoadInt64(&backfillCount) {
+				case 0:
+					// Keep track of the span provided with the first backfill
+					// attempt.
+					retriedSpan = sp
+				case 1:
+					// Ensure that the second backfill attempt provides the
+					// same span as the first.
+					if sp.Equal(retriedSpan) {
+						atomic.AddInt64(&retriedBackfill, 1)
+					}
+				}
+				return nil
+			},
+			RunAfterBackfillChunk: func() {
+				atomic.AddInt64(&backfillCount, 1)
+				if atomic.SwapUint32(&dontAbortBackfill, 1) == 1 {
+					return
+				}
+				// Close channel to notify that the backfill has been
+				// completed but hasn't yet committed.
+				close(backfillNotification)
+				// Receive signal that the commands that push the backfill
+				// transaction have completed; The backfill will attempt
+				// to commit and will abort.
+				<-commandsDone
+			},
+			AsyncExecNotification: asyncSchemaChangerDisabled,
+			// Set the backfill chunk size for all the backfill operations.
+			BackfillChunkSize: maxValue,
+		},
+	}
+	server, sqlDB, kvDB := serverutils.StartServer(t, params)
+	defer server.Stopper().Stop()
+
+	if _, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Bulk insert enough rows to exceed the chunk size.
+	inserts := make([]string, maxValue+1)
+	for i := 0; i < maxValue+1; i++ {
+		inserts[i] = fmt.Sprintf(`(%d, %d)`, i, i)
+	}
+	if _, err := sqlDB.Exec(`INSERT INTO t.test VALUES ` + strings.Join(inserts, ",")); err != nil {
+		t.Fatal(err)
+	}
+
+	// The two drop cases (column and index) do not need to be tested here
+	// because the INSERT down below will not insert an entry for a dropped
+	// column or index, however, it's still nice to have them just in case
+	// INSERT gets messed up.
+	testCases := []struct {
+		sql string
+		// Each schema change adds/drops a schema element that affects the
+		// number of keys representing a table row.
+		expectedNumKeysPerRow int
+	}{
+		{"ALTER TABLE t.test ADD COLUMN x DECIMAL DEFAULT (DECIMAL '1.4')", 2},
+		{"ALTER TABLE t.test DROP x", 1},
+		{"CREATE UNIQUE INDEX foo ON t.test (v)", 2},
+		{"DROP INDEX t.test@foo", 1},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(testCase.sql, func(t *testing.T) {
+			// Delete two rows so that the table size is smaller than a backfill
+			// chunk. The two values will be added later to make the table larger
+			// than a backfill chunk after the schema change backfill is aborted.
+			for i := 0; i < 2; i++ {
+				if _, err := sqlDB.Exec(`DELETE FROM t.test WHERE k = $1`, i); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			backfillNotification = make(chan struct{})
+			commandsDone = make(chan struct{})
+			atomic.StoreUint32(&dontAbortBackfill, 0)
+			// Run the column schema change in a separate goroutine.
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				// Start schema change that eventually runs a backfill.
+				if _, err := sqlDB.Exec(testCase.sql); err != nil {
+					t.Error(err)
+				}
+
+				wg.Done()
+			}()
+
+			// Wait until the schema change backfill has finished writing its
+			// intents.
+			<-backfillNotification
+
+			// Delete a row that will push the backfill transaction.
+			if _, err := sqlDB.Exec(`
+BEGIN TRANSACTION PRIORITY HIGH;
+DELETE FROM t.test WHERE k = 2;
+COMMIT;
+			`); err != nil {
+				t.Fatal(err)
+			}
+
+			// Add missing rows so that the table exceeds the size of a
+			// backfill chunk.
+			for i := 0; i < 3; i++ {
+				if _, err := sqlDB.Exec(`INSERT INTO t.test VALUES($1, $2)`, i, i); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// Release backfill so that it can try to commit and in the
+			// process discover that it was aborted.
+			close(commandsDone)
+
+			wg.Wait() // for schema change to complete
+
+			// Backfill retry happened.
+			if count, e := atomic.SwapInt64(&retriedBackfill, 0), int64(1); count != e {
+				t.Fatalf("expected = %d, found = %d", e, count)
+			}
+			// 1 failed + 2 retried backfill chunks.
+			expectNumBackfills := int64(3)
+			if i == len(testCases)-1 {
+				// The DROP INDEX case: The above INSERTs do not add any index
+				// entries for the inserted rows, so the index remains smaller
+				// than a backfill chunk and is dropped in a single retried
+				// backfill chunk.
+				expectNumBackfills = 2
+			}
+			if count := atomic.SwapInt64(&backfillCount, 0); count != expectNumBackfills {
+				t.Fatalf("expected = %d, found = %d", expectNumBackfills, count)
+			}
+
+			// Verify the number of keys left behind in the table to validate
+			// schema change operations.
+			tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
+			tablePrefix := roachpb.Key(keys.MakeTablePrefix(uint32(tableDesc.ID)))
+			tableEnd := tablePrefix.PrefixEnd()
+			if kvs, err := kvDB.Scan(context.TODO(), tablePrefix, tableEnd, 0); err != nil {
+				t.Fatal(err)
+			} else if e := testCase.expectedNumKeysPerRow * (maxValue + 1); len(kvs) != e {
+				t.Fatalf("expected %d key value pairs, but got %d", e, len(kvs))
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
In #10164 all the side-effects produced in calls to Txn()
during a schema change backfill were recomputed when the function passed to Txn()
returned an error. However when the function passed in returns nil,
the transaction can still abort while committing. This
change ensures that all side-effects are reprocessed when the function
is called again after an aborted transaction.

fixes #10021

Without this change the test breaks under stress. I'm happy to entertain how we could test these kinds of situations without resorting to stress.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10233)

<!-- Reviewable:end -->
