### PR TITLE
sql: bugfix for filtered outer joins

### DIFF
--- a/pkg/sql/testdata/join
+++ b/pkg/sql/testdata/join
@@ -302,6 +302,34 @@ SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = a.y
 45  45  42    53
 45  45  45    45
 
+# Inner join with filter predicate
+query II
+SELECT o.x, t.y FROM onecolumn o INNER JOIN twocolumn t ON (o.x=t.x AND t.y=53)
+----
+42   53
+
+# Outer joins with filter predicate
+query II
+SELECT o.x, t.y FROM onecolumn o LEFT OUTER JOIN twocolumn t ON (o.x=t.x AND t.y=53)
+----
+44   NULL
+NULL NULL
+42   53
+
+query II
+SELECT o.x, t.y FROM onecolumn o LEFT OUTER JOIN twocolumn t ON (o.x=t.x AND o.x=44)
+----
+44   51
+NULL NULL
+42   NULL
+
+query II
+SELECT o.x, t.y FROM onecolumn o LEFT OUTER JOIN twocolumn t ON (o.x=t.x AND t.x=44)
+----
+44   51
+NULL NULL
+42   NULL
+
 # Check column orders and names.
 query IIIIII colnames
 SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twocolumn.x JOIN twocolumn AS c(d,e) ON a.b=c.d AND c.d=onecolumn.x) LIMIT 1


### PR DESCRIPTION
This commit fixes a regression in `OUTER JOIN` operations with
predicates, wherein rows with failed predicates would be erroneously
skipped despite the fact that the join is `OUTER`.

We need some test cases for `RIGHT OUTER JOIN` here, but we can't write them until #12329 is resolved.

Fixes #12311.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12350)
<!-- Reviewable:end -->
