### PR TITLE
storage: randomize rangeCountBalancer.selectBad

### DIFF
--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -738,7 +738,7 @@ func TestAllocatorRemoveTarget(t *testing.T) {
 		{
 			StoreID:  2,
 			Node:     roachpb.NodeDescriptor{NodeID: 2},
-			Capacity: roachpb.StoreCapacity{Capacity: 100, Available: 65, RangeCount: 12},
+			Capacity: roachpb.StoreCapacity{Capacity: 100, Available: 65, RangeCount: 14},
 		},
 		{
 			StoreID:  3,
@@ -754,7 +754,8 @@ func TestAllocatorRemoveTarget(t *testing.T) {
 	sg := gossiputil.NewStoreGossiper(g)
 	sg.GossipStores(stores, t)
 
-	targetRepl, err := a.RemoveTarget(replicas, stores[0].StoreID)
+	// Exclude store 2 as a removal target so that only store 3 is a candidate.
+	targetRepl, err := a.RemoveTarget(replicas, stores[1].StoreID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -762,14 +763,27 @@ func TestAllocatorRemoveTarget(t *testing.T) {
 		t.Fatalf("RemoveTarget did not select expected replica; expected %v, got %v", e, a)
 	}
 
-	// Now perform the same test, but pass in the store ID of store 3 so it's
-	// excluded.
+	// Now exclude store 3 so that only store 2 is a candidate.
 	targetRepl, err = a.RemoveTarget(replicas, stores[2].StoreID)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if a, e := targetRepl, replicas[1]; a != e {
 		t.Fatalf("RemoveTarget did not select expected replica; expected %v, got %v", e, a)
+	}
+
+	var counts [4]int
+	for i := 0; i < 100; i++ {
+		// Exclude store 1 as a removal target. We should see stores 2 and 3
+		// randomly selected as the removal target.
+		targetRepl, err := a.RemoveTarget(replicas, stores[0].StoreID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		counts[targetRepl.StoreID-1]++
+	}
+	if counts[0] != 0 || counts[3] != 0 || counts[1] == 0 || counts[2] == 0 {
+		t.Fatalf("unexpected removal target counts: %d", counts)
 	}
 }
 


### PR DESCRIPTION
Previously, we deterministically selected the "worst" replica as the
target for removal, but doing so caused a thundering herd effect where
an the worst store would have lots of replicas removed quickly and drop
to underfull.

```
_elapsed__ops/sec___errors_replicas_________1_________2_________3_________4
      1s   1072.0        0       18       6/1       6/0       5/0       1/0
      2s   1034.8        0       24       8/7       8/0       7/0       1/0
      3s   1032.7        0       30      10/8      10/0       9/0       1/0
      4s   1069.8        0       30     10/10      10/0       9/0       1/0
      5s    910.9        0       42     14/10      14/0      13/0       1/0
      6s   1007.9        0       42     14/14      14/0      13/0       1/0
      7s   1025.9        0       42     14/14      14/0      13/0       1/0
      8s    962.8        0       42     14/14      14/0      13/0       1/0
      9s    948.7        0       57     19/14      11/0      18/0       9/0
     10s   1011.1        0       66     22/15       6/0      21/0      17/0
     11s   1032.8        0       66     22/18       6/0      21/0      17/0
     12s    983.0        0       66     22/18       6/0      21/0      17/0
     13s    993.9        0       66     22/18       6/0      21/0      17/0
     14s   1022.6        0       66     22/18       6/0      21/0      17/0
     15s    874.9        0       66     22/18       6/0      21/0      17/0
     16s    834.2        0       72     24/18      11/0      18/0      19/0
     17s    868.9        0       87     29/20      21/0      13/0      24/0
     18s    861.2        0      102     34/25      31/0       8/0      29/0
     19s    950.3        0      108     36/30      35/0       6/0      31/0
     20s    929.9        0      114     38/32      38/0       5/0      33/0
```

We're not rebalancing away from node 1 because that node holds all of
the leases (see #9462). We initially rebalancing to node 4 from node 2,
but we do that too quickly because we lack randomization in the
selection of the removal target. When the periodic gossip (which occurs
on a 5s interval) occurs, node 2 is underfull and then we start
rebalancing away from node 3. This cycle repeats a few times until we
reach an equilibrium. With this change we see:

```
_elapsed__ops/sec___errors_replicas_________1_________2_________3_________4
      1s   1095.0        0       18       6/1       6/0       4/0       2/0
      2s   1048.9        0       24       8/7       8/0       6/0       2/0
      3s    980.8        0       30      10/8      10/0       8/0       2/0
      4s   1026.9        0       30     10/10      10/0       8/0       2/0
      5s    907.9        0       39     13/10      13/0      11/0       2/0
      6s   1011.9        0       42     14/13      14/0      12/0       2/0
      7s    966.9        0       42     14/14      14/0      12/0       2/0
      8s    881.9        0       42     14/14      14/0      12/0       2/0
      9s    806.9        0       48     16/14      15/0      11/0       6/0
     10s    927.9        0       66     22/12      14/0      12/0      18/0
     11s    910.9        0       66     22/18      14/0      12/0      18/0
```

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10330)
<!-- Reviewable:end -->
