### PR TITLE
gitattributes: prevent git automerging glide.lock

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@ pkg/sql/parser/sql.go -diff
 pkg/ui/app/js/protos.js -diff
 pkg/ui/embedded.go -diff
 pkg/ui/generated/* -diff
+glide.lock -merge


### PR DESCRIPTION
since glide.lock represents the computation of *a set* of mututally compatible versions, it should
not be mechanically merged, but rather just marked conflicted, ideally to be resolved by re-resolving.

sql.go and embedded.go also should not be auto-merged, though that seems unlikely to happen in practice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12316)
<!-- Reviewable:end -->
