### PR TITLE
vendor: regenerate glide config for glide 0.12.3

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,8 @@
-hash: cce06e107658fb4ccbd882ee3f3cb9834836a91fba163e9a864cf3144fcb48d1
-updated: 2016-11-23T15:43:53.309850752Z
+hash: 978bc226e4f562c7d20e703f6780be01b79573e0c2863cb3ddcebb06a7c2ecab
+updated: 2016-11-24T00:23:37.560268231-05:00
 imports:
 - name: github.com/abourget/teamcity
   version: 6dde447fa54bc5b08b1a7bb1b85e39089cf27fb1
-- name: github.com/agtorre/gocolorize
-  version: f42b554bf7f006936130c9bb4f971afd2d87f671
 - name: github.com/Azure/go-ansiterm
   version: fa152c58bc15761d0200cb75fe958b89a9d4888e
   subpackages:
@@ -14,22 +12,26 @@ imports:
 - name: github.com/biogo/store
   version: 913427a1d5e89604e50ea1db0f28f34966d61602
   subpackages:
-  - llrb
   - interval
+  - llrb
 - name: github.com/cenk/backoff
   version: b02f2bbce11d7ea6b97f282ef1771b0fe2f65ef3
 - name: github.com/chzyer/readline
   version: c914be64f07d9998f52bf0d598ec26d457168c0f
 - name: github.com/client9/misspell
   version: 9a1fc2456ac9e8c9b4cbe9d005b6e7adac0d357f
+  subpackages:
+  - cmd/misspell
 - name: github.com/cockroachdb/c-jemalloc
   version: 42e6a32cd7a4dff9c70d80323681d46d046181ef
 - name: github.com/cockroachdb/c-protobuf
   version: 070b64667a22925d971878b61e4f0c1df31e8599
+  subpackages:
+  - cmd/protoc
 - name: github.com/cockroachdb/c-rocksdb
   version: b5ca031b93fde49bfa2ba99aba423136aebf3c06
 - name: github.com/cockroachdb/c-snappy
-  version: d4e7b428fe7fc09e93573df3448567a62df8c9fa
+  version: c0cd3c9ce92f195001595e1fbbe66f045daad34f
 - name: github.com/cockroachdb/cmux
   version: b64f5908f4945f4b11ed4a0a9d3cc1e23350866d
 - name: github.com/cockroachdb/cockroach-go
@@ -45,45 +47,45 @@ imports:
 - name: github.com/codahale/hdrhistogram
   version: 3a0bb77429bd3a61596f5e8a3172445844342120
 - name: github.com/coreos/etcd
-  version: aea9c6668fdc95fecacfabdc46e9c3f9b840ac94
+  version: c31b1ab8d18ff7990a43bd258ca54f80c5a3c952
   subpackages:
-  - raft/raftpb
   - raft
+  - raft/raftpb
 - name: github.com/cpuguy83/go-md2man
   version: a65d4d2de4d5f7c74868dfa9b202a3c8be315aaa
   subpackages:
   - md2man
 - name: github.com/docker/distribution
-  version: a6bf3dd064f15598166bca2d66a9962a9555139e
+  version: 38fbd03266d86923d963566a6565c3fa01f496d8
   subpackages:
-  - reference
   - digest
+  - reference
 - name: github.com/docker/docker
   version: 7248742ae7127347a52ab9d215451c213b7b59da
   subpackages:
   - api/types
+  - api/types/blkiodev
   - api/types/container
   - api/types/events
   - api/types/filters
-  - api/types/network
-  - client
-  - pkg/jsonmessage
-  - pkg/stdcopy
-  - pkg/namesgenerator
   - api/types/mount
-  - api/types/registry
-  - api/types/swarm
-  - api/types/blkiodev
-  - api/types/strslice
-  - api/types/versions
+  - api/types/network
   - api/types/reference
+  - api/types/registry
+  - api/types/strslice
+  - api/types/swarm
   - api/types/time
+  - api/types/versions
   - api/types/volume
-  - pkg/tlsconfig
+  - client
   - pkg/jsonlog
