### PR TITLE
HLC: remove access to "bare" physical time

### DIFF
--- a/pkg/acceptance/partition.go
+++ b/pkg/acceptance/partition.go
@@ -56,7 +56,7 @@ type NemesisFn func(t *testing.T, stop <-chan struct{}, c cluster.Cluster)
 // symmetrically between two random groups of nodes. Partitioned and connected
 // mode take alternating turns, with random durations of up to 15s.
 func BidirectionalPartitionNemesis(t *testing.T, stop <-chan struct{}, c cluster.Cluster) {
-	randSec := func() time.Duration { return time.Duration(rand.Int63n(15 * int64(time.Second))) }
+	randSec := func() time.Duration { return time.Duration(rand.Int63n(15 * time.Second.Nanoseconds())) }
 	log.Infof(context.Background(), "cleaning up any previous rules")
 	_ = restoreNetwork(t, c) // clean up any potential leftovers
 	log.Infof(context.Background(), "starting partition nemesis")

--- a/pkg/kv/dist_sender_server_test.go
+++ b/pkg/kv/dist_sender_server_test.go
@@ -747,7 +747,7 @@ func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 				// with a strictly higher timestamp. We're dropping logical
 				// ticks and the clock may just have been pushed into the
 				// future, so that's necessary. See #3122.
-				if ts[0].WallTime >= s.Clock().Now().WallTime {
+				if s.Clock().Now().Less(ts[0]) {
 					return errors.New("time stands still")
 				}
 				return nil

--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -734,8 +734,8 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 			pErr:      nil,
 			expEpoch:  0,
 			expPri:    1,
-			expTS:     origTS,
-			expOrigTS: origTS,
+			expTS:     origTS.Add(0, 1), // the act of reading the clock increments it
+			expOrigTS: origTS.Add(0, 1), // the act of reading the clock increments it
 		},
 		{
 			// On uncertainty error, new epoch begins and node is seen.

--- a/pkg/rpc/breaker.go
+++ b/pkg/rpc/breaker.go
@@ -43,7 +43,7 @@ func (c *breakerClock) AfterFunc(d time.Duration, f func()) *clock.Timer {
 }
 
 func (c *breakerClock) Now() time.Time {
-	return c.clock.PhysicalTime()
+	return c.clock.Now().GoTime()
 }
 
 func (c *breakerClock) Sleep(d time.Duration) {

--- a/pkg/rpc/clock_offset.go
+++ b/pkg/rpc/clock_offset.go
@@ -97,7 +97,7 @@ func (r *RemoteClockMonitor) UpdateOffset(addr string, offset RemoteOffset) {
 		if !emptyOffset {
 			r.mu.offsets[addr] = offset
 		}
-	} else if oldOffset.isStale(r.offsetTTL, r.clock.PhysicalTime()) {
+	} else if oldOffset.isStale(r.offsetTTL, r.clock.Now().GoTime()) {
 		// We have a measurement but it's old - if the incoming measurement is not empty,
 		// set it, otherwise delete the old measurement.
 		if !emptyOffset {
@@ -128,7 +128,7 @@ func (r *RemoteClockMonitor) VerifyClockOffset() error {
 	// of the max offset is disabled. However we may still want to
 	// propagate the information to a status node.
 	if maxOffset := r.clock.MaxOffset(); maxOffset != 0 {
-		now := r.clock.PhysicalTime()
+		now := r.clock.Now().GoTime()
 
 		healthyOffsetCount := 0
 

--- a/pkg/rpc/clock_offset_test.go
+++ b/pkg/rpc/clock_offset_test.go
@@ -46,7 +46,7 @@ func TestUpdateOffset(t *testing.T) {
 	offset1 := RemoteOffset{
 		Offset:      0,
 		Uncertainty: 20,
-		MeasuredAt:  monitor.clock.PhysicalTime().Add(-(monitor.offsetTTL + 1)).UnixNano(),
+		MeasuredAt:  monitor.clock.Now().GoTime().Add(-(monitor.offsetTTL + 1)).UnixNano(),
 	}
 	monitor.UpdateOffset(key, offset1)
 	monitor.mu.Lock()
@@ -61,7 +61,7 @@ func TestUpdateOffset(t *testing.T) {
 	offset2 := RemoteOffset{
 		Offset:      0,
 		Uncertainty: 20,
-		MeasuredAt:  monitor.clock.PhysicalTime().Add(-(monitor.offsetTTL + 1)).UnixNano(),
+		MeasuredAt:  monitor.clock.Now().GoTime().Add(-(monitor.offsetTTL + 1)).UnixNano(),
 	}
 	monitor.UpdateOffset(key, offset2)
 	monitor.mu.Lock()

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -295,11 +295,11 @@ func (ctx *Context) runHeartbeat(cc *grpc.ClientConn, remoteAddr string) error {
 			heartbeatTimer.Read = true
 		}
 
-		sendTime := ctx.localClock.PhysicalTime()
+		sendTime := ctx.localClock.Now().GoTime()
 		response, err := ctx.heartbeat(heartbeatClient, request)
 		ctx.setConnHealthy(remoteAddr, err == nil)
 		if err == nil {
-			receiveTime := ctx.localClock.PhysicalTime()
+			receiveTime := ctx.localClock.Now().GoTime()
 
 			// Only update the clock offset measurement if we actually got a
 			// successful response from the server.

--- a/pkg/rpc/heartbeat.go
+++ b/pkg/rpc/heartbeat.go
@@ -76,7 +76,7 @@ func (hs *HeartbeatService) Ping(ctx context.Context, args *PingRequest) (*PingR
 	hs.remoteClockMonitor.UpdateOffset(args.Addr, serverOffset)
 	return &PingResponse{
 		Pong:       args.Ping,
-		ServerTime: hs.clock.PhysicalNow(),
+		ServerTime: hs.clock.Now().WallTime,
 	}, nil
 }
 

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -207,7 +207,7 @@ func (mr *MetricsRecorder) GetTimeSeriesData() []tspb.TimeSeriesData {
 	data := make([]tspb.TimeSeriesData, 0, mr.mu.lastDataCount)
 
 	// Record time series from node-level registries.
-	now := mr.mu.clock.PhysicalNow()
+	now := mr.mu.clock.Now().WallTime
 	recorder := registryRecorder{
 		registry:       mr.mu.nodeRegistry,
 		format:         nodeTimeSeriesPrefix,
@@ -245,7 +245,7 @@ func (mr *MetricsRecorder) GetStatusSummary() *NodeStatus {
 		return nil
 	}
 
-	now := mr.mu.clock.PhysicalNow()
+	now := mr.mu.clock.Now().WallTime
 
 	// Generate an node status with no store data.
 	nodeStat := &NodeStatus{

--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -124,7 +124,7 @@ func MakeRuntimeStatSampler(clock *hlc.Clock) RuntimeStatSampler {
 
 	return RuntimeStatSampler{
 		clock:          clock,
-		startTimeNanos: clock.PhysicalNow(),
+		startTimeNanos: clock.Now().WallTime,
 		CgoCalls:       metric.NewGauge(metaCgoCalls),
 		Goroutines:     metric.NewGauge(metaGoroutines),
 		GoAllocBytes:   metric.NewGauge(metaGoAllocBytes),
@@ -194,7 +194,7 @@ func (rsr *RuntimeStatSampler) SampleEnvironment() {
 	// Time statistics can be compared to the total elapsed time to create a
 	// useful percentage of total CPU usage, which would be somewhat less accurate
 	// if calculated later using downsampled time series data.
-	now := rsr.clock.PhysicalNow()
+	now := rsr.clock.Now().WallTime
 	dur := float64(now - rsr.lastNow)
 	// cpu.{User,Sys} are in milliseconds, convert to nanoseconds.
 	newUtime := int64(cpu.User) * 1e6

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -388,7 +388,7 @@ func TestMetricsRecording(t *testing.T) {
 	// Verify that metrics for the current timestamp are recorded. This should
 	// be true very quickly.
 	util.SucceedsSoon(t, func() error {
-		now := s.Clock().PhysicalNow()
+		now := s.Clock().Now().WallTime
 		if err := checkTimeSeriesKey(now, "cr.store.livebytes.1"); err != nil {
 			return err
 		}

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -138,7 +138,7 @@ VALUES(
 // physical time instead.
 func (ev EventLogger) selectEventTimestamp(input hlc.Timestamp) time.Time {
 	if input == hlc.ZeroTimestamp {
-		return ev.LeaseManager.clock.PhysicalTime()
+		return ev.LeaseManager.clock.Now().GoTime()
 	}
 	return input.GoTime()
 }

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -542,7 +542,7 @@ func (e *Executor) execRequest(session *Session, sql string, copymsg copyMsg) St
 			}
 			txnState.resetForNewSQLTxn(e, session)
 			txnState.autoRetry = true
-			txnState.sqlTimestamp = e.cfg.Clock.PhysicalTime()
+			txnState.sqlTimestamp = e.cfg.Clock.Now().GoTime()
 			if execOpt.AutoCommit {
 				txnState.txn.SetDebugName(sqlImplicitTxnName, 0)
 			} else {
@@ -937,7 +937,7 @@ func (e *Executor) execStmtInOpenTxn(
 	}
 
 	planMaker.evalCtx.SetTxnTimestamp(txnState.sqlTimestamp)
-	planMaker.evalCtx.SetStmtTimestamp(e.cfg.Clock.PhysicalTime())
+	planMaker.evalCtx.SetStmtTimestamp(e.cfg.Clock.Now().GoTime())
 
 	session := planMaker.session
 	log.Eventf(session.context, "%s", stmt)

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -140,7 +140,7 @@ func (s LeaseStore) Acquire(
 	minExpirationTime parser.DTimestamp,
 ) (*LeaseState, error) {
 	lease := &LeaseState{testingKnobs: s.testingKnobs}
-	expiration := time.Unix(0, s.clock.Now().WallTime).Add(jitteredLeaseDuration())
+	expiration := s.clock.Now().GoTime().Add(jitteredLeaseDuration())
 	expiration = expiration.Round(time.Microsecond)
 	if !minExpirationTime.IsZero() && expiration.Before(minExpirationTime.Time) {
 		expiration = minExpirationTime.Time

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -135,7 +135,7 @@ func TestRejectFutureCommand(t *testing.T) {
 
 	// Once the accumulated offset reaches MaxOffset, commands will be rejected.
 	_, pErr := client.SendWrappedWith(context.Background(), rg1(mtc.stores[0]), roachpb.Header{Timestamp: ts1.Add(clock.MaxOffset().Nanoseconds()+1, 0)}, &incArgs)
-	if !testutils.IsPError(pErr, "rejecting command with timestamp in the future") {
+	if !testutils.IsPError(pErr, "rejecting command: offset .* exceeds maximum .*") {
 		t.Fatalf("unexpected error %v", pErr)
 	}
 

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -53,7 +53,7 @@ func (s *Store) ComputeMVCCStats() (enginepb.MVCCStats, error) {
 	var err error
 
 	visitor := newStoreReplicaVisitor(s)
-	now := s.Clock().PhysicalNow()
+	now := s.Clock().Now().WallTime
 	visitor.Visit(func(r *Replica) bool {
 		var stats enginepb.MVCCStats
 		stats, err = ComputeStatsForRange(r.Desc(), s.Engine(), now)

--- a/pkg/storage/log.go
+++ b/pkg/storage/log.go
@@ -200,7 +200,7 @@ func (s *Store) logChange(
 // physical time instead.
 func selectEventTimestamp(s *Store, input hlc.Timestamp) time.Time {
 	if input == hlc.ZeroTimestamp {
-		return s.Clock().PhysicalTime()
+		return s.Clock().Now().GoTime()
 	}
 	return input.GoTime()
 }

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -324,8 +324,8 @@ func (r *Replica) leasePostApply(
 		// requests, this is kosher). This means that we don't use the old
 		// lease's expiration but instead use the new lease's start to initialize
 		// the timestamp cache low water.
-		log.Infof(ctx, "new range lease %s following %s [physicalTime=%s]",
-			newLease, prevLease, r.store.Clock().PhysicalTime())
+		log.Infof(ctx, "new range lease %s following %s [ts=%s]",
+			newLease, prevLease, r.store.Clock().Now())
 		r.mu.Lock()
 		r.mu.tsCache.SetLowWater(newLease.Start)
 		r.mu.Unlock()

--- a/pkg/storage/store_pool.go
+++ b/pkg/storage/store_pool.go
@@ -530,7 +530,7 @@ func (sp *StorePool) getStoreList(rangeID roachpb.RangeID) (StoreList, int, int)
 	var throttledStoreCount int
 	var storeDescriptors []roachpb.StoreDescriptor
 
-	now := sp.clock.PhysicalTime()
+	now := sp.clock.Now().GoTime()
 	for _, storeID := range storeIDs {
 		detail := sp.mu.storeDetails[storeID]
 		switch detail.status(now, rangeID) {

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -995,7 +995,7 @@ func TestStoreSendWithClockOffset(t *testing.T) {
 	// Set args timestamp to exceed max offset.
 	reqTS := store.cfg.Clock.Now().Add(store.cfg.Clock.MaxOffset().Nanoseconds()+1, 0)
 	_, pErr := client.SendWrappedWith(context.Background(), store.testSender(), roachpb.Header{Timestamp: reqTS}, &args)
-	if !testutils.IsPError(pErr, "rejecting command with timestamp in the future") {
+	if !testutils.IsPError(pErr, "rejecting command: offset .* exceeds maximum .*") {
 		t.Errorf("unexpected error: %v", pErr)
 	}
 }

--- a/pkg/storage/ts_maintenance_queue_test.go
+++ b/pkg/storage/ts_maintenance_queue_test.go
@@ -178,7 +178,7 @@ func TestTimeSeriesMaintenanceQueueServer(t *testing.T) {
 	// periods; this simplifies verification.
 	seriesName := "test.metric"
 	sourceName := "source1"
-	now := tsrv.Clock().PhysicalNow()
+	now := tsrv.Clock().Now().WallTime
 	nearPast := now - (ts.Resolution10s.PruneThreshold() * 2)
 	farPast := now - (ts.Resolution10s.PruneThreshold() * 4)
 	sampleDuration := ts.Resolution10s.SampleDuration()

--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -24,6 +24,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -131,18 +132,18 @@ func (c *Clock) MaxOffset() time.Duration {
 // getPhysicalClockLocked returns the current physical clock and checks for
 // time jumps.
 func (c *Clock) getPhysicalClockLocked() int64 {
-	newTime := c.physicalClock()
+	physicalTime := c.physicalClock()
 
 	if c.mu.lastPhysicalTime != 0 {
-		interval := c.mu.lastPhysicalTime - newTime
-		if interval > int64(c.maxOffset/10) {
+		interval := time.Duration(c.mu.lastPhysicalTime - physicalTime)
+		if 10*interval > c.maxOffset {
 			c.mu.monotonicityErrorsCount++
-			log.Warningf(context.TODO(), "backward time jump detected (%f seconds)", float64(newTime-c.mu.lastPhysicalTime)/1e9)
+			log.Warningf(context.TODO(), "backward time jump detected (%s)", interval)
 		}
 	}
 
-	c.mu.lastPhysicalTime = newTime
-	return newTime
+	c.mu.lastPhysicalTime = physicalTime
+	return physicalTime
 }
 
 // Now returns a timestamp associated with an event from
@@ -153,28 +154,35 @@ func (c *Clock) getPhysicalClockLocked() int64 {
 func (c *Clock) Now() Timestamp {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if physicalClock := c.getPhysicalClockLocked(); c.mu.timestamp.WallTime >= physicalClock {
+	if physicalTime := c.getPhysicalClockLocked(); c.mu.timestamp.WallTime >= physicalTime {
 		// The wall time is ahead, so the logical clock ticks.
 		c.mu.timestamp.Logical++
 	} else {
 		// Use the physical clock, and reset the logical one.
-		c.mu.timestamp.WallTime = physicalClock
+		c.mu.timestamp.WallTime = physicalTime
 		c.mu.timestamp.Logical = 0
 	}
 	return c.mu.timestamp
 }
 
-// PhysicalNow returns the local wall time. It corresponds to the physicalClock
-// provided at instantiation. For a timestamp value, use Now() instead.
-func (c *Clock) PhysicalNow() int64 {
+// CheckOffset checks the timestamp against the clock and returns an error if
+// the timestamp is ahead of the clock by more than the clock's max offset and
+// the clock's max offset is not zero.
+func (c *Clock) CheckOffset(ts Timestamp) error {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.getPhysicalClockLocked()
+	physicalTime := c.getPhysicalClockLocked()
+	c.mu.Unlock()
+	return c.checkOffset(ts, physicalTime)
 }
 
-// PhysicalTime returns a time.Time struct using the local wall time.
-func (c *Clock) PhysicalTime() time.Time {
-	return time.Unix(0, c.PhysicalNow()).UTC()
+func (c *Clock) checkOffset(ts Timestamp, physicalTime int64) error {
+	if c.maxOffset == 0 {
+		return nil
+	}
+	if offset := ts.WallTime - physicalTime; offset > c.maxOffset.Nanoseconds() {
+		return errors.Errorf("offset %s exceeds maximum %s", time.Duration(offset), c.maxOffset)
+	}
+	return nil
 }
 
 // Update takes a hybrid timestamp, usually originating from
@@ -186,15 +194,15 @@ func (c *Clock) PhysicalTime() time.Time {
 // in which case the timestamp of the clock will not have been
 // altered.
 // To timestamp events of local origin, use Now instead.
-func (c *Clock) Update(rt Timestamp) Timestamp {
+func (c *Clock) Update(ts Timestamp) Timestamp {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	physicalClock := c.getPhysicalClockLocked()
+	physicalTime := c.getPhysicalClockLocked()
 
-	if physicalClock > c.mu.timestamp.WallTime && physicalClock > rt.WallTime {
+	if physicalTime > c.mu.timestamp.WallTime && physicalTime > ts.WallTime {
 		// Our physical clock is ahead of both wall times. It is used
 		// as the new wall time and the logical clock is reset.
-		c.mu.timestamp.WallTime = physicalClock
+		c.mu.timestamp.WallTime = physicalTime
 		c.mu.timestamp.Logical = 0
 		return c.mu.timestamp
 	}
@@ -202,24 +210,23 @@ func (c *Clock) Update(rt Timestamp) Timestamp {
 	// In the remaining cases, our physical clock plays no role
 	// as it is behind the local and remote wall times. Instead,
 	// the logical clock comes into play.
-	if rt.WallTime > c.mu.timestamp.WallTime {
-		offset := time.Duration(rt.WallTime-physicalClock) * time.Nanosecond
-		if c.maxOffset > 0 && offset > c.maxOffset {
-			log.Warningf(context.TODO(), "remote wall time is too far ahead (%s) to be trustworthy - updating anyway", offset)
+	if ts.WallTime > c.mu.timestamp.WallTime {
+		if err := c.checkOffset(ts, physicalTime); err != nil {
+			log.Warningf(context.TODO(), "%s: updating anyway", err)
 		}
 		// The remote clock is ahead of ours, and we update
 		// our own logical clock with theirs.
-		c.mu.timestamp.WallTime = rt.WallTime
-		c.mu.timestamp.Logical = rt.Logical + 1
-	} else if c.mu.timestamp.WallTime > rt.WallTime {
+		c.mu.timestamp.WallTime = ts.WallTime
+		c.mu.timestamp.Logical = ts.Logical + 1
+	} else if c.mu.timestamp.WallTime > ts.WallTime {
 		// Our wall time is larger, so it remains but we tick
 		// the logical clock.
 		c.mu.timestamp.Logical++
 	} else {
 		// Both wall times are equal, and the larger logical
 		// clock is used for the update.
-		if rt.Logical > c.mu.timestamp.Logical {
-			c.mu.timestamp.Logical = rt.Logical
+		if ts.Logical > c.mu.timestamp.Logical {
+			c.mu.timestamp.Logical = ts.Logical
 		}
 		c.mu.timestamp.Logical++
 	}

--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -31,11 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
-// TODO(Tobias): Figure out if it would make sense to save some
-// history of the physical clock and react if it jumps backwards
-// repeatedly. This is expected during NTP updates, but may
-// indicate a broken clock in some cases.
-
 // Clock is a hybrid logical clock. Objects of this
 // type model causality while maintaining a relation
 // to physical time. Roughly speaking, timestamps


### PR DESCRIPTION
This should alleviate some of the rejecting timestamp in future
failures we've been seeing in tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10610)
<!-- Reviewable:end -->
