### PR TITLE
sql: implement array_agg aggregate function

### DIFF
--- a/pkg/sql/testdata/aggregate
+++ b/pkg/sql/testdata/aggregate
@@ -7,21 +7,21 @@ CREATE TABLE kv (
 )
 
 # Aggregate functions return NULL if there are no rows.
-query IIIRRRRBB
-SELECT MIN(1), MAX(1), COUNT(1), AVG(1), SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_AND(false) FROM kv
+query IIITRRRRBB
+SELECT MIN(1), MAX(1), COUNT(1), ARRAY_AGG(1), AVG(1), SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_AND(false) FROM kv
 ----
-NULL NULL 0 NULL NULL NULL NULL NULL NULL
+NULL NULL 0 NULL NULL NULL NULL NULL NULL NULL
 
-query IIIRRRRBB
-SELECT MIN(v), MAX(v), COUNT(v), AVG(v), SUM(v), STDDEV(v), VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1) FROM kv
+query IIITRRRRBB
+SELECT MIN(v), MAX(v), COUNT(v), ARRAY_AGG(v), AVG(v), SUM(v), STDDEV(v), VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1) FROM kv
 ----
-NULL NULL 0 NULL NULL NULL NULL NULL NULL
+NULL NULL 0 NULL NULL NULL NULL NULL NULL NULL
 
 # Aggregate functions triggers aggregation and computation when there is no source.
-query IIIRRRRBB
-SELECT MIN(1), COUNT(1), MAX(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(true)
+query IIITRRRRBB
+SELECT MIN(1), COUNT(1), MAX(1), ARRAY_AGG(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(true)
 ----
-1 1 1 1 1 NULL NULL true true
+1 1 1 {1} 1 1 NULL NULL true true
 
 statement OK
 INSERT INTO kv VALUES
@@ -33,10 +33,10 @@ INSERT INTO kv VALUES
 (8, 4, 2, 'A')
 
 # Aggregate functions triggers aggregation and computation for every row even when applied to a constant.
-query IIIRRRRBB
-SELECT MIN(1), COUNT(1), MAX(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1)::float, BOOL_AND(true), BOOL_OR(true) FROM kv
+query IIITRRRRBB
+SELECT MIN(1), COUNT(1), MAX(1), ARRAY_AGG(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1)::float, BOOL_AND(true), BOOL_OR(true) FROM kv
 ----
-1 6 1 1 6 0 0 true true
+1 6 1 {1,1,1,1,1,1} 1 6 0 0 true true
 
 # Even with no aggregate functions, grouping occurs in the presence of GROUP BY.
 query I rowsort
@@ -419,6 +419,11 @@ SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM kv WHERE k > 8
 ----
 NULL NULL NULL NULL
 
+query TT
+SELECT ARRAY_AGG(k), ARRAY_AGG(s) FROM kv
+----
+{1,3,5,6,7,8} {'a','a',NULL,'b','b','A'}
+
 query RRRR
 SELECT AVG(k), AVG(v), SUM(k), SUM(v) FROM kv
 ----
@@ -779,4 +784,3 @@ EXPLAIN (DEBUG) SELECT MAX(a) FROM ab
 0 /ab/primary/5/b 50   PARTIAL
 0 /ab/primary/5   NULL BUFFERED
 0 0               (5)  ROW
-


### PR DESCRIPTION
... for ints and strings.

This aggregate function creates an array out of the values passed to it. See docs at https://www.postgresql.org/docs/9.6/static/functions-aggregate.html.

Resolves #12115.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12186)
<!-- Reviewable:end -->
