### PR TITLE
storage: print newline before consistency checker diff

### DIFF
--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1879,9 +1879,10 @@ func (r *Replica) CheckConsistency(
 				if report := r.store.cfg.TestingKnobs.BadChecksumReportDiff; report != nil {
 					report(r.store.Ident, diff)
 				}
+				buf.WriteByte('\n')
 				_, _ = diff.WriteTo(&buf)
 			}
-			log.Error(ctx, "\n", buf.String())
+			log.Error(ctx, buf.String())
 		}); err != nil {
 			log.Error(ctx, errors.Wrap(err, "could not run async CollectChecksum"))
 			wg.Done()


### PR DESCRIPTION
Noticed in #11191.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11198)
<!-- Reviewable:end -->
