### PR TITLE
storage: stop consulting next lease when determining replica GC

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -1373,10 +1373,6 @@ func runReplicateRestartAfterTruncation(t *testing.T, removeBeforeTruncateAndReA
 		mtc.manualClock.Increment(int64(storage.ReplicaGCQueueInactivityThreshold + 1))
 		mtc.stores[1].ForceReplicaGCScanAndProcess()
 		util.SucceedsSoon(t, func() error {
-			if true {
-				// TODO(spencerkimball): fix the flakiness seen in #8670 and remove.
-				return nil
-			}
 			_, err := mtc.stores[1].GetReplica(rangeID)
 			if _, ok := err.(*roachpb.RangeNotFoundError); !ok {
 				return errors.Errorf("expected replica to be garbage collected")


### PR DESCRIPTION
The next lease is only an attempt. In the case of a replica being
removed from a Raft group, this value will never become reality.
Since this is exactly what happens in `TestReplicateRestartAfterTruncationWithRemoveAndReAdd`,
it's better to simply ignore checking the next lease as a sign that
a replica is active and doesn't need GCing. The `shouldQueue` method
is only advisory; no work to GC will actually be done regardless of
whether the `shouldQueue` method becomes more lenient.

Also, future proofed the code here for epoch-based range leases
by using the new `Lease.ProposedTS` instead of `Lease.Expiration`.

Fixes #8670

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11619)
<!-- Reviewable:end -->
