### PR TITLE
storage: fix segfault during declined snapshots

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2624,8 +2624,11 @@ func (s *Store) maybeUpdateTransaction(
 	return txn, nil
 }
 
+// reserveSnapshot throttles incoming snapshots. The returned closure is used
+// to cleanup the reservation and release its resources. A nil cleanup function
+// and a nil error indicates the reservation was declined.
 func (s *Store) reserveSnapshot(
-	ctx context.Context, header *SnapshotRequest_Header, stream SnapshotResponseStream,
+	ctx context.Context, header *SnapshotRequest_Header,
 ) (func(), error) {
 	if header.CanDecline {
 		select {
@@ -2635,7 +2638,7 @@ func (s *Store) reserveSnapshot(
 		case <-s.stopper.ShouldStop():
 			return nil, errors.Errorf("stopped")
 		default:
-			return nil, stream.Send(&SnapshotResponse{Status: SnapshotResponse_DECLINED})
+			return nil, nil
 		}
 	} else {
 		select {
@@ -2662,9 +2665,12 @@ func (s *Store) HandleSnapshot(header *SnapshotRequest_Header, stream SnapshotRe
 	s.metrics.raftRcvdMessages[raftpb.MsgSnap].Inc(1)
 
 	ctx := s.AnnotateCtx(stream.Context())
-	cleanup, err := s.reserveSnapshot(ctx, header, stream)
+	cleanup, err := s.reserveSnapshot(ctx, header)
 	if err != nil {
 		return err
+	}
+	if cleanup == nil {
+		return stream.Send(&SnapshotResponse{Status: SnapshotResponse_DECLINED})
 	}
 	defer cleanup()
 

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -2660,7 +2660,7 @@ func TestReserveSnapshotThrottling(t *testing.T) {
 	s := tc.store
 
 	ctx := context.Background()
-	cleanup1, err := s.reserveSnapshot(ctx, &SnapshotRequest_Header{}, nil)
+	cleanup1, err := s.reserveSnapshot(ctx, &SnapshotRequest_Header{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2679,7 +2679,7 @@ func TestReserveSnapshotThrottling(t *testing.T) {
 		}
 	}()
 
-	cleanup2, err := s.reserveSnapshot(ctx, &SnapshotRequest_Header{}, nil)
+	cleanup2, err := s.reserveSnapshot(ctx, &SnapshotRequest_Header{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
If a snapshot is declined, Store.reserveSnapshot does not return an
error but does return a nil cleanup function. Avoid invoking this nil
cleanup function which was never intended.

Fixes #12249

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12269)
<!-- Reviewable:end -->
