### PR TITLE
storage: don't mutate client's protos

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -6233,3 +6233,57 @@ func TestDeprecatedRequests(t *testing.T) {
 		t.Fatalf("expected %T but got %T", &roachpb.DeprecatedVerifyChecksumResponse{}, reply)
 	}
 }
+
+func TestReplicaTimestampCacheBumpNotLost(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tc := testContext{}
+	tc.Start(t)
+	defer tc.Stop()
+
+	ctx := tc.store.AnnotateCtx(context.TODO())
+	key := keys.LocalMax
+
+	txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
+	origTxn := txn.Clone()
+
+	minNewTS := func() hlc.Timestamp {
+		var ba roachpb.BatchRequest
+		scan := scanArgs(key, tc.rng.Desc().EndKey.AsRawKey())
+		ba.Add(&scan)
+
+		resp, pErr := tc.Sender().Send(ctx, ba)
+		if pErr != nil {
+			t.Fatal(pErr)
+		}
+		if !txn.Timestamp.Less(resp.Timestamp) {
+			t.Fatalf("expected txn ts %s < scan TS %s", txn.Timestamp, resp.Timestamp)
+		}
+		return resp.Timestamp
+	}()
+
+	var ba roachpb.BatchRequest
+	ba.Txn = txn
+	txnPut := putArgs(key, []byte("timestamp should be bumped"))
+	ba.Add(&txnPut)
+
+	resp, pErr := tc.Sender().Send(ctx, ba)
+	if pErr != nil {
+		t.Fatal(pErr)
+	}
+
+	if !reflect.DeepEqual(&origTxn, txn) {
+		t.Fatalf(
+			"original transaction proto was mutated: %s",
+			pretty.Diff(&origTxn, txn),
+		)
+	}
+	if resp.Txn == nil {
+		t.Fatal("no transaction in response")
+	} else if resp.Txn.Timestamp.Less(minNewTS) {
+		t.Fatalf(
+			"expected txn ts bumped at least to %s, but got %s",
+			minNewTS, txn.Timestamp,
+		)
+	}
+}


### PR DESCRIPTION
Prior to fix, would fail with

```
--- FAIL: TestReplicaTimestampCacheBumpNotLost (0.00s)
       	replica_test.go:6282: original transaction proto was mutated: [TxnMeta.Timestamp.Logical: 20 != 22]
```

Also added an assertion against the following potential anomaly (tracked as
issue #10401):

- client starts txn at ts=1
- client writes and applyTimestampCache bumps the write to ts=2
- client receives no response with its request, keeps thinking ts=1 is the
  current timestamp
- client commits at ts=1
- one of its writes is at ts=2, and there is no correct way of resolving the
  situation; either the write is lost or it commits, invalidating a prior read.

Unfortunately, that assertion fires and it was downgraded to a workaround plus
a Warning. Obviously, it should be addressed.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10402)
<!-- Reviewable:end -->
