### PR TITLE
sql: correct string array wire representation

### DIFF
--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -552,7 +552,7 @@ func (d *DString) max() (Datum, bool) {
 
 // Format implements the NodeFormatter interface.
 func (d *DString) Format(buf *bytes.Buffer, f FmtFlags) {
-	encodeSQLString(buf, string(*d))
+	encodeSQLStringWithFlags(buf, string(*d), f)
 }
 
 // Size implements the Datum interface.

--- a/pkg/sql/parser/format.go
+++ b/pkg/sql/parser/format.go
@@ -36,6 +36,8 @@ type fmtFlags struct {
 	// starDatumFormat is an optional interceptor for StarDatum.Format calls,
 	// can be used to customize the formatting of StarDatums.
 	starDatumFormat func(buf *bytes.Buffer, f FmtFlags)
+	// If true, strings will be rendered without wrapping quotes if possible.
+	bareStrings bool
 }
 
 // FmtFlags enables conditional formatting in the pretty-printer.
@@ -58,6 +60,10 @@ var FmtShowTypes FmtFlags = &fmtFlags{showTypes: true}
 // print indexedVars using symbolic notation, to
 // disambiguate columns.
 var FmtSymbolicVars FmtFlags = &fmtFlags{symbolicVars: true}
+
+// FmtBareStrings instructs the pretty-printer to print strings without
+// wrapping quotes, if possible.
+var FmtBareStrings FmtFlags = &fmtFlags{bareStrings: true}
 
 // FmtNormalizeTableNames returns FmtFlags that instructs the pretty-printer
 // to normalize all table names using the provided function.

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -216,7 +216,7 @@ func (b *writeBuffer) writeTextDatum(d parser.Datum, sessionLoc *time.Location) 
 			if i > 0 {
 				b.variablePutbuf.WriteString(",")
 			}
-			d.Format(&b.variablePutbuf, parser.FmtSimple)
+			d.Format(&b.variablePutbuf, parser.FmtBareStrings)
 		}
 		b.variablePutbuf.WriteString("}")
 		b.writeLengthPrefixedVariablePutbuf()

--- a/pkg/sql/testdata/aggregate
+++ b/pkg/sql/testdata/aggregate
@@ -422,7 +422,7 @@ NULL NULL NULL NULL
 query TT
 SELECT ARRAY_AGG(k), ARRAY_AGG(s) FROM kv
 ----
-{1,3,5,6,7,8} {'a','a',NULL,'b','b','A'}
+{1,3,5,6,7,8} {a,a,NULL,b,b,A}
 
 query RRRR
 SELECT AVG(k), AVG(v), SUM(k), SUM(v) FROM kv

--- a/pkg/sql/testdata/array
+++ b/pkg/sql/testdata/array
@@ -12,9 +12,9 @@ query error expected true to be of type string, found type bool
 SELECT ARRAY['a', true, 1]
 
 query T
-SELECT ARRAY['a', 'b', 'c']
+SELECT ARRAY['a,', 'b{', 'c}', 'd']
 ----
-{'a','b','c'}
+{'a,','b{','c}',d}
 
 # array construction from subqueries
 
@@ -31,7 +31,7 @@ SELECT ARRAY(VALUES (1),(2),(1))
 query T
 SELECT ARRAY(VALUES ('a'),('b'),('c'))
 ----
-{'a','b','c'}
+{a,b,c}
 
 query error subquery must return only one column, found 2
 SELECT ARRAY(SELECT 1, 2)

--- a/pkg/sql/testdata/builtin_function
+++ b/pkg/sql/testdata/builtin_function
@@ -1149,12 +1149,12 @@ SELECT foo.* IS NOT TRUE FROM (VALUES (1)) AS foo(x)
 query T
 SELECT CURRENT_SCHEMAS(true)
 ----
-{'pg_catalog','test'}
+{pg_catalog,test}
 
 query T
 SELECT CURRENT_SCHEMAS(false)
 ----
-{'test'}
+{test}
 
 query error pq: unknown signature: current_schemas()
 SELECT CURRENT_SCHEMAS()


### PR DESCRIPTION
In Postgres, string arrays are rendered so that the enclosed strings do
not have wrapping quotes unless they contain special characters. This
commit updates our string array representation to comply with this
behavior.

Note that in Postgres the inner strings get wrapped with double quotes
if they need to be wrapped - we preserve our original behavior of
wrapping in single quotes. This doesn't seem to make a difference to
clients, and it seems more correct, allowing our output format to be
used again as an input.

Updates #12207.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12268)
<!-- Reviewable:end -->
