### PR TITLE
storage: don't include RaftTombstoneKey in consistency checks

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -1899,6 +1899,18 @@ func TestRaftRemoveRace(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		mtc.unreplicateRange(rangeID, 2)
 		mtc.replicateRange(rangeID, 2)
+
+		// Verify the tombstone key does not exist. See #12130.
+		tombstoneKey := keys.RaftTombstoneKey(rangeID)
+		var tombstone roachpb.RaftTombstone
+		if ok, err := engine.MVCCGetProto(
+			context.Background(), mtc.stores[2].Engine(), tombstoneKey,
+			hlc.ZeroTimestamp, true, nil, &tombstone,
+		); err != nil {
+			t.Fatal(err)
+		} else if ok {
+			t.Fatal("tombstone should not exist")
+		}
 	}
 }
 

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -2005,11 +2005,22 @@ func (r *Replica) sha512(
 	desc roachpb.RangeDescriptor, snap engine.Reader, snapshot *roachpb.RaftSnapshotData,
 ) ([]byte, error) {
 	hasher := sha512.New()
+	tombstoneKey := engine.MakeMVCCMetadataKey(keys.RaftTombstoneKey(desc.RangeID))
+
 	// Iterate over all the data in the range.
 	iter := NewReplicaDataIterator(&desc, snap, true /* replicatedOnly */)
 	defer iter.Close()
+
 	for ; iter.Valid(); iter.Next() {
 		key := iter.Key()
+		if key.Equal(tombstoneKey) {
+			// Skip the tombstone key which is marked as replicated even though it
+			// isn't.
+			//
+			// TODO(peter): Figure out a way to migrate this key to the unreplicated
+			// key space.
+			continue
+		}
 		value := iter.Value()
 
 		if snapshot != nil {


### PR DESCRIPTION
See #12130

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12131)
<!-- Reviewable:end -->
