### PR TITLE
storage: move the computation of the snapshot generated metric

### DIFF
--- a/pkg/storage/raft_transport.go
+++ b/pkg/storage/raft_transport.go
@@ -624,6 +624,7 @@ func (t *RaftTransport) SendSnapshot(
 	header SnapshotRequest_Header,
 	snap *OutgoingSnapshot,
 	newBatch func() engine.Batch,
+	sent func(),
 ) error {
 	var stream MultiRaft_RaftSnapshotClient
 	nodeID := header.RaftMessageRequest.ToReplica.NodeID
@@ -653,5 +654,5 @@ func (t *RaftTransport) SendSnapshot(
 		snapshotClientWithBreaker{
 			MultiRaft_RaftSnapshotClient: stream,
 			breaker: breaker,
-		}, storePool, header, snap, newBatch)
+		}, storePool, header, snap, newBatch, sent)
 }

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -3315,8 +3315,11 @@ func (r *Replica) sendSnapshot(
 		// Recipients can choose to decline snapshots.
 		CanDecline: true,
 	}
+	sent := func() {
+		r.store.metrics.RangeSnapshotsGenerated.Inc(1)
+	}
 	if err := r.store.cfg.Transport.SendSnapshot(
-		ctx, r.store.allocator.storePool, req, snap, r.store.Engine().NewBatch); err != nil {
+		ctx, r.store.allocator.storePool, req, snap, r.store.Engine().NewBatch, sent); err != nil {
 		return &preemptiveSnapshotError{
 			errors.Wrapf(err, "%s: change replicas aborted due to failed preemptive snapshot", r),
 		}

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -317,8 +317,6 @@ func (r *Replica) GetSnapshot(ctx context.Context, snapType string) (*OutgoingSn
 		log.Errorf(ctx, "error generating snapshot: %s", err)
 		return nil, err
 	}
-	log.Event(ctx, "snapshot generated")
-	r.store.metrics.RangeSnapshotsGenerated.Inc(1)
 	return &snapData, nil
 }
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2050,10 +2050,10 @@ func (s *Store) removePlaceholderLocked(rngID roachpb.RangeID) bool {
 		return true
 	case nil:
 		ctx := s.AnnotateCtx(context.TODO())
-		log.Fatalf(ctx, "range=%d: placeholder not found", rngID)
+		log.Fatalf(ctx, "r%d: placeholder not found", rngID)
 	default:
 		ctx := s.AnnotateCtx(context.TODO())
-		log.Fatalf(ctx, "range=%d: expected placeholder, got %T", rngID, exRng)
+		log.Fatalf(ctx, "r%d: expected placeholder, got %T", rngID, exRng)
 	}
 	return false // appease the compiler
 }
