### PR TITLE
sql: use walkPlan() more; simplify Start().

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -681,7 +681,7 @@ func (sc *SchemaChanger) backfillIndexesChunk(
 			return err
 		}
 
-		if err := rows.Start(); err != nil {
+		if err := planner.startPlan(rows); err != nil {
 			return err
 		}
 

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -140,7 +140,7 @@ func (p *planner) validateCheckExpr(
 	if err != nil {
 		return err
 	}
-	if err := rows.Start(); err != nil {
+	if err := p.startPlan(rows); err != nil {
 		return err
 	}
 	next, err := rows.Next()

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -684,7 +684,7 @@ func (n *createTableNode) Start() error {
 		if err != nil {
 			return err
 		}
-		if err = insertPlan.Start(); err != nil {
+		if err = n.p.startPlan(insertPlan); err != nil {
 			return err
 		}
 		// This loop is done here instead of in the Next method

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -1512,8 +1512,7 @@ func (p *planner) populateViewBackrefs(
 	plan planNode, tbl *sqlbase.TableDescriptor, backrefs map[sqlbase.ID]*sqlbase.TableDescriptor,
 ) {
 	b := &backrefCollector{p: p, tbl: tbl, backrefs: backrefs}
-	v := planVisitor{observer: b}
-	v.visit(plan)
+	walkPlan(plan, b)
 }
 
 type backrefCollector struct {
@@ -1597,8 +1596,7 @@ func populateViewBackrefFromViewDesc(
 // plan contains a star expansion.
 func (p *planner) planContainsStar(plan planNode) bool {
 	s := &starDetector{}
-	v := planVisitor{observer: s}
-	v.visit(plan)
+	walkPlan(plan, s)
 	return s.foundStar
 }
 

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -1512,7 +1512,7 @@ func (p *planner) populateViewBackrefs(
 	plan planNode, tbl *sqlbase.TableDescriptor, backrefs map[sqlbase.ID]*sqlbase.TableDescriptor,
 ) {
 	b := &backrefCollector{p: p, tbl: tbl, backrefs: backrefs}
-	v := planVisitor{p: p, observer: b}
+	v := planVisitor{observer: b}
 	v.visit(plan)
 }
 
@@ -1597,7 +1597,7 @@ func populateViewBackrefFromViewDesc(
 // plan contains a star expansion.
 func (p *planner) planContainsStar(plan planNode) bool {
 	s := &starDetector{}
-	v := planVisitor{p: p, observer: s}
+	v := planVisitor{observer: s}
 	v.visit(plan)
 	return s.foundStar
 }

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -1512,7 +1512,7 @@ func (p *planner) populateViewBackrefs(
 	plan planNode, tbl *sqlbase.TableDescriptor, backrefs map[sqlbase.ID]*sqlbase.TableDescriptor,
 ) {
 	b := &backrefCollector{p: p, tbl: tbl, backrefs: backrefs}
-	walkPlan(plan, b)
+	_ = walkPlan(plan, b)
 }
 
 type backrefCollector struct {
@@ -1577,6 +1577,7 @@ func (b *backrefCollector) enterNode(_ string, plan planNode) bool {
 func (b *backrefCollector) attr(_, _, _ string)                    {}
 func (b *backrefCollector) expr(_, _ string, _ int, _ parser.Expr) {}
 func (b *backrefCollector) leaveNode(_ string)                     {}
+func (b *backrefCollector) subqueryNode(_ *subquery) error         { return nil }
 
 func populateViewBackrefFromViewDesc(
 	dependency *sqlbase.TableDescriptor,
@@ -1596,7 +1597,7 @@ func populateViewBackrefFromViewDesc(
 // plan contains a star expansion.
 func (p *planner) planContainsStar(plan planNode) bool {
 	s := &starDetector{}
-	walkPlan(plan, s)
+	_ = walkPlan(plan, s)
 	return s.foundStar
 }
 
@@ -1623,3 +1624,4 @@ func (s *starDetector) enterNode(_ string, plan planNode) bool {
 func (s *starDetector) attr(_, _, _ string)                    {}
 func (s *starDetector) expr(_, _ string, _ int, _ parser.Expr) {}
 func (s *starDetector) leaveNode(_ string)                     {}
+func (s *starDetector) subqueryNode(_ *subquery) error         { return nil }

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -129,10 +129,6 @@ func (d *deleteNode) Start() error {
 		}
 	}
 
-	if err := d.rh.startPlans(); err != nil {
-		return err
-	}
-
 	return d.run.tw.init(d.p.txn)
 }
 

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -103,7 +103,7 @@ func (p *planner) Delete(
 }
 
 func (d *deleteNode) Start() error {
-	if err := d.run.startEditNode(); err != nil {
+	if err := d.run.startEditNode(&d.editNodeBase, &d.tw); err != nil {
 		return err
 	}
 

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1234,8 +1234,8 @@ func (e *Executor) execDistSQL(planMaker *planner, tree planNode, result *Result
 
 // execClassic runs a plan using the classic (non-distributed) SQL
 // implementation.
-func (e *Executor) execClassic(plan planNode, result *Result) error {
-	if err := plan.Start(); err != nil {
+func (e *Executor) execClassic(planMaker *planner, plan planNode, result *Result) error {
+	if err := planMaker.startPlan(plan); err != nil {
 		return err
 	}
 
@@ -1342,7 +1342,7 @@ func (e *Executor) execStmt(
 		}
 		err = e.execDistSQL(planMaker, plan, &result)
 	} else {
-		err = e.execClassic(plan, &result)
+		err = e.execClassic(planMaker, plan, &result)
 	}
 	return result, err
 }

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -40,16 +40,13 @@ func (p *planner) expandPlan(plan planNode) (planNode, error) {
 		n.sourcePlan, err = p.expandPlan(n.sourcePlan)
 
 	case *updateNode:
-		// TODO(knz) eliminate this once #12599 is fixed.
-		err = n.run.expandEditNodePlan(&n.editNodeBase, &n.tw)
+		n.run.rows, err = p.expandPlan(n.run.rows)
 
 	case *insertNode:
-		// TODO(knz) eliminate this once #12599 is fixed.
-		err = n.run.expandEditNodePlan(&n.editNodeBase, n.tw)
+		n.run.rows, err = p.expandPlan(n.run.rows)
 
 	case *deleteNode:
-		// TODO(knz) eliminate this once #12599 is fixed.
-		err = n.run.expandEditNodePlan(&n.editNodeBase, &n.tw)
+		n.run.rows, err = p.expandPlan(n.run.rows)
 
 	case *createViewNode:
 		n.sourcePlan, err = p.expandPlan(n.sourcePlan)

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -131,7 +131,7 @@ func (p *planner) populateExplain(e *explainer, v *valuesNode, plan planNode) er
 	}
 
 	e.err = nil
-	visitPlan := planVisitor{p: p, observer: e}
+	visitPlan := planVisitor{observer: e}
 	visitPlan.visit(plan)
 	return e.err
 }
@@ -159,7 +159,7 @@ func planToString(plan planNode) string {
 			}
 		},
 	}
-	v := planVisitor{p: makePlanner("planToString"), observer: &e}
+	v := planVisitor{observer: &e}
 	v.visit(plan)
 	return buf.String()
 }

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -131,7 +131,7 @@ func (p *planner) populateExplain(e *explainer, v *valuesNode, plan planNode) er
 	}
 
 	e.err = nil
-	walkPlan(plan, e)
+	_ = walkPlan(plan, e)
 	return e.err
 }
 
@@ -158,7 +158,7 @@ func planToString(plan planNode) string {
 			}
 		},
 	}
-	walkPlan(plan, &e)
+	_ = walkPlan(plan, &e)
 	return buf.String()
 }
 
@@ -215,6 +215,9 @@ func (e *explainer) leaveNode(name string) {
 	}
 	e.level--
 }
+
+// subqueryNode implements the planObserver interface.
+func (e *explainer) subqueryNode(_ *subquery) error { return nil }
 
 // formatColumns converts a column signature for a data source /
 // planNode to a string. The column types are printed iff the 2nd

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -131,8 +131,7 @@ func (p *planner) populateExplain(e *explainer, v *valuesNode, plan planNode) er
 	}
 
 	e.err = nil
-	visitPlan := planVisitor{observer: e}
-	visitPlan.visit(plan)
+	walkPlan(plan, e)
 	return e.err
 }
 
@@ -159,8 +158,7 @@ func planToString(plan planNode) string {
 			}
 		},
 	}
-	v := planVisitor{observer: &e}
-	v.visit(plan)
+	walkPlan(plan, &e)
 	return buf.String()
 }
 

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -217,7 +217,7 @@ func (e *explainer) leaveNode(name string) {
 }
 
 // subqueryNode implements the planObserver interface.
