### PR TITLE
sql, distsql: aggregation planning

### DIFF
--- a/pkg/sql/distsql/flow_diagram.go
+++ b/pkg/sql/distsql/flow_diagram.go
@@ -62,6 +62,10 @@ func (*NoopCoreSpec) summary() (string, []string) {
 	return "No-op", []string{}
 }
 
+func (*AggregatorSpec) summary() (string, []string) {
+	return "Aggregator", []string{}
+}
+
 func (tr *TableReaderSpec) summary() (string, []string) {
 	index := "primary"
 	if tr.IndexIdx > 0 {

--- a/pkg/sql/distsql_aggregator_visitors.go
+++ b/pkg/sql/distsql_aggregator_visitors.go
@@ -1,0 +1,187 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Irfan Sharif (irfansharif@cockroachlabs.com)
+//
+// This file implements the visitors needed to extract aggregation expressions
+// as needed for distsql physical planning of aggregators.
+// See extractAggExprs and extractPostAggExprs.
+
+package sql
+
+import (
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+)
+
+type aggExprVisitor struct {
+	exprs []distsql.AggregatorSpec_Expr
+}
+
+var _ parser.Visitor = &aggExprVisitor{}
+
+// Our base case is when our expression is of type *aggregateFuncHolder, in
+// which case we construct the equivalent AggregatorSpec_Expr and accumulate it.
+// If our expression is NOT of the type *aggregateFuncHolder we may have an
+// expression like 'COUNT(k) + 1', we recurse.
+func (v *aggExprVisitor) VisitPre(expr parser.Expr) (bool, parser.Expr) {
+	fholder, ok := expr.(*aggregateFuncHolder)
+	if !ok {
+		return true, expr
+	}
+
+	f, ok := fholder.expr.(*parser.FuncExpr)
+	if !ok {
+		aggexpr := distsql.AggregatorSpec_Expr{
+			Func: distsql.AggregatorSpec_IDENT,
+		}
+		v.exprs = append(v.exprs, aggexpr)
+		return false, expr
+	}
+
+	aggexpr := distsql.AggregatorSpec_Expr{
+		Func: distsql.AggregatorSpec_Func(
+			distsql.AggregatorSpec_Func_value[strings.ToUpper(
+				f.Func.FunctionReference.String(),
+			)],
+		),
+		Distinct: f.Type == parser.DistinctFuncType,
+	}
+	v.exprs = append(v.exprs, aggexpr)
+	return false, expr
+}
+
+func (v *aggExprVisitor) VisitPost(expr parser.Expr) parser.Expr {
+	return expr
+}
+
+func (v aggExprVisitor) extract(typedExpr parser.TypedExpr) []distsql.AggregatorSpec_Expr {
+	parser.WalkExprConst(&v, typedExpr)
+	return v.exprs
+}
+
+// extractAggExprs translates the render expressions into the form needed by
+// the AggregatorSpec where per "aggregation function" we specify the function
+// type (SUM, COUNT, IDENT, etc) and the column this function is going to be
+// operating on (@1, @2, @3, etc).
+// In order to do this we need to "flatten" out the render expressions.
+// The following examples detail out what we mean by this.
+//
+// - 'SELECT COUNT(k), SUM(v + w), v + w FROM kv GROUP BY v + w'
+//   The output schema of the selectNode (groupNode's source) here is
+//   [k v+w v+w v+w], the render expressions we are concerned with are
+//   [k v+w v+w].
+//   We see for COUNT, the corresponding input stream is the very first (k).
+//   For SUM it is the second (v+w) and for 'v + w' we use the IDENT aggregation
+//   function.
+//   Concisely: for the n-th aggregation function we operate on the n-th stream.
+//
+// - 'SELECT COUNT(k) + COUNT(v) FROM kv'
+//   The output schema of groupNode's source here is [k v], the render
+//   expressions we are concerned with are [k v]. We see that we need a COUNT
+//   to operate on the first stream, another COUNT to operate on the second.
+//   Again we see that for the n-th aggregation function we operate on the n-th
+//   stream (note, this is distinct from the n-th render expression).
+//
+//   NB: The actual addition in 'COUNT(k) + COUNT(v)' will be computed in
+//   postAggExprVisitor.
+func (dsp *distSQLPlanner) extractAggExprs(
+	render []parser.TypedExpr,
+) (aggExprs []distsql.AggregatorSpec_Expr) {
+	v := aggExprVisitor{}
+	for _, expr := range render {
+		aggExprs = append(aggExprs, v.extract(expr)...)
+	}
+	for i := range aggExprs {
+		aggExprs[i].ColIdx = uint32(i)
+	}
+	return aggExprs
+}
+
+type postAggExprVisitor struct {
+	count int
+}
+
+var _ parser.Visitor = &postAggExprVisitor{}
+
+func (v *postAggExprVisitor) VisitPre(expr parser.Expr) (bool, parser.Expr) {
+	return true, expr
+}
+
+// Our base case is the *aggregateFuncHolder, every time we come across one we
+// substitute it with an ordinal reference. An expression of any other type is
+// left as is.
+//
+// We make the deliberate choice of doing this transformation in VisitPost
+// instead of VisitPre, an example to demonstrate why is that if we have
+// 'SELECT COUNT(k) + COUNT(v) FROM kv', for our render expression
+// 'COUNT(k) + COUNT(v)' we want it to be substituted by @1 + @2. Therefore we
+// need to first substitute the "leaf nodes" of this expression (COUNT(k),
+// COUNT(v)) before evaluating the binary "+" expression.
+func (v *postAggExprVisitor) VisitPost(expr parser.Expr) parser.Expr {
+	if _, ok := expr.(*aggregateFuncHolder); !ok {
+		return expr
+	}
+
+	newExpr := parser.NewOrdinalReference(v.count)
+	v.count++
+	return newExpr
+}
+
+func (v *postAggExprVisitor) extract(typedExpr parser.TypedExpr) parser.TypedExpr {
+	expr, _ := parser.WalkExpr(v, typedExpr)
+	return expr.(parser.TypedExpr)
+}
+
+// extractPostAggrExprs returns a list of expressions to be evaluated following
+// the aggregation stage.
+// For e.g. if we have 'SELECT COUNT(k)+COUNT(v) FROM kv', the output schema of
+// our aggregator would be [count(k) count(v)], but the output schema of the
+// current groupNode implementation is [count(k)+count(v)], to bridge this gap
+// we need to introduce an aggregator with the expression [@1 + @2].
+// There's one subtle thing to note here:
+// - We need to account for the "flattening" of the render expressions that had
+//   to take place earlier.
+//
+// The following example details out the considerations we had to make.
+// - 'SELECT COUNT(k), COUNT(v), COUNT(k) + COUNT(v) FROM kv'
+// The output schema of our aggregator is [count(k) count(v) count(k) count(v)].
+// The post aggregation evaluator we need to add has to be instantiated with the
+// expression [@1 @2 @3 + @4].
+// Note that, as before, the n-th render expression is distinct from the n-th
+// stream. Therefore we need to maintain this "counter" state as we iterate
+// through each of the render expressions, assigning a monotonically increasing
+// ordinal reference to each instance of an *aggregateFuncHolder (our base
+// case).
+// To this end we have a pointer receiver for postAggExprVisitor.extract(...).
+//
+// Additionally if we see that all of our evalExprs are simply of type
+// *parser.IndexedVar, we have an evaluator that simply forwards every single
+// row without any transformation/evaluation. In this case we return false for
+// needEval.
+func (dsp *distSQLPlanner) extractPostAggrExprs(
+	render []parser.TypedExpr,
+) (evalExprs []parser.TypedExpr, needEval bool) {
+	v := postAggExprVisitor{}
+	for _, expr := range render {
+		result := v.extract(expr)
+		if _, ok := result.(*parser.IndexedVar); !ok {
+			needEval = true
+		}
+		evalExprs = append(evalExprs, result)
+	}
+	return evalExprs, needEval
+}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -14,6 +14,7 @@
 // permissions and limitations under the License.
 //
 // Author: Radu Berinde (radu@cockroachlabs.com)
+// Author: Irfan Sharif (irfansharif@cockroachlabs.com)
 
 package sql
 
@@ -124,7 +125,7 @@ func (v *distSQLExprCheckVisitor) VisitPost(expr parser.Expr) parser.Expr { retu
 
 // checkExpr verifies that an expression doesn't contain things that are not yet
 // supported by distSQL, like subqueries.
-func checkExpr(expr parser.Expr) error {
+func (dsp *distSQLPlanner) checkExpr(expr parser.Expr) error {
 	if expr == nil {
 		return nil
 	}
@@ -167,7 +168,7 @@ func (dsp *distSQLPlanner) CheckSupport(tree planNode) (shouldRunDist bool, notS
 				typ.FamilyEqual(parser.TypeIntArray) {
 				return false, errors.Errorf("unsupported render type %s", typ)
 			}
-			if err := checkExpr(e); err != nil {
+			if err := dsp.checkExpr(e); err != nil {
 				return false, err
 			}
 		}
@@ -183,7 +184,7 @@ func (dsp *distSQLPlanner) CheckSupport(tree planNode) (shouldRunDist bool, notS
 		if n.joinType != joinTypeInner {
 			return false, errors.Errorf("only inner join supported")
 		}
-		if err := checkExpr(n.pred.filter); err != nil {
+		if err := dsp.checkExpr(n.pred.filter); err != nil {
 			return false, err
 		}
 		shouldRunDistLeft, err := dsp.CheckSupport(n.left.plan)
@@ -205,7 +206,7 @@ func (dsp *distSQLPlanner) CheckSupport(tree planNode) (shouldRunDist bool, notS
 		// We recommend running scans distributed if we have a filtering
 		// expression or if we have a full table scan.
 		if n.filter != nil {
-			if err := checkExpr(n.filter); err != nil {
+			if err := dsp.checkExpr(n.filter); err != nil {
 				return false, err
 			}
 			return true, nil
@@ -283,7 +284,7 @@ type physicalPlan struct {
 
 	// resultRouters identifies the output routers which output the results of the
 	// plan. These are the routers to which we have to connect new streams in
-	// order to extend the plan. All routers have the same "schema".
+	// order to extend the plan. All result routers have the same "schema".
 	//
 	// We assume all processors have a single output so we only need the processor
 	// index.
@@ -582,7 +583,11 @@ func (dsp *distSQLPlanner) createTableReaders(
 	if err != nil {
 		return physicalPlan{}, err
 	}
-	var p physicalPlan
+
+	p := physicalPlan{
+		ordering:           ordering,
+		planToStreamColMap: planToStreamColMap,
+	}
 	for _, sp := range spanPartitions {
 		proc := processor{
 			node: sp.node,
@@ -601,8 +606,6 @@ func (dsp *distSQLPlanner) createTableReaders(
 
 		pIdx := p.addProcessor(proc)
 		p.resultRouters = append(p.resultRouters, pIdx)
-		p.planToStreamColMap = planToStreamColMap
-		p.ordering = ordering
 	}
 	return p, nil
 }
@@ -696,13 +699,11 @@ func (dsp *distSQLPlanner) selectRenders(
 
 // addSorters adds sorters corresponding to a sortNode and updates the plan to
 // reflect the sort node.
-func (dsp *distSQLPlanner) addSorters(
-	planCtx *planningCtx, p *physicalPlan, n *sortNode, sourceNode planNode,
-) {
+func (dsp *distSQLPlanner) addSorters(planCtx *planningCtx, p *physicalPlan, n *sortNode) {
 	sorterSpec := distsql.SorterSpec{
 		OutputOrdering: dsp.convertOrdering(n.ordering, p.planToStreamColMap),
 		OrderingMatchLen: uint32(computeOrderingMatch(
-			n.ordering, sourceNode.Ordering(), false, /* reverse */
+			n.ordering, n.plan.Ordering(), false, /* reverse */
 		)),
 	}
 	if len(sorterSpec.OutputOrdering.Columns) != len(n.ordering) {
@@ -1034,8 +1035,9 @@ func (dsp *distSQLPlanner) createPlanForNode(
 		if err != nil {
 			return physicalPlan{}, err
 		}
+
 		if n.sort != nil {
-			dsp.addSorters(planCtx, &plan, n.sort, n.source)
+			dsp.addSorters(planCtx, &plan, n.sort)
 		}
 		return plan, nil
 

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1,5 +1,4 @@
 // Copyright 2016 The Cockroach Authors.
-
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +21,7 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
@@ -142,7 +142,9 @@ func (dsp *distSQLPlanner) CheckSupport(tree planNode) (shouldRunDist bool, notS
 	switch n := tree.(type) {
 	case *selectTopNode:
 		if n.group != nil {
-			return false, errors.Errorf("grouping not supported yet")
+			if _, err := dsp.CheckSupport(n.group); err != nil {
+				return false, err
+			}
 		}
 		if n.window != nil {
 			return false, errors.Errorf("windows not supported yet")
@@ -224,6 +226,19 @@ func (dsp *distSQLPlanner) CheckSupport(tree planNode) (shouldRunDist bool, notS
 			return false, err
 		}
 		return dsp.CheckSupport(n.index)
+
+	case *groupNode:
+		if n.having != nil {
+			return false, errors.Errorf("group with having not supported yet")
+		}
+		for _, fholder := range n.funcs {
+			if f, ok := fholder.expr.(*parser.FuncExpr); ok {
+				if strings.ToUpper(f.Func.FunctionReference.String()) == "ARRAY_AGG" {
+					return false, errors.Errorf("ARRAY_AGG aggregation not supported yet")
+				}
+			}
+		}
+		return false, nil
 
 	default:
 		return false, errors.Errorf("unsupported node %T", tree)
@@ -355,29 +370,47 @@ func mergePlans(
 }
 
 // The distsql Expression uses the placeholder syntax (@1, @2, @3..) to
-// refer to columns. We format the expression using an IndexedVar formatting
-// interceptor. A columnMap can optionally be used to remap the indices.
+// refer to columns. We format the expression using the IndexedVar and StarDatum
+// formatting interceptors. A columnMap can optionally be used to remap the
+// indices.
 func distSQLExpression(expr parser.TypedExpr, columnMap []int) distsql.Expression {
 	if expr == nil {
 		return distsql.Expression{}
 	}
+
+	// TODO(irfansharif): currently there’s no nice way to “compose” FmtFlags
+	// out of multiple FmtFlag‘s (this unit does not exist today).
+	// By introducing such composability, the flags below can be constructed
+	// once and reused for subsequent calls. Additionally the construction of
+	// the flags would not need to inspect expression type.
 	var f parser.FmtFlags
-	if columnMap == nil {
-		f = parser.FmtIndexedVarFormat(
-			func(buf *bytes.Buffer, _ parser.FmtFlags, _ parser.IndexedVarContainer, idx int) {
-				fmt.Fprintf(buf, "@%d", idx+1)
+	switch expr.(type) {
+	case *parser.StarDatum:
+		// By default parser.StarDatum is rendered as a DInt(0), but formatting
+		// this as 0 we can replicate this behavior in distsql.
+		f = parser.FmtStarDatumFormat(
+			func(buf *bytes.Buffer, _ parser.FmtFlags) {
+				fmt.Fprintf(buf, "0")
 			},
 		)
-	} else {
-		f = parser.FmtIndexedVarFormat(
-			func(buf *bytes.Buffer, _ parser.FmtFlags, _ parser.IndexedVarContainer, idx int) {
-				remappedIdx := columnMap[idx]
-				if remappedIdx < 0 {
-					panic(fmt.Sprintf("unmapped index %d", idx))
-				}
-				fmt.Fprintf(buf, "@%d", remappedIdx+1)
-			},
-		)
+	default:
+		if columnMap == nil {
+			f = parser.FmtIndexedVarFormat(
+				func(buf *bytes.Buffer, _ parser.FmtFlags, _ parser.IndexedVarContainer, idx int) {
+					fmt.Fprintf(buf, "@%d", idx+1)
+				},
+			)
+		} else {
+			f = parser.FmtIndexedVarFormat(
+				func(buf *bytes.Buffer, _ parser.FmtFlags, _ parser.IndexedVarContainer, idx int) {
+					remappedIdx := columnMap[idx]
+					if remappedIdx < 0 {
+						panic(fmt.Sprintf("unmapped index %d", idx))
+					}
+					fmt.Fprintf(buf, "@%d", remappedIdx+1)
+				},
+			)
+		}
 	}
 	var buf bytes.Buffer
 	expr.Format(&buf, f)
@@ -649,20 +682,24 @@ func (dsp *distSQLPlanner) addNoGroupingStage(p *physicalPlan, core distsql.Proc
 // corresponding to the select node itself. An evaluator stage is added if the
 // select node has any expressions which are not just simple column references.
 //
-// TODO(irfansharif): An evaluator stage is also added if there isn't a strict
-// 1-1 mapping between n.Columns() and n.source.plan.Columns(). Arguably simple
-// multiplexing or column re-mapping is too lightweight to warrant an entire
-// evaluator processor, but the current implementations of certain processors
-// don't have mappings to push such multiplexing/column re-mapping down to
-// the processor. This happens for when `n.top.group != nil` because
-// aggregators don't have internal mappings, also for `n.top.sort != nil`
+// An evaluator stage is also added in some cases where a strict 1-1 mapping is
+// required between the planNode columns and the distSQL streams.
+// Arguably simple multiplexing or column re-mapping is too lightweight to
+// warrant an entire evaluator processor, but the current implementations of
+// certain processors don't have mappings to push such multiplexing/column
+// re-mapping down to the processor. This happens for when n.top.group != nil
+// because aggregators don't have internal mappings, also for n.top.sort != nil
 // because sorters are not configured to output only specific columns.
 //
-// For e.g. for `SELECT COUNT(k), SUM(k) GROUP BY k`, if the output schema of a
-// `scanNode` is [k], the input schema of the `groupNode` (and by parity
-// aggregators as well) is [k k k]. In order to multiplex `[k]` to `[k k k]` we
+// For e.g. for 'SELECT COUNT(k), SUM(k) GROUP BY k', if the output schema of a
+// scanNode is [k], the input schema of the groupNode (and by parity
+// aggregators as well) is [k k k]. In order to multiplex [k] to [k k k] we
 // add an evaluator stage. The specs for such processors can definitely be
 // improved upon.
+//
+// TODO(irfansharif): Add "projections" for sorters to "hide" certain columns.
+// TODO(irfansharif): Add multiplexing/column re-mapping logic to aggregators,
+// this avoids the need to add an evaluator before the aggregator.
 func (dsp *distSQLPlanner) selectRenders(
 	planCtx *planningCtx, p *physicalPlan, n *selectNode,
 ) error {
@@ -786,6 +823,71 @@ func (dsp *distSQLPlanner) addSingleGroupStage(
 	// We now have a single result stream.
 	p.resultRouters = p.resultRouters[:1]
 	p.resultRouters[0] = pIdx
+}
+
+// addAggregators adds aggregators corresponding to a groupNode and updates the plan to
+// reflect the groupNode. An evaluator stage is added if necessary.
+// Invariants assumed:
+//  - There is strictly no "pre-evaluation" necessary. If the given query is
+//  'SELECT COUNT(k), v + w FROM kv GROUP BY v + w', the evaluation of the first
+//  'v + w' is done at the source of the groupNode.
+//  - We only operate on the following expressions:
+//      - ONLY aggregation functions, with arguments pre-evaluated. So for
+//        COUNT(k + v), we assume a stream of evaluated 'k + v' values.
+//      - Expressions that CONTAIN an aggregation function, e.g. 'COUNT(k) + 1'.
+//        This is evaluated the post aggregation evaluator attached after.
+//      - Expressions that also appear verbatim in the GROUP BY expressions.
+//        For 'SELECT k GROUP BY k', the aggregation function added is IDENT,
+//        therefore k just passes through unchanged.
+//    All other expressions simply pass through unchanged, for e.g. '1' in
+//    'SELECT 1 GROUP BY k'.
+func (dsp *distSQLPlanner) addAggregators(planCtx *planningCtx, p *physicalPlan, n *groupNode) {
+	aggExprs := dsp.extractAggExprs(n.render)
+	types := dsp.getTypesForPlanResult(p.planToStreamColMap, n.plan)
+	// The way our planNode construction currently orders columns between
+	// groupNode and its source is that the first len(n.funcs) columns are the
+	// arguments for the aggregation functions. The remaining columns are
+	// columns we group by.
+	// For 'SELECT 1, SUM(k) GROUP BY k', the output schema of groupNode's
+	// source will be [1 k k], with 1, k being arguments fed to the aggregation
+	// functions and k being the column we group by.
+	groupCols := make([]uint32, 0, len(n.plan.Columns())-len(n.funcs))
+	for i := len(n.funcs); i < len(n.plan.Columns()); i++ {
+		groupCols = append(groupCols, uint32(i))
+	}
+
+	aggregatorSpec := distsql.AggregatorSpec{
+		Exprs:     aggExprs,
+		Types:     types,
+		GroupCols: groupCols,
+	}
+	// TODO(irfansharif): Some possible optimizations:
+	//  - We could add a local "no grouping" stage to pre-aggregate results
+	//    before the final aggregation.
+	//  - We could route by hash to multiple final aggregators.
+	dsp.addSingleGroupStage(
+		p, dsp.nodeDesc.NodeID, distsql.ProcessorCoreUnion{Aggregator: &aggregatorSpec},
+	)
+
+	evalExprs, needEval := dsp.extractPostAggrExprs(n.render)
+	if needEval {
+		// Add a stage with Evaluator processors.
+		postevalSpec := distsql.EvaluatorSpec{
+			Exprs: make([]distsql.Expression, len(evalExprs)),
+		}
+
+		for i := range evalExprs {
+			postevalSpec.Exprs[i] = distSQLExpression(evalExprs[i], p.planToStreamColMap)
+		}
+
+		dsp.addSingleGroupStage(
+			p, dsp.nodeDesc.NodeID, distsql.ProcessorCoreUnion{Evaluator: &postevalSpec},
+		)
+	}
+
+	// Remove any columns that were only used for grouping.
+	p.planToStreamColMap = p.planToStreamColMap[:len(n.Columns())]
+	p.ordering = dsp.convertOrdering(n.desiredOrdering, p.planToStreamColMap)
 }
 
 func (dsp *distSQLPlanner) createPlanForIndexJoin(
@@ -1068,6 +1170,10 @@ func (dsp *distSQLPlanner) createPlanForNode(
 		plan, err := dsp.createPlanForNode(planCtx, n.source)
 		if err != nil {
 			return physicalPlan{}, err
+		}
+
+		if n.group != nil {
+			dsp.addAggregators(planCtx, &plan, n.group)
 		}
 
 		if n.sort != nil {

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -689,6 +689,9 @@ var _ parser.TypedExpr = &aggregateFuncHolder{}
 var _ parser.VariableExpr = &aggregateFuncHolder{}
 
 type aggregateFuncHolder struct {
+	// expr must either contain an aggregation function (SUM, COUNT, etc.) or an
+	// expression that also appears as one of the GROUP BY expressions (v+w in
+	// SELECT v+w FROM kvw GROUP BY v+w).
 	expr          parser.TypedExpr
 	arg           parser.TypedExpr
 	create        func() parser.AggregateFunc

--- a/pkg/sql/testdata/aggregate
+++ b/pkg/sql/testdata/aggregate
@@ -7,21 +7,38 @@ CREATE TABLE kv (
 )
 
 # Aggregate functions return NULL if there are no rows.
-query IIITRRRRBB
-SELECT MIN(1), MAX(1), COUNT(1), ARRAY_AGG(1), AVG(1), SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_AND(false) FROM kv
+query IIIRRRRBB
+SELECT MIN(1), MAX(1), COUNT(1), AVG(1), SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_AND(false) FROM kv
 ----
-NULL NULL 0 NULL NULL NULL NULL NULL NULL NULL
+NULL NULL 0 NULL NULL NULL NULL NULL NULL
 
-query IIITRRRRBB
-SELECT MIN(v), MAX(v), COUNT(v), ARRAY_AGG(v), AVG(v), SUM(v), STDDEV(v), VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1) FROM kv
+# Aggregate functions return NULL if there are no rows.
+query T
+SELECT ARRAY_AGG(1) FROM kv
 ----
-NULL NULL 0 NULL NULL NULL NULL NULL NULL NULL
+NULL
+
+query IIIRRRRBB
+SELECT MIN(v), MAX(v), COUNT(v), AVG(v), SUM(v), STDDEV(v), VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1) FROM kv
+----
+NULL NULL 0 NULL NULL NULL NULL NULL NULL
+
+query T
+SELECT ARRAY_AGG(v) FROM kv
+----
+NULL
 
 # Aggregate functions triggers aggregation and computation when there is no source.
-query IIITRRRRBB
-SELECT MIN(1), COUNT(1), MAX(1), ARRAY_AGG(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(true)
+query IIIRRRRBB
+SELECT MIN(1), COUNT(1), MAX(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(true)
 ----
-1 1 1 {1} 1 1 NULL NULL true true
+1 1 1 1 1 NULL NULL true true
+
+# Aggregate functions triggers aggregation and computation when there is no source.
+query T
+SELECT ARRAY_AGG(1)
+----
+{1}
 
 statement OK
 INSERT INTO kv VALUES
@@ -33,10 +50,16 @@ INSERT INTO kv VALUES
 (8, 4, 2, 'A')
 
 # Aggregate functions triggers aggregation and computation for every row even when applied to a constant.
-query IIITRRRRBB
-SELECT MIN(1), COUNT(1), MAX(1), ARRAY_AGG(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1)::float, BOOL_AND(true), BOOL_OR(true) FROM kv
+query IIIRRRRBB
+SELECT MIN(1), COUNT(1), MAX(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1)::float, BOOL_AND(true), BOOL_OR(true) FROM kv
 ----
-1 6 1 {1,1,1,1,1,1} 1 6 0 0 true true
+1 6 1 1 6 0 0 true true
+
+# Aggregate functions triggers aggregation and computation for every row even when applied to a constant.
+query T
+SELECT ARRAY_AGG(1) FROM kv
+----
+{1,1,1,1,1,1}
 
 # Even with no aggregate functions, grouping occurs in the presence of GROUP BY.
 query I rowsort

--- a/pkg/sql/testdata/set
+++ b/pkg/sql/testdata/set
@@ -136,3 +136,15 @@ SET CLIENT_ENCODING = 'other'
 
 statement ok
 SET SEARCH_PATH = 'blah'
+
+statement ok
+SET DIST_SQL = ALWAYS
+
+statement ok
+SET DIST_SQL = ON
+
+statement ok
+SET DIST_SQL = OFF
+
+statement error not supported
+SET DIST_SQL = bogus


### PR DESCRIPTION
Introduce distributed sql physical planning for aggregation (`GROUP BY`).
Note that we currently do not support aggregation in presence of
`HAVING`, for e.g. `SELECT 3 FROM kv HAVING TRUE`, or the `ARRAY_AGG`
function due to the lack of support of array types in distsql.

Concisely we replace the `groupNode` in our `planNode` tree by adding
`aggregator` processors, an `evaluator` too if necessary.

See individual commits.
cc @knz @andreimatei

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12235)
<!-- Reviewable:end -->
