### PR TITLE
pgwire: close v3Conn when draining and session has no txn

### DIFF
--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -316,7 +316,7 @@ func (c *v3Conn) closeSession(ctx context.Context) {
 	c.session = nil
 }
 
-func (c *v3Conn) serve(ctx context.Context, reserved mon.BoundAccount) error {
+func (c *v3Conn) serve(ctx context.Context, draining func() bool, reserved mon.BoundAccount) error {
 	for key, value := range statusReportParams {
 		c.writeBuf.initMsg(serverMsgParameterStatus)
 		c.writeBuf.writeTerminatedString(key)
@@ -336,8 +336,19 @@ func (c *v3Conn) serve(ctx context.Context, reserved mon.BoundAccount) error {
 	defer c.closeSession(ctx)
 
 	// Once a session has been set up, the underlying net.Conn is switched to
-	// a conn that exits if the session's context is cancelled.
-	c.conn = newReadTimeoutConn(c.conn, c.session.Ctx().Err)
+	// a conn that exits if the session's context is cancelled or if the server
+	// is draining and the session does not have an ongoing transaction.
+	c.conn = newReadTimeoutConn(c.conn, func() error {
+		if err := func() error {
+			if draining() && c.session.TxnState.State == sql.NoTxn {
+				return errors.New(ErrDraining)
+			}
+			return c.session.Ctx().Err()
+		}(); err != nil {
+			return newAdminShutdownErr(err)
+		}
+		return nil
+	})
 	c.rd = bufio.NewReader(c.conn)
 
 	for {
@@ -1075,5 +1086,10 @@ func (c *v3Conn) copyIn(columns []sql.ResultColumn) (int64, error) {
 func newUnrecognizedMsgTypeErr(typ clientMessageType) error {
 	err := errors.Errorf("unrecognized client message type %v", typ)
 	err = pgerror.WithPGCode(err, pgerror.CodeProtocolViolationError)
+	return pgerror.WithSourceContext(err, 1)
+}
+
+func newAdminShutdownErr(err error) error {
+	err = pgerror.WithPGCode(err, pgerror.CodeAdminShutdownError)
 	return pgerror.WithSourceContext(err, 1)
 }

--- a/pkg/sql/pgwire/v3_test.go
+++ b/pkg/sql/pgwire/v3_test.go
@@ -101,7 +101,11 @@ func testMaliciousInput(t *testing.T, data []byte) {
 
 	v3Conn := makeTestV3Conn(r)
 	defer v3Conn.finish(context.Background())
-	_ = v3Conn.serve(context.Background(), mon.BoundAccount{})
+	_ = v3Conn.serve(
+		context.Background(),
+		func() bool { return false }, /* draining */
+		mon.BoundAccount{},
+	)
 }
 
 // TestReadTimeoutConn asserts that a readTimeoutConn performs reads normally

--- a/pkg/sql/pgwire_test.go
+++ b/pkg/sql/pgwire_test.go
@@ -174,8 +174,9 @@ func TestPGWire(t *testing.T) {
 	}
 }
 
-// TestPGWireDrainClient makes sure the server refuses new connections when
-// it's in draining mode.
+// TestPGWireDrainClient makes sure that in draining mode, the server refuses
+// new connections and allows sessions with ongoing transactions to finish
+// before closing them.
 func TestPGWireDrainClient(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	params, _ := createTestServerParams()
@@ -194,22 +195,55 @@ func TestPGWireDrainClient(t *testing.T) {
 		RawQuery: "sslmode=disable",
 	}
 
-	on := []serverpb.DrainMode{serverpb.DrainMode_CLIENT}
+	db, err := gosql.Open("postgres", pgBaseURL.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	txn, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	if now, err := s.(*server.TestServer).Drain(on); err != nil {
+	on := []serverpb.DrainMode{serverpb.DrainMode_CLIENT}
+	// Draining runs in a separate goroutine since it won't return until
+	// the connection with an ongoing transaction finishes.
+	errChan := make(chan error)
+	go func() {
+		defer close(errChan)
+		errChan <- func() error {
+			if now, err := s.(*server.TestServer).Drain(on); err != nil {
+				return err
+			} else if !reflect.DeepEqual(on, now) {
+				return fmt.Errorf("expected drain modes %v, got %v", on, now)
+			}
+			return nil
+		}()
+	}()
+
+	// Ensure server is in draining mode and rejects new connections.
+	testutils.SucceedsSoon(t, func() error {
+		if err := trivialQuery(pgBaseURL); !testutils.IsError(err, pgwire.ErrDraining) {
+			return fmt.Errorf("unexpected error: %v", err)
+		}
+		return nil
+	})
+
+	if _, err := txn.Exec("SELECT 1"); err != nil {
 		t.Fatal(err)
-	} else if !reflect.DeepEqual(on, now) {
-		t.Fatalf("expected drain modes %v, got %v", on, now)
 	}
-	if err := trivialQuery(pgBaseURL); !testutils.IsError(err, pgwire.ErrDraining) {
+	if err := txn.Commit(); err != nil {
 		t.Fatal(err)
 	}
-	if now := s.(*server.TestServer).Undrain(
-		[]serverpb.DrainMode{serverpb.DrainMode_CLIENT}); len(now) != 0 {
+
+	for err := range errChan {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if now := s.(*server.TestServer).Undrain(on); len(now) != 0 {
 		t.Fatalf("unexpected active drain modes: %v", now)
-	}
-	if err := trivialQuery(pgBaseURL); err != nil {
-		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
Connections with sessions with no ongoing transactions are closed when
draining is activated. Connections with ongoing transactions are allowed
to finish up to drainMaxWait. pgerror.AdminShutdownError is returned
when attempting to establish a connection to a draining server and when
closing a connection to be compatible with popular third-party load
balancers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12952)
<!-- Reviewable:end -->
