### PR TITLE
storage: remove duplicate logging of *Replica

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2044,8 +2044,8 @@ func defaultSubmitProposalLocked(r *Replica, p *ProposalData) error {
 		// EndTransactionRequest with a ChangeReplicasTrigger is special
 		// because raft needs to understand it; it cannot simply be an
 		// opaque command.
-		log.Infof(ctx, "proposing %s %+v for range %d: %+v",
-			crt.ChangeType, crt.Replica, p.RangeID, crt.UpdatedReplicas)
+		log.Infof(ctx, "proposing %s %+v: %+v",
+			crt.ChangeType, crt.Replica, crt.UpdatedReplicas)
 
 		confChangeCtx := ConfChangeContext{
 			CommandID: string(p.idKey),


### PR DESCRIPTION
The contexts are already annotated.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10546)
<!-- Reviewable:end -->
