### PR TITLE
pgwire: add a periodic timeout to check for exit conditions on idle conns

### DIFF
--- a/pkg/sql/pgwire/encoding.go
+++ b/pkg/sql/pgwire/encoding.go
@@ -65,11 +65,11 @@ func (b *readBuffer) reset(size int) {
 }
 
 // readUntypedMsg reads a length-prefixed message. It is only used directly
-// during the authentication phase of the protocol; readTypedMsg is
-// used at all other times. This returns the number of bytes read and an error,
-// if there was one. The number of bytes returned can be non-zero even with an
-// error (e.g. if data was read but didn't validate) so that we can more
-// accurately measure network traffic.
+// during the authentication phase of the protocol; readTypedMsg is used at all
+// other times. This returns the number of bytes read and an error, if there
+// was one. The number of bytes returned can be non-zero even with an error
+// (e.g. if data was read but didn't validate) so that we can more accurately
+// measure network traffic.
 func (b *readBuffer) readUntypedMsg(rd io.Reader) (int, error) {
 	nread, err := io.ReadFull(rd, b.tmp[:])
 	if err != nil {

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -270,7 +270,7 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 		// We make a connection before anything. If there is an error
 		// parsing the connection arguments, the connection will only be
 		// used to send a report of that error.
-		v3conn := makeV3Conn(ctx, conn, &s.metrics, &s.sqlMemoryPool, s.executor)
+		v3conn := makeV3Conn(conn, &s.metrics, &s.sqlMemoryPool, s.executor)
 		defer v3conn.finish(ctx)
 
 		if v3conn.sessionArgs, err = parseOptions(buf.msg); err != nil {

--- a/pkg/sql/pgwire/v3_test.go
+++ b/pkg/sql/pgwire/v3_test.go
@@ -17,6 +17,7 @@
 package pgwire
 
 import (
+	"bytes"
 	"io"
 	"io/ioutil"
 	"net"
@@ -26,10 +27,12 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/mon"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/pkg/errors"
 )
 
 func makeTestV3Conn(c net.Conn) v3Conn {
@@ -42,7 +45,7 @@ func makeTestV3Conn(c net.Conn) v3Conn {
 		},
 		nil, /* stopper */
 	)
-	return makeV3Conn(context.Background(), c, &metrics, &mon, exec)
+	return makeV3Conn(c, &metrics, &mon, exec)
 }
 
 // TestMaliciousInputs verifies that known malicious inputs sent to
@@ -99,4 +102,71 @@ func testMaliciousInput(t *testing.T, data []byte) {
 	v3Conn := makeTestV3Conn(r)
 	defer v3Conn.finish(context.Background())
 	_ = v3Conn.serve(context.Background(), mon.BoundAccount{})
+}
+
+// TestReadTimeoutConn asserts that a readTimeoutConn performs reads normally
+// and exits with an appropriate error when exit conditions are satisfied.
+func TestReadTimeoutConnExits(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	// Cannot use net.Pipe because deadlines are not supported.
+	ln, err := net.Listen(util.TestAddr.Network(), util.TestAddr.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := ln.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	expectedRead := []byte("expectedRead")
+
+	// Start a goroutine that performs reads using a readTimeoutConn.
+	errChan := make(chan error)
+	go func() {
+		defer close(errChan)
+		errChan <- func() error {
+			c, err := ln.Accept()
+			if err != nil {
+				return err
+			}
+			defer c.Close()
+
+			readTimeoutConn := newReadTimeoutConn(c, ctx.Err)
+			// Assert that reads are performed normally.
+			readBytes := make([]byte, len(expectedRead))
+			if _, err := readTimeoutConn.Read(readBytes); err != nil {
+				return err
+			}
+			if !bytes.Equal(readBytes, expectedRead) {
+				return errors.Errorf("expected %v got %v", expectedRead, readBytes)
+			}
+
+			// The main goroutine will cancel the context, which should abort
+			// this read with an appropriate error.
+			_, err = readTimeoutConn.Read(make([]byte, 1))
+			return err
+		}()
+	}()
+
+	c, err := net.Dial(ln.Addr().Network(), ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	if _, err := c.Write(expectedRead); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case err := <-errChan:
+		t.Fatalf("goroutine unexpectedly returned: %v", err)
+	default:
+	}
+	cancel()
+	if err := <-errChan; err != context.Canceled {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }


### PR DESCRIPTION
This change allows us to trigger the cleanup/closing of a connection by
cancelling the context of the session associated with the connection.
This is useful during draining.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12317)
<!-- Reviewable:end -->
