### PR TITLE
sql: lowercase pg_settings & add max_index_keys

### DIFF
--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -930,23 +930,23 @@ CREATE TABLE pg_catalog.pg_settings (
 			value := gen(p)
 			valueDatum := parser.NewDString(value)
 			if err := addRow(
-				parser.NewDString(vName), // name
-				valueDatum,               // setting
-				parser.DNull,             // unit
-				parser.DNull,             // category
-				parser.DNull,             // short_desc
-				parser.DNull,             // extra_desc
-				settingsCtxUser,          // context
-				varTypeString,            // vartype
-				parser.DNull,             // source
-				parser.DNull,             // min_val
-				parser.DNull,             // max_val
-				parser.DNull,             // enumvals
-				valueDatum,               // boot_val
-				valueDatum,               // reset_val
-				parser.DNull,             // sourcefile
-				parser.DNull,             // sourceline
-				parser.MakeDBool(false),  // pending_restart
+				parser.NewDString(strings.ToLower(vName)), // name
+				valueDatum,              // setting
+				parser.DNull,            // unit
+				parser.DNull,            // category
+				parser.DNull,            // short_desc
+				parser.DNull,            // extra_desc
+				settingsCtxUser,         // context
+				varTypeString,           // vartype
+				parser.DNull,            // source
+				parser.DNull,            // min_val
+				parser.DNull,            // max_val
+				parser.DNull,            // enumvals
+				valueDatum,              // boot_val
+				valueDatum,              // reset_val
+				parser.DNull,            // sourcefile
+				parser.DNull,            // sourceline
+				parser.MakeDBool(false), // pending_restart
 			); err != nil {
 				return err
 			}

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -36,6 +36,7 @@ var varGen = map[string]func(p *planner) string{
 	`TIME ZONE`:                     func(p *planner) string { return p.session.Location.String() },
 	`TRANSACTION ISOLATION LEVEL`:   func(p *planner) string { return p.txn.Proto.Isolation.String() },
 	`TRANSACTION PRIORITY`:          func(p *planner) string { return p.txn.UserPriority.String() },
+	`MAX_INDEX_KEYS`:                func(_ *planner) string { return "32" },
 }
 var varNames = func() []string {
 	res := make([]string, 0, len(varGen))

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -741,31 +741,31 @@ query TTTTTT colnames
 SELECT name, setting, category, short_desc, extra_desc, vartype FROM pg_catalog.pg_settings
 ----
 name                           setting       category  short_desc  extra_desc  vartype
-DATABASE                       test          NULL      NULL        NULL        string
-DEFAULT_TRANSACTION_ISOLATION  SERIALIZABLE  NULL      NULL        NULL        string
-SYNTAX                         Traditional   NULL      NULL        NULL        string
-TIME ZONE                      UTC           NULL      NULL        NULL        string
-TRANSACTION ISOLATION LEVEL    SERIALIZABLE  NULL      NULL        NULL        string
-TRANSACTION PRIORITY           NORMAL        NULL      NULL        NULL        string
+database                       test          NULL      NULL        NULL        string
+default_transaction_isolation  SERIALIZABLE  NULL      NULL        NULL        string
+syntax                         Traditional   NULL      NULL        NULL        string
+time zone                      UTC           NULL      NULL        NULL        string
+transaction isolation level    SERIALIZABLE  NULL      NULL        NULL        string
+transaction priority           NORMAL        NULL      NULL        NULL        string
 
 query TTTTTTT colnames
 SELECT name, setting, unit, context, enumvals, boot_val, reset_val FROM pg_catalog.pg_settings
 ----
 name                           setting       unit  context  enumvals  boot_val      reset_val
-DATABASE                       test          NULL  user     NULL      test          test
-DEFAULT_TRANSACTION_ISOLATION  SERIALIZABLE  NULL  user     NULL      SERIALIZABLE  SERIALIZABLE
-SYNTAX                         Traditional   NULL  user     NULL      Traditional   Traditional
-TIME ZONE                      UTC           NULL  user     NULL      UTC           UTC 
-TRANSACTION ISOLATION LEVEL    SERIALIZABLE  NULL  user     NULL      SERIALIZABLE  SERIALIZABLE
-TRANSACTION PRIORITY           NORMAL        NULL  user     NULL      NORMAL        NORMAL
+database                       test          NULL  user     NULL      test          test
+default_transaction_isolation  SERIALIZABLE  NULL  user     NULL      SERIALIZABLE  SERIALIZABLE
+syntax                         Traditional   NULL  user     NULL      Traditional   Traditional
+time zone                      UTC           NULL  user     NULL      UTC           UTC
+transaction isolation level    SERIALIZABLE  NULL  user     NULL      SERIALIZABLE  SERIALIZABLE
+transaction priority           NORMAL        NULL  user     NULL      NORMAL        NORMAL
 
 query TTTTTT colnames
 SELECT name, source, min_val, max_val, sourcefile, sourceline FROM pg_catalog.pg_settings
 ----
 name                           source  min_val  max_val  sourcefile  sourceline
-DATABASE                       NULL    NULL     NULL     NULL        NULL
-DEFAULT_TRANSACTION_ISOLATION  NULL    NULL     NULL     NULL        NULL
-SYNTAX                         NULL    NULL     NULL     NULL        NULL
-TIME ZONE                      NULL    NULL     NULL     NULL        NULL
-TRANSACTION ISOLATION LEVEL    NULL    NULL     NULL     NULL        NULL
-TRANSACTION PRIORITY           NULL    NULL     NULL     NULL        NULL
+database                       NULL    NULL     NULL     NULL        NULL
+default_transaction_isolation  NULL    NULL     NULL     NULL        NULL
+syntax                         NULL    NULL     NULL     NULL        NULL
+time zone                      NULL    NULL     NULL     NULL        NULL
+transaction isolation level    NULL    NULL     NULL     NULL        NULL
+transaction priority           NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -743,6 +743,7 @@ SELECT name, setting, category, short_desc, extra_desc, vartype FROM pg_catalog.
 name                           setting       category  short_desc  extra_desc  vartype
 database                       test          NULL      NULL        NULL        string
 default_transaction_isolation  SERIALIZABLE  NULL      NULL        NULL        string
+max_index_keys                 32            NULL      NULL        NULL        string
 syntax                         Traditional   NULL      NULL        NULL        string
 time zone                      UTC           NULL      NULL        NULL        string
 transaction isolation level    SERIALIZABLE  NULL      NULL        NULL        string
@@ -754,6 +755,7 @@ SELECT name, setting, unit, context, enumvals, boot_val, reset_val FROM pg_catal
 name                           setting       unit  context  enumvals  boot_val      reset_val
 database                       test          NULL  user     NULL      test          test
 default_transaction_isolation  SERIALIZABLE  NULL  user     NULL      SERIALIZABLE  SERIALIZABLE
+max_index_keys                 32            NULL  user     NULL      32            32
 syntax                         Traditional   NULL  user     NULL      Traditional   Traditional
 time zone                      UTC           NULL  user     NULL      UTC           UTC
 transaction isolation level    SERIALIZABLE  NULL  user     NULL      SERIALIZABLE  SERIALIZABLE
@@ -765,6 +767,7 @@ SELECT name, source, min_val, max_val, sourcefile, sourceline FROM pg_catalog.pg
 name                           source  min_val  max_val  sourcefile  sourceline
 database                       NULL    NULL     NULL     NULL        NULL
 default_transaction_isolation  NULL    NULL     NULL     NULL        NULL
+max_index_keys                 NULL    NULL     NULL     NULL        NULL
 syntax                         NULL    NULL     NULL     NULL        NULL
 time zone                      NULL    NULL     NULL     NULL        NULL
 transaction isolation level    NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/testdata/set
+++ b/pkg/sql/testdata/set
@@ -103,6 +103,7 @@ SHOW ALL
 ----
 DATABASE                       foo
 DEFAULT_TRANSACTION_ISOLATION  SERIALIZABLE
+MAX_INDEX_KEYS                 32
 SYNTAX                         Modern
 TIME ZONE                      UTC
 TRANSACTION ISOLATION LEVEL    SERIALIZABLE


### PR DESCRIPTION
Lowercasing of names in pg_setttings is needed, because Hibernate
expects names in pg_settings to be lowercase. Also, Postgres exposes
settings as lowercase.

Also adds max_index_keys to pg_settings with Postgres's default value
(32).

Fixes #10524

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10548)
<!-- Reviewable:end -->
