### PR TITLE
sql/parser: disallow octal literals

### DIFF
--- a/pkg/sql/parser/scan.go
+++ b/pkg/sql/parser/scan.go
@@ -620,6 +620,16 @@ func (s *Scanner) scanNumber(lval *sqlSymType, ch int) {
 			return
 		}
 
+		// Strip off leading zeros from non-hex (decimal) literals so that
+		// constant.MakeFromLiteral doesn't inappropriately interpret the
+		// string as an octal literal. Note: we can't use strings.TrimLeft
+		// here, because it will truncate '0' to ''.
+		if !isHex {
+			for len(lval.str) > 1 && lval.str[0] == '0' {
+				lval.str = lval.str[1:]
+			}
+		}
+
 		lval.id = ICONST
 		intConst := constant.MakeFromLiteral(lval.str, token.INT, 0)
 		if intConst.Kind() == constant.Unknown {

--- a/pkg/sql/parser/scan_test.go
+++ b/pkg/sql/parser/scan_test.go
@@ -229,12 +229,16 @@ func TestScanNumber(t *testing.T) {
 		expected string
 		id       int
 	}{
+		{`0`, `0`, ICONST},
+		{`000`, `0`, ICONST},
 		{`1`, `1`, ICONST},
 		{`0x1`, `0x1`, ICONST},
 		{`0X2`, `0X2`, ICONST},
 		{`0xff`, `0xff`, ICONST},
 		{`0xff.`, `0xff`, ICONST},
 		{`12345`, `12345`, ICONST},
+		{`08`, `8`, ICONST},
+		{`0011`, `11`, ICONST},
 		{`1.`, `1.`, FCONST},
 		{`.1`, `.1`, FCONST},
 		{`1..2`, `1`, ICONST},
@@ -410,7 +414,6 @@ func TestScanError(t *testing.T) {
 		{`1.0x`, "invalid hexadecimal numeric literal"},
 		{`0x0x`, "invalid hexadecimal numeric literal"},
 		{`00x0x`, "invalid hexadecimal numeric literal"},
-		{`08`, "could not make constant int from literal \"08\""},
 		{`x'zzz'`, "invalid hexadecimal string literal"},
 		{`X'zzz'`, "invalid hexadecimal string literal"},
 		{`x'beef\x41'`, "invalid hexadecimal string literal"},


### PR DESCRIPTION
Hi!

I'm joining the team next month and figured I'd start getting my feet wet in the codebase. #7205 (disallowing octal literals) seemed like an easy place to start. Won't be offended in the slightest if y'all would rather solve this another way, but following are "cleaner" implementations strategies that failed:

* Explicitly specifying the base when calling `constant.MakeFromLiteral`. But nope, the API doesn't support that.
* Doing string conversion ourselves using `strconv`, which *does* allow explicitly specifying the base, then passing the resulting int64 directly to `constant.MakeInt64`. But this isn't workable for literals that overflow an int64 because, though `math/big.SetString` allows explicitly specifying a base, `constant.MakeIntBig` doesn't exist.
* Stripping leading zeros without requiring a second loop over the literal. But you can't strip leading zeros from a hexadecimal literal, nor can you strip a zero if it's the last remaining character in the literal. Handling these edge cases on the first pass through the literal is awkward, at least with my limited go foo.

/cc @nvanbenschoten it seems like it's mostly your code I've ruined!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12803)
<!-- Reviewable:end -->
