### PR TITLE
Revert "acceptance: skip flaky TestClusterRecovery."

### DIFF
--- a/pkg/acceptance/zchaos_test.go
+++ b/pkg/acceptance/zchaos_test.go
@@ -319,8 +319,6 @@ func waitClientsStop(ctx context.Context, num int, state *testState, stallDurati
 // being killed and restarted continuously. The test doesn't measure write
 // performance, but cluster recovery.
 func TestClusterRecovery(t *testing.T) {
-	t.Skip("Skipped due to flakiness until we can investigate #8538 further.")
-
 	s := log.Scope(t)
 	defer s.Close(t)
 


### PR DESCRIPTION
Re-enable TestClusterRecovery since the expected fix has long been
merged.

Fixes #8538.

This reverts commit 8d5ab7c03e363860475f84ff6271a400559c4b18.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10514)
<!-- Reviewable:end -->
