### PR TITLE
build: plumb TC_SERVER_URL

### DIFF
--- a/build/teamcity-stress-meta.sh
+++ b/build/teamcity-stress-meta.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-build/builder.sh env TC_API_USER="$TC_API_USER" TC_API_PASSWORD="$TC_API_PASSWORD" teamcity-trigger
+build/builder.sh env TC_API_USER="$TC_API_USER" TC_API_PASSWORD="$TC_API_PASSWORD" TC_SERVER_URL="$TC_SERVER_URL" teamcity-trigger

--- a/build/teamcity-stress.sh
+++ b/build/teamcity-stress.sh
@@ -7,7 +7,7 @@ exit_status=0
 build/builder.sh make stress COCKROACH_PROPOSER_EVALUATED_KV="${COCKROACH_PROPOSER_EVALUATED_KV-}" PKG="$PKG" GOFLAGS="${GOFLAGS-}" TAGS="${TAGS-}" TESTTIMEOUT=0 TESTFLAGS='-test.v' STRESSFLAGS='-maxtime 15m -maxfails 1 -stderr' 2>&1 | tee artifacts/stress.log || exit_status=$?
 
 if [ $exit_status -ne 0 ]; then
-  build/builder.sh env GITHUB_API_TOKEN="$GITHUB_API_TOKEN" BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" github-post < artifacts/stress.log
+  build/builder.sh env GITHUB_API_TOKEN="$GITHUB_API_TOKEN" BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" TC_SERVER_URL="$TC_SERVER_URL" github-post < artifacts/stress.log
 fi;
 
 exit $exit_status

--- a/build/teamcity-stress.sh
+++ b/build/teamcity-stress.sh
@@ -7,7 +7,7 @@ exit_status=0
 build/builder.sh make stress COCKROACH_PROPOSER_EVALUATED_KV="${COCKROACH_PROPOSER_EVALUATED_KV-}" PKG="$PKG" GOFLAGS="${GOFLAGS-}" TAGS="${TAGS-}" TESTTIMEOUT=0 TESTFLAGS='-test.v' STRESSFLAGS='-maxtime 15m -maxfails 1 -stderr' 2>&1 | tee artifacts/stress.log || exit_status=$?
 
 if [ $exit_status -ne 0 ]; then
-  build/builder.sh env GITHUB_API_TOKEN="$GITHUB_API_TOKEN" BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" TC_SERVER_URL="$TC_SERVER_URL" github-post < artifacts/stress.log
+  build/builder.sh env GITHUB_API_TOKEN="$GITHUB_API_TOKEN" BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" TC_SERVER_URL="$TC_SERVER_URL" PKG="$PKG" github-post < artifacts/stress.log
 fi;
 
 exit $exit_status

--- a/pkg/cmd/github-post/main_test.go
+++ b/pkg/cmd/github-post/main_test.go
@@ -60,6 +60,8 @@ Stress build found a failed test: %s
 		teamcityVCSNumberEnv: sha,
 		teamcityServerURLEnv: serverURL,
 		teamcityBuildIDEnv:   strconv.Itoa(buildID),
+
+		pkgEnv: pkg,
 	} {
 		if val, ok := os.LookupEnv(key); ok {
 			defer func() {
@@ -91,9 +93,7 @@ Stress build found a failed test: %s
 			if repo != expRepo {
 				t.Fatalf("got %s, expected %s", repo, expRepo)
 			}
-			// TODO(tamird): why is the package name blank?
-			_ = pkg // suppress unused warning
-			if expected := fmt.Sprintf("%s: %s failed under stress", "", "TestReplicateQueueRebalance"); *issue.Title != expected {
+			if expected := fmt.Sprintf("%s: %s failed under stress", pkg, "TestReplicateQueueRebalance"); *issue.Title != expected {
 				t.Fatalf("got %s, expected %s", *issue.Title, expected)
 			}
 			if !issueBodyRe.MatchString(*issue.Body) {


### PR DESCRIPTION
Also grabs the package name from the environment, which should fix the lack of package names in generated issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10757)
<!-- Reviewable:end -->
