### PR TITLE
sql: avoid adjusting MaxOffset mid-test

### DIFF
--- a/pkg/sql/lease_internal_test.go
+++ b/pkg/sql/lease_internal_test.go
@@ -272,10 +272,12 @@ func TestNameCacheEntryDoesntReturnExpiredLease(t *testing.T) {
 	defer s.Stopper().Stop()
 	leaseManager := s.LeaseManager().(*LeaseManager)
 
-	if _, err := db.Exec(`
+	const tableName = "test"
+
+	if _, err := db.Exec(fmt.Sprintf(`
 CREATE DATABASE t;
-CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
-`); err != nil {
+CREATE TABLE t.%s (k CHAR PRIMARY KEY, v CHAR);
+`, tableName)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -284,24 +286,23 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 		t.Fatal(err)
 	}
 
-	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
+	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", tableName)
 
 	// Check the assumptions this tests makes: that there is a cache entry
 	// (with a valid lease).
-	lease := leaseManager.tableNames.get(tableDesc.ParentID, "test", s.Clock())
-	if lease == nil {
-		t.Fatalf("no name cache entry")
+	if lease := leaseManager.tableNames.get(tableDesc.ParentID, tableName, s.Clock()); lease == nil {
+		t.Fatalf("name cache has no unexpired entry for (%d, %s)", tableDesc.ParentID, tableName)
+	} else {
+		if err := leaseManager.Release(lease); err != nil {
+			t.Fatal(err)
+		}
 	}
-	if err := leaseManager.Release(lease); err != nil {
-		t.Fatal(err)
-	}
-	// Advance the clock to expire the lease.
-	s.Clock().SetMaxOffset(10 * LeaseDuration)
-	s.Clock().Update(s.Clock().Now().Add(int64(2*LeaseDuration), 0))
+
+	leaseManager.ExpireLeases(s.Clock())
 
 	// Check the name no longer resolves.
-	if leaseManager.tableNames.get(tableDesc.ParentID, "test", s.Clock()) != nil {
-		t.Fatalf("name resolves when it shouldn't")
+	if lease := leaseManager.tableNames.get(tableDesc.ParentID, tableName, s.Clock()); lease != nil {
+		t.Fatalf("name cache has unexpired entry for (%d, %s): %s", tableDesc.ParentID, tableName, lease)
 	}
 }
 


### PR DESCRIPTION
This prevents a panic when the clock adjustment happens while a
heartbeat RPC is in-flight. Easily reproduces with the `deadlock` tag.

See https://teamcity.cockroachdb.com/viewLog.html?tab=buildLog&logTab=tree&filter=debug&expand=all&buildId=37365#_focus=2167

I'm not sure why no issue was created for this run.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10257)

<!-- Reviewable:end -->
