### PR TITLE
sql: build set of tables being dropped first, skip FK checks on them

### DIFF
--- a/pkg/sql/testdata/fk
+++ b/pkg/sql/testdata/fk
@@ -395,6 +395,9 @@ statement error foreign key violation
 DELETE FROM employees WHERE id > 1
 
 statement ok
+DROP TABLE employees
+
+statement ok
 CREATE TABLE pairs (id INT PRIMARY KEY, src INT, dest STRING, UNIQUE (src, dest))
 
 statement ok
@@ -491,3 +494,9 @@ INSERT INTO crossdb VALUES (2)
 
 statement error foreign key violation: values \[2] in columns \[id\] referenced in table "crossdb"
 DELETE FROM otherdb.othertable WHERE id = 2
+
+statement error "othertable" is referenced by foreign key from table "crossdb"
+DROP TABLE otherdb.othertable
+
+statement ok
+DROP TABLE otherdb.othertable, crossdb


### PR DESCRIPTION
we shouldn't need to check refs from other things that are also being dropped (including the table itself)

Fixes #12916.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12958)
<!-- Reviewable:end -->
