### PR TITLE
build: simplify and fix upload-coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,14 +159,6 @@ bench: TESTS := -
 bench: TESTTIMEOUT := $(BENCHTIMEOUT)
 bench: test
 
-.PHONY: coverage
-coverage: gotestdashi
-ifeq ($(BENCHES),-)
-	$(GO) test $(GOFLAGS) -tags '$(TAGS)' -cover -run "$(TESTS)" $(PKG) $(TESTFLAGS)
-else
-	$(GO) test $(GOFLAGS) -tags '$(TAGS)' -cover -run "$(TESTS)" -bench "$(BENCHES)" $(PKG) $(TESTFLAGS)
-endif
-
 .PHONY: upload-coverage
 upload-coverage:
 	$(GO) install ./vendor/github.com/wadey/gocovmerge

--- a/build/checkdeps.sh
+++ b/build/checkdeps.sh
@@ -14,11 +14,22 @@ echo "checking that 'vendor' matches manifest"
 
 echo "checking that all deps are in 'vendor''"
 
-missing=$(sed -n 's,[[:space:]]*_[[:space:]]*"\(.*\)",\1,p' build/tool_imports.go | awk '{print} END {print "./pkg/..."}' \
-  | xargs go list -f '{{ join .Deps "\n"}}{{"\n"}}{{ join .TestImports "\n"}}{{"\n"}}{{ join .XTestImports "\n"}}' \
-  | grep -v '^github.com/cockroachdb/cockroach' \
-  | sort | uniq \
-  | xargs go list -f '{{if not .Standard}}{{.ImportPath}}{{end}}')
+top_deps=$(go list -f '{{join .Imports "\n"}}{{"\n"}}{{join .TestImports "\n"}}{{"\n"}}{{join .XTestImports "\n"}}' ./pkg/...)
+cmd_deps=$(sed -n 's,[[:space:]]*_[[:space:]]*"\(.*\)",./vendor/\1,p' build/tool_imports.go)
+
+deps="
+$top_deps
+$cmd_deps
+"
+
+# Note that grep's exit status is ignored here to allow for packages with no
+# dependencies.
+missing=$(echo "$deps" | \
+	sort | uniq | grep -v '^C$' | \
+	xargs go list -f '{{if not .Standard}}{{join .Deps "\n" }}{{end}}' | sort | uniq | \
+	sort | uniq | grep -v '^C$' | \
+	xargs go list -f '{{if not .Standard}}{{.ImportPath}}{{end}}' | \
+	grep -v '^github.com/cockroachdb/cockroach' || true)
 
 if [ -n "$missing" ]; then
   echo "vendor is missing some 3rd-party dependencies:"

--- a/build/upload-coverage.sh
+++ b/build/upload-coverage.sh
@@ -1,80 +1,52 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -euxo pipefail
 
-if [ -z "$COVERALLS_TOKEN" ]; then
+if [ -z "${COVERALLS_TOKEN-}" ]; then
   echo "FAIL: Missing or empty COVERALLS_TOKEN."
   exit 1
 fi
-if [ -z "$CODECOV_TOKEN" ]; then
+if [ -z "${CODECOV_TOKEN-}" ]; then
   echo "FAIL: Missing or empty CODECOV_TOKEN."
   exit 1
 fi
 
-if [ -n "${TMPDIR-}" ]; then
-  outdir="${TMPDIR}"
-else
-  outdir="/tmp"
-fi
+prefix=github.com/cockroachdb/cockroach/pkg
 
-prefix="github.com/cockroachdb/cockroach/pkg"
-# This regex removes files from the uploaded coverage.
-ignore_files="$prefix/(acceptance|cmd|ui/embedded|storage/simulation|sql/pgbench|.*\.(pb|pb\.gw)\.go)"
+coverage_dir=coverage
+coverage_profile=$coverage_dir/coverage.out
 
-coverage_dir="${outdir}/coverage"
-coverage_profile="${coverage_dir}/coverage.out"
-coverage_mode=count
+trap "rm -rf $coverage_dir" EXIT
 
