### PR TITLE
build: Move protobuf go:generate line to roachpb

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,8 +16,6 @@
 
 package main
 
-//go:generate make protobuf
-
 import (
 	"fmt"
 	"math/rand"

--- a/pkg/roachpb/main_test.go
+++ b/pkg/roachpb/main_test.go
@@ -16,4 +16,6 @@
 // Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
 package roachpb_test
 
+//go:generate make -C ../.. protobuf
+
 import _ "github.com/cockroachdb/cockroach/pkg/util/log" // for flags


### PR DESCRIPTION
With the new recommendation to use `go generate ./pkg/...` the protobuf
generation step was getting skipped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11216)
<!-- Reviewable:end -->
