### PR TITLE
sql: allow ALTER TABLE DROP COLUMN to drop dependent indices.

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -210,11 +210,61 @@ func (n *alterTableNode) Start() error {
 				if n.tableDesc.PrimaryIndex.ContainsColumnID(col.ID) {
 					return fmt.Errorf("column %q is referenced by the primary key", col.Name)
 				}
-				// TODO(#10122): Should we drop dependent indexes if CASCADE was
-				// specified?
 				for _, idx := range n.tableDesc.AllNonDropIndexes() {
-					if idx.ContainsColumnID(col.ID) {
-						return fmt.Errorf("column %q is referenced by existing index %q", col.Name, idx.Name)
+					// We automatically drop indexes on that column that only
+					// index that column (and no other columns). If CASCADE is
+					// specified, we also drop other indices that refer to this
+					// column.  The criteria to determine whether an index "only
+					// indexes that column":
+					//
+					// Assume a table created with CREATE TABLE foo (a INT, b INT).
+					// Then assume the user issues ALTER TABLE foo DROP COLUMN a.
+					//
+					// INDEX i1 ON foo(a) -> i1 deleted
+					// INDEX i2 ON foo(a) STORING(b) -> i2 deleted
+					// INDEX i3 ON foo(a, b) -> i3 not deleted unless CASCADE is specified.
+					// INDEX i4 ON foo(b) STORING(a) -> i4 not deleted unless CASCADE is specified.
+
+					// containsThisColumn becomes true if the index is defined
+					// over the column being dropped.
+					containsThisColumn := false
+					// containsOnlyThisColumn becomes false if the index also
+					// includes non-PK columns other than the one being dropped.
+					containsOnlyThisColumn := true
+
+					// Analyze the index.
+					for _, id := range idx.ColumnIDs {
+						if id == col.ID {
+							containsThisColumn = true
+						} else {
+							containsOnlyThisColumn = false
+						}
+					}
+					for _, id := range idx.ExtraColumnIDs {
+						if n.tableDesc.PrimaryIndex.ContainsColumnID(id) {
+							// All secondary indices necessary contain the PK
+							// columns, too. (See the comments on the definition of
+							// IndexDescriptor). The presence of a PK column in the
+							// secondary index should thus not be seen as a
+							// sufficient reason to reject the DROP.
+							continue
+						}
+						if id == col.ID {
+							containsThisColumn = true
+						}
+					}
+
+					// Perform the DROP.
+					if containsThisColumn {
+						if containsOnlyThisColumn || t.DropBehavior == parser.DropCascade {
+							if err := n.p.dropIndexByName(
+								parser.Name(idx.Name), n.tableDesc, false, t.DropBehavior, n.n.String(),
+							); err != nil {
+								return err
+							}
+						} else {
+							return fmt.Errorf("column %q is referenced by existing index %q", col.Name, idx.Name)
+						}
 					}
 				}
 				n.tableDesc.AddColumnMutation(col, sqlbase.DescriptorMutation_DROP)

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -895,7 +895,7 @@ func TestTableMutationQueue(t *testing.T) {
 	// Create a table with column i and an index on v and i.
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
-CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
+CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR UNIQUE);
 `); err != nil {
 		t.Fatal(err)
 	}
@@ -946,7 +946,9 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 		// Third.
 		{"idx_g", 3, sqlbase.DescriptorMutation_DELETE_ONLY},
 		// Drop mutations start off in the WRITE_ONLY state.
-		{"v", 4, sqlbase.DescriptorMutation_WRITE_ONLY},
+		// UNIQUE column deletion gets split into two mutation ids.
+		{"test_v_key", 4, sqlbase.DescriptorMutation_WRITE_ONLY},
+		{"v", 5, sqlbase.DescriptorMutation_WRITE_ONLY},
 	}
 
 	if len(tableDesc.Mutations) != len(expected) {

--- a/pkg/sql/testdata/alter_table
+++ b/pkg/sql/testdata/alter_table
@@ -154,9 +154,6 @@ ALTER TABLE t DROP IF EXISTS d
 statement error column "a" is referenced by the primary key
 ALTER TABLE t DROP a
 
-statement error column "b" is referenced by existing index "foo"
-ALTER TABLE t DROP b
-
 statement error constraint "bar" does not exist
 ALTER TABLE t DROP CONSTRAINT bar
 
@@ -267,15 +264,11 @@ a   d     x     y     z
 31  32    NULL  1.3   1.4
 33  34    2     2.1   2.2
 
-# fix #6463
-statement error column "d" is referenced by existing index "t_d_key"
+statement ok
 ALTER TABLE t DROP COLUMN d
 
 statement ok
-DROP INDEX t@t_d_key
-
-statement ok
-ALTER TABLE t ADD COLUMN e INT
+ALTER TABLE t ADD COLUMN e INT; ALTER TABLE t ADD COLUMN d INT
 
 statement ok
 CREATE VIEW v AS SELECT x, y FROM t WHERE e > 5
@@ -309,6 +302,24 @@ ALTER TABLE t DROP COLUMN IF EXISTS e
 
 statement ok
 ALTER TABLE t DROP COLUMN IF EXISTS e CASCADE
+
+statement ok
+ALTER TABLE t ADD COLUMN g INT UNIQUE
+
+statement ok
+CREATE TABLE o (gf INT REFERENCES t (g), h INT, i INT, INDEX ii (i) STORING(h))
+
+statement error "t_g_key" is referenced by foreign key from table "o"
+ALTER TABLE t DROP COLUMN g
+
+statement ok
+ALTER TABLE t DROP COLUMN g CASCADE
+
+statement error column "h" is referenced by existing index "ii"
+ALTER TABLE o DROP COLUMN h
+
+statement ok
+ALTER TABLE o DROP COLUMN h CASCADE
 
 statement error adding a CHECK constraint via ALTER not supported
 ALTER TABLE t ADD f INT CHECK (f>1)


### PR DESCRIPTION
Prior to this patch, `ALTER TABLE DROP COLUMN` would refuse to drop a
column if it was involved in any index, even ignoring the drop
behavior specification (`RESTRICT`/`CASCADE`).

With this patch, the following is implemented:

- if a column is not indexed, then it is dropped, as usual;
- for each index on that column:

  - if the index is defined on that column only, then it is
    automatically dropped as per `DROP INDEX` *without* `CASCADE`.
  - if the index is defined on that column and also other columns,
    then if `CASCADE` is also specified it is automatically dropped as
    per `DROP INDEX CASCADE`; otherwise an error is reported (the same
    error as before).

  In both cases when an index is dropped, the usual checks performed
  by DROP INDEX apply, and the RESTRICT/CASCADE clause on ALTER TABLE
  DROP COLUMN is propagated to the underlying DROP INDEX.

Addresses most of the concerns in  #10122 (all?)
Fixes #6463.

cc @vivekmenezes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12782)
<!-- Reviewable:end -->
