### PR TITLE
sql: implement col_description()

### DIFF
--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -1579,6 +1579,18 @@ var Builtins = map[string][]Builtin{
 				"Currently, the type modifier is ignored.",
 		},
 	},
+	"pg_catalog.col_description": {
+		Builtin{
+			Types:      NamedArgTypes{{"table_oid", TypeInt}, {"column_number", TypeInt}},
+			ReturnType: TypeString,
+			fn: func(_ *EvalContext, _ DTuple) (Datum, error) {
+				return DNull, nil
+			},
+			category: categoryCompatibility,
+			Info: "col_description returns the comment for a table column. " +
+				"Currently, CockroachDB does not support adding comments to columns.",
+		},
+	},
 }
 
 var substringImpls = []Builtin{

--- a/pkg/sql/testdata/builtin_function
+++ b/pkg/sql/testdata/builtin_function
@@ -1438,3 +1438,9 @@ CREATE INDEX pg_indexdef_idx ON test.pg_indexdef_test (a ASC)
 
 query error pq: unknown signature: pg_catalog.pg_get_indexdef\(int, int, bool\)
 SELECT pg_catalog.pg_get_indexdef(0, 0, true)
+
+# This function always returns NULL since we don't support column comments.
+query T
+SELECT col_description('pg_class'::regclass::oid, 2)
+----
+NULL


### PR DESCRIPTION
This postgres builtin retrieves the comment, if present, on a column in
a table. We don't support commenting on columns, so for us this function
currently always returns NULL.

Resolves #12783.
The test query in that issue hasn't yet been added to the ORM test file because it also depends on `pg_catalog.pg_collation`, which is tracked in #12976.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12978)
<!-- Reviewable:end -->
