### PR TITLE
storage: fix potential memory leak in the pq

### DIFF
--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -88,6 +88,7 @@ func (pq *priorityQueue) Pop() interface{} {
 	n := len(old)
 	item := old[n-1]
 	item.index = -1 // for safety
+	old[n-1] = nil  // for gc
 	*pq = old[0 : n-1]
 	return item
 }


### PR DESCRIPTION
Simple fix, without setting the last item to nil, you will shrink the slice pointer but the memory location will still exist and reference the no longer needed item.  This nils out the last position before shrinking the slice so the GC will collect orphaned items.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10777)
<!-- Reviewable:end -->
