### PR TITLE
intervalccl: add a utility for computing interval covering merges

### DIFF
--- a/pkg/ccl/ccl_init.go
+++ b/pkg/ccl/ccl_init.go
@@ -12,7 +12,9 @@ package ccl
 // import of this package enables building a binary with CCL features.
 
 import (
-	_ "github.com/cockroachdb/cockroach/pkg/ccl/buildccl"   // ccl init hooks
-	_ "github.com/cockroachdb/cockroach/pkg/ccl/sqlccl"     // ccl init hooks
-	_ "github.com/cockroachdb/cockroach/pkg/ccl/storageccl" // ccl init hooks
+	// ccl init hooks
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/buildccl"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/sqlccl"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/utilccl/intervalccl"
 )

--- a/pkg/ccl/utilccl/intervalccl/overlap_merge.go
+++ b/pkg/ccl/utilccl/intervalccl/overlap_merge.go
@@ -1,0 +1,144 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Cockroach Community Licence (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+
+package intervalccl
+
+import (
+	"bytes"
+	"sort"
+)
+
+// Range is an interval with a payload.
+type Range struct {
+	Start   []byte
+	End     []byte
+	Payload interface{}
+}
+
+// Covering represents a non-overlapping, but possibly non-contiguous, set of
+// intervals.
+type Covering []Range
+
+var _ sort.Interface = Covering{}
+
+func (c Covering) Len() int      { return len(c) }
+func (c Covering) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c Covering) Less(i, j int) bool {
+	if cmp := bytes.Compare(c[i].Start, c[j].Start); cmp != 0 {
+		return cmp < 0
+	}
+	return bytes.Compare(c[i].End, c[j].End) < 0
+}
+
+// OverlapCoveringMerge returns the set of intervals covering every range in the
+// input such that no output range crosses an input endpoint. The payloads are
+// returned as a `[]interface{}` and in the same order as they are in coverings.
+//
+// Example:
+//  covering 1: [1, 2) -> 'a', [3, 4) -> 'b', [6, 7) -> 'c'
+//  covering 2: [1, 5) -> 'd'
+//  output: [1, 2) -> 'ad', [2, 3) -> `d`, [3, 4) -> 'bd', [4, 5) -> 'd', [6, 7) -> 'c'
+//
+// The input is mutated (sorted). It is also assumed (and not checked) to be
+// valid (e.g. non-overlapping intervals in each covering).
+func OverlapCoveringMerge(coverings []Covering) []Range {
+	for _, covering := range coverings {
+		sort.Sort(covering)
+	}
+	// TODO(dan): Verify that the ranges in each covering are non-overlapping.
+
+	// Each covering is now sorted. Repeatedly iterate through the first range
+	// in each covering to find the next output range. Then remove the ranges
+	// that have been fully represented in the output from the front of each
+	// covering.
+	//
+	// TODO(dan): This is O(number of coverings * total number of input ranges).
+	// The number of ranges in the output is O(total number of input ranges) and
+	// each has a payload that is O(number of coverings), so we can't do any
+	// better without changing the output representation. That said, constants
+	// matter so if this ever turns out to be too slow, we could sort all start
+	// and end points (each point becomes an "event" to either start or end a
+	// range) and scan them in order, maintaining a list of intervals that are
+	// currently "open"
+	var ret []Range
+	var previousEndKey []byte
+	for {
+		// Find the start key of the next range. It will either be the end key
+		// of the range just added to the output or the minimum start key
+		// remaining in the coverings (if there is a gap).
+		var startKey []byte
+		startKeySet := false
+		for _, covering := range coverings {
+			if len(covering) == 0 {
+				continue
+			}
+			if !startKeySet || bytes.Compare(covering[0].Start, startKey) < 0 {
+				startKey = covering[0].Start
+				startKeySet = true
+			}
+		}
+		if !startKeySet {
+			break
+		}
+		if bytes.Compare(startKey, previousEndKey) < 0 {
+			startKey = previousEndKey
+		}
+
+		// Find the end key of the next range. It's the minimum of all end keys
+		// of ranges that intersect the start and all start keys of ranges after
+		// the end key of the range just added to the output.
+		var endKey []byte
+		endKeySet := false
+		for _, covering := range coverings {
+			if len(covering) == 0 {
+				continue
+			}
+
+			if bytes.Compare(covering[0].Start, startKey) > 0 {
+				if !endKeySet || bytes.Compare(covering[0].Start, endKey) < 0 {
+					endKey = covering[0].Start
+					endKeySet = true
+				}
+			}
+			if !endKeySet || bytes.Compare(covering[0].End, endKey) < 0 {
+				endKey = covering[0].End
+				endKeySet = true
+			}
+		}
+
+		// Collect all payloads of ranges that intersect the start and end keys
+		// just selected. Also trim any ranges with an end key <= the one just
+		// selected, they will not be output after this.
+		var payloads []interface{}
+		for i := range coverings {
+			// Because of how we chose startKey and endKey, we know that
+			// coverings[i][0].End >= endKey and that coverings[i][0].Start is
+			// either <= startKey or >= endKey.
+
+			for len(coverings[i]) > 0 {
+				if bytes.Compare(coverings[i][0].Start, startKey) > 0 {
+					break
+				}
+				payloads = append(payloads, coverings[i][0].Payload)
+				if !bytes.Equal(coverings[i][0].End, endKey) {
+					break
+				}
+				coverings[i] = coverings[i][1:]
+			}
+		}
+
+		ret = append(ret, Range{
+			Start:   startKey,
+			End:     endKey,
+			Payload: payloads,
+		})
+		previousEndKey = endKey
+	}
+
+	return ret
+}

