### PR TITLE
sql: DROP DATABASE handles tables with fk refs

### DIFF
--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -666,6 +666,10 @@ func (p *planner) removeFK(ref sqlbase.ForeignKeyReference, table *sqlbase.Table
 			return err
 		}
 	}
+	if table.Dropped() {
+		// The referenced table is being dropped. No need to modify it further.
+		return nil
+	}
 	idx, err := table.FindIndexByID(ref.Index)
 	if err != nil {
 		return err
@@ -678,6 +682,10 @@ func (p *planner) removeInterleave(ref sqlbase.ForeignKeyReference) error {
 	table, err := sqlbase.GetTableDescFromID(p.txn, ref.Table)
 	if err != nil {
 		return err
+	}
+	if table.Dropped() {
+		// The referenced table is being dropped. No need to modify it further.
+		return nil
 	}
 	idx, err := table.FindIndexByID(ref.Index)
 	if err != nil {
@@ -846,6 +854,10 @@ func (p *planner) removeFKBackReference(
 	if err != nil {
 		return errors.Errorf("error resolving referenced table ID %d: %v", idx.ForeignKey.Table, err)
 	}
+	if t.Dropped() {
+		// The referenced table is being dropped. No need to modify it further.
+		return nil
+	}
 	targetIdx, err := t.FindIndexByID(idx.ForeignKey.Index)
 	if err != nil {
 		return err
@@ -868,6 +880,10 @@ func (p *planner) removeInterleaveBackReference(
 	t, err := sqlbase.GetTableDescFromID(p.txn, ancestor.TableID)
 	if err != nil {
 		return errors.Errorf("error resolving referenced table ID %d: %v", ancestor.TableID, err)
+	}
+	if t.Dropped() {
+		// The referenced table is being dropped. No need to modify it further.
+		return nil
 	}
 	targetIdx, err := t.FindIndexByID(ancestor.IndexID)
 	if err != nil {

--- a/pkg/sql/testdata/drop_database
+++ b/pkg/sql/testdata/drop_database
@@ -171,3 +171,36 @@ test
 
 query error database "d2" does not exist
 SELECT * FROM d2.v1
+
+## drop a database containing tables with foreign key constraints, e.g. #8497
+
+statement ok
+CREATE DATABASE constraint_db
+
+statement ok
+CREATE TABLE constraint_db.t1 (
+  p FLOAT PRIMARY KEY,
+  a INT UNIQUE CHECK (a > 4),
+  CONSTRAINT c2 CHECK (a < 99)
+)
+
+statement ok
+CREATE TABLE constraint_db.t2 (
+    t1_ID INT,
+    CONSTRAINT fk FOREIGN KEY (t1_ID) REFERENCES constraint_db.t1(a),
+    INDEX (t1_ID)
+)
+
+statement ok
+DROP DATABASE constraint_db
+
+query T
+SHOW DATABASES
+----
+information_schema
+pg_catalog
+system
+test
+
+query error database "constraint_db" does not exist
+SELECT * FROM constraint_db.t1

--- a/pkg/sql/testdata/information_schema
+++ b/pkg/sql/testdata/information_schema
@@ -588,10 +588,6 @@ def                 constraint_db      t1_a_key         constraint_db  t1       
 def                 constraint_db      fk               constraint_db  t2          FOREIGN KEY
 def                 constraint_db      primary          constraint_db  t2          PRIMARY KEY
 
-# TODO(nvanbenschoten) blocked on #8497.
-#statement ok
-#DROP DATABASE constraint_db
-
 
 ## information_schema.key_column_usage
 
@@ -697,6 +693,9 @@ NULL     root     def            system             zones       GRANT           
 NULL     root     def            system             zones       INSERT          NULL          NULL
 NULL     root     def            system             zones       SELECT          NULL          NULL
 NULL     root     def            system             zones       UPDATE          NULL          NULL
+
+statement ok
+DROP DATABASE constraint_db
 
 statement ok
 CREATE TABLE other_db.xyz (i INT)


### PR DESCRIPTION
Previously, `DROP DATABASE` could fail when the database to drop
contained tables with foreign keys. This is because the order in which
tables are dropped when dropping a database is arbitrary, and dropping a
table with foreign key references must modify the table it refers to,
which is illegal if that table has already been dropped.

This commit modifies the behavior of dropping a table so that we do not
attempt to modify other tables that reference it if they have already
been dropped.

Resolves #8497.
Resolves #10830.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12036)
<!-- Reviewable:end -->
