### PR TITLE
util/stop: increase test timeouts

### DIFF
--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -55,14 +55,14 @@ func TestStopper(t *testing.T) {
 	select {
 	case <-waiting:
 		t.Fatal("expected stopper to have blocked")
-	case <-time.After(1 * time.Millisecond):
+	case <-time.After(100 * time.Millisecond):
 		// Expected.
 	}
 	close(running)
 	select {
 	case <-waiting:
 		// Success.
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(time.Second):
 		t.Fatal("stopper should have finished waiting")
 	}
 	close(cleanup)
@@ -93,20 +93,20 @@ func TestStopperIsStopped(t *testing.T) {
 
 	select {
 	case <-s.ShouldStop():
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(time.Second):
 		t.Fatal("stopper should have finished waiting")
 	}
 	select {
 	case <-s.IsStopped():
 		t.Fatal("expected blocked closer to prevent stop")
-	case <-time.After(1 * time.Millisecond):
+	case <-time.After(100 * time.Millisecond):
 		// Expected.
 	}
 	bc.Unblock()
 	select {
 	case <-s.IsStopped():
 		// Expected
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(time.Second):
 		t.Fatal("stopper should have finished stopping")
 	}
 }
@@ -141,7 +141,7 @@ func TestStopperStartFinishTasks(t *testing.T) {
 		select {
 		case <-s.ShouldStop():
 			t.Fatal("expected stopper to be quiesceing")
-		case <-time.After(1 * time.Millisecond):
+		case <-time.After(100 * time.Millisecond):
 			// Expected.
 		}
 	}); err != nil {
@@ -150,7 +150,7 @@ func TestStopperStartFinishTasks(t *testing.T) {
 	select {
 	case <-s.ShouldStop():
 		// Success.
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(time.Second):
 		t.Fatal("stopper should be ready to stop")
 	}
 }
@@ -169,7 +169,7 @@ func TestStopperRunWorker(t *testing.T) {
 	select {
 	case <-closer:
 		// Success.
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(time.Second):
 		t.Fatal("stopper should be ready to stop")
 	}
 }


### PR DESCRIPTION
This deflakes TestStopperStartFinishTasks at the cost of increasesing
the running time of the tests from 55ms to 365ms, which is acceptable.

Fixes #12266.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12282)
<!-- Reviewable:end -->
