### PR TITLE
storage: avoid erroneous invocation of Replica.CloseOutSnap

### DIFF
--- a/pkg/storage/client_bench_test.go
+++ b/pkg/storage/client_bench_test.go
@@ -44,7 +44,7 @@ func BenchmarkReplicaSnapshot(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if _, err := rep.GetSnapshot(context.Background()); err != nil {
+		if _, err := rep.GetSnapshot(context.Background(), "bench"); err != nil {
 			b.Fatal(err)
 		}
 		rep.CloseOutSnap()

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -3176,10 +3176,7 @@ func (r *Replica) ChangeReplicas(
 		// progress which might be required for this ChangeReplicas operation to
 		// complete. See #10409.
 		if err := func() error {
-			snap, err := r.GetSnapshot(ctx)
-			r.mu.Lock()
-			r.mu.outSnap.claimed = true
-			r.mu.Unlock()
+			snap, err := r.GetSnapshot(ctx, snapTypePreemptive)
 			defer r.CloseOutSnap()
 			log.Event(ctx, "generated snapshot")
 			if err != nil {

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -270,25 +270,27 @@ func (r *Replica) GetFirstIndex() (uint64, error) {
 // Snapshot requires that the replica lock is held.
 func (r *Replica) Snapshot() (raftpb.Snapshot, error) {
 	ctx := r.AnnotateCtx(context.TODO())
-	snap, err := r.SnapshotWithContext(ctx)
+	snap, err := r.snapshotWithContext(ctx, snapTypeRaft)
 	if err != nil {
 		return raftpb.Snapshot{}, err
 	}
 	return snap.RaftSnap, err
 }
 
-// SnapshotWithContext is the main implementation for Snapshot() but it takes
+// snapshotWithContext is the main implementation for Snapshot() but it takes
 // a context to allow tracing. If this method returns without error, callers
 // must eventually call CloseOutSnap to ready this replica for more snapshots.
-func (r *Replica) SnapshotWithContext(ctx context.Context) (*OutgoingSnapshot, error) {
+func (r *Replica) snapshotWithContext(
+	ctx context.Context, snapType string,
+) (*OutgoingSnapshot, error) {
 	rangeID := r.RangeID
 
 	if r.exceedsDoubleSplitSizeLocked() {
 		maxBytes := r.mu.maxBytes
 		size := r.mu.state.Stats.Total()
 		log.Infof(ctx,
-			"%s: not generating snapshot because replica is too large: %d > 2 * %d",
-			r, size, maxBytes)
+			"not generating %s snapshot because replica is too large: %d > 2 * %d",
+			snapType, size, maxBytes)
 		return &OutgoingSnapshot{}, raft.ErrSnapshotTemporarilyUnavailable
 	}
 
@@ -313,7 +315,7 @@ func (r *Replica) SnapshotWithContext(ctx context.Context) (*OutgoingSnapshot, e
 	// Delegate to a static function to make sure that we do not depend
 	// on any indirect calls to r.store.Engine() (or other in-memory
 	// state of the Replica). Everything must come from the snapshot.
-	snapData, err := snapshot(ctx, snap, rangeID, r.store.raftEntryCache, startKey)
+	snapData, err := snapshot(ctx, snapType, snap, rangeID, r.store.raftEntryCache, startKey)
 	if err != nil {
 		log.Errorf(ctx, "error generating snapshot: %s", err)
 		return nil, err
@@ -329,7 +331,7 @@ func (r *Replica) SnapshotWithContext(ctx context.Context) (*OutgoingSnapshot, e
 // to be held and it will block instead of returning
 // ErrSnapshotTemporaryUnavailable. The caller is directly responsible for
 // calling r.CloseOutSnap.
-func (r *Replica) GetSnapshot(ctx context.Context) (*OutgoingSnapshot, error) {
+func (r *Replica) GetSnapshot(ctx context.Context, snapType string) (*OutgoingSnapshot, error) {
 	// Use shorter-than-usual backoffs because this rarely succeeds on
 	// the first attempt and this method is used a lot in tests.
 	// Unsuccessful attempts are cheap, so we can have a low MaxBackoff.
@@ -348,7 +350,7 @@ func (r *Replica) GetSnapshot(ctx context.Context) (*OutgoingSnapshot, error) {
 		<-doneChan
 
 		r.mu.Lock()
-		snap, err := r.SnapshotWithContext(ctx)
+		snap, err := r.snapshotWithContext(ctx, snapType)
 		if err == nil {
 			r.mu.outSnap.claimed = true
 		}
@@ -390,20 +392,21 @@ type IncomingSnapshot struct {
 
 // CloseOutSnap closes the Replica's outgoing snapshot, freeing its resources
 // and readying the Replica to send more snapshots. Must be called after any
-// invocation of SnapshotWithContext.
+// invocation of snapshotWithContext.
 func (r *Replica) CloseOutSnap() {
 	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.mu.outSnap.Iter.Close()
 	r.mu.outSnap.EngineSnap.Close()
 	r.mu.outSnap = OutgoingSnapshot{}
 	close(r.mu.outSnapDone)
 	r.store.ReleaseRaftSnapshot()
-	r.mu.Unlock()
 }
 
 // snapshot creates an OutgoingSnapshot containing a rocksdb snapshot for the given range.
 func snapshot(
 	ctx context.Context,
+	snapType string,
 	snap engine.Reader,
 	rangeID roachpb.RangeID,
 	eCache *raftEntryCache,
@@ -449,8 +452,8 @@ func snapshot(
 	iter := NewReplicaDataIterator(&desc, snap, true /* replicatedOnly */)
 	snapUUID := uuid.MakeV4()
 
-	log.Infof(ctx, "generated snapshot %s at index %d",
-		snapUUID.Short(), appliedIndex)
+	log.Infof(ctx, "generated %s snapshot %s at index %d",
+		snapType, snapUUID.Short(), appliedIndex)
 	return OutgoingSnapshot{
 		EngineSnap: snap,
 		Iter:       iter,
@@ -549,6 +552,11 @@ func (r *Replica) updateRangeInfo(desc *roachpb.RangeDescriptor) error {
 	return nil
 }
 
+const (
+	snapTypeRaft       = "Raft"
+	snapTypePreemptive = "preemptive"
+)
+
 // applySnapshot updates the replica based on the given snapshot and associated
 // HardState (which may be empty, as Raft may apply some snapshots which don't
 // require an update to the HardState). All snapshots must pass through Raft
@@ -557,7 +565,7 @@ func (r *Replica) updateRangeInfo(desc *roachpb.RangeDescriptor) error {
 // r.store.processRangeDescriptorUpdate(r) after a successful applySnapshot.
 func (r *Replica) applySnapshot(
 	ctx context.Context, inSnap IncomingSnapshot, snap raftpb.Snapshot, hs raftpb.HardState,
-) error {
+) (err error) {
 	// Extract the updated range descriptor.
 	desc := inSnap.RangeDescriptor
 
@@ -567,9 +575,8 @@ func (r *Replica) applySnapshot(
 	r.mu.Unlock()
 
 	isPreemptive := replicaID == 0 // only used for accounting and log format
-	var appliedSuccessfully bool
 	defer func() {
-		if appliedSuccessfully {
+		if err == nil {
 			if !isPreemptive {
 				r.store.metrics.RangeSnapshotsNormalApplied.Inc(1)
 			} else {
@@ -582,13 +589,12 @@ func (r *Replica) applySnapshot(
 		// Raft discarded the snapshot, indicating that our local state is
 		// already ahead of what the snapshot provides. But we count it for
 		// stats (see the defer above).
-		appliedSuccessfully = true
 		return nil
 	}
 
-	snapType := "preemptive"
+	snapType := snapTypePreemptive
 	if !isPreemptive {
-		snapType = "Raft"
+		snapType = snapTypeRaft
 	}
 
 	var stats struct {
@@ -660,7 +666,7 @@ func (r *Replica) applySnapshot(
 		}
 	}
 	// Write the snapshot's Raft log into the range.
-	_, raftLogSize, err := r.append(ctx, distinctBatch, 0, raftLogSize, logEntries)
+	_, raftLogSize, err = r.append(ctx, distinctBatch, 0, raftLogSize, logEntries)
 	if err != nil {
 		return err
 	}
@@ -732,8 +738,6 @@ func (r *Replica) applySnapshot(
 	}
 
 	r.setDescWithoutProcessUpdate(&desc)
-
-	appliedSuccessfully = true
 	return nil
 }
 

--- a/pkg/storage/replica_raftstorage_test.go
+++ b/pkg/storage/replica_raftstorage_test.go
@@ -80,7 +80,7 @@ func TestSkipLargeReplicaSnapshot(t *testing.T) {
 
 	fillTestRange(t, rep, snapSize)
 
-	if _, err := rep.GetSnapshot(context.Background()); err != nil {
+	if _, err := rep.GetSnapshot(context.Background(), "test"); err != nil {
 		t.Fatal(err)
 	}
 	rep.CloseOutSnap()


### PR DESCRIPTION
Replica.handleRaftReadyRaftMuLocked was invoking
Replica.maybeAbandonSnapshot whenever it saw a non-empty snapshot during
a call to Replica.sendRaftMessage. But Replica.sendRaftMessage was
already ensuring such snapshots were released. The result was that
Replica.maybeAbandonSnapshot was being invoked unnecessarily which could
then race with a preemptive snapshot.

Improve the logging when generating snapshots: we know if they are being
generated by Raft or preemptively.

Fixes #10864

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10875)
<!-- Reviewable:end -->
