### PR TITLE
server: Fix test flake by adding a SkipSystemMigrations option

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/gogo/protobuf/jsonpb"
+	"github.com/pkg/errors"
 )
 
 var nodeTestBaseContext = testutils.NewNodeTestBaseContext()
@@ -413,33 +414,7 @@ func TestSystemConfigGossip(t *testing.T) {
 		t.Fatal("did not receive gossip message")
 	}
 
-	// Try a plain KV write first.
-	if err := kvDB.Put(ctx, key, valAt(0)); err != nil {
-		t.Fatal(err)
-	}
-
-	// Now do it as part of a transaction, but without the trigger set.
-	if err := kvDB.Txn(ctx, func(txn *client.Txn) error {
-		return txn.Put(key, valAt(1))
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	// Gossip channel should be dormant.
-	// TODO(tschottdorf): This test is likely flaky. Why can't some other
-	// process trigger gossip? It seems that a new range lease being
-	// acquired will gossip a new system config since the hash changed and fail
-	// the test (seen in practice during some buggy WIP).
-	var systemConfig config.SystemConfig
-	select {
-	case <-resultChan:
-		systemConfig, _ = ts.gossip.GetSystemConfig()
-		t.Fatalf("unexpected message received on gossip channel: %v", systemConfig)
-
-	case <-time.After(50 * time.Millisecond):
-	}
-
-	// This time mark the transaction as having a Gossip trigger.
+	// Write a system key with the transaction marked as having a Gossip trigger.
 	if err := kvDB.Txn(ctx, func(txn *client.Txn) error {
 		txn.SetSystemConfigTrigger()
 		return txn.Put(key, valAt(2))
@@ -447,35 +422,42 @@ func TestSystemConfigGossip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// New system config received.
-	select {
-	case <-resultChan:
-		systemConfig, _ = ts.gossip.GetSystemConfig()
+	// This has to be wrapped in a SucceedSoon because system migrations on the
+	// testserver's startup can trigger system config updates without the key we
+	// wrote.
+	testutils.SucceedsSoon(t, func() error {
+		// New system config received.
+		var systemConfig config.SystemConfig
+		select {
+		case <-resultChan:
+			systemConfig, _ = ts.gossip.GetSystemConfig()
 
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("did not receive gossip message")
-	}
-
-	// Now check the new config.
-	var val *roachpb.Value
-	for _, kv := range systemConfig.Values {
-		if bytes.Equal(key, kv.Key) {
-			val = &kv.Value
-			break
+		case <-time.After(500 * time.Millisecond):
+			return errors.Errorf("did not receive gossip message")
 		}
-	}
-	if val == nil {
-		t.Fatal("key not found in gossiped info")
-	}
 
-	// Make sure the returned value is valAt(2).
-	got := new(sqlbase.DatabaseDescriptor)
-	if err := val.GetProto(got); err != nil {
-		t.Fatal(err)
-	}
-	if expected := valAt(2); !reflect.DeepEqual(got, expected) {
-		t.Fatalf("mismatch: expected %+v, got %+v", *expected, *got)
-	}
+		// Now check the new config.
+		var val *roachpb.Value
+		for _, kv := range systemConfig.Values {
+			if bytes.Equal(key, kv.Key) {
+				val = &kv.Value
+				break
+			}
+		}
+		if val == nil {
+			return errors.Errorf("key not found in gossiped info")
+		}
+
+		// Make sure the returned value is valAt(2).
+		got := new(sqlbase.DatabaseDescriptor)
+		if err := val.GetProto(got); err != nil {
+			return err
+		}
+		if expected := valAt(2); !reflect.DeepEqual(got, expected) {
+			return errors.Errorf("mismatch: expected %+v, got %+v", *expected, *got)
+		}
+		return nil
+	})
 }
 
 func checkOfficialize(t *testing.T, network, oldAddrString, newAddrString, expAddrString string) {


### PR DESCRIPTION
I was hoping we wouldn't have to skip system migrations in tests, but the other option (removing the dormancy check and wrapping the rest of the test in a `testutils.SucceedsSoon` to make it resilient to updates that include a migration but not the key written by the test) makes the test fairly obtuse in my opinion. What do you think?

Fixes #12351

@tamird

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12459)
<!-- Reviewable:end -->