-func (e *explainer) subqueryNode(_ *subquery) error { return nil }
+func (e *explainer) subqueryNode(sq *subquery) error { return nil }
 
 // formatColumns converts a column signature for a data source /
 // planNode to a string. The column types are printed iff the 2nd

--- a/pkg/sql/filter.go
+++ b/pkg/sql/filter.go
@@ -58,12 +58,7 @@ func (f *filterNode) IndexedVarFormat(buf *bytes.Buffer, fl parser.FmtFlags, idx
 }
 
 // Start implements the planNode interface.
-func (f *filterNode) Start() error {
-	if err := f.p.startSubqueryPlans(f.filter); err != nil {
-		return err
-	}
-	return f.source.plan.Start()
-}
+func (f *filterNode) Start() error { return f.source.plan.Start() }
 
 // Next implements the planNode interface.
 func (f *filterNode) Next() (bool, error) {

--- a/pkg/sql/generator.go
+++ b/pkg/sql/generator.go
@@ -87,10 +87,6 @@ func (p *planner) makeGenerator(t *parser.FuncExpr) (planNode, string, error) {
 }
 
 func (n *valueGenerator) Start() error {
-	if err := n.p.startSubqueryPlans(n.expr); err != nil {
-		return err
-	}
-
 	expr, err := n.expr.Eval(&n.p.evalCtx)
 	if err != nil {
 		return err

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -320,19 +320,7 @@ func (n *groupNode) DebugValues() debugValues {
 	return vals
 }
 
-func (n *groupNode) Start() error {
-	if err := n.plan.Start(); err != nil {
-		return err
-	}
-
-	for _, e := range n.render {
-		if err := n.planner.startSubqueryPlans(e); err != nil {
-			return err
-		}
-	}
-
-	return n.planner.startSubqueryPlans(n.having)
-}
+func (n *groupNode) Start() error { return n.plan.Start() }
 
 func (n *groupNode) Next() (bool, error) {
 	var scratch []byte

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -721,7 +721,7 @@ func forEachUser(p *planner, fn func(username string) error) error {
 		return nil
 	}
 	defer plan.Close()
-	if err := plan.Start(); err != nil {
+	if err := p.startPlan(plan); err != nil {
 		return err
 	}
 

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -278,7 +278,7 @@ func (n *insertNode) Start() error {
 		return err
 	}
 
-	if err := n.run.startEditNode(); err != nil {
+	if err := n.run.startEditNode(&n.editNodeBase, n.tw); err != nil {
 		return err
 	}
 

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -274,10 +274,6 @@ func (n *insertNode) Start() error {
 		}
 	}
 
-	if err := n.rh.startPlans(); err != nil {
-		return err
-	}
-
 	if err := n.run.startEditNode(&n.editNodeBase, n.tw); err != nil {
 		return err
 	}

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -291,10 +291,6 @@ func (n *joinNode) MarkDebug(mode explainMode) {
 
 // Start implements the planNode interface.
 func (n *joinNode) Start() error {
-	if err := n.planner.startSubqueryPlans(n.pred.onCond); err != nil {
-		return err
-	}
-
 	if err := n.left.plan.Start(); err != nil {
 		return err
 	}

--- a/pkg/sql/limit.go
+++ b/pkg/sql/limit.go
@@ -139,10 +139,6 @@ func (n *limitNode) evalLimit() error {
 
 	for _, datum := range data {
 		if datum.src != nil {
-			if err := n.p.startSubqueryPlans(datum.src); err != nil {
-				return err
-			}
-
 			dstDatum, err := datum.src.Eval(&n.p.evalCtx)
 			if err != nil {
 				return err

--- a/pkg/sql/optimize.go
+++ b/pkg/sql/optimize.go
@@ -42,7 +42,7 @@ func (p *planner) optimizePlan(plan planNode, needed []bool) (planNode, error) {
 
 	// Now do the same work for all sub-queries.
 	i := subqueryInitializer{p: p}
-	v := planVisitor{p: p, observer: &i}
+	v := planVisitor{observer: &i}
 	v.visit(plan)
 	return plan, i.err
 }

--- a/pkg/sql/optimize.go
+++ b/pkg/sql/optimize.go
@@ -42,8 +42,7 @@ func (p *planner) optimizePlan(plan planNode, needed []bool) (planNode, error) {
 
 	// Now do the same work for all sub-queries.
 	i := subqueryInitializer{p: p}
-	v := planVisitor{observer: &i}
-	v.visit(plan)
+	walkPlan(plan, &i)
 	return plan, i.err
 }
 

--- a/pkg/sql/optimize.go
+++ b/pkg/sql/optimize.go
@@ -34,48 +34,31 @@ func (p *planner) optimizePlan(plan planNode, needed []bool) (planNode, error) {
 	if err != nil {
 		return nil, err
 	}
-	plan = newPlan
 
 	// We now propagate the needed columns again. This will ensure that
 	// the needed columns are properly computed for newly expanded nodes.
-	setNeededColumns(plan, needed)
+	setNeededColumns(newPlan, needed)
 
 	// Now do the same work for all sub-queries.
 	i := subqueryInitializer{p: p}
-	walkPlan(plan, &i)
-	return plan, i.err
+	if err := walkPlan(newPlan, &i); err != nil {
+		return plan, err
+	}
+	return newPlan, nil
 }
 
 // subqueryInitializer ensures that initNeededColumns() and
 // optimizeFilters() is called on the planNodes of all sub-query
 // expressions.
 type subqueryInitializer struct {
-	p   *planner
-	err error
+	p *planner
 }
 
 var _ planObserver = &subqueryInitializer{}
-var _ parser.Visitor = &subqueryInitializer{}
 
-// expr implements the planObserver interface.
-func (i *subqueryInitializer) expr(_, _ string, _ int, expr parser.Expr) {
-	if expr == nil || i.err != nil {
-		return
-	}
-	parser.WalkExprConst(i, expr)
-}
-
-func (i *subqueryInitializer) enterNode(_ string, _ planNode) bool { return true }
-func (i *subqueryInitializer) leaveNode(_ string)                  {}
-func (i *subqueryInitializer) attr(_, _, _ string)                 {}
-
-// VisitPre implements the parser.Visitor interface.
-func (i *subqueryInitializer) VisitPre(expr parser.Expr) (recurse bool, newExpr parser.Expr) {
-	if i.err != nil {
-		return false, expr
-	}
-
-	if sq, ok := expr.(*subquery); ok && sq.plan != nil && !sq.expanded {
+// subqueryNode implements the planObserver interface.
+func (i *subqueryInitializer) subqueryNode(sq *subquery) error {
+	if sq.plan != nil && !sq.expanded {
 		needed := make([]bool, len(sq.plan.Columns()))
 		if sq.execMode != execModeExists {
 			// EXISTS does not need values; the rest does.
@@ -86,13 +69,14 @@ func (i *subqueryInitializer) VisitPre(expr parser.Expr) (recurse bool, newExpr 
 		var err error
 		sq.plan, err = i.p.optimizePlan(sq.plan, needed)
 		if err != nil {
-			i.err = err
+			return err
 		}
 		sq.expanded = true
-		return false, expr
 	}
-	return true, expr
+	return nil
 }
 
-// VisitPost implements the parser.Visitor interface.
-func (i *subqueryInitializer) VisitPost(expr parser.Expr) parser.Expr { return expr }
+func (i *subqueryInitializer) enterNode(_ string, _ planNode) bool    { return true }
+func (i *subqueryInitializer) expr(_, _ string, _ int, _ parser.Expr) {}
+func (i *subqueryInitializer) leaveNode(_ string)                     {}
+func (i *subqueryInitializer) attr(_, _, _ string)                    {}

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -121,6 +121,8 @@ type planNode interface {
 	// performing side effects for data-modifying statements. Returns an
 	// error if initial processing fails.
 	//
+	// Note: Don't use directly. Use startPlan() instead.
+	//
 	// Available after optimizePlan() (or makePlan).
 	Start() error
 
@@ -216,6 +218,14 @@ func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, er
 		log.Infof(p.ctx(), "statement %s compiled to:\n%s", stmt, planToString(plan))
 	}
 	return plan, nil
+}
+
+// startPlan starts the plan and all its sub-query nodes.
+func (p *planner) startPlan(plan planNode) error {
+	if err := p.startSubqueryPlans(plan); err != nil {
+		return err
+	}
+	return plan.Start()
 }
 
 // newPlan constructs a planNode from a statement. This is used

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -72,10 +72,9 @@ type planner struct {
 	copyFrom *copyNode
 
 	// Avoid allocations by embedding commonly used visitors.
-	subqueryVisitor             subqueryVisitor
-	subqueryPlanVisitor         subqueryPlanVisitor
-	collectSubqueryPlansVisitor collectSubqueryPlansVisitor
-	nameResolutionVisitor       nameResolutionVisitor
+	subqueryVisitor       subqueryVisitor
+	subqueryPlanVisitor   subqueryPlanVisitor
+	nameResolutionVisitor nameResolutionVisitor
 
 	execCfg *ExecutorConfig
 

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -318,7 +318,7 @@ func (p *planner) queryRows(sql string, args ...interface{}) ([]parser.DTuple, e
 		return nil, err
 	}
 	defer plan.Close()
-	if err := plan.Start(); err != nil {
+	if err := p.startPlan(plan); err != nil {
 		return nil, err
 	}
 	if next, err := plan.Next(); err != nil || !next {
@@ -358,7 +358,7 @@ func (p *planner) exec(sql string, args ...interface{}) (int, error) {
 		return 0, err
 	}
 	defer plan.Close()
-	if err := plan.Start(); err != nil {
+	if err := p.startPlan(plan); err != nil {
 		return 0, err
 	}
 	return countRowsAffected(plan)

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -119,19 +119,7 @@ func (s *renderNode) DebugValues() debugValues {
 	return s.source.plan.DebugValues()
 }
 
-func (s *renderNode) Start() error {
-	if err := s.source.plan.Start(); err != nil {
-		return err
-	}
-
-	for _, e := range s.render {
-		if err := s.planner.startSubqueryPlans(e); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
+func (s *renderNode) Start() error { return s.source.plan.Start() }
 
 func (s *renderNode) Next() (bool, error) {
 	if next, err := s.source.plan.Next(); !next {

--- a/pkg/sql/returning.go
+++ b/pkg/sql/returning.go
@@ -102,15 +102,6 @@ func (rh *returningHelper) cookResultRow(rowVals parser.DTuple) (parser.DTuple, 
 	return resRow, nil
 }
 
-func (rh *returningHelper) startPlans() error {
-	for _, expr := range rh.exprs {
-		if err := rh.p.startSubqueryPlans(expr); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // IndexedVarEval implements the parser.IndexedVarContainer interface.
 func (rh *returningHelper) IndexedVarEval(idx int, ctx *parser.EvalContext) (parser.Datum, error) {
 	return rh.curSourceRow[idx].Eval(ctx)

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -142,13 +142,8 @@ func (n *scanNode) disableBatchLimit() {
 }
 
 func (n *scanNode) Start() error {
-	err := n.fetcher.Init(&n.desc, n.colIdxMap, n.index, n.reverse, n.isSecondaryIndex, n.cols,
+	return n.fetcher.Init(&n.desc, n.colIdxMap, n.index, n.reverse, n.isSecondaryIndex, n.cols,
 		n.valNeededForCol)
-	if err != nil {
-		return err
-	}
-
-	return n.p.startSubqueryPlans(n.filter)
 }
 
 func (n *scanNode) Close() {}

--- a/pkg/sql/split.go
+++ b/pkg/sql/split.go
@@ -107,9 +107,6 @@ func (n *splitNode) Start() error {
 	values := make([]parser.Datum, len(n.exprs))
 	colMap := make(map[sqlbase.ColumnID]int)
 	for i, e := range n.exprs {
-		if err := n.p.startSubqueryPlans(e); err != nil {
-			return err
-		}
 		val, err := e.Eval(&n.p.evalCtx)
 		if err != nil {
 			return err

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -108,14 +108,15 @@ func (s *subquery) Eval(_ *parser.EvalContext) (parser.Datum, error) {
 	return s.result, s.err
 }
 
-func (s *subquery) doEval() (parser.Datum, error) {
-	var result parser.Datum
+func (s *subquery) doEval() (result parser.Datum, err error) {
+	// After evaluation, there is no plan remaining.
+	defer func() { s.plan.Close(); s.plan = nil }()
+
 	switch s.execMode {
 	case execModeExists:
 		// For EXISTS expressions, all we want to know is if there is at least one
 		// result.
 		next, err := s.plan.Next()
-		s.plan.Close()
 		if s.err = err; err != nil {
 			return result, err
 		}
@@ -148,7 +149,6 @@ func (s *subquery) doEval() (parser.Datum, error) {
 				rows = append(rows, &valuesCopy)
 			}
 		}
-		s.plan.Close()
 		if s.err = err; err != nil {
 			return result, err
 		}
@@ -161,12 +161,9 @@ func (s *subquery) doEval() (parser.Datum, error) {
 		result = parser.DNull
 		hasRow, err := s.plan.Next()
 		if s.err = err; err != nil {
-			s.plan.Close()
 			return result, err
 		}
-		if !hasRow {
-			s.plan.Close()
-		} else {
+		if hasRow {
 			values := s.plan.Values()
 			switch len(values) {
 			case 1:
@@ -177,7 +174,6 @@ func (s *subquery) doEval() (parser.Datum, error) {
 				result = &valuesCopy
 			}
 			another, err := s.plan.Next()
-			s.plan.Close()
 			if s.err = err; err != nil {
 				return result, err
 			}
@@ -193,59 +189,50 @@ func (s *subquery) doEval() (parser.Datum, error) {
 
 // subqueryPlanVisitor is responsible for acting on the query plan
 // that implements the sub-query, after it has been populated by
-// subqueryVisitor.  This visitor supports both expanding, starting
+// subqueryVisitor. This visitor supports both starting
 // and evaluating the sub-plans in one recursion.
 type subqueryPlanVisitor struct {
-	p       *planner
-	doStart bool
-	doEval  bool
-	err     error
+	p *planner
 }
 
-var _ parser.Visitor = &subqueryPlanVisitor{}
+var _ planObserver = &subqueryPlanVisitor{}
 
-func (v *subqueryPlanVisitor) VisitPre(expr parser.Expr) (recurse bool, newExpr parser.Expr) {
-	if v.err != nil {
-		return false, expr
+func (v *subqueryPlanVisitor) subqueryNode(sq *subquery) error {
+	if !sq.expanded {
+		panic("subquery was not expanded properly")
 	}
-	if sq, ok := expr.(*subquery); ok {
-		if !sq.expanded {
-			sq.plan, v.err = v.p.optimizePlan(sq.plan, allColumns(sq.plan))
-			sq.expanded = true
+	if !sq.started {
+		if err := v.p.startPlan(sq.plan); err != nil {
+			return err
 		}
-		if v.err == nil && v.doStart && !sq.started {
-			if !sq.expanded {
-				panic("subquery was not expanded properly")
-			}
-			v.err = sq.plan.Start()
-			sq.started = true
+		sq.started = true
+		res, err := sq.doEval()
+		if err != nil {
+			return err
 		}
-		if v.err == nil && v.doEval && sq.result == nil {
-			if !sq.expanded || !sq.started {
-				panic("subquery was not expanded or prepared properly")
-			}
-			sq.result, sq.err = sq.doEval()
-			if sq.err != nil {
-				v.err = sq.err
-			}
-		}
-		return false, expr
+		sq.result = res
 	}
-	return true, expr
+	return nil
 }
 
-func (v *subqueryPlanVisitor) VisitPost(expr parser.Expr) parser.Expr { return expr }
-
-func (p *planner) startSubqueryPlans(expr parser.Expr) error {
-	if expr == nil {
-		return nil
+func (v *subqueryPlanVisitor) enterNode(_ string, n planNode) bool {
+	if _, ok := n.(*explainPlanNode); ok {
+		// EXPLAIN doesn't start/substitute sub-queries.
+		return false
 	}
+	return true
+}
+
+func (v *subqueryPlanVisitor) attr(_, _, _ string)                    {}
+func (v *subqueryPlanVisitor) expr(_, _ string, _ int, _ parser.Expr) {}
+func (v *subqueryPlanVisitor) leaveNode(_ string)                     {}
+
+func (p *planner) startSubqueryPlans(plan planNode) error {
 	// We also run and pre-evaluate the subqueries during start,
 	// so as to avoid re-running the sub-query for every row
 	// in the results of the surrounding planNode.
-	p.subqueryPlanVisitor = subqueryPlanVisitor{doStart: true, doEval: true}
-	_, _ = parser.WalkExpr(&p.subqueryPlanVisitor, expr)
-	return p.subqueryPlanVisitor.err
+	p.subqueryPlanVisitor = subqueryPlanVisitor{p: p}
+	return walkPlan(plan, &p.subqueryPlanVisitor)
 }
 
 // subqueryVisitor replaces parser.Subquery syntax nodes by a

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -31,12 +31,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-// expressionCarrier handles expanding and starting sub-query plans
-// contained in Expr objects.
+// expressionCarrier handles visiting sub-expressions and starting
+// sub-query plans contained in Expr objects.
 type expressionCarrier interface {
-	// expand the sub-plans contained by expressions
-	// held by this object, if any.
-	expand() error
+	// walkExprs explores all sub-expressions held by this object, if
+	// any.
+	walkExprs(func(desc string, index int, expr parser.TypedExpr))
 
 	// start the sub-plans contained by expressions
 	// held by this object, if any.
@@ -87,13 +87,8 @@ type tableInserter struct {
 	b   *client.Batch
 }
 
-func (ti *tableInserter) expand() error {
-	return nil
-}
-
-func (ti *tableInserter) start() error {
-	return nil
-}
+func (ti *tableInserter) walkExprs(_ func(desc string, index int, expr parser.TypedExpr)) {}
+func (ti *tableInserter) start() error                                                    { return nil }
 
 func (ti *tableInserter) init(txn *client.Txn) error {
 	ti.txn = txn
@@ -132,13 +127,8 @@ type tableUpdater struct {
 	b   *client.Batch
 }
 
-func (tu *tableUpdater) expand() error {
-	return nil
-}
-
-func (tu *tableUpdater) start() error {
-	return nil
-}
+func (tu *tableUpdater) walkExprs(_ func(desc string, index int, expr parser.TypedExpr)) {}
+func (tu *tableUpdater) start() error                                                    { return nil }
 
 func (tu *tableUpdater) init(txn *client.Txn) error {
 	tu.txn = txn
@@ -231,11 +221,10 @@ type tableUpserter struct {
 	indexKeyPrefix []byte
 }
 
-func (tu *tableUpserter) expand() error {
+func (tu *tableUpserter) walkExprs(walk func(desc string, index int, expr parser.TypedExpr)) {
 	if tu.evaler != nil {
-		return tu.evaler.expand()
+		tu.evaler.walkExprs(walk)
 	}
-	return nil
 }
 
 func (tu *tableUpserter) start() error {
@@ -491,13 +480,8 @@ type tableDeleter struct {
 	b   *client.Batch
 }
 
-func (td *tableDeleter) expand() error {
-	return nil
-}
-
-func (td *tableDeleter) start() error {
-	return nil
-}
+func (td *tableDeleter) walkExprs(_ func(desc string, index int, expr parser.TypedExpr)) {}
+func (td *tableDeleter) start() error                                                    { return nil }
 
 func (td *tableDeleter) init(txn *client.Txn) error {
 	td.txn = txn

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -31,16 +31,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-// expressionCarrier handles visiting sub-expressions and starting
-// sub-query plans contained in Expr objects.
+// expressionCarrier handles visiting sub-expressions.
 type expressionCarrier interface {
 	// walkExprs explores all sub-expressions held by this object, if
 	// any.
 	walkExprs(func(desc string, index int, expr parser.TypedExpr))
-
-	// start the sub-plans contained by expressions
-	// held by this object, if any.
-	start() error
 }
 
 // tableWriter handles writing kvs and forming table rows.
@@ -88,7 +83,6 @@ type tableInserter struct {
 }
 
 func (ti *tableInserter) walkExprs(_ func(desc string, index int, expr parser.TypedExpr)) {}
-func (ti *tableInserter) start() error                                                    { return nil }
 
 func (ti *tableInserter) init(txn *client.Txn) error {
 	ti.txn = txn
@@ -128,7 +122,6 @@ type tableUpdater struct {
 }
 
 func (tu *tableUpdater) walkExprs(_ func(desc string, index int, expr parser.TypedExpr)) {}
-func (tu *tableUpdater) start() error                                                    { return nil }
 
 func (tu *tableUpdater) init(txn *client.Txn) error {
 	tu.txn = txn
@@ -225,13 +218,6 @@ func (tu *tableUpserter) walkExprs(walk func(desc string, index int, expr parser
 	if tu.evaler != nil {
 		tu.evaler.walkExprs(walk)
 	}
-}
-
-func (tu *tableUpserter) start() error {
-	if tu.evaler != nil {
-		return tu.evaler.start()
-	}
-	return nil
 }
 
 func (tu *tableUpserter) init(txn *client.Txn) error {
@@ -481,7 +467,6 @@ type tableDeleter struct {
 }
 
 func (td *tableDeleter) walkExprs(_ func(desc string, index int, expr parser.TypedExpr)) {}
-func (td *tableDeleter) start() error                                                    { return nil }
 
 func (td *tableDeleter) init(txn *client.Txn) error {
 	td.txn = txn

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -94,11 +94,7 @@ func (r *editNodeRun) startEditNode(en *editNodeBase, tw tableWriter) error {
 
 	r.tw = tw
 
-	if err := r.tw.start(); err != nil {
-		return err
-	}
-
-	return r.rows.Start()
+	return en.p.startPlan(r.rows)
 }
 
 type updateNode struct {
@@ -271,14 +267,9 @@ func (p *planner) Update(
 }
 
 func (u *updateNode) Start() error {
-	if err := u.rh.startPlans(); err != nil {
-		return err
-	}
-
 	if err := u.run.startEditNode(&u.editNodeBase, &u.tw); err != nil {
 		return err
 	}
-
 	return u.run.tw.init(u.p.txn)
 }
 

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -86,24 +86,14 @@ func (r *editNodeRun) initEditNode(
 	return nil
 }
 
-func (r *editNodeRun) expandEditNodePlan(en *editNodeBase, tw tableWriter) error {
+func (r *editNodeRun) startEditNode(en *editNodeBase, tw tableWriter) error {
 	if sqlbase.IsSystemConfigID(en.tableDesc.GetID()) {
 		// Mark transaction as operating on the system DB.
 		en.p.txn.SetSystemConfigTrigger()
 	}
 
-	if err := tw.expand(); err != nil {
-		return err
-	}
-
 	r.tw = tw
 
-	var err error
-	r.rows, err = en.p.expandPlan(r.rows)
-	return err
-}
-
-func (r *editNodeRun) startEditNode() error {
 	if err := r.tw.start(); err != nil {
 		return err
 	}
@@ -285,7 +275,7 @@ func (u *updateNode) Start() error {
 		return err
 	}
 
-	if err := u.run.startEditNode(); err != nil {
+	if err := u.run.startEditNode(&u.editNodeBase, &u.tw); err != nil {
 		return err
 	}
 

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -157,15 +157,6 @@ func (uh *upsertHelper) walkExprs(walk func(desc string, index int, expr parser.
 	}
 }
 
-func (uh *upsertHelper) start() error {
-	for _, evalExpr := range uh.evalExprs {
-		if err := uh.p.startSubqueryPlans(evalExpr); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // eval returns the values for the update case of an upsert, given the row
 // that would have been inserted and the existing (conflicting) values.
 func (uh *upsertHelper) eval(

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -151,13 +151,10 @@ func (p *planner) makeUpsertHelper(
 	return helper, nil
 }
 
-func (uh *upsertHelper) expand() error {
-	for _, evalExpr := range uh.evalExprs {
-		if err := uh.p.expandSubqueryPlans(evalExpr); err != nil {
-			return err
-		}
+func (uh *upsertHelper) walkExprs(walk func(desc string, index int, expr parser.TypedExpr)) {
+	for i, evalExpr := range uh.evalExprs {
+		walk("eval", i, evalExpr)
 	}
-	return nil
 }
 
 func (uh *upsertHelper) start() error {

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -133,10 +133,6 @@ func (n *valuesNode) Start() error {
 			if n.columns[i].omitted {
 				row[i] = parser.DNull
 			} else {
-				if err := n.p.startSubqueryPlans(typedExpr); err != nil {
-					return err
-				}
-
 				var err error
 				row[i], err = typedExpr.Eval(&n.p.evalCtx)
 				if err != nil {

--- a/pkg/sql/values_test.go
+++ b/pkg/sql/values_test.go
@@ -130,7 +130,7 @@ func TestValues(t *testing.T) {
 				t.Errorf("%d: unexpected error in optimizePlan: %v", i, err)
 				continue
 			}
-			if err := plan.Start(); err != nil {
+			if err := p.startPlan(plan); err != nil {
 				t.Errorf("%d: unexpected error in Start: %v", i, err)
 				continue
 			}

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -405,6 +405,13 @@ func (v *planVisitor) expr(
 	v.observer.expr(v.nodeName, fieldName, n, expr)
 
 	if expr != nil {
+		// Note: the recursion through WalkExprConst does nothing else
+		// than calling observer.subqueryNode() and collect subplans in
+		// v.subplans, in particular it does not recurse into the
+		// collected subplans (this recursion is performed by visit() only
+		// after all the subplans have been collected). Therefore, there
+		// is no risk that v.subplans will be clobbered by a recursion
+		// into visit().
 		v.subplans = subplans
 		parser.WalkExprConst(v, expr)
 		subplans = v.subplans

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -46,7 +46,15 @@ type planObserver interface {
 	leaveNode(nodeName string)
 }
 
-// planVisitor is the support structure for visit().
+// walkPlan performs a depth-first traversal of the plan given as
+// argument, informing the planObserver of the node details at each
+// level.
+func walkPlan(plan planNode, observer planObserver) {
+	v := planVisitor{observer: observer}
+	v.visit(plan)
+}
+
+// planVisitor is the support structure for walkPlan().
 type planVisitor struct {
 	observer planObserver
 	nodeName string
@@ -56,9 +64,7 @@ type planVisitor struct {
 	subplans []planNode
 }
 
-// visit performs a depth-first traversal of the plan given as
-// argument, informing the planObserver of the node details at each
-// level.
+// visit is the recursive function that supports walkPlan().
 func (v *planVisitor) visit(plan planNode) {
 	if plan == nil {
 		return

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -290,6 +290,9 @@ func (v *planVisitor) visit(plan planNode) {
 		for i, rexpr := range n.rh.exprs {
 			subplans = lv.expr("returning", i, rexpr, subplans)
 		}
+		n.tw.walkExprs(func(d string, i int, e parser.TypedExpr) {
+			subplans = lv.expr(d, i, e, subplans)
+		})
 		lv.subqueries(subplans)
 		lv.visit(n.run.rows)
 
@@ -309,6 +312,9 @@ func (v *planVisitor) visit(plan planNode) {
 		for i, rexpr := range n.rh.exprs {
 			subplans = lv.expr("returning", i, rexpr, subplans)
 		}
+		n.tw.walkExprs(func(d string, i int, e parser.TypedExpr) {
+			subplans = lv.expr(d, i, e, subplans)
+		})
 		lv.subqueries(subplans)
 		lv.visit(n.run.rows)
 
@@ -318,6 +324,9 @@ func (v *planVisitor) visit(plan planNode) {
 		for i, rexpr := range n.rh.exprs {
 			subplans = lv.expr("returning", i, rexpr, subplans)
 		}
+		n.tw.walkExprs(func(d string, i int, e parser.TypedExpr) {
+			subplans = lv.expr(d, i, e, subplans)
+		})
 		lv.subqueries(subplans)
 		lv.visit(n.run.rows)
 

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -406,19 +406,7 @@ func (n *windowNode) DebugValues() debugValues {
 	return vals
 }
 
-func (n *windowNode) Start() error {
-	if err := n.plan.Start(); err != nil {
-		return err
-	}
-
-	for _, e := range n.windowRender {
-		if err := n.planner.startSubqueryPlans(e); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
+func (n *windowNode) Start() error { return n.plan.Start() }
 
 func (n *windowNode) Next() (bool, error) {
 	for !n.populated {


### PR DESCRIPTION
Fixes #12599.

Requested by #12618.

Also makes the new walkPlan() responsible for walking sub-queries always, both to expand and to start them. This simplifies the planNodes' Start() methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12724)
<!-- Reviewable:end -->
