### PR TITLE
sql: use consistent spelling for 'SET TIME ZONE' in command tag

### DIFF
--- a/pkg/sql/parser/stmt.go
+++ b/pkg/sql/parser/stmt.go
@@ -305,7 +305,7 @@ func (*SetTransaction) StatementTag() string { return "SET TRANSACTION" }
 func (*SetTimeZone) StatementType() StatementType { return Ack }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*SetTimeZone) StatementTag() string { return "SET TIMEZONE" }
+func (*SetTimeZone) StatementTag() string { return "SET TIME ZONE" }
 
 // StatementType implements the Statement interface.
 func (*SetDefaultIsolation) StatementType() StatementType { return Ack }


### PR DESCRIPTION
Minor nit to fix this inconsistency:

```
root@:26257> SET TIME ZONE 'utc';
SET TIMEZONE
```

With this patch applied:

```
root@:26257> SET TIME ZONE 'utc';
SET TIME ZONE
```

Perhaps worth noting that Postgres's tag is just `SET`, if that matters.

```
benesch=# SET TIME ZONE 'utc';
SET
```

```
benesch=# BEGIN;
BEGIN
benesch=# SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
SET
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12867)
<!-- Reviewable:end -->
