### PR TITLE
gossip: Add locking around missed call to startClientLocked in test

### DIFF
--- a/pkg/gossip/gossip_test.go
+++ b/pkg/gossip/gossip_test.go
@@ -408,7 +408,9 @@ func TestGossipOrphanedStallDetection(t *testing.T) {
 	peerAddr := peer.GetNodeAddr()
 	peerAddrStr := peerAddr.String()
 
+	local.mu.Lock()
 	local.startClientLocked(peerAddr)
+	local.mu.Unlock()
 
 	testutils.SucceedsSoon(t, func() error {
 		for _, peerID := range local.Outgoing() {


### PR DESCRIPTION
I'm apparently an idiot.

Fixes #13019

@tamird

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13022)
<!-- Reviewable:end -->
