### PR TITLE
storage: make intentResolver.processIntentsAsync really async

### DIFF
--- a/pkg/storage/command_queue.go
+++ b/pkg/storage/command_queue.go
@@ -205,7 +205,9 @@ func (cq *CommandQueue) getWait(readOnly bool, spans ...roachpb.Span) (chans []<
 		// interval tree and add all of its children.
 		restart := false
 		for _, c := range overlaps {
-			restart = restart || cq.expand(c, true /* isInserted */)
+			// Operand order matters: call cq.expand() for its side effects
+			// even if `restart` is already true.
+			restart = cq.expand(c, true /* isInserted */) || restart
 		}
 		if restart {
 			i--

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -979,6 +979,8 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	// Add the bookie to the store.
 	s.bookie = newBookie(s.metrics)
 
+	s.intentResolver.Start(stopper)
+
 	// Read the store ident if not already initialized. "NodeID != 0" implies
 	// the store has already been initialized.
 	if s.Ident.NodeID == 0 {


### PR DESCRIPTION
Previously, intentResolver.processIntentsAsync could block if the
intentResolverTaskLimit was reached. This is problematic because this
method is called while holding Replica.raftMu which blocks all Raft
processing for the Replica.

processIntentsAsync now queues up the intent resolution work and a new
intentResolver worker goroutine dispatches that work.

Fixes #10733

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10867)
<!-- Reviewable:end -->
