### PR TITLE
distsql: fix null results in evaluator

### DIFF
--- a/pkg/sql/distsql/evaluator_test.go
+++ b/pkg/sql/distsql/evaluator_test.go
@@ -34,12 +34,12 @@ func TestEvaluator(t *testing.T) {
 		v[i].SetDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
 	}
 
-	dTrue, _ := parser.ParseDBool("true")
-	dFalse, _ := parser.ParseDBool("false")
-
 	b := [2]sqlbase.EncDatum{}
-	b[0].SetDatum(sqlbase.ColumnType_BOOL, dTrue)
-	b[1].SetDatum(sqlbase.ColumnType_BOOL, dFalse)
+	b[0].SetDatum(sqlbase.ColumnType_BOOL, parser.DBoolTrue)
+	b[1].SetDatum(sqlbase.ColumnType_BOOL, parser.DBoolFalse)
+
+	var nullInt sqlbase.EncDatum
+	nullInt.SetDatum(sqlbase.ColumnType_INT, parser.DNull)
 
 	testCases := []struct {
 		spec     EvaluatorSpec
@@ -56,6 +56,7 @@ func TestEvaluator(t *testing.T) {
 				{v[6], v[2]},
 				{v[7], v[2]},
 				{v[8], v[4]},
+				{nullInt, nullInt},
 			},
 			expected: sqlbase.EncDatumRows{
 				{v[2], v[1]},
@@ -63,6 +64,7 @@ func TestEvaluator(t *testing.T) {
 				{v[2], v[6]},
 				{v[2], v[7]},
 				{v[4], v[8]},
+				{nullInt, nullInt},
 			},
 		}, {
 			spec: EvaluatorSpec{

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1623,6 +1623,34 @@ func (c *ColumnType) NumericScale() (int32, bool) {
 	return 0, false
 }
 
+// DatumTypeToColumnKind converts a parser Type to a ColumnType_Kind.
+func DatumTypeToColumnKind(typ parser.Type) ColumnType_Kind {
+	switch typ {
+	case parser.TypeBool:
+		return ColumnType_BOOL
+	case parser.TypeInt:
+		return ColumnType_INT
+	case parser.TypeFloat:
+		return ColumnType_FLOAT
+	case parser.TypeDecimal:
+		return ColumnType_DECIMAL
+	case parser.TypeBytes:
+		return ColumnType_BYTES
+	case parser.TypeString:
+		return ColumnType_STRING
+	case parser.TypeDate:
+		return ColumnType_DATE
+	case parser.TypeTimestamp:
+		return ColumnType_TIMESTAMP
+	case parser.TypeTimestampTZ:
+		return ColumnType_TIMESTAMPTZ
+	case parser.TypeInterval:
+		return ColumnType_INTERVAL
+	default:
+		panic(fmt.Sprintf("unsupported result type: %s", typ))
+	}
+}
+
 // ToDatumType converts the ColumnType_Kind to the correct type, or nil if there
 // is no correspondence.
 func (k ColumnType_Kind) ToDatumType() parser.Type {


### PR DESCRIPTION
We cannot "blindly" convert a `Datum` to an `EncDatum` without passing a column
type: it doesn't work for NULLs.

For evaluator, we can determine the types from the `TypedExpr`.

We need to do a similar fix in aggregator, and then remove the `DatumToEncDatum`
functions.

CC @arjunravinarayan

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10701)
<!-- Reviewable:end -->
