### PR TITLE
storage: throttle lease rebalancing

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -77,6 +77,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -114,10 +115,6 @@ const (
 	// efficiently targeted connection to the most distant node.
 	defaultCullInterval = 60 * time.Second
 
-	// DefaultGossipStoresInterval is the default interval for gossiping storage-
-	// related info.
-	DefaultGossipStoresInterval = 5 * time.Second
-
 	unknownNodeID roachpb.NodeID = 0
 )
 
@@ -129,6 +126,12 @@ var (
 	MetaInfosReceivedRates       = metric.Metadata{Name: "gossip.infos.received"}
 	MetaBytesSentRates           = metric.Metadata{Name: "gossip.bytes.sent"}
 	MetaBytesReceivedRates       = metric.Metadata{Name: "gossip.bytes.received"}
+)
+
+var (
+	// GossipStoresInterval is the interval for gossipping storage-related info.
+	GossipStoresInterval = envutil.EnvOrDefaultDuration("COCKROACH_GOSSIP_STORES_INTERVAL",
+		5*time.Second)
 )
 
 // Storage is an interface which allows the gossip instance

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -43,7 +43,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -600,10 +599,8 @@ func (n *Node) startGossip(stopper *stop.Stopper) {
 			panic(err)
 		}
 
-		gossipStoresInterval := envutil.EnvOrDefaultDuration("COCKROACH_GOSSIP_STORES_INTERVAL",
-			gossip.DefaultGossipStoresInterval)
 		statusTicker := time.NewTicker(gossipStatusInterval)
-		storesTicker := time.NewTicker(gossipStoresInterval)
+		storesTicker := time.NewTicker(gossip.GossipStoresInterval)
 		nodeTicker := time.NewTicker(gossipNodeDescriptorInterval)
 		defer storesTicker.Stop()
 		defer nodeTicker.Stop()

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 const (
@@ -38,13 +39,22 @@ const (
 	replicateQueueTimerDuration = 0 // zero duration to process replication greedily
 )
 
+var (
+	// minLeaseTransferInterval controls how frequently leases can be transferred
+	// for rebalancing. It does not prevent transferring leases in order to allow
+	// a replica to be removed from a range. The value should be some reasonable
+	// fraction of the store descriptor gossip interval which currently
+	minLeaseTransferInterval = gossip.GossipStoresInterval / 5
+)
+
 // replicateQueue manages a queue of replicas which may need to add an
 // additional replica to their range.
 type replicateQueue struct {
 	*baseQueue
-	allocator  Allocator
-	clock      *hlc.Clock
-	updateChan chan struct{}
+	allocator         Allocator
+	clock             *hlc.Clock
+	updateChan        chan struct{}
+	lastLeaseTransfer time.Time
 }
 
 // newReplicateQueue returns a new instance of replicateQueue.
@@ -119,8 +129,8 @@ func (rq *replicateQueue) shouldQueue(
 	var leaseStoreID roachpb.StoreID
 	if lease, _ := repl.getLease(); lease != nil && lease.Covers(now) {
 		leaseStoreID = lease.Replica.StoreID
-		if rq.allocator.ShouldTransferLease(
-			zone.Constraints, leaseStoreID, desc.RangeID) {
+		if rq.canTransferLease() &&
+			rq.allocator.ShouldTransferLease(zone.Constraints, leaseStoreID, desc.RangeID) {
 			if log.V(2) {
 				log.Infof(ctx, "%s lease transfer needed, enqueuing", repl)
 			}
@@ -226,6 +236,7 @@ func (rq *replicateQueue) process(
 				if err := repl.AdminTransferLease(target.StoreID); err != nil {
 					return errors.Wrapf(err, "%s: unable to transfer lease to s%d", repl, target.StoreID)
 				}
+				rq.lastLeaseTransfer = timeutil.Now()
 				// Do not requeue as we transferred our lease away.
 				return nil
 			}
@@ -253,18 +264,21 @@ func (rq *replicateQueue) process(
 		// rebalance. Attempt to find a rebalancing target.
 		log.Event(ctx, "considering a rebalance")
 
-		// We require the lease in order to process replicas, so
-		// repl.store.StoreID() corresponds to the lease-holder's store ID.
-		target := rq.allocator.TransferLeaseTarget(
-			zone.Constraints, desc.Replicas, repl.store.StoreID(), desc.RangeID,
-			true /* checkTransferLeaseSource */)
-		if target.StoreID != 0 {
-			log.VEventf(ctx, 1, "transferring lease to s%d", target.StoreID)
-			if err := repl.AdminTransferLease(target.StoreID); err != nil {
-				return errors.Wrapf(err, "%s: unable to transfer lease to s%d", repl, target.StoreID)
+		if rq.canTransferLease() {
+			// We require the lease in order to process replicas, so
+			// repl.store.StoreID() corresponds to the lease-holder's store ID.
+			target := rq.allocator.TransferLeaseTarget(
+				zone.Constraints, desc.Replicas, repl.store.StoreID(), desc.RangeID,
+				true /* checkTransferLeaseSource */)
+			if target.StoreID != 0 {
+				log.VEventf(ctx, 1, "transferring lease to s%d", target.StoreID)
+				if err := repl.AdminTransferLease(target.StoreID); err != nil {
+					return errors.Wrapf(err, "%s: unable to transfer lease to s%d", repl, target.StoreID)
+				}
+				rq.lastLeaseTransfer = timeutil.Now()
+				// Do not requeue as we transferred our lease away.
+				return nil
 			}
-			// Do not requeue as we transferred our lease away.
-			return nil
 		}
 
 		rebalanceStore, err := rq.allocator.RebalanceTarget(
@@ -325,6 +339,10 @@ func (rq *replicateQueue) removeReplica(
 	desc *roachpb.RangeDescriptor,
 ) error {
 	return repl.ChangeReplicas(ctx, roachpb.REMOVE_REPLICA, repDesc, desc)
+}
+
+func (rq *replicateQueue) canTransferLease() bool {
+	return timeutil.Since(rq.lastLeaseTransfer) > minLeaseTransferInterval
 }
 
 func (*replicateQueue) timer() time.Duration {

--- a/pkg/storage/replicate_queue_test.go
+++ b/pkg/storage/replicate_queue_test.go
@@ -18,12 +18,13 @@ package storage_test
 
 import (
 	"math"
-	"os"
 	"testing"
+	"time"
 
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -40,14 +41,10 @@ func TestReplicateQueueRebalance(t *testing.T) {
 
 	// Set the gossip stores interval lower to speed up rebalancing. With the
 	// default of 5s we have to wait ~5s for the rebalancing to start.
-	if err := os.Setenv("COCKROACH_GOSSIP_STORES_INTERVAL", "100ms"); err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.Unsetenv("COCKROACH_GOSSIP_STORES_INTERVAL"); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	defer func(v time.Duration) {
+		gossip.GossipStoresInterval = v
+	}(gossip.GossipStoresInterval)
+	gossip.GossipStoresInterval = 100 * time.Millisecond
 
 	// TODO(peter): Remove when lease rebalancing is the default.
 	defer func(v bool) {


### PR DESCRIPTION
Only allow 5 lease transfers for rebalancing per gossip store
interval. This effectively throttles the rate at which lease transfers
for rebalancing can be performed.

Verified that this eliminates lease thrashing using `allocsim -n 4 -w 4`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10766)
<!-- Reviewable:end -->
