### PR TITLE
cmd/zerosum: adjust to fail-fast semantics

### DIFF
--- a/pkg/cmd/zerosum/main.go
+++ b/pkg/cmd/zerosum/main.go
@@ -154,7 +154,7 @@ func (z *zeroSum) accountsLen() int {
 }
 
 func (z *zeroSum) maybeLogError(err error) {
-	if strings.Contains(err.Error(), "range is frozen") {
+	if isUnavailableError(err) || strings.Contains(err.Error(), "range is frozen") {
 		return
 	}
 	log.Error(context.Background(), err)


### PR DESCRIPTION
32616a9 made KV over gRPC fail-fast. Fix zerosum to retry scan
operations when the cluster is just starting up.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10297)

<!-- Reviewable:end -->
