### PR TITLE
server: Ignore byte fields in TestStatusSummaries

### DIFF
--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -457,9 +457,6 @@ func compareNodeStatus(
 				"replicas.leaseholders",
 			},
 			[]string{
-				"livebytes",
-				"keybytes",
-				"valbytes",
 				"livecount",
 				"keycount",
 				"valcount",


### PR DESCRIPTION
TestStatusSummaries occasionally fails because of the asynchronous updating of
the "node liveness" table on the TestServer; occasionally, this update would
interleave with status summary generation in a way that threw off the
expectations of the test.

This is the second time this situation has happened; previously, this test
became flaky due to interleaving with the asynchronous recording of the
"NodeJoin" event by the TestServer. Because this has occurred multiple times,
instead of attempting to disable the Liveness heartbeat we will instead simply
relax the expectations of the test; it will no longer verify any "bytes" fields
on the status summary, checking only counts fields. The small value of the
verification of "Bytes" fields does not make up for the numerous headaches this
test has caused by occasionally failing incorrectly.

Fixes #9972

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10620)
<!-- Reviewable:end -->
