### PR TITLE
sql: fix ORDER BY with aggregates

### DIFF
--- a/pkg/sql/parser/aggregate_builtins.go
+++ b/pkg/sql/parser/aggregate_builtins.go
@@ -27,7 +27,7 @@ import (
 func initAggregateBuiltins() {
 	// Add all aggregates to the Builtins map after a few sanity checks.
 	for k, v := range Aggregates {
-		for _, a := range v {
+		for i, a := range v {
 			if !a.impure {
 				panic(fmt.Sprintf("aggregate functions should all be impure, found %v", a))
 			}
@@ -43,7 +43,15 @@ func initAggregateBuiltins() {
 				panic(fmt.Sprintf("aggregate functions should have WindowFunc constructors, "+
 					"found %v", a))
 			}
+
+			// The aggregate functions are considered "row dependent". This is
+			// because each aggregate function application receives the set of
+			// grouped rows as implicit parameter. It may have a different
+			// value in every group, so it cannot be considered constant in
+			// the context of a data source.
+			v[i].needsRepeatedEvaluation = true
 		}
+
 		Builtins[k] = v
 	}
 }

--- a/pkg/sql/parser/function_definition.go
+++ b/pkg/sql/parser/function_definition.go
@@ -1,0 +1,115 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package parser
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// FunctionDefinition implements a reference to the (possibly several)
+// overloads for a built-in function.
+type FunctionDefinition struct {
+	// Name is the short name of the function.
+	Name string
+	// HasOverloadsNeedingRepeatedEvaluation is true if one or more of
+	// the overload definitions has needsRepeatedEvaluation set.
+	// Set e.g. for aggregate functions.
+	HasOverloadsNeedingRepeatedEvaluation bool
+	// Definition is the set of overloads for this function name.
+	Definition []Builtin
+}
+
+func newFunctionDefinition(name string, def []Builtin) *FunctionDefinition {
+	hasRowDependentOverloads := false
+	for _, d := range def {
+		if d.needsRepeatedEvaluation {
+			hasRowDependentOverloads = true
+			break
+		}
+	}
+	return &FunctionDefinition{
+		Name: name,
+		HasOverloadsNeedingRepeatedEvaluation: hasRowDependentOverloads,
+		Definition:                            def,
+	}
+}
+
+// funDefs holds pre-allocated FunctionDefinition instances
+// for every builtin function. Initialized by setupBuiltins().
+var funDefs map[string]*FunctionDefinition
+
+// Format implements the NodeFormatter interface.
+func (fd *FunctionDefinition) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString(fd.Name)
+}
+
+func (fd *FunctionDefinition) String() string { return AsString(fd) }
+
+// SearchPath represents a list of namespaces to search builtins in.
+// The names must be normalized (as per Name.Normalize) already.
+type SearchPath []string
+
+// ResolveFunction transforms an UnresolvedName to a FunctionDefinition.
+func (n UnresolvedName) ResolveFunction(searchPath SearchPath) (*FunctionDefinition, error) {
+	fn, err := n.normalizeFunctionName()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(fn.selector) > 0 {
+		// We do not support selectors at this point.
+		return nil, fmt.Errorf("invalid function name: %s", n)
+	}
+
+	if d, ok := funDefs[fn.function()]; ok && fn.prefix() == "" {
+		// Fast path: return early.
+		return d, nil
+	}
+
+	// Although the conversion from Name to string should go via
+	// Name.Normalize(), functions are special in that they are
+	// guaranteed to not contain special Unicode characters. So we can
+	// use ToLower directly.
+	prefix := strings.ToLower(fn.prefix())
+	smallName := strings.ToLower(fn.function())
+	fullName := smallName
+	if prefix != "" {
+		fullName = prefix + "." + smallName
+	}
+	def, ok := funDefs[fullName]
+	if !ok {
+		found := false
+		if prefix == "" {
+			// The function wasn't qualified, so we must search for it via
+			// the search path first.
+			for _, alt := range searchPath {
+				fullName = alt + "." + smallName
+				if def, ok = funDefs[fullName]; ok {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			return nil, fmt.Errorf("unknown function: %s()", n)
+		}
+	}
+
+	return def, nil
+}

--- a/pkg/sql/parser/function_name.go
+++ b/pkg/sql/parser/function_name.go
@@ -19,7 +19,6 @@ package parser
 import (
 	"bytes"
 	"fmt"
-	"strings"
 )
 
 // Function names are used in expressions in the FuncExpr node.
@@ -138,75 +137,4 @@ func (fn *functionName) function() string {
 // Prefix retrieves the unqualified prefix.
 func (fn *functionName) prefix() string {
 	return string(fn.prefixName)
-}
-
-// FunctionDefinition implements a reference to one or more function
-// overloads for a built-in function.
-type FunctionDefinition struct {
-	Name       string
-	Definition []Builtin
-}
-
-// funDefs holds pre-allocated FunctionDefinition instances
-// for every builtin function. Initialized by setupBuiltins().
-var funDefs map[string]*FunctionDefinition
-
-// Format implements the NodeFormatter interface.
-func (fd *FunctionDefinition) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString(fd.Name)
-}
-
-func (fd *FunctionDefinition) String() string { return AsString(fd) }
-
-// SearchPath represents a list of namespaces to search builtins in.
-// The names must be normalized (as per Name.Normalize) already.
-type SearchPath []string
-
-// ResolveFunction transforms an UnresolvedName to a FunctionDefinition.
-func (n UnresolvedName) ResolveFunction(searchPath SearchPath) (*FunctionDefinition, error) {
-	fn, err := n.normalizeFunctionName()
-	if err != nil {
-		return nil, err
-	}
-
-	if len(fn.selector) > 0 {
-		// We do not support selectors at this point.
-		return nil, fmt.Errorf("invalid function name: %s", n)
-	}
-
-	if d, ok := funDefs[fn.function()]; ok && fn.prefix() == "" {
-		// Fast path: return early.
-		return d, nil
-	}
-
-	// Although the conversion from Name to string should go via
-	// Name.Normalize(), functions are special in that they are
-	// guaranteed to not contain special Unicode characters. So we can
-	// use ToLower directly.
-	prefix := strings.ToLower(fn.prefix())
-	smallName := strings.ToLower(fn.function())
-	fullName := smallName
-	if prefix != "" {
-		fullName = prefix + "." + smallName
-	}
-	def, ok := funDefs[fullName]
-	if !ok {
-		found := false
-		if prefix == "" {
-			// The function wasn't qualified, so we must search for it via
-			// the search path first.
-			for _, alt := range searchPath {
-				fullName = alt + "." + smallName
-				if def, ok = funDefs[fullName]; ok {
-					found = true
-					break
-				}
-			}
-		}
-		if !found {
-			return nil, fmt.Errorf("unknown function: %s()", n)
-		}
-	}
-
-	return def, nil
 }

--- a/pkg/sql/select_name_resolution.go
+++ b/pkg/sql/select_name_resolution.go
@@ -101,18 +101,14 @@ func (v *nameResolutionVisitor) VisitPre(expr parser.Expr) (recurse bool, newNod
 			return false, expr
 		}
 
-		if strings.EqualFold(fd.Name, "random") {
-			// `random()` changes values every row. So report we found
-			// a dependent variable.
-			// TODO(knz): in the future we may have more than one built-in
-			// function that has different values for every row. In that
-			// case, the property becomes an attribute of the
-			// built-in. However then overload resolution (type checking)
-			// must occur before this property can be detected. This
-			// would be a more significant refactoring, which is why
-			// we don't do this yet.
+		if fd.HasOverloadsNeedingRepeatedEvaluation {
+			// TODO(knz): this property should really be an attribute of the
+			// individual overloads. By looking at the name-level property
+			// indicator, we are marking a function as row-dependent as
+			// soon as one overload is, even if the particular overload
+			// that would be selected by type checking for this FuncExpr
+			// is constant. This could be more fine-grained.
 			v.foundDependentVars = true
-			break
 		}
 
 		// Check for invalid use of *, which, if it is an argument, is the only argument.
@@ -152,10 +148,6 @@ func (v *nameResolutionVisitor) VisitPre(expr parser.Expr) (recurse bool, newNod
 
 			t = t.CopyNode()
 			t.Exprs[0] = parser.StarDatumInstance
-
-			// the StartDatumInstance refers implicitly to columns,
-			// so it is a dependent variable.
-			v.foundDependentVars = true
 
 			return true, t
 		}

--- a/pkg/sql/testdata/aggregate
+++ b/pkg/sql/testdata/aggregate
@@ -318,20 +318,6 @@ SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY v DESC
 NULL 1
 
 query II
-SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
-----
-NULL 1
-4 2
-2 3
-
-query II
-SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
-----
-NULL 1
-4 2
-2 3
-
-query II
 SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k) DESC
 ----
 2 3
@@ -784,3 +770,24 @@ EXPLAIN (DEBUG) SELECT MAX(a) FROM ab
 0 /ab/primary/5/b 50   PARTIAL
 0 /ab/primary/5   NULL BUFFERED
 0 0               (5)  ROW
+
+query ITT
+EXPLAIN SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
+----
+0   sort    +"COUNT(k)"
+1   group   v, count(k) GROUP BY (@3)
+2   scan    kv@primary
+
+query ITT
+EXPLAIN SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
+----
+0   sort    +"COUNT(*)"
+1   group   v, count(*) GROUP BY (@3)
+2   scan    kv@primary
+
+query ITT
+EXPLAIN SELECT v, COUNT(1) FROM kv GROUP BY v ORDER BY COUNT(1)
+----
+0   sort    +"COUNT(1)"
+1   group   v, count(1) GROUP BY (@3)
+2   scan    kv@primary


### PR DESCRIPTION
Since 146344b we have this
optimization which elides a sort if the sort expression(s) are known
to be constant throughout all the rows being sorted.

However the test to decide whether to elide the sort was (incorrectly)
relying only on the presence of columns from the input data source;
which was later extended (but still incorrectly) to the "random"
function and "count" applied to a StarDatumInstance. This was still
incorrect because *any* aggregate function is susceptible to change
values between the rows being sorted -- the rows being sorted, with an
aggregate function, are the results of grouping, and the evaluated
value of the aggregate function call is different for every group.

This patch addresses the issue more durably by:

- introducing a new built-in attribute "RowDependent" which indicates
  whether a particular function is row-dependent. "random" and all
  aggregate functions are marked with this property.

- using this new property in the code that elides the sort.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12185)
<!-- Reviewable:end -->