--- a/pkg/ccl/utilccl/intervalccl/overlap_merge_test.go
+++ b/pkg/ccl/utilccl/intervalccl/overlap_merge_test.go
@@ -1,0 +1,120 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Cockroach Community Licence (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+
+package intervalccl
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// TODO(dan): Write a simple version of the algorithm that uses the fact that
+// the endpoints are small integers (e.g. fill out a [100][]string) and
+// use it to cross-check the results. This could also be used to generate tests
+// of random inputs.
+func TestOverlapCoveringMerge(t *testing.T) {
+	tests := []struct {
+		name string
+		// inputs is a slice of coverings. The inner slice represents a covering
+		// as an even number of ints, which are pairwise endpoints. So (1, 2, 2,
+		// 4) means [/1, /2) and [/2, /4).
+		inputs [][]byte
+		// expectedIntervals is the output ranges in the same format as an input
+		// covering.
+		expectedIntervals []byte
+		// expectedPayloads is the output payloads, corresponding 1:1 with
+		// entries in expectedIntervals. Each input range is given an int
+		// payload from 0..N-1 where N is the total number of ranges in all
+		// input coverings for this test. Each of these is formatted as a string
+		// concatenation of these ints.
+		//
+		// So for covering [1, 2), [2, 3) and covering [1, 3), the output
+		// payloads would be "02" for [1, 2) and "12" for [2, 3).
+		expectedPayloads []string
+	}{
+		{"no input",
+			[][]byte{},
+			nil, nil,
+		},
+		{"one empty covering",
+			[][]byte{{}},
+			nil, nil,
+		},
+		{"two empty coverings",
+			[][]byte{{}, {}},
+			nil, nil,
+		},
+		{"one",
+			[][]byte{{1, 2}, {}},
+			[]byte{1, 2}, []string{"0"},
+		},
+		{"same",
+			[][]byte{{1, 2}, {1, 2}},
+			[]byte{1, 2}, []string{"01"},
+		},
+		{"overlap",
+			[][]byte{{1, 3}, {2, 3}},
+			[]byte{1, 2, 2, 3}, []string{"0", "01"}},
+		{"overlap reversed",
+			[][]byte{{2, 3}, {1, 3}},
+			[]byte{1, 2, 2, 3}, []string{"1", "01"}},
+		{"no overlap",
+			[][]byte{{1, 2, 5, 6}, {3, 4}},
+			[]byte{1, 2, 3, 4, 5, 6}, []string{"0", "2", "1"},
+		},
+		{"cockroach range splits and merges",
+			[][]byte{{1, 3, 3, 4}, {1, 4}, {1, 2, 2, 4}},
+			[]byte{1, 2, 2, 3, 3, 4}, []string{"023", "024", "124"},
+		},
+		{"godoc example",
+			[][]byte{{1, 2, 3, 4, 6, 7}, {1, 5}},
+			[]byte{1, 2, 2, 3, 3, 4, 4, 5, 6, 7}, []string{"03", "3", "13", "3", "2"},
+		},
+		{"empty",
+			[][]byte{{1, 2, 2, 2, 2, 2, 4, 5}, {1, 5}},
+			[]byte{1, 2, 2, 2, 2, 4, 4, 5}, []string{"04", "124", "4", "34"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var payload int
+			var inputs []Covering
+			for _, endpoints := range test.inputs {
+				var c Covering
+				for i := 0; i < len(endpoints); i += 2 {
+					c = append(c, Range{
+						Start:   []byte{endpoints[i]},
+						End:     []byte{endpoints[i+1]},
+						Payload: payload,
+					})
+					payload++
+				}
+				inputs = append(inputs, c)
+			}
+			var outputIntervals []byte
+			var outputPayloads []string
+			for _, r := range OverlapCoveringMerge(inputs) {
+				outputIntervals = append(outputIntervals, r.Start[0], r.End[0])
+				var payload bytes.Buffer
+				for _, p := range r.Payload.([]interface{}) {
+					fmt.Fprintf(&payload, "%d", p.(int))
+				}
+				outputPayloads = append(outputPayloads, payload.String())
+			}
+			if !reflect.DeepEqual(outputIntervals, test.expectedIntervals) {
+				t.Errorf("intervals got\n%v\nexpected\n%v", outputIntervals, test.expectedIntervals)
+			}
+			if !reflect.DeepEqual(outputPayloads, test.expectedPayloads) {
+				t.Errorf("payloads got\n%v\nexpected\n%v", outputPayloads, test.expectedPayloads)
+			}
+		})
+	}
+}


### PR DESCRIPTION
OverlapCoveringMerge returns the set of intervals covering every range
in the input such that no output range crosses an input endpoint. The
payloads are returned as a `[]interface{}` and in the same order as they
are in coverings.

Example:
   covering 1: [1, 2) -> 'a', [3, 4) -> 'b', [6, 7) -> 'c'
   covering 2: [1, 5) -> 'd'
   output: [1, 2) -> 'ad', [2, 3) -> `d`, [3, 4) -> 'bd', [4, 5) -> 'd', [6, 7) -> 'c'

The input is mutated. It is also assumed (and not checked) to be valid
(e.g.  non-overlapping intervals in each covering).

This will be used to compute the key ranges (and path) in a restore of a
full backup with incrementals. WriteBatch can only write to an empty
range, so we can't restore the full backup and then each incremental.
Additionally, there may have been splits and merges in between the
backups, so they may have different coverings of the keyrange.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13086)
<!-- Reviewable:end -->
