### PR TITLE
sql: don't bind a Context in BoundAccount

### DIFF
--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -238,7 +238,7 @@ func TestAdminAPIDatabases(t *testing.T) {
 	defer session.Finish(ts.sqlExecutor)
 	query := "CREATE DATABASE " + testdb
 	createRes := ts.sqlExecutor.ExecuteStatements(session, query, nil)
-	defer createRes.Close()
+	defer createRes.Close(ctx)
 
 	if createRes.ResultList[0].Err != nil {
 		t.Fatal(createRes.ResultList[0].Err)
@@ -266,7 +266,7 @@ func TestAdminAPIDatabases(t *testing.T) {
 	testuser := "testuser"
 	grantQuery := "GRANT " + strings.Join(privileges, ", ") + " ON DATABASE " + testdb + " TO " + testuser
 	grantRes := s.(*TestServer).sqlExecutor.ExecuteStatements(session, grantQuery, nil)
-	defer grantRes.Close()
+	defer grantRes.Close(ctx)
 	if grantRes.ResultList[0].Err != nil {
 		t.Fatal(grantRes.ResultList[0].Err)
 	}
@@ -306,7 +306,7 @@ func TestAdminAPIDatabases(t *testing.T) {
 	}
 
 	// Verify Descriptor ID.
-	path, err := ts.admin.queryDescriptorIDPath(session, []string{testdb})
+	path, err := ts.admin.queryDescriptorIDPath(ctx, session, []string{testdb})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -436,7 +436,7 @@ func testAdminAPITableDetailsInner(t *testing.T, dbName, tblName string) {
 
 	for _, q := range setupQueries {
 		res := ts.sqlExecutor.ExecuteStatements(session, q, nil)
-		defer res.Close()
+		defer res.Close(ctx)
 		if res.ResultList[0].Err != nil {
 			t.Fatalf("error executing '%s': %s", q, res.ResultList[0].Err)
 		}
@@ -517,7 +517,7 @@ func testAdminAPITableDetailsInner(t *testing.T, dbName, tblName string) {
 		showCreateTableQuery := fmt.Sprintf("SHOW CREATE TABLE %s.%s", escDBName, escTblName)
 
 		resSet := ts.sqlExecutor.ExecuteStatements(session, showCreateTableQuery, nil)
-		defer resSet.Close()
+		defer resSet.Close(ctx)
 		res := resSet.ResultList[0]
 		if res.Err != nil {
 			t.Fatalf("error executing '%s': %s", showCreateTableQuery, res.Err)
@@ -535,7 +535,7 @@ func testAdminAPITableDetailsInner(t *testing.T, dbName, tblName string) {
 	}
 
 	// Verify Descriptor ID.
-	path, err := ts.admin.queryDescriptorIDPath(session, []string{dbName, tblName})
+	path, err := ts.admin.queryDescriptorIDPath(ctx, session, []string{dbName, tblName})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -565,7 +565,7 @@ func TestAdminAPIZoneDetails(t *testing.T) {
 	}
 	for _, q := range setupQueries {
 		res := ts.sqlExecutor.ExecuteStatements(session, q, nil)
-		defer res.Close()
+		defer res.Close(ctx)
 		if res.ResultList[0].Err != nil {
 			t.Fatalf("error executing '%s': %s", q, res.ResultList[0].Err)
 		}
@@ -622,7 +622,7 @@ func TestAdminAPIZoneDetails(t *testing.T) {
 		params.SetValue(`1`, parser.NewDInt(parser.DInt(id)))
 		params.SetValue(`2`, parser.NewDBytes(parser.DBytes(zoneBytes)))
 		res := ts.sqlExecutor.ExecuteStatements(session, query, params)
-		defer res.Close()
+		defer res.Close(ctx)
 		if res.ResultList[0].Err != nil {
 			t.Fatalf("error executing '%s': %s", query, res.ResultList[0].Err)
 		}
@@ -634,7 +634,7 @@ func TestAdminAPIZoneDetails(t *testing.T) {
 
 	// Get ID path for table. This will be an array of three IDs, containing the ID of the root namespace,
 	// the database, and the table (in that order).
-	idPath, err := ts.admin.queryDescriptorIDPath(session, []string{"test", "tbl"})
+	idPath, err := ts.admin.queryDescriptorIDPath(ctx, session, []string{"test", "tbl"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -674,7 +674,7 @@ func TestAdminAPIUsers(t *testing.T) {
 INSERT INTO system.users (username, hashedPassword)
 VALUES ('admin', 'abc'), ('bob', 'xyz')`
 	res := ts.sqlExecutor.ExecuteStatements(session, query, nil)
-	defer res.Close()
+	defer res.Close(ctx)
 	if a, e := len(res.ResultList), 1; a != e {
 		t.Fatalf("len(results) %d != %d", a, e)
 	} else if res.ResultList[0].Err != nil {
@@ -725,7 +725,7 @@ func TestAdminAPIEvents(t *testing.T) {
 	}
 	for _, q := range setupQueries {
 		res := ts.sqlExecutor.ExecuteStatements(session, q, nil)
-		defer res.Close()
+		defer res.Close(ctx)
 		if res.ResultList[0].Err != nil {
 			t.Fatalf("error executing '%s': %s", q, res.ResultList[0].Err)
 		}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -775,7 +775,9 @@ func (n *Node) recordJoinEvent() {
 		retryOpts.Closer = n.stopper.ShouldStop()
 		for r := retry.Start(retryOpts); r.Next(); {
 			if err := n.storeCfg.DB.Txn(ctx, func(txn *client.Txn) error {
-				return n.eventLogger.InsertEventRecord(txn,
+				return n.eventLogger.InsertEventRecord(
+					ctx,
+					txn,
 					logEventType,
 					int32(n.Descriptor.NodeID),
 					int32(n.Descriptor.NodeID),

--- a/pkg/sql/analyze.go
+++ b/pkg/sql/analyze.go
@@ -22,6 +22,8 @@ import (
 	"regexp"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 )
@@ -1603,6 +1605,7 @@ func makeIsNotNull(left parser.TypedExpr) parser.TypedExpr {
 // name resolution should be performed. The IndexedVars map will be filled
 // as a result.
 func (p *planner) analyzeExpr(
+	ctx context.Context,
 	raw parser.Expr,
 	sources multiSourceInfo,
 	iVarHelper parser.IndexedVarHelper,
@@ -1615,7 +1618,7 @@ func (p *planner) analyzeExpr(
 	// is expected. Tell this to replaceSubqueries.  (See UPDATE for a
 	// counter-example; cases where a subquery is an operand of a
 	// comparison are handled specially in the subqueryVisitor already.)
-	replaced, err := p.replaceSubqueries(raw, 1 /* one value expected */)
+	replaced, err := p.replaceSubqueries(ctx, raw, 1 /* one value expected */)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -96,7 +96,9 @@ func (sc *SchemaChanger) getChunkSize(chunkSize int64) int64 {
 }
 
 // runBackfill runs the backfill for the schema changer.
-func (sc *SchemaChanger) runBackfill(lease *sqlbase.TableDescriptor_SchemaChangeLease) error {
+func (sc *SchemaChanger) runBackfill(
+	ctx context.Context, lease *sqlbase.TableDescriptor_SchemaChangeLease,
+) error {
 	if sc.testingKnobs.RunBeforeBackfill != nil {
 		if err := sc.testingKnobs.RunBeforeBackfill(); err != nil {
 			return err
@@ -172,21 +174,21 @@ func (sc *SchemaChanger) runBackfill(lease *sqlbase.TableDescriptor_SchemaChange
 
 	// Drop indexes.
 	if err := sc.truncateIndexes(
-		lease, version, droppedIndexDescs, droppedIndexMutationIdx,
+		ctx, lease, version, droppedIndexDescs, droppedIndexMutationIdx,
 	); err != nil {
 		return err
 	}
 
 	// Add and drop columns.
 	if err := sc.truncateAndBackfillColumns(
-		lease, version, addedColumnDescs, droppedColumnDescs, columnMutationIdx,
+		ctx, lease, version, addedColumnDescs, droppedColumnDescs, columnMutationIdx,
 	); err != nil {
 		return err
 	}
 
 	// Add new indexes.
 	if len(addedIndexDescs) > 0 {
-		if err := sc.backfillIndexes(lease, version); err != nil {
+		if err := sc.backfillIndexes(ctx, lease, version); err != nil {
 			return err
 		}
 	}
@@ -269,9 +271,9 @@ func (sc *SchemaChanger) makePlanner(txn *client.Txn) *planner {
 }
 
 func (sc *SchemaChanger) getTableLease(
-	p *planner, version sqlbase.DescriptorVersion,
+	ctx context.Context, p *planner, version sqlbase.DescriptorVersion,
 ) (*sqlbase.TableDescriptor, error) {
-	tableDesc, err := p.getTableLeaseByID(sc.tableID)
+	tableDesc, err := p.getTableLeaseByID(ctx, sc.tableID)
 	if err != nil {
 		return nil, err
 	}
@@ -282,6 +284,7 @@ func (sc *SchemaChanger) getTableLease(
 }
 
 func (sc *SchemaChanger) truncateAndBackfillColumns(
+	ctx context.Context,
 	lease *sqlbase.TableDescriptor_SchemaChangeLease,
 	version sqlbase.DescriptorVersion,
 	added []sqlbase.ColumnDescriptor,
@@ -350,7 +353,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 
 			// Add and delete columns for a chunk of the key space.
 			sp.Key, done, err = sc.truncateAndBackfillColumnsChunk(
-				version, added, dropped, defaultExprs, sp,
+				ctx, version, added, dropped, defaultExprs, sp,
 				updateValues, nonNullViolationColumnName, chunkSize, mutationIdx, &lastCheckpoint)
 			if err != nil {
 				return err
@@ -364,6 +367,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 // next-key and done are invalid if error != nil. next-key is invalid if done
 // is true.
 func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
+	ctx context.Context,
 	version sqlbase.DescriptorVersion,
 	added []sqlbase.ColumnDescriptor,
 	dropped []sqlbase.ColumnDescriptor,
@@ -391,8 +395,8 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 		txn.SetSystemConfigTrigger()
 
 		p := sc.makePlanner(txn)
-		defer p.releaseLeases()
-		tableDesc, err := sc.getTableLease(p, version)
+		defer p.releaseLeases(ctx)
+		tableDesc, err := sc.getTableLease(ctx, p, version)
 		if err != nil {
 			return err
 		}
@@ -400,7 +404,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 		updateCols := append(added, dropped...)
 		fkTables := tablesNeededForFKs(*tableDesc, CheckUpdates)
 		for k := range fkTables {
-			table, err := p.getTableLeaseByID(k)
+			table, err := p.getTableLeaseByID(ctx, k)
 			if err != nil {
 				return err
 			}
@@ -503,6 +507,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 }
 
 func (sc *SchemaChanger) truncateIndexes(
+	ctx context.Context,
 	lease *sqlbase.TableDescriptor_SchemaChangeLease,
 	version sqlbase.DescriptorVersion,
 	dropped []sqlbase.IndexDescriptor,
@@ -540,8 +545,8 @@ func (sc *SchemaChanger) truncateIndexes(
 				txn.SetSystemConfigTrigger()
 
 				p := sc.makePlanner(txn)
-				defer p.releaseLeases()
-				tableDesc, err := sc.getTableLease(p, version)
+				defer p.releaseLeases(ctx)
+				tableDesc, err := sc.getTableLease(ctx, p, version)
 				if err != nil {
 					return err
 				}
@@ -610,7 +615,9 @@ func (sc *SchemaChanger) backfillIndexesSpans() ([]roachpb.Span, error) {
 }
 
 func (sc *SchemaChanger) backfillIndexes(
-	lease *sqlbase.TableDescriptor_SchemaChangeLease, version sqlbase.DescriptorVersion,
+	ctx context.Context,
+	lease *sqlbase.TableDescriptor_SchemaChangeLease,
+	version sqlbase.DescriptorVersion,
 ) error {
 	duration := checkpointInterval
 	if sc.testingKnobs.WriteCheckpointInterval > 0 {
@@ -630,8 +637,8 @@ func (sc *SchemaChanger) backfillIndexes(
 		if err := sc.db.Txn(context.TODO(), func(txn *client.Txn) error {
 			p := sc.makePlanner(txn)
 			// Use a leased table descriptor for the backfill.
-			defer p.releaseLeases()
-			tableDesc, err := sc.getTableLease(p, version)
+			defer p.releaseLeases(ctx)
+			tableDesc, err := sc.getTableLease(ctx, p, version)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -19,6 +19,8 @@ package sql
 import (
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/pkg/errors"
@@ -50,7 +52,7 @@ CREATE TABLE crdb_internal.tables (
   CREATE_TABLE             STRING NOT NULL
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		descs, err := p.getAllDescriptors()
 		if err != nil {
 			return err
@@ -82,7 +84,7 @@ CREATE TABLE crdb_internal.tables (
 					time.Unix(0, table.Lease.ExpirationTime), time.Nanosecond,
 				)
 			}
-			create, err := p.showCreateTable(parser.Name(table.Name), table)
+			create, err := p.showCreateTable(ctx, parser.Name(table.Name), table)
 			if err != nil {
 				return err
 			}
@@ -120,7 +122,7 @@ CREATE TABLE crdb_internal.schema_changes (
   DIRECTION     STRING NOT NULL
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		descs, err := p.getAllDescriptors()
 		if err != nil {
 			return err
@@ -179,7 +181,7 @@ CREATE TABLE crdb_internal.leases (
   DELETED     BOOL NOT NULL
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		leaseMgr := p.leaseMgr
 		nodeID := parser.NewDInt(parser.DInt(int64(leaseMgr.nodeID.Get())))
 

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -86,17 +86,19 @@ func (p *planner) CreateDatabase(n *parser.CreateDatabase) (planNode, error) {
 	return &createDatabaseNode{p: p, n: n}, nil
 }
 
-func (n *createDatabaseNode) Start() error {
+func (n *createDatabaseNode) Start(ctx context.Context) error {
 	desc := makeDatabaseDesc(n.n)
 
-	created, err := n.p.createDatabase(&desc, n.n.IfNotExists)
+	created, err := n.p.createDatabase(ctx, &desc, n.n.IfNotExists)
 	if err != nil {
 		return err
 	}
 	if created {
 		// Log Create Database event. This is an auditable log event and is
 		// recorded in the same transaction as the table descriptor update.
-		if err := MakeEventLogger(n.p.leaseMgr).InsertEventRecord(n.p.txn,
+		if err := MakeEventLogger(n.p.leaseMgr).InsertEventRecord(
+			ctx,
+			n.p.txn,
 			EventLogCreateDatabase,
 			int32(desc.ID),
 			int32(n.p.evalCtx.NodeID),
@@ -112,13 +114,13 @@ func (n *createDatabaseNode) Start() error {
 	return nil
 }
 
-func (n *createDatabaseNode) Next() (bool, error)        { return false, nil }
-func (n *createDatabaseNode) Close()                     {}
-func (n *createDatabaseNode) Columns() ResultColumns     { return make(ResultColumns, 0) }
-func (n *createDatabaseNode) Ordering() orderingInfo     { return orderingInfo{} }
-func (n *createDatabaseNode) Values() parser.Datums      { return parser.Datums{} }
-func (n *createDatabaseNode) DebugValues() debugValues   { return debugValues{} }
-func (n *createDatabaseNode) MarkDebug(mode explainMode) {}
+func (n *createDatabaseNode) Next(context.Context) (bool, error) { return false, nil }
+func (n *createDatabaseNode) Close(context.Context)              {}
+func (n *createDatabaseNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
+func (n *createDatabaseNode) Ordering() orderingInfo             { return orderingInfo{} }
+func (n *createDatabaseNode) Values() parser.Datums              { return parser.Datums{} }
+func (n *createDatabaseNode) DebugValues() debugValues           { return debugValues{} }
+func (n *createDatabaseNode) MarkDebug(mode explainMode)         {}
 
 type createIndexNode struct {
 	p         *planner
@@ -148,7 +150,7 @@ func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, error) {
 	return &createIndexNode{p: p, tableDesc: tableDesc, n: n}, nil
 }
 
-func (n *createIndexNode) Start() error {
+func (n *createIndexNode) Start(ctx context.Context) error {
 	status, i, err := n.tableDesc.FindIndexByName(n.n.Name)
 	if err == nil {
 		if status == sqlbase.DescriptorIncomplete {
@@ -203,7 +205,9 @@ func (n *createIndexNode) Start() error {
 	// Record index creation in the event log. This is an auditable log
 	// event and is recorded in the same transaction as the table descriptor
 	// update.
-	if err := MakeEventLogger(n.p.leaseMgr).InsertEventRecord(n.p.txn,
+	if err := MakeEventLogger(n.p.leaseMgr).InsertEventRecord(
+		ctx,
+		n.p.txn,
 		EventLogCreateIndex,
 		int32(n.tableDesc.ID),
 		int32(n.p.evalCtx.NodeID),
@@ -222,13 +226,13 @@ func (n *createIndexNode) Start() error {
 	return nil
 }
 
-func (n *createIndexNode) Next() (bool, error)        { return false, nil }
-func (n *createIndexNode) Close()                     {}
-func (n *createIndexNode) Columns() ResultColumns     { return make(ResultColumns, 0) }
-func (n *createIndexNode) Ordering() orderingInfo     { return orderingInfo{} }
-func (n *createIndexNode) Values() parser.Datums      { return parser.Datums{} }
-func (n *createIndexNode) DebugValues() debugValues   { return debugValues{} }
-func (n *createIndexNode) MarkDebug(mode explainMode) {}
+func (n *createIndexNode) Next(context.Context) (bool, error) { return false, nil }
+func (n *createIndexNode) Close(context.Context)              {}
+func (n *createIndexNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
+func (n *createIndexNode) Ordering() orderingInfo             { return orderingInfo{} }
+func (n *createIndexNode) Values() parser.Datums              { return parser.Datums{} }
+func (n *createIndexNode) DebugValues() debugValues           { return debugValues{} }
+func (n *createIndexNode) MarkDebug(mode explainMode)         {}
 
 type createUserNode struct {
 	p        *planner
@@ -265,7 +269,7 @@ func (p *planner) CreateUser(n *parser.CreateUser) (planNode, error) {
 	return &createUserNode{p: p, n: n, password: resolvedPassword}, nil
 }
 
-func (n *createUserNode) Start() error {
+func (n *createUserNode) Start(ctx context.Context) error {
 	var hashedPassword []byte
 	if n.password != "" {
 		var err error
@@ -279,6 +283,7 @@ func (n *createUserNode) Start() error {
 
 	internalExecutor := InternalExecutor{LeaseManager: n.p.leaseMgr}
 	rowsAffected, err := internalExecutor.ExecuteStatementInTransaction(
+		ctx,
 		"create-user",
 		n.p.txn,
 		"INSERT INTO system.users VALUES ($1, $2);",
@@ -299,13 +304,13 @@ func (n *createUserNode) Start() error {
 	return nil
 }
 
-func (n *createUserNode) Next() (bool, error)        { return false, nil }
-func (n *createUserNode) Close()                     {}
-func (n *createUserNode) Columns() ResultColumns     { return make(ResultColumns, 0) }
-func (n *createUserNode) Ordering() orderingInfo     { return orderingInfo{} }
-func (n *createUserNode) Values() parser.Datums      { return parser.Datums{} }
-func (n *createUserNode) DebugValues() debugValues   { return debugValues{} }
-func (n *createUserNode) MarkDebug(mode explainMode) {}
+func (n *createUserNode) Next(context.Context) (bool, error) { return false, nil }
+func (n *createUserNode) Close(context.Context)              {}
+func (n *createUserNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
+func (n *createUserNode) Ordering() orderingInfo             { return orderingInfo{} }
+func (n *createUserNode) Values() parser.Datums              { return parser.Datums{} }
+func (n *createUserNode) DebugValues() debugValues           { return debugValues{} }
+func (n *createUserNode) MarkDebug(mode explainMode)         {}
 
 type createViewNode struct {
 	p           *planner
@@ -320,7 +325,7 @@ type createViewNode struct {
 //   notes: postgres requires CREATE on database plus SELECT on all the
 //						selected columns.
 //          mysql requires CREATE VIEW plus SELECT on all the selected columns.
-func (p *planner) CreateView(n *parser.CreateView) (planNode, error) {
+func (p *planner) CreateView(ctx context.Context, n *parser.CreateView) (planNode, error) {
 	name, err := n.Name.NormalizeWithDatabaseName(p.session.Database)
 	if err != nil {
 		return nil, err
@@ -339,7 +344,7 @@ func (p *planner) CreateView(n *parser.CreateView) (planNode, error) {
 	// depends on, make sure we use the most recent versions of table
 	// descriptors rather than the copies in the lease cache.
 	p.avoidCachedDescriptors = true
-	sourcePlan, err := p.Select(n.AsSource, []parser.Type{}, false)
+	sourcePlan, err := p.Select(ctx, n.AsSource, []parser.Type{}, false)
 	if err != nil {
 		p.avoidCachedDescriptors = false
 		return nil, err
@@ -350,7 +355,7 @@ func (p *planner) CreateView(n *parser.CreateView) (planNode, error) {
 		// Ensure that we clean up after ourselves if an error occurs, because if
 		// construction of the planNode fails, Close() won't be called on it.
 		if result == nil {
-			sourcePlan.Close()
+			sourcePlan.Close(ctx)
 			p.avoidCachedDescriptors = false
 		}
 	}()
@@ -371,9 +376,9 @@ func (p *planner) CreateView(n *parser.CreateView) (planNode, error) {
 		parser.FmtNormalizeTableNames(
 			parser.FmtParsable,
 			func(t *parser.NormalizableTableName) *parser.TableName {
-				tn, err := p.QualifyWithDatabase(t)
+				tn, err := p.QualifyWithDatabase(ctx, t)
 				if err != nil {
-					log.Warningf(p.ctx(), "failed to qualify table name %q with database name: %v", t, err)
+					log.Warningf(ctx, "failed to qualify table name %q with database name: %v", t, err)
 					fmtErr = err
 					return nil
 				}
@@ -386,7 +391,7 @@ func (p *planner) CreateView(n *parser.CreateView) (planNode, error) {
 	}
 
 	// TODO(a-robinson): Support star expressions as soon as we can (#10028).
-	if p.planContainsStar(sourcePlan) {
+	if p.planContainsStar(ctx, sourcePlan) {
 		return nil, fmt.Errorf("views do not currently support * expressions")
 	}
 
@@ -402,7 +407,7 @@ func (p *planner) CreateView(n *parser.CreateView) (planNode, error) {
 	return result, nil
 }
 
-func (n *createViewNode) Start() error {
+func (n *createViewNode) Start(ctx context.Context) error {
 	tKey := tableKey{parentID: n.dbDesc.ID, name: n.n.Name.TableName().Table()}
 	key := tKey.Key()
 	if exists, err := n.p.descExists(key); err == nil && exists {
@@ -421,7 +426,8 @@ func (n *createViewNode) Start() error {
 	privs := n.dbDesc.GetPrivileges()
 
 	affected := make(map[sqlbase.ID]*sqlbase.TableDescriptor)
-	desc, err := n.makeViewTableDesc(n.n, n.dbDesc.ID, id, n.sourcePlan.Columns(), privs, affected)
+	desc, err := n.makeViewTableDesc(
+		ctx, n.n, n.dbDesc.ID, id, n.sourcePlan.Columns(), privs, affected)
 	if err != nil {
 		return err
 	}
@@ -431,7 +437,7 @@ func (n *createViewNode) Start() error {
 		return err
 	}
 
-	err = n.p.createDescriptorWithID(key, id, &desc)
+	err = n.p.createDescriptorWithID(ctx, key, id, &desc)
 	if err != nil {
 		return err
 	}
@@ -451,7 +457,9 @@ func (n *createViewNode) Start() error {
 
 	// Log Create View event. This is an auditable log event and is
 	// recorded in the same transaction as the table descriptor update.
-	if err := MakeEventLogger(n.p.leaseMgr).InsertEventRecord(n.p.txn,
+	if err := MakeEventLogger(n.p.leaseMgr).InsertEventRecord(
+		ctx,
+		n.p.txn,
 		EventLogCreateView,
 		int32(desc.ID),
 		int32(n.p.evalCtx.NodeID),
@@ -467,18 +475,18 @@ func (n *createViewNode) Start() error {
 	return nil
 }
 
-func (n *createViewNode) Close() {
-	n.sourcePlan.Close()
+func (n *createViewNode) Close(ctx context.Context) {
+	n.sourcePlan.Close(ctx)
 	n.sourcePlan = nil
 	n.p.avoidCachedDescriptors = false
 }
 
-func (n *createViewNode) Next() (bool, error)        { return false, nil }
-func (n *createViewNode) Columns() ResultColumns     { return make(ResultColumns, 0) }
-func (n *createViewNode) Ordering() orderingInfo     { return orderingInfo{} }
-func (n *createViewNode) Values() parser.Datums      { return parser.Datums{} }
-func (n *createViewNode) DebugValues() debugValues   { return debugValues{} }
-func (n *createViewNode) MarkDebug(mode explainMode) {}
+func (n *createViewNode) Next(context.Context) (bool, error) { return false, nil }
+func (n *createViewNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
+func (n *createViewNode) Ordering() orderingInfo             { return orderingInfo{} }
+func (n *createViewNode) Values() parser.Datums              { return parser.Datums{} }
+func (n *createViewNode) DebugValues() debugValues           { return debugValues{} }
+func (n *createViewNode) MarkDebug(mode explainMode)         {}
 
 type createTableNode struct {
 	p          *planner
@@ -490,7 +498,7 @@ type createTableNode struct {
 // CreateTable creates a table.
 // Privileges: CREATE on database.
 //   Notes: postgres/mysql require CREATE on database.
-func (p *planner) CreateTable(n *parser.CreateTable) (planNode, error) {
+func (p *planner) CreateTable(ctx context.Context, n *parser.CreateTable) (planNode, error) {
 	tn, err := n.Table.NormalizeWithDatabaseName(p.session.Database)
 	if err != nil {
 		return nil, err
@@ -521,14 +529,14 @@ func (p *planner) CreateTable(n *parser.CreateTable) (planNode, error) {
 		// to populate the new table descriptor in Start() below. We
 		// instantiate the sourcePlan as early as here so that EXPLAIN has
 		// something useful to show about CREATE TABLE .. AS ...
-		sourcePlan, err = p.Select(n.AsSource, []parser.Type{}, false)
+		sourcePlan, err = p.Select(ctx, n.AsSource, []parser.Type{}, false)
 		if err != nil {
 			return nil, err
 		}
 		numColNames := len(n.AsColumnNames)
 		numColumns := len(sourcePlan.Columns())
 		if numColNames != 0 && numColNames != numColumns {
-			sourcePlan.Close()
+			sourcePlan.Close(ctx)
 			return nil, sqlbase.NewSyntaxError(fmt.Sprintf(
 				"CREATE TABLE specifies %d column name%s, but data source has %d column%s",
 				numColNames, util.Pluralize(int64(numColNames)),
@@ -568,7 +576,7 @@ func hoistConstraints(n *parser.CreateTable) {
 	}
 }
 
-func (n *createTableNode) Start() error {
+func (n *createTableNode) Start(ctx context.Context) error {
 	tKey := tableKey{parentID: n.dbDesc.ID, name: n.n.Table.TableName().Table()}
 	key := tKey.Key()
 	if exists, err := n.p.descExists(key); err == nil && exists {
@@ -612,7 +620,7 @@ func (n *createTableNode) Start() error {
 		return err
 	}
 
-	if err := n.p.createDescriptorWithID(key, id, &desc); err != nil {
+	if err := n.p.createDescriptorWithID(ctx, key, id, &desc); err != nil {
 		return err
 	}
 
@@ -639,7 +647,9 @@ func (n *createTableNode) Start() error {
 
 	// Log Create Table event. This is an auditable log event and is
 	// recorded in the same transaction as the table descriptor update.
-	if err := MakeEventLogger(n.p.leaseMgr).InsertEventRecord(n.p.txn,
+	if err := MakeEventLogger(n.p.leaseMgr).InsertEventRecord(
+		ctx,
+		n.p.txn,
 		EventLogCreateTable,
 		int32(desc.ID),
 		int32(n.p.evalCtx.NodeID),
@@ -661,7 +671,7 @@ func (n *createTableNode) Start() error {
 		// below would cause a 2nd invocation and cause a panic. So
 		// instead we close this sourcePlan and let the insertNode create
 		// it anew from the AsSource syntax node.
-		n.sourcePlan.Close()
+		n.sourcePlan.Close(ctx)
 		n.sourcePlan = nil
 
 		insert := &parser.Insert{
@@ -669,22 +679,22 @@ func (n *createTableNode) Start() error {
 			Rows:      n.n.AsSource,
 			Returning: parser.AbsentReturningClause,
 		}
-		insertPlan, err := n.p.Insert(insert, nil, false)
+		insertPlan, err := n.p.Insert(ctx, insert, nil /* desiredTypes */, false /* autoCommit */)
 		if err != nil {
 			return err
 		}
-		defer insertPlan.Close()
-		insertPlan, err = n.p.optimizePlan(insertPlan, allColumns(insertPlan))
+		defer insertPlan.Close(ctx)
+		insertPlan, err = n.p.optimizePlan(ctx, insertPlan, allColumns(insertPlan))
 		if err != nil {
 			return err
 		}
-		if err = n.p.startPlan(insertPlan); err != nil {
+		if err = n.p.startPlan(ctx, insertPlan); err != nil {
 			return err
 		}
 		// This loop is done here instead of in the Next method
 		// since CREATE TABLE is a DDL statement and Executor only
 		// runs Next() for statements with type "Rows".
-		for done := true; done; done, err = insertPlan.Next() {
+		for done := true; done; done, err = insertPlan.Next(ctx) {
 			if err != nil {
 				return err
 			}
@@ -693,19 +703,19 @@ func (n *createTableNode) Start() error {
 	return nil
 }
 
-func (n *createTableNode) Close() {
+func (n *createTableNode) Close(ctx context.Context) {
 	if n.sourcePlan != nil {
-		n.sourcePlan.Close()
+		n.sourcePlan.Close(ctx)
 		n.sourcePlan = nil
 	}
 }
 
-func (n *createTableNode) Next() (bool, error)        { return false, nil }
-func (n *createTableNode) Columns() ResultColumns     { return make(ResultColumns, 0) }
-func (n *createTableNode) Ordering() orderingInfo     { return orderingInfo{} }
-func (n *createTableNode) Values() parser.Datums      { return parser.Datums{} }
-func (n *createTableNode) DebugValues() debugValues   { return debugValues{} }
-func (n *createTableNode) MarkDebug(mode explainMode) {}
+func (n *createTableNode) Next(context.Context) (bool, error) { return false, nil }
+func (n *createTableNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
+func (n *createTableNode) Ordering() orderingInfo             { return orderingInfo{} }
+func (n *createTableNode) Values() parser.Datums              { return parser.Datums{} }
+func (n *createTableNode) DebugValues() debugValues           { return debugValues{} }
+func (n *createTableNode) MarkDebug(mode explainMode)         {}
 
 type indexMatch bool
 
@@ -1077,6 +1087,7 @@ func (p *planner) finalizeInterleave(
 // doesn't matter if reads/writes use a cached descriptor that doesn't
 // include the back-references.
 func (n *createViewNode) makeViewTableDesc(
+	ctx context.Context,
 	p *parser.CreateView,
 	parentID sqlbase.ID,
 	id sqlbase.ID,
@@ -1111,7 +1122,7 @@ func (n *createViewNode) makeViewTableDesc(
 		desc.AddColumn(*col)
 	}
 
-	n.resolveViewDependencies(&desc, affected)
+	n.resolveViewDependencies(ctx, &desc, affected)
 
 	return desc, desc.AllocateIDs()
 }
@@ -1503,9 +1514,11 @@ func CreateTestTableDescriptor(
 // descriptors are put into the backrefs map of other tables so that they can
 // be updated when this view is created.
 func (n *createViewNode) resolveViewDependencies(
-	tbl *sqlbase.TableDescriptor, backrefs map[sqlbase.ID]*sqlbase.TableDescriptor,
+	ctx context.Context,
+	tbl *sqlbase.TableDescriptor,
+	backrefs map[sqlbase.ID]*sqlbase.TableDescriptor,
 ) {
-	n.p.populateViewBackrefs(n.sourcePlan, tbl, backrefs)
+	n.p.populateViewBackrefs(ctx, n.sourcePlan, tbl, backrefs)
 
 	// Also create the forward references in the new view's descriptor.
 	tbl.DependsOn = make([]sqlbase.ID, 0, len(backrefs))
@@ -1517,10 +1530,13 @@ func (n *createViewNode) resolveViewDependencies(
 // populateViewBackrefs adds back-references to the descriptor for each referenced
 // table / view in the plan.
 func (p *planner) populateViewBackrefs(
-	plan planNode, tbl *sqlbase.TableDescriptor, backrefs map[sqlbase.ID]*sqlbase.TableDescriptor,
+	ctx context.Context,
+	plan planNode,
+	tbl *sqlbase.TableDescriptor,
+	backrefs map[sqlbase.ID]*sqlbase.TableDescriptor,
 ) {
 	b := &backrefCollector{p: p, tbl: tbl, backrefs: backrefs}
-	_ = walkPlan(plan, planObserver{enterNode: b.enterNode})
+	_ = walkPlan(ctx, plan, planObserver{enterNode: b.enterNode})
 }
 
 type backrefCollector struct {
@@ -1529,8 +1545,8 @@ type backrefCollector struct {
 	backrefs map[sqlbase.ID]*sqlbase.TableDescriptor
 }
 
-// enterNode implements the planObserver interface.
-func (b *backrefCollector) enterNode(_ string, plan planNode) bool {
+// enterNode is used by a planObserver.
+func (b *backrefCollector) enterNode(ctx context.Context, _ string, plan planNode) bool {
 	// I was initially concerned about doing type assertions on every node in
 	// the tree, but it's actually faster than a string comparison on the name
 	// returned by ExplainPlan, judging by a mini-benchmark run on my laptop
@@ -1548,12 +1564,12 @@ func (b *backrefCollector) enterNode(_ string, plan planNode) bool {
 		if join.left.info.viewDesc != nil {
 			populateViewBackrefFromViewDesc(join.left.info.viewDesc, b.tbl, b.backrefs)
 		} else {
-			b.p.populateViewBackrefs(join.left.plan, b.tbl, b.backrefs)
+			b.p.populateViewBackrefs(ctx, join.left.plan, b.tbl, b.backrefs)
 		}
 		if join.right.info.viewDesc != nil {
 			populateViewBackrefFromViewDesc(join.right.info.viewDesc, b.tbl, b.backrefs)
 		} else {
-			b.p.populateViewBackrefs(join.right.plan, b.tbl, b.backrefs)
+			b.p.populateViewBackrefs(ctx, join.right.plan, b.tbl, b.backrefs)
 		}
 		// Return early to avoid re-processing the children.
 		return false
@@ -1597,9 +1613,9 @@ func populateViewBackrefFromViewDesc(
 
 // planContainsStar returns true if one of the render nodes in the
 // plan contains a star expansion.
-func (p *planner) planContainsStar(plan planNode) bool {
+func (p *planner) planContainsStar(ctx context.Context, plan planNode) bool {
 	s := &starDetector{}
-	_ = walkPlan(plan, planObserver{enterNode: s.enterNode})
+	_ = walkPlan(ctx, plan, planObserver{enterNode: s.enterNode})
 	return s.foundStar
 }
 
@@ -1609,7 +1625,7 @@ type starDetector struct {
 }
 
 // enterNode implements the planObserver interface.
-func (s *starDetector) enterNode(_ string, plan planNode) bool {
+func (s *starDetector) enterNode(_ context.Context, _ string, plan planNode) bool {
 	if s.foundStar {
 		return false
 	}

--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -117,7 +117,7 @@ func newAggregator(
 
 		ag.outputTypes[i] = retType
 	}
-	if err := ag.out.init(post, ag.outputTypes, flowCtx.evalCtx, output); err != nil {
+	if err := ag.out.init(post, ag.outputTypes, &flowCtx.evalCtx, output); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/distsqlrun/aggregator_test.go
+++ b/pkg/sql/distsqlrun/aggregator_test.go
@@ -282,7 +282,7 @@ func TestAggregator(t *testing.T) {
 		out := &RowBuffer{}
 
 		flowCtx := FlowCtx{
-			evalCtx: &parser.EvalContext{},
+			evalCtx: parser.EvalContext{},
 		}
 
 		ag, err := newAggregator(&flowCtx, &ags, in, &PostProcessSpec{}, out)

--- a/pkg/sql/distsqlrun/distinct.go
+++ b/pkg/sql/distsqlrun/distinct.go
@@ -47,7 +47,7 @@ func newDistinct(
 		d.orderedCols[col] = struct{}{}
 	}
 
-	if err := d.out.init(post, input.Types(), flowCtx.evalCtx, output); err != nil {
+	if err := d.out.init(post, input.Types(), &flowCtx.evalCtx, output); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -48,7 +48,7 @@ type FlowCtx struct {
 	log.AmbientContext
 
 	id           FlowID
-	evalCtx      *parser.EvalContext
+	evalCtx      parser.EvalContext
 	rpcCtx       *rpc.Context
 	txnProto     *roachpb.Transaction
 	clientDB     *client.DB

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -47,10 +47,17 @@ type FlowID struct {
 type FlowCtx struct {
 	log.AmbientContext
 
-	id           FlowID
-	evalCtx      parser.EvalContext
-	rpcCtx       *rpc.Context
-	txnProto     *roachpb.Transaction
+	// id is a unique identifier for a flow.
+	id FlowID
+	// evalCtx is used by all the processors in the flow to evaluate expressions.
+	evalCtx parser.EvalContext
+	// rpcCtx is used by the Outboxes that may be present in the flow for
+	// connecting to other nodes.
+	rpcCtx *rpc.Context
+	// txnProto is the transaction in which kv operations performed by processors
+	// in the flow must be performed.
+	txnProto *roachpb.Transaction
+	// clientDB is a handle to the cluster. Used to run transactions.
 	clientDB     *client.DB
 	testingKnobs TestingKnobs
 }

--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -486,7 +486,7 @@ func TestHashJoiner(t *testing.T) {
 		leftInput := NewRowBuffer(nil, c.inputs[0])
 		rightInput := NewRowBuffer(nil, c.inputs[1])
 		out := &RowBuffer{}
-		flowCtx := FlowCtx{evalCtx: &parser.EvalContext{}}
+		flowCtx := FlowCtx{evalCtx: parser.EvalContext{}}
 
 		post := PostProcessSpec{OutputColumns: c.outCols}
 		h, err := newHashJoiner(&flowCtx, &hs, leftInput, rightInput, &post, out)

--- a/pkg/sql/distsqlrun/joinerbase.go
+++ b/pkg/sql/distsqlrun/joinerbase.go
@@ -61,10 +61,10 @@ func (jb *joinerBase) init(
 	types = append(types, leftTypes...)
 	types = append(types, rightTypes...)
 
-	if err := jb.onCond.init(onExpr, types, flowCtx.evalCtx); err != nil {
+	if err := jb.onCond.init(onExpr, types, &flowCtx.evalCtx); err != nil {
 		return err
 	}
-	return jb.out.init(post, types, flowCtx.evalCtx, output)
+	return jb.out.init(post, types, &flowCtx.evalCtx, output)
 }
 
 // render evaluates the provided on-condition and constructs a row with columns

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -70,7 +70,7 @@ func newJoinReader(
 		types[i] = spec.Table.Columns[i].Type
 	}
 
-	if err := jr.out.init(post, types, flowCtx.evalCtx, output); err != nil {
+	if err := jr.out.init(post, types, &flowCtx.evalCtx, output); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/distsqlrun/joinreader_test.go
+++ b/pkg/sql/distsqlrun/joinreader_test.go
@@ -96,7 +96,7 @@ func TestJoinReader(t *testing.T) {
 	}
 	for _, c := range testCases {
 		flowCtx := FlowCtx{
-			evalCtx:  &parser.EvalContext{},
+			evalCtx:  parser.EvalContext{},
 			txnProto: &roachpb.Transaction{},
 			clientDB: kvDB,
 		}

--- a/pkg/sql/distsqlrun/mergejoiner_test.go
+++ b/pkg/sql/distsqlrun/mergejoiner_test.go
@@ -289,7 +289,7 @@ func TestMergeJoiner(t *testing.T) {
 		leftInput := NewRowBuffer(nil, c.inputs[0])
 		rightInput := NewRowBuffer(nil, c.inputs[1])
 		out := &RowBuffer{}
-		flowCtx := FlowCtx{evalCtx: &parser.EvalContext{}}
+		flowCtx := FlowCtx{evalCtx: parser.EvalContext{}}
 
 		post := PostProcessSpec{OutputColumns: c.outCols}
 		m, err := newMergeJoiner(&flowCtx, &ms, leftInput, rightInput, &post, out)

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -228,7 +228,7 @@ func newNoopProcessor(
 	flowCtx *FlowCtx, input RowSource, post *PostProcessSpec, output RowReceiver,
 ) (*noopProcessor, error) {
 	n := &noopProcessor{flowCtx: flowCtx, input: input}
-	if err := n.out.init(post, input.Types(), flowCtx.evalCtx, output); err != nil {
+	if err := n.out.init(post, input.Types(), &flowCtx.evalCtx, output); err != nil {
 		return nil, err
 	}
 	return n, nil

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -99,16 +99,22 @@ func (ds *ServerImpl) setupFlow(
 	flowCtx := FlowCtx{
 		AmbientContext: ds.AmbientContext,
 		id:             req.Flow.FlowID,
-		evalCtx:        &ds.evalCtx,
-		rpcCtx:         ds.RPCContext,
-		txnProto:       &req.Txn,
-		clientDB:       ds.DB,
-		testingKnobs:   ds.TestingKnobs,
+		// TODO(andrei): more fields from evalCtx need to be initialized (#13821).
+		evalCtx:      ds.evalCtx,
+		rpcCtx:       ds.RPCContext,
+		txnProto:     &req.Txn,
+		clientDB:     ds.DB,
+		testingKnobs: ds.TestingKnobs,
+	}
+	ctx = flowCtx.AnnotateCtx(ctx)
+	flowCtx.evalCtx.Ctx = func() context.Context {
+		// TODO(andrei): This is wrong. Each processor should override Ctx with its
+		// own context.
+		return ctx
 	}
 
 	f := newFlow(flowCtx, ds.flowRegistry, syncFlowConsumer)
 	flowCtx.AddLogTagStr("f", f.id.Short())
-	ctx = flowCtx.AnnotateCtx(ctx)
 	if err := f.setupFlow(ctx, &req.Flow); err != nil {
 		log.Error(ctx, err)
 		sp.Finish()

--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -48,7 +48,7 @@ func newSorter(
 		matchLen: spec.OrderingMatchLen,
 		limit:    spec.Limit,
 	}
-	if err := s.out.init(post, input.Types(), flowCtx.evalCtx, output); err != nil {
+	if err := s.out.init(post, input.Types(), &flowCtx.evalCtx, output); err != nil {
 		return nil, err
 	}
 	return s, nil

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -92,7 +92,7 @@ func newTableReader(
 	for i := range types {
 		types[i] = spec.Table.Columns[i].Type
 	}
-	if err := tr.out.init(post, types, flowCtx.evalCtx, output); err != nil {
+	if err := tr.out.init(post, types, &flowCtx.evalCtx, output); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -115,7 +115,7 @@ func TestTableReader(t *testing.T) {
 		ts.Table = *td
 
 		flowCtx := FlowCtx{
-			evalCtx:  &parser.EvalContext{},
+			evalCtx:  parser.EvalContext{},
 			txnProto: &roachpb.Transaction{},
 			clientDB: kvDB,
 		}

--- a/pkg/sql/distsqlrun/values.go
+++ b/pkg/sql/distsqlrun/values.go
@@ -48,7 +48,7 @@ func newValuesProcessor(
 	for i := range v.columns {
 		types[i] = v.columns[i].Type
 	}
-	if err := v.out.init(post, types, flowCtx.evalCtx, output); err != nil {
+	if err := v.out.init(post, types, &flowCtx.evalCtx, output); err != nil {
 		return nil, err
 	}
 	return v, nil

--- a/pkg/sql/empty.go
+++ b/pkg/sql/empty.go
@@ -16,7 +16,11 @@
 
 package sql
 
-import "github.com/cockroachdb/cockroach/pkg/sql/parser"
+import (
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+)
 
 // emptyNode is a planNode with no columns and either no rows (default) or a single row with empty
 // results (if results is initialized to true). The former is used for nodes that have no results
@@ -27,12 +31,12 @@ type emptyNode struct {
 	results bool
 }
 
-func (*emptyNode) Columns() ResultColumns  { return nil }
-func (*emptyNode) Ordering() orderingInfo  { return orderingInfo{} }
-func (*emptyNode) Values() parser.Datums   { return nil }
-func (*emptyNode) Start() error            { return nil }
-func (*emptyNode) MarkDebug(_ explainMode) {}
-func (*emptyNode) Close()                  {}
+func (*emptyNode) Columns() ResultColumns      { return nil }
+func (*emptyNode) Ordering() orderingInfo      { return orderingInfo{} }
+func (*emptyNode) Values() parser.Datums       { return nil }
+func (*emptyNode) Start(context.Context) error { return nil }
+func (*emptyNode) MarkDebug(_ explainMode)     {}
+func (*emptyNode) Close(context.Context)       {}
 
 func (e *emptyNode) DebugValues() debugValues {
 	return debugValues{
@@ -43,7 +47,7 @@ func (e *emptyNode) DebugValues() debugValues {
 	}
 }
 
-func (e *emptyNode) Next() (bool, error) {
+func (e *emptyNode) Next(context.Context) (bool, error) {
 	r := e.results
 	e.results = false
 	return r, nil

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -51,7 +51,9 @@ var explainStrings = map[explainMode]string{
 // info about the wrapped statement.
 //
 // Privileges: the same privileges as the statement being explained.
-func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, error) {
+func (p *planner) Explain(
+	ctx context.Context, n *parser.Explain, autoCommit bool,
+) (planNode, error) {
 	mode := explainNone
 
 	optimized := true
@@ -132,7 +134,7 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, error) 
 
 	p.evalCtx.SkipNormalize = !normalizeExprs
 
-	plan, err := p.newPlan(n.Statement, nil, autoCommit)
+	plan, err := p.newPlan(ctx, n.Statement, nil, autoCommit)
 	if err != nil {
 		return nil, err
 	}
@@ -247,9 +249,15 @@ var debugColumns = ResultColumns{
 
 func (*explainDebugNode) Columns() ResultColumns { return debugColumns }
 func (*explainDebugNode) Ordering() orderingInfo { return orderingInfo{} }
-func (n *explainDebugNode) Start() error         { return n.plan.Start() }
-func (n *explainDebugNode) Next() (bool, error)  { return n.plan.Next() }
-func (n *explainDebugNode) Close()               { n.plan.Close() }
+func (n *explainDebugNode) Start(ctx context.Context) error {
+	return n.plan.Start(ctx)
+}
+func (n *explainDebugNode) Next(ctx context.Context) (bool, error) {
+	return n.plan.Next(ctx)
+}
+func (n *explainDebugNode) Close(ctx context.Context) {
+	n.plan.Close(ctx)
+}
 
 func (n *explainDebugNode) Values() parser.Datums {
 	vals := n.plan.DebugValues()
@@ -289,7 +297,7 @@ type explainDistSQLNode struct {
 func (*explainDistSQLNode) Ordering() orderingInfo   { return orderingInfo{} }
 func (*explainDistSQLNode) MarkDebug(_ explainMode)  {}
 func (*explainDistSQLNode) DebugValues() debugValues { return debugValues{} }
-func (n *explainDistSQLNode) Close()                 {}
+func (n *explainDistSQLNode) Close(context.Context)  {}
 
 var explainDistSQLColumns = ResultColumns{
 	{Name: "Automatic", Typ: parser.TypeBool},
@@ -299,7 +307,7 @@ var explainDistSQLColumns = ResultColumns{
 
 func (*explainDistSQLNode) Columns() ResultColumns { return explainDistSQLColumns }
 
-func (n *explainDistSQLNode) Start() error {
+func (n *explainDistSQLNode) Start(context.Context) error {
 	// Trigger limit propagation.
 	setUnlimited(n.plan)
 
@@ -328,7 +336,7 @@ func (n *explainDistSQLNode) Start() error {
 	return nil
 }
 
-func (n *explainDistSQLNode) Next() (bool, error) {
+func (n *explainDistSQLNode) Next(context.Context) (bool, error) {
 	if n.done {
 		return false, nil
 	}

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -19,6 +19,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 )
 
@@ -102,7 +104,9 @@ var emptyString = parser.NewDString("")
 
 // populateExplain invokes explain() with a makeRow method
 // which populates a valuesNode.
-func (p *planner) populateExplain(e *explainer, v *valuesNode, plan planNode) error {
+func (p *planner) populateExplain(
+	ctx context.Context, e *explainer, v *valuesNode, plan planNode,
+) error {
 	e.makeRow = func(level int, name, field, description string, plan planNode) {
 		if e.err != nil {
 			return
@@ -122,18 +126,18 @@ func (p *planner) populateExplain(e *explainer, v *valuesNode, plan planNode) er
 				row = append(row, emptyString, emptyString)
 			}
 		}
-		if _, err := v.rows.AddRow(row); err != nil {
+		if _, err := v.rows.AddRow(ctx, row); err != nil {
 			e.err = err
 		}
 	}
 
 	e.err = nil
-	_ = walkPlan(plan, e.observer())
+	_ = walkPlan(ctx, plan, e.observer())
 	return e.err
 }
 
 // planToString uses explain() to build a string representation of the planNode.
-func planToString(plan planNode) string {
+func planToString(ctx context.Context, plan planNode) string {
 	var buf bytes.Buffer
 	e := explainer{
 		showMetadata: true,
@@ -154,7 +158,7 @@ func planToString(plan planNode) string {
 			}
 		},
 	}
-	_ = walkPlan(plan, e.observer())
+	_ = walkPlan(ctx, plan, e.observer())
 	return buf.String()
 }
 
@@ -184,7 +188,7 @@ func (e *explainer) expr(nodeName, fieldName string, n int, expr parser.Expr) {
 }
 
 // enterNode implements the planObserver interface.
-func (e *explainer) enterNode(name string, plan planNode) bool {
+func (e *explainer) enterNode(_ context.Context, name string, plan planNode) bool {
 	desc := ""
 	if e.doIndent {
 		desc = fmt.Sprintf("%*s-> %s", e.level*3, " ", name)
@@ -267,20 +271,22 @@ type explainPlanNode struct {
 	optimized bool
 }
 
-func (e *explainPlanNode) Next() (bool, error)        { return e.results.Next() }
+func (e *explainPlanNode) Next(ctx context.Context) (bool, error) {
+	return e.results.Next(ctx)
+}
 func (e *explainPlanNode) Columns() ResultColumns     { return e.results.Columns() }
 func (e *explainPlanNode) Ordering() orderingInfo     { return e.results.Ordering() }
 func (e *explainPlanNode) Values() parser.Datums      { return e.results.Values() }
 func (e *explainPlanNode) DebugValues() debugValues   { return debugValues{} }
 func (e *explainPlanNode) MarkDebug(mode explainMode) {}
-func (e *explainPlanNode) Start() error {
+func (e *explainPlanNode) Start(ctx context.Context) error {
 	// Note that we don't call start on e.plan. That's on purpose, Start() can
 	// have side effects. And it's supposed to not be needed for the way in which
 	// we're going to use e.plan.
-	return e.p.populateExplain(&e.explainer, e.results, e.plan)
+	return e.p.populateExplain(ctx, &e.explainer, e.results, e.plan)
 }
 
-func (e *explainPlanNode) Close() {
-	e.plan.Close()
-	e.results.Close()
+func (e *explainPlanNode) Close(ctx context.Context) {
+	e.plan.Close(ctx)
+	e.results.Close(ctx)
 }

--- a/pkg/sql/filter.go
+++ b/pkg/sql/filter.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
@@ -53,12 +55,14 @@ func (f *filterNode) IndexedVarFormat(buf *bytes.Buffer, fl parser.FmtFlags, idx
 }
 
 // Start implements the planNode interface.
-func (f *filterNode) Start() error { return f.source.plan.Start() }
+func (f *filterNode) Start(ctx context.Context) error {
+	return f.source.plan.Start(ctx)
+}
 
 // Next implements the planNode interface.
-func (f *filterNode) Next() (bool, error) {
+func (f *filterNode) Next(ctx context.Context) (bool, error) {
 	for {
-		if next, err := f.source.plan.Next(); !next {
+		if next, err := f.source.plan.Next(ctx); !next {
 			return false, err
 		}
 
@@ -102,7 +106,9 @@ func (f *filterNode) DebugValues() debugValues {
 	return f.debugVals
 }
 
-func (f *filterNode) Close()                 { f.source.plan.Close() }
+func (f *filterNode) Close(ctx context.Context) {
+	f.source.plan.Close(ctx)
+}
 func (f *filterNode) Values() parser.Datums  { return f.source.plan.Values() }
 func (f *filterNode) Columns() ResultColumns { return f.source.plan.Columns() }
 func (f *filterNode) Ordering() orderingInfo { return f.source.plan.Ordering() }

--- a/pkg/sql/generator.go
+++ b/pkg/sql/generator.go
@@ -19,6 +19,8 @@ package sql
 import (
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/pkg/errors"
 )
@@ -47,7 +49,7 @@ type valueGenerator struct {
 
 // makeGenerator creates a valueGenerator instance that wraps a call to a
 // generator function.
-func (p *planner) makeGenerator(t *parser.FuncExpr) (planNode, error) {
+func (p *planner) makeGenerator(ctx context.Context, t *parser.FuncExpr) (planNode, error) {
 	origName := t.Func.String()
 
 	if err := p.parser.AssertNoAggregationOrWindowing(t, "FROM", p.session.SearchPath); err != nil {
@@ -55,7 +57,7 @@ func (p *planner) makeGenerator(t *parser.FuncExpr) (planNode, error) {
 	}
 
 	normalized, err := p.analyzeExpr(
-		t, multiSourceInfo{}, parser.IndexedVarHelper{}, parser.TypeAny, false, "FROM",
+		ctx, t, multiSourceInfo{}, parser.IndexedVarHelper{}, parser.TypeAny, false, "FROM",
 	)
 	if err != nil {
 		return nil, err
@@ -86,7 +88,7 @@ func (p *planner) makeGenerator(t *parser.FuncExpr) (planNode, error) {
 	}, nil
 }
 
-func (n *valueGenerator) Start() error {
+func (n *valueGenerator) Start(context.Context) error {
 	expr, err := n.expr.Eval(&n.p.evalCtx)
 	if err != nil {
 		return err
@@ -102,12 +104,12 @@ func (n *valueGenerator) Start() error {
 	return nil
 }
 
-func (n *valueGenerator) Next() (bool, error) {
+func (n *valueGenerator) Next(context.Context) (bool, error) {
 	n.rowCount++
 	return n.gen.Next()
 }
 
-func (n *valueGenerator) Close() {
+func (n *valueGenerator) Close(context.Context) {
 	if n.gen != nil {
 		n.gen.Close()
 	}

--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -19,6 +19,8 @@ package sql
 import (
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -237,14 +239,14 @@ func (n *indexJoinNode) DebugValues() debugValues {
 	return n.debugVals
 }
 
-func (n *indexJoinNode) Start() error {
-	if err := n.table.Start(); err != nil {
+func (n *indexJoinNode) Start(ctx context.Context) error {
+	if err := n.table.Start(ctx); err != nil {
 		return err
 	}
-	return n.index.Start()
+	return n.index.Start(ctx)
 }
 
-func (n *indexJoinNode) Next() (bool, error) {
+func (n *indexJoinNode) Next(ctx context.Context) (bool, error) {
 	// Loop looking up the next row. We either are going to pull a row from the
 	// table or a batch of rows from the index. If we pull a batch of rows from
 	// the index we perform another iteration of the loop looking for rows in the
@@ -253,7 +255,7 @@ func (n *indexJoinNode) Next() (bool, error) {
 	for tableLookup := (len(n.table.spans) > 0); true; tableLookup = true {
 		// First, try to pull a row from the table.
 		if tableLookup {
-			next, err := n.table.Next()
+			next, err := n.table.Next(ctx)
 			if err != nil {
 				return false, err
 			}
@@ -270,7 +272,7 @@ func (n *indexJoinNode) Next() (bool, error) {
 		n.table.spans = n.table.spans[:0]
 
 		for len(n.table.spans) < indexJoinBatchSize {
-			if next, err := n.index.Next(); !next {
+			if next, err := n.index.Next(ctx); !next {
 				// The index is out of rows or an error occurred.
 				if err != nil {
 					return false, err
@@ -309,13 +311,13 @@ func (n *indexJoinNode) Next() (bool, error) {
 		}
 
 		if log.V(3) {
-			log.Infof(n.index.p.ctx(), "table scan: %s", sqlbase.PrettySpans(n.table.spans, 0))
+			log.Infof(ctx, "table scan: %s", sqlbase.PrettySpans(n.table.spans, 0))
 		}
 	}
 	return false, nil
 }
 
-func (n *indexJoinNode) Close() {
-	n.index.Close()
-	n.table.Close()
+func (n *indexJoinNode) Close(ctx context.Context) {
+	n.index.Close(ctx)
+	n.table.Close(ctx)
 }

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -19,6 +19,8 @@ package sql
 import (
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -50,14 +52,14 @@ type insertNode struct {
 //   Notes: postgres requires INSERT. No "on duplicate key update" option.
 //          mysql requires INSERT. Also requires UPDATE on "ON DUPLICATE KEY UPDATE".
 func (p *planner) Insert(
-	n *parser.Insert, desiredTypes []parser.Type, autoCommit bool,
+	ctx context.Context, n *parser.Insert, desiredTypes []parser.Type, autoCommit bool,
 ) (planNode, error) {
 	tn, err := p.getAliasedTableName(n.Table)
 	if err != nil {
 		return nil, err
 	}
 
-	en, err := p.makeEditNode(tn, autoCommit, privilege.INSERT)
+	en, err := p.makeEditNode(ctx, tn, autoCommit, privilege.INSERT)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +121,7 @@ func (p *planner) Insert(
 	// Create the plan for the data source.
 	// This performs type checking on source expressions, collecting
 	// types for placeholders in the process.
-	rows, err := p.newPlan(insertRows, desiredTypesFromSelect, false)
+	rows, err := p.newPlan(ctx, insertRows, desiredTypesFromSelect, false)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +131,7 @@ func (p *planner) Insert(
 	}
 
 	fkTables := tablesNeededForFKs(*en.tableDesc, CheckInserts)
-	if err := p.fillFKTableMap(fkTables); err != nil {
+	if err := p.fillFKTableMap(ctx, fkTables); err != nil {
 		return nil, err
 	}
 	ri, err := MakeRowInserter(p.txn, en.tableDesc, fkTables, cols, checkFKs)
@@ -180,13 +182,14 @@ func (p *planner) Insert(
 				}
 			}
 
-			helper, err := p.makeUpsertHelper(tn, en.tableDesc, ri.insertCols, updateCols, updateExprs, conflictIndex)
+			helper, err := p.makeUpsertHelper(
+				ctx, tn, en.tableDesc, ri.insertCols, updateCols, updateExprs, conflictIndex)
 			if err != nil {
 				return nil, err
 			}
 
 			fkTables := tablesNeededForFKs(*en.tableDesc, CheckUpdates)
-			if err := p.fillFKTableMap(fkTables); err != nil {
+			if err := p.fillFKTableMap(ctx, fkTables); err != nil {
 				return nil, err
 			}
 			tw = &tableUpserter{
@@ -209,11 +212,12 @@ func (p *planner) Insert(
 		tw: tw,
 	}
 
-	if err := in.checkHelper.init(p, tn, en.tableDesc); err != nil {
+	if err := in.checkHelper.init(ctx, p, tn, en.tableDesc); err != nil {
 		return nil, err
 	}
 
-	if err := in.run.initEditNode(&in.editNodeBase, rows, n.Returning, desiredTypes); err != nil {
+	if err := in.run.initEditNode(
+		ctx, &in.editNodeBase, rows, n.Returning, desiredTypes); err != nil {
 		return nil, err
 	}
 
@@ -262,7 +266,7 @@ func ProcessDefaultColumns(
 	return cols, defaultExprs, err
 }
 
-func (n *insertNode) Start() error {
+func (n *insertNode) Start(ctx context.Context) error {
 	// Prepare structures for building values to pass to rh.
 	if n.rh.exprs != nil {
 		// In some cases (e.g. `INSERT INTO t (a) ...`) rowVals does not contain all the table
@@ -286,20 +290,19 @@ func (n *insertNode) Start() error {
 		}
 	}
 
-	if err := n.run.startEditNode(&n.editNodeBase, n.tw); err != nil {
+	if err := n.run.startEditNode(ctx, &n.editNodeBase, n.tw); err != nil {
 		return err
 	}
 
 	return n.run.tw.init(n.p.txn)
 }
 
-func (n *insertNode) Close() {
-	n.run.rows.Close()
+func (n *insertNode) Close(ctx context.Context) {
+	n.run.rows.Close(ctx)
 }
 
-func (n *insertNode) Next() (bool, error) {
-	ctx := n.editNodeBase.p.ctx()
-	if next, err := n.run.rows.Next(); !next {
+func (n *insertNode) Next(ctx context.Context) (bool, error) {
+	if next, err := n.run.rows.Next(ctx); !next {
 		if err == nil {
 			// We're done. Finish the batch.
 			err = n.tw.finalize(ctx)

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -17,6 +17,8 @@
 package sql
 
 import (
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -39,17 +41,17 @@ var _ sqlutil.InternalExecutor = InternalExecutor{}
 // ExecuteStatementInTransaction executes the supplied SQL statement as part of
 // the supplied transaction. Statements are currently executed as the root user.
 func (ie InternalExecutor) ExecuteStatementInTransaction(
-	opName string, txn *client.Txn, statement string, qargs ...interface{},
+	ctx context.Context, opName string, txn *client.Txn, statement string, qargs ...interface{},
 ) (int, error) {
 	p := makeInternalPlanner(opName, txn, security.RootUser, ie.LeaseManager.memMetrics)
 	defer finishInternalPlanner(p)
 	p.leaseMgr = ie.LeaseManager
-	return p.exec(statement, qargs...)
+	return p.exec(ctx, statement, qargs...)
 }
 
 // GetTableSpan gets the key span for a SQL table, including any indices.
 func (ie InternalExecutor) GetTableSpan(
-	user string, txn *client.Txn, dbName, tableName string,
+	ctx context.Context, user string, txn *client.Txn, dbName, tableName string,
 ) (roachpb.Span, error) {
 	// Lookup the table ID.
 	p := makeInternalPlanner("get-table-span", txn, user, ie.LeaseManager.memMetrics)
@@ -57,7 +59,7 @@ func (ie InternalExecutor) GetTableSpan(
 	p.leaseMgr = ie.LeaseManager
 
 	tn := parser.TableName{DatabaseName: parser.Name(dbName), TableName: parser.Name(tableName)}
-	tableID, err := getTableID(p, &tn)
+	tableID, err := getTableID(ctx, p, &tn)
 	if err != nil {
 		return roachpb.Span{}, err
 	}
@@ -70,7 +72,7 @@ func (ie InternalExecutor) GetTableSpan(
 }
 
 // getTableID retrieves the table ID for the specified table.
-func getTableID(p *planner, tn *parser.TableName) (sqlbase.ID, error) {
+func getTableID(ctx context.Context, p *planner, tn *parser.TableName) (sqlbase.ID, error) {
 	if err := tn.QualifyWithDatabase(p.session.Database); err != nil {
 		return 0, err
 	}
@@ -83,7 +85,7 @@ func getTableID(p *planner, tn *parser.TableName) (sqlbase.ID, error) {
 		return virtual.GetID(), nil
 	}
 
-	dbID, err := p.getDatabaseID(tn.Database())
+	dbID, err := p.getDatabaseID(ctx, tn.Database())
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/sql/join_predicate.go
+++ b/pkg/sql/join_predicate.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -143,7 +145,7 @@ func (p *joinPredicate) tryAddEqualityFilter(filter parser.Expr, left, right *da
 
 // makeOnPredicate constructs a joinPredicate object for joins with a ON clause.
 func (p *planner) makeOnPredicate(
-	left, right *dataSourceInfo, expr parser.Expr,
+	ctx context.Context, left, right *dataSourceInfo, expr parser.Expr,
 ) (*joinPredicate, *dataSourceInfo, error) {
 	pred, info, err := makeEqualityPredicate(left, right, nil, nil, 0, nil)
 	if err != nil {
@@ -151,7 +153,7 @@ func (p *planner) makeOnPredicate(
 	}
 
 	// Determine the on condition expression.
-	onCond, err := p.analyzeExpr(expr, multiSourceInfo{info}, pred.iVarHelper, parser.TypeBool, true, "ON")
+	onCond, err := p.analyzeExpr(ctx, expr, multiSourceInfo{info}, pred.iVarHelper, parser.TypeBool, true, "ON")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/sql/lease_internal_test.go
+++ b/pkg/sql/lease_internal_test.go
@@ -159,7 +159,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	var leases []*LeaseState
 	err := kvDB.Txn(context.TODO(), func(txn *client.Txn) error {
 		for i := 0; i < 3; i++ {
-			lease, err := leaseManager.acquireFreshestFromStore(txn, tableDesc.ID)
+			lease, err := leaseManager.acquireFreshestFromStore(txn.Context, txn, tableDesc.ID)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -179,7 +179,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	}
 
 	if err := ts.purgeOldLeases(
-		kvDB, false, 1 /* minVersion */, leaseManager); err != nil {
+		context.TODO(), kvDB, false, 1 /* minVersion */, leaseManager); err != nil {
 		t.Fatal(err)
 	}
 
@@ -370,7 +370,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	var lease *LeaseState
 	if err := kvDB.Txn(context.TODO(), func(txn *client.Txn) error {
 		var err error
-		lease, err = leaseManager.AcquireByName(txn, tableDesc.ParentID, "test")
+		lease, err = leaseManager.AcquireByName(txn.Context, txn, tableDesc.ParentID, "test")
 		return err
 	}); err != nil {
 		t.Fatal(err)
@@ -401,7 +401,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 		var leaseByName *LeaseState
 		if err := kvDB.Txn(context.TODO(), func(txn *client.Txn) error {
 			var err error
-			lease, err := leaseManager.AcquireByName(txn, tableDesc.ParentID, "test")
+			lease, err := leaseManager.AcquireByName(txn.Context, txn, tableDesc.ParentID, "test")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -416,7 +416,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 			// Start the race: signal the other guy to release, and we do another
 			// acquire at the same time.
 			leaseChan <- lease
-			leaseByName, err = leaseManager.AcquireByName(txn, tableDesc.ParentID, "test")
+			leaseByName, err = leaseManager.AcquireByName(txn.Context, txn, tableDesc.ParentID, "test")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -483,7 +483,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 		go func() {
 			defer wg.Done()
 			err := kvDB.Txn(context.TODO(), func(txn *client.Txn) error {
-				lease, err := leaseManager.acquireFreshestFromStore(txn, tableDesc.ID)
+				lease, err := leaseManager.acquireFreshestFromStore(txn.Context, txn, tableDesc.ID)
 				if err != nil {
 					return err
 				}

--- a/pkg/sql/mon/mem_usage_test.go
+++ b/pkg/sql/mon/mem_usage_test.go
@@ -218,8 +218,8 @@ func TestMemoryAccount(t *testing.T) {
 
 	var a1, a2 MemoryAccount
 
-	m.OpenAccount(ctx, &a1)
-	m.OpenAccount(ctx, &a2)
+	m.OpenAccount(&a1)
+	m.OpenAccount(&a2)
 
 	if err := m.GrowAccount(ctx, &a1, 10); err != nil {
 		t.Fatalf("monitor refused allocation: %v", err)

--- a/pkg/sql/ordinality.go
+++ b/pkg/sql/ordinality.go
@@ -16,7 +16,11 @@
 
 package sql
 
-import "github.com/cockroachdb/cockroach/pkg/sql/parser"
+import (
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+)
 
 // ordinalityNode represents a node that adds an "ordinality" column
 // to its child node which numbers the rows it produces. Used to
@@ -79,8 +83,8 @@ func (p *planner) wrapOrdinality(ds planDataSource) planDataSource {
 	return ds
 }
 
-func (o *ordinalityNode) Next() (bool, error) {
-	hasNext, err := o.source.Next()
+func (o *ordinalityNode) Next(ctx context.Context) (bool, error) {
+	hasNext, err := o.source.Next(ctx)
 	if !hasNext || err != nil {
 		return hasNext, err
 	}
@@ -97,5 +101,7 @@ func (o *ordinalityNode) Values() parser.Datums      { return o.row }
 func (o *ordinalityNode) DebugValues() debugValues   { return o.source.DebugValues() }
 func (o *ordinalityNode) MarkDebug(mode explainMode) { o.source.MarkDebug(mode) }
 func (o *ordinalityNode) Columns() ResultColumns     { return o.columns }
-func (o *ordinalityNode) Start() error               { return o.source.Start() }
-func (o *ordinalityNode) Close()                     { o.source.Close() }
+func (o *ordinalityNode) Start(ctx context.Context) error {
+	return o.source.Start(ctx)
+}
+func (o *ordinalityNode) Close(ctx context.Context) { o.source.Close(ctx) }

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -1568,7 +1568,7 @@ var Builtins = map[string][]Builtin{
 			ReturnType: fixedReturnType(TypeString),
 			fn: func(ctx *EvalContext, args Datums) (Datum, error) {
 				r, err := ctx.Planner.QueryRow(
-					"SELECT indexdef FROM pg_catalog.pg_indexes WHERE crdb_oid=$1", args[0])
+					ctx.Ctx(), "SELECT indexdef FROM pg_catalog.pg_indexes WHERE crdb_oid=$1", args[0])
 				if err != nil {
 					return nil, err
 				}
@@ -1606,7 +1606,8 @@ var Builtins = map[string][]Builtin{
 			ReturnType: fixedReturnType(TypeString),
 			fn: func(ctx *EvalContext, args Datums) (Datum, error) {
 				oid := args[0]
-				t, err := ctx.Planner.QueryRow("SELECT rolname FROM pg_catalog.pg_roles WHERE oid=$1", oid)
+				t, err := ctx.Planner.QueryRow(
+					ctx.Ctx(), "SELECT rolname FROM pg_catalog.pg_roles WHERE oid=$1", oid)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -1720,8 +1720,11 @@ func (e *MultipleResultsError) Error() string {
 type EvalPlanner interface {
 	// QueryRow executes a SQL query string where exactly 1 result row is
 	// expected and returns that row.
-	QueryRow(sql string, args ...interface{}) (Datums, error)
+	QueryRow(ctx context.Context, sql string, args ...interface{}) (Datums, error)
 }
+
+// contextHolder is a wrapper that returns a Context.
+type contextHolder func() context.Context
 
 // EvalContext defines the context in which to evaluate an expression, allowing
 // the retrieval of state such as the node ID or statement start time.
@@ -1745,6 +1748,14 @@ type EvalContext struct {
 	// unqualified table name. Names in the search path are normalized already.
 	// This must not be modified (this is shared from the session).
 	SearchPath SearchPath
+	// Ctx represents the context in which the expression is evaluated. This will
+	// point to the Session's context container.
+	// NOTE: seems a bit lazy to hold a pointer to the session's context here,
+	// instead of making sure the right context is explicitly set before the
+	// EvalContext is used. But there's already precedent with the Location field,
+	// and also at the time of writing, EvalContexts are initialized with the
+	// planner and not mutated.
+	Ctx contextHolder
 
 	Planner EvalPlanner
 
@@ -1995,7 +2006,11 @@ func queryOid(ctx *EvalContext, typ *OidColType, d Datum) (Datum, error) {
 		panic(fmt.Sprintf("invalid argument to OID cast: %s", d))
 	}
 	results, err := ctx.Planner.QueryRow(
-		fmt.Sprintf("SELECT oid, %s FROM pg_catalog.%s WHERE %s = $1", info.nameCol, info.tableName, queryCol), d)
+		ctx.Ctx(),
+		fmt.Sprintf(
+			"SELECT oid, %s FROM pg_catalog.%s WHERE %s = $1",
+			info.nameCol, info.tableName, queryCol),
+		d)
 	if err != nil {
 		if _, ok := err.(*MultipleResultsError); ok {
 			return nil, errors.Errorf("more than one %s named %s", info.objName, d)

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"unicode"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -88,7 +90,7 @@ CREATE TABLE pg_catalog.pg_am (
 	amtype CHAR
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
 		h.writeStr(cockroachIndexEncoding)
 		return addRow(
@@ -111,7 +113,7 @@ CREATE TABLE pg_catalog.pg_attrdef (
 	adsrc STRING
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
 		return forEachTableDesc(p,
 			func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
@@ -163,7 +165,7 @@ CREATE TABLE pg_catalog.pg_attribute (
 	attfdwoptions STRING
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
 		return forEachTableDesc(p,
 			func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
@@ -259,7 +261,7 @@ CREATE TABLE pg_catalog.pg_class (
 	reloptions STRING
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
 		return forEachTableDesc(p,
 			func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
@@ -349,7 +351,7 @@ CREATE TABLE pg_catalog.pg_collation (
   collctype STRING
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
 		for _, tag := range collate.Supported() {
 			collName := tag.String()
@@ -435,7 +437,7 @@ CREATE TABLE pg_catalog.pg_constraint (
 	consrc STRING
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
 		return forEachTableDescWithTableLookup(p,
 			func(
@@ -605,7 +607,7 @@ CREATE TABLE pg_catalog.pg_database (
 	datacl STRING
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
 		return forEachDatabaseDesc(p, func(db *sqlbase.DatabaseDescriptor) error {
 			return addRow(
@@ -665,7 +667,7 @@ CREATE TABLE pg_catalog.pg_depend (
   deptype CHAR
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
 		db, err := p.getDatabaseDesc(pgCatalogName)
 		if err != nil {
@@ -738,7 +740,7 @@ CREATE TABLE pg_catalog.pg_description (
 	description STRING
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		// Comments on database objects are not currently supported.
 		return nil
 	},
@@ -754,7 +756,7 @@ CREATE TABLE pg_catalog.pg_enum (
   enumlabel STRING
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		// Enum types are not currently supported.
 		return nil
 	},
@@ -773,7 +775,7 @@ CREATE TABLE pg_catalog.pg_extension (
   extcondition STRING
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		// Extensions are not supported.
 		return nil
 	},
@@ -793,7 +795,7 @@ CREATE TABLE pg_catalog.pg_foreign_server (
   srvoptions STRING
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		// Foreign servers are not supported.
 		return nil
 	},
@@ -808,7 +810,7 @@ CREATE TABLE pg_catalog.pg_foreign_table (
   ftoptions STRING
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		// Foreign tables are not supported.
 		return nil
 	},
@@ -839,7 +841,7 @@ CREATE TABLE pg_catalog.pg_index (
     indpred STRING
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
 		return forEachTableDesc(p,
 			func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
@@ -904,7 +906,7 @@ CREATE TABLE pg_catalog.pg_indexes (
 	indexdef STRING
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
 		return forEachTableDesc(p,
 			func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
@@ -997,7 +999,7 @@ CREATE TABLE pg_catalog.pg_inherits (
 	inhseqno INT
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		// Table inheritance is not supported.
 		return nil
 	},
@@ -1013,7 +1015,7 @@ CREATE TABLE pg_catalog.pg_namespace (
 	aclitem STRING
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
 		return forEachDatabaseDesc(p, func(db *sqlbase.DatabaseDescriptor) error {
 			return addRow(
@@ -1076,7 +1078,7 @@ CREATE TABLE pg_catalog.pg_proc (
 	proacl STRING
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
 		dbDesc, err := p.getDatabaseDesc(pgCatalogName)
 		if err != nil {
@@ -1200,7 +1202,7 @@ CREATE TABLE pg_catalog.pg_range (
 	rngsubdiff INT
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		// We currently do not support any range types, so this table is empty.
 		// This table should be populated when any range types are added to
 		// oidToDatum (and therefore pg_type).
@@ -1226,13 +1228,13 @@ CREATE TABLE pg_catalog.pg_roles (
 	rolconfig STRING
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		// We intentionally do not check if the user has access to system.user.
 		// Because Postgres allows access to pg_roles by non-privileged users, we
 		// need to do the same. This shouldn't be an issue, because pg_roles doesn't
 		// include sensitive information such as password hashes.
 		h := makeOidHasher()
-		return forEachUser(p,
+		return forEachUser(ctx, p,
 			func(username string) error {
 				isRoot := parser.DBool(username == security.RootUser)
 				return addRow(
@@ -1282,7 +1284,7 @@ CREATE TABLE pg_catalog.pg_settings (
     pending_restart BOOL
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		for _, vName := range varNames {
 			gen := varGen[vName]
 			value := gen(p)
@@ -1327,7 +1329,7 @@ CREATE TABLE pg_catalog.pg_tables (
 	rowsecurity BOOL
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		return forEachTableDesc(p,
 			func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
 				if table.IsView() {
@@ -1435,7 +1437,7 @@ CREATE TABLE pg_catalog.pg_type (
 	typacl STRING
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
 		for oid, typ := range parser.OidToType {
 			cat := typCategory(typ)
@@ -1579,7 +1581,7 @@ CREATE TABLE pg_catalog.pg_views (
 	definition STRING
 );
 `,
-	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		return forEachTableDesc(p,
 			func(db *sqlbase.DatabaseDescriptor, desc *sqlbase.TableDescriptor) error {
 				if !desc.IsView() {

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -406,8 +406,8 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 		// authentication has completed successfully, so as to prevent a DoS
 		// attack: many open-but-unauthenticated connections that exhaust
 		// the memory available to connections already open.
-		acc := s.connMonitor.MakeBoundAccount(ctx)
-		if err := acc.Grow(baseSQLMemoryBudget); err != nil {
+		acc := s.connMonitor.MakeBoundAccount()
+		if err := acc.Grow(ctx, baseSQLMemoryBudget); err != nil {
 			return errors.Errorf("unable to pre-allocate %d bytes for this connection: %v",
 				baseSQLMemoryBudget, err)
 		}

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -17,6 +17,8 @@
 package sql
 
 import (
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -35,7 +37,9 @@ type planMaker interface {
 	//
 	// This method should not be used directly; instead prefer makePlan()
 	// or prepare() below.
-	newPlan(stmt parser.Statement, desiredTypes []parser.Type, autoCommit bool) (planNode, error)
+	newPlan(
+		ctx context.Context, stmt parser.Statement, desiredTypes []parser.Type, autoCommit bool,
+	) (planNode, error)
 
 	// makePlan prepares the query plan for a single SQL statement.  it
 	// calls newPlan() then optimizePlan() on the result.  Execution must
@@ -54,7 +58,7 @@ type planMaker interface {
 	// commit the transaction along with other KV operations.
 	// Note: The autoCommit parameter enables operations to enable the
 	// 1PC optimization. This is a bit hackish/preliminary at present.
-	makePlan(stmt parser.Statement, autoCommit bool) (planNode, error)
+	makePlan(ctx context.Context, stmt parser.Statement, autoCommit bool) (planNode, error)
 
 	// prepare does the same checks as makePlan but skips building some
 	// data structures necessary for execution, based on the assumption
@@ -63,7 +67,7 @@ type planMaker interface {
 	// SQL statement and determine types for placeholders. However it is
 	// not appropriate to call optimizePlan(), Next() or Values() on a plan
 	// object created with prepare().
-	prepare(stmt parser.Statement) (planNode, error)
+	prepare(ctx context.Context, stmt parser.Statement) (planNode, error)
 }
 
 var _ planMaker = &planner{}
@@ -112,7 +116,7 @@ type planNode interface {
 	// Note: Don't use directly. Use startPlan() instead.
 	//
 	// Available after optimizePlan() (or makePlan).
-	Start() error
+	Start(ctx context.Context) error
 
 	// Next performs one unit of work, returning false if an error is
 	// encountered or if there is no more work to do. For statements
@@ -122,7 +126,7 @@ type planNode interface {
 	//
 	// Available after Start(). It is illegal to call Next() after it returns
 	// false.
-	Next() (bool, error)
+	Next(ctx context.Context) (bool, error)
 
 	// Values returns the values at the current row. The result is only valid
 	// until the next call to Next().
@@ -144,7 +148,7 @@ type planNode interface {
 	// This method should be called if the node has been used in any way (any
 	// methods on it have been called) after it was constructed. Note that this
 	// doesn't imply that Start() has been necessarily called.
-	Close()
+	Close(ctx context.Context)
 }
 
 // planNodeFastPath is implemented by nodes that can perform all their
@@ -157,6 +161,7 @@ type planNodeFastPath interface {
 }
 
 var _ planNode = &alterTableNode{}
+var _ planNode = &copyNode{}
 var _ planNode = &createDatabaseNode{}
 var _ planNode = &createIndexNode{}
 var _ planNode = &createTableNode{}
@@ -171,7 +176,9 @@ var _ planNode = &dropViewNode{}
 var _ planNode = &emptyNode{}
 var _ planNode = &explainDebugNode{}
 var _ planNode = &explainDistSQLNode{}
+var _ planNode = &explainPlanNode{}
 var _ planNode = &explainTraceNode{}
+var _ planNode = &hookFnNode{}
 var _ planNode = &filterNode{}
 var _ planNode = &groupNode{}
 var _ planNode = &indexJoinNode{}
@@ -190,8 +197,10 @@ var _ planNode = &valuesNode{}
 var _ planNode = &windowNode{}
 
 // makePlan implements the Planner interface.
-func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, error) {
-	plan, err := p.newPlan(stmt, nil, autoCommit)
+func (p *planner) makePlan(
+	ctx context.Context, stmt parser.Statement, autoCommit bool,
+) (planNode, error) {
+	plan, err := p.newPlan(ctx, stmt, nil, autoCommit)
 	if err != nil {
 		return nil, err
 	}
@@ -200,23 +209,23 @@ func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, er
 	}
 
 	needed := allColumns(plan)
-	plan, err = p.optimizePlan(plan, needed)
+	plan, err = p.optimizePlan(ctx, plan, needed)
 	if err != nil {
 		return nil, err
 	}
 
 	if log.V(3) {
-		log.Infof(p.ctx(), "statement %s compiled to:\n%s", stmt, planToString(plan))
+		log.Infof(ctx, "statement %s compiled to:\n%s", stmt, planToString(ctx, plan))
 	}
 	return plan, nil
 }
 
 // startPlan starts the plan and all its sub-query nodes.
-func (p *planner) startPlan(plan planNode) error {
-	if err := p.startSubqueryPlans(plan); err != nil {
+func (p *planner) startPlan(ctx context.Context, plan planNode) error {
+	if err := p.startSubqueryPlans(ctx, plan); err != nil {
 		return err
 	}
-	if err := plan.Start(); err != nil {
+	if err := plan.Start(ctx); err != nil {
 		return err
 	}
 	// Trigger limit propagation through the plan and sub-queries.
@@ -224,14 +233,14 @@ func (p *planner) startPlan(plan planNode) error {
 	return nil
 }
 
-func (p *planner) maybePlanHook(stmt parser.Statement) (planNode, error) {
+func (p *planner) maybePlanHook(ctx context.Context, stmt parser.Statement) (planNode, error) {
 	// TODO(dan): This iteration makes the plan dispatch no longer constant
 	// time. We could fix that with a map of `reflect.Type` but including
 	// reflection in such a primary codepath is unfortunate. Instead, the
 	// upcoming IR work will provide unique numeric type tags, which will
 	// elegantly solve this.
 	for _, planHook := range planHooks {
-		if fn, header, err := planHook(p.ctx(), stmt, p); err != nil {
+		if fn, header, err := planHook(ctx, stmt, p); err != nil {
 			return nil, err
 		} else if fn != nil {
 			return &hookFnNode{f: fn, header: header}, nil
@@ -243,7 +252,7 @@ func (p *planner) maybePlanHook(stmt parser.Statement) (planNode, error) {
 // newPlan constructs a planNode from a statement. This is used
 // recursively by the various node constructors.
 func (p *planner) newPlan(
-	stmt parser.Statement, desiredTypes []parser.Type, autoCommit bool,
+	ctx context.Context, stmt parser.Statement, desiredTypes []parser.Type, autoCommit bool,
 ) (planNode, error) {
 	tracing.AnnotateTrace()
 
@@ -256,7 +265,7 @@ func (p *planner) newPlan(
 		p.txn.SetSystemConfigTrigger()
 	}
 
-	if plan, err := p.maybePlanHook(stmt); plan != nil || err != nil {
+	if plan, err := p.maybePlanHook(ctx, stmt); plan != nil || err != nil {
 		return plan, err
 	}
 
@@ -266,53 +275,53 @@ func (p *planner) newPlan(
 	case *parser.BeginTransaction:
 		return p.BeginTransaction(n)
 	case CopyDataBlock:
-		return p.CopyData(n, autoCommit)
+		return p.CopyData(ctx, n, autoCommit)
 	case *parser.CopyFrom:
-		return p.CopyFrom(n, autoCommit)
+		return p.CopyFrom(ctx, n, autoCommit)
 	case *parser.CreateDatabase:
 		return p.CreateDatabase(n)
 	case *parser.CreateIndex:
 		return p.CreateIndex(n)
 	case *parser.CreateTable:
-		return p.CreateTable(n)
+		return p.CreateTable(ctx, n)
 	case *parser.CreateUser:
 		return p.CreateUser(n)
 	case *parser.CreateView:
-		return p.CreateView(n)
+		return p.CreateView(ctx, n)
 	case *parser.Delete:
-		return p.Delete(n, desiredTypes, autoCommit)
+		return p.Delete(ctx, n, desiredTypes, autoCommit)
 	case *parser.DropDatabase:
-		return p.DropDatabase(n)
+		return p.DropDatabase(ctx, n)
 	case *parser.DropIndex:
 		return p.DropIndex(n)
 	case *parser.DropTable:
-		return p.DropTable(n)
+		return p.DropTable(ctx, n)
 	case *parser.DropView:
-		return p.DropView(n)
+		return p.DropView(ctx, n)
 	case *parser.Explain:
-		return p.Explain(n, autoCommit)
+		return p.Explain(ctx, n, autoCommit)
 	case *parser.Grant:
-		return p.Grant(n)
+		return p.Grant(ctx, n)
 	case *parser.Help:
-		return p.Help(n)
+		return p.Help(ctx, n)
 	case *parser.Insert:
-		return p.Insert(n, desiredTypes, autoCommit)
+		return p.Insert(ctx, n, desiredTypes, autoCommit)
 	case *parser.ParenSelect:
-		return p.newPlan(n.Select, desiredTypes, autoCommit)
+		return p.newPlan(ctx, n.Select, desiredTypes, autoCommit)
 	case *parser.RenameColumn:
-		return p.RenameColumn(n)
+		return p.RenameColumn(ctx, n)
 	case *parser.RenameDatabase:
-		return p.RenameDatabase(n)
+		return p.RenameDatabase(ctx, n)
 	case *parser.RenameIndex:
-		return p.RenameIndex(n)
+		return p.RenameIndex(ctx, n)
 	case *parser.RenameTable:
-		return p.RenameTable(n)
+		return p.RenameTable(ctx, n)
 	case *parser.Revoke:
-		return p.Revoke(n)
+		return p.Revoke(ctx, n)
 	case *parser.Select:
-		return p.Select(n, desiredTypes, autoCommit)
+		return p.Select(ctx, n, desiredTypes, autoCommit)
 	case *parser.SelectClause:
-		return p.SelectClause(n, nil, nil, desiredTypes, publicColumns)
+		return p.SelectClause(ctx, n, nil, nil, desiredTypes, publicColumns)
 	case *parser.Set:
 		return p.Set(n)
 	case *parser.SetTimeZone:
@@ -324,78 +333,78 @@ func (p *planner) newPlan(
 	case *parser.Show:
 		return p.Show(n)
 	case *parser.ShowColumns:
-		return p.ShowColumns(n)
+		return p.ShowColumns(ctx, n)
 	case *parser.ShowConstraints:
-		return p.ShowConstraints(n)
+		return p.ShowConstraints(ctx, n)
 	case *parser.ShowCreateTable:
-		return p.ShowCreateTable(n)
+		return p.ShowCreateTable(ctx, n)
 	case *parser.ShowCreateView:
-		return p.ShowCreateView(n)
+		return p.ShowCreateView(ctx, n)
 	case *parser.ShowDatabases:
-		return p.ShowDatabases(n)
+		return p.ShowDatabases(ctx, n)
 	case *parser.ShowGrants:
-		return p.ShowGrants(n)
+		return p.ShowGrants(ctx, n)
 	case *parser.ShowIndex:
-		return p.ShowIndex(n)
+		return p.ShowIndex(ctx, n)
 	case *parser.ShowTables:
-		return p.ShowTables(n)
+		return p.ShowTables(ctx, n)
 	case *parser.ShowUsers:
-		return p.ShowUsers(n)
+		return p.ShowUsers(ctx, n)
 	case *parser.Split:
-		return p.Split(n)
+		return p.Split(ctx, n)
 	case *parser.Truncate:
-		return p.Truncate(n)
+		return p.Truncate(ctx, n)
 	case *parser.UnionClause:
-		return p.UnionClause(n, desiredTypes, autoCommit)
+		return p.UnionClause(ctx, n, desiredTypes, autoCommit)
 	case *parser.Update:
-		return p.Update(n, desiredTypes, autoCommit)
+		return p.Update(ctx, n, desiredTypes, autoCommit)
 	case *parser.ValuesClause:
-		return p.ValuesClause(n, desiredTypes)
+		return p.ValuesClause(ctx, n, desiredTypes)
 	default:
 		return nil, errors.Errorf("unknown statement type: %T", stmt)
 	}
 }
 
-func (p *planner) prepare(stmt parser.Statement) (planNode, error) {
-	if plan, err := p.maybePlanHook(stmt); plan != nil || err != nil {
+func (p *planner) prepare(ctx context.Context, stmt parser.Statement) (planNode, error) {
+	if plan, err := p.maybePlanHook(ctx, stmt); plan != nil || err != nil {
 		return plan, err
 	}
 
 	switch n := stmt.(type) {
 	case *parser.Delete:
-		return p.Delete(n, nil, false)
+		return p.Delete(ctx, n, nil, false)
 	case *parser.Help:
-		return p.Help(n)
+		return p.Help(ctx, n)
 	case *parser.Insert:
-		return p.Insert(n, nil, false)
+		return p.Insert(ctx, n, nil, false)
 	case *parser.Select:
-		return p.Select(n, nil, false)
+		return p.Select(ctx, n, nil, false)
 	case *parser.SelectClause:
-		return p.SelectClause(n, nil, nil, nil, publicColumns)
+		return p.SelectClause(ctx, n, nil, nil, nil, publicColumns)
 	case *parser.Show:
 		return p.Show(n)
 	case *parser.ShowCreateTable:
-		return p.ShowCreateTable(n)
+		return p.ShowCreateTable(ctx, n)
 	case *parser.ShowCreateView:
-		return p.ShowCreateView(n)
+		return p.ShowCreateView(ctx, n)
 	case *parser.ShowColumns:
-		return p.ShowColumns(n)
+		return p.ShowColumns(ctx, n)
 	case *parser.ShowDatabases:
-		return p.ShowDatabases(n)
+		return p.ShowDatabases(ctx, n)
 	case *parser.ShowGrants:
-		return p.ShowGrants(n)
+		return p.ShowGrants(ctx, n)
 	case *parser.ShowIndex:
-		return p.ShowIndex(n)
+		return p.ShowIndex(ctx, n)
 	case *parser.ShowConstraints:
-		return p.ShowConstraints(n)
+		return p.ShowConstraints(ctx, n)
 	case *parser.ShowTables:
-		return p.ShowTables(n)
+		return p.ShowTables(ctx, n)
 	case *parser.ShowUsers:
-		return p.ShowUsers(n)
+		return p.ShowUsers(ctx, n)
 	case *parser.Split:
-		return p.Split(n)
+		return p.Split(ctx, n)
 	case *parser.Update:
-		return p.Update(n, nil, false)
+		return p.Update(ctx, n, nil, false)
 	default:
 		// Other statement types do not support placeholders so there is no need
 		// for any special handling here.

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -63,13 +63,11 @@ type hookFnNode struct {
 	resIdx int
 }
 
-var _ planNode = &hookFnNode{}
-
 func (*hookFnNode) Ordering() orderingInfo  { return orderingInfo{} }
 func (*hookFnNode) MarkDebug(_ explainMode) {}
-func (*hookFnNode) Close()                  {}
+func (*hookFnNode) Close(context.Context)   {}
 
-func (f *hookFnNode) Start() error {
+func (f *hookFnNode) Start(context.Context) error {
 	var err error
 	f.res, err = f.f()
 	f.resIdx = -1
@@ -78,7 +76,7 @@ func (f *hookFnNode) Start() error {
 func (f *hookFnNode) Columns() ResultColumns {
 	return f.header
 }
-func (f *hookFnNode) Next() (bool, error) {
+func (f *hookFnNode) Next(context.Context) (bool, error) {
 	if f.res == nil {
 		return false, nil
 	}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -124,15 +124,15 @@ type queryRunner interface {
 	parser.EvalPlanner
 
 	// queryRows executes a SQL query string where multiple result rows are returned.
-	queryRows(sql string, args ...interface{}) ([]parser.Datums, error)
+	queryRows(ctx context.Context, sql string, args ...interface{}) ([]parser.Datums, error)
 
 	// queryRowsAsRoot executes a SQL query string using security.RootUser
 	// and multiple result rows are returned.
-	queryRowsAsRoot(sql string, args ...interface{}) ([]parser.Datums, error)
+	queryRowsAsRoot(ctx context.Context, sql string, args ...interface{}) ([]parser.Datums, error)
 
 	// exec executes a SQL query string and returns the number of rows
 	// affected.
-	exec(sql string, args ...interface{}) (int, error)
+	exec(ctx context.Context, sql string, args ...interface{}) (int, error)
 
 	// The following methods can be used during testing.
 
@@ -174,11 +174,6 @@ type queryRunner interface {
 }
 
 var _ queryRunner = &planner{}
-
-// ctx returns the current session context (suitable for logging/tracing).
-func (p *planner) ctx() context.Context {
-	return p.session.Ctx()
-}
 
 func (p *planner) ExecCfg() *ExecutorConfig {
 	return p.execCfg
@@ -233,11 +228,14 @@ func (p *planner) resetContexts() {
 		Database:   p.session.Database,
 		SearchPath: p.session.SearchPath,
 		Planner:    p,
+		Ctx:        p.session.Ctx,
 	}
 }
 
 // runShowTransactionState returns the state of current transaction.
-func (p *planner) runShowTransactionState(txnState *txnState, implicitTxn bool) (Result, error) {
+func (p *planner) runShowTransactionState(
+	ctx context.Context, txnState *txnState, implicitTxn bool,
+) (Result, error) {
 	var result Result
 	result.PGTag = (*parser.Show)(nil).StatementTag()
 	result.Type = (*parser.Show)(nil).StatementType()
@@ -247,8 +245,10 @@ func (p *planner) runShowTransactionState(txnState *txnState, implicitTxn bool) 
 	if implicitTxn {
 		state = NoTxn
 	}
-	if _, err := result.Rows.AddRow(parser.Datums{parser.NewDString(state.String())}); err != nil {
-		result.Rows.Close()
+	if _, err := result.Rows.AddRow(
+		ctx, parser.Datums{parser.NewDString(state.String())},
+	); err != nil {
+		result.Rows.Close(ctx)
 		return result, err
 	}
 	return result, nil
@@ -308,11 +308,11 @@ func (p *planner) resetForBatch(e *Executor) {
 
 // query initializes a planNode from a SQL statement string. Close() must be
 // called on the returned planNode after use.
-func (p *planner) query(sql string, args ...interface{}) (planNode, error) {
+func (p *planner) query(ctx context.Context, sql string, args ...interface{}) (planNode, error) {
 	if log.V(2) {
-		log.Infof(p.ctx(), "internal query: %s", sql)
+		log.Infof(ctx, "internal query: %s", sql)
 		if len(args) > 0 {
-			log.Infof(p.ctx(), "placeholders: %q", args)
+			log.Infof(ctx, "placeholders: %q", args)
 		}
 	}
 	stmt, err := parser.ParseOneTraditional(sql)
@@ -320,12 +320,14 @@ func (p *planner) query(sql string, args ...interface{}) (planNode, error) {
 		return nil, err
 	}
 	golangFillQueryArguments(p.semaCtx.Placeholders, args)
-	return p.makePlan(stmt, false)
+	return p.makePlan(ctx, stmt, false)
 }
 
 // QueryRow implements the parser.EvalPlanner interface.
-func (p *planner) QueryRow(sql string, args ...interface{}) (parser.Datums, error) {
-	rows, err := p.queryRows(sql, args...)
+func (p *planner) QueryRow(
+	ctx context.Context, sql string, args ...interface{},
+) (parser.Datums, error) {
+	rows, err := p.queryRows(ctx, sql, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -340,16 +342,18 @@ func (p *planner) QueryRow(sql string, args ...interface{}) (parser.Datums, erro
 }
 
 // queryRows implements the queryRunner interface.
-func (p *planner) queryRows(sql string, args ...interface{}) ([]parser.Datums, error) {
-	plan, err := p.query(sql, args...)
+func (p *planner) queryRows(
+	ctx context.Context, sql string, args ...interface{},
+) ([]parser.Datums, error) {
+	plan, err := p.query(ctx, sql, args...)
 	if err != nil {
 		return nil, err
 	}
-	defer plan.Close()
-	if err := p.startPlan(plan); err != nil {
+	defer plan.Close(ctx)
+	if err := p.startPlan(ctx, plan); err != nil {
 		return nil, err
 	}
-	if next, err := plan.Next(); err != nil || !next {
+	if next, err := plan.Next(ctx); err != nil || !next {
 		return nil, err
 	}
 
@@ -360,7 +364,7 @@ func (p *planner) queryRows(sql string, args ...interface{}) ([]parser.Datums, e
 			rows = append(rows, valCopy)
 		}
 
-		next, err := plan.Next()
+		next, err := plan.Next(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -372,24 +376,26 @@ func (p *planner) queryRows(sql string, args ...interface{}) ([]parser.Datums, e
 }
 
 // queryRowsAsRoot implements the queryRunner interface.
-func (p *planner) queryRowsAsRoot(sql string, args ...interface{}) ([]parser.Datums, error) {
+func (p *planner) queryRowsAsRoot(
+	ctx context.Context, sql string, args ...interface{},
+) ([]parser.Datums, error) {
 	currentUser := p.session.User
 	defer func() { p.session.User = currentUser }()
 	p.session.User = security.RootUser
-	return p.queryRows(sql, args...)
+	return p.queryRows(ctx, sql, args...)
 }
 
 // exec implements the queryRunner interface.
-func (p *planner) exec(sql string, args ...interface{}) (int, error) {
-	plan, err := p.query(sql, args...)
+func (p *planner) exec(ctx context.Context, sql string, args ...interface{}) (int, error) {
+	plan, err := p.query(ctx, sql, args...)
 	if err != nil {
 		return 0, err
 	}
-	defer plan.Close()
-	if err := p.startPlan(plan); err != nil {
+	defer plan.Close(ctx)
+	if err := p.startPlan(ctx, plan); err != nil {
 		return 0, err
 	}
-	return countRowsAffected(plan)
+	return countRowsAffected(ctx, plan)
 }
 
 // setTestingVerifyMetadata implements the queryRunner interface.
@@ -440,9 +446,9 @@ func (p *planner) checkTestingVerifyMetadataOrDie(e *Executor, stmts parser.Stat
 	p.testingVerifyMetadataFn = nil
 }
 
-func (p *planner) fillFKTableMap(m tableLookupsByID) error {
+func (p *planner) fillFKTableMap(ctx context.Context, m tableLookupsByID) error {
 	for tableID := range m {
-		table, err := p.getTableLeaseByID(tableID)
+		table, err := p.getTableLeaseByID(ctx, tableID)
 		if err == errTableAdding {
 			m[tableID] = tableLookup{isAdding: true}
 			continue

--- a/pkg/sql/prepare.go
+++ b/pkg/sql/prepare.go
@@ -67,8 +67,10 @@ func (ps PreparedStatements) Exists(name string) bool {
 // New creates a new PreparedStatement with the provided name and corresponding
 // query string, using the given PlaceholderTypes hints to assist in inferring
 // placeholder types.
+//
+// ps.session.Ctx() is used as the logging context for the prepare operation.
 func (ps PreparedStatements) New(
-	ctx context.Context, e *Executor, name, query string, placeholderHints parser.PlaceholderTypes,
+	e *Executor, name, query string, placeholderHints parser.PlaceholderTypes,
 ) (*PreparedStatement, error) {
 	// Prepare the query. This completes the typing of placeholders.
 	stmt, err := e.Prepare(query, ps.session, placeholderHints)
@@ -80,12 +82,12 @@ func (ps PreparedStatements) New(
 	// statement name. When we start storing the prepared query plan
 	// during prepare, this should be tallied up to the monitor as well.
 	sz := int64(uintptr(len(query)+len(name)) + unsafe.Sizeof(*stmt))
-	if err := stmt.memAcc.Wsession(ps.session).OpenAndInit(sz); err != nil {
+	if err := stmt.memAcc.Wsession(ps.session).OpenAndInit(ps.session.Ctx(), sz); err != nil {
 		return nil, err
 	}
 
 	if prevStmt, ok := ps.Get(name); ok {
-		prevStmt.memAcc.Wsession(ps.session).Close()
+		prevStmt.memAcc.Wsession(ps.session).Close(ps.session.Ctx())
 	}
 
 	ps.stmts[name] = stmt
@@ -94,17 +96,17 @@ func (ps PreparedStatements) New(
 
 // Delete removes the PreparedStatement with the provided name from the PreparedStatements.
 // The method returns whether a statement with that name was found and removed.
-func (ps PreparedStatements) Delete(name string) bool {
+func (ps PreparedStatements) Delete(ctx context.Context, name string) bool {
 	if stmt, ok := ps.Get(name); ok {
 		if ps.session.PreparedPortals.portals != nil {
 			for portalName := range stmt.portalNames {
 				if portal, ok := ps.session.PreparedPortals.Get(name); ok {
 					delete(ps.session.PreparedPortals.portals, portalName)
-					portal.memAcc.Wsession(ps.session).Close()
+					portal.memAcc.Wsession(ps.session).Close(ctx)
 				}
 			}
 		}
-		stmt.memAcc.Wsession(ps.session).Close()
+		stmt.memAcc.Wsession(ps.session).Close(ctx)
 		delete(ps.stmts, name)
 		return true
 	}
@@ -112,19 +114,19 @@ func (ps PreparedStatements) Delete(name string) bool {
 }
 
 // closeAll de-registers all statements and portals from the monitor.
-func (ps PreparedStatements) closeAll(s *Session) {
+func (ps PreparedStatements) closeAll(ctx context.Context, s *Session) {
 	for _, stmt := range ps.stmts {
-		stmt.memAcc.Wsession(s).Close()
+		stmt.memAcc.Wsession(s).Close(ctx)
 	}
 	for _, portal := range s.PreparedPortals.portals {
-		portal.memAcc.Wsession(s).Close()
+		portal.memAcc.Wsession(s).Close(ctx)
 	}
 }
 
 // ClearStatementsAndPortals de-registers all statements and
 // portals. Afterwards none can be added any more.
-func (s *Session) ClearStatementsAndPortals() {
-	s.PreparedStatements.closeAll(s)
+func (s *Session) ClearStatementsAndPortals(ctx context.Context) {
+	s.PreparedStatements.closeAll(ctx, s)
 	s.PreparedStatements.stmts = nil
 	s.PreparedPortals.portals = nil
 }
@@ -133,8 +135,8 @@ func (s *Session) ClearStatementsAndPortals() {
 // remove all PreparedPortals from the session's PreparedPortals.
 // This is used by the "delete" message in the pgwire protocol; after DeleteAll
 // statements and portals can be added again.
-func (ps *PreparedStatements) DeleteAll() {
-	ps.closeAll(ps.session)
+func (ps *PreparedStatements) DeleteAll(ctx context.Context) {
+	ps.closeAll(ctx, ps.session)
 	ps.stmts = make(map[string]*PreparedStatement)
 	ps.session.PreparedPortals.portals = make(map[string]*PreparedPortal)
 }
@@ -178,21 +180,21 @@ func (pp PreparedPortals) Exists(name string) bool {
 // New creates a new PreparedPortal with the provided name and corresponding
 // PreparedStatement, binding the statement using the given QueryArguments.
 func (pp PreparedPortals) New(
-	name string, stmt *PreparedStatement, qargs parser.QueryArguments,
+	ctx context.Context, name string, stmt *PreparedStatement, qargs parser.QueryArguments,
 ) (*PreparedPortal, error) {
 	portal := &PreparedPortal{
 		Stmt:  stmt,
 		Qargs: qargs,
 	}
 	sz := int64(uintptr(len(name)) + unsafe.Sizeof(*portal))
-	if err := portal.memAcc.Wsession(pp.session).OpenAndInit(sz); err != nil {
+	if err := portal.memAcc.Wsession(pp.session).OpenAndInit(ctx, sz); err != nil {
 		return nil, err
 	}
 
 	stmt.portalNames[name] = struct{}{}
 
 	if prevPortal, ok := pp.Get(name); ok {
-		prevPortal.memAcc.Wsession(pp.session).Close()
+		prevPortal.memAcc.Wsession(pp.session).Close(ctx)
 	}
 
 	pp.portals[name] = portal
@@ -201,10 +203,10 @@ func (pp PreparedPortals) New(
 
 // Delete removes the PreparedPortal with the provided name from the PreparedPortals.
 // The method returns whether a portal with that name was found and removed.
-func (pp PreparedPortals) Delete(name string) bool {
+func (pp PreparedPortals) Delete(ctx context.Context, name string) bool {
 	if portal, ok := pp.Get(name); ok {
 		delete(portal.Stmt.portalNames, name)
-		portal.memAcc.Wsession(pp.session).Close()
+		portal.memAcc.Wsession(pp.session).Close(ctx)
 		delete(pp.portals, name)
 		return true
 	}

--- a/pkg/sql/returning.go
+++ b/pkg/sql/returning.go
@@ -19,6 +19,8 @@ package sql
 import (
 	"bytes"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -48,6 +50,7 @@ type returningHelper struct {
 // newReturningHelper creates a new returningHelper for use by an
 // insert/update node.
 func (p *planner) newReturningHelper(
+	ctx context.Context,
 	r parser.ReturningClause,
 	desiredTypes []parser.Type,
 	alias string,
@@ -86,7 +89,8 @@ func (p *planner) newReturningHelper(
 	rh.exprs = make([]parser.TypedExpr, 0, len(rExprs))
 	ivarHelper := parser.MakeIndexedVarHelper(rh, len(tablecols))
 	for _, target := range rExprs {
-		cols, typedExprs, _, err := p.computeRender(target, parser.TypeAny, rh.source, ivarHelper, true)
+		cols, typedExprs, _, err := p.computeRender(
+			ctx, target, parser.TypeAny, rh.source, ivarHelper, true /* allowStars */)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/row_container_test.go
+++ b/pkg/sql/row_container_test.go
@@ -38,13 +38,13 @@ func TestRowContainer(t *testing.T) {
 					resCol[i] = ResultColumn{Typ: parser.TypeInt}
 				}
 				m := mon.MakeUnlimitedMonitor(context.Background(), "test", nil, nil, math.MaxInt64)
-				rc := NewRowContainer(m.MakeBoundAccount(context.Background()), resCol, 0)
+				rc := NewRowContainer(m.MakeBoundAccount(), resCol, 0)
 				row := make(parser.Datums, numCols)
 				for i := 0; i < numRows; i++ {
 					for j := range row {
 						row[j] = parser.NewDInt(parser.DInt(i*numCols + j))
 					}
-					if _, err := rc.AddRow(row); err != nil {
+					if _, err := rc.AddRow(context.Background(), row); err != nil {
 						t.Fatal(err)
 					}
 				}

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -137,12 +139,12 @@ func (n *scanNode) disableBatchLimit() {
 	n.softLimit = 0
 }
 
-func (n *scanNode) Start() error {
+func (n *scanNode) Start(context.Context) error {
 	return n.fetcher.Init(&n.desc, n.colIdxMap, n.index, n.reverse, n.isSecondaryIndex, n.cols,
 		n.valNeededForCol, false /* returnRangeInfo */)
 }
 
-func (n *scanNode) Close() {}
+func (n *scanNode) Close(context.Context) {}
 
 // initScan sets up the rowFetcher and starts a scan.
 func (n *scanNode) initScan() error {
@@ -177,7 +179,7 @@ func (n *scanNode) initScan() error {
 }
 
 // debugNext is a helper function used by Next() when in explainDebug mode.
-func (n *scanNode) debugNext() (bool, error) {
+func (n *scanNode) debugNext(context.Context) (bool, error) {
 	// In debug mode, we output a set of debug values for each key.
 	n.debugVals.rowIdx = n.rowIndex
 	var err error
@@ -211,7 +213,7 @@ func (n *scanNode) debugNext() (bool, error) {
 	return true, nil
 }
 
-func (n *scanNode) Next() (bool, error) {
+func (n *scanNode) Next(ctx context.Context) (bool, error) {
 	tracing.AnnotateTrace()
 	if !n.scanInitialized {
 		if err := n.initScan(); err != nil {
@@ -220,7 +222,7 @@ func (n *scanNode) Next() (bool, error) {
 	}
 
 	if n.explain == explainDebug {
-		return n.debugNext()
+		return n.debugNext(ctx)
 	}
 
 	// We fetch one row at a time until we find one that passes the filter.

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -192,8 +192,9 @@ INSERT INTO t.test VALUES ('a', 'b'), ('c', 'd');
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
 
 	expectedVersion := tableDesc.Version
+	ctx := context.TODO()
 
-	desc, err := changer.MaybeIncrementVersion()
+	desc, err := changer.MaybeIncrementVersion(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +216,7 @@ INSERT INTO t.test VALUES ('a', 'b'), ('c', 'd');
 		t.Fatal(err)
 	}
 
-	desc, err = changer.MaybeIncrementVersion()
+	desc, err = changer.MaybeIncrementVersion(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -232,7 +233,7 @@ INSERT INTO t.test VALUES ('a', 'b'), ('c', 'd');
 
 	// Check that RunStateMachineBeforeBackfill doesn't do anything
 	// if there are no mutations queued.
-	if err := changer.RunStateMachineBeforeBackfill(); err != nil {
+	if err := changer.RunStateMachineBeforeBackfill(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -276,7 +277,7 @@ INSERT INTO t.test VALUES ('a', 'b'), ('c', 'd');
 		}
 		// Run two times to ensure idempotency of operations.
 		for i := 0; i < 2; i++ {
-			if err := changer.RunStateMachineBeforeBackfill(); err != nil {
+			if err := changer.RunStateMachineBeforeBackfill(ctx); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1183,10 +1184,13 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
 	id := tableDesc.ID
+	ctx := context.TODO()
 
 	upTableVersion = func() {
 		leaseMgr := s.LeaseManager().(*sql.LeaseManager)
-		if _, err := leaseMgr.Publish(id,
+		if _, err := leaseMgr.Publish(
+			ctx,
+			id,
 			func(table *sqlbase.TableDescriptor) error {
 				table.Version++
 				return nil
@@ -1198,7 +1202,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 			InitialBackoff: time.Millisecond,
 			MaxBackoff:     time.Millisecond,
 		}
-		if _, err := leaseMgr.WaitForOneVersion(id, retryOpts); err != nil {
+		if _, err := leaseMgr.WaitForOneVersion(ctx, id, retryOpts); err != nil {
 			t.Error(err)
 		}
 	}

--- a/pkg/sql/session_mem_usage.go
+++ b/pkg/sql/session_mem_usage.go
@@ -28,14 +28,14 @@ import (
 // OpenAccount interfaces between Session and mon.MemoryMonitor.
 func (s *Session) OpenAccount() WrappableMemoryAccount {
 	res := WrappableMemoryAccount{}
-	s.mon.OpenAccount(s.context, &res.acc)
+	s.mon.OpenAccount(&res.acc)
 	return res
 }
 
 // OpenAccount interfaces between TxnState and mon.MemoryMonitor.
 func (ts *txnState) OpenAccount() WrappableMemoryAccount {
 	res := WrappableMemoryAccount{}
-	ts.mon.OpenAccount(ts.Ctx, &res.acc)
+	ts.mon.OpenAccount(&res.acc)
 	return res
 }
 
@@ -45,25 +45,21 @@ type WrappableMemoryAccount struct {
 	acc mon.MemoryAccount
 }
 
-// Wsession captures the current session monitor pointer and session
-// logging context so they can be provided transparently to the other
-// Account APIs below.
+// Wsession captures the current session monitor pointer so it can be provided
+// transparently to the other Account APIs below.
 func (w *WrappableMemoryAccount) Wsession(s *Session) WrappedMemoryAccount {
 	return WrappedMemoryAccount{
 		acc: &w.acc,
 		mon: &s.sessionMon,
-		ctx: s.context,
 	}
 }
 
-// Wtxn captures the current txn-specific monitor pointer and session
-// logging context so they can be provided transparently to the other
-// Account APIs below.
+// Wtxn captures the current txn-specific monitor pointer so it can be provided
+// transparently to the other Account APIs below.
 func (w *WrappableMemoryAccount) Wtxn(s *Session) WrappedMemoryAccount {
 	return WrappedMemoryAccount{
 		acc: &w.acc,
 		mon: &s.TxnState.mon,
-		ctx: s.TxnState.Ctx,
 	}
 }
 
@@ -72,32 +68,31 @@ func (w *WrappableMemoryAccount) Wtxn(s *Session) WrappedMemoryAccount {
 type WrappedMemoryAccount struct {
 	acc *mon.MemoryAccount
 	mon *mon.MemoryMonitor
-	ctx context.Context
 }
 
 // OpenAndInit interfaces between Session and mon.MemoryMonitor.
-func (w WrappedMemoryAccount) OpenAndInit(initialAllocation int64) error {
-	return w.mon.OpenAndInitAccount(w.ctx, w.acc, initialAllocation)
+func (w WrappedMemoryAccount) OpenAndInit(ctx context.Context, initialAllocation int64) error {
+	return w.mon.OpenAndInitAccount(ctx, w.acc, initialAllocation)
 }
 
 // Grow interfaces between Session and mon.MemoryMonitor.
-func (w WrappedMemoryAccount) Grow(extraSize int64) error {
-	return w.mon.GrowAccount(w.ctx, w.acc, extraSize)
+func (w WrappedMemoryAccount) Grow(ctx context.Context, extraSize int64) error {
+	return w.mon.GrowAccount(ctx, w.acc, extraSize)
 }
 
 // Close interfaces between Session and mon.MemoryMonitor.
-func (w WrappedMemoryAccount) Close() {
-	w.mon.CloseAccount(w.ctx, w.acc)
+func (w WrappedMemoryAccount) Close(ctx context.Context) {
+	w.mon.CloseAccount(ctx, w.acc)
 }
 
 // Clear interfaces between Session and mon.MemoryMonitor.
-func (w WrappedMemoryAccount) Clear() {
-	w.mon.ClearAccount(w.ctx, w.acc)
+func (w WrappedMemoryAccount) Clear(ctx context.Context) {
+	w.mon.ClearAccount(ctx, w.acc)
 }
 
 // ResizeItem interfaces between Session and mon.MemoryMonitor.
-func (w WrappedMemoryAccount) ResizeItem(oldSize, newSize int64) error {
-	return w.mon.ResizeItem(w.ctx, w.acc, oldSize, newSize)
+func (w WrappedMemoryAccount) ResizeItem(ctx context.Context, oldSize, newSize int64) error {
+	return w.mon.ResizeItem(ctx, w.acc, oldSize, newSize)
 }
 
 // noteworthyMemoryUsageBytes is the minimum size tracked by a
@@ -148,9 +143,9 @@ func (s *Session) deriveAndStartMonitors() {
 }
 
 func (s *Session) makeBoundAccount() mon.BoundAccount {
-	return s.sessionMon.MakeBoundAccount(s.context)
+	return s.sessionMon.MakeBoundAccount()
 }
 
 func (ts *txnState) makeBoundAccount() mon.BoundAccount {
-	return ts.mon.MakeBoundAccount(ts.Ctx)
+	return ts.mon.MakeBoundAccount()
 }

--- a/pkg/sql/split.go
+++ b/pkg/sql/split.go
@@ -28,7 +28,7 @@ import (
 
 // Split executes a KV split.
 // Privileges: INSERT on table.
-func (p *planner) Split(n *parser.Split) (planNode, error) {
+func (p *planner) Split(ctx context.Context, n *parser.Split) (planNode, error) {
 	var tn *parser.TableName
 	var err error
 	if n.Index == nil {
@@ -80,7 +80,7 @@ func (p *planner) Split(n *parser.Split) (planNode, error) {
 			return nil, err
 		}
 		desired := c.Type.ToDatumType()
-		typedExpr, err := p.analyzeExpr(expr, nil, parser.IndexedVarHelper{}, desired, true, "SPLIT AT")
+		typedExpr, err := p.analyzeExpr(ctx, expr, nil, parser.IndexedVarHelper{}, desired, true, "SPLIT AT")
 		if err != nil {
 			return nil, err
 		}
@@ -103,7 +103,7 @@ type splitNode struct {
 	key       []byte
 }
 
-func (n *splitNode) Start() error {
+func (n *splitNode) Start(context.Context) error {
 	values := make([]parser.Datum, len(n.exprs))
 	colMap := make(map[sqlbase.ColumnID]int)
 	for i, e := range n.exprs {
@@ -128,7 +128,7 @@ func (n *splitNode) Start() error {
 	return n.p.execCfg.DB.AdminSplit(context.TODO(), n.key)
 }
 
-func (n *splitNode) Next() (bool, error) {
+func (n *splitNode) Next(context.Context) (bool, error) {
 	return n.key != nil, nil
 }
 
@@ -154,7 +154,7 @@ func (*splitNode) Columns() ResultColumns {
 	}
 }
 
-func (*splitNode) Close()                  {}
+func (*splitNode) Close(context.Context)   {}
 func (*splitNode) Ordering() orderingInfo  { return orderingInfo{} }
 func (*splitNode) MarkDebug(_ explainMode) {}
 

--- a/pkg/sql/sqlutil/internal_executor.go
+++ b/pkg/sql/sqlutil/internal_executor.go
@@ -16,7 +16,11 @@
 
 package sqlutil
 
-import "github.com/cockroachdb/cockroach/pkg/internal/client"
+import (
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+)
 
 // InternalExecutor is meant to be used by layers below SQL in the system that
 // nevertheless want to execute SQL queries (presumably against system tables).
@@ -26,5 +30,6 @@ type InternalExecutor interface {
 	// ExecuteStatementInTransaction executes the supplied SQL statement as part of
 	// the supplied transaction. Statements are currently executed as the root user.
 	ExecuteStatementInTransaction(
-		opName string, txn *client.Txn, statement string, params ...interface{}) (int, error)
+		ctx context.Context, opName string, txn *client.Txn, statement string, params ...interface{},
+	) (int, error)
 }

--- a/pkg/sql/subquery_test.go
+++ b/pkg/sql/subquery_test.go
@@ -19,6 +19,8 @@ package sql
 import (
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -38,11 +40,11 @@ func TestStartSubqueriesReturnsError(t *testing.T) {
 		t.Fatalf("expected to parse 1 statement, got: %d", len(stmts))
 	}
 	stmt := stmts[0]
-	plan, err := p.makePlan(stmt, false /* autoCommit */)
+	plan, err := p.makePlan(context.TODO(), stmt, false /* autoCommit */)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := p.startSubqueryPlans(plan); !testutils.IsError(err, `forced by crdb_internal\.force_retry\(\)`) {
+	if err := p.startSubqueryPlans(context.TODO(), plan); !testutils.IsError(err, `forced by crdb_internal\.force_retry\(\)`) {
 		t.Fatalf("expected error from force_retry(), got: %v", err)
 	}
 }

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -21,6 +21,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -79,7 +81,7 @@ type SchemaAccessor interface {
 
 	// getTableOrViewDesc returns a table descriptor for either a table or view,
 	// or nil if the descriptor is not found.
-	getTableOrViewDesc(tn *parser.TableName) (*sqlbase.TableDescriptor, error)
+	getTableOrViewDesc(ctx context.Context, tn *parser.TableName) (*sqlbase.TableDescriptor, error)
 
 	// getTableDesc returns a table descriptor for a table, or nil if the
 	// descriptor is not found. If you want the "not found" condition to
@@ -92,11 +94,13 @@ type SchemaAccessor interface {
 	// descriptor is not found.
 	// Returns an error if the underlying table descriptor actually
 	// represents a table rather than a view.
-	getViewDesc(tn *parser.TableName) (*sqlbase.TableDescriptor, error)
+	getViewDesc(ctx context.Context, tn *parser.TableName) (*sqlbase.TableDescriptor, error)
 
 	// mustGetTableOrViewDesc returns a table descriptor for either a table or
 	// view, or an error if the descriptor is not found.
-	mustGetTableOrViewDesc(tn *parser.TableName) (*sqlbase.TableDescriptor, error)
+	mustGetTableOrViewDesc(
+		ctx context.Context, tn *parser.TableName,
+	) (*sqlbase.TableDescriptor, error)
 
 	// mustGetTableDesc returns a table descriptor for a table, or an error if
 	// the descriptor is not found.
@@ -104,7 +108,7 @@ type SchemaAccessor interface {
 
 	// mustGetViewDesc returns a table descriptor for a view, or an error if the
 	// descriptor is not found.
-	mustGetViewDesc(tn *parser.TableName) (*sqlbase.TableDescriptor, error)
+	mustGetViewDesc(ctx context.Context, tn *parser.TableName) (*sqlbase.TableDescriptor, error)
 
 	// NB: one can use GetTableDescFromID() to retrieve a descriptor for
 	// a table from a transaction using its ID, assuming it was loaded
@@ -116,10 +120,10 @@ type SchemaAccessor interface {
 
 	// getTableLease acquires a lease for the specified table. The lease will be
 	// released when the planner closes.
-	getTableLease(tn *parser.TableName) (*sqlbase.TableDescriptor, error)
+	getTableLease(ctx context.Context, tn *parser.TableName) (*sqlbase.TableDescriptor, error)
 
 	// releaseLeases releases all leases currently held by the planner.
-	releaseLeases()
+	releaseLeases(ctx context.Context)
 
 	// writeTableDesc effectively writes a table descriptor to the
 	// database within the current planner transaction.
@@ -128,7 +132,9 @@ type SchemaAccessor interface {
 
 var _ SchemaAccessor = &planner{}
 
-func (p *planner) getTableOrViewDesc(tn *parser.TableName) (*sqlbase.TableDescriptor, error) {
+func (p *planner) getTableOrViewDesc(
+	_ context.Context, tn *parser.TableName,
+) (*sqlbase.TableDescriptor, error) {
 	return getTableOrViewDesc(p.txn, &p.session.virtualSchemas, tn)
 }
 
@@ -178,8 +184,10 @@ func getTableDesc(
 }
 
 // getViewDesc implements the SchemaAccessor interface.
-func (p *planner) getViewDesc(tn *parser.TableName) (*sqlbase.TableDescriptor, error) {
-	desc, err := p.getTableOrViewDesc(tn)
+func (p *planner) getViewDesc(
+	ctx context.Context, tn *parser.TableName,
+) (*sqlbase.TableDescriptor, error) {
+	desc, err := p.getTableOrViewDesc(ctx, tn)
 	if err != nil {
 		return desc, err
 	}
@@ -190,8 +198,10 @@ func (p *planner) getViewDesc(tn *parser.TableName) (*sqlbase.TableDescriptor, e
 }
 
 // mustGetTableOrViewDesc implements the SchemaAccessor interface.
-func (p *planner) mustGetTableOrViewDesc(tn *parser.TableName) (*sqlbase.TableDescriptor, error) {
-	desc, err := p.getTableOrViewDesc(tn)
+func (p *planner) mustGetTableOrViewDesc(
+	ctx context.Context, tn *parser.TableName,
+) (*sqlbase.TableDescriptor, error) {
+	desc, err := p.getTableOrViewDesc(ctx, tn)
 	if err != nil {
 		return nil, err
 	}
@@ -226,8 +236,10 @@ func mustGetTableDesc(
 }
 
 // mustGetViewDesc implements the SchemaAccessor interface.
-func (p *planner) mustGetViewDesc(tn *parser.TableName) (*sqlbase.TableDescriptor, error) {
-	desc, err := p.getViewDesc(tn)
+func (p *planner) mustGetViewDesc(
+	ctx context.Context, tn *parser.TableName,
+) (*sqlbase.TableDescriptor, error) {
+	desc, err := p.getViewDesc(ctx, tn)
 	if err != nil {
 		return nil, err
 	}
@@ -256,9 +268,11 @@ func filterTableState(tableDesc *sqlbase.TableDescriptor) error {
 }
 
 // getTableLease implements the SchemaAccessor interface.
-func (p *planner) getTableLease(tn *parser.TableName) (*sqlbase.TableDescriptor, error) {
+func (p *planner) getTableLease(
+	ctx context.Context, tn *parser.TableName,
+) (*sqlbase.TableDescriptor, error) {
 	if log.V(2) {
-		log.Infof(p.ctx(), "planner acquiring lease on table '%s'", tn)
+		log.Infof(ctx, "planner acquiring lease on table '%s'", tn)
 	}
 
 	isSystemDB := tn.Database() == sqlbase.SystemDB.Name
@@ -282,7 +296,7 @@ func (p *planner) getTableLease(tn *parser.TableName) (*sqlbase.TableDescriptor,
 		return tbl, nil
 	}
 
-	dbID, err := p.getDatabaseID(tn.Database())
+	dbID, err := p.getDatabaseID(ctx, tn.Database())
 	if err != nil {
 		return nil, err
 	}
@@ -297,16 +311,16 @@ func (p *planner) getTableLease(tn *parser.TableName) (*sqlbase.TableDescriptor,
 			l.ParentID == dbID {
 			lease = l
 			if log.V(2) {
-				log.Infof(p.ctx(), "found lease in planner cache for table '%s'", tn)
+				log.Infof(ctx, "found lease in planner cache for table '%s'", tn)
 			}
 			break
 		}
 	}
 
 	// If we didn't find a lease or the lease is about to expire, acquire one.
-	if lease == nil || p.removeLeaseIfExpiring(lease) {
+	if lease == nil || p.removeLeaseIfExpiring(ctx, lease) {
 		var err error
-		lease, err = p.leaseMgr.AcquireByName(p.txn, dbID, tn.Table())
+		lease, err = p.leaseMgr.AcquireByName(ctx, p.txn, dbID, tn.Table())
 		if err != nil {
 			if err == sqlbase.ErrDescriptorNotFound {
 				// Transform the descriptor error into an error that references the
@@ -317,7 +331,7 @@ func (p *planner) getTableLease(tn *parser.TableName) (*sqlbase.TableDescriptor,
 		}
 		p.leases = append(p.leases, lease)
 		if log.V(2) {
-			log.Infof(p.ctx(), "added lease on table '%s' to planner cache", tn)
+			log.Infof(ctx, "added lease on table '%s' to planner cache", tn)
 		}
 		// If the lease we just acquired expires before the txn's deadline, reduce
 		// the deadline.
@@ -327,9 +341,11 @@ func (p *planner) getTableLease(tn *parser.TableName) (*sqlbase.TableDescriptor,
 }
 
 // getTableLeaseByID is a by-ID variant of getTableLease (i.e. uses same cache).
-func (p *planner) getTableLeaseByID(tableID sqlbase.ID) (*sqlbase.TableDescriptor, error) {
+func (p *planner) getTableLeaseByID(
+	ctx context.Context, tableID sqlbase.ID,
+) (*sqlbase.TableDescriptor, error) {
 	if log.V(2) {
-		log.Infof(p.ctx(), "planner acquiring lease on table ID %d", tableID)
+		log.Infof(ctx, "planner acquiring lease on table ID %d", tableID)
 	}
 
 	if testDisableTableLeases {
@@ -350,16 +366,16 @@ func (p *planner) getTableLeaseByID(tableID sqlbase.ID) (*sqlbase.TableDescripto
 		if l.ID == tableID {
 			lease = l
 			if log.V(2) {
-				log.Infof(p.ctx(), "found lease in planner cache for table %d", tableID)
+				log.Infof(ctx, "found lease in planner cache for table %d", tableID)
 			}
 			break
 		}
 	}
 
 	// If we didn't find a lease or the lease is about to expire, acquire one.
-	if lease == nil || p.removeLeaseIfExpiring(lease) {
+	if lease == nil || p.removeLeaseIfExpiring(ctx, lease) {
 		var err error
-		lease, err = p.leaseMgr.Acquire(p.txn, tableID, 0)
+		lease, err = p.leaseMgr.Acquire(ctx, p.txn, tableID, 0)
 		if err != nil {
 			if err == sqlbase.ErrDescriptorNotFound {
 				// Transform the descriptor error into an error that references the
@@ -378,7 +394,7 @@ func (p *planner) getTableLeaseByID(tableID sqlbase.ID) (*sqlbase.TableDescripto
 
 // removeLeaseIfExpiring removes a lease and returns true if it is about to expire.
 // The method also resets the transaction deadline.
-func (p *planner) removeLeaseIfExpiring(lease *LeaseState) bool {
+func (p *planner) removeLeaseIfExpiring(ctx context.Context, lease *LeaseState) bool {
 	if lease == nil || lease.hasSomeLifeLeft(p.leaseMgr.clock) {
 		return false
 	}
@@ -392,7 +408,7 @@ func (p *planner) removeLeaseIfExpiring(lease *LeaseState) bool {
 		}
 	}
 	if idx == -1 {
-		log.Warningf(p.ctx(), "lease (%s) not found", lease)
+		log.Warningf(ctx, "lease (%s) not found", lease)
 		return false
 	}
 	p.leases[idx] = p.leases[len(p.leases)-1]
@@ -400,7 +416,7 @@ func (p *planner) removeLeaseIfExpiring(lease *LeaseState) bool {
 	p.leases = p.leases[:len(p.leases)-1]
 
 	if err := p.leaseMgr.Release(lease); err != nil {
-		log.Warning(p.ctx(), err)
+		log.Warning(ctx, err)
 	}
 
 	// Reset the deadline so that a new deadline will be set after the lease is acquired.
@@ -462,14 +478,14 @@ func (p *planner) notifySchemaChange(id sqlbase.ID, mutationID sqlbase.MutationI
 }
 
 // releaseLeases implements the SchemaAccessor interface.
-func (p *planner) releaseLeases() {
+func (p *planner) releaseLeases(ctx context.Context) {
 	if p.leases != nil {
 		if log.V(2) {
-			log.Infof(p.ctx(), "planner releasing %d leases", len(p.leases))
+			log.Infof(ctx, "planner releasing %d leases", len(p.leases))
 		}
 		for _, lease := range p.leases {
 			if err := p.leaseMgr.Release(lease); err != nil {
-				log.Warning(p.ctx(), err)
+				log.Warning(ctx, err)
 			}
 		}
 		p.leases = nil
@@ -519,7 +535,7 @@ func (p *planner) expandTableGlob(pattern parser.TablePattern) (parser.TableName
 // provided TableName is modified in-place in case of success, and
 // left unchanged otherwise.
 // The table name must not be qualified already.
-func (p *planner) searchAndQualifyDatabase(tn *parser.TableName) error {
+func (p *planner) searchAndQualifyDatabase(ctx context.Context, tn *parser.TableName) error {
 	t := *tn
 
 	descFunc := p.getTableLease
@@ -533,7 +549,7 @@ func (p *planner) searchAndQualifyDatabase(tn *parser.TableName) error {
 
 	if p.session.Database != "" {
 		t.DatabaseName = parser.Name(p.session.Database)
-		desc, err := descFunc(&t)
+		desc, err := descFunc(ctx, &t)
 		if err != nil && !sqlbase.IsUndefinedTableError(err) && !sqlbase.IsUndefinedDatabaseError(err) {
 			return err
 		}
@@ -548,7 +564,7 @@ func (p *planner) searchAndQualifyDatabase(tn *parser.TableName) error {
 	// the search path instead.
 	for _, database := range p.session.SearchPath {
 		t.DatabaseName = parser.Name(database)
-		desc, err := descFunc(&t)
+		desc, err := descFunc(ctx, &t)
 		if err != nil && !sqlbase.IsUndefinedTableError(err) && !sqlbase.IsUndefinedDatabaseError(err) {
 			return err
 		}

--- a/pkg/sql/table_test.go
+++ b/pkg/sql/table_test.go
@@ -261,7 +261,7 @@ func TestRemoveLeaseIfExpiring(t *testing.T) {
 	txn := client.Txn{Context: context.Background()}
 	p.setTxn(&txn)
 
-	if p.removeLeaseIfExpiring(nil) {
+	if p.removeLeaseIfExpiring(context.TODO(), nil) {
 		t.Error("expected false with nil input")
 	}
 
@@ -272,7 +272,7 @@ func TestRemoveLeaseIfExpiring(t *testing.T) {
 	et := hlc.Timestamp{WallTime: l1.Expiration().UnixNano()}
 	txn.UpdateDeadlineMaybe(et)
 
-	if p.removeLeaseIfExpiring(l1) {
+	if p.removeLeaseIfExpiring(context.TODO(), l1) {
 		t.Error("expected false with a non-expiring lease")
 	}
 	if d := *p.txn.GetDeadline(); d != et {
@@ -285,7 +285,7 @@ func TestRemoveLeaseIfExpiring(t *testing.T) {
 	// Add another lease.
 	l2 := &LeaseState{expiration: parser.DTimestamp{Time: time.Unix(0, mc.UnixNano()+d+1)}}
 	p.leases = append(p.leases, l2)
-	if !p.removeLeaseIfExpiring(l1) {
+	if !p.removeLeaseIfExpiring(context.TODO(), l1) {
 		t.Error("expected true with an expiring lease")
 	}
 	et = hlc.Timestamp{WallTime: l2.Expiration().UnixNano()}

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -94,7 +94,7 @@ func (ti *tableInserter) row(ctx context.Context, values parser.Datums) (parser.
 	return nil, ti.ri.InsertRow(ctx, ti.b, values, false)
 }
 
-func (ti *tableInserter) finalize(_ context.Context) error {
+func (ti *tableInserter) finalize(context.Context) error {
 	var err error
 	if ti.autoCommit {
 		// An auto-txn can commit the transaction with the batch. This is an
@@ -498,7 +498,7 @@ func (td *tableDeleter) row(ctx context.Context, values parser.Datums) (parser.D
 	return nil, td.rd.deleteRow(ctx, td.b, values)
 }
 
-func (td *tableDeleter) finalize(_ context.Context) error {
+func (td *tableDeleter) finalize(context.Context) error {
 	if td.autoCommit {
 		// An auto-txn can commit the transaction with the batch. This is an
 		// optimization to avoid an extra round-trip to the transaction

--- a/pkg/sql/targets.go
+++ b/pkg/sql/targets.go
@@ -17,6 +17,8 @@
 package sql
 
 import (
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/pkg/errors"
 )
@@ -25,6 +27,7 @@ import (
 // than one, in case there is a star). Whether star expansion occurred
 // is indicated by the third return value.
 func (p *planner) computeRender(
+	ctx context.Context,
 	target parser.SelectExpr,
 	desiredType parser.Type,
 	info *dataSourceInfo,
@@ -49,7 +52,7 @@ func (p *planner) computeRender(
 	outputName := getRenderColName(target)
 
 	normalized, err := p.analyzeExpr(
-		target.Expr, multiSourceInfo{info}, ivarHelper, desiredType, false, "")
+		ctx, target.Expr, multiSourceInfo{info}, ivarHelper, desiredType, false, "")
 	if err != nil {
 		return nil, nil, false, err
 	}

--- a/pkg/sql/trace.go
+++ b/pkg/sql/trace.go
@@ -37,14 +37,13 @@ import (
 type explainTraceNode struct {
 	plan planNode
 	// Internal state, not to be initialized.
-	earliest     time.Time
-	exhausted    bool
-	rows         []parser.Datums
-	lastTS       time.Time
-	lastPos      int
-	trace        *tracing.RecordedTrace
-	p            *planner
-	spanFinished bool
+	earliest  time.Time
+	exhausted bool
+	rows      []parser.Datums
+	lastTS    time.Time
+	lastPos   int
+	trace     *tracing.RecordedTrace
+	p         *planner
 
 	// Initialized at Start() time. When called, restores the planner's context to
 	// what it was before this node hijacked it.
@@ -96,18 +95,15 @@ func (n *explainTraceNode) Start(ctx context.Context) error {
 // happening in the current txn before explainTraceNode.Close() to happen inside
 // a recorded trace.
 //
-// !!! The facts in the TODO below are no longer true. Change accordingly.
 // TODO(andrei): This is currently called from Next(), which means that
 // `n.plan.Start()` is not traced. That's a shame, but unfortunately we can't
 // hijack in explainTraceNode.Start() because we need to only hijack after the
 // sortNode wrapping the explainTraceNode has started execution. This is because
-// the sortNode creates a BoundMemoryAccount that is destroyed after the
-// explainTraceNode.Next() has returned all the results (i.e. the point where
-// the context is unhijacked). We could hijack in Start() and unhijack in
-// Close() instead of doing it in Next(), but then we'd also be tracing that
-// sortNode, which is not part of the user's query.
-// This is caused by the fact that BoundMemoryAccount binds the session's
-// context when it's created, which is bad. Rework this once that is fixed.
+// the context that's passed to the first call of sortNode.Next() (the call
+// that's responsible for exhausting the explainTraceNode) needs to be the
+// un-hijacked one - otherwise, the hijacked ctx will be used by that call to
+// sortNode.Next() after the explandPlanNode closes the tracing span (resulting
+// in a span use-after-finish).
 func (n *explainTraceNode) hijackTxnContext(ctx context.Context) error {
 	tracingCtx, recorder, err := tracing.StartSnowballTrace(ctx, "explain trace")
 	if err != nil {
@@ -123,14 +119,9 @@ func (n *explainTraceNode) hijackTxnContext(ctx context.Context) error {
 }
 
 func (n *explainTraceNode) Close(ctx context.Context) {
-	// tracingCtx can be nil if hijackTxnContext() hasn't been called (in
-	// particular, if this node is wrapped in an EXPLAIN(PLAN)).
-	if n.tracingCtx == nil {
-		return
-	}
-	sp := opentracing.SpanFromContext(n.tracingCtx)
-	if sp != nil && !n.spanFinished {
+	if n.restorePlannerCtx != nil {
 		n.unhijackCtx()
+		sp := opentracing.SpanFromContext(n.tracingCtx)
 		sp.Finish()
 	}
 	n.plan.Close(ctx)
@@ -149,10 +140,13 @@ func (n *explainTraceNode) Next(ctx context.Context) (bool, error) {
 		if err := n.hijackTxnContext(ctx); err != nil {
 			return false, err
 		}
+		// After the call to hijackTxnContext, the current and future invocations of
+		// explainTraceNode.Next() need to use n.tracingCtx instead of the method
+		// argument.
 	}
 	for !n.exhausted && len(n.rows) <= 1 {
 		var vals debugValues
-		if next, err := n.plan.Next(ctx); !next {
+		if next, err := n.plan.Next(n.tracingCtx); !next {
 			sp := opentracing.SpanFromContext(n.tracingCtx)
 			n.exhausted = true
 			// Finish the tracing span that we began in Start().
@@ -163,7 +157,6 @@ func (n *explainTraceNode) Next(ctx context.Context) (bool, error) {
 			sp.LogFields(otlog.String("event", "tracing completed"))
 			n.unhijackCtx()
 			sp.Finish()
-			n.spanFinished = true
 		} else {
 			vals = n.plan.DebugValues()
 		}

--- a/pkg/sql/trace.go
+++ b/pkg/sql/trace.go
@@ -24,11 +24,12 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"golang.org/x/net/context"
 )
 
 // explainTraceNode is a planNode that wraps another node and converts DebugValues() results to a
@@ -87,14 +88,15 @@ func (p *planner) makeTraceNode(plan planNode) planNode {
 func (*explainTraceNode) Columns() ResultColumns { return traceColumnsWithTS }
 func (*explainTraceNode) Ordering() orderingInfo { return orderingInfo{} }
 
-func (n *explainTraceNode) Start() error {
-	return n.plan.Start()
+func (n *explainTraceNode) Start(ctx context.Context) error {
+	return n.plan.Start(ctx)
 }
 
 // hijackTxnContext hijacks the session's/txn's context, causing everything
 // happening in the current txn before explainTraceNode.Close() to happen inside
 // a recorded trace.
 //
+// !!! The facts in the TODO below are no longer true. Change accordingly.
 // TODO(andrei): This is currently called from Next(), which means that
 // `n.plan.Start()` is not traced. That's a shame, but unfortunately we can't
 // hijack in explainTraceNode.Start() because we need to only hijack after the
@@ -106,8 +108,8 @@ func (n *explainTraceNode) Start() error {
 // sortNode, which is not part of the user's query.
 // This is caused by the fact that BoundMemoryAccount binds the session's
 // context when it's created, which is bad. Rework this once that is fixed.
-func (n *explainTraceNode) hijackTxnContext() error {
-	tracingCtx, recorder, err := tracing.StartSnowballTrace(n.p.ctx(), "explain trace")
+func (n *explainTraceNode) hijackTxnContext(ctx context.Context) error {
+	tracingCtx, recorder, err := tracing.StartSnowballTrace(ctx, "explain trace")
 	if err != nil {
 		return err
 	}
@@ -120,7 +122,7 @@ func (n *explainTraceNode) hijackTxnContext() error {
 	return nil
 }
 
-func (n *explainTraceNode) Close() {
+func (n *explainTraceNode) Close(ctx context.Context) {
 	// tracingCtx can be nil if hijackTxnContext() hasn't been called (in
 	// particular, if this node is wrapped in an EXPLAIN(PLAN)).
 	if n.tracingCtx == nil {
@@ -131,7 +133,7 @@ func (n *explainTraceNode) Close() {
 		n.unhijackCtx()
 		sp.Finish()
 	}
-	n.plan.Close()
+	n.plan.Close(ctx)
 }
 
 func (n *explainTraceNode) unhijackCtx() {
@@ -140,17 +142,17 @@ func (n *explainTraceNode) unhijackCtx() {
 	n.restorePlannerCtx = nil
 }
 
-func (n *explainTraceNode) Next() (bool, error) {
+func (n *explainTraceNode) Next(ctx context.Context) (bool, error) {
 	first := n.rows == nil
 	if first {
 		n.rows = []parser.Datums{}
-		if err := n.hijackTxnContext(); err != nil {
+		if err := n.hijackTxnContext(ctx); err != nil {
 			return false, err
 		}
 	}
 	for !n.exhausted && len(n.rows) <= 1 {
 		var vals debugValues
-		if next, err := n.plan.Next(); !next {
+		if next, err := n.plan.Next(ctx); !next {
 			sp := opentracing.SpanFromContext(n.tracingCtx)
 			n.exhausted = true
 			// Finish the tracing span that we began in Start().

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -38,7 +38,7 @@ const TableTruncateChunkSize = indexTruncateChunkSize
 // Privileges: DROP on table.
 //   Notes: postgres requires TRUNCATE.
 //          mysql requires DROP (for mysql >= 5.1.16, DELETE before that).
-func (p *planner) Truncate(n *parser.Truncate) (planNode, error) {
+func (p *planner) Truncate(ctx context.Context, n *parser.Truncate) (planNode, error) {
 	// Since truncation may cascade to a given table any number of times, start by
 	// building the unique set (by ID) of tables to truncate.
 	toTruncate := make(map[sqlbase.ID]*sqlbase.TableDescriptor, len(n.Tables))
@@ -52,7 +52,7 @@ func (p *planner) Truncate(n *parser.Truncate) (planNode, error) {
 			return nil, err
 		}
 
-		tableDesc, err := p.getTableLease(tn)
+		tableDesc, err := p.getTableLease(ctx, tn)
 		if err != nil {
 			return nil, err
 		}
@@ -77,7 +77,7 @@ func (p *planner) Truncate(n *parser.Truncate) (planNode, error) {
 					continue
 				}
 
-				other, err := p.getTableLeaseByID(ref.Table)
+				other, err := p.getTableLeaseByID(ctx, ref.Table)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -79,6 +81,7 @@ func (uh *upsertHelper) IndexedVarFormat(buf *bytes.Buffer, f parser.FmtFlags, i
 }
 
 func (p *planner) makeUpsertHelper(
+	ctx context.Context,
 	tn *parser.TableName,
 	tableDesc *sqlbase.TableDescriptor,
 	insertCols []sqlbase.ColumnDescriptor,
@@ -124,7 +127,7 @@ func (p *planner) makeUpsertHelper(
 	ivarHelper := parser.MakeIndexedVarHelper(helper, len(sourceInfo.sourceColumns)+len(excludedSourceInfo.sourceColumns))
 	sources := multiSourceInfo{sourceInfo, excludedSourceInfo}
 	for _, expr := range untupledExprs {
-		normExpr, err := p.analyzeExpr(expr, sources, ivarHelper, parser.TypeAny, false, "")
+		normExpr, err := p.analyzeExpr(ctx, expr, sources, ivarHelper, parser.TypeAny, false, "")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -42,7 +42,7 @@ func GetUserHashedPassword(
 		defer finishInternalPlanner(p)
 		const getHashedPassword = `SELECT hashedPassword FROM system.users ` +
 			`WHERE username=$1`
-		values, err := p.QueryRow(getHashedPassword, normalizedUsername)
+		values, err := p.QueryRow(ctx, getHashedPassword, normalizedUsername)
 		if err != nil {
 			return errors.Errorf("error looking up user %s", normalizedUsername)
 		}

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -124,12 +124,13 @@ func (s *Store) GetDeadReplicas() roachpb.StoreDeadReplicas {
 // LogReplicaChangeTest adds a fake replica change event to the log for the
 // range which contains the given key.
 func (s *Store) LogReplicaChangeTest(
+	ctx context.Context,
 	txn *client.Txn,
 	changeType roachpb.ReplicaChangeType,
 	replica roachpb.ReplicaDescriptor,
 	desc roachpb.RangeDescriptor,
 ) error {
-	return s.logChange(txn, changeType, replica, desc)
+	return s.logChange(ctx, txn, changeType, replica, desc)
 }
 
 // ReplicateQueuePurgatoryLength returns the number of replicas in replicate

--- a/pkg/storage/log_test.go
+++ b/pkg/storage/log_test.go
@@ -155,7 +155,7 @@ func TestLogRebalances(t *testing.T) {
 	// Log several fake events using the store.
 	logEvent := func(changeType roachpb.ReplicaChangeType) {
 		if err := db.Txn(context.TODO(), func(txn *client.Txn) error {
-			return store.LogReplicaChangeTest(txn, changeType, desc.Replicas[0], *desc)
+			return store.LogReplicaChangeTest(txn.Context, txn, changeType, desc.Replicas[0], *desc)
 		}); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -2491,7 +2491,7 @@ func (r *Replica) adminSplitWithDescriptor(
 		// instead of a transaction; there's no reason this logging
 		// shouldn't be done in parallel via the batch with the updated
 		// range addressing.
-		if err := r.store.logSplit(txn, leftDesc, *rightDesc); err != nil {
+		if err := r.store.logSplit(ctx, txn, leftDesc, *rightDesc); err != nil {
 			return err
 		}
 
@@ -3327,7 +3327,7 @@ func (r *Replica) ChangeReplicas(
 		}
 
 		// Log replica change into range event log.
-		if err := r.store.logChange(txn, changeType, repDesc, updatedDesc); err != nil {
+		if err := r.store.logChange(ctx, txn, changeType, repDesc, updatedDesc); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
A BoundAccount is a MemoryAccount bound to a MemoryMonitor. When
creating a BoundAcc, we used to bind a context to be used by the Acc
throughout its lifetime. This means that the context had to stay "valid"
throughout (e.g. the span in the ctx, if any, had to stay open). This is
conceptually a problem because it means you can't open an acc in one
place and close it in a completely different place (and also diminishes
the utility of contexts, as Account operations were not logged in a
context corresponding to the function actually performing them). In
particular, this was a problem for accounts created for RowContainers
and the way how EXPLAIN(TRACE) temporarily hijacks the session's
context: a container's account could easily be bound to one of these
temporarily hijacked contexts, and closed after the corresponding span
had already been Finish()ed.

This patch plumbs through a Context to the accounts, through various
cascading layers.

A bunch of accounts are opened by various planNodes, and there the
question of what context to use I believe is not yet flushed out. So
far, planNodes that already used contexts were using the planner's
current context (which is the session's context). Not all planNodes
maintained a reference to the planner, though. Where a reference
existed, I continued using it. Where it didn't, instead of adding one,
I've bound a context directly to the planNode at ctor time.

cc @RaduBerinde in case you've got any thoughts on how `planNodes` should think about contexts.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10478)
<!-- Reviewable:end -->
