### PR TITLE
acceptance: check cluster consistency in chaosMonkey

### DIFF
--- a/pkg/acceptance/chaos_test.go
+++ b/pkg/acceptance/chaos_test.go
@@ -254,9 +254,7 @@ func chaosMonkey(
 			time.Sleep(time.Second)
 		}
 		c.Assert(ctx, state.t)
-		// TODO(peter): Disabled until https://github.com/grpc/grpc-go/pull/818 (or
-		// similar) goes in.
-		// cluster.Consistent(state.t, c)
+		cluster.Consistent(ctx, state.t, c)
 		log.Warningf(ctx, "round %d: cluster recovered", curRound)
 	}
 }

--- a/pkg/acceptance/freeze_test.go
+++ b/pkg/acceptance/freeze_test.go
@@ -154,14 +154,6 @@ func testFreezeClusterInner(
 			t.Fatal(err)
 		}
 
-		// TODO(tschottdorf): moving the client creation outside of the retry
-		// loop will break the test with the following message:
-		//
-		//   client/rpc_sender.go:61: roachpb.Batch RPC failed as client
-		//   connection was closed
-		//
-		// Perhaps the cluster updates the address too late after restarting
-		// the node.
 		db := c.NewClient(ctx, t, 0)
 
 		if _, err := db.Scan(ctx, keys.LocalMax, roachpb.KeyMax, 0); err != nil {


### PR DESCRIPTION
This should be safe now that the following PRs have been merged:
- grpc/grpc-go#818
- grpc/grpc-go#864

Also remove a TODO about creating the client outside of a retry loop;
creation of these clients during node startup is inherently prone to
non-temporary connection refused errors.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10442)
<!-- Reviewable:end -->
