### PR TITLE
Revert "build: update homebrew for beta-20161110"

### DIFF
--- a/build/cockroach.rb
+++ b/build/cockroach.rb
@@ -4,8 +4,8 @@ class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
   url "https://github.com/cockroachdb/cockroach.git",
-      :tag => "beta-20161110",
-      :revision => "954063f71de001d4861d62592779408fa120dbb3"
+      :tag => "beta-20161103",
+      :revision => "9ce883365db916baa8a6d66d16bc153e7b3977e0"
   head "https://github.com/cockroachdb/cockroach.git"
 
   depends_on "go" => :build


### PR DESCRIPTION
This reverts commit 586325e65a656f6c3a6a3c5ef9aeba97ea25f736.

See #10602

Note that there's a risk here that's not present with simply removing download links from the release notes: someone who has upgraded to 1110 might get downgraded to 1103 and end up in a worse state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10664)
<!-- Reviewable:end -->
