### PR TITLE
log: clean up the handling of logging in tests.

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -50,61 +50,77 @@ import (
 type cliTest struct {
 	*server.TestServer
 	certsDir    string
-	cleanupFunc func()
+	cleanupFunc func() error
 }
 
-func (c cliTest) stop() {
-	c.cleanupFunc()
-	security.SetReadFileFn(securitytest.Asset)
-	c.Stopper().Stop()
-}
+func newCLITest(t *testing.T, insecure bool) (cliTest, error) {
+	c := cliTest{}
 
-func newCLITest() cliTest {
+	certsDir, err := ioutil.TempDir("", "cli-test")
+	if err != nil {
+		return cliTest{}, err
+	}
+	c.certsDir = certsDir
+
 	// Reset the client context for each test. We don't reset the
 	// pointer (because they are tied into the flags), but instead
 	// overwrite the existing struct's values.
 	baseCfg.InitDefaults()
 	cliCtx.InitCLIDefaults()
 
+	s, err := serverutils.StartServerRaw(base.TestServerArgs{Insecure: insecure})
+	if err != nil {
+		return cliTest{}, err
+	}
+	c.TestServer = s.(*server.TestServer)
+
+	if insecure {
+		c.cleanupFunc = func() error { return nil }
+	} else {
+		// Copy these assets to disk from embedded strings, so this test can
+		// run from a standalone binary.
+		// Disable embedded certs, or the security library will try to load
+		// our real files as embedded assets.
+		security.ResetReadFileFn()
+
+		assets := []string{
+			filepath.Join(security.EmbeddedCertsDir, security.EmbeddedCACert),
+			filepath.Join(security.EmbeddedCertsDir, security.EmbeddedCAKey),
+			filepath.Join(security.EmbeddedCertsDir, security.EmbeddedNodeCert),
+			filepath.Join(security.EmbeddedCertsDir, security.EmbeddedNodeKey),
+			filepath.Join(security.EmbeddedCertsDir, security.EmbeddedRootCert),
+			filepath.Join(security.EmbeddedCertsDir, security.EmbeddedRootKey),
+		}
+
+		for _, a := range assets {
+			securitytest.RestrictedCopy(nil, a, certsDir, filepath.Base(a))
+		}
+
+		c.cleanupFunc = func() error {
+			security.SetReadFileFn(securitytest.Asset)
+			return os.RemoveAll(certsDir)
+		}
+	}
+
+	// Ensure that CLI error messages are logged to stdout, where they
+	// can be captured.
 	osStderr = os.Stdout
 
-	s, err := serverutils.StartServerRaw(base.TestServerArgs{})
-	if err != nil {
-		log.Fatalf(context.Background(), "Could not start server: %s", err)
+	return c, nil
+}
+
+// stop cleans up after the test.
+// It also stops the test server is runStopper is true.
+// The log files are removed if the test has succeeded.
+func (c cliTest) stop(runStopper bool) {
+	// Restore stderr.
+	osStderr = os.Stderr
+
+	if runStopper {
+		c.Stopper().Stop()
 	}
-
-	tempDir, err := ioutil.TempDir("", "cli-test")
-	if err != nil {
-		log.Fatal(context.Background(), err)
-	}
-
-	// Copy these assets to disk from embedded strings, so this test can
-	// run from a standalone binary.
-	// Disable embedded certs, or the security library will try to load
-	// our real files as embedded assets.
-	security.ResetReadFileFn()
-
-	assets := []string{
-		filepath.Join(security.EmbeddedCertsDir, security.EmbeddedCACert),
-		filepath.Join(security.EmbeddedCertsDir, security.EmbeddedCAKey),
-		filepath.Join(security.EmbeddedCertsDir, security.EmbeddedNodeCert),
-		filepath.Join(security.EmbeddedCertsDir, security.EmbeddedNodeKey),
-		filepath.Join(security.EmbeddedCertsDir, security.EmbeddedRootCert),
-		filepath.Join(security.EmbeddedCertsDir, security.EmbeddedRootKey),
-	}
-
-	for _, a := range assets {
-		securitytest.RestrictedCopy(nil, a, tempDir, filepath.Base(a))
-	}
-
-	return cliTest{
-		TestServer: s.(*server.TestServer),
-		certsDir:   tempDir,
-		cleanupFunc: func() {
-			if err := os.RemoveAll(tempDir); err != nil {
-				log.Fatal(context.Background(), err)
-			}
-		},
+	if err := c.cleanupFunc(); err != nil {
+		panic(err)
 	}
 }
 
@@ -200,7 +216,15 @@ func (c cliTest) RunWithArgs(origArgs []string) {
 
 func TestQuit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	c := newCLITest()
+
+	c, err := newCLITest(t, false)
+	if err != nil {
+		panic(err)
+	}
+	// This test does not need to invoke the stopper because
+	// "quit" will have taken care of this.
+	defer c.stop(false)
+
 	c.Run("quit")
 	// Wait until this async command stops the server.
 	<-c.Stopper().IsStopped()
@@ -208,7 +232,7 @@ func TestQuit(t *testing.T) {
 	// NB: if this test is ever flaky due to port reuse, we could run against
 	// :0 (which however changes some of the errors we get).
 	// One way of getting that is:
-	//	c.TestServer.Cfg.AdvertiseAddr = "127.0.0.1:0"
+	//	c.Cfg.AdvertiseAddr = "127.0.0.1:0"
 
 	styled := func(s string) string {
 		const preamble = `unable to connect or connection lost.
@@ -251,15 +275,14 @@ communicate with a secure cluster\).
 			t.Errorf("expected '%s' to match pattern\n%s\ngot:\n%s", test.cmd, exp, out)
 		}
 	}
-	// Manually run the cleanup functions (intentionally only on success,
-	// preserving the logs on failure).
-	c.cleanupFunc()
-	security.SetReadFileFn(securitytest.Asset)
 }
 
 func Example_basic() {
-	c := newCLITest()
-	defer c.stop()
+	c, err := newCLITest(nil, false)
+	if err != nil {
+		panic(err)
+	}
+	defer c.stop(true)
 
 	c.Run("debug kv put a 1 b 2 c 3")
 	c.Run("debug kv scan")
@@ -316,8 +339,11 @@ func Example_basic() {
 }
 
 func Example_quoted() {
-	c := newCLITest()
-	defer c.stop()
+	c, err := newCLITest(nil, false)
+	if err != nil {
+		panic(err)
+	}
+	defer c.stop(true)
 
 	c.Run(`debug kv put a\x00 日本語`)                                  // UTF-8 input text
 	c.Run(`debug kv put a\x01 \u65e5\u672c\u8a9e`)                   // explicit Unicode code points
@@ -350,13 +376,11 @@ func Example_quoted() {
 }
 
 func Example_insecure() {
-	s, err := serverutils.StartServerRaw(
-		base.TestServerArgs{Insecure: true})
+	c, err := newCLITest(nil, true)
 	if err != nil {
-		log.Fatalf(context.Background(), "Could not start server: %v", err)
+		panic(err)
 	}
-	defer s.Stopper().Stop()
-	c := cliTest{TestServer: s.(*server.TestServer), cleanupFunc: func() {}}
+	defer c.stop(true)
 
 	c.Run("debug kv put a 1 b 2")
 	c.Run("debug kv scan")
@@ -370,8 +394,11 @@ func Example_insecure() {
 }
 
 func Example_ranges() {
-	c := newCLITest()
-	defer c.stop()
+	c, err := newCLITest(nil, false)
+	if err != nil {
+		panic(err)
+	}
+	defer c.stop(true)
 
 	c.Run("debug kv put a 1 b 2 c 3 d 4")
 	c.Run("debug kv scan")
@@ -432,8 +459,11 @@ func Example_ranges() {
 }
 
 func Example_logging() {
-	c := newCLITest()
-	defer c.stop()
+	c, err := newCLITest(nil, false)
+	if err != nil {
+		panic(err)
+	}
+	defer c.stop(true)
 
 	c.RunWithArgs([]string{"sql", "--alsologtostderr=false", "-e", "select 1"})
 	c.RunWithArgs([]string{"sql", "--log-backtrace-at=foo.go:1", "-e", "select 1"})
@@ -470,8 +500,11 @@ func Example_logging() {
 }
 
 func Example_cput() {
-	c := newCLITest()
-	defer c.stop()
+	c, err := newCLITest(nil, false)
+	if err != nil {
+		panic(err)
+	}
+	defer c.stop(true)
 
 	c.Run("debug kv put a 1 b 2 c 3 d 4")
 	c.Run("debug kv scan")
@@ -499,8 +532,11 @@ func Example_cput() {
 }
 
 func Example_max_results() {
-	c := newCLITest()
-	defer c.stop()
+	c, err := newCLITest(nil, false)
+	if err != nil {
+		panic(err)
+	}
+	defer c.stop(true)
 
 	c.Run("debug kv put a 1 b 2 c 3 d 4")
 	c.Run("debug kv scan --max-results=3")
@@ -531,8 +567,11 @@ func Example_max_results() {
 }
 
 func Example_zone() {
-	c := newCLITest()
-	defer c.stop()
+	c, err := newCLITest(nil, false)
+	if err != nil {
+		panic(err)
+	}
+	defer c.stop(true)
 
 	c.Run("zone ls")
 	c.Run("zone set system --file=./testdata/zone_attrs.yaml")
@@ -626,8 +665,11 @@ func Example_zone() {
 }
 
 func Example_sql() {
-	c := newCLITest()
-	defer c.stop()
+	c, err := newCLITest(nil, false)
+	if err != nil {
+		panic(err)
+	}
+	defer c.stop(true)
 
 	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.f (x int, y int); insert into t.f values (42, 69)"})
 	c.RunWithArgs([]string{"sql", "-e", "select 3", "-e", "select * from t.f"})
@@ -678,8 +720,11 @@ func Example_sql() {
 }
 
 func Example_sql_escape() {
-	c := newCLITest()
-	defer c.stop()
+	c, err := newCLITest(nil, false)
+	if err != nil {
+		panic(err)
+	}
+	defer c.stop(true)
 
 	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.t (s string, d string);"})
 	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'foo', 'printable ASCII')"})
@@ -797,8 +842,11 @@ func Example_sql_escape() {
 }
 
 func Example_user() {
-	c := newCLITest()
-	defer c.stop()
+	c, err := newCLITest(nil, false)
+	if err != nil {
+		panic(err)
+	}
+	defer c.stop(true)
 
 	c.Run("user ls")
 	c.Run("user ls --pretty")
@@ -843,18 +891,19 @@ func Example_user() {
 }
 
 func Example_user_insecure() {
-	s, err := serverutils.StartServerRaw(
-		base.TestServerArgs{Insecure: true})
+	c, err := newCLITest(nil, true)
 	if err != nil {
-		log.Fatalf(context.Background(), "Could not start server: %v", err)
+		panic(err)
 	}
-	defer s.Stopper().Stop()
-	c := cliTest{TestServer: s.(*server.TestServer), cleanupFunc: func() {}}
+	defer c.stop(true)
 
 	// Since util.IsolatedTestAddr is used on Linux in insecure test clusters,
 	// we have to reset the advertiseHost so that the value from previous
 	// tests is not used to construct an incorrect postgres URL by the client.
+	// However, ensure the value is restored in case subsequent tests need it.
+	advertiseHostSave := advertiseHost
 	advertiseHost = ""
+	defer func() { advertiseHost = advertiseHostSave }()
 
 	// No prompting for password in insecure mode.
 	c.Run("user set foo")
@@ -938,7 +987,7 @@ Available Commands:
 Flags:
       --alsologtostderr Severity[=INFO]   logs at or above this threshold go to stderr (default NONE)
       --log-backtrace-at traceLocation    when logging hits line file:N, emit a stack trace (default :0)
-      --log-dir string                    if non-empty, write log files in this directory (default "")
+      --log-dir string                    if non-empty, write log files in this directory
       --logtostderr                       log to standard error instead of files
       --no-color                          disable standard error log colorization
 
@@ -951,11 +1000,14 @@ Use "cockroach [command] --help" for more information about a command.
 }
 
 func Example_node() {
-	c := newCLITest()
-	defer c.stop()
+	c, err := newCLITest(nil, false)
+	if err != nil {
+		panic(err)
+	}
+	defer c.stop(true)
 
 	// Refresh time series data, which is required to retrieve stats.
-	if err := c.TestServer.WriteSummaries(); err != nil {
+	if err := c.WriteSummaries(); err != nil {
 		log.Fatalf(context.Background(), "Couldn't write stats summaries: %s", err)
 	}
 
@@ -982,8 +1034,11 @@ func Example_node() {
 func TestFreeze(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	c := newCLITest()
-	defer c.stop()
+	c, err := newCLITest(t, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.stop(true)
 
 	assertOutput := func(msg string) {
 		if !strings.HasSuffix(strings.TrimSpace(msg), "ok") {
@@ -1011,11 +1066,14 @@ func TestNodeStatus(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	start := timeutil.Now()
-	c := newCLITest()
-	defer c.stop()
+	c, err := newCLITest(t, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.stop(true)
 
 	// Refresh time series data, which is required to retrieve stats.
-	if err := c.TestServer.WriteSummaries(); err != nil {
+	if err := c.WriteSummaries(); err != nil {
 		t.Fatalf("couldn't write stats summaries: %s", err)
 	}
 

--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -30,9 +30,7 @@ import (
 	"github.com/spf13/pflag"
 	"gopkg.in/inf.v0"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
-	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -42,8 +40,11 @@ import (
 func TestDumpRow(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	c := newCLITest()
-	defer c.stop()
+	c, err := newCLITest(t, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.stop(true)
 
 	const create = `
 	CREATE DATABASE d;
@@ -129,10 +130,13 @@ INSERT INTO t VALUES
 func TestDumpBytes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	c, err := newCLITest(t, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.stop(true)
 
-	url, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), "TestDumpBytes", url.User(security.RootUser))
+	url, cleanup := sqlutils.PGUrl(t, c.ServingAddr(), "TestDumpBytes", url.User(security.RootUser))
 	defer cleanup()
 
 	conn := makeSQLConn(url.String())
@@ -193,10 +197,13 @@ func init() {
 func TestDumpRandom(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	c, err := newCLITest(t, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.stop(true)
 
-	url, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), "TestDumpRandom", url.User(security.RootUser))
+	url, cleanup := sqlutils.PGUrl(t, c.ServingAddr(), "TestDumpRandom", url.User(security.RootUser))
 	defer cleanup()
 
 	conn := makeSQLConn(url.String())

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -196,7 +196,9 @@ func TestStatusLocalLogs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	log.EnableLogFileOutput(dir)
+	if err := log.EnableLogFileOutput(dir); err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
 		log.DisableLogFileOutput()
 		if err := os.RemoveAll(dir); err != nil {

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -399,6 +399,9 @@ func TestListLogFiles(t *testing.T) {
 }
 
 func TestGetLogReader(t *testing.T) {
+	s := logScope(t)
+	defer s.close(t)
+
 	setFlags()
 	Warning(context.Background(), "x")
 	warn, ok := logging.file[Severity_WARNING].(*syncBuffer)
@@ -416,7 +419,11 @@ func TestGetLogReader(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	otherFile, err := os.Create(filepath.Join(logDir, "other.txt"))
+	dir, err := logDir.get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherFile, err := os.Create(filepath.Join(dir, "other.txt"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -428,11 +435,11 @@ func TestGetLogReader(t *testing.T) {
 		expErrUnrestricted string
 	}{
 		// File is not specified (trying to open a directory instead).
-		{logDir, "pathnames must be basenames", "not a regular file"},
+		{dir, "pathnames must be basenames", "not a regular file"},
 		// Absolute filename is specified.
 		{warn.file.Name(), "pathnames must be basenames", ""},
 		// Symlink to a log file.
-		{filepath.Join(logDir, removePeriods(program)+".WARNING"), "pathnames must be basenames", ""},
+		{filepath.Join(dir, removePeriods(program)+".WARNING"), "pathnames must be basenames", ""},
 		// Symlink relative to logDir.
 		{removePeriods(program) + ".WARNING", "malformed log filename", ""},
 		// Non-log file.
@@ -476,6 +483,9 @@ func TestGetLogReader(t *testing.T) {
 }
 
 func TestRollover(t *testing.T) {
+	s := logScope(t)
+	defer s.close(t)
+
 	setFlags()
 	var err error
 	defer func(previous func(error)) { logExitFunc = previous }(logExitFunc)
@@ -521,6 +531,9 @@ func TestRollover(t *testing.T) {
 }
 
 func TestLogBacktraceAt(t *testing.T) {
+	s := logScope(t)
+	defer s.close(t)
+
 	setFlags()
 	defer logging.swap(logging.newBuffers())
 	// The peculiar style of this code simplifies line counting and maintenance of the
@@ -563,6 +576,9 @@ func TestLogBacktraceAt(t *testing.T) {
 // in the future clog and this test can be adapted to actually test that;
 // right now clog writes straight to os.StdErr.
 func TestFatalStacktraceStderr(t *testing.T) {
+	s := logScope(t)
+	defer s.close(t)
+
 	setFlags()
 	logging.stderrThreshold = Severity_NONE
 	logging.toStderr = false

--- a/pkg/util/log/file.go
+++ b/pkg/util/log/file.go
@@ -34,6 +34,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/pkg/errors"
 )
 
@@ -43,47 +44,61 @@ var MaxSize uint64 = 1024 * 1024 * 10
 // If non-empty, overrides the choice of directory in which to write logs. See
 // createLogDirs for the full list of possible destinations. Note that the
 // default is to log to stderr independent of this setting. See --logtostderr.
-var logDir = func() string {
-	name, err := ioutil.TempDir("", "cockroach")
-	if err != nil {
-		panic(err)
-	}
-	return name
-}()
-var logDirSet bool
 
-// DirSet returns true of the log directory has been changed from its default.
-func DirSet() bool {
-	return logDirSet
+type logDirName struct {
+	syncutil.Mutex
+	name string
 }
 
-type stringValue struct {
-	val *string
-	set *bool
-}
+var _ flag.Value = &logDirName{}
 
-var _ flag.Value = &stringValue{}
+var logDir logDirName
 
-func newStringValue(val *string, set *bool) *stringValue {
-	return &stringValue{val: val, set: set}
-}
-
-func (s *stringValue) Set(val string) error {
-	*s.val = val
-	*s.set = true
+// Set implements the flag.Value interface.
+func (l *logDirName) Set(dir string) error {
+	l.Lock()
+	defer l.Unlock()
+	l.name = dir
 	return nil
 }
 
-func (s *stringValue) Type() string {
+// Type implements the flag.Value interface.
+func (l *logDirName) Type() string {
 	return "string"
 }
 
-func (s *stringValue) String() string {
-	if s.val == nil {
-		return ""
-	}
-	return *s.val
+// String implements the flag.Value interface.
+func (l *logDirName) String() string {
+	l.Lock()
+	defer l.Unlock()
+	return l.name
 }
+
+func (l *logDirName) clear() {
+	// For testing only.
+	l.Lock()
+	defer l.Unlock()
+	l.name = ""
+}
+
+func (l *logDirName) get() (string, error) {
+	l.Lock()
+	defer l.Unlock()
+	if len(l.name) == 0 {
+		return "", errDirectoryNotSet
+	}
+	return l.name, nil
+}
+
+func (l *logDirName) isSet() bool {
+	l.Lock()
+	res := l.name != ""
+	l.Unlock()
+	return res
+}
+
+// DirSet returns true of the log directory has been changed from its default.
+func DirSet() bool { return logDir.isSet() }
 
 // logFileRE matches log files to avoid exposing non-log files accidentally
 // and it splits the details of the filename into groups for easy parsing.
@@ -193,17 +208,18 @@ var errDirectoryNotSet = errors.New("log: log directory not set")
 // successfully, create also attempts to update the symlink for that tag, ignoring
 // errors.
 func create(severity Severity, t time.Time) (f *os.File, filename string, err error) {
-	if len(logDir) == 0 {
-		return nil, "", errDirectoryNotSet
+	dir, err := logDir.get()
+	if err != nil {
+		return nil, "", err
 	}
 	name, link := logName(severity, t)
-	fname := filepath.Join(logDir, name)
+	fname := filepath.Join(dir, name)
 
 	// Open the file os.O_APPEND|os.O_CREATE rather than use os.Create.
 	// Append is almost always more efficient than O_RDRW on most modern file systems.
 	f, err = os.OpenFile(fname, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0664)
 	if err == nil {
-		symlink := filepath.Join(logDir, link)
+		symlink := filepath.Join(dir, link)
 		_ = os.Remove(symlink) // ignore err
 		err = os.Symlink(fname, symlink)
 	}
@@ -241,10 +257,13 @@ func verifyFile(filename string) error {
 // on the local node, in any of the configured log directories.
 func ListLogFiles() ([]FileInfo, error) {
 	var results []FileInfo
-	if logDir == "" {
+	dir, err := logDir.get()
+	if err != nil {
+		// No log directory configured: simply indicate that there are no
+		// log files.
 		return nil, nil
 	}
-	infos, err := ioutil.ReadDir(logDir)
+	infos, err := ioutil.ReadDir(dir)
 	if err != nil {
 		return results, err
 	}
@@ -272,10 +291,14 @@ func ListLogFiles() ([]FileInfo, error) {
 func GetLogReader(filename string, restricted bool) (io.ReadCloser, error) {
 	// Verify there are no path separators in a restricted-mode pathname.
 	if restricted && filepath.Base(filename) != filename {
-		return nil, fmt.Errorf("pathnames must be basenames only: %s", filename)
+		return nil, errors.Errorf("pathnames must be basenames only: %s", filename)
 	}
 	if !filepath.IsAbs(filename) {
-		filename = filepath.Join(logDir, filename)
+		dir, err := logDir.get()
+		if err != nil {
+			return nil, err
+		}
+		filename = filepath.Join(dir, filename)
 	}
 	if !restricted {
 		var err error

--- a/pkg/util/log/flags.go
+++ b/pkg/util/log/flags.go
@@ -24,7 +24,7 @@ import (
 
 func init() {
 	logflags.InitFlags(&logging.mu, &logging.toStderr,
-		newStringValue(&logDir, &logDirSet), &logging.nocolor, &logging.verbosity,
+		&logDir, &logging.nocolor, &logging.verbosity,
 		&logging.vmodule, &logging.traceLocation)
 	// We define this flag here because stderrThreshold has the type Severity
 	// which we can't pass to logflags without creating an import cycle.

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -52,12 +52,12 @@ func FatalOnPanic() {
 
 // EnableLogFileOutput turns on logging using the specified directory.
 // For unittesting only.
-func EnableLogFileOutput(dir string) {
+func EnableLogFileOutput(dir string) error {
 	logging.mu.Lock()
 	defer logging.mu.Unlock()
-	logDir = dir
 	logging.toStderr = false
 	logging.stderrThreshold = Severity_INFO
+	return logDir.Set(dir)
 }
 
 // DisableLogFileOutput turns off logging. For unittesting only.
@@ -67,7 +67,7 @@ func DisableLogFileOutput() {
 	if err := logging.removeFilesLocked(); err != nil {
 		logging.exit(err)
 	}
-	logDir = ""
+	logDir.clear()
 	logging.toStderr = true
 	logging.stderrThreshold = Severity_NONE
 }

--- a/pkg/util/log/log_scope_test.go
+++ b/pkg/util/log/log_scope_test.go
@@ -1,0 +1,115 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package log
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/caller"
+)
+
+// testLogScope represents the lifetime of a logging output.  It
+// ensures that the log files are stored in a directory specific to a
+// test, and asserts that logging output is not written to this
+// directory beyond the lifetime of the scope.
+type testLogScope string
+
+// logScope creates a testLogScope which corresponds to the
+// lifetime of a logging directory. The logging directory is named
+// after the caller of MaketestLogScope, up `skip` caller levels.
+func logScope(t *testing.T) testLogScope {
+	testName := "logUnknown"
+	if _, _, f := caller.Lookup(1); f != "" {
+		parts := strings.Split(f, ".")
+		testName = "log" + parts[len(parts)-1]
+	}
+	tempDir, err := ioutil.TempDir("", testName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := dirTestOverride(tempDir); err != nil {
+		t.Fatal(err)
+	}
+	return testLogScope(tempDir)
+}
+
+// close cleans up a testLogScope. The directory and its contents are
+// deleted, unless the test has failed and the directory is non-empty.
+func (l testLogScope) close(t *testing.T) {
+	// Flush/Close the log files.
+	if err := dirTestOverride(""); err != nil {
+		t.Fatal(err)
+	}
+	// Check whether there is something to remove.
+	emptyDir, err := isDirEmpty(string(l))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if t.Failed() && !emptyDir {
+		// If the test failed, we keep the log files for further investigation,
+		// but only if there were any.
+		t.Errorf("test log files left over in: %s", l)
+	} else {
+		// Clean up.
+		if err := os.RemoveAll(string(l)); err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+// dirTestOverride sets the default value for the logging output directory
+// for use in tests.
+func dirTestOverride(dir string) error {
+	// Ensure any remaining logs are written.
+	Flush()
+
+	logDir.Lock()
+	logDir.name = dir
+	logDir.Unlock()
+
+	// When we change the directory we close the current logging
+	// output, so that a rotation to the new directory is forced on
+	// the next logging event.
+	logging.mu.Lock()
+	err := logging.closeFilesLocked()
+	logging.mu.Unlock()
+
+	return err
+}
+
+func isDirEmpty(dirname string) (bool, error) {
+	f, err := os.Open(dirname)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	list, err := f.Readdir(1)
+	errClose := f.Close()
+	if err != nil && err != io.EOF {
+		return false, err
+	}
+	if errClose != nil {
+		return false, errClose
+	}
+	return len(list) > 0, nil
+}

--- a/pkg/util/log/main_test.go
+++ b/pkg/util/log/main_test.go
@@ -34,6 +34,8 @@ func TestMain(m *testing.M) {
 			Errorf(context.Background(), "failed to clean up temp directory: %s", err)
 		}
 	}()
-	logDir = tmpDir
+	if err := logDir.Set(tmpDir); err != nil {
+		Fatal(context.Background(), err)
+	}
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
Prior to this patch, if no logging output directory is specified and
there is no store configured on the command line (the default in most
tests), logging would silently create an output directory in the
system-wide temporary directory. This caused test logging output to be
undiscoverable, and, since this directory was never removed, would
cause stress test to exhaust the filesystem's inode supply.

This patch improves upon this behavior as follows:

- a logging output directory is not any more created automatically.

- during normal logging, if no output directory is set, logging goes
  to stderr automatically instead.

- a new struct TestLogScope is introduced, intended to be used by
  tests to scope their logging output to the duration of the test.
  This automatically creates a temporary directory named after the
  test and removes it when the test complete, only when the test has
  failed.

- the tests in `pkg/util/log` and `pkg/cli` that need it are modified
  to use `TestLogScope`.

- as a side effect, the tests in pkg/cli are simplified, and a bug in
  the implementation of TestUserInsecure that would
  non-deterministically cause TestDumpRow to fail has been fixed.

Fixes #10670.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10675)
<!-- Reviewable:end -->
