### PR TITLE
util/log: add GC of old log files

### DIFF
--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	stdLog "log"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -577,8 +578,10 @@ func init() {
 
 	logging.setVState(0, nil, false)
 	logging.exitFunc = os.Exit
+	logging.gcNotify = make(chan struct{}, 1)
 
 	go logging.flushDaemon()
+	go logging.gcDaemon()
 }
 
 // Flush flushes all pending log I/O.
@@ -624,9 +627,10 @@ type loggingT struct {
 	traceLocation traceLocation
 	// These flags are modified only under lock, although verbosity may be fetched
 	// safely using atomic.LoadInt32.
-	vmodule   moduleSpec // The state of the --vmodule flag.
-	verbosity level      // V logging level, the value of the --verbosity flag/
-	exitFunc  func(int)  // func that will be called on fatal errors
+	vmodule   moduleSpec    // The state of the --vmodule flag.
+	verbosity level         // V logging level, the value of the --verbosity flag/
+	exitFunc  func(int)     // func that will be called on fatal errors
+	gcNotify  chan struct{} // notify GC daemon that a new log file was created
 }
 
 // buffer holds a byte Buffer for reuse. The zero value is ready for use.
@@ -952,6 +956,11 @@ func (sb *syncBuffer) rotateFile(now time.Time) error {
 		}
 		logging.putBuffer(buf)
 	}
+
+	select {
+	case logging.gcNotify <- struct{}{}:
+	default:
+	}
 	return nil
 }
 
@@ -1034,6 +1043,49 @@ func (l *loggingT) flushAll() {
 		if file != nil {
 			_ = file.Flush() // ignore error
 			_ = file.Sync()  // ignore error
+		}
+	}
+}
+
+func (l *loggingT) gcDaemon() {
+	l.gcOldFiles()
+	for range l.gcNotify {
+		l.gcOldFiles()
+	}
+}
+
+func (l *loggingT) gcOldFiles() {
+	dir, err := logDir.get()
+	if err != nil {
+		// No log directory configured. Nothing to do.
+		return
+	}
+
+	allFiles, err := ListLogFiles()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unable to GC log files: %s\n", err)
+		return
+	}
+
+	maxSizePerSeverity := atomic.LoadUint64(&MaxSizePerSeverity)
+	for s := Severity_INFO; s <= Severity_FATAL; s++ {
+		severityFiles := selectFiles(allFiles, s, math.MaxInt64)
+		if len(severityFiles) == 0 {
+			continue
+		}
+		// severityFiles is sorted with the newest log files first (which we want
+		// to keep). Note that we always keep the most recent log file per
+		// severity.
+		sum := severityFiles[0].SizeBytes
+		for _, f := range severityFiles[1:] {
+			sum += f.SizeBytes
+			if uint64(sum) < maxSizePerSeverity {
+				continue
+			}
+			path := filepath.Join(dir, f.Name)
+			if err := os.Remove(path); err != nil {
+				fmt.Fprintf(os.Stderr, "%s\n", err)
+			}
 		}
 	}
 }

--- a/pkg/util/log/file.go
+++ b/pkg/util/log/file.go
@@ -41,6 +41,12 @@ import (
 // MaxSize is the maximum size of a log file in bytes.
 var MaxSize uint64 = 1024 * 1024 * 10
 
+// MaxSizePerSeverity is the maximum total size in bytes for log files per
+// severity. Note that this is only checked when log files are created, so the
+// total size of log files per severity might temporarily be up to MaxSize
+// larger.
+var MaxSizePerSeverity = MaxSize * 10
+
 // If non-empty, overrides the choice of directory in which to write logs. See
 // createLogDirs for the full list of possible destinations. Note that the
 // default is to log to stderr independent of this setting. See --logtostderr.


### PR DESCRIPTION
GC old log files, controlled by the MaxFilesPerSeverity setting (default
20).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13083)
<!-- Reviewable:end -->
