### PR TITLE
kv: cancel outstanding RPCs when DistSender.sendRPC returns

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -352,6 +352,11 @@ func (ds *DistSender) sendRPC(
 	// RangeNotFoundErrors.
 	ba.RangeID = rangeID
 
+	// A given RPC may generate retries to multiple replicas, but as soon as we
+	// get a response from one we want to cancel those other RPCs.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	// Set RPC opts with stipulation that one of N RPCs must succeed.
 	rpcOpts := SendOptions{
 		ctx:              ctx,

--- a/pkg/kv/transport.go
+++ b/pkg/kv/transport.go
@@ -188,15 +188,7 @@ func (gt *grpcTransport) SendNext(done chan<- BatchCall) {
 	}
 
 	go func() {
-		// HACK: GRPC leaks if client calls are made with a context which
-		// is cancelable but doesn't actually get canceled. Insulate this
-		// call from our outer context, which may last for the lifetime of
-		// a client session.
-		// TODO(bdarnell): remove after https://github.com/grpc/grpc-go/issues/888
-		// is fixed.
-		ctx, cancel := context.WithCancel(gt.opts.ctx)
-		defer cancel()
-		reply, err := client.client.Batch(ctx, &client.args)
+		reply, err := client.client.Batch(gt.opts.ctx, &client.args)
 		if reply != nil {
 			for i := range reply.Responses {
 				if err := reply.Responses[i].GetInner().Verify(client.args.Requests[i].GetInner()); err != nil {


### PR DESCRIPTION
Fixes #10968

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/10970)
<!-- Reviewable:end -->
