### PR TITLE
storage: add comment about RaftCommand.OriginLease

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -3255,6 +3255,8 @@ func (r *Replica) processRaftCommand(
 	// held, and can be used, or is expired, and can be replaced.
 	// Verify checks that the lease has not been modified since proposal
 	// due to Raft delays / reorderings.
+	// To understand why this lease verification is necessary, see comments on the
+	// origin_lease field in the proto.
 	//
 	// TODO(spencer): remove the special-casing for the pre-epoch range
 	// leases.

--- a/pkg/storage/storagebase/proposer_kv.pb.go
+++ b/pkg/storage/storagebase/proposer_kv.pb.go
@@ -150,6 +150,16 @@ type RaftCommand struct {
 	// If the command was proposed prior to the introduction of epoch leases,
 	// origin_lease will be nil, but the combination of origin_replica and
 	// the request timestamp are used to verify an expiration-based lease.
+	//
+	// To see why lease verification downstream of Raft is required, consider the
+	// following example:
+	// - replica 1 receives a client request for a write
+	// - replica 1 checks the lease; the write is permitted
+	// - replica 1 proposes the command
+	// - time passes, replica 2 commits a new lease
+	// - the command applies on replica 1
+	// - replica 2 serves anomalous reads which don't see the write
+	// - the command applies on replica 2
 	OriginLease *cockroach_roachpb1.Lease `protobuf:"bytes,5,opt,name=origin_lease,json=originLease" json:"origin_lease,omitempty"`
 	// When the command is applied, its result is an error if the lease log
 	// counter has already reached (or exceeded) max_lease_index.

--- a/pkg/storage/storagebase/proposer_kv.proto
+++ b/pkg/storage/storagebase/proposer_kv.proto
@@ -121,6 +121,16 @@ message RaftCommand {
   // If the command was proposed prior to the introduction of epoch leases,
   // origin_lease will be nil, but the combination of origin_replica and
   // the request timestamp are used to verify an expiration-based lease.
+  //
+  // To see why lease verification downstream of Raft is required, consider the
+  // following example:
+  // - replica 1 receives a client request for a write
+  // - replica 1 checks the lease; the write is permitted
+  // - replica 1 proposes the command
+  // - time passes, replica 2 commits a new lease
+  // - the command applies on replica 1
+  // - replica 2 serves anomalous reads which don't see the write
+  // - the command applies on replica 2
   optional roachpb.Lease origin_lease = 5;
 
   // When the command is applied, its result is an error if the lease log


### PR DESCRIPTION
... explaining why lease checking downstream of raft is necessary.
Copied example from the epoch leases RFC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12461)
<!-- Reviewable:end -->
