### PR TITLE
sqlbase: generalize function to create a primary index key in tests

### DIFF
--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -1563,3 +1563,56 @@ func (desc TableDescriptor) collectConstraintInfo(
 	}
 	return info, nil
 }
+
+// MakePrimaryIndexKey creates a key prefix that corresponds to a table row
+// (in the primary index); it is intended for tests.
+//
+// The value types must match the primary key columns (or a prefix of them);
+// supported types are: - Datum
+//  - bool (converts to DBool)
+//  - int (converts to DInt)
+//  - string (converts to DString)
+func MakePrimaryIndexKey(desc *TableDescriptor, vals ...interface{}) (roachpb.Key, error) {
+	index := &desc.PrimaryIndex
+	if len(vals) > len(index.ColumnIDs) {
+		return nil, errors.Errorf("got %d values, PK has %d columns", len(vals), len(index.ColumnIDs))
+	}
+	datums := make([]parser.Datum, len(vals))
+	for i, v := range vals {
+		switch v := v.(type) {
+		case bool:
+			datums[i] = parser.MakeDBool(parser.DBool(v))
+		case int:
+			datums[i] = parser.NewDInt(parser.DInt(v))
+		case string:
+			datums[i] = parser.NewDString(v)
+		case parser.Datum:
+			datums[i] = v
+		default:
+			return nil, errors.Errorf("unexpected value type %T", v)
+		}
+		// Check that the value type matches.
+		colID := index.ColumnIDs[i]
+		for _, c := range desc.Columns {
+			if c.ID == colID {
+				if t := DatumTypeToColumnKind(datums[i].ResolvedType()); t != c.Type.Kind {
+					return nil, errors.Errorf("column %d of type %s, got value of type %s", i, c.Type.Kind, t)
+				}
+				break
+			}
+		}
+	}
+	// Create the ColumnID to index in datums slice map needed by
+	// MakeIndexKeyPrefix.
+	colIDToRowIndex := make(map[ColumnID]int)
+	for i := range vals {
+		colIDToRowIndex[index.ColumnIDs[i]] = i
+	}
+
+	keyPrefix := MakeIndexKeyPrefix(desc, index.ID)
+	key, _, err := EncodeIndexKey(desc, index, colIDToRowIndex, datums, keyPrefix)
+	if err != nil {
+		return nil, err
+	}
+	return roachpb.Key(key), nil
+}


### PR DESCRIPTION
Generalizing a function used in a test to create a key corresponding to a
primary index row and moving it to sqlbase. It will be used by other tests
and/or test infrastructure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12164)
<!-- Reviewable:end -->
