### PR TITLE
cli: update the cobra dependency and fix `gen man`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ If you plan on working on the UI, check out [the ui readme](pkg/ui).
 
 To add or update a go dependency:
 
-- see `vendor/README.md` for details on adding or updating dependencies
+- see `build/README.md` for details on adding or updating dependencies
 - run `go generate ./pkg/...` to update generated files.
 - create a PR with all the changes
 
@@ -156,6 +156,6 @@ make acceptance TESTS='TestPut$$' TESTFLAGS='-v -d 1200s -l .' TESTTIMEOUT=1210s
 ```
 
 runs the `Put` acceptance test for 20 minutes with logging (useful to look at
-the stacktrace in case of a node dying). When it starts, all the relevant
+the stack trace in case of a node dying). When it starts, all the relevant
 commands for `pprof`, `trace` and logs are logged to allow for convenient
 inspection of the cluster.

--- a/build/README.md
+++ b/build/README.md
@@ -34,13 +34,13 @@ resulting image `cockroachdb/cockroach` can be run via `docker run` in the
 usual fashion.
 
 #  Dependencies
-A snapshot of cockroachdb's dependencies is maintained at https://github.com/cockroachdb/vendored
-and checked out as a submodule at `./vendor`.
+A snapshot of CockroachDB's dependencies is maintained at https://github.com/cockroachdb/vendored
+and checked out as a sub-module at `./vendor`.
 
 ## Updating Dependencies
 This snapshot was built and is managed using `glide`.
 
-The [docs](https://github.com/Masterminds/glide) have detailed instructgions, but in brief:
+The [docs](https://github.com/Masterminds/glide) have detailed instructions, but in brief:
 * run `./scripts/glide.sh` in `cockroachdb/cockroach`.
 * add new dependencies with `./scripts/glide.sh get -s github.com/my/dependency`
 	- Note: if you are adding a non-import dependency (e.g. a binary tool to be used in development),
@@ -60,14 +60,15 @@ can and perhaps should pin the other library.
 
 You can also, if you *really* want to, just change the resolution of a single dependency, by editing
 its resolved version in glide.lock, then re-generating `vendor` from the edited resolution with
-`sciprts/glide.sh install`. This is not recommended, as it circumvents the normal resolution logic.
+`scripts/glide.sh install`. This is not recommended, as it circumvents the normal resolution logic.
 
-## Working with Submodules
-Since dependendies are stored in their own repository, and `cockroachdb/cockroach` depends on it,
+## Working with Sub-modules
+
+Since dependencies are stored in their own repository, and `cockroachdb/cockroach` depends on it,
 changing a dependency requires pushing two things, in order: first the changes to the `vendored`
 repository, then the reference to those changes to the main repository.
 
-After adding or updating dependencies (and running all tests), switch into the `vendor` submodule
+After adding or updating dependencies (and running all tests), switch into the `vendor` sub-module
 and commit changes (or use `git -C`). The commit must be available on `github.com/cockroachdb/vendored`
 *before* submitting a pull request to `cockroachdb/cockroach` that references it.
 * Organization members can push new refs directly.
@@ -80,7 +81,7 @@ request.
 
 ## Repository Name
 We only want the vendor directory used by builds when it is explicitly checked out *and managed* as a
-submodule at `./vendor`.
+sub-module at `./vendor`.
 
 If a go build fails to find a dependency in `./vendor`, it will continue searching anything named
 "vendor" in parent directories. Thus the vendor repository is _not_ named "vendor", to minimize the risk

--- a/glide.lock
+++ b/glide.lock
@@ -297,7 +297,7 @@ imports:
 - name: github.com/Sirupsen/logrus
   version: 881bee4e20a5d11a6a88a5667c6f292072ac1963
 - name: github.com/spf13/cobra
-  version: b62566898a99f2db9c68ed0026aa0a052e59678d
+  version: 1dd5ff2e11b6dca62fdcb275eb804b94607d8b06
   subpackages:
   - doc
 - name: github.com/spf13/pflag


### PR DESCRIPTION
This updates the dependency spf13/cobra, which resolves a
long-standing bug: the discrepancy between the page names given in the
SEE ALSO section of generated pages, and the actual generated file
names. With this patch applied, both names match and use hyphens (`-`)
to replace spaces.

Fixes #4917.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12758)
<!-- Reviewable:end -->
