### PR TITLE
sql: fix the ordering information for sort nodes

### DIFF
--- a/pkg/sql/select.go
+++ b/pkg/sql/select.go
@@ -392,7 +392,7 @@ func (s *selectNode) expandPlan() error {
 		ordering = s.top.group.desiredOrdering
 		grouping = true
 	} else if s.top.sort != nil {
-		ordering = s.top.sort.Ordering().ordering
+		ordering = s.top.sort.ordering
 	}
 
 	// Estimate the limit parameters. We can't full eval them just yet,

--- a/pkg/sql/testdata/explain
+++ b/pkg/sql/testdata/explain
@@ -64,12 +64,12 @@ EXPLAIN (TRACE, UNKNOWN) SELECT 1
 query ITTTTT
 EXPLAIN(METADATA) EXPLAIN(TRACE) SELECT 1
 ----
-0      select                                        ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition)             +@10,+"Span Pos"
-1      sort                  +Timestamp,+"Span Pos"  ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition)             +@10,+"Span Pos"
-2      explain               trace                   ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition, Timestamp)
-3      select                                        ("1")
-4      render/filter(debug)  from ()                 ("1")
-5      nullrow                                       ()
+0  select                                          ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition)
+1  sort                    +Timestamp,+"Span Pos"  ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition)
+2  explain                 trace                   ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition, Timestamp)
+3  select                                          ("1")
+4  render/filter(debug)    from ()                 ("1")
+5  nullrow                                         ()
 
 # Ensure that all relevant statement types can be explained
 query ITTT

--- a/pkg/sql/testdata/order_by
+++ b/pkg/sql/testdata/order_by
@@ -347,6 +347,17 @@ EXPLAIN SELECT a, b FROM abc ORDER BY b, c
 0 nosort +b,+c
 1 scan   abc@bc ALL
 
+query ITTTTT
+EXPLAIN(VERBOSE) SELECT a, b FROM abc ORDER BY b, c
+----
+0  select                                                                          (a, b)                 +b
+1  nosort                   +b,+c                                                  (a, b)                 +b
+2  render/filter            from (test.abc.a, test.abc.b, test.abc.c, test.abc.d)  (a, b, c)              +b,+c,unique
+2  render/filter  render 0  test.abc.a
+2  render/filter  render 1  test.abc.b
+2  render/filter  render 2  test.abc.c
+3  scan                     abc@bc ALL                                             (a, b, c, d[omitted])  +b,+c,unique
+
 query ITTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a
 ----

--- a/pkg/sql/testdata/window
+++ b/pkg/sql/testdata/window
@@ -508,8 +508,8 @@ EXPLAIN (DEBUG) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) 
 query ITTTTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
 ----
-0  select                                                                                                                        (k int, "stddev(d) OVER w" decimal)                                                              +@3,+k
-1  sort                                      +"variance(d) OVER w",+k                                                            (k int, "stddev(d) OVER w" decimal)                                                              +@3,+k
+0  select                                                                                                                        (k int, "stddev(d) OVER w" decimal)
+1  sort                                      +"variance(d) OVER w",+k                                                            (k int, "stddev(d) OVER w" decimal)
 2  window                                    stddev(d) OVER w, variance(d) OVER w                                                (k int, "stddev(d) OVER w" decimal, "variance(d) OVER w" decimal)
 2  window         render stddev(d) OVER w    (stddev((d)[decimal]) OVER w)[decimal]
 2  window         render variance(d) OVER w  (variance((d)[decimal]) OVER w)[decimal]
@@ -524,8 +524,8 @@ EXPLAIN (TYPES) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) 
 query ITTTTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-0  select                                                                                                                                            (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                                    +@3,+k
-1  sort                                                          +"variance(d) OVER (PARTITION BY v, 100)",+k                                        (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                                    +@3,+k
+0  select                                                                                                                                            (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)
+1  sort                                                          +"variance(d) OVER (PARTITION BY v, 100)",+k                                        (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)
 2  window                                                        stddev(d) OVER (PARTITION BY v, 'a'), variance(d) OVER (PARTITION BY v, 100)        (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal, "variance(d) OVER (PARTITION BY v, 100)" decimal)
 2  window         render stddev(d) OVER (PARTITION BY v, 'a')    (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
 2  window         render variance(d) OVER (PARTITION BY v, 100)  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]
@@ -556,8 +556,8 @@ EXPLAIN (TYPES,NONORMALIZE) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM 
 query ITTTTT
 EXPLAIN (TYPES) SELECT k, k + stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-0  select                                                                                                                                                             (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                                    +@3,+k
-1  sort                                                            +"variance(d) OVER (PARTITION BY v, 100)",+k                                                       (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                                    +@3,+k
+0  select                                                                                                                                                             (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)
+1  sort                                                            +"variance(d) OVER (PARTITION BY v, 100)",+k                                                       (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)
 2  window                                                          stddev(d) OVER (PARTITION BY v, 'a'), variance(d) OVER (PARTITION BY v, 100)                       (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal, "variance(d) OVER (PARTITION BY v, 100)" decimal)
 2  window         render k + stddev(d) OVER (PARTITION BY v, 'a')  ((k)[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]
 2  window         render variance(d) OVER (PARTITION BY v, 100)    (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]


### PR DESCRIPTION
Prior to this patch the sort node could report ordering columns to its
downstream that do not exist. This happened when an ORDER BY clause
referred to columns not selected in the output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12548)
<!-- Reviewable:end -->
