### PR TITLE
build: add a start command to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ GOFLAGS :=
 # Set to 1 to use static linking for all builds (including tests).
 STATIC :=
 
+COCKROACH := ./cockroach
+
 # Variables to be overridden on the command line, e.g.
 #   make test PKG=./pkg/storage TESTFLAGS=--vmodule=raft=1
 PKG          := ./pkg/...
@@ -35,6 +37,7 @@ BENCHTIMEOUT := 5m
 TESTFLAGS    :=
 STRESSFLAGS  :=
 DUPLFLAGS    := -t 100
+STARTFLAGS   := -s type=mem,size=1GiB --alsologtostderr
 BUILDMODE    := install
 SUFFIX       :=
 export GOPATH := $(realpath ../../../..)
@@ -73,6 +76,12 @@ all: build test check
 .PHONY: build
 build: BUILDMODE = build -i -o cockroach$(SUFFIX)
 build: install
+
+.PHONY: start
+start: build
+start:
+	$(COCKROACH) start $(STARTFLAGS)
+
 
 .PHONY: install
 install: LDFLAGS += $(shell GOPATH=${GOPATH} build/ldflags.sh)


### PR DESCRIPTION
This commit adds a very simple shortcut for building cockroach and
starting it from the Makefile: `make start`. STARTFLAGS is settable to
provide flags to pass to `cockroach start`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12234)
<!-- Reviewable:end -->
