### PR TITLE
vendor: bump etcd and golang tools

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: f97869d3329aea5fd9e34771aaf95ad59b296f03c9095d9ad5017ed8d2bcd1fd
-updated: 2016-12-02T23:03:47.30088231-05:00
+updated: 2016-12-06T05:22:24.546912697Z
 imports:
 - name: cloud.google.com/go
   version: 2b8eb373216db8c887f4934051ab8338581e3656
@@ -54,7 +54,7 @@ imports:
 - name: github.com/codahale/hdrhistogram
   version: 3a0bb77429bd3a61596f5e8a3172445844342120
 - name: github.com/coreos/etcd
-  version: d844440ffbf5e88c3d3d3e18fc80d184156696f9
+  version: f61b4ae5adde2b8dbaa4b4f88c73c9be85ae3404
   subpackages:
   - raft
   - raft/raftpb
@@ -336,7 +336,7 @@ imports:
   - transform
   - unicode/norm
 - name: golang.org/x/tools
-  version: 366e27042d04e36bdf2d0033252e4e29f958f175
+  version: e04df2157ae7263e17159baabadc99fb03fc7514
   subpackages:
   - cmd/goimports
   - cmd/goyacc


### PR DESCRIPTION
etcd looks uinteresting, mostly grpc metrics https://github.com/coreos/etcd/compare/f61b4ae5adde2b8dbaa4b4f88c73c9be85ae3404...d844440ffbf5e88c3d3d3e18fc80d184156696f9
golang x tools: https://github.com/golang/tools/compare/e04df2157ae7263e17159baabadc99fb03fc7514...366e27042d04e36bdf2d0033252e4e29f958f175 (cmd/guru: handle source file aliasing gracefully)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12044)
<!-- Reviewable:end -->
