### PR TITLE
storage: update capacity score to contain range counts

### DIFF
--- a/pkg/storage/rule_solver_test.go
+++ b/pkg/storage/rule_solver_test.go
@@ -77,7 +77,7 @@ func TestCandidateSelection(t *testing.T) {
 
 	type scoreTuple struct {
 		constraint int
-		capacity   int
+		rangeCount int
 	}
 	genCandidates := func(scores []scoreTuple, idShift int) candidateList {
 		var cl candidateList
@@ -87,7 +87,7 @@ func TestCandidateSelection(t *testing.T) {
 					StoreID: roachpb.StoreID(i + idShift),
 				},
 				constraintScore: float64(score.constraint),
-				capacityScore:   float64(score.capacity),
+				rangeCount:      score.rangeCount,
 				valid:           true,
 			})
 		}
@@ -101,7 +101,7 @@ func TestCandidateSelection(t *testing.T) {
 			if i != 0 {
 				buffer.WriteRune(',')
 			}
-			buffer.WriteString(fmt.Sprintf("%d:%d", int(c.constraintScore), int(c.capacityScore)))
+			buffer.WriteString(fmt.Sprintf("%d:%d", int(c.constraintScore), c.rangeCount))
 		}
 		return buffer.String()
 	}
@@ -121,18 +121,18 @@ func TestCandidateSelection(t *testing.T) {
 			bad:        scoreTuple{0, 0},
 		},
 		{
-			candidates: []scoreTuple{{0, 1}, {0, 0}},
-			best:       []scoreTuple{{0, 1}, {0, 0}},
-			worst:      []scoreTuple{{0, 1}, {0, 0}},
-			good:       scoreTuple{0, 1},
-			bad:        scoreTuple{0, 0},
+			candidates: []scoreTuple{{0, 0}, {0, 1}},
+			best:       []scoreTuple{{0, 0}, {0, 1}},
+			worst:      []scoreTuple{{0, 0}, {0, 1}},
+			good:       scoreTuple{0, 0},
+			bad:        scoreTuple{0, 1},
 		},
 		{
-			candidates: []scoreTuple{{0, 2}, {0, 1}, {0, 0}},
-			best:       []scoreTuple{{0, 2}, {0, 1}, {0, 0}},
-			worst:      []scoreTuple{{0, 2}, {0, 1}, {0, 0}},
+			candidates: []scoreTuple{{0, 0}, {0, 1}, {0, 2}},
+			best:       []scoreTuple{{0, 0}, {0, 1}, {0, 2}},
+			worst:      []scoreTuple{{0, 0}, {0, 1}, {0, 2}},
 			good:       scoreTuple{0, 1},
-			bad:        scoreTuple{0, 0},
+			bad:        scoreTuple{0, 2},
 		},
 		{
 			candidates: []scoreTuple{{1, 0}, {0, 1}},
@@ -142,25 +142,25 @@ func TestCandidateSelection(t *testing.T) {
 			bad:        scoreTuple{0, 1},
 		},
 		{
-			candidates: []scoreTuple{{1, 0}, {0, 2}, {0, 1}},
+			candidates: []scoreTuple{{1, 0}, {0, 1}, {0, 2}},
 			best:       []scoreTuple{{1, 0}},
-			worst:      []scoreTuple{{0, 2}, {0, 1}},
+			worst:      []scoreTuple{{0, 1}, {0, 2}},
 			good:       scoreTuple{1, 0},
-			bad:        scoreTuple{0, 1},
+			bad:        scoreTuple{0, 2},
 		},
 		{
-			candidates: []scoreTuple{{1, 1}, {1, 0}, {0, 2}},
-			best:       []scoreTuple{{1, 1}, {1, 0}},
+			candidates: []scoreTuple{{1, 0}, {1, 1}, {0, 2}},
+			best:       []scoreTuple{{1, 0}, {1, 1}},
 			worst:      []scoreTuple{{0, 2}},
-			good:       scoreTuple{1, 1},
+			good:       scoreTuple{1, 0},
 			bad:        scoreTuple{0, 2},
 		},
 		{
-			candidates: []scoreTuple{{1, 1}, {1, 0}, {0, 3}, {0, 2}},
-			best:       []scoreTuple{{1, 1}, {1, 0}},
-			worst:      []scoreTuple{{0, 3}, {0, 2}},
-			good:       scoreTuple{1, 1},
-			bad:        scoreTuple{0, 2},
+			candidates: []scoreTuple{{1, 0}, {1, 1}, {0, 2}, {0, 3}},
+			best:       []scoreTuple{{1, 0}, {1, 1}},
+			worst:      []scoreTuple{{0, 2}, {0, 3}},
+			good:       scoreTuple{1, 0},
+			bad:        scoreTuple{0, 3},
 		},
 	}
 
