### PR TITLE
kubernetes: Properly delete PodDisruptionBudget resources

### DIFF
--- a/cloud/kubernetes/README.md
+++ b/cloud/kubernetes/README.md
@@ -159,5 +159,5 @@ Because all of the resources in this example have been tagged with the label `ap
 we can clean up everything that we created in one quick command using a selector on that label:
 
 ```shell
-kubectl delete statefulsets,pods,persistentvolumes,persistentvolumeclaims,services -l app=cockroachdb
+kubectl delete statefulsets,pods,persistentvolumes,persistentvolumeclaims,services,poddisruptionbudget -l app=cockroachdb
 ```

--- a/cloud/kubernetes/aws.sh
+++ b/cloud/kubernetes/aws.sh
@@ -3,7 +3,7 @@
 set -exuo pipefail
 
 # Clean up anything from a prior run:
-kubectl delete statefulsets,pods,persistentvolumes,persistentvolumeclaims,services -l app=cockroachdb
+kubectl delete statefulsets,pods,persistentvolumes,persistentvolumeclaims,services,poddisruptionbudget -l app=cockroachdb
 
 # The persistent volume auto-provisioner will create the necessary persistent
 # volumes for us, unlike when using Minikube.

--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -58,6 +58,8 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: cockroachdb-budget
+  labels:
+    app: cockroachdb
 spec:
   selector:
     matchLabels:
@@ -105,6 +107,7 @@ spec:
             {
                 "name": "bootstrap",
                 "image": "cockroachdb/cockroach-k8s-init:0.1",
+                "imagePullPolicy": "IfNotPresent",
                 "args": [
                   "-on-start=/on-start.sh",
                   "-service=cockroachdb"

--- a/cloud/kubernetes/gce.sh
+++ b/cloud/kubernetes/gce.sh
@@ -3,7 +3,7 @@
 set -exuo pipefail
 
 # Clean up anything from a prior run:
-kubectl delete statefulsets,pods,persistentvolumes,persistentvolumeclaims,services -l app=cockroachdb
+kubectl delete statefulsets,pods,persistentvolumes,persistentvolumeclaims,services,poddisruptionbudget -l app=cockroachdb
 
 # The persistent volume auto-provisioner will create the necessary persistent
 # volumes for us, unlike when using Minikube.

--- a/cloud/kubernetes/minikube.sh
+++ b/cloud/kubernetes/minikube.sh
@@ -3,7 +3,7 @@
 set -exuo pipefail
 
 # Clean up anything from a prior run:
-kubectl delete statefulsets,pods,persistentvolumes,persistentvolumeclaims,services -l app=cockroachdb
+kubectl delete statefulsets,pods,persistentvolumes,persistentvolumeclaims,services,poddisruptionbudget -l app=cockroachdb
 
 # Make persistent volumes and (correctly named) claims. We must create the
 # claims here manually even though that sounds counter-intuitive. For details


### PR DESCRIPTION
Also add an ImagePullPolicy to the init container, since apparently
1.5.1 has [some issues with not adding a default pull policy to init
containers](https://github.com/kubernetes/kubernetes/issues/38542) (and it's decent practice anyway)

Sorry for missing the proper deletion command earlier, @jseldess. We'll want to add it to the docs as well to avoid stranding the disruption budget resource in people's clusters. Leaving it around won't actually harm anything, but without this running the example multiple times doesn't work without manually deleting it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12544)
<!-- Reviewable:end -->
