### PR TITLE
.gitignore: ignore autogenerated datastores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@
 
 .bootstrap
 /cockroach
-/cockroach-data
+/cockroach-data*
 /cockroach-darwin*
 /certs
 # make stress, acceptance produce stress.test, acceptance.test


### PR DESCRIPTION
ignore datastores generated when running multiple nodes, i.e.
`cockroach-data1`, `cockroach-data2`, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11672)
<!-- Reviewable:end -->
