### PR TITLE
sql: render/column interface improvements

### DIFF
--- a/pkg/sql/group_test.go
+++ b/pkg/sql/group_test.go
@@ -51,10 +51,7 @@ func TestDesiredAggregateOrder(t *testing.T) {
 		sel := makeSelectNode(t)
 		expr := parseAndNormalizeExpr(t, d.expr, sel)
 		group := &groupNode{planner: p}
-		_, err := extractAggregatesVisitor{n: group}.extract(expr)
-		if err != nil {
-			t.Fatal(err)
-		}
+		(extractAggregatesVisitor{n: group}).extract(expr)
 		ordering := desiredAggregateOrdering(group.funcs)
 		if !reflect.DeepEqual(d.ordering, ordering) {
 			t.Fatalf("%s: expected %v, but found %v", d.expr, d.ordering, ordering)

--- a/pkg/sql/testdata/explain_types
+++ b/pkg/sql/testdata/explain_types
@@ -72,12 +72,13 @@ EXPLAIN (TYPES,NOEXPAND) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v
 0   select          having     ((v)[int] < (2)[int])[bool]
 0   select          render z   ((2)[int] * (count((k)[int]))[int])[int]
 0   select          render v   (v)[int]
-1   render/filter   result     (k int, v int, v int, v int)
+1   render/filter   result     ("2" int, k int, v int, "v < 2" bool, v int)
 1   render/filter   filter     ((v)[int] > (123)[int])[bool]
-1   render/filter   render 0   (k)[int]
-1   render/filter   render 1   (v)[int]
+1   render/filter   render 0   (2)[int]
+1   render/filter   render 1   (k)[int]
 1   render/filter   render 2   (v)[int]
-1   render/filter   render 3   (v)[int]
+1   render/filter   render 3   ((v)[int] < (2)[int])[bool]
+1   render/filter   render 4   (v)[int]
 2   scan            result     (k int, v int)
 
 query ITTT
@@ -88,13 +89,15 @@ EXPLAIN (TYPES) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v
 1   group           having     ((v)[int] < (2)[int])[bool]
 1   group           render z   ((2)[int] * (count((k)[int]))[int])[int]
 1   group           render v   (v)[int]
-2   render/filter   result     (k int, v int, v int, v int)
-2   render/filter   render 0   (k)[int]
-2   render/filter   render 1   (v)[int]
+2   render/filter   result     ("2" int, k int, v int, "v < 2" bool, v int)
+2   render/filter   render 0   (2)[int]
+2   render/filter   render 1   (k)[int]
 2   render/filter   render 2   (v)[int]
-2   render/filter   render 3   (v)[int]
+2   render/filter   render 3   ((v)[int] < (2)[int])[bool]
+2   render/filter   render 4   (v)[int]
 3   scan            result     (k int, v int)
 3   scan            filter     ((v)[int] > (123)[int])[bool]
+
 
 query ITTT
 EXPLAIN (TYPES,NOEXPAND) DELETE FROM t WHERE v > 1


### PR DESCRIPTION
this changeset is a lot of cleanup/refactor of our exisiting `groupNode`
implementation in addition to revisiting some earlier choices made in
the way of the render/columns interface between the `selectNode` and the
`groupNode`.
concisely any possible evaluations of expressions NOT
containing aggregation functions are delegated to the "source"
`selectNode` (for eg. the evaluation of the first 
`k + v` in `SELECT k + v FROM kv GROUP by k + v`).

the output schema of `selectNode` therefore changes (the `groupNode`
output schema remains as is).

cc @RaduBerinde

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12104)
<!-- Reviewable:end -->
