### PR TITLE
gossip: remove duplicate "node %d:" prefixes from log messages

### DIFF
--- a/pkg/gossip/client.go
+++ b/pkg/gossip/client.go
@@ -79,7 +79,6 @@ func (c *client) start(
 	disconnected chan *client,
 	rpcCtx *rpc.Context,
 	stopper *stop.Stopper,
-	nodeID roachpb.NodeID,
 	breaker *circuit.Breaker,
 ) {
 	stopper.RunWorker(func() {
@@ -117,20 +116,20 @@ func (c *client) start(
 			return c.requestGossip(g, stream)
 		}, 0); err != nil {
 			if consecFailures == 0 {
-				log.Warningf(ctx, "node %d: failed to start gossip client: %s", nodeID, err)
+				log.Warningf(ctx, "failed to start gossip client to %s: %s", c.addr, err)
 			}
 			return
 		}
 
 		// Start gossiping.
-		log.Infof(ctx, "node %d: started gossip client to %s", nodeID, c.addr)
+		log.Infof(ctx, "started gossip client to %s", c.addr)
 		if err := c.gossip(ctx, g, stream, stopper, &wg); err != nil {
 			if !grpcutil.IsClosedConnection(err) {
 				g.mu.Lock()
 				if c.peerID != 0 {
-					log.Infof(ctx, "node %d: closing client to node %d (%s): %s", nodeID, c.peerID, c.addr, err)
+					log.Infof(ctx, "closing client to node %d (%s): %s", c.peerID, c.addr, err)
 				} else {
-					log.Infof(ctx, "node %d: closing client to %s: %s", nodeID, c.addr, err)
+					log.Infof(ctx, "closing client to %s: %s", c.addr, err)
 				}
 				g.mu.Unlock()
 			}

--- a/pkg/gossip/client_test.go
+++ b/pkg/gossip/client_test.go
@@ -164,7 +164,7 @@ func gossipSucceedsSoon(
 		select {
 		case client := <-disconnected:
 			// If the client wasn't able to connect, restart it.
-			client.start(gossip[client], disconnected, rpcContext, stopper, gossip[client].NodeID.Get(), rpcContext.NewBreaker())
+			client.start(gossip[client], disconnected, rpcContext, stopper, rpcContext.NewBreaker())
 		default:
 		}
 
@@ -300,7 +300,7 @@ func TestClientNodeID(t *testing.T) {
 			return
 		case <-disconnected:
 			// The client hasn't been started or failed to start, loop and try again.
-			c.start(local, disconnected, rpcContext, stopper, localNodeID, rpcContext.NewBreaker())
+			c.start(local, disconnected, rpcContext, stopper, rpcContext.NewBreaker())
 		}
 	}
 }
@@ -322,7 +322,7 @@ func TestClientDisconnectLoopback(t *testing.T) {
 	// startClient requires locks are held, so acquire here.
 	local.mu.Lock()
 	lAddr := local.mu.is.NodeAddr
-	local.startClient(&lAddr, local.NodeID.Get())
+	local.startClient(&lAddr)
 	local.mu.Unlock()
 	local.manage()
 	util.SucceedsSoon(t, func() error {
@@ -348,8 +348,8 @@ func TestClientDisconnectRedundant(t *testing.T) {
 	remote.mu.Lock()
 	rAddr := remote.mu.is.NodeAddr
 	lAddr := local.mu.is.NodeAddr
-	local.startClient(&rAddr, remote.NodeID.Get())
-	remote.startClient(&lAddr, local.NodeID.Get())
+	local.startClient(&rAddr)
+	remote.startClient(&lAddr)
 	local.mu.Unlock()
 	remote.mu.Unlock()
 	local.manage()
@@ -387,8 +387,8 @@ func TestClientDisallowMultipleConns(t *testing.T) {
 	// Start two clients from local to remote. RPC client cache is
 	// disabled via the context, so we'll start two different outgoing
 	// connections.
-	local.startClient(&rAddr, remote.NodeID.Get())
-	local.startClient(&rAddr, remote.NodeID.Get())
+	local.startClient(&rAddr)
+	local.startClient(&rAddr)
 	local.mu.Unlock()
 	remote.mu.Unlock()
 	local.manage()

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -902,7 +902,7 @@ func (g *Gossip) bootstrap() {
 				if !haveClients || !haveSentinel {
 					// Try to get another bootstrap address from the resolvers.
 					if addr := g.getNextBootstrapAddress(); addr != nil {
-						g.startClient(addr, g.NodeID.Get())
+						g.startClient(addr)
 					} else {
 						bootstrapAddrs := make([]string, 0, len(g.bootstrapping))
 						for addr := range g.bootstrapping {
@@ -1023,7 +1023,7 @@ func (g *Gossip) tightenNetwork(distantNodeID roachpb.NodeID) {
 		} else {
 			log.Infof(ctx, "starting client to distant node %d to tighten network graph", distantNodeID)
 			log.Eventf(ctx, "tightening network with new client to %s", nodeAddr)
-			g.startClient(nodeAddr, g.NodeID.Get())
+			g.startClient(nodeAddr)
 		}
 	}
 }
@@ -1035,7 +1035,7 @@ func (g *Gossip) doDisconnected(c *client) {
 
 	// If the client was disconnected with a forwarding address, connect now.
 	if c.forwardAddr != nil {
-		g.startClient(c.forwardAddr, g.NodeID.Get())
+		g.startClient(c.forwardAddr)
 	}
 	g.maybeSignalStatusChangeLocked()
 }
@@ -1104,7 +1104,7 @@ func (g *Gossip) signalConnectedLocked() {
 // startClient launches a new client connected to remote address.
 // The client is added to the outgoing address set and launched in
 // a goroutine.
-func (g *Gossip) startClient(addr net.Addr, nodeID roachpb.NodeID) {
+func (g *Gossip) startClient(addr net.Addr) {
 	g.clientsMu.Lock()
 	defer g.clientsMu.Unlock()
 	breaker, ok := g.clientsMu.breakers[addr.String()]
@@ -1116,7 +1116,7 @@ func (g *Gossip) startClient(addr net.Addr, nodeID roachpb.NodeID) {
 	log.Eventf(ctx, "starting new client to %s", addr)
 	c := newClient(g.server.AmbientContext, addr, g.serverMetrics)
 	g.clientsMu.clients = append(g.clientsMu.clients, c)
-	c.start(g, g.disconnected, g.rpcContext, g.server.stopper, nodeID, breaker)
+	c.start(g, g.disconnected, g.rpcContext, g.server.stopper, breaker)
 }
 
 // removeClient removes the specified client. Called when a client

--- a/pkg/gossip/gossip_test.go
+++ b/pkg/gossip/gossip_test.go
@@ -104,7 +104,7 @@ func TestGossipRaceLogStatus(t *testing.T) {
 
 	local.mu.Lock()
 	peer := startGossip(2, stopper, t, metric.NewRegistry())
-	local.startClient(&peer.mu.is.NodeAddr, peer.NodeID.Get())
+	local.startClient(&peer.mu.is.NodeAddr)
 	local.mu.Unlock()
 
 	// Race gossiping against LogStatus.
@@ -201,7 +201,7 @@ func TestGossipNoForwardSelf(t *testing.T) {
 		for {
 			localAddr := local.GetNodeAddr()
 			c := newClient(log.AmbientContext{}, localAddr, makeMetrics())
-			c.start(peer, disconnectedCh, peer.rpcContext, stopper, peer.NodeID.Get(), peer.rpcContext.NewBreaker())
+			c.start(peer, disconnectedCh, peer.rpcContext, stopper, peer.rpcContext.NewBreaker())
 
 			disconnectedClient := <-disconnectedCh
 			if disconnectedClient != c {
@@ -232,7 +232,7 @@ func TestGossipCullNetwork(t *testing.T) {
 	local.mu.Lock()
 	for i := 0; i < minPeers; i++ {
 		peer := startGossip(roachpb.NodeID(i+2), stopper, t, metric.NewRegistry())
-		local.startClient(peer.GetNodeAddr(), peer.NodeID.Get())
+		local.startClient(peer.GetNodeAddr())
 	}
 	local.mu.Unlock()
 
@@ -281,7 +281,7 @@ func TestGossipOrphanedStallDetection(t *testing.T) {
 	peerAddr := peer.GetNodeAddr()
 	peerAddrStr := peerAddr.String()
 
-	local.startClient(peerAddr, peerNodeID)
+	local.startClient(peerAddr)
 
 	util.SucceedsSoon(t, func() error {
 		for _, peerID := range local.Outgoing() {


### PR DESCRIPTION
The logging contexts already know the node ID; also, it seems that some
of the node IDs logged are those of the remote node, and some are those
of the local node. wat.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10447)
<!-- Reviewable:end -->
