### PR TITLE
sql: fix a regression in the indexJoin code.

### DIFF
--- a/pkg/sql/needed_columns.go
+++ b/pkg/sql/needed_columns.go
@@ -62,8 +62,15 @@ func setNeededColumns(plan planNode, needed []bool) {
 		setNeededColumns(n.plan, needed)
 
 	case *indexJoinNode:
-		setNeededColumns(n.index, n.valNeededIndex)
+		// Currently all the needed result columns are provided by the
+		// table sub-source; from the index sub-source we only need the PK
+		// columns sufficient to configure the table sub-source.
+		// TODO(radu/knz) see the comments at the start of index_join.go,
+		// perhaps this can be optimized to utilize the column values
+		// already provided by the index instead of re-retrieving them
+		// using the table scanNode.
 		setNeededColumns(n.table, needed)
+		setNeededColumns(n.index, n.primaryKeyColumns)
 
 	case *unionNode:
 		if !n.emitAll {

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -49,8 +49,15 @@ type scanNode struct {
 	// Contains values for the current row. There is a 1-1 correspondence
 	// between resultColumns and values in row.
 	row parser.DTuple
-	// For each column in resultColumns, indicates if the value is needed (used
-	// as an optimization when the upper layer doesn't need all values).
+	// For each column in resultColumns, indicates if the value is
+	// needed (used as an optimization when the upper layer doesn't need
+	// all values).
+	// TODO(radu/knz): currently the optimization always loads the
+	// entire row from KV and only skips unnecessary decodes to
+	// Datum. Investigate whether performance is to be gained (e.g. for
+	// tables with wide rows) by reading only certain columns from KV
+	// using point lookups instead of a single range lookup for the
+	// entire row.
 	valNeededForCol []bool
 
 	// Map used to get the index for columns in cols.

--- a/pkg/sql/testdata/explain_plan
+++ b/pkg/sql/testdata/explain_plan
@@ -102,12 +102,12 @@ CREATE TABLE tc (a INT, b INT, INDEX c(a))
 query ITTTTT
 EXPLAIN(METADATA) SELECT * FROM tc WHERE a = 10 ORDER BY b
 ----
-0  select                         (a, b)                          +b
-1  sort                           (a, b)                          +b
+0  select                         (a, b)                                   +b
+1  sort                           (a, b)                                   +b
 1              order  +b
-2  index-join                     (a, b, rowid[hidden,omitted])   =a,+rowid,unique
-3  scan                           (a, b[omitted], rowid[hidden])  =a,+rowid,unique
+2  index-join                     (a, b, rowid[hidden,omitted])            =a,+rowid,unique
+3  scan                           (a[omitted], b[omitted], rowid[hidden])  =a,+rowid,unique
 3              table  tc@c
 3              spans  /10-/11
-3  scan                           (a, b, rowid[hidden,omitted])   +rowid,unique
+3  scan                           (a, b, rowid[hidden,omitted])            +rowid,unique
 3              table  tc@primary

--- a/pkg/sql/testdata/select_non_covering_index_filtering
+++ b/pkg/sql/testdata/select_non_covering_index_filtering
@@ -125,3 +125,27 @@ EXPLAIN (DEBUG) SELECT * FROM t WHERE b > 1 AND ((c = b+1 AND s != '23') OR (a >
 2 /t/primary/9/b 3    PARTIAL
 2 /t/primary/9/c 3    PARTIAL
 2 /t/primary/9/s '33' ROW
+
+# Check that splitting of the expression filter does not mistakenly
+# bring non-indexed columns (s) under the index scanNode. (#12582)
+# To test this we need an expression containing non-indexed
+# columns that disappears during range simplification.
+query ITTTTT
+EXPLAIN(VERBOSE) SELECT a FROM t WHERE b = 2 OR ((b BETWEEN 2 AND 1) AND ((s != 'a') OR (s = 'a')))
+----
+0  select                              (a)
+1  render/filter                       (a)
+1                 render 0  test.t.a
+2  index-join                          (a, b[omitted], c[omitted], s[omitted])  +b,+c,+a,unique
+3  scan                                (a, b[omitted], c[omitted], s[omitted])  +b,+c,+a,unique
+3                 table     t@bc
+3                 spans     /2-/3
+3  scan                                (a, b[omitted], c[omitted], s[omitted])  +a,unique
+3                 table     t@primary
+
+query I
+SELECT a FROM t WHERE b = 2 OR ((b BETWEEN 2 AND 1) AND ((s != 'a') OR (s = 'a')))
+----
+4
+5
+6


### PR DESCRIPTION
Commit a2490286c11b2b3fd04c5952a4e67891d714f3dd had introduced a
regression where in some cases columns that participate in a filter
expression are *requested* from an index's scanNode even when the
index does not *provide* them (e.g. they are not indexed).

This patch fixes the issue by ensuring that only the columns required
by the index' sub-filter are requested from the index scanNode.

Fixes #12582.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12583)
<!-- Reviewable:end -->
