### PR TITLE
storage: fix merge skew in data.pb.cc

### DIFF
--- a/pkg/storage/engine/rocksdb/cockroach/pkg/roachpb/data.pb.cc
+++ b/pkg/storage/engine/rocksdb/cockroach/pkg/roachpb/data.pb.cc
@@ -60,7 +60,6 @@ void protobuf_InitDefaults_cockroach_2fpkg_2froachpb_2fdata_2eproto_impl() {
   ::google::protobuf::internal::GetEmptyString();
   Transaction_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  ::google::protobuf::internal::GetEmptyString();
   Intent_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
   Lease_default_instance_.DefaultConstruct();


### PR DESCRIPTION
Somehow an extra line was added here - it gets removed when the protos are regenerated. Committing the result of regenning the protos.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12511)
<!-- Reviewable:end -->
