### PR TITLE
distsqlrun: outer distributed hash joins can use ON filter expressions correctly

### DIFF
--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -124,6 +124,7 @@ func TestHashJoiner(t *testing.T) {
 				{v[0], v[1], v[4]},
 			},
 		},
+		// Test that inner joins work with filter expressions.
 		{
 			spec: HashJoinerSpec{
 				LeftEqColumns: []uint32{0},
@@ -334,6 +335,107 @@ func TestHashJoiner(t *testing.T) {
 			expected: sqlbase.EncDatumRows{
 				{v[3], v[4], v[1]},
 				{v[4], v[4], v[5]},
+			},
+		},
+		// Test that left outer joins work with filters as expected.
+		{
+			spec: HashJoinerSpec{
+				LeftEqColumns: []uint32{0},
+				LeftTypes: []sqlbase.ColumnType{
+					columnTypeInt,
+				},
+				RightEqColumns: []uint32{0},
+				RightTypes: []sqlbase.ColumnType{
+					columnTypeInt,
+				},
+				Type:          JoinType_LEFT_OUTER,
+				OutputColumns: []uint32{0, 1},
+				Expr:          Expression{Expr: "@2 > 1"},
+			},
+			inputs: []sqlbase.EncDatumRows{
+				{
+					{v[0]},
+					{v[1]},
+					{v[2]},
+				},
+				{
+					{v[1]},
+					{v[2]},
+					{v[3]},
+				},
+			},
+			expected: sqlbase.EncDatumRows{
+				{v[0], null},
+				{v[1], null},
+				{v[2], v[2]},
+			},
+		},
+		// Test that right outer joins work with filters as expected.
+		{
+			spec: HashJoinerSpec{
+				LeftEqColumns: []uint32{0},
+				LeftTypes: []sqlbase.ColumnType{
+					columnTypeInt,
+				},
+				RightEqColumns: []uint32{0},
+				RightTypes: []sqlbase.ColumnType{
+					columnTypeInt,
+				},
+				Type:          JoinType_RIGHT_OUTER,
+				OutputColumns: []uint32{0, 1},
+				Expr:          Expression{Expr: "@2 > 1"},
+			},
+			inputs: []sqlbase.EncDatumRows{
+				{
+					{v[0]},
+					{v[1]},
+					{v[2]},
+				},
+				{
+					{v[1]},
+					{v[2]},
+					{v[3]},
+				},
+			},
+			expected: sqlbase.EncDatumRows{
+				{null, v[1]},
+				{v[2], v[2]},
+				{null, v[3]},
+			},
+		},
+		// Test that full outer joins work with filters as expected.
+		{
+			spec: HashJoinerSpec{
+				LeftEqColumns: []uint32{0},
+				LeftTypes: []sqlbase.ColumnType{
+					columnTypeInt,
+				},
+				RightEqColumns: []uint32{0},
+				RightTypes: []sqlbase.ColumnType{
+					columnTypeInt,
+				},
+				Type:          JoinType_FULL_OUTER,
+				OutputColumns: []uint32{0, 1},
+				Expr:          Expression{Expr: "@2 > 1"},
+			},
+			inputs: []sqlbase.EncDatumRows{
+				{
+					{v[0]},
+					{v[1]},
+					{v[2]},
+				},
+				{
+					{v[1]},
+					{v[2]},
+					{v[3]},
+				},
+			},
+			expected: sqlbase.EncDatumRows{
+				{v[0], null},
+				{null, v[1]},
+				{v[1], null},
+				{v[2], v[2]},
+				{null, v[3]},
 			},
 		},
 

--- a/pkg/sql/distsqlrun/joinerbase.go
+++ b/pkg/sql/distsqlrun/joinerbase.go
@@ -77,23 +77,31 @@ func (jb *joinerBase) init(
 // render returns a nil row if no row is to be emitted (eg. if join type is
 // inner join and one of the given rows is nil).
 func (jb *joinerBase) render(lrow, rrow sqlbase.EncDatumRow) (sqlbase.EncDatumRow, error) {
+	lnil := lrow == nil
+	rnil := rrow == nil
 	switch jb.joinType {
 	case innerJoin:
-		if lrow == nil || rrow == nil {
+		if lnil || rnil {
 			return nil, nil
 		}
 	case fullOuter:
-		if lrow == nil {
+		if lnil {
 			lrow = jb.emptyLeft
-		} else if rrow == nil {
+		} else if rnil {
 			rrow = jb.emptyRight
 		}
 	case leftOuter:
-		if rrow == nil {
+		if lnil {
+			return nil, nil
+		}
+		if rnil {
 			rrow = jb.emptyRight
 		}
 	case rightOuter:
-		if lrow == nil {
+		if rnil {
+			return nil, nil
+		}
+		if lnil {
 			lrow = jb.emptyLeft
 		}
 	}

--- a/pkg/sql/distsqlrun/joinerbase.go
+++ b/pkg/sql/distsqlrun/joinerbase.go
@@ -82,31 +82,17 @@ func (jb *joinerBase) render(
 ) (ret sqlbase.EncDatumRow, failedFilter bool, err error) {
 	lnil := lrow == nil
 	rnil := rrow == nil
-	switch jb.joinType {
-	case innerJoin:
-		if lnil || rnil {
+	if lnil {
+		if jb.joinType == innerJoin || jb.joinType == leftOuter {
 			return nil, false, nil
 		}
-	case fullOuter:
-		if lnil {
-			lrow = jb.emptyLeft
-		} else if rnil {
-			rrow = jb.emptyRight
-		}
-	case leftOuter:
-		if lnil {
+		lrow = jb.emptyLeft
+	}
+	if rnil {
+		if jb.joinType == innerJoin || jb.joinType == rightOuter {
 			return nil, false, nil
 		}
-		if rnil {
-			rrow = jb.emptyRight
-		}
-	case rightOuter:
-		if rnil {
-			return nil, false, nil
-		}
-		if lnil {
-			lrow = jb.emptyLeft
-		}
+		rrow = jb.emptyRight
 	}
 	jb.combinedRow = append(jb.combinedRow[:0], lrow...)
 	jb.combinedRow = append(jb.combinedRow, rrow...)

--- a/pkg/sql/distsqlrun/joinerbase.go
+++ b/pkg/sql/distsqlrun/joinerbase.go
@@ -31,7 +31,7 @@ type joinerBase struct {
 
 	joinType    joinType
 	outputCols  columns
-	filter      exprHelper
+	onCond      exprHelper
 	rowAlloc    sqlbase.EncDatumRowAlloc
 	emptyLeft   sqlbase.EncDatumRow
 	emptyRight  sqlbase.EncDatumRow
@@ -67,19 +67,19 @@ func (jb *joinerBase) init(
 	types = append(types, leftTypes...)
 	types = append(types, rightTypes...)
 
-	return jb.filter.init(expr, types, flowCtx.evalCtx)
+	return jb.onCond.init(expr, types, flowCtx.evalCtx)
 }
 
-// render evaluates the provided filter and constructs a row with columns from
-// both rows as specified by the provided output columns. We expect left or
-// right to be nil if there was no explicit "join" match, the filter is then
-// evaluated on a combinedRow with null values for the columns of the nil row.
-// render returns a nil row if no row is to be emitted (eg. if join type is
+// render evaluates the provided on-condition and constructs a row with columns
+// from both rows as specified by the provided output columns. We expect left or
+// right to be nil if there was no explicit "join" match, the on condition is
+// then evaluated on a combinedRow with null values for the columns of the nil
+// row. render returns a nil row if no row is to be emitted (eg. if join type is
 // inner join and one of the given rows is nil). The returned boolean indicates
-// whether or not the returned row failed the filter condition.
+// whether or not the returned row failed the on condition.
 func (jb *joinerBase) render(
 	lrow, rrow sqlbase.EncDatumRow,
-) (ret sqlbase.EncDatumRow, failedFilter bool, err error) {
+) (ret sqlbase.EncDatumRow, failedOnCond bool, err error) {
 	lnil := lrow == nil
 	rnil := rrow == nil
 	if lnil {
@@ -96,20 +96,21 @@ func (jb *joinerBase) render(
 	}
 	jb.combinedRow = append(jb.combinedRow[:0], lrow...)
 	jb.combinedRow = append(jb.combinedRow, rrow...)
-	res, err := jb.filter.evalFilter(jb.combinedRow)
+	res, err := jb.onCond.evalFilter(jb.combinedRow)
 	if err != nil {
 		return nil, false, err
 	}
 	if !res && !rnil && !lnil {
-		// The filter failed and we're trying to render a row that's been
-		// successfully equality joined already. In this case, we need to output
-		// a failed match row that contains just the left side, if we're required
-		// to by the join style.
+		// The on condition failed and we're trying to render a row that's been
+		// successfully equality joined already. In this case, we need to
+		// output a failed match row that contains just the left side, if we're
+		// required to by the join style.
 		if jb.joinType == innerJoin || jb.joinType == rightOuter {
-			// If we're doing an inner or right outer join, we shouldn't return a row:
-			// we don't want to output rows with NULL right sides. We still need to
-			// notify the caller that the filter failed, though, because they'll want
-			// to render the corresponding right side row by itself later.
+			// If we're doing an inner or right outer join, we shouldn't return
+			// a row: we don't want to output rows with NULL right sides. We
+			// still need to notify the caller that the on condition failed,
+			// though, because they'll want to render the corresponding right
+			// side row by itself later.
 			return nil, true, nil
 		}
 		jb.combinedRow = append(jb.combinedRow[:len(lrow)], jb.emptyRight...)

--- a/pkg/sql/distsqlrun/mergejoiner.go
+++ b/pkg/sql/distsqlrun/mergejoiner.go
@@ -86,7 +86,7 @@ func (m *mergeJoiner) Run(wg *sync.WaitGroup) {
 			return
 		}
 		for _, rowPair := range batch {
-			row, err := m.render(rowPair[0], rowPair[1])
+			row, _, err := m.render(rowPair[0], rowPair[1])
 			if err != nil {
 				m.output.Close(err)
 				return


### PR DESCRIPTION
This PR fixes a few bugs in distributed hash join and provides support for filter expressions in `OUTER JOIN`.

@knz I did not add memory accounting in the same place as before because I didn't see a nearby memory account in the code. There's probably something that I'm missing about that - please let me know what it is!

cc @irfansharif 

Updates #12550.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12558)
<!-- Reviewable:end -->
