### PR TITLE
acceptance/cli: expect memory exhaustion from C++, not only Go

### DIFF
--- a/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
+++ b/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
@@ -68,7 +68,12 @@ send "select * from columns as a, columns as b, columns as c, columns as d limit
 
 # Check that the query crashed the server
 set spawn_id $shell_spawn_id
-eexpect "out of memory"
+# Error is either "out of memory" (Go) or "cannot allocate memory" (C++)
+expect {
+    "out of memory" {}
+    "cannot allocate memory" {}
+    timeout {exit 1}
+}
 eexpect ":/# "
 
 # Check that the client got a bad connection error


### PR DESCRIPTION
Prior to this patch the test was expecting only the "out of memory"
message from the Go runtime. However C++'s "cannot allocate memory"
can also be produced.

Fixes #10399.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10403)
<!-- Reviewable:end -->
