### PR TITLE
sql/parser: improved utf8 rune error handling

### DIFF
--- a/pkg/sql/parser/encode.go
+++ b/pkg/sql/parser/encode.go
@@ -77,15 +77,18 @@ func encodeSQLStringWithFlags(buf *bytes.Buffer, in string, f FmtFlags) {
 		}
 		buf.WriteString(in[start:i])
 		ln := utf8.RuneLen(r)
-		if ln < 0 || r == utf8.RuneError {
+		if ln < 0 {
 			start = i + 1
 		} else {
 			start = i + ln
 		}
 		if r == utf8.RuneError {
-			// Errors are due to invalid unicode points, so escape the byte (Go guarantees
-			// that it's a byte in the case of an error).
+			// Errors are due to invalid unicode points, so escape the bytes.
+			// Make sure this is run at least once in case ln == -1.
 			buf.Write(hexMap[in[i]])
+			for ri := 1; ri < ln; ri++ {
+				buf.Write(hexMap[in[i+ri]])
+			}
 		} else if ln == 1 {
 			// For single-byte runes, do the same as encodeSQLBytes.
 			if encodedChar := encodeMap[ch]; encodedChar != dontEscape {


### PR DESCRIPTION
There is some input that causes Go's string range rune to produce a
RuneError that has length != 1, as would be expected for a RuneError
due to the Go spec about range on strings. This input is still valid
(utf8.ValidString is true). Allow encodeSQLString to correctly output
the bytes for these cases. Note that we cannot simply use the normal
paths below the RuneError path because r == '\uFFFD', but in[i:i+ln]
!= '\uFFFD'.

Fixes #12156

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12194)
<!-- Reviewable:end -->
