### PR TITLE
storage: remove pointers from allocator returns

### DIFF
--- a/pkg/cmd/balancersim/range.go
+++ b/pkg/cmd/balancersim/range.go
@@ -142,7 +142,7 @@ func (r *Range) getRemoveTarget() (roachpb.StoreID, error) {
 // candidate to add a replica for rebalancing. Returns true only if a target is
 // found.
 func (r *Range) getRebalanceTarget(storeID roachpb.StoreID) (roachpb.StoreID, bool) {
-	rebalanceTarget, err := r.allocator.RebalanceTarget(
+	rebalanceTarget, ok, err := r.allocator.RebalanceTarget(
 		r.zone.Constraints,
 		r.desc.Replicas,
 		storeID,
@@ -151,7 +151,7 @@ func (r *Range) getRebalanceTarget(storeID roachpb.StoreID) (roachpb.StoreID, bo
 	if err != nil {
 		panic(err)
 	}
-	if rebalanceTarget == nil {
+	if !ok {
 		return 0, false
 	}
 	return rebalanceTarget.StoreID, true


### PR DESCRIPTION
Specifically, remove them from RebalanceTarget and AllocateTarget.

Part of #10275.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11206)
<!-- Reviewable:end -->
