### PR TITLE
sql/parser: Add support for wildcard types throughout type checking

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1305,16 +1305,6 @@ func golangFillQueryArguments(pinfo *parser.PlaceholderInfo, args []interface{})
 }
 
 func checkResultType(typ parser.Type) error {
-	// Compare all types that cannot rely on == equality.
-	istype := typ.FamilyEqual
-	switch {
-	case istype(parser.TypeCollatedString):
-		return nil
-	case istype(parser.TypePlaceholder):
-		return errors.Errorf("could not determine data type of %s", typ)
-	case istype(parser.TypeTuple):
-		return nil
-	}
 	// Compare all types that can rely on == equality.
 	switch typ {
 	case parser.TypeNull:
@@ -1331,7 +1321,16 @@ func checkResultType(typ parser.Type) error {
 	case parser.TypeStringArray:
 	case parser.TypeIntArray:
 	default:
-		return errors.Errorf("unsupported result type: %s", typ)
+		// Compare all types that cannot rely on == equality.
+		istype := typ.FamilyEqual
+		switch {
+		case istype(parser.TypeCollatedString):
+		case istype(parser.TypeTuple):
+		case istype(parser.TypePlaceholder):
+			return errors.Errorf("could not determine data type of %s", typ)
+		default:
+			return errors.Errorf("unsupported result type: %s", typ)
+		}
 	}
 	return nil
 }

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -159,7 +159,7 @@ func (p *planner) groupBy(n *parser.SelectClause, s *selectNode) (*groupNode, er
 
 	// Add the group-by expressions so they are available for bucketing.
 	for _, g := range groupBy {
-		if err := s.addRender(parser.SelectExpr{Expr: g}, nil); err != nil {
+		if err := s.addRender(parser.SelectExpr{Expr: g}, parser.NoTypePreference); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -1213,8 +1213,7 @@ var Builtins = map[string][]Builtin{
 
 	"array_length": {
 		Builtin{
-			// TODO(nvanbenschoten): Make this work with all types of arrays.
-			Types:      ArgTypes{TypeStringArray, TypeInt},
+			Types:      ArgTypes{TypeAnyArray, TypeInt},
 			ReturnType: TypeInt,
 			category:   categorySystemInfo,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
@@ -1231,8 +1230,7 @@ var Builtins = map[string][]Builtin{
 
 	"array_lower": {
 		Builtin{
-			// TODO(nvanbenschoten): Make this work with all types of arrays.
-			Types:      ArgTypes{TypeStringArray, TypeInt},
+			Types:      ArgTypes{TypeAnyArray, TypeInt},
 			ReturnType: TypeInt,
 			category:   categorySystemInfo,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
@@ -1249,8 +1247,7 @@ var Builtins = map[string][]Builtin{
 
 	"array_upper": {
 		Builtin{
-			// TODO(nvanbenschoten): Make this work with all types of arrays.
-			Types:      ArgTypes{TypeStringArray, TypeInt},
+			Types:      ArgTypes{TypeAnyArray, TypeInt},
 			ReturnType: TypeInt,
 			category:   categorySystemInfo,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {

--- a/pkg/sql/parser/constant.go
+++ b/pkg/sql/parser/constant.go
@@ -60,7 +60,7 @@ func isNumericConstant(expr Expr) bool {
 
 func typeCheckConstant(c Constant, ctx *SemaContext, desired Type) (TypedExpr, error) {
 	avail := c.AvailableTypes()
-	if desired != nil {
+	if desired != NoTypePreference {
 		for _, typ := range avail {
 			if desired.Equal(typ) {
 				return c.ResolveAsType(ctx, desired)

--- a/pkg/sql/parser/expr.go
+++ b/pkg/sql/parser/expr.go
@@ -37,7 +37,10 @@ type Expr interface {
 	//
 	// The ctx parameter defines the context in which to perform type checking.
 	// The desired parameter hints the desired type that the method's caller wants from
-	// the resulting TypedExpr.
+	// the resulting TypedExpr. It is not valid to call TypeCheck with a nil desired
+	// type. Instead, call it with the NoTypePreference value if no specific type is
+	// desired. This restriction is also true of most methods and functions related
+	// to type checking.
 	TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, error)
 }
 

--- a/pkg/sql/parser/indexed_vars_test.go
+++ b/pkg/sql/parser/indexed_vars_test.go
@@ -60,7 +60,7 @@ func TestIndexedVars(t *testing.T) {
 	c[0] = NewDInt(3)
 	c[1] = NewDInt(5)
 	c[2] = NewDInt(6)
-	typedExpr, err := expr.TypeCheck(nil, nil)
+	typedExpr, err := expr.TypeCheck(nil, NoTypePreference)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/parser/overload.go
+++ b/pkg/sql/parser/overload.go
@@ -71,7 +71,15 @@ func (a ArgTypes) match(types ArgTypes) bool {
 }
 
 func (a ArgTypes) matchAt(typ Type, i int) bool {
-	return i < len(a) && a[i].FamilyEqual(typ)
+	// The parameterized types for Tuples are checked in the type checking
+	// routines before getting here, so we only need to check if the argument
+	// type is a TypeTuple below. This allows us to avoid defining overloads
+	// for TypeTuple{}, TypeTuple{TypeAny}, TypeTuple{TypeAny, TypeAny}, etc.
+	// for Tuple operators.
+	if typ.FamilyEqual(TypeTuple) {
+		typ = TypeTuple
+	}
+	return i < len(a) && a[i].Equal(typ)
 }
 
 func (a ArgTypes) matchLen(l int) bool {
@@ -124,7 +132,11 @@ func (a NamedArgTypes) match(types ArgTypes) bool {
 }
 
 func (a NamedArgTypes) matchAt(typ Type, i int) bool {
-	return i < len(a) && a[i].Typ.FamilyEqual(typ)
+	// See ArgTypes.matchAt for explanation.
+	if typ.FamilyEqual(TypeTuple) {
+		typ = TypeTuple
+	}
+	return i < len(a) && a[i].Typ.Equal(typ)
 }
 
 func (a NamedArgTypes) matchLen(l int) bool {
@@ -285,7 +297,7 @@ func typeCheckOverloadedExprs(
 	// and adds them to the type checked slice.
 	defaultTypeCheck := func(errorOnPlaceholders bool) error {
 		for _, expr := range constExprs {
-			typ, err := expr.e.TypeCheck(ctx, nil)
+			typ, err := expr.e.TypeCheck(ctx, NoTypePreference)
 			if err != nil {
 				return fmt.Errorf("error type checking constant value: %v", err)
 			}
@@ -293,7 +305,7 @@ func typeCheckOverloadedExprs(
 		}
 		for _, expr := range placeholderExprs {
 			if errorOnPlaceholders {
-				_, err := expr.e.TypeCheck(ctx, nil)
+				_, err := expr.e.TypeCheck(ctx, NoTypePreference)
 				return err
 			}
 			// If we dont want to error on args, avoid type checking them without a desired type.
@@ -305,7 +317,7 @@ func typeCheckOverloadedExprs(
 	// If no overloads are provided, just type check parameters and return.
 	if len(overloads) == 0 {
 		for _, expr := range resolvableExprs {
-			typ, err := expr.e.TypeCheck(ctx, nil)
+			typ, err := expr.e.TypeCheck(ctx, NoTypePreference)
 			if err != nil {
 				return nil, nil, fmt.Errorf("error type checking resolved expression: %v", err)
 			}
@@ -410,7 +422,7 @@ func typeCheckOverloadedExprs(
 	}
 
 	// The first heuristic is to prefer candidates that return the desired type.
-	if desired != nil {
+	if desired != NoTypePreference {
 		filterOverloads(func(o overloadImpl) bool {
 			return o.returnType().Equal(desired)
 		})

--- a/pkg/sql/parser/overload_test.go
+++ b/pkg/sql/parser/overload_test.go
@@ -164,7 +164,11 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 	for i, d := range testData {
 		ctx := MakeSemaContext()
 		ctx.Placeholders.SetTypes(d.ptypes)
-		_, fn, err := typeCheckOverloadedExprs(&ctx, d.desired, d.overloads, d.exprs...)
+		desired := NoTypePreference
+		if d.desired != nil {
+			desired = d.desired
+		}
+		_, fn, err := typeCheckOverloadedExprs(&ctx, desired, d.overloads, d.exprs...)
 		if d.expectedOverload != nil {
 			if err != nil {
 				t.Errorf("%d: unexpected error returned from typeCheckOverloadedExprs when type checking %s: %v", i, d.exprs, err)

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -76,7 +76,7 @@ func (p *Parser) Parse(sql string, syntax Syntax) (stmts StatementList, err erro
 
 // NoTypePreference can be provided to TypeCheck's desired type parameter to indicate that
 // the caller of the function has no preference on the type of the resulting TypedExpr.
-var NoTypePreference = Type(nil)
+var NoTypePreference = TypeAny
 
 // TypeCheck performs type checking on the provided expression tree, returning
 // the new typed expression tree, which additionally permits evaluation and type
@@ -87,6 +87,9 @@ var NoTypePreference = Type(nil)
 // be used to hint the desired type for the root of the resulting typed expression
 // tree.
 func TypeCheck(expr Expr, ctx *SemaContext, desired Type) (TypedExpr, error) {
+	if desired == nil {
+		panic("the desired type for parser.TypeCheck cannot be nil, use NoTypePreference instead")
+	}
 	expr, err := foldConstantLiterals(expr)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -127,7 +127,7 @@ func (expr *BinaryExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, er
 
 	if fn == nil {
 		var desStr string
-		if desired != nil {
+		if desired != NoTypePreference {
 			desStr = fmt.Sprintf(" (desired <%s>)", desired)
 		}
 		return nil, fmt.Errorf("unsupported binary operator: <%s> %s <%s>%s",
@@ -150,7 +150,7 @@ func (expr *CaseExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, erro
 			tmpExprs = append(tmpExprs, when.Cond)
 		}
 
-		typedSubExprs, _, err := typeCheckSameTypedExprs(ctx, nil, tmpExprs...)
+		typedSubExprs, _, err := typeCheckSameTypedExprs(ctx, NoTypePreference, tmpExprs...)
 		if err != nil {
 			return nil, decorateTypeCheckError(err, "incompatible condition type")
 		}
@@ -360,7 +360,7 @@ func (expr *FuncExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, erro
 			typeNames = append(typeNames, expr.ResolvedType().String())
 		}
 		var desStr string
-		if desired != nil {
+		if desired != NoTypePreference {
 			desStr = fmt.Sprintf(" (desired <%s>)", desired)
 		}
 		return nil, fmt.Errorf("unknown signature: %s(%s)%s",
@@ -533,7 +533,7 @@ func (expr *AllColumnsSelector) TypeCheck(_ *SemaContext, desired Type) (TypedEx
 
 // TypeCheck implements the Expr interface.
 func (expr *RangeCond) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, error) {
-	typedSubExprs, _, err := typeCheckSameTypedExprs(ctx, nil, expr.Left, expr.From, expr.To)
+	typedSubExprs, _, err := typeCheckSameTypedExprs(ctx, NoTypePreference, expr.Left, expr.From, expr.To)
 	if err != nil {
 		return nil, err
 	}
@@ -569,7 +569,7 @@ func (expr *UnaryExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, err
 
 	if fn == nil {
 		var desStr string
-		if desired != nil {
+		if desired != NoTypePreference {
 			desStr = fmt.Sprintf(" (desired <%s>)", desired)
 		}
 		return nil, fmt.Errorf("unsupported unary operator: %s <%s>%s",
@@ -763,7 +763,7 @@ func typeCheckComparisonOp(
 		sameTypeExprs = append(sameTypeExprs, foldedLeft)
 		sameTypeExprs = append(sameTypeExprs, rightTuple.Exprs...)
 
-		typedSubExprs, retType, err := typeCheckSameTypedExprs(ctx, nil, sameTypeExprs...)
+		typedSubExprs, retType, err := typeCheckSameTypedExprs(ctx, NoTypePreference, sameTypeExprs...)
 		if err != nil {
 			return nil, nil, CmpOp{}, fmt.Errorf(unsupportedCompErrFmtWithExprs,
 				left, op, right, err)
@@ -792,7 +792,7 @@ func typeCheckComparisonOp(
 			return nil, nil, CmpOp{}, fmt.Errorf(unsupportedCompErrFmtWithTypes, TypeTuple, op, TypeTuple)
 		}
 		// Using non-folded left and right to avoid having to swap later.
-		typedSubExprs, _, err := typeCheckSameTypedTupleExprs(ctx, nil, left, right)
+		typedSubExprs, _, err := typeCheckSameTypedTupleExprs(ctx, NoTypePreference, left, right)
 		if err != nil {
 			return nil, nil, CmpOp{}, err
 		}
@@ -803,7 +803,7 @@ func typeCheckComparisonOp(
 	for i := range ops {
 		overloads[i] = ops[i]
 	}
-	typedSubExprs, fn, err := typeCheckOverloadedExprs(ctx, nil, overloads, foldedLeft, foldedRight)
+	typedSubExprs, fn, err := typeCheckOverloadedExprs(ctx, NoTypePreference, overloads, foldedLeft, foldedRight)
 	if err != nil {
 		return nil, nil, CmpOp{}, err
 	}
@@ -909,7 +909,7 @@ func typeCheckSameTypedExprs(
 		}
 
 		// If typ is not nil, all consts try to become typ.
-		if typ != nil {
+		if typ != NoTypePreference {
 			all := true
 			for _, constExpr := range constExprs {
 				if !canConstantBecome(constExpr.e.(Constant), typ) {

--- a/pkg/sql/parser/type_check_test.go
+++ b/pkg/sql/parser/type_check_test.go
@@ -231,7 +231,11 @@ func attemptTypeCheckSameTypedExprs(t *testing.T, idx int, test sameTypedExprsTe
 	forEachPerm(test.exprs, 0, func(exprs []copyableExpr) {
 		ctx := MakeSemaContext()
 		ctx.Placeholders.SetTypes(clonePlaceholderTypes(test.ptypes))
-		_, typ, err := typeCheckSameTypedExprs(&ctx, test.desired, buildExprs(exprs)...)
+		desired := NoTypePreference
+		if test.desired != nil {
+			desired = test.desired
+		}
+		_, typ, err := typeCheckSameTypedExprs(&ctx, desired, buildExprs(exprs)...)
 		if err != nil {
 			t.Errorf("%d: unexpected error returned from typeCheckSameTypedExprs: %v", idx, err)
 		} else {
@@ -368,8 +372,12 @@ func TestTypeCheckSameTypedExprsError(t *testing.T) {
 	for i, d := range testData {
 		ctx := MakeSemaContext()
 		ctx.Placeholders.SetTypes(d.ptypes)
+		desired := NoTypePreference
+		if d.desired != nil {
+			desired = d.desired
+		}
 		forEachPerm(d.exprs, 0, func(exprs []copyableExpr) {
-			if _, _, err := typeCheckSameTypedExprs(&ctx, d.desired, buildExprs(exprs)...); !testutils.IsError(err, d.expectedErr) {
+			if _, _, err := typeCheckSameTypedExprs(&ctx, desired, buildExprs(exprs)...); !testutils.IsError(err, d.expectedErr) {
 				t.Errorf("%d: expected %s, but found %v", i, d.expectedErr, err)
 			}
 		})

--- a/pkg/sql/pgtypes.go
+++ b/pkg/sql/pgtypes.go
@@ -80,6 +80,8 @@ func DatumToOid(typ parser.Type) (oid.Oid, bool) {
 			return oid.T__int8, true
 		case parser.TypeStringArray:
 			return oid.T__text, true
+		case parser.TypeAnyArray:
+			return oid.T_anyarray, true
 		}
 	}
 	return dOid, ok

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -79,14 +79,6 @@ type pgNumeric struct {
 }
 
 func pgTypeForParserType(t parser.Type) pgType {
-	// Compare all types that cannot rely on == equality.
-	istype := t.FamilyEqual
-	switch {
-	case istype(parser.TypeCollatedString):
-		return pgType{oid.T_unknown, -1}
-	case istype(parser.TypeTuple):
-		return pgType{oid.T_record, -1}
-	}
 	// Compare all types that can rely on == equality.
 	switch t {
 	case parser.TypeNull:
@@ -116,7 +108,16 @@ func pgTypeForParserType(t parser.Type) pgType {
 	case parser.TypeIntArray:
 		return pgType{oid.T__int8, -1}
 	default:
-		panic(fmt.Sprintf("unsupported type %s", t))
+		// Compare all types that cannot rely on == equality.
+		istype := t.FamilyEqual
+		switch {
+		case istype(parser.TypeCollatedString):
+			return pgType{oid.T_unknown, -1}
+		case istype(parser.TypeTuple):
+			return pgType{oid.T_record, -1}
+		default:
+			panic(fmt.Sprintf("unsupported type %s", t))
+		}
 	}
 }
 

--- a/pkg/sql/select.go
+++ b/pkg/sql/select.go
@@ -488,7 +488,7 @@ func (s *selectNode) initTargets(targets parser.SelectExprs, desiredTypes []pars
 	// we're going to use to generate the returned column set and the names for
 	// those columns.
 	for i, target := range targets {
-		var desiredType parser.Type
+		desiredType := parser.NoTypePreference
 		if len(desiredTypes) > i {
 			desiredType = desiredTypes[i]
 		}

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -207,7 +207,8 @@ func (p *planner) orderBy(orderBy parser.OrderBy, n planNode) (*sortNode, error)
 			// not be optimized as well as "ORDER BY foo.x, foo.y".  We
 			// could do this either here or as a separate later
 			// optimization.
-			if err := s.addRender(parser.SelectExpr{Expr: expr}, nil); err != nil {
+			err := s.addRender(parser.SelectExpr{Expr: expr}, parser.NoTypePreference)
+			if err != nil {
 				return nil, err
 			}
 

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -204,6 +204,9 @@ func (p *planner) Update(
 	// Remember the index where the targets for exprs start.
 	exprTargetIdx := len(targets)
 	desiredTypesFromSelect := make([]parser.Type, len(targets), len(targets)+len(exprs))
+	for i := range targets {
+		desiredTypesFromSelect[i] = parser.NoTypePreference
+	}
 	for _, expr := range exprs {
 		if expr.Tuple {
 			switch t := expr.Expr.(type) {

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -176,7 +176,9 @@ func (n *windowNode) constructWindowDefinitions(sc *parser.SelectClause, s *sele
 		// Validate PARTITION BY clause.
 		for _, partition := range windowDef.Partitions {
 			windowFn.partitionIdxs = append(windowFn.partitionIdxs, len(s.render)-origRenderLen)
-			if err := s.addRender(parser.SelectExpr{Expr: partition}, nil); err != nil {
+
+			err := s.addRender(parser.SelectExpr{Expr: partition}, parser.NoTypePreference)
+			if err != nil {
 				return err
 			}
 		}
@@ -192,7 +194,9 @@ func (n *windowNode) constructWindowDefinitions(sc *parser.SelectClause, s *sele
 				Direction: direction,
 			}
 			windowFn.columnOrdering = append(windowFn.columnOrdering, ordering)
-			if err := s.addRender(parser.SelectExpr{Expr: orderBy.Expr}, nil); err != nil {
+
+			err := s.addRender(parser.SelectExpr{Expr: orderBy.Expr}, parser.NoTypePreference)
+			if err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Fixes #10619.

One of the major changes here is that `NoTypePreference` has been moved
to be an alias of `TypeAny`. This means that by desiring a type like
`tArray{TypeAny}`, we are essentially desiring an array with no
preference on its parameterized type.

This is going to conflict with #10584, so I intend to let that change merge first.
Once that merges, I'll also be able to include a second commit here adding in
`tArray{tInt}` tests using the `tArray{tAny}` overloads to better demonstrate
that this works without creating ambiguity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10717)
<!-- Reviewable:end -->
