### PR TITLE
storage: gossip system data when lease changes for ranges holding system data

### DIFF
--- a/pkg/keys/spans.go
+++ b/pkg/keys/spans.go
@@ -31,10 +31,6 @@ var (
 	// UserDataSpan is the non-meta and non-structured portion of the key space.
 	UserDataSpan = roachpb.Span{Key: SystemMax, EndKey: TableDataMin}
 
-	// GossipedSystemSpans are spans which contain system data which needs to be
-	// shared with other nodes in the system via gossip.
-	GossipedSystemSpans = []roachpb.Span{NodeLivenessSpan, SystemConfigSpan}
-
 	// NoSplitSpans describes the ranges that should never be split.
 	// Meta1Span: needed to find other ranges.
 	// NodeLivenessSpan: liveness information on nodes in the cluster.

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1747,20 +1747,12 @@ func (r *Replica) applyNewLeaseLocked(
 	// through potential consequences.
 	pd.Replicated.BlockReads = !isExtension
 	pd.Replicated.State.Lease = &lease
-	if l := r.mu.state.Lease; l == nil || l.Replica.StoreID != lease.Replica.StoreID {
-		pd.Local.maybeGossipNodeLiveness = &keys.NodeLivenessSpan
-	}
 	pd.Local.leaseMetricsResult = new(leaseMetricsType)
 	if isTransfer {
 		*pd.Local.leaseMetricsResult = leaseTransferSuccess
 	} else {
 		*pd.Local.leaseMetricsResult = leaseRequestSuccess
 	}
-	// TODO(tschottdorf): having traced the origin of this call back to
-	// rev 6281926, it seems that we should only be doing this when the
-	// lease holder has changed. However, it's likely not a big deal to
-	// do it always.
-	pd.Local.maybeGossipSystemConfig = true
 	return pd, nil
 }
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -94,6 +94,13 @@ const (
 	defaultGossipWhenCapacityDeltaExceedsFraction = 0.01
 
 	defaultStoreMutexWarnThreshold = 100 * time.Millisecond
+
+	// systemDataGossipInterval is the interval at which range lease
+	// holders verify that the most recent system data is gossiped.
+	// This ensures that system data is always eventually gossiped, even
+	// if a range lease holder experiences a failure causing a missed
+	// gossip update.
+	systemDataGossipInterval = 1 * time.Minute
 )
 
 var changeTypeInternalToRaft = map[roachpb.ReplicaChangeType]raftpb.ConfChangeType{
@@ -421,6 +428,12 @@ type Store struct {
 	// the time of its creation was riddled with deadlock (but that situation
 	// has likely improved).
 	drainLeases atomic.Value
+
+	// These vars are atomically updated from 0 to 1 once per store
+	// lifetime to ensure we gossip system data in the event that the
+	// node ends up owning the relevant range lease on a restart.
+	haveGossipedSystemConfig int32
+	haveGossipedNodeLiveness int32
 
 	// Locking notes: To avoid deadlocks, the following lock order must be
 	// obeyed: Replica.raftMu < Replica.readOnlyCmdMu < Store.mu < Replica.mu
@@ -1268,9 +1281,18 @@ func (s *Store) startGossip() {
 			interval:    sentinelGossipInterval,
 		},
 		{
-			fn:          s.maybeGossipSystemData,
+			fn: func(ctx context.Context) error {
+				return s.maybeGossipSystemData(ctx, keys.SystemConfigSpan)
+			},
 			description: "system config",
-			interval:    configGossipInterval,
+			interval:    systemDataGossipInterval,
+		},
+		{
+			fn: func(ctx context.Context) error {
+				return s.maybeGossipSystemData(ctx, keys.NodeLivenessSpan)
+			},
+			description: "node liveness",
+			interval:    systemDataGossipInterval,
 		},
 	}
 
@@ -1327,27 +1349,26 @@ func (s *Store) maybeGossipFirstRange(ctx context.Context) error {
 	return nil
 }
 
-// maybeGossipSystemData looks for the ranges containing system data
-// and acquires the range lease for them which in turn will trigger
-// Replica.maybeGossipSystemConfig and Replica.maybeGossipNodeLiveness.
-func (s *Store) maybeGossipSystemData(ctx context.Context) error {
+// maybeGossipSystemData looks for the range containing the specified
+// span and acquires the range lease, which in turn triggers a system
+// data gossip function (e.g. Replica.maybeGossipSystemConfig or
+// Replica.maybeGossipNodeLiveness).
+func (s *Store) maybeGossipSystemData(ctx context.Context, span roachpb.Span) error {
 	if s.cfg.TestingKnobs.DisablePeriodicGossips {
 		return nil
 	}
 
-	for _, span := range keys.GossipedSystemSpans {
-		repl := s.LookupReplica(roachpb.RKey(span.Key), nil)
-		if repl == nil {
-			// This store has no range with this configuration.
-			continue
-		}
-		// Wake up the replica. If it acquires a fresh lease, it will
-		// gossip. If an unexpected error occurs (i.e. nobody else seems to
-		// have an active lease but we still failed to obtain it), return
-		// that error.
-		if _, pErr := repl.getLeaseForGossip(ctx); pErr != nil {
-			return pErr.GoError()
-		}
+	repl := s.LookupReplica(roachpb.RKey(span.Key), nil)
+	if repl == nil {
+		// This store has no range with this configuration.
+		return nil
+	}
+	// Wake up the replica. If it acquires a fresh lease, gossip the
+	// gossip. If an unexpected error occurs (i.e. nobody else seems to
+	// have an active lease but we still failed to obtain it), return
+	// that error.
+	if _, pErr := repl.getLeaseForGossip(ctx); pErr != nil {
+		return pErr.GoError()
 	}
 	return nil
 }


### PR DESCRIPTION
We previously relied on the first lease gossip happening when the replica was
first instantiated. This unfortunately may not have gossiped in the event that
a lease was not already held. In some cases (definitely requires sufficiently
long-running clusters), it's possible that the range containing the system
config table wouldn't start with a lease and the system config table would
then never be gossiped. This was recently happening on blue.

This change does a few things:

- Adds a context to the `Replica.maybeGossipSystemConfig` and
  `Replica.maybeGossipNodeLivness` methods and also returns error from both.
- Simplifies the code in `Store.maybeGossipSystemData` and now use a more
  appropriately-named constant for the gossip interval. Cleaned up comments.
- Instead of relying on the lease to be held when a replica is first
  instantiated by the store, *potentially* re-gossip node liveness and system
  config data any time a replica acquires the range lease for system data range.

+cc @cockroachdb/stability

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12798)
<!-- Reviewable:end -->
