### PR TITLE
hlc: remove SetMaxOffset

### DIFF
--- a/pkg/acceptance/terrafarm/farmer.go
+++ b/pkg/acceptance/terrafarm/farmer.go
@@ -216,11 +216,11 @@ func (f *Farmer) NewClient(t *testing.T, i int) (*client.DB, *stop.Stopper) {
 		Insecure: true,
 		User:     security.NodeUser,
 	}, nil, stopper)
-	sender, err := client.NewSender(rpcContext, f.Addr(i, base.DefaultPort))
+	conn, err := rpcContext.GRPCDial(f.Addr(i, base.DefaultPort))
 	if err != nil {
 		t.Fatal(err)
 	}
-	return client.NewDB(sender), stopper
+	return client.NewDB(client.NewSender(conn)), stopper
 }
 
 // PGUrl returns a URL string for the given node postgres server.

--- a/pkg/cli/backup.go
+++ b/pkg/cli/backup.go
@@ -56,7 +56,7 @@ func runBackup(cmd *cobra.Command, args []string) error {
 	}
 	defer stopper.Stop()
 
-	desc, err := sql.Backup(ctx, *kvDB, base, hlc.NewClock(hlc.UnixNano).Now())
+	desc, err := sql.Backup(ctx, *kvDB, base, hlc.Timestamp{WallTime: hlc.UnixNano()})
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -459,7 +459,13 @@ func rerunBackground() error {
 func getGRPCConn() (*grpc.ClientConn, *stop.Stopper, error) {
 	stopper := stop.NewStopper()
 	rpcContext := rpc.NewContext(
-		log.AmbientContext{}, serverCfg.Config, hlc.NewClock(hlc.UnixNano), stopper,
+		log.AmbientContext{},
+		serverCfg.Config,
+		// 0 to disable max offset checks; this RPC context is not a member of the
+		// cluster, so there's no need to enforce that its max offset is the same
+		// as that of nodes in the cluster.
+		hlc.NewClock(hlc.UnixNano, 0),
+		stopper,
 	)
 	addr, err := addrWithDefaultHost(serverCfg.AdvertiseAddr)
 	if err != nil {

--- a/pkg/cmd/internal/localcluster/localcluster.go
+++ b/pkg/cmd/internal/localcluster/localcluster.go
@@ -169,11 +169,11 @@ func (c *Cluster) makeNode(nodeIdx int, extraArgs, extraEnv []string) *Node {
 }
 
 func (c *Cluster) makeClient(nodeIdx int) *client.DB {
-	sender, err := client.NewSender(c.rpcCtx, c.RPCAddr(nodeIdx))
+	conn, err := c.rpcCtx.GRPCDial(c.RPCAddr(nodeIdx))
 	if err != nil {
 		log.Fatalf(context.Background(), "failed to initialize KV client: %s", err)
 	}
-	return client.NewDB(sender)
+	return client.NewDB(client.NewSender(conn))
 }
 
 func (c *Cluster) makeStatus(nodeIdx int) serverpb.StatusClient {

--- a/pkg/gossip/gossip_test.go
+++ b/pkg/gossip/gossip_test.go
@@ -26,7 +26,6 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/gossip/resolver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
@@ -42,7 +41,7 @@ func TestGossipInfoStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	rpcContext := rpc.NewContext(log.AmbientContext{}, &base.Config{Insecure: true}, nil, stopper)
+	rpcContext := newInsecureRPCContext(stopper)
 	g := NewTest(1, rpcContext, rpc.NewServer(rpcContext), nil, stopper, metric.NewRegistry())
 	slice := []byte("b")
 	if err := g.AddInfo("s", slice, time.Hour); err != nil {
@@ -77,9 +76,7 @@ func TestGossipGetNextBootstrapAddress(t *testing.T) {
 	if len(resolvers) != 3 {
 		t.Errorf("expected 3 resolvers; got %d", len(resolvers))
 	}
-	server := rpc.NewServer(
-		rpc.NewContext(log.AmbientContext{}, &base.Config{Insecure: true}, nil, stopper),
-	)
+	server := rpc.NewServer(newInsecureRPCContext(stopper))
 	g := NewTest(0, nil, server, resolvers, stop.NewStopper(), metric.NewRegistry())
 
 	// Using specified resolvers, fetch bootstrap addresses 3 times

--- a/pkg/gossip/simulation/network.go
+++ b/pkg/gossip/simulation/network.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
@@ -71,7 +72,12 @@ func NewNetwork(stopper *stop.Stopper, nodeCount int, createResolvers bool) *Net
 		Nodes:   []*Node{},
 		Stopper: stopper,
 	}
-	n.rpcContext = rpc.NewContext(log.AmbientContext{}, &base.Config{Insecure: true}, nil, n.Stopper)
+	n.rpcContext = rpc.NewContext(
+		log.AmbientContext{},
+		&base.Config{Insecure: true},
+		hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		n.Stopper,
+	)
 	var err error
 	n.tlsConfig, err = n.rpcContext.GetServerTLSConfig()
 	if err != nil {

--- a/pkg/internal/client/rpc_sender.go
+++ b/pkg/internal/client/rpc_sender.go
@@ -18,9 +18,9 @@ package client
 
 import (
 	"golang.org/x/net/context"
+	"google.golang.org/grpc"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/rpc"
 )
 
 type sender struct {
@@ -33,12 +33,8 @@ type sender struct {
 //
 // This must not be used by server.Server or any of its components, only by
 // clients talking to a Cockroach cluster through the external interface.
-func NewSender(ctx *rpc.Context, target string) (Sender, error) {
-	conn, err := ctx.GRPCDial(target)
-	if err != nil {
-		return nil, err
-	}
-	return sender{roachpb.NewExternalClient(conn)}, nil
+func NewSender(conn *grpc.ClientConn) Sender {
+	return sender{roachpb.NewExternalClient(conn)}
 }
 
 // Send implements the Sender interface.

--- a/pkg/internal/client/txn_test.go
+++ b/pkg/internal/client/txn_test.go
@@ -566,8 +566,8 @@ func TestAbortedRetryRenewsTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	// Create a TestSender that aborts a transaction 2 times before succeeding.
-	mc := hlc.NewManualClock(0)
-	clock := hlc.NewClock(mc.UnixNano)
+	mc := hlc.NewManualClock(123)
+	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
 	count := 0
 	db := NewDB(newTestSender(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 		if _, ok := ba.GetArg(roachpb.Put); ok {
@@ -719,10 +719,11 @@ func TestTimestampSelectionInOptions(t *testing.T) {
 	txn := NewTxn(context.Background(), *db)
 
 	mc := hlc.NewManualClock(100)
-	clock := hlc.NewClock(mc.UnixNano)
-	var execOpt TxnExecOptions
+	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
+	execOpt := TxnExecOptions{
+		Clock: clock,
+	}
 	refTimestamp := clock.Now()
-	execOpt.Clock = clock
 
 	txnClosure := func(txn *Txn, opt *TxnExecOptions) error {
 		// Ensure the KV transaction is created.

--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -140,16 +140,14 @@ type DistSenderConfig struct {
 // DistSenderContext or the fields within is optional. For omitted values, sane
 // defaults will be used.
 func NewDistSender(cfg DistSenderConfig, g *gossip.Gossip) *DistSender {
-	ds := &DistSender{gossip: g}
+	ds := &DistSender{
+		clock:  cfg.Clock,
+		gossip: g,
+	}
 
 	ds.AmbientContext = cfg.AmbientCtx
 	if ds.AmbientContext.Tracer == nil {
 		ds.AmbientContext.Tracer = tracing.NewTracer()
-	}
-
-	ds.clock = cfg.Clock
-	if ds.clock == nil {
-		ds.clock = hlc.NewClock(hlc.UnixNano)
 	}
 
 	if cfg.nodeDescriptor != nil {

--- a/pkg/kv/range_iter_test.go
+++ b/pkg/kv/range_iter_test.go
@@ -79,13 +79,13 @@ func TestRangeIterForward(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 
-	cfg := DistSenderConfig{
+	g, clock := makeGossip(t, stopper)
+	ds := NewDistSender(DistSenderConfig{
+		Clock:             clock,
 		RangeDescriptorDB: alphaRangeDescriptorDB,
-	}
-	ctx := context.Background()
+	}, g)
 
-	g := makeGossip(t, stopper)
-	ds := NewDistSender(cfg, g)
+	ctx := context.Background()
 
 	ri := NewRangeIterator(ds, false /*reverse*/)
 	i := 0
@@ -107,13 +107,13 @@ func TestRangeIterSeekForward(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 
-	cfg := DistSenderConfig{
+	g, clock := makeGossip(t, stopper)
+	ds := NewDistSender(DistSenderConfig{
+		Clock:             clock,
 		RangeDescriptorDB: alphaRangeDescriptorDB,
-	}
-	ctx := context.Background()
+	}, g)
 
-	g := makeGossip(t, stopper)
-	ds := NewDistSender(cfg, g)
+	ctx := context.Background()
 
 	ri := NewRangeIterator(ds, false /*reverse*/)
 	i := 0
@@ -140,13 +140,13 @@ func TestRangeIterReverse(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 
-	cfg := DistSenderConfig{
+	g, clock := makeGossip(t, stopper)
+	ds := NewDistSender(DistSenderConfig{
+		Clock:             clock,
 		RangeDescriptorDB: alphaRangeDescriptorDB,
-	}
-	ctx := context.Background()
+	}, g)
 
-	g := makeGossip(t, stopper)
-	ds := NewDistSender(cfg, g)
+	ctx := context.Background()
 
 	ri := NewRangeIterator(ds, true /*reverse*/)
 	i := len(alphaRangeDescriptors) - 1
@@ -168,13 +168,13 @@ func TestRangeIterSeekReverse(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 
-	cfg := DistSenderConfig{
+	g, clock := makeGossip(t, stopper)
+	ds := NewDistSender(DistSenderConfig{
+		Clock:             clock,
 		RangeDescriptorDB: alphaRangeDescriptorDB,
-	}
-	ctx := context.Background()
+	}, g)
 
-	g := makeGossip(t, stopper)
-	ds := NewDistSender(cfg, g)
+	ctx := context.Background()
 
 	ri := NewRangeIterator(ds, true /*reverse*/)
 	i := len(alphaRangeDescriptors) - 1

--- a/pkg/kv/send_test.go
+++ b/pkg/kv/send_test.go
@@ -92,7 +92,7 @@ func TestSendToOneClient(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 
-	ctx := newNodeTestContext(nil, stopper)
+	ctx := newNodeTestContext(hlc.NewClock(hlc.UnixNano, time.Nanosecond), stopper)
 	s, ln := newTestServer(t, ctx)
 	roachpb.RegisterInternalServer(s, Node(0))
 
@@ -113,10 +113,10 @@ func TestRetryableError(t *testing.T) {
 
 	clientStopper := stop.NewStopper()
 	defer clientStopper.Stop()
-	clientContext := newNodeTestContext(nil, clientStopper)
+	clientContext := newNodeTestContext(hlc.NewClock(hlc.UnixNano, time.Nanosecond), clientStopper)
 
 	serverStopper := stop.NewStopper()
-	serverContext := newNodeTestContext(nil, serverStopper)
+	serverContext := newNodeTestContext(hlc.NewClock(hlc.UnixNano, time.Nanosecond), serverStopper)
 
 	s, ln := newTestServer(t, serverContext)
 	roachpb.RegisterInternalServer(s, Node(0))
@@ -181,7 +181,7 @@ func (*channelSaveTransport) Close() {
 // distinguishing them and just send a single channel.
 func setupSendNextTest(t *testing.T) ([]chan<- BatchCall, chan BatchCall, *stop.Stopper) {
 	stopper := stop.NewStopper()
-	nodeContext := newNodeTestContext(nil, stopper)
+	nodeContext := newNodeTestContext(hlc.NewClock(hlc.UnixNano, time.Nanosecond), stopper)
 
 	addrs := []net.Addr{
 		util.NewUnresolvedAddr("dummy", "1"),
@@ -434,7 +434,7 @@ func TestComplexScenarios(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 
-	nodeContext := newNodeTestContext(nil, stopper)
+	nodeContext := newNodeTestContext(hlc.NewClock(hlc.UnixNano, time.Nanosecond), stopper)
 
 	// TODO(bdarnell): the retryable flag is no longer used for RPC errors.
 	// Rework this test to incorporate application-level errors carried in

--- a/pkg/rpc/clock_offset_test.go
+++ b/pkg/rpc/clock_offset_test.go
@@ -36,8 +36,9 @@ const errOffsetGreaterThanMaxOffset = "fewer than half the known nodes are withi
 // not update the offset for an addr.
 func TestUpdateOffset(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	monitor := newRemoteClockMonitor(
-		context.TODO(), hlc.NewClock(hlc.NewManualClock(123).UnixNano), time.Hour)
+
+	clock := hlc.NewClock(hlc.NewManualClock(123).UnixNano, time.Nanosecond)
+	monitor := newRemoteClockMonitor(context.TODO(), clock, time.Hour)
 
 	const key = "addr"
 
@@ -100,8 +101,7 @@ func TestUpdateOffset(t *testing.T) {
 func TestVerifyClockOffset(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	clock := hlc.NewClock(hlc.NewManualClock(123).UnixNano)
-	clock.SetMaxOffset(50 * time.Nanosecond)
+	clock := hlc.NewClock(hlc.NewManualClock(123).UnixNano, 50*time.Nanosecond)
 	monitor := newRemoteClockMonitor(context.TODO(), clock, time.Hour)
 
 	for idx, tc := range []struct {
@@ -166,8 +166,7 @@ func TestClockOffsetMetrics(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 
-	clock := hlc.NewClock(hlc.NewManualClock(123).UnixNano)
-	clock.SetMaxOffset(20 * time.Nanosecond)
+	clock := hlc.NewClock(hlc.NewManualClock(123).UnixNano, 20*time.Nanosecond)
 	monitor := newRemoteClockMonitor(context.TODO(), clock, time.Hour)
 	monitor.mu.offsets = map[string]RemoteOffset{
 		"0": {

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -115,15 +115,11 @@ func NewContext(
 	ambient log.AmbientContext, baseCtx *base.Config, hlcClock *hlc.Clock, stopper *stop.Stopper,
 ) *Context {
 	ctx := &Context{
-		Config: baseCtx,
-	}
-	if hlcClock != nil {
-		ctx.localClock = hlcClock
-	} else {
-		ctx.localClock = hlc.NewClock(hlc.UnixNano)
-	}
-	ctx.breakerClock = breakerClock{
-		clock: ctx.localClock,
+		Config:     baseCtx,
+		localClock: hlcClock,
+		breakerClock: breakerClock{
+			clock: hlcClock,
+		},
 	}
 	var cancel context.CancelFunc
 	ctx.masterCtx, cancel = context.WithCancel(ambient.AnnotateCtx(context.Background()))

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -114,6 +114,9 @@ type Context struct {
 func NewContext(
 	ambient log.AmbientContext, baseCtx *base.Config, hlcClock *hlc.Clock, stopper *stop.Stopper,
 ) *Context {
+	if hlcClock == nil {
+		panic("nil clock is forbidden")
+	}
 	ctx := &Context{
 		Config:     baseCtx,
 		localClock: hlcClock,

--- a/pkg/rpc/heartbeat_test.go
+++ b/pkg/rpc/heartbeat_test.go
@@ -44,7 +44,7 @@ func TestRemoteOffsetString(t *testing.T) {
 func TestHeartbeatReply(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	manual := hlc.NewManualClock(5)
-	clock := hlc.NewClock(manual.UnixNano)
+	clock := hlc.NewClock(manual.UnixNano, time.Nanosecond)
 	heartbeat := &HeartbeatService{
 		clock:              clock,
 		remoteClockMonitor: newRemoteClockMonitor(context.TODO(), clock, time.Hour),
@@ -70,7 +70,7 @@ func TestHeartbeatReply(t *testing.T) {
 func TestManualHeartbeat(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	manual := hlc.NewManualClock(5)
-	clock := hlc.NewClock(manual.UnixNano)
+	clock := hlc.NewClock(manual.UnixNano, time.Nanosecond)
 	manualHeartbeat := &ManualHeartbeatService{
 		clock:              clock,
 		remoteClockMonitor: newRemoteClockMonitor(context.TODO(), clock, time.Hour),
@@ -117,8 +117,7 @@ func TestClockOffsetMismatch(t *testing.T) {
 		}
 	}()
 
-	clock := hlc.NewClock(hlc.UnixNano)
-	clock.SetMaxOffset(250 * time.Millisecond)
+	clock := hlc.NewClock(hlc.UnixNano, 250*time.Millisecond)
 	hs := &HeartbeatService{
 		clock:              clock,
 		remoteClockMonitor: newRemoteClockMonitor(context.TODO(), clock, time.Hour),

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -173,11 +173,12 @@ func bootstrapCluster(engines []engine.Engine, txnMetrics kv.TxnMetrics) (uuid.U
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 
-	cfg := storage.StoreConfig{}
+	cfg := storage.StoreConfig{
+		Clock: hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+	}
 	cfg.ScanInterval = 10 * time.Minute
 	cfg.MetricsSampleInterval = time.Duration(math.MaxInt64)
 	cfg.ConsistencyCheckInterval = 10 * time.Minute
-	cfg.Clock = hlc.NewClock(hlc.UnixNano)
 	cfg.AmbientCtx.Tracer = tracing.NewTracer()
 	// Create a KV DB with a local sender.
 	stores := storage.NewStores(cfg.AmbientCtx, cfg.Clock)

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -63,10 +63,9 @@ import (
 func createTestNode(
 	addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t *testing.T,
 ) (*grpc.Server, net.Addr, *hlc.Clock, *Node, *stop.Stopper) {
-	cfg := storage.StoreConfig{}
+	cfg := storage.TestStoreConfig(nil)
 
 	stopper := stop.NewStopper()
-	cfg.Clock = hlc.NewClock(hlc.UnixNano)
 	nodeRPCContext := rpc.NewContext(log.AmbientContext{}, nodeTestBaseContext, cfg.Clock, stopper)
 	cfg.ScanInterval = 10 * time.Hour
 	cfg.ConsistencyCheckInterval = 10 * time.Hour

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -131,7 +131,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 
 	s := &Server{
 		mux:     http.NewServeMux(),
-		clock:   hlc.NewClock(hlc.UnixNano),
+		clock:   hlc.NewClock(hlc.UnixNano, cfg.MaxOffset),
 		stopper: stopper,
 		cfg:     cfg,
 	}
@@ -153,8 +153,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	if s.cfg.Insecure {
 		log.Warning(ctx, "running in insecure mode, this is strongly discouraged. See --insecure.")
 	}
-
-	s.clock.SetMaxOffset(cfg.MaxOffset)
 
 	s.rpcContext = rpc.NewContext(s.cfg.AmbientCtx, s.cfg.Config, s.clock, s.stopper)
 	s.rpcContext.HeartbeatCB = func() {

--- a/pkg/server/status/recorder_test.go
+++ b/pkg/server/status/recorder_test.go
@@ -144,7 +144,7 @@ func TestMetricsRecorder(t *testing.T) {
 		registry: metric.NewRegistry(),
 	}
 	manual := hlc.NewManualClock(100)
-	recorder := NewMetricsRecorder(hlc.NewClock(manual.UnixNano))
+	recorder := NewMetricsRecorder(hlc.NewClock(manual.UnixNano, time.Nanosecond))
 	recorder.AddStore(store1)
 	recorder.AddStore(store2)
 	recorder.AddNode(reg1, nodeDesc, 50)

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -508,7 +508,9 @@ func (e *Executor) execRequest(session *Session, sql string, copymsg copyMsg) St
 		// Each iteration consumes a transaction's worth of statements.
 
 		inTxn := txnState.State != NoTxn
-		var execOpt client.TxnExecOptions
+		execOpt := client.TxnExecOptions{
+			Clock: e.cfg.Clock,
+		}
 		// Figure out the statements out of which we're going to try to consume
 		// this iteration. If we need to create an implicit txn, only one statement
 		// can be consumed.
@@ -516,7 +518,6 @@ func (e *Executor) execRequest(session *Session, sql string, copymsg copyMsg) St
 		// If protoTS is set, the transaction proto sets its Orig and Max timestamps
 		// to it each retry.
 		var protoTS *hlc.Timestamp
-		execOpt.Clock = e.cfg.Clock
 		// We can AutoRetry the next batch of statements if we're in a clean state
 		// (i.e. the next statements we're going to see are the first statements in
 		// a transaction).

--- a/pkg/sql/kv_test.go
+++ b/pkg/sql/kv_test.go
@@ -61,20 +61,19 @@ func newKVNative(b *testing.B) kvInterface {
 	// TestServer.DB() returns the TxnCoordSender wrapped client. But that isn't
 	// a fair comparison with SQL as we want these client requests to be sent
 	// over the network.
-	sender, err := client.NewSender(
-		rpc.NewContext(log.AmbientContext{}, &base.Config{
-			User:       security.NodeUser,
-			SSLCA:      filepath.Join(security.EmbeddedCertsDir, security.EmbeddedCACert),
-			SSLCert:    filepath.Join(security.EmbeddedCertsDir, "node.crt"),
-			SSLCertKey: filepath.Join(security.EmbeddedCertsDir, "node.key"),
-		}, nil, s.Stopper()),
-		s.ServingAddr())
+	rpcContext := rpc.NewContext(log.AmbientContext{}, &base.Config{
+		User:       security.NodeUser,
+		SSLCA:      filepath.Join(security.EmbeddedCertsDir, security.EmbeddedCACert),
+		SSLCert:    filepath.Join(security.EmbeddedCertsDir, "node.crt"),
+		SSLCertKey: filepath.Join(security.EmbeddedCertsDir, "node.key"),
+	}, nil, s.Stopper())
+	conn, err := rpcContext.GRPCDial(s.ServingAddr())
 	if err != nil {
 		b.Fatal(err)
 	}
 
 	return &kvNative{
-		db: client.NewDB(sender),
+		db: client.NewDB(client.NewSender(conn)),
 		doneFn: func() {
 			s.Stopper().Stop()
 			enableTracing()

--- a/pkg/sql/table_test.go
+++ b/pkg/sql/table_test.go
@@ -255,8 +255,8 @@ func TestRemoveLeaseIfExpiring(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	p := planner{session: &Session{context: context.Background()}}
-	mc := hlc.NewManualClock(0)
-	p.leaseMgr = &LeaseManager{LeaseStore: LeaseStore{clock: hlc.NewClock(mc.UnixNano)}}
+	mc := hlc.NewManualClock(123)
+	p.leaseMgr = &LeaseManager{LeaseStore: LeaseStore{clock: hlc.NewClock(mc.UnixNano, time.Nanosecond)}}
 	p.leases = make([]*LeaseState, 0)
 	txn := client.Txn{Context: context.Background()}
 	p.setTxn(&txn)

--- a/pkg/storage/client_bench_test.go
+++ b/pkg/storage/client_bench_test.go
@@ -26,9 +26,9 @@ import (
 
 func BenchmarkReplicaSnapshot(b *testing.B) {
 	defer tracing.Disable()()
-	storeCfg := TestStoreConfig()
+	storeCfg := TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, _, stopper := createTestStoreWithContext(b, &storeCfg)
+	store, stopper := createTestStoreWithConfig(b, &storeCfg)
 	defer stopper.Stop()
 	// We want to manually control the size of the raft log.
 	store.SetRaftLogQueueActive(false)

--- a/pkg/storage/client_raft_log_queue_test.go
+++ b/pkg/storage/client_raft_log_queue_test.go
@@ -48,7 +48,7 @@ func TestRaftLogQueue(t *testing.T) {
 
 	// Turn off raft elections so the raft leader won't change out from under
 	// us in this test.
-	sc := storage.TestStoreConfig()
+	sc := storage.TestStoreConfig(nil)
 	sc.RaftTickInterval = math.MaxInt32
 	sc.RaftElectionTimeoutTicks = 1000000
 	mtc.storeConfig = &sc

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -65,7 +65,7 @@ func mustGetInt(v *roachpb.Value) int64 {
 // after being stopped and recreated.
 func TestStoreRecoverFromEngine(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	storeCfg := storage.TestStoreConfig()
+	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 
 	rangeID := roachpb.RangeID(1)
@@ -73,8 +73,6 @@ func TestStoreRecoverFromEngine(t *testing.T) {
 	key1 := roachpb.Key("a")
 	key2 := roachpb.Key("z")
 
-	manual := hlc.NewManualClock(0)
-	clock := hlc.NewClock(manual.UnixNano)
 	engineStopper := stop.NewStopper()
 	defer engineStopper.Stop()
 	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
@@ -105,7 +103,7 @@ func TestStoreRecoverFromEngine(t *testing.T) {
 	func() {
 		stopper := stop.NewStopper()
 		defer stopper.Stop()
-		store := createTestStoreWithEngine(t, eng, clock, true, storeCfg, stopper)
+		store := createTestStoreWithEngine(t, eng, true, storeCfg, stopper)
 
 		increment := func(rangeID roachpb.RangeID, key roachpb.Key, value int64) (*roachpb.IncrementResponse, *roachpb.Error) {
 			args := incrementArgs(key, value)
@@ -142,7 +140,7 @@ func TestStoreRecoverFromEngine(t *testing.T) {
 	// Now create a new store with the same engine and make sure the expected data is present.
 	// We must use the same clock because a newly-created manual clock will be behind the one
 	// we wrote with and so will see stale MVCC data.
-	store := createTestStoreWithEngine(t, eng, clock, false, storeCfg, engineStopper)
+	store := createTestStoreWithEngine(t, eng, false, storeCfg, engineStopper)
 
 	// Raft processing is initialized lazily; issue a no-op write request on each key to
 	// ensure that is has been started.
@@ -164,19 +162,16 @@ func TestStoreRecoverFromEngine(t *testing.T) {
 // applied so they are not retried after recovery.
 func TestStoreRecoverWithErrors(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	manual := hlc.NewManualClock(0)
-	clock := hlc.NewClock(manual.UnixNano)
-	engineStopper := stop.NewStopper()
-	defer engineStopper.Stop()
+	storeCfg := storage.TestStoreConfig(nil)
 	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
-	engineStopper.AddCloser(eng)
+	defer eng.Close()
 
 	numIncrements := 0
 
 	func() {
 		stopper := stop.NewStopper()
 		defer stopper.Stop()
-		storeCfg := storage.TestStoreConfig()
+		storeCfg := storeCfg // copy
 		storeCfg.TestingKnobs.TestingCommandFilter =
 			func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 				_, ok := filterArgs.Req.(*roachpb.IncrementRequest)
@@ -185,7 +180,7 @@ func TestStoreRecoverWithErrors(t *testing.T) {
 				}
 				return nil
 			}
-		store := createTestStoreWithEngine(t, eng, clock, true, storeCfg, stopper)
+		store := createTestStoreWithEngine(t, eng, true, storeCfg, stopper)
 
 		// Write a bytes value so the increment will fail.
 		putArgs := putArgs(roachpb.Key("a"), []byte("asdf"))
@@ -205,9 +200,11 @@ func TestStoreRecoverWithErrors(t *testing.T) {
 		t.Fatalf("expected 1 increments; was %d", numIncrements)
 	}
 
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+
 	// Recover from the engine.
-	store := createTestStoreWithEngine(
-		t, eng, clock, false, storage.TestStoreConfig(), engineStopper)
+	store := createTestStoreWithEngine(t, eng, false, storeCfg, stopper)
 
 	// Issue a no-op write to lazily initialize raft on the range.
 	incArgs := incrementArgs(roachpb.Key("b"), 0)
@@ -302,7 +299,7 @@ func TestReplicateRange(t *testing.T) {
 func TestRestoreReplicas(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	sc := storage.TestStoreConfig()
+	sc := storage.TestStoreConfig(nil)
 	// Disable periodic gossip activities. The periodic gossiping of the first
 	// range can cause spurious lease transfers which cause this test to fail.
 	sc.TestingKnobs.DisablePeriodicGossips = true
@@ -401,7 +398,7 @@ func TestFailedReplicaChange(t *testing.T) {
 	var runFilter atomic.Value
 	runFilter.Store(true)
 
-	sc := storage.TestStoreConfig()
+	sc := storage.TestStoreConfig(nil)
 	sc.TestingKnobs.TestingCommandFilter = func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 		if runFilter.Load().(bool) {
 			if et, ok := filterArgs.Req.(*roachpb.EndTransactionRequest); ok && et.Commit {
@@ -699,7 +696,7 @@ func TestRefreshPendingCommands(t *testing.T) {
 	}
 	for _, c := range testCases {
 		func() {
-			sc := storage.TestStoreConfig()
+			sc := storage.TestStoreConfig(nil)
 			sc.TestingKnobs = c
 			// Disable periodic gossip tasks which can move the range 1 lease
 			// unexpectedly.
@@ -810,7 +807,7 @@ func TestStoreRangeCorruptionChangeReplicas(t *testing.T) {
 	const numReplicas = 3
 	const extraStores = 3
 
-	sc := storage.TestStoreConfig()
+	sc := storage.TestStoreConfig(nil)
 	var corrupt struct {
 		syncutil.Mutex
 		store *storage.Store
@@ -1199,7 +1196,7 @@ func TestReplicateRestartAfterTruncation(t *testing.T) {
 }
 
 func runReplicateRestartAfterTruncation(t *testing.T, removeBeforeTruncateAndReAdd bool) {
-	sc := storage.TestStoreConfig()
+	sc := storage.TestStoreConfig(nil)
 	// Don't timeout raft leaders or range leases (see the relation between
 	// RaftElectionTimeoutTicks and rangeLeaseActiveDuration). This test expects
 	// mtc.stores[0] to hold the range lease for range 1.
@@ -1285,7 +1282,7 @@ func runReplicateRestartAfterTruncation(t *testing.T, removeBeforeTruncateAndReA
 }
 
 func testReplicaAddRemove(t *testing.T, addFirst bool) {
-	sc := storage.TestStoreConfig()
+	sc := storage.TestStoreConfig(nil)
 	// We're gonna want to validate the state of the store before and after the
 	// replica GC queue does its work, so we disable the replica gc queue here
 	// and run it manually when we're ready.
@@ -1890,7 +1887,7 @@ func TestStoreRangeRebalance(t *testing.T) {
 	storage.RebalanceThreshold = 0
 
 	// Start multiTestContext with replica rebalancing enabled.
-	sc := storage.TestStoreConfig()
+	sc := storage.TestStoreConfig(nil)
 	sc.AllocatorOptions = storage.AllocatorOptions{
 		AllowRebalance: true,
 		Deterministic:  true,
@@ -2219,7 +2216,7 @@ func TestReplicateRemovedNodeDisruptiveElection(t *testing.T) {
 func TestReplicaTooOldGC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	sc := storage.TestStoreConfig()
+	sc := storage.TestStoreConfig(nil)
 	sc.TestingKnobs.DisableScanner = true
 	mtc := &multiTestContext{storeConfig: &sc}
 	mtc.Start(t, 4)
@@ -2277,7 +2274,7 @@ func TestReplicaTooOldGC(t *testing.T) {
 func TestReplicaLazyLoad(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	sc := storage.TestStoreConfig()
+	sc := storage.TestStoreConfig(nil)
 	sc.RaftTickInterval = time.Millisecond // safe because there is only a single node
 	sc.TestingKnobs.DisableScanner = true
 	sc.TestingKnobs.DisablePeriodicGossips = true
@@ -2348,19 +2345,22 @@ func TestReplicateReAddAfterDown(t *testing.T) {
 	mtc.waitForValues(roachpb.Key("a"), []int64{16, 16, 16})
 }
 
-// TestLeaderRemoveSelf verifies that a lease holder can remove itself
+// TestLeaseHolderRemoveSelf verifies that a lease holder can remove itself
 // without panicking and future access to the range returns a
 // RangeNotFoundError (not RaftGroupDeletedError, and even before
 // the ReplicaGCQueue has run).
-func TestLeaderRemoveSelf(t *testing.T) {
+func TestLeaseHolderRemoveSelf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	mtc := startMultiTestContext(t, 2)
 	defer mtc.Stop()
+
+	leaseHolder := mtc.stores[0]
+
 	// Disable the replica GC queue. This verifies that the replica is
 	// considered removed even before the gc queue has run, and also
 	// helps avoid a deadlock at shutdown.
-	mtc.stores[0].SetReplicaGCQueueActive(false)
+	leaseHolder.SetReplicaGCQueueActive(false)
 	raftID := roachpb.RangeID(1)
 	mtc.replicateRange(raftID, 1)
 	// Remove the replica from first store.
@@ -2368,15 +2368,10 @@ func TestLeaderRemoveSelf(t *testing.T) {
 	getArgs := getArgs([]byte("a"))
 
 	// Force the read command request a new lease.
-	clock := mtc.clocks[0]
-	header := roachpb.Header{
-		Timestamp: clock.Update(
-			clock.Now().Add(mtc.stores[0].LeaseExpiration(clock), 0),
-		),
-	}
+	mtc.manualClock.Increment(leaseHolder.LeaseExpiration(mtc.clock))
 
 	// Expect get a RangeNotFoundError.
-	_, pErr := client.SendWrappedWith(context.Background(), rg1(mtc.stores[0]), header, &getArgs)
+	_, pErr := client.SendWrappedWith(context.Background(), rg1(leaseHolder), roachpb.Header{}, &getArgs)
 	if _, ok := pErr.GetDetail().(*roachpb.RangeNotFoundError); !ok {
 		t.Fatalf("expect get RangeNotFoundError, actual get %v ", pErr)
 	}
@@ -2388,7 +2383,7 @@ func TestLeaderRemoveSelf(t *testing.T) {
 func TestRemoveRangeWithoutGC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	sc := storage.TestStoreConfig()
+	sc := storage.TestStoreConfig(nil)
 	sc.TestingKnobs.DisableScanner = true
 	mtc := &multiTestContext{storeConfig: &sc}
 	mtc.Start(t, 2)
@@ -2480,7 +2475,7 @@ func TestCheckConsistencyMultiStore(t *testing.T) {
 func TestCheckInconsistent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	sc := storage.TestStoreConfig()
+	sc := storage.TestStoreConfig(nil)
 	mtc := &multiTestContext{storeConfig: &sc}
 	// Store 0 will report a diff with inconsistent key "e".
 	diffKey := []byte("e")
@@ -2530,7 +2525,7 @@ func TestCheckInconsistent(t *testing.T) {
 	// Write some arbitrary data only to store 1. Inconsistent key "e"!
 	var val roachpb.Value
 	val.SetInt(42)
-	diffTimestamp = mtc.stores[1].Clock().Timestamp()
+	diffTimestamp = mtc.stores[1].Clock().Now()
 	if err := engine.MVCCPut(
 		context.Background(), mtc.stores[1].Engine(), nil, diffKey, diffTimestamp, val, nil,
 	); err != nil {
@@ -2564,7 +2559,7 @@ func TestTransferRaftLeadership(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	const numStores = 3
-	sc := storage.TestStoreConfig()
+	sc := storage.TestStoreConfig(nil)
 	// Suppress timeout-based elections (which also includes a previous
 	// leader stepping down due to a quorum check). Running tests on a
 	// heavily loaded CPU is enough to reach the raft election timeout
@@ -2665,7 +2660,7 @@ func TestFailedPreemptiveSnapshot(t *testing.T) {
 func TestRaftBlockedReplica(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	sc := storage.TestStoreConfig()
+	sc := storage.TestStoreConfig(nil)
 	sc.TestingKnobs.DisableScanner = true
 	mtc := &multiTestContext{storeConfig: &sc}
 	mtc.Start(t, 3)
@@ -2720,7 +2715,7 @@ func TestRaftBlockedReplica(t *testing.T) {
 func TestRangeQuiescence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	sc := storage.TestStoreConfig()
+	sc := storage.TestStoreConfig(nil)
 	sc.TestingKnobs.DisableScanner = true
 	sc.TestingKnobs.DisablePeriodicGossips = true
 	mtc := &multiTestContext{storeConfig: &sc}

--- a/pkg/storage/client_replica_gc_test.go
+++ b/pkg/storage/client_replica_gc_test.go
@@ -45,7 +45,7 @@ func TestReplicaGCQueueDropReplicaDirect(t *testing.T) {
 	// no GC will take place since the consistent RangeLookup hits the first
 	// Node. We use the TestingCommandFilter to make sure that the second Node
 	// waits for the first.
-	cfg := storage.TestStoreConfig()
+	cfg := storage.TestStoreConfig(nil)
 	mtc.storeConfig = &cfg
 	mtc.storeConfig.TestingKnobs.TestingCommandFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -93,9 +93,9 @@ func TestStoreRangeSplitAtIllegalKeys(t *testing.T) {
 // UserTableDataMin and still gossip the SystemConfig properly.
 func TestStoreRangeSplitAtTablePrefix(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	storeCfg := storage.TestStoreConfig()
+	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper, _ := createTestStoreWithConfig(t, storeCfg)
+	store, stopper := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 
 	key := keys.MakeRowSentinelKey(append([]byte(nil), keys.UserTableDataMin...))
@@ -145,9 +145,9 @@ func TestStoreRangeSplitAtTablePrefix(t *testing.T) {
 // a table row will cause a split at a boundary between rows.
 func TestStoreRangeSplitInsideRow(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	storeCfg := storage.TestStoreConfig()
+	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper, _ := createTestStoreWithConfig(t, storeCfg)
+	store, stopper := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 
 	// Manually create some the column keys corresponding to the table:
@@ -198,9 +198,9 @@ func TestStoreRangeSplitInsideRow(t *testing.T) {
 // that all intents are cleared and the transaction record cleaned up.
 func TestStoreRangeSplitIntents(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	storeCfg := storage.TestStoreConfig()
+	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper, _ := createTestStoreWithConfig(t, storeCfg)
+	store, stopper := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 
 	// First, write some values left and right of the proposed split key.
@@ -251,9 +251,9 @@ func TestStoreRangeSplitIntents(t *testing.T) {
 // to split at the start of the newly split range.
 func TestStoreRangeSplitAtRangeBounds(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	storeCfg := storage.TestStoreConfig()
+	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper, _ := createTestStoreWithConfig(t, storeCfg)
+	store, stopper := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 
 	args := adminSplitArgs(roachpb.KeyMin, []byte("a"))
@@ -276,9 +276,9 @@ func TestStoreRangeSplitAtRangeBounds(t *testing.T) {
 // because the split key is invalid after the first split succeeds.
 func TestStoreRangeSplitConcurrent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	storeCfg := storage.TestStoreConfig()
+	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper, _ := createTestStoreWithConfig(t, storeCfg)
+	store, stopper := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 
 	splitKey := roachpb.Key("a")
@@ -335,9 +335,9 @@ func TestStoreRangeSplitConcurrent(t *testing.T) {
 // can't be replayed.
 func TestStoreRangeSplitIdempotency(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	storeCfg := storage.TestStoreConfig()
+	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper, _ := createTestStoreWithConfig(t, storeCfg)
+	store, stopper := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 	rangeID := roachpb.RangeID(1)
 	splitKey := roachpb.Key("m")
@@ -483,9 +483,10 @@ func TestStoreRangeSplitIdempotency(t *testing.T) {
 // the pre-split.
 func TestStoreRangeSplitStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	storeCfg := storage.TestStoreConfig()
+	manual := hlc.NewManualClock(123)
+	storeCfg := storage.TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper, manual := createTestStoreWithConfig(t, storeCfg)
+	store, stopper := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 
 	// Split the range after the last table data key.
@@ -591,9 +592,10 @@ func TestStoreRangeSplitStats(t *testing.T) {
 // requests' impact on MVCCStats are only estimated. See updateStatsOnMerge.
 func TestStoreRangeSplitStatsWithMerges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	storeCfg := storage.TestStoreConfig()
+	manual := hlc.NewManualClock(123)
+	storeCfg := storage.TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper, manual := createTestStoreWithConfig(t, storeCfg)
+	store, stopper := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 
 	// Split the range after the last table data key.
@@ -1090,7 +1092,7 @@ func TestStoreSplitTimestampCacheReadRace(t *testing.T) {
 
 	getContinues := make(chan struct{})
 	var getStarted sync.WaitGroup
-	storeCfg := storage.TestStoreConfig()
+	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	storeCfg.TestingKnobs.TestingCommandFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
@@ -1107,7 +1109,7 @@ func TestStoreSplitTimestampCacheReadRace(t *testing.T) {
 			}
 			return nil
 		}
-	store, stopper, _ := createTestStoreWithConfig(t, storeCfg)
+	store, stopper := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 
 	now := store.Clock().Now()
@@ -1323,7 +1325,7 @@ func TestStoreSplitTimestampCacheDifferentLeaseHolder(t *testing.T) {
 func TestStoreRangeSplitRaceUninitializedRHS(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	mtc := &multiTestContext{}
-	storeCfg := storage.TestStoreConfig()
+	storeCfg := storage.TestStoreConfig(nil)
 	// An aggressive tick interval lets groups communicate more and thus
 	// triggers test failures much more reliably. We can't go too aggressive
 	// or race tests never make any progress.
@@ -1452,7 +1454,7 @@ func TestStoreRangeSplitRaceUninitializedRHS(t *testing.T) {
 // elects a leader without waiting for an election timeout.
 func TestLeaderAfterSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	storeConfig := storage.TestStoreConfig()
+	storeConfig := storage.TestStoreConfig(nil)
 	storeConfig.RaftElectionTimeoutTicks = 1000000
 	mtc := &multiTestContext{
 		storeConfig: &storeConfig,
@@ -1484,9 +1486,9 @@ func TestLeaderAfterSplit(t *testing.T) {
 
 func BenchmarkStoreRangeSplit(b *testing.B) {
 	defer tracing.Disable()()
-	storeCfg := storage.TestStoreConfig()
+	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper, _ := createTestStoreWithConfig(b, storeCfg)
+	store, stopper := createTestStoreWithConfig(b, storeCfg)
 	defer stopper.Stop()
 
 	// Perform initial split of ranges.
@@ -1620,7 +1622,8 @@ func TestStoreSplitBeginTxnPushMetaIntentRace(t *testing.T) {
 
 	wroteMeta2 := make(chan struct{}, 1)
 
-	storeCfg := storage.TestStoreConfig()
+	manual := hlc.NewManualClock(123)
+	storeCfg := storage.TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	storeCfg.TestingKnobs.TestingCommandFilter = func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 		startMu.Lock()
@@ -1649,7 +1652,7 @@ func TestStoreSplitBeginTxnPushMetaIntentRace(t *testing.T) {
 		}
 		return nil
 	}
-	store, stopper, manual := createTestStoreWithConfig(t, storeCfg)
+	store, stopper := createTestStoreWithConfig(t, storeCfg)
 	defer stopper.Stop()
 
 	// Advance the clock past the transaction cleanup expiration.

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -83,24 +83,25 @@ func rg1(s *storage.Store) client.Sender {
 // createTestStore creates a test store using an in-memory
 // engine. The caller is responsible for stopping the stopper on exit.
 func createTestStore(t testing.TB) (*storage.Store, *stop.Stopper, *hlc.ManualClock) {
-	return createTestStoreWithConfig(t, storage.TestStoreConfig())
+	manual := hlc.NewManualClock(123)
+	cfg := storage.TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
+	store, stopper := createTestStoreWithConfig(t, cfg)
+	return store, stopper, manual
 }
 
 func createTestStoreWithConfig(
 	t testing.TB, storeCfg storage.StoreConfig,
-) (*storage.Store, *stop.Stopper, *hlc.ManualClock) {
+) (*storage.Store, *stop.Stopper) {
 	stopper := stop.NewStopper()
-	manual := hlc.NewManualClock(123)
 	eng := engine.NewInMem(roachpb.Attributes{}, 10<<20)
 	stopper.AddCloser(eng)
 	store := createTestStoreWithEngine(t,
 		eng,
-		hlc.NewClock(manual.UnixNano),
 		true,
 		storeCfg,
 		stopper,
 	)
-	return store, stopper, manual
+	return store, stopper
 }
 
 // createTestStoreWithEngine creates a test store using the given engine and clock.
@@ -109,7 +110,6 @@ func createTestStoreWithConfig(
 func createTestStoreWithEngine(
 	t testing.TB,
 	eng engine.Engine,
-	clock *hlc.Clock,
 	bootstrap bool,
 	storeCfg storage.StoreConfig,
 	stopper *stop.Stopper,
@@ -118,14 +118,14 @@ func createTestStoreWithEngine(
 	ac := log.AmbientContext{Tracer: tracer}
 	storeCfg.AmbientCtx = ac
 
-	rpcContext := rpc.NewContext(ac, &base.Config{Insecure: true}, clock, stopper)
+	rpcContext := rpc.NewContext(ac, &base.Config{Insecure: true}, storeCfg.Clock, stopper)
 	nodeDesc := &roachpb.NodeDescriptor{NodeID: 1}
 	server := rpc.NewServer(rpcContext) // never started
 	storeCfg.Gossip = gossip.NewTest(
 		nodeDesc.NodeID, rpcContext, server, nil, stopper, metric.NewRegistry(),
 	)
 	storeCfg.ScanMaxIdleTime = 1 * time.Second
-	stores := storage.NewStores(ac, clock)
+	stores := storage.NewStores(ac, storeCfg.Clock)
 
 	if err := storeCfg.Gossip.SetNodeDescriptor(nodeDesc); err != nil {
 		t.Fatal(err)
@@ -134,7 +134,7 @@ func createTestStoreWithEngine(
 	retryOpts := base.DefaultRetryOptions()
 	retryOpts.Closer = stopper.ShouldQuiesce()
 	distSender := kv.NewDistSender(kv.DistSenderConfig{
-		Clock:            clock,
+		Clock:            storeCfg.Clock,
 		TransportFactory: kv.SenderTransportFactory(tracer, stores),
 		RPCRetryOptions:  &retryOpts,
 	}, storeCfg.Gossip)
@@ -142,17 +142,16 @@ func createTestStoreWithEngine(
 	sender := kv.NewTxnCoordSender(
 		ac,
 		distSender,
-		clock,
+		storeCfg.Clock,
 		false,
 		stopper,
 		kv.MakeTxnMetrics(metric.TestSampleInterval),
 	)
-	storeCfg.Clock = clock
 	storeCfg.DB = client.NewDB(sender)
 	storeCfg.StorePool = storage.NewStorePool(
 		log.AmbientContext{},
 		storeCfg.Gossip,
-		clock,
+		storeCfg.Clock,
 		rpcContext,
 		storage.TestTimeUntilStoreDeadOff,
 		stopper,
@@ -266,10 +265,10 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 	m.nodeLivenesses = make([]*storage.NodeLiveness, numStores)
 
 	if m.manualClock == nil {
-		m.manualClock = hlc.NewManualClock(0)
+		m.manualClock = hlc.NewManualClock(123)
 	}
 	if m.clock == nil {
-		m.clock = hlc.NewClock(m.manualClock.UnixNano)
+		m.clock = hlc.NewClock(m.manualClock.UnixNano, time.Nanosecond)
 	}
 	if m.transportStopper == nil {
 		m.transportStopper = stop.NewStopper()
@@ -589,10 +588,10 @@ func (m *multiTestContext) makeStoreConfig(i int) storage.StoreConfig {
 	var cfg storage.StoreConfig
 	if m.storeConfig != nil {
 		cfg = *m.storeConfig
+		cfg.Clock = m.clocks[i]
 	} else {
-		cfg = storage.TestStoreConfig()
+		cfg = storage.TestStoreConfig(m.clocks[i])
 	}
-	cfg.Clock = m.clocks[i]
 	cfg.Transport = m.transports[i]
 	cfg.DB = m.dbs[i]
 	cfg.Gossip = m.gossips[i]

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 	"unsafe"
 
 	"golang.org/x/net/context"
@@ -1872,7 +1873,7 @@ func TestMVCCConditionalPut(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	clock := hlc.NewClock(hlc.NewManualClock(0).UnixNano)
+	clock := hlc.NewClock(hlc.NewManualClock(123).UnixNano, time.Nanosecond)
 
 	err := MVCCConditionalPut(context.Background(), engine, nil, testKey1, clock.Now(), value1, &value2, nil)
 	if err == nil {
@@ -1966,7 +1967,7 @@ func TestMVCCConditionalPutWithTxn(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	clock := hlc.NewClock(hlc.NewManualClock(0).UnixNano)
+	clock := hlc.NewClock(hlc.NewManualClock(123).UnixNano, time.Nanosecond)
 
 	// Write value1.
 	txn := *txn1
@@ -1988,7 +1989,7 @@ func TestMVCCConditionalPutWithTxn(t *testing.T) {
 	// Commit value3.
 	txnCommit := txn
 	txnCommit.Status = roachpb.COMMITTED
-	txnCommit.Timestamp = makeTS(1, 0)
+	txnCommit.Timestamp = clock.Now().Add(1, 0)
 	if err := MVCCResolveWriteIntent(context.Background(), engine, nil, roachpb.Intent{Span: roachpb.Span{Key: testKey1}, Status: txnCommit.Status, Txn: txnCommit.TxnMeta}); err != nil {
 		t.Fatal(err)
 	}
@@ -2062,7 +2063,7 @@ func TestMVCCInitPutWithTxn(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	clock := hlc.NewClock(hlc.NewManualClock(0).UnixNano)
+	clock := hlc.NewClock(hlc.NewManualClock(123).UnixNano, time.Nanosecond)
 
 	txn := *txn1
 	txn.Sequence++
@@ -2090,7 +2091,7 @@ func TestMVCCInitPutWithTxn(t *testing.T) {
 	// Commit value3.
 	txnCommit := txn
 	txnCommit.Status = roachpb.COMMITTED
-	txnCommit.Timestamp = makeTS(1, 0)
+	txnCommit.Timestamp = clock.Now().Add(1, 0)
 	if err := MVCCResolveWriteIntent(context.Background(), engine, nil,
 		roachpb.Intent{
 			Span:   roachpb.Span{Key: testKey1},

--- a/pkg/storage/queue_test.go
+++ b/pkg/storage/queue_test.go
@@ -281,7 +281,7 @@ func TestBaseQueueAdd(t *testing.T) {
 // processed according to the timer function.
 func TestBaseQueueProcess(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	tsc := TestStoreConfig()
+	tsc := TestStoreConfig(nil)
 	tc := testContext{}
 	tc.StartWithStoreConfig(t, tsc)
 	defer tc.Stop()
@@ -313,7 +313,7 @@ func TestBaseQueueProcess(t *testing.T) {
 		},
 	}
 	bq := makeTestBaseQueue("test", testQueue, tc.store, tc.gossip, queueConfig{maxSize: 2})
-	bq.Start(tc.clock, tc.stopper)
+	bq.Start(tc.Clock(), tc.stopper)
 
 	bq.MaybeAdd(r1, hlc.ZeroTimestamp)
 	bq.MaybeAdd(r2, hlc.ZeroTimestamp)
@@ -382,8 +382,8 @@ func TestBaseQueueAddRemove(t *testing.T) {
 		},
 	}
 	bq := makeTestBaseQueue("test", testQueue, tc.store, tc.gossip, queueConfig{maxSize: 2})
-	mc := hlc.NewManualClock(0)
-	clock := hlc.NewClock(mc.UnixNano)
+	mc := hlc.NewManualClock(123)
+	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
 	bq.Start(clock, tc.stopper)
 
 	bq.MaybeAdd(r, hlc.ZeroTimestamp)
@@ -530,7 +530,7 @@ func (*testError) purgatoryErrorMarker() {
 // the purgatory channel causes the replicas to be reprocessed.
 func TestBaseQueuePurgatory(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	tsc := TestStoreConfig()
+	tsc := TestStoreConfig(nil)
 	tc := testContext{}
 	tc.StartWithStoreConfig(t, tsc)
 	defer tc.Stop()
@@ -557,7 +557,7 @@ func TestBaseQueuePurgatory(t *testing.T) {
 
 	replicaCount := 10
 	bq := makeTestBaseQueue("test", testQueue, tc.store, tc.gossip, queueConfig{maxSize: replicaCount})
-	bq.Start(tc.clock, tc.stopper)
+	bq.Start(tc.Clock(), tc.stopper)
 
 	for i := 1; i <= replicaCount; i++ {
 		r := createReplica(tc.store, roachpb.RangeID(i+1000),
@@ -700,7 +700,7 @@ func TestBaseQueueProcessTimeout(t *testing.T) {
 	}
 	bq := makeTestBaseQueue("test", ptQueue, tc.store, tc.gossip,
 		queueConfig{maxSize: 1, processTimeout: 1 * time.Millisecond})
-	bq.Start(tc.clock, tc.stopper)
+	bq.Start(tc.Clock(), tc.stopper)
 	bq.MaybeAdd(r, hlc.ZeroTimestamp)
 
 	if l := bq.Length(); l != 1 {
@@ -751,7 +751,7 @@ func TestBaseQueueTimeMetric(t *testing.T) {
 	}
 	bq := makeTestBaseQueue("test", ptQueue, tc.store, tc.gossip,
 		queueConfig{maxSize: 1, processTimeout: 1 * time.Millisecond})
-	bq.Start(tc.clock, tc.stopper)
+	bq.Start(tc.Clock(), tc.stopper)
 	bq.MaybeAdd(r, hlc.ZeroTimestamp)
 
 	util.SucceedsSoon(t, func() error {

--- a/pkg/storage/raft_transport_test.go
+++ b/pkg/storage/raft_transport_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -102,7 +103,10 @@ func newRaftTransportTestContext(t testing.TB) *raftTransportTestContext {
 		transports: map[roachpb.NodeID]*storage.RaftTransport{},
 	}
 	rttc.nodeRPCContext = rpc.NewContext(
-		log.AmbientContext{}, testutils.NewNodeTestBaseContext(), nil, rttc.stopper,
+		log.AmbientContext{},
+		testutils.NewNodeTestBaseContext(),
+		hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		rttc.stopper,
 	)
 	server := rpc.NewServer(rttc.nodeRPCContext) // never started
 	rttc.gossip = gossip.NewTest(

--- a/pkg/storage/replica_data_iter_test.go
+++ b/pkg/storage/replica_data_iter_test.go
@@ -139,7 +139,7 @@ func TestReplicaDataIteratorEmptyRange(t *testing.T) {
 // it verifies the pre and post ranges still contain the expected data.
 func TestReplicaDataIterator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	cfg := TestStoreConfig()
+	cfg := TestStoreConfig(nil)
 	// Disable Raft processing for this test as it mucks with low-level details
 	// of replica storage in an unsafe way.
 	cfg.TestingKnobs.DisableProcessRaft = true

--- a/pkg/storage/replica_raftstorage_test.go
+++ b/pkg/storage/replica_raftstorage_test.go
@@ -57,7 +57,7 @@ func fillTestRange(t testing.TB, rep *Replica, size int64) {
 
 func TestSkipLargeReplicaSnapshot(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	storeCfg := TestStoreConfig()
+	storeCfg := TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 
 	const snapSize = 1 << 20 // 1 MiB
@@ -65,7 +65,7 @@ func TestSkipLargeReplicaSnapshot(t *testing.T) {
 	cfg.RangeMaxBytes = snapSize
 	defer config.TestingSetDefaultZoneConfig(cfg)()
 
-	store, _, stopper := createTestStoreWithContext(t, &storeCfg)
+	store, stopper := createTestStoreWithConfig(t, &storeCfg)
 	defer stopper.Stop()
 
 	rep, err := store.GetReplica(rangeID)

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -122,15 +122,19 @@ type testContext struct {
 	gossip        *gossip.Gossip
 	engine        engine.Engine
 	manualClock   *hlc.ManualClock
-	clock         *hlc.Clock
 	stopper       *stop.Stopper
 	bootstrapMode bootstrapMode
+}
+
+func (tc *testContext) Clock() *hlc.Clock {
+	return tc.store.cfg.Clock
 }
 
 // Start initializes the test context with a single range covering the
 // entire keyspace.
 func (tc *testContext) Start(t testing.TB) {
-	cfg := TestStoreConfig()
+	tc.manualClock = hlc.NewManualClock(123)
+	cfg := TestStoreConfig(hlc.NewClock(tc.manualClock.UnixNano, time.Nanosecond))
 	tc.StartWithStoreConfig(t, cfg)
 }
 
@@ -144,15 +148,9 @@ func (tc *testContext) StartWithStoreConfig(t testing.TB, cfg StoreConfig) {
 	// Setup fake zone config handler.
 	config.TestingSetupZoneConfigHook(tc.stopper)
 	if tc.gossip == nil {
-		rpcContext := rpc.NewContext(cfg.AmbientCtx, &base.Config{Insecure: true}, nil, tc.stopper)
+		rpcContext := rpc.NewContext(cfg.AmbientCtx, &base.Config{Insecure: true}, cfg.Clock, tc.stopper)
 		server := rpc.NewServer(rpcContext) // never started
 		tc.gossip = gossip.NewTest(1, rpcContext, server, nil, tc.stopper, metric.NewRegistry())
-	}
-	if tc.manualClock == nil {
-		tc.manualClock = hlc.NewManualClock(0)
-	}
-	if tc.clock == nil {
-		tc.clock = hlc.NewClock(tc.manualClock.UnixNano)
 	}
 	if tc.engine == nil {
 		tc.engine = engine.NewInMem(roachpb.Attributes{Attrs: []string{"dc1", "mem"}}, 1<<20)
@@ -163,7 +161,6 @@ func (tc *testContext) StartWithStoreConfig(t testing.TB, cfg StoreConfig) {
 	}
 
 	if tc.store == nil {
-		cfg.Clock = tc.clock
 		cfg.Gossip = tc.gossip
 		cfg.Transport = tc.transport
 		// Create a test sender without setting a store. This is to deal with the
@@ -237,7 +234,7 @@ func (tc *testContext) Sender() client.Sender {
 			ba.RangeID = 1
 		}
 		if ba.Timestamp == hlc.ZeroTimestamp {
-			if err := ba.SetActiveTimestamp(tc.clock.Now); err != nil {
+			if err := ba.SetActiveTimestamp(tc.Clock().Now); err != nil {
 				tc.Fatal(err)
 			}
 		}
@@ -338,7 +335,7 @@ func TestIsOnePhaseCommit(t *testing.T) {
 		{txnReqs, true, true, true, false},
 	}
 
-	clock := hlc.NewClock(hlc.UnixNano)
+	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	for i, c := range testCases {
 		ba := roachpb.BatchRequest{Requests: c.bu}
 		if c.isTxn {
@@ -443,7 +440,7 @@ func TestReplicaReadConsistency(t *testing.T) {
 	}
 
 	// Try an inconsistent read within a transaction.
-	txn := newTransaction("test", roachpb.Key("a"), 1, enginepb.SERIALIZABLE, tc.clock)
+	txn := newTransaction("test", roachpb.Key("a"), 1, enginepb.SERIALIZABLE, tc.Clock())
 
 	if _, err := tc.SendWrappedWith(roachpb.Header{
 		Txn:             txn,
@@ -454,8 +451,8 @@ func TestReplicaReadConsistency(t *testing.T) {
 
 	// Lose the lease and verify CONSISTENT reads receive NotLeaseHolderError
 	// and INCONSISTENT reads work as expected.
-	start := hlc.ZeroTimestamp.Add(leaseExpiry(tc.rng), 0)
-	tc.manualClock.Set(start.WallTime)
+	tc.manualClock.Set(leaseExpiry(tc.rng))
+	start := tc.Clock().Now()
 	if err := sendLeaseRequest(tc.rng, &roachpb.Lease{
 		Start:       start,
 		StartStasis: start.Add(10, 0),
@@ -508,8 +505,8 @@ func TestApplyCmdLeaseError(t *testing.T) {
 	pArgs := putArgs(roachpb.Key("a"), []byte("asd"))
 
 	// Lose the lease.
-	start := hlc.ZeroTimestamp.Add(leaseExpiry(tc.rng), 0)
-	tc.manualClock.Set(start.WallTime)
+	tc.manualClock.Set(leaseExpiry(tc.rng))
+	start := tc.Clock().Now()
 	if err := sendLeaseRequest(tc.rng, &roachpb.Lease{
 		Start:       start,
 		StartStasis: start.Add(10, 0),
@@ -524,7 +521,7 @@ func TestApplyCmdLeaseError(t *testing.T) {
 	}
 
 	_, pErr := tc.SendWrappedWith(roachpb.Header{
-		Timestamp: tc.clock.Now().Add(-100, 0),
+		Timestamp: tc.Clock().Now().Add(-100, 0),
 	}, &pArgs)
 	if _, ok := pErr.GetDetail().(*roachpb.NotLeaseHolderError); !ok {
 		t.Fatalf("expected not lease holder error in return, got %v", pErr)
@@ -599,11 +596,11 @@ func TestReplicaLease(t *testing.T) {
 		}
 	}
 
-	if held, _ := hasLease(tc.rng, tc.clock.Now()); !held {
+	if held, _ := hasLease(tc.rng, tc.Clock().Now()); !held {
 		t.Errorf("expected lease on range start")
 	}
 	tc.manualClock.Set(leaseExpiry(tc.rng))
-	now := tc.clock.Now()
+	now := tc.Clock().Now()
 	if err := sendLeaseRequest(tc.rng, &roachpb.Lease{
 		Start:       now.Add(10, 0),
 		StartStasis: now.Add(20, 0),
@@ -612,7 +609,7 @@ func TestReplicaLease(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if held, expired := hasLease(tc.rng, tc.clock.Now().Add(15, 0)); held || expired {
+	if held, expired := hasLease(tc.rng, tc.Clock().Now().Add(15, 0)); held || expired {
 		t.Errorf("expected second replica to have range lease")
 	}
 
@@ -625,7 +622,7 @@ func TestReplicaLease(t *testing.T) {
 	// Advance clock past expiration and verify that another has
 	// range lease will not be true.
 	tc.manualClock.Increment(21) // 21ns have passed
-	if held, expired := hasLease(tc.rng, tc.clock.Now()); held || !expired {
+	if held, expired := hasLease(tc.rng, tc.Clock().Now()); held || !expired {
 		t.Errorf("expected another replica to have expired lease")
 	}
 
@@ -670,7 +667,7 @@ func TestReplicaNotLeaseHolderError(t *testing.T) {
 	tc.rng.setDescWithoutProcessUpdate(&rngDesc)
 
 	tc.manualClock.Set(leaseExpiry(tc.rng))
-	now := tc.clock.Now()
+	now := tc.Clock().Now()
 	if err := sendLeaseRequest(tc.rng, &roachpb.Lease{
 		Start:       now,
 		StartStasis: now.Add(10, 0),
@@ -731,7 +728,7 @@ func TestReplicaLeaseCounters(t *testing.T) {
 	assert(metrics.LeaseRequestSuccessCount.Count(), 1, 1000)
 	assert(metrics.LeaseRequestErrorCount.Count(), 0, 0)
 
-	now := tc.clock.Now()
+	now := tc.Clock().Now()
 	if err := sendLeaseRequest(tc.rng, &roachpb.Lease{
 		Start:       now,
 		StartStasis: now.Add(10, 0),
@@ -804,7 +801,7 @@ func TestReplicaGossipConfigsOnLease(t *testing.T) {
 	// Expire our own lease which we automagically acquired due to being
 	// first range and config holder.
 	tc.manualClock.Set(leaseExpiry(tc.rng))
-	now := tc.clock.Now()
+	now := tc.Clock().Now()
 
 	// Give lease to someone else.
 	if err := sendLeaseRequest(tc.rng, &roachpb.Lease{
@@ -821,8 +818,8 @@ func TestReplicaGossipConfigsOnLease(t *testing.T) {
 	}
 
 	// Expire that lease.
-	tc.manualClock.Increment(11 + int64(tc.clock.MaxOffset())) // advance time
-	now = tc.clock.Now()
+	tc.manualClock.Increment(11 + int64(tc.Clock().MaxOffset())) // advance time
+	now = tc.Clock().Now()
 
 	// Give lease to this range.
 	if err := sendLeaseRequest(tc.rng, &roachpb.Lease{
@@ -882,12 +879,7 @@ func TestReplicaTSCacheLowWaterOnLease(t *testing.T) {
 	tc.rng.setDescWithoutProcessUpdate(&rngDesc)
 
 	tc.manualClock.Set(leaseExpiry(tc.rng))
-	now := hlc.Timestamp{WallTime: tc.manualClock.UnixNano()}
-
-	tc.rng.mu.Lock()
-	baseRTS, _, _ := tc.rng.mu.tsCache.GetMaxRead(roachpb.Key("a"), nil /* end */)
-	tc.rng.mu.Unlock()
-	baseLowWater := baseRTS.WallTime
+	now := tc.Clock().Now()
 
 	testCases := []struct {
 		storeID     roachpb.StoreID
@@ -915,13 +907,13 @@ func TestReplicaTSCacheLowWaterOnLease(t *testing.T) {
 			start: now.Add(31, 0), expiration: now.Add(50, 0),
 			// The cache now moves to this other store, and we can't query that.
 			expLowWater: 0},
-		// Lease is regranted to this replica. The low-water mark is updated to the
+		// Lease is regranted to this store. The low-water mark is updated to the
 		// beginning of the lease.
 		{storeID: tc.store.StoreID(),
 			start: now.Add(60, 0), expiration: now.Add(70, 0),
 			// We expect 50, not 60, because the new lease is wound back to the end
 			// of the previous lease.
-			expLowWater: now.Add(50, 0).WallTime + baseLowWater},
+			expLowWater: now.Add(50, 0).WallTime},
 	}
 
 	for i, test := range testCases {
@@ -963,7 +955,7 @@ func TestReplicaLeaseRejectUnknownRaftNodeID(t *testing.T) {
 	defer tc.Stop()
 
 	tc.manualClock.Set(leaseExpiry(tc.rng))
-	now := tc.clock.Now()
+	now := tc.Clock().Now()
 	lease := &roachpb.Lease{
 		Start:       now,
 		StartStasis: now.Add(10, 0),
@@ -1029,7 +1021,7 @@ func TestReplicaDrainLease(t *testing.T) {
 		t.Fatal("DrainLeases returned with active lease")
 	}
 	tc.rng.mu.Lock()
-	pErr := <-tc.rng.requestLeaseLocked(tc.clock.Now())
+	pErr := <-tc.rng.requestLeaseLocked(tc.Clock().Now())
 	tc.rng.mu.Unlock()
 	_, ok := pErr.GetDetail().(*roachpb.NotLeaseHolderError)
 	if !ok {
@@ -1116,7 +1108,7 @@ func TestReplicaNoGossipConfig(t *testing.T) {
 	// Write some arbitrary data in the system span (up to, but not including MaxReservedID+1)
 	key := keys.MakeTablePrefix(keys.MaxReservedDescID)
 
-	txn := newTransaction("test", key, 1 /* userPriority */, enginepb.SERIALIZABLE, tc.clock)
+	txn := newTransaction("test", key, 1 /* userPriority */, enginepb.SERIALIZABLE, tc.Clock())
 	h := roachpb.Header{Txn: txn}
 	req1 := putArgs(key, []byte("foo"))
 	req2, _ := endTxnArgs(txn, true /* commit */)
@@ -1161,7 +1153,7 @@ func TestReplicaNoGossipFromNonLeader(t *testing.T) {
 	// Write some arbitrary data in the system span (up to, but not including MaxReservedID+1)
 	key := keys.MakeTablePrefix(keys.MaxReservedDescID)
 
-	txn := newTransaction("test", key, 1 /* userPriority */, enginepb.SERIALIZABLE, tc.clock)
+	txn := newTransaction("test", key, 1 /* userPriority */, enginepb.SERIALIZABLE, tc.Clock())
 	req1 := putArgs(key, nil)
 	if _, pErr := maybeWrapWithBeginTransaction(context.Background(), tc.Sender(), roachpb.Header{
 		Txn: txn,
@@ -1185,7 +1177,7 @@ func TestReplicaNoGossipFromNonLeader(t *testing.T) {
 
 	// Increment the clock's timestamp to expire the range lease.
 	tc.manualClock.Set(leaseExpiry(tc.rng))
-	if lease, _ := tc.rng.getLease(); lease.Covers(tc.clock.Now()) {
+	if lease, _ := tc.rng.getLease(); lease.Covers(tc.Clock().Now()) {
 		t.Fatal("range lease should have been expired")
 	}
 
@@ -1555,7 +1547,7 @@ func TestAcquireLease(t *testing.T) {
 		expStart := lease.Start
 		tc.manualClock.Set(leaseExpiry(tc.rng))
 
-		ts := tc.clock.Now().Next()
+		ts := tc.Clock().Now().Next()
 		if _, pErr := tc.SendWrappedWith(roachpb.Header{Timestamp: ts}, test); pErr != nil {
 			t.Error(pErr)
 		}
@@ -1657,7 +1649,7 @@ func TestLeaseConcurrent(t *testing.T) {
 
 			active.Store(true)
 			tc.manualClock.Increment(leaseExpiry(tc.rng))
-			ts := tc.clock.Now()
+			ts := tc.Clock().Now()
 			pErrCh := make(chan *roachpb.Error, num)
 			for i := 0; i < num; i++ {
 				if err := tc.stopper.RunAsyncTask(context.Background(), func(_ context.Context) {
@@ -1709,15 +1701,15 @@ func TestReplicaUpdateTSCache(t *testing.T) {
 	tc := testContext{}
 	tc.Start(t)
 	defer tc.Stop()
+
+	startNanos := tc.Clock().Now().WallTime
+
 	// Set clock to time 1s and do the read.
 	t0 := 1 * time.Second
 	tc.manualClock.Set(t0.Nanoseconds())
 	gArgs := getArgs([]byte("a"))
-	ts := tc.clock.Now()
 
-	_, pErr := tc.SendWrappedWith(roachpb.Header{Timestamp: ts}, &gArgs)
-
-	if pErr != nil {
+	if _, pErr := tc.SendWrappedWith(roachpb.Header{Timestamp: tc.Clock().Now()}, &gArgs); pErr != nil {
 		t.Error(pErr)
 	}
 	// Set clock to time 2s for write.
@@ -1725,11 +1717,8 @@ func TestReplicaUpdateTSCache(t *testing.T) {
 	key := roachpb.Key([]byte("b"))
 	tc.manualClock.Set(t1.Nanoseconds())
 	drArgs := roachpb.NewDeleteRange(key, key.Next(), false)
-	ts = tc.clock.Now()
 
-	_, pErr = tc.SendWrappedWith(roachpb.Header{Timestamp: ts}, drArgs)
-
-	if pErr != nil {
+	if _, pErr := tc.SendWrappedWith(roachpb.Header{Timestamp: tc.Clock().Now()}, drArgs); pErr != nil {
 		t.Error(pErr)
 	}
 	// Verify the timestamp cache has rTS=1s and wTS=0s for "a".
@@ -1743,19 +1732,19 @@ func TestReplicaUpdateTSCache(t *testing.T) {
 	tc.rng.mu.tsCache.ExpandRequests(hlc.ZeroTimestamp)
 	rTS, _, rOK := tc.rng.mu.tsCache.GetMaxRead(roachpb.Key("a"), nil)
 	wTS, _, wOK := tc.rng.mu.tsCache.GetMaxWrite(roachpb.Key("a"), nil)
-	if rTS.WallTime != t0.Nanoseconds() || wTS.WallTime != 0 || !rOK || wOK {
+	if rTS.WallTime != t0.Nanoseconds() || wTS.WallTime != startNanos || !rOK || wOK {
 		t.Errorf("expected rTS=1s and wTS=0s, but got %s, %s; rOK=%t, wOK=%t", rTS, wTS, rOK, wOK)
 	}
 	// Verify the timestamp cache has rTS=0s and wTS=2s for "b".
 	rTS, _, rOK = tc.rng.mu.tsCache.GetMaxRead(roachpb.Key("b"), nil)
 	wTS, _, wOK = tc.rng.mu.tsCache.GetMaxWrite(roachpb.Key("b"), nil)
-	if rTS.WallTime != 0 || wTS.WallTime != t1.Nanoseconds() || rOK || !wOK {
+	if rTS.WallTime != startNanos || wTS.WallTime != t1.Nanoseconds() || rOK || !wOK {
 		t.Errorf("expected rTS=0s and wTS=2s, but got %s, %s; rOK=%t, wOK=%t", rTS, wTS, rOK, wOK)
 	}
 	// Verify another key ("c") has 0sec in timestamp cache.
 	rTS, _, rOK = tc.rng.mu.tsCache.GetMaxRead(roachpb.Key("c"), nil)
 	wTS, _, wOK = tc.rng.mu.tsCache.GetMaxWrite(roachpb.Key("c"), nil)
-	if rTS.WallTime != 0 || wTS.WallTime != 0 || rOK || wOK {
+	if rTS.WallTime != startNanos || wTS.WallTime != startNanos || rOK || wOK {
 		t.Errorf("expected rTS=0s and wTS=0s, but got %s %s; rOK=%t, wOK=%t", rTS, wTS, rOK, wOK)
 	}
 }
@@ -1770,7 +1759,7 @@ func TestReplicaCommandQueue(t *testing.T) {
 	blockingDone := make(chan struct{})
 
 	tc := testContext{}
-	tsc := TestStoreConfig()
+	tsc := TestStoreConfig(nil)
 	tsc.TestingKnobs.TestingCommandFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if filterArgs.Hdr.UserPriority == 42 {
@@ -1893,7 +1882,7 @@ func TestReplicaCommandQueueInconsistent(t *testing.T) {
 	blockingDone := make(chan struct{})
 
 	tc := testContext{}
-	tsc := TestStoreConfig()
+	tsc := TestStoreConfig(nil)
 	tsc.TestingKnobs.TestingCommandFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if put, ok := filterArgs.Req.(*roachpb.PutRequest); ok {
@@ -1966,7 +1955,7 @@ func TestReplicaCommandQueueCancellation(t *testing.T) {
 	blockingDone := make(chan struct{})
 
 	tc := testContext{}
-	tsc := TestStoreConfig()
+	tsc := TestStoreConfig(nil)
 	tsc.TestingKnobs.TestingCommandFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if filterArgs.Hdr.UserPriority == 42 {
@@ -2078,7 +2067,7 @@ func TestReplicaUseTSCache(t *testing.T) {
 	if pErr != nil {
 		t.Fatal(pErr)
 	}
-	if respH.Timestamp.WallTime != tc.clock.Timestamp().WallTime {
+	if respH.Timestamp.WallTime != tc.Clock().Now().WallTime {
 		t.Errorf("expected write timestamp to upgrade to 1s; got %s", respH.Timestamp)
 	}
 }
@@ -2094,7 +2083,7 @@ func TestReplicaNoTSCacheInconsistent(t *testing.T) {
 	t0 := 1 * time.Second
 	tc.manualClock.Set(t0.Nanoseconds())
 	args := getArgs([]byte("a"))
-	ts := tc.clock.Now()
+	ts := tc.Clock().Now()
 
 	_, pErr := tc.SendWrappedWith(roachpb.Header{
 		Timestamp:       ts,
@@ -2110,7 +2099,7 @@ func TestReplicaNoTSCacheInconsistent(t *testing.T) {
 	if pErr != nil {
 		t.Fatal(pErr)
 	}
-	if respH.Timestamp.WallTime == tc.clock.Timestamp().WallTime {
+	if respH.Timestamp.WallTime == tc.Clock().Now().WallTime {
 		t.Errorf("expected write timestamp not to upgrade to 1s; got %s", respH.Timestamp)
 	}
 }
@@ -2130,7 +2119,7 @@ func TestReplicaNoTSCacheUpdateOnFailure(t *testing.T) {
 
 		// Start by laying down an intent to trip up future read or write to same key.
 		pArgs := putArgs(key, []byte("value"))
-		txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
+		txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 
 		_, pErr := tc.SendWrappedWith(roachpb.Header{
 			Txn: txn,
@@ -2141,7 +2130,7 @@ func TestReplicaNoTSCacheUpdateOnFailure(t *testing.T) {
 
 		// Now attempt read or write.
 		args := readOrWriteArgs(key, read)
-		ts := tc.clock.Now() // later timestamp
+		ts := tc.Clock().Now() // later timestamp
 
 		if _, pErr := tc.SendWrappedWith(roachpb.Header{
 			Timestamp: ts,
@@ -2170,7 +2159,7 @@ func TestReplicaNoTimestampIncrementWithinTxn(t *testing.T) {
 
 	// Test for both read & write attempts.
 	key := roachpb.Key("a")
-	txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
+	txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 
 	// Start with a read to warm the timestamp cache.
 	gArgs := getArgs(key)
@@ -2228,7 +2217,7 @@ func TestReplicaAbortCacheReadError(t *testing.T) {
 	defer tc.Stop()
 
 	k := []byte("a")
-	txn := newTransaction("test", k, 10, enginepb.SERIALIZABLE, tc.clock)
+	txn := newTransaction("test", k, 10, enginepb.SERIALIZABLE, tc.Clock())
 	args := incrementArgs(k, 1)
 	txn.Sequence = 1
 
@@ -2264,7 +2253,7 @@ func TestReplicaAbortCacheStoredTxnRetryError(t *testing.T) {
 
 	key := []byte("a")
 	{
-		txn := newTransaction("test", key, 10, enginepb.SERIALIZABLE, tc.clock)
+		txn := newTransaction("test", key, 10, enginepb.SERIALIZABLE, tc.Clock())
 		txn.Sequence = int32(1)
 		entry := roachpb.AbortCacheEntry{
 			Key:       txn.Key,
@@ -2286,7 +2275,7 @@ func TestReplicaAbortCacheStoredTxnRetryError(t *testing.T) {
 
 	// Try the same again, this time verifying that the Put will actually
 	// populate the cache appropriately.
-	txn := newTransaction("test", key, 10, enginepb.SERIALIZABLE, tc.clock)
+	txn := newTransaction("test", key, 10, enginepb.SERIALIZABLE, tc.Clock())
 	txn.Sequence = 321
 	args := incrementArgs(key, 1)
 	try := func() *roachpb.Error {
@@ -2331,8 +2320,8 @@ func TestTransactionRetryLeavesIntents(t *testing.T) {
 	defer tc.Stop()
 
 	key := roachpb.Key("a")
-	pushee := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
-	pusher := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
+	pushee := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
+	pusher := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 	pushee.Priority = 1
 	pusher.Priority = 2 // pusher will win
 
@@ -2373,7 +2362,7 @@ func TestReplicaAbortCacheOnlyWithIntent(t *testing.T) {
 	tc.Start(t)
 	defer tc.Stop()
 
-	txn := newTransaction("test", []byte("test"), 10, enginepb.SERIALIZABLE, tc.clock)
+	txn := newTransaction("test", []byte("test"), 10, enginepb.SERIALIZABLE, tc.Clock())
 	txn.Sequence = 100
 	entry := roachpb.AbortCacheEntry{
 		Key:       txn.Key,
@@ -2403,7 +2392,7 @@ func TestEndTransactionDeadline(t *testing.T) {
 	// 4 cases: no deadline, past deadline, equal deadline, future deadline.
 	for i := 0; i < 4; i++ {
 		key := roachpb.Key("key: " + strconv.Itoa(i))
-		txn := newTransaction("txn: "+strconv.Itoa(i), key, 1, enginepb.SERIALIZABLE, tc.clock)
+		txn := newTransaction("txn: "+strconv.Itoa(i), key, 1, enginepb.SERIALIZABLE, tc.Clock())
 		put := putArgs(key, key)
 
 		_, header := beginTxnArgs(key, txn)
@@ -2480,9 +2469,9 @@ func TestEndTransactionTxnSpanGCThreshold(t *testing.T) {
 
 	// This pushee should never be allowed to write a txn record because it
 	// will be aborted before it even tries.
-	pushee := newTransaction("foo", key, 1, enginepb.SERIALIZABLE, tc.clock)
+	pushee := newTransaction("foo", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 	pushReq := pushTxnArgs(pusher, pushee, roachpb.PUSH_TOUCH)
-	pushReq.Now = tc.clock.Now()
+	pushReq.Now = tc.Clock().Now()
 	resp, pErr := tc.SendWrapped(&pushReq)
 	if pErr != nil {
 		t.Fatal(pErr)
@@ -2510,7 +2499,7 @@ func TestEndTransactionTxnSpanGCThreshold(t *testing.T) {
 			Keys: []roachpb.GCRequest_GCKey{
 				{Key: keys.TransactionKey(pushee.Key, pushee.ID)},
 			},
-			TxnSpanGCThreshold: tc.clock.Now(),
+			TxnSpanGCThreshold: tc.Clock().Now(),
 		}
 		if _, pErr := tc.SendWrapped(&gcReq); pErr != nil {
 			t.Fatal(pErr)
@@ -2537,7 +2526,7 @@ func TestEndTransactionTxnSpanGCThreshold(t *testing.T) {
 	// be prevented from writing its record.
 	// See #9522.
 	{
-		txn := newTransaction("foo", key, 1, enginepb.SERIALIZABLE, tc.clock)
+		txn := newTransaction("foo", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 		beginArgs, header := beginTxnArgs(key, txn)
 		if _, pErr := tc.SendWrappedWith(header, &beginArgs); pErr != nil {
 			t.Fatal(pErr)
@@ -2555,7 +2544,7 @@ func TestEndTransactionDeadline_1PC(t *testing.T) {
 	defer tc.Stop()
 
 	key := roachpb.Key("a")
-	txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
+	txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 	bt, _ := beginTxnArgs(key, txn)
 	put := putArgs(key, []byte("value"))
 	et, etH := endTxnArgs(txn, true)
@@ -2581,7 +2570,7 @@ func TestEndTransactionWithMalformedSplitTrigger(t *testing.T) {
 	defer tc.Stop()
 
 	key := roachpb.Key("foo")
-	txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
+	txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 	pArgs := putArgs(key, []byte("only here to make this a rw transaction"))
 	txn.Sequence++
 	if _, pErr := maybeWrapWithBeginTransaction(context.Background(), tc.Sender(), roachpb.Header{
@@ -2621,7 +2610,7 @@ func TestEndTransactionBeforeHeartbeat(t *testing.T) {
 
 	key := []byte("a")
 	for _, commit := range []bool{true, false} {
-		txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
+		txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 		_, btH := beginTxnArgs(key, txn)
 		put := putArgs(key, key)
 		if _, pErr := maybeWrapWithBeginTransaction(context.Background(), tc.Sender(), btH, &put); pErr != nil {
@@ -2671,7 +2660,7 @@ func TestEndTransactionAfterHeartbeat(t *testing.T) {
 
 	key := roachpb.Key("a")
 	for _, commit := range []bool{true, false} {
-		txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
+		txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 		_, btH := beginTxnArgs(key, txn)
 		put := putArgs(key, key)
 		if _, pErr := maybeWrapWithBeginTransaction(context.Background(), tc.Sender(), btH, &put); pErr != nil {
@@ -2736,8 +2725,8 @@ func TestEndTransactionWithPushedTimestamp(t *testing.T) {
 	}
 	key := roachpb.Key("a")
 	for i, test := range testCases {
-		pushee := newTransaction("pushee", key, 1, test.isolation, tc.clock)
-		pusher := newTransaction("pusher", key, 1, enginepb.SERIALIZABLE, tc.clock)
+		pushee := newTransaction("pushee", key, 1, test.isolation, tc.Clock())
+		pusher := newTransaction("pusher", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 		pushee.Priority = 1
 		pusher.Priority = 2 // pusher will win
 		_, btH := beginTxnArgs(key, pushee)
@@ -2788,7 +2777,7 @@ func TestEndTransactionWithIncrementedEpoch(t *testing.T) {
 	defer tc.Stop()
 
 	key := []byte("a")
-	txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
+	txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 	_, btH := beginTxnArgs(key, txn)
 	put := putArgs(key, key)
 	if _, pErr := maybeWrapWithBeginTransaction(context.Background(), tc.Sender(), btH, &put); pErr != nil {
@@ -2836,9 +2825,8 @@ func TestEndTransactionWithErrors(t *testing.T) {
 	tc.Start(t)
 	defer tc.Stop()
 
-	regressTS := tc.clock.Now()
-	tc.manualClock.Set(1)
-	txn := newTransaction("test", roachpb.Key(""), 1, enginepb.SERIALIZABLE, tc.clock)
+	regressTS := tc.Clock().Now()
+	txn := newTransaction("test", roachpb.Key(""), 1, enginepb.SERIALIZABLE, tc.Clock())
 
 	doesNotExist := roachpb.TransactionStatus(-1)
 
@@ -2853,7 +2841,7 @@ func TestEndTransactionWithErrors(t *testing.T) {
 		{roachpb.Key("a"), roachpb.COMMITTED, txn.Epoch, txn.Timestamp, "txn \"test\" id=.*: already committed"},
 		{roachpb.Key("b"), roachpb.ABORTED, txn.Epoch, txn.Timestamp, "txn aborted \"test\" id=.*"},
 		{roachpb.Key("c"), roachpb.PENDING, txn.Epoch + 1, txn.Timestamp, "txn \"test\" id=.*: epoch regression: 0"},
-		{roachpb.Key("d"), roachpb.PENDING, txn.Epoch, regressTS, `txn "test" id=.*: timestamp regression: 0.000000001,\d+`},
+		{roachpb.Key("d"), roachpb.PENDING, txn.Epoch, regressTS, `txn "test" id=.*: timestamp regression: 0.\d+,\d+`},
 	}
 	for i, test := range testCases {
 		// Establish existing txn state by writing directly to range engine.
@@ -2896,7 +2884,7 @@ func TestEndTransactionRollbackAbortedTransaction(t *testing.T) {
 	defer tc.Stop()
 
 	key := []byte("a")
-	txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
+	txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 	_, btH := beginTxnArgs(key, txn)
 	put := putArgs(key, key)
 	if _, pErr := maybeWrapWithBeginTransaction(context.Background(), tc.Sender(), btH, &put); pErr != nil {
@@ -2904,7 +2892,7 @@ func TestEndTransactionRollbackAbortedTransaction(t *testing.T) {
 	}
 
 	// Abort the transaction by pushing it with a higher priority.
-	pusher := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
+	pusher := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 	pusher.Priority = txn.Priority + 1 // will push successfully
 	pushArgs := pushTxnArgs(pusher, btH.Txn, roachpb.PUSH_ABORT)
 	if _, pErr := tc.SendWrapped(&pushArgs); pErr != nil {
@@ -2915,7 +2903,7 @@ func TestEndTransactionRollbackAbortedTransaction(t *testing.T) {
 	var ba roachpb.BatchRequest
 	gArgs := getArgs(key)
 	ba.Add(&gArgs)
-	if err := ba.SetActiveTimestamp(tc.clock.Now); err != nil {
+	if err := ba.SetActiveTimestamp(tc.Clock().Now); err != nil {
 		t.Fatal(err)
 	}
 	_, pErr := tc.Sender().Send(context.Background(), ba)
@@ -3054,13 +3042,13 @@ func TestRaftReplayProtection(t *testing.T) {
 func TestRaftReplayProtectionInTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer setTxnAutoGC(true)()
-	cfg := TestStoreConfig()
+	cfg := TestStoreConfig(nil)
 	tc := testContext{}
 	tc.StartWithStoreConfig(t, cfg)
 	defer tc.Stop()
 
 	key := roachpb.Key("a")
-	txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
+	txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 
 	// Send a batch with begin txn, put & end txn.
 	var ba roachpb.BatchRequest
@@ -3147,7 +3135,7 @@ func TestReplayProtection(t *testing.T) {
 	for i, iso := range []enginepb.IsolationType{enginepb.SERIALIZABLE, enginepb.SNAPSHOT} {
 		key := roachpb.Key(fmt.Sprintf("a-%d", i))
 		keyB := roachpb.Key(fmt.Sprintf("b-%d", i))
-		txn := newTransaction("test", key, 1, iso, tc.clock)
+		txn := newTransaction("test", key, 1, iso, tc.Clock())
 
 		// Send a batch with put to key.
 		var ba roachpb.BatchRequest
@@ -3156,7 +3144,7 @@ func TestReplayProtection(t *testing.T) {
 		ba.Header = btH
 		ba.Add(&bt)
 		ba.Add(&put)
-		if err := ba.SetActiveTimestamp(tc.clock.Now); err != nil {
+		if err := ba.SetActiveTimestamp(tc.Clock().Now); err != nil {
 			t.Fatal(err)
 		}
 		br, pErr := tc.Sender().Send(context.Background(), ba)
@@ -3233,7 +3221,7 @@ func TestDuplicateBeginTransaction(t *testing.T) {
 	defer tc.Stop()
 
 	key := roachpb.Key("a")
-	txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
+	txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 	bt, btH := beginTxnArgs(key, txn)
 	var ba roachpb.BatchRequest
 	ba.Header = btH
@@ -3256,7 +3244,7 @@ func TestEndTransactionLocalGC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer setTxnAutoGC(true)()
 	tc := testContext{}
-	tsc := TestStoreConfig()
+	tsc := TestStoreConfig(nil)
 	tsc.TestingKnobs.TestingCommandFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			// Make sure the direct GC path doesn't interfere with this test.
@@ -3287,7 +3275,7 @@ func TestEndTransactionLocalGC(t *testing.T) {
 		// Intent inside and outside.
 		{[]roachpb.Span{{Key: roachpb.Key("a")}, {Key: splitKey.AsRawKey()}}, false},
 	} {
-		txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
+		txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 		_, btH := beginTxnArgs(key, txn)
 		put := putArgs(putKey, key)
 		if _, pErr := maybeWrapWithBeginTransaction(context.Background(), tc.Sender(), btH, &put); pErr != nil {
@@ -3321,7 +3309,7 @@ func setupResolutionTest(
 	// Split the range and create an intent at splitKey and key.
 	newRng := splitTestRange(tc.store, splitKey, splitKey, t)
 
-	txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
+	txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 	// These increments are not required, but testing feels safer when zero
 	// values are unexpected.
 	txn.Sequence++
@@ -3361,7 +3349,7 @@ func setupResolutionTest(
 func TestEndTransactionResolveOnlyLocalIntents(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
-	tsc := TestStoreConfig()
+	tsc := TestStoreConfig(nil)
 	key := roachpb.Key("a")
 	splitKey := roachpb.RKey(key).Next()
 	tsc.TestingKnobs.TestingCommandFilter =
@@ -3383,7 +3371,7 @@ func TestEndTransactionResolveOnlyLocalIntents(t *testing.T) {
 		var ba roachpb.BatchRequest
 		gArgs := getArgs(splitKey)
 		ba.Add(&gArgs)
-		if err := ba.SetActiveTimestamp(tc.clock.Now); err != nil {
+		if err := ba.SetActiveTimestamp(tc.Clock().Now); err != nil {
 			t.Fatal(err)
 		}
 		_, pErr := newRng.Send(context.Background(), ba)
@@ -3466,7 +3454,7 @@ func TestEndTransactionDirectGCFailure(t *testing.T) {
 	key := roachpb.Key("a")
 	splitKey := roachpb.RKey(key).Next()
 	var count int64
-	tsc := TestStoreConfig()
+	tsc := TestStoreConfig(nil)
 	tsc.TestingKnobs.TestingCommandFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if filterArgs.Req.Method() == roachpb.ResolveIntent &&
@@ -3509,7 +3497,7 @@ func TestEndTransactionDirectGC_1PC(t *testing.T) {
 			defer tc.Stop()
 
 			key := roachpb.Key("a")
-			txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
+			txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 			bt, _ := beginTxnArgs(key, txn)
 			put := putArgs(key, []byte("value"))
 			et, etH := endTxnArgs(txn, commit)
@@ -3541,7 +3529,7 @@ func TestReplicaResolveIntentNoWait(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var seen int32
 	key := roachpb.Key("zresolveme")
-	tsc := TestStoreConfig()
+	tsc := TestStoreConfig(nil)
 	tsc.TestingKnobs.TestingCommandFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if filterArgs.Req.Method() == roachpb.ResolveIntent &&
@@ -3556,7 +3544,7 @@ func TestReplicaResolveIntentNoWait(t *testing.T) {
 	defer tc.Stop()
 	splitKey := roachpb.RKey("aa")
 	setupResolutionTest(t, tc, roachpb.Key("a") /* irrelevant */, splitKey, true /* commit */)
-	txn := newTransaction("name", key, 1, enginepb.SERIALIZABLE, tc.clock)
+	txn := newTransaction("name", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 	txn.Status = roachpb.COMMITTED
 	if pErr := tc.store.intentResolver.resolveIntents(context.Background(),
 		[]roachpb.Intent{{
@@ -3591,8 +3579,8 @@ func TestSequenceCachePoisonOnResolve(t *testing.T) {
 		tc.Start(t)
 		defer tc.Stop()
 
-		pushee := newTransaction("test", key, 1, iso, tc.clock)
-		pusher := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
+		pusher := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
+		pushee := newTransaction("test", key, 1, iso, tc.Clock())
 		pusher.Priority = 2
 		pushee.Priority = 1 // pusher will win
 
@@ -3625,42 +3613,63 @@ func TestSequenceCachePoisonOnResolve(t *testing.T) {
 
 		// Have the pusher run into the intent. That pushes our pushee and
 		// resolves the intent, which in turn should poison the abort cache.
-		var assert func(*roachpb.Error)
+		var assert func(*roachpb.Error) error
 		if abort {
 			// Write/Write conflict will abort pushee.
 			if _, pErr := inc(pusher, key); pErr != nil {
 				t.Fatal(pErr)
 			}
-			assert = func(pErr *roachpb.Error) {
+			assert = func(pErr *roachpb.Error) error {
 				if _, ok := pErr.GetDetail().(*roachpb.TransactionAbortedError); !ok {
-					t.Fatalf("abort=%t, iso=%s: expected txn abort, got %s", abort, iso, pErr)
+					return errors.Errorf("abort=%t, iso=%s: expected txn abort, got %s", abort, iso, pErr)
 				}
+				return nil
 			}
 		} else {
 			// Verify we're not poisoned.
-			assert = func(pErr *roachpb.Error) {
+			assert = func(pErr *roachpb.Error) error {
 				if pErr != nil {
-					t.Fatalf("abort=%t, iso=%s: unexpected: %s", abort, iso, pErr)
+					return errors.Errorf("abort=%t, iso=%s: unexpected: %s", abort, iso, pErr)
 				}
+				return nil
 			}
 		}
 
-		// Our assert should be true for any reads or writes.
-		pErr := get(pushee, key)
-		assert(pErr)
-		_, pErr = inc(pushee, key)
-		assert(pErr)
-		// Still poisoned (on any key on the Range).
-		pErr = get(pushee, key.Next())
-		assert(pErr)
-		_, pErr = inc(pushee, key.Next())
-		assert(pErr)
-
-		// Pretend we're coming back. Increasing the epoch on an abort should
-		// still fail obviously, while on no abort will succeed.
-		pushee.Epoch++
-		_, pErr = inc(pushee, roachpb.Key("b"))
-		assert(pErr)
+		{
+			// Our assert should be true for any reads or writes.
+			pErr := get(pushee, key)
+			if err := assert(pErr); err != nil {
+				t.Fatal(err)
+			}
+		}
+		{
+			_, pErr := inc(pushee, key)
+			if err := assert(pErr); err != nil {
+				t.Fatal(err)
+			}
+		}
+		{
+			// Still poisoned (on any key on the Range).
+			pErr := get(pushee, key.Next())
+			if err := assert(pErr); err != nil {
+				t.Fatal(err)
+			}
+		}
+		{
+			_, pErr := inc(pushee, key.Next())
+			if err := assert(pErr); err != nil {
+				t.Fatal(err)
+			}
+		}
+		{
+			// Pretend we're coming back. Increasing the epoch on an abort should
+			// still fail obviously, while on no abort will succeed.
+			pushee.Epoch++
+			_, pErr := inc(pushee, roachpb.Key("b"))
+			if err := assert(pErr); err != nil {
+				t.Fatal(err)
+			}
+		}
 	}
 
 	for _, abort := range []bool{false, true} {
@@ -3681,7 +3690,7 @@ func TestAbortCacheError(t *testing.T) {
 	txn.ID = uuid.NewV4()
 	txn.Priority = 1
 	txn.Sequence = 1
-	txn.Timestamp = hlc.Timestamp{WallTime: 1}
+	txn.Timestamp = tc.Clock().Now().Add(1, 0)
 
 	key := roachpb.Key("k")
 	ts := txn.Timestamp.Next()
@@ -3715,8 +3724,8 @@ func TestPushTxnBadKey(t *testing.T) {
 	tc.Start(t)
 	defer tc.Stop()
 
-	pusher := newTransaction("test", roachpb.Key("a"), 1, enginepb.SERIALIZABLE, tc.clock)
-	pushee := newTransaction("test", roachpb.Key("b"), 1, enginepb.SERIALIZABLE, tc.clock)
+	pusher := newTransaction("test", roachpb.Key("a"), 1, enginepb.SERIALIZABLE, tc.Clock())
+	pushee := newTransaction("test", roachpb.Key("b"), 1, enginepb.SERIALIZABLE, tc.Clock())
 
 	args := pushTxnArgs(pusher, pushee, roachpb.PUSH_ABORT)
 	args.Key = pusher.Key
@@ -3742,8 +3751,8 @@ func TestPushTxnAlreadyCommittedOrAborted(t *testing.T) {
 
 	for i, status := range []roachpb.TransactionStatus{roachpb.COMMITTED, roachpb.ABORTED} {
 		key := roachpb.Key(fmt.Sprintf("key-%d", i))
-		pusher := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
-		pushee := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
+		pusher := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
+		pushee := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 		pusher.Priority = 1
 		pushee.Priority = 2 // pusher will lose, meaning we shouldn't push unless pushee is already ended.
 
@@ -3783,8 +3792,9 @@ func TestPushTxnUpgradeExistingTxn(t *testing.T) {
 	tc.Start(t)
 	defer tc.Stop()
 
-	ts1 := hlc.Timestamp{WallTime: 1}
-	ts2 := hlc.Timestamp{WallTime: 2}
+	now := tc.Clock().Now()
+	ts1 := now.Add(1, 0)
+	ts2 := now.Add(2, 0)
 	testCases := []struct {
 		startTS, ts, expTS hlc.Timestamp
 	}{
@@ -3798,8 +3808,8 @@ func TestPushTxnUpgradeExistingTxn(t *testing.T) {
 
 	for i, test := range testCases {
 		key := roachpb.Key(fmt.Sprintf("key-%d", i))
-		pusher := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
-		pushee := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
+		pusher := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
+		pushee := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 		pushee.Priority = 1
 		pushee.Epoch = 12345
 		pusher.Priority = 2   // Pusher will win
@@ -3845,16 +3855,17 @@ func TestPushTxnHeartbeatTimeout(t *testing.T) {
 	tc.Start(t)
 	defer tc.Stop()
 
-	ts := hlc.Timestamp{WallTime: 1}
+	now := tc.Clock().Now()
+	ts := now.Add(1, 0)
 	ns := base.DefaultHeartbeatInterval.Nanoseconds()
 	testCases := []struct {
-		heartbeat   hlc.Timestamp // zero value indicates no heartbeat
-		currentTime int64         // nanoseconds
-		pushType    roachpb.PushTxnType
-		expSuccess  bool
+		heartbeat  hlc.Timestamp // zero value indicates no heartbeat
+		timeOffset int64         // nanoseconds
+		pushType   roachpb.PushTxnType
+		expSuccess bool
 	}{
-		// Avoid using 0 as currentTime since our manualClock is at 0 and we
-		// don't want to have outcomes depend on random logical ticks.
+		// Avoid using 0 as timeOffset to avoid having outcomes depend on random
+		// logical ticks.
 		{hlc.ZeroTimestamp, 1, roachpb.PUSH_TIMESTAMP, false},
 		{hlc.ZeroTimestamp, 1, roachpb.PUSH_ABORT, false},
 		{hlc.ZeroTimestamp, 1, roachpb.PUSH_TOUCH, false},
@@ -3883,8 +3894,8 @@ func TestPushTxnHeartbeatTimeout(t *testing.T) {
 
 	for i, test := range testCases {
 		key := roachpb.Key(fmt.Sprintf("key-%d", i))
-		pushee := newTransaction(fmt.Sprintf("test-%d", i), key, 1, enginepb.SERIALIZABLE, tc.clock)
-		pusher := newTransaction("pusher", key, 1, enginepb.SERIALIZABLE, tc.clock)
+		pushee := newTransaction(fmt.Sprintf("test-%d", i), key, 1, enginepb.SERIALIZABLE, tc.Clock())
+		pusher := newTransaction("pusher", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 		pushee.Priority = 2
 		pusher.Priority = 1 // Pusher won't win based on priority.
 
@@ -3901,7 +3912,7 @@ func TestPushTxnHeartbeatTimeout(t *testing.T) {
 
 		// Now, attempt to push the transaction with Now set to our current time.
 		args := pushTxnArgs(pusher, pushee, test.pushType)
-		args.Now = hlc.Timestamp{WallTime: test.currentTime}
+		args.Now = now.Add(test.timeOffset, 0)
 		args.PushTo = args.Now
 
 		reply, pErr := tc.SendWrapped(&args)
@@ -3933,7 +3944,7 @@ func TestResolveIntentPushTxnReplyTxn(t *testing.T) {
 	b := tc.engine.NewBatch()
 	defer b.Close()
 
-	txn := newTransaction("test", roachpb.Key("test"), 1, enginepb.SERIALIZABLE, tc.clock)
+	txn := newTransaction("test", roachpb.Key("test"), 1, enginepb.SERIALIZABLE, tc.Clock())
 	txnPushee := txn.Clone()
 	txnPushee.Priority--
 	pa := pushTxnArgs(txn, &txnPushee, roachpb.PUSH_ABORT)
@@ -3979,8 +3990,9 @@ func TestPushTxnPriorities(t *testing.T) {
 	tc.Start(t)
 	defer tc.Stop()
 
-	ts1 := hlc.Timestamp{WallTime: 1}
-	ts2 := hlc.Timestamp{WallTime: 2}
+	now := tc.Clock().Now()
+	ts1 := now.Add(1, 0)
+	ts2 := now.Add(2, 0)
 	testCases := []struct {
 		pusherPriority, pusheePriority int32
 		pusherTS, pusheeTS             hlc.Timestamp
@@ -4016,8 +4028,8 @@ func TestPushTxnPriorities(t *testing.T) {
 
 	for i, test := range testCases {
 		key := roachpb.Key(fmt.Sprintf("key-%d", i))
-		pusher := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
-		pushee := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
+		pusher := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
+		pushee := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 		pusher.Priority = test.pusherPriority
 		pushee.Priority = test.pusheePriority
 		pusher.Timestamp = test.pusherTS
@@ -4059,12 +4071,13 @@ func TestPushTxnPushTimestamp(t *testing.T) {
 	tc.Start(t)
 	defer tc.Stop()
 
-	pusher := newTransaction("test", roachpb.Key("a"), 1, enginepb.SERIALIZABLE, tc.clock)
-	pushee := newTransaction("test", roachpb.Key("b"), 1, enginepb.SERIALIZABLE, tc.clock)
+	pusher := newTransaction("test", roachpb.Key("a"), 1, enginepb.SERIALIZABLE, tc.Clock())
+	pushee := newTransaction("test", roachpb.Key("b"), 1, enginepb.SERIALIZABLE, tc.Clock())
 	pusher.Priority = 2
 	pushee.Priority = 1 // pusher will win
-	pusher.Timestamp = hlc.Timestamp{WallTime: 50, Logical: 25}
-	pushee.Timestamp = hlc.Timestamp{WallTime: 5, Logical: 1}
+	now := tc.Clock().Now()
+	pusher.Timestamp = now.Add(50, 25)
+	pushee.Timestamp = now.Add(5, 1)
 
 	key := roachpb.Key("a")
 	_, btH := beginTxnArgs(key, pushee)
@@ -4102,12 +4115,13 @@ func TestPushTxnPushTimestampAlreadyPushed(t *testing.T) {
 	tc.Start(t)
 	defer tc.Stop()
 
-	pusher := newTransaction("test", roachpb.Key("a"), 1, enginepb.SERIALIZABLE, tc.clock)
-	pushee := newTransaction("test", roachpb.Key("b"), 1, enginepb.SERIALIZABLE, tc.clock)
+	pusher := newTransaction("test", roachpb.Key("a"), 1, enginepb.SERIALIZABLE, tc.Clock())
+	pushee := newTransaction("test", roachpb.Key("b"), 1, enginepb.SERIALIZABLE, tc.Clock())
 	pusher.Priority = 1
 	pushee.Priority = 2 // pusher will lose
-	pusher.Timestamp = hlc.Timestamp{WallTime: 50, Logical: 0}
-	pushee.Timestamp = hlc.Timestamp{WallTime: 50, Logical: 1}
+	now := tc.Clock().Now()
+	pusher.Timestamp = now.Add(50, 0)
+	pushee.Timestamp = now.Add(50, 1)
 
 	key := roachpb.Key("a")
 	_, btH := beginTxnArgs(key, pushee)
@@ -4146,8 +4160,8 @@ func TestPushTxnSerializableRestart(t *testing.T) {
 	defer tc.Stop()
 
 	key := roachpb.Key("a")
-	pushee := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
-	pusher := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
+	pushee := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
+	pusher := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 	pushee.Priority = 1
 	pusher.Priority = 2 // pusher will win
 
@@ -4211,7 +4225,7 @@ func TestReplicaResolveIntentRange(t *testing.T) {
 	defer tc.Stop()
 
 	keys := []roachpb.Key{roachpb.Key("a"), roachpb.Key("b")}
-	txn := newTransaction("test", keys[0], 1, enginepb.SERIALIZABLE, tc.clock)
+	txn := newTransaction("test", keys[0], 1, enginepb.SERIALIZABLE, tc.Clock())
 
 	// Put two values transactionally.
 	for _, key := range keys {
@@ -4278,6 +4292,9 @@ func TestReplicaStatsComputation(t *testing.T) {
 		SysBytes: 8,
 	})
 
+	// Our clock might not be set to zero.
+	baseStats.LastUpdateNanos = tc.manualClock.UnixNano()
+
 	// Put a value.
 	pArgs := putArgs([]byte("a"), []byte("value1"))
 
@@ -4308,7 +4325,7 @@ func TestReplicaStatsComputation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	txn := newTransaction("test", pArgs.Key, 1, enginepb.SERIALIZABLE, tc.clock)
+	txn := newTransaction("test", pArgs.Key, 1, enginepb.SERIALIZABLE, tc.Clock())
 	txn.Priority = 123 // So we don't have random values messing with the byte counts on encoding
 	txn.ID = uuid
 
@@ -4646,7 +4663,7 @@ func TestAppliedIndex(t *testing.T) {
 func TestReplicaCorruption(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	tsc := TestStoreConfig()
+	tsc := TestStoreConfig(nil)
 	tsc.TestingKnobs.TestingCommandFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if filterArgs.Req.Header().Key.Equal(roachpb.Key("boom")) {
@@ -4774,7 +4791,7 @@ func testRangeDanglingMetaIntent(t *testing.T, isReverse bool) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
+	txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 	// Officially begin the transaction. If not for this, the intent resolution
 	// machinery would simply remove the intent we write below, see #3020.
 	// We send directly to Replica throughout this test, so there's no danger
@@ -4792,7 +4809,7 @@ func testRangeDanglingMetaIntent(t *testing.T, isReverse bool) {
 	rlArgs.Key = keys.RangeMetaKey(roachpb.RKey{'A'})
 
 	reply, pErr = tc.SendWrappedWith(roachpb.Header{
-		Timestamp:       hlc.MinTimestamp,
+		Timestamp:       tc.Clock().Now(),
 		ReadConsistency: roachpb.INCONSISTENT,
 	}, rlArgs)
 	if pErr != nil {
@@ -4873,7 +4890,7 @@ func TestReplicaLookupUseReverseScan(t *testing.T) {
 	}
 
 	{
-		txn := newTransaction("test", roachpb.Key{}, 1, enginepb.SERIALIZABLE, tc.clock)
+		txn := newTransaction("test", roachpb.Key{}, 1, enginepb.SERIALIZABLE, tc.Clock())
 		for _, r := range testRanges {
 			// Write the new descriptor as an intent.
 			data, err := protoutil.Marshal(&r)
@@ -4927,7 +4944,7 @@ func TestReplicaLookupUseReverseScan(t *testing.T) {
 	}
 
 	// Write the new descriptors as intents.
-	txn := newTransaction("test", roachpb.Key{}, 1, enginepb.SERIALIZABLE, tc.clock)
+	txn := newTransaction("test", roachpb.Key{}, 1, enginepb.SERIALIZABLE, tc.Clock())
 	for _, r := range []roachpb.RangeDescriptor{splitRangeLHS, splitRangeRHS} {
 		// Write the new descriptor as an intent.
 		data, err := protoutil.Marshal(&r)
@@ -5028,10 +5045,9 @@ func TestRequestLeaderEncounterGroupDeleteError(t *testing.T) {
 
 	gArgs := getArgs(roachpb.Key("a"))
 	// Force the read command request a new lease.
-	clock := tc.clock
-	ts := clock.Update(clock.Now().Add(leaseExpiry(tc.rng), 0))
+	tc.manualClock.Set(leaseExpiry(rng))
 	_, pErr := client.SendWrappedWith(context.Background(), tc.store, roachpb.Header{
-		Timestamp: ts,
+		Timestamp: tc.Clock().Now(),
 		RangeID:   1,
 	}, &gArgs)
 	if _, ok := pErr.GetDetail().(*roachpb.RangeNotFoundError); !ok {
@@ -5497,8 +5513,9 @@ func TestGCIncorrectRange(t *testing.T) {
 	key := splitKey.PrefixEnd().AsRawKey()
 	val := []byte("value")
 	putReq := putArgs(key, val)
-	ts1 := makeTS(1, 0)
-	ts2 := makeTS(2, 0)
+	now := tc.Clock().Now()
+	ts1 := now.Add(1, 0)
+	ts2 := now.Add(2, 0)
 	ts1Header := roachpb.Header{Timestamp: ts1}
 	ts2Header := roachpb.Header{Timestamp: ts2}
 	if _, pErr := client.SendWrappedWith(context.Background(), rng2, ts1Header, &putReq); pErr != nil {
@@ -5513,7 +5530,7 @@ func TestGCIncorrectRange(t *testing.T) {
 	// the request for the incorrect key will be silently dropped.
 	gKey := gcKey(key, ts1)
 	gcReq := gcArgs(rng1.Desc().StartKey, rng1.Desc().EndKey, gKey)
-	if _, pErr := client.SendWrappedWith(context.Background(), rng1, roachpb.Header{Timestamp: tc.clock.Now()}, &gcReq); pErr != nil {
+	if _, pErr := client.SendWrappedWith(context.Background(), rng1, roachpb.Header{Timestamp: tc.Clock().Now()}, &gcReq); pErr != nil {
 		t.Errorf("unexpected pError on garbage collection request to incorrect range: %s", pErr)
 	}
 
@@ -5527,7 +5544,7 @@ func TestGCIncorrectRange(t *testing.T) {
 
 	// Send GC request to range 2 for the same key.
 	gcReq = gcArgs(rng2.Desc().StartKey, rng2.Desc().EndKey, gKey)
-	if _, pErr := client.SendWrappedWith(context.Background(), rng2, roachpb.Header{Timestamp: tc.clock.Now()}, &gcReq); pErr != nil {
+	if _, pErr := client.SendWrappedWith(context.Background(), rng2, roachpb.Header{Timestamp: tc.Clock().Now()}, &gcReq); pErr != nil {
 		t.Errorf("unexpected pError on garbage collection request to correct range: %s", pErr)
 	}
 
@@ -5551,7 +5568,7 @@ func TestReplicaCancelRaft(t *testing.T) {
 	ba.Add(&roachpb.GetRequest{
 		Span: roachpb.Span{Key: key},
 	})
-	if err := ba.SetActiveTimestamp(tc.clock.Now); err != nil {
+	if err := ba.SetActiveTimestamp(tc.Clock().Now); err != nil {
 		t.Fatal(err)
 	}
 	tc.Stop()
@@ -5725,7 +5742,7 @@ func TestDiffRange(t *testing.T) {
 func TestSyncSnapshot(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	tsc := TestStoreConfig()
+	tsc := TestStoreConfig(nil)
 	tc := testContext{}
 	tc.StartWithStoreConfig(t, tsc)
 	defer tc.Stop()
@@ -5751,7 +5768,7 @@ func TestReplicaIDChangePending(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	tc := testContext{}
-	cfg := TestStoreConfig()
+	cfg := TestStoreConfig(nil)
 	// Disable ticks to avoid automatic reproposals after a timeout, which
 	// would pass this test.
 	cfg.RaftTickInterval = math.MaxInt32
@@ -5765,7 +5782,7 @@ func TestReplicaIDChangePending(t *testing.T) {
 	rng.mu.Unlock()
 
 	// Add a command to the pending list.
-	magicTS := tc.clock.Now()
+	magicTS := tc.Clock().Now()
 	ba := roachpb.BatchRequest{}
 	ba.Timestamp = magicTS
 	ba.Add(&roachpb.GetRequest{
@@ -5826,7 +5843,7 @@ func TestReplicaRetryRaftProposal(t *testing.T) {
 	{
 		var ba roachpb.BatchRequest
 		ba.Add(&pArg)
-		ba.Timestamp = tc.clock.Now()
+		ba.Timestamp = tc.Clock().Now()
 		if _, pErr := tc.Sender().Send(ctx, ba); pErr != nil {
 			t.Fatal(pErr)
 		}
@@ -5845,7 +5862,7 @@ func TestReplicaRetryRaftProposal(t *testing.T) {
 	log.Infof(ctx, "test begins")
 
 	var ba roachpb.BatchRequest
-	ba.Timestamp = tc.clock.Now()
+	ba.Timestamp = tc.Clock().Now()
 	const expInc = 123
 	iArg := incrementArgs(roachpb.Key("b"), expInc)
 	ba.Add(&iArg)
@@ -5902,7 +5919,7 @@ func TestReplicaCancelRaftCommandProgress(t *testing.T) {
 	func() {
 		for i := 0; i < num; i++ {
 			var ba roachpb.BatchRequest
-			ba.Timestamp = tc.clock.Now()
+			ba.Timestamp = tc.Clock().Now()
 			ba.Add(&roachpb.PutRequest{Span: roachpb.Span{
 				Key: roachpb.Key(fmt.Sprintf("k%d", i))}})
 			cmd := rng.evaluateProposal(context.Background(), makeIDKey(), repDesc, ba)
@@ -5975,7 +5992,7 @@ func TestReplicaBurstPendingCommandsAndRepropose(t *testing.T) {
 			expIndexes = append(expIndexes, i+1)
 			ctx := context.WithValue(context.Background(), magicKey{}, "foo")
 			var ba roachpb.BatchRequest
-			ba.Timestamp = tc.clock.Now()
+			ba.Timestamp = tc.Clock().Now()
 			ba.Add(&roachpb.PutRequest{Span: roachpb.Span{
 				Key: roachpb.Key(fmt.Sprintf("k%d", i))}})
 			cmd := tc.rng.evaluateProposal(ctx, makeIDKey(), repDesc, ba)
@@ -6028,7 +6045,7 @@ func TestReplicaBurstPendingCommandsAndRepropose(t *testing.T) {
 func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var tc testContext
-	cfg := TestStoreConfig()
+	cfg := TestStoreConfig(nil)
 	// Disable ticks which would interfere with the manual ticking in this test.
 	cfg.RaftTickInterval = math.MaxInt32
 	tc.StartWithStoreConfig(t, cfg)
@@ -6084,7 +6101,7 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 		// Add another pending command on each iteration.
 		id := fmt.Sprintf("%08d", i)
 		var ba roachpb.BatchRequest
-		ba.Timestamp = tc.clock.Now()
+		ba.Timestamp = tc.Clock().Now()
 		ba.Add(&roachpb.PutRequest{Span: roachpb.Span{Key: roachpb.Key(id)}})
 		cmd := r.evaluateProposal(context.Background(),
 			storagebase.CmdIDKey(id), repDesc, ba)
@@ -6147,9 +6164,10 @@ func TestCommandTimeThreshold(t *testing.T) {
 	tc.Start(t)
 	defer tc.Stop()
 
-	ts := makeTS(1, 0)
-	ts2 := makeTS(2, 0)
-	ts3 := makeTS(3, 0)
+	now := tc.Clock().Now()
+	ts1 := now.Add(1, 0)
+	ts2 := now.Add(2, 0)
+	ts3 := now.Add(3, 0)
 
 	key := roachpb.Key("a")
 	keycp := roachpb.Key("c")
@@ -6160,7 +6178,7 @@ func TestCommandTimeThreshold(t *testing.T) {
 	// Verify a Get works.
 	gArgs := getArgs(key)
 	if _, err := tc.SendWrappedWith(roachpb.Header{
-		Timestamp: ts,
+		Timestamp: ts1,
 	}, &gArgs); err != nil {
 		t.Fatalf("could not get data: %s", err)
 	}
@@ -6174,7 +6192,7 @@ func TestCommandTimeThreshold(t *testing.T) {
 	// Put some data for use with CP later on.
 	pArgs := putArgs(keycp, va)
 	if _, err := tc.SendWrappedWith(roachpb.Header{
-		Timestamp: ts,
+		Timestamp: ts1,
 	}, &pArgs); err != nil {
 		t.Fatalf("could not put data: %s", err)
 	}
@@ -6188,35 +6206,31 @@ func TestCommandTimeThreshold(t *testing.T) {
 	}
 
 	// Do the same Get, which should now fail.
-	if _, err := tc.SendWrappedWith(roachpb.Header{
-		Timestamp: ts,
-	}, &gArgs); err == nil {
-		t.Fatal("expected failure")
-	} else if err.String() != "batch timestamp 0.000000001,0 must be after replica GC threshold 0.000000002,0" {
-		t.Fatalf("unexpected error: %s", err)
+	if _, pErr := tc.SendWrappedWith(roachpb.Header{
+		Timestamp: ts1,
+	}, &gArgs); !testutils.IsPError(pErr, `batch timestamp 0.\d+,\d+ must be after replica GC threshold 0.\d+,\d+`) {
+		t.Fatalf("unexpected error: %v", pErr)
 	}
 
 	// Verify a later Get works.
-	if _, err := tc.SendWrappedWith(roachpb.Header{
+	if _, pErr := tc.SendWrappedWith(roachpb.Header{
 		Timestamp: ts3,
-	}, &gArgs); err != nil {
-		t.Fatalf("could not get data: %s", err)
+	}, &gArgs); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// Verify an early CPut fails.
 	cpArgs := cPutArgs(keycp, vb, va)
-	if _, err := tc.SendWrappedWith(roachpb.Header{
+	if _, pErr := tc.SendWrappedWith(roachpb.Header{
 		Timestamp: ts2,
-	}, &cpArgs); err == nil {
-		t.Fatal("expected failure")
-	} else if err.String() != "batch timestamp 0.000000002,0 must be after replica GC threshold 0.000000002,0" {
-		t.Fatalf("unexpected error: %s", err)
+	}, &cpArgs); !testutils.IsPError(pErr, `batch timestamp 0.\d+,\d+ must be after replica GC threshold 0.\d+,\d+`) {
+		t.Fatalf("unexpected error: %v", pErr)
 	}
 	// Verify a later CPut works.
-	if _, err := tc.SendWrappedWith(roachpb.Header{
+	if _, pErr := tc.SendWrappedWith(roachpb.Header{
 		Timestamp: ts3,
-	}, &cpArgs); err != nil {
-		t.Fatalf("could not cput data: %s", err)
+	}, &cpArgs); pErr != nil {
+		t.Fatal(pErr)
 	}
 }
 

--- a/pkg/storage/scanner_test.go
+++ b/pkg/storage/scanner_test.go
@@ -197,8 +197,8 @@ func TestScannerAddToQueues(t *testing.T) {
 	q2.setDisabled(true)
 	s := newReplicaScanner(log.AmbientContext{}, 1*time.Millisecond, 0, ranges)
 	s.AddQueues(q1, q2)
-	mc := hlc.NewManualClock(0)
-	clock := hlc.NewClock(mc.UnixNano)
+	mc := hlc.NewManualClock(123)
+	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
 	stopper := stop.NewStopper()
 
 	// Start scanner and verify that all ranges are added to both queues.
@@ -249,8 +249,8 @@ func TestScannerTiming(t *testing.T) {
 			q := &testQueue{}
 			s := newReplicaScanner(log.AmbientContext{}, duration, 0, ranges)
 			s.AddQueues(q)
-			mc := hlc.NewManualClock(0)
-			clock := hlc.NewClock(mc.UnixNano)
+			mc := hlc.NewManualClock(123)
+			clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
 			stopper := stop.NewStopper()
 			s.Start(clock, stopper)
 			time.Sleep(runTime)
@@ -312,8 +312,8 @@ func TestScannerDisabled(t *testing.T) {
 	q := &testQueue{}
 	s := newReplicaScanner(log.AmbientContext{}, 1*time.Millisecond, 0, ranges)
 	s.AddQueues(q)
-	mc := hlc.NewManualClock(0)
-	clock := hlc.NewClock(mc.UnixNano)
+	mc := hlc.NewManualClock(123)
+	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
 	stopper := stop.NewStopper()
 	s.Start(clock, stopper)
 	defer stopper.Stop()
@@ -375,8 +375,8 @@ func TestScannerEmptyRangeSet(t *testing.T) {
 	q := &testQueue{}
 	s := newReplicaScanner(log.AmbientContext{}, time.Hour, 0, ranges)
 	s.AddQueues(q)
-	mc := hlc.NewManualClock(0)
-	clock := hlc.NewClock(mc.UnixNano)
+	mc := hlc.NewManualClock(123)
+	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	s.Start(clock, stopper)

--- a/pkg/storage/simulation/cluster.go
+++ b/pkg/storage/simulation/cluster.go
@@ -24,6 +24,7 @@ import (
 	"math/rand"
 	"sort"
 	"text/tabwriter"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
@@ -76,7 +77,7 @@ func createCluster(
 	script Script,
 	rand *rand.Rand,
 ) *Cluster {
-	clock := hlc.NewClock(hlc.UnixNano)
+	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	rpcContext := rpc.NewContext(log.AmbientContext{}, &base.Config{Insecure: true}, clock, stopper)
 	server := rpc.NewServer(rpcContext)
 	// We set the node ID to MaxInt32 for the cluster Gossip instance to prevent

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -128,9 +128,13 @@ func RangeLeaseDurations(
 }
 
 // TestStoreConfig has some fields initialized with values relevant in tests.
-func TestStoreConfig() StoreConfig {
+func TestStoreConfig(clock *hlc.Clock) StoreConfig {
+	if clock == nil {
+		clock = hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+	}
 	return StoreConfig{
 		AmbientCtx:                     log.AmbientContext{Tracer: tracing.NewTracer()},
+		Clock:                          clock,
 		RaftTickInterval:               100 * time.Millisecond,
 		CoalescedHeartbeatsInterval:    50 * time.Millisecond,
 		RaftHeartbeatIntervalTicks:     1,

--- a/pkg/storage/store_pool_test.go
+++ b/pkg/storage/store_pool_test.go
@@ -59,8 +59,8 @@ func createTestStorePool(
 	timeUntilStoreDead time.Duration,
 ) (*stop.Stopper, *gossip.Gossip, *hlc.ManualClock, *StorePool) {
 	stopper := stop.NewStopper()
-	mc := hlc.NewManualClock(0)
-	clock := hlc.NewClock(mc.UnixNano)
+	mc := hlc.NewManualClock(123)
+	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
 	rpcContext := rpc.NewContext(log.AmbientContext{}, &base.Config{Insecure: true}, clock, stopper)
 	server := rpc.NewServer(rpcContext) // never started
 	g := gossip.NewTest(1, rpcContext, server, nil, stopper, metric.NewRegistry())

--- a/pkg/storage/stores_test.go
+++ b/pkg/storage/stores_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -34,7 +35,7 @@ import (
 
 func TestStoresAddStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	ls := NewStores(log.AmbientContext{}, hlc.NewClock(hlc.UnixNano))
+	ls := NewStores(log.AmbientContext{}, hlc.NewClock(hlc.UnixNano, time.Nanosecond))
 	store := Store{}
 	ls.AddStore(&store)
 	if !ls.HasStore(store.Ident.StoreID) {
@@ -47,7 +48,7 @@ func TestStoresAddStore(t *testing.T) {
 
 func TestStoresRemoveStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	ls := NewStores(log.AmbientContext{}, hlc.NewClock(hlc.UnixNano))
+	ls := NewStores(log.AmbientContext{}, hlc.NewClock(hlc.UnixNano, time.Nanosecond))
 
 	storeID := roachpb.StoreID(89)
 
@@ -62,7 +63,7 @@ func TestStoresRemoveStore(t *testing.T) {
 
 func TestStoresGetStoreCount(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	ls := NewStores(log.AmbientContext{}, hlc.NewClock(hlc.UnixNano))
+	ls := NewStores(log.AmbientContext{}, hlc.NewClock(hlc.UnixNano, time.Nanosecond))
 	if ls.GetStoreCount() != 0 {
 		t.Errorf("expected 0 stores in new local sender")
 	}
@@ -78,7 +79,7 @@ func TestStoresGetStoreCount(t *testing.T) {
 
 func TestStoresVisitStores(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	ls := NewStores(log.AmbientContext{}, hlc.NewClock(hlc.UnixNano))
+	ls := NewStores(log.AmbientContext{}, hlc.NewClock(hlc.UnixNano, time.Nanosecond))
 	numStores := 10
 	for i := 0; i < numStores; i++ {
 		ls.AddStore(&Store{Ident: roachpb.StoreIdent{StoreID: roachpb.StoreID(i)}})
@@ -106,7 +107,7 @@ func TestStoresVisitStores(t *testing.T) {
 
 func TestStoresGetStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	ls := NewStores(log.AmbientContext{}, hlc.NewClock(hlc.UnixNano))
+	ls := NewStores(log.AmbientContext{}, hlc.NewClock(hlc.UnixNano, time.Nanosecond))
 	store := Store{}
 	replica := roachpb.ReplicaDescriptor{StoreID: store.Ident.StoreID}
 	s, pErr := ls.GetStore(replica.StoreID)
@@ -130,9 +131,7 @@ func TestStoresLookupReplica(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	cfg := TestStoreConfig()
-	manualClock := hlc.NewManualClock(0)
-	cfg.Clock = hlc.NewClock(manualClock.UnixNano)
+	cfg := TestStoreConfig(nil)
 	ls := NewStores(log.AmbientContext{}, cfg.Clock)
 
 	// Create two new stores with ranges we care about.
@@ -230,9 +229,8 @@ var storeIDAlloc roachpb.StoreID
 // createStores creates a slice of count stores.
 func createStores(count int, t *testing.T) (*hlc.ManualClock, []*Store, *Stores, *stop.Stopper) {
 	stopper := stop.NewStopper()
-	cfg := TestStoreConfig()
-	manualClock := hlc.NewManualClock(0)
-	cfg.Clock = hlc.NewClock(manualClock.UnixNano)
+	manual := hlc.NewManualClock(123)
+	cfg := TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
 	ls := NewStores(log.AmbientContext{}, cfg.Clock)
 
 	// Create two stores with ranges we care about.
@@ -247,7 +245,7 @@ func createStores(count int, t *testing.T) (*hlc.ManualClock, []*Store, *Stores,
 		stores = append(stores, s)
 	}
 
-	return manualClock, stores, ls, stopper
+	return manual, stores, ls, stopper
 }
 
 // TestStoresGossipStorage verifies reading and writing of bootstrap info.
@@ -256,8 +254,6 @@ func TestStoresGossipStorage(t *testing.T) {
 	manual, stores, ls, stopper := createStores(2, t)
 	defer stopper.Stop()
 	ls.AddStore(stores[0])
-
-	manual.Set(1)
 
 	// Verify initial read is empty.
 	var bi gossip.BootstrapInfo
@@ -307,9 +303,6 @@ func TestStoresGossipStorageReadLatest(t *testing.T) {
 	manual, stores, ls, stopper := createStores(2, t)
 	defer stopper.Stop()
 	ls.AddStore(stores[0])
-
-	// Set clock to 1.
-	manual.Set(1)
 
 	// Add a fake address and write.
 	var bi gossip.BootstrapInfo

--- a/pkg/storage/ts_maintenance_queue_test.go
+++ b/pkg/storage/ts_maintenance_queue_test.go
@@ -94,12 +94,12 @@ func TestTimeSeriesMaintenanceQueue(t *testing.T) {
 		pruneSeenEndKeys:   make(map[string]struct{}),
 	}
 
-	cfg := storage.TestStoreConfig()
+	cfg := storage.TestStoreConfig(nil)
 	cfg.TimeSeriesDataStore = model
 	cfg.TestingKnobs.DisableScanner = true
 	cfg.TestingKnobs.DisableSplitQueue = true
 
-	store, stopper, _ := createTestStoreWithConfig(t, cfg)
+	store, stopper := createTestStoreWithConfig(t, cfg)
 	defer stopper.Stop()
 
 	// Generate several splits.

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -91,8 +91,8 @@ func (ltc *LocalTestCluster) Start(t util.Tester, baseCtx *base.Config, initSend
 	nodeDesc := &roachpb.NodeDescriptor{NodeID: nodeID}
 
 	ltc.tester = t
-	ltc.Manual = hlc.NewManualClock(0)
-	ltc.Clock = hlc.NewClock(ltc.Manual.UnixNano)
+	ltc.Manual = hlc.NewManualClock(123)
+	ltc.Clock = hlc.NewClock(ltc.Manual.UnixNano, 50*time.Millisecond)
 	ltc.Stopper = stop.NewStopper()
 	rpcContext := rpc.NewContext(ambient, baseCtx, ltc.Clock, ltc.Stopper)
 	server := rpc.NewServer(rpcContext) // never started
@@ -110,12 +110,11 @@ func (ltc *LocalTestCluster) Start(t util.Tester, baseCtx *base.Config, initSend
 	}
 	ltc.DB = client.NewDBWithContext(ltc.Sender, *ltc.DBContext)
 	transport := storage.NewDummyRaftTransport()
-	cfg := storage.TestStoreConfig()
+	cfg := storage.TestStoreConfig(ltc.Clock)
 	if ltc.RangeRetryOptions != nil {
 		cfg.RangeRetryOptions = *ltc.RangeRetryOptions
 	}
 	cfg.AmbientCtx = ambient
-	cfg.Clock = ltc.Clock
 	cfg.DB = ltc.DB
 	cfg.Gossip = ltc.Gossip
 	cfg.Transport = transport

--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -49,21 +49,29 @@ import (
 // See NewClock for details.
 type Clock struct {
 	physicalClock func() int64
-	// Clock contains a mutex used to lock the below
-	// fields while methods operate on them.
-	syncutil.Mutex
-	state Timestamp
-	// MaxOffset specifies how far ahead of the physical
-	// clock (and cluster time) the wall time can be.
-	// See SetMaxOffset.
+
+	// The maximal offset of the HLC's wall time from the underlying physical
+	// clock. A well-chosen value is large enough to ignore a reasonable amount
+	// of clock skew but will prevent ill-configured nodes from dramatically
+	// skewing the wall time of the clock into the future.
+	//
+	// RPC heartbeats compare detected clock skews against this value to protect
+	// data consistency.
+	//
+	// TODO(tamird): make this dynamic in the distant future.
 	maxOffset time.Duration
 
-	// monotonicityErrorsCount indicate how often this clock was
-	// observed to jump backwards.
-	monotonicityErrorsCount int32
-	// lastPhysicalTime reports the last measured physical time. This
-	// is used to detect clock jumps.
-	lastPhysicalTime int64
+	mu struct {
+		syncutil.Mutex
+		timestamp Timestamp
+
+		// monotonicityErrorsCount indicate how often this clock was
+		// observed to jump backwards.
+		monotonicityErrorsCount int32
+		// lastPhysicalTime reports the last measured physical time. This
+		// is used to detect clock jumps.
+		lastPhysicalTime int64
+	}
 }
 
 // ManualClock is a convenience type to facilitate
@@ -108,67 +116,34 @@ func UnixNano() int64 {
 // The physical clock is typically given by the wall time
 // of the local machine in unix epoch nanoseconds, using
 // hlc.UnixNano. This is not a requirement.
-func NewClock(physicalClock func() int64) *Clock {
+func NewClock(physicalClock func() int64, maxOffset time.Duration) *Clock {
 	return &Clock{
 		physicalClock: physicalClock,
+		maxOffset:     maxOffset,
 	}
 }
 
-// SetMaxOffset sets the maximal offset of the physical clock from the cluster.
-// It is used to set the max offset a call to Update may cause and to ensure
-// an upperbound on timestamp WallTime in transactions. A well-chosen value is
-// large enough to ignore a reasonable amount of clock skew but will prevent
-// ill-configured nodes from dramatically skewing the wall time of the clock
-// into the future.
+// MaxOffset returns the maximal clock offset to any node in the cluster.
 //
-// A value of zero disables all safety features.
-// The default value for a new instance is zero.
-func (c *Clock) SetMaxOffset(delta time.Duration) {
-	c.Lock()
-	defer c.Unlock()
-	c.maxOffset = delta
-}
-
-// MaxOffset returns the maximal offset allowed.
 // A value of 0 means offset checking is disabled.
-// See SetMaxOffset for details.
 func (c *Clock) MaxOffset() time.Duration {
-	c.Lock()
-	defer c.Unlock()
 	return c.maxOffset
 }
 
-// Timestamp returns a copy of the clock's current timestamp,
-// without performing a clock adjustment.
-func (c *Clock) Timestamp() Timestamp {
-	c.Lock()
-	defer c.Unlock()
-	return c.timestamp()
-}
-
-// timestamp returns the state as a timestamp, without
-// a lock on the clock's state, for internal usage.
-func (c *Clock) timestamp() Timestamp {
-	return Timestamp{
-		WallTime: c.state.WallTime,
-		Logical:  c.state.Logical,
-	}
-}
-
-// getPhysicalClock returns the current physical clock and checks for
+// getPhysicalClockLocked returns the current physical clock and checks for
 // time jumps.
-func (c *Clock) getPhysicalClock() int64 {
+func (c *Clock) getPhysicalClockLocked() int64 {
 	newTime := c.physicalClock()
 
-	if c.lastPhysicalTime != 0 {
-		interval := c.lastPhysicalTime - newTime
+	if c.mu.lastPhysicalTime != 0 {
+		interval := c.mu.lastPhysicalTime - newTime
 		if interval > int64(c.maxOffset/10) {
-			c.monotonicityErrorsCount++
-			log.Warningf(context.TODO(), "backward time jump detected (%f seconds)", float64(newTime-c.lastPhysicalTime)/1e9)
+			c.mu.monotonicityErrorsCount++
+			log.Warningf(context.TODO(), "backward time jump detected (%f seconds)", float64(newTime-c.mu.lastPhysicalTime)/1e9)
 		}
 	}
 
-	c.lastPhysicalTime = newTime
+	c.mu.lastPhysicalTime = newTime
 	return newTime
 }
 
@@ -178,28 +153,25 @@ func (c *Clock) getPhysicalClock() int64 {
 // of Update, which is passed a timestamp received from
 // another member of the distributed network.
 func (c *Clock) Now() Timestamp {
-	c.Lock()
-	defer c.Unlock()
-
-	physicalClock := c.getPhysicalClock()
-	if c.state.WallTime >= physicalClock {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if physicalClock := c.getPhysicalClockLocked(); c.mu.timestamp.WallTime >= physicalClock {
 		// The wall time is ahead, so the logical clock ticks.
-		c.state.Logical++
+		c.mu.timestamp.Logical++
 	} else {
 		// Use the physical clock, and reset the logical one.
-		c.state.WallTime = physicalClock
-		c.state.Logical = 0
+		c.mu.timestamp.WallTime = physicalClock
+		c.mu.timestamp.Logical = 0
 	}
-	return c.timestamp()
+	return c.mu.timestamp
 }
 
 // PhysicalNow returns the local wall time. It corresponds to the physicalClock
 // provided at instantiation. For a timestamp value, use Now() instead.
 func (c *Clock) PhysicalNow() int64 {
-	c.Lock()
-	defer c.Unlock()
-	wallTime := c.getPhysicalClock()
-	return wallTime
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.getPhysicalClockLocked()
 }
 
 // PhysicalTime returns a time.Time struct using the local wall time.
@@ -213,45 +185,45 @@ func (c *Clock) PhysicalTime() time.Time {
 // associated to the receipt of the event returned.
 // An error may only occur if offset checking is active and
 // the remote timestamp was rejected due to clock offset,
-// in which case the state of the clock will not have been
+// in which case the timestamp of the clock will not have been
 // altered.
 // To timestamp events of local origin, use Now instead.
 func (c *Clock) Update(rt Timestamp) Timestamp {
-	c.Lock()
-	defer c.Unlock()
-	physicalClock := c.getPhysicalClock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	physicalClock := c.getPhysicalClockLocked()
 
-	if physicalClock > c.state.WallTime && physicalClock > rt.WallTime {
+	if physicalClock > c.mu.timestamp.WallTime && physicalClock > rt.WallTime {
 		// Our physical clock is ahead of both wall times. It is used
 		// as the new wall time and the logical clock is reset.
-		c.state.WallTime = physicalClock
-		c.state.Logical = 0
-		return c.timestamp()
+		c.mu.timestamp.WallTime = physicalClock
+		c.mu.timestamp.Logical = 0
+		return c.mu.timestamp
 	}
 
 	// In the remaining cases, our physical clock plays no role
 	// as it is behind the local and remote wall times. Instead,
 	// the logical clock comes into play.
-	if rt.WallTime > c.state.WallTime {
+	if rt.WallTime > c.mu.timestamp.WallTime {
 		offset := time.Duration(rt.WallTime-physicalClock) * time.Nanosecond
 		if c.maxOffset > 0 && offset > c.maxOffset {
 			log.Warningf(context.TODO(), "remote wall time is too far ahead (%s) to be trustworthy - updating anyway", offset)
 		}
 		// The remote clock is ahead of ours, and we update
 		// our own logical clock with theirs.
-		c.state.WallTime = rt.WallTime
-		c.state.Logical = rt.Logical + 1
-	} else if c.state.WallTime > rt.WallTime {
+		c.mu.timestamp.WallTime = rt.WallTime
+		c.mu.timestamp.Logical = rt.Logical + 1
+	} else if c.mu.timestamp.WallTime > rt.WallTime {
 		// Our wall time is larger, so it remains but we tick
 		// the logical clock.
-		c.state.Logical++
+		c.mu.timestamp.Logical++
 	} else {
 		// Both wall times are equal, and the larger logical
 		// clock is used for the update.
-		if rt.Logical > c.state.Logical {
-			c.state.Logical = rt.Logical
+		if rt.Logical > c.mu.timestamp.Logical {
+			c.mu.timestamp.Logical = rt.Logical
 		}
-		c.state.Logical++
+		c.mu.timestamp.Logical++
 	}
-	return c.timestamp()
+	return c.mu.timestamp
 }

--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -84,6 +84,9 @@ type ManualClock struct {
 // NewManualClock returns a new instance, initialized with
 // specified timestamp.
 func NewManualClock(nanos int64) *ManualClock {
+	if nanos == 0 {
+		panic("zero clock is forbidden")
+	}
 	return &ManualClock{nanos: nanos}
 }
 


### PR DESCRIPTION
...and rewrite countless tests that depend on it, and generally have
bad clock discipline. In particular, many tests previously assumed that
the clock they use starts at zero, leading to sloppy assertions at best
and completely bogus tests at worst. See
storage.TestReplicaTSCacheLowWaterOnLease for an example of the latter.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10376)
<!-- Reviewable:end -->
