### PR TITLE
storage: fix merge skew

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -6258,7 +6258,7 @@ func TestReplicaTimestampCacheBumpNotLost(t *testing.T) {
 	ctx := tc.store.AnnotateCtx(context.TODO())
 	key := keys.LocalMax
 
-	txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.clock)
+	txn := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 	origTxn := txn.Clone()
 
 	minNewTS := func() hlc.Timestamp {


### PR DESCRIPTION
Merge skew caused `replica_test` to no longer compile.

Fixes #10422 

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10423)
<!-- Reviewable:end -->
