### PR TITLE
util: improve smalltrace output

### DIFF
--- a/pkg/util/smalltrace.go
+++ b/pkg/util/smalltrace.go
@@ -17,6 +17,7 @@
 package util
 
 import (
+	"fmt"
 	"runtime"
 	"strings"
 )
@@ -27,13 +28,17 @@ func GetSmallTrace(skip int) string {
 	pc := make([]uintptr, 5)
 	nCallers := runtime.Callers(skip, pc[:])
 	callers := make([]string, nCallers)
+	frames := runtime.CallersFrames(pc)
 
 	for i := range callers {
-		callers[i] = strings.TrimPrefix(
-			runtime.FuncForPC(pc[i]).Name(),
-			"github.com/cockroachdb/cockroach/pkg/",
-		)
+		f, more := frames.Next()
+		if !more {
+			break
+		}
+
+		callers[i] = fmt.Sprintf("%s:%d",
+			strings.TrimPrefix(f.Function, "github.com/cockroachdb/cockroach/pkg/"), f.Line)
 	}
 
-	return strings.Join(callers, ":")
+	return strings.Join(callers, ",")
 }

--- a/pkg/util/smalltrace_test.go
+++ b/pkg/util/smalltrace_test.go
@@ -23,7 +23,7 @@ import (
 
 func testSmallTrace2(t *testing.T) {
 	s := GetSmallTrace(2)
-	if !strings.Contains(s, "TestGenerateSmallTrace") {
+	if !strings.Contains(s, "util.testSmallTrace:32,util.TestGenerateSmallTrace:36") {
 		t.Fatalf("trace not generated properly: %q", s)
 	}
 }


### PR DESCRIPTION
This improves the output of `-vmodule=mem_usage=2` by adding line numbers to the memory account stack trace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12411)
<!-- Reviewable:end -->
