### PR TITLE
storage: Re-enable DisruptiveElection test on propEvalKV

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2383,10 +2383,6 @@ func (errorChannelTestHandler) HandleSnapshot(
 func TestReplicateRemovedNodeDisruptiveElection(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	if storage.ProposerEvaluatedKVEnabled() {
-		t.Skip("#10577")
-	}
-
 	mtc := &multiTestContext{}
 	defer mtc.Stop()
 	mtc.Start(t, 4)


### PR DESCRIPTION
The test now appears stable when run under stress.

Closes #10577

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12468)
<!-- Reviewable:end -->
