### PR TITLE
storage: require all replicas live before consistency checking range

### DIFF
--- a/pkg/storage/consistency_queue_test.go
+++ b/pkg/storage/consistency_queue_test.go
@@ -1,0 +1,58 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Spencer Kimball (spencer@cockroachlabs.com)
+
+package storage_test
+
+import (
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+// TestConsistencyQueueRequiresLive verifies the queue will not
+// process ranges whose replicas are not all live.
+func TestConsistencyQueueRequiresLive(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	sc := storage.TestStoreConfig(nil)
+	mtc := &multiTestContext{storeConfig: &sc}
+	defer mtc.Stop()
+	mtc.Start(t, 3)
+
+	// Replicate the range to three nodes.
+	repl := mtc.stores[0].LookupReplica(roachpb.RKeyMin, nil)
+	rangeID := repl.RangeID
+	mtc.replicateRange(rangeID, 1, 2)
+
+	// Verify that queueing is immediately possible.
+	if shouldQ, priority := mtc.stores[0].ConsistencyQueueShouldQueue(
+		context.TODO(), mtc.clock.Now(), repl, config.SystemConfig{}); !shouldQ {
+		t.Fatalf("expected shouldQ true; got %t, %f", shouldQ, priority)
+	}
+
+	// Stop a node and expire leases.
+	mtc.stopStore(2)
+	mtc.expireLeases()
+
+	if shouldQ, priority := mtc.stores[0].ConsistencyQueueShouldQueue(
+		context.TODO(), mtc.clock.Now(), repl, config.SystemConfig{}); shouldQ {
+		t.Fatalf("expected shouldQ false; got %t, %f", shouldQ, priority)
+	}
+}

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -27,6 +27,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
@@ -97,6 +98,14 @@ func (s *Store) ForceRaftLogScanAndProcess() {
 // maintenance queue.
 func (s *Store) ForceTimeSeriesMaintenanceQueueProcess() {
 	forceScanAndProcess(s, s.tsMaintenanceQueue.baseQueue)
+}
+
+// ConsistencyQueueShouldQueue invokes the shouldQueue method on the
+// store's consistency queue.
+func (s *Store) ConsistencyQueueShouldQueue(
+	ctx context.Context, now hlc.Timestamp, r *Replica, cfg config.SystemConfig,
+) (bool, float64) {
+	return s.consistencyQueue.shouldQueue(ctx, now, r, cfg)
 }
 
 // GetDeadReplicas exports s.deadReplicas for tests.


### PR DESCRIPTION
Also includes some fixes to `multiTestContext`'s use of `NodeLiveness`.

Fixes #11796

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12049)
<!-- Reviewable:end -->
