### PR TITLE
sql: replace JOIN ON with equality operations

### DIFF
--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -246,7 +246,12 @@ func (p *planner) makeJoin(
 		switch t := cond.(type) {
 		case *parser.OnJoinCond:
 			pred, info, err = p.makeOnPredicate(leftInfo, rightInfo, t.Expr)
-			algorithm = nestedLoopJoin
+			switch pred.(type) {
+			case *equalityPredicate:
+				algorithm = hashJoin
+			default:
+				algorithm = nestedLoopJoin
+			}
 		case parser.NaturalJoinCond:
 			cols := commonColumns(leftInfo, rightInfo)
 			pred, info, err = p.makeUsingPredicate(leftInfo, rightInfo, cols)

--- a/pkg/sql/testdata/join
+++ b/pkg/sql/testdata/join
@@ -173,12 +173,12 @@ SELECT * FROM empty AS a JOIN onecolumn AS b USING(x)
 ----
 
 query II colnames
-SELECT * FROM onecolumn AS a(x) LEFT OUTER JOIN empty AS b(y) ON a.x = b.y
+SELECT * FROM onecolumn AS a(x) LEFT OUTER JOIN empty AS b(y) ON a.x = b.y ORDER BY a.x
 ----
-x    y
-44   NULL
-NULL NULL
-42   NULL
+x     y
+NULL  NULL
+42    NULL
+44    NULL
 
 query I colnames
 SELECT * FROM onecolumn AS a LEFT OUTER JOIN empty AS b USING(x) ORDER BY x
@@ -205,12 +205,12 @@ SELECT * FROM onecolumn AS a RIGHT OUTER JOIN empty AS b USING(x)
 ----
 
 query II colnames
-SELECT * FROM empty AS a(x) FULL OUTER JOIN onecolumn AS b(y) ON a.x = b.y
+SELECT * FROM empty AS a(x) FULL OUTER JOIN onecolumn AS b(y) ON a.x = b.y ORDER BY b.y
 ----
-x    y
-NULL 44
-NULL NULL
-NULL 42
+x     y
+NULL  NULL
+NULL  42
+NULL  44
 
 query I colnames
 SELECT * FROM empty AS a FULL OUTER JOIN onecolumn AS b USING(x) ORDER BY x
@@ -221,12 +221,12 @@ NULL
 44
 
 query II colnames
-SELECT * FROM onecolumn AS a(x) FULL OUTER JOIN empty AS b(y) ON a.x = b.y
+SELECT * FROM onecolumn AS a(x) FULL OUTER JOIN empty AS b(y) ON a.x = b.y ORDER BY a.x
 ----
-x    y
-44   NULL
-NULL NULL
-42   NULL
+x     y
+NULL  NULL
+42    NULL
+44    NULL
 
 query I colnames
 SELECT * FROM onecolumn AS a FULL OUTER JOIN empty AS b USING(x) ORDER BY x
@@ -237,12 +237,16 @@ NULL
 44
 
 query II colnames
-SELECT * FROM empty AS a(x) FULL OUTER JOIN onecolumn AS b(y) ON a.x = b.y
+SELECT * FROM empty AS a(x) FULL OUTER JOIN onecolumn AS b(y) ON a.x = b.y ORDER BY b.y
 ----
-x    y
-NULL 44
-NULL NULL
-NULL 42
+x     y
+NULL  NULL
+NULL  42
+NULL  44
+
+
+
+
 
 query I colnames
 SELECT * FROM empty AS a FULL OUTER JOIN onecolumn AS b USING(x) ORDER BY x
@@ -253,7 +257,7 @@ NULL
 44
 
 statement ok
-CREATE TABLE twocolumn (x INT, y INT); INSERT INTO twocolumn(x, y) VALUES (44,51), (NULL,52), (42,53)
+CREATE TABLE twocolumn (x INT, y INT); INSERT INTO twocolumn(x, y) VALUES (44,51), (NULL,52), (42,53), (45,45)
 
 # Natural joins with partial match
 query II colnames
@@ -262,6 +266,14 @@ SELECT * FROM onecolumn NATURAL JOIN twocolumn;
 x    y
 44   51
 42   53
+
+query IIII 
+SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = a.y
+----
+45  45  44    51
+45  45  NULL  52
+45  45  42    53
+45  45  45    45
 
 # Check column orders and names.
 query IIIIII colnames
@@ -278,12 +290,45 @@ EXPLAIN SELECT * FROM onecolumn JOIN twocolumn USING(x)
 1  scan  onecolumn@primary
 1  scan  twocolumn@primary
 
+# Check EXPLAIN.
+query ITT 
+EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
+----
+0  join  HASH JOIN, INNER ON EQUALS((x),(y))
+1  scan  twocolumn@primary
+1  scan  twocolumn@primary
+
+# Check EXPLAIN.
+query ITT 
+EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
+----
+0  join  NESTED LOOP JOIN, INNER ON a.x = 44
+1  scan  twocolumn@primary
+1  scan  twocolumn@primary
+
+# Check EXPLAIN.
+query ITT 
+EXPLAIN SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
+----
+0  join  HASH JOIN, INNER ON EQUALS((x),(y))
+1  scan  onecolumn@primary
+1  scan  twocolumn@primary
+
+# Check EXPLAIN.
+query ITT 
+EXPLAIN SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
+----
+0  join  HASH JOIN, INNER ON EQUALS((x),(y))
+1  scan  onecolumn@primary
+1  scan  twocolumn@primary
+
+
 query ITT
 EXPLAIN SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twocolumn.x JOIN twocolumn AS c(d,e) ON a.b=c.d AND c.d=onecolumn.x) LIMIT 1
 ----
 0  limit  count: 1
 1  join   NESTED LOOP JOIN, INNER ON (a.b = c.d) AND (c.d = test.onecolumn.x)
-2  join   NESTED LOOP JOIN, INNER ON a.b = test.twocolumn.x
+2  join   HASH JOIN, INNER ON EQUALS((x),(b))
 3  join   NESTED LOOP JOIN, CROSS
 4  scan   onecolumn@primary
 4  scan   twocolumn@primary
@@ -320,9 +365,10 @@ x  y  y  y
 query IIIIII colnames
 SELECT a.x, b.x, c.x, a.y, b.y, c.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x) JOIN twocolumn AS c USING(x)) ORDER BY x
 ----
-x    x    x    y  y  y
-42   42   42   53 53 53
-44   44   44   51 51 51
+ x   x   x   y   y   y
+ 42  42  42  53  53  53
+ 44  44  44  51  51  51
+ 45  45  45  45  45  45
 
 query error column "y" specified in USING clause does not exist
 SELECT * FROM (onecolumn AS a JOIN onecolumn AS b USING(y))


### PR DESCRIPTION
Fixes #10631.

cc @knz.

I use a bool `isUsingExpr` to identify if it's `USING` or `ON` expr, I think it's not a good way to do that thing, maybe a enum `equalityType` is better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10755)
<!-- Reviewable:end -->
