### PR TITLE
storage: Move constraint filtering out of getStoreList

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -179,6 +179,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		s.rpcContext,
 		s.cfg.TimeUntilStoreDead,
 		s.stopper,
+		/* deterministic */ false,
 	)
 
 	// A custom RetryOptions is created which uses stopper.ShouldQuiesce() as

--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -123,12 +123,6 @@ type AllocatorOptions struct {
 	// AllowRebalance allows this store to attempt to rebalance its own
 	// replicas to other stores.
 	AllowRebalance bool
-
-	// Deterministic makes allocation decisions deterministic, based on
-	// current cluster statistics. If this flag is not set, allocation operations
-	// will have random behavior. This flag is intended to be set for testing
-	// purposes only.
-	Deterministic bool
 }
 
 // Allocator tries to spread replicas as evenly as possible across the stores
@@ -142,7 +136,7 @@ type Allocator struct {
 // MakeAllocator creates a new allocator using the specified StorePool.
 func MakeAllocator(storePool *StorePool, options AllocatorOptions) Allocator {
 	var randSource rand.Source
-	if options.Deterministic {
+	if storePool != nil && storePool.deterministic {
 		randSource = rand.NewSource(777)
 	} else {
 		randSource = rand.NewSource(rand.Int63())
@@ -214,16 +208,14 @@ func (a *Allocator) AllocateTarget(
 		existingNodes[repl.NodeID] = struct{}{}
 	}
 
+	sl, aliveStoreCount, throttledStoreCount := a.storePool.getStoreList(rangeID)
+
 	// Because more redundancy is better than less, if relaxConstraints, the
 	// matching here is lenient, and tries to find a target by relaxing an
 	// attribute constraint, from last attribute to first.
-	for attrs := append([]config.Constraint(nil), constraints.Constraints...); ; attrs = attrs[:len(attrs)-1] {
-		sl, aliveStoreCount, throttledStoreCount := a.storePool.getStoreList(
-			config.Constraints{Constraints: attrs},
-			rangeID,
-			a.options.Deterministic,
-		)
-		if target := a.selectGood(sl, existingNodes); target != nil {
+	for attrs := constraints.Constraints; ; attrs = attrs[:len(attrs)-1] {
+		filteredSL := sl.filter(config.Constraints{Constraints: attrs})
+		if target := a.selectGood(filteredSL, existingNodes); target != nil {
 			return target, nil
 		}
 
@@ -259,18 +251,17 @@ func (a Allocator) RemoveTarget(
 	}
 
 	// Retrieve store descriptors for the provided replicas from the StorePool.
-	sl := StoreList{}
+	var descriptors []roachpb.StoreDescriptor
 	for _, exist := range existing {
 		if exist.StoreID == leaseStoreID {
 			continue
 		}
-		desc, ok := a.storePool.getStoreDescriptor(exist.StoreID)
-		if !ok {
-			continue
+		if desc, ok := a.storePool.getStoreDescriptor(exist.StoreID); ok {
+			descriptors = append(descriptors, desc)
 		}
-		sl.add(desc)
 	}
 
+	sl := makeStoreList(descriptors)
 	if bad := a.selectBad(sl); bad != nil {
 		for _, exist := range existing {
 			if exist.StoreID == bad.StoreID {
@@ -311,11 +302,8 @@ func (a Allocator) RebalanceTarget(
 		return nil
 	}
 
-	sl, _, _ := a.storePool.getStoreList(
-		constraints,
-		rangeID,
-		a.options.Deterministic,
-	)
+	sl, _, _ := a.storePool.getStoreList(rangeID)
+	sl = sl.filter(constraints)
 	if log.V(3) {
 		log.Infof(context.TODO(), "rebalance-target (lease-holder=%d):\n%s", leaseStoreID, sl)
 	}

--- a/pkg/storage/balancer.go
+++ b/pkg/storage/balancer.go
@@ -102,7 +102,7 @@ func (rcb rangeCountBalancer) selectBad(sl StoreList) *roachpb.StoreDescriptor {
 
 		rcb.rand.Lock()
 		if len(candidates) > 0 {
-			// Randomnly choose a store from one of the above average range count
+			// Randomly choose a store from one of the above average range count
 			// candidates.
 			bad = candidates[rcb.rand.Intn(len(candidates))]
 		} else {

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2015,10 +2015,7 @@ func TestStoreRangeRebalance(t *testing.T) {
 
 	// Start multiTestContext with replica rebalancing enabled.
 	sc := storage.TestStoreConfig(nil)
-	sc.AllocatorOptions = storage.AllocatorOptions{
-		AllowRebalance: true,
-		Deterministic:  true,
-	}
+	sc.AllocatorOptions = storage.AllocatorOptions{AllowRebalance: true}
 	mtc := &multiTestContext{storeConfig: &sc}
 
 	mtc.Start(t, 6)

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -27,7 +27,6 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
@@ -206,10 +205,8 @@ func (r *Replica) GetTimestampCacheLowWater() hlc.Timestamp {
 }
 
 // GetStoreList is the same function as GetStoreList exposed for tests only.
-func (sp *StorePool) GetStoreList(
-	constraints config.Constraints, rangeID roachpb.RangeID, deterministic bool,
-) (StoreList, int, int) {
-	return sp.getStoreList(constraints, rangeID, deterministic)
+func (sp *StorePool) GetStoreList(rangeID roachpb.RangeID) (StoreList, int, int) {
+	return sp.getStoreList(rangeID)
 }
 
 // IsQuiescent returns whether the replica is quiescent or not.

--- a/pkg/storage/simulation/cluster.go
+++ b/pkg/storage/simulation/cluster.go
@@ -83,6 +83,8 @@ func createCluster(
 	// We set the node ID to MaxInt32 for the cluster Gossip instance to prevent
 	// conflicts with real node IDs.
 	g := gossip.NewTest(math.MaxInt32, rpcContext, server, nil, stopper, metric.NewRegistry())
+	// Set the store pool to deterministic so that a run with the exact same
+	// input will always produce the same output.
 	storePool := storage.NewStorePool(
 		log.AmbientContext{},
 		g,
@@ -90,6 +92,7 @@ func createCluster(
 		rpcContext,
 		storage.TestTimeUntilStoreDeadOff,
 		stopper,
+		/* deterministic */ true,
 	)
 	c := &Cluster{
 		stopper:   stopper,
@@ -99,7 +102,6 @@ func createCluster(
 		storePool: storePool,
 		allocator: storage.MakeAllocator(storePool, storage.AllocatorOptions{
 			AllowRebalance: true,
-			Deterministic:  true,
 		}),
 		storeGossiper:   gossiputil.NewStoreGossiper(g),
 		nodes:           make(map[roachpb.NodeID]*Node),

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -161,6 +161,7 @@ func createTestStoreWithoutStart(t testing.TB, cfg *StoreConfig) (*Store, *stop.
 		rpcContext,
 		TestTimeUntilStoreDeadOff,
 		stopper,
+		/* deterministic */ false,
 	)
 	eng := engine.NewInMem(roachpb.Attributes{}, 10<<20)
 	stopper.AddCloser(eng)


### PR DESCRIPTION
This is the first step in adding back in the constraint rule solver. In this
commit, the filtering has been pulled out into a separate function.

Also, the allocator option "deterministic" has been removed and moved to the
store pool.  The allocator option was not always used correctly, a lot of
tests set it after the allocator was already initialized, and an allocator
requires a store pool when initializing, so it can determine the value from
there.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10404)
<!-- Reviewable:end -->
