### PR TITLE
storage: Don't add NoopRequests to the command queue

### DIFF
--- a/pkg/storage/command_queue.go
+++ b/pkg/storage/command_queue.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"container/heap"
 	"fmt"
+	"strings"
 
 	"golang.org/x/net/context"
 
@@ -118,6 +119,24 @@ func NewCommandQueue(coveringOptimization bool) *CommandQueue {
 		coveringOptimization: coveringOptimization,
 	}
 	return cq
+}
+
+// String dumps the contents of the command queue for testing.
+func (cq *CommandQueue) String() string {
+	var keys []string
+	count := 0
+	cq.tree.Do(func(i interval.Interface) bool {
+		c := i.(*cmd)
+		keys = append(keys, fmt.Sprintf("%s-%s", roachpb.Key(c.key.Start), roachpb.Key(c.key.End)))
+
+		count++
+		if count > 10 {
+			keys = append(keys, "...")
+			return true
+		}
+		return false
+	})
+	return strings.Join(keys, ",")
 }
 
 // prepareSpans ensures the spans all have an end key. Note that this function

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1214,7 +1214,11 @@ func (r *Replica) beginCmds(
 		var spansLocal []roachpb.Span
 
 		for _, union := range ba.Requests {
-			header := union.GetInner().Header()
+			inner := union.GetInner()
+			if _, ok := inner.(*roachpb.NoopRequest); ok {
+				continue
+			}
+			header := inner.Header()
 			if keys.IsLocal(header.Key) {
 				spansLocal = append(spansLocal, header)
 			} else {


### PR DESCRIPTION
Doing so was creating unnecessary contention in the command queue for the empty key.

Discovered during investigation of #10427

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10470)
<!-- Reviewable:end -->
