### PR TITLE
acceptance: add password authentication tests

### DIFF
--- a/pkg/acceptance/cli_test.go
+++ b/pkg/acceptance/cli_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/docker/docker/api/types/container"
 )
 
 const testGlob = "../cli/interactive_tests/test*.tcl"
@@ -34,7 +35,11 @@ var cmdBase = []string{
 }
 
 func TestDockerCLI(t *testing.T) {
-	if err := testDockerOneShot(t, "cli_test", []string{"stat", cluster.CockroachBinaryInContainer}); err != nil {
+	containerConfig := container.Config{
+		Image: postgresTestImage,
+		Cmd:   []string{"stat", cluster.CockroachBinaryInContainer},
+	}
+	if err := testDockerOneShot(t, "cli_test", containerConfig); err != nil {
 		t.Skipf(`TODO(dt): No binary in one-shot container, see #6086: %s`, err)
 	}
 
@@ -56,7 +61,8 @@ func TestDockerCLI(t *testing.T) {
 				cmd = append(cmd, "-d")
 			}
 			cmd = append(cmd, "-f", testPath, cluster.CockroachBinaryInContainer)
-			if err := testDockerOneShot(t, "cli_test", cmd); err != nil {
+			containerConfig.Cmd = cmd
+			if err := testDockerOneShot(t, "cli_test", containerConfig); err != nil {
 				t.Error(err)
 			}
 		})

--- a/pkg/acceptance/reference_test.go
+++ b/pkg/acceptance/reference_test.go
@@ -21,14 +21,20 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/acceptance/cluster"
+	"github.com/docker/docker/api/types/container"
 )
 
 func runReferenceTestWithScript(t *testing.T, script string) {
-	if err := testDockerOneShot(t, "reference", []string{"stat", cluster.CockroachBinaryInContainer}); err != nil {
+	containerConfig := container.Config{
+		Image: postgresTestImage,
+		Cmd:   []string{"stat", cluster.CockroachBinaryInContainer},
+	}
+	if err := testDockerOneShot(t, "reference", containerConfig); err != nil {
 		t.Skipf(`TODO(dt): No binary in one-shot container, see #6086: %s`, err)
 	}
 
-	if err := testDockerOneShot(t, "reference", []string{"/bin/bash", "-c", script}); err != nil {
+	containerConfig.Cmd = []string{"/bin/bash", "-c", script}
+	if err := testDockerOneShot(t, "reference", containerConfig); err != nil {
 		t.Error(err)
 	}
 }

--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -2,16 +2,80 @@
 
 source [file join [file dirname $argv0] common.tcl]
 
-proc start_secure_server {argv} {
-    system "$argv start --ca-cert=/certs/ca.crt --cert=/certs/node.crt --key=/certs/node.key & echo \$! > server_pid"
+set ca_crt "/certs/ca.crt"
+set node_crt "/certs/node.crt"
+set node_key "/certs/node.key"
+set root_crt "/certs/root.crt"
+set root_key "/certs/root.key"
+
+proc start_secure_server {argv ca_crt node_crt node_key} {
+    system "$argv start --ca-cert=$ca_crt --cert=$node_crt --key=$node_key & echo \$! > server_pid"
     sleep 1
 }
 
-start_secure_server $argv
+start_secure_server $argv $ca_crt $node_crt $node_key
 
-spawn $argv node ls --ca-cert=/certs/ca.crt --cert=/certs/node.crt --key=/certs/node.key
+spawn /bin/bash
+send "PS1=':''/# '\r"
+
+set prompt ":/# "
+eexpect $prompt
+
+send "$argv node ls --ca-cert=$ca_crt --cert=$node_crt --key=$node_key\r"
 eexpect "id"
 eexpect "1"
 eexpect "1 row"
+
+eexpect $prompt
+
+# Invalid combination.
+send "$argv sql --ca-cert=$ca_crt --cert=$node_crt\r"
+eexpect "Error: missing --key flag"
+eexpect "Failed running \"sql\""
+
+eexpect $prompt
+
+# CA cert must be specified regardless of authentication mode.
+send "$argv sql\r"
+eexpect "cleartext connections are not permitted"
+
+eexpect $prompt
+
+# A nonexistent user cannot authenticate with either form of authentication.
+send "$argv sql --user=nonexistent --ca-cert=$ca_crt --cert=$node_crt --key=$node_key\r"
+eexpect "user nonexistent does not exist"
+
+eexpect $prompt
+
+# Root can only authenticate using certificate authentication.
+send "$argv sql --ca-cert=$ca_crt\r"
+eexpect "user root must authenticate using a client certificate"
+
+eexpect $prompt
+
+send "$argv sql --ca-cert=$ca_crt --cert=$root_crt --key=$root_key\r"
+eexpect "root@"
+send "CREATE USER carl WITH PASSWORD 'woof';\r"
+eexpect "CREATE USER\r\n"
+
+# Terminate with Ctrl+C.
+send "\003"
+
+eexpect $prompt
+
+send "$argv sql --ca-cert=$ca_crt --user=carl\r"
+eexpect "Enter password:"
+send "woof\r"
+eexpect "Confirm password:"
+send "woof\r"
+eexpect "carl@"
+
+# Terminate with Ctrl+C.
+send "\003"
+
+eexpect $prompt
+
+send "exit 0\r"
+eexpect eof
 
 stop_server $argv

--- a/pkg/security/auth.go
+++ b/pkg/security/auth.go
@@ -136,7 +136,7 @@ func UserAuthPasswordHook(insecureMode bool, password string, hashedPassword []b
 		}
 
 		if requestedUser == RootUser {
-			return errors.Errorf("user %s cannot authenticate using a password", RootUser)
+			return errors.Errorf("user %s must authenticate using a client certificate ", RootUser)
 		}
 
 		// If the requested user has an empty password, disallow authentication.

--- a/pkg/sql/pgwire_test.go
+++ b/pkg/sql/pgwire_test.go
@@ -106,7 +106,7 @@ func TestPGWire(t *testing.T) {
 			} else {
 				// No certificates provided in secure mode defaults to password
 				// authentication. This is disallowed for security.RootUser.
-				if !testutils.IsError(err, fmt.Sprintf("pq: user %s cannot authenticate using a password", security.RootUser)) {
+				if !testutils.IsError(err, fmt.Sprintf("pq: user %s must authenticate using a client certificate", security.RootUser)) {
 					t.Errorf("unexpected error: %v", err)
 				}
 			}
@@ -136,7 +136,7 @@ func TestPGWire(t *testing.T) {
 					t.Error(err)
 				}
 			} else {
-				if !testutils.IsError(err, fmt.Sprintf("pq: user %s cannot authenticate using a password", security.RootUser)) {
+				if !testutils.IsError(err, fmt.Sprintf("pq: user %s must authenticate using a client certificate", security.RootUser)) {
 					t.Errorf("unexpected error: %v", err)
 				}
 			}


### PR DESCRIPTION
Necessary to test cli integration with server password authentication.
Also refactored some tests to be able to use an empty environment. The
default environment would result in the client providing the PGSSLCERT
to the server.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10449)
<!-- Reviewable:end -->
