### PR TITLE
Update README.md with new roadmap link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ https://github.com/cockroachdb/cockroach#design).
 ## Status
 
 CockroachDB is currently in beta. See our
-[Roadmap](https://github.com/cockroachdb/cockroach/issues/12854) and
+[1.0 Roadmap](https://github.com/cockroachdb/cockroach/issues/12854) and
 [Issues](https://github.com/cockroachdb/cockroach/issues) for a list of features planned or in development.
 
 ## Docs

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ https://github.com/cockroachdb/cockroach#design).
 ## Status
 
 CockroachDB is currently in beta. See our
-[Roadmap](https://github.com/cockroachdb/cockroach/wiki) and
+[Roadmap](https://github.com/cockroachdb/cockroach/issues/12854) and
 [Issues](https://github.com/cockroachdb/cockroach/issues) for a list of features planned or in development.
 
 ## Docs


### PR DESCRIPTION
Previous roadmap link was pointing to the wiki, where the roadmap used to sit. There were too many copies of the roadmap, and the roadmap now sits solely in a GitHub issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12889)
<!-- Reviewable:end -->
