### PR TITLE
storage: Fix circuit breaker flake in TestReplicateReAddAfterDown

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2363,6 +2363,8 @@ func TestReplicateReAddAfterDown(t *testing.T) {
 	mtc := startMultiTestContext(t, 3)
 	defer mtc.Stop()
 
+	downedStoreIdx := 2
+
 	// First put the range on all three nodes.
 	raftID := roachpb.RangeID(1)
 	mtc.replicateRange(raftID, 1, 2)
@@ -2378,7 +2380,7 @@ func TestReplicateReAddAfterDown(t *testing.T) {
 
 	// Stop node 2; while it is down remove the range from it. Since the node is
 	// down it won't see the removal and clean up its replica.
-	mtc.stopStore(2)
+	mtc.stopStore(downedStoreIdx)
 	mtc.unreplicateRange(raftID, 2)
 
 	// Perform another write.
@@ -2395,8 +2397,8 @@ func TestReplicateReAddAfterDown(t *testing.T) {
 	// replica gets recreated, the replica ID is changed by this
 	// process. An ill-timed GC has been known to cause bugs including
 	// https://github.com/cockroachdb/cockroach/issues/2873.
-	mtc.restartStore(2)
-	mtc.replicateRange(raftID, 2)
+	mtc.restartStore(downedStoreIdx)
+	mtc.replicateRange(raftID, downedStoreIdx)
 
 	// The range should be synced back up.
 	mtc.waitForValues(roachpb.Key("a"), []int64{16, 16, 16})

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -841,6 +841,18 @@ func (m *multiTestContext) restartStore(i int) {
 	m.senders[i].AddStore(m.stores[i])
 }
 
+// disableCircuitBreakersToStore ensures that no store's RaftTransport will
+// reject requests just because past connections to the given store have failed.
+// If you're stopping store and restarting them, you may want to use this to
+// ensure that errors from when the store was down don't cause other nodes to
+// avoid opening new connections to it.
+func (m *multiTestContext) disableCircuitBreakersToStore(i int) {
+	nodeID := roachpb.NodeID(i + 1)
+	for _, transport := range m.transports {
+		transport.GetCircuitBreaker(nodeID).ShouldTrip = nil
+	}
+}
+
 func (m *multiTestContext) Store(i int) *storage.Store {
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
Fixes #10758. It's very possible that fixing the circuit breaker will cause other flakes in our code base to become more frequent, so feel free to point me at anything that seems to have gotten worse lately and I'll take a look. We may want to start injecting circuit breakers that won't trip into RaftTransport for the sake of avoiding flakes like this.

As for the mechanism of the fix, it might seem like it'd be better to add retries to [the call that's being blocked by the circuit breaker](https://github.com/cockroachdb/cockroach/blob/master/pkg/storage/client_test.go#L918), but we don't really know how many times to retry given that the circuit breaker's backoff is based on time rather than number of attempts.

@tamird

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10773)
<!-- Reviewable:end -->
