### PR TITLE
storage: disable lease rebalancing by default

### DIFF
--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -550,10 +550,12 @@ func (a *Allocator) ShouldTransferLease(
 	return shouldTransferLease(sl, source)
 }
 
-var enableLeaseRebalancing = envutil.EnvOrDefaultBool("COCKROACH_ENABLE_LEASE_REBALANCING", true)
+// EnableLeaseRebalancing controls whether lease rebalancing is enabled or
+// not. Exported for testing.
+var EnableLeaseRebalancing = envutil.EnvOrDefaultBool("COCKROACH_ENABLE_LEASE_REBALANCING", false)
 
 func shouldTransferLease(sl StoreList, source roachpb.StoreDescriptor) bool {
-	if !enableLeaseRebalancing {
+	if !EnableLeaseRebalancing {
 		return false
 	}
 	// Allow lease transfer if we're above the overfull threshold, which is

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -943,6 +943,12 @@ func TestAllocatorTransferLeaseTarget(t *testing.T) {
 	)
 	defer stopper.Stop()
 
+	// TODO(peter): Remove when lease rebalancing is the default.
+	defer func(v bool) {
+		EnableLeaseRebalancing = v
+	}(EnableLeaseRebalancing)
+	EnableLeaseRebalancing = true
+
 	// 3 stores where the lease count for each store is equal to 10x the store
 	// ID.
 	var stores []*roachpb.StoreDescriptor
@@ -999,6 +1005,12 @@ func TestAllocatorShouldTransferLease(t *testing.T) {
 		/* useRuleSolver */ false,
 	)
 	defer stopper.Stop()
+
+	// TODO(peter): Remove when lease rebalancing is the default.
+	defer func(v bool) {
+		EnableLeaseRebalancing = v
+	}(EnableLeaseRebalancing)
+	EnableLeaseRebalancing = true
 
 	// 3 stores where the lease count for each store is equal to 10x the store
 	// ID.

--- a/pkg/storage/replicate_queue_test.go
+++ b/pkg/storage/replicate_queue_test.go
@@ -49,6 +49,12 @@ func TestReplicateQueueRebalance(t *testing.T) {
 		}
 	}()
 
+	// TODO(peter): Remove when lease rebalancing is the default.
+	defer func(v bool) {
+		storage.EnableLeaseRebalancing = v
+	}(storage.EnableLeaseRebalancing)
+	storage.EnableLeaseRebalancing = true
+
 	const numNodes = 5
 	tc := testcluster.StartTestCluster(t, numNodes,
 		base.TestClusterArgs{ReplicationMode: base.ReplicationAuto},


### PR DESCRIPTION
Lease rebalancing appears to be dramatically slowing down necessary
up-replication. Disable by default while this is being investigated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10730)
<!-- Reviewable:end -->
