### PR TITLE
storage: fix applied snapshot metrics

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2733,6 +2733,10 @@ func (s *Store) HandleSnapshot(header *SnapshotRequest_Header, stream SnapshotRe
 				Batches:    batches,
 				LogEntries: logEntries,
 				State:      &header.State,
+				snapType:   snapTypeRaft,
+			}
+			if header.RaftMessageRequest.ToReplica.ReplicaID == 0 {
+				inSnap.snapType = snapTypePreemptive
 			}
 
 			if err := s.processRaftRequest(ctx, &header.RaftMessageRequest, inSnap); err != nil {


### PR DESCRIPTION
Add IncomingSnapshot.snapType and properly compute its value from the
ToReplica.ReplicaID of the request.

Fixes #13041

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13082)
<!-- Reviewable:end -->
