### PR TITLE
gossip: Fix test flake caused by peer node ID changing after placeholderResolution

### DIFF
--- a/pkg/gossip/client.go
+++ b/pkg/gossip/client.go
@@ -233,11 +233,16 @@ func (c *client) handleResponse(ctx context.Context, g *Gossip, reply *Response)
 		g.maybeTightenLocked()
 	}
 	c.peerID = reply.NodeID
-	if !c.resolvedPlaceholder {
+	c.remoteHighWaterStamps = reply.HighWaterStamps
+
+	// If we haven't yet recorded which node ID we're connected to in the outgoing
+	// nodeSet, do so now. Note that we only want to do this if the peer has a
+	// node ID allocated (i.e. if it's nonzero), because otherwise it could change
+	// after we record it.
+	if !c.resolvedPlaceholder && c.peerID != 0 {
 		c.resolvedPlaceholder = true
 		g.outgoing.resolvePlaceholder(c.peerID)
 	}
-	c.remoteHighWaterStamps = reply.HighWaterStamps
 
 	// Handle remote forwarding.
 	if reply.AlternateAddr != nil {

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -657,7 +657,7 @@ func TestStatusSummaries(t *testing.T) {
 func TestStartNodeWithLocality(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	testLocalityWitNewNode := func(locality roachpb.Locality) {
+	testLocalityWithNewNode := func(locality roachpb.Locality) {
 		e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 		defer e.Close()
 		if _, err := bootstrapCluster(
@@ -713,6 +713,6 @@ func TestStartNodeWithLocality(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testLocalityWitNewNode(testCase)
+		testLocalityWithNewNode(testCase)
 	}
 }


### PR DESCRIPTION
Fixes #12964 

@tamird 

    This fixes a race where a node would open a gossip connection to itself
    on initial startup. At this point it would have a node ID equal to 0
    because it hasn't allocated itself one yet. Its server would return a
    response to its localhost client with the reply's NodeID set to 0. This
    would cause the client to resolve the node set's placeholder to 0, since
    it was previously blindly resolving the placeholder. This would be fine
    if the outgoing connection was removed from the node set while its ID
    was still 0, but in certain execution orders the node's ID could get
    changed to 1 in between when resolvePlaceholders and removeNode get
    called, causing the removeNode call to not find a node with the expected
    ID (1) and to decrement the placeholders count instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12974)
<!-- Reviewable:end -->
