### PR TITLE
storage: enable the rule solver as the default option

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -107,7 +107,7 @@ var storeSchedulerConcurrency = envutil.EnvOrDefaultInt(
 var enablePreVote = envutil.EnvOrDefaultBool(
 	"COCKROACH_ENABLE_PREVOTE", false)
 
-var enableRuleSolver = envutil.EnvOrDefaultBool("COCKROACH_ENABLE_RULE_SOLVER", false)
+var enableRuleSolver = envutil.EnvOrDefaultBool("COCKROACH_ENABLE_RULE_SOLVER", true)
 
 // RaftElectionTimeout returns the raft election timeout, as computed
 // from the specified tick interval and number of election timeout


### PR DESCRIPTION
I've tested this quite extensively and I'd like to see what happens in our other test clusters.  There's more work to do with expressive zone configs, see #12782 but I think it's ready.

I don't think we should remove the legacy code just yet, so we can disable it if needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12795)
<!-- Reviewable:end -->
