### PR TITLE
sql: bugfixes in FULL and RIGHT OUTER JOIN

### DIFF
--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -355,11 +355,13 @@ func (n *joinNode) Start() error {
 
 	// If needed, pre-allocate left and right rows of NULL tuples for when the
 	// join predicate fails to match.
-	if n.joinType != joinTypeInner {
+	if n.joinType == joinTypeLeftOuter || n.joinType == joinTypeFullOuter {
 		n.emptyRight = make(parser.DTuple, len(n.right.plan.Columns()))
 		for i := range n.emptyRight {
 			n.emptyRight[i] = parser.DNull
 		}
+	}
+	if n.joinType == joinTypeRightOuter || n.joinType == joinTypeFullOuter {
 		n.emptyLeft = make(parser.DTuple, len(n.left.plan.Columns()))
 		for i := range n.emptyLeft {
 			n.emptyLeft[i] = parser.DNull

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -88,8 +88,8 @@ func (b *buckets) AddRow(acc WrappedMemoryAccount, encoding []byte, row parser.D
 	return nil
 }
 
-// InitSeen must be run before the buckets are used to initialize the rows'
-// seen arrays.
+// InitSeen initializes the seen array for each of the buckets. It must be run
+// before the buckets' seen state is used.
 func (b *buckets) InitSeen() {
 	for _, bucket := range b.buckets {
 		bucket.seen = make([]bool, len(bucket.rows))
@@ -393,7 +393,9 @@ func (n *joinNode) hashJoinStart() error {
 
 		scratch = encoding[:0]
 	}
-	n.buckets.InitSeen()
+	if n.joinType == joinTypeFullOuter || n.joinType == joinTypeRightOuter {
+		n.buckets.InitSeen()
+	}
 	return nil
 }
 
@@ -541,10 +543,11 @@ func (n *joinNode) Next() (res bool, err error) {
 			foundMatch = true
 
 			n.pred.prepareRow(n.output, lrow, rrow)
-			// TODO(jordan) MarkSeen is not required unless the join is RIGHT
-			// or FULL. In these cases, we can skip allocating the seen arrays
-			// for every bucket.
-			b.MarkSeen(idx)
+			if wantUnmatchedRight {
+				// Mark the row as seen if we need to retrieve the rows
+				// without matches for right or full joins later.
+				b.MarkSeen(idx)
+			}
 			if _, err := n.buffer.AddRow(n.output); err != nil {
 				return false, err
 			}

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -418,8 +418,11 @@ func (n *joinNode) Next() (res bool, err error) {
 		return n.debugNext()
 	}
 
+	wantUnmatchedLeft := n.joinType == joinTypeLeftOuter || n.joinType == joinTypeFullOuter
+	wantUnmatchedRight := n.joinType == joinTypeRightOuter || n.joinType == joinTypeFullOuter
+
 	if len(n.buckets.Buckets()) == 0 {
-		if n.joinType != joinTypeLeftOuter && n.joinType != joinTypeFullOuter {
+		if !wantUnmatchedLeft {
 			// No rows on right; don't even try.
 			return false, nil
 		}
@@ -492,7 +495,7 @@ func (n *joinNode) Next() (res bool, err error) {
 		//    | NULL |  52  |
 		//    | NULL |  52  |
 		if containsNull {
-			if n.joinType == joinTypeInner || n.joinType == joinTypeRightOuter {
+			if !wantUnmatchedLeft {
 				scratch = encoding[:0]
 				// Failed to match -- no matching row, nothing to do.
 				continue
@@ -508,7 +511,7 @@ func (n *joinNode) Next() (res bool, err error) {
 
 		b, ok := n.buckets.Fetch(encoding)
 		if !ok {
-			if n.joinType == joinTypeInner || n.joinType == joinTypeRightOuter {
+			if !wantUnmatchedLeft {
 				scratch = encoding[:0]
 				continue
 			}
@@ -546,7 +549,7 @@ func (n *joinNode) Next() (res bool, err error) {
 				return false, err
 			}
 		}
-		if !foundMatch && n.joinType != joinTypeInner && n.joinType != joinTypeRightOuter {
+		if !foundMatch && wantUnmatchedLeft {
 			// If none of the rows matched the filter and we are computing a
 			// left or full outer join, we need to add a row with an empty
 			// right side.
@@ -562,7 +565,7 @@ func (n *joinNode) Next() (res bool, err error) {
 	}
 
 	// no more lrows, we go through the unmatched rows in the internal hashmap.
-	if n.joinType == joinTypeInner || n.joinType == joinTypeLeftOuter {
+	if !wantUnmatchedRight {
 		return false, nil
 	}
 

--- a/pkg/sql/testdata/join
+++ b/pkg/sql/testdata/join
@@ -90,8 +90,8 @@ SELECT * FROM onecolumn AS a(x) RIGHT OUTER JOIN onecolumn AS b(y) ON a.x = b.y
 ----
    x     y
   44    44
-NULL  NULL
   42    42
+NULL  NULL
 
 query I colnames
 SELECT * FROM onecolumn AS a RIGHT OUTER JOIN onecolumn AS b USING(x) ORDER BY x
@@ -106,8 +106,8 @@ SELECT * FROM onecolumn AS a NATURAL RIGHT OUTER JOIN onecolumn AS b
 ----
    x
   44
-NULL
   42
+NULL
 
 statement ok
 CREATE TABLE onecolumn_w(w INT); INSERT INTO onecolumn_w(w) VALUES (42),(43)
@@ -329,6 +329,43 @@ SELECT o.x, t.y FROM onecolumn o LEFT OUTER JOIN twocolumn t ON (o.x=t.x AND t.x
 44   51
 NULL NULL
 42   NULL
+
+# Simple test cases for inner, left, right, and outer joins
+
+statement ok
+CREATE TABLE a (i int); INSERT INTO a VALUES (1), (2), (3)
+
+statement ok
+CREATE TABLE b (i int, b bool); INSERT INTO b VALUES (2, true), (3, true), (4, false)
+
+query IIB
+SELECT * FROM a INNER JOIN b ON a.i = b.i
+----
+2 2 true
+3 3 true
+
+query IIB
+SELECT * FROM a LEFT OUTER JOIN b ON a.i = b.i
+----
+1 NULL NULL
+2 2    true
+3 3    true
+
+query IIB
+SELECT * FROM a RIGHT OUTER JOIN b ON a.i = b.i
+----
+2    2    true
+3    3    true
+NULL 4    false
+
+query IIB
+SELECT * FROM a FULL OUTER JOIN b ON a.i = b.i
+----
+1    NULL NULL
+2    2    true
+3    3    true
+NULL 4    false
+
 
 # Check column orders and names.
 query IIIIII colnames

--- a/pkg/sql/testdata/join
+++ b/pkg/sql/testdata/join
@@ -368,12 +368,33 @@ NULL 4    false
 
 # Full outer join with filter predicate
 query IIB
-SELECT * FROM a FULL OUTER JOIN b ON (a.i = b.i and a.i>2);
+SELECT * FROM a FULL OUTER JOIN b ON (a.i = b.i and a.i>2) ORDER BY a.i, b.i;
 ----
+NULL 2    true
+NULL 4    false
 1    NULL NULL
 2    NULL NULL
 3    3    true
-NULL 2    true
+
+# Duplicate right matches for a single left row
+statement ok
+INSERT INTO b VALUES (3, false)
+
+query IIB
+SELECT * FROM a RIGHT OUTER JOIN b ON a.i=b.i ORDER BY b.i, b.b;
+----
+2    2 true
+3    3 false
+3    3 true
+NULL 4 false
+
+query IIB
+SELECT * FROM a FULL OUTER JOIN b ON a.i=b.i ORDER BY b.i, b.b;
+----
+1    NULL NULL
+2    2    true
+3    3    false
+3    3    true
 NULL 4    false
 
 

--- a/pkg/sql/testdata/join
+++ b/pkg/sql/testdata/join
@@ -330,7 +330,7 @@ SELECT o.x, t.y FROM onecolumn o LEFT OUTER JOIN twocolumn t ON (o.x=t.x AND t.x
 NULL NULL
 42   NULL
 
-# Simple test cases for inner, left, right, and outer joins
+## Simple test cases for inner, left, right, and outer joins
 
 statement ok
 CREATE TABLE a (i int); INSERT INTO a VALUES (1), (2), (3)
@@ -364,6 +364,16 @@ SELECT * FROM a FULL OUTER JOIN b ON a.i = b.i
 1    NULL NULL
 2    2    true
 3    3    true
+NULL 4    false
+
+# Full outer join with filter predicate
+query IIB
+SELECT * FROM a FULL OUTER JOIN b ON (a.i = b.i and a.i>2);
+----
+1    NULL NULL
+2    NULL NULL
+3    3    true
+NULL 2    true
 NULL 4    false
 
 


### PR DESCRIPTION
This PR solves a couple of issues with our implementation of `JOIN`.

`RIGHT OUTER JOIN` no longer swaps the `JOIN` operands and performs a `LEFT OUTER JOIN` - this simplifies the implementation by removing the `swapped` field from the `joinNode` along with its associated swapping logic. Previously there was a panicking bug in the swap logic that caused `RIGHT JOIN` to fail.

`FULL OUTER JOIN` now behaves correctly when the buckets in our hash join implementation contain more than one row apiece. Previously this caused `RIGHT` and `FULL OUTER JOIN` to fail to output all of the unmatched rows on the right side of the join.

Fixes #12311.
Fixes #12329.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12364)
<!-- Reviewable:end -->
