### PR TITLE
cli: display timestamps in parseable format

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -737,7 +737,7 @@ func Example_sql() {
 	// 2
 }
 
-func Example_sql_escape() {
+func Example_sql_format() {
 	c, err := newCLITest(nil, false)
 	if err != nil {
 		panic(err)
@@ -760,6 +760,9 @@ func Example_sql_escape() {
 	c.RunWithArgs([]string{"sql", "-e", "insert into t.u values (0, 0, 0, 0, 0)"})
 	c.RunWithArgs([]string{"sql", "-e", "show columns from t.u"})
 	c.RunWithArgs([]string{"sql", "-e", "select * from t.u"})
+	c.RunWithArgs([]string{"sql", "-e", "create table t.times (bare timestamp, withtz timestamptz)"})
+	c.RunWithArgs([]string{"sql", "-e", "insert into t.times values ('2016-01-25 10:10:10', '2016-01-25 10:10:10-05:00')"})
+	c.RunWithArgs([]string{"sql", "-e", "select * from t.times"})
 	c.RunWithArgs([]string{"sql", "--pretty", "-e", "select * from t.t"})
 	c.RunWithArgs([]string{"sql", "--pretty", "-e", "show columns from t.u"})
 	c.RunWithArgs([]string{"sql", "--pretty", "-e", "select * from t.u"})
@@ -821,6 +824,14 @@ func Example_sql_escape() {
 	// 1 row
 	// "\"foo"	"\\foo"	"foo\nbar"	"\u03ba\u1f79\u03c3\u03bc\u03b5"	"\u070885"
 	// 0	0	0	0	0
+	// sql -e create table t.times (bare timestamp, withtz timestamptz)
+	// CREATE TABLE
+	// sql -e insert into t.times values ('2016-01-25 10:10:10', '2016-01-25 10:10:10-05:00')
+	// INSERT 1
+	// sql -e select * from t.times
+	// 1 row
+	// bare	withtz
+	// 2016-01-25 10:10:10+00:00	2016-01-25 15:10:10+00:00
 	// sql --pretty -e select * from t.t
 	// +--------------------------------+--------------------------------+
 	// |               s                |               d                |

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"strings"
 	"text/tabwriter"
+	"time"
 	"unicode"
 	"unicode/utf8"
 
@@ -32,6 +33,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/pq"
@@ -424,6 +426,10 @@ func formatVal(val driver.Value, showPrintableUnicode bool, showNewLinesAndTabs 
 			}
 		}
 		return fmt.Sprintf("%+q", t)
+
+	case time.Time:
+		return t.Format(parser.TimestampNodeFormat)
 	}
+
 	return fmt.Sprint(val)
 }

--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -882,7 +882,7 @@ const (
 	timestampWithNamedZoneFormat          = timestampFormat + " MST"
 	timestampRFC3339NanoWithoutZoneFormat = "2006-01-02T15:04:05"
 
-	timestampNodeFormat = timestampFormat + ".999999-07:00"
+	TimestampNodeFormat = timestampFormat + ".999999-07:00"
 )
 
 var timeFormats = []string{
@@ -893,7 +893,7 @@ var timeFormats = []string{
 	timestampFormat,
 	timestampWithNamedZoneFormat,
 	timestampRFC3339NanoWithoutZoneFormat,
-	timestampNodeFormat,
+	TimestampNodeFormat,
 }
 
 func parseTimestampInLocation(s string, loc *time.Location) (time.Time, error) {
@@ -1008,7 +1008,7 @@ func (d *DTimestamp) Format(buf *bytes.Buffer, f FmtFlags) {
 	if !f.bareStrings {
 		buf.WriteByte('\'')
 	}
-	buf.WriteString(d.UTC().Format(timestampNodeFormat))
+	buf.WriteString(d.UTC().Format(TimestampNodeFormat))
 	if !f.bareStrings {
 		buf.WriteByte('\'')
 	}
@@ -1112,7 +1112,7 @@ func (d *DTimestampTZ) Format(buf *bytes.Buffer, f FmtFlags) {
 	if !f.bareStrings {
 		buf.WriteByte('\'')
 	}
-	buf.WriteString(d.UTC().Format(timestampNodeFormat))
+	buf.WriteString(d.UTC().Format(TimestampNodeFormat))
 	if !f.bareStrings {
 		buf.WriteByte('\'')
 	}


### PR DESCRIPTION
Currently, the CLI displays time.Time objects returned by libpq in their
native Go format, which is not a format understood by Cockroach's
timestamp parser. Before this change:
```
> SELECT now()
2017-01-10 16:25:09.900823 +0000 +0000

> SELECT '2017-01-10 16:25:09.900823 +0000 +0000'::TIMESTAMPTZ;
pq: could not parse '2017-01-10 16:25:09.900823 +0000 +0000' as type timestamp
```

After this change:
```
> SELECT now()
2017-01-10 16:25:09.900823+00:00

> SELECT '2017-01-10 16:25:09.900823+00:00'::TIMESTAMPTZ;
2017-01-10 16:25:09.900823+00:00
```
Fixes #12819.

This format string already exists in two places in the repository:

* https://github.com/cockroachdb/cockroach/blob/bab403fb37b8158ef5dbff180238334fd978a70b/pkg/sql/parser/datum.go#L885

* https://github.com/cockroachdb/cockroach/blob/bab403fb37b8158ef5dbff180238334fd978a70b/pkg/sql/pgwire/types.go#L313

I wasn't sure which of these to choose, if any, nor how to expose them, so I figured this patch was a good place to launch the discussion. This patch also breaks any documentation example that returns a timestamp without first casting it to a string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12886)
<!-- Reviewable:end -->
