### PR TITLE
ui: add a bar across all graphs when hovering over one graph

### DIFF
--- a/pkg/ui/app/components/graphs.tsx
+++ b/pkg/ui/app/components/graphs.tsx
@@ -527,3 +527,48 @@ export class TextGraph extends React.Component<MetricsDataComponentProps, {}> {
     }</div>;
   }
 }
+
+/**
+ * mouseEnter, mouseMove, and mouseLeave are helper functions used by LineChart
+ * and StackedAreaChart to show/hide lines on all the graphs when hovering over
+ * a specific graph.
+ */
+
+// GraphLineState is a shared state that indicates whether the current graph is
+// receiving the mousemove events. This is used to hide the guideline for the
+// current graph.
+export class GraphLineState {
+  mouseIn: boolean = false;
+}
+
+// mouseEnter sets the graph-lines--show class on the element with the
+// .graph-lines class, which should be a parent element of all graphs which need
+// graph lines. This will cause all the graph lines to appear. It also sets the
+// mouseIn state to true which is used to hide the guideline on the current
+// graph in favor of the nvd3 line.
+export function mouseEnter (node: React.Component<any, GraphLineState>) {
+  this.setState({
+    mouseIn: true,
+  });
+  d3.select(".graph-lines").classed("graph-lines--show", true);
+};
+
+// mouseMove changes the graph line positions based on the mouse position.
+export function mouseMove() {
+  let currentGuideline = d3.select("line.nv-guideline");
+  // HACK: Gets x value of the currently visible guideline.
+  // TODO: set this based on the chart axis, not based on the guideline.
+  let x = currentGuideline && currentGuideline.data()[0] || 0;
+  d3.selectAll(".graph-lines__line").style("left", (x + CHART_MARGINS.left) + "px");
+};
+
+// mouseLeave removes the graph-line--show class on the element with the
+// .graph-lines class which will cause all the graph lines to be hidden. It also
+// sets the mouseIn state to false so that the current graph's guideline will
+// appear when hovering over a different graph.
+export function mouseLeave(node: React.Component<any, GraphLineState>) {
+  this.setState({
+    mouseIn: false,
+  });
+  d3.select(".graph-lines").classed("graph-lines--show", false);
+};

--- a/pkg/ui/app/components/linegraph.tsx
+++ b/pkg/ui/app/components/linegraph.tsx
@@ -5,6 +5,7 @@ import { createSelector } from "reselect";
 import { findChildrenOfType } from "../util/find";
 import {
   MetricsDataComponentProps, Axis, AxisProps, ConfigureLineChart, InitLineChart,
+  GraphLineState, mouseEnter, mouseMove, mouseLeave,
 } from "./graphs";
 import { Metric, MetricProps } from "./metric";
 import Visualization from "./visualization";
