### PR TITLE
ui: timescale selector tweaks

### DIFF
--- a/pkg/ui/app/components/dropdown.tsx
+++ b/pkg/ui/app/components/dropdown.tsx
@@ -24,6 +24,12 @@ interface DropdownOwnProps {
   onArrowClick?: (direction: ArrowDirection) => void;
   // Disable any arrows in the arrow direction array.
   disabledArrows?: ArrowDirection[];
+  // Highlight the relevant arrow.
+  highlightedArrow?: ArrowDirection;
+}
+
+class DropdownState {
+
 }
 
 /**
@@ -39,7 +45,7 @@ export default class Dropdown extends React.Component<DropdownOwnProps, {}> {
     return <div className={className}>
       {/* TODO (maxlang): consider moving arrows outside the dropdown component */}
       <span
-        className="dropdown__side-arrow"
+        className={"dropdown__side-arrow" + (this.props.highlightedArrow === ArrowDirection.LEFT ? " dropdown__side-arrow--highlight" : "")}
         disabled={_.includes(disabledArrows, ArrowDirection.LEFT)}
         dangerouslySetInnerHTML={trustIcon(leftArrow)}
         onClick={() => this.props.onArrowClick(ArrowDirection.LEFT)}>
@@ -47,7 +53,7 @@ export default class Dropdown extends React.Component<DropdownOwnProps, {}> {
       <span className="dropdown__title">{this.props.title}{this.props.title ? ":" : ""}</span>
       <Select className="dropdown__select" clearable={false} searchable={false} options={options} value={selected} onChange={onChange} />
       <span
-        className="dropdown__side-arrow"
+        className={"dropdown__side-arrow" + (this.props.highlightedArrow === ArrowDirection.RIGHT ? " dropdown__side-arrow--highlight" : "")}
         disabled={_.includes(disabledArrows, ArrowDirection.RIGHT)}
         dangerouslySetInnerHTML={trustIcon(rightArrow)}
         onClick={() => this.props.onArrowClick(ArrowDirection.RIGHT)}>

--- a/pkg/ui/app/components/dropdown.tsx
+++ b/pkg/ui/app/components/dropdown.tsx
@@ -28,14 +28,17 @@ interface DropdownOwnProps {
   highlightedArrow?: ArrowDirection;
 }
 
-class DropdownState {
-
+enum ArrowButtonHighlightState {
+  NOT_HIGHLIGHTED, HIGHLIGHTED, FADING,
 }
 
 /**
  * Dropdown component that uses the URL query string for state.
  */
 export default class Dropdown extends React.Component<DropdownOwnProps, {}> {
+
+  arrowButtonHighlightState: ArrowButtonHighlightState = ArrowButtonHighlightState.NOT_HIGHLIGHTED;
+
   render() {
     let {selected, options, onChange, onArrowClick, disabledArrows} = this.props;
     let className = "dropdown";

--- a/pkg/ui/app/containers/timescale.tsx
+++ b/pkg/ui/app/containers/timescale.tsx
@@ -139,9 +139,18 @@ class TimeScaleDropdown extends React.Component<TimeScaleDropdownProps, {}> {
     }
   }
 
+  keypress = (event: KeyboardEvent) => {
+    if (event.which === 37) {
+      this.arrowClick(ArrowDirection.LEFT);
+    } else if (event.which === 39) {
+      this.arrowClick(ArrowDirection.RIGHT);
+    }
+  }
+
   componentWillMount() {
     this.props.refreshNodes();
     this.setDefaultTime();
+    document.addEventListener("keydown", this.keypress);
   }
 
   componentWillReceiveProps(props: TimeScaleDropdownProps) {
@@ -150,6 +159,10 @@ class TimeScaleDropdown extends React.Component<TimeScaleDropdownProps, {}> {
     } else {
       this.setDefaultTime(props);
     }
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener("keydown", this.keypress);
   }
 
   render() {

--- a/pkg/ui/app/containers/timescale.tsx
+++ b/pkg/ui/app/containers/timescale.tsx
@@ -66,9 +66,16 @@ interface TimeScaleDropdownProps {
   defaultTimescaleSet: boolean;
 }
 
+class TimeScaleDropdownState {
+  keyJustPressed: ArrowDirection;
+}
+
 // TimeScaleDropdown is the dropdown that allows users to select the time range
 // for graphs.
-class TimeScaleDropdown extends React.Component<TimeScaleDropdownProps, {}> {
+class TimeScaleDropdown extends React.Component<TimeScaleDropdownProps, TimeScaleDropdownState> {
+
+  state = new TimeScaleDropdownState();
+
   changeSettings = (newTimescaleKey: DropdownOption) => {
     let newSettings = timewindow.availableTimeScales[newTimescaleKey.value];
     if (newSettings) {
@@ -140,10 +147,19 @@ class TimeScaleDropdown extends React.Component<TimeScaleDropdownProps, {}> {
   }
 
   keypress = (event: KeyboardEvent) => {
+    let arrowDirection;
     if (event.which === 37) {
-      this.arrowClick(ArrowDirection.LEFT);
+      arrowDirection = ArrowDirection.LEFT;
     } else if (event.which === 39) {
-      this.arrowClick(ArrowDirection.RIGHT);
+      arrowDirection = ArrowDirection.RIGHT;
+    }
+
+    if (!_.isUndefined(arrowDirection)) {
+      this.arrowClick(arrowDirection);
+      this.setState({
+        keyJustPressed: arrowDirection,
+      });
+      setTimeout(() => this.setState({ keyJustPressed: null }));
     }
   }
 
@@ -187,6 +203,7 @@ class TimeScaleDropdown extends React.Component<TimeScaleDropdownProps, {}> {
         onChange={this.changeSettings}
         onArrowClick={this.arrowClick}
         disabledArrows={disabledArrows}
+        highlightedArrow={this.state.keyJustPressed}
         />
       <span>{timeRange}</span>
     </div>;

--- a/pkg/ui/styl/components/dropdown.styl
+++ b/pkg/ui/styl/components/dropdown.styl
@@ -59,8 +59,11 @@
 
     .dropdown__side-arrow
       display inline
+      transition background-color 0.5s ease-in-out
+      background-color transparent
 
-      &:hover
+      &:hover, &.dropdown__side-arrow--highlight
         background-color $hover-gray
+        transition background-color 0s ease-in-out
 
 // NOTE: react-select styles can be found in shame.styl


### PR DESCRIPTION
  - Move backwards/forwards in time when using the left/right
arrow keys respectively.
  - Timescale now defaults to 6 hrs instead of 24 when a cluster
has been running long enough.

cc @kuanluo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12714)
<!-- Reviewable:end -->
