### PR TITLE
storage: don't allow rebalances when a node is recovering

### DIFF
--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -883,6 +883,11 @@ func (m *multiTestContext) restartStore(i int) {
 		}
 		return nil
 	})
+
+	// Normally, the newly restarted store would not be able to accept rebalances
+	// until the election timeout passed. But we're using a manual clock which
+	// won't advance the time properly, so manually enable rebalances.
+	m.stores[i].SetRebalancesDisabled(false)
 }
 
 func (m *multiTestContext) Store(i int) *storage.Store {

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -23,6 +23,7 @@ package storage
 
 import (
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/net/context"
@@ -158,6 +159,14 @@ func (s *Store) SetSplitQueueActive(active bool) {
 // inactive, removals are still processed.
 func (s *Store) SetReplicaScannerActive(active bool) {
 	s.setScannerActive(active)
+}
+
+func (s *Store) SetRebalancesDisabled(v bool) {
+	var i int32
+	if v {
+		i = 1
+	}
+	atomic.StoreInt32(&s.rebalancesDisabled, i)
 }
 
 // EnqueueRaftUpdateCheck enqueues the replica for a Raft update check, forcing

--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -200,8 +200,10 @@ var (
 	}
 
 	// Raft log metrics.
-	metaRaftLogBehindCount = metric.Metadata{Name: "raftlog.behind",
-		Help: "Number of Raft log entries followers are behind"}
+	metaRaftLogFollowerBehindCount = metric.Metadata{Name: "raftlog.behind",
+		Help: "Number of Raft log entries followers are other stores behind"}
+	metaRaftLogSelfBehindCount = metric.Metadata{Name: "raftlog.selfbehind",
+		Help: "Number of Raft log entries followers on this store are behind"}
 	metaRaftLogTruncated = metric.Metadata{Name: "raftlog.truncated",
 		Help: "Number of Raft log entries truncated"}
 
@@ -429,8 +431,9 @@ type StoreMetrics struct {
 	RaftRcvdMsgDropped        *metric.Counter
 
 	// Raft log metrics.
-	RaftLogBehindCount *metric.Gauge
-	RaftLogTruncated   *metric.Counter
+	RaftLogFollowerBehindCount *metric.Gauge
+	RaftLogSelfBehindCount     *metric.Gauge
+	RaftLogTruncated           *metric.Counter
 
 	// A map for conveniently finding the appropriate metric. The individual
 	// metric references must exist as AddMetricStruct adds them by reflection
@@ -618,8 +621,9 @@ func newStoreMetrics(sampleInterval time.Duration) *StoreMetrics {
 		RaftCoalescedHeartbeatsPending: metric.NewGauge(metaRaftCoalescedHeartbeatsPending),
 
 		// Raft log metrics.
-		RaftLogBehindCount: metric.NewGauge(metaRaftLogBehindCount),
-		RaftLogTruncated:   metric.NewCounter(metaRaftLogTruncated),
+		RaftLogFollowerBehindCount: metric.NewGauge(metaRaftLogFollowerBehindCount),
+		RaftLogSelfBehindCount:     metric.NewGauge(metaRaftLogSelfBehindCount),
+		RaftLogTruncated:           metric.NewCounter(metaRaftLogTruncated),
 
 		// Replica queue metrics.
 		GCQueueSuccesses:                          metric.NewCounter(metaGCQueueSuccesses),

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -312,6 +312,10 @@ type Replica struct {
 		lastAssignedLeaseIndex uint64
 		// Last index persisted to the raft log (not necessarily committed).
 		lastIndex uint64
+		// The most recent commit index seen in a message from the leader. Used by
+		// the follower to estimate the number of Raft log entries it is
+		// behind. This field is only valid when the Replica is a follower.
+		estimatedCommitIndex uint64
 		// The raft log index of a pending preemptive snapshot. Used to prohibit
 		// raft log truncation while a preemptive snapshot is in flight. A value of
 		// 0 indicates that there is no pending snapshot.
@@ -801,6 +805,46 @@ func (r *Replica) setReplicaIDLocked(replicaID roachpb.ReplicaID) error {
 	}
 
 	return nil
+}
+
+func (r *Replica) setEstimatedCommitIndexLocked(commit uint64) {
+	// The estimated commit index only ratchets up to account for Raft messages
+	// arriving out of order.
+	if r.mu.estimatedCommitIndex < commit {
+		r.mu.estimatedCommitIndex = commit
+	}
+}
+
+// getEstimatedBehindCountLocked returns an estimate of how far this replica is
+// behind. A return value of 0 indicates that the replica is up to date.
+func (r *Replica) getEstimatedBehindCountLocked(raftStatus *raft.Status) int64 {
+	if r.mu.quiescent {
+		// The range is quiescent, so it is up to date.
+		return 0
+	}
+	if raftStatus != nil && roachpb.ReplicaID(raftStatus.SoftState.Lead) == r.mu.replicaID {
+		// We're the leader, so we can't be behind.
+		return 0
+	}
+	if !hasRaftLeader(raftStatus) && r.store.canCampaignIdleReplica() {
+		// The Raft group is idle or there is no Raft leader. This can be a
+		// temporary situation due to an in progress election or because the group
+		// can't achieve quorum. In either case, assume we're up to date.
+		return 0
+	}
+	if r.mu.estimatedCommitIndex == 0 {
+		// We haven't heard from the leader, assume we're far behind. This is the
+		// case that is commonly hit when a node restarts. In particular, we hit
+		// this case until an election timeout passes and canCampaignIdleReplica
+		// starts to return true. The results it that a restarted node will
+		// consider its replicas far behind initially which will in turn cause it
+		// to reject rebalances.
+		return prohibitRebalancesBehindThreshold
+	}
+	if r.mu.estimatedCommitIndex >= r.mu.state.RaftAppliedIndex {
+		return int64(r.mu.estimatedCommitIndex - r.mu.state.RaftAppliedIndex)
+	}
+	return 0
 }
 
 // GetMaxBytes atomically gets the range maximum byte limit.
@@ -4514,6 +4558,7 @@ type replicaMetrics struct {
 	unavailable     bool
 	underreplicated bool
 	behindCount     int64
+	selfBehindCount int64
 }
 
 func (r *Replica) metrics(
@@ -4527,10 +4572,11 @@ func (r *Replica) metrics(
 	status := r.leaseStatus(r.mu.state.Lease, now, r.mu.minLeaseProposedTS)
 	quiescent := r.mu.quiescent || r.mu.internalRaftGroup == nil
 	desc := r.mu.state.Desc
+	selfBehindCount := r.getEstimatedBehindCountLocked(raftStatus)
 	r.mu.Unlock()
 
 	return calcReplicaMetrics(ctx, now, cfg, livenessMap, desc,
-		raftStatus, status, r.store.StoreID(), quiescent)
+		raftStatus, status, r.store.StoreID(), quiescent, selfBehindCount)
 }
 
 func isRaftLeader(raftStatus *raft.Status) bool {
@@ -4551,6 +4597,7 @@ func calcReplicaMetrics(
 	status LeaseStatus,
 	storeID roachpb.StoreID,
 	quiescent bool,
+	selfBehindCount int64,
 ) replicaMetrics {
 	var m replicaMetrics
 
@@ -4563,6 +4610,9 @@ func calcReplicaMetrics(
 	m.leaseholder = m.leaseValid && leaseOwner
 	m.leader = isRaftLeader(raftStatus)
 	m.quiescent = quiescent
+	if !m.leader {
+		m.selfBehindCount = selfBehindCount
+	}
 
 	// We gather per-range stats on either the leader or, if there is no leader,
 	// the first live replica in the descriptor. Note that the first live replica
@@ -4639,7 +4689,8 @@ func calcGoodReplicas(
 			}
 			if progress.Match > 0 &&
 				progress.Match < raftStatus.Commit {
-				behindCount += int64(raftStatus.Commit) - int64(progress.Match)
+				v := int64(raftStatus.Commit) - int64(progress.Match)
+				behindCount += v
 			}
 		}
 	}

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -3312,8 +3312,8 @@ func (r *Replica) sendSnapshot(
 			},
 		},
 		RangeSize: r.GetMVCCStats().Total(),
-		// Recipients can choose to decline snapshots.
-		CanDecline: true,
+		// Recipients can choose to decline preemptive snapshots.
+		CanDecline: snapType == snapTypePreemptive,
 	}
 	sent := func() {
 		r.store.metrics.RangeSnapshotsGenerated.Inc(1)

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -7064,7 +7064,7 @@ func TestReplicaMetrics(t *testing.T) {
 				rangeCounter:    false,
 				unavailable:     false,
 				underreplicated: false,
-				behindCount:     0,
+				selfBehindCount: 5,
 			}},
 		// Both replicas of a 2-replica range are live, but follower is behind.
 		{2, 1, desc(1, 2), status(1, progress(2, 1)), live(1, 2),
@@ -7155,6 +7155,7 @@ func TestReplicaMetrics(t *testing.T) {
 				rangeCounter:    true,
 				unavailable:     false,
 				underreplicated: false,
+				selfBehindCount: 15,
 			}},
 		// Range has no leader, local replica is the range counter.
 		{3, 3, desc(3, 2, 1), status(0, progress(2, 2, 2)), live(1, 2, 3),
@@ -7163,6 +7164,7 @@ func TestReplicaMetrics(t *testing.T) {
 				rangeCounter:    true,
 				unavailable:     false,
 				underreplicated: false,
+				selfBehindCount: 16,
 			}},
 		// Range has no leader, local replica is not the range counter.
 		{3, 2, desc(1, 2, 3), status(0, progress(2, 2, 2)), live(1, 2, 3),
@@ -7171,6 +7173,7 @@ func TestReplicaMetrics(t *testing.T) {
 				rangeCounter:    false,
 				unavailable:     false,
 				underreplicated: false,
+				selfBehindCount: 17,
 			}},
 		// Range has no leader, local replica is not the range counter.
 		{3, 3, desc(1, 2, 3), status(0, progress(2, 2, 2)), live(1, 2, 3),
@@ -7179,6 +7182,7 @@ func TestReplicaMetrics(t *testing.T) {
 				rangeCounter:    false,
 				unavailable:     false,
 				underreplicated: false,
+				selfBehindCount: 18,
 			}},
 	}
 	for i, c := range testCases {
@@ -7192,7 +7196,7 @@ func TestReplicaMetrics(t *testing.T) {
 			metrics := calcReplicaMetrics(
 				context.Background(), hlc.Timestamp{}, config.SystemConfig{},
 				c.liveness, &c.desc, c.raftStatus, LeaseStatus{},
-				c.storeID, c.expected.quiescent)
+				c.storeID, c.expected.quiescent, int64(i+1))
 			if c.expected != metrics {
 				t.Fatalf("unexpected metrics:\n%s", pretty.Diff(c.expected, metrics))
 			}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -101,6 +101,13 @@ const (
 	// if a range lease holder experiences a failure causing a missed
 	// gossip update.
 	systemDataGossipInterval = 1 * time.Minute
+
+	// prohibitRebalancesBehindThreshold is the maximum number of log entries a
+	// store allows its replicas to be behind before it starts prohibiting
+	// rebalances. We prohibit rebalances in this situation to avoid adding
+	// additional work to a store that is either not keeping up or is undergoing
+	// recovery because it is on a recently restarted node.
+	prohibitRebalancesBehindThreshold = 1000
 )
 
 var changeTypeInternalToRaft = map[roachpb.ReplicaChangeType]raftpb.ConfChangeType{
@@ -420,6 +427,10 @@ type Store struct {
 	// Semaphore to limit concurrent snapshot application and replica data
 	// destruction.
 	snapshotApplySem chan struct{}
+	// Are rebalances to this store allowed or prohibited. Rebalances are
+	// prohibited while a store is catching up replicas (i.e. recovering) after
+	// being restarted.
+	rebalancesDisabled int32
 
 	// drainLeases holds a bool which indicates whether Replicas should be
 	// allowed to acquire or extend range leases; see DrainLeases().
@@ -2640,6 +2651,9 @@ func (s *Store) reserveSnapshot(
 	ctx context.Context, header *SnapshotRequest_Header,
 ) (func(), error) {
 	if header.CanDecline {
+		if atomic.LoadInt32(&s.rebalancesDisabled) == 1 {
+			return nil, nil
+		}
 		select {
 		case s.snapshotApplySem <- struct{}{}:
 		case <-ctx.Done():
@@ -3080,6 +3094,9 @@ func (s *Store) processRaftRequest(
 		// We're processing a message from another replica which means that the
 		// other replica is not quiesced, so we don't need to wake the leader.
 		r.unquiesceLocked()
+		if req.Message.Type == raftpb.MsgApp {
+			r.setEstimatedCommitIndexLocked(req.Message.Commit)
+		}
 		return false, /* !unquiesceAndWakeLeader */
 			raftGroup.Step(req.Message)
 	}); err != nil {
@@ -3763,6 +3780,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 		unavailableRangeCount     int64
 		underreplicatedRangeCount int64
 		behindCount               int64
+		selfBehindCount           int64
 	)
 
 	timestamp := s.cfg.Clock.Now()
@@ -3802,6 +3820,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 			}
 		}
 		behindCount += metrics.behindCount
+		selfBehindCount += metrics.selfBehindCount
 		return true // more
 	})
 
@@ -3815,8 +3834,14 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 	s.metrics.RangeCount.Update(rangeCount)
 	s.metrics.UnavailableRangeCount.Update(unavailableRangeCount)
 	s.metrics.UnderReplicatedRangeCount.Update(underreplicatedRangeCount)
-	s.metrics.RaftLogBehindCount.Update(behindCount)
+	s.metrics.RaftLogFollowerBehindCount.Update(behindCount)
+	s.metrics.RaftLogSelfBehindCount.Update(selfBehindCount)
 
+	if selfBehindCount > prohibitRebalancesBehindThreshold {
+		atomic.StoreInt32(&s.rebalancesDisabled, 1)
+	} else {
+		atomic.StoreInt32(&s.rebalancesDisabled, 0)
+	}
 	return nil
 }
 


### PR DESCRIPTION
A replica now maintains an estimate of how far it is behind the leader
by watching the Commit field of MsgApp requests. This powers a new
raftlog.selfbehind metric which in turn is used to disable rebalances
when a store is sufficiently far behind.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13043)
<!-- Reviewable:end -->
