### PR TITLE
security: make error message clearer

### DIFF
--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -49,7 +49,7 @@ eexpect $prompt
 
 # Root can only authenticate using certificate authentication.
 send "$argv sql --ca-cert=$ca_crt\r"
-eexpect "user root must authenticate using a client certificate"
+eexpect "user root must use certificate authentication instead of password authentication"
 
 eexpect $prompt
 

--- a/pkg/security/auth.go
+++ b/pkg/security/auth.go
@@ -136,7 +136,7 @@ func UserAuthPasswordHook(insecureMode bool, password string, hashedPassword []b
 		}
 
 		if requestedUser == RootUser {
-			return errors.Errorf("user %s must authenticate using a client certificate ", RootUser)
+			return errors.Errorf("user %s must use certificate authentication instead of password authentication", RootUser)
 		}
 
 		// If the requested user has an empty password, disallow authentication.

--- a/pkg/sql/pgwire_test.go
+++ b/pkg/sql/pgwire_test.go
@@ -105,7 +105,7 @@ func TestPGWire(t *testing.T) {
 			} else {
 				// No certificates provided in secure mode defaults to password
 				// authentication. This is disallowed for security.RootUser.
-				if !testutils.IsError(err, fmt.Sprintf("pq: user %s must authenticate using a client certificate", security.RootUser)) {
+				if !testutils.IsError(err, fmt.Sprintf("pq: user %s must use certificate authentication instead of password authentication", security.RootUser)) {
 					t.Errorf("unexpected error: %v", err)
 				}
 			}
@@ -135,7 +135,7 @@ func TestPGWire(t *testing.T) {
 					t.Error(err)
 				}
 			} else {
-				if !testutils.IsError(err, fmt.Sprintf("pq: user %s must authenticate using a client certificate", security.RootUser)) {
+				if !testutils.IsError(err, fmt.Sprintf("pq: user %s must use certificate authentication instead of password authentication", security.RootUser)) {
 					t.Errorf("unexpected error: %v", err)
 				}
 			}


### PR DESCRIPTION
https://github.com/cockroachdb/docs/issues/930 brought to attention that
the error message returned when attempting to use password
authentication as the root user was confusing because it was not clear
that certificate authentication must be used instead.

cc @sploiselle

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12539)
<!-- Reviewable:end -->
