### PR TITLE
log+cli: sanitize the logging to stderr.

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logflags"
 )
 
@@ -402,6 +403,18 @@ func init() {
 
 // extraFlagInit is a standalone function so we can test more easily.
 func extraFlagInit() {
+	// If no log directory has been set, reduce the logging verbosity by default.
+	// `start` increases it again as a special case.
+	if !log.DirSet() {
+		pf := cockroachCmd.PersistentFlags()
+		f := pf.Lookup(logflags.AlsoLogToStderrName)
+		if !f.Changed {
+			if err := f.Value.Set(log.Severity_WARNING.String()); err != nil {
+				panic(err)
+			}
+		}
+	}
+
 	// If any of the security flags have been set, clear the insecure
 	// setting. Note that we do the inverse when the --insecure flag is
 	// set. See insecureValue.Set().

--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -1,0 +1,32 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+spawn /bin/bash
+send "PS1=':''/# '\r"
+eexpect ":/# "
+
+# Check that a server started with only in-memory stores automatically
+# logs to stderr.
+send "$argv start --store=type=mem,size=1GiB\r"
+eexpect "CockroachDB"
+eexpect "starting cockroach node"
+
+# Stop it.
+send "\003"
+sleep 1
+send "\003"
+eexpect ":/# "
+
+# Start a regular server
+send "$argv start >/dev/null 2>&1 & sleep 1\r"
+
+# Now stop this server, and test that `quit` does not emit logging
+# output between the point the command starts until it prints the
+# final ok message.
+send "echo marker; $argv quit\r"
+set timeout 20
+eexpect "marker\r\nok\r\n:/# "
+
+send "exit\r"
+eexpect eof

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -718,12 +718,10 @@ func (l *loggingT) outputLogEntry(s Severity, file string, line int, msg string)
 		}
 	}
 
-	if l.toStderr || !logDir.isSet() {
+	if s >= l.stderrThreshold.get() {
 		l.outputToStderr(entry, stacks)
-	} else {
-		if s >= l.stderrThreshold.get() {
-			l.outputToStderr(entry, stacks)
-		}
+	}
+	if !l.toStderr && logDir.isSet() {
 		if l.file[s] == nil {
 			if err := l.createFiles(s); err != nil {
 				// Make sure the message appears somewhere.


### PR DESCRIPTION
The changes in b00cf84b22f042d9bc39181ff24c643e217e760f have solved
the problem of logging output disappearing in some invisible directory
in /tmp that was never cleaned up; however they also introduced two
new issues:

- the `start` command would fail if it was specified to only use
  in-memory stores, because then there is no logging directory name to
  be inferred from the store locations and the mkdir command would
  fail.
- other CLI commands like `quit` and others would then start logging
  informational messages to stderr, where none was previously expected.

This patch complements the previous patch by introducing the following
behavior:

- all logging is now subject to the "stderr threshold" (i.e. the
  setting that can be set manually via `--alsologtostderr`), including
  when `--logtostderr` is specified or `--log-dir` is not. This means
  it is now possible to filter out what goes to stderr in all
  cases. Previously, it was not possible to configure a threshold if
  `--logtostderr` was set or `--log-dir` wasn't.

- when `--log-dir` is not specified and it is not possible to infer a
  value automatically from the store configuration, the `start`
  commands defaults the logging threshold to INFO, i.e. all logging
  messages are emitted to stderr. It is possible to override this with
  the `--alsologtostderr` flag.

- when `--log-dir` is not specified and another CLI command than
  `start` is issued, then the threshold is defaulted to WARNING,
  i.e. INFO messages are hidden by default. Again it is possible to
  override this with the `--alsologtostderr` flag.

Fixes #9206.
Fixes #10910.
Fixes #10915.

cc @bdarnell @jseldess.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10926)
<!-- Reviewable:end -->
