### PR TITLE
sql: support extract from date types

### DIFF
--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -864,58 +864,26 @@ var Builtins = map[string][]Builtin{
 			Types:      ArgTypes{TypeString, TypeTimestamp},
 			ReturnType: TypeInt,
 			category:   categoryDateAndTime,
-			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
+			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				// extract timeSpan fromTime.
-				fromTime := *args[1].(*DTimestamp)
+				fromTS := args[1].(*DTimestamp)
 				timeSpan := strings.ToLower(string(*args[0].(*DString)))
-				switch timeSpan {
-				case "year", "years":
-					return NewDInt(DInt(fromTime.Year())), nil
-
-				case "quarter":
-					return NewDInt(DInt(fromTime.Month()/4 + 1)), nil
-
-				case "month", "months":
-					return NewDInt(DInt(fromTime.Month())), nil
-
-				case "week", "weeks":
-					_, week := fromTime.ISOWeek()
-					return NewDInt(DInt(week)), nil
-
-				case "day", "days":
-					return NewDInt(DInt(fromTime.Day())), nil
-
-				case "dayofweek", "dow":
-					return NewDInt(DInt(fromTime.Weekday())), nil
-
-				case "dayofyear", "doy":
-					return NewDInt(DInt(fromTime.YearDay())), nil
-
-				case "hour", "hours":
-					return NewDInt(DInt(fromTime.Hour())), nil
-
-				case "minute", "minutes":
-					return NewDInt(DInt(fromTime.Minute())), nil
-
-				case "second", "seconds":
-					return NewDInt(DInt(fromTime.Second())), nil
-
-				case "millisecond", "milliseconds":
-					// This a PG extension not supported in MySQL.
-					return NewDInt(DInt(fromTime.Nanosecond() / int(time.Millisecond))), nil
-
-				case "microsecond", "microseconds":
-					return NewDInt(DInt(fromTime.Nanosecond() / int(time.Microsecond))), nil
-
-				case "epoch":
-					return NewDInt(DInt(fromTime.Unix())), nil
-
-				default:
-					return nil, fmt.Errorf("unsupported timespan: %s", timeSpan)
-				}
+				return extractStringFromTimestamp(ctx, fromTS.Time, timeSpan)
+			},
+		},
+		Builtin{
+			Types:      ArgTypes{TypeString, TypeDate},
+			ReturnType: TypeInt,
+			category:   categoryDateAndTime,
+			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
+				timeSpan := strings.ToLower(string(*args[0].(*DString)))
+				date := args[1].(*DDate)
+				fromTSTZ := MakeDTimestampTZFromDate(ctx.GetLocation(), date)
+				return extractStringFromTimestamp(ctx, fromTSTZ.Time, timeSpan)
 			},
 		},
 	},
