### PR TITLE
sql: Add pg_views table to pg_catalog

### DIFF
--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -50,6 +50,7 @@ var pgCatalog = virtualSchema{
 		pgCatalogNamespaceTable,
 		pgCatalogTablesTable,
 		pgCatalogTypeTable,
+		pgCatalogViewsTable,
 	},
 }
 
@@ -791,6 +792,41 @@ var datumToTypeCategory = map[reflect.Type]*parser.DString{
 
 func typCategory(typ parser.Type) parser.Datum {
 	return datumToTypeCategory[reflect.TypeOf(typ)]
+}
+
+// See: https://www.postgresql.org/docs/9.6/static/view-pg-views.html.
+var pgCatalogViewsTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE pg_catalog.pg_views (
+	schemaname STRING,
+	viewname STRING,
+	viewowner STRING,
+	definition STRING
+);
+`,
+	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+		return forEachTableDesc(p,
+			func(db *sqlbase.DatabaseDescriptor, desc *sqlbase.TableDescriptor) error {
+				if !desc.IsView() {
+					return nil
+				}
+				// Note that the view query printed will not include any column aliases
+				// specified outside the initial view query into the definition
+				// returned, unlike postgres. For example, for the view created via
+				//  `CREATE VIEW (a) AS SELECT b FROM foo`
+				// we'll only print `SELECT b FROM foo` as the view definition here,
+				// while postgres would more accurately print `SELECT b AS a FROM foo`.
+				// TODO(a-robinson): Insert column aliases into view query once we
+				// have a semantic query representation to work with (#10083).
+				return addRow(
+					parser.NewDString(db.Name),        // schemaname
+					parser.NewDString(desc.Name),      // viewname
+					parser.DNull,                      // viewowner
+					parser.NewDString(desc.ViewQuery), // definition
+				)
+			},
+		)
+	},
 }
 
 // oidHasher provides a consistent hashing mechanism for object identifiers in

--- a/pkg/sql/testdata/information_schema
+++ b/pkg/sql/testdata/information_schema
@@ -350,6 +350,7 @@ pg_indexes
 pg_namespace
 pg_tables
 pg_type
+pg_views
 descriptor
 eventlog
 lease
@@ -372,6 +373,7 @@ table_constraints
 schemata
 schema_privileges
 rangelog
+pg_views
 pg_type
 pg_tables
 pg_namespace
@@ -403,6 +405,7 @@ def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1
 def            pg_catalog          pg_type            SYSTEM VIEW  1
+def            pg_catalog          pg_views           SYSTEM VIEW  1
 def            system              descriptor         BASE TABLE   1
 def            system              eventlog           BASE TABLE   1
 def            system              lease              BASE TABLE   1
@@ -442,6 +445,7 @@ def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1
 def            pg_catalog          pg_type            SYSTEM VIEW  1
+def            pg_catalog          pg_views           SYSTEM VIEW  1
 
 user root
 
@@ -470,6 +474,7 @@ def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1
 def            pg_catalog          pg_type            SYSTEM VIEW  1
+def            pg_catalog          pg_views           SYSTEM VIEW  1
 
 user root
 

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -52,6 +52,7 @@ pg_indexes
 pg_namespace
 pg_tables
 pg_type
+pg_views
 
 query TT colnames
 SHOW CREATE TABLE pg_catalog.pg_namespace
@@ -151,6 +152,14 @@ tablename          hasindexes
 table_constraints  false
 table_privileges   false
 tables             false
+
+## pg_catalog.pg_views
+
+query TTTT colnames
+SELECT * FROM pg_catalog.pg_views
+----
+schemaname     viewname  viewowner  definition
+constraint_db  v1        NULL       SELECT p, a, b, c FROM constraint_db.t1
 
 ## pg_catalog.pg_class
 


### PR DESCRIPTION
Fixes #10240

Question: postgres includes all the pg_catalog and information_schema virtual tables in the pg_views table. Do you think we should we worry about doing the same?

@nvanbenschoten

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10276)

<!-- Reviewable:end -->
