### PR TITLE
sql/pgerror: Overhaul pgError's optional fields as wrappable errors

### DIFF
--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -313,10 +313,9 @@ func (n *createUserNode) Start() error {
 		hashedPassword,
 	)
 	if err != nil {
-		if _, ok := err.(*sqlbase.ErrUniquenessConstraintViolation); ok {
-			err = fmt.Errorf("user %s already exists", normalizedUsername)
+		if sqlbase.IsUniquenessConstraintViolationError(err) {
+			err = errors.Errorf("user %s already exists", normalizedUsername)
 		}
-
 		return err
 	} else if rowsAffected != 1 {
 		return errors.Errorf(

--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -1005,13 +1006,13 @@ func (p *planner) getViewDescForCascade(
 			if err != nil {
 				log.Warningf(p.ctx(), "unable to retrieve qualified name of view %d: %v", viewID, err)
 				msg := fmt.Sprintf("cannot drop %s %q because a view depends on it", typeName, objName)
-				return nil, sqlbase.NewDependentObjectError(msg, "")
+				return nil, sqlbase.NewDependentObjectError(msg)
 			}
 		}
 		msg := fmt.Sprintf("cannot drop %s %q because view %q depends on it",
 			typeName, objName, viewName)
 		hint := fmt.Sprintf("you can drop %s instead.", viewName)
-		return nil, sqlbase.NewDependentObjectError(msg, hint)
+		return nil, pgerror.WithHint(sqlbase.NewDependentObjectError(msg), hint)
 	}
 	return viewDesc, nil
 }

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -932,7 +932,7 @@ func (e *Executor) execStmtInAbortedTxn(
 			return Result{}, nil
 		}
 		err := sqlbase.NewTransactionAbortedError(fmt.Sprintf(
-			"SAVEPOINT %s has not been used or a non-retriable error was encountered.",
+			"SAVEPOINT %s has not been used or a non-retriable error was encountered",
 			parser.RestartSavepointName))
 		return Result{Err: err}, err
 	default:

--- a/pkg/sql/pgwire/pgerror/errors.go
+++ b/pkg/sql/pgwire/pgerror/errors.go
@@ -1,0 +1,257 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nathan VanBenschoten (nvanbenschoten@gmail.com)
+
+package pgerror
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/cockroachdb/cockroach/pkg/util/caller"
+)
+
+// pgError is an error that contains optional Postgres structured error
+// fields. Implementations of the interface annotate these fields onto
+// standard errors by wrapping them. The fields can then be retrieved from
+// the errors using the functions like Hint and Detail below.
+//
+// See https://www.postgresql.org/docs/current/static/protocol-error-fields.html
+// for a list of all Postgres error fields, most of which are optional and can
+// be used to provide auxiliary error information.
+//
+// The style for the implementation is inspired by github.com/pkg/errors,
+// and all pgError implementations are made to play nicely with that package.
+// For instance, a pgError can be wrapped by errors.Wrap and its annotations
+// can still be retrieved. pgErrors also implement the errors.causer interface,
+// meaning that errors.Cause will work correctly with them.
+type pgError interface {
+	error
+	causer
+
+	// structured Postgres error fields. Each method attempts to return the
+	// optional field and a boolean signifying if the optional field was
+	// present.
+	PGCode() (string, bool)
+	Detail() (string, bool)
+	Hint() (string, bool)
+	SourceContext() (SrcCtx, bool)
+
+	// formatting methods.
+	fmt.Formatter
+	verboseFormat() string
+}
+
+// from github.com/pkg/errors package.
+type causer interface {
+	Cause() error
+}
+
+var _ pgError = &withPGCode{}
+var _ pgError = &withDetail{}
+var _ pgError = &withHint{}
+var _ pgError = &withSrcCtx{}
+
+// pgErrorCause is embedded by each pgError implementation to eliminate
+// method duplication.
+type pgErrorCause struct {
+	error
+}
+
+func (ec pgErrorCause) Cause() error                  { return ec.error }
+func (ec pgErrorCause) PGCode() (string, bool)        { return PGCode(ec.error) }
+func (ec pgErrorCause) Detail() (string, bool)        { return Detail(ec.error) }
+func (ec pgErrorCause) Hint() (string, bool)          { return Hint(ec.error) }
+func (ec pgErrorCause) SourceContext() (SrcCtx, bool) { return SourceContext(ec.error) }
+
+// WithPGCode annotates err with a Postgres error code.
+// If err is nil, WithPGCode returns nil.
+func WithPGCode(err error, code string) error {
+	if err == nil || code == "" {
+		return err
+	}
+	return &withPGCode{
+		pgErrorCause: pgErrorCause{err},
+		code:         code,
+	}
+}
+
+type withPGCode struct {
+	pgErrorCause
+	code string
+}
+
+func (w *withPGCode) PGCode() (string, bool)        { return w.code, true }
+func (w *withPGCode) verboseFormat() string         { return "code: " + w.code }
+func (w *withPGCode) Format(s fmt.State, verb rune) { formatPGError(w, s, verb) }
+
+// WithDetail annotates err with a detail message.
+// If err is nil, WithDetail returns nil.
+func WithDetail(err error, detail string) error {
+	if err == nil || detail == "" {
+		return err
+	}
+	return &withDetail{
+		pgErrorCause: pgErrorCause{err},
+		detail:       detail,
+	}
+}
+
+type withDetail struct {
+	pgErrorCause
+	detail string
+}
+
+func (w *withDetail) Detail() (string, bool)        { return w.detail, true }
+func (w *withDetail) verboseFormat() string         { return "detail: " + w.detail }
+func (w *withDetail) Format(s fmt.State, verb rune) { formatPGError(w, s, verb) }
+
+// WithHint annotates err with a hint for users to resolve the
+// issue in the future.
+// If err is nil, WithHint returns nil.
+func WithHint(err error, hint string) error {
+	if err == nil || hint == "" {
+		return err
+	}
+	return &withHint{
+		pgErrorCause: pgErrorCause{err},
+		hint:         hint,
+	}
+}
+
+type withHint struct {
+	pgErrorCause
+	hint string
+}
+
+func (w *withHint) Hint() (string, bool)          { return w.hint, true }
+func (w *withHint) verboseFormat() string         { return "hint: " + w.hint }
+func (w *withHint) Format(s fmt.State, verb rune) { formatPGError(w, s, verb) }
+
+// SrcCtx contains contextual information about the source of an error.
+type SrcCtx struct {
+	File     string
+	Line     int
+	Function string
+}
+
+// makeSrcCtx creates a SrcCtx value with contextual information about the
+// caller at the requested depth.
+func makeSrcCtx(depth int) SrcCtx {
+	f, l, fun := caller.Lookup(depth + 1)
+	return SrcCtx{File: f, Line: l, Function: fun}
+}
+
+// WithSourceContext annotates err with contextual information about the
+// caller at the requested depth.
+// If err is nil, WithSourceContext returns nil.
+func WithSourceContext(err error, depth int) error {
+	if err == nil {
+		return nil
+	}
+	return &withSrcCtx{
+		pgErrorCause: pgErrorCause{err},
+		ctx:          makeSrcCtx(depth + 1),
+	}
+}
+
+type withSrcCtx struct {
+	pgErrorCause
+	ctx SrcCtx
+}
+
+func (w *withSrcCtx) SourceContext() (SrcCtx, bool) { return w.ctx, true }
+func (w *withSrcCtx) verboseFormat() string {
+	return fmt.Sprintf("location: %s, %s:%d", w.ctx.Function, w.ctx.File, w.ctx.Line)
+}
+func (w *withSrcCtx) Format(s fmt.State, verb rune) { formatPGError(w, s, verb) }
+
+// PGCode returns the Postgres error code of the error, if possible.
+//
+// If a code was never annotated onto the error, no code will be
+// returned and a "found" flag will be returned as false.
+func PGCode(err error) (string, bool) {
+	if pgErr := unwrapToPGError(err); pgErr != nil {
+		return pgErr.PGCode()
+	}
+	return "", false
+}
+
+// Detail returns the detail message of the error, if possible.
+//
+// If a detail was never annotated onto the error, no detail will
+// be returned and a "found" flag will be returned as false.
+func Detail(err error) (string, bool) {
+	if pgErr := unwrapToPGError(err); pgErr != nil {
+		return pgErr.Detail()
+	}
+	return "", false
+}
+
+// Hint returns the hint message of the error, if possible.
+//
+// If a hint was never annotated onto the error, no hint will be
+// returned and a "found" flag will be returned as false.
+func Hint(err error) (string, bool) {
+	if pgErr := unwrapToPGError(err); pgErr != nil {
+		return pgErr.Hint()
+	}
+	return "", false
+}
+
+// SourceContext returns contextual information about the source of
+// an error, if possible.
+//
+// If contextual information was never annotated onto the error, no
+// SrcCtx will be returned and a "found" flag will be returned as false.
+func SourceContext(err error) (SrcCtx, bool) {
+	if pgErr := unwrapToPGError(err); pgErr != nil {
+		return pgErr.SourceContext()
+	}
+	return SrcCtx{}, false
+}
+
+// unwrapToPGError returns an unwrapped pgError annotation, if possible.
+// The method behaves similarly to errors.Cause, but will only unwrap (call
+// Cause on) non-pgError implementations. This allows us to strip errors
+// added by errors.Wrap, and find the next pgError.
+func unwrapToPGError(err error) pgError {
+	for err != nil {
+		if pgErr, ok := err.(pgError); ok {
+			return pgErr
+		}
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return nil
+}
+
+func formatPGError(pgErr pgError, s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n%s", pgErr.Cause(), pgErr.verboseFormat())
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		if _, err := io.WriteString(s, pgErr.Error()); err != nil {
+			panic(err)
+		}
+	}
+}

