### PR TITLE
sql: introduce a new virtual database crdb_internal

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -658,8 +658,9 @@ func Example_sql() {
 	// x	y
 	// 42	69
 	// sql --execute=show databases
-	// 4 rows
+	// 5 rows
 	// Database
+	// crdb_internal
 	// information_schema
 	// pg_catalog
 	// system

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -251,7 +251,7 @@ func TestAdminAPIDatabases(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedDBs := []string{"information_schema", "pg_catalog", "system", testdb}
+	expectedDBs := []string{"crdb_internal", "information_schema", "pg_catalog", "system", testdb}
 	if a, e := len(resp.Databases), len(expectedDBs); a != e {
 		t.Fatalf("length of result %d != expected %d", a, e)
 	}

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1,0 +1,365 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package sql
+
+import (
+	"strings"
+	"time"
+	"unsafe"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+var crdbInternal = virtualSchema{
+	name: "crdb_internal",
+	tables: []virtualSchemaTable{
+		crdbInternalTablesTable,
+		crdbInternalSessionsTable,
+		crdbInternalTxnsTable,
+		crdbInternalLeasesTable,
+		crdbInternalSchemaChangesTable,
+	},
+}
+
+type sessionRegistry struct {
+	syncutil.Mutex
+	store map[*Session]struct{}
+}
+
+func makeSessionRegistry() sessionRegistry {
+	return sessionRegistry{store: make(map[*Session]struct{})}
+}
+
+func (r *sessionRegistry) register(s *Session) {
+	r.Lock()
+	r.store[s] = struct{}{}
+	r.Unlock()
+}
+
+func (r *sessionRegistry) deregister(s *Session) {
+	r.Lock()
+	delete(r.store, s)
+	r.Unlock()
+}
+
+var crdbInternalTablesTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE crdb_internal.tables (
+  TABLE_ID                 INT NOT NULL,
+  PARENT_ID                INT NOT NULL,
+  NAME                     STRING NOT NULL,
+  VERSION                  INT NOT NULL,
+  MODIFICATION_TIME        TIMESTAMP NOT NULL,
+  MODIFICATION_TIME_L      DECIMAL NOT NULL,
+  FORMAT_VERSION           STRING NOT NULL,
+  STATE                    STRING NOT NULL,
+  SC_LEASE_NODE_ID         INT,
+  SC_LEASE_EXPIRATION_TIME TIMESTAMP
+);
+`,
+	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+		descs, err := p.getAllDescriptors()
+		if err != nil {
+			return err
+		}
+		// Note: we do not use forEachTableDesc() here because we want to
+		// include added and dropped descriptors.
+		for _, desc := range descs {
+			table, ok := desc.(*sqlbase.TableDescriptor)
+			if !ok || !userCanSeeDescriptor(table, p.session.User) {
+				continue
+			}
+			leaseNodeDatum := parser.DNull
+			leaseExpDatum := parser.DNull
+			if table.Lease != nil {
+				leaseNodeDatum = parser.NewDInt(parser.DInt(int64(table.Lease.NodeID)))
+				leaseExpDatum = parser.MakeDTimestamp(
+					time.Unix(0, table.Lease.ExpirationTime), time.Nanosecond,
+				)
+			}
+			if err := addRow(
+				parser.NewDInt(parser.DInt(int64(table.ID))),
+				parser.NewDInt(parser.DInt(int64(table.ParentID))),
+				parser.NewDString(parser.Name(table.Name).String()),
+				parser.NewDInt(parser.DInt(int64(table.Version))),
+				parser.MakeDTimestamp(time.Unix(0, table.ModificationTime.WallTime), time.Microsecond),
+				parser.TimestampToDecimal(table.ModificationTime),
+				parser.NewDString(table.FormatVersion.String()),
+				parser.NewDString(table.State.String()),
+				leaseNodeDatum,
+				leaseExpDatum,
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	},
+}
+
+var crdbInternalSchemaChangesTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE crdb_internal.schema_changes (
+  TABLE_ID      INT NOT NULL,
+  PARENT_ID     INT NOT NULL,
+  NAME          STRING NOT NULL,
+  TYPE          STRING NOT NULL,
+  TARGET_ID     INT,
+  TARGET_NAME   STRING,
+  STATE         STRING NOT NULL,
+  DIRECTION     STRING NOT NULL
+);
+`,
+	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+		descs, err := p.getAllDescriptors()
+		if err != nil {
+			return err
+		}
+		// Note: we do not use forEachTableDesc() here because we want to
+		// include added and dropped descriptors.
+		for _, desc := range descs {
+			table, ok := desc.(*sqlbase.TableDescriptor)
+			if !ok || !userCanSeeDescriptor(table, p.session.User) {
+				continue
+			}
+			tableID := parser.NewDInt(parser.DInt(int64(table.ID)))
+			parentID := parser.NewDInt(parser.DInt(int64(table.ParentID)))
+			tableName := parser.NewDString(parser.Name(table.Name).String())
+			for _, mut := range table.Mutations {
+				mutType := "UNKNOWN"
+				targetID := parser.DNull
+				targetName := parser.DNull
+				switch d := mut.Descriptor_.(type) {
+				case *sqlbase.DescriptorMutation_Column:
+					mutType = "COLUMN"
+					targetID = parser.NewDInt(parser.DInt(int64(d.Column.ID)))
+					targetName = parser.NewDString(d.Column.Name)
+				case *sqlbase.DescriptorMutation_Index:
+					mutType = "INDEX"
+					targetID = parser.NewDInt(parser.DInt(int64(d.Index.ID)))
+					targetName = parser.NewDString(d.Index.Name)
+				}
+				if err := addRow(
+					tableID,
+					parentID,
+					tableName,
+					parser.NewDString(mutType),
+					targetID,
+					targetName,
+					parser.NewDString(mut.State.String()),
+					parser.NewDString(mut.Direction.String()),
+				); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	},
+}
+
+var crdbInternalSessionsTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE crdb_internal.sessions (
+  NODE_ID                 INT NOT NULL,
+  SESSION_ID              INT NOT NULL,
+  CLIENT                  STRING NOT NULL,
+  "USER"                  STRING NOT NULL,
+  TXN_STATE               STRING NOT NULL,
+  TXN_ID                  INT,
+  AUTO_RETRY              BOOL NOT NULL,
+  SQL_TIMESTAMP           TIMESTAMP NOT NULL,
+  DEFAULT_DATABASE        STRING NOT NULL,
+  DEFAULT_ISOLATION_LEVEL STRING NOT NULL,
+  TIME_ZONE               STRING NOT NULL,
+  MEMORY_USAGE            INT NOT NULL,
+  SEARCH_PATH             STRING NOT NULL
+);
+`,
+	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+		if p.session.sessionRegistry == nil {
+			return nil
+		}
+		registry := p.session.sessionRegistry
+		registry.Lock()
+		defer registry.Unlock()
+		nodeID := parser.NewDInt(parser.DInt(int64(p.leaseMgr.nodeID.Get())))
+		for s := range registry.store {
+			if s.User != p.session.User && p.session.User != security.RootUser {
+				continue
+			}
+
+			txnDatum := parser.DNull
+			txn := s.TxnState.txn
+			if txn != nil {
+				txnDatum = parser.NewDInt(parser.DInt(int64(uintptr(unsafe.Pointer(txn)))))
+			}
+			if err := addRow(
+				nodeID,
+				parser.NewDInt(parser.DInt(int64(uintptr(unsafe.Pointer(s))))),
+				parser.NewDString(s.Client),
+				parser.NewDString(s.User),
+				parser.NewDString(s.TxnState.State.String()),
+				txnDatum,
+				parser.MakeDBool(parser.DBool(s.TxnState.autoRetry)),
+				parser.MakeDTimestamp(s.TxnState.sqlTimestamp, time.Microsecond),
+				parser.NewDString(s.Database),
+				parser.NewDString(s.DefaultIsolationLevel.String()),
+				parser.NewDString(s.Location.String()),
+				parser.NewDInt(parser.DInt(s.mon.CurAllocated())),
+				parser.NewDString(strings.Join(s.SearchPath, ",")),
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	},
+}
+
+var crdbInternalTxnsTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE crdb_internal.txns (
+  NODE_ID           INT NOT NULL,
+  TXN_ID            INT NOT NULL,
+  KV_TXN_UUID       STRING,
+  KEY               BYTES,
+  EPOCH             INT NOT NULL,
+  TIMESTAMP         TIMESTAMP NOT NULL,
+  TIMESTAMP_L       DECIMAL NOT NULL,
+  PRIORITY          INT NOT NULL,
+  SEQUENCE          INT NOT NULL,
+  ISOLATION         STRING NOT NULL,
+  NAME              STRING NOT NULL,
+  STATUS            STRING NOT NULL,
+  ORIG_TIMESTAMP    TIMESTAMP NOT NULL,
+  ORIG_TIMESTAMP_L  DECIMAL NOT NULL,
+  WRITING           BOOL NOT NULL,
+  NUM_INTENTS       INT NOT NULL
+);
+`,
+	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+		// TODO(knz) We probably would like this table to report on all
+		// Txn objects currently active, but we do not yet have a proper
+		// registry for that. So for now the virtual table reports only
+		// the Txns known to Session objects.
+		if p.session.sessionRegistry == nil {
+			return nil
+		}
+		registry := p.session.sessionRegistry
+		registry.Lock()
+		defer registry.Unlock()
+		nodeID := parser.NewDInt(parser.DInt(int64(p.leaseMgr.nodeID.Get())))
+		for s := range registry.store {
+			if s.User != p.session.User && p.session.User != security.RootUser {
+				continue
+			}
+
+			txn := s.TxnState.txn
+			if txn == nil {
+				continue
+			}
+			id := txn.Proto.ID
+			idDatum := parser.DNull
+			if id != nil {
+				idDatum = parser.NewDString(id.String())
+			}
+			key := txn.Proto.Key
+			keyDatum := parser.DNull
+			if key != nil {
+				keyDatum = parser.NewDBytes(parser.DBytes(key))
+			}
+			if err := addRow(
+				nodeID,
+				parser.NewDInt(parser.DInt(int64(uintptr(unsafe.Pointer(txn))))),
+				idDatum,
+				keyDatum,
+				parser.NewDInt(parser.DInt(int64(txn.Proto.Epoch))),
+				parser.MakeDTimestamp(time.Unix(0, txn.Proto.Timestamp.WallTime), time.Microsecond),
+				parser.TimestampToDecimal(txn.Proto.Timestamp),
+				parser.NewDInt(parser.DInt(int64(txn.Proto.Priority))),
+				parser.NewDInt(parser.DInt(int64(txn.Proto.Sequence))),
+				parser.NewDString(txn.Proto.Isolation.String()),
+				parser.NewDString(txn.Proto.Name),
+				parser.NewDString(txn.Proto.Status.String()),
+				parser.MakeDTimestamp(time.Unix(0, txn.Proto.OrigTimestamp.WallTime), time.Microsecond),
+				parser.TimestampToDecimal(txn.Proto.OrigTimestamp),
+				parser.MakeDBool(parser.DBool(txn.Proto.Writing)),
+				parser.NewDInt(parser.DInt(int64(len(txn.Proto.Intents)))),
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	},
+}
+
+var crdbInternalLeasesTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE crdb_internal.leases (
+  NODE_ID     INT NOT NULL,
+  TABLE_ID    INT NOT NULL,
+  NAME        STRING NOT NULL,
+  PARENT_ID   INT NOT NULL,
+  EXPIRATION  TIMESTAMP NOT NULL,
+  RELEASED    BOOL NOT NULL,
+  DELETED     BOOL NOT NULL
+);
+`,
+	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+		leaseMgr := p.leaseMgr
+		nodeID := parser.NewDInt(parser.DInt(int64(leaseMgr.nodeID.Get())))
+
+		leaseMgr.mu.Lock()
+		defer leaseMgr.mu.Unlock()
+
+		for tid, ts := range leaseMgr.tables {
+			tableID := parser.NewDInt(parser.DInt(int64(tid)))
+
+			adder := func() error {
+				ts.mu.Lock()
+				defer ts.mu.Unlock()
+
+				deleted := parser.MakeDBool(parser.DBool(ts.deleted))
+
+				for _, state := range ts.active.data {
+					if !userCanSeeDescriptor(&state.TableDescriptor, p.session.User) {
+						continue
+					}
+					expCopy := state.expiration
+					if err := addRow(
+						nodeID,
+						tableID,
+						parser.NewDString(parser.Name(state.Name).String()),
+						parser.NewDInt(parser.DInt(int64(state.ParentID))),
+						&expCopy,
+						parser.MakeDBool(parser.DBool(state.released)),
+						deleted,
+					); err != nil {
+						return err
+					}
+				}
+				return nil
+			}
+
+			if err := adder(); err != nil {
+				return err
+			}
+		}
+		return nil
+	},
+}

--- a/pkg/sql/mon/mem_usage.go
+++ b/pkg/sql/mon/mem_usage.go
@@ -591,3 +591,8 @@ func (mm *MemoryMonitor) adjustBudget(ctx context.Context) {
 		mm.pool.ShrinkAccount(ctx, &mm.mu.curBudget, mm.mu.curBudget.curAllocated-neededBytes)
 	}
 }
+
+// CurAllocated exposes the current curAllocated member.
+func (mm *MemoryMonitor) CurAllocated() int64 {
+	return mm.mu.curBudget.curAllocated
+}

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -1489,6 +1489,25 @@ func (ctx *EvalContext) GetStmtTimestamp() time.Time {
 	return ctx.stmtTimestamp
 }
 
+// TimestampToDecimal converts the logical timestamp into a decimal
+// value with the number of nanoseconds in the integer part and the
+// logical counter in the decimal part.
+func TimestampToDecimal(ts hlc.Timestamp) *DDecimal {
+	// Compute Walltime * 10^10 + Logical.
+	// We need 10 decimals for the Logical field because its maximum
+	// value is 4294967295 (2^32-1), a value with 10 decimal digits.
+	var res DDecimal
+	val := res.UnscaledBig()
+	val.SetInt64(ts.WallTime)
+	val.Mul(val, decimal.PowerOfTenInt(10))
+	val.Add(val, big.NewInt(int64(ts.Logical)))
+
+	// Shift 10 decimals to the right, so that the logical
+	// field appears as fractional part.
+	res.Dec.SetScale(10)
+	return &res
+}
+
 // GetClusterTimestamp retrieves the current cluster timestamp as per
 // the evaluation context. The timestamp is guaranteed to be nonzero.
 func (ctx *EvalContext) GetClusterTimestamp() *DDecimal {
@@ -1500,19 +1519,7 @@ func (ctx *EvalContext) GetClusterTimestamp() *DDecimal {
 		}
 	}
 
-	// Compute Walltime * 10^10 + Logical.
-	// We need 10 decimals for the Logical field because its maximum
-	// value is 4294967295 (2^32-1), a value with 10 decimal digits.
-	var res DDecimal
-	val := res.UnscaledBig()
-	val.SetInt64(ctx.clusterTimestamp.WallTime)
-	val.Mul(val, decimal.PowerOfTenInt(10))
-	val.Add(val, big.NewInt(int64(ctx.clusterTimestamp.Logical)))
-
-	// Shift 10 decimals to the right, so that the logical
-	// field appears as fractional part.
-	res.Dec.SetScale(10)
-	return &res
+	return TimestampToDecimal(ctx.clusterTimestamp)
 }
 
 // GetTxnTimestamp retrieves the current transaction timestamp as per

--- a/pkg/sql/pgwire_test.go
+++ b/pkg/sql/pgwire_test.go
@@ -427,7 +427,7 @@ func TestPGPreparedQuery(t *testing.T) {
 				Results("hashedPassword", "BYTES", true, gosql.NullBool{}),
 		},
 		"SHOW DATABASES": {
-			baseTest.Results("information_schema").Results("pg_catalog").Results("d").Results("system"),
+			baseTest.Results("crdb_internal").Results("information_schema").Results("pg_catalog").Results("d").Results("system"),
 		},
 		"SHOW GRANTS ON system.users": {
 			baseTest.Results("users", security.RootUser, "DELETE,GRANT,INSERT,SELECT,UPDATE"),

--- a/pkg/sql/testdata/crdb_internal
+++ b/pkg/sql/testdata/crdb_internal
@@ -1,0 +1,50 @@
+query error user root does not have DROP privilege on database crdb_internal
+ALTER DATABASE crdb_internal RENAME TO not_crdb_internal
+
+statement error user root does not have CREATE privilege on database crdb_internal
+CREATE TABLE crdb_internal.t (x INT)
+
+query error user root does not have DROP privilege on database crdb_internal
+DROP DATABASE crdb_internal
+
+statement ok
+CREATE DATABASE testdb; CREATE TABLE testdb.foo(x INT)
+
+query TIT
+SELECT t.name, t.version, t.state FROM crdb_internal.tables AS t JOIN system.namespace AS n ON (n.id = t.parent_id and n.name = 'testdb');
+----
+foo 1 PUBLIC
+
+# Ensure there is a lease taken on foo.
+query I
+SELECT * FROM testdb.foo
+----
+
+# Check the lease.
+query T
+SELECT l.name FROM crdb_internal.leases AS l JOIN system.namespace AS n ON (n.id = l.table_id and n.name = 'foo');
+----
+foo
+
+# We merely check the column list for schema_changes.
+query IITTITTT colnames
+SELECT * FROM crdb_internal.schema_changes
+----
+TABLE_ID PARENT_ID NAME TYPE TARGET_ID TARGET_NAME STATE DIRECTION
+
+query TB colnames
+SET DATABASE=testdb; SELECT s.txn_state, tx.writing FROM crdb_internal.sessions AS s JOIN crdb_internal.txns AS tx USING(txn_id) WHERE s.default_database='testdb'
+----
+txn_state writing
+Open      false
+
+
+query TB colnames
+SET DATABASE=testdb; BEGIN;
+     DROP TABLE testdb.foo;
+     SELECT s.txn_state, tx.writing FROM crdb_internal.sessions AS s JOIN crdb_internal.txns AS tx USING(txn_id) WHERE s.default_database='testdb';
+     COMMIT
+----
+txn_state writing
+Open      true
+

--- a/pkg/sql/testdata/database
+++ b/pkg/sql/testdata/database
@@ -14,6 +14,7 @@ query T colnames
 SHOW DATABASES
 ----
 Database
+crdb_internal
 information_schema
 pg_catalog
 a
@@ -35,6 +36,7 @@ CREATE DATABASE c
 query T
 SHOW DATABASES
 ----
+crdb_internal
 information_schema
 pg_catalog
 a
@@ -75,6 +77,7 @@ query T colnames
 SHOW DATABASES
 ----
 Database
+crdb_internal
 information_schema
 pg_catalog
 a

--- a/pkg/sql/testdata/drop_database
+++ b/pkg/sql/testdata/drop_database
@@ -4,6 +4,7 @@ CREATE DATABASE "foo-bar"
 query T
 SHOW DATABASES
 ----
+crdb_internal
 information_schema
 pg_catalog
 foo-bar
@@ -16,6 +17,7 @@ DROP DATABASE "foo-bar"
 query T
 SHOW DATABASES
 ----
+crdb_internal
 information_schema
 pg_catalog
 system
@@ -27,6 +29,7 @@ CREATE DATABASE "foo bar"
 query T
 SHOW DATABASES
 ----
+crdb_internal
 information_schema
 pg_catalog
 foo bar
@@ -39,6 +42,7 @@ DROP DATABASE "foo bar"
 query T
 SHOW DATABASES
 ----
+crdb_internal
 information_schema
 pg_catalog
 system
@@ -123,6 +127,7 @@ SELECT * FROM d2.v4
 query T
 SHOW DATABASES
 ----
+crdb_internal
 information_schema
 pg_catalog
 d1
@@ -136,6 +141,7 @@ DROP DATABASE d1
 query T
 SHOW DATABASES
 ----
+crdb_internal
 information_schema
 pg_catalog
 d2
@@ -164,6 +170,7 @@ DROP DATABASE d2
 query T
 SHOW DATABASES
 ----
+crdb_internal
 information_schema
 pg_catalog
 system

--- a/pkg/sql/testdata/explain
+++ b/pkg/sql/testdata/explain
@@ -126,7 +126,7 @@ query ITT
 EXPLAIN SHOW DATABASES
 ----
 0 virtual table SHOW DATABASES
-1 values 1 column, 5 rows
+1 values 1 column, 6 rows
 
 query ITT
 EXPLAIN SHOW TABLES

--- a/pkg/sql/testdata/information_schema
+++ b/pkg/sql/testdata/information_schema
@@ -96,6 +96,7 @@ SET DATABASE = test
 query T
 SHOW DATABASES
 ----
+crdb_internal
 information_schema
 pg_catalog
 system
@@ -119,12 +120,12 @@ SHOW CREATE TABLE information_schema.tables
 ----
 Table                      CreateTable
 information_schema.tables  CREATE TABLE "information_schema.tables" (
-                               TABLE_CATALOG STRING NOT NULL DEFAULT '',
-                               TABLE_SCHEMA STRING NOT NULL DEFAULT '',
-                               TABLE_NAME STRING NOT NULL DEFAULT '',
-                               TABLE_TYPE STRING NOT NULL DEFAULT '',
-                               VERSION INT NULL
-                           )
+			       TABLE_CATALOG STRING NOT NULL DEFAULT '',
+			       TABLE_SCHEMA STRING NOT NULL DEFAULT '',
+			       TABLE_NAME STRING NOT NULL DEFAULT '',
+			       TABLE_TYPE STRING NOT NULL DEFAULT '',
+			       VERSION INT NULL
+			   )
 
 query TTBT colnames
 SHOW COLUMNS FROM information_schema.tables
@@ -159,7 +160,7 @@ Table  User  Privileges
 query TTTTI colnames
 SELECT table_catalog, table_schema, table_name, column_name, ordinal_position
 FROM information_schema.columns
-WHERE table_schema != 'information_schema' AND table_schema != 'pg_catalog'
+WHERE table_schema != 'information_schema' AND table_schema != 'pg_catalog' AND table_schema != 'crdb_internal'
 ----
 table_catalog  table_schema        table_name  column_name               ordinal_position
 def            system              descriptor  id                        1
@@ -291,6 +292,7 @@ query TTTT colnames
 SELECT * FROM information_schema.schemata
 ----
 CATALOG_NAME  SCHEMA_NAME         DEFAULT_CHARACTER_SET_NAME  SQL_PATH
+def           crdb_internal       NULL                        NULL
 def           information_schema  NULL                        NULL
 def           pg_catalog          NULL                        NULL
 def           system              NULL                        NULL
@@ -300,6 +302,7 @@ query TTTT colnames
 SELECT * FROM INFormaTION_SCHEMa.schemata
 ----
 CATALOG_NAME  SCHEMA_NAME         DEFAULT_CHARACTER_SET_NAME  SQL_PATH
+def           crdb_internal       NULL                        NULL
 def           information_schema  NULL                        NULL
 def           pg_catalog          NULL                        NULL
 def           system              NULL                        NULL
@@ -312,6 +315,7 @@ query TTTT colnames
 SELECT * FROM information_schema.schemata
 ----
 CATALOG_NAME  SCHEMA_NAME         DEFAULT_CHARACTER_SET_NAME  SQL_PATH
+def           crdb_internal       NULL                        NULL
 def           information_schema  NULL                        NULL
 def           other_db            NULL                        NULL
 def           pg_catalog          NULL                        NULL
@@ -335,6 +339,11 @@ CREATE VIEW other_db.abc AS SELECT i from other_db.xyz
 query T
 SELECT table_name FROM information_schema.tables
 ----
+leases
+schema_changes
+sessions
+tables
+txns
 columns
 key_column_usage
 schema_privileges
@@ -378,12 +387,16 @@ xyz
 views
 users
 ui
+txns
+tables
 tables
 table_privileges
 table_constraints
 statistics
+sessions
 schemata
 schema_privileges
+schema_changes
 rangelog
 pg_views
 pg_type
@@ -406,6 +419,11 @@ query TTTTI colnames
 SELECT * FROM information_schema.tables
 ----
 TABLE_CATALOG  TABLE_SCHEMA        TABLE_NAME         TABLE_TYPE   VERSION
+def            crdb_internal       leases             SYSTEM VIEW  1
+def            crdb_internal       schema_changes     SYSTEM VIEW  1
+def            crdb_internal       sessions           SYSTEM VIEW  1
+def            crdb_internal       tables             SYSTEM VIEW  1
+def            crdb_internal       txns               SYSTEM VIEW  1
 def            information_schema  columns            SYSTEM VIEW  1
 def            information_schema  key_column_usage   SYSTEM VIEW  1
 def            information_schema  schema_privileges  SYSTEM VIEW  1
@@ -456,6 +474,11 @@ query TTTTI colnames
 SELECT * FROM information_schema.tables
 ----
 TABLE_CATALOG  TABLE_SCHEMA        TABLE_NAME         TABLE_TYPE   VERSION
+def            crdb_internal       leases             SYSTEM VIEW  1
+def            crdb_internal       schema_changes     SYSTEM VIEW  1
+def            crdb_internal       sessions           SYSTEM VIEW  1
+def            crdb_internal       tables             SYSTEM VIEW  1
+def            crdb_internal       txns               SYSTEM VIEW  1
 def            information_schema  columns            SYSTEM VIEW  1
 def            information_schema  key_column_usage   SYSTEM VIEW  1
 def            information_schema  schema_privileges  SYSTEM VIEW  1
@@ -492,6 +515,11 @@ query TTTTI colnames
 SELECT * FROM information_schema.tables
 ----
 TABLE_CATALOG  TABLE_SCHEMA        TABLE_NAME         TABLE_TYPE   VERSION
+def            crdb_internal       leases             SYSTEM VIEW  1
+def            crdb_internal       schema_changes     SYSTEM VIEW  1
+def            crdb_internal       sessions           SYSTEM VIEW  1
+def            crdb_internal       tables             SYSTEM VIEW  1
+def            crdb_internal       txns               SYSTEM VIEW  1
 def            information_schema  columns            SYSTEM VIEW  1
 def            information_schema  key_column_usage   SYSTEM VIEW  1
 def            information_schema  schema_privileges  SYSTEM VIEW  1

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -136,6 +136,7 @@ SELECT * FROM pg_catalog.pg_namespace
 ----
 oid         nspname             nspowner  aclitem
 3061586988  constraint_db       NULL      NULL
+1685686813  crdb_internal       NULL      NULL
 3816276882  information_schema  NULL      NULL
 3178318485  pg_catalog          NULL      NULL
 1793492844  system              NULL      NULL
@@ -625,6 +626,7 @@ FROM pg_catalog.pg_database
 ORDER BY oid
 ----
 oid         datname             datdba  encoding  datcollate  datctype    datistemplate  datallowconn
+1685686813  crdb_internal       NULL    6         en_US.utf8  en_US.utf8  false          true
 1793492844  system              NULL    6         en_US.utf8  en_US.utf8  false          true
 2091240128  test                NULL    6         en_US.utf8  en_US.utf8  false          true
 3061586988  constraint_db       NULL    6         en_US.utf8  en_US.utf8  false          true
@@ -637,6 +639,7 @@ FROM pg_catalog.pg_database
 ORDER BY oid
 ----
 oid         datname             datconnlimit  datlastsysoid  datfrozenxid  datminmxid  dattablespace  datacl
+1685686813  crdb_internal       -1            NULL           NULL          NULL        NULL           NULL 
 1793492844  system              -1            NULL           NULL          NULL        NULL           NULL
 2091240128  test                -1            NULL           NULL          NULL        NULL           NULL
 3061586988  constraint_db       -1            NULL           NULL          NULL        NULL           NULL

--- a/pkg/sql/testdata/rename_database
+++ b/pkg/sql/testdata/rename_database
@@ -1,6 +1,7 @@
 query T
 SHOW DATABASES
 ----
+crdb_internal
 information_schema
 pg_catalog
 system
@@ -41,6 +42,7 @@ SHOW GRANTS ON DATABASE test
 query T
 SHOW DATABASES
 ----
+crdb_internal
 information_schema
 pg_catalog
 system
@@ -89,6 +91,7 @@ ALTER DATABASE t RENAME TO v
 query T
 SHOW DATABASES
 ----
+crdb_internal
 information_schema
 pg_catalog
 system

--- a/pkg/sql/testdata/system
+++ b/pkg/sql/testdata/system
@@ -1,6 +1,7 @@
 query T
 SHOW DATABASES
 ----
+crdb_internal
 information_schema
 pg_catalog
 system

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -54,6 +54,7 @@ type virtualSchemaTable struct {
 var virtualSchemas = []virtualSchema{
 	informationSchema,
 	pgCatalog,
+	crdbInternal,
 }
 
 //

--- a/pkg/ui/config.js
+++ b/pkg/ui/config.js
@@ -1153,10 +1153,24 @@ System.config({
       "hoek": "npm:hoek@2.16.3",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
+    "npm:source-map-support@0.4.6": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "child_process": "github:jspm/nodelibs-child_process@0.1.0",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "module": "github:jspm/nodelibs-module@0.1.0",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "querystring": "github:jspm/nodelibs-querystring@0.1.0",
+      "source-map": "npm:source-map@0.5.6"
+    },
     "npm:source-map@0.2.0": {
       "amdefine": "npm:amdefine@1.0.0",
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:source-map@0.5.6": {
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:sshpk@1.10.1": {
@@ -1236,7 +1250,8 @@ System.config({
     },
     "npm:typescript@2.0.3": {
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
-      "os": "github:jspm/nodelibs-os@0.1.0"
+      "os": "github:jspm/nodelibs-os@0.1.0",
+      "source-map-support": "npm:source-map-support@0.4.6"
     },
     "npm:ua-parser-js@0.7.10": {
       "systemjs-json": "github:systemjs/plugin-json@0.1.2"


### PR DESCRIPTION
This exposes the following virtual tables:
- `tables`: table descriptor details.
- `schema_changes`: schema changes currently ongoing.
- `sessions`: SQL sessions on the node where the query inspecting the
  `sessions` table is ran.
- `txns`: SQL transactions on the node where the query inspecting the
  `txns` table is ran.
- `leases`: table leases held on the node where the query inspecting
  the `leases` table is ran.

These tables are intended for debugging / troubleshooting purposes.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10317)

<!-- Reviewable:end -->
