### PR TITLE
cli/interactive_tests: prevent test_missing_log_output from fighting under-replication errors.

### DIFF
--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -17,6 +17,13 @@ interrupt
 interrupt
 eexpect ":/# "
 
+# Disable replication so as to avoid spurious purgatory errors.
+start_server $argv
+send "$argv zone set .default --disable-replication\r"
+eexpect "num_replicas: 1"
+eexpect ":/# "
+stop_server $argv
+
 # Check that a server started with --logtostderr
 # logs even info messages to stderr.
 send "$argv start --logtostderr\r"


### PR DESCRIPTION
Needed for #12743.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12915)
<!-- Reviewable:end -->
