### PR TITLE
security: don't hash empty password

### DIFF
--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -57,7 +57,7 @@ eexpect $prompt
 send "$argv user set carl --password --ca-cert=$ca_crt --cert=$root_crt --key=$root_key\r"
 eexpect "Enter password:"
 send "\r"
-eexpect "empty passwords not permitted"
+eexpect "empty passwords are not permitted"
 
 eexpect $prompt
 

--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -53,6 +53,14 @@ eexpect "user root must authenticate using a client certificate"
 
 eexpect $prompt
 
+# Cannot create users with empty passwords.
+send "$argv user set carl --password --ca-cert=$ca_crt --cert=$root_crt --key=$root_key\r"
+eexpect "Enter password:"
+send "\r"
+eexpect "empty passwords not permitted"
+
+eexpect $prompt
+
 send "$argv user set carl --password --ca-cert=$ca_crt --cert=$root_crt --key=$root_key\r"
 eexpect "Enter password:"
 send "woof\r"

--- a/pkg/cli/user.go
+++ b/pkg/cli/user.go
@@ -125,11 +125,6 @@ func runSetUser(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-	} else {
-		hashed, err = security.HashPassword("")
-		if err != nil {
-			return err
-		}
 	}
 
 	conn, err := getPasswordAndMakeSQLClient()

--- a/pkg/security/password.go
+++ b/pkg/security/password.go
@@ -33,6 +33,9 @@ import (
 // For now, we use the library's default cost.
 const bcryptCost = bcrypt.DefaultCost
 
+// ErrEmptyPassword indicates that an empty password was attempted to be set.
+var ErrEmptyPassword = errors.New("empty passwords are not permitted")
+
 func compareHashAndPassword(hashedPassword []byte, password string) error {
 	h := sha256.New()
 	return bcrypt.CompareHashAndPassword(hashedPassword, h.Sum([]byte(password)))
@@ -53,7 +56,7 @@ func PromptForPassword() (string, error) {
 		return "", err
 	}
 	if len(one) == 0 {
-		return "", errors.New("empty passwords not permitted")
+		return "", ErrEmptyPassword
 	}
 	fmt.Print("\nConfirm password: ")
 	two, err := terminal.ReadPassword(syscall.Stdin)

--- a/pkg/security/password.go
+++ b/pkg/security/password.go
@@ -52,6 +52,9 @@ func PromptForPassword() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if len(one) == 0 {
+		return "", errors.New("empty passwords not permitted")
+	}
 	fmt.Print("\nConfirm password: ")
 	two, err := terminal.ReadPassword(syscall.Stdin)
 	if err != nil {
@@ -72,6 +75,9 @@ func PromptForPasswordAndHash() ([]byte, error) {
 	password, err := PromptForPassword()
 	if err != nil {
 		return nil, err
+	}
+	if password == "" {
+		return nil, nil
 	}
 	return HashPassword(password)
 }

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -308,9 +308,13 @@ func (n *createUserNode) expandPlan() error {
 }
 
 func (n *createUserNode) Start() error {
-	hashedPassword, err := security.HashPassword(n.password)
-	if err != nil {
-		return err
+	var hashedPassword []byte
+	if n.password != "" {
+		var err error
+		hashedPassword, err = security.HashPassword(n.password)
+		if err != nil {
+			return err
+		}
 	}
 
 	normalizedUsername := n.n.Name.Normalize()

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -298,6 +298,9 @@ func (p *planner) CreateUser(n *parser.CreateUser) (planNode, error) {
 		}
 
 		resolvedPassword = string(*password.(*parser.DString))
+		if resolvedPassword == "" {
+			return nil, security.ErrEmptyPassword
+		}
 	}
 
 	return &createUserNode{p: p, n: n, password: resolvedPassword}, nil

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1093,6 +1093,13 @@ SELECT ANNOTATE_TYPE(1.2+2.3, notatype)
                               ^
 `,
 		},
+		{
+			`CREATE USER foo WITH PASSWORD`,
+			`syntax error at or near "EOF"
+CREATE USER foo WITH PASSWORD
+                             ^
+`,
+		},
 	}
 	for _, d := range testData {
 		_, err := parseTraditional(d.sql)

--- a/pkg/sql/testdata/user
+++ b/pkg/sql/testdata/user
@@ -20,6 +20,9 @@ CREATE USER user1
 statement error user user1 already exists
 CREATE USER UsEr1
 
+statement error empty passwords are not permitted
+CREATE USER test WITH PASSWORD ''
+
 statement ok
 CREATE USER uSEr2 WITH PASSWORD 'cockroach'
 


### PR DESCRIPTION
Avoid hashing empty password (which happens when creating users with no
password). This makes the sql tests faster. See #11746.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11781)
<!-- Reviewable:end -->
