### PR TITLE
kv: a hopefully better measure of available range count

### DIFF
--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -89,6 +89,7 @@ var nodesColumnHeaders = []string{
 	"system_bytes",
 	"replicas_leaders",
 	"replicas_leaseholders",
+	"ranges",
 	"ranges_available",
 }
 
@@ -177,6 +178,7 @@ func nodeStatusesToRows(statuses []status.NodeStatus) [][]string {
 			strconv.FormatInt(int64(metricVals["sysbytes"]), 10),
 			strconv.FormatInt(int64(metricVals["replicas.leaders"]), 10),
 			strconv.FormatInt(int64(metricVals["replicas.leaseholders"]), 10),
+			strconv.FormatInt(int64(metricVals["ranges"]), 10),
 			strconv.FormatInt(int64(metricVals["ranges.available"]), 10),
 		})
 	}

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -636,6 +636,7 @@ func TestStatusSummaries(t *testing.T) {
 	store1["replicas"]++
 	store1["replicas.leaders"]++
 	store1["replicas.leaseholders"]++
+	store1["ranges"]++
 	store1["ranges.available"]++
 
 	forceWriteStatus()

--- a/pkg/server/status/recorder_test.go
+++ b/pkg/server/status/recorder_test.go
@@ -210,6 +210,7 @@ func TestMetricsRecorder(t *testing.T) {
 		{"ranges", "counter", 1},
 		{"replicas.leaders", "gauge", 1},
 		{"replicas.leaseholders", "gauge", 1},
+		{"ranges", "gauge", 1},
 		{"ranges.available", "gauge", 1},
 	}
 

--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -58,6 +58,7 @@ var (
 		Help: "Number of read-only commands in all CommandQueues combined"}
 
 	// Range metrics.
+	metaRangeCount          = metric.Metadata{Name: "ranges"}
 	metaAvailableRangeCount = metric.Metadata{Name: "ranges.available"}
 
 	// Replication metrics.
@@ -313,6 +314,7 @@ type StoreMetrics struct {
 	CombinedCommandReadCount  *metric.Gauge
 
 	// Range metrics.
+	RangeCount          *metric.Gauge
 	AvailableRangeCount *metric.Gauge
 
 	// Replication metrics.
@@ -487,6 +489,7 @@ func newStoreMetrics(sampleInterval time.Duration) *StoreMetrics {
 		CombinedCommandReadCount:  metric.NewGauge(metaCombinedCommandReadCount),
 
 		// Range metrics.
+		RangeCount:          metric.NewGauge(metaRangeCount),
 		AvailableRangeCount: metric.NewGauge(metaAvailableRangeCount),
 
 		// Replication metrics.

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -46,9 +46,9 @@ var (
 	metaEpochIncrements    = metric.Metadata{Name: "liveness.epochincrements"}
 )
 
-func (l *Liveness) isLive(clock *hlc.Clock) bool {
-	expiration := l.Expiration.Add(-int64(clock.MaxOffset()), 0)
-	return clock.Now().Less(expiration)
+func (l *Liveness) isLive(now hlc.Timestamp, maxOffset time.Duration) bool {
+	expiration := l.Expiration.Add(-maxOffset.Nanoseconds(), 0)
+	return now.Less(expiration)
 }
 
 // LivenessMetrics holds metrics for use with node liveness activity.
@@ -114,6 +114,12 @@ func NewNodeLiveness(
 	return nl
 }
 
+// GetLivenessThreshold returns the maximum duration between heartbeats
+// before a node is considered not-live.
+func (nl *NodeLiveness) GetLivenessThreshold() time.Duration {
+	return nl.livenessThreshold
+}
+
 // IsLive returns whether or not the specified node is considered live
 // based on the last receipt of a liveness update via gossip. It is an
 // error if the specified node is not in the local liveness table.
@@ -122,7 +128,7 @@ func (nl *NodeLiveness) IsLive(nodeID roachpb.NodeID) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return liveness.isLive(nl.clock), nil
+	return liveness.isLive(nl.clock.Now(), nl.clock.MaxOffset()), nil
 }
 
 // StartHeartbeat starts a periodic heartbeat to refresh this node's
@@ -212,6 +218,22 @@ func (nl *NodeLiveness) Self() (Liveness, error) {
 	return nl.getLivenessLocked(nl.gossip.NodeID.Get())
 }
 
+// GetLivenessMap returns a map of nodeID to liveness.
+func (nl *NodeLiveness) GetLivenessMap() map[roachpb.NodeID]bool {
+	nl.mu.Lock()
+	defer nl.mu.Unlock()
+	lMap := map[roachpb.NodeID]bool{}
+	now := nl.clock.Now()
+	maxOffset := nl.clock.MaxOffset()
+	for nID, l := range nl.mu.nodes {
+		lMap[nID] = l.isLive(now, maxOffset)
+	}
+	if nl.mu.self.NodeID != 0 {
+		lMap[nl.mu.self.NodeID] = nl.mu.self.isLive(now, maxOffset)
+	}
+	return lMap
+}
+
 // GetLiveness returns the liveness record for the specified nodeID.
 // ErrNoLivenessRecord is returned in the event that nothing is yet
 // known about nodeID via liveness gossip.
@@ -245,7 +267,7 @@ func (nl *NodeLiveness) IncrementEpoch(ctx context.Context, nodeID roachpb.NodeI
 	if err != nil {
 		return err
 	}
-	if liveness.isLive(nl.clock) {
+	if liveness.isLive(nl.clock.Now(), nl.clock.MaxOffset()) {
 		return errors.Errorf("cannot increment epoch on live node: %+v", liveness)
 	}
 	newLiveness := liveness

--- a/pkg/ui/app/containers/nodeOverview.tsx
+++ b/pkg/ui/app/containers/nodeOverview.tsx
@@ -79,11 +79,14 @@ class NodeOverview extends React.Component<NodeOverviewProps, {}> {
                         title="Raft Leaders"
                         valueFn={(metrics) => metrics.get(MetricConstants.raftLeaders).toString()} />
               <TableRow data={node}
+                        title="Total Ranges"
+                        valueFn={(metrics) => metrics.get(MetricConstants.ranges)} />
+              <TableRow data={node}
                         title="Available"
-                        valueFn={(metrics) => Percentage(metrics.get(MetricConstants.availableRanges), metrics.get(MetricConstants.raftLeaders))} />
+                        valueFn={(metrics) => Percentage(metrics.get(MetricConstants.availableRanges), metrics.get(MetricConstants.ranges))} />
               <TableRow data={node}
                         title="Fully Replicated"
-                        valueFn={(metrics) => Percentage(metrics.get(MetricConstants.replicatedRanges), metrics.get(MetricConstants.raftLeaders))} />
+                        valueFn={(metrics) => Percentage(metrics.get(MetricConstants.replicatedRanges), metrics.get(MetricConstants.ranges))} />
               <TableRow data={node}
                         title="Available Capacity"
                         valueFn={(metrics) => Bytes(metrics.get(MetricConstants.availableCapacity))} />

--- a/pkg/ui/app/util/proto.ts
+++ b/pkg/ui/app/util/proto.ts
@@ -40,6 +40,7 @@ export namespace MetricConstants {
   export const replicas: string = "replicas";
   export const raftLeaders: string = "replicas.leaders";
   export const leaseHolders: string = "replicas.leaseholders";
+  export const ranges: string = "ranges";
   export const availableRanges: string = "ranges.available";
   export const replicatedRanges: string  = "ranges.allocator.noop";
   export const liveBytes: string = "livebytes";


### PR DESCRIPTION
Available range counts seem to suffer from noisy results in Grafana. This
apparently is caused by no replicas in raft being at the applied log index.
Looking more closely at the code where we measure available ranges also
suggests that the mechanism we currently use won't apply to epoch-based
range leases.

Added a getter for a map from node ID -> liveness from `NodeLiveness` to
avoid busy lookups through a mutex when checking liveness of many nodes
repeatedly while computing range availability stats.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11213)
<!-- Reviewable:end -->
