### PR TITLE
sql: add pg_catalog.pg_roles for Hibernate support

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -19,6 +19,7 @@ package sql
 import (
 	"sort"
 
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/pkg/errors"
@@ -669,6 +670,40 @@ func forEachColumnInIndex(
 			if err := fn(column); err != nil {
 				return err
 			}
+		}
+	}
+	return nil
+}
+
+func forEachUser(p *planner, fn func(username string) error) error {
+	query := `SELECT username FROM system.users`
+	plan, err := p.query(query)
+	if err != nil {
+		return nil
+	}
+	defer plan.Close()
+	if err := plan.Start(); err != nil {
+		return err
+	}
+
+	// TODO(cuongdo/asubiotto): Get rid of root user special-casing if/when a row
+	// for "root" exists in system.user.
+	if err := fn(security.RootUser); err != nil {
+		return err
+	}
+
+	for {
+		next, err := plan.Next()
+		if err != nil {
+			return err
+		}
+		if !next {
+			break
+		}
+		row := plan.Values()
+		username := row[0].(*parser.DString)
+		if err := fn(string(*username)); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/sql/testdata/information_schema
+++ b/pkg/sql/testdata/information_schema
@@ -353,6 +353,7 @@ pg_database
 pg_indexes
 pg_namespace
 pg_proc
+pg_roles
 pg_tables
 pg_type
 pg_views
@@ -382,6 +383,7 @@ rangelog
 pg_views
 pg_type
 pg_tables
+pg_roles
 pg_proc
 pg_namespace
 pg_indexes
@@ -416,6 +418,7 @@ def            pg_catalog          pg_database        SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_proc            SYSTEM VIEW  1
+def            pg_catalog          pg_roles           SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1
 def            pg_catalog          pg_type            SYSTEM VIEW  1
 def            pg_catalog          pg_views           SYSTEM VIEW  1
@@ -460,6 +463,7 @@ def            pg_catalog          pg_database        SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_proc            SYSTEM VIEW  1
+def            pg_catalog          pg_roles           SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1
 def            pg_catalog          pg_type            SYSTEM VIEW  1
 def            pg_catalog          pg_views           SYSTEM VIEW  1
@@ -493,6 +497,7 @@ def            pg_catalog          pg_database        SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_proc            SYSTEM VIEW  1
+def            pg_catalog          pg_roles           SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1
 def            pg_catalog          pg_type            SYSTEM VIEW  1
 def            pg_catalog          pg_views           SYSTEM VIEW  1

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -53,6 +53,7 @@ pg_database
 pg_indexes
 pg_namespace
 pg_proc
+pg_roles
 pg_tables
 pg_type
 pg_views
@@ -704,3 +705,23 @@ WHERE proname='least'
 ----
 proname  provariadic  pronargs  prorettype  proargtypes  proargmodes
 least    2283         1         2283        2283         v
+
+## pg_catalog.pg_roles
+
+query ITBBBBBBI colnames
+SELECT oid, rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb, rolcatupdate, rolcanlogin, rolconnlimit
+FROM pg_catalog.pg_roles
+ORDER BY rolname;
+----
+oid         rolname   rolsuper  rolinherit  rolcreaterole  rolcreatedb  rolcatupdate  rolcanlogin  rolconnlimit
+4230608961  root      true      false       true           true         false         true         -1
+4079356392  testuser  false     false       false          false        false         true         -1
+
+query ITTTT colnames
+SELECT oid, rolname, rolpassword, rolvaliduntil, rolconfig
+FROM pg_catalog.pg_roles
+ORDER BY rolname;
+----
+oid         rolname   rolpassword  rolvaliduntil  rolconfig
+4230608961  root      ********     NULL           {}
+4079356392  testuser  ********     NULL           {}


### PR DESCRIPTION
To support Hibernate, this introduces support for the `pg_roles` view in
`pg_catalog`. See:

https://www.postgresql.org/docs/8.3/static/view-pg-roles.html

Closes #10077 

cc @asubiotto because this interacts with database users

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10377)
<!-- Reviewable:end -->
