### PR TITLE
ts: Fix flaky TestServerQuery

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -697,12 +697,15 @@ type StoreTestingKnobs struct {
 	// replica.TransferLease() encounters an in-progress lease extension.
 	// nextLeader is the replica that we're trying to transfer the lease to.
 	LeaseTransferBlockedOnExtensionEvent func(nextLeader roachpb.ReplicaDescriptor)
-	// DisableReplicaGCQueue disables the replication queue.
+	// DisableReplicaGCQueue disables the replica GC queue.
 	DisableReplicaGCQueue bool
 	// DisableReplicateQueue disables the replication queue.
 	DisableReplicateQueue bool
 	// DisableSplitQueue disables the split queue.
 	DisableSplitQueue bool
+	// DisableTimeSeriesMaintenanceQueue disables the time series maintenance
+	// queue.
+	DisableTimeSeriesMaintenanceQueue bool
 	// DisableScanner disables the replica scanner.
 	DisableScanner bool
 	// DisablePeriodicGossips disables periodic gossiping.
@@ -886,6 +889,9 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 	}
 	if cfg.TestingKnobs.DisableSplitQueue {
 		s.setSplitQueueActive(false)
+	}
+	if cfg.TestingKnobs.DisableTimeSeriesMaintenanceQueue {
+		s.setTimeSeriesMaintenanceQueueActive(false)
 	}
 	if cfg.TestingKnobs.DisableScanner {
 		s.setScannerActive(false)
@@ -4005,6 +4011,9 @@ func (s *Store) setReplicateQueueActive(active bool) {
 }
 func (s *Store) setSplitQueueActive(active bool) {
 	s.splitQueue.SetDisabled(!active)
+}
+func (s *Store) setTimeSeriesMaintenanceQueueActive(active bool) {
+	s.tsMaintenanceQueue.SetDisabled(!active)
 }
 func (s *Store) setScannerActive(active bool) {
 	s.scanner.SetDisabled(!active)

--- a/pkg/ts/server_test.go
+++ b/pkg/ts/server_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
@@ -35,7 +36,13 @@ import (
 
 func TestServerQuery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			Store: &storage.StoreTestingKnobs{
+				DisableTimeSeriesMaintenanceQueue: true,
+			},
+		},
+	})
 	defer s.Stopper().Stop()
 	tsrv := s.(*server.TestServer)
 


### PR DESCRIPTION
This test has been flaky since the addition of time series pruning; it uses
constant timestamps for data which are near zero, which always makes them a candidate for pruning by the time series maintenance queue.

Fix is to disable the time series maintenance queue using a testing knob.

Fixes #10823

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12004)
<!-- Reviewable:end -->
