### PR TITLE
sql/pgwire: Fix format verbs

### DIFF
--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -452,7 +452,7 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 				return d, errors.Errorf("unsupported binary bool: %q", b)
 			}
 		default:
-			return d, errors.Errorf("unsupported bool format code: %s", code)
+			return d, errors.Errorf("unsupported bool format code: %d", code)
 		}
 	case oid.T_int2:
 		switch code {
@@ -469,7 +469,7 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 			i := int16(binary.BigEndian.Uint16(b))
 			d = parser.NewDInt(parser.DInt(i))
 		default:
-			return d, errors.Errorf("unsupported int2 format code: %s", code)
+			return d, errors.Errorf("unsupported int2 format code: %d", code)
 		}
 	case oid.T_int4:
 		switch code {
@@ -486,7 +486,7 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 			i := int32(binary.BigEndian.Uint32(b))
 			d = parser.NewDInt(parser.DInt(i))
 		default:
-			return d, errors.Errorf("unsupported int4 format code: %s", code)
+			return d, errors.Errorf("unsupported int4 format code: %d", code)
 		}
 	case oid.T_int8:
 		switch code {
@@ -503,7 +503,7 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 			i := int64(binary.BigEndian.Uint64(b))
 			d = parser.NewDInt(parser.DInt(i))
 		default:
-			return d, errors.Errorf("unsupported int8 format code: %s", code)
+			return d, errors.Errorf("unsupported int8 format code: %d", code)
 		}
 	case oid.T_float4:
 		switch code {
@@ -520,7 +520,7 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 			f := math.Float32frombits(binary.BigEndian.Uint32(b))
 			d = parser.NewDFloat(parser.DFloat(f))
 		default:
-			return d, errors.Errorf("unsupported float4 format code: %s", code)
+			return d, errors.Errorf("unsupported float4 format code: %d", code)
 		}
 	case oid.T_float8:
 		switch code {
@@ -537,7 +537,7 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 			f := math.Float64frombits(binary.BigEndian.Uint64(b))
 			d = parser.NewDFloat(parser.DFloat(f))
 		default:
-			return d, errors.Errorf("unsupported float8 format code: %s", code)
+			return d, errors.Errorf("unsupported float8 format code: %d", code)
 		}
 	case oid.T_numeric:
 		switch code {
@@ -617,19 +617,19 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 			case pgNumericNeg:
 				alloc.dd.Neg(&alloc.dd.Dec)
 			default:
-				return d, errors.Errorf("unsupported numeric sign: %s", alloc.pgNum.sign)
+				return d, errors.Errorf("unsupported numeric sign: %d", alloc.pgNum.sign)
 			}
 
 			d = &alloc.dd
 		default:
-			return d, errors.Errorf("unsupported numeric format code: %s", code)
+			return d, errors.Errorf("unsupported numeric format code: %d", code)
 		}
 	case oid.T_text, oid.T_varchar:
 		switch code {
 		case formatText, formatBinary:
 			d = parser.NewDString(string(b))
 		default:
-			return d, errors.Errorf("unsupported text format code: %s", code)
+			return d, errors.Errorf("unsupported text format code: %d", code)
 		}
 	case oid.T_bytea:
 		switch code {
@@ -652,7 +652,7 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 		case formatBinary:
 			d = parser.NewDBytes(parser.DBytes(b))
 		default:
-			return d, errors.Errorf("unsupported bytea format code: %s", code)
+			return d, errors.Errorf("unsupported bytea format code: %d", code)
 		}
 	case oid.T_timestamp:
 		switch code {
@@ -669,7 +669,7 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 			i := int64(binary.BigEndian.Uint64(b))
 			d = parser.MakeDTimestamp(pgBinaryToTime(i), time.Microsecond)
 		default:
-			return d, errors.Errorf("unsupported timestamp format code: %s", code)
+			return d, errors.Errorf("unsupported timestamp format code: %d", code)
 		}
 	case oid.T_timestamptz:
 		switch code {
@@ -686,7 +686,7 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 			i := int64(binary.BigEndian.Uint64(b))
 			d = parser.MakeDTimestampTZ(pgBinaryToTime(i), time.Microsecond)
 		default:
-			return d, errors.Errorf("unsupported timestamptz format code: %s", code)
+			return d, errors.Errorf("unsupported timestamptz format code: %d", code)
 		}
 	case oid.T_date:
 		switch code {
@@ -709,7 +709,7 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 			i := int32(binary.BigEndian.Uint32(b))
 			d = pgBinaryToDate(i)
 		default:
-			return d, errors.Errorf("unsupported date format code: %s", code)
+			return d, errors.Errorf("unsupported date format code: %d", code)
 		}
 	case oid.T_interval:
 		switch code {
@@ -720,7 +720,7 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 			}
 			return d, nil
 		default:
-			return d, errors.Errorf("unsupported interval format code: %s", code)
+			return d, errors.Errorf("unsupported interval format code: %d", code)
 		}
 	default:
 		return d, errors.Errorf("unsupported OID: %v", id)


### PR DESCRIPTION
The verbs for `uint`s were `%s` instead of `%d`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10714)
<!-- Reviewable:end -->
