### PR TITLE
sql/parser: Support ARRAY type annotations

### DIFF
--- a/pkg/sql/parser/col_types.go
+++ b/pkg/sql/parser/col_types.go
@@ -306,3 +306,34 @@ func DatumTypeToColumnType(t Type) (ColumnType, error) {
 	}
 	return nil, errors.Errorf("internal error: unknown Datum type %s", t)
 }
+
+// columnTypeToDatumType produces a Datum type equivalent to the given
+// SQL column type.
+func columnTypeToDatumType(t ColumnType) Type {
+	switch ct := t.(type) {
+	case *BoolColType:
+		return TypeBool
+	case *IntColType:
+		return TypeInt
+	case *FloatColType:
+		return TypeFloat
+	case *DecimalColType:
+		return TypeDecimal
+	case *StringColType:
+		return TypeString
+	case *BytesColType:
+		return TypeBytes
+	case *DateColType:
+		return TypeDate
+	case *TimestampColType:
+		return TypeTimestamp
+	case *TimestampTZColType:
+		return TypeTimestampTZ
+	case *IntervalColType:
+		return TypeInterval
+	case *ArrayColType:
+		return tArray{columnTypeToDatumType(ct.ParamType)}
+	default:
+		panic(errors.Errorf("unexpected ColumnType %T", t))
+	}
+}

--- a/pkg/sql/parser/eval_test.go
+++ b/pkg/sql/parser/eval_test.go
@@ -394,8 +394,7 @@ func TestEval(t *testing.T) {
 		{`lower('HELLO')`, `'hello'`},
 		{`UPPER('hello')`, `'HELLO'`},
 		// Array constructors.
-		// TODO(nathan) Test empty array literals when they become supported.
-		// {`ARRAY[]:::int[]`, `{}`},
+		{`ARRAY[]:::int[]`, `{}`},
 		{`ARRAY[NULL]`, `{NULL}`},
 		{`ARRAY[1, 2, 3]`, `{1,2,3}`},
 		{`ARRAY['a', 'b', 'c']`, `{'a','b','c'}`},
@@ -726,10 +725,6 @@ func TestEvalError(t *testing.T) {
 			`could not parse '3 4' as type interval: interval: missing unit in postgres duration 3 4`},
 		{`'3t-4 2:3'::interval`,
 			`could not parse '3t-4 2:3' as type interval: interval: invalid SQL stardard duration 3t-4`},
-		{`ANNOTATE_TYPE('a', int)`,
-			`incompatible type assertion for 'a' as int, found type: string`},
-		{`ANNOTATE_TYPE(ANNOTATE_TYPE(1, int), decimal)`,
-			`incompatible type assertion for ANNOTATE_TYPE(1, INT) as decimal, found type: int`},
 		{`b'\xff\xfe\xfd'::string`, `invalid utf8: "\xff\xfe\xfd"`},
 		{`ARRAY[NULL, ARRAY[1, 2]]`, `multidimensional arrays must have array expressions with matching dimensions`},
 		{`ARRAY[ARRAY[1, 2], NULL]`, `multidimensional arrays must have array expressions with matching dimensions`},

--- a/pkg/sql/parser/expr.go
+++ b/pkg/sql/parser/expr.go
@@ -973,6 +973,10 @@ func (node *CastExpr) Format(buf *bytes.Buffer, f FmtFlags) {
 	}
 }
 
