### PR TITLE
Update dependencies

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c7659df3c8e53d7ca9210b38bfea490c45476d6cd028c876d6e20b257fcf139c
-updated: 2016-12-13T13:32:44.183863499-05:00
+hash: e0fffc4acc1b902edd5ea6df36166d89f3daf9151dcf841385b3057416fabca8
+updated: 2016-12-19T07:30:11.856809103-05:00
 imports:
 - name: cloud.google.com/go
   version: 9d965e63e8cceb1b5d7977a202f0fcb8866d6525
@@ -44,7 +44,7 @@ imports:
 - name: github.com/cockroachdb/cmux
   version: b64f5908f4945f4b11ed4a0a9d3cc1e23350866d
 - name: github.com/cockroachdb/cockroach-go
-  version: 140a8c585a33363479fceb56093c277032a17894
+  version: ba57380fe1f490388284806affe325d081e62be6
   subpackages:
   - crdb
 - name: github.com/cockroachdb/crlfmt
@@ -56,7 +56,7 @@ imports:
 - name: github.com/codahale/hdrhistogram
   version: 3a0bb77429bd3a61596f5e8a3172445844342120
 - name: github.com/coreos/etcd
-  version: cc37beff3526794df3819654faf6a43d35f2531d
+  version: d62ce55584a064968c11b309f1d57a9c1872bc40
   subpackages:
   - raft
   - raft/raftpb
@@ -65,7 +65,7 @@ imports:
   subpackages:
   - md2man
 - name: github.com/docker/distribution
-  version: 923c7763b0e49cbb9f34da368108e8dde34e009d
+  version: 2d500932f2c7f032d2abc51f2ef940871d541319
   subpackages:
   - digest
   - reference
@@ -163,7 +163,7 @@ imports:
   - protoc-gen-go/plugin
   - ptypes/timestamp
 - name: github.com/google/btree
-  version: 0c3044bc8bada22db67b93f5760fe3f05d6a5c25
+  version: 316fb6d3f031ae8f4d457c6c5186b9e3ded70435
 - name: github.com/google/go-github
   version: 466070b0580728e63bd1a415e0019639e55d7148
   subpackages:
@@ -226,7 +226,7 @@ imports:
 - name: github.com/mattn/go-runewidth
   version: 737072b4e32b7a5018b4a7125da8d12de90e8045
 - name: github.com/mattn/goveralls
-  version: a63d65fe590e2c830e60ad260cde6755ce3482a5
+  version: 61ac1a6b48f7f76ff3d14e00d3192e7dd0b9db91
 - name: github.com/matttproud/golang_protobuf_extensions
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
@@ -248,7 +248,7 @@ imports:
 - name: github.com/olekukonko/tablewriter
   version: bdcc175572fd7abece6c831e643891b9331bc9e7
 - name: github.com/opencontainers/runc
-  version: 083933fb9092a3d65d682ba34a08676104c95462
+  version: 9a1e53eafc0ebef4712b442a0aa53a1a7016a23d
   subpackages:
   - libcontainer/user
 - name: github.com/opentracing/basictracer-go
@@ -297,15 +297,15 @@ imports:
 - name: github.com/Sirupsen/logrus
   version: 881bee4e20a5d11a6a88a5667c6f292072ac1963
 - name: github.com/spf13/cobra
-  version: 9495bc009a56819bdb0ddbc1a373e29c140bc674
+  version: b62566898a99f2db9c68ed0026aa0a052e59678d
   subpackages:
   - doc
 - name: github.com/spf13/pflag
-  version: 5ccb023bc27df288a957c5e994cd44fd19619465
+  version: 25f8b5b07aece3207895bf19f7ab517eb3b22a40
 - name: github.com/StackExchange/wmi
   version: e54cbda6595d7293a7a468ccf9525f6bc8887f99
 - name: github.com/tebeka/go2xunit
-  version: aaee8a42931ce35b4821d9c7cd68f73de70cba3d
+  version: 5856a592616c62734bf27dac02b6b5f076f96ba6
   subpackages:
   - lib
 - name: github.com/VividCortex/ewma
