### PR TITLE
testutils: add replication-related methods to the shim

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -19,6 +19,7 @@ package base
 import (
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
@@ -83,9 +84,10 @@ type TestServerArgs struct {
 // cluster. It contains a TestServerArgs instance which will be copied over to
 // every server.
 //
-// The zero value means "full replication".
+// The zero value means "ReplicationAuto".
 type TestClusterArgs struct {
-	// ServerArgs will be copied to each constituent TestServer.
+	// ServerArgs will be copied to each constituent TestServer. Used for all the
+	// servers not overridden in ServerArgsPerNode.
 	ServerArgs TestServerArgs
 	// ReplicationMode controls how replication is to be done in the cluster.
 	ReplicationMode TestClusterReplicationMode
@@ -117,3 +119,9 @@ const (
 	// replication through the TestServer.
 	ReplicationManual
 )
+
+// ReplicationTarget identifies a node/store pair.
+type ReplicationTarget struct {
+	NodeID  roachpb.NodeID
+	StoreID roachpb.StoreID
+}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -416,8 +416,7 @@ func (ts *TestServer) DistSender() *kv.DistSender {
 	return ts.distSender
 }
 
-// GetFirstStoreID is a utility function returning the StoreID of the first
-// store on this node.
+// GetFirstStoreID is part of TestServerInterface.
 func (ts *TestServer) GetFirstStoreID() roachpb.StoreID {
 	firstStoreID := roachpb.StoreID(-1)
 	err := ts.Stores().VisitStores(func(s *storage.Store) error {

--- a/pkg/sql/ambiguous_commit_test.go
+++ b/pkg/sql/ambiguous_commit_test.go
@@ -102,7 +102,7 @@ func TestAmbiguousCommitDueToLeadershipChange(t *testing.T) {
 	}
 	leaseHolder, err := tc.FindRangeLeaseHolder(
 		tableRangeDesc,
-		&testcluster.ReplicationTarget{
+		&base.ReplicationTarget{
 			NodeID:  tc.Servers[0].GetNode().Descriptor.NodeID,
 			StoreID: tc.Servers[0].GetFirstStoreID(),
 		})

--- a/pkg/sql/backup_test.go
+++ b/pkg/sql/backup_test.go
@@ -183,7 +183,7 @@ func backupRestoreTestSetup(
 		sqlDB.Exec(split)
 	}
 
-	targets := make([]testcluster.ReplicationTarget, backupRestoreClusterSize-1)
+	targets := make([]base.ReplicationTarget, backupRestoreClusterSize-1)
 	for i := 1; i < backupRestoreClusterSize; i++ {
 		targets[i-1] = tc.Target(i)
 	}

--- a/pkg/storage/main_test.go
+++ b/pkg/storage/main_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
@@ -41,6 +42,7 @@ var verifyBelowRaftProtos bool
 func TestMain(m *testing.M) {
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 
 	// Create a set of all protos we believe to be marshalled downstream of raft.
 	// After the tests are run, we'll subtract the encountered protos from this

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
@@ -48,6 +49,52 @@ type TestClusterInterface interface {
 	// Stopper retrieves the stopper for this test cluster. Tests should call or
 	// defer the Stop() method on this stopper after starting a test cluster.
 	Stopper() *stop.Stopper
+
+	// AddReplicas adds replicas for a range on a set of stores.
+	// It's illegal to have multiple replicas of the same range on stores of a single
+	// node.
+	// The method blocks until a snapshot of the range has been copied to all the
+	// new replicas and the new replicas become part of the Raft group.
+	AddReplicas(
+		startKey roachpb.Key, targets ...base.ReplicationTarget,
+	) (roachpb.RangeDescriptor, error)
+
+	// RemoveReplicas removes one or more replicas from a range.
+	RemoveReplicas(
+		startKey roachpb.Key, targets ...base.ReplicationTarget,
+	) (roachpb.RangeDescriptor, error)
+
+	// FindRangeLeaseHolder returns the current lease holder for the given range.
+	// In particular, it returns one particular node's (the hint, if specified) view
+	// of the current lease.
+	// An error is returned if there's no active lease.
+	//
+	// Note that not all nodes have necessarily applied the latest lease,
+	// particularly immediately after a TransferRangeLease() call. So specifying
+	// different hints can yield different results. The one server that's guaranteed
+	// to have applied the transfer is the previous lease holder.
+	FindRangeLeaseHolder(
+		rangeDesc roachpb.RangeDescriptor,
+		hint *base.ReplicationTarget,
+	) (base.ReplicationTarget, error)
+
+	// TransferRangeLease transfers the lease for a range from whoever has it to
+	// a particular store. That store must already have a replica of the range. If
+	// that replica already has the (active) lease, this method is a no-op.
+	//
+	// When this method returns, it's guaranteed that the old lease holder has
+	// applied the new lease, but that's about it. It's not guaranteed that the new
+	// lease holder has applied it (so it might not know immediately that it is the
+	// new lease holder).
+	TransferRangeLease(
+		rangeDesc roachpb.RangeDescriptor, dest base.ReplicationTarget,
+	) error
+
+	// LookupRange returns the descriptor of the range containing key.
+	LookupRange(key roachpb.Key) (roachpb.RangeDescriptor, error)
+
+	// Target returns a base.ReplicationTarget for the specified server.
+	Target(serverIdx int) base.ReplicationTarget
 }
 
 // TestClusterFactory encompasses the actual implementation of the shim

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -92,6 +93,10 @@ type TestServerInterface interface {
 	// WriteSummaries records summaries of time-series data, which is required for
 	// any tests that query server stats.
 	WriteSummaries() error
+
+	// GetFirstStoreID is a utility function returning the StoreID of the first
+	// store on this node.
+	GetFirstStoreID() roachpb.StoreID
 }
 
 // TestServerFactory encompasses the actual implementation of the shim

--- a/pkg/testutils/testcluster/testcluster_test.go
+++ b/pkg/testutils/testcluster/testcluster_test.go
@@ -101,7 +101,7 @@ func TestManualReplication(t *testing.T) {
 	// Transfer the lease to node 1.
 	leaseHolder, err := tc.FindRangeLeaseHolder(
 		tableRangeDesc,
-		&ReplicationTarget{
+		&base.ReplicationTarget{
 			NodeID:  tc.Servers[0].GetNode().Descriptor.NodeID,
 			StoreID: tc.Servers[0].GetFirstStoreID(),
 		})
@@ -123,7 +123,7 @@ func TestManualReplication(t *testing.T) {
 	// new lease.
 	leaseHolder, err = tc.FindRangeLeaseHolder(
 		tableRangeDesc,
-		&ReplicationTarget{
+		&base.ReplicationTarget{
 			NodeID:  tc.Servers[0].GetNode().Descriptor.NodeID,
 			StoreID: tc.Servers[0].GetFirstStoreID(),
 		})


### PR DESCRIPTION
TestClusterInterface

To be used in distsql tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12300)
<!-- Reviewable:end -->
