### PR TITLE
testutils: Make IsError interpret empty re as not expecting an error

### DIFF
--- a/pkg/base/config_test.go
+++ b/pkg/base/config_test.go
@@ -67,7 +67,7 @@ func TestClientSSLSettings(t *testing.T) {
 			t.Fatalf("#%d: expected HTTPRequestScheme=%s, got: %s", tcNum, tc.requestScheme, cfg.HTTPRequestScheme())
 		}
 		tlsConfig, err := cfg.GetClientTLSConfig()
-		if !(tc.configErr == "" && err == nil || testutils.IsError(err, tc.configErr)) {
+		if !testutils.IsError(err, tc.configErr) {
 			t.Fatalf("#%d: expected err=%s, got err=%v", tcNum, tc.configErr, err)
 		}
 		if err != nil {

--- a/pkg/cli/start_test.go
+++ b/pkg/cli/start_test.go
@@ -66,12 +66,8 @@ func TestInitInsecure(t *testing.T) {
 		}
 
 		err := initInsecure()
-		if c.expected == "" {
-			if err != nil {
-				t.Fatalf("%d: expected success, but found %v", i, err)
-			}
-		} else if !testutils.IsError(err, c.expected) {
-			t.Fatalf("%d: expected %s, but found %v", i, c.expected, err)
+		if !testutils.IsError(err, c.expected) {
+			t.Fatalf("%d: expected %q, but found %v", i, c.expected, err)
 		}
 	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -196,13 +196,11 @@ func TestGetLargestID(t *testing.T) {
 	for tcNum, tc := range testCases {
 		cfg.Values = tc.values
 		ret, err := cfg.GetLargestObjectID(tc.maxID)
-		if tc.errStr == "" {
-			if err != nil {
-				t.Errorf("#%d: error: %v", tcNum, err)
-				continue
-			}
-		} else if !testutils.IsError(err, tc.errStr) {
-			t.Errorf("#%d: expected err=%s, got %v", tcNum, tc.errStr, err)
+		if !testutils.IsError(err, tc.errStr) {
+			t.Errorf("#%d: expected err=%q, got %v", tcNum, tc.errStr, err)
+			continue
+		}
+		if err != nil {
 			continue
 		}
 		if ret != tc.largest {
@@ -343,12 +341,8 @@ func TestZoneConfigValidate(t *testing.T) {
 	}
 	for i, c := range testCases {
 		err := c.cfg.Validate()
-		if c.expected == "" {
-			if err != nil {
-				t.Fatalf("%d: expected success, but got %v", i, err)
-			}
-		} else if !testutils.IsError(err, c.expected) {
-			t.Fatalf("%d: expected %s, but got %v", i, c.expected, err)
+		if !testutils.IsError(err, c.expected) {
+			t.Fatalf("%d: expected %q, got %v", i, c.expected, err)
 		}
 	}
 }

--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -258,7 +258,7 @@ func TestMetaScanBounds(t *testing.T) {
 	for i, test := range testCases {
 		resStart, resEnd, err := MetaScanBounds(test.key)
 
-		if !(test.expError == "" && err == nil || testutils.IsError(err, test.expError)) {
+		if !testutils.IsError(err, test.expError) {
 			t.Errorf("expected error: %s ; got %v", test.expError, err)
 		}
 
@@ -326,10 +326,8 @@ func TestMetaReverseScanBounds(t *testing.T) {
 	for i, test := range testCases {
 		resStart, resEnd, err := MetaReverseScanBounds(roachpb.RKey(test.key))
 
-		if err != nil && !testutils.IsError(err, test.expError) {
-			t.Errorf("expected error: %s ; got %v", test.expError, err)
-		} else if err == nil && test.expError != "" {
-			t.Errorf("expected error: %s", test.expError)
+		if !testutils.IsError(err, test.expError) {
+			t.Errorf("expected error %q ; got %v", test.expError, err)
 		}
 
 		if !resStart.Equal(test.expStart) || !resEnd.Equal(test.expEnd) {
@@ -518,7 +516,7 @@ func TestEnsureSafeSplitKey(t *testing.T) {
 	for i, d := range errorData {
 		_, err := EnsureSafeSplitKey(d.in)
 		if !testutils.IsError(err, d.err) {
-			t.Fatalf("%d: %s: expected %s, but got %v", i, d.in, d.err, err)
+			t.Fatalf("%d: %s: expected %q, but got %v", i, d.in, d.err, err)
 		}
 	}
 }

--- a/pkg/kv/truncate_test.go
+++ b/pkg/kv/truncate_test.go
@@ -169,8 +169,8 @@ func TestTruncate(t *testing.T) {
 		}
 		ba, num, err := truncate(original, rs)
 		if err != nil || test.err != "" {
-			if test.err == "" || !testutils.IsError(err, test.err) {
-				t.Errorf("%d: %v (expected: %s)", i, err, test.err)
+			if !testutils.IsError(err, test.err) {
+				t.Errorf("%d: %v (expected: %q)", i, err, test.err)
 			}
 			continue
 		}

--- a/pkg/sql/logic_test.go
+++ b/pkg/sql/logic_test.go
@@ -801,7 +801,7 @@ func (t *logicTest) verifyError(sql, pos, expectErr, expectErrCode string, err e
 	if expectErr == "" && expectErrCode == "" && err != nil {
 		return t.unexpectedError(sql, pos, err)
 	}
-	if expectErr != "" && !testutils.IsError(err, expectErr) {
+	if !testutils.IsError(err, expectErr) {
 		t.Errorf("%s: expected %q, but found %v", pos, expectErr, err)
 		return false
 	}

--- a/pkg/sql/pgwire_test.go
+++ b/pkg/sql/pgwire_test.go
@@ -899,14 +899,9 @@ func TestPGPreparedExec(t *testing.T) {
 					t.Errorf("%s: %v: expected error: %s, got %s", query, test.qargs, test.error, err)
 				}
 			} else {
-				if rowsAffected, err := result.RowsAffected(); err != nil {
-					if test.rowsAffectedErr == "" {
-						t.Errorf("%s: %v: unexpected error: %s", query, test.qargs, err)
-					} else if !testutils.IsError(err, test.rowsAffectedErr) {
-						t.Errorf("%s: %v: expected %s, got %s", query, test.qargs, test.rowsAffectedErr, err)
-					}
-				} else if test.rowsAffectedErr != "" {
-					t.Errorf("%s: %v: expected error: %s", query, test.qargs, test.rowsAffectedErr)
+				rowsAffected, err := result.RowsAffected()
+				if !testutils.IsError(err, test.rowsAffectedErr) {
+					t.Errorf("%s: %v: expected %q, got %v", query, test.qargs, test.rowsAffectedErr, err)
 				} else if rowsAffected != test.rowsAffected {
 					t.Errorf("%s: %v: expected %v, got %v", query, test.qargs, test.rowsAffected, rowsAffected)
 				}

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -3733,7 +3733,7 @@ func TestMVCCGarbageCollectNonDeleted(t *testing.T) {
 		vals     []roachpb.Value
 		expError string
 	}{
-		{roachpb.Key("a"), []roachpb.Value{val1, val2}, `request to GC non-deleted, latest value ok "a"`},
+		{roachpb.Key("a"), []roachpb.Value{val1, val2}, `request to GC non-deleted, latest value of "a"`},
 		{roachpb.Key("inline"), []roachpb.Value{valInline}, ""},
 	}
 
@@ -3749,14 +3749,8 @@ func TestMVCCGarbageCollectNonDeleted(t *testing.T) {
 			{Key: test.key, Timestamp: ts2},
 		}
 		err := MVCCGarbageCollect(context.Background(), engine, nil, keys, ts2)
-		if test.expError == "" {
-			if err != nil {
-				t.Fatalf("expected no error garbage collecting a non-deleted inline live value, found %v", err)
-			}
-		} else {
-			if testutils.IsError(err, test.expError) {
-				t.Fatalf("expected error %q when garbage collecting a non-deleted live value, found %v", test.expError, err)
-			}
+		if !testutils.IsError(err, test.expError) {
+			t.Fatalf("expected error %q when garbage collecting a non-deleted live value, found %v", test.expError, err)
 		}
 	}
 

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -190,9 +190,6 @@ func TestRocksDBOpenWithVersions(t *testing.T) {
 
 	for i, testCase := range testCases {
 		err := openRocksDBWithVersion(t, testCase.hasFile, testCase.ver)
-		if err == nil && len(testCase.expectedErr) == 0 {
-			continue
-		}
 		if !testutils.IsError(err, testCase.expectedErr) {
 			t.Errorf("%d: expected error '%s', actual '%v'", i, testCase.expectedErr, err)
 		}

--- a/pkg/storage/replica_state_test.go
+++ b/pkg/storage/replica_state_test.go
@@ -77,8 +77,9 @@ func TestSynthesizeHardState(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := synthesizeHardState(context.Background(), batch, testState, oldHS); !(test.Err == "" && err == nil || testutils.IsError(err, test.Err)) {
-				t.Fatalf("%d: expected %s got %v", i, test.Err, err)
+			err = synthesizeHardState(context.Background(), batch, testState, oldHS)
+			if !testutils.IsError(err, test.Err) {
+				t.Fatalf("%d: expected %q got %v", i, test.Err, err)
 			} else if err != nil {
 				// No further checking if we expected an error and got it.
 				return

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -1056,7 +1056,7 @@ func TestReplicaTSCacheLowWaterOnLease(t *testing.T) {
 				NodeID:    roachpb.NodeID(test.storeID),
 				StoreID:   test.storeID,
 			},
-		}); !(test.expErr == "" && err == nil || testutils.IsError(err, test.expErr)) {
+		}); !testutils.IsError(err, test.expErr) {
 			t.Fatalf("%d: unexpected error %v", i, err)
 		}
 		// Verify expected low water mark.
@@ -6062,12 +6062,8 @@ func TestSetReplicaID(t *testing.T) {
 			repl.mu.Unlock()
 
 			err := repl.setReplicaID(c.newReplicaID)
-			if c.expected == "" {
-				if err != nil {
-					t.Fatalf("expected success, but found %v", err)
-				}
-			} else if !testutils.IsError(err, c.expected) {
-				t.Fatalf("expected %s, but found %v", c.expected, err)
+			if !testutils.IsError(err, c.expected) {
+				t.Fatalf("expected %q, but found %v", c.expected, err)
 			}
 		})
 	}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -437,14 +437,8 @@ func TestReplicasByKey(t *testing.T) {
 	for i, desc := range reps {
 		desc.replica = createReplica(store, roachpb.RangeID(desc.id), desc.start, desc.end)
 		err := store.AddReplica(desc.replica)
-		if desc.expectedErrorOnAdd == "" {
-			if err != nil {
-				t.Fatalf("adding replica %d: expected success, but encountered %s", i, err)
-			}
-		} else {
-			if !testutils.IsError(err, desc.expectedErrorOnAdd) {
-				t.Fatalf("adding replica %d: expected err %s, but encountered %v", i, desc.expectedErrorOnAdd, err)
-			}
+		if !testutils.IsError(err, desc.expectedErrorOnAdd) {
+			t.Fatalf("adding replica %d: expected err %q, but encountered %v", i, desc.expectedErrorOnAdd, err)
 		}
 	}
 }
@@ -1967,8 +1961,8 @@ func TestStoreBadRequests(t *testing.T) {
 		if test.header.Txn != nil {
 			test.header.Txn.Sequence++
 		}
-		if _, pErr := client.SendWrappedWith(context.Background(), store.testSender(), *test.header, test.args); pErr == nil || test.err == "" || !testutils.IsPError(pErr, test.err) {
-			t.Errorf("%d unexpected result: %s", i, pErr)
+		if _, pErr := client.SendWrappedWith(context.Background(), store.testSender(), *test.header, test.args); !testutils.IsPError(pErr, test.err) {
+			t.Errorf("%d expected error %q, got error %v", i, test.err, pErr)
 		}
 	}
 }

--- a/pkg/testutils/error.go
+++ b/pkg/testutils/error.go
@@ -25,10 +25,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
 )
 
-// IsError returns true if err is non-nil and the error string matches the
-// supplied regexp.
+// IsError returns true if the error string matches the supplied regex.
+// An empty regex is interpreted to mean that a nil error is expected.
 func IsError(err error, re string) bool {
-	if err == nil {
+	if err == nil && re == "" {
+		return true
+	}
+	if err == nil || re == "" {
 		return false
 	}
 	matched, merr := regexp.MatchString(re, err.Error())
@@ -38,10 +41,13 @@ func IsError(err error, re string) bool {
 	return matched
 }
 
-// IsPError returns true if pErr is non-nil and the error message matches the
-// supplied regexp.
+// IsPError returns true if pErr's message matches the supplied regex.
+// An empty regex is interpreted to mean that a nil error is expected.
 func IsPError(pErr *roachpb.Error, re string) bool {
-	if pErr == nil {
+	if pErr == nil && re == "" {
+		return true
+	}
+	if pErr == nil || re == "" {
 		return false
 	}
 	matched, merr := regexp.MatchString(re, pErr.Message)

--- a/pkg/ts/timeseries_test.go
+++ b/pkg/ts/timeseries_test.go
@@ -134,14 +134,8 @@ func TestToInternal(t *testing.T) {
 
 	for i, tc := range tcases {
 		actual, err := tc.input.ToInternal(tc.keyDuration, tc.sampleDuration)
-		if e := tc.expectedError; len(e) > 0 {
-			if !testutils.IsError(err, e) {
-				t.Errorf("unexpected error from case %d: %v", i, err)
-			}
-		} else {
-			if err != nil {
-				t.Errorf("unexpected error from case %d: %v", i, err)
-			}
+		if !testutils.IsError(err, tc.expectedError) {
+			t.Errorf("expected error %q from case %d, got %v", tc.expectedError, i, err)
 		}
 
 		if !reflect.DeepEqual(actual, tc.expected) {


### PR DESCRIPTION
This makes using IsError (and IsPError) much simpler in tests that
don't always expect an error, since now you don't have to first check
whether an error is expected before calling IsError. It's worth noting
that this broke zero tests -- no test was relying on the behavior of
saying that every error matched with the empty regex.

I've gone and cleaned up the uses of IsError that were working around
its old behavior to simplify them and get rid of bad examples for
future developers to copy from. In the process, I found an MVCC test
that wasn't actually testing what it was supposed to be and fixed it.

This was annoying me while I was writing tests for the migration code last week.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11646)
<!-- Reviewable:end -->
