### PR TITLE
cmd: fix link to TeamCity build log

### DIFF
--- a/pkg/cmd/github-post/main_test.go
+++ b/pkg/cmd/github-post/main_test.go
@@ -95,7 +95,7 @@ Stress build found a failed test: %s
 %s
 `,
 					regexp.QuoteMeta(sha),
-					regexp.QuoteMeta(fmt.Sprintf("%s/viewLog.html?buildId=%d", serverURL, buildID)),
+					regexp.QuoteMeta(fmt.Sprintf("%s/viewLog.html?buildId=%d&tab=buildLog", serverURL, buildID)),
 					regexp.QuoteMeta(expectations.body),
 				),
 			)


### PR DESCRIPTION
Link to the build log directly instead of the the test overview which is
usually not as useful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10905)
<!-- Reviewable:end -->
