### PR TITLE
sql: add pg_catalog.pg_am meta table

### DIFF
--- a/pkg/sql/testdata/information_schema
+++ b/pkg/sql/testdata/information_schema
@@ -344,6 +344,7 @@ table_privileges
 tables
 abc
 xyz
+pg_am
 pg_attrdef
 pg_attribute
 pg_class
@@ -389,6 +390,7 @@ pg_constraint
 pg_class
 pg_attribute
 pg_attrdef
+pg_am
 namespace
 
 query TTTTI colnames
@@ -405,6 +407,7 @@ def            information_schema  table_privileges   SYSTEM VIEW  1
 def            information_schema  tables             SYSTEM VIEW  1
 def            other_db            abc                VIEW         1
 def            other_db            xyz                BASE TABLE   2
+def            pg_catalog          pg_am              SYSTEM VIEW  1
 def            pg_catalog          pg_attrdef         SYSTEM VIEW  1
 def            pg_catalog          pg_attribute       SYSTEM VIEW  1
 def            pg_catalog          pg_class           SYSTEM VIEW  1
@@ -448,6 +451,7 @@ def            information_schema  statistics         SYSTEM VIEW  1
 def            information_schema  table_constraints  SYSTEM VIEW  1
 def            information_schema  table_privileges   SYSTEM VIEW  1
 def            information_schema  tables             SYSTEM VIEW  1
+def            pg_catalog          pg_am              SYSTEM VIEW  1
 def            pg_catalog          pg_attrdef         SYSTEM VIEW  1
 def            pg_catalog          pg_attribute       SYSTEM VIEW  1
 def            pg_catalog          pg_class           SYSTEM VIEW  1
@@ -480,6 +484,7 @@ def            information_schema  table_constraints  SYSTEM VIEW  1
 def            information_schema  table_privileges   SYSTEM VIEW  1
 def            information_schema  tables             SYSTEM VIEW  1
 def            other_db            xyz                BASE TABLE   6
+def            pg_catalog          pg_am              SYSTEM VIEW  1
 def            pg_catalog          pg_attrdef         SYSTEM VIEW  1
 def            pg_catalog          pg_attribute       SYSTEM VIEW  1
 def            pg_catalog          pg_class           SYSTEM VIEW  1
@@ -558,7 +563,7 @@ CREATE TABLE constraint_column.t1 (
   a INT UNIQUE,
   b INT,
   c INT,
-  UNIQUE INDEX index_key(b, c) 
+  UNIQUE INDEX index_key(b, c)
 )
 
 statement ok

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -44,6 +44,7 @@ SET DATABASE = test
 query T
 SHOW TABLES FROM pg_catalog
 ----
+pg_am
 pg_attrdef
 pg_attribute
 pg_class
@@ -167,7 +168,7 @@ constraint_db  v1        NULL       SELECT p, a, b, c FROM constraint_db.t1
 
 query ITIIIIII colnames
 SELECT c.oid, relname, relnamespace, reltype, relowner, relam, relfilenode, reltablespace
-FROM pg_catalog.pg_class c 
+FROM pg_catalog.pg_class c
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'constraint_db'
 ----
@@ -186,7 +187,7 @@ oid         relname       relnamespace  reltype  relowner  relam  relfilenode  r
 
 query TIRIIBB colnames
 SELECT relname, relpages, reltuples, relallvisible, reltoastrelid, relhasindex, relisshared
-FROM pg_catalog.pg_class c 
+FROM pg_catalog.pg_class c
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'constraint_db'
 ----
@@ -205,7 +206,7 @@ v1            NULL      NULL       0              0              false        fa
 
 query TBTIIBB colnames
 SELECT relname, relistemp, relkind, relnatts, relchecks, relhasoids, relhaspkey
-FROM pg_catalog.pg_class c 
+FROM pg_catalog.pg_class c
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'constraint_db'
 ----
@@ -224,7 +225,7 @@ v1            false      v        4         0          false       false
 
 query TBBBITT colnames
 SELECT relname, relhasrules, relhastriggers, relhassubclass, relfrozenxid, relacl, reloptions
-FROM pg_catalog.pg_class c 
+FROM pg_catalog.pg_class c
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'constraint_db'
 ----
@@ -326,6 +327,16 @@ v1            p        false         true        0            NULL    NULL      
 v1            a        false         true        0            NULL    NULL        NULL
 v1            b        false         true        0            NULL    NULL        NULL
 v1            c        false         true        0            NULL    NULL        NULL
+
+
+## pg_catalog.pg_am
+
+query ITIT colnames
+SELECT *
+FROM pg_catalog.pg_am
+----
+oid         amname  amhandler  amtype
+2631952481  prefix  NULL       i
 
 ## pg_catalog.pg_attrdef
 


### PR DESCRIPTION
in postgres 9.6 the pg_am table was dramatically cut back, from 30 cols to 4, with some pg_ functions
instead providing some of the old information. we only offer one index method for now, so this is a
relatively trivial table implemented only for compatibility with an orm or tool that expects it to
exist.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10363)
<!-- Reviewable:end -->
