### PR TITLE
WIP distsql, ui: add statement execution latency graph

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/pkg/errors"
 )
 
@@ -57,22 +58,25 @@ var errNotRetriable = errors.New("the transaction is not in a retriable state")
 
 const sqlTxnName string = "sql txn"
 const sqlImplicitTxnName string = "sql txn implicit"
+const metricsSampleInterval = 10 * time.Second
 
 // Fully-qualified names for metrics.
 var (
-	MetaLatency       = metric.Metadata{Name: "sql.latency"}
-	MetaTxnBegin      = metric.Metadata{Name: "sql.txn.begin.count"}
-	MetaTxnCommit     = metric.Metadata{Name: "sql.txn.commit.count"}
-	MetaTxnAbort      = metric.Metadata{Name: "sql.txn.abort.count"}
-	MetaTxnRollback   = metric.Metadata{Name: "sql.txn.rollback.count"}
-	MetaSelect        = metric.Metadata{Name: "sql.select.count"}
-	MetaDistSQLSelect = metric.Metadata{Name: "sql.distsql.select.count"}
-	MetaUpdate        = metric.Metadata{Name: "sql.update.count"}
-	MetaInsert        = metric.Metadata{Name: "sql.insert.count"}
-	MetaDelete        = metric.Metadata{Name: "sql.delete.count"}
-	MetaDdl           = metric.Metadata{Name: "sql.ddl.count"}
-	MetaMisc          = metric.Metadata{Name: "sql.misc.count"}
-	MetaQuery         = metric.Metadata{Name: "sql.query.count"}
+	MetaLatency            = metric.Metadata{Name: "sql.latency"}
+	MetaTxnBegin           = metric.Metadata{Name: "sql.txn.begin.count"}
+	MetaTxnCommit          = metric.Metadata{Name: "sql.txn.commit.count"}
+	MetaTxnAbort           = metric.Metadata{Name: "sql.txn.abort.count"}
+	MetaTxnRollback        = metric.Metadata{Name: "sql.txn.rollback.count"}
+	MetaSelect             = metric.Metadata{Name: "sql.select.count"}
+	MetaSQLExecLatency     = metric.Metadata{Name: "sql.exec.latency"}
+	MetaDistSQLSelect      = metric.Metadata{Name: "sql.distsql.select.count"}
+	MetaDistSQLExecLatency = metric.Metadata{Name: "sql.distsql.exec.latency"}
+	MetaUpdate             = metric.Metadata{Name: "sql.update.count"}
+	MetaInsert             = metric.Metadata{Name: "sql.insert.count"}
+	MetaDelete             = metric.Metadata{Name: "sql.delete.count"}
+	MetaDdl                = metric.Metadata{Name: "sql.ddl.count"}
+	MetaMisc               = metric.Metadata{Name: "sql.misc.count"}
+	MetaQuery              = metric.Metadata{Name: "sql.query.count"}
 )
 
 // distSQLExecMode controls if and when the Executor uses DistSQL.
@@ -215,6 +219,8 @@ type Executor struct {
 	SelectCount *metric.Counter
 	// The subset of SELECTs that are processed through DistSQL.
 	DistSQLSelectCount *metric.Counter
+	DistSQLExecLatency *metric.Histogram
+	SQLExecLatency     *metric.Histogram
 	TxnBeginCount      *metric.Counter
 
 	// txnCommitCount counts the number of times a COMMIT was attempted.
@@ -316,12 +322,17 @@ func NewExecutor(cfg ExecutorConfig, stopper *stop.Stopper) *Executor {
 		TxnRollbackCount:   metric.NewCounter(MetaTxnRollback),
 		SelectCount:        metric.NewCounter(MetaSelect),
 		DistSQLSelectCount: metric.NewCounter(MetaDistSQLSelect),
-		UpdateCount:        metric.NewCounter(MetaUpdate),
-		InsertCount:        metric.NewCounter(MetaInsert),
-		DeleteCount:        metric.NewCounter(MetaDelete),
-		DdlCount:           metric.NewCounter(MetaDdl),
-		MiscCount:          metric.NewCounter(MetaMisc),
-		QueryCount:         metric.NewCounter(MetaQuery),
+		// TODO(mrtracy): See HistogramWindowInterval in server/config.go for the 6x factor.
+		DistSQLExecLatency: metric.NewLatency(MetaDistSQLExecLatency,
+			6*metricsSampleInterval),
+		SQLExecLatency: metric.NewLatency(MetaSQLExecLatency,
+			6*metricsSampleInterval),
+		UpdateCount: metric.NewCounter(MetaUpdate),
+		InsertCount: metric.NewCounter(MetaInsert),
+		DeleteCount: metric.NewCounter(MetaDelete),
+		DdlCount:    metric.NewCounter(MetaDdl),
+		MiscCount:   metric.NewCounter(MetaMisc),
+		QueryCount:  metric.NewCounter(MetaQuery),
 	}
 }
 
