### PR TITLE
sql: add TestLogicDistSQL

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -110,6 +110,16 @@ var defaultDistSQLMode = distSQLExecModeFromString(
 	envutil.EnvOrDefaultString("COCKROACH_DISTSQL_MODE", "OFF"),
 )
 
+// SetDefaultDistSQLMode changes the default DistSQL mode; returns a function
+// that can be used to restore the previous mode.
+func SetDefaultDistSQLMode(mode string) func() {
+	prevMode := defaultDistSQLMode
+	defaultDistSQLMode = distSQLExecModeFromString(mode)
+	return func() {
+		defaultDistSQLMode = prevMode
+	}
+}
+
 type traceResult struct {
 	tag   string
 	count int

--- a/pkg/sql/logic_test.go
+++ b/pkg/sql/logic_test.go
@@ -1182,6 +1182,16 @@ func TestLogic(t *testing.T) {
 	l.outf("--- total: %d tests, %d failures%s", total, totalFail, unsupportedMsg)
 }
 
+// TestLogicDistSQL is a variant of TestLogic that uses DistSQL for all
+// supported queries.
+func TestLogicDistSQL(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	defer sql.SetDefaultDistSQLMode("ON")()
+
+	TestLogic(t)
+}
+
 type errorSummaryEntry struct {
 	errmsg string
 	sql    []string


### PR DESCRIPTION
Add a variant of the logic test which turns DistSQL on.

Opened #13025 to discuss whether we want to run this only in TeamCity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13026)
<!-- Reviewable:end -->
