### PR TITLE
Bump RocksDB to 5.0.2.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -38,7 +38,7 @@ imports:
   subpackages:
   - cmd/protoc
 - name: github.com/cockroachdb/c-rocksdb
-  version: 894d369c4ea259b65f75563feeb06bea322a8450
+  version: 2e47574d8f26a3ecd8cdf8039e4f665d645d5d37
 - name: github.com/cockroachdb/c-snappy
   version: c0cd3c9ce92f195001595e1fbbe66f045daad34f
 - name: github.com/cockroachdb/cmux

--- a/pkg/storage/abort_cache.go
+++ b/pkg/storage/abort_cache.go
@@ -89,7 +89,7 @@ func (sc *AbortCache) ClearData(e engine.Engine) error {
 	defer iter.Close()
 	b := e.NewWriteOnlyBatch()
 	defer b.Close()
-	err := b.ClearRange(iter, engine.MakeMVCCMetadataKey(sc.min()),
+	err := b.ClearIterRange(iter, engine.MakeMVCCMetadataKey(sc.min()),
 		engine.MakeMVCCMetadataKey(sc.max()))
 	if err != nil {
 		return err

--- a/pkg/storage/engine/bench_test.go
+++ b/pkg/storage/engine/bench_test.go
@@ -594,39 +594,43 @@ func BenchmarkMVCCPutDelete_RocksDB(b *testing.B) {
 	}
 }
 
-func BenchmarkClearRange_RocksDB(b *testing.B) {
+func runBenchmarkClearRange(
+	b *testing.B, clearRange func(e Engine, b Batch, start, end MVCCKey) error,
+) {
 	const rangeBytes = 64 << 20
 	const valueBytes = 92
 	numKeys := rangeBytes / (overhead + valueBytes)
-	eng, dir := setupMVCCData(setupMVCCRocksDB, 1, numKeys, valueBytes, b)
+	eng, _ := setupMVCCData(setupMVCCRocksDB, 1, numKeys, valueBytes, b)
 	defer eng.Close()
 
 	b.SetBytes(rangeBytes)
-	b.StopTimer()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		locDirty := dir + "_dirty"
-		if err := os.RemoveAll(locDirty); err != nil {
+		batch := eng.NewWriteOnlyBatch()
+		if err := clearRange(eng, batch, NilKey, MVCCKeyMax); err != nil {
 			b.Fatal(err)
 		}
-		if err := shutil.CopyTree(dir, locDirty, nil); err != nil {
-			b.Fatal(err)
-		}
-		dupEng := setupMVCCRocksDB(b, locDirty)
-
-		b.StartTimer()
-		iter := dupEng.NewIterator(false)
-		batch := dupEng.NewWriteOnlyBatch()
-		if err := batch.ClearRange(iter, NilKey, MVCCKeyMax); err != nil {
-			b.Fatal(err)
-		}
-		iter.Close()
-		if err := batch.Commit(); err != nil {
-			b.Fatal(err)
-		}
-		b.StopTimer()
-
-		dupEng.Close()
+		// NB: We don't actually commit the batch here as we don't want to delete
+		// the data. Doing so would require repopulating on every iteration of the
+		// loop which was ok when ClearRange was slow but now causes the benchmark
+		// to take an exceptionally long time since ClearRange is very fast.
+		batch.Close()
 	}
+
+	b.StopTimer()
+}
+
+func BenchmarkClearRange_RocksDB(b *testing.B) {
+	runBenchmarkClearRange(b, func(eng Engine, batch Batch, start, end MVCCKey) error {
+		return batch.ClearRange(start, end)
+	})
+}
+
+func BenchmarkClearIterRange_RocksDB(b *testing.B) {
+	runBenchmarkClearRange(b, func(eng Engine, batch Batch, start, end MVCCKey) error {
+		iter := eng.NewIterator(false)
+		defer iter.Close()
+		return batch.ClearIterRange(iter, start, end)
+	})
 }

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -134,7 +134,13 @@ type Writer interface {
 	// ClearRange removes a set of entries, from start (inclusive) to end
 	// (exclusive). Similar to Clear, this method actually removes entries from
 	// the storage engine.
-	ClearRange(iter Iterator, start, end MVCCKey) error
+	ClearRange(start, end MVCCKey) error
+	// ClearIterRange removes a set of entries, from start (inclusive) to end
+	// (exclusive). Similar to Clear and ClearRange, this method actually removes
+	// entries from the storage engine. Unlike ClearRange, the entries to remove
+	// are determined by iterating over iter and per-key tombstones are
+	// generated.
+	ClearIterRange(iter Iterator, start, end MVCCKey) error
 	// Merge is a high-performance write operation used for values which are
 	// accumulated over several writes. Multiple values can be merged
 	// sequentially into a single key; a subsequent read will return a "merged"

--- a/pkg/storage/engine/rocksdb/db.h
+++ b/pkg/storage/engine/rocksdb/db.h
@@ -112,7 +112,13 @@ DBStatus DBGet(DBEngine* db, DBKey key, DBString* value);
 DBStatus DBDelete(DBEngine* db, DBKey key);
 
 // Deletes a range of keys from start (inclusive) to end (exclusive).
-DBStatus DBDeleteRange(DBEngine* db, DBIterator *iter, DBKey start, DBKey end);
+DBStatus DBDeleteRange(DBEngine* db, DBKey start, DBKey end);
+
+// Deletes a range of keys from start (inclusive) to end
+// (exclusive). Unlike DBDeleteRange, this function finds the keys to
+// delete by iterating over the supplied iterator and creating
+// tombstones for the individual keys.
+DBStatus DBDeleteIterRange(DBEngine* db, DBIterator *iter, DBKey start, DBKey end);
 
 // Applies a batch of operations (puts, merges and deletes) to the
 // database atomically and closes the batch. It is only valid to call

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -702,15 +702,10 @@ func (r *Replica) destroyDataRaftMuLocked(
 	batch := r.store.Engine().NewWriteOnlyBatch()
 	defer batch.Close()
 
-	iter := r.store.Engine().NewIterator(false)
-	defer iter.Close()
-
 	// NB: this uses the local descriptor instead of the consistent one to match
 	// the data on disk.
-	for _, keyRange := range makeAllKeyRanges(r.Desc()) {
-		if err := batch.ClearRange(iter, keyRange.start, keyRange.end); err != nil {
-			return err
-		}
+	if err := clearRangeData(r.Desc(), r.store.Engine(), batch); err != nil {
+		return err
 	}
 	clearTime := timeutil.Now()
 

--- a/pkg/storage/replica_data_iter.go
+++ b/pkg/storage/replica_data_iter.go
@@ -51,6 +51,9 @@ func makeReplicatedKeyRanges(d *roachpb.RangeDescriptor) []keyRange {
 	return makeReplicaKeyRanges(d, keys.MakeRangeIDReplicatedPrefix)
 }
 
+// makeReplicaKeyRanges returns a slice of 3 key ranges. The last key range in
+// the returned slice corresponds to the actual range data (i.e. not the range
+// metadata).
 func makeReplicaKeyRanges(
 	d *roachpb.RangeDescriptor, metaFunc func(roachpb.RangeID) roachpb.Key,
 ) []keyRange {


### PR DESCRIPTION
Use the new RocksDB DeleteRange op. This needs testing on production
clusters before merging.

```
name                  old time/op   new time/op        delta
ClearRange_RocksDB-8    216ms ± 2%           0ms ± 2%       -100.00% (p=0.000 n=10+10)

name                  old speed     new speed          delta
ClearRange_RocksDB-8  310MB/s ± 2%  83215447MB/s ± 2%  +26820751.44% (p=0.000 n=10+10)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12913)
<!-- Reviewable:end -->
