### PR TITLE
server: avoid log spam even if reg server sends excessive updates

### DIFF
--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -55,6 +55,7 @@ func init() {
 const updateCheckFrequency = time.Hour * 24
 const updateCheckJitterSeconds = 120
 const updateCheckRetryFrequency = time.Hour
+const updateMaxVersionsToReport = 3
 
 const optinKey = serverUIDataKeyPrefix + "optin-reporting"
 
@@ -209,6 +210,12 @@ func (s *Server) checkForUpdates(ctx context.Context) {
 		return
 	}
 
+	// Ideally the updates server only returns the most relevant updates for us,
+	// but if it replied with an excessive number of updates, limit log spam by
+	// only printing the last few.
+	if len(r.Details) > updateMaxVersionsToReport {
+		r.Details = r.Details[len(r.Details)-updateMaxVersionsToReport:]
+	}
 	for _, v := range r.Details {
 		log.Infof(ctx, "A new version is available: %s, details: %s", v.Version, v.Details)
 	}


### PR DESCRIPTION
Obviously we should make the reg server reply with only the most relevant
updates for the version that checked, but in case we accidentally send
an excessive number, the node should protect itself from log spam.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12225)
<!-- Reviewable:end -->
