### PR TITLE
distsql: support interleaved tables in JoinReader

### DIFF
--- a/pkg/sql/distsql/joinreader.go
+++ b/pkg/sql/distsql/joinreader.go
@@ -87,7 +87,7 @@ func (jr *joinReader) generateKey(
 		}
 	}
 
-	return sqlbase.MakeKeyFromEncDatums(row, index.ColumnDirections, primaryKeyPrefix, alloc)
+	return sqlbase.MakeKeyFromEncDatums(row, &jr.desc, index, primaryKeyPrefix, alloc)
 }
 
 // mainLoop runs the mainLoop and returns any error.


### PR DESCRIPTION
Fixes #10702.

There is no specific test in this change, but `TestLogic/interleaved` now passes when distSQL is used (as part of some other WIP changes).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10716)
<!-- Reviewable:end -->
