### PR TITLE
storage: Check ShouldQuiesce in beginCmds

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1393,6 +1393,10 @@ func (r *Replica) beginCmds(ctx context.Context, ba *roachpb.BatchRequest) (*end
 					r.cmdQMu.Unlock()
 				}()
 				return nil, err
+			case <-r.store.stopper.ShouldQuiesce():
+				// While shutting down, commands may have been added to the
+				// command queue that will never finish.
+				return nil, &roachpb.NodeUnavailableError{}
 			}
 		}
 		if numChans > 0 {


### PR DESCRIPTION
Recent changes to cancellation may leave commands that will never finish
in the command queue, so any commands blocked on the command queue must
also exit when quiescing.

Fixes #10883

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10896)
<!-- Reviewable:end -->
