### PR TITLE
storage: add a "raftlog.behind" metric

### DIFF
--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -199,6 +199,10 @@ var (
 		Help: "Number of pending heartbeats and responses waiting to be coalesced",
 	}
 
+	// Raft log metrics.
+	metaRaftLogBehindCount = metric.Metadata{Name: "raftlog.behind",
+		Help: "Number of Raft log entries followers are behind"}
+
 	// Replica queue metrics.
 	metaGCQueueSuccesses = metric.Metadata{Name: "queue.gc.process.success",
 		Help: "Number of replicas successfully processed by the GC queue"}
@@ -422,6 +426,9 @@ type StoreMetrics struct {
 	RaftRcvdMsgTimeoutNow     *metric.Counter
 	RaftRcvdMsgDropped        *metric.Counter
 
+	// Raft log metrics.
+	RaftLogBehindCount *metric.Gauge
+
 	// A map for conveniently finding the appropriate metric. The individual
 	// metric references must exist as AddMetricStruct adds them by reflection
 	// on this struct and does not process map types.
@@ -606,6 +613,9 @@ func newStoreMetrics(sampleInterval time.Duration) *StoreMetrics {
 		// This Gauge measures the number of heartbeats queued up just before
 		// the queue is cleared, to avoid flapping wildly.
 		RaftCoalescedHeartbeatsPending: metric.NewGauge(metaRaftCoalescedHeartbeatsPending),
+
+		// Raft log metrics.
+		RaftLogBehindCount: metric.NewGauge(metaRaftLogBehindCount),
 
 		// Replica queue metrics.
 		GCQueueSuccesses:                          metric.NewCounter(metaGCQueueSuccesses),

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4594,10 +4594,12 @@ func calcGoodReplicas(
 			if !leader {
 				goodReplicas++
 			} else if progress, ok := raftStatus.Progress[uint64(rd.ReplicaID)]; ok {
-				// TODO(peter): Put more thought into this value. A single range
-				// can process thousands of ops/sec, so a replica that is 100 Raft
-				// log entries behind is fairly current.
-				const behindThreshold = 100
+				// A single range can process thousands of ops/sec, so a replica that
+				// is 10 Raft log entries behind is fairly current. Setting this value
+				// to 0 makes the under-replicated metric overly sensitive. Setting
+				// this value too high and the metric doesn't show all of the
+				// under-replicated replicas.
+				const behindThreshold = 10
 				// TODO(peter): progress.Match will be 0 if this node recently
 				// became the leader. Presume such replicas are up to date until we
 				// hear otherwise. This is a bit of a hack.

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4495,6 +4495,7 @@ type replicaMetrics struct {
 	rangeCounter    bool
 	unavailable     bool
 	underreplicated bool
+	behindCount     int64
 }
 
 func (r *Replica) metrics(
@@ -4568,7 +4569,8 @@ func calcReplicaMetrics(
 	}
 
 	if m.rangeCounter {
-		goodReplicas := calcGoodReplicas(raftStatus, desc, livenessMap)
+		var goodReplicas int
+		goodReplicas, m.behindCount = calcGoodReplicas(raftStatus, desc, livenessMap)
 		if goodReplicas < computeQuorum(len(desc.Replicas)) {
 			m.unavailable = true
 		}
@@ -4582,18 +4584,27 @@ func calcReplicaMetrics(
 	return m
 }
 
-// calcGoodReplicas returns a count of the replicas which are on a live node
-// and, if there is a leader, which are not too far behind.
+// calcGoodReplicas returns a count of the "good" replicas and a count of the
+// number of log entries the replicas are behind. The log entry count is only
+// returned if the local replica is the leader. A "good" replica must be on a
+// live node and, if there is a leader, not too far behind.
 func calcGoodReplicas(
 	raftStatus *raft.Status, desc *roachpb.RangeDescriptor, livenessMap map[roachpb.NodeID]bool,
-) int {
+) (int, int64) {
 	leader := isRaftLeader(raftStatus)
 	var goodReplicas int
+	var behindCount int64
 	for _, rd := range desc.Replicas {
-		if livenessMap[rd.NodeID] {
-			if !leader {
+		live := livenessMap[rd.NodeID]
+		if !leader {
+			if live {
 				goodReplicas++
-			} else if progress, ok := raftStatus.Progress[uint64(rd.ReplicaID)]; ok {
+			}
+			continue
+		}
+
+		if progress, ok := raftStatus.Progress[uint64(rd.ReplicaID)]; ok {
+			if live {
 				// A single range can process thousands of ops/sec, so a replica that
 				// is 10 Raft log entries behind is fairly current. Setting this value
 				// to 0 makes the under-replicated metric overly sensitive. Setting
@@ -4608,7 +4619,11 @@ func calcGoodReplicas(
 					goodReplicas++
 				}
 			}
+			if progress.Match > 0 &&
+				progress.Match < raftStatus.Commit {
+				behindCount += int64(raftStatus.Commit) - int64(progress.Match)
+			}
 		}
 	}
-	return goodReplicas
+	return goodReplicas, behindCount
 }

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -7018,7 +7018,7 @@ func TestReplicaMetrics(t *testing.T) {
 		}
 		// The commit index is set so that a progress.Match value of 1 is behind
 		// and 2 is ok.
-		status.HardState.Commit = 102
+		status.HardState.Commit = 12
 		if lead == 1 {
 			status.SoftState.RaftState = raft.StateLeader
 		} else {
@@ -7061,6 +7061,7 @@ func TestReplicaMetrics(t *testing.T) {
 				rangeCounter:    true,
 				unavailable:     false,
 				underreplicated: false,
+				behindCount:     10,
 			}},
 		// The leader of a 2-replica range is up (only 1 replica present).
 		{2, 1, desc(1), status(1, progress(2)), live(1),
@@ -7069,6 +7070,7 @@ func TestReplicaMetrics(t *testing.T) {
 				rangeCounter:    true,
 				unavailable:     false,
 				underreplicated: true,
+				behindCount:     10,
 			}},
 		// The leader of a 2-replica range is up.
 		{2, 1, desc(1, 2), status(1, progress(2)), live(1),
@@ -7077,6 +7079,7 @@ func TestReplicaMetrics(t *testing.T) {
 				rangeCounter:    true,
 				unavailable:     true,
 				underreplicated: true,
+				behindCount:     10,
 			}},
 		// Both replicas of a 2-replica range are up to date.
 		{2, 1, desc(1, 2), status(1, progress(2, 2)), live(1, 2),
@@ -7085,6 +7088,7 @@ func TestReplicaMetrics(t *testing.T) {
 				rangeCounter:    true,
 				unavailable:     false,
 				underreplicated: false,
+				behindCount:     20,
 			}},
 		// Both replicas of a 2-replica range are up to date (local replica is not leader)
 		{2, 2, desc(1, 2), status(2, progress(2, 2)), live(1, 2),
@@ -7093,6 +7097,7 @@ func TestReplicaMetrics(t *testing.T) {
 				rangeCounter:    false,
 				unavailable:     false,
 				underreplicated: false,
+				behindCount:     0,
 			}},
 		// Both replicas of a 2-replica range are live, but follower is behind.
 		{2, 1, desc(1, 2), status(1, progress(2, 1)), live(1, 2),
@@ -7101,6 +7106,7 @@ func TestReplicaMetrics(t *testing.T) {
 				rangeCounter:    true,
 				unavailable:     true,
 				underreplicated: true,
+				behindCount:     21,
 			}},
 		// Both replicas of a 2-replica range are up to date, but follower is dead.
 		{2, 1, desc(1, 2), status(1, progress(2, 2)), live(1),
@@ -7109,6 +7115,7 @@ func TestReplicaMetrics(t *testing.T) {
 				rangeCounter:    true,
 				unavailable:     true,
 				underreplicated: true,
+				behindCount:     20,
 			}},
 		// The leader of a 3-replica range is up.
 		{3, 1, desc(1, 2, 3), status(1, progress(1)), live(1),
@@ -7117,6 +7124,7 @@ func TestReplicaMetrics(t *testing.T) {
 				rangeCounter:    true,
 				unavailable:     true,
 				underreplicated: true,
+				behindCount:     11,
 			}},
 		// All replicas of a 3-replica range are up to date.
 		{3, 1, desc(1, 2, 3), status(1, progress(2, 2, 2)), live(1, 2, 3),
@@ -7125,6 +7133,7 @@ func TestReplicaMetrics(t *testing.T) {
 				rangeCounter:    true,
 				unavailable:     false,
 				underreplicated: false,
+				behindCount:     30,
 			}},
 		// All replicas of a 3-replica range are up to date (match = 0 is
 		// considered up to date).
@@ -7134,38 +7143,43 @@ func TestReplicaMetrics(t *testing.T) {
 				rangeCounter:    true,
 				unavailable:     false,
 				underreplicated: false,
+				behindCount:     20,
 			}},
-		// All replica of a 3-replica range are live but one replica is behind.
+		// All replicas of a 3-replica range are live but one replica is behind.
 		{3, 1, desc(1, 2, 3), status(1, progress(2, 2, 1)), live(1, 2, 3),
 			replicaMetrics{
 				leader:          true,
 				rangeCounter:    true,
 				unavailable:     false,
 				underreplicated: true,
+				behindCount:     31,
 			}},
-		// All replica of a 3-replica range are live but two replicas are behind.
+		// All replicas of a 3-replica range are live but two replicas are behind.
 		{3, 1, desc(1, 2, 3), status(1, progress(2, 1, 1)), live(1, 2, 3),
 			replicaMetrics{
 				leader:          true,
 				rangeCounter:    true,
 				unavailable:     true,
 				underreplicated: true,
+				behindCount:     32,
 			}},
-		// All replica of a 3-replica range are up to date, but one replica is dead.
+		// All replicas of a 3-replica range are up to date, but one replica is dead.
 		{3, 1, desc(1, 2, 3), status(1, progress(2, 2, 2)), live(1, 2),
 			replicaMetrics{
 				leader:          true,
 				rangeCounter:    true,
 				unavailable:     false,
 				underreplicated: true,
+				behindCount:     30,
 			}},
-		// All replica of a 3-replica range are up to date, but two replicas are dead.
+		// All replicas of a 3-replica range are up to date, but two replicas are dead.
 		{3, 1, desc(1, 2, 3), status(1, progress(2, 2, 2)), live(1),
 			replicaMetrics{
 				leader:          true,
 				rangeCounter:    true,
 				unavailable:     true,
 				underreplicated: true,
+				behindCount:     30,
 			}},
 		// Range has no leader, local replica is the range counter.
 		{3, 1, desc(1, 2, 3), status(0, progress(2, 2, 2)), live(1, 2, 3),

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3738,6 +3738,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 		rangeCount                int64
 		unavailableRangeCount     int64
 		underreplicatedRangeCount int64
+		behindCount               int64
 	)
 
 	timestamp := s.cfg.Clock.Now()
@@ -3776,6 +3777,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 				underreplicatedRangeCount++
 			}
 		}
+		behindCount += metrics.behindCount
 		return true // more
 	})
 
@@ -3789,6 +3791,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 	s.metrics.RangeCount.Update(rangeCount)
 	s.metrics.UnavailableRangeCount.Update(unavailableRangeCount)
 	s.metrics.UnderReplicatedRangeCount.Update(underreplicatedRangeCount)
+	s.metrics.RaftLogBehindCount.Update(behindCount)
 
 	return nil
 }


### PR DESCRIPTION
Add a new raftlog.behind metric which counts the number of Raft log
entries followers are behind.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12800)
<!-- Reviewable:end -->
