### PR TITLE
sql: release discarded results from retried queries

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -107,7 +107,12 @@ type StatementResults struct {
 
 // Close ensures that the resources claimed by the results are released.
 func (s *StatementResults) Close() {
-	for _, r := range s.ResultList {
+	s.ResultList.Close()
+}
+
+// Close ensures that the resources claimed by the results are released.
+func (rl ResultList) Close() {
+	for _, r := range rl {
 		r.Close()
 	}
 }
@@ -564,6 +569,10 @@ func (e *Executor) execRequest(session *Session, sql string, copymsg copyMsg) St
 			}
 
 			var err error
+			if results != nil {
+				// Some results were produced by a previous attempt. Discard them.
+				ResultList(results).Close()
+			}
 			results, remainingStmts, err = runTxnAttempt(e, planMaker, origState, txnState, opt, stmtsToExec)
 
 			// TODO(andrei): Until #7881 fixed.


### PR DESCRIPTION
When a query is retried the result list from a previous attempt must
be properly released. Otherwise the monitor would complain that some
memory was leaked.

Fixes  #10296.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10298)

<!-- Reviewable:end -->
