### PR TITLE
sql: skip test with race

### DIFF
--- a/pkg/sql/copy_in_test.go
+++ b/pkg/sql/copy_in_test.go
@@ -292,7 +292,7 @@ func TestCopyError(t *testing.T) {
 func TestCopyOne(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	t.Skip("fails testrace")
+	t.Skip("https://github.com/lib/pq/issues/558")
 
 	params, _ := createTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
@@ -325,6 +325,8 @@ func TestCopyOne(t *testing.T) {
 // cannot run.
 func TestCopyInProgress(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	t.Skip("https://github.com/lib/pq/issues/558")
 
 	params, _ := createTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)


### PR DESCRIPTION
This was previously skipped, but the skip was removed last commit
because the linked issue in lib/pq was fixed. But there are some more
underlying races, so we must ignore it again.

Closes #12934

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12951)
<!-- Reviewable:end -->
