### PR TITLE
server: change defaultScanMaxIdleTime from 5s to 200ms

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -51,7 +51,7 @@ const (
 	defaultSQLMemoryPoolSize        = 512 << 20 // 512 MB
 	defaultScanInterval             = 10 * time.Minute
 	defaultConsistencyCheckInterval = 24 * time.Hour
-	defaultScanMaxIdleTime          = 5 * time.Second
+	defaultScanMaxIdleTime          = 200 * time.Millisecond
 	defaultMetricsSampleInterval    = 10 * time.Second
 	defaultTimeUntilStoreDead       = 5 * time.Minute
 	defaultStorePath                = "cockroach-data"


### PR DESCRIPTION
This primarily affects test clusters. With the default scan interval of
10m a node with 3000 replicas will be scanning a replica every 200ms
regardless of this setting. One downside to this change is that we'll be
performing timeseries maintenance very frequently (once per second) for
newly created clusters which is actually visible in profiling, but this
is still a tiny amount of cpu.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10433)
<!-- Reviewable:end -->
