### PR TITLE
storage: speed up TestSkipLargeReplicaSnapshot

### DIFF
--- a/pkg/storage/client_bench_test.go
+++ b/pkg/storage/client_bench_test.go
@@ -39,7 +39,9 @@ func BenchmarkReplicaSnapshot(b *testing.B) {
 	}
 
 	snapSize := rep.GetMaxBytes()
-	fillTestRange(b, rep, snapSize)
+	if err := fillTestRange(rep, snapSize); err != nil {
+		b.Fatal(err)
+	}
 	b.SetBytes(snapSize)
 
 	b.ResetTimer()


### PR DESCRIPTION
Before: 12.170s
After: 0.142s

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11752)
<!-- Reviewable:end -->
