### PR TITLE
storage: add a shuffle to the store pool's getStoreList.

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/shuffle"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
@@ -246,7 +247,7 @@ func (ds *DistSender) RangeLookup(
 		Reverse:   useReverseScan,
 	})
 	replicas := newReplicaSlice(ds.gossip, desc)
-	replicas.Shuffle()
+	shuffle.Shuffle(replicas)
 	br, err := ds.sendRPC(ctx, desc.RangeID, replicas, ba)
 	if err != nil {
 		return nil, nil, roachpb.NewError(err)
@@ -288,7 +289,7 @@ func (ds *DistSender) optimizeReplicaOrder(replicas ReplicaSlice) {
 	nodeDesc := ds.getNodeDescriptor()
 	// If we don't know which node we're on, don't optimize anything.
 	if nodeDesc == nil {
-		replicas.Shuffle()
+		shuffle.Shuffle(replicas)
 		return
 	}
 	// Sort replicas by attribute affinity (if any), which we treat as a stand-in

--- a/pkg/kv/replica_slice_test.go
+++ b/pkg/kv/replica_slice_test.go
@@ -17,7 +17,6 @@
 package kv
 
 import (
-	"math/rand"
 	"reflect"
 	"testing"
 
@@ -114,22 +113,4 @@ func TestReplicaSetMoveToFront(t *testing.T) {
 	if stores := getStores(rs); !reflect.DeepEqual(stores, exp) {
 		t.Errorf("expected order %s, got %s", exp, stores)
 	}
-}
-
-func verifyRandPermOrdering(startIndex int, topIndex int, exp []roachpb.StoreID, t *testing.T) {
-	r := rand.New(rand.NewSource(0))
-	rs := createReplicaSlice()
-	rs.randPerm(startIndex, topIndex, r.Intn)
-	if stores := getStores(rs); !reflect.DeepEqual(stores, exp) {
-		t.Errorf("expected order %s, got %s", exp, stores)
-	}
-}
-
-func TestReplicaSetRandPerm(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	verifyRandPermOrdering(2, 2, []roachpb.StoreID{1, 2, 3, 4, 5}, t)
-	verifyRandPermOrdering(3, 4, []roachpb.StoreID{1, 2, 3, 5, 4}, t)
-	verifyRandPermOrdering(0, 2, []roachpb.StoreID{3, 1, 2, 4, 5}, t)
-	verifyRandPermOrdering(1, 3, []roachpb.StoreID{1, 4, 2, 3, 5}, t)
-	verifyRandPermOrdering(0, 4, []roachpb.StoreID{3, 5, 2, 1, 4}, t)
 }

--- a/pkg/storage/store_pool.go
+++ b/pkg/storage/store_pool.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/shuffle"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -524,6 +525,8 @@ func (sp *StorePool) getStoreList(rangeID roachpb.RangeID) (StoreList, int, int)
 
 	if sp.deterministic {
 		sort.Sort(storeIDs)
+	} else {
+		shuffle.Shuffle(storeIDs)
 	}
 
 	var aliveStoreCount int

--- a/pkg/util/shuffle/shuffle.go
+++ b/pkg/util/shuffle/shuffle.go
@@ -1,0 +1,36 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package shuffle
+
+import "math/rand"
+
+// Interface for shuffle. When it is satisfied, a collection can be shuffled by
+// the routines in this package. The methods require that the elements of the
+// collection be enumerable by an integer index. This interface is similar to
+// sort.Interface.
+type Interface interface {
+	// Len is the number of elements in the collection.
+	Len() int
+	// Swap swaps the elements with indexes i and j.
+	Swap(i, j int)
+}
+
+// Shuffle randomizes the order of the array.
+func Shuffle(data Interface) {
+	n := data.Len()
+	for i := 1; i < n; i++ {
+		data.Swap(i, rand.Intn(i+1))
+	}
+}

--- a/pkg/util/shuffle/shuffle_test.go
+++ b/pkg/util/shuffle/shuffle_test.go
@@ -1,0 +1,80 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package shuffle
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+type testSlice []int
+
+// testSlice implements shuffle.Interface.
+func (ts testSlice) Len() int      { return len(ts) }
+func (ts testSlice) Swap(i, j int) { ts[i], ts[j] = ts[j], ts[i] }
+
+func TestShuffle(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	rand.Seed(0)
+
+	verify := func(original, expected testSlice) {
+		Shuffle(original)
+		if !reflect.DeepEqual(original, expected) {
+			t.Errorf("expected %v, got %v", expected, original)
+		}
+	}
+
+	ts := testSlice{}
+	verify(ts, testSlice{})
+	verify(ts, testSlice{})
+
+	ts = testSlice{1}
+	verify(ts, testSlice{1})
+	verify(ts, testSlice{1})
+
+	ts = testSlice{1, 2}
+	verify(ts, testSlice{2, 1})
+	verify(ts, testSlice{1, 2})
+
+	ts = testSlice{1, 2, 3}
+	verify(ts, testSlice{1, 3, 2})
+	verify(ts, testSlice{1, 2, 3})
+	verify(ts, testSlice{1, 2, 3})
+	verify(ts, testSlice{3, 1, 2})
+
+	ts = testSlice{1, 2, 3, 4, 5}
+	verify(ts, testSlice{2, 1, 3, 5, 4})
+	verify(ts, testSlice{4, 2, 1, 5, 3})
+	verify(ts, testSlice{1, 4, 2, 3, 5})
+	verify(ts, testSlice{2, 5, 4, 1, 3})
+	verify(ts, testSlice{4, 2, 3, 1, 5})
+
+	verify(ts[2:2], testSlice{})
+	verify(ts[0:0], testSlice{})
+	verify(ts[5:5], testSlice{})
+	verify(ts[3:5], testSlice{1, 5})
+	verify(ts[3:5], testSlice{5, 1})
+	verify(ts[0:2], testSlice{4, 2})
+	verify(ts[0:2], testSlice{2, 4})
+	verify(ts[1:4], testSlice{3, 5, 4})
+	verify(ts[1:4], testSlice{5, 4, 3})
+	verify(ts[0:4], testSlice{4, 5, 2, 3})
+	verify(ts[0:4], testSlice{2, 4, 3, 5})
+
+	verify(ts, testSlice{1, 3, 4, 2, 5})
+}


### PR DESCRIPTION
**Describe the problem**

there was no notification that the upgrade to 21.1.0 would now report server_version as 13.0.0

**To Reproduce**

look at server variables.

**Expected behavior**

some clients restrict functionality based on postgre server version. a bump from 9.5 to 13 should at least be noted in the changelog

**Environment:**
 - CockroachDB version 21.1.0

**Additional context**
What was the impact?

not yet known


Jira issue: CRDB-7599