### PR TITLE
sql: rename join filter to onCond

### DIFF
--- a/pkg/sql/testdata/join
+++ b/pkg/sql/testdata/join
@@ -447,8 +447,8 @@ EXPLAIN(EXPRS) SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
 0                 render 2  x
 0                 render 3  y
 1  join
-1                 type      inner
-1                 filter    a.x = 44
+1                 type    inner
+1                 pred    a.x = 44
 2  scan
 2                 table     twocolumn@primary
 2  scan
@@ -500,8 +500,8 @@ EXPLAIN(EXPRS) SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a
 1                 render 4  d
 1                 render 5  e
 2  join
-2                 type      inner
-2                 filter    (a.b = c.d) AND (c.d = test.onecolumn.x)
+2                 type    inner
+2                 pred    (a.b = c.d) AND (c.d = test.onecolumn.x)
 3  join
 3                 type      inner
 3                 equality  (x) = (b)

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -131,7 +131,7 @@ func (v *planVisitor) visit(plan planNode) {
 		switch n.joinType {
 		case joinTypeInner:
 			jType = "inner"
-			if len(n.pred.leftColNames) == 0 && n.pred.filter == nil {
+			if len(n.pred.leftColNames) == 0 && n.pred.onCond == nil {
 				jType = "cross"
 			}
 		case joinTypeLeftOuter:
@@ -152,7 +152,7 @@ func (v *planVisitor) visit(plan planNode) {
 			buf.WriteByte(')')
 			lv.attr("equality", buf.String())
 		}
-		subplans := lv.expr("filter", -1, n.pred.filter, nil)
+		subplans := lv.expr("pred", -1, n.pred.onCond, nil)
 		lv.subqueries(subplans)
 		lv.visit(n.left.plan)
 		lv.visit(n.right.plan)


### PR DESCRIPTION
As mentioned in #12558, it's confusing that the expression on `ON`
conditions of `JOIN`s are referred to as filters, because that is
ambiguous with respect to `WHERE` conditions.

Rename the `filter` field in `join_predicate` to `onCond`.

cc @RaduBerinde

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12568)
<!-- Reviewable:end -->
