### PR TITLE
storage: set minLeaseTransferInterval to 1s

### DIFF
--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -39,14 +39,11 @@ const (
 	// replicateQueueTimerDuration is the duration between replication of queued
 	// replicas.
 	replicateQueueTimerDuration = 0 // zero duration to process replication greedily
-)
 
-var (
 	// minLeaseTransferInterval controls how frequently leases can be transferred
 	// for rebalancing. It does not prevent transferring leases in order to allow
-	// a replica to be removed from a range. The value should be some reasonable
-	// fraction of the store descriptor gossip interval which currently
-	minLeaseTransferInterval = gossip.GossipStoresInterval / 5
+	// a replica to be removed from a range.
+	minLeaseTransferInterval = time.Second
 )
 
 // replicateQueue manages a queue of replicas which may need to add an


### PR DESCRIPTION
The recent change to GossipStoresInterval from 5s to 60s slowed lease
transfers down too much. Now that store gossiping is reactive (and thus
occurs at varying frequency) we can't easily base
minLeaseTransferInterval on it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11729)
<!-- Reviewable:end -->
