### PR TITLE
sql: new generic planNode walker + EXPLAIN improvements

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -847,14 +847,16 @@ func Example_sql_escape() {
 	// +-------+
 	// (1 row)
 	// sql --pretty -e explain(indent) select s from t.t union all select s from t.t
-	// +-------+-------+-------+----------------------+
-	// | Level | Type  | Field |     Description      |
-	// +-------+-------+-------+----------------------+
-	// |     0 | union |       | -> union -           |
-	// |     1 | scan  |       | ‌   -> scan t@primary |
-	// |     1 | scan  |       | ‌   -> scan t@primary |
-	// +-------+-------+-------+----------------------+
-	// (3 rows)
+	// +-------+--------+-------+-----------------+
+	// | Level |  Type  | Field |   Description   |
+	// +-------+--------+-------+-----------------+
+	// |     0 | append |       | ‌ -> append      |
+	// |     1 | scan   |       | ‌   -> scan      |
+	// |     1 |        | table | ‌      t@primary |
+	// |     1 | scan   |       | ‌   -> scan      |
+	// |     1 |        | table | ‌      t@primary |
+	// +-------+--------+-------+-----------------+
+	// (5 rows)
 }
 
 func Example_user() {

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -395,19 +395,15 @@ func (n *alterTableNode) Start() error {
 	return nil
 }
 
-func (n *alterTableNode) Next() (bool, error)                      { return false, nil }
-func (n *alterTableNode) Close()                                   {}
-func (n *alterTableNode) Columns() ResultColumns                   { return make(ResultColumns, 0) }
-func (n *alterTableNode) Ordering() orderingInfo                   { return orderingInfo{} }
-func (n *alterTableNode) Values() parser.DTuple                    { return parser.DTuple{} }
-func (n *alterTableNode) DebugValues() debugValues                 { return debugValues{} }
-func (n *alterTableNode) explainExprs(_ func(string, parser.Expr)) {}
-func (n *alterTableNode) SetLimitHint(_ int64, _ bool)             {}
-func (n *alterTableNode) setNeededColumns(_ []bool)                {}
-func (n *alterTableNode) MarkDebug(mode explainMode)               {}
-func (n *alterTableNode) ExplainPlan(v bool) (string, string, []planNode) {
-	return "alter table", "", nil
-}
+func (n *alterTableNode) Next() (bool, error)          { return false, nil }
+func (n *alterTableNode) Close()                       {}
+func (n *alterTableNode) Columns() ResultColumns       { return make(ResultColumns, 0) }
+func (n *alterTableNode) Ordering() orderingInfo       { return orderingInfo{} }
+func (n *alterTableNode) Values() parser.DTuple        { return parser.DTuple{} }
+func (n *alterTableNode) DebugValues() debugValues     { return debugValues{} }
+func (n *alterTableNode) SetLimitHint(_ int64, _ bool) {}
+func (n *alterTableNode) setNeededColumns(_ []bool)    {}
+func (n *alterTableNode) MarkDebug(mode explainMode)   {}
 
 func applyColumnMutation(
 	col *sqlbase.ColumnDescriptor, mut parser.ColumnMutationCmd, searchPath parser.SearchPath,

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -49,22 +49,17 @@ type copyNode struct {
 	rowsMemAcc    WrappableMemoryAccount
 }
 
-func (n *copyNode) Columns() ResultColumns                 { return n.resultColumns }
-func (*copyNode) Ordering() orderingInfo                   { return orderingInfo{} }
-func (*copyNode) Values() parser.DTuple                    { return nil }
-func (*copyNode) explainExprs(_ func(string, parser.Expr)) {}
-func (*copyNode) SetLimitHint(_ int64, _ bool)             {}
-func (*copyNode) setNeededColumns(_ []bool)                {}
-func (*copyNode) MarkDebug(_ explainMode)                  {}
-func (*copyNode) expandPlan() error                        { return nil }
-func (*copyNode) Next() (bool, error)                      { return false, nil }
+func (n *copyNode) Columns() ResultColumns     { return n.resultColumns }
+func (*copyNode) Ordering() orderingInfo       { return orderingInfo{} }
+func (*copyNode) Values() parser.DTuple        { return nil }
+func (*copyNode) SetLimitHint(_ int64, _ bool) {}
+func (*copyNode) setNeededColumns(_ []bool)    {}
+func (*copyNode) MarkDebug(_ explainMode)      {}
+func (*copyNode) expandPlan() error            { return nil }
+func (*copyNode) Next() (bool, error)          { return false, nil }
 
 func (n *copyNode) Close() {
 	n.rowsMemAcc.Wtxn(n.p.session).Close()
-}
-
-func (*copyNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
-	return "copy", "-", nil
 }
 
 func (*copyNode) DebugValues() debugValues {

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -136,19 +136,15 @@ func (n *createDatabaseNode) Start() error {
 	return nil
 }
 
-func (n *createDatabaseNode) Next() (bool, error)                      { return false, nil }
-func (n *createDatabaseNode) Close()                                   {}
-func (n *createDatabaseNode) Columns() ResultColumns                   { return make(ResultColumns, 0) }
-func (n *createDatabaseNode) Ordering() orderingInfo                   { return orderingInfo{} }
-func (n *createDatabaseNode) Values() parser.DTuple                    { return parser.DTuple{} }
-func (n *createDatabaseNode) DebugValues() debugValues                 { return debugValues{} }
-func (n *createDatabaseNode) explainExprs(_ func(string, parser.Expr)) {}
-func (n *createDatabaseNode) SetLimitHint(_ int64, _ bool)             {}
-func (n *createDatabaseNode) setNeededColumns(_ []bool)                {}
-func (n *createDatabaseNode) MarkDebug(mode explainMode)               {}
-func (n *createDatabaseNode) ExplainPlan(v bool) (string, string, []planNode) {
-	return "create database", "", nil
-}
+func (n *createDatabaseNode) Next() (bool, error)          { return false, nil }
+func (n *createDatabaseNode) Close()                       {}
+func (n *createDatabaseNode) Columns() ResultColumns       { return make(ResultColumns, 0) }
+func (n *createDatabaseNode) Ordering() orderingInfo       { return orderingInfo{} }
+func (n *createDatabaseNode) Values() parser.DTuple        { return parser.DTuple{} }
+func (n *createDatabaseNode) DebugValues() debugValues     { return debugValues{} }
+func (n *createDatabaseNode) SetLimitHint(_ int64, _ bool) {}
+func (n *createDatabaseNode) setNeededColumns(_ []bool)    {}
+func (n *createDatabaseNode) MarkDebug(mode explainMode)   {}
 
 type createIndexNode struct {
 	p         *planner
@@ -256,19 +252,15 @@ func (n *createIndexNode) Start() error {
 	return nil
 }
 
-func (n *createIndexNode) Next() (bool, error)                      { return false, nil }
-func (n *createIndexNode) Close()                                   {}
-func (n *createIndexNode) Columns() ResultColumns                   { return make(ResultColumns, 0) }
-func (n *createIndexNode) Ordering() orderingInfo                   { return orderingInfo{} }
-func (n *createIndexNode) Values() parser.DTuple                    { return parser.DTuple{} }
-func (n *createIndexNode) DebugValues() debugValues                 { return debugValues{} }
-func (n *createIndexNode) explainExprs(_ func(string, parser.Expr)) {}
-func (n *createIndexNode) SetLimitHint(_ int64, _ bool)             {}
-func (n *createIndexNode) setNeededColumns(_ []bool)                {}
-func (n *createIndexNode) MarkDebug(mode explainMode)               {}
-func (n *createIndexNode) ExplainPlan(v bool) (string, string, []planNode) {
-	return "create index", "", nil
-}
+func (n *createIndexNode) Next() (bool, error)          { return false, nil }
+func (n *createIndexNode) Close()                       {}
+func (n *createIndexNode) Columns() ResultColumns       { return make(ResultColumns, 0) }
+func (n *createIndexNode) Ordering() orderingInfo       { return orderingInfo{} }
+func (n *createIndexNode) Values() parser.DTuple        { return parser.DTuple{} }
+func (n *createIndexNode) DebugValues() debugValues     { return debugValues{} }
+func (n *createIndexNode) SetLimitHint(_ int64, _ bool) {}
+func (n *createIndexNode) setNeededColumns(_ []bool)    {}
+func (n *createIndexNode) MarkDebug(mode explainMode)   {}
 
 type createUserNode struct {
 	p        *planner
@@ -349,19 +341,15 @@ func (n *createUserNode) Start() error {
 	return nil
 }
 
-func (n *createUserNode) Next() (bool, error)                      { return false, nil }
-func (n *createUserNode) Close()                                   {}
-func (n *createUserNode) Columns() ResultColumns                   { return make(ResultColumns, 0) }
-func (n *createUserNode) Ordering() orderingInfo                   { return orderingInfo{} }
-func (n *createUserNode) Values() parser.DTuple                    { return parser.DTuple{} }
-func (n *createUserNode) DebugValues() debugValues                 { return debugValues{} }
-func (n *createUserNode) explainExprs(_ func(string, parser.Expr)) {}
-func (n *createUserNode) SetLimitHint(_ int64, _ bool)             {}
-func (n *createUserNode) setNeededColumns(_ []bool)                {}
-func (n *createUserNode) MarkDebug(mode explainMode)               {}
-func (n *createUserNode) ExplainPlan(v bool) (string, string, []planNode) {
-	return "create user", "", nil
-}
+func (n *createUserNode) Next() (bool, error)          { return false, nil }
+func (n *createUserNode) Close()                       {}
+func (n *createUserNode) Columns() ResultColumns       { return make(ResultColumns, 0) }
+func (n *createUserNode) Ordering() orderingInfo       { return orderingInfo{} }
+func (n *createUserNode) Values() parser.DTuple        { return parser.DTuple{} }
+func (n *createUserNode) DebugValues() debugValues     { return debugValues{} }
+func (n *createUserNode) SetLimitHint(_ int64, _ bool) {}
+func (n *createUserNode) setNeededColumns(_ []bool)    {}
+func (n *createUserNode) MarkDebug(mode explainMode)   {}
 
 type createViewNode struct {
 	p           *planner
@@ -504,19 +492,15 @@ func (n *createViewNode) Close() {
 	n.sourcePlan = nil
 }
 
-func (n *createViewNode) expandPlan() error                        { return n.sourcePlan.expandPlan() }
-func (n *createViewNode) Next() (bool, error)                      { return false, nil }
-func (n *createViewNode) Columns() ResultColumns                   { return make(ResultColumns, 0) }
-func (n *createViewNode) Ordering() orderingInfo                   { return orderingInfo{} }
-func (n *createViewNode) Values() parser.DTuple                    { return parser.DTuple{} }
-func (n *createViewNode) DebugValues() debugValues                 { return debugValues{} }
-func (n *createViewNode) explainExprs(_ func(string, parser.Expr)) {}
-func (n *createViewNode) setNeededColumns(_ []bool)                {}
-func (n *createViewNode) SetLimitHint(_ int64, _ bool)             {}
-func (n *createViewNode) MarkDebug(mode explainMode)               {}
-func (n *createViewNode) ExplainPlan(v bool) (string, string, []planNode) {
-	return "create view", "", nil
-}
+func (n *createViewNode) expandPlan() error            { return n.sourcePlan.expandPlan() }
+func (n *createViewNode) Next() (bool, error)          { return false, nil }
+func (n *createViewNode) Columns() ResultColumns       { return make(ResultColumns, 0) }
+func (n *createViewNode) Ordering() orderingInfo       { return orderingInfo{} }
+func (n *createViewNode) Values() parser.DTuple        { return parser.DTuple{} }
+func (n *createViewNode) DebugValues() debugValues     { return debugValues{} }
+func (n *createViewNode) setNeededColumns(_ []bool)    {}
+func (n *createViewNode) SetLimitHint(_ int64, _ bool) {}
+func (n *createViewNode) MarkDebug(mode explainMode)   {}
 
 type createTableNode struct {
 	p          *planner
@@ -739,21 +723,14 @@ func (n *createTableNode) Close() {
 	}
 }
 
-func (n *createTableNode) Next() (bool, error)                      { return false, nil }
-func (n *createTableNode) Columns() ResultColumns                   { return make(ResultColumns, 0) }
-func (n *createTableNode) Ordering() orderingInfo                   { return orderingInfo{} }
-func (n *createTableNode) Values() parser.DTuple                    { return parser.DTuple{} }
-func (n *createTableNode) DebugValues() debugValues                 { return debugValues{} }
-func (n *createTableNode) explainExprs(_ func(string, parser.Expr)) {}
-func (n *createTableNode) SetLimitHint(_ int64, _ bool)             {}
-func (n *createTableNode) setNeededColumns(_ []bool)                {}
-func (n *createTableNode) MarkDebug(mode explainMode)               {}
-func (n *createTableNode) ExplainPlan(v bool) (string, string, []planNode) {
-	if n.n.As() {
-		return "create table", "create table as", []planNode{n.sourcePlan}
-	}
-	return "create table", "", nil
-}
+func (n *createTableNode) Next() (bool, error)          { return false, nil }
+func (n *createTableNode) Columns() ResultColumns       { return make(ResultColumns, 0) }
+func (n *createTableNode) Ordering() orderingInfo       { return orderingInfo{} }
+func (n *createTableNode) Values() parser.DTuple        { return parser.DTuple{} }
+func (n *createTableNode) DebugValues() debugValues     { return debugValues{} }
+func (n *createTableNode) SetLimitHint(_ int64, _ bool) {}
+func (n *createTableNode) setNeededColumns(_ []bool)    {}
+func (n *createTableNode) MarkDebug(mode explainMode)   {}
 
 type indexMatch bool
 
@@ -1155,7 +1132,7 @@ func (n *createViewNode) makeViewTableDesc(
 	}
 
 	// TODO(a-robinson): Support star expressions as soon as we can (#10028).
-	if planContainsStar(n.sourcePlan) {
+	if n.p.planContainsStar(n.sourcePlan) {
 		return desc, fmt.Errorf("views do not currently support * expressions")
 	}
 
@@ -1543,9 +1520,7 @@ func CreateTestTableDescriptor(
 func (n *createViewNode) resolveViewDependencies(
 	tbl *sqlbase.TableDescriptor, backrefs map[sqlbase.ID]*sqlbase.TableDescriptor,
 ) {
-	// Add the necessary back-references to the descriptor for each referenced
-	// table / view.
-	populateViewBackrefs(n.sourcePlan, tbl, backrefs)
+	n.p.populateViewBackrefs(n.sourcePlan, tbl, backrefs)
 
 	// Also create the forward references in the new view's descriptor.
 	tbl.DependsOn = make([]sqlbase.ID, 0, len(backrefs))
@@ -1554,9 +1529,26 @@ func (n *createViewNode) resolveViewDependencies(
 	}
 }
 
-func populateViewBackrefs(
+// populateViewBackrefs adds back-references to the descriptor for each referenced
+// table / view in the plan.
+func (p *planner) populateViewBackrefs(
 	plan planNode, tbl *sqlbase.TableDescriptor, backrefs map[sqlbase.ID]*sqlbase.TableDescriptor,
 ) {
+	b := &backrefCollector{p: p, tbl: tbl, backrefs: backrefs}
+	v := planVisitor{p: p, observer: b}
+	v.visit(plan)
+}
+
+type backrefCollector struct {
+	p        *planner
+	tbl      *sqlbase.TableDescriptor
+	backrefs map[sqlbase.ID]*sqlbase.TableDescriptor
+}
+
+var _ planObserver = &backrefCollector{}
+
+// enterNode implements the planObserver interface.
+func (b *backrefCollector) enterNode(_ string, plan planNode) bool {
 	// I was initially concerned about doing type assertions on every node in
 	// the tree, but it's actually faster than a string comparison on the name
 	// returned by ExplainPlan, judging by a mini-benchmark run on my laptop
@@ -1566,31 +1558,31 @@ func populateViewBackrefs(
 		// We instead prefer to track the dependency on the view itself rather
 		// than on its indirect dependencies.
 		if sel.source.info.viewDesc != nil {
-			populateViewBackrefFromViewDesc(sel.source.info.viewDesc, tbl, backrefs)
+			populateViewBackrefFromViewDesc(sel.source.info.viewDesc, b.tbl, b.backrefs)
 			// Return early to avoid processing the view's underlying query.
-			return
+			return false
 		}
 	} else if join, ok := plan.(*joinNode); ok {
 		if join.left.info.viewDesc != nil {
-			populateViewBackrefFromViewDesc(join.left.info.viewDesc, tbl, backrefs)
+			populateViewBackrefFromViewDesc(join.left.info.viewDesc, b.tbl, b.backrefs)
 		} else {
-			populateViewBackrefs(join.left.plan, tbl, backrefs)
+			b.p.populateViewBackrefs(join.left.plan, b.tbl, b.backrefs)
 		}
 		if join.right.info.viewDesc != nil {
-			populateViewBackrefFromViewDesc(join.right.info.viewDesc, tbl, backrefs)
+			populateViewBackrefFromViewDesc(join.right.info.viewDesc, b.tbl, b.backrefs)
 		} else {
-			populateViewBackrefs(join.right.plan, tbl, backrefs)
+			b.p.populateViewBackrefs(join.right.plan, b.tbl, b.backrefs)
 		}
 		// Return early to avoid re-processing the children.
-		return
+		return false
 	} else if scan, ok := plan.(*scanNode); ok {
-		desc, ok := backrefs[scan.desc.ID]
+		desc, ok := b.backrefs[scan.desc.ID]
 		if !ok {
 			desc = &scan.desc
-			backrefs[desc.ID] = desc
+			b.backrefs[desc.ID] = desc
 		}
 		ref := sqlbase.TableDescriptor_Reference{
-			ID:        tbl.ID,
+			ID:        b.tbl.ID,
 			ColumnIDs: make([]sqlbase.ColumnID, 0, len(scan.cols)),
 		}
 		if scan.specifiedIndex != nil {
@@ -1604,14 +1596,11 @@ func populateViewBackrefs(
 		}
 		desc.DependedOnBy = append(desc.DependedOnBy, ref)
 	}
-
-	// We have to use the verbose version of ExplainPlan because the non-verbose
-	// form skips over some layers of the tree (e.g. selectTopNode, selectNode).
-	_, _, children := plan.ExplainPlan(true)
-	for _, child := range children {
-		populateViewBackrefs(child, tbl, backrefs)
-	}
+	return true
 }
+func (b *backrefCollector) attr(_, _, _ string)                    {}
+func (b *backrefCollector) expr(_, _ string, _ int, _ parser.Expr) {}
+func (b *backrefCollector) leaveNode(_ string)                     {}
 
 func populateViewBackrefFromViewDesc(
 	dependency *sqlbase.TableDescriptor,
@@ -1627,18 +1616,35 @@ func populateViewBackrefFromViewDesc(
 	desc.DependedOnBy = append(desc.DependedOnBy, ref)
 }
 
-func planContainsStar(plan planNode) bool {
+// planContainsStar returns true if one of the select nodes in the
+// plan contains a star expansion.
+func (p *planner) planContainsStar(plan planNode) bool {
+	s := &starDetector{}
+	v := planVisitor{p: p, observer: s}
+	v.visit(plan)
+	return s.foundStar
+}
+
+// starDetector supports planContainsStar().
+type starDetector struct {
+	foundStar bool
+}
+
+var _ planObserver = &starDetector{}
+
+// enterNode implements the planObserver interface.
+func (s *starDetector) enterNode(_ string, plan planNode) bool {
+	if s.foundStar {
+		return false
+	}
 	if sel, ok := plan.(*selectNode); ok {
 		if sel.isStar {
-			return true
+			s.foundStar = true
+			return false
 		}
 	}
-
-	_, _, children := plan.ExplainPlan(true)
-	for _, child := range children {
-		if containsStar := planContainsStar(child); containsStar {
-			return true
-		}
-	}
-	return false
+	return true
 }
+func (s *starDetector) attr(_, _, _ string)                    {}
+func (s *starDetector) expr(_, _ string, _ int, _ parser.Expr) {}
+func (s *starDetector) leaveNode(_ string)                     {}

--- a/pkg/sql/delayed.go
+++ b/pkg/sql/delayed.go
@@ -54,18 +54,10 @@ func (d *delayedNode) Close() {
 	}
 }
 
-func (d *delayedNode) ExplainPlan(verbose bool) (name, description string, children []planNode) {
-	if d.plan != nil {
-		children = []planNode{d.plan}
-	}
-	return "virtual table", d.name, children
-}
-
-func (d *delayedNode) explainExprs(rt func(string, parser.Expr)) {}
-func (d *delayedNode) Columns() ResultColumns                    { return d.columns }
-func (d *delayedNode) Ordering() orderingInfo                    { return orderingInfo{} }
-func (d *delayedNode) MarkDebug(_ explainMode)                   {}
-func (d *delayedNode) Start() error                              { return d.plan.Start() }
-func (d *delayedNode) Next() (bool, error)                       { return d.plan.Next() }
-func (d *delayedNode) Values() parser.DTuple                     { return d.plan.Values() }
-func (d *delayedNode) DebugValues() debugValues                  { return d.plan.DebugValues() }
+func (d *delayedNode) Columns() ResultColumns   { return d.columns }
+func (d *delayedNode) Ordering() orderingInfo   { return orderingInfo{} }
+func (d *delayedNode) MarkDebug(_ explainMode)  {}
+func (d *delayedNode) Start() error             { return d.plan.Start() }
+func (d *delayedNode) Next() (bool, error)      { return d.plan.Next() }
+func (d *delayedNode) Values() parser.DTuple    { return d.plan.Values() }
+func (d *delayedNode) DebugValues() debugValues { return d.plan.DebugValues() }

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -17,7 +17,6 @@
 package sql
 
 import (
-	"bytes"
 	"fmt"
 
 	"golang.org/x/net/context"
@@ -241,34 +240,6 @@ func (d *deleteNode) DebugValues() debugValues {
 
 func (d *deleteNode) Ordering() orderingInfo {
 	return d.run.rows.Ordering()
-}
-
-func (d *deleteNode) ExplainPlan(v bool) (name, description string, children []planNode) {
-	var buf bytes.Buffer
-	if v {
-		fmt.Fprintf(&buf, "from %s returning (", d.tableDesc.Name)
-		for i, col := range d.rh.columns {
-			if i > 0 {
-				fmt.Fprintf(&buf, ", ")
-			}
-			fmt.Fprintf(&buf, "%s", col.Name)
-		}
-		fmt.Fprintf(&buf, ")")
-	}
-
-	subplans := []planNode{d.run.rows}
-	for _, e := range d.rh.exprs {
-		subplans = d.p.collectSubqueryPlans(e, subplans)
-	}
-
-	return "delete", buf.String(), subplans
-}
-
-func (d *deleteNode) explainExprs(regTypes func(string, parser.Expr)) {
-	cols := d.rh.columns
-	for i, rexpr := range d.rh.exprs {
-		regTypes(fmt.Sprintf("returning %s", cols[i].Name), rexpr)
-	}
 }
 
 func (d *deleteNode) SetLimitHint(numRows int64, soft bool) {}

--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -210,19 +210,15 @@ func (n *dropDatabaseNode) Start() error {
 	return nil
 }
 
-func (n *dropDatabaseNode) Next() (bool, error)                      { return false, nil }
-func (n *dropDatabaseNode) Close()                                   {}
-func (n *dropDatabaseNode) Columns() ResultColumns                   { return make(ResultColumns, 0) }
-func (n *dropDatabaseNode) Ordering() orderingInfo                   { return orderingInfo{} }
-func (n *dropDatabaseNode) Values() parser.DTuple                    { return parser.DTuple{} }
-func (n *dropDatabaseNode) DebugValues() debugValues                 { return debugValues{} }
-func (n *dropDatabaseNode) explainExprs(_ func(string, parser.Expr)) {}
-func (n *dropDatabaseNode) SetLimitHint(_ int64, _ bool)             {}
-func (n *dropDatabaseNode) setNeededColumns(_ []bool)                {}
-func (n *dropDatabaseNode) MarkDebug(mode explainMode)               {}
-func (n *dropDatabaseNode) ExplainPlan(v bool) (string, string, []planNode) {
-	return "drop database", "", nil
-}
+func (n *dropDatabaseNode) Next() (bool, error)          { return false, nil }
+func (n *dropDatabaseNode) Close()                       {}
+func (n *dropDatabaseNode) Columns() ResultColumns       { return make(ResultColumns, 0) }
+func (n *dropDatabaseNode) Ordering() orderingInfo       { return orderingInfo{} }
+func (n *dropDatabaseNode) Values() parser.DTuple        { return parser.DTuple{} }
+func (n *dropDatabaseNode) DebugValues() debugValues     { return debugValues{} }
+func (n *dropDatabaseNode) SetLimitHint(_ int64, _ bool) {}
+func (n *dropDatabaseNode) setNeededColumns(_ []bool)    {}
+func (n *dropDatabaseNode) MarkDebug(mode explainMode)   {}
 
 type dropIndexNode struct {
 	p        *planner
@@ -391,19 +387,15 @@ func (n *dropIndexNode) Start() error {
 	return nil
 }
 
-func (n *dropIndexNode) Next() (bool, error)                      { return false, nil }
-func (n *dropIndexNode) Close()                                   {}
-func (n *dropIndexNode) Columns() ResultColumns                   { return make(ResultColumns, 0) }
-func (n *dropIndexNode) Ordering() orderingInfo                   { return orderingInfo{} }
-func (n *dropIndexNode) Values() parser.DTuple                    { return parser.DTuple{} }
-func (n *dropIndexNode) DebugValues() debugValues                 { return debugValues{} }
-func (n *dropIndexNode) explainExprs(_ func(string, parser.Expr)) {}
-func (n *dropIndexNode) SetLimitHint(_ int64, _ bool)             {}
-func (n *dropIndexNode) setNeededColumns(_ []bool)                {}
-func (n *dropIndexNode) MarkDebug(mode explainMode)               {}
-func (n *dropIndexNode) ExplainPlan(v bool) (string, string, []planNode) {
-	return "drop index", "", nil
-}
+func (n *dropIndexNode) Next() (bool, error)          { return false, nil }
+func (n *dropIndexNode) Close()                       {}
+func (n *dropIndexNode) Columns() ResultColumns       { return make(ResultColumns, 0) }
+func (n *dropIndexNode) Ordering() orderingInfo       { return orderingInfo{} }
+func (n *dropIndexNode) Values() parser.DTuple        { return parser.DTuple{} }
+func (n *dropIndexNode) DebugValues() debugValues     { return debugValues{} }
+func (n *dropIndexNode) SetLimitHint(_ int64, _ bool) {}
+func (n *dropIndexNode) setNeededColumns(_ []bool)    {}
+func (n *dropIndexNode) MarkDebug(mode explainMode)   {}
 
 type dropViewNode struct {
 	p  *planner
@@ -508,19 +500,15 @@ func (n *dropViewNode) Start() error {
 	return nil
 }
 
-func (n *dropViewNode) Next() (bool, error)                      { return false, nil }
-func (n *dropViewNode) Close()                                   {}
-func (n *dropViewNode) Columns() ResultColumns                   { return make(ResultColumns, 0) }
-func (n *dropViewNode) Ordering() orderingInfo                   { return orderingInfo{} }
-func (n *dropViewNode) Values() parser.DTuple                    { return parser.DTuple{} }
-func (n *dropViewNode) explainExprs(_ func(string, parser.Expr)) {}
-func (n *dropViewNode) DebugValues() debugValues                 { return debugValues{} }
-func (n *dropViewNode) SetLimitHint(_ int64, _ bool)             {}
-func (n *dropViewNode) setNeededColumns(_ []bool)                {}
-func (n *dropViewNode) MarkDebug(mode explainMode)               {}
-func (n *dropViewNode) ExplainPlan(v bool) (string, string, []planNode) {
-	return "drop view", "", nil
-}
+func (n *dropViewNode) Next() (bool, error)          { return false, nil }
+func (n *dropViewNode) Close()                       {}
+func (n *dropViewNode) Columns() ResultColumns       { return make(ResultColumns, 0) }
+func (n *dropViewNode) Ordering() orderingInfo       { return orderingInfo{} }
+func (n *dropViewNode) Values() parser.DTuple        { return parser.DTuple{} }
+func (n *dropViewNode) DebugValues() debugValues     { return debugValues{} }
+func (n *dropViewNode) SetLimitHint(_ int64, _ bool) {}
+func (n *dropViewNode) setNeededColumns(_ []bool)    {}
+func (n *dropViewNode) MarkDebug(mode explainMode)   {}
 
 type dropTableNode struct {
 	p  *planner
@@ -737,19 +725,15 @@ func (n *dropTableNode) Start() error {
 	return nil
 }
 
-func (n *dropTableNode) Next() (bool, error)                      { return false, nil }
-func (n *dropTableNode) Close()                                   {}
-func (n *dropTableNode) Columns() ResultColumns                   { return make(ResultColumns, 0) }
-func (n *dropTableNode) Ordering() orderingInfo                   { return orderingInfo{} }
-func (n *dropTableNode) Values() parser.DTuple                    { return parser.DTuple{} }
-func (n *dropTableNode) explainExprs(_ func(string, parser.Expr)) {}
-func (n *dropTableNode) DebugValues() debugValues                 { return debugValues{} }
-func (n *dropTableNode) SetLimitHint(_ int64, _ bool)             {}
-func (n *dropTableNode) setNeededColumns(_ []bool)                {}
-func (n *dropTableNode) MarkDebug(mode explainMode)               {}
-func (n *dropTableNode) ExplainPlan(v bool) (string, string, []planNode) {
-	return "drop table", "", nil
-}
+func (n *dropTableNode) Next() (bool, error)          { return false, nil }
+func (n *dropTableNode) Close()                       {}
+func (n *dropTableNode) Columns() ResultColumns       { return make(ResultColumns, 0) }
+func (n *dropTableNode) Ordering() orderingInfo       { return orderingInfo{} }
+func (n *dropTableNode) Values() parser.DTuple        { return parser.DTuple{} }
+func (n *dropTableNode) DebugValues() debugValues     { return debugValues{} }
+func (n *dropTableNode) SetLimitHint(_ int64, _ bool) {}
+func (n *dropTableNode) setNeededColumns(_ []bool)    {}
+func (n *dropTableNode) MarkDebug(mode explainMode)   {}
 
 // dropTableOrViewPrepare/dropTableImpl is used to drop a single table by
 // name, which can result from either a DROP TABLE or DROP DATABASE

--- a/pkg/sql/empty.go
+++ b/pkg/sql/empty.go
@@ -27,24 +27,15 @@ type emptyNode struct {
 	results bool
 }
 
-func (*emptyNode) Columns() ResultColumns                   { return nil }
-func (*emptyNode) Ordering() orderingInfo                   { return orderingInfo{} }
-func (*emptyNode) Values() parser.DTuple                    { return nil }
-func (*emptyNode) explainExprs(_ func(string, parser.Expr)) {}
-func (*emptyNode) Start() error                             { return nil }
-func (*emptyNode) SetLimitHint(_ int64, _ bool)             {}
-func (*emptyNode) setNeededColumns(_ []bool)                {}
-func (*emptyNode) MarkDebug(_ explainMode)                  {}
-func (*emptyNode) expandPlan() error                        { return nil }
-func (*emptyNode) Close()                                   {}
-
-func (e *emptyNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
-	name = "empty"
-	if e.results {
-		name = "nullrow"
-	}
-	return name, "", nil
-}
+func (*emptyNode) Columns() ResultColumns       { return nil }
+func (*emptyNode) Ordering() orderingInfo       { return orderingInfo{} }
+func (*emptyNode) Values() parser.DTuple        { return nil }
+func (*emptyNode) Start() error                 { return nil }
+func (*emptyNode) SetLimitHint(_ int64, _ bool) {}
+func (*emptyNode) setNeededColumns(_ []bool)    {}
+func (*emptyNode) MarkDebug(_ explainMode)      {}
+func (*emptyNode) expandPlan() error            { return nil }
+func (*emptyNode) Close()                       {}
 
 func (e *emptyNode) DebugValues() debugValues {
 	return debugValues{

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -239,12 +239,6 @@ func (n *explainDebugNode) Start() error        { return n.plan.Start() }
 func (n *explainDebugNode) Next() (bool, error) { return n.plan.Next() }
 func (n *explainDebugNode) Close()              { n.plan.Close() }
 
-func (n *explainDebugNode) ExplainPlan(v bool) (name, description string, children []planNode) {
-	return n.plan.ExplainPlan(v)
-}
-
-func (n *explainDebugNode) explainExprs(fn func(string, parser.Expr)) {}
-
 func (n *explainDebugNode) Values() parser.DTuple {
 	vals := n.plan.DebugValues()
 

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -79,13 +79,15 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, error) 
 		} else if strings.EqualFold(opt, "QUALIFY") {
 			explainer.qualifyNames = true
 		} else if strings.EqualFold(opt, "VERBOSE") {
-			// VERBOSE shows expression fields.
+			// VERBOSE implies EXPRS.
 			explainer.showExprs = true
 			// VERBOSE implies QUALIFY.
 			explainer.qualifyNames = true
 			// VERBOSE implies METADATA.
 			explainer.showSelectTop = true
 			explainer.showMetadata = true
+		} else if strings.EqualFold(opt, "EXPRS") {
+			explainer.showExprs = true
 		} else if strings.EqualFold(opt, "NOEXPAND") {
 			expanded = false
 		} else if strings.EqualFold(opt, "NONORMALIZE") {

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -56,11 +56,6 @@ type explainer struct {
 	// level is the current depth in the tree of planNodes.
 	level int
 
-	// prefix is the whitespace inserted in front of the description to
-	// clarify the hierarchical structure of the plans when doIndent is
-	// true.
-	prefix string
-
 	// doIndent indicates whether the output should be clarified
 	// with leading white spaces.
 	doIndent bool
@@ -97,6 +92,7 @@ func (p *planner) makeExplainPlanNode(explainer explainer, expanded bool, plan p
 		explainer.showTypes, explainer.symbolicVars, explainer.qualifyNames)
 
 	node := &explainPlanNode{
+		p:         p,
 		explainer: explainer,
 		expanded:  expanded,
 		plan:      plan,
@@ -109,7 +105,7 @@ var emptyString = parser.NewDString("")
 
 // populateExplain invokes explain() with a makeRow method
 // which populates a valuesNode.
-func (e *explainer) populateExplain(v *valuesNode, plan planNode) error {
+func (p *planner) populateExplain(e *explainer, v *valuesNode, plan planNode) error {
 	e.makeRow = func(level int, name, field, description string, plan planNode) {
 		if e.err != nil {
 			return
@@ -135,7 +131,8 @@ func (e *explainer) populateExplain(v *valuesNode, plan planNode) error {
 	}
 
 	e.err = nil
-	e.explain(plan)
+	visitPlan := planVisitor{p: p, observer: e}
+	visitPlan.visit(plan)
 	return e.err
 }
 
@@ -157,63 +154,63 @@ func planToString(plan planNode) string {
 			)
 		},
 	}
-	e.explain(plan)
+	v := planVisitor{p: makePlanner("planToString"), observer: &e}
+	v.visit(plan)
 	return buf.String()
 }
 
-// explain extract information from planNodes and produces the EXPLAIN
-// output via the makeRow callback in the explainer.
-func (e *explainer) explain(plan planNode) {
-	if e.err != nil {
-		return
-	}
-
-	name, description, children := plan.ExplainPlan(e.showMetadata)
-
-	if name == "select" && !e.showSelectTop {
-		e.explain(children[len(children)-1])
-		return
-	}
-
-	e.node(name, description, plan)
-
-	if e.showExprs {
-		plan.explainExprs(func(elt string, expr parser.Expr) {
-			if e.err != nil {
-				return
-			}
-			if expr != nil {
-				e.attr(name, elt, parser.AsStringWithFlags(expr, e.fmtFlags))
-			}
-		})
-	}
-
-	for _, child := range children {
-		e.subnode(child)
+// expr implements the planObserver interface.
+func (e *explainer) expr(nodeName, fieldName string, n int, expr parser.Expr) {
+	if e.showExprs && expr != nil {
+		if nodeName == "join" {
+			qualifySave := e.fmtFlags.ShowTableAliases
+			e.fmtFlags.ShowTableAliases = true
+			defer func() { e.fmtFlags.ShowTableAliases = qualifySave }()
+		}
+		if n >= 0 {
+			fieldName = fmt.Sprintf("%s %d", fieldName, n)
+		}
+		e.attr(nodeName, fieldName,
+			parser.AsStringWithFlags(expr, e.fmtFlags))
 	}
 }
 
-func (e *explainer) node(name, desc string, plan planNode) {
+// enterNode implements the planObserver interface.
+func (e *explainer) enterNode(name string, plan planNode) bool {
+	if !e.showSelectTop && name == "select" {
+		return true
+	}
+	if !e.showExprs && name == "render/filter" {
+		return true
+	}
+
+	desc := ""
 	if e.doIndent {
-		desc = fmt.Sprintf("%s-> %s %s", e.prefix, name, desc)
-		e.prefix += "   "
+		desc = fmt.Sprintf("%*s-> %s", e.level*3, " ", name)
 	}
 	e.makeRow(e.level, name, "", desc, plan)
-}
 
-func (e *explainer) attr(name, t, v string) {
-	if e.doIndent {
-		v = fmt.Sprintf("%s%s", e.prefix, v)
-	}
-	e.makeRow(e.level, name, t, v, nil)
-}
-
-func (e *explainer) subnode(plan planNode) {
-	curPrefix := e.prefix
 	e.level++
-	e.explain(plan)
+	return true
+}
+
+// attr implements the planObserver interface.
+func (e *explainer) attr(nodeName, fieldName, attr string) {
+	if e.doIndent {
+		attr = fmt.Sprintf("%*s%s", e.level*3, " ", attr)
+	}
+	e.makeRow(e.level-1, "", fieldName, attr, nil)
+}
+
+// leaveNode implements the planObserver interface.
+func (e *explainer) leaveNode(name string) {
+	if !e.showSelectTop && name == "select" {
+		return
+	}
+	if !e.showExprs && name == "render/filter" {
+		return
+	}
 	e.level--
-	e.prefix = curPrefix
 }
 
 // formatColumns converts a column signature for a data source /
@@ -259,21 +256,21 @@ func formatColumns(cols ResultColumns, printTypes bool) string {
 
 // explainPlanNode wraps the logic for EXPLAIN as a planNode.
 type explainPlanNode struct {
+	p         *planner
 	explainer explainer
 	expanded  bool
 	plan      planNode
 	results   *valuesNode
 }
 
-func (e *explainPlanNode) explainExprs(fn func(string, parser.Expr)) {}
-func (e *explainPlanNode) Next() (bool, error)                       { return e.results.Next() }
-func (e *explainPlanNode) Columns() ResultColumns                    { return e.results.Columns() }
-func (e *explainPlanNode) Ordering() orderingInfo                    { return e.results.Ordering() }
-func (e *explainPlanNode) Values() parser.DTuple                     { return e.results.Values() }
-func (e *explainPlanNode) DebugValues() debugValues                  { return debugValues{} }
-func (e *explainPlanNode) SetLimitHint(n int64, s bool)              { e.results.SetLimitHint(n, s) }
-func (e *explainPlanNode) setNeededColumns(_ []bool)                 {}
-func (e *explainPlanNode) MarkDebug(mode explainMode)                {}
+func (e *explainPlanNode) Next() (bool, error)          { return e.results.Next() }
+func (e *explainPlanNode) Columns() ResultColumns       { return e.results.Columns() }
+func (e *explainPlanNode) Ordering() orderingInfo       { return e.results.Ordering() }
+func (e *explainPlanNode) Values() parser.DTuple        { return e.results.Values() }
+func (e *explainPlanNode) DebugValues() debugValues     { return debugValues{} }
+func (e *explainPlanNode) SetLimitHint(n int64, s bool) { e.results.SetLimitHint(n, s) }
+func (e *explainPlanNode) setNeededColumns(_ []bool)    {}
+func (e *explainPlanNode) MarkDebug(mode explainMode)   {}
 func (e *explainPlanNode) expandPlan() error {
 	if e.expanded {
 		if err := e.plan.expandPlan(); err != nil {
@@ -287,12 +284,9 @@ func (e *explainPlanNode) expandPlan() error {
 	}
 	return nil
 }
-func (e *explainPlanNode) ExplainPlan(v bool) (string, string, []planNode) {
-	return "explain", "plan", []planNode{e.plan}
-}
 
 func (e *explainPlanNode) Start() error {
-	return e.explainer.populateExplain(e.results, e.plan)
+	return e.p.populateExplain(&e.explainer, e.results, e.plan)
 }
 
 func (e *explainPlanNode) Close() {

--- a/pkg/sql/generator.go
+++ b/pkg/sql/generator.go
@@ -121,11 +121,6 @@ func (n *valueGenerator) Close() {
 	}
 }
 
-func (n *valueGenerator) ExplainPlan(_ bool) (string, string, []planNode) {
-	subplans := n.p.collectSubqueryPlans(n.expr, nil)
-	return "generator", n.expr.String(), subplans
-}
-
 func (n *valueGenerator) DebugValues() debugValues {
 	row := n.gen.Values()
 	return debugValues{
@@ -134,10 +129,6 @@ func (n *valueGenerator) DebugValues() debugValues {
 		value:  row.String(),
 		output: debugValueRow,
 	}
-}
-
-func (n *valueGenerator) explainExprs(regTypes func(string, parser.Expr)) {
-	regTypes("generator", n.expr)
 }
 
 func (n *valueGenerator) Ordering() orderingInfo       { return orderingInfo{} }

--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -239,12 +239,6 @@ func (n *indexJoinNode) Next() (bool, error) {
 	return false, nil
 }
 
-func (n *indexJoinNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
-	return "index-join", "", []planNode{n.index, n.table}
-}
-
-func (n *indexJoinNode) explainExprs(_ func(string, parser.Expr)) {}
-
 func (n *indexJoinNode) SetLimitHint(numRows int64, soft bool) {
 	n.index.SetLimitHint(numRows, soft)
 }

--- a/pkg/sql/join_predicate.go
+++ b/pkg/sql/join_predicate.go
@@ -368,25 +368,6 @@ func makeEqualityPredicate(
 	return pred, info, nil
 }
 
-func (p *joinPredicate) format(buf *bytes.Buffer) {
-	if p.filter != nil || len(p.leftColNames) > 0 {
-		buf.WriteString(" ON ")
-	}
-	prefix := ""
-	if len(p.leftColNames) > 0 {
-		buf.WriteString("EQUALS((")
-		p.leftColNames.Format(buf, parser.FmtSimple)
-		buf.WriteString("),(")
-		p.rightColNames.Format(buf, parser.FmtSimple)
-		buf.WriteString("))")
-		prefix = " AND "
-	}
-	if p.filter != nil {
-		buf.WriteString(prefix)
-		p.filter.Format(buf, parser.FmtQualify)
-	}
-}
-
 // IndexedVarEval implements the parser.IndexedVarContainer interface.
 func (p *joinPredicate) IndexedVarEval(idx int, ctx *parser.EvalContext) (parser.Datum, error) {
 	return p.curRow[idx].Eval(ctx)

--- a/pkg/sql/ordinality.go
+++ b/pkg/sql/ordinality.go
@@ -129,17 +129,12 @@ func (o *ordinalityNode) Next() (bool, error) {
 	return true, nil
 }
 
-func (o *ordinalityNode) ExplainPlan(_ bool) (string, string, []planNode) {
-	return "ordinality", "", []planNode{o.source}
-}
-
-func (o *ordinalityNode) Ordering() orderingInfo                   { return o.ordering }
-func (o *ordinalityNode) Values() parser.DTuple                    { return o.row }
-func (o *ordinalityNode) DebugValues() debugValues                 { return o.source.DebugValues() }
-func (o *ordinalityNode) MarkDebug(mode explainMode)               { o.source.MarkDebug(mode) }
-func (o *ordinalityNode) Columns() ResultColumns                   { return o.columns }
-func (o *ordinalityNode) Start() error                             { return o.source.Start() }
-func (o *ordinalityNode) Close()                                   { o.source.Close() }
-func (o *ordinalityNode) explainExprs(_ func(string, parser.Expr)) {}
-func (o *ordinalityNode) SetLimitHint(numRows int64, soft bool)    { o.source.SetLimitHint(numRows, soft) }
-func (o *ordinalityNode) setNeededColumns(_ []bool)                {}
+func (o *ordinalityNode) Ordering() orderingInfo                { return o.ordering }
+func (o *ordinalityNode) Values() parser.DTuple                 { return o.row }
+func (o *ordinalityNode) DebugValues() debugValues              { return o.source.DebugValues() }
+func (o *ordinalityNode) MarkDebug(mode explainMode)            { o.source.MarkDebug(mode) }
+func (o *ordinalityNode) Columns() ResultColumns                { return o.columns }
+func (o *ordinalityNode) Start() error                          { return o.source.Start() }
+func (o *ordinalityNode) Close()                                { o.source.Close() }
+func (o *ordinalityNode) SetLimitHint(numRows int64, soft bool) { o.source.SetLimitHint(numRows, soft) }
+func (o *ordinalityNode) setNeededColumns(_ []bool)             {}

--- a/pkg/sql/parser/format.go
+++ b/pkg/sql/parser/format.go
@@ -48,10 +48,6 @@ type FmtFlags *fmtFlags
 // syntax that makes prettyprint+parse idempotent.
 var FmtSimple FmtFlags = &fmtFlags{showTypes: false}
 
-// FmtQualify instructs the pretty-printer to qualify names with the
-// table name.
-var FmtQualify FmtFlags = &fmtFlags{ShowTableAliases: true}
-
 // FmtShowTypes instructs the pretty-printer to
 // annotate expressions with their resolved types.
 var FmtShowTypes FmtFlags = &fmtFlags{showTypes: true}

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -70,11 +70,6 @@ var _ planMaker = &planner{}
 
 // planNode defines the interface for executing a query or portion of a query.
 type planNode interface {
-	// explainExprs reports the expressions involved in the node.
-	//
-	// Available after newPlan().
-	explainExprs(explainFn func(elem string, desc parser.Expr))
-
 	// SetLimitHint tells this node to optimize things under the assumption that
 	// we will only need the first `numRows` rows.
 	//
@@ -114,11 +109,6 @@ type planNode interface {
 	//
 	// Available after newPlan().
 	expandPlan() error
-
-	// ExplainPlan returns a name and description and a list of child nodes.
-	//
-	// Available after expandPlan() (or makePlan).
-	ExplainPlan(verbose bool) (name, description string, children []planNode)
 
 	// Columns returns the column names and types. The length of the
 	// returned slice is guaranteed to be equal to the length of the
@@ -210,15 +200,17 @@ var _ planNode = &indexJoinNode{}
 var _ planNode = &insertNode{}
 var _ planNode = &joinNode{}
 var _ planNode = &limitNode{}
+var _ planNode = &ordinalityNode{}
 var _ planNode = &scanNode{}
 var _ planNode = &selectNode{}
 var _ planNode = &selectTopNode{}
 var _ planNode = &sortNode{}
+var _ planNode = &splitNode{}
 var _ planNode = &unionNode{}
 var _ planNode = &updateNode{}
-var _ planNode = &valuesNode{}
-var _ planNode = &ordinalityNode{}
 var _ planNode = &valueGenerator{}
+var _ planNode = &valuesNode{}
+var _ planNode = &windowNode{}
 
 // makePlan implements the Planner interface.
 func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, error) {

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -56,13 +56,12 @@ type hookFnNode struct {
 
 var _ planNode = &hookFnNode{}
 
-func (*hookFnNode) Ordering() orderingInfo                   { return orderingInfo{} }
-func (*hookFnNode) explainExprs(_ func(string, parser.Expr)) {}
-func (*hookFnNode) SetLimitHint(_ int64, _ bool)             {}
-func (*hookFnNode) MarkDebug(_ explainMode)                  {}
-func (*hookFnNode) expandPlan() error                        { return nil }
-func (*hookFnNode) Close()                                   {}
-func (*hookFnNode) setNeededColumns(_ []bool)                {}
+func (*hookFnNode) Ordering() orderingInfo       { return orderingInfo{} }
+func (*hookFnNode) SetLimitHint(_ int64, _ bool) {}
+func (*hookFnNode) MarkDebug(_ explainMode)      {}
+func (*hookFnNode) expandPlan() error            { return nil }
+func (*hookFnNode) Close()                       {}
+func (*hookFnNode) setNeededColumns(_ []bool)    {}
 
 func (f *hookFnNode) Start() error {
 	var err error
@@ -81,10 +80,6 @@ func (f *hookFnNode) Next() (bool, error) {
 	return f.resIdx < len(f.res), nil
 }
 func (f *hookFnNode) Values() parser.DTuple { return f.res[f.resIdx] }
-
-func (*hookFnNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
-	return "func", "-", nil
-}
 
 func (*hookFnNode) DebugValues() debugValues {
 	return debugValues{

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -237,38 +237,6 @@ func (n *scanNode) Next() (bool, error) {
 	}
 }
 
-func (n *scanNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
-	if n.reverse {
-		name = "revscan"
-	} else {
-		name = "scan"
-	}
-	var desc bytes.Buffer
-	fmt.Fprintf(&desc, "%s@%s", n.desc.Name, n.index.Name)
-	spans := sqlbase.PrettySpans(n.spans, 2)
-	if spans != "" {
-		if spans == "-" {
-			spans = "ALL"
-		}
-		fmt.Fprintf(&desc, " %s", spans)
-	}
-	if n.limitHint > 0 && !n.limitSoft {
-		if n.limitHint == 1 {
-			desc.WriteString(" (max 1 row)")
-		} else {
-			fmt.Fprintf(&desc, " (max %d rows)", n.limitHint)
-		}
-	}
-
-	subplans := n.p.collectSubqueryPlans(n.filter, nil)
-
-	return name, desc.String(), subplans
-}
-
-func (n *scanNode) explainExprs(regTypes func(string, parser.Expr)) {
-	regTypes("filter", n.filter)
-}
-
 // Initializes a scanNode with a table descriptor.
 func (n *scanNode) initTable(
 	p *planner,

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -17,7 +17,6 @@
 package sql
 
 import (
-	"bytes"
 	"container/heap"
 	"fmt"
 	"math"
@@ -318,36 +317,6 @@ func (n *sortNode) DebugValues() debugValues {
 	}
 	return n.debugVals
 }
-
-func (n *sortNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
-	if n.needSort {
-		name = "sort"
-	} else {
-		name = "nosort"
-	}
-
-	var buf bytes.Buffer
-	var columns ResultColumns
-	if n.plan != nil {
-		columns = n.plan.Columns()
-	}
-	// We use n.ordering here because n.Ordering() does not contain
-	// columns not present in the output.
-	order := orderingInfo{ordering: n.ordering}
-	order.Format(&buf, columns)
-
-	switch ss := n.sortStrategy.(type) {
-	case *iterativeSortStrategy:
-		buf.WriteString(" (iterative)")
-	case *sortTopKStrategy:
-		fmt.Fprintf(&buf, " (top %d)", ss.topK)
-	}
-	description = buf.String()
-
-	return name, description, []planNode{n.plan}
-}
-
-func (n *sortNode) explainExprs(_ func(string, parser.Expr)) {}
 
 func (n *sortNode) SetLimitHint(numRows int64, soft bool) {
 	if !n.needSort {

--- a/pkg/sql/split.go
+++ b/pkg/sql/split.go
@@ -17,9 +17,6 @@
 package sql
 
 import (
-	"bytes"
-	"fmt"
-
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -174,24 +171,6 @@ func (*splitNode) Ordering() orderingInfo       { return orderingInfo{} }
 func (*splitNode) SetLimitHint(_ int64, _ bool) {}
 func (*splitNode) setNeededColumns(_ []bool)    {}
 func (*splitNode) MarkDebug(_ explainMode)      {}
-
-func (n *splitNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
-	var buf bytes.Buffer
-	for i, e := range n.exprs {
-		if i > 0 {
-			buf.WriteString(", ")
-		}
-		e.Format(&buf, parser.FmtSimple)
-		children = n.p.collectSubqueryPlans(e, children)
-	}
-	return "split", buf.String(), children
-}
-
-func (n *splitNode) explainExprs(regTypes func(string, parser.Expr)) {
-	for i, expr := range n.exprs {
-		regTypes(fmt.Sprintf("expr %d", i), expr)
-	}
-}
 
 func (n *splitNode) DebugValues() debugValues {
 	return debugValues{

--- a/pkg/sql/testdata/aggregate
+++ b/pkg/sql/testdata/aggregate
@@ -459,10 +459,15 @@ SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv
 14.00000000000000000
 
 query ITTT
-EXPLAIN SELECT COUNT(k) FROM kv
+EXPLAIN(EXPRS) SELECT COUNT(k) FROM kv
 ----
-0 group count(k)
-1 scan  kv@primary
+0  group
+0                 aggregate 0  count(k)
+0                 render 0     count(k)
+1  render/filter
+1                 render 0     k
+2  scan
+2                 table        kv@primary
 
 statement ok
 CREATE TABLE abc (
@@ -477,10 +482,17 @@ INSERT INTO abc VALUES ('one', 1.5, true, 5::decimal), ('two', 2.0, false, 1.1::
 
 # Verify we don't try to apply the single-key optimization to the primary index.
 query ITTT
-EXPLAIN SELECT MIN(a) FROM abc
+EXPLAIN(EXPRS) SELECT MIN(a) FROM abc
 ----
-0 group min(a)
-1 scan  abc@primary ALL (max 1 row)
+0  group
+0                 aggregate 0  min(a)
+0                 render 0     min(a)
+1  render/filter
+1                 render 0     a
+2  scan
+2                 table        abc@primary
+2                 spans        ALL
+2                 limit        1
 
 query TRBR
 SELECT MIN(a), MIN(b), MIN(c), MIN(d) FROM abc
@@ -536,10 +548,17 @@ SELECT MIN(x) FROM xyz
 1
 
 query ITTT
-EXPLAIN SELECT MIN(x) FROM xyz
+EXPLAIN(EXPRS) SELECT MIN(x) FROM xyz
 ----
-0 group min(x)
-1 scan  xyz@xy ALL (max 1 row)
+0  group
+0                 aggregate 0  min(x)
+0                 render 0     min(x)
+1  render/filter
+1                 render 0     x
+2  scan
+2                 table        xyz@xy
+2                 spans        ALL
+2                 limit        1
 
 query I
 SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
@@ -547,10 +566,17 @@ SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
 4
 
 query ITTT
-EXPLAIN SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
+EXPLAIN(EXPRS) SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
 ----
-0 group min(x)
-1 scan  xyz@xy /0-/1 /4-/5 /7-/8 (max 1 row)
+0  group
+0                 aggregate 0  min(x)
+0                 render 0     min(x)
+1  render/filter
+1                 render 0     x
+2  scan
+2                 table        xyz@xy
+2                 spans        /0-/1 /4-/5 /7-/8
+2                 limit        1
 
 query I
 SELECT MAX(x) FROM xyz
@@ -558,10 +584,17 @@ SELECT MAX(x) FROM xyz
 7
 
 query ITTT
-EXPLAIN SELECT MAX(x) FROM xyz
+EXPLAIN(EXPRS) SELECT MAX(x) FROM xyz
 ----
-0 group    max(x)
-1 revscan  xyz@xy ALL (max 1 row)
+0  group
+0                 aggregate 0  max(x)
+0                 render 0     max(x)
+1  render/filter
+1                 render 0     x
+2  revscan
+2                 table        xyz@xy
+2                 spans        ALL
+2                 limit        1
 
 query I
 SELECT MIN(y) FROM xyz WHERE x = 1
@@ -569,10 +602,17 @@ SELECT MIN(y) FROM xyz WHERE x = 1
 2
 
 query ITTT
-EXPLAIN SELECT MIN(y) FROM xyz WHERE x = 1
+EXPLAIN(EXPRS) SELECT MIN(y) FROM xyz WHERE x = 1
 ----
-0 group min(y)
-1 scan  xyz@xy /1/#-/2 (max 1 row)
+0  group
+0                 aggregate 0  min(y)
+0                 render 0     min(y)
+1  render/filter
+1                 render 0     y
+2  scan
+2                 table        xyz@xy
+2                 spans        /1/#-/2
+2                 limit        1
 
 query I
 SELECT MAX(y) FROM xyz WHERE x = 1
@@ -580,10 +620,17 @@ SELECT MAX(y) FROM xyz WHERE x = 1
 2
 
 query ITTT
-EXPLAIN SELECT MAX(y) FROM xyz WHERE x = 1
+EXPLAIN(EXPRS) SELECT MAX(y) FROM xyz WHERE x = 1
 ----
-0 group   max(y)
-1 revscan xyz@xy /1/#-/2 (max 1 row)
+0  group
+0                 aggregate 0  max(y)
+0                 render 0     max(y)
+1  render/filter
+1                 render 0     y
+2  revscan
+2                 table        xyz@xy
+2                 spans        /1/#-/2
+2                 limit        1
 
 query I
 SELECT MIN(y) FROM xyz WHERE x = 7
@@ -591,10 +638,17 @@ SELECT MIN(y) FROM xyz WHERE x = 7
 NULL
 
 query ITTT
-EXPLAIN SELECT MIN(y) FROM xyz WHERE x = 7
+EXPLAIN(EXPRS) SELECT MIN(y) FROM xyz WHERE x = 7
 ----
-0 group min(y)
-1 scan  xyz@xy /7/#-/8 (max 1 row)
+0  group
+0                 aggregate 0  min(y)
+0                 render 0     min(y)
+1  render/filter
+1                 render 0     y
+2  scan
+2                 table        xyz@xy
+2                 spans        /7/#-/8
+2                 limit        1
 
 query I
 SELECT MAX(y) FROM xyz WHERE x = 7
@@ -602,10 +656,17 @@ SELECT MAX(y) FROM xyz WHERE x = 7
 NULL
 
 query ITTT
-EXPLAIN SELECT MAX(y) FROM xyz WHERE x = 7
+EXPLAIN(EXPRS) SELECT MAX(y) FROM xyz WHERE x = 7
 ----
-0 group   max(y)
-1 revscan xyz@xy /7/#-/8 (max 1 row)
+0  group
+0                 aggregate 0  max(y)
+0                 render 0     max(y)
+1  render/filter
+1                 render 0     y
+2  revscan
+2                 table        xyz@xy
+2                 spans        /7/#-/8
+2                 limit        1
 
 query I
 SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
@@ -613,13 +674,20 @@ SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 1
 
 query ITTT
-EXPLAIN SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
+EXPLAIN(EXPRS) SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 ----
-0 group min(x)
-1 scan  xyz@zyx /3/2/#-/3/3 (max 1 row)
+0  group
+0                 aggregate 0  min(x)
+0                 render 0     min(x)
+1  render/filter
+1                 render 0     x
+2  scan
+2                 table        xyz@zyx
+2                 spans        /3/2/#-/3/3
+2                 limit        1
 
 query ITTT
-EXPLAIN (DEBUG) SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
+EXPLAIN(DEBUG) SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 ----
 0 /xyz/zyx/3.0/2/1 NULL BUFFERED
 0 0                (1)  ROW
@@ -630,10 +698,17 @@ SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
 1
 
 query ITTT
-EXPLAIN SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
+EXPLAIN(EXPRS) SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
 ----
-0 group   max(x)
-1 revscan xyz@zyx /3/2/#-/3/3 (max 1 row)
+0  group
+0                 aggregate 0  max(x)
+0                 render 0     max(x)
+1  render/filter
+1                 render 0     x
+2  revscan
+2                 table        xyz@zyx
+2                 spans        /3/2/#-/3/3
+2                 limit        1
 
 query RRR
 SELECT VARIANCE(x), VARIANCE(y::decimal), VARIANCE(z) FROM xyz
@@ -664,10 +739,16 @@ SELECT VARIANCE(x) FROM xyz WHERE x = 1
 NULL
 
 query ITTT
-EXPLAIN SELECT VARIANCE(x) FROM xyz WHERE x = 1
+EXPLAIN(EXPRS) SELECT VARIANCE(x) FROM xyz WHERE x = 1
 ----
-0 group variance(x)
-1 scan xyz@xy /1-/2
+0  group
+0                 aggregate 0  variance(x)
+0                 render 0     variance(x)
+1  render/filter
+1                 render 0     x
+2  scan
+2                 table        xyz@xy
+2                 spans        /1-/2
 
 query RRR
 SELECT STDDEV(x), STDDEV(y::decimal), STDDEV(z) FROM xyz
@@ -772,24 +853,38 @@ INSERT INTO ab VALUES
   (5, 50)
 
 query ITTT
-EXPLAIN SELECT MIN(a) FROM abc
+EXPLAIN(EXPRS) SELECT MIN(a) FROM abc
 ----
-0 group min(a)
-1 scan  abc@primary ALL (max 1 row)
+0  group
+0                 aggregate 0  min(a)
+0                 render 0     min(a)
+1  render/filter
+1                 render 0     a
+2  scan
+2                 table        abc@primary
+2                 spans        ALL
+2                 limit        1
 
 # Verify we only buffer one row.
 query ITTT
-EXPLAIN (DEBUG) SELECT MIN(a) FROM ab
+EXPLAIN(DEBUG) SELECT MIN(a) FROM ab
 ----
 0 /ab/primary/1   NULL PARTIAL
 0 /ab/primary/1/b 10   BUFFERED
 0 0               (1)  ROW
 
 query ITTT
-EXPLAIN SELECT MAX(a) FROM abc
+EXPLAIN(EXPRS) SELECT MAX(a) FROM abc
 ----
-0 group   max(a)
-1 revscan abc@primary ALL (max 1 row)
+0  group
+0                 aggregate 0  max(a)
+0                 render 0     max(a)
+1  render/filter
+1                 render 0     a
+2  revscan
+2                 table        abc@primary
+2                 spans        ALL
+2                 limit        1
 
 # Verify we only buffer one row.
 query ITTT
@@ -800,22 +895,52 @@ EXPLAIN (DEBUG) SELECT MAX(a) FROM ab
 0 0               (5)  ROW
 
 query ITTT
-EXPLAIN SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
+EXPLAIN(EXPRS) SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
 ----
-0   sort    +"COUNT(k)"
-1   group   v, count(k) GROUP BY (@3)
-2   scan    kv@primary
+0  sort
+0                 order        +"COUNT(k)"
+1  group
+1                 aggregate 0  v
+1                 aggregate 1  count(k)
+1                 render 0     v
+1                 render 1     count(k)
+2  render/filter
+2                 render 0     v
+2                 render 1     k
+2                 render 2     v
+3  scan
+3                 table        kv@primary
 
 query ITTT
-EXPLAIN SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
+EXPLAIN(EXPRS) SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
 ----
-0   sort    +"COUNT(*)"
-1   group   v, count(*) GROUP BY (@3)
-2   scan    kv@primary
+0  sort
+0                 order        +"COUNT(*)"
+1  group
+1                 aggregate 0  v
+1                 aggregate 1  count(*)
+1                 render 0     v
+1                 render 1     count(*)
+2  render/filter
+2                 render 0     v
+2                 render 1     *
+2                 render 2     v
+3  scan
+3                 table        kv@primary
 
 query ITTT
-EXPLAIN SELECT v, COUNT(1) FROM kv GROUP BY v ORDER BY COUNT(1)
+EXPLAIN(EXPRS) SELECT v, COUNT(1) FROM kv GROUP BY v ORDER BY COUNT(1)
 ----
-0   sort    +"COUNT(1)"
-1   group   v, count(1) GROUP BY (@3)
-2   scan    kv@primary
+0  sort
+0                 order        +"COUNT(1)"
+1  group
+1                 aggregate 0  v
+1                 aggregate 1  count(1)
+1                 render 0     v
+1                 render 1     count(1)
+2  render/filter
+2                 render 0     v
+2                 render 1     1
+2                 render 2     v
+3  scan
+3                 table        kv@primary

--- a/pkg/sql/testdata/delete
+++ b/pkg/sql/testdata/delete
@@ -134,9 +134,11 @@ k v
 query ITTT colnames
 EXPLAIN DELETE FROM unindexed
 ----
-Level Type   Field Description
-0     delete
-1     scan         unindexed@primary
+Level  Type    Field  Description
+0      delete
+0              from   unindexed
+1      scan
+1              table  unindexed@primary
 
 query II colnames
 SELECT k, v FROM unindexed

--- a/pkg/sql/testdata/distinct
+++ b/pkg/sql/testdata/distinct
@@ -33,8 +33,9 @@ SELECT DISTINCT y, z FROM xyz
 query ITTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz
 ----
-0      distinct
-1      scan           xyz@primary
+0  distinct
+1  scan
+1            table  xyz@primary
 
 query II
 SELECT DISTINCT y, z FROM xyz ORDER BY z
@@ -48,8 +49,11 @@ SELECT DISTINCT y, z FROM xyz ORDER BY z
 query ITTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY z
 ----
-0      distinct y,z
-1      scan     xyz@foo ALL
+0  distinct
+0            key    y, z
+1  scan
+1            table  xyz@foo
+1            spans  ALL
 
 query II
 SELECT DISTINCT y, z FROM xyz ORDER BY y, z
@@ -63,9 +67,13 @@ SELECT DISTINCT y, z FROM xyz ORDER BY y, z
 query ITTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y
 ----
-0      distinct y
-1      sort     +y
-2      scan     xyz@foo ALL
+0  distinct
+0            key    y
+1  sort
+1            order  +y
+2  scan
+2            table  xyz@foo
+2            spans  ALL
 
 query II
 SELECT DISTINCT y, z FROM xyz ORDER BY y, z
@@ -79,9 +87,13 @@ SELECT DISTINCT y, z FROM xyz ORDER BY y, z
 query ITTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y, z
 ----
-0      distinct y,z
-1      sort     +y,+z
-2      scan     xyz@foo ALL
+0  distinct
+0            key    y, z
+1  sort
+1            order  +y,+z
+2  scan
+2            table  xyz@foo
+2            spans  ALL
 
 query I
 SELECT DISTINCT y + z FROM xyz ORDER by (y + z)
@@ -93,9 +105,13 @@ SELECT DISTINCT y + z FROM xyz ORDER by (y + z)
 query ITTT
 EXPLAIN SELECT DISTINCT y + z FROM xyz ORDER BY y + z
 ----
-0      distinct y + z
-1      sort     +"y + z"
-2      scan     xyz@foo ALL
+0  distinct
+0            key    y + z
+1  sort
+1            order  +"y + z"
+2  scan
+2            table  xyz@foo
+2            spans  ALL
 
 query I
 SELECT DISTINCT y AS w FROM xyz ORDER by z
@@ -107,9 +123,12 @@ SELECT DISTINCT y AS w FROM xyz ORDER by z
 query ITTT
 EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY z
 ----
-0      distinct
-1      nosort   +z
-2      scan     xyz@foo ALL
+0  distinct
+1  nosort
+1            order  +z
+2  scan
+2            table  xyz@foo
+2            spans  ALL
 
 query I
 SELECT DISTINCT y AS w FROM xyz ORDER by y
@@ -121,9 +140,13 @@ SELECT DISTINCT y AS w FROM xyz ORDER by y
 query ITTT
 EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY y
 ----
-0      distinct w
-1      sort     +w
-2      scan     xyz@foo ALL
+0  distinct
+0            key    w
+1  sort
+1            order  +w
+2  scan
+2            table  xyz@foo
+2            spans  ALL
 
 # Insert NULL values for z.
 statement ok

--- a/pkg/sql/testdata/explain
+++ b/pkg/sql/testdata/explain
@@ -7,18 +7,16 @@ Level  Type    Field Description
 query ITTTTT colnames
 EXPLAIN (PLAN, METADATA) SELECT 1
 ----
-Level  Type           Field Description    Columns Ordering
-0      select                              ("1")
-1      render/filter        from ()        ("1")
-2      nullrow                             ()
+Level  Type    Field Description    Columns Ordering
+0      select                       ("1")
+1      nullrow                      ()
 
 query ITTTTT colnames
 EXPLAIN (METADATA, PLAN) SELECT 1
 ----
-Level  Type          Field  Description Columns Ordering
-0      select                           ("1")
-1      render/filter        from ()     ("1")
-2      nullrow                          ()
+Level  Type      Field  Description Columns Ordering
+0      select                       ("1")
+1      nullrow                      ()
 
 query ITTT colnames
 EXPLAIN (DEBUG) SELECT 1
@@ -44,8 +42,8 @@ EXPLAIN (TYPES) SELECT 1
 ----
 Level  Type           Field     Description  Columns    Ordering
 0      select                                ("1" int)
-1      render/filter            from ()      ("1" int)
-1      render/filter  render 0  (1)[int]
+1      render/filter                         ("1" int)
+1                     render 0  (1)[int]
 2      nullrow                               ()
 
 statement error cannot set EXPLAIN mode more than once
@@ -64,12 +62,13 @@ EXPLAIN (TRACE, UNKNOWN) SELECT 1
 query ITTTTT
 EXPLAIN(METADATA) EXPLAIN(TRACE) SELECT 1
 ----
-0  select                                          ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition)
-1  sort                    +Timestamp,+"Span Pos"  ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition)
-2  explain                 trace                   ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition, Timestamp)
-3  select                                          ("1")
-4  render/filter(debug)    from ()                 ("1")
-5  nullrow                                         ()
+0  select                                  ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition)
+1  sort                                    ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition)
+1                 order  +Timestamp,+"Span Pos"
+2  explain trace                           ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition, Timestamp)
+3  select                                  ("1")
+3                 mode   debug
+4  nullrow                                 ()
 
 # Ensure that all relevant statement types can be explained
 query ITTT
@@ -112,9 +111,10 @@ EXPLAIN ALTER TABLE foo ADD COLUMN y INT
 0 alter table
 
 query ITTT
-EXPLAIN ALTER TABLE foo SPLIT AT (42)
+EXPLAIN (EXPRS) ALTER TABLE foo SPLIT AT (42)
 ----
-0 split 42
+0 split
+0        expr 0   42
 
 query ITTT
 EXPLAIN DROP TABLE foo
@@ -124,79 +124,107 @@ EXPLAIN DROP TABLE foo
 query ITTT
 EXPLAIN SHOW DATABASES
 ----
-0  sort           +Database
-1  virtual table  information_schema.schemata
-2  values         4 columns, 5 rows
+0  sort
+0                 order   +Database
+1  virtual table
+1                 source  information_schema.schemata
+2  values
+2                 size    4 columns, 5 rows
 
 query ITTT
 EXPLAIN SHOW TABLES
 ----
-0  virtual table  SHOW TABLES FROM test
-1  values         1 column, 1 row
+0  virtual table
+0                 source  SHOW TABLES FROM test
+1  values
+1                 size    1 column, 1 row
 
 query ITTT
 EXPLAIN SHOW DATABASE
 ----
-0 virtual table SHOW DATABASE
-1 values 1 column, 1 row
+0 virtual table
+0                 source  SHOW DATABASE
+1 values
+1                 size    1 column, 1 row
 
 query ITTT
 EXPLAIN SHOW TIME ZONE
 ----
-0 virtual table SHOW TIME ZONE
-1 values 1 column, 1 row
+0 virtual table
+0                 source  SHOW TIME ZONE
+1 values
+1                 size    1 column, 1 row
 
 query ITTT
 EXPLAIN SHOW SYNTAX
 ----
-0 virtual table SHOW SYNTAX
-1 values 1 column, 1 row
+0 virtual table
+0                 source  SHOW SYNTAX
+1 values
+1                 size    1 column, 1 row
 
 query ITTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
 ----
-0 virtual table SHOW DEFAULT_TRANSACTION_ISOLATION
-1 values 1 column, 1 row
+0 virtual table
+0                 source  SHOW DEFAULT_TRANSACTION_ISOLATION
+1 values
+1                 size    1 column, 1 row
 
 query ITTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
 ----
-0 virtual table SHOW TRANSACTION ISOLATION LEVEL
-1 values 1 column, 1 row
+0  virtual table
+0                 source  SHOW TRANSACTION ISOLATION LEVEL
+1  values
+1                 size    1 column, 1 row
 
 query ITTT
 EXPLAIN SHOW TRANSACTION PRIORITY
 ----
-0 virtual table SHOW TRANSACTION PRIORITY
-1 values 1 column, 1 row
+0  virtual table
+0                 source  SHOW TRANSACTION PRIORITY
+1  values
+1                 size    1 column, 1 row
 
 query ITTT
 EXPLAIN SHOW COLUMNS FROM foo
 ----
-0  virtual table  SHOW COLUMNS FROM foo
-1  values         4 columns, 1 row
+0  virtual table
+0                 source  SHOW COLUMNS FROM foo
+1  values
+1                 size    4 columns, 1 row
 
 query ITTT
 EXPLAIN SHOW GRANTS ON foo
 ----
-0  virtual table  SHOW GRANTS
-1  sort           +"Table",+"User",+Privileges
-2  values         3 columns, 1 row
+0  virtual table
+0                 source  SHOW GRANTS
+1  sort
+1                 order   +"Table",+"User",+Privileges
+2  values
+2                 size    3 columns, 1 row
 
 query ITTT
 EXPLAIN SHOW INDEX FROM foo
 ----
-0 virtual table SHOW INDEX FROM foo
-1 values 7 columns, 2 rows
+0  virtual table
+0                 source  SHOW INDEX FROM foo
+1  values
+1                 size    7 columns, 2 rows
 
 query ITTT
 EXPLAIN SHOW CONSTRAINTS FROM foo
 ----
-0 virtual table SHOW CONSTRAINTS FROM foo
-1 sort          +"Table",+Name
-2 values        5 columns, 1 row
+0  virtual table
+0                 source  SHOW CONSTRAINTS FROM foo
+1  sort
+1                 order   +"Table",+Name
+2  values
+2                 size    5 columns, 1 row
 
 query ITTT
 EXPLAIN SHOW USERS
 ----
-0 scan users@primary
+0  scan
+0        table  users@primary

--- a/pkg/sql/testdata/explain_plan
+++ b/pkg/sql/testdata/explain_plan
@@ -7,8 +7,10 @@ CREATE TABLE t (
 query ITTT
 EXPLAIN INSERT INTO t VALUES (1, 2)
 ----
-0      insert
-1      values 2 columns, 1 row
+0  insert
+0          into  t(k, v)
+1  values
+1          size  2 columns, 1 row
 
 statement ok
 INSERT INTO t VALUES (1, 2)
@@ -16,59 +18,83 @@ INSERT INTO t VALUES (1, 2)
 query ITTT
 EXPLAIN SELECT * FROM t
 ----
-0      scan  t@primary
+0  scan
+0        table  t@primary
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM t
 ----
-0      select                                   (k, v)  +k,unique
-1      render/filter from (test.t.k, test.t.v)  (k, v)  +k,unique
-2      scan          t@primary                  (k, v)  +k,unique
+0  select                    (k, v)  +k,unique
+1  scan                      (k, v)  +k,unique
+1          table  t@primary
 
 query ITTT
 EXPLAIN SELECT * FROM t WHERE k = 1 OR k = 3
 ----
-0      scan  t@primary /1-/2 /3-/4
+0  scan
+0        table  t@primary
+0        spans  /1-/2 /3-/4
 
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE k % 2 = 0
 ----
-0  select                                              (k, v)  +k,unique
-1  render/filter            from (test.t.k, test.t.v)  (k, v)  +k,unique
-1  render/filter  render 0  test.t.k
-1  render/filter  render 1  test.t.v
-2  scan                     t@primary ALL              (k, v)  +k,unique
-2  scan           filter    (k % 2) = 0
+0  select                                (k, v)  +k,unique
+1  render/filter                         (k, v)  +k,unique
+1                 render 0  test.t.k
+1                 render 1  test.t.v
+2  scan                                  (k, v)  +k,unique
+2                 table     t@primary
+2                 spans     ALL
+2                 filter    (k % 2) = 0
 
 query ITTT
 EXPLAIN VALUES (1, 2, 3), (4, 5, 6)
 ----
-0      values  3 columns, 2 rows
+0  values
+0          size  3 columns, 2 rows
 
 query ITTT
 EXPLAIN VALUES (1)
 ----
-0      values  1 column, 1 row
+0  values
+0          size  1 column, 1 row
 
 query ITTT
-EXPLAIN SELECT * FROM t WITH ORDINALITY LIMIT 1 OFFSET 1
+EXPLAIN(EXPRS) SELECT * FROM t WITH ORDINALITY LIMIT 1 OFFSET 1
 ----
-0      limit   count: 1, offset:  1
-1      ordinality
-2      scan    t@primary (max 2 rows)
+0  limit
+0                 count     1
+0                 offset    1
+1  render/filter
+1                 render 0  k
+1                 render 1  v
+1                 render 2  ordinality
+2  ordinality
+3  scan
+3                 table     t@primary
+3                 limit     2
 
 query ITTT
 EXPLAIN SELECT DISTINCT * FROM t
 ----
-0      distinct k
-1      scan     t@primary
+0  distinct
+0            key    k
+1  scan
+1            table  t@primary
 
 query ITTT
-EXPLAIN SELECT DISTINCT * FROM t LIMIT 1 OFFSET 1
+EXPLAIN(EXPRS) SELECT DISTINCT * FROM t LIMIT 1 OFFSET 1
 ----
-0      limit    count: 1, offset:  1
-1      distinct k
-2      scan     t@primary
+0  limit
+0                 count     1
+0                 offset    1
+1  distinct
+1                 key       k
+2  render/filter
+2                 render 0  k
+2                 render 1  v
+3  scan
+3                 table     t@primary
 
 statement ok
 CREATE TABLE tc (a INT, b INT, INDEX c(a))
@@ -76,9 +102,12 @@ CREATE TABLE tc (a INT, b INT, INDEX c(a))
 query ITTTTT
 EXPLAIN(METADATA) SELECT * FROM tc WHERE a = 10 ORDER BY b
 ----
-0      select                                                      (a, b)                          +b
-1      sort           +b                                           (a, b)                          +b
-2      render/filter  from (test.tc.a, test.tc.b, *test.tc.rowid)  (a, b)                          =a
-3      index-join                                                  (a, b, rowid[hidden,omitted])   =a,+rowid,unique
-4      scan           tc@c /10-/11                                 (a, b[omitted], rowid[hidden])  =a,+rowid,unique
-4      scan           tc@primary                                   (a, b, rowid[hidden,omitted])   +rowid,unique
+0  select                         (a, b)                          +b
+1  sort                           (a, b)                          +b
+1              order  +b
+2  index-join                     (a, b, rowid[hidden,omitted])   =a,+rowid,unique
+3  scan                           (a, b[omitted], rowid[hidden])  =a,+rowid,unique
+3              table  tc@c
+3              spans  /10-/11
+3  scan                           (a, b, rowid[hidden,omitted])   +rowid,unique
+3              table  tc@primary

--- a/pkg/sql/testdata/explain_types
+++ b/pkg/sql/testdata/explain_types
@@ -7,11 +7,13 @@ CREATE TABLE t (
 query ITTTTT colnames
 EXPLAIN (TYPES) INSERT INTO t VALUES (1, 2)
 ----
-Level  Type    Field          Description                 Columns                     Ordering
-0      insert                 into t (k, v) returning ()  ()
-1      values                 2 columns, 1 row            (column1 int, column2 int)
-1      values  row 0, expr 0  (1)[int]
-1      values  row 0, expr 1  (2)[int]
+Level  Type    Field          Description       Columns                     Ordering
+0      insert                                   ()
+0              into           t(k, v)
+1      values                                   (column1 int, column2 int)
+1              size           2 columns, 1 row
+1              row 0, expr 0  (1)[int]
+1              row 0, expr 1  (2)[int]
 
 statement ok
 INSERT INTO t VALUES (1, 2)
@@ -20,210 +22,257 @@ query ITTTTT
 EXPLAIN (TYPES) SELECT 42;
 ----
 0  select                              ("42" int)
-1  render/filter            from ()    ("42" int)
-1  render/filter  render 0  (42)[int]
+1  render/filter                       ("42" int)
+1                 render 0  (42)[int]
 2  nullrow                             ()
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT * FROM t
 ----
-0  select                                              (k int, v int)  +k,unique
-1  render/filter            from (test.t.k, test.t.v)  (k int, v int)  +k,unique
-1  render/filter  render 0  (k)[int]
-1  render/filter  render 1  (v)[int]
-2  scan                     t@primary                  (k int, v int)  +k,unique
+0  select                              (k int, v int)  +k,unique
+1  render/filter                       (k int, v int)  +k,unique
+1                 render 0  (k)[int]
+1                 render 1  (v)[int]
+2  scan                                (k int, v int)  +k,unique
+2                 table     t@primary
 
 query ITTTTT
 EXPLAIN (TYPES, SYMVARS) SELECT * FROM t
 ----
-0  select                                              (k int, v int)  +k,unique
-1  render/filter            from (test.t.k, test.t.v)  (k int, v int)  +k,unique
-1  render/filter  render 0  (@1)[int]
-1  render/filter  render 1  (@2)[int]
-2  scan                     t@primary                  (k int, v int)  +k,unique
+0  select                              (k int, v int)  +k,unique
+1  render/filter                       (k int, v int)  +k,unique
+1                 render 0  (@1)[int]
+1                 render 1  (@2)[int]
+2  scan                                (k int, v int)  +k,unique
+2                 table     t@primary
 
 query ITTTTT
 EXPLAIN (TYPES, QUALIFY) SELECT * FROM t
 ----
-0  select                                              (k int, v int)  +k,unique
-1  render/filter            from (test.t.k, test.t.v)  (k int, v int)  +k,unique
-1  render/filter  render 0  (test.t.k)[int]
-1  render/filter  render 1  (test.t.v)[int]
-2  scan                     t@primary                  (k int, v int)  +k,unique
+0  select                                    (k int, v int)  +k,unique
+1  render/filter                             (k int, v int)  +k,unique
+1                 render 0  (test.t.k)[int]
+1                 render 1  (test.t.v)[int]
+2  scan                                      (k int, v int)  +k,unique
+2                 table     t@primary
 
 query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT * FROM t WHERE v > 123
 ----
 0  select                                                  (k int, v int)
-1  render/filter            from (test.t.k, test.t.v)      (k int, v int)
-1  render/filter  filter    ((v)[int] > (123)[int])[bool]
-1  render/filter  render 0  (k)[int]
-1  render/filter  render 1  (v)[int]
-2  scan                     t@primary                      (k int, v int)
+1  render/filter                                           (k int, v int)
+1                 filter    ((v)[int] > (123)[int])[bool]
+1                 render 0  (k)[int]
+1                 render 1  (v)[int]
+2  scan                                                    (k int, v int)
+2                 table     t@primary
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT * FROM t WHERE v > 123
 ----
 0  select                                                  (k int, v int)  +k,unique
-1  render/filter            from (test.t.k, test.t.v)      (k int, v int)  +k,unique
-1  render/filter  render 0  (k)[int]
-1  render/filter  render 1  (v)[int]
-2  scan                     t@primary ALL                  (k int, v int)  +k,unique
-2  scan           filter    ((v)[int] > (123)[int])[bool]
+1  render/filter                                           (k int, v int)  +k,unique
+1                 render 0  (k)[int]
+1                 render 1  (v)[int]
+2  scan                                                    (k int, v int)  +k,unique
+2                 table     t@primary
+2                 spans     ALL
+2                 filter    ((v)[int] > (123)[int])[bool]
 
 query ITTTTT
 EXPLAIN (TYPES) VALUES (1, 2, 3), (4, 5, 6)
 ----
 0  select                                    (column1 int, column2 int, column3 int)
-1  values                 3 columns, 2 rows  (column1 int, column2 int, column3 int)
-1  values  row 0, expr 0  (1)[int]
-1  values  row 0, expr 1  (2)[int]
-1  values  row 0, expr 2  (3)[int]
-1  values  row 1, expr 0  (4)[int]
-1  values  row 1, expr 1  (5)[int]
-1  values  row 1, expr 2  (6)[int]
+1  values                                    (column1 int, column2 int, column3 int)
+1          size           3 columns, 2 rows
+1          row 0, expr 0  (1)[int]
+1          row 0, expr 1  (2)[int]
+1          row 0, expr 2  (3)[int]
+1          row 1, expr 0  (4)[int]
+1          row 1, expr 1  (5)[int]
+1          row 1, expr 2  (6)[int]
 
 query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2
 ----
-0  select                                                             (z int, v int)
-0  select         having    ((v)[int] < (2)[int])[bool]
-0  select         render z  ((2)[int] * (count((k)[int]))[int])[int]
-0  select         render v  (v)[int]
-1  render/filter            from (test.t.k, test.t.v)                 ("2" int, k int, v int, "v < 2" bool, v int)
-1  render/filter  filter    ((v)[int] > (123)[int])[bool]
-1  render/filter  render 0  (2)[int]
-1  render/filter  render 1  (k)[int]
-1  render/filter  render 2  (v)[int]
-1  render/filter  render 3  ((v)[int] < (2)[int])[bool]
-1  render/filter  render 4  (v)[int]
-2  scan                     t@primary                                 (k int, v int)
+0  select                                                                (z int, v int)
+1  group                                                                 (z int, v int)
+1                 aggregate 0  (2)[int]
+1                 aggregate 1  (count((k)[int]))[int]
+1                 aggregate 2  (v)[int]
+1                 aggregate 3  ((v)[int] < (2)[int])[bool]
+1                 render 0     ((2)[int] * (count((k)[int]))[int])[int]
+1                 render 1     (v)[int]
+1                 having       ((v)[int] < (2)[int])[bool]
+1  render/filter                                                         ("2" int, k int, v int, "v < 2" bool, v int)
+1                 filter       ((v)[int] > (123)[int])[bool]
+1                 render 0     (2)[int]
+1                 render 1     (k)[int]
+1                 render 2     (v)[int]
+1                 render 3     ((v)[int] < (2)[int])[bool]
+1                 render 4     (v)[int]
+2  scan                                                                  (k int, v int)
+2                 table        t@primary
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2
 ----
-0  select                                                                     (z int, v int)
-1  group                    2, count(k), v, v < 2 GROUP BY (@5) HAVING v < 2  (z int, v int)
-1  group          having    ((v)[int] < (2)[int])[bool]
-1  group          render z  ((2)[int] * (count((k)[int]))[int])[int]
-1  group          render v  (v)[int]
-2  render/filter            from (test.t.k, test.t.v)                         ("2" int, k int, v int, "v < 2" bool, v int)  +k,unique
-2  render/filter  render 0  (2)[int]
-2  render/filter  render 1  (k)[int]
-2  render/filter  render 2  (v)[int]
-2  render/filter  render 3  ((v)[int] < (2)[int])[bool]
-2  render/filter  render 4  (v)[int]
-3  scan                     t@primary ALL                                     (k int, v int)                                +k,unique
-3  scan           filter    ((v)[int] > (123)[int])[bool]
+0  select                                                                (z int, v int)
+1  group                                                                 (z int, v int)
+1                 aggregate 0  (2)[int]
+1                 aggregate 1  (count((k)[int]))[int]
+1                 aggregate 2  (v)[int]
+1                 aggregate 3  ((v)[int] < (2)[int])[bool]
+1                 render 0     ((2)[int] * (count((k)[int]))[int])[int]
+1                 render 1     (v)[int]
+1                 having       ((v)[int] < (2)[int])[bool]
+2  render/filter                                                         ("2" int, k int, v int, "v < 2" bool, v int)  +k,unique
+2                 render 0     (2)[int]
+2                 render 1     (k)[int]
+2                 render 2     (v)[int]
+2                 render 3     ((v)[int] < (2)[int])[bool]
+2                 render 4     (v)[int]
+3  scan                                                                  (k int, v int)                                +k,unique
+3                 table        t@primary
+3                 spans        ALL
+3                 filter       ((v)[int] > (123)[int])[bool]
 
 query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) DELETE FROM t WHERE v > 1
 ----
-0  delete                   from t returning ()          ()
+0  delete                                                ()
+0                 from      t
 1  select                                                (k int)
-2  render/filter            from (test.t.k, test.t.v)    (k int)
-2  render/filter  filter    ((v)[int] > (1)[int])[bool]
-2  render/filter  render 0  (k)[int]
-3  scan                     t@primary                    (k int, v int)
+2  render/filter                                         (k int)
+2                 filter    ((v)[int] > (1)[int])[bool]
+2                 render 0  (k)[int]
+3  scan                                                  (k int, v int)
+3                 table     t@primary
 
 query ITTTTT
 EXPLAIN (TYPES) DELETE FROM t WHERE v > 1
 ----
-0  delete                   from t returning ()          ()              +@1,unique
+0  delete                                                ()              +@1,unique
+0                 from      t
 1  select                                                (k int)         +k,unique
-2  render/filter            from (test.t.k, test.t.v)    (k int)         +k,unique
-2  render/filter  render 0  (k)[int]
-3  scan                     t@primary ALL                (k int, v int)  +k,unique
-3  scan           filter    ((v)[int] > (1)[int])[bool]
+2  render/filter                                         (k int)         +k,unique
+2                 render 0  (k)[int]
+3  scan                                                  (k int, v int)  +k,unique
+3                 table     t@primary
+3                 spans     ALL
+3                 filter    ((v)[int] > (1)[int])[bool]
 
 query ITTTTT
 EXPLAIN (TYPES) UPDATE t SET v = k + 1 WHERE v > 123
 ----
-0  update                   set t (v) returning ()         ()                           +@1,unique
+0  update                                                  ()                           +@1,unique
+0                 table     t
+0                 set       v
 1  select                                                  (k int, v int, "k + 1" int)  +k,unique
-2  render/filter            from (test.t.k, test.t.v)      (k int, v int, "k + 1" int)  +k,unique
-2  render/filter  render 0  (k)[int]
-2  render/filter  render 1  (v)[int]
-2  render/filter  render 2  ((k)[int] + (1)[int])[int]
-3  scan                     t@primary ALL                  (k int, v int)               +k,unique
-3  scan           filter    ((v)[int] > (123)[int])[bool]
+2  render/filter                                           (k int, v int, "k + 1" int)  +k,unique
+2                 render 0  (k)[int]
+2                 render 1  (v)[int]
+2                 render 2  ((k)[int] + (1)[int])[int]
+3  scan                                                    (k int, v int)               +k,unique
+3                 table     t@primary
+3                 spans     ALL
+3                 filter    ((v)[int] > (123)[int])[bool]
 
 query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) UPDATE t SET v = k + 1 WHERE v > 123
 ----
-0  update                   set t (v) returning ()         ()
+0  update                                                  ()
+0                 table     t
+0                 set       v
 1  select                                                  (k int, v int, "k + 1" int)
-2  render/filter            from (test.t.k, test.t.v)      (k int, v int, "k + 1" int)
-2  render/filter  filter    ((v)[int] > (123)[int])[bool]
-2  render/filter  render 0  (k)[int]
-2  render/filter  render 1  (v)[int]
-2  render/filter  render 2  ((k)[int] + (1)[int])[int]
-3  scan                     t@primary                      (k int, v int)
+2  render/filter                                           (k int, v int, "k + 1" int)
+2                 filter    ((v)[int] > (123)[int])[bool]
+2                 render 0  (k)[int]
+2                 render 1  (v)[int]
+2                 render 2  ((k)[int] + (1)[int])[int]
+3  scan                                                    (k int, v int)
+3                 table     t@primary
 
 query ITTTTT
 EXPLAIN (TYPES) VALUES (1) UNION VALUES (2)
 ----
 0  select                                  (column1 int)
-1  union                  -                (column1 int)
+1  union                                   (column1 int)
 2  select                                  (column1 int)
-3  values                 1 column, 1 row  (column1 int)
-3  values  row 0, expr 0  (1)[int]
+3  values                                  (column1 int)
+3          size           1 column, 1 row
+3          row 0, expr 0  (1)[int]
 2  select                                  (column1 int)
-3  values                 1 column, 1 row  (column1 int)
-3  values  row 0, expr 0  (2)[int]
+3  values                                  (column1 int)
+3          size           1 column, 1 row
+3          row 0, expr 0  (2)[int]
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT DISTINCT k FROM t
 ----
-0  select                                              (k int)                  +k,unique
-1  distinct                 k                          (k int)                  +k,unique
-2  render/filter            from (test.t.k, test.t.v)  (k int)                  +k,unique
-2  render/filter  render 0  (k)[int]
-3  scan                     t@primary                  (k int, v[omitted] int)  +k,unique
+0  select                              (k int)                  +k,unique
+1  distinct                            (k int)                  +k,unique
+1                 key       k
+2  render/filter                       (k int)                  +k,unique
+2                 render 0  (k)[int]
+3  scan                                (k int, v[omitted] int)  +k,unique
+3                 table     t@primary
 
 query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT DISTINCT k FROM t
 ----
-0  select                                              (k int)
-1  render/filter            from (test.t.k, test.t.v)  (k int)
-1  render/filter  render 0  (k)[int]
-2  scan                     t@primary                  (k int, v int)
+0  select                              (k int)
+1  distinct                            (k int)
+1  render/filter                       (k int)
+1                 render 0  (k)[int]
+2  scan                                (k int, v int)
+2                 table     t@primary
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT v FROM t ORDER BY v
 ----
-0  select                                              (v int)                  +v
-1  sort                     +v                         (v int)                  +v
-2  render/filter            from (test.t.k, test.t.v)  (v int)
-2  render/filter  render 0  (v)[int]
-3  scan                     t@primary ALL              (k[omitted] int, v int)  +k,unique
+0  select                              (v int)                  +v
+1  sort                                (v int)                  +v
+1                 order     +v
+2  render/filter                       (v int)
+2                 render 0  (v)[int]
+3  scan                                (k[omitted] int, v int)  +k,unique
+3                 table     t@primary
+3                 spans     ALL
 
 query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT v FROM t ORDER BY v
 ----
-0  select                                              (v int)
-1  render/filter            from (test.t.k, test.t.v)  (v int)
-1  render/filter  render 0  (v)[int]
-2  scan                     t@primary                  (k int, v int)
+0  select                              (v int)         +v
+1  nosort                              (v int)         +v
+1                 order     +@1
+1  render/filter                       (v int)
+1                 render 0  (v)[int]
+2  scan                                (k int, v int)
+2                 table     t@primary
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT v FROM t LIMIT 1
 ----
-0  select                                              (v int)
-1  limit                    count: 1                   (v int)
-1  limit          count     (1)[int]
-2  render/filter            from (test.t.k, test.t.v)  (v int)
-2  render/filter  render 0  (v)[int]
-3  scan                     t@primary (max 1 row)      (k[omitted] int, v int)  +k,unique
+0  select                              (v int)
+1  limit                               (v int)
+1                 count     (1)[int]
+2  render/filter                       (v int)
+2                 render 0  (v)[int]
+3  scan                                (k[omitted] int, v int)  +k,unique
+3                 table     t@primary
+3                 limit     1
 
 query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT v FROM t LIMIT 1
 ----
-0  select                                              (v int)
-0  select         count     (1)[int]
-1  render/filter            from (test.t.k, test.t.v)  (v int)
-1  render/filter  render 0  (v)[int]
-2  scan                     t@primary                  (k int, v int)
+0  select                              (v int)
+1  limit                               (v int)
+1                 count     (1)[int]
+1  render/filter                       (v int)
+1                 render 0  (v)[int]
+2  scan                                (k int, v int)
+2                 table     t@primary
 
 statement ok
 CREATE TABLE tt (x INT, y INT, INDEX a(x), INDEX b(y))
@@ -231,46 +280,50 @@ CREATE TABLE tt (x INT, y INT, INDEX a(x), INDEX b(y))
 query ITTTTT
 EXPLAIN (TYPES) SELECT * FROM tt WHERE x < 10 AND y > 10
 ----
-0  select                                                                (x int, y int)                              +x
-1  render/filter            from (test.tt.x, test.tt.y, *test.tt.rowid)  (x int, y int)                              +x
-1  render/filter  render 0  (x)[int]
-1  render/filter  render 1  (y)[int]
-2  index-join                                                            (x int, y int, rowid[hidden,omitted] int)   +x,+rowid,unique
-3  scan                     tt@a /#-/10                                  (x int, y[omitted] int, rowid[hidden] int)  +x,+rowid,unique
-3  scan           filter    ((x)[int] < (10)[int])[bool]
-3  scan                     tt@primary                                   (x int, y int, rowid[hidden,omitted] int)   +rowid,unique
-3  scan           filter    ((y)[int] > (10)[int])[bool]
+0  select                                                 (x int, y int)                              +x
+1  render/filter                                          (x int, y int)                              +x
+1                 render 0  (x)[int]
+1                 render 1  (y)[int]
+2  index-join                                             (x int, y int, rowid[hidden,omitted] int)   +x,+rowid,unique
+3  scan                                                   (x int, y[omitted] int, rowid[hidden] int)  +x,+rowid,unique
+3                 table     tt@a
+3                 spans     /#-/10
+3                 filter    ((x)[int] < (10)[int])[bool]
+3  scan                                                   (x int, y int, rowid[hidden,omitted] int)   +rowid,unique
+3                 table     tt@primary
+3                 filter    ((y)[int] > (10)[int])[bool]
 
 query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT * FROM tt WHERE x < 10 AND y > 10
 ----
 0  select                                                                                              (x int, y int)
-1  render/filter            from (test.tt.x, test.tt.y, *test.tt.rowid)                                (x int, y int)
-1  render/filter  filter    ((((x)[int] < (10)[int])[bool]) AND (((y)[int] > (10)[int])[bool]))[bool]
-1  render/filter  render 0  (x)[int]
-1  render/filter  render 1  (y)[int]
-2  scan                     tt@primary                                                                 (x int, y int, rowid[hidden] int)
+1  render/filter                                                                                       (x int, y int)
+1                 filter    ((((x)[int] < (10)[int])[bool]) AND (((y)[int] > (10)[int])[bool]))[bool]
+1                 render 0  (x)[int]
+1                 render 1  (y)[int]
+2  scan                                                                                                (x int, y int, rowid[hidden] int)
+2                 table     tt@primary
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT $1 + 2 AS a
 ----
 0  select                                                (a int)
-1  render/filter            from ()                      (a int)
-1  render/filter  render 0  (($1)[int] + (2)[int])[int]
+1  render/filter                                         (a int)
+1                 render 0  (($1)[int] + (2)[int])[int]
 2  nullrow                                               ()
 
 query ITTTTT
 EXPLAIN (TYPES, NONORMALIZE) SELECT ABS(2-3) AS a
 ----
 0  select                                          (a int)
-1  render/filter            from ()                (a int)
-1  render/filter  render 0  (abs((-1)[int]))[int]
+1  render/filter                                   (a int)
+1                 render 0  (abs((-1)[int]))[int]
 2  nullrow                                         ()
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT ABS(2-3) AS a
 ----
 0  select                             (a int)
-1  render/filter            from ()   (a int)
-1  render/filter  render 0  (1)[int]
+1  render/filter                      (a int)
+1                 render 0  (1)[int]
 2  nullrow                            ()

--- a/pkg/sql/testdata/insert
+++ b/pkg/sql/testdata/insert
@@ -488,11 +488,17 @@ statement ok
 INSERT INTO select_t VALUES(1, 2),(2,3),(3,4)
 
 query ITTT
-EXPLAIN (PLAN) INSERT INTO insert_t SELECT * FROM select_t LIMIT 1
+EXPLAIN (PLAN,EXPRS) INSERT INTO insert_t SELECT * FROM select_t LIMIT 1
 ----
 0  insert
-1  limit   count: 1
-2  scan    select_t@primary
+0                 into      insert_t(x, v)
+1  limit
+1                 count     1
+2  render/filter
+2                 render 0  x
+2                 render 1  v
+3  scan
+3                 table     select_t@primary
 
 statement ok
 INSERT INTO insert_t SELECT * FROM select_t LIMIT 1
@@ -517,22 +523,28 @@ query ITTT
 EXPLAIN (PLAN) INSERT INTO insert_t VALUES(1,'AAA'),(2,'BBB') LIMIT 1
 ----
 0  insert
-1  limit   count: 1
-2  values  2 columns, 2 rows
+0          into           insert_t(x, v)
+1  limit
+2  values
+2          size           2 columns, 2 rows
 
 query ITTT
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES(1,'AAA'),(2,'BBB')) LIMIT 1
 ----
 0  insert
-1  limit   count: 1
-2  values  2 columns, 2 rows
+0          into           insert_t(x, v)
+1  limit
+2  values
+2          size           2 columns, 2 rows
 
 query ITTT
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES(1,'AAA'),(2,'BBB') LIMIT 1)
 ----
 0  insert
-1  limit   count: 1
-2  values  2 columns, 2 rows
+0          into  insert_t(x, v)
+1  limit
+2  values
+2          size  2 columns, 2 rows
 
 statement error pq: multiple LIMIT clauses not allowed
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES(1,'AAA'),(2,'BBB') LIMIT 1) LIMIT 1

--- a/pkg/sql/testdata/join
+++ b/pkg/sql/testdata/join
@@ -407,56 +407,114 @@ x  x  y  b  d  e
 
 # Check EXPLAIN.
 query ITTT
-EXPLAIN SELECT * FROM onecolumn JOIN twocolumn USING(x)
+EXPLAIN(EXPRS) SELECT * FROM onecolumn JOIN twocolumn USING(x)
 ----
-0  join  INNER ON EQUALS((x),(x))
-1  scan  onecolumn@primary
-1  scan  twocolumn@primary
+0  render/filter
+0                 render 0  x
+0                 render 1  y
+1  join
+1                 type      inner
+1                 equality  (x) = (x)
+2  scan
+2                 table     onecolumn@primary
+2  scan
+2                 table     twocolumn@primary
 
 # Check EXPLAIN.
 query ITTT
-EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
+EXPLAIN(EXPRS) SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
 ----
-0  join  INNER ON EQUALS((x),(y))
-1  scan  twocolumn@primary
-1  scan  twocolumn@primary
+0  render/filter
+0                 render 0  x
+0                 render 1  y
+0                 render 2  x
+0                 render 3  y
+1  join
+1                 type      inner
+1                 equality  (x) = (y)
+2  scan
+2                 table     twocolumn@primary
+2  scan
+2                 table     twocolumn@primary
 
 # Check EXPLAIN.
 query ITTT
-EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
+EXPLAIN(EXPRS) SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
 ----
-0  join  INNER ON a.x = 44
-1  scan  twocolumn@primary
-1  scan  twocolumn@primary
+0  render/filter
+0                 render 0  x
+0                 render 1  y
+0                 render 2  x
+0                 render 3  y
+1  join
+1                 type      inner
+1                 filter    a.x = 44
+2  scan
+2                 table     twocolumn@primary
+2  scan
+2                 table     twocolumn@primary
 
 # Check EXPLAIN.
 query ITTT
-EXPLAIN SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
+EXPLAIN(EXPRS) SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
 ----
-0  join  INNER ON EQUALS((x),(y))
-1  scan  onecolumn@primary
-1  scan  twocolumn@primary
+0  render/filter
+0                 render 0  x
+0                 render 1  x
+0                 render 2  y
+1  join
+1                 type      inner
+1                 equality  (x) = (y)
+2  scan
+2                 table     onecolumn@primary
+2  scan
+2                 table     twocolumn@primary
 
 # Check EXPLAIN.
 query ITTT
-EXPLAIN SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
+EXPLAIN(EXPRS) SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
 ----
-0  join  INNER ON EQUALS((x),(y))
-1  scan  onecolumn@primary
-1  scan  twocolumn@primary
+0  render/filter
+0                 render 0  x
+0                 render 1  x
+0                 render 2  y
+1  join
+1                 type      inner
+1                 equality  (x) = (y)
+2  scan
+2                 table     onecolumn@primary
+2  scan
+2                 table     twocolumn@primary
 
 
 query ITTT
-EXPLAIN SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twocolumn.x JOIN twocolumn AS c(d,e) ON a.b=c.d AND c.d=onecolumn.x) LIMIT 1
+EXPLAIN(EXPRS) SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twocolumn.x JOIN twocolumn AS c(d,e) ON a.b=c.d AND c.d=onecolumn.x) LIMIT 1
 ----
-0  limit  count: 1
-1  join   INNER ON (a.b = c.d) AND (c.d = test.onecolumn.x)
-2  join   INNER ON EQUALS((x),(b))
-3  join   CROSS
-4  scan   onecolumn@primary
-4  scan   twocolumn@primary
-3  scan   onecolumn@primary
-2  scan   twocolumn@primary
+0  limit
+0                 count     1
+1  render/filter
+1                 render 0  x
+1                 render 1  x
+1                 render 2  y
+1                 render 3  b
+1                 render 4  d
+1                 render 5  e
+2  join
+2                 type      inner
+2                 filter    (a.b = c.d) AND (c.d = test.onecolumn.x)
+3  join
+3                 type      inner
+3                 equality  (x) = (b)
+4  join
+4                 type      cross
+5  scan
+5                 table     onecolumn@primary
+5  scan
+5                 table     twocolumn@primary
+4  scan
+4                 table     onecolumn@primary
+3  scan
+3                 table     twocolumn@primary
 
 # Check sub-queries in ON conditions.
 query III colnames
@@ -556,53 +614,66 @@ CREATE TABLE s(x INT); INSERT INTO s(x) VALUES (1),(2),(3),(4),(5),(6),(7),(8),(
 query ITTTTT
 EXPLAIN (METADATA) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
 ----
-0  select                                                                          (x, y)
-1  render/filter  from ("".a.x, "".a.y, *"".a.rowid, "".b.x, "".b.y, *"".b.rowid)  (x, y)
-2  join           CROSS                                                            (x, y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])
-3  scan           twocolumn@primary                                                (x, y[omitted], rowid[hidden,omitted])
-3  scan           twocolumn@primary                                                (x[omitted], y, rowid[hidden,omitted])
-
+0  select                            (x, y)
+1  join                              (x, y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])
+1          type   cross
+2  scan                              (x, y[omitted], rowid[hidden,omitted])
+2          table  twocolumn@primary
+2  scan                              (x[omitted], y, rowid[hidden,omitted])
+2          table  twocolumn@primary
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
 ----
-0  select                                                                                     (y)
-1  render/filter  from (""."".x, *"".a.x, "".a.y, *"".a.rowid, *"".b.x, "".b.y, *"".b.rowid)  (y)
-2  join           INNER ON EQUALS((x),(x))                                                    (x[omitted], x[hidden,omitted], y[omitted], rowid[hidden,omitted], x[hidden,omitted], y, rowid[hidden,omitted])
-3  scan           twocolumn@primary                                                           (x, y[omitted], rowid[hidden,omitted])
-3  scan           twocolumn@primary                                                           (x, y, rowid[hidden,omitted])
+0  select                               (y)
+1  join                                 (x[omitted], x[hidden,omitted], y[omitted], rowid[hidden,omitted], x[hidden,omitted], y, rowid[hidden,omitted])
+1          type      inner
+1          equality  (x) = (x)
+2  scan                                 (x, y[omitted], rowid[hidden,omitted])
+2          table     twocolumn@primary
+2  scan                                 (x, y, rowid[hidden,omitted])
+2          table     twocolumn@primary
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b.x)
 ----
-0  select                                                                          (y)
-1  render/filter  from ("".a.x, "".a.y, *"".a.rowid, "".b.x, "".b.y, *"".b.rowid)  (y)
-2  join           INNER ON EQUALS((x),(x))                                         (x[omitted], y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])
-3  scan           twocolumn@primary                                                (x, y[omitted], rowid[hidden,omitted])
-3  scan           twocolumn@primary                                                (x, y, rowid[hidden,omitted])
+0  select                               (y)
+1  join                                 (x[omitted], y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])
+1          type      inner
+1          equality  (x) = (x)
+2  scan                                 (x, y[omitted], rowid[hidden,omitted])
+2          table     twocolumn@primary
+2  scan                                 (x, y, rowid[hidden,omitted])
+2          table     twocolumn@primary
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b.y)
 ----
-0  select                                                                          (x)
-1  render/filter  from ("".a.x, "".a.y, *"".a.rowid, "".b.x, "".b.y, *"".b.rowid)  (x)
-2  join           INNER ON a.x < b.y                                               (x, y[omitted], rowid[hidden,omitted], x[omitted], y[omitted], rowid[hidden,omitted])
-3  scan           twocolumn@primary                                                (x, y[omitted], rowid[hidden,omitted])
-3  scan           twocolumn@primary                                                (x[omitted], y, rowid[hidden,omitted])
+0  select                            (x)
+1  join                              (x, y[omitted], rowid[hidden,omitted], x[omitted], y[omitted], rowid[hidden,omitted])
+1          type   inner
+2  scan                              (x, y[omitted], rowid[hidden,omitted])
+2          table  twocolumn@primary
+2  scan                              (x[omitted], y, rowid[hidden,omitted])
+2          table  twocolumn@primary
 
 # Ensure that the ordering information for the result of joins is sane. (#12037)
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES (9, 1), (8, 2)) AS a (u, k) ORDER BY k)
 				INNER JOIN (VALUES (1, 1), (2, 2)) AS b (k, w) USING (k) ORDER BY u
 ----
-0   select                                                          (k, u, w)            +u
-1   sort            +u                                              (k, u, w)            +u
-2   render/filter   from (""."".k, _.u, *""."".k, *"".b.k, "".b.w)  (k, u, w)
-3   join            INNER ON EQUALS((k),(k))                        (k, u, k[hidden,omitted], k[hidden,omitted], w)
-4   select                                                          (u, k)               +k
-5   sort            +k                                              (u, k)               +k
-6   render/filter   from ("".a.u, "".a.k)                           (u, k)
-7   select                                                          (column1, column2)
-8   values          2 columns, 2 rows                               (column1, column2)
-4   select                                                          (column1, column2)
-5   values          2 columns, 2 rows                               (column1, column2)
+0  select                               (k, u, w)                                        +u
+1  sort                                 (k, u, w)                                        +u
+1          order     +u
+2  join                                 (k, u, k[hidden,omitted], k[hidden,omitted], w)
+2          type      inner
+2          equality  (k) = (k)
+3  select                               (u, k)                                           +k
+4  sort                                 (u, k)                                           +k
+4          order     +k
+5  select                               (column1, column2)
+6  values                               (column1, column2)
+6          size      2 columns, 2 rows
+3  select                               (column1, column2)
+4  values                               (column1, column2)
+4          size      2 columns, 2 rows

--- a/pkg/sql/testdata/order_by
+++ b/pkg/sql/testdata/order_by
@@ -41,8 +41,11 @@ SELECT a, b FROM t ORDER BY b
 query ITTT
 EXPLAIN SELECT a, b FROM t ORDER BY b
 ----
-0 sort +b
-1 scan t@primary ALL
+0  sort
+0        order  +b
+1  scan
+1        table  t@primary
+1        spans  ALL
 
 query II
 SELECT a, b FROM t ORDER BY b DESC
@@ -54,8 +57,11 @@ SELECT a, b FROM t ORDER BY b DESC
 query ITTT
 EXPLAIN SELECT a, b FROM t ORDER BY b DESC
 ----
-0 sort -b
-1 scan t@primary ALL
+0  sort
+0        order  -b
+1  scan
+1        table  t@primary
+1        spans  ALL
 
 query I
 SELECT a FROM t ORDER BY 1 DESC
@@ -67,9 +73,13 @@ SELECT a FROM t ORDER BY 1 DESC
 query ITTT
 EXPLAIN SELECT a, b FROM t ORDER BY b LIMIT 2
 ----
-0 limit count: 2
-1 sort  +b (top 2)
-2 scan  t@primary ALL
+0  limit
+1  sort
+1         order     +b
+1         strategy  top 2
+2  scan
+2         table     t@primary
+2         spans     ALL
 
 query II
 SELECT a, b FROM t ORDER BY b DESC LIMIT 2
@@ -80,10 +90,14 @@ SELECT a, b FROM t ORDER BY b DESC LIMIT 2
 query ITTT
 EXPLAIN SELECT DISTINCT a FROM t ORDER BY b LIMIT 2
 ----
-0 limit    count: 2
-1 distinct
-2 sort     +b (iterative)
-3 scan     t@primary ALL
+0  limit
+1  distinct
+2  sort
+2            order     +b
+2            strategy  iterative
+3  scan
+3            table     t@primary
+3            spans     ALL
 
 query I
 SELECT DISTINCT a FROM t ORDER BY b DESC LIMIT 2
@@ -133,20 +147,29 @@ SELECT b FROM t ORDER BY a DESC
 query ITTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC
 ----
-0 nosort -a
-1 revscan t@primary ALL
+0  nosort
+0           order  -a
+1  revscan
+1           table  t@primary
+1           spans  ALL
 
 query ITTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b ASC
 ----
-0 nosort -a,+b
-1 revscan t@primary ALL
+0  nosort
+0           order  -a,+b
+1  revscan
+1           table  t@primary
+1           spans  ALL
 
 query ITTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b DESC
 ----
-0 nosort -a,-b
-1 revscan t@primary ALL
+0  nosort
+0           order  -a,-b
+1  revscan
+1           table  t@primary
+1           spans  ALL
 
 statement ok
 INSERT INTO t VALUES (4, 7), (5, 7)
@@ -236,39 +259,47 @@ SELECT a FROM t ORDER BY a.b
 query ITTT
 EXPLAIN SELECT * FROM t ORDER BY 1+2
 ----
-0 scan t@primary
+0  scan
+0        table  t@primary
 
 query ITTT
 EXPLAIN SELECT * FROM t ORDER BY length('abc')
 ----
-0 scan t@primary
+0  scan
+0        table  t@primary
 
 # Check that the sort key reuses the existing render.
 query ITTTTT
 EXPLAIN(METADATA) SELECT b+2 FROM t ORDER BY b+2
 ----
-0   select                                              ("b + 2")   +"b + 2"
-1   sort            +"b + 2"                            ("b + 2")   +"b + 2"
-2   render/filter   from (test.t.a, test.t.b, test.t.c) ("b + 2")
-3   scan            t@primary ALL                       (a[omitted], b, c[omitted])   +a,unique
+0  select                    ("b + 2")                    +"b + 2"
+1  sort                      ("b + 2")                    +"b + 2"
+1          order  +"b + 2"
+2  scan                      (a[omitted], b, c[omitted])  +a,unique
+2          table  t@primary
+2          spans  ALL
 
 # Check that the sort picks up a renamed render properly.
 query ITTTTT
 EXPLAIN(METADATA) SELECT b+2 AS y FROM t ORDER BY y
 ----
-0   select                                              (y)   +y
-1   sort            +y                                  (y)   +y
-2   render/filter   from (test.t.a, test.t.b, test.t.c) (y)
-3   scan            t@primary ALL                       (a[omitted], b, c[omitted])   +a,unique
+0  select                    (y)                          +y
+1  sort                      (y)                          +y
+1          order  +y
+2  scan                      (a[omitted], b, c[omitted])  +a,unique
+2          table  t@primary
+2          spans  ALL
 
 # Check that the sort reuses a render behind a rename properly.
 query ITTTTT
 EXPLAIN(METADATA) SELECT b+2 AS y FROM t ORDER BY b+2
 ----
-0   select                                              (y)   +y
-1   sort            +y                                  (y)   +y
-2   render/filter   from (test.t.a, test.t.b, test.t.c) (y)
-3   scan            t@primary ALL                       (a[omitted], b, c[omitted])   +a,unique
+0  select                    (y)                          +y
+1  sort                      (y)                          +y
+1          order  +y
+2  scan                      (a[omitted], b, c[omitted])  +a,unique
+2          table  t@primary
+2          spans  ALL
 
 statement ok
 CREATE TABLE abc (
@@ -303,7 +334,9 @@ EXPLAIN (DEBUG) SELECT * FROM abc ORDER BY a
 query ITTT
 EXPLAIN SELECT * FROM abc ORDER BY a
 ----
-0 scan abc@primary ALL
+0  scan
+0        table  abc@primary
+0        spans  ALL
 
 query ITTT
 EXPLAIN (DEBUG) SELECT a, b FROM abc ORDER BY b, a
@@ -314,61 +347,84 @@ EXPLAIN (DEBUG) SELECT a, b FROM abc ORDER BY b, a
 query ITTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, a
 ----
-0 scan abc@ba ALL
+0  scan
+0        table  abc@ba
+0        spans  ALL
 
 # The non-unique index ba includes column c (required to make the keys unique)
 # so the results will already be sorted.
 query ITTT
 EXPLAIN SELECT a, b, c FROM abc ORDER BY b, a, c
 ----
-0 scan abc@ba ALL
+0  scan
+0        table  abc@ba
+0        spans  ALL
 
 # We use the WHERE condition to force the use of index ba.
 query ITTT
 EXPLAIN SELECT a, b, c FROM abc WHERE b > 10 ORDER BY b, a, d
 ----
-0 sort       +b,+a,+d
-1 index-join
-2 scan       abc@ba /11-
-2 scan       abc@primary
+0  sort
+0              order  +b,+a,+d
+1  index-join
+2  scan
+2              table  abc@ba
+2              spans  /11-
+2  scan
+2              table  abc@primary
 
 # We cannot have rows with identical values for a,b,c so we don't need to
 # sort for d.
 query ITTT
 EXPLAIN SELECT a, b, c, d FROM abc WHERE b > 10 ORDER BY b, a, c, d
 ----
-0 index-join
-1 scan       abc@ba /11-
-1 scan       abc@primary
+0  index-join
+1  scan
+1              table  abc@ba
+1              spans  /11-
+1  scan
+1              table  abc@primary
 
 query ITTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c
 ----
-0 nosort +b,+c
-1 scan   abc@bc ALL
+0  nosort
+0          order  +b,+c
+1  scan
+1          table  abc@bc
+1          spans  ALL
 
 query ITTTTT
 EXPLAIN(VERBOSE) SELECT a, b FROM abc ORDER BY b, c
 ----
-0  select                                                                          (a, b)                 +b
-1  nosort                   +b,+c                                                  (a, b)                 +b
-2  render/filter            from (test.abc.a, test.abc.b, test.abc.c, test.abc.d)  (a, b, c)              +b,+c,unique
-2  render/filter  render 0  test.abc.a
-2  render/filter  render 1  test.abc.b
-2  render/filter  render 2  test.abc.c
-3  scan                     abc@bc ALL                                             (a, b, c, d[omitted])  +b,+c,unique
+0  select                               (a, b)                 +b
+1  nosort                               (a, b)                 +b
+1                 order     +b,+c
+2  render/filter                        (a, b, c)              +b,+c,unique
+2                 render 0  test.abc.a
+2                 render 1  test.abc.b
+2                 render 2  test.abc.c
+3  scan                                 (a, b, c, d[omitted])  +b,+c,unique
+3                 table     abc@bc
+3                 spans     ALL
 
 query ITTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a
 ----
-0 nosort +b,+c,+a
-1 scan   abc@bc ALL
+0  nosort
+0          order  +b,+c,+a
+1  scan
+1          table  abc@bc
+1          spans  ALL
 
 query ITTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a DESC
 ----
-0 nosort +b,+c,-a
-1 scan   abc@bc ALL
+0  nosort
+0          order  +b,+c,-a
+1  scan
+1          table  abc@bc
+1          spans  ALL
 
 query ITTT
 EXPLAIN (DEBUG) SELECT b, c FROM abc ORDER BY b, c
@@ -393,7 +449,9 @@ EXPLAIN (DEBUG) SELECT a FROM abc ORDER BY a DESC
 query ITTT
 EXPLAIN SELECT a FROM abc ORDER BY a DESC
 ----
-0 revscan abc@primary ALL
+0  revscan
+0           table  abc@primary
+0           spans  ALL
 
 query I
 SELECT a FROM abc ORDER BY a DESC
@@ -414,12 +472,16 @@ SELECT a FROM abc ORDER BY a DESC OFFSET 1
 query ITTT
 EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c
 ----
-0 scan abc@bc /2-/3
+0  scan
+0        table  abc@bc
+0        spans  /2-/3
 
 query ITTT
 EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c DESC
 ----
-0 revscan abc@bc /2-/3
+0  revscan
+0           table  abc@bc
+0           spans  /2-/3
 
 statement ok
 CREATE TABLE bar (id INT PRIMARY KEY, baz STRING, UNIQUE INDEX i_bar (baz));
@@ -449,22 +511,30 @@ INSERT INTO abcd VALUES (1, 4, 2, 3), (2, 3, 4, 1), (3, 2, 1, 2), (4, 4, 1, 1)
 query ITTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c
 ----
-0 scan abcd@abc /1/4-/1/5
+0  scan
+0        table  abcd@abc
+0        spans  /1/4-/1/5
 
 query ITTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c, b, a
 ----
-0 scan abcd@abc /1/4-/1/5
+0  scan
+0        table  abcd@abc
+0        spans  /1/4-/1/5
 
 query ITTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, a, c
 ----
-0 scan abcd@abc /1/4-/1/5
+0  scan
+0        table  abcd@abc
+0        spans  /1/4-/1/5
 
 query ITTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, c, a
 ----
-0 scan abcd@abc /1/4-/1/5
+0  scan
+0        table  abcd@abc
+0        spans  /1/4-/1/5
 
 statement ok
 CREATE TABLE nan (id INT PRIMARY KEY, x REAL);
@@ -484,45 +554,47 @@ query ITTTTT
 EXPLAIN(METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x);
 ----
 0  select                           (x)        +x
-1  render/filter  from (""."".x)    (x)        +x
-2  select                           (x)        +x
-3  sort           +x                (x)        +x
-4  render/filter  from ("".c.x)     (x)
-5  select                           (column1)
-6  values         1 column, 3 rows  (column1)
+1  select                           (x)        +x
+2  sort                             (x)        +x
+2          order  +x
+3  select                           (column1)
+4  values                           (column1)
+4          size   1 column, 3 rows
 
 query ITTT
 EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality ASC;
 ----
-0 ordinality
-1 values 1 column, 3 rows
+0  ordinality
+1  values
+1              size  1 column, 3 rows
 
 query ITTT
 EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality DESC;
 ----
-0 sort -ordinality
-1 ordinality
-2 values 1 column, 3 rows
+0  sort
+0              order  -ordinality
+1  ordinality
+2  values
+2              size   1 column, 3 rows
 
 query ITTTTT
 EXPLAIN(METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY;
 ----
-0  select                                           (x, ordinality)  +ordinality,unique
-1  render/filter  from (""."".x, ""."".ordinality)  (x, ordinality)  +ordinality,unique
-2  ordinality                                       (x, ordinality)  +ordinality,unique
-3  select                                           (x)
-4  render/filter  from ("".c.x)                     (x)
-5  select                                           (column1)
-6  values         1 column, 3 rows                  (column1)
+0  select                              (x, ordinality)  +ordinality,unique
+1  ordinality                          (x, ordinality)  +ordinality,unique
+2  select                              (x)
+3  select                              (column1)
+4  values                              (column1)
+4              size  1 column, 3 rows
 
 query ITTTTT
 EXPLAIN(METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY;
 ----
-0  select                                           (x, ordinality)  +x
-1  render/filter  from (""."".x, ""."".ordinality)  (x, ordinality)  +x
-2  ordinality                                       (x, ordinality)  +x
-3  select                                           (x)              +x
-4  sort           +x                                (x)              +x
-5  render/filter  from ("".c.x)                     (x)
-6  select                                           (column1)
-7  values         1 column, 3 rows                  (column1)
+0  select                               (x, ordinality)  +x
+1  ordinality                           (x, ordinality)  +x
+2  select                               (x)              +x
+3  sort                                 (x)              +x
+3              order  +x
+4  select                               (column1)
+5  values                               (column1)
+5              size   1 column, 3 rows

--- a/pkg/sql/testdata/ordinal_references
+++ b/pkg/sql/testdata/ordinal_references
@@ -46,12 +46,17 @@ a 3
 
 # Check that sort by ordinal picks up the existing render.
 query ITTTTT
-EXPLAIN(METADATA) SELECT b, a FROM foo ORDER BY @1
+EXPLAIN(VERBOSE) SELECT b, a FROM foo ORDER BY @1
 ----
-0  select                                                         (b, a)                 +a
-1  sort           +a                                              (b, a)                 +a
-2  render/filter  from (test.foo.a, test.foo.b, *test.foo.rowid)  (b, a)
-3  scan           foo@primary ALL                                 (a, b, rowid[hidden,omitted])  +rowid,unique
+0  select                                (b, a)                         +a
+1  sort                                  (b, a)                         +a
+1                 order     +a
+2  render/filter                         (b, a)
+2                 render 0  test.foo.b
+2                 render 1  test.foo.a
+3  scan                                  (a, b, rowid[hidden,omitted])  +rowid,unique
+3                 table     foo@primary
+3                 spans     ALL
 
 statement ok
 INSERT INTO foo(a, b) VALUES (4, 'c'), (5, 'c'), (6, 'c')
@@ -75,20 +80,32 @@ SELECT SUM(a) AS s FROM foo GROUP BY @2 ORDER BY s
 
 # Check that GROUP BY picks up column ordinals.
 query ITTTTT
-EXPLAIN(METADATA) SELECT min(a) AS m FROM foo GROUP BY @1;
+EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1;
 ----
-0  select                                                         (m)
-1  group          min(a) GROUP BY (@2)                            (m)
-2  render/filter  from (test.foo.a, test.foo.b, *test.foo.rowid)  (a, a)
-3  scan           foo@primary ALL                                 (a, b[omitted], rowid[hidden,omitted])  +rowid,unique
+0  select                                       (m)
+1  group                                        (m)
+1                 aggregate 0  min(test.foo.a)
+1                 render 0     min(test.foo.a)
+2  render/filter                                (a, a)
+2                 render 0     test.foo.a
+2                 render 1     test.foo.a
+3  scan                                         (a, b[omitted], rowid[hidden,omitted])  +rowid,unique
+3                 table        foo@primary
+3                 spans        ALL
 
 query ITTTTT
-EXPLAIN(METADATA) SELECT min(a) AS m FROM foo GROUP BY @2;
+EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2;
 ----
-0  select                                                         (m)
-1  group          min(a) GROUP BY (@2)                            (m)
-2  render/filter  from (test.foo.a, test.foo.b, *test.foo.rowid)  (a, b)
-3  scan           foo@primary ALL                                 (a, b, rowid[hidden,omitted])  +rowid,unique
+0  select                                       (m)
+1  group                                        (m)
+1                 aggregate 0  min(test.foo.a)
+1                 render 0     min(test.foo.a)
+2  render/filter                                (a, b)
+2                 render 0     test.foo.a
+2                 render 1     test.foo.b
+3  scan                                         (a, b, rowid[hidden,omitted])  +rowid,unique
+3                 table        foo@primary
+3                 spans        ALL
 
 statement error column reference @1 not allowed in this context
 INSERT INTO foo(a, b) VALUES (@1, @2)

--- a/pkg/sql/testdata/ordinality
+++ b/pkg/sql/testdata/ordinality
@@ -83,19 +83,19 @@ true
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM foo WHERE x > 'a') WITH ORDINALITY;
 ----
-0  select                                           (x, ordinality)  +x,unique
-1  render/filter  from (""."".x, ""."".ordinality)  (x, ordinality)  +x,unique
-2  ordinality                                       (x, ordinality)  +x,unique
-3  select                                           (x)              +x,unique
-4  render/filter  from (test.foo.x)                 (x)              +x,unique
-5  scan           foo@primary /"a\x00"-             (x)              +x,unique
+0  select                          (x, ordinality)  +x,unique
+1  ordinality                      (x, ordinality)  +x,unique
+2  select                          (x)              +x,unique
+3  scan                            (x)              +x,unique
+3              table  foo@primary
+3              spans  /"a\x00"-
 
 # Show that the primary key cannot be used with a PK predicate
 # outside of ordinalityNode.
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM foo WITH ORDINALITY WHERE x > 'a';
 ----
-0  select                                              (x, ordinality)  +ordinality,unique
-1  render/filter  from (test.foo.x, ""."".ordinality)  (x, ordinality)  +ordinality,unique
-2  ordinality                                          (x, ordinality)  +ordinality,unique
-3  scan           foo@primary                          (x)
+0  select                          (x, ordinality)  +ordinality,unique
+1  ordinality                      (x, ordinality)  +ordinality,unique
+2  scan                            (x)
+2              table  foo@primary

--- a/pkg/sql/testdata/select_index
+++ b/pkg/sql/testdata/select_index
@@ -254,42 +254,58 @@ SELECT b FROM t WHERE c > 4.0 AND a < 4
 query ITTT
 EXPLAIN SELECT a FROM t WHERE c > 1
 ----
-0 scan t@bc ALL
+0  scan
+0        table  t@bc
+0        spans  ALL
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE c < 1 AND b < 5
 ----
-0 scan t@bc /#-/4/1
+0  scan
+0        table  t@bc
+0        spans  /#-/4/1
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE c > 1.0
 ----
-0 scan t@bc ALL
+0  scan
+0        table  t@bc
+0        spans  ALL
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE c < 1.0
 ----
-0 scan t@bc ALL
+0  scan
+0        table  t@bc
+0        spans  ALL
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE c > 1.0 AND b < 5
 ----
-0 scan t@bc /#-/5
+0  scan
+0        table  t@bc
+0        spans  /#-/5
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE b < 5.0 AND c < 1
 ----
-0 scan t@bc /#-/4/1
+0  scan
+0        table  t@bc
+0        spans  /#-/4/1
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE (b, c) = (5, 1)
 ----
-0 scan t@bc /5/1-/5/2
+0  scan
+0        table  t@bc
+0        spans  /5/1-/5/2
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE (b, c) = (5.0, 1)
 ----
-0 scan t@bc /5/1-/5/2
+0  scan
+0        table  t@bc
+0        spans  /5/1-/5/2
 
 query error tuples \(b, c\), \(5.1, 1\) are not the same type: expected 5.1 to be of type int, found type decimal
 EXPLAIN SELECT a FROM t WHERE (b, c) = (5.1, 1)
@@ -297,7 +313,9 @@ EXPLAIN SELECT a FROM t WHERE (b, c) = (5.1, 1)
 query ITTT
 EXPLAIN SELECT a FROM t WHERE b IN (5.0, 1)
 ----
-0 scan t@b_desc /-6-/-5 /-2-/-1
+0  scan
+0        table  t@b_desc
+0        spans  /-6-/-5 /-2-/-1
 
 statement ok
 CREATE TABLE abcd (
@@ -314,12 +332,16 @@ CREATE TABLE abcd (
 query ITTT
 EXPLAIN SELECT b FROM abcd WHERE (a, b) = (1, 4)
 ----
-0 scan abcd@abcd /1/4-/1/5
+0  scan
+0        table  abcd@abcd
+0        spans  /1/4-/1/5
 
 query ITTT
 EXPLAIN SELECT b FROM abcd WHERE (a, b) IN ((1, 4), (2, 9))
 ----
-0 scan abcd@abcd /1/4-/1/5 /2/9-/2/10
+0  scan
+0        table  abcd@abcd
+0        spans  /1/4-/1/5 /2/9-/2/10
 
 statement ok
 CREATE TABLE ab (
@@ -345,4 +367,6 @@ SELECT i, s FROM ab@baz WHERE (i, s) < (1, 'c')
 query ITTT
 EXPLAIN SELECT i, s FROM ab@baz WHERE (i, s) < (1, 'c')
 ----
-0 scan ab@baz /#-/1/"c"
+0  scan
+0        table  ab@baz
+0        spans  /#-/1/"c"

--- a/pkg/sql/testdata/select_index_hints
+++ b/pkg/sql/testdata/select_index_hints
@@ -23,7 +23,9 @@ SELECT * FROM abcd WHERE a >= 20 AND a <= 30
 query ITTT
 EXPLAIN SELECT * FROM abcd WHERE a >= 20 AND a <= 30
 ----
-0 scan       abcd@primary /20-/31
+0  scan
+0        table  abcd@primary
+0        spans  /20-/31
 
 # Force primary
 
@@ -36,7 +38,9 @@ SELECT * FROM abcd@primary WHERE a >= 20 AND a <= 30
 query ITTT
 EXPLAIN SELECT * FROM abcd@primary WHERE a >= 20 AND a <= 30
 ----
-0 scan       abcd@primary /20-/31
+0  scan
+0        table  abcd@primary
+0        spans  /20-/31
 
 # Force index b
 
@@ -49,9 +53,12 @@ SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30
 query ITTT
 EXPLAIN SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
-0 index-join
-1 scan       abcd@b       ALL
-1 scan       abcd@primary
+0  index-join
+1  scan
+1              table  abcd@b
+1              spans  ALL
+1  scan
+1              table  abcd@primary
 
 # Force index cd
 
@@ -64,16 +71,21 @@ SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
 query ITTT
 EXPLAIN SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
 ----
-0 index-join
-1 scan       abcd@cd      ALL
-1 scan       abcd@primary
+0  index-join
+1  scan
+1              table  abcd@cd
+1              spans  ALL
+1  scan
+1              table  abcd@primary
 
 # Force index bcd
 
 query ITTT
 EXPLAIN SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
 ----
-0 scan       abcd@bcd     ALL
+0  scan
+0        table  abcd@bcd
+0        spans  ALL
 
 query IIII
 SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
@@ -86,16 +98,21 @@ SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
 query ITTT
 EXPLAIN SELECT b FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
-0 scan       abcd@b       ALL
+0  scan
+0        table  abcd@b
+0        spans  ALL
 
 # Force index b (non-covering due to WHERE clause)
 
 query ITTT
 EXPLAIN SELECT b FROM abcd@b WHERE c >= 20 AND c <= 30
 ----
-0 index-join
-1 scan       abcd@b       ALL
-1 scan       abcd@primary
+0  index-join
+1  scan
+1              table  abcd@b
+1              spans  ALL
+1  scan
+1              table  abcd@primary
 
 # No hint, should be using index cd
 
@@ -108,7 +125,9 @@ SELECT c, d FROM abcd WHERE c >= 20 AND c < 40
 query ITTT
 EXPLAIN SELECT c, d FROM abcd WHERE c >= 20 AND c < 40
 ----
-0 scan       abcd@cd /20-/40
+0  scan
+0        table  abcd@cd
+0        spans  /20-/40
 
 # Force no index
 
@@ -121,7 +140,9 @@ SELECT c, d FROM abcd@primary WHERE c >= 20 AND c < 40
 query ITTT
 EXPLAIN SELECT c, d FROM abcd@primary WHERE c >= 20 AND c < 40
 ----
-0 scan       abcd@primary ALL
+0  scan
+0        table  abcd@primary
+0        spans  ALL
 
 # Force index b
 
@@ -134,9 +155,12 @@ SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
 query ITTT
 EXPLAIN SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
 ----
-0 index-join
-1 scan       abcd@b       ALL
-1 scan       abcd@primary
+0  index-join
+1  scan
+1              table  abcd@b
+1              spans  ALL
+1  scan
+1              table  abcd@primary
 
 query error index \"badidx\" not found
 SELECT * FROM abcd@badidx
@@ -147,31 +171,43 @@ SELECT * FROM abcd@{FORCE_INDEX=badidx}
 query ITTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b} WHERE a >= 20 AND a <= 30
 ----
-0 index-join
-1 scan       abcd@b       ALL
-1 scan       abcd@primary
+0  index-join
+1  scan
+1              table  abcd@b
+1              spans  ALL
+1  scan
+1              table  abcd@primary
 
 query ITTT
 EXPLAIN SELECT b, c, d FROM abcd WHERE c = 10
 ----
-0 index-join
-1 scan       abcd@cd      /10-/11
-1 scan       abcd@primary
+0  index-join
+1  scan
+1              table  abcd@cd
+1              spans  /10-/11
+1  scan
+1              table  abcd@primary
 
 query ITTT
 EXPLAIN SELECT b, c, d FROM abcd@{NO_INDEX_JOIN} WHERE c = 10
 ----
-0 scan       abcd@bcd ALL
+0  scan
+0        table  abcd@bcd
+0        spans  ALL
 
 query ITTT
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=bcd,NO_INDEX_JOIN} WHERE c = 10
 ----
-0 scan       abcd@bcd ALL
+0  scan
+0        table  abcd@bcd
+0        spans  ALL
 
 query ITTT
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=primary,NO_INDEX_JOIN} WHERE c = 10
 ----
-0 scan       abcd@primary ALL
+0  scan
+0        table  abcd@primary
+0        spans  ALL
 
 query error index \"cd\" is not covering and NO_INDEX_JOIN was specified
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=cd,NO_INDEX_JOIN} WHERE c = 10

--- a/pkg/sql/testdata/select_index_span_ranges
+++ b/pkg/sql/testdata/select_index_span_ranges
@@ -56,8 +56,11 @@ query ITTT
 EXPLAIN SELECT * FROM t WHERE (c >= 80) ORDER BY c
 ----
 0  index-join
-1  scan        t@c /80-
-1  scan        t@primary
+1  scan
+1              table  t@c
+1              spans  /80-
+1  scan
+1              table  t@primary
 
 query IIII
 SELECT * FROM t WHERE (c >= 80) ORDER BY c

--- a/pkg/sql/testdata/select_non_covering_index
+++ b/pkg/sql/testdata/select_non_covering_index
@@ -18,9 +18,12 @@ INSERT INTO t VALUES (1, 2, 3, 4), (5, 6, 7, 8)
 query ITTT
 EXPLAIN SELECT * FROM t WHERE b = 2
 ----
-0 index-join
-1 scan       t@b /2-/3
-1 scan       t@primary
+0  index-join
+1  scan
+1              table  t@b
+1              spans  /2-/3
+1  scan
+1              table  t@primary
 
 query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t WHERE b = 2
@@ -39,9 +42,12 @@ SELECT * FROM t WHERE b = 2
 query ITTT
 EXPLAIN SELECT * FROM t WHERE c = 6
 ----
-0 index-join
-1 scan       t@c /6-/7
-1 scan       t@primary
+0  index-join
+1  scan
+1              table  t@c
+1              spans  /6-/7
+1  scan
+1              table  t@primary
 
 query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t WHERE c = 7
@@ -66,16 +72,22 @@ SELECT * FROM t WHERE c > 0 ORDER BY c DESC
 query ITTT
 EXPLAIN SELECT * FROM t WHERE c > 0 ORDER BY c DESC
 ----
-0 index-join
-1 revscan    t@c /1-
-1 scan       t@primary
+0  index-join
+1  revscan
+1              table  t@c
+1              spans  /1-
+1  scan
+1              table  t@primary
 
 query ITTT
 EXPLAIN SELECT * FROM t WHERE c > 0 ORDER BY c
 ----
-0 index-join
-1 scan       t@c /1-
-1 scan       t@primary
+0  index-join
+1  scan
+1              table  t@c
+1              spans  /1-
+1  scan
+1              table  t@primary
 
 query IIII
 SELECT * FROM t WHERE c > 0 AND d = 8
@@ -85,9 +97,12 @@ SELECT * FROM t WHERE c > 0 AND d = 8
 query ITTT
 EXPLAIN SELECT * FROM t WHERE c > 0 AND d = 8
 ----
-0 index-join
-1 scan       t@c /1-
-1 scan       t@primary
+0  index-join
+1  scan
+1              table  t@c
+1              spans  /1-
+1  scan
+1              table  t@primary
 
 # The following testcases verify that when we have a small limit, we prefer an
 # order-matching index.
@@ -95,35 +110,72 @@ EXPLAIN SELECT * FROM t WHERE c > 0 AND d = 8
 query ITTT
 EXPLAIN SELECT * FROM t ORDER BY c
 ----
-0 sort       +c
-1 scan       t@primary ALL
+0  sort
+0        order  +c
+1  scan
+1        table  t@primary
+1        spans  ALL
 
 query ITTT
 EXPLAIN SELECT * FROM t ORDER BY c LIMIT 5
 ----
-0 limit      count: 5
-1 index-join
-2 scan       t@c ALL (max 5 rows)
-2 scan       t@primary
+0  limit
+1  index-join
+2  scan
+2              table  t@c
+2              spans  ALL
+2              limit  5
+2  scan
+2              table  t@primary
 
 query ITTT
-EXPLAIN SELECT * FROM t ORDER BY c OFFSET 5
+EXPLAIN(EXPRS) SELECT * FROM t ORDER BY c OFFSET 5
 ----
-0 limit      offset: 5
-1 sort       +c
-2 scan       t@primary ALL
+0  limit
+0                 offset    5
+1  sort
+1                 order     +c
+2  render/filter
+2                 render 0  a
+2                 render 1  b
+2                 render 2  c
+2                 render 3  d
+3  scan
+3                 table     t@primary
+3                 spans     ALL
 
 query ITTT
-EXPLAIN SELECT * FROM t ORDER BY c LIMIT 5 OFFSET 5
+EXPLAIN(EXPRS) SELECT * FROM t ORDER BY c LIMIT 5 OFFSET 5
 ----
-0 limit      count: 5, offset: 5
-1 index-join
-2 scan       t@c ALL (max 10 rows)
-2 scan       t@primary
+0  limit
+0                 count     5
+0                 offset    5
+1  render/filter
+1                 render 0  a
+1                 render 1  b
+1                 render 2  c
+1                 render 3  d
+2  index-join
+3  scan
+3                 table     t@c
+3                 spans     ALL
+3                 limit     10
+3  scan
+3                 table     t@primary
 
 query ITTT
-EXPLAIN SELECT * FROM t ORDER BY c LIMIT 1000000
+EXPLAIN(EXPRS) SELECT * FROM t ORDER BY c LIMIT 1000000
 ----
-0 limit      count: 1000000
-1 sort       +c (top 1000000)
-2 scan       t@primary ALL
+0  limit
+0                 count     1000000
+1  sort
+1                 order     +c
+1                 strategy  top 1000000
+2  render/filter
+2                 render 0  a
+2                 render 1  b
+2                 render 2  c
+2                 render 3  d
+3  scan
+3                 table     t@primary
+3                 spans     ALL

--- a/pkg/sql/testdata/select_non_covering_index_filtering
+++ b/pkg/sql/testdata/select_non_covering_index_filtering
@@ -28,11 +28,20 @@ INSERT INTO t VALUES
   (9, 3, 3, '33')
 
 query ITTT
-EXPLAIN SELECT * FROM t WHERE b = 2 AND c % 2 = 0
+EXPLAIN(EXPRS) SELECT * FROM t WHERE b = 2 AND c % 2 = 0
 ----
-0 index-join
-1 scan       t@bc /2-/3
-1 scan       t@primary
+0  render/filter
+0                 render 0  a
+0                 render 1  b
+0                 render 2  c
+0                 render 3  s
+1  index-join
+2  scan
+2                 table     t@bc
+2                 spans     /2-/3
+2                 filter    (c % 2) = 0
+2  scan
+2                 table     t@primary
 
 # We do NOT look up the table row for '21' and '23'.
 query ITTT
@@ -47,11 +56,20 @@ EXPLAIN (DEBUG) SELECT * FROM t WHERE b = 2 AND c % 2 = 0
 2 /t/bc/2/3/6    NULL FILTERED
 
 query ITTT
-EXPLAIN SELECT * FROM t WHERE b = 2 AND c != b
+EXPLAIN(EXPRS) SELECT * FROM t WHERE b = 2 AND c != b
 ----
-0 index-join
-1 scan       t@bc /2-/3
-1 scan       t@primary
+0  render/filter
+0                 render 0  a
+0                 render 1  b
+0                 render 2  c
+0                 render 3  s
+1  index-join
+2  scan
+2                 table     t@bc
+2                 spans     /2-/3
+2                 filter    c != b
+2  scan
+2                 table     t@primary
 
 # We do NOT look up the table row for '22'.
 query ITTT

--- a/pkg/sql/testdata/subquery
+++ b/pkg/sql/testdata/subquery
@@ -43,8 +43,9 @@ INSERT INTO abc VALUES (1, 2, 3), (4, 5, 6)
 query ITTT
 EXPLAIN ALTER TABLE abc SPLIT AT ((SELECT 42))
 ----
-0 split (SELECT 42)
-1 nullrow
+0  split
+0           subqueries  1
+1  nullrow
 
 statement ok
 ALTER TABLE abc SPLIT AT ((SELECT 1))
@@ -269,9 +270,12 @@ foo1 moo2 moo3
 query ITTT
 EXPLAIN SELECT * FROM (SELECT * FROM (VALUES (1, 8, 8), (3, 1, 1), (2, 4, 4)) AS moo (moo1, moo2, moo3) ORDER BY moo2) as foo (foo1) ORDER BY foo1
 ----
-0 sort   +foo1
-1 sort   +moo2
-2 values 3 columns, 3 rows
+0  sort
+0          order  +foo1
+1  sort
+1          order  +moo2
+2  values
+2          size   3 columns, 3 rows
 
 query II colnames
 SELECT a, b FROM (VALUES (1, 2, 3), (3, 4, 7), (5, 6, 10)) AS foo (a, b, c) WHERE a + b = c
@@ -322,12 +326,14 @@ true
 query ITTTTT
 EXPLAIN(METADATA) SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz);
 ----
-0  select                                                    (x)                          +x,unique
-1  render/filter  from (test.xyz.x, test.xyz.y, test.xyz.z)  (x)                          +x,unique
-2  scan           xyz@primary ALL                            (x, y[omitted], z[omitted])  +x,unique
-3  select                                                    (x)                          +x,unique
-4  render/filter  from (test.xyz.x, test.xyz.y, test.xyz.z)  (x)                          +x,unique
-5  scan           xyz@primary                                (x, y[omitted], z[omitted])  +x,unique
+0  select                           (x)                          +x,unique
+1  scan                             (x, y[omitted], z[omitted])  +x,unique
+1          table       xyz@primary
+1          spans       ALL
+1          subqueries  1
+2  select                           (x)                          +x,unique
+3  scan                             (x, y[omitted], z[omitted])  +x,unique
+3          table       xyz@primary
 
 # This test checks that the double sub-query plan expansion caused by a
 # sub-expression being shared by two or more plan nodes does not
@@ -349,7 +355,16 @@ query ITTT
 EXPLAIN SELECT col0 FROM tab4 WHERE (col0 <= 0 AND col4 <= 5.38) OR (col4 IN (SELECT col1 FROM tab4 WHERE col1 > 8.27)) AND (col3 <= 5 AND (col3 BETWEEN 7 AND 9))
 ----
 0  index-join
-1  scan        tab4@idx_tab4_0 /#-/5.38/1
-2  scan        tab4@primary    ALL
-1  scan        tab4@primary
-2  scan        tab4@primary    ALL
+1  scan
+1              table       tab4@idx_tab4_0
+1              spans       /#-/5.38/1
+1              subqueries  1
+2  scan
+2              table       tab4@primary
+2              spans       ALL
+1  scan
+1              table       tab4@primary
+1              subqueries  1
+2  scan
+2              table       tab4@primary
+2              spans       ALL

--- a/pkg/sql/testdata/union
+++ b/pkg/sql/testdata/union
@@ -137,9 +137,21 @@ SELECT v FROM uniontest WHERE k = 1 UNION ALL SELECT v FROM uniontest WHERE k = 
 query ITTT rowsort
 EXPLAIN SELECT v FROM uniontest UNION SELECT k FROM uniontest
 ----
-0 union -
-1 scan uniontest@primary
-1 scan uniontest@primary
+0  union
+1  scan
+1         table  uniontest@primary
+1  scan
+1         table  uniontest@primary
+
+query ITTT rowsort
+EXPLAIN SELECT v FROM uniontest UNION ALL SELECT k FROM uniontest
+----
+0  append
+1  scan
+1         table  uniontest@primary
+1  scan
+1         table  uniontest@primary
+
 
 query error each UNION query must have the same number of columns: 2 vs 1
 SELECT 1, 2 UNION SELECT 3

--- a/pkg/sql/testdata/values
+++ b/pkg/sql/testdata/values
@@ -29,5 +29,7 @@ VALUES ((SELECT 1)), ((SELECT 2))
 query ITTT
 EXPLAIN VALUES (1), ((SELECT 2))
 ----
-0 values 1 column, 2 rows
-1 nullrow
+0  values
+0           size        1 column, 2 rows
+0           subqueries  1
+1  nullrow

--- a/pkg/sql/testdata/window
+++ b/pkg/sql/testdata/window
@@ -468,9 +468,12 @@ SELECT k, max(stddev) OVER (ORDER BY d DESC) FROM (SELECT k, d, stddev(d) OVER (
 query ITTT
 EXPLAIN SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
 ----
-0  sort    +"variance(d) OVER w",+k
-1  window  stddev(d) OVER w, variance(d) OVER w
-2  scan    kv@primary ALL
+0  sort
+0          order  +"variance(d) OVER w",+k
+1  window
+2  scan
+2          table  kv@primary
+2          spans  ALL
 
 query ITTT
 EXPLAIN (DEBUG) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
@@ -508,69 +511,88 @@ EXPLAIN (DEBUG) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) 
 query ITTTTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
 ----
-0  select                                                                                                                        (k int, "stddev(d) OVER w" decimal)
-1  sort                                      +"variance(d) OVER w",+k                                                            (k int, "stddev(d) OVER w" decimal)
-2  window                                    stddev(d) OVER w, variance(d) OVER w                                                (k int, "stddev(d) OVER w" decimal, "variance(d) OVER w" decimal)
-2  window         render stddev(d) OVER w    (stddev((d)[decimal]) OVER w)[decimal]
-2  window         render variance(d) OVER w  (variance((d)[decimal]) OVER w)[decimal]
-3  render/filter                             from (test.kv.k, test.kv.v, test.kv.w, test.kv.f, test.kv.d, test.kv.s, test.kv.b)  (k int, d decimal, d decimal, v int, v int)                                                      +k,unique
-3  render/filter  render 0                   (k)[int]
-3  render/filter  render 1                   (d)[decimal]
-3  render/filter  render 2                   (d)[decimal]
-3  render/filter  render 3                   (v)[int]
-3  render/filter  render 4                   (v)[int]
-4  scan                                      kv@primary ALL                                                                      (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  +k,unique
+0  select                                                             (k int, "stddev(d) OVER w" decimal)
+1  sort                                                               (k int, "stddev(d) OVER w" decimal)
+1                 order     +"variance(d) OVER w",+k
+2  window                                                             (k int, "stddev(d) OVER w" decimal, "variance(d) OVER w" decimal)
+2                 window 0  (stddev((d)[decimal]) OVER w)[decimal]
+2                 window 1  (variance((d)[decimal]) OVER w)[decimal]
+2                 render 1  (stddev((d)[decimal]) OVER w)[decimal]
+2                 render 2  (variance((d)[decimal]) OVER w)[decimal]
+3  render/filter                                                      (k int, d decimal, d decimal, v int, v int)                                                      +k,unique
+3                 render 0  (k)[int]
+3                 render 1  (d)[decimal]
+3                 render 2  (d)[decimal]
+3                 render 3  (v)[int]
+3                 render 4  (v)[int]
+4  scan                                                               (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  +k,unique
+4                 table     kv@primary
+4                 spans     ALL
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-0  select                                                                                                                                            (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)
-1  sort                                                          +"variance(d) OVER (PARTITION BY v, 100)",+k                                        (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)
-2  window                                                        stddev(d) OVER (PARTITION BY v, 'a'), variance(d) OVER (PARTITION BY v, 100)        (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal, "variance(d) OVER (PARTITION BY v, 100)" decimal)
-2  window         render stddev(d) OVER (PARTITION BY v, 'a')    (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
-2  window         render variance(d) OVER (PARTITION BY v, 100)  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]
-3  render/filter                                                 from (test.kv.k, test.kv.v, test.kv.w, test.kv.f, test.kv.d, test.kv.s, test.kv.b)  (k int, d decimal, d decimal, v int, "'a'" string, v int, "100" int)                                       +k,unique
-3  render/filter  render 0                                       (k)[int]
-3  render/filter  render 1                                       (d)[decimal]
-3  render/filter  render 2                                       (d)[decimal]
-3  render/filter  render 3                                       (v)[int]
-3  render/filter  render 4                                       ('a')[string]
-3  render/filter  render 5                                       (v)[int]
-3  render/filter  render 6                                       (100)[int]
-4  scan                                                          kv@primary ALL                                                                      (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)            +k,unique
+0  select                                                                                                (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)
+1  sort                                                                                                  (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)
+1                 order     +"variance(d) OVER (PARTITION BY v, 100)",+k
+2  window                                                                                                (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal, "variance(d) OVER (PARTITION BY v, 100)" decimal)
+2                 window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
+2                 window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]
+2                 render 1  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
+2                 render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]
+3  render/filter                                                                                         (k int, d decimal, d decimal, v int, "'a'" string, v int, "100" int)                                       +k,unique
+3                 render 0  (k)[int]
+3                 render 1  (d)[decimal]
+3                 render 2  (d)[decimal]
+3                 render 3  (v)[int]
+3                 render 4  ('a')[string]
+3                 render 5  (v)[int]
+3                 render 6  (100)[int]
+4  scan                                                                                                  (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)            +k,unique
+4                 table     kv@primary
+4                 spans     ALL
 
 query ITTTTT
 EXPLAIN (TYPES,NONORMALIZE) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY k
 ----
-0  select                                                                                                                                          (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                          +k
-1  sort                                                        +k                                                                                  (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                          +k
-2  window                                                      stddev(d) OVER (PARTITION BY v, 'a')                                                (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)
-2  window         render stddev(d) OVER (PARTITION BY v, 'a')  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
-3  render/filter                                               from (test.kv.k, test.kv.v, test.kv.w, test.kv.f, test.kv.d, test.kv.s, test.kv.b)  (k int, d decimal, v int, "'a'" string)                                                          +k,unique
-3  render/filter  render 0                                     (k)[int]
-3  render/filter  render 1                                     (d)[decimal]
-3  render/filter  render 2                                     (v)[int]
-3  render/filter  render 3                                     ('a')[string]
-4  scan                                                        kv@primary ALL                                                                      (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  +k,unique
+0  select                                                                                                (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                          +k
+1  sort                                                                                                  (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                          +k
+1                 order     +k
+2  window                                                                                                (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)
+2                 window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
+2                 render 1  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
+3  render/filter                                                                                         (k int, d decimal, v int, "'a'" string)                                                          +k,unique
+3                 render 0  (k)[int]
+3                 render 1  (d)[decimal]
+3                 render 2  (v)[int]
+3                 render 3  ('a')[string]
+4  scan                                                                                                  (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  +k,unique
+4                 table     kv@primary
+4                 spans     ALL
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT k, k + stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-0  select                                                                                                                                                             (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)
-1  sort                                                            +"variance(d) OVER (PARTITION BY v, 100)",+k                                                       (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)
-2  window                                                          stddev(d) OVER (PARTITION BY v, 'a'), variance(d) OVER (PARTITION BY v, 100)                       (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal, "variance(d) OVER (PARTITION BY v, 100)" decimal)
-2  window         render k + stddev(d) OVER (PARTITION BY v, 'a')  ((k)[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]
-2  window         render variance(d) OVER (PARTITION BY v, 100)    (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]
-3  render/filter                                                   from (test.kv.k, test.kv.v, test.kv.w, test.kv.f, test.kv.d, test.kv.s, test.kv.b)                 (k int, d decimal, d decimal, v int, "'a'" string, v int, "100" int, k int)                                    +k,unique
-3  render/filter  render 0                                         (k)[int]
-3  render/filter  render 1                                         (d)[decimal]
-3  render/filter  render 2                                         (d)[decimal]
-3  render/filter  render 3                                         (v)[int]
-3  render/filter  render 4                                         ('a')[string]
-3  render/filter  render 5                                         (v)[int]
-3  render/filter  render 6                                         (100)[int]
-3  render/filter  render 7                                         (k)[int]
-4  scan                                                            kv@primary ALL                                                                                     (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)                +k,unique
+0  select                                                                                                                      (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)
+1  sort                                                                                                                        (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)
+1                 order     +"variance(d) OVER (PARTITION BY v, 100)",+k
+2  window                                                                                                                      (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal, "variance(d) OVER (PARTITION BY v, 100)" decimal)
+2                 window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
+2                 window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]
+2                 render 1  ((k)[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]
+2                 render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]
+3  render/filter                                                                                                               (k int, d decimal, d decimal, v int, "'a'" string, v int, "100" int, k int)                                    +k,unique
+3                 render 0  (k)[int]
+3                 render 1  (d)[decimal]
+3                 render 2  (d)[decimal]
+3                 render 3  (v)[int]
+3                 render 4  ('a')[string]
+3                 render 5  (v)[int]
+3                 render 6  (100)[int]
+3                 render 7  (k)[int]
+4  scan                                                                                                                        (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)                +k,unique
+4                 table     kv@primary
+4                 spans     ALL
 
 statement OK
 INSERT INTO kv VALUES

--- a/pkg/sql/trace.go
+++ b/pkg/sql/trace.go
@@ -202,12 +202,6 @@ func (n *explainTraceNode) Next() (bool, error) {
 	return true, nil
 }
 
-func (n *explainTraceNode) ExplainPlan(v bool) (name, description string, children []planNode) {
-	return "explain", "trace", []planNode{n.plan}
-}
-
-func (n *explainTraceNode) explainExprs(fn func(string, parser.Expr)) {}
-
 func (n *explainTraceNode) Values() parser.DTuple {
 	return n.rows[0]
 }

--- a/pkg/sql/union.go
+++ b/pkg/sql/union.go
@@ -158,12 +158,6 @@ func (n *unionNode) SetLimitHint(numRows int64, soft bool) {
 
 func (n *unionNode) setNeededColumns(_ []bool) {}
 
-func (n *unionNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
-	return "union", "-", []planNode{n.left, n.right}
-}
-
-func (n *unionNode) explainExprs(_ func(string, parser.Expr)) {}
-
 func (n *unionNode) MarkDebug(mode explainMode) {
 	if mode != explainDebug {
 		panic(fmt.Sprintf("unknown debug mode %d", mode))

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 )
 
@@ -306,39 +305,6 @@ func (n *valuesNode) InitMaxHeap() {
 func (n *valuesNode) InitMinHeap() {
 	n.invertSorting = false
 	heap.Init(n)
-}
-
-func (n *valuesNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
-	name = "values"
-	suffix := "not yet populated"
-	if n.rows != nil {
-		suffix = fmt.Sprintf("%d row%s",
-			n.rows.Len(), util.Pluralize(int64(n.rows.Len())))
-	} else if n.tuples != nil {
-		suffix = fmt.Sprintf("%d row%s",
-			len(n.tuples), util.Pluralize(int64(len(n.tuples))))
-	}
-	description = fmt.Sprintf("%d column%s, %s",
-		len(n.columns), util.Pluralize(int64(len(n.columns))), suffix)
-
-	var subplans []planNode
-	for _, tuple := range n.tuples {
-		for _, expr := range tuple {
-			subplans = n.p.collectSubqueryPlans(expr, subplans)
-		}
-	}
-
-	return name, description, subplans
-}
-
-func (n *valuesNode) explainExprs(regTypes func(string, parser.Expr)) {
-	if n.n != nil {
-		for i, tuple := range n.tuples {
-			for j, expr := range tuple {
-				regTypes(fmt.Sprintf("row %d, expr %d", i, j), expr)
-			}
-		}
-	}
 }
 
 func (*valuesNode) SetLimitHint(_ int64, _ bool) {}

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -1,0 +1,433 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package sql
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+// planObserver is the interface to implement by components that need
+// to visit a planNode tree.
+// Used mainly by EXPLAIN, but also for the collector of back-references
+// for view definitions.
+type planObserver interface {
+	// enterNode is invoked upon entering a tree node. It can return false to
+	// stop the recursion at this node.
+	enterNode(nodeName string, plan planNode) bool
+
+	// expr is invoked for each expression field in each node.
+	expr(nodeName, fieldName string, n int, expr parser.Expr)
+
+	// attr is invoked for non-expression metadata in each node.
+	attr(nodeName, fieldName, attr string)
+
+	// leaveNode is invoked upon leaving a tree node.
+	leaveNode(nodeName string)
+}
+
+// planVisitor is the support structure for visit().
+type planVisitor struct {
+	p        *planner
+	observer planObserver
+	nodeName string
+}
+
+// visit performs a depth-first traversal of the plan given as
+// argument, informing the planObserver of the node details at each
+// level.
+func (v *planVisitor) visit(plan planNode) {
+	if plan == nil {
+		return
+	}
+
+	lv := *v
+	lv.nodeName = nodeName(plan)
+	recurse := v.observer.enterNode(lv.nodeName, plan)
+	defer lv.observer.leaveNode(lv.nodeName)
+
+	if !recurse {
+		return
+	}
+
+	switch n := plan.(type) {
+	case *valuesNode:
+		suffix := "not yet populated"
+		if n.rows != nil {
+			suffix = fmt.Sprintf("%d row%s",
+				n.rows.Len(), util.Pluralize(int64(n.rows.Len())))
+		} else if n.tuples != nil {
+			suffix = fmt.Sprintf("%d row%s",
+				len(n.tuples), util.Pluralize(int64(len(n.tuples))))
+		}
+		description := fmt.Sprintf("%d column%s, %s",
+			len(n.columns), util.Pluralize(int64(len(n.columns))), suffix)
+		lv.attr("size", description)
+
+		var subplans []planNode
+		for i, tuple := range n.tuples {
+			for j, expr := range tuple {
+				subplans = lv.expr(fmt.Sprintf("row %d, expr", i), j, expr, subplans)
+			}
+		}
+		lv.subqueries(subplans)
+
+	case *valueGenerator:
+		subplans := lv.expr("expr", -1, n.expr, nil)
+		lv.subqueries(subplans)
+
+	case *scanNode:
+		lv.attr("table", fmt.Sprintf("%s@%s", n.desc.Name, n.index.Name))
+		spans := sqlbase.PrettySpans(n.spans, 2)
+		if spans != "" {
+			if spans == "-" {
+				spans = "ALL"
+			}
+			lv.attr("spans", spans)
+		}
+		if n.limitHint > 0 && !n.limitSoft {
+			lv.attr("limit", fmt.Sprintf("%d", n.limitHint))
+		}
+		subplans := lv.expr("filter", -1, n.filter, nil)
+		lv.subqueries(subplans)
+
+	case *selectNode:
+		subplans := lv.expr("filter", -1, n.filter, nil)
+		for i, r := range n.render {
+			subplans = lv.expr("render", i, r, subplans)
+		}
+		if n.explain != explainNone {
+			lv.attr("mode", explainStrings[n.explain])
+		}
+		lv.subqueries(subplans)
+		lv.visit(n.source.plan)
+
+	case *indexJoinNode:
+		lv.visit(n.index)
+		lv.visit(n.table)
+
+	case *joinNode:
+		jType := ""
+		switch n.joinType {
+		case joinTypeInner:
+			jType = "inner"
+			if len(n.pred.leftColNames) == 0 && n.pred.filter == nil {
+				jType = "cross"
+			}
+		case joinTypeLeftOuter:
+			jType = "left outer"
+		case joinTypeRightOuter:
+			jType = "right outer"
+		case joinTypeFullOuter:
+			jType = "full outer"
+		}
+		lv.attr("type", jType)
+
+		if len(n.pred.leftColNames) > 0 {
+			var buf bytes.Buffer
+			buf.WriteByte('(')
+			n.pred.leftColNames.Format(&buf, parser.FmtSimple)
+			buf.WriteString(") = (")
+			n.pred.rightColNames.Format(&buf, parser.FmtSimple)
+			buf.WriteByte(')')
+			lv.attr("equality", buf.String())
+		}
+		subplans := lv.expr("filter", -1, n.pred.filter, nil)
+		lv.subqueries(subplans)
+		lv.visit(n.left.plan)
+		lv.visit(n.right.plan)
+
+	case *selectTopNode:
+		if n.plan != nil {
+			lv.visit(n.plan)
+		} else {
+			if n.limit != nil {
+				lv.visit(n.limit)
+			}
+			if n.distinct != nil {
+				lv.visit(n.distinct)
+			}
+			if n.sort != nil {
+				lv.visit(n.sort)
+			}
+			if n.window != nil {
+				lv.visit(n.window)
+			}
+			if n.group != nil {
+				lv.visit(n.group)
+			}
+			lv.visit(n.source)
+		}
+
+	case *limitNode:
+		subplans := lv.expr("count", -1, n.countExpr, nil)
+		subplans = lv.expr("offset", -1, n.offsetExpr, subplans)
+		lv.subqueries(subplans)
+		lv.visit(n.plan)
+
+	case *distinctNode:
+		if n.columnsInOrder != nil {
+			var buf bytes.Buffer
+			prefix := ""
+			columns := n.Columns()
+			for i, key := range n.columnsInOrder {
+				if key {
+					buf.WriteString(prefix)
+					buf.WriteString(columns[i].Name)
+					prefix = ", "
+				}
+			}
+			lv.attr("key", buf.String())
+		}
+		lv.visit(n.plan)
+
+	case *sortNode:
+		var columns ResultColumns
+		if n.plan != nil {
+			columns = n.plan.Columns()
+		}
+		// We use n.ordering and not plan.Ordering() because
+		// plan.Ordering() does not include the added sort columns not
+		// present in the output.
+		order := orderingInfo{ordering: n.ordering}
+		lv.attr("order", order.AsString(columns))
+		switch ss := n.sortStrategy.(type) {
+		case *iterativeSortStrategy:
+			lv.attr("strategy", "iterative")
+		case *sortTopKStrategy:
+			lv.attr("strategy", fmt.Sprintf("top %d", ss.topK))
+		}
+		lv.visit(n.plan)
+
+	case *groupNode:
+		var subplans []planNode
+		for i, agg := range n.funcs {
+			subplans = lv.expr("aggregate", i, agg.expr, subplans)
+		}
+		for i, rexpr := range n.render {
+			subplans = lv.expr("render", i, rexpr, subplans)
+		}
+		subplans = lv.expr("having", -1, n.having, subplans)
+		lv.subqueries(subplans)
+		lv.visit(n.plan)
+
+	case *windowNode:
+		var subplans []planNode
+		for i, agg := range n.funcs {
+			subplans = lv.expr("window", i, agg.expr, subplans)
+		}
+		for i, rexpr := range n.windowRender {
+			subplans = lv.expr("render", i, rexpr, subplans)
+		}
+		lv.subqueries(subplans)
+		lv.visit(n.plan)
+
+	case *unionNode:
+		lv.visit(n.left)
+		lv.visit(n.right)
+
+	case *splitNode:
+		var subplans []planNode
+		for i, e := range n.exprs {
+			subplans = lv.expr("expr", i, e, subplans)
+		}
+		lv.subqueries(subplans)
+
+	case *insertNode:
+		var buf bytes.Buffer
+		buf.WriteString(n.tableDesc.Name)
+		buf.WriteByte('(')
+		for i, col := range n.insertCols {
+			if i > 0 {
+				buf.WriteString(", ")
+			}
+			buf.WriteString(col.Name)
+		}
+		buf.WriteByte(')')
+		lv.attr("into", buf.String())
+
+		var subplans []planNode
+		for i, dexpr := range n.defaultExprs {
+			subplans = lv.expr("default", i, dexpr, subplans)
+		}
+		for i, cexpr := range n.checkHelper.exprs {
+			subplans = lv.expr("check", i, cexpr, subplans)
+		}
+		for i, rexpr := range n.rh.exprs {
+			subplans = lv.expr("returning", i, rexpr, subplans)
+		}
+		lv.subqueries(subplans)
+		lv.visit(n.run.rows)
+
+	case *updateNode:
+		lv.attr("table", n.tableDesc.Name)
+		if len(n.tw.ru.updateCols) > 0 {
+			var buf bytes.Buffer
+			for i, col := range n.tw.ru.updateCols {
+				if i > 0 {
+					buf.WriteString(", ")
+				}
+				buf.WriteString(col.Name)
+			}
+			lv.attr("set", buf.String())
+		}
+		var subplans []planNode
+		for i, rexpr := range n.rh.exprs {
+			subplans = lv.expr("returning", i, rexpr, subplans)
+		}
+		lv.subqueries(subplans)
+		lv.visit(n.run.rows)
+
+	case *deleteNode:
+		lv.attr("from", n.tableDesc.Name)
+		var subplans []planNode
+		for i, rexpr := range n.rh.exprs {
+			subplans = lv.expr("returning", i, rexpr, subplans)
+		}
+		lv.subqueries(subplans)
+		lv.visit(n.run.rows)
+
+	case *createTableNode:
+		if n.n.As() {
+			lv.visit(n.sourcePlan)
+		}
+
+	case *createViewNode:
+		lv.attr("query", n.sourceQuery)
+		lv.visit(n.sourcePlan)
+
+	case *delayedNode:
+		lv.attr("source", n.name)
+		lv.visit(n.plan)
+
+	case *explainDebugNode:
+		lv.visit(n.plan)
+
+	case *ordinalityNode:
+		lv.visit(n.source)
+
+	case *explainTraceNode:
+		lv.visit(n.plan)
+
+	case *explainPlanNode:
+		lv.attr("expanded", strconv.FormatBool(n.expanded))
+		lv.visit(n.plan)
+	}
+}
+
+// attr wraps observer.attr() and provides it with the current node's name.
+func (v *planVisitor) attr(name, value string) {
+	v.observer.attr(v.nodeName, name, value)
+}
+
+// subqueries informs the observer that the following sub-plans are
+// for sub-queries.
+func (v *planVisitor) subqueries(subplans []planNode) {
+	if len(subplans) == 0 {
+		return
+	}
+	v.attr("subqueries", strconv.Itoa(len(subplans)))
+	for _, p := range subplans {
+		v.visit(p)
+	}
+}
+
+// expr wraps observer.expr() and provides it with the current node's
+// name. It also collects the plans for the sub-queries.
+func (v *planVisitor) expr(
+	fieldName string, n int, expr parser.Expr, subplans []planNode,
+) []planNode {
+	v.observer.expr(v.nodeName, fieldName, n, expr)
+	subplans = v.p.collectSubqueryPlans(expr, subplans)
+	return subplans
+}
+
+// nodeName returns the name of the given planNode as string.  The
+// node's current state is taken into account, e.g. sortNode has
+// either name "sort" or "nosort" depending on whether sorting is
+// needed.
+func nodeName(plan planNode) string {
+	// Some nodes have custom names depending on attributes.
+	switch n := plan.(type) {
+	case *emptyNode:
+		if n.results {
+			return "nullrow"
+		}
+	case *sortNode:
+		if !n.needSort {
+			return "nosort"
+		}
+	case *scanNode:
+		if n.reverse {
+			return "revscan"
+		}
+	case *unionNode:
+		if n.emitAll {
+			return "append"
+		}
+	}
+
+	name, ok := planNodeNames[reflect.TypeOf(plan)]
+	if !ok {
+		panic(fmt.Sprintf("name missing for type %T", plan))
+	}
+
+	return name
+}
+
+// planNodeNames is the mapping from node type to strings.  The
+// strings are constant and not precomptued so that the type names can
+// be changed without changing the output of "EXPLAIN".
+var planNodeNames = map[reflect.Type]string{
+	reflect.TypeOf(&alterTableNode{}):     "alter table",
+	reflect.TypeOf(&createDatabaseNode{}): "create database",
+	reflect.TypeOf(&createIndexNode{}):    "create index",
+	reflect.TypeOf(&createTableNode{}):    "create table",
+	reflect.TypeOf(&createViewNode{}):     "create view",
+	reflect.TypeOf(&delayedNode{}):        "virtual table",
+	reflect.TypeOf(&deleteNode{}):         "delete",
+	reflect.TypeOf(&distinctNode{}):       "distinct",
+	reflect.TypeOf(&dropDatabaseNode{}):   "drop database",
+	reflect.TypeOf(&dropIndexNode{}):      "drop index",
+	reflect.TypeOf(&dropTableNode{}):      "drop table",
+	reflect.TypeOf(&dropViewNode{}):       "drop view",
+	reflect.TypeOf(&emptyNode{}):          "empty",
+	reflect.TypeOf(&explainDebugNode{}):   "explain debug",
+	reflect.TypeOf(&explainTraceNode{}):   "explain trace",
+	reflect.TypeOf(&groupNode{}):          "group",
+	reflect.TypeOf(&indexJoinNode{}):      "index-join",
+	reflect.TypeOf(&insertNode{}):         "insert",
+	reflect.TypeOf(&joinNode{}):           "join",
+	reflect.TypeOf(&limitNode{}):          "limit",
+	reflect.TypeOf(&ordinalityNode{}):     "ordinality",
+	reflect.TypeOf(&scanNode{}):           "scan",
+	reflect.TypeOf(&selectNode{}):         "render/filter",
+	reflect.TypeOf(&selectTopNode{}):      "select",
+	reflect.TypeOf(&sortNode{}):           "sort",
+	reflect.TypeOf(&splitNode{}):          "split",
+	reflect.TypeOf(&unionNode{}):          "union",
+	reflect.TypeOf(&updateNode{}):         "update",
+	reflect.TypeOf(&valueGenerator{}):     "generator",
+	reflect.TypeOf(&valuesNode{}):         "values",
+	reflect.TypeOf(&windowNode{}):         "window",
+}

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -759,32 +759,6 @@ func (n *windowNode) populateValues() error {
 	return nil
 }
 
-func (n *windowNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
-	name = "window"
-	var buf bytes.Buffer
-	for i, f := range n.funcs {
-		if i > 0 {
-			buf.WriteString(", ")
-		}
-		f.Format(&buf, parser.FmtSimple)
-	}
-
-	subplans := []planNode{n.plan}
-	for _, e := range n.windowRender {
-		subplans = n.planner.collectSubqueryPlans(e, subplans)
-	}
-	return name, buf.String(), subplans
-}
-
-func (n *windowNode) explainExprs(regTypes func(string, parser.Expr)) {
-	cols := n.Columns()
-	for i, rexpr := range n.windowRender {
-		if rexpr != nil {
-			regTypes(fmt.Sprintf("render %s", cols[i].Name), rexpr)
-		}
-	}
-}
-
 func (*windowNode) SetLimitHint(_ int64, _ bool) {}
 func (*windowNode) setNeededColumns(_ []bool)    {}
 


### PR DESCRIPTION
This patch:

- captures the ExplanPlan / explainExprs logic into a new
  multi-purpose (reusable) `planVisitor`.

- adapts the back-reference analysis for view definitions to use this
  new visitor, as well as the (temporary) detection of star expansion.

- adapts the EXPLAIN logic to use this new visitor.

- clarifies the output of EXPLAIN even when INDENT is not specified.

Before:
```
EXPLAIN(VERBOSE) SELECT a, b FROM abc ORDER BY b, c
----
0  select                                                                          (a, b)                 +b
1  nosort                   +b,+c                                                  (a, b)                 +b
2  render/filter            from (test.abc.a, test.abc.b, test.abc.c, test.abc.d)  (a, b, c)              +b,+c,unique
2  render/filter  render 0  test.abc.a
2  render/filter  render 1  test.abc.b
2  render/filter  render 2  test.abc.c
3  scan                     abc@bc ALL                                             (a, b, c, d[omitted])  +b,+c,unique
```

After:

```
EXPLAIN(VERBOSE) SELECT a, b FROM abc ORDER BY b, c
----
0  select                               (a, b)                 +b
1  nosort                               (a, b)                 +b
1                 order     +b,+c
2  render/filter                        (a, b, c)              +b,+c,unique
2                 render 0  test.abc.a
2                 render 1  test.abc.b
2                 render 2  test.abc.c
3  scan                                 (a, b, c, d[omitted])  +b,+c,unique
3                 table     abc@bc
3                 spans     ALL
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12553)
<!-- Reviewable:end -->
