### PR TITLE
distsql: flow diagram generator

### DIFF
--- a/pkg/sql/distsql/flow_diagram.go
+++ b/pkg/sql/distsql/flow_diagram.go
@@ -1,0 +1,275 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package distsql
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+type diagramCellType interface {
+	// summary produces a title and an arbitrary number of lines that describe a
+	// "cell" in a diagram node (input sync, processor core, or output router).
+	summary() (title string, details []string)
+}
+
+func (ord *Ordering) diagramString() string {
+	var buf bytes.Buffer
+	for i, c := range ord.Columns {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		fmt.Fprintf(&buf, "%d", c.ColIdx)
+		if c.Direction == Ordering_Column_DESC {
+			buf.WriteByte('-')
+		} else {
+			buf.WriteByte('+')
+		}
+	}
+	return buf.String()
+}
+
+func colListStr(cols []uint32) string {
+	var buf bytes.Buffer
+	for i, c := range cols {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		fmt.Fprintf(&buf, "%d", c)
+	}
+	return buf.String()
+}
+
+func (*NoopCoreSpec) summary() (string, []string) {
+	return "No-op", []string{}
+}
+
+func (tr *TableReaderSpec) summary() (string, []string) {
+	index := "primary"
+	if tr.IndexIdx > 0 {
+		index = tr.Table.Indexes[tr.IndexIdx-1].Name
+	}
+	details := []string{
+		fmt.Sprintf("%s@%s", index, tr.Table.Name),
+		colListStr(tr.OutputColumns),
+	}
+	if tr.Filter.Expr != "" {
+		details = append(details, tr.Filter.Expr)
+	}
+	// TODO(radu): a summary of the spans
+	return "TableReader", details
+}
+
+func (jr *JoinReaderSpec) summary() (string, []string) {
+	index := "primary"
+	if jr.IndexIdx > 0 {
+		index = jr.Table.Indexes[jr.IndexIdx-1].Name
+	}
+	details := []string{
+		fmt.Sprintf("%s@%s", index, jr.Table.Name),
+		colListStr(jr.OutputColumns),
+	}
+	if jr.Filter.Expr != "" {
+		details = append(details, jr.Filter.Expr)
+	}
+	return "JoinReader", details
+}
+
+func (hj *HashJoinerSpec) summary() (string, []string) {
+	details := []string{
+		fmt.Sprintf(
+			"ON left(%s)=right(%s)", colListStr(hj.LeftEqColumns), colListStr(hj.RightEqColumns),
+		),
+		colListStr(hj.OutputColumns),
+	}
+	if hj.Expr.Expr != "" {
+		details = append(details, hj.Expr.Expr)
+	}
+	return "HashJoiner", details
+}
+
+// TODO(radu): implement summary() for other core types.
+
+func (is *InputSyncSpec) summary() (string, []string) {
+	switch is.Type {
+	case InputSyncSpec_UNORDERED:
+		return "unordered", []string{}
+	case InputSyncSpec_ORDERED:
+		return "ordered", []string{is.Ordering.diagramString()}
+	default:
+		return "unknown", []string{}
+	}
+}
+
+func (r *OutputRouterSpec) summary() (string, []string) {
+	switch r.Type {
+	case OutputRouterSpec_MIRROR:
+		return "mirror", []string{}
+	case OutputRouterSpec_BY_HASH:
+		return "by hash", []string{colListStr(r.HashColumns)}
+	case OutputRouterSpec_BY_RANGE:
+		return "by range", []string{}
+	default:
+		return "unknown", []string{}
+	}
+}
+
+type diagramCell struct {
+	Title   string   `json:"title"`
+	Details []string `json:"details"`
+}
+
+type diagramProcessor struct {
+	NodeIdx int           `json:"nodeIdx"`
+	Inputs  []diagramCell `json:"inputs"`
+	Core    diagramCell   `json:"core"`
+	Outputs []diagramCell `json:"outputs"`
+}
+
+type diagramEdge struct {
+	SourceProc   int `json:"sourceProc"`
+	SourceOutput int `json:"sourceOutput"`
+	DestProc     int `json:"destProc"`
+	DestInput    int `json:"destInput"`
+}
+
+type diagramData struct {
+	NodeNames  []string           `json:"nodeNames"`
+	Processors []diagramProcessor `json:"processors"`
+	Edges      []diagramEdge      `json:"edges"`
+}
+
+func generateDiagramData(flows []FlowSpec, nodeNames []string) (diagramData, error) {
+	d := diagramData{NodeNames: nodeNames}
+
+	// inPorts maps streams to their "destination" attachment point. Only DestProc
+	// and DestInput are set in each diagramEdge value.
+	inPorts := make(map[StreamID]diagramEdge)
+	syncResponseNode := -1
+
+	pIdx := 0
+	for n := range flows {
+		for _, p := range flows[n].Processors {
+			proc := diagramProcessor{NodeIdx: n}
+			proc.Core.Title, proc.Core.Details = p.Core.GetValue().(diagramCellType).summary()
+
+			// We need explicit synchronizers if we have multiple inputs, or if the
+			// one input has multiple input streams.
+			if len(p.Input) > 1 || (len(p.Input) == 1 && len(p.Input[0].Streams) > 1) {
+				proc.Inputs = make([]diagramCell, len(p.Input))
+				for i, s := range p.Input {
+					proc.Inputs[i].Title, proc.Inputs[i].Details = s.summary()
+				}
+			} else {
+				proc.Inputs = []diagramCell{}
+			}
+
+			// Add entries in the map for the inputs.
+			for i, input := range p.Input {
+				val := diagramEdge{
+					DestProc: pIdx,
+				}
+				if len(proc.Inputs) > 0 {
+					val.DestInput = i + 1
+				}
+				for _, stream := range input.Streams {
+					inPorts[stream.StreamID] = val
+				}
+			}
+
+			for _, r := range p.Output {
+				for _, o := range r.Streams {
+					if o.Type == StreamEndpointSpec_SYNC_RESPONSE {
+						if syncResponseNode != -1 && syncResponseNode != n {
+							return diagramData{}, errors.Errorf("multiple nodes with SyncResponse")
+						}
+						syncResponseNode = n
+					}
+				}
+			}
+
+			// We need explicit routers if we have multiple outputs, or if the one
+			// output has multiple input streams.
+			if len(p.Output) > 1 || (len(p.Output) == 1 && len(p.Output[0].Streams) > 1) {
+				proc.Outputs = make([]diagramCell, len(p.Output))
+				for i, r := range p.Output {
+					proc.Outputs[i].Title, proc.Outputs[i].Details = r.summary()
+				}
+			} else {
+				proc.Outputs = []diagramCell{}
+			}
+			d.Processors = append(d.Processors, proc)
+			pIdx++
+		}
+	}
+
+	if syncResponseNode != -1 {
+		d.Processors = append(d.Processors, diagramProcessor{
+			NodeIdx: syncResponseNode,
+			Core:    diagramCell{Title: "Response", Details: []string{}},
+			Inputs:  []diagramCell{},
+			Outputs: []diagramCell{},
+		})
+	}
+
+	// Produce the edges.
+	pIdx = 0
+	for n := range flows {
+		for _, p := range flows[n].Processors {
+			for i, output := range p.Output {
+				srcOutput := 0
+				if len(d.Processors[pIdx].Outputs) > 0 {
+					srcOutput = i + 1
+				}
+				for _, o := range output.Streams {
+					edge := diagramEdge{
+						SourceProc:   pIdx,
+						SourceOutput: srcOutput,
+					}
+					if o.Type == StreamEndpointSpec_SYNC_RESPONSE {
+						edge.DestProc = len(d.Processors) - 1
+					} else {
+						to, ok := inPorts[o.StreamID]
+						if !ok {
+							return diagramData{}, errors.Errorf("stream %d has no destination", o.StreamID)
+						}
+						edge.DestProc = to.DestProc
+						edge.DestInput = to.DestInput
+					}
+					d.Edges = append(d.Edges, edge)
+				}
+			}
+			pIdx++
+		}
+	}
+	return d, nil
+}
+
+// GeneratePlanDiagram generates the json data for a flow diagram.  There should
+// be one FlowSpec per node. The function assumes that StreamIDs are unique
+// across all flows.
+func GeneratePlanDiagram(flows []FlowSpec, nodeNames []string, w io.Writer) error {
+	d, err := generateDiagramData(flows, nodeNames)
+	if err != nil {
+		return err
+	}
+	return json.NewEncoder(w).Encode(d)
+}

