### PR TITLE
migrations: Migration that adds zone configs for system ranges

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -591,6 +591,9 @@ func Example_zone() {
 	// Output:
 	// zone ls
 	// .default
+	// .meta
+	// .identifier
+	// .system
 	// zone set system --file=./testdata/zone_attrs.yaml
 	// range_min_bytes: 1048576
 	// range_max_bytes: 67108864
@@ -600,6 +603,9 @@ func Example_zone() {
 	// constraints: [us-east-1a, ssd]
 	// zone ls
 	// .default
+	// .meta
+	// .identifier
+	// .system
 	// system
 	// zone get system.nonexistent
 	// system.nonexistent not found
@@ -630,6 +636,9 @@ func Example_zone() {
 	// DELETE 1
 	// zone ls
 	// .default
+	// .meta
+	// .identifier
+	// .system
 	// zone rm .default
 	// unable to remove .default
 	// zone set .default --file=./testdata/zone_range_max_bytes.yaml

--- a/pkg/cli/zone.go
+++ b/pkg/cli/zone.go
@@ -166,6 +166,17 @@ func queryNamespace(conn *sqlConn, parentID sqlbase.ID, name string) (sqlbase.ID
 
 func queryDescriptorIDPath(conn *sqlConn, names []string) ([]sqlbase.ID, error) {
 	path := []sqlbase.ID{keys.RootNamespaceID}
+	str := strings.Join(names, ".")
+	switch str {
+	case ".default":
+		return path, nil
+	case ".meta":
+		return []sqlbase.ID{keys.MetaSystemID}, nil
+	case ".identifier":
+		return []sqlbase.ID{keys.IdentifierSystemID}, nil
+	case ".system":
+		return []sqlbase.ID{keys.NormalSystemID}, nil
+	}
 	for _, name := range names {
 		id, err := queryNamespace(conn, path[len(path)-1], name)
 		if err != nil {
@@ -177,9 +188,11 @@ func queryDescriptorIDPath(conn *sqlConn, names []string) ([]sqlbase.ID, error) 
 }
 
 func parseZoneName(s string) ([]string, error) {
-	if strings.ToLower(s) == ".default" {
-		return nil, nil
+	switch t := strings.ToLower(s); s {
+	case ".default", ".meta", ".identifier", ".system":
+		return []string{t}, nil
 	}
+
 	// TODO(knz): we are passing a name that might not be escaped correctly.
 	// See #8389.
 	tn, err := parser.ParseTableNameTraditional(s)
@@ -244,9 +257,16 @@ func runGetZone(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if id == 0 {
+	switch id {
+	case keys.RootNamespaceID:
 		fmt.Println(".default")
-	} else {
+	case keys.MetaSystemID:
+		fmt.Println(".meta")
+	case keys.IdentifierSystemID:
+		fmt.Println(".identifier")
+	case keys.NormalSystemID:
+		fmt.Println(".system")
+	default:
 		for i := range path {
 			if path[i] == id {
 				fmt.Println(strings.Join(names[:i], "."))
@@ -328,8 +348,16 @@ func runLsZones(cmd *cobra.Command, args []string) error {
 
 	sort.Strings(output)
 	// Ensure the default zone is always printed first.
-	if _, ok := zones[0]; ok {
-		fmt.Println(".default")
+	zoneNames := map[sqlbase.ID]string{
+		keys.RootNamespaceID:    ".default",
+		keys.MetaSystemID:       ".meta",
+		keys.IdentifierSystemID: ".identifier",
+		keys.NormalSystemID:     ".system",
+	}
+	for id, name := range zoneNames {
+		if _, ok := zones[id]; ok {
+			fmt.Printf("%s\n", name)
+		}
 	}
 	for _, o := range output {
 		fmt.Println(o)
@@ -377,7 +405,8 @@ func runRmZone(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	id := path[len(path)-1]
-	if id == keys.RootNamespaceID {
+	switch id {
+	case keys.RootNamespaceID, keys.MetaSystemID, keys.IdentifierSystemID, keys.NormalSystemID:
 		return fmt.Errorf("unable to remove %s", args[0])
 	}
 

--- a/pkg/cli/zone.go
+++ b/pkg/cli/zone.go
@@ -348,15 +348,18 @@ func runLsZones(cmd *cobra.Command, args []string) error {
 
 	sort.Strings(output)
 	// Ensure the default zone is always printed first.
-	zoneNames := map[sqlbase.ID]string{
-		keys.RootNamespaceID:    ".default",
-		keys.MetaSystemID:       ".meta",
-		keys.IdentifierSystemID: ".identifier",
-		keys.NormalSystemID:     ".system",
+	zoneNames := []struct {
+		id   sqlbase.ID
+		name string
+	}{
+		{keys.RootNamespaceID, ".default"},
+		{keys.MetaSystemID, ".meta"},
+		{keys.IdentifierSystemID, ".identifier"},
+		{keys.NormalSystemID, ".system"},
 	}
-	for id, name := range zoneNames {
-		if _, ok := zones[id]; ok {
-			fmt.Printf("%s\n", name)
+	for _, idName := range zoneNames {
+		if _, ok := zones[idName.id]; ok {
+			fmt.Printf("%s\n", idName.name)
 		}
 	}
 	for _, o := range output {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,6 +54,39 @@ var (
 		},
 	}
 
+	// metaZoneConfig is meta1/meta2 zone configuration used when no custom
+	// config has been specified.
+	metaZoneConfig = ZoneConfig{
+		NumReplicas:   3,
+		RangeMinBytes: 1 << 20,  // 1 MB
+		RangeMaxBytes: 64 << 20, // 64 MB
+		GC: GCPolicy{
+			TTLSeconds: 24 * 60 * 60, // 1 day
+		},
+	}
+
+	// identifierZoneConfig is the default zone configuration for system key which has
+	// prefix 'NodeLivenessPrefix', 'DescIDGenerator', 'NodeIDGenerator', '',
+	// 'RangeIDGenerator', 'StoreIDGenerator' etc.
+	identifierZoneConfig = ZoneConfig{
+		NumReplicas:   5,
+		RangeMinBytes: 1 << 20,  // 1 MB
+		RangeMaxBytes: 64 << 20, // 64 MB
+		GC: GCPolicy{
+			TTLSeconds: 24 * 60 * 60, // 1 day
+		},
+	}
+
+	// systemZoneConfig is the default zone configuration for other system keys.
+	systemZoneConfig = ZoneConfig{
+		NumReplicas:   3,
+		RangeMinBytes: 1 << 20,  // 1 MB
+		RangeMaxBytes: 64 << 20, // 64 MB
+		GC: GCPolicy{
+			TTLSeconds: 24 * 60 * 60, // 1 day
+		},
+	}
+
 	// ZoneConfigHook is a function used to lookup a zone config given a table
 	// or database ID.
 	// This is also used by testing to simplify fake configs.
@@ -137,6 +170,27 @@ func DefaultZoneConfig() ZoneConfig {
 	testingLock.Lock()
 	defer testingLock.Unlock()
 	return defaultZoneConfig
+}
+
+// MetaZoneConfig is the default meta1/meta2 zone configuration.
+func MetaZoneConfig() ZoneConfig {
+	testingLock.Lock()
+	defer testingLock.Unlock()
+	return metaZoneConfig
+}
+
+// IdetifierZoneConfig is a plumb function for idetifierZoneConfig.
+func IdetifierZoneConfig() ZoneConfig {
+	testingLock.Lock()
+	defer testingLock.Unlock()
+	return identifierZoneConfig
+}
+
+// SystemZoneConfig is a plumb function for systemZoneConfig.
+func SystemZoneConfig() ZoneConfig {
+	testingLock.Lock()
+	defer testingLock.Unlock()
+	return systemZoneConfig
 }
 
 // TestingSetDefaultZoneConfig is a testing-only function that changes the
@@ -343,6 +397,15 @@ func (s SystemConfig) GetZoneConfigForKey(key roachpb.RKey) (ZoneConfig, error) 
 	} else if objectID <= keys.MaxReservedDescID {
 		// For now, only user databases and tables get custom zone configs.
 		objectID = keys.RootNamespaceID
+	}
+	if bytes.HasPrefix(key, keys.Meta1Prefix) || bytes.HasPrefix(key, keys.Meta2Prefix) {
+		objectID = keys.MetaSystemID
+	}
+	if bytes.HasPrefix(key, keys.SystemPrefix) {
+		if bytes.HasPrefix(key, keys.TimeseriesPrefix) || bytes.HasPrefix(key, keys.StatusPrefix) || bytes.HasPrefix(key, keys.UpdateCheckPrefix) {
+			objectID = keys.NormalSystemID
+		}
+		objectID = keys.IdentifierSystemID
 	}
 	return s.getZoneConfigForID(objectID)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -179,8 +179,8 @@ func MetaZoneConfig() ZoneConfig {
 	return metaZoneConfig
 }
 
-// IdetifierZoneConfig is a plumb function for idetifierZoneConfig.
-func IdetifierZoneConfig() ZoneConfig {
+// IdentifierZoneConfig is a plumb function for idetifierZoneConfig.
+func IdentifierZoneConfig() ZoneConfig {
 	testingLock.Lock()
 	defer testingLock.Unlock()
 	return identifierZoneConfig

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -279,6 +279,10 @@ const (
 	UsersTableID      = 4
 	ZonesTableID      = 5
 
+	MetaSystemID       = 15
+	IdentifierSystemID = 16
+	NormalSystemID     = 17
+
 	// Reserved IDs for other system tables. If you're adding a new system table,
 	// it probably belongs here.
 	// NOTE: IDs must be <= MaxReservedDescID.

--- a/pkg/migrations/main_test.go
+++ b/pkg/migrations/main_test.go
@@ -1,0 +1,33 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package migrations_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+)
+
+func TestMain(m *testing.M) {
+	security.SetReadFileFn(securitytest.Asset)
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	os.Exit(m.Run())
+}
+
+//go:generate ../util/leaktest/add-leaktest.sh *_test.go

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -46,6 +47,10 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 	{
 		name:   "default UniqueID to uuid_v4 in system.eventlog",
 		workFn: eventlogUniqueIDDefault,
+	},
+	{
+		name:   "add zone configs for system ranges",
+		workFn: systemZoneConfigs,
 	},
 }
 
@@ -79,6 +84,7 @@ type leaseManager interface {
 type db interface {
 	Scan(ctx context.Context, begin, end interface{}, maxRows int64) ([]client.KeyValue, error)
 	Put(ctx context.Context, key, value interface{}) error
+	Txn(ctx context.Context, retryable func(txn *client.Txn) error) error
 }
 
 // Manager encapsulates the necessary functionality for handling migrations
@@ -265,4 +271,28 @@ func eventlogUniqueIDDefault(ctx context.Context, r runner) error {
 		log.Warningf(ctx, "failed attempt to update system.eventlog schema: %s", err)
 	}
 	return err
+}
+
+func systemZoneConfigs(ctx context.Context, r runner) error {
+	var kvs []roachpb.KeyValue
+	kvs = append(kvs, sqlbase.CreateMetaZoneConfig()...)
+	kvs = append(kvs, sqlbase.CreateIdentifierZoneConfig()...)
+	kvs = append(kvs, sqlbase.CreateSystemZoneConfig()...)
+
+	for _, kv := range kvs {
+		if err := r.db.Txn(ctx, func(txn *client.Txn) error {
+			if res, err := txn.Get(kv.Key); err != nil {
+				return errors.Wrapf(err, "failed to get key %q", kv.Key)
+			} else if res.Exists() {
+				return nil
+			}
+			if err := txn.Put(kv.Key, &kv.Value); err != nil {
+				return errors.Wrapf(err, "failed to put key %q", kv.Key)
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/migrations/migrations_test.go
+++ b/pkg/migrations/migrations_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/pkg/errors"
@@ -209,6 +210,7 @@ func TestEnsureMigrations(t *testing.T) {
 }
 
 func TestDBErrors(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	db := &fakeDB{}
 	mgr := Manager{
 		stopper:      stop.NewStopper(),
@@ -268,6 +270,7 @@ func TestDBErrors(t *testing.T) {
 // we don't test that here due to the added code that would be needed to change
 // its retry settings to allow for testing it in a reasonable amount of time.
 func TestLeaseErrors(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	db := &fakeDB{kvs: make(map[string][]byte)}
 	mgr := Manager{
 		stopper: stop.NewStopper(),
@@ -296,6 +299,7 @@ func TestLeaseErrors(t *testing.T) {
 // The lease not having enough time left on it to finish migrations should
 // cause the process to exit via a call to log.Fatal.
 func TestLeaseExpiration(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	db := &fakeDB{kvs: make(map[string][]byte)}
 	mgr := Manager{
 		stopper:      stop.NewStopper(),

--- a/pkg/migrations/migrations_test.go
+++ b/pkg/migrations/migrations_test.go
@@ -23,13 +23,18 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 )
 
@@ -116,7 +121,12 @@ func (f *fakeDB) Put(ctx context.Context, key, value interface{}) error {
 	return nil
 }
 
+func (*fakeDB) Txn(context.Context, func(*client.Txn) error) error {
+	return nil
+}
+
 func TestEnsureMigrations(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	db := &fakeDB{}
 	mgr := Manager{
 		stopper:      stop.NewStopper(),
@@ -330,5 +340,85 @@ func TestLeaseExpiration(t *testing.T) {
 	backwardCompatibleMigrations = []migrationDescriptor{waitForExitMigration}
 	if err := mgr.EnsureMigrations(context.Background()); err != nil {
 		t.Error(err)
+	}
+}
+
+func TestSystemZoneConfigs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	testCases := []struct {
+		preexistingKeys []sqlbase.ID
+		preexistingVals []config.ZoneConfig
+	}{
+		{},
+		{
+			[]sqlbase.ID{keys.MetaSystemID},
+			[]config.ZoneConfig{config.MetaZoneConfig()},
+		},
+		{
+			[]sqlbase.ID{keys.IdentifierSystemID},
+			[]config.ZoneConfig{config.IdentifierZoneConfig()},
+		},
+		{
+			[]sqlbase.ID{keys.NormalSystemID},
+			[]config.ZoneConfig{config.SystemZoneConfig()},
+		},
+		{
+			[]sqlbase.ID{keys.MetaSystemID, keys.NormalSystemID},
+			[]config.ZoneConfig{config.MetaZoneConfig(), config.SystemZoneConfig()},
+		},
+		{
+			[]sqlbase.ID{keys.MetaSystemID, keys.IdentifierSystemID, keys.NormalSystemID},
+			[]config.ZoneConfig{config.MetaZoneConfig(), config.IdentifierZoneConfig(), config.SystemZoneConfig()},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			// Start up a test server without running any migrations.
+			backwardCompatibleMigrations = nil
+			s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+			defer s.Stopper().Stop()
+
+			// Put the test case's initial keys into the DB
+			for i := range tc.preexistingKeys {
+				key := sqlbase.MakeZoneKey(tc.preexistingKeys[i])
+				var val roachpb.Value
+				if err := val.SetProto(&tc.preexistingVals[i]); err != nil {
+					t.Fatal(err)
+				}
+				if err := kvDB.Put(ctx, key, &val); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// Then try running just the migration.
+			mgr := NewManager(s.Stopper(), kvDB, nil, s.Clock(), "clientID")
+			backwardCompatibleMigrations = []migrationDescriptor{
+				{name: "add zone configs for system ranges", workFn: systemZoneConfigs},
+			}
+			if err := mgr.EnsureMigrations(ctx); err != nil {
+				t.Fatal(err)
+			}
+
+			expectedKVs := []struct {
+				id  sqlbase.ID
+				val config.ZoneConfig
+			}{
+				{keys.MetaSystemID, config.MetaZoneConfig()},
+				{keys.IdentifierSystemID, config.IdentifierZoneConfig()},
+				{keys.NormalSystemID, config.SystemZoneConfig()},
+			}
+			for _, expected := range expectedKVs {
+				key := sqlbase.MakeZoneKey(expected.id)
+				var zoneCfg config.ZoneConfig
+				if err := kvDB.GetProto(ctx, key, &zoneCfg); err != nil {
+					t.Errorf("key %q (id %d) not persisted: %s", key, expected.id, err)
+				} else if !proto.Equal(&expected.val, &zoneCfg) {
+					t.Errorf("expected %v for id %d, got %v", expected.val, expected.id, zoneCfg)
+				}
+			}
+		})
 	}
 }

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -419,7 +419,9 @@ func createDefaultZoneConfig() []roachpb.KeyValue {
 	return ret
 }
 
-func createMetaZoneConfig() []roachpb.KeyValue {
+// CreateMetaZoneConfig creates the key/value pairs for the default meta zone
+// config entry.
+func CreateMetaZoneConfig() []roachpb.KeyValue {
 	var ret []roachpb.KeyValue
 	value := roachpb.Value{}
 	desc := config.MetaZoneConfig()
@@ -433,7 +435,9 @@ func createMetaZoneConfig() []roachpb.KeyValue {
 	return ret
 }
 
-func createIdentifierZoneConfig() []roachpb.KeyValue {
+// CreateIdentifierZoneConfig creates the key/value pairs for the default
+// identifier zone config entry.
+func CreateIdentifierZoneConfig() []roachpb.KeyValue {
 	var ret []roachpb.KeyValue
 	value := roachpb.Value{}
 	desc := config.IdentifierZoneConfig()
@@ -447,7 +451,9 @@ func createIdentifierZoneConfig() []roachpb.KeyValue {
 	return ret
 }
 
-func createSystemZoneConfig() []roachpb.KeyValue {
+// CreateSystemZoneConfig creates the key/value pairs for the default system
+// zone config entry.
+func CreateSystemZoneConfig() []roachpb.KeyValue {
 	var ret []roachpb.KeyValue
 	value := roachpb.Value{}
 	desc := config.SystemZoneConfig()
@@ -482,9 +488,9 @@ func addSystemDatabaseToSchema(target *MetadataSchema) {
 	target.AddDescriptor(keys.SystemDatabaseID, &UITable)
 
 	target.otherKV = append(target.otherKV, createDefaultZoneConfig()...)
-	target.otherKV = append(target.otherKV, createMetaZoneConfig()...)
-	target.otherKV = append(target.otherKV, createIdentifierZoneConfig()...)
-	target.otherKV = append(target.otherKV, createSystemZoneConfig()...)
+	target.otherKV = append(target.otherKV, CreateMetaZoneConfig()...)
+	target.otherKV = append(target.otherKV, CreateIdentifierZoneConfig()...)
+	target.otherKV = append(target.otherKV, CreateSystemZoneConfig()...)
 }
 
 // IsSystemConfigID returns true if this ID is for a system config object.

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -419,6 +419,48 @@ func createDefaultZoneConfig() []roachpb.KeyValue {
 	return ret
 }
 
+func createMetaZoneConfig() []roachpb.KeyValue {
+	var ret []roachpb.KeyValue
+	value := roachpb.Value{}
+	desc := config.MetaZoneConfig()
+	if err := value.SetProto(&desc); err != nil {
+		log.Fatalf(context.TODO(), "could not marshal %v", desc)
+	}
+	ret = append(ret, roachpb.KeyValue{
+		Key:   MakeZoneKey(keys.MetaSystemID),
+		Value: value,
+	})
+	return ret
+}
+
+func createIdentifierZoneConfig() []roachpb.KeyValue {
+	var ret []roachpb.KeyValue
+	value := roachpb.Value{}
+	desc := config.IdetifierZoneConfig()
+	if err := value.SetProto(&desc); err != nil {
+		log.Fatalf(context.TODO(), "could not marshal %v", desc)
+	}
+	ret = append(ret, roachpb.KeyValue{
+		Key:   MakeZoneKey(keys.IdentifierSystemID),
+		Value: value,
+	})
+	return ret
+}
+
+func createSystemZoneConfig() []roachpb.KeyValue {
+	var ret []roachpb.KeyValue
+	value := roachpb.Value{}
+	desc := config.SystemZoneConfig()
+	if err := value.SetProto(&desc); err != nil {
+		log.Fatalf(context.TODO(), "could not marshal %v", desc)
+	}
+	ret = append(ret, roachpb.KeyValue{
+		Key:   MakeZoneKey(keys.NormalSystemID),
+		Value: value,
+	})
+	return ret
+}
+
 // addSystemDatabaseToSchema populates the supplied MetadataSchema with the
 // System database and its tables. The descriptors for these objects exist
 // statically in this file, but a MetadataSchema can be used to persist these
@@ -440,6 +482,9 @@ func addSystemDatabaseToSchema(target *MetadataSchema) {
 	target.AddDescriptor(keys.SystemDatabaseID, &UITable)
 
 	target.otherKV = append(target.otherKV, createDefaultZoneConfig()...)
+	target.otherKV = append(target.otherKV, createMetaZoneConfig()...)
+	target.otherKV = append(target.otherKV, createIdentifierZoneConfig()...)
+	target.otherKV = append(target.otherKV, createSystemZoneConfig()...)
 }
 
 // IsSystemConfigID returns true if this ID is for a system config object.

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -436,7 +436,7 @@ func createMetaZoneConfig() []roachpb.KeyValue {
 func createIdentifierZoneConfig() []roachpb.KeyValue {
 	var ret []roachpb.KeyValue
 	value := roachpb.Value{}
-	desc := config.IdetifierZoneConfig()
+	desc := config.IdentifierZoneConfig()
 	if err := value.SetProto(&desc); err != nil {
 		log.Fatalf(context.TODO(), "could not marshal %v", desc)
 	}

--- a/pkg/sql/system_table_test.go
+++ b/pkg/sql/system_table_test.go
@@ -34,7 +34,7 @@ func TestInitialKeys(t *testing.T) {
 
 	const nonSystemDesc = 4
 	const keysPerDesc = 2
-	const nonDescKeys = 2
+	const nonDescKeys = 5
 
 	ms := sqlbase.MakeMetadataSchema()
 	kv := ms.GetInitialValues()


### PR DESCRIPTION
Adds a migration for @a6802739's original PR, #12335, and fixes a couple small issues with it. We may actually want to remove the part of the original commit that adds the new zone configs during cluster bootstrap, since as @bdarnell has repeatedly noted we'd prefer all clusters, both old and new, to have their configurations added in the same way.

@a6802739 @petermattis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12513)
<!-- Reviewable:end -->
