### PR TITLE
acceptance/terraform: fix nodectl chown failure

### DIFF
--- a/pkg/acceptance/terraform/nodectl
+++ b/pkg/acceptance/terraform/nodectl
@@ -29,7 +29,10 @@ if [ $# -ne 2 ]; then
 fi
 
 # ~/.config/gcloud may be erroneously owned by root, so fix that.
-sudo chown -R "${USER}" "${HOME}/.config/gcloud"
+GCLOUD_DIR="${HOME}/.config/gcloud"
+if [[ -d "${GCLOUD_DIR}" ]]; then
+    sudo chown -R "${USER}" "${GCLOUD_DIR}"
+fi
 
 # CockroachDB nodes are named blah-cockroach-[0-9]*, so extract the final
 # numeric part.


### PR DESCRIPTION
Previously, there were times where a brand-new GCE instance would come
with a pre-exsting ~ubuntu/.config/gcloud directory that was owned by
root. So, we'd have to `chown` that for `gcloud` commands to succeed
during our allocator tests.  Somehow, that changed yesterday, and that
directory now doesn't seem to exist on new VMs. So, this more
defensively handles that directory in case it mysteriously appears
again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10756)
<!-- Reviewable:end -->
