### PR TITLE
teamcity-trigger: allow passing additional build parameters

### DIFF
--- a/build/teamcity-proposer-evaluated-kv.sh
+++ b/build/teamcity-proposer-evaluated-kv.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+build/builder.sh env TC_API_USER="$TC_API_USER" TC_API_PASSWORD="$TC_API_PASSWORD" teamcity-trigger -build Cockroach_UnitTests -add-params env.COCKROACH_PROPOSER_EVALUATED_KV=true -pkgs ""


### PR DESCRIPTION
This allows a proposer-evaluated KV build to be triggered by invoking teamcity-trigger as follows:

```
teamcity-trigger -pkgs ""
  -add-params env.COCKROACH_PROPOSER_EVALUATED_KV=true
  -build Cockroach_UnitTests
```

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10467)
<!-- Reviewable:end -->
