### PR TITLE
storage: remove Store.snapshotSem

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -478,31 +478,6 @@ func TestFailedReplicaChange(t *testing.T) {
 	})
 }
 
-// Test that the preemptive snapshot has been released before the associated
-// transaction for ChangeReplicas operation is run.
-func TestPreemptiveSnapshotReleasedAfterApply(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	var mtc *multiTestContext
-	sc := storage.TestStoreConfig(nil)
-	sc.TestingKnobs.TestingCommandFilter = func(filterArgs storagebase.FilterArgs) *roachpb.Error {
-		if et, ok := filterArgs.Req.(*roachpb.EndTransactionRequest); ok && et.Commit {
-			if !mtc.stores[filterArgs.Sid-1].MaybeAcquireRaftSnapshot() {
-				// We couldn't acquire the store snapshot which means the preemptive
-				// snapshot was not released. Return an error in order to fail the
-				// test.
-				return roachpb.NewErrorWithTxn(errors.Errorf("boom"), filterArgs.Hdr.Txn)
-			}
-		}
-		return nil
-	}
-	mtc = &multiTestContext{storeConfig: &sc}
-	defer mtc.Stop()
-	mtc.Start(t, 2)
-
-	mtc.replicateRange(1, 1)
-}
-
 // We can truncate the old log entries and a new replica will be brought up from a snapshot.
 func TestReplicateAfterTruncation(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -166,15 +166,6 @@ func (s *Store) EnqueueRaftUpdateCheck(rangeID roachpb.RangeID) {
 	s.enqueueRaftUpdateCheck(rangeID)
 }
 
-func (s *Store) MaybeAcquireRaftSnapshot() bool {
-	select {
-	case s.snapshotSem <- struct{}{}:
-		return true
-	default:
-		return false
-	}
-}
-
 func manualQueue(s *Store, q queueImpl, repl *Replica) error {
 	cfg, ok := s.Gossip().GetSystemConfig()
 	if !ok {

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -2167,30 +2167,6 @@ func TestStoreChangeFrozen(t *testing.T) {
 	}
 }
 
-func TestStoreNoConcurrentRaftSnapshots(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	cfg := TestStoreConfig(nil)
-	cfg.concurrentSnapshotLimit = 1
-	stopper := stop.NewStopper()
-	defer stopper.Stop()
-	store := createTestStoreWithConfig(t, stopper, &cfg)
-
-	if !store.MaybeAcquireRaftSnapshot() {
-		t.Fatal("expected true")
-	}
-
-	if store.MaybeAcquireRaftSnapshot() {
-		t.Fatalf("expected false")
-	}
-
-	store.ReleaseRaftSnapshot()
-
-	if !store.MaybeAcquireRaftSnapshot() {
-		t.Fatal("expected true")
-	}
-	store.ReleaseRaftSnapshot()
-}
-
 func TestStoreGCThreshold(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}


### PR DESCRIPTION
We now rely on snapshots being generated only by replicateQueue and
raftSnapshotQueue. This effectively changes the concurrency from 1 to 2,
but the simplification seems worth it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12778)
<!-- Reviewable:end -->
