### PR TITLE
sql: use a leased table descriptor during a schema change backfill. 

### DIFF
--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -247,13 +247,13 @@ func (s LeaseStore) Release(lease *LeaseState) error {
 	return err
 }
 
-// waitForOneVersion returns once there are no unexpired leases on the
+// WaitForOneVersion returns once there are no unexpired leases on the
 // previous version of the table descriptor. It returns the current version.
 // After returning there can only be versions of the descriptor >= to the
 // returned version. Lease acquisition (see acquire()) maintains the
 // invariant that no new leases for desc.Version-1 will be granted once
 // desc.Version exists.
-func (s LeaseStore) waitForOneVersion(
+func (s LeaseStore) WaitForOneVersion(
 	tableID sqlbase.ID, retryOpts retry.Options,
 ) (sqlbase.DescriptorVersion, error) {
 	desc := &sqlbase.Descriptor{}
@@ -306,7 +306,7 @@ func (s LeaseStore) Publish(
 	for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
 		// Wait until there are no unexpired leases on the previous version
 		// of the table.
-		expectedVersion, err := s.waitForOneVersion(tableID, base.DefaultRetryOptions())
+		expectedVersion, err := s.WaitForOneVersion(tableID, base.DefaultRetryOptions())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -431,7 +431,7 @@ func (sc *SchemaChanger) waitToUpdateLeases(tableID sqlbase.ID) error {
 	if log.V(2) {
 		log.Infof(context.TODO(), "waiting for a single version of table %d...", tableID)
 	}
-	_, err := sc.leaseMgr.waitForOneVersion(tableID, retryOpts)
+	_, err := sc.leaseMgr.WaitForOneVersion(tableID, retryOpts)
 	if log.V(2) {
 		log.Infof(context.TODO(), "waiting for a single version of table %d... done", tableID)
 	}


### PR DESCRIPTION
This eliminates the need for a schema change backfill chunk operation to read the table descriptor from the database. I suppose in the future we can potentially allow backfills to run in a distributed fashion using table descriptor leases.

 I don't expect to read your review before the new year, but if you get to it I'll take a look. Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12567)
<!-- Reviewable:end -->
