### PR TITLE
storage: include range and lease counts in snapshot responses

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -653,55 +653,6 @@ func TestSnapshotAfterTruncation(t *testing.T) {
 	mtc.waitForValues(key, []int64{incAB, incAB, incAB})
 }
 
-type fakeSnapshotStream struct {
-	nextReq *storage.SnapshotRequest
-	nextErr error
-}
-
-// Recv implements the SnapshotResponseStream interface.
-func (c fakeSnapshotStream) Recv() (*storage.SnapshotRequest, error) {
-	return c.nextReq, c.nextErr
-}
-
-// Send implements the SnapshotResponseStream interface.
-func (c fakeSnapshotStream) Send(request *storage.SnapshotResponse) error {
-	return nil
-}
-
-// Context implements the SnapshotResponseStream interface.
-func (c fakeSnapshotStream) Context() context.Context {
-	return context.Background()
-}
-
-// TestFailedSnapshotFillsReservation tests that failing to finish applying an
-// incoming snapshot still cleans up the outstanding reservation that was made.
-func TestFailedSnapshotFillsReservation(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	mtc := startMultiTestContext(t, 3)
-	defer mtc.Stop()
-
-	rep, err := mtc.stores[0].GetReplica(1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	header := storage.SnapshotRequest_Header{
-		CanDecline:      true,
-		RangeSize:       100,
-		RangeDescriptor: *rep.Desc(),
-	}
-	// Cause this stream to return an error as soon as we ask it for something.
-	// This injects an error into HandleSnapshotStream when we try to send the
-	// "snapshot accepted" message.
-	expectedErr := errors.Errorf("")
-	stream := fakeSnapshotStream{nil, expectedErr}
-	if err := mtc.stores[1].HandleSnapshot(&header, stream); err != expectedErr {
-		t.Fatalf("expected error %s, but found %v", expectedErr, err)
-	}
-	if n := mtc.stores[1].ReservationCount(); n != 0 {
-		t.Fatalf("expected 0 reservations, but found %d", n)
-	}
-}
-
 // TestConcurrentRaftSnapshots tests that snapshots still work correctly when
 // Raft requests multiple non-preemptive snapshots at the same time. This
 // situation occurs when two replicas need snapshots at the same time.


### PR DESCRIPTION
@spencerkimball @petermattis I went down the rabbit hole, so here it is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11690)
<!-- Reviewable:end -->
