### PR TITLE
sql: Fix flake in TestQueryCounts

### DIFF
--- a/pkg/sql/metric_test.go
+++ b/pkg/sql/metric_test.go
@@ -50,7 +50,7 @@ func TestQueryCounts(t *testing.T) {
 
 	var testcases = []queryCounter{
 		// The counts are deltas for each query.
-		{"", 0, 0, 0, 0, 0, 0, 1, 0, 0, 0},
+		{"", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		{"BEGIN; END", 1, 0, 0, 0, 0, 0, 0, 0, 1, 0},
 		{"SELECT 1", 0, 1, 0, 0, 0, 0, 0, 0, 1, 0},
 		{"CREATE DATABASE mt", 0, 0, 0, 0, 0, 0, 1, 0, 0, 0},
@@ -69,7 +69,11 @@ func TestQueryCounts(t *testing.T) {
 		{"SET database = system", 0, 0, 0, 0, 0, 0, 0, 1, 0, 0},
 	}
 
+	// Initialize accum while accounting for system migrations that may have run
+	// DDL statements.
 	accum := testcases[0]
+	accum.ddlCount = s.MustGetSQLCounter(sql.MetaDdl.Name)
+
 	for _, tc := range testcases {
 		if tc.query == "" {
 			continue


### PR DESCRIPTION
It was conceivable that the system migration that does a DDL statement
could be retried, causing the DDL count to be 2 instead of 1 in some
cases. This fixes that and is also less fragile to future migrations
being added.

Fixes #12371

@arjunravinarayan

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12480)
<!-- Reviewable:end -->
