### PR TITLE
build: build protoc when and only when needed

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -2,14 +2,11 @@ cmd ./pkg/cmd/github-post
 cmd ./pkg/cmd/github-pull-request-make
 cmd ./pkg/cmd/glock-diff-parser
 cmd ./pkg/cmd/metacheck
-cmd ./pkg/cmd/protoc-gen-gogoroach
 cmd ./pkg/cmd/teamcity-trigger
 cmd ./vendor/github.com/client9/misspell/cmd/misspell
-cmd ./vendor/github.com/cockroachdb/c-protobuf/cmd/protoc
 cmd ./vendor/github.com/cockroachdb/crlfmt
 cmd ./vendor/github.com/cockroachdb/stress
 cmd ./vendor/github.com/golang/lint/golint
-cmd ./vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
 cmd ./vendor/github.com/jteeuwen/go-bindata/go-bindata
 cmd ./vendor/github.com/kisielk/errcheck
 cmd ./vendor/github.com/kkaneda/returncheck

--- a/build/protobuf.mk
+++ b/build/protobuf.mk
@@ -66,6 +66,14 @@ CPP_SOURCES := $(subst ./,$(NATIVE_ROOT)/,$(CPP_PROTOS:%.proto=%.pb.cc))
 .PHONY: protos
 protos: $(GO_SOURCES) $(UI_SOURCES) $(CPP_HEADERS) $(CPP_SOURCES) $(ENGINE_CPP_HEADERS) $(ENGINE_CPP_SOURCES) $(GW_SOURCES)
 
+$(PROTOC): goinstall
+
+.PHONY: goinstall
+goinstall:
+	go install $(REPO_ROOT)/pkg/cmd/protoc-gen-gogoroach
+	go install $(REPO_ROOT)/vendor/github.com/cockroachdb/c-protobuf/cmd/protoc
+	go install $(REPO_ROOT)/vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
+
 REPO_NAME := cockroachdb
 IMPORT_PREFIX := github.com/$(REPO_NAME)/
 


### PR DESCRIPTION
Unlike #12021, this doesn't introduce a local tool directory and the associated reorganization of the paths, but rather just switches when we go install the protoc tools.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12029)
<!-- Reviewable:end -->
