### PR TITLE
sql: move row allocation inside RowContainer

### DIFF
--- a/pkg/sql/row_container.go
+++ b/pkg/sql/row_container.go
@@ -138,25 +138,6 @@ func (c *RowContainer) Swap(i, j int) {
 	c.rows[i], c.rows[j] = c.rows[j], c.rows[i]
 }
 
-// PseudoPop retrieves a pointer to the last row, and decreases the
-// visible size of the RowContainer.  This is used for heap sorting in
-// sql.sortNode.  A pointer is returned to avoid an allocation when
-// passing the DTuple as an interface{} to heap.Push().
-// Note that the pointer is only valid until the next call to AddRow.
-// We use this for heap sorting in sort.go.
-func (c *RowContainer) PseudoPop() *parser.DTuple {
-	idx := len(c.rows) - 1
-	x := &(c.rows)[idx]
-	c.rows = c.rows[:idx]
-	return x
-}
-
-// ResetLen cancels the effects of PseudoPop(), that is, it restores
-// the visible size of the RowContainer to its actual size.
-func (c *RowContainer) ResetLen(l int) {
-	c.rows = c.rows[:l]
-}
-
 // Replace substitutes one row for another. This does query the
 // MemoryMonitor to determine whether the new row fits the
 // allowance.

--- a/pkg/sql/row_container.go
+++ b/pkg/sql/row_container.go
@@ -17,11 +17,15 @@
 package sql
 
 import (
+	"fmt"
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/mon"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 )
+
+// targetChunkSize is the target number of Datums in a RowContainer chunk.
+const targetChunkSize = 64
 
 // RowContainer is a container for rows of DTuples which tracks the
 // approximate amount of memory allocated for row data.
@@ -31,9 +35,19 @@ import (
 // TODO(knz): this does not currently track the amount of memory used
 // for the outer array of DTuple references.
 type RowContainer struct {
-	rows    []parser.DTuple
 	numCols int
 
+	// rowsPerChunk is the number of rows in a chunk; we pack multiple rows in a
+	// single []Datum to reduce the overhead of the slice if we have few columns.
+	rowsPerChunk int
+	// preallocChunks is the number of chunks we allocate upfront (on the first
+	// AddRow call).
+	preallocChunks int
+	chunks         [][]parser.Datum
+	numRows        int
+
+	// chunkMemSize is the memory used by a chunk.
+	chunkMemSize int64
 	// fixedColsSize is the sum of widths of fixed-width columns in a
 	// single row.
 	fixedColsSize int64
@@ -67,36 +81,67 @@ type RowContainer struct {
 // test properly.  The trade-off is that very large table schemas or
 // column selections could cause unchecked and potentially dangerous
 // memory growth.
-func (p *planner) NewRowContainer(
-	acc mon.BoundAccount, h ResultColumns, rowCapacity int,
-) *RowContainer {
+func NewRowContainer(acc mon.BoundAccount, h ResultColumns, rowCapacity int) *RowContainer {
 	nCols := len(h)
 
-	res := &RowContainer{
-		rows:            make([]parser.DTuple, 0, rowCapacity),
-		numCols:         nCols,
-		varSizedColumns: make([]int, 0, nCols),
-		memAcc:          acc,
+	c := &RowContainer{
+		numCols:        nCols,
+		memAcc:         acc,
+		preallocChunks: 1,
+	}
+
+	if nCols != 0 {
+		c.rowsPerChunk = (targetChunkSize + nCols - 1) / nCols
+		if rowCapacity > 0 {
+			c.preallocChunks = (rowCapacity + c.rowsPerChunk - 1) / c.rowsPerChunk
+		}
 	}
 
 	for i := 0; i < nCols; i++ {
 		sz, variable := h[i].Typ.Size()
 		if variable {
-			res.varSizedColumns = append(res.varSizedColumns, i)
+			if c.varSizedColumns == nil {
+				// Only allocate varSizedColumns if necessary.
+				c.varSizedColumns = make([]int, 0, nCols)
+			}
+			c.varSizedColumns = append(c.varSizedColumns, i)
 		} else {
-			res.fixedColsSize += int64(sz)
+			c.fixedColsSize += int64(sz)
 		}
 	}
-	res.fixedColsSize += int64(unsafe.Sizeof(parser.Datum(nil)) * uintptr(nCols))
 
-	return res
+	// Precalculate the memory used for a chunk, specifically by the Datums in the
+	// chunk and the slice pointing at the chunk.
+	c.chunkMemSize = int64(unsafe.Sizeof(parser.Datum(nil))) * int64(c.rowsPerChunk*c.numCols)
+	c.chunkMemSize += int64(unsafe.Sizeof([]parser.Datum(nil)))
+
+	return c
 }
 
 // Close releases the memory associated with the RowContainer.
 func (c *RowContainer) Close() {
-	c.rows = nil
+	c.chunks = nil
 	c.varSizedColumns = nil
 	c.memAcc.Close()
+}
+
+func (c *RowContainer) allocChunks(numChunks int) error {
+	datumsPerChunk := c.rowsPerChunk * c.numCols
+
+	if err := c.memAcc.Grow(c.chunkMemSize * int64(numChunks)); err != nil {
+		return err
+	}
+
+	if c.chunks == nil {
+		c.chunks = make([][]parser.Datum, 0, numChunks)
+	}
+
+	datums := make([]parser.Datum, numChunks*datumsPerChunk)
+	for i, pos := 0, 0; i < numChunks; i++ {
+		c.chunks = append(c.chunks, datums[pos:pos+datumsPerChunk])
+		pos += datumsPerChunk
+	}
+	return nil
 }
 
 // rowSize computes the size of a single row.
@@ -108,19 +153,49 @@ func (c *RowContainer) rowSize(row parser.DTuple) int64 {
 	return rsz
 }
 
-// AddRow attempts to insert a new row in the RowContainer.
+// getChunkAndPos returns the chunk index and the position inside the chunk for
+// a given row index.
+func (c *RowContainer) getChunkAndPos(rowIdx int) (chunk int, pos int) {
+	// This is a potential hot path; use int32 for faster division.
+	row := int32(rowIdx)
+	div := int32(c.rowsPerChunk)
+	return int(row / div), int(row % div * int32(c.numCols))
+
+}
+
+// AddRow attempts to insert a new row in the RowContainer. The row slice is not
+// used directly: the Datums inside the DTuple are copied to internal storage.
 // Returns an error if the allocation was denied by the MemoryMonitor.
 func (c *RowContainer) AddRow(row parser.DTuple) error {
+	if len(row) != c.numCols {
+		panic(fmt.Sprintf("invalid row length %d, expected %d", len(row), c.numCols))
+	}
+	if c.numCols == 0 {
+		c.numRows++
+		return nil
+	}
 	if err := c.memAcc.Grow(c.rowSize(row)); err != nil {
 		return err
 	}
-	c.rows = append(c.rows, row)
+	chunk, pos := c.getChunkAndPos(c.numRows)
+	if chunk == len(c.chunks) {
+		numChunks := c.preallocChunks
+		if len(c.chunks) > 0 {
+			// Grow the number of chunks by a fraction.
+			numChunks = 1 + len(c.chunks)/8
+		}
+		if err := c.allocChunks(numChunks); err != nil {
+			return err
+		}
+	}
+	copy(c.chunks[chunk][pos:pos+c.numCols], row)
+	c.numRows++
 	return nil
 }
 
 // Len reports the number of rows currently held in this RowContainer.
 func (c *RowContainer) Len() int {
-	return len(c.rows)
+	return c.numRows
 }
 
 // NumCols reports the number of columns held in this RowContainer.
@@ -130,12 +205,23 @@ func (c *RowContainer) NumCols() int {
 
 // At accesses a row at a specific index.
 func (c *RowContainer) At(i int) parser.DTuple {
-	return c.rows[i]
+	if i < 0 || i >= c.numRows {
+		panic(fmt.Sprintf("row index %d out of range", i))
+	}
+	if c.numCols == 0 {
+		return nil
+	}
+	chunk, pos := c.getChunkAndPos(i)
+	return c.chunks[chunk][pos : pos+c.numCols : pos+c.numCols]
 }
 
 // Swap exchanges two rows. Used for sorting.
 func (c *RowContainer) Swap(i, j int) {
-	c.rows[i], c.rows[j] = c.rows[j], c.rows[i]
+	r1 := c.At(i)
+	r2 := c.At(j)
+	for idx := 0; idx < c.numCols; idx++ {
+		r1[idx], r2[idx] = r2[idx], r1[idx]
+	}
 }
 
 // Replace substitutes one row for another. This does query the
@@ -143,15 +229,13 @@ func (c *RowContainer) Swap(i, j int) {
 // allowance.
 func (c *RowContainer) Replace(i int, newRow parser.DTuple) error {
 	newSz := c.rowSize(newRow)
-	oldSz := int64(0)
-	if c.rows[i] != nil {
-		oldSz = c.rowSize(c.rows[i])
-	}
+	row := c.At(i)
+	oldSz := c.rowSize(row)
 	if newSz != oldSz {
 		if err := c.memAcc.ResizeItem(oldSz, newSz); err != nil {
 			return err
 		}
 	}
-	c.rows[i] = newRow
+	copy(row, newRow)
 	return nil
 }

--- a/pkg/sql/row_container_test.go
+++ b/pkg/sql/row_container_test.go
@@ -1,0 +1,60 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package sql
+
+import (
+	"math"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/mon"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestRowContainer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	for _, numCols := range []int{1, 2, 3, 5, 10, 15} {
+		for _, numRows := range []int{1, 5, 10, 100} {
+			resCol := make(ResultColumns, numCols)
+			for i := range resCol {
+				resCol[i] = ResultColumn{Typ: parser.TypeInt}
+			}
+			m := mon.MakeUnlimitedMonitor(context.Background(), "test", nil, nil, math.MaxInt64)
+			rc := NewRowContainer(m.MakeBoundAccount(context.Background()), resCol, 0)
+			row := make(parser.DTuple, numCols)
+			for i := 0; i < numRows; i++ {
+				for j := range row {
+					row[j] = parser.NewDInt(parser.DInt(i*numCols + j))
+				}
+				if err := rc.AddRow(row); err != nil {
+					t.Fatal(err)
+				}
+			}
+			for i := 0; i < numRows; i++ {
+				row := rc.At(i)
+				for j := range row {
+					dint, ok := row[j].(*parser.DInt)
+					if !ok || int(*dint) != i*numCols+j {
+						t.Fatalf("invalid value %+v on row %d, col %d", row[j], i, j)
+					}
+				}
+			}
+		}
+	}
+}

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -77,8 +77,9 @@ func (p *planner) Show(n *parser.Show) (planNode, error) {
 				for _, vName := range varNames {
 					gen := varGen[vName]
 					value := gen(p)
-					if err := v.rows.AddRow(parser.DTuple{parser.NewDString(vName),
-						parser.NewDString(value)}); err != nil {
+					if err := v.rows.AddRow(
+						parser.DTuple{parser.NewDString(vName), parser.NewDString(value)},
+					); err != nil {
 						v.rows.Close()
 						return nil, err
 					}

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -570,11 +570,10 @@ func (ss *sortTopKStrategy) Finish() {
 	// Pop all values in the heap, resulting in the inverted ordering
 	// being sorted in reverse. Therefore, the slice is ordered correctly
 	// in-place.
-	origLen := ss.vNode.Len()
 	for ss.vNode.Len() > 0 {
 		heap.Pop(ss.vNode)
 	}
-	ss.vNode.rows.ResetLen(origLen)
+	ss.vNode.ResetLen()
 }
 
 func (ss *sortTopKStrategy) Next() (bool, error) {

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -428,9 +428,7 @@ func newSortAllStrategy(vNode *valuesNode) sortingStrategy {
 }
 
 func (ss *sortAllStrategy) Add(values parser.DTuple) error {
-	valuesCopy := make(parser.DTuple, len(values))
-	copy(valuesCopy, values)
-	return ss.vNode.rows.AddRow(valuesCopy)
+	return ss.vNode.rows.AddRow(values)
 }
 
 func (ss *sortAllStrategy) Finish() {
@@ -476,9 +474,7 @@ func newIterativeSortStrategy(vNode *valuesNode) sortingStrategy {
 }
 
 func (ss *iterativeSortStrategy) Add(values parser.DTuple) error {
-	valuesCopy := make(parser.DTuple, len(values))
-	copy(valuesCopy, values)
-	return ss.vNode.rows.AddRow(valuesCopy)
+	return ss.vNode.rows.AddRow(values)
 }
 
 func (ss *iterativeSortStrategy) Finish() {
@@ -545,20 +541,14 @@ func (ss *sortTopKStrategy) Add(values parser.DTuple) error {
 	switch {
 	case int64(ss.vNode.Len()) < ss.topK:
 		// The first k values all go into the max-heap.
-		valuesCopy := make(parser.DTuple, len(values))
-		copy(valuesCopy, values)
-
-		if err := ss.vNode.PushValues(valuesCopy); err != nil {
+		if err := ss.vNode.PushValues(values); err != nil {
 			return err
 		}
 	case ss.vNode.ValuesLess(values, ss.vNode.rows.At(0)):
 		// Once the heap is full, only replace the top
 		// value if a new value is less than it. If so
 		// replace and fix the heap.
-		valuesCopy := make(parser.DTuple, len(values))
-		copy(valuesCopy, values)
-
-		if err := ss.vNode.rows.Replace(0, valuesCopy); err != nil {
+		if err := ss.vNode.rows.Replace(0, values); err != nil {
 			return err
 		}
 		heap.Fix(ss.vNode, 0)

--- a/pkg/sql/table_join.go
+++ b/pkg/sql/table_join.go
@@ -621,9 +621,7 @@ func (n *joinNode) Start() error {
 				break
 			}
 			row := n.right.plan.Values()
-			newRow := make([]parser.Datum, len(row))
-			copy(newRow, row)
-			if err := n.rightRows.rows.AddRow(newRow); err != nil {
+			if err := n.rightRows.rows.AddRow(row); err != nil {
 				return err
 			}
 		}

--- a/pkg/sql/testdata/explain
+++ b/pkg/sql/testdata/explain
@@ -64,13 +64,13 @@ EXPLAIN (TRACE, UNKNOWN) SELECT 1
 query ITTTT colnames
 EXPLAIN(VERBOSE) EXPLAIN(TRACE) SELECT 1
 ----
-Level  Type                  Description    Columns                                                                                      Ordering
-0      select                               ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition) +9,+"Span Pos"
-1      sort                  +9,+"Span Pos" ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition) +9,+"Span Pos"
-2      explain               trace          ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition)
-3      select                               ("1")
-4      render/filter(debug)  from ()        ("1")
-5      empty                 -              ()
+Level  Type                  Description             Columns                                                                                                  Ordering
+0      select                                        ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition)             +9,+"Span Pos"
+1      sort                  +Timestamp,+"Span Pos"  ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition)             +9,+"Span Pos"
+2      explain               trace                   ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition, Timestamp)
+3      select                                        ("1")
+4      render/filter(debug)  from ()                 ("1")
+5      empty                 -                       ()
 
 # Ensure that all relevant statement types can be explained
 query ITT

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -36,6 +36,11 @@ type valuesNode struct {
 	tuples   [][]parser.TypedExpr
 	rows     *RowContainer
 
+	// rowsPopped is used for heaps, it indicates the number of rows that were
+	// "popped". These rows are still part of the underlying RowContainer, in the
+	// range [rows.Len()-n.rowsPopped, rows.Len).
+	rowsPopped int
+
 	desiredTypes []parser.Type // This can be removed when we only type check once.
 
 	nextRow       int           // The index of the next row.
@@ -206,7 +211,7 @@ func (n *valuesNode) Close() {
 }
 
 func (n *valuesNode) Len() int {
-	return n.rows.Len()
+	return n.rows.Len() - n.rowsPopped
 }
 
 func (n *valuesNode) Less(i, j int) bool {
@@ -264,14 +269,28 @@ func (n *valuesNode) PushValues(values parser.DTuple) error {
 
 // Pop implements the heap.Interface interface.
 func (n *valuesNode) Pop() interface{} {
-	return n.rows.PseudoPop()
+	if n.rowsPopped >= n.rows.Len() {
+		panic("no more rows to pop")
+	}
+	n.rowsPopped++
+	// Returning a DTuple as an interface{} involves an allocation. Luckily, the
+	// value of Pop is only used for the return value of heap.Pop, which we can
+	// avoid using.
+	return nil
 }
 
 // PopValues pops the top DTuple value off the heap representation
 // of the valuesNode.
 func (n *valuesNode) PopValues() parser.DTuple {
-	x := heap.Pop(n)
-	return *x.(*parser.DTuple)
+	heap.Pop(n)
+	// Return the last popped row.
+	return n.rows.At(n.rows.Len() - n.rowsPopped)
+}
+
+// ResetLen resets the length to that of the underlying row container. This
+// resets the effect that popping values had on the valuesNode's visible length.
+func (n *valuesNode) ResetLen() {
+	n.rowsPopped = 0
 }
 
 // SortAll sorts all values in the valuesNode.rows slice.

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -52,7 +52,7 @@ type valuesNode struct {
 func (p *planner) newContainerValuesNode(columns ResultColumns, capacity int) *valuesNode {
 	return &valuesNode{
 		columns: columns,
-		rows:    p.NewRowContainer(p.session.TxnState.makeBoundAccount(), columns, capacity),
+		rows:    NewRowContainer(p.session.TxnState.makeBoundAccount(), columns, capacity),
 	}
 }
 
@@ -143,15 +143,10 @@ func (n *valuesNode) Start() error {
 	// others that create a valuesNode internally for storing results
 	// from other planNodes), so its expressions need evaluting.
 	// This may run subqueries.
-	n.rows = n.p.NewRowContainer(n.p.session.TxnState.makeBoundAccount(), n.columns, len(n.n.Tuples))
+	n.rows = NewRowContainer(n.p.session.TxnState.makeBoundAccount(), n.columns, len(n.n.Tuples))
 
-	numCols := len(n.columns)
-	rowBuf := make([]parser.Datum, len(n.n.Tuples)*numCols)
+	row := make([]parser.Datum, len(n.columns))
 	for _, tupleRow := range n.tuples {
-		// Chop off prefix of rowBuf and limit its capacity.
-		row := rowBuf[:numCols:numCols]
-		rowBuf = rowBuf[numCols:]
-
 		for i, typedExpr := range tupleRow {
 			if err := n.p.startSubqueryPlans(typedExpr); err != nil {
 				return err


### PR DESCRIPTION
The majority of RowContainer.AddRow() callers make copies of the rows; most are
unoptimized (one allocation per row).

Changing RowContainer to manage row storage internally, instead of using the
slices passed by the caller. We allocate rows in chunks, which reduces the
allocations as well as the overhead of storing a slice for every row. The
callers are simplified.

This change also fixes a couple of bugs that were uncovered:
 - explainTraceNode exposed incorrect Columns();
 - insert code was appending to a row returned by a plan node via Values().

CC @nvanbenschoten for the first commit

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10534)
<!-- Reviewable:end -->
