### PR TITLE
acceptance: Fix flake in TestNodeRestart

### DIFF
--- a/pkg/acceptance/chaos_test.go
+++ b/pkg/acceptance/chaos_test.go
@@ -188,6 +188,7 @@ func chaosMonkey(
 	c cluster.Cluster,
 	stopClients bool,
 	pickNodes func() []int,
+	consistentIdx int,
 ) {
 	defer close(state.teardown)
 	for curRound := uint64(1); !state.done(); curRound++ {
@@ -255,7 +256,7 @@ func chaosMonkey(
 		}
 		c.Assert(ctx, state.t)
 
-		if err := cluster.Consistent(ctx, c); err != nil {
+		if err := cluster.Consistent(ctx, c, consistentIdx); err != nil {
 			state.t.Error(err)
 		}
 		log.Warningf(ctx, "round %d: cluster recovered", curRound)
@@ -356,7 +357,7 @@ func testClusterRecoveryInner(
 	pickNodes := func() []int {
 		return rnd.Perm(num)[:rnd.Intn(num)+1]
 	}
-	go chaosMonkey(ctx, &state, c, true, pickNodes)
+	go chaosMonkey(ctx, &state, c, true, pickNodes, 0)
 
 	waitClientsStop(ctx, num, &state, stall)
 
@@ -401,9 +402,10 @@ func testNodeRestartInner(
 		clients:  make([]testClient, 1),
 	}
 
+	clientIdx := num - 1
 	client := &state.clients[0]
 	client.Lock()
-	client.db = makePGClient(t, c.PGUrl(ctx, num-1))
+	client.db = makePGClient(t, c.PGUrl(ctx, clientIdx))
 	client.Unlock()
 	go transferMoneyLoop(ctx, 0, &state, *numAccounts, *maxTransfer)
 
@@ -415,9 +417,9 @@ func testNodeRestartInner(
 	rnd, seed := randutil.NewPseudoRand()
 	log.Warningf(ctx, "monkey starts (seed %d)", seed)
 	pickNodes := func() []int {
-		return []int{rnd.Intn(num - 1)}
+		return []int{rnd.Intn(clientIdx)}
 	}
-	go chaosMonkey(ctx, &state, c, false, pickNodes)
+	go chaosMonkey(ctx, &state, c, false, pickNodes, clientIdx)
 
 	waitClientsStop(ctx, 1, &state, stall)
 

--- a/pkg/acceptance/chaos_test.go
+++ b/pkg/acceptance/chaos_test.go
@@ -238,8 +238,8 @@ func chaosMonkey(
 
 		preCount := state.counts()
 
-		madeProgress := func(lastIdx int) bool {
-			newCounts := state.counts()[:lastIdx]
+		madeProgress := func() bool {
+			newCounts := state.counts()
 			for i := range newCounts {
 				if newCounts[i] > preCount[i] {
 					return true
@@ -250,16 +250,11 @@ func chaosMonkey(
 
 		// Sleep until at least one client is writing successfully.
 		log.Warningf(ctx, "round %d: monkey sleeping while cluster recovers...", curRound)
-		for !state.done() && !madeProgress(len(preCount)) {
+		for !state.done() && !madeProgress() {
 			time.Sleep(time.Second)
 		}
 		c.Assert(ctx, state.t)
 
-		// Sleep until the first client is writing successfully, as that is the
-		// node that will be used by cluster.Consistent().
-		for !state.done() && !madeProgress(1) {
-			time.Sleep(time.Second)
-		}
 		if err := cluster.Consistent(ctx, c); err != nil {
 			state.t.Error(err)
 		}

--- a/pkg/acceptance/cluster/cluster.go
+++ b/pkg/acceptance/cluster/cluster.go
@@ -63,10 +63,10 @@ type Cluster interface {
 }
 
 // Consistent performs a replication consistency check on all the ranges
-// in the cluster. It depends on a majority of the nodes being up.
-func Consistent(ctx context.Context, c Cluster) error {
-	// Always connect to the first node in the cluster.
-	kvClient, err := c.NewClient(ctx, 0)
+// in the cluster. It depends on a majority of the nodes being up, and does
+// the check against the node at index i.
+func Consistent(ctx context.Context, c Cluster, i int) error {
+	kvClient, err := c.NewClient(ctx, i)
 	if err != nil {
 		return err
 	}

--- a/pkg/acceptance/put_test.go
+++ b/pkg/acceptance/put_test.go
@@ -79,7 +79,7 @@ func testPutInner(ctx context.Context, t *testing.T, c cluster.Cluster, cfg clus
 			loadedCount := atomic.LoadInt64(&count)
 			log.Infof(ctx, "%d (%d/s)", loadedCount, loadedCount-baseCount)
 			c.Assert(ctx, t)
-			if err := cluster.Consistent(ctx, c); err != nil {
+			if err := cluster.Consistent(ctx, c, 0); err != nil {
 				t.Fatal(err)
 			}
 		}


### PR DESCRIPTION
It looks like the flake was caused by cluster.Consistent always checking
the node at index 0, despite TestNodeRestart not guaranteeing that node
0 is up and running. Because TestNodeRestart only has a client open to
the node at index 2, that's the only one that's definitely making
progress and that we can trust to use without retries.

I could have also fixed the test with less code by just switching the
client node TestNodeRestart from index 2 to index 0, but I imagine that
restarting the node at index 0 makes for a more interesting test, given
that it likely has the most leases on it to begin with.

I've also reverted ec32818123d1ac8f116effdf23e1bdc454cfcd68, since I don't believe it was doing anything.

Fixes #12196 (hopefully)

@tamird

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12226)
<!-- Reviewable:end -->