@@ -319,7 +319,7 @@ imports:
   - blowfish
   - ssh/terminal
 - name: golang.org/x/net
-  version: cfae461cedfdcab6e261a26eb77db53695623303
+  version: 45e771701b814666a7eb299e6c7a57d0b1799e91
   subpackages:
   - context
   - context/ctxhttp
@@ -338,12 +338,12 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: 478fcf54317e52ab69f40bb4c7a1520288d7f7ea
+  version: d75a52659825e75fff6158388dddc6a5b04f9ba5
   subpackages:
   - unix
   - windows
 - name: golang.org/x/text
-  version: 47a200a05c8b3fd1b698571caecbb68beb2611ec
+  version: a49bea13b776691cb1b49873e5d8df96ec74831a
   subpackages:
   - collate
   - internal/colltab
@@ -353,7 +353,7 @@ imports:
   - unicode/norm
   - width
 - name: golang.org/x/tools
-  version: 0a14ca4e16cec5dfac9208167b18539631488a10
+  version: dd796641777bce15ee87fb6bea64943b648bdcf3
   subpackages:
   - cmd/goimports
   - cmd/goyacc
@@ -378,7 +378,7 @@ imports:
   - storage/v1
   - transport
 - name: google.golang.org/appengine
-  version: ca59ef35f409df61fa4a5f8290ff289b37eccfb8
+  version: 08a149cfaee099e6ce4be01c0113a78c85ee1dee
   subpackages:
   - internal
   - internal/app_identity
@@ -408,7 +408,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: a5b47d31c556af34a302ce5d659e6fea44d90de0
 - name: honnef.co/go/lint
-  version: 0d04e3c683eb052bf18d889331e846989da97021
+  version: f0b0056a162cdb787050cef0670f175b85625697
   subpackages:
   - lintutil
 - name: honnef.co/go/simple
@@ -416,7 +416,7 @@ imports:
 - name: honnef.co/go/ssa
   version: 1cf7f34afde4f3f9cb9f7b15f8f2727ebcaa179a
 - name: honnef.co/go/staticcheck
-  version: 9f575d2374dfeb3f8da0dd1d8311567cba368fa1
+  version: a1dced908a8310dad6912e6be1c47222097d525c
   subpackages:
   - pure
   - vrp

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,7 @@ import:
   version: 7248742ae7127347a52ab9d215451c213b7b59da
 # etcd pins this via glide, so we must pin harder.
 - package: golang.org/x/net
-  version: cfae461cedfdcab6e261a26eb77db53695623303
+  version: 45e771701b814666a7eb299e6c7a57d0b1799e91
 # used by a long-lived branch. TODO(dt): remove when merged.
 - package: cloud.google.com/go
   version: 9d965e63e8cceb1b5d7977a202f0fcb8866d6525


### PR DESCRIPTION
 - github.com/cockroachdb/cockroach-go: nothing of note.
 - github.com/coreos/etcd: nothing of note.
 - github.com/docker/distribution: nothing of note.
 - github.com/google/btree: nothing of note.
 - github.com/mattn/goveralls: nothing of note.
 - github.com/opencontainers/runc: nothing of note.
 - github.com/spf13/cobra: nothing of note.
 - github.com/spf13/pflag: nothing of note.
 - github.com/tebeka/go2xunit: nothing of note.
 - golang.org/x/net: nothing of note.
 - golang.org/x/sys: nothing of note.
 - golang.org/x/text: nothing of note.
 - golang.org/x/tools: nothing of note.
 - google.golang.org/appengine: nothing of note.
 - honnef.co/go/lint:
   - Process packages in parallel (https://github.com/dominikh/go-lint/commit/f0b0056)
 - honnef.co/go/staticcheck:
   - Performance improvements: (https://github.com/dominikh/go-staticcheck/compare/9f575d2...a1dced9)

This improves `make check` performance from 57.815s to 37.309s per
discussion in https://github.com/dominikh/go-staticcheck/issues/55.

cc @dominikh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12471)
<!-- Reviewable:end -->