+func (node *CastExpr) castType() Type {
+	return columnTypeToDatumType(node.Type)
+}
+
 var (
 	boolCastTypes = []Type{TypeNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString}
 	intCastTypes  = []Type{TypeNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString,
@@ -989,34 +993,29 @@ var (
 	intervalCastTypes  = []Type{TypeNull, TypeString, TypeInt, TypeInterval}
 )
 
-func colTypeToTypeAndValidArgTypes(t ColumnType) (Type, []Type) {
-	switch t.(type) {
-	case *BoolColType:
-		return TypeBool, boolCastTypes
-	case *IntColType:
-		return TypeInt, intCastTypes
-	case *FloatColType:
-		return TypeFloat, floatCastTypes
-	case *DecimalColType:
-		return TypeDecimal, decimalCastTypes
-	case *StringColType:
-		return TypeString, stringCastTypes
-	case *BytesColType:
-		return TypeBytes, bytesCastTypes
-	case *DateColType:
-		return TypeDate, dateCastTypes
-	case *TimestampColType:
-		return TypeTimestamp, timestampCastTypes
-	case *TimestampTZColType:
-		return TypeTimestampTZ, timestampCastTypes
-	case *IntervalColType:
-		return TypeInterval, intervalCastTypes
+// validCastTypes returns a set of types that can be cast into the provided type.
+func validCastTypes(t Type) []Type {
+	switch t {
+	case TypeBool:
+		return boolCastTypes
+	case TypeInt:
+		return intCastTypes
+	case TypeFloat:
+		return floatCastTypes
+	case TypeDecimal:
+		return decimalCastTypes
+	case TypeString:
+		return stringCastTypes
+	case TypeBytes:
+		return bytesCastTypes
+	case TypeDate:
+		return dateCastTypes
+	case TypeTimestamp, TypeTimestampTZ:
+		return timestampCastTypes
+	case TypeInterval:
+		return intervalCastTypes
 	}
-	return nil, nil
-}
-
-func (node *CastExpr) castTypeAndValidArgTypes() (Type, []Type) {
-	return colTypeToTypeAndValidArgTypes(node.Type)
+	return nil
 }
 
 // IndirectionExpr represents a subscript expression.
@@ -1071,8 +1070,7 @@ func (node *AnnotateTypeExpr) TypedInnerExpr() TypedExpr {
 }
 
 func (node *AnnotateTypeExpr) annotationType() Type {
-	typ, _ := colTypeToTypeAndValidArgTypes(node.Type)
-	return typ
+	return columnTypeToDatumType(node.Type)
 }
 
 // CollateExpr represents an (expr COLLATE locale) expression.

--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -191,7 +191,7 @@ func (expr *CaseExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, erro
 
 // TypeCheck implements the Expr interface.
 func (expr *CastExpr) TypeCheck(ctx *SemaContext, _ Type) (TypedExpr, error) {
-	returnDatum, validTypes := expr.castTypeAndValidArgTypes()
+	returnType := expr.castType()
 
 	// The desired type provided to a CastExpr is ignored. Instead,
 	// TypeAny is passed to the child of the cast. There are two
@@ -199,11 +199,11 @@ func (expr *CastExpr) TypeCheck(ctx *SemaContext, _ Type) (TypedExpr, error) {
 	desired := TypeAny
 	switch {
 	case isConstant(expr.Expr):
-		if canConstantBecome(expr.Expr.(Constant), returnDatum) {
+		if canConstantBecome(expr.Expr.(Constant), returnType) {
 			// If a Constant is subject to a cast which it can naturally become (which
 			// is in its resolvable type set), we desire the cast's type for the Constant,
 			// which will result in the CastExpr becoming an identity cast.
-			desired = returnDatum
+			desired = returnType
 		}
 	case ctx.isUnresolvedPlaceholder(expr.Expr):
 		// This case will be triggered if ProcessPlaceholderAnnotations found
@@ -219,10 +219,10 @@ func (expr *CastExpr) TypeCheck(ctx *SemaContext, _ Type) (TypedExpr, error) {
 	}
 
 	castFrom := typedSubExpr.ResolvedType()
-	for _, t := range validTypes {
+	for _, t := range validCastTypes(returnType) {
 		if castFrom.Equal(t) {
 			expr.Expr = typedSubExpr
-			expr.typ = returnDatum
+			expr.typ = returnType
 			return expr, nil
 		}
 	}
@@ -270,7 +270,7 @@ func (expr *IndirectionExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExp
 func (expr *AnnotateTypeExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, error) {
 	annotType := expr.annotationType()
 	subExpr, err := typeCheckAndRequire(ctx, expr.Expr, annotType,
-		fmt.Sprintf("type assertion for %v as %s, found", expr.Expr, annotType))
+		fmt.Sprintf("type annotation for %v as %s, found", expr.Expr, annotType))
 	if err != nil {
 		return nil, err
 	}
@@ -1151,7 +1151,7 @@ func (v *placeholderAnnotationVisitor) VisitPre(expr Expr) (recurse bool, newExp
 		}
 	case *CastExpr:
 		if arg, ok := t.Expr.(*Placeholder); ok {
-			castType, _ := t.castTypeAndValidArgTypes()
+			castType := t.castType()
 			if state, ok := v.placeholders[arg.Name]; ok {
 				// Ignore casts once an assertion has been seen.
 				if state.sawAssertion {

--- a/pkg/sql/parser/type_check_test.go
+++ b/pkg/sql/parser/type_check_test.go
@@ -122,6 +122,9 @@ func TestTypeCheckError(t *testing.T) {
 		{`NULLIF(1, '5')`, `incompatible NULLIF expressions: expected 1 to be of type string, found type int`},
 		{`COALESCE(1, 2, 3, 4, '5')`, `incompatible COALESCE expressions: expected 1 to be of type string, found type int`},
 		{`ARRAY[]`, `cannot determine type of empty array`},
+		{`ANNOTATE_TYPE('a', int)`, `incompatible type annotation for 'a' as int, found type: string`},
+		{`ANNOTATE_TYPE(ANNOTATE_TYPE(1, int), decimal)`, `incompatible type annotation for ANNOTATE_TYPE(1, INT) as decimal, found type: int`},
+		{`3:::int[]`, `incompatible type annotation for 3 as int[], found type: int`},
 	}
 	for _, d := range testData {
 		expr, err := ParseExprTraditional(d.expr)

--- a/pkg/sql/testdata/array
+++ b/pkg/sql/testdata/array
@@ -41,11 +41,10 @@ SELECT ARRAY(VALUES ('a'),('b'),('c'))
 query error subquery must return only one column, found 2
 SELECT ARRAY(SELECT 1, 2)
 
-# TODO(nvanbenschoten) Uncomment when int[] is added as a column type.
-# query T
-# SELECT ARRAY[]:::int[]
-# ----
-# {}
+query T
+SELECT ARRAY[]:::int[]
+----
+{}
 
 # decimal arrays are unsupported
 


### PR DESCRIPTION
Fixes #11674.

This change adds support for ARRAY type annotations. It also cleans up
code surrounding type annotations and casts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11693)
<!-- Reviewable:end -->
