### PR TITLE
sql/parser: Improve TestEval and TestNormalizeExpr using type annotations

### DIFF
--- a/pkg/sql/parser/normalize_test.go
+++ b/pkg/sql/parser/normalize_test.go
@@ -150,8 +150,7 @@ func TestNormalizeExpr(t *testing.T) {
 		{`(1, 2, 3) IN ((1, 2, 3), (4, 5, 6))`, `true`},
 		{`(1, 'one')`, `(1, 'one')`},
 		{`ANNOTATE_TYPE(1, float)`, `1.0`},
-		// TODO(nvanbenschoten) introduce a shorthand type annotation notation.
-		// {`1!float`, `1.0`},
+		{`1:::float`, `1.0`},
 		{`IF((true AND a < 0), (0 + a)::decimal, 2 / (1 - 1))`, `IF(a < 0, a::DECIMAL, 2 / 0)`},
 		{`IF((true OR a < 0), (0 + a)::decimal, 2 / (1 - 1))`, `a::DECIMAL`},
 		{`COALESCE(NULL, (NULL < 3), a = 2 - 1, d)`, `COALESCE(a = 1, d)`},


### PR DESCRIPTION
This change:
- addresses a TODO to use type annotations in `TestEval`
- addresses a TODO to use type annotations in `TestNormalizeExpr`
- uses type annotations instead of casts for numeric operations in `TestEval`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12597)
<!-- Reviewable:end -->
