### PR TITLE
storage: use setTruncatedState from Replica.TruncateLog

### DIFF
--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1599,7 +1599,7 @@ func (r *Replica) TruncateLog(
 	pd.Replicated.State.TruncatedState = tState
 	pd.Replicated.RaftLogDelta = &diff.SysBytes
 
-	return reply, pd, engine.MVCCPutProto(ctx, batch, ms, keys.RaftTruncatedStateKey(r.RangeID), hlc.ZeroTimestamp, nil, tState)
+	return reply, pd, setTruncatedState(ctx, batch, ms, r.RangeID, tState)
 }
 
 func newFailedLeaseTrigger() EvalResult {

--- a/pkg/storage/replica_state.go
+++ b/pkg/storage/replica_state.go
@@ -112,7 +112,7 @@ func saveState(
 	if err := setTxnSpanGCThreshold(ctx, eng, ms, rangeID, &state.TxnSpanGCThreshold); err != nil {
 		return enginepb.MVCCStats{}, err
 	}
-	if err := setTruncatedState(ctx, eng, ms, rangeID, *state.TruncatedState); err != nil {
+	if err := setTruncatedState(ctx, eng, ms, rangeID, state.TruncatedState); err != nil {
 		return enginepb.MVCCStats{}, err
 	}
 	if err := setMVCCStats(ctx, eng, rangeID, state.Stats); err != nil {
@@ -286,13 +286,13 @@ func setTruncatedState(
 	eng engine.ReadWriter,
 	ms *enginepb.MVCCStats,
 	rangeID roachpb.RangeID,
-	truncState roachpb.RaftTruncatedState,
+	truncState *roachpb.RaftTruncatedState,
 ) error {
-	if (truncState == roachpb.RaftTruncatedState{}) {
+	if (*truncState == roachpb.RaftTruncatedState{}) {
 		return errors.New("cannot persist empty RaftTruncatedState")
 	}
 	return engine.MVCCPutProto(ctx, eng, ms,
-		keys.RaftTruncatedStateKey(rangeID), hlc.ZeroTimestamp, nil, &truncState)
+		keys.RaftTruncatedStateKey(rangeID), hlc.ZeroTimestamp, nil, truncState)
 }
 
 func loadGCThreshold(


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12093)
<!-- Reviewable:end -->