--- a/pkg/sql/distsql/flow_diagram_test.go
+++ b/pkg/sql/distsql/flow_diagram_test.go
@@ -1,0 +1,348 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package distsql
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+// compareDiagrams verifies that two JSON strings decode to equal diagramData
+// structures. This allows the expected string to be formatted differently.
+func compareDiagrams(t *testing.T, result string, expected string) {
+	dec := json.NewDecoder(strings.NewReader(result))
+	var resData, expData diagramData
+	if err := dec.Decode(&resData); err != nil {
+		t.Fatal(err)
+	}
+	dec = json.NewDecoder(strings.NewReader(expected))
+	if err := dec.Decode(&expData); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(resData, expData) {
+		t.Errorf("\ngot:\n%s\nwant:\n%s", result, expected)
+	}
+}
+
+func TestPlanDiagramIndexJoin(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	desc := &sqlbase.TableDescriptor{
+		Name:    "Table",
+		Indexes: []sqlbase.IndexDescriptor{{Name: "SomeIndex"}},
+	}
+	tr := TableReaderSpec{
+		Table:         *desc,
+		IndexIdx:      1,
+		OutputColumns: []uint32{0, 1},
+	}
+
+	jr := JoinReaderSpec{
+		Table:         *desc,
+		OutputColumns: []uint32{2},
+		Filter:        Expression{Expr: "$0+$1<$2"},
+	}
+
+	f1 := FlowSpec{
+		Processors: []ProcessorSpec{{
+			Core: ProcessorCoreUnion{TableReader: &tr},
+			Output: []OutputRouterSpec{{
+				Type: OutputRouterSpec_MIRROR,
+				Streams: []StreamEndpointSpec{
+					{StreamID: 0},
+				},
+			}},
+		}},
+	}
+
+	f2 := FlowSpec{
+		Processors: []ProcessorSpec{{
+			Core: ProcessorCoreUnion{TableReader: &tr},
+			Output: []OutputRouterSpec{{
+				Type: OutputRouterSpec_MIRROR,
+				Streams: []StreamEndpointSpec{
+					{StreamID: 1},
+				},
+			}},
+		}},
+	}
+
+	f3 := FlowSpec{
+		Processors: []ProcessorSpec{
+			{
+				Core: ProcessorCoreUnion{TableReader: &tr},
+				Output: []OutputRouterSpec{{
+					Type: OutputRouterSpec_MIRROR,
+					Streams: []StreamEndpointSpec{
+						{StreamID: 2},
+					},
+				}},
+			},
+			{
+				Input: []InputSyncSpec{{
+					Type:     InputSyncSpec_ORDERED,
+					Ordering: Ordering{Columns: []Ordering_Column{{1, Ordering_Column_ASC}}},
+					Streams: []StreamEndpointSpec{
+						{StreamID: 0},
+						{StreamID: 1},
+						{StreamID: 2},
+					},
+				}},
+				Core: ProcessorCoreUnion{JoinReader: &jr},
+				Output: []OutputRouterSpec{{
+					Type:    OutputRouterSpec_MIRROR,
+					Streams: []StreamEndpointSpec{{Type: StreamEndpointSpec_SYNC_RESPONSE}},
+				}}},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := GeneratePlanDiagram(
+		[]FlowSpec{f1, f2, f3}, []string{"1", "2", "3"}, &buf,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `
+		{"nodeNames":["1","2","3"],
+			"processors":[
+				{"nodeIdx":0,"inputs":[],"core":{"title":"TableReader","details":["SomeIndex@Table","0,1"]},"outputs":[]},
+				{"nodeIdx":1,"inputs":[],"core":{"title":"TableReader","details":["SomeIndex@Table","0,1"]},"outputs":[]},
+				{"nodeIdx":2,"inputs":[],"core":{"title":"TableReader","details":["SomeIndex@Table","0,1"]},"outputs":[]},
+				{"nodeIdx":2,"inputs":[{"title":"ordered","details":["1+"]}],"core":{"title":"JoinReader","details":["primary@Table","2","$0+$1\u003c$2"]},"outputs":[]},
+				{"nodeIdx":2,"inputs":[],"core":{"title":"Response","details":[]},"outputs":[]}
+			],
+			"edges":[
+				{"sourceProc":0,"sourceOutput":0,"destProc":3,"destInput":1},
+				{"sourceProc":1,"sourceOutput":0,"destProc":3,"destInput":1},
+				{"sourceProc":2,"sourceOutput":0,"destProc":3,"destInput":1},
+				{"sourceProc":3,"sourceOutput":0,"destProc":4,"destInput":0}
+			]
+		}
+	`
+
+	compareDiagrams(t, buf.String(), expected)
+}
+
+func TestPlanDiagramJoin(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	descA := &sqlbase.TableDescriptor{Name: "TableA"}
+	descB := &sqlbase.TableDescriptor{Name: "TableB"}
+
+	trA := TableReaderSpec{
+		Table:         *descA,
+		OutputColumns: []uint32{0, 1, 3},
+	}
+
+	trB := TableReaderSpec{
+		Table:         *descB,
+		OutputColumns: []uint32{1, 2, 4},
+	}
+
+	hj := HashJoinerSpec{
+		LeftEqColumns:  []uint32{0, 2},
+		RightEqColumns: []uint32{2, 1},
+		OutputColumns:  []uint32{0, 1, 2, 3, 4, 5},
+		Expr:           Expression{Expr: "$0+$1<$5"},
+	}
+
+	f1 := FlowSpec{
+		Processors: []ProcessorSpec{
+			{
+				Core: ProcessorCoreUnion{TableReader: &trA},
+				Output: []OutputRouterSpec{{
+					Type:        OutputRouterSpec_BY_HASH,
+					HashColumns: []uint32{0, 1},
+					Streams: []StreamEndpointSpec{
+						{StreamID: 11},
+						{StreamID: 12},
+					},
+				}},
+			},
+		},
+	}
+
+	f2 := FlowSpec{
+		Processors: []ProcessorSpec{
+			{
+				Core: ProcessorCoreUnion{TableReader: &trA},
+				Output: []OutputRouterSpec{{
+					Type:        OutputRouterSpec_BY_HASH,
+					HashColumns: []uint32{0, 1},
+					Streams: []StreamEndpointSpec{
+						{StreamID: 21},
+						{StreamID: 22},
+					},
+				}},
+			},
+			{
+				Input: []InputSyncSpec{
+					{
+						Type: InputSyncSpec_UNORDERED,
+						Streams: []StreamEndpointSpec{
+							{StreamID: 11},
+							{StreamID: 21},
+							{StreamID: 31},
+						},
+					},
+					{
+						Type: InputSyncSpec_UNORDERED,
+						Streams: []StreamEndpointSpec{
+							{StreamID: 41},
+							{StreamID: 51},
+						},
+					},
+				},
+				Core: ProcessorCoreUnion{HashJoiner: &hj},
+				Output: []OutputRouterSpec{{
+					Type: OutputRouterSpec_MIRROR,
+					Streams: []StreamEndpointSpec{
+						{StreamID: 101},
+					},
+				}},
+			},
+			{
+				Input: []InputSyncSpec{{
+					Type: InputSyncSpec_UNORDERED,
+					Streams: []StreamEndpointSpec{
+						{StreamID: 101},
+						{StreamID: 102},
+					},
+				}},
+				Core: ProcessorCoreUnion{Noop: &NoopCoreSpec{}},
+				Output: []OutputRouterSpec{{
+					Type:    OutputRouterSpec_MIRROR,
+					Streams: []StreamEndpointSpec{{Type: StreamEndpointSpec_SYNC_RESPONSE}},
+				}}},
+		},
+	}
+
+	f3 := FlowSpec{
+		Processors: []ProcessorSpec{
+			{
+				Core: ProcessorCoreUnion{TableReader: &trA},
+				Output: []OutputRouterSpec{{
+					Type:        OutputRouterSpec_BY_HASH,
+					HashColumns: []uint32{0, 1},
+					Streams: []StreamEndpointSpec{
+						{StreamID: 31},
+						{StreamID: 32},
+					},
+				}},
+			},
+			{
+				Core: ProcessorCoreUnion{TableReader: &trB},
+				Output: []OutputRouterSpec{{
+					Type:        OutputRouterSpec_BY_HASH,
+					HashColumns: []uint32{2, 1},
+					Streams: []StreamEndpointSpec{
+						{StreamID: 41},
+						{StreamID: 42},
+					},
+				}},
+			},
+			{
+				Input: []InputSyncSpec{
+					{
+						Type: InputSyncSpec_UNORDERED,
+						Streams: []StreamEndpointSpec{
+							{StreamID: 12},
+							{StreamID: 22},
+							{StreamID: 32},
+						},
+					},
+					{
+						Type: InputSyncSpec_UNORDERED,
+						Streams: []StreamEndpointSpec{
+							{StreamID: 42},
+							{StreamID: 52},
+						},
+					},
+				},
+				Core: ProcessorCoreUnion{HashJoiner: &hj},
+				Output: []OutputRouterSpec{{
+					Type: OutputRouterSpec_MIRROR,
+					Streams: []StreamEndpointSpec{
+						{StreamID: 101},
+					},
+				}},
+			},
+		},
+	}
+
+	f4 := FlowSpec{
+		Processors: []ProcessorSpec{{
+			Core: ProcessorCoreUnion{TableReader: &trB},
+			Output: []OutputRouterSpec{{
+				Type:        OutputRouterSpec_BY_HASH,
+				HashColumns: []uint32{2, 1},
+				Streams: []StreamEndpointSpec{
+					{StreamID: 51},
+					{StreamID: 52},
+				},
+			}},
+		}},
+	}
+
+	var buf bytes.Buffer
+	if err := GeneratePlanDiagram(
+		[]FlowSpec{f1, f2, f3, f4}, []string{"1", "2", "3", "4"}, &buf,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `
+		{
+			"nodeNames":["1","2","3","4"],
+			"processors":[
+				{"nodeIdx":0,"inputs":[],"core":{"title":"TableReader","details":["primary@TableA","0,1,3"]},"outputs":[{"title":"by hash","details":["0,1"]}]},
+				{"nodeIdx":1,"inputs":[],"core":{"title":"TableReader","details":["primary@TableA","0,1,3"]},"outputs":[{"title":"by hash","details":["0,1"]}]},
+				{"nodeIdx":1,"inputs":[{"title":"unordered","details":[]},{"title":"unordered","details":[]}],"core":{"title":"HashJoiner","details":["ON left(0,2)=right(2,1)","0,1,2,3,4,5","$0+$1\u003c$5"]},"outputs":[]},
+				{"nodeIdx":1,"inputs":[{"title":"unordered","details":[]}],"core":{"title":"No-op","details":[]},"outputs":[]},
+				{"nodeIdx":2,"inputs":[],"core":{"title":"TableReader","details":["primary@TableA","0,1,3"]},"outputs":[{"title":"by hash","details":["0,1"]}]},
+				{"nodeIdx":2,"inputs":[],"core":{"title":"TableReader","details":["primary@TableB","1,2,4"]},"outputs":[{"title":"by hash","details":["2,1"]}]},
+				{"nodeIdx":2,"inputs":[{"title":"unordered","details":[]},{"title":"unordered","details":[]}],"core":{"title":"HashJoiner","details":["ON left(0,2)=right(2,1)","0,1,2,3,4,5","$0+$1\u003c$5"]},"outputs":[]},
+				{"nodeIdx":3,"inputs":[],"core":{"title":"TableReader","details":["primary@TableB","1,2,4"]},"outputs":[{"title":"by hash","details":["2,1"]}]},
+				{"nodeIdx":1,"inputs":[],"core":{"title":"Response","details":[]},"outputs":[]}
+			],
+			"edges":[
+				{"sourceProc":0,"sourceOutput":1,"destProc":2,"destInput":1},
+				{"sourceProc":0,"sourceOutput":1,"destProc":6,"destInput":1},
+				{"sourceProc":1,"sourceOutput":1,"destProc":2,"destInput":1},
+				{"sourceProc":1,"sourceOutput":1,"destProc":6,"destInput":1},
+				{"sourceProc":2,"sourceOutput":0,"destProc":3,"destInput":1},
+				{"sourceProc":3,"sourceOutput":0,"destProc":8,"destInput":0},
+				{"sourceProc":4,"sourceOutput":1,"destProc":2,"destInput":1},
+				{"sourceProc":4,"sourceOutput":1,"destProc":6,"destInput":1},
+				{"sourceProc":5,"sourceOutput":1,"destProc":2,"destInput":2},
+				{"sourceProc":5,"sourceOutput":1,"destProc":6,"destInput":2},
+				{"sourceProc":6,"sourceOutput":0,"destProc":3,"destInput":1},
+				{"sourceProc":7,"sourceOutput":1,"destProc":2,"destInput":2},
+				{"sourceProc":7,"sourceOutput":1,"destProc":6,"destInput":2}
+			]
+		}
+	`
+
+	compareDiagrams(t, buf.String(), expected)
+}


### PR DESCRIPTION
Code to generate a json data describing a diagram of a distributed flow. This
will be used by a javascript that will display the diagram.

This will help during development/debugging. We can eventually allow the debug
endpoint to request diagrams on a running server.

Demo script that consumes this json data here:  https://raduberinde.github.io/test.html  (try to drag stuff around)

CC @irfansharif

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10505)
<!-- Reviewable:end -->
