### PR TITLE
server: Use node liveness for the admin health check

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -862,6 +862,13 @@ func (s *adminServer) Cluster(
 func (s *adminServer) Health(
 	ctx context.Context, req *serverpb.HealthRequest,
 ) (*serverpb.HealthResponse, error) {
+	isLive, err := s.server.nodeLiveness.IsLive(s.server.NodeID())
+	if err != nil {
+		return nil, grpc.Errorf(codes.Internal, err.Error())
+	}
+	if !isLive {
+		return nil, grpc.Errorf(codes.Unavailable, "node is not live")
+	}
 	return &serverpb.HealthResponse{}, nil
 }
 

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -913,6 +913,35 @@ func TestClusterAPI(t *testing.T) {
 	})
 }
 
+func TestHealthAPI(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop()
+
+	// We need to retry because the node ID isn't set until after
+	// bootstrapping.
+	testutils.SucceedsSoon(t, func() error {
+		var resp serverpb.HealthResponse
+		return getAdminJSONProto(s, "health", &resp)
+	})
+
+	// Expire this node's liveness record by pausing heartbeats and advancing the
+	// server's clock.
+	ts := s.(*TestServer)
+	ts.nodeLiveness.PauseHeartbeat(true)
+	self, err := ts.nodeLiveness.Self()
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Clock().Update(self.Expiration.Add(1, 0))
+
+	expected := "node is not live"
+	var resp serverpb.HealthResponse
+	if err := getAdminJSONProto(s, "health", &resp); !testutils.IsError(err, expected) {
+		t.Errorf("expected %q error, got %v", expected, err)
+	}
+}
+
 func TestClusterFreeze(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})


### PR DESCRIPTION
Fixes #8852

@spencerkimball @tamird @maxlang

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12287)
<!-- Reviewable:end -->
