### PR TITLE
ui: Syntax highlighting for Create Table Statement

### DIFF
--- a/pkg/ui/app/containers/databases/tableDetails.tsx
+++ b/pkg/ui/app/containers/databases/tableDetails.tsx
@@ -13,6 +13,7 @@ import { SummaryBar, SummaryItem } from "../../components/summaryBar";
 import { TableInfo } from "./data";
 import { SortSetting } from "../../components/sortabletable";
 import { SortedTable } from "../../components/sortedtable";
+import * as hljs from "highlight.js";
 
 type Grant = Proto2TypeScript.cockroach.server.serverpb.TableDetailsResponse.Grant;
 
@@ -58,6 +59,8 @@ type TableMainProps = TableMainData & TableMainActions & IInjectedProps;
  * data table of all databases.
  */
 class TableMain extends React.Component<TableMainProps, {}> {
+  createStmtNode: Node;
+
   componentWillMount() {
     this.props.refreshTableDetails(new protos.cockroach.server.serverpb.TableDetailsRequest({
       database: this.props.params[databaseNameAttr],
@@ -74,6 +77,10 @@ class TableMain extends React.Component<TableMainProps, {}> {
     this.props.setUISetting(UI_DATABASE_TABLE_GRANTS_SORT_SETTING_KEY, setting);
   }
 
+  componentDidMount() {
+    hljs.highlightBlock(this.createStmtNode);
+  }
+
   render() {
     let { tableInfo, grantsSortSetting } = this.props;
 
@@ -83,7 +90,7 @@ class TableMain extends React.Component<TableMainProps, {}> {
           { this.props.params[tableNameAttr] }
         </div>
         <div className="content">
-          <pre className="create-table">
+          <pre className="sql" ref={(node) => this.createStmtNode = node}>
             {/* TODO (mrtracy): format and highlight create table statement */}
             {tableInfo.createStatement}
           </pre>

--- a/pkg/ui/config.js
+++ b/pkg/ui/config.js
@@ -82,6 +82,7 @@ System.config({
     "d3": "npm:d3@3.5.17",
     "enzyme": "npm:enzyme@2.4.1",
     "fetch-mock": "npm:fetch-mock@5.5.0",
+    "highlight.js": "npm:highlight.js@9.8.0",
     "lodash": "npm:lodash@4.16.3",
     "long": "npm:long@3.2.0",
     "moment": "npm:moment@2.15.1",
@@ -692,6 +693,10 @@ System.config({
       "sntp": "npm:sntp@1.0.9",
       "systemjs-json": "github:systemjs/plugin-json@0.1.2",
       "url": "github:jspm/nodelibs-url@0.1.0"
+    },
+    "npm:highlight.js@9.8.0": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:history@2.1.2": {
       "deep-equal": "npm:deep-equal@1.0.1",

--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -23,6 +23,7 @@
       "classnames": "npm:classnames@^2.2.5",
       "css": "github:systemjs/plugin-css@^0.1.23",
       "d3": "npm:d3@^3.5.17",
+      "highlight.js": "npm:highlight.js@^9.8.0",
       "lodash": "npm:lodash@^4.14.0",
       "long": "npm:long@^3.2.0",
       "moment": "npm:moment@^2.14.1",

--- a/pkg/ui/styl/app.styl
+++ b/pkg/ui/styl/app.styl
@@ -24,6 +24,7 @@ Author: Matt Tracy (matt@cockroachlabs.com)
 @require 'partials/navigation-bar.styl'
 @require 'partials/table.styl'
 @require 'partials/visualizations.styl'
+@require 'partials/syntax.styl'
 
 @require 'css/icons.css'
 

--- a/pkg/ui/styl/modules/palette.styl
+++ b/pkg/ui/styl/modules/palette.styl
@@ -72,3 +72,9 @@ $secondary-blue-2 = #317DAB // submit button hover
 
 $secondary-gold-2 = #ECB51A // banner opt-in button hover
 
+
+// Syntax colors
+
+$syntax-orange = #EE833B
+$syntax-blue = #6DC0CE
+

--- a/pkg/ui/styl/partials/syntax.styl
+++ b/pkg/ui/styl/partials/syntax.styl
@@ -1,0 +1,11 @@
+pre.sql.hljs
+    background-color $main-dark-gray
+    color $secondary-gray-12
+    font-family inconsolata
+
+    .hljs-string
+        color $syntax-orange
+
+    .hljs-keyword
+    .hljs-literal
+        color $syntax-blue

--- a/pkg/ui/typings.json
+++ b/pkg/ui/typings.json
@@ -4,6 +4,7 @@
     "classnames": "registry:dt/classnames#0.0.0+20160316155526",
     "cockroach-protos": "file:generated/protos.d.ts",
     "fetch-mock": "registry:dt/fetch-mock#5.0.0+20160829142453",
+    "highlightjs": "registry:dt/highlightjs#9.1.0+20160317120654",
     "long": "registry:dt/long#3.0.2+20160602144319",
     "mocha": "registry:dt/mocha#2.2.5+20160720003353",
     "react": "registry:dt/react#0.14.0+20160927082313",


### PR DESCRIPTION
Add syntax highlighting for the "CREATE TABLE" statement displayed on the table
details page. This utilizes highlight.js, which appears to be the most widely
used library for this purpose.

Included are a few custom CSS styles that colorize the syntax to match Kuan's
current design prototypes. However, since those colors are likely not final, I
haven't invested much effort in making them correct. We als might want to
invest effort in selecting exactly which keywords in the SQL syntax are
highlighted; it's a bit inconsistent as-is.

<img width="1321" alt="screen shot 2016-11-09 at 5 52 57 pm" src="https://cloud.githubusercontent.com/assets/6969858/20158029/fed6a370-a6a5-11e6-8bd9-dad9f7a89f16.png">

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10579)
<!-- Reviewable:end -->
