### PR TITLE
testcluster: create TestCluster servers concurrently

### DIFF
--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -50,10 +50,6 @@ var (
 	metaFDOpen         = metric.Metadata{Name: "sys.fd.open", Help: "Process open file descriptors"}
 	metaFDSoftLimit    = metric.Metadata{Name: "sys.fd.softlimit", Help: "Process open FD soft limit"}
 	metaUptime         = metric.Metadata{Name: "sys.uptime", Help: "Process uptime in seconds"}
-
-	// Build information. Placed here for lack of a better location.
-	// Labels for this metric get populated in MakeRuntimeStatSampler
-	metaBuildTimestamp = metric.Metadata{Name: "build.timestamp", Help: "Build information"}
 )
 
 // getCgoMemStats is a function that fetches stats for the C++ portion of the code.
@@ -116,6 +112,8 @@ func MakeRuntimeStatSampler(clock *hlc.Clock) RuntimeStatSampler {
 		log.Warningf(context.TODO(), "Could not parse build timestamp: %v", err)
 	}
 
+	// Build information.
+	metaBuildTimestamp := metric.Metadata{Name: "build.timestamp", Help: "Build information"}
 	metaBuildTimestamp.AddLabel("tag", info.Tag)
 	metaBuildTimestamp.AddLabel("go_version", info.GoVersion)
 

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -159,10 +159,15 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	}
 	// Copy over the store specs.
 	cfg.Stores = base.StoreSpecList{Specs: params.StoreSpecs}
-	if cfg.TestingKnobs.Store == nil {
-		cfg.TestingKnobs.Store = &storage.StoreTestingKnobs{}
+
+	// Make a separate copy of the store testing knobs because we intend to
+	// modify it, and some other TestingKnobs struct can be referencing it.
+	storeTestingKnob := storage.StoreTestingKnobs{}
+	if cfg.TestingKnobs.Store != nil {
+		storeTestingKnob = *(cfg.TestingKnobs.Store.(*storage.StoreTestingKnobs))
 	}
-	cfg.TestingKnobs.Store.(*storage.StoreTestingKnobs).SkipMinSizeCheck = true
+	storeTestingKnob.SkipMinSizeCheck = true
+	cfg.TestingKnobs.Store = &storeTestingKnob
 
 	return cfg
 }


### PR DESCRIPTION
create the first server and then the remaining servers concurrently.
Fix two race conditions that occur at startup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11647)
<!-- Reviewable:end -->
