### PR TITLE
build: plumb COCKROACH_PROPOSER_EVALUATED_KV env var

### DIFF
--- a/build/teamcity-stress.sh
+++ b/build/teamcity-stress.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 mkdir artifacts
 
 exit_status=0
-build/builder.sh make stress PKG="$PKG" GOFLAGS="${GOFLAGS-}" TAGS="${TAGS-}" TESTTIMEOUT=0 TESTFLAGS='-test.v' STRESSFLAGS='-maxtime 15m -maxfails 1 -stderr' 2>&1 | tee artifacts/stress.log || exit_status=$?
+build/builder.sh make stress COCKROACH_PROPOSER_EVALUATED_KV="${COCKROACH_PROPOSER_EVALUATED_KV-}" PKG="$PKG" GOFLAGS="${GOFLAGS-}" TAGS="${TAGS-}" TESTTIMEOUT=0 TESTFLAGS='-test.v' STRESSFLAGS='-maxtime 15m -maxfails 1 -stderr' 2>&1 | tee artifacts/stress.log || exit_status=$?
 
 if [ $exit_status -ne 0 ]; then
   build/builder.sh env GITHUB_API_TOKEN="$GITHUB_API_TOKEN" BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" github-post < artifacts/stress.log

--- a/build/teamcity-test.sh
+++ b/build/teamcity-test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -euxo pipefail
-build/builder.sh make test TESTFLAGS='-v' 2>&1 | go-test-teamcity
+build/builder.sh make test COCKROACH_PROPOSER_EVALUATED_KV="${COCKROACH_PROPOSER_EVALUATED_KV-}" TESTFLAGS='-v' 2>&1 | go-test-teamcity
 
 build/builder.sh env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" TARGET=stress github-pull-request-make

--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -euxo pipefail
-build/builder.sh make testrace TESTFLAGS='-v' 2>&1 | go-test-teamcity
+build/builder.sh make testrace COCKROACH_PROPOSER_EVALUATED_KV="${COCKROACH_PROPOSER_EVALUATED_KV-}" TESTFLAGS='-v' 2>&1 | go-test-teamcity
 
 build/builder.sh env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" TARGET=stressrace github-pull-request-make

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -96,7 +96,13 @@ var txnAutoGC = true
 var tickQuiesced = envutil.EnvOrDefaultBool("COCKROACH_TICK_QUIESCED", true)
 
 // Whether to enable experimental support for proposer-evaluated KV.
-var propEvalKV = envutil.EnvOrDefaultBool("COCKROACH_PROPOSER_EVALUATED_KV", false)
+var propEvalKV = func() bool {
+	enabled := envutil.EnvOrDefaultBool("COCKROACH_PROPOSER_EVALUATED_KV", false)
+	if enabled {
+		log.Warningf(context.Background(), "running with experimental support for proposer-evaluated KV, see #10431")
+	}
+	return enabled
+}()
 
 // raftInitialLog{Index,Term} are the starting points for the raft log. We
 // bootstrap the raft membership by synthesizing a snapshot as if there were


### PR DESCRIPTION
This should make it easy to run a nightly build for which tests are run using
proposer-evaluated KV.

Updates #10454.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10455)
<!-- Reviewable:end -->
