### PR TITLE
storage: filter unusable stores from candidate count

### DIFF
--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -437,6 +437,29 @@ func (a *Allocator) TransferLeaseTarget(
 	sl, _, _ := a.storePool.getStoreList(rangeID)
 	sl = sl.filter(constraints)
 
+	// Filter stores that are on nodes containing existing replicas, but leave
+	// the stores containing the existing replicas in place. This excludes stores
+	// that we can't rebalance to, avoiding an issue in a 3-node cluster where
+	// there are multiple stores per node.
+	//
+	// TODO(peter,bram): This will need adjustment with the new allocator. `sl`
+	// needs to contain only the possible rebalance candidates + the existing
+	// stores the replicas are on.
+	filteredDescs := make([]roachpb.StoreDescriptor, 0, len(sl.stores))
+	for _, s := range sl.stores {
+		var exclude bool
+		for _, r := range existing {
+			if r.NodeID == s.Node.NodeID && r.StoreID != s.StoreID {
+				exclude = true
+				break
+			}
+		}
+		if !exclude {
+			filteredDescs = append(filteredDescs, s)
+		}
+	}
+	sl = makeStoreList(filteredDescs)
+
 	source, ok := a.storePool.getStoreDescriptor(leaseStoreID)
 	if !ok {
 		return roachpb.ReplicaDescriptor{}


### PR DESCRIPTION
Stores that are on the same node as existing replicas are not usable
targets for rebalancing which can foul up the lease rebalancing
heuristics. In particular, in a 3-node cluster with 2 stores per node a
3 replica range will see half the stores as being unusable for
rebalancing. Not being able to rebalance replicas to those stores then
fouls up the lease rebalancing heuristics which tries to keep the number
of leases per store close to the average. Now we only consider stores
which are usable rebalance targets in compute the average lease per
store.

Fixes #12322

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12565)
<!-- Reviewable:end -->
