### PR TITLE
stop: Include stack trace in log message when Stop is called

### DIFF
--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -393,7 +393,9 @@ func (s *Stopper) Stop() {
 	defer s.Recover()
 	defer unregister(s)
 
-	log.Info(context.TODO(), "stop has been called, stopping or quiescing all running tasks")
+	file, line, _ := caller.Lookup(1)
+	log.Infof(context.TODO(),
+		"stop has been called from %s:%d, stopping or quiescing all running tasks", file, line)
 	// Don't bother doing stuff cleanly if we're panicking, that would likely
 	// block. Instead, best effort only. This cleans up the stack traces,
 	// avoids stalls and helps some tests in `./cli` finish cleanly (where


### PR DESCRIPTION
I've noticed a pattern in my debugging of wishing I knew where Stop() was called from. If that's a sign that I'm doing things wrong, let me know. Otherwise, it seems like it'd be useful to know.

@tamird, thoughts?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12325)
<!-- Reviewable:end -->
