### PR TITLE
sql: fix UPDATE using a secondary index during a column add

### DIFF
--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -125,7 +125,7 @@ func (p *planner) makeIndexJoin(
 	// Create a new scanNode that will be used with the primary index.
 	table := p.Scan()
 	table.desc = origScan.desc
-	table.initDescDefaults(publicColumns)
+	table.initDescDefaults(origScan.scanVisibility)
 	table.initOrdering(0)
 	table.disableBatchLimit()
 

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -1552,3 +1552,71 @@ CREATE TABLE t.test (
 		t.Fatalf("read the wrong number of rows: e = %d, v = %d", eCount, count)
 	}
 }
+
+// Test an UPDATE using a primary and a secondary index in the middle
+// of a column backfill.
+func TestUpdateDuringColumnBackfill(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	backfillNotification := make(chan bool)
+	continueBackfillNotification := make(chan bool)
+	params, _ := createTestServerParams()
+	params.Knobs = base.TestingKnobs{
+		SQLSchemaChanger: &csql.SchemaChangerTestingKnobs{
+			RunBeforeBackfillChunk: func(sp roachpb.Span) error {
+				if backfillNotification != nil {
+					// Close channel to notify that the schema change has
+					// been queued and the backfill has started.
+					close(backfillNotification)
+					backfillNotification = nil
+					<-continueBackfillNotification
+				}
+				return nil
+			},
+			AsyncExecNotification: asyncSchemaChangerDisabled,
+		},
+	}
+	server, sqlDB, _ := serverutils.StartServer(t, params)
+	defer server.Stopper().Stop()
+
+	if _, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test (
+    k INT NOT NULL,
+    v INT NOT NULL,
+    length INT NOT NULL,
+    CONSTRAINT "primary" PRIMARY KEY (k),
+    INDEX v_idx (v),
+    FAMILY "primary" (k, v, length)
+);
+INSERT INTO t.test (k, v, length) VALUES (0, 1, 1);
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run the column schema change in a separate goroutine.
+	notification := backfillNotification
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		if _, err := sqlDB.Exec(`ALTER TABLE t.test ADD id int NOT NULL DEFAULT 0;`); err != nil {
+			t.Error(err)
+		}
+		wg.Done()
+	}()
+
+	<-notification
+
+	// UPDATE the row using the secondary index.
+	if _, err := sqlDB.Exec(`UPDATE t.test SET length = 27000 WHERE v = 1`); err != nil {
+		t.Error(err)
+	}
+
+	// UPDATE the row using the primary index.
+	if _, err := sqlDB.Exec(`UPDATE t.test SET length = 27001 WHERE k = 0`); err != nil {
+		t.Error(err)
+	}
+
+	close(continueBackfillNotification)
+
+	wg.Wait()
+}


### PR DESCRIPTION
An UPDATE needs to read all columns including those being backfilled
in case it needs to update an index. This was done correctly when
an update used a primary index. An UPDATE using a secondary index
runs an index join which was hard coded to not scan the new column.

Added TestUpdateUsingSecondaryIndexDuringColumnBackfill

fixes #12774

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12794)
<!-- Reviewable:end -->
