### PR TITLE
Adding FROM_IP and TO_IP builtins

### DIFF
--- a/pkg/sql/testdata/builtin_function
+++ b/pkg/sql/testdata/builtin_function
@@ -1146,3 +1146,31 @@ SELECT CURRENT_SCHEMAS(NULL::bool)
 ----
 NULL
 
+query T
+SELECT FROM_IP(b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x01\x02\x03\x04')
+----
+1.2.3.4
+
+query T
+SELECT FROM_IP(TO_IP('1.2.3.4'))
+----
+1.2.3.4
+
+# net.IP.String() always gives us the most succinct form of ipv6
+query T
+select FROM_IP(TO_IP('2001:0db8:85a3:0000:0000:8a2e:0370:7334'))
+----
+2001:db8:85a3::8a2e:370:7334
+
+query error pq: unknown signature for TO_IP: TO_IP()
+SELECT TO_IP()
+
+query error pq: FROM_IP: Zero length IP
+SELECT FROM_IP(b'')
+
+query error pq: TO_IP: Invalid IP format: ''
+SELECT TO_IP('')
+
+query error pq: TO_IP: Invalid IP format: 'asdf'
+select TO_IP('asdf')
+


### PR DESCRIPTION
This adds two methods, FROM_IP and TO_IP builtins.

FROM_IP() takes a single BYTES value representing a binary IPV6 type and returns an appropriate string representation of that IP.  For IPV4 addresses, this is in dotted decimal format (i.e., 1.2.3.4) and for IPV6, it is in colon seprated format in shortest form(i.e., 2001::1).  Note that IPV4 can be encoded in this format as well, by prefixing two bytes of FF to the normal 8 byte (this is handled for you automatically in the next method).

TO_IP() takes a string representing either an IPV4 or IPV6 address and returns BYTES binary representation.  This is useful for storing IP data into a BYTES column.

Storing IP data in BYTES types allows you to do range queries, as an example:

    root@:26257> create table foo(ip bytes not null);
    CREATE TABLE
    root@:26257> insert into foo(ip) values (to_ip('2002:0db8:85a3:1234:1234:8a2e:0370:7334'));
    INSERT 1
    root@:26257> insert into foo(ip) values (to_ip('2000:0db8:85a3:1234:1234:8a2e:0370:7334'));
    INSERT 1
    root@:26257> insert into foo(ip) values (to_ip('2000:0db8:85a3:0000:0000:8a2e:0370:7334'));
    INSERT 1
    root@:26257> insert into foo(ip) values (to_ip('1.2.3.4'));
    INSERT 1
    root@:26257> select from_ip(ip) as ip from foo;
    +---------------------------------------+
    |                  ip                   |
    +---------------------------------------+
    | 2002:db8:85a3:1234:1234:8a2e:370:7334 |
    | 2000:db8:85a3:1234:1234:8a2e:370:7334 |
    | 2000:db8:85a3::8a2e:370:7334          |
    | 1.2.3.4                               |
    +---------------------------------------+
    (4 rows)
    root@:26257> select from_ip(ip) as ip from foo where ip between to_ip('1.1.1.1') and to_ip('2.2.2.2');
    +---------+
    |   ip    |
    +---------+
    | 1.2.3.4 |
    +---------+
    (1 row)
    root@:26257> select from_ip(ip) as ip from foo where ip between to_ip('2000::1') and to_ip('2002::1');
    +---------------------------------------+
    |                  ip                   |
    +---------------------------------------+
    | 2000:db8:85a3:1234:1234:8a2e:370:7334 |
    | 2000:db8:85a3::8a2e:370:7334          |
    +---------------------------------------+
    (2 rows)
    root@:26257>

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10349)
<!-- Reviewable:end -->
