### PR TITLE
storage: check leader not leaseholder condition on all commands

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2911,20 +2911,35 @@ func TestTransferRaftLeadership(t *testing.T) {
 		}
 	}
 
-	repl := store0.LookupReplica(keys.MustAddr(key), nil)
-	if repl == nil {
+	repl0 := store0.LookupReplica(keys.MustAddr(key), nil)
+	if repl0 == nil {
 		t.Fatalf("no replica found for key '%s'", key)
 	}
-	mtc.replicateRange(repl.RangeID, 1, 2)
+	rd0, err := repl0.GetReplicaDescriptor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtc.replicateRange(repl0.RangeID, 1, 2)
+
+	repl1 := store1.LookupReplica(keys.MustAddr(key), nil)
+	if repl1 == nil {
+		t.Fatalf("no replica found for key '%s'", key)
+	}
+	rd1, err := repl1.GetReplicaDescriptor()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	getArgs := getArgs([]byte("a"))
-	if _, pErr := client.SendWrappedWith(context.Background(), store0, roachpb.Header{RangeID: repl.RangeID}, getArgs); pErr != nil {
+	if _, pErr := client.SendWrappedWith(
+		context.Background(), store0, roachpb.Header{RangeID: repl0.RangeID}, getArgs,
+	); pErr != nil {
 		t.Fatalf("expect get nil, actual get %v ", pErr)
 	}
 
-	status := repl.RaftStatus()
-	if status != nil && status.Lead != 1 {
-		t.Fatalf("raft leader should be 1, but got status %+v", status)
+	status := repl0.RaftStatus()
+	if status == nil || status.Lead != uint64(rd0.ReplicaID) {
+		t.Fatalf("raft leader should be %d, but got status %+v", rd0.ReplicaID, status)
 	}
 
 	// Force a read on Store 2 to request a new lease. Other moving parts in
@@ -2933,10 +2948,7 @@ func TestTransferRaftLeadership(t *testing.T) {
 	for {
 		mtc.expireLeases()
 		if _, pErr := client.SendWrappedWith(
-			context.Background(),
-			store1,
-			roachpb.Header{RangeID: repl.RangeID},
-			getArgs,
+			context.Background(), store1, roachpb.Header{RangeID: repl0.RangeID}, getArgs,
 		); pErr == nil {
 			break
 		} else {
@@ -2947,11 +2959,33 @@ func TestTransferRaftLeadership(t *testing.T) {
 			}
 		}
 	}
-	// Wait for raft leadership transferring to be finished.
+	// Verify lease is transferred.
 	testutils.SucceedsSoon(t, func() error {
-		status = repl.RaftStatus()
-		if status.Lead != 2 {
-			return errors.Errorf("expected raft leader be 2; got %d", status.Lead)
+		if a, e := repl0.RaftStatus().Lead, uint64(rd1.ReplicaID); a != e {
+			return errors.Errorf("expected raft leader be %d; got %d", e, a)
+		}
+		if a, e := store0.Metrics().RangeRaftLeaderTransfers.Count(), int64(1); a < e {
+			return errors.Errorf("expected raft leader transfer count >= %d; got %d", e, a)
+		}
+		return nil
+	})
+
+	// Manually transfer raft leadership to node 0.
+	testutils.SucceedsSoon(t, func() error {
+		repl1.RaftTransferLeader(context.Background(), rd0.ReplicaID)
+		if a, e := repl1.RaftStatus().Lead, uint64(rd0.ReplicaID); a != e {
+			return errors.Errorf("expected raft leader be %d; got %d", e, a)
+		}
+		return nil
+	})
+
+	// Verify that Raft leadership reverts back to the leaseholder.
+	testutils.SucceedsSoon(t, func() error {
+		if a, e := repl0.RaftStatus().Lead, uint64(rd1.ReplicaID); a != e {
+			return errors.Errorf("expected raft leader be %d; got %d", e, a)
+		}
+		if a, e := store1.Metrics().RangeRaftLeaderTransfers.Count(), int64(1); a < e {
+			return errors.Errorf("expected raft leader transfer count >= %d; got %d", e, a)
 		}
 		return nil
 	})

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -250,6 +250,10 @@ func (r *Replica) GetQueueLastProcessed(ctx context.Context, queue string) (hlc.
 	return r.getQueueLastProcessed(ctx, queue)
 }
 
+func (r *Replica) RaftTransferLeader(ctx context.Context, target roachpb.ReplicaID) {
+	r.maybeTransferRaftLeadership(ctx, target)
+}
+
 func GetGCQueueTxnCleanupThreshold() time.Duration {
 	return txnCleanupThreshold
 }

--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -117,6 +117,7 @@ var (
 	metaRangeSnapshotsGenerated         = metric.Metadata{Name: "range.snapshots.generated"}
 	metaRangeSnapshotsNormalApplied     = metric.Metadata{Name: "range.snapshots.normal-applied"}
 	metaRangeSnapshotsPreemptiveApplied = metric.Metadata{Name: "range.snapshots.preemptive-applied"}
+	metaRangeRaftLeaderTransfers        = metric.Metadata{Name: "range.raftleadertransfers"}
 
 	// Raft processing metrics.
 	metaRaftTicks = metric.Metadata{
@@ -384,6 +385,7 @@ type StoreMetrics struct {
 	RangeSnapshotsGenerated         *metric.Counter
 	RangeSnapshotsNormalApplied     *metric.Counter
 	RangeSnapshotsPreemptiveApplied *metric.Counter
+	RangeRaftLeaderTransfers        *metric.Counter
 
 	// Raft processing metrics.
 	RaftTicks                *metric.Counter
@@ -556,6 +558,7 @@ func newStoreMetrics(sampleInterval time.Duration) *StoreMetrics {
 		RangeSnapshotsGenerated:         metric.NewCounter(metaRangeSnapshotsGenerated),
 		RangeSnapshotsNormalApplied:     metric.NewCounter(metaRangeSnapshotsNormalApplied),
 		RangeSnapshotsPreemptiveApplied: metric.NewCounter(metaRangeSnapshotsPreemptiveApplied),
+		RangeRaftLeaderTransfers:        metric.NewCounter(metaRangeRaftLeaderTransfers),
 
 		// Raft processing metrics.
 		RaftTicks:                metric.NewCounter(metaRaftTicks),

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2824,6 +2824,23 @@ func (r *Replica) maybeQuiesceLocked() bool {
 		}
 		return false
 	}
+	// Only quiesce if this replica is the leaseholder as well;
+	// otherwise the replica which is the valid leaseholder may have
+	// pending commands which it's waiting on this leader to propose.
+	if l := r.mu.state.Lease; !l.OwnedBy(r.store.StoreID()) &&
+		r.isLeaseValidLocked(l, r.store.Clock().Now()) {
+		if log.V(4) {
+			log.Infof(ctx, "not quiescing: not leaseholder")
+		}
+		// Try to correct leader-not-leaseholder condition, if encountered,
+		// assuming the leaseholder is caught up to the commit index.
+		if pr, ok := status.Progress[uint64(l.Replica.ReplicaID)]; ok && pr.Match >= status.Commit {
+			log.VEventf(ctx, 1, "transferring raft leadership to replica ID %v", l.Replica.ReplicaID)
+			r.store.metrics.RangeRaftLeaderTransfers.Inc(1)
+			r.mu.internalRaftGroup.TransferLeader(uint64(l.Replica.ReplicaID))
+		}
+		return false
+	}
 	// We need all of Applied, Commit, LastIndex and Progress.Match indexes to be
 	// equal in order to quiesce.
 	if status.Applied != status.Commit {

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -415,13 +415,9 @@ func (r *Replica) leasePostApply(
 		// when leases and raft leadership are collocated because that facilitates
 		// quick command application (requests generally need to make it to both the
 		// lease holder and the raft leader before being applied by other replicas).
-		//
-		// TODO(andrei): We want to do this attempt when a lease changes hands, and
-		// then periodically check that the collocation is fine. So we keep checking
-		// it here on lease extensions, which happen periodically, but that's pretty
-		// arbitrary. There might be a more natural place elsewhere where this
-		// periodic check should happen.
-		r.maybeTransferRaftLeadership(ctx, replicaID, newLease.Replica.ReplicaID)
+		// Note that this condition is also checked periodically when computing
+		// replica metrics.
+		r.maybeTransferRaftLeadership(ctx, newLease.Replica.ReplicaID)
 	}
 
 	// Notify the store that a lease change occurred and it may need to
@@ -432,19 +428,20 @@ func (r *Replica) leasePostApply(
 	}
 }
 
-// maybeTransferRaftLeadership attempts to transfer the leadership away from
-// this node to target, if this node is the current raft leader.
-// The transfer might silently fail, particularly (only?) if the transferee is
-// behind on applying the log.
-func (r *Replica) maybeTransferRaftLeadership(
-	ctx context.Context, replicaID roachpb.ReplicaID, target roachpb.ReplicaID,
-) {
+// maybeTransferRaftLeadership attempts to transfer the leadership
+// away from this node to target, if this node is the current raft
+// leader. We don't attempt to transfer leadership if the transferee
+// is behind on applying the log.
+func (r *Replica) maybeTransferRaftLeadership(ctx context.Context, target roachpb.ReplicaID) {
 	err := r.withRaftGroup(func(raftGroup *raft.RawNode) (bool, error) {
-		if raftGroup.Status().RaftState == raft.StateLeader {
-			// Only the raft leader can attempt a leadership transfer.
-			log.Infof(ctx, "range %s: transferring raft leadership to replica ID %v",
-				r, target)
-			raftGroup.TransferLeader(uint64(target))
+		// Only the raft leader can attempt a leadership transfer.
+		if status := raftGroup.Status(); status.RaftState == raft.StateLeader {
+			// Only attempt this if the target has all the log entries.
+			if pr, ok := status.Progress[uint64(target)]; ok && pr.Match == r.mu.lastIndex {
+				log.VEventf(ctx, 1, "transferring raft leadership to replica ID %v", target)
+				r.store.metrics.RangeRaftLeaderTransfers.Inc(1)
+				raftGroup.TransferLeader(uint64(target))
+			}
 		}
 		return true, nil
 	})


### PR DESCRIPTION
Previously, we only checked for leader-not-leaseholder when completing a
lease operation. This relied on the constant renewals of expiration-based
leases to transfer Raft leadership reliably.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12323)
<!-- Reviewable:end -->
