### PR TITLE
storage: Send node liveness heartbeats more frequently

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -214,7 +214,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 
 	// Use the range lease expiration and renewal durations as the node
 	// liveness expiration and heartbeat interval.
-	active, renewal := storage.RangeLeaseDurations(
+	active, renewal := storage.NodeLivenessDurations(
 		storage.RaftElectionTimeout(s.cfg.RaftTickInterval, s.cfg.RaftElectionTimeoutTicks))
 	s.nodeLiveness = storage.NewNodeLiveness(
 		s.cfg.AmbientCtx, s.clock, s.db, s.gossip, active, renewal,

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -84,6 +84,10 @@ const (
 	// duration should be of the range lease active time.
 	rangeLeaseRenewalDivisor = 5
 
+	// livenessRenewalFraction specifies what fraction the node liveness renewal
+	// duration should be of the node liveness duration.
+	livenessRenewalFraction = 0.5
+
 	// replicaRequestQueueSize specifies the maximum number of requests to queue
 	// for a replica.
 	replicaRequestQueueSize = 100
@@ -129,6 +133,16 @@ func RangeLeaseDurations(
 ) (rangeLeaseActive time.Duration, rangeLeaseRenewal time.Duration) {
 	rangeLeaseActive = rangeLeaseRaftElectionTimeoutMultiplier * raftElectionTimeout
 	rangeLeaseRenewal = rangeLeaseActive / rangeLeaseRenewalDivisor
+	return
+}
+
+// NodeLivenessDurations computes durations for node liveness expiration
+// and renewal based on a default multiple of Raft election timeout.
+func NodeLivenessDurations(
+	raftElectionTimeout time.Duration,
+) (livenessActive time.Duration, livenessRenewal time.Duration) {
+	livenessActive, _ = RangeLeaseDurations(raftElectionTimeout)
+	livenessRenewal = time.Duration(float64(livenessActive) * livenessRenewalFraction)
 	return
 }
 


### PR DESCRIPTION
Also log when they take more than a second.

Hopefully the first commit will reduce the frequency of blips in the per-node view of node liveness that we've been seeing in our metrics.

I'm not sure the second commit is worth it -- if a lot of heartbeats get backed up it could seemingly generate a fair amount of log spam. Let me know what you think.

@spencerkimball

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12500)
<!-- Reviewable:end -->
