### PR TITLE
sql,distsql: logic test flag for distsql execution

### DIFF
--- a/pkg/sql/logic_test.go
+++ b/pkg/sql/logic_test.go
@@ -96,7 +96,7 @@ import (
 // names for query results, or expected errors.
 //
 // The overall architecture of TestLogic is as follows:
-
+//
 // - TestLogic() selects the input files and instantiates
 //   a `logicTest` object for each input file.
 //
@@ -126,7 +126,7 @@ import (
 // -bigtest   cancels any -d setting and selects all relevant input
 //            files from CockroachDB's fork of Sqllogictest.
 //
-// Error mode:
+// Testing mode:
 //
 // -max-errors N  stop testing after N errors have been
 //                encountered. Default 1. Set to 0 for no limit.
@@ -143,6 +143,9 @@ import (
 //                different numeric type than the one expected by the
 //                test. This enables reusing tests designed for
 //                database with sligtly different typing semantics.
+//
+// -distsql       if the given query is supported by distSQL, run the
+//                tests through the distSQL physical planner instead.
 //
 // Test output:
 //
@@ -191,6 +194,8 @@ var (
 	allowPrepareFail = flag.Bool("allow-prepare-fail", false, "tolerate unexpected errors when preparing a query")
 	flexTypes        = flag.Bool("flex-types", false,
 		"do not fail when a test expects a column of a numeric type but the query provides another type")
+	distSQL = flag.Bool("distsql", false,
+		"run distSQL supported queries through distSQL instead")
 
 	// Output parameters
 	showSQL = flag.Bool("show-sql", false,
@@ -425,6 +430,12 @@ func (t *logicTest) setUser(user string) func() {
 	db, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
 		t.Fatal(err)
+	}
+	if *distSQL {
+		_, err := t.db.Exec(`SET DIST_SQL = ON`)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 	t.clients[user] = db
 	t.db = db


### PR DESCRIPTION
Additional flag for ease of testing, if the given query is supported by
distSQL run tests through the distSQL physical planner instead.
I presume once physical planning is more _stable_ we can change this 
out to run both `sql` and `distsql` consecutively.

```bash
make test PKG=./pkg/sql TESTS=TestLogic TESTFLAGS='-v -distsql -d testdata/aggregate'
```

thoughts?
cc @knz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12181)
<!-- Reviewable:end -->
