### PR TITLE
util/log: overwrite log tags with tags from an AmbientContext

### DIFF
--- a/pkg/util/log/ambient_context.go
+++ b/pkg/util/log/ambient_context.go
@@ -105,7 +105,9 @@ func (ac *AmbientContext) FinishEventLog() {
 // AnnotateCtx annotates a given context with the information in AmbientContext:
 //  - the EventLog is embedded in the context if the context doesn't already
 //    have en event log or an open trace.
-//  - the log tags in AmbientContext are added (if ctx doesn't already have them).
+//  - the log tags in AmbientContext are added (if ctx doesn't already have
+//  them). If the tags already exist, the values from the AmbientContext
+//  overwrite the existing values, but the order of the tags might change.
 //
 // For background operations, context.Background() should be passed; however, in
 // that case it is strongly recommended to open a span if possible (using
@@ -117,7 +119,7 @@ func (ac *AmbientContext) AnnotateCtx(ctx context.Context) context.Context {
 		ctx = embedCtxEventLog(ctx, ac.eventLog)
 	}
 	if ac.tags != nil {
-		ctx = copyTagChain(ctx, ac.tags)
+		ctx = augmentTagChain(ctx, ac.tags)
 	}
 	return ctx
 }
@@ -133,7 +135,7 @@ func (ac *AmbientContext) AnnotateCtxWithSpan(
 	ctx context.Context, opName string,
 ) (context.Context, opentracing.Span) {
 	if ac.tags != nil {
-		ctx = copyTagChain(ctx, ac.tags)
+		ctx = augmentTagChain(ctx, ac.tags)
 	}
 
 	var span opentracing.Span

--- a/pkg/util/log/ambient_context_test.go
+++ b/pkg/util/log/ambient_context_test.go
@@ -38,7 +38,7 @@ func TestAnnotateCtxTags(t *testing.T) {
 	ctx = WithLogTag(ctx, "aa", nil)
 	ctx = ac.AnnotateCtx(ctx)
 
-	if exp, val := "[a10,aa,b2] test", makeMessage(ctx, "test", nil); val != exp {
+	if exp, val := "[aa,a1,b2] test", makeMessage(ctx, "test", nil); val != exp {
 		t.Errorf("expected '%s', got '%s'", exp, val)
 	}
 }

--- a/pkg/util/log/log_context_test.go
+++ b/pkg/util/log/log_context_test.go
@@ -19,6 +19,9 @@ package log
 import (
 	"testing"
 
+	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/pkg/errors"
+
 	"golang.org/x/net/context"
 )
 
@@ -68,6 +71,19 @@ func TestLogContext(t *testing.T) {
 	}
 }
 
+// withLogTagsFromCtx returns a context based on ctx with fromCtx's log tags
+// added on.
+//
+// The result is equivalent to replicating the WithLogTag* calls that were
+// used to obtain fromCtx and applying them to ctx in the same order - but
+// skipping those for which ctx already has a tag with the same name.
+func withLogTagsFromCtx(ctx, fromCtx context.Context) context.Context {
+	if bottomTag := contextBottomTag(fromCtx); bottomTag != nil {
+		return augmentTagChain(ctx, bottomTag)
+	}
+	return ctx
+}
+
 func TestWithLogTagsFromCtx(t *testing.T) {
 	ctx1 := context.Background()
 	ctx1A := WithLogTagInt(ctx1, "1A", 1)
@@ -82,54 +98,112 @@ func TestWithLogTagsFromCtx(t *testing.T) {
 		expected string
 	}{
 		{
-			ctx:      WithLogTagsFromCtx(ctx1, ctx2),
+			ctx:      withLogTagsFromCtx(ctx1, ctx2),
 			expected: "test",
 		},
 
 		{
-			ctx:      WithLogTagsFromCtx(ctx1, ctx2A),
+			ctx:      withLogTagsFromCtx(ctx1, ctx2A),
 			expected: "[2A=1] test",
 		},
 
 		{
-			ctx:      WithLogTagsFromCtx(ctx1, ctx2B),
+			ctx:      withLogTagsFromCtx(ctx1, ctx2B),
 			expected: "[2A=1,2B] test",
 		},
 
 		{
-			ctx:      WithLogTagsFromCtx(ctx1A, ctx2),
+			ctx:      withLogTagsFromCtx(ctx1A, ctx2),
 			expected: "[1A=1] test",
 		},
 
 		{
-			ctx:      WithLogTagsFromCtx(ctx1A, ctx2A),
+			ctx:      withLogTagsFromCtx(ctx1A, ctx2A),
 			expected: "[1A=1,2A=1] test",
 		},
 
 		{
-			ctx:      WithLogTagsFromCtx(ctx1A, ctx2B),
+			ctx:      withLogTagsFromCtx(ctx1A, ctx2B),
 			expected: "[1A=1,2A=1,2B] test",
 		},
 
 		{
-			ctx:      WithLogTagsFromCtx(ctx1B, ctx2),
+			ctx:      withLogTagsFromCtx(ctx1B, ctx2),
 			expected: "[1A=1,1B] test",
 		},
 
 		{
-			ctx:      WithLogTagsFromCtx(ctx1B, ctx2A),
+			ctx:      withLogTagsFromCtx(ctx1B, ctx2A),
 			expected: "[1A=1,1B,2A=1] test",
 		},
 
 		{
-			ctx:      WithLogTagsFromCtx(ctx1B, ctx2B),
+			ctx:      withLogTagsFromCtx(ctx1B, ctx2B),
 			expected: "[1A=1,1B,2A=1,2B] test",
 		},
 	}
 
-	for i, tc := range testCases {
-		if value := makeMessage(tc.ctx, "test", nil); value != tc.expected {
-			t.Errorf("test case %d failed: expected '%s', got '%s'", i, tc.expected, value)
+	for _, tc := range testCases {
+		t.Run(tc.expected, func(t *testing.T) {
+			if value := makeMessage(tc.ctx, "test", nil); value != tc.expected {
+				t.Errorf("expected '%s', got '%s'", tc.expected, value)
+			}
+		})
+	}
+}
+
+type chain struct {
+	head, tail *logTag
+}
+
+func (c *chain) appendToChain(t logTag) *chain {
+	if t.parent != nil {
+		panic("can't append a chain")
+	}
+	if c.head == nil {
+		c.head = &t
+	} else {
+		c.tail.parent = &t
+	}
+	c.tail = &t
+	return c
+}
+
+func makeTag(key string, val int) logTag {
+	return logTag{Field: otlog.Int(key, val)}
+}
+
+func checkChain(expected *logTag, actual *logTag) error {
+	e, a := expected, actual
+	for {
+		if e == nil && a == nil {
+			return nil
 		}
+		if e == nil && a != nil {
+			return errors.Errorf("expected done, actual has extra nodes starting with %s", a)
+		}
+		if e != nil && a == nil {
+			return errors.Errorf("actual done, expected has extra nodes starting with %s", e)
+		}
+		if e.Key() != a.Key() || e.Value() != a.Value() {
+			return errors.Errorf("%s != %s", e, a)
+		}
+		e = e.parent
+		a = a.parent
+	}
+}
+
+func TestMergeChains(t *testing.T) {
+	var c1, c2 chain
+	c1.appendToChain(makeTag("A", 1)).appendToChain(makeTag("B", 1)).appendToChain(
+		makeTag("C", 1)).appendToChain(makeTag("D", 1))
+	c2.appendToChain(makeTag("A", 2)).appendToChain(makeTag("B", 2)).appendToChain(
+		makeTag("D", 2)).appendToChain(makeTag("E", 2))
+	r := mergeChains(c1.head, c2.head)
+	var expected chain
+	if err := checkChain(r,
+		expected.appendToChain(makeTag("A", 2)).appendToChain(makeTag("B", 2)).appendToChain(
+			makeTag("D", 2)).appendToChain(makeTag("E", 2)).appendToChain(makeTag("C", 1)).head); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Today, annotating a context doesn't overwrite existing tags. We have
tests in which a replica uses its context to call into another replica,
and it's very confusing that those log messages appear to be in the
context of the caller replica.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12515)
<!-- Reviewable:end -->
