### PR TITLE
sql: don't scan unnecessary columns under JOINs

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -403,6 +403,7 @@ func (n *alterTableNode) Values() parser.DTuple               { return parser.DT
 func (n *alterTableNode) DebugValues() debugValues            { return debugValues{} }
 func (n *alterTableNode) ExplainTypes(_ func(string, string)) {}
 func (n *alterTableNode) SetLimitHint(_ int64, _ bool)        {}
+func (n *alterTableNode) setNeededColumns(_ []bool)           {}
 func (n *alterTableNode) MarkDebug(mode explainMode)          {}
 func (n *alterTableNode) ExplainPlan(v bool) (string, string, []planNode) {
 	return "alter table", "", nil

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -54,6 +54,7 @@ func (*copyNode) Ordering() orderingInfo              { return orderingInfo{} }
 func (*copyNode) Values() parser.DTuple               { return nil }
 func (*copyNode) ExplainTypes(_ func(string, string)) {}
 func (*copyNode) SetLimitHint(_ int64, _ bool)        {}
+func (*copyNode) setNeededColumns(_ []bool)           {}
 func (*copyNode) MarkDebug(_ explainMode)             {}
 func (*copyNode) expandPlan() error                   { return nil }
 func (*copyNode) Next() (bool, error)                 { return false, nil }

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -142,6 +142,7 @@ func (n *createDatabaseNode) Values() parser.DTuple               { return parse
 func (n *createDatabaseNode) DebugValues() debugValues            { return debugValues{} }
 func (n *createDatabaseNode) ExplainTypes(_ func(string, string)) {}
 func (n *createDatabaseNode) SetLimitHint(_ int64, _ bool)        {}
+func (n *createDatabaseNode) setNeededColumns(_ []bool)           {}
 func (n *createDatabaseNode) MarkDebug(mode explainMode)          {}
 func (n *createDatabaseNode) ExplainPlan(v bool) (string, string, []planNode) {
 	return "create database", "", nil
@@ -261,6 +262,7 @@ func (n *createIndexNode) Values() parser.DTuple               { return parser.D
 func (n *createIndexNode) DebugValues() debugValues            { return debugValues{} }
 func (n *createIndexNode) ExplainTypes(_ func(string, string)) {}
 func (n *createIndexNode) SetLimitHint(_ int64, _ bool)        {}
+func (n *createIndexNode) setNeededColumns(_ []bool)           {}
 func (n *createIndexNode) MarkDebug(mode explainMode)          {}
 func (n *createIndexNode) ExplainPlan(v bool) (string, string, []planNode) {
 	return "create index", "", nil
@@ -346,6 +348,7 @@ func (n *createUserNode) Values() parser.DTuple               { return parser.DT
 func (n *createUserNode) DebugValues() debugValues            { return debugValues{} }
 func (n *createUserNode) ExplainTypes(_ func(string, string)) {}
 func (n *createUserNode) SetLimitHint(_ int64, _ bool)        {}
+func (n *createUserNode) setNeededColumns(_ []bool)           {}
 func (n *createUserNode) MarkDebug(mode explainMode)          {}
 func (n *createUserNode) ExplainPlan(v bool) (string, string, []planNode) {
 	return "create user", "", nil
@@ -476,6 +479,7 @@ func (n *createViewNode) Ordering() orderingInfo              { return orderingI
 func (n *createViewNode) Values() parser.DTuple               { return parser.DTuple{} }
 func (n *createViewNode) DebugValues() debugValues            { return debugValues{} }
 func (n *createViewNode) ExplainTypes(_ func(string, string)) {}
+func (n *createViewNode) setNeededColumns(_ []bool)           {}
 func (n *createViewNode) SetLimitHint(_ int64, _ bool)        {}
 func (n *createViewNode) MarkDebug(mode explainMode)          {}
 func (n *createViewNode) ExplainPlan(v bool) (string, string, []planNode) {
@@ -704,6 +708,7 @@ func (n *createTableNode) Values() parser.DTuple               { return parser.D
 func (n *createTableNode) DebugValues() debugValues            { return debugValues{} }
 func (n *createTableNode) ExplainTypes(_ func(string, string)) {}
 func (n *createTableNode) SetLimitHint(_ int64, _ bool)        {}
+func (n *createTableNode) setNeededColumns(_ []bool)           {}
 func (n *createTableNode) MarkDebug(mode explainMode)          {}
 func (n *createTableNode) ExplainPlan(v bool) (string, string, []planNode) {
 	if n.n.As() {

--- a/pkg/sql/delayed.go
+++ b/pkg/sql/delayed.go
@@ -32,6 +32,8 @@ type delayedNode struct {
 type nodeConstructor func(p *planner) (planNode, error)
 
 func (d *delayedNode) SetLimitHint(_ int64, _ bool) {}
+func (d *delayedNode) setNeededColumns(_ []bool)    {}
+
 func (d *delayedNode) expandPlan() error {
 	v, err := d.constructor(d.p)
 	if err != nil {

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -272,3 +272,4 @@ func (d *deleteNode) ExplainTypes(regTypes func(string, string)) {
 }
 
 func (d *deleteNode) SetLimitHint(numRows int64, soft bool) {}
+func (d *deleteNode) setNeededColumns(_ []bool)             {}

--- a/pkg/sql/distinct.go
+++ b/pkg/sql/distinct.go
@@ -255,6 +255,8 @@ func (n *distinctNode) SetLimitHint(numRows int64, soft bool) {
 	n.plan.SetLimitHint(numRows, true)
 }
 
+func (*distinctNode) setNeededColumns(_ []bool) {}
+
 func (n *distinctNode) Close() {
 	n.plan.Close()
 	n.prefixSeen = nil

--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -218,6 +218,7 @@ func (n *dropDatabaseNode) Values() parser.DTuple               { return parser.
 func (n *dropDatabaseNode) DebugValues() debugValues            { return debugValues{} }
 func (n *dropDatabaseNode) ExplainTypes(_ func(string, string)) {}
 func (n *dropDatabaseNode) SetLimitHint(_ int64, _ bool)        {}
+func (n *dropDatabaseNode) setNeededColumns(_ []bool)           {}
 func (n *dropDatabaseNode) MarkDebug(mode explainMode)          {}
 func (n *dropDatabaseNode) ExplainPlan(v bool) (string, string, []planNode) {
 	return "drop database", "", nil
@@ -398,6 +399,7 @@ func (n *dropIndexNode) Values() parser.DTuple               { return parser.DTu
 func (n *dropIndexNode) DebugValues() debugValues            { return debugValues{} }
 func (n *dropIndexNode) ExplainTypes(_ func(string, string)) {}
 func (n *dropIndexNode) SetLimitHint(_ int64, _ bool)        {}
+func (n *dropIndexNode) setNeededColumns(_ []bool)           {}
 func (n *dropIndexNode) MarkDebug(mode explainMode)          {}
 func (n *dropIndexNode) ExplainPlan(v bool) (string, string, []planNode) {
 	return "drop index", "", nil
@@ -514,6 +516,7 @@ func (n *dropViewNode) Values() parser.DTuple               { return parser.DTup
 func (n *dropViewNode) ExplainTypes(_ func(string, string)) {}
 func (n *dropViewNode) DebugValues() debugValues            { return debugValues{} }
 func (n *dropViewNode) SetLimitHint(_ int64, _ bool)        {}
+func (n *dropViewNode) setNeededColumns(_ []bool)           {}
 func (n *dropViewNode) MarkDebug(mode explainMode)          {}
 func (n *dropViewNode) ExplainPlan(v bool) (string, string, []planNode) {
 	return "drop view", "", nil
@@ -734,6 +737,7 @@ func (n *dropTableNode) Values() parser.DTuple               { return parser.DTu
 func (n *dropTableNode) ExplainTypes(_ func(string, string)) {}
 func (n *dropTableNode) DebugValues() debugValues            { return debugValues{} }
 func (n *dropTableNode) SetLimitHint(_ int64, _ bool)        {}
+func (n *dropTableNode) setNeededColumns(_ []bool)           {}
 func (n *dropTableNode) MarkDebug(mode explainMode)          {}
 func (n *dropTableNode) ExplainPlan(v bool) (string, string, []planNode) {
 	return "drop table", "", nil

--- a/pkg/sql/empty.go
+++ b/pkg/sql/empty.go
@@ -33,6 +33,7 @@ func (*emptyNode) Values() parser.DTuple               { return nil }
 func (*emptyNode) ExplainTypes(_ func(string, string)) {}
 func (*emptyNode) Start() error                        { return nil }
 func (*emptyNode) SetLimitHint(_ int64, _ bool)        {}
+func (*emptyNode) setNeededColumns(_ []bool)           {}
 func (*emptyNode) MarkDebug(_ explainMode)             {}
 func (*emptyNode) expandPlan() error                   { return nil }
 func (*emptyNode) Close()                              {}

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -157,6 +157,9 @@ type ResultColumn struct {
 
 	// If set, this is an implicit column; used internally.
 	hidden bool
+
+	// If set, a value won't be produced for this column; used internally.
+	omitted bool
 }
 
 // ResultColumns is the type used throughout the sql module to

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -157,6 +157,7 @@ func (e *explainTypesNode) Ordering() orderingInfo               { return e.resu
 func (e *explainTypesNode) Values() parser.DTuple                { return e.results.Values() }
 func (e *explainTypesNode) DebugValues() debugValues             { return e.results.DebugValues() }
 func (e *explainTypesNode) SetLimitHint(n int64, s bool)         { e.results.SetLimitHint(n, s) }
+func (e *explainTypesNode) setNeededColumns(_ []bool)            {}
 func (e *explainTypesNode) MarkDebug(mode explainMode)           {}
 func (e *explainTypesNode) ExplainPlan(v bool) (string, string, []planNode) {
 	return "explain", "types", []planNode{e.plan}
@@ -281,6 +282,7 @@ func (e *explainPlanNode) Ordering() orderingInfo               { return e.resul
 func (e *explainPlanNode) Values() parser.DTuple                { return e.results.Values() }
 func (e *explainPlanNode) DebugValues() debugValues             { return debugValues{} }
 func (e *explainPlanNode) SetLimitHint(n int64, s bool)         { e.results.SetLimitHint(n, s) }
+func (e *explainPlanNode) setNeededColumns(_ []bool)            {}
 func (e *explainPlanNode) MarkDebug(mode explainMode)           {}
 func (e *explainPlanNode) expandPlan() error {
 	if err := e.plan.expandPlan(); err != nil {
@@ -454,3 +456,4 @@ func (n *explainDebugNode) Values() parser.DTuple {
 func (*explainDebugNode) MarkDebug(_ explainMode)      {}
 func (*explainDebugNode) DebugValues() debugValues     { return debugValues{} }
 func (*explainDebugNode) SetLimitHint(_ int64, _ bool) {}
+func (*explainDebugNode) setNeededColumns(_ []bool)    {}

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -193,9 +193,27 @@ func formatColumns(cols ResultColumns, printTypes bool) string {
 			buf.WriteString(", ")
 		}
 		parser.Name(rCol.Name).Format(&buf, parser.FmtSimple)
-		if rCol.hidden {
-			buf.WriteString("[hidden]")
+		// Output extra properties like [hidden,omitted].
+		hasProps := false
+		outputProp := func(prop string) {
+			if hasProps {
+				buf.WriteByte(',')
+			} else {
+				buf.WriteByte('[')
+			}
+			hasProps = true
+			buf.WriteString(prop)
 		}
+		if rCol.hidden {
+			outputProp("hidden")
+		}
+		if rCol.omitted {
+			outputProp("omitted")
+		}
+		if hasProps {
+			buf.WriteByte(']')
+		}
+
 		if printTypes {
 			buf.WriteByte(' ')
 			buf.WriteString(rCol.Typ.String())

--- a/pkg/sql/generator.go
+++ b/pkg/sql/generator.go
@@ -145,3 +145,4 @@ func (n *valueGenerator) Values() parser.DTuple        { return n.gen.Values() }
 func (n *valueGenerator) MarkDebug(_ explainMode)      {}
 func (n *valueGenerator) Columns() ResultColumns       { return n.columns }
 func (n *valueGenerator) SetLimitHint(_ int64, _ bool) {}
+func (n *valueGenerator) setNeededColumns(_ []bool)    {}

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -426,6 +426,7 @@ func (n *groupNode) ExplainTypes(regTypes func(string, string)) {
 }
 
 func (*groupNode) SetLimitHint(_ int64, _ bool) {}
+func (*groupNode) setNeededColumns(_ []bool)    {}
 
 func (n *groupNode) Close() {
 	n.plan.Close()

--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -249,6 +249,8 @@ func (n *indexJoinNode) SetLimitHint(numRows int64, soft bool) {
 	n.index.SetLimitHint(numRows, soft)
 }
 
+func (*indexJoinNode) setNeededColumns(_ []bool) {}
+
 func (n *indexJoinNode) Close() {
 	n.index.Close()
 	n.table.Close()

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -597,3 +597,4 @@ func (n *insertNode) ExplainTypes(regTypes func(string, string)) {
 }
 
 func (n *insertNode) SetLimitHint(numRows int64, soft bool) {}
+func (n *insertNode) setNeededColumns(_ []bool)             {}

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -217,9 +217,9 @@ func (p *planner) makeJoin(
 	}
 
 	// Check that the same table name is not used on both sides.
-	for alias := range right.info.sourceAliases {
-		if _, ok := left.info.sourceAliases[alias]; ok {
-			t := alias.Table()
+	for _, alias := range right.info.sourceAliases {
+		if _, ok := left.info.sourceAliases.srcIdx(alias.name); ok {
+			t := alias.name.Table()
 			if t == "" {
 				return planDataSource{}, errors.New(
 					"cannot join columns from multiple anonymous sources (missing AS clause)")
@@ -240,7 +240,7 @@ func (p *planner) makeJoin(
 	)
 
 	if cond == nil {
-		pred, info, err = p.makeCrossPredicate(leftInfo, rightInfo)
+		pred, info = p.makeCrossPredicate(leftInfo, rightInfo)
 	} else {
 		switch t := cond.(type) {
 		case *parser.OnJoinCond:

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -304,6 +304,9 @@ func (n *joinNode) ExplainTypes(regTypes func(string, string)) {
 // SetLimitHint implements the planNode interface.
 func (n *joinNode) SetLimitHint(numRows int64, soft bool) {}
 
+// setNeededColumns implements the planNode interface.
+func (n *joinNode) setNeededColumns(_ []bool) {}
+
 // expandPlan implements the planNode interface.
 func (n *joinNode) expandPlan() error {
 	if err := n.pred.expand(); err != nil {

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -240,8 +240,7 @@ func (p *planner) makeJoin(
 	)
 
 	if cond == nil {
-		pred = &crossPredicate{}
-		info, err = concatDataSourceInfos(leftInfo, rightInfo)
+		pred, info, err = p.makeCrossPredicate(leftInfo, rightInfo)
 	} else {
 		switch t := cond.(type) {
 		case *parser.OnJoinCond:
@@ -305,7 +304,14 @@ func (n *joinNode) ExplainTypes(regTypes func(string, string)) {
 func (n *joinNode) SetLimitHint(numRows int64, soft bool) {}
 
 // setNeededColumns implements the planNode interface.
-func (n *joinNode) setNeededColumns(_ []bool) {}
+func (n *joinNode) setNeededColumns(needed []bool) {
+	leftNeeded, rightNeeded := n.pred.getNeededColumns(needed)
+	n.left.plan.setNeededColumns(leftNeeded)
+	n.right.plan.setNeededColumns(rightNeeded)
+	for i, v := range needed {
+		n.columns[i].omitted = !v
+	}
+}
 
 // expandPlan implements the planNode interface.
 func (n *joinNode) expandPlan() error {

--- a/pkg/sql/join_predicate.go
+++ b/pkg/sql/join_predicate.go
@@ -36,6 +36,9 @@ type joinPredicate interface {
 	// right size, which can be used as intermediate buffer.
 	eval(result, leftRow, rightRow parser.DTuple) (bool, error)
 
+	// getNeededColumns figures out the columns needed for the two sources.
+	getNeededColumns(neededJoined []bool) (neededLeft []bool, neededRight []bool)
+
 	// prepareRow prepares the output row by combining values from the
 	// input data sources.
 	prepareRow(result, leftRow, rightRow parser.DTuple)
@@ -58,6 +61,22 @@ var _ joinPredicate = &onPredicate{}
 var _ joinPredicate = &crossPredicate{}
 var _ joinPredicate = &equalityPredicate{}
 
+// joinPredicateBase contains fields common to all joinPredicates.
+type joinPredicateBase struct {
+	numLeftCols, numRightCols int
+}
+
+func (p *joinPredicateBase) getNeededColumnsConcat(
+	neededJoined []bool,
+) (neededLeft []bool, neededRight []bool) {
+	if len(neededJoined) != p.numLeftCols+p.numRightCols {
+		panic(fmt.Sprintf(
+			"expected %d+%d cols, got %d", p.numLeftCols, p.numRightCols, len(neededJoined),
+		))
+	}
+	return neededJoined[:p.numLeftCols], neededJoined[p.numLeftCols:]
+}
+
 // prepareRowConcat implement the simple case of CROSS JOIN or JOIN
 // with an ON clause, where the rows of the two inputs are simply
 // concatenated.
@@ -68,11 +87,18 @@ func prepareRowConcat(result parser.DTuple, leftRow parser.DTuple, rightRow pars
 
 // crossPredicate implements the predicate logic for CROSS JOIN. The
 // predicate is always true, the work done here is thus minimal.
-type crossPredicate struct{}
+type crossPredicate struct {
+	joinPredicateBase
+}
 
 func (p *crossPredicate) eval(_, _, _ parser.DTuple) (bool, error) {
 	return true, nil
 }
+
+func (p *crossPredicate) getNeededColumns(neededJoined []bool) ([]bool, []bool) {
+	return p.getNeededColumnsConcat(neededJoined)
+}
+
 func (p *crossPredicate) prepareRow(result, leftRow, rightRow parser.DTuple) {
 	prepareRowConcat(result, leftRow, rightRow)
 }
@@ -84,12 +110,28 @@ func (p *crossPredicate) encode(_ []byte, _ parser.DTuple, _ int) ([]byte, bool,
 	return nil, false, nil
 }
 
+// makeCrossPredicate constructs a joinPredicate object for joins with a ON clause.
+func (p *planner) makeCrossPredicate(
+	left, right *dataSourceInfo,
+) (joinPredicate, *dataSourceInfo, error) {
+	pred := &crossPredicate{
+		joinPredicateBase: joinPredicateBase{
+			numLeftCols:  len(left.sourceColumns),
+			numRightCols: len(right.sourceColumns),
+		},
+	}
+	info, err := concatDataSourceInfos(left, right)
+	return pred, info, err
+}
+
 // onPredicate implements the predicate logic for joins with an ON clause.
 type onPredicate struct {
-	p      *planner
-	filter parser.TypedExpr
-	info   *dataSourceInfo
-	curRow parser.DTuple
+	joinPredicateBase
+	p          *planner
+	iVarHelper parser.IndexedVarHelper
+	filter     parser.TypedExpr
+	info       *dataSourceInfo
+	curRow     parser.DTuple
 
 	// This struct must be allocated on the heap and its location stay
 	// stable after construction because it implements
@@ -124,6 +166,17 @@ func (p *onPredicate) eval(result, leftRow, rightRow parser.DTuple) (bool, error
 	p.curRow = result
 	prepareRowConcat(p.curRow, leftRow, rightRow)
 	return sqlbase.RunFilter(p.filter, &p.p.evalCtx)
+}
+
+func (p *onPredicate) getNeededColumns(neededJoined []bool) ([]bool, []bool) {
+	// The columns that are part of the expression are always needed.
+	neededJoined = append([]bool(nil), neededJoined...)
+	for i := range neededJoined {
+		if p.iVarHelper.IndexedVarUsed(i) {
+			neededJoined[i] = true
+		}
+	}
+	return p.getNeededColumnsConcat(neededJoined)
 }
 
 func (p *onPredicate) prepareRow(result, leftRow, rightRow parser.DTuple) {
@@ -197,14 +250,18 @@ func (p *planner) makeOnPredicate(
 	}
 
 	pred := &onPredicate{
+		joinPredicateBase: joinPredicateBase{
+			numLeftCols:  len(left.sourceColumns),
+			numRightCols: len(right.sourceColumns),
+		},
 		p:    p,
 		info: info,
 	}
 
 	// Determine the filter expression.
 	colInfo := multiSourceInfo{left, right}
-	iVarHelper := parser.MakeIndexedVarHelper(pred, len(info.sourceColumns))
-	filter, err := p.analyzeExpr(expr, colInfo, iVarHelper, parser.TypeBool, true, "ON")
+	pred.iVarHelper = parser.MakeIndexedVarHelper(pred, len(info.sourceColumns))
+	filter, err := p.analyzeExpr(expr, colInfo, pred.iVarHelper, parser.TypeBool, true, "ON")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -215,6 +272,8 @@ func (p *planner) makeOnPredicate(
 
 // equalityPredicate implements the predicate logic for joins with a USING clause.
 type equalityPredicate struct {
+	joinPredicateBase
+
 	p *planner
 
 	// The comparison function to use for each column. We need
@@ -276,6 +335,40 @@ func (p *equalityPredicate) eval(_, leftRow, rightRow parser.DTuple) (bool, erro
 		}
 	}
 	return true, nil
+}
+
+func (p *equalityPredicate) getNeededColumns(neededJoined []bool) ([]bool, []bool) {
+	if !p.mergeEqualityColumns {
+		leftNeeded, rightNeeded := p.getNeededColumnsConcat(neededJoined)
+		// The equality columns are always needed.
+		for i := range p.leftEqualityIndices {
+			leftNeeded[p.leftEqualityIndices[i]] = true
+			rightNeeded[p.rightEqualityIndices[i]] = true
+		}
+		return leftNeeded, rightNeeded
+	}
+	leftNeeded := make([]bool, p.numLeftCols)
+	rightNeeded := make([]bool, p.numRightCols)
+
+	// The equality columns are always needed.
+	for i := range p.leftEqualityIndices {
+		leftNeeded[p.leftEqualityIndices[i]] = true
+		rightNeeded[p.rightEqualityIndices[i]] = true
+	}
+
+	delta := len(p.leftEqualityIndices)
+	for i := range p.leftRestIndices {
+		if neededJoined[delta+i] {
+			leftNeeded[p.leftRestIndices[i]] = true
+		}
+	}
+	delta += len(p.leftRestIndices)
+	for i := range p.rightRestIndices {
+		if neededJoined[delta+i] {
+			rightNeeded[p.rightRestIndices[i]] = true
+		}
+	}
+	return leftNeeded, rightNeeded
 }
 
 // prepareRow for equalityPredicate. First, we should check if this
@@ -507,6 +600,10 @@ func (p *planner) makeEqualityPredicate(
 	}
 
 	return &equalityPredicate{
+		joinPredicateBase: joinPredicateBase{
+			numLeftCols:  len(left.sourceColumns),
+			numRightCols: len(right.sourceColumns),
+		},
 		p:                    p,
 		leftColNames:         leftColNames,
 		rightColNames:        rightColNames,

--- a/pkg/sql/limit.go
+++ b/pkg/sql/limit.go
@@ -312,3 +312,5 @@ func (n *limitNode) SetLimitHint(count int64, soft bool) {
 	}
 	n.plan.SetLimitHint(getLimit(hintCount, n.offset), soft)
 }
+
+func (*limitNode) setNeededColumns(_ []bool) {}

--- a/pkg/sql/ordinality.go
+++ b/pkg/sql/ordinality.go
@@ -135,3 +135,4 @@ func (o *ordinalityNode) Start() error                          { return o.sourc
 func (o *ordinalityNode) Close()                                { o.source.Close() }
 func (o *ordinalityNode) ExplainTypes(_ func(string, string))   {}
 func (o *ordinalityNode) SetLimitHint(numRows int64, soft bool) { o.source.SetLimitHint(numRows, soft) }
+func (o *ordinalityNode) setNeededColumns(_ []bool)             {}

--- a/pkg/sql/ordinality.go
+++ b/pkg/sql/ordinality.go
@@ -59,7 +59,8 @@ func (p *planner) wrapOrdinality(ds planDataSource) planDataSource {
 	// Allocate an extra column for the ordinality values.
 	res.columns = make(ResultColumns, len(srcColumns)+1)
 	copy(res.columns, srcColumns)
-	res.columns[len(res.columns)-1] = ResultColumn{
+	newColIdx := len(res.columns) - 1
+	res.columns[newColIdx] = ResultColumn{
 		Name: "ordinality",
 		Typ:  parser.TypeInt,
 	}
@@ -67,9 +68,15 @@ func (p *planner) wrapOrdinality(ds planDataSource) planDataSource {
 	// Extend the dataSourceInfo with information about the
 	// new column.
 	ds.info.sourceColumns = res.columns
-	entry := ds.info.sourceAliases[anonymousTable]
-	entry = append(entry, len(res.columns)-1)
-	ds.info.sourceAliases[anonymousTable] = entry
+	if srcIdx, ok := ds.info.sourceAliases.srcIdx(anonymousTable); !ok {
+		ds.info.sourceAliases = append(ds.info.sourceAliases, sourceAlias{
+			name:        anonymousTable,
+			columnRange: []int{newColIdx},
+		})
+	} else {
+		srcAlias := &ds.info.sourceAliases[srcIdx]
+		srcAlias.columnRange = append(srcAlias.columnRange, newColIdx)
+	}
 
 	ds.plan = res
 

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -100,6 +100,11 @@ type planNode interface {
 	// Available during/after newPlan().
 	SetLimitHint(numRows int64, soft bool)
 
+	// setNeededColumns is optionally called when the values for some of the
+	// Columns() are not required for this node. There must be one value per
+	// column. It must be called before expandPlan.
+	setNeededColumns(needed []bool)
+
 	// expandPlan finalizes type checking of placeholders and expands
 	// the query plan to its final form, including index selection and
 	// expansion of sub-queries. Returns an error if the initialization

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -302,6 +302,9 @@ func (n *scanNode) setNeededColumns(needed []bool) {
 			len(needed), len(n.valNeededForCol), needed))
 	}
 	copy(n.valNeededForCol, needed)
+	for i, val := range needed {
+		n.resultColumns[i].omitted = !val
+	}
 }
 
 // Initializes the column structures.

--- a/pkg/sql/select.go
+++ b/pkg/sql/select.go
@@ -228,6 +228,8 @@ func (s *selectNode) SetLimitHint(numRows int64, soft bool) {
 	s.source.plan.SetLimitHint(numRows, soft || s.filter != nil)
 }
 
+func (*selectNode) setNeededColumns(_ []bool) {}
+
 func (s *selectNode) Close() {
 	s.source.plan.Close()
 }

--- a/pkg/sql/select.go
+++ b/pkg/sql/select.go
@@ -398,16 +398,16 @@ func (s *selectNode) expandPlan() error {
 	// cannot occur during expandPlan.
 	limitCount, limitOffset := s.top.limit.estimateLimit()
 
-	if scan, ok := s.source.plan.(*scanNode); ok {
-		// Find the set of columns that we actually need values for. This is an
-		// optimization to avoid unmarshaling unnecessary values and is also
-		// used for index selection.
-		neededCols := make([]bool, len(s.source.info.sourceColumns))
-		for i := range neededCols {
-			neededCols[i] = s.ivarHelper.IndexedVarUsed(i)
-		}
-		scan.setNeededColumns(neededCols)
+	// Find the set of columns that we actually need values for. This is an
+	// optimization to avoid unmarshaling unnecessary values and is also
+	// used for index selection.
+	neededCols := make([]bool, len(s.source.info.sourceColumns))
+	for i := range neededCols {
+		neededCols[i] = s.ivarHelper.IndexedVarUsed(i)
+	}
+	s.source.plan.setNeededColumns(neededCols)
 
+	if scan, ok := s.source.plan.(*scanNode); ok {
 		// Compute a filter expression for the scan node.
 		convFunc := func(expr parser.VariableExpr) (bool, parser.VariableExpr) {
 			ivar := expr.(*parser.IndexedVar)

--- a/pkg/sql/select_top.go
+++ b/pkg/sql/select_top.go
@@ -64,6 +64,8 @@ func (n *selectTopNode) SetLimitHint(numRows int64, soft bool) {
 	n.plan.SetLimitHint(numRows, soft)
 }
 
+func (*selectTopNode) setNeededColumns(_ []bool) {}
+
 func (n *selectTopNode) expandPlan() error {
 	if n.plan != nil {
 		panic("can't expandPlan twice!")

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -351,6 +351,8 @@ func (n *sortNode) SetLimitHint(numRows int64, soft bool) {
 	}
 }
 
+func (n *sortNode) setNeededColumns(_ []bool) {}
+
 // wrap the supplied planNode with the sortNode if sorting is required.
 // The first returned value is "true" if the sort node can be squashed
 // in the selectTopNode (sorting unneeded).

--- a/pkg/sql/split.go
+++ b/pkg/sql/split.go
@@ -172,6 +172,7 @@ func (*splitNode) Columns() ResultColumns {
 func (*splitNode) Close()                       {}
 func (*splitNode) Ordering() orderingInfo       { return orderingInfo{} }
 func (*splitNode) SetLimitHint(_ int64, _ bool) {}
+func (*splitNode) setNeededColumns(_ []bool)    {}
 func (*splitNode) MarkDebug(_ explainMode)      {}
 
 func (n *splitNode) ExplainPlan(_ bool) (name, description string, children []planNode) {

--- a/pkg/sql/testdata/explain_plan
+++ b/pkg/sql/testdata/explain_plan
@@ -75,10 +75,10 @@ CREATE TABLE tc (a INT, b INT, INDEX c(a))
 query ITTTT colnames
 EXPLAIN(VERBOSE) SELECT * FROM tc WHERE a = 10 ORDER BY b
 ----
-Level Type          Description                                  Columns               Ordering
-0     select                                                     (a, b)                +b
-1     sort          +b                                           (a, b)                +b
-2     render/filter from (test.tc.a, test.tc.b, *test.tc.rowid)  (a, b)                =a
-3     index-join                                                 (a, b, rowid[hidden]) =a,+rowid,unique
-4     scan          tc@c /10-/11                                 (a, b, rowid[hidden]) =a,+rowid,unique
-4     scan          tc@primary                                   (a, b, rowid[hidden]) +rowid,unique
+Level  Type           Description                                  Columns                         Ordering
+0      select                                                      (a, b)                          +b
+1      sort           +b                                           (a, b)                          +b
+2      render/filter  from (test.tc.a, test.tc.b, *test.tc.rowid)  (a, b)                          =a
+3      index-join                                                  (a, b, rowid[hidden,omitted])   =a,+rowid,unique
+4      scan           tc@c /10-/11                                 (a, b[omitted], rowid[hidden])  =a,+rowid,unique
+4      scan           tc@primary                                   (a, b, rowid[hidden,omitted])   +rowid,unique

--- a/pkg/sql/testdata/explain_types
+++ b/pkg/sql/testdata/explain_types
@@ -155,11 +155,11 @@ EXPLAIN (TYPES) VALUES (1) UNION VALUES (2)
 query ITTT
 EXPLAIN (TYPES) SELECT DISTINCT k FROM t
 ----
-0   select          result     (k int)
-1   distinct        result     (k int)
-2   render/filter   result     (k int)
-2   render/filter   render 0   (k)[int]
-3   scan            result     (k int, v int)
+0  select         result    (k int)
+1  distinct       result    (k int)
+2  render/filter  result    (k int)
+2  render/filter  render 0  (k)[int]
+3  scan           result    (k int, v[omitted] int)
 
 query ITTT
 EXPLAIN (TYPES,NOEXPAND) SELECT DISTINCT k FROM t
@@ -176,7 +176,7 @@ EXPLAIN (TYPES) SELECT v FROM t ORDER BY v
 1   sort            result     (v int)
 2   render/filter   result     (v int)
 2   render/filter   render 0   (v)[int]
-3   scan            result     (k int, v int)
+3   scan            result     (k[omitted] int, v int)
 
 query ITTT
 EXPLAIN (TYPES,NOEXPAND) SELECT v FROM t ORDER BY v
@@ -194,7 +194,7 @@ EXPLAIN (TYPES) SELECT v FROM t LIMIT 1
 1   limit           count      (1)[int]
 2   render/filter   result     (v int)
 2   render/filter   render 0   (v)[int]
-3   scan            result     (k int, v int)
+3   scan            result     (k[omitted] int, v int)
 
 query ITTT
 EXPLAIN (TYPES,NOEXPAND) SELECT v FROM t LIMIT 1
@@ -211,15 +211,15 @@ CREATE TABLE tt (x INT, y INT, INDEX a(x), INDEX b(y))
 query ITTT
 EXPLAIN (TYPES) SELECT * FROM tt WHERE x < 10 AND y > 10
 ----
-0   select          result     (x int, y int)
-1   render/filter   result     (x int, y int)
-1   render/filter   render 0   (x)[int]
-1   render/filter   render 1   (y)[int]
-2   index-join      result     (x int, y int, rowid[hidden] int)
-3   scan            result     (x int, y int, rowid[hidden] int)
-3   scan            filter     ((x)[int] < (10)[int])[bool]
-3   scan            result     (x int, y int, rowid[hidden] int)
-3   scan            filter     ((y)[int] > (10)[int])[bool]
+0  select         result    (x int, y int)
+1  render/filter  result    (x int, y int)
+1  render/filter  render 0  (x)[int]
+1  render/filter  render 1  (y)[int]
+2  index-join     result    (x int, y int, rowid[hidden,omitted] int)
+3  scan           result    (x int, y[omitted] int, rowid[hidden] int)
+3  scan           filter    ((x)[int] < (10)[int])[bool]
+3  scan           result    (x int, y int, rowid[hidden,omitted] int)
+3  scan           filter    ((y)[int] > (10)[int])[bool]
 
 query ITTT
 EXPLAIN (TYPES,NOEXPAND) SELECT * FROM tt WHERE x < 10 AND y > 10

--- a/pkg/sql/testdata/join
+++ b/pkg/sql/testdata/join
@@ -403,3 +403,41 @@ CREATE TABLE s(x INT); INSERT INTO s(x) VALUES (1),(2),(3),(4),(5),(6),(7),(8),(
 # The following query demands at least 100GB of RAM if unoptimized.
 query error memory budget exceeded
 SELECT COUNT(*) FROM s AS a, s AS b, s AS c, s AS d, s AS e, s AS f, s AS g, s AS h, s AS i, s AS j, s AS k;
+
+# THe following queries verify that only the necessary columns are scanned.
+query ITTTT
+EXPLAIN (VERBOSE) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
+----
+0  select                                                                          (x, y)
+1  render/filter  from ("".a.x, "".a.y, *"".a.rowid, "".b.x, "".b.y, *"".b.rowid)  (x, y)
+2  join           NESTED LOOP JOIN, CROSS                                          (x, y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])
+3  scan           twocolumn@primary                                                (x, y[omitted], rowid[hidden,omitted])
+3  scan           twocolumn@primary                                                (x[omitted], y, rowid[hidden,omitted])
+
+
+query ITTTT
+EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
+----
+0  select                                                                  (y)
+1  render/filter  from ("".a.x, "".a.y, *"".a.rowid, "".b.y, *"".b.rowid)  (y)
+2  join           HASH JOIN, INNER ON EQUALS((x),(x))                      (x[omitted], y[omitted], rowid[hidden,omitted], y, rowid[hidden,omitted])
+3  scan           twocolumn@primary                                        (x, y[omitted], rowid[hidden,omitted])
+3  scan           twocolumn@primary                                        (x, y, rowid[hidden,omitted])
+
+query ITTTT
+EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b.x)
+----
+0  select                                                                          (y)
+1  render/filter  from ("".a.x, "".a.y, *"".a.rowid, "".b.x, "".b.y, *"".b.rowid)  (y)
+2  join           HASH JOIN, INNER ON EQUALS((x),(x))                              (x, y[omitted], rowid[hidden,omitted], x, y, rowid[hidden,omitted])
+3  scan           twocolumn@primary                                                (x, y[omitted], rowid[hidden,omitted])
+3  scan           twocolumn@primary                                                (x, y, rowid[hidden,omitted])
+
+query ITTTT
+EXPLAIN (VERBOSE) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b.y)
+----
+0  select                                                                          (x)
+1  render/filter  from ("".a.x, "".a.y, *"".a.rowid, "".b.x, "".b.y, *"".b.rowid)  (x)
+2  join           NESTED LOOP JOIN, INNER ON a.x < b.y                             (x, y[omitted], rowid[hidden,omitted], x[omitted], y[omitted], rowid[hidden,omitted])
+3  scan           twocolumn@primary                                                (x, y[omitted], rowid[hidden,omitted])
+3  scan           twocolumn@primary                                                (x[omitted], y, rowid[hidden,omitted])

--- a/pkg/sql/testdata/order_by
+++ b/pkg/sql/testdata/order_by
@@ -230,7 +230,7 @@ EXPLAIN(VERBOSE) SELECT b+2 FROM t ORDER BY b+2
 0   select                                              ("b + 2")   +"b + 2"
 1   sort            +"b + 2"                            ("b + 2")   +"b + 2"
 2   render/filter   from (test.t.a, test.t.b, test.t.c) ("b + 2")
-3   scan            t@primary -                         (a, b, c)   +a,unique
+3   scan            t@primary -                         (a[omitted], b, c[omitted])   +a,unique
 
 # Check that the sort picks up a renamed render properly.
 query ITTTT
@@ -239,7 +239,7 @@ EXPLAIN(VERBOSE) SELECT b+2 AS y FROM t ORDER BY y
 0   select                                              (y)   +y
 1   sort            +y                                  (y)   +y
 2   render/filter   from (test.t.a, test.t.b, test.t.c) (y)
-3   scan            t@primary -                         (a, b, c)   +a,unique
+3   scan            t@primary -                         (a[omitted], b, c[omitted])   +a,unique
 
 # Check that the sort reuses a render behind a rename properly.
 query ITTTT
@@ -248,7 +248,7 @@ EXPLAIN(VERBOSE) SELECT b+2 AS y FROM t ORDER BY b+2
 0   select                                              (y)   +y
 1   sort            +y                                  (y)   +y
 2   render/filter   from (test.t.a, test.t.b, test.t.c) (y)
-3   scan            t@primary -                         (a, b, c)   +a,unique
+3   scan            t@primary -                         (a[omitted], b, c[omitted])   +a,unique
 
 statement ok
 CREATE TABLE abc (

--- a/pkg/sql/testdata/ordinal_references
+++ b/pkg/sql/testdata/ordinal_references
@@ -51,7 +51,7 @@ EXPLAIN(VERBOSE) SELECT b, a FROM foo ORDER BY @1
 0  select                                                         (b, a)                 +a
 1  sort           +a                                              (b, a)                 +a
 2  render/filter  from (test.foo.a, test.foo.b, *test.foo.rowid)  (b, a)
-3  scan           foo@primary -                                   (a, b, rowid[hidden])  +rowid,unique
+3  scan           foo@primary -                                   (a, b, rowid[hidden,omitted])  +rowid,unique
 
 statement ok
 INSERT INTO foo(a, b) VALUES (4, 'c'), (5, 'c'), (6, 'c')
@@ -80,7 +80,7 @@ EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1;
 0  select                                                         (m)
 1  group          min(a) GROUP BY (@2)                            (m)
 2  render/filter  from (test.foo.a, test.foo.b, *test.foo.rowid)  (a, a)
-3  scan           foo@primary -                                   (a, b, rowid[hidden])  +rowid,unique
+3  scan           foo@primary -                                   (a, b[omitted], rowid[hidden,omitted])  +rowid,unique
 
 query ITTTT
 EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2;
@@ -88,7 +88,7 @@ EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2;
 0  select                                                         (m)
 1  group          min(a) GROUP BY (@2)                            (m)
 2  render/filter  from (test.foo.a, test.foo.b, *test.foo.rowid)  (a, b)
-3  scan           foo@primary -                                   (a, b, rowid[hidden])  +rowid,unique
+3  scan           foo@primary -                                   (a, b, rowid[hidden,omitted])  +rowid,unique
 
 statement error column reference @1 not allowed in this context
 INSERT INTO foo(a, b) VALUES (@1, @2)

--- a/pkg/sql/testdata/subquery
+++ b/pkg/sql/testdata/subquery
@@ -322,12 +322,12 @@ true
 query ITTTT
 EXPLAIN(VERBOSE) SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz);
 ----
-0 select                                                   (x)        +x,unique
-1 render/filter  from (test.xyz.x, test.xyz.y, test.xyz.z) (x)        +x,unique
-2 scan           xyz@primary  -                            (x, y, z)  +x,unique
-3 select                                                   (x)        +x,unique
-4 render/filter  from (test.xyz.x, test.xyz.y, test.xyz.z) (x)        +x,unique
-5 scan           xyz@primary                               (x, y, z)  +x,unique
+0  select                                                    (x)                          +x,unique
+1  render/filter  from (test.xyz.x, test.xyz.y, test.xyz.z)  (x)                          +x,unique
+2  scan           xyz@primary -                              (x, y[omitted], z[omitted])  +x,unique
+3  select                                                    (x)                          +x,unique
+4  render/filter  from (test.xyz.x, test.xyz.y, test.xyz.z)  (x)                          +x,unique
+5  scan           xyz@primary                                (x, y[omitted], z[omitted])  +x,unique
 
 # This test checks that the double sub-query plan expansion caused by a
 # sub-expression being shared by two or more plan nodes does not

--- a/pkg/sql/testdata/window
+++ b/pkg/sql/testdata/window
@@ -487,7 +487,7 @@ EXPLAIN (TYPES) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) 
 3  render/filter  render 2                   (d)[decimal]
 3  render/filter  render 3                   (v)[int]
 3  render/filter  render 4                   (v)[int]
-4  scan           result                     (k int, v int, w int, f float, d decimal, s string, b bool)
+4  scan           result                     (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)
 
 query ITTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
@@ -505,7 +505,7 @@ EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY 
 3  render/filter  render 4                                       ('a')[string]
 3  render/filter  render 5                                       (v)[int]
 3  render/filter  render 6                                       (100)[int]
-4  scan           result                                         (k int, v int, w int, f float, d decimal, s string, b bool)
+4  scan           result                                         (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)
 
 query ITTT
 EXPLAIN (TYPES) SELECT k, k + stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
@@ -524,7 +524,7 @@ EXPLAIN (TYPES) SELECT k, k + stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER
 3  render/filter  render 5                                         (v)[int]
 3  render/filter  render 6                                         (100)[int]
 3  render/filter  render 7                                         (k)[int]
-4  scan           result                                           (k int, v int, w int, f float, d decimal, s string, b bool)
+4  scan           result                                           (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)
 
 statement OK
 INSERT INTO kv VALUES

--- a/pkg/sql/trace.go
+++ b/pkg/sql/trace.go
@@ -214,3 +214,4 @@ func (n *explainTraceNode) Values() parser.DTuple {
 func (*explainTraceNode) MarkDebug(_ explainMode)      {}
 func (*explainTraceNode) DebugValues() debugValues     { return debugValues{} }
 func (*explainTraceNode) SetLimitHint(_ int64, _ bool) {}
+func (*explainTraceNode) setNeededColumns(_ []bool)    {}

--- a/pkg/sql/union.go
+++ b/pkg/sql/union.go
@@ -156,6 +156,8 @@ func (n *unionNode) SetLimitHint(numRows int64, soft bool) {
 	n.left.SetLimitHint(numRows, true)
 }
 
+func (n *unionNode) setNeededColumns(_ []bool) {}
+
 func (n *unionNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
 	return "union", "-", []planNode{n.left, n.right}
 }

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -459,3 +459,4 @@ func (u *updateNode) ExplainTypes(regTypes func(string, string)) {
 }
 
 func (u *updateNode) SetLimitHint(numRows int64, soft bool) {}
+func (u *updateNode) setNeededColumns(_ []bool)             {}

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -342,3 +342,4 @@ func (n *valuesNode) ExplainTypes(regTypes func(string, string)) {
 }
 
 func (*valuesNode) SetLimitHint(_ int64, _ bool) {}
+func (*valuesNode) setNeededColumns(_ []bool)    {}

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -772,6 +772,7 @@ func (n *windowNode) ExplainTypes(regTypes func(string, string)) {
 }
 
 func (*windowNode) SetLimitHint(_ int64, _ bool) {}
+func (*windowNode) setNeededColumns(_ []bool)    {}
 
 func (n *windowNode) Close() {
 	n.plan.Close()


### PR DESCRIPTION
Currently for any join, the scanNodes decode and return all the columns in the table. This is not ideal and will be even more of a problem with distSQL which uses the scanNodes for physical planning.

This set of commits plumbs the "val needed for column" information through joins.

CC @a6802739

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11736)
<!-- Reviewable:end -->
