### PR TITLE
Error without format string and two misspelled words

### DIFF
--- a/pkg/internal/client/txn_test.go
+++ b/pkg/internal/client/txn_test.go
@@ -80,7 +80,7 @@ func TestTxnSnowballTrace(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !found {
-		t.Fatalf("didnt match: %s", dump)
+		t.Fatalf("didn't match: %s", dump)
 	}
 }
 
@@ -230,7 +230,7 @@ func TestTxnResetTxnOnAbort(t *testing.T) {
 	}
 
 	if txn.Proto.ID != nil {
-		t.Errorf("expected txn to be cleared")
+		t.Error("expected txn to be cleared")
 	}
 }
 

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -24,7 +24,7 @@ import (
 
 // planHookFn is a function that can intercept a statement being planned and
 // provide an alternate implementation. It's primarily intended to allow
-// implemention of certain sql statements to live outside of the sql package.
+// implementation of certain sql statements to live outside of the sql package.
 //
 // To intercept a statement the function should return a non-nil function for
 // `fn` as well as the appropriate ResultColumns describing the results it will


### PR DESCRIPTION
Error without format string changed from:
`t.Errorf("expected txn to be cleared")`
to:
`t.Error("expected txn to be cleared")`

and two misspelled words:

```
Misspell Finds commonly misspelled English words
cockroach/pkg/internal/client/txn_test.go
Line 83: warning: found "didnt" a misspelling of "didn\'t" (misspell)
cockroach/pkg/sql/planhook.go
Line 27: warning: found "implemention" a misspelling of "implementation" (misspell)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13050)
<!-- Reviewable:end -->
