### PR TITLE
sql: add current_schema built-in function

### DIFF
--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -1250,6 +1250,20 @@ var Builtins = map[string][]Builtin{
 		},
 	},
 
+	"current_schema": {
+		Builtin{
+			Types:      ArgTypes{},
+			ReturnType: TypeString,
+			category:   categorySystemInfo,
+			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
+				if len(ctx.Database) == 0 {
+					return DNull, nil
+				}
+				return NewDString(ctx.Database), nil
+			},
+		},
+	},
+
 	// For now, schemas are the same as databases. So, current_schemas returns the
 	// current database (if one has been set by the user) and, if the passed in
 	// parameter is true, the session's database search path.

--- a/pkg/sql/testdata/builtin_function
+++ b/pkg/sql/testdata/builtin_function
@@ -1246,7 +1246,28 @@ SELECT current_schemas(false), array_upper(current_schemas(false), 1);
 {}  NULL
 
 statement ok
+SET DATABASE = ''
+
+query T
+SELECT current_schema()
+----
+NULL
+
+statement ok
 SET DATABASE = 'test'
+
+query T
+SELECT current_schema()
+----
+test
+
+statement ok
+SET DATABASE = ''
+
+query T
+SELECT current_schema()
+----
+NULL
 
 query T
 SELECT FROM_IP(b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x01\x02\x03\x04')


### PR DESCRIPTION
This is needed for Hibernate. Essentially, this returns the current
database, or NULL if there is none.

Resolves #10704

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10707)
<!-- Reviewable:end -->
