### PR TITLE
storage: Move replicaGCQueue logic out of LocalProposalData

### DIFF
--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1029,7 +1029,6 @@ func TestSplitSnapshotRace_SplitWins(t *testing.T) {
 // so it still has a conflicting range.
 func TestSplitSnapshotRace_SnapshotWins(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#8416")
 	runSetupSplitSnapshotRace(t, func(mtc *multiTestContext, leftKey, rightKey roachpb.Key) {
 		// Bring the right range up first.
 		for i := 3; i <= 5; i++ {


### PR DESCRIPTION
LocalProposalData is processed only on the proposer, which is unlikely in
practice to be the node being removed (but was apparently the case in
all of our tests except in rare cases).

This deflakes the SplitSnapshotRace tests, which would occasionally end
up with the lease on a different store and miss the automatic GC (and
because the test uses a manual clock, the background replicaGCQueue scan
wouldn't GC them either).

Fixes #8416
Fixes #9204

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10500)
<!-- Reviewable:end -->
