### PR TITLE
sql: rewrite setNeededColumns() and complete the feature.

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -402,7 +402,6 @@ func (n *alterTableNode) Ordering() orderingInfo       { return orderingInfo{} }
 func (n *alterTableNode) Values() parser.DTuple        { return parser.DTuple{} }
 func (n *alterTableNode) DebugValues() debugValues     { return debugValues{} }
 func (n *alterTableNode) SetLimitHint(_ int64, _ bool) {}
-func (n *alterTableNode) setNeededColumns(_ []bool)    {}
 func (n *alterTableNode) MarkDebug(mode explainMode)   {}
 
 func applyColumnMutation(

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -53,7 +53,6 @@ func (n *copyNode) Columns() ResultColumns     { return n.resultColumns }
 func (*copyNode) Ordering() orderingInfo       { return orderingInfo{} }
 func (*copyNode) Values() parser.DTuple        { return nil }
 func (*copyNode) SetLimitHint(_ int64, _ bool) {}
-func (*copyNode) setNeededColumns(_ []bool)    {}
 func (*copyNode) MarkDebug(_ explainMode)      {}
 func (*copyNode) expandPlan() error            { return nil }
 func (*copyNode) Next() (bool, error)          { return false, nil }

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -143,7 +143,6 @@ func (n *createDatabaseNode) Ordering() orderingInfo       { return orderingInfo
 func (n *createDatabaseNode) Values() parser.DTuple        { return parser.DTuple{} }
 func (n *createDatabaseNode) DebugValues() debugValues     { return debugValues{} }
 func (n *createDatabaseNode) SetLimitHint(_ int64, _ bool) {}
-func (n *createDatabaseNode) setNeededColumns(_ []bool)    {}
 func (n *createDatabaseNode) MarkDebug(mode explainMode)   {}
 
 type createIndexNode struct {
@@ -259,7 +258,6 @@ func (n *createIndexNode) Ordering() orderingInfo       { return orderingInfo{} 
 func (n *createIndexNode) Values() parser.DTuple        { return parser.DTuple{} }
 func (n *createIndexNode) DebugValues() debugValues     { return debugValues{} }
 func (n *createIndexNode) SetLimitHint(_ int64, _ bool) {}
-func (n *createIndexNode) setNeededColumns(_ []bool)    {}
 func (n *createIndexNode) MarkDebug(mode explainMode)   {}
 
 type createUserNode struct {
@@ -348,7 +346,6 @@ func (n *createUserNode) Ordering() orderingInfo       { return orderingInfo{} }
 func (n *createUserNode) Values() parser.DTuple        { return parser.DTuple{} }
 func (n *createUserNode) DebugValues() debugValues     { return debugValues{} }
 func (n *createUserNode) SetLimitHint(_ int64, _ bool) {}
-func (n *createUserNode) setNeededColumns(_ []bool)    {}
 func (n *createUserNode) MarkDebug(mode explainMode)   {}
 
 type createViewNode struct {
@@ -498,7 +495,6 @@ func (n *createViewNode) Columns() ResultColumns       { return make(ResultColum
 func (n *createViewNode) Ordering() orderingInfo       { return orderingInfo{} }
 func (n *createViewNode) Values() parser.DTuple        { return parser.DTuple{} }
 func (n *createViewNode) DebugValues() debugValues     { return debugValues{} }
-func (n *createViewNode) setNeededColumns(_ []bool)    {}
 func (n *createViewNode) SetLimitHint(_ int64, _ bool) {}
 func (n *createViewNode) MarkDebug(mode explainMode)   {}
 
@@ -729,7 +725,6 @@ func (n *createTableNode) Ordering() orderingInfo       { return orderingInfo{} 
 func (n *createTableNode) Values() parser.DTuple        { return parser.DTuple{} }
 func (n *createTableNode) DebugValues() debugValues     { return debugValues{} }
 func (n *createTableNode) SetLimitHint(_ int64, _ bool) {}
-func (n *createTableNode) setNeededColumns(_ []bool)    {}
 func (n *createTableNode) MarkDebug(mode explainMode)   {}
 
 type indexMatch bool

--- a/pkg/sql/delayed.go
+++ b/pkg/sql/delayed.go
@@ -32,7 +32,6 @@ type delayedNode struct {
 type nodeConstructor func(p *planner) (planNode, error)
 
 func (d *delayedNode) SetLimitHint(_ int64, _ bool) {}
-func (d *delayedNode) setNeededColumns(_ []bool)    {}
 
 func (d *delayedNode) expandPlan() error {
 	v, err := d.constructor(d.p)

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -238,9 +238,7 @@ func (d *deleteNode) DebugValues() debugValues {
 	return d.run.rows.DebugValues()
 }
 
-func (d *deleteNode) Ordering() orderingInfo {
-	return d.run.rows.Ordering()
-}
+func (d *deleteNode) Ordering() orderingInfo { return orderingInfo{} }
 
 func (d *deleteNode) SetLimitHint(numRows int64, soft bool) {}
 func (d *deleteNode) setNeededColumns(_ []bool)             {}

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -241,4 +241,3 @@ func (d *deleteNode) DebugValues() debugValues {
 func (d *deleteNode) Ordering() orderingInfo { return orderingInfo{} }
 
 func (d *deleteNode) SetLimitHint(numRows int64, soft bool) {}
-func (d *deleteNode) setNeededColumns(_ []bool)             {}

--- a/pkg/sql/distinct.go
+++ b/pkg/sql/distinct.go
@@ -244,8 +244,6 @@ func (n *distinctNode) SetLimitHint(numRows int64, soft bool) {
 	n.plan.SetLimitHint(numRows, true)
 }
 
-func (*distinctNode) setNeededColumns(_ []bool) {}
-
 func (n *distinctNode) Close() {
 	n.plan.Close()
 	n.prefixSeen = nil

--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -217,7 +217,6 @@ func (n *dropDatabaseNode) Ordering() orderingInfo       { return orderingInfo{}
 func (n *dropDatabaseNode) Values() parser.DTuple        { return parser.DTuple{} }
 func (n *dropDatabaseNode) DebugValues() debugValues     { return debugValues{} }
 func (n *dropDatabaseNode) SetLimitHint(_ int64, _ bool) {}
-func (n *dropDatabaseNode) setNeededColumns(_ []bool)    {}
 func (n *dropDatabaseNode) MarkDebug(mode explainMode)   {}
 
 type dropIndexNode struct {
@@ -394,7 +393,6 @@ func (n *dropIndexNode) Ordering() orderingInfo       { return orderingInfo{} }
 func (n *dropIndexNode) Values() parser.DTuple        { return parser.DTuple{} }
 func (n *dropIndexNode) DebugValues() debugValues     { return debugValues{} }
 func (n *dropIndexNode) SetLimitHint(_ int64, _ bool) {}
-func (n *dropIndexNode) setNeededColumns(_ []bool)    {}
 func (n *dropIndexNode) MarkDebug(mode explainMode)   {}
 
 type dropViewNode struct {
@@ -507,7 +505,6 @@ func (n *dropViewNode) Ordering() orderingInfo       { return orderingInfo{} }
 func (n *dropViewNode) Values() parser.DTuple        { return parser.DTuple{} }
 func (n *dropViewNode) DebugValues() debugValues     { return debugValues{} }
 func (n *dropViewNode) SetLimitHint(_ int64, _ bool) {}
-func (n *dropViewNode) setNeededColumns(_ []bool)    {}
 func (n *dropViewNode) MarkDebug(mode explainMode)   {}
 
 type dropTableNode struct {
@@ -732,7 +729,6 @@ func (n *dropTableNode) Ordering() orderingInfo       { return orderingInfo{} }
 func (n *dropTableNode) Values() parser.DTuple        { return parser.DTuple{} }
 func (n *dropTableNode) DebugValues() debugValues     { return debugValues{} }
 func (n *dropTableNode) SetLimitHint(_ int64, _ bool) {}
-func (n *dropTableNode) setNeededColumns(_ []bool)    {}
 func (n *dropTableNode) MarkDebug(mode explainMode)   {}
 
 // dropTableOrViewPrepare/dropTableImpl is used to drop a single table by

--- a/pkg/sql/empty.go
+++ b/pkg/sql/empty.go
@@ -32,7 +32,6 @@ func (*emptyNode) Ordering() orderingInfo       { return orderingInfo{} }
 func (*emptyNode) Values() parser.DTuple        { return nil }
 func (*emptyNode) Start() error                 { return nil }
 func (*emptyNode) SetLimitHint(_ int64, _ bool) {}
-func (*emptyNode) setNeededColumns(_ []bool)    {}
 func (*emptyNode) MarkDebug(_ explainMode)      {}
 func (*emptyNode) expandPlan() error            { return nil }
 func (*emptyNode) Close()                       {}

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -44,6 +44,7 @@ var explainStrings = []string{"", "debug", "plan", "trace", "types"}
 func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, error) {
 	mode := explainNone
 
+	optimized := true
 	expanded := true
 	normalizeExprs := true
 	explainer := explainer{
@@ -92,6 +93,8 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, error) 
 			expanded = false
 		} else if strings.EqualFold(opt, "NONORMALIZE") {
 			normalizeExprs = false
+		} else if strings.EqualFold(opt, "NOOPTIMIZE") {
+			optimized = false
 		} else {
 			return nil, fmt.Errorf("unsupported EXPLAIN option: %s", opt)
 		}
@@ -130,7 +133,7 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, error) 
 		// We may want to show placeholder types, so ensure no values
 		// are missing.
 		p.semaCtx.Placeholders.FillUnassigned()
-		return p.makeExplainPlanNode(explainer, expanded, plan), nil
+		return p.makeExplainPlanNode(explainer, expanded, optimized, plan), nil
 
 	case explainTrace:
 		return p.makeTraceNode(plan, p.txn), nil
@@ -258,4 +261,3 @@ func (n *explainDebugNode) Values() parser.DTuple {
 func (*explainDebugNode) MarkDebug(_ explainMode)      {}
 func (*explainDebugNode) DebugValues() debugValues     { return debugValues{} }
 func (*explainDebugNode) SetLimitHint(_ int64, _ bool) {}
-func (*explainDebugNode) setNeededColumns(_ []bool)    {}

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -68,7 +68,9 @@ type explainer struct {
 }
 
 // newExplainPlanNode instantiates a planNode that runs an EXPLAIN query.
-func (p *planner) makeExplainPlanNode(explainer explainer, expanded bool, plan planNode) planNode {
+func (p *planner) makeExplainPlanNode(
+	explainer explainer, expanded, optimized bool, plan planNode,
+) planNode {
 	columns := ResultColumns{
 		// Level is the depth of the node in the tree.
 		{Name: "Level", Typ: parser.TypeInt},
@@ -95,6 +97,7 @@ func (p *planner) makeExplainPlanNode(explainer explainer, expanded bool, plan p
 		p:         p,
 		explainer: explainer,
 		expanded:  expanded,
+		optimized: optimized,
 		plan:      plan,
 		results:   p.newContainerValuesNode(columns, 0),
 	}
@@ -258,9 +261,18 @@ func formatColumns(cols ResultColumns, printTypes bool) string {
 type explainPlanNode struct {
 	p         *planner
 	explainer explainer
-	expanded  bool
-	plan      planNode
-	results   *valuesNode
+
+	// plan is the sub-node being explained.
+	plan planNode
+
+	// results is the container for EXPLAIN's output.
+	results *valuesNode
+
+	// expanded indicates whether to invoke expandPlan() on the sub-node.
+	expanded bool
+
+	// optimized indicates whether to invoke initNeededColumns() on the sub-node.
+	optimized bool
 }
 
 func (e *explainPlanNode) Next() (bool, error)          { return e.results.Next() }
@@ -269,10 +281,14 @@ func (e *explainPlanNode) Ordering() orderingInfo       { return e.results.Order
 func (e *explainPlanNode) Values() parser.DTuple        { return e.results.Values() }
 func (e *explainPlanNode) DebugValues() debugValues     { return debugValues{} }
 func (e *explainPlanNode) SetLimitHint(n int64, s bool) { e.results.SetLimitHint(n, s) }
-func (e *explainPlanNode) setNeededColumns(_ []bool)    {}
 func (e *explainPlanNode) MarkDebug(mode explainMode)   {}
 func (e *explainPlanNode) expandPlan() error {
+
 	if e.expanded {
+		if e.optimized {
+			e.p.initNeededColumns(e.plan, allColumns(e.plan), false)
+		}
+
 		if err := e.plan.expandPlan(); err != nil {
 			return err
 		}
@@ -282,6 +298,11 @@ func (e *explainPlanNode) expandPlan() error {
 		// interested in.
 		e.plan.SetLimitHint(math.MaxInt64, true)
 	}
+
+	if e.optimized {
+		e.p.initNeededColumns(e.plan, allColumns(e.plan), true)
+	}
+
 	return nil
 }
 

--- a/pkg/sql/expr_filter.go
+++ b/pkg/sql/expr_filter.go
@@ -108,6 +108,9 @@ func exprCheckVars(expr parser.Expr, conv varConvertFunc) bool {
 // Convert the variables in the given expression; the expression must only contain
 // variables known to the conversion function (exprCheckVars should be used first).
 func exprConvertVars(expr parser.TypedExpr, conv varConvertFunc) parser.TypedExpr {
+	if expr == nil {
+		return expr
+	}
 	v := varConvertVisitor{justCheck: false, conv: conv}
 	ret, _ := parser.WalkExpr(&v, expr)
 	return ret.(parser.TypedExpr)

--- a/pkg/sql/generator.go
+++ b/pkg/sql/generator.go
@@ -136,4 +136,3 @@ func (n *valueGenerator) Values() parser.DTuple        { return n.gen.Values() }
 func (n *valueGenerator) MarkDebug(_ explainMode)      {}
 func (n *valueGenerator) Columns() ResultColumns       { return n.columns }
 func (n *valueGenerator) SetLimitHint(_ int64, _ bool) {}
-func (n *valueGenerator) setNeededColumns(_ []bool)    {}

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -414,7 +414,6 @@ func (n *groupNode) computeAggregates() error {
 }
 
 func (*groupNode) SetLimitHint(_ int64, _ bool) {}
-func (*groupNode) setNeededColumns(_ []bool)    {}
 
 func (n *groupNode) Close() {
 	n.plan.Close()

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -575,9 +575,7 @@ func (n *insertNode) DebugValues() debugValues {
 	return n.run.rows.DebugValues()
 }
 
-func (n *insertNode) Ordering() orderingInfo {
-	return n.run.rows.Ordering()
-}
+func (n *insertNode) Ordering() orderingInfo { return orderingInfo{} }
 
 func (n *insertNode) SetLimitHint(numRows int64, soft bool) {}
 func (n *insertNode) setNeededColumns(_ []bool)             {}

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -578,4 +578,3 @@ func (n *insertNode) DebugValues() debugValues {
 func (n *insertNode) Ordering() orderingInfo { return orderingInfo{} }
 
 func (n *insertNode) SetLimitHint(numRows int64, soft bool) {}
-func (n *insertNode) setNeededColumns(_ []bool)             {}

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -273,16 +273,6 @@ func (p *planner) makeJoin(
 // SetLimitHint implements the planNode interface.
 func (n *joinNode) SetLimitHint(numRows int64, soft bool) {}
 
-// setNeededColumns implements the planNode interface.
-func (n *joinNode) setNeededColumns(needed []bool) {
-	leftNeeded, rightNeeded := n.pred.getNeededColumns(needed)
-	n.left.plan.setNeededColumns(leftNeeded)
-	n.right.plan.setNeededColumns(rightNeeded)
-	for i, v := range needed {
-		n.columns[i].omitted = !v
-	}
-}
-
 // expandPlan implements the planNode interface.
 func (n *joinNode) expandPlan() error {
 	if err := n.planner.expandSubqueryPlans(n.pred.filter); err != nil {

--- a/pkg/sql/join_predicate.go
+++ b/pkg/sql/join_predicate.go
@@ -399,8 +399,15 @@ func (p *joinPredicate) eval(
 	return true, nil
 }
 
-// getNeededColumns figures out the columns needed for the two sources.
+// getNeededColumns figures out the columns needed for the two
+// sources.  This takes into account both the equality columns and the
+// predicate expression.
 func (p *joinPredicate) getNeededColumns(neededJoined []bool) ([]bool, []bool) {
+	// Reset the helper and rebind the variable to detect which columns
+	// are effectively needed.
+	p.iVarHelper.Reset()
+	p.filter = p.iVarHelper.Rebind(p.filter)
+
 	// The columns that are part of the expression are always needed.
 	neededJoined = append([]bool(nil), neededJoined...)
 	for i := range neededJoined {

--- a/pkg/sql/limit.go
+++ b/pkg/sql/limit.go
@@ -289,5 +289,3 @@ func (n *limitNode) SetLimitHint(count int64, soft bool) {
 	}
 	n.plan.SetLimitHint(getLimit(hintCount, n.offset), soft)
 }
-
-func (*limitNode) setNeededColumns(_ []bool) {}

--- a/pkg/sql/needed_columns.go
+++ b/pkg/sql/needed_columns.go
@@ -1,0 +1,266 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package sql
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+)
+
+// initNeededColumns triggers needed column detection and propagation
+// throughout the planNode. Sub-queries, if any and doSubqueries is
+// true, are also processed.
+func (p *planner) initNeededColumns(plan planNode, needed []bool, doSubqueries bool) {
+	setNeededColumns(plan, needed)
+	if doSubqueries {
+		v := planVisitor{p: p, observer: subqueryInitializer{p: p}}
+		v.visit(plan)
+	}
+}
+
+// setNeededColumns informs the node about which columns are
+// effectively needed by the consumer of its result rows. The needed
+// array can be nil, which means that the current non-omitted columns
+// in the result set are needed, i.e. preserve and propagate the
+// existing settings.
+func setNeededColumns(plan planNode, needed []bool) {
+	switch n := plan.(type) {
+	case *createTableNode:
+		if n.n.As() {
+			setNeededColumns(n.sourcePlan, allColumns(n.sourcePlan))
+		}
+
+	case *createViewNode:
+		setNeededColumns(n.sourcePlan, allColumns(n.sourcePlan))
+
+	case *explainDebugNode:
+		setNeededColumns(n.plan, allColumns(n.plan))
+
+	case *explainTraceNode:
+		setNeededColumns(n.plan, allColumns(n.plan))
+
+	case *explainPlanNode:
+		// EXPLAIN(PLAN) takes care of its needed column initialization
+		// itself, based on the presence of the NOOPTIMIZE option.
+
+	case *limitNode:
+		setNeededColumns(n.plan, needed)
+
+	case *indexJoinNode:
+		setNeededColumns(n.index, n.valNeededIndex)
+		setNeededColumns(n.table, needed)
+
+	case *unionNode:
+		if !n.emitAll {
+			// For UNION (as opposed to UNION ALL) we have to check for
+			// uniqueness so we need all the columns.
+			needed = allColumns(n)
+		}
+		setNeededColumns(n.left, needed)
+		setNeededColumns(n.right, needed)
+
+	case *joinNode:
+		// Note: getNeededColumns takes into account both the columns
+		// tested for equality and the join predicate expression.
+		leftNeeded, rightNeeded := n.pred.getNeededColumns(needed)
+		setNeededColumns(n.left.plan, leftNeeded)
+		setNeededColumns(n.right.plan, rightNeeded)
+		markOmitted(n.columns, needed)
+
+	case *ordinalityNode:
+		setNeededColumns(n.source, needed[:len(needed)-1])
+		markOmitted(n.columns[:len(needed)-1], needed[:len(needed)-1])
+
+	case *valuesNode:
+		markOmitted(n.columns, needed)
+
+	case *scanNode:
+		copy(n.valNeededForCol, needed)
+		for i := range needed {
+			// All the values involved in the filter expression are needed too.
+			if n.filterVars.IndexedVarUsed(i) {
+				n.valNeededForCol[i] = true
+			}
+		}
+		markOmitted(n.resultColumns, n.valNeededForCol)
+
+	case *distinctNode:
+		sourceNeeded := make([]bool, len(n.plan.Columns()))
+		copy(sourceNeeded, needed)
+		// All the sorting columns are also needed.
+		for i, o := range n.columnsInOrder {
+			sourceNeeded[i] = sourceNeeded[i] || o
+		}
+		setNeededColumns(n.plan, sourceNeeded)
+
+	case *selectNode:
+		// Optimization: remove all the render expressions that are not
+		// needed. While doing so, some indexed vars may disappear
+		// entirely, which may enable omission of more columns from the
+		// source. To detect this, we need to reset the IndexedVarHelper
+		// and re-bind all the expressions.
+		n.ivarHelper.Reset()
+		for i, val := range needed {
+			if !val {
+				// This render is not used, so reduce its expression to NULL.
+				n.render[i] = parser.DNull
+				continue
+			}
+			n.render[i] = n.ivarHelper.Rebind(n.render[i])
+		}
+		n.filter = n.ivarHelper.Rebind(n.filter)
+
+		// Now detect which columns from the source are still needed.
+		neededFromSource := make([]bool, len(n.source.info.sourceColumns))
+		for i := range neededFromSource {
+			neededFromSource[i] = n.ivarHelper.IndexedVarUsed(i)
+		}
+		setNeededColumns(n.source.plan, neededFromSource)
+		markOmitted(n.columns, needed)
+
+	case *selectTopNode:
+		if n.plan == nil {
+			// Not yet expanded: we don't know what the relationship is
+			// between the sub-nodes, so the best we can do is to trigger
+			// the optimization in the source node as if all columns were
+			// needed.
+			setNeededColumns(n.source, allColumns(n.source))
+		} else {
+			setNeededColumns(n.plan, needed)
+		}
+
+	case *sortNode:
+		sourceNeeded := make([]bool, len(n.plan.Columns()))
+		copy(sourceNeeded[:len(needed)], needed)
+
+		// All the ordering columns are also needed.
+		for _, o := range n.ordering {
+			sourceNeeded[o.ColIdx] = true
+		}
+
+		setNeededColumns(n.plan, sourceNeeded)
+		markOmitted(n.columns, sourceNeeded[:len(n.columns)])
+
+	case *groupNode:
+		// TODO(knz) This can be optimized by removing the aggregation
+		// results that are not needed, then removing additional renders
+		// from the source that would otherwise only be needed for the
+		// omitted aggregation results.
+		setNeededColumns(n.plan, allColumns(n.plan))
+
+	case *windowNode:
+		// TODO(knz) This can be optimized by removing the window function
+		// definitions that are not needed, then removing additional
+		// renders from the source that would otherwise only be needed for
+		// the omitted window definitions.
+		setNeededColumns(n.plan, allColumns(n.plan))
+
+	case *deleteNode:
+		// TODO(knz) This can be optimized by omitting the columns that
+		// are not part of the primary key, do not participate in
+		// foreign key relations and that are not needed for RETURNING.
+		setNeededColumns(n.run.rows, allColumns(n.run.rows))
+
+	case *updateNode:
+		// TODO(knz) This can be optimized by omitting the columns that
+		// are not part of the primary key, do not participate in
+		// foreign key relations and that are not needed for RETURNING.
+		setNeededColumns(n.run.rows, allColumns(n.run.rows))
+
+	case *insertNode:
+		// TODO(knz) This can be optimized by omitting the columns that
+		// are not part of the primary key, do not participate in
+		// foreign key relations and that are not needed for RETURNING.
+		setNeededColumns(n.run.rows, allColumns(n.run.rows))
+
+	case *alterTableNode:
+	case *copyNode:
+	case *createDatabaseNode:
+	case *createIndexNode:
+	case *createUserNode:
+	case *delayedNode:
+	case *dropDatabaseNode:
+	case *dropIndexNode:
+	case *dropTableNode:
+	case *dropViewNode:
+	case *emptyNode:
+	case *hookFnNode:
+	case *splitNode:
+	case *valueGenerator:
+
+	default:
+		panic(fmt.Sprintf("unhandled node type: %T", plan))
+	}
+}
+
+// allColumns returns true for every column produced by the plan.
+func allColumns(plan planNode) []bool {
+	needed := make([]bool, len(plan.Columns()))
+	for i := range needed {
+		needed[i] = true
+	}
+	return needed
+}
+
+// markOmitted propagates the information from the needed array back
+// to the ResultColumns array.
+func markOmitted(cols ResultColumns, needed []bool) {
+	for i, val := range needed {
+		cols[i].omitted = !val
+	}
+}
+
+// subqueryInitializer ensures that initNeededColumns() is called on
+// the planNodes of all sub-query expressions.
+type subqueryInitializer struct {
+	p *planner
+}
+
+var _ planObserver = subqueryInitializer{}
+var _ parser.Visitor = subqueryInitializer{}
+
+// expr implements the planObserver interface.
+func (i subqueryInitializer) expr(_, _ string, _ int, expr parser.Expr) {
+	if expr == nil {
+		return
+	}
+	parser.WalkExprConst(i, expr)
+}
+
+func (i subqueryInitializer) enterNode(_ string, _ planNode) bool { return true }
+func (i subqueryInitializer) leaveNode(_ string)                  {}
+func (i subqueryInitializer) attr(_, _, _ string)                 {}
+
+// VisitPre implements the parser.Visitor interface.
+func (i subqueryInitializer) VisitPre(expr parser.Expr) (recurse bool, newExpr parser.Expr) {
+	if sq, ok := expr.(*subquery); ok && sq.plan != nil {
+		needed := make([]bool, len(sq.plan.Columns()))
+		if sq.execMode != execModeExists {
+			// EXISTS does not need values; the rest does.
+			for i := range needed {
+				needed[i] = true
+			}
+		}
+		i.p.initNeededColumns(sq.plan, needed, true)
+		return false, expr
+	}
+	return true, expr
+}
+
+// VisitPost implements the parser.Visitor interface.
+func (i subqueryInitializer) VisitPost(expr parser.Expr) parser.Expr { return expr }

--- a/pkg/sql/ordinality.go
+++ b/pkg/sql/ordinality.go
@@ -137,4 +137,3 @@ func (o *ordinalityNode) Columns() ResultColumns                { return o.colum
 func (o *ordinalityNode) Start() error                          { return o.source.Start() }
 func (o *ordinalityNode) Close()                                { o.source.Close() }
 func (o *ordinalityNode) SetLimitHint(numRows int64, soft bool) { o.source.SetLimitHint(numRows, soft) }
-func (o *ordinalityNode) setNeededColumns(_ []bool)             {}

--- a/pkg/sql/parser/indexed_vars.go
+++ b/pkg/sql/parser/indexed_vars.go
@@ -184,3 +184,34 @@ func (h *IndexedVarHelper) GetIndexedVars() []IndexedVar {
 	h.vars = nil
 	return ret
 }
+
+// Reset re-initialized an IndexedVarHelper structure with the same
+// number of slots. After a helper has been reset, all the expressions
+// that were linked to the helper before it was reset must be re-bound,
+// e.g. using Rebind().
+func (h *IndexedVarHelper) Reset() {
+	h.vars = make([]IndexedVar, len(h.vars))
+}
+
+// Rebind collects all the IndexedVars in the given expression
+// and re-binds them to this helper.
+func (h *IndexedVarHelper) Rebind(expr TypedExpr) TypedExpr {
+	if expr == nil {
+		return expr
+	}
+	ret, _ := WalkExpr(h, expr)
+	return ret.(TypedExpr)
+}
+
+var _ Visitor = &IndexedVarHelper{}
+
+// VisitPre implements the Visitor interface.
+func (h *IndexedVarHelper) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
+	if iv, ok := expr.(*IndexedVar); ok {
+		return false, h.IndexedVar(iv.Idx)
+	}
+	return true, expr
+}
+
+// VisitPost implements the Visitor interface.
+func (*IndexedVarHelper) VisitPost(expr Expr) Expr { return expr }

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -95,11 +95,6 @@ type planNode interface {
 	// Available during/after newPlan().
 	SetLimitHint(numRows int64, soft bool)
 
-	// setNeededColumns is optionally called when the values for some of the
-	// Columns() are not required for this node. There must be one value per
-	// column. It must be called before expandPlan.
-	setNeededColumns(needed []bool)
-
 	// expandPlan finalizes type checking of placeholders and expands
 	// the query plan to its final form, including index selection and
 	// expansion of sub-queries. Returns an error if the initialization
@@ -221,9 +216,23 @@ func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, er
 	if err := p.semaCtx.Placeholders.AssertAllAssigned(); err != nil {
 		return nil, err
 	}
+
+	// We propagate the needed columns once. This will remove any unused
+	// renders, which in turn may simplify expansion (remove
+	// sub-expressions).
+	needed := allColumns(plan)
+	p.initNeededColumns(plan, needed, false)
+
 	if err := plan.expandPlan(); err != nil {
 		return nil, err
 	}
+
+	// We now propagate the needed columns again. This will ensure that
+	// the needed columns are properly computed for newly expanded nodes.
+	// We also request initialization of needed columns in the sub-queries,
+	// which are now expanded.
+	p.initNeededColumns(plan, needed, true)
+
 	if log.V(3) {
 		log.Infof(p.ctx(), "statement %s compiled to:\n%s", stmt, planToString(plan))
 	}

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -61,7 +61,6 @@ func (*hookFnNode) SetLimitHint(_ int64, _ bool) {}
 func (*hookFnNode) MarkDebug(_ explainMode)      {}
 func (*hookFnNode) expandPlan() error            { return nil }
 func (*hookFnNode) Close()                       {}
-func (*hookFnNode) setNeededColumns(_ []bool)    {}
 
 func (f *hookFnNode) Start() error {
 	var err error

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -273,18 +273,6 @@ func (n *scanNode) initTable(
 	return nil
 }
 
-// setNeededColumns sets the flags indicating which columns are needed by the upper layer.
-func (n *scanNode) setNeededColumns(needed []bool) {
-	if len(needed) != len(n.valNeededForCol) {
-		panic(fmt.Sprintf("invalid setNeededColumns argument (len %d instead of %d): %v",
-			len(needed), len(n.valNeededForCol), needed))
-	}
-	copy(n.valNeededForCol, needed)
-	for i, val := range needed {
-		n.resultColumns[i].omitted = !val
-	}
-}
-
 // Initializes the column structures.
 func (n *scanNode) initDescDefaults(scanVisibility scanVisibility) {
 	n.index = &n.desc.PrimaryIndex

--- a/pkg/sql/select.go
+++ b/pkg/sql/select.go
@@ -181,8 +181,6 @@ func (s *selectNode) SetLimitHint(numRows int64, soft bool) {
 	s.source.plan.SetLimitHint(numRows, soft || s.filter != nil)
 }
 
-func (*selectNode) setNeededColumns(_ []bool) {}
-
 func (s *selectNode) Close() {
 	s.source.plan.Close()
 }
@@ -350,15 +348,6 @@ func (s *selectNode) expandPlan() error {
 	// because evaluation requires running potential sub-queries, which
 	// cannot occur during expandPlan.
 	limitCount, limitOffset := s.top.limit.estimateLimit()
-
-	// Find the set of columns that we actually need values for. This is an
-	// optimization to avoid unmarshaling unnecessary values and is also
-	// used for index selection.
-	neededCols := make([]bool, len(s.source.info.sourceColumns))
-	for i := range neededCols {
-		neededCols[i] = s.ivarHelper.IndexedVarUsed(i)
-	}
-	s.source.plan.setNeededColumns(neededCols)
 
 	if scan, ok := s.source.plan.(*scanNode); ok {
 		// Compute a filter expression for the scan node.

--- a/pkg/sql/select_top.go
+++ b/pkg/sql/select_top.go
@@ -39,8 +39,6 @@ func (n *selectTopNode) SetLimitHint(numRows int64, soft bool) {
 	n.plan.SetLimitHint(numRows, soft)
 }
 
-func (*selectTopNode) setNeededColumns(_ []bool) {}
-
 func (n *selectTopNode) expandPlan() error {
 	if n.plan != nil {
 		panic("can't expandPlan twice!")

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -336,8 +336,6 @@ func (n *sortNode) SetLimitHint(numRows int64, soft bool) {
 	}
 }
 
-func (n *sortNode) setNeededColumns(_ []bool) {}
-
 // wrap the supplied planNode with the sortNode if sorting is required.
 // The first returned value is "true" if the sort node can be squashed
 // in the selectTopNode (sorting unneeded).

--- a/pkg/sql/split.go
+++ b/pkg/sql/split.go
@@ -169,7 +169,6 @@ func (*splitNode) Columns() ResultColumns {
 func (*splitNode) Close()                       {}
 func (*splitNode) Ordering() orderingInfo       { return orderingInfo{} }
 func (*splitNode) SetLimitHint(_ int64, _ bool) {}
-func (*splitNode) setNeededColumns(_ []bool)    {}
 func (*splitNode) MarkDebug(_ explainMode)      {}
 
 func (n *splitNode) DebugValues() debugValues {

--- a/pkg/sql/testdata/explain_types
+++ b/pkg/sql/testdata/explain_types
@@ -225,7 +225,7 @@ EXPLAIN (TYPES,NOEXPAND) SELECT DISTINCT k FROM t
 1  distinct                            (k int)
 1  render/filter                       (k int)
 1                 render 0  (k)[int]
-2  scan                                (k int, v int)
+2  scan                                (k int, v[omitted] int)
 2                 table     t@primary
 
 query ITTTTT
@@ -248,7 +248,7 @@ EXPLAIN (TYPES,NOEXPAND) SELECT v FROM t ORDER BY v
 1                 order     +@1
 1  render/filter                       (v int)
 1                 render 0  (v)[int]
-2  scan                                (k int, v int)
+2  scan                                (k[omitted] int, v int)
 2                 table     t@primary
 
 query ITTTTT
@@ -271,7 +271,7 @@ EXPLAIN (TYPES,NOEXPAND) SELECT v FROM t LIMIT 1
 1                 count     (1)[int]
 1  render/filter                       (v int)
 1                 render 0  (v)[int]
-2  scan                                (k int, v int)
+2  scan                                (k[omitted] int, v int)
 2                 table     t@primary
 
 statement ok
@@ -301,7 +301,7 @@ EXPLAIN (TYPES,NOEXPAND) SELECT * FROM tt WHERE x < 10 AND y > 10
 1                 filter    ((((x)[int] < (10)[int])[bool]) AND (((y)[int] > (10)[int])[bool]))[bool]
 1                 render 0  (x)[int]
 1                 render 1  (y)[int]
-2  scan                                                                                                (x int, y int, rowid[hidden] int)
+2  scan                                                                                                (x int, y int, rowid[hidden,omitted] int)
 2                 table     tt@primary
 
 query ITTTTT

--- a/pkg/sql/testdata/explain_types
+++ b/pkg/sql/testdata/explain_types
@@ -152,7 +152,7 @@ EXPLAIN (TYPES,NOEXPAND) DELETE FROM t WHERE v > 1
 query ITTTTT
 EXPLAIN (TYPES) DELETE FROM t WHERE v > 1
 ----
-0  delete                                                ()              +@1,unique
+0  delete                                                ()
 0                 from      t
 1  select                                                (k int)         +k,unique
 2  render/filter                                         (k int)         +k,unique
@@ -165,7 +165,7 @@ EXPLAIN (TYPES) DELETE FROM t WHERE v > 1
 query ITTTTT
 EXPLAIN (TYPES) UPDATE t SET v = k + 1 WHERE v > 123
 ----
-0  update                                                  ()                           +@1,unique
+0  update                                                  ()
 0                 table     t
 0                 set       v
 1  select                                                  (k int, v int, "k + 1" int)  +k,unique

--- a/pkg/sql/testdata/needed_columns
+++ b/pkg/sql/testdata/needed_columns
@@ -1,0 +1,174 @@
+query ITTTTT
+EXPLAIN (METADATA, NOOPTIMIZE) SELECT 1 FROM (SELECT 2 AS s)
+----
+0   select                          ("1")
+1   select                          (s)
+2   nullrow                         ()
+
+# Propagation to data sources.
+query ITTTTT
+EXPLAIN (METADATA) SELECT 1 FROM (SELECT 2 AS s)
+----
+0   select                          ("1")
+1   select                          (s[omitted])
+2   nullrow                         ()
+
+# Propagation through CREATE TABLE.
+query ITTTTT
+EXPLAIN (METADATA) CREATE TABLE t AS SELECT 1 FROM (SELECT 2 AS s)
+----
+0   create table                         ()
+1   select                               ("1")
+2   select                               (s[omitted])
+3   nullrow                              ()
+
+# Propagation through LIMIT.
+query ITTTTT
+EXPLAIN (METADATA) SELECT 1 FROM (SELECT 2 AS s) LIMIT 1
+----
+0   select                               ("1")
+1   limit                                ("1")
+2   select                               (s[omitted])
+3   nullrow                              ()
+
+query ITTTTT
+EXPLAIN (METADATA) SELECT 1 FROM (SELECT 2 AS s LIMIT 1)
+----
+0   select                               ("1")
+1   select                               (s[omitted])
+2   limit                                (s[omitted])
+3   nullrow                              ()
+
+# Propagation through UNION.
+query ITTTTT
+EXPLAIN (METADATA) SELECT 1 FROM (SELECT 1 AS s UNION SELECT 2 AS s)
+----
+0   select                          ("1")
+1   select                          (s)
+2   union                           (s)
+3   select                          (s)
+4   nullrow                         ()
+3   select                          (s)
+4   nullrow                         ()
+
+query ITTTTT
+EXPLAIN (METADATA) SELECT 1 FROM (SELECT 1 AS s UNION ALL SELECT 2 AS s)
+----
+0   select                          ("1")
+1   select                          (s[omitted])
+2   append                          (s[omitted])
+3   select                          (s[omitted])
+4   nullrow                         ()
+3   select                          (s[omitted])
+4   nullrow                         ()
+
+# Propagation through WITH ORDINALITY.
+query ITTTTT
+EXPLAIN (METADATA) SELECT 1 FROM (SELECT 1 AS s) WITH ORDINALITY
+----
+0   select                             ("1")
+1   ordinality                         (s[omitted], ordinality)   +ordinality,unique
+2   select                             (s[omitted])
+3   nullrow                            ()
+
+# Propagation through sort, when the sorting column is in the results.
+query ITTTTT
+EXPLAIN (METADATA) SELECT x FROM (SELECT 1 AS x, 2 AS y) ORDER BY x
+----
+0   select                          (x)               +x
+1   sort                            (x)               +x
+1             order   +x
+2   select                          (x, y[omitted])
+3   nullrow                         ()
+
+# Propagation through sort, when the sorting column is not in the results.
+query ITTTTT
+EXPLAIN (METADATA) SELECT x FROM (SELECT 1 AS x, 2 AS y, 3 AS z) ORDER BY y
+----
+0   select                          (x)
+1   sort                            (x)
+1             order   +y
+2   select                          (x, y, z[omitted])
+3   nullrow                         ()
+
+# Propagation to sub-queries.
+query ITTTTT
+EXPLAIN (METADATA) SELECT 1 = (SELECT 2 AS x FROM (SELECT 3 AS s)) AS y
+----
+0   select                               (y)
+0             subqueries             1
+1   select                               (x)
+2   select                               (s[omitted])
+3   nullrow                              ()
+1   nullrow                              ()
+
+# Propagation through table scans.
+statement ok
+CREATE TABLE kv(k INT PRIMARY KEY, v INT)
+
+query ITTTTT
+EXPLAIN(METADATA) SELECT 1 FROM kv
+----
+0   select                         ("1")
+1   scan                           (k[omitted], v[omitted])   +k,unique
+1            table   kv@primary
+
+# Propagation through DISTINCT.
+query ITTTTT
+EXPLAIN (METADATA) SELECT DISTINCT v FROM kv;
+----
+0   select                           (v)
+1   distinct                         (v)
+2   scan                             (k[omitted], v)   +k,unique
+2              table   kv@primary
+
+# Propagation through INSERT.
+query ITTTTT
+EXPLAIN(METADATA) INSERT INTO kv(k, v) SELECT 1, 2 FROM (SELECT 3 AS x, 4 AS y)
+----
+0   insert                          ()
+0             into    kv(k, v)
+1   select                          ("1", "2")
+2   select                          (x[omitted], y[omitted])
+3   nullrow                         ()
+
+# Propagation through DELETE.
+query ITTTTT
+EXPLAIN (METADATA) DELETE FROM kv WHERE k = 3
+----
+0   delete                         ()
+0            from    kv
+1   select                         (k)               +k,unique
+2   scan                           (k, v[omitted])   +k,unique
+2            table   kv@primary
+2            spans   /3-/4
+
+# Ensure that propagations through a select node removes the renders
+# and properly propagates the remaining needed columns.
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT x FROM (SELECT 1 AS x, y FROM (SELECT 2 AS y))
+----
+0   select                                   (x)
+1   render/filter                            (x)
+1                   render 0   x
+2   select                                   (x, y[omitted])
+3   render/filter                            (x, y[omitted])
+3                   render 0   1
+3                   render 1   NULL
+4   select                                   (y[omitted])
+5   render/filter                            (y[omitted])
+5                   render 0   NULL
+6   nullrow                                  ()
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT 1 FROM (SELECT k+1 AS x, v-2 AS y FROM kv)
+----
+0   select                                   ("1")
+1   render/filter                            ("1")
+1                   render 0   1
+2   select                                   (x[omitted], y[omitted])
+3   render/filter                            (x[omitted], y[omitted])
+3                   render 0   NULL
+3                   render 1   NULL
+4   scan                                     (k[omitted], v[omitted])   +k,unique
+4                   table      kv@primary

--- a/pkg/sql/testdata/order_by
+++ b/pkg/sql/testdata/order_by
@@ -598,3 +598,35 @@ EXPLAIN(METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c
 4  select                               (column1)
 5  values                               (column1)
 5              size   1 column, 3 rows
+
+# Check that the ordering of the source does not propagate blindly to RETURNING.
+query ITTTTT
+EXPLAIN (METADATA) INSERT INTO t(a, b) SELECT * FROM (SELECT 1 AS x, 2 AS y) ORDER BY x RETURNING b
+----
+0   insert                          (b)
+0             into    t(a, b)
+1   select                          (x, y)    +x
+2   sort                            (x, y)    +x
+2             order   +x
+3   select                          (x, y)
+4   nullrow                         ()
+
+query ITTTTT
+EXPLAIN (METADATA) DELETE FROM t WHERE a = 3 RETURNING b
+----
+0   delete                         (b)
+0            from    t
+1   select                         (a, b, c)    +a,unique
+2   scan                           (a, b, c)    +a,unique
+2            table   t@primary
+2            spans   /3-/4
+
+query ITTTTT
+EXPLAIN (METADATA) UPDATE t SET c = TRUE RETURNING b
+----
+0  update                    (b)
+0          table  t
+0          set    c
+1  select                    (a, b, c, "true")  +a,unique
+2  scan                      (a, b, c)          +a,unique
+2          table  t@primary

--- a/pkg/sql/trace.go
+++ b/pkg/sql/trace.go
@@ -209,4 +209,3 @@ func (n *explainTraceNode) Values() parser.DTuple {
 func (*explainTraceNode) MarkDebug(_ explainMode)      {}
 func (*explainTraceNode) DebugValues() debugValues     { return debugValues{} }
 func (*explainTraceNode) SetLimitHint(_ int64, _ bool) {}
-func (*explainTraceNode) setNeededColumns(_ []bool)    {}

--- a/pkg/sql/union.go
+++ b/pkg/sql/union.go
@@ -156,8 +156,6 @@ func (n *unionNode) SetLimitHint(numRows int64, soft bool) {
 	n.left.SetLimitHint(numRows, true)
 }
 
-func (n *unionNode) setNeededColumns(_ []bool) {}
-
 func (n *unionNode) MarkDebug(mode explainMode) {
 	if mode != explainDebug {
 		panic(fmt.Sprintf("unknown debug mode %d", mode))

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -418,9 +418,7 @@ func (u *updateNode) DebugValues() debugValues {
 	return u.run.rows.DebugValues()
 }
 
-func (u *updateNode) Ordering() orderingInfo {
-	return u.run.rows.Ordering()
-}
+func (u *updateNode) Ordering() orderingInfo { return orderingInfo{} }
 
 func (u *updateNode) SetLimitHint(numRows int64, soft bool) {}
 func (u *updateNode) setNeededColumns(_ []bool)             {}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -421,4 +421,3 @@ func (u *updateNode) DebugValues() debugValues {
 func (u *updateNode) Ordering() orderingInfo { return orderingInfo{} }
 
 func (u *updateNode) SetLimitHint(numRows int64, soft bool) {}
-func (u *updateNode) setNeededColumns(_ []bool)             {}

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -400,9 +400,11 @@ func nodeName(plan planNode) string {
 // be changed without changing the output of "EXPLAIN".
 var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&alterTableNode{}):     "alter table",
+	reflect.TypeOf(&copyNode{}):           "copy",
 	reflect.TypeOf(&createDatabaseNode{}): "create database",
 	reflect.TypeOf(&createIndexNode{}):    "create index",
 	reflect.TypeOf(&createTableNode{}):    "create table",
+	reflect.TypeOf(&createUserNode{}):     "create user",
 	reflect.TypeOf(&createViewNode{}):     "create view",
 	reflect.TypeOf(&delayedNode{}):        "virtual table",
 	reflect.TypeOf(&deleteNode{}):         "delete",
@@ -413,8 +415,10 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&dropViewNode{}):       "drop view",
 	reflect.TypeOf(&emptyNode{}):          "empty",
 	reflect.TypeOf(&explainDebugNode{}):   "explain debug",
+	reflect.TypeOf(&explainPlanNode{}):    "explain plan",
 	reflect.TypeOf(&explainTraceNode{}):   "explain trace",
 	reflect.TypeOf(&groupNode{}):          "group",
+	reflect.TypeOf(&hookFnNode{}):         "plugin",
 	reflect.TypeOf(&indexJoinNode{}):      "index-join",
 	reflect.TypeOf(&insertNode{}):         "insert",
 	reflect.TypeOf(&joinNode{}):           "join",

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -760,7 +760,6 @@ func (n *windowNode) populateValues() error {
 }
 
 func (*windowNode) SetLimitHint(_ int64, _ bool) {}
-func (*windowNode) setNeededColumns(_ []bool)    {}
 
 func (n *windowNode) Close() {
 	n.plan.Close()


### PR DESCRIPTION
This patch rewrites and largely extends the feature introduced in
1993af0: marking unused planNode
columns as "omitted" to save I/O operations.

This is done by:

- removing `setNeededColumns()` from the planNode interface, and
  replacing its implementations by planNodes by a single recursive
  function `setNeededColumns()`. The new function is written so that
  it is guaranteed to traverse every planNode in the tree.

- adding some missing implementations of `setNeededColumns()`, for
  `unionNode`, `distinctNode`, `selectNode`, `sortNode`,
  `createTableNode`. This yields some previously unattainable
  optimizations. (`windowNode` and `groupNode` are still conspicuously
  missing.)

- rewriting the initialization logic for `indexJoinNode` and ensuring
  its `setNeededColumns()` code can be reused multiple times.

- adding a new `initNeededColumns()` method on `planner` that is
  called for every plan constructed, which calls both
  `setNeededColumns()` on the plan and `initNeededColumns()` on all
  the sub-query plans. This ensures that all plans undergo this
  optimization.

- adding a new EXPLAIN option `NOOPTIMIZE` that shows the planNode
  when `initNeededColumns()` has not been called.

Needed for the work on #10633.
The first three commits are clean-ups that make testing of the last commit, the main one, more clear.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12575)
<!-- Reviewable:end -->
