### PR TITLE
kv: handle some additional cases where we need to signal ambiguous re…

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2021,8 +2021,9 @@ func (s *Store) removeReplicaImpl(
 	// Clear the pending command queue.
 	if len(rep.mu.proposals) > 0 {
 		resp := proposalResult{
-			Reply: &roachpb.BatchResponse{},
-			Err:   roachpb.NewError(roachpb.NewRangeNotFoundError(rep.RangeID)),
+			Reply:         &roachpb.BatchResponse{},
+			Err:           roachpb.NewError(roachpb.NewRangeNotFoundError(rep.RangeID)),
+			ProposalRetry: proposalRangeNoLongerExists,
 		}
 		for _, p := range rep.mu.proposals {
 			p.Local.finish(resp)


### PR DESCRIPTION
…sult

These ones slipped through the cracks. One is the case of a missing range
(because of rebalancing). We want to be careful not to say that the batch
failed with the no range error when in fact it may have succeeded. The
other is a re-proposal where submission to Raft fails. Again, since the
original proposal may have succeeded, we must be careful to also return
AmbiguousResultError where appropriate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11211)
<!-- Reviewable:end -->
