### PR TITLE
acceptance: fix TestDockerCLI/test_sql_mem_monitor.tcl

### DIFF
--- a/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
+++ b/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
@@ -72,6 +72,7 @@ set spawn_id $shell_spawn_id
 expect {
     "out of memory" {}
     "cannot allocate memory" {}
+    "std::bad_alloc" {}
     timeout {exit 1}
 }
 eexpect ":/# "


### PR DESCRIPTION
The memory overflow error must check for run-time allocation errors.
Since C++ may also throw bad_alloc in case of allocation failure,
the test must also check for it.

Fixes #12096.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12140)
<!-- Reviewable:end -->
