### PR TITLE
scripts: Add MemorySanitizer support to {gce,az}workers

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -33,6 +33,8 @@ RUN \
  unzip terraform_linux_amd64.zip && \
  rm terraform_linux_amd64.zip
 
+# Both clang and gcc are installed and gcc is used by default. To use clang,
+# set CC=clang and CXX=clang++ when building.
 ENV PATH=/opt/backtrace/bin:/third_party/llvm-build/Release+Asserts/bin:$PATH
 
 RUN chmod -R a+w $(go env GOTOOLDIR)

--- a/pkg/storage/engine/rocksdb/db.cc
+++ b/pkg/storage/engine/rocksdb/db.cc
@@ -366,14 +366,8 @@ DBStatus FmtStatus(const char *fmt, ...) {
 }
 
 DBIterState DBIterGetState(DBIterator* iter) {
-  DBIterState state;
+  DBIterState state = {};
   state.valid = iter->rep->Valid();
-  state.key.key.data = NULL;
-  state.key.key.len = 0;
-  state.key.wall_time = 0;
-  state.key.logical = 0;
-  state.value.data = NULL;
-  state.value.len = 0;
 
   if (state.valid) {
     rocksdb::Slice key;

--- a/scripts/bootstrap-debian.sh
+++ b/scripts/bootstrap-debian.sh
@@ -7,10 +7,35 @@ set -euxo pipefail
 
 cd "$(dirname "${0}")"
 
-sudo apt-get update -q && sudo apt-get install -q -y --no-install-recommends build-essential git gdb patch bzip2 docker.io
+sudo apt-get update -q && sudo apt-get install -q -y --no-install-recommends build-essential git gdb patch bzip2 docker.io clang cmake subversion
 
 sudo adduser "${USER}" docker
 
+
+# Install an msan-enabled build of libc++, following instructions from
+# https://github.com/google/sanitizers/wiki/MemorySanitizerLibcxxHowTo
+
+# Build libcxx from head, because rocksdb 4.11 doesn't build with libcxx 3.9 on linux.
+# TODO(bdarnell): after we upgrade to rocksdb 5.0, replace these svn commands with the
+# commented-out tarball installation below.
+
+svn co -q http://llvm.org/svn/llvm-project/llvm/trunk ~/llvm
+(cd ~/llvm/projects && svn co -q http://llvm.org/svn/llvm-project/libcxx/trunk libcxx)
+(cd ~/llvm/projects && svn co -q http://llvm.org/svn/llvm-project/libcxxabi/trunk libcxxabi)
+
+#mkdir ~/llvm && curl -sfSL http://releases.llvm.org/3.9.1/llvm-3.9.1.src.tar.xz | tar --strip-components=1 -C ~/llvm -xJ
+#mkdir ~/llvm/projects/libcxx && curl -sfSL http://releases.llvm.org/3.9.1/libcxx-3.9.1.src.tar.xz | tar --strip-components=1 -C ~/llvm/projects/libcxx -xJ
+#mkdir ~/llvm/projects/libcxxabi && curl -sfSL http://releases.llvm.org/3.9.1/libcxxabi-3.9.1.src.tar.xz | tar --strip-components=1 -C ~/llvm/projects/libcxxabi -xJ
+
+
+
+mkdir ~/libcxx_msan
+(cd ~/libcxx_msan &&
+cmake ../llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_USE_SANITIZER=Memory -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ &&
+make cxx -j16)
+
+
+# Install Go from source so we can add a patch to run cgo builds in parallel.
 mkdir -p ~/go-bootstrap ~/goroot ~/go
 curl "https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz" | tar -C ~/go-bootstrap -xz --strip=1
 curl "https://storage.googleapis.com/golang/go${GOVERSION}.src.tar.gz" | tar --strip-components=1 -C ~/goroot -xz
@@ -21,9 +46,14 @@ patch -p1 -d ../goroot < "parallelbuilds-go${GOPATCHVER}.patch"
 
 (cd ~/goroot/src && GOROOT_BOOTSTRAP=~/go-bootstrap ./make.bash)
 
-echo 'export GOPATH=${HOME}/go; export PATH="${HOME}/goroot/bin:${HOME}/go/bin:${PATH}"' >> ~/.bashrc_go
+
+# Configure environment variables
+echo 'export GOPATH=${HOME}/go; export PATH="${HOME}/goroot/bin:${HOME}/go/bin:${HOME}/scripts:${PATH}"' >> ~/.bashrc_go
 echo '. ~/.bashrc_go' >> ~/.bashrc
 
 . ~/.bashrc_go
+
+# Allow Go support files in gdb.
+echo "add-auto-load-safe-path ${HOME}/goroot/src/runtime/runtime-gdb.py" >> ~/.gdbinit
 
 go get -d github.com/cockroachdb/cockroach

--- a/scripts/with-msan
+++ b/scripts/with-msan
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# To build a program with MemorySanitizer enabled, prefix it with this script:
+#   with-msan make test PKG=./pkg/storage GOFLAGS=-msan TAGS=stdmalloc TESTTIMEOUT=10m
+# or
+#   with-msan $(SHELL)
+#
+# MemorySanitizer is only available on linux; this script assumes the machine has
+# been set up with bootstrap-debian.sh.
+
+export CC=clang
+export CXX=clang++
+export CGO_CPPFLAGS="-fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer -I${HOME}/libcxx_msan/include -I${HOME}/libcxx_msan/include/c++/v1"
+export CGO_LDFLAGS="-fsanitize=memory -stdlib=libc++ -L${HOME}/libcxx_msan/lib -lc++abi -Wl,-rpath,${HOME}/libcxx_msan/lib"
+
+"$@"


### PR DESCRIPTION
This requires a custom build of libc++ and using the standard malloc instead of jemalloc.

Fix a false positive in `storage/engine/rocksdb`. Other than this issue, our test suite is now msan-clean.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13047)
<!-- Reviewable:end -->
