### PR TITLE
sql: fix parsing of second-precise intervals

### DIFF
--- a/pkg/sql/parser/sql.go
+++ b/pkg/sql/parser/sql.go
@@ -8469,7 +8469,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:3464
 		{
-			sqlVAL.union.val = sqlDollar[1].union
+			sqlVAL.union.val = sqlDollar[1].union.durationField()
 		}
 	case 564:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
@@ -8493,7 +8493,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
 		//line sql.y:3482
 		{
-			sqlVAL.union.val = sqlDollar[3].union
+			sqlVAL.union.val = sqlDollar[3].union.durationField()
 		}
 	case 568:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
@@ -8505,13 +8505,13 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
 		//line sql.y:3490
 		{
-			sqlVAL.union.val = sqlDollar[3].union
+			sqlVAL.union.val = sqlDollar[3].union.durationField()
 		}
 	case 570:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
 		//line sql.y:3494
 		{
-			sqlVAL.union.val = sqlDollar[3].union
+			sqlVAL.union.val = sqlDollar[3].union.durationField()
 		}
 	case 571:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3466,7 +3466,7 @@ opt_interval:
   }
 | interval_second
   {
-    $$.val = $1
+    $$.val = $1.durationField()
   }
 // Like Postgres, we ignore the left duration field. See explanation:
 // https://www.postgresql.org/message-id/20110510040219.GD5617%40tornado.gateway.2wire.net
@@ -3484,7 +3484,7 @@ opt_interval:
   }
 | DAY TO interval_second
   {
-    $$.val = $3
+    $$.val = $3.durationField()
   }
 | HOUR TO MINUTE
   {
@@ -3492,11 +3492,11 @@ opt_interval:
   }
 | HOUR TO interval_second
   {
-    $$.val = $3
+    $$.val = $3.durationField()
   }
 | MINUTE TO interval_second
   {
-    $$.val = $3
+    $$.val = $3.durationField()
   }
 | /* EMPTY */ {}
 

--- a/pkg/sql/testdata/datetime
+++ b/pkg/sql/testdata/datetime
@@ -687,6 +687,22 @@ SHOW TIME ZONE
 -5
 
 statement ok
+SET TIME ZONE INTERVAL '+04:00' HOUR TO MINUTE;
+
+query T
+SELECT '2015-08-24 21:45:45.53453'::timestamptz
+----
+2015-08-24 21:45:45.53453 +0400 +0400
+
+statement ok
+SET TIME ZONE INTERVAL '-04:00' MINUTE TO SECOND;
+
+query T
+SELECT '2015-08-24 21:45:45.53453'::timestamptz
+----
+2015-08-24 21:45:45.53453 -0400 -0400
+
+statement ok
 SET TIME ZONE 0
 
 query T


### PR DESCRIPTION
And add tests. The grammar was defined incorrectly.

Fixes #12564.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12566)
<!-- Reviewable:end -->
