### PR TITLE
*: Switch tests from using health endpoint to metrics endpoint

### DIFF
--- a/pkg/security/certs_test.go
+++ b/pkg/security/certs_test.go
@@ -167,14 +167,15 @@ func TestUseCerts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	req, err := http.NewRequest("GET", s.AdminURL()+"/_admin/v1/health", nil)
+	req, err := http.NewRequest("GET", s.AdminURL()+"/_status/metrics/local", nil)
 	if err != nil {
 		t.Fatalf("could not create request: %v", err)
 	}
 	resp, err := httpClient.Do(req)
 	if err == nil {
-		resp.Body.Close()
-		t.Fatalf("Expected SSL error, got success")
+		defer resp.Body.Close()
+		body, _ := ioutil.ReadAll(resp.Body)
+		t.Fatalf("Expected SSL error, got success: %s", body)
 	}
 
 	// New client. With certs this time.
@@ -186,7 +187,7 @@ func TestUseCerts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected success, got %v", err)
 	}
-	req, err = http.NewRequest("GET", s.AdminURL()+"/_admin/v1/health", nil)
+	req, err = http.NewRequest("GET", s.AdminURL()+"/_status/metrics/local", nil)
 	if err != nil {
 		t.Fatalf("could not create request: %v", err)
 	}
@@ -194,8 +195,9 @@ func TestUseCerts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected success, got %v", err)
 	}
-	resp.Body.Close()
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("Expected OK, got: %d", resp.StatusCode)
+		body, _ := ioutil.ReadAll(resp.Body)
+		t.Fatalf("Expected OK, got %q with body: %s", resp.Status, body)
 	}
 }


### PR DESCRIPTION
A handful of tests were hitting the health check URL as a way of
verifying basic responsiveness of the server. As of
b314d64706b1dbf1db64a1ff487299a6d692cd37, the health check metric
doesn't just blindly return healthy, it relies on node liveness, which
means it's now (very infrequently) flaky.

The local metrics endpoint shouldn't be flaky, since all it does is call
through the prometheus export logic.

Alternatively we can take @paperstreet's sarcastic suggestion of adding a "/noopz" endpoint for this purpose, since that's really what "/_admin/v1/health" was being used for.

Fixes #12304 (and potentially other recently introduced flakes).

@tamird

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12330)
<!-- Reviewable:end -->
