### PR TITLE
roachpb: Print a batch's timestamp in String() if it has one

### DIFF
--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -336,6 +336,9 @@ func (ba BatchRequest) Split(canSplitET bool) [][]RequestUnion {
 // See #2198.
 func (ba BatchRequest) String() string {
 	var str []string
+	if !ba.Timestamp.Equal(hlc.ZeroTimestamp) {
+		str = append(str, fmt.Sprintf("[timestamp: %s]", ba.Timestamp))
+	}
 	if ba.Txn != nil {
 		str = append(str, fmt.Sprintf("[txn: %s]", ba.Txn.Short()))
 	}


### PR DESCRIPTION
@petermattis - this is just a quick change that may or may not actually succeed at helping us tell how long a batch was underway when it's cancelled (https://github.com/cockroachdb/cockroach/issues/10427#issuecomment-262055992), since the API makes it sound as though a BatchRequest's timestamp won't always be filled in. Let me know if it's worthless for our purposes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10918)
<!-- Reviewable:end -->
