### PR TITLE
storage: remove risk of lock reacquisition in proposalData.endCmds

### DIFF
--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -97,9 +97,11 @@ type ProposalData struct {
 // invoked here in order to allow the original client to be cancelled
 // and possibly no longer listening to this done channel, and so can't
 // be counted on to invoke endCmds itself.
-func (proposal *ProposalData) finish(pr proposalResult) {
+// replica.mu needs to be held for the replica that's waiting for the
+// application of this proposal.
+func (proposal *ProposalData) finishLocked(pr proposalResult) {
 	if proposal.endCmds != nil {
-		proposal.endCmds.done(pr.Reply, pr.Err, pr.ProposalRetry)
+		proposal.endCmds.doneLocked(pr.Reply, pr.Err, pr.ProposalRetry)
 		proposal.endCmds = nil
 	}
 	proposal.doneCh <- pr

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -1856,7 +1856,7 @@ func TestLeaseConcurrent(t *testing.T) {
 						// otherwise its context (and tracing span) may be used after the
 						// client cleaned up.
 						delete(tc.repl.mu.proposals, proposal.idKey)
-						proposal.finish(proposalResult{Err: roachpb.NewErrorf(origMsg)})
+						proposal.finishLocked(proposalResult{Err: roachpb.NewErrorf(origMsg)})
 						return
 					}
 					if err := defaultSubmitProposalLocked(tc.repl, proposal); err != nil {


### PR DESCRIPTION
Exalate commented:


[Install a Driver or ORM Framework](https://www.cockroachlabs.com/docs/stable/install-client-drivers.html?filters=js-ts) lists `pg` and `Sequelize` support as Beta, and omits `Knex.js` entirely. This is incorrect.

See [Example apps](https://www.cockroachlabs.com/docs/stable/example-apps.html) for a correct list.

Jira Issue: DOC-2319

Jira issue: CRDB-12315