### PR TITLE
cli: make the interactive_tests more robust

### DIFF
--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -26,6 +26,18 @@ proc eexpect {text} {
     }
 }
 
+# Convenience function that sends Ctrl+C to the monitored process.
+proc interrupt {} {
+    send "\003"
+    sleep 0.4
+}
+
+# Tests that wish to concatenate a marker with the first line of
+# output need to exclude messages about the env. var
+# PROPOSER_EVALUATED_KV as this may be emitted before the logging
+# flags are handled.
+set silence_prop_eval_kv "2>&1 | grep -v 'running with experimental support for proposer-evaluated KV'"
+
 # Convenience functions to start/shutdown the server.
 # Preserves the invariant that the server's PID is saved
 # in `server_pid`.

--- a/pkg/cli/interactive_tests/test_client_side_checking.tcl
+++ b/pkg/cli/interactive_tests/test_client_side_checking.tcl
@@ -43,7 +43,7 @@ send "commit;\r"
 eexpect "ROLLBACK"
 eexpect root@
 
-send "\003"
+interrupt
 eexpect eof
 
 # Check that syntax errors are handled server-side by default when running non-interactive.

--- a/pkg/cli/interactive_tests/test_history.tcl
+++ b/pkg/cli/interactive_tests/test_history.tcl
@@ -56,13 +56,13 @@ eexpect "SELECT 1;"
 
 # Test that the client cannot terminate with Ctrl+C while
 # cursor is on recalled line
-send "\003"
+interrupt
 send "\rselect 1;\r"
 eexpect "1 row"
 eexpect root@
 
 # Finally terminate with Ctrl+C
-send "\003"
+interrupt
 eexpect eof
 
 stop_server $argv

--- a/pkg/cli/interactive_tests/test_local_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_local_cmds.tcl
@@ -62,7 +62,7 @@ eexpect "hello\\\\nworld"
 eexpect root@
 
 # Finally terminate with Ctrl+C.
-send "\003"
+interrupt
 eexpect eof
 
 spawn /bin/bash

--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -13,9 +13,8 @@ eexpect "CockroachDB"
 eexpect "starting cockroach node"
 
 # Stop it.
-send "\003"
-sleep 1
-send "\003"
+interrupt
+interrupt
 eexpect ":/# "
 
 # Check that a server started with --logtostderr
@@ -25,38 +24,34 @@ eexpect "CockroachDB"
 eexpect "starting cockroach node"
 
 # Stop it.
-send "\003"
-sleep 1
-send "\003"
+interrupt
+interrupt
 eexpect ":/# "
 
 # Check that --alsologtostderr can override the threshold
 # regardless of what --logtostderr has set.
-send "echo marker; $argv start --alsologtostderr=ERROR\r"
+send "echo marker; $argv start --alsologtostderr=ERROR $silence_prop_eval_kv\r"
 eexpect "marker\r\nCockroachDB node starting"
 
 # Stop it.
-send "\003"
-sleep 1
-send "\003"
+interrupt
+interrupt
 eexpect ":/# "
 
-send "echo marker; $argv start --alsologtostderr=ERROR --logtostderr\r"
+send "echo marker; $argv start --alsologtostderr=ERROR --logtostderr $silence_prop_eval_kv\r"
 eexpect "marker\r\nCockroachDB node starting"
 
 # Stop it.
-send "\003"
-sleep 1
-send "\003"
+interrupt
+interrupt
 eexpect ":/# "
 
-send "echo marker; $argv start --alsologtostderr=ERROR --logtostderr=false\r"
+send "echo marker; $argv start --alsologtostderr=ERROR --logtostderr=false $silence_prop_eval_kv\r"
 eexpect "marker\r\nCockroachDB node starting"
 
 # Stop it.
-send "\003"
-sleep 1
-send "\003"
+interrupt
+interrupt
 eexpect ":/# "
 
 # Start a regular server
@@ -65,7 +60,7 @@ send "$argv start >/dev/null 2>&1 & sleep 1\r"
 # Now test `quit` as non-start command, and test that `quit` does not
 # emit logging output between the point the command starts until it
 # prints the final ok message.
-send "echo marker; $argv quit\r"
+send "echo marker; $argv quit $silence_prop_eval_kv\r"
 set timeout 20
 eexpect "marker\r\nok\r\n:/# "
 set timeout 5
@@ -74,7 +69,7 @@ set timeout 5
 # that the default logging level is WARNING, so that no INFO messages
 # are printed between the marker and the (first line) error message
 # from quit. Quit will error out because the server is already stopped.
-send "echo marker; $argv quit --logtostderr\r"
+send "echo marker; $argv quit --logtostderr $silence_prop_eval_kv\r"
 eexpect "marker\r\nError"
 eexpect ":/# "
 

--- a/pkg/cli/interactive_tests/test_multiline_statements.tcl
+++ b/pkg/cli/interactive_tests/test_multiline_statements.tcl
@@ -43,7 +43,7 @@ send "\r"
 eexpect root@
 send "SELECT\r"
 eexpect " ->"
-send "\003"
+interrupt
 eexpect root@
 
 # Test that BEGIN .. without COMMIT begins a multi-line statement.
@@ -70,7 +70,7 @@ send "SELECT 1; COMMIT;\r"
 eexpect "1 row"
 eexpect root@
 
-send "\003"
+interrupt
 eexpect eof
 
 stop_server $argv

--- a/pkg/cli/interactive_tests/test_pretty.tcl
+++ b/pkg/cli/interactive_tests/test_pretty.tcl
@@ -18,7 +18,7 @@ eexpect ":/# "
 
 # Check that tables are not pretty-printed when input is not a terminal
 # and --pretty is not speciifed.
-send "echo begin; echo 'select 1;' | $argv sql\r"
+send "echo begin; echo 'select 1;' | $argv sql $silence_prop_eval_kv\r"
 eexpect "begin\r\n1 row\r\n1\r\n1\r\n"
 
 # Check that tables are pretty-printed when input is a terminal

--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -78,7 +78,7 @@ send "woof\r"
 eexpect "carl@"
 
 # Terminate with Ctrl+C.
-send "\003"
+interrupt
 
 eexpect $prompt
 

--- a/pkg/cli/interactive_tests/test_server_sig.tcl
+++ b/pkg/cli/interactive_tests/test_server_sig.tcl
@@ -24,7 +24,7 @@ eexpect ":/# "
 send "$argv start & echo $! >server_pid; fg\r"
 eexpect "restarted"
 
-send "\003"
+interrupt
 eexpect "initiating graceful shutdown"
 eexpect "shutdown completed"
 eexpect ":/# "
@@ -38,9 +38,9 @@ eexpect ":/# "
 send "$argv start & echo $! >server_pid; fg\r"
 eexpect "restarted"
 
-send "\003"
+interrupt
 eexpect "initiating graceful shutdown"
-send "\003"
+interrupt
 eexpect "hard shutdown"
 eexpect ":/# "
 


### PR DESCRIPTION
- This patch ensures that the tests in test_missing_log_output.tcl
  properly work even when the tests are running with env var
  COCKROACH_PROPOSER_EVALUATED_KV set to true.

- This patch also ensure that the tests that rely on a double Ctrl+C
  to stop a server wait a little bit after issuing a Ctrl+C, to work
  around a bug in (some versions of) bash/readline that would cause
  the next character after Ctrl+C to be swallowed and the test
  to spuriously fail.

Fixes #12853.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12882)
<!-- Reviewable:end -->