@@ -3184,21 +3184,21 @@ func sendSnapshot(
 			if len(resp.Message) > 0 {
 				declinedMsg = resp.Message
 			}
-			return errors.Errorf("range=%s: remote declined snapshot: %s",
+			return errors.Errorf("r%d: remote declined snapshot: %s",
 				header.State.Desc.RangeID, declinedMsg)
 		}
 		storePool.throttle(throttleFailed, storeID)
-		return errors.Errorf("range=%s: programming error: remote declined required snapshot: %s",
+		return errors.Errorf("r%d: programming error: remote declined required snapshot: %s",
 			header.State.Desc.RangeID, resp.Message)
 	case SnapshotResponse_ERROR:
 		storePool.throttle(throttleFailed, storeID)
-		return errors.Errorf("range=%s: remote couldn't accept snapshot with error: %s",
+		return errors.Errorf("r%d: remote couldn't accept snapshot with error: %s",
 			header.State.Desc.RangeID, resp.Message)
 	case SnapshotResponse_ACCEPTED:
 	// This is the response we're expecting. Continue with snapshot sending.
 	default:
 		storePool.throttle(throttleFailed, storeID)
-		return errors.Errorf("range=%s: server sent an invalid status during negotiation: %s",
+		return errors.Errorf("r%d: server sent an invalid status during negotiation: %s",
 			header.State.Desc.RangeID, resp.Status)
 	}
 
@@ -3274,23 +3274,23 @@ func sendSnapshot(
 
 	resp, err = stream.Recv()
 	if err != nil {
-		return errors.Wrapf(err, "range=%s: remote failed to apply snapshot", rangeID)
+		return errors.Wrapf(err, "r%d: remote failed to apply snapshot", rangeID)
 	}
 	// NB: wait for EOF which ensures that all processing on the server side has
 	// completed (such as defers that might be run after the previous message was
 	// received).
 	if unexpectedResp, err := stream.Recv(); err != io.EOF {
-		return errors.Errorf("range=%s: expected EOF, got resp=%v err=%v",
+		return errors.Errorf("r%d: expected EOF, got resp=%v err=%v",
 			rangeID, unexpectedResp, err)
 	}
 	switch resp.Status {
 	case SnapshotResponse_ERROR:
-		return errors.Errorf("range=%s: remote failed to apply snapshot for reason %s",
+		return errors.Errorf("r%d: remote failed to apply snapshot for reason %s",
 			rangeID, resp.Message)
 	case SnapshotResponse_APPLIED:
 		return nil
 	default:
-		return errors.Errorf("range=%s: server sent an invalid status during finalization: %s",
+		return errors.Errorf("r%d: server sent an invalid status during finalization: %s",
 			rangeID, resp.Status)
 	}
 }

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -2567,7 +2567,7 @@ func TestSendSnapshotThrottling(t *testing.T) {
 		sp := &fakeStorePool{}
 		expectedErr := errors.New("")
 		c := fakeSnapshotStream{nil, expectedErr}
-		err := sendSnapshot(ctx, c, sp, header, nil, newBatch)
+		err := sendSnapshot(ctx, c, sp, header, nil, newBatch, nil)
 		if sp.failedThrottles != 1 {
 			t.Fatalf("expected 1 failed throttle, but found %d", sp.failedThrottles)
 		}
@@ -2583,7 +2583,7 @@ func TestSendSnapshotThrottling(t *testing.T) {
 			Status: SnapshotResponse_DECLINED,
 		}
 		c := fakeSnapshotStream{resp, nil}
-		err := sendSnapshot(ctx, c, sp, header, nil, newBatch)
+		err := sendSnapshot(ctx, c, sp, header, nil, newBatch, nil)
 		if sp.declinedThrottles != 1 {
 			t.Fatalf("expected 1 declined throttle, but found %d", sp.declinedThrottles)
 		}
@@ -2600,7 +2600,7 @@ func TestSendSnapshotThrottling(t *testing.T) {
 			Status: SnapshotResponse_DECLINED,
 		}
 		c := fakeSnapshotStream{resp, nil}
-		err := sendSnapshot(ctx, c, sp, header, nil, newBatch)
+		err := sendSnapshot(ctx, c, sp, header, nil, newBatch, nil)
 		if sp.failedThrottles != 1 {
 			t.Fatalf("expected 1 failed throttle, but found %d", sp.failedThrottles)
 		}
@@ -2616,7 +2616,7 @@ func TestSendSnapshotThrottling(t *testing.T) {
 			Status: SnapshotResponse_ERROR,
 		}
 		c := fakeSnapshotStream{resp, nil}
-		err := sendSnapshot(ctx, c, sp, header, nil, newBatch)
+		err := sendSnapshot(ctx, c, sp, header, nil, newBatch, nil)
 		if sp.failedThrottles != 1 {
 			t.Fatalf("expected 1 failed throttle, but found %d", sp.failedThrottles)
 		}


### PR DESCRIPTION
Move the computation of the snapshot generated metric from
Replica.GetSnapshot to after it is sent. The previous location caused the
metric to be incremented when almost no work for the snapshot had been
done. If the snapshot was then rejected by the remote we'd see the
generated metric significantly higher than the applied snapshot metrics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12848)
<!-- Reviewable:end -->
