### PR TITLE
storage: Fix TestTimeSeriesMaintenanceQueueServer

### DIFF
--- a/pkg/storage/ts_maintenance_queue_test.go
+++ b/pkg/storage/ts_maintenance_queue_test.go
@@ -219,7 +219,13 @@ func TestTimeSeriesMaintenanceQueue(t *testing.T) {
 func TestTimeSeriesMaintenanceQueueServer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	s, _, db := serverutils.StartServer(t, base.TestServerArgs{})
+	s, _, db := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			Store: &storage.StoreTestingKnobs{
+				DisableScanner: true,
+			},
+		},
+	})
 	defer s.Stopper().Stop()
 	tsrv := s.(*server.TestServer)
 	tsdb := tsrv.TsDB()


### PR DESCRIPTION
TestTimeSeriesMaintenanceQueueServer has evidentally been flaky since its
inception, but this was only recently revealed by a recent optimization. The
fix is to disable the replica scanner, which disables the automatic pruning of time series. The automatic pruning was occuring too early in the test, causing a false negative.

Fixes #11774

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12005)
<!-- Reviewable:end -->
