### PR TITLE
sql: Remove getCachedDatabaseDesc from DatabaseAccessor interface

### DIFF
--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -100,11 +100,6 @@ type DatabaseAccessor interface {
 	// returning an error if the descriptor is not found.
 	mustGetDatabaseDesc(name string) (*sqlbase.DatabaseDescriptor, error)
 
-	// getCachedDatabaseDesc looks up the database descriptor from
-	// the descriptor cache, given its name.
-	// TODO(nvanbenschoten) This method doesn't belong in the interface.
-	getCachedDatabaseDesc(name string) (*sqlbase.DatabaseDescriptor, error)
-
 	// getAllDatabaseDescs looks up and returns all available database
 	// descriptors.
 	getAllDatabaseDescs() ([]*sqlbase.DatabaseDescriptor, error)
@@ -166,7 +161,8 @@ func MustGetDatabaseDesc(
 	return desc, nil
 }
 
-// getCachedDatabaseDesc implements the DatabaseAccessor interface.
+// getCachedDatabaseDesc looks up the database descriptor from the descriptor cache,
+// given its name.
 func (p *planner) getCachedDatabaseDesc(name string) (*sqlbase.DatabaseDescriptor, error) {
 	if name == sqlbase.SystemDB.Name {
 		return &sqlbase.SystemDB, nil


### PR DESCRIPTION
This change addresses a TODO to remove `getCachedDatabaseDesc` from
the `DatabaseAccessor` interface. The reason for the TODO is because
`getCachedDatabaseDesc` was only used as a helper function within an
implementation of the interface, and therefore did not belong to the
external-facing contract of the interface. This decision is consistent with all
other methods in `sql.DatabaseAccessor` and `sql.SchemaAccessor`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12602)
<!-- Reviewable:end -->
