### PR TITLE
sql: print a summary of indices in the output of SHOW COLUMNS

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -803,12 +803,12 @@ func Example_sql_format() {
 	// INSERT 1
 	// sql -e show columns from t.u
 	// 5 rows
-	// Field	Type	Null	Default
-	// "\"foo"	INT	true	NULL
-	// "\\foo"	INT	true	NULL
-	// "foo\nbar"	INT	true	NULL
-	// "\u03ba\u1f79\u03c3\u03bc\u03b5"	INT	true	NULL
-	// "\u070885"	INT	true	NULL
+	// Field	Type	Null	Default	Indices
+	// "\"foo"	INT	true	NULL	{}
+	// "\\foo"	INT	true	NULL	{}
+	// "foo\nbar"	INT	true	NULL	{}
+	// "\u03ba\u1f79\u03c3\u03bc\u03b5"	INT	true	NULL	{}
+	// "\u070885"	INT	true	NULL	{}
 	// sql -e select * from t.u
 	// 1 row
 	// "\"foo"	"\\foo"	"foo\nbar"	"\u03ba\u1f79\u03c3\u03bc\u03b5"	"\u070885"
@@ -839,16 +839,16 @@ func Example_sql_format() {
 	// +--------------------------------+--------------------------------+
 	// (9 rows)
 	// sql --pretty -e show columns from t.u
-	// +----------+------+------+---------+
-	// |  Field   | Type | Null | Default |
-	// +----------+------+------+---------+
-	// | "foo     | INT  | true | NULL    |
-	// | \foo     | INT  | true | NULL    |
-	// | foo␤     | INT  | true | NULL    |
-	// | bar      |      |      |         |
-	// | κόσμε    | INT  | true | NULL    |
-	// | ܈85      | INT  | true | NULL    |
-	// +----------+------+------+---------+
+	// +----------+------+------+---------+---------+
+	// |  Field   | Type | Null | Default | Indices |
+	// +----------+------+------+---------+---------+
+	// | "foo     | INT  | true | NULL    | {}      |
+	// | \foo     | INT  | true | NULL    | {}      |
+	// | foo␤     | INT  | true | NULL    | {}      |
+	// | bar      |      |      |         |         |
+	// | κόσμε    | INT  | true | NULL    | {}      |
+	// | ܈85      | INT  | true | NULL    | {}      |
+	// +----------+------+------+---------+---------+
 	// (5 rows)
 	// sql --pretty -e select * from t.u
 	// +------+------+------------+-------+-----+

--- a/pkg/cli/sql_util_test.go
+++ b/pkg/cli/sql_util_test.go
@@ -62,15 +62,15 @@ SET
 		t.Fatal(err)
 	}
 
-	expectedCols := []string{"Field", "Type", "Null", "Default"}
+	expectedCols := []string{"Field", "Type", "Null", "Default", "Indices"}
 	if !reflect.DeepEqual(expectedCols, cols) {
 		t.Fatalf("expected:\n%v\ngot:\n%v", expectedCols, cols)
 	}
 
 	expectedRows := [][]string{
-		{`parentID`, `INT`, `false`, `NULL`},
-		{`name`, `STRING`, `false`, `NULL`},
-		{`id`, `INT`, `true`, `NULL`},
+		{`parentID`, `INT`, `false`, `NULL`, `{primary}`},
+		{`name`, `STRING`, `false`, `NULL`, `{primary}`},
+		{`id`, `INT`, `true`, `NULL`, `{}`},
 	}
 	if !reflect.DeepEqual(expectedRows, rows) {
 		t.Fatalf("expected:\n%v\ngot:\n%v", expectedRows, rows)
@@ -82,13 +82,13 @@ SET
 	}
 
 	expected = `
-+----------+--------+-------+---------+
-|  Field   |  Type  | Null  | Default |
-+----------+--------+-------+---------+
-| parentID | INT    | false | NULL    |
-| name     | STRING | false | NULL    |
-| id       | INT    | true  | NULL    |
-+----------+--------+-------+---------+
++----------+--------+-------+---------+-----------+
+|  Field   |  Type  | Null  | Default |  Indices  |
++----------+--------+-------+---------+-----------+
+| parentID | INT    | false | NULL    | {primary} |
+| name     | STRING | false | NULL    | {primary} |
+| id       | INT    | true  | NULL    | {}        |
++----------+--------+-------+---------+-----------+
 (3 rows)
 `
 

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -854,9 +854,9 @@ CREATE TABLE t.test (a CHAR PRIMARY KEY, b CHAR, c CHAR, INDEX foo (c));
 	mt.CheckQueryResults(
 		"SHOW COLUMNS FROM t.test",
 		[][]string{
-			{"a", "STRING", "false", "NULL"},
-			{"d", "STRING", "true", "NULL"},
-			{"e", "STRING", "true", "NULL"},
+			{"a", "STRING", "false", "NULL", "{primary,ufo}"},
+			{"d", "STRING", "true", "NULL", "{ufo}"},
+			{"e", "STRING", "true", "NULL", "{}"},
 		},
 	)
 

--- a/pkg/sql/pgwire_test.go
+++ b/pkg/sql/pgwire_test.go
@@ -461,8 +461,8 @@ func TestPGPreparedQuery(t *testing.T) {
 		},
 		"SHOW COLUMNS FROM system.users": {
 			baseTest.
-				Results("username", "STRING", false, gosql.NullBool{}).
-				Results("hashedPassword", "BYTES", true, gosql.NullBool{}),
+				Results("username", "STRING", false, gosql.NullBool{}, "{primary}").
+				Results("hashedPassword", "BYTES", true, gosql.NullBool{}, "{}"),
 		},
 		"SHOW DATABASES": {
 			baseTest.Results("d").Results("information_schema").Results("pg_catalog").Results("system"),

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -223,6 +223,7 @@ func (p *planner) ShowColumns(n *parser.ShowColumns) (planNode, error) {
 		{Name: "Type", Typ: parser.TypeString},
 		{Name: "Null", Typ: parser.TypeBool},
 		{Name: "Default", Typ: parser.TypeString},
+		{Name: "Indices", Typ: parser.TypeString},
 	}
 	return &delayedNode{
 		name:    "SHOW COLUMNS FROM " + tn.String(),
@@ -230,14 +231,25 @@ func (p *planner) ShowColumns(n *parser.ShowColumns) (planNode, error) {
 		constructor: func(p *planner) (planNode, error) {
 			const getColumnsQuery = `
 				SELECT
-					COLUMN_NAME AS "Field", 
-					DATA_TYPE AS "Type", 
+					COLUMN_NAME AS "Field",
+					DATA_TYPE AS "Type",
 					(IS_NULLABLE != 'NO') AS "Null",
-					COLUMN_DEFAULT AS "Default"
-				FROM information_schema.columns
-				WHERE 
-					TABLE_SCHEMA=$1 AND 
-					TABLE_NAME=$2
+					COLUMN_DEFAULT AS "Default",
+					IF(inames[1] IS NULL, ARRAY[]:::STRING[], inames) AS "Indices"
+				FROM
+					(SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT, ORDINAL_POSITION,
+									ARRAY_AGG(INDEX_NAME) AS inames
+						 FROM
+								 (SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT, ORDINAL_POSITION
+										FROM information_schema.columns
+									 WHERE TABLE_SCHEMA=$1 AND TABLE_NAME=$2)
+								 LEFT OUTER JOIN
+								 (SELECT COLUMN_NAME, INDEX_NAME
+										FROM information_schema.statistics
+									 WHERE TABLE_SCHEMA=$1 AND TABLE_NAME=$2)
+								 USING(COLUMN_NAME)
+						GROUP BY COLUMN_NAME, DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT, ORDINAL_POSITION
+					 )
 				ORDER BY ORDINAL_POSITION`
 
 			db := tn.Database()

--- a/pkg/sql/testdata/alter_table
+++ b/pkg/sql/testdata/alter_table
@@ -22,13 +22,13 @@ ALTER TABLE t RENAME TO t.*
 statement ok
 ALTER TABLE t ADD b INT
 
-query TTBT colnames
+query TTBTT colnames
 SHOW COLUMNS FROM t
 ----
-Field Type Null  Default
-a     INT  false NULL
-f     INT  true  NULL
-b     INT  true  NULL
+Field Type Null  Default Indices
+a     INT  false NULL    {primary,t_f_idx}
+f     INT  true  NULL    {t_f_idx}
+b     INT  true  NULL    {}
 
 statement ok
 ALTER TABLE t ADD CONSTRAINT foo UNIQUE (b)
@@ -376,15 +376,15 @@ ALTER TABLE tt ADD COLUMN s DECIMAL UNIQUE NOT NULL
 statement ok
 ALTER TABLE tt ADD t DECIMAL UNIQUE DEFAULT 4.0
 
-query TTBT colnames
+query TTBTT colnames
 SHOW COLUMNS FROM tt
 ----
-Field  Type     Null   Default
-a      INT      false  NULL
-q      DECIMAL  false  NULL
-r      DECIMAL  true   NULL
-s      DECIMAL  false  NULL
-t      DECIMAL  true   4.0
+Field  Type     Null   Default Indices
+a      INT      false  NULL    {primary,tt_s_key,tt_t_key}
+q      DECIMAL  false  NULL    {}
+r      DECIMAL  true   NULL    {}
+s      DECIMAL  false  NULL    {tt_s_key}
+t      DECIMAL  true   4.0     {tt_t_key}
 
 # Default values can be added and changed after table creation.
 statement ok
@@ -517,12 +517,12 @@ ALTER TABLE privs ADD CONSTRAINT foo UNIQUE (b)
 
 user root
 
-query TTBT colnames
+query TTBTT colnames
 SHOW COLUMNS FROM privs
 ----
-Field Type Null  Default
-a     INT  false NULL
-b     INT  true  NULL
+Field Type Null  Default Indices
+a     INT  false NULL    {primary}
+b     INT  true  NULL    {}
 
 statement ok
 GRANT CREATE ON privs TO testuser
@@ -535,13 +535,13 @@ ALTER TABLE privs ADD c INT
 statement ok
 ALTER TABLE privs ADD CONSTRAINT foo UNIQUE (b)
 
-query TTBT colnames
+query TTBTT colnames
 SHOW COLUMNS FROM privs
 ----
-Field Type Null  Default
-a     INT  false NULL
-b     INT  true  NULL
-c     INT  true  NULL
+Field Type Null  Default Indices
+a     INT  false NULL    {primary,foo}
+b     INT  true  NULL    {foo}
+c     INT  true  NULL    {}
 
 statement error table "nonexistent" does not exist
 ALTER TABLE nonexistent SPLIT AT (42)

--- a/pkg/sql/testdata/datetime
+++ b/pkg/sql/testdata/datetime
@@ -625,13 +625,13 @@ CREATE TABLE tz (
   d TIMESTAMPTZ
 )
 
-query TTBB
+query TTBTT
 SHOW COLUMNS FROM tz
 ----
-a     INT                       false     NULL
-b     TIMESTAMP                 true      NULL
-c     TIMESTAMP WITH TIME ZONE  true      NULL
-d     TIMESTAMP WITH TIME ZONE  true      NULL
+a     INT                       false     NULL {primary}
+b     TIMESTAMP                 true      NULL {}
+c     TIMESTAMP WITH TIME ZONE  true      NULL {}
+d     TIMESTAMP WITH TIME ZONE  true      NULL {}
 
 statement ok
 INSERT INTO tz VALUES

--- a/pkg/sql/testdata/default
+++ b/pkg/sql/testdata/default
@@ -25,13 +25,13 @@ CREATE TABLE t (
   c FLOAT DEFAULT random()
 )
 
-query TTBT colnames
+query TTBTT colnames
 SHOW COLUMNS FROM t
 ----
-Field Type      Null Default
-a     INT       false 42
-b     TIMESTAMP true now()
-c     FLOAT     true random()
+Field Type      Null  Default  Indices
+a     INT       false 42       {primary}
+b     TIMESTAMP true  now()    {}
+c     FLOAT     true  random() {}
 
 statement ok
 INSERT INTO t VALUES (DEFAULT, DEFAULT, DEFAULT)

--- a/pkg/sql/testdata/explain
+++ b/pkg/sql/testdata/explain
@@ -190,7 +190,7 @@ EXPLAIN SHOW COLUMNS FROM foo
 0  virtual table
 0                 source  SHOW COLUMNS FROM foo
 1  values
-1                 size    4 columns, 1 row
+1                 size    5 columns, 1 row
 
 query ITTT
 EXPLAIN SHOW GRANTS ON foo

--- a/pkg/sql/testdata/information_schema
+++ b/pkg/sql/testdata/information_schema
@@ -126,15 +126,15 @@ information_schema.tables  CREATE TABLE "information_schema.tables" (
                                VERSION INT NULL
                            )
 
-query TTBT colnames
+query TTBTT colnames
 SHOW COLUMNS FROM information_schema.tables
 ----
-Field            Type       Null   Default
-TABLE_CATALOG    STRING     false  ''
-TABLE_SCHEMA     STRING     false  ''
-TABLE_NAME       STRING     false  ''
-TABLE_TYPE       STRING     false  ''
-VERSION          INT        true   NULL
+Field            Type       Null   Default Indices
+TABLE_CATALOG    STRING     false  ''      {}
+TABLE_SCHEMA     STRING     false  ''	   {}
+TABLE_NAME       STRING     false  ''	   {}
+TABLE_TYPE       STRING     false  ''	   {}
+VERSION          INT        true   NULL    {}
 
 query TTBITTBB colnames
 SHOW INDEXES FROM information_schema.tables

--- a/pkg/sql/testdata/no_primary_key
+++ b/pkg/sql/testdata/no_primary_key
@@ -57,12 +57,12 @@ SELECT rowid FROM t WHERE a = 10
 ----
 11
 
-query TTBT
+query TTBTT
 SHOW COLUMNS FROM t
 ----
-a  INT     true  NULL
-b  INT     true  NULL
-c  STRING  true  NULL
+a  INT     true  NULL {}
+b  INT     true  NULL {}
+c  STRING  true  NULL {}
 
 statement ok
 CREATE INDEX a_idx ON t (a)

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -76,14 +76,14 @@ pg_catalog.pg_namespace  CREATE TABLE "pg_catalog.pg_namespace" (
                              aclitem STRING NULL
 )
 
-query TTBT colnames
+query TTBTT colnames
 SHOW COLUMNS FROM pg_catalog.pg_namespace
 ----
-Field     Type    Null   Default
-oid       OID     true   NULL
-nspname   NAME    false  NULL
-nspowner  OID     true   NULL
-aclitem   STRING  true   NULL
+Field     Type    Null   Default Indices
+oid       OID     true   NULL    {}
+nspname   NAME    false  NULL    {}
+nspowner  OID     true   NULL    {}
+aclitem   STRING  true   NULL    {}
 
 query TTBITTBB colnames
 SHOW INDEXES FROM pg_catalog.pg_namespace

--- a/pkg/sql/testdata/privileges_table
+++ b/pkg/sql/testdata/privileges_table
@@ -99,11 +99,11 @@ GRANT SELECT ON t TO testuser
 
 user testuser
 
-query TTBT
+query TTBTT
 SHOW COLUMNS FROM t
 ----
-k INT false NULL
-v INT true  NULL
+k INT false NULL {primary}
+v INT true  NULL {}
 
 statement error user testuser does not have GRANT privilege on table t
 GRANT ALL ON t TO bar

--- a/pkg/sql/testdata/system
+++ b/pkg/sql/testdata/system
@@ -67,56 +67,56 @@ SELECT length(descriptor) * (id - 1) FROM system.descriptor WHERE id = 1
 0
 
 # Verify format of system tables.
-query TTBT
+query TTBTT
 SHOW COLUMNS FROM system.namespace;
 ----
-parentID INT    false NULL
-name     STRING false NULL
-id       INT    true NULL
+parentID INT    false NULL {primary}
+name     STRING false NULL {primary}
+id       INT    true  NULL {}
 
-query TTBT
+query TTBTT
 SHOW COLUMNS FROM system.descriptor;
 ----
-id         INT   false NULL
-descriptor BYTES true NULL
+id         INT   false NULL {primary}
+descriptor BYTES true  NULL {}
 
-query TTBT
+query TTBTT
 SHOW COLUMNS FROM system.lease;
 ----
-descID     INT       false NULL
-version    INT       false NULL
-nodeID     INT       false NULL
-expiration TIMESTAMP false NULL
+descID     INT       false NULL {primary}
+version    INT       false NULL {primary}
+nodeID     INT       false NULL {primary}
+expiration TIMESTAMP false NULL {primary}
 
-query TTBT
+query TTBTT
 SHOW COLUMNS FROM system.ui;
 ----
-key          STRING     false  NULL
-value        BYTES      true   NULL
-lastUpdated  TIMESTAMP  false  NULL
+key          STRING     false  NULL {primary}
+value        BYTES      true   NULL {}
+lastUpdated  TIMESTAMP  false  NULL {}
 
-query TTBT
+query TTBTT
 SHOW COLUMNS FROM system.rangelog;
 ----
-timestamp     TIMESTAMP  false  NULL
-rangeID       INT        false  NULL
-storeID       INT        false  NULL
-eventType     STRING     false  NULL
-otherRangeID  INT        true   NULL
-info          STRING     true   NULL
-uniqueID      INT        false  unique_rowid()
+timestamp     TIMESTAMP  false  NULL           {primary}
+rangeID       INT        false  NULL           {}
+storeID       INT        false  NULL		   {}
+eventType     STRING     false  NULL		   {}
+otherRangeID  INT        true   NULL		   {}
+info          STRING     true   NULL           {}
+uniqueID      INT        false  unique_rowid() {primary}
 
-query TTBT
+query TTBTT
 SHOW COLUMNS FROM system.users;
 ----
-username       STRING false NULL
-hashedPassword BYTES  true NULL
+username       STRING false NULL {primary}
+hashedPassword BYTES  true  NULL {}
 
-query TTBT
+query TTBTT
 SHOW COLUMNS FROM system.zones;
 ----
-id     INT   false NULL
-config BYTES true NULL
+id     INT   false NULL {primary}
+config BYTES true  NULL {}
 
 # Verify default privileges on system tables.
 query TTT

--- a/pkg/sql/testdata/table
+++ b/pkg/sql/testdata/table
@@ -73,22 +73,22 @@ CREATE TABLE d (
   id    INT PRIMARY KEY NULL
 )
 
-query TTBT colnames
+query TTBTT colnames
 SHOW COLUMNS FROM d
 ----
-Field Type   Null  Default
-id    INT    false  NULL
+Field Type   Null  Default Indices
+id    INT    false NULL    {primary}
 
 statement ok
 CREATE TABLE e (
   id    INT NULL PRIMARY KEY
 )
 
-query TTBT colnames
+query TTBTT colnames
 SHOW COLUMNS FROM e
 ----
-Field Type   Null  Default
-id    INT    false  NULL
+Field Type   Null   Default Indices
+id    INT    false  NULL    {primary}
 
 statement ok
 CREATE TABLE f (
@@ -98,13 +98,13 @@ CREATE TABLE f (
   PRIMARY KEY (a, b, c)
 )
 
-query TTBT colnames
+query TTBTT colnames
 SHOW COLUMNS FROM f
 ----
-Field Type   Null  Default
-a     INT   false  NULL
-b     INT   false  NULL
-c     INT   false  NULL
+Field Type   Null  Default Indices
+a     INT   false  NULL    {primary}
+b     INT   false  NULL    {primary}
+c     INT   false  NULL    {primary}
 
 query T
 SHOW TABLES FROM test
@@ -150,16 +150,16 @@ CREATE TABLE test.users (
   UNIQUE INDEX bar (id, name)
 )
 
-query TTBT colnames
+query TTBTT colnames
 SHOW COLUMNS FROM test.users
 ----
-Field       Type        Null    Default
-id          INT         false   NULL
-name        STRING      false   NULL
-title       STRING      true    NULL
-nickname    STRING      true    NULL
-username    STRING(10)  true    NULL
-email       STRING(100) true    NULL
+Field       Type        Null    Default Indices
+id          INT         false   NULL    {primary,foo,bar}
+name        STRING      false   NULL    {foo,bar}
+title       STRING      true    NULL    {}
+nickname    STRING      true    NULL	{}
+username    STRING(10)  true    NULL	{}
+email       STRING(100) true    NULL    {}
 
 query TTBITTBB colnames
 SHOW INDEXES FROM test.users
@@ -335,48 +335,48 @@ CREATE TABLE test.alltypes (
   al INTERVAL
   )
 
-query TTBT colnames
+query TTBTT colnames
 SHOW COLUMNS FROM test.alltypes
 ----
-Field       Type        Null    Default
-a      BOOL                      true   NULL
-b      INT                       true   NULL
-c      INT                       true   NULL
-d      INT                       true   NULL
-e      INT                       true   NULL
-f      INT                       true   NULL
-g      INT                       true   NULL
-h      INT                       true   unique_rowid()
-i      INT                       true   unique_rowid()
-j      INT                       true   unique_rowid()
-k      BIT(1)                    true   NULL
-l      BIT(12)                   true   NULL
-m      STRING                    true   NULL
-n      STRING(12)                true   NULL
-o      STRING                    true   NULL
-p      STRING(12)                true   NULL
-q      FLOAT                     true   NULL
-r      FLOAT                     true   NULL
-s      FLOAT                     true   NULL
-t      DECIMAL                   true   NULL
-u      DECIMAL(1)                true   NULL
-v      DECIMAL(2,1)              true   NULL
-w      DECIMAL                   true   NULL
-x      DECIMAL(1)                true   NULL
-y      DECIMAL(2,1)              true   NULL
-z      DECIMAL                   true   NULL
-aa     DECIMAL(1)                true   NULL
-ab     DECIMAL(2,1)              true   NULL
-ac     DATE                      true   NULL
-ad     TIMESTAMP                 true   NULL
-ae     TIMESTAMP WITH TIME ZONE  true   NULL
-af     STRING                    true   NULL
-ag     STRING(12)                true   NULL
-ah     STRING                    true   NULL
-ai     BYTES                     true   NULL
-aj     BYTES                     true   NULL
-ak     BYTES                     true   NULL
-al     INTERVAL                  true   NULL
+Field  Type                      Null   Default         Indices
+a      BOOL                      true   NULL            {}
+b      INT                       true   NULL			{}
+c      INT                       true   NULL			{}
+d      INT                       true   NULL			{}
+e      INT                       true   NULL			{}
+f      INT                       true   NULL			{}
+g      INT                       true   NULL			{}
+h      INT                       true   unique_rowid()	{}
+i      INT                       true   unique_rowid()	{}
+j      INT                       true   unique_rowid()	{}
+k      BIT(1)                    true   NULL			{}
+l      BIT(12)                   true   NULL			{}
+m      STRING                    true   NULL			{}
+n      STRING(12)                true   NULL			{}
+o      STRING                    true   NULL			{}
+p      STRING(12)                true   NULL			{}
+q      FLOAT                     true   NULL			{}
+r      FLOAT                     true   NULL			{}
+s      FLOAT                     true   NULL			{}
+t      DECIMAL                   true   NULL			{}
+u      DECIMAL(1)                true   NULL			{}
+v      DECIMAL(2,1)              true   NULL			{}
+w      DECIMAL                   true   NULL			{}
+x      DECIMAL(1)                true   NULL			{}
+y      DECIMAL(2,1)              true   NULL			{}
+z      DECIMAL                   true   NULL			{}
+aa     DECIMAL(1)                true   NULL			{}
+ab     DECIMAL(2,1)              true   NULL			{}
+ac     DATE                      true   NULL			{}
+ad     TIMESTAMP                 true   NULL			{}
+ae     TIMESTAMP WITH TIME ZONE  true   NULL			{}
+af     STRING                    true   NULL			{}
+ag     STRING(12)                true   NULL			{}
+ah     STRING                    true   NULL			{}
+ai     BYTES                     true   NULL			{}
+aj     BYTES                     true   NULL			{}
+ak     BYTES                     true   NULL			{}
+al     INTERVAL                  true   NULL            {}
 
 statement ok
 CREATE DATABASE IF NOT EXISTS smtng;


### PR DESCRIPTION
This patch adds a new column "Indices" in the output of SHOW COLUMNS.
This column has type "array of strings" and contains the list of
indices that the column described by the row is involved in. The array
is empty if the designated column does not participate in any index.

Feature requested/suggested by @glycerine.

Three alternative designs were considered:

- like in MySQL, using a visual code that summarizes how the column is
  indexed (NULL|PRI|UNI|MUL). This approach was not chosen because it
  obscures which concrete indexes the column is involved in and poorly
  communicates when a column is both part of a primary and secondary
  index.
- like in `information_schema`, multiply the row that describes the
  column, with one copy per index that it participates in. This would
  make the output more difficult to read by humans.
- like in the present patch, but using a space-delimited list
  of index names (as a single string) instead of a string array.
  This approach was abandoned as it makes it (slightly) harder to
  post-process the output of SHOW COLUMNS in automated tools.

Fixes #4191.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12907)
<!-- Reviewable:end -->
