### PR TITLE
storage: add a debug log for reservations

### DIFF
--- a/pkg/storage/reservation.go
+++ b/pkg/storage/reservation.go
@@ -183,6 +183,10 @@ func (b *bookie) Reserve(
 	// Make sure that we don't add back a destroyed replica.
 	for _, rep := range deadReplicas {
 		if req.RangeID == rep.RangeID {
+			if log.V(1) {
+				log.Infof(ctx, "could not book reservation %+v, the replica has been destroyed",
+					req)
+			}
 			return ReservationResponse{Reserved: false}
 		}
 	}


### PR DESCRIPTION
Previously, there was no debug log for when a reservation is declined
due to its target being in the dead replicas list. Add this log so that
there is always a log explanation for a reservation rejection.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10239)

<!-- Reviewable:end -->
