### PR TITLE
sql: Add pg_description table to pg_catalog

### DIFF
--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -57,6 +57,7 @@ var pgCatalog = virtualSchema{
 		pgCatalogClassTable,
 		pgCatalogConstraintTable,
 		pgCatalogDatabaseTable,
+		pgCatalogDescriptionTable,
 		pgCatalogIndexesTable,
 		pgCatalogNamespaceTable,
 		pgCatalogProcTable,
@@ -512,6 +513,71 @@ func colIDArrayToDatum(arr []sqlbase.ColumnID) parser.Datum {
 	return parser.NewDString(buf.String())
 }
 
+var (
+	// http://doxygen.postgresql.org/pg__wchar_8h.html#a22e0c8b9f59f6e226a5968620b4bb6a9aac3b065b882d3231ba59297524da2f23
+	datEncodingUTFId  = parser.NewDInt(6)
+	datEncodingEnUTF8 = parser.NewDString("en_US.utf8")
+)
+
+// See https://www.postgresql.org/docs/9.6/static/catalog-pg-database.html
+var pgCatalogDatabaseTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE pg_catalog.pg_database (
+	oid INT,
+	datname STRING,
+	datdba INT,
+	encoding INT,
+	datcollate STRING,
+	datctype STRING,
+	datistemplate BOOL,
+	datallowconn BOOL,
+	datconnlimit INT,
+	datlastsysoid INT,
+	datfrozenxid INT,
+	datminmxid INT,
+	dattablespace INT,
+	datacl STRING
+);
+`,
+	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+		h := makeOidHasher()
+		return forEachDatabaseDesc(p, func(db *sqlbase.DatabaseDescriptor) error {
+			return addRow(
+				h.DBOid(db),                // oid
+				parser.NewDString(db.Name), // datname
+				parser.DNull,               // datdba
+				datEncodingUTFId,           // encoding
+				datEncodingEnUTF8,          // datcollate
+				datEncodingEnUTF8,          // datctype
+				parser.MakeDBool(false),    // datistemplate
+				parser.MakeDBool(true),     // datallowconn
+				negOneVal,                  // datconnlimit
+				parser.DNull,               // datlastsysoid
+				parser.DNull,               // datfrozenxid
+				parser.DNull,               // datminmxid
+				parser.DNull,               // dattablespace
+				parser.DNull,               // datacl
+			)
+		})
+	},
+}
+
+// See: https://www.postgresql.org/docs/9.6/static/catalog-pg-description.html.
+var pgCatalogDescriptionTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE pg_catalog.pg_description (
+	objoid INT,
+	classoid INT,
+	objsubid INT,
+	description STRING
+);
+`,
+	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+		// Comments on database objects are not currently supported.
+		return nil
+	},
+}
+
 // See: https://www.postgresql.org/docs/9.6/static/view-pg-indexes.html.
 var pgCatalogIndexesTable = virtualSchemaTable{
 	schema: `
@@ -943,55 +1009,6 @@ CREATE TABLE pg_catalog.pg_type (
 			}
 		}
 		return nil
-	},
-}
-
-var (
-	// http://doxygen.postgresql.org/pg__wchar_8h.html#a22e0c8b9f59f6e226a5968620b4bb6a9aac3b065b882d3231ba59297524da2f23
-	datEncodingUTFId = parser.NewDInt(6)
-	datEncodingEnUTF = parser.NewDString("en_US.utf8")
-)
-
-// See https://www.postgresql.org/docs/9.6/static/catalog-pg-database.html
-var pgCatalogDatabaseTable = virtualSchemaTable{
-	schema: `
-CREATE TABLE pg_catalog.pg_database (
-	oid INT,
-	datname STRING,
-	datdba INT,
-	encoding INT,
-	datcollate STRING,
-	datctype STRING,
-	datistemplate BOOL,
-	datallowconn BOOL,
-	datconnlimit INT,
-	datlastsysoid INT,
-	datfrozenxid INT,
-	datminmxid INT,
-	dattablespace INT,
-	datacl STRING
-);
-`,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
-		h := makeOidHasher()
-		return forEachDatabaseDesc(p, func(db *sqlbase.DatabaseDescriptor) error {
-			return addRow(
-				h.DBOid(db),                // oid
-				parser.NewDString(db.Name), // datname
-				parser.DNull,               // datdba
-				datEncodingUTFId,           // encoding
-				datEncodingEnUTF,           // datcollate
-				datEncodingEnUTF,           // datctype
-				parser.MakeDBool(false),    // datistemplate
-				parser.MakeDBool(true),     // datallowconn
-				negOneVal,                  // datconnlimit
-				parser.DNull,               // datlastsysoid
-				parser.DNull,               // datfrozenxid
-				parser.DNull,               // datminmxid
-				parser.DNull,               // dattablespace
-				parser.DNull,               // datacl
-			)
-		})
 	},
 }
 

--- a/pkg/sql/testdata/information_schema
+++ b/pkg/sql/testdata/information_schema
@@ -352,6 +352,7 @@ pg_attribute
 pg_class
 pg_constraint
 pg_database
+pg_description
 pg_indexes
 pg_namespace
 pg_proc
@@ -390,6 +391,7 @@ pg_roles
 pg_proc
 pg_namespace
 pg_indexes
+pg_description
 pg_database
 pg_constraint
 pg_class
@@ -419,6 +421,7 @@ def            pg_catalog          pg_attribute       SYSTEM VIEW  1
 def            pg_catalog          pg_class           SYSTEM VIEW  1
 def            pg_catalog          pg_constraint      SYSTEM VIEW  1
 def            pg_catalog          pg_database        SYSTEM VIEW  1
+def            pg_catalog          pg_description     SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_proc            SYSTEM VIEW  1
@@ -465,6 +468,7 @@ def            pg_catalog          pg_attribute       SYSTEM VIEW  1
 def            pg_catalog          pg_class           SYSTEM VIEW  1
 def            pg_catalog          pg_constraint      SYSTEM VIEW  1
 def            pg_catalog          pg_database        SYSTEM VIEW  1
+def            pg_catalog          pg_description     SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_proc            SYSTEM VIEW  1
@@ -500,6 +504,7 @@ def            pg_catalog          pg_attribute       SYSTEM VIEW  1
 def            pg_catalog          pg_class           SYSTEM VIEW  1
 def            pg_catalog          pg_constraint      SYSTEM VIEW  1
 def            pg_catalog          pg_database        SYSTEM VIEW  1
+def            pg_catalog          pg_description     SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_proc            SYSTEM VIEW  1

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -50,6 +50,7 @@ pg_attribute
 pg_class
 pg_constraint
 pg_database
+pg_description
 pg_indexes
 pg_namespace
 pg_proc
@@ -725,3 +726,10 @@ ORDER BY rolname;
 oid         rolname   rolpassword  rolvaliduntil  rolconfig
 4230608961  root      ********     NULL           {}
 4079356392  testuser  ********     NULL           {}
+
+## pg_catalog.pg_description
+
+query IIIT colnames
+SELECT * FROM pg_catalog.pg_description
+----
+objoid  classoid  objsubid  description


### PR DESCRIPTION
Fixes #10074.

The `pg_description` table stores optional descriptions (comments) for
each database object.

Notes:
- Hibernate accesses this table, but only through LEFT JOINs, so mocking
  it out with an empty table is sufficient.
- This commit also moves the `pg_database` declaration up in the
  `pg_catalog.go` file, without modifying it.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10381)
<!-- Reviewable:end -->
