### PR TITLE
storage: deflake TestStoreRangeSystemSplits

### DIFF
--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -158,6 +158,8 @@ func createTestStoreWithEngine(
 	storeCfg.Transport = storage.NewDummyRaftTransport()
 	// TODO(bdarnell): arrange to have the transport closed.
 	store := storage.NewStore(storeCfg, eng, nodeDesc)
+	// Disable consistency queue because it uses NodeLiveness which we aren't initializing.
+	store.SetConsistencyQueueActive(false)
 	if bootstrap {
 		if err := store.Bootstrap(roachpb.StoreIdent{NodeID: 1, StoreID: 1}); err != nil {
 			t.Fatal(err)

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -154,6 +154,11 @@ func (s *Store) SetSplitQueueActive(active bool) {
 	s.setSplitQueueActive(active)
 }
 
+// SetConsistencyQueueActive enables or disables the consistency queue.
+func (s *Store) SetConsistencyQueueActive(active bool) {
+	s.setConsistencyQueueActive(active)
+}
+
 // SetReplicaScannerActive enables or disables the scanner. Note that while
 // inactive, removals are still processed.
 func (s *Store) SetReplicaScannerActive(active bool) {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3946,6 +3946,9 @@ func (s *Store) setSplitQueueActive(active bool) {
 func (s *Store) setTimeSeriesMaintenanceQueueActive(active bool) {
 	s.tsMaintenanceQueue.SetDisabled(!active)
 }
+func (s *Store) setConsistencyQueueActive(active bool) {
+	s.consistencyQueue.SetDisabled(!active)
+}
 func (s *Store) setScannerActive(active bool) {
 	s.scanner.SetDisabled(!active)
 }


### PR DESCRIPTION
The consistency queue was kicking in and processing before the test could
complete. We don't initialize a `NodeLiveness` instance for the store-only
tests, so this was getting a nil pointer exception.

Fixes #12218

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12224)
<!-- Reviewable:end -->
