### PR TITLE
distsqlrun: add missing interface assertions

### DIFF
--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -73,6 +73,8 @@ type aggregator struct {
 	buckets   map[string]struct{} // The set of bucket keys.
 }
 
+var _ processor = &aggregator{}
+
 func newAggregator(
 	ctx *FlowCtx, spec *AggregatorSpec, input RowSource, output RowReceiver,
 ) (*aggregator, error) {

--- a/pkg/sql/distsqlrun/distinct.go
+++ b/pkg/sql/distsqlrun/distinct.go
@@ -35,6 +35,8 @@ type distinct struct {
 	datumAlloc   sqlbase.DatumAlloc
 }
 
+var _ processor = &distinct{}
+
 func newDistinct(
 	flowCtx *FlowCtx, spec *DistinctSpec, input RowSource, output RowReceiver,
 ) (*distinct, error) {

--- a/pkg/sql/distsqlrun/evaluator.go
+++ b/pkg/sql/distsqlrun/evaluator.go
@@ -38,6 +38,8 @@ type evaluator struct {
 	rowAlloc sqlbase.EncDatumRowAlloc
 }
 
+var _ processor = &evaluator{}
+
 func newEvaluator(
 	flowCtx *FlowCtx, spec *EvaluatorSpec, input RowSource, output RowReceiver,
 ) (*evaluator, error) {


### PR DESCRIPTION
Assert that aggregator, distinct, and evaluator are processors, as all the other processors do. I ran into this while trying to grep for all the processors, which returned an incomplete list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12791)
<!-- Reviewable:end -->
