### PR TITLE
distsql: multi-stage aggregation planning

### DIFF
--- a/pkg/sql/distsqlplan/aggregator_funcs.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs.go
@@ -32,6 +32,11 @@ type DistAggregationInfo struct {
 // DistAggregationTable is DistAggregationInfo look-up table. Functions that
 // don't have an entry in the table are not optimized with a local stage.
 var DistAggregationTable = map[distsqlrun.AggregatorSpec_Func]DistAggregationInfo{
+	distsqlrun.AggregatorSpec_IDENT: {
+		LocalStage: distsqlrun.AggregatorSpec_IDENT,
+		FinalStage: distsqlrun.AggregatorSpec_IDENT,
+	},
+
 	distsqlrun.AggregatorSpec_BOOL_AND: {
 		LocalStage: distsqlrun.AggregatorSpec_BOOL_AND,
 		FinalStage: distsqlrun.AggregatorSpec_BOOL_AND,

--- a/pkg/sql/distsqlplan/aggregator_funcs_test.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs_test.go
@@ -244,6 +244,12 @@ func TestDistAggregationTable(t *testing.T) {
 	desc := sqlbase.GetTableDescriptor(kvDB, "test", "t")
 
 	for fn, info := range DistAggregationTable {
+		if info.LocalStage == distsqlrun.AggregatorSpec_IDENT &&
+			info.FinalStage == distsqlrun.AggregatorSpec_IDENT {
+			// IDENT only works as expected if all rows have the same value on the
+			// relevant column; skip testing this trivial case.
+			continue
+		}
 		// We're going to test each aggregation function on every column that can be
 		// used as input for it.
 		foundCol := false


### PR DESCRIPTION
Adding planning for multi-stage aggregation. Especially useful for things like
`COUNT` and `SUM` where most of the work will be done locally.

CC @irfansharif

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12547)
<!-- Reviewable:end -->
