### PR TITLE
Prevent replica command retries from updating timestamp cache

### DIFF
--- a/pkg/sql/bench_test.go
+++ b/pkg/sql/bench_test.go
@@ -1245,12 +1245,10 @@ func BenchmarkInsertDistinct1Multinode_Cockroach(b *testing.B) {
 }
 
 func BenchmarkInsertDistinct10Multinode_Cockroach(b *testing.B) {
-	b.Skip("https://github.com/cockroachdb/cockroach/issues/10551")
 	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkInsertDistinct(b, db, 10) })
 }
 
 func BenchmarkInsertDistinct100Multinode_Cockroach(b *testing.B) {
-	b.Skip("https://github.com/cockroachdb/cockroach/issues/10551")
 	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkInsertDistinct(b, db, 100) })
 }
 


### PR DESCRIPTION
Previously, in the event that we reproposed a command or else discovered
on Raft application that our index was out of order, we'd both retry the
command as well as update the timestamp cache. This caused replay txn
errors in some cases.

Fixes #10551

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10639)
<!-- Reviewable:end -->
