### PR TITLE
sql: Fix privileges required for SHOW CREATE VIEW

### DIFF
--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -339,6 +339,12 @@ func (p *planner) ShowCreateView(n *parser.ShowCreateView) (planNode, error) {
 			if !ok {
 				return nil, errors.Errorf("failed to parse underlying query from view %q as a select", tn)
 			}
+
+			// When constructing the Select plan, make sure we don't require any
+			// privileges on the underlying tables.
+			p.skipSelectPrivilegeChecks = true
+			defer func() { p.skipSelectPrivilegeChecks = false }()
+
 			sourcePlan, err := p.Select(sel, []parser.Type{}, false)
 			if err != nil {
 				return nil, err

--- a/pkg/sql/testdata/views
+++ b/pkg/sql/testdata/views
@@ -160,6 +160,9 @@ SELECT * FROM v1;
 query error user testuser does not have SELECT privilege on view v6
 SELECT * FROM v6;
 
+query error user testuser has no privileges on view v1
+SHOW CREATE VIEW v1;
+
 user root
 
 statement ok
@@ -182,6 +185,11 @@ SELECT * FROM v1;
 
 query error user testuser does not have SELECT privilege on view v6
 SELECT * FROM v6;
+
+query TT
+SHOW CREATE VIEW v1;
+----
+v1 CREATE VIEW v1 AS SELECT a, b FROM test.t
 
 user root
 


### PR DESCRIPTION
Don't require any privileges on underlying tables when expanding out the
view query.

Fixes #10245

@dt @jseldess

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10270)

<!-- Reviewable:end -->
