### PR TITLE
storage: Deflake TestSplitSnapshotRace_SplitWins (and others)

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -744,15 +744,13 @@ func (r *Replica) destroyDataRaftMuLocked(
 
 func (r *Replica) cancelPendingCommandsLocked() {
 	r.mu.AssertHeld()
-	if len(r.mu.proposals) > 0 {
+	for _, p := range r.mu.proposals {
 		resp := proposalResult{
 			Reply:         &roachpb.BatchResponse{},
 			Err:           roachpb.NewError(roachpb.NewAmbiguousResultError("removing replica")),
 			ProposalRetry: proposalRangeNoLongerExists,
 		}
-		for _, p := range r.mu.proposals {
-			p.finish(resp)
-		}
+		p.finish(resp)
 	}
 	r.mu.proposals = map[storagebase.CmdIDKey]*ProposalData{}
 }


### PR DESCRIPTION
Catch ConditionFailedErrors in addition to AmbiguousResultErrors from
ChangeReplicas.

Fixes #12469

storage: Give each canceled command its own Error object

Sharing error objects can result in data races when the Error's Txn
field is modified later. This race previously reproduced when stressing
TestSplitSnapshotRace_SplitWins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12499)
<!-- Reviewable:end -->
