### PR TITLE
sql/parser: Remove SingleType typeList implementation

### DIFF
--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -72,7 +72,7 @@ func (UnaryOp) preferred() bool {
 func init() {
 	for op, overload := range UnaryOps {
 		for i, impl := range overload {
-			impl.types = SingleType{impl.Typ}
+			impl.types = ArgTypes{impl.Typ}
 			UnaryOps[op][i] = impl
 		}
 	}

--- a/pkg/sql/parser/overload.go
+++ b/pkg/sql/parser/overload.go
@@ -53,7 +53,6 @@ var _ typeList = ArgTypes{}
 var _ typeList = NamedArgTypes{}
 var _ typeList = AnyType{}
 var _ typeList = VariadicType{}
-var _ typeList = SingleType{}
 
 // ArgTypes is a typeList implementation that accepts a specific number of
 // argument types.
@@ -237,52 +236,6 @@ func (v VariadicType) Types() []Type {
 
 func (v VariadicType) String() string {
 	return fmt.Sprintf("%s...", v.Typ)
-}
-
-// SingleType is a typeList implementation which accepts a single
-// argument of type typ. It is logically identical to an ArgTypes
-// implementation with length 1, but avoids the slice allocation.
-type SingleType struct {
-	Typ Type
-}
-
-func (s SingleType) match(types ArgTypes) bool {
-	if len(types) != 1 {
-		return false
-	}
-	return s.matchAt(types[0], 0)
-}
-
-func (s SingleType) matchAt(typ Type, i int) bool {
-	if i != 0 {
-		return false
-	}
-	return typ.Equal(s.Typ)
-}
-
-func (s SingleType) matchLen(l int) bool {
-	return l == 1
-}
-
-func (s SingleType) getAt(i int) Type {
-	if i != 0 {
-		return nil
-	}
-	return s.Typ
-}
-
-// Length implements the typeList interface.
-func (s SingleType) Length() int {
-	return 1
-}
-
-// Types implements the typeList interface.
-func (s SingleType) Types() []Type {
-	return []Type{s.Typ}
-}
-
-func (s SingleType) String() string {
-	return s.Typ.String()
 }
 
 // typeCheckOverloadedExprs determines the correct overload to use for the given set of


### PR DESCRIPTION
The type was a specialization of `ArgTypes` that duplicated logic for
the purpose of performance, but was only used through static
initialization. This reduces code and repetition.

If we are ever worried about performance here (which we won't be), we
can always share a single instance of `ArgTypes` for all `typeList`s
with the same types. We could also do something like this with an
`EmptyArgType` variable, but it doesn't seem necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10718)
<!-- Reviewable:end -->
