### PR TITLE
kv: wait for pending results before returning AmbiguousCommitError

### DIFF
--- a/pkg/internal/client/db_test.go
+++ b/pkg/internal/client/db_test.go
@@ -395,6 +395,7 @@ func TestCommonMethods(t *testing.T) {
 		key{txnType, "SetSystemConfigTrigger"}: {},
 		key{txnType, "SystemConfigTrigger"}:    {},
 		key{txnType, "UpdateDeadlineMaybe"}:    {},
+		key{txnType, "AddCommitTrigger"}:       {},
 	}
 
 	for b := range omittedChecks {

--- a/pkg/sql/ambiguous_commit_test.go
+++ b/pkg/sql/ambiguous_commit_test.go
@@ -148,7 +148,7 @@ func TestAmbiguousCommit(t *testing.T) {
 		}
 	}
 
-	// Close the wait channel and wait for the error from the pending SQL insert.
+	// Wait for the error from the pending SQL insert.
 	if err := <-sqlErrCh; !testutils.IsError(err, "transaction commit result is ambiguous") {
 		t.Errorf("expected ambiguous commit error; got %v", err)
 	}

--- a/pkg/sql/create_test.go
+++ b/pkg/sql/create_test.go
@@ -183,10 +183,16 @@ func createTestTable(
 			val INT
 		)`, id)
 
-	if _, err := db.Exec(tableSQL); err != nil {
-		t.Errorf("table %d: could not be created: %s", id, err)
-	} else {
+	for {
+		if _, err := db.Exec(tableSQL); err != nil {
+			if testutils.IsSQLRetryableError(err) {
+				continue
+			}
+			t.Errorf("table %d: could not be created: %v", id, err)
+			return
+		}
 		completed <- id
+		break
 	}
 }
 

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -88,10 +88,12 @@ func (ev EventLogger) InsertEventRecord(
 	txn *client.Txn, eventType EventLogType, targetID, reportingID int32, info interface{},
 ) error {
 	// Record event record insertion in local log output.
-	log.Infof(txn.Context, "Event: %q, target: %d, info: %+v",
-		eventType,
-		targetID,
-		info)
+	txn.AddCommitTrigger(func() {
+		log.Infof(txn.Context, "Event: %q, target: %d, info: %+v",
+			eventType,
+			targetID,
+			info)
+	})
 
 	const insertEventTableStmt = `
 INSERT INTO system.eventlog (


### PR DESCRIPTION
Instead of assuming the worst in the event that a failing error is
returned from a node and we still have pending RPCs, let those finish.

Fixes #10194

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10251)

<!-- Reviewable:end -->