--- a/pkg/sql/pgwire/pgerror/errors_test.go
+++ b/pkg/sql/pgwire/pgerror/errors_test.go
@@ -1,0 +1,349 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nathan VanBenschoten (nvanbenschoten@gmail.com)
+
+package pgerror
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	initErr = errors.Errorf("err")
+	code    = "abc"
+	detail  = "def"
+	hint    = "ghi"
+	wrap    = "jkl"
+)
+
+func TestWithPGCodeNil(t *testing.T) {
+	got := WithPGCode(nil, "")
+	if got != nil {
+		t.Errorf("pgerror.WithPGCode(nil, \"\"): got %#v, expected nil", got)
+	}
+}
+
+func TestWithPGCodeEmptyCode(t *testing.T) {
+	got := WithPGCode(initErr, "")
+	if got != initErr {
+		t.Errorf("pgerror.WithPGCode(initErr, \"\"): got %#v, expected %#v", got, initErr)
+	}
+}
+
+func TestWithDetailNil(t *testing.T) {
+	got := WithDetail(nil, "")
+	if got != nil {
+		t.Errorf("pgerror.WithDetail(nil, \"\"): got %#v, expected nil", got)
+	}
+}
+
+func TestWithDetailEmptyDetail(t *testing.T) {
+	got := WithDetail(initErr, "")
+	if got != initErr {
+		t.Errorf("pgerror.WithDetail(initErr, \"\"): got %#v, expected %#v", got, initErr)
+	}
+}
+
+func TestWithHintNil(t *testing.T) {
+	got := WithHint(nil, "")
+	if got != nil {
+		t.Errorf("pgerror.WithHint(nil, \"\"): got %#v, expected nil", got)
+	}
+}
+
+func TestWithHintEmptyHint(t *testing.T) {
+	got := WithHint(initErr, "")
+	if got != initErr {
+		t.Errorf("pgerror.WithHint(initErr, \"\"): got %#v, expected %#v", got, initErr)
+	}
+}
+
+func TestWithSourceContextNil(t *testing.T) {
+	got := WithSourceContext(nil, 0)
+	if got != nil {
+		t.Errorf("pgerror.WithSourceContext(nil, \"\"): got %#v, expected nil", got)
+	}
+}
+
+func TestCause(t *testing.T) {
+	tests := []error{
+		WithPGCode(initErr, code),
+		WithDetail(initErr, detail),
+		WithHint(initErr, hint),
+		WithSourceContext(initErr, 0),
+		WithDetail(WithPGCode(initErr, code), detail),
+		WithPGCode(WithDetail(initErr, detail), code),
+		WithSourceContext(WithHint(initErr, hint), 0),
+		WithHint(WithSourceContext(initErr, 0), hint),
+		WithSourceContext(WithHint(WithDetail(WithPGCode(initErr, code), detail), hint), 0),
+		WithPGCode(WithDetail(WithHint(WithSourceContext(initErr, 0), hint), detail), code),
+		WithPGCode(WithDetail(errors.Wrap(WithHint(WithSourceContext(initErr, 0), hint), wrap), detail), code),
+		errors.Wrap(WithPGCode(WithDetail(WithHint(WithSourceContext(initErr, 0), hint), detail), code), wrap),
+	}
+	for i, tc := range tests {
+		got := errors.Cause(tc)
+		if got != initErr {
+			t.Errorf("%d: errors.Cause(%#v): got %#v, expected %#v", i, tc, got, initErr)
+		}
+	}
+}
+
+func TestPGCode(t *testing.T) {
+	tests := []struct {
+		err     error
+		hasCode bool
+	}{
+		{WithPGCode(initErr, code), true},
+		{WithDetail(initErr, detail), false},
+		{WithHint(initErr, hint), false},
+		{WithSourceContext(initErr, 0), false},
+		{WithDetail(WithPGCode(initErr, code), detail), true},
+		{WithPGCode(WithDetail(initErr, detail), code), true},
+		{WithSourceContext(WithHint(initErr, hint), 0), false},
+		{WithHint(WithSourceContext(initErr, 0), hint), false},
+		{WithSourceContext(WithHint(WithDetail(WithPGCode(initErr, code), detail), hint), 0), true},
+		{WithPGCode(WithDetail(WithHint(WithSourceContext(initErr, 0), hint), detail), code), true},
+		{WithSourceContext(WithHint(errors.Wrap(WithDetail(WithPGCode(initErr, code), detail), wrap), hint), 0), true},
+		{errors.Wrap(WithPGCode(WithDetail(WithHint(WithSourceContext(initErr, 0), hint), detail), code), wrap), true},
+	}
+	for i, tc := range tests {
+		gotCodeStr, gotCode := PGCode(tc.err)
+		switch {
+		case gotCode && tc.hasCode:
+			// verify code
+			if gotCodeStr != code {
+				t.Errorf("%d: pgerror.PGCode(%#v): got code %q, expected code %q", i, tc.err, gotCodeStr, code)
+			}
+		case gotCode && !tc.hasCode:
+			t.Errorf("%d: pgerror.PGCode(%#v): got code %q, expected no code", i, tc.err, gotCodeStr)
+		case !gotCode && tc.hasCode:
+			t.Errorf("%d: pgerror.PGCode(%#v): got no code, expected code %q", i, tc.err, code)
+		case !gotCode && !tc.hasCode:
+			// no code to verify
+		default:
+			panic("unhandled case")
+		}
+	}
+}
+
+func TestDetail(t *testing.T) {
+	tests := []struct {
+		err       error
+		hasDetail bool
+	}{
+		{WithPGCode(initErr, code), false},
+		{WithDetail(initErr, detail), true},
+		{WithHint(initErr, hint), false},
+		{WithSourceContext(initErr, 0), false},
+		{WithDetail(WithPGCode(initErr, code), detail), true},
+		{WithPGCode(WithDetail(initErr, detail), code), true},
+		{WithSourceContext(WithHint(initErr, hint), 0), false},
+		{WithHint(WithSourceContext(initErr, 0), hint), false},
+		{WithSourceContext(WithHint(WithDetail(WithPGCode(initErr, code), detail), hint), 0), true},
+		{WithPGCode(WithDetail(WithHint(WithSourceContext(initErr, 0), hint), detail), code), true},
+		{WithSourceContext(WithHint(errors.Wrap(WithDetail(WithPGCode(initErr, code), detail), wrap), hint), 0), true},
+		{errors.Wrap(WithPGCode(WithDetail(WithHint(WithSourceContext(initErr, 0), hint), detail), code), wrap), true},
+	}
+	for i, tc := range tests {
+		gotDetailStr, gotDetail := Detail(tc.err)
+		switch {
+		case gotDetail && tc.hasDetail:
+			// verify detail
+			if gotDetailStr != detail {
+				t.Errorf("%d: pgerror.Detail(%#v): got detail %q, expected detail %q", i, tc.err, gotDetailStr, detail)
+			}
+		case gotDetail && !tc.hasDetail:
+			t.Errorf("%d: pgerror.Detail(%#v): got detail %q, expected no detail", i, tc.err, gotDetailStr)
+		case !gotDetail && tc.hasDetail:
+			t.Errorf("%d: pgerror.Detail(%#v): got no detail, expected detail %q", i, tc.err, detail)
+		case !gotDetail && !tc.hasDetail:
+			// no detail to verify
+		default:
+			panic("unhandled case")
+		}
+	}
+}
+
+func TestHint(t *testing.T) {
+	tests := []struct {
+		err     error
+		hasHint bool
+	}{
+		{WithPGCode(initErr, code), false},
+		{WithDetail(initErr, detail), false},
+		{WithHint(initErr, hint), true},
+		{WithSourceContext(initErr, 0), false},
+		{WithDetail(WithPGCode(initErr, code), detail), false},
+		{WithPGCode(WithDetail(initErr, detail), code), false},
+		{WithSourceContext(WithHint(initErr, hint), 0), true},
+		{WithHint(WithSourceContext(initErr, 0), hint), true},
+		{WithSourceContext(WithHint(WithDetail(WithPGCode(initErr, code), detail), hint), 0), true},
+		{WithPGCode(WithDetail(WithHint(WithSourceContext(initErr, 0), hint), detail), code), true},
+		{WithSourceContext(WithHint(errors.Wrap(WithDetail(WithPGCode(initErr, code), detail), wrap), hint), 0), true},
+		{errors.Wrap(WithPGCode(WithDetail(WithHint(WithSourceContext(initErr, 0), hint), detail), code), wrap), true},
+	}
+	for i, tc := range tests {
+		gotHintStr, gotHint := Hint(tc.err)
+		switch {
+		case gotHint && tc.hasHint:
+			// verify hint
+			if gotHintStr != hint {
+				t.Errorf("%d: pgerror.Hint(%#v): got hint %q, expected hint %q", i, tc.err, gotHintStr, hint)
+			}
+		case gotHint && !tc.hasHint:
+			t.Errorf("%d: pgerror.Hint(%#v): got hint %q, expected no hint", i, tc.err, gotHintStr)
+		case !gotHint && tc.hasHint:
+			t.Errorf("%d: pgerror.Hint(%#v): got no hint, expected hint %q", i, tc.err, hint)
+		case !gotHint && !tc.hasHint:
+			// no hint to verify
+		default:
+			panic("unhandled case")
+		}
+	}
+}
+
+func TestSourceContext(t *testing.T) {
+	tests := []struct {
+		err       error
+		hasSrcCtx bool
+	}{
+		{WithPGCode(initErr, code), false},
+		{WithDetail(initErr, detail), false},
+		{WithHint(initErr, hint), false},
+		{WithSourceContext(initErr, 0), true},
+		{WithDetail(WithPGCode(initErr, code), detail), false},
+		{WithPGCode(WithDetail(initErr, detail), code), false},
+		{WithSourceContext(WithHint(initErr, hint), 0), true},
+		{WithHint(WithSourceContext(initErr, 0), hint), true},
+		{WithSourceContext(WithHint(errors.Wrap(WithDetail(WithPGCode(initErr, code), detail), wrap), hint), 0), true},
+		{errors.Wrap(WithPGCode(WithDetail(WithHint(WithSourceContext(initErr, 0), hint), detail), code), wrap), true},
+	}
+	for i, tc := range tests {
+		gotSrcCtxObj, gotSrcCtx := SourceContext(tc.err)
+		switch {
+		case gotSrcCtx && tc.hasSrcCtx:
+			// verify SourceContext
+			const srcCtxFileSuffix = "pgerror/errors_test.go"
+			const srcCtxFunc = "TestSourceContext"
+
+			if a, e := gotSrcCtxObj.File, srcCtxFileSuffix; !strings.HasSuffix(a, e) {
+				t.Errorf("%d: pgerror.SourceContext(%#v): got SrcCtx.File %q, expected file with suffix %q", i, tc.err, a, e)
+			}
+			if a, e := gotSrcCtxObj.Function, srcCtxFunc; a != e {
+				t.Errorf("%d: pgerror.SourceContext(%#v): got SrcCtx.Function %q, expected function %q", i, tc.err, a, e)
+			}
+		case gotSrcCtx && !tc.hasSrcCtx:
+			t.Errorf("%d: pgerror.SourceContext(%#v): got SrcCtx %q, expected no SrcCtx", i, tc.err, gotSrcCtxObj)
+		case !gotSrcCtx && tc.hasSrcCtx:
+			t.Errorf("%d: pgerror.SourceContext(%#v): got no SrcCtx, expected SrcCtx", i, tc.err)
+		case !gotSrcCtx && !tc.hasSrcCtx:
+			// no SourceContext to verify
+		default:
+			panic("unhandled case")
+		}
+	}
+}
+
+func TestFormatPgError(t *testing.T) {
+	tests := []struct {
+		err  error
+		want string
+	}{
+		{WithPGCode(initErr, code),
+			`err
+.*sql/pgwire/pgerror.*
+code: abc`},
+		{WithDetail(initErr, detail),
+			`err
+.*sql/pgwire/pgerror.*
+detail: def`},
+		{WithHint(initErr, hint),
+			`err
+.*sql/pgwire/pgerror.*
+hint: ghi`},
+		{WithSourceContext(initErr, 0),
+			`err
+.*sql/pgwire/pgerror.*
+location: TestFormatPgError, .*/pgerror/errors_test.go:\d*`},
+		{WithDetail(WithPGCode(initErr, code), detail),
+			`err
+.*sql/pgwire/pgerror.*
+code: abc
+detail: def`},
+		{WithPGCode(WithDetail(initErr, detail), code),
+			`err
+.*sql/pgwire/pgerror.*
+detail: def
+code: abc`},
+		{WithSourceContext(WithHint(initErr, hint), 0),
+			`err
+.*sql/pgwire/pgerror.*
+hint: ghi
+location: TestFormatPgError, .*/pgerror/errors_test.go:\d*`},
+		{WithHint(WithSourceContext(initErr, 0), hint),
+			`err
+.*sql/pgwire/pgerror.*
+location: TestFormatPgError, .*/pgerror/errors_test.go:\d*
+hint: ghi`},
+		{WithSourceContext(WithHint(WithDetail(WithPGCode(initErr, code), detail), hint), 0),
+			`err
+.*sql/pgwire/pgerror.*
+code: abc
+detail: def
+hint: ghi
+location: TestFormatPgError, .*/pgerror/errors_test.go:\d*`},
+		{WithPGCode(WithDetail(WithHint(WithSourceContext(initErr, 0), hint), detail), code),
+			`err
+.*sql/pgwire/pgerror.*
+location: TestFormatPgError, .*/pgerror/errors_test.go:\d*
+hint: ghi
+detail: def
+code: abc`},
+		{WithSourceContext(WithHint(errors.Wrap(WithDetail(WithPGCode(initErr, code), detail), wrap), hint), 0),
+			`err
+.*sql/pgwire/pgerror.*
+code: abc
+detail: def
+jkl
+.*sql/pgwire/pgerror.*
+hint: ghi
+location: TestFormatPgError, .*/pgerror/errors_test.go:\d*`},
+		{errors.Wrap(WithPGCode(WithDetail(WithHint(WithSourceContext(initErr, 0), hint), detail), code), wrap),
+			`err
+.*sql/pgwire/pgerror.*
+location: TestFormatPgError, .*/pgerror/errors_test.go:\d*
+hint: ghi
+detail: def
+code: abc
+jkl
+.*sql/pgwire/pgerror.*`},
+	}
+	for i, tc := range tests {
+		got := fmt.Sprintf("%+v", tc.err)
+
+		match, err := regexp.MatchString("(?s)"+tc.want, got)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !match {
+			t.Errorf("%d: fmt.Sprintf(%%+v, err):\n got: %q\nwant: %q", i, got, tc.want)
+		}
+	}
+}

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -19,13 +19,12 @@
 package sqlbase
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/util/caller"
+	"github.com/pkg/errors"
 )
 
 // Cockroach error extensions:
