### PR TITLE
acceptance: add traffic to rebalancing tests

### DIFF
--- a/pkg/acceptance/allocator_test.go
+++ b/pkg/acceptance/allocator_test.go
@@ -187,6 +187,14 @@ func (at *allocatorTest) Run(ctx context.Context, t *testing.T) {
 	CheckGossip(ctx, t, at.f, longWaitTime, HasPeers(at.EndNodes))
 	at.f.Assert(ctx, t)
 
+	log.Infof(ctx, "starting load on cluster")
+	if err := at.f.StartLoad(ctx, "block_writer", *flagCLTWriters); err != nil {
+		t.Fatal(err)
+	}
+	if err := at.f.StartLoad(ctx, "photos", *flagCLTWriters); err != nil {
+		t.Fatal(err)
+	}
+
 	log.Info(ctx, "waiting for rebalance to finish")
 	if err := at.WaitForRebalance(ctx, t); err != nil {
 		t.Fatal(err)

--- a/pkg/acceptance/terrafarm/farmer.go
+++ b/pkg/acceptance/terrafarm/farmer.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/pkg/errors"
 )
@@ -358,4 +359,22 @@ func (f *Farmer) logf(format string, args ...interface{}) {
 	if f.Output != nil {
 		fmt.Fprintf(f.Output, format, args...)
 	}
+}
+
+// StartLoad starts n loadGenerator processes.
+func (f *Farmer) StartLoad(ctx context.Context, loadGenerator string, n int) error {
+	if n > len(f.Nodes()) {
+		return errors.Errorf("writers (%d) > nodes (%d)", n, len(f.Nodes()))
+	}
+
+	// We may have to retry restarting the load generators, because CockroachDB
+	// might have been started too recently to start accepting connections.
+	for i := 0; i < n; i++ {
+		if err := util.RetryForDuration(10*time.Second, func() error {
+			return f.Start(ctx, i, loadGenerator)
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
With lease holder rebalancing working, it makes sense
to add some traffic to the rebalancing tests so that they
are more realistic.

fixes #10465

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12177)
<!-- Reviewable:end -->
