### PR TITLE
sql: add SUM_INT aggregate function

### DIFF
--- a/pkg/sql/parser/aggregate_builtins_test.go
+++ b/pkg/sql/parser/aggregate_builtins_test.go
@@ -104,6 +104,10 @@ func TestMinBoolResultDeepCopy(t *testing.T) {
 	testAggregateResultDeepCopy(t, newMinAggregate, makeBoolTestDatum(10))
 }
 
+func TestSumSmallIntResultDeepCopy(t *testing.T) {
+	testAggregateResultDeepCopy(t, newSmallIntSumAggregate, makeIntTestDatum(10))
+}
+
 func TestSumIntResultDeepCopy(t *testing.T) {
 	testAggregateResultDeepCopy(t, newIntSumAggregate, makeIntTestDatum(10))
 }
@@ -232,6 +236,10 @@ func BenchmarkAvgAggregateDecimal1K(b *testing.B) {
 
 func BenchmarkCountAggregate1K(b *testing.B) {
 	runBenchmarkAggregate(b, newCountAggregate, makeIntTestDatum(1000))
+}
+
+func BenchmarkSumIntAggregateInt1K(b *testing.B) {
+	runBenchmarkAggregate(b, newSmallIntSumAggregate, makeSmallIntTestDatum(1000))
 }
 
 func BenchmarkSumAggregateInt1K(b *testing.B) {

--- a/pkg/sql/testdata/aggregate
+++ b/pkg/sql/testdata/aggregate
@@ -7,10 +7,10 @@ CREATE TABLE kv (
 )
 
 # Aggregate functions return NULL if there are no rows.
-query IIIRRRRBB
-SELECT MIN(1), MAX(1), COUNT(1), AVG(1), SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_AND(false) FROM kv
+query IIIIRRRRBB
+SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_AND(false) FROM kv
 ----
-NULL NULL 0 NULL NULL NULL NULL NULL NULL
+NULL NULL 0 NULL NULL NULL NULL NULL NULL NULL
 
 # Aggregate functions return NULL if there are no rows.
 query T
@@ -18,10 +18,10 @@ SELECT ARRAY_AGG(1) FROM kv
 ----
 NULL
 
-query IIIRRRRBB
-SELECT MIN(v), MAX(v), COUNT(v), AVG(v), SUM(v), STDDEV(v), VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1) FROM kv
+query IIIIRRRRBB
+SELECT MIN(v), MAX(v), COUNT(v), SUM_INT(1), AVG(v), SUM(v), STDDEV(v), VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1) FROM kv
 ----
-NULL NULL 0 NULL NULL NULL NULL NULL NULL
+NULL NULL 0 NULL NULL NULL NULL NULL NULL NULL
 
 query T
 SELECT ARRAY_AGG(v) FROM kv
@@ -29,10 +29,10 @@ SELECT ARRAY_AGG(v) FROM kv
 NULL
 
 # Aggregate functions triggers aggregation and computation when there is no source.
-query IIIRRRRBB
-SELECT MIN(1), COUNT(1), MAX(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(true)
+query IIIIRRRRBB
+SELECT MIN(1), COUNT(1), MAX(1), SUM_INT(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(true)
 ----
-1 1 1 1 1 NULL NULL true true
+1 1 1 1 1 1 NULL NULL true true
 
 # Aggregate functions triggers aggregation and computation when there is no source.
 query T
@@ -50,10 +50,10 @@ INSERT INTO kv VALUES
 (8, 4, 2, 'A')
 
 # Aggregate functions triggers aggregation and computation for every row even when applied to a constant.
-query IIIRRRRBB
-SELECT MIN(1), COUNT(1), MAX(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1)::float, BOOL_AND(true), BOOL_OR(true) FROM kv
+query IIIIRRRRBB
+SELECT MIN(1), COUNT(1), MAX(1), SUM_INT(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1)::float, BOOL_AND(true), BOOL_OR(true) FROM kv
 ----
-1 6 1 1 6 0 0 true true
+1 6 1 6 1 6 0 0 true true
 
 # Aggregate functions triggers aggregation and computation for every row even when applied to a constant.
 query T


### PR DESCRIPTION
Adding a variant of `SUM` that outputs an integer (instead of decimal). This
will make distributing COUNT easier (the final stage will be `SUM_INT`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12512)
<!-- Reviewable:end -->
