### PR TITLE
sql: Standardize SQL error format using PG's structured errors

### DIFF
--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -988,12 +988,14 @@ func (p *planner) getViewDescForCascade(
 			viewName, err = p.getQualifiedTableName(viewDesc)
 			if err != nil {
 				log.Warningf(p.ctx(), "unable to retrieve qualified name of view %d: %v", viewID, err)
-				return nil, sqlbase.NewDependentObjectError(
-					"cannot drop %s %q because a view depends on it", typeName, objName)
+				msg := fmt.Sprintf("cannot drop %s %q because a view depends on it", typeName, objName)
+				return nil, sqlbase.NewDependentObjectError(msg, "")
 			}
 		}
-		return nil, sqlbase.NewDependentObjectError("cannot drop %s %q because view %q depends on it",
+		msg := fmt.Sprintf("cannot drop %s %q because view %q depends on it",
 			typeName, objName, viewName)
+		hint := fmt.Sprintf("you can drop %s instead.", viewName)
+		return nil, sqlbase.NewDependentObjectError(msg, hint)
 	}
 	return viewDesc, nil
 }

--- a/pkg/sql/pgwire/servererrfieldtype_string.go
+++ b/pkg/sql/pgwire/servererrfieldtype_string.go
@@ -5,31 +5,36 @@ package pgwire
 import "fmt"
 
 const (
-	_serverErrFieldType_name_0 = "serverErrFieldSQLState"
+	_serverErrFieldType_name_0 = "serverErrFieldSQLStateserverErrFileldDetail"
 	_serverErrFieldType_name_1 = "serverErrFieldSrcFile"
-	_serverErrFieldType_name_2 = "serverErrFieldSrcLineserverErrFieldMsgPrimary"
-	_serverErrFieldType_name_3 = "serverErrFieldSrcFunctionserverErrFieldSeverity"
+	_serverErrFieldType_name_2 = "serverErrFileldHint"
+	_serverErrFieldType_name_3 = "serverErrFieldSrcLineserverErrFieldMsgPrimary"
+	_serverErrFieldType_name_4 = "serverErrFieldSrcFunctionserverErrFieldSeverity"
 )
 
 var (
-	_serverErrFieldType_index_0 = [...]uint8{0, 22}
+	_serverErrFieldType_index_0 = [...]uint8{0, 22, 43}
 	_serverErrFieldType_index_1 = [...]uint8{0, 21}
-	_serverErrFieldType_index_2 = [...]uint8{0, 21, 45}
-	_serverErrFieldType_index_3 = [...]uint8{0, 25, 47}
+	_serverErrFieldType_index_2 = [...]uint8{0, 19}
+	_serverErrFieldType_index_3 = [...]uint8{0, 21, 45}
+	_serverErrFieldType_index_4 = [...]uint8{0, 25, 47}
 )
 
 func (i serverErrFieldType) String() string {
 	switch {
-	case i == 67:
-		return _serverErrFieldType_name_0
+	case 67 <= i && i <= 68:
+		i -= 67
+		return _serverErrFieldType_name_0[_serverErrFieldType_index_0[i]:_serverErrFieldType_index_0[i+1]]
 	case i == 70:
 		return _serverErrFieldType_name_1
+	case i == 72:
+		return _serverErrFieldType_name_2
 	case 76 <= i && i <= 77:
 		i -= 76
-		return _serverErrFieldType_name_2[_serverErrFieldType_index_2[i]:_serverErrFieldType_index_2[i+1]]
+		return _serverErrFieldType_name_3[_serverErrFieldType_index_3[i]:_serverErrFieldType_index_3[i+1]]
 	case 82 <= i && i <= 83:
 		i -= 82
-		return _serverErrFieldType_name_3[_serverErrFieldType_index_3[i]:_serverErrFieldType_index_3[i+1]]
+		return _serverErrFieldType_name_4[_serverErrFieldType_index_4[i]:_serverErrFieldType_index_4[i+1]]
 	default:
 		return fmt.Sprintf("serverErrFieldType(%d)", i)
 	}

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -86,6 +86,8 @@ const (
 	serverErrFieldSeverity    serverErrFieldType = 'S'
 	serverErrFieldSQLState    serverErrFieldType = 'C'
 	serverErrFieldMsgPrimary  serverErrFieldType = 'M'
+	serverErrFileldDetail     serverErrFieldType = 'D'
+	serverErrFileldHint       serverErrFieldType = 'H'
 	serverErrFieldSrcFile     serverErrFieldType = 'F'
 	serverErrFieldSrcLine     serverErrFieldType = 'L'
 	serverErrFieldSrcFunction serverErrFieldType = 'R'
@@ -425,7 +427,7 @@ func (c *v3Conn) serve(ctx context.Context, reserved mon.BoundAccount) error {
 			// The spec says to drop any extra of these messages.
 
 		default:
-			err = c.sendErrorWithCode(pgerror.CodeProtocolViolationError, sqlbase.MakeSrcCtx(0),
+			err = c.sendErrorWithCode(pgerror.CodeProtocolViolationError, "", "", sqlbase.MakeSrcCtx(0),
 				fmt.Sprintf("unrecognized client message type %s", typ))
 		}
 		if err != nil {
@@ -812,7 +814,7 @@ func (c *v3Conn) sendCommandComplete(tag []byte) error {
 
 func (c *v3Conn) sendError(err error) error {
 	if sqlErr, ok := err.(sqlbase.ErrorWithPGCode); ok {
-		return c.sendErrorWithCode(sqlErr.Code(), sqlErr.SrcContext(), err.Error())
+		return c.sendErrorWithCode(sqlErr.Code(), sqlErr.Detail(), sqlErr.Hint(), sqlErr.SrcContext(), err.Error())
 	}
 	return c.sendInternalError(err.Error())
 }
@@ -820,12 +822,14 @@ func (c *v3Conn) sendError(err error) error {
 // TODO(andrei): Figure out the correct codes to send for all the errors
 // in this file and remove this function.
 func (c *v3Conn) sendInternalError(errToSend string) error {
-	return c.sendErrorWithCode(pgerror.CodeInternalError, sqlbase.MakeSrcCtx(1), errToSend)
+	return c.sendErrorWithCode(pgerror.CodeInternalError, "", "", sqlbase.MakeSrcCtx(1), errToSend)
 }
 
 // errCode is a postgres error code, plus our extensions.
 // See http://www.postgresql.org/docs/9.5/static/errcodes-appendix.html
-func (c *v3Conn) sendErrorWithCode(errCode string, errCtx sqlbase.SrcCtx, errToSend string) error {
+func (c *v3Conn) sendErrorWithCode(
+	errCode, detail, hint string, errCtx sqlbase.SrcCtx, errToSend string,
+) error {
 	if c.doingExtendedQueryMessage {
 		c.ignoreTillSync = true
 	}
@@ -834,6 +838,16 @@ func (c *v3Conn) sendErrorWithCode(errCode string, errCtx sqlbase.SrcCtx, errToS
 
 	c.writeBuf.putErrFieldMsg(serverErrFieldSeverity)
 	c.writeBuf.writeTerminatedString("ERROR")
+
+	if detail != "" {
+		c.writeBuf.putErrFieldMsg(serverErrFileldDetail)
+		c.writeBuf.writeTerminatedString(detail)
+	}
+
+	if hint != "" {
+		c.writeBuf.putErrFieldMsg(serverErrFileldHint)
+		c.writeBuf.writeTerminatedString(hint)
+	}
 
 	c.writeBuf.putErrFieldMsg(serverErrFieldSQLState)
 	c.writeBuf.writeTerminatedString(errCode)
@@ -1037,7 +1051,7 @@ func (c *v3Conn) copyIn(columns []sql.ResultColumn) error {
 			// Spec says to "ignore Flush and Sync messages received during copy-in mode".
 
 		default:
-			return c.sendErrorWithCode(pgerror.CodeProtocolViolationError, sqlbase.MakeSrcCtx(0),
+			return c.sendErrorWithCode(pgerror.CodeProtocolViolationError, "", "", sqlbase.MakeSrcCtx(0),
 				fmt.Sprintf("unrecognized client message type %s", typ))
 		}
 		for _, res := range sr.ResultList {

--- a/pkg/sql/rename.go
+++ b/pkg/sql/rename.go
@@ -90,12 +90,13 @@ func (p *planner) RenameDatabase(n *parser.RenameDatabase) (planNode, error) {
 				if err != nil {
 					log.Warningf(p.ctx(), "Unable to retrieve fully-qualified name of view %d: %v",
 						viewDesc.ID, err)
-					return nil, sqlbase.NewDependentObjectError(
-						"cannot rename database because a view depends on table %q", tbDesc.Name)
+					msg := fmt.Sprintf("cannot rename database because a view depends on table %q", tbDesc.Name)
+					return nil, sqlbase.NewDependentObjectError(msg, "")
 				}
 			}
-			return nil, sqlbase.NewDependentObjectError(
-				"cannot rename database because view %q depends on table %q", viewName, tbDesc.Name)
+			msg := fmt.Sprintf("cannot rename database because view %q depends on table %q", viewName, tbDesc.Name)
+			hint := fmt.Sprintf("you can drop %s instead.", viewName)
+			return nil, sqlbase.NewDependentObjectError(msg, hint)
 		}
 	}
 
@@ -452,10 +453,13 @@ func (p *planner) dependentViewRenameError(
 		viewName, err = p.getQualifiedTableName(viewDesc)
 		if err != nil {
 			log.Warningf(p.ctx(), "unable to retrieve name of view %d: %v", viewID, err)
-			return sqlbase.NewDependentObjectError("cannot rename %s %q because a view depends on it",
+			msg := fmt.Sprintf("cannot rename %s %q because a view depends on it",
 				typeName, objName)
+			return sqlbase.NewDependentObjectError(msg, "")
 		}
 	}
-	return sqlbase.NewDependentObjectError("cannot rename %s %q because view %q depends on it",
+	msg := fmt.Sprintf("cannot rename %s %q because view %q depends on it",
 		typeName, objName, viewName)
+	hint := fmt.Sprintf("you can drop %s instead.", viewName)
+	return sqlbase.NewDependentObjectError(msg, hint)
 }


### PR DESCRIPTION
Fixes #10668

I add some hints and some details according to PG.

I think maybe we should refactor `pkg/sql/sqlbase/errors.go`, just move all the `msg`, `code` filed from `ErrorWithPGCode` to the struct`errData`.

cc @nvanbenschoten.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12401)
<!-- Reviewable:end -->