### PR TITLE
sql: skip broken benchmarks

### DIFF
--- a/pkg/sql/bench_test.go
+++ b/pkg/sql/bench_test.go
@@ -1245,10 +1245,12 @@ func BenchmarkInsertDistinct1Multinode_Cockroach(b *testing.B) {
 }
 
 func BenchmarkInsertDistinct10Multinode_Cockroach(b *testing.B) {
+	b.Skip("https://github.com/cockroachdb/cockroach/issues/10551")
 	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkInsertDistinct(b, db, 10) })
 }
 
 func BenchmarkInsertDistinct100Multinode_Cockroach(b *testing.B) {
+	b.Skip("https://github.com/cockroachdb/cockroach/issues/10551")
 	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkInsertDistinct(b, db, 100) })
 }
 


### PR DESCRIPTION
...until #10551 is resolved. It'd be nice to get the nightly benchmark
runs working again.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10555)
<!-- Reviewable:end -->
