### PR TITLE
storage: avoid storing stopper on testContext

### DIFF
--- a/pkg/storage/addressing_test.go
+++ b/pkg/storage/addressing_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
 type metaRecord struct {
@@ -67,8 +68,9 @@ func metaKey(key roachpb.RKey) []byte {
 // correctly updated on creation of new range descriptors.
 func TestUpdateRangeAddressing(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 
 	// When split is false, merging treats the right range as the merged
 	// range. With merging, expNewLeft indicates the addressing keys we

--- a/pkg/storage/client_bench_test.go
+++ b/pkg/storage/client_bench_test.go
@@ -21,6 +21,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
@@ -28,8 +29,9 @@ func BenchmarkReplicaSnapshot(b *testing.B) {
 	defer tracing.Disable()()
 	storeCfg := TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper := createTestStoreWithConfig(b, &storeCfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(b, stopper, &storeCfg)
 	// We want to manually control the size of the raft log.
 	store.SetRaftLogQueueActive(false)
 

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -324,8 +324,9 @@ func TestStoreRangeMergeLastRange(t *testing.T) {
 // that are not on the same stores.
 func TestStoreRangeMergeNonCollocated(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	mtc := startMultiTestContext(t, 4)
+	mtc := &multiTestContext{}
 	defer mtc.Stop()
+	mtc.Start(t, 4)
 
 	store := mtc.stores[0]
 

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
@@ -69,8 +70,9 @@ func TestStoreRangeMergeTwoEmptyRanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper := createTestStoreWithConfig(t, storeCfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	if _, _, err := createSplitRanges(store); err != nil {
 		t.Fatal(err)
@@ -98,8 +100,9 @@ func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper := createTestStoreWithConfig(t, storeCfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	scan := func(f func(roachpb.KeyValue) (bool, error)) {
 		if _, err := engine.MVCCIterate(context.Background(), store.Engine(), roachpb.KeyMin, roachpb.KeyMax, hlc.ZeroTimestamp, true, nil, false, f); err != nil {
@@ -177,8 +180,9 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper := createTestStoreWithConfig(t, storeCfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	content := roachpb.Key("testing!")
 
@@ -305,8 +309,9 @@ func TestStoreRangeMergeLastRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper := createTestStoreWithConfig(t, storeCfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	// Merge last range.
 	args := adminMergeArgs(roachpb.KeyMin)
@@ -372,8 +377,9 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	manual := hlc.NewManualClock(123)
 	storeCfg := storage.TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper := createTestStoreWithConfig(t, storeCfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	// Split the range.
 	aDesc, bDesc, pErr := createSplitRanges(store)
@@ -432,8 +438,9 @@ func BenchmarkStoreRangeMerge(b *testing.B) {
 	defer tracing.Disable()()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper := createTestStoreWithConfig(b, storeCfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(b, stopper, storeCfg)
 
 	// Perform initial split of ranges.
 	sArgs := adminSplitArgs(roachpb.KeyMin, []byte("b"))

--- a/pkg/storage/client_metrics_test.go
+++ b/pkg/storage/client_metrics_test.go
@@ -168,8 +168,9 @@ func TestStoreMetrics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	t.Skip("TODO(mrtracy): #9204")
 
-	mtc := startMultiTestContext(t, 3)
+	mtc := &multiTestContext{}
 	defer mtc.Stop()
+	mtc.Start(t, 3)
 
 	// Flush RocksDB memtables, so that RocksDB begins using block-based tables.
 	// This is useful, because most of the stats we track don't apply to

--- a/pkg/storage/client_raft_log_queue_test.go
+++ b/pkg/storage/client_raft_log_queue_test.go
@@ -37,7 +37,7 @@ import (
 func TestRaftLogQueue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	var mtc multiTestContext
+	mtc := &multiTestContext{}
 
 	// Set maxBytes to something small so we can trigger the raft log truncation
 	// without adding 64MB of logs.
@@ -53,8 +53,8 @@ func TestRaftLogQueue(t *testing.T) {
 	sc.RaftElectionTimeoutTicks = 1000000
 	mtc.storeConfig = &sc
 
-	mtc.Start(t, 3)
 	defer mtc.Stop()
+	mtc.Start(t, 3)
 
 	// Write a single value to ensure we have a leader.
 	pArgs := putArgs([]byte("key"), []byte("value"))

--- a/pkg/storage/client_replica_gc_test.go
+++ b/pkg/storage/client_replica_gc_test.go
@@ -70,8 +70,8 @@ func TestReplicaGCQueueDropReplicaDirect(t *testing.T) {
 			return nil
 		}
 
-	mtc.Start(t, numStores)
 	defer mtc.Stop()
+	mtc.Start(t, numStores)
 
 	mtc.replicateRange(rangeID, 1, 2)
 	mtc.unreplicateRange(rangeID, 1)
@@ -90,8 +90,9 @@ func TestReplicaGCQueueDropReplicaDirect(t *testing.T) {
 func TestReplicaGCQueueDropReplicaGCOnScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	mtc := startMultiTestContext(t, 3)
+	mtc := &multiTestContext{}
 	defer mtc.Stop()
+	mtc.Start(t, 3)
 	// Disable the replica gc queue to prevent direct removal of replica.
 	mtc.stores[1].SetReplicaGCQueueActive(false)
 

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -322,8 +322,9 @@ func TestRangeLookupUseReverse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper := createTestStoreWithConfig(t, storeCfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	// Init test ranges:
 	// ["","a"), ["a","c"), ["c","e"), ["e","g") and ["g","\xff\xff").

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -61,8 +61,8 @@ func TestRangeCommandClockUpdate(t *testing.T) {
 		clocks = append(clocks, hlc.NewClock(manuals[i].UnixNano, 100*time.Millisecond))
 	}
 	mtc := &multiTestContext{clocks: clocks}
-	mtc.Start(t, numNodes)
 	defer mtc.Stop()
+	mtc.Start(t, numNodes)
 	mtc.replicateRange(1, 1, 2)
 
 	// Advance the lease holder's clock ahead of the followers (by more than
@@ -109,8 +109,8 @@ func TestRejectFutureCommand(t *testing.T) {
 	manual := hlc.NewManualClock(123)
 	clock := hlc.NewClock(manual.UnixNano, 100*time.Millisecond)
 	mtc := &multiTestContext{clock: clock}
-	mtc.Start(t, 1)
 	defer mtc.Stop()
+	mtc.Start(t, 1)
 
 	ts1 := clock.Now()
 
@@ -481,8 +481,8 @@ func TestRangeTransferLease(t *testing.T) {
 	}
 	mtc := &multiTestContext{}
 	mtc.storeConfig = &cfg
-	mtc.Start(t, 2)
 	defer mtc.Stop()
+	mtc.Start(t, 2)
 
 	// First, do a write; we'll use it to determine when the dust has settled.
 	leftKey := roachpb.Key("a")
@@ -686,8 +686,8 @@ func TestLeaseNotUsedAfterRestart(t *testing.T) {
 		}
 	}
 	mtc := &multiTestContext{storeConfig: &sc}
-	mtc.Start(t, 1)
 	defer mtc.Stop()
+	mtc.Start(t, 1)
 
 	// Send a read, to acquire a lease.
 	getArgs := getArgs([]byte("a"))
@@ -952,8 +952,9 @@ func TestErrorHandlingForNonKVCommand(t *testing.T) {
 
 func TestRangeInfo(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	mtc := startMultiTestContext(t, 2)
+	mtc := &multiTestContext{}
 	defer mtc.Stop()
+	mtc.Start(t, 2)
 
 	// Up-replicate to two replicas.
 	mtc.replicateRange(mtc.stores[0].LookupReplica(roachpb.RKeyMin, nil).RangeID, 1)

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -919,8 +919,9 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 func runSetupSplitSnapshotRace(
 	t *testing.T, testFn func(*multiTestContext, roachpb.Key, roachpb.Key),
 ) {
-	mtc := startMultiTestContext(t, 6)
+	mtc := &multiTestContext{}
 	defer mtc.Stop()
+	mtc.Start(t, 6)
 
 	leftKey := roachpb.Key("a")
 	rightKey := roachpb.Key("z")
@@ -1403,8 +1404,8 @@ func TestStoreRangeSplitRaceUninitializedRHS(t *testing.T) {
 	}
 
 	mtc.storeConfig = &storeCfg
-	mtc.Start(t, 2)
 	defer mtc.Stop()
+	mtc.Start(t, 2)
 
 	leftRange := mtc.stores[0].LookupReplica(roachpb.RKey("a"), nil)
 
@@ -1490,8 +1491,8 @@ func TestLeaderAfterSplit(t *testing.T) {
 	mtc := &multiTestContext{
 		storeConfig: &storeConfig,
 	}
-	mtc.Start(t, 3)
 	defer mtc.Stop()
+	mtc.Start(t, 3)
 
 	mtc.replicateRange(1, 1, 2)
 

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -71,8 +72,9 @@ func adminSplitArgs(key, splitKey roachpb.Key) roachpb.AdminSplitRequest {
 // at illegal keys.
 func TestStoreRangeSplitAtIllegalKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, stopper, _ := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 
 	for _, key := range []roachpb.Key{
 		keys.Meta1Prefix,
@@ -95,8 +97,9 @@ func TestStoreRangeSplitAtTablePrefix(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper := createTestStoreWithConfig(t, storeCfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	key := keys.MakeRowSentinelKey(append([]byte(nil), keys.UserTableDataMin...))
 	args := adminSplitArgs(key, key)
@@ -147,8 +150,9 @@ func TestStoreRangeSplitInsideRow(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper := createTestStoreWithConfig(t, storeCfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	// Manually create some the column keys corresponding to the table:
 	//
@@ -200,8 +204,9 @@ func TestStoreRangeSplitIntents(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper := createTestStoreWithConfig(t, storeCfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	// First, write some values left and right of the proposed split key.
 	pArgs := putArgs([]byte("c"), []byte("foo"))
@@ -261,8 +266,9 @@ func TestStoreRangeSplitAtRangeBounds(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper := createTestStoreWithConfig(t, storeCfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	args := adminSplitArgs(roachpb.KeyMin, []byte("a"))
 	if _, err := client.SendWrapped(context.Background(), rg1(store), &args); err != nil {
@@ -286,8 +292,9 @@ func TestStoreRangeSplitConcurrent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper := createTestStoreWithConfig(t, storeCfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	splitKey := roachpb.Key("a")
 	concurrentCount := 10
@@ -344,8 +351,9 @@ func TestStoreRangeSplitIdempotency(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper := createTestStoreWithConfig(t, storeCfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, storeCfg)
 	rangeID := roachpb.RangeID(1)
 	splitKey := roachpb.Key("m")
 	content := roachpb.Key("asdvb")
@@ -493,8 +501,9 @@ func TestStoreRangeSplitStats(t *testing.T) {
 	manual := hlc.NewManualClock(123)
 	storeCfg := storage.TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper := createTestStoreWithConfig(t, storeCfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	// Split the range after the last table data key.
 	keyPrefix := keys.MakeTablePrefix(keys.MaxReservedDescID + 1)
@@ -602,8 +611,9 @@ func TestStoreRangeSplitStatsWithMerges(t *testing.T) {
 	manual := hlc.NewManualClock(123)
 	storeCfg := storage.TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper := createTestStoreWithConfig(t, storeCfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	// Split the range after the last table data key.
 	keyPrefix := keys.MakeTablePrefix(keys.MaxReservedDescID + 1)
@@ -702,9 +712,10 @@ func fillRange(
 // exceeding zone's RangeMaxBytes.
 func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, stopper, _ := createTestStore(t)
-	config.TestingSetupZoneConfigHook(stopper)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
+	config.TestingSetupZoneConfigHook(stopper)
 
 	const maxBytes = 1 << 16
 	// Set max bytes.
@@ -757,9 +768,10 @@ func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 // split.
 func TestStoreRangeSplitWithMaxBytesUpdate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, stopper, _ := createTestStore(t)
-	config.TestingSetupZoneConfigHook(stopper)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
+	config.TestingSetupZoneConfigHook(stopper)
 
 	origRng := store.LookupReplica(roachpb.RKeyMin, nil)
 
@@ -791,8 +803,9 @@ func TestStoreRangeSplitWithMaxBytesUpdate(t *testing.T) {
 // the SystemConfig span.
 func TestStoreRangeSystemSplits(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, stopper, _ := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 
 	schema := sqlbase.MakeMetadataSchema()
 	initialSystemValues := schema.GetInitialValues()
@@ -1125,8 +1138,9 @@ func TestStoreSplitTimestampCacheReadRace(t *testing.T) {
 			}
 			return nil
 		}
-	store, stopper := createTestStoreWithConfig(t, storeCfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	now := store.Clock().Now()
 
@@ -1505,8 +1519,9 @@ func BenchmarkStoreRangeSplit(b *testing.B) {
 	defer tracing.Disable()()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper := createTestStoreWithConfig(b, storeCfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(b, stopper, storeCfg)
 
 	// Perform initial split of ranges.
 	sArgs := adminSplitArgs(roachpb.KeyMin, []byte("b"))
@@ -1669,8 +1684,9 @@ func TestStoreSplitBeginTxnPushMetaIntentRace(t *testing.T) {
 		}
 		return nil
 	}
-	store, stopper := createTestStoreWithConfig(t, storeCfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	// Advance the clock past the transaction cleanup expiration.
 	manual.Increment(storage.GetGCQueueTxnCleanupThreshold().Nanoseconds() + 1)
@@ -1744,9 +1760,10 @@ func TestStoreRangeGossipOnSplits(t *testing.T) {
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.GossipWhenCapacityDeltaExceedsFraction = 0.5 // 50% for testing
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper := createTestStoreWithConfig(t, storeCfg)
-	storeKey := gossip.MakeStoreKey(store.StoreID())
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, storeCfg)
+	storeKey := gossip.MakeStoreKey(store.StoreID())
 
 	// Avoid excessive logging on under-replicated ranges due to our many splits.
 	config.TestingSetupZoneConfigHook(stopper)

--- a/pkg/storage/client_status_test.go
+++ b/pkg/storage/client_status_test.go
@@ -30,8 +30,9 @@ import (
 
 func TestComputeStatsForKeySpan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	mtc := startMultiTestContext(t, 3)
+	mtc := &multiTestContext{}
 	defer mtc.Stop()
+	mtc.Start(t, 3)
 
 	// Create a number of ranges using splits.
 	splitKeys := []string{"a", "c", "e", "g", "i"}

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -224,14 +224,6 @@ func (m *multiTestContext) getNodeIDAddress(nodeID roachpb.NodeID) (net.Addr, er
 	return nil, errors.Errorf("unknown peer %d", nodeID)
 }
 
-// startMultiTestContext is a convenience function to create, start, and return
-// a multiTestContext.
-func startMultiTestContext(t *testing.T, numStores int) *multiTestContext {
-	m := &multiTestContext{}
-	m.Start(t, numStores)
-	return m
-}
-
 func (m *multiTestContext) Start(t *testing.T, numStores int) {
 	{
 		// Only the fields we nil out below can be injected into m as it

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -80,18 +80,17 @@ func rg1(s *storage.Store) client.Sender {
 }
 
 // createTestStore creates a test store using an in-memory
-// engine. The caller is responsible for stopping the stopper on exit.
-func createTestStore(t testing.TB) (*storage.Store, *stop.Stopper, *hlc.ManualClock) {
+// engine.
+func createTestStore(t testing.TB, stopper *stop.Stopper) (*storage.Store, *hlc.ManualClock) {
 	manual := hlc.NewManualClock(123)
 	cfg := storage.TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
-	store, stopper := createTestStoreWithConfig(t, cfg)
-	return store, stopper, manual
+	store := createTestStoreWithConfig(t, stopper, cfg)
+	return store, manual
 }
 
 func createTestStoreWithConfig(
-	t testing.TB, storeCfg storage.StoreConfig,
-) (*storage.Store, *stop.Stopper) {
-	stopper := stop.NewStopper()
+	t testing.TB, stopper *stop.Stopper, storeCfg storage.StoreConfig,
+) *storage.Store {
 	eng := engine.NewInMem(roachpb.Attributes{}, 10<<20)
 	stopper.AddCloser(eng)
 	store := createTestStoreWithEngine(t,
@@ -100,7 +99,7 @@ func createTestStoreWithConfig(
 		storeCfg,
 		stopper,
 	)
-	return store, stopper
+	return store
 }
 
 // createTestStoreWithEngine creates a test store using the given engine and clock.

--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
@@ -54,8 +55,9 @@ func makeTS(nanos int64, logical int32) hlc.Timestamp {
 func TestGCQueueShouldQueue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
-	tc.Start(t)
-	defer tc.Stop()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	tc.Start(t, stopper)
 
 	cfg, ok := tc.gossip.GetSystemConfig()
 	if !ok {
@@ -163,8 +165,9 @@ func TestGCQueueShouldQueue(t *testing.T) {
 func TestGCQueueProcess(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
-	tc.Start(t)
-	defer tc.Stop()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	tc.Start(t, stopper)
 
 	tc.manualClock.Increment(48 * 60 * 60 * 1E9) // 2d past the epoch
 	now := tc.Clock().Now().WallTime
@@ -453,8 +456,9 @@ func TestGCQueueTransactionTable(t *testing.T) {
 			return nil
 		}
 	tc := testContext{manualClock: manual}
-	tc.StartWithStoreConfig(t, tsc)
-	defer tc.Stop()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	tc.StartWithStoreConfig(t, stopper, tsc)
 
 	outsideKey := tc.repl.Desc().EndKey.Next().AsRawKey()
 	testIntents := []roachpb.Span{{Key: roachpb.Key("intent")}}
@@ -566,8 +570,9 @@ func TestGCQueueTransactionTable(t *testing.T) {
 func TestGCQueueIntentResolution(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
-	tc.Start(t)
-	defer tc.Stop()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	tc.Start(t, stopper)
 
 	tc.manualClock.Set(48 * 60 * 60 * 1E9) // 2d past the epoch
 	now := tc.Clock().Now().WallTime
@@ -630,8 +635,9 @@ func TestGCQueueIntentResolution(t *testing.T) {
 func TestGCQueueLastProcessedTimestamps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
-	tc.Start(t)
-	defer tc.Stop()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	tc.Start(t, stopper)
 
 	// Create two last processed times both at the range start key and
 	// also at some mid-point key in order to simulate a merge.

--- a/pkg/storage/id_alloc_test.go
+++ b/pkg/storage/id_alloc_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
 // TestIDAllocator creates an ID allocator which allocates from
@@ -40,8 +41,9 @@ import (
 // from 2 to 101 are present.
 func TestIDAllocator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 	const maxI, maxJ = 10, 10
 	allocd := make(chan uint32, maxI*maxJ)
 	errChan := make(chan error, maxI*maxJ)
@@ -92,8 +94,9 @@ func TestIDAllocator(t *testing.T) {
 // and push the id allocation into positive integers.
 func TestIDAllocatorNegativeValue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 
 	// Increment our key to a negative value.
 	newValue, err := engine.MVCCIncrement(context.Background(), store.Engine(), nil, keys.RangeIDGenerator, store.cfg.Clock.Now(), nil, -1024)
@@ -142,8 +145,9 @@ func TestNewIDAllocatorInvalidArgs(t *testing.T) {
 // 5) Check if the following allocations return correctly.
 func TestAllocateErrorAndRecovery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 	const routines = 10
 	allocd := make(chan uint32, routines)
 
@@ -235,7 +239,8 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 
 func TestAllocateWithStopper(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
+	store, _ := createTestStore(t, stopper)
 	idAlloc, err := newIDAllocator(
 		log.AmbientContext{}, keys.RangeIDGenerator, store.cfg.DB, 2, 10, stopper,
 	)

--- a/pkg/storage/intent_resolver_test.go
+++ b/pkg/storage/intent_resolver_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
 // TestPushTransactionsWithNonPendingIntent verifies that maybePushTransactions
@@ -33,8 +34,9 @@ func TestPushTransactionsWithNonPendingIntent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	tc := testContext{}
-	tc.Start(t)
-	defer tc.Stop()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	tc.Start(t, stopper)
 
 	intents := []roachpb.Intent{{Span: roachpb.Span{Key: roachpb.Key("a")}, Status: roachpb.ABORTED}}
 	if _, pErr := tc.store.intentResolver.maybePushTransactions(

--- a/pkg/storage/node_liveness_test.go
+++ b/pkg/storage/node_liveness_test.go
@@ -58,8 +58,9 @@ func stopNodeLivenessHeartbeats(mtc *multiTestContext) {
 
 func TestNodeLiveness(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	mtc := startMultiTestContext(t, 3)
+	mtc := &multiTestContext{}
 	defer mtc.Stop()
+	mtc.Start(t, 3)
 
 	// Verify liveness of all nodes for all nodes.
 	verifyLiveness(t, mtc)
@@ -98,8 +99,9 @@ func TestNodeLiveness(t *testing.T) {
 // live.
 func TestNodeLivenessEpochIncrement(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	mtc := startMultiTestContext(t, 2)
+	mtc := &multiTestContext{}
 	defer mtc.Stop()
+	mtc.Start(t, 2)
 
 	verifyLiveness(t, mtc)
 	stopNodeLivenessHeartbeats(mtc)
@@ -149,8 +151,9 @@ func TestNodeLivenessEpochIncrement(t *testing.T) {
 // restarted, the node liveness records are re-gossiped immediately.
 func TestNodeLivenessRestart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	mtc := startMultiTestContext(t, 2)
+	mtc := &multiTestContext{}
 	defer mtc.Stop()
+	mtc.Start(t, 2)
 
 	// After verifying node is in liveness table, stop store.
 	verifyLiveness(t, mtc)
@@ -204,8 +207,9 @@ func TestNodeLivenessRestart(t *testing.T) {
 // might be received belatedly through gossip.
 func TestNodeLivenessSelf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	mtc := startMultiTestContext(t, 1)
+	mtc := &multiTestContext{}
 	defer mtc.Stop()
+	mtc.Start(t, 1)
 
 	// Verify liveness of all nodes for all nodes.
 	stopNodeLivenessHeartbeats(mtc)
@@ -254,8 +258,9 @@ func TestNodeLivenessSelf(t *testing.T) {
 
 func TestNodeLivenessGetLivenessMap(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	mtc := startMultiTestContext(t, 3)
+	mtc := &multiTestContext{}
 	defer mtc.Stop()
+	mtc.Start(t, 3)
 
 	verifyLiveness(t, mtc)
 	stopNodeLivenessHeartbeats(mtc)

--- a/pkg/storage/queue_test.go
+++ b/pkg/storage/queue_test.go
@@ -411,8 +411,9 @@ func TestBaseQueueAddRemove(t *testing.T) {
 // rejected when the queue has 'acceptsUnsplitRanges = false'.
 func TestAcceptsUnsplitRanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	s, _ := createTestStore(t, stopper)
 
 	dataMaxAddr, err := keys.Addr(keys.SystemConfigTableDataMax)
 	if err != nil {

--- a/pkg/storage/raft_log_queue_test.go
+++ b/pkg/storage/raft_log_queue_test.go
@@ -21,14 +21,15 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/etcd/raft"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/coreos/etcd/raft"
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
 func TestGetQuorumIndex(t *testing.T) {
@@ -114,8 +115,9 @@ func TestComputeTruncatableIndex(t *testing.T) {
 // removed.
 func TestGetTruncatableIndexes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 	store.SetRaftLogQueueActive(false)
 
 	r, err := store.GetReplica(1)
@@ -227,8 +229,9 @@ func TestProactiveRaftLogTruncate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	t.Skip("#9772")
 
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 
 	store.SetReplicaScannerActive(false)
 

--- a/pkg/storage/replica_data_iter_test.go
+++ b/pkg/storage/replica_data_iter_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
@@ -115,8 +116,9 @@ func TestReplicaDataIteratorEmptyRange(t *testing.T) {
 	tc := testContext{
 		bootstrapMode: bootstrapRangeOnly,
 	}
-	tc.Start(t)
-	defer tc.Stop()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	tc.Start(t, stopper)
 
 	// Adjust the range descriptor to avoid existing data such as meta
 	// records and config entries during the iteration. This is a rather
@@ -146,8 +148,9 @@ func TestReplicaDataIterator(t *testing.T) {
 	tc := testContext{
 		bootstrapMode: bootstrapRangeOnly,
 	}
-	tc.StartWithStoreConfig(t, cfg)
-	defer tc.Stop()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	tc.StartWithStoreConfig(t, stopper, cfg)
 
 	// See notes in EmptyRange test method for adjustment to descriptor.
 	newDesc := *tc.repl.Desc()

--- a/pkg/storage/replica_raftstorage_test.go
+++ b/pkg/storage/replica_raftstorage_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
 const rangeID = 1
@@ -67,8 +68,9 @@ func TestSkipLargeReplicaSnapshot(t *testing.T) {
 	cfg.RangeMaxBytes = snapSize
 	defer config.TestingSetDefaultZoneConfig(cfg)()
 
-	store, stopper := createTestStoreWithConfig(t, &storeCfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, &storeCfg)
 
 	rep, err := store.GetReplica(rangeID)
 	if err != nil {

--- a/pkg/storage/replicate_queue_test.go
+++ b/pkg/storage/replicate_queue_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -34,7 +35,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/pkg/errors"
 )
 
 func TestReplicateQueueRebalance(t *testing.T) {

--- a/pkg/storage/replicate_test.go
+++ b/pkg/storage/replicate_test.go
@@ -19,16 +19,19 @@ package storage_test
 import (
 	"testing"
 
+	"github.com/pkg/errors"
+
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
 func TestEagerReplication(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, stopper, _ := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 
 	// Disable the replica scanner so that we rely on the eager replication code
 	// path that occurs after splits.

--- a/pkg/storage/split_queue_test.go
+++ b/pkg/storage/split_queue_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
 // TestSplitQueueShouldQueue verifies shouldQueue method correctly
@@ -36,8 +37,9 @@ import (
 func TestSplitQueueShouldQueue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
-	tc.Start(t)
-	defer tc.Stop()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	tc.Start(t, stopper)
 
 	// Set zone configs.
 	config.TestingSetZoneConfig(2000, config.ZoneConfig{RangeMaxBytes: 32 << 20})

--- a/pkg/storage/stats_test.go
+++ b/pkg/storage/stats_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
 // initialStats are the stats for a Replica which has been created through
@@ -41,8 +42,9 @@ func TestRangeStatsEmpty(t *testing.T) {
 	tc := testContext{
 		bootstrapMode: bootstrapRangeOnly,
 	}
-	tc.Start(t)
-	defer tc.Stop()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	tc.Start(t, stopper)
 
 	ms := tc.repl.GetMVCCStats()
 	if exp := initialStats(); !reflect.DeepEqual(ms, exp) {
@@ -53,8 +55,9 @@ func TestRangeStatsEmpty(t *testing.T) {
 func TestRangeStatsInit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
-	tc.Start(t)
-	defer tc.Stop()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	tc.Start(t, stopper)
 	ms := enginepb.MVCCStats{
 		LiveBytes:       1,
 		KeyBytes:        2,

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -140,16 +140,9 @@ func (db *testSender) Send(
 // clock's manual unix nanos time and a stopper. The caller is
 // responsible for stopping the stopper upon completion.
 // Some fields of ctx are populated by this function.
-func createTestStoreWithoutStart(t testing.TB, cfg *StoreConfig) (*Store, *stop.Stopper) {
-	stopper := stop.NewStopper()
+func createTestStoreWithoutStart(t testing.TB, stopper *stop.Stopper, cfg *StoreConfig) *Store {
 	// Setup fake zone config handler.
 	config.TestingSetupZoneConfigHook(stopper)
-
-	defer func() {
-		if t.Failed() {
-			stopper.Stop()
-		}
-	}()
 
 	rpcContext := rpc.NewContext(log.AmbientContext{}, &base.Config{Insecure: true}, cfg.Clock, stopper)
 	server := rpc.NewServer(rpcContext) // never started
@@ -176,10 +169,10 @@ func createTestStoreWithoutStart(t testing.TB, cfg *StoreConfig) (*Store, *stop.
 	if err := store.BootstrapRange(nil); err != nil {
 		t.Fatal(err)
 	}
-	return store, stopper
+	return store
 }
 
-func createTestStore(t testing.TB) (*Store, *hlc.ManualClock, *stop.Stopper) {
+func createTestStore(t testing.TB, stopper *stop.Stopper) (*Store, *hlc.ManualClock) {
 	manual := hlc.NewManualClock(123)
 	cfg := TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
 	// Many tests using this test harness (as opposed to higher-level
@@ -192,16 +185,16 @@ func createTestStore(t testing.TB) (*Store, *hlc.ManualClock, *stop.Stopper) {
 	// The scanner affects background operations; we must also disable
 	// the split queue separately to cover event-driven splits.
 	cfg.TestingKnobs.DisableSplitQueue = true
-	store, stopper := createTestStoreWithConfig(t, &cfg)
-	return store, manual, stopper
+	store := createTestStoreWithConfig(t, stopper, &cfg)
+	return store, manual
 }
 
 // createTestStore creates a test store using an in-memory
 // engine. It returns the store, the store clock's manual unix nanos time
 // and a stopper. The caller is responsible for stopping the stopper
 // upon completion.
-func createTestStoreWithConfig(t testing.TB, cfg *StoreConfig) (*Store, *stop.Stopper) {
-	store, stopper := createTestStoreWithoutStart(t, cfg)
+func createTestStoreWithConfig(t testing.TB, stopper *stop.Stopper, cfg *StoreConfig) *Store {
+	store := createTestStoreWithoutStart(t, stopper, cfg)
 	// Put an empty system config into gossip.
 	if err := store.Gossip().AddInfoProto(gossip.KeySystemConfig,
 		&config.SystemConfig{}, 0); err != nil {
@@ -211,7 +204,7 @@ func createTestStoreWithConfig(t testing.TB, cfg *StoreConfig) (*Store, *stop.St
 		t.Fatal(err)
 	}
 	store.WaitForInit()
-	return store, stopper
+	return store
 }
 
 // TestStoreInitAndBootstrap verifies store initialization and bootstrap.
@@ -224,54 +217,58 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 	stopper.AddCloser(eng)
 	cfg.Transport = NewDummyRaftTransport()
-	store := NewStore(cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
 
-	// Can't start as haven't bootstrapped.
-	if err := store.Start(context.Background(), stopper); err == nil {
-		t.Error("expected failure starting un-bootstrapped store")
-	}
+	{
+		store := NewStore(cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
+		// Can't start as haven't bootstrapped.
+		if err := store.Start(context.Background(), stopper); err == nil {
+			t.Error("expected failure starting un-bootstrapped store")
+		}
 
-	// Bootstrap with a fake ident.
-	if err := store.Bootstrap(testIdent); err != nil {
-		t.Errorf("error bootstrapping store: %s", err)
-	}
+		// Bootstrap with a fake ident.
+		if err := store.Bootstrap(testIdent); err != nil {
+			t.Errorf("error bootstrapping store: %s", err)
+		}
 
-	// Verify we can read the store ident after a flush.
-	if err := eng.Flush(); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := ReadStoreIdent(context.Background(), eng); err != nil {
-		t.Fatalf("unable to read store ident: %s", err)
-	}
+		// Verify we can read the store ident after a flush.
+		if err := eng.Flush(); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := ReadStoreIdent(context.Background(), eng); err != nil {
+			t.Fatalf("unable to read store ident: %s", err)
+		}
 
-	// Try to get 1st range--non-existent.
-	if _, err := store.GetReplica(1); err == nil {
-		t.Error("expected error fetching non-existent range")
-	}
+		// Try to get 1st range--non-existent.
+		if _, err := store.GetReplica(1); err == nil {
+			t.Error("expected error fetching non-existent range")
+		}
 
-	// Bootstrap first range.
-	if err := store.BootstrapRange(nil); err != nil {
-		t.Errorf("failure to create first range: %s", err)
+		// Bootstrap first range.
+		if err := store.BootstrapRange(nil); err != nil {
+			t.Errorf("failure to create first range: %s", err)
+		}
 	}
 
 	// Now, attempt to initialize a store with a now-bootstrapped range.
-	store = NewStore(cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
-	if err := store.Start(context.Background(), stopper); err != nil {
-		t.Errorf("failure initializing bootstrapped store: %s", err)
-	}
-	// 1st range should be available.
-	r, err := store.GetReplica(1)
-	if err != nil {
-		t.Errorf("failure fetching 1st range: %s", err)
-	}
-	rs := r.GetMVCCStats()
+	{
+		store := NewStore(cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
+		if err := store.Start(context.Background(), stopper); err != nil {
+			t.Fatalf("failure initializing bootstrapped store: %s", err)
+		}
+		// 1st range should be available.
+		r, err := store.GetReplica(1)
+		if err != nil {
+			t.Fatalf("failure fetching 1st range: %s", err)
+		}
+		rs := r.GetMVCCStats()
 
-	// Stats should agree with a recomputation.
-	now := r.store.Clock().Now()
-	if ms, err := ComputeStatsForRange(r.Desc(), eng, now.WallTime); err != nil {
-		t.Errorf("failure computing range's stats: %s", err)
-	} else if ms != rs {
-		t.Errorf("expected range's stats to agree with recomputation: %s", pretty.Diff(ms, rs))
+		// Stats should agree with a recomputation.
+		now := r.store.Clock().Now()
+		if ms, err := ComputeStatsForRange(r.Desc(), eng, now.WallTime); err != nil {
+			t.Errorf("failure computing range's stats: %s", err)
+		} else if ms != rs {
+			t.Errorf("expected range's stats to agree with recomputation: %s", pretty.Diff(ms, rs))
+		}
 	}
 }
 
@@ -333,8 +330,9 @@ func createReplica(s *Store, rangeID roachpb.RangeID, start, end roachpb.RKey) *
 
 func TestStoreAddRemoveRanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 	if _, err := store.GetReplica(0); err == nil {
 		t.Error("expected GetRange to fail on missing range")
 	}
@@ -403,8 +401,9 @@ func TestStoreAddRemoveRanges(t *testing.T) {
 // snapshot is applied that advances a replica past a split.
 func TestReplicasByKey(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 
 	// Shrink the main replica.
 	rep, err := store.GetReplica(1)
@@ -444,8 +443,9 @@ func TestReplicasByKey(t *testing.T) {
 
 func TestStoreRemoveReplicaOldDescriptor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 
 	rep, err := store.GetReplica(1)
 	if err != nil {
@@ -478,8 +478,9 @@ func TestStoreRemoveReplicaOldDescriptor(t *testing.T) {
 
 func TestStoreRemoveReplicaDestroy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 
 	repl1, err := store.GetReplica(1)
 	if err != nil {
@@ -514,8 +515,9 @@ func TestStoreRemoveReplicaDestroy(t *testing.T) {
 
 func TestStoreReplicaVisitor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 
 	// Remove range 1.
 	repl1, err := store.GetReplica(1)
@@ -575,8 +577,9 @@ func TestStoreReplicaVisitor(t *testing.T) {
 
 func TestHasOverlappingReplica(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 	if _, err := store.GetReplica(0); err == nil {
 		t.Error("expected GetRange to fail on missing range")
 	}
@@ -632,8 +635,9 @@ func TestHasOverlappingReplica(t *testing.T) {
 
 func TestProcessRangeDescriptorUpdate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 
 	// Clobber the existing range so we can test overlaps that aren't KeyMin or KeyMax.
 	repl1, err := store.GetReplica(1)
@@ -701,8 +705,9 @@ func TestProcessRangeDescriptorUpdate(t *testing.T) {
 // of both a read-only and a read-write command.
 func TestStoreSend(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 	gArgs := getArgs([]byte("a"))
 
 	// Try a successful get request.
@@ -779,8 +784,9 @@ func TestStoreObservedTimestamp(t *testing.T) {
 					}
 					return nil
 				}
-			store, stopper := createTestStoreWithConfig(t, &cfg)
+			stopper := stop.NewStopper()
 			defer stopper.Stop()
+			store := createTestStoreWithConfig(t, stopper, &cfg)
 			txn := newTransaction("test", test.key, 1, enginepb.SERIALIZABLE, store.cfg.Clock)
 			txn.MaxTimestamp = hlc.MaxTimestamp
 			pArgs := putArgs(test.key, []byte("value"))
@@ -841,8 +847,9 @@ func TestStoreAnnotateNow(t *testing.T) {
 						}
 						return nil
 					}
-				store, stopper := createTestStoreWithConfig(t, &cfg)
+				stopper := stop.NewStopper()
 				defer stopper.Stop()
+				store := createTestStoreWithConfig(t, stopper, &cfg)
 				var txn *roachpb.Transaction
 				if useTxn {
 					txn = newTransaction("test", test.key, 1, enginepb.SERIALIZABLE, store.cfg.Clock)
@@ -865,8 +872,9 @@ func TestStoreAnnotateNow(t *testing.T) {
 
 func TestStoreExecuteNoop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 	ba := roachpb.BatchRequest{}
 	ba.RangeID = 1
 	ba.Replica = roachpb.ReplicaDescriptor{StoreID: store.StoreID()}
@@ -887,8 +895,9 @@ func TestStoreExecuteNoop(t *testing.T) {
 // that end keys must sort >= start.
 func TestStoreVerifyKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 	// Try a start key == KeyMax.
 	gArgs := getArgs(roachpb.KeyMax)
 	if _, pErr := client.SendWrapped(context.Background(), store.testSender(), &gArgs); !testutils.IsPError(pErr, "must be less than KeyMax") {
@@ -944,8 +953,9 @@ func TestStoreVerifyKeys(t *testing.T) {
 // TestStoreSendUpdateTime verifies that the node clock is updated.
 func TestStoreSendUpdateTime(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 	args := getArgs([]byte("a"))
 	reqTS := store.cfg.Clock.Now().Add(store.cfg.Clock.MaxOffset().Nanoseconds(), 0)
 	_, pErr := client.SendWrappedWith(context.Background(), store.testSender(), roachpb.Header{Timestamp: reqTS}, &args)
@@ -962,8 +972,9 @@ func TestStoreSendUpdateTime(t *testing.T) {
 // the command to assume the node's wall time.
 func TestStoreSendWithZeroTime(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 	args := getArgs([]byte("a"))
 
 	_, respH, pErr := SendWrapped(context.Background(), store.testSender(), roachpb.Header{}, &args)
@@ -983,8 +994,9 @@ func TestStoreSendWithZeroTime(t *testing.T) {
 // maximum allowed clock offset, the cmd fails.
 func TestStoreSendWithClockOffset(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 	args := getArgs([]byte("a"))
 	// Set args timestamp to exceed max offset.
 	reqTS := store.cfg.Clock.Now().Add(store.cfg.Clock.MaxOffset().Nanoseconds()+1, 0)
@@ -997,8 +1009,9 @@ func TestStoreSendWithClockOffset(t *testing.T) {
 // TestStoreSendBadRange passes a bad range.
 func TestStoreSendBadRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 	args := getArgs([]byte("0"))
 	if _, pErr := client.SendWrappedWith(context.Background(), store.testSender(), roachpb.Header{
 		RangeID: 2, // no such range
@@ -1043,8 +1056,9 @@ func splitTestRange(store *Store, key, splitKey roachpb.RKey, t *testing.T) *Rep
 // within the range's key range.
 func TestStoreSendOutOfRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 
 	repl2 := splitTestRange(store, roachpb.RKeyMin, roachpb.RKey(roachpb.Key("b")), t)
 
@@ -1069,8 +1083,9 @@ func TestStoreSendOutOfRange(t *testing.T) {
 // allocated in successive blocks.
 func TestStoreRangeIDAllocation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 
 	// Range IDs should be allocated from ID 2 (first allocated range)
 	// to rangeIDAllocCount * 3 + 1.
@@ -1090,8 +1105,9 @@ func TestStoreRangeIDAllocation(t *testing.T) {
 // the sorted replicasByKey slice.
 func TestStoreReplicasByKey(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 
 	r0 := store.LookupReplica(roachpb.RKeyMin, nil)
 	r1 := splitTestRange(store, roachpb.RKeyMin, roachpb.RKey("A"), t)
@@ -1133,8 +1149,9 @@ func TestStoreReplicasByKey(t *testing.T) {
 // verify the ranges' max bytes are updated appropriately.
 func TestStoreSetRangesMaxBytes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 
 	baseID := uint32(keys.MaxReservedDescID + 1)
 	testData := []struct {
@@ -1180,8 +1197,9 @@ func TestStoreLongTxnStarvation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	storeCfg := TestStoreConfig(nil)
 	storeCfg.RangeRetryOptions = testRetryOptions()
-	store, stopper := createTestStoreWithConfig(t, &storeCfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, &storeCfg)
 
 	for i, iso := range []enginepb.IsolationType{enginepb.SERIALIZABLE, enginepb.SNAPSHOT} {
 		key := roachpb.Key(fmt.Sprintf("a-%d", i))
@@ -1250,8 +1268,9 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 			}
 			return nil
 		}
-	store, stopper := createTestStoreWithConfig(t, &cfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, &cfg)
 
 	for i, resolvable := range []bool{true, false} {
 		key := roachpb.Key(fmt.Sprintf("key-%d", i))
@@ -1309,8 +1328,9 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 // intent by aborting it yields the previous value.
 func TestStoreResolveWriteIntentRollback(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 
 	key := roachpb.Key("a")
 	pusher := newTransaction("test", key, 1, enginepb.SERIALIZABLE, store.cfg.Clock)
@@ -1348,8 +1368,9 @@ func TestStoreResolveWriteIntentPushOnRead(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	storeCfg := TestStoreConfig(nil)
 	storeCfg.RangeRetryOptions = testRetryOptions()
-	store, stopper := createTestStoreWithConfig(t, &storeCfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, &storeCfg)
 
 	testCases := []struct {
 		resolvable bool
@@ -1467,8 +1488,9 @@ func TestStoreResolveWriteIntentPushOnRead(t *testing.T) {
 // timestamp can always be pushed if txn has snapshot isolation.
 func TestStoreResolveWriteIntentSnapshotIsolation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 
 	key := roachpb.Key("a")
 
@@ -1523,8 +1545,9 @@ func TestStoreResolveWriteIntentSnapshotIsolation(t *testing.T) {
 // which are not part of a transaction can push intents.
 func TestStoreResolveWriteIntentNoTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 
 	key := roachpb.Key("a")
 	pushee := newTransaction("test", key, 1, enginepb.SERIALIZABLE, store.cfg.Clock)
@@ -1616,8 +1639,9 @@ func TestStoreReadInconsistent(t *testing.T) {
 	// intent, while preserving the Txn record. Turn off
 	// automatic cleanup for this to work.
 	defer setTxnAutoGC(false)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 
 	for _, canPush := range []bool{true, false} {
 		keyA := roachpb.Key(fmt.Sprintf("%t-a", canPush))
@@ -1735,8 +1759,9 @@ func TestStoreScanIntents(t *testing.T) {
 			}
 			return nil
 		}
-	store, stopper := createTestStoreWithConfig(t, &cfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, &cfg)
 
 	testCases := []struct {
 		consistent bool
@@ -1855,8 +1880,9 @@ func TestStoreScanInconsistentResolvesIntents(t *testing.T) {
 			}
 			return nil
 		}
-	store, stopper := createTestStoreWithConfig(t, &cfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, &cfg)
 
 	// Lay down 10 intents to scan over.
 	txn := newTransaction("test", roachpb.Key("foo"), 1, enginepb.SERIALIZABLE, store.cfg.Clock)
@@ -1903,8 +1929,9 @@ func TestStoreScanInconsistentResolvesIntents(t *testing.T) {
 // TODO(kkaneda): Add more test cases.
 func TestStoreBadRequests(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store, _ := createTestStore(t, stopper)
 
 	txn := newTransaction("test", roachpb.Key("a"), 1 /* priority */, enginepb.SERIALIZABLE, store.cfg.Clock)
 
@@ -1989,8 +2016,9 @@ func (fq *fakeRangeQueue) MaybeRemove(rangeID roachpb.RangeID) {
 func TestMaybeRemove(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	cfg := TestStoreConfig(nil)
-	store, stopper := createTestStoreWithoutStart(t, &cfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithoutStart(t, stopper, &cfg)
 
 	// Add a queue to the scanner before starting the store and running the scanner.
 	// This is necessary to avoid data race.
@@ -2145,8 +2173,9 @@ func TestStoreNoConcurrentRaftSnapshots(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	cfg := TestStoreConfig(nil)
 	cfg.concurrentSnapshotLimit = 1
-	store, stopper := createTestStoreWithConfig(t, &cfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, &cfg)
 
 	if !store.AcquireRaftSnapshot() {
 		t.Fatal("expected true")

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -201,7 +201,6 @@ func createTestStore(t testing.TB) (*Store, *hlc.ManualClock, *stop.Stopper) {
 // and a stopper. The caller is responsible for stopping the stopper
 // upon completion.
 func createTestStoreWithConfig(t testing.TB, cfg *StoreConfig) (*Store, *stop.Stopper) {
-
 	store, stopper := createTestStoreWithoutStart(t, cfg)
 	// Put an empty system config into gossip.
 	if err := store.Gossip().AddInfoProto(gossip.KeySystemConfig,
@@ -2022,8 +2021,9 @@ func TestMaybeRemove(t *testing.T) {
 func TestStoreChangeFrozen(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
-	tc.Start(t)
-	defer tc.Stop()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	tc.Start(t, stopper)
 	store := tc.store
 
 	assertFrozen := func(b storagebase.ReplicaState_FrozenEnum) {
@@ -2167,8 +2167,9 @@ func TestStoreNoConcurrentRaftSnapshots(t *testing.T) {
 func TestStoreGCThreshold(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
-	tc.Start(t)
-	defer tc.Stop()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	tc.Start(t, stopper)
 	store := tc.store
 
 	assertThreshold := func(ts hlc.Timestamp) {
@@ -2217,8 +2218,9 @@ func TestStoreGCThreshold(t *testing.T) {
 func TestStoreRangePlaceholders(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
-	tc.Start(t)
-	defer tc.Stop()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	tc.Start(t, stopper)
 	s := tc.store
 
 	s.mu.Lock()
@@ -2315,8 +2317,9 @@ func TestStoreRangePlaceholders(t *testing.T) {
 func TestStoreRemovePlaceholderOnError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
-	tc.Start(t)
-	defer tc.Stop()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	tc.Start(t, stopper)
 	s := tc.store
 	ctx := context.Background()
 
@@ -2387,8 +2390,9 @@ func TestStoreRemovePlaceholderOnError(t *testing.T) {
 func TestStoreRemovePlaceholderOnRaftIgnored(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
-	tc.Start(t)
-	defer tc.Stop()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	tc.Start(t, stopper)
 	s := tc.store
 	ctx := context.Background()
 
@@ -2472,8 +2476,9 @@ func TestStoreRemovePlaceholderOnRaftIgnored(t *testing.T) {
 func TestCanCampaignIdleReplica(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
-	tc.Start(t)
-	defer tc.Stop()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	tc.Start(t, stopper)
 	s := tc.store
 	ctx := context.Background()
 

--- a/pkg/storage/ts_maintenance_queue_test.go
+++ b/pkg/storage/ts_maintenance_queue_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kr/pretty"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -36,9 +38,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/kr/pretty"
-	"github.com/pkg/errors"
 )
 
 type modelTimeSeriesDataStore struct {
@@ -102,8 +103,9 @@ func TestTimeSeriesMaintenanceQueue(t *testing.T) {
 	cfg.TestingKnobs.DisableScanner = true
 	cfg.TestingKnobs.DisableSplitQueue = true
 
-	store, stopper := createTestStoreWithConfig(t, cfg)
+	stopper := stop.NewStopper()
 	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, cfg)
 
 	// Generate several splits.
 	splitKeys := []roachpb.Key{roachpb.Key("c"), roachpb.Key("b"), roachpb.Key("a")}


### PR DESCRIPTION
This prevents panics when tests fail at init time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11981)
<!-- Reviewable:end -->
