### PR TITLE
storage: prioritize up-replication over dead-replica removal

### DIFF
--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -40,8 +40,8 @@ const (
 	maxFractionUsedThreshold = 0.95
 
 	// priorities for various repair operations.
-	removeDeadReplicaPriority  float64 = 10000
-	addMissingReplicaPriority  float64 = 1000
+	addMissingReplicaPriority  float64 = 10000
+	removeDeadReplicaPriority  float64 = 1000
 	removeExtraReplicaPriority float64 = 100
 )
 

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -799,6 +799,64 @@ func TestAllocatorComputeAction(t *testing.T) {
 		desc           roachpb.RangeDescriptor
 		expectedAction AllocatorAction
 	}{
+		// Needs Three replicas, have two
+		{
+			zone: config.ZoneConfig{
+				NumReplicas:   3,
+				Constraints:   config.Constraints{Constraints: []config.Constraint{{Value: "us-east"}}},
+				RangeMinBytes: 0,
+				RangeMaxBytes: 64000,
+			},
+			desc: roachpb.RangeDescriptor{
+				Replicas: []roachpb.ReplicaDescriptor{
+					{
+						StoreID:   1,
+						NodeID:    1,
+						ReplicaID: 1,
+					},
+					{
+						StoreID:   2,
+						NodeID:    2,
+						ReplicaID: 2,
+					},
+				},
+			},
+			expectedAction: AllocatorAdd,
+		},
+		// Needs Five replicas, have four.
+		{
+			zone: config.ZoneConfig{
+				NumReplicas:   5,
+				Constraints:   config.Constraints{Constraints: []config.Constraint{{Value: "us-east"}}},
+				RangeMinBytes: 0,
+				RangeMaxBytes: 64000,
+			},
+			desc: roachpb.RangeDescriptor{
+				Replicas: []roachpb.ReplicaDescriptor{
+					{
+						StoreID:   1,
+						NodeID:    1,
+						ReplicaID: 1,
+					},
+					{
+						StoreID:   2,
+						NodeID:    2,
+						ReplicaID: 2,
+					},
+					{
+						StoreID:   3,
+						NodeID:    3,
+						ReplicaID: 3,
+					},
+					{
+						StoreID:   4,
+						NodeID:    4,
+						ReplicaID: 4,
+					},
+				},
+			},
+			expectedAction: AllocatorAdd,
+		},
 		// Needs three replicas, two are on dead stores.
 		{
 			zone: config.ZoneConfig{
@@ -924,64 +982,6 @@ func TestAllocatorComputeAction(t *testing.T) {
 				},
 			},
 			expectedAction: AllocatorRemoveDead,
-		},
-		// Needs Three replicas, have two
-		{
-			zone: config.ZoneConfig{
-				NumReplicas:   3,
-				Constraints:   config.Constraints{Constraints: []config.Constraint{{Value: "us-east"}}},
-				RangeMinBytes: 0,
-				RangeMaxBytes: 64000,
-			},
-			desc: roachpb.RangeDescriptor{
-				Replicas: []roachpb.ReplicaDescriptor{
-					{
-						StoreID:   1,
-						NodeID:    1,
-						ReplicaID: 1,
-					},
-					{
-						StoreID:   2,
-						NodeID:    2,
-						ReplicaID: 2,
-					},
-				},
-			},
-			expectedAction: AllocatorAdd,
-		},
-		// Needs Five replicas, have four.
-		{
-			zone: config.ZoneConfig{
-				NumReplicas:   5,
-				Constraints:   config.Constraints{Constraints: []config.Constraint{{Value: "us-east"}}},
-				RangeMinBytes: 0,
-				RangeMaxBytes: 64000,
-			},
-			desc: roachpb.RangeDescriptor{
-				Replicas: []roachpb.ReplicaDescriptor{
-					{
-						StoreID:   1,
-						NodeID:    1,
-						ReplicaID: 1,
-					},
-					{
-						StoreID:   2,
-						NodeID:    2,
-						ReplicaID: 2,
-					},
-					{
-						StoreID:   3,
-						NodeID:    3,
-						ReplicaID: 3,
-					},
-					{
-						StoreID:   4,
-						NodeID:    4,
-						ReplicaID: 4,
-					},
-				},
-			},
-			expectedAction: AllocatorAdd,
 		},
 		// Need three replicas, have four.
 		{


### PR DESCRIPTION
Previously, dead-replica removal was prioritized over up-replication
which could lead to situations in which the up-replication work created
by the removal of a dead-replica was starved for a significant period of
time. Additionally, dead-replica removal is quite fast in comparison to
up-replication so prioritizing it allows a whole bunch of up-replication
work to be generated fairly quickly. Now we prioritize up-replication
work over dead-replica removal. If a stable cluster (no replication work
needed), when a node dies each replicateQueue will alternate between
removing a dead replica from a range and bringing that same range back
to full replication.

Fixes #10476

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10492)
<!-- Reviewable:end -->
