### PR TITLE
storage,roachpb: fix the rule solver's diversity rule

### DIFF
--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -234,6 +234,43 @@ func (Locality) Type() string {
 	return "Locality"
 }
 
+// DiversityScore returns a score comparing the two localities which ranges from
+// 1, meaning completely diverse, to 0 which means not diverse at all (that
+// their localities match). This function ignores the locality tier key names
+// and only considers differences in their values.
+//
+// All localities are sorted from most global to most local so any localities
+// after any differing values are irrelevant.
+//
+// While we recommend that all nodes have the same locality keys and same
+// total number of keys, there's nothing wrong with having different locality
+// keys as long as the immediately next keys are all the same for each value.
+// For example:
+// region:USA -> state:NY -> ...
+// region:USA -> state:WA -> ...
+// region:EUR -> country:UK -> ...
+// region:EUR -> country:France -> ...
+// is perfectly fine. This holds true at each level lower as well.
+//
+// There is also a need to consider the cases where the localities have
+// different lengths. For these cases, we treat the missing key on one side as
+// different.
+func (l Locality) DiversityScore(other Locality) float64 {
+	length := len(l.Tiers)
+	if len(other.Tiers) < length {
+		length = len(other.Tiers)
+	}
+	for i := 0; i < length; i++ {
+		if l.Tiers[i].Value != other.Tiers[i].Value {
+			return float64(length-i) / float64(length)
+		}
+	}
+	if len(l.Tiers) != len(other.Tiers) {
+		return 1.0 / float64(length+1)
+	}
+	return 0
+}
+
 // Set sets the value of the Locality. It is the important part of
 // pflag's value interface.
 func (l *Locality) Set(value string) error {

--- a/pkg/roachpb/metadata_test.go
+++ b/pkg/roachpb/metadata_test.go
@@ -17,6 +17,7 @@
 package roachpb
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -138,5 +139,65 @@ func TestLocalityConversions(t *testing.T) {
 		if !reflect.DeepEqual(l, tc.expected) {
 			t.Errorf("%d: Locality.Set(%q) = %+v; not %+v", i, tc.in, l, tc.expected)
 		}
+	}
+}
+
+func TestDiversityScore(t *testing.T) {
+	// Keys are not considered for score, just the order, so we don't need to
+	// specify them.
+	generateLocality := func(values string) Locality {
+		var locality Locality
+		if len(values) > 0 {
+			for i, value := range strings.Split(values, ",") {
+				locality.Tiers = append(locality.Tiers, Tier{
+					Key:   fmt.Sprintf("%d", i),
+					Value: value,
+				})
+			}
+		}
+		return locality
+	}
+
+	testCases := []struct {
+		left     string
+		right    string
+		expected float64
+	}{
+		{"", "", 0},
+		{"a", "", 1},
+		{"a,b", "", 1},
+		{"a,b,c", "", 1},
+		{"a", "b", 1},
+		{"a,aa", "b,bb", 1},
+		{"a,aa,aaa", "b,bb,bbb", 1},
+		{"a,aa,aaa", "b,aa,aaa", 1},
+		{"a", "a", 0},
+		{"a,aa", "a,aa", 0},
+		{"a,aa,aaa", "a,aa,aaa", 0},
+		{"a,aa,aaa", "a,aa", 1.0 / 3.0},
+		{"a,aa", "a,bb", 1.0 / 2.0},
+		{"a,aa,aaa", "a,bb,bbb", 2.0 / 3.0},
+		{"a,aa,aaa", "a,bb,aaa", 2.0 / 3.0},
+		{"a,aa,aaa", "a,aa,bbb", 1.0 / 3.0},
+		{"a,aa,aaa,aaaa", "b,aa,aaa,aaaa", 1},
+		{"a,aa,aaa,aaaa", "a,bb,aaa,aaaa", 3.0 / 4.0},
+		{"a,aa,aaa,aaaa", "a,aa,bbb,aaaa", 2.0 / 4.0},
+		{"a,aa,aaa,aaaa", "a,aa,aaa,bbbb", 1.0 / 4.0},
+		{"a,aa,aaa,aaaa", "a,aa,aaa", 1.0 / 4.0},
+		{"a,aa,aaa,aaaa", "b,aa", 1},
+		{"a,aa,aaa,aaaa", "a,bb", 1.0 / 2.0},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(fmt.Sprintf("%s:%s", testCase.left, testCase.right), func(t *testing.T) {
+			left := generateLocality(testCase.left)
+			right := generateLocality(testCase.right)
+			if a := left.DiversityScore(right); a != testCase.expected {
+				t.Fatalf("expected %f, got %f", testCase.expected, a)
+			}
+			if a := right.DiversityScore(left); a != testCase.expected {
+				t.Fatalf("expected %f, got %f", testCase.expected, a)
+			}
+		})
 	}
 }

