### PR TITLE
sql: fix the error handling for ordinal references.

### DIFF
--- a/pkg/sql/parser/indexed_vars.go
+++ b/pkg/sql/parser/indexed_vars.go
@@ -55,6 +55,15 @@ func (v *IndexedVar) Walk(_ Visitor) Expr {
 
 // TypeCheck is part of the Expr interface.
 func (v *IndexedVar) TypeCheck(_ *SemaContext, desired Type) (TypedExpr, error) {
+	if v.container == nil {
+		// A more technically correct message would be to say that the
+		// reference is unbound and thus cannot be typed. However this is
+		// a tad bit too technical for the average SQL use case and
+		// instead we acknowledge that we only get here if someone has
+		// used a column reference in a place where it's not allowed by
+		// the docs, so just say that instead.
+		return nil, errors.Errorf("column reference %s not allowed in this context", v)
+	}
 	return v, nil
 }
 

--- a/pkg/sql/testdata/ordinal_references
+++ b/pkg/sql/testdata/ordinal_references
@@ -1,8 +1,12 @@
 statement ok
 CREATE TABLE foo(a INT, b CHAR)
 
-statement ok
-INSERT INTO foo(a, b) VALUES (1,'c'), (2,'b'), (3,'a')
+query I
+INSERT INTO foo(a, b) VALUES (1,'c'), (2,'b'), (3,'a') RETURNING @1
+----
+1
+2
+3
 
 query error invalid column ordinal
 SELECT @0 FROM foo
@@ -85,3 +89,15 @@ EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2;
 1  group          min(a) GROUP BY (@2)                            (m)
 2  render/filter  from (test.foo.a, test.foo.b, *test.foo.rowid)  (m, b)
 3  scan           foo@primary -                                   (a, b, rowid[hidden])  +rowid,unique
+
+statement error column reference @1 not allowed in this context
+INSERT INTO foo(a, b) VALUES (@1, @2)
+
+query error column reference @485 not allowed in this context
+VALUES (@485)
+
+query error column reference @1 not allowed in this context
+SELECT * FROM foo LIMIT @1
+
+query error column reference @1 not allowed in this context
+SELECT * FROM foo OFFSET @1


### PR DESCRIPTION
Ensure that unbound references cause an error message instead of a
panic.

Fixes #10960.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10963)
<!-- Reviewable:end -->
