### PR TITLE
sql: re-enable COPY tests

### DIFF
--- a/pkg/sql/copy_in_test.go
+++ b/pkg/sql/copy_in_test.go
@@ -291,8 +291,6 @@ func TestCopyError(t *testing.T) {
 func TestCopyOne(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	t.Skip("https://github.com/lib/pq/issues/494")
-
 	params, _ := createTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop()
@@ -324,8 +322,6 @@ func TestCopyOne(t *testing.T) {
 // cannot run.
 func TestCopyInProgress(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-
-	t.Skip("https://github.com/lib/pq/issues/494")
 
 	params, _ := createTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)


### PR DESCRIPTION
The race condition in the listed issue has been fixed.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10571)
<!-- Reviewable:end -->
