### PR TITLE
gossip: Fix a couple data races in tests

### DIFF
--- a/pkg/gossip/client.go
+++ b/pkg/gossip/client.go
@@ -75,7 +75,7 @@ func newClient(ambient log.AmbientContext, addr net.Addr, nodeMetrics Metrics) *
 // start dials the remote addr and commences gossip once connected. Upon exit,
 // the client is sent on the disconnected channel. This method starts client
 // processing in a goroutine and returns immediately.
-func (c *client) start(
+func (c *client) startLocked(
 	g *Gossip,
 	disconnected chan *client,
 	rpcCtx *rpc.Context,

--- a/pkg/gossip/client_test.go
+++ b/pkg/gossip/client_test.go
@@ -164,7 +164,10 @@ func gossipSucceedsSoon(
 		select {
 		case client := <-disconnected:
 			// If the client wasn't able to connect, restart it.
-			client.start(gossip[client], disconnected, rpcContext, stopper, rpcContext.NewBreaker())
+			g := gossip[client]
+			g.mu.Lock()
+			client.startLocked(g, disconnected, rpcContext, stopper, rpcContext.NewBreaker())
+			g.mu.Unlock()
 		default:
 		}
 
@@ -300,7 +303,9 @@ func TestClientNodeID(t *testing.T) {
 			return
 		case <-disconnected:
 			// The client hasn't been started or failed to start, loop and try again.
-			c.start(local, disconnected, rpcContext, stopper, rpcContext.NewBreaker())
+			local.mu.Lock()
+			c.startLocked(local, disconnected, rpcContext, stopper, rpcContext.NewBreaker())
+			local.mu.Unlock()
 		}
 	}
 }

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1237,7 +1237,7 @@ func (g *Gossip) startClientLocked(addr net.Addr) {
 	log.Eventf(ctx, "starting new client to %s", addr)
 	c := newClient(g.server.AmbientContext, addr, g.serverMetrics)
 	g.clientsMu.clients = append(g.clientsMu.clients, c)
-	c.start(g, g.disconnected, g.rpcContext, g.server.stopper, breaker)
+	c.startLocked(g, g.disconnected, g.rpcContext, g.server.stopper, breaker)
 }
 
 // removeClientLocked removes the specified client. Called when a client

--- a/pkg/gossip/gossip_test.go
+++ b/pkg/gossip/gossip_test.go
@@ -326,7 +326,9 @@ func TestGossipNoForwardSelf(t *testing.T) {
 		for {
 			localAddr := local.GetNodeAddr()
 			c := newClient(log.AmbientContext{}, localAddr, makeMetrics())
-			c.start(peer, disconnectedCh, peer.rpcContext, stopper, peer.rpcContext.NewBreaker())
+			peer.mu.Lock()
+			c.startLocked(peer, disconnectedCh, peer.rpcContext, stopper, peer.rpcContext.NewBreaker())
+			peer.mu.Unlock()
 
 			disconnectedClient := <-disconnectedCh
 			if disconnectedClient != c {


### PR DESCRIPTION
Fallout from some refactoring done during the review of #12880 

Without this, client.Start's call to add a placeholder to the gossip's outgoing nodeSet races with possible background work also using the outgoing nodeSet.

@tamird

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13006)
<!-- Reviewable:end -->
