### PR TITLE
scripts: add helper to restore vendor submodule after glide replacement

### DIFF
--- a/scripts/fix-vendor-submodule.sh
+++ b/scripts/fix-vendor-submodule.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# glide likes to *replace* the 'vendor' directory when it adds or updates a dep.
+# While this means that the vendor is sure what and only what is in the glide.lock
+# file, it has the unfortunate side effect of nuking the .git file that makes 
+# 'vendor/' a submodule, as well as the hand-written README in the root.
+#
+# This script restores the .git submodule pointer and then the README.
+echo 'gitdir: ../.git/modules/vendor' > vendor/.git
+git -C vendor checkout README.md


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11689)
<!-- Reviewable:end -->
