### PR TITLE
ui: Add some summary bar metrics

### DIFF
--- a/pkg/ui/app/app.tsx
+++ b/pkg/ui/app/app.tsx
@@ -16,9 +16,6 @@
  *      - Help us
  *    - Right-side Summary Section
  *      - Link to Nodes page
- *      - Stats
- *        - Unavailable Ranges
- *        - Queries Per Second?
  *      - Events?
  *    - Graphs
  *      - Intelligent Tick Selection

--- a/pkg/ui/app/components/graphs.tsx
+++ b/pkg/ui/app/components/graphs.tsx
@@ -3,6 +3,8 @@ import _ from "lodash";
 import * as protos from "../js/protos";
 import Long from "long";
 
+import { MetricProps } from "./metric";
+
 type TSResponseMessage = Proto2TypeScript.cockroach.ts.tspb.TimeSeriesQueryResponseMessage;
 
 // Global set of colors for graph series.
@@ -10,37 +12,6 @@ export let seriesPalette = [
   "#5F6C87", "#F2BE2C", "#F16969", "#4E9FD1", "#49D990", "#D77FBF", "#87326D", "#A3415B",
   "#B59153", "#C9DB6D", "#203D9B", "#748BF2", "#91C8F2", "#FF9696", "#EF843C", "#DCCD4B",
 ];
-
-/**
- * MetricProps reperesents the properties assigned to a selector component. A
- * selector describes a single time series that should be queried from the
- * server, along with some basic information on how that data should be rendered
- * in a graph context.
- */
-export interface MetricProps {
-  name: string;
-  sources?: string[];
-  title?: string;
-  rate?: boolean;
-  nonNegativeRate?: boolean;
-  aggregateMax?: boolean;
-  aggregateMin?: boolean;
-  aggregateAvg?: boolean;
-  downsampleMax?: boolean;
-  downsampleMin?: boolean;
-}
-
-/**
- * Metric is a React component which describes a selector. This exists as a
- * component for convenient syntax, and should not be rendered directly; rather,
- * a renderable component will contain metrics, but will use them
- * only informationally within rendering them.
- */
-export class Metric extends React.Component<MetricProps, {}> {
-  render(): React.ReactElement<any> {
-    throw new Error("Component <Metric /> should never render.");
-  }
-};
 
 /**
  * AxisProps represents the properties of a renderable graph axis.
@@ -114,7 +85,7 @@ class AxisDomain {
     this.max = _.max(_.values<number>(this.stackedSum));
   }
 
-  // ticks computes tick values for a graph given the current max/min and 
+  // ticks computes tick values for a graph given the current max/min and
   // tickCount.
   ticks(transform: (n: number) => any = _.identity): number[] {
     let increment = (this.max - this.min) / (this.tickCount + 1);

--- a/pkg/ui/app/components/linegraph.tsx
+++ b/pkg/ui/app/components/linegraph.tsx
@@ -7,8 +7,9 @@ import _ from "lodash";
 import { findChildrenOfType } from "../util/find";
 import { NanoToMilli } from "../util/convert";
 import {
-  MetricsDataComponentProps, Axis, AxisProps, Metric, MetricProps, ProcessDataPoints, seriesPalette,
+  MetricsDataComponentProps, Axis, AxisProps, ProcessDataPoints, seriesPalette,
 } from "./graphs";
+import { Metric, MetricProps } from "./metric";
 import Visualization from "./visualization";
 
 // Chart margins to match design.
@@ -162,5 +163,3 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
     </Visualization>;
   }
 }
-
-export { Axis, Metric } from "./graphs";

--- a/pkg/ui/app/components/metric.tsx
+++ b/pkg/ui/app/components/metric.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+
+/**
+ * MetricProps reperesents the properties assigned to a selector component. A
+ * selector describes a single time series that should be queried from the
+ * server, along with some basic information on how that data should be rendered
+ * in a graph context.
+ */
+export interface MetricProps {
+  name: string;
+  sources?: string[];
+  title?: string;
+  rate?: boolean;
+  nonNegativeRate?: boolean;
+  aggregateMax?: boolean;
+  aggregateMin?: boolean;
+  aggregateAvg?: boolean;
+  downsampleMax?: boolean;
+  downsampleMin?: boolean;
+}
+
+/**
+ * Metric is a React component which describes a selector. This exists as a
+ * component for convenient syntax, and should not be rendered directly; rather,
+ * a renderable component will contain metrics, but will use them
+ * only informationally within rendering them.
+ */
+export class Metric extends React.Component<MetricProps, {}> {
+  render(): React.ReactElement<any> {
+    throw new Error("Component <Metric /> should never render.");
+  }
+};

