### PR TITLE
util/decimal: decrease allowed shift length

### DIFF
--- a/pkg/util/decimal/decimal.go
+++ b/pkg/util/decimal/decimal.go
@@ -333,8 +333,15 @@ func Log(z *inf.Dec, x *inf.Dec, s inf.Scale) (*inf.Dec, error) {
 
 	// maxExp10 is the maximum number of digits exp10 is expected to return. Above
 	// this it becomes very slow. However since the implementation for that lies
-	// in the inf package, we instead check the length in this function.
-	const maxExp10 = 500000
+	// in the inf package, we instead check the length in this function. The
+	// tests in TestDecimalLogN using strE (a very high-precision E value)
+	// need just under 350000 to complete. They, however, could easily add
+	// more precision because, although the shift value is high, it converges
+	// quickly. If we need to improve this heuristic in the future (which is
+	// designed to prevent slowness only), perhays maxExp10 should decrease as
+	// loop.i increases. This would allow fast-converging calculations to have high
+	// precision and prevent slow-converging calculations from taking all the CPU.
+	const maxExp10 = 350000
 
 	// Loop over the Maclaurin series given above until convergence.
 	for loop := newLoop("log", x, s, 40); ; {

--- a/pkg/util/decimal/no_race_test.go
+++ b/pkg/util/decimal/no_race_test.go
@@ -1,0 +1,21 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build !race
+
+package decimal
+
+import "time"
+
+const testFuncTimeout = time.Second * 5

--- a/pkg/util/decimal/race_test.go
+++ b/pkg/util/decimal/race_test.go
@@ -1,0 +1,21 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build race
+
+package decimal
+
+import "time"
+
+const testFuncTimeout = time.Minute


### PR DESCRIPTION
Improve decimal testing to include a 5s timeout. Also use subtests for
better test messages.

Fixes #10928

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10934)
<!-- Reviewable:end -->
