### PR TITLE
distsql: use separate client.Txn for each reader

### DIFF
--- a/pkg/sql/distsql/flow.go
+++ b/pkg/sql/distsql/flow.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -44,11 +45,18 @@ type FlowID struct {
 
 // FlowCtx encompasses the contexts needed for various flow components.
 type FlowCtx struct {
-	Context context.Context
-	id      FlowID
-	evalCtx *parser.EvalContext
-	rpcCtx  *rpc.Context
-	txn     *client.Txn
+	Context  context.Context
+	id       FlowID
+	evalCtx  *parser.EvalContext
+	rpcCtx   *rpc.Context
+	txnProto *roachpb.Transaction
+	clientDB *client.DB
+}
+
+func (flowCtx *FlowCtx) setupTxn(ctx context.Context) *client.Txn {
+	txn := client.NewTxn(ctx, *flowCtx.clientDB)
+	txn.Proto = *flowCtx.txnProto
+	return txn
 }
 
 type flowStatus int

--- a/pkg/sql/distsql/joinreader.go
+++ b/pkg/sql/distsql/joinreader.go
@@ -101,6 +101,8 @@ func (jr *joinReader) mainLoop() error {
 	ctx, span := tracing.ChildSpan(jr.ctx, "join reader")
 	defer tracing.FinishSpan(span)
 
+	txn := jr.flowCtx.setupTxn(ctx)
+
 	log.VEventf(ctx, 1, "starting (filter: %s)", &jr.filter)
 	if log.V(1) {
 		defer log.Infof(ctx, "exiting")
@@ -132,7 +134,7 @@ func (jr *joinReader) mainLoop() error {
 			})
 		}
 
-		err := jr.fetcher.StartScan(jr.flowCtx.txn, spans, false /* no batch limits */, 0)
+		err := jr.fetcher.StartScan(txn, spans, false /* no batch limits */, 0)
 		if err != nil {
 			log.Errorf(ctx, "scan error: %s", err)
 			return err

--- a/pkg/sql/distsql/joinreader_test.go
+++ b/pkg/sql/distsql/joinreader_test.go
@@ -22,7 +22,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -98,11 +98,11 @@ func TestJoinReader(t *testing.T) {
 		js := c.spec
 		js.Table = *td
 
-		txn := client.NewTxn(context.Background(), *kvDB)
 		flowCtx := FlowCtx{
-			Context: context.Background(),
-			evalCtx: &parser.EvalContext{},
-			txn:     txn,
+			Context:  context.Background(),
+			evalCtx:  &parser.EvalContext{},
+			txnProto: &roachpb.Transaction{},
+			clientDB: kvDB,
 		}
 
 		in := &RowBuffer{}

--- a/pkg/sql/distsql/tablereader.go
+++ b/pkg/sql/distsql/tablereader.go
@@ -102,13 +102,15 @@ func (tr *tableReader) Run(wg *sync.WaitGroup) {
 	ctx, span := tracing.ChildSpan(tr.ctx, "table reader")
 	defer tracing.FinishSpan(span)
 
+	txn := tr.flowCtx.setupTxn(ctx)
+
 	log.VEventf(ctx, 1, "starting (filter: %s)", &tr.filter)
 	if log.V(1) {
 		defer log.Infof(ctx, "exiting")
 	}
 
 	if err := tr.fetcher.StartScan(
-		tr.flowCtx.txn, tr.spans, true /* limit batches */, tr.getLimitHint(),
+		txn, tr.spans, true /* limit batches */, tr.getLimitHint(),
 	); err != nil {
 		log.Errorf(ctx, "scan error: %s", err)
 		tr.output.Close(err)

--- a/pkg/sql/distsql/tablereader_test.go
+++ b/pkg/sql/distsql/tablereader_test.go
@@ -22,7 +22,6 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -106,11 +105,11 @@ func TestTableReader(t *testing.T) {
 		ts := c.spec
 		ts.Table = *td
 
-		txn := client.NewTxn(context.Background(), *kvDB)
 		flowCtx := FlowCtx{
-			Context: context.Background(),
-			evalCtx: &parser.EvalContext{},
-			txn:     txn,
+			Context:  context.Background(),
+			evalCtx:  &parser.EvalContext{},
+			txnProto: &roachpb.Transaction{},
+			clientDB: kvDB,
 		}
 
 		out := &RowBuffer{}


### PR DESCRIPTION
Using the same Txn for multiple readers within the same flow leads to data
races; create a separate Txn for each table reader.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12347)
<!-- Reviewable:end -->