-  - pkg/term
+  - pkg/jsonmessage
+  - pkg/namesgenerator
   - pkg/random
+  - pkg/stdcopy
+  - pkg/term
   - pkg/term/windows
+  - pkg/tlsconfig
 - name: github.com/docker/go-connections
   version: 4ccf312bf1d35e5dbda654e57a9be4c3f3cd0366
   subpackages:
@@ -102,24 +104,15 @@ imports:
   version: 9a6736ed45b44bf3835afeebb3034b57ed329f3e
 - name: github.com/facebookgo/clock
   version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
-- name: github.com/ghemawat/stream
-  version: 78e682abcae4f96ac7ddbe39912967a5f7cbbaa6
 - name: github.com/go-ole/go-ole
   version: 5e9c030faf78847db7aa77e3661b9cc449de29b7
   subpackages:
   - oleutil
-- name: github.com/go-sql-driver/mysql
-  version: 665b83488b90b902ce0a305ef6652e599771cdf9
 - name: github.com/gogo/protobuf
   version: ccdc7fbcb4cd13f34b76d7262805e58316faaaf4
   subpackages:
-  - proto
-  - protoc-gen-gogo/descriptor
-  - vanity
-  - vanity/command
-  - sortkeys
-  - jsonpb
   - gogoproto
+  - jsonpb
   - plugin/compare
   - plugin/defaultcheck
   - plugin/description
@@ -136,19 +129,24 @@ imports:
   - plugin/testgen
   - plugin/union
   - plugin/unmarshal
+  - proto
+  - protoc-gen-gogo/descriptor
   - protoc-gen-gogo/generator
   - protoc-gen-gogo/grpc
   - protoc-gen-gogo/plugin
+  - sortkeys
   - types
-- name: github.com/golang/glog
-  version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
+  - vanity
+  - vanity/command
 - name: github.com/golang/lint
   version: 206c0f020eba0f7fbcfbc467a5eb808037df2ed6
-- name: github.com/golang/protobuf
-  version: 8ee79997227bf9b34611aee7946ae64735e6fd93
   subpackages:
-  - proto
+  - golint
+- name: github.com/golang/protobuf
+  version: 4bd1920723d7b7c925de087aa32e2187708897f7
+  subpackages:
   - jsonpb
+  - proto
   - protoc-gen-go/descriptor
   - ptypes/timestamp
 - name: github.com/google/btree
@@ -162,18 +160,21 @@ imports:
   subpackages:
   - query
 - name: github.com/grpc-ecosystem/grpc-gateway
-  version: 9108558898db5ff1671121738778c71a49c5aab4
+  version: 84398b94e188ee336f307779b57b3aa91af7063c
   subpackages:
+  - protoc-gen-grpc-gateway
   - runtime
+  - runtime/internal
   - third_party/googleapis/google/api
   - utilities
-  - runtime/internal
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jeffjen/datefmt
   version: 6688647cfa0439b86e09b097cac96ed328d5fa34
 - name: github.com/jteeuwen/go-bindata
   version: a0ff2567cfb70903282db057e799fd826784d41d
+  subpackages:
+  - go-bindata
 - name: github.com/kisielk/errcheck
   version: db0ca22445717d1b2c51ac1034440e0a2a2de645
 - name: github.com/kisielk/gotool
@@ -194,11 +195,11 @@ imports:
   version: b1bc6c278e9a007584bbc0b9139e776b4e3203e3
   subpackages:
   - collectorpb
-  - thrift_rpc
   - lightstep_thrift
   - thrift_0_9_2/lib/go/thrift
+  - thrift_rpc
 - name: github.com/mattn/go-isatty
-  version: 66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8
+  version: 30a891c33c7cde7b02a981314b4228ec99380cca
 - name: github.com/mattn/go-runewidth
   version: 737072b4e32b7a5018b4a7125da8d12de90e8045
 - name: github.com/mattn/goveralls
@@ -218,7 +219,7 @@ imports:
 - name: github.com/olekukonko/tablewriter
   version: bdcc175572fd7abece6c831e643891b9331bc9e7
 - name: github.com/opencontainers/runc
