### PR TITLE
cli: always reject extra positional arguments

### DIFF
--- a/pkg/cli/cert.go
+++ b/pkg/cli/cert.go
@@ -34,8 +34,7 @@ var createCACertCmd = &cobra.Command{
 	Long: `
 Generates CA certificate and key, writing them to --ca-cert and --ca-key.
 `,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runCreateCACert),
+	RunE: MaybeDecorateGRPCError(runCreateCACert),
 }
 
 // runCreateCACert generates key pair and CA certificate and writes them
@@ -57,8 +56,7 @@ Generates node certificate and keys for a given node, writing them to
 --cert and --key. CA certificate and key must be passed in.
 At least one host should be passed in (either IP address or dns name).
 `,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runCreateNodeCert),
+	RunE: MaybeDecorateGRPCError(runCreateNodeCert),
 }
 
 // runCreateNodeCert generates key pair and CA certificate and writes them
@@ -84,8 +82,7 @@ Generates a client certificate and key, writing them to --cert and --key.
 CA certificate and key must be passed in.
 The certs directory should contain a CA cert and key.
 `,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runCreateClientCert),
+	RunE: MaybeDecorateGRPCError(runCreateClientCert),
 }
 
 // runCreateClientCert generates key pair and CA certificate and writes them

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -59,6 +59,13 @@ var cockroachCmd = &cobra.Command{
 	Short: "CockroachDB command-line interface and server",
 	// TODO(cdo): Add a pointer to the docs in Long.
 	Long: `CockroachDB command-line interface and server.`,
+	// Disable automatic printing of usage information whenever an error
+	// occurs. Many errors are not the result of a bad command invocation,
+	// e.g. attempting to start a node on an in-use port, and printing the
+	// usage information in these cases obscures the cause of the error.
+	// Commands should manually print usage information when the error is,
+	// in fact, a result of a bad invocation, e.g. too many arguments.
+	SilenceUsage: true,
 }
 
 // isInteractive indicates whether both stdin and stdout refer to the

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -65,12 +65,21 @@ type cliTestParams struct {
 	insecure bool
 }
 