--- a/pkg/ui/app/components/stackedgraph.tsx
+++ b/pkg/ui/app/components/stackedgraph.tsx
@@ -7,8 +7,9 @@ import _ from "lodash";
 import { findChildrenOfType } from "../util/find";
 import { NanoToMilli } from "../util/convert";
 import {
-  MetricsDataComponentProps, Axis, AxisProps, Metric, MetricProps, ProcessDataPoints, seriesPalette,
+  MetricsDataComponentProps, Axis, AxisProps, ProcessDataPoints, seriesPalette,
 } from "./graphs";
+import { Metric, MetricProps } from "./metric";
 import Visualization from "./visualization";
 
 // Chart margins to match design.
@@ -169,5 +170,3 @@ export class StackedAreaGraph extends React.Component<StackedAreaGraphProps, {}>
     </Visualization>;
   }
 }
-
-export { Axis, Metric } from "./graphs";

--- a/pkg/ui/app/components/summaryBar.tsx
+++ b/pkg/ui/app/components/summaryBar.tsx
@@ -1,6 +1,9 @@
 import _ from "lodash";
 import * as React from "react";
 
+import { MetricsDataProvider } from "../containers/metricsDataProvider";
+import { MetricsDataComponentProps } from "../components/graphs";
+
 interface SummaryStatProps {
   title: React.ReactNode;
   tooltip?: string;
@@ -19,7 +22,7 @@ function computeValue(value: number, format: (n: number) => string = numberToStr
   return format(value);
 }
 
-// SummaryBar is a simple component backing a common motif in our UI: a 
+// SummaryBar is a simple component backing a common motif in our UI: a
 // collection of summarized statistics.
 // TODO(mrtracy): Add tooltip support.
 export function SummaryBar(props: { children?: any }) {
@@ -50,7 +53,19 @@ export function SummaryStat(props: SummaryStatProps & {children?: any}) {
   </div>;
 }
 
-// SummaryHeadlineStat displays a single item in a summary bar as a "Headline 
+function SummaryMetricStatHelper(props: MetricsDataComponentProps & SummaryStatProps & { children?: any }) {
+  let datapoints = props.data && props.data.results && props.data.results[0] && props.data.results[0].datapoints;
+  let value = datapoints && datapoints[0] && _.last(datapoints).value;
+  return <SummaryStat {...props} value={_.isNumber(value) ? value : props.value} />;
+}
+
+export function SummaryMetricStat(props: SummaryStatProps & { id: string } & { children?: any }) {
+  return <MetricsDataProvider current id={props.id} >
+    <SummaryMetricStatHelper {...props} />
+  </MetricsDataProvider>;
+}
+
+// SummaryHeadlineStat displays a single item in a summary bar as a "Headline
 // Stat", which is formatted to place attention on the number.
 export class SummaryHeadlineStat extends React.Component<SummaryStatProps, {}> {
   render() {

--- a/pkg/ui/app/containers/metricsDataProvider.spec.tsx
+++ b/pkg/ui/app/containers/metricsDataProvider.spec.tsx
@@ -6,7 +6,8 @@ import Long from "long";
 import * as sinon from "sinon";
 
 import * as protos from  "../js/protos";
-import { TextGraph, Axis, Metric } from "../components/graphs";
+import { TextGraph, Axis } from "../components/graphs";
+import { Metric } from "../components/metric";
 import {
   MetricsDataProviderUnconnected as MetricsDataProvider,
   QueryTimeInfo,

--- a/pkg/ui/app/redux/metrics.ts
+++ b/pkg/ui/app/redux/metrics.ts
@@ -331,6 +331,11 @@ export function queryMetrics<S>(id: string, query: TSRequestMessage) {
   };
 }
 
-function timespanKey(query: TSRequestMessage): string {
-  return query.start_nanos.toString() + ":" + query.end_nanos.toString();
+interface SimpleTimespan {
+  start_nanos?: Long;
+  end_nanos?: Long;
+}
+
+function timespanKey(timewindow: SimpleTimespan): string {
+  return (timewindow.start_nanos && timewindow.start_nanos.toString()) + ":" + (timewindow.end_nanos && timewindow.end_nanos.toString());
 }

--- a/pkg/ui/styl/components/summarybar.styl
+++ b/pkg/ui/styl/components/summarybar.styl
@@ -29,7 +29,8 @@
 
 .summary-stat
   clearfix()
-  padding 12px 0
+  padding 10px 0
+  line-height 18px
 
   &__title
     color $light-blue
@@ -38,6 +39,7 @@
   &__value
     float right
     color $light-green
+    font-family Lato-Bold
 
   &__tooltip
     display block


### PR DESCRIPTION
This commit adds metrics as per the current design, though they
can be easily changed.

I added a "current" flag to MetricsDataProvider that always uses
the current time rounded down to the last 10 seconds. Then I
created a SummaryMetricStat component that inserts a
MetricDataProvider with the current flag and pulls data for any
Metric elements and inserts that data into a SummaryStat.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12486)
<!-- Reviewable:end -->
