### PR TITLE
storage: deflake TestRaftRemoveRace

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2087,7 +2087,7 @@ func (s *Store) Descriptor() (*roachpb.StoreDescriptor, error) {
 	}, nil
 }
 
-// deadReplicas returns a list of all the dead replicas on the store.
+// deadReplicas returns a list of all the corrupt replicas on the store.
 func (s *Store) deadReplicas() roachpb.StoreDeadReplicas {
 	// We can't use a storeReplicaVisitor here as it skips destroyed replicas.
 	// Similar to in the storeReplicaVisitor, make a copy of the current
@@ -2105,11 +2105,11 @@ func (s *Store) deadReplicas() roachpb.StoreDeadReplicas {
 	var deadReplicas []roachpb.ReplicaIdent
 	for _, r := range replicas {
 		r.mu.Lock()
-		destroyed := r.mu.destroyed
+		corrupted := r.mu.corrupted
 		desc := r.mu.state.Desc
 		r.mu.Unlock()
 		replicaDesc, ok := desc.GetReplicaDescriptor(s.Ident.StoreID)
-		if ok && destroyed != nil {
+		if ok && corrupted {
 			deadReplicas = append(deadReplicas, roachpb.ReplicaIdent{
 				RangeID: desc.RangeID,
 				Replica: replicaDesc,


### PR DESCRIPTION
Rename Store.deadReplicas() to Store.corruptReplicas() and change it to
only return corrupted replicas, not all replicas which have been marked
as destroyed. The latter includes replicas that have been removed and
which we can re-add to the store without problem.

Fixes #10235

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10243)

<!-- Reviewable:end -->
