### PR TITLE
scripts: always clear glide cache in wrapper

### DIFF
--- a/scripts/glide.sh
+++ b/scripts/glide.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+glide cache-clear
+
 # Glide *replaces* the vendor directory when it operates on it (e.g. in update
 # or get) which has the side-effect of breaking the .git submodule pointer.
 mv vendor/.git vendorgit


### PR DESCRIPTION
'up' can use stale dep versions, sometimes moving unrelated (cached) deps backwards, if they cache isn't cleared before every usage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12095)
<!-- Reviewable:end -->
