### PR TITLE
sql: support GROUP BY for ARRAY columns

### DIFF
--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -480,6 +480,15 @@ func EncodeTableKey(b []byte, val parser.Datum, dir encoding.Direction) ([]byte,
 			}
 		}
 		return b, nil
+	case *parser.DArray:
+		for _, datum := range t.Array {
+			var err error
+			b, err = EncodeTableKey(b, datum, dir)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return b, nil
 	}
 	return nil, errors.Errorf("unable to encode table key: %T", val)
 }

--- a/pkg/sql/testdata/array
+++ b/pkg/sql/testdata/array
@@ -191,3 +191,8 @@ SELECT (1,2,3)[1]
 
 query error cannot subscript type tuple{int, int, int} because it is not an array
 SELECT ROW (1,2,3)[1]
+
+# Ensure grouping by an array column works
+
+statement ok
+SELECT conkey FROM pg_catalog.pg_constraint GROUP BY conkey


### PR DESCRIPTION
Previously, queries could not be grouped by ARRAY columns. This commit teaches `EncodeTableKey` about the `DArray` type, which resolves the problem.

Resolves #12188.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12198)
<!-- Reviewable:end -->
