### PR TITLE
storage: Call evaluateProposal only once

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -424,7 +424,7 @@ func tryRaftLogEntry(kv engine.MVCCKeyValue) (string, error) {
 	if ent.Type == raftpb.EntryNormal {
 		if len(ent.Data) > 0 {
 			_, cmdData := storage.DecodeRaftCommand(ent.Data)
-			var cmd storagebase.ReplicatedProposalData
+			var cmd storagebase.RaftCommand
 			if err := cmd.Unmarshal(cmdData); err != nil {
 				return "", err
 			}

--- a/pkg/roachpb/string_test.go
+++ b/pkg/roachpb/string_test.go
@@ -62,7 +62,7 @@ func TestTransactionString(t *testing.T) {
 	var txnEmpty roachpb.Transaction
 	_ = txnEmpty.String() // prevent regression of NPE
 
-	cmd := storagebase.ReplicatedProposalData{
+	cmd := storagebase.RaftCommand{
 		Cmd: &roachpb.BatchRequest{},
 	}
 	cmd.Cmd.Txn = &txn

--- a/pkg/storage/raft.go
+++ b/pkg/storage/raft.go
@@ -184,7 +184,7 @@ func raftEntryFormatter(data []byte) string {
 		// large snapshot entries.
 		return fmt.Sprintf("[%x] [%d]", commandID, len(data))
 	}
-	var cmd storagebase.ReplicatedProposalData
+	var cmd storagebase.RaftCommand
 	if err := proto.Unmarshal(encodedCmd, &cmd); err != nil {
 		return fmt.Sprintf("[error parsing entry: %s]", err)
 	}

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1808,6 +1808,27 @@ func (r *Replica) tryAddWriteCmd(
 	}
 }
 
+// requestToProposal converts a BatchRequest into a ProposalData,
+// evalutating it or not according to the propEvalKV setting.
+func (r *Replica) requestToProposal(
+	ctx context.Context,
+	idKey storagebase.CmdIDKey,
+	replica roachpb.ReplicaDescriptor,
+	ba roachpb.BatchRequest,
+) (*ProposalData, *roachpb.Error) {
+	if propEvalKV {
+		return r.evaluateProposal(ctx, idKey, replica, ba)
+	}
+	return &ProposalData{
+		Cmd: &ba,
+		LocalProposalData: LocalProposalData{
+			ctx:   ctx,
+			idKey: idKey,
+			done:  make(chan proposalResult, 1),
+		},
+	}, nil
+}
+
 // evaluateProposal generates ProposalData from the given request by evaluating
 // it, returning both state which is held only on the proposer and that which
 // is to be replicated through Raft. The return value is ready to be inserted
@@ -1818,17 +1839,8 @@ func (r *Replica) tryAddWriteCmd(
 // handling LocalProposalData.
 //
 // Replica.mu must not be held.
-//
-// reallyEvaluate is a temporary parameter aiding the transition to
-// proposer-evaluated kv. It is true iff the method is called in a pre-Raft
-// (i.e. proposer-evaluated) context, in which case a WriteBatch will be
-// prepared. In the other mode, the BatchRequest is put on the returned
-// ProposalData and is not evaluated. The intention is that in that case, the
-// same invocation with reallyEvaluate=true will be carried out downstream of
-// Raft, simulating the "old" follower-evaluated behavior.
 func (r *Replica) evaluateProposal(
 	ctx context.Context,
-	reallyEvaluate bool,
 	idKey storagebase.CmdIDKey,
 	replica roachpb.ReplicaDescriptor,
 	ba roachpb.BatchRequest,
@@ -1838,48 +1850,17 @@ func (r *Replica) evaluateProposal(
 	// evaluated KV).
 	var pd ProposalData
 
-	if !reallyEvaluate {
-		// Not using proposer-evaluated KV. Stick the Batch on
-		// ReplicatedProposalData and (mostly) call it a day.
-		pd.Cmd = &ba
-
-		// Populating these fields here avoids making code in
-		// processRaftCommand more awkward to deal with both cases.
-		if union, ok := ba.GetArg(roachpb.EndTransaction); ok {
-			ict := union.(*roachpb.EndTransactionRequest).InternalCommitTrigger
-			if tr := ict.GetChangeReplicasTrigger(); tr != nil {
-				pd.ChangeReplicas = &storagebase.ChangeReplicas{
-					ChangeReplicasTrigger: *tr,
-				}
-			}
-			if tr := ict.GetSplitTrigger(); tr != nil {
-				pd.Split = &storagebase.Split{
-					SplitTrigger: *tr,
-				}
-			}
-			if tr := ict.GetMergeTrigger(); tr != nil {
-				pd.Merge = &storagebase.Merge{
-					MergeTrigger: *tr,
-				}
-			}
-		}
-		// Set a bogus WriteBatch so that we know below that this isn't
-		// a failfast proposal (we didn't evaluate anything, so we can't fail
-		// fast).
-		pd.WriteBatch = &storagebase.ReplicatedProposalData_WriteBatch{}
-	} else {
-		if ba.Timestamp == hlc.ZeroTimestamp {
-			return nil, roachpb.NewErrorf("can't propose Raft command with zero timestamp")
-		}
-
-		pd = r.applyRaftCommandInBatch(ctx, idKey, ba)
-		// TODO(tschottdorf): tests which use TestingCommandFilter use this.
-		// Decide how that will work in the future, presumably the
-		// CommandFilter would run at proposal time or we allow an opaque
-		// struct to be attached to a proposal which is then available as it
-		// applies.
-		pd.Cmd = &ba
+	if ba.Timestamp == hlc.ZeroTimestamp {
+		return nil, roachpb.NewErrorf("can't propose Raft command with zero timestamp")
 	}
+
+	pd = r.applyRaftCommandInBatch(ctx, idKey, ba)
+	// TODO(tschottdorf): tests which use TestingCommandFilter use this.
+	// Decide how that will work in the future, presumably the
+	// CommandFilter would run at proposal time or we allow an opaque
+	// struct to be attached to a proposal which is then available as it
+	// applies.
+	pd.Cmd = &ba
 
 	if pd.Err != nil {
 		// Failed proposals (whether they're failfast or not) can't have any
@@ -1894,8 +1875,6 @@ func (r *Replica) evaluateProposal(
 		}
 	}
 
-	pd.RangeID = r.RangeID
-	pd.OriginReplica = replica
 	pd.ctx = ctx
 	pd.idKey = idKey
 	pd.done = make(chan proposalResult, 1)
@@ -1916,7 +1895,7 @@ func (r *Replica) evaluateProposal(
 	return &pd, nil
 }
 
-func (r *Replica) insertProposalLocked(pd *ProposalData) {
+func (r *Replica) insertProposalLocked(pd *ProposalData, originReplica roachpb.ReplicaDescriptor) {
 	// Assign a lease index. Note that we do this as late as possible
 	// to make sure (to the extent that we can) that we don't assign
 	// (=predict) the index differently from the order in which commands are
@@ -1924,10 +1903,11 @@ func (r *Replica) insertProposalLocked(pd *ProposalData) {
 	if r.mu.lastAssignedLeaseIndex < r.mu.state.LeaseAppliedIndex {
 		r.mu.lastAssignedLeaseIndex = r.mu.state.LeaseAppliedIndex
 	}
-	if !pd.IsLeaseRequest {
+	if !pd.Cmd.IsLeaseRequest() {
 		r.mu.lastAssignedLeaseIndex++
 	}
 	pd.MaxLeaseIndex = r.mu.lastAssignedLeaseIndex
+	pd.OriginReplica = originReplica
 	if log.V(4) {
 		log.Infof(pd.ctx, "submitting proposal %x: maxLeaseIndex=%d",
 			pd.idKey, pd.MaxLeaseIndex)
@@ -1988,12 +1968,13 @@ func (r *Replica) propose(
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()
 
-	pCmd, pErr := r.evaluateProposal(ctx, propEvalKV, makeIDKey(), repDesc, ba)
+	idKey := makeIDKey()
+	pCmd, pErr := r.requestToProposal(ctx, idKey, repDesc, ba)
 	// An error here corresponds to a failfast-proposal: The command resulted
 	// in an error and did not need to commit a batch (the common error case).
 	if pErr != nil {
 		r.handleProposalData(
-			ctx, pCmd.LocalProposalData, pCmd.ReplicatedProposalData,
+			ctx, repDesc, pCmd.LocalProposalData, pCmd.ReplicatedProposalData,
 		)
 		ch := make(chan proposalResult, 1)
 		ch <- proposalResult{Err: pErr}
@@ -2003,7 +1984,7 @@ func (r *Replica) propose(
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.insertProposalLocked(pCmd)
+	r.insertProposalLocked(pCmd, repDesc)
 
 	if err := r.submitProposalLocked(pCmd); err != nil {
 		delete(r.mu.proposals, pCmd.idKey)
@@ -2011,7 +1992,6 @@ func (r *Replica) propose(
 	}
 	// Must not use `pCmd` in the closure below as a proposal which is not
 	// present in r.mu.proposals is no longer protected by the mutex.
-	idKey := pCmd.idKey
 	tryAbandon := func() bool {
 		r.mu.Lock()
 		_, ok := r.mu.proposals[idKey]
@@ -2041,13 +2021,37 @@ func (r *Replica) isSoloReplicaLocked() bool {
 func defaultSubmitProposalLocked(r *Replica, p *ProposalData) error {
 	ctx := r.AnnotateCtx(context.TODO())
 
-	data, err := protoutil.Marshal(&p.ReplicatedProposalData)
+	raftCmd := storagebase.RaftCommand{
+		Cmd:           p.Cmd,
+		OriginReplica: p.OriginReplica,
+		MaxLeaseIndex: p.MaxLeaseIndex,
+	}
+	if p.ReplicatedProposalData != (storagebase.ReplicatedProposalData{}) {
+		raftCmd.ReplicatedProposalData = &p.ReplicatedProposalData
+		raftCmd.WriteBatch = p.WriteBatch
+	}
+
+	data, err := protoutil.Marshal(&raftCmd)
 	if err != nil {
 		return err
 	}
 	defer r.store.enqueueRaftUpdateCheck(r.RangeID)
 
-	if crt := p.ChangeReplicas; crt != nil {
+	var changeReplicas *storagebase.ChangeReplicas
+	if p.ReplicatedProposalData != (storagebase.ReplicatedProposalData{}) {
+		changeReplicas = p.ChangeReplicas
+	} else {
+		if union, ok := p.Cmd.GetArg(roachpb.EndTransaction); ok {
+			ict := union.(*roachpb.EndTransactionRequest).InternalCommitTrigger
+			if tr := ict.GetChangeReplicasTrigger(); tr != nil {
+				changeReplicas = &storagebase.ChangeReplicas{
+					ChangeReplicasTrigger: *tr,
+				}
+			}
+		}
+	}
+
+	if crt := changeReplicas; crt != nil {
 		// EndTransactionRequest with a ChangeReplicasTrigger is special
 		// because raft needs to understand it; it cannot simply be an
 		// opaque command.
@@ -2310,8 +2314,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(inSnap IncomingSnapshot) error {
 		case raftpb.EntryNormal:
 
 			var commandID storagebase.CmdIDKey
-			// TODO(tschottdorf): rename to `rpd`.
-			var command storagebase.ReplicatedProposalData
+			var command storagebase.RaftCommand
 
 			// Process committed entries. etcd raft occasionally adds a nil entry
 			// (our own commands are never empty). This happens in two situations:
@@ -2349,8 +2352,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(inSnap IncomingSnapshot) error {
 			if err := ccCtx.Unmarshal(cc.Context); err != nil {
 				return err
 			}
-			// TODO(tschottdorf): rename to `rpd`.
-			var command storagebase.ReplicatedProposalData
+			var command storagebase.RaftCommand
 			if err := command.Unmarshal(ccCtx.Payload); err != nil {
 				return err
 			}
@@ -2930,13 +2932,8 @@ func (r *Replica) reportSnapshotStatus(to uint64, snapErr error) {
 // TODO(tschottdorf): once we properly check leases and lease requests etc,
 // make sure that the error returned from this method is always populated in
 // those cases, as one of the callers uses it to abort replica changes.
-//
-// TODO(tschottdorf): rename raftCmd to `rpd`
 func (r *Replica) processRaftCommand(
-	ctx context.Context,
-	idKey storagebase.CmdIDKey,
-	index uint64,
-	raftCmd storagebase.ReplicatedProposalData,
+	ctx context.Context, idKey storagebase.CmdIDKey, index uint64, raftCmd storagebase.RaftCommand,
 ) (pErr *roachpb.Error) {
 	if index == 0 {
 		log.Fatalf(ctx, "processRaftCommand requires a non-zero index")
@@ -2946,16 +2943,32 @@ func (r *Replica) processRaftCommand(
 		log.Infof(ctx, "processing command %x: maxLeaseIndex=%d", idKey, raftCmd.MaxLeaseIndex)
 	}
 
+	// TODO(bdarnell): the isConsistencyRelated field is insufficiently tested;
+	// no tests fail if it is always set to false.
+	var isLeaseRequest, isFreeze, isConsistencyRelated bool
+	var ts hlc.Timestamp
+	if raftCmd.ReplicatedProposalData != nil {
+		isLeaseRequest = raftCmd.ReplicatedProposalData.IsLeaseRequest
+		isFreeze = raftCmd.ReplicatedProposalData.IsFreeze
+		isConsistencyRelated = raftCmd.ReplicatedProposalData.IsConsistencyRelated
+		ts = raftCmd.ReplicatedProposalData.Timestamp
+	} else if idKey != "" {
+		isLeaseRequest = raftCmd.Cmd.IsLeaseRequest()
+		isFreeze = raftCmd.Cmd.IsFreeze()
+		ts = raftCmd.Cmd.Timestamp
+		isConsistencyRelated = raftCmd.Cmd.IsConsistencyRelated()
+	}
+
 	r.mu.Lock()
 	cmd, cmdProposedLocally := r.mu.proposals[idKey]
 
 	isLeaseError := func() bool {
 		l, origin := r.mu.state.Lease, raftCmd.OriginReplica
-		if l.Replica != origin && !raftCmd.IsLeaseRequest {
+		if l.Replica != origin && !isLeaseRequest {
 			return true
 		}
-		notCovered := !l.OwnedBy(origin.StoreID) || !l.Covers(raftCmd.Timestamp)
-		if notCovered && !raftCmd.IsFreeze && !raftCmd.IsLeaseRequest {
+		notCovered := !l.OwnedBy(origin.StoreID) || !l.Covers(ts)
+		if notCovered && !isFreeze && !isLeaseRequest {
 			// Verify the range lease is held, unless this command is trying
 			// to obtain it or is a freeze change (which can be proposed by any
 			// Replica). Any other Raft command has had the range lease held
@@ -2997,7 +3010,7 @@ func (r *Replica) processRaftCommand(
 		)
 		forcedErr = roachpb.NewError(newNotLeaseHolderError(
 			r.mu.state.Lease, raftCmd.OriginReplica.StoreID, r.mu.state.Desc))
-	} else if raftCmd.IsLeaseRequest {
+	} else if isLeaseRequest {
 		// Lease commands are ignored by the counter (and their MaxLeaseIndex
 		// is ignored). This makes sense since lease commands are proposed by
 		// anyone, so we can't expect a coherent MaxLeaseIndex. Also, lease
@@ -3050,7 +3063,7 @@ func (r *Replica) processRaftCommand(
 	// TODO(tschottdorf): move up to processRaftCommand and factor it out from
 	// there so that proposer-evaluated KV can run this check too before even
 	// proposing.
-	if mayApply := !r.mu.state.IsFrozen() || cmd.IsFreeze || cmd.IsConsistencyRelated; !mayApply {
+	if mayApply := !r.mu.state.IsFrozen() || isFreeze || isConsistencyRelated; !mayApply {
 		forcedErr = roachpb.NewError(roachpb.NewRangeFrozenError(*r.mu.state.Desc))
 	}
 	r.mu.Unlock()
@@ -3063,7 +3076,7 @@ func (r *Replica) processRaftCommand(
 	} else {
 		log.Event(ctx, "applying command")
 
-		if splitMergeUnlock := r.maybeAcquireSplitMergeLock(&raftCmd); splitMergeUnlock != nil {
+		if splitMergeUnlock := r.maybeAcquireSplitMergeLock(raftCmd); splitMergeUnlock != nil {
 			// Close over pErr to capture its value at execution time.
 			defer func() {
 				splitMergeUnlock(pErr)
@@ -3072,14 +3085,13 @@ func (r *Replica) processRaftCommand(
 	}
 
 	var response proposalResult
+	var writeBatch *storagebase.WriteBatch
 	{
-		if !propEvalKV && forcedErr == nil {
+		if raftCmd.ReplicatedProposalData == nil && forcedErr == nil {
 			// If not proposer-evaluating, then our raftCmd consists only of
-			// the BatchRequest and some metadata. Call the evaluation step
-			// (again), but this time passing reallyEvaluate=true.
+			// the BatchRequest and some metadata.
 			innerPD, pErr := r.evaluateProposal(
 				ctx,
-				true, // reallyEvaluate
 				idKey,
 				raftCmd.OriginReplica,
 				*raftCmd.Cmd,
@@ -3092,7 +3104,8 @@ func (r *Replica) processRaftCommand(
 			// Note that this (intentionally) overwrites the LocalProposalData,
 			// so we must salvage the done channel if we have a client waiting
 			// on it.
-			raftCmd = innerPD.ReplicatedProposalData
+			raftCmd.ReplicatedProposalData = &innerPD.ReplicatedProposalData
+			writeBatch = innerPD.WriteBatch
 			if cmdProposedLocally {
 				done := cmd.LocalProposalData.done
 				cmd.LocalProposalData = innerPD.LocalProposalData
@@ -3107,24 +3120,32 @@ func (r *Replica) processRaftCommand(
 
 		if forcedErr != nil {
 			// Apply an empty entry.
-			raftCmd.Strip()
+			if raftCmd.ReplicatedProposalData != nil {
+				raftCmd.ReplicatedProposalData.Strip()
+			} else {
+				raftCmd.ReplicatedProposalData = &storagebase.ReplicatedProposalData{}
+			}
+			raftCmd.WriteBatch = nil
 		}
-		raftCmd.State.RaftAppliedIndex = index
-		raftCmd.State.LeaseAppliedIndex = leaseIndex
+		raftCmd.ReplicatedProposalData.State.RaftAppliedIndex = index
+		raftCmd.ReplicatedProposalData.State.LeaseAppliedIndex = leaseIndex
 
 		// Update the node clock with the serviced request. This maintains
 		// a high water mark for all ops serviced, so that received ops without
 		// a timestamp specified are guaranteed one higher than any op already
 		// executed for overlapping keys.
-		r.store.Clock().Update(raftCmd.Timestamp)
+		r.store.Clock().Update(ts)
 
 		var pErr *roachpb.Error
-		raftCmd.Delta, pErr = r.applyRaftCommand(ctx, idKey, raftCmd)
+		if raftCmd.WriteBatch != nil {
+			writeBatch = raftCmd.WriteBatch
+		}
+		raftCmd.ReplicatedProposalData.Delta, pErr = r.applyRaftCommand(ctx, idKey, *raftCmd.ReplicatedProposalData, writeBatch)
 
 		if filter := r.store.cfg.TestingKnobs.TestingApplyFilter; pErr == nil && filter != nil {
 			pErr = filter(storagebase.ApplyFilterArgs{
 				CmdID: idKey,
-				ReplicatedProposalData: raftCmd,
+				ReplicatedProposalData: *raftCmd.ReplicatedProposalData,
 				StoreID:                r.store.StoreID(),
 				RangeID:                r.RangeID,
 			})
@@ -3159,7 +3180,7 @@ func (r *Replica) processRaftCommand(
 		//
 		// Note that this must happen after committing (the engine.Batch), but
 		// before notifying a potentially waiting client.
-		r.handleProposalData(ctx, lpd, raftCmd)
+		r.handleProposalData(ctx, raftCmd.OriginReplica, lpd, *raftCmd.ReplicatedProposalData)
 	}
 
 	if cmdProposedLocally {
@@ -3173,12 +3194,34 @@ func (r *Replica) processRaftCommand(
 }
 
 func (r *Replica) maybeAcquireSplitMergeLock(
-	rpd *storagebase.ReplicatedProposalData,
+	raftCmd storagebase.RaftCommand,
 ) func(pErr *roachpb.Error) {
-	if rpd.Split != nil {
-		return r.acquireSplitLock(&rpd.Split.SplitTrigger)
-	} else if rpd.Merge != nil {
-		return r.acquireMergeLock(&rpd.Merge.MergeTrigger)
+	var split *storagebase.Split
+	var merge *storagebase.Merge
+	if raftCmd.ReplicatedProposalData != nil {
+		split = raftCmd.ReplicatedProposalData.Split
+		merge = raftCmd.ReplicatedProposalData.Merge
+	} else {
+		if union, ok := raftCmd.Cmd.GetArg(roachpb.EndTransaction); ok {
+			ict := union.(*roachpb.EndTransactionRequest).InternalCommitTrigger
+			if tr := ict.GetSplitTrigger(); tr != nil {
+				split = &storagebase.Split{
+					SplitTrigger: *tr,
+				}
+			}
+			if tr := ict.GetMergeTrigger(); tr != nil {
+				merge = &storagebase.Merge{
+					MergeTrigger: *tr,
+				}
+			}
+
+		}
+	}
+
+	if split != nil {
+		return r.acquireSplitLock(&split.SplitTrigger)
+	} else if merge != nil {
+		return r.acquireMergeLock(&merge.MergeTrigger)
 	}
 	return nil
 }
@@ -3246,7 +3289,10 @@ func (r *Replica) acquireMergeLock(merge *roachpb.MergeTrigger) func(pErr *roach
 // be updated, an error (which is likely a ReplicaCorruptionError) is returned
 // and must be handled by the caller.
 func (r *Replica) applyRaftCommand(
-	ctx context.Context, idKey storagebase.CmdIDKey, rpd storagebase.ReplicatedProposalData,
+	ctx context.Context,
+	idKey storagebase.CmdIDKey,
+	rpd storagebase.ReplicatedProposalData,
+	writeBatch *storagebase.WriteBatch,
 ) (enginepb.MVCCStats, *roachpb.Error) {
 	if rpd.State.RaftAppliedIndex <= 0 {
 		log.Fatalf(ctx, "raft command index is <= 0")
@@ -3267,8 +3313,8 @@ func (r *Replica) applyRaftCommand(
 
 	batch := r.store.Engine().NewBatch()
 	defer batch.Close()
-	if rpd.WriteBatch != nil {
-		if err := batch.ApplyBatchRepr(rpd.WriteBatch.Data); err != nil {
+	if writeBatch != nil {
+		if err := batch.ApplyBatchRepr(writeBatch.Data); err != nil {
 			return enginepb.MVCCStats{}, roachpb.NewError(NewReplicaCorruptionError(
 				errors.Wrap(err, "unable to apply WriteBatch")))
 		}
@@ -3381,6 +3427,10 @@ func (r *Replica) applyRaftCommandInBatch(
 				// TODO(tschottdorf): we're mutating the client's original
 				// memory erroneously when proposer-evaluated KV is on, failing
 				// TestTxnDBLostDeleteAnomaly (and likely others).
+				//
+				// TODO(bdarnell): we shouldn't be looking at the propEvalKV
+				// variable downstream of raft, we should look at the request
+				// to see whether this request was proposer-evaluated or not.
 				if propEvalKV {
 					ba.Txn.Writing = wasWriting
 				}
@@ -3394,7 +3444,7 @@ func (r *Replica) applyRaftCommandInBatch(
 		pd.Reply = nil
 	}
 
-	pd.WriteBatch = &storagebase.ReplicatedProposalData_WriteBatch{
+	pd.WriteBatch = &storagebase.WriteBatch{
 		Data: pd.Batch.Repr(),
 	}
 	// TODO(tschottdorf): could keep this open and commit as the proposal

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -104,7 +104,11 @@ type LocalProposalData struct {
 //    it must run when the command has applied (such as resolving intents).
 type ProposalData struct {
 	LocalProposalData
+	MaxLeaseIndex uint64
+	OriginReplica roachpb.ReplicaDescriptor
+	Cmd           *roachpb.BatchRequest
 	storagebase.ReplicatedProposalData
+	WriteBatch *storagebase.WriteBatch
 }
 
 // coalesceBool ORs rhs into lhs and then zeroes rhs.
@@ -398,13 +402,9 @@ func (r *Replica) handleReplicatedProposalData(
 	// they don't trigger an assertion at the end of the method (which checks
 	// that all fields were handled).
 	{
-		rpd.WriteBatch = nil
 		rpd.IsLeaseRequest = false
 		rpd.IsConsistencyRelated = false
 		rpd.IsFreeze = false
-		rpd.RangeID = 0
-		rpd.Cmd = nil
-		rpd.MaxLeaseIndex = 0
 		rpd.Timestamp = hlc.ZeroTimestamp
 	}
 
@@ -440,7 +440,6 @@ func (r *Replica) handleReplicatedProposalData(
 	rpd.State.Stats = enginepb.MVCCStats{}
 	rpd.State.LeaseAppliedIndex = 0
 	rpd.State.RaftAppliedIndex = 0
-	rpd.OriginReplica = roachpb.ReplicaDescriptor{}
 
 	// The above are always present, so we assert only if there are
 	// "nontrivial" actions below.
@@ -670,9 +669,11 @@ func (r *Replica) handleLocalProposalData(
 }
 
 func (r *Replica) handleProposalData(
-	ctx context.Context, lpd LocalProposalData, rpd storagebase.ReplicatedProposalData,
+	ctx context.Context,
+	originReplica roachpb.ReplicaDescriptor,
+	lpd LocalProposalData,
+	rpd storagebase.ReplicatedProposalData,
 ) {
-	originReplica := rpd.OriginReplica
 	// Careful: `shouldAssert = f() || g()` will not run both if `f()` is true.
 	shouldAssert := r.handleReplicatedProposalData(ctx, rpd)
 	shouldAssert = r.handleLocalProposalData(ctx, originReplica, lpd) || shouldAssert

--- a/pkg/storage/storagebase/proposer_kv.go
+++ b/pkg/storage/storagebase/proposer_kv.go
@@ -14,11 +14,11 @@
 
 package storagebase
 
-// Strip removes all state changes from the ReplicatedProposalData, leaving
-// only metadata behind.
+// Strip removes all state changes from the ReplicatedProposalData,
+// leaving only metadata behind.
+//
+// TODO(bdarnell): this method is insufficiently tested; there are
+// no tests that fail if it becomes a no-op.
 func (rpd *ReplicatedProposalData) Strip() {
-	*rpd = ReplicatedProposalData{
-		OriginReplica: rpd.OriginReplica,
-		RangeID:       rpd.RangeID,
-	}
+	*rpd = ReplicatedProposalData{}
 }

--- a/pkg/storage/storagebase/proposer_kv.proto
+++ b/pkg/storage/storagebase/proposer_kv.proto
@@ -59,7 +59,7 @@ message ChangeReplicas {
     (gogoproto.embed) = true];
 }
 
-// ReplicaProposalData is the structured information which together with
+// ReplicatedProposalData is the structured information which together with
 // a RocksDB WriteBatch constitutes the proposal payload in proposer-evaluated
 // KV. For the majority of proposals, we expect ReplicatedProposalData to be
 // trivial; only changes to the metadata state (splits, merges, rebalances,
@@ -70,15 +70,51 @@ message ChangeReplicas {
 // followers to reliably produce errors for proposals which apply after a
 // lease change.
 message ReplicatedProposalData {
-  // ======================================
-  // Beginning of what was formerly RaftCommand.
-  // ======================================
+  // Whether to block concurrent readers while processing the proposal data.
+  optional bool block_reads = 10001 [(gogoproto.nullable) = false];
+  // Updates to the Replica's ReplicaState. By convention and as outlined on
+  // the comment on the ReplicaState message, this field is sparsely populated
+  // and any field set overwrites the corresponding field in the state, perhaps
+  // which additional side effects (for instance on a descriptor update).
+  optional storage.storagebase.ReplicaState state = 10002 [(gogoproto.nullable) = false];
+  optional Split split = 10003;
+  optional Merge merge = 10004;
+  // TODO(tschottdorf): trim this down; we shouldn't need the whole request.
+  optional roachpb.ComputeChecksumRequest compute_checksum = 10005;
+  optional bool is_lease_request = 10006 [(gogoproto.nullable) = false];
+  optional bool is_freeze = 10007 [(gogoproto.nullable) = false];
+  // Denormalizes BatchRequest.Timestamp during the transition period for
+  // proposer-evaluated KV. Only used to verify lease coverage.
+  optional util.hlc.Timestamp timestamp = 10008 [(gogoproto.nullable) = false];
+  optional bool is_consistency_related = 10009 [(gogoproto.nullable) = false];
+  // The stats delta corresponding to the data in this WriteBatch. On
+  // a split, contains only the contributions to the left-hand side.
+  optional storage.engine.enginepb.MVCCStats delta = 10010 [(gogoproto.nullable) = false];
+  optional ChangeReplicas change_replicas = 10012;
+}
 
-  optional int64 range_id = 1 [(gogoproto.nullable) = false,
-      (gogoproto.customname) = "RangeID",
-      (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID"];
+// WriteBatch is the serialized representation of a RocksDB write
+// batch. A wrapper message is used so that the absence of the field
+// can be distinguished from a zero-length batch, and so structs
+// containing pointers to it can be compared with the == operator (we
+// rely on this in storage.ProposalData)
+message WriteBatch {
+  optional bytes data = 1;
+}
+
+// RaftCommand is the message written to the raft log. It contains
+// some metadata about the proposal itself, then either a BatchRequest
+// (legacy mode) or a ReplicatedProposalData + WriteBatch
+// (proposer-evaluated KV mode).
+message RaftCommand {
+  // Metadata about the proposal itself. These fields exist at
+  // top-level instead of being grouped in a sub-message for
+  // backwards-compatibility.
+
+  // origin_replica is the replica which proposed this command, to be
+  // used for lease validation.
   optional roachpb.ReplicaDescriptor origin_replica = 2 [(gogoproto.nullable) = false];
-  optional roachpb.BatchRequest cmd = 3;
+
   // When the command is applied, its result is an error if the lease log
   // counter has already reached (or exceeded) max_lease_index.
   //
@@ -107,39 +143,25 @@ message ReplicatedProposalData {
   // well as that uproots whatever ordering was originally envisioned.
   optional uint64 max_lease_index = 4 [(gogoproto.nullable) = false];
 
-  // ======================================
-  // End of what was formerly RaftCommand and beginning of proposer-evaluated
-  // KV protos. These are not stable. While general proto compatibility rules
+  // Legacy mode (post-raft evaluation):
+
+  // cmd is the KV command to apply.
+  // TODO(bdarnell): Should not be set when propEvalKV is used, but is currently
+  // required to support test filters.
+  optional roachpb.BatchRequest cmd = 3;
+
+  // Proposer-evaluated KV mode.
+  // These are not stable. While general proto compatibility rules
   // apply, these are intentionally kept at high tag numbers for now so that
   // a stabilized version can be inserted at low tag numbers in the future.
-  // ======================================
+  // These fields are only populated if proposer-evaluated KV was in effect when
+  // the command was proposed.
 
-  // Whether to block concurrent readers while processing the proposal data.
-  optional bool block_reads = 10001 [(gogoproto.nullable) = false];
-  // Updates to the Replica's ReplicaState. By convention and as outlined on
-  // the comment on the ReplicaState message, this field is sparsely populated
-  // and any field set overwrites the corresponding field in the state, perhaps
-  // which additional side effects (for instance on a descriptor update).
-  optional storage.storagebase.ReplicaState state = 10002 [(gogoproto.nullable) = false];
-  optional Split split = 10003;
-  optional Merge merge = 10004;
-  // TODO(tschottdorf): trim this down; we shouldn't need the whole request.
-  optional roachpb.ComputeChecksumRequest compute_checksum = 10005;
-  optional bool is_lease_request = 10006 [(gogoproto.nullable) = false];
-  optional bool is_freeze = 10007 [(gogoproto.nullable) = false];
-  // Denormalizes BatchRequest.Timestamp during the transition period for
-  // proposer-evaluated KV. Only used to verify lease coverage.
-  optional util.hlc.Timestamp timestamp = 10008 [(gogoproto.nullable) = false];
-  optional bool is_consistency_related = 10009 [(gogoproto.nullable) = false];
-  // The stats delta corresponding to the data in this WriteBatch. On
-  // a split, contains only the contributions to the left-hand side.
-  optional storage.engine.enginepb.MVCCStats delta = 10010 [(gogoproto.nullable) = false];
-  message WriteBatch {
-    optional bytes data = 1;
-  }
+  optional ReplicatedProposalData replicated_proposal_data = 10013;
   // TODO(tschottdorf): using an extra message here (and not just `bytes`) to
-  // allow the generated ReplicatedProposalData to be compared directly. If
+  // allow the generated RaftCommand to be compared directly. If
   // this costs an extra large allocation, we need to do something different.
   optional WriteBatch write_batch = 10011;
-  optional ChangeReplicas change_replicas = 10012;
+
+  reserved 1, 10001 to 10010, 10012;
 }


### PR DESCRIPTION
This method was previously called both before and after raft, and the
after-raft logic relied on fields that were set in the
ReplicatedProposalData by the before-raft logic. This caused
inconsistencies when #10327 was deployed without freeze-cluster.

Now, evaluateProposal is called only once, either before or after raft,
and the post-raft logic handles the command in whichever fashion is
appropriate for the version that proposed it.

Fixes #10602

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10681)
<!-- Reviewable:end -->
