### PR TITLE
Makefile: define `make bench` in terms of `make test`

### DIFF
--- a/pkg/cmd/github-pull-request-make/main.go
+++ b/pkg/cmd/github-pull-request-make/main.go
@@ -165,7 +165,7 @@ func main() {
 				target,
 				fmt.Sprintf("PKG=./%s", name),
 				fmt.Sprintf("TESTS=%s", tests),
-				fmt.Sprintf("TESTFLAGS=-test.bench %s", benchmarks),
+				fmt.Sprintf("BENCHES=%s", benchmarks),
 				fmt.Sprintf("STRESSFLAGS=-stderr -maxfails 1 -maxtime %s", duration),
 			)
 			cmd.Dir = crdb.Dir


### PR DESCRIPTION
Mimic the handling of TESTS with the new BENCHES. Fixes an issue where
new benchmarks would cause the stress runner to produce invalid syntax.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10923)
<!-- Reviewable:end -->
