### PR TITLE
ui: Graph Colors, small tweaks

### DIFF
--- a/pkg/ui/app/components/graphs.tsx
+++ b/pkg/ui/app/components/graphs.tsx
@@ -1,10 +1,15 @@
 import * as React from "react";
-import * as d3 from "d3";
 import _ from "lodash";
 import * as protos from "../js/protos";
 import Long from "long";
 
 type TSResponseMessage = Proto2TypeScript.cockroach.ts.tspb.TimeSeriesQueryResponseMessage;
+
+// Global set of colors for graph series.
+export let seriesPalette = [
+  "#5F6C87", "#F2BE2C", "#F16969", "#4E9FD1", "#49D990", "#D77FBF", "#87326D", "#A3415B",
+  "#B59153", "#C9DB6D", "#203D9B", "#748BF2", "#91C8F2", "#FF9696", "#EF843C", "#DCCD4B",
+];
 
 /**
  * MetricProps reperesents the properties assigned to a selector component. A
@@ -127,9 +132,6 @@ class AxisDomain {
   }
 }
 
-// Global set of d3 colors.
-let colors: d3.scale.Ordinal<string, string> = d3.scale.category10();
-
 /**
  * getTimestamps is a helper function that takes graph data from the server and
  * returns a SeenTimestamps object with all the values set to false. This object
@@ -190,7 +192,6 @@ export function ProcessDataPoints(metrics: React.ReactElement<MetricProps>[],
       formattedData.push({
         values: datapoints || [],
         key: s.props.title || s.props.name,
-        color: colors(s.props.name),
         area: true,
         fillOpacity: .1,
       });

--- a/pkg/ui/app/components/linegraph.tsx
+++ b/pkg/ui/app/components/linegraph.tsx
@@ -7,7 +7,7 @@ import _ from "lodash";
 import { findChildrenOfType } from "../util/find";
 import { NanoToMilli } from "../util/convert";
 import {
-  MetricsDataComponentProps, Axis, AxisProps, Metric, MetricProps, ProcessDataPoints,
+  MetricsDataComponentProps, Axis, AxisProps, Metric, MetricProps, ProcessDataPoints, seriesPalette,
 } from "./graphs";
 import Visualization from "./visualization";
 
@@ -15,7 +15,7 @@ import Visualization from "./visualization";
 const CHART_MARGINS: nvd3.Margin = {top: 20, right: 60, bottom: 20, left: 60};
 
 // Maximum number of series we will show in the legend. If there are more we hide the legend.
-const MAX_LEGEND_SERIES: number = 3;
+const MAX_LEGEND_SERIES: number = 4;
 
 interface LineGraphProps extends MetricsDataComponentProps {
   title?: string;
@@ -31,8 +31,6 @@ interface LineGraphProps extends MetricsDataComponentProps {
  * axis.
  */
 export class LineGraph extends React.Component<LineGraphProps, {}> {
-  static colors: d3.scale.Ordinal<string, string> = d3.scale.category10();
-
   // The SVG Element in the DOM used to render the graph.
   svgEl: SVGElement;
 
@@ -75,6 +73,7 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
       .showYAxis(true)
       .showXAxis(this.props.xAxis || true)
       .xScale(d3.time.scale())
+      .color(seriesPalette)
       .margin(CHART_MARGINS);
 
     this.chart.xAxis

--- a/pkg/ui/app/components/stackedgraph.tsx
+++ b/pkg/ui/app/components/stackedgraph.tsx
@@ -7,7 +7,7 @@ import _ from "lodash";
 import { findChildrenOfType } from "../util/find";
 import { NanoToMilli } from "../util/convert";
 import {
-  MetricsDataComponentProps, Axis, AxisProps, Metric, MetricProps, ProcessDataPoints,
+  MetricsDataComponentProps, Axis, AxisProps, Metric, MetricProps, ProcessDataPoints, seriesPalette,
 } from "./graphs";
 import Visualization from "./visualization";
 
@@ -73,6 +73,7 @@ export class StackedAreaGraph extends React.Component<StackedAreaGraphProps, {}>
       .showYAxis(true)
       .showXAxis(this.props.xAxis || true)
       .xScale(d3.time.scale())
+      .color(seriesPalette)
       .margin(CHART_MARGINS);
 
     this.chart.showControls(false);

--- a/pkg/ui/app/containers/nodeGraphs.tsx
+++ b/pkg/ui/app/containers/nodeGraphs.tsx
@@ -130,7 +130,6 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
           </GraphGroup>
 
           <GraphGroup groupId="node.resources" hide={dashboard !== "resources"}>
-            <h2>System Resources</h2>
             <StackedAreaGraph title="CPU Usage" sources={sources} tooltip={`The average percentage of CPU used by CockroachDB (User %) and system-level operations (Sys %) ${specifier}.`}>
               <Axis format={ d3.format(".2%") }>
                 <Metric name="cr.node.sys.cpu.user.percent" aggregateAvg title="CPU User %" />

--- a/pkg/ui/styl/components/visualizations.styl
+++ b/pkg/ui/styl/components/visualizations.styl
@@ -38,13 +38,11 @@ $viz-sides = 62px
     clearfix()
 
   &__title
-    text-transform uppercase
     font-size 14px
     font-family lato
     float left
 
   &__subtitle
-    text-transform uppercase
     color $light-gray
     margin-left 5px
     font-size 12px


### PR DESCRIPTION
Adds initial set of graph colors from Kuan; graph colors are not the same for
each graph (i.e. the first series on every graph is now the same color);
previously, colors were randomly allotted to series and would differ from
graph-to-graph.

Small tweaks:
+ No longer capitalize graph titles
+ Increase graph legend limit to 4 series to take advantage of additional space on wide graphs
+ Remove superfluous h2 tag from "system resources" dashboard.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12152)
<!-- Reviewable:end -->
