### PR TITLE
storage: Add a "node is alive" metric

### DIFF
--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -48,9 +48,22 @@ var (
 
 // Node liveness metrics counter names.
 var (
-	metaHeartbeatSuccesses = metric.Metadata{Name: "liveness.heartbeatsuccesses"}
-	metaHeartbeatFailures  = metric.Metadata{Name: "liveness.heartbeatfailures"}
-	metaEpochIncrements    = metric.Metadata{Name: "liveness.epochincrements"}
+	metaLiveNodes = metric.Metadata{
+		Name: "liveness.livenodes",
+		Help: "Number of live nodes in the cluster (will be 0 if this node is not itself live)",
+	}
+	metaHeartbeatSuccesses = metric.Metadata{
+		Name: "liveness.heartbeatsuccesses",
+		Help: "Number of successful node liveness heartbeats from this node",
+	}
+	metaHeartbeatFailures = metric.Metadata{
+		Name: "liveness.heartbeatfailures",
+		Help: "Number of failed node liveness heartbeats from this node",
+	}
+	metaEpochIncrements = metric.Metadata{
+		Name: "liveness.epochincrements",
+		Help: "Number of times this node has incremented its liveness epoch",
+	}
 )
 
 func (l *Liveness) isLive(now hlc.Timestamp, maxOffset time.Duration) bool {
@@ -60,6 +73,7 @@ func (l *Liveness) isLive(now hlc.Timestamp, maxOffset time.Duration) bool {
 
 // LivenessMetrics holds metrics for use with node liveness activity.
 type LivenessMetrics struct {
+	LiveNodes          *metric.Gauge
 	HeartbeatSuccesses *metric.Counter
 	HeartbeatFailures  *metric.Counter
 	EpochIncrements    *metric.Counter
@@ -106,11 +120,12 @@ func NewNodeLiveness(
 		gossip:            g,
 		livenessThreshold: livenessThreshold,
 		heartbeatInterval: livenessThreshold - renewalDuration,
-		metrics: LivenessMetrics{
-			HeartbeatSuccesses: metric.NewCounter(metaHeartbeatSuccesses),
-			HeartbeatFailures:  metric.NewCounter(metaHeartbeatFailures),
-			EpochIncrements:    metric.NewCounter(metaEpochIncrements),
-		},
+	}
+	nl.metrics = LivenessMetrics{
+		LiveNodes:          metric.NewFunctionalGauge(metaLiveNodes, nl.numLiveNodes),
+		HeartbeatSuccesses: metric.NewCounter(metaHeartbeatSuccesses),
+		HeartbeatFailures:  metric.NewCounter(metaHeartbeatFailures),
+		EpochIncrements:    metric.NewCounter(metaEpochIncrements),
 	}
 	nl.pauseHeartbeat.Store(false)
 	nl.mu.nodes = map[roachpb.NodeID]Liveness{}
@@ -395,4 +410,38 @@ func (nl *NodeLiveness) livenessGossipUpdate(key string, content roachpb.Value) 
 	if !ok || exLiveness.Expiration.Less(liveness.Expiration) || exLiveness.Epoch < liveness.Epoch {
 		nl.mu.nodes[liveness.NodeID] = liveness
 	}
+}
+
+// numLiveNodes is used to populate a metric that tracks the number of live
+// nodes in the cluster. Returns 0 if this node is not itself live, to avoid
+// reporting potentially inaccurate data.
+// We export this metric from every live node rather than a single particular
+// live node because liveness information is gossiped and thus may be stale.
+// That staleness could result in no nodes reporting the metric or multiple
+// nodes reporting the metric, so it's simplest to just have all live nodes
+// report it.
+func (nl *NodeLiveness) numLiveNodes() int64 {
+	selfID := nl.gossip.NodeID.Get()
+	if selfID == 0 {
+		return 0
+	}
+
+	nl.mu.Lock()
+	defer nl.mu.Unlock()
+
+	// If this node isn't live, we don't want to report its view of node liveness
+	// because it's more likely to be inaccurate than the view of a live node.
+	now := nl.clock.Now()
+	maxOffset := nl.clock.MaxOffset()
+	if !nl.mu.self.isLive(now, maxOffset) {
+		return 0
+	}
+
+	var liveNodes int64
+	for _, l := range nl.mu.nodes {
+		if l.isLive(now, maxOffset) {
+			liveNodes++
+		}
+	}
+	return liveNodes
 }

--- a/pkg/util/metric/metric_test.go
+++ b/pkg/util/metric/metric_test.go
@@ -56,6 +56,18 @@ func TestGauge(t *testing.T) {
 	testMarshal(t, g, "10")
 }
 
+func TestFunctionalGauge(t *testing.T) {
+	valToReturn := int64(10)
+	g := NewFunctionalGauge(emptyMetadata, func() int64 { return valToReturn })
+	if v := g.Value(); v != 10 {
+		t.Fatalf("unexpected value: %d", v)
+	}
+	valToReturn = 15
+	if v := g.Value(); v != 15 {
+		t.Fatalf("unexpected value: %d", v)
+	}
+}
+
 func TestGaugeFloat64(t *testing.T) {
 	g := NewGaugeFloat64(emptyMetadata)
 	g.Update(10.4)


### PR DESCRIPTION
The idea being that you would aggregate this metric across your nodes to
determine how many healthy nodes you have at any given time, while still
maintaining the ability to check each individual node's health.

For this to graph well in the admin UI, we'll need to have a pretty low leniency for missing data points (given that a non-live node is unlikely to be able to persist its timeseries data).

Fixes #12222

@mrtracy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12296)
<!-- Reviewable:end -->
