### PR TITLE
storage: allocate a more conservative slice of raft log entries

### DIFF
--- a/pkg/storage/entry_cache.go
+++ b/pkg/storage/entry_cache.go
@@ -103,11 +103,10 @@ func (rec *raftEntryCache) addEntries(rangeID roachpb.RangeID, ents []raftpb.Ent
 // 1) all entries exclusive of hi are fetched, 2) > maxBytes of
 // entries data is fetched, or 3) a cache miss occurs.
 func (rec *raftEntryCache) getEntries(
-	rangeID roachpb.RangeID, lo, hi, maxBytes uint64,
+	ents []raftpb.Entry, rangeID roachpb.RangeID, lo, hi, maxBytes uint64,
 ) ([]raftpb.Entry, uint64, uint64) {
 	rec.Lock()
 	defer rec.Unlock()
-	var ents []raftpb.Entry
 	var ent raftpb.Entry
 	var bytes uint64
 	nextIndex := lo

--- a/pkg/storage/entry_cache_test.go
+++ b/pkg/storage/entry_cache_test.go
@@ -49,7 +49,7 @@ func verifyGet(
 	expEnts []raftpb.Entry,
 	expNextIndex uint64,
 ) {
-	ents, _, nextIndex := rec.getEntries(rangeID, lo, hi, 0)
+	ents, _, nextIndex := rec.getEntries(nil, rangeID, lo, hi, 0)
 	if !(len(expEnts) == 0 && len(ents) == 0) && !reflect.DeepEqual(expEnts, ents) {
 		t.Fatalf("expected entries %+v; got %+v", expEnts, ents)
 	}
@@ -101,10 +101,10 @@ func TestEntryCacheClearTo(t *testing.T) {
 	rec.addEntries(rangeID, []raftpb.Entry{newEntry(2, 1)})
 	rec.addEntries(rangeID, []raftpb.Entry{newEntry(20, 1), newEntry(21, 1)})
 	rec.clearTo(rangeID, 21)
-	if ents, _, _ := rec.getEntries(rangeID, 2, 21, 0); len(ents) != 0 {
+	if ents, _, _ := rec.getEntries(nil, rangeID, 2, 21, 0); len(ents) != 0 {
 		t.Errorf("expected no entries after clearTo")
 	}
-	if ents, _, _ := rec.getEntries(rangeID, 21, 22, 0); len(ents) != 1 {
+	if ents, _, _ := rec.getEntries(nil, rangeID, 21, 22, 0); len(ents) != 1 {
 		t.Errorf("expected entry 22 to remain in the cache clearTo")
 	}
 }
@@ -114,13 +114,13 @@ func TestEntryCacheEviction(t *testing.T) {
 	rangeID := roachpb.RangeID(1)
 	rec := newRaftEntryCache(100)
 	rec.addEntries(rangeID, []raftpb.Entry{newEntry(1, 40), newEntry(2, 40)})
-	ents, _, hi := rec.getEntries(rangeID, 1, 3, 0)
+	ents, _, hi := rec.getEntries(nil, rangeID, 1, 3, 0)
 	if len(ents) != 2 || hi != 3 {
 		t.Errorf("expected both entries; got %+v, %d", ents, hi)
 	}
 	// Add another entry to evict first.
 	rec.addEntries(rangeID, []raftpb.Entry{newEntry(3, 40)})
-	ents, _, hi = rec.getEntries(rangeID, 2, 4, 0)
+	ents, _, hi = rec.getEntries(nil, rangeID, 2, 4, 0)
 	if len(ents) != 2 || hi != 4 {
 		t.Errorf("expected only two entries; got %+v, %d", ents, hi)
 	}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -5617,7 +5617,7 @@ func TestEntries(t *testing.T) {
 		if tc.setup != nil {
 			tc.setup()
 		}
-		cacheEntries, _, _ := repl.store.raftEntryCache.getEntries(rangeID, tc.lo, tc.hi, tc.maxBytes)
+		cacheEntries, _, _ := repl.store.raftEntryCache.getEntries(nil, rangeID, tc.lo, tc.hi, tc.maxBytes)
 		if len(cacheEntries) != tc.expCacheCount {
 			t.Errorf("%d: expected cache count %d, got %d", i, tc.expCacheCount, len(cacheEntries))
 		}


### PR DESCRIPTION
Note that this currently doesn't reallocate if the raft log entry cache is empty.

Also, we should probably pass a pre-allocated slice into the raft log entry cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12100)
<!-- Reviewable:end -->