-func newCLITest(params cliTestParams) (cliTest, error) {
+func newCLITest(params cliTestParams) cliTest {
 	c := cliTest{t: params.t}
+
+	fail := func(err interface{}) {
+		if c.t != nil {
+			defer c.logScope.Close(c.t)
+			c.t.Fatal(err)
+		} else {
+			panic(err)
+		}
+	}
 
 	certsDir, err := ioutil.TempDir("", "cli-test")
 	if err != nil {
-		return cliTest{}, err
+		fail(err)
 	}
 	c.certsDir = certsDir
 
@@ -86,10 +95,7 @@ func newCLITest(params cliTestParams) (cliTest, error) {
 
 	s, err := serverutils.StartServerRaw(base.TestServerArgs{Insecure: params.insecure})
 	if err != nil {
-		if c.t != nil {
-			c.logScope.Close(c.t)
-		}
-		return cliTest{}, err
+		fail(err)
 	}
 	c.TestServer = s.(*server.TestServer)
 
@@ -125,11 +131,10 @@ func newCLITest(params cliTestParams) (cliTest, error) {
 	// can be captured.
 	osStderr = os.Stdout
 
-	return c, nil
+	return c
 }
 
-// cleanup cleans up after the test.
-// It also stops the test server is runStopper is true.
+// cleanup cleans up after the test, stopping the server if necessary.
 // The log files are removed if the test has succeeded.
 func (c cliTest) cleanup() {
 	if c.t != nil {
@@ -246,10 +251,7 @@ func (c cliTest) RunWithArgs(origArgs []string) {
 func TestQuit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	c, err := newCLITest(cliTestParams{t: t})
-	if err != nil {
-		panic(err)
-	}
+	c := newCLITest(cliTestParams{t: t})
 	defer c.cleanup()
 
 	c.Run("quit")
@@ -305,10 +307,7 @@ communicate with a secure cluster\).
 }
 
 func Example_basic() {
-	c, err := newCLITest(cliTestParams{})
-	if err != nil {
-		panic(err)
-	}
+	c := newCLITest(cliTestParams{})
 	defer c.cleanup()
 
 	c.Run("debug kv put a 1 b 2 c 3")
@@ -366,10 +365,7 @@ func Example_basic() {
 }
 
 func Example_quoted() {
-	c, err := newCLITest(cliTestParams{})
-	if err != nil {
-		panic(err)
-	}
+	c := newCLITest(cliTestParams{})
 	defer c.cleanup()
 
 	c.Run(`debug kv put a\x00 日本語`)                                  // UTF-8 input text
@@ -403,10 +399,7 @@ func Example_quoted() {
 }
 
 func Example_insecure() {
-	c, err := newCLITest(cliTestParams{insecure: true})
-	if err != nil {
-		panic(err)
-	}
+	c := newCLITest(cliTestParams{insecure: true})
 	defer c.cleanup()
 
 	c.Run("debug kv put a 1 b 2")
@@ -421,10 +414,7 @@ func Example_insecure() {
 }
 
 func Example_ranges() {
-	c, err := newCLITest(cliTestParams{})
-	if err != nil {
-		panic(err)
-	}
+	c := newCLITest(cliTestParams{})
 	defer c.cleanup()
 
 	c.Run("debug kv put a 1 b 2 c 3 d 4")
@@ -486,10 +476,7 @@ func Example_ranges() {
 }
 
 func Example_logging() {
-	c, err := newCLITest(cliTestParams{})
-	if err != nil {
-		panic(err)
-	}
+	c := newCLITest(cliTestParams{})
 	defer c.cleanup()
 
 	c.RunWithArgs([]string{"sql", "--alsologtostderr=false", "-e", "select 1"})
@@ -527,10 +514,7 @@ func Example_logging() {
 }
 
 func Example_cput() {
-	c, err := newCLITest(cliTestParams{})
-	if err != nil {
-		panic(err)
-	}
+	c := newCLITest(cliTestParams{})
 	defer c.cleanup()
 
 	c.Run("debug kv put a 1 b 2 c 3 d 4")
@@ -559,10 +543,7 @@ func Example_cput() {
 }
 
 func Example_max_results() {
-	c, err := newCLITest(cliTestParams{})
-	if err != nil {
-		panic(err)
-	}
+	c := newCLITest(cliTestParams{})
 	defer c.cleanup()
 
 	c.Run("debug kv put a 1 b 2 c 3 d 4")
@@ -594,10 +575,7 @@ func Example_max_results() {
 }
 
 func Example_zone() {
-	c, err := newCLITest(cliTestParams{})
-	if err != nil {
-		panic(err)
-	}
+	c := newCLITest(cliTestParams{})
 	defer c.cleanup()
 
 	c.Run("zone ls")
@@ -692,10 +670,7 @@ func Example_zone() {
 }
 
 func Example_sql() {
-	c, err := newCLITest(cliTestParams{})
-	if err != nil {
-		panic(err)
-	}
+	c := newCLITest(cliTestParams{})
 	defer c.cleanup()
 
 	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.f (x int, y int); insert into t.f values (42, 69)"})
@@ -747,10 +722,7 @@ func Example_sql() {
 }
 
 func Example_sql_format() {
-	c, err := newCLITest(cliTestParams{})
-	if err != nil {
-		panic(err)
-	}
+	c := newCLITest(cliTestParams{})
 	defer c.cleanup()
 
 	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.t (s string, d string);"})
@@ -898,10 +870,7 @@ func Example_sql_format() {
 }
 
 func Example_user() {
-	c, err := newCLITest(cliTestParams{})
-	if err != nil {
-		panic(err)
-	}
+	c := newCLITest(cliTestParams{})
 	defer c.cleanup()
 
 	c.Run("user ls")
@@ -1025,10 +994,7 @@ Use "cockroach [command] --help" for more information about a command.
 }
 
 func Example_node() {
-	c, err := newCLITest(cliTestParams{})
-	if err != nil {
-		panic(err)
-	}
+	c := newCLITest(cliTestParams{})
 	defer c.cleanup()
 
 	// Refresh time series data, which is required to retrieve stats.
@@ -1059,10 +1025,7 @@ func Example_node() {
 func TestFreeze(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	c, err := newCLITest(cliTestParams{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	c := newCLITest(cliTestParams{})
 	defer c.cleanup()
 
 	assertOutput := func(msg string) {
@@ -1091,10 +1054,7 @@ func TestNodeStatus(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	start := timeutil.Now()
-	c, err := newCLITest(cliTestParams{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	c := newCLITest(cliTestParams{})
 	defer c.cleanup()
 
 	// Refresh time series data, which is required to retrieve stats.

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -60,8 +60,13 @@ type cliTest struct {
 	logScope log.TestLogScope
 }
 
-func newCLITest(t *testing.T, insecure bool) (cliTest, error) {
-	c := cliTest{t: t}
+type cliTestParams struct {
+	t        *testing.T
+	insecure bool
+}
+
+func newCLITest(params cliTestParams) (cliTest, error) {
+	c := cliTest{t: params.t}
 
 	certsDir, err := ioutil.TempDir("", "cli-test")
 	if err != nil {
@@ -75,20 +80,20 @@ func newCLITest(t *testing.T, insecure bool) (cliTest, error) {
 	baseCfg.InitDefaults()
 	InitCLIDefaults()
 
-	if t != nil {
-		c.logScope = log.Scope(t, "")
+	if c.t != nil {
+		c.logScope = log.Scope(c.t, "")
 	}
 
-	s, err := serverutils.StartServerRaw(base.TestServerArgs{Insecure: insecure})
+	s, err := serverutils.StartServerRaw(base.TestServerArgs{Insecure: params.insecure})
 	if err != nil {
-		if t != nil {
-			c.logScope.Close(t)
+		if c.t != nil {
+			c.logScope.Close(c.t)
 		}
 		return cliTest{}, err
 	}
 	c.TestServer = s.(*server.TestServer)
 
-	if insecure {
+	if params.insecure {
 		c.cleanupFunc = func() error { return nil }
 	} else {
 		// Copy these assets to disk from embedded strings, so this test can
@@ -123,10 +128,10 @@ func newCLITest(t *testing.T, insecure bool) (cliTest, error) {
 	return c, nil
 }
 
-// stop cleans up after the test.
+// cleanup cleans up after the test.
 // It also stops the test server is runStopper is true.
 // The log files are removed if the test has succeeded.
-func (c cliTest) stop(runStopper bool) {
+func (c cliTest) cleanup() {
 	if c.t != nil {
 		defer c.logScope.Close(c.t)
 	}
@@ -134,9 +139,15 @@ func (c cliTest) stop(runStopper bool) {
 	// Restore stderr.
 	osStderr = os.Stderr
 
-	if runStopper {
+	select {
+	case <-c.Stopper().ShouldStop():
+		// If ShouldStop() doesn't block, that means someone has already
+		// called Stop(). We just need to wait.
+		<-c.Stopper().IsStopped()
+	default:
 		c.Stopper().Stop()
 	}
+
 	if err := c.cleanupFunc(); err != nil {
 		panic(err)
 	}
@@ -235,16 +246,14 @@ func (c cliTest) RunWithArgs(origArgs []string) {
 func TestQuit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	c, err := newCLITest(t, false)
+	c, err := newCLITest(cliTestParams{t: t})
 	if err != nil {
 		panic(err)
 	}
-	// This test does not need to invoke the stopper because
-	// "quit" will have taken care of this.
-	defer c.stop(false)
+	defer c.cleanup()
 
 	c.Run("quit")
-	// Wait until this async command stops the server.
+	// Wait until this async command cleanups the server.
 	<-c.Stopper().IsStopped()
 
 	// NB: if this test is ever flaky due to port reuse, we could run against
@@ -296,11 +305,11 @@ communicate with a secure cluster\).
 }
 
 func Example_basic() {
-	c, err := newCLITest(nil, false)
+	c, err := newCLITest(cliTestParams{})
 	if err != nil {
 		panic(err)
 	}
-	defer c.stop(true)
+	defer c.cleanup()
 
 	c.Run("debug kv put a 1 b 2 c 3")
 	c.Run("debug kv scan")
@@ -357,11 +366,11 @@ func Example_basic() {
 }
 
 func Example_quoted() {
-	c, err := newCLITest(nil, false)
+	c, err := newCLITest(cliTestParams{})
 	if err != nil {
 		panic(err)
 	}
-	defer c.stop(true)
+	defer c.cleanup()
 
 	c.Run(`debug kv put a\x00 日本語`)                                  // UTF-8 input text
 	c.Run(`debug kv put a\x01 \u65e5\u672c\u8a9e`)                   // explicit Unicode code points
@@ -394,11 +403,11 @@ func Example_quoted() {
 }
 
 func Example_insecure() {
-	c, err := newCLITest(nil, true)
+	c, err := newCLITest(cliTestParams{insecure: true})
 	if err != nil {
 		panic(err)
 	}
-	defer c.stop(true)
+	defer c.cleanup()
 
 	c.Run("debug kv put a 1 b 2")
 	c.Run("debug kv scan")
@@ -412,11 +421,11 @@ func Example_insecure() {
 }
 
 func Example_ranges() {
-	c, err := newCLITest(nil, false)
+	c, err := newCLITest(cliTestParams{})
 	if err != nil {
 		panic(err)
 	}
-	defer c.stop(true)
+	defer c.cleanup()
 
 	c.Run("debug kv put a 1 b 2 c 3 d 4")
 	c.Run("debug kv scan")
@@ -477,11 +486,11 @@ func Example_ranges() {
 }
 
 func Example_logging() {
-	c, err := newCLITest(nil, false)
+	c, err := newCLITest(cliTestParams{})
 	if err != nil {
 		panic(err)
 	}
-	defer c.stop(true)
+	defer c.cleanup()
 
 	c.RunWithArgs([]string{"sql", "--alsologtostderr=false", "-e", "select 1"})
 	c.RunWithArgs([]string{"sql", "--log-backtrace-at=foo.go:1", "-e", "select 1"})
@@ -518,11 +527,11 @@ func Example_logging() {
 }
 
 func Example_cput() {
-	c, err := newCLITest(nil, false)
+	c, err := newCLITest(cliTestParams{})
 	if err != nil {
 		panic(err)
 	}
-	defer c.stop(true)
+	defer c.cleanup()
 
 	c.Run("debug kv put a 1 b 2 c 3 d 4")
 	c.Run("debug kv scan")
@@ -550,11 +559,11 @@ func Example_cput() {
 }
 
 func Example_max_results() {
-	c, err := newCLITest(nil, false)
+	c, err := newCLITest(cliTestParams{})
 	if err != nil {
 		panic(err)
 	}
-	defer c.stop(true)
+	defer c.cleanup()
 
 	c.Run("debug kv put a 1 b 2 c 3 d 4")
 	c.Run("debug kv scan --max-results=3")
@@ -585,11 +594,11 @@ func Example_max_results() {
 }
 
 func Example_zone() {
-	c, err := newCLITest(nil, false)
+	c, err := newCLITest(cliTestParams{})
 	if err != nil {
 		panic(err)
 	}
-	defer c.stop(true)
+	defer c.cleanup()
 
 	c.Run("zone ls")
 	c.Run("zone set system --file=./testdata/zone_attrs.yaml")
@@ -683,11 +692,11 @@ func Example_zone() {
 }
 
 func Example_sql() {
-	c, err := newCLITest(nil, false)
+	c, err := newCLITest(cliTestParams{})
 	if err != nil {
 		panic(err)
 	}
-	defer c.stop(true)
+	defer c.cleanup()
 
 	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.f (x int, y int); insert into t.f values (42, 69)"})
 	c.RunWithArgs([]string{"sql", "-e", "select 3", "-e", "select * from t.f"})
@@ -738,11 +747,11 @@ func Example_sql() {
 }
 
 func Example_sql_format() {
-	c, err := newCLITest(nil, false)
+	c, err := newCLITest(cliTestParams{})
 	if err != nil {
 		panic(err)
 	}
-	defer c.stop(true)
+	defer c.cleanup()
 
 	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.t (s string, d string);"})
 	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'foo', 'printable ASCII')"})
@@ -889,11 +898,11 @@ func Example_sql_format() {
 }
 
 func Example_user() {
-	c, err := newCLITest(nil, false)
+	c, err := newCLITest(cliTestParams{})
 	if err != nil {
 		panic(err)
 	}
-	defer c.stop(true)
+	defer c.cleanup()
 
 	c.Run("user ls")
 	c.Run("user ls --pretty")
@@ -1016,11 +1025,11 @@ Use "cockroach [command] --help" for more information about a command.
 }
 
 func Example_node() {
-	c, err := newCLITest(nil, false)
+	c, err := newCLITest(cliTestParams{})
 	if err != nil {
 		panic(err)
 	}
-	defer c.stop(true)
+	defer c.cleanup()
 
 	// Refresh time series data, which is required to retrieve stats.
 	if err := c.WriteSummaries(); err != nil {
@@ -1050,11 +1059,11 @@ func Example_node() {
 func TestFreeze(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	c, err := newCLITest(t, false)
+	c, err := newCLITest(cliTestParams{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.stop(true)
+	defer c.cleanup()
 
 	assertOutput := func(msg string) {
 		if !strings.HasSuffix(strings.TrimSpace(msg), "ok") {
@@ -1082,11 +1091,11 @@ func TestNodeStatus(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	start := timeutil.Now()
-	c, err := newCLITest(t, false)
+	c, err := newCLITest(cliTestParams{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.stop(true)
+	defer c.cleanup()
 
 	// Refresh time series data, which is required to retrieve stats.
 	if err := c.WriteSummaries(); err != nil {

--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -38,8 +38,7 @@ var dumpCmd = &cobra.Command{
 Dump SQL tables of a cockroach database. If the table name
 is omitted, dump all tables in the database.
 `,
-	RunE:         MaybeDecorateGRPCError(runDump),
-	SilenceUsage: true,
+	RunE: MaybeDecorateGRPCError(runDump),
 }
 
 func runDump(cmd *cobra.Command, args []string) error {

--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -41,10 +41,7 @@ import (
 func TestDumpRow(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	c, err := newCLITest(cliTestParams{t: t})
-	if err != nil {
-		t.Fatal(err)
-	}
+	c := newCLITest(cliTestParams{t: t})
 	defer c.cleanup()
 
 	const create = `
@@ -132,10 +129,7 @@ INSERT INTO t (i, f, s, b, d, t, n, o, e, tz, e1, e2, s1) VALUES
 func TestDumpFlags(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	c, err := newCLITest(cliTestParams{t: t})
-	if err != nil {
-		t.Fatal(err)
-	}
+	c := newCLITest(cliTestParams{t: t})
 	defer c.cleanup()
 
 	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.f (x int, y int); insert into t.f values (42, 69)"})
@@ -190,10 +184,7 @@ INSERT INTO f (x, y) VALUES
 func TestDumpMultipleTables(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	c, err := newCLITest(cliTestParams{t: t})
-	if err != nil {
-		t.Fatal(err)
-	}
+	c := newCLITest(cliTestParams{t: t})
 	defer c.cleanup()
 
 	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.f (x int, y int); insert into t.f values (42, 69)"})
@@ -270,10 +261,7 @@ func dumpSingleTable(w io.Writer, conn *sqlConn, dbName string, tName string) er
 func TestDumpBytes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	c, err := newCLITest(cliTestParams{t: t})
-	if err != nil {
-		t.Fatal(err)
-	}
+	c := newCLITest(cliTestParams{t: t})
 	defer c.cleanup()
 
 	url, cleanup := sqlutils.PGUrl(t, c.ServingAddr(), "TestDumpBytes", url.User(security.RootUser))
@@ -337,10 +325,7 @@ func init() {
 func TestDumpRandom(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	c, err := newCLITest(cliTestParams{t: t})
-	if err != nil {
-		t.Fatal(err)
-	}
+	c := newCLITest(cliTestParams{t: t})
 	defer c.cleanup()
 
 	url, cleanup := sqlutils.PGUrl(t, c.ServingAddr(), "TestDumpRandom", url.User(security.RootUser))

--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -41,11 +41,11 @@ import (
 func TestDumpRow(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	c, err := newCLITest(t, false)
+	c, err := newCLITest(cliTestParams{t: t})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.stop(true)
+	defer c.cleanup()
 
 	const create = `
 	CREATE DATABASE d;
@@ -132,11 +132,11 @@ INSERT INTO t (i, f, s, b, d, t, n, o, e, tz, e1, e2, s1) VALUES
 func TestDumpFlags(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	c, err := newCLITest(t, false)
+	c, err := newCLITest(cliTestParams{t: t})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.stop(true)
+	defer c.cleanup()
 
 	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.f (x int, y int); insert into t.f values (42, 69)"})
 
@@ -190,11 +190,11 @@ INSERT INTO f (x, y) VALUES
 func TestDumpMultipleTables(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	c, err := newCLITest(t, false)
+	c, err := newCLITest(cliTestParams{t: t})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.stop(true)
+	defer c.cleanup()
 
 	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.f (x int, y int); insert into t.f values (42, 69)"})
 	c.RunWithArgs([]string{"sql", "-e", "create table t.g (x int, y int); insert into t.g values (3, 4)"})
@@ -270,11 +270,11 @@ func dumpSingleTable(w io.Writer, conn *sqlConn, dbName string, tName string) er
 func TestDumpBytes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	c, err := newCLITest(t, false)
+	c, err := newCLITest(cliTestParams{t: t})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.stop(true)
+	defer c.cleanup()
 
 	url, cleanup := sqlutils.PGUrl(t, c.ServingAddr(), "TestDumpBytes", url.User(security.RootUser))
 	defer cleanup()
@@ -337,11 +337,11 @@ func init() {
 func TestDumpRandom(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	c, err := newCLITest(t, false)
+	c, err := newCLITest(cliTestParams{t: t})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.stop(true)
+	defer c.cleanup()
 
 	url, cleanup := sqlutils.PGUrl(t, c.ServingAddr(), "TestDumpRandom", url.User(security.RootUser))
 	defer cleanup()

--- a/pkg/cli/gen.go
+++ b/pkg/cli/gen.go
@@ -41,6 +41,10 @@ many Unix-like systems, use "--path=/usr/local/share/man/man1".
 }
 
 func runGenManCmd(cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		return usageAndError(cmd)
+	}
+
 	info := build.GetInfo()
 	header := &doc.GenManHeader{
 		Section: "1",
@@ -92,6 +96,9 @@ package (or an equivalent) and follow the post-install instructions.
 }
 
 func runGenAutocompleteCmd(cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		return usageAndError(cmd)
+	}
 	if err := cmd.Root().GenBashCompletionFile(autoCompletePath); err != nil {
 		return err
 	}

--- a/pkg/cli/kv.go
+++ b/pkg/cli/kv.go
@@ -74,8 +74,7 @@ var getCmd = &cobra.Command{
 	Long: `
 Fetches and displays the value for <key>.
 `,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runGet),
+	RunE: MaybeDecorateGRPCError(runGet),
 }
 
 func runGet(cmd *cobra.Command, args []string) error {
@@ -114,8 +113,7 @@ in pairs on the command line.
 
 WARNING: Modifying system or table keys can corrupt your cluster.
 `,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runPut),
+	RunE: MaybeDecorateGRPCError(runPut),
 }
 
 func runPut(cmd *cobra.Command, args []string) error {
@@ -156,8 +154,7 @@ pass nil for expValue. The expValue defaults to 1 if not specified.
 
 WARNING: Modifying system or table keys can corrupt your cluster.
 `,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runCPut),
+	RunE: MaybeDecorateGRPCError(runCPut),
 }
 
 func runCPut(cmd *cobra.Command, args []string) error {
@@ -201,8 +198,7 @@ flags.
 
 WARNING: Modifying system or table keys can corrupt your cluster.
 `,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runInc),
+	RunE: MaybeDecorateGRPCError(runInc),
 }
 
 func runInc(cmd *cobra.Command, args []string) error {
@@ -246,8 +242,7 @@ Deletes the values of one or more keys.
 
 WARNING: Modifying system or table keys can corrupt your cluster.
 `,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runDel),
+	RunE: MaybeDecorateGRPCError(runDel),
 }
 
 func runDel(cmd *cobra.Command, args []string) error {
@@ -283,8 +278,7 @@ Deletes the values for the range of keys [startKey, endKey).
 
 WARNING: Modifying system or table keys can corrupt your cluster.
 `,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runDelRange),
+	RunE: MaybeDecorateGRPCError(runDelRange),
 }
 
 func runDelRange(cmd *cobra.Command, args []string) error {
@@ -323,8 +317,7 @@ is specified then all (non-system) key/value pairs are retrieved. If no
 <end-key> is specified then all keys greater than or equal to <start-key>
 are retrieved.
 `,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runScan),
+	RunE: MaybeDecorateGRPCError(runScan),
 }
 
 func runScan(cmd *cobra.Command, args []string) error {
@@ -361,8 +354,7 @@ is specified then all (non-system) key/value pairs are retrieved. If no
 <end-key> is specified then all keys greater than or equal to <start-key>
 are retrieved.
 `,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runReverseScan),
+	RunE: MaybeDecorateGRPCError(runReverseScan),
 }
 
 func runReverseScan(cmd *cobra.Command, args []string) error {

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -45,8 +45,7 @@ var lsNodesCmd = &cobra.Command{
 	Displays IDs for all nodes in cluster, which can be used with the status and stores
 	commands.
 	`,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runLsNodes),
+	RunE: MaybeDecorateGRPCError(runLsNodes),
 }
 
 func runLsNodes(cmd *cobra.Command, args []string) error {
@@ -101,8 +100,7 @@ var statusNodeCmd = &cobra.Command{
 	If a node ID is specified, this will show the status for the corresponding node. If no node ID
 	is specified, this will display the status for all nodes in the cluster.
 	`,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runStatusNode),
+	RunE: MaybeDecorateGRPCError(runStatusNode),
 }
 
 func runStatusNode(cmd *cobra.Command, args []string) error {

--- a/pkg/cli/range.go
+++ b/pkg/cli/range.go
@@ -34,8 +34,7 @@ var lsRangesCmd = &cobra.Command{
 	Long: `
 Lists the ranges in a cluster.
 `,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runLsRanges),
+	RunE: MaybeDecorateGRPCError(runLsRanges),
 }
 
 func runLsRanges(cmd *cobra.Command, args []string) error {
@@ -90,8 +89,7 @@ var splitRangeCmd = &cobra.Command{
 	Long: `
 Splits the range containing <key> at <key>.
 `,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runSplitRange),
+	RunE: MaybeDecorateGRPCError(runSplitRange),
 }
 
 func runSplitRange(cmd *cobra.Command, args []string) error {

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -53,8 +53,7 @@ var sqlShellCmd = &cobra.Command{
 	Long: `
 Open a sql shell running against a cockroach database.
 `,
-	RunE:         MaybeDecorateGRPCError(runTerm),
-	SilenceUsage: true,
+	RunE: MaybeDecorateGRPCError(runTerm),
 }
 
 // cliState defines the current state of the CLI during

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -250,7 +250,11 @@ var ErrorCode = 1
 // storage devices ("stores") on this machine and --join as the list
 // of other active nodes used to join this node to the cockroach
 // cluster, if this is its first time connecting.
-func runStart(_ *cobra.Command, args []string) error {
+func runStart(cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		return usageAndError(cmd)
+	}
+
 	if startBackground {
 		return rerunBackground()
 	}

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -78,9 +78,8 @@ flags are required. If the cluster already exists, and this node is
 uninitialized, specify the --join flag to point to any healthy node
 (or list of nodes) already part of the cluster.
 `,
-	Example:      `  cockroach start --insecure --store=attrs=ssd,path=/mnt/ssd1 [--join=host:port,[host:port]]`,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runStart),
+	Example: `  cockroach start --insecure --store=attrs=ssd,path=/mnt/ssd1 [--join=host:port,[host:port]]`,
+	RunE:    MaybeDecorateGRPCError(runStart),
 }
 
 func setDefaultSizeParameters(ctx *server.Config) {
@@ -563,8 +562,7 @@ Shutdown the server. The first stage is drain, where any new requests
 will be ignored by the server. When all extant requests have been
 completed, the server exits.
 `,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runQuit),
+	RunE: MaybeDecorateGRPCError(runQuit),
 }
 
 // doShutdown attempts to trigger a server shutdown. When given an empty
@@ -670,8 +668,7 @@ nodes in the cluster should be terminated, all binaries updated, and only then
 restarted. A failed or incomplete invocation of this command can be rolled back
 using the --undo flag, or by restarting all the nodes in the cluster.
 `,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runFreezeCluster),
+	RunE: MaybeDecorateGRPCError(runFreezeCluster),
 }
 
 func runFreezeCluster(_ *cobra.Command, _ []string) error {

--- a/pkg/cli/user.go
+++ b/pkg/cli/user.go
@@ -33,8 +33,7 @@ var getUserCmd = &cobra.Command{
 	Long: `
 Fetches and displays the user for <username>.
 `,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runGetUser),
+	RunE: MaybeDecorateGRPCError(runGetUser),
 }
 
 func runGetUser(cmd *cobra.Command, args []string) error {
@@ -57,8 +56,7 @@ var lsUsersCmd = &cobra.Command{
 	Long: `
 List all users.
 `,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runLsUsers),
+	RunE: MaybeDecorateGRPCError(runLsUsers),
 }
 
 func runLsUsers(cmd *cobra.Command, args []string) error {
@@ -81,8 +79,7 @@ var rmUserCmd = &cobra.Command{
 	Long: `
 Remove an existing user by username.
 `,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runRmUser),
+	RunE: MaybeDecorateGRPCError(runRmUser),
 }
 
 func runRmUser(cmd *cobra.Command, args []string) error {
@@ -106,8 +103,7 @@ var setUserCmd = &cobra.Command{
 Create or update a user for the specified username, prompting
 for the password.
 `,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runSetUser),
+	RunE: MaybeDecorateGRPCError(runSetUser),
 }
 
 // runSetUser prompts for a password, then inserts the user and hash

--- a/pkg/cli/zone.go
+++ b/pkg/cli/zone.go
@@ -208,8 +208,7 @@ var getZoneCmd = &cobra.Command{
 Fetches and displays the zone configuration for the specified database or
 table.
 `,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runGetZone),
+	RunE: MaybeDecorateGRPCError(runGetZone),
 }
 
 // runGetZone retrieves the zone config for a given object id,
@@ -270,8 +269,7 @@ var lsZonesCmd = &cobra.Command{
 	Long: `
 List zone configs.
 `,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runLsZones),
+	RunE: MaybeDecorateGRPCError(runLsZones),
 }
 
 func runLsZones(cmd *cobra.Command, args []string) error {
@@ -344,8 +342,7 @@ var rmZoneCmd = &cobra.Command{
 	Long: `
 Remove an existing zone config for the specified database or table.
 `,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runRmZone),
+	RunE: MaybeDecorateGRPCError(runRmZone),
 }
 
 func runRmZone(cmd *cobra.Command, args []string) error {
@@ -414,8 +411,7 @@ EOF
 Note that the specified zone config is merged with the existing zone config for
 the database or table.
 `,
-	SilenceUsage: true,
-	RunE:         MaybeDecorateGRPCError(runSetZone),
+	RunE: MaybeDecorateGRPCError(runSetZone),
 }
 
 func readZoneConfig() (conf []byte, err error) {


### PR DESCRIPTION
`cockroach gen autocomplete`, `cockroach gen man`, and `cockroach start`
didn't reject unrecognized positional arguments. In the case of start in
particular, command line options inadvertently specified as positional
arguments would be silently ignored. This commit adds the missing check
to those three commands, thus fixing #6201.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12901)
<!-- Reviewable:end -->
