### PR TITLE
server: Skip TestSystemConfigGossip

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -390,6 +390,8 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 
 func TestSystemConfigGossip(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("#12351")
+
 	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop()
 	ts := s.(*TestServer)


### PR DESCRIPTION
It got flakier after adding the SQL migrations on startup. Skip it until
the flakiness is resolved.

I'll work on this ASAP.

@irfansharif

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12451)
<!-- Reviewable:end -->
