### PR TITLE
storage: change allocator metrics to counters

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -649,7 +649,7 @@ func (n *Node) startComputePeriodicMetrics(stopper *stop.Stopper, interval time.
 		for tick := 0; ; tick++ {
 			select {
 			case <-ticker.C:
-				if err := n.computePeriodicMetrics(tick); err != nil {
+				if err := n.computePeriodicMetrics(ctx, tick); err != nil {
 					log.Errorf(ctx, "failed computing periodic metrics: %s", err)
 				}
 			case <-stopper.ShouldStop():
@@ -661,10 +661,9 @@ func (n *Node) startComputePeriodicMetrics(stopper *stop.Stopper, interval time.
 
 // computePeriodicMetrics instructs each store to compute the value of
 // complicated metrics.
-func (n *Node) computePeriodicMetrics(tick int) error {
+func (n *Node) computePeriodicMetrics(ctx context.Context, tick int) error {
 	return n.stores.VisitStores(func(store *storage.Store) error {
-		if err := store.ComputeMetrics(tick); err != nil {
-			ctx := n.AnnotateCtx(context.TODO())
+		if err := store.ComputeMetrics(ctx, tick); err != nil {
 			log.Warningf(ctx, "%s: unable to compute metrics: %s", store, err)
 		}
 		return nil

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -561,7 +561,7 @@ func TestStatusSummaries(t *testing.T) {
 	// were multiple replicas, more care would need to be taken in the initial
 	// syncFeed().
 	forceWriteStatus := func() {
-		if err := ts.node.computePeriodicMetrics(0); err != nil {
+		if err := ts.node.computePeriodicMetrics(ctx, 0); err != nil {
 			t.Fatalf("error publishing store statuses: %s", err)
 		}
 

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -173,7 +173,7 @@ func startServer(t *testing.T) *TestServer {
 	// Make sure the node status is available. This is done by forcing stores to
 	// publish their status, synchronizing to the event feed with a canary
 	// event, and then forcing the server to write summaries immediately.
-	if err := ts.node.computePeriodicMetrics(0); err != nil {
+	if err := ts.node.computePeriodicMetrics(context.TODO(), 0); err != nil {
 		t.Fatalf("error publishing store statuses: %s", err)
 	}
 

--- a/pkg/storage/client_metrics_test.go
+++ b/pkg/storage/client_metrics_test.go
@@ -135,7 +135,7 @@ func verifyStats(t *testing.T, mtc *multiTestContext, storeIdxSlice ...int) {
 }
 
 func verifyRocksDBStats(t *testing.T, s *storage.Store) {
-	if err := s.ComputeMetrics(0); err != nil {
+	if err := s.ComputeMetrics(context.TODO(), 0); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -52,9 +52,8 @@ func (s *Store) ComputeMVCCStats() (enginepb.MVCCStats, error) {
 	var totalStats enginepb.MVCCStats
 	var err error
 
-	visitor := newStoreReplicaVisitor(s)
 	now := s.Clock().PhysicalNow()
-	visitor.Visit(func(r *Replica) bool {
+	newStoreReplicaVisitor(s).Visit(func(r *Replica) bool {
 		var stats enginepb.MVCCStats
 		stats, err = ComputeStatsForRange(r.Desc(), s.Engine(), now)
 		if err != nil {

--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -33,7 +33,7 @@ var (
 	metaRaftLeaderCount               = metric.Metadata{Name: "replicas.leaders"}
 	metaRaftLeaderNotLeaseHolderCount = metric.Metadata{
 		Name: "replicas.leaders_not_leaseholders",
-		Help: "Total number of Replicas that are Raft leaders whose Range lease is held by another store.",
+		Help: "Number of replicas that are Raft leaders whose range lease is held by another store",
 	}
 	metaLeaseHolderCount = metric.Metadata{Name: "replicas.leaseholders"}
 	metaQuiescentCount   = metric.Metadata{Name: "replicas.quiescent"}
@@ -131,51 +131,51 @@ var (
 	// Raft message metrics.
 	metaRaftRcvdProp = metric.Metadata{
 		Name: "raft.rcvd.prop",
-		Help: "Total number of MsgProp messages received by this store",
+		Help: "Number of MsgProp messages received by this store",
 	}
 	metaRaftRcvdApp = metric.Metadata{
 		Name: "raft.rcvd.app",
-		Help: "Total number of MsgApp messages received by this store",
+		Help: "Number of MsgApp messages received by this store",
 	}
 	metaRaftRcvdAppResp = metric.Metadata{
 		Name: "raft.rcvd.appresp",
-		Help: "Total number of MsgAppResp messages received by this store",
+		Help: "Number of MsgAppResp messages received by this store",
 	}
 	metaRaftRcvdVote = metric.Metadata{
 		Name: "raft.rcvd.vote",
-		Help: "Total number of MsgVote messages received by this store",
+		Help: "Number of MsgVote messages received by this store",
 	}
 	metaRaftRcvdVoteResp = metric.Metadata{
 		Name: "raft.rcvd.voteresp",
-		Help: "Total number of MsgVoteResp messages received by this store",
+		Help: "Number of MsgVoteResp messages received by this store",
 	}
 	metaRaftRcvdPreVote = metric.Metadata{
 		Name: "raft.rcvd.prevote",
-		Help: "Total number of MsgPreVote messages received by this store",
+		Help: "Number of MsgPreVote messages received by this store",
 	}
 	metaRaftRcvdPreVoteResp = metric.Metadata{
 		Name: "raft.rcvd.prevoteresp",
-		Help: "Total number of MsgPreVoteResp messages received by this store",
+		Help: "Number of MsgPreVoteResp messages received by this store",
 	}
 	metaRaftRcvdSnap = metric.Metadata{
 		Name: "raft.rcvd.snap",
-		Help: "Total number of MsgSnap messages received by this store",
+		Help: "Number of MsgSnap messages received by this store",
 	}
 	metaRaftRcvdHeartbeat = metric.Metadata{
 		Name: "raft.rcvd.heartbeat",
-		Help: "Total number of (coalesced, if enabled) MsgHeartbeat messages received by this store",
+		Help: "Number of (coalesced, if enabled) MsgHeartbeat messages received by this store",
 	}
 	metaRaftRcvdHeartbeatResp = metric.Metadata{
 		Name: "raft.rcvd.heartbeatresp",
-		Help: "Total number of (coalesced, if enabled) MsgHeartbeatResp messages received by this store",
+		Help: "Number of (coalesced, if enabled) MsgHeartbeatResp messages received by this store",
 	}
 	metaRaftRcvdTransferLeader = metric.Metadata{
 		Name: "raft.rcvd.transferleader",
-		Help: "Total number of MsgTransferLeader messages received by this store",
+		Help: "Number of MsgTransferLeader messages received by this store",
 	}
 	metaRaftRcvdTimeoutNow = metric.Metadata{
 		Name: "raft.rcvd.timeoutnow",
-		Help: "Total number of MsgTimeoutNow messages received by this store",
+		Help: "Number of MsgTimeoutNow messages received by this store",
 	}
 	metaRaftRcvdDropped = metric.Metadata{
 		Name: "raft.rcvd.dropped",
@@ -200,13 +200,13 @@ var (
 	metaGCQueueProcessingNanos = metric.Metadata{Name: "queue.gc.processingnanos",
 		Help: "Nanoseconds spent processing replicas in the GC queue"}
 	metaRaftLogQueueSuccesses = metric.Metadata{Name: "queue.raftlog.process.success",
-		Help: "Number of replicas successfully processed by the raft log queue"}
+		Help: "Number of replicas successfully processed by the Raft log queue"}
 	metaRaftLogQueueFailures = metric.Metadata{Name: "queue.raftlog.process.failure",
-		Help: "Number of replicas which failed processing in the raft log queue"}
+		Help: "Number of replicas which failed processing in the Raft log queue"}
 	metaRaftLogQueuePending = metric.Metadata{Name: "queue.raftlog.pending",
-		Help: "Number of pending replicas in the raft log queue"}
+		Help: "Number of pending replicas in the Raft log queue"}
 	metaRaftLogQueueProcessingNanos = metric.Metadata{Name: "queue.raftlog.processingnanos",
-		Help: "Nanoseconds spent processing replicas in the raft log queue"}
+		Help: "Nanoseconds spent processing replicas in the Raft log queue"}
 	metaConsistencyQueueSuccesses = metric.Metadata{Name: "queue.consistency.process.success",
 		Help: "Number of replicas successfully processed by the consistency checker queue"}
 	metaConsistencyQueueFailures = metric.Metadata{Name: "queue.consistency.process.failure",
@@ -259,7 +259,7 @@ var (
 	metaGCIntentTxns = metric.Metadata{Name: "queue.gc.info.intenttxns",
 		Help: "Number of associated distinct transactions"}
 	metaGCTransactionSpanScanned = metric.Metadata{Name: "queue.gc.info.transactionspanscanned",
-		Help: "Total number of entries in the transaction span scanned from the engine"}
+		Help: "Number of entries in the transaction span scanned from the engine"}
 	metaGCTransactionSpanGCAborted = metric.Metadata{Name: "queue.gc.info.transactionspangcaborted",
 		Help: "Number of GC'able entries corresponding to aborted txns"}
 	metaGCTransactionSpanGCCommitted = metric.Metadata{Name: "queue.gc.info.transactionspangccommitted",
@@ -267,15 +267,15 @@ var (
 	metaGCTransactionSpanGCPending = metric.Metadata{Name: "queue.gc.info.transactionspangcpending",
 		Help: "Number of GC'able entries corresponding to pending txns"}
 	metaGCAbortSpanScanned = metric.Metadata{Name: "queue.gc.info.abortspanscanned",
-		Help: "Total number of transactions present in the abort cache scanned from the engine"}
+		Help: "Number of transactions present in the abort cache scanned from the engine"}
 	metaGCAbortSpanConsidered = metric.Metadata{Name: "queue.gc.info.abortspanconsidered",
 		Help: "Number of abort cache entries old enough to be considered for removal"}
 	metaGCAbortSpanGCNum = metric.Metadata{Name: "queue.gc.info.abortspangcnum",
 		Help: "Number of abort cache entries fit for removal"}
 	metaGCPushTxn = metric.Metadata{Name: "queue.gc.info.pushtxn",
-		Help: "Total number of attempted pushes"}
+		Help: "Number of attempted pushes"}
 	metaGCResolveTotal = metric.Metadata{Name: "queue.gc.info.resolvetotal",
-		Help: "Total number of attempted intent resolutions"}
+		Help: "Number of attempted intent resolutions"}
 	metaGCResolveSuccess = metric.Metadata{Name: "queue.gc.info.resolvesuccess",
 		Help: "Number of successful intent resolutions"}
 
@@ -324,7 +324,7 @@ type StoreMetrics struct {
 	ReplicaAllocatorRemoveDeadCount *metric.Gauge
 
 	// Lease request metrics for successful and failed lease requests. These
-	// count proposals (i.e. it does not matter how many Replicas apply the
+	// count proposals (i.e. it does not matter how many replicas apply the
 	// lease).
 	LeaseRequestSuccessCount *metric.Counter
 	LeaseRequestErrorCount   *metric.Counter

--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -58,14 +58,12 @@ var (
 		Help: "Number of read-only commands in all CommandQueues combined"}
 
 	// Range metrics.
-	metaRangeCount          = metric.Metadata{Name: "ranges"}
-	metaAvailableRangeCount = metric.Metadata{Name: "ranges.available"}
-
-	// Replication metrics.
-	metaReplicaAllocatorNoopCount       = metric.Metadata{Name: "ranges.allocator.noop"}
-	metaReplicaAllocatorRemoveCount     = metric.Metadata{Name: "ranges.allocator.remove"}
-	metaReplicaAllocatorAddCount        = metric.Metadata{Name: "ranges.allocator.add"}
-	metaReplicaAllocatorRemoveDeadCount = metric.Metadata{Name: "ranges.allocator.removedead"}
+	metaRangeCount = metric.Metadata{Name: "ranges",
+		Help: "Number of ranges"}
+	metaAvailableRangeCount = metric.Metadata{Name: "ranges.available",
+		Help: "Number of ranges with a quorum of live replicas"}
+	metaUnderReplicatedRangeCount = metric.Metadata{Name: "ranges.underreplicated",
+		Help: "Number of ranges with fewer than the configured number of live replicas"}
 
 	// Lease request metrics.
 	metaLeaseRequestSuccessCount = metric.Metadata{Name: "leases.success"}
@@ -314,14 +312,9 @@ type StoreMetrics struct {
 	CombinedCommandReadCount  *metric.Gauge
 
 	// Range metrics.
-	RangeCount          *metric.Gauge
-	AvailableRangeCount *metric.Gauge
-
-	// Replication metrics.
-	ReplicaAllocatorNoopCount       *metric.Gauge
-	ReplicaAllocatorRemoveCount     *metric.Gauge
-	ReplicaAllocatorAddCount        *metric.Gauge
-	ReplicaAllocatorRemoveDeadCount *metric.Gauge
+	RangeCount                *metric.Gauge
+	AvailableRangeCount       *metric.Gauge
+	UnderReplicatedRangeCount *metric.Gauge
 
 	// Lease request metrics for successful and failed lease requests. These
 	// count proposals (i.e. it does not matter how many replicas apply the
@@ -489,14 +482,9 @@ func newStoreMetrics(sampleInterval time.Duration) *StoreMetrics {
 		CombinedCommandReadCount:  metric.NewGauge(metaCombinedCommandReadCount),
 
 		// Range metrics.
-		RangeCount:          metric.NewGauge(metaRangeCount),
-		AvailableRangeCount: metric.NewGauge(metaAvailableRangeCount),
-
-		// Replication metrics.
-		ReplicaAllocatorNoopCount:       metric.NewGauge(metaReplicaAllocatorNoopCount),
-		ReplicaAllocatorRemoveCount:     metric.NewGauge(metaReplicaAllocatorRemoveCount),
-		ReplicaAllocatorAddCount:        metric.NewGauge(metaReplicaAllocatorAddCount),
-		ReplicaAllocatorRemoveDeadCount: metric.NewGauge(metaReplicaAllocatorRemoveDeadCount),
+		RangeCount:                metric.NewGauge(metaRangeCount),
+		AvailableRangeCount:       metric.NewGauge(metaAvailableRangeCount),
+		UnderReplicatedRangeCount: metric.NewGauge(metaUnderReplicatedRangeCount),
 
 		// Lease request metrics.
 		LeaseRequestSuccessCount: metric.NewCounter(metaLeaseRequestSuccessCount),

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -199,30 +199,31 @@ func (rq *replicateQueue) processOneChange(
 	ctx context.Context, now hlc.Timestamp, repl *Replica, sysCfg config.SystemConfig,
 ) error {
 	desc := repl.Desc()
-	// Find the zone config for this range.
-	zone, err := sysCfg.GetZoneConfigForKey(desc.StartKey)
-	if err != nil {
-		return err
-	}
-	action, _ := rq.allocator.ComputeAction(zone, desc)
 
 	// Avoid taking action if the range has too many dead replicas to make
 	// quorum.
 	deadReplicas := rq.allocator.storePool.deadReplicas(desc.RangeID, desc.Replicas)
-	quorum := computeQuorum(len(desc.Replicas))
-	liveReplicaCount := len(desc.Replicas) - len(deadReplicas)
-	if liveReplicaCount < quorum {
-		return errors.Errorf("range requires a replication change, but lacks a quorum of live nodes.")
+	{
+		quorum := computeQuorum(len(desc.Replicas))
+		liveReplicaCount := len(desc.Replicas) - len(deadReplicas)
+		if liveReplicaCount < quorum {
+			return errors.Errorf("range requires a replication change, but lacks a quorum of live replicas (%d/%d)", liveReplicaCount, quorum)
+		}
 	}
 
-	switch action {
+	zone, err := sysCfg.GetZoneConfigForKey(desc.StartKey)
+	if err != nil {
+		return err
+	}
+
+	switch action, _ := rq.allocator.ComputeAction(zone, desc); action {
 	case AllocatorAdd:
 		log.Event(ctx, "adding a new replica")
 		newStore, err := rq.allocator.AllocateTarget(
 			zone.Constraints,
 			desc.Replicas,
 			desc.RangeID,
-			true,
+			true, /* relaxConstraints */
 		)
 		if err != nil {
 			return err
@@ -263,17 +264,12 @@ func (rq *replicateQueue) processOneChange(
 			// need to be able to transfer leases in AllocatorRemove in order to get
 			// out of situations where this store is overfull and yet holds all the
 			// leases.
-			candidates := filterBehindReplicas(repl.RaftStatus(), desc.Replicas)
-			target := rq.allocator.TransferLeaseTarget(
-				zone.Constraints, candidates, repl.store.StoreID(), desc.RangeID,
-				false /* checkTransferLeaseSource */)
-			if target != (roachpb.ReplicaDescriptor{}) {
-				log.VEventf(ctx, 1, "transferring lease to s%d", target.StoreID)
-				if err := repl.AdminTransferLease(target.StoreID); err != nil {
-					return errors.Wrapf(err, "%s: unable to transfer lease to s%d", repl, target.StoreID)
-				}
-				rq.lastLeaseTransfer.Store(timeutil.Now())
-				// Do not requeue as we transferred our lease away.
+			transferred, err := rq.transferLease(ctx, repl, desc, zone, false /* checkTransferLeaseSource */)
+			if err != nil {
+				return err
+			}
+			// Do not requeue as we transferred our lease away.
+			if transferred {
 				return nil
 			}
 		} else {
@@ -286,7 +282,7 @@ func (rq *replicateQueue) processOneChange(
 		log.Event(ctx, "removing a dead replica")
 		if len(deadReplicas) == 0 {
 			if log.V(1) {
-				log.Warningf(ctx, "Range of replica %s was identified as having dead replicas, but no dead replicas were found.", repl)
+				log.Warningf(ctx, "range of replica %s was identified as having dead replicas, but no dead replicas were found", repl)
 			}
 			break
 		}
@@ -303,17 +299,12 @@ func (rq *replicateQueue) processOneChange(
 		if rq.canTransferLease() {
 			// We require the lease in order to process replicas, so
 			// repl.store.StoreID() corresponds to the lease-holder's store ID.
-			candidates := filterBehindReplicas(repl.RaftStatus(), desc.Replicas)
-			target := rq.allocator.TransferLeaseTarget(
-				zone.Constraints, candidates, repl.store.StoreID(), desc.RangeID,
-				true /* checkTransferLeaseSource */)
-			if target != (roachpb.ReplicaDescriptor{}) {
-				log.VEventf(ctx, 1, "transferring lease to s%d", target.StoreID)
-				if err := repl.AdminTransferLease(target.StoreID); err != nil {
-					return errors.Wrapf(err, "%s: unable to transfer lease to s%d", repl, target.StoreID)
-				}
-				rq.lastLeaseTransfer.Store(timeutil.Now())
-				// Do not requeue as we transferred our lease away.
+			transferred, err := rq.transferLease(ctx, repl, desc, zone, true /* checkTransferLeaseSource */)
+			if err != nil {
+				return err
+			}
+			// Do not requeue as we transferred our lease away.
+			if transferred {
 				return nil
 			}
 		}
@@ -345,6 +336,31 @@ func (rq *replicateQueue) processOneChange(
 	}
 
 	return nil
+}
+
+func (rq *replicateQueue) transferLease(
+	ctx context.Context,
+	repl *Replica,
+	desc *roachpb.RangeDescriptor,
+	zone config.ZoneConfig,
+	checkTransferLeaseSource bool,
+) (bool, error) {
+	candidates := filterBehindReplicas(repl.RaftStatus(), desc.Replicas)
+	if target := rq.allocator.TransferLeaseTarget(
+		zone.Constraints,
+		candidates,
+		repl.store.StoreID(),
+		desc.RangeID,
+		checkTransferLeaseSource,
+	); target != (roachpb.ReplicaDescriptor{}) {
+		log.VEventf(ctx, 1, "transferring lease to s%d", target.StoreID)
+		if err := repl.AdminTransferLease(target.StoreID); err != nil {
+			return false, errors.Wrapf(err, "%s: unable to transfer lease to s%d", repl, target.StoreID)
+		}
+		rq.lastLeaseTransfer.Store(timeutil.Now())
+		return true, nil
+	}
+	return false, nil
 }
 
 func (rq *replicateQueue) addReplica(

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -275,10 +275,13 @@ type storeReplicaVisitor struct {
 	visited int        // Number of visited ranges, -1 before first call to Visit()
 }
 
-// storeReplicaVisitor implements the shuffle.Interface.
-func (rs storeReplicaVisitor) Len() int      { return len(rs.repls) }
+// Len implements shuffle.Interface.
+func (rs storeReplicaVisitor) Len() int { return len(rs.repls) }
+
+// Swap implements shuffle.Interface.
 func (rs storeReplicaVisitor) Swap(i, j int) { rs.repls[i], rs.repls[j] = rs.repls[j], rs.repls[i] }
 
+// newStoreReplicaVisitor constructs a storeReplicaVisitor.
 func newStoreReplicaVisitor(store *Store) *storeReplicaVisitor {
 	return &storeReplicaVisitor{
 		store:   store,
@@ -325,6 +328,9 @@ func (rs *storeReplicaVisitor) Visit(visitor func(*Replica) bool) {
 	rs.visited = 0
 }
 
+// EstimatedCount returns an estimated count of the underlying store's
+// replicas.
+//
 // TODO(tschottdorf): this method has highly doubtful semantics.
 func (rs *storeReplicaVisitor) EstimatedCount() int {
 	if rs.visited <= 0 {
@@ -1202,7 +1208,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		})
 
 		// Run metrics computation up front to populate initial statistics.
-		if err = s.ComputeMetrics(-1); err != nil {
+		if err = s.ComputeMetrics(ctx, -1); err != nil {
 			log.Infof(ctx, "%s: failed initial metrics computation: %s", s, err)
 		}
 		log.Event(ctx, "computed initial metrics")
@@ -3672,7 +3678,7 @@ func (s *Store) updateCapacityGauges() error {
 // TODO(bram): #4564 It may be appropriate to compute these statistics while
 // scanning ranges. An ideal solution would be to create incremental events
 // whenever availability changes.
-func (s *Store) updateReplicationGauges() error {
+func (s *Store) updateReplicationGauges(ctx context.Context) error {
 	// Load the system config.
 	cfg, ok := s.Gossip().GetSystemConfig()
 	if !ok {
@@ -3702,7 +3708,6 @@ func (s *Store) updateReplicationGauges() error {
 		desc := rep.Desc()
 		zoneConfig, err := cfg.GetZoneConfigForKey(desc.StartKey)
 		if err != nil {
-			ctx := s.AnnotateCtx(context.TODO())
 			log.Error(ctx, err)
 			return true
 		}
@@ -3862,15 +3867,14 @@ func (s *Store) updateCommandQueueGauges() error {
 // ComputeMetrics immediately computes the current value of store metrics which
 // cannot be computed incrementally. This method should be invoked periodically
 // by a higher-level system which records store metrics.
-func (s *Store) ComputeMetrics(tick int) error {
+func (s *Store) ComputeMetrics(ctx context.Context, tick int) error {
+	ctx = s.AnnotateCtx(ctx)
 	if err := s.updateCapacityGauges(); err != nil {
 		return err
 	}
-
-	if err := s.updateReplicationGauges(); err != nil {
+	if err := s.updateReplicationGauges(ctx); err != nil {
 		return err
 	}
-
 	if err := s.updateCommandQueueGauges(); err != nil {
 		return err
 	}
@@ -3890,7 +3894,6 @@ func (s *Store) ComputeMetrics(tick int) error {
 		s.metrics.RdbReadAmplification.Update(int64(readAmp))
 		// Log this metric infrequently.
 		if tick%100 == 0 {
-			ctx := s.AnnotateCtx(context.TODO())
 			log.Infof(ctx, "sstables (read amplification = %d):\n%s", readAmp, sstables)
 		}
 	}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -537,26 +537,26 @@ func TestStoreReplicaVisitor(t *testing.T) {
 	}
 
 	// Verify two passes of the visit.
-	ranges := newStoreReplicaVisitor(store)
+	visitor := newStoreReplicaVisitor(store)
 	exp := make(map[roachpb.RangeID]struct{})
 	for i := 0; i < newCount; i++ {
 		exp[roachpb.RangeID(i+1)] = struct{}{}
 	}
 
 	for pass := 0; pass < 2; pass++ {
-		if ec := ranges.EstimatedCount(); ec != 10 {
+		if ec := visitor.EstimatedCount(); ec != 10 {
 			t.Fatalf("expected 10 remaining; got %d", ec)
 		}
 		i := 1
 		seen := make(map[roachpb.RangeID]struct{})
-		ranges.Visit(func(repl *Replica) bool {
+		visitor.Visit(func(repl *Replica) bool {
 			_, ok := seen[repl.RangeID]
 			if ok {
 				t.Fatalf("already saw %d", repl.RangeID)
 			}
 
 			seen[repl.RangeID] = struct{}{}
-			if ec := ranges.EstimatedCount(); ec != 10-i {
+			if ec := visitor.EstimatedCount(); ec != 10-i {
 				t.Fatalf(
 					"expected %d remaining; got %d after seeing %+v",
 					10-i, ec, seen,
@@ -565,7 +565,7 @@ func TestStoreReplicaVisitor(t *testing.T) {
 			i++
 			return true
 		})
-		if ec := ranges.EstimatedCount(); ec != 10 {
+		if ec := visitor.EstimatedCount(); ec != 10 {
 			t.Fatalf("expected 10 remaining; got %d", ec)
 		}
 		if !reflect.DeepEqual(exp, seen) {

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -520,7 +520,7 @@ func (tc *TestCluster) waitForFullReplication() error {
 				if err := s.ComputeMetrics(context.TODO(), 0); err != nil {
 					return err
 				}
-				if s.Metrics().ReplicaAllocatorAddCount.Value() > 0 {
+				if s.Metrics().UnderReplicatedRangeCount.Value() > 0 {
 					notReplicated = true
 				}
 				return nil

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -517,7 +517,7 @@ func (tc *TestCluster) waitForFullReplication() error {
 		notReplicated = false
 		for _, s := range tc.Servers {
 			err := s.Stores().VisitStores(func(s *storage.Store) error {
-				if err := s.ComputeMetrics(0); err != nil {
+				if err := s.ComputeMetrics(context.TODO(), 0); err != nil {
 					return err
 				}
 				if s.Metrics().ReplicaAllocatorAddCount.Value() > 0 {


### PR DESCRIPTION
Changes allocator metrics to record actions taken by the allocator,
rather than attempting to record future actions by the allocator, which
is inherently racy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11733)
<!-- Reviewable:end -->
