### PR TITLE
vendor: add deps of binary tools/utils

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,10 @@
-hash: 978bc226e4f562c7d20e703f6780be01b79573e0c2863cb3ddcebb06a7c2ecab
-updated: 2016-11-24T00:23:37.560268231-05:00
+hash: 25cafe1ddc0e3a1c44003743074780c3bef5ec5dfad764e2085f103a16636f95
+updated: 2016-11-28T19:24:55.079179654Z
 imports:
 - name: github.com/abourget/teamcity
   version: 6dde447fa54bc5b08b1a7bb1b85e39089cf27fb1
+- name: github.com/agtorre/gocolorize
+  version: f42b554bf7f006936130c9bb4f971afd2d87f671
 - name: github.com/Azure/go-ansiterm
   version: fa152c58bc15761d0200cb75fe958b89a9d4888e
   subpackages:
@@ -138,6 +140,8 @@ imports:
   - types
   - vanity
   - vanity/command
+- name: github.com/golang/glog
+  version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
 - name: github.com/golang/lint
   version: 206c0f020eba0f7fbcfbc467a5eb808037df2ed6
   subpackages:
@@ -231,6 +235,8 @@ imports:
   subpackages:
   - ext
   - log
+- name: github.com/pborman/uuid
+  version: 3d4f2ba23642d3cfd06bd4b54cf03d99d95c0f1b
 - name: github.com/petermattis/goid
   version: ba001f8780f3bf978180f390ad7b5bac39fbf70a
 - name: github.com/pkg/errors

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,13 +10,11 @@ import:
 - package: github.com/cenk/backoff
 - package: github.com/chzyer/readline
 - package: github.com/cockroachdb/c-jemalloc
-  # Inherently risky.
   version: 42e6a32cd7a4dff9c70d80323681d46d046181ef
 - package: github.com/cockroachdb/c-protobuf
   subpackages:
   - cmd/protoc
 - package: github.com/cockroachdb/c-rocksdb
-  # Inherently risky.
   version: b5ca031b93fde49bfa2ba99aba423136aebf3c06
 - package: github.com/cockroachdb/cmux
 - package: github.com/cockroachdb/cockroach-go
@@ -29,7 +27,6 @@ import:
   - raft
   - raft/raftpb
 - package: github.com/docker/docker
-  # https://github.com/docker/docker/pull/27912 broke all dependents.
   version: 7248742ae7127347a52ab9d215451c213b7b59da
   subpackages:
   - api/types
@@ -48,7 +45,6 @@ import:
 - package: github.com/elazarl/go-bindata-assetfs
 - package: github.com/facebookgo/clock
 - package: github.com/gogo/protobuf
-  # Updated with google.golang.org/grpc.
   version: ccdc7fbcb4cd13f34b76d7262805e58316faaaf4
   subpackages:
   - jsonpb
@@ -124,7 +120,6 @@ import:
   - language
   - unicode/norm
 - package: google.golang.org/grpc
-  # Inherently risky.
   version: 79b7c349179cdd6efd8bac4a1ce7f01b98c16e9b
   subpackages:
   - codes
@@ -164,6 +159,9 @@ import:
   - cmd/goimports
   - cmd/goyacc
   - cmd/stringer
+- package: github.com/golang/glog
+- package: github.com/pborman/uuid
+- package: github.com/agtorre/gocolorize
 testImport:
 - package: github.com/ghemawat/stream
 - package: github.com/go-sql-driver/mysql


### PR DESCRIPTION
a couple of these got dropped when we recomputed deps from source, since they aren't transitive deps of cockroach,
only of tools we use

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11665)
<!-- Reviewable:end -->