@@ -36,459 +35,173 @@ const (
 	CodeRangeUnavailable string = "XXC00"
 )
 
-// SrcCtx contains contextual information about the source of an error.
-type SrcCtx struct {
-	File     string
-	Line     int
-	Function string
-}
-
-// MakeSrcCtx creates a SrcCtx value with contextual information about the
-// caller at the requested depth.
-func MakeSrcCtx(depth int) SrcCtx {
-	f, l, fun := caller.Lookup(depth + 1)
-	return SrcCtx{File: f, Line: l, Function: fun}
-}
-
-type errData struct {
-	detail string
-	hint   string
-}
-
-// Detail returns the detail of PostgreSQL structured error.
-func (e errData) Detail() string {
-	return e.detail
-}
-
-// Hint returns the hint of PostgreSQL structured error.
-func (e errData) Hint() string {
-	return e.hint
-}
-
-// ErrorWithPGCode represents errors that carries an error code to the user.
-// pgwire recognizes this interfaces and extracts the code.
-type ErrorWithPGCode interface {
-	error
-	Code() string
-	Detail() string
-	Hint() string
-	SrcContext() SrcCtx
-}
-
-var _ ErrorWithPGCode = &ErrRetry{}
-var _ ErrorWithPGCode = &ErrTransactionAborted{}
-var _ ErrorWithPGCode = &ErrTransactionCommitted{}
-var _ ErrorWithPGCode = &ErrNonNullViolation{}
-var _ ErrorWithPGCode = &ErrUniquenessConstraintViolation{}
-var _ ErrorWithPGCode = &ErrUndefinedDatabase{}
-var _ ErrorWithPGCode = &ErrUndefinedTable{}
-var _ ErrorWithPGCode = &ErrDatabaseAlreadyExists{}
-var _ ErrorWithPGCode = &ErrRelationAlreadyExists{}
-var _ ErrorWithPGCode = &ErrWrongObjectType{}
-var _ ErrorWithPGCode = &ErrSyntax{}
-var _ ErrorWithPGCode = &ErrDependentObject{}
-
 const (
 	txnAbortedMsg = "current transaction is aborted, commands ignored " +
 		"until end of transaction block"
 	txnCommittedMsg = "current transaction is committed, commands ignored " +
 		"until end of transaction block"
-	txnRetryMsgPrefix = "restart transaction:"
+	txnRetryMsgPrefix = "restart transaction"
 )
 
