### PR TITLE
roachpb: more convincingly avoid nil transaction ID NPEs

### DIFF
--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -296,10 +296,12 @@ func (tc *TxnCoordSender) Send(
 			return nil, roachpb.NewError(err)
 		}
 
+		txnID := *ba.Txn.ID
+
 		// Associate the txnID with the trace. We need to do this after the
 		// maybeBeginTxn call. We set both a baggage item and a tag because only
 		// tags show up in the LIghtstep UI.
-		txnIDStr := ba.Txn.ID.String()
+		txnIDStr := txnID.String()
 		sp.SetTag("txnID", txnIDStr)
 		sp.SetBaggageItem("txnID", txnIDStr)
 
@@ -337,7 +339,7 @@ func (tc *TxnCoordSender) Send(
 
 			// Populate et.IntentSpans, taking into account both any existing
 			// and new writes, and taking care to perform proper deduplication.
-			txnMeta := tc.txns[*ba.Txn.ID]
+			txnMeta := tc.txns[txnID]
 			distinctSpans := true
 			if txnMeta != nil {
 				et.IntentSpans = txnMeta.keys
@@ -447,7 +449,7 @@ func (tc *TxnCoordSender) Send(
 	if tc.linearizable && sleepNS > 0 {
 		defer func() {
 			if log.V(1) {
-				log.Infof(ctx, "%v: waiting %s on EndTransaction for linearizability", br.Txn.ID.Short(), util.TruncateDuration(sleepNS, time.Millisecond))
+				log.Infof(ctx, "%v: waiting %s on EndTransaction for linearizability", br.Txn.Short(), util.TruncateDuration(sleepNS, time.Millisecond))
 			}
 			time.Sleep(sleepNS)
 		}()

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -337,7 +337,7 @@ func (ba BatchRequest) Split(canSplitET bool) [][]RequestUnion {
 func (ba BatchRequest) String() string {
 	var str []string
 	if ba.Txn != nil {
-		str = append(str, fmt.Sprintf("[txn: %s]", ba.Txn.ID.Short()))
+		str = append(str, fmt.Sprintf("[txn: %s]", ba.Txn.Short()))
 	}
 	for count, arg := range ba.Requests {
 		// Limit the strings to provide just a summary. Without this limit

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -913,12 +913,8 @@ func (t Transaction) String() string {
 	if len(t.Name) > 0 {
 		fmt.Fprintf(&buf, "%q ", t.Name)
 	}
-	short := "<nil>"
-	if id := t.ID; id != nil {
-		short = id.Short()
-	}
 	fmt.Fprintf(&buf, "id=%s key=%s rw=%t pri=%.8f iso=%s stat=%s epo=%d ts=%s orig=%s max=%s wto=%t rop=%t",
-		short, Key(t.Key), t.Writing, floatPri, t.Isolation, t.Status, t.Epoch, t.Timestamp,
+		t.Short(), Key(t.Key), t.Writing, floatPri, t.Isolation, t.Status, t.Epoch, t.Timestamp,
 		t.OrigTimestamp, t.MaxTimestamp, t.WriteTooOld, t.RetryOnPush)
 	return buf.String()
 }

--- a/pkg/roachpb/string_test.go
+++ b/pkg/roachpb/string_test.go
@@ -66,19 +66,20 @@ func TestTransactionString(t *testing.T) {
 		Cmd: &roachpb.BatchRequest{},
 	}
 	cmd.Cmd.Txn = &txn
-	if actStr, idStr := fmt.Sprintf("%s", &cmd), txn.ID.String(); !strings.Contains(actStr, idStr) {
+	if actStr, idStr := fmt.Sprintf("%s", &cmd), txnID.String(); !strings.Contains(actStr, idStr) {
 		t.Fatalf("expected to find '%s' in '%s'", idStr, actStr)
 	}
 }
 
 func TestBatchRequestString(t *testing.T) {
 	br := roachpb.BatchRequest{}
+	br.Txn = new(roachpb.Transaction)
 	for i := 0; i < 100; i++ {
 		br.Requests = append(br.Requests, roachpb.RequestUnion{Get: &roachpb.GetRequest{}})
 	}
 	br.Requests = append(br.Requests, roachpb.RequestUnion{EndTransaction: &roachpb.EndTransactionRequest{}})
 
-	e := `Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), ... 76 skipped ..., Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), EndTransaction [/Min,/Min)`
+	e := `[txn: <nil>], Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), ... 76 skipped ..., Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), Get [/Min,/Min), EndTransaction [/Min,/Min)`
 	if e != br.String() {
 		t.Fatalf("e = %s, v = %s", e, br.String())
 	}

--- a/pkg/storage/engine/enginepb/mvcc.go
+++ b/pkg/storage/engine/enginepb/mvcc.go
@@ -17,6 +17,14 @@
 
 package enginepb
 
+// Short returns a prefix of the transaction's ID.
+func (t TxnMeta) Short() string {
+	if id := t.ID; id != nil {
+		return id.Short()
+	}
+	return "<nil>"
+}
+
 // Total returns the range size as the sum of the key and value
 // bytes. This includes all non-live keys and all versioned values.
 func (ms MVCCStats) Total() int64 {

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -769,7 +769,7 @@ func updateTxnWithExternalIntents(
 	key := keys.TransactionKey(txn.Key, *txn.ID)
 	if txnAutoGC && len(externalIntents) == 0 {
 		if log.V(2) {
-			log.Infof(ctx, "auto-gc'ed %s (%d intents)", txn.ID.Short(), len(args.IntentSpans))
+			log.Infof(ctx, "auto-gc'ed %s (%d intents)", txn.Short(), len(args.IntentSpans))
 		}
 		return engine.MVCCDelete(ctx, batch, ms, key, hlc.ZeroTimestamp, nil /* txn */)
 	}
@@ -1413,16 +1413,9 @@ func (r *Replica) PushTxn(
 		if !pusherWins {
 			s = "failed to push"
 		}
-		pusherShort := "<nil>"
-		if id := args.PusherTxn.ID; id != nil {
-			pusherShort = id.Short()
-		}
-		pusheeShort := "<nil>"
-		if id := args.PusheeTxn.ID; id != nil {
-			pusheeShort = id.Short()
-		}
 		log.Infof(ctx, "%s "+s+" %s: %s (pushee last active: %s)",
-			pusherShort, pusheeShort, reason, reply.PusheeTxn.LastActive())
+			args.PusherTxn.Short(), args.PusheeTxn.Short(),
+			reason, reply.PusheeTxn.LastActive())
 	}
 
 	if !pusherWins {


### PR DESCRIPTION
This removes all direct callers to `Txn.ID.{Short,String}()`, hopefully putting this issue behind us.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10621)
<!-- Reviewable:end -->
