### PR TITLE
sql: Return an error from the checkCounter test functions

### DIFF
--- a/pkg/sql/metric_test.go
+++ b/pkg/sql/metric_test.go
@@ -74,21 +74,38 @@ func TestQueryCounts(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		checkCounterEQ(t, s, sql.MetaTxnBegin, tc.txnBeginCount)
-		checkCounterEQ(t, s, sql.MetaTxnCommit, tc.txnCommitCount)
-		checkCounterEQ(t, s, sql.MetaTxnRollback, tc.txnRollbackCount)
-		checkCounterEQ(t, s, sql.MetaTxnAbort, 0)
-		checkCounterEQ(t, s, sql.MetaSelect, tc.selectCount)
-		checkCounterEQ(t, s, sql.MetaUpdate, tc.updateCount)
-		checkCounterEQ(t, s, sql.MetaInsert, tc.insertCount)
-		checkCounterEQ(t, s, sql.MetaDelete, tc.deleteCount)
-		checkCounterEQ(t, s, sql.MetaDdl, tc.ddlCount)
-		checkCounterEQ(t, s, sql.MetaMisc, tc.miscCount)
-
-		// Everything after this query will also fail, so quit now to avoid deluge of errors.
-		if t.Failed() {
-			t.FailNow()
+		if err := checkCounterEQ(s, sql.MetaTxnBegin, tc.txnBeginCount); err != nil {
+			t.Errorf("%q: %s", tc.query, err)
 		}
+		if err := checkCounterEQ(s, sql.MetaTxnRollback, tc.txnRollbackCount); err != nil {
+			t.Errorf("%q: %s", tc.query, err)
+		}
+		if err := checkCounterEQ(s, sql.MetaTxnAbort, 0); err != nil {
+			t.Errorf("%q: %s", tc.query, err)
+		}
+		if err := checkCounterEQ(s, sql.MetaSelect, tc.selectCount); err != nil {
+			t.Errorf("%q: %s", tc.query, err)
+		}
+		if err := checkCounterEQ(s, sql.MetaUpdate, tc.updateCount); err != nil {
+			t.Errorf("%q: %s", tc.query, err)
+		}
+		if err := checkCounterEQ(s, sql.MetaInsert, tc.insertCount); err != nil {
+			t.Errorf("%q: %s", tc.query, err)
+		}
+		if err := checkCounterEQ(s, sql.MetaDelete, tc.deleteCount); err != nil {
+			t.Errorf("%q: %s", tc.query, err)
+		}
+		if err := checkCounterEQ(s, sql.MetaDdl, tc.ddlCount); err != nil {
+			t.Errorf("%q: %s", tc.query, err)
+		}
+		if err := checkCounterEQ(s, sql.MetaMisc, tc.miscCount); err != nil {
+			t.Errorf("%q: %s", tc.query, err)
+		}
+	}
+
+	// Everything after this query will also fail, so quit now to avoid deluge of errors.
+	if t.Failed() {
+		t.FailNow()
 	}
 }
 
@@ -134,11 +151,21 @@ func TestAbortCountConflictingWrites(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	checkCounterEQ(t, s, sql.MetaTxnAbort, 1)
-	checkCounterEQ(t, s, sql.MetaTxnBegin, 1)
-	checkCounterEQ(t, s, sql.MetaTxnRollback, 0)
-	checkCounterEQ(t, s, sql.MetaTxnCommit, 0)
-	checkCounterEQ(t, s, sql.MetaInsert, 1)
+	if err := checkCounterEQ(s, sql.MetaTxnAbort, 1); err != nil {
+		t.Error(err)
+	}
+	if err := checkCounterEQ(s, sql.MetaTxnBegin, 1); err != nil {
+		t.Error(err)
+	}
+	if err := checkCounterEQ(s, sql.MetaTxnRollback, 0); err != nil {
+		t.Error(err)
+	}
+	if err := checkCounterEQ(s, sql.MetaTxnCommit, 0); err != nil {
+		t.Error(err)
+	}
+	if err := checkCounterEQ(s, sql.MetaInsert, 1); err != nil {
+		t.Error(err)
+	}
 }
 
 // TestErrorDuringTransaction tests that the transaction abort count goes up when a query
@@ -158,7 +185,13 @@ func TestAbortCountErrorDuringTransaction(t *testing.T) {
 		t.Fatal("Expected an error but didn't get one")
 	}
 
-	checkCounterEQ(t, s, sql.MetaTxnAbort, 1)
-	checkCounterEQ(t, s, sql.MetaTxnBegin, 1)
-	checkCounterEQ(t, s, sql.MetaSelect, 1)
+	if err := checkCounterEQ(s, sql.MetaTxnAbort, 1); err != nil {
+		t.Error(err)
+	}
+	if err := checkCounterEQ(s, sql.MetaTxnBegin, 1); err != nil {
+		t.Error(err)
+	}
+	if err := checkCounterEQ(s, sql.MetaSelect, 1); err != nil {
+		t.Error(err)
+	}
 }

--- a/pkg/sql/metric_util_test.go
+++ b/pkg/sql/metric_util_test.go
@@ -19,21 +19,21 @@
 package sql_test
 
 import (
-	"testing"
-
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/pkg/errors"
 )
 
-func checkCounterEQ(t *testing.T, s serverutils.TestServerInterface, meta metric.Metadata, e int64) {
+func checkCounterEQ(s serverutils.TestServerInterface, meta metric.Metadata, e int64) error {
 	if a := s.MustGetSQLCounter(meta.Name); a != e {
-		t.Error(errors.Errorf("stat %s: actual %d != expected %d", meta.Name, a, e))
+		return errors.Errorf("stat %s: actual %d != expected %d", meta.Name, a, e)
 	}
+	return nil
 }
 
-func checkCounterGE(t *testing.T, s serverutils.TestServerInterface, meta metric.Metadata, e int64) {
+func checkCounterGE(s serverutils.TestServerInterface, meta metric.Metadata, e int64) error {
 	if a := s.MustGetSQLCounter(meta.Name); a < e {
-		t.Error(errors.Errorf("stat %s: expected: actual %d >= %d", meta.Name, a, e))
+		return errors.Errorf("stat %s: expected: actual %d >= %d", meta.Name, a, e)
 	}
+	return nil
 }

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -799,7 +799,9 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
 			// Check that the commit counter was incremented. It could have been
 			// incremented by more than 1 because of the transactions we use to force
 			// aborts, plus who knows what else the server is doing in the background.
-			checkCounterGE(t, s, sql.MetaTxnCommit, commitCount+1)
+			if err := checkCounterGE(s, sql.MetaTxnCommit, commitCount+1); err != nil {
+				t.Error(err)
+			}
 			// Clean up the table for the next test iteration.
 			_, err = sqlDB.Exec("DELETE FROM t.test WHERE true")
 			if err != nil {


### PR DESCRIPTION
Exalate commented:

We've had to reduce `kv.bulk_io_write.concurrent_export_requests` on our clusters in order to avoid saturating our network when doing backups. Is there a reason not to add it to https://www.cockroachlabs.com/docs/stable/cluster-settings.html ? I had to find it by looking through the crdb source.

Jira Issue: DOC-1134

Jira issue: CRDB-11138