### PR TITLE
storage: Ignore RangeNotFound errors in queues when checking for lease

### DIFF
--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -521,6 +521,11 @@ func (bq *baseQueue) processReplica(
 	defer cancel()
 	log.Eventf(ctx, "processing replica")
 
+	if err := repl.IsDestroyed(); err != nil {
+		log.VEventf(queueCtx, 3, "replica destroyed (%s); skipping", err)
+		return nil
+	}
+
 	// If the queue requires a replica to have the range lease in
 	// order to be processed, check whether this replica has range lease
 	// and renew or acquire if necessary.

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -770,6 +770,13 @@ func (r *Replica) IsFirstRange() bool {
 	return r.RangeID == 1
 }
 
+// IsDestroyed returns a non-nil error if the replica has been destroyed.
+func (r *Replica) IsDestroyed() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.mu.destroyed
+}
+
 // getLease returns the current lease, and the tentative next one, if a lease
 // request initiated by this replica is in progress.
 func (r *Replica) getLease() (*roachpb.Lease, *roachpb.Lease) {


### PR DESCRIPTION
Fixes #10677 

I believe this completely fixes the consistency queue case, but do you know whether any of the other queues that don't require the range lease may be returning errors due to a similar situation? Should I check that out?

@petermattis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10689)
<!-- Reviewable:end -->