+
 	"extract_duration": {
 		Builtin{
 			Types:      ArgTypes{TypeString, TypeInterval},
@@ -2067,4 +2035,52 @@ func arrayLower(arr *DArray, dim int64) Datum {
 		return DNull
 	}
 	return arrayLower(a, dim-1)
+}
+
+func extractStringFromTimestamp(_ *EvalContext, fromTime time.Time, timeSpan string) (Datum, error) {
+	switch timeSpan {
+	case "year", "years":
+		return NewDInt(DInt(fromTime.Year())), nil
+
+	case "quarter":
+		return NewDInt(DInt(fromTime.Month()/4 + 1)), nil
+
+	case "month", "months":
+		return NewDInt(DInt(fromTime.Month())), nil
+
+	case "week", "weeks":
+		_, week := fromTime.ISOWeek()
+		return NewDInt(DInt(week)), nil
+
+	case "day", "days":
+		return NewDInt(DInt(fromTime.Day())), nil
+
+	case "dayofweek", "dow":
+		return NewDInt(DInt(fromTime.Weekday())), nil
+
+	case "dayofyear", "doy":
+		return NewDInt(DInt(fromTime.YearDay())), nil
+
+	case "hour", "hours":
+		return NewDInt(DInt(fromTime.Hour())), nil
+
+	case "minute", "minutes":
+		return NewDInt(DInt(fromTime.Minute())), nil
+
+	case "second", "seconds":
+		return NewDInt(DInt(fromTime.Second())), nil
+
+	case "millisecond", "milliseconds":
+		// This a PG extension not supported in MySQL.
+		return NewDInt(DInt(fromTime.Nanosecond() / int(time.Millisecond))), nil
+
+	case "microsecond", "microseconds":
+		return NewDInt(DInt(fromTime.Nanosecond() / int(time.Microsecond))), nil
+
+	case "epoch":
+		return NewDInt(DInt(fromTime.Unix())), nil
+
+	default:
+		return nil, fmt.Errorf("unsupported timespan: %s", timeSpan)
+	}
 }

--- a/pkg/sql/parser/eval_test.go
+++ b/pkg/sql/parser/eval_test.go
@@ -591,8 +591,19 @@ func TestEval(t *testing.T) {
 		{`ANNOTATE_TYPE(NULL, int)`, `NULL`},
 		{`ANNOTATE_TYPE(NULL, string)`, `NULL`},
 		{`ANNOTATE_TYPE(NULL, timestamp)`, `NULL`},
-		// Extract on timestamps and intervals.
-		{`extract(year from '2010-09-28 12:13:14.1+00:00')`, `2010`},
+		// Extract from dates.
+		// TODO(nvanbenschoten): these casts can be removed once we improve
+		// strConst's type inference.
+		{`extract(year from '2010-09-28'::date)`, `2010`},
+		{`extract(year from '2010-09-28'::date)`, `2010`},
+		{`extract(month from '2010-09-28'::date)`, `9`},
+		{`extract(day from '2010-09-28'::date)`, `28`},
+		{`extract(dayofyear from '2010-09-28'::date)`, `271`},
+		{`extract(week from '2010-01-14'::date)`, `2`},
+		{`extract(dayofweek from '2010-09-28'::date)`, `2`},
+		{`extract(quarter from '2010-09-28'::date)`, `3`},
+		// Extract from timestamps.
+		{`extract(year from '2010-09-28 12:13:14.1+00:00'::timestamp)`, `2010`},
 		{`extract(year from '2010-09-28 12:13:14.1+00:00'::timestamp)`, `2010`},
 		{`extract(month from '2010-09-28 12:13:14.1+00:00'::timestamp)`, `9`},
 		{`extract(day from '2010-09-28 12:13:14.1+00:00'::timestamp)`, `28`},
@@ -606,6 +617,7 @@ func TestEval(t *testing.T) {
 		{`extract(millisecond from '2010-01-10 12:13:14.123456+00:00'::timestamp)`, `123`},
 		{`extract(microsecond from '2010-01-10 12:13:14.123456+00:00'::timestamp)`, `123456`},
 		{`extract(epoch from '2010-01-10 12:13:14.1+00:00'::timestamp)`, `1263125594`},
+		// Extract from intervals.
 		{`extract_duration(hour from '123m')`, `2`},
 		{`extract_duration(hour from '123m'::interval)`, `2`},
 		{`extract_duration(minute from '123m10s'::interval)`, `123`},

--- a/pkg/sql/testdata/datetime
+++ b/pkg/sql/testdata/datetime
@@ -341,82 +341,82 @@ SELECT k FROM kv ORDER BY v
 6
 
 query I
-SELECT extract(year from '2001-04-10 12:04:59')
+SELECT extract(year from '2001-04-10 12:04:59'::timestamp)
 ----
 2001
 
 query I
-SELECT extract(quarter from '2001-04-10 12:04:59')
+SELECT extract(quarter from '2001-04-10 12:04:59'::timestamp)
 ----
 2
 
 query I
-SELECT extract(month from '2001-04-10 12:04:59')
+SELECT extract(month from '2001-04-10 12:04:59'::timestamp)
 ----
 4
 
 query I
-SELECT extract(week from '2001-04-10 12:04:59')
+SELECT extract(week from '2001-04-10 12:04:59'::timestamp)
 ----
 15
 
 query I
-SELECT extract(day from '2001-04-10 12:04:59')
+SELECT extract(day from '2001-04-10 12:04:59'::timestamp)
 ----
 10
 
 query I
-SELECT extract(dayofweek from '2001-04-10 12:04:59')
+SELECT extract(dayofweek from '2001-04-10 12:04:59'::timestamp)
 ----
 2
 
 query I
-SELECT extract(dow from '2001-04-12 12:04:59')
+SELECT extract(dow from '2001-04-12 12:04:59'::timestamp)
 ----
 4
 
 query I
-SELECT extract(dayofyear from '2001-04-10 12:04:59')
+SELECT extract(dayofyear from '2001-04-10 12:04:59'::timestamp)
 ----
 100
 
 query I
-SELECT extract(doy from '2001-04-12 12:04:59')
+SELECT extract(doy from '2001-04-12 12:04:59'::timestamp)
 ----
 102
 
 query I
-SELECT extract(epoch from '2001-04-10 12:04:59')
+SELECT extract(epoch from '2001-04-10 12:04:59'::timestamp)
 ----
 986904299
 
 query I
-SELECT extract(hour from '2001-04-10 12:04:59')
+SELECT extract(hour from '2001-04-10 12:04:59'::timestamp)
 ----
 12
 
 query I
-SELECT extract(minute from '2001-04-10 12:04:59')
+SELECT extract(minute from '2001-04-10 12:04:59'::timestamp)
 ----
 4
 
 query I
-SELECT extract(second from '2001-04-10 12:04:59.234')
+SELECT extract(second from '2001-04-10 12:04:59.234'::timestamp)
 ----
 59
 
 query I
-SELECT extract(millisecond from '2001-04-10 12:04:59.234567')
+SELECT extract(millisecond from '2001-04-10 12:04:59.234567'::timestamp)
 ----
 234
 
 query I
-SELECT extract(microsecond from '2001-04-10 12:04:59.34565423')
+SELECT extract(microsecond from '2001-04-10 12:04:59.34565423'::timestamp)
 ----
 345654
 
 query error extract\(\): unsupported timespan: nansecond
-SELECT extract(nansecond from '2001-04-10 12:04:59.34565423')
+SELECT extract(nansecond from '2001-04-10 12:04:59.34565423'::timestamp)
 
 # Test SET TIME ZONE
 


### PR DESCRIPTION
Add extract support for dates. This unfortunately means that extracts
from string constants are potentially ambiguous, and now require
explicit type casts. This matches Postgres behavior, which also
requires explicit typecasts for extracts on string constants.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12479)
<!-- Reviewable:end -->
