### PR TITLE
storage: fill snapshot reservations in Store.HandleSnapshot

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -1990,6 +1990,9 @@ func TestStoreRangeRebalance(t *testing.T) {
 		generated += m.RangeSnapshotsGenerated.Count()
 		normalApplied += m.RangeSnapshotsNormalApplied.Count()
 		preemptiveApplied += m.RangeSnapshotsPreemptiveApplied.Count()
+		if n := s.ReservationCount(); n != 0 {
+			t.Fatalf("expected 0 reservations, but found %d", n)
+		}
 	}
 	if generated == 0 {
 		t.Fatalf("expected at least 1 snapshot, but found 0")

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -169,6 +169,12 @@ func (s *Store) ManualReplicaGC(repl *Replica) error {
 	return s.gcQueue.process(ctx, s.Clock().Now(), repl, cfg)
 }
 
+func (s *Store) ReservationCount() int {
+	s.bookie.mu.Lock()
+	defer s.bookie.mu.Unlock()
+	return len(s.bookie.mu.reservationsByRangeID)
+}
+
 func (r *Replica) RaftLock() {
 	r.raftMu.Lock()
 }

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -553,9 +553,6 @@ func (r *Replica) applySnapshot(
 ) error {
 	// Extract the updated range descriptor.
 	desc := inSnap.RangeDescriptor
-	// Fill the reservation if there was one for this range, regardless of
-	// whether the application succeeded.
-	defer r.store.bookie.Fill(desc.RangeID)
 
 	r.mu.Lock()
 	replicaID := r.mu.replicaID

--- a/pkg/storage/reservation_test.go
+++ b/pkg/storage/reservation_test.go
@@ -105,6 +105,7 @@ func TestBookieReserve(t *testing.T) {
 		{rangeID: 0, reserve: false, expSuc: true, expOut: 0, expBytes: 0, expReservations: 5},
 	}
 
+	ctx := context.Background()
 	for i, testCase := range testCases {
 		if testCase.reserve {
 			// Try to reserve the range.
@@ -116,7 +117,7 @@ func TestBookieReserve(t *testing.T) {
 				RangeID:   roachpb.RangeID(testCase.rangeID),
 				RangeSize: int64(testCase.rangeID),
 			}
-			if resp := b.Reserve(context.Background(), req, testCase.deadReplicas); resp.Reserved != testCase.expSuc {
+			if resp := b.Reserve(ctx, req, testCase.deadReplicas); resp.Reserved != testCase.expSuc {
 				if testCase.expSuc {
 					t.Errorf("%d: expected a successful reservation, was rejected", i)
 				} else {
@@ -125,7 +126,7 @@ func TestBookieReserve(t *testing.T) {
 			}
 		} else {
 			// Fill the reservation.
-			if filled := b.Fill(roachpb.RangeID(testCase.rangeID)); filled != testCase.expSuc {
+			if filled := b.Fill(ctx, roachpb.RangeID(testCase.rangeID)); filled != testCase.expSuc {
 				if testCase.expSuc {
 					t.Errorf("%d: expected a successful filled reservation, was rejected", i)
 				} else {
@@ -313,7 +314,7 @@ func TestReservationQueue(t *testing.T) {
 	verifyBookie(t, b, 10 /*reservations*/, 10 /*queue*/, 10*bytesPerReservation /*bytes*/)
 
 	// Fill reservation 2.
-	if !b.Fill(2) {
+	if !b.Fill(context.Background(), 2) {
 		t.Fatalf("Could not fill reservation 2")
 	}
 	// After filling a reservation, wait a full cycle so that it can be timed
@@ -325,10 +326,10 @@ func TestReservationQueue(t *testing.T) {
 	verifyBookie(t, b, 8 /*reservations*/, 9 /*queue*/, 8*bytesPerReservation /*bytes*/)
 
 	// Fill reservations 4 and 6.
-	if !b.Fill(4) {
+	if !b.Fill(context.Background(), 4) {
 		t.Fatalf("Could not fill reservation 4")
 	}
-	if !b.Fill(6) {
+	if !b.Fill(context.Background(), 6) {
 		t.Fatalf("Could not fill reservation 6")
 	}
 	verifyBookie(t, b, 6 /*reservations*/, 9 /*queue*/, 6*bytesPerReservation /*bytes*/)
@@ -383,7 +384,7 @@ func TestReservationQueue(t *testing.T) {
 	verifyBookie(t, b, 8 /*reservations*/, 9 /*queue*/, 8*bytesPerReservation /*bytes*/)
 
 	// Fill 1 a second time.
-	if !b.Fill(1) {
+	if !b.Fill(context.Background(), 1) {
 		t.Fatalf("Could not fill reservation 1 (second pass)")
 	}
 	verifyBookie(t, b, 7 /*reservations*/, 9 /*queue*/, 7*bytesPerReservation /*bytes*/)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2505,6 +2505,7 @@ func (s *Store) HandleSnapshot(
 				StoreCapacity: capacity,
 			})
 		}
+		defer s.bookie.Fill(header.RangeDescriptor.RangeID)
 	}
 
 	// Check to see if the snapshot can be applied but don't attempt to add

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2505,7 +2505,7 @@ func (s *Store) HandleSnapshot(
 				StoreCapacity: capacity,
 			})
 		}
-		defer s.bookie.Fill(header.RangeDescriptor.RangeID)
+		defer s.bookie.Fill(ctx, header.RangeDescriptor.RangeID)
 	}
 
 	// Check to see if the snapshot can be applied but don't attempt to add


### PR DESCRIPTION
Previously we were filling reservations in Replica.applySnapshot(), but
that could leave dangling a reservation if we never reached that method
because the snapshot could not be applied.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10391)
<!-- Reviewable:end -->