-// NewRetryError creates a ErrRetry.
+// NewRetryError creates an error signifying that the transaction can be retried.
+// It signals to the user that the SQL txn entered the RESTART_WAIT state after a
+// serialization error, and that a ROLLBACK TO SAVEPOINT COCKROACH_RESTART statement
+// should be issued.
 func NewRetryError(cause error) error {
-	return &ErrRetry{errData: errData{}, ctx: MakeSrcCtx(1), msg: fmt.Sprintf("%s %v", txnRetryMsgPrefix, cause)}
+	err := errors.WithMessage(cause, txnRetryMsgPrefix)
+	err = pgerror.WithPGCode(err, pgerror.CodeSerializationFailureError)
+	return pgerror.WithSourceContext(err, 1)
 }
 
-// ErrRetry means that the transaction can be retried. It signals to the user
-// that the SQL txn entered the RESTART_WAIT state after a serialization error,
-// and that a ROLLBACK TO SAVEPOINT COCKROACH_RESTART statement should be issued.
-type ErrRetry struct {
-	errData
-	ctx SrcCtx
-	msg string
-}
+var txnAbortedErrTemplate = pgerror.WithPGCode(
+	errors.Errorf(txnAbortedMsg),
+	pgerror.CodeInFailedSQLTransactionError,
+)
 
