### PR TITLE
distsql: Replace Datums in RowFetcher with EncDatums

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -446,7 +446,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 		var lastRowSeen parser.DTuple
 		i := int64(0)
 		for ; i < chunkSize; i++ {
-			row, err := rf.NextRow()
+			row, err := rf.NextRowDecoded()
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/distsql/aggregator.go
+++ b/pkg/sql/distsql/aggregator.go
@@ -175,9 +175,16 @@ func (ag *aggregator) computeAggregates() error {
 		}
 
 		row := ag.rowAlloc.AllocRow(len(tuple))
-		err := sqlbase.DTupleToEncDatumRow(row, tuple)
-		if err != nil {
-			return err
+		if len(row) != len(tuple) {
+			return errors.Errorf(
+				"Length mismatch (%d and %d) between row and tuple", len(row), len(tuple))
+		}
+		for i, datum := range tuple {
+			encD, err := sqlbase.DatumToEncDatumWithInferredType(datum)
+			if err != nil {
+				return err
+			}
+			row[i] = encD
 		}
 
 		if ok := ag.rows.PushRow(row); !ok {

--- a/pkg/sql/distsql/aggregator.go
+++ b/pkg/sql/distsql/aggregator.go
@@ -154,7 +154,7 @@ func (ag *aggregator) accumulateRows() error {
 		ag.buckets[string(encoded)] = struct{}{}
 		// Feed the func holders for this bucket the non-grouping datums.
 		for i, colIdx := range ag.inputCols {
-			if err := row[colIdx].Decode(&ag.datumAlloc); err != nil {
+			if err := row[colIdx].EnsureDecoded(&ag.datumAlloc); err != nil {
 				return err
 			}
 			if err := ag.funcs[i].add(encoded, row[colIdx].Datum); err != nil {

--- a/pkg/sql/distsql/aggregator_test.go
+++ b/pkg/sql/distsql/aggregator_test.go
@@ -41,7 +41,7 @@ func TestAggregator(t *testing.T) {
 
 	v := [15]sqlbase.EncDatum{}
 	for i := range v {
-		v[i] = sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
+		v[i] = sqlbase.DatumToEncDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
 	}
 
 	testCases := []struct {

--- a/pkg/sql/distsql/aggregator_test.go
+++ b/pkg/sql/distsql/aggregator_test.go
@@ -41,7 +41,7 @@ func TestAggregator(t *testing.T) {
 
 	v := [15]sqlbase.EncDatum{}
 	for i := range v {
-		v[i].SetDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
+		v[i] = sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
 	}
 
 	testCases := []struct {

--- a/pkg/sql/distsql/distinct_test.go
+++ b/pkg/sql/distsql/distinct_test.go
@@ -31,7 +31,7 @@ func TestDistinct(t *testing.T) {
 
 	v := [15]sqlbase.EncDatum{}
 	for i := range v {
-		v[i].SetDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
+		v[i] = sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
 	}
 
 	testCases := []struct {

--- a/pkg/sql/distsql/distinct_test.go
+++ b/pkg/sql/distsql/distinct_test.go
@@ -31,7 +31,7 @@ func TestDistinct(t *testing.T) {
 
 	v := [15]sqlbase.EncDatum{}
 	for i := range v {
-		v[i] = sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
+		v[i] = sqlbase.DatumToEncDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
 	}
 
 	testCases := []struct {

--- a/pkg/sql/distsql/evaluator.go
+++ b/pkg/sql/distsql/evaluator.go
@@ -122,7 +122,7 @@ func (ev *evaluator) eval(row sqlbase.EncDatumRow) (sqlbase.EncDatumRow, error) 
 		if err != nil {
 			return nil, err
 		}
-		outRow[i].SetDatum(ev.exprTypes[i], datum)
+		outRow[i] = sqlbase.DatumToEncDatum(ev.exprTypes[i], datum)
 	}
 
 	return outRow, nil

--- a/pkg/sql/distsql/evaluator_test.go
+++ b/pkg/sql/distsql/evaluator_test.go
@@ -31,15 +31,14 @@ func TestEvaluator(t *testing.T) {
 
 	v := [15]sqlbase.EncDatum{}
 	for i := range v {
-		v[i] = sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
+		v[i] = sqlbase.DatumToEncDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
 	}
 
 	b := [2]sqlbase.EncDatum{}
-	b[0].SetDatum(sqlbase.ColumnType_BOOL, parser.DBoolTrue)
-	b[1].SetDatum(sqlbase.ColumnType_BOOL, parser.DBoolFalse)
+	b[0] = sqlbase.DatumToEncDatum(sqlbase.ColumnType_BOOL, parser.DBoolTrue)
+	b[1] = sqlbase.DatumToEncDatum(sqlbase.ColumnType_BOOL, parser.DBoolFalse)
 
-	var nullInt sqlbase.EncDatum
-	nullInt.SetDatum(sqlbase.ColumnType_INT, parser.DNull)
+	nullInt := sqlbase.DatumToEncDatum(sqlbase.ColumnType_INT, parser.DNull)
 
 	testCases := []struct {
 		spec     EvaluatorSpec

--- a/pkg/sql/distsql/evaluator_test.go
+++ b/pkg/sql/distsql/evaluator_test.go
@@ -31,7 +31,7 @@ func TestEvaluator(t *testing.T) {
 
 	v := [15]sqlbase.EncDatum{}
 	for i := range v {
-		v[i].SetDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
+		v[i] = sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
 	}
 
 	b := [2]sqlbase.EncDatum{}

--- a/pkg/sql/distsql/expr.go
+++ b/pkg/sql/distsql/expr.go
@@ -110,7 +110,7 @@ func (eh *exprHelper) IndexedVarResolvedType(idx int) parser.Type {
 
 // IndexedVarEval is part of the parser.IndexedVarContainer interface.
 func (eh *exprHelper) IndexedVarEval(idx int, ctx *parser.EvalContext) (parser.Datum, error) {
-	err := eh.row[idx].Decode(&eh.datumAlloc)
+	err := eh.row[idx].EnsureDecoded(&eh.datumAlloc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/distsql/hashjoiner_test.go
+++ b/pkg/sql/distsql/hashjoiner_test.go
@@ -32,7 +32,7 @@ func TestHashJoiner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	v := [6]sqlbase.EncDatum{}
 	for i := range v {
-		v[i].SetDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
+		v[i] = sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
 	}
 	null := sqlbase.EncDatum{Datum: parser.DNull}
 

--- a/pkg/sql/distsql/hashjoiner_test.go
+++ b/pkg/sql/distsql/hashjoiner_test.go
@@ -32,7 +32,7 @@ func TestHashJoiner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	v := [6]sqlbase.EncDatum{}
 	for i := range v {
-		v[i] = sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
+		v[i] = sqlbase.DatumToEncDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
 	}
 	null := sqlbase.EncDatum{Datum: parser.DNull}
 

--- a/pkg/sql/distsql/input_sync_test.go
+++ b/pkg/sql/distsql/input_sync_test.go
@@ -30,7 +30,7 @@ func TestOrderedSync(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	v := [6]sqlbase.EncDatum{}
 	for i := range v {
-		v[i].SetDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
+		v[i] = sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
 	}
 
 	asc := encoding.Ascending
@@ -141,9 +141,8 @@ func TestUnorderedSync(t *testing.T) {
 	for i := 1; i <= 5; i++ {
 		go func(i int) {
 			for j := 1; j <= 100; j++ {
-				var a, b sqlbase.EncDatum
-				a.SetDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
-				b.SetDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(j)))
+				a := sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
+				b := sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(j)))
 				row := sqlbase.EncDatumRow{a, b}
 				mrc.PushRow(row)
 			}
@@ -183,9 +182,8 @@ func TestUnorderedSync(t *testing.T) {
 	for i := 1; i <= 5; i++ {
 		go func(i int) {
 			for j := 1; j <= 100; j++ {
-				var a, b sqlbase.EncDatum
-				a.SetDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
-				b.SetDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(j)))
+				a := sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
+				b := sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(j)))
 				row := sqlbase.EncDatumRow{a, b}
 				mrc.PushRow(row)
 			}

--- a/pkg/sql/distsql/input_sync_test.go
+++ b/pkg/sql/distsql/input_sync_test.go
@@ -30,7 +30,7 @@ func TestOrderedSync(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	v := [6]sqlbase.EncDatum{}
 	for i := range v {
-		v[i] = sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
+		v[i] = sqlbase.DatumToEncDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
 	}
 
 	asc := encoding.Ascending
@@ -141,8 +141,8 @@ func TestUnorderedSync(t *testing.T) {
 	for i := 1; i <= 5; i++ {
 		go func(i int) {
 			for j := 1; j <= 100; j++ {
-				a := sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
-				b := sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(j)))
+				a := sqlbase.DatumToEncDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
+				b := sqlbase.DatumToEncDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(j)))
 				row := sqlbase.EncDatumRow{a, b}
 				mrc.PushRow(row)
 			}
@@ -182,8 +182,8 @@ func TestUnorderedSync(t *testing.T) {
 	for i := 1; i <= 5; i++ {
 		go func(i int) {
 			for j := 1; j <= 100; j++ {
-				a := sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
-				b := sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(j)))
+				a := sqlbase.DatumToEncDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
+				b := sqlbase.DatumToEncDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(j)))
 				row := sqlbase.EncDatumRow{a, b}
 				mrc.PushRow(row)
 			}

--- a/pkg/sql/distsql/joinreader_test.go
+++ b/pkg/sql/distsql/joinreader_test.go
@@ -109,7 +109,7 @@ func TestJoinReader(t *testing.T) {
 		for _, row := range c.input {
 			encRow := make(sqlbase.EncDatumRow, len(row))
 			for i, d := range row {
-				encRow[i] = sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, d)
+				encRow[i] = sqlbase.DatumToEncDatum(sqlbase.ColumnType_INT, d)
 			}
 			in.rows = append(in.rows, encRow)
 		}

--- a/pkg/sql/distsql/joinreader_test.go
+++ b/pkg/sql/distsql/joinreader_test.go
@@ -109,7 +109,7 @@ func TestJoinReader(t *testing.T) {
 		for _, row := range c.input {
 			encRow := make(sqlbase.EncDatumRow, len(row))
 			for i, d := range row {
-				encRow[i].SetDatum(sqlbase.ColumnType_INT, d)
+				encRow[i] = sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, d)
 			}
 			in.rows = append(in.rows, encRow)
 		}

--- a/pkg/sql/distsql/mergejoiner_test.go
+++ b/pkg/sql/distsql/mergejoiner_test.go
@@ -31,7 +31,7 @@ func TestMergeJoiner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	v := [6]sqlbase.EncDatum{}
 	for i := range v {
-		v[i].SetDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
+		v[i] = sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
 	}
 	null := sqlbase.EncDatum{Datum: parser.DNull}
 

--- a/pkg/sql/distsql/mergejoiner_test.go
+++ b/pkg/sql/distsql/mergejoiner_test.go
@@ -31,7 +31,7 @@ func TestMergeJoiner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	v := [6]sqlbase.EncDatum{}
 	for i := range v {
-		v[i] = sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
+		v[i] = sqlbase.DatumToEncDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
 	}
 	null := sqlbase.EncDatum{Datum: parser.DNull}
 

--- a/pkg/sql/distsql/readerbase.go
+++ b/pkg/sql/distsql/readerbase.go
@@ -119,12 +119,9 @@ func (rb *readerBase) nextRow() (sqlbase.EncDatumRow, error) {
 			return nil, err
 		}
 
-		// TODO(radu): we are defeating the purpose of EncDatum here - we
-		// should modify RowFetcher to return EncDatums directly and avoid
-		// the cost of decoding/reencoding.
 		for i := range fetcherRow {
-			if fetcherRow[i] != nil {
-				rb.row[i] = sqlbase.EncDatumFromDatum(rb.desc.Columns[i].Type.Kind, fetcherRow[i])
+			if !fetcherRow[i].IsUnset() {
+				rb.row[i] = fetcherRow[i]
 			}
 		}
 		passesFilter, err := rb.filter.evalFilter(rb.row)

--- a/pkg/sql/distsql/readerbase.go
+++ b/pkg/sql/distsql/readerbase.go
@@ -124,7 +124,7 @@ func (rb *readerBase) nextRow() (sqlbase.EncDatumRow, error) {
 		// the cost of decoding/reencoding.
 		for i := range fetcherRow {
 			if fetcherRow[i] != nil {
-				rb.row[i].SetDatum(rb.desc.Columns[i].Type.Kind, fetcherRow[i])
+				rb.row[i] = sqlbase.EncDatumFromDatum(rb.desc.Columns[i].Type.Kind, fetcherRow[i])
 			}
 		}
 		passesFilter, err := rb.filter.evalFilter(rb.row)

--- a/pkg/sql/distsql/sorter_test.go
+++ b/pkg/sql/distsql/sorter_test.go
@@ -31,7 +31,7 @@ func TestSorter(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	v := [6]sqlbase.EncDatum{}
 	for i := range v {
-		v[i].SetDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
+		v[i] = sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
 	}
 
 	asc := encoding.Ascending

--- a/pkg/sql/distsql/sorter_test.go
+++ b/pkg/sql/distsql/sorter_test.go
@@ -31,7 +31,7 @@ func TestSorter(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	v := [6]sqlbase.EncDatum{}
 	for i := range v {
-		v[i] = sqlbase.EncDatumFromDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
+		v[i] = sqlbase.DatumToEncDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
 	}
 
 	asc := encoding.Ascending

--- a/pkg/sql/distsql/stream_data_test.go
+++ b/pkg/sql/distsql/stream_data_test.go
@@ -97,7 +97,7 @@ func TestStreamEncodeDecode(t *testing.T) {
 		for i := range rows {
 			rows[i] = make(sqlbase.EncDatumRow, rowLen)
 			for j := range rows[i] {
-				rows[i][j] = sqlbase.EncDatumFromDatum(info[j].Type, sqlbase.RandDatum(rng, info[j].Type, true))
+				rows[i][j] = sqlbase.DatumToEncDatum(info[j].Type, sqlbase.RandDatum(rng, info[j].Type, true))
 			}
 		}
 		var trailerErr error

--- a/pkg/sql/distsql/stream_data_test.go
+++ b/pkg/sql/distsql/stream_data_test.go
@@ -97,7 +97,7 @@ func TestStreamEncodeDecode(t *testing.T) {
 		for i := range rows {
 			rows[i] = make(sqlbase.EncDatumRow, rowLen)
 			for j := range rows[i] {
-				rows[i][j].SetDatum(info[j].Type, sqlbase.RandDatum(rng, info[j].Type, true))
+				rows[i][j] = sqlbase.EncDatumFromDatum(info[j].Type, sqlbase.RandDatum(rng, info[j].Type, true))
 			}
 		}
 		var trailerErr error

--- a/pkg/sql/distsql/stream_decoder.go
+++ b/pkg/sql/distsql/stream_decoder.go
@@ -111,7 +111,7 @@ func (sd *StreamDecoder) GetRow(rowBuf sqlbase.EncDatumRow) (sqlbase.EncDatumRow
 	}
 	for i := range rowBuf {
 		var err error
-		sd.data, err = rowBuf[i].SetFromBuffer(sd.info[i].Type, sd.info[i].Encoding, sd.data)
+		rowBuf[i], sd.data, err = sqlbase.EncDatumFromBuffer(sd.info[i].Type, sd.info[i].Encoding, sd.data)
 		if err != nil {
 			// Reset sd because it is no longer usable.
 			*sd = StreamDecoder{}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -939,7 +939,7 @@ func (r *distSQLReceiver) PushRow(row sqlbase.EncDatumRow) bool {
 		r.row = make(parser.DTuple, len(r.resultToStreamColMap))
 	}
 	for i, resIdx := range r.resultToStreamColMap {
-		err := row[resIdx].Decode(&r.alloc)
+		err := row[resIdx].EnsureDecoded(&r.alloc)
 		if err != nil {
 			r.err = err
 			return false

--- a/pkg/sql/fk.go
+++ b/pkg/sql/fk.go
@@ -306,5 +306,5 @@ func (f baseFKHelper) check(values parser.DTuple) (parser.DTuple, error) {
 	if err := f.rf.StartScan(f.txn, spans, true /* limit batches */, 1); err != nil {
 		return nil, err
 	}
-	return f.rf.NextRow()
+	return f.rf.NextRowDecoded()
 }

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/pkg/errors"
 )
 
 // A scanNode handles scanning over the key/value pairs for a table and
@@ -177,25 +178,33 @@ func (n *scanNode) debugNext() (bool, error) {
 	// In debug mode, we output a set of debug values for each key.
 	n.debugVals.rowIdx = n.rowIndex
 	var err error
-	n.debugVals.key, n.debugVals.value, n.row, err = n.fetcher.NextKeyDebug()
+	var encRow sqlbase.EncDatumRow
+	n.debugVals.key, n.debugVals.value, encRow, err = n.fetcher.NextKeyDebug()
 	if err != nil || n.debugVals.key == "" {
 		return false, err
 	}
-
-	if n.row != nil {
-		passesFilter, err := sqlbase.RunFilter(n.filter, &n.p.evalCtx)
-		if err != nil {
-			return false, err
-		}
-		if passesFilter {
-			n.debugVals.output = debugValueRow
-		} else {
-			n.debugVals.output = debugValueFiltered
-		}
-		n.rowIndex++
-	} else {
+	if encRow == nil {
+		n.row = nil
 		n.debugVals.output = debugValuePartial
+		return true, nil
 	}
+	tuple := make(parser.DTuple, len(encRow))
+	var da sqlbase.DatumAlloc
+
+	if err := sqlbase.EncDatumRowToDTuple(tuple, encRow, &da); err != nil {
+		return false, errors.Errorf("Could not decode row: %v", err)
+	}
+	n.row = tuple
+	passesFilter, err := sqlbase.RunFilter(n.filter, &n.p.evalCtx)
+	if err != nil {
+		return false, err
+	}
+	if passesFilter {
+		n.debugVals.output = debugValueRow
+	} else {
+		n.debugVals.output = debugValueFiltered
+	}
+	n.rowIndex++
 	return true, nil
 }
 
@@ -214,7 +223,7 @@ func (n *scanNode) Next() (bool, error) {
 	// We fetch one row at a time until we find one that passes the filter.
 	for {
 		var err error
-		n.row, err = n.fetcher.NextRow()
+		n.row, err = n.fetcher.NextRowDecoded()
 		if err != nil || n.row == nil {
 			return false, err
 		}

--- a/pkg/sql/sqlbase/encoded_datum_test.go
+++ b/pkg/sql/sqlbase/encoded_datum_test.go
@@ -26,18 +26,18 @@ import (
 
 func TestEncDatum(t *testing.T) {
 	a := &DatumAlloc{}
-	x := EncDatum{}
-	if !x.IsUnset() {
+	v := EncDatum{}
+	if !v.IsUnset() {
 		t.Errorf("empty EncDatum should be unset")
 	}
 
-	if _, ok := x.Encoding(); ok {
+	if _, ok := v.Encoding(); ok {
 		t.Errorf("empty EncDatum has an encoding")
 	}
 
-	x = EncDatumFromDatum(ColumnType_INT, parser.NewDInt(5))
+	x := DatumToEncDatum(ColumnType_INT, parser.NewDInt(5))
 	if x.IsUnset() {
-		t.Errorf("unset after EncDatumFromDatum()")
+		t.Errorf("unset after DatumToEncDatum()")
 	}
 
 	encoded, err := x.Encode(a, DatumEncoding_ASCENDING_KEY, nil)
@@ -85,6 +85,10 @@ func TestEncDatum(t *testing.T) {
 	}
 	if cmp := y.Datum.Compare(z.Datum); cmp != 0 {
 		t.Errorf("Datums should be equal, cmp = %d", cmp)
+	}
+	y.UnsetDatum()
+	if !y.IsUnset() {
+		t.Error("not unset after UnsetDatum()")
 	}
 }
 
@@ -148,8 +152,8 @@ func TestEncDatumCompare(t *testing.T) {
 				break
 			}
 		}
-		v1 := EncDatumFromDatum(typ, d1)
-		v2 := EncDatumFromDatum(typ, d2)
+		v1 := DatumToEncDatum(typ, d1)
+		v2 := DatumToEncDatum(typ, d2)
 
 		if val, err := v1.Compare(a, &v2); err != nil {
 			t.Fatal(err)
@@ -226,7 +230,7 @@ func TestEncDatumFromBuffer(t *testing.T) {
 func TestEncDatumRowCompare(t *testing.T) {
 	v := [5]EncDatum{}
 	for i := range v {
-		v[i] = EncDatumFromDatum(ColumnType_INT, parser.NewDInt(parser.DInt(i)))
+		v[i] = DatumToEncDatum(ColumnType_INT, parser.NewDInt(parser.DInt(i)))
 	}
 
 	asc := encoding.Ascending

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -74,14 +74,13 @@ type RowFetcher struct {
 
 	// -- Fields updated during a scan --
 
-	kvFetcher        kvFetcher
-	keyValTypes      []parser.Type  // the index key value types for the current row
-	keyVals          []parser.Datum // the index key values for the current row
-	implicitValTypes []parser.Type  // the implicit value types for unique indexes
-	implicitVals     []parser.Datum // the implicit values for unique indexes
-	indexKey         []byte         // the index key of the current row
-	row              parser.DTuple
-	prettyValueBuf   bytes.Buffer
+	kvFetcher      kvFetcher
+	keyVals        []EncDatum  // the index key values for the current row
+	implicitVals   EncDatumRow // the implicit values for unique indexes
+	indexKey       []byte      // the index key of the current row
+	row            EncDatumRow
+	decodedRow     parser.DTuple
+	prettyValueBuf bytes.Buffer
 
 	// The current key/value, unless kvEnd is true.
 	kv                client.KeyValue
@@ -110,7 +109,8 @@ func (rf *RowFetcher) Init(
 	rf.isSecondaryIndex = isSecondaryIndex
 	rf.cols = cols
 	rf.valNeededForCol = valNeededForCol
-	rf.row = make([]parser.Datum, len(rf.cols))
+	rf.row = make([]EncDatum, len(rf.cols))
+	rf.decodedRow = make([]parser.Datum, len(rf.cols))
 
 	var indexColumnIDs []ColumnID
 	indexColumnIDs, rf.indexColumnDirs = index.FullColumnIDs()
@@ -130,22 +130,20 @@ func (rf *RowFetcher) Init(
 
 	var err error
 	// Prepare our index key vals slice.
-	rf.keyValTypes, err = MakeKeyVals(rf.desc, indexColumnIDs)
+	rf.keyVals, err = MakeEncodedKeyVals(rf.desc, indexColumnIDs)
 	if err != nil {
 		return err
 	}
-	rf.keyVals = make([]parser.Datum, len(rf.keyValTypes))
 
 	if isSecondaryIndex && index.Unique {
 		// Unique secondary indexes have a value that is the primary index
 		// key. Prepare implicitVals for use in decoding this value.
 		// Primary indexes only contain ascendingly-encoded values. If this
 		// ever changes, we'll probably have to figure out the directions here too.
-		rf.implicitValTypes, err = MakeKeyVals(desc, index.ImplicitColumnIDs)
+		rf.implicitVals, err = MakeEncodedKeyVals(desc, index.ImplicitColumnIDs)
 		if err != nil {
 			return err
 		}
-		rf.implicitVals = make([]parser.Datum, len(rf.implicitValTypes))
 	}
 	return nil
 }
@@ -238,17 +236,20 @@ func (rf *RowFetcher) NextKey() (rowDone bool, err error) {
 	}
 }
 
-func prettyDatums(vals []parser.Datum) string {
+func prettyEncDatums(vals []EncDatum) string {
 	var buf bytes.Buffer
 	for _, v := range vals {
-		fmt.Fprintf(&buf, "/%v", v)
+		if err := v.EnsureDecoded(&DatumAlloc{}); err != nil {
+			fmt.Fprintf(&buf, "error decoding: %v", err)
+		}
+		fmt.Fprintf(&buf, "/%v", v.Datum)
 	}
 	return buf.String()
 }
 
 // ReadIndexKey decodes an index key for the fetcher's table.
 func (rf *RowFetcher) ReadIndexKey(k roachpb.Key) (remaining []byte, ok bool, err error) {
-	return DecodeIndexKey(&rf.alloc, rf.desc, rf.index.ID, rf.keyValTypes, rf.keyVals,
+	return DecodeIndexKey(&rf.alloc, rf.desc, rf.index.ID, rf.keyVals,
 		rf.indexColumnDirs, k)
 }
 
@@ -259,7 +260,7 @@ func (rf *RowFetcher) ProcessKV(
 	kv client.KeyValue, debugStrings bool,
 ) (prettyKey string, prettyValue string, err error) {
 	if debugStrings {
-		prettyKey = fmt.Sprintf("/%s/%s%s", rf.desc.Name, rf.index.Name, prettyDatums(rf.keyVals))
+		prettyKey = fmt.Sprintf("/%s/%s%s", rf.desc.Name, rf.index.Name, prettyEncDatums(rf.keyVals))
 	}
 
 	if rf.indexKey == nil {
@@ -269,7 +270,7 @@ func (rf *RowFetcher) ProcessKV(
 		// Reset the row to nil; it will get filled in with the column
 		// values as we decode the key-value pairs for the row.
 		for i := range rf.row {
-			rf.row[i] = nil
+			rf.row[i].UnsetDatum()
 		}
 
 		// Fill in the column values that are part of the index key.
@@ -302,8 +303,7 @@ func (rf *RowFetcher) ProcessKV(
 		if rf.implicitVals != nil {
 			// This is a unique index; decode the implicit column values from
 			// the value.
-			_, err := DecodeKeyVals(&rf.alloc, rf.implicitValTypes, rf.implicitVals, nil,
-				kv.ValueBytes())
+			_, err := DecodeKeyVals(&rf.alloc, rf.implicitVals, nil, kv.ValueBytes())
 			if err != nil {
 				return "", "", err
 			}
@@ -313,13 +313,13 @@ func (rf *RowFetcher) ProcessKV(
 				}
 			}
 			if debugStrings {
-				prettyValue = prettyDatums(rf.implicitVals)
+				prettyValue = prettyEncDatums(rf.implicitVals)
 			}
 		}
 
 		if log.V(2) {
 			if rf.implicitVals != nil {
-				log.Infof(context.TODO(), "Scan %s -> %s", kv.Key, prettyDatums(rf.implicitVals))
+				log.Infof(context.TODO(), "Scan %s -> %s", kv.Key, prettyEncDatums(rf.implicitVals))
 			} else {
 				log.Infof(context.TODO(), "Scan %s", kv.Key)
 			}
@@ -358,8 +358,11 @@ func (rf *RowFetcher) processValueSingle(
 			prettyKey = fmt.Sprintf("%s/%s", prettyKey, rf.desc.Columns[idx].Name)
 		}
 		kind := rf.cols[idx].Type.Kind
-		// TODO(dan): Once we decide if we're changing the tuple encoding, see if we
-		// can get rid of UnmarshalColumnValue in favor of DecodeTableValue.
+		// TODO(arjun): The value is a directly marshaled single value, so we
+		// unmarshal it eagerly here. This can potentially be optimized out,
+		// although that would require changing UnmarshalColumnValue to operate
+		// on bytes, and for Encode/DecodeTableValue to operate on marshaled
+		// single values.
 		value, err := UnmarshalColumnValue(&rf.alloc, kind, kv.Value)
 		if err != nil {
 			return "", "", err
@@ -367,10 +370,10 @@ func (rf *RowFetcher) processValueSingle(
 		if debugStrings {
 			prettyValue = value.String()
 		}
-		if rf.row[idx] != nil {
+		if !rf.row[idx].IsUnset() {
 			panic(fmt.Sprintf("duplicate value for column %d", idx))
 		}
-		rf.row[idx] = value
+		rf.row[idx] = DatumToEncDatum(rf.cols[idx].Type.Kind, value)
 		if log.V(3) {
 			log.Infof(context.TODO(), "Scan %s -> %v", kv.Key, value)
 		}
@@ -411,17 +414,13 @@ func (rf *RowFetcher) processValueTuple(
 		colID := lastColID + ColumnID(colIDDiff)
 		lastColID = colID
 		idx, ok := rf.colIdxMap[colID]
-		// TODO(dan): Ideally rowFetcher would generate EncDatums instead of Datums
-		// and that would make the logic simpler. We won't need valNeededForCol at
-		// all, it would be up to the user of the class to decide if they want to
-		// decode them or not.
 		if !ok || !rf.valNeededForCol[idx] {
 			// This column wasn't requested, so read its length and skip it.
-			_, i, err := encoding.PeekValueLength(tupleBytes)
+			_, len, err := encoding.PeekValueLength(tupleBytes)
 			if err != nil {
 				return "", "", err
 			}
-			tupleBytes = tupleBytes[i:]
+			tupleBytes = tupleBytes[len:]
 			if log.V(3) {
 				log.Infof(context.TODO(), "Scan %s -> [%d] (skipped)", kv.Key, colID)
 			}
@@ -432,18 +431,27 @@ func (rf *RowFetcher) processValueTuple(
 			prettyKey = fmt.Sprintf("%s/%s", prettyKey, rf.desc.Columns[idx].Name)
 		}
 
-		kind := rf.cols[idx].Type.Kind.ToDatumType()
-		value, tupleBytes, err = DecodeTableValue(&rf.alloc, kind, tupleBytes)
+		kind := rf.cols[idx].Type.Kind
+		if err != nil {
+			return "", "", err
+		}
+		var encValue EncDatum
+		encValue, tupleBytes, err = EncDatumFromBuffer(kind, DatumEncoding_VALUE, tupleBytes)
 		if err != nil {
 			return "", "", err
 		}
 		if debugStrings {
+			err := encValue.EnsureDecoded(&rf.alloc)
+			if err != nil {
+				return "", "", err
+			}
+			value = encValue.Datum
 			fmt.Fprintf(&rf.prettyValueBuf, "/%v", value)
 		}
-		if rf.row[idx] != nil {
+		if !rf.row[idx].IsUnset() {
 			panic(fmt.Sprintf("duplicate value for column %d", idx))
 		}
-		rf.row[idx] = value
+		rf.row[idx] = encValue
 		if log.V(3) {
 			log.Infof(context.TODO(), "Scan %d -> %v", idx, value)
 		}
@@ -455,13 +463,12 @@ func (rf *RowFetcher) processValueTuple(
 	return prettyKey, prettyValue, nil
 }
 
-// NextRow processes keys until we complete one row, which is returned as a
-// DTuple. The row contains one value per table column, regardless of the index
-// used; values that are not needed (as per valNeededForCol) are nil.
-//
-// The DTuple should not be modified and is only valid until the next call. When
-// there are no more rows, the DTuple is nil.
-func (rf *RowFetcher) NextRow() (parser.DTuple, error) {
+// NextRow processes keys until we complete one row, which is returned as an
+// EncDatumRow. The row contains one value per table column, regardless of the
+// index used; values that are not needed (as per valNeededForCol) are nil. The
+// EncDatumRow should not be modified and is only valid until the next call.
+// When there are no more rows, the EncDatumRow is nil.
+func (rf *RowFetcher) NextRow() (EncDatumRow, error) {
 	if rf.kvEnd {
 		return nil, nil
 	}
@@ -488,10 +495,28 @@ func (rf *RowFetcher) NextRow() (parser.DTuple, error) {
 	}
 }
 
+// NextRowDecoded calls NextRow and decodes the EncDatumRow into a DTuple.
+// The DTuple should not be modified and is only valid until the next call.
+// When there are no more rows, the DTuple is nil.
+func (rf *RowFetcher) NextRowDecoded() (parser.DTuple, error) {
+	encRow, err := rf.NextRow()
+	if err != nil {
+		return nil, err
+	}
+	if encRow == nil {
+		return nil, nil
+	}
+	err = EncDatumRowToDTuple(rf.decodedRow, encRow, &rf.alloc)
+	if err != nil {
+		return nil, err
+	}
+	return rf.decodedRow, nil
+}
+
 // NextKeyDebug processes one key at a time and returns a pretty printed key and
 // value. If we completed a row, the row is returned as well (see nextRow). If
 // there are no more keys, prettyKey is "".
-func (rf *RowFetcher) NextKeyDebug() (prettyKey string, prettyValue string, row parser.DTuple, err error) {
+func (rf *RowFetcher) NextKeyDebug() (prettyKey string, prettyValue string, row EncDatumRow, err error) {
 	if rf.kvEnd {
 		return "", "", nil, nil
 	}
@@ -513,11 +538,14 @@ func (rf *RowFetcher) NextKeyDebug() (prettyKey string, prettyValue string, row 
 func (rf *RowFetcher) finalizeRow() {
 	// Fill in any missing values with NULLs
 	for i, col := range rf.cols {
-		if rf.valNeededForCol[i] && rf.row[i] == nil {
+		if rf.valNeededForCol[i] && rf.row[i].IsUnset() {
 			if !col.Nullable {
 				panic("Non-nullable column with no value!")
 			}
-			rf.row[i] = parser.DNull
+			rf.row[i] = EncDatum{
+				Type:  col.Type.Kind,
+				Datum: parser.DNull,
+			}
 		}
 	}
 }

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -515,20 +515,18 @@ func EncodeTableValue(appendTo []byte, colID ColumnID, val parser.Datum) ([]byte
 	return nil, errors.Errorf("unable to encode table value: %T", val)
 }
 
-// MakeKeyVals returns a slice with the correct types for the given columns.
-func MakeKeyVals(desc *TableDescriptor, columnIDs []ColumnID) ([]parser.Type, error) {
-	vals := make([]parser.Type, len(columnIDs))
+// MakeEncodedKeyVals returns a slice of EncDatums with the correct types for
+// the given columns.
+func MakeEncodedKeyVals(desc *TableDescriptor, columnIDs []ColumnID) ([]EncDatum, error) {
+	keyVals := make([]EncDatum, len(columnIDs))
 	for i, id := range columnIDs {
 		col, err := desc.FindActiveColumnByID(id)
 		if err != nil {
 			return nil, err
 		}
-
-		if vals[i] = col.Type.ToDatumType(); vals[i] == nil {
-			panic(fmt.Sprintf("unsupported column type: %s", col.Type.Kind))
-		}
+		keyVals[i].Type = col.Type.Kind
 	}
-	return vals, nil
+	return keyVals, nil
 }
 
 // DecodeTableIDIndexID decodes a table id followed by an index id.
@@ -620,8 +618,7 @@ func DecodeIndexKey(
 	a *DatumAlloc,
 	desc *TableDescriptor,
 	indexID IndexID,
-	valTypes []parser.Type,
-	vals []parser.Datum,
+	vals []EncDatum,
 	colDirs []encoding.Direction,
 	key []byte,
 ) ([]byte, bool, error) {
@@ -640,11 +637,11 @@ func DecodeIndexKey(
 			}
 
 			length := int(ancestor.SharedPrefixLen)
-			key, err = DecodeKeyVals(a, valTypes[:length], vals[:length], colDirs[:length], key)
+			key, err = DecodeKeyVals(a, vals[:length], colDirs[:length], key)
 			if err != nil {
 				return nil, false, err
 			}
-			valTypes, vals, colDirs = valTypes[length:], vals[length:], colDirs[length:]
+			vals, colDirs = vals[length:], colDirs[length:]
 
 			// We reuse NotNullDescending as the interleave sentinel, consume it.
 			var ok bool
@@ -663,7 +660,7 @@ func DecodeIndexKey(
 		return nil, false, nil
 	}
 
-	key, err = DecodeKeyVals(a, valTypes, vals, colDirs, key)
+	key, err = DecodeKeyVals(a, vals, colDirs, key)
 	if err != nil {
 		return nil, false, err
 	}
@@ -677,33 +674,24 @@ func DecodeIndexKey(
 	return key, true, nil
 }
 
-// DecodeKeyVals decodes the values that are part of the key. ValTypes is a
-// slice returned from makeKeyVals. The decoded values are stored in the vals
-// parameter while the valTypes parameter is unmodified. Note that len(vals) >=
-// len(valTypes). The types of the decoded values will match the corresponding
-// entry in the valTypes parameter with the exception that a value might also
-// be parser.DNull. The remaining bytes in the key after decoding the values
-// are returned. A slice of directions can be provided to enforce encoding
-// direction on each value in valTypes. If this slice is nil, the direction
+// DecodeKeyVals decodes the values that are part of the key. The decoded
+// values are stored in the vals. If this slice is nil, the direction
 // used will default to encoding.Ascending.
 func DecodeKeyVals(
-	a *DatumAlloc,
-	valTypes []parser.Type,
-	vals []parser.Datum,
-	directions []encoding.Direction,
-	key []byte,
+	a *DatumAlloc, vals []EncDatum, directions []encoding.Direction, key []byte,
 ) ([]byte, error) {
-	if directions != nil && len(directions) != len(valTypes) {
-		return nil, errors.Errorf("encoding directions doesn't parallel valTypes: %d vs %d.",
-			len(directions), len(valTypes))
+	if directions != nil && len(directions) != len(vals) {
+		return nil, errors.Errorf("encoding directions doesn't parallel val: %d vs %d.",
+			len(directions), len(vals))
 	}
-	for j := range valTypes {
-		direction := encoding.Ascending
-		if directions != nil {
-			direction = directions[j]
+	for j := range vals {
+
+		enc := DatumEncoding_ASCENDING_KEY
+		if directions != nil && (directions[j] == encoding.Descending) {
+			enc = DatumEncoding_DESCENDING_KEY
 		}
 		var err error
-		vals[j], key, err = DecodeTableKey(a, valTypes[j], key, direction)
+		vals[j], key, err = EncDatumFromBuffer(vals[j].Type, enc, key)
 		if err != nil {
 			return nil, err
 		}
@@ -732,7 +720,7 @@ func ExtractIndexKey(
 	}
 
 	// Extract the values for index.ColumnIDs.
-	valueTypes, err := MakeKeyVals(tableDesc, index.ColumnIDs)
+	values, err := MakeEncodedKeyVals(tableDesc, index.ColumnIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -743,13 +731,12 @@ func ExtractIndexKey(
 			return nil, err
 		}
 	}
-	extractedValues := make([]parser.Datum, len(index.ColumnIDs))
 	if i, err := tableDesc.FindIndexByID(indexID); err == nil && len(i.Interleave.Ancestors) > 0 {
 		// TODO(dan): In the interleaved index case, we parse the key twice; once to
 		// find the index id so we can look up the descriptor, and once to extract
 		// the values. Only parse once.
 		var ok bool
-		_, ok, err = DecodeIndexKey(a, tableDesc, indexID, valueTypes, extractedValues, dirs, entry.Key)
+		_, ok, err = DecodeIndexKey(a, tableDesc, indexID, values, dirs, entry.Key)
 		if err != nil {
 			return nil, err
 		}
@@ -757,14 +744,14 @@ func ExtractIndexKey(
 			return nil, errors.Errorf("descriptor did not match key")
 		}
 	} else {
-		key, err = DecodeKeyVals(a, valueTypes, extractedValues, dirs, key)
+		key, err = DecodeKeyVals(a, values, dirs, key)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	// Extract the values for index.ImplicitColumnIDs
-	valueTypes, err = MakeKeyVals(tableDesc, index.ImplicitColumnIDs)
+	implicitValues, err := MakeEncodedKeyVals(tableDesc, index.ImplicitColumnIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -773,7 +760,6 @@ func ExtractIndexKey(
 		// Implicit columns are always encoded Ascending.
 		dirs[i] = encoding.Ascending
 	}
-	extractedImplicitValues := make([]parser.Datum, len(index.ImplicitColumnIDs))
 	implicitKey := key
 	if index.Unique {
 		implicitKey, err = entry.Value.GetBytes()
@@ -781,13 +767,13 @@ func ExtractIndexKey(
 			return nil, err
 		}
 	}
-	_, err = DecodeKeyVals(a, valueTypes, extractedImplicitValues, dirs, implicitKey)
+	_, err = DecodeKeyVals(a, implicitValues, dirs, implicitKey)
 	if err != nil {
 		return nil, err
 	}
 
 	// Encode the index key from its components.
-	extractedValues = append(extractedValues, extractedImplicitValues...)
+	values = append(values, implicitValues...)
 	colMap := make(map[ColumnID]int)
 	for i, columnID := range index.ColumnIDs {
 		colMap[columnID] = i
@@ -796,8 +782,17 @@ func ExtractIndexKey(
 		colMap[columnID] = i + len(index.ColumnIDs)
 	}
 	indexKeyPrefix := MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIndex.ID)
+	decodedValues := make([]parser.Datum, len(values))
+	var da DatumAlloc
+	for i, value := range values {
+		err := value.EnsureDecoded(&da)
+		if err != nil {
+			return nil, err
+		}
+		decodedValues[i] = value.Datum
+	}
 	indexKey, _, err := EncodeIndexKey(
-		tableDesc, &tableDesc.PrimaryIndex, colMap, extractedValues, indexKeyPrefix)
+		tableDesc, &tableDesc.PrimaryIndex, colMap, decodedValues, indexKeyPrefix)
 	return indexKey, err
 }
 

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -133,7 +133,7 @@ func RandDatumEncoding(rng *rand.Rand) DatumEncoding {
 func RandEncDatum(rng *rand.Rand) EncDatum {
 	typ := RandColumnType(rng)
 	datum := RandDatum(rng, typ, true)
-	return EncDatumFromDatum(typ, datum)
+	return DatumToEncDatum(typ, datum)
 }
 
 // RandEncDatumSlice generates a slice of random EncDatum values of the same random
@@ -142,7 +142,7 @@ func RandEncDatumSlice(rng *rand.Rand, numVals int) []EncDatum {
 	typ := RandColumnType(rng)
 	vals := make([]EncDatum, numVals)
 	for i := range vals {
-		vals[i] = EncDatumFromDatum(typ, RandDatum(rng, typ, true))
+		vals[i] = DatumToEncDatum(typ, RandDatum(rng, typ, true))
 	}
 	return vals
 }

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -133,9 +133,7 @@ func RandDatumEncoding(rng *rand.Rand) DatumEncoding {
 func RandEncDatum(rng *rand.Rand) EncDatum {
 	typ := RandColumnType(rng)
 	datum := RandDatum(rng, typ, true)
-	var ed EncDatum
-	ed.SetDatum(typ, datum)
-	return ed
+	return EncDatumFromDatum(typ, datum)
 }
 
 // RandEncDatumSlice generates a slice of random EncDatum values of the same random
@@ -144,7 +142,7 @@ func RandEncDatumSlice(rng *rand.Rand, numVals int) []EncDatum {
 	typ := RandColumnType(rng)
 	vals := make([]EncDatum, numVals)
 	for i := range vals {
-		vals[i].SetDatum(typ, RandDatum(rng, typ, true))
+		vals[i] = EncDatumFromDatum(typ, RandDatum(rng, typ, true))
 	}
 	return vals
 }

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -451,7 +451,7 @@ func (tu *tableUpserter) fetchExisting(ctx context.Context) ([]parser.DTuple, er
 
 	rows := make([]parser.DTuple, len(primaryKeys))
 	for {
-		row, err := tu.fetcher.NextRow()
+		row, err := tu.fetcher.NextRowDecoded()
 		if err != nil {
 			return nil, err
 		}
@@ -658,7 +658,7 @@ func (td *tableDeleter) deleteAllRowsScan(
 	}
 
 	for i := int64(0); i < limit; i++ {
-		row, err := rf.NextRow()
+		row, err := rf.NextRowDecoded()
 		if err != nil {
 			return resume, err
 		}
@@ -750,7 +750,7 @@ func (td *tableDeleter) deleteIndexScan(
 	}
 
 	for i := int64(0); i < limit; i++ {
-		row, err := rf.NextRow()
+		row, err := rf.NextRowDecoded()
 		if err != nil {
 			return resume, err
 		}


### PR DESCRIPTION
This is a work in progress, out for preliminary feedback to ensure I'm not 
doing something extremely flawed. 

RowFetcher should return EncDatums. Downstream users who expect a
Datum should extract it from the EncDatum using EncDatumToDTuple.

Other minor changes:
1) Rename EncDatum.Decode to EncDatum.EnsureDecoded.

2) Change SetDatum/SetEncoded/SetFromBuffer from methods that 
mutate structs to functions that return values 

3) (WIP) Merge the functionality of DatumToEncDatum with
SetDatum. Almost done, with the exception of RowFetcher.ProcessKV,
which requires converting RowFetcher.keyVals to []EncDatum.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10550)
<!-- Reviewable:end -->
