### PR TITLE
parser: debug strings for expressions

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -415,6 +415,9 @@ func distSQLExpression(expr parser.TypedExpr, columnMap []int) distsqlrun.Expres
 	}
 	var buf bytes.Buffer
 	expr.Format(&buf, f)
+	if log.V(1) {
+		log.Infof(context.TODO(), "Expr %s:\n%s", buf.String(), parser.ExprDebugString(expr))
+	}
 	return distsqlrun.Expression{Expr: buf.String()}
 }
 

--- a/pkg/sql/parser/walk.go
+++ b/pkg/sql/parser/walk.go
@@ -17,8 +17,10 @@
 package parser
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
+	"strings"
 )
 
 // Visitor defines methods that are called for nodes during an expression or statement walk.
@@ -968,3 +970,45 @@ func SimpleVisit(expr Expr, preFn SimpleVisitFn) (Expr, error) {
 	}
 	return newExpr, nil
 }
+
+type debugVisitor struct {
+	buf   bytes.Buffer
+	level int
+}
+
+var _ Visitor = &debugVisitor{}
+
+func (v *debugVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
+	v.level++
+	fmt.Fprintf(&v.buf, "%*s", 2*v.level, " ")
+	str := fmt.Sprintf("%#v\n", expr)
+	// Remove "parser." to make the string more compact.
+	str = strings.Replace(str, "parser.", "", -1)
+	v.buf.WriteString(str)
+	return true, expr
+}
+
+func (v *debugVisitor) VisitPost(expr Expr) Expr {
+	v.level--
+	return expr
+}
+
+// ExprDebugString generates a multi-line debug string with one node per line in
+// Go format.
+func ExprDebugString(expr Expr) string {
+	v := debugVisitor{}
+	WalkExprConst(&v, expr)
+	return v.buf.String()
+}
+
+// StmtDebugString generates multi-line debug strings in Go format for the
+// expressions that are part of the given statement.
+func StmtDebugString(stmt Statement) string {
+	v := debugVisitor{}
+	WalkStmt(&v, stmt)
+	return v.buf.String()
+}
+
+// Silence any warnings if these functions are not used.
+var _ = ExprDebugString
+var _ = StmtDebugString


### PR DESCRIPTION
Adding a visitor that generates a debug string shhowing the fields of all the
nodes in an expression tree. DistSQL planner now logs this information in
verbose mode.

This was useful while investigating #12532.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12608)
<!-- Reviewable:end -->
