### PR TITLE
distsql: don't use collated strings in TestHashRouter

### DIFF
--- a/pkg/sql/distsql/routers_test.go
+++ b/pkg/sql/distsql/routers_test.go
@@ -35,7 +35,19 @@ func TestHashRouter(t *testing.T) {
 
 	// Generate tables of possible values for each column; we have fewer possible
 	// values than rows to guarantee many occurrences of each value.
-	vals := sqlbase.RandEncDatumSlices(rng, numCols, numRows/10)
+	// TODO(radu): we don't support collated strings yet, as equal strings can
+	// have different key encodings. When we support them, we should revert to
+	// using RandEncDatumSlices.
+	vals := make([][]sqlbase.EncDatum, numCols)
+	for i := range vals {
+		for {
+			vals[i] = sqlbase.RandEncDatumSlice(rng, numRows/10)
+			// If we generated collated string, try again.
+			if vals[i][0].Type.Kind != sqlbase.ColumnType_COLLATEDSTRING {
+				break
+			}
+		}
+	}
 
 	testCases := []struct {
 		hashColumns []uint32


### PR DESCRIPTION
Fixes #12435.

CC @eisenstatdavid

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12455)
<!-- Reviewable:end -->
