### PR TITLE
distsql: remove row buffer in aggregator

### DIFF
--- a/pkg/sql/sqlbase/encoded_datum.go
+++ b/pkg/sql/sqlbase/encoded_datum.go
@@ -261,17 +261,6 @@ func (r EncDatumRow) String() string {
 	return b.String()
 }
 
-// DTupleToEncDatumRow converts a parser.DTuple to an EncDatumRow.
-func DTupleToEncDatumRow(row EncDatumRow, types []ColumnType, tuple parser.DTuple) {
-	if len(row) != len(tuple) || len(tuple) != len(types) {
-		panic(fmt.Sprintf("Length mismatch (%d, %d and %d) between row, types and tuple",
-			len(row), len(types), len(tuple)))
-	}
-	for i, datum := range tuple {
-		row[i] = DatumToEncDatum(types[i], datum)
-	}
-}
-
 // EncDatumRowToDTuple converts a given EncDatumRow to a DTuple.
 func EncDatumRowToDTuple(tuple parser.DTuple, row EncDatumRow, da *DatumAlloc) error {
 	if len(row) != len(tuple) {


### PR DESCRIPTION
For some reason, aggregator stores each resulting row in a RowBuffer instead of
directly emitting each one. Fixing and adding a missing span.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12953)
<!-- Reviewable:end -->
