### PR TITLE
storage: fix lease verification of lease request commands

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -987,15 +987,33 @@ func TestRefreshPendingCommands(t *testing.T) {
 				return nil
 			})
 
+			if !c.DisableRefreshReasonNewLeader {
+				// Wait for range 1 to have a leader again. When node 3 restarts, it
+				// might become aware of the leader while the leader itself is not
+				// sure. Detecting leadership change via changes to SoftState.Lead is
+				// somewhat less robust than other refresh reasons but used because it
+				// can often detect a new leader earlier.
+				testutils.SucceedsSoon(t, func() error {
+					if status := mtc.stores[0].RaftStatus(1); status != nil && status.SoftState.Lead != 0 {
+						return nil
+					}
+					return errors.New("no leader for range")
+				})
+			}
+
 			// Restart node 2 and wait for the snapshot to be applied. Note that
 			// waitForValues reads directly from the engine and thus isn't executing
 			// a Raft command.
+			log.Infof(context.Background(), "restarting node")
 			mtc.restartStore(2)
+			pauseNodeLivenessHeartbeats(mtc, true)
+
 			mtc.waitForValues(roachpb.Key("a"), []int64{10, 10, 10})
 
 			// Send an increment to the restarted node. If we don't refresh pending
 			// commands appropriately, the range lease command will not get
 			// re-proposed when we discover the new leader.
+			log.Infof(context.Background(), "sending increment")
 			if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[2]), incArgs); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2369,7 +2369,7 @@ func defaultSubmitProposalLocked(r *Replica, p *ProposalData) error {
 
 	return r.withRaftGroupLocked(true, func(raftGroup *raft.RawNode) (bool, error) {
 		if log.V(4) {
-			log.Infof(ctx, "proposing command %x", p.idKey)
+			log.Infof(ctx, "proposing command %x: %s", p.idKey, p.Request.Summary())
 		}
 		// We're proposing a command so there is no need to wake the leader if we
 		// were quiesced.


### PR DESCRIPTION
Exalate commented:

**Describe the problem**

A [PR](https://github.com/cockroachdb/cockroach/issues/71102) was merged and released in CRDB v21.2.0 that added a check to the client cert authentication that ensured that the CN matches the username of the user we are authenticating as. It would be good to document this change in the release notes for 21.2.0 for others who may encounter this change.

**To Reproduce**

While less than stellar, we had a cron job that was using the node certificate bundle to authenticate as the root user. While this isn't optimal, upgrading our clusters to 21.2.0 suddenly broke our job. After some research, we found that the PR for issue 711202 changed the check, and switching to use the root user cert package instead resolved the issue.

**Expected behavior**
The change to validate the CN of the certificate bundle against the username should be documented for anyone who might encounter this in the future.

**Additional data / screenshots**
If the problem is SQL-related, include a copy of the SQL query and the schema
of the supporting tables.

If a node in your cluster encountered a fatal error, supply the contents of the
log directories (at minimum of the affected node(s), but preferably all nodes).

Note that log files can contain confidential information. Please continue
creating this issue, but contact support@cockroachlabs.com to submit the log
files in private.

If applicable, add screenshots to help explain your problem.

**Environment:**
 - CockroachDB version 21.1.9 upgraded to 21.2.0
 - Server OS: Linux
 - Client App: JDBC

**Additional context**
A cron job using the node certificate bundle to authenticate as root failed to authenticate suddenly after the upgrade to v21.2.0


***
If you all welcome outside PRs to documentation, simply point me in the right direction and I am happy to give it a shot :D
***


Jira Issue: DOC-1862

Jira issue: CRDB-11396