### PR TITLE
storage: add a callback to StorePool for store status updates

### DIFF
--- a/pkg/gossip/keys.go
+++ b/pkg/gossip/keys.go
@@ -91,12 +91,6 @@ func MakePrefixPattern(prefix string) string {
 	return regexp.QuoteMeta(prefix+separator) + ".*"
 }
 
-// MakeOrPattern returns a regular expression pattern that matches
-// any of the provided components.
-func MakeOrPattern(components ...string) string {
-	return strings.Join(components, "|")
-}
-
 // MakeNodeIDKey returns the gossip key for node ID info.
 func MakeNodeIDKey(nodeID roachpb.NodeID) string {
 	return MakeKey(KeyNodeIDPrefix, nodeID.String())

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -80,6 +80,10 @@ type LivenessMetrics struct {
 	EpochIncrements    *metric.Counter
 }
 
+// IsLiveCallback is invoked when a node's IsLive state changes to true.
+// Callbacks can be registered via NodeLiveness.RegisterCallback().
+type IsLiveCallback func(nodeID roachpb.NodeID)
+
 // NodeLiveness encapsulates information on node liveness and provides
 // an API for querying, updating, and invalidating node
 // liveness. Nodes periodically "heartbeat" the range holding the node
@@ -101,8 +105,9 @@ type NodeLiveness struct {
 
 	mu struct {
 		syncutil.Mutex
-		self  Liveness
-		nodes map[roachpb.NodeID]Liveness
+		self      Liveness
+		callbacks []IsLiveCallback
+		nodes     map[roachpb.NodeID]Liveness
 	}
 }
 
@@ -380,6 +385,14 @@ func (nl *NodeLiveness) Metrics() LivenessMetrics {
 	return nl.metrics
 }
 
+// RegisterCallback registers a callback to be invoked any time a
+// node's IsLive() state changes to true.
+func (nl *NodeLiveness) RegisterCallback(cb IsLiveCallback) {
+	nl.mu.Lock()
+	defer nl.mu.Unlock()
+	nl.mu.callbacks = append(nl.mu.callbacks, cb)
+}
+
 // updateLiveness does a conditional put on the node liveness record
 // for the node specified by nodeID. In the event that the conditional
 // put fails, and the handleCondFailed callback is not nil, it's
@@ -451,11 +464,23 @@ func (nl *NodeLiveness) livenessGossipUpdate(key string, content roachpb.Value) 
 	// If there's an existing liveness record, only update the received
 	// timestamp if this is our first receipt of this node's liveness
 	// or if the expiration or epoch was advanced.
+	var callbacks []IsLiveCallback
 	nl.mu.Lock()
-	defer nl.mu.Unlock()
 	exLiveness, ok := nl.mu.nodes[liveness.NodeID]
 	if !ok || exLiveness.Expiration.Less(liveness.Expiration) || exLiveness.Epoch < liveness.Epoch {
 		nl.mu.nodes[liveness.NodeID] = liveness
+
+		// If isLive status is now true, but previously false, invoke any registered callbacks.
+		now, offset := nl.clock.Now(), nl.clock.MaxOffset()
+		if !exLiveness.isLive(now, offset) && liveness.isLive(now, offset) {
+			callbacks = append(callbacks, nl.mu.callbacks...)
+		}
+	}
+	nl.mu.Unlock()
+
+	// Invoke any "is live" callbacks after releasing lock.
+	for _, cb := range callbacks {
+		cb(liveness.NodeID)
 	}
 }
 

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -115,18 +115,23 @@ func newReplicateQueue(
 		},
 	)
 
+	updateFn := func() {
+		select {
+		case rq.updateChan <- struct{}{}:
+		default:
+		}
+	}
+
+	// Register a gossip and node liveness callbacks to signal queue
+	// that replicas in purgatory might be retried.
 	if g != nil { // gossip is nil for some unittests
-		// Register a gossip callback to signal queue that replicas in
-		// purgatory might be retried due to new store gossip.
-		pattern := gossip.MakeOrPattern(
-			gossip.MakePrefixPattern(gossip.KeyStorePrefix),
-			gossip.MakePrefixPattern(gossip.KeyNodeLivenessPrefix),
-		)
-		g.RegisterCallback(pattern, func(_ string, _ roachpb.Value) {
-			select {
-			case rq.updateChan <- struct{}{}:
-			default:
-			}
+		g.RegisterCallback(gossip.MakePrefixPattern(gossip.KeyStorePrefix), func(_ string, _ roachpb.Value) {
+			updateFn()
+		})
+	}
+	if nl := store.cfg.NodeLiveness; nl != nil { // node liveness is nil for some unittests
+		nl.RegisterCallback(func(_ roachpb.NodeID) {
+			updateFn()
 		})
 	}
 


### PR DESCRIPTION
This prevents busy purgatory checks for the replicate queue on every
node liveness heartbeat. However, we still do the check on the
periodic node status updates, which happen once a minute by default.

Fixes #12298

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12528)
<!-- Reviewable:end -->
