### PR TITLE
storage: serialize replica destruction with applying snapshots

### DIFF
--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -993,6 +993,8 @@ func (m *multiTestContext) changeReplicasLocked(
 			// and call ChangeReplicas on that replica, instead of calling
 			// it on an arbitrary replica and catching this failure.
 			continue
+		} else if storage.IsPreemptiveSnapshotError(err) {
+			continue
 		} else {
 			return 0, err
 		}


### PR DESCRIPTION
Destroying replica data and applying snapshots are both expensive
operations. Serialize them to ensure they don't run concurrently which
can slow down a store excessively.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12737)
<!-- Reviewable:end -->
