### PR TITLE
storage: fix filterBehindReplicas

### DIFF
--- a/pkg/storage/raft_log_queue.go
+++ b/pkg/storage/raft_log_queue.go
@@ -180,7 +180,14 @@ func computeTruncatableIndex(
 // getQuorumIndex returns the index which a quorum of the nodes have
 // committed. The pendingSnapshotIndex indicates the index of a pending
 // snapshot which is considered part of the Raft group even though it hasn't
-// been added yet.
+// been added yet. Note that getQuorumIndex may return 0 if the progress map
+// doesn't contain information for a sufficient number of followers (e.g. the
+// local replica has only recently become the leader). In general, the value
+// returned by getQuorumIndex may be smaller than raftStatus.Commit which is
+// the log index that has been committed by a quorum of replicas where that
+// quorum was determined at the time the index was written. If you're thinking
+// of using getQuorumIndex for some purpose, consider that raftStatus.Commit
+// might be more appropriate (e.g. determining if a replica is up to date).
 func getQuorumIndex(raftStatus *raft.Status, pendingSnapshotIndex uint64) uint64 {
 	match := make([]uint64, 0, len(raftStatus.Progress)+1)
 	for _, progress := range raftStatus.Progress {


### PR DESCRIPTION
Fix a bug in filterBehindReplicas where it could return a replica as a
candidate even though the replica was behind. This occurred when a
replica became the Raft leader and was still probing its followers for
the commit index. In that situation, getQuorumIndex can return 0. Using
getQuorumIndex here was inappropriate for other reasons too because the
quorum index can be behind the commit index when a new replica is added
for rebalancing. Switching to using raft.Status.Commit fixes both
problems. Additionally, we require candidates to be in
ProgressStateReplicate as an additional sanity check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12736)
<!-- Reviewable:end -->
