### PR TITLE
sql: add some missing postgres vars for ORM compatibility

### DIFF
--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -200,7 +200,7 @@ var statusReportParams = map[string]string{
 	// of this package. We specify this version to avoid having to support old
 	// code paths which various client tools fall back to if they can't
 	// determine that the server is new enough.
-	"server_version": "9.5.0",
+	"server_version": sql.PgServerVersion,
 }
 
 // handleAuthentication should discuss with the client to arrange

--- a/pkg/sql/set.go
+++ b/pkg/sql/set.go
@@ -79,13 +79,6 @@ func (p *planner) Set(n *parser.Set) (planNode, error) {
 			return nil, fmt.Errorf("%s: \"%s\" is not in (%q, %q)", name, s, parser.Modern, parser.Traditional)
 		}
 
-	case `EXTRA_FLOAT_DIGITS`:
-		// These settings are sent by the JDBC driver but we silently ignore them.
-
-	case `APPLICATION_NAME`:
-		// These settings are sent by the clients to improve query logging on the server,
-		// but we silently ignore them.
-
 	case `DEFAULT_TRANSACTION_ISOLATION`:
 		// It's unfortunate that clients want us to support both SET
 		// SESSION CHARACTERISTICS AS TRANSACTION ..., which takes the
@@ -121,6 +114,48 @@ func (p *planner) Set(n *parser.Set) (planNode, error) {
 		default:
 			return nil, fmt.Errorf("%s: \"%s\" not supported", name, s)
 		}
+
+	// These settings are sent by various client drivers. We don't support
+	// changing them, so we either silently ignore them or throw an error given
+	// a setting that we do not respect.
+	case `EXTRA_FLOAT_DIGITS`:
+	// See https://www.postgresql.org/docs/9.6/static/runtime-config-client.html
+	case `APPLICATION_NAME`:
+	// Set by clients to improve query logging.
+	// See https://www.postgresql.org/docs/9.6/static/runtime-config-logging.html#GUC-APPLICATION-NAME
+	case `CLIENT_ENCODING`:
+		// See https://www.postgresql.org/docs/9.6/static/multibyte.html
+		s, err := p.getStringVal(name, typedValues)
+		if err != nil {
+			return nil, err
+		}
+		if strings.ToUpper(s) != "UTF8" {
+			return nil, fmt.Errorf("non-UTF8 encoding %s not supported", s)
+		}
+	case `SEARCH_PATH`:
+	// Controls the schema search order. We don't really support this as we
+	// don't have first-class support for schemas.
+	// TODO(jordan) can we hook this up to EvalContext.SearchPath without
+	// breaking things?
+	// See https://www.postgresql.org/docs/9.6/static/runtime-config-client.html
+	case `STANDARD_CONFORMING_STRINGS`:
+		// If true, escape backslash literals in strings. We do this by default,
+		// and we do not support the opposite behavior.
+		// See https://www.postgresql.org/docs/9.1/static/runtime-config-compatible.html#GUC-STANDARD-CONFORMING-STRINGS
+		s, err := p.getStringVal(name, typedValues)
+		if err != nil {
+			return nil, err
+		}
+		switch parser.Name(s).Normalize() {
+		case parser.ReNormalizeName("off"):
+			return nil, fmt.Errorf("STANDARD_CONFORMING_STRINGS=off not supported")
+		case parser.ReNormalizeName("on"):
+		default:
+			return nil, fmt.Errorf("%s: \"%s\" not supported", name, s)
+		}
+	case `CLIENT_MIN_MESSAGES`:
+	// Controls returned message verbosity. We don't support this.
+	// See https://www.postgresql.org/docs/9.6/static/runtime-config-compatible.html
 
 	default:
 		return nil, fmt.Errorf("unknown variable: %q", name)