-  version: a6e649f5835b7ebf354a73ff3a80f3223e3cb5de
+  version: f156f73c2aab1b735df23c9323c976ad5dca1d78
   subpackages:
   - libcontainer/user
 - name: github.com/opentracing/basictracer-go
@@ -228,10 +229,8 @@ imports:
 - name: github.com/opentracing/opentracing-go
   version: 902ca977fd85455c364050f985eba376b44315f0
   subpackages:
-  - log
   - ext
-- name: github.com/pborman/uuid
-  version: 3d4f2ba23642d3cfd06bd4b54cf03d99d95c0f1b
+  - log
 - name: github.com/petermattis/goid
   version: ba001f8780f3bf978180f390ad7b5bac39fbf70a
 - name: github.com/pkg/errors
@@ -263,7 +262,9 @@ imports:
 - name: github.com/shurcooL/sanitized_anchor_name
   version: 1dba4b3954bc059efc3991ec364f9f9a35f597d2
 - name: github.com/Sirupsen/logrus
-  version: a437dfd2463eaedbec3dfe443e477d3b0a810b3f
+  version: 55eb11d21d2a31a3cc93838241d04800f52e823d
+  subpackages:
+  - formatters/logstash
 - name: github.com/spf13/cobra
   version: 9495bc009a56819bdb0ddbc1a373e29c140bc674
   subpackages:
@@ -273,33 +274,29 @@ imports:
 - name: github.com/StackExchange/wmi
   version: e54cbda6595d7293a7a468ccf9525f6bc8887f99
 - name: github.com/tebeka/go2xunit
-  version: d24fbe74ef38cbfb80b38eaeb51cb281d8c75df0
+  version: aaee8a42931ce35b4821d9c7cd68f73de70cba3d
   subpackages:
   - lib
-- name: github.com/termie/go-shutil
-  version: bcacb06fecaeec8dc42af03c87c6949f4a05c74c
 - name: github.com/VividCortex/ewma
   version: c595cd886c223c6c28fc9ae2727a61b5e4693d85
 - name: github.com/wadey/gocovmerge
   version: b5bfa59ec0adc420475f97f89b58045c721d761c
 - name: golang.org/x/crypto
-  version: ede567c8e044a5913dad1d1af3696d9da953104c
+  version: 1351f936d976c60a0a48d728281922cf63eafb8d
   subpackages:
   - bcrypt
-  - ssh/terminal
   - blowfish
+  - ssh/terminal
 - name: golang.org/x/net
-  version: 4971afdc2f162e82d185353533d3cf16188a9f4e
+  version: 6acef71eb69611914f7a30939ea9f6e194c78172
   subpackages:
   - context
-  - trace
-  - http2
-  - internal/timeseries
-  - http2/hpack
-  - idna
-  - lex/httplex
   - context/ctxhttp
+  - http2
+  - http2/hpack
+  - internal/timeseries
   - proxy
+  - trace
 - name: golang.org/x/oauth2
   version: d5040cddfc0da40b408c9a1da4728662435176a9
   subpackages:
@@ -313,40 +310,43 @@ imports:
   version: b01949dc0793a9af5e4cb3fce4d42999e76e8ca1
   subpackages:
   - collate
-  - language
-  - unicode/norm
   - internal/colltab
   - internal/tag
+  - language
   - transform
+  - unicode/norm
 - name: golang.org/x/tools
-  version: 4c6345e8dcc0f4b741dea01f83c49ad201a26673
+  version: 167995c67fa45f3a7fc8dab62bb872212e397c11
   subpackages:
+  - cmd/goimports
+  - cmd/goyacc
+  - cmd/stringer
   - go/ast/astutil
+  - go/buildutil
   - go/loader
   - go/ssa
   - go/types/typeutil
-  - go/buildutil
 - name: google.golang.org/appengine
-  version: ca59ef35f409df61fa4a5f8290ff289b37eccfb8
+  version: 12d5545dc1cfa6047a286d5e853841b6471f4c19
   subpackages:
