### PR TITLE
storage: only allow lease transfers to up to date replicas

### DIFF
--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coreos/etcd/raft"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -1654,6 +1655,52 @@ func TestAllocatorThrottled(t *testing.T) {
 			t.Fatalf("expected a non purgatory error, got: %v", err)
 		}
 	})
+}
+
+func TestFilterBehindReplicas(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		progress []uint64
+		expected []uint64
+	}{
+		{[]uint64{1}, []uint64{1}},
+		{[]uint64{2}, []uint64{2}},
+		{[]uint64{1, 2}, []uint64{1, 2}},
+		{[]uint64{3, 2}, []uint64{3, 2}},
+		{[]uint64{1, 2, 3}, []uint64{2, 3}},
+		{[]uint64{4, 3, 2}, []uint64{4, 3}},
+		{[]uint64{1, 1, 1}, []uint64{1, 1, 1}},
+		{[]uint64{1, 1, 2}, []uint64{1, 1, 2}},
+		{[]uint64{1, 2, 2}, []uint64{2, 2}},
+		{[]uint64{1, 2, 3, 4}, []uint64{2, 3, 4}},
+		{[]uint64{5, 4, 3, 2}, []uint64{5, 4, 3}},
+		{[]uint64{1, 2, 3, 4, 5}, []uint64{3, 4, 5}},
+		{[]uint64{6, 5, 4, 3, 2}, []uint64{6, 5, 4}},
+	}
+	for i, c := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			status := &raft.Status{
+				Progress: make(map[uint64]raft.Progress),
+			}
+			var replicas []roachpb.ReplicaDescriptor
+			for j, v := range c.progress {
+				status.Progress[uint64(j)] = raft.Progress{Match: v}
+				replicas = append(replicas, roachpb.ReplicaDescriptor{
+					ReplicaID: roachpb.ReplicaID(j),
+					StoreID:   roachpb.StoreID(v),
+				})
+			}
+			candidates := filterBehindReplicas(status, replicas)
+			var ids []uint64
+			for _, c := range candidates {
+				ids = append(ids, uint64(c.StoreID))
+			}
+			if !reflect.DeepEqual(c.expected, ids) {
+				t.Fatalf("%d: expected %d, but got %d", i, c.expected, ids)
+			}
+		})
+	}
 }
 
 type testStore struct {


### PR DESCRIPTION
Added filterBehindReplicas which filters the list of replicas for a
range to only include replicas which are at or past the quorum commit
index. This avoids transferring a lease to a behind replica.

Fixes #10965

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11201)
<!-- Reviewable:end -->
