### PR TITLE
storage: bump raftSnapshotQueue size from 100 to 10000

### DIFF
--- a/pkg/storage/consistency_queue.go
+++ b/pkg/storage/consistency_queue.go
@@ -28,10 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
-const (
-	consistencyQueueSize = 100
-)
-
 type consistencyQueue struct {
 	*baseQueue
 	interval       time.Duration
@@ -47,7 +43,7 @@ func newConsistencyQueue(store *Store, gossip *gossip.Gossip) *consistencyQueue 
 	q.baseQueue = newBaseQueue(
 		"replica consistency checker", q, store, gossip,
 		queueConfig{
-			maxSize:              consistencyQueueSize,
+			maxSize:              defaultQueueMaxSize,
 			needsLease:           true,
 			acceptsUnsplitRanges: true,
 			successes:            store.metrics.ConsistencyQueueSuccesses,

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -41,8 +41,6 @@ import (
 )
 
 const (
-	// gcQueueMaxSize is the max size of the gc queue.
-	gcQueueMaxSize = 100
 	// gcQueueTimerDuration is the duration between GCs of queued replicas.
 	gcQueueTimerDuration = 1 * time.Second
 	// gcByteCountNormalization is the count of GC'able bytes which
@@ -101,7 +99,7 @@ func newGCQueue(store *Store, gossip *gossip.Gossip) *gcQueue {
 	gcq.baseQueue = newBaseQueue(
 		"gc", gcq, store, gossip,
 		queueConfig{
-			maxSize:              gcQueueMaxSize,
+			maxSize:              defaultQueueMaxSize,
 			needsLease:           true,
 			acceptsUnsplitRanges: false,
 			successes:            store.metrics.GCQueueSuccesses,

--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -43,6 +43,8 @@ const (
 	// The timeout prevents a queue from getting stuck on a replica.
 	// For example, a replica whose range is not reachable for quorum.
 	defaultProcessTimeout = 1 * time.Minute
+	// defaultQueueMaxSize is the default max size for a queue.
+	defaultQueueMaxSize = 10000
 )
 
 // a purgatoryError indicates a replica processing failure which indicates

--- a/pkg/storage/raft_log_queue.go
+++ b/pkg/storage/raft_log_queue.go
@@ -34,8 +34,6 @@ import (
 )
 
 const (
-	// raftLogQueueMaxSize is the max size of the queue.
-	raftLogQueueMaxSize = 100
 	// RaftLogQueueTimerDuration is the duration between truncations. This needs
 	// to be relatively short so that truncations can keep up with raft log entry
 	// creation.
@@ -64,7 +62,7 @@ func newRaftLogQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *raftLo
 	rlq.baseQueue = newBaseQueue(
 		"raftlog", rlq, store, gossip,
 		queueConfig{
-			maxSize:              raftLogQueueMaxSize,
+			maxSize:              defaultQueueMaxSize,
 			needsLease:           false,
 			acceptsUnsplitRanges: true,
 			successes:            store.metrics.RaftLogQueueSuccesses,

--- a/pkg/storage/raft_snapshot_queue.go
+++ b/pkg/storage/raft_snapshot_queue.go
@@ -29,9 +29,6 @@ import (
 )
 
 const (
-	// raftSnapshotQueueMaxSize is the max size of the Raft snapshot queue.
-	raftSnapshotQueueMaxSize = 100
-
 	// raftSnapshotQueueTimerDuration is the duration between Raft snapshot of
 	// queued replicas.
 	raftSnapshotQueueTimerDuration = 0 // zero duration to process Raft snapshots greedily
@@ -54,7 +51,7 @@ func newRaftSnapshotQueue(store *Store, g *gossip.Gossip, clock *hlc.Clock) *raf
 	rq.baseQueue = newBaseQueue(
 		"raftsnapshot", rq, store, g,
 		queueConfig{
-			maxSize: raftSnapshotQueueMaxSize,
+			maxSize: defaultQueueMaxSize,
 			// The Raft leader (which sends Raft snapshots) may not be the
 			// leaseholder. Operating on a replica without holding the lease is the
 			// reason Raft snapshots cannot be performed by the replicateQueue.

--- a/pkg/storage/replica_gc_queue.go
+++ b/pkg/storage/replica_gc_queue.go
@@ -34,9 +34,6 @@ import (
 )
 
 const (
-	// replicaGCQueueMaxSize is the max size of the gc queue.
-	replicaGCQueueMaxSize = 100
-
 	// replicaGCQueueTimerDuration is the duration between GCs of queued replicas.
 	replicaGCQueueTimerDuration = 50 * time.Millisecond
 
@@ -97,7 +94,7 @@ func newReplicaGCQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *repl
 	rgcq.baseQueue = newBaseQueue(
 		"replicaGC", rgcq, store, gossip,
 		queueConfig{
-			maxSize:              replicaGCQueueMaxSize,
+			maxSize:              defaultQueueMaxSize,
 			needsLease:           false,
 			acceptsUnsplitRanges: true,
 			successes:            store.metrics.ReplicaGCQueueSuccesses,

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -34,9 +34,6 @@ import (
 )
 
 const (
-	// replicateQueueMaxSize is the max size of the replicate queue.
-	replicateQueueMaxSize = 100
-
 	// replicateQueueTimerDuration is the duration between replication of queued
 	// replicas.
 	replicateQueueTimerDuration = 0 // zero duration to process replication greedily
@@ -104,7 +101,7 @@ func newReplicateQueue(
 	rq.baseQueue = newBaseQueue(
 		"replicate", rq, store, g,
 		queueConfig{
-			maxSize:              replicateQueueMaxSize,
+			maxSize:              defaultQueueMaxSize,
 			needsLease:           true,
 			acceptsUnsplitRanges: store.TestingKnobs().ReplicateQueueAcceptsUnsplit,
 			successes:            store.metrics.ReplicateQueueSuccesses,

--- a/pkg/storage/split_queue.go
+++ b/pkg/storage/split_queue.go
@@ -31,8 +31,6 @@ import (
 )
 
 const (
-	// splitQueueMaxSize is the max size of the split queue.
-	splitQueueMaxSize = 100
 	// splitQueueTimerDuration is the duration between splits of queued ranges.
 	splitQueueTimerDuration = 0 // zero duration to process splits greedily.
 )
@@ -52,7 +50,7 @@ func newSplitQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *splitQue
 	sq.baseQueue = newBaseQueue(
 		"split", sq, store, gossip,
 		queueConfig{
-			maxSize:              splitQueueMaxSize,
+			maxSize:              defaultQueueMaxSize,
 			needsLease:           true,
 			acceptsUnsplitRanges: true,
 			successes:            store.metrics.SplitQueueSuccesses,

--- a/pkg/storage/ts_maintenance_queue.go
+++ b/pkg/storage/ts_maintenance_queue.go
@@ -33,8 +33,7 @@ import (
 const (
 	// TimeSeriesMaintenanceInterval is the minimum interval between two
 	// time series maintenance runs on a replica.
-	TimeSeriesMaintenanceInterval     = 24 * time.Hour // daily
-	timeSeriesMaintenanceQueueMaxSize = 100
+	TimeSeriesMaintenanceInterval = 24 * time.Hour // daily
 )
 
 // TimeSeriesDataStore is an interface defined in the storage package that can
@@ -93,7 +92,7 @@ func newTimeSeriesMaintenanceQueue(
 	q.baseQueue = newBaseQueue(
 		"timeSeriesMaintenance", q, store, g,
 		queueConfig{
-			maxSize:              timeSeriesMaintenanceQueueMaxSize,
+			maxSize:              defaultQueueMaxSize,
 			needsLease:           true,
 			acceptsUnsplitRanges: true,
 			successes:            store.metrics.TimeSeriesMaintenanceQueueSuccesses,


### PR DESCRIPTION
Set the raftSnapshotQueue size significantly larger than the number of
replicas that can be processed by the queue in a single scanner cycle to
avoid inadvertently leaving the queue idle.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12781)
<!-- Reviewable:end -->