--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -222,7 +222,12 @@ func (a *Allocator) AllocateTarget(
 			return nil, errors.Errorf("%d matching stores are currently throttled", throttledStoreCount)
 		}
 
-		candidates, err := a.ruleSolver.Solve(sl, constraints, existing)
+		candidates, err := a.ruleSolver.Solve(
+			sl,
+			constraints,
+			existing,
+			a.storePool.getNodeLocalities(existing),
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -306,12 +311,11 @@ func (a Allocator) RemoveTarget(
 			}
 
 			candidate, valid := a.ruleSolver.computeCandidate(solveState{
-				constraints: constraints,
-				store:       desc,
-				existing:    nil,
-				sl:          sl,
-				tierOrder:   canonicalTierOrder(sl),
-				tiers:       storeTierMap(sl),
+				constraints:            constraints,
+				store:                  desc,
+				sl:                     sl,
+				existing:               nil,
+				existingNodeLocalities: a.storePool.getNodeLocalities(existing),
 			})
 			// When a candidate is not valid, it means that it can be
 			// considered the worst existing replica.
@@ -428,11 +432,11 @@ func (a Allocator) RebalanceTarget(
 		existingStoreList := makeStoreList(existingDescs)
 		candidateStoreList := makeStoreList(candidateDescs)
 
-		existingCandidates, err := a.ruleSolver.Solve(existingStoreList, constraints, nil)
+		existingCandidates, err := a.ruleSolver.Solve(existingStoreList, constraints, nil, nil)
 		if err != nil {
 			return nil, err
 		}
-		candidates, err := a.ruleSolver.Solve(candidateStoreList, constraints, nil)
+		candidates, err := a.ruleSolver.Solve(candidateStoreList, constraints, nil, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/storage/rule_solver.go
+++ b/pkg/storage/rule_solver.go
@@ -36,12 +36,11 @@ type candidate struct {
 
 // solveState is used to pass solution state information into a rule.
 type solveState struct {
-	constraints config.Constraints
-	store       roachpb.StoreDescriptor
-	existing    []roachpb.ReplicaDescriptor
-	sl          StoreList
-	tiers       map[roachpb.StoreID]map[string]roachpb.Tier
-	tierOrder   []string
+	constraints            config.Constraints
+	store                  roachpb.StoreDescriptor
+	sl                     StoreList
+	existing               []roachpb.ReplicaDescriptor
+	existingNodeLocalities map[roachpb.NodeID]roachpb.Locality
 }
 
 // rule is a function that given a solveState will score and possibly
@@ -64,15 +63,17 @@ var defaultRuleSolver = ruleSolver{
 // Solve runs the rules against the stores in the store list and returns all
 // passing stores and their scores ordered from best to worst score.
 func (rs ruleSolver) Solve(
-	sl StoreList, c config.Constraints, existing []roachpb.ReplicaDescriptor,
+	sl StoreList,
+	c config.Constraints,
+	existing []roachpb.ReplicaDescriptor,
+	existingNodeLocalities map[roachpb.NodeID]roachpb.Locality,
 ) ([]candidate, error) {
 	candidates := make([]candidate, 0, len(sl.stores))
 	state := solveState{
-		constraints: c,
-		existing:    existing,
-		sl:          sl,
-		tierOrder:   canonicalTierOrder(sl),
-		tiers:       storeTierMap(sl),
+		constraints:            c,
+		sl:                     sl,
+		existing:               existing,
+		existingNodeLocalities: existingNodeLocalities,
 	}
 
 	for _, store := range sl.stores {
@@ -157,26 +158,13 @@ func ruleConstraints(state solveState) (float64, bool) {
 // ruleDiversity returns higher scores for stores with the fewest locality tiers
 // in common with already existing replicas. It always returns true.
 func ruleDiversity(state solveState) (float64, bool) {
-	storeTiers := state.tiers[state.store.StoreID]
-	var maxScore, score float64
-	for i, tierKey := range state.tierOrder {
-		storeTier, ok := storeTiers[tierKey]
-		if !ok {
-			continue
-		}
-		tierScore := 1 / (float64(i) + 1)
-		for _, existing := range state.existing {
-			existingTier, ok := state.tiers[existing.StoreID][tierKey]
-			if ok && existingTier.Value != storeTier.Value {
-				score += tierScore
-			}
-			maxScore += tierScore
+	minScore := 1.0
+	for _, locality := range state.existingNodeLocalities {
+		if newScore := state.store.Node.Locality.DiversityScore(locality); newScore < minScore {
+			minScore = newScore
 		}
 	}
-	if maxScore == 0 {
-		return 0, true
-	}
-	return score / maxScore * ruleDiversityWeight, true
+	return minScore * ruleDiversityWeight, true
 }
 
 // ruleCapacity returns true iff a new replica won't overfill the store. The
@@ -190,58 +178,6 @@ func ruleCapacity(state solveState) (float64, bool) {
 	}
 
 	return ruleCapacityWeight / float64(state.store.Capacity.RangeCount+1), true
-}
-
-// canonicalTierOrder returns the most common key at each tier level in
-// order from the most broad tier down to the most local tier. If a majority of
-// the stores' nodes have no tier at any level, all subsequent levels are
-// ignored.
-func canonicalTierOrder(sl StoreList) []string {
-	maxTierCount := 0
-	for _, store := range sl.stores {
-		if count := len(store.Node.Locality.Tiers); maxTierCount < count {
-			maxTierCount = count
-		}
-	}
-
-	// Might have up to maxTierCount of tiers.
-	keys := make([]string, 0, maxTierCount)
-	for i := 0; i < maxTierCount; i++ {
-		// At each tier, count the number of occurrences of each key.
-		counts := map[string]int{}
-		maxKey := ""
-		for _, store := range sl.stores {
-			key := ""
-			if i < len(store.Node.Locality.Tiers) {
-				key = store.Node.Locality.Tiers[i].Key
-			}
-			counts[key]++
-			if counts[key] > counts[maxKey] {
-				maxKey = key
-			}
-		}
-		// Don't add the tier if most nodes don't have that many tiers.
-		if maxKey != "" {
-			keys = append(keys, maxKey)
-		} else {
-			break
-		}
-	}
-	return keys
-}
-
-// storeTierMap indexes a store list so it can be used to look up the locality
-// tier value from store ID and tier key.
-func storeTierMap(sl StoreList) map[roachpb.StoreID]map[string]roachpb.Tier {
-	m := map[roachpb.StoreID]map[string]roachpb.Tier{}
-	for _, store := range sl.stores {
-		sm := map[string]roachpb.Tier{}
-		m[store.StoreID] = sm
-		for _, tier := range store.Node.Locality.Tiers {
-			sm[tier.Key] = tier
-		}
-	}
-	return m
 }
 
 // byScore implements sort.Interface to sort by scores.

--- a/pkg/storage/rule_solver_test.go
+++ b/pkg/storage/rule_solver_test.go
@@ -17,7 +17,6 @@
 package storage
 
 import (
-	"reflect"
 	"sort"
 	"testing"
 
@@ -50,13 +49,13 @@ func TestRuleSolver(t *testing.T) {
 	)
 	defer stopper.Stop()
 
-	storeRSa := roachpb.StoreID(1)   // datacenter (us), rack, slot + a
-	storeRab := roachpb.StoreID(2)   // datacenter (us), rack + a,b
-	storeFRabc := roachpb.StoreID(3) // datacenter (us), floor, rack + a,b,c
+	storeUSa15 := roachpb.StoreID(1) // us-a-1-5
+	storeUSa1 := roachpb.StoreID(2)  // us-a-1
+	storeUSb := roachpb.StoreID(3)   // us-b
 	storeDead := roachpb.StoreID(4)
-	storeEurope := roachpb.StoreID(5) // datacenter (eur), rack
+	storeEurope := roachpb.StoreID(5) // eur-a-1-5
 
-	mockStorePool(storePool, []roachpb.StoreID{storeRSa, storeRab, storeFRabc, storeEurope}, []roachpb.StoreID{storeDead}, nil)
+	mockStorePool(storePool, []roachpb.StoreID{storeUSa15, storeUSa1, storeUSb, storeEurope}, []roachpb.StoreID{storeDead}, nil)
 
 	// tierSetup returns a tier struct constructed using the passed in values.
 	// If any value is an empty string, it is not included.
@@ -89,20 +88,24 @@ func TestRuleSolver(t *testing.T) {
 
 	storePool.mu.Lock()
 
-	storePool.mu.storeDetails[storeRSa].desc.Attrs.Attrs = []string{"a"}
-	storePool.mu.storeDetails[storeRSa].desc.Node.Locality.Tiers = tierSetup("us", "", "1", "5")
-	storePool.mu.storeDetails[storeRSa].desc.Capacity = capacitySetup(1, 99)
+	storePool.mu.storeDetails[storeUSa15].desc.Attrs.Attrs = []string{"a"}
+	storePool.mu.storeDetails[storeUSa15].desc.Node.Locality.Tiers = tierSetup("us", "a", "1", "5")
+	storePool.mu.storeDetails[storeUSa15].desc.Capacity = capacitySetup(1, 99)
+	storePool.mu.nodeLocalities[roachpb.NodeID(storeUSa15)] = storePool.mu.storeDetails[storeUSa15].desc.Node.Locality
 
-	storePool.mu.storeDetails[storeRab].desc.Attrs.Attrs = []string{"a", "b"}
-	storePool.mu.storeDetails[storeRab].desc.Node.Locality.Tiers = tierSetup("us", "", "1", "")
-	storePool.mu.storeDetails[storeRab].desc.Capacity = capacitySetup(100, 0)
+	storePool.mu.storeDetails[storeUSa1].desc.Attrs.Attrs = []string{"a", "b"}
+	storePool.mu.storeDetails[storeUSa1].desc.Node.Locality.Tiers = tierSetup("us", "a", "1", "")
+	storePool.mu.storeDetails[storeUSa1].desc.Capacity = capacitySetup(100, 0)
+	storePool.mu.nodeLocalities[roachpb.NodeID(storeUSa1)] = storePool.mu.storeDetails[storeUSa1].desc.Node.Locality
 
-	storePool.mu.storeDetails[storeFRabc].desc.Attrs.Attrs = []string{"a", "b", "c"}
-	storePool.mu.storeDetails[storeFRabc].desc.Node.Locality.Tiers = tierSetup("us", "1", "2", "")
-	storePool.mu.storeDetails[storeFRabc].desc.Capacity = capacitySetup(50, 50)
+	storePool.mu.storeDetails[storeUSb].desc.Attrs.Attrs = []string{"a", "b", "c"}
+	storePool.mu.storeDetails[storeUSb].desc.Node.Locality.Tiers = tierSetup("us", "b", "", "")
+	storePool.mu.storeDetails[storeUSb].desc.Capacity = capacitySetup(50, 50)
+	storePool.mu.nodeLocalities[roachpb.NodeID(storeUSb)] = storePool.mu.storeDetails[storeUSb].desc.Node.Locality
 
-	storePool.mu.storeDetails[storeEurope].desc.Node.Locality.Tiers = tierSetup("eur", "", "1", "")
+	storePool.mu.storeDetails[storeEurope].desc.Node.Locality.Tiers = tierSetup("eur", "a", "1", "5")
 	storePool.mu.storeDetails[storeEurope].desc.Capacity = capacitySetup(60, 40)
+	storePool.mu.nodeLocalities[roachpb.NodeID(storeEurope)] = storePool.mu.storeDetails[storeEurope].desc.Node.Locality
 
 	storePool.mu.Unlock()
 
@@ -115,38 +118,38 @@ func TestRuleSolver(t *testing.T) {
 	}{
 		{
 			name:     "no constraints or rules",
-			expected: []roachpb.StoreID{storeRSa, storeRab, storeFRabc, storeEurope},
+			expected: []roachpb.StoreID{storeUSa15, storeUSa1, storeUSb, storeEurope},
 		},
 		{
 			name: "white list rule",
 			rule: func(state solveState) (float64, bool) {
 				switch state.store.StoreID {
-				case storeRSa:
+				case storeUSa15:
 					return 0, true
-				case storeFRabc:
+				case storeUSb:
 					return 1, true
 				default:
 					return 0, false
 				}
 			},
-			expected: []roachpb.StoreID{storeFRabc, storeRSa},
+			expected: []roachpb.StoreID{storeUSb, storeUSa15},
 		},
 		{
 			name: "ruleReplicasUniqueNodes - 2 available nodes",
 			rule: ruleReplicasUniqueNodes,
 			existing: []roachpb.ReplicaDescriptor{
-				{NodeID: roachpb.NodeID(storeRSa)},
-				{NodeID: roachpb.NodeID(storeFRabc)},
+				{NodeID: roachpb.NodeID(storeUSa15)},
+				{NodeID: roachpb.NodeID(storeUSb)},
 			},
-			expected: []roachpb.StoreID{storeRab, storeEurope},
+			expected: []roachpb.StoreID{storeUSa1, storeEurope},
 		},
 		{
 			name: "ruleReplicasUniqueNodes - 0 available nodes",
 			rule: ruleReplicasUniqueNodes,
 			existing: []roachpb.ReplicaDescriptor{
-				{NodeID: roachpb.NodeID(storeRSa)},
-				{NodeID: roachpb.NodeID(storeRab)},
-				{NodeID: roachpb.NodeID(storeFRabc)},
+				{NodeID: roachpb.NodeID(storeUSa15)},
+				{NodeID: roachpb.NodeID(storeUSa1)},
+				{NodeID: roachpb.NodeID(storeUSb)},
 				{NodeID: roachpb.NodeID(storeEurope)},
 			},
 			expected: nil,
@@ -159,7 +162,7 @@ func TestRuleSolver(t *testing.T) {
 					{Value: "b", Type: config.Constraint_REQUIRED},
 				},
 			},
-			expected: []roachpb.StoreID{storeRab, storeFRabc},
+			expected: []roachpb.StoreID{storeUSa1, storeUSb},
 		},
 		{
 			name: "ruleConstraints - required locality constraints",
@@ -169,7 +172,7 @@ func TestRuleSolver(t *testing.T) {
 					{Key: "datacenter", Value: "us", Type: config.Constraint_REQUIRED},
 				},
 			},
-			expected: []roachpb.StoreID{storeRSa, storeRab, storeFRabc},
+			expected: []roachpb.StoreID{storeUSa15, storeUSa1, storeUSb},
 		},
 		{
 			name: "ruleConstraints - prohibited constraints",
@@ -179,7 +182,7 @@ func TestRuleSolver(t *testing.T) {
 					{Value: "b", Type: config.Constraint_PROHIBITED},
 				},
 			},
-			expected: []roachpb.StoreID{storeRSa, storeEurope},
+			expected: []roachpb.StoreID{storeUSa15, storeEurope},
 		},
 		{
 			name: "ruleConstraints - prohibited locality constraints",
@@ -201,7 +204,7 @@ func TestRuleSolver(t *testing.T) {
 					{Value: "c"},
 				},
 			},
-			expected: []roachpb.StoreID{storeFRabc, storeRab, storeRSa, storeEurope},
+			expected: []roachpb.StoreID{storeUSb, storeUSa1, storeUSa15, storeEurope},
 		},
 		{
 			name: "ruleConstraints - positive locality constraints",
@@ -211,26 +214,35 @@ func TestRuleSolver(t *testing.T) {
 					{Key: "datacenter", Value: "eur"},
 				},
 			},
-			expected: []roachpb.StoreID{storeEurope, storeRSa, storeRab, storeFRabc},
+			expected: []roachpb.StoreID{storeEurope, storeUSa15, storeUSa1, storeUSb},
 		},
 		{
 			name:     "ruleDiversity - no existing replicas",
 			rule:     ruleDiversity,
 			existing: nil,
-			expected: []roachpb.StoreID{storeRSa, storeRab, storeFRabc, storeEurope},
+			expected: []roachpb.StoreID{storeUSa15, storeUSa1, storeUSb, storeEurope},
 		},
 		{
 			name: "ruleDiversity - one existing replicas",
 			rule: ruleDiversity,
 			existing: []roachpb.ReplicaDescriptor{
-				{StoreID: storeRSa},
+				{NodeID: roachpb.NodeID(storeUSa15)},
 			},
-			expected: []roachpb.StoreID{storeEurope, storeFRabc, storeRSa, storeRab},
+			expected: []roachpb.StoreID{storeEurope, storeUSb, storeUSa1, storeUSa15},
+		},
+		{
+			name: "ruleDiversity - two existing replicas",
+			rule: ruleDiversity,
+			existing: []roachpb.ReplicaDescriptor{
+				{NodeID: roachpb.NodeID(storeUSa15)},
+				{NodeID: roachpb.NodeID(storeEurope)},
+			},
+			expected: []roachpb.StoreID{storeUSb, storeUSa1, storeUSa15, storeEurope},
 		},
 		{
 			name:     "ruleCapacity",
 			rule:     ruleCapacity,
-			expected: []roachpb.StoreID{storeRab, storeEurope, storeFRabc},
+			expected: []roachpb.StoreID{storeUSa1, storeEurope, storeUSb},
 		},
 	}
 
@@ -241,7 +253,12 @@ func TestRuleSolver(t *testing.T) {
 				solver = ruleSolver{tc.rule}
 			}
 			sl, _, _ := storePool.getStoreList(roachpb.RangeID(0))
-			candidates, err := solver.Solve(sl, tc.c, tc.existing)
+			candidates, err := solver.Solve(
+				sl,
+				tc.c,
+				tc.existing,
+				storePool.getNodeLocalities(tc.existing),
+			)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -254,95 +271,6 @@ func TestRuleSolver(t *testing.T) {
 					t.Errorf("candidates[%d].store.StoreID = %d; not %d; %+v",
 						i, actual, expected, candidates)
 				}
-			}
-		})
-	}
-}
-
-func TestCanonicalTierOrder(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	testCases := []struct {
-		name          string
-		tiersPerStore [][]roachpb.Tier
-		expected      []string
-	}{
-		{
-			name:          "no tiers at all",
-			tiersPerStore: nil,
-			expected:      []string{},
-		},
-		{
-			name:          "one store with two empty tiers",
-			tiersPerStore: [][]roachpb.Tier{nil, nil},
-			expected:      []string{},
-		},
-		{
-			name: "one store with three tiers",
-			tiersPerStore: [][]roachpb.Tier{
-				{
-					{Key: "a"},
-					{Key: "b"},
-					{Key: "c"},
-				},
-			},
-			expected: []string{"a", "b", "c"},
-		},
-		{
-			name: "3 stores with the same tiers, one with an extra one",
-			tiersPerStore: [][]roachpb.Tier{
-				{
-					{Key: "a"},
-					{Key: "b"},
-					{Key: "c"},
-				},
-				{
-					{Key: "a"},
-					{Key: "b"},
-					{Key: "c"},
-				},
-				{
-					{Key: "b"},
-					{Key: "c"},
-					{Key: "a"},
-					{Key: "d"},
-				},
-			},
-			expected: []string{"a", "b", "c"},
-		},
-		{
-			name: "two stores with completely different tiers",
-			tiersPerStore: [][]roachpb.Tier{
-				{
-					{Key: "a"},
-					{Key: "b"},
-					{Key: "c"},
-				},
-				{
-					{Key: "e"},
-					{Key: "f"},
-					{Key: "g"},
-				},
-			},
-			expected: []string{"a", "b", "c"},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			var descriptors []roachpb.StoreDescriptor
-			for _, tiers := range tc.tiersPerStore {
-				descriptors = append(descriptors, roachpb.StoreDescriptor{
-					Node: roachpb.NodeDescriptor{
-						Locality: roachpb.Locality{Tiers: tiers},
-					},
-				})
-			}
-
-			sl := makeStoreList(descriptors)
-			if actual := canonicalTierOrder(sl); !reflect.DeepEqual(actual, tc.expected) {
-				t.Errorf("canonicalTierOrder(%+v) = %+v; not %+v",
-					tc.tiersPerStore, actual, tc.expected)
 			}
 		})
 	}

--- a/pkg/storage/store_pool.go
+++ b/pkg/storage/store_pool.go
@@ -214,8 +214,9 @@ type StorePool struct {
 		syncutil.RWMutex
 		// Each storeDetail is contained in both a map and a priorityQueue;
 		// pointers are used so that data can be kept in sync.
-		storeDetails map[roachpb.StoreID]*storeDetail
-		queue        storePoolPQ
+		storeDetails   map[roachpb.StoreID]*storeDetail
+		queue          storePoolPQ
+		nodeLocalities map[roachpb.NodeID]roachpb.Locality
 	}
 }
 
