### PR TITLE
distsql: fix WaitGroup race

### DIFF
--- a/pkg/sql/distsql/flow.go
+++ b/pkg/sql/distsql/flow.go
@@ -342,13 +342,15 @@ func (f *Flow) Start(doneFn func()) {
 		f.Context, 1, "starting (%d processors, %d outboxes)", len(f.outboxes), len(f.processors),
 	)
 	f.status = FlowRunning
+
+	// Once we call RegisterFlow, the inbound streams become accessible; we must
+	// set up the WaitGroup counter before.
+	f.waitGroup.Add(len(f.inboundStreams) + len(f.outboxes) + len(f.processors))
+
 	f.flowRegistry.RegisterFlow(f.id, f, f.inboundStreams)
 	if log.V(1) {
 		log.Infof(f.Context, "registered flow %s", f.id.Short())
 	}
-	f.waitGroup.Add(len(f.inboundStreams))
-	f.waitGroup.Add(len(f.outboxes))
-	f.waitGroup.Add(len(f.processors))
 	for _, o := range f.outboxes {
 		o.start(&f.waitGroup)
 	}


### PR DESCRIPTION
We first register the flow, then set up the WaitGroup counter. This is a race
because once we register the flow, inbound streams can connect (in fact, there
may be inbound streams waiting for the flow to be registered which will get
woken up immediately). Fixing by reversing the order.

Fixes #12406.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12412)
<!-- Reviewable:end -->
