### PR TITLE
sql/parser: Define overload returnTypeStyle and cleanup builtins

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1454,6 +1454,7 @@ func checkResultType(typ parser.Type) error {
 	case parser.TypeInterval:
 	case parser.TypeStringArray:
 	case parser.TypeIntArray:
+	case parser.TypeNullArray:
 	default:
 		// Compare all types that cannot rely on == equality.
 		istype := typ.FamilyEqual

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -87,8 +87,9 @@ const (
 
 // Builtin is a built-in function.
 type Builtin struct {
-	Types      typeList
-	ReturnType Type
+	Types           typeList
+	ReturnTypeStyle returnTypeStyle
+	ReturnType      Type
 
 	// When multiple overloads are eligible based on types even after all of of
 	// the heuristics to pick one have been used, if one of the overloads is a
@@ -134,6 +135,10 @@ type Builtin struct {
 
 func (b Builtin) params() typeList {
 	return b.Types
+}
+
+func (b Builtin) returnTypeStyle() returnTypeStyle {
+	return b.ReturnTypeStyle
 }
 
 func (b Builtin) returnType() Type {
@@ -782,9 +787,10 @@ var Builtins = map[string][]Builtin{
 
 	"greatest": {
 		Builtin{
-			Types:      AnyType{},
-			ReturnType: TypeAny,
-			category:   categoryComparison,
+			Types:           HomogeneousType{},
+			ReturnTypeStyle: identity,
+			ReturnType:      TypeAny,
+			category:        categoryComparison,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return pickFromTuple(ctx, true /* greatest */, args)
 			},
@@ -794,9 +800,10 @@ var Builtins = map[string][]Builtin{
 
 	"least": {
 		Builtin{
-			Types:      AnyType{},
-			ReturnType: TypeAny,
-			category:   categoryComparison,
+			Types:           HomogeneousType{},
+			ReturnTypeStyle: identity,
+			ReturnType:      TypeAny,
+			category:        categoryComparison,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return pickFromTuple(ctx, false /* !greatest */, args)
 			},

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -62,6 +62,10 @@ func (op UnaryOp) params() typeList {
 	return op.types
 }
 
+func (UnaryOp) returnTypeStyle() returnTypeStyle {
+	return standard
+}
+
 func (op UnaryOp) returnType() Type {
 	return op.ReturnType
 }
@@ -172,6 +176,10 @@ func (op BinOp) params() typeList {
 
 func (op BinOp) matchParams(l, r Type) bool {
 	return op.params().matchAt(l, 0) && op.params().matchAt(r, 1)
+}
+
+func (BinOp) returnTypeStyle() returnTypeStyle {
+	return standard
 }
 
 func (op BinOp) returnType() Type {
@@ -885,6 +893,10 @@ func (op CmpOp) params() typeList {
 
 func (op CmpOp) matchParams(l, r Type) bool {
 	return op.params().matchAt(l, 0) && op.params().matchAt(r, 1)
+}
+
+func (CmpOp) returnTypeStyle() returnTypeStyle {
+	return standard
 }
 
 func (op CmpOp) returnType() Type {

--- a/pkg/sql/parser/overload_test.go
+++ b/pkg/sql/parser/overload_test.go
@@ -34,6 +34,10 @@ func (to *testOverload) params() typeList {
 	return to.paramTypes
 }
 
+func (to *testOverload) returnTypeStyle() returnTypeStyle {
+	return standard
+}
+
 func (to *testOverload) returnType() Type {
 	return to.retType
 }

--- a/pkg/sql/parser/type.go
+++ b/pkg/sql/parser/type.go
@@ -97,6 +97,9 @@ var (
 	// TypeIntArray is the type family of a DArray containing ints. Can be
 	// compared with ==.
 	TypeIntArray Type = tArray{TypeInt}
+	// TypeNullArray is the type of a DArray containing nulls. Can be
+	// compared with ==.
+	TypeNullArray Type = tArray{TypeNull}
 	// TypeAnyArray is the type of a DArray with a wildcard parameterized type.
 	// Can be compared with ==.
 	TypeAnyArray Type = tArray{TypeAny}

--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -444,15 +444,7 @@ func (expr *FuncExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, erro
 		expr.Exprs[i] = subExpr
 	}
 	expr.fn = builtin
-	returnType := fn.returnType()
-	if _, ok := expr.fn.params().(AnyType); ok {
-		if len(typedSubExprs) > 0 {
-			returnType = typedSubExprs[0].ResolvedType()
-		} else {
-			returnType = TypeNull
-		}
-	}
-	expr.typ = returnType
+	expr.typ = overloadReturnTypeGivenArgs(builtin, typedSubExprs)
 	return expr, nil
 }
 

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1005,12 +1005,11 @@ CREATE TABLE pg_catalog.pg_proc (
 					argType := argTypes.Types()[0]
 					oid := datumToOidOrPanic(argType, builtin)
 					variadicType = parser.NewDInt(parser.DInt(oid))
-				case parser.AnyType:
+				case parser.HomogeneousType:
 					argmodes = proArgModeVariadic
 					argType := parser.TypeAny
 					oid := datumToOidOrPanic(argType, builtin)
 					variadicType = parser.NewDInt(parser.DInt(oid))
-
 				default:
 					argmodes = parser.DNull
 					variadicType = oidZero

--- a/pkg/sql/rsg_test.go
+++ b/pkg/sql/rsg_test.go
@@ -132,7 +132,7 @@ func TestRandomSyntaxFunctions(t *testing.T) {
 			for _, arg := range ft {
 				args = append(args, r.GenerateRandomArg(arg.Typ))
 			}
-		case parser.AnyType:
+		case parser.HomogeneousType:
 			for i := r.Intn(5); i > 0; i-- {
 				var typ parser.Type
 				switch r.Intn(4) {

--- a/pkg/sql/testdata/pgoidtype
+++ b/pkg/sql/testdata/pgoidtype
@@ -13,8 +13,8 @@ SELECT 'upper'::REGPROC, 'upper'::REGPROCEDURE
 ----
 1736923753  1736923753
 
-query error more than one function named 'max'
-SELECT 'max'::REGPROC
+query error more than one function named 'sqrt'
+SELECT 'sqrt'::REGPROC
 
 query I
 SELECT 'public'::REGNAMESPACE


### PR DESCRIPTION
This change introduces the notion of a returnTypeStyle for overload
implementations. The purpose of this is to more clearly express cases
where overloads return types are based on their input argument types.
This was previously possible, but was messy and inextensible.

> returnTypeStyle defines the method in which an functions' return type is determined.
> The vast majority of functions have a hard-coded return type, denoted as "standard".
> However, some functions' return types are not hard-coded, but are instead based
> on the types of arguments provided to them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12644)
<!-- Reviewable:end -->
