### PR TITLE
sql: fix TestRaceWithBackfill

### DIFF
--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -58,8 +58,11 @@ var (
 
 // LeaseState holds the state for a lease. Exported only for testing.
 type LeaseState struct {
+	// This descriptor is immutable and can be shared by many goroutines.
+	// Care must be taken to not modify it.
 	sqlbase.TableDescriptor
 	expiration parser.DTimestamp
+
 	// mu protects refcount and released
 	mu       syncutil.Mutex
 	refcount int
@@ -173,6 +176,8 @@ func (s LeaseStore) Acquire(
 		return nil, err
 	}
 	tableDesc.MaybeUpgradeFormatVersion()
+	// Once the descriptor is set it is immutable and care must be taken
+	// to not modify it.
 	lease.TableDescriptor = *tableDesc
 
 	// ValidateTable instead of Validate, even though we have a txn available,

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -541,7 +541,6 @@ func bulkInsertIntoTable(sqlDB *gosql.DB, maxValue int) error {
 // that run simultaneously.
 func TestRaceWithBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skipf("TODO(vivek): make stress TESTS=TestRaceWithBackfill PKG=./sql")
 	var backfillNotification chan bool
 	params, _ := createTestServerParams()
 	// Disable asynchronous schema change execution to allow synchronous path


### PR DESCRIPTION
The table descriptor used during a backfill is from a lease
which is shared across parallel operations and is meant to be
immutable. Do not modify the table descriptor when
calling convertBackfillError.

fixes #12621

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12664)
<!-- Reviewable:end -->
