### PR TITLE
sql: fix the implementation of GROUP BY with planNodes.

### DIFF
--- a/pkg/sql/select.go
+++ b/pkg/sql/select.go
@@ -56,8 +56,9 @@ type selectNode struct {
 	// as invoked initially by initTargets() and initWhere().
 	// sortNode peeks into the render array defined by initTargets() as an optimization.
 	// sortNode adds extra selectNode renders for sort columns not requested as select targets.
-	// groupNode copies/extends the render array defined by initTargets()
+	// groupNode copies/extends the render array defined by initTargets() and
 	// will add extra selectNode renders for the aggregation sources.
+	// windowNode also adds additional renders for the window functions.
 	render  []parser.TypedExpr
 	columns ResultColumns
 
@@ -598,10 +599,28 @@ func (s *selectNode) addRender(target parser.SelectExpr, desiredType parser.Type
 	if err != nil {
 		return err
 	}
-	s.render = append(s.render, normalized)
 
-	s.columns = append(s.columns, ResultColumn{Name: outputName, Typ: normalized.ResolvedType()})
+	s.addRenderColumn(normalized, ResultColumn{Name: outputName, Typ: normalized.ResolvedType()})
+
 	return nil
+}
+
+// appendRenderColumn adds a new render expression at the end of the current list.
+// The expression must be normalized already.
+func (s *selectNode) addRenderColumn(expr parser.TypedExpr, col ResultColumn) {
+	s.render = append(s.render, expr)
+	s.columns = append(s.columns, col)
+}
+
+// resetRenderColumns resets all the render expressions. This is used e.g. by
+// aggregation and windowing (see group.go / window.go). The method also
+// asserts that both the render and columns array have the same size.
+func (s *selectNode) resetRenderColumns(exprs []parser.TypedExpr, cols ResultColumns) {
+	if len(exprs) != len(cols) {
+		panic(fmt.Sprintf("resetRenderColumns used with arrays of different sizes: %d != %d", len(exprs), len(cols)))
+	}
+	s.render = exprs
+	s.columns = cols
 }
 
 // renderRow renders the row by evaluating the render expressions.

--- a/pkg/sql/testdata/explain_types
+++ b/pkg/sql/testdata/explain_types
@@ -72,7 +72,7 @@ EXPLAIN (TYPES,NOEXPAND) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v
 0   select          having     ((v)[int] < (2)[int])[bool]
 0   select          render z   ((2)[int] * (count((k)[int]))[int])[int]
 0   select          render v   (v)[int]
-1   render/filter   result     (z int, v int, v int)
+1   render/filter   result     (k int, v int, v int, v int)
 1   render/filter   filter     ((v)[int] > (123)[int])[bool]
 1   render/filter   render 0   (k)[int]
 1   render/filter   render 1   (v)[int]
@@ -88,7 +88,7 @@ EXPLAIN (TYPES) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v
 1   group           having     ((v)[int] < (2)[int])[bool]
 1   group           render z   ((2)[int] * (count((k)[int]))[int])[int]
 1   group           render v   (v)[int]
-2   render/filter   result     (z int, v int, v int)
+2   render/filter   result     (k int, v int, v int, v int)
 2   render/filter   render 0   (k)[int]
 2   render/filter   render 1   (v)[int]
 2   render/filter   render 2   (v)[int]

--- a/pkg/sql/testdata/ordinal_references
+++ b/pkg/sql/testdata/ordinal_references
@@ -79,7 +79,7 @@ EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1;
 ----
 0  select                                                         (m)
 1  group          min(a) GROUP BY (@2)                            (m)
-2  render/filter  from (test.foo.a, test.foo.b, *test.foo.rowid)  (m, a)
+2  render/filter  from (test.foo.a, test.foo.b, *test.foo.rowid)  (a, a)
 3  scan           foo@primary -                                   (a, b, rowid[hidden])  +rowid,unique
 
 query ITTTT
@@ -87,7 +87,7 @@ EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2;
 ----
 0  select                                                         (m)
 1  group          min(a) GROUP BY (@2)                            (m)
-2  render/filter  from (test.foo.a, test.foo.b, *test.foo.rowid)  (m, b)
+2  render/filter  from (test.foo.a, test.foo.b, *test.foo.rowid)  (a, b)
 3  scan           foo@primary -                                   (a, b, rowid[hidden])  +rowid,unique
 
 statement error column reference @1 not allowed in this context


### PR DESCRIPTION
This patch ensures that the `Columns()` method on the selectNode is
always synchronized with the set of render expressions computed by
selectNode (and available via its `Values()`).

This is needed for proper translation to distSQL query plans.

Found by @irfansharif.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11682)
<!-- Reviewable:end -->
