### PR TITLE
sql/parser: implement a COALESCE builtin

### DIFF
--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -804,6 +804,23 @@ var Builtins = map[string][]Builtin{
 		},
 	},
 
+	"coalesce": {
+		Builtin{
+			Types:      AnyType{},
+			ReturnType: TypeAny,
+			category:   categoryComparison,
+			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
+				for _, arg := range args {
+					if arg != DNull {
+						return arg, nil
+					}
+				}
+				return DNull, nil
+			},
+			Info: "Returns the first non-null element.",
+		},
+	},
+
 	// Timestamp/Date functions.
 
 	"experimental_strftime": {

--- a/pkg/sql/testdata/builtin_function
+++ b/pkg/sql/testdata/builtin_function
@@ -1030,6 +1030,39 @@ SELECT GREATEST(1, 1.2)
 ----
 1.2
 
+query T
+SELECT COALESCE(NULL)
+----
+NULL
+
+query I
+SELECT COALESCE(NULL, GREATEST(NULL), NULL)
+----
+NULL
+
+query I
+SELECT COALESCE(2)
+----
+2
+
+query I
+SELECT COALESCE(2, 3)
+----
+2
+
+query T
+SELECT COALESCE('a', 'b')
+----
+a
+
+query I
+SELECT COALESCE(NULL, GREATEST(NULL), 2, GREATEST(3, 4), NULL)
+----
+2
+
+query error incompatible COALESCE expressions: expected 2 to be of type string, found type int
+SELECT COALESCE(2, '4')
+
 # Test float and int comparison.
 
 query BBBB


### PR DESCRIPTION
`COALESCE(a, b, ...)` returns the first non-null element passed to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12879)
<!-- Reviewable:end -->
