### PR TITLE
storage: test for failed snapshots' reservations

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -623,6 +623,55 @@ func TestSnapshotAfterTruncation(t *testing.T) {
 	mtc.waitForValues(key, []int64{incAB, incAB, incAB})
 }
 
+type fakeSnapshotStream struct {
+	nextReq *storage.SnapshotRequest
+	nextErr error
+}
+
+// Recv implements the SnapshotResponseStream interface.
+func (c fakeSnapshotStream) Recv() (*storage.SnapshotRequest, error) {
+	return c.nextReq, c.nextErr
+}
+
+// Send implements the SnapshotResponseStream interface.
+func (c fakeSnapshotStream) Send(request *storage.SnapshotResponse) error {
+	return nil
+}
+
+// Context implements the SnapshotResponseStream interface.
+func (c fakeSnapshotStream) Context() context.Context {
+	return context.Background()
+}
+
+// TestFailedSnapshotFillsReservation tests that failing to finish applying an
+// incoming snapshot still cleans up the outstanding reservation that was made.
+func TestFailedSnapshotFillsReservation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	mtc := startMultiTestContext(t, 3)
+	defer mtc.Stop()
+
+	rep, err := mtc.stores[0].GetReplica(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	header := storage.SnapshotRequest_Header{
+		CanDecline:      true,
+		RangeSize:       100,
+		RangeDescriptor: *rep.Desc(),
+	}
+	// Cause this stream to return an error as soon as we ask it for something.
+	// This injects an error into HandleSnapshotStream when we try to send the
+	// "snapshot accepted" message.
+	expectedErr := errors.Errorf("")
+	stream := fakeSnapshotStream{nil, expectedErr}
+	if err := mtc.stores[1].HandleSnapshot(&header, stream); err != expectedErr {
+		t.Fatalf("expected error %s, but found %v", expectedErr, err)
+	}
+	if n := mtc.stores[1].ReservationCount(); n != 0 {
+		t.Fatalf("expected 0 reservations, but found %d", n)
+	}
+}
+
 // TestConcurrentRaftSnapshots tests that snapshots still work correctly when
 // Raft requests multiple non-preemptive snapshots at the same time. This
 // situation occurs when two replicas need snapshots at the same time.

--- a/pkg/storage/raft_transport.go
+++ b/pkg/storage/raft_transport.go
@@ -58,11 +58,19 @@ const (
 	raftIdleTimeout = time.Minute
 )
 
-// RaftMessageResponseStream is a subset of the
+// RaftMessageResponseStream is the subset of the
 // MultiRaft_RaftMessageServer interface that is needed for sending responses.
 type RaftMessageResponseStream interface {
 	Context() context.Context
 	Send(*RaftMessageResponse) error
+}
+
+// SnapshotResponseStream is the subset of the
+// MultiRaft_RaftSnapshotServer interface that is needed for sending responses.
+type SnapshotResponseStream interface {
+	Context() context.Context
+	Send(*SnapshotResponse) error
+	Recv() (*SnapshotRequest, error)
 }
 
 // RaftMessageHandler is the interface that must be implemented by
@@ -82,7 +90,7 @@ type RaftMessageHandler interface {
 
 	// HandleSnapshot is called for each new incoming snapshot stream, after
 	// parsing the initial SnapshotRequest_Header on the stream.
-	HandleSnapshot(header *SnapshotRequest_Header, stream MultiRaft_RaftSnapshotServer) error
+	HandleSnapshot(header *SnapshotRequest_Header, respStream SnapshotResponseStream) error
 }
 
 // NodeAddressResolver is the function used by RaftTransport to map node IDs to

--- a/pkg/storage/raft_transport_test.go
+++ b/pkg/storage/raft_transport_test.go
@@ -79,7 +79,7 @@ func (s channelServer) HandleRaftResponse(ctx context.Context, resp *storage.Raf
 }
 
 func (s channelServer) HandleSnapshot(
-	header *storage.SnapshotRequest_Header, stream storage.MultiRaft_RaftSnapshotServer,
+	header *storage.SnapshotRequest_Header, stream storage.SnapshotResponseStream,
 ) error {
 	panic("unexpected HandleSnapshot")
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2471,9 +2471,7 @@ func (s *Store) maybeUpdateTransaction(
 
 // HandleSnapshot reads an incoming streaming snapshot and applies it if
 // possible.
-func (s *Store) HandleSnapshot(
-	header *SnapshotRequest_Header, stream MultiRaft_RaftSnapshotServer,
-) error {
+func (s *Store) HandleSnapshot(header *SnapshotRequest_Header, stream SnapshotResponseStream) error {
 	s.metrics.raftRcvdMessages[raftpb.MsgSnap].Inc(1)
 
 	var capacity *roachpb.StoreCapacity

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2987,8 +2987,12 @@ func sendSnapshot(
 	case SnapshotResponse_DECLINED:
 		if header.CanDecline {
 			storePool.throttle(throttleDeclined, storeID)
+			declinedMsg := "reservation rejected"
+			if len(resp.Message) > 0 {
+				declinedMsg = resp.Message
+			}
 			return errors.Errorf("range=%s: remote declined snapshot: %s",
-				header.RangeDescriptor.RangeID, resp.Message)
+				header.RangeDescriptor.RangeID, declinedMsg)
 		}
 		storePool.throttle(throttleFailed, storeID)
 		return errors.Errorf("range=%s: programming error: remote declined required snapshot: %s",


### PR DESCRIPTION
Add a test that ensures that failing to apply an incoming snapshot cleans up the reservation that was added for it. This fails as expected if run before #10391.

Also, clean up the extra colon from the "snapshot declined" log message.

Fixes #10392.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10398)
<!-- Reviewable:end -->
