### PR TITLE
storage: fix race condition in multiTestContext

### DIFF
--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -1098,8 +1098,12 @@ func (m *multiTestContext) expireLeases() {
 	m.expireLeasesWithoutIncrementingEpochs()
 
 	// Increment epochs.
+	m.mu.RLock()
+	nls := append([]*storage.NodeLiveness(nil), m.nodeLivenesses...)
+	m.mu.RUnlock()
+
 	ctx := context.Background()
-	for idx, nl := range m.nodeLivenesses {
+	for idx, nl := range nls {
 		l, err := nl.Self()
 		if err != nil {
 			continue


### PR DESCRIPTION
Introduced a race condition with improvements to re-initialize the
node liveness when a node is restarted.

Fixes #12197

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12199)
<!-- Reviewable:end -->
