### PR TITLE
rpc: specify grpc.WithBackoffMaxDelay(time.Second)

### DIFF
--- a/pkg/rpc/breaker.go
+++ b/pkg/rpc/breaker.go
@@ -26,6 +26,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
+const maxBackoff = time.Second
+
 // breakerClock is an implementation of clock.Clock that internally uses an
 // hlc.Clock. It is used to bridge the hlc clock to the circuit breaker
 // clocks. Note that it only implements the After() and Now() methods needed by
@@ -82,7 +84,7 @@ func newBackOff(clock backoff.Clock) backoff.BackOff {
 		InitialInterval:     500 * time.Millisecond,
 		RandomizationFactor: 0.5,
 		Multiplier:          1.5,
-		MaxInterval:         1 * time.Second,
+		MaxInterval:         maxBackoff,
 		MaxElapsedTime:      0,
 		Clock:               clock,
 	}

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -212,8 +212,9 @@ func (ctx *Context) GRPCDial(target string, opts ...grpc.DialOption) (*grpc.Clie
 			dialOpt = grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
 		}
 
-		dialOpts := make([]grpc.DialOption, 0, 1+len(opts))
+		dialOpts := make([]grpc.DialOption, 0, 2+len(opts))
 		dialOpts = append(dialOpts, dialOpt)
+		dialOpts = append(dialOpts, grpc.WithBackoffMaxDelay(maxBackoff))
 		dialOpts = append(dialOpts, opts...)
 
 		if log.V(1) {

--- a/pkg/ui/config.js
+++ b/pkg/ui/config.js
@@ -1153,10 +1153,24 @@ System.config({
       "hoek": "npm:hoek@2.16.3",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
+    "npm:source-map-support@0.4.6": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "child_process": "github:jspm/nodelibs-child_process@0.1.0",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "module": "github:jspm/nodelibs-module@0.1.0",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "querystring": "github:jspm/nodelibs-querystring@0.1.0",
+      "source-map": "npm:source-map@0.5.6"
+    },
     "npm:source-map@0.2.0": {
       "amdefine": "npm:amdefine@1.0.0",
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:source-map@0.5.6": {
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:sshpk@1.10.1": {
@@ -1236,7 +1250,8 @@ System.config({
     },
     "npm:typescript@2.0.3": {
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
-      "os": "github:jspm/nodelibs-os@0.1.0"
+      "os": "github:jspm/nodelibs-os@0.1.0",
+      "source-map-support": "npm:source-map-support@0.4.6"
     },
     "npm:ua-parser-js@0.7.10": {
       "systemjs-json": "github:systemjs/plugin-json@0.1.2"


### PR DESCRIPTION
The default grpc backoff delay is 2m. This delay kicks in when a grpc
connection encounters a transient error such as being unable to connect
or the remote end terminating the connection. Using such a high backoff
causes problems when a node is down for a significant period of
time. When the node comes back up, it will be able to talk to other
nodes in the cluster, but the other nodes won't be able to talk to it.

Fixes #10643

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10652)
<!-- Reviewable:end -->
