### PR TITLE
sql: fix behavior of ARRAY_AGG and NULL values

### DIFF
--- a/pkg/sql/parser/aggregate_builtins.go
+++ b/pkg/sql/parser/aggregate_builtins.go
@@ -206,8 +206,7 @@ func (a *identAggregate) Result() Datum {
 }
 
 type arrayAggregate struct {
-	arr        *DArray
-	sawNonNull bool
+	arr *DArray
 }
 
 func newIntArrayAggregate() AggregateFunc {
@@ -220,9 +219,6 @@ func newStringArrayAggregate() AggregateFunc {
 
 // Add accumulates the passed datum into the array.
 func (a *arrayAggregate) Add(datum Datum) {
-	if datum != DNull {
-		a.sawNonNull = true
-	}
 	if err := a.arr.Append(datum); err != nil {
 		panic(fmt.Sprintf("error appending to array: %s", err))
 	}
@@ -230,7 +226,7 @@ func (a *arrayAggregate) Add(datum Datum) {
 
 // Result returns an array of all datums passed to Add.
 func (a *arrayAggregate) Result() Datum {
-	if a.sawNonNull {
+	if len(a.arr.Array) > 0 {
 		return a.arr
 	}
 	return DNull

--- a/pkg/sql/testdata/aggregate
+++ b/pkg/sql/testdata/aggregate
@@ -433,6 +433,11 @@ SELECT ARRAY_AGG(k), ARRAY_AGG(s) FROM kv
 ----
 {1,3,5,6,7,8} {a,a,NULL,b,b,A}
 
+query T
+SELECT array_agg(s) FROM kv WHERE s IS NULL
+----
+{NULL}
+
 query RRRR
 SELECT AVG(k), AVG(v), SUM(k), SUM(v) FROM kv
 ----


### PR DESCRIPTION
Previously, `ARRAY_AGG` would erroneously collapse inputs of only `NULL `into a `NULL` output - not an array of `NULL`s. This behavior is incorrect - `ARRAY_AGG` should only return `NULL` if there are no input rows.

Fixes #12524.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12534)
<!-- Reviewable:end -->
