### PR TITLE
sql/sqlbase: helper for invalidating FK constraints on a table

### DIFF
--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1742,3 +1742,16 @@ func (desc *Descriptor) GetName() string {
 func (f ForeignKeyReference) IsSet() bool {
 	return f.Table != 0
 }
+
+// InvalidateFKConstraints sets all FK constraints to un-validated.
+func (desc *TableDescriptor) InvalidateFKConstraints() {
+	// We don't use GetConstraintInfo because we want to edit the passed desc.
+	if desc.PrimaryIndex.ForeignKey.IsSet() {
+		desc.PrimaryIndex.ForeignKey.Validity = ConstraintValidity_Unvalidated
+	}
+	for i := range desc.Indexes {
+		if desc.Indexes[i].ForeignKey.IsSet() {
+			desc.Indexes[i].ForeignKey.Validity = ConstraintValidity_Unvalidated
+		}
+	}
+}


### PR DESCRIPTION
In some cases, such as after a table is restored from a backup, we can no longer be certain that foreign key constraints still hold for data on disk. This helper will be used to flip all such constraints to Unvalidated, indicating that.

Note that we generally *can* assume CHECK or UNIQUE constraints to still hold if they held when the table was backed up, as they are entirely contained within the table and thus preserved across a backup and restore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10786)
<!-- Reviewable:end -->
