### PR TITLE
storage: fooArgs test helpers return pointers instead of values

### DIFF
--- a/pkg/storage/client_metrics_test.go
+++ b/pkg/storage/client_metrics_test.go
@@ -189,7 +189,7 @@ func TestStoreMetrics(t *testing.T) {
 
 	// Perform a split, which has special metrics handling.
 	splitArgs := adminSplitArgs(roachpb.KeyMin, roachpb.Key("m"))
-	if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), &splitArgs); err != nil {
+	if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), splitArgs); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/storage/client_raft_log_queue_test.go
+++ b/pkg/storage/client_raft_log_queue_test.go
@@ -58,7 +58,7 @@ func TestRaftLogQueue(t *testing.T) {
 
 	// Write a single value to ensure we have a leader.
 	pArgs := putArgs([]byte("key"), []byte("value"))
-	if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), &pArgs); err != nil {
+	if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), pArgs); err != nil {
 		t.Fatal(err)
 	}
 
@@ -82,7 +82,7 @@ func TestRaftLogQueue(t *testing.T) {
 	value := bytes.Repeat([]byte("a"), 1000) // 1KB
 	for size := int64(0); size < 2*maxBytes; size += int64(len(value)) {
 		pArgs = putArgs([]byte(fmt.Sprintf("key-%d", size)), value)
-		if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), &pArgs); err != nil {
+		if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), pArgs); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/pkg/storage/client_status_test.go
+++ b/pkg/storage/client_status_test.go
@@ -43,7 +43,7 @@ func TestComputeStatsForKeySpan(t *testing.T) {
 		header := roachpb.Header{
 			RangeID: repl.RangeID,
 		}
-		if _, err := client.SendWrappedWith(context.Background(), mtc.stores[0], header, &args); err != nil {
+		if _, err := client.SendWrappedWith(context.Background(), mtc.stores[0], header, args); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -1068,8 +1068,8 @@ func (m *multiTestContext) getRaftLeader(rangeID roachpb.RangeID) *storage.Repli
 
 // getArgs returns a GetRequest and GetResponse pair addressed to
 // the default replica for the specified key.
-func getArgs(key roachpb.Key) roachpb.GetRequest {
-	return roachpb.GetRequest{
+func getArgs(key roachpb.Key) *roachpb.GetRequest {
+	return &roachpb.GetRequest{
 		Span: roachpb.Span{
 			Key: key,
 		},
@@ -1078,8 +1078,8 @@ func getArgs(key roachpb.Key) roachpb.GetRequest {
 
 // putArgs returns a PutRequest and PutResponse pair addressed to
 // the default replica for the specified key / value.
-func putArgs(key roachpb.Key, value []byte) roachpb.PutRequest {
-	return roachpb.PutRequest{
+func putArgs(key roachpb.Key, value []byte) *roachpb.PutRequest {
+	return &roachpb.PutRequest{
 		Span: roachpb.Span{
 			Key: key,
 		},
@@ -1089,8 +1089,8 @@ func putArgs(key roachpb.Key, value []byte) roachpb.PutRequest {
 
 // incrementArgs returns an IncrementRequest addressed to the default replica
 // for the specified key.
-func incrementArgs(key roachpb.Key, inc int64) roachpb.IncrementRequest {
-	return roachpb.IncrementRequest{
+func incrementArgs(key roachpb.Key, inc int64) *roachpb.IncrementRequest {
+	return &roachpb.IncrementRequest{
 		Span: roachpb.Span{
 			Key: key,
 		},
@@ -1098,8 +1098,8 @@ func incrementArgs(key roachpb.Key, inc int64) roachpb.IncrementRequest {
 	}
 }
 
-func truncateLogArgs(index uint64, rangeID roachpb.RangeID) roachpb.TruncateLogRequest {
-	return roachpb.TruncateLogRequest{
+func truncateLogArgs(index uint64, rangeID roachpb.RangeID) *roachpb.TruncateLogRequest {
+	return &roachpb.TruncateLogRequest{
 		Index:   index,
 		RangeID: rangeID,
 	}

--- a/pkg/storage/ts_maintenance_queue_test.go
+++ b/pkg/storage/ts_maintenance_queue_test.go
@@ -114,7 +114,7 @@ func TestTimeSeriesMaintenanceQueue(t *testing.T) {
 		args := adminSplitArgs(k, k)
 		if _, pErr := client.SendWrappedWith(context.Background(), store, roachpb.Header{
 			RangeID: repl.RangeID,
-		}, &args); pErr != nil {
+		}, args); pErr != nil {
 			t.Fatal(pErr)
 		}
 	}


### PR DESCRIPTION
When returning values to be placed on the stack, the stack memory is
sometimes overwritten with a new request while an asynchronous goroutine
from the previous request is still running, leading to (rare) data
races.

This could also allow the functions to be used with SendWrapped directly
without naming a local variable, although in this commit I have left the
local variables in place.

I haven't seen this on teamcity but it did happen locally while running the SplitSnapshotRace tests under stressrace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12007)
<!-- Reviewable:end -->
