### PR TITLE
sql: correctly stop RSG tests at specified time

### DIFF
--- a/pkg/sql/rsg_test.go
+++ b/pkg/sql/rsg_test.go
@@ -215,7 +215,10 @@ func testRandomSyntax(
 		t.Fatal(err)
 	}
 	// Broadcast channel for all workers.
-	done := time.After(*flagRSGTime)
+	done := make(chan struct{})
+	time.AfterFunc(*flagRSGTime, func() {
+		close(done)
+	})
 	var wg sync.WaitGroup
 	var countsMu struct {
 		syncutil.Mutex


### PR DESCRIPTION
The previous cleanup only stops one go routine, not all of them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10741)
<!-- Reviewable:end -->
