### PR TITLE
sql/sqlbase: remove hack to insert string datums into byte columns

### DIFF
--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -1256,7 +1256,7 @@ func CheckColumnType(col ColumnDescriptor, typ parser.Type, pmap *parser.Placeho
 			return fmt.Errorf("cannot infer type for placeholder %s from column %q: %s",
 				p.Name, col.Name, err)
 		}
-	} else if !(typ.Equivalent(set) || (set == parser.TypeBytes && typ == parser.TypeString)) {
+	} else if !typ.Equivalent(set) {
 		// Not a placeholder; check that the value cast has succeeded.
 		return fmt.Errorf("value type %s doesn't match type %s of column %q",
 			typ, col.Type.Kind, col.Name)
@@ -1302,10 +1302,6 @@ func MarshalColumnValue(col ColumnDescriptor, val parser.Datum) (roachpb.Value, 
 		}
 	case ColumnType_BYTES:
 		if v, ok := val.(*parser.DBytes); ok {
-			r.SetString(string(*v))
-			return r, nil
-		}
-		if v, ok := val.(*parser.DString); ok {
 			r.SetString(string(*v))
 			return r, nil
 		}

--- a/pkg/sql/testdata/insert
+++ b/pkg/sql/testdata/insert
@@ -551,3 +551,25 @@ INSERT INTO insert_t (VALUES(1, DEFAULT),(2,'BBB') LIMIT 1)
 
 query error DEFAULT can only appear in a VALUES list within INSERT
 INSERT INTO insert_t (VALUES(1, DEFAULT),(2,'BBB')) LIMIT 1
+
+statement ok
+CREATE TABLE bytes_t (
+  b BYTES PRIMARY KEY
+)
+
+statement ok
+INSERT INTO bytes_t VALUES ('byte')
+
+statement ok
+CREATE TABLE string_t (
+  s STRING PRIMARY KEY
+)
+
+statement ok
+INSERT INTO string_t VALUES ('str')
+
+query error value type string doesn't match type BYTES of column "b"
+INSERT INTO bytes_t SELECT * FROM string_t
+
+query error value type bytes doesn't match type STRING of column "s"
+INSERT INTO string_t SELECT * FROM bytes_t


### PR DESCRIPTION
This hack was introduced in 028387f5db0f708090ac0f5e4bfee9369876973d
back before our type system allowed string literals to be inserted into
byte columns. Back then the statement `INSERT INTO b VALUES ('str')`
would not work.

Since the introduction of the Summer type system, literal type inference
has improved to the point where the above query now works. Because of
this, we no longer need the hack.

As a side effect of this change, statements like
`INSERT INTO bytesT SELECT strCol FROM strT` are no longer supported,
but supporting that statement was a break in consistency of our type
system, and was never the intended effect of this hack anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12977)
<!-- Reviewable:end -->