-  - urlfetch
   - internal
-  - internal/urlfetch
   - internal/base
   - internal/datastore
   - internal/log
   - internal/remote_api
+  - internal/urlfetch
+  - urlfetch
 - name: google.golang.org/grpc
   version: 79b7c349179cdd6efd8bac4a1ce7f01b98c16e9b
   subpackages:
   - codes
   - credentials
-  - peer
   - grpclog
-  - transport
   - internal
   - metadata
   - naming
+  - peer
+  - transport
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
@@ -361,4 +361,10 @@ imports:
   version: 1808e1b5cd4acae8f67421110d05222214cebe4d
 - name: honnef.co/go/unused
   version: bc7f902391ead3f59bf5ab82ddf3c7d489837b62
-testImports: []
+testImports:
+- name: github.com/ghemawat/stream
+  version: 78e682abcae4f96ac7ddbe39912967a5f7cbbaa6
+- name: github.com/go-sql-driver/mysql
+  version: 665b83488b90b902ce0a305ef6652e599771cdf9
+- name: github.com/termie/go-shutil
+  version: bcacb06fecaeec8dc42af03c87c6949f4a05c74c

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,96 +1,170 @@
 package: github.com/cockroachdb/cockroach
 import:
-- package: github.com/Azure/go-ansiterm
-- package: github.com/Microsoft/go-winio
-- package: github.com/Sirupsen/logrus
-- package: github.com/StackExchange/wmi
 - package: github.com/VividCortex/ewma
 - package: github.com/abourget/teamcity
-- package: github.com/agtorre/gocolorize
 - package: github.com/backtrace-labs/go-bcd
 - package: github.com/biogo/store
+  subpackages:
+  - interval
+  - llrb
 - package: github.com/cenk/backoff
 - package: github.com/chzyer/readline
-- package: github.com/client9/misspell
 - package: github.com/cockroachdb/c-jemalloc
+  # Inherently risky.
+  version: 42e6a32cd7a4dff9c70d80323681d46d046181ef
 - package: github.com/cockroachdb/c-protobuf
+  subpackages:
+  - cmd/protoc
 - package: github.com/cockroachdb/c-rocksdb
-- package: github.com/cockroachdb/c-snappy
+  # Inherently risky.
+  version: b5ca031b93fde49bfa2ba99aba423136aebf3c06
 - package: github.com/cockroachdb/cmux
 - package: github.com/cockroachdb/cockroach-go
-- package: github.com/cockroachdb/crlfmt
+  subpackages:
+  - crdb
 - package: github.com/cockroachdb/pq
-- package: github.com/cockroachdb/stress
 - package: github.com/codahale/hdrhistogram
 - package: github.com/coreos/etcd
-- package: github.com/cpuguy83/go-md2man
-- package: github.com/docker/distribution
+  subpackages:
+  - raft
+  - raft/raftpb
 - package: github.com/docker/docker
+  # https://github.com/docker/docker/pull/27912 broke all dependents.
+  version: 7248742ae7127347a52ab9d215451c213b7b59da
+  subpackages:
+  - api/types
+  - api/types/container
+  - api/types/events
+  - api/types/filters
+  - api/types/network
+  - client
+  - pkg/jsonmessage
+  - pkg/stdcopy
 - package: github.com/docker/go-connections
-- package: github.com/docker/go-units
+  subpackages:
+  - nat
 - package: github.com/dustin/go-humanize
 - package: github.com/elastic/gosigar
 - package: github.com/elazarl/go-bindata-assetfs
 - package: github.com/facebookgo/clock
-- package: github.com/ghemawat/stream
-- package: github.com/go-ole/go-ole
-- package: github.com/go-sql-driver/mysql
 - package: github.com/gogo/protobuf
-- package: github.com/golang/glog
-- package: github.com/golang/lint
+  # Updated with google.golang.org/grpc.
+  version: ccdc7fbcb4cd13f34b76d7262805e58316faaaf4
+  subpackages:
+  - jsonpb
+  - proto
+  - protoc-gen-gogo/descriptor
+  - sortkeys
+  - vanity
+  - vanity/command
 - package: github.com/golang/protobuf
