### PR TITLE
distsql: fix bug in FlowRegistry 

### DIFF
--- a/pkg/sql/distsql/flow.go
+++ b/pkg/sql/distsql/flow.go
@@ -335,6 +335,9 @@ func (f *Flow) Start(doneFn func()) {
 	)
 	f.status = FlowRunning
 	f.flowRegistry.RegisterFlow(f.id, f, f.inboundStreams)
+	if log.V(1) {
+		log.Infof(f.Context, "registered flow %s", f.id.Short())
+	}
 	f.waitGroup.Add(len(f.inboundStreams))
 	f.waitGroup.Add(len(f.outboxes))
 	f.waitGroup.Add(len(f.processors))

--- a/pkg/sql/distsql/flow_registry_test.go
+++ b/pkg/sql/distsql/flow_registry_test.go
@@ -38,6 +38,9 @@ func TestFlowRegistry(t *testing.T) {
 	id3 := FlowID{uuid.MakeV4()}
 	f3 := &Flow{}
 
+	id4 := FlowID{uuid.MakeV4()}
+	f4 := &Flow{}
+
 	// A basic duration; needs to be significantly larger than possible delays
 	// in scheduling goroutines.
 	jiffy := 10 * time.Millisecond
@@ -122,4 +125,16 @@ func TestFlowRegistry(t *testing.T) {
 	wg1.Wait()
 	reg.RegisterFlow(id3, f3, nil)
 	wg2.Wait()
+
+	// -- Lookup with huge timeout, register in the meantime. --
+
+	go func() {
+		time.Sleep(jiffy)
+		reg.RegisterFlow(id4, f4, nil)
+	}()
+
+	// This should return in a jiffy.
+	if f := reg.LookupFlow(id4, time.Hour); f != f4 {
+		t.Error("couldn't lookup registered flow (with wait)")
+	}
 }

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -153,7 +153,7 @@ func (ds *ServerImpl) SetupFlow(_ context.Context, req *SetupFlowRequest) (*Simp
 	return &SimpleResponse{}, nil
 }
 
-func (ds *ServerImpl) flowStreamInt(stream DistSQL_FlowStreamServer) error {
+func (ds *ServerImpl) flowStreamInt(ctx context.Context, stream DistSQL_FlowStreamServer) error {
 	// Receive the first message.
 	msg, err := stream.Recv()
 	if err != nil {
@@ -166,10 +166,15 @@ func (ds *ServerImpl) flowStreamInt(stream DistSQL_FlowStreamServer) error {
 		return errors.Errorf("no header in first message")
 	}
 	flowID := msg.Header.FlowID
-	f, streamInfo, err := ds.flowRegistry.ConnectInboundStream(flowID, msg.Header.StreamID)
+	streamID := msg.Header.StreamID
+	if log.V(1) {
+		log.Infof(ctx, "connecting inbound stream %s/%d", flowID.Short(), streamID)
+	}
+	f, streamInfo, err := ds.flowRegistry.ConnectInboundStream(flowID, streamID)
 	if err != nil {
 		return err
 	}
+	log.VEventf(ctx, 1, "connected inbound stream %s/%d", flowID.Short(), streamID)
 	defer ds.flowRegistry.FinishInboundStream(streamInfo)
 	return ProcessInboundStream(&f.FlowCtx, stream, msg, streamInfo.receiver)
 }
@@ -177,7 +182,7 @@ func (ds *ServerImpl) flowStreamInt(stream DistSQL_FlowStreamServer) error {
 // FlowStream is part of the DistSQLServer interface.
 func (ds *ServerImpl) FlowStream(stream DistSQL_FlowStreamServer) error {
 	ctx := ds.AnnotateCtx(stream.Context())
-	err := ds.flowStreamInt(stream)
+	err := ds.flowStreamInt(ctx, stream)
 	if err != nil {
 		log.Error(ctx, err)
 	}


### PR DESCRIPTION
Due to a typo, if an inbound stream arrives before the flow is registered, we
wait for the entire timeout. Fixing and adding a test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12327)
<!-- Reviewable:end -->
