### PR TITLE
sql: implement trivial pg_catalog.pg_range

### DIFF
--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -62,6 +62,7 @@ var pgCatalog = virtualSchema{
 		pgCatalogIndexesTable,
 		pgCatalogNamespaceTable,
 		pgCatalogProcTable,
+		pgCatalogRangeTable,
 		pgCatalogRolesTable,
 		pgCatalogSettingsTable,
 		pgCatalogTablesTable,
@@ -1046,6 +1047,26 @@ CREATE TABLE pg_catalog.pg_proc (
 				}
 			}
 		}
+		return nil
+	},
+}
+
+// See: https://www.postgresql.org/docs/9.6/static/view-pg-range.html.
+var pgCatalogRangeTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE pg_catalog.pg_range (
+	rngtypid INT,
+	rngsubtype INT,
+	rngcollation INT,
+	rngsubopc INT,
+	rngcanonical INT,
+	rngsubdiff INT
+);
+`,
+	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+		// We currently do not support any range types, so this table is empty.
+		// This table should be populated when any range types are added to
+		// oidToDatum (and therefore pg_type).
 		return nil
 	},
 }

--- a/pkg/sql/testdata/information_schema
+++ b/pkg/sql/testdata/information_schema
@@ -358,6 +358,7 @@ pg_index
 pg_indexes
 pg_namespace
 pg_proc
+pg_range
 pg_roles
 pg_settings
 pg_tables
@@ -392,6 +393,7 @@ pg_type
 pg_tables
 pg_settings
 pg_roles
+pg_range
 pg_proc
 pg_namespace
 pg_indexes
@@ -433,6 +435,7 @@ def            pg_catalog          pg_index           SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_proc            SYSTEM VIEW  1
+def            pg_catalog          pg_range           SYSTEM VIEW  1
 def            pg_catalog          pg_roles           SYSTEM VIEW  1
 def            pg_catalog          pg_settings        SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1
@@ -483,6 +486,7 @@ def            pg_catalog          pg_index           SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_proc            SYSTEM VIEW  1
+def            pg_catalog          pg_range           SYSTEM VIEW  1
 def            pg_catalog          pg_roles           SYSTEM VIEW  1
 def            pg_catalog          pg_settings        SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1
@@ -522,6 +526,7 @@ def            pg_catalog          pg_index           SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_proc            SYSTEM VIEW  1
+def            pg_catalog          pg_range           SYSTEM VIEW  1
 def            pg_catalog          pg_roles           SYSTEM VIEW  1
 def            pg_catalog          pg_settings        SYSTEM VIEW  1
 def            pg_catalog          pg_tables          SYSTEM VIEW  1

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -56,6 +56,7 @@ pg_index
 pg_indexes
 pg_namespace
 pg_proc
+pg_range
 pg_roles
 pg_settings
 pg_tables
@@ -809,6 +810,12 @@ WHERE proname='least'
 ----
 proname  provariadic  pronargs  prorettype  proargtypes  proargmodes
 least    2283         1         2283        2283         v
+
+## pg_catalog.pg_range
+query IIIIII colnames
+SELECT * from pg_catalog.pg_range
+----
+rngtypid  rngsubtype  rngcollation  rngsubopc  rngcanonical  rngsubdiff
 
 ## pg_catalog.pg_roles
 


### PR DESCRIPTION
This commit adds trivial support for pg_catalog.pg_range. This table
contains information on range types. We currently do not support any
range types, so we implement this as an empty table.

Closes #10762

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11725)
<!-- Reviewable:end -->
