### PR TITLE
gossip: Remove assertion that nodeSet is never larger than maxSize

### DIFF
--- a/pkg/gossip/node_set.go
+++ b/pkg/gossip/node_set.go
@@ -85,13 +85,7 @@ func (as nodeSet) hasNode(node roachpb.NodeID) bool {
 
 // setMaxSize adjusts the maximum size allowed for the node set.
 func (as *nodeSet) setMaxSize(maxSize int) {
-	// Only allow increases to maxSize to avoid potentially breaking the
-	// placeholders logic. Keeping extra gossip connections open is safe.
-	// TODO(a-robinson): Remove this clumsy workaround, potentially by just
-	// not killing the server if our assertions fail (e.g. #12680).
-	if maxSize > as.maxSize {
-		as.maxSize = maxSize
-	}
+	as.maxSize = maxSize
 }
 
 // addNode adds the node to the nodes set.
@@ -139,12 +133,5 @@ func (as *nodeSet) updateGauge() {
 		log.Fatalf(context.TODO(),
 			"nodeSet.placeholders should never be less than 0; gossip logic is broken %+v", as)
 	}
-
-	newTotal := as.len()
-	if newTotal > as.maxSize {
-		log.Fatalf(context.TODO(),
-			"too many nodes (%d) in nodeSet (maxSize=%d); gossip logic is broken: %+v",
-			newTotal, as.maxSize, as)
-	}
-	as.gauge.Update(int64(newTotal))
+	as.gauge.Update(int64(as.len()))
 }


### PR DESCRIPTION
This allows us to undo the temporary hack of never decreasing maxSize.
This assertion was useful while refactoring the gossip code, but breaks
in cases where the bootstrap logic needs to spin up more than maxSize
clients before it receives the sentinel gossip info.

We could potentially change the bootstrap logic instead, but I'm not
convinced that limiting the number of bootstrap connections is safe --
it seems as though it could lead to a cluster being split up into
multiple connected components rather than a single connected network,
one of which might end up without the sentinel key if none of its nodes
contains the first range.

Fixes #12979

@spencerkimball

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/12984)
<!-- Reviewable:end -->
