### PR TITLE
cloud: Update Kubernetes docs to reflect the changes in version 1.5

### DIFF
--- a/cloud/kubernetes/README.md
+++ b/cloud/kubernetes/README.md
@@ -1,10 +1,11 @@
-# CockroachDB on Kubernetes as a PetSet
+# CockroachDB on Kubernetes as a StatefulSet
 
-This example deploys CockroachDB on [Kubernetes](https://kubernetes.io) as
-a [PetSet](http://kubernetes.io/docs/user-guide/petset/). Kubernetes is an
-open source system for managing containerized applications across multiple
-hosts, providing basic mechanisms for deployment, maintenance, and scaling
-of applications.
+This example deploys CockroachDB on [Kubernetes](https://kubernetes.io) as a
+a
+[StatefulSet](http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/).
+Kubernetes is an open source system for managing containerized applications
+across multiple hosts, providing basic mechanisms for deployment, maintenance,
+and scaling of applications.
 
 This is a copy of the [similar example stored in the Kubernetes
 repository](https://github.com/kubernetes/kubernetes/tree/master/examples/cockroachdb).
@@ -22,19 +23,20 @@ kubectl run cockroachdb --image=cockroachdb/cockroach --restart=Never -- start
 
 ## Limitations
 
-### PetSet limitations
+### StatefulSet limitations
 
-PetSets are an alpha feature as of Kubernetes version 1.4. As such, they may
-not be available in some production-ready hosting environments.
+StatefulSets were broadly introduced in Kubernetes version 1.5. If using an
+older version of Kubernetes, you may want to look at [an older version of these
+instructions](https://github.com/cockroachdb/cockroach/blob/beta-20161215/cloud/kubernetes/README.md).
 
-Also, there is currently no possibility to use node-local storage (outside of
+There is currently no possibility to use node-local storage (outside of
 single-node tests), and so there is likely a performance hit associated with
 running CockroachDB on some external storage. Note that CockroachDB already
 does replication and thus, for better performance, should not be deployed on a
 persistent volume which already replicates internally. High-performance use
 cases on a private Kubernetes cluster may want to consider a
-[DaemonSet](http://kubernetes.io/docs/admin/daemons/) deployment until PetSets
-support node-local storage
+[DaemonSet](http://kubernetes.io/docs/admin/daemons/) deployment until
+StatefulSets support node-local storage
 ([open issue here](https://github.com/kubernetes/kubernetes/issues/7562)).
 
 ### Recovery after persistent storage failure
@@ -70,7 +72,7 @@ Set up your cluster following the
 [instructions provided in the Kubernetes docs](http://kubernetes.io/docs/getting-started-guides/aws/).
 
 Then once you have a Kubernetes cluster running, either run the
-[aws.sh](aws.sh) script or just run `kubectl create -f cockroachdb-petset.yaml`
+[aws.sh](aws.sh) script or just run `kubectl create -f cockroachdb-statefulset.yaml`
 to create your cockroachdb cluster.
 
 ## Testing in the cloud on GCE
@@ -85,12 +87,12 @@ gcloud alpha container clusters create NAME --enable-kubernetes-alpha
 ```
 
 Then once you have a Kubernetes cluster running, either run the
-[gce.sh](gce.sh) script or just run `kubectl create -f cockroachdb-petset.yaml`
+[gce.sh](gce.sh) script or just run `kubectl create -f cockroachdb-statefulset.yaml`
 to create your cockroachdb cluster.
 
 ## Accessing the database
 
-Along with our PetSet configuration, we expose a standard Kubernetes service
+Along with our StatefulSet configuration, we expose a standard Kubernetes service
 that offers a load-balanced virtual IP for clients to access the database
 with. In our example, we've called this service `cockroachdb-public`.
 
@@ -139,10 +141,10 @@ database and ensuring the other replicas have all data that was written.
 
 ## Scaling up or down
 
-Simply patch the PetSet by running
+Simply patch the StatefulSet by running
 
 ```shell
-kubectl patch petset cockroachdb -p '{"spec":{"replicas":4}}'
+kubectl patch statefulset cockroachdb -p '{"spec":{"replicas":4}}'
 ```
 
 Note that you may need to create a new persistent volume claim first. If you
@@ -157,5 +159,5 @@ Because all of the resources in this example have been tagged with the label `ap
 we can clean up everything that we created in one quick command using a selector on that label:
 
 ```shell
-kubectl delete petsets,pods,persistentvolumes,persistentvolumeclaims,services -l app=cockroachdb
+kubectl delete statefulsets,pods,persistentvolumes,persistentvolumeclaims,services -l app=cockroachdb
 ```

--- a/cloud/kubernetes/aws.sh
+++ b/cloud/kubernetes/aws.sh
@@ -3,8 +3,8 @@
 set -exuo pipefail
 
 # Clean up anything from a prior run:
-kubectl delete petsets,pods,persistentvolumes,persistentvolumeclaims,services -l app=cockroachdb
+kubectl delete statefulsets,pods,persistentvolumes,persistentvolumeclaims,services -l app=cockroachdb
 
 # The persistent volume auto-provisioner will create the necessary persistent
 # volumes for us, unlike when using Minikube.
-kubectl create -f cockroachdb-petset.yaml
+kubectl create -f cockroachdb-statefulset.yaml

--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -23,10 +23,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  # This service only exists to create DNS entries for each pet in the petset
-  # such that they can resolve each other's IP addresses. It does not create a
-  # load-balanced ClusterIP and should not be used directly by clients in most
-  # circumstances.
+  # This service only exists to create DNS entries for each pod in the stateful
+  # set such that they can resolve each other's IP addresses. It does not
+  # create a load-balanced ClusterIP and should not be used directly by clients
+  # in most circumstances.
   name: cockroachdb
   labels:
     app: cockroachdb
@@ -54,8 +54,8 @@ spec:
   selector:
     app: cockroachdb
 ---
-apiVersion: apps/v1alpha1
-kind: PetSet
+apiVersion: apps/v1beta1
+kind: StatefulSet
 metadata:
   name: cockroachdb
 spec:
@@ -66,13 +66,12 @@ spec:
       labels:
         app: cockroachdb
       annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
         # Init containers are run only once in the lifetime of a pod, before
         # it's started up for the first time. It has to exit successfully
         # before the pod's main containers are allowed to start.
         # This particular init container does a DNS lookup for other pods in
-        # the petset to help determine whether or not a cluster already exists.
-        # If any other pets exist, it creates a file in the cockroach-data
+        # the set to help determine whether or not a cluster already exists.
+        # If any other pods exist, it creates a file in the cockroach-data
         # directory to pass that information along to the primary container that
         # has to decide what command-line flags to use when starting CockroachDB.
         # This only matters when a pod's persistent volume is empty - if it has

--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -54,6 +54,16 @@ spec:
   selector:
     app: cockroachdb
 ---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: cockroachdb-budget
+spec:
+  selector:
+    matchLabels:
+      app: cockroachdb
+  minAvailable: 67%
+---
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
@@ -66,6 +76,21 @@ spec:
       labels:
         app: cockroachdb
       annotations:
+        scheduler.alpha.kubernetes.io/affinity: >
+            {
+              "podAntiAffinity": {
+                "requiredDuringSchedulingRequiredDuringExecution": [{
+                  "labelSelector": {
+                    "matchExpressions": [{
+                      "key": "app",
+                      "operator": "In",
+                      "values": ["cockroachdb"]
+                    }]
+                  },
+                  "topologyKey": "kubernetes.io/hostname"
+                }]
+              }
+            }
         # Init containers are run only once in the lifetime of a pod, before
         # it's started up for the first time. It has to exit successfully
         # before the pod's main containers are allowed to start.

--- a/cloud/kubernetes/gce.sh
+++ b/cloud/kubernetes/gce.sh
@@ -3,8 +3,8 @@
 set -exuo pipefail
 
 # Clean up anything from a prior run:
-kubectl delete petsets,pods,persistentvolumes,persistentvolumeclaims,services -l app=cockroachdb
+kubectl delete statefulsets,pods,persistentvolumes,persistentvolumeclaims,services -l app=cockroachdb
 
 # The persistent volume auto-provisioner will create the necessary persistent
 # volumes for us, unlike when using Minikube.
-kubectl create -f cockroachdb-petset.yaml
+kubectl create -f cockroachdb-statefulset.yaml

--- a/cloud/kubernetes/init/README.md
+++ b/cloud/kubernetes/init/README.md
@@ -3,8 +3,8 @@
 The Dockerfile in this directory defines a lightweight wrapper around the
 [Kubernetes-maintained "peer-finder"
 image](https://github.com/kubernetes/contrib/tree/master/pets/peer-finder),
-which finds whether any other instances from the same PetSet currently exist in
-the cluster.
+which finds whether any other instances from the same StatefulSet currently
+exist in the cluster.
 
 The `on-start.sh` script in this directory is invoked by the peer-finder binary
 with a newline separated list of the DNS results matching the provided

--- a/cloud/kubernetes/minikube.sh
+++ b/cloud/kubernetes/minikube.sh
@@ -3,7 +3,7 @@
 set -exuo pipefail
 
 # Clean up anything from a prior run:
-kubectl delete petsets,pods,persistentvolumes,persistentvolumeclaims,services -l app=cockroachdb
+kubectl delete statefulsets,pods,persistentvolumes,persistentvolumeclaims,services -l app=cockroachdb
 
 # Make persistent volumes and (correctly named) claims. We must create the
 # claims here manually even though that sounds counter-intuitive. For details
@@ -43,4 +43,4 @@ spec:
 EOF
 done;
 
-kubectl create -f cockroachdb-petset.yaml
+kubectl create -f cockroachdb-statefulset.yaml


### PR DESCRIPTION
There are also a couple new features that'll enable us to avoid colocation of cockroach instances and minimize disruption, but I'll add those in a follow-up. This is basically just a find-and-replace of PetSet to StatefulSet.

https://github.com/cockroachdb/docs/issues/932

@jseldess 

Should we also consider updating the blog post, @jess-edwards, or just leave that as it was when published?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12536)
<!-- Reviewable:end -->
