### PR TITLE
storage: skip TestReplicaCancelRaft

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -5755,6 +5755,7 @@ func TestGCIncorrectRange(t *testing.T) {
 // commands via a cancelable context.Context.
 func TestReplicaCancelRaft(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("TODO(spencerkimball): https://github.com/cockroachdb/cockroach/issues/10488")
 	// Pick a key unlikely to be used by background processes.
 	key := []byte("acdfg")
 	tc := testContext{}


### PR DESCRIPTION
See #10488.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10609)
<!-- Reviewable:end -->
