### PR TITLE
require at least TLS1.2

### DIFF
--- a/pkg/security/tls.go
+++ b/pkg/security/tls.go
@@ -106,8 +106,7 @@ func newServerTLSConfig(certPEM, keyPEM, caPEM []byte) (*tls.Config, error) {
 		// Prefer the server-specified suite.
 		PreferServerCipherSuites: true,
 
-		// TLS 1.1 and 1.2 support is crappy out there. Let's use 1.0.
-		MinVersion: tls.VersionTLS10,
+		MinVersion: tls.VersionTLS12,
 
 		// Should we disable session resumption? This may break forward secrecy.
 		// SessionTicketsDisabled: true,


### PR DESCRIPTION
Allowing TLS1.0 voids PCI compliance.[1] The client requires TLS1.2 already. This PR makes the server require it as well.

[1]https://blog.varonis.com/ssl-and-tls-1-0-no-longer-acceptable-for-pci-compliance/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12898)
<!-- Reviewable:end -->
