### PR TITLE
storage: Really deflake TestStoreRangeSystemSplits

### DIFF
--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -158,8 +158,6 @@ func createTestStoreWithEngine(
 	storeCfg.Transport = storage.NewDummyRaftTransport()
 	// TODO(bdarnell): arrange to have the transport closed.
 	store := storage.NewStore(storeCfg, eng, nodeDesc)
-	// Disable consistency queue because it uses NodeLiveness which we aren't initializing.
-	store.SetConsistencyQueueActive(false)
 	if bootstrap {
 		if err := store.Bootstrap(roachpb.StoreIdent{NodeID: 1, StoreID: 1}); err != nil {
 			t.Fatal(err)

--- a/pkg/storage/consistency_queue.go
+++ b/pkg/storage/consistency_queue.go
@@ -72,13 +72,15 @@ func (q *consistencyQueue) shouldQueue(
 			return false, 0
 		}
 	}
-	// Check if all replicas are live.
-	for _, rep := range repl.Desc().Replicas {
-		if live, err := repl.store.cfg.NodeLiveness.IsLive(rep.NodeID); err != nil {
-			log.ErrEventf(ctx, "node %d liveness failed: %s", rep.NodeID, err)
-			return false, 0
-		} else if !live {
-			return false, 0
+	// Check if all replicas are live. Some tests run without a NodeLiveness configured.
+	if repl.store.cfg.NodeLiveness != nil {
+		for _, rep := range repl.Desc().Replicas {
+			if live, err := repl.store.cfg.NodeLiveness.IsLive(rep.NodeID); err != nil {
+				log.ErrEventf(ctx, "node %d liveness failed: %s", rep.NodeID, err)
+				return false, 0
+			} else if !live {
+				return false, 0
+			}
 		}
 	}
 	return true, priority

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -154,11 +154,6 @@ func (s *Store) SetSplitQueueActive(active bool) {
 	s.setSplitQueueActive(active)
 }
 
-// SetConsistencyQueueActive enables or disables the consistency queue.
-func (s *Store) SetConsistencyQueueActive(active bool) {
-	s.setConsistencyQueueActive(active)
-}
-
 // SetReplicaScannerActive enables or disables the scanner. Note that while
 // inactive, removals are still processed.
 func (s *Store) SetReplicaScannerActive(active bool) {

--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -323,7 +323,7 @@ func (bq *baseQueue) MaybeAdd(repl *Replica, now hlc.Timestamp) {
 	bq.mu.Lock()
 	defer bq.mu.Unlock()
 
-	if bq.mu.stopped {
+	if bq.mu.stopped && bq.mu.disabled {
 		return
 	}
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3984,9 +3984,6 @@ func (s *Store) setSplitQueueActive(active bool) {
 func (s *Store) setTimeSeriesMaintenanceQueueActive(active bool) {
 	s.tsMaintenanceQueue.SetDisabled(!active)
 }
-func (s *Store) setConsistencyQueueActive(active bool) {
-	s.consistencyQueue.SetDisabled(!active)
-}
 func (s *Store) setScannerActive(active bool) {
 	s.scanner.SetDisabled(!active)
 }


### PR DESCRIPTION
The fix in #12224 did nothing because disabling the queue prevents calls
to process() but left the calls to shouldQueue, which were crashing.
Disabling a queue now prevents calls to shouldQueue.

consistencyQueue.shouldQueue is now robust against a missing
NodeLiveness instead of requiring all tests that may omit NodeLiveness
to explicitly disable the queue.

Fixes #12248

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12404)
<!-- Reviewable:end -->