+  subpackages:
+  - proto
 - package: github.com/google/btree
 - package: github.com/google/go-github
-- package: github.com/google/go-querystring
+  subpackages:
+  - github
 - package: github.com/grpc-ecosystem/grpc-gateway
-- package: github.com/inconshreveable/mousetrap
+  subpackages:
+  - runtime
+  - third_party/googleapis/google/api
+  - utilities
+  - protoc-gen-grpc-gateway
 - package: github.com/jeffjen/datefmt
-- package: github.com/jteeuwen/go-bindata
-- package: github.com/kisielk/errcheck
 - package: github.com/kisielk/gotool
-- package: github.com/kkaneda/returncheck
 - package: github.com/kr/pretty
 - package: github.com/kr/text
 - package: github.com/leekchan/timeutil
 - package: github.com/lib/pq
+  subpackages:
+  - oid
 - package: github.com/lightstep/lightstep-tracer-go
 - package: github.com/mattn/go-isatty
-- package: github.com/mattn/go-runewidth
-- package: github.com/mattn/goveralls
-- package: github.com/matttproud/golang_protobuf_extensions
-- package: github.com/mdempsky/unconvert
-- package: github.com/mibk/dupl
 - package: github.com/montanaflynn/stats
 - package: github.com/olekukonko/tablewriter
-- package: github.com/opencontainers/runc
 - package: github.com/opentracing/basictracer-go
 - package: github.com/opentracing/opentracing-go
-- package: github.com/pborman/uuid
+  subpackages:
+  - ext
+  - log
 - package: github.com/petermattis/goid
 - package: github.com/pkg/errors
 - package: github.com/prometheus/client_model
+  subpackages:
+  - go
 - package: github.com/prometheus/common
+  subpackages:
+  - expfmt
 - package: github.com/rcrowley/go-metrics
-- package: github.com/robfig/glock
+  subpackages:
+  - exp
 - package: github.com/rubyist/circuitbreaker
 - package: github.com/sasha-s/go-deadlock
 - package: github.com/satori/go.uuid
 - package: github.com/spf13/cobra
+  subpackages:
+  - doc
 - package: github.com/spf13/pflag
 - package: github.com/tebeka/go2xunit
-- package: github.com/termie/go-shutil
-- package: github.com/wadey/gocovmerge
+  subpackages:
+  - lib
 - package: golang.org/x/crypto
+  subpackages:
+  - bcrypt
+  - ssh/terminal
 - package: golang.org/x/net
+  subpackages:
+  - context
+  - http2
+  - trace
 - package: golang.org/x/oauth2
-- package: golang.org/x/sys
 - package: golang.org/x/text
-- package: golang.org/x/tools
-- package: google.golang.org/appengine
+  subpackages:
+  - collate
+  - language
+  - unicode/norm
 - package: google.golang.org/grpc
+  # Inherently risky.
+  version: 79b7c349179cdd6efd8bac4a1ce7f01b98c16e9b
+  subpackages:
+  - codes
+  - credentials
+  - grpclog
+  - peer
+  - transport
 - package: gopkg.in/inf.v0
 - package: gopkg.in/yaml.v2
 - package: honnef.co/go/lint
+  subpackages:
+  - lintutil
 - package: honnef.co/go/simple
 - package: honnef.co/go/staticcheck
 - package: honnef.co/go/unused
+- package: github.com/jteeuwen/go-bindata
+  subpackages:
+  - go-bindata
+- package: github.com/mattn/goveralls
+- package: github.com/client9/misspell
+  subpackages:
+  - cmd/misspell
+- package: github.com/cockroachdb/crlfmt
+- package: github.com/cockroachdb/stress
+- package: github.com/golang/lint
+  subpackages:
+  - golint
+- package: github.com/kisielk/errcheck
+- package: github.com/kkaneda/returncheck
+- package: github.com/mdempsky/unconvert
+- package: github.com/mibk/dupl
+- package: github.com/robfig/glock
+- package: github.com/wadey/gocovmerge
+- package: golang.org/x/tools
+  subpackages:
+  - go/buildutil
+  - cmd/goimports
+  - cmd/goyacc
+  - cmd/stringer
+testImport:
+- package: github.com/ghemawat/stream
+- package: github.com/go-sql-driver/mysql
+- package: github.com/termie/go-shutil

