### PR TITLE
sql/pgwire: Avoid at least one allocation for most Datum types when using PG's text format

### DIFF
--- a/pkg/sql/pgwire/encoding.go
+++ b/pkg/sql/pgwire/encoding.go
@@ -158,6 +158,10 @@ type writeBuffer struct {
 	// These two buffers are used as temporary storage. Use putbuf when the
 	// length of the required temp space is known. Use variablePutbuf when the length
 	// of the required temp space is unknown, or when a bytes.Buffer is needed.
+	//
+	// We keep both of these because there are operations that are only possible to
+	// perform (efficiently) with one or the other, such as strconv.AppendInt with
+	// putbuf or Datum.Format with variablePutbuf.
 	putbuf         [64]byte
 	variablePutbuf bytes.Buffer
 

--- a/pkg/sql/pgwire/encoding.go
+++ b/pkg/sql/pgwire/encoding.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"unsafe"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/pkg/errors"
 )
@@ -153,7 +154,12 @@ func (b *readBuffer) getUint32() (uint32, error) {
 type writeBuffer struct {
 	wrapped bytes.Buffer
 	err     error
-	putbuf  [64]byte
+
+	// These two buffers are used as temporary storage. Use putbuf when the
+	// length of the required temp space is known. Use variablePutbuf when the length
+	// of the required temp space is unknown, or when a bytes.Buffer is needed.
+	putbuf         [64]byte
+	variablePutbuf bytes.Buffer
 
 	// bytecount counts the number of bytes written across all pgwire connections, not just this
 	// buffer. This is passed in so that finishMsg can track all messages we've sent to a network
@@ -185,14 +191,33 @@ func (b *writeBuffer) nullTerminate() {
 	}
 }
 
-// writeString writes a length-prefixed string. The length is encoded as
-// an int32.
+// writeLengthPrefixedVariablePutbuf writes the current contents of
+// variablePutbuf with a length prefix. The function will reset
+// variablePutbuf.
+func (b *writeBuffer) writeLengthPrefixedVariablePutbuf() {
+	if b.err == nil {
+		b.putInt32(int32(b.variablePutbuf.Len()))
+
+		// bytes.Buffer.WriteTo resets the Buffer.
+		_, b.err = b.variablePutbuf.WriteTo(&b.wrapped)
+	}
+}
+
+// writeLengthPrefixedString writes a length-prefixed string. The
+// length is encoded as an int32.
 func (b *writeBuffer) writeLengthPrefixedString(s string) {
 	b.putInt32(int32(len(s)))
 	b.writeString(s)
 }
 
-// writeString writes a null-terminated string.
+// writeLengthPrefixedDatum writes a length-prefixed Datum in its
+// string representation. The length is encoded as an int32.
+func (b *writeBuffer) writeLengthPrefixedDatum(d parser.Datum) {
+	d.Format(&b.variablePutbuf, parser.FmtSimple)
+	b.writeLengthPrefixedVariablePutbuf()
+}
+
+// writeTerminatedString writes a null-terminated string.
 func (b *writeBuffer) writeTerminatedString(s string) {
 	b.writeString(s)
 	b.nullTerminate()

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -172,17 +172,20 @@ func (b *writeBuffer) writeTextDatum(d parser.Datum, sessionLoc *time.Location) 
 
 	case *parser.DDate:
 		t := time.Unix(int64(*v)*secondsInDay, 0)
-		s := formatTs(t, nil)
+		// Start at offset 4 because `putInt32` clobbers the first 4 bytes.
+		s := formatTs(t, nil, b.putbuf[4:4])
 		b.putInt32(int32(len(s)))
 		b.write(s)
 
 	case *parser.DTimestamp:
-		s := formatTs(v.Time, nil)
+		// Start at offset 4 because `putInt32` clobbers the first 4 bytes.
+		s := formatTs(v.Time, nil, b.putbuf[4:4])
 		b.putInt32(int32(len(s)))
 		b.write(s)
 
 	case *parser.DTimestampTZ:
-		s := formatTs(v.Time, sessionLoc)
+		// Start at offset 4 because `putInt32` clobbers the first 4 bytes.
+		s := formatTs(v.Time, sessionLoc, b.putbuf[4:4])
 		b.putInt32(int32(len(s)))
 		b.write(s)
 
@@ -339,9 +342,11 @@ func (b *writeBuffer) writeBinaryDatum(d parser.Datum, sessionLoc *time.Location
 const pgTimeStampFormatNoOffset = "2006-01-02 15:04:05.999999"
 const pgTimeStampFormat = pgTimeStampFormatNoOffset + "-07:00"
 
-// formatTs formats t into a format lib/pq understands.
-// Mostly cribbed from github.com/lib/pq.
-func formatTs(t time.Time, offset *time.Location) (b []byte) {
+// formatTs formats t with an optional offset into a format lib/pq understands,
+// appending to the provided tmp buffer and reallocating if needed. The function
+// will then return the resulting buffer. formatTs is mostly cribbed from
+// github.com/lib/pq.
+func formatTs(t time.Time, offset *time.Location, tmp []byte) (b []byte) {
 	// Need to send dates before 0001 A.D. with " BC" suffix, instead of the
 	// minus sign preferred by Go.
 	// Beware, "0000" in ISO is "1 BC", "-0001" is "2 BC" and so on
@@ -358,9 +363,9 @@ func formatTs(t time.Time, offset *time.Location) (b []byte) {
 	}
 
 	if offset != nil {
-		b = []byte(t.Format(pgTimeStampFormat))
+		b = t.AppendFormat(tmp, pgTimeStampFormat)
 	} else {
-		b = []byte(t.Format(pgTimeStampFormatNoOffset))
+		b = t.AppendFormat(tmp, pgTimeStampFormatNoOffset)
 	}
 
 	if bc {

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -151,7 +151,7 @@ func (b *writeBuffer) writeTextDatum(d parser.Datum, sessionLoc *time.Location) 
 		b.write(s)
 
 	case *parser.DDecimal:
-		b.writeLengthPrefixedString(v.Dec.String())
+		b.writeLengthPrefixedDatum(v)
 
 	case *parser.DBytes:
 		// http://www.postgresql.org/docs/current/static/datatype-binary.html#AEN5667
@@ -187,35 +187,33 @@ func (b *writeBuffer) writeTextDatum(d parser.Datum, sessionLoc *time.Location) 
 		b.write(s)
 
 	case *parser.DInterval:
-		b.writeLengthPrefixedString(v.String())
+		b.writeLengthPrefixedDatum(v)
 
 	case *parser.DTuple:
-		var tb bytes.Buffer
-		tb.WriteString("(")
+		b.variablePutbuf.WriteString("(")
 		for i, d := range *v {
 			if i > 0 {
-				tb.WriteString(",")
+				b.variablePutbuf.WriteString(",")
 			}
 			if d == parser.DNull {
 				// Emit nothing on NULL.
 				continue
 			}
-			tb.WriteString(d.String())
+			d.Format(&b.variablePutbuf, parser.FmtSimple)
 		}
-		tb.WriteString(")")
-		b.writeLengthPrefixedString(tb.String())
+		b.variablePutbuf.WriteString(")")
+		b.writeLengthPrefixedVariablePutbuf()
 
 	case *parser.DArray:
-		var tb bytes.Buffer
-		tb.WriteString("{")
+		b.variablePutbuf.WriteString("{")
 		for i, d := range *v {
 			if i > 0 {
-				tb.WriteString(",")
+				b.variablePutbuf.WriteString(",")
 			}
-			tb.WriteString(d.String())
+			d.Format(&b.variablePutbuf, parser.FmtSimple)
 		}
-		tb.WriteString("}")
-		b.writeLengthPrefixedString(tb.String())
+		b.variablePutbuf.WriteString("}")
+		b.writeLengthPrefixedVariablePutbuf()
 
 	default:
 		b.setError(errors.Errorf("unsupported type %T", d))

--- a/pkg/sql/pgwire/types_test.go
+++ b/pkg/sql/pgwire/types_test.go
@@ -67,7 +67,7 @@ func TestTimestampRoundtrip(t *testing.T) {
 		return decoded.UTC()
 	}
 
-	if actual := parse(formatTs(ts, nil)); !ts.Equal(actual) {
+	if actual := parse(formatTs(ts, nil, nil)); !ts.Equal(actual) {
 		t.Fatalf("timestamp did not roundtrip got [%s] expected [%s]", actual, ts)
 	}
 
@@ -76,7 +76,7 @@ func TestTimestampRoundtrip(t *testing.T) {
 	EST := time.FixedZone("America/New_York", 0)
 
 	for _, tz := range []*time.Location{time.UTC, CET, EST} {
-		if actual := parse(formatTs(ts, tz)); !ts.Equal(actual) {
+		if actual := parse(formatTs(ts, tz, nil)); !ts.Equal(actual) {
 			t.Fatalf("[%s]: timestamp did not roundtrip got [%s] expected [%s]", tz, actual, ts)
 		}
 	}


### PR DESCRIPTION
The first commit avoids an allocation for:
- Each `DDecimal` Datum
- Each `DInterval` Datum
- Each element in a `DTuple`
- Each element in a `DArray`

The second commit avoids an allocation for:
- Each `DDate` Datum
- Each `DTimestamp` Datum
- Each `DTimestampTZ` Datum

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10531)
<!-- Reviewable:end -->
