### PR TITLE
storage/engine/rocksdb: tune level0_{slowdown,stop}_writes_trigger

### DIFF
--- a/pkg/storage/engine/rocksdb/db.cc
+++ b/pkg/storage/engine/rocksdb/db.cc
@@ -1587,11 +1587,14 @@ DBStatus DBOpen(DBEngine **db, DBSlice dir, DBOptions db_opts) {
   // this number is reached.
   //
   // TODO(peter): untuned.
-  options.level0_slowdown_writes_trigger = 16;
-  // Maximum number of L0 files. Writes are stopped at this point.
+  options.level0_slowdown_writes_trigger = 20;
+  // Maximum number of L0 files. Writes are stopped at this
+  // point. This is set significantly higher than
+  // level0_slowdown_writes_trigger to avoid completely blocking
+  // writes.
   //
   // TODO(peter): untuned.
-  options.level0_stop_writes_trigger = 17;
+  options.level0_stop_writes_trigger = 32;
   // Flush write buffers to L0 as soon as they are full. A higher
   // value could be beneficial if there are duplicate records in each
   // of the individual write buffers, but perf testing hasn't shown


### PR DESCRIPTION
Set level0_{slowdown,stop}_writes_trigger to 20 and 32
respectively. These follow the new defaults in
https://github.com/facebook/rocksdb/commit/cd7c4143d795ab9a53e6eaeb4ee572b4e258313b.

I did some experiments which showed fewer write stoppages due to this
change, but nothing that could easily be put into a test. It's not clear
to me if we're actually experiencing write stoppages in production
clusters or not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12677)
<!-- Reviewable:end -->
