### PR TITLE
distsql: fix join expression in planning 

### DIFF
--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1661,8 +1661,9 @@ func DatumTypeToColumnType(ptyp parser.Type) ColumnType {
 		if t, ok := ptyp.(parser.TCollatedString); ok {
 			ctyp.Kind = ColumnType_COLLATEDSTRING
 			ctyp.Locale = &t.Locale
+		} else {
+			panic(fmt.Sprintf("unsupported result type: %s", ptyp))
 		}
-		panic(fmt.Sprintf("unsupported result type: %s", ptyp))
 	}
 	return ctyp
 }


### PR DESCRIPTION
Forgot to remap ordinal references in the join expression. Logic tests with `COCKROACH_DISTSQL_MODE=on` pass again.

Any thoughts on making a `Logic` test run in DISTSQL mode as part of the tests? I didn't do it because I hate to add 20-30s to `make test`, I think it might be time to put tests into groups (e.g. must-run vs only-run-if-you-changed-this-package).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12423)
<!-- Reviewable:end -->
