### PR TITLE
cli: remove prompting for password in insecure mode

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -842,6 +842,36 @@ func Example_user() {
 	// (0 rows)
 }
 
+func Example_user_insecure() {
+	s, err := serverutils.StartServerRaw(
+		base.TestServerArgs{Insecure: true})
+	if err != nil {
+		log.Fatalf(context.Background(), "Could not start server: %v", err)
+	}
+	defer s.Stopper().Stop()
+	c := cliTest{TestServer: s.(*server.TestServer), cleanupFunc: func() {}}
+
+	// Since util.IsolatedTestAddr is used on Linux in insecure test clusters,
+	// we have to reset the advertiseHost so that the value from previous
+	// tests is not used to construct an incorrect postgres URL by the client.
+	advertiseHost = ""
+
+	// No prompting for password in insecure mode.
+	c.Run("user set foo")
+	c.Run("user ls --pretty")
+
+	// Output:
+	// user set foo
+	// INSERT 1
+	// user ls --pretty
+	// +----------+
+	// | username |
+	// +----------+
+	// | foo      |
+	// +----------+
+	// (1 row)
+}
+
 // TestFlagUsage is a basic test to make sure the fragile
 // help template does not break.
 func TestFlagUsage(t *testing.T) {

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -242,8 +242,8 @@ server to listen on an external address in insecure mode.`,
 		Name:   "password",
 		EnvVar: "COCKROACH_PASSWORD",
 		Description: `
-The created user's password. If provided, disables prompting. Pass '-' to
-provide the password on standard input.`,
+The created user's password. If not provided in secure mode, the password is
+entered through a prompt. Pass '-' to provide the password on standard input.`,
 	}
 
 	CACert = FlagInfo{


### PR DESCRIPTION
Resolves #10543.

The user set cli command would prompt for a password for the user being
created in insecure mode. Since passwords are irrelevant in this mode,
a user is created with an empty password instead. Passwords can still be
specified using the --password flag in insecure mode.

cc @sploiselle

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10547)
<!-- Reviewable:end -->
