### PR TITLE
sql: add pg_catalog.pg_collation

### DIFF
--- a/pkg/sql/testdata/information_schema
+++ b/pkg/sql/testdata/information_schema
@@ -219,6 +219,7 @@ pg_am
 pg_attrdef
 pg_attribute
 pg_class
+pg_collation
 pg_constraint
 pg_database
 pg_depend
@@ -273,6 +274,7 @@ pg_description
 pg_depend
 pg_database
 pg_constraint
+pg_collation
 pg_class
 pg_attribute
 pg_attrdef
@@ -298,6 +300,7 @@ def            pg_catalog          pg_am              SYSTEM VIEW  1
 def            pg_catalog          pg_attrdef         SYSTEM VIEW  1
 def            pg_catalog          pg_attribute       SYSTEM VIEW  1
 def            pg_catalog          pg_class           SYSTEM VIEW  1
+def            pg_catalog          pg_collation       SYSTEM VIEW  1
 def            pg_catalog          pg_constraint      SYSTEM VIEW  1
 def            pg_catalog          pg_database        SYSTEM VIEW  1
 def            pg_catalog          pg_depend          SYSTEM VIEW  1
@@ -351,6 +354,7 @@ def            pg_catalog          pg_am              SYSTEM VIEW  1
 def            pg_catalog          pg_attrdef         SYSTEM VIEW  1
 def            pg_catalog          pg_attribute       SYSTEM VIEW  1
 def            pg_catalog          pg_class           SYSTEM VIEW  1
+def            pg_catalog          pg_collation       SYSTEM VIEW  1
 def            pg_catalog          pg_constraint      SYSTEM VIEW  1
 def            pg_catalog          pg_database        SYSTEM VIEW  1
 def            pg_catalog          pg_depend          SYSTEM VIEW  1
@@ -395,6 +399,7 @@ def            pg_catalog          pg_am              SYSTEM VIEW  1
 def            pg_catalog          pg_attrdef         SYSTEM VIEW  1
 def            pg_catalog          pg_attribute       SYSTEM VIEW  1
 def            pg_catalog          pg_class           SYSTEM VIEW  1
+def            pg_catalog          pg_collation       SYSTEM VIEW  1
 def            pg_catalog          pg_constraint      SYSTEM VIEW  1
 def            pg_catalog          pg_database        SYSTEM VIEW  1
 def            pg_catalog          pg_depend          SYSTEM VIEW  1

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -362,6 +362,20 @@ v1            b        false         true        0            NULL    NULL      
 v1            c        false         true        0            NULL    NULL        NULL
 
 
+# Select all columns with collations.
+query TTTIT colnames
+SELECT c.relname, attname, t.typname, attcollation, k.collname
+FROM pg_catalog.pg_attribute a
+JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
+JOIN pg_catalog.pg_type t ON a.atttypid = t.oid
+JOIN pg_catalog.pg_collation k ON a.attcollation = k.oid
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE n.nspname = 'public'
+----
+relname  attname  typname  attcollation  collname
+t3       c        string   1661428263    en-US
+
+
 ## pg_catalog.pg_am
 
 query ITIT colnames
@@ -745,14 +759,14 @@ oid   typname      typndims  typcollation  typdefaultbin  typdefault  typacl
 20    int          0         0             NULL           NULL        NULL
 21    int          0         0             NULL           NULL        NULL
 23    int          0         0             NULL           NULL        NULL
-25    string       0         0             NULL           NULL        NULL
+25    string       0         1661428263    NULL           NULL        NULL
 700   float        0         0             NULL           NULL        NULL
 701   float        0         0             NULL           NULL        NULL
 1005  int[]        0         0             NULL           NULL        NULL
 1007  int[]        0         0             NULL           NULL        NULL
-1009  string[]     0         0             NULL           NULL        NULL
+1009  string[]     0         1661428263    NULL           NULL        NULL
 1016  int[]        0         0             NULL           NULL        NULL
-1043  string       0         0             NULL           NULL        NULL
+1043  string       0         1661428263    NULL           NULL        NULL
 1082  date         0         0             NULL           NULL        NULL
 1114  timestamp    0         0             NULL           NULL        NULL
 1184  timestamptz  0         0             NULL           NULL        NULL

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -48,6 +48,7 @@ pg_am
 pg_attrdef
 pg_attribute
 pg_class
+pg_collation
 pg_constraint
 pg_database
 pg_depend
@@ -450,6 +451,14 @@ indexrelid  indrelid    indislive  indisreplident  indkey  indcollation  indclas
 724530982   908875140   true       false           {1,6}   0             0         0          NULL      NULL
 3505585425  2199392917  true       false           {1,2}   0             0         0          NULL      NULL
 3491800018  3270885600  true       false           {1,7}   0             0         0          NULL      NULL
+
+## pg_catalog.pg_collation
+query ITIIITT colnames
+SELECT * FROM pg_collation
+WHERE collname='en-US'
+----
+oid         collname  collnamespace  collowner  collencoding  collcollate  collctype
+1661428263  en-US     1782195457     NULL       6             NULL         NULL
 
 ## pg_catalog.pg_constraint
 ##


### PR DESCRIPTION
`pg_catalog.pg_collation` is now populated based on the values of the locales returned by the [`tag.Provided()`](https://godoc.org/golang.org/x/text/collate#Supported) method in Go's collation library. It's missing the columns that link collations to their corresponding names in `LC_COLLATE` and `LC_CTYPE` format because I couldn't figure out how to easily generate those names. I don't think these columns are critical for us.

The `pg_attribute.attcollation` column is now present, which links database columns to their associated collation if any. The `pg_type.typcollation` field is now updated to link types to their default collations.

cc @eisenstatdavid

Resolves #12976.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12983)
<!-- Reviewable:end -->
