### PR TITLE
sql: detect old sentinel values correctly

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -1332,3 +1332,111 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 		t.Fatalf("expected %d key value pairs, but got %d", e, len(kvs))
 	}
 }
+
+// This test checks backward compatibility with old data that contains
+// sentinel k:v pairs at the start of each table row. Cockroachdb used
+// to write table rows with sentinel values in the past. When a new column
+// is added to such a table with the new column included in the same
+// column family as the primary key columns, the sentinel k:v pairs
+// start representing this new column. This test checks that the sentinel
+// values represent NULL column values, and that an UPDATE to such
+// a column works correctly.
+func TestParseSentinelValueWithNewColumnInSentinelFamily(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	params, _ := createTestServerParams()
+	server, sqlDB, kvDB := serverutils.StartServer(t, params)
+	defer server.Stopper().Stop()
+
+	if _, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test (
+	k INT PRIMARY KEY,
+	FAMILY F1 (k)
+);
+`); err != nil {
+		t.Fatal(err)
+	}
+	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
+	if tableDesc.Families[0].DefaultColumnID != 0 {
+		t.Fatalf("default column id not set properly: %s", tableDesc)
+	}
+
+	// Add some data.
+	const maxValue = 10
+	inserts := make([]string, maxValue+1)
+	for i := range inserts {
+		inserts[i] = fmt.Sprintf(`(%d)`, i)
+	}
+	if _, err := sqlDB.Exec(`INSERT INTO t.test VALUES ` + strings.Join(inserts, ",")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Convert table data created by the above INSERT into sentinel
+	// values. This is done to make the table appear like it were
+	// written in the past when cockroachdb used to write sentinel
+	// values for each table row.
+	startKey := roachpb.Key(keys.MakeTablePrefix(uint32(tableDesc.ID)))
+	kvs, err := kvDB.Scan(
+		context.TODO(),
+		startKey,
+		startKey.PrefixEnd(),
+		maxValue+1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, kv := range kvs {
+		value := roachpb.MakeValueFromBytes(nil)
+		if err := kvDB.Put(context.TODO(), kv.Key, &value); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Add a new column that gets added to column family 0,
+	// updating DefaultColumnID.
+	if _, err := sqlDB.Exec(`ALTER TABLE t.test ADD COLUMN v INT FAMILY F1`); err != nil {
+		t.Fatal(err)
+	}
+	tableDesc = sqlbase.GetTableDescriptor(kvDB, "t", "test")
+	if tableDesc.Families[0].DefaultColumnID != 2 {
+		t.Fatalf("default column id not set properly: %s", tableDesc)
+	}
+
+	// Update one of the rows.
+	const setKey = 5
+	const setVal = maxValue - setKey
+	if _, err := sqlDB.Exec(`UPDATE t.test SET v = $1 WHERE k = $2`, setVal, setKey); err != nil {
+		t.Fatal(err)
+	}
+
+	// The table contains the one updated value and remaining NULL values.
+	rows, err := sqlDB.Query(`SELECT v from t.test`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const eCount = maxValue + 1
+	count := 0
+	for ; rows.Next(); count++ {
+		var val *int
+		if err := rows.Scan(&val); err != nil {
+			t.Errorf("row %d scan failed: %s", count, err)
+			continue
+		}
+		if count == setKey {
+			if val != nil {
+				if setVal != *val {
+					t.Errorf("value = %d, expected %d", *val, setVal)
+				}
+			} else {
+				t.Error("received nil value for column 'v'")
+			}
+		} else if val != nil {
+			t.Error("received non NULL value for column 'v'")
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if eCount != count {
+		t.Fatalf("read the wrong number of rows: e = %d, v = %d", eCount, count)
+	}
+}

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -341,14 +341,13 @@ func (rf *RowFetcher) processValueSingle(
 ) (prettyKey string, prettyValue string, err error) {
 	prettyKey = prettyKeyPrefix
 
+	// If this is the sentinel family, a value is not expected, so we're done.
+	if family.ID == keys.SentinelFamilyID {
+		return "", "", nil
+	}
+
 	colID := family.DefaultColumnID
 	if colID == 0 {
-		// If this is the sentinel family, a value is not expected, so we're done.
-		// Otherwise, this means something went wrong in the TableDescriptor
-		// bookkeeping.
-		if family.ID == keys.SentinelFamilyID {
-			return "", "", nil
-		}
 		return "", "", errors.Errorf("single entry value with no default column id")
 	}
 


### PR DESCRIPTION
When a new column gets added to Family 0 it is set as the
default_column_id for family 0. When an old sentinel value is
read using this new family descriptor it should ignore
default_column_id. The default_column_id is
only be used for non 0 family values. Family 0 values are assumed
to be either sentinel values or of type VALUE_TUPLE.

Family 0 is always stored as a VALUE_TUPLE type and unfortunately
sentinel values are not stored as this type. When a sentinel value
is updated to include a non primary column, it is correctly upgraded
to a non-sentinel value of type VALUE_TUPLE.

Added TestParseSentinelValueWithNewColumnInSentinelFamily

fixes #12415

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12475)
<!-- Reviewable:end -->
