### PR TITLE
rsg: force func arguments to be a specific type

### DIFF
--- a/pkg/internal/rsg/rsg.go
+++ b/pkg/internal/rsg/rsg.go
@@ -212,5 +212,5 @@ func (r *RSG) GenerateRandomArg(typ parser.Type) string {
 			panic(fmt.Errorf("unknown arg type: %s (%T)", typ, typ))
 		}
 	}
-	return fmt.Sprint(v)
+	return fmt.Sprintf("%v::%s", v, typ.String())
 }


### PR DESCRIPTION
Previously numeric types were left ambiguous, so the executor would
have to choose between int, float, and decimal. However we know
the type requested, so use that to force the correct version of the
function we are testing to execute.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10445)
<!-- Reviewable:end -->
