### PR TITLE
storage/engine: fix comment around intent resolution

### DIFF
--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -1731,9 +1731,7 @@ func MVCCIterate(
 // timestamp. This might be because writes to different keys had to
 // use higher timestamps than expected because of existing, committed
 // value, or because reads pushed the transaction's commit timestamp
-// forward. Retries also occur in the event that the txn tries to push
-// another txn in order to write an intent but fails (i.e. it has
-// lower priority).
+// forward.
 //
 // Because successive retries of a transaction may end up writing to
 // different keys, the epochs serve to classify which intents get


### PR DESCRIPTION
A comment inaccurately said
```
// Retries also occur in the event that the txn tries to push
// another txn in order to write an intent but fails (i.e. it has
// lower priority).
```

That's not true; failure to push just causes the would-be pusher to spin in `Store.Send()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12640)
<!-- Reviewable:end -->