--- a/pkg/sql/set.go
+++ b/pkg/sql/set.go
@@ -146,11 +146,7 @@ func (p *planner) Set(n *parser.Set) (planNode, error) {
 		if err != nil {
 			return nil, err
 		}
-		switch parser.Name(s).Normalize() {
-		case parser.ReNormalizeName("off"):
-			return nil, fmt.Errorf("STANDARD_CONFORMING_STRINGS=off not supported")
-		case parser.ReNormalizeName("on"):
-		default:
+		if parser.Name(s).Normalize() != parser.ReNormalizeName("on") {
 			return nil, fmt.Errorf("%s: \"%s\" not supported", name, s)
 		}
 	case `CLIENT_MIN_MESSAGES`:

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -28,6 +28,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	// PgServerVersion is the latest version of postgres that we claim to support.
+	PgServerVersion = "9.5.0"
+)
+
 var varGen = map[string]func(p *planner) string{
 	`DATABASE`:                      func(p *planner) string { return p.session.Database },
 	`DEFAULT_TRANSACTION_ISOLATION`: func(p *planner) string { return p.session.DefaultIsolationLevel.String() },
@@ -37,6 +42,7 @@ var varGen = map[string]func(p *planner) string{
 	`TRANSACTION PRIORITY`:          func(p *planner) string { return p.txn.UserPriority.String() },
 	`MAX_INDEX_KEYS`:                func(_ *planner) string { return "32" },
 	`SEARCH_PATH`:                   func(p *planner) string { return strings.Join(p.session.SearchPath, ", ") },
+	`SERVER_VERSION`:                func(_ *planner) string { return PgServerVersion },
 }
 var varNames = func() []string {
 	res := make([]string, 0, len(varGen))

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -854,6 +854,7 @@ database                       test          NULL      NULL        NULL        s
 default_transaction_isolation  SERIALIZABLE  NULL      NULL        NULL        string
 max_index_keys                 32            NULL      NULL        NULL        string
 search_path                    pg_catalog    NULL      NULL        NULL        string
+server_version                 9.5.0         NULL      NULL        NULL        string
 syntax                         Traditional   NULL      NULL        NULL        string
 time zone                      UTC           NULL      NULL        NULL        string
 transaction isolation level    SERIALIZABLE  NULL      NULL        NULL        string
@@ -867,6 +868,7 @@ database                       test          NULL  user     NULL      test      
 default_transaction_isolation  SERIALIZABLE  NULL  user     NULL      SERIALIZABLE  SERIALIZABLE
 max_index_keys                 32            NULL  user     NULL      32            32
 search_path                    pg_catalog    NULL  user     NULL      pg_catalog    pg_catalog
+server_version                 9.5.0         NULL  user     NULL      9.5.0         9.5.0
 syntax                         Traditional   NULL  user     NULL      Traditional   Traditional
 time zone                      UTC           NULL  user     NULL      UTC           UTC
 transaction isolation level    SERIALIZABLE  NULL  user     NULL      SERIALIZABLE  SERIALIZABLE
@@ -880,6 +882,7 @@ database                       NULL    NULL     NULL     NULL        NULL
 default_transaction_isolation  NULL    NULL     NULL     NULL        NULL
 max_index_keys                 NULL    NULL     NULL     NULL        NULL
 search_path                    NULL    NULL     NULL     NULL        NULL
+server_version                 NULL    NULL     NULL     NULL        NULL
 syntax                         NULL    NULL     NULL     NULL        NULL
 time zone                      NULL    NULL     NULL     NULL        NULL
 transaction isolation level    NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/testdata/set
+++ b/pkg/sql/testdata/set
@@ -110,9 +110,22 @@ TIME ZONE                      UTC
 TRANSACTION ISOLATION LEVEL    SERIALIZABLE
 TRANSACTION PRIORITY           NORMAL
 
+## Test that our no-op compatibility vars work
+
 statement ok
 SET APPLICATION_NAME = 'hello'
 
 statement ok
 SET EXTRA_FLOAT_DIGITS = 3
 
+statement ok
+SET CLIENT_MIN_MESSAGES = 'debug'
+
+statement ok
+SET STANDARD_CONFORMING_STRINGS = 'on'
+
+statement ok
+SET CLIENT_ENCODING = 'UTF8'
+
+statement ok
+SET SEARCH_PATH = 'blah'

--- a/pkg/sql/testdata/set
+++ b/pkg/sql/testdata/set
@@ -105,6 +105,7 @@ DATABASE                       foo
 DEFAULT_TRANSACTION_ISOLATION  SERIALIZABLE
 MAX_INDEX_KEYS                 32
 SEARCH_PATH                    pg_catalog
+SERVER_VERSION                 9.5.0
 SYNTAX                         Modern
 TIME ZONE                      UTC
 TRANSACTION ISOLATION LEVEL    SERIALIZABLE
@@ -124,8 +125,14 @@ SET CLIENT_MIN_MESSAGES = 'debug'
 statement ok
 SET STANDARD_CONFORMING_STRINGS = 'on'
 
+statement error STANDARD_CONFORMING_STRINGS: "off" not supported
+SET STANDARD_CONFORMING_STRINGS = 'off'
+
 statement ok
 SET CLIENT_ENCODING = 'UTF8'
+
+statement error non-UTF8 encoding other not supported
+SET CLIENT_ENCODING = 'other'
 
 statement ok
 SET SEARCH_PATH = 'blah'


### PR DESCRIPTION
This PR adds no-op support for setting the following variables, to improve ORM compatability:

- `SEARCH_PATH`
- `CLIENT_ENCODING`
- `STANDARD_CONFORMING_STRINGS`
- `CLIENT_MIN_MESSAGES`

It also adds support for`SHOW SERVER_VERSION`, always returning the `9.5.0` postgres version that we return over `pgwire`.

Resolves #12137 
Resolves #12134 
Resolves #12113 
Resolves #12109 
Resolves #12112

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12149)
<!-- Reviewable:end -->
