### PR TITLE
*: s/rng/rep/ for vars of type Replica

### DIFF
--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -413,18 +413,18 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	if _, err := client.SendWrapped(context.Background(), rg1(store), &args); err != nil {
 		t.Fatal(err)
 	}
-	rngMerged := store.LookupReplica(aDesc.StartKey, nil)
+	replMerged := store.LookupReplica(aDesc.StartKey, nil)
 
 	// Get the range stats for the merged range and verify.
 	snap = store.Engine().NewSnapshot()
 	defer snap.Close()
-	msMerged, err := engine.MVCCGetRangeStats(context.Background(), snap, rngMerged.RangeID)
+	msMerged, err := engine.MVCCGetRangeStats(context.Background(), snap, replMerged.RangeID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Merged stats should agree with recomputation.
-	if err := verifyRecomputedStats(snap, rngMerged.Desc(), msMerged, manual.UnixNano()); err != nil {
+	if err := verifyRecomputedStats(snap, replMerged.Desc(), msMerged, manual.UnixNano()); err != nil {
 		t.Errorf("failed to verify range's stats after merge: %v", err)
 	}
 }

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -35,10 +35,10 @@ import (
 
 // AddReplica adds the replica to the store's replica map and to the sorted
 // replicasByKey slice. To be used only by unittests.
-func (s *Store) AddReplica(rng *Replica) error {
+func (s *Store) AddReplica(repl *Replica) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if err := s.addReplicaInternalLocked(rng); err != nil {
+	if err := s.addReplicaInternalLocked(repl); err != nil {
 		return err
 	}
 	s.metrics.ReplicaCount.Inc(1)

--- a/pkg/storage/queue_test.go
+++ b/pkg/storage/queue_test.go
@@ -135,11 +135,11 @@ func TestBaseQueueAddUpdateAndRemove(t *testing.T) {
 	defer tc.Stop()
 
 	// Remove replica for range 1 since it encompasses the entire keyspace.
-	rng1, err := tc.store.GetReplica(1)
+	repl1, err := tc.store.GetReplica(1)
 	if err != nil {
 		t.Error(err)
 	}
-	if err := tc.store.RemoveReplica(rng1, *rng1.Desc(), true); err != nil {
+	if err := tc.store.RemoveReplica(repl1, *repl1.Desc(), true); err != nil {
 		t.Error(err)
 	}
 
@@ -287,11 +287,11 @@ func TestBaseQueueProcess(t *testing.T) {
 	defer tc.Stop()
 
 	// Remove replica for range 1 since it encompasses the entire keyspace.
-	rng1, err := tc.store.GetReplica(1)
+	repl1, err := tc.store.GetReplica(1)
 	if err != nil {
 		t.Error(err)
 	}
-	if err := tc.store.RemoveReplica(rng1, *rng1.Desc(), true); err != nil {
+	if err := tc.store.RemoveReplica(repl1, *repl1.Desc(), true); err != nil {
 		t.Error(err)
 	}
 
@@ -415,11 +415,11 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 	}
 
 	// Remove replica for range 1 since it encompasses the entire keyspace.
-	rng1, err := s.GetReplica(1)
+	repl1, err := s.GetReplica(1)
 	if err != nil {
 		t.Error(err)
 	}
-	if err := s.RemoveReplica(rng1, *rng1.Desc(), true); err != nil {
+	if err := s.RemoveReplica(repl1, *repl1.Desc(), true); err != nil {
 		t.Error(err)
 	}
 
@@ -547,11 +547,11 @@ func TestBaseQueuePurgatory(t *testing.T) {
 	}
 
 	// Remove replica for range 1 since it encompasses the entire keyspace.
-	rng1, err := tc.store.GetReplica(1)
+	repl1, err := tc.store.GetReplica(1)
 	if err != nil {
 		t.Error(err)
 	}
-	if err := tc.store.RemoveReplica(rng1, *rng1.Desc(), true); err != nil {
+	if err := tc.store.RemoveReplica(repl1, *repl1.Desc(), true); err != nil {
 		t.Error(err)
 	}
 

--- a/pkg/storage/replica_data_iter_test.go
+++ b/pkg/storage/replica_data_iter_test.go
@@ -121,10 +121,10 @@ func TestReplicaDataIteratorEmptyRange(t *testing.T) {
 	// Adjust the range descriptor to avoid existing data such as meta
 	// records and config entries during the iteration. This is a rather
 	// nasty little hack, but since it's test code, meh.
-	newDesc := *tc.rng.Desc()
+	newDesc := *tc.repl.Desc()
 	newDesc.RangeID = 125125125
 
-	iter := NewReplicaDataIterator(&newDesc, tc.rng.store.Engine(), false /* !replicatedOnly */)
+	iter := NewReplicaDataIterator(&newDesc, tc.repl.store.Engine(), false /* !replicatedOnly */)
 	defer iter.Close()
 	for ; iter.Valid(); iter.Next() {
 		t.Errorf("unexpected: %s", iter.Key())
@@ -150,10 +150,10 @@ func TestReplicaDataIterator(t *testing.T) {
 	defer tc.Stop()
 
 	// See notes in EmptyRange test method for adjustment to descriptor.
-	newDesc := *tc.rng.Desc()
+	newDesc := *tc.repl.Desc()
 	newDesc.StartKey = roachpb.RKey("b")
 	newDesc.EndKey = roachpb.RKey("c")
-	if err := tc.rng.setDesc(&newDesc); err != nil {
+	if err := tc.repl.setDesc(&newDesc); err != nil {
 		t.Fatal(err)
 	}
 	// Create two more ranges, one before the test range and one after.
@@ -168,11 +168,11 @@ func TestReplicaDataIterator(t *testing.T) {
 
 	// Create range data for all three ranges.
 	preKeys := createRangeData(t, preRng)
-	curKeys := createRangeData(t, tc.rng)
+	curKeys := createRangeData(t, tc.repl)
 	postKeys := createRangeData(t, postRng)
 
 	// Verify the contents of the "b"-"c" range.
-	iter := NewReplicaDataIterator(tc.rng.Desc(), tc.rng.store.Engine(), false /* !replicatedOnly */)
+	iter := NewReplicaDataIterator(tc.repl.Desc(), tc.repl.store.Engine(), false /* !replicatedOnly */)
 	defer iter.Close()
 	i := 0
 	for ; iter.Valid(); iter.Next() {
@@ -194,8 +194,8 @@ func TestReplicaDataIterator(t *testing.T) {
 	}
 
 	// Verify that the replicated-only iterator ignores unreplicated keys.
-	unreplicatedPrefix := keys.MakeRangeIDUnreplicatedPrefix(tc.rng.RangeID)
-	iter = NewReplicaDataIterator(tc.rng.Desc(), tc.rng.store.Engine(), true /* replicatedOnly */)
+	unreplicatedPrefix := keys.MakeRangeIDUnreplicatedPrefix(tc.repl.RangeID)
+	iter = NewReplicaDataIterator(tc.repl.Desc(), tc.repl.store.Engine(), true /* replicatedOnly */)
 	defer iter.Close()
 	for ; iter.Valid(); iter.Next() {
 		if err := iter.Error(); err != nil {
@@ -207,15 +207,15 @@ func TestReplicaDataIterator(t *testing.T) {
 	}
 
 	// Destroy range and verify that its data has been completely cleared.
-	if err := tc.store.removeReplicaImpl(tc.rng, *tc.rng.Desc(), true); err != nil {
+	if err := tc.store.removeReplicaImpl(tc.repl, *tc.repl.Desc(), true); err != nil {
 		t.Fatal(err)
 	}
-	iter = NewReplicaDataIterator(tc.rng.Desc(), tc.rng.store.Engine(), false /* !replicatedOnly */)
+	iter = NewReplicaDataIterator(tc.repl.Desc(), tc.repl.store.Engine(), false /* !replicatedOnly */)
 	defer iter.Close()
 	if iter.Valid() {
 		// If the range is destroyed, only a tombstone key should be there.
 		k1 := iter.Key().Key
-		if tombstoneKey := keys.RaftTombstoneKey(tc.rng.RangeID); !bytes.Equal(k1, tombstoneKey) {
+		if tombstoneKey := keys.RaftTombstoneKey(tc.repl.RangeID); !bytes.Equal(k1, tombstoneKey) {
 			t.Errorf("expected a tombstone key %q, but found %q", tombstoneKey, k1)
 		}
 

--- a/pkg/storage/split_queue.go
+++ b/pkg/storage/split_queue.go
@@ -68,9 +68,9 @@ func newSplitQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *splitQue
 // splitting. This is true if the range is intersected by a zone config
 // prefix or if the range's size in bytes exceeds the limit for the zone.
 func (sq *splitQueue) shouldQueue(
-	ctx context.Context, now hlc.Timestamp, rng *Replica, sysCfg config.SystemConfig,
+	ctx context.Context, now hlc.Timestamp, repl *Replica, sysCfg config.SystemConfig,
 ) (shouldQ bool, priority float64) {
-	desc := rng.Desc()
+	desc := repl.Desc()
 	if len(sysCfg.ComputeSplitKeys(desc.StartKey, desc.EndKey)) > 0 {
 		// Set priority to 1 in the event the range is split by zone configs.
 		priority = 1
@@ -85,7 +85,7 @@ func (sq *splitQueue) shouldQueue(
 		return
 	}
 
-	if ratio := float64(rng.GetMVCCStats().Total()) / float64(zone.RangeMaxBytes); ratio > 1 {
+	if ratio := float64(repl.GetMVCCStats().Total()) / float64(zone.RangeMaxBytes); ratio > 1 {
 		priority += ratio
 		shouldQ = true
 	}

--- a/pkg/storage/split_queue_test.go
+++ b/pkg/storage/split_queue_test.go
@@ -85,22 +85,22 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 		func() {
 			// Hold lock throughout to reduce chance of random commands leading
 			// to inconsistent state.
-			tc.rng.mu.Lock()
-			defer tc.rng.mu.Unlock()
+			tc.repl.mu.Lock()
+			defer tc.repl.mu.Unlock()
 			ms := enginepb.MVCCStats{KeyBytes: test.bytes}
-			if err := setMVCCStats(context.Background(), tc.rng.store.Engine(), tc.rng.RangeID, ms); err != nil {
+			if err := setMVCCStats(context.Background(), tc.repl.store.Engine(), tc.repl.RangeID, ms); err != nil {
 				t.Fatal(err)
 			}
-			tc.rng.mu.state.Stats = ms
+			tc.repl.mu.state.Stats = ms
 		}()
 
-		copy := *tc.rng.Desc()
+		copy := *tc.repl.Desc()
 		copy.StartKey = test.start
 		copy.EndKey = test.end
-		if err := tc.rng.setDesc(&copy); err != nil {
+		if err := tc.repl.setDesc(&copy); err != nil {
 			t.Fatal(err)
 		}
-		shouldQ, priority := splitQ.shouldQueue(context.TODO(), hlc.ZeroTimestamp, tc.rng, cfg)
+		shouldQ, priority := splitQ.shouldQueue(context.TODO(), hlc.ZeroTimestamp, tc.repl, cfg)
 		if shouldQ != test.shouldQ {
 			t.Errorf("%d: should queue expected %t; got %t", i, test.shouldQ, shouldQ)
 		}

--- a/pkg/storage/stats_test.go
+++ b/pkg/storage/stats_test.go
@@ -44,7 +44,7 @@ func TestRangeStatsEmpty(t *testing.T) {
 	tc.Start(t)
 	defer tc.Stop()
 
-	ms := tc.rng.GetMVCCStats()
+	ms := tc.repl.GetMVCCStats()
 	if exp := initialStats(); !reflect.DeepEqual(ms, exp) {
 		t.Errorf("expected stats %+v; got %+v", exp, ms)
 	}
@@ -71,7 +71,7 @@ func TestRangeStatsInit(t *testing.T) {
 	if err := engine.MVCCSetRangeStats(context.Background(), tc.engine, 1, &ms); err != nil {
 		t.Fatal(err)
 	}
-	loadMS, err := engine.MVCCGetRangeStats(context.Background(), tc.engine, tc.rng.RangeID)
+	loadMS, err := engine.MVCCGetRangeStats(context.Background(), tc.engine, tc.repl.RangeID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/ts_maintenance_queue_test.go
+++ b/pkg/storage/ts_maintenance_queue_test.go
@@ -105,10 +105,10 @@ func TestTimeSeriesMaintenanceQueue(t *testing.T) {
 	// Generate several splits.
 	splitKeys := []roachpb.Key{roachpb.Key("c"), roachpb.Key("b"), roachpb.Key("a")}
 	for _, k := range splitKeys {
-		rng := store.LookupReplica(roachpb.RKey(k), nil)
+		repl := store.LookupReplica(roachpb.RKey(k), nil)
 		args := adminSplitArgs(k, k)
 		if _, pErr := client.SendWrappedWith(context.Background(), store, roachpb.Header{
-			RangeID: rng.RangeID,
+			RangeID: repl.RangeID,
 		}, &args); pErr != nil {
 			t.Fatal(pErr)
 		}


### PR DESCRIPTION
It's confusing to have variables named `rng` when their type is `Replica` and not `Range` or similar. This is a large cosmetic change that fixes a lot of those occurrences.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10421)
<!-- Reviewable:end -->
