### PR TITLE
storage: deflake TestRefreshPendingCommands

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -967,17 +967,25 @@ func TestRefreshPendingCommands(t *testing.T) {
 			mtc.stopStore(0)
 			mtc.restartStore(0)
 
+			// Disable node liveness heartbeats which can reacquire leases when we're
+			// trying to expire them. We pause liveness heartbeats here after node 0
+			// was restarted (which creates a new NodeLiveness).
+			pauseNodeLivenessHeartbeats(mtc, true)
+
 			// Expire existing leases (i.e. move the clock forward, but don't
 			// increment epochs). This allows node 2 to grab the lease later
 			// in the test.
-			mtc.expireLeasesWithoutIncrementingEpochs()
-			// Drain leases from nodes 0 and 1 to prevent them from grabbing any new
-			// leases.
-			for i := 0; i < 2; i++ {
-				if err := mtc.stores[i].DrainLeases(true); err != nil {
-					t.Fatalf("store %d: %v", i, err)
+			testutils.SucceedsSoon(t, func() error {
+				mtc.expireLeasesWithoutIncrementingEpochs()
+				// Drain leases from nodes 0 and 1 to prevent them from grabbing any new
+				// leases.
+				for i := 0; i < 2; i++ {
+					if err := mtc.stores[i].DrainLeases(true); err != nil {
+						return errors.Wrapf(err, "store %d", i)
+					}
 				}
-			}
+				return nil
+			})
 
 			// Restart node 2 and wait for the snapshot to be applied. Note that
 			// waitForValues reads directly from the engine and thus isn't executing


### PR DESCRIPTION
Node liveness heartbeats were causing a range lease to be reacquired
when the test was waiting for them to be drained. Due to the manual
clock, the draining would never properly complete.

Fixes #11771

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12425)
<!-- Reviewable:end -->
