### PR TITLE
sql: Address merge skew and fix comments

### DIFF
--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -120,7 +120,7 @@ type queryRunner interface {
 	// expected and returns that row.
 	queryRow(sql string, args ...interface{}) (parser.DTuple, error)
 
-	// queryRow executes a SQL query string where multiple result rows are returned.
+	// queryRows executes a SQL query string where multiple result rows are returned.
 	queryRows(sql string, args ...interface{}) ([]parser.DTuple, error)
 
 	// queryRowsAsRoot executes a SQL query string using security.RootUser
@@ -342,7 +342,7 @@ func (p *planner) queryRows(sql string, args ...interface{}) ([]parser.DTuple, e
 	return rows, nil
 }
 
-// queryRows implements the queryRunner interface.
+// queryRowsAsRoot implements the queryRunner interface.
 func (p *planner) queryRowsAsRoot(sql string, args ...interface{}) ([]parser.DTuple, error) {
 	currentUser := p.session.User
 	defer func() { p.session.User = currentUser }()

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -132,7 +132,7 @@ func (p *planner) ShowColumns(n *parser.ShowColumns) (planNode, error) {
 		constructor: func(p *planner) (planNode, error) {
 			const getColumns = `SELECT COLUMN_NAME AS "Field", DATA_TYPE AS "Type", (IS_NULLABLE!='NO') AS "Null",` +
 				` COLUMN_DEFAULT AS "Default" FROM information_schema.columns WHERE TABLE_SCHEMA=$1 AND TABLE_NAME=$2` +
-				` ORDER BY ORDINAL_POSITION;`
+				` ORDER BY ORDINAL_POSITION`
 			{
 				// Check if the database exists by using the security.RootUser.
 				values, err := p.queryRowsAsRoot(checkSchema, tn.Database())
@@ -421,7 +421,7 @@ func (p *planner) ShowCreateView(n *parser.ShowCreateView) (planNode, error) {
 //          mysql has a "SHOW DATABASES" permission, but we have no system-level permissions.
 func (p *planner) ShowDatabases(n *parser.ShowDatabases) (planNode, error) {
 	const getDatabases = `SELECT SCHEMA_NAME AS "Database" FROM information_schema.schemata
-							ORDER BY "Database";`
+							ORDER BY "Database"`
 	stmt, err := parser.ParseOneTraditional(getDatabases)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/testdata/explain
+++ b/pkg/sql/testdata/explain
@@ -135,7 +135,7 @@ EXPLAIN SHOW TABLES
 0  virtual table  SHOW TABLES FROM test
 1  sort           +TABLE_NAME
 2  virtual table  information_schema.tables
-3  values         5 columns, 35 rows
+3  values         5 columns, 36 rows
 
 query ITT
 EXPLAIN SHOW DATABASE


### PR DESCRIPTION
Addresses merge skew introduced when merging #10196. My hypothesis for
what caused the issue is that #10196 introduced a dependency on the
number of system tables (see `testdata/explain:138`), and #11725 was
merged under the change, adding a new table to `pg_catalog`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11794)
<!-- Reviewable:end -->
