### PR TITLE
sql: lower the timeouts in testdata/manual_retry.

### DIFF
--- a/pkg/sql/testdata/manual_retry
+++ b/pkg/sql/testdata/manual_retry
@@ -1,7 +1,7 @@
 # On an implicit transaction, we retry implicitly and the function
 # eventually returns a result.
 query I
-SELECT CRDB_INTERNAL.FORCE_RETRY('1s':::INTERVAL)
+SELECT CRDB_INTERNAL.FORCE_RETRY('50ms':::INTERVAL)
 ----
 0
 
@@ -9,19 +9,19 @@ statement ok
 BEGIN TRANSACTION; SAVEPOINT cockroach_restart
 
 query error restart transaction: forced
-SELECT CRDB_INTERNAL.FORCE_RETRY('1s':::INTERVAL)
+SELECT CRDB_INTERNAL.FORCE_RETRY('500ms':::INTERVAL)
 
 statement ok
 ROLLBACK TO SAVEPOINT cockroach_restart
 
-# wait until the transaction is at least 2 seconds old
-sleep 2s
+# wait until the transaction is at least 1 second
+sleep 1s
 
 statement ok
 SAVEPOINT cockroach_restart
 
 query I
-SELECT CRDB_INTERNAL.FORCE_RETRY('1s':::INTERVAL)
+SELECT CRDB_INTERNAL.FORCE_RETRY('500ms':::INTERVAL)
 ----
 0
 


### PR DESCRIPTION
Requested in https://github.com/cockroachdb/cockroach/issues/11746#issuecomment-264346438 - makes TestLogic run (slightly) faster, by about 1.5 second.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12013)
<!-- Reviewable:end -->
