### PR TITLE
Tweak version in binary.

### DIFF
--- a/build/ldflags.sh
+++ b/build/ldflags.sh
@@ -4,7 +4,12 @@ set -eu
 
 cd "$(dirname "${0}")"/..
 
+build_version="$(git describe --tags --exact-match 2> /dev/null || git rev-parse --short HEAD)"
+if [ -n "$(git status --porcelain)" ]; then
+  build_version="${build_version}-dirty"
+fi
+
 # The build.utcTime format must remain in sync with TimeFormat in info.go.
-echo '-X "github.com/cockroachdb/cockroach/pkg/build.tag='$(git describe --dirty --tags)'"' \
+echo '-X "github.com/cockroachdb/cockroach/pkg/build.tag='${build_version}'"' \
      '-X "github.com/cockroachdb/cockroach/pkg/build.utcTime='$(date -u '+%Y/%m/%d %H:%M:%S')'"' \
      '-X "github.com/cockroachdb/cockroach/pkg/build.deps='$(build/depvers.sh)'"'


### PR DESCRIPTION
If we're exactly at a tag, use that, otherwise, use the current sha.

The current version always uses the most recent tag + the number of
commits since. eg: beta-20161110-295-gd75dd1a

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10899)
<!-- Reviewable:end -->
