### PR TITLE
storage: don't assume replica presence when sending fails

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3434,12 +3434,14 @@ func (s *Store) sendQueuedHeartbeatsToNode(beats, resps []RaftHeartbeat, to roac
 	if !s.cfg.Transport.SendAsync(chReq) {
 		s.mu.Lock()
 		for _, beat := range beats {
-			replica := s.mu.replicas[beat.RangeID]
-			replica.addUnreachableRemoteReplica(beat.ToReplicaID)
+			if replica, ok := s.mu.replicas[beat.RangeID]; ok {
+				replica.addUnreachableRemoteReplica(beat.ToReplicaID)
+			}
 		}
 		for _, resp := range resps {
-			replica := s.mu.replicas[resp.RangeID]
-			replica.addUnreachableRemoteReplica(resp.ToReplicaID)
+			if replica, ok := s.mu.replicas[resp.RangeID]; ok {
+				replica.addUnreachableRemoteReplica(resp.ToReplicaID)
+			}
 		}
 		s.mu.Unlock()
 		return 0


### PR DESCRIPTION
Ideally, this would have a test, but I've not been able to write one.
My latest attempt was roughly:

```go
// TestReportUnreachableRemoveRace adds and removes the raft leader replica
// repeatedly while one of its peers is unreachable in an attempt to expose
// races (primarily in asynchronous coalesced heartbeats).
func TestReportUnreachableRemoveRace(t *testing.T) {
	defer leaktest.AfterTest(t)()
	mtc := startMultiTestContext(t, 3)
	defer mtc.Stop()

	const rangeID = roachpb.RangeID(1)
	mtc.replicateRange(rangeID, 1, 2)

	for i := 0; i < 1; i++ {
		for idx, store := range mtc.stores {
			repl, err := store.GetReplica(rangeID)
			if err != nil {
				t.Fatal(err)
			}
			if repl.RaftStatus().SoftState.RaftState == raft.StateLeader {
				for _, toStore := range mtc.stores {
					if toStore == store {
						continue
					}
					log.Infof(repl.AnnotateCtx(context.TODO()), "leader=%s follower=%s", store, toStore)
					cb := mtc.transport.GetCircuitBreaker(toStore.Ident.NodeID)
					cb.Break()
					mtc.unreplicateRange(rangeID, idx)
					cb.Reset()
					mtc.replicateRange(rangeID, idx)
					break
				}
			}
		}
	}
}
```

@arjunravinarayan could you pick up writing this test?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/11985)
<!-- Reviewable:end -->
