### PR TITLE
storage: Deflake TestTransferRaftLeadership

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2894,6 +2894,11 @@ func TestTransferRaftLeadership(t *testing.T) {
 	// and cause leadership to change hands in ways this test doesn't
 	// expect.
 	sc.RaftElectionTimeoutTicks = 100000
+	// This test can rapidly advance the clock via expireLeases(),
+	// which could lead the replication queue to consider a store dead
+	// and remove a replica in the middle of the test. Disable the
+	// replication queue; we'll control replication manually.
+	sc.TestingKnobs.DisableReplicateQueue = true
 	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, numStores)


### PR DESCRIPTION
This test was flaky with propEvalKV because the manual clock could be
advanced fast enough for the replication queue to deem a node dead.
This bug does not appear to be unique to propEvalKV, but for unknown
reasons it has only been observed there.

Fixes #12233

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12470)
<!-- Reviewable:end -->
