### PR TITLE
server: Increase defaultMaxOffset to 500ms

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -46,8 +46,12 @@ import (
 
 // Context defaults.
 const (
+	// On Azure, clock offsets between 250ms and 500ms are common. On
+	// AWS and GCE, clock offsets generally stay below 250ms.
+	// See comments on Config.MaxOffset for more on this setting.
+	defaultMaxOffset = 500 * time.Millisecond
+
 	defaultCGroupMemPath            = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
-	defaultMaxOffset                = 250 * time.Millisecond
 	defaultCacheSize                = 512 << 20 // 512 MB
 	defaultSQLMemoryPoolSize        = 512 << 20 // 512 MB
 	defaultScanInterval             = 10 * time.Minute
@@ -118,7 +122,12 @@ type Config struct {
 	// Environment Variable: COCKROACH_LINEARIZABLE
 	Linearizable bool
 
-	// Maximum clock offset for the cluster.
+	// Maximum allowed clock offset for the cluster. If observed clock
+	// offsets exceed this limit, inconsistency may result, and servers
+	// will panic to minimize the likelihood of inconsistent data.
+	// Increasing this value will increase time to recovery after
+	// failures, and increase the frequency and impact of
+	// ReadWithinUncertaintyIntervalError.
 	// Environment Variable: COCKROACH_MAX_OFFSET
 	MaxOffset time.Duration
 


### PR DESCRIPTION
On Azure, clock offsets between 250ms and 500ms appear to be common;
this has been showing up in both our test runs and beta clusters.
500ms appears to be a safer default for MaxOffset.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12821)
<!-- Reviewable:end -->
