### PR TITLE
storage: optimize range deletion

### DIFF
--- a/pkg/storage/abort_cache.go
+++ b/pkg/storage/abort_cache.go
@@ -76,9 +76,12 @@ func (sc *AbortCache) max() roachpb.Key {
 
 // ClearData removes all persisted items stored in the cache.
 func (sc *AbortCache) ClearData(e engine.Engine) error {
-	b := e.NewBatch()
+	iter := e.NewIterator(false)
+	defer iter.Close()
+	b := e.NewWriteOnlyBatch()
 	defer b.Close()
-	_, err := engine.ClearRange(b, engine.MakeMVCCMetadataKey(sc.min()), engine.MakeMVCCMetadataKey(sc.max()))
+	err := b.ClearRange(iter, engine.MakeMVCCMetadataKey(sc.min()),
+		engine.MakeMVCCMetadataKey(sc.max()))
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/engine/bench_test.go
+++ b/pkg/storage/engine/bench_test.go
@@ -39,6 +39,8 @@ import (
 	"github.com/termie/go-shutil"
 )
 
+const overhead = 48 // Per key/value overhead (empirically determined)
+
 // readAllFiles reads all of the files matching pattern thus ensuring they are
 // in the OS buffer cache.
 func readAllFiles(pattern string) {
@@ -191,7 +193,6 @@ func runMVCCScan(emk engineMaker, numRows, numVersions, valueSize int, b *testin
 // runMVCCGet first creates test data (and resets the benchmarking
 // timer). It then performs b.N MVCCGets.
 func runMVCCGet(emk engineMaker, numVersions, valueSize int, b *testing.B) {
-	const overhead = 48          // Per key/value overhead (empirically determined)
 	const targetSize = 512 << 20 // 512 MB
 	// Adjust the number of keys so that each test has approximately the same
 	// amount of data.
@@ -470,7 +471,6 @@ func BenchmarkMVCCMergeTimeSeries_RocksDB(b *testing.B) {
 func runMVCCDeleteRange(emk engineMaker, valueBytes int, b *testing.B) {
 	// 512 KB ranges so the benchmark doesn't take forever
 	const rangeBytes = 512 * 1024
-	const overhead = 48 // Per key/value overhead (empirically determined)
 	numKeys := rangeBytes / (overhead + valueBytes)
 	eng, dir := setupMVCCData(emk, 1, numKeys, valueBytes, b)
 	defer eng.Close()
@@ -505,7 +505,6 @@ func runMVCCDeleteRange(emk engineMaker, valueBytes int, b *testing.B) {
 // runMVCCComputeStats benchmarks computing MVCC stats on a 64MB range of data.
 func runMVCCComputeStats(emk engineMaker, valueBytes int, b *testing.B) {
 	const rangeBytes = 64 * 1024 * 1024
-	const overhead = 48 // Per key/value overhead (empirically determined)
 	numKeys := rangeBytes / (overhead + valueBytes)
 	eng, _ := setupMVCCData(emk, 1, numKeys, valueBytes, b)
 	defer eng.Close()
@@ -592,5 +591,42 @@ func BenchmarkMVCCPutDelete_RocksDB(b *testing.B) {
 		if err := MVCCDelete(context.Background(), rocksdb, nil, key, zeroTS, nil /* txn */); err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+func BenchmarkClearRange_RocksDB(b *testing.B) {
+	const rangeBytes = 64 << 20
+	const valueBytes = 92
+	numKeys := rangeBytes / (overhead + valueBytes)
+	eng, dir := setupMVCCData(setupMVCCRocksDB, 1, numKeys, valueBytes, b)
+	defer eng.Close()
+
+	b.SetBytes(rangeBytes)
+	b.StopTimer()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		locDirty := dir + "_dirty"
+		if err := os.RemoveAll(locDirty); err != nil {
+			b.Fatal(err)
+		}
+		if err := shutil.CopyTree(dir, locDirty, nil); err != nil {
+			b.Fatal(err)
+		}
+		dupEng := setupMVCCRocksDB(b, locDirty)
+
+		b.StartTimer()
+		iter := dupEng.NewIterator(false)
+		batch := dupEng.NewWriteOnlyBatch()
+		if err := batch.ClearRange(iter, NilKey, MVCCKeyMax); err != nil {
+			b.Fatal(err)
+		}
+		iter.Close()
+		if err := batch.Commit(); err != nil {
+			b.Fatal(err)
+		}
+		b.StopTimer()
+
+		dupEng.Close()
 	}
 }

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -131,6 +131,10 @@ type Writer interface {
 	// Note that clear actually removes entries from the storage
 	// engine, rather than inserting tombstones.
 	Clear(key MVCCKey) error
+	// ClearRange removes a set of entries, from start (inclusive) to end
+	// (exclusive). Similar to Clear, this method actually removes entries from
+	// the storage engine.
+	ClearRange(iter Iterator, start, end MVCCKey) error
 	// Merge is a high-performance write operation used for values which are
 	// accumulated over several writes. Multiple values can be merged
 	// sequentially into a single key; a subsequent read will return a "merged"
@@ -262,24 +266,4 @@ func Scan(engine Reader, start, end MVCCKey, max int64) ([]MVCCKeyValue, error) 
 		return false, nil
 	})
 	return kvs, err
-}
-
-// ClearRange removes a set of entries, from start (inclusive) to end
-// (exclusive). This function returns the number of entries
-// removed. Either all entries within the range will be deleted, or
-// none, and an error will be returned. Note that this function
-// actually removes entries from the storage engine, rather than
-// inserting tombstones, as with deletion through the MVCC.
-func ClearRange(engine ReadWriter, start, end MVCCKey) (int, error) {
-	count := 0
-	if err := engine.Iterate(start, end, func(kv MVCCKeyValue) (bool, error) {
-		if err := engine.Clear(kv.Key); err != nil {
-			return false, err
-		}
-		count++
-		return false, nil
-	}); err != nil {
-		return 0, err
-	}
-	return count, nil
 }

--- a/pkg/storage/engine/engine_test.go
+++ b/pkg/storage/engine/engine_test.go
@@ -594,14 +594,11 @@ func TestEngineDeleteRange(t *testing.T) {
 		verifyScan(mvccKey(roachpb.RKeyMin), mvccKey(roachpb.RKeyMax), 10, keys[:5], engine, t)
 
 		// Delete a range of keys
-		numDeleted, err := ClearRange(engine, mvccKey("aa"), mvccKey("abc"))
-		// Verify what was deleted
-		if err != nil {
+		iter := engine.NewIterator(false)
+		if err := engine.ClearRange(iter, mvccKey("aa"), mvccKey("abc")); err != nil {
 			t.Error("Not expecting an error")
 		}
-		if numDeleted != 3 {
-			t.Errorf("Expected to delete 3 entries; was %v", numDeleted)
-		}
+		iter.Close()
 		// Verify what's left
 		verifyScan(mvccKey(roachpb.RKeyMin), mvccKey(roachpb.RKeyMax), 10,
 			[]MVCCKey{mvccKey("a"), mvccKey("abc")}, engine, t)

--- a/pkg/storage/engine/rocksdb/db.cc
+++ b/pkg/storage/engine/rocksdb/db.cc
@@ -1777,6 +1777,22 @@ DBStatus DBDelete(DBEngine *db, DBKey key) {
   return db->Delete(key);
 }
 
+DBStatus DBDeleteRange(DBEngine* db, DBIterator *iter, DBKey start, DBKey end) {
+  // TODO(peter): Replace with the RocksDB DeleteRange support when
+  // that lands and is stable.
+  rocksdb::Iterator *const iter_rep = iter->rep.get();
+  iter_rep->Seek(EncodeKey(start));
+  const std::string end_key = EncodeKey(end);
+  for (; iter_rep->Valid() && kComparator.Compare(iter_rep->key(), end_key) < 0;
+       iter_rep->Next()) {
+    DBStatus status = db->Delete(ToDBKey(iter_rep->key()));
+    if (status.data != NULL) {
+      return status;
+    }
+  }
+  return kSuccess;
+}
+
 DBStatus DBImpl::CommitBatch() {
   return FmtStatus("unsupported");
 }

--- a/pkg/storage/engine/rocksdb/db.h
+++ b/pkg/storage/engine/rocksdb/db.h
@@ -111,6 +111,9 @@ DBStatus DBGet(DBEngine* db, DBKey key, DBString* value);
 // Deletes the database entry for "key".
 DBStatus DBDelete(DBEngine* db, DBKey key);
 
+// Deletes a range of keys from start (inclusive) to end (exclusive).
+DBStatus DBDeleteRange(DBEngine* db, DBIterator *iter, DBKey start, DBKey end);
+
 // Applies a batch of operations (puts, merges and deletes) to the
 // database atomically and closes the batch. It is only valid to call
 // this function on an engine created by DBNewBatch. If an error is

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -706,7 +706,9 @@ func (r *Replica) String() string {
 func (r *Replica) destroyDataRaftMuLocked(
 	ctx context.Context, consistentDesc roachpb.RangeDescriptor,
 ) error {
-	batch := r.store.Engine().NewBatch()
+	// Use a more efficient write-only batch because we don't need to do any
+	// reads from the batch.
+	batch := r.store.Engine().NewWriteOnlyBatch()
 	defer batch.Close()
 
 	iter := r.store.Engine().NewIterator(false)

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -590,22 +590,18 @@ func (r *Replica) applySnapshot(
 	batch := r.store.Engine().NewWriteOnlyBatch()
 	defer batch.Close()
 
-	// Clear the range using a distinct batch in order to prevent the iteration
-	// from forcing the batch to flush from Go to C++.
-	distinctBatch := batch.Distinct()
+	iter := r.store.Engine().NewIterator(false)
+	defer iter.Close()
 
 	// Delete everything in the range and recreate it from the snapshot.
 	// We need to delete any old Raft log entries here because any log entries
 	// that predate the snapshot will be orphaned and never truncated or GC'd.
-	iter := NewReplicaDataIterator(s.Desc, r.store.Engine(), false /* !replicatedOnly */)
-	defer iter.Close()
-	for ; iter.Valid(); iter.Next() {
-		if err := distinctBatch.Clear(iter.Key()); err != nil {
+	for _, keyRange := range makeAllKeyRanges(s.Desc) {
+		if err := batch.ClearRange(iter, keyRange.start, keyRange.end); err != nil {
 			return err
 		}
 	}
 
-	distinctBatch.Close()
 	stats.clear = timeutil.Now()
 
 	// Write the snapshot into the range.
@@ -617,7 +613,7 @@ func (r *Replica) applySnapshot(
 
 	// The log entries are all written to distinct keys so we can use a
 	// distinct batch.
-	distinctBatch = batch.Distinct()
+	distinctBatch := batch.Distinct()
 	stats.batch = timeutil.Now()
 
 	logEntries := make([]raftpb.Entry, len(inSnap.LogEntries))


### PR DESCRIPTION
Optimize deletion of a range of keys by changing the implementation from
iterating over the keys in Go to doing the work in C++. This avoids a
significant number of allocations and cgo calls, though additional
experimentation shows that it is the reduction in cgo calls (not the
reduction in allocations) the provided the bulk of the speedup.

```
name                  old time/op    new time/op    delta
ClearRange_RocksDB-8     424ms ± 4%     226ms ± 3%   -46.72%  (p=0.000 n=10+10)

name                  old speed      new speed      delta
ClearRange_RocksDB-8   158MB/s ± 4%   297MB/s ± 3%   +87.65%  (p=0.000 n=10+10)

name                  old allocs/op  new allocs/op  delta
ClearRange_RocksDB-8      479k ± 0%        0k ± 0%  -100.00%   (p=0.000 n=6+10)
```

This also paves the way for using the RocksDB DeleteRange operation when
it becomes available.

Fixes #12712

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12745)
<!-- Reviewable:end -->
