### PR TITLE
storage: deflake TestRefreshPendingCommands

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -910,9 +910,14 @@ func TestRefreshPendingCommands(t *testing.T) {
 	// insufficient on its own. In addition, there is a fourth reproposal
 	// mechanism (reasonNewLeaderOrConfigChange) which is not relevant to this
 	// scenario.
+	//
+	// We don't test with only reasonNewLeader because that mechanism is less
+	// robust than refreshing due to snapshot or ticks. In particular, it is
+	// possible for node 3 to propose the RequestLease command and have that
+	// command executed by the other nodes but to never see the execution locally
+	// because it is caught up by applying a snapshot.
 	testCases := []storage.StoreTestingKnobs{
 		{DisableRefreshReasonNewLeader: true, DisableRefreshReasonTicks: true},
-		{DisableRefreshReasonSnapshotApplied: true, DisableRefreshReasonTicks: true},
 		{DisableRefreshReasonNewLeader: true, DisableRefreshReasonSnapshotApplied: true},
 	}
 	for _, c := range testCases {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2369,7 +2369,7 @@ func defaultSubmitProposalLocked(r *Replica, p *ProposalData) error {
 
 	return r.withRaftGroupLocked(true, func(raftGroup *raft.RawNode) (bool, error) {
 		if log.V(4) {
-			log.Infof(ctx, "proposing command %x", p.idKey)
+			log.Infof(ctx, "proposing command %x: %s", p.idKey, p.Request.Summary())
 		}
 		// We're proposing a command so there is no need to wake the leader if we
 		// were quiesced.


### PR DESCRIPTION
Don't test with with only reasonNewLeader because that mechanism is less
robust than refreshing due to snapshot or ticks. In particular, it is
possible for node 3 to propose the RequestLease command and have that
command executed by the other nodes but to never see the execution
locally because it is caught up by applying a snapshot.

Fixes #12020

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12478)
<!-- Reviewable:end -->
