### PR TITLE
storage: enhance Allocator.ShouldTransferLease

### DIFF
--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -508,7 +508,7 @@ func (a *Allocator) TransferLeaseTarget(
 	if !ok {
 		return roachpb.ReplicaDescriptor{}
 	}
-	if checkTransferLeaseSource && !shouldTransferLease(sl, source) {
+	if checkTransferLeaseSource && !a.shouldTransferLease(sl, source, existing) {
 		return roachpb.ReplicaDescriptor{}
 	}
 
@@ -537,7 +537,10 @@ func (a *Allocator) TransferLeaseTarget(
 // of leases with respect to the other stores matching the specified
 // attributes.
 func (a *Allocator) ShouldTransferLease(
-	constraints config.Constraints, leaseStoreID roachpb.StoreID, rangeID roachpb.RangeID,
+	constraints config.Constraints,
+	existing []roachpb.ReplicaDescriptor,
+	leaseStoreID roachpb.StoreID,
+	rangeID roachpb.RangeID,
 ) bool {
 	if !a.options.AllowRebalance {
 		return false
@@ -552,14 +555,16 @@ func (a *Allocator) ShouldTransferLease(
 	if log.V(3) {
 		log.Infof(context.TODO(), "transfer-lease-source (lease-holder=%d):\n%s", leaseStoreID, sl)
 	}
-	return shouldTransferLease(sl, source)
+	return a.shouldTransferLease(sl, source, existing)
 }
 
 // EnableLeaseRebalancing controls whether lease rebalancing is enabled or
 // not. Exported for testing.
 var EnableLeaseRebalancing = envutil.EnvOrDefaultBool("COCKROACH_ENABLE_LEASE_REBALANCING", false)
 
-func shouldTransferLease(sl StoreList, source roachpb.StoreDescriptor) bool {
+func (a Allocator) shouldTransferLease(
+	sl StoreList, source roachpb.StoreDescriptor, existing []roachpb.ReplicaDescriptor,
+) bool {
 	if !EnableLeaseRebalancing {
 		return false
 	}
@@ -570,7 +575,28 @@ func shouldTransferLease(sl StoreList, source roachpb.StoreDescriptor) bool {
 	if overfullLeaseThreshold < minOverfullThreshold {
 		overfullLeaseThreshold = minOverfullThreshold
 	}
-	return source.Capacity.LeaseCount > overfullLeaseThreshold
+	if source.Capacity.LeaseCount > overfullLeaseThreshold {
+		return true
+	}
+
+	if float64(source.Capacity.LeaseCount) > sl.candidateLeases.mean {
+		underfullLeaseThreshold := int32(math.Ceil(sl.candidateLeases.mean * (1 - rebalanceThreshold)))
+		minUnderfullThreshold := int32(math.Ceil(sl.candidateLeases.mean - 5))
+		if underfullLeaseThreshold > minUnderfullThreshold {
+			underfullLeaseThreshold = minUnderfullThreshold
+		}
+
+		for _, repl := range existing {
+			storeDesc, ok := a.storePool.getStoreDescriptor(repl.StoreID)
+			if !ok {
+				continue
+			}
+			if storeDesc.Capacity.LeaseCount < underfullLeaseThreshold {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // selectGood attempts to select a store from the supplied store list that it
@@ -599,8 +625,9 @@ func (a Allocator) improve(sl StoreList, excluded nodeIDSet) *roachpb.StoreDescr
 	return rcb.improve(sl, excluded)
 }
 
-// rebalanceThreshold is the minimum ratio of a store's range surplus to the
-// mean range count that permits rebalances away from that store.
+// rebalanceThreshold is the minimum ratio of a store's range/lease surplus to
+// the mean range/lease count that permits rebalances/lease-transfers away from
+// that store.
 var rebalanceThreshold = envutil.EnvOrDefaultFloat("COCKROACH_REBALANCE_THRESHOLD", 0.05)
 
 // shouldRebalance returns whether the specified store is a candidate for

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -129,7 +129,8 @@ func (rq *replicateQueue) shouldQueue(
 	if lease, _ := repl.getLease(); lease != nil && lease.Covers(now) {
 		leaseStoreID = lease.Replica.StoreID
 		if rq.canTransferLease() &&
-			rq.allocator.ShouldTransferLease(zone.Constraints, leaseStoreID, desc.RangeID) {
+			rq.allocator.ShouldTransferLease(
+				zone.Constraints, desc.Replicas, leaseStoreID, desc.RangeID) {
 			if log.V(2) {
 				log.Infof(ctx, "%s lease transfer needed, enqueuing", repl)
 			}
@@ -240,7 +241,8 @@ func (rq *replicateQueue) processOneChange(
 		// If the lease holder (our local store) is an overfull store (in terms of
 		// leases) allow transferring the lease away.
 		leaseHolderStoreID := repl.store.StoreID()
-		if rq.allocator.ShouldTransferLease(zone.Constraints, leaseHolderStoreID, desc.RangeID) {
+		if rq.allocator.ShouldTransferLease(
+			zone.Constraints, desc.Replicas, leaseHolderStoreID, desc.RangeID) {
 			leaseHolderStoreID = 0
 		}
 		removeReplica, err := rq.allocator.RemoveTarget(


### PR DESCRIPTION
Similar to replica rebalancing, allow a replica to be a source for lease
transfers if it is on a node with greater than the average number of
leases and one of the candidates is on a node that is underfull in terms
of leases.

Fixes #10695

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11664)
<!-- Reviewable:end -->
