### PR TITLE
*: misc go1.8 compatibility

### DIFF
--- a/pkg/cli/kv.go
+++ b/pkg/cli/kv.go
@@ -216,10 +216,10 @@ func runInc(cmd *cobra.Command, args []string) error {
 	}
 	defer stopper.Stop()
 
-	amount := 1
+	amount := int64(1)
 	if len(args) == 2 {
 		var err error
-		if amount, err = strconv.Atoi(args[1]); err != nil {
+		if amount, err = strconv.ParseInt(args[1], 10, 0); err != nil {
 			return errors.Wrap(err, "invalid increment")
 		}
 	}
@@ -229,7 +229,7 @@ func runInc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	key := roachpb.Key(unquoted)
-	r, err := kvDB.Inc(context.TODO(), key, int64(amount))
+	r, err := kvDB.Inc(context.TODO(), key, amount)
 	if err != nil {
 		return errors.Wrap(err, "increment failed")
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -139,6 +139,10 @@ func TestSecureHTTPRedirect(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Avoid automatically following redirects.
+	httpClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
 
 	origURL := "http://" + ts.Cfg.HTTPAddr
 	expURL := url.URL{Scheme: "https", Host: ts.Cfg.HTTPAddr, Path: "/"}


### PR DESCRIPTION
There are still some issues with leaking goroutines from the `database/sql` package's new context support, but fixing those requires changing `(*DB).Begin` calls to `(*DB).BeginTx` (and possibly others), so they'll have to wait until we actually boil the ocean and upgrade to 1.8.

Closes #12897. cc @glycerine

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12917)
<!-- Reviewable:end -->
