### PR TITLE
storage: Fix a race introduced by #12561

### DIFF
--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -148,9 +148,12 @@ func (r *Replica) executeCmd(
 
 	if cmd, ok := commands[args.Method()]; ok {
 		cArgs := CommandArgs{
-			Repl:    r,
-			Header:  h,
-			Args:    args,
+			Repl:   r,
+			Header: h,
+			// Some commands mutate their arguments, so give each invocation
+			// its own copy (shallow to mimic earlier versions of this code
+			// in which args were passed by value instead of pointer).
+			Args:    args.ShallowCopy(),
 			MaxKeys: maxKeys,
 			Stats:   ms,
 		}


### PR DESCRIPTION
Some commands (including at least RequestLease and PushTxn) mutate their
arguments and need a copy to be made.

Fixes #12570

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12571)
<!-- Reviewable:end -->
