### PR TITLE
cli+log: fix the initialization of the default stderr logging threshold.

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -954,7 +954,7 @@ Available Commands:
   debug          debugging commands
 
 Flags:
-      --alsologtostderr Severity[=INFO]   logs at or above this threshold go to stderr (default NONE)
+      --alsologtostderr Severity[=INFO]   logs at or above this threshold go to stderr (default INFO)
       --log-backtrace-at traceLocation    when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                    if non-empty, write log files in this directory
       --logtostderr                       log to standard error instead of files

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -570,8 +570,10 @@ func formatLogEntry(entry Entry, stacks []byte, colors *colorProfile) *buffer {
 }
 
 func init() {
-	// Default stderrThreshold to log nothing.
-	logging.stderrThreshold = Severity_NONE
+	// Default stderrThreshold to log everything.
+	// This will be the default in tests unless overridden; the CLI
+	// commands set their default separately in cli/flags.go
+	logging.stderrThreshold = Severity_INFO
 
 	logging.setVState(0, nil, false)
 	logging.exitFunc = os.Exit


### PR DESCRIPTION
The selection of the default introduced in
6293e15 was making incorrect
assumptions about the semantics of Flag objects, causing `start
--logtostderr` to not print anything unless `--alsologtostderr` was
also set.

This patch corrects this problem and also adds the missing tests that
exercise the various combinations of `--logtostderr` and
`--alsologtostderr`.

For documentation, let's clarify this as follows:

- now any logging message is a candidate to be printed on stderr,
  subject to the configured *severity threshold*, regardless of
  whether `--log-dir` is specified.

- the severity threshold can always be overridden via
  `--alsologtostderr=XXX`.

- When `--alsologtostderr` is not specified, the severity threshold
  gets a default value that depends on the command being run and other
  things:

  - for `start`:

    - `--log-dir` specified and non-empty, or there is at least one
      disk-based store. Then `--logtostderr` decides, either INFO
      (everything) if specified and true, or NONE (nothing) if
      unspecified or false.

    - `--log-dir` not specified or empty, and only in-memory stores:
      default threshold is INFO, `--logtostderr` makes no difference.

  - for other CLI commands:

    - `--log-dir` specified and non-empty: `--logtostderr` decides,
      either INFO (everything) if specified and true, or NONE
      (nothing) if unspecified or false.

    - `--log-dir` not specified or empty: default threshold is
      WARNING, `--logtostderr` makes no difference.
cc @petermattis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10962)
<!-- Reviewable:end -->
