### PR TITLE
sql: improve COPY IN handling

### DIFF
--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -170,6 +170,9 @@ func (p *planner) ProcessCopyData(data string, msg copyMsg) (parser.StatementLis
 		if len(line) > 0 && line[len(line)-1] == '\r' {
 			line = line[:len(line)-1]
 		}
+		if buf.Len() == 0 && bytes.Equal(line, []byte(`\.`)) {
+			break
+		}
 		if err := cf.addRow(line); err != nil {
 			return nil, err
 		}

--- a/pkg/sql/copy_in_test.go
+++ b/pkg/sql/copy_in_test.go
@@ -292,7 +292,7 @@ func TestCopyError(t *testing.T) {
 func TestCopyOne(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	t.Skip("https://github.com/lib/pq/issues/494")
+	t.Skip("fails testrace")
 
 	params, _ := createTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
@@ -325,8 +325,6 @@ func TestCopyOne(t *testing.T) {
 // cannot run.
 func TestCopyInProgress(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-
-	t.Skip("https://github.com/lib/pq/issues/494")
 
 	params, _ := createTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)

--- a/pkg/sql/parser/stmt.go
+++ b/pkg/sql/parser/stmt.go
@@ -102,7 +102,7 @@ func (*CommitTransaction) StatementTag() string { return "COMMIT" }
 func (*CopyFrom) StatementType() StatementType { return CopyIn }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*CopyFrom) StatementTag() string { return "COPY FROM" }
+func (*CopyFrom) StatementTag() string { return "COPY" }
 
 // StatementType implements the Statement interface.
 func (*CreateDatabase) StatementType() StatementType { return DDL }

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -956,7 +956,15 @@ func (c *v3Conn) sendResponse(
 			}
 
 		case parser.CopyIn:
-			if err := c.copyIn(result.Columns); err != nil {
+			rows, err := c.copyIn(result.Columns)
+			if err != nil {
+				return err
+			}
+
+			// Send CommandComplete.
+			tag = append(tag, ' ')
+			tag = strconv.AppendInt(tag, rows, 10)
+			if err := c.sendCommandComplete(tag); err != nil {
 				return err
 			}
 
@@ -999,8 +1007,10 @@ func (c *v3Conn) sendRowDescription(
 	return c.writeBuf.finishMsg(c.wr)
 }
 
+// copyIn processes COPY IN data and returns the number of rows inserted.
 // See: https://www.postgresql.org/docs/current/static/protocol-flow.html#PROTOCOL-COPY
-func (c *v3Conn) copyIn(columns []sql.ResultColumn) error {
+func (c *v3Conn) copyIn(columns []sql.ResultColumn) (int64, error) {
+	var rows int64
 	defer c.session.CopyEnd()
 
 	c.writeBuf.initMsg(serverMsgCopyInResponse)
@@ -1010,17 +1020,17 @@ func (c *v3Conn) copyIn(columns []sql.ResultColumn) error {
 		c.writeBuf.putInt16(int16(formatText))
 	}
 	if err := c.writeBuf.finishMsg(c.wr); err != nil {
-		return err
+		return 0, err
 	}
 	if err := c.wr.Flush(); err != nil {
-		return err
+		return 0, err
 	}
 
 	for {
 		typ, n, err := c.readBuf.readTypedMsg(c.rd)
 		c.metrics.BytesInCount.Inc(int64(n))
 		if err != nil {
-			return err
+			return rows, err
 		}
 		var sr sql.StatementResults
 		var done bool
@@ -1043,15 +1053,16 @@ func (c *v3Conn) copyIn(columns []sql.ResultColumn) error {
 			// Spec says to "ignore Flush and Sync messages received during copy-in mode".
 
 		default:
-			return c.sendError(newUnrecognizedMsgTypeErr(typ))
+			return rows, c.sendError(newUnrecognizedMsgTypeErr(typ))
 		}
 		for _, res := range sr.ResultList {
+			rows += int64(res.RowsAffected)
 			if res.Err != nil {
-				return c.sendError(res.Err)
+				return rows, c.sendError(res.Err)
 			}
 		}
 		if done {
-			return nil
+			return rows, nil
 		}
 	}
 }


### PR DESCRIPTION
- Send CommandComplete response after COPY IN.
- Use correct command tag.
- Write affected rows in command tag.
- Accept the special `\.` empty row.
- Reenable the skipped tests (fixed in lib/pq).

No tests for these because lib/pq doesn't expose result command
tags. We also can't test the \. thing because lib/pq escapes the `\`
to `\\` since it believes it to be a valid statement parameter from
the database/sql API.

Fixes #12709

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12723)
<!-- Reviewable:end -->
