### PR TITLE
storage: Fix and deflake TestRemoveRangeWithoutGC

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2441,7 +2441,7 @@ func TestRemoveRangeWithoutGC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	sc := storage.TestStoreConfig(nil)
-	sc.TestingKnobs.DisableScanner = true
+	sc.TestingKnobs.DisableReplicaGCQueue = true
 	mtc := &multiTestContext{storeConfig: &sc}
 	mtc.Start(t, 2)
 	defer mtc.Stop()
@@ -2449,7 +2449,9 @@ func TestRemoveRangeWithoutGC(t *testing.T) {
 	mtc.replicateRange(rangeID, 1)
 	mtc.unreplicateRange(rangeID, 0)
 
-	// Wait for store 0 to process the removal.
+	// Wait for store 0 to process the removal. The in-memory replica
+	// object still exists but store 0 is no longer present in the
+	// configuration.
 	util.SucceedsSoon(t, func() error {
 		rep, err := mtc.stores[0].GetReplica(rangeID)
 		if err != nil {
@@ -2462,8 +2464,7 @@ func TestRemoveRangeWithoutGC(t *testing.T) {
 		return nil
 	})
 
-	// The replica's data is still on disk even though the Replica
-	// object is removed.
+	// The replica's data is still on disk.
 	var desc roachpb.RangeDescriptor
 	descKey := keys.RangeDescriptorKey(roachpb.RKeyMin)
 	if ok, err := engine.MVCCGetProto(context.Background(), mtc.stores[0].Engine(), descKey,
@@ -2473,16 +2474,29 @@ func TestRemoveRangeWithoutGC(t *testing.T) {
 		t.Fatal("expected range descriptor to be present")
 	}
 
-	// Stop and restart the store to reset the replica's raftGroup
-	// pointer to nil. As long as the store has not been restarted it
-	// can continue to use its last known replica ID.
+	// Stop and restart the store. The primary motiviation for this test
+	// is to ensure that the store does not panic on restart (as was
+	// previously the case).
 	mtc.stopStore(0)
 	mtc.restartStore(0)
 
+	// Initially, the in-memory Replica object is recreated from the
+	// on-disk state.
+	if _, err := mtc.stores[0].GetReplica(rangeID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-enable the GC queue to allow the replica to be destroyed
+	// (after the simulated passage of time).
+	mtc.expireLeases()
+	mtc.manualClock.Increment(int64(storage.ReplicaGCQueueInactivityThreshold + 1))
+	mtc.stores[0].SetReplicaGCQueueActive(true)
+	mtc.stores[0].ForceReplicaGCScanAndProcess()
+
 	util.SucceedsSoon(t, func() error {
 		// The Replica object should be removed.
-		if _, err := mtc.stores[0].GetReplica(rangeID); err == nil {
-			return errors.Errorf("expected replica to be missing")
+		if _, err := mtc.stores[0].GetReplica(rangeID); !testutils.IsError(err, "range [0-9]+ was not found") {
+			return errors.Errorf("expected replica to be missing; got %v", err)
 		}
 
 		// And the data should no longer be on disk.
@@ -2490,7 +2504,7 @@ func TestRemoveRangeWithoutGC(t *testing.T) {
 			mtc.stores[0].Clock().Now(), true, nil, &desc); err != nil {
 			return err
 		} else if ok {
-			return errors.Errorf("expected range descriptor to be absent")
+			return errors.New("expected range descriptor to be absent")
 		}
 		return nil
 	})

--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -695,6 +695,16 @@ func (bq *baseQueue) remove(item *replicaItem) {
 // DrainQueue locks the queue and processes the remaining queued replicas. It
 // processes the replicas in the order they're queued in, one at a time.
 // Exposed for testing only.
+//
+// TODO(bdarnell): this method may race with the call to bq.pop() in
+// the main loop, in which case it does not guarantee that all
+// replicas have been processed by the time it returns. This is most
+// noticeable with ForceReplicaGCScanAndProcess, since the replica GC
+// queue has many event-driven triggers. This should synchronize
+// somehow with processLoop so we wait for anything being handled
+// there to finish too. When that's done, the SucceedsSoon at the end
+// of TestRemoveRangeWithoutGC (and perhaps others) can be replaced
+// with a one-time check.
 func (bq *baseQueue) DrainQueue(clock *hlc.Clock) {
 	ctx := bq.AnnotateCtx(context.TODO())
 	for repl := bq.pop(); repl != nil; repl = bq.pop() {


### PR DESCRIPTION
The fact that this test has been passing the vast majority of the time
has been due to false positives; the range was in fact getting GCed at
the start of the test but this asynchronous process was slow enough that
we didn't see it.

Fix the test by correctly disabling the replica GC queue and adding
additional checks to ensure that the data is still present after
restart.

Fixes #9506

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10540)
<!-- Reviewable:end -->
