### PR TITLE
sql: fix the behavior of arithmetic on aggregate results over empty tables.

### DIFF
--- a/pkg/sql/parser/aggregate_builtins.go
+++ b/pkg/sql/parser/aggregate_builtins.go
@@ -217,6 +217,12 @@ type identAggregate struct {
 	val Datum
 }
 
+// IsIdentAggregate returns true for identAggregate.
+func IsIdentAggregate(f AggregateFunc) bool {
+	_, ok := f.(*identAggregate)
+	return ok
+}
+
 // NewIdentAggregate returns an identAggregate (see comment on struct).
 func NewIdentAggregate() AggregateFunc {
 	return &identAggregate{}
@@ -229,6 +235,9 @@ func (a *identAggregate) Add(datum Datum) {
 
 // Result returns the value most recently passed to Add.
 func (a *identAggregate) Result() Datum {
+	// It is significant that identAggregate returns nil, and not DNull,
+	// if no result was known via Add(). See
+	// sql.(*aggregateFuncHolder).Eval() for details.
 	return a.val
 }
 

--- a/pkg/sql/testdata/aggregate
+++ b/pkg/sql/testdata/aggregate
@@ -40,6 +40,33 @@ SELECT ARRAY_AGG(1)
 ----
 {1}
 
+# Check that COALESCE using aggregate results over an empty table
+# work properly. (#12525)
+query I
+SELECT COALESCE(MAX(1), 0) FROM generate_series(1,0)
+----
+0
+
+# Same, using arithmetic on COUNT.
+query I
+SELECT 1 + COUNT(*) FROM generate_series(1,0)
+----
+1
+
+# Same, using an empty table.
+# The following test *must* occur before the first INSERT to the tables,
+# so that it can observe an empty table.
+query II
+SELECT COUNT(*), COALESCE(MAX(k), 1) FROM kv
+----
+0 1
+
+# Same, using a subquery. (#12705)
+query I
+SELECT (SELECT COALESCE(MAX(1), 0) FROM generate_series(1,0))
+----
+0
+
 statement OK
 INSERT INTO kv VALUES
 (1, 2, 3, 'a'),


### PR DESCRIPTION
Prior to this patch, performing arithmetic or calling functions using
the results of aggregations would crash if the input of the
aggregation was empty.

This patch ensures that the results are always defined.

Note: this patch is a stop-gap until #12615 is addressed -- this latter issue will yield a rather major rewrite of the code which will make the identAggregate completely disappear.

Fixes #12705.
Informs #12525.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12733)
<!-- Reviewable:end -->
