### PR TITLE
server: skip logging body of nil response after error

### DIFF
--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -292,10 +292,13 @@ func (s *Server) reportUsage(ctx context.Context) {
 	reportingURL.RawQuery = q.Encode()
 
 	res, err := http.Post(reportingURL.String(), "application/json", b)
-	if err != nil && log.V(2) {
-		// This is probably going to be relatively common in production
-		// environments where network access is usually curtailed.
-		log.Warning(ctx, "Failed to report node usage metrics: ", err)
+
+	if err != nil {
+		if log.V(2) {
+			// This is probably going to be relatively common in production
+			// environments where network access is usually curtailed.
+			log.Warning(ctx, "Failed to report node usage metrics: ", err)
+		}
 		return
 	}
 


### PR DESCRIPTION
When the HTTP client returns an error instead of a valid http response (e.g. due to network errors),
the Response returned is nil, so we'll crash if we attempt to dereference the fields of it, which is
exactly what we do after the 'err' check. The err check should include an early return to prevent this
but that was incorrectly skipped at lower verbosity levels.

Moving the verbosity check to be only around the message, such that the early return in the case of non-nil
err is always hit, should avoid this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12467)
<!-- Reviewable:end -->
