### PR TITLE
build/teamcity-stress-meta: always rebuild teamcity-trigger

### DIFF
--- a/build/teamcity-stress-meta.sh
+++ b/build/teamcity-stress-meta.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
+build/builder.sh make .bootstrap # explicitly recompile teamcity-trigger
 build/builder.sh env TC_API_USER="$TC_API_USER" TC_API_PASSWORD="$TC_API_PASSWORD" TC_SERVER_URL="$TC_SERVER_URL" teamcity-trigger

--- a/pkg/cmd/teamcity-trigger/main_test.go
+++ b/pkg/cmd/teamcity-trigger/main_test.go
@@ -1,0 +1,39 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tamir Duberstein (tamird@gmail.com)
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRunTC(t *testing.T) {
+	count := 0
+	runTC(func(parameters map[string]string) {
+		count++
+		if pkg, ok := parameters["env.PKG"]; ok {
+			if strings.Contains(pkg, "/vendor/") {
+				t.Errorf("unexpected package %s", pkg)
+			}
+		} else {
+			t.Errorf("parameters did not include package: %+v", parameters)
+		}
+	})
+	if count == 0 {
+		t.Fatal("no builds were created")
+	}
+}


### PR DESCRIPTION
Sigh. Closed all the issues again:
```
require 'octokit'
client = Octokit::Client.new(access_token: 'd34db33f')
client.auto_paginate = true
client.search_issues(
  'github.com/cockroachdb/cockroach/vendor',
  repo: 'cockroachdb/cockroach',
).items.select do |item|
  item.title.include?('github.com/cockroachdb/cockroach/vendor/') && item.state == 'open'
end.each do |item|
  client.close_issue('cockroachdb/cockroach', item.number)
end
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11979)
<!-- Reviewable:end -->
