### PR TITLE
*: Downgrade routine log messages to V(*)

### DIFF
--- a/pkg/base/node_id.go
+++ b/pkg/base/node_id.go
@@ -59,7 +59,9 @@ func (n *NodeIDContainer) Set(ctx context.Context, val roachpb.NodeID) {
 	}
 	oldVal := atomic.SwapInt32(&n.nodeID, int32(val))
 	if oldVal == 0 {
-		log.Infof(ctx, "NodeID set to %d", val)
+		if log.V(2) {
+			log.Infof(ctx, "NodeID set to %d", val)
+		}
 	} else if oldVal != int32(val) {
 		log.Fatalf(ctx, "different NodeIDs set: %d, then %d", oldVal, val)
 	}

--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -80,15 +80,15 @@ eexpect ":/# "
 
 # Now check that `--alsologtostderr` can override the default
 # properly, with or without `--logtostderr`.
-send "$argv quit --alsologtostderr=INFO --logtostderr\r"
+send "$argv quit --alsologtostderr=INFO --logtostderr --vmodule=stopper=1\r"
 eexpect "stop has been called"
 eexpect ":/# "
 
-send "$argv quit --alsologtostderr=INFO --logtostderr=false\r"
+send "$argv quit --alsologtostderr=INFO --logtostderr=false --vmodule=stopper=1\r"
 eexpect "stop has been called"
 eexpect ":/# "
 
-send "$argv quit --alsologtostderr=INFO\r"
+send "$argv quit --alsologtostderr=INFO --vmodule=stopper=1\r"
 eexpect "stop has been called"
 eexpect ":/# "
 

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -245,7 +245,9 @@ func New(
 		resolverAddrs[i] = resolver.Addr()
 	}
 	ctx := g.AnnotateCtx(context.Background())
-	log.Infof(ctx, "initial resolvers: %v", resolverAddrs)
+	if log.V(1) {
+		log.Infof(ctx, "initial resolvers: %v", resolverAddrs)
+	}
 	g.SetResolvers(resolvers)
 
 	g.mu.Lock()
@@ -1121,7 +1123,9 @@ func (g *Gossip) maybeSignalStatusChangeLocked() {
 			log.Eventf(ctx, "now stalled")
 			if orphaned {
 				if len(g.resolvers) == 0 {
-					log.Warningf(ctx, "no resolvers found; use --join to specify a connected node")
+					if log.V(1) {
+						log.Warningf(ctx, "no resolvers found; use --join to specify a connected node")
+					}
 				} else {
 					log.Warningf(ctx, "no incoming or outgoing connections")
 				}

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -337,7 +337,9 @@ func (r *RocksDB) open() error {
 				versionCurrent, ver, versionMinimum)
 		}
 	} else {
-		log.Infof(context.TODO(), "opening in memory rocksdb instance")
+		if log.V(2) {
+			log.Infof(context.TODO(), "opening in memory rocksdb instance")
+		}
 
 		// In memory dbs are always current.
 		ver = versionCurrent

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -386,8 +386,10 @@ func (r *Replica) leasePostApply(
 		// requests, this is kosher). This means that we don't use the old
 		// lease's expiration but instead use the new lease's start to initialize
 		// the timestamp cache low water.
-		log.Infof(ctx, "new range lease %s following %s [physicalTime=%s]",
-			newLease, prevLease, r.store.Clock().PhysicalTime())
+		if log.V(1) {
+			log.Infof(ctx, "new range lease %s following %s [physicalTime=%s]",
+				newLease, prevLease, r.store.Clock().PhysicalTime())
+		}
 		r.mu.Lock()
 		r.mu.tsCache.SetLowWater(newLease.Start)
 		r.mu.Unlock()

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -393,9 +393,11 @@ func (s *Stopper) Stop() {
 	defer s.Recover()
 	defer unregister(s)
 
-	file, line, _ := caller.Lookup(1)
-	log.Infof(context.TODO(),
-		"stop has been called from %s:%d, stopping or quiescing all running tasks", file, line)
+	if log.V(1) {
+		file, line, _ := caller.Lookup(1)
+		log.Infof(context.TODO(),
+			"stop has been called from %s:%d, stopping or quiescing all running tasks", file, line)
+	}
 	// Don't bother doing stuff cleanly if we're panicking, that would likely
 	// block. Instead, best effort only. This cleans up the stack traces,
 	// avoids stalls and helps some tests in `./cli` finish cleanly (where


### PR DESCRIPTION
These messages are generally uninteresting and occur in nearly every
test case. With this change many tests now run with no log output.

I know there was some recent discussion about the stopper log line in #12325 (cc @a-robinson); even though it's sometimes useful to see what's stopping the stopper in tests, I'd rather leave that as a `--vmodule` option and have our default log output be minimal (so that the teamcity build log page can load)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12496)
<!-- Reviewable:end -->
