### PR TITLE
distsql: flow diagram generator

### DIFF
--- a/pkg/sql/distsql/flow_diagram.go
+++ b/pkg/sql/distsql/flow_diagram.go
@@ -1,0 +1,318 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package distsql
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"io"
+)
+
+type diagramCell interface {
+	// lines produces a title and an arbitrary number of lines that describe a
+	// "cell" in a diagram node (input sync, processor core, or output router).
+	lines() (string, []string)
+}
+
+func (ord *Ordering) diagramString() string {
+	var buf bytes.Buffer
+	for i, c := range ord.Columns {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		fmt.Fprintf(&buf, "%d", c.ColIdx)
+		if c.Direction == Ordering_Column_DESC {
+			buf.WriteByte('-')
+		} else {
+			buf.WriteByte('+')
+		}
+	}
+	return buf.String()
+}
+
+func colListStr(cols []uint32) string {
+	var buf bytes.Buffer
+	for i, c := range cols {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		fmt.Fprintf(&buf, "%d", c)
+	}
+	return buf.String()
+}
+
+func (*NoopCoreSpec) lines() (string, []string) {
+	return "No-op", nil
+}
+
+func (tr *TableReaderSpec) lines() (string, []string) {
+	index := "primary"
+	if tr.IndexIdx > 0 {
+		index = tr.Table.Indexes[tr.IndexIdx-1].Name
+	}
+	lines := []string{
+		fmt.Sprintf("%s@%s", index, tr.Table.Name),
+		colListStr(tr.OutputColumns),
+	}
+	if tr.Filter.Expr != "" {
+		lines = append(lines, tr.Filter.Expr)
+	}
+	// TODO(radu): a summary of the spans
+	return "TableReader", lines
+}
+
+func (jr *JoinReaderSpec) lines() (string, []string) {
+	index := "primary"
+	if jr.IndexIdx > 0 {
+		index = jr.Table.Indexes[jr.IndexIdx-1].Name
+	}
+	lines := []string{
+		fmt.Sprintf("%s@%s", index, jr.Table.Name),
+		colListStr(jr.OutputColumns),
+	}
+	if jr.Filter.Expr != "" {
+		lines = append(lines, jr.Filter.Expr)
+	}
+	return "JoinReader", lines
+}
+
+func (hj *HashJoinerSpec) lines() (string, []string) {
+	lines := []string{
+		fmt.Sprintf(
+			"ON left(%s)=right(%s)", colListStr(hj.LeftEqColumns), colListStr(hj.RightEqColumns),
+		),
+		colListStr(hj.OutputColumns),
+	}
+	if hj.Expr.Expr != "" {
+		lines = append(lines, hj.Expr.Expr)
+	}
+	return "HashJoiner", lines
+}
+
+// TODO(radu): implement node() for other core types.
+
+func (is *InputSyncSpec) lines() (string, []string) {
+	switch is.Type {
+	case InputSyncSpec_UNORDERED:
+		return "unordered", nil
+	case InputSyncSpec_ORDERED:
+		return "ordered", []string{is.Ordering.diagramString()}
+	default:
+		return "unknown", nil
+	}
+}
+
+func (r *OutputRouterSpec) lines() (string, []string) {
+	switch r.Type {
+	case OutputRouterSpec_MIRROR:
+		return "mirror", nil
+	case OutputRouterSpec_BY_HASH:
+		return "by hash", []string{colListStr(r.HashColumns)}
+	case OutputRouterSpec_BY_RANGE:
+		return "by range", nil
+	default:
+		return "unknown", nil
+	}
+}
+
+// GeneratePlanDiagram generates a diagram of a set of flows in DOT format.
+// There should be one `FlowSpec` per node. The function assumes that StreamIDs
+// are unique across all specs.
+func GeneratePlanDiagram(flows []FlowSpec, nodeNames []string, w io.Writer) error {
+	// inPorts[streamID] will be populated with the node:port for the input
+	// synchronizer for that stream.
+	inPorts := make(map[StreamID]string)
+
+	fmt.Fprintln(w, "digraph G {")
+	for n := range flows {
+		fmt.Fprintf(w, "subgraph cluster_%d {\n", n)
+		fmt.Fprintf(w, "label=\"node %s\"\n", nodeNames[n])
+
+		simpleResponse := false
+
+		for pIdx, p := range flows[n].Processors {
+			var info procDiagramInfo
+			info.Core.Title, info.Core.ExtraLines = p.Core.GetValue().(diagramCell).lines()
+			procName := fmt.Sprintf("p%d_%d", n, pIdx)
+
+			// See if we need explicit synchronizer boxes.
+			syncBoxes := false
+			for _, s := range p.Input {
+				if len(s.Streams) > 1 {
+					syncBoxes = true
+					break
+				}
+			}
+
+			for i, input := range p.Input {
+				var port string
+				if syncBoxes {
+					port = fmt.Sprintf("%s:in%d", procName, i)
+				} else {
+					port = procName + ":core"
+				}
+				for _, stream := range input.Streams {
+					inPorts[stream.StreamID] = port
+				}
+			}
+
+			// See if we need explicit router boxes.
+			routerBoxes := false
+			for _, r := range p.Output {
+				if len(r.Streams) > 1 {
+					routerBoxes = true
+				}
+				for _, o := range r.Streams {
+					if o.Mailbox != nil && o.Mailbox.SimpleResponse {
+						simpleResponse = true
+					}
+				}
+			}
+
+			numCols := 1
+			if syncBoxes {
+				numCols = len(p.Input)*2 + 1
+			}
+			if routerBoxes {
+				v := len(p.Output)*2 + 1
+				if numCols < v {
+					numCols = v
+				}
+			}
+			info.NumCols = numCols
+			info.Core.Port = "core"
+			if syncBoxes {
+				info.Inputs = make([]cellContents, numCols)
+				// We have numCols columns and len(p.Input) boxes we want to space
+				// evenly. There are (numCols - len(p.input)) empty columns and
+				// len(p.Input)+1 spaces.
+				spacing := (numCols - len(p.Input)) / (len(p.Input) + 1)
+				for i, s := range p.Input {
+					var c cellContents
+					c.Title, c.ExtraLines = s.lines()
+					c.Port = fmt.Sprintf("in%d", i)
+					info.Inputs[spacing+(spacing+1)*i] = c
+				}
+			}
+			if routerBoxes {
+				info.Outputs = make([]cellContents, numCols)
+				spacing := (numCols - len(p.Output)) / (len(p.Output) + 1)
+				for i, r := range p.Output {
+					var c cellContents
+					c.Title, c.ExtraLines = r.lines()
+					c.Port = fmt.Sprintf("out%d", i)
+					info.Outputs[spacing+(spacing+1)*i] = c
+				}
+			}
+			fmt.Fprintf(w, "%s [shape=none margin=0 label=<\n", procName)
+			if err := info.genHTML(w); err != nil {
+				return err
+			}
+			fmt.Fprintln(w, "> ]")
+		}
+
+		if simpleResponse {
+			fmt.Fprintln(w, "SimpleResponse")
+		}
+
+		fmt.Fprintln(w, "}")
+	}
+
+	// Produce the edges.
+	for n := range flows {
+		for pIdx, p := range flows[n].Processors {
+			procName := fmt.Sprintf("p%d_%d", n, pIdx)
+
+			// See if we have explicit router boxes.
+			routerBoxes := false
+			for _, r := range p.Output {
+				if len(r.Streams) > 1 {
+					routerBoxes = true
+					break
+				}
+			}
+
+			for i, output := range p.Output {
+				var port string
+				if routerBoxes {
+					port = fmt.Sprintf("%s:out%d", procName, i)
+				} else {
+					port = procName + ":core"
+				}
+				for _, o := range output.Streams {
+					if o.Mailbox != nil && o.Mailbox.SimpleResponse {
+						fmt.Fprintf(w, "%s -> SimpleResponse\n", port)
+					} else {
+						if to, ok := inPorts[o.StreamID]; !ok {
+							fmt.Fprintf(w, "%s -> unknown\n", port)
+						} else {
+							fmt.Fprintf(w, "%s -> %s\n", port, to)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	fmt.Fprintln(w, "}")
+	return nil
+}
+
+type cellContents struct {
+	Title      string
+	ExtraLines []string
+	Port       string
+}
+
+// procDiagramInfo contains the information needed to generate a HTML label for
+// a diagram node.
+type procDiagramInfo struct {
+	Inputs  []cellContents
+	Core    cellContents
+	NumCols int
+	Outputs []cellContents
+}
+
+func (p procDiagramInfo) genHTML(w io.Writer) error {
+	return processorHTMLTemplate.Execute(w, p)
+}
+
+// processorHTML is a template for creating the HTML label of processor nodes.
+// Note that the <TD> ... </TD> lines cannot be broken up: it looks like the
+// extra whitespace ends up being displayed.
+const processorHTML = `
+<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0" CELLPADDING="4">
+{{if .Inputs}}<TR>
+{{range .Inputs}}{{if .Title}}
+  <TD BORDER="1" BGCOLOR="YELLOW"{{if .Port}} port="{{.Port}}"{{end}}><FONT POINT-SIZE="10">{{.Title}}</FONT>{{range .ExtraLines}}<BR/><FONT POINT-SIZE="9">{{.}}</FONT>{{end}}</TD>
+  {{else}}<TD WIDTH="20"></TD>
+{{end}}{{end}}
+</TR>{{end}}
+<TR>
+  <TD BORDER="1" COLSPAN="{{.NumCols}}" BGCOLOR="SKYBLUE"{{if .Core.Port}} port="{{.Core.Port}}"{{end}}>{{.Core.Title}}{{range .Core.ExtraLines}}<BR/><FONT POINT-SIZE="10">{{.}}</FONT>{{end}}</TD>
+</TR>
+{{if .Outputs}}<TR>
+{{range .Outputs}}{{if .Title}}
+  <TD BORDER="1" BGCOLOR="RED"{{if .Port}} port="{{.Port}}"{{end}}><FONT POINT-SIZE="10">{{.Title}}</FONT>{{range .ExtraLines}}<BR/><FONT POINT-SIZE="9">{{.}}</FONT>{{end}}</TD>
+  {{else}}<TD WIDTH="20"></TD>
+{{end}}{{end}}
+</TR>{{end}}
+</TABLE>
+`
+
+var processorHTMLTemplate = template.Must(template.New("processor").Parse(processorHTML))

--- a/pkg/sql/distsql/flow_diagram_test.go
+++ b/pkg/sql/distsql/flow_diagram_test.go
@@ -1,0 +1,572 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package distsql
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestProcessorHTML(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	p := procDiagramInfo{
+		Inputs: []cellContents{
+			{},
+			{Title: "ordered", ExtraLines: []string{"1+ 2-"}, Port: "in0"},
+			{},
+			{Title: "unordered", Port: "in1"},
+			{},
+		},
+		Core: cellContents{
+			Title:      "MergeJoin",
+			ExtraLines: []string{"on 0,2", "filter: $1+$2=$3"},
+		},
+		NumCols: 5,
+		Outputs: []cellContents{
+			{},
+			{},
+			{Title: "mirror", Port: "out0"},
+			{},
+			{},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := p.genHTML(&buf); err != nil {
+		fmt.Printf("Error: %s\n", err)
+	}
+	result := buf.String()
+	expected := `
+<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0" CELLPADDING="4">
+<TR>
+<TD WIDTH="20"></TD>
+
+  <TD BORDER="1" BGCOLOR="YELLOW" port="in0"><FONT POINT-SIZE="10">ordered</FONT><BR/><FONT POINT-SIZE="9">1&#43; 2-</FONT></TD>
+  <TD WIDTH="20"></TD>
+
+  <TD BORDER="1" BGCOLOR="YELLOW" port="in1"><FONT POINT-SIZE="10">unordered</FONT></TD>
+  <TD WIDTH="20"></TD>
+
+</TR>
+<TR>
+  <TD BORDER="1" COLSPAN="5" BGCOLOR="SKYBLUE">MergeJoin<BR/><FONT POINT-SIZE="10">on 0,2</FONT><BR/><FONT POINT-SIZE="10">filter: $1&#43;$2=$3</FONT></TD>
+</TR>
+<TR>
+<TD WIDTH="20"></TD>
+<TD WIDTH="20"></TD>
+
+  <TD BORDER="1" BGCOLOR="RED" port="out0"><FONT POINT-SIZE="10">mirror</FONT></TD>
+  <TD WIDTH="20"></TD>
+<TD WIDTH="20"></TD>
+
+</TR>
+</TABLE>
+`
+
+	if result != expected {
+		t.Errorf("\ngot:\n%s\nwant:\n%s", result, expected)
+	}
+}
+
+func TestPlanDiagram(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	desc := &sqlbase.TableDescriptor{
+		Name:    "Table",
+		Indexes: []sqlbase.IndexDescriptor{{Name: "SomeIndex"}},
+	}
+	tr := TableReaderSpec{
+		Table:         *desc,
+		IndexIdx:      1,
+		OutputColumns: []uint32{0, 1},
+	}
+
+	jr := JoinReaderSpec{
+		Table:         *desc,
+		OutputColumns: []uint32{2},
+		Filter:        Expression{Expr: "$0+$1<$2"},
+	}
+
+	f1 := FlowSpec{
+		Processors: []ProcessorSpec{{
+			Core: ProcessorCoreUnion{TableReader: &tr},
+			Output: []OutputRouterSpec{{
+				Type: OutputRouterSpec_MIRROR,
+				Streams: []StreamEndpointSpec{
+					{StreamID: 0},
+				},
+			}},
+		}},
+	}
+
+	f2 := FlowSpec{
+		Processors: []ProcessorSpec{{
+			Core: ProcessorCoreUnion{TableReader: &tr},
+			Output: []OutputRouterSpec{{
+				Type: OutputRouterSpec_MIRROR,
+				Streams: []StreamEndpointSpec{
+					{StreamID: 1},
+				},
+			}},
+		}},
+	}
+
+	f3 := FlowSpec{
+		Processors: []ProcessorSpec{
+			{
+				Core: ProcessorCoreUnion{TableReader: &tr},
+				Output: []OutputRouterSpec{{
+					Type: OutputRouterSpec_MIRROR,
+					Streams: []StreamEndpointSpec{
+						{StreamID: StreamID(2)},
+					},
+				}},
+			},
+			{
+				Input: []InputSyncSpec{{
+					Type:     InputSyncSpec_ORDERED,
+					Ordering: Ordering{Columns: []Ordering_Column{{1, Ordering_Column_ASC}}},
+					Streams: []StreamEndpointSpec{
+						{StreamID: 0},
+						{StreamID: 1},
+						{StreamID: 2},
+					},
+				}},
+				Core: ProcessorCoreUnion{JoinReader: &jr},
+				Output: []OutputRouterSpec{{
+					Type:    OutputRouterSpec_MIRROR,
+					Streams: []StreamEndpointSpec{{Mailbox: &MailboxSpec{SimpleResponse: true}}},
+				}}},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := GeneratePlanDiagram(
+		[]FlowSpec{f1, f2, f3}, []string{"1", "2", "3"}, &buf,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `digraph G {
+subgraph cluster_0 {
+label="node 1"
+p0_0 [shape=none margin=0 label=<
+
+<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0" CELLPADDING="4">
+
+<TR>
+  <TD BORDER="1" COLSPAN="1" BGCOLOR="SKYBLUE" port="core">TableReader<BR/><FONT POINT-SIZE="10">SomeIndex@Table</FONT><BR/><FONT POINT-SIZE="10">0,1</FONT></TD>
+</TR>
+
+</TABLE>
+> ]
+}
+subgraph cluster_1 {
+label="node 2"
+p1_0 [shape=none margin=0 label=<
+
+<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0" CELLPADDING="4">
+
+<TR>
+  <TD BORDER="1" COLSPAN="1" BGCOLOR="SKYBLUE" port="core">TableReader<BR/><FONT POINT-SIZE="10">SomeIndex@Table</FONT><BR/><FONT POINT-SIZE="10">0,1</FONT></TD>
+</TR>
+
+</TABLE>
+> ]
+}
+subgraph cluster_2 {
+label="node 3"
+p2_0 [shape=none margin=0 label=<
+
+<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0" CELLPADDING="4">
+
+<TR>
+  <TD BORDER="1" COLSPAN="1" BGCOLOR="SKYBLUE" port="core">TableReader<BR/><FONT POINT-SIZE="10">SomeIndex@Table</FONT><BR/><FONT POINT-SIZE="10">0,1</FONT></TD>
+</TR>
+
+</TABLE>
+> ]
+p2_1 [shape=none margin=0 label=<
+
+<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0" CELLPADDING="4">
+<TR>
+<TD WIDTH="20"></TD>
+
+  <TD BORDER="1" BGCOLOR="YELLOW" port="in0"><FONT POINT-SIZE="10">ordered</FONT><BR/><FONT POINT-SIZE="9">1&#43;</FONT></TD>
+  <TD WIDTH="20"></TD>
+
+</TR>
+<TR>
+  <TD BORDER="1" COLSPAN="3" BGCOLOR="SKYBLUE" port="core">JoinReader<BR/><FONT POINT-SIZE="10">primary@Table</FONT><BR/><FONT POINT-SIZE="10">2</FONT><BR/><FONT POINT-SIZE="10">$0&#43;$1&lt;$2</FONT></TD>
+</TR>
+
+</TABLE>
+> ]
+SimpleResponse
+}
+p0_0:core -> p2_1:in0
+p1_0:core -> p2_1:in0
+p2_0:core -> p2_1:in0
+p2_1:core -> SimpleResponse
+}
+`
+	if result := buf.String(); result != expected {
+		t.Errorf("\ngot:\n%s\nwant:\n%s", result, expected)
+	}
+}
+
+func TestPlanDiagramJoin(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	descA := &sqlbase.TableDescriptor{Name: "TableA"}
+	descB := &sqlbase.TableDescriptor{Name: "TableB"}
+
+	trA := TableReaderSpec{
+		Table:         *descA,
+		OutputColumns: []uint32{0, 1, 3},
+	}
+
+	trB := TableReaderSpec{
+		Table:         *descB,
+		OutputColumns: []uint32{1, 2, 4},
+	}
+
+	hj := HashJoinerSpec{
+		LeftEqColumns:  []uint32{0, 2},
+		RightEqColumns: []uint32{2, 1},
+		OutputColumns:  []uint32{0, 1, 2, 3, 4, 5},
+		Expr:           Expression{Expr: "$0+$1<$5"},
+	}
+
+	f1 := FlowSpec{
+		Processors: []ProcessorSpec{
+			{
+				Core: ProcessorCoreUnion{TableReader: &trA},
+				Output: []OutputRouterSpec{{
+					Type:        OutputRouterSpec_BY_HASH,
+					HashColumns: []uint32{0, 1},
+					Streams: []StreamEndpointSpec{
+						{StreamID: 11},
+						{StreamID: 12},
+					},
+				}},
+			},
+		},
+	}
+
+	f2 := FlowSpec{
+		Processors: []ProcessorSpec{
+			{
+				Core: ProcessorCoreUnion{TableReader: &trA},
+				Output: []OutputRouterSpec{{
+					Type:        OutputRouterSpec_BY_HASH,
+					HashColumns: []uint32{0, 1},
+					Streams: []StreamEndpointSpec{
+						{StreamID: 21},
+						{StreamID: 22},
+					},
+				}},
+			},
+			{
+				Input: []InputSyncSpec{
+					{
+						Type: InputSyncSpec_UNORDERED,
+						Streams: []StreamEndpointSpec{
+							{StreamID: 11},
+							{StreamID: 21},
+							{StreamID: 31},
+						},
+					},
+					{
+						Type: InputSyncSpec_UNORDERED,
+						Streams: []StreamEndpointSpec{
+							{StreamID: 41},
+							{StreamID: 51},
+						},
+					},
+				},
+				Core: ProcessorCoreUnion{HashJoiner: &hj},
+				Output: []OutputRouterSpec{{
+					Type: OutputRouterSpec_MIRROR,
+					Streams: []StreamEndpointSpec{
+						{StreamID: 101},
+					},
+				}},
+			},
+			{
+				Input: []InputSyncSpec{{
+					Type: InputSyncSpec_UNORDERED,
+					Streams: []StreamEndpointSpec{
+						{StreamID: 101},
+						{StreamID: 102},
+					},
+				}},
+				Core: ProcessorCoreUnion{Noop: &NoopCoreSpec{}},
+				Output: []OutputRouterSpec{{
+					Type:    OutputRouterSpec_MIRROR,
+					Streams: []StreamEndpointSpec{{Mailbox: &MailboxSpec{SimpleResponse: true}}},
+				}}},
+		},
+	}
+
+	f3 := FlowSpec{
+		Processors: []ProcessorSpec{
+			{
+				Core: ProcessorCoreUnion{TableReader: &trA},
+				Output: []OutputRouterSpec{{
+					Type:        OutputRouterSpec_BY_HASH,
+					HashColumns: []uint32{0, 1},
+					Streams: []StreamEndpointSpec{
+						{StreamID: 31},
+						{StreamID: 32},
+					},
+				}},
+			},
+			{
+				Core: ProcessorCoreUnion{TableReader: &trB},
+				Output: []OutputRouterSpec{{
+					Type:        OutputRouterSpec_BY_HASH,
+					HashColumns: []uint32{2, 1},
+					Streams: []StreamEndpointSpec{
+						{StreamID: 41},
+						{StreamID: 42},
+					},
+				}},
+			},
+			{
+				Input: []InputSyncSpec{
+					{
+						Type: InputSyncSpec_UNORDERED,
+						Streams: []StreamEndpointSpec{
+							{StreamID: 12},
+							{StreamID: 22},
+							{StreamID: 32},
+						},
+					},
+					{
+						Type: InputSyncSpec_UNORDERED,
+						Streams: []StreamEndpointSpec{
+							{StreamID: 42},
+							{StreamID: 52},
+						},
+					},
+				},
+				Core: ProcessorCoreUnion{HashJoiner: &hj},
+				Output: []OutputRouterSpec{{
+					Type: OutputRouterSpec_MIRROR,
+					Streams: []StreamEndpointSpec{
+						{StreamID: 101},
+					},
+				}},
+			},
+		},
+	}
+
+	f4 := FlowSpec{
+		Processors: []ProcessorSpec{{
+			Core: ProcessorCoreUnion{TableReader: &trB},
+			Output: []OutputRouterSpec{{
+				Type:        OutputRouterSpec_BY_HASH,
+				HashColumns: []uint32{2, 1},
+				Streams: []StreamEndpointSpec{
+					{StreamID: 51},
+					{StreamID: 52},
+				},
+			}},
+		}},
+	}
+
+	var buf bytes.Buffer
+	if err := GeneratePlanDiagram(
+		[]FlowSpec{f1, f2, f3, f4}, []string{"1", "2", "3", "4"}, &buf,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `digraph G {
+subgraph cluster_0 {
+label="node 1"
+p0_0 [shape=none margin=0 label=<
+
+<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0" CELLPADDING="4">
+
+<TR>
+  <TD BORDER="1" COLSPAN="3" BGCOLOR="SKYBLUE" port="core">TableReader<BR/><FONT POINT-SIZE="10">primary@TableA</FONT><BR/><FONT POINT-SIZE="10">0,1,3</FONT></TD>
+</TR>
+<TR>
+<TD WIDTH="20"></TD>
+
+  <TD BORDER="1" BGCOLOR="RED" port="out0"><FONT POINT-SIZE="10">by hash</FONT><BR/><FONT POINT-SIZE="9">0,1</FONT></TD>
+  <TD WIDTH="20"></TD>
+
+</TR>
+</TABLE>
+> ]
+}
+subgraph cluster_1 {
+label="node 2"
+p1_0 [shape=none margin=0 label=<
+
+<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0" CELLPADDING="4">
+
+<TR>
+  <TD BORDER="1" COLSPAN="3" BGCOLOR="SKYBLUE" port="core">TableReader<BR/><FONT POINT-SIZE="10">primary@TableA</FONT><BR/><FONT POINT-SIZE="10">0,1,3</FONT></TD>
+</TR>
+<TR>
+<TD WIDTH="20"></TD>
+
+  <TD BORDER="1" BGCOLOR="RED" port="out0"><FONT POINT-SIZE="10">by hash</FONT><BR/><FONT POINT-SIZE="9">0,1</FONT></TD>
+  <TD WIDTH="20"></TD>
+
+</TR>
+</TABLE>
+> ]
+p1_1 [shape=none margin=0 label=<
+
+<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0" CELLPADDING="4">
+<TR>
+<TD WIDTH="20"></TD>
+
+  <TD BORDER="1" BGCOLOR="YELLOW" port="in0"><FONT POINT-SIZE="10">unordered</FONT></TD>
+  <TD WIDTH="20"></TD>
+
+  <TD BORDER="1" BGCOLOR="YELLOW" port="in1"><FONT POINT-SIZE="10">unordered</FONT></TD>
+  <TD WIDTH="20"></TD>
+
+</TR>
+<TR>
+  <TD BORDER="1" COLSPAN="5" BGCOLOR="SKYBLUE" port="core">HashJoiner<BR/><FONT POINT-SIZE="10">ON left(0,2)=right(2,1)</FONT><BR/><FONT POINT-SIZE="10">0,1,2,3,4,5</FONT><BR/><FONT POINT-SIZE="10">$0&#43;$1&lt;$5</FONT></TD>
+</TR>
+
+</TABLE>
+> ]
+p1_2 [shape=none margin=0 label=<
+
+<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0" CELLPADDING="4">
+<TR>
+<TD WIDTH="20"></TD>
+
+  <TD BORDER="1" BGCOLOR="YELLOW" port="in0"><FONT POINT-SIZE="10">unordered</FONT></TD>
+  <TD WIDTH="20"></TD>
+
+</TR>
+<TR>
+  <TD BORDER="1" COLSPAN="3" BGCOLOR="SKYBLUE" port="core">No-op</TD>
+</TR>
+
+</TABLE>
+> ]
+SimpleResponse
+}
+subgraph cluster_2 {
+label="node 3"
+p2_0 [shape=none margin=0 label=<
+
+<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0" CELLPADDING="4">
+
+<TR>
+  <TD BORDER="1" COLSPAN="3" BGCOLOR="SKYBLUE" port="core">TableReader<BR/><FONT POINT-SIZE="10">primary@TableA</FONT><BR/><FONT POINT-SIZE="10">0,1,3</FONT></TD>
+</TR>
+<TR>
+<TD WIDTH="20"></TD>
+
+  <TD BORDER="1" BGCOLOR="RED" port="out0"><FONT POINT-SIZE="10">by hash</FONT><BR/><FONT POINT-SIZE="9">0,1</FONT></TD>
+  <TD WIDTH="20"></TD>
+
+</TR>
+</TABLE>
+> ]
+p2_1 [shape=none margin=0 label=<
+
+<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0" CELLPADDING="4">
+
+<TR>
+  <TD BORDER="1" COLSPAN="3" BGCOLOR="SKYBLUE" port="core">TableReader<BR/><FONT POINT-SIZE="10">primary@TableB</FONT><BR/><FONT POINT-SIZE="10">1,2,4</FONT></TD>
+</TR>
+<TR>
+<TD WIDTH="20"></TD>
+
+  <TD BORDER="1" BGCOLOR="RED" port="out0"><FONT POINT-SIZE="10">by hash</FONT><BR/><FONT POINT-SIZE="9">2,1</FONT></TD>
+  <TD WIDTH="20"></TD>
+
+</TR>
+</TABLE>
+> ]
+p2_2 [shape=none margin=0 label=<
+
+<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0" CELLPADDING="4">
+<TR>
+<TD WIDTH="20"></TD>
+
+  <TD BORDER="1" BGCOLOR="YELLOW" port="in0"><FONT POINT-SIZE="10">unordered</FONT></TD>
+  <TD WIDTH="20"></TD>
+
+  <TD BORDER="1" BGCOLOR="YELLOW" port="in1"><FONT POINT-SIZE="10">unordered</FONT></TD>
+  <TD WIDTH="20"></TD>
+
+</TR>
+<TR>
+  <TD BORDER="1" COLSPAN="5" BGCOLOR="SKYBLUE" port="core">HashJoiner<BR/><FONT POINT-SIZE="10">ON left(0,2)=right(2,1)</FONT><BR/><FONT POINT-SIZE="10">0,1,2,3,4,5</FONT><BR/><FONT POINT-SIZE="10">$0&#43;$1&lt;$5</FONT></TD>
+</TR>
+
+</TABLE>
+> ]
+}
+subgraph cluster_3 {
+label="node 4"
+p3_0 [shape=none margin=0 label=<
+
+<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0" CELLPADDING="4">
+
+<TR>
+  <TD BORDER="1" COLSPAN="3" BGCOLOR="SKYBLUE" port="core">TableReader<BR/><FONT POINT-SIZE="10">primary@TableB</FONT><BR/><FONT POINT-SIZE="10">1,2,4</FONT></TD>
+</TR>
+<TR>
+<TD WIDTH="20"></TD>
+
+  <TD BORDER="1" BGCOLOR="RED" port="out0"><FONT POINT-SIZE="10">by hash</FONT><BR/><FONT POINT-SIZE="9">2,1</FONT></TD>
+  <TD WIDTH="20"></TD>
+
+</TR>
+</TABLE>
+> ]
+}
+p0_0:out0 -> p1_1:in0
+p0_0:out0 -> p2_2:in0
+p1_0:out0 -> p1_1:in0
+p1_0:out0 -> p2_2:in0
+p1_1:core -> p1_2:in0
+p1_2:core -> SimpleResponse
+p2_0:out0 -> p1_1:in0
+p2_0:out0 -> p2_2:in0
+p2_1:out0 -> p1_1:in1
+p2_1:out0 -> p2_2:in1
+p2_2:core -> p1_2:in0
+p3_0:out0 -> p1_1:in1
+p3_0:out0 -> p2_2:in1
+}
+`
+
+	if result := buf.String(); result != expected {
+		t.Errorf("\ngot:\n%s\nwant:\n%s", result, expected)
+	}
+}


### PR DESCRIPTION
Code to generate a DOT file with a diagram of a distributed flow. This will
help during development/debugging. We can eventually allow the debug endpoint
to request diagrams on a running server.

It is TBD what method we will use to generate the actual images. Currently one
can install `graphviz` locally and run `dot` to generate an image. We probably
want to avoid requiring `graphviz` or including something like that in our
binary; perhaps we could set up some public servers that take in dot files and
present the image.

Note to reviewers: the code is pretty tedious, I wouldn't spend time on understanding all the details. One complexity is that we don't show synchronizers or routers when they are trivial (single stream).

Sample diagram (from `TestPlanDiagram`):
![meh](https://cloud.githubusercontent.com/assets/16544120/19901049/16adc5d4-a03c-11e6-84ba-9af9925dc62f.png)

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10370)
<!-- Reviewable:end -->
