### PR TITLE
storage: Get wait chans for local spans from local command queue

### DIFF
--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -395,7 +395,7 @@ func Addr(k roachpb.Key) (roachpb.RKey, error) {
 		if _, k, err = encoding.DecodeBytesAscending(k, nil); err != nil {
 			return nil, err
 		}
-		if !bytes.HasPrefix(k, localPrefix) {
+		if !IsLocal(k) {
 			break
 		}
 	}
@@ -423,7 +423,7 @@ func AddrUpperBound(k roachpb.Key) (roachpb.RKey, error) {
 	if err != nil {
 		return rk, err
 	}
-	if bytes.HasPrefix(k, localPrefix) {
+	if IsLocal(k) {
 		// The upper bound for a range-local key that addresses to key k
 		// is the key directly after k.
 		rk = rk.Next()

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1540,7 +1540,7 @@ func (r *Replica) beginCmds(ctx context.Context, ba *roachpb.BatchRequest) (*end
 
 		r.cmdQMu.Lock()
 		chans := r.cmdQMu.global.getWait(readOnly, spansGlobal...)
-		chans = append(chans, r.cmdQMu.global.getWait(readOnly, spansLocal...)...)
+		chans = append(chans, r.cmdQMu.local.getWait(readOnly, spansLocal...)...)
 		cmdGlobal = r.cmdQMu.global.add(readOnly, spansGlobal...)
 		cmdLocal = r.cmdQMu.local.add(readOnly, spansLocal...)
 		r.cmdQMu.Unlock()

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -1978,25 +1978,6 @@ func TestReplicaUpdateTSCache(t *testing.T) {
 // TODO(tschottdorf): hacks around #10084 (see usage of propEvalKV).
 func TestReplicaCommandQueue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	// Intercept commands with matching command IDs and block them.
-	blockingStart := make(chan struct{})
-	blockingDone := make(chan struct{})
-
-	tc := testContext{}
-	tsc := TestStoreConfig(nil)
-	tsc.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
-			if filterArgs.Hdr.UserPriority == 42 {
-				blockingStart <- struct{}{}
-				<-blockingDone
-			}
-			return nil
-		}
-	stopper := stop.NewStopper()
-	defer stopper.Stop()
-	tc.StartWithStoreConfig(t, stopper, tsc)
-
-	defer close(blockingDone) // make sure teardown can happen
 	// Test all four combinations of reads & writes waiting.
 	testCases := []struct {
 		cmd1Read, cmd2Read bool
@@ -2020,8 +2001,30 @@ func TestReplicaCommandQueue(t *testing.T) {
 			if addNoop {
 				testName += "-noop"
 			}
+			key1 := roachpb.Key(fmt.Sprintf("key1-%s", testName))
+			key2 := roachpb.Key(fmt.Sprintf("key2-%s", testName))
 			t.Run(testName,
 				func(t *testing.T) {
+					// Intercept commands matching a specific priority and block them.
+					const blockingPriority = 42
+					blockingStart := make(chan struct{})
+					blockingDone := make(chan struct{})
+
+					tc := testContext{}
+					tsc := TestStoreConfig(nil)
+					tsc.TestingKnobs.TestingCommandFilter =
+						func(filterArgs storagebase.FilterArgs) *roachpb.Error {
+							if filterArgs.Hdr.UserPriority == blockingPriority {
+								blockingStart <- struct{}{}
+								<-blockingDone
+							}
+							return nil
+						}
+					stopper := stop.NewStopper()
+					defer stopper.Stop()
+					tc.StartWithStoreConfig(t, stopper, tsc)
+
+					defer close(blockingDone) // make sure teardown can happen
 
 					sendWithHeader := func(header roachpb.Header, args roachpb.Request) *roachpb.Error {
 						ba := roachpb.BatchRequest{}
@@ -2036,15 +2039,13 @@ func TestReplicaCommandQueue(t *testing.T) {
 						return pErr
 					}
 
-					key1 := roachpb.Key(fmt.Sprintf("key1-%s", testName))
-					key2 := roachpb.Key(fmt.Sprintf("key2-%s", testName))
-					// Asynchronously put a value to the rng with blocking enabled.
+					// Asynchronously put a value to the range with blocking enabled.
 					cmd1Done := make(chan *roachpb.Error, 1)
 					if err := stopper.RunAsyncTask(context.Background(), func(_ context.Context) {
 						args := readOrWriteArgs(key1, test.cmd1Read)
 
 						pErr := sendWithHeader(roachpb.Header{
-							UserPriority: 42,
+							UserPriority: blockingPriority,
 						}, args)
 
 						cmd1Done <- pErr
@@ -2058,7 +2059,7 @@ func TestReplicaCommandQueue(t *testing.T) {
 						t.Fatalf("waited %s for cmd1 to enter command queue", tooLong)
 					}
 
-					// First, try a command for same key as cmd1 to verify it blocks.
+					// First, try a command for same key as cmd1 to verify whether it blocks.
 					cmd2Done := make(chan *roachpb.Error, 1)
 					if err := stopper.RunAsyncTask(context.Background(), func(_ context.Context) {
 						args := readOrWriteArgs(key1, test.cmd2Read)
@@ -2086,22 +2087,31 @@ func TestReplicaCommandQueue(t *testing.T) {
 						close(cmd3Done)
 					}
 
+					// Verify that cmd3 finishes quickly no matter what cmds 1 and 2 were.
+					select {
+					case pErr := <-cmd3Done:
+						if pErr != nil {
+							t.Fatalf("cmd3 failed: %s", pErr)
+						}
+						// success.
+					case pErr := <-cmd1Done:
+						t.Fatalf("should not have been able execute cmd1 while blocked (pErr: %v)", pErr)
+					case <-time.After(tooLong):
+						t.Fatalf("waited %s for cmd3 of key2", tooLong)
+					}
+
 					if test.expWait {
-						// Verify cmd3 finishes but not cmd2.
+						// Ensure that cmd2 didn't finish while cmd1 is still blocked.
 						select {
 						case pErr := <-cmd2Done:
 							t.Fatalf("should not have been able to execute cmd2 (pErr: %v)", pErr)
-						case pErr := <-cmd3Done:
-							if pErr != nil {
-								t.Fatalf("cmd3 failed: %s", pErr)
-							}
-							// success.
 						case pErr := <-cmd1Done:
 							t.Fatalf("should not have been able execute cmd1 while blocked (pErr: %v)", pErr)
-						case <-time.After(tooLong):
-							t.Fatalf("waited %s for cmd3 of key2", tooLong)
+						default:
+							// success
 						}
 					} else {
+						// Ensure that cmd2 finished if we didn't expect to have to wait.
 						select {
 						case pErr := <-cmd2Done:
 							if pErr != nil {
@@ -2113,10 +2123,20 @@ func TestReplicaCommandQueue(t *testing.T) {
 						case <-time.After(tooLong):
 							t.Fatalf("waited %s for cmd2 of key1", tooLong)
 						}
-						<-cmd3Done
 					}
 
+					// Wait for cmd1 to finish.
 					blockingDone <- struct{}{}
+					select {
+					case pErr := <-cmd1Done:
+						if pErr != nil {
+							t.Fatalf("cmd1 failed: %s", pErr)
+						}
+						// success.
+					case <-time.After(tooLong):
+						t.Fatalf("waited %s for cmd1 of key1", tooLong)
+					}
+
 					// Wait for cmd2 now if it didn't finish above.
 					if test.expWait {
 						select {


### PR DESCRIPTION
This looks like a copy-and-paste bug that could cause some inconsistent/mis-ordered reads when reading range-local data, but maybe it's just confusing code that needs a comment?

edit: Looks like this is also in the write path, so scratch the part of my original comment about this only affecting reads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12770)
<!-- Reviewable:end -->
