### PR TITLE
util/log: protect against file name collisions during rotations.

### DIFF
--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -225,9 +225,17 @@ func TestStatusLocalLogs(t *testing.T) {
 	if a, e := len(wrapper.Files), 3; a != e {
 		t.Fatalf("expected %d log files; got %d", e, a)
 	}
-	for i, name := range []string{"log.ERROR", "log.INFO", "log.WARNING"} {
-		if !strings.Contains(wrapper.Files[i].Name, name) {
-			t.Errorf("expected log file name %s to contain %q", wrapper.Files[i].Name, name)
+	for _, fileInfo := range wrapper.Files {
+		fName := fileInfo.Name
+		found := false
+		for i, name := range []string{"ERROR.log", "INFO.log", "WARNING.log"} {
+			if strings.Contains(wrapper.Files[i].Name, name) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected log file name %s to contain ERROR, INFO or WARNING.", fName)
 		}
 	}
 

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -885,9 +885,10 @@ func (l *loggingT) exit(err error) {
 type syncBuffer struct {
 	logger *loggingT
 	*bufio.Writer
-	file   *os.File
-	sev    Severity
-	nbytes uint64 // The number of bytes written to this file
+	file         *os.File
+	sev          Severity
+	lastRotation int64
+	nbytes       uint64 // The number of bytes written to this file
 }
 
 func (sb *syncBuffer) Sync() error {
@@ -919,7 +920,7 @@ func (sb *syncBuffer) rotateFile(now time.Time) error {
 		}
 	}
 	var err error
-	sb.file, _, err = create(sb.sev, now)
+	sb.file, sb.lastRotation, _, err = create(sb.sev, now, sb.lastRotation)
 	sb.nbytes = 0
 	if err != nil {
 		return err

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -357,6 +357,8 @@ func TestVmoduleGlob(t *testing.T) {
 }
 
 func TestListLogFiles(t *testing.T) {
+	s := logScope(t)
+	defer s.close(t)
 	setFlags()
 
 	methods := map[Severity]func(context.Context, ...interface{}){
@@ -445,7 +447,7 @@ func TestGetLogReader(t *testing.T) {
 		// Non-log file.
 		{"other.txt", "malformed log filename", "malformed log filename"},
 		// Non-existent file matching RE.
-		{"cockroach.roach0.root.log.ERROR.2015-09-25T19_24_19Z.1", "no such file", "no such file"},
+		{"cockroach.roach0.root.2015-09-25T19_24_19Z.00000.ERROR.log", "no such file", "no such file"},
 		// Base filename is specified.
 		{warnName, "", ""},
 		// Relative path with directory components.
@@ -511,11 +513,6 @@ func TestRollover(t *testing.T) {
 
 	// Make sure the next log file gets a file name with a different
 	// time stamp.
-	//
-	// TODO: determine whether we need to support subsecond log
-	// rotation.  C++ does not appear to handle this case (nor does it
-	// handle Daylight Savings Time properly).
-	time.Sleep(1 * time.Second)
 
 	Info(context.Background(), "x") // create a new file
 	if err != nil {

--- a/pkg/util/log/file_test.go
+++ b/pkg/util/log/file_test.go
@@ -45,7 +45,7 @@ func TestLogFilenameParsing(t *testing.T) {
 			t.Errorf("%d: Severities do not match, expected:%s - actual:%s", i, testCase.Severity.Name(), details.Severity.Name())
 		}
 		if a, e := time.Unix(0, details.Time).Format(time.RFC3339), testCase.Time.Format(time.RFC3339); a != e {
-			t.Errorf("%d: Times do not match, expected:%s - actual:%s", i, a, e)
+			t.Errorf("%d: Times do not match, expected:%s - actual:%s", i, e, a)
 		}
 	}
 }


### PR DESCRIPTION
Prior to this patch log files were named like this:

`cockroach.kenabook.kena.log.ERROR.2016-11-28T20_00_35Z.9524`

With this patch they are named like this:

`cockroach.kenabook.kena.2016-11-28T20_00_35Z.009524.ERROR.log`

Why?

The time stamp used to generate the file names is not guaranteed to be
monotonic (time can go backwards due to leap seconds or system
adjustments) or even to change fast enough that every new file gets a
different time stamp (time can be stalled by NTP to correct for a
skew).  The time going backwards is especially problematic, because it
can cause the apparent ordering of log files (based on their name) to
become incompatible with the actual ordering of the logging output.

How this was fixed / what's new?

- the numeric fields are formatted with a fixed width so that
  lexicographic sorting does the right thing.

- the file name extension `.log` is at the end so that utility
  programs run by users can guess what to do with a log file by just
  looking at its name.

Fixes #10936.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11666)
<!-- Reviewable:end -->
