### PR TITLE
client: added an example of snowball tracing with a txn

### DIFF
--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -382,7 +382,7 @@ func (ts *txnState) finishSQLTxn(sessionCtx context.Context) {
 	ts.sp = nil
 	if (traceSQL && timeutil.Since(ts.sqlTimestamp) >= traceSQLDuration) ||
 		(traceSQLFor7881 && sampledFor7881) {
-		dump := tracing.FormatRawSpans(ts.CollectedSpans)
+		dump := tracing.FormatRawSpans(ts.CollectedSpans, true /*formatTiming*/)
 		if len(dump) > 0 {
 			log.Infof(sessionCtx, "SQL trace:\n%s", dump)
 		}

--- a/pkg/util/tracing/format.go
+++ b/pkg/util/tracing/format.go
@@ -49,7 +49,7 @@ func (l traceLogs) Swap(i, j int) {
 // FormatRawSpans formats the given spans for human consumption, showing the
 // relationship using nesting and times as both relative to the previous event
 // and cumulative.
-func FormatRawSpans(spans []basictracer.RawSpan) string {
+func FormatRawSpans(spans []basictracer.RawSpan, formatTiming bool) string {
 	m := make(map[uint64]*basictracer.RawSpan)
 	for i, sp := range spans {
 		m[sp.Context.SpanID] = &spans[i]
@@ -83,10 +83,12 @@ func FormatRawSpans(spans []basictracer.RawSpan) string {
 		last = logs[0].Timestamp
 	}
 	for _, entry := range logs {
-		fmt.Fprintf(&buf, "% 10.3fms % 10.3fms%s",
-			1000*entry.Timestamp.Sub(start).Seconds(),
-			1000*entry.Timestamp.Sub(last).Seconds(),
-			strings.Repeat("    ", entry.depth+1))
+		if formatTiming {
+			fmt.Fprintf(&buf, "% 10.3fms % 10.3fms",
+				1000*entry.Timestamp.Sub(start).Seconds(),
+				1000*entry.Timestamp.Sub(last).Seconds())
+		}
+		fmt.Fprintf(&buf, "%s", strings.Repeat("    ", entry.depth+1))
 		for i, f := range entry.Fields {
 			if i != 0 {
 				buf.WriteByte(' ')


### PR DESCRIPTION
I thought this was worth adding if anyone wanted to know how to do it outside of SQL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12002)
<!-- Reviewable:end -->
