### PR TITLE
sql/sqlbase: skip validation of FKs during drop

### DIFF
--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -678,6 +678,9 @@ func (desc *TableDescriptor) Validate(txn *client.Txn) error {
 	if err != nil {
 		return err
 	}
+	if desc.Dropped() {
+		return nil
+	}
 	return desc.validateCrossReferences(txn)
 }
 


### PR DESCRIPTION
ValidateCrossTableReferences checks that the tables on both sides of
reference note that reference. However, the txn that moves a table to 
the DROP state also removes the references to it, at which point that 
validation no longer holds and should be skipped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12514)
<!-- Reviewable:end -->
