### PR TITLE
Ignore untracked files in "-dirty" detection.

### DIFF
--- a/build/ldflags.sh
+++ b/build/ldflags.sh
@@ -5,7 +5,7 @@ set -eu
 cd "$(dirname "${0}")"/..
 
 build_version="$(git describe --tags --exact-match 2> /dev/null || git rev-parse --short HEAD)"
-if [ -n "$(git status --porcelain)" ]; then
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
   build_version="${build_version}-dirty"
 fi
 


### PR DESCRIPTION
The older version used `git describe --tags --dirty` which ignored
untracked files. We need to do the same with `git status`, or builds
that have untracked files (and not in gitignore) will throw up the
"-dirty" prefix. Teamcity currently goes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11194)
<!-- Reviewable:end -->
