### PR TITLE
storage: deflake TestStoreRangeUpReplicate

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -953,6 +953,9 @@ func TestStoreRangeUpReplicate(t *testing.T) {
 			if r == nil {
 				return errors.Errorf("expected replica for keys \"a\" - \"b\"")
 			}
+			if n := s.ReservationCount(); n != 0 {
+				return errors.Errorf("expected 0 reservations, but found %d", n)
+			}
 		}
 		return nil
 	})
@@ -965,9 +968,6 @@ func TestStoreRangeUpReplicate(t *testing.T) {
 		generated += m.RangeSnapshotsGenerated.Count()
 		normalApplied += m.RangeSnapshotsNormalApplied.Count()
 		preemptiveApplied += m.RangeSnapshotsPreemptiveApplied.Count()
-		if n := s.ReservationCount(); n != 0 {
-			t.Fatalf("expected 0 reservations, but found %d", n)
-		}
 	}
 	if generated == 0 {
 		t.Fatalf("expected at least 1 snapshot, but found 0")


### PR DESCRIPTION
The replica can appear before the reservation has been filled, so move
the check that the reservation count drops to 0 into the retry loop.

Fixes #10553

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10564)
<!-- Reviewable:end -->
