### PR TITLE
storage: fill the reservation before sending the snapshot response

### DIFF
--- a/pkg/storage/raft_transport.go
+++ b/pkg/storage/raft_transport.go
@@ -20,6 +20,7 @@ package storage
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"net"
 	"sort"
 	"sync/atomic"
@@ -601,7 +602,7 @@ func (c snapshotClientWithBreaker) Send(m *SnapshotRequest) error {
 
 func (c snapshotClientWithBreaker) Recv() (*SnapshotResponse, error) {
 	m, err := c.MultiRaft_RaftSnapshotClient.Recv()
-	if err != nil {
+	if err != nil && err != io.EOF {
 		c.breaker.Fail()
 	}
 	return m, err


### PR DESCRIPTION
If we send the response before filling the reservation the RPC can be
sent over the network waking up the goroutine which initiated the
preemptive snapshot and allowing it to perform another one before the
reservation is filled. This second preemptive snapshot would get
rejected and cause full replication to take much longer to achieve
resulting in test flakiness.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10440)
<!-- Reviewable:end -->
