### PR TITLE
storage_test: Plumb context into expireLeases

### DIFF
--- a/pkg/storage/client_lease_test.go
+++ b/pkg/storage/client_lease_test.go
@@ -67,7 +67,7 @@ func TestStoreRangeLease(t *testing.T) {
 
 			// Allow leases to expire and send commands to ensure we
 			// re-acquire, then check types again.
-			mtc.expireLeases()
+			mtc.expireLeases(context.TODO())
 			for _, key := range splitKeys {
 				if _, err := mtc.dbs[0].Inc(context.TODO(), key, 1); err != nil {
 					t.Fatalf("%s failed to increment: %s", key, err)
@@ -111,7 +111,7 @@ func TestStoreRangeLeaseSwitcheroo(t *testing.T) {
 
 	// Allow leases to expire and send commands to ensure we
 	// re-acquire, then check types again.
-	mtc.expireLeases()
+	mtc.expireLeases(context.TODO())
 	if _, err := mtc.dbs[0].Inc(context.TODO(), splitKey, 1); err != nil {
 		t.Fatalf("failed to increment: %s", err)
 	}
@@ -128,7 +128,7 @@ func TestStoreRangeLeaseSwitcheroo(t *testing.T) {
 	sc.EnableEpochRangeLeases = false
 	mtc.restartStore(0)
 
-	mtc.expireLeases()
+	mtc.expireLeases(context.TODO())
 	if _, err := mtc.dbs[0].Inc(context.TODO(), splitKey, 1); err != nil {
 		t.Fatalf("failed to increment: %s", err)
 	}
@@ -145,7 +145,7 @@ func TestStoreRangeLeaseSwitcheroo(t *testing.T) {
 	sc.EnableEpochRangeLeases = true
 	mtc.restartStore(0)
 
-	mtc.expireLeases()
+	mtc.expireLeases(context.TODO())
 	if _, err := mtc.dbs[0].Inc(context.TODO(), splitKey, 1); err != nil {
 		t.Fatalf("failed to increment: %s", err)
 	}

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -854,7 +854,7 @@ func TestReplicateAfterRemoveAndSplit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mtc.expireLeases()
+	mtc.expireLeases(context.TODO())
 
 	// Restart store 2.
 	mtc.restartStore(2)
@@ -1561,7 +1561,7 @@ func testReplicaAddRemove(t *testing.T, addFirst bool) {
 	}))
 
 	// Wait out the range lease and the unleased duration to make the replica GC'able.
-	mtc.expireLeases()
+	mtc.expireLeases(context.TODO())
 	mtc.manualClock.Increment(int64(storage.ReplicaGCQueueInactivityThreshold + 1))
 	mtc.stores[1].SetReplicaGCQueueActive(true)
 	mtc.stores[1].ForceReplicaGCScanAndProcess()
@@ -1894,7 +1894,7 @@ func TestRaftAfterRemoveRange(t *testing.T) {
 
 	// Expire leases to ensure any remaining intent resolutions can complete.
 	// TODO(bdarnell): understand why some tests need this.
-	mtc.expireLeases()
+	mtc.expireLeases(context.TODO())
 }
 
 // TestRaftRemoveRace adds and removes a replica repeatedly in an attempt to
@@ -2259,7 +2259,7 @@ func TestReplicateRogueRemovedNode(t *testing.T) {
 	// moved under the lock, then the GC scan can be moved out of this loop.
 	mtc.stores[1].SetReplicaGCQueueActive(true)
 	testutils.SucceedsSoon(t, func() error {
-		mtc.expireLeases()
+		mtc.expireLeases(context.TODO())
 		mtc.manualClock.Increment(int64(
 			storage.ReplicaGCQueueInactivityThreshold) + 1)
 		mtc.stores[1].ForceReplicaGCScanAndProcess()
@@ -2343,7 +2343,7 @@ func TestReplicateRogueRemovedNode(t *testing.T) {
 	// will see that the range has been moved and delete the old
 	// replica.
 	mtc.stores[2].SetReplicaGCQueueActive(true)
-	mtc.expireLeases()
+	mtc.expireLeases(context.TODO())
 	mtc.manualClock.Increment(int64(
 		storage.ReplicaGCQueueInactivityThreshold) + 1)
 	mtc.stores[2].ForceReplicaGCScanAndProcess()
@@ -2391,7 +2391,7 @@ func TestReplicateRemovedNodeDisruptiveElection(t *testing.T) {
 	const rangeID = roachpb.RangeID(1)
 	mtc.replicateRange(rangeID, 1, 2, 3)
 	mtc.unreplicateRange(rangeID, 0)
-	mtc.expireLeases()
+	mtc.expireLeases(context.TODO())
 
 	// Ensure that we have a stable lease and raft leader so we can tell if the
 	// removed node causes a disruption. This is a three-step process.
@@ -2740,7 +2740,7 @@ func TestRemoveRangeWithoutGC(t *testing.T) {
 
 	// Re-enable the GC queue to allow the replica to be destroyed
 	// (after the simulated passage of time).
-	mtc.expireLeases()
+	mtc.expireLeases(context.TODO())
 	mtc.manualClock.Increment(int64(storage.ReplicaGCQueueInactivityThreshold + 1))
 	mtc.stores[0].SetReplicaGCQueueActive(true)
 	mtc.stores[0].ForceReplicaGCScanAndProcess()
@@ -2931,7 +2931,7 @@ func TestTransferRaftLeadership(t *testing.T) {
 	// the system could have requested another lease as well, so we
 	// expire-request in a loop until we get our foot in the door.
 	for {
-		mtc.expireLeases()
+		mtc.expireLeases(context.TODO())
 		if _, pErr := client.SendWrappedWith(
 			context.Background(),
 			store1,

--- a/pkg/storage/client_replica_gc_test.go
+++ b/pkg/storage/client_replica_gc_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -110,7 +111,7 @@ func TestReplicaGCQueueDropReplicaGCOnScan(t *testing.T) {
 	mtc.stores[1].SetReplicaGCQueueActive(true)
 
 	// Increment the clock's timestamp to make the replica GC queue process the range.
-	mtc.expireLeases()
+	mtc.expireLeases(context.TODO())
 	mtc.manualClock.Increment(int64(storage.ReplicaGCQueueInactivityThreshold + 1))
 
 	// Make sure the range is removed from the store.

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -743,7 +743,7 @@ func TestLeaseMetricsOnSplitAndTransfer(t *testing.T) {
 	// Expire current leases and put a key to RHS of split to request
 	// an epoch-based lease.
 	testutils.SucceedsSoon(t, func() error {
-		mtc.expireLeases()
+		mtc.expireLeases(context.TODO())
 		if err := mtc.stores[0].DB().Put(context.TODO(), "a", "foo"); err != nil {
 			return err
 		}

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -956,14 +956,14 @@ func runSetupSplitSnapshotRace(
 	// Replicate the left range onto nodes 1-3 and remove it from node 0.
 	mtc.replicateRange(leftRangeID, 1, 2, 3)
 	mtc.unreplicateRange(leftRangeID, 0)
-	mtc.expireLeases()
+	mtc.expireLeases(context.TODO())
 
 	mtc.waitForValues(leftKey, []int64{0, 1, 1, 1, 0, 0})
 	mtc.waitForValues(rightKey, []int64{0, 2, 2, 2, 0, 0})
 
 	// Stop node 3 so it doesn't hear about the split.
 	mtc.stopStore(3)
-	mtc.expireLeases()
+	mtc.expireLeases(context.TODO())
 
 	// Split the data range.
 	splitArgs = adminSplitArgs(keys.SystemMax, roachpb.Key("m"))

--- a/pkg/storage/consistency_queue_test.go
+++ b/pkg/storage/consistency_queue_test.go
@@ -49,7 +49,7 @@ func TestConsistencyQueueRequiresLive(t *testing.T) {
 
 	// Stop a node and expire leases.
 	mtc.stopStore(2)
-	mtc.expireLeases()
+	mtc.expireLeases(context.TODO())
 
 	if shouldQ, priority := mtc.stores[0].ConsistencyQueueShouldQueue(
 		context.TODO(), mtc.clock.Now(), repl, config.SystemConfig{}); shouldQ {


### PR DESCRIPTION
Now that expireLeases makes RPCs instead of just advancing the manual
clock, it is sometimes necessary to respect context cancellation to
prevent hangs at shutdown. In particular, a NodeLiveness heartbeat in
TestRemoveRangeWithoutGC has been seen to get stuck.

Fixes #12491
Fixes #12492

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12497)
<!-- Reviewable:end -->