--- a/pkg/cmd/github-post/main_test.go
+++ b/pkg/cmd/github-post/main_test.go
@@ -89,7 +89,7 @@ func TestRunGH(t *testing.T) {
 		},
 		"stress-fatal": {
 			packageName: envPkg,
-			testName:    "(unknown)",
+			testName:    "TestRaftRemoveRace",
 			body:        "F161007 00:27:33.243126 449 storage/store.go:2446  [s3] [n3,s3,r1:/M{in-ax}]: could not remove placeholder after preemptive snapshot",
 		},
 	} {

--- a/scripts/glide-up.sh
+++ b/scripts/glide-up.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+mv vendor/.git vendorgit && \
+glide up && \
+mv vendorgit vendor/.git && \
+git -C vendor checkout README.md


### PR DESCRIPTION
Performed with:
```
rm glide.yaml && glide init && cat GLOCKFILE | cut -f2 -d' ' | grep -F vendor | sed -e s,./vendor/,, | xargs glide get --non-interactive
```

Manually pins risky packages:
- github.com/cockroachdb/c-jemalloc
- github.com/cockroachdb/c-rocksdb
- google.golang.org/grpc & github.com/gogo/protobuf

Manually pins broken updates:
- githu.com/docker/docker

This reveals serious problems with the dependency update flow under
glide. `glide update` completely removes the vendor directory, which
means that the `.git` directory and all non-source content (README.md)
are lost. The workflow needed to achieve a reasonable result is thus:
```
mv vendor/.git vendorgit && \
glide up && \
mv vendorgit vendor/.git && \
git -C vendor checkout README.md
```

This script is checked in as `scripts/glide-up.sh`.

Running `git clean -dxn` in `vendor` produces:
```
Would remove github.com/cockroachdb/c-snappy/internal/testdata/
Would remove github.com/docker/distribution/contrib/docker-integration/malevolent-certs/ca.pem
Would remove github.com/docker/distribution/contrib/docker-integration/nginx/ssl/
Would remove github.com/docker/distribution/contrib/docker-integration/tokenserver-oauth/certs/ca.pem
Would remove github.com/docker/distribution/contrib/docker-integration/tokenserver/certs/ca.pem
Would remove github.com/lightstep/lightstep-tracer-go/lightstep-tracer-common/
```

`github.com/cockroachdb/c-snappy` and `github.com/docker/distribution`
report ignored files because the repositories track files which are
ostensibly ignored by various `.gitignore`s. This PR picks up
https://github.com/cockroachdb/c-snappy/pull/10 which fixes this for
that package.

However, `github.com/lightstep/lightstep-tracer-go` reporting
`github.com/lightstep/lightstep-tracer-go/lightstep-tracer-common` as
ignored revealed a serious problem: this directory is a submodule, and
in our vendor checkout, it is empty. This suggests that `glide` did not
check out the submodule, despite that being the behaviour of `go get`
since https://golang.org/cl/9815.

`glide update` is also terribly slow, clocking in around 1m30s.

Finally, the move to glide of course breaks `glock-diff-parser`, which
means the list of upstream changes must again be compiled manually. The
changes are:
- github.com/tebeka/go2xunit:
  - tests ending in os.Exit() are now parsed: https://github.com/tebeka/go2xunit/pull/42

Note that glide also "updated" `github.com/grpc-ecosystem/grpc-gateway`
to an older version, losing an earlier fix
(https://github.com/grpc-ecosystem/grpc-gateway/pull/256). My best
guess is that one of our dependencies uses this earlier version, likely
`github.com/coreos/etcd`. There seems to be no way to avoid this
behaviour.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11218)
<!-- Reviewable:end -->
