### PR TITLE
distsql: use ordinal references in distsql expressions

### DIFF
--- a/pkg/sql/dist_sql_node.go
+++ b/pkg/sql/dist_sql_node.go
@@ -183,13 +183,13 @@ func scanNodeToTableReaderSpec(n *scanNode) *distsql.TableReaderSpec {
 	if n.filter != nil {
 		// Ugly hack to get the expression to print the way we want it.
 		//
-		// The distsql Expression uses the placeholder syntax ($0, $1, $2..) to
+		// The distsql Expression uses the placeholder syntax (@1, @2, @3..) to
 		// refer to columns. We temporarily rename the scanNode columns to
-		// (literally) "$0", "$1", ... and convert to a string.
+		// (literally) "@1", "@2", ... and convert to a string.
 		tmp := n.resultColumns
 		n.resultColumns = make(ResultColumns, len(tmp))
 		for i, orig := range tmp {
-			n.resultColumns[i].Name = fmt.Sprintf("$%d", i)
+			n.resultColumns[i].Name = fmt.Sprintf("@%d", i+1)
 			n.resultColumns[i].Typ = orig.Typ
 			n.resultColumns[i].hidden = orig.hidden
 		}

--- a/pkg/sql/distsql/aggregator.go
+++ b/pkg/sql/distsql/aggregator.go
@@ -268,7 +268,7 @@ func (ag *aggregator) extractFunc(
 		Func: parser.ResolvableFunctionReference{
 			FunctionReference: parser.UnresolvedName{parser.Name(expr.Func.String())},
 		},
-		Exprs: []parser.Expr{eh.indexToExpr(int(expr.ColIdx))},
+		Exprs: []parser.Expr{eh.vars.IndexedVar(int(expr.ColIdx))},
 	}
 
 	_, err := p.TypeCheck(nil, parser.NoTypePreference)

--- a/pkg/sql/distsql/aggregator_test.go
+++ b/pkg/sql/distsql/aggregator_test.go
@@ -50,7 +50,7 @@ func TestAggregator(t *testing.T) {
 		expected sqlbase.EncDatumRows
 	}{
 		{
-			// SELECT $1, COUNT($0), GROUP BY $1.
+			// SELECT @2, COUNT(@1), GROUP BY @2.
 			spec: AggregatorSpec{
 				Types:     []sqlbase.ColumnType_Kind{sqlbase.ColumnType_INT, sqlbase.ColumnType_INT},
 				GroupCols: []uint32{1},
@@ -77,7 +77,7 @@ func TestAggregator(t *testing.T) {
 				{v[2], v[3]},
 			},
 		}, {
-			// SELECT $1, SUM($0), GROUP BY $1.
+			// SELECT @2, SUM(@1), GROUP BY @2.
 			spec: AggregatorSpec{
 				Types:     []sqlbase.ColumnType_Kind{sqlbase.ColumnType_INT, sqlbase.ColumnType_INT},
 				GroupCols: []uint32{1},
@@ -104,7 +104,7 @@ func TestAggregator(t *testing.T) {
 				{v[4], v[11]},
 			},
 		}, {
-			// SELECT COUNT($0), SUM($0), GROUP BY [] (empty group key).
+			// SELECT COUNT(@1), SUM(@1), GROUP BY [] (empty group key).
 			spec: AggregatorSpec{
 				Types: []sqlbase.ColumnType_Kind{sqlbase.ColumnType_INT, sqlbase.ColumnType_INT},
 				Exprs: []AggregatorSpec_Expr{
@@ -130,7 +130,7 @@ func TestAggregator(t *testing.T) {
 			},
 		},
 		{
-			// SELECT SUM DISTINCT ($0), GROUP BY [] (empty group key).
+			// SELECT SUM DISTINCT (@1), GROUP BY [] (empty group key).
 			spec: AggregatorSpec{
 				Types: []sqlbase.ColumnType_Kind{sqlbase.ColumnType_INT},
 				Exprs: []AggregatorSpec_Expr{
@@ -153,7 +153,7 @@ func TestAggregator(t *testing.T) {
 			},
 		},
 		{
-			// SELECT $0, GROUP BY [] (empty group key).
+			// SELECT @1, GROUP BY [] (empty group key).
 			spec: AggregatorSpec{
 				Types: []sqlbase.ColumnType_Kind{sqlbase.ColumnType_INT},
 				Exprs: []AggregatorSpec_Expr{
@@ -172,7 +172,7 @@ func TestAggregator(t *testing.T) {
 				{v[1]},
 			},
 		}, {
-			// SELECT MAX($0), MIN($1), COUNT($1), COUNT DISTINCT ($1), GROUP BY [] (empty group key).
+			// SELECT MAX(@1), MIN(@2), COUNT(@2), COUNT DISTINCT (@2), GROUP BY [] (empty group key).
 			spec: AggregatorSpec{
 				Types: []sqlbase.ColumnType_Kind{sqlbase.ColumnType_INT, sqlbase.ColumnType_INT},
 				Exprs: []AggregatorSpec_Expr{

--- a/pkg/sql/distsql/data.pb.go
+++ b/pkg/sql/distsql/data.pb.go
@@ -186,8 +186,8 @@ func (OutputRouterSpec_Type) EnumDescriptor() ([]byte, []int) { return fileDescr
 type Expression struct {
 	// TODO(radu): TBD how this will be used
 	Version string `protobuf:"bytes,1,opt,name=version" json:"version"`
-	// SQL expressions are passed as a string, with placeholders ($0, $1, $2 ..)
-	// used for "input" variables.
+	// SQL expressions are passed as a string, with ordinal references
+	// (@1, @2, @3 ..) used for "input" variables.
 	Expr string `protobuf:"bytes,2,opt,name=expr" json:"expr"`
 }
 

--- a/pkg/sql/distsql/data.proto
+++ b/pkg/sql/distsql/data.proto
@@ -32,8 +32,8 @@ message Expression {
   // TODO(radu): TBD how this will be used
   optional string version = 1 [(gogoproto.nullable) = false];
 
-  // SQL expressions are passed as a string, with placeholders ($0, $1, $2 ..)
-  // used for "input" variables.
+  // SQL expressions are passed as a string, with ordinal references
+  // (@1, @2, @3 ..) used for "input" variables.
   optional string expr = 2 [(gogoproto.nullable) = false];
 }
 

--- a/pkg/sql/distsql/evaluator_test.go
+++ b/pkg/sql/distsql/evaluator_test.go
@@ -48,7 +48,7 @@ func TestEvaluator(t *testing.T) {
 	}{
 		{
 			spec: EvaluatorSpec{
-				Exprs: []Expression{{Expr: "$1"}, {Expr: "((($0)))"}},
+				Exprs: []Expression{{Expr: "@2"}, {Expr: "(((@1)))"}},
 			},
 			input: sqlbase.EncDatumRows{
 				{v[1], v[2]},
@@ -69,9 +69,9 @@ func TestEvaluator(t *testing.T) {
 		}, {
 			spec: EvaluatorSpec{
 				Exprs: []Expression{
-					{Expr: "$0 + $1"},
-					{Expr: "$0 - $1"},
-					{Expr: "$0 >= 8"},
+					{Expr: "@1 + @2"},
+					{Expr: "@1 - @2"},
+					{Expr: "@1 >= 8"},
 				},
 			},
 			input: sqlbase.EncDatumRows{
@@ -91,9 +91,9 @@ func TestEvaluator(t *testing.T) {
 		}, {
 			spec: EvaluatorSpec{
 				Exprs: []Expression{
-					{Expr: "$0 AND $0"},
-					{Expr: "$0 AND $1"},
-					{Expr: "NOT $0"},
+					{Expr: "@1 AND @1"},
+					{Expr: "@1 AND @2"},
+					{Expr: "NOT @1"},
 				},
 			},
 			input: sqlbase.EncDatumRows{

--- a/pkg/sql/distsql/expr_test.go
+++ b/pkg/sql/distsql/expr_test.go
@@ -42,7 +42,7 @@ func (d testVarContainer) IndexedVarFormat(buf *bytes.Buffer, _ parser.FmtFlags,
 func TestProcessExpression(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	e := Expression{Expr: "$0 * ($1 + $2) + $0"}
+	e := Expression{Expr: "@1 * (@2 + @3) + @1"}
 	h := parser.MakeIndexedVarHelper(testVarContainer{}, 4)
 	expr, err := processExpression(e, &h)
 	if err != nil {

--- a/pkg/sql/distsql/flow_diagram_test.go
+++ b/pkg/sql/distsql/flow_diagram_test.go
@@ -60,7 +60,7 @@ func TestPlanDiagramIndexJoin(t *testing.T) {
 	jr := JoinReaderSpec{
 		Table:         *desc,
 		OutputColumns: []uint32{2},
-		Filter:        Expression{Expr: "$0+$1<$2"},
+		Filter:        Expression{Expr: "@1+@2<@3"},
 	}
 
 	f1 := FlowSpec{
@@ -129,7 +129,7 @@ func TestPlanDiagramIndexJoin(t *testing.T) {
 				{"nodeIdx":0,"inputs":[],"core":{"title":"TableReader","details":["SomeIndex@Table","0,1"]},"outputs":[]},
 				{"nodeIdx":1,"inputs":[],"core":{"title":"TableReader","details":["SomeIndex@Table","0,1"]},"outputs":[]},
 				{"nodeIdx":2,"inputs":[],"core":{"title":"TableReader","details":["SomeIndex@Table","0,1"]},"outputs":[]},
-				{"nodeIdx":2,"inputs":[{"title":"ordered","details":["1+"]}],"core":{"title":"JoinReader","details":["primary@Table","2","$0+$1\u003c$2"]},"outputs":[]},
+				{"nodeIdx":2,"inputs":[{"title":"ordered","details":["1+"]}],"core":{"title":"JoinReader","details":["primary@Table","2","@1+@2\u003c@3"]},"outputs":[]},
 				{"nodeIdx":2,"inputs":[],"core":{"title":"Response","details":[]},"outputs":[]}
 			],
 			"edges":[
@@ -164,7 +164,7 @@ func TestPlanDiagramJoin(t *testing.T) {
 		LeftEqColumns:  []uint32{0, 2},
 		RightEqColumns: []uint32{2, 1},
 		OutputColumns:  []uint32{0, 1, 2, 3, 4, 5},
-		Expr:           Expression{Expr: "$0+$1<$5"},
+		Expr:           Expression{Expr: "@1+@2<@6"},
 	}
 
 	f1 := FlowSpec{
@@ -318,11 +318,11 @@ func TestPlanDiagramJoin(t *testing.T) {
 			"processors":[
 				{"nodeIdx":0,"inputs":[],"core":{"title":"TableReader","details":["primary@TableA","0,1,3"]},"outputs":[{"title":"by hash","details":["0,1"]}]},
 				{"nodeIdx":1,"inputs":[],"core":{"title":"TableReader","details":["primary@TableA","0,1,3"]},"outputs":[{"title":"by hash","details":["0,1"]}]},
-				{"nodeIdx":1,"inputs":[{"title":"unordered","details":[]},{"title":"unordered","details":[]}],"core":{"title":"HashJoiner","details":["ON left(0,2)=right(2,1)","0,1,2,3,4,5","$0+$1\u003c$5"]},"outputs":[]},
+				{"nodeIdx":1,"inputs":[{"title":"unordered","details":[]},{"title":"unordered","details":[]}],"core":{"title":"HashJoiner","details":["ON left(0,2)=right(2,1)","0,1,2,3,4,5","@1+@2\u003c@6"]},"outputs":[]},
 				{"nodeIdx":1,"inputs":[{"title":"unordered","details":[]}],"core":{"title":"No-op","details":[]},"outputs":[]},
 				{"nodeIdx":2,"inputs":[],"core":{"title":"TableReader","details":["primary@TableA","0,1,3"]},"outputs":[{"title":"by hash","details":["0,1"]}]},
 				{"nodeIdx":2,"inputs":[],"core":{"title":"TableReader","details":["primary@TableB","1,2,4"]},"outputs":[{"title":"by hash","details":["2,1"]}]},
-				{"nodeIdx":2,"inputs":[{"title":"unordered","details":[]},{"title":"unordered","details":[]}],"core":{"title":"HashJoiner","details":["ON left(0,2)=right(2,1)","0,1,2,3,4,5","$0+$1\u003c$5"]},"outputs":[]},
+				{"nodeIdx":2,"inputs":[{"title":"unordered","details":[]},{"title":"unordered","details":[]}],"core":{"title":"HashJoiner","details":["ON left(0,2)=right(2,1)","0,1,2,3,4,5","@1+@2\u003c@6"]},"outputs":[]},
 				{"nodeIdx":3,"inputs":[],"core":{"title":"TableReader","details":["primary@TableB","1,2,4"]},"outputs":[{"title":"by hash","details":["2,1"]}]},
 				{"nodeIdx":1,"inputs":[],"core":{"title":"Response","details":[]},"outputs":[]}
 			],

--- a/pkg/sql/distsql/hashjoiner_test.go
+++ b/pkg/sql/distsql/hashjoiner_test.go
@@ -56,7 +56,7 @@ func TestHashJoiner(t *testing.T) {
 				},
 				Type:          JoinType_INNER,
 				OutputColumns: []uint32{0, 3, 4},
-				// Implicit $0 = $2 constraint.
+				// Implicit @1 = @3 constraint.
 			},
 			inputs: []sqlbase.EncDatumRows{
 				{
@@ -94,7 +94,7 @@ func TestHashJoiner(t *testing.T) {
 				},
 				Type:          JoinType_INNER,
 				OutputColumns: []uint32{0, 1, 3},
-				// Implicit $0 = $2 constraint.
+				// Implicit @1 = @3 constraint.
 			},
 			inputs: []sqlbase.EncDatumRows{
 				{
@@ -137,8 +137,8 @@ func TestHashJoiner(t *testing.T) {
 				},
 				Type:          JoinType_INNER,
 				OutputColumns: []uint32{0, 1, 3},
-				Expr:          Expression{Expr: "$3 >= 4"},
-				// Implicit AND $0 = $2 constraint.
+				Expr:          Expression{Expr: "@4 >= 4"},
+				// Implicit AND @1 = @3 constraint.
 			},
 			inputs: []sqlbase.EncDatumRows{
 				{
@@ -190,7 +190,7 @@ func TestHashJoiner(t *testing.T) {
 				},
 				Type:          JoinType_LEFT_OUTER,
 				OutputColumns: []uint32{0, 3, 4},
-				// Implicit $0 = $2 constraint.
+				// Implicit @1 = @3 constraint.
 			},
 			inputs: []sqlbase.EncDatumRows{
 				{
@@ -231,7 +231,7 @@ func TestHashJoiner(t *testing.T) {
 				},
 				Type:          JoinType_RIGHT_OUTER,
 				OutputColumns: []uint32{3, 1, 2},
-				// Implicit $0 = $2 constraint.
+				// Implicit @1 = @3 constraint.
 			},
 			inputs: []sqlbase.EncDatumRows{
 				{
@@ -272,7 +272,7 @@ func TestHashJoiner(t *testing.T) {
 				},
 				Type:          JoinType_FULL_OUTER,
 				OutputColumns: []uint32{0, 3, 4},
-				// Implicit $0 = $2 constraint.
+				// Implicit @1 = @3 constraint.
 			},
 			inputs: []sqlbase.EncDatumRows{
 				{
@@ -313,7 +313,7 @@ func TestHashJoiner(t *testing.T) {
 				},
 				Type:          JoinType_INNER,
 				OutputColumns: []uint32{0, 3, 4},
-				// Implicit $0 = $2 constraint.
+				// Implicit @1 = @3 constraint.
 			},
 			inputs: []sqlbase.EncDatumRows{
 				{

--- a/pkg/sql/distsql/joinreader_test.go
+++ b/pkg/sql/distsql/joinreader_test.go
@@ -78,7 +78,7 @@ func TestJoinReader(t *testing.T) {
 		},
 		{
 			spec: JoinReaderSpec{
-				Filter:        Expression{Expr: "$2 <= 5"}, // sum <= 5
+				Filter:        Expression{Expr: "@3 <= 5"}, // sum <= 5
 				OutputColumns: []uint32{3},
 			},
 			input: [][]parser.Datum{

--- a/pkg/sql/distsql/mergejoiner_test.go
+++ b/pkg/sql/distsql/mergejoiner_test.go
@@ -61,7 +61,7 @@ func TestMergeJoiner(t *testing.T) {
 				},
 				Type:          JoinType_INNER,
 				OutputColumns: []uint32{0, 3, 4},
-				// Implicit $0 = $2 constraint.
+				// Implicit @1 = @3 constraint.
 			},
 			inputs: []sqlbase.EncDatumRows{
 				{
@@ -105,7 +105,7 @@ func TestMergeJoiner(t *testing.T) {
 				},
 				Type:          JoinType_INNER,
 				OutputColumns: []uint32{0, 1, 3},
-				// Implicit $0 = $2 constraint.
+				// Implicit @1 = @3 constraint.
 			},
 			inputs: []sqlbase.EncDatumRows{
 				{
@@ -154,8 +154,8 @@ func TestMergeJoiner(t *testing.T) {
 				},
 				Type:          JoinType_INNER,
 				OutputColumns: []uint32{0, 1, 3},
-				Expr:          Expression{Expr: "$3 >= 4"},
-				// Implicit AND $0 = $2 constraint.
+				Expr:          Expression{Expr: "@4 >= 4"},
+				// Implicit AND @1 = @3 constraint.
 			},
 			inputs: []sqlbase.EncDatumRows{
 				{
@@ -213,7 +213,7 @@ func TestMergeJoiner(t *testing.T) {
 				},
 				Type:          JoinType_LEFT_OUTER,
 				OutputColumns: []uint32{0, 3, 4},
-				// Implicit $0 = $2 constraint.
+				// Implicit @1 = @3 constraint.
 			},
 			inputs: []sqlbase.EncDatumRows{
 				{
@@ -260,7 +260,7 @@ func TestMergeJoiner(t *testing.T) {
 				},
 				Type:          JoinType_RIGHT_OUTER,
 				OutputColumns: []uint32{3, 1, 2},
-				// Implicit $0 = $2 constraint.
+				// Implicit @1 = @3 constraint.
 			},
 			inputs: []sqlbase.EncDatumRows{
 				{
@@ -307,7 +307,7 @@ func TestMergeJoiner(t *testing.T) {
 				},
 				Type:          JoinType_FULL_OUTER,
 				OutputColumns: []uint32{0, 3, 4},
-				// Implicit $0 = $2 constraint.
+				// Implicit @1 = @3 constraint.
 			},
 			inputs: []sqlbase.EncDatumRows{
 				{

--- a/pkg/sql/distsql/processors.pb.go
+++ b/pkg/sql/distsql/processors.pb.go
@@ -159,8 +159,8 @@ type TableReaderSpec struct {
 	Reverse  bool              `protobuf:"varint,3,opt,name=reverse" json:"reverse"`
 	Spans    []TableReaderSpan `protobuf:"bytes,4,rep,name=spans" json:"spans"`
 	// The filter expression references the columns in the table (table.columns)
-	// via $0, $1, etc. If a secondary index is used, the columns that are not
-	// available as part of the index cannot be referenced.
+	// via ordinal references (@1, @2, etc). If a secondary index is used, the
+	// columns that are not available as part of the index cannot be referenced.
 	Filter Expression `protobuf:"bytes,5,opt,name=filter" json:"filter"`
 	// The table reader will only produce values for these columns, referenced by
 	// their indices in table.columns.
@@ -188,8 +188,8 @@ type JoinReaderSpec struct {
 	// TODO(radu): figure out the correct semantics when joining with an index.
 	IndexIdx uint32 `protobuf:"varint,2,opt,name=index_idx,json=indexIdx" json:"index_idx"`
 	// The filter expression references the columns in the table (table.columns)
-	// via $0, $1, etc. If a secondary index is used, the columns that are not
-	// available as part of the index cannot be referenced.
+	// via ordinal references (@1, @2, etc). If a secondary index is used, the
+	// columns that are not available as part of the index cannot be referenced.
 	Filter Expression `protobuf:"bytes,3,opt,name=filter" json:"filter"`
 	// The table reader will only produce values for these columns, referenced by
 	// their indices in table.columns.
@@ -229,7 +229,7 @@ func (*SorterSpec) Descriptor() ([]byte, []int) { return fileDescriptorProcessor
 // expressions on the input row.
 //
 // TODO(irfansharif): Add support for an optional output filter expression.
-// The filter expression would reference the columns in the row via $0, $1,
+// The filter expression would reference the columns in the row via @1, @2,
 // etc., possibly optimizing if filtering on expressions common to the
 // 'program'.
 type EvaluatorSpec struct {
@@ -275,9 +275,9 @@ type MergeJoinerSpec struct {
 	RightTypes    []cockroach_sql_sqlbase1.ColumnType_Kind `protobuf:"varint,4,rep,name=right_types,json=rightTypes,enum=cockroach.sql.sqlbase.ColumnType_Kind" json:"right_types,omitempty"`
 	// "ON" expression (in addition to the equality constraints captured by the
 	// orderings). Assuming that the left stream has N columns and the right
-	// stream has M columns, in this expression variables $0 to $(N-1) refer to
-	// columns of the left stream and variables $N to $(N+M-1) refer to columns in
-	// the right stream.
+	// stream has M columns, in this expression ordinal references @1 to @N refer
+	// to columns of the left stream and variables @(N+1) to @(N+M) refer to
+	// columns in the right stream.
 	Expr Expression `protobuf:"bytes,5,opt,name=expr" json:"expr"`
 	Type JoinType   `protobuf:"varint,6,opt,name=type,enum=cockroach.sql.distsql.JoinType" json:"type"`
 	// Columns for the output stream. Assuming that the left stream has N columns
@@ -309,8 +309,8 @@ type HashJoinerSpec struct {
 	RightTypes     []cockroach_sql_sqlbase1.ColumnType_Kind `protobuf:"varint,4,rep,name=right_types,json=rightTypes,enum=cockroach.sql.sqlbase.ColumnType_Kind" json:"right_types,omitempty"`
 	// "ON" expression (in addition to the equality constraints captured by the
 	// orderings). Assuming that the left stream has N columns and the right
-	// stream has M columns, in this expression variables $0 to $(N-1) refer to
-	// columns of the left stream and variables $N to $(N+M-1) refer to columns in
+	// stream has M columns, in this expression variables @1 to @N refer to
+	// columns of the left stream and variables @N to @(N+M) refer to columns in
 	// the right stream.
 	Expr Expression `protobuf:"bytes,5,opt,name=expr" json:"expr"`
 	Type JoinType   `protobuf:"varint,6,opt,name=type,enum=cockroach.sql.distsql.JoinType" json:"type"`

--- a/pkg/sql/distsql/processors.proto
+++ b/pkg/sql/distsql/processors.proto
@@ -54,8 +54,8 @@ message TableReaderSpec {
   repeated TableReaderSpan spans = 4 [(gogoproto.nullable) = false];
 
   // The filter expression references the columns in the table (table.columns)
-  // via $0, $1, etc. If a secondary index is used, the columns that are not
-  // available as part of the index cannot be referenced.
+  // via ordinal references (@1, @2, etc). If a secondary index is used, the
+  // columns that are not available as part of the index cannot be referenced.
   optional Expression filter = 5 [(gogoproto.nullable) = false];
 
   // The table reader will only produce values for these columns, referenced by
@@ -82,8 +82,8 @@ message JoinReaderSpec {
   optional uint32 index_idx = 2 [(gogoproto.nullable) = false];
 
   // The filter expression references the columns in the table (table.columns)
-  // via $0, $1, etc. If a secondary index is used, the columns that are not
-  // available as part of the index cannot be referenced.
+  // via ordinal references (@1, @2, etc). If a secondary index is used, the
+  // columns that are not available as part of the index cannot be referenced.
   optional Expression filter = 3 [(gogoproto.nullable) = false];
 
   // The table reader will only produce values for these columns, referenced by
@@ -119,7 +119,7 @@ message SorterSpec {
 // expressions on the input row.
 //
 // TODO(irfansharif): Add support for an optional output filter expression.
-// The filter expression would reference the columns in the row via $0, $1,
+// The filter expression would reference the columns in the row via @1, @2,
 // etc., possibly optimizing if filtering on expressions common to the
 // 'program'.
 message EvaluatorSpec {
@@ -164,9 +164,9 @@ message MergeJoinerSpec {
 
   // "ON" expression (in addition to the equality constraints captured by the
   // orderings). Assuming that the left stream has N columns and the right
-  // stream has M columns, in this expression variables $0 to $(N-1) refer to
-  // columns of the left stream and variables $N to $(N+M-1) refer to columns in
-  // the right stream.
+  // stream has M columns, in this expression ordinal references @1 to @N refer
+  // to columns of the left stream and variables @(N+1) to @(N+M) refer to
+  // columns in the right stream.
   optional Expression expr = 5 [(gogoproto.nullable) = false];
 
   optional JoinType type = 6 [(gogoproto.nullable) = false];
@@ -197,8 +197,8 @@ message HashJoinerSpec {
 
   // "ON" expression (in addition to the equality constraints captured by the
   // orderings). Assuming that the left stream has N columns and the right
-  // stream has M columns, in this expression variables $0 to $(N-1) refer to
-  // columns of the left stream and variables $N to $(N+M-1) refer to columns in
+  // stream has M columns, in this expression variables @1 to @N refer to
+  // columns of the left stream and variables @N to @(N+M) refer to columns in
   // the right stream.
   optional Expression expr = 5 [(gogoproto.nullable) = false];
 

--- a/pkg/sql/distsql/server_test.go
+++ b/pkg/sql/distsql/server_test.go
@@ -53,7 +53,7 @@ func TestServer(t *testing.T) {
 		IndexIdx:      0,
 		Reverse:       false,
 		Spans:         nil,
-		Filter:        Expression{Expr: "$0 != 2"}, // a != 2
+		Filter:        Expression{Expr: "@1 != 2"}, // a != 2
 		OutputColumns: []uint32{0, 1},              // a
 	}
 

--- a/pkg/sql/distsql/tablereader_test.go
+++ b/pkg/sql/distsql/tablereader_test.go
@@ -76,14 +76,14 @@ func TestTableReader(t *testing.T) {
 	}{
 		{
 			spec: TableReaderSpec{
-				Filter:        Expression{Expr: "$2 < 5 AND $1 != 3"}, // sum < 5 && b != 3
+				Filter:        Expression{Expr: "@3 < 5 AND @2 != 3"}, // sum < 5 && b != 3
 				OutputColumns: []uint32{0, 1},
 			},
 			expected: "[[0 1] [0 2] [0 4] [1 0] [1 1] [1 2] [2 0] [2 1] [2 2] [3 0] [3 1] [4 0]]",
 		},
 		{
 			spec: TableReaderSpec{
-				Filter:        Expression{Expr: "$2 < 5 AND $1 != 3"},
+				Filter:        Expression{Expr: "@3 < 5 AND @2 != 3"},
 				OutputColumns: []uint32{3}, // s
 				HardLimit:     4,
 			},
@@ -94,7 +94,7 @@ func TestTableReader(t *testing.T) {
 				IndexIdx:      1,
 				Reverse:       true,
 				Spans:         []TableReaderSpan{makeIndexSpan(4, 6)},
-				Filter:        Expression{Expr: "$0 < 3"}, // sum < 8
+				Filter:        Expression{Expr: "@1 < 3"}, // sum < 8
 				OutputColumns: []uint32{0, 1},
 				SoftLimit:     1,
 			},


### PR DESCRIPTION
Replacing the hacky placeholder syntax with the new ordinal references.

CC @knz @irfansharif @andreimatei

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10930)
<!-- Reviewable:end -->
