### PR TITLE
storage: always initialize Raft groups on receipt of request

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -3109,3 +3109,59 @@ func TestRangeQuiescence(t *testing.T) {
 		t.Fatalf("%s should be the leader: %s", rep, state)
 	}
 }
+
+// TestInitRaftGroupOnRequest verifies that an uninitialized Raft group
+// is initialized if a request is received, even if the current range
+// lease points to a different replica.
+func TestInitRaftGroupOnRequest(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	mtc := &multiTestContext{}
+	defer mtc.Stop()
+	mtc.Start(t, 2)
+
+	// Split so we can rely on RHS range being quiescent after a restart.
+	// We use UserTableDataMin to avoid having the range activated to
+	// gossip system table data.
+	splitKey := keys.MakeRowSentinelKey(keys.UserTableDataMin)
+	splitArgs := adminSplitArgs(roachpb.KeyMin, splitKey)
+	if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), splitArgs); err != nil {
+		t.Fatal(err)
+	}
+
+	repl := mtc.stores[0].LookupReplica(roachpb.RKey(splitKey), nil)
+	if repl == nil {
+		t.Fatal("replica should not be nil for RHS range")
+	}
+	mtc.replicateRange(repl.RangeID, 1)
+
+	// Find the leaseholder and then restart the test context.
+	lease, _ := repl.GetLease()
+	mtc.restart()
+
+	// Get replica from the store which isn't the leaseholder.
+	storeIdx := int(lease.Replica.StoreID) % len(mtc.stores)
+	if repl = mtc.stores[storeIdx].LookupReplica(roachpb.RKey(splitKey), nil); repl == nil {
+		t.Fatal("replica should not be nil for RHS range")
+	}
+
+	// TODO(spencer): Raft messages seem to turn up
+	// occassionally on restart, which initialize the replica, so
+	// this is not a test failure. Not sure how to work around this
+	// problem.
+	// Verify the raft group isn't initialized yet.
+	if repl.IsRaftGroupInitialized() {
+		log.Errorf(context.TODO(), "expected raft group to be uninitialized")
+	}
+
+	// Send an increment and verify that initializes the Raft group.
+	incArgs := incrementArgs(splitKey, 1)
+	_, pErr := client.SendWrappedWith(
+		context.Background(), mtc.stores[storeIdx], roachpb.Header{RangeID: repl.RangeID}, incArgs,
+	)
+	if _, ok := pErr.GetDetail().(*roachpb.NotLeaseHolderError); !ok {
+		t.Fatalf("expected NotLeaseHolderError; got %s", pErr)
+	}
+	if !repl.IsRaftGroupInitialized() {
+		t.Fatal("expected raft group to be initialized")
+	}
+}

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -3145,7 +3145,7 @@ func TestInitRaftGroupOnRequest(t *testing.T) {
 	}
 
 	// TODO(spencer): Raft messages seem to turn up
-	// occassionally on restart, which initialize the replica, so
+	// occasionally on restart, which initialize the replica, so
 	// this is not a test failure. Not sure how to work around this
 	// problem.
 	// Verify the raft group isn't initialized yet.

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -227,6 +227,12 @@ func (r *Replica) GetRaftLogSize() int64 {
 	return r.mu.raftLogSize
 }
 
+func (r *Replica) IsRaftGroupInitialized() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.mu.internalRaftGroup != nil
+}
+
 // StorePoolNodeLivenessTrue is a NodeLivenessFunc which always returns true.
 func StorePoolNodeLivenessTrue(_ roachpb.NodeID, _ time.Time, _ time.Duration) bool {
 	return true


### PR DESCRIPTION
Previously a Raft group would not load if a request was received for a
replica that didn't hold the lease. On certain restart scenarios, it's
possible for two replicas to hold different leases, where one of the two
is actually behind on Raft. With epoch-based leases and no necessary
expiration, this could lead to `NotLeaseholderError`s pinging back and
forth between the two replicas with uninitialized raft groups.

This change guarantees that the raft group is activated and so no
replica can stubbornly believe the veracity of its lease without also
catching up on Raft.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12465)
<!-- Reviewable:end -->
