### PR TITLE
sql: fix flaky test by ensuring full replication in test cluster

### DIFF
--- a/pkg/sql/ambiguous_commit_test.go
+++ b/pkg/sql/ambiguous_commit_test.go
@@ -28,9 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/pkg/errors"
 )
 
 // TestAmbiguousCommitDueToLeadershipChange verifies that an ambiguous
@@ -45,7 +43,6 @@ import (
 // duplicate key violations. See #6053, #7604, and #10023.
 func TestAmbiguousCommitDueToLeadershipChange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#10341")
 
 	// Create a command filter which prevents EndTransaction from
 	// returning a response.
@@ -93,20 +90,10 @@ func TestAmbiguousCommitDueToLeadershipChange(t *testing.T) {
 	tableID := sqlutils.QueryTableID(t, tc.Conns[0], "test", "t")
 	tableStartKey.Store(keys.MakeTablePrefix(tableID))
 
-	// Wait for new table to split.
-	util.SucceedsSoon(t, func() error {
-		startKey := tableStartKey.Load().([]byte)
-
-		desc, err := tc.LookupRange(keys.MakeRowSentinelKey(startKey))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !desc.StartKey.Equal(startKey) {
-			return errors.Errorf("expected range start key %s; got %s",
-				startKey, desc.StartKey)
-		}
-		return nil
-	})
+	// Wait for new table to split & replication.
+	if err := tc.WaitForSplitAndReplication(tableStartKey.Load().([]byte)); err != nil {
+		t.Fatal(err)
+	}
 
 	// Lookup the lease.
 	tableRangeDesc, err := tc.LookupRange(keys.MakeRowSentinelKey(tableStartKey.Load().([]byte)))

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -491,6 +491,42 @@ func (tc *TestCluster) FindRangeLeaseHolder(
 	return ReplicationTarget{NodeID: replicaDesc.NodeID, StoreID: replicaDesc.StoreID}, nil
 }
 
+// WaitForSplitAndReplication waits for a range which starts with
+// startKey and then verifies that each replica in the range
+// descriptor has been created.
+func (tc *TestCluster) WaitForSplitAndReplication(startKey roachpb.Key) error {
+	return util.RetryForDuration(util.DefaultSucceedsSoonDuration, func() error {
+		desc, err := tc.LookupRange(startKey)
+		if err != nil {
+			return errors.Wrapf(err, "unable to lookup range for %s", startKey)
+		}
+		// Verify the split first.
+		if !desc.StartKey.Equal(startKey) {
+			return errors.Errorf("expected range start key %s; got %s",
+				startKey, desc.StartKey)
+		}
+		// Once we've verified the split, make sure that replicas exist.
+		for _, rDesc := range desc.Replicas {
+			store, err := tc.findMemberStore(rDesc.StoreID)
+			if err != nil {
+				return err
+			}
+			repl, err := store.GetReplica(desc.RangeID)
+			if err != nil {
+				return err
+			}
+			actualReplicaDesc, err := repl.GetReplicaDescriptor()
+			if err != nil {
+				return err
+			}
+			if actualReplicaDesc != rDesc {
+				return errors.Errorf("expected replica %s; got %s", rDesc, actualReplicaDesc)
+			}
+		}
+		return nil
+	})
+}
+
 // findMemberStore returns the store containing a given replica.
 func (tc *TestCluster) findMemberStore(storeID roachpb.StoreID) (*storage.Store, error) {
 	for _, server := range tc.Servers {

--- a/pkg/util/testing.go
+++ b/pkg/util/testing.go
@@ -98,7 +98,9 @@ func CleanupDir(dir string) {
 	_ = os.RemoveAll(dir)
 }
 
-const defaultSucceedsSoonDuration = 45 * time.Second
+// DefaultSucceedsSoonDuration is the maximum amount of time unittests
+// will wait for a condition to become true. See SucceedsSoon().
+const DefaultSucceedsSoonDuration = 45 * time.Second
 
 // SucceedsSoon fails the test (with t.Fatal) unless the supplied
 // function runs without error within a preset maximum duration. The
@@ -112,9 +114,9 @@ func SucceedsSoon(t Tester, fn func() error) {
 // SucceedsSoonDepth is like SucceedsSoon() but with an additional
 // stack depth offset.
 func SucceedsSoonDepth(depth int, t Tester, fn func() error) {
-	if err := RetryForDuration(defaultSucceedsSoonDuration, fn); err != nil {
+	if err := RetryForDuration(DefaultSucceedsSoonDuration, fn); err != nil {
 		file, line, _ := caller.Lookup(depth + 1)
-		t.Fatalf("%s:%d, condition failed to evaluate within %s: %s", file, line, defaultSucceedsSoonDuration, err)
+		t.Fatalf("%s:%d, condition failed to evaluate within %s: %s", file, line, DefaultSucceedsSoonDuration, err)
 	}
 }
 


### PR DESCRIPTION
Added a new `TestCluster.WaitForSplitAndReplication` command in order
to fully verify that a split has occurred *and* snapshots have been
sent to each replica.

Fixes #10341
Fixes #10299

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10925)
<!-- Reviewable:end -->
