### PR TITLE
cli: remove redundant text in cockroach cert create-client --help

### DIFF
--- a/pkg/cli/cert.go
+++ b/pkg/cli/cert.go
@@ -81,7 +81,7 @@ var createClientCertCmd = &cobra.Command{
 	Short: "create client cert and key",
 	Long: `
 Generates a client certificate and key, writing them to --cert and --key.
---cert and --key. CA certificate and key must be passed in.
+CA certificate and key must be passed in.
 The certs directory should contain a CA cert and key.
 `,
 	SilenceUsage: true,


### PR DESCRIPTION
Removed the redundant text in cockroach cert create-client command help text.

@jseldess 

Fixes #10539

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10676)
<!-- Reviewable:end -->
