### PR TITLE
sql: bump rsg func exec timeout to 10s

### DIFF
--- a/pkg/sql/rsg_test.go
+++ b/pkg/sql/rsg_test.go
@@ -163,7 +163,7 @@ func TestRandomSyntaxFunctions(t *testing.T) {
 		select {
 		case err := <-funcdone:
 			return err
-		case <-time.After(time.Second * 5):
+		case <-time.After(time.Second * 10):
 			panic(fmt.Sprintf("func exec timeout: %s", s))
 		}
 	})


### PR DESCRIPTION
5s is maybe too conservative with so many rsg goroutines running in parallel. This will hopefully fix the recent RSG test failures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10831)
<!-- Reviewable:end -->
