### PR TITLE
storage: use an empty command instead of nil proposal to unquiesce

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2441,10 +2441,8 @@ func (r *Replica) unquiesceAndWakeLeaderLocked() {
 			log.Infof(ctx, "unquiescing: waking leader")
 		}
 		r.mu.quiescent = false
-		// Send an empty proposal which will wake the leader. Empty proposals also
-		// trigger reproposal of pending commands, but this is expected to be a
-		// very rare situation.
-		_ = r.mu.internalRaftGroup.Propose(nil)
+		// Propose an empty command which will wake the leader.
+		_ = r.mu.internalRaftGroup.Propose(encodeRaftCommand(makeIDKey(), nil))
 	}
 }
 
@@ -2642,7 +2640,11 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 			} else {
 				var encodedCommand []byte
 				commandID, encodedCommand = DecodeRaftCommand(e.Data)
-				if err := command.Unmarshal(encodedCommand); err != nil {
+				// An empty command is used to unquiesce a range and wake the
+				// leader. Clear commandID so it's ignored for processing.
+				if len(encodedCommand) == 0 {
+					commandID = ""
+				} else if err := command.Unmarshal(encodedCommand); err != nil {
 					return stats, err
 				}
 			}


### PR DESCRIPTION
This avoid the problem of spurious leader change assumption, an event
that triggers refresh of any pending commands. This seemed to be
happening incredibly frequently in various chaos scenarios.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12487)
<!-- Reviewable:end -->
