### PR TITLE
storage: Unskip TestReplicaBurstPendingCommandsAndRepropose

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2694,7 +2694,7 @@ func (r *Replica) refreshProposalsLocked(refreshAtDelta int, reason refreshRaftR
 	if log.V(1) && (numShouldRetry > 0 || len(reproposals) > 0) {
 		ctx := r.AnnotateCtx(context.TODO())
 		log.Infof(ctx,
-			"pending commands: sent %d back to client, reproposing %d (at %d.%d)k %s",
+			"pending commands: sent %d back to client, reproposing %d (at %d.%d) %s",
 			numShouldRetry, len(reproposals), r.mu.state.RaftAppliedIndex,
 			r.mu.state.LeaseAppliedIndex, reason)
 	}


### PR DESCRIPTION
This test needed some updates for new locks, but I can no longer
reproduce the issue that caused it to be skipped.

Fixes #8422

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10722)
<!-- Reviewable:end -->
