### PR TITLE
sql: add drain mode to LeaseManager

### DIFF
--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -536,7 +536,7 @@ type tableState struct {
 // acquire returns a lease at the specifies version. The lease will have its
 // refcount incremented, so the caller is responsible to call release() on it.
 func (t *tableState) acquire(
-	txn *client.Txn, version sqlbase.DescriptorVersion, store LeaseStore,
+	txn *client.Txn, version sqlbase.DescriptorVersion, m *LeaseManager,
 ) (*LeaseState, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -544,7 +544,7 @@ func (t *tableState) acquire(
 	for {
 		s := t.active.findNewest(version)
 		if s != nil {
-			if checkedLease := t.checkLease(s, version, store.clock); checkedLease != nil {
+			if checkedLease := t.checkLease(s, version, m.clock); checkedLease != nil {
 				return checkedLease, nil
 			}
 		} else if version != 0 {
@@ -555,7 +555,7 @@ func (t *tableState) acquire(
 			}
 		}
 
-		if err := t.acquireFromStoreLocked(txn, version, store); err != nil {
+		if err := t.acquireFromStoreLocked(txn, version, m); err != nil {
 			return nil, err
 		}
 		// A new lease was added, so loop and perform the lookup again.
@@ -588,7 +588,7 @@ func (t *tableState) checkLease(
 // acquireFromStoreLocked acquires a new lease from the store and inserts it
 // into the active set. t.mu must be locked.
 func (t *tableState) acquireFromStoreLocked(
-	txn *client.Txn, version sqlbase.DescriptorVersion, store LeaseStore,
+	txn *client.Txn, version sqlbase.DescriptorVersion, m *LeaseManager,
 ) error {
 	// Ensure there is no lease acquisition in progress.
 	if t.acquireWait() {
@@ -597,7 +597,7 @@ func (t *tableState) acquireFromStoreLocked(
 		return nil
 	}
 
-	s, err := t.acquireNodeLease(txn, version, store, parser.DTimestamp{})
+	s, err := t.acquireNodeLease(txn, version, m, parser.DTimestamp{})
 	if err != nil {
 		return err
 	}
@@ -617,7 +617,7 @@ func (t *tableState) acquireFromStoreLocked(
 //
 // t.mu must be locked.
 func (t *tableState) acquireFreshestFromStoreLocked(
-	txn *client.Txn, version sqlbase.DescriptorVersion, store LeaseStore,
+	txn *client.Txn, version sqlbase.DescriptorVersion, m *LeaseManager,
 ) error {
 	// Ensure there is no lease acquisition in progress.
 	t.acquireWait()
@@ -633,7 +633,7 @@ func (t *tableState) acquireFreshestFromStoreLocked(
 			Time: newestLease.expiration.Add(time.Millisecond)}
 	}
 
-	s, err := t.acquireNodeLease(txn, version, store, minExpirationTime)
+	s, err := t.acquireNodeLease(txn, version, m, minExpirationTime)
 	if err != nil {
 		return err
 	}
@@ -641,12 +641,12 @@ func (t *tableState) acquireFreshestFromStoreLocked(
 	return nil
 }
 
-// releaseLeasesIfNotActive releases the leases in `leases` with refcount 0.
+// releaseInactiveLeases releases the leases in t.active.data with refcount 0.
 // t.mu must be locked.
-// leases must be a not overlap t.active.data, since t.active.data will
-// be changed by this function.
-func (t *tableState) releaseLeasesIfNotActive(leases []*LeaseState, store LeaseStore) {
-	for _, lease := range leases {
+func (t *tableState) releaseInactiveLeases(store LeaseStore) {
+	// A copy of t.active.data must be made since t.active.data will be changed
+	// by `removeLease`.
+	for _, lease := range append([]*LeaseState(nil), t.active.data...) {
 		func() {
 			lease.mu.Lock()
 			defer lease.mu.Unlock()
@@ -685,9 +685,13 @@ func (t *tableState) acquireWait() bool {
 func (t *tableState) acquireNodeLease(
 	txn *client.Txn,
 	minVersion sqlbase.DescriptorVersion,
-	store LeaseStore,
+	m *LeaseManager,
 	minExpirationTime parser.DTimestamp,
 ) (*LeaseState, error) {
+	if m.isDraining() {
+		return nil, errors.New("cannot acquire lease when draining")
+	}
+
 	// Notify when lease has been acquired.
 	t.acquiring = make(chan struct{})
 	defer func() {
@@ -698,7 +702,7 @@ func (t *tableState) acquireNodeLease(
 	// acquisition.
 	t.mu.Unlock()
 	defer t.mu.Lock()
-	lease, err := store.Acquire(txn, t.id, minVersion, minExpirationTime)
+	lease, err := m.LeaseStore.Acquire(txn, t.id, minVersion, minExpirationTime)
 	if err != nil {
 		return nil, err
 	}
@@ -706,7 +710,7 @@ func (t *tableState) acquireNodeLease(
 	return lease, nil
 }
 
-func (t *tableState) release(lease *LeaseState, store LeaseStore) error {
+func (t *tableState) release(lease *LeaseState, m *LeaseManager) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -717,24 +721,18 @@ func (t *tableState) release(lease *LeaseState, store LeaseStore) error {
 	// Decrements the refcount and returns true if the lease has to be removed
 	// from the store.
 	decRefcount := func(s *LeaseState) bool {
-		// Figure out if we'd like to remove the lease from the store asap (i.e. when
-		// the refcount drops to 0). If so, we'll need to mark the lease as released.
-		removeOnceDereferenced := false
-
-		if store.testingKnobs.RemoveOnceDereferenced {
-			removeOnceDereferenced = true
-		}
-
-		// Release from the store if the table has been deleted; no leases can be
-		// acquired any more.
-		if t.deleted {
-			removeOnceDereferenced = true
-		}
-		// Release from the store if the lease is not for the latest version; only
-		// leases for the latest version can be acquired.
-		if s != t.active.findNewest(0) {
-			removeOnceDereferenced = true
-		}
+		// Figure out if we'd like to remove the lease from the store asap (i.e.
+		// when the refcount drops to 0). If so, we'll need to mark the lease as
+		// released.
+		removeOnceDereferenced := m.LeaseStore.testingKnobs.RemoveOnceDereferenced ||
+			// Release from the store if the table has been deleted; no leases
+			// can be acquired any more.
+			t.deleted ||
+			// Release from the store if the LeaseManager is draining.
+			m.isDraining() ||
+			// Release from the store if the lease is not for the latest
+			// version; only leases for the latest version can be acquired.
+			s != t.active.findNewest(0)
 
 		s.mu.Lock()
 		defer s.mu.Unlock()
@@ -751,7 +749,7 @@ func (t *tableState) release(lease *LeaseState, store LeaseStore) error {
 		return s.released
 	}
 	if decRefcount(s) {
-		t.removeLease(s, store)
+		t.removeLease(s, m.LeaseStore)
 	}
 	return nil
 }
@@ -779,7 +777,7 @@ func (t *tableState) removeLease(lease *LeaseState, store LeaseStore) {
 // they're not in use any more.
 // If t has no active leases, nothing is done.
 func (t *tableState) purgeOldLeases(
-	db *client.DB, deleted bool, minVersion sqlbase.DescriptorVersion, store LeaseStore,
+	db *client.DB, deleted bool, minVersion sqlbase.DescriptorVersion, m *LeaseManager,
 ) error {
 	t.mu.Lock()
 	empty := len(t.active.data) == 0
@@ -795,7 +793,7 @@ func (t *tableState) purgeOldLeases(
 	err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 		var err error
 		if !deleted {
-			lease, err = t.acquire(txn, minVersion, store)
+			lease, err = t.acquire(txn, minVersion, m)
 			if err == errTableDropped {
 				deleted = true
 			}
@@ -803,13 +801,10 @@ func (t *tableState) purgeOldLeases(
 		if err == nil || deleted {
 			t.mu.Lock()
 			defer t.mu.Unlock()
-			var toRelease []*LeaseState
 			if deleted {
 				t.deleted = true
 			}
-			toRelease = append([]*LeaseState(nil), t.active.data...)
-
-			t.releaseLeasesIfNotActive(toRelease, store)
+			t.releaseInactiveLeases(m.LeaseStore)
 			return nil
 		}
 		return err
@@ -820,7 +815,7 @@ func (t *tableState) purgeOldLeases(
 	if lease == nil {
 		return nil
 	}
-	return t.release(lease, store)
+	return t.release(lease, m)
 }
 
 // LeaseStoreTestingKnobs contains testing knobs.
@@ -961,8 +956,9 @@ func makeTableNameCacheKey(dbID sqlbase.ID, tableName string) tableNameCacheKey 
 // LeaseManager.mu > tableState.mu > tableNameCache.mu > LeaseState.mu
 type LeaseManager struct {
 	LeaseStore
-	mu     syncutil.Mutex
-	tables map[sqlbase.ID]*tableState
+	mu       syncutil.Mutex
+	draining bool
+	tables   map[sqlbase.ID]*tableState
 
 	// tableNames is a cache for name -> id mappings. A mapping for the cache
 	// should only be used if we currently have an active lease on the respective
@@ -1110,7 +1106,7 @@ func (m *LeaseManager) Acquire(
 	txn *client.Txn, tableID sqlbase.ID, version sqlbase.DescriptorVersion,
 ) (*LeaseState, error) {
 	t := m.findTableState(tableID, true)
-	lease, err := t.acquire(txn, version, m.LeaseStore)
+	lease, err := t.acquire(txn, version, m)
 	if m.LeaseStore.testingKnobs.LeaseAcquiredEvent != nil {
 		m.LeaseStore.testingKnobs.LeaseAcquiredEvent(lease, err)
 	}
@@ -1130,7 +1126,7 @@ func (m *LeaseManager) acquireFreshestFromStore(
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if err := t.acquireFreshestFromStoreLocked(
-		txn, 0 /* version */, m.LeaseStore,
+		txn, 0 /* version */, m,
 	); err != nil {
 		return nil, err
 	}
@@ -1154,7 +1150,29 @@ func (m *LeaseManager) Release(lease *LeaseState) error {
 	// could be bad if a lot of tables keep being created. I looked into cleaning
 	// up a bit, but it seems tricky to do with the current locking which is split
 	// between LeaseManager and tableState.
-	return t.release(lease, m.LeaseStore)
+	return t.release(lease, m)
+}
+
+func (m *LeaseManager) isDraining() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.draining
+}
+
+// SetDraining (when called with 'true') removes all inactive leases. Any leases
+// that are active will be removed once the lease's reference count drops to 0.
+func (m *LeaseManager) SetDraining(drain bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.draining = drain
+	if !drain {
+		return
+	}
+	for _, t := range m.tables {
+		t.mu.Lock()
+		t.releaseInactiveLeases(m.LeaseStore)
+		t.mu.Unlock()
+	}
 }
 
 // If create is set, cache and stopper need to be set as well.
@@ -1213,7 +1231,7 @@ func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *client.DB, gossip *gos
 						// Try to refresh the table lease to one >= this version.
 						if t := m.findTableState(table.ID, false /* create */); t != nil {
 							if err := t.purgeOldLeases(
-								db, table.Dropped(), table.Version, m.LeaseStore); err != nil {
+								db, table.Dropped(), table.Version, m); err != nil {
 								log.Warningf(context.TODO(), "error purging leases for table %d(%s): %s",
 									table.ID, table.Name, err)
 							}

--- a/pkg/sql/lease_internal_test.go
+++ b/pkg/sql/lease_internal_test.go
@@ -179,7 +179,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	}
 
 	if err := ts.purgeOldLeases(
-		kvDB, false, 1 /* minVersion */, leaseManager.LeaseStore); err != nil {
+		kvDB, false, 1 /* minVersion */, leaseManager); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -405,6 +405,63 @@ func TestLeaseManagerPublishVersionChanged(testingT *testing.T) {
 	t.expectLeases(descID, "/3/1")
 }
 
+func TestLeaseManagerDrain(testingT *testing.T) {
+	defer leaktest.AfterTest(testingT)()
+	params, _ := createTestServerParams()
+	leaseRemovalTracker := csql.NewLeaseRemovalTracker()
+	params.Knobs = base.TestingKnobs{
+		SQLLeaseManager: &csql.LeaseManagerTestingKnobs{
+			LeaseStoreTestingKnobs: csql.LeaseStoreTestingKnobs{
+				LeaseReleasedEvent: leaseRemovalTracker.LeaseRemovedNotification,
+			},
+		},
+	}
+	t := newLeaseTest(testingT, params)
+	defer t.cleanup()
+
+	const descID = keys.LeaseTableID
+
+	{
+		l1 := t.mustAcquire(1, descID, 0)
+		l2 := t.mustAcquire(2, descID, 0)
+		t.mustRelease(1, l1, nil)
+		t.expectLeases(descID, "/1/1 /1/2")
+
+		// Removal tracker to track for node 1's lease removal once the node
+		// starts draining.
+		l1RemovalTracker := leaseRemovalTracker.TrackRemoval(l1)
+
+		t.nodes[1].SetDraining(true)
+		t.nodes[2].SetDraining(true)
+
+		// Leases cannot be acquired when in draining mode.
+		if _, err := t.acquire(1, descID, 0); !testutils.IsError(err, "cannot acquire lease when draining") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Node 1's lease has a refcount of 0 and should therefore be removed from
+		// the store.
+		if err := l1RemovalTracker.WaitForRemoval(); err != nil {
+			t.Fatal(err)
+		}
+		t.expectLeases(descID, "/1/2")
+
+		// Once node 2's lease is released, the lease should be removed from the
+		// store.
+		t.mustRelease(2, l2, leaseRemovalTracker)
+		t.expectLeases(descID, "")
+	}
+
+	{
+		// Check that leases with a refcount of 0 are correctly kept in the
+		// store once the drain mode has been exited.
+		t.nodes[1].SetDraining(false)
+		l1 := t.mustAcquire(1, descID, 0)
+		t.mustRelease(1, l1, nil)
+		t.expectLeases(descID, "/1/1")
+	}
+}
+
 // Test that we fail to lease a table that was marked for deletion.
 func TestCantLeaseDeletedTable(testingT *testing.T) {
 	defer leaktest.AfterTest(testingT)()


### PR DESCRIPTION
Fixes #9493 by deleting all unreferenced table descriptor leases on
clean shutdown. Leases whose refcount drops to 0 while in this drain
mode are also deleted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12501)
<!-- Reviewable:end -->
