### PR TITLE
sql: implement pg_catalog.pg_enum

### DIFF
--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -57,6 +57,7 @@ var pgCatalog = virtualSchema{
 		pgCatalogDatabaseTable,
 		pgCatalogDependTable,
 		pgCatalogDescriptionTable,
+		pgCatalogEnumTable,
 		pgCatalogIndexTable,
 		pgCatalogIndexesTable,
 		pgCatalogNamespaceTable,
@@ -682,6 +683,22 @@ CREATE TABLE pg_catalog.pg_description (
 `,
 	populate: func(p *planner, addRow func(...parser.Datum) error) error {
 		// Comments on database objects are not currently supported.
+		return nil
+	},
+}
+
+// See: https://www.postgresql.org/docs/9.6/static/catalog-pg-enum.html.
+var pgCatalogEnumTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE pg_catalog.pg_enum (
+  oid INT,
+  enumtypid INT,
+  enumsortorder FLOAT,
+  enumlabel STRING
+);
+`,
+	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+		// Enum types are not currently supported.
 		return nil
 	},
 }

--- a/pkg/sql/testdata/information_schema
+++ b/pkg/sql/testdata/information_schema
@@ -223,6 +223,7 @@ pg_constraint
 pg_database
 pg_depend
 pg_description
+pg_enum
 pg_index
 pg_indexes
 pg_namespace
@@ -267,6 +268,7 @@ pg_proc
 pg_namespace
 pg_indexes
 pg_index
+pg_enum
 pg_description
 pg_depend
 pg_database
@@ -300,6 +302,7 @@ def            pg_catalog          pg_constraint      SYSTEM VIEW  1
 def            pg_catalog          pg_database        SYSTEM VIEW  1
 def            pg_catalog          pg_depend          SYSTEM VIEW  1
 def            pg_catalog          pg_description     SYSTEM VIEW  1
+def            pg_catalog          pg_enum            SYSTEM VIEW  1
 def            pg_catalog          pg_index           SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
@@ -352,6 +355,7 @@ def            pg_catalog          pg_constraint      SYSTEM VIEW  1
 def            pg_catalog          pg_database        SYSTEM VIEW  1
 def            pg_catalog          pg_depend          SYSTEM VIEW  1
 def            pg_catalog          pg_description     SYSTEM VIEW  1
+def            pg_catalog          pg_enum            SYSTEM VIEW  1
 def            pg_catalog          pg_index           SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
@@ -395,6 +399,7 @@ def            pg_catalog          pg_constraint      SYSTEM VIEW  1
 def            pg_catalog          pg_database        SYSTEM VIEW  1
 def            pg_catalog          pg_depend          SYSTEM VIEW  1
 def            pg_catalog          pg_description     SYSTEM VIEW  1
+def            pg_catalog          pg_enum            SYSTEM VIEW  1
 def            pg_catalog          pg_index           SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1

--- a/pkg/sql/testdata/orms
+++ b/pkg/sql/testdata/orms
@@ -17,3 +17,14 @@ SELECT a.attname, format_type(a.atttypid, a.atttypmod), pg_get_expr(d.adbin, d.a
 ----
 id   bigint  NULL  false  20  -1
 name text    NULL  false  25  -1
+
+
+## 12115
+query TT
+SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_value
+    FROM pg_type t
+    JOIN pg_enum e ON t.oid = e.enumtypid
+    JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+    WHERE n.nspname = 'public'
+    GROUP BY 1;
+----

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -52,6 +52,7 @@ pg_constraint
 pg_database
 pg_depend
 pg_description
+pg_enum
 pg_index
 pg_indexes
 pg_namespace
@@ -848,6 +849,13 @@ query IIIT colnames
 SELECT * FROM pg_catalog.pg_description
 ----
 objoid  classoid  objsubid  description
+
+## pg_catalog.pg_enum
+
+query IIRT colnames
+SELECT * FROM pg_catalog.pg_enum
+----
+oid  enumtypid  enumsortorder  enumlabel
 
 ## pg_catalog.pg_settings
 


### PR DESCRIPTION
Add the pg_enum virtual table. We don't currently support enum types, so
this table has no rows at this time.

Resolves #12971.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12972)
<!-- Reviewable:end -->
