### PR TITLE
cli: Print the time a node starts to stdout when initializing

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -338,6 +338,7 @@ func runStart(_ *cobra.Command, args []string) error {
 	}
 
 	tw := tabwriter.NewWriter(os.Stdout, 2, 1, 2, ' ', 0)
+	fmt.Fprintf(tw, "CockroachDB node starting at %s\n", timeutil.Now())
 	fmt.Fprintf(tw, "build:\t%s @ %s (%s)\n", info.Tag, info.Time, info.GoVersion)
 	fmt.Fprintf(tw, "admin:\t%s\n", serverCfg.AdminURL())
 	fmt.Fprintf(tw, "sql:\t%s\n", pgURL)


### PR DESCRIPTION
Not having something like this in the stdout logs has been annoying me while looking into production problems, but feel free to tell me I'm wrong.

Makes for a stdout looking like:
```
CockroachDB node starting at 2016-11-09 14:09:33.929282962 -0500 EST
build:      beta-20161103-160-g28a31c0-dirty @ 2016/11/09 19:09:16 (go1.7.1)
admin:      http://localhost:8080
sql:        postgresql://root@localhost:26257?sslmode=disable
logs:       foobar/logs
store[0]:   path=foobar
status:     restarted pre-existing node
clusterID:  {21a96fa8-3623-4b8b-9944-134d88aa3b4d}
nodeID:     1
```

@jseldess in case this would be too annoying to update in the docs

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10568)
<!-- Reviewable:end -->
