### PR TITLE
WIP: storage: add TestRebalanceWhileSplitting

### DIFF
--- a/pkg/storage/replicate_queue_test.go
+++ b/pkg/storage/replicate_queue_test.go
@@ -35,6 +35,39 @@ import (
 	"github.com/pkg/errors"
 )
 
+func TestRebalanceWhileSplitting(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Set the gossip stores interval lower to speed up rebalancing. With the
+	// default of 5s we have to wait ~5s for the rebalancing to start.
+	if err := os.Setenv("COCKROACH_GOSSIP_STORES_INTERVAL", "100ms"); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Unsetenv("COCKROACH_GOSSIP_STORES_INTERVAL"); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	const numNodes = 5
+	tc := testcluster.StartTestCluster(t, numNodes,
+		base.TestClusterArgs{ReplicationMode: base.ReplicationAuto},
+	)
+	defer tc.Stopper().Stop()
+
+	const newRanges = 5
+	for i := 0; i < newRanges; i++ {
+		tableID := keys.MaxReservedDescID + i + 1
+		splitKey := keys.MakeRowSentinelKey(keys.MakeTablePrefix(uint32(tableID)))
+		for {
+			if _, _, err := tc.SplitRange(splitKey); err != nil {
+				t.Fatal(err)
+			}
+			break
+		}
+	}
+}
+
 func TestReplicateQueueRebalance(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 


### PR DESCRIPTION
This test passes whenever COCKROACH_GOSSIP_STORES_INTERVAL is left
at its default value. It fails when it is set to 100ms.

What I'm seeing is a Cput(k, A, E) on a range descriptor running before a Cput(k, B, E) on the same descriptor (expected value=E)resulting in the second CPut() failing since E has already been replaced with A. The second CPut is originating from an AdminSplit command which indicates that AdminSplit is reading the older value E instead of A.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10710)
<!-- Reviewable:end -->
