### PR TITLE
sql: fix the ordering of joins.

### DIFF
--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -367,7 +367,7 @@ func (n *joinNode) ExplainPlan(v bool) (name, description string, children []pla
 func (n *joinNode) Columns() ResultColumns { return n.columns }
 
 // Ordering implements the planNode interface.
-func (n *joinNode) Ordering() orderingInfo { return n.left.plan.Ordering() }
+func (n *joinNode) Ordering() orderingInfo { return orderingInfo{} }
 
 // MarkDebug implements the planNode interface.
 func (n *joinNode) MarkDebug(mode explainMode) {

--- a/pkg/sql/testdata/join
+++ b/pkg/sql/testdata/join
@@ -441,3 +441,20 @@ EXPLAIN (VERBOSE) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b
 2  join           NESTED LOOP JOIN, INNER ON a.x < b.y                             (x, y[omitted], rowid[hidden,omitted], x[omitted], y[omitted], rowid[hidden,omitted])
 3  scan           twocolumn@primary                                                (x, y[omitted], rowid[hidden,omitted])
 3  scan           twocolumn@primary                                                (x[omitted], y, rowid[hidden,omitted])
+
+# Ensure that the ordering information for the result of joins is sane. (#12037)
+query ITTTT
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES (9, 1), (8, 2)) AS a (u, k) ORDER BY k)
+				INNER JOIN (VALUES (1, 1), (2, 2)) AS b (k, w) USING (k) ORDER BY u
+----
+0   select                                                (k, u, w)            +u
+1   sort            +u                                    (k, u, w)            +u
+2   render/filter   from (""."".k, ""."".u, "".b.w)       (k, u, w)
+3   join            HASH JOIN, INNER ON EQUALS((k),(k))   (k, u, w)
+4   select                                                (u, k)               +k
+5   sort            +k                                    (u, k)               +k
+6   render/filter   from ("".a.u, "".a.k)                 (u, k)
+7   select                                                (column1, column2)
+8   values          2 columns, 2 rows                     (column1, column2)
+4   select                                                (column1, column2)
+5   values          2 columns, 2 rows                     (column1, column2)


### PR DESCRIPTION
Prior to this patch, a join data source would advertise that its
ordering is that of its left operand. This was wildly incorrect,
because the join operation can turn unique columns non-unique, a hash
join can shuffle the rows, and the presence of merged columns at the
beginning of the output column list causes the ordering column indices
to become incorrect.

This patch addresses the issue by simply advertising that join results
are not ordered.

Fixes #12037.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12236)
<!-- Reviewable:end -->
