### PR TITLE
storage: do not call Replica.CloseOutSnap on error.

### DIFF
--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -3177,11 +3177,11 @@ func (r *Replica) ChangeReplicas(
 		// complete. See #10409.
 		if err := func() error {
 			snap, err := r.GetSnapshot(ctx, snapTypePreemptive)
+			if err != nil {
+				return errors.Wrapf(err, "%s: change replicas failed to generate snapshot", r)
+			}
 			defer r.CloseOutSnap()
 			log.Event(ctx, "generated snapshot")
-			if err != nil {
-				return errors.Wrapf(err, "%s: change replicas failed", r)
-			}
 
 			fromRepDesc, err := r.GetReplicaDescriptor()
 			if err != nil {


### PR DESCRIPTION
Fixes #10895

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10897)
<!-- Reviewable:end -->
