### PR TITLE
sql: add a new internal builtin that forces transaction retries.

### DIFF
--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -49,6 +49,15 @@ func (e *RetryableTxnError) Error() string {
 
 var _ error = &RetryableTxnError{}
 
+// NewRetryableTxnError creates a shim RetryableTxnError that
+// reports the given cause when converted to String(). This can be
+// used to fake/force a retry at the SQL layer.
+func NewRetryableTxnError(cause string) *RetryableTxnError {
+	return &RetryableTxnError{
+		message: cause,
+	}
+}
+
 // ErrorUnexpectedlySet creates a string to panic with when a response (typically
 // a roachpb.BatchResponse) unexpectedly has Error set in its response header.
 func ErrorUnexpectedlySet(culprit, response interface{}) string {

--- a/pkg/sql/logic_test.go
+++ b/pkg/sql/logic_test.go
@@ -531,6 +531,20 @@ func (t *logicTest) processTestFile(path string) error {
 			}
 			repeat = count
 
+		case "sleep":
+			var err error
+			var duration time.Duration
+			// A line "sleep Xs" makes the test sleep for X seconds.
+			if len(fields) != 2 {
+				err = errors.New("invalid line format")
+			} else if duration, err = time.ParseDuration(fields[1]); err != nil {
+				err = errors.New("invalid duration")
+			}
+			if err != nil {
+				return fmt.Errorf("%s:%d invalid sleep line: %s", path, s.line, err)
+			}
+			time.Sleep(duration)
+
 		case "statement":
 			stmt := logicStatement{pos: fmt.Sprintf("%s:%d", path, s.line)}
 			// Parse "statement error <regexp>"

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/decimal"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -1315,6 +1316,24 @@ var Builtins = map[string][]Builtin{
 					}
 				}
 				return schemas, nil
+			},
+		},
+	},
+
+	"crdb_internal.force_retry": {
+		Builtin{
+			Types:      ArgTypes{TypeInterval},
+			ReturnType: TypeInt,
+			impure:     true,
+			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
+				minDuration := args[0].(*DInterval).Duration
+				elapsed := duration.Duration{
+					Nanos: int64(ctx.stmtTimestamp.Sub(ctx.txnTimestamp)),
+				}
+				if elapsed.Compare(minDuration) < 0 {
+					return nil, roachpb.NewRetryableTxnError("forced by crdb_internal.force_retry()")
+				}
+				return NewDInt(0), nil
 			},
 		},
 	},

--- a/pkg/sql/testdata/manual_retry
+++ b/pkg/sql/testdata/manual_retry
@@ -1,0 +1,29 @@
+# On an implicit transaction, we retry implicitly and the function
+# eventually returns a result.
+query I
+SELECT CRDB_INTERNAL.FORCE_RETRY('1s':::INTERVAL)
+----
+0
+
+statement ok
+BEGIN TRANSACTION; SAVEPOINT cockroach_restart
+
+query error restart transaction: forced
+SELECT CRDB_INTERNAL.FORCE_RETRY('1s':::INTERVAL)
+
+statement ok
+ROLLBACK TO SAVEPOINT cockroach_restart
+
+# wait until the transaction is at least 2 seconds old
+sleep 2s
+
+statement ok
+SAVEPOINT cockroach_restart
+
+query I
+SELECT CRDB_INTERNAL.FORCE_RETRY('1s':::INTERVAL)
+----
+0
+
+statement ok
+COMMIT


### PR DESCRIPTION
This patch introduces the new built-in function
`crdb_internal.force_retry()`. This function takes a single parameter
of type INTERVAL and operates as follows:

- if the current transaction is older than the parameter value,
  then the function returns 0.

- otherwise, the function reports a "restart transaction" error.

The error plumbing guarantees that the SQL executor sees this
"query-generated" error and subjects the transaction to the standard
retry mechanisms.

Needed for #10866 and will help during demos and future acceptance tests.

cc @andreimatei @bdarnell @spencerkimball.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11193)
<!-- Reviewable:end -->
