### PR TITLE
storage: remove reservation queue

### DIFF
--- a/pkg/storage/reservation.go
+++ b/pkg/storage/reservation.go
@@ -15,17 +15,12 @@
 package storage
 
 import (
-	"time"
-
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 const (
@@ -36,83 +31,38 @@ const (
 	defaultMaxReservedBytes = 250 << 20 // 250 MiB
 )
 
-// ReservationRequest represents a request for a replica reservation.
-type ReservationRequest struct {
+// reservationRequest represents a request for a replica reservation.
+type reservationRequest struct {
 	StoreRequestHeader
 	RangeID   roachpb.RangeID
 	RangeSize int64
 }
 
-// ReservationResponse represents a response from the reservation system.
-type ReservationResponse struct {
+// reservationResponse represents a response from the reservation system.
+type reservationResponse struct {
 	Reserved bool
-}
-
-// reservation is an item in both the reservationQ and the used in bookie's
-// reservation map.
-type reservation struct {
-	ReservationRequest
-	expireAt hlc.Timestamp
-}
-
-// reservationQ is a queue for reservations. Since all new reservations have the
-// same time until expireAt, a simple FIFO queue is sufficient.
-// It is not threadsafe.
-type reservationQ []*reservation
-
-// peek returns the next value in the queue without dequeuing it.
-func (pq reservationQ) peek() *reservation {
-	if len(pq) == 0 {
-		return nil
-	}
-	return pq[0]
-}
-
-// enqueue adds the reservation to the queue.
-func (pq *reservationQ) enqueue(book *reservation) {
-	*pq = append(*pq, book)
-}
-
-// dequeue removes the next reservation from the queue.
-func (pq *reservationQ) dequeue() *reservation {
-	if len(*pq) == 0 {
-		return nil
-	}
-	book := (*pq)[0]
-	// Remove the pointer to the removed element for more efficient gc.
-	(*pq)[0] = nil
-	*pq = (*pq)[1:]
-	return book
 }
 
 // bookie contains a store's replica reservations.
 type bookie struct {
-	clock              *hlc.Clock
-	metrics            *StoreMetrics
-	reservationTimeout time.Duration // How long each reservation is held.
-	maxReservations    int           // Maximum number of allowed reservations.
-	maxReservedBytes   int64         // Maximum bytes allowed for all reservations combined.
-	mu                 struct {
-		syncutil.Mutex                                         // Protects all values within the mu struct.
-		queue                 reservationQ                     // Queue used to handle expiring of reservations.
-		reservationsByRangeID map[roachpb.RangeID]*reservation // All active reservations
-		size                  int64                            // Total bytes required for all reservations.
+	metrics          *StoreMetrics
+	maxReservations  int   // Maximum number of allowed reservations.
+	maxReservedBytes int64 // Maximum bytes allowed for all reservations combined.
+	mu               struct {
+		syncutil.Mutex                                               // Protects all values within the mu struct.
+		reservationsByRangeID map[roachpb.RangeID]reservationRequest // All active reservations
+		size                  int64                                  // Total bytes required for all reservations.
 	}
 }
 
-// newBookie creates a reservations system and starts its timeout queue.
-func newBookie(
-	clock *hlc.Clock, stopper *stop.Stopper, metrics *StoreMetrics, reservationTimeout time.Duration,
-) *bookie {
+// newBookie creates a reservations system.
+func newBookie(metrics *StoreMetrics) *bookie {
 	b := &bookie{
-		clock:              clock,
-		metrics:            metrics,
-		reservationTimeout: reservationTimeout,
-		maxReservations:    envutil.EnvOrDefaultInt("COCKROACH_MAX_RESERVATIONS", defaultMaxReservations),
-		maxReservedBytes:   envutil.EnvOrDefaultBytes("COCKROACH_MAX_RESERVED_BYTES", defaultMaxReservedBytes),
+		metrics:          metrics,
+		maxReservations:  envutil.EnvOrDefaultInt("COCKROACH_MAX_RESERVATIONS", defaultMaxReservations),
+		maxReservedBytes: envutil.EnvOrDefaultBytes("COCKROACH_MAX_RESERVED_BYTES", defaultMaxReservedBytes),
 	}
-	b.mu.reservationsByRangeID = make(map[roachpb.RangeID]*reservation)
-	b.start(stopper)
+	b.mu.reservationsByRangeID = make(map[roachpb.RangeID]reservationRequest)
 	return b
 }
 
@@ -120,12 +70,12 @@ func newBookie(
 // outstanding reservations already or not having enough free disk space.
 // Accepted reservations return a ReservationResponse with Reserved set to true.
 func (b *bookie) Reserve(
-	ctx context.Context, req ReservationRequest, deadReplicas []roachpb.ReplicaIdent,
-) ReservationResponse {
+	ctx context.Context, req reservationRequest, deadReplicas []roachpb.ReplicaIdent,
+) reservationResponse {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	resp := ReservationResponse{
+	resp := reservationResponse{
 		Reserved: false,
 	}
 
@@ -185,17 +135,11 @@ func (b *bookie) Reserve(
 				log.Infof(ctx, "[r%d] unable to book reservation, the replica has been destroyed",
 					req.RangeID)
 			}
-			return ReservationResponse{Reserved: false}
+			return reservationResponse{Reserved: false}
 		}
 	}
 
-	newReservation := &reservation{
-		ReservationRequest: req,
-		expireAt:           b.clock.Now().Add(b.reservationTimeout.Nanoseconds(), 0),
-	}
-
-	b.mu.reservationsByRangeID[req.RangeID] = newReservation
-	b.mu.queue.enqueue(newReservation)
+	b.mu.reservationsByRangeID[req.RangeID] = req
 	b.mu.size += req.RangeSize
 
 	// Update the store metrics.
@@ -203,8 +147,7 @@ func (b *bookie) Reserve(
 	b.metrics.Reserved.Inc(req.RangeSize)
 
 	if log.V(1) {
-		log.Infof(ctx, "[r%s] new reservation, size=%d",
-			newReservation.RangeID, newReservation.RangeSize)
+		log.Infof(ctx, "[r%s] new reservation, size=%d", req.RangeID, req.RangeSize)
 	}
 
 	resp.Reserved = true
@@ -232,7 +175,7 @@ func (b *bookie) Fill(ctx context.Context, rangeID roachpb.RangeID) bool {
 
 // fillReservationLocked fills a reservation. It requires that the bookie's
 // lock is held. This should only be called internally.
-func (b *bookie) fillReservationLocked(ctx context.Context, res *reservation) {
+func (b *bookie) fillReservationLocked(ctx context.Context, res reservationRequest) {
 	if log.V(2) {
 		log.Infof(ctx, "[r%d] filling reservation", res.RangeID)
 	}
@@ -247,47 +190,4 @@ func (b *bookie) fillReservationLocked(ctx context.Context, res *reservation) {
 	// Update the store metrics.
 	b.metrics.ReservedReplicaCount.Dec(1)
 	b.metrics.Reserved.Dec(res.RangeSize)
-}
-
-// start will run continuously and expire old reservations.
-func (b *bookie) start(stopper *stop.Stopper) {
-	stopper.RunWorker(func() {
-		var timeoutTimer timeutil.Timer
-		defer timeoutTimer.Stop()
-		ctx := context.TODO()
-		for {
-			var timeout time.Duration
-			b.mu.Lock()
-			nextExpiration := b.mu.queue.peek()
-			if nextExpiration == nil {
-				// No reservations to expire.
-				timeout = b.reservationTimeout
-			} else {
-				now := b.clock.Now()
-				if now.GoTime().After(nextExpiration.expireAt.GoTime()) {
-					// We have a reservation expiration, remove it.
-					expiredReservation := b.mu.queue.dequeue()
-					// Is it an active reservation?
-					if b.mu.reservationsByRangeID[expiredReservation.RangeID] == expiredReservation {
-						b.fillReservationLocked(ctx, expiredReservation)
-					} else if log.V(2) {
-						log.Infof(ctx, "[r%d] expired reservation has already been filled",
-							expiredReservation.RangeID)
-					}
-					// Set the timeout to 0 to force another peek.
-					timeout = 0
-				} else {
-					timeout = nextExpiration.expireAt.GoTime().Sub(now.GoTime())
-				}
-			}
-			b.mu.Unlock()
-			timeoutTimer.Reset(timeout)
-			select {
-			case <-timeoutTimer.C:
-				timeoutTimer.Read = true
-			case <-stopper.ShouldStop():
-				return
-			}
-		}
-	})
 }

--- a/pkg/storage/reservation_test.go
+++ b/pkg/storage/reservation_test.go
@@ -15,7 +15,6 @@
 package storage
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -24,20 +23,14 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
 // createTestBookie creates a new bookie, stopper and manual clock for testing.
 func createTestBookie(
 	reservationTimeout time.Duration, maxReservations int, maxReservedBytes int64,
-) (*stop.Stopper, *hlc.ManualClock, *bookie) {
-	stopper := stop.NewStopper()
-	mc := hlc.NewManualClock(0)
-	clock := hlc.NewClock(mc.UnixNano)
-	b := newBookie(clock, stopper, newStoreMetrics(time.Hour), reservationTimeout)
+) *bookie {
+	b := newBookie(newStoreMetrics(time.Hour))
 	// Lock the bookie to prevent the main loop from running as we change some
 	// of the bookie's state.
 	b.mu.Lock()
@@ -46,28 +39,18 @@ func createTestBookie(
 	b.maxReservedBytes = maxReservedBytes
 	// Set a high number for a mocked total available space.
 	b.metrics.Available.Update(defaultMaxReservedBytes * 10)
-	return stopper, mc, b
+	return b
 }
 
-// verifyBookie ensures that the correct number of reservations, reserved bytes,
-// and that the expirationQueue's length are correct.
-func verifyBookie(t *testing.T, b *bookie, reservations, queueLen int, reservedBytes int64) {
+// verifyBookie ensures that there are the correct number of reservations and
+// reserved bytes.
+func verifyBookie(t *testing.T, b *bookie, reservations int, reservedBytes int64) {
 	if e, a := reservedBytes, b.metrics.Reserved.Count(); e != a {
 		t.Error(errors.Errorf("expected total bytes reserved to be %d, got %d", e, a))
 	}
 	if e, a := reservations, int(b.metrics.ReservedReplicaCount.Count()); e != a {
 		t.Error(errors.Errorf("expected total reservations to be %d, got %d", e, a))
 	}
-	if e, a := queueLen, bookieQueueLen(b); e != a {
-		t.Error(errors.Errorf("expected total queue length to be %d, got %d", e, a))
-	}
-}
-
-// bookieQueueLen returns the length of the bookie queue.
-func bookieQueueLen(b *bookie) int {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return len(b.mu.queue)
 }
 
 // TestBookieReserve ensures that you can never have more than one reservation
@@ -75,41 +58,39 @@ func bookieQueueLen(b *bookie) int {
 // correctly.
 func TestBookieReserve(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	stopper, _, b := createTestBookie(time.Hour, 5, defaultMaxReservedBytes)
-	defer stopper.Stop()
+	b := createTestBookie(time.Hour, 5, defaultMaxReservedBytes)
 
 	testCases := []struct {
-		rangeID         int
-		reserve         bool                   // true for reserve, false for fill
-		expSuc          bool                   // is the operation expected to succeed
-		expOut          int                    // expected number of reserved replicas
-		expBytes        int64                  // expected number of bytes being reserved
-		expReservations int                    // expected number of reservations held in the bookie's queue
-		deadReplicas    []roachpb.ReplicaIdent // dead replicas that we should not reserve over
+		rangeID      int
+		reserve      bool                   // true for reserve, false for fill
+		expSuc       bool                   // is the operation expected to succeed
+		expOut       int                    // expected number of reserved replicas
+		expBytes     int64                  // expected number of bytes being reserved
+		deadReplicas []roachpb.ReplicaIdent // dead replicas that we should not reserve over
 	}{
-		{rangeID: 1, reserve: true, expSuc: true, expOut: 1, expBytes: 1, expReservations: 1},
-		{rangeID: 1, reserve: true, expSuc: false, expOut: 1, expBytes: 1, expReservations: 1},
-		{rangeID: 1, reserve: false, expSuc: true, expOut: 0, expBytes: 0, expReservations: 1},
-		{rangeID: 1, reserve: false, expSuc: false, expOut: 0, expBytes: 0, expReservations: 1},
-		{rangeID: 2, reserve: true, expSuc: true, expOut: 1, expBytes: 2, expReservations: 2},
-		{rangeID: 3, reserve: true, expSuc: true, expOut: 2, expBytes: 5, expReservations: 3},
-		{rangeID: 1, reserve: true, expSuc: true, expOut: 3, expBytes: 6, expReservations: 4},
-		{rangeID: 2, reserve: true, expSuc: false, expOut: 3, expBytes: 6, expReservations: 4},
-		{rangeID: 2, reserve: false, expSuc: true, expOut: 2, expBytes: 4, expReservations: 4},
-		{rangeID: 2, reserve: false, expSuc: false, expOut: 2, expBytes: 4, expReservations: 4},
-		{rangeID: 3, reserve: false, expSuc: true, expOut: 1, expBytes: 1, expReservations: 4},
-		{rangeID: 1, reserve: false, expSuc: true, expOut: 0, expBytes: 0, expReservations: 4},
-		{rangeID: 2, reserve: false, expSuc: false, expOut: 0, expBytes: 0, expReservations: 4},
-		{rangeID: 0, reserve: true, expSuc: false, expOut: 0, expBytes: 0, expReservations: 4, deadReplicas: []roachpb.ReplicaIdent{{RangeID: 0}}},
-		{rangeID: 0, reserve: true, expSuc: true, expOut: 1, expBytes: 0, expReservations: 5, deadReplicas: []roachpb.ReplicaIdent{{RangeID: 1}}},
-		{rangeID: 0, reserve: false, expSuc: true, expOut: 0, expBytes: 0, expReservations: 5},
+		{rangeID: 1, reserve: true, expSuc: true, expOut: 1, expBytes: 1},
+		{rangeID: 1, reserve: true, expSuc: false, expOut: 1, expBytes: 1},
+		{rangeID: 1, reserve: false, expSuc: true, expOut: 0, expBytes: 0},
+		{rangeID: 1, reserve: false, expSuc: false, expOut: 0, expBytes: 0},
+		{rangeID: 2, reserve: true, expSuc: true, expOut: 1, expBytes: 2},
+		{rangeID: 3, reserve: true, expSuc: true, expOut: 2, expBytes: 5},
+		{rangeID: 1, reserve: true, expSuc: true, expOut: 3, expBytes: 6},
+		{rangeID: 2, reserve: true, expSuc: false, expOut: 3, expBytes: 6},
+		{rangeID: 2, reserve: false, expSuc: true, expOut: 2, expBytes: 4},
+		{rangeID: 2, reserve: false, expSuc: false, expOut: 2, expBytes: 4},
+		{rangeID: 3, reserve: false, expSuc: true, expOut: 1, expBytes: 1},
+		{rangeID: 1, reserve: false, expSuc: true, expOut: 0, expBytes: 0},
+		{rangeID: 2, reserve: false, expSuc: false, expOut: 0, expBytes: 0},
+		{rangeID: 0, reserve: true, expSuc: false, expOut: 0, expBytes: 0, deadReplicas: []roachpb.ReplicaIdent{{RangeID: 0}}},
+		{rangeID: 0, reserve: true, expSuc: true, expOut: 1, expBytes: 0, deadReplicas: []roachpb.ReplicaIdent{{RangeID: 1}}},
+		{rangeID: 0, reserve: false, expSuc: true, expOut: 0, expBytes: 0},
 	}
 
 	ctx := context.Background()
 	for i, testCase := range testCases {
 		if testCase.reserve {
 			// Try to reserve the range.
-			req := ReservationRequest{
+			req := reservationRequest{
 				StoreRequestHeader: StoreRequestHeader{
 					StoreID: roachpb.StoreID(i),
 					NodeID:  roachpb.NodeID(i),
@@ -135,12 +116,12 @@ func TestBookieReserve(t *testing.T) {
 			}
 		}
 
-		verifyBookie(t, b, testCase.expOut, testCase.expReservations, testCase.expBytes)
+		verifyBookie(t, b, testCase.expOut, testCase.expBytes)
 	}
 
 	// Test that repeated requests with the same store and node number extend
 	// the timeout of the pre-existing reservation.
-	repeatReq := ReservationRequest{
+	repeatReq := reservationRequest{
 		StoreRequestHeader: StoreRequestHeader{
 			StoreID: 100,
 			NodeID:  100,
@@ -148,17 +129,15 @@ func TestBookieReserve(t *testing.T) {
 		RangeID:   100,
 		RangeSize: 100,
 	}
-	queueLen := bookieQueueLen(b)
 	for i := 1; i < 10; i++ {
 		if !b.Reserve(context.Background(), repeatReq, nil).Reserved {
 			t.Errorf("%d: could not add repeated reservation", i)
 		}
-		verifyBookie(t, b, 1, queueLen+i, 100)
+		verifyBookie(t, b, 1, 100)
 	}
-	queueLen = bookieQueueLen(b)
 
 	// Test rejecting a reservation due to disk space constraints.
-	overfilledReq := ReservationRequest{
+	overfilledReq := reservationRequest{
 		StoreRequestHeader: StoreRequestHeader{
 			StoreID: 200,
 			NodeID:  200,
@@ -175,7 +154,7 @@ func TestBookieReserve(t *testing.T) {
 	if b.Reserve(context.Background(), overfilledReq, nil).Reserved {
 		t.Errorf("expected reservation to fail due to disk space constraints, but it succeeded")
 	}
-	verifyBookie(t, b, 1, queueLen, 100) // The same numbers from the last call to verifyBookie.
+	verifyBookie(t, b, 1, 100) // The same numbers from the last call to verifyBookie.
 }
 
 // TestBookieReserveMaxRanges ensures that over-booking doesn't occur when there
@@ -185,12 +164,11 @@ func TestBookieReserveMaxRanges(t *testing.T) {
 
 	previousReserved := 10
 
-	stopper, _, b := createTestBookie(time.Hour, previousReserved, defaultMaxReservedBytes)
-	defer stopper.Stop()
+	b := createTestBookie(time.Hour, previousReserved, defaultMaxReservedBytes)
 
 	// Load up reservations.
 	for i := 1; i <= previousReserved; i++ {
-		req := ReservationRequest{
+		req := reservationRequest{
 			StoreRequestHeader: StoreRequestHeader{
 				StoreID: roachpb.StoreID(i),
 				NodeID:  roachpb.NodeID(i),
@@ -201,10 +179,10 @@ func TestBookieReserveMaxRanges(t *testing.T) {
 		if !b.Reserve(context.Background(), req, nil).Reserved {
 			t.Errorf("%d: could not add reservation", i)
 		}
-		verifyBookie(t, b, i, i, int64(i))
+		verifyBookie(t, b, i, int64(i))
 	}
 
-	overbookedReq := ReservationRequest{
+	overbookedReq := reservationRequest{
 		StoreRequestHeader: StoreRequestHeader{
 			StoreID: roachpb.StoreID(previousReserved + 1),
 			NodeID:  roachpb.NodeID(previousReserved + 1),
@@ -216,7 +194,7 @@ func TestBookieReserveMaxRanges(t *testing.T) {
 		t.Errorf("expected reservation to fail due to too many already existing reservations, but it succeeded")
 	}
 	// The same numbers from the last call to verifyBookie.
-	verifyBookie(t, b, previousReserved, previousReserved, int64(previousReserved))
+	verifyBookie(t, b, previousReserved, int64(previousReserved))
 }
 
 // TestBookieReserveMaxBytes ensures that over-booking doesn't occur when trying
@@ -226,12 +204,11 @@ func TestBookieReserveMaxBytes(t *testing.T) {
 
 	previousReservedBytes := 10
 
-	stopper, _, b := createTestBookie(time.Hour, previousReservedBytes*2, int64(previousReservedBytes))
-	defer stopper.Stop()
+	b := createTestBookie(time.Hour, previousReservedBytes*2, int64(previousReservedBytes))
 
 	// Load up reservations with a size of 1 each.
 	for i := 1; i <= previousReservedBytes; i++ {
-		req := ReservationRequest{
+		req := reservationRequest{
 			StoreRequestHeader: StoreRequestHeader{
 				StoreID: roachpb.StoreID(i),
 				NodeID:  roachpb.NodeID(i),
@@ -242,10 +219,10 @@ func TestBookieReserveMaxBytes(t *testing.T) {
 		if !b.Reserve(context.Background(), req, nil).Reserved {
 			t.Errorf("%d: could not add reservation", i)
 		}
-		verifyBookie(t, b, i, i, int64(i))
+		verifyBookie(t, b, i, int64(i))
 	}
 
-	overbookedReq := ReservationRequest{
+	overbookedReq := reservationRequest{
 		StoreRequestHeader: StoreRequestHeader{
 			StoreID: roachpb.StoreID(previousReservedBytes + 1),
 			NodeID:  roachpb.NodeID(previousReservedBytes + 1),
@@ -257,155 +234,5 @@ func TestBookieReserveMaxBytes(t *testing.T) {
 		t.Errorf("expected reservation to fail due to too many already existing reservations, but it succeeded")
 	}
 	// The same numbers from the last call to verifyBookie.
-	verifyBookie(t, b, previousReservedBytes, previousReservedBytes, int64(previousReservedBytes))
-}
-
-// expireNextReservation advances the manual clock to one nanosecond passed the
-// next expiring reservation and waits until exactly one reservation has expired.
-func expireNextReservation(t *testing.T, mc *hlc.ManualClock, b *bookie) {
-	b.mu.Lock()
-	nextExpiredReservation := b.mu.queue.peek()
-	if nextExpiredReservation == nil {
-		t.Fatalf("expected at least one reservation, but there are none")
-	}
-	expectedExpires := len(b.mu.queue) - 1
-	// Set the clock to after next timeout.
-	mc.Set(nextExpiredReservation.expireAt.WallTime + 1)
-	b.mu.Unlock()
-
-	util.SucceedsSoon(t, func() error {
-		b.mu.Lock()
-		defer b.mu.Unlock()
-		if expectedExpires != len(b.mu.queue) {
-			nextExpiredReservation := b.mu.queue.peek()
-			return fmt.Errorf("expiration has not yet occurred, next expiration in %s for rangeID:%d",
-				nextExpiredReservation.expireAt, nextExpiredReservation.RangeID)
-		}
-		return nil
-	})
-}
-
-// TestReservationQueue checks to ensure that the expiration loop functions
-// correctly expiring any unfilled reservations in a number of different cases.
-func TestReservationQueue(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	// This test loads up 7 reservations at once, so set the queue higher to
-	// accommodate them.
-	stopper, mc, b := createTestBookie(time.Microsecond, 20, defaultMaxReservedBytes)
-	defer stopper.Stop()
-
-	bytesPerReservation := int64(100)
-
-	// Load a collection of reservations into the bookie.
-	for i := 1; i <= 10; i++ {
-		// Ensure all the reservations expire 100 nanoseconds apart.
-		mc.Increment(100)
-		if !b.Reserve(context.Background(), ReservationRequest{
-			StoreRequestHeader: StoreRequestHeader{
-				StoreID: roachpb.StoreID(i),
-				NodeID:  roachpb.NodeID(i),
-			},
-			RangeID:   roachpb.RangeID(i),
-			RangeSize: bytesPerReservation,
-		}, nil).Reserved {
-			t.Fatalf("could not book a reservation for reservation number %d", i)
-		}
-	}
-	verifyBookie(t, b, 10 /*reservations*/, 10 /*queue*/, 10*bytesPerReservation /*bytes*/)
-
-	// Fill reservation 2.
-	if !b.Fill(context.Background(), 2) {
-		t.Fatalf("Could not fill reservation 2")
-	}
-	// After filling a reservation, wait a full cycle so that it can be timed
-	// out.
-	verifyBookie(t, b, 9 /*reservations*/, 10 /*queue*/, 9*bytesPerReservation /*bytes*/)
-
-	// Expire reservation 1.
-	expireNextReservation(t, mc, b)
-	verifyBookie(t, b, 8 /*reservations*/, 9 /*queue*/, 8*bytesPerReservation /*bytes*/)
-
-	// Fill reservations 4 and 6.
-	if !b.Fill(context.Background(), 4) {
-		t.Fatalf("Could not fill reservation 4")
-	}
-	if !b.Fill(context.Background(), 6) {
-		t.Fatalf("Could not fill reservation 6")
-	}
-	verifyBookie(t, b, 6 /*reservations*/, 9 /*queue*/, 6*bytesPerReservation /*bytes*/)
-
-	expireNextReservation(t, mc, b) // Expire 2 (already filled)
-	verifyBookie(t, b, 6 /*reservations*/, 8 /*queue*/, 6*bytesPerReservation /*bytes*/)
-	expireNextReservation(t, mc, b) // Expire 3
-	verifyBookie(t, b, 5 /*reservations*/, 7 /*queue*/, 5*bytesPerReservation /*bytes*/)
-	expireNextReservation(t, mc, b) // Expire 4 (already filled)
-	verifyBookie(t, b, 5 /*reservations*/, 6 /*queue*/, 5*bytesPerReservation /*bytes*/)
-
-	// Add three new reservations, 1 and 2, which have already been filled and
-	// timed out, and 6, which has been filled by not timed out. Only increment
-	// by 10 here to ensure we don't expire any of the other reservations.
-	mc.Increment(10)
-	if !b.Reserve(context.Background(), ReservationRequest{
-		StoreRequestHeader: StoreRequestHeader{
-			StoreID: roachpb.StoreID(11),
-			NodeID:  roachpb.NodeID(11),
-		},
-		RangeID:   roachpb.RangeID(1),
-		RangeSize: bytesPerReservation,
-	}, nil).Reserved {
-		t.Fatalf("could not book a reservation for reservation number 1 (second pass)")
-	}
-	verifyBookie(t, b, 6 /*reservations*/, 7 /*queue*/, 6*bytesPerReservation /*bytes*/)
-
-	mc.Increment(10)
-	if !b.Reserve(context.Background(), ReservationRequest{
-		StoreRequestHeader: StoreRequestHeader{
-			StoreID: roachpb.StoreID(12),
-			NodeID:  roachpb.NodeID(12),
-		},
-		RangeID:   roachpb.RangeID(2),
-		RangeSize: bytesPerReservation,
-	}, nil).Reserved {
-		t.Fatalf("could not book a reservation for reservation number 2 (second pass)")
-	}
-	verifyBookie(t, b, 7 /*reservations*/, 8 /*queue*/, 7*bytesPerReservation /*bytes*/)
-
-	mc.Increment(10)
-	if !b.Reserve(context.Background(), ReservationRequest{
-		StoreRequestHeader: StoreRequestHeader{
-			StoreID: roachpb.StoreID(13),
-			NodeID:  roachpb.NodeID(13),
-		},
-		RangeID:   roachpb.RangeID(6),
-		RangeSize: bytesPerReservation,
-	}, nil).Reserved {
-		t.Fatalf("could not book a reservation for reservation number 6 (second pass)")
-	}
-	verifyBookie(t, b, 8 /*reservations*/, 9 /*queue*/, 8*bytesPerReservation /*bytes*/)
-
-	// Fill 1 a second time.
-	if !b.Fill(context.Background(), 1) {
-		t.Fatalf("Could not fill reservation 1 (second pass)")
-	}
-	verifyBookie(t, b, 7 /*reservations*/, 9 /*queue*/, 7*bytesPerReservation /*bytes*/)
-
-	// Expire all the remaining reservations one at a time.
-	expireNextReservation(t, mc, b) // Expire 5
-	verifyBookie(t, b, 6 /*reservations*/, 8 /*queue*/, 6*bytesPerReservation /*bytes*/)
-	expireNextReservation(t, mc, b) // Expire 6(1) - already filled
-	verifyBookie(t, b, 6 /*reservations*/, 7 /*queue*/, 6*bytesPerReservation /*bytes*/)
-	expireNextReservation(t, mc, b) // Expire 7
-	verifyBookie(t, b, 5 /*reservations*/, 6 /*queue*/, 5*bytesPerReservation /*bytes*/)
-	expireNextReservation(t, mc, b) // Expire 8
-	verifyBookie(t, b, 4 /*reservations*/, 5 /*queue*/, 4*bytesPerReservation /*bytes*/)
-	expireNextReservation(t, mc, b) // Expire 9
-	verifyBookie(t, b, 3 /*reservations*/, 4 /*queue*/, 3*bytesPerReservation /*bytes*/)
-	expireNextReservation(t, mc, b) // Expire 10
-	verifyBookie(t, b, 2 /*reservations*/, 3 /*queue*/, 2*bytesPerReservation /*bytes*/)
-	expireNextReservation(t, mc, b) // Expire 1(2) - already filled
-	verifyBookie(t, b, 2 /*reservations*/, 2 /*queue*/, 2*bytesPerReservation /*bytes*/)
-	expireNextReservation(t, mc, b) // Expire 2(2)
-	verifyBookie(t, b, 1 /*reservations*/, 1 /*queue*/, 1*bytesPerReservation /*bytes*/)
-	expireNextReservation(t, mc, b) // Expire 6(2)
-	verifyBookie(t, b, 0 /*reservations*/, 0 /*queue*/, 0 /*bytes*/)
+	verifyBookie(t, b, previousReservedBytes, int64(previousReservedBytes))
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -947,12 +947,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	s.stopper = stopper
 
 	// Add the bookie to the store.
-	s.bookie = newBookie(
-		s.cfg.Clock,
-		s.stopper,
-		s.metrics,
-		envutil.EnvOrDefaultDuration("COCKROACH_RESERVATION_TIMEOUT", ttlStoreGossip),
-	)
+	s.bookie = newBookie(s.metrics)
 
 	// Read the store ident if not already initialized. "NodeID != 0" implies
 	// the store has already been initialized.
@@ -2491,7 +2486,7 @@ func (s *Store) HandleSnapshot(
 
 	if header.CanDecline {
 		// Check the bookie to see if we can apply the snapshot.
-		resp := s.Reserve(ctx, ReservationRequest{
+		resp := s.reserve(ctx, reservationRequest{
 			StoreRequestHeader: StoreRequestHeader{
 				NodeID:  s.nodeDesc.NodeID,
 				StoreID: s.StoreID(),
@@ -3774,8 +3769,8 @@ func (s *Store) FrozenStatus(collectFrozen bool) (repDescs []roachpb.ReplicaDesc
 	return
 }
 
-// Reserve requests a reservation from the store's bookie.
-func (s *Store) Reserve(ctx context.Context, req ReservationRequest) ReservationResponse {
+// reserve requests a reservation from the store's bookie.
+func (s *Store) reserve(ctx context.Context, req reservationRequest) reservationResponse {
 	return s.bookie.Reserve(ctx, req, s.deadReplicas().Replicas)
 }
 


### PR DESCRIPTION
Now that we reservations are added and removed within the processing of
a single snapshot RPC, there is no need for the reservation queue and
the background goroutine to cleanup expired reservations.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10393)
<!-- Reviewable:end -->
