### PR TITLE
sql: complete the implementation of function lookups.

### DIFF
--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -1078,7 +1080,8 @@ func (n *createViewNode) makeViewTableDesc(
 		if len(p.ColumnNames) > i {
 			columnTableDef.Name = p.ColumnNames[i]
 		}
-		col, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef)
+		// We pass an empty search path here because there are no names to resolve.
+		col, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, nil)
 		if err != nil {
 			return desc, err
 		}
@@ -1138,7 +1141,8 @@ func makeTableDescIfAs(
 		if len(p.AsColumnNames) > i {
 			columnTableDef.Name = p.AsColumnNames[i]
 		}
-		col, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef)
+		// We pass an empty search path here because we do not have any expressions to resolve.
+		col, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, nil)
 		if err != nil {
 			return desc, err
 		}
@@ -1176,7 +1180,7 @@ func (p *planner) makeTableDesc(
 				}
 			}
 
-			col, idx, err := sqlbase.MakeColumnDefDescs(d)
+			col, idx, err := sqlbase.MakeColumnDefDescs(d, p.session.SearchPath)
 			if err != nil {
 				return desc, err
 			}
@@ -1293,7 +1297,7 @@ func (p *planner) makeTableDesc(
 			// pass, handled above.
 
 		case *parser.CheckConstraintTableDef:
-			ck, err := makeCheckConstraint(desc, d, generatedNames)
+			ck, err := makeCheckConstraint(desc, d, generatedNames, p.session.SearchPath)
 			if err != nil {
 				return desc, err
 			}
@@ -1366,7 +1370,10 @@ func (d dummyColumnItem) ResolvedType() parser.Type {
 }
 
 func makeCheckConstraint(
-	desc sqlbase.TableDescriptor, d *parser.CheckConstraintTableDef, inuseNames map[string]struct{},
+	desc sqlbase.TableDescriptor,
+	d *parser.CheckConstraintTableDef,
+	inuseNames map[string]struct{},
+	searchPath parser.SearchPath,
 ) (*sqlbase.TableDescriptor_CheckConstraint, error) {
 	// CHECK expressions seem to vary across databases. Wikipedia's entry on
 	// Check_constraint (https://en.wikipedia.org/wiki/Check_constraint) says
@@ -1420,11 +1427,11 @@ func makeCheckConstraint(
 	}
 
 	var p parser.Parser
-	if err := p.AssertNoAggregationOrWindowing(expr, "CHECK expressions"); err != nil {
+	if err := p.AssertNoAggregationOrWindowing(expr, "CHECK expressions", searchPath); err != nil {
 		return nil, err
 	}
 
-	if err := sqlbase.SanitizeVarFreeExpr(expr, parser.TypeBool, "CHECK"); err != nil {
+	if err := sqlbase.SanitizeVarFreeExpr(expr, parser.TypeBool, "CHECK", searchPath); err != nil {
 		return nil, err
 	}
 	if generateName {
@@ -1461,7 +1468,7 @@ func CreateTestTableDescriptor(
 	if err != nil {
 		return sqlbase.TableDescriptor{}, err
 	}
-	var p planner
+	p := planner{session: &Session{context: context.Background()}}
 	return p.makeTableDesc(stmt.(*parser.CreateTable), parentID, id, privileges, nil)
 }
 

--- a/pkg/sql/distsql/expr.go
+++ b/pkg/sql/distsql/expr.go
@@ -138,7 +138,7 @@ func (eh *exprHelper) init(
 		return err
 	}
 	var p parser.Parser
-	if p.AggregateInExpr(eh.expr) {
+	if p.AggregateInExpr(eh.expr, evalCtx.SearchPath) {
 		return errors.Errorf("expression '%s' has aggregate", eh.expr)
 	}
 	return nil

--- a/pkg/sql/distsql/hashjoiner_test.go
+++ b/pkg/sql/distsql/hashjoiner_test.go
@@ -340,7 +340,7 @@ func TestHashJoiner(t *testing.T) {
 		hs := c.spec
 		inputs := []RowSource{&RowBuffer{rows: c.inputs[0]}, &RowBuffer{rows: c.inputs[1]}}
 		out := &RowBuffer{}
-		flowCtx := FlowCtx{Context: context.Background()}
+		flowCtx := FlowCtx{Context: context.Background(), evalCtx: &parser.EvalContext{}}
 
 		h, err := newHashJoiner(&flowCtx, &hs, inputs, out)
 		if err != nil {

--- a/pkg/sql/distsql/mergejoiner_test.go
+++ b/pkg/sql/distsql/mergejoiner_test.go
@@ -339,7 +339,7 @@ func TestMergeJoiner(t *testing.T) {
 		ms := c.spec
 		inputs := []RowSource{&RowBuffer{rows: c.inputs[0]}, &RowBuffer{rows: c.inputs[1]}}
 		out := &RowBuffer{}
-		flowCtx := FlowCtx{Context: context.Background()}
+		flowCtx := FlowCtx{Context: context.Background(), evalCtx: &parser.EvalContext{}}
 
 		m, err := newMergeJoiner(&flowCtx, &ms, inputs, out)
 		if err != nil {

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -74,7 +74,9 @@ func (p *planner) groupBy(n *parser.SelectClause, s *selectNode) (*groupNode, er
 			groupBy[i] = resolved
 		}
 
-		if err := p.parser.AssertNoAggregationOrWindowing(rawExpr, "GROUP BY"); err != nil {
+		if err := p.parser.AssertNoAggregationOrWindowing(
+			rawExpr, "GROUP BY", p.session.SearchPath,
+		); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/sql/limit.go
+++ b/pkg/sql/limit.go
@@ -59,7 +59,9 @@ func (p *planner) Limit(n *parser.Limit) (*limitNode, error) {
 
 	for _, datum := range data {
 		if datum.src != nil {
-			if err := p.parser.AssertNoAggregationOrWindowing(datum.src, datum.name); err != nil {
+			if err := p.parser.AssertNoAggregationOrWindowing(
+				datum.src, datum.name, p.session.SearchPath,
+			); err != nil {
 				return nil, err
 			}
 

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -1487,7 +1487,7 @@ type EvalContext struct {
 	// SearchPath is the search path for databases used when encountering an
 	// unqualified table name. Names in the search path are normalized already.
 	// This must not be modified (this is shared from the session).
-	SearchPath []string
+	SearchPath SearchPath
 
 	ReCache *RegexpCache
 	tmpDec  inf.Dec

--- a/pkg/sql/parser/function_name.go
+++ b/pkg/sql/parser/function_name.go
@@ -46,7 +46,7 @@ func (fn ResolvableFunctionReference) String() string { return AsString(fn) }
 
 // Resolve checks if the function name is already resolved and
 // resolves it as necessary.
-func (fn *ResolvableFunctionReference) Resolve(searchPath []string) (*FunctionDefinition, error) {
+func (fn *ResolvableFunctionReference) Resolve(searchPath SearchPath) (*FunctionDefinition, error) {
 	switch t := fn.FunctionReference.(type) {
 	case *FunctionDefinition:
 		return t, nil
@@ -158,8 +158,12 @@ func (fd *FunctionDefinition) Format(buf *bytes.Buffer, f FmtFlags) {
 
 func (fd *FunctionDefinition) String() string { return AsString(fd) }
 
+// SearchPath represents a list of namespaces to search builtins in.
+// The names must be normalized (as per Name.Normalize) already.
+type SearchPath []string
+
 // ResolveFunction transforms an UnresolvedName to a FunctionDefinition.
-func (n UnresolvedName) ResolveFunction(searchPath []string) (*FunctionDefinition, error) {
+func (n UnresolvedName) ResolveFunction(searchPath SearchPath) (*FunctionDefinition, error) {
 	fn, err := n.normalizeFunctionName()
 	if err != nil {
 		return nil, err

--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -338,7 +338,7 @@ func (expr *ExistsExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, er
 
 // TypeCheck implements the Expr interface.
 func (expr *FuncExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, error) {
-	var searchPath []string
+	var searchPath SearchPath
 	if ctx != nil {
 		searchPath = ctx.SearchPath
 	}

--- a/pkg/sql/returning.go
+++ b/pkg/sql/returning.go
@@ -60,7 +60,9 @@ func (p *planner) newReturningHelper(
 	}
 
 	for _, e := range r {
-		if err := p.parser.AssertNoAggregationOrWindowing(e.Expr, "RETURNING"); err != nil {
+		if err := p.parser.AssertNoAggregationOrWindowing(
+			e.Expr, "RETURNING", p.session.SearchPath,
+		); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/sql/select.go
+++ b/pkg/sql/select.go
@@ -520,7 +520,9 @@ func (s *selectNode) initWhere(where *parser.Where) error {
 
 	// Make sure there are no aggregation/window functions in the filter
 	// (after subqueries have been expanded).
-	if err := s.planner.parser.AssertNoAggregationOrWindowing(s.filter, "WHERE"); err != nil {
+	if err := s.planner.parser.AssertNoAggregationOrWindowing(
+		s.filter, "WHERE", s.planner.session.SearchPath,
+	); err != nil {
 		return err
 	}
 

--- a/pkg/sql/select_name_resolution.go
+++ b/pkg/sql/select_name_resolution.go
@@ -39,7 +39,7 @@ type nameResolutionVisitor struct {
 	sources            multiSourceInfo
 	colOffsets         []int
 	iVarHelper         parser.IndexedVarHelper
-	searchPath         []string
+	searchPath         parser.SearchPath
 	foundDependentVars bool
 }
 

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/mon"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -65,7 +66,7 @@ type Session struct {
 	//
 	// NOTE: If we allow the user to set this, we'll need to handle the case where
 	// the session database or pg_catalog are in this path.
-	SearchPath  []string
+	SearchPath  parser.SearchPath
 	User        string
 	Syntax      int32
 	DistSQLMode distSQLExecMode
@@ -121,7 +122,7 @@ func NewSession(
 	ctx = e.AnnotateCtx(ctx)
 	s := &Session{
 		Database:       args.Database,
-		SearchPath:     []string{"pg_catalog"},
+		SearchPath:     parser.SearchPath{"pg_catalog"},
 		User:           args.User,
 		Location:       time.UTC,
 		virtualSchemas: e.virtualSchemas,

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -37,6 +37,7 @@ var varGen = map[string]func(p *planner) string{
 	`TRANSACTION ISOLATION LEVEL`:   func(p *planner) string { return p.txn.Proto.Isolation.String() },
 	`TRANSACTION PRIORITY`:          func(p *planner) string { return p.txn.UserPriority.String() },
 	`MAX_INDEX_KEYS`:                func(_ *planner) string { return "32" },
+	`SEARCH_PATH`:                   func(p *planner) string { return strings.Join(p.session.SearchPath, ", ") },
 }
 var varNames = func() []string {
 	res := make([]string, 0, len(varGen))

--- a/pkg/sql/testdata/function_lookup
+++ b/pkg/sql/testdata/function_lookup
@@ -1,0 +1,28 @@
+statement ok
+CREATE TABLE foo(x INT DEFAULT LENGTH(PG_TYPEOF(1234))-1)
+
+statement ok
+CREATE TABLE bar(x INT, CHECK(PG_TYPEOF(123) = 'int'))
+
+statement ok
+ALTER TABLE foo ALTER COLUMN x SET DEFAULT LENGTH(PG_TYPEOF(123))
+
+statement ok
+ALTER TABLE foo ADD CONSTRAINT z CHECK(PG_TYPEOF(123) = 'int')
+
+query I
+SELECT COUNT(*) FROM foo GROUP BY PG_TYPEOF(x)
+----
+
+query I
+SELECT * FROM foo LIMIT LENGTH(PG_TYPEOF(123))
+----
+
+query I
+SELECT * FROM foo WHERE PG_TYPEOF(x) = 'int'
+----
+
+query T
+INSERT INTO foo(x) VALUES (42) RETURNING PG_TYPEOF(x)
+----
+int

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -847,6 +847,7 @@ name                           setting       category  short_desc  extra_desc  v
 database                       test          NULL      NULL        NULL        string
 default_transaction_isolation  SERIALIZABLE  NULL      NULL        NULL        string
 max_index_keys                 32            NULL      NULL        NULL        string
+search_path                    pg_catalog    NULL      NULL        NULL        string
 syntax                         Traditional   NULL      NULL        NULL        string
 time zone                      UTC           NULL      NULL        NULL        string
 transaction isolation level    SERIALIZABLE  NULL      NULL        NULL        string
@@ -859,6 +860,7 @@ name                           setting       unit  context  enumvals  boot_val  
 database                       test          NULL  user     NULL      test          test
 default_transaction_isolation  SERIALIZABLE  NULL  user     NULL      SERIALIZABLE  SERIALIZABLE
 max_index_keys                 32            NULL  user     NULL      32            32
+search_path                    pg_catalog    NULL  user     NULL      pg_catalog    pg_catalog
 syntax                         Traditional   NULL  user     NULL      Traditional   Traditional
 time zone                      UTC           NULL  user     NULL      UTC           UTC
 transaction isolation level    SERIALIZABLE  NULL  user     NULL      SERIALIZABLE  SERIALIZABLE
@@ -871,6 +873,7 @@ name                           source  min_val  max_val  sourcefile  sourceline
 database                       NULL    NULL     NULL     NULL        NULL
 default_transaction_isolation  NULL    NULL     NULL     NULL        NULL
 max_index_keys                 NULL    NULL     NULL     NULL        NULL
+search_path                    NULL    NULL     NULL     NULL        NULL
 syntax                         NULL    NULL     NULL     NULL        NULL
 time zone                      NULL    NULL     NULL     NULL        NULL
 transaction isolation level    NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/testdata/set
+++ b/pkg/sql/testdata/set
@@ -104,6 +104,7 @@ SHOW ALL
 DATABASE                       foo
 DEFAULT_TRANSACTION_ISOLATION  SERIALIZABLE
 MAX_INDEX_KEYS                 32
+SEARCH_PATH                    pg_catalog
 SYNTAX                         Modern
 TIME ZONE                      UTC
 TRANSACTION ISOLATION LEVEL    SERIALIZABLE

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -85,7 +85,9 @@ func (p *planner) ValuesClause(
 		tupleBuf = tupleBuf[numCols:]
 
 		for i, expr := range tuple.Exprs {
-			if err := p.parser.AssertNoAggregationOrWindowing(expr, "VALUES"); err != nil {
+			if err := p.parser.AssertNoAggregationOrWindowing(
+				expr, "VALUES", p.session.SearchPath,
+			); err != nil {
 				return nil, err
 			}
 


### PR DESCRIPTION
The changes 90f51926dc29b5af7d30b0e78430e67cc6c09381 have set up the
basics of the mechanisms for function lookups based on a search path,
however this was not properly plumbed to the rest of the SQL
execution, resulting in function names not being looked up properly in
practice.

This patch completes the earlier implementations and adds SQL-level tests.

(Basically #10595 was incomplete and I didn't realize because there were no SQL tests.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10956)
<!-- Reviewable:end -->
