### PR TITLE
storage: Improve coverage of replaced node test without a big slowdown

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -19,6 +19,7 @@ package base
 import (
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
@@ -53,7 +54,10 @@ type TestServerArgs struct {
 
 	// Fields copied to the server.Config.
 	Insecure                 bool
+	RetryOptions             retry.Options
 	MetricsSampleInterval    time.Duration
+	RaftTickInterval         time.Duration
+	RaftElectionTimeoutTicks int
 	SocketFile               string
 	ScanInterval             time.Duration
 	ScanMaxIdleTime          time.Duration

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 )
 
 // Context defaults.
@@ -83,6 +84,9 @@ type Config struct {
 	// connecting to the gossip network. Each item in the list can actually be
 	// multiple comma-separated addresses, kept for backward-compatibility.
 	JoinList base.JoinListType
+
+	// RetryOptions controls the retry behavior of the server.
+	RetryOptions retry.Options
 
 	// CacheSize is the amount of memory in bytes to use for caching data.
 	// The value is split evenly between the stores if there are more than one.

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -160,7 +160,9 @@ func TestBootstrapCluster(t *testing.T) {
 	defer stopper.Stop()
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 	stopper.AddCloser(e)
-	if _, err := bootstrapCluster([]engine.Engine{e}, kv.MakeTxnMetrics(metric.TestSampleInterval)); err != nil {
+	if _, err := bootstrapCluster(
+		storage.StoreConfig{}, []engine.Engine{e}, kv.MakeTxnMetrics(metric.TestSampleInterval),
+	); err != nil {
 		t.Fatal(err)
 	}
 
@@ -199,7 +201,9 @@ func TestBootstrapCluster(t *testing.T) {
 func TestBootstrapNewStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
-	if _, err := bootstrapCluster([]engine.Engine{e}, kv.MakeTxnMetrics(metric.TestSampleInterval)); err != nil {
+	if _, err := bootstrapCluster(
+		storage.StoreConfig{}, []engine.Engine{e}, kv.MakeTxnMetrics(metric.TestSampleInterval),
+	); err != nil {
 		t.Fatal(err)
 	}
 
@@ -249,7 +253,9 @@ func TestNodeJoin(t *testing.T) {
 	defer engineStopper.Stop()
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 	engineStopper.AddCloser(e)
-	if _, err := bootstrapCluster([]engine.Engine{e}, kv.MakeTxnMetrics(metric.TestSampleInterval)); err != nil {
+	if _, err := bootstrapCluster(
+		storage.StoreConfig{}, []engine.Engine{e}, kv.MakeTxnMetrics(metric.TestSampleInterval),
+	); err != nil {
 		t.Fatal(err)
 	}
 
@@ -330,7 +336,9 @@ func TestCorruptedClusterID(t *testing.T) {
 
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 	defer e.Close()
-	if _, err := bootstrapCluster([]engine.Engine{e}, kv.MakeTxnMetrics(metric.TestSampleInterval)); err != nil {
+	if _, err := bootstrapCluster(
+		storage.StoreConfig{}, []engine.Engine{e}, kv.MakeTxnMetrics(metric.TestSampleInterval),
+	); err != nil {
 		t.Fatal(err)
 	}
 
@@ -654,7 +662,7 @@ func TestStartNodeWithLocality(t *testing.T) {
 		e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 		defer e.Close()
 		if _, err := bootstrapCluster(
-			[]engine.Engine{e}, kv.MakeTxnMetrics(metric.TestSampleInterval),
+			storage.StoreConfig{}, []engine.Engine{e}, kv.MakeTxnMetrics(metric.TestSampleInterval),
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -60,6 +60,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/sdnotify"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -193,7 +194,10 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	// However, on a single-node setup (such as a test), retries will never
 	// succeed because the only server has been shut down; thus, thus the
 	// DistSender needs to know that it should not retry in this situation.
-	retryOpts := base.DefaultRetryOptions()
+	retryOpts := s.cfg.RetryOptions
+	if retryOpts == (retry.Options{}) {
+		retryOpts = base.DefaultRetryOptions()
+	}
 	retryOpts.Closer = s.stopper.ShouldQuiesce()
 	distSenderCfg := kv.DistSenderConfig{
 		AmbientCtx:      s.cfg.AmbientCtx,
@@ -301,6 +305,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		Gossip:                         s.gossip,
 		NodeLiveness:                   s.nodeLiveness,
 		Transport:                      s.raftTransport,
+		RangeRetryOptions:              s.cfg.RetryOptions,
 		RaftTickInterval:               s.cfg.RaftTickInterval,
 		ScanInterval:                   s.cfg.ScanInterval,
 		ScanMaxIdleTime:                s.cfg.ScanMaxIdleTime,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -94,18 +94,25 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	}
 	cfg.Insecure = params.Insecure
 	cfg.SocketFile = params.SocketFile
-	if params.MetricsSampleInterval != time.Duration(0) {
+	cfg.RetryOptions = params.RetryOptions
+	if params.MetricsSampleInterval != 0 {
 		cfg.MetricsSampleInterval = params.MetricsSampleInterval
 	}
+	if params.RaftTickInterval != 0 {
+		cfg.RaftTickInterval = params.RaftTickInterval
+	}
+	if params.RaftElectionTimeoutTicks != 0 {
+		cfg.RaftElectionTimeoutTicks = params.RaftElectionTimeoutTicks
+	}
 	if knobs := params.Knobs.Store; knobs != nil {
-		if mo := knobs.(*storage.StoreTestingKnobs).MaxOffset; mo != time.Duration(0) {
+		if mo := knobs.(*storage.StoreTestingKnobs).MaxOffset; mo != 0 {
 			cfg.MaxOffset = mo
 		}
 	}
-	if params.ScanInterval != time.Duration(0) {
+	if params.ScanInterval != 0 {
 		cfg.ScanInterval = params.ScanInterval
 	}
-	if params.ScanMaxIdleTime != time.Duration(0) {
+	if params.ScanMaxIdleTime != 0 {
 		cfg.ScanMaxIdleTime = params.ScanMaxIdleTime
 	}
 	if params.SSLCA != "" {


### PR DESCRIPTION
It's down from 12 seconds to about 700ms. Still slower than if we killed the second node, but as mentioned in #11780 this gives better coverage.

It was so slow because it had to wait at least 9 seconds for the first
range's lease to expire. Backoff delays also added some time on top of
that. Resolve this by cutting down the raft tick interval and election
timeout to speed things up. This has shown to not be flaky.

@tamird

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12023)
<!-- Reviewable:end -->