@@ -244,6 +245,7 @@ func NewStorePool(
 	}
 	sp.mu.storeDetails = make(map[roachpb.StoreID]*storeDetail)
 	heap.Init(&sp.mu.queue)
+	sp.mu.nodeLocalities = make(map[roachpb.NodeID]roachpb.Locality)
 	storeRegex := gossip.MakePrefixPattern(gossip.KeyStorePrefix)
 	g.RegisterCallback(storeRegex, sp.storeGossipUpdate)
 	deadReplicasRegex := gossip.MakePrefixPattern(gossip.KeyDeadReplicasPrefix)
@@ -297,6 +299,7 @@ func (sp *StorePool) storeGossipUpdate(_ string, content roachpb.Value) {
 	// Does this storeDetail exist yet?
 	detail := sp.getStoreDetailLocked(storeDesc.StoreID)
 	detail.markAlive(sp.clock.Now(), &storeDesc)
+	sp.mu.nodeLocalities[storeDesc.Node.NodeID] = storeDesc.Node.Locality
 	sp.mu.queue.enqueue(detail)
 }
 
@@ -604,4 +607,23 @@ func (sp *StorePool) updateRemoteCapacityEstimate(
 		// TODO(jordan,bram): Consider updating the full capacity here.
 		desc.Capacity.RangeCount = capacity.RangeCount
 	}
+}
+
+// getNodeLocalities returns the localities for the provided replicas.
+// TODO(bram): consider storing a full list of all node to node diversity
+// scores for faster lookups.
+func (sp *StorePool) getNodeLocalities(
+	replicas []roachpb.ReplicaDescriptor,
+) map[roachpb.NodeID]roachpb.Locality {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	localities := make(map[roachpb.NodeID]roachpb.Locality)
+	for _, replica := range replicas {
+		if locality, ok := sp.mu.nodeLocalities[replica.NodeID]; ok {
+			localities[replica.NodeID] = locality
+		} else {
+			localities[replica.NodeID] = roachpb.Locality{}
+		}
+	}
+	return localities
 }


### PR DESCRIPTION
This commit adds a diversity score between two localities and then uses this score in an updated diversity rule.
This also adds a nodeID to localities map within the store pool to be able to quickly retrieve a node's locality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10774)
<!-- Reviewable:end -->
