### PR TITLE
storage: Log time taken by cancelled replica write commands

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1777,6 +1777,7 @@ func (r *Replica) addWriteCmd(
 func (r *Replica) tryAddWriteCmd(
 	ctx context.Context, ba roachpb.BatchRequest,
 ) (br *roachpb.BatchResponse, pErr *roachpb.Error, retry proposalRetryReason) {
+	startTime := timeutil.Now()
 	isNonKV := ba.IsNonKV()
 	var endCmds *endCmds
 	if !isNonKV {
@@ -1877,7 +1878,8 @@ func (r *Replica) tryAddWriteCmd(
 			// AmbiguousResultError indicates to caller that the command may
 			// have executed.
 			if tryAbandon() {
-				log.Warningf(ctx, "context cancellation of command %s", ba)
+				log.Warningf(ctx, "context cancellation after %0.1fs of attempting command %s",
+					timeutil.Since(startTime).Seconds(), ba)
 				// Set endCmds to nil because they will be invoked in processRaftCommand.
 				endCmds = nil
 				return nil, roachpb.NewError(roachpb.NewAmbiguousResultError(ctx.Err().Error())), proposalNoRetry
@@ -1898,7 +1900,8 @@ func (r *Replica) tryAddWriteCmd(
 			// the stopper quiescing, no new commands can be proposed to
 			// Raft successfully.
 			if tryAbandon() {
-				log.Warningf(ctx, "shutdown cancellation of command %s", ba)
+				log.Warningf(ctx, "shutdown cancellation after %0.1fs of attempting command %s",
+					timeutil.Since(startTime).Seconds(), ba)
 				return nil, roachpb.NewError(roachpb.NewAmbiguousResultError("server shutdown")), proposalNoRetry
 			}
 			shouldQuiesce = nil


### PR DESCRIPTION
Dead simple replacement for #10918.

@petermattis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10961)
<!-- Reviewable:end -->
