### PR TITLE
cli: switch password flag from string to bool

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -851,7 +851,7 @@ func Example_user() {
 	c.Run("user ls")
 	c.Run("user ls --pretty")
 	c.Run("user ls --pretty=false")
-	c.Run("user set foo --password=bar")
+	c.Run("user set foo")
 	// Don't use get, since the output of hashedPassword is random.
 	// c.Run("user get foo")
 	c.Run("user ls --pretty")
@@ -871,7 +871,7 @@ func Example_user() {
 	// user ls --pretty=false
 	// 0 rows
 	// username
-	// user set foo --password=bar
+	// user set foo
 	// INSERT 1
 	// user ls --pretty
 	// +----------+
@@ -888,37 +888,6 @@ func Example_user() {
 	// +----------+
 	// +----------+
 	// (0 rows)
-}
-
-func Example_user_insecure() {
-	c, err := newCLITest(nil, true)
-	if err != nil {
-		panic(err)
-	}
-	defer c.stop(true)
-
-	// Since util.IsolatedTestAddr is used on Linux in insecure test clusters,
-	// we have to reset the advertiseHost so that the value from previous
-	// tests is not used to construct an incorrect postgres URL by the client.
-	// However, ensure the value is restored in case subsequent tests need it.
-	advertiseHostSave := advertiseHost
-	advertiseHost = ""
-	defer func() { advertiseHost = advertiseHostSave }()
-
-	// No prompting for password in insecure mode.
-	c.Run("user set foo")
-	c.Run("user ls --pretty")
-
-	// Output:
-	// user set foo
-	// INSERT 1
-	// user ls --pretty
-	// +----------+
-	// | username |
-	// +----------+
-	// | foo      |
-	// +----------+
-	// (1 row)
 }
 
 // TestFlagUsage is a basic test to make sure the fragile

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -239,11 +239,8 @@ server to listen on an external address in insecure mode.`,
 	}
 
 	Password = FlagInfo{
-		Name:   "password",
-		EnvVar: "COCKROACH_PASSWORD",
-		Description: `
-The created user's password. If not provided in secure mode, the password is
-entered through a prompt. Pass '-' to provide the password on standard input.`,
+		Name:        "password",
+		Description: `Prompt for the new user's password.`,
 	}
 
 	CACert = FlagInfo{

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -316,7 +316,7 @@ func init() {
 		intFlag(f, &keySize, cliflags.KeySize, defaultKeySize)
 	}
 
-	stringFlag(setUserCmd.Flags(), &password, cliflags.Password, "")
+	boolFlag(setUserCmd.Flags(), &password, cliflags.Password, false)
 
 	clientCmds := []*cobra.Command{
 		sqlShellCmd, quitCmd, freezeClusterCmd, dumpCmd, /* startCmd is covered above */

--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -53,13 +53,12 @@ eexpect "user root must authenticate using a client certificate"
 
 eexpect $prompt
 
-send "$argv sql --ca-cert=$ca_crt --cert=$root_crt --key=$root_key\r"
-eexpect "root@"
-send "CREATE USER carl WITH PASSWORD 'woof';\r"
-eexpect "CREATE USER\r\n"
-
-# Terminate with Ctrl+C.
-send "\003"
+send "$argv user set carl --password --ca-cert=$ca_crt --cert=$root_crt --key=$root_key\r"
+eexpect "Enter password:"
+send "woof\r"
+eexpect "Confirm password:"
+send "woof\r"
+eexpect "INSERT 1\r\n"
 
 eexpect $prompt
 


### PR DESCRIPTION
Removes special casing as mentioned in #10329. Additionally, prior to
this change, a created user's password would be saved to the cli
history.

This change is also in line with the fact that cert authentication
should be the default form of authentication. Users are created by
default without a password whereas before, an empty password flag would
trigger prompting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10680)
<!-- Reviewable:end -->
