### PR TITLE
cloud: fix for Terraform 0.7.4 redux

### DIFF
--- a/cloud/aws/benchmarks/main.tf
+++ b/cloud/aws/benchmarks/main.tf
@@ -30,7 +30,7 @@ resource "aws_instance" "benchmark" {
 
   connection {
     user = "ubuntu"
-    key_file = "~/.ssh/${var.key_name}.pem"
+    private_key = "${file(format("~/.ssh/%s.pem", var.key_name))}"
   }
 
   provisioner "file" {

--- a/cloud/aws/tests/main.tf
+++ b/cloud/aws/tests/main.tf
@@ -40,7 +40,7 @@ resource "aws_instance" "sql_logic_test" {
 
   connection {
     user = "ubuntu"
-    key_file = "~/.ssh/${var.key_name}.pem"
+    private_key = "${file(format("~/.ssh/%s.pem", var.key_name))}"
   }
 
   provisioner "file" {

--- a/cloud/gce/benchmarks/main.tf
+++ b/cloud/gce/benchmarks/main.tf
@@ -45,7 +45,7 @@ resource "google_compute_instance" "benchmark" {
 
   connection {
     user = "ubuntu"
-    key_file = "~/.ssh/${var.key_name}"
+    private_key = "${file("~/.ssh/${var.key_name}")}"
   }
 
   service_account {

--- a/cloud/gce/sql_logic_tests/main.tf
+++ b/cloud/gce/sql_logic_tests/main.tf
@@ -50,7 +50,7 @@ resource "google_compute_instance" "sql_logic_test" {
 
   connection {
     user = "ubuntu"
-    key_file = "~/.ssh/${var.key_name}"
+    private_key = "${file("~/.ssh/${var.key_name}")}"
   }
 
   service_account {


### PR DESCRIPTION
Replace all remaining uses of the deprecated/removed `key_file`
configuration variable in Terraform configurations with `private_key`.
Continues the work started in #9615.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10278)

<!-- Reviewable:end -->
