### PR TITLE
sql: add flag to print logs for logic test

### DIFF
--- a/pkg/sql/logic_test.go
+++ b/pkg/sql/logic_test.go
@@ -162,6 +162,9 @@ import (
 //                "FAIL" to indicate an unexpected/undesired test
 //                failure.
 //
+// -show-logs     shows logs (by default, logs go to temporary files which are
+//                kept only for tests that fail)
+//
 // -error-summary produces a report organized by error message
 //                of all queries that have caused that error.  Useful
 //                with -allow-prepare-fail and/or -flex-types.
@@ -195,6 +198,8 @@ var (
 	// Output parameters
 	showSQL = flag.Bool("show-sql", false,
 		"print the individual SQL statement/queries before processing")
+	showLogs = flag.Bool("show-logs", false,
+		"print logs instead of saving them in files")
 	printErrorSummary = flag.Bool("error-summary", false,
 		"print a per-error summary of failing queries at the end of testing, when -allow-prepare-fail is set")
 	fullMessages = flag.Bool("full-messages", false,
@@ -455,7 +460,9 @@ func (t *logicTest) setUser(user string) func() {
 }
 
 func (t *logicTest) setup() {
-	t.logScope = log.Scope(t.t, "TestLogic")
+	if !*showLogs {
+		t.logScope = log.Scope(t.t, "TestLogic")
+	}
 
 	// TODO(pmattis): Add a flag to make it easy to run the tests against a local
 	// MySQL or Postgres instance.

--- a/pkg/util/log/test_log_scope.go
+++ b/pkg/util/log/test_log_scope.go
@@ -69,6 +69,10 @@ func Scope(t tShim, testName string) TestLogScope {
 // Close cleans up a TestLogScope. The directory and its contents are
 // deleted, unless the test has failed and the directory is non-empty.
 func (l TestLogScope) Close(t tShim) {
+	if string(l) == "" {
+		// Never initialized.
+		return
+	}
 	defer func() {
 		// Check whether there is something to remove.
 		emptyDir, err := isDirEmpty(string(l))


### PR DESCRIPTION
Recent changes have made the logs for logic test go to files which are removed
for passing tests. Adding flag to allow the old behavior (necessary for
inspecting logs for passing tests).

Fixes #12980.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13021)
<!-- Reviewable:end -->
