### PR TITLE
sql: skip TestAmbiguousCommitDueToLeadershipChange

### DIFF
--- a/pkg/sql/ambiguous_commit_test.go
+++ b/pkg/sql/ambiguous_commit_test.go
@@ -45,6 +45,7 @@ import (
 // duplicate key violations. See #6053, #7604, and #10023.
 func TestAmbiguousCommitDueToLeadershipChange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("#10341")
 
 	// Create a command filter which prevents EndTransaction from
 	// returning a response.


### PR DESCRIPTION
It times out during `stress` (and also on my PR).

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10342)
<!-- Reviewable:end -->
