### PR TITLE
sql/parser: remove anon ArgTypes

### DIFF
--- a/pkg/sql/parser/aggregate_builtins.go
+++ b/pkg/sql/parser/aggregate_builtins.go
@@ -167,7 +167,7 @@ func makeAggBuiltin(in, ret Type, f func() AggregateFunc, info string) Builtin {
 		// of the Builtins array above.
 		impure:        true,
 		class:         AggregateClass,
-		Types:         NamedArgTypes{{"arg", in}},
+		Types:         ArgTypes{{"arg", in}},
 		ReturnType:    ret,
 		AggregateFunc: f,
 		WindowFunc: func() WindowFunc {

--- a/pkg/sql/parser/aggregate_builtins.go
+++ b/pkg/sql/parser/aggregate_builtins.go
@@ -167,7 +167,7 @@ func makeAggBuiltin(in, ret Type, f func() AggregateFunc, info string) Builtin {
 		// of the Builtins array above.
 		impure:        true,
 		class:         AggregateClass,
-		Types:         ArgTypes{in},
+		Types:         NamedArgTypes{{"arg", in}},
 		ReturnType:    ret,
 		AggregateFunc: f,
 		WindowFunc: func() WindowFunc {
@@ -186,7 +186,7 @@ func makeAggBuiltins(f func() AggregateFunc, info string, types ...Type) []Built
 }
 
 func countImpls() []Builtin {
-	types := ArgTypes{TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString, TypeBytes,
+	types := []Type{TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString, TypeBytes,
 		TypeDate, TypeTimestamp, TypeTimestampTZ, TypeInterval, TypeTuple}
 	r := make([]Builtin, len(types))
 	for i := range types {

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -166,10 +166,6 @@ func (b Builtin) Category() string {
 	}
 	// If single argument attempt to categorize by the type of the argument.
 	switch typ := b.Types.(type) {
-	case ArgTypes:
-		if len(typ) == 1 {
-			return categorizeType(typ[0])
-		}
 	case NamedArgTypes:
 		if len(typ) == 1 {
 			return categorizeType(typ[0].Typ)

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -166,7 +166,7 @@ func (b Builtin) Category() string {
 	}
 	// If single argument attempt to categorize by the type of the argument.
 	switch typ := b.Types.(type) {
-	case NamedArgTypes:
+	case ArgTypes:
 		if len(typ) == 1 {
 			return categorizeType(typ[0].Typ)
 		}
@@ -311,7 +311,7 @@ var Builtins = map[string][]Builtin{
 
 	"to_uuid": {
 		Builtin{
-			Types:      NamedArgTypes{{"val", TypeString}},
+			Types:      ArgTypes{{"val", TypeString}},
 			ReturnType: TypeBytes,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				s := string(*args[0].(*DString))
@@ -328,7 +328,7 @@ var Builtins = map[string][]Builtin{
 
 	"from_uuid": {
 		Builtin{
-			Types:      NamedArgTypes{{"val", TypeBytes}},
+			Types:      ArgTypes{{"val", TypeBytes}},
 			ReturnType: TypeString,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				b := []byte(*args[0].(*DBytes))
@@ -345,7 +345,7 @@ var Builtins = map[string][]Builtin{
 
 	"from_ip": {
 		Builtin{
-			Types:      NamedArgTypes{{"val", TypeBytes}},
+			Types:      ArgTypes{{"val", TypeBytes}},
 			ReturnType: TypeString,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				ipstr := args[0].(*DBytes)
@@ -364,7 +364,7 @@ var Builtins = map[string][]Builtin{
 
 	"to_ip": {
 		Builtin{
-			Types:      NamedArgTypes{{"val", TypeString}},
+			Types:      ArgTypes{{"val", TypeString}},
 			ReturnType: TypeBytes,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				ipdstr := args[0].(*DString)
@@ -383,7 +383,7 @@ var Builtins = map[string][]Builtin{
 
 	"split_part": {
 		Builtin{
-			Types: NamedArgTypes{
+			Types: ArgTypes{
 				{"input", TypeString},
 				{"delimiter", TypeString},
 				{"return_index_pos", TypeInt},
@@ -412,7 +412,7 @@ var Builtins = map[string][]Builtin{
 
 	"repeat": {
 		Builtin{
-			Types:      NamedArgTypes{{"input", TypeString}, {"repeat_counter", TypeInt}},
+			Types:      ArgTypes{{"input", TypeString}, {"repeat_counter", TypeInt}},
 			ReturnType: TypeString,
 			fn: func(_ *EvalContext, args DTuple) (_ Datum, err error) {
 				s := string(*args[0].(*DString))
@@ -456,7 +456,7 @@ var Builtins = map[string][]Builtin{
 
 	"to_hex": {
 		Builtin{
-			Types:      NamedArgTypes{{"val", TypeInt}},
+			Types:      ArgTypes{{"val", TypeInt}},
 			ReturnType: TypeString,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return NewDString(fmt.Sprintf("%x", int64(*args[0].(*DInt)))), nil
@@ -478,7 +478,7 @@ var Builtins = map[string][]Builtin{
 
 	"overlay": {
 		Builtin{
-			Types: NamedArgTypes{
+			Types: ArgTypes{
 				{"input", TypeString},
 				{"overlay_val", TypeString},
 				{"start_pos", TypeInt},
@@ -496,7 +496,7 @@ var Builtins = map[string][]Builtin{
 				"`dCATie`.",
 		},
 		Builtin{
-			Types: NamedArgTypes{
+			Types: ArgTypes{
 				{"input", TypeString},
 				{"overlay_val", TypeString},
 				{"start_pos", TypeInt},
@@ -600,7 +600,7 @@ var Builtins = map[string][]Builtin{
 
 	"regexp_extract": {
 		Builtin{
-			Types:      NamedArgTypes{{"input", TypeString}, {"regex", TypeString}},
+			Types:      ArgTypes{{"input", TypeString}, {"regex", TypeString}},
 			ReturnType: TypeString,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				s := string(*args[0].(*DString))
@@ -613,7 +613,7 @@ var Builtins = map[string][]Builtin{
 
 	"regexp_replace": {
 		Builtin{
-			Types: NamedArgTypes{
+			Types: ArgTypes{
 				{"input", TypeString},
 				{"regex", TypeString},
 				{"replace", TypeString},
@@ -629,7 +629,7 @@ var Builtins = map[string][]Builtin{
 				"Regular Expression `replace`.",
 		},
 		Builtin{
-			Types: NamedArgTypes{
+			Types: ArgTypes{
 				{"input", TypeString},
 				{"regex", TypeString},
 				{"replace", TypeString},
@@ -669,7 +669,7 @@ var Builtins = map[string][]Builtin{
 
 	"left": {
 		Builtin{
-			Types:      NamedArgTypes{{"input", TypeBytes}, {"return_set", TypeInt}},
+			Types:      ArgTypes{{"input", TypeBytes}, {"return_set", TypeInt}},
 			ReturnType: TypeBytes,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				bytes := []byte(*args[0].(*DBytes))
@@ -687,7 +687,7 @@ var Builtins = map[string][]Builtin{
 			Info: "Returns the first `return_set` bytes from `input`.",
 		},
 		Builtin{
-			Types:      NamedArgTypes{{"input", TypeString}, {"return_set", TypeInt}},
+			Types:      ArgTypes{{"input", TypeString}, {"return_set", TypeInt}},
 			ReturnType: TypeString,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				runes := []rune(string(*args[0].(*DString)))
@@ -708,7 +708,7 @@ var Builtins = map[string][]Builtin{
 
 	"right": {
 		Builtin{
-			Types:      NamedArgTypes{{"input", TypeBytes}, {"return_set", TypeInt}},
+			Types:      ArgTypes{{"input", TypeBytes}, {"return_set", TypeInt}},
 			ReturnType: TypeBytes,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				bytes := []byte(*args[0].(*DBytes))
@@ -726,7 +726,7 @@ var Builtins = map[string][]Builtin{
 			Info: "Returns the last `return_set` bytes from `input`.",
 		},
 		Builtin{
-			Types:      NamedArgTypes{{"input", TypeString}, {"return_set", TypeInt}},
+			Types:      ArgTypes{{"input", TypeString}, {"return_set", TypeInt}},
 			ReturnType: TypeString,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				runes := []rune(string(*args[0].(*DString)))
@@ -747,7 +747,7 @@ var Builtins = map[string][]Builtin{
 
 	"random": {
 		Builtin{
-			Types:                   NamedArgTypes{},
+			Types:                   ArgTypes{},
 			ReturnType:              TypeFloat,
 			impure:                  true,
 			needsRepeatedEvaluation: true,
@@ -760,7 +760,7 @@ var Builtins = map[string][]Builtin{
 
 	"unique_rowid": {
 		Builtin{
-			Types:      NamedArgTypes{},
+			Types:      ArgTypes{},
 			ReturnType: TypeInt,
 			category:   categoryIDGeneration,
 			impure:     true,
@@ -805,7 +805,7 @@ var Builtins = map[string][]Builtin{
 
 	"experimental_strftime": {
 		Builtin{
-			Types:      NamedArgTypes{{"input", TypeTimestamp}, {"extract_format", TypeString}},
+			Types:      ArgTypes{{"input", TypeTimestamp}, {"extract_format", TypeString}},
 			ReturnType: TypeString,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				fromTime := args[0].(*DTimestamp).Time
@@ -820,7 +820,7 @@ var Builtins = map[string][]Builtin{
 				"using standard `strftime` notation (though not all formatting is supported).",
 		},
 		Builtin{
-			Types:      NamedArgTypes{{"input", TypeDate}, {"extract_format", TypeString}},
+			Types:      ArgTypes{{"input", TypeDate}, {"extract_format", TypeString}},
 			ReturnType: TypeString,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				fromTime := time.Unix(int64(*args[0].(*DDate))*secondsInDay, 0).UTC()
@@ -835,7 +835,7 @@ var Builtins = map[string][]Builtin{
 				"using standard `strftime` notation (though not all formatting is supported).",
 		},
 		Builtin{
-			Types:      NamedArgTypes{{"input", TypeTimestampTZ}, {"extract_format", TypeString}},
+			Types:      ArgTypes{{"input", TypeTimestampTZ}, {"extract_format", TypeString}},
 			ReturnType: TypeString,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				fromTime := args[0].(*DTimestampTZ).Time
@@ -853,7 +853,7 @@ var Builtins = map[string][]Builtin{
 
 	"experimental_strptime": {
 		Builtin{
-			Types:      NamedArgTypes{{"format", TypeString}, {"input", TypeString}},
+			Types:      ArgTypes{{"format", TypeString}, {"input", TypeString}},
 			ReturnType: TypeTimestampTZ,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				format := string(*args[0].(*DString))
@@ -871,7 +871,7 @@ var Builtins = map[string][]Builtin{
 
 	"age": {
 		Builtin{
-			Types:        NamedArgTypes{{"val", TypeTimestampTZ}},
+			Types:        ArgTypes{{"val", TypeTimestampTZ}},
 			ReturnType:   TypeInterval,
 			ctxDependent: true,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
@@ -880,7 +880,7 @@ var Builtins = map[string][]Builtin{
 			Info: "Calculates the interval between `val` and the current time.",
 		},
 		Builtin{
-			Types:      NamedArgTypes{{"begin", TypeTimestampTZ}, {"end", TypeTimestampTZ}},
+			Types:      ArgTypes{{"begin", TypeTimestampTZ}, {"end", TypeTimestampTZ}},
 			ReturnType: TypeInterval,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return timestampMinusBinOp.fn(ctx, args[0], args[1])
@@ -891,7 +891,7 @@ var Builtins = map[string][]Builtin{
 
 	"current_date": {
 		Builtin{
-			Types:        NamedArgTypes{},
+			Types:        ArgTypes{},
 			ReturnType:   TypeDate,
 			ctxDependent: true,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
@@ -908,7 +908,7 @@ var Builtins = map[string][]Builtin{
 
 	"statement_timestamp": {
 		Builtin{
-			Types:             NamedArgTypes{},
+			Types:             ArgTypes{},
 			ReturnType:        TypeTimestampTZ,
 			preferredOverload: true,
 			impure:            true,
@@ -919,7 +919,7 @@ var Builtins = map[string][]Builtin{
 			Info: "Returns the current statement's timestamp.",
 		},
 		Builtin{
-			Types:        NamedArgTypes{},
+			Types:        ArgTypes{},
 			ReturnType:   TypeTimestamp,
 			impure:       true,
 			ctxDependent: true,
@@ -932,7 +932,7 @@ var Builtins = map[string][]Builtin{
 
 	"cluster_logical_timestamp": {
 		Builtin{
-			Types:        NamedArgTypes{},
+			Types:        ArgTypes{},
 			ReturnType:   TypeDecimal,
 			category:     categorySystemInfo,
 			impure:       true,
@@ -946,7 +946,7 @@ var Builtins = map[string][]Builtin{
 
 	"clock_timestamp": {
 		Builtin{
-			Types:             NamedArgTypes{},
+			Types:             ArgTypes{},
 			ReturnType:        TypeTimestampTZ,
 			preferredOverload: true,
 			impure:            true,
@@ -956,7 +956,7 @@ var Builtins = map[string][]Builtin{
 			Info: "Returns the current wallclock time.",
 		},
 		Builtin{
-			Types:      NamedArgTypes{},
+			Types:      ArgTypes{},
 			ReturnType: TypeTimestamp,
 			impure:     true,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
@@ -968,7 +968,7 @@ var Builtins = map[string][]Builtin{
 
 	"extract": {
 		Builtin{
-			Types:      NamedArgTypes{{"element", TypeString}, {"input", TypeTimestamp}},
+			Types:      ArgTypes{{"element", TypeString}, {"input", TypeTimestamp}},
 			ReturnType: TypeInt,
 			category:   categoryDateAndTime,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
@@ -983,7 +983,7 @@ var Builtins = map[string][]Builtin{
 				"second<br/>&#8226; millisecond<br/>&#8226; microsecond<br/>&#8226; epoch",
 		},
 		Builtin{
-			Types:      NamedArgTypes{{"element", TypeString}, {"input", TypeDate}},
+			Types:      ArgTypes{{"element", TypeString}, {"input", TypeDate}},
 			ReturnType: TypeInt,
 			category:   categoryDateAndTime,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
@@ -1001,7 +1001,7 @@ var Builtins = map[string][]Builtin{
 
 	"extract_duration": {
 		Builtin{
-			Types:      NamedArgTypes{{"element", TypeString}, {"input", TypeInterval}},
+			Types:      ArgTypes{{"element", TypeString}, {"input", TypeInterval}},
 			ReturnType: TypeInt,
 			category:   categoryDateAndTime,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
@@ -1046,7 +1046,7 @@ var Builtins = map[string][]Builtin{
 			return dd, nil
 		}, "Calculates the absolute value of `val`."),
 		Builtin{
-			Types:      NamedArgTypes{{"val", TypeInt}},
+			Types:      ArgTypes{{"val", TypeInt}},
 			ReturnType: TypeInt,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				x := *args[0].(*DInt)
@@ -1131,7 +1131,7 @@ var Builtins = map[string][]Builtin{
 			return dd, nil
 		}, "Calculates the integer quotient of `x`/`y`."),
 		{
-			Types:      NamedArgTypes{{"x", TypeInt}, {"y", TypeInt}},
+			Types:      ArgTypes{{"x", TypeInt}, {"y", TypeInt}},
 			ReturnType: TypeInt,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				y := *args[1].(*DInt)
@@ -1192,7 +1192,7 @@ var Builtins = map[string][]Builtin{
 			return dd, nil
 		}, "Calculates `x`%`y`."),
 		Builtin{
-			Types:      NamedArgTypes{{"x", TypeInt}, {"y", TypeInt}},
+			Types:      ArgTypes{{"x", TypeInt}, {"y", TypeInt}},
 			ReturnType: TypeInt,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				y := *args[1].(*DInt)
@@ -1208,7 +1208,7 @@ var Builtins = map[string][]Builtin{
 
 	"pi": {
 		Builtin{
-			Types:      NamedArgTypes{},
+			Types:      ArgTypes{},
 			ReturnType: TypeFloat,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return NewDFloat(math.Pi), nil
@@ -1234,7 +1234,7 @@ var Builtins = map[string][]Builtin{
 			return roundDecimal(x, 0)
 		}, "Rounds `val` to the nearest integer."),
 		Builtin{
-			Types:      NamedArgTypes{{"input", TypeFloat}, {"decimal_accuracy", TypeInt}},
+			Types:      ArgTypes{{"input", TypeFloat}, {"decimal_accuracy", TypeInt}},
 			ReturnType: TypeFloat,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return round(float64(*args[0].(*DFloat)), int64(*args[1].(*DInt)))
@@ -1243,7 +1243,7 @@ var Builtins = map[string][]Builtin{
 				" in `input`.",
 		},
 		Builtin{
-			Types:      NamedArgTypes{{"input", TypeDecimal}, {"decimal_accuracy", TypeInt}},
+			Types:      ArgTypes{{"input", TypeDecimal}, {"decimal_accuracy", TypeInt}},
 			ReturnType: TypeDecimal,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				scale := int64(*args[1].(*DInt))
@@ -1278,7 +1278,7 @@ var Builtins = map[string][]Builtin{
 		}, "Determines the sign of `val`: **1** for positive; **0** for 0 values; **-1** for "+
 			"negative."),
 		Builtin{
-			Types:      NamedArgTypes{{"val", TypeInt}},
+			Types:      ArgTypes{{"val", TypeInt}},
 			ReturnType: TypeInt,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				x := *args[0].(*DInt)
@@ -1333,7 +1333,7 @@ var Builtins = map[string][]Builtin{
 
 	"array_length": {
 		Builtin{
-			Types:      NamedArgTypes{{"input", TypeAnyArray}, {"array_dimension", TypeInt}},
+			Types:      ArgTypes{{"input", TypeAnyArray}, {"array_dimension", TypeInt}},
 			ReturnType: TypeInt,
 			category:   categorySystemInfo,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
@@ -1349,7 +1349,7 @@ var Builtins = map[string][]Builtin{
 
 	"array_lower": {
 		Builtin{
-			Types:      NamedArgTypes{{"input", TypeAnyArray}, {"array_dimension", TypeInt}},
+			Types:      ArgTypes{{"input", TypeAnyArray}, {"array_dimension", TypeInt}},
 			ReturnType: TypeInt,
 			category:   categorySystemInfo,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
@@ -1365,7 +1365,7 @@ var Builtins = map[string][]Builtin{
 
 	"array_upper": {
 		Builtin{
-			Types:      NamedArgTypes{{"input", TypeAnyArray}, {"array_dimension", TypeInt}},
+			Types:      ArgTypes{{"input", TypeAnyArray}, {"array_dimension", TypeInt}},
 			ReturnType: TypeInt,
 			category:   categorySystemInfo,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
@@ -1383,7 +1383,7 @@ var Builtins = map[string][]Builtin{
 
 	"version": {
 		Builtin{
-			Types:      NamedArgTypes{},
+			Types:      ArgTypes{},
 			ReturnType: TypeString,
 			category:   categorySystemInfo,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
@@ -1395,7 +1395,7 @@ var Builtins = map[string][]Builtin{
 
 	"current_schema": {
 		Builtin{
-			Types:      NamedArgTypes{},
+			Types:      ArgTypes{},
 			ReturnType: TypeString,
 			category:   categorySystemInfo,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
@@ -1413,7 +1413,7 @@ var Builtins = map[string][]Builtin{
 	// parameter is true, the session's database search path.
 	"current_schemas": {
 		Builtin{
-			Types:        NamedArgTypes{{"include_implicit", TypeBool}},
+			Types:        ArgTypes{{"include_implicit", TypeBool}},
 			ReturnType:   TypeStringArray,
 			category:     categorySystemInfo,
 			ctxDependent: true,
@@ -1441,7 +1441,7 @@ var Builtins = map[string][]Builtin{
 
 	"crdb_internal.force_retry": {
 		Builtin{
-			Types:      NamedArgTypes{{"val", TypeInterval}},
+			Types:      ArgTypes{{"val", TypeInterval}},
 			ReturnType: TypeInt,
 			impure:     true,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
@@ -1469,7 +1469,7 @@ var Builtins = map[string][]Builtin{
 	// optional third argument.
 	"pg_catalog.pg_get_expr": {
 		Builtin{
-			Types: NamedArgTypes{
+			Types: ArgTypes{
 				{"pg_node_tree", TypeString},
 				{"relation_oid", TypeInt},
 			},
@@ -1481,7 +1481,7 @@ var Builtins = map[string][]Builtin{
 			Info:     "Not usable; supported only for ORM compatibility",
 		},
 		Builtin{
-			Types: NamedArgTypes{
+			Types: ArgTypes{
 				{"pg_node_tree", TypeString},
 				{"relation_oid", TypeInt},
 				{"pretty_bool", TypeBool},
@@ -1499,7 +1499,7 @@ var Builtins = map[string][]Builtin{
 	// statement.
 	"pg_catalog.pg_get_indexdef": {
 		Builtin{
-			Types: NamedArgTypes{
+			Types: ArgTypes{
 				{"index_oid", TypeInt},
 			},
 			ReturnType: TypeString,
@@ -1527,7 +1527,7 @@ var Builtins = map[string][]Builtin{
 		// TODO(knz): This is a proof-of-concept until TypeAny works
 		// properly.
 		Builtin{
-			Types:      NamedArgTypes{{"val", TypeAny}},
+			Types:      ArgTypes{{"val", TypeAny}},
 			ReturnType: TypeString,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return NewDString(args[0].ResolvedType().String()), nil
@@ -1538,7 +1538,7 @@ var Builtins = map[string][]Builtin{
 	},
 	"pg_catalog.pg_get_userbyid": {
 		Builtin{
-			Types: NamedArgTypes{
+			Types: ArgTypes{
 				{"role_oid", TypeInt},
 			},
 			ReturnType: TypeString,
@@ -1560,7 +1560,7 @@ var Builtins = map[string][]Builtin{
 	"pg_catalog.format_type": {
 		Builtin{
 			// TODO(jordan) typemod should be a Nullable TypeInt when supported.
-			Types:      NamedArgTypes{{"type_oid", TypeInt}, {"typemod", TypeInt}},
+			Types:      ArgTypes{{"type_oid", TypeInt}, {"typemod", TypeInt}},
 			ReturnType: TypeString,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				typ, ok := OidToType[oid.Oid(int(*args[0].(*DInt)))]
@@ -1577,7 +1577,7 @@ var Builtins = map[string][]Builtin{
 	},
 	"pg_catalog.col_description": {
 		Builtin{
-			Types:      NamedArgTypes{{"table_oid", TypeInt}, {"column_number", TypeInt}},
+			Types:      ArgTypes{{"table_oid", TypeInt}, {"column_number", TypeInt}},
 			ReturnType: TypeString,
 			fn: func(_ *EvalContext, _ DTuple) (Datum, error) {
 				return DNull, nil
@@ -1591,7 +1591,7 @@ var Builtins = map[string][]Builtin{
 
 var substringImpls = []Builtin{
 	{
-		Types: NamedArgTypes{
+		Types: ArgTypes{
 			{"input", TypeString},
 			{"substr_pos", TypeInt},
 		},
@@ -1612,7 +1612,7 @@ var substringImpls = []Builtin{
 		Info: "Returns a substring of `input` starting at `substr_pos` (count starts at 1).",
 	},
 	{
-		Types: NamedArgTypes{
+		Types: ArgTypes{
 			{"input", TypeString},
 			{"start_pos", TypeInt},
 			{"end_pos", TypeInt},
@@ -1649,7 +1649,7 @@ var substringImpls = []Builtin{
 		Info: "Returns a substring of `input` between `start_pos` and `end_pos` (count starts at 1).",
 	},
 	{
-		Types: NamedArgTypes{
+		Types: ArgTypes{
 			{"input", TypeString},
 			{"regex", TypeString},
 		},
@@ -1662,7 +1662,7 @@ var substringImpls = []Builtin{
 		Info: "Returns a substring of `input` that matches the regular expression `regex`.",
 	},
 	{
-		Types: NamedArgTypes{
+		Types: ArgTypes{
 			{"input", TypeString},
 			{"regex", TypeString},
 			{"escape_char", TypeString},
@@ -1680,7 +1680,7 @@ var substringImpls = []Builtin{
 }
 
 var uuidV4Impl = Builtin{
-	Types:      NamedArgTypes{},
+	Types:      ArgTypes{},
 	ReturnType: TypeBytes,
 	category:   categoryIDGeneration,
 	impure:     true,
@@ -1703,7 +1703,7 @@ var ceilImpl = []Builtin{
 
 var txnTSImpl = []Builtin{
 	{
-		Types:             NamedArgTypes{},
+		Types:             ArgTypes{},
 		ReturnType:        TypeTimestampTZ,
 		preferredOverload: true,
 		impure:            true,
@@ -1714,7 +1714,7 @@ var txnTSImpl = []Builtin{
 		Info: "Returns the current transaction's timestamp.",
 	},
 	{
-		Types:        NamedArgTypes{},
+		Types:        ArgTypes{},
 		ReturnType:   TypeTimestamp,
 		impure:       true,
 		ctxDependent: true,
@@ -1735,7 +1735,7 @@ var powImpls = []Builtin{
 		return dd, err
 	}, "Calculates `x`^`y`."),
 	{
-		Types: NamedArgTypes{
+		Types: ArgTypes{
 			{"x", TypeInt},
 			{"y", TypeInt},
 		},
@@ -1765,7 +1765,7 @@ func decimalLogFn(logFn func(*inf.Dec, *inf.Dec, inf.Scale) (*inf.Dec, error), i
 
 func floatBuiltin1(f func(float64) (Datum, error), info string) Builtin {
 	return Builtin{
-		Types:      NamedArgTypes{{"val", TypeFloat}},
+		Types:      ArgTypes{{"val", TypeFloat}},
 		ReturnType: TypeFloat,
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(float64(*args[0].(*DFloat)))
@@ -1776,7 +1776,7 @@ func floatBuiltin1(f func(float64) (Datum, error), info string) Builtin {
 
 func floatBuiltin2(a, b string, f func(float64, float64) (Datum, error), info string) Builtin {
 	return Builtin{
-		Types:      NamedArgTypes{{a, TypeFloat}, {b, TypeFloat}},
+		Types:      ArgTypes{{a, TypeFloat}, {b, TypeFloat}},
 		ReturnType: TypeFloat,
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(float64(*args[0].(*DFloat)),
@@ -1788,7 +1788,7 @@ func floatBuiltin2(a, b string, f func(float64, float64) (Datum, error), info st
 
 func decimalBuiltin1(f func(*inf.Dec) (Datum, error), info string) Builtin {
 	return Builtin{
-		Types:      NamedArgTypes{{"val", TypeDecimal}},
+		Types:      ArgTypes{{"val", TypeDecimal}},
 		ReturnType: TypeDecimal,
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			dec := &args[0].(*DDecimal).Dec
@@ -1800,7 +1800,7 @@ func decimalBuiltin1(f func(*inf.Dec) (Datum, error), info string) Builtin {
 
 func decimalBuiltin2(a, b string, f func(*inf.Dec, *inf.Dec) (Datum, error), info string) Builtin {
 	return Builtin{
-		Types:      NamedArgTypes{{a, TypeDecimal}, {b, TypeDecimal}},
+		Types:      ArgTypes{{a, TypeDecimal}, {b, TypeDecimal}},
 		ReturnType: TypeDecimal,
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			dec1 := &args[0].(*DDecimal).Dec
@@ -1813,7 +1813,7 @@ func decimalBuiltin2(a, b string, f func(*inf.Dec, *inf.Dec) (Datum, error), inf
 
 func stringBuiltin1(f func(string) (Datum, error), returnType Type, info string) Builtin {
 	return Builtin{
-		Types:      NamedArgTypes{{"val", TypeString}},
+		Types:      ArgTypes{{"val", TypeString}},
 		ReturnType: returnType,
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(string(*args[0].(*DString)))
@@ -1826,7 +1826,7 @@ func stringBuiltin2(
 	a, b string, f func(string, string) (Datum, error), returnType Type, info string,
 ) Builtin {
 	return Builtin{
-		Types:      NamedArgTypes{{a, TypeString}, {b, TypeString}},
+		Types:      ArgTypes{{a, TypeString}, {b, TypeString}},
 		ReturnType: returnType,
 		category:   categorizeType(TypeString),
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
@@ -1840,7 +1840,7 @@ func stringBuiltin3(
 	a, b, c string, f func(string, string, string) (Datum, error), returnType Type, info string,
 ) Builtin {
 	return Builtin{
-		Types:      NamedArgTypes{{a, TypeString}, {b, TypeString}, {c, TypeString}},
+		Types:      ArgTypes{{a, TypeString}, {b, TypeString}, {c, TypeString}},
 		ReturnType: returnType,
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(string(*args[0].(*DString)), string(*args[1].(*DString)), string(*args[2].(*DString)))
@@ -1851,7 +1851,7 @@ func stringBuiltin3(
 
 func bytesBuiltin1(f func(string) (Datum, error), returnType Type, info string) Builtin {
 	return Builtin{
-		Types:      NamedArgTypes{{"val", TypeBytes}},
+		Types:      ArgTypes{{"val", TypeBytes}},
 		ReturnType: returnType,
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(string(*args[0].(*DBytes)))

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -73,7 +73,7 @@ func (UnaryOp) preferred() bool {
 func init() {
 	for op, overload := range UnaryOps {
 		for i, impl := range overload {
-			impl.types = NamedArgTypes{{"arg", impl.Typ}}
+			impl.types = ArgTypes{{"arg", impl.Typ}}
 			UnaryOps[op][i] = impl
 		}
 	}
@@ -185,7 +185,7 @@ func (BinOp) preferred() bool {
 func init() {
 	for op, overload := range BinOps {
 		for i, impl := range overload {
-			impl.types = NamedArgTypes{{"left", impl.LeftType}, {"right", impl.RightType}}
+			impl.types = ArgTypes{{"left", impl.LeftType}, {"right", impl.RightType}}
 			BinOps[op][i] = impl
 		}
 	}
@@ -898,7 +898,7 @@ func (CmpOp) preferred() bool {
 func init() {
 	for op, overload := range CmpOps {
 		for i, impl := range overload {
-			impl.types = NamedArgTypes{{"left", impl.LeftType}, {"right", impl.RightType}}
+			impl.types = ArgTypes{{"left", impl.LeftType}, {"right", impl.RightType}}
 			CmpOps[op][i] = impl
 		}
 	}

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -73,7 +73,7 @@ func (UnaryOp) preferred() bool {
 func init() {
 	for op, overload := range UnaryOps {
 		for i, impl := range overload {
-			impl.types = ArgTypes{impl.Typ}
+			impl.types = NamedArgTypes{{"arg", impl.Typ}}
 			UnaryOps[op][i] = impl
 		}
 	}
@@ -185,7 +185,7 @@ func (BinOp) preferred() bool {
 func init() {
 	for op, overload := range BinOps {
 		for i, impl := range overload {
-			impl.types = ArgTypes{impl.LeftType, impl.RightType}
+			impl.types = NamedArgTypes{{"left", impl.LeftType}, {"right", impl.RightType}}
 			BinOps[op][i] = impl
 		}
 	}
@@ -898,7 +898,7 @@ func (CmpOp) preferred() bool {
 func init() {
 	for op, overload := range CmpOps {
 		for i, impl := range overload {
-			impl.types = ArgTypes{impl.LeftType, impl.RightType}
+			impl.types = NamedArgTypes{{"left", impl.LeftType}, {"right", impl.RightType}}
 			CmpOps[op][i] = impl
 		}
 	}
@@ -2338,7 +2338,7 @@ func (expr *FuncExpr) Eval(ctx *EvalContext) (Datum, error) {
 		args = append(args, arg)
 	}
 
-	if !expr.fn.Types.match(ArgTypes(args.ResolvedType().(TTuple))) {
+	if !expr.fn.Types.match([]Type(args.ResolvedType().(TTuple))) {
 		// The argument types no longer match the memoized function. This happens
 		// when a non-NULL argument becomes NULL and the function does not support
 		// NULL arguments. For example, "SELECT LOWER(col) FROM TABLE" where col is

--- a/pkg/sql/parser/generator_builtins.go
+++ b/pkg/sql/parser/generator_builtins.go
@@ -103,13 +103,13 @@ func initGeneratorBuiltins() {
 var generators = map[string][]Builtin{
 	"pg_catalog.generate_series": {
 		makeGeneratorBuiltin(
-			ArgTypes{TypeInt, TypeInt},
+			NamedArgTypes{{"a", TypeInt}, {"b", TypeInt}},
 			TTuple{TypeInt},
 			makeSeriesGenerator,
 			"Not usable; supported only for ORM compatibility.",
 		),
 		makeGeneratorBuiltin(
-			ArgTypes{TypeInt, TypeInt, TypeInt},
+			NamedArgTypes{{"a", TypeInt}, {"b", TypeInt}, {"c", TypeInt}},
 			TTuple{TypeInt},
 			makeSeriesGenerator,
 			"Not usable; supported only for ORM compatibility.",
@@ -117,7 +117,7 @@ var generators = map[string][]Builtin{
 	},
 }
 
-func makeGeneratorBuiltin(in ArgTypes, ret TTuple, g generatorFactory, info string) Builtin {
+func makeGeneratorBuiltin(in NamedArgTypes, ret TTuple, g generatorFactory, info string) Builtin {
 	return Builtin{
 		impure:     true,
 		class:      GeneratorClass,

--- a/pkg/sql/parser/generator_builtins.go
+++ b/pkg/sql/parser/generator_builtins.go
@@ -103,13 +103,13 @@ func initGeneratorBuiltins() {
 var generators = map[string][]Builtin{
 	"pg_catalog.generate_series": {
 		makeGeneratorBuiltin(
-			NamedArgTypes{{"a", TypeInt}, {"b", TypeInt}},
+			ArgTypes{{"a", TypeInt}, {"b", TypeInt}},
 			TTuple{TypeInt},
 			makeSeriesGenerator,
 			"Not usable; supported only for ORM compatibility.",
 		),
 		makeGeneratorBuiltin(
-			NamedArgTypes{{"a", TypeInt}, {"b", TypeInt}, {"c", TypeInt}},
+			ArgTypes{{"a", TypeInt}, {"b", TypeInt}, {"c", TypeInt}},
 			TTuple{TypeInt},
 			makeSeriesGenerator,
 			"Not usable; supported only for ORM compatibility.",
@@ -117,7 +117,7 @@ var generators = map[string][]Builtin{
 	},
 }
 
-func makeGeneratorBuiltin(in NamedArgTypes, ret TTuple, g generatorFactory, info string) Builtin {
+func makeGeneratorBuiltin(in ArgTypes, ret TTuple, g generatorFactory, info string) Builtin {
 	return Builtin{
 		impure:     true,
 		class:      GeneratorClass,

--- a/pkg/sql/parser/overload.go
+++ b/pkg/sql/parser/overload.go
@@ -49,19 +49,19 @@ type typeList interface {
 	String() string
 }
 
-var _ typeList = NamedArgTypes{}
+var _ typeList = ArgTypes{}
 var _ typeList = AnyType{}
 var _ typeList = VariadicType{}
 
-// NamedArgTypes is very similar to ArgTypes except it allows keeping a string
+// ArgTypes is very similar to ArgTypes except it allows keeping a string
 // name for each argument as well and using those when printing the
 // human-readable signature.
-type NamedArgTypes []struct {
+type ArgTypes []struct {
 	Name string
 	Typ  Type
 }
 
-func (a NamedArgTypes) match(types []Type) bool {
+func (a ArgTypes) match(types []Type) bool {
 	if len(types) != len(a) {
 		return false
 	}
@@ -73,7 +73,7 @@ func (a NamedArgTypes) match(types []Type) bool {
 	return true
 }
 
-func (a NamedArgTypes) matchAt(typ Type, i int) bool {
+func (a ArgTypes) matchAt(typ Type, i int) bool {
 	// The parameterized types for Tuples are checked in the type checking
 	// routines before getting here, so we only need to check if the argument
 	// type is a TypeTuple below. This allows us to avoid defining overloads
@@ -85,21 +85,21 @@ func (a NamedArgTypes) matchAt(typ Type, i int) bool {
 	return i < len(a) && a[i].Typ.Equivalent(typ)
 }
 
-func (a NamedArgTypes) matchLen(l int) bool {
+func (a ArgTypes) matchLen(l int) bool {
 	return len(a) == l
 }
 
-func (a NamedArgTypes) getAt(i int) Type {
+func (a ArgTypes) getAt(i int) Type {
 	return a[i].Typ
 }
 
 // Length implements the typeList interface.
-func (a NamedArgTypes) Length() int {
+func (a ArgTypes) Length() int {
 	return len(a)
 }
 
 // Types implements the typeList interface.
-func (a NamedArgTypes) Types() []Type {
+func (a ArgTypes) Types() []Type {
 	n := len(a)
 	ret := make([]Type, n, n)
 	for i, s := range a {
@@ -108,7 +108,7 @@ func (a NamedArgTypes) Types() []Type {
 	return ret
 }
 
-func (a NamedArgTypes) String() string {
+func (a ArgTypes) String() string {
 	var s bytes.Buffer
 	for i, arg := range a {
 		if i > 0 {

--- a/pkg/sql/parser/overload_test.go
+++ b/pkg/sql/parser/overload_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 type testOverload struct {
-	paramTypes NamedArgTypes
+	paramTypes ArgTypes
 	retType    Type
 	pref       bool
 }
@@ -51,7 +51,7 @@ func (to *testOverload) String() string {
 }
 
 func makeTestOverload(retType Type, params ...Type) overloadImpl {
-	t := make(NamedArgTypes, len(params))
+	t := make(ArgTypes, len(params))
 	for i := range params {
 		t[i].Typ = params[i]
 	}
@@ -76,7 +76,7 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 	}
 
 	unaryIntFn := makeTestOverload(TypeInt, TypeInt)
-	unaryIntFnPref := &testOverload{retType: TypeInt, paramTypes: NamedArgTypes{}, pref: true}
+	unaryIntFnPref := &testOverload{retType: TypeInt, paramTypes: ArgTypes{}, pref: true}
 	unaryFloatFn := makeTestOverload(TypeFloat, TypeFloat)
 	unaryDecimalFn := makeTestOverload(TypeDecimal, TypeDecimal)
 	unaryStringFn := makeTestOverload(TypeString, TypeString)

--- a/pkg/sql/parser/overload_test.go
+++ b/pkg/sql/parser/overload_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 type testOverload struct {
-	paramTypes ArgTypes
+	paramTypes NamedArgTypes
 	retType    Type
 	pref       bool
 }
@@ -45,14 +45,18 @@ func (to testOverload) preferred() bool {
 func (to *testOverload) String() string {
 	typeNames := make([]string, len(to.paramTypes))
 	for i, param := range to.paramTypes {
-		typeNames[i] = param.String()
+		typeNames[i] = param.Typ.String()
 	}
 	return fmt.Sprintf("func(%s) %s", strings.Join(typeNames, ","), to.retType)
 }
 
 func makeTestOverload(retType Type, params ...Type) overloadImpl {
+	t := make(NamedArgTypes, len(params))
+	for i := range params {
+		t[i].Typ = params[i]
+	}
 	return &testOverload{
-		paramTypes: ArgTypes(params),
+		paramTypes: t,
 		retType:    retType,
 	}
 }
@@ -72,7 +76,7 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 	}
 
 	unaryIntFn := makeTestOverload(TypeInt, TypeInt)
-	unaryIntFnPref := &testOverload{retType: TypeInt, paramTypes: ArgTypes{}, pref: true}
+	unaryIntFnPref := &testOverload{retType: TypeInt, paramTypes: NamedArgTypes{}, pref: true}
 	unaryFloatFn := makeTestOverload(TypeFloat, TypeFloat)
 	unaryDecimalFn := makeTestOverload(TypeDecimal, TypeDecimal)
 	unaryStringFn := makeTestOverload(TypeString, TypeString)

--- a/pkg/sql/parser/window_builtins.go
+++ b/pkg/sql/parser/window_builtins.go
@@ -106,53 +106,55 @@ type WindowFunc interface {
 // See `windowFuncHolder` in the sql package.
 var windows = map[string][]Builtin{
 	"row_number": {
-		makeWindowBuiltin(ArgTypes{}, TypeInt, newRowNumberWindow),
+		makeWindowBuiltin(NamedArgTypes{}, TypeInt, newRowNumberWindow),
 	},
 	"rank": {
-		makeWindowBuiltin(ArgTypes{}, TypeInt, newRankWindow),
+		makeWindowBuiltin(NamedArgTypes{}, TypeInt, newRankWindow),
 	},
 	"dense_rank": {
-		makeWindowBuiltin(ArgTypes{}, TypeInt, newDenseRankWindow),
+		makeWindowBuiltin(NamedArgTypes{}, TypeInt, newDenseRankWindow),
 	},
 	"percent_rank": {
-		makeWindowBuiltin(ArgTypes{}, TypeFloat, newPercentRankWindow),
+		makeWindowBuiltin(NamedArgTypes{}, TypeFloat, newPercentRankWindow),
 	},
 	"cume_dist": {
-		makeWindowBuiltin(ArgTypes{}, TypeFloat, newCumulativeDistWindow),
+		makeWindowBuiltin(NamedArgTypes{}, TypeFloat, newCumulativeDistWindow),
 	},
 	"ntile": {
-		makeWindowBuiltin(ArgTypes{TypeInt}, TypeInt, newNtileWindow),
+		makeWindowBuiltin(NamedArgTypes{{"n", TypeInt}}, TypeInt, newNtileWindow),
 	},
 	"lag": mergeBuiltinSlices(
 		collectWindowBuiltins(func(t Type) Builtin {
-			return makeWindowBuiltin(ArgTypes{t}, t, makeLeadLagWindowConstructor(false, false, false))
+			return makeWindowBuiltin(NamedArgTypes{{"val", t}}, t, makeLeadLagWindowConstructor(false, false, false))
 		}, anyElementTypes...),
 		collectWindowBuiltins(func(t Type) Builtin {
-			return makeWindowBuiltin(ArgTypes{t, TypeInt}, t, makeLeadLagWindowConstructor(false, true, false))
+			return makeWindowBuiltin(NamedArgTypes{{"val", t}, {"n", TypeInt}}, t, makeLeadLagWindowConstructor(false, true, false))
 		}, anyElementTypes...),
 		collectWindowBuiltins(func(t Type) Builtin {
-			return makeWindowBuiltin(ArgTypes{t, TypeInt, t}, t, makeLeadLagWindowConstructor(false, true, true))
+			return makeWindowBuiltin(NamedArgTypes{{"val", t}, {"n", TypeInt}, {"default", t}},
+				t, makeLeadLagWindowConstructor(false, true, true))
 		}, anyElementTypes...),
 	),
 	"lead": mergeBuiltinSlices(
 		collectWindowBuiltins(func(t Type) Builtin {
-			return makeWindowBuiltin(ArgTypes{t}, t, makeLeadLagWindowConstructor(true, false, false))
+			return makeWindowBuiltin(NamedArgTypes{{"val", t}}, t, makeLeadLagWindowConstructor(true, false, false))
 		}, anyElementTypes...),
 		collectWindowBuiltins(func(t Type) Builtin {
-			return makeWindowBuiltin(ArgTypes{t, TypeInt}, t, makeLeadLagWindowConstructor(true, true, false))
+			return makeWindowBuiltin(NamedArgTypes{{"val", t}, {"n", TypeInt}}, t, makeLeadLagWindowConstructor(true, true, false))
 		}, anyElementTypes...),
 		collectWindowBuiltins(func(t Type) Builtin {
-			return makeWindowBuiltin(ArgTypes{t, TypeInt, t}, t, makeLeadLagWindowConstructor(true, true, true))
+			return makeWindowBuiltin(NamedArgTypes{{"val", t}, {"n", TypeInt}, {"default", t}},
+				t, makeLeadLagWindowConstructor(true, true, true))
 		}, anyElementTypes...),
 	),
 	"first_value": collectWindowBuiltins(func(t Type) Builtin {
-		return makeWindowBuiltin(ArgTypes{t}, t, newFirstValueWindow)
+		return makeWindowBuiltin(NamedArgTypes{{"val", t}}, t, newFirstValueWindow)
 	}, anyElementTypes...),
 	"last_value": collectWindowBuiltins(func(t Type) Builtin {
-		return makeWindowBuiltin(ArgTypes{t}, t, newLastValueWindow)
+		return makeWindowBuiltin(NamedArgTypes{{"val", t}}, t, newLastValueWindow)
 	}, anyElementTypes...),
 	"nth_value": collectWindowBuiltins(func(t Type) Builtin {
-		return makeWindowBuiltin(ArgTypes{t, TypeInt}, t, newNthValueWindow)
+		return makeWindowBuiltin(NamedArgTypes{{"val", t}, {"n", TypeInt}}, t, newNthValueWindow)
 	}, anyElementTypes...),
 }
 
@@ -169,7 +171,7 @@ var anyElementTypes = []Type{
 	TypeTuple,
 }
 
-func makeWindowBuiltin(in ArgTypes, ret Type, f func() WindowFunc) Builtin {
+func makeWindowBuiltin(in NamedArgTypes, ret Type, f func() WindowFunc) Builtin {
 	return Builtin{
 		impure:     true,
 		class:      WindowClass,

--- a/pkg/sql/parser/window_builtins.go
+++ b/pkg/sql/parser/window_builtins.go
@@ -106,55 +106,55 @@ type WindowFunc interface {
 // See `windowFuncHolder` in the sql package.
 var windows = map[string][]Builtin{
 	"row_number": {
-		makeWindowBuiltin(NamedArgTypes{}, TypeInt, newRowNumberWindow),
+		makeWindowBuiltin(ArgTypes{}, TypeInt, newRowNumberWindow),
 	},
 	"rank": {
-		makeWindowBuiltin(NamedArgTypes{}, TypeInt, newRankWindow),
+		makeWindowBuiltin(ArgTypes{}, TypeInt, newRankWindow),
 	},
 	"dense_rank": {
-		makeWindowBuiltin(NamedArgTypes{}, TypeInt, newDenseRankWindow),
+		makeWindowBuiltin(ArgTypes{}, TypeInt, newDenseRankWindow),
 	},
 	"percent_rank": {
-		makeWindowBuiltin(NamedArgTypes{}, TypeFloat, newPercentRankWindow),
+		makeWindowBuiltin(ArgTypes{}, TypeFloat, newPercentRankWindow),
 	},
 	"cume_dist": {
-		makeWindowBuiltin(NamedArgTypes{}, TypeFloat, newCumulativeDistWindow),
+		makeWindowBuiltin(ArgTypes{}, TypeFloat, newCumulativeDistWindow),
 	},
 	"ntile": {
-		makeWindowBuiltin(NamedArgTypes{{"n", TypeInt}}, TypeInt, newNtileWindow),
+		makeWindowBuiltin(ArgTypes{{"n", TypeInt}}, TypeInt, newNtileWindow),
 	},
 	"lag": mergeBuiltinSlices(
 		collectWindowBuiltins(func(t Type) Builtin {
-			return makeWindowBuiltin(NamedArgTypes{{"val", t}}, t, makeLeadLagWindowConstructor(false, false, false))
+			return makeWindowBuiltin(ArgTypes{{"val", t}}, t, makeLeadLagWindowConstructor(false, false, false))
 		}, anyElementTypes...),
 		collectWindowBuiltins(func(t Type) Builtin {
-			return makeWindowBuiltin(NamedArgTypes{{"val", t}, {"n", TypeInt}}, t, makeLeadLagWindowConstructor(false, true, false))
+			return makeWindowBuiltin(ArgTypes{{"val", t}, {"n", TypeInt}}, t, makeLeadLagWindowConstructor(false, true, false))
 		}, anyElementTypes...),
 		collectWindowBuiltins(func(t Type) Builtin {
-			return makeWindowBuiltin(NamedArgTypes{{"val", t}, {"n", TypeInt}, {"default", t}},
+			return makeWindowBuiltin(ArgTypes{{"val", t}, {"n", TypeInt}, {"default", t}},
 				t, makeLeadLagWindowConstructor(false, true, true))
 		}, anyElementTypes...),
 	),
 	"lead": mergeBuiltinSlices(
 		collectWindowBuiltins(func(t Type) Builtin {
-			return makeWindowBuiltin(NamedArgTypes{{"val", t}}, t, makeLeadLagWindowConstructor(true, false, false))
+			return makeWindowBuiltin(ArgTypes{{"val", t}}, t, makeLeadLagWindowConstructor(true, false, false))
 		}, anyElementTypes...),
 		collectWindowBuiltins(func(t Type) Builtin {
-			return makeWindowBuiltin(NamedArgTypes{{"val", t}, {"n", TypeInt}}, t, makeLeadLagWindowConstructor(true, true, false))
+			return makeWindowBuiltin(ArgTypes{{"val", t}, {"n", TypeInt}}, t, makeLeadLagWindowConstructor(true, true, false))
 		}, anyElementTypes...),
 		collectWindowBuiltins(func(t Type) Builtin {
-			return makeWindowBuiltin(NamedArgTypes{{"val", t}, {"n", TypeInt}, {"default", t}},
+			return makeWindowBuiltin(ArgTypes{{"val", t}, {"n", TypeInt}, {"default", t}},
 				t, makeLeadLagWindowConstructor(true, true, true))
 		}, anyElementTypes...),
 	),
 	"first_value": collectWindowBuiltins(func(t Type) Builtin {
-		return makeWindowBuiltin(NamedArgTypes{{"val", t}}, t, newFirstValueWindow)
+		return makeWindowBuiltin(ArgTypes{{"val", t}}, t, newFirstValueWindow)
 	}, anyElementTypes...),
 	"last_value": collectWindowBuiltins(func(t Type) Builtin {
-		return makeWindowBuiltin(NamedArgTypes{{"val", t}}, t, newLastValueWindow)
+		return makeWindowBuiltin(ArgTypes{{"val", t}}, t, newLastValueWindow)
 	}, anyElementTypes...),
 	"nth_value": collectWindowBuiltins(func(t Type) Builtin {
-		return makeWindowBuiltin(NamedArgTypes{{"val", t}, {"n", TypeInt}}, t, newNthValueWindow)
+		return makeWindowBuiltin(ArgTypes{{"val", t}, {"n", TypeInt}}, t, newNthValueWindow)
 	}, anyElementTypes...),
 }
 
@@ -171,7 +171,7 @@ var anyElementTypes = []Type{
 	TypeTuple,
 }
 
-func makeWindowBuiltin(in NamedArgTypes, ret Type, f func() WindowFunc) Builtin {
+func makeWindowBuiltin(in ArgTypes, ret Type, f func() WindowFunc) Builtin {
 	return Builtin{
 		impure:     true,
 		class:      WindowClass,

--- a/pkg/sql/rsg_test.go
+++ b/pkg/sql/rsg_test.go
@@ -124,10 +124,6 @@ func TestRandomSyntaxFunctions(t *testing.T) {
 		nb := <-namedBuiltinChan
 		var args []string
 		switch ft := nb.builtin.Types.(type) {
-		case parser.ArgTypes:
-			for _, typ := range ft {
-				args = append(args, r.GenerateRandomArg(typ))
-			}
 		case parser.NamedArgTypes:
 			for _, arg := range ft {
 				args = append(args, r.GenerateRandomArg(arg.Typ))

--- a/pkg/sql/rsg_test.go
+++ b/pkg/sql/rsg_test.go
@@ -124,7 +124,7 @@ func TestRandomSyntaxFunctions(t *testing.T) {
 		nb := <-namedBuiltinChan
 		var args []string
 		switch ft := nb.builtin.Types.(type) {
-		case parser.NamedArgTypes:
+		case parser.ArgTypes:
 			for _, arg := range ft {
 				args = append(args, r.GenerateRandomArg(arg.Typ))
 			}


### PR DESCRIPTION
This switches the remaining uses of `ArgTypes` to `NamedArgTypes` and removes the un-named.
This is an alternative approach to removing the duplication between the two addressed in #13032.

Closes #13032.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13046)
<!-- Reviewable:end -->
