### PR TITLE
cli,engine: Introduce `cockroach debug rocksdb`

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -669,6 +669,23 @@ func runDebugCheckStoreCmd(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+var debugRocksDBCmd = &cobra.Command{
+	Use:   "rocksdb",
+	Short: "run the RocksDB 'ldb' tool",
+	Long: `
+Runs the RocksDB 'ldb' tool, which provides various subcommands for examining
+raw store data. 'cockroach debug rocksdb' accepts the same arguments and flags
+as 'ldb'.
+
+https://github.com/facebook/rocksdb/wiki/Administration-and-Data-Access-Tool#ldb-tool
+`,
+	// LDB does its own flag parsing.
+	DisableFlagParsing: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		engine.RunLDB(args)
+	},
+}
+
 var debugEnvCmd = &cobra.Command{
 	Use:   "env",
 	Short: "output environment settings",
@@ -761,6 +778,7 @@ var debugCmds = []*cobra.Command{
 	debugRaftLogCmd,
 	debugGCCmd,
 	debugCheckStoreCmd,
+	debugRocksDBCmd,
 	debugCompactCmd,
 	debugSSTablesCmd,
 	kvCmd,

--- a/pkg/storage/engine/rocksdb/db.h
+++ b/pkg/storage/engine/rocksdb/db.h
@@ -18,6 +18,7 @@
 #define ROACHLIB_DB_H
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -267,6 +268,8 @@ DBStatus DBSstFileWriterAdd(DBSstFileWriter* fw, DBKey key, DBSlice val);
 // Closes the writer, flushing any remaining writes to disk and freeing
 // memory and other resources. At least one kv entry must have been added.
 DBStatus DBSstFileWriterClose(DBSstFileWriter* fw);
+
+void DBRunLDB(int argc, char** argv);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
Requires cockroachdb/c-rocksdb#30

This wraps the RocksDB `ldb` command with support for our custom
comparator, prefix extractor, and key printer (the first two are
necessary for `ldb` to be able to do anything).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12914)
<!-- Reviewable:end -->
