### PR TITLE
storage: add a raftlog.truncated metric

### DIFF
--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -202,6 +202,8 @@ var (
 	// Raft log metrics.
 	metaRaftLogBehindCount = metric.Metadata{Name: "raftlog.behind",
 		Help: "Number of Raft log entries followers are behind"}
+	metaRaftLogTruncated = metric.Metadata{Name: "raftlog.truncated",
+		Help: "Number of Raft log entries truncated"}
 
 	// Replica queue metrics.
 	metaGCQueueSuccesses = metric.Metadata{Name: "queue.gc.process.success",
@@ -428,6 +430,7 @@ type StoreMetrics struct {
 
 	// Raft log metrics.
 	RaftLogBehindCount *metric.Gauge
+	RaftLogTruncated   *metric.Counter
 
 	// A map for conveniently finding the appropriate metric. The individual
 	// metric references must exist as AddMetricStruct adds them by reflection
@@ -616,6 +619,7 @@ func newStoreMetrics(sampleInterval time.Duration) *StoreMetrics {
 
 		// Raft log metrics.
 		RaftLogBehindCount: metric.NewGauge(metaRaftLogBehindCount),
+		RaftLogTruncated:   metric.NewCounter(metaRaftLogTruncated),
 
 		// Replica queue metrics.
 		GCQueueSuccesses:                          metric.NewCounter(metaGCQueueSuccesses),

--- a/pkg/storage/raft_log_queue.go
+++ b/pkg/storage/raft_log_queue.go
@@ -237,7 +237,10 @@ func (rlq *raftLogQueue) process(ctx context.Context, r *Replica, _ config.Syste
 			Index:   oldestIndex,
 			RangeID: r.RangeID,
 		})
-		return rlq.db.Run(ctx, b)
+		if err := rlq.db.Run(ctx, b); err != nil {
+			return err
+		}
+		r.store.metrics.RaftLogTruncated.Inc(int64(truncatableIndexes))
 	}
 	return nil
 }


### PR DESCRIPTION
Raft log truncation seems to be correlated to performance blips. Provide
some insight as to how much work is being done.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12852)
<!-- Reviewable:end -->
