### PR TITLE
storage: use NodeLiveness in conjunction with gossip for allocator

### DIFF
--- a/pkg/gossip/keys.go
+++ b/pkg/gossip/keys.go
@@ -91,6 +91,12 @@ func MakePrefixPattern(prefix string) string {
 	return regexp.QuoteMeta(prefix+separator) + ".*"
 }
 
+// MakeOrPattern returns a regular expression pattern that matches
+// any of the provided components.
+func MakeOrPattern(components ...string) string {
+	return strings.Join(components, "|")
+}
+
 // MakeNodeIDKey returns the gossip key for node ID info.
 func MakeNodeIDKey(nodeID roachpb.NodeID) string {
 	return MakeKey(KeyNodeIDPrefix, nodeID.String())

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/coreos/etcd/raft"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"
@@ -176,7 +175,8 @@ var multiDCStores = []*roachpb.StoreDescriptor{
 func createTestAllocator(
 	deterministic bool, useRuleSolver bool,
 ) (*stop.Stopper, *gossip.Gossip, *StorePool, Allocator, *hlc.ManualClock) {
-	stopper, g, manualClock, storePool := createTestStorePool(TestTimeUntilStoreDeadOff, deterministic)
+	stopper, g, manualClock, storePool, _ := createTestStorePool(
+		TestTimeUntilStoreDeadOff, deterministic, true /* defaultNodeLiveness */)
 	a := MakeAllocator(storePool, AllocatorOptions{
 		AllowRebalance: true,
 		UseRuleSolver:  useRuleSolver,
@@ -195,24 +195,22 @@ func mockStorePool(
 	storePool.mu.Lock()
 	defer storePool.mu.Unlock()
 
-	storePool.mu.storeDetails = make(map[roachpb.StoreID]*storeDetail)
+	liveNodeSet := map[roachpb.NodeID]struct{}{}
+	storePool.mu.storeDetails = map[roachpb.StoreID]*storeDetail{}
 	for _, storeID := range aliveStoreIDs {
-		detail := newStoreDetail(context.TODO())
+		liveNodeSet[roachpb.NodeID(storeID)] = struct{}{}
+		detail := storePool.getStoreDetailLocked(storeID)
 		detail.desc = &roachpb.StoreDescriptor{
 			StoreID: storeID,
 			Node:    roachpb.NodeDescriptor{NodeID: roachpb.NodeID(storeID)},
 		}
-
-		storePool.mu.storeDetails[storeID] = detail
 	}
 	for _, storeID := range deadStoreIDs {
-		detail := newStoreDetail(context.TODO())
-		detail.dead = true
+		detail := storePool.getStoreDetailLocked(storeID)
 		detail.desc = &roachpb.StoreDescriptor{
 			StoreID: storeID,
 			Node:    roachpb.NodeDescriptor{NodeID: roachpb.NodeID(storeID)},
 		}
-		storePool.mu.storeDetails[storeID] = detail
 	}
 	for storeID, detail := range storePool.mu.storeDetails {
 		for _, replica := range deadReplicas {
@@ -222,6 +220,13 @@ func mockStorePool(
 			detail.deadReplicas[replica.RangeID] = append(detail.deadReplicas[replica.RangeID], replica.Replica)
 		}
 	}
+
+	// Set the node liveness function using the set we constructed.
+	storePool.nodeLivenessFn =
+		func(nodeID roachpb.NodeID, now time.Time, threshold time.Duration) bool {
+			_, ok := liveNodeSet[nodeID]
+			return ok
+		}
 }
 
 func runToggleRuleSolver(t *testing.T, test func(useRuleSolver bool, t *testing.T)) {
@@ -1761,9 +1766,8 @@ func exampleRebalancingCore(useRuleSolver bool) {
 		log.AmbientContext{},
 		g,
 		clock,
-		nil,
+		newMockNodeLiveness(true /* defaultNodeLiveness */).nodeLivenessFunc,
 		TestTimeUntilStoreDeadOff,
-		stopper,
 		/* deterministic */ true,
 	)
 	alloc := MakeAllocator(sp, AllocatorOptions{

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -151,9 +151,8 @@ func createTestStoreWithEngine(
 		log.AmbientContext{},
 		storeCfg.Gossip,
 		storeCfg.Clock,
-		rpcContext,
+		storage.StorePoolNodeLivenessTrue,
 		storage.TestTimeUntilStoreDeadOff,
-		stopper,
 		/* deterministic */ false,
 	)
 	storeCfg.Transport = storage.NewDummyRaftTransport()
@@ -602,9 +601,7 @@ func (m *multiTestContext) makeStoreConfig(i int) storage.StoreConfig {
 		cfg = storage.TestStoreConfig(m.clocks[i])
 	}
 	cfg.Transport = m.transport
-	cfg.DB = m.dbs[i]
 	cfg.Gossip = m.gossips[i]
-	cfg.StorePool = m.storePools[i]
 	cfg.TestingKnobs.DisableSplitQueue = true
 	cfg.TestingKnobs.ReplicateQueueAcceptsUnsplit = true
 	return cfg
@@ -647,14 +644,13 @@ func (m *multiTestContext) populateDB(idx int, stopper *stop.Stopper) {
 	m.dbs[idx] = client.NewDB(sender)
 }
 
-func (m *multiTestContext) populateStorePool(idx int, stopper *stop.Stopper) {
+func (m *multiTestContext) populateStorePool(idx int, nodeLiveness *storage.NodeLiveness) {
 	m.storePools[idx] = storage.NewStorePool(
 		log.AmbientContext{},
 		m.gossips[idx],
 		m.clock,
-		m.rpcContext,
+		storage.MakeStorePoolNodeLivenessFunc(nodeLiveness),
 		m.timeUntilStoreDead,
-		stopper,
 		/* deterministic */ false,
 	)
 }
@@ -716,17 +712,19 @@ func (m *multiTestContext) addStore(idx int) {
 		m.timeUntilStoreDead = storage.TestTimeUntilStoreDeadOff
 	}
 
-	m.populateStorePool(idx, stopper)
-	m.populateDB(idx, stopper)
-
 	nodeID := roachpb.NodeID(idx + 1)
 	cfg := m.makeStoreConfig(idx)
 	cfg.SetDefaults()
+	m.populateDB(idx, stopper)
 	m.nodeLivenesses[idx] = storage.NewNodeLiveness(
 		ambient, m.clocks[idx], m.dbs[idx], m.gossips[idx],
 		cfg.RangeLeaseActiveDuration, cfg.RangeLeaseRenewalDuration,
 	)
+	m.populateStorePool(idx, m.nodeLivenesses[idx])
+	cfg.DB = m.dbs[idx]
 	cfg.NodeLiveness = m.nodeLivenesses[idx]
+	cfg.StorePool = m.storePools[idx]
+
 	store := storage.NewStore(cfg, eng, &roachpb.NodeDescriptor{NodeID: nodeID})
 	if needBootstrap {
 		if err := store.Bootstrap(roachpb.StoreIdent{
@@ -859,16 +857,17 @@ func (m *multiTestContext) restartStore(i int) {
 	m.mu.Lock()
 	stopper := stop.NewStopper()
 	m.stoppers[i] = stopper
-	m.populateDB(i, stopper)
-	m.populateStorePool(i, stopper)
-
 	cfg := m.makeStoreConfig(i)
 	cfg.SetDefaults()
+	m.populateDB(i, stopper)
 	m.nodeLivenesses[i] = storage.NewNodeLiveness(
 		log.AmbientContext{Tracer: tracing.NewTracer()}, m.clocks[i], m.dbs[i], m.gossips[i],
 		cfg.RangeLeaseActiveDuration, cfg.RangeLeaseRenewalDuration,
 	)
+	m.populateStorePool(i, m.nodeLivenesses[i])
+	cfg.DB = m.dbs[i]
 	cfg.NodeLiveness = m.nodeLivenesses[i]
+	cfg.StorePool = m.storePools[i]
 	store := storage.NewStore(cfg, m.engines[i], &roachpb.NodeDescriptor{NodeID: roachpb.NodeID(i + 1)})
 	m.stores[i] = store
 

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -237,6 +237,11 @@ func (r *Replica) GetRaftLogSize() int64 {
 	return r.mu.raftLogSize
 }
 
+// StorePoolNodeLivenessTrue is a NodeLivenessFunc which always returns true.
+func StorePoolNodeLivenessTrue(_ roachpb.NodeID, _ time.Time, _ time.Duration) bool {
+	return true
+}
+
 // GetStoreList is the same function as GetStoreList exposed for tests only.
 func (sp *StorePool) GetStoreList(rangeID roachpb.RangeID) (StoreList, int, int) {
 	return sp.getStoreList(rangeID)

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1768,7 +1768,9 @@ func (r *Replica) applyNewLeaseLocked(
 	pd.Replicated.BlockReads = !isExtension
 	pd.Replicated.State.Lease = &lease
 	pd.Local.leaseMetricsResult = proto.Bool(true)
-	pd.Local.maybeGossipNodeLiveness = &keys.NodeLivenessSpan
+	if l := r.mu.state.Lease; l == nil || l.Replica.StoreID != lease.Replica.StoreID {
+		pd.Local.maybeGossipNodeLiveness = &keys.NodeLivenessSpan
+	}
 	// TODO(tschottdorf): having traced the origin of this call back to
 	// rev 6281926, it seems that we should only be doing this when the
 	// lease holder has changed. However, it's likely not a big deal to
@@ -1825,7 +1827,6 @@ func (r *Replica) CheckConsistency(
 	}
 	var inconsistencyCount uint32
 	var wg sync.WaitGroup
-	sp := r.store.cfg.StorePool
 	for _, replica := range desc.Replicas {
 		if replica == localReplica {
 			continue
@@ -1834,12 +1835,12 @@ func (r *Replica) CheckConsistency(
 		replica := replica // per-iteration copy
 		if err := r.store.Stopper().RunAsyncTask(ctx, func(ctx context.Context) {
 			defer wg.Done()
-			addr, err := sp.resolver(replica.NodeID)
+			addr, err := r.store.cfg.Transport.resolver(replica.NodeID)
 			if err != nil {
 				log.Error(ctx, errors.Wrapf(err, "could not resolve node ID %d", replica.NodeID))
 				return
 			}
-			conn, err := sp.rpcContext.GRPCDial(addr.String())
+			conn, err := r.store.cfg.Transport.rpcContext.GRPCDial(addr.String())
 			if err != nil {
 				log.Error(ctx,
 					errors.Wrapf(err, "could not dial node ID %d address %s", replica.NodeID, addr))

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -118,7 +118,11 @@ func newReplicateQueue(
 	if g != nil { // gossip is nil for some unittests
 		// Register a gossip callback to signal queue that replicas in
 		// purgatory might be retried due to new store gossip.
-		g.RegisterCallback(gossip.MakePrefixPattern(gossip.KeyStorePrefix), func(_ string, _ roachpb.Value) {
+		pattern := gossip.MakeOrPattern(
+			gossip.MakePrefixPattern(gossip.KeyStorePrefix),
+			gossip.MakePrefixPattern(gossip.KeyNodeLivenessPrefix),
+		)
+		g.RegisterCallback(pattern, func(_ string, _ roachpb.Value) {
 			select {
 			case rq.updateChan <- struct{}{}:
 			default:

--- a/pkg/storage/rule_solver_test.go
+++ b/pkg/storage/rule_solver_test.go
@@ -43,9 +43,10 @@ func (c byScoreAndID) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
 func TestRuleSolver(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	stopper, _, _, storePool := createTestStorePool(
+	stopper, _, _, storePool, _ := createTestStorePool(
 		TestTimeUntilStoreDeadOff,
 		/* deterministic */ false,
+		/* defaultNodeLiveness */ true,
 	)
 	defer stopper.Stop()
 

--- a/pkg/storage/store_pool.go
+++ b/pkg/storage/store_pool.go
@@ -18,7 +18,6 @@ package storage
 
 import (
 	"bytes"
-	"container/heap"
 	"fmt"
 	"sort"
 	"time"
@@ -28,14 +27,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/shuffle"
-	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 const (
@@ -56,40 +52,34 @@ const (
 	defaultDeclinedReservationsTimeout = 0 * time.Second
 )
 
-type storeDetail struct {
-	ctx         context.Context
-	desc        *roachpb.StoreDescriptor
-	dead        bool
-	timesDied   int
-	foundDeadOn hlc.Timestamp
-	// throttledUntil is when an throttled store can be considered available
-	// again due to a failed or declined Reserve RPC.
-	throttledUntil  time.Time
-	lastUpdatedTime hlc.Timestamp // This is also the priority for the queue.
-	index           int           // index of the item in the heap, required for heap.Interface
-	deadReplicas    map[roachpb.RangeID][]roachpb.ReplicaDescriptor
-}
+// A NodeLivenessFunc accepts a node ID, current time and threshold before
+// a node is considered dead and returns whether or not the node is live.
+type NodeLivenessFunc func(roachpb.NodeID, time.Time, time.Duration) bool
 
-// markDead sets the storeDetail to dead(inactive).
-func (sd *storeDetail) markDead(foundDeadOn hlc.Timestamp) {
-	sd.dead = true
-	sd.foundDeadOn = foundDeadOn
-	sd.timesDied++
-	if sd.desc != nil {
-		// sd.desc can still be nil if it was markedAlive and enqueued in getStoreDetailLocked
-		// and never markedAlive again.
-		log.Warningf(
-			sd.ctx, "store %s on node %s is now considered offline", sd.desc.StoreID, sd.desc.Node.NodeID,
-		)
+// MakeStorePoolNodeLivenessFunc returns a function which determines
+// whether or not a node is alive based on information provided by
+// the specified NodeLiveness.
+func MakeStorePoolNodeLivenessFunc(nodeLiveness *NodeLiveness) NodeLivenessFunc {
+	return func(nodeID roachpb.NodeID, now time.Time, threshold time.Duration) bool {
+		// Mark the store dead if the node it's on is not live.
+		liveness, err := nodeLiveness.GetLiveness(nodeID)
+		if err != nil {
+			return false
+		}
+		deadAsOf := liveness.Expiration.GoTime().Add(threshold)
+		return now.Before(deadAsOf)
 	}
 }
 
-// markAlive sets the storeDetail to alive(active) and saves the updated time
-// and descriptor.
-func (sd *storeDetail) markAlive(foundAliveOn hlc.Timestamp, storeDesc *roachpb.StoreDescriptor) {
-	sd.desc = storeDesc
-	sd.dead = false
-	sd.lastUpdatedTime = foundAliveOn
+type storeDetail struct {
+	desc *roachpb.StoreDescriptor
+	// throttledUntil is when an throttled store can be considered available
+	// again due to a failed or declined Reserve RPC.
+	throttledUntil time.Time
+	// lastUpdatedTime is set when a store is first consulted and every time
+	// gossip arrives for a store.
+	lastUpdatedTime time.Time
+	deadReplicas    map[roachpb.RangeID][]roachpb.ReplicaDescriptor
 }
 
 // isThrottled returns whether the store is currently throttled.
@@ -113,89 +103,44 @@ const (
 	storeStatusAvailable
 )
 
+func (sd *storeDetail) isDead(
+	now time.Time, threshold time.Duration, livenessFn NodeLivenessFunc,
+) bool {
+	// The store is considered dead if it hasn't been updated via gossip
+	// within the liveness threshold. Note that lastUpdatedTime is set
+	// when the store detail is created and will have a non-zero value
+	// even before the first gossip arrives for a store.
+	deadAsOf := sd.lastUpdatedTime.Add(threshold)
+	if now.After(deadAsOf) {
+		return true
+	}
+	// If there's no descriptor (meaning no gossip ever arrived for this
+	// store), we can't check the node liveness, so presume this node live.
+	if sd.desc == nil {
+		return false
+	}
+	// Even if the store has been updated via gossip, we still rely on
+	// the node liveness to determine whether it is considered live.
+	return !livenessFn(sd.desc.Node.NodeID, now, threshold)
+}
+
 // status returns the current status of the store.
-func (sd *storeDetail) status(now time.Time, rangeID roachpb.RangeID) storeStatus {
-	// The store must be alive and it must have a descriptor to be considered
-	// alive.
-	if sd.dead || sd.desc == nil {
+func (sd *storeDetail) status(
+	now time.Time, threshold time.Duration, rangeID roachpb.RangeID, nl NodeLivenessFunc,
+) storeStatus {
+	// TODO(spencer): there are two ideas of dead in this code right now.
+	// This method considers a node dead if isDead() is true OR if sd.desc
+	// is null. Dead should mean one thing or the other, not both.
+	if sd.isDead(now, threshold, nl) || sd.desc == nil {
 		return storeStatusDead
 	}
-
-	// The store must not have a recent declined reservation to be available.
 	if sd.isThrottled(now) {
 		return storeStatusThrottled
 	}
-
-	// The store must not have a corrupt replica on it.
 	if len(sd.deadReplicas[rangeID]) > 0 {
 		return storeStatusReplicaCorrupted
 	}
-
 	return storeStatusAvailable
-}
-
-// storePoolPQ implements the heap.Interface (which includes sort.Interface)
-// and holds storeDetail. storePoolPQ is not threadsafe.
-type storePoolPQ []*storeDetail
-
-// Len implements the sort.Interface.
-func (pq storePoolPQ) Len() int {
-	return len(pq)
-}
-
-// Less implements the sort.Interface.
-func (pq storePoolPQ) Less(i, j int) bool {
-	return pq[i].lastUpdatedTime.Less(pq[j].lastUpdatedTime)
-}
-
-// Swap implements the sort.Interface.
-func (pq storePoolPQ) Swap(i, j int) {
-	pq[i], pq[j] = pq[j], pq[i]
-	pq[i].index, pq[j].index = i, j
-}
-
-// Push implements the heap.Interface.
-func (pq *storePoolPQ) Push(x interface{}) {
-	n := len(*pq)
-	item := x.(*storeDetail)
-	item.index = n
-	*pq = append(*pq, item)
-}
-
-// Pop implements the heap.Interface.
-func (pq *storePoolPQ) Pop() interface{} {
-	old := *pq
-	n := len(old)
-	item := old[n-1]
-	item.index = -1 // for safety
-	*pq = old[0 : n-1]
-	return item
-}
-
-// peek returns the next value in the priority queue without dequeuing it.
-func (pq storePoolPQ) peek() *storeDetail {
-	if len(pq) == 0 {
-		return nil
-	}
-	return (pq)[0]
-}
-
-// enqueue either adds the detail to the queue or updates its location in the
-// priority queue.
-func (pq *storePoolPQ) enqueue(detail *storeDetail) {
-	if detail.index < 0 {
-		heap.Push(pq, detail)
-	} else {
-		heap.Fix(pq, detail.index)
-	}
-}
-
-// dequeue removes the next detail from the priority queue.
-func (pq *storePoolPQ) dequeue() *storeDetail {
-	if len(*pq) == 0 {
-		return nil
-	}
-	return heap.Pop(pq).(*storeDetail)
 }
 
 // StorePool maintains a list of all known stores in the cluster and
@@ -204,18 +149,14 @@ type StorePool struct {
 	log.AmbientContext
 
 	clock                       *hlc.Clock
+	nodeLivenessFn              NodeLivenessFunc
 	timeUntilStoreDead          time.Duration
-	rpcContext                  *rpc.Context
 	failedReservationsTimeout   time.Duration
 	declinedReservationsTimeout time.Duration
-	resolver                    NodeAddressResolver
 	deterministic               bool
 	mu                          struct {
 		syncutil.RWMutex
-		// Each storeDetail is contained in both a map and a priorityQueue;
-		// pointers are used so that data can be kept in sync.
 		storeDetails   map[roachpb.StoreID]*storeDetail
-		queue          storePoolPQ
 		nodeLocalities map[roachpb.NodeID]roachpb.Locality
 	}
 }
@@ -226,31 +167,28 @@ func NewStorePool(
 	ambient log.AmbientContext,
 	g *gossip.Gossip,
 	clock *hlc.Clock,
-	rpcContext *rpc.Context,
+	nodeLivenessFn NodeLivenessFunc,
 	timeUntilStoreDead time.Duration,
-	stopper *stop.Stopper,
 	deterministic bool,
 ) *StorePool {
 	sp := &StorePool{
 		AmbientContext:     ambient,
 		clock:              clock,
+		nodeLivenessFn:     nodeLivenessFn,
 		timeUntilStoreDead: timeUntilStoreDead,
-		rpcContext:         rpcContext,
 		failedReservationsTimeout: envutil.EnvOrDefaultDuration("COCKROACH_FAILED_RESERVATION_TIMEOUT",
 			defaultFailedReservationsTimeout),
 		declinedReservationsTimeout: envutil.EnvOrDefaultDuration("COCKROACH_DECLINED_RESERVATION_TIMEOUT",
 			defaultDeclinedReservationsTimeout),
-		resolver:      GossipAddressResolver(g),
 		deterministic: deterministic,
 	}
 	sp.mu.storeDetails = make(map[roachpb.StoreID]*storeDetail)
-	heap.Init(&sp.mu.queue)
 	sp.mu.nodeLocalities = make(map[roachpb.NodeID]roachpb.Locality)
+
 	storeRegex := gossip.MakePrefixPattern(gossip.KeyStorePrefix)
 	g.RegisterCallback(storeRegex, sp.storeGossipUpdate)
 	deadReplicasRegex := gossip.MakePrefixPattern(gossip.KeyDeadReplicasPrefix)
 	g.RegisterCallback(deadReplicasRegex, sp.deadReplicasGossipUpdate)
-	sp.start(stopper)
 
 	return sp
 }
@@ -266,12 +204,12 @@ func (sp *StorePool) String() string {
 	sort.Sort(ids)
 
 	var buf bytes.Buffer
-	now := timeutil.Now()
+	now := sp.clock.PhysicalTime()
 
 	for _, id := range ids {
 		detail := sp.mu.storeDetails[id]
 		fmt.Fprintf(&buf, "%d", id)
-		if detail.dead {
+		if detail.isDead(now, sp.timeUntilStoreDead, sp.nodeLivenessFn) {
 			_, _ = buf.WriteString("*")
 		}
 		fmt.Fprintf(&buf, ": range-count=%d fraction-used=%.2f",
@@ -296,11 +234,10 @@ func (sp *StorePool) storeGossipUpdate(_ string, content roachpb.Value) {
 
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
-	// Does this storeDetail exist yet?
 	detail := sp.getStoreDetailLocked(storeDesc.StoreID)
-	detail.markAlive(sp.clock.Now(), &storeDesc)
+	detail.desc = &storeDesc
+	detail.lastUpdatedTime = sp.clock.PhysicalTime()
 	sp.mu.nodeLocalities[storeDesc.Node.NodeID] = storeDesc.Node.Locality
-	sp.mu.queue.enqueue(detail)
 }
 
 // deadReplicasGossipUpdate is the gossip callback used to keep the StorePool up to date.
@@ -322,53 +259,10 @@ func (sp *StorePool) deadReplicasGossipUpdate(_ string, content roachpb.Value) {
 	detail.deadReplicas = deadReplicas
 }
 
-// start will run continuously and mark stores as offline if they haven't been
-// heard from in longer than timeUntilStoreDead.
-func (sp *StorePool) start(stopper *stop.Stopper) {
-	stopper.RunWorker(func() {
-		var timeoutTimer timeutil.Timer
-		defer timeoutTimer.Stop()
-		for {
-			var timeout time.Duration
-			sp.mu.Lock()
-			detail := sp.mu.queue.peek()
-			if detail == nil {
-				// No stores yet, wait the full timeout.
-				timeout = sp.timeUntilStoreDead
-			} else {
-				// Check to see if the store should be marked as dead.
-				deadAsOf := detail.lastUpdatedTime.GoTime().Add(sp.timeUntilStoreDead)
-				now := sp.clock.Now()
-				if now.GoTime().After(deadAsOf) {
-					deadDetail := sp.mu.queue.dequeue()
-					deadDetail.markDead(now)
-					// The next store might be dead as well, set the timeout to
-					// 0 to process it immediately.
-					timeout = 0
-				} else {
-					// Store is still alive, schedule the next check for when
-					// it should timeout.
-					timeout = deadAsOf.Sub(now.GoTime())
-				}
-			}
-			sp.mu.Unlock()
-			timeoutTimer.Reset(timeout)
-			select {
-			case <-timeoutTimer.C:
-				timeoutTimer.Read = true
-			case <-stopper.ShouldStop():
-				return
-			}
-		}
-	})
-}
-
 // newStoreDetail makes a new storeDetail struct. It sets index to be -1 to
 // ensure that it will be processed by a queue immediately.
-func newStoreDetail(ctx context.Context) *storeDetail {
+func newStoreDetail() *storeDetail {
 	return &storeDetail{
-		ctx:          ctx,
-		index:        -1,
 		deadReplicas: make(map[roachpb.RangeID][]roachpb.ReplicaDescriptor),
 	}
 }
@@ -384,13 +278,10 @@ func (sp *StorePool) getStoreDetailLocked(storeID roachpb.StoreID) *storeDetail 
 		// network). The first time this occurs, presume the store is
 		// alive, but start the clock so it will become dead if enough
 		// time passes without updates from gossip.
-		ctx := sp.AnnotateCtx(context.TODO())
-		detail = newStoreDetail(ctx)
+		detail = newStoreDetail()
+		detail.lastUpdatedTime = sp.clock.PhysicalTime()
 		sp.mu.storeDetails[storeID] = detail
-		detail.markAlive(sp.clock.Now(), nil)
-		sp.mu.queue.enqueue(detail)
 	}
-
 	return detail
 }
 
@@ -415,11 +306,11 @@ func (sp *StorePool) deadReplicas(
 	defer sp.mu.Unlock()
 
 	var deadReplicas []roachpb.ReplicaDescriptor
-outer:
+	now := sp.clock.PhysicalTime()
 	for _, repl := range repls {
 		detail := sp.getStoreDetailLocked(repl.StoreID)
 		// Mark replica as dead if store is dead.
-		if detail.dead {
+		if detail.isDead(now, sp.timeUntilStoreDead, sp.nodeLivenessFn) {
 			deadReplicas = append(deadReplicas, repl)
 			continue
 		}
@@ -427,7 +318,7 @@ outer:
 		for _, deadRepl := range detail.deadReplicas[rangeID] {
 			if deadRepl.ReplicaID == repl.ReplicaID {
 				deadReplicas = append(deadReplicas, repl)
-				continue outer
+				break
 			}
 		}
 	}
@@ -539,7 +430,7 @@ func (sp *StorePool) getStoreList(rangeID roachpb.RangeID) (StoreList, int, int)
 	now := sp.clock.PhysicalTime()
 	for _, storeID := range storeIDs {
 		detail := sp.mu.storeDetails[storeID]
-		switch detail.status(now, rangeID) {
+		switch detail.status(now, sp.timeUntilStoreDead, rangeID, sp.nodeLivenessFn) {
 		case storeStatusThrottled:
 			aliveStoreCount++
 			throttledStoreCount++
@@ -579,13 +470,13 @@ func (sp *StorePool) throttle(reason throttleReason, toStoreID roachpb.StoreID) 
 	// timeout period has passed.
 	switch reason {
 	case throttleDeclined:
-		detail.throttledUntil = sp.clock.Now().GoTime().Add(sp.declinedReservationsTimeout)
+		detail.throttledUntil = sp.clock.PhysicalTime().Add(sp.declinedReservationsTimeout)
 		if log.V(2) {
 			log.Infof(ctx, "snapshot declined, store:%s will be throttled for %s until %s",
 				toStoreID, sp.declinedReservationsTimeout, detail.throttledUntil)
 		}
 	case throttleFailed:
-		detail.throttledUntil = sp.clock.Now().GoTime().Add(sp.failedReservationsTimeout)
+		detail.throttledUntil = sp.clock.PhysicalTime().Add(sp.failedReservationsTimeout)
 		if log.V(2) {
 			log.Infof(ctx, "snapshot failed, store:%s will be throttled for %s until %s",
 				toStoreID, sp.failedReservationsTimeout, detail.throttledUntil)

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -150,9 +150,8 @@ func createTestStoreWithoutStart(t testing.TB, stopper *stop.Stopper, cfg *Store
 		log.AmbientContext{},
 		cfg.Gossip,
 		cfg.Clock,
-		rpcContext,
+		StorePoolNodeLivenessTrue,
 		TestTimeUntilStoreDeadOff,
-		stopper,
 		/* deterministic */ false,
 	)
 	eng := engine.NewInMem(roachpb.Attributes{}, 10<<20)


### PR DESCRIPTION
Previously, we were using only how recently a store had gossiped
its store descriptor to determine whether a store was live for the
purposes of allocations and rebalancing. We now additionally
consult the NodeLiveness table, which requires a node be able to
actively heartbeat its liveness system record. Using only gossip
introduced an asymmetry because gossip is considerably more tolerant
of failures.

Simplified the `StorePool` struct to remove the priority queue and
dedicated goroutine.

Fixes #12101

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12178)
<!-- Reviewable:end -->