@@ -22,9 +23,11 @@ interface LineGraphProps extends MetricsDataComponentProps {
  * supports a single Y-axis, but multiple metrics can be graphed on the same
  * axis.
  */
-export class LineGraph extends React.Component<LineGraphProps, {}> {
+export class LineGraph extends React.Component<LineGraphProps, GraphLineState> {
   // The SVG Element in the DOM used to render the graph.
   svgEl: SVGElement;
+
+  state = new GraphLineState();
 
   // A configured NVD3 chart used to render the chart.
   chart: nvd3.LineChart;
@@ -104,9 +107,18 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
 
   render() {
     let { title, subtitle, tooltip, data } = this.props;
+    let graphLineClass = "graph-lines__line";
+    if (this.state.mouseIn) {
+      graphLineClass += " graph-lines__line--hidden";
+    }
+
+    let mouseEnterBound = () => mouseEnter(this);
+    let mouseLeaveBound = () => mouseLeave(this);
+
     return <Visualization title={title} subtitle={subtitle} tooltip={tooltip} loading={!data} >
       <div className="linegraph">
-        <svg className="graph" ref={(svg) => this.svgEl = svg}/>
+        <div className={graphLineClass}></div>
+        <svg className="graph" ref={(svg) => this.svgEl = svg} onMouseMove={mouseMove} onMouseEnter={mouseEnterBound} onMouseLeave={mouseLeaveBound} />
       </div>
     </Visualization>;
   }

--- a/pkg/ui/app/components/stackedgraph.tsx
+++ b/pkg/ui/app/components/stackedgraph.tsx
@@ -5,6 +5,7 @@ import { createSelector } from "reselect";
 import { findChildrenOfType } from "../util/find";
 import {
   MetricsDataComponentProps, Axis, AxisProps, InitLineChart, ConfigureLineChart,
+  GraphLineState, mouseEnter, mouseMove, mouseLeave,
 } from "./graphs";
 import { Metric, MetricProps } from "./metric";
 import Visualization from "./visualization";
@@ -22,9 +23,11 @@ interface StackedAreaGraphProps extends MetricsDataComponentProps {
  * currently only supports a single Y-axis, but multiple metrics can be graphed
  * on the same axis.
  */
-export class StackedAreaGraph extends React.Component<StackedAreaGraphProps, {}> {
+export class StackedAreaGraph extends React.Component<StackedAreaGraphProps, GraphLineState> {
   // The SVG Element in the DOM used to render the graph.
   svgEl: SVGElement;
+
+  state = new GraphLineState();
 
   // A configured NVD3 chart used to render the chart.
   chart: nvd3.StackedAreaChart;
@@ -111,9 +114,18 @@ export class StackedAreaGraph extends React.Component<StackedAreaGraphProps, {}>
 
   render() {
     let { title, subtitle, tooltip, data } = this.props;
+    let graphLineClass = "graph-lines__line";
+    if (this.state.mouseIn) {
+      graphLineClass += " graph-lines__line--hidden";
+    }
+
+    let mouseEnterBound = () => mouseEnter(this);
+    let mouseLeaveBound = () => mouseLeave(this);
+
     return <Visualization title={title} subtitle={subtitle} tooltip={tooltip} loading={!data} >
       <div className="linegraph">
-        <svg className="graph" ref={(svg) => this.svgEl = svg}/>
+        <div className={graphLineClass}></div>
+        <svg className="graph" ref={(svg) => this.svgEl = svg} onMouseMove={mouseMove} onMouseEnter={mouseEnterBound} onMouseLeave={mouseLeaveBound} />
       </div>
     </Visualization>;
   }

--- a/pkg/ui/app/containers/nodeGraphs.tsx
+++ b/pkg/ui/app/containers/nodeGraphs.tsx
@@ -57,7 +57,7 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
   nodeAddress(nid: string) {
     let ns = this.props.nodeStatusByID[nid];
     if (!ns) {
-      // This should only happen immediately after loading a page, and 
+      // This should only happen immediately after loading a page, and
       // associated graphs should display no data.
       return "unknown address";
     }
@@ -102,7 +102,7 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
     let capacityUsed = capacityTotal - capacityAvailable;
     let capacityPercent = capacityTotal !== 0 ? (capacityUsed / capacityTotal * 100) : 100;
 
-    return <div className="section l-columns">
+    return <div className="section l-columns graph-lines">
       <div className="chart-group l-columns__left">
         <GraphGroup groupId="node.runtime" hide={dashboard !== "runtime"}>
           <LineGraph title="Node Count" tooltip="The number of nodes active on the cluster.">
@@ -183,7 +183,7 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
           </LineGraph>
 
           <LineGraph title="Exec Latency: 99th percentile"
-                    tooltip={`The 99th percentile of latency between query requests and responses 
+                    tooltip={`The 99th percentile of latency between query requests and responses
                               over a 1 minute period.
                               Values are displayed individually for each node on each node.`}>
             <Axis units={ AxisUnits.Duration }>
@@ -200,7 +200,7 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
           </LineGraph>
 
           <LineGraph title="Exec Latency: 90th percentile"
-                    tooltip={`The 90th percentile of latency between query requests and responses 
+                    tooltip={`The 90th percentile of latency between query requests and responses
                               over a 1 minute period.
                               Values are displayed individually for each node on each node.`}>
             <Axis units={ AxisUnits.Duration }>
@@ -246,7 +246,7 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
             </Axis>
           </LineGraph>
 
-          <LineGraph title="Live Bytes" sources={storeSources} tooltip={`The amount of Live data used by both applications and the CockroachDB system ${specifier}. 
+          <LineGraph title="Live Bytes" sources={storeSources} tooltip={`The amount of Live data used by both applications and the CockroachDB system ${specifier}.
                                                                     This excludes historical and deleted data.`}>
             <Axis units={ AxisUnits.Bytes }>
               <Metric name="cr.store.livebytes" title="Live" />

--- a/pkg/ui/styl/base/palette.styl
+++ b/pkg/ui/styl/base/palette.styl
@@ -91,6 +91,5 @@ $light-gray-2 = #DCDCDC
 $lighter-gray = #F2F2F2
 $gray-blue = #C8CBD4
 $dark-gray-blue = #728099
-$dark-gray-blue = #728099
 $hover-gray = #F0F0F0 // dropdown hover
 $table-gray = #5D5D5D

--- a/pkg/ui/styl/components/visualizations.styl
+++ b/pkg/ui/styl/components/visualizations.styl
@@ -76,3 +76,19 @@ $viz-sides = 62px
   .nv-group
   .nv-areaWrap
     opacity .2
+
+.graph-lines__line
+  width 1px
+  background-color $glow-blue
+  border 0
+  padding 0
+  margin 0
+  height 50%
+  position absolute
+  top 83px
+  visibility hidden
+
+.graph-lines--show .graph-lines__line
+  visibility visible
+  &.graph-lines__line--hidden
+    visibility hidden


### PR DESCRIPTION
Shows/hides a bar across all graphs when you're hovering over any
graph to allow correlating temporal events across graphs. The
current implementation adds an html element outside the svg graph
and then just superimposes it. In the future we may wish to
make this more integrated with nvd3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12645)
<!-- Reviewable:end -->