-func (e *ErrRetry) Error() string {
-	return e.msg
-}
-
-// Code implements the ErrorWithPGCode interface.
-func (*ErrRetry) Code() string {
-	return pgerror.CodeSerializationFailureError
-}
-
-// SrcContext implements the ErrorWithPGCode interface.
-func (e *ErrRetry) SrcContext() SrcCtx {
-	return e.ctx
-}
-
-// NewTransactionAbortedError creates a new ErrTransactionAborted.
+// NewTransactionAbortedError creates an error for trying to run a command in
+// the context of transaction that's already aborted.
 func NewTransactionAbortedError(customMsg string) error {
-	return &ErrTransactionAborted{errData: errData{}, ctx: MakeSrcCtx(1), CustomMsg: customMsg}
-}
-
-// ErrTransactionAborted represents an error for trying to run a command in the
-// context of transaction that's already aborted.
-type ErrTransactionAborted struct {
-	errData
-	ctx       SrcCtx
-	CustomMsg string
-}
-
-func (e *ErrTransactionAborted) Error() string {
-	msg := txnAbortedMsg
-	if e.CustomMsg != "" {
-		msg += "; " + e.CustomMsg
+	err := txnAbortedErrTemplate
+	if customMsg != "" {
+		err = errors.WithMessage(err, customMsg)
 	}
-	return msg
+	return pgerror.WithSourceContext(err, 1)
 }
 
-// Code implements the ErrorWithPGCode interface.
-func (*ErrTransactionAborted) Code() string {
-	return pgerror.CodeInFailedSQLTransactionError
-}
+var txnCommittedErrTemplate = pgerror.WithPGCode(
+	errors.Errorf(txnCommittedMsg),
+	pgerror.CodeInvalidTransactionStateError,
+)
 
-// SrcContext implements the ErrorWithPGCode interface.
-func (e *ErrTransactionAborted) SrcContext() SrcCtx {
-	return e.ctx
-}
-
-// NewTransactionCommittedError creates a new ErrTransactionCommitted.
+// NewTransactionCommittedError creates an error that signals that the SQL txn
+// is in the COMMIT_WAIT state and that only a COMMIT statement will be accepted.
 func NewTransactionCommittedError() error {
-	return &ErrTransactionCommitted{errData: errData{}, ctx: MakeSrcCtx(1)}
+	return pgerror.WithSourceContext(txnCommittedErrTemplate, 1)
 }
 
-// ErrTransactionCommitted signals that the SQL txn is in the COMMIT_WAIT state
-// and that only a COMMIT statement will be accepted.
-type ErrTransactionCommitted struct {
-	errData
-	ctx SrcCtx
-}
-
-func (*ErrTransactionCommitted) Error() string {
-	return txnCommittedMsg
-}
-
-// Code implements the ErrorWithPGCode interface.
-func (*ErrTransactionCommitted) Code() string {
-	return pgerror.CodeInvalidTransactionStateError
-}
-
-// SrcContext implements the ErrorWithPGCode interface.
-func (e *ErrTransactionCommitted) SrcContext() SrcCtx {
-	return e.ctx
-}
-
-// NewNonNullViolationError creates a new ErrNonNullViolation.
+// NewNonNullViolationError creates an error for a violation of a non-NULL constraint.
 func NewNonNullViolationError(columnName string) error {
-	return &ErrNonNullViolation{errData: errData{}, ctx: MakeSrcCtx(1), columnName: columnName}
+	err := errors.Errorf("null value in column %q violates not-null constraint", columnName)
+	err = pgerror.WithPGCode(err, pgerror.CodeNotNullViolationError)
+	return pgerror.WithSourceContext(err, 1)
 }
 
-// ErrNonNullViolation represents a violation of a non-NULL constraint.
-type ErrNonNullViolation struct {
-	errData
-	ctx        SrcCtx
-	columnName string
-}
-
-func (e *ErrNonNullViolation) Error() string {
-	return fmt.Sprintf("null value in column %q violates not-null constraint", e.columnName)
-}
-
-// Code implements the ErrorWithPGCode interface.
-func (*ErrNonNullViolation) Code() string {
-	return pgerror.CodeNotNullViolationError
-}
-
-// SrcContext implements the ErrorWithPGCode interface.
-func (e *ErrNonNullViolation) SrcContext() SrcCtx {
-	return e.ctx
-}
-
-// NewUniquenessConstraintViolationError creates a new
-// ErrUniquenessConstrainViolation.
+// NewUniquenessConstraintViolationError creates an error that represents a
+// violation of a UNIQUE constraint.
 func NewUniquenessConstraintViolationError(index *IndexDescriptor, vals []parser.Datum) error {
-	return &ErrUniquenessConstraintViolation{
-		errData: errData{detail: fmt.Sprintf("key %s already exists.", index.Name)},
-		ctx:     MakeSrcCtx(1),
-		index:   index,
-		vals:    vals,
-	}
-}
-
-// ErrUniquenessConstraintViolation represents a violation of a UNIQUE constraint.
-type ErrUniquenessConstraintViolation struct {
-	errData
-	ctx   SrcCtx
-	index *IndexDescriptor
-	vals  []parser.Datum
-}
-
-// Code implements the ErrorWithPGCode interface.
-func (*ErrUniquenessConstraintViolation) Code() string {
-	return pgerror.CodeUniqueViolationError
-}
-
-func (e *ErrUniquenessConstraintViolation) Error() string {
-	valStrs := make([]string, 0, len(e.vals))
-	for _, val := range e.vals {
+	valStrs := make([]string, 0, len(vals))
+	for _, val := range vals {
 		valStrs = append(valStrs, val.String())
 	}
 
-	return fmt.Sprintf("duplicate key value (%s)=(%s) violates unique constraint %q",
-		strings.Join(e.index.ColumnNames, ","),
+	err := errors.Errorf("duplicate key value (%s)=(%s) violates unique constraint %q",
+		strings.Join(index.ColumnNames, ","),
 		strings.Join(valStrs, ","),
-		e.index.Name)
+		index.Name)
+
+	err = pgerror.WithPGCode(err, pgerror.CodeUniqueViolationError)
+	return pgerror.WithSourceContext(err, 1)
 }
 
-// SrcContext implements the ErrorWithPGCode interface.
-func (e *ErrUniquenessConstraintViolation) SrcContext() SrcCtx {
-	return e.ctx
-}
-
-// NewUndefinedDatabaseError creates a new ErrUndefinedDatabase.
-func NewUndefinedDatabaseError(name string) error {
-	return &ErrUndefinedDatabase{errData: errData{}, ctx: MakeSrcCtx(1), name: name}
-}
-
-// ErrUndefinedDatabase represents a missing database error.
-type ErrUndefinedDatabase struct {
-	errData
-	ctx  SrcCtx
-	name string
-}
-
-func (e *ErrUndefinedDatabase) Error() string {
-	return fmt.Sprintf("database %q does not exist", e.name)
-}
-
-// Code implements the ErrorWithPGCode interface.
-func (*ErrUndefinedDatabase) Code() string {
-	// Postgres will return an UndefinedTable error on queries that go to a "relation"
-	// that does not exist (a query to a non-existent table or database), but will
-	// return an InvalidCatalogName error when connecting to a database that does
-	// not exist. We've chosen to return this code for all cases where the error cause
-	// is a missing database.
-	return pgerror.CodeInvalidCatalogNameError
-}
-
-// SrcContext implements the ErrorWithPGCode interface.
-func (e *ErrUndefinedDatabase) SrcContext() SrcCtx {
-	return e.ctx
-}
-
-// NewUndefinedTableError creates a new ErrUndefinedTable.
-func NewUndefinedTableError(name string) error {
-	return &ErrUndefinedTable{errData: errData{}, ctx: MakeSrcCtx(1), objType: "table", name: name}
-}
-
-// NewUndefinedViewError creates a new ErrUndefinedTable, which is also used
-// for views (sharing the same postgres error code).
-func NewUndefinedViewError(name string) error {
-	return &ErrUndefinedTable{errData: errData{}, ctx: MakeSrcCtx(1), objType: "view", name: name}
-}
-
-// ErrUndefinedTable represents a missing database table.
-type ErrUndefinedTable struct {
-	errData
-	ctx     SrcCtx
-	objType string
-	name    string
-}
-
-func (e *ErrUndefinedTable) Error() string {
-	return fmt.Sprintf("%s %q does not exist", e.objType, e.name)
-}
-
-// Code implements the ErrorWithPGCode interface.
-func (*ErrUndefinedTable) Code() string {
-	return pgerror.CodeUndefinedTableError
-}
-
-// SrcContext implements the ErrorWithPGCode interface.
-func (e *ErrUndefinedTable) SrcContext() SrcCtx {
-	return e.ctx
-}
-
-// NewDatabaseAlreadyExistsError creates a new ErrDatabaseAlreadyExists.
-func NewDatabaseAlreadyExistsError(name string) error {
-	return &ErrDatabaseAlreadyExists{errData: errData{}, ctx: MakeSrcCtx(1), name: name}
-}
-
-// ErrDatabaseAlreadyExists represents a missing database error.
-type ErrDatabaseAlreadyExists struct {
-	errData
-	ctx  SrcCtx
-	name string
-}
-
-func (e *ErrDatabaseAlreadyExists) Error() string {
-	return fmt.Sprintf("database %q already exists", e.name)
-}
-
-// Code implements the ErrorWithPGCode interface.
-func (*ErrDatabaseAlreadyExists) Code() string {
-	return pgerror.CodeDuplicateDatabaseError
-}
-
-// SrcContext implements the ErrorWithPGCode interface.
-func (e *ErrDatabaseAlreadyExists) SrcContext() SrcCtx {
-	return e.ctx
-}
-
-// NewRelationAlreadyExistsError creates a new ErrRelationAlreadyExists.
-func NewRelationAlreadyExistsError(name string) error {
-	return &ErrRelationAlreadyExists{errData: errData{}, ctx: MakeSrcCtx(1), name: name}
-}
-
-// ErrRelationAlreadyExists represents a missing database error.
-type ErrRelationAlreadyExists struct {
-	errData
-	ctx  SrcCtx
-	name string
-}
-
-func (e *ErrRelationAlreadyExists) Error() string {
-	return fmt.Sprintf("relation %q already exists", e.name)
-}
-
-// Code implements the ErrorWithPGCode interface.
-func (*ErrRelationAlreadyExists) Code() string {
-	return pgerror.CodeDuplicateRelationError
-}
-
-// SrcContext implements the ErrorWithPGCode interface.
-func (e *ErrRelationAlreadyExists) SrcContext() SrcCtx {
-	return e.ctx
-}
-
-// NewWrongObjectTypeError creates a new ErrWrongObjectType.
-func NewWrongObjectTypeError(name, desiredObjType string) error {
-	return &ErrWrongObjectType{errData: errData{}, ctx: MakeSrcCtx(1), name: name, desiredObjType: desiredObjType}
-}
-
-// ErrWrongObjectType represents a wrong object type error.
-type ErrWrongObjectType struct {
-	errData
-	ctx            SrcCtx
-	name           string
-	desiredObjType string
-}
-
-func (e *ErrWrongObjectType) Error() string {
-	return fmt.Sprintf("%q is not a %s", e.name, e.desiredObjType)
-}
-
-// Code implements the ErrorWithPGCode interface.
-func (*ErrWrongObjectType) Code() string {
-	return pgerror.CodeWrongObjectTypeError
-}
-
-// SrcContext implements the ErrorWithPGCode interface.
-func (e *ErrWrongObjectType) SrcContext() SrcCtx {
-	return e.ctx
-}
-
-// NewSyntaxError creates a new ErrSyntax.
-func NewSyntaxError(msg string) error {
-	return &ErrSyntax{errData: errData{}, ctx: MakeSrcCtx(1), msg: msg}
-}
-
-// ErrSyntax represents a syntax error.
-type ErrSyntax struct {
-	errData
-	ctx SrcCtx
-	msg string
-}
-
-func (e *ErrSyntax) Error() string {
-	return e.msg
-}
-
-// Code implements the ErrorWithPGCode interface.
-func (*ErrSyntax) Code() string {
-	return pgerror.CodeSyntaxError
-}
-
-// SrcContext implements the ErrorWithPGCode interface.
-func (e *ErrSyntax) SrcContext() SrcCtx {
-	return e.ctx
-}
-
-// NewDependentObjectError creates a new ErrDependentObject.
-func NewDependentObjectError(msg string, hint string) error {
-	return &ErrDependentObject{errData: errData{hint: hint}, ctx: MakeSrcCtx(1), msg: msg}
-}
-
-// ErrDependentObject represents a dependent object error.
-type ErrDependentObject struct {
-	errData
-	ctx SrcCtx
-	msg string
-}
-
-func (e *ErrDependentObject) Error() string {
-	return e.msg
-}
-
-// Code implements the ErrorWithPGCode interface.
-func (*ErrDependentObject) Code() string {
-	return pgerror.CodeDependentObjectsStillExistError
-}
-
-// SrcContext implements the ErrorWithPGCode interface.
-func (e *ErrDependentObject) SrcContext() SrcCtx {
-	return e.ctx
+// IsUniquenessConstraintViolationError returns true if the error is for a
+// uniqueness constraint violation.
+func IsUniquenessConstraintViolationError(err error) bool {
+	return errHasCode(err, pgerror.CodeUniqueViolationError)
 }
 
 // IsIntegrityConstraintError returns true if the error is some kind of SQL
 // constraint violation.
 func IsIntegrityConstraintError(err error) bool {
-	switch err.(type) {
-	case *ErrNonNullViolation, *ErrUniquenessConstraintViolation:
-		return true
-	default:
-		return false
-	}
+	return errHasCode(err, pgerror.CodeNotNullViolationError) ||
+		errHasCode(err, pgerror.CodeUniqueViolationError)
 }
 
-// RangeUnavailableError represents an attempt to access a range that is
-// temporarily unavailable.
-type RangeUnavailableError struct {
-	errData
-	ctx     SrcCtx
-	rangeID roachpb.RangeID
-	nodeIDs []roachpb.NodeID
-	origErr error
+// NewUndefinedDatabaseError creates an error that represents a missing database.
+func NewUndefinedDatabaseError(name string) error {
+	err := errors.Errorf("database %q does not exist", name)
+
+	// Postgres will return an UndefinedTable error on queries that go to a "relation"
+	// that does not exist (a query to a non-existent table or database), but will
+	// return an InvalidCatalogName error when connecting to a database that does
+	// not exist. We've chosen to return this code for all cases where the error cause
+	// is a missing database.
+	err = pgerror.WithPGCode(err, pgerror.CodeInvalidCatalogNameError)
+
+	return pgerror.WithSourceContext(err, 1)
 }
 
-// NewRangeUnavailableError creates a new RangeUnavailableError.
+// IsUndefinedDatabaseError returns true if the error is for an undefined database.
+func IsUndefinedDatabaseError(err error) bool {
+	return errHasCode(err, pgerror.CodeInvalidCatalogNameError)
+}
+
+// NewUndefinedTableError creates an error that represents a missing database table.
+func NewUndefinedTableError(name string) error {
+	err := errors.Errorf("table %q does not exist", name)
+	err = pgerror.WithPGCode(err, pgerror.CodeUndefinedTableError)
+	return pgerror.WithSourceContext(err, 1)
+}
+
+// NewUndefinedViewError creates an error that represents a missing database view.
+func NewUndefinedViewError(name string) error {
+	err := errors.Errorf("view %q does not exist", name)
+	err = pgerror.WithPGCode(err, pgerror.CodeUndefinedTableError)
+	return pgerror.WithSourceContext(err, 1)
+}
+
+// IsUndefinedTableError returns true if the error is for an undefined table.
+func IsUndefinedTableError(err error) bool {
+	return errHasCode(err, pgerror.CodeUndefinedTableError)
+}
+
+// NewDatabaseAlreadyExistsError creates an error for a preexisting database.
+func NewDatabaseAlreadyExistsError(name string) error {
+	err := errors.Errorf("database %q already exists", name)
+	err = pgerror.WithPGCode(err, pgerror.CodeDuplicateDatabaseError)
+	return pgerror.WithSourceContext(err, 1)
+}
+
+// NewRelationAlreadyExistsError creates an error for a preexisting relation.
+func NewRelationAlreadyExistsError(name string) error {
+	err := errors.Errorf("relation %q already exists", name)
+	err = pgerror.WithPGCode(err, pgerror.CodeDuplicateRelationError)
+	return pgerror.WithSourceContext(err, 1)
+}
+
+// NewWrongObjectTypeError creates a wrong object type error.
+func NewWrongObjectTypeError(name, desiredObjType string) error {
+	err := errors.Errorf("%q is not a %s", name, desiredObjType)
+	err = pgerror.WithPGCode(err, pgerror.CodeWrongObjectTypeError)
+	return pgerror.WithSourceContext(err, 1)
+}
+
+// NewSyntaxError creates a syntax error.
+func NewSyntaxError(msg string) error {
+	err := errors.Errorf(msg)
+	err = pgerror.WithPGCode(err, pgerror.CodeSyntaxError)
+	return pgerror.WithSourceContext(err, 1)
+}
+
+// NewDependentObjectError creates a dependent object error.
+func NewDependentObjectError(msg string) error {
+	err := errors.Errorf(msg)
+	err = pgerror.WithPGCode(err, pgerror.CodeDependentObjectsStillExistError)
+	return pgerror.WithSourceContext(err, 1)
+}
+
+// NewRangeUnavailableError creates an unavailable range error.
 func NewRangeUnavailableError(
 	rangeID roachpb.RangeID, origErr error, nodeIDs ...roachpb.NodeID,
 ) error {
-	err := &RangeUnavailableError{
-		errData: errData{},
-		ctx:     MakeSrcCtx(1),
-		rangeID: rangeID,
-		nodeIDs: nodeIDs,
-		origErr: origErr,
+	err := errors.Errorf("key range id:%d is unavailable; missing nodes: %s. Original error: %v",
+		rangeID, nodeIDs, origErr)
+	err = pgerror.WithPGCode(err, CodeRangeUnavailable)
+	return pgerror.WithSourceContext(err, 1)
+}
+
+func errHasCode(err error, code string) bool {
+	if c, ok := pgerror.PGCode(err); ok {
+		return c == code
 	}
-	return err
-}
-
-func (e *RangeUnavailableError) Error() string {
-	return fmt.Sprintf("key range id:%d is unavailable; missing nodes: %s. Original error: %v",
-		e.rangeID, e.nodeIDs, e.origErr)
-}
-
-// Code implements the ErrorWithPGCode interface.
-func (*RangeUnavailableError) Code() string {
-	return CodeRangeUnavailable
-}
-
-// SrcContext implements the ErrorWithPGCode interface.
-func (e *RangeUnavailableError) SrcContext() SrcCtx {
-	return e.ctx
+	return false
 }

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -137,7 +137,7 @@ func getTableOrViewDesc(
 ) (*sqlbase.TableDescriptor, error) {
 	virtual, err := vt.getVirtualTableDesc(tn)
 	if err != nil || virtual != nil {
-		if _, ok := err.(*sqlbase.ErrUndefinedTable); ok {
+		if sqlbase.IsUndefinedTableError(err) {
 			return nil, nil
 		}
 		return virtual, err
@@ -522,7 +522,7 @@ func (p *planner) databaseFromSearchPath(tn *parser.TableName) (string, error) {
 		t.DatabaseName = parser.Name(database)
 		desc, err := p.getTableOrViewDesc(&t)
 		if err != nil {
-			if _, ok := err.(*sqlbase.ErrUndefinedDatabase); ok {
+			if sqlbase.IsUndefinedDatabaseError(err) {
 				// Keep iterating through search path if a database in the search path
 				// doesn't exist.
 				continue

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -998,9 +998,9 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if _, err := tx.Exec("ROLLBACK TO SAVEPOINT cockroach_restart"); !testutils.IsError(
-		err, "current transaction is aborted, commands ignored until end of "+
-			"transaction block; SAVEPOINT COCKROACH_RESTART has not been used or a "+
-			"non-retriable error was encountered.") {
+		err, "SAVEPOINT COCKROACH_RESTART has not been used or a non-retriable error "+
+			"was encountered: current transaction is aborted, commands ignored until "+
+			"end of transaction block") {
 		t.Fatal(err)
 	}
 	if err = tx.Rollback(); err != nil {


### PR DESCRIPTION
Fixes #10668.

This change reintroduces pgError as a cleaner interface, inspired
by `github.com/pkg/errors`.

> pgError is an error that contains optional Postgres structured error
> fields. Implementations of the interface annotate these fields onto
> standard errors by wrapping them. The fields can then be retrieved from
> the errors using the functions like Hint and Detail below.
>
> See https://www.postgresql.org/docs/current/static/protocol-error-fields.html
> for a list of all Postgres error fields, most of which are optional and can
> be used to provide auxiliary error information.
>
> The style for the implementation is inspired by github.com/pkg/errors,
> and all pgError implementations are made to play nicely with that package.
> For instance, a pgError can be wrapped by errors.Wrap and its annotations
> can still be retrieved. pgErrors also implement the errors.causer interface,
> meaning that errors.Cause will work correctly with them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12752)
<!-- Reviewable:end -->
