### PR TITLE
sql: correctly add delay to schema changer in async path

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -843,23 +843,24 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 					if timeutil.Since(sc.execAfter) > 0 {
 						err := sc.exec()
 						if err != nil {
-							if err == errExistingSchemaChangeLease {
-							} else if err == sqlbase.ErrDescriptorNotFound {
+							if err == sqlbase.ErrDescriptorNotFound {
 								// Someone deleted this table. Don't try to run the schema
 								// changer again. Note that there's no gossip update for the
 								// deletion which would remove this schemaChanger.
 								delete(s.schemaChangers, tableID)
-							} else {
+								break
+							} else if err != errExistingSchemaChangeLease {
 								// We don't need to act on integrity
 								// constraints violations because exec()
 								// purges mutations that violate integrity
 								// constraints.
-								log.Warningf(context.TODO(), "Error executing schema change: %s", err)
+								log.Warningf(context.TODO(), "error executing schema change: %s", err)
 							}
 						}
 						// Advance the execAfter time so that this schema
 						// changer doesn't get called again for a while.
 						sc.execAfter = timeutil.Now().Add(delay)
+						s.schemaChangers[tableID] = sc
 					}
 					// Only attempt to run one schema changer.
 					break

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -333,7 +333,10 @@ func TestAsyncSchemaChanger(t *testing.T) {
 			SyncFilter: func(tscc csql.TestingSchemaChangerCollection) {
 				tscc.ClearSchemaChangers()
 			},
-			AsyncExecQuickly: true,
+			// Speed up evaluation of async schema changes.
+			AsyncExecDelay: func() time.Duration {
+				return 20 * time.Millisecond
+			},
 		},
 	}
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
@@ -1168,7 +1171,9 @@ func TestSchemaChangePurgeFailure(t *testing.T) {
 			},
 			// Speed up evaluation of async schema changes so that it
 			// processes a purged schema change quickly.
-			AsyncExecQuickly:  true,
+			AsyncExecDelay: func() time.Duration {
+				return 20 * time.Millisecond
+			},
 			BackfillChunkSize: chunkSize,
 		},
 	}
@@ -1284,7 +1289,10 @@ func TestSchemaChangeReverseMutations(t *testing.T) {
 				}
 				return nil
 			},
-			AsyncExecQuickly:  true,
+			// Speed up evaluation of async schema changes.
+			AsyncExecDelay: func() time.Duration {
+				return 20 * time.Millisecond
+			},
 			BackfillChunkSize: chunkSize,
 		},
 	}

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -483,6 +483,9 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 				break
 			}
 			if err := sc.exec(); err != nil {
+				if err != errExistingSchemaChangeLease {
+					log.Warningf(ctx, "error executing schema change: %s", err)
+				}
 				if isSchemaChangeRetryError(err) {
 					// Try again
 					continue
@@ -498,7 +501,6 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 				if scEntry.epoch == scc.curGroupNum {
 					results[scEntry.idx] = Result{Err: err}
 				}
-				log.Warningf(ctx, "error executing schema change: %s", err)
 			}
 			break
 		}


### PR DESCRIPTION
improve logging when schema change fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12447)
<!-- Reviewable:end -->
