### PR TITLE
storage: fix improper boolean short-circuiting

### DIFF
--- a/pkg/storage/command_queue.go
+++ b/pkg/storage/command_queue.go
@@ -205,7 +205,9 @@ func (cq *CommandQueue) getWait(readOnly bool, spans ...roachpb.Span) (chans []<
 		// interval tree and add all of its children.
 		restart := false
 		for _, c := range overlaps {
-			restart = restart || cq.expand(c, true /* isInserted */)
+			// Operand order matters: call cq.expand() for its side effects
+			// even if `restart` is already true.
+			restart = cq.expand(c, true /* isInserted */) || restart
 		}
 		if restart {
 			i--


### PR DESCRIPTION
I need to figure out how to write a test for this, but this line was introduced in #10173 and could be the cause of #10733.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10854)
<!-- Reviewable:end -->
