### PR TITLE
ui: Match Admin UI Graphs to Grafana

### DIFF
--- a/pkg/ui/app/app.tsx
+++ b/pkg/ui/app/app.tsx
@@ -101,7 +101,7 @@ ReactDOM.render(
       <Route path="/" component={Layout}>
         <IndexRedirect to="cluster" />
         <Route path="cluster" component={ Nodes }>
-          <IndexRedirect to="all/activity" />
+          <IndexRedirect to="all/runtime" />
           <Route path={`all/:${dashboardNameAttr}`} component={NodeGraphs} />
           <Route path={ `node/:${nodeIDAttr}/:${dashboardNameAttr}` } component={NodeGraphs} />
         </Route>

--- a/pkg/ui/app/containers/nodes.tsx
+++ b/pkg/ui/app/containers/nodes.tsx
@@ -26,10 +26,12 @@ interface ClusterOverviewState {
 }
 
 let dashboards = [
-  { value: "activity", label: "Activity" },
-  { value: "queries", label: "SQL Queries" },
-  { value: "resources", label: "System Resources" },
-  { value: "internals", label: "Advanced Internals" },
+  { value: "runtime", label: "Runtime" },
+  { value: "sql", label: "SQL" },
+  { value: "storage", label: "Storage" },
+  { value: "replication", label: "Replication" },
+  { value: "queues", label: "Queues" },
+  { value: "requests", label: "Slow Requests" },
 ];
 
 /**

--- a/pkg/ui/app/util/format.ts
+++ b/pkg/ui/app/util/format.ts
@@ -17,7 +17,7 @@ export function ComputePrefixExponent(value: number, prefixMultiple: number, pre
   let maxUnits = Math.abs(value);
   let prefixScale: number;
   for (prefixScale = 0;
-       maxUnits >= prefixMultiple && prefixScale < prefixList.length;
+       maxUnits >= prefixMultiple && prefixScale < (prefixList.length - 1);
        prefixScale++) {
     maxUnits /= prefixMultiple;
   }


### PR DESCRIPTION
Changes the set of available graphs in the Admin UI to match those used in our
production grafana. The motivating though behind this is that the graphs on our
production cluster were designed by cockroach's current most prolific users and
deployers, as opposed to the fairly arbitrary graphs in the current admin UI.

+ There are now six dashboards instead of four.
+ Several of the graphs display a series per-node, rather than a cluster
aggregate, when in Cluster mode.
+ Addresses the issue where some nodes may have more than one store - graphs of
store metrics are constrained to the stores present on the selected node.
+ Fixes an issue in our prefix scale computation when the numbers are very
large.

Addresses the first section of #12279 

![screen shot 2017-01-09 at 5 01 12 pm](https://cloud.githubusercontent.com/assets/6969858/21785415/6d943b3a-d68d-11e6-9bb4-304241b256a5.png)
![screen shot 2017-01-09 at 5 01 22 pm](https://cloud.githubusercontent.com/assets/6969858/21785417/6fb2ecb8-d68d-11e6-9bd5-dcbb0f3b91f1.png)

Some of the graphs are missing tooltips, but tooltips are not currently displaying due to recent UI changes; I will add the tooltips in a follow-up PR where I re-enable them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12797)
<!-- Reviewable:end -->
