### PR TITLE
sql: refactor some SQL functions

### DIFF
--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -24,6 +24,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -737,6 +738,15 @@ func matchesIndex(
 	return true
 }
 
+func (p *planner) resolveFK(
+	tbl *sqlbase.TableDescriptor,
+	d *parser.ForeignKeyConstraintTableDef,
+	backrefs map[sqlbase.ID]*sqlbase.TableDescriptor,
+	mode sqlbase.ConstraintValidity,
+) error {
+	return resolveFK(p.txn, &p.session.virtualSchemas, tbl, d, backrefs, mode)
+}
+
 // resolveFK looks up the tables and columns mentioned in a `REFERENCES`
 // constraint and adds metadata representing that constraint to the descriptor.
 // It may, in doing so, add to or alter descriptors in the passed in `backrefs`
@@ -745,14 +755,16 @@ func matchesIndex(
 // "unvalidated", but when table is empty (e.g. during creation), no existing
 // data imples no existing violations, and thus the constraint can be created
 // without the unvalidated flag.
-func (p *planner) resolveFK(
+func resolveFK(
+	txn *client.Txn,
+	vt VirtualTabler,
 	tbl *sqlbase.TableDescriptor,
 	d *parser.ForeignKeyConstraintTableDef,
 	backrefs map[sqlbase.ID]*sqlbase.TableDescriptor,
 	mode sqlbase.ConstraintValidity,
 ) error {
 	targetTable := d.Table.TableName()
-	target, err := p.getTableDesc(targetTable)
+	target, err := getTableDesc(txn, vt, targetTable)
 	if err != nil {
 		return err
 	}
@@ -942,22 +954,33 @@ func (p *planner) saveNonmutationAndNotify(td *sqlbase.TableDescriptor) error {
 	return nil
 }
 
-// addInterleave marks an index as one that is interleaved in some parent data
-// according to the given definition.
 func (p *planner) addInterleave(
 	desc *sqlbase.TableDescriptor, index *sqlbase.IndexDescriptor, interleave *parser.InterleaveDef,
+) error {
+	return addInterleave(p.txn, &p.session.virtualSchemas, desc, index, interleave, p.session.Database)
+}
+
+// addInterleave marks an index as one that is interleaved in some parent data
+// according to the given definition.
+func addInterleave(
+	txn *client.Txn,
+	vt VirtualTabler,
+	desc *sqlbase.TableDescriptor,
+	index *sqlbase.IndexDescriptor,
+	interleave *parser.InterleaveDef,
+	sessionDB string,
 ) error {
 	if interleave.DropBehavior != parser.DropDefault {
 		return util.UnimplementedWithIssueErrorf(
 			7854, "unsupported shorthand %s", interleave.DropBehavior)
 	}
 
-	tn, err := interleave.Parent.NormalizeWithDatabaseName(p.session.Database)
+	tn, err := interleave.Parent.NormalizeWithDatabaseName(sessionDB)
 	if err != nil {
 		return err
 	}
 
-	parentTable, err := p.mustGetTableDesc(tn)
+	parentTable, err := mustGetTableDesc(txn, vt, tn)
 	if err != nil {
 		return err
 	}
@@ -1153,11 +1176,15 @@ func makeTableDescIfAs(
 }
 
 // MakeTableDesc creates a table descriptor from a CreateTable statement.
-func (p *planner) makeTableDesc(
+func MakeTableDesc(
+	txn *client.Txn,
+	vt VirtualTabler,
+	searchPath parser.SearchPath,
 	n *parser.CreateTable,
 	parentID, id sqlbase.ID,
 	privileges *sqlbase.PrivilegeDescriptor,
 	affected map[sqlbase.ID]*sqlbase.TableDescriptor,
+	sessionDB string,
 ) (sqlbase.TableDescriptor, error) {
 	desc := sqlbase.TableDescriptor{
 		ID:            id,
@@ -1180,7 +1207,7 @@ func (p *planner) makeTableDesc(
 				}
 			}
 
-			col, idx, err := sqlbase.MakeColumnDefDescs(d, p.session.SearchPath)
+			col, idx, err := sqlbase.MakeColumnDefDescs(d, searchPath)
 			if err != nil {
 				return desc, err
 			}
@@ -1279,7 +1306,7 @@ func (p *planner) makeTableDesc(
 	}
 
 	if n.Interleave != nil {
-		if err := p.addInterleave(&desc, &desc.PrimaryIndex, n.Interleave); err != nil {
+		if err := addInterleave(txn, vt, &desc, &desc.PrimaryIndex, n.Interleave, sessionDB); err != nil {
 			return desc, err
 		}
 	}
@@ -1297,14 +1324,14 @@ func (p *planner) makeTableDesc(
 			// pass, handled above.
 
 		case *parser.CheckConstraintTableDef:
-			ck, err := makeCheckConstraint(desc, d, generatedNames, p.session.SearchPath)
+			ck, err := makeCheckConstraint(desc, d, generatedNames, searchPath)
 			if err != nil {
 				return desc, err
 			}
 			desc.Checks = append(desc.Checks, ck)
 
 		case *parser.ForeignKeyConstraintTableDef:
-			err := p.resolveFK(&desc, d, affected, sqlbase.ConstraintValidity_Validated)
+			err := resolveFK(txn, vt, &desc, d, affected, sqlbase.ConstraintValidity_Validated)
 			if err != nil {
 				return desc, err
 			}
@@ -1329,6 +1356,16 @@ func (p *planner) makeTableDesc(
 	}
 
 	return desc, desc.AllocateIDs()
+}
+
+// makeTableDesc creates a table descriptor from a CreateTable statement.
+func (p *planner) makeTableDesc(
+	n *parser.CreateTable,
+	parentID, id sqlbase.ID,
+	privileges *sqlbase.PrivilegeDescriptor,
+	affected map[sqlbase.ID]*sqlbase.TableDescriptor,
+) (sqlbase.TableDescriptor, error) {
+	return MakeTableDesc(p.txn, &p.session.virtualSchemas, p.session.SearchPath, n, parentID, id, privileges, affected, p.session.Database)
 }
 
 // dummyColumnItem is used in makeCheckConstraint to construct an expression

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -79,7 +79,7 @@ var _ tableWriter = (*tableDeleter)(nil)
 
 // tableInserter handles writing kvs and forming table rows for inserts.
 type tableInserter struct {
-	ri         rowInserter
+	ri         RowInserter
 	autoCommit bool
 
 	// Set by init.
@@ -102,7 +102,7 @@ func (ti *tableInserter) init(txn *client.Txn) error {
 }
 
 func (ti *tableInserter) row(ctx context.Context, values parser.DTuple) (parser.DTuple, error) {
-	return nil, ti.ri.insertRow(ctx, ti.b, values, false)
+	return nil, ti.ri.InsertRow(ctx, ti.b, values, false)
 }
 
 func (ti *tableInserter) finalize(_ context.Context) error {
@@ -202,7 +202,7 @@ type tableUpsertEvaler interface {
 // operated on during `row`, and run during `finalize`. This is the same model
 // as the other `tableFoo`s, which are more simple than upsert.
 type tableUpserter struct {
-	ri            rowInserter
+	ri            RowInserter
 	conflictIndex sqlbase.IndexDescriptor
 
 	// These are set for ON CONFLICT DO UPDATE, but not for DO NOTHING
@@ -298,7 +298,7 @@ func (tu *tableUpserter) init(txn *client.Txn) error {
 func (tu *tableUpserter) row(ctx context.Context, row parser.DTuple) (parser.DTuple, error) {
 	if tu.fastPathBatch != nil {
 		primaryKey, _, err := sqlbase.EncodeIndexKey(
-			tu.tableDesc, &tu.tableDesc.PrimaryIndex, tu.ri.insertColIDtoRowIndex, row, tu.indexKeyPrefix)
+			tu.tableDesc, &tu.tableDesc.PrimaryIndex, tu.ri.InsertColIDtoRowIndex, row, tu.indexKeyPrefix)
 		if err != nil {
 			return nil, err
 		}
@@ -306,7 +306,7 @@ func (tu *tableUpserter) row(ctx context.Context, row parser.DTuple) (parser.DTu
 			return nil, fmt.Errorf("UPSERT/ON CONFLICT DO UPDATE command cannot affect row a second time")
 		}
 		tu.fastPathKeys[string(primaryKey)] = struct{}{}
-		err = tu.ri.insertRow(ctx, tu.fastPathBatch, row, true)
+		err = tu.ri.InsertRow(ctx, tu.fastPathBatch, row, true)
 		return nil, err
 	}
 
@@ -331,7 +331,7 @@ func (tu *tableUpserter) flush(ctx context.Context) error {
 		existingRow := existingRows[i]
 
 		if existingRow == nil {
-			err := tu.ri.insertRow(ctx, b, insertRow, false)
+			err := tu.ri.InsertRow(ctx, b, insertRow, false)
 			if err != nil {
 				return err
 			}
@@ -368,7 +368,7 @@ func (tu *tableUpserter) upsertRowPKs(ctx context.Context) ([]roachpb.Key, error
 		// conflicts.
 		for i, insertRow := range tu.insertRows {
 			upsertRowPK, _, err := sqlbase.EncodeIndexKey(
-				tu.tableDesc, &tu.conflictIndex, tu.ri.insertColIDtoRowIndex, insertRow, tu.indexKeyPrefix)
+				tu.tableDesc, &tu.conflictIndex, tu.ri.InsertColIDtoRowIndex, insertRow, tu.indexKeyPrefix)
 			if err != nil {
 				return nil, err
 			}
@@ -384,7 +384,7 @@ func (tu *tableUpserter) upsertRowPKs(ctx context.Context) ([]roachpb.Key, error
 	b := tu.txn.NewBatch()
 	for _, insertRow := range tu.insertRows {
 		entry, err := sqlbase.EncodeSecondaryIndex(
-			tu.tableDesc, &tu.conflictIndex, tu.ri.insertColIDtoRowIndex, insertRow)
+			tu.tableDesc, &tu.conflictIndex, tu.ri.InsertColIDtoRowIndex, insertRow)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -237,6 +237,12 @@ func (vs *virtualSchemaHolder) getVirtualTableEntry(
 	return virtualTableEntry{}, nil
 }
 
+// VirtualTabler is used to fetch descriptors for virtual tables and databases.
+type VirtualTabler interface {
+	getVirtualTableDesc(tn *parser.TableName) (*sqlbase.TableDescriptor, error)
+	getVirtualDatabaseDesc(name string) *sqlbase.DatabaseDescriptor
+}
+
 // getVirtualTableDesc checks if the provided name matches a virtual database/table
 // pair, and returns its descriptor if it does.
 func (vs *virtualSchemaHolder) getVirtualTableDesc(


### PR DESCRIPTION
This is in preparation for merging the some work currently on a branch, which already has
this change.

Newly exported names: sql.MakeTableDesc, sql.MustGetDatabaseDesc,
sql.ProcessDefaultColumns, sql.GenerateInsertRow, sql.RowInserter,
sql.MakeRowInserter. There are also a few new interfaces for dealing
with RowInserter in a more general way. These have all been added to
split out some of the create and insert logic so that it can be used in
other paths that aren't direct insertion into a SQL table, but instead
allow us to simulate the creation and insertion of tables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11758)
<!-- Reviewable:end -->
