### PR TITLE
cli: disable backtrace

### DIFF
--- a/pkg/cli/backtrace.go
+++ b/pkg/cli/backtrace.go
@@ -34,7 +34,15 @@ import (
 	"github.com/backtrace-labs/go-bcd"
 )
 
+// Currently disabled as backtrace appears to be obscuring problems when test
+// clusters encounter panics. See #10872.
+const backtraceEnabled = false
+
 func initBacktrace(logDir string) *stop.Stopper {
+	if !backtraceEnabled {
+		return stop.NewStopper()
+	}
+
 	const ptracePath = "/opt/backtrace/bin/ptrace"
 	if _, err := os.Stat(ptracePath); err != nil {
 		log.Infof(context.TODO(), "backtrace disabled: %s", err)


### PR DESCRIPTION
Disable backtrace as it appears to be obscuring problems in test
clusters.

See #10872

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10874)
<!-- Reviewable:end -->
