### PR TITLE
server: locate the ui package using go/build

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -21,6 +21,7 @@ import (
 	"compress/gzip"
 	"crypto/tls"
 	"fmt"
+	"go/build"
 	"io"
 	"net"
 	"net/http"
@@ -672,7 +673,11 @@ func (s *Server) Start(ctx context.Context) error {
 	var uiFileSystem http.FileSystem
 	uiDebug := envutil.EnvOrDefaultBool("COCKROACH_DEBUG_UI", false)
 	if uiDebug {
-		uiFileSystem = http.Dir("pkg/ui")
+		uiPkg, err := build.Import("github.com/cockroachdb/cockroach/pkg/ui", "", build.FindOnly)
+		if err != nil {
+			return err
+		}
+		uiFileSystem = http.Dir(uiPkg.Dir)
 	} else {
 		uiFileSystem = &assetfs.AssetFS{
 			Asset:     ui.Asset,


### PR DESCRIPTION
Makes the code resilient to package movement, and has the added benefit
of making it possible to run in debug mode from any directory, rather
than having to run from the repo root.

Fixes #10038.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10916)
<!-- Reviewable:end -->
