### PR TITLE
sql: avoid splitting the planner when expanding sub-queries

### DIFF
--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/mon"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -78,6 +79,8 @@ type planner struct {
 	nameResolutionVisitor       nameResolutionVisitor
 
 	execCfg *ExecutorConfig
+
+	noCopy util.NoCopy
 }
 
 // makePlanner creates a new planner instances, referencing a dummy Session.

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/mon"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -106,6 +107,8 @@ type Session struct {
 	// statistics for result sets (which escape transactions).
 	mon        mon.MemoryMonitor
 	sessionMon mon.MemoryMonitor
+
+	noCopy util.NoCopy
 }
 
 // SessionArgs contains arguments for creating a new Session with NewSession().

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -323,8 +323,11 @@ func (v *subqueryVisitor) VisitPre(expr parser.Expr) (recurse bool, newExpr pars
 		}
 	}
 
-	planMaker := *v.planner
-	plan, err := planMaker.newPlan(sq.Select, nil, false)
+	// Calling newPlan() might recursively invoke expandSubqueries, so we need to preserve
+	// the state of the visitor across the call to newPlan().
+	visitorCopy := v.planner.subqueryVisitor
+	plan, err := v.planner.newPlan(sq.Select, nil, false)
+	v.planner.subqueryVisitor = visitorCopy
 	if err != nil {
 		v.err = err
 		return false, expr


### PR DESCRIPTION
Prior to this patch, the code that expands sub-queries would duplicate
the `planner` object to create the sub-query planNode's
recursively. This was perceived to be needed, as indicated by a
previous comment that had been erased in
4acdc8a77e8554180ca0fbda8b3d14dc7ad35482, because there may be nested
sub-queries that would cause the `subqueryVisitor` embedded in planner
to be reset during the recursion.

The problem with this approach is that whichever leases were acquired
by the sub-queries, and embedded in the planner copy, are then lost
after the sub-query is replaced and cannot be released at the end of
the session.

This patch fixes this problem by ensuring the same planner object is
reused throughout the recursion, and preserves only the state of the
embedded `subqueryVisitor` across the recursive call.

A proper long-term protection against this type of issue would be to
avoid embedding visitors in the planner object, and instead managing a
cache of visitor objects if profiling shows that visitor allocation is
hurting performance.

Fixes #11701.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11730)
<!-- Reviewable:end -->
