### PR TITLE
sql/sqlbase: embed batch in kvFetcher to avoid alloc on each fetch

### DIFF
--- a/pkg/sql/sqlbase/kvfetcher.go
+++ b/pkg/sql/sqlbase/kvfetcher.go
@@ -90,6 +90,9 @@ type kvFetcher struct {
 	useBatchLimit   bool
 	firstBatchLimit int64
 
+	// Fields used to avoid allocations.
+	batch client.Batch
+
 	batchIdx     int
 	fetchEnd     bool
 	kvs          []client.KeyValue
@@ -187,7 +190,8 @@ func makeKVFetcher(
 func (f *kvFetcher) fetch() error {
 	batchSize := f.getBatchSize()
 
-	b := &client.Batch{}
+	b := &f.batch
+	*b = client.Batch{}
 	b.Header.MaxSpanRequestKeys = batchSize
 
 	for _, span := range f.spans {


### PR DESCRIPTION
```
name                 old allocs/op  new allocs/op  delta
Select1_Cockroach-4       113 ± 0%       113 ± 0%    ~     (all samples are equal)
Select2_Cockroach-4     1.52k ± 0%     1.52k ± 0%  -0.07%          (p=0.001 n=8+9)
Select3_Cockroach-4     2.40k ± 0%     2.40k ± 0%    ~           (p=0.421 n=10+10)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12787)
<!-- Reviewable:end -->
