### PR TITLE
cli/sql: avoid crashing if there is no username in the connection URL.

### DIFF
--- a/pkg/cli/interactive_tests/test_url_login.tcl
+++ b/pkg/cli/interactive_tests/test_url_login.tcl
@@ -1,0 +1,17 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_server $argv
+
+# Check that the client can start when no username is specified.
+# This is run as an acceptance test to ensure that the code path
+# that generates the interactive prompt presented to the user is
+# also exercised by the test.
+spawn $argv sql --url "postgresql://localhost:26257?sslmode=disable"
+eexpect @localhost
+
+send "\004"
+eexpect eof
+
+stop_server $argv

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -353,9 +353,13 @@ func preparePrompts(dbURL string) (fullPrompt string, continuePrompt string) {
 	// continued statement prompt is: "        -> "
 	fullPrompt = dbURL
 	if parsedURL, err := url.Parse(dbURL); err == nil {
+		username := ""
+		if parsedURL.User != nil {
+			username = parsedURL.User.Username()
+		}
 		// If parsing fails, we keep the entire URL. The Open call succeeded, and that
 		// is the important part.
-		fullPrompt = fmt.Sprintf("%s@%s", parsedURL.User.Username(), parsedURL.Host)
+		fullPrompt = fmt.Sprintf("%s@%s", username, parsedURL.Host)
 	}
 
 	if len(fullPrompt) == 0 {


### PR DESCRIPTION
Fixes #10835.

cc @donpdonp.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10862)
<!-- Reviewable:end -->
