### PR TITLE
util/log: various micro optimizations to log tags

### DIFF
--- a/pkg/kv/range_cache.go
+++ b/pkg/kv/range_cache.go
@@ -295,7 +295,6 @@ func (rdc *rangeDescriptorCache) lookupRangeDescriptorInternal(
 		returnToken := rdc.makeEvictionToken(desc, func() error {
 			return rdc.evictCachedRangeDescriptorLocked(key, desc, useReverseScan)
 		})
-		log.Event(ctx, "looked up range descriptor from cache")
 		return desc, returnToken, nil
 	}
 

--- a/pkg/kv/range_iter.go
+++ b/pkg/kv/range_iter.go
@@ -152,7 +152,6 @@ func (ri *RangeIterator) Seek(ctx context.Context, key roachpb.RKey, scanDir Sca
 	// Retry loop for looking up next range in the span. The retry loop
 	// deals with retryable range descriptor lookups.
 	for r := retry.StartWithCtx(ctx, ri.ds.rpcRetryOptions); r.Next(); {
-		log.Event(ctx, "meta descriptor lookup")
 		var err error
 		ri.desc, ri.token, err = ri.ds.getDescriptor(
 			ctx, ri.key, ri.token, ri.scanDir == Descending)

--- a/pkg/util/log/log_context.go
+++ b/pkg/util/log/log_context.go
@@ -50,13 +50,25 @@ func contextBottomTag(ctx context.Context) *logTag {
 	return val.(*logTag)
 }
 
-func contextLogTags(ctx context.Context) []logTag {
-	var tags []logTag
-	for t := contextBottomTag(ctx); t != nil; t = t.parent {
-		tags = append(tags, *t)
+// contextLogTags returns the tags in the context in order. The given tags
+// buffer is potentially used to avoid allocations.
+func contextLogTags(ctx context.Context, tags []*logTag) []*logTag {
+	t := contextBottomTag(ctx)
+	if t == nil {
+		return nil
 	}
-	for i, j := 0, len(tags)-1; i < j; i, j = i+1, j-1 {
-		tags[i], tags[j] = tags[j], tags[i]
+	var n int
+	for q := t; q != nil; q = q.parent {
+		n++
+	}
+	if cap(tags) < n {
+		tags = make([]*logTag, n)
+	} else {
+		tags = tags[:n]
+	}
+	for ; t != nil; t = t.parent {
+		n--
+		tags[n] = t
 	}
 	return tags
 }


### PR DESCRIPTION
Remove log.Events from RangeIterator and RangeCache that were
repetitive, mildly expensive and not terribly interesting: logging an
event on each iteration of range lookup and logging an event when we
found a range in the cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11778)
<!-- Reviewable:end -->
