### PR TITLE
distsql: make SUM_INT the final stage of COUNT

### DIFF
--- a/pkg/sql/distsqlplan/aggregator_funcs.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs.go
@@ -49,7 +49,7 @@ var DistAggregationTable = map[distsqlrun.AggregatorSpec_Func]DistAggregationInf
 
 	distsqlrun.AggregatorSpec_COUNT: {
 		LocalStage: distsqlrun.AggregatorSpec_COUNT,
-		FinalStage: distsqlrun.AggregatorSpec_SUM,
+		FinalStage: distsqlrun.AggregatorSpec_SUM_INT,
 	},
 
 	distsqlrun.AggregatorSpec_MAX: {

--- a/pkg/sql/distsqlplan/aggregator_funcs_test.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs_test.go
@@ -199,6 +199,17 @@ func checkDistAggregationInfo(
 	procs = append(procs, finalProc)
 	rowsDist := runTestFlow(t, srv, procs...)
 
+	if len(rowsDist[0]) != len(rowsNonDist[0]) {
+		t.Errorf("different row lengths (dist: %d non-dist: %d)", len(rowsDist[0]), len(rowsNonDist[0]))
+	} else {
+		for i := range rowsDist[0] {
+			tDist := rowsDist[0][i].Type.String()
+			tNonDist := rowsNonDist[0][i].Type.String()
+			if tDist != tNonDist {
+				t.Errorf("different type for column %d (dist: %s non-dist: %s)", i, tDist, tNonDist)
+			}
+		}
+	}
 	if rowsDist.String() != rowsNonDist.String() {
 		t.Errorf("different results\nw/o local stage:   %s\nwith local stage:  %s", rowsNonDist, rowsDist)
 	}


### PR DESCRIPTION
Correcting a mistake in the aggregate functions table: SUM returns a DECIMAL,
SUM_INT was added specifically for aggregating COUNT.

Improving the test to cross-check the types (which would have detected this).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12894)
<!-- Reviewable:end -->
