### PR TITLE
build: fix coverage build

### DIFF
--- a/build/upload-coverage.sh
+++ b/build/upload-coverage.sh
@@ -45,8 +45,8 @@ iterative_coverpkg() {
 rm -rf "$coverage_dir"
 mkdir -p "$coverage_dir"
 
-# Run "make coverage" on each package.
-for pkg in $(go list ./...); do
+# Run "make coverage" on each package except for those in cmd.
+for pkg in $(go list ./pkg/... | grep -vF 'pkg/cmd'); do
   echo "Processing $pkg..."
   # Verify package has test files.
   if [ -z "$(go list -f '{{join .TestGoFiles ""}}{{join .XTestGoFiles ""}}' $pkg)" ]; then

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -483,7 +483,7 @@ func TestRollover(t *testing.T) {
 		err = e
 	}
 	defer func(previous uint64) { MaxSize = previous }(MaxSize)
-	MaxSize = 1024
+	MaxSize = 2048
 
 	Info(context.Background(), "x") // Be sure we have a file.
 	info, ok := logging.file[Severity_INFO].(*syncBuffer)


### PR DESCRIPTION
Fix a few issues that are causing the coverage nightly job to fail. The coverage script was never updated after the move to `pkg`, and a test was fragile with respect to the size of the `go test` command line invocation.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10418)
<!-- Reviewable:end -->
