### PR TITLE
sql/parser: Document limitation with StrVal.AvailableTypes

### DIFF
--- a/pkg/sql/parser/eval_test.go
+++ b/pkg/sql/parser/eval_test.go
@@ -592,8 +592,6 @@ func TestEval(t *testing.T) {
 		{`ANNOTATE_TYPE(NULL, string)`, `NULL`},
 		{`ANNOTATE_TYPE(NULL, timestamp)`, `NULL`},
 		// Extract from dates.
-		// TODO(nvanbenschoten): these casts can be removed once we improve
-		// strConst's type inference.
 		{`extract(year from '2010-09-28'::date)`, `2010`},
 		{`extract(year from '2010-09-28'::date)`, `2010`},
 		{`extract(month from '2010-09-28'::date)`, `9`},


### PR DESCRIPTION
This change addresses a TODO to improve string literal type inference.
The TODO will not be addressed at this time, because of the reasons
added to the method comment:

> To fully take advantage of literal type inference, this method would
> determine exactly which types are available for a given string. This would
> entail attempting to parse the literal string as a date, a timestamp, an
> interval, etc. and having more fine-grained results than strValAvailAllParsable.
> However, this is not feasible in practice because of the associated parsing
> overhead.
>
> Conservative approaches like checking the string's length have been investigated
> to reduce ambiguity and improve type inference in some cases. When doing so, the
> length of the string literal was compared against all valid date and timestamp
> formats to quickly gain limited insight into whether parsing the string as the
> respective datum types could succeed. The hope was to eliminate impossibilities
> and constrain the returned type sets as much as possible. Unfortunately, two issues
> were found with this approach:
> - date and timestamp formats do not always imply a fixed-length valid input. For
>   instance, timestamp formats that take fractional seconds can successfully parse
>   inputs of varied length.
> - the set of date and timestamp formats are not disjoint, which means that ambiguity
>   can not be eliminated when inferring the type of string literals that use these
>   shared formats.
>
> While these limitations still permitted improved type inference in many cases, they
> resulted in behavior that was ultimately incomplete, resulted in unpredictable levels
> of inference, and occasionally failed to eliminate ambiguity. Further heuristics could
> have been applied to improve the accuracy of the inference, like checking that all
> or some characters were digits, but it would not have circumvented the fundamental
> issues here. Fully parsing the literal into each type would be the only way to
> concretely avoid the issue of unpredictable inference behavior.

cc. @arjunravinarayan

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12596)
<!-- Reviewable:end -->
