### PR TITLE
build: add teamcity-jepsen test runner

### DIFF
--- a/build/teamcity-jepsen.sh
+++ b/build/teamcity-jepsen.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# This script provisions a Jepsen controller and 5 nodes, and runs tests
+# against them.
+
+COCKROACH_PATH="${GOPATH}/src/github.com/cockroachdb/cockroach"
+KEY_NAME="${KEY_NAME-google_compute_engine}"
+LOG_DIR="${COCKROACH_PATH}/artifacts"
+mkdir -p "${LOG_DIR}"
+
+cd "${COCKROACH_PATH}/cloud/gce/jepsen"
+
+# Generate ssh keys for the controller to talk to the workers.
+rm -f controller.id_rsa controller.id_rsa.pub
+ssh-keygen -f controller.id_rsa -N ''
+
+function destroy {
+  set +e
+  echo "Tearing down cluster..."
+  terraform destroy --var=key_name="${KEY_NAME}" --force
+}
+trap destroy EXIT
+
+# Spin up the cluster.
+terraform apply --var=key_name="${KEY_NAME}"
+
+controller="$(terraform output controller-ip)"
+
+nemeses=(
+    # big-skews disabled since they assume an eth0 interface.
+    #"--nemesis big-skews"
+    "--nemesis majority-ring"
+    "--nemesis start-stop-2"
+    "--nemesis start-kill-2"
+    #"--nemesis majority-ring --nemesis2 big-skews"
+    #"--nemesis big-skews --nemesis2 start-kill-2"
+    "--nemesis majority-ring --nemesis2 start-kill-2"
+    "--nemesis parts --nemesis2 start-kill-2"
+)
+
+tests=(
+    "bank"
+    "comments"
+    "register"
+    "monotonic"
+    "sets"
+    "sequential"
+)
+
+testcmd_base="cd jepsen/cockroachdb && ~/lein run test --tarball file:///home/ubuntu/cockroach.tgz --username ubuntu --ssh-private-key ~/.ssh/id_rsa --nodes-file ~/nodes --time-limit 180 --test-count 1 --os ubuntu"
+
+# Don't quit after just one test.
+# Can't have -x on when echoing the teamcity status lines or else we'll
+# get duplicates.
+set +ex
+for test in "${tests[@]}"; do
+    for nemesis in "${nemeses[@]}"; do
+        # We pipe stdout to /dev/null because it's already recorded by Jepsen
+        # and placed in the artifacts for us.
+        testcmd="${testcmd_base} --test ${test} ${nemesis} > /dev/null"
+        echo "##teamcity[testStarted name='${test} ${nemesis}']"
+        echo "Testing with args --test ${test} ${nemesis}"
+        # Run each test over an ssh connection.
+        # If this begins to time out frequently, let's do this via nohup and poll.
+        ssh -o "ServerAliveInterval=60" -o "StrictHostKeyChecking no" -i "$HOME/.ssh/${KEY_NAME}" "ubuntu@${controller}" "${testcmd}"
+        # Remove spaces from test name to get the artifacts subdirectory
+        testname=$(echo "${test}${nemesis}" | sed 's/ //g')
+        artifacts_dir="${LOG_DIR}/${testname}"
+        mkdir -p "${artifacts_dir}"
+        if [ $? -ne 0 ]; then
+            # Test failed: grab everything.
+            echo "Test failed. Grabbing logs..."
+            scp -o "StrictHostKeyChecking no" -ri "$HOME/.ssh/${KEY_NAME}" "ubuntu@${controller}:jepsen/cockroachdb/store/latest" "${artifacts_dir}"
+            echo "##teamcity[testFailed name='${test} ${nemesis}']"
+        else
+            # Test passed. grab just the results file.
+            echo "Test passed. Grabbing minimal logs..."
+            scp -o "StrictHostKeyChecking no" -ri "$HOME/.ssh/${KEY_NAME}" "ubuntu@${controller}:jepsen/cockroachdb/store/latest/test.fressian" "${artifacts_dir}"
+        fi
+        echo "##teamcity[testFinished name='${test} ${nemesis}']"
+        echo "##teamcity[publishArtifacts '${LOG_DIR}']"
+    done
+done

--- a/cloud/gce/jepsen/main.tf
+++ b/cloud/gce/jepsen/main.tf
@@ -160,6 +160,11 @@ resource "null_resource" "cockroach-runner" {
       "sudo apt-get -qqy upgrade -o Dpkg::Options::='--force-confold' >/dev/null",
       # Allow access to the cockroach instances from the Jepsen controller.
       "sudo cp ~/.ssh/authorized_keys2 /root/.ssh/authorized_keys2",
+      # Download latest cockroach binary, zip so that Jepsen understands it
+      "mkdir -p /tmp/cockroach",
+      "curl http://s3.amazonaws.com/cockroach/cockroach/cockroach.$(curl http://s3.amazonaws.com/cockroach/cockroach/cockroach.LATEST) -o /tmp/cockroach/cockroach",
+      "chmod +x /tmp/cockroach/cockroach",
+      "tar -C /tmp -czf /home/ubuntu/cockroach.tgz cockroach",
     ]
   }
 }


### PR DESCRIPTION
This (proof of concept for now) script spins up a Jepsen cluster and
runs a test with a single nemesis pair, persisting the logs to the
artifacts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12684)
<!-- Reviewable:end -->
