### PR TITLE
parser: stardatum fmt interceptor

### DIFF
--- a/pkg/sql/parser/format.go
+++ b/pkg/sql/parser/format.go
@@ -33,6 +33,9 @@ type fmtFlags struct {
 	// IndexedVarContainer.IndexedVarFormat calls; it can be used to
 	// customize the formatting of IndexedVars.
 	indexedVarFormat func(buf *bytes.Buffer, f FmtFlags, c IndexedVarContainer, idx int)
+	// starDatumFormat is an optional interceptor for StarDatum.Format calls,
+	// can be used to customize the formatting of StarDatums.
+	starDatumFormat func(buf *bytes.Buffer, f FmtFlags)
 }
 
 // FmtFlags enables conditional formatting in the pretty-printer.
@@ -68,6 +71,12 @@ func FmtIndexedVarFormat(
 	fn func(buf *bytes.Buffer, f FmtFlags, c IndexedVarContainer, idx int),
 ) FmtFlags {
 	return &fmtFlags{indexedVarFormat: fn}
+}
+
+// FmtStarDatumFormat returns FmtFlags that customizes the printing of
+// StarDatums using the provided function.
+func FmtStarDatumFormat(fn func(buf *bytes.Buffer, f FmtFlags)) FmtFlags {
+	return &fmtFlags{starDatumFormat: fn}
 }
 
 // NodeFormatter is implemented by nodes that can be pretty-printed.

--- a/pkg/sql/parser/star_datum.go
+++ b/pkg/sql/parser/star_datum.go
@@ -39,7 +39,11 @@ func (*StarDatum) Variable() {}
 
 // Format implements the NodeFormatter interface.
 func (*StarDatum) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteByte('*')
+	if f.starDatumFormat != nil {
+		f.starDatumFormat(buf, f)
+	} else {
+		buf.WriteByte('*')
+	}
 }
 
 func (s *StarDatum) String() string { return AsString(s) }

--- a/pkg/sql/parser/star_datum_test.go
+++ b/pkg/sql/parser/star_datum_test.go
@@ -1,0 +1,40 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Irfan Sharif (irfansharif@cockroachlabs.com)
+
+package parser
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestStarDatum(t *testing.T) {
+	typedExpr := StarDatumInstance
+	// Test formatting using the indexed var format interceptor.
+	var buf bytes.Buffer
+	typedExpr.Format(
+		&buf,
+		FmtStarDatumFormat(func(buf *bytes.Buffer, _ FmtFlags) {
+			fmt.Fprintf(buf, "STAR")
+		}),
+	)
+	str := buf.String()
+	expectedStr := "STAR"
+	if str != expectedStr {
+		t.Errorf("invalid expression string '%s', expected '%s'", str, expectedStr)
+	}
+}


### PR DESCRIPTION
similar to work done for custom `IndexedVar` formatting  [4b311bfc52e](https://github.com/cockroachdb/cockroach/pull/10759/commits/4b311bfc52ee1a538d945367ccb3739957e4d04b) ,
needed for serialization of expressions for distsql. by default `*` is rendered 
as a `DInt(0)`, by formatting this as `0` we can replicate this behavior in 
distsql.

NB: I realize there’s no nice way to “compose” `FmtFlags` out of multiple 
`FmtFlag`‘s (this unit does not exist today). for example I can’t have 
`var f parser.FmtFlags` with my own custom defined `FmtNormalizeTableNames` 
*and* `FmtIndexedVarFormat`, it has to be one or the other. I've punted this
for now to complete `distsql/aggregator` work but will look at this after.

cc @knz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12189)
<!-- Reviewable:end -->
