### PR TITLE
vendor: add fake imports for glide's benefit

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -40,9 +40,12 @@ and checked out as a submodule at `./vendor`.
 ## Updating Dependencies
 This snapshot was built and is managed using `glide`.
 
-The [docs](https://github.com/Masterminds/glide) have detailed instructions, but in brief:
+The [docs](https://github.com/Masterminds/glide) have detailed instructgions, but in brief:
 * run `./scripts/glide.sh` in `cockroachdb/cockroach`.
 * add new dependencies with `./scripts/glide.sh get -s github.com/my/dependency`
+	- Note: if you are adding a non-import dependency (e.g. a binary tool to be used in development),
+		please add a dummy import to `build/tool_imports.go`. This is a workaround for an upstream issue:
+		https://github.com/Masterminds/glide/issues/690.
 * update dependencies to their latest version with `./scripts/glide.sh up`
   - to pin a dependency to a particular version, add a `version: ...` line to `glide.yaml`, then update.
   - to update a pinned dependency, change the version in `glide.yaml`, then update.

--- a/build/checkdeps.sh
+++ b/build/checkdeps.sh
@@ -14,7 +14,7 @@ echo "checking that 'vendor' matches manifest"
 
 echo "checking that all deps are in 'vendor''"
 
-missing=$(cat GLOCKFILE | cut -f2 -d' ' | grep -v '^./pkg/' | awk '{print} END {print "./pkg/..."}' \
+missing=$(sed -n 's,[[:space:]]*_[[:space:]]*"\(.*\)",\1,p' build/tool_imports.go | awk '{print} END {print "./pkg/..."}' \
   | xargs go list -f '{{ join .Deps "\n"}}{{"\n"}}{{ join .TestImports "\n"}}{{"\n"}}{{ join .XTestImports "\n"}}' \
   | grep -v '^github.com/cockroachdb/cockroach' \
   | sort | uniq \

--- a/build/tool_imports.go
+++ b/build/tool_imports.go
@@ -1,0 +1,48 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build glide
+
+package main
+
+// Our vendoring tool, glide, only considers imports as the set of roots used
+// to compute the transitive closure of dependencies it should resolve.
+// We depend on many tools which we don't actually import directly elsewhere –
+// e.g in a `go generate` or our Makefiles – but convincing `glide` to vendor
+// them, and their dependencies, is difficult: https://github.com/Masterminds/glide/issues/690
+//
+// Thus, instead of trying to use `glide get` or `glide.yaml` to document those
+// additional dependency roots, we add fake imports here for glide to find.
+// NB: Some of these are `package main` so they cannot actually be imported, so
+// this file is build-tagged +glide to prevent attempting to build it.
+
+import (
+	_ "github.com/client9/misspell/cmd/misspell"
+	_ "github.com/cockroachdb/c-protobuf/cmd/protoc"
+	_ "github.com/cockroachdb/crlfmt"
+	_ "github.com/cockroachdb/stress"
+	_ "github.com/golang/lint/golint"
+	_ "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway"
+	_ "github.com/jteeuwen/go-bindata/go-bindata"
+	_ "github.com/kisielk/errcheck"
+	_ "github.com/kkaneda/returncheck"
+	_ "github.com/mattn/goveralls"
+	_ "github.com/mdempsky/unconvert"
+	_ "github.com/mibk/dupl"
+	_ "github.com/robfig/glock"
+	_ "github.com/wadey/gocovmerge"
+	_ "golang.org/x/tools/cmd/goimports"
+	_ "golang.org/x/tools/cmd/goyacc"
+	_ "golang.org/x/tools/cmd/stringer"
+)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f97869d3329aea5fd9e34771aaf95ad59b296f03c9095d9ad5017ed8d2bcd1fd
-updated: 2016-12-06T20:35:54.139578972Z
+hash: f1146668d1b64c6bb73e2a2f888975bf6e026ac486e26bcc47aecac5cc5b180c
+updated: 2016-12-08T04:22:04.906667276Z
 imports:
 - name: cloud.google.com/go
   version: 2b8eb373216db8c887f4934051ab8338581e3656
@@ -42,7 +42,7 @@ imports:
 - name: github.com/cockroachdb/cmux
   version: b64f5908f4945f4b11ed4a0a9d3cc1e23350866d
 - name: github.com/cockroachdb/cockroach-go
-  version: 2c874f130e4765aea4655923ff11c4c111397a41
+  version: 140a8c585a33363479fceb56093c277032a17894
   subpackages:
   - crdb
 - name: github.com/cockroachdb/crlfmt
@@ -54,7 +54,7 @@ imports:
 - name: github.com/codahale/hdrhistogram
   version: 3a0bb77429bd3a61596f5e8a3172445844342120
 - name: github.com/coreos/etcd
-  version: cfd10b4bbfc6a9a1cf2d3f5ec8e31dae31e15122
+  version: b713113094826715b431bab47ba2b8e1991cc056
   subpackages:
   - raft
   - raft/raftpb
@@ -63,7 +63,7 @@ imports:
   subpackages:
   - md2man
 - name: github.com/docker/distribution
-  version: 67095fbce3e4b079c3db62d08836548854a4b7ad
+  version: 844b92879f179f16a26ce441631880aa3079b7f4
   subpackages:
   - digest
   - reference
@@ -157,11 +157,13 @@ imports:
   - jsonpb
   - proto
   - protoc-gen-go/descriptor
+  - protoc-gen-go/generator
+  - protoc-gen-go/plugin
   - ptypes/timestamp
 - name: github.com/google/btree
   version: 925471ac9e2131377a91e1595defec898166fe49
 - name: github.com/google/go-github
-  version: 171a9316fc826fdb616072bd967483452eb1e2cf
+  version: 43e7458cf61b30944e822345dc028a649d7f87b4
   subpackages:
   - github
 - name: github.com/google/go-querystring
@@ -174,6 +176,10 @@ imports:
   version: 84398b94e188ee336f307779b57b3aa91af7063c
   subpackages:
   - protoc-gen-grpc-gateway
+  - protoc-gen-grpc-gateway/descriptor
+  - protoc-gen-grpc-gateway/generator
+  - protoc-gen-grpc-gateway/gengateway
+  - protoc-gen-grpc-gateway/httprule
   - runtime
   - runtime/internal
   - third_party/googleapis/google/api
@@ -188,10 +194,14 @@ imports:
   - go-bindata
 - name: github.com/kisielk/errcheck
   version: db0ca22445717d1b2c51ac1034440e0a2a2de645
+  subpackages:
+  - internal/errcheck
 - name: github.com/kisielk/gotool
   version: 0de1eaf82fa3f583ce21fde859f1e7e0c5e9b220
 - name: github.com/kkaneda/returncheck
   version: bf081fa7155e3a27df1f056a49d50685edfa5b1b
+  subpackages:
+  - internal
 - name: github.com/kr/pretty
   version: cfb55aafdaf3ec08f0db22699ab822c50091b1c4
 - name: github.com/kr/text
@@ -223,6 +233,12 @@ imports:
   version: beb68d938016d2dec1d1b078054f4d3db25f97be
 - name: github.com/mibk/dupl
   version: f008fcf5e62793d38bda510ee37aab8b0c68e76c
+  subpackages:
+  - job
+  - output
+  - suffixtree
+  - syntax
+  - syntax/golang
 - name: github.com/Microsoft/go-winio
   version: 24a3e3d3fc7451805e09d11e11e95d9a0a4f205e
 - name: github.com/montanaflynn/stats
@@ -230,7 +246,7 @@ imports:
 - name: github.com/olekukonko/tablewriter
   version: bdcc175572fd7abece6c831e643891b9331bc9e7
 - name: github.com/opencontainers/runc
-  version: 5974b4c7a1a4d4579c0c25cbb01b0070d1285bbc
+  version: 34f23cb99c30040e2ca82442eeb22d15a757f78d
   subpackages:
   - libcontainer/user
 - name: github.com/opentracing/basictracer-go
@@ -278,8 +294,6 @@ imports:
   version: 1dba4b3954bc059efc3991ec364f9f9a35f597d2
 - name: github.com/Sirupsen/logrus
   version: 55eb11d21d2a31a3cc93838241d04800f52e823d
-  subpackages:
-  - formatters/logstash
 - name: github.com/spf13/cobra
   version: 9495bc009a56819bdb0ddbc1a373e29c140bc674
   subpackages:
@@ -335,16 +349,20 @@ imports:
   - language
   - transform
   - unicode/norm
+  - width
 - name: golang.org/x/tools
-  version: ae1141fc8b3e38d9e074b383af516745815897c3
+  version: 3d92dd60033c312e3ae7cac319c792271cf67e37
   subpackages:
   - cmd/goimports
   - cmd/goyacc
   - cmd/stringer
+  - cover
   - go/ast/astutil
   - go/buildutil
+  - go/gcimporter15
   - go/loader
   - go/types/typeutil
+  - imports
 - name: google.golang.org/api
   version: 3ef9447cad8d725923ca024dab57786299cf745a
   subpackages:
@@ -375,8 +393,6 @@ imports:
   subpackages:
   - compute/metadata
   - internal
-  - internal/opts
-  - storage
 - name: google.golang.org/grpc
   version: 79b7c349179cdd6efd8bac4a1ce7f01b98c16e9b
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,39 +11,10 @@ import:
   version: 7248742ae7127347a52ab9d215451c213b7b59da
 - package: github.com/gogo/protobuf
   version: ccdc7fbcb4cd13f34b76d7262805e58316faaaf4
-- package: github.com/grpc-ecosystem/grpc-gateway
-  subpackages:
-  - protoc-gen-grpc-gateway
 - package: golang.org/x/net
   version: 97edce0b2e423f6a8debb459af47f4a3cb4ff954
 - package: google.golang.org/grpc
   version: 79b7c349179cdd6efd8bac4a1ce7f01b98c16e9b
-- package: github.com/jteeuwen/go-bindata
-  subpackages:
-  - go-bindata
-- package: github.com/mattn/goveralls
-- package: github.com/client9/misspell
-  subpackages:
-  - cmd/misspell
-- package: github.com/cockroachdb/crlfmt
-- package: github.com/cockroachdb/stress
-- package: github.com/golang/lint
-  subpackages:
-  - golint
-- package: github.com/kisielk/errcheck
-- package: github.com/kkaneda/returncheck
-- package: github.com/mdempsky/unconvert
-- package: github.com/mibk/dupl
-- package: github.com/robfig/glock
-- package: github.com/wadey/gocovmerge
-- package: golang.org/x/tools
-  subpackages:
-  - cmd/goimports
-  - cmd/goyacc
-  - cmd/stringer
-- package: github.com/golang/glog
-- package: github.com/pborman/uuid
-- package: github.com/agtorre/gocolorize
 - package: google.golang.org/api
   version: 3ef9447cad8d725923ca024dab57786299cf745a
 - package: cloud.google.com/go


### PR DESCRIPTION
We've repeatedly encountered issues arising from the fact that entries in `glide.yaml` are not treated as the, or even as additional, roots in the calculation of the transitive dependency closure.

Previously in #11797, we attempted to clarify the situation by pruning all derivable specs from `glide.yaml`, so that it would be clear where the dependency roots were indeed coming from.

We however left vendored tools, and their transitive dependencies, there, as they were not derivable from any imports (e.g. some are not importable due to `package main`).

As we've already found though, simply adding a tool to `glide.yaml`, or even `glide get`'ing them, doesn't work: Masterminds/glide#690.

Thus, to reliably vendor tools and their dependencies, we need to introduce artifical imports of them. We get around the `package main` issue with by hiding the imports in a file that is build-tagged `+glide` so we never attempt to build it.

---

The `glide up` used to test this also picked up the following uninteresting changes:
	

- golang.org/x/tools: ae1141fc -> 3d92dd6
  - https://github.com/golang/tools/compare/ae1141fc...3d92dd60
- github.com/cockroachdb/cockroach-go: 2c874f13 -> 140a8c58
  - https://github.com/cockroachdb/cockroach-go/compare/2c874f130e4765aea4655923ff11c4c111397a41...140a8c585a33363479fceb56093c277032a17894
- github.com/coreos/etcd: cfd10b4b -> b7131130
  - https://github.com/coreos/etcd/compare/cfd10b4bbfc6a9a1cf2d3f5ec8e31dae31e15122...b713113094826715b431bab47ba2b8e1991cc056
- github.com/docker/distribution: 67095fbc -> 844b9287
  - https://github.com/docker/distribution/compare/67095fbce3e4b079c3db62d08836548854a4b7ad...844b92879f179f16a26ce441631880aa3079b7f4
- github.com/google/go-github: 171a9316 -> 43e7458c
  - https://github.com/google/go-github/compare/171a9316fc826fdb616072bd967483452eb1e2cf...43e7458cf61b30944e822345dc028a649d7f87b4
- github.com/opencontainers/runc: 5974b4c7 -> 34f23cb9
  - https://github.com/opencontainers/runc/compare/5974b4c7a1a4d4579c0c25cbb01b0070d1285bbc...34f23cb99c30040e2ca82442eeb22d15a757f78d

Note: The etcd bump *does* include [a raft change](https://github.com/coreos/etcd/pull/6935), but it is test only

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12166)
<!-- Reviewable:end -->