### PR TITLE
time series: Parallel Queries + Benchmark

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -48,16 +48,17 @@ type TestServerArgs struct {
 	// will be used.
 	StoreSpecs []StoreSpec
 
-	// Fields copied to the server.Context.
-	Insecure              bool
-	MetricsSampleInterval time.Duration
-	MaxOffset             time.Duration
-	SocketFile            string
-	ScanInterval          time.Duration
-	ScanMaxIdleTime       time.Duration
-	SSLCA                 string
-	SSLCert               string
-	SSLCertKey            string
+	// Fields copied to the server.Config.
+	Insecure                 bool
+	MetricsSampleInterval    time.Duration
+	MaxOffset                time.Duration
+	SocketFile               string
+	ScanInterval             time.Duration
+	ScanMaxIdleTime          time.Duration
+	SSLCA                    string
+	SSLCert                  string
+	SSLCertKey               string
+	TimeSeriesQueryWorkerMax int
 
 	// If set, this will be appended to the Postgres URL by functions that
 	// automatically open a connection to the server. That's equivalent to running

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -85,6 +86,10 @@ type Config struct {
 	// CacheSize is the amount of memory in bytes to use for caching data.
 	// The value is split evenly between the stores if there are more than one.
 	CacheSize int64
+
+	// TimeSeriesServerConfig contains configuration specific to the time series
+	// server.
+	TimeSeriesServerConfig ts.ServerConfig
 
 	// Parsed values.
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -277,7 +277,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	s.registry.AddMetricStruct(s.pgServer.Metrics())
 
 	s.tsDB = ts.NewDB(s.db)
-	s.tsServer = ts.MakeServer(s.cfg.AmbientCtx, s.tsDB)
+	s.tsServer = ts.MakeServer(s.cfg.AmbientCtx, s.tsDB, s.cfg.TimeSeriesServerConfig, s.stopper)
 
 	// TODO(bdarnell): make StoreConfig configurable.
 	storeCfg := storage.StoreConfig{

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -120,6 +120,9 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	if params.SSLCertKey != "" {
 		cfg.SSLCertKey = params.SSLCertKey
 	}
+	if params.TimeSeriesQueryWorkerMax != 0 {
+		cfg.TimeSeriesServerConfig.QueryWorkerMax = params.TimeSeriesQueryWorkerMax
+	}
 	if params.DisableEventLog {
 		cfg.EventLogEnabled = false
 	}

--- a/pkg/ts/server.go
+++ b/pkg/ts/server.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 )
 
@@ -31,21 +32,40 @@ const (
 	// URLPrefix is the prefix for all time series endpoints hosted by the
 	// server.
 	URLPrefix = "/ts/"
+	// queryWorkerMax is the default maximum number of worker goroutines that
+	// the time series server can use to service incoming queries.
+	queryWorkerMax = 250
 )
+
+// ServerConfig provides a means for tests to override settings in the time
+// series server.
+type ServerConfig struct {
+	// The maximum number of query workers used by the server. If this
+	// value is zero, a default non-zero value is used instead.
+	QueryWorkerMax int
+}
 
 // Server handles incoming external requests related to time series data.
 type Server struct {
 	log.AmbientContext
-	db *DB
+	db        *DB
+	stopper   *stop.Stopper
+	workerSem chan struct{}
 }
 
 // MakeServer instantiates a new Server which services requests with data from
 // the supplied DB.
-func MakeServer(ambient log.AmbientContext, db *DB) Server {
+func MakeServer(ambient log.AmbientContext, db *DB, cfg ServerConfig, stopper *stop.Stopper) Server {
 	ambient.AddLogTag("ts-srv", nil)
+	queryWorkerMax := queryWorkerMax
+	if cfg.QueryWorkerMax != 0 {
+		queryWorkerMax = cfg.QueryWorkerMax
+	}
 	return Server{
 		AmbientContext: ambient,
 		db:             db,
+		stopper:        stopper,
+		workerSem:      make(chan struct{}, queryWorkerMax),
 	}
 }
 
@@ -79,27 +99,79 @@ func (s *Server) Query(
 	}
 
 	response := tspb.TimeSeriesQueryResponse{
-		Results: make([]tspb.TimeSeriesQueryResponse_Result, 0, len(request.Queries)),
+		Results: make([]tspb.TimeSeriesQueryResponse_Result, len(request.Queries)),
 	}
-	for _, query := range request.Queries {
-		datapoints, sources, err := s.db.Query(
-			ctx,
-			query,
-			Resolution10s,
-			sampleNanos,
-			request.StartNanos,
-			request.EndNanos,
-		)
-		if err != nil {
-			return nil, grpc.Errorf(codes.Internal, err.Error())
-		}
-		result := tspb.TimeSeriesQueryResponse_Result{
-			Query:      query,
-			Datapoints: datapoints,
-		}
 
-		result.Sources = sources
-		response.Results = append(response.Results, result)
+	// Defer cancellation of context passed to worker tasks; if main task
+	// returns early, worker tasks should be torn down quickly.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Channel which workers use to report their result, which is either an
+	// error or nil (when successful).
+	workerOutput := make(chan error)
+
+	// Start a task which is itself responsible for starting per-query worker
+	// tasks. This is needed because RunLimitedAsyncTask can block; in the
+	// case where a single request has more queries than the semaphore limit,
+	// a deadlock would occur because queries cannot complete until
+	// they have written their result to the "output" channel, which is
+	// processed later in the main function.
+	if err := s.stopper.RunAsyncTask(ctx, func(ctx context.Context) {
+		for queryIdx, query := range request.Queries {
+			queryIdx := queryIdx
+			query := query
+			if err := s.stopper.RunLimitedAsyncTask(
+				ctx,
+				s.workerSem,
+				true, /* wait */
+				func(ctx context.Context) {
+					datapoints, sources, err := s.db.Query(
+						ctx,
+						query,
+						Resolution10s,
+						sampleNanos,
+						request.StartNanos,
+						request.EndNanos,
+					)
+					if err == nil {
+						response.Results[queryIdx] = tspb.TimeSeriesQueryResponse_Result{
+							Query:      query,
+							Datapoints: datapoints,
+						}
+						response.Results[queryIdx].Sources = sources
+					}
+					select {
+					case workerOutput <- err:
+					case <-ctx.Done():
+					}
+				},
+			); err != nil {
+				// Stopper has been closed and is draining. Return an error and
+				// exit the worker-spawning loop.
+				select {
+				case workerOutput <- err:
+				case <-ctx.Done():
+				}
+				return
+			}
+		}
+	}); err != nil {
+		return nil, err
+	}
+
+	for range request.Queries {
+		select {
+		case err := <-workerOutput:
+			if err != nil {
+				// Return the first error encountered. This will cancel the
+				// worker context and cause all other in-progress workers to
+				// exit.
+				return nil, err
+			}
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	}
 
 	return &response, nil

--- a/pkg/ts/server_test.go
+++ b/pkg/ts/server_test.go
@@ -17,6 +17,7 @@
 package ts_test
 
 import (
+	"fmt"
 	"sort"
 	"testing"
 
@@ -242,4 +243,81 @@ func TestServerQuery(t *testing.T) {
 		t.Fatalf("actual response \n%v\n did not match expected response \n%v",
 			response, expectedResult)
 	}
+}
+
+func BenchmarkServerQuery(b *testing.B) {
+	s, _, _ := serverutils.StartServer(b, base.TestServerArgs{})
+	defer s.Stopper().Stop()
+	tsrv := s.(*server.TestServer)
+
+	// Populate data for large number of time series.
+	seriesCount := 50
+	sourceCount := 10
+	if err := populateSeries(seriesCount, sourceCount, tsrv.TsDB()); err != nil {
+		b.Fatal(err)
+	}
+
+	conn, err := tsrv.RPCContext().GRPCDial(tsrv.Cfg.Addr)
+	if err != nil {
+		b.Fatal(err)
+	}
+	client := tspb.NewTimeSeriesClient(conn)
+
+	queries := make([]tspb.Query, 0, seriesCount)
+	for i := 0; i < seriesCount; i++ {
+		queries = append(queries, tspb.Query{
+			Name: fmt.Sprintf("metric.%d", i),
+		})
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := client.Query(context.Background(), &tspb.TimeSeriesQueryRequest{
+			StartNanos: 0 * 1e9,
+			EndNanos:   500 * 1e9,
+			Queries:    queries,
+		}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func seriesName(seriesNum int) string {
+	return fmt.Sprintf("metric.%d", seriesNum)
+}
+
+func sourceName(sourceNum int) string {
+	return fmt.Sprintf("source.%d", sourceNum)
+}
+
+func populateSeries(seriesCount, sourceCount int, tsdb *ts.DB) error {
+	for series := 0; series < seriesCount; series++ {
+		for source := 0; source < sourceCount; source++ {
+			if err := tsdb.StoreData(context.TODO(), ts.Resolution10s, []tspb.TimeSeriesData{
+				{
+					Name:   seriesName(series),
+					Source: sourceName(source),
+					Datapoints: []tspb.TimeSeriesDatapoint{
+						{
+							TimestampNanos: 100 * 1e9,
+							Value:          100.0,
+						},
+						{
+							TimestampNanos: 200 * 1e9,
+							Value:          200.0,
+						},
+						{
+							TimestampNanos: 300 * 1e9,
+							Value:          300.0,
+						},
+					},
+				},
+			}); err != nil {
+				return fmt.Errorf(
+					"error storing data for series %d, source %d: %s", series, source, err,
+				)
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -19,6 +19,7 @@ package stop_test
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -464,6 +465,62 @@ func TestStopperRunLimitedAsyncTask(t *testing.T) {
 	)
 	if err != stop.ErrThrottled {
 		t.Fatalf("expected %v; got %v", stop.ErrThrottled, err)
+	}
+}
+
+func TestStopperRunLimitedAsyncTaskCancelContext(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s := stop.NewStopper()
+	defer s.Stop()
+
+	const maxConcurrency = 5
+	sem := make(chan struct{}, maxConcurrency)
+
+	// Synchronization channels.
+	workersDone := make(chan struct{})
+	workerStarted := make(chan struct{})
+
+	var workersRun int32
+	var workersCancelled int32
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	f := func(ctx context.Context) {
+		atomic.AddInt32(&workersRun, 1)
+		workerStarted <- struct{}{}
+		<-ctx.Done()
+	}
+
+	// This loop will block when the semaphore is filled.
+	if err := s.RunAsyncTask(ctx, func(ctx context.Context) {
+		for i := 0; i < maxConcurrency*2; i++ {
+			if err := s.RunLimitedAsyncTask(ctx, sem, true, f); err != nil {
+				if err != context.Canceled {
+					t.Fatal(err)
+				}
+				atomic.AddInt32(&workersCancelled, 1)
+			}
+		}
+		close(workersDone)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure that the semaphore fills up, leaving maxConcurrency workers
+	// waiting for context cancelation.
+	for i := 0; i < maxConcurrency; i++ {
+		<-workerStarted
+	}
+
+	// Cancel the context, which should result in all subsequent attempts to
+	// queue workers failing.
+	cancel()
+	<-workersDone
+
+	if a, e := atomic.LoadInt32(&workersRun), int32(maxConcurrency); a != e {
+		t.Fatalf("%d workers ran before context close, expected exactly %d", a, e)
+	}
+	if a, e := atomic.LoadInt32(&workersCancelled), int32(maxConcurrency); a != e {
+		t.Fatalf("%d workers cancelled after context close, expected exactly %d", a, e)
 	}
 }
 


### PR DESCRIPTION
Allows the server to run the individual queries in an incoming
QueryRequest in parallel. This is a significant performance improvement over the
previous design, which executed the individual queries serially; typical UI
query requests routinely request data for more than 50-100 series at once.

Query worker count is managed via the stoppers "StartLimitedAsyncTask", which
limits the total count of workers for the entire server across all queries. The
limit has been arbitrarily set at 250, but can be adjusted for tests via a
TestingKnob (also added in this commit).

Also includes a commit to add a benchmark test for multi-query requests. This is added in a preceding commit, in order to demonstrate the difference in performance from the old serial execution. Benchstat output (50 runs):

```
name           old time/op  new time/op  delta
ServerQuery-8  9.76ms ± 9%  4.11ms ±13%  -57.91%  (p=0.000 n=50+50)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10250)

<!-- Reviewable:end -->
