### PR TITLE
storage: replace "available ranges" with "unavailable ranges"

### DIFF
--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -90,7 +90,8 @@ var nodesColumnHeaders = []string{
 	"replicas_leaders",
 	"replicas_leaseholders",
 	"ranges",
-	"ranges_available",
+	"ranges_unavailable",
+	"ranges_underreplicated",
 }
 
 var statusNodeCmd = &cobra.Command{
@@ -179,7 +180,8 @@ func nodeStatusesToRows(statuses []status.NodeStatus) [][]string {
 			strconv.FormatInt(int64(metricVals["replicas.leaders"]), 10),
 			strconv.FormatInt(int64(metricVals["replicas.leaseholders"]), 10),
 			strconv.FormatInt(int64(metricVals["ranges"]), 10),
-			strconv.FormatInt(int64(metricVals["ranges.available"]), 10),
+			strconv.FormatInt(int64(metricVals["ranges.unavailable"]), 10),
+			strconv.FormatInt(int64(metricVals["ranges.underreplicated"]), 10),
 		})
 	}
 	return rows

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -637,7 +637,6 @@ func TestStatusSummaries(t *testing.T) {
 	store1["replicas.leaders"]++
 	store1["replicas.leaseholders"]++
 	store1["ranges"]++
-	store1["ranges.available"]++
 
 	forceWriteStatus()
 	expectedNodeStatus = compareNodeStatus(t, ts, expectedNodeStatus, 3)

--- a/pkg/server/status/recorder_test.go
+++ b/pkg/server/status/recorder_test.go
@@ -211,7 +211,8 @@ func TestMetricsRecorder(t *testing.T) {
 		{"replicas.leaders", "gauge", 1},
 		{"replicas.leaseholders", "gauge", 1},
 		{"ranges", "gauge", 1},
-		{"ranges.available", "gauge", 1},
+		{"ranges.unavailable", "gauge", 1},
+		{"ranges.underreplicated", "gauge", 1},
 	}
 
 	// Add the metrics to each registry and set their values. At the same time,

--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -60,10 +60,10 @@ var (
 	// Range metrics.
 	metaRangeCount = metric.Metadata{Name: "ranges",
 		Help: "Number of ranges"}
-	metaAvailableRangeCount = metric.Metadata{Name: "ranges.available",
-		Help: "Number of ranges with a quorum of live replicas"}
+	metaUnavailableRangeCount = metric.Metadata{Name: "ranges.unavailable",
+		Help: "Number of ranges with fewer live replicas than needed for quorum"}
 	metaUnderReplicatedRangeCount = metric.Metadata{Name: "ranges.underreplicated",
-		Help: "Number of ranges with fewer than the configured number of live replicas"}
+		Help: "Number of ranges with fewer live replicas than the replication target"}
 
 	// Lease request metrics.
 	metaLeaseRequestSuccessCount = metric.Metadata{Name: "leases.success"}
@@ -313,7 +313,7 @@ type StoreMetrics struct {
 
 	// Range metrics.
 	RangeCount                *metric.Gauge
-	AvailableRangeCount       *metric.Gauge
+	UnavailableRangeCount     *metric.Gauge
 	UnderReplicatedRangeCount *metric.Gauge
 
 	// Lease request metrics for successful and failed lease requests. These
@@ -483,7 +483,7 @@ func newStoreMetrics(sampleInterval time.Duration) *StoreMetrics {
 
 		// Range metrics.
 		RangeCount:                metric.NewGauge(metaRangeCount),
-		AvailableRangeCount:       metric.NewGauge(metaAvailableRangeCount),
+		UnavailableRangeCount:     metric.NewGauge(metaUnavailableRangeCount),
 		UnderReplicatedRangeCount: metric.NewGauge(metaUnderReplicatedRangeCount),
 
 		// Lease request metrics.

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3692,7 +3692,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 		quiescentCount                int64
 
 		rangeCount                int64
-		availableRangeCount       int64
+		unavailableRangeCount     int64
 		underreplicatedRangeCount int64
 	)
 
@@ -3752,9 +3752,8 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 			// If this replica is the highest replica ID, it does the counting.
 			if highestIdx != -1 && desc.Replicas[highestIdx].StoreID == s.StoreID() {
 				rangeCount++
-				// If a quorum of replicas are live, consider this range available.
-				if liveReplicas > computeQuorum(len(desc.Replicas)) {
-					availableRangeCount++
+				if liveReplicas < computeQuorum(len(desc.Replicas)) {
+					unavailableRangeCount++
 				}
 
 				if zoneConfig, err := cfg.GetZoneConfigForKey(desc.StartKey); err != nil {
@@ -3776,7 +3775,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 	s.metrics.QuiescentCount.Update(quiescentCount)
 
 	s.metrics.RangeCount.Update(rangeCount)
-	s.metrics.AvailableRangeCount.Update(availableRangeCount)
+	s.metrics.UnavailableRangeCount.Update(unavailableRangeCount)
 	s.metrics.UnderReplicatedRangeCount.Update(underreplicatedRangeCount)
 
 	return nil

--- a/pkg/ui/app/containers/nodeOverview.tsx
+++ b/pkg/ui/app/containers/nodeOverview.tsx
@@ -82,11 +82,11 @@ class NodeOverview extends React.Component<NodeOverviewProps, {}> {
                         title="Total Ranges"
                         valueFn={(metrics) => metrics.get(MetricConstants.ranges)} />
               <TableRow data={node}
-                        title="Available"
-                        valueFn={(metrics) => Percentage(metrics.get(MetricConstants.availableRanges), metrics.get(MetricConstants.ranges))} />
+                        title="Unavailable"
+                        valueFn={(metrics) => Percentage(metrics.get(MetricConstants.unavailableRanges), metrics.get(MetricConstants.ranges))} />
               <TableRow data={node}
-                        title="Fully Replicated"
-                        valueFn={(metrics) => Percentage(metrics.get(MetricConstants.replicatedRanges), metrics.get(MetricConstants.ranges))} />
+                        title="Under Replicated"
+                        valueFn={(metrics) => Percentage(metrics.get(MetricConstants.underReplicatedRanges), metrics.get(MetricConstants.ranges))} />
               <TableRow data={node}
                         title="Available Capacity"
                         valueFn={(metrics) => Bytes(metrics.get(MetricConstants.availableCapacity))} />

--- a/pkg/ui/app/util/proto.ts
+++ b/pkg/ui/app/util/proto.ts
@@ -41,8 +41,8 @@ export namespace MetricConstants {
   export const raftLeaders: string = "replicas.leaders";
   export const leaseHolders: string = "replicas.leaseholders";
   export const ranges: string = "ranges";
-  export const availableRanges: string = "ranges.available";
-  export const replicatedRanges: string  = "ranges.allocator.noop";
+  export const unavailableRanges: string = "ranges.unavailable";
+  export const underReplicatedRanges: string  = "ranges.underreplicated";
   export const liveBytes: string = "livebytes";
   export const keyBytes: string = "keybytes";
   export const valBytes: string = "valbytes";


### PR DESCRIPTION
This corrects a bug where ranges were previously considered live
only if they had _more_ live replicas than needed for quorum. In other
words, the old code produced incorrect results for ranges which had
exactly a quorum of live nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11760)
<!-- Reviewable:end -->
