### PR TITLE
storage: tune raft.Config.{MaxSizePerMsg,MaxInflightMsgs}

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -150,6 +150,11 @@ func TestStoreConfig(clock *hlc.Clock) StoreConfig {
 	}
 }
 
+var (
+	raftMaxSizePerMsg   = envutil.EnvOrDefaultInt("COCKROACH_RAFT_MAX_SIZE_PER_MSG", 16*1024)
+	raftMaxInflightMsgs = envutil.EnvOrDefaultInt("COCKROACH_RAFT_MAX_INFLIGHT_MSGS", 4)
+)
+
 func newRaftConfig(
 	strg raft.Storage, id uint64, appliedIndex uint64, storeCfg StoreConfig, logger raft.Logger,
 ) *raft.Config {
@@ -168,9 +173,17 @@ func newRaftConfig(
 		PreVote:     enablePreVote,
 		CheckQuorum: !enablePreVote,
 
-		// TODO(bdarnell): make these configurable; evaluate defaults.
-		MaxSizePerMsg:   1024 * 1024,
-		MaxInflightMsgs: 256,
+		// MaxSizePerMsg controls how many Raft log entries the leader will send to
+		// followers in a single MsgApp.
+		MaxSizePerMsg: uint64(raftMaxSizePerMsg),
+		// MaxInflightMsgs controls how many "inflight" messages Raft will send to
+		// a follower without hearing a response. The total number of Raft log
+		// entries is a combination of this setting and MaxSizePerMsg. The current
+		// settings provide for up to 64 KB of raft log to be sent without
+		// acknowledgement. With an average entry size of 1 KB that translates to
+		// ~64 commands that might be executed in the handling of a single
+		// raft.Ready operation.
+		MaxInflightMsgs: raftMaxInflightMsgs,
 	}
 }
 
@@ -2961,7 +2974,7 @@ func (s *Store) processRaftRequest(
 		removePlaceholder = false
 	} else {
 		// Force the replica to deal with this snapshot right now.
-		if err := r.handleRaftReadyRaftMuLocked(inSnap); err != nil {
+		if _, err := r.handleRaftReadyRaftMuLocked(inSnap); err != nil {
 			// mimic the behavior in processRaft.
 			panic(err)
 		}
@@ -3209,19 +3222,20 @@ func (s *Store) processReady(rangeID roachpb.RangeID) {
 	s.mu.Unlock()
 
 	if ok {
-		if err := r.handleRaftReady(IncomingSnapshot{}); err != nil {
+		stats, err := r.handleRaftReady(IncomingSnapshot{})
+		if err != nil {
 			panic(err) // TODO(bdarnell)
 		}
 		elapsed := timeutil.Since(start)
 		s.metrics.RaftWorkingDurationNanos.Inc(elapsed.Nanoseconds())
-		// If Raft processing took longer than 10x the raft tick interval something
-		// bad is going on. Such long processing time means we'll have starved
-		// local replicas of ticks and remote replicas will likely start
-		// campaigning.
-		var warnDuration = 10 * s.cfg.RaftTickInterval
-		if elapsed >= warnDuration {
+		// Warn if Raft processing took too long. We use the same duration as we
+		// use for warning about excessive raft mutex lock hold times. Long
+		// processing time means we'll have starved local replicas of ticks and
+		// remote replicas will likely start campaigning.
+		if elapsed >= defaultReplicaRaftMuWarnThreshold {
 			ctx := r.AnnotateCtx(context.TODO())
-			log.Warningf(ctx, "handle raft ready: %.1fs", elapsed.Seconds())
+			log.Warningf(ctx, "handle raft ready: %.1fs [processed=%d]",
+				elapsed.Seconds(), stats.processed)
 		}
 		if !r.IsInitialized() {
 			// Only an uninitialized replica can have a placeholder since, by


### PR DESCRIPTION
The previous settings allowed up to 256 MB of Raft log entries to be
inflight to a follower, resulting in a single Replica.handleRaftReady
call processing thousands or 10s of thousands of commands.

Log the number of commands processed when Replica.handleRaftReady takes
too long.

Fixes #10917

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10929)
<!-- Reviewable:end -->