@@ -1035,6 +1046,7 @@ func (e *Executor) execStmtInOpenTxn(
 	txnState *txnState,
 	isAutomaticRetry bool,
 ) (Result, error) {
+	tStart := timeutil.Now()
 	if txnState.State != Open {
 		panic("execStmtInOpenTxn called outside of an open txn")
 	}
@@ -1150,7 +1162,7 @@ func (e *Executor) execStmtInOpenTxn(
 	}
 
 	autoCommit := implicitTxn && !e.cfg.TestingKnobs.DisableAutoCommit
-	result, err := e.execStmt(stmt, planMaker, autoCommit, isAutomaticRetry)
+	result, err := e.execStmt(stmt, planMaker, autoCommit, isAutomaticRetry, tStart)
 	if err != nil {
 		if result.Rows != nil {
 			result.Rows.Close()
@@ -1358,7 +1370,11 @@ func (e *Executor) shouldUseDistSQL(planMaker *planner, plan planNode) (bool, er
 // The current transaction might have been committed/rolled back when this returns.
 // The caller closes result.Rows (even in error cases).
 func (e *Executor) execStmt(
-	stmt parser.Statement, planMaker *planner, autoCommit bool, isAutomaticRetry bool,
+	stmt parser.Statement,
+	planMaker *planner,
+	autoCommit bool,
+	isAutomaticRetry bool,
+	tStart time.Time,
 ) (Result, error) {
 	plan, err := planMaker.makePlan(stmt, autoCommit)
 	if err != nil {
@@ -1391,8 +1407,12 @@ func (e *Executor) execStmt(
 			e.DistSQLSelectCount.Inc(1)
 		}
 		err = e.execDistSQL(planMaker, plan, &result)
+		execDuration := timeutil.Since(tStart).Nanoseconds()
+		e.DistSQLExecLatency.RecordValue(execDuration)
 	} else {
 		err = e.execClassic(planMaker, plan, &result)
+		execDuration := timeutil.Since(tStart).Nanoseconds()
+		e.SQLExecLatency.RecordValue(execDuration)
 	}
 	return result, err
 }

--- a/pkg/ui/app/containers/nodeGraphs.tsx
+++ b/pkg/ui/app/containers/nodeGraphs.tsx
@@ -241,13 +241,73 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
             </Axis>
           </LineGraph>
 
-          <LineGraph title="SQL Queries" sources={nodeSources} tooltip={`The average number of SELECT, INSERT, UPDATE, and DELETE statements per second across ${specifier}.`}>
+          <LineGraph title="SQL Queries" sources={nodeSources} tooltip={`The average number of SELECT, INSERT, UPDATE, and DELETE statements per second ${specifier}.`}>
             <Axis>
               <Metric name="cr.node.sql.select.count" title="Total Reads" nonNegativeRate />
               <Metric name="cr.node.sql.distsql.select.count" title="DistSQL Reads" nonNegativeRate />
               <Metric name="cr.node.sql.update.count" title="Updates" nonNegativeRate />
               <Metric name="cr.node.sql.insert.count" title="Inserts" nonNegativeRate />
               <Metric name="cr.node.sql.delete.count" title="Deletes" nonNegativeRate />
+            </Axis>
+          </LineGraph>
+
+          <LineGraph title="Backend Statement Execution Latency: SQL, 99th percentile"
+                       tooltip={`The latency of backend statements executed over 10 second periods ${specifier}.`}>
+            <Axis units={ AxisUnits.Duration }>
+              {
+                _.map(nodeIds, (node) =>
+                  <Metric key={node}
+                          name="cr.node.sql.exec.latency-p99"
+                          title={this.nodeAddress(node)}
+                          sources={[node]}
+                          downsampleMax />,
+                )
+              }
+            </Axis>
+          </LineGraph>
+
+          <LineGraph title="Backend Statement Execution Latency: SQL, 90th percentile"
+                       tooltip={`The latency of backend statements executed over 10 second periods ${specifier}.`}>
+            <Axis units={ AxisUnits.Duration }>
+              {
+                _.map(nodeIds, (node) =>
+                  <Metric key={node}
+                          name="cr.node.sql.exec.latency-p90"
+                          title={this.nodeAddress(node)}
+                          sources={[node]}
+                          downsampleMax />,
+                )
+              }
+            </Axis>
+          </LineGraph>
+
+          <LineGraph title="Backend Statement Execution Latency: DistSQL, 99th percentile"
+                       tooltip={`The latency of backend statements executed over 10 second periods ${specifier}.`}>
+            <Axis units={ AxisUnits.Duration }>
+              {
+                _.map(nodeIds, (node) =>
+                  <Metric key={node}
+                          name="cr.node.sql.distsql.exec.latency-p99"
+                          title={this.nodeAddress(node)}
+                          sources={[node]}
+                          downsampleMax />,
+                )
+              }
+            </Axis>
+          </LineGraph>
+
+          <LineGraph title="Backend Statement Execution Latency: DistSQL, 90th percentile"
+                       tooltip={`The latency of backend statements executed over 10 second periods ${specifier}.`}>
+            <Axis units={ AxisUnits.Duration }>
+              {
+                _.map(nodeIds, (node) =>
+                  <Metric key={node}
+                          name="cr.node.sql.distsql.exec.latency-p90"
+                          title={this.nodeAddress(node)}
+                          sources={[node]}
+                          downsampleMax />,
+                )
+              }
             </Axis>
           </LineGraph>
 


### PR DESCRIPTION
Add a graph that tracks the backend execution latency for each SQL statement, which separately tracks DistSQL queries and SQL queries.

WIP as I'm not sure if I'm using the right metric types and setting them up in the nodeGraphs UI page the correct way, and need a quick sanity check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12790)
<!-- Reviewable:end -->
