### PR TITLE
build: install govermerge/goveralls only when needed

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -13,11 +13,9 @@ cmd ./vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
 cmd ./vendor/github.com/jteeuwen/go-bindata/go-bindata
 cmd ./vendor/github.com/kisielk/errcheck
 cmd ./vendor/github.com/kkaneda/returncheck
-cmd ./vendor/github.com/mattn/goveralls
 cmd ./vendor/github.com/mdempsky/unconvert
 cmd ./vendor/github.com/mibk/dupl
 cmd ./vendor/github.com/robfig/glock
-cmd ./vendor/github.com/wadey/gocovmerge
 cmd ./vendor/golang.org/x/tools/cmd/goimports
 cmd ./vendor/golang.org/x/tools/cmd/goyacc
 cmd ./vendor/golang.org/x/tools/cmd/stringer

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,8 @@ endif
 
 .PHONY: upload-coverage
 upload-coverage:
+	$(GO) install ./vendor/github.com/wadey/gocovmerge
+	$(GO) install ./vendor/github.com/mattn/goveralls
 	@build/upload-coverage.sh
 
 .PHONY: acceptance


### PR DESCRIPTION
since these are only used in upload-coverage.sh, we don't need to force everyone to build them via GLOCKFILE

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12032)
<!-- Reviewable:end -->
