### PR TITLE
server: trick the runtime into growing the goroutine stack early

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -845,6 +845,8 @@ func (n *Node) batchInternal(
 func (n *Node) Batch(
 	ctx context.Context, args *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, error) {
+	growStack()
+
 	ctx = n.AnnotateCtx(ctx)
 
 	br, err := n.batchInternal(ctx, args)
@@ -864,4 +866,24 @@ func (n *Node) Batch(
 		br.Error = roachpb.NewError(err)
 	}
 	return br, nil
+}
+
+var growStackGlobal = false
+
+//go:noinline
+func growStack() {
+	// Goroutine stacks currently start at 2 KB in size. The code paths through
+	// the storage package often need a stack that is 32 KB in size. The stack
+	// growth is mildly expensive making it useful to trick the runtime into
+	// growing the stack early. Since goroutine stacks grow in multiples of 2 and
+	// start at 2 KB in size, by placing a 16 KB object on the stack early in the
+	// lifetime of a goroutine we force the runtime to use a 32 KB stack for the
+	// goroutine.
+	var buf [16 << 10] /* 16 KB */ byte
+	if growStackGlobal {
+		// Make sure the compiler doesn't optimize away buf.
+		for i := range buf {
+			buf[i] = byte(i)
+		}
+	}
 }


### PR DESCRIPTION
Goroutine stacks currently start at 2 KB in size. The code paths through
the storage package often need a stack that is 32 KB in size. The stack
growth is mildly expensive making it useful to trick the runtime into
growing the stack early.

Fixes #11205

Comparison vs master:

```
name              old time/op  new time/op  delta
KVInsert1_SQL-8    383µs ± 2%   348µs ± 2%   -9.29%    (p=0.000 n=9+9)
KVInsert10_SQL-8   520µs ± 2%   507µs ± 1%   -2.50%  (p=0.000 n=10+10)
KVUpdate1_SQL-8    581µs ± 1%   528µs ± 1%   -9.22%   (p=0.000 n=10+9)
KVUpdate10_SQL-8   829µs ± 1%   788µs ± 1%   -4.94%  (p=0.000 n=10+10)
KVDelete1_SQL-8    521µs ± 1%   467µs ± 1%  -10.30%   (p=0.000 n=9+10)
KVDelete10_SQL-8   732µs ± 1%   685µs ± 1%   -6.32%   (p=0.000 n=9+10)
KVScan1_SQL-8      226µs ± 1%   192µs ± 0%  -15.05%   (p=0.000 n=9+10)
KVScan10_SQL-8     252µs ± 1%   216µs ± 0%  -14.00%   (p=0.000 n=9+10)
```

Comparison against no-goroutine for local calls:

```
name              old time/op  new time/op  delta
KVInsert1_SQL-8    353µs ± 3%   348µs ± 2%     ~      (p=0.079 n=10+9)
KVInsert10_SQL-8   491µs ± 1%   507µs ± 1%   +3.21%  (p=0.000 n=10+10)
KVUpdate1_SQL-8    508µs ± 0%   528µs ± 1%   +3.94%   (p=0.000 n=10+9)
KVUpdate10_SQL-8   750µs ± 1%   788µs ± 1%   +5.17%  (p=0.000 n=10+10)
KVDelete1_SQL-8    460µs ± 1%   467µs ± 1%   +1.40%  (p=0.000 n=10+10)
KVDelete10_SQL-8   654µs ± 1%   685µs ± 1%   +4.89%  (p=0.000 n=10+10)
KVScan1_SQL-8      213µs ± 3%   192µs ± 0%  -10.00%  (p=0.000 n=10+10)
KVScan10_SQL-8     247µs ± 2%   216µs ± 0%  -12.28%  (p=0.000 n=10+10)
```

It's surprising that using a goroutine+growstack-hack is faster for the
Scan benchmarks than no goroutine at all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11616)
<!-- Reviewable:end -->