-# iterative_coverpkg fetches all test deps and main deps, filters them, and
-# converts them into a comma separated list stored in $coverpkg.
-iterative_coverpkg() {
-  local imports="$1"
-  local old_line_count="-1"
-  local line_count=""
-  while [ "$old_line_count" != "$line_count" ]; do
-    old_line_count=$line_count
-    imports+=$'\n'$(go list  -f '{{join .Imports "\n"}}
-{{join .TestImports "\n"}}
-{{join .XTestImports "\n"}}' $imports | grep $prefix)
-    imports=$(echo "$imports" | sort | uniq)
-    line_count=$(echo $imports | wc -w)
-  done
-  coverpkg=$(echo $imports | sed 's/ /,/g')
-}
+rm -rf $coverage_dir
+mkdir -p $coverage_dir
 
-rm -rf "$coverage_dir"
-mkdir -p "$coverage_dir"
-
-# Run "make coverage" on each package except for those in cmd.
-for pkg in $(go list ./pkg/... | grep -vF 'pkg/cmd'); do
-  echo "Processing $pkg..."
-  # Verify package has test files.
-  if [ -z "$(go list -f '{{join .TestGoFiles ""}}{{join .XTestGoFiles ""}}' $pkg)" ]; then
-    echo "$pkg: Skipping due to no test files."
-    continue
-  fi
-
+# Run coverage on each package, because go test "cannot use test profile flag
+# with multiple packages". See https://github.com/golang/go/issues/6909.
+for pkg in $(go list $prefix/...); do
   # Only generate coverage for cockroach dependencies.
-  iterative_coverpkg $pkg
+  #
+  # Note that grep's exit status is ignored here to allow for packages with no
+  # dependencies.
+  coverpkg=$(go list -f '{{join .Imports "\n"}}{{"\n"}}{{join .TestImports "\n"}}{{"\n"}}{{join .XTestImports "\n"}}' $pkg | \
+    sort | uniq | grep -v '^C$' | \
+    xargs go list -f '{{if not .Standard}}{{join .Deps "\n" }}{{end}}' | sort | uniq | \
+    sort | uniq | grep -v '^C$' | \
+    xargs go list -f '{{if not .Standard}}{{.ImportPath}}{{end}}' | \
+    grep $prefix || true)
 
-  # Find all cockroach packages that are imported by this package or in it's
-  # tests.
-  f="${coverage_dir}/$(echo $pkg | tr / -).cover"
-  touch $f
-  time make coverage \
-    PKG="$pkg" \
-    TESTFLAGS="-v -coverprofile=$f -covermode=$coverage_mode -coverpkg=$coverpkg" | \
-    tee "${outdir}/coverage.log"
+  time make test PKG="$pkg" TESTFLAGS="-coverpkg=${coverpkg//$'\n'/,} -coverprofile=${coverage_dir}/${pkg//\//-}.cover -covermode=count"
 done
 
 # Merge coverage profiles and remove lines that match our ignore filter.
-gocovmerge "$coverage_dir"/*.cover | grep -vE "$ignore_files" > "$coverage_profile"
+gocovmerge $coverage_dir/*.cover | \
+  grep -vE "$prefix/(acceptance|cmd|ui/embedded|sql/pgbench|.*\.pb(\.gw)?\.go)" > $coverage_profile
 
 # Upload profiles to coveralls.io.
 goveralls \
-  -coverprofile="$coverage_profile" \
+  -coverprofile=$coverage_profile \
   -service=teamcity \
-  -repotoken=$COVERALLS_TOKEN
+  -repotoken="$COVERALLS_TOKEN"
 
-# Upload profiles to codecov.io.
-bash <(curl -s https://codecov.io/bash) -f "$coverage_profile"
+# Upload profiles to codecov.io. Uses CODECOV_TOKEN.
+bash <(curl -s https://codecov.io/bash) -f $coverage_profile


### PR DESCRIPTION
This should fix the recent string of failures. I believe the cause of
failures was grep exiting non-zero on empty dependencies, but this
script also just needed a rewrite because it was terrible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12535)
<!-- Reviewable:end -->
