### PR TITLE
protoutil: Make protoutil.Clone type-based

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -1731,12 +1731,14 @@ func TestAcquireLease(t *testing.T) {
 	}
 }
 
+// TestLeaseConcurrent requests the lease multiple times, all of which
+// will join the same LeaseRequest command. This exercises the cloning of
+// the *roachpb.Error to ensure that each requestor gets a distinct
+// error object (which prevents regression of #6111)
 func TestLeaseConcurrent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	const num = 5
 
-	// Testing concurrent range lease requests is still a good idea. We check
-	// that they work and clone *Error, which prevents regression of #6111.
 	const origMsg = "boom"
 	for _, withError := range []bool{false, true} {
 		func(withError bool) {

--- a/pkg/util/protoutil/clone.go
+++ b/pkg/util/protoutil/clone.go
@@ -56,8 +56,13 @@ func init() {
 // upstream, see https://github.com/gogo/protobuf/issues/147.
 func Clone(pb proto.Message) proto.Message {
 	for _, verbotenKind := range verbotenKinds {
-		if v := findVerboten(reflect.ValueOf(pb), verbotenKind); v != nil {
-			panic(fmt.Sprintf("attempt to clone %+v, which contains %+v", pb, v))
+		if typeIsOrContainsVerboten(reflect.TypeOf(pb), verbotenKind) {
+			// Try to find an example of the problematic field.
+			if v := findVerboten(reflect.ValueOf(pb), verbotenKind); v != nil {
+				panic(fmt.Sprintf("attempt to clone %T, which contains uncloneable %T %+v", pb, v, v))
+			}
+			// If we couldn't find one, panic anyway.
+			panic(fmt.Sprintf("attempt to clone %T, which contains uncloneable fields", pb))
 		}
 	}
 

--- a/pkg/util/protoutil/clone_test.go
+++ b/pkg/util/protoutil/clone_test.go
@@ -25,9 +25,13 @@ import (
 	"github.com/gogo/protobuf/proto"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
 func TestCloneProto(t *testing.T) {
@@ -41,8 +45,17 @@ func TestCloneProto(t *testing.T) {
 		{&roachpb.Transaction{}, true},
 		{&roachpb.Error{}, true},
 
-		// Cloneable types.
+		// Cloneable types. This includes all types for which a
+		// protoutil.Clone call exists in the codebase as of 2016-11-21.
 		{&config.ZoneConfig{}, false},
+		{&gossip.Info{}, false},
+		{&gossip.BootstrapInfo{}, false},
+		{&tracing.SpanContextCarrier{}, false},
+		{&sqlbase.IndexDescriptor{}, false},
+		{&roachpb.SplitTrigger{}, false},
+		{&roachpb.Value{}, false},
+		{&storagebase.ReplicaState{}, false},
+		{&roachpb.RangeDescriptor{}, false},
 	}
 	for _, tc := range testCases {
 		var clone proto.Message

--- a/pkg/util/protoutil/clone_test.go
+++ b/pkg/util/protoutil/clone_test.go
@@ -28,26 +28,21 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
 func TestCloneProto(t *testing.T) {
-	u := uuid.MakeV4()
-
 	testCases := []struct {
 		pb          proto.Message
 		shouldPanic bool
 	}{
-		// StoreIdent contains a UUID by value, so it is always uncloneable.
+		// Uncloneable types (all contain UUID fields).
 		{&roachpb.StoreIdent{}, true},
-		{&roachpb.StoreIdent{ClusterID: uuid.MakeV4()}, true},
-		// TxnMeta contains a UUID by pointer, so it is cloneable if the id is nil.
-		{&enginepb.TxnMeta{}, false},
-		{&enginepb.TxnMeta{ID: &u}, true},
-		{&roachpb.Transaction{}, false},
-		{&roachpb.Error{}, false},
-		{&roachpb.Error{UnexposedTxn: &roachpb.Transaction{TxnMeta: enginepb.TxnMeta{ID: &u}}}, true},
-		{&config.ZoneConfig{RangeMinBytes: 123, RangeMaxBytes: 456}, false},
+		{&enginepb.TxnMeta{}, true},
+		{&roachpb.Transaction{}, true},
+		{&roachpb.Error{}, true},
+
+		// Cloneable types.
+		{&config.ZoneConfig{}, false},
 	}
 	for _, tc := range testCases {
 		var clone proto.Message


### PR DESCRIPTION
With these changes, `protoutil.Clone()` now behaves consistently for all values of a type, instead of producing variable results depending on which fields are initialized. 

The first commit is from #10869, without which the new stricter assertions fail on attempts to clone roachpb.Error. The second commit fixes the tests for this function (which had been incorrectly passing since #10566), the third changes the runtime behavior of `Clone()`, and the fourth expands the test to make sure that all types that we currently clone will pass the stricter test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10876)
<!-- Reviewable:end -->
