### PR TITLE
sql: Add migration to change schema of system.eventlog (simpler version)

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -43,8 +44,8 @@ var (
 // node versions are currently running within the cluster.
 var backwardCompatibleMigrations = []migrationDescriptor{
 	{
-		name:   "example migration",
-		workFn: exampleNoopMigration,
+		name:   "default UniqueID to uuid_v4 in system.eventlog",
+		workFn: eventlogUniqueIDDefault,
 	},
 }
 
@@ -232,6 +233,36 @@ func migrationKey(migration migrationDescriptor) roachpb.Key {
 	return append(keys.MigrationPrefix, roachpb.RKey(migration.name)...)
 }
 
-func exampleNoopMigration(ctx context.Context, r runner) error {
+func checkQueryResults(results []sql.Result, numResults int) error {
+	for _, result := range results {
+		if result.Err != nil {
+			return result.Err
+		}
+	}
+	if a, e := len(results), numResults; a != e {
+		return errors.Errorf("number of results %d != expected %d", a, e)
+	}
 	return nil
+}
+
+func eventlogUniqueIDDefault(ctx context.Context, r runner) error {
+	const alterStmt = "ALTER TABLE system.eventlog ALTER COLUMN uniqueID SET DEFAULT uuid_v4();"
+
+	// System tables can only be modified by a privileged internal user.
+	session := sql.NewSession(ctx, sql.SessionArgs{User: security.NodeUser}, r.sqlExecutor, nil, nil)
+	defer session.Finish(r.sqlExecutor)
+
+	// Retry a limited number of times because returning an error and letting
+	// the node kill itself is better than holding the migration lease for an
+	// arbitrarily long time.
+	var err error
+	for retry := retry.Start(retry.Options{MaxRetries: 5}); retry.Next(); {
+		res := r.sqlExecutor.ExecuteStatements(session, alterStmt, nil)
+		err = checkQueryResults(res.ResultList, 1)
+		if err == nil {
+			break
+		}
+		log.Warningf(ctx, "failed attempt to update system.eventlog schema: %s", err)
+	}
+	return err
 }

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -736,7 +736,7 @@ func TestAdminAPIEvents(t *testing.T) {
 		eventType sql.EventLogType
 		expCount  int
 	}{
-		{"", 7},
+		{"", 8},
 		{sql.EventLogNodeJoin, 1},
 		{sql.EventLogNodeRestart, 0},
 		{sql.EventLogDropDatabase, 0},

--- a/pkg/sql/metric_test.go
+++ b/pkg/sql/metric_test.go
@@ -46,20 +46,20 @@ func TestQueryCounts(t *testing.T) {
 		txnCommitCount   int64
 		txnRollbackCount int64
 	}{
-		{"", 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		{"BEGIN; END", 1, 0, 0, 0, 0, 0, 0, 1, 0},
-		{"SELECT 1", 1, 1, 0, 0, 0, 0, 0, 1, 0},
-		{"CREATE DATABASE mt", 1, 1, 0, 0, 0, 1, 0, 1, 0},
-		{"CREATE TABLE mt.n (num INTEGER)", 1, 1, 0, 0, 0, 2, 0, 1, 0},
-		{"INSERT INTO mt.n VALUES (3)", 1, 1, 0, 1, 0, 2, 0, 1, 0},
-		{"UPDATE mt.n SET num = num + 1", 1, 1, 1, 1, 0, 2, 0, 1, 0},
-		{"DELETE FROM mt.n", 1, 1, 1, 1, 1, 2, 0, 1, 0},
-		{"ALTER TABLE mt.n ADD COLUMN num2 INTEGER", 1, 1, 1, 1, 1, 3, 0, 1, 0},
-		{"EXPLAIN SELECT * FROM mt.n", 1, 1, 1, 1, 1, 3, 1, 1, 0},
-		{"BEGIN; UPDATE mt.n SET num = num + 1; END", 2, 1, 2, 1, 1, 3, 1, 2, 0},
-		{"SELECT * FROM mt.n; SELECT * FROM mt.n; SELECT * FROM mt.n", 2, 4, 2, 1, 1, 3, 1, 2, 0},
-		{"DROP TABLE mt.n", 2, 4, 2, 1, 1, 4, 1, 2, 0},
-		{"SET database = system", 2, 4, 2, 1, 1, 4, 2, 2, 0},
+		{"", 0, 0, 0, 0, 0, 1, 0, 0, 0},
+		{"BEGIN; END", 1, 0, 0, 0, 0, 1, 0, 1, 0},
+		{"SELECT 1", 1, 1, 0, 0, 0, 1, 0, 1, 0},
+		{"CREATE DATABASE mt", 1, 1, 0, 0, 0, 2, 0, 1, 0},
+		{"CREATE TABLE mt.n (num INTEGER)", 1, 1, 0, 0, 0, 3, 0, 1, 0},
+		{"INSERT INTO mt.n VALUES (3)", 1, 1, 0, 1, 0, 3, 0, 1, 0},
+		{"UPDATE mt.n SET num = num + 1", 1, 1, 1, 1, 0, 3, 0, 1, 0},
+		{"DELETE FROM mt.n", 1, 1, 1, 1, 1, 3, 0, 1, 0},
+		{"ALTER TABLE mt.n ADD COLUMN num2 INTEGER", 1, 1, 1, 1, 1, 4, 0, 1, 0},
+		{"EXPLAIN SELECT * FROM mt.n", 1, 1, 1, 1, 1, 4, 1, 1, 0},
+		{"BEGIN; UPDATE mt.n SET num = num + 1; END", 2, 1, 2, 1, 1, 4, 1, 2, 0},
+		{"SELECT * FROM mt.n; SELECT * FROM mt.n; SELECT * FROM mt.n", 2, 4, 2, 1, 1, 4, 1, 2, 0},
+		{"DROP TABLE mt.n", 2, 4, 2, 1, 1, 5, 1, 2, 0},
+		{"SET database = system", 2, 4, 2, 1, 1, 5, 2, 2, 0},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/sql/sqlbase/privilege.go
+++ b/pkg/sql/sqlbase/privilege.go
@@ -230,7 +230,8 @@ func (p PrivilegeDescriptor) Show() []UserPrivilegeString {
 func (p PrivilegeDescriptor) CheckPrivilege(user string, priv privilege.Kind) bool {
 	userPriv, ok := p.findUser(user)
 	if !ok {
-		return false
+		// User "node" has all privileges.
+		return user == security.NodeUser
 	}
 	// ALL is always good.
 	if isPrivilegeSet(userPriv.Privileges, privilege.ALL) {

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -76,7 +76,7 @@ CREATE TABLE system.lease (
   PRIMARY KEY (descID, version, expiration, nodeID)
 );`
 
-	// EventLogTableSchema describes the schema of the event log table.
+	// EventLogTableSchema describes the schema of the eventlog table.
 	EventLogTableSchema = `
 CREATE TABLE system.eventlog (
   timestamp    TIMESTAMP  NOT NULL,
@@ -84,7 +84,7 @@ CREATE TABLE system.eventlog (
   targetID     INT        NOT NULL,
   reportingID  INT        NOT NULL,
   info         STRING,
-  uniqueID     BYTES      DEFAULT experimental_unique_bytes(),
+  uniqueID     BYTES      DEFAULT uuid_v4(),
   PRIMARY KEY (timestamp, uniqueID)
 );`
 
@@ -298,7 +298,7 @@ var (
 		NextMutationID: 1,
 	}
 
-	experimentalUniqueBytesString = "experimental_unique_bytes()"
+	uuidV4String = "uuid_v4()"
 
 	// EventLogTable is the descriptor for the event log table.
 	EventLogTable = TableDescriptor{
@@ -312,7 +312,7 @@ var (
 			{Name: "targetID", ID: 3, Type: colTypeInt},
 			{Name: "reportingID", ID: 4, Type: colTypeInt},
 			{Name: "info", ID: 5, Type: colTypeString, Nullable: true},
-			{Name: "uniqueID", ID: 6, Type: colTypeBytes, DefaultExpr: &experimentalUniqueBytesString},
+			{Name: "uniqueID", ID: 6, Type: colTypeBytes, DefaultExpr: &uuidV4String},
 		},
 		NextColumnID: 7,
 		Families: []ColumnFamilyDescriptor{

--- a/pkg/sql/testdata/builtin_function
+++ b/pkg/sql/testdata/builtin_function
@@ -948,11 +948,6 @@ SELECT extract(epoch FROM '1970-01-02 00:00:01.000001'::timestamp)
 ----
 86401
 
-query BI
-SELECT experimental_unique_bytes() < experimental_unique_bytes(), length(experimental_unique_bytes())
-----
-true 9
-
 query B
 SELECT unique_rowid() < unique_rowid()
 ----

--- a/pkg/sql/testdata/event_log
+++ b/pkg/sql/testdata/event_log
@@ -64,6 +64,7 @@ query II
 SELECT targetID, reportingID FROM system.eventlog
 WHERE eventType = 'alter_table'
 ----
+12 1
 
 statement ok
 ALTER TABLE test.a ADD val INT
@@ -72,6 +73,7 @@ query II
 SELECT targetID, reportingID FROM system.eventlog
 WHERE eventType = 'alter_table'
 ----
+12 1
 51 1
 
 query II
@@ -109,6 +111,7 @@ query II
 SELECT targetID, reportingID FROM system.eventlog
 WHERE eventType = 'alter_table'
 ----
+12 1
 51 1
 51 1
 

--- a/pkg/sql/testdata/information_schema
+++ b/pkg/sql/testdata/information_schema
@@ -442,7 +442,7 @@ def            pg_catalog          pg_tables          SYSTEM VIEW  1
 def            pg_catalog          pg_type            SYSTEM VIEW  1
 def            pg_catalog          pg_views           SYSTEM VIEW  1
 def            system              descriptor         BASE TABLE   1
-def            system              eventlog           BASE TABLE   1
+def            system              eventlog           BASE TABLE   2
 def            system              lease              BASE TABLE   1
 def            system              namespace          BASE TABLE   1
 def            system              rangelog           BASE TABLE   1
@@ -458,6 +458,7 @@ SELECT TABLE_SCHEMA, TABLE_NAME, VERSION FROM information_schema.tables WHERE ve
 ----
 TABLE_SCHEMA  TABLE_NAME  VERSION
 other_db      xyz         5
+system        eventlog    2
 
 user testuser
 


### PR DESCRIPTION
This just swaps out experimental_unique_bytes with uuid_v4 rather than
dealing with changing the type of uniqueID from BYTES to INT.

An alternative to #12158 that cuts out most of the ugliness. This is a truly backwards-compatible change. If you guys agree we should just take this easier route, I'll cook up some unit tests for it.

Again, only the last commit is new.

@bdarnell @vivekmenezes @paperstreet

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12228)
<!-- Reviewable:end -->
