### PR TITLE
util/stop: Increase timeout in TestStopperQuiesce to reduce flakiness

### DIFF
--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -227,7 +227,7 @@ func TestStopperQuiesce(t *testing.T) {
 
 	select {
 	case <-done:
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(time.Second):
 		t.Errorf("timed out waiting for stop")
 	}
 }


### PR DESCRIPTION
Previously I could only run the test a few times before getting a
failure. After the change, I ran it more than 10k times without any
failures.

Fixes #11639

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11661)
<!-- Reviewable:end -->