@@ -199,7 +199,7 @@ func TestCandidateSelection(t *testing.T) {
 			if good == nil {
 				t.Fatalf("candidate for store %d not found in candidate list: %s", goodStore.StoreID, cl)
 			}
-			actual := scoreTuple{int(good.constraintScore), int(good.capacityScore)}
+			actual := scoreTuple{int(good.constraintScore), good.rangeCount}
 			if actual != tc.good {
 				t.Errorf("expected:%v actual:%v", tc.good, actual)
 			}
@@ -213,7 +213,7 @@ func TestCandidateSelection(t *testing.T) {
 			if bad == nil {
 				t.Fatalf("candidate for store %d not found in candidate list: %s", badStore.StoreID, cl)
 			}
-			actual := scoreTuple{int(bad.constraintScore), int(bad.capacityScore)}
+			actual := scoreTuple{int(bad.constraintScore), bad.rangeCount}
 			if actual != tc.bad {
 				t.Errorf("expected:%v actual:%v", tc.bad, actual)
 			}
@@ -228,57 +228,57 @@ func TestBetterThan(t *testing.T) {
 		{
 			valid:           true,
 			constraintScore: 1,
-			capacityScore:   1,
+			rangeCount:      0,
 		},
 		{
 			valid:           true,
 			constraintScore: 1,
-			capacityScore:   1,
+			rangeCount:      0,
 		},
 		{
 			valid:           true,
 			constraintScore: 1,
-			capacityScore:   0,
+			rangeCount:      1,
 		},
 		{
 			valid:           true,
 			constraintScore: 1,
-			capacityScore:   0,
+			rangeCount:      1,
 		},
 		{
 			valid:           true,
 			constraintScore: 0,
-			capacityScore:   1,
+			rangeCount:      0,
 		},
 		{
 			valid:           true,
 			constraintScore: 0,
-			capacityScore:   1,
+			rangeCount:      0,
 		},
 		{
 			valid:           true,
 			constraintScore: 0,
-			capacityScore:   0,
+			rangeCount:      1,
 		},
 		{
 			valid:           true,
 			constraintScore: 0,
-			capacityScore:   0,
+			rangeCount:      1,
 		},
 		{
 			valid:           false,
 			constraintScore: 1,
-			capacityScore:   0.5,
+			rangeCount:      0,
 		},
 		{
 			valid:           false,
 			constraintScore: 0,
-			capacityScore:   0.5,
+			rangeCount:      0,
 		},
 		{
 			valid:           false,
 			constraintScore: 0,
-			capacityScore:   0,
+			rangeCount:      1,
 		},
 	}
 
@@ -631,8 +631,7 @@ func TestDiversityRemovalScore(t *testing.T) {
 	}
 }
 
-// TestCapacityScore tests both capacityScore and maxCapacityCheck.
-func TestCapacityScore(t *testing.T) {
+func TestMaxCapacity(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	expectedCheck := map[roachpb.StoreID]bool{
@@ -641,17 +640,8 @@ func TestCapacityScore(t *testing.T) {
 		testStoreUSb:    true,
 		testStoreEurope: true,
 	}
-	expectedScore := map[roachpb.StoreID]float64{
-		testStoreUSa15:  1.0 / 100.0,
-		testStoreUSa1:   1.0,
-		testStoreUSb:    1.0 / 51.0,
-		testStoreEurope: 1.0 / 41.0,
-	}
 
 	for _, s := range testStores {
-		if e, a := expectedScore[s.StoreID], capacityScore(s); e != a {
-			t.Errorf("store %d expected capacity score: %.2f, actual %.2f", s.StoreID, e, a)
-		}
 		if e, a := expectedCheck[s.StoreID], maxCapacityCheck(s); e != a {
 			t.Errorf("store %d expected max capacity check: %t, actual %t", s.StoreID, e, a)
 		}


### PR DESCRIPTION
This gets rid of the wired 1/(1+rangecount) that was there before. If a
more complex scoring is required, it can be added then.

Part of #10275.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12458)
<!-- Reviewable:end -->
