### PR TITLE
sql: implement foreign key references in pg_depend

### DIFF
--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -57,6 +57,7 @@ var pgCatalog = virtualSchema{
 		pgCatalogClassTable,
 		pgCatalogConstraintTable,
 		pgCatalogDatabaseTable,
+		pgCatalogDependTable,
 		pgCatalogDescriptionTable,
 		pgCatalogIndexesTable,
 		pgCatalogNamespaceTable,
@@ -560,6 +561,113 @@ CREATE TABLE pg_catalog.pg_database (
 				parser.DNull,               // datacl
 			)
 		})
+	},
+}
+var (
+	depTypeNormal        = parser.NewDString("n")
+	depTypeAuto          = parser.NewDString("a")
+	depTypeInternal      = parser.NewDString("i")
+	depTypeExtension     = parser.NewDString("e")
+	depTypeAutoExtension = parser.NewDString("x")
+	depTypePin           = parser.NewDString("p")
+
+	// Avoid unused warning for constants.
+	_ = depTypeAuto
+	_ = depTypeInternal
+	_ = depTypeExtension
+	_ = depTypeAutoExtension
+	_ = depTypePin
+)
+
+// See https://www.postgresql.org/docs/9.6/static/catalog-pg-depend.html.
+//
+// pg_depend is a fairly complex table that details many different kinds of
+// relationships between database objects. We do not implement the vast
+// majority of this table, as it is mainly used by pgjdbc to address a
+// deficiency in pg_constraint that was removed in postgres v9.0 with the
+// addition of the conindid column. To provide backward compatibility with
+// pgjdbc drivers before https://github.com/pgjdbc/pgjdbc/pull/689, we
+// provide those rows in pg_depend that track the dependency of foreign key
+// constraints on their supporting index entries in pg_class.
+var pgCatalogDependTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE pg_catalog.pg_depend (
+  classid INT,
+  objid INT,
+  objsubid INT,
+  refclassid INT,
+  refobjid INT,
+  refobjsubid INT,
+  deptype CHAR
+);
+`,
+	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+		h := makeOidHasher()
+		db, err := p.getDatabaseDesc("pg_catalog")
+		if err != nil {
+			return errors.New("could not find pg_catalog")
+		}
+		pgConstraintDesc, err := p.getTableDesc(
+			&parser.TableName{
+				DatabaseName: "pg_catalog",
+				TableName:    "pg_constraint"})
+		if err != nil {
+			return errors.New("could not find pg_catalog.pg_constraint")
+		}
+		pgConstraintTableOid := h.TableOid(db, pgConstraintDesc)
+
+		pgClassDesc, err := p.getTableDesc(
+			&parser.TableName{
+				DatabaseName: "pg_catalog",
+				TableName:    "pg_class"})
+		if err != nil {
+			return errors.New("could not find pg_catalog.pg_class")
+		}
+		pgClassTableOid := h.TableOid(db, pgClassDesc)
+
+		return forEachTableDescWithTableLookup(p,
+			func(
+				db *sqlbase.DatabaseDescriptor,
+				table *sqlbase.TableDescriptor,
+				tableLookup tableLookupFn,
+			) error {
+				info, err := table.GetConstraintInfoWithLookup(func(id sqlbase.ID) (
+					*sqlbase.TableDescriptor, error,
+				) {
+					if _, t := tableLookup(id); t != nil {
+						return t, nil
+					}
+					return nil, errors.Errorf("could not find referenced table with ID %v", id)
+				})
+				if err != nil {
+					return err
+				}
+				for _, c := range info {
+					if c.Kind != sqlbase.ConstraintTypeFK {
+						continue
+					}
+					referencedDB, _ := tableLookup(c.ReferencedTable.ID)
+					if referencedDB == nil {
+						panic(fmt.Sprintf("could not find database of %+v", c.ReferencedTable))
+					}
+
+					constraintOid := h.ForeignKeyConstraintOid(db, table, c.FK)
+					refObjID := h.IndexOid(referencedDB, c.ReferencedTable, c.ReferencedIndex)
+
+					if err := addRow(
+						pgConstraintTableOid, // classid
+						constraintOid,        // objid
+						zeroVal,              // objsubid
+						pgClassTableOid,      // refclassid
+						refObjID,             // refobjid
+						zeroVal,              // refobjsubid
+						depTypeNormal,        // deptype
+					); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
 	},
 }
 

--- a/pkg/sql/testdata/information_schema
+++ b/pkg/sql/testdata/information_schema
@@ -352,6 +352,7 @@ pg_attribute
 pg_class
 pg_constraint
 pg_database
+pg_depend
 pg_description
 pg_indexes
 pg_namespace
@@ -394,6 +395,7 @@ pg_proc
 pg_namespace
 pg_indexes
 pg_description
+pg_depend
 pg_database
 pg_constraint
 pg_class
@@ -423,6 +425,7 @@ def            pg_catalog          pg_attribute       SYSTEM VIEW  1
 def            pg_catalog          pg_class           SYSTEM VIEW  1
 def            pg_catalog          pg_constraint      SYSTEM VIEW  1
 def            pg_catalog          pg_database        SYSTEM VIEW  1
+def            pg_catalog          pg_depend          SYSTEM VIEW  1
 def            pg_catalog          pg_description     SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
@@ -471,6 +474,7 @@ def            pg_catalog          pg_attribute       SYSTEM VIEW  1
 def            pg_catalog          pg_class           SYSTEM VIEW  1
 def            pg_catalog          pg_constraint      SYSTEM VIEW  1
 def            pg_catalog          pg_database        SYSTEM VIEW  1
+def            pg_catalog          pg_depend          SYSTEM VIEW  1
 def            pg_catalog          pg_description     SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
@@ -508,6 +512,7 @@ def            pg_catalog          pg_attribute       SYSTEM VIEW  1
 def            pg_catalog          pg_class           SYSTEM VIEW  1
 def            pg_catalog          pg_constraint      SYSTEM VIEW  1
 def            pg_catalog          pg_database        SYSTEM VIEW  1
+def            pg_catalog          pg_depend          SYSTEM VIEW  1
 def            pg_catalog          pg_description     SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -50,6 +50,7 @@ pg_attribute
 pg_class
 pg_constraint
 pg_database
+pg_depend
 pg_description
 pg_indexes
 pg_namespace
@@ -499,6 +500,54 @@ ORDER BY con.oid
 conname  confkey  conpfeqop  conppeqop  conffeqop  conexclop  conbin  consrc
 fk       {2}      NULL       NULL       NULL       NULL       NULL    NULL
 fk       {3,4}    NULL       NULL       NULL       NULL       NULL    NULL
+
+## pg_catalog.pg_depend
+
+query IIIIIIT colnames
+SELECT classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype
+FROM pg_catalog.pg_depend
+ORDER BY objid
+----
+classid   objid       objsubid  refclassid  refobjid    refobjsubid  deptype
+71078581  1226447819  0         1652754864  1759889452  0            n
+71078581  1830805222  0         1652754864  1759889453  0            n
+
+# All entries in pg_depend are dependency links from the pg_constraint system
+# table to the pg_class system table.
+
+query IITT colnames
+SELECT DISTINCT classid, refclassid, cla.relname AS tablename, refcla.relname AS reftablename
+FROM pg_catalog.pg_depend
+JOIN pg_class cla ON classid=cla.oid
+JOIN pg_class refcla ON refclassid=refcla.oid
+----
+classid   refclassid  tablename      reftablename
+71078581  1652754864  pg_constraint  pg_class
+
+# All entries in pg_depend are foreign key constraints that reference an index
+# in pg_class.
+
+query TT colnames
+SELECT relname, relkind
+FROM pg_depend
+JOIN pg_class ON refobjid=pg_class.oid
+ORDER BY relname
+----
+relname    relkind
+index_key  i
+t1_a_key   i
+
+
+# All entries are pg_depend are linked to a foreign key constraint whose
+# supporting index is the referenced object id.
+
+query T colnames
+SELECT DISTINCT pg_constraint.contype
+FROM pg_depend
+JOIN pg_constraint ON objid=pg_constraint.oid AND refobjid=pg_constraint.conindid
+----
+contype
+f
 
 ## pg_catalog.pg_type
 


### PR DESCRIPTION
This commit adds a new virtual table: `pg_catalog.pg_depend`. Postgres uses [`pg_depend`](https://www.postgresql.org/docs/9.6/static/catalog-pg-depend.html) to keep track of dependency relationships between many different types of database objects. It's a fairly complex table that contains far more information than we need.

We are adding this virtual table to support `pgjdbc`, which contains a [query](https://github.com/pgjdbc/pgjdbc/blob/8be516d47ece60b7aeba5a9474b5cac1d538a04a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java#L2459) that uses `pg_depend` to determine the id of the index that supports a foreign key constraint. This join is no longer necessary in postgres 9.0, which introduced the `conindid` column to `pg_constraint` that contains exactly this data. However, `pgjdbc` still uses `pg_depend` for this purpose so we need to provide it for compatability with `pgdjbc`-based ORMs like Hibernate. https://github.com/pgjdbc/pgjdbc/pull/689 has been opened to remove usages of `pg_depend` from `pgjdbc` when the postgres backend is new enough. 

This commit adds the bare minimum for `pgjdbc` support: exactly those `pg_depend` rows that relate foreign key constraints to their supporting index entries in `pg_class`.

Fixes #10521.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10696)
<!-- Reviewable:end -->
