### PR TITLE
gossip: Fix bootstrap race in TestGossipStorageCleanup

### DIFF
--- a/pkg/gossip/storage_test.go
+++ b/pkg/gossip/storage_test.go
@@ -248,6 +248,12 @@ func TestGossipStorageCleanup(t *testing.T) {
 	// Wait for the gossip network to connect.
 	network.RunUntilFullyConnected()
 
+	// Let the gossip network continue running in the background without the
+	// simulation cycler preventing it from operating.
+	for _, node := range network.Nodes {
+		node.Gossip.EnableSimulationCycler(false)
+	}
+
 	// Wait long enough for storage to get the expected number of
 	// addresses and no pending cleanups.
 	util.SucceedsSoon(t, func() error {


### PR DESCRIPTION
In rare cases, the nodes would know about each other so the network
simulation's `isNetworkConnected` method would return true, but the
last one or two nodes would be stuck in bootstrap races due the earlier
nodes being stuck on the simulation cycler.

Increasing the bootstrap interval from 1ms to 10ms also makes the flake
go away, but this seems like a more solid fix.

Fixes #11595

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11734)
<!-- Reviewable:end -->
