### PR TITLE
sql: reuse test infrastructure in logic tests

### DIFF
--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -666,6 +666,10 @@ func (p *planner) removeFK(ref sqlbase.ForeignKeyReference, table *sqlbase.Table
 			return err
 		}
 	}
+	if table.Dropped() {
+		// The referenced table is being dropped. No need to modify it further.
+		return nil
+	}
 	idx, err := table.FindIndexByID(ref.Index)
 	if err != nil {
 		return err
@@ -678,6 +682,10 @@ func (p *planner) removeInterleave(ref sqlbase.ForeignKeyReference) error {
 	table, err := sqlbase.GetTableDescFromID(p.txn, ref.Table)
 	if err != nil {
 		return err
+	}
+	if table.Dropped() {
+		// The referenced table is being dropped. No need to modify it further.
+		return nil
 	}
 	idx, err := table.FindIndexByID(ref.Index)
 	if err != nil {
@@ -846,6 +854,10 @@ func (p *planner) removeFKBackReference(
 	if err != nil {
 		return errors.Errorf("error resolving referenced table ID %d: %v", idx.ForeignKey.Table, err)
 	}
+	if t.Dropped() {
+		// The referenced table is being dropped. No need to modify it further.
+		return nil
+	}
 	targetIdx, err := t.FindIndexByID(idx.ForeignKey.Index)
 	if err != nil {
 		return err
@@ -868,6 +880,10 @@ func (p *planner) removeInterleaveBackReference(
 	t, err := sqlbase.GetTableDescFromID(p.txn, ancestor.TableID)
 	if err != nil {
 		return errors.Errorf("error resolving referenced table ID %d: %v", ancestor.TableID, err)
+	}
+	if t.Dropped() {
+		// The referenced table is being dropped. No need to modify it further.
+		return nil
 	}
 	targetIdx, err := t.FindIndexByID(ancestor.IndexID)
 	if err != nil {

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -27,6 +27,8 @@ import (
 
 const (
 	informationSchemaName = "information_schema"
+	pgCatalogName         = "pg_catalog"
+	systemDatabaseName    = "system"
 )
 
 var informationSchema = virtualSchema{
@@ -56,6 +58,11 @@ var (
 	yesString = parser.NewDString("YES")
 	noString  = parser.NewDString("NO")
 )
+
+// IsSystemDatabaseName returns true if the input is the name of a system database.
+func IsSystemDatabaseName(name string) bool {
+	return name == informationSchemaName || name == pgCatalogName || name == systemDatabaseName
+}
 
 func yesOrNoDatum(b bool) parser.Datum {
 	if b {

--- a/pkg/sql/logic_test.go
+++ b/pkg/sql/logic_test.go
@@ -370,10 +370,36 @@ func (t *logicTest) close() {
 		t.cleanupRootUser()
 		t.cleanupRootUser = nil
 	}
-	if t.srv != nil {
-		t.srv.Stopper().Stop()
-		t.srv = nil
+	cleanup := t.setUser(security.RootUser)
+	// Drop all databases that were created in the test.
+	var toDrop []string
+	func() {
+		rows, err := t.db.Query("SHOW DATABASES")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var dbName string
+			if err := rows.Scan(&dbName); err != nil {
+				t.Fatal(err)
+			}
+			if sql.IsSystemDatabaseName(dbName) {
+				continue
+			}
+			toDrop = append(toDrop, dbName)
+		}
+	}()
+	for _, dbName := range toDrop {
+		fmt.Printf("dropping database %s...\n", dbName)
+		if _, err := t.db.Exec(fmt.Sprintf("DROP DATABASE %s", dbName)); err != nil {
+			t.Fatal(err)
+		}
 	}
+	if _, err := t.db.Exec("DELETE FROM system.users WHERE username=$1", server.TestUser); err != nil {
+		t.Fatal(err)
+	}
+	cleanup()
 	if t.clients != nil {
 		for _, c := range t.clients {
 			c.Close()
@@ -438,22 +464,6 @@ func (t *logicTest) setUser(user string) func() {
 }
 
 func (t *logicTest) setup() {
-	// TODO(pmattis): Add a flag to make it easy to run the tests against a local
-	// MySQL or Postgres instance.
-	// TODO(andrei): if createTestServerParams() is used here, the command filter
-	// it installs detects a transaction that doesn't have
-	// modifiedSystemConfigSpan set even though it should, for
-	// "testdata/rename_table". Figure out what's up with that.
-	params := base.TestServerArgs{
-		Knobs: base.TestingKnobs{
-			SQLExecutor: &sql.ExecutorTestingKnobs{
-				WaitForGossipUpdate:   true,
-				CheckStmtStringChange: true,
-			},
-		},
-	}
-	t.srv, _, _ = serverutils.StartServer(t.T, params)
-
 	// db may change over the lifetime of this function, with intermediate
 	// values cached in t.clients and finally closed in t.close().
 	t.cleanupRootUser = t.setUser(security.RootUser)
@@ -1105,9 +1115,31 @@ func TestLogic(t *testing.T) {
 		verbose:         testing.Verbose() || log.V(1),
 		perErrorSummary: make(map[string][]string),
 	}
-	if *printErrorSummary {
-		defer l.printErrorSummary()
+	// TODO(pmattis): Add a flag to make it easy to run the tests against a local
+	// MySQL or Postgres instance.
+	// TODO(andrei): if createTestServerParams() is used here, the command filter
+	// it installs detects a transaction that doesn't have
+	// modifiedSystemConfigSpan set even though it should, for
+	// "testdata/rename_table". Figure out what's up with that.
+	params := base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLExecutor: &sql.ExecutorTestingKnobs{
+				WaitForGossipUpdate:   true,
+				CheckStmtStringChange: true,
+			},
+		},
 	}
+	l.srv, _, _ = serverutils.StartServer(l.T, params)
+	defer func() {
+		if l.srv != nil {
+			l.srv.Stopper().Stop()
+			l.srv = nil
+
+			if *printErrorSummary {
+				l.printErrorSummary()
+			}
+		}
+	}()
 	for _, path := range paths {
 		t.Run(path, func(t *testing.T) {
 			// the `t` given to this anonymous function may be different

--- a/pkg/sql/logic_test.go
+++ b/pkg/sql/logic_test.go
@@ -396,6 +396,9 @@ func (t *logicTest) close() {
 			t.Fatal(err)
 		}
 	}
+	if _, err := t.db.Exec("DELETE FROM system.eventlog"); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := t.db.Exec("DELETE FROM system.users WHERE username=$1", server.TestUser); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -40,7 +40,6 @@ var (
 )
 
 const (
-	pgCatalogName          = "pg_catalog"
 	cockroachIndexEncoding = "prefix"
 )
 

--- a/pkg/sql/testdata/multi_statement
+++ b/pkg/sql/testdata/multi_statement
@@ -61,3 +61,6 @@ ROLLBACK
 
 statement error pq: table "system.t" does not exist
 BEGIN TRANSACTION; SELECT * FROM system.t; INSERT INTO t(a) VALUES (1);
+
+statement ok
+COMMIT

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -145,29 +145,40 @@ oid         nspname             nspowner  aclitem
 
 ## pg_catalog.pg_database
 
-query ITIITTBB colnames
-SELECT oid, datname, datdba, encoding, datcollate, datctype, datistemplate, datallowconn
+query IT colnames
+SELECT oid, datname
 FROM pg_catalog.pg_database
+WHERE datname != 'constraint_db' AND datname != 'test'
 ORDER BY oid
 ----
-oid         datname             datdba  encoding  datcollate  datctype    datistemplate  datallowconn
-381876367   system              NULL    6         en_US.utf8  en_US.utf8  false          true
-437457361   constraint_db       NULL    6         en_US.utf8  en_US.utf8  false          true
-1965331359  test                NULL    6         en_US.utf8  en_US.utf8  false          true
-2157629366  pg_catalog          NULL    6         en_US.utf8  en_US.utf8  false          true
-3177026209  information_schema  NULL    6         en_US.utf8  en_US.utf8  false          true
+oid         datname
+381876367   system
+2157629366  pg_catalog
+3177026209  information_schema
 
-query ITIIIIIT colnames
-SELECT oid, datname, datconnlimit, datlastsysoid, datfrozenxid, datminmxid, dattablespace, datacl
+query TIITTBB colnames
+SELECT datname, datdba, encoding, datcollate, datctype, datistemplate, datallowconn
 FROM pg_catalog.pg_database
-ORDER BY oid
+ORDER BY datname
 ----
-oid         datname             datconnlimit  datlastsysoid  datfrozenxid  datminmxid  dattablespace  datacl
-381876367   system              -1            NULL           NULL          NULL        NULL           NULL
-437457361   constraint_db       -1            NULL           NULL          NULL        NULL           NULL
-1965331359  test                -1            NULL           NULL          NULL        NULL           NULL
-2157629366  pg_catalog          -1            NULL           NULL          NULL        NULL           NULL
-3177026209  information_schema  -1            NULL           NULL          NULL        NULL           NULL
+datname             datdba  encoding  datcollate  datctype    datistemplate  datallowconn
+constraint_db       NULL    6         en_US.utf8  en_US.utf8  false          true
+information_schema  NULL    6         en_US.utf8  en_US.utf8  false          true
+pg_catalog          NULL    6         en_US.utf8  en_US.utf8  false          true
+system              NULL    6         en_US.utf8  en_US.utf8  false          true
+test                NULL    6         en_US.utf8  en_US.utf8  false          true
+
+query TIIIIIT colnames
+SELECT datname, datconnlimit, datlastsysoid, datfrozenxid, datminmxid, dattablespace, datacl
+FROM pg_catalog.pg_database
+ORDER BY datname
+----
+datname             datconnlimit  datlastsysoid  datfrozenxid  datminmxid  dattablespace  datacl
+constraint_db       -1            NULL           NULL          NULL        NULL           NULL
+information_schema  -1            NULL           NULL          NULL        NULL           NULL
+pg_catalog          -1            NULL           NULL          NULL        NULL           NULL
+system              -1            NULL           NULL          NULL        NULL           NULL
+test                -1            NULL           NULL          NULL        NULL           NULL
 
 ## pg_catalog.pg_tables
 
@@ -197,24 +208,24 @@ constraint_db  v1        NULL       SELECT p, a, b, c FROM constraint_db.t1
 
 ## pg_catalog.pg_class
 
-query ITIIIIII colnames
-SELECT c.oid, relname, relnamespace, reltype, relowner, relam, relfilenode, reltablespace
+query TIIIIII colnames
+SELECT relname, relnamespace, reltype, relowner, relam, relfilenode, reltablespace
 FROM pg_catalog.pg_class c
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ----
-oid         relname       relnamespace  reltype  relowner  relam  relfilenode  reltablespace
-2876473678  t1            268867073     0        NULL      NULL   0            0
-335779562   primary       268867073     0        NULL      NULL   0            0
-335779561   t1_a_key      268867073     0        NULL      NULL   0            0
-335779560   index_key     268867073     0        NULL      NULL   0            0
-3110815990  t2            268867073     0        NULL      NULL   0            0
-4235777034  primary       268867073     0        NULL      NULL   0            0
-4235777033  t2_t1_ID_idx  268867073     0        NULL      NULL   0            0
-3211628798  t3            268867073     0        NULL      NULL   0            0
-624432002   primary       268867073     0        NULL      NULL   0            0
-624432001   t3_a_b_idx    268867073     0        NULL      NULL   0            0
-2875635133  v1            268867073     0        NULL      NULL   0            0
+relname       relnamespace  reltype  relowner  relam  relfilenode  reltablespace
+t1            268867073     0        NULL      NULL   0            0
+primary       268867073     0        NULL      NULL   0            0
+t1_a_key      268867073     0        NULL      NULL   0            0
+index_key     268867073     0        NULL      NULL   0            0
+t2            268867073     0        NULL      NULL   0            0
+primary       268867073     0        NULL      NULL   0            0
+t2_t1_ID_idx  268867073     0        NULL      NULL   0            0
+t3            268867073     0        NULL      NULL   0            0
+primary       268867073     0        NULL      NULL   0            0
+t3_a_b_idx    268867073     0        NULL      NULL   0            0
+v1            268867073     0        NULL      NULL   0            0
 
 query TIRIIBB colnames
 SELECT relname, relpages, reltuples, relallvisible, reltoastrelid, relhasindex, relisshared
@@ -371,16 +382,17 @@ oid         amname  amhandler  amtype
 
 ## pg_catalog.pg_attrdef
 
-query ITIITT colnames
-SELECT ad.oid, c.relname, adrelid, adnum, adbin, adsrc
+query TIITT colnames
+SELECT c.relname, adrelid, adnum, adbin, adsrc
 FROM pg_catalog.pg_attrdef ad
 JOIN pg_catalog.pg_class c ON ad.adrelid = c.oid
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
+ORDER BY relname
 ----
-oid         relname  adrelid     adnum  adbin  adsrc
-2737381215  t1       2876473678  4      12     12
-2989572986  t3       3211628798  3      'FOO'  'FOO'
+relname  adrelid     adnum  adbin  adsrc
+t1       2876473678  4      12     12
+t3       3211628798  3      'FOO'  'FOO'
 
 ## pg_catalog.pg_indexes
 
@@ -898,12 +910,13 @@ SELECT pg_catalog.pg_get_expr('1', 0, true)
 ----
 1
 
-query ITT
-SELECT def.oid, c.relname, pg_catalog.pg_get_expr(def.adbin, def.adrelid)
+query TT
+SELECT c.relname, pg_catalog.pg_get_expr(def.adbin, def.adrelid)
 FROM pg_catalog.pg_attrdef def
 JOIN pg_catalog.pg_class c ON def.adrelid = c.oid
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
+ORDER BY c.relname
 ----
-2737381215  t1  12
-2989572986  t3  'FOO'
+t1  12
+t3  'FOO'

--- a/pkg/sql/testdata/system
+++ b/pkg/sql/testdata/system
@@ -18,25 +18,28 @@ ui
 users
 zones
 
+# This database descriptor might not have a consistent ID, so stick with
+# testing system databases.
+statement ok
+DROP DATABASE test;
+
 query ITTT
-EXPLAIN (DEBUG) SELECT * FROM system.namespace
+EXPLAIN (DEBUG) SELECT parentID, name FROM system.namespace
 ----
-0 /namespace/primary/0/'system'/id     1    ROW
-1 /namespace/primary/0/'test'/id       50   ROW
-2 /namespace/primary/1/'descriptor'/id 3    ROW
-3 /namespace/primary/1/'eventlog'/id   12   ROW
-4 /namespace/primary/1/'lease'/id      11   ROW
-5 /namespace/primary/1/'namespace'/id  2    ROW
-6 /namespace/primary/1/'rangelog'/id   13   ROW
-7 /namespace/primary/1/'ui'/id         14   ROW
-8 /namespace/primary/1/'users'/id      4    ROW
-9 /namespace/primary/1/'zones'/id      5    ROW
+0 /namespace/primary/0/'system'/id     ROW
+2 /namespace/primary/1/'descriptor'/id ROW
+3 /namespace/primary/1/'eventlog'/id   ROW
+4 /namespace/primary/1/'lease'/id      ROW
+5 /namespace/primary/1/'namespace'/id  ROW
+6 /namespace/primary/1/'rangelog'/id   ROW
+7 /namespace/primary/1/'ui'/id         ROW
+8 /namespace/primary/1/'users'/id      ROW
+9 /namespace/primary/1/'zones'/id      ROW
 
 query ITI
 SELECT * FROM system.namespace
 ----
 0 system     1
-0 test       50
 1 descriptor 3
 1 eventlog   12
 1 lease      11
@@ -58,7 +61,6 @@ SELECT id FROM system.descriptor
 12
 13
 14
-50
 
 # Verify we can read "protobuf" columns.
 query I


### PR DESCRIPTION
This commit changes the behavior of `LogicTest` to not have to spin up and down a test server for every single subtest. Now, it spins up a single test server and cleans up created resources in between each subtest.

This is currently blocked on the resolution of #11701.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11719)
<!-- Reviewable:end -->
