### PR TITLE
githooks: just update submodule on ref changes

### DIFF
--- a/githooks/post-checkout
+++ b/githooks/post-checkout
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-[[ ! $GIT_REFLOG_ACTION =~ pull[[:space:]]+--rebase ]] && exit 0
-
-make .bootstrap
+if [ "$1" != "$2" ]; then # previous ref != new ref.
+  exec git submodule update --init
+fi

--- a/githooks/post-merge
+++ b/githooks/post-merge
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-[[ ! $GIT_REFLOG_ACTION =~ pull ]] && exit 0
-
-make .bootstrap
+exec git submodule update --init

--- a/githooks/post-rewrite
+++ b/githooks/post-rewrite
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-[[ ! $GIT_REFLOG_ACTION =~ rebase ]] && exit 0
-
-make .bootstrap
+# TODO(dt): do we want to submomdule update here?


### PR DESCRIPTION
with deps now managed by the scm directly (the vendor submodule), we don't need to run glock or make during scm operations

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12088)
<!-- Reviewable:end -->
