### PR TITLE
Various usability improvements for EXPLAIN(PLAN).

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -708,7 +708,7 @@ func Example_sql() {
 	// t
 	// sql -e explain select 3
 	// 1 row
-	// Level	Type	Description
+	// Level	Type	Field	Description
 	// 0	nullrow
 	// sql -e select 1; select 2
 	// 1 row

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -709,7 +709,7 @@ func Example_sql() {
 	// sql -e explain select 3
 	// 1 row
 	// Level	Type	Description
-	// 0	empty	-
+	// 0	nullrow
 	// sql -e select 1; select 2
 	// 1 row
 	// 1

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -746,6 +746,7 @@ func Example_sql_escape() {
 	c.RunWithArgs([]string{"sql", "--pretty", "-e", "show columns from t.u"})
 	c.RunWithArgs([]string{"sql", "--pretty", "-e", "select * from t.u"})
 	c.RunWithArgs([]string{"sql", "--pretty", "-e", "select '  hai' as x"})
+	c.RunWithArgs([]string{"sql", "--pretty", "-e", "explain(indent) select s from t.t union all select s from t.t"})
 
 	// Output:
 	// sql -e create database t; create table t.t (s string, d string);
@@ -845,6 +846,15 @@ func Example_sql_escape() {
 	// | ‌  hai |
 	// +-------+
 	// (1 row)
+	// sql --pretty -e explain(indent) select s from t.t union all select s from t.t
+	// +-------+-------+-------+----------------------+
+	// | Level | Type  | Field |     Description      |
+	// +-------+-------+-------+----------------------+
+	// |     0 | union |       | -> union -           |
+	// |     1 | scan  |       | ‌   -> scan t@primary |
+	// |     1 | scan  |       | ‌   -> scan t@primary |
+	// +-------+-------+-------+----------------------+
+	// (3 rows)
 }
 
 func Example_user() {

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -745,6 +745,7 @@ func Example_sql_escape() {
 	c.RunWithArgs([]string{"sql", "--pretty", "-e", "select * from t.t"})
 	c.RunWithArgs([]string{"sql", "--pretty", "-e", "show columns from t.u"})
 	c.RunWithArgs([]string{"sql", "--pretty", "-e", "select * from t.u"})
+	c.RunWithArgs([]string{"sql", "--pretty", "-e", "select '  hai' as x"})
 
 	// Output:
 	// sql -e create database t; create table t.t (s string, d string);
@@ -836,6 +837,13 @@ func Example_sql_escape() {
 	// +------+------+------------+-------+-----+
 	// |    0 |    0 |          0 |     0 |   0 |
 	// +------+------+------------+-------+-----+
+	// (1 row)
+	// sql --pretty -e select '  hai' as x
+	// +-------+
+	// |   x   |
+	// +-------+
+	// | ‌  hai |
+	// +-------+
 	// (1 row)
 }
 

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -366,7 +366,7 @@ func printQueryOutput(w io.Writer, cols []string, allRows [][]string, tag string
 			// Then print the results themselves.
 			fmt.Fprintln(w, strings.Join(cols, "\t"))
 			for _, row := range allRows {
-				fmt.Fprintln(w, strings.Join(row, "\t"))
+				fmt.Fprintln(w, strings.TrimRight(strings.Join(row, "\t"), "\t "))
 			}
 		}
 	}

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -348,6 +348,17 @@ func printQueryOutput(w io.Writer, cols []string, allRows [][]string, tag string
 		for _, row := range allRows {
 			for i, r := range row {
 				row[i] = expandTabsAndNewLines(r)
+				if firstChar, _ := utf8.DecodeRuneInString(row[i]); unicode.IsSpace(firstChar) {
+					// table.Append below trims whitespace in order to compute
+					// the padding. This is unfortunate, since leading spaces
+					// can be usefully exploited for formatting. Disable
+					// trimming by inserting an invisible unicode character
+					// (left-to-right mark) at the start.
+					// TODO(knz) We can revisit this once
+					// https://github.com/olekukonko/tablewriter/issues/52 is
+					// fixed (or we use another table writer).
+					row[i] = "\u200C" + row[i]
+				}
 			}
 			table.Append(row)
 		}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -395,16 +395,16 @@ func (n *alterTableNode) Start() error {
 	return nil
 }
 
-func (n *alterTableNode) Next() (bool, error)                 { return false, nil }
-func (n *alterTableNode) Close()                              {}
-func (n *alterTableNode) Columns() ResultColumns              { return make(ResultColumns, 0) }
-func (n *alterTableNode) Ordering() orderingInfo              { return orderingInfo{} }
-func (n *alterTableNode) Values() parser.DTuple               { return parser.DTuple{} }
-func (n *alterTableNode) DebugValues() debugValues            { return debugValues{} }
-func (n *alterTableNode) ExplainTypes(_ func(string, string)) {}
-func (n *alterTableNode) SetLimitHint(_ int64, _ bool)        {}
-func (n *alterTableNode) setNeededColumns(_ []bool)           {}
-func (n *alterTableNode) MarkDebug(mode explainMode)          {}
+func (n *alterTableNode) Next() (bool, error)                      { return false, nil }
+func (n *alterTableNode) Close()                                   {}
+func (n *alterTableNode) Columns() ResultColumns                   { return make(ResultColumns, 0) }
+func (n *alterTableNode) Ordering() orderingInfo                   { return orderingInfo{} }
+func (n *alterTableNode) Values() parser.DTuple                    { return parser.DTuple{} }
+func (n *alterTableNode) DebugValues() debugValues                 { return debugValues{} }
+func (n *alterTableNode) explainExprs(_ func(string, parser.Expr)) {}
+func (n *alterTableNode) SetLimitHint(_ int64, _ bool)             {}
+func (n *alterTableNode) setNeededColumns(_ []bool)                {}
+func (n *alterTableNode) MarkDebug(mode explainMode)               {}
 func (n *alterTableNode) ExplainPlan(v bool) (string, string, []planNode) {
 	return "alter table", "", nil
 }

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -49,15 +49,15 @@ type copyNode struct {
 	rowsMemAcc    WrappableMemoryAccount
 }
 
-func (n *copyNode) Columns() ResultColumns            { return n.resultColumns }
-func (*copyNode) Ordering() orderingInfo              { return orderingInfo{} }
-func (*copyNode) Values() parser.DTuple               { return nil }
-func (*copyNode) ExplainTypes(_ func(string, string)) {}
-func (*copyNode) SetLimitHint(_ int64, _ bool)        {}
-func (*copyNode) setNeededColumns(_ []bool)           {}
-func (*copyNode) MarkDebug(_ explainMode)             {}
-func (*copyNode) expandPlan() error                   { return nil }
-func (*copyNode) Next() (bool, error)                 { return false, nil }
+func (n *copyNode) Columns() ResultColumns                 { return n.resultColumns }
+func (*copyNode) Ordering() orderingInfo                   { return orderingInfo{} }
+func (*copyNode) Values() parser.DTuple                    { return nil }
+func (*copyNode) explainExprs(_ func(string, parser.Expr)) {}
+func (*copyNode) SetLimitHint(_ int64, _ bool)             {}
+func (*copyNode) setNeededColumns(_ []bool)                {}
+func (*copyNode) MarkDebug(_ explainMode)                  {}
+func (*copyNode) expandPlan() error                        { return nil }
+func (*copyNode) Next() (bool, error)                      { return false, nil }
 
 func (n *copyNode) Close() {
 	n.rowsMemAcc.Wtxn(n.p.session).Close()

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -136,16 +136,16 @@ func (n *createDatabaseNode) Start() error {
 	return nil
 }
 
-func (n *createDatabaseNode) Next() (bool, error)                 { return false, nil }
-func (n *createDatabaseNode) Close()                              {}
-func (n *createDatabaseNode) Columns() ResultColumns              { return make(ResultColumns, 0) }
-func (n *createDatabaseNode) Ordering() orderingInfo              { return orderingInfo{} }
-func (n *createDatabaseNode) Values() parser.DTuple               { return parser.DTuple{} }
-func (n *createDatabaseNode) DebugValues() debugValues            { return debugValues{} }
-func (n *createDatabaseNode) ExplainTypes(_ func(string, string)) {}
-func (n *createDatabaseNode) SetLimitHint(_ int64, _ bool)        {}
-func (n *createDatabaseNode) setNeededColumns(_ []bool)           {}
-func (n *createDatabaseNode) MarkDebug(mode explainMode)          {}
+func (n *createDatabaseNode) Next() (bool, error)                      { return false, nil }
+func (n *createDatabaseNode) Close()                                   {}
+func (n *createDatabaseNode) Columns() ResultColumns                   { return make(ResultColumns, 0) }
+func (n *createDatabaseNode) Ordering() orderingInfo                   { return orderingInfo{} }
+func (n *createDatabaseNode) Values() parser.DTuple                    { return parser.DTuple{} }
+func (n *createDatabaseNode) DebugValues() debugValues                 { return debugValues{} }
+func (n *createDatabaseNode) explainExprs(_ func(string, parser.Expr)) {}
+func (n *createDatabaseNode) SetLimitHint(_ int64, _ bool)             {}
+func (n *createDatabaseNode) setNeededColumns(_ []bool)                {}
+func (n *createDatabaseNode) MarkDebug(mode explainMode)               {}
 func (n *createDatabaseNode) ExplainPlan(v bool) (string, string, []planNode) {
 	return "create database", "", nil
 }
@@ -256,16 +256,16 @@ func (n *createIndexNode) Start() error {
 	return nil
 }
 
-func (n *createIndexNode) Next() (bool, error)                 { return false, nil }
-func (n *createIndexNode) Close()                              {}
-func (n *createIndexNode) Columns() ResultColumns              { return make(ResultColumns, 0) }
-func (n *createIndexNode) Ordering() orderingInfo              { return orderingInfo{} }
-func (n *createIndexNode) Values() parser.DTuple               { return parser.DTuple{} }
-func (n *createIndexNode) DebugValues() debugValues            { return debugValues{} }
-func (n *createIndexNode) ExplainTypes(_ func(string, string)) {}
-func (n *createIndexNode) SetLimitHint(_ int64, _ bool)        {}
-func (n *createIndexNode) setNeededColumns(_ []bool)           {}
-func (n *createIndexNode) MarkDebug(mode explainMode)          {}
+func (n *createIndexNode) Next() (bool, error)                      { return false, nil }
+func (n *createIndexNode) Close()                                   {}
+func (n *createIndexNode) Columns() ResultColumns                   { return make(ResultColumns, 0) }
+func (n *createIndexNode) Ordering() orderingInfo                   { return orderingInfo{} }
+func (n *createIndexNode) Values() parser.DTuple                    { return parser.DTuple{} }
+func (n *createIndexNode) DebugValues() debugValues                 { return debugValues{} }
+func (n *createIndexNode) explainExprs(_ func(string, parser.Expr)) {}
+func (n *createIndexNode) SetLimitHint(_ int64, _ bool)             {}
+func (n *createIndexNode) setNeededColumns(_ []bool)                {}
+func (n *createIndexNode) MarkDebug(mode explainMode)               {}
 func (n *createIndexNode) ExplainPlan(v bool) (string, string, []planNode) {
 	return "create index", "", nil
 }
@@ -349,16 +349,16 @@ func (n *createUserNode) Start() error {
 	return nil
 }
 
-func (n *createUserNode) Next() (bool, error)                 { return false, nil }
-func (n *createUserNode) Close()                              {}
-func (n *createUserNode) Columns() ResultColumns              { return make(ResultColumns, 0) }
-func (n *createUserNode) Ordering() orderingInfo              { return orderingInfo{} }
-func (n *createUserNode) Values() parser.DTuple               { return parser.DTuple{} }
-func (n *createUserNode) DebugValues() debugValues            { return debugValues{} }
-func (n *createUserNode) ExplainTypes(_ func(string, string)) {}
-func (n *createUserNode) SetLimitHint(_ int64, _ bool)        {}
-func (n *createUserNode) setNeededColumns(_ []bool)           {}
-func (n *createUserNode) MarkDebug(mode explainMode)          {}
+func (n *createUserNode) Next() (bool, error)                      { return false, nil }
+func (n *createUserNode) Close()                                   {}
+func (n *createUserNode) Columns() ResultColumns                   { return make(ResultColumns, 0) }
+func (n *createUserNode) Ordering() orderingInfo                   { return orderingInfo{} }
+func (n *createUserNode) Values() parser.DTuple                    { return parser.DTuple{} }
+func (n *createUserNode) DebugValues() debugValues                 { return debugValues{} }
+func (n *createUserNode) explainExprs(_ func(string, parser.Expr)) {}
+func (n *createUserNode) SetLimitHint(_ int64, _ bool)             {}
+func (n *createUserNode) setNeededColumns(_ []bool)                {}
+func (n *createUserNode) MarkDebug(mode explainMode)               {}
 func (n *createUserNode) ExplainPlan(v bool) (string, string, []planNode) {
 	return "create user", "", nil
 }
@@ -504,16 +504,16 @@ func (n *createViewNode) Close() {
 	n.sourcePlan = nil
 }
 
-func (n *createViewNode) expandPlan() error                   { return n.sourcePlan.expandPlan() }
-func (n *createViewNode) Next() (bool, error)                 { return false, nil }
-func (n *createViewNode) Columns() ResultColumns              { return make(ResultColumns, 0) }
-func (n *createViewNode) Ordering() orderingInfo              { return orderingInfo{} }
-func (n *createViewNode) Values() parser.DTuple               { return parser.DTuple{} }
-func (n *createViewNode) DebugValues() debugValues            { return debugValues{} }
-func (n *createViewNode) ExplainTypes(_ func(string, string)) {}
-func (n *createViewNode) setNeededColumns(_ []bool)           {}
-func (n *createViewNode) SetLimitHint(_ int64, _ bool)        {}
-func (n *createViewNode) MarkDebug(mode explainMode)          {}
+func (n *createViewNode) expandPlan() error                        { return n.sourcePlan.expandPlan() }
+func (n *createViewNode) Next() (bool, error)                      { return false, nil }
+func (n *createViewNode) Columns() ResultColumns                   { return make(ResultColumns, 0) }
+func (n *createViewNode) Ordering() orderingInfo                   { return orderingInfo{} }
+func (n *createViewNode) Values() parser.DTuple                    { return parser.DTuple{} }
+func (n *createViewNode) DebugValues() debugValues                 { return debugValues{} }
+func (n *createViewNode) explainExprs(_ func(string, parser.Expr)) {}
+func (n *createViewNode) setNeededColumns(_ []bool)                {}
+func (n *createViewNode) SetLimitHint(_ int64, _ bool)             {}
+func (n *createViewNode) MarkDebug(mode explainMode)               {}
 func (n *createViewNode) ExplainPlan(v bool) (string, string, []planNode) {
 	return "create view", "", nil
 }
@@ -739,15 +739,15 @@ func (n *createTableNode) Close() {
 	}
 }
 
-func (n *createTableNode) Next() (bool, error)                 { return false, nil }
-func (n *createTableNode) Columns() ResultColumns              { return make(ResultColumns, 0) }
-func (n *createTableNode) Ordering() orderingInfo              { return orderingInfo{} }
-func (n *createTableNode) Values() parser.DTuple               { return parser.DTuple{} }
-func (n *createTableNode) DebugValues() debugValues            { return debugValues{} }
-func (n *createTableNode) ExplainTypes(_ func(string, string)) {}
-func (n *createTableNode) SetLimitHint(_ int64, _ bool)        {}
-func (n *createTableNode) setNeededColumns(_ []bool)           {}
-func (n *createTableNode) MarkDebug(mode explainMode)          {}
+func (n *createTableNode) Next() (bool, error)                      { return false, nil }
+func (n *createTableNode) Columns() ResultColumns                   { return make(ResultColumns, 0) }
+func (n *createTableNode) Ordering() orderingInfo                   { return orderingInfo{} }
+func (n *createTableNode) Values() parser.DTuple                    { return parser.DTuple{} }
+func (n *createTableNode) DebugValues() debugValues                 { return debugValues{} }
+func (n *createTableNode) explainExprs(_ func(string, parser.Expr)) {}
+func (n *createTableNode) SetLimitHint(_ int64, _ bool)             {}
+func (n *createTableNode) setNeededColumns(_ []bool)                {}
+func (n *createTableNode) MarkDebug(mode explainMode)               {}
 func (n *createTableNode) ExplainPlan(v bool) (string, string, []planNode) {
 	if n.n.As() {
 		return "create table", "create table as", []planNode{n.sourcePlan}

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -725,7 +725,7 @@ func (src *dataSourceInfo) findTableAlias(colIdx int) (parser.TableName, bool) {
 }
 
 func (src *dataSourceInfo) FormatVar(buf *bytes.Buffer, f parser.FmtFlags, colIdx int) {
-	if f == parser.FmtQualify {
+	if f.ShowTableAliases {
 		tableAlias, found := src.findTableAlias(colIdx)
 		if found {
 			if tableAlias.TableName != "" {

--- a/pkg/sql/delayed.go
+++ b/pkg/sql/delayed.go
@@ -61,11 +61,11 @@ func (d *delayedNode) ExplainPlan(verbose bool) (name, description string, child
 	return "virtual table", d.name, children
 }
 
-func (d *delayedNode) ExplainTypes(rt func(string, string)) {}
-func (d *delayedNode) Columns() ResultColumns               { return d.columns }
-func (d *delayedNode) Ordering() orderingInfo               { return orderingInfo{} }
-func (d *delayedNode) MarkDebug(_ explainMode)              {}
-func (d *delayedNode) Start() error                         { return d.plan.Start() }
-func (d *delayedNode) Next() (bool, error)                  { return d.plan.Next() }
-func (d *delayedNode) Values() parser.DTuple                { return d.plan.Values() }
-func (d *delayedNode) DebugValues() debugValues             { return d.plan.DebugValues() }
+func (d *delayedNode) explainExprs(rt func(string, parser.Expr)) {}
+func (d *delayedNode) Columns() ResultColumns                    { return d.columns }
+func (d *delayedNode) Ordering() orderingInfo                    { return orderingInfo{} }
+func (d *delayedNode) MarkDebug(_ explainMode)                   {}
+func (d *delayedNode) Start() error                              { return d.plan.Start() }
+func (d *delayedNode) Next() (bool, error)                       { return d.plan.Next() }
+func (d *delayedNode) Values() parser.DTuple                     { return d.plan.Values() }
+func (d *delayedNode) DebugValues() debugValues                  { return d.plan.DebugValues() }

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -264,10 +264,10 @@ func (d *deleteNode) ExplainPlan(v bool) (name, description string, children []p
 	return "delete", buf.String(), subplans
 }
 
-func (d *deleteNode) ExplainTypes(regTypes func(string, string)) {
+func (d *deleteNode) explainExprs(regTypes func(string, parser.Expr)) {
 	cols := d.rh.columns
 	for i, rexpr := range d.rh.exprs {
-		regTypes(fmt.Sprintf("returning %s", cols[i].Name), parser.AsStringWithFlags(rexpr, parser.FmtShowTypes))
+		regTypes(fmt.Sprintf("returning %s", cols[i].Name), rexpr)
 	}
 }
 

--- a/pkg/sql/distinct.go
+++ b/pkg/sql/distinct.go
@@ -248,7 +248,7 @@ func (n *distinctNode) ExplainPlan(_ bool) (string, string, []planNode) {
 	return "distinct", description, []planNode{n.plan}
 }
 
-func (n *distinctNode) ExplainTypes(_ func(string, string)) {}
+func (n *distinctNode) explainExprs(_ func(string, parser.Expr)) {}
 
 func (n *distinctNode) SetLimitHint(numRows int64, soft bool) {
 	// Any limit becomes a "soft" limit underneath.

--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -210,16 +210,16 @@ func (n *dropDatabaseNode) Start() error {
 	return nil
 }
 
-func (n *dropDatabaseNode) Next() (bool, error)                 { return false, nil }
-func (n *dropDatabaseNode) Close()                              {}
-func (n *dropDatabaseNode) Columns() ResultColumns              { return make(ResultColumns, 0) }
-func (n *dropDatabaseNode) Ordering() orderingInfo              { return orderingInfo{} }
-func (n *dropDatabaseNode) Values() parser.DTuple               { return parser.DTuple{} }
-func (n *dropDatabaseNode) DebugValues() debugValues            { return debugValues{} }
-func (n *dropDatabaseNode) ExplainTypes(_ func(string, string)) {}
-func (n *dropDatabaseNode) SetLimitHint(_ int64, _ bool)        {}
-func (n *dropDatabaseNode) setNeededColumns(_ []bool)           {}
-func (n *dropDatabaseNode) MarkDebug(mode explainMode)          {}
+func (n *dropDatabaseNode) Next() (bool, error)                      { return false, nil }
+func (n *dropDatabaseNode) Close()                                   {}
+func (n *dropDatabaseNode) Columns() ResultColumns                   { return make(ResultColumns, 0) }
+func (n *dropDatabaseNode) Ordering() orderingInfo                   { return orderingInfo{} }
+func (n *dropDatabaseNode) Values() parser.DTuple                    { return parser.DTuple{} }
+func (n *dropDatabaseNode) DebugValues() debugValues                 { return debugValues{} }
+func (n *dropDatabaseNode) explainExprs(_ func(string, parser.Expr)) {}
+func (n *dropDatabaseNode) SetLimitHint(_ int64, _ bool)             {}
+func (n *dropDatabaseNode) setNeededColumns(_ []bool)                {}
+func (n *dropDatabaseNode) MarkDebug(mode explainMode)               {}
 func (n *dropDatabaseNode) ExplainPlan(v bool) (string, string, []planNode) {
 	return "drop database", "", nil
 }
@@ -391,16 +391,16 @@ func (n *dropIndexNode) Start() error {
 	return nil
 }
 
-func (n *dropIndexNode) Next() (bool, error)                 { return false, nil }
-func (n *dropIndexNode) Close()                              {}
-func (n *dropIndexNode) Columns() ResultColumns              { return make(ResultColumns, 0) }
-func (n *dropIndexNode) Ordering() orderingInfo              { return orderingInfo{} }
-func (n *dropIndexNode) Values() parser.DTuple               { return parser.DTuple{} }
-func (n *dropIndexNode) DebugValues() debugValues            { return debugValues{} }
-func (n *dropIndexNode) ExplainTypes(_ func(string, string)) {}
-func (n *dropIndexNode) SetLimitHint(_ int64, _ bool)        {}
-func (n *dropIndexNode) setNeededColumns(_ []bool)           {}
-func (n *dropIndexNode) MarkDebug(mode explainMode)          {}
+func (n *dropIndexNode) Next() (bool, error)                      { return false, nil }
+func (n *dropIndexNode) Close()                                   {}
+func (n *dropIndexNode) Columns() ResultColumns                   { return make(ResultColumns, 0) }
+func (n *dropIndexNode) Ordering() orderingInfo                   { return orderingInfo{} }
+func (n *dropIndexNode) Values() parser.DTuple                    { return parser.DTuple{} }
+func (n *dropIndexNode) DebugValues() debugValues                 { return debugValues{} }
+func (n *dropIndexNode) explainExprs(_ func(string, parser.Expr)) {}
+func (n *dropIndexNode) SetLimitHint(_ int64, _ bool)             {}
+func (n *dropIndexNode) setNeededColumns(_ []bool)                {}
+func (n *dropIndexNode) MarkDebug(mode explainMode)               {}
 func (n *dropIndexNode) ExplainPlan(v bool) (string, string, []planNode) {
 	return "drop index", "", nil
 }
@@ -508,16 +508,16 @@ func (n *dropViewNode) Start() error {
 	return nil
 }
 
-func (n *dropViewNode) Next() (bool, error)                 { return false, nil }
-func (n *dropViewNode) Close()                              {}
-func (n *dropViewNode) Columns() ResultColumns              { return make(ResultColumns, 0) }
-func (n *dropViewNode) Ordering() orderingInfo              { return orderingInfo{} }
-func (n *dropViewNode) Values() parser.DTuple               { return parser.DTuple{} }
-func (n *dropViewNode) ExplainTypes(_ func(string, string)) {}
-func (n *dropViewNode) DebugValues() debugValues            { return debugValues{} }
-func (n *dropViewNode) SetLimitHint(_ int64, _ bool)        {}
-func (n *dropViewNode) setNeededColumns(_ []bool)           {}
-func (n *dropViewNode) MarkDebug(mode explainMode)          {}
+func (n *dropViewNode) Next() (bool, error)                      { return false, nil }
+func (n *dropViewNode) Close()                                   {}
+func (n *dropViewNode) Columns() ResultColumns                   { return make(ResultColumns, 0) }
+func (n *dropViewNode) Ordering() orderingInfo                   { return orderingInfo{} }
+func (n *dropViewNode) Values() parser.DTuple                    { return parser.DTuple{} }
+func (n *dropViewNode) explainExprs(_ func(string, parser.Expr)) {}
+func (n *dropViewNode) DebugValues() debugValues                 { return debugValues{} }
+func (n *dropViewNode) SetLimitHint(_ int64, _ bool)             {}
+func (n *dropViewNode) setNeededColumns(_ []bool)                {}
+func (n *dropViewNode) MarkDebug(mode explainMode)               {}
 func (n *dropViewNode) ExplainPlan(v bool) (string, string, []planNode) {
 	return "drop view", "", nil
 }
@@ -737,16 +737,16 @@ func (n *dropTableNode) Start() error {
 	return nil
 }
 
-func (n *dropTableNode) Next() (bool, error)                 { return false, nil }
-func (n *dropTableNode) Close()                              {}
-func (n *dropTableNode) Columns() ResultColumns              { return make(ResultColumns, 0) }
-func (n *dropTableNode) Ordering() orderingInfo              { return orderingInfo{} }
-func (n *dropTableNode) Values() parser.DTuple               { return parser.DTuple{} }
-func (n *dropTableNode) ExplainTypes(_ func(string, string)) {}
-func (n *dropTableNode) DebugValues() debugValues            { return debugValues{} }
-func (n *dropTableNode) SetLimitHint(_ int64, _ bool)        {}
-func (n *dropTableNode) setNeededColumns(_ []bool)           {}
-func (n *dropTableNode) MarkDebug(mode explainMode)          {}
+func (n *dropTableNode) Next() (bool, error)                      { return false, nil }
+func (n *dropTableNode) Close()                                   {}
+func (n *dropTableNode) Columns() ResultColumns                   { return make(ResultColumns, 0) }
+func (n *dropTableNode) Ordering() orderingInfo                   { return orderingInfo{} }
+func (n *dropTableNode) Values() parser.DTuple                    { return parser.DTuple{} }
+func (n *dropTableNode) explainExprs(_ func(string, parser.Expr)) {}
+func (n *dropTableNode) DebugValues() debugValues                 { return debugValues{} }
+func (n *dropTableNode) SetLimitHint(_ int64, _ bool)             {}
+func (n *dropTableNode) setNeededColumns(_ []bool)                {}
+func (n *dropTableNode) MarkDebug(mode explainMode)               {}
 func (n *dropTableNode) ExplainPlan(v bool) (string, string, []planNode) {
 	return "drop table", "", nil
 }

--- a/pkg/sql/empty.go
+++ b/pkg/sql/empty.go
@@ -38,8 +38,12 @@ func (*emptyNode) MarkDebug(_ explainMode)             {}
 func (*emptyNode) expandPlan() error                   { return nil }
 func (*emptyNode) Close()                              {}
 
-func (*emptyNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
-	return "empty", "-", nil
+func (e *emptyNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
+	name = "empty"
+	if e.results {
+		name = "nullrow"
+	}
+	return name, "", nil
 }
 
 func (e *emptyNode) DebugValues() debugValues {

--- a/pkg/sql/empty.go
+++ b/pkg/sql/empty.go
@@ -27,16 +27,16 @@ type emptyNode struct {
 	results bool
 }
 
-func (*emptyNode) Columns() ResultColumns              { return nil }
-func (*emptyNode) Ordering() orderingInfo              { return orderingInfo{} }
-func (*emptyNode) Values() parser.DTuple               { return nil }
-func (*emptyNode) ExplainTypes(_ func(string, string)) {}
-func (*emptyNode) Start() error                        { return nil }
-func (*emptyNode) SetLimitHint(_ int64, _ bool)        {}
-func (*emptyNode) setNeededColumns(_ []bool)           {}
-func (*emptyNode) MarkDebug(_ explainMode)             {}
-func (*emptyNode) expandPlan() error                   { return nil }
-func (*emptyNode) Close()                              {}
+func (*emptyNode) Columns() ResultColumns                   { return nil }
+func (*emptyNode) Ordering() orderingInfo                   { return orderingInfo{} }
+func (*emptyNode) Values() parser.DTuple                    { return nil }
+func (*emptyNode) explainExprs(_ func(string, parser.Expr)) {}
+func (*emptyNode) Start() error                             { return nil }
+func (*emptyNode) SetLimitHint(_ int64, _ bool)             {}
+func (*emptyNode) setNeededColumns(_ []bool)                {}
+func (*emptyNode) MarkDebug(_ explainMode)                  {}
+func (*emptyNode) expandPlan() error                        { return nil }
+func (*emptyNode) Close()                                   {}
 
 func (e *emptyNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
 	name = "empty"

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -129,9 +129,10 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, error) 
 		}
 
 		node := &explainPlanNode{
-			verbose: verbose,
-			plan:    plan,
-			results: p.newContainerValuesNode(columns, 0),
+			verbose:  verbose,
+			expanded: expanded,
+			plan:     plan,
+			results:  p.newContainerValuesNode(columns, 0),
 		}
 		return node, nil
 

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -118,23 +118,7 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, error) 
 		return node, nil
 
 	case explainPlan:
-		columns := ResultColumns{
-			{Name: "Level", Typ: parser.TypeInt},
-			{Name: "Type", Typ: parser.TypeString},
-			{Name: "Description", Typ: parser.TypeString},
-		}
-		if verbose {
-			columns = append(columns, ResultColumn{Name: "Columns", Typ: parser.TypeString})
-			columns = append(columns, ResultColumn{Name: "Ordering", Typ: parser.TypeString})
-		}
-
-		node := &explainPlanNode{
-			verbose:  verbose,
-			expanded: expanded,
-			plan:     plan,
-			results:  p.newContainerValuesNode(columns, 0),
-		}
-		return node, nil
+		return p.makeExplainPlanNode(verbose, expanded, plan), nil
 
 	case explainTrace:
 		return p.makeTraceNode(plan, p.txn), nil

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -229,7 +229,7 @@ func (n *explainDebugNode) ExplainPlan(v bool) (name, description string, childr
 	return n.plan.ExplainPlan(v)
 }
 
-func (n *explainDebugNode) ExplainTypes(fn func(string, string)) {}
+func (n *explainDebugNode) explainExprs(fn func(string, parser.Expr)) {}
 
 func (n *explainDebugNode) Values() parser.DTuple {
 	vals := n.plan.DebugValues()

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -51,6 +51,7 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, error) 
 		showSelectTop: false,
 		showExprs:     false,
 		showTypes:     false,
+		doIndent:      false,
 	}
 
 	for _, opt := range n.Options {
@@ -68,6 +69,8 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, error) 
 			// TYPES implies VERBOSE.
 			explainer.showSelectTop = true
 			explainer.showMetadata = true
+		} else if strings.EqualFold(opt, "INDENT") {
+			explainer.doIndent = true
 		} else if strings.EqualFold(opt, "VERBOSE") {
 			explainer.showSelectTop = true
 			explainer.showMetadata = true

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -17,7 +17,6 @@
 package sql
 
 import (
-	"bytes"
 	"fmt"
 	"math"
 	"strings"
@@ -186,44 +185,6 @@ func (e *explainTypesNode) Close() {
 	e.results.Close()
 }
 
-func formatColumns(cols ResultColumns, printTypes bool) string {
-	var buf bytes.Buffer
-	buf.WriteByte('(')
-	for i, rCol := range cols {
-		if i > 0 {
-			buf.WriteString(", ")
-		}
-		parser.Name(rCol.Name).Format(&buf, parser.FmtSimple)
-		// Output extra properties like [hidden,omitted].
-		hasProps := false
-		outputProp := func(prop string) {
-			if hasProps {
-				buf.WriteByte(',')
-			} else {
-				buf.WriteByte('[')
-			}
-			hasProps = true
-			buf.WriteString(prop)
-		}
-		if rCol.hidden {
-			outputProp("hidden")
-		}
-		if rCol.omitted {
-			outputProp("omitted")
-		}
-		if hasProps {
-			buf.WriteByte(']')
-		}
-
-		if printTypes {
-			buf.WriteByte(' ')
-			buf.WriteString(rCol.Typ.String())
-		}
-	}
-	buf.WriteByte(')')
-	return buf.String()
-}
-
 func populateTypes(v *valuesNode, plan planNode, level int) error {
 	name, _, children := plan.ExplainPlan(true)
 
@@ -266,69 +227,6 @@ func populateTypes(v *valuesNode, plan planNode, level int) error {
 		}
 	}
 
-	return nil
-}
-
-type explainPlanNode struct {
-	verbose bool
-	plan    planNode
-	results *valuesNode
-}
-
-func (e *explainPlanNode) ExplainTypes(fn func(string, string)) {}
-func (e *explainPlanNode) Next() (bool, error)                  { return e.results.Next() }
-func (e *explainPlanNode) Columns() ResultColumns               { return e.results.Columns() }
-func (e *explainPlanNode) Ordering() orderingInfo               { return e.results.Ordering() }
-func (e *explainPlanNode) Values() parser.DTuple                { return e.results.Values() }
-func (e *explainPlanNode) DebugValues() debugValues             { return debugValues{} }
-func (e *explainPlanNode) SetLimitHint(n int64, s bool)         { e.results.SetLimitHint(n, s) }
-func (e *explainPlanNode) setNeededColumns(_ []bool)            {}
-func (e *explainPlanNode) MarkDebug(mode explainMode)           {}
-func (e *explainPlanNode) expandPlan() error {
-	if err := e.plan.expandPlan(); err != nil {
-		return err
-	}
-	// Trigger limit hint propagation, which would otherwise only occur
-	// during the plan's Start() phase. This may trigger additional
-	// optimizations (eg. in sortNode) which the user of EXPLAIN will be
-	// interested in.
-	e.plan.SetLimitHint(math.MaxInt64, true)
-	return nil
-}
-func (e *explainPlanNode) ExplainPlan(v bool) (string, string, []planNode) {
-	return "explain", "plan", []planNode{e.plan}
-}
-
-func (e *explainPlanNode) Start() error {
-	return populateExplain(e.verbose, e.results, e.plan, 0)
-}
-
-func (e *explainPlanNode) Close() {
-	e.plan.Close()
-	e.results.Close()
-}
-
-func populateExplain(verbose bool, v *valuesNode, plan planNode, level int) error {
-	name, description, children := plan.ExplainPlan(verbose)
-
-	row := parser.DTuple{
-		parser.NewDInt(parser.DInt(level)),
-		parser.NewDString(name),
-		parser.NewDString(description),
-	}
-	if verbose {
-		row = append(row, parser.NewDString(formatColumns(plan.Columns(), false)))
-		row = append(row, parser.NewDString(plan.Ordering().AsString(plan.Columns())))
-	}
-	if _, err := v.rows.AddRow(row); err != nil {
-		return err
-	}
-
-	for _, child := range children {
-		if err := populateExplain(verbose, v, child, level+1); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -71,6 +71,10 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, error) 
 			explainer.showMetadata = true
 		} else if strings.EqualFold(opt, "INDENT") {
 			explainer.doIndent = true
+		} else if strings.EqualFold(opt, "SYMVARS") {
+			explainer.symbolicVars = true
+		} else if strings.EqualFold(opt, "QUALIFY") {
+			explainer.qualifyNames = true
 		} else if strings.EqualFold(opt, "VERBOSE") {
 			explainer.showSelectTop = true
 			explainer.showMetadata = true

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -66,16 +66,24 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, error) 
 			newMode = explainPlan
 			explainer.showExprs = true
 			explainer.showTypes = true
-			// TYPES implies VERBOSE.
+			// TYPES implies METADATA.
 			explainer.showSelectTop = true
 			explainer.showMetadata = true
 		} else if strings.EqualFold(opt, "INDENT") {
 			explainer.doIndent = true
 		} else if strings.EqualFold(opt, "SYMVARS") {
 			explainer.symbolicVars = true
+		} else if strings.EqualFold(opt, "METADATA") {
+			explainer.showSelectTop = true
+			explainer.showMetadata = true
 		} else if strings.EqualFold(opt, "QUALIFY") {
 			explainer.qualifyNames = true
 		} else if strings.EqualFold(opt, "VERBOSE") {
+			// VERBOSE shows expression fields.
+			explainer.showExprs = true
+			// VERBOSE implies QUALIFY.
+			explainer.qualifyNames = true
+			// VERBOSE implies METADATA.
 			explainer.showSelectTop = true
 			explainer.showMetadata = true
 		} else if strings.EqualFold(opt, "NOEXPAND") {

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -18,7 +18,6 @@ package sql
 
 import (
 	"fmt"
-	"math"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -34,7 +33,6 @@ const (
 	explainDebug
 	explainPlan
 	explainTrace
-	explainTypes
 )
 
 var explainStrings = []string{"", "debug", "plan", "trace", "types"}
@@ -45,9 +43,16 @@ var explainStrings = []string{"", "debug", "plan", "trace", "types"}
 // Privileges: the same privileges as the statement being explained.
 func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, error) {
 	mode := explainNone
-	verbose := false
+
 	expanded := true
-	normalizedExplainTypes := false
+	normalizeExprs := true
+	explainer := explainer{
+		showMetadata:  false,
+		showSelectTop: false,
+		showExprs:     false,
+		showTypes:     false,
+	}
+
 	for _, opt := range n.Options {
 		newMode := explainNone
 		if strings.EqualFold(opt, "DEBUG") {
@@ -57,13 +62,19 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, error) 
 		} else if strings.EqualFold(opt, "PLAN") {
 			newMode = explainPlan
 		} else if strings.EqualFold(opt, "TYPES") {
-			newMode = explainTypes
+			newMode = explainPlan
+			explainer.showExprs = true
+			explainer.showTypes = true
+			// TYPES implies VERBOSE.
+			explainer.showSelectTop = true
+			explainer.showMetadata = true
 		} else if strings.EqualFold(opt, "VERBOSE") {
-			verbose = true
+			explainer.showSelectTop = true
+			explainer.showMetadata = true
 		} else if strings.EqualFold(opt, "NOEXPAND") {
 			expanded = false
-		} else if strings.EqualFold(opt, "NORMALIZE") {
-			normalizedExplainTypes = true
+		} else if strings.EqualFold(opt, "NONORMALIZE") {
+			normalizeExprs = false
 		} else {
 			return nil, fmt.Errorf("unsupported EXPLAIN option: %s", opt)
 		}
@@ -88,9 +99,7 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, error) 
 		p.txn.Context = opentracing.ContextWithSpan(p.txn.Context, sp)
 	}
 
-	if mode == explainTypes {
-		p.evalCtx.SkipNormalize = !normalizedExplainTypes
-	}
+	p.evalCtx.SkipNormalize = !normalizeExprs
 
 	plan, err := p.newPlan(n.Statement, nil, autoCommit)
 	if err != nil {
@@ -100,25 +109,11 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, error) 
 	case explainDebug:
 		return &explainDebugNode{plan}, nil
 
-	case explainTypes:
-		columns := ResultColumns{
-			{Name: "Level", Typ: parser.TypeInt},
-			{Name: "Type", Typ: parser.TypeString},
-			{Name: "Element", Typ: parser.TypeString},
-			{Name: "Description", Typ: parser.TypeString},
-		}
-		node := &explainTypesNode{
-			plan:     plan,
-			expanded: expanded,
-			results:  p.newContainerValuesNode(columns, 0),
-		}
-		// We want to show placeholder types, so ensure no values
+	case explainPlan:
+		// We may want to show placeholder types, so ensure no values
 		// are missing.
 		p.semaCtx.Placeholders.FillUnassigned()
-		return node, nil
-
-	case explainPlan:
-		return p.makeExplainPlanNode(verbose, expanded, plan), nil
+		return p.makeExplainPlanNode(explainer, expanded, plan), nil
 
 	case explainTrace:
 		return p.makeTraceNode(plan, p.txn), nil
@@ -126,93 +121,6 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, error) 
 	default:
 		return nil, fmt.Errorf("unsupported EXPLAIN mode: %d", mode)
 	}
-}
-
-type explainTypesNode struct {
-	plan     planNode
-	expanded bool
-	results  *valuesNode
-}
-
-func (e *explainTypesNode) ExplainTypes(fn func(string, string)) {}
-func (e *explainTypesNode) Next() (bool, error)                  { return e.results.Next() }
-func (e *explainTypesNode) Columns() ResultColumns               { return e.results.Columns() }
-func (e *explainTypesNode) Ordering() orderingInfo               { return e.results.Ordering() }
-func (e *explainTypesNode) Values() parser.DTuple                { return e.results.Values() }
-func (e *explainTypesNode) DebugValues() debugValues             { return e.results.DebugValues() }
-func (e *explainTypesNode) SetLimitHint(n int64, s bool)         { e.results.SetLimitHint(n, s) }
-func (e *explainTypesNode) setNeededColumns(_ []bool)            {}
-func (e *explainTypesNode) MarkDebug(mode explainMode)           {}
-func (e *explainTypesNode) ExplainPlan(v bool) (string, string, []planNode) {
-	return "explain", "types", []planNode{e.plan}
-}
-
-func (e *explainTypesNode) expandPlan() error {
-	if e.expanded {
-		if err := e.plan.expandPlan(); err != nil {
-			return err
-		}
-		// Trigger limit hint propagation, which would otherwise only
-		// occur during the plan's Start() phase. This may trigger
-		// additional optimizations (eg. in sortNode) which the user of
-		// EXPLAIN will be interested in.
-		e.plan.SetLimitHint(math.MaxInt64, true)
-	}
-	return nil
-}
-
-func (e *explainTypesNode) Start() error {
-	return populateTypes(e.results, e.plan, 0)
-}
-
-func (e *explainTypesNode) Close() {
-	e.plan.Close()
-	e.results.Close()
-}
-
-func populateTypes(v *valuesNode, plan planNode, level int) error {
-	name, _, children := plan.ExplainPlan(true)
-
-	// Format the result column types.
-	row := parser.DTuple{
-		parser.NewDInt(parser.DInt(level)),
-		parser.NewDString(name),
-		parser.NewDString("result"),
-		parser.NewDString(formatColumns(plan.Columns(), true)),
-	}
-	if _, err := v.rows.AddRow(row); err != nil {
-		return err
-	}
-
-	// Format the node's typing details.
-	var err error
-	regType := func(elt string, desc string) {
-		if err != nil {
-			return
-		}
-
-		row := parser.DTuple{
-			parser.NewDInt(parser.DInt(level)),
-			parser.NewDString(name),
-			parser.NewDString(elt),
-			parser.NewDString(desc),
-		}
-		_, err = v.rows.AddRow(row)
-	}
-	plan.ExplainTypes(regType)
-
-	if err != nil {
-		return err
-	}
-
-	// Recurse into sub-nodes.
-	for _, child := range children {
-		if err := populateTypes(v, child, level+1); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 type debugValueType int

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -85,6 +85,9 @@ func (p *planner) makeExplainPlanNode(explainer explainer, expanded bool, plan p
 		columns = append(columns, ResultColumn{Name: "Ordering", Typ: parser.TypeString})
 	}
 
+	explainer.fmtFlags = parser.FmtExpr(
+		explainer.showTypes, explainer.symbolicVars, explainer.qualifyNames)
+
 	node := &explainPlanNode{
 		explainer: explainer,
 		expanded:  expanded,
@@ -104,6 +107,17 @@ type explainer struct {
 	// showExprs indicates whether the plan prints expressions
 	// embedded inside the node.
 	showExprs bool
+
+	// qualifyNames determines whether column names in expressions
+	// should be fully qualified during pretty-printing.
+	qualifyNames bool
+
+	// symbolicVars determines whether ordinal column references
+	// should be printed numerically.
+	symbolicVars bool
+
+	// fmtFlags is the formatter to use for pretty-printing expressions.
+	fmtFlags parser.FmtFlags
 
 	// showTypes indicates whether to print the type of embedded
 	// expressions and result columns.
@@ -210,7 +224,7 @@ func (e *explainer) explain(plan planNode) {
 				return
 			}
 			if expr != nil {
-				e.attr(name, elt, parser.AsStringWithFlags(expr, parser.FmtShowTypes))
+				e.attr(name, elt, parser.AsStringWithFlags(expr, e.fmtFlags))
 			}
 		})
 	}

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -65,7 +65,7 @@ func formatColumns(cols ResultColumns, printTypes bool) string {
 }
 
 // newExplainPlanNode instantiates a planNode that runs an EXPLAIN query.
-func (p *planner) makeExplainPlanNode(verbose, expanded bool, plan planNode) planNode {
+func (p *planner) makeExplainPlanNode(explainer explainer, expanded bool, plan planNode) planNode {
 	columns := ResultColumns{
 		// Level is the depth of the node in the tree.
 		{Name: "Level", Typ: parser.TypeInt},
@@ -78,7 +78,7 @@ func (p *planner) makeExplainPlanNode(verbose, expanded bool, plan planNode) pla
 		// Description contains details about the field.
 		{Name: "Description", Typ: parser.TypeString},
 	}
-	if verbose {
+	if explainer.showMetadata {
 		// Columns is the type signature of the data source.
 		columns = append(columns, ResultColumn{Name: "Columns", Typ: parser.TypeString})
 		// Ordering indicates the known ordering of the data from this source.
@@ -86,22 +86,32 @@ func (p *planner) makeExplainPlanNode(verbose, expanded bool, plan planNode) pla
 	}
 
 	node := &explainPlanNode{
-		explainer: explainer{
-			verbose: verbose,
-		},
-		expanded: expanded,
-		plan:     plan,
-		results:  p.newContainerValuesNode(columns, 0),
+		explainer: explainer,
+		expanded:  expanded,
+		plan:      plan,
+		results:   p.newContainerValuesNode(columns, 0),
 	}
 	return node
 }
 
 // explainer represents the run-time state of the EXPLAIN logic.
 type explainer struct {
-	// verbose indicates whether the output has separate columns for the
+	// showMetadata indicates whether the output has separate columns for the
 	// schema signature and ordering information of the intermediate
 	// nodes.
-	verbose bool
+	showMetadata bool
+
+	// showExprs indicates whether the plan prints expressions
+	// embedded inside the node.
+	showExprs bool
+
+	// showTypes indicates whether to print the type of embedded
+	// expressions and result columns.
+	showTypes bool
+
+	// showSelectTop indicates whether intermediate selectTopNodes
+	// are rendered.
+	showSelectTop bool
 
 	// level is the current depth in the tree of planNodes.
 	level int
@@ -112,6 +122,8 @@ type explainer struct {
 	// err remembers whether any error was encountered by makeRow.
 	err error
 }
+
+var emptyString = parser.NewDString("")
 
 // populateExplain invokes explain() with a makeRow method
 // which populates a valuesNode.
@@ -127,9 +139,13 @@ func (e *explainer) populateExplain(v *valuesNode, plan planNode) error {
 			parser.NewDString(field),
 			parser.NewDString(description),
 		}
-		if e.verbose {
-			row = append(row, parser.NewDString(formatColumns(plan.Columns(), false)))
-			row = append(row, parser.NewDString(plan.Ordering().AsString(plan.Columns())))
+		if e.showMetadata {
+			if plan != nil {
+				row = append(row, parser.NewDString(formatColumns(plan.Columns(), e.showTypes)))
+				row = append(row, parser.NewDString(plan.Ordering().AsString(plan.Columns())))
+			} else {
+				row = append(row, emptyString, emptyString)
+			}
 		}
 		if _, err := v.rows.AddRow(row); err != nil {
 			e.err = err
@@ -145,13 +161,16 @@ func (e *explainer) populateExplain(v *valuesNode, plan planNode) error {
 func planToString(plan planNode) string {
 	var buf bytes.Buffer
 	e := explainer{
-		verbose: true,
+		showMetadata:  true,
+		showTypes:     true,
+		showExprs:     true,
+		showSelectTop: true,
 		makeRow: func(level int, name, field, description string, plan planNode) {
 			if field != "" {
 				field = "." + field
 			}
 			fmt.Fprintf(&buf, "%d %s%s %s %s %s\n", level, name, field, description,
-				formatColumns(plan.Columns(), false),
+				formatColumns(plan.Columns(), true),
 				plan.Ordering().AsString(plan.Columns()),
 			)
 		},
@@ -167,8 +186,23 @@ func (e *explainer) explain(plan planNode) {
 		return
 	}
 
-	name, description, children := plan.ExplainPlan(e.verbose)
+	name, description, children := plan.ExplainPlan(e.showMetadata)
+
+	if name == "select" && !e.showSelectTop {
+		e.explain(children[len(children)-1])
+		return
+	}
+
 	e.makeRow(e.level, name, "", description, plan)
+
+	if e.showExprs {
+		plan.ExplainTypes(func(elt, desc string) {
+			if e.err != nil {
+				return
+			}
+			e.makeRow(e.level, name, elt, desc, nil)
+		})
+	}
 
 	e.level++
 	defer func() { e.level-- }()

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -17,6 +17,7 @@ package sql
 
 import (
 	"bytes"
+	"fmt"
 	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -128,6 +129,22 @@ func (e *explainer) populateExplain(v *valuesNode, plan planNode) error {
 	e.err = nil
 	e.explain(plan)
 	return e.err
+}
+
+// planToString uses explain() to build a string representation of the planNode.
+func planToString(plan planNode) string {
+	var buf bytes.Buffer
+	e := explainer{
+		verbose: true,
+		makeRow: func(level int, name, description string, plan planNode) {
+			fmt.Fprintf(&buf, "%d %s %s %s %s\n", level, name, description,
+				formatColumns(plan.Columns(), false),
+				plan.Ordering().AsString(plan.Columns()),
+			)
+		},
+	}
+	e.explain(plan)
+	return buf.String()
 }
 
 // explain extract information from planNodes and produces the EXPLAIN

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -116,6 +116,15 @@ type explainer struct {
 	// level is the current depth in the tree of planNodes.
 	level int
 
+	// prefix is the whitespace inserted in front of the description to
+	// clarify the hierarchical structure of the plans when doIndent is
+	// true.
+	prefix string
+
+	// doIndent indicates whether the output should be clarified
+	// with leading white spaces.
+	doIndent bool
+
 	// makeRow produces one row of EXPLAIN output.
 	makeRow func(level int, typ, field, desc string, plan planNode)
 
@@ -193,22 +202,43 @@ func (e *explainer) explain(plan planNode) {
 		return
 	}
 
-	e.makeRow(e.level, name, "", description, plan)
+	e.node(name, description, plan)
 
 	if e.showExprs {
 		plan.ExplainTypes(func(elt, desc string) {
 			if e.err != nil {
 				return
 			}
-			e.makeRow(e.level, name, elt, desc, nil)
+			e.attr(name, elt, desc)
 		})
 	}
 
-	e.level++
-	defer func() { e.level-- }()
 	for _, child := range children {
-		e.explain(child)
+		e.subnode(child)
 	}
+}
+
+func (e *explainer) node(name, desc string, plan planNode) {
+	if e.doIndent {
+		desc = fmt.Sprintf("%s-> %s %s", e.prefix, name, desc)
+		e.prefix += "   "
+	}
+	e.makeRow(e.level, name, "", desc, plan)
+}
+
+func (e *explainer) attr(name, t, v string) {
+	if e.doIndent {
+		v = fmt.Sprintf("%s%s", e.prefix, v)
+	}
+	e.makeRow(e.level, name, t, v, nil)
+}
+
+func (e *explainer) subnode(plan planNode) {
+	curPrefix := e.prefix
+	e.level++
+	e.explain(plan)
+	e.level--
+	e.prefix = curPrefix
 }
 
 // explainPlanNode implements the logic for EXPLAIN.

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -1,0 +1,124 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+package sql
+
+import (
+	"bytes"
+	"math"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+)
+
+func formatColumns(cols ResultColumns, printTypes bool) string {
+	var buf bytes.Buffer
+	buf.WriteByte('(')
+	for i, rCol := range cols {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		parser.Name(rCol.Name).Format(&buf, parser.FmtSimple)
+		// Output extra properties like [hidden,omitted].
+		hasProps := false
+		outputProp := func(prop string) {
+			if hasProps {
+				buf.WriteByte(',')
+			} else {
+				buf.WriteByte('[')
+			}
+			hasProps = true
+			buf.WriteString(prop)
+		}
+		if rCol.hidden {
+			outputProp("hidden")
+		}
+		if rCol.omitted {
+			outputProp("omitted")
+		}
+		if hasProps {
+			buf.WriteByte(']')
+		}
+
+		if printTypes {
+			buf.WriteByte(' ')
+			buf.WriteString(rCol.Typ.String())
+		}
+	}
+	buf.WriteByte(')')
+	return buf.String()
+}
+
+func populateExplain(verbose bool, v *valuesNode, plan planNode, level int) error {
+	name, description, children := plan.ExplainPlan(verbose)
+
+	row := parser.DTuple{
+		parser.NewDInt(parser.DInt(level)),
+		parser.NewDString(name),
+		parser.NewDString(description),
+	}
+	if verbose {
+		row = append(row, parser.NewDString(formatColumns(plan.Columns(), false)))
+		row = append(row, parser.NewDString(plan.Ordering().AsString(plan.Columns())))
+	}
+	if _, err := v.rows.AddRow(row); err != nil {
+		return err
+	}
+
+	for _, child := range children {
+		if err := populateExplain(verbose, v, child, level+1); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type explainPlanNode struct {
+	verbose bool
+	plan    planNode
+	results *valuesNode
+}
+
+func (e *explainPlanNode) ExplainTypes(fn func(string, string)) {}
+func (e *explainPlanNode) Next() (bool, error)                  { return e.results.Next() }
+func (e *explainPlanNode) Columns() ResultColumns               { return e.results.Columns() }
+func (e *explainPlanNode) Ordering() orderingInfo               { return e.results.Ordering() }
+func (e *explainPlanNode) Values() parser.DTuple                { return e.results.Values() }
+func (e *explainPlanNode) DebugValues() debugValues             { return debugValues{} }
+func (e *explainPlanNode) SetLimitHint(n int64, s bool)         { e.results.SetLimitHint(n, s) }
+func (e *explainPlanNode) setNeededColumns(_ []bool)            {}
+func (e *explainPlanNode) MarkDebug(mode explainMode)           {}
+func (e *explainPlanNode) expandPlan() error {
+	if err := e.plan.expandPlan(); err != nil {
+		return err
+	}
+	// Trigger limit hint propagation, which would otherwise only occur
+	// during the plan's Start() phase. This may trigger additional
+	// optimizations (eg. in sortNode) which the user of EXPLAIN will be
+	// interested in.
+	e.plan.SetLimitHint(math.MaxInt64, true)
+	return nil
+}
+func (e *explainPlanNode) ExplainPlan(v bool) (string, string, []planNode) {
+	return "explain", "plan", []planNode{e.plan}
+}
+
+func (e *explainPlanNode) Start() error {
+	return populateExplain(e.verbose, e.results, e.plan, 0)
+}
+
+func (e *explainPlanNode) Close() {
+	e.plan.Close()
+	e.results.Close()
+}

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -205,11 +205,13 @@ func (e *explainer) explain(plan planNode) {
 	e.node(name, description, plan)
 
 	if e.showExprs {
-		plan.ExplainTypes(func(elt, desc string) {
+		plan.explainExprs(func(elt string, expr parser.Expr) {
 			if e.err != nil {
 				return
 			}
-			e.attr(name, elt, desc)
+			if expr != nil {
+				e.attr(name, elt, parser.AsStringWithFlags(expr, parser.FmtShowTypes))
+			}
 		})
 	}
 
@@ -249,15 +251,15 @@ type explainPlanNode struct {
 	results   *valuesNode
 }
 
-func (e *explainPlanNode) ExplainTypes(fn func(string, string)) {}
-func (e *explainPlanNode) Next() (bool, error)                  { return e.results.Next() }
-func (e *explainPlanNode) Columns() ResultColumns               { return e.results.Columns() }
-func (e *explainPlanNode) Ordering() orderingInfo               { return e.results.Ordering() }
-func (e *explainPlanNode) Values() parser.DTuple                { return e.results.Values() }
-func (e *explainPlanNode) DebugValues() debugValues             { return debugValues{} }
-func (e *explainPlanNode) SetLimitHint(n int64, s bool)         { e.results.SetLimitHint(n, s) }
-func (e *explainPlanNode) setNeededColumns(_ []bool)            {}
-func (e *explainPlanNode) MarkDebug(mode explainMode)           {}
+func (e *explainPlanNode) explainExprs(fn func(string, parser.Expr)) {}
+func (e *explainPlanNode) Next() (bool, error)                       { return e.results.Next() }
+func (e *explainPlanNode) Columns() ResultColumns                    { return e.results.Columns() }
+func (e *explainPlanNode) Ordering() orderingInfo                    { return e.results.Ordering() }
+func (e *explainPlanNode) Values() parser.DTuple                     { return e.results.Values() }
+func (e *explainPlanNode) DebugValues() debugValues                  { return debugValues{} }
+func (e *explainPlanNode) SetLimitHint(n int64, s bool)              { e.results.SetLimitHint(n, s) }
+func (e *explainPlanNode) setNeededColumns(_ []bool)                 {}
+func (e *explainPlanNode) MarkDebug(mode explainMode)                {}
 func (e *explainPlanNode) expandPlan() error {
 	if e.expanded {
 		if err := e.plan.expandPlan(); err != nil {

--- a/pkg/sql/generator.go
+++ b/pkg/sql/generator.go
@@ -136,8 +136,8 @@ func (n *valueGenerator) DebugValues() debugValues {
 	}
 }
 
-func (n *valueGenerator) ExplainTypes(regTypes func(string, string)) {
-	regTypes("generator", parser.AsStringWithFlags(n.expr, parser.FmtShowTypes))
+func (n *valueGenerator) explainExprs(regTypes func(string, parser.Expr)) {
+	regTypes("generator", n.expr)
 }
 
 func (n *valueGenerator) Ordering() orderingInfo       { return orderingInfo{} }

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -448,13 +448,11 @@ func (n *groupNode) ExplainPlan(_ bool) (name, description string, children []pl
 	return name, buf.String(), subplans
 }
 
-func (n *groupNode) ExplainTypes(regTypes func(string, string)) {
-	if n.having != nil {
-		regTypes("having", parser.AsStringWithFlags(n.having, parser.FmtShowTypes))
-	}
+func (n *groupNode) explainExprs(regTypes func(string, parser.Expr)) {
+	regTypes("having", n.having)
 	cols := n.Columns()
 	for i, rexpr := range n.render {
-		regTypes(fmt.Sprintf("render %s", cols[i].Name), parser.AsStringWithFlags(rexpr, parser.FmtShowTypes))
+		regTypes(fmt.Sprintf("render %s", cols[i].Name), rexpr)
 	}
 }
 

--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -243,7 +243,7 @@ func (n *indexJoinNode) ExplainPlan(_ bool) (name, description string, children 
 	return "index-join", "", []planNode{n.index, n.table}
 }
 
-func (n *indexJoinNode) ExplainTypes(_ func(string, string)) {}
+func (n *indexJoinNode) explainExprs(_ func(string, parser.Expr)) {}
 
 func (n *indexJoinNode) SetLimitHint(numRows int64, soft bool) {
 	n.index.SetLimitHint(numRows, soft)

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -613,16 +613,16 @@ func (n *insertNode) ExplainPlan(v bool) (name, description string, children []p
 	return "insert", buf.String(), subplans
 }
 
-func (n *insertNode) ExplainTypes(regTypes func(string, string)) {
+func (n *insertNode) explainExprs(regTypes func(string, parser.Expr)) {
 	for i, dexpr := range n.defaultExprs {
-		regTypes(fmt.Sprintf("default %d", i), parser.AsStringWithFlags(dexpr, parser.FmtShowTypes))
+		regTypes(fmt.Sprintf("default %d", i), dexpr)
 	}
 	for i, cexpr := range n.checkHelper.exprs {
-		regTypes(fmt.Sprintf("check %d", i), parser.AsStringWithFlags(cexpr, parser.FmtShowTypes))
+		regTypes(fmt.Sprintf("check %d", i), cexpr)
 	}
 	cols := n.rh.columns
 	for i, rexpr := range n.rh.exprs {
-		regTypes(fmt.Sprintf("returning %s", cols[i].Name), parser.AsStringWithFlags(rexpr, parser.FmtShowTypes))
+		regTypes(fmt.Sprintf("returning %s", cols[i].Name), rexpr)
 	}
 }
 

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -271,11 +271,9 @@ func (p *planner) makeJoin(
 	}, nil
 }
 
-// ExplainTypes implements the planNode interface.
-func (n *joinNode) ExplainTypes(regTypes func(string, string)) {
-	if n.pred.filter != nil {
-		regTypes("filter", parser.AsStringWithFlags(n.pred.filter, parser.FmtShowTypes))
-	}
+// explainExprs implements the planNode interface.
+func (n *joinNode) explainExprs(regTypes func(string, parser.Expr)) {
+	regTypes("filter", n.pred.filter)
 }
 
 // SetLimitHint implements the planNode interface.

--- a/pkg/sql/limit.go
+++ b/pkg/sql/limit.go
@@ -183,13 +183,9 @@ func (n *limitNode) evalLimit() error {
 	return nil
 }
 
-func (n *limitNode) ExplainTypes(regTypes func(string, string)) {
-	if n.countExpr != nil {
-		regTypes("count", parser.AsStringWithFlags(n.countExpr, parser.FmtShowTypes))
-	}
-	if n.offsetExpr != nil {
-		regTypes("offset", parser.AsStringWithFlags(n.offsetExpr, parser.FmtShowTypes))
-	}
+func (n *limitNode) explainExprs(regTypes func(string, parser.Expr)) {
+	regTypes("count", n.countExpr)
+	regTypes("offset", n.offsetExpr)
 }
 
 // setTop connects the limitNode back to the selectTopNode that caused

--- a/pkg/sql/ordinality.go
+++ b/pkg/sql/ordinality.go
@@ -133,13 +133,13 @@ func (o *ordinalityNode) ExplainPlan(_ bool) (string, string, []planNode) {
 	return "ordinality", "", []planNode{o.source}
 }
 
-func (o *ordinalityNode) Ordering() orderingInfo                { return o.ordering }
-func (o *ordinalityNode) Values() parser.DTuple                 { return o.row }
-func (o *ordinalityNode) DebugValues() debugValues              { return o.source.DebugValues() }
-func (o *ordinalityNode) MarkDebug(mode explainMode)            { o.source.MarkDebug(mode) }
-func (o *ordinalityNode) Columns() ResultColumns                { return o.columns }
-func (o *ordinalityNode) Start() error                          { return o.source.Start() }
-func (o *ordinalityNode) Close()                                { o.source.Close() }
-func (o *ordinalityNode) ExplainTypes(_ func(string, string))   {}
-func (o *ordinalityNode) SetLimitHint(numRows int64, soft bool) { o.source.SetLimitHint(numRows, soft) }
-func (o *ordinalityNode) setNeededColumns(_ []bool)             {}
+func (o *ordinalityNode) Ordering() orderingInfo                   { return o.ordering }
+func (o *ordinalityNode) Values() parser.DTuple                    { return o.row }
+func (o *ordinalityNode) DebugValues() debugValues                 { return o.source.DebugValues() }
+func (o *ordinalityNode) MarkDebug(mode explainMode)               { o.source.MarkDebug(mode) }
+func (o *ordinalityNode) Columns() ResultColumns                   { return o.columns }
+func (o *ordinalityNode) Start() error                             { return o.source.Start() }
+func (o *ordinalityNode) Close()                                   { o.source.Close() }
+func (o *ordinalityNode) explainExprs(_ func(string, parser.Expr)) {}
+func (o *ordinalityNode) SetLimitHint(numRows int64, soft bool)    { o.source.SetLimitHint(numRows, soft) }
+func (o *ordinalityNode) setNeededColumns(_ []bool)                {}

--- a/pkg/sql/parser/format.go
+++ b/pkg/sql/parser/format.go
@@ -71,6 +71,16 @@ func FmtNormalizeTableNames(fn func(*NormalizableTableName) *TableName) FmtFlags
 	return &fmtFlags{tableNameNormalizer: fn}
 }
 
+// FmtExpr returns FmtFlags that indicate how the pretty-printer
+// should format expressions.
+func FmtExpr(showTypes, symbolicVars, showTableAliases bool) FmtFlags {
+	return &fmtFlags{
+		showTypes:        showTypes,
+		symbolicVars:     symbolicVars,
+		ShowTableAliases: showTableAliases,
+	}
+}
+
 // FmtIndexedVarFormat returns FmtFlags that customizes the printing of
 // IndexedVars using the provided function.
 func FmtIndexedVarFormat(

--- a/pkg/sql/parser/format.go
+++ b/pkg/sql/parser/format.go
@@ -23,7 +23,7 @@ import (
 
 type fmtFlags struct {
 	showTypes        bool
-	showTableAliases bool
+	ShowTableAliases bool
 	symbolicVars     bool
 	// tableNameNormalizer will be called on all NormalizableTableNames if it is
 	// non-nil. Its results will be used if they are non-nil, or ignored if they
@@ -50,7 +50,7 @@ var FmtSimple FmtFlags = &fmtFlags{showTypes: false}
 
 // FmtQualify instructs the pretty-printer to qualify names with the
 // table name.
-var FmtQualify FmtFlags = &fmtFlags{showTableAliases: true}
+var FmtQualify FmtFlags = &fmtFlags{ShowTableAliases: true}
 
 // FmtShowTypes instructs the pretty-printer to
 // annotate expressions with their resolved types.

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -70,11 +70,10 @@ var _ planMaker = &planner{}
 
 // planNode defines the interface for executing a query or portion of a query.
 type planNode interface {
-	// ExplainTypes reports the data types involved in the node, excluding
-	// the result column types.
+	// explainExprs reports the expressions involved in the node.
 	//
 	// Available after newPlan().
-	ExplainTypes(explainFn func(elem string, desc string))
+	explainExprs(explainFn func(elem string, desc parser.Expr))
 
 	// SetLimitHint tells this node to optimize things under the assumption that
 	// we will only need the first `numRows` rows.

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -18,6 +18,7 @@ package sql
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/pkg/errors"
 )
@@ -231,6 +232,9 @@ func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, er
 	}
 	if err := plan.expandPlan(); err != nil {
 		return nil, err
+	}
+	if log.V(3) {
+		log.Infof(p.ctx(), "statement %s compiled to:\n%s", stmt, planToString(plan))
 	}
 	return plan, nil
 }

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -56,13 +56,13 @@ type hookFnNode struct {
 
 var _ planNode = &hookFnNode{}
 
-func (*hookFnNode) Ordering() orderingInfo              { return orderingInfo{} }
-func (*hookFnNode) ExplainTypes(_ func(string, string)) {}
-func (*hookFnNode) SetLimitHint(_ int64, _ bool)        {}
-func (*hookFnNode) MarkDebug(_ explainMode)             {}
-func (*hookFnNode) expandPlan() error                   { return nil }
-func (*hookFnNode) Close()                              {}
-func (*hookFnNode) setNeededColumns(_ []bool)           {}
+func (*hookFnNode) Ordering() orderingInfo                   { return orderingInfo{} }
+func (*hookFnNode) explainExprs(_ func(string, parser.Expr)) {}
+func (*hookFnNode) SetLimitHint(_ int64, _ bool)             {}
+func (*hookFnNode) MarkDebug(_ explainMode)                  {}
+func (*hookFnNode) expandPlan() error                        { return nil }
+func (*hookFnNode) Close()                                   {}
+func (*hookFnNode) setNeededColumns(_ []bool)                {}
 
 func (f *hookFnNode) Start() error {
 	var err error

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -247,6 +247,9 @@ func (n *scanNode) ExplainPlan(_ bool) (name, description string, children []pla
 	fmt.Fprintf(&desc, "%s@%s", n.desc.Name, n.index.Name)
 	spans := sqlbase.PrettySpans(n.spans, 2)
 	if spans != "" {
+		if spans == "-" {
+			spans = "ALL"
+		}
 		fmt.Fprintf(&desc, " %s", spans)
 	}
 	if n.limitHint > 0 && !n.limitSoft {

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -265,10 +265,8 @@ func (n *scanNode) ExplainPlan(_ bool) (name, description string, children []pla
 	return name, desc.String(), subplans
 }
 
-func (n *scanNode) ExplainTypes(regTypes func(string, string)) {
-	if n.filter != nil {
-		regTypes("filter", parser.AsStringWithFlags(n.filter, parser.FmtShowTypes))
-	}
+func (n *scanNode) explainExprs(regTypes func(string, parser.Expr)) {
+	regTypes("filter", n.filter)
 }
 
 // Initializes a scanNode with a table descriptor.

--- a/pkg/sql/select.go
+++ b/pkg/sql/select.go
@@ -177,12 +177,10 @@ func (s *selectNode) Next() (bool, error) {
 	}
 }
 
-func (s *selectNode) ExplainTypes(regTypes func(string, string)) {
-	if s.filter != nil {
-		regTypes("filter", parser.AsStringWithFlags(s.filter, parser.FmtShowTypes))
-	}
+func (s *selectNode) explainExprs(regTypes func(string, parser.Expr)) {
+	regTypes("filter", s.filter)
 	for i, rexpr := range s.render {
-		regTypes(fmt.Sprintf("render %d", i), parser.AsStringWithFlags(rexpr, parser.FmtShowTypes))
+		regTypes(fmt.Sprintf("render %d", i), rexpr)
 	}
 }
 

--- a/pkg/sql/select_top.go
+++ b/pkg/sql/select_top.go
@@ -35,24 +35,24 @@ type selectTopNode struct {
 	plan planNode
 }
 
-func (n *selectTopNode) ExplainTypes(f func(string, string)) {
+func (n *selectTopNode) explainExprs(f func(string, parser.Expr)) {
 	if n.plan == nil {
 		// The sub-nodes are not connected yet.
 		// Ask them for typing individually.
 		if n.limit != nil {
-			n.limit.ExplainTypes(f)
+			n.limit.explainExprs(f)
 		}
 		if n.distinct != nil {
-			n.distinct.ExplainTypes(f)
+			n.distinct.explainExprs(f)
 		}
 		if n.sort != nil {
-			n.sort.ExplainTypes(f)
+			n.sort.explainExprs(f)
 		}
 		if n.window != nil {
-			n.window.ExplainTypes(f)
+			n.window.explainExprs(f)
 		}
 		if n.group != nil {
-			n.group.ExplainTypes(f)
+			n.group.explainExprs(f)
 		}
 
 		// The source is always reported as sub-plan by ExplainPlan,

--- a/pkg/sql/select_top.go
+++ b/pkg/sql/select_top.go
@@ -119,10 +119,6 @@ func (n *selectTopNode) expandPlan() error {
 }
 
 func (n *selectTopNode) ExplainPlan(v bool) (name, description string, subplans []planNode) {
-	if !v {
-		return n.plan.ExplainPlan(v)
-	}
-
 	if n.plan != nil {
 		subplans = []planNode{n.plan}
 	} else {

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -324,7 +324,7 @@ func (n *sortNode) ExplainPlan(_ bool) (name, description string, children []pla
 	return name, description, []planNode{n.plan}
 }
 
-func (n *sortNode) ExplainTypes(_ func(string, string)) {}
+func (n *sortNode) explainExprs(_ func(string, parser.Expr)) {}
 
 func (n *sortNode) SetLimitHint(numRows int64, soft bool) {
 	if !n.needSort {

--- a/pkg/sql/split.go
+++ b/pkg/sql/split.go
@@ -187,9 +187,9 @@ func (n *splitNode) ExplainPlan(_ bool) (name, description string, children []pl
 	return "split", buf.String(), children
 }
 
-func (n *splitNode) ExplainTypes(regTypes func(string, string)) {
+func (n *splitNode) explainExprs(regTypes func(string, parser.Expr)) {
 	for i, expr := range n.exprs {
-		regTypes(fmt.Sprintf("expr %d", i), parser.AsStringWithFlags(expr, parser.FmtShowTypes))
+		regTypes(fmt.Sprintf("expr %d", i), expr)
 	}
 }
 

--- a/pkg/sql/testdata/aggregate
+++ b/pkg/sql/testdata/aggregate
@@ -475,7 +475,7 @@ query ITT
 EXPLAIN SELECT MIN(a) FROM abc
 ----
 0 group min(a)
-1 scan  abc@primary - (max 1 row)
+1 scan  abc@primary ALL (max 1 row)
 
 query TRBR
 SELECT MIN(a), MIN(b), MIN(c), MIN(d) FROM abc
@@ -534,7 +534,7 @@ query ITT
 EXPLAIN SELECT MIN(x) FROM xyz
 ----
 0 group min(x)
-1 scan  xyz@xy - (max 1 row)
+1 scan  xyz@xy ALL (max 1 row)
 
 query I
 SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
@@ -556,7 +556,7 @@ query ITT
 EXPLAIN SELECT MAX(x) FROM xyz
 ----
 0 group    max(x)
-1 revscan  xyz@xy - (max 1 row)
+1 revscan  xyz@xy ALL (max 1 row)
 
 query I
 SELECT MIN(y) FROM xyz WHERE x = 1
@@ -770,7 +770,7 @@ query ITT
 EXPLAIN SELECT MIN(a) FROM abc
 ----
 0 group min(a)
-1 scan  abc@primary - (max 1 row)
+1 scan  abc@primary ALL (max 1 row)
 
 # Verify we only buffer one row.
 query ITTT
@@ -784,7 +784,7 @@ query ITT
 EXPLAIN SELECT MAX(a) FROM abc
 ----
 0 group   max(a)
-1 revscan abc@primary - (max 1 row)
+1 revscan abc@primary ALL (max 1 row)
 
 # Verify we only buffer one row.
 query ITTT

--- a/pkg/sql/testdata/aggregate
+++ b/pkg/sql/testdata/aggregate
@@ -453,7 +453,7 @@ SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv
 ----
 14.00000000000000000
 
-query ITT
+query ITTT
 EXPLAIN SELECT COUNT(k) FROM kv
 ----
 0 group count(k)
@@ -471,7 +471,7 @@ statement ok
 INSERT INTO abc VALUES ('one', 1.5, true, 5::decimal), ('two', 2.0, false, 1.1::decimal)
 
 # Verify we don't try to apply the single-key optimization to the primary index.
-query ITT
+query ITTT
 EXPLAIN SELECT MIN(a) FROM abc
 ----
 0 group min(a)
@@ -530,7 +530,7 @@ SELECT MIN(x) FROM xyz
 ----
 1
 
-query ITT
+query ITTT
 EXPLAIN SELECT MIN(x) FROM xyz
 ----
 0 group min(x)
@@ -541,7 +541,7 @@ SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
 ----
 4
 
-query ITT
+query ITTT
 EXPLAIN SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
 ----
 0 group min(x)
@@ -552,7 +552,7 @@ SELECT MAX(x) FROM xyz
 ----
 7
 
-query ITT
+query ITTT
 EXPLAIN SELECT MAX(x) FROM xyz
 ----
 0 group    max(x)
@@ -563,7 +563,7 @@ SELECT MIN(y) FROM xyz WHERE x = 1
 ----
 2
 
-query ITT
+query ITTT
 EXPLAIN SELECT MIN(y) FROM xyz WHERE x = 1
 ----
 0 group min(y)
@@ -574,7 +574,7 @@ SELECT MAX(y) FROM xyz WHERE x = 1
 ----
 2
 
-query ITT
+query ITTT
 EXPLAIN SELECT MAX(y) FROM xyz WHERE x = 1
 ----
 0 group   max(y)
@@ -585,7 +585,7 @@ SELECT MIN(y) FROM xyz WHERE x = 7
 ----
 NULL
 
-query ITT
+query ITTT
 EXPLAIN SELECT MIN(y) FROM xyz WHERE x = 7
 ----
 0 group min(y)
@@ -596,7 +596,7 @@ SELECT MAX(y) FROM xyz WHERE x = 7
 ----
 NULL
 
-query ITT
+query ITTT
 EXPLAIN SELECT MAX(y) FROM xyz WHERE x = 7
 ----
 0 group   max(y)
@@ -607,7 +607,7 @@ SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 ----
 1
 
-query ITT
+query ITTT
 EXPLAIN SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 ----
 0 group min(x)
@@ -624,7 +624,7 @@ SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
 ----
 1
 
-query ITT
+query ITTT
 EXPLAIN SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
 ----
 0 group   max(x)
@@ -658,7 +658,7 @@ SELECT VARIANCE(x) FROM xyz WHERE x = 1
 ----
 NULL
 
-query ITT
+query ITTT
 EXPLAIN SELECT VARIANCE(x) FROM xyz WHERE x = 1
 ----
 0 group variance(x)
@@ -766,7 +766,7 @@ INSERT INTO ab VALUES
   (4, 40),
   (5, 50)
 
-query ITT
+query ITTT
 EXPLAIN SELECT MIN(a) FROM abc
 ----
 0 group min(a)
@@ -780,7 +780,7 @@ EXPLAIN (DEBUG) SELECT MIN(a) FROM ab
 0 /ab/primary/1/b 10   BUFFERED
 0 0               (1)  ROW
 
-query ITT
+query ITTT
 EXPLAIN SELECT MAX(a) FROM abc
 ----
 0 group   max(a)
@@ -794,21 +794,21 @@ EXPLAIN (DEBUG) SELECT MAX(a) FROM ab
 0 /ab/primary/5   NULL BUFFERED
 0 0               (5)  ROW
 
-query ITT
+query ITTT
 EXPLAIN SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
 ----
 0   sort    +"COUNT(k)"
 1   group   v, count(k) GROUP BY (@3)
 2   scan    kv@primary
 
-query ITT
+query ITTT
 EXPLAIN SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
 ----
 0   sort    +"COUNT(*)"
 1   group   v, count(*) GROUP BY (@3)
 2   scan    kv@primary
 
-query ITT
+query ITTT
 EXPLAIN SELECT v, COUNT(1) FROM kv GROUP BY v ORDER BY COUNT(1)
 ----
 0   sort    +"COUNT(1)"

--- a/pkg/sql/testdata/delete
+++ b/pkg/sql/testdata/delete
@@ -131,12 +131,12 @@ k v
 7 8
 
 # Check that EXPLAIN does not destroy data (#6613)
-query ITT colnames
+query ITTT colnames
 EXPLAIN DELETE FROM unindexed
 ----
-Level Type   Description
+Level Type   Field Description
 0     delete
-1     scan   unindexed@primary
+1     scan         unindexed@primary
 
 query II colnames
 SELECT k, v FROM unindexed

--- a/pkg/sql/testdata/distinct
+++ b/pkg/sql/testdata/distinct
@@ -51,7 +51,7 @@ EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY z
 ----
 Level  Type     Description
 0      distinct y,z
-1      scan     xyz@foo -
+1      scan     xyz@foo ALL
 
 query II
 SELECT DISTINCT y, z FROM xyz ORDER BY y, z
@@ -68,7 +68,7 @@ EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y
 Level  Type     Description
 0      distinct y
 1      sort     +y
-2      scan     xyz@foo -
+2      scan     xyz@foo ALL
 
 query II
 SELECT DISTINCT y, z FROM xyz ORDER BY y, z
@@ -85,7 +85,7 @@ EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y, z
 Level  Type     Description
 0      distinct y,z
 1      sort     +y,+z
-2      scan     xyz@foo -
+2      scan     xyz@foo ALL
 
 query I
 SELECT DISTINCT y + z FROM xyz ORDER by (y + z)
@@ -100,7 +100,7 @@ EXPLAIN SELECT DISTINCT y + z FROM xyz ORDER BY y + z
 Level  Type     Description
 0      distinct y + z
 1      sort     +"y + z"
-2      scan     xyz@foo -
+2      scan     xyz@foo ALL
 
 query I
 SELECT DISTINCT y AS w FROM xyz ORDER by z
@@ -115,7 +115,7 @@ EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY z
 Level  Type     Description
 0      distinct
 1      nosort   +z
-2      scan     xyz@foo -
+2      scan     xyz@foo ALL
 
 query I
 SELECT DISTINCT y AS w FROM xyz ORDER by y
@@ -130,7 +130,7 @@ EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY y
 Level  Type     Description
 0      distinct w
 1      sort     +w
-2      scan     xyz@foo -
+2      scan     xyz@foo ALL
 
 # Insert NULL values for z.
 statement ok

--- a/pkg/sql/testdata/distinct
+++ b/pkg/sql/testdata/distinct
@@ -30,12 +30,11 @@ SELECT DISTINCT y, z FROM xyz
 2 9
 
 # TODO(vivek): Use the secondary index. Use distinct in index selection.
-query ITT colnames
+query ITTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz
 ----
-Level  Type     Description
 0      distinct
-1      scan     xyz@primary
+1      scan           xyz@primary
 
 query II
 SELECT DISTINCT y, z FROM xyz ORDER BY z
@@ -46,10 +45,9 @@ SELECT DISTINCT y, z FROM xyz ORDER BY z
 5 6
 2 9
 
-query ITT colnames
+query ITTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY z
 ----
-Level  Type     Description
 0      distinct y,z
 1      scan     xyz@foo ALL
 
@@ -62,10 +60,9 @@ SELECT DISTINCT y, z FROM xyz ORDER BY y, z
 3 5
 5 6
 
-query ITT colnames
+query ITTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y
 ----
-Level  Type     Description
 0      distinct y
 1      sort     +y
 2      scan     xyz@foo ALL
@@ -79,10 +76,9 @@ SELECT DISTINCT y, z FROM xyz ORDER BY y, z
 3 5
 5 6
 
-query ITT colnames
+query ITTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y, z
 ----
-Level  Type     Description
 0      distinct y,z
 1      sort     +y,+z
 2      scan     xyz@foo ALL
@@ -94,10 +90,9 @@ SELECT DISTINCT y + z FROM xyz ORDER by (y + z)
 8
 11
 
-query ITT colnames
+query ITTT
 EXPLAIN SELECT DISTINCT y + z FROM xyz ORDER BY y + z
 ----
-Level  Type     Description
 0      distinct y + z
 1      sort     +"y + z"
 2      scan     xyz@foo ALL
@@ -109,10 +104,9 @@ SELECT DISTINCT y AS w FROM xyz ORDER by z
 3
 5
 
-query ITT colnames
+query ITTT
 EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY z
 ----
-Level  Type     Description
 0      distinct
 1      nosort   +z
 2      scan     xyz@foo ALL
@@ -124,10 +118,9 @@ SELECT DISTINCT y AS w FROM xyz ORDER by y
 3
 5
 
-query ITT colnames
+query ITTT
 EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY y
 ----
-Level  Type     Description
 0      distinct w
 1      sort     +w
 2      scan     xyz@foo ALL

--- a/pkg/sql/testdata/explain
+++ b/pkg/sql/testdata/explain
@@ -1,24 +1,24 @@
-query ITT colnames
+query ITTT colnames
 EXPLAIN (PLAN) SELECT 1
 ----
-Level  Type    Description
+Level  Type    Field Description
 0      nullrow
 
-query ITTTT colnames
+query ITTTTT colnames
 EXPLAIN (PLAN, VERBOSE) SELECT 1
 ----
-Level  Type           Description    Columns Ordering
-0      select                        ("1")
-1      render/filter  from ()        ("1")
-2      nullrow                       ()
+Level  Type           Field Description    Columns Ordering
+0      select                              ("1")
+1      render/filter        from ()        ("1")
+2      nullrow                             ()
 
-query ITTTT colnames
+query ITTTTT colnames
 EXPLAIN (VERBOSE, PLAN) SELECT 1
 ----
-Level  Type           Description Columns Ordering
-0      select                     ("1")
-1      render/filter  from ()     ("1")
-2      nullrow                    ()
+Level  Type          Field  Description Columns Ordering
+0      select                           ("1")
+1      render/filter        from ()     ("1")
+2      nullrow                          ()
 
 query ITTT colnames
 EXPLAIN (DEBUG) SELECT 1
@@ -61,10 +61,9 @@ statement error unsupported EXPLAIN option
 EXPLAIN (TRACE, UNKNOWN) SELECT 1
 
 # Ensure that tracing results are sorted after gathering
-query ITTTT colnames
+query ITTTTT
 EXPLAIN(VERBOSE) EXPLAIN(TRACE) SELECT 1
 ----
-Level  Type                  Description             Columns                                                                                                  Ordering
 0      select                                        ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition)             +@10,+"Span Pos"
 1      sort                  +Timestamp,+"Span Pos"  ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition)             +@10,+"Span Pos"
 2      explain               trace                   ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition, Timestamp)
@@ -73,12 +72,12 @@ Level  Type                  Description             Columns                    
 5      nullrow                                       ()
 
 # Ensure that all relevant statement types can be explained
-query ITT
+query ITTT
 EXPLAIN CREATE DATABASE foo
 ----
 0 create database
 
-query ITT
+query ITTT
 EXPLAIN CREATE TABLE foo (x INT)
 ----
 0 create table
@@ -86,7 +85,7 @@ EXPLAIN CREATE TABLE foo (x INT)
 statement ok
 CREATE TABLE foo (x INT)
 
-query ITT
+query ITTT
 EXPLAIN CREATE INDEX a ON foo(x)
 ----
 0 create index
@@ -94,7 +93,7 @@ EXPLAIN CREATE INDEX a ON foo(x)
 statement ok
 CREATE DATABASE foo
 
-query ITT
+query ITTT
 EXPLAIN DROP DATABASE foo
 ----
 0 drop database
@@ -102,102 +101,102 @@ EXPLAIN DROP DATABASE foo
 statement ok
 CREATE INDEX a ON foo(x)
 
-query ITT
+query ITTT
 EXPLAIN DROP INDEX foo@a
 ----
 0 drop index
 
-query ITT
+query ITTT
 EXPLAIN ALTER TABLE foo ADD COLUMN y INT
 ----
 0 alter table
 
-query ITT
+query ITTT
 EXPLAIN ALTER TABLE foo SPLIT AT (42)
 ----
 0 split 42
 
-query ITT
+query ITTT
 EXPLAIN DROP TABLE foo
 ----
 0 drop table
 
-query ITT
+query ITTT
 EXPLAIN SHOW DATABASES
 ----
 0  sort           +Database
 1  virtual table  information_schema.schemata
 2  values         4 columns, 5 rows
 
-query ITT
+query ITTT
 EXPLAIN SHOW TABLES
 ----
 0  virtual table  SHOW TABLES FROM test
 1  values         1 column, 1 row
 
-query ITT
+query ITTT
 EXPLAIN SHOW DATABASE
 ----
 0 virtual table SHOW DATABASE
 1 values 1 column, 1 row
 
-query ITT
+query ITTT
 EXPLAIN SHOW TIME ZONE
 ----
 0 virtual table SHOW TIME ZONE
 1 values 1 column, 1 row
 
-query ITT
+query ITTT
 EXPLAIN SHOW SYNTAX
 ----
 0 virtual table SHOW SYNTAX
 1 values 1 column, 1 row
 
-query ITT
+query ITTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
 ----
 0 virtual table SHOW DEFAULT_TRANSACTION_ISOLATION
 1 values 1 column, 1 row
 
-query ITT
+query ITTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
 ----
 0 virtual table SHOW TRANSACTION ISOLATION LEVEL
 1 values 1 column, 1 row
 
-query ITT
+query ITTT
 EXPLAIN SHOW TRANSACTION PRIORITY
 ----
 0 virtual table SHOW TRANSACTION PRIORITY
 1 values 1 column, 1 row
 
-query ITT
+query ITTT
 EXPLAIN SHOW COLUMNS FROM foo
 ----
 0  virtual table  SHOW COLUMNS FROM foo
 1  values         4 columns, 1 row
 
-query ITT
+query ITTT
 EXPLAIN SHOW GRANTS ON foo
 ----
 0  virtual table  SHOW GRANTS
 1  sort           +"Table",+"User",+Privileges
 2  values         3 columns, 1 row
 
-query ITT
+query ITTT
 EXPLAIN SHOW INDEX FROM foo
 ----
 0 virtual table SHOW INDEX FROM foo
 1 values 7 columns, 2 rows
 
-query ITT
+query ITTT
 EXPLAIN SHOW CONSTRAINTS FROM foo
 ----
 0 virtual table SHOW CONSTRAINTS FROM foo
 1 sort          +"Table",+Name
 2 values        5 columns, 1 row
 
-query ITT
+query ITTT
 EXPLAIN SHOW USERS
 ----
 0 scan users@primary

--- a/pkg/sql/testdata/explain
+++ b/pkg/sql/testdata/explain
@@ -39,14 +39,14 @@ Cumulative Time  Duration  Span Pos   Operation         Event        RowIdx  Key
 0.000ms                           1                                       0  NULL  NULL   t
 0.000ms                           0  coordinator  tracing completed       0  NULL         NULL
 
-query ITTT colnames
+query ITTTTT colnames
 EXPLAIN (TYPES) SELECT 1
 ----
-Level Type          Element  Description
-0     select        result   ("1" int)
-1     render/filter result   ("1" int)
-1     render/filter render 0 (1)[int]
-2     nullrow       result   ()
+Level  Type           Field     Description  Columns    Ordering
+0      select                                ("1" int)
+1      render/filter            from ()      ("1" int)
+1      render/filter  render 0  (1)[int]
+2      nullrow                               ()
 
 statement error cannot set EXPLAIN mode more than once
 EXPLAIN (TRACE, TRACE) SELECT 1

--- a/pkg/sql/testdata/explain
+++ b/pkg/sql/testdata/explain
@@ -5,7 +5,7 @@ Level  Type    Field Description
 0      nullrow
 
 query ITTTTT colnames
-EXPLAIN (PLAN, VERBOSE) SELECT 1
+EXPLAIN (PLAN, METADATA) SELECT 1
 ----
 Level  Type           Field Description    Columns Ordering
 0      select                              ("1")
@@ -13,7 +13,7 @@ Level  Type           Field Description    Columns Ordering
 2      nullrow                             ()
 
 query ITTTTT colnames
-EXPLAIN (VERBOSE, PLAN) SELECT 1
+EXPLAIN (METADATA, PLAN) SELECT 1
 ----
 Level  Type          Field  Description Columns Ordering
 0      select                           ("1")
@@ -27,7 +27,7 @@ RowIdx  Key  Value  Disposition
 0       NULL NULL   ROW
 
 query ITTT colnames
-EXPLAIN (DEBUG, VERBOSE) SELECT 1
+EXPLAIN (DEBUG, METADATA) SELECT 1
 ----
 RowIdx  Key  Value  Disposition
 0       NULL NULL   ROW
@@ -62,7 +62,7 @@ EXPLAIN (TRACE, UNKNOWN) SELECT 1
 
 # Ensure that tracing results are sorted after gathering
 query ITTTTT
-EXPLAIN(VERBOSE) EXPLAIN(TRACE) SELECT 1
+EXPLAIN(METADATA) EXPLAIN(TRACE) SELECT 1
 ----
 0      select                                        ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition)             +@10,+"Span Pos"
 1      sort                  +Timestamp,+"Span Pos"  ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition)             +@10,+"Span Pos"

--- a/pkg/sql/testdata/explain
+++ b/pkg/sql/testdata/explain
@@ -1,8 +1,8 @@
 query ITT colnames
 EXPLAIN (PLAN) SELECT 1
 ----
-Level  Type  Description
-0      empty -
+Level  Type    Description
+0      nullrow
 
 query ITTTT colnames
 EXPLAIN (PLAN, VERBOSE) SELECT 1
@@ -10,7 +10,7 @@ EXPLAIN (PLAN, VERBOSE) SELECT 1
 Level  Type           Description    Columns Ordering
 0      select                        ("1")
 1      render/filter  from ()        ("1")
-2      empty          -              ()
+2      nullrow                       ()
 
 query ITTTT colnames
 EXPLAIN (VERBOSE, PLAN) SELECT 1
@@ -18,7 +18,7 @@ EXPLAIN (VERBOSE, PLAN) SELECT 1
 Level  Type           Description Columns Ordering
 0      select                     ("1")
 1      render/filter  from ()     ("1")
-2      empty          -           ()
+2      nullrow                    ()
 
 query ITTT colnames
 EXPLAIN (DEBUG) SELECT 1
@@ -46,7 +46,7 @@ Level Type          Element  Description
 0     select        result   ("1" int)
 1     render/filter result   ("1" int)
 1     render/filter render 0 (1)[int]
-2     empty         result   ()
+2     nullrow       result   ()
 
 statement error cannot set EXPLAIN mode more than once
 EXPLAIN (TRACE, TRACE) SELECT 1
@@ -70,7 +70,7 @@ Level  Type                  Description             Columns                    
 2      explain               trace                   ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition, Timestamp)
 3      select                                        ("1")
 4      render/filter(debug)  from ()                 ("1")
-5      empty                 -                       ()
+5      nullrow                                       ()
 
 # Ensure that all relevant statement types can be explained
 query ITT

--- a/pkg/sql/testdata/explain_plan
+++ b/pkg/sql/testdata/explain_plan
@@ -19,7 +19,7 @@ EXPLAIN SELECT * FROM t
 0      scan  t@primary
 
 query ITTTTT
-EXPLAIN (VERBOSE) SELECT * FROM t
+EXPLAIN (METADATA) SELECT * FROM t
 ----
 0      select                                   (k, v)  +k,unique
 1      render/filter from (test.t.k, test.t.v)  (k, v)  +k,unique
@@ -29,6 +29,16 @@ query ITTT
 EXPLAIN SELECT * FROM t WHERE k = 1 OR k = 3
 ----
 0      scan  t@primary /1-/2 /3-/4
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE k % 2 = 0
+----
+0  select                                              (k, v)  +k,unique
+1  render/filter            from (test.t.k, test.t.v)  (k, v)  +k,unique
+1  render/filter  render 0  test.t.k
+1  render/filter  render 1  test.t.v
+2  scan                     t@primary ALL              (k, v)  +k,unique
+2  scan           filter    (k % 2) = 0
 
 query ITTT
 EXPLAIN VALUES (1, 2, 3), (4, 5, 6)
@@ -64,7 +74,7 @@ statement ok
 CREATE TABLE tc (a INT, b INT, INDEX c(a))
 
 query ITTTTT
-EXPLAIN(VERBOSE) SELECT * FROM tc WHERE a = 10 ORDER BY b
+EXPLAIN(METADATA) SELECT * FROM tc WHERE a = 10 ORDER BY b
 ----
 0      select                                                      (a, b)                          +b
 1      sort           +b                                           (a, b)                          +b

--- a/pkg/sql/testdata/explain_plan
+++ b/pkg/sql/testdata/explain_plan
@@ -4,67 +4,58 @@ CREATE TABLE t (
   v INT
 )
 
-query ITT colnames
+query ITTT
 EXPLAIN INSERT INTO t VALUES (1, 2)
 ----
-Level  Type   Description
 0      insert
 1      values 2 columns, 1 row
 
 statement ok
 INSERT INTO t VALUES (1, 2)
 
-query ITT colnames
+query ITTT
 EXPLAIN SELECT * FROM t
 ----
-Level  Type  Description
 0      scan  t@primary
 
-query ITTTT colnames
+query ITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t
 ----
-Level  Type          Description                Columns Ordering
 0      select                                   (k, v)  +k,unique
 1      render/filter from (test.t.k, test.t.v)  (k, v)  +k,unique
 2      scan          t@primary                  (k, v)  +k,unique
 
-query ITT colnames
+query ITTT
 EXPLAIN SELECT * FROM t WHERE k = 1 OR k = 3
 ----
-Level  Type  Description
 0      scan  t@primary /1-/2 /3-/4
 
-query ITT colnames
+query ITTT
 EXPLAIN VALUES (1, 2, 3), (4, 5, 6)
 ----
-Level  Type    Description
 0      values  3 columns, 2 rows
 
-query ITT colnames
+query ITTT
 EXPLAIN VALUES (1)
 ----
-Level  Type    Description
 0      values  1 column, 1 row
 
-query ITT colnames
+query ITTT
 EXPLAIN SELECT * FROM t WITH ORDINALITY LIMIT 1 OFFSET 1
 ----
-Level  Type    Description
 0      limit   count: 1, offset:  1
 1      ordinality
 2      scan    t@primary (max 2 rows)
 
-query ITT colnames
+query ITTT
 EXPLAIN SELECT DISTINCT * FROM t
 ----
-Level  Type     Description
 0      distinct k
 1      scan     t@primary
 
-query ITT colnames
+query ITTT
 EXPLAIN SELECT DISTINCT * FROM t LIMIT 1 OFFSET 1
 ----
-Level  Type     Description
 0      limit    count: 1, offset:  1
 1      distinct k
 2      scan     t@primary
@@ -72,10 +63,9 @@ Level  Type     Description
 statement ok
 CREATE TABLE tc (a INT, b INT, INDEX c(a))
 
-query ITTTT colnames
+query ITTTTT
 EXPLAIN(VERBOSE) SELECT * FROM tc WHERE a = 10 ORDER BY b
 ----
-Level  Type           Description                                  Columns                         Ordering
 0      select                                                      (a, b)                          +b
 1      sort           +b                                           (a, b)                          +b
 2      render/filter  from (test.tc.a, test.tc.b, *test.tc.rowid)  (a, b)                          =a

--- a/pkg/sql/testdata/explain_types
+++ b/pkg/sql/testdata/explain_types
@@ -4,256 +4,255 @@ CREATE TABLE t (
   v INT
 )
 
-query ITTT colnames
+query ITTTTT colnames
 EXPLAIN (TYPES) INSERT INTO t VALUES (1, 2)
 ----
-Level  Type   Element       Description
-0      insert result        ()
-1      values result        (column1 int, column2 int)
-1      values row 0, expr 0 (1)[int]
-1      values row 0, expr 1 (2)[int]
+Level  Type    Field          Description                 Columns                     Ordering
+0      insert                 into t (k, v) returning ()  ()
+1      values                 2 columns, 1 row            (column1 int, column2 int)
+1      values  row 0, expr 0  (1)[int]
+1      values  row 0, expr 1  (2)[int]
 
 statement ok
 INSERT INTO t VALUES (1, 2)
 
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES) SELECT 42;
 ----
-0  select        result    ("42" int)
-1  render/filter result    ("42" int)
-1  render/filter render 0  (42)[int]
-2  nullrow       result    ()
+0  select                              ("42" int)
+1  render/filter            from ()    ("42" int)
+1  render/filter  render 0  (42)[int]
+2  nullrow                             ()
 
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES) SELECT * FROM t
 ----
-0      select        result   (k int, v int)
-1      render/filter result   (k int, v int)
-1      render/filter render 0 (k)[int]
-1      render/filter render 1 (v)[int]
-2      scan          result   (k int, v int)
+0  select                                              (k int, v int)  +k,unique
+1  render/filter            from (test.t.k, test.t.v)  (k int, v int)  +k,unique
+1  render/filter  render 0  (k)[int]
+1  render/filter  render 1  (v)[int]
+2  scan                     t@primary                  (k int, v int)  +k,unique
 
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT * FROM t WHERE v > 123
 ----
-0  select        result   (k int, v int)
-1  render/filter result   (k int, v int)
-1  render/filter filter   ((v)[int] > (123)[int])[bool]
-1  render/filter render 0 (k)[int]
-1  render/filter render 1 (v)[int]
-2  scan          result   (k int, v int)
+0  select                                                  (k int, v int)
+1  render/filter            from (test.t.k, test.t.v)      (k int, v int)
+1  render/filter  filter    ((v)[int] > (123)[int])[bool]
+1  render/filter  render 0  (k)[int]
+1  render/filter  render 1  (v)[int]
+2  scan                     t@primary                      (k int, v int)
 
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES) SELECT * FROM t WHERE v > 123
 ----
-0   select          result     (k int, v int)
-1   render/filter   result     (k int, v int)
-1   render/filter   render 0   (k)[int]
-1   render/filter   render 1   (v)[int]
-2   scan            result     (k int, v int)
-2   scan            filter     ((v)[int] > (123)[int])[bool]
+0  select                                                  (k int, v int)  +k,unique
+1  render/filter            from (test.t.k, test.t.v)      (k int, v int)  +k,unique
+1  render/filter  render 0  (k)[int]
+1  render/filter  render 1  (v)[int]
+2  scan                     t@primary ALL                  (k int, v int)  +k,unique
+2  scan           filter    ((v)[int] > (123)[int])[bool]
 
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES) VALUES (1, 2, 3), (4, 5, 6)
 ----
-0 select  result  (column1 int, column2 int, column3 int)
-1 values  result  (column1 int, column2 int, column3 int)
-1 values  row 0, expr 0 (1)[int]
-1 values  row 0, expr 1 (2)[int]
-1 values  row 0, expr 2 (3)[int]
-1 values  row 1, expr 0 (4)[int]
-1 values  row 1, expr 1 (5)[int]
-1 values  row 1, expr 2 (6)[int]
+0  select                                    (column1 int, column2 int, column3 int)
+1  values                 3 columns, 2 rows  (column1 int, column2 int, column3 int)
+1  values  row 0, expr 0  (1)[int]
+1  values  row 0, expr 1  (2)[int]
+1  values  row 0, expr 2  (3)[int]
+1  values  row 1, expr 0  (4)[int]
+1  values  row 1, expr 1  (5)[int]
+1  values  row 1, expr 2  (6)[int]
 
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2
 ----
-0   select          result     (z int, v int)
-0   select          having     ((v)[int] < (2)[int])[bool]
-0   select          render z   ((2)[int] * (count((k)[int]))[int])[int]
-0   select          render v   (v)[int]
-1   render/filter   result     ("2" int, k int, v int, "v < 2" bool, v int)
-1   render/filter   filter     ((v)[int] > (123)[int])[bool]
-1   render/filter   render 0   (2)[int]
-1   render/filter   render 1   (k)[int]
-1   render/filter   render 2   (v)[int]
-1   render/filter   render 3   ((v)[int] < (2)[int])[bool]
-1   render/filter   render 4   (v)[int]
-2   scan            result     (k int, v int)
+0  select                                                             (z int, v int)
+0  select         having    ((v)[int] < (2)[int])[bool]
+0  select         render z  ((2)[int] * (count((k)[int]))[int])[int]
+0  select         render v  (v)[int]
+1  render/filter            from (test.t.k, test.t.v)                 ("2" int, k int, v int, "v < 2" bool, v int)
+1  render/filter  filter    ((v)[int] > (123)[int])[bool]
+1  render/filter  render 0  (2)[int]
+1  render/filter  render 1  (k)[int]
+1  render/filter  render 2  (v)[int]
+1  render/filter  render 3  ((v)[int] < (2)[int])[bool]
+1  render/filter  render 4  (v)[int]
+2  scan                     t@primary                                 (k int, v int)
 
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2
 ----
-0   select          result     (z int, v int)
-1   group           result     (z int, v int)
-1   group           having     ((v)[int] < (2)[int])[bool]
-1   group           render z   ((2)[int] * (count((k)[int]))[int])[int]
-1   group           render v   (v)[int]
-2   render/filter   result     ("2" int, k int, v int, "v < 2" bool, v int)
-2   render/filter   render 0   (2)[int]
-2   render/filter   render 1   (k)[int]
-2   render/filter   render 2   (v)[int]
-2   render/filter   render 3   ((v)[int] < (2)[int])[bool]
-2   render/filter   render 4   (v)[int]
-3   scan            result     (k int, v int)
-3   scan            filter     ((v)[int] > (123)[int])[bool]
+0  select                                                                     (z int, v int)
+1  group                    2, count(k), v, v < 2 GROUP BY (@5) HAVING v < 2  (z int, v int)
+1  group          having    ((v)[int] < (2)[int])[bool]
+1  group          render z  ((2)[int] * (count((k)[int]))[int])[int]
+1  group          render v  (v)[int]
+2  render/filter            from (test.t.k, test.t.v)                         ("2" int, k int, v int, "v < 2" bool, v int)  +k,unique
+2  render/filter  render 0  (2)[int]
+2  render/filter  render 1  (k)[int]
+2  render/filter  render 2  (v)[int]
+2  render/filter  render 3  ((v)[int] < (2)[int])[bool]
+2  render/filter  render 4  (v)[int]
+3  scan                     t@primary ALL                                     (k int, v int)                                +k,unique
+3  scan           filter    ((v)[int] > (123)[int])[bool]
 
-
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) DELETE FROM t WHERE v > 1
 ----
-0   delete          result     ()
-1   select          result     (k int)
-2   render/filter   result     (k int)
-2   render/filter   filter     ((v)[int] > (1)[int])[bool]
-2   render/filter   render 0   (k)[int]
-3   scan            result     (k int, v int)
+0  delete                   from t returning ()          ()
+1  select                                                (k int)
+2  render/filter            from (test.t.k, test.t.v)    (k int)
+2  render/filter  filter    ((v)[int] > (1)[int])[bool]
+2  render/filter  render 0  (k)[int]
+3  scan                     t@primary                    (k int, v int)
 
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES) DELETE FROM t WHERE v > 1
 ----
-0   delete          result     ()
-1   select          result     (k int)
-2   render/filter   result     (k int)
-2   render/filter   render 0   (k)[int]
-3   scan            result     (k int, v int)
-3   scan            filter     ((v)[int] > (1)[int])[bool]
+0  delete                   from t returning ()          ()              +@1,unique
+1  select                                                (k int)         +k,unique
+2  render/filter            from (test.t.k, test.t.v)    (k int)         +k,unique
+2  render/filter  render 0  (k)[int]
+3  scan                     t@primary ALL                (k int, v int)  +k,unique
+3  scan           filter    ((v)[int] > (1)[int])[bool]
 
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES) UPDATE t SET v = k + 1 WHERE v > 123
 ----
-0   update          result     ()
-1   select          result     (k int, v int, "k + 1" int)
-2   render/filter   result     (k int, v int, "k + 1" int)
-2   render/filter   render 0   (k)[int]
-2   render/filter   render 1   (v)[int]
-2   render/filter   render 2   ((k)[int] + (1)[int])[int]
-3   scan            result     (k int, v int)
-3   scan            filter     ((v)[int] > (123)[int])[bool]
+0  update                   set t (v) returning ()         ()                           +@1,unique
+1  select                                                  (k int, v int, "k + 1" int)  +k,unique
+2  render/filter            from (test.t.k, test.t.v)      (k int, v int, "k + 1" int)  +k,unique
+2  render/filter  render 0  (k)[int]
+2  render/filter  render 1  (v)[int]
+2  render/filter  render 2  ((k)[int] + (1)[int])[int]
+3  scan                     t@primary ALL                  (k int, v int)               +k,unique
+3  scan           filter    ((v)[int] > (123)[int])[bool]
 
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) UPDATE t SET v = k + 1 WHERE v > 123
 ----
-0   update          result     ()
-1   select          result     (k int, v int, "k + 1" int)
-2   render/filter   result     (k int, v int, "k + 1" int)
-2   render/filter   filter     ((v)[int] > (123)[int])[bool]
-2   render/filter   render 0   (k)[int]
-2   render/filter   render 1   (v)[int]
-2   render/filter   render 2   ((k)[int] + (1)[int])[int]
-3   scan            result     (k int, v int)
+0  update                   set t (v) returning ()         ()
+1  select                                                  (k int, v int, "k + 1" int)
+2  render/filter            from (test.t.k, test.t.v)      (k int, v int, "k + 1" int)
+2  render/filter  filter    ((v)[int] > (123)[int])[bool]
+2  render/filter  render 0  (k)[int]
+2  render/filter  render 1  (v)[int]
+2  render/filter  render 2  ((k)[int] + (1)[int])[int]
+3  scan                     t@primary                      (k int, v int)
 
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES) VALUES (1) UNION VALUES (2)
 ----
-0   select   result          (column1 int)
-1   union    result          (column1 int)
-2   select   result          (column1 int)
-3   values   result          (column1 int)
-3   values   row 0, expr 0   (1)[int]
-2   select   result          (column1 int)
-3   values   result          (column1 int)
-3   values   row 0, expr 0   (2)[int]
+0  select                                  (column1 int)
+1  union                  -                (column1 int)
+2  select                                  (column1 int)
+3  values                 1 column, 1 row  (column1 int)
+3  values  row 0, expr 0  (1)[int]
+2  select                                  (column1 int)
+3  values                 1 column, 1 row  (column1 int)
+3  values  row 0, expr 0  (2)[int]
 
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES) SELECT DISTINCT k FROM t
 ----
-0  select         result    (k int)
-1  distinct       result    (k int)
-2  render/filter  result    (k int)
+0  select                                              (k int)                  +k,unique
+1  distinct                 k                          (k int)                  +k,unique
+2  render/filter            from (test.t.k, test.t.v)  (k int)                  +k,unique
 2  render/filter  render 0  (k)[int]
-3  scan           result    (k int, v[omitted] int)
+3  scan                     t@primary                  (k int, v[omitted] int)  +k,unique
 
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT DISTINCT k FROM t
 ----
-0   select          result     (k int)
-1   render/filter   result     (k int)
-1   render/filter   render 0   (k)[int]
-2   scan            result     (k int, v int)
+0  select                                              (k int)
+1  render/filter            from (test.t.k, test.t.v)  (k int)
+1  render/filter  render 0  (k)[int]
+2  scan                     t@primary                  (k int, v int)
 
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES) SELECT v FROM t ORDER BY v
 ----
-0   select          result     (v int)
-1   sort            result     (v int)
-2   render/filter   result     (v int)
-2   render/filter   render 0   (v)[int]
-3   scan            result     (k[omitted] int, v int)
+0  select                                              (v int)                  +v
+1  sort                     +v                         (v int)                  +v
+2  render/filter            from (test.t.k, test.t.v)  (v int)
+2  render/filter  render 0  (v)[int]
+3  scan                     t@primary ALL              (k[omitted] int, v int)  +k,unique
 
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT v FROM t ORDER BY v
 ----
-0   select          result     (v int)
-1   render/filter   result     (v int)
-1   render/filter   render 0   (v)[int]
-2   scan            result     (k int, v int)
+0  select                                              (v int)
+1  render/filter            from (test.t.k, test.t.v)  (v int)
+1  render/filter  render 0  (v)[int]
+2  scan                     t@primary                  (k int, v int)
 
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES) SELECT v FROM t LIMIT 1
 ----
-0   select          result     (v int)
-1   limit           result     (v int)
-1   limit           count      (1)[int]
-2   render/filter   result     (v int)
-2   render/filter   render 0   (v)[int]
-3   scan            result     (k[omitted] int, v int)
+0  select                                              (v int)
+1  limit                    count: 1                   (v int)
+1  limit          count     (1)[int]
+2  render/filter            from (test.t.k, test.t.v)  (v int)
+2  render/filter  render 0  (v)[int]
+3  scan                     t@primary (max 1 row)      (k[omitted] int, v int)  +k,unique
 
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT v FROM t LIMIT 1
 ----
-0   select          result     (v int)
-0   select          count      (1)[int]
-1   render/filter   result     (v int)
-1   render/filter   render 0   (v)[int]
-2   scan            result     (k int, v int)
+0  select                                              (v int)
+0  select         count     (1)[int]
+1  render/filter            from (test.t.k, test.t.v)  (v int)
+1  render/filter  render 0  (v)[int]
+2  scan                     t@primary                  (k int, v int)
 
 statement ok
 CREATE TABLE tt (x INT, y INT, INDEX a(x), INDEX b(y))
 
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES) SELECT * FROM tt WHERE x < 10 AND y > 10
 ----
-0  select         result    (x int, y int)
-1  render/filter  result    (x int, y int)
+0  select                                                                (x int, y int)                              +x
+1  render/filter            from (test.tt.x, test.tt.y, *test.tt.rowid)  (x int, y int)                              +x
 1  render/filter  render 0  (x)[int]
 1  render/filter  render 1  (y)[int]
-2  index-join     result    (x int, y int, rowid[hidden,omitted] int)
-3  scan           result    (x int, y[omitted] int, rowid[hidden] int)
+2  index-join                                                            (x int, y int, rowid[hidden,omitted] int)   +x,+rowid,unique
+3  scan                     tt@a /#-/10                                  (x int, y[omitted] int, rowid[hidden] int)  +x,+rowid,unique
 3  scan           filter    ((x)[int] < (10)[int])[bool]
-3  scan           result    (x int, y int, rowid[hidden,omitted] int)
+3  scan                     tt@primary                                   (x int, y int, rowid[hidden,omitted] int)   +rowid,unique
 3  scan           filter    ((y)[int] > (10)[int])[bool]
 
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT * FROM tt WHERE x < 10 AND y > 10
 ----
-0   select          result     (x int, y int)
-1   render/filter   result     (x int, y int)
-1   render/filter   filter     ((((x)[int] < (10)[int])[bool]) AND (((y)[int] > (10)[int])[bool]))[bool]
-1   render/filter   render 0   (x)[int]
-1   render/filter   render 1   (y)[int]
-2   scan            result     (x int, y int, rowid[hidden] int)
+0  select                                                                                              (x int, y int)
+1  render/filter            from (test.tt.x, test.tt.y, *test.tt.rowid)                                (x int, y int)
+1  render/filter  filter    ((((x)[int] < (10)[int])[bool]) AND (((y)[int] > (10)[int])[bool]))[bool]
+1  render/filter  render 0  (x)[int]
+1  render/filter  render 1  (y)[int]
+2  scan                     tt@primary                                                                 (x int, y int, rowid[hidden] int)
 
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES) SELECT $1 + 2 AS a
 ----
-0      select          result     (a int)
-1      render/filter   result     (a int)
-1      render/filter   render 0   (($1)[int] + (2)[int])[int]
-2      nullrow         result     ()
+0  select                                                (a int)
+1  render/filter            from ()                      (a int)
+1  render/filter  render 0  (($1)[int] + (2)[int])[int]
+2  nullrow                                               ()
 
-query ITTT
+query ITTTTT
+EXPLAIN (TYPES, NONORMALIZE) SELECT ABS(2-3) AS a
+----
+0  select                                          (a int)
+1  render/filter            from ()                (a int)
+1  render/filter  render 0  (abs((-1)[int]))[int]
+2  nullrow                                         ()
+
+query ITTTTT
 EXPLAIN (TYPES) SELECT ABS(2-3) AS a
 ----
-0      select          result     (a int)
-1      render/filter   result     (a int)
-1      render/filter   render 0   (abs((-1)[int]))[int]
-2      nullrow         result     ()
-
-query ITTT
-EXPLAIN (TYPES, NORMALIZE) SELECT ABS(2-3) AS a
-----
-0      select          result     (a int)
-1      render/filter   result     (a int)
-1      render/filter   render 0   (1)[int]
-2      nullrow         result     ()
+0  select                             (a int)
+1  render/filter            from ()   (a int)
+1  render/filter  render 0  (1)[int]
+2  nullrow                            ()

--- a/pkg/sql/testdata/explain_types
+++ b/pkg/sql/testdata/explain_types
@@ -34,6 +34,24 @@ EXPLAIN (TYPES) SELECT * FROM t
 2  scan                     t@primary                  (k int, v int)  +k,unique
 
 query ITTTTT
+EXPLAIN (TYPES, SYMVARS) SELECT * FROM t
+----
+0  select                                              (k int, v int)  +k,unique
+1  render/filter            from (test.t.k, test.t.v)  (k int, v int)  +k,unique
+1  render/filter  render 0  (@1)[int]
+1  render/filter  render 1  (@2)[int]
+2  scan                     t@primary                  (k int, v int)  +k,unique
+
+query ITTTTT
+EXPLAIN (TYPES, QUALIFY) SELECT * FROM t
+----
+0  select                                              (k int, v int)  +k,unique
+1  render/filter            from (test.t.k, test.t.v)  (k int, v int)  +k,unique
+1  render/filter  render 0  (test.t.k)[int]
+1  render/filter  render 1  (test.t.v)[int]
+2  scan                     t@primary                  (k int, v int)  +k,unique
+
+query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT * FROM t WHERE v > 123
 ----
 0  select                                                  (k int, v int)

--- a/pkg/sql/testdata/explain_types
+++ b/pkg/sql/testdata/explain_types
@@ -22,7 +22,7 @@ EXPLAIN (TYPES) SELECT 42;
 0  select        result    ("42" int)
 1  render/filter result    ("42" int)
 1  render/filter render 0  (42)[int]
-2  empty         result    ()
+2  nullrow       result    ()
 
 query ITTT
 EXPLAIN (TYPES) SELECT * FROM t
@@ -240,7 +240,7 @@ EXPLAIN (TYPES) SELECT $1 + 2 AS a
 0      select          result     (a int)
 1      render/filter   result     (a int)
 1      render/filter   render 0   (($1)[int] + (2)[int])[int]
-2      empty           result     ()
+2      nullrow         result     ()
 
 query ITTT
 EXPLAIN (TYPES) SELECT ABS(2-3) AS a
@@ -248,7 +248,7 @@ EXPLAIN (TYPES) SELECT ABS(2-3) AS a
 0      select          result     (a int)
 1      render/filter   result     (a int)
 1      render/filter   render 0   (abs((-1)[int]))[int]
-2      empty           result     ()
+2      nullrow         result     ()
 
 query ITTT
 EXPLAIN (TYPES, NORMALIZE) SELECT ABS(2-3) AS a
@@ -256,4 +256,4 @@ EXPLAIN (TYPES, NORMALIZE) SELECT ABS(2-3) AS a
 0      select          result     (a int)
 1      render/filter   result     (a int)
 1      render/filter   render 0   (1)[int]
-2      empty           result     ()
+2      nullrow         result     ()

--- a/pkg/sql/testdata/insert
+++ b/pkg/sql/testdata/insert
@@ -487,7 +487,7 @@ CREATE TABLE select_t (x INT,v INT,PRIMARY KEY (x))
 statement ok
 INSERT INTO select_t VALUES(1, 2),(2,3),(3,4)
 
-query ITT
+query ITTT
 EXPLAIN (PLAN) INSERT INTO insert_t SELECT * FROM select_t LIMIT 1
 ----
 0  insert
@@ -513,21 +513,21 @@ SELECT * FROM insert_t
 ----
 1  2
 
-query ITT
+query ITTT
 EXPLAIN (PLAN) INSERT INTO insert_t VALUES(1,'AAA'),(2,'BBB') LIMIT 1
 ----
 0  insert
 1  limit   count: 1
 2  values  2 columns, 2 rows
 
-query ITT
+query ITTT
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES(1,'AAA'),(2,'BBB')) LIMIT 1
 ----
 0  insert
 1  limit   count: 1
 2  values  2 columns, 2 rows
 
-query ITT
+query ITTT
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES(1,'AAA'),(2,'BBB') LIMIT 1)
 ----
 0  insert

--- a/pkg/sql/testdata/join
+++ b/pkg/sql/testdata/join
@@ -406,7 +406,7 @@ x  x  y  b  d  e
 44 44 51 44 44 51
 
 # Check EXPLAIN.
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM onecolumn JOIN twocolumn USING(x)
 ----
 0  join  INNER ON EQUALS((x),(x))
@@ -414,7 +414,7 @@ EXPLAIN SELECT * FROM onecolumn JOIN twocolumn USING(x)
 1  scan  twocolumn@primary
 
 # Check EXPLAIN.
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
 ----
 0  join  INNER ON EQUALS((x),(y))
@@ -422,7 +422,7 @@ EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
 1  scan  twocolumn@primary
 
 # Check EXPLAIN.
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
 ----
 0  join  INNER ON a.x = 44
@@ -430,7 +430,7 @@ EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
 1  scan  twocolumn@primary
 
 # Check EXPLAIN.
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
 ----
 0  join  INNER ON EQUALS((x),(y))
@@ -438,7 +438,7 @@ EXPLAIN SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
 1  scan  twocolumn@primary
 
 # Check EXPLAIN.
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
 ----
 0  join  INNER ON EQUALS((x),(y))
@@ -446,7 +446,7 @@ EXPLAIN SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
 1  scan  twocolumn@primary
 
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twocolumn.x JOIN twocolumn AS c(d,e) ON a.b=c.d AND c.d=onecolumn.x) LIMIT 1
 ----
 0  limit  count: 1
@@ -549,7 +549,7 @@ query error memory budget exceeded
 SELECT COUNT(*) FROM s AS a, s AS b, s AS c, s AS d, s AS e, s AS f, s AS g, s AS h, s AS i, s AS j, s AS k;
 
 # THe following queries verify that only the necessary columns are scanned.
-query ITTTT
+query ITTTTT
 EXPLAIN (VERBOSE) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
 ----
 0  select                                                                          (x, y)
@@ -559,7 +559,7 @@ EXPLAIN (VERBOSE) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
 3  scan           twocolumn@primary                                                (x[omitted], y, rowid[hidden,omitted])
 
 
-query ITTTT
+query ITTTTT
 EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
 ----
 0  select                                                                                     (y)
@@ -568,7 +568,7 @@ EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
 3  scan           twocolumn@primary                                                           (x, y[omitted], rowid[hidden,omitted])
 3  scan           twocolumn@primary                                                           (x, y, rowid[hidden,omitted])
 
-query ITTTT
+query ITTTTT
 EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b.x)
 ----
 0  select                                                                          (y)
@@ -577,7 +577,7 @@ EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b
 3  scan           twocolumn@primary                                                (x, y[omitted], rowid[hidden,omitted])
 3  scan           twocolumn@primary                                                (x, y, rowid[hidden,omitted])
 
-query ITTTT
+query ITTTTT
 EXPLAIN (VERBOSE) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b.y)
 ----
 0  select                                                                          (x)
@@ -587,7 +587,7 @@ EXPLAIN (VERBOSE) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b
 3  scan           twocolumn@primary                                                (x[omitted], y, rowid[hidden,omitted])
 
 # Ensure that the ordering information for the result of joins is sane. (#12037)
-query ITTTT
+query ITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES (9, 1), (8, 2)) AS a (u, k) ORDER BY k)
 				INNER JOIN (VALUES (1, 1), (2, 2)) AS b (k, w) USING (k) ORDER BY u
 ----

--- a/pkg/sql/testdata/join
+++ b/pkg/sql/testdata/join
@@ -550,7 +550,7 @@ SELECT COUNT(*) FROM s AS a, s AS b, s AS c, s AS d, s AS e, s AS f, s AS g, s A
 
 # THe following queries verify that only the necessary columns are scanned.
 query ITTTTT
-EXPLAIN (VERBOSE) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
+EXPLAIN (METADATA) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
 ----
 0  select                                                                          (x, y)
 1  render/filter  from ("".a.x, "".a.y, *"".a.rowid, "".b.x, "".b.y, *"".b.rowid)  (x, y)
@@ -560,7 +560,7 @@ EXPLAIN (VERBOSE) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
 
 
 query ITTTTT
-EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
+EXPLAIN (METADATA) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
 ----
 0  select                                                                                     (y)
 1  render/filter  from (""."".x, *"".a.x, "".a.y, *"".a.rowid, *"".b.x, "".b.y, *"".b.rowid)  (y)
@@ -569,7 +569,7 @@ EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
 3  scan           twocolumn@primary                                                           (x, y, rowid[hidden,omitted])
 
 query ITTTTT
-EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b.x)
+EXPLAIN (METADATA) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b.x)
 ----
 0  select                                                                          (y)
 1  render/filter  from ("".a.x, "".a.y, *"".a.rowid, "".b.x, "".b.y, *"".b.rowid)  (y)
@@ -578,7 +578,7 @@ EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b
 3  scan           twocolumn@primary                                                (x, y, rowid[hidden,omitted])
 
 query ITTTTT
-EXPLAIN (VERBOSE) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b.y)
+EXPLAIN (METADATA) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b.y)
 ----
 0  select                                                                          (x)
 1  render/filter  from ("".a.x, "".a.y, *"".a.rowid, "".b.x, "".b.y, *"".b.rowid)  (x)
@@ -588,7 +588,7 @@ EXPLAIN (VERBOSE) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b
 
 # Ensure that the ordering information for the result of joins is sane. (#12037)
 query ITTTTT
-EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES (9, 1), (8, 2)) AS a (u, k) ORDER BY k)
+EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES (9, 1), (8, 2)) AS a (u, k) ORDER BY k)
 				INNER JOIN (VALUES (1, 1), (2, 2)) AS b (k, w) USING (k) ORDER BY u
 ----
 0   select                                                          (k, u, w)            +u

--- a/pkg/sql/testdata/order_by
+++ b/pkg/sql/testdata/order_by
@@ -38,7 +38,7 @@ SELECT a, b FROM t ORDER BY b
 2 8
 1 9
 
-query ITT
+query ITTT
 EXPLAIN SELECT a, b FROM t ORDER BY b
 ----
 0 sort +b
@@ -51,7 +51,7 @@ SELECT a, b FROM t ORDER BY b DESC
 2 8
 3 7
 
-query ITT
+query ITTT
 EXPLAIN SELECT a, b FROM t ORDER BY b DESC
 ----
 0 sort -b
@@ -64,7 +64,7 @@ SELECT a FROM t ORDER BY 1 DESC
 2
 1
 
-query ITT
+query ITTT
 EXPLAIN SELECT a, b FROM t ORDER BY b LIMIT 2
 ----
 0 limit count: 2
@@ -77,7 +77,7 @@ SELECT a, b FROM t ORDER BY b DESC LIMIT 2
 1 9
 2 8
 
-query ITT
+query ITTT
 EXPLAIN SELECT DISTINCT a FROM t ORDER BY b LIMIT 2
 ----
 0 limit    count: 2
@@ -130,19 +130,19 @@ SELECT b FROM t ORDER BY a DESC
 8
 9
 
-query ITT
+query ITTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC
 ----
 0 nosort -a
 1 revscan t@primary ALL
 
-query ITT
+query ITTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b ASC
 ----
 0 nosort -a,+b
 1 revscan t@primary ALL
 
-query ITT
+query ITTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b DESC
 ----
 0 nosort -a,-b
@@ -233,18 +233,18 @@ query error source name "a" not found in FROM clause
 SELECT a FROM t ORDER BY a.b
 
 # Check that sort is skipped if the ORDER BY clause is constant.
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM t ORDER BY 1+2
 ----
 0 scan t@primary
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM t ORDER BY length('abc')
 ----
 0 scan t@primary
 
 # Check that the sort key reuses the existing render.
-query ITTTT
+query ITTTTT
 EXPLAIN(VERBOSE) SELECT b+2 FROM t ORDER BY b+2
 ----
 0   select                                              ("b + 2")   +"b + 2"
@@ -253,7 +253,7 @@ EXPLAIN(VERBOSE) SELECT b+2 FROM t ORDER BY b+2
 3   scan            t@primary ALL                       (a[omitted], b, c[omitted])   +a,unique
 
 # Check that the sort picks up a renamed render properly.
-query ITTTT
+query ITTTTT
 EXPLAIN(VERBOSE) SELECT b+2 AS y FROM t ORDER BY y
 ----
 0   select                                              (y)   +y
@@ -262,7 +262,7 @@ EXPLAIN(VERBOSE) SELECT b+2 AS y FROM t ORDER BY y
 3   scan            t@primary ALL                       (a[omitted], b, c[omitted])   +a,unique
 
 # Check that the sort reuses a render behind a rename properly.
-query ITTTT
+query ITTTTT
 EXPLAIN(VERBOSE) SELECT b+2 AS y FROM t ORDER BY b+2
 ----
 0   select                                              (y)   +y
@@ -300,7 +300,7 @@ EXPLAIN (DEBUG) SELECT * FROM abc ORDER BY a
 1 /abc/primary/4/5/6   NULL  PARTIAL
 1 /abc/primary/4/5/6/d 'Two' ROW
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM abc ORDER BY a
 ----
 0 scan abc@primary ALL
@@ -311,20 +311,20 @@ EXPLAIN (DEBUG) SELECT a, b FROM abc ORDER BY b, a
 0 /abc/ba/2/1/3 NULL ROW
 1 /abc/ba/5/4/6 NULL ROW
 
-query ITT
+query ITTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, a
 ----
 0 scan abc@ba ALL
 
 # The non-unique index ba includes column c (required to make the keys unique)
 # so the results will already be sorted.
-query ITT
+query ITTT
 EXPLAIN SELECT a, b, c FROM abc ORDER BY b, a, c
 ----
 0 scan abc@ba ALL
 
 # We use the WHERE condition to force the use of index ba.
-query ITT
+query ITTT
 EXPLAIN SELECT a, b, c FROM abc WHERE b > 10 ORDER BY b, a, d
 ----
 0 sort       +b,+a,+d
@@ -334,26 +334,26 @@ EXPLAIN SELECT a, b, c FROM abc WHERE b > 10 ORDER BY b, a, d
 
 # We cannot have rows with identical values for a,b,c so we don't need to
 # sort for d.
-query ITT
+query ITTT
 EXPLAIN SELECT a, b, c, d FROM abc WHERE b > 10 ORDER BY b, a, c, d
 ----
 0 index-join
 1 scan       abc@ba /11-
 1 scan       abc@primary
 
-query ITT
+query ITTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c
 ----
 0 nosort +b,+c
 1 scan   abc@bc ALL
 
-query ITT
+query ITTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a
 ----
 0 nosort +b,+c,+a
 1 scan   abc@bc ALL
 
-query ITT
+query ITTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a DESC
 ----
 0 nosort +b,+c,-a
@@ -379,7 +379,7 @@ EXPLAIN (DEBUG) SELECT a FROM abc ORDER BY a DESC
 1 /abc/primary/1/2/3/d 'one' PARTIAL
 1 /abc/primary/1/2/3   NULL  ROW
 
-query ITT
+query ITTT
 EXPLAIN SELECT a FROM abc ORDER BY a DESC
 ----
 0 revscan abc@primary ALL
@@ -400,12 +400,12 @@ SELECT a FROM abc ORDER BY a DESC OFFSET 1
 ----
 1
 
-query ITT
+query ITTT
 EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c
 ----
 0 scan abc@bc /2-/3
 
-query ITT
+query ITTT
 EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c DESC
 ----
 0 revscan abc@bc /2-/3
@@ -435,22 +435,22 @@ statement ok
 INSERT INTO abcd VALUES (1, 4, 2, 3), (2, 3, 4, 1), (3, 2, 1, 2), (4, 4, 1, 1)
 
 # The following tests verify we recognize that sorting is not necessary
-query ITT
+query ITTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c
 ----
 0 scan abcd@abc /1/4-/1/5
 
-query ITT
+query ITTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c, b, a
 ----
 0 scan abcd@abc /1/4-/1/5
 
-query ITT
+query ITTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, a, c
 ----
 0 scan abcd@abc /1/4-/1/5
 
-query ITT
+query ITTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, c, a
 ----
 0 scan abcd@abc /1/4-/1/5
@@ -469,7 +469,7 @@ NaN
 -1
 1
 
-query ITTTT
+query ITTTTT
 EXPLAIN(VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x);
 ----
 0  select                           (x)        +x
@@ -480,20 +480,20 @@ EXPLAIN(VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(
 5  select                           (column1)
 6  values         1 column, 3 rows  (column1)
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality ASC;
 ----
 0 ordinality
 1 values 1 column, 3 rows
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality DESC;
 ----
 0 sort -ordinality
 1 ordinality
 2 values 1 column, 3 rows
 
-query ITTTT
+query ITTTTT
 EXPLAIN(VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY;
 ----
 0  select                                           (x, ordinality)  +ordinality,unique
@@ -504,7 +504,7 @@ EXPLAIN(VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(
 5  select                                           (column1)
 6  values         1 column, 3 rows                  (column1)
 
-query ITTTT
+query ITTTTT
 EXPLAIN(VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY;
 ----
 0  select                                           (x, ordinality)  +x

--- a/pkg/sql/testdata/order_by
+++ b/pkg/sql/testdata/order_by
@@ -42,7 +42,7 @@ query ITT
 EXPLAIN SELECT a, b FROM t ORDER BY b
 ----
 0 sort +b
-1 scan t@primary -
+1 scan t@primary ALL
 
 query II
 SELECT a, b FROM t ORDER BY b DESC
@@ -55,7 +55,7 @@ query ITT
 EXPLAIN SELECT a, b FROM t ORDER BY b DESC
 ----
 0 sort -b
-1 scan t@primary -
+1 scan t@primary ALL
 
 query I
 SELECT a FROM t ORDER BY 1 DESC
@@ -69,7 +69,7 @@ EXPLAIN SELECT a, b FROM t ORDER BY b LIMIT 2
 ----
 0 limit count: 2
 1 sort  +b (top 2)
-2 scan  t@primary -
+2 scan  t@primary ALL
 
 query II
 SELECT a, b FROM t ORDER BY b DESC LIMIT 2
@@ -83,7 +83,7 @@ EXPLAIN SELECT DISTINCT a FROM t ORDER BY b LIMIT 2
 0 limit    count: 2
 1 distinct
 2 sort     +b (iterative)
-3 scan     t@primary -
+3 scan     t@primary ALL
 
 query I
 SELECT DISTINCT a FROM t ORDER BY b DESC LIMIT 2
@@ -134,19 +134,19 @@ query ITT
 EXPLAIN SELECT b FROM t ORDER BY a DESC
 ----
 0 nosort -a
-1 revscan t@primary -
+1 revscan t@primary ALL
 
 query ITT
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b ASC
 ----
 0 nosort -a,+b
-1 revscan t@primary -
+1 revscan t@primary ALL
 
 query ITT
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b DESC
 ----
 0 nosort -a,-b
-1 revscan t@primary -
+1 revscan t@primary ALL
 
 statement ok
 INSERT INTO t VALUES (4, 7), (5, 7)
@@ -250,7 +250,7 @@ EXPLAIN(VERBOSE) SELECT b+2 FROM t ORDER BY b+2
 0   select                                              ("b + 2")   +"b + 2"
 1   sort            +"b + 2"                            ("b + 2")   +"b + 2"
 2   render/filter   from (test.t.a, test.t.b, test.t.c) ("b + 2")
-3   scan            t@primary -                         (a[omitted], b, c[omitted])   +a,unique
+3   scan            t@primary ALL                       (a[omitted], b, c[omitted])   +a,unique
 
 # Check that the sort picks up a renamed render properly.
 query ITTTT
@@ -259,7 +259,7 @@ EXPLAIN(VERBOSE) SELECT b+2 AS y FROM t ORDER BY y
 0   select                                              (y)   +y
 1   sort            +y                                  (y)   +y
 2   render/filter   from (test.t.a, test.t.b, test.t.c) (y)
-3   scan            t@primary -                         (a[omitted], b, c[omitted])   +a,unique
+3   scan            t@primary ALL                       (a[omitted], b, c[omitted])   +a,unique
 
 # Check that the sort reuses a render behind a rename properly.
 query ITTTT
@@ -268,7 +268,7 @@ EXPLAIN(VERBOSE) SELECT b+2 AS y FROM t ORDER BY b+2
 0   select                                              (y)   +y
 1   sort            +y                                  (y)   +y
 2   render/filter   from (test.t.a, test.t.b, test.t.c) (y)
-3   scan            t@primary -                         (a[omitted], b, c[omitted])   +a,unique
+3   scan            t@primary ALL                       (a[omitted], b, c[omitted])   +a,unique
 
 statement ok
 CREATE TABLE abc (
@@ -303,7 +303,7 @@ EXPLAIN (DEBUG) SELECT * FROM abc ORDER BY a
 query ITT
 EXPLAIN SELECT * FROM abc ORDER BY a
 ----
-0 scan abc@primary -
+0 scan abc@primary ALL
 
 query ITTT
 EXPLAIN (DEBUG) SELECT a, b FROM abc ORDER BY b, a
@@ -314,14 +314,14 @@ EXPLAIN (DEBUG) SELECT a, b FROM abc ORDER BY b, a
 query ITT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, a
 ----
-0 scan abc@ba -
+0 scan abc@ba ALL
 
 # The non-unique index ba includes column c (required to make the keys unique)
 # so the results will already be sorted.
 query ITT
 EXPLAIN SELECT a, b, c FROM abc ORDER BY b, a, c
 ----
-0 scan abc@ba -
+0 scan abc@ba ALL
 
 # We use the WHERE condition to force the use of index ba.
 query ITT
@@ -345,19 +345,19 @@ query ITT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c
 ----
 0 nosort +b,+c
-1 scan   abc@bc -
+1 scan   abc@bc ALL
 
 query ITT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a
 ----
 0 nosort +b,+c,+a
-1 scan   abc@bc -
+1 scan   abc@bc ALL
 
 query ITT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a DESC
 ----
 0 nosort +b,+c,-a
-1 scan   abc@bc -
+1 scan   abc@bc ALL
 
 query ITTT
 EXPLAIN (DEBUG) SELECT b, c FROM abc ORDER BY b, c
@@ -382,7 +382,7 @@ EXPLAIN (DEBUG) SELECT a FROM abc ORDER BY a DESC
 query ITT
 EXPLAIN SELECT a FROM abc ORDER BY a DESC
 ----
-0 revscan abc@primary -
+0 revscan abc@primary ALL
 
 query I
 SELECT a FROM abc ORDER BY a DESC

--- a/pkg/sql/testdata/order_by
+++ b/pkg/sql/testdata/order_by
@@ -245,7 +245,7 @@ EXPLAIN SELECT * FROM t ORDER BY length('abc')
 
 # Check that the sort key reuses the existing render.
 query ITTTTT
-EXPLAIN(VERBOSE) SELECT b+2 FROM t ORDER BY b+2
+EXPLAIN(METADATA) SELECT b+2 FROM t ORDER BY b+2
 ----
 0   select                                              ("b + 2")   +"b + 2"
 1   sort            +"b + 2"                            ("b + 2")   +"b + 2"
@@ -254,7 +254,7 @@ EXPLAIN(VERBOSE) SELECT b+2 FROM t ORDER BY b+2
 
 # Check that the sort picks up a renamed render properly.
 query ITTTTT
-EXPLAIN(VERBOSE) SELECT b+2 AS y FROM t ORDER BY y
+EXPLAIN(METADATA) SELECT b+2 AS y FROM t ORDER BY y
 ----
 0   select                                              (y)   +y
 1   sort            +y                                  (y)   +y
@@ -263,7 +263,7 @@ EXPLAIN(VERBOSE) SELECT b+2 AS y FROM t ORDER BY y
 
 # Check that the sort reuses a render behind a rename properly.
 query ITTTTT
-EXPLAIN(VERBOSE) SELECT b+2 AS y FROM t ORDER BY b+2
+EXPLAIN(METADATA) SELECT b+2 AS y FROM t ORDER BY b+2
 ----
 0   select                                              (y)   +y
 1   sort            +y                                  (y)   +y
@@ -470,7 +470,7 @@ NaN
 1
 
 query ITTTTT
-EXPLAIN(VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x);
+EXPLAIN(METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x);
 ----
 0  select                           (x)        +x
 1  render/filter  from (""."".x)    (x)        +x
@@ -494,7 +494,7 @@ EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordi
 2 values 1 column, 3 rows
 
 query ITTTTT
-EXPLAIN(VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY;
+EXPLAIN(METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY;
 ----
 0  select                                           (x, ordinality)  +ordinality,unique
 1  render/filter  from (""."".x, ""."".ordinality)  (x, ordinality)  +ordinality,unique
@@ -505,7 +505,7 @@ EXPLAIN(VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(
 6  values         1 column, 3 rows                  (column1)
 
 query ITTTTT
-EXPLAIN(VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY;
+EXPLAIN(METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY;
 ----
 0  select                                           (x, ordinality)  +x
 1  render/filter  from (""."".x, ""."".ordinality)  (x, ordinality)  +x

--- a/pkg/sql/testdata/ordinal_references
+++ b/pkg/sql/testdata/ordinal_references
@@ -51,7 +51,7 @@ EXPLAIN(VERBOSE) SELECT b, a FROM foo ORDER BY @1
 0  select                                                         (b, a)                 +a
 1  sort           +a                                              (b, a)                 +a
 2  render/filter  from (test.foo.a, test.foo.b, *test.foo.rowid)  (b, a)
-3  scan           foo@primary -                                   (a, b, rowid[hidden,omitted])  +rowid,unique
+3  scan           foo@primary ALL                                 (a, b, rowid[hidden,omitted])  +rowid,unique
 
 statement ok
 INSERT INTO foo(a, b) VALUES (4, 'c'), (5, 'c'), (6, 'c')
@@ -80,7 +80,7 @@ EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1;
 0  select                                                         (m)
 1  group          min(a) GROUP BY (@2)                            (m)
 2  render/filter  from (test.foo.a, test.foo.b, *test.foo.rowid)  (a, a)
-3  scan           foo@primary -                                   (a, b[omitted], rowid[hidden,omitted])  +rowid,unique
+3  scan           foo@primary ALL                                 (a, b[omitted], rowid[hidden,omitted])  +rowid,unique
 
 query ITTTT
 EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2;
@@ -88,7 +88,7 @@ EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2;
 0  select                                                         (m)
 1  group          min(a) GROUP BY (@2)                            (m)
 2  render/filter  from (test.foo.a, test.foo.b, *test.foo.rowid)  (a, b)
-3  scan           foo@primary -                                   (a, b, rowid[hidden,omitted])  +rowid,unique
+3  scan           foo@primary ALL                                 (a, b, rowid[hidden,omitted])  +rowid,unique
 
 statement error column reference @1 not allowed in this context
 INSERT INTO foo(a, b) VALUES (@1, @2)

--- a/pkg/sql/testdata/ordinal_references
+++ b/pkg/sql/testdata/ordinal_references
@@ -45,7 +45,7 @@ c 1
 a 3
 
 # Check that sort by ordinal picks up the existing render.
-query ITTTT
+query ITTTTT
 EXPLAIN(VERBOSE) SELECT b, a FROM foo ORDER BY @1
 ----
 0  select                                                         (b, a)                 +a
@@ -74,7 +74,7 @@ SELECT SUM(a) AS s FROM foo GROUP BY @2 ORDER BY s
 16
 
 # Check that GROUP BY picks up column ordinals.
-query ITTTT
+query ITTTTT
 EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1;
 ----
 0  select                                                         (m)
@@ -82,7 +82,7 @@ EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1;
 2  render/filter  from (test.foo.a, test.foo.b, *test.foo.rowid)  (a, a)
 3  scan           foo@primary ALL                                 (a, b[omitted], rowid[hidden,omitted])  +rowid,unique
 
-query ITTTT
+query ITTTTT
 EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2;
 ----
 0  select                                                         (m)

--- a/pkg/sql/testdata/ordinal_references
+++ b/pkg/sql/testdata/ordinal_references
@@ -46,7 +46,7 @@ a 3
 
 # Check that sort by ordinal picks up the existing render.
 query ITTTTT
-EXPLAIN(VERBOSE) SELECT b, a FROM foo ORDER BY @1
+EXPLAIN(METADATA) SELECT b, a FROM foo ORDER BY @1
 ----
 0  select                                                         (b, a)                 +a
 1  sort           +a                                              (b, a)                 +a
@@ -75,7 +75,7 @@ SELECT SUM(a) AS s FROM foo GROUP BY @2 ORDER BY s
 
 # Check that GROUP BY picks up column ordinals.
 query ITTTTT
-EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1;
+EXPLAIN(METADATA) SELECT min(a) AS m FROM foo GROUP BY @1;
 ----
 0  select                                                         (m)
 1  group          min(a) GROUP BY (@2)                            (m)
@@ -83,7 +83,7 @@ EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1;
 3  scan           foo@primary ALL                                 (a, b[omitted], rowid[hidden,omitted])  +rowid,unique
 
 query ITTTTT
-EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2;
+EXPLAIN(METADATA) SELECT min(a) AS m FROM foo GROUP BY @2;
 ----
 0  select                                                         (m)
 1  group          min(a) GROUP BY (@2)                            (m)

--- a/pkg/sql/testdata/ordinality
+++ b/pkg/sql/testdata/ordinality
@@ -80,7 +80,7 @@ true
 true
 
 # Show that the primary key is used under ordinalityNode.
-query ITTTT
+query ITTTTT
 EXPLAIN (verbose) SELECT * FROM (SELECT * FROM foo WHERE x > 'a') WITH ORDINALITY;
 ----
 0  select                                           (x, ordinality)  +x,unique
@@ -92,7 +92,7 @@ EXPLAIN (verbose) SELECT * FROM (SELECT * FROM foo WHERE x > 'a') WITH ORDINALIT
 
 # Show that the primary key cannot be used with a PK predicate
 # outside of ordinalityNode.
-query ITTTT
+query ITTTTT
 EXPLAIN (verbose) SELECT * FROM foo WITH ORDINALITY WHERE x > 'a';
 ----
 0  select                                              (x, ordinality)  +ordinality,unique

--- a/pkg/sql/testdata/ordinality
+++ b/pkg/sql/testdata/ordinality
@@ -81,7 +81,7 @@ true
 
 # Show that the primary key is used under ordinalityNode.
 query ITTTTT
-EXPLAIN (verbose) SELECT * FROM (SELECT * FROM foo WHERE x > 'a') WITH ORDINALITY;
+EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM foo WHERE x > 'a') WITH ORDINALITY;
 ----
 0  select                                           (x, ordinality)  +x,unique
 1  render/filter  from (""."".x, ""."".ordinality)  (x, ordinality)  +x,unique
@@ -93,7 +93,7 @@ EXPLAIN (verbose) SELECT * FROM (SELECT * FROM foo WHERE x > 'a') WITH ORDINALIT
 # Show that the primary key cannot be used with a PK predicate
 # outside of ordinalityNode.
 query ITTTTT
-EXPLAIN (verbose) SELECT * FROM foo WITH ORDINALITY WHERE x > 'a';
+EXPLAIN (METADATA) SELECT * FROM foo WITH ORDINALITY WHERE x > 'a';
 ----
 0  select                                              (x, ordinality)  +ordinality,unique
 1  render/filter  from (test.foo.x, ""."".ordinality)  (x, ordinality)  +ordinality,unique

--- a/pkg/sql/testdata/select_index
+++ b/pkg/sql/testdata/select_index
@@ -133,7 +133,7 @@ EXPLAIN (DEBUG) SELECT * FROM t WHERE a > 1 AND b > 'b'
 query ITT
 EXPLAIN SELECT * FROM t WHERE a > 1 AND a < 2
 ----
-0 empty -
+0 empty
 
 query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t WHERE a = 1 AND 'a' < b AND 'c' > b
@@ -220,7 +220,7 @@ EXPLAIN (DEBUG) SELECT * FROM t@ab WHERE a + 1 = 4
 query ITT
 EXPLAIN SELECT * FROM t WHERE a = 1 AND false
 ----
-0 empty -
+0 empty
 
 # Make sure that mixed type comparison operations are not used
 # for selecting indexes.

--- a/pkg/sql/testdata/select_index
+++ b/pkg/sql/testdata/select_index
@@ -254,7 +254,7 @@ SELECT b FROM t WHERE c > 4.0 AND a < 4
 query ITT
 EXPLAIN SELECT a FROM t WHERE c > 1
 ----
-0 scan t@bc -
+0 scan t@bc ALL
 
 query ITT
 EXPLAIN SELECT a FROM t WHERE c < 1 AND b < 5
@@ -264,12 +264,12 @@ EXPLAIN SELECT a FROM t WHERE c < 1 AND b < 5
 query ITT
 EXPLAIN SELECT a FROM t WHERE c > 1.0
 ----
-0 scan t@bc -
+0 scan t@bc ALL
 
 query ITT
 EXPLAIN SELECT a FROM t WHERE c < 1.0
 ----
-0 scan t@bc -
+0 scan t@bc ALL
 
 query ITT
 EXPLAIN SELECT a FROM t WHERE c > 1.0 AND b < 5

--- a/pkg/sql/testdata/select_index
+++ b/pkg/sql/testdata/select_index
@@ -130,7 +130,7 @@ query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t WHERE a > 1 AND b > 'b'
 ----
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM t WHERE a > 1 AND a < 2
 ----
 0 empty
@@ -217,7 +217,7 @@ EXPLAIN (DEBUG) SELECT * FROM t@ab WHERE a + 1 = 4
 ----
 0 /t/ab/3/4 NULL ROW
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM t WHERE a = 1 AND false
 ----
 0 empty
@@ -251,42 +251,42 @@ SELECT b FROM t WHERE c > 4.0 AND a < 4
 ----
 4
 
-query ITT
+query ITTT
 EXPLAIN SELECT a FROM t WHERE c > 1
 ----
 0 scan t@bc ALL
 
-query ITT
+query ITTT
 EXPLAIN SELECT a FROM t WHERE c < 1 AND b < 5
 ----
 0 scan t@bc /#-/4/1
 
-query ITT
+query ITTT
 EXPLAIN SELECT a FROM t WHERE c > 1.0
 ----
 0 scan t@bc ALL
 
-query ITT
+query ITTT
 EXPLAIN SELECT a FROM t WHERE c < 1.0
 ----
 0 scan t@bc ALL
 
-query ITT
+query ITTT
 EXPLAIN SELECT a FROM t WHERE c > 1.0 AND b < 5
 ----
 0 scan t@bc /#-/5
 
-query ITT
+query ITTT
 EXPLAIN SELECT a FROM t WHERE b < 5.0 AND c < 1
 ----
 0 scan t@bc /#-/4/1
 
-query ITT
+query ITTT
 EXPLAIN SELECT a FROM t WHERE (b, c) = (5, 1)
 ----
 0 scan t@bc /5/1-/5/2
 
-query ITT
+query ITTT
 EXPLAIN SELECT a FROM t WHERE (b, c) = (5.0, 1)
 ----
 0 scan t@bc /5/1-/5/2
@@ -294,7 +294,7 @@ EXPLAIN SELECT a FROM t WHERE (b, c) = (5.0, 1)
 query error tuples \(b, c\), \(5.1, 1\) are not the same type: expected 5.1 to be of type int, found type decimal
 EXPLAIN SELECT a FROM t WHERE (b, c) = (5.1, 1)
 
-query ITT
+query ITTT
 EXPLAIN SELECT a FROM t WHERE b IN (5.0, 1)
 ----
 0 scan t@b_desc /-6-/-5 /-2-/-1
@@ -311,12 +311,12 @@ CREATE TABLE abcd (
 
 # Verify that we prefer the index where more columns are constrained, even if it
 # has more keys per row.
-query ITT
+query ITTT
 EXPLAIN SELECT b FROM abcd WHERE (a, b) = (1, 4)
 ----
 0 scan abcd@abcd /1/4-/1/5
 
-query ITT
+query ITTT
 EXPLAIN SELECT b FROM abcd WHERE (a, b) IN ((1, 4), (2, 9))
 ----
 0 scan abcd@abcd /1/4-/1/5 /2/9-/2/10
@@ -342,7 +342,7 @@ SELECT i, s FROM ab@baz WHERE (i, s) < (1, 'c')
 1 a
 1 b
 
-query ITT
+query ITTT
 EXPLAIN SELECT i, s FROM ab@baz WHERE (i, s) < (1, 'c')
 ----
 0 scan ab@baz /#-/1/"c"

--- a/pkg/sql/testdata/select_index_hints
+++ b/pkg/sql/testdata/select_index_hints
@@ -50,7 +50,7 @@ query ITT
 EXPLAIN SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
 0 index-join
-1 scan       abcd@b       -
+1 scan       abcd@b       ALL
 1 scan       abcd@primary
 
 # Force index cd
@@ -65,7 +65,7 @@ query ITT
 EXPLAIN SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
 ----
 0 index-join
-1 scan       abcd@cd      -
+1 scan       abcd@cd      ALL
 1 scan       abcd@primary
 
 # Force index bcd
@@ -73,7 +73,7 @@ EXPLAIN SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
 query ITT
 EXPLAIN SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
 ----
-0 scan       abcd@bcd     -
+0 scan       abcd@bcd     ALL
 
 query IIII
 SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
@@ -86,7 +86,7 @@ SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
 query ITT
 EXPLAIN SELECT b FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
-0 scan       abcd@b       -
+0 scan       abcd@b       ALL
 
 # Force index b (non-covering due to WHERE clause)
 
@@ -94,7 +94,7 @@ query ITT
 EXPLAIN SELECT b FROM abcd@b WHERE c >= 20 AND c <= 30
 ----
 0 index-join
-1 scan       abcd@b       -
+1 scan       abcd@b       ALL
 1 scan       abcd@primary
 
 # No hint, should be using index cd
@@ -121,7 +121,7 @@ SELECT c, d FROM abcd@primary WHERE c >= 20 AND c < 40
 query ITT
 EXPLAIN SELECT c, d FROM abcd@primary WHERE c >= 20 AND c < 40
 ----
-0 scan       abcd@primary -
+0 scan       abcd@primary ALL
 
 # Force index b
 
@@ -135,7 +135,7 @@ query ITT
 EXPLAIN SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
 ----
 0 index-join
-1 scan       abcd@b       -
+1 scan       abcd@b       ALL
 1 scan       abcd@primary
 
 query error index \"badidx\" not found
@@ -148,7 +148,7 @@ query ITT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b} WHERE a >= 20 AND a <= 30
 ----
 0 index-join
-1 scan       abcd@b       -
+1 scan       abcd@b       ALL
 1 scan       abcd@primary
 
 query ITT
@@ -161,17 +161,17 @@ EXPLAIN SELECT b, c, d FROM abcd WHERE c = 10
 query ITT
 EXPLAIN SELECT b, c, d FROM abcd@{NO_INDEX_JOIN} WHERE c = 10
 ----
-0 scan       abcd@bcd -
+0 scan       abcd@bcd ALL
 
 query ITT
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=bcd,NO_INDEX_JOIN} WHERE c = 10
 ----
-0 scan       abcd@bcd -
+0 scan       abcd@bcd ALL
 
 query ITT
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=primary,NO_INDEX_JOIN} WHERE c = 10
 ----
-0 scan       abcd@primary -
+0 scan       abcd@primary ALL
 
 query error index \"cd\" is not covering and NO_INDEX_JOIN was specified
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=cd,NO_INDEX_JOIN} WHERE c = 10

--- a/pkg/sql/testdata/select_index_hints
+++ b/pkg/sql/testdata/select_index_hints
@@ -20,7 +20,7 @@ SELECT * FROM abcd WHERE a >= 20 AND a <= 30
 20 21 22 23
 30 31 32 33
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM abcd WHERE a >= 20 AND a <= 30
 ----
 0 scan       abcd@primary /20-/31
@@ -33,7 +33,7 @@ SELECT * FROM abcd@primary WHERE a >= 20 AND a <= 30
 20 21 22 23
 30 31 32 33
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM abcd@primary WHERE a >= 20 AND a <= 30
 ----
 0 scan       abcd@primary /20-/31
@@ -46,7 +46,7 @@ SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30
 20 21 22 23
 30 31 32 33
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
 0 index-join
@@ -61,7 +61,7 @@ SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
 20 21 22 23
 30 31 32 33
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
 ----
 0 index-join
@@ -70,7 +70,7 @@ EXPLAIN SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
 
 # Force index bcd
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
 ----
 0 scan       abcd@bcd     ALL
@@ -83,14 +83,14 @@ SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
 
 # Force index b (covering)
 
-query ITT
+query ITTT
 EXPLAIN SELECT b FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
 0 scan       abcd@b       ALL
 
 # Force index b (non-covering due to WHERE clause)
 
-query ITT
+query ITTT
 EXPLAIN SELECT b FROM abcd@b WHERE c >= 20 AND c <= 30
 ----
 0 index-join
@@ -105,7 +105,7 @@ SELECT c, d FROM abcd WHERE c >= 20 AND c < 40
 22 23
 32 33
 
-query ITT
+query ITTT
 EXPLAIN SELECT c, d FROM abcd WHERE c >= 20 AND c < 40
 ----
 0 scan       abcd@cd /20-/40
@@ -118,7 +118,7 @@ SELECT c, d FROM abcd@primary WHERE c >= 20 AND c < 40
 22 23
 32 33
 
-query ITT
+query ITTT
 EXPLAIN SELECT c, d FROM abcd@primary WHERE c >= 20 AND c < 40
 ----
 0 scan       abcd@primary ALL
@@ -131,7 +131,7 @@ SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
 22 23
 32 33
 
-query ITT
+query ITTT
 EXPLAIN SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
 ----
 0 index-join
@@ -144,31 +144,31 @@ SELECT * FROM abcd@badidx
 query error index \"badidx\" not found
 SELECT * FROM abcd@{FORCE_INDEX=badidx}
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b} WHERE a >= 20 AND a <= 30
 ----
 0 index-join
 1 scan       abcd@b       ALL
 1 scan       abcd@primary
 
-query ITT
+query ITTT
 EXPLAIN SELECT b, c, d FROM abcd WHERE c = 10
 ----
 0 index-join
 1 scan       abcd@cd      /10-/11
 1 scan       abcd@primary
 
-query ITT
+query ITTT
 EXPLAIN SELECT b, c, d FROM abcd@{NO_INDEX_JOIN} WHERE c = 10
 ----
 0 scan       abcd@bcd ALL
 
-query ITT
+query ITTT
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=bcd,NO_INDEX_JOIN} WHERE c = 10
 ----
 0 scan       abcd@bcd ALL
 
-query ITT
+query ITTT
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=primary,NO_INDEX_JOIN} WHERE c = 10
 ----
 0 scan       abcd@primary ALL

--- a/pkg/sql/testdata/select_index_span_ranges
+++ b/pkg/sql/testdata/select_index_span_ranges
@@ -52,7 +52,7 @@ ALTER INDEX t@c SPLIT AT (90)
 statement ok
 ALTER INDEX c SPLIT AT (10)
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM t WHERE (c >= 80) ORDER BY c
 ----
 0  index-join

--- a/pkg/sql/testdata/select_non_covering_index
+++ b/pkg/sql/testdata/select_non_covering_index
@@ -96,14 +96,14 @@ query ITT
 EXPLAIN SELECT * FROM t ORDER BY c
 ----
 0 sort       +c
-1 scan       t@primary -
+1 scan       t@primary ALL
 
 query ITT
 EXPLAIN SELECT * FROM t ORDER BY c LIMIT 5
 ----
 0 limit      count: 5
 1 index-join
-2 scan       t@c - (max 5 rows)
+2 scan       t@c ALL (max 5 rows)
 2 scan       t@primary
 
 query ITT
@@ -111,14 +111,14 @@ EXPLAIN SELECT * FROM t ORDER BY c OFFSET 5
 ----
 0 limit      offset: 5
 1 sort       +c
-2 scan       t@primary -
+2 scan       t@primary ALL
 
 query ITT
 EXPLAIN SELECT * FROM t ORDER BY c LIMIT 5 OFFSET 5
 ----
 0 limit      count: 5, offset: 5
 1 index-join
-2 scan       t@c - (max 10 rows)
+2 scan       t@c ALL (max 10 rows)
 2 scan       t@primary
 
 query ITT
@@ -126,4 +126,4 @@ EXPLAIN SELECT * FROM t ORDER BY c LIMIT 1000000
 ----
 0 limit      count: 1000000
 1 sort       +c (top 1000000)
-2 scan       t@primary -
+2 scan       t@primary ALL

--- a/pkg/sql/testdata/select_non_covering_index
+++ b/pkg/sql/testdata/select_non_covering_index
@@ -15,7 +15,7 @@ CREATE TABLE t (
 statement ok
 INSERT INTO t VALUES (1, 2, 3, 4), (5, 6, 7, 8)
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM t WHERE b = 2
 ----
 0 index-join
@@ -36,7 +36,7 @@ SELECT * FROM t WHERE b = 2
 ----
 1 2 3 4
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM t WHERE c = 6
 ----
 0 index-join
@@ -63,14 +63,14 @@ SELECT * FROM t WHERE c > 0 ORDER BY c DESC
 5 6 7 8
 1 2 3 4
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM t WHERE c > 0 ORDER BY c DESC
 ----
 0 index-join
 1 revscan    t@c /1-
 1 scan       t@primary
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM t WHERE c > 0 ORDER BY c
 ----
 0 index-join
@@ -82,7 +82,7 @@ SELECT * FROM t WHERE c > 0 AND d = 8
 ----
 5 6 7 8
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM t WHERE c > 0 AND d = 8
 ----
 0 index-join
@@ -92,13 +92,13 @@ EXPLAIN SELECT * FROM t WHERE c > 0 AND d = 8
 # The following testcases verify that when we have a small limit, we prefer an
 # order-matching index.
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM t ORDER BY c
 ----
 0 sort       +c
 1 scan       t@primary ALL
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM t ORDER BY c LIMIT 5
 ----
 0 limit      count: 5
@@ -106,14 +106,14 @@ EXPLAIN SELECT * FROM t ORDER BY c LIMIT 5
 2 scan       t@c ALL (max 5 rows)
 2 scan       t@primary
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM t ORDER BY c OFFSET 5
 ----
 0 limit      offset: 5
 1 sort       +c
 2 scan       t@primary ALL
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM t ORDER BY c LIMIT 5 OFFSET 5
 ----
 0 limit      count: 5, offset: 5
@@ -121,7 +121,7 @@ EXPLAIN SELECT * FROM t ORDER BY c LIMIT 5 OFFSET 5
 2 scan       t@c ALL (max 10 rows)
 2 scan       t@primary
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM t ORDER BY c LIMIT 1000000
 ----
 0 limit      count: 1000000

--- a/pkg/sql/testdata/select_non_covering_index_filtering
+++ b/pkg/sql/testdata/select_non_covering_index_filtering
@@ -27,7 +27,7 @@ INSERT INTO t VALUES
   (8, 3, 2, '32'),
   (9, 3, 3, '33')
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM t WHERE b = 2 AND c % 2 = 0
 ----
 0 index-join
@@ -46,7 +46,7 @@ EXPLAIN (DEBUG) SELECT * FROM t WHERE b = 2 AND c % 2 = 0
 0 /t/primary/5/s '22' ROW
 2 /t/bc/2/3/6    NULL FILTERED
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM t WHERE b = 2 AND c != b
 ----
 0 index-join

--- a/pkg/sql/testdata/subquery
+++ b/pkg/sql/testdata/subquery
@@ -324,7 +324,7 @@ EXPLAIN(VERBOSE) SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz);
 ----
 0  select                                                    (x)                          +x,unique
 1  render/filter  from (test.xyz.x, test.xyz.y, test.xyz.z)  (x)                          +x,unique
-2  scan           xyz@primary -                              (x, y[omitted], z[omitted])  +x,unique
+2  scan           xyz@primary ALL                            (x, y[omitted], z[omitted])  +x,unique
 3  select                                                    (x)                          +x,unique
 4  render/filter  from (test.xyz.x, test.xyz.y, test.xyz.z)  (x)                          +x,unique
 5  scan           xyz@primary                                (x, y[omitted], z[omitted])  +x,unique
@@ -350,6 +350,6 @@ EXPLAIN SELECT col0 FROM tab4 WHERE (col0 <= 0 AND col4 <= 5.38) OR (col4 IN (SE
 ----
 0  index-join
 1  scan        tab4@idx_tab4_0 /#-/5.38/1
-2  scan        tab4@primary    -
+2  scan        tab4@primary    ALL
 1  scan        tab4@primary
-2  scan        tab4@primary    -
+2  scan        tab4@primary    ALL

--- a/pkg/sql/testdata/subquery
+++ b/pkg/sql/testdata/subquery
@@ -40,7 +40,7 @@ CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
 statement ok
 INSERT INTO abc VALUES (1, 2, 3), (4, 5, 6)
 
-query ITT
+query ITTT
 EXPLAIN ALTER TABLE abc SPLIT AT ((SELECT 42))
 ----
 0 split (SELECT 42)
@@ -266,7 +266,7 @@ foo1 moo2 moo3
 2    4    4
 3    1    1
 
-query ITT
+query ITTT
 EXPLAIN SELECT * FROM (SELECT * FROM (VALUES (1, 8, 8), (3, 1, 1), (2, 4, 4)) AS moo (moo1, moo2, moo3) ORDER BY moo2) as foo (foo1) ORDER BY foo1
 ----
 0 sort   +foo1
@@ -319,7 +319,7 @@ INSERT INTO xyz (x, y, z) VALUES (13, 11, 12) RETURNING (y IN (SELECT y FROM xyz
 true
 
 # check that residual filters are not expanded twice
-query ITTTT
+query ITTTTT
 EXPLAIN(VERBOSE) SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz);
 ----
 0  select                                                    (x)                          +x,unique
@@ -345,7 +345,7 @@ query I
 SELECT col0 FROM tab4 WHERE (col0 <= 0 AND col4 <= 5.38) OR (col4 IN (SELECT col1 FROM tab4 WHERE col1 > 8.27)) AND (col3 <= 5 AND (col3 BETWEEN 7 AND 9))
 ----
 
-query ITT
+query ITTT
 EXPLAIN SELECT col0 FROM tab4 WHERE (col0 <= 0 AND col4 <= 5.38) OR (col4 IN (SELECT col1 FROM tab4 WHERE col1 > 8.27)) AND (col3 <= 5 AND (col3 BETWEEN 7 AND 9))
 ----
 0  index-join

--- a/pkg/sql/testdata/subquery
+++ b/pkg/sql/testdata/subquery
@@ -44,7 +44,7 @@ query ITT
 EXPLAIN ALTER TABLE abc SPLIT AT ((SELECT 42))
 ----
 0 split (SELECT 42)
-1 empty -
+1 nullrow
 
 statement ok
 ALTER TABLE abc SPLIT AT ((SELECT 1))

--- a/pkg/sql/testdata/subquery
+++ b/pkg/sql/testdata/subquery
@@ -320,7 +320,7 @@ true
 
 # check that residual filters are not expanded twice
 query ITTTTT
-EXPLAIN(VERBOSE) SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz);
+EXPLAIN(METADATA) SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz);
 ----
 0  select                                                    (x)                          +x,unique
 1  render/filter  from (test.xyz.x, test.xyz.y, test.xyz.z)  (x)                          +x,unique

--- a/pkg/sql/testdata/union
+++ b/pkg/sql/testdata/union
@@ -134,7 +134,7 @@ SELECT v FROM uniontest WHERE k = 1 UNION ALL SELECT v FROM uniontest WHERE k = 
 3
 2
 
-query ITT rowsort
+query ITTT rowsort
 EXPLAIN SELECT v FROM uniontest UNION SELECT k FROM uniontest
 ----
 0 union -

--- a/pkg/sql/testdata/values
+++ b/pkg/sql/testdata/values
@@ -26,7 +26,7 @@ VALUES ((SELECT 1)), ((SELECT 2))
 2
 
 # the subquery's plan must be visible in EXPLAIN
-query ITT
+query ITTT
 EXPLAIN VALUES (1), ((SELECT 2))
 ----
 0 values 1 column, 2 rows

--- a/pkg/sql/testdata/values
+++ b/pkg/sql/testdata/values
@@ -30,4 +30,4 @@ query ITT
 EXPLAIN VALUES (1), ((SELECT 2))
 ----
 0 values 1 column, 2 rows
-1 empty  -
+1 nullrow

--- a/pkg/sql/testdata/window
+++ b/pkg/sql/testdata/window
@@ -465,7 +465,7 @@ SELECT k, max(stddev) OVER (ORDER BY d DESC) FROM (SELECT k, d, stddev(d) OVER (
 7  3.5355339059327376
 8  3.5355339059327376
 
-query ITT
+query ITTT
 EXPLAIN SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
 ----
 0  sort    +"variance(d) OVER w",+k

--- a/pkg/sql/testdata/window
+++ b/pkg/sql/testdata/window
@@ -470,7 +470,7 @@ EXPLAIN SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY
 ----
 0  sort    +"variance(d) OVER w",+k
 1  window  stddev(d) OVER w, variance(d) OVER w
-2  scan    kv@primary -
+2  scan    kv@primary ALL
 
 query ITTT
 EXPLAIN (DEBUG) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k

--- a/pkg/sql/testdata/window
+++ b/pkg/sql/testdata/window
@@ -505,31 +505,31 @@ EXPLAIN (DEBUG) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) 
 4  4                (3, 3.5355339059327376, 12.5000000000000000)  ROW
 5  5                (8, 3.5355339059327376, 12.5000000000000000)  ROW
 
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
 ----
-0  select         result                     (k int, "stddev(d) OVER w" decimal)
-1  sort           result                     (k int, "stddev(d) OVER w" decimal)
-2  window         result                     (k int, "stddev(d) OVER w" decimal, "variance(d) OVER w" decimal)
+0  select                                                                                                                        (k int, "stddev(d) OVER w" decimal)                                                              +@3,+k
+1  sort                                      +"variance(d) OVER w",+k                                                            (k int, "stddev(d) OVER w" decimal)                                                              +@3,+k
+2  window                                    stddev(d) OVER w, variance(d) OVER w                                                (k int, "stddev(d) OVER w" decimal, "variance(d) OVER w" decimal)
 2  window         render stddev(d) OVER w    (stddev((d)[decimal]) OVER w)[decimal]
 2  window         render variance(d) OVER w  (variance((d)[decimal]) OVER w)[decimal]
-3  render/filter  result                     (k int, d decimal, d decimal, v int, v int)
+3  render/filter                             from (test.kv.k, test.kv.v, test.kv.w, test.kv.f, test.kv.d, test.kv.s, test.kv.b)  (k int, d decimal, d decimal, v int, v int)                                                      +k,unique
 3  render/filter  render 0                   (k)[int]
 3  render/filter  render 1                   (d)[decimal]
 3  render/filter  render 2                   (d)[decimal]
 3  render/filter  render 3                   (v)[int]
 3  render/filter  render 4                   (v)[int]
-4  scan           result                     (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)
+4  scan                                      kv@primary ALL                                                                      (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  +k,unique
 
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-0  select         result                                         (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)
-1  sort           result                                         (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)
-2  window         result                                         (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal, "variance(d) OVER (PARTITION BY v, 100)" decimal)
+0  select                                                                                                                                            (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                                    +@3,+k
+1  sort                                                          +"variance(d) OVER (PARTITION BY v, 100)",+k                                        (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                                    +@3,+k
+2  window                                                        stddev(d) OVER (PARTITION BY v, 'a'), variance(d) OVER (PARTITION BY v, 100)        (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal, "variance(d) OVER (PARTITION BY v, 100)" decimal)
 2  window         render stddev(d) OVER (PARTITION BY v, 'a')    (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
 2  window         render variance(d) OVER (PARTITION BY v, 100)  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]
-3  render/filter  result                                         (k int, d decimal, d decimal, v int, "'a'" string, v int, "100" int)
+3  render/filter                                                 from (test.kv.k, test.kv.v, test.kv.w, test.kv.f, test.kv.d, test.kv.s, test.kv.b)  (k int, d decimal, d decimal, v int, "'a'" string, v int, "100" int)                                       +k,unique
 3  render/filter  render 0                                       (k)[int]
 3  render/filter  render 1                                       (d)[decimal]
 3  render/filter  render 2                                       (d)[decimal]
@@ -537,31 +537,31 @@ EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY 
 3  render/filter  render 4                                       ('a')[string]
 3  render/filter  render 5                                       (v)[int]
 3  render/filter  render 6                                       (100)[int]
-4  scan           result                                         (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)
+4  scan                                                          kv@primary ALL                                                                      (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)            +k,unique
 
-query ITTT
-EXPLAIN (TYPES,NORMALIZE) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY k
+query ITTTTT
+EXPLAIN (TYPES,NONORMALIZE) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY k
 ----
-0  select         result                                       (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)
-1  sort           result                                       (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)
-2  window         result                                       (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)
+0  select                                                                                                                                          (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                          +k
+1  sort                                                        +k                                                                                  (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                          +k
+2  window                                                      stddev(d) OVER (PARTITION BY v, 'a')                                                (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)
 2  window         render stddev(d) OVER (PARTITION BY v, 'a')  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
-3  render/filter  result                                       (k int, d decimal, v int, "'a'" string)
+3  render/filter                                               from (test.kv.k, test.kv.v, test.kv.w, test.kv.f, test.kv.d, test.kv.s, test.kv.b)  (k int, d decimal, v int, "'a'" string)                                                          +k,unique
 3  render/filter  render 0                                     (k)[int]
 3  render/filter  render 1                                     (d)[decimal]
 3  render/filter  render 2                                     (v)[int]
 3  render/filter  render 3                                     ('a')[string]
-4  scan           result                                       (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)
+4  scan                                                        kv@primary ALL                                                                      (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  +k,unique
 
-query ITTT
+query ITTTTT
 EXPLAIN (TYPES) SELECT k, k + stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-0  select         result                                           (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)
-1  sort           result                                           (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)
-2  window         result                                           (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal, "variance(d) OVER (PARTITION BY v, 100)" decimal)
+0  select                                                                                                                                                             (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                                    +@3,+k
+1  sort                                                            +"variance(d) OVER (PARTITION BY v, 100)",+k                                                       (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                                    +@3,+k
+2  window                                                          stddev(d) OVER (PARTITION BY v, 'a'), variance(d) OVER (PARTITION BY v, 100)                       (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal, "variance(d) OVER (PARTITION BY v, 100)" decimal)
 2  window         render k + stddev(d) OVER (PARTITION BY v, 'a')  ((k)[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]
 2  window         render variance(d) OVER (PARTITION BY v, 100)    (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]
-3  render/filter  result                                           (k int, d decimal, d decimal, v int, "'a'" string, v int, "100" int, k int)
+3  render/filter                                                   from (test.kv.k, test.kv.v, test.kv.w, test.kv.f, test.kv.d, test.kv.s, test.kv.b)                 (k int, d decimal, d decimal, v int, "'a'" string, v int, "100" int, k int)                                    +k,unique
 3  render/filter  render 0                                         (k)[int]
 3  render/filter  render 1                                         (d)[decimal]
 3  render/filter  render 2                                         (d)[decimal]
@@ -570,7 +570,7 @@ EXPLAIN (TYPES) SELECT k, k + stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER
 3  render/filter  render 5                                         (v)[int]
 3  render/filter  render 6                                         (100)[int]
 3  render/filter  render 7                                         (k)[int]
-4  scan           result                                           (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)
+4  scan                                                            kv@primary ALL                                                                                     (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)                +k,unique
 
 statement OK
 INSERT INTO kv VALUES

--- a/pkg/sql/trace.go
+++ b/pkg/sql/trace.go
@@ -206,7 +206,7 @@ func (n *explainTraceNode) ExplainPlan(v bool) (name, description string, childr
 	return "explain", "trace", []planNode{n.plan}
 }
 
-func (n *explainTraceNode) ExplainTypes(fn func(string, string)) {}
+func (n *explainTraceNode) explainExprs(fn func(string, parser.Expr)) {}
 
 func (n *explainTraceNode) Values() parser.DTuple {
 	return n.rows[0]

--- a/pkg/sql/union.go
+++ b/pkg/sql/union.go
@@ -162,7 +162,7 @@ func (n *unionNode) ExplainPlan(_ bool) (name, description string, children []pl
 	return "union", "-", []planNode{n.left, n.right}
 }
 
-func (n *unionNode) ExplainTypes(_ func(string, string)) {}
+func (n *unionNode) explainExprs(_ func(string, parser.Expr)) {}
 
 func (n *unionNode) MarkDebug(mode explainMode) {
 	if mode != explainDebug {

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -451,10 +451,10 @@ func (u *updateNode) ExplainPlan(v bool) (name, description string, children []p
 	return "update", buf.String(), subplans
 }
 
-func (u *updateNode) ExplainTypes(regTypes func(string, string)) {
+func (u *updateNode) explainExprs(regTypes func(string, parser.Expr)) {
 	cols := u.rh.columns
 	for i, rexpr := range u.rh.exprs {
-		regTypes(fmt.Sprintf("returning %s", cols[i].Name), parser.AsStringWithFlags(rexpr, parser.FmtShowTypes))
+		regTypes(fmt.Sprintf("returning %s", cols[i].Name), rexpr)
 	}
 }
 

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -331,11 +331,11 @@ func (n *valuesNode) ExplainPlan(_ bool) (name, description string, children []p
 	return name, description, subplans
 }
 
-func (n *valuesNode) ExplainTypes(regTypes func(string, string)) {
+func (n *valuesNode) explainExprs(regTypes func(string, parser.Expr)) {
 	if n.n != nil {
 		for i, tuple := range n.tuples {
 			for j, expr := range tuple {
-				regTypes(fmt.Sprintf("row %d, expr %d", i, j), parser.AsStringWithFlags(expr, parser.FmtShowTypes))
+				regTypes(fmt.Sprintf("row %d, expr %d", i, j), expr)
 			}
 		}
 	}

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -776,12 +776,11 @@ func (n *windowNode) ExplainPlan(_ bool) (name, description string, children []p
 	return name, buf.String(), subplans
 }
 
-func (n *windowNode) ExplainTypes(regTypes func(string, string)) {
+func (n *windowNode) explainExprs(regTypes func(string, parser.Expr)) {
 	cols := n.Columns()
 	for i, rexpr := range n.windowRender {
 		if rexpr != nil {
-			regTypes(fmt.Sprintf("render %s", cols[i].Name),
-				parser.AsStringWithFlags(rexpr, parser.FmtShowTypes))
+			regTypes(fmt.Sprintf("render %s", cols[i].Name), rexpr)
 		}
 	}
 }


### PR DESCRIPTION
These improvements were needed to properly test / evaluate the work on filter optimization #10633.

User-visible changes:

1. simpler/more regular EXPLAIN options. In particular TYPES is now an option to EXPLAIN(PLAN) instead of a separate explain mode.
2. new option INDENT which reveals the hierarchical structure of the tree more clearly.
3. "empty" now reads "nullrow" when that's what the node does.
4. spans in "scan" now read "ALL" for full table scans instead of the less useful "-".

Regarding point 1:

| Option        | Expr. Fields | Expr. Types | Ordinal references | Qualified names | Extra columns | Indented output |
| ------------- | ------------ | ----------- | ------------------ | --------------- | ------------- | --------------- |
| (none)        | no           | no          | no                 | no              | no            | no              |
| SYMVARS       | -            | -           | yes                | -               | -             | -               |
| QUALIFY       | -            | -           | -                  | yes             | -             | -               |
| METADATA      | -            | -           | -                  | -               | yes           | -               |
| TYPES         | yes          | yes         | -                  | -               | yes           | -               |
| VERBOSE       | yes          | -           | yes                | yes             | yes           | -               |
| TYPES,VERBOSE | yes          | yes         | yes                | yes             | yes           | -               |
| INDENT        | -            | -           | -                  | -               | -             | yes             |

Regarding point 2:

```
root@:26257> explain select s from t union all select s from t;
+-------+-------+-------+-------------+
| Level | Type  | Field | Description |
+-------+-------+-------+-------------+
|     0 | union |       |           - |
|     1 | scan  |       | t@primary   |
|     1 | scan  |       | t@primary   |
+-------+-------+-------+-------------+
(3 rows)
root@:26257> explain(indent) select s from t union all select s from t;
+-------+-------+-------+----------------------+
| Level | Type  | Field |     Description      |
+-------+-------+-------+----------------------+
|     0 | union |       | -> union -           |
|     1 | scan  |       |    -> scan t@primary |
|     1 | scan  |       |    -> scan t@primary |
+-------+-------+-------+----------------------+
(3 rows)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12506)
<!-- Reviewable:end -->
