### PR TITLE
sql/pgwire: report 'integer_datetimes' status param to clients

### DIFF
--- a/pkg/acceptance/c_test.go
+++ b/pkg/acceptance/c_test.go
@@ -83,6 +83,10 @@ void intervalPrint(PGinterval interval) {
 }
 
 int dateEqual(PGdate left, PGdate right) {
+	// Only check the fields we explicitly set. The uninitialized fields for our
+	// expected result will have non-deterministic values, and those same fields
+	// may be populated in the actual result by libpqtypes after decoding the
+	// database query's output.
 	if (left.isbc != right.isbc) {
 		return 0;
 	}
@@ -95,15 +99,6 @@ int dateEqual(PGdate left, PGdate right) {
 	if (left.mday != right.mday) {
 		return 0;
 	}
-	if (left.jday != right.jday) {
-		return 0;
-	}
-	if (left.yday != right.yday) {
-		return 0;
-	}
-	if (left.wday != right.wday) {
-		return 0;
-	}
 	return 1;
 }
 
@@ -112,12 +107,10 @@ void datePrint(PGdate date) {
 	fprintf(stderr, "year=%d\n", date.year);
 	fprintf(stderr, "mon=%d\n", date.mon);
 	fprintf(stderr, "mday=%d\n", date.mday);
-	fprintf(stderr, "jday=%d\n", date.jday);
-	fprintf(stderr, "yday=%d\n", date.yday);
-	fprintf(stderr, "wday=%d\n", date.wday);
 }
 
 int timeEqual(PGtime left, PGtime right) {
+	// Only check the fields we explicitly set. See comment on dateEqual.
 	if (left.hour != right.hour) {
 		return 0;
 	}
@@ -133,13 +126,7 @@ int timeEqual(PGtime left, PGtime right) {
 	if (left.withtz != right.withtz) {
 		return 0;
 	}
-	if (left.isdst != right.isdst) {
-		return 0;
-	}
 	if (left.gmtoff != right.gmtoff) {
-		return 0;
-	}
-	if (left.tzabbr != right.tzabbr) {
 		return 0;
 	}
 	return 1;
@@ -151,9 +138,7 @@ void timePrint(PGtime time) {
 	fprintf(stderr, "sec=%d\n", time.sec);
 	fprintf(stderr, "usec=%d\n", time.usec);
 	fprintf(stderr, "withtz=%d\n", time.withtz);
-	fprintf(stderr, "isdst=%d\n", time.isdst);
 	fprintf(stderr, "gmtoff=%d\n", time.gmtoff);
-	fprintf(stderr, "tzabbr=%d\n", time.tzabbr);
 }
 
 int timestampEqual(PGtimestamp left, PGtimestamp right) {
@@ -266,6 +251,7 @@ int main(int argc, char const *argv[]) {
 
 	// '2000-01-19 10:41:06'
 	PGtimestamp ts;
+	ts.epoch       = 948278466; // expected, but not used in PQputf.
 	ts.date.isbc   = 0;
 	ts.date.year   = 2000;
 	ts.date.mon    = 0;
@@ -274,6 +260,8 @@ int main(int argc, char const *argv[]) {
 	ts.time.min    = 41;
 	ts.time.sec    = 6;
 	ts.time.usec   = 0;
+	ts.time.withtz = 0;
+	ts.time.gmtoff = 0; // PQputf normalizes to GMT, so set and expect 0.
 	if (!PQputf(param, "%timestamp", &ts)) {
 		fprintf(stderr, "ERROR PQputf(timestamp): %s\n", PQgeterror());
 		return 1;
@@ -281,6 +269,7 @@ int main(int argc, char const *argv[]) {
 
 	// '2000-01-19 10:41:06-05'
 	PGtimestamp tstz;
+	tstz.epoch       = 948278466;
 	tstz.date.isbc   = 0;
 	tstz.date.year   = 2000;
 	tstz.date.mon    = 0;
@@ -289,7 +278,8 @@ int main(int argc, char const *argv[]) {
 	tstz.time.min    = 41;
 	tstz.time.sec    = 6;
 	tstz.time.usec   = 0;
-	tstz.time.gmtoff = -18000;
+	tstz.time.withtz = 1;
+	tstz.time.gmtoff = 0;
 	if (!PQputf(param, "%timestamptz", &tstz)) {
 		fprintf(stderr, "ERROR PQputf(timestamptz): %s\n", PQgeterror());
 		return 1;
@@ -338,32 +328,12 @@ int main(int argc, char const *argv[]) {
 				fprintf(stderr, "ERROR resultFormat=%d PQgetf(date): %s\n", resultFormat, PQgeterror());
 				return 1;
 			}
-			// TODO(tamird,nvanbenschoten): fix date decoding
-			// resultFormat={0,1} expected:
-			// isbc=1
-			// year=1401
-			// mon=0
-			// mday=19
-			// jday=-1804639424
-			// yday=32764
-			// wday=-1804639440
-			//
-			// got:
-			// isbc=1
-			// year=1401
-			// mon=0
-			// mday=19
-			// jday=1209739
-			// yday=18
-			// wday=0
 			if (!dateEqual(recvdate, date)) {
 				fprintf(stderr, "resultFormat=%d expected:\n", resultFormat);
 				datePrint(date);
 				fprintf(stderr, "\ngot:\n");
 				datePrint(recvdate);
-				if (0) {
-					return 1;
-				}
+				return 1;
 			}
 
 			PGnumeric recvnumeric1;
@@ -437,178 +407,14 @@ int main(int argc, char const *argv[]) {
 				fprintf(stderr, "ERROR resultFormat=%d PQgetf(timestamp): %s\n", resultFormat, PQgeterror());
 				return 1;
 			}
-			// TODO(tamird,nvanbenschoten): fix ts decoding
-			// resultFormat=0 expected:
-			// epoch=-1804639240
-			// date:
-			// isbc=0
-			// year=2000
-			// mon=0
-			// mday=19
-			// jday=428660541
-			// yday=32582
-			// wday=0
-			// time:
-			// hour=10
-			// min=41
-			// sec=6
-			// usec=0
-			// withtz=0
-			// isdst=0
-			// gmtoff=0
-			// tzabbr=-1804640132
-			//
-			// got:
-			// epoch=1848018046
-			// date:
-			// isbc=0
-			// year=150924
-			// mon=3
-			// mday=3
-			// jday=56845012
-			// yday=93
-			// wday=1
-			// time:
-			// hour=1
-			// min=44
-			// sec=30
-			// usec=803968
-			// withtz=0
-			// isdst=-1
-			// gmtoff=0
-			// tzabbr=-1804640132
-			//
-			//
-			// resultFormat=1 expected:
-			// epoch=-1804639240
-			// date:
-			// isbc=0
-			// year=2000
-			// mon=0
-			// mday=19
-			// jday=428660541
-			// yday=32582
-			// wday=0
-			// time:
-			// hour=10
-			// min=41
-			// sec=6
-			// usec=0
-			// withtz=0
-			// isdst=0
-			// gmtoff=0
-			// tzabbr=-1804640132
-			//
-			// got:
-			// epoch=948278466
-			// date:
-			// isbc=0
-			// year=2000
-			// mon=0
-			// mday=19
-			// jday=2451563
-			// yday=18
-			// wday=3
-			// time:
-			// hour=10
-			// min=41
-			// sec=6
-			// usec=0
-			// withtz=0
-			// isdst=-1
-			// gmtoff=0
-			// tzabbr=-1804640132
 			if (!timestampEqual(recvts, ts)) {
 				fprintf(stderr, "resultFormat=%d expected:\n", resultFormat);
 				timestampPrint(ts);
 				fprintf(stderr, "\ngot:\n");
 				timestampPrint(recvts);
-				if (0) {
-					return 1;
-				}
+				return 1;
 			}
 
-			// TODO(tamird,nvanbenschoten): fix ts decoding
-			// resultFormat=0 expected:
-			// epoch=430804992
-			// date:
-			// isbc=0
-			// year=2000
-			// mon=0
-			// mday=19
-			// jday=4195360
-			// yday=0
-			// wday=0
-			// time:
-			// hour=10
-			// min=41
-			// sec=6
-			// usec=0
-			// withtz=32764
-			// isdst=430774272
-			// gmtoff=-18000
-			// tzabbr=-1804640132
-			//
-			// got:
-			// epoch=1925327458
-			// date:
-			// isbc=0
-			// year=150926
-			// mon=8
-			// mday=14
-			// jday=56845906
-			// yday=256
-			// wday=6
-			// time:
-			// hour=20
-			// min=34
-			// sec=42
-			// usec=131968
-			// withtz=1
-			// isdst=-1
-			// gmtoff=0
-			// tzabbr=-1804640132
-			//
-			//
-			// resultFormat=1 expected:
-			// epoch=430804992
-			// date:
-			// isbc=0
-			// year=2000
-			// mon=0
-			// mday=19
-			// jday=4195360
-			// yday=0
-			// wday=0
-			// time:
-			// hour=10
-			// min=41
-			// sec=6
-			// usec=0
-			// withtz=32764
-			// isdst=430774272
-			// gmtoff=-18000
-			// tzabbr=-1804640132
-			//
-			// got:
-			// epoch=948296466
-			// date:
-			// isbc=0
-			// year=2000
-			// mon=0
-			// mday=19
-			// jday=2451563
-			// yday=18
-			// wday=3
-			// time:
-			// hour=15
-			// min=41
-			// sec=6
-			// usec=0
-			// withtz=1
-			// isdst=0
-			// gmtoff=0
-			// tzabbr=-1804640132
 			PGtimestamp recvtstz;
 			if (!PQgetf(result, 0, "%timestamptz", i++, &recvtstz)) {
 				fprintf(stderr, "ERROR resultFormat=%d PQgetf(timestamptz): %s\n", resultFormat, PQgeterror());
@@ -619,9 +425,7 @@ int main(int argc, char const *argv[]) {
 				timestampPrint(tstz);
 				fprintf(stderr, "\ngot:\n");
 				timestampPrint(recvtstz);
-				if (0) {
-					return 1;
-				}
+				return 1;
 			}
 	}
 

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -240,6 +240,11 @@ func parseOptions(data []byte) (sql.SessionArgs, error) {
 var statusReportParams = map[string]string{
 	"client_encoding": "UTF8",
 	"DateStyle":       "ISO",
+	// All datetime binary formats expect 64-bit integer microsecond values.
+	// This param needs to be provided to clients or some may provide 64-bit
+	// floating-point microsecond values instead, which was a legacy datetime
+	// binary format.
+	"integer_datetimes": "on",
 	// The latest version of the docs that was consulted during the development
 	// of this package. We specify this version to avoid having to support old
 	// code paths which various client tools fall back to if they can't

--- a/pkg/sql/pgwire_test.go
+++ b/pkg/sql/pgwire_test.go
@@ -1163,6 +1163,7 @@ func TestSQLNetworkMetrics(t *testing.T) {
 	defer cleanupFn()
 
 	const minbytes = 20
+	const maxbytes = 350
 
 	// Make sure we're starting at 0.
 	if _, _, err := checkSQLNetworkMetrics(s, 0, 0, 0, 0); err != nil {
@@ -1173,7 +1174,7 @@ func TestSQLNetworkMetrics(t *testing.T) {
 	if err := trivialQuery(pgURL); err != nil {
 		t.Fatal(err)
 	}
-	bytesIn, bytesOut, err := checkSQLNetworkMetrics(s, minbytes, minbytes, 300, 300)
+	bytesIn, bytesOut, err := checkSQLNetworkMetrics(s, minbytes, minbytes, maxbytes, maxbytes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1182,7 +1183,7 @@ func TestSQLNetworkMetrics(t *testing.T) {
 	}
 
 	// A second query should give us more I/O.
-	_, _, err = checkSQLNetworkMetrics(s, bytesIn+minbytes, bytesOut+minbytes, 300, 300)
+	_, _, err = checkSQLNetworkMetrics(s, bytesIn+minbytes, bytesOut+minbytes, maxbytes, maxbytes)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fixes #12432.

Postgres has a legacy mode where the binary format of timestamps were
encoded as microseconds within float64s instead of microseconds within
int64s. This mode is still usable through a compiler flag, and results
in their code being littered with preprocessor checks for the
`HAVE_INT64_TIMESTAMP` identifier, like [this one](https://github.com/postgres/postgres/blob/1d25779284fe1ba08ecd57e647292a9deb241376/src/backend/utils/adt/timestamp.c#L255) in their timestamp
binary decoding logic. This mode is reported to clients through a status
report parameter called `integer_datetimes` on connection initialization.
Since some clients like libpq (C) and pgjdbc (Java) also support this legacy
mode, we needed to make sure we were passing this status param.

The changes to `acceptance/c_test.go` are somewhat subtle, but are
explained in the comment on `dateEqual`. For each of the `<type>Equal`
functions, we now only check the fields we explicitly set. This is
because the uninitialized fields for our expected result will have
non-deterministic values, and those same fields may be populated in
the actual result by libpqtypes after decoding the database query's
output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12842)
<!-- Reviewable:end -->
