### PR TITLE
build: move grep ealier to reduce output

### DIFF
--- a/build/upload-coverage.sh
+++ b/build/upload-coverage.sh
@@ -30,7 +30,7 @@ for pkg in $(go list $prefix/...); do
   # dependencies.
   coverpkg=$(go list -f '{{join .Imports "\n"}}{{"\n"}}{{join .TestImports "\n"}}{{"\n"}}{{join .XTestImports "\n"}}' $pkg | \
     sort | uniq | grep -v '^C$' | \
-    xargs go list -f '{{if not .Standard}}{{join .Deps "\n" }}{{end}}' | sort | uniq | \
+    xargs go list -f '{{if not .Standard}}{{join .Deps "\n" }}{{end}}' | \
     sort | uniq | grep -v '^C$' | \
     xargs go list -f '{{if not .Standard}}{{.ImportPath}}{{end}}' | \
     grep $prefix || true)


### PR DESCRIPTION
printing the def of top_deps is quite verbose unless we filter it first -- we don't really need to do so again after adding cmd_deps since those are going to be main pkgs which won't appear in top deps anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12676)
<!-- Reviewable:end -->
