### PR TITLE
githooks: reintroduce post-rewrite

### DIFF
--- a/githooks/post-rewrite
+++ b/githooks/post-rewrite
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-# TODO(dt): do we want to submomdule update here?
+[[ ! $GIT_REFLOG_ACTION =~ rebase ]] && exit 0
+
+exec git submodule update --init


### PR DESCRIPTION
it seems some workflows do end up with steps that leave submodules unupdated without it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12291)
<!-- Reviewable:end -->
