### PR TITLE
acceptance: Add which node an error came from in failure messages

### DIFF
--- a/pkg/acceptance/admin_test.go
+++ b/pkg/acceptance/admin_test.go
@@ -45,7 +45,7 @@ func testAdminLossOfQuorumInner(t *testing.T, c cluster.Cluster, cfg cluster.Tes
 	for i := 0; i < c.NumNodes(); i++ {
 		var details serverpb.DetailsResponse
 		if err := httputil.GetJSON(cluster.HTTPClient, c.URL(i)+"/_status/details/local", &details); err != nil {
-			t.Fatal(err)
+			t.Fatalf("failed to get local details from node %d: %s", i, err)
 		}
 		nodeIDs[i] = details.NodeID
 	}

--- a/pkg/acceptance/cluster/localcluster.go
+++ b/pkg/acceptance/cluster/localcluster.go
@@ -826,13 +826,19 @@ func (l *LocalCluster) NumNodes() int {
 
 // Kill kills the i-th node.
 func (l *LocalCluster) Kill(i int) error {
-	return l.Nodes[i].Kill()
+	if err := l.Nodes[i].Kill(); err != nil {
+		return errors.Wrapf(err, "failed to kill node %d", i)
+	}
+	return nil
 }
 
 // Restart restarts the given node. If the node isn't running, this starts it.
 func (l *LocalCluster) Restart(i int) error {
 	// The default timeout is 10 seconds.
-	return l.Nodes[i].Restart(nil)
+	if err := l.Nodes[i].Restart(nil); err != nil {
+		return errors.Wrapf(err, "failed to restart node %d", i)
+	}
+	return nil
 }
 
 // URL returns the base url.

--- a/pkg/acceptance/gossip_peerings_test.go
+++ b/pkg/acceptance/gossip_peerings_test.go
@@ -55,7 +55,7 @@ func checkGossip(t *testing.T, c cluster.Cluster, d time.Duration, f checkGossip
 		var infoStatus gossip.InfoStatus
 		for i := 0; i < c.NumNodes(); i++ {
 			if err := httputil.GetJSON(cluster.HTTPClient, c.URL(i)+"/_status/gossip/local", &infoStatus); err != nil {
-				return err
+				return errors.Wrapf(err, "failed to get gossip status from node %d", i)
 			}
 			if err := f(infoStatus.Infos); err != nil {
 				return errors.Errorf("node %d: %s", i, err)


### PR DESCRIPTION
This helped me narrow down where to look when dealing with a failure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11685)
<!-- Reviewable:end -->
