### PR TITLE
cli: extend `dump` to support dumping multiple tables.

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -73,7 +73,7 @@ func newCLITest(t *testing.T, insecure bool) (cliTest, error) {
 	// pointer (because they are tied into the flags), but instead
 	// overwrite the existing struct's values.
 	baseCfg.InitDefaults()
-	cliCtx.InitCLIDefaults()
+	InitCLIDefaults()
 
 	if t != nil {
 		c.logScope = log.Scope(t, "")

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -134,6 +134,13 @@ If left unspecified, defaults to 25% of the physical memory, or
 		Description: `Include dependency versions`,
 	}
 
+	DumpMode = FlagInfo{
+		Name: "dump-mode",
+		Description: `
+What to dump. "schema" dumps the schema only. "data" dumps the data only.
+"both" (default) dumps the schema then the data.`,
+	}
+
 	Execute = FlagInfo{
 		Name:      "execute",
 		Shorthand: "e",

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -52,16 +52,59 @@ type cliContext struct {
 	prettyFmt bool
 }
 
-func (ctx *cliContext) InitCLIDefaults() {
-	ctx.prettyFmt = false
-}
-
 type sqlContext struct {
 	// Embed the cli context.
 	*cliContext
 
 	// execStmts is a list of statements to execute.
 	execStmts statementsValue
+}
+
+type dumpContext struct {
+	// Embed the cli context.
+	*cliContext
+
+	// dumpMode determines which part of the database should be dumped.
+	dumpMode dumpMode
+}
+
+type dumpMode int
+
+const (
+	dumpBoth dumpMode = iota
+	dumpSchemaOnly
+	dumpDataOnly
+)
+
+// Type implements the pflag.Value interface.
+func (m *dumpMode) Type() string { return "string" }
+
+// String implements the pflag.Value interface.
+func (m *dumpMode) String() string {
+	switch *m {
+	case dumpBoth:
+		return "both"
+	case dumpSchemaOnly:
+		return "schema"
+	case dumpDataOnly:
+		return "data"
+	}
+	return ""
+}
+
+// Set implements the pflag.Value interface.
+func (m *dumpMode) Set(s string) error {
+	switch s {
+	case "both":
+		*m = dumpBoth
+	case "schema":
+		*m = dumpSchemaOnly
+	case "data":
+		*m = dumpDataOnly
+	default:
+		return fmt.Errorf("invalid value for --dump-mode: %s", s)
+	}
+	return nil
 }
 
 type keyType int

--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -68,17 +68,21 @@ func runDump(cmd *cobra.Command, args []string) error {
 	// topological order to ensure key relationships can be verified
 	// during load.
 
-	for i, md := range mds {
-		if i > 0 {
-			fmt.Println()
-		}
-		if err := dumpCreateTable(os.Stdout, md); err != nil {
-			return err
+	if dumpCtx.dumpMode != dumpDataOnly {
+		for i, md := range mds {
+			if i > 0 {
+				fmt.Println()
+			}
+			if err := dumpCreateTable(os.Stdout, md); err != nil {
+				return err
+			}
 		}
 	}
-	for _, md := range mds {
-		if err := dumpTableData(os.Stdout, conn, ts, md); err != nil {
-			return err
+	if dumpCtx.dumpMode != dumpSchemaOnly {
+		for _, md := range mds {
+			if err := dumpTableData(os.Stdout, conn, ts, md); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -115,7 +115,7 @@ CREATE TABLE t (
 	FAMILY fam_3_e (e)
 );
 
-INSERT INTO t(i, f, s, b, d, t, n, o, e, tz, e1, e2, s1) VALUES
+INSERT INTO t (i, f, s, b, d, t, n, o, e, tz, e1, e2, s1) VALUES
 	(1, 2.3, 'striiing', b'a1b2c3', '2016-03-26', '2016-01-25 10:10:10+00:00', '2h30m30s', true, 1.2345, '2016-01-25 10:10:10+00:00', 3.4, 4.5, 's'),
 	(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
 	(NULL, +Inf, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
@@ -128,12 +128,84 @@ INSERT INTO t(i, f, s, b, d, t, n, o, e, tz, e1, e2, s1) VALUES
 	}
 }
 
+func TestDumpMultipleTables(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	c, err := newCLITest(t, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.stop(true)
+
+	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.f (x int, y int); insert into t.f values (42, 69)"})
+	c.RunWithArgs([]string{"sql", "-e", "create table t.g (x int, y int); insert into t.g values (3, 4)"})
+
+	out, err := c.RunWithCapture("dump t f g")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `dump t f g
+CREATE TABLE f (
+	x INT NULL,
+	y INT NULL,
+	FAMILY "primary" (x, y, rowid)
+);
+
+CREATE TABLE g (
+	x INT NULL,
+	y INT NULL,
+	FAMILY "primary" (x, y, rowid)
+);
+
+INSERT INTO f (x, y) VALUES
+	(42, 69);
+
+INSERT INTO g (x, y) VALUES
+	(3, 4);
+`
+	if string(out) != expected {
+		t.Fatalf("expected %s\ngot: %s", expected, out)
+	}
+
+	out, err = c.RunWithCapture("dump t")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected = `dump t
+CREATE TABLE f (
+	x INT NULL,
+	y INT NULL,
+	FAMILY "primary" (x, y, rowid)
+);
+
+CREATE TABLE g (
+	x INT NULL,
+	y INT NULL,
+	FAMILY "primary" (x, y, rowid)
+);
+
+INSERT INTO f (x, y) VALUES
+	(42, 69);
+
+INSERT INTO g (x, y) VALUES
+	(3, 4);
+`
+	if string(out) != expected {
+		t.Fatalf("expected %s\ngot: %s", expected, out)
+	}
+}
+
 func dumpSingleTable(w io.Writer, conn *sqlConn, dbName string, tName string) error {
-	mds, ts, err := getDumpMetadata(conn, []string{dbName, tName})
+	mds, ts, err := getDumpMetadata(conn, dbName, []string{tName})
 	if err != nil {
 		return err
 	}
-	return DumpTable(w, conn, ts, mds[0])
+	if err := dumpCreateTable(w, mds[0]); err != nil {
+		return err
+	}
+	return dumpTableData(w, conn, ts, mds[0])
 }
 
 func TestDumpBytes(t *testing.T) {

--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -126,6 +126,65 @@ INSERT INTO t (i, f, s, b, d, t, n, o, e, tz, e1, e2, s1) VALUES
 	if string(out) != expect {
 		t.Fatalf("expected: %s\ngot: %s", expect, out)
 	}
+
+}
+
+func TestDumpFlags(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	c, err := newCLITest(t, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.stop(true)
+
+	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.f (x int, y int); insert into t.f values (42, 69)"})
+
+	out, err := c.RunWithCapture("dump t f --dump-mode=both")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := `dump t f --dump-mode=both
+CREATE TABLE f (
+	x INT NULL,
+	y INT NULL,
+	FAMILY "primary" (x, y, rowid)
+);
+
+INSERT INTO f (x, y) VALUES
+	(42, 69);
+`
+	if string(out) != expected {
+		t.Fatalf("expected %s\ngot: %s", expected, out)
+	}
+
+	out, err = c.RunWithCapture("dump t f --dump-mode=schema")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected = `dump t f --dump-mode=schema
+CREATE TABLE f (
+	x INT NULL,
+	y INT NULL,
+	FAMILY "primary" (x, y, rowid)
+);
+`
+	if string(out) != expected {
+		t.Fatalf("expected %s\ngot: %s", expected, out)
+	}
+
+	out, err = c.RunWithCapture("dump t f --dump-mode=data")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected = `dump t f --dump-mode=data
+
+INSERT INTO f (x, y) VALUES
+	(42, 69);
+`
+	if string(out) != expected {
+		t.Fatalf("expected %s\ngot: %s", expected, out)
+	}
 }
 
 func TestDumpMultipleTables(t *testing.T) {

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -52,10 +52,17 @@ var serverCfg = server.MakeConfig()
 var baseCfg = serverCfg.Config
 var cliCtx = cliContext{Config: baseCfg}
 var sqlCtx = sqlContext{cliContext: &cliCtx}
+var dumpCtx = dumpContext{cliContext: &cliCtx, dumpMode: dumpBoth}
 var debugCtx = debugContext{
 	startKey:   engine.NilKey,
 	endKey:     engine.MVCCKeyMax,
 	replicated: false,
+}
+
+// InitCLIDefaults is used for testing.
+func InitCLIDefaults() {
+	cliCtx.prettyFmt = false
+	dumpCtx.dumpMode = dumpBoth
 }
 
 var sqlSize *bytesValue
@@ -361,6 +368,7 @@ func init() {
 	boolFlag(zf, &zoneDisableReplication, cliflags.ZoneDisableReplication, false)
 
 	varFlag(sqlShellCmd.Flags(), &sqlCtx.execStmts, cliflags.Execute)
+	varFlag(dumpCmd.Flags(), &dumpCtx.dumpMode, cliflags.DumpMode)
 
 	boolFlag(freezeClusterCmd.PersistentFlags(), &undoFreezeCluster, cliflags.UndoFreezeCluster, false)
 


### PR DESCRIPTION
With this patch `dump` now both accepts multiple table names as
argument, which dumps all the specified tables, or none at all, which
indicates to dump all tables.

All the tables are dumped at the same "logical" instant to capture a consistent mutual state.

It also adds a new flag `--dump-mode` to choose either schema+data
(`--dump-mode=both`, which is default), schema only
(`--dump-mode=schema`) or data only (`--dump-mode=data`).

Fixes #8881.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12759)
<!-- Reviewable:end -->
