### PR TITLE
vendor: update golang.org/x/tools

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -322,7 +322,7 @@ imports:
   - transform
   - unicode/norm
 - name: golang.org/x/tools
-  version: 167995c67fa45f3a7fc8dab62bb872212e397c11
+  version: ebf631f91765900b0af5a2010d1ee5e471db6b49
   subpackages:
   - cmd/goimports
   - cmd/goyacc


### PR DESCRIPTION
This picks up https://github.com/golang/tools/commit/ebf631f91, which
allows us to continue growing `sql.y` without incurring the wrath of
`goyacc`'s maximum number of parser states.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11671)
<!-- Reviewable:end -->
