### PR TITLE
engineccl: introduce MVCCIncrementalIterator

### DIFF
--- a/pkg/ccl/storageccl/engineccl/mvcc.go
+++ b/pkg/ccl/storageccl/engineccl/mvcc.go
@@ -1,0 +1,167 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Cockroach Community Licence (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+
+package engineccl
+
+import (
+	"errors"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
+
+// MVCCIncrementalIterator iterates over the diff of the key range [start,end)
+// and time range [start,end). If a key was added or modified between startTime
+// and endTime, the iterator will position at the most recent version (before
+// endTime) of that key. If the key was most recently deleted, this is signalled
+// with an empty value.
+//
+// Expected usage:
+//    iter := NewMVCCIncrementalIterator(e)
+//    defer iter.Close()
+//    for iter.Reset(...); iter.Valid(); iter.Next() {
+//        [code using iter.Key() and iter.Value()]
+//    }
+//    if err := iter.Error(); err != nil {
+//      ...
+//    }
+type MVCCIncrementalIterator struct {
+	// TODO(dan): Move all this logic into c++ and make this a thin wrapper.
+
+	iter engine.Iterator
+
+	endKey    engine.MVCCKey
+	startTime hlc.Timestamp
+	endTime   hlc.Timestamp
+	err       error
+	valid     bool
+	nextkey   bool
+
+	// For allocation avoidance.
+	meta enginepb.MVCCMetadata
+}
+
+// NewMVCCIncrementalIterator creates an MVCCIncrementalIterator with the
+// specified engine.
+func NewMVCCIncrementalIterator(e engine.Reader) *MVCCIncrementalIterator {
+	return &MVCCIncrementalIterator{iter: e.NewIterator(false)}
+}
+
+// Close frees up resources held by the iterator.
+func (i *MVCCIncrementalIterator) Close() {
+	i.iter.Close()
+}
+
+// Reset begins a new iteration with the specified key and time ranges.
+func (i *MVCCIncrementalIterator) Reset(
+	startKey, endKey roachpb.Key, startTime, endTime hlc.Timestamp,
+) {
+	i.iter.Seek(engine.MakeMVCCMetadataKey(startKey))
+	i.endKey = engine.MakeMVCCMetadataKey(endKey)
+	i.startTime, i.endTime = startTime, endTime
+	i.err = nil
+	i.valid = true
+	i.nextkey = false
+	i.Next()
+}
+
+// Next advances the iterator to the next key/value in the iteration.
+func (i *MVCCIncrementalIterator) Next() {
+	for {
+		if !i.valid {
+			return
+		}
+		if !i.iter.Valid() {
+			i.err = i.iter.Error()
+			i.valid = false
+			return
+		}
+
+		if i.nextkey {
+			i.nextkey = false
+			i.iter.NextKey()
+			continue
+		}
+
+		// TODO(dan): iter.unsafeKey() to avoid the allocation.
+		metaKey := i.iter.Key()
+		if !metaKey.Less(i.endKey) {
+			i.valid = false
+			return
+		}
+		if metaKey.IsValue() {
+			i.meta.Reset()
+			i.meta.Timestamp = metaKey.Timestamp
+		} else {
+			if i.err = i.iter.ValueProto(&i.meta); i.err != nil {
+				i.valid = false
+				return
+			}
+		}
+		if i.meta.IsInline() {
+			// Inline values are only used in non-user data. They're not needed
+			// for backup, so they're not handled by this method. If one shows
+			// up, throw an error so it's obvious something is wrong.
+			i.valid = false
+			i.err = errors.New("inline values are unsupported by MVCCIncrementalIterator")
+			return
+		}
+		if metaKey.Key == nil {
+			// iter was pointed after i.endKey.
+			break
+		}
+
+		if i.meta.Txn != nil {
+			if !i.meta.Timestamp.Less(i.endTime) {
+				i.err = &roachpb.WriteIntentError{
+					Intents: []roachpb.Intent{{Span: roachpb.Span{Key: metaKey.Key}, Status: roachpb.PENDING, Txn: *i.meta.Txn}},
+				}
+				i.valid = false
+				return
+			}
+			i.iter.Next()
+			continue
+		}
+
+		if !i.meta.Timestamp.Less(i.endTime) {
+			i.iter.Next()
+			continue
+		}
+		if i.meta.Timestamp.Less(i.startTime) {
+			i.iter.NextKey()
+			continue
+		}
+
+		i.nextkey = true
+		break
+	}
+}
+
+// Valid returns true if the iterator is currently valid. An iterator that
+// hasn't had Reset called on it or has gone past the end of the key range is
+// invalid.
+func (i *MVCCIncrementalIterator) Valid() bool {
+	return i.valid
+}
+
+// Error returns the error, if any, which the iterator encountered.
+func (i *MVCCIncrementalIterator) Error() error {
+	return i.err
+}
+
+// Key returns the current key.
+func (i *MVCCIncrementalIterator) Key() engine.MVCCKey {
+	return i.iter.Key()
+}
+
+// Value returns the current value as a byte slice.
+func (i *MVCCIncrementalIterator) Value() []byte {
+	return i.iter.Value()
+}

--- a/pkg/ccl/storageccl/engineccl/mvcc_test.go
+++ b/pkg/ccl/storageccl/engineccl/mvcc_test.go
@@ -1,0 +1,167 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Cockroach Community Licence (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+
+package engineccl
+
+import (
+	"bytes"
+	"math"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+)
+
+func TestMVCCIterateIncremental(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	defer e.Close()
+
+	var (
+		keyMin   = roachpb.KeyMin
+		keyMax   = roachpb.KeyMax
+		testKey1 = roachpb.Key("/db1")
+		testKey2 = roachpb.Key("/db2")
+
+		testValue1 = []byte("val1")
+		testValue2 = []byte("val2")
+		testValue3 = []byte("val3")
+		testValue4 = []byte("val4")
+
+		ts0   = hlc.Timestamp{WallTime: 0, Logical: 0}
+		ts1   = hlc.Timestamp{WallTime: 1, Logical: 0}
+		ts2   = hlc.Timestamp{WallTime: 2, Logical: 0}
+		ts3   = hlc.Timestamp{WallTime: 3, Logical: 0}
+		ts4   = hlc.Timestamp{WallTime: 4, Logical: 0}
+		tsMax = hlc.Timestamp{WallTime: math.MaxInt64, Logical: 0}
+	)
+
+	makeKVT := func(key roachpb.Key, value []byte, ts hlc.Timestamp) engine.MVCCKeyValue {
+		return engine.MVCCKeyValue{Key: engine.MVCCKey{Key: key, Timestamp: ts}, Value: value}
+	}
+
+	assertEqualKVs := func(
+		startKey, endKey roachpb.Key, startTime, endTime hlc.Timestamp,
+		expected []engine.MVCCKeyValue,
+	) {
+		t.Run("", func(t *testing.T) {
+			iter := NewMVCCIncrementalIterator(e)
+			defer iter.Close()
+			var kvs []engine.MVCCKeyValue
+			for iter.Reset(startKey, endKey, startTime, endTime); iter.Valid(); iter.Next() {
+				kvs = append(kvs, engine.MVCCKeyValue{Key: iter.Key(), Value: iter.Value()})
+			}
+
+			if len(kvs) != len(expected) {
+				t.Fatalf("got %d kvs but expected %d: %v", len(kvs), len(expected), kvs)
+			}
+			for i := range kvs {
+				if !kvs[i].Key.Equal(expected[i].Key) {
+					t.Fatalf("%d key: got %v but expected %v", i, kvs[i].Key, expected[i].Key)
+				}
+				if !bytes.Equal(kvs[i].Value, expected[i].Value) {
+					t.Fatalf("%d value: got %x but expected %x", i, kvs[i].Value, expected[i].Value)
+				}
+			}
+		})
+	}
+
+	iterateExpectErr := func(
+		startKey, endKey roachpb.Key, startTime, endTime hlc.Timestamp, errString string,
+	) {
+		t.Run("", func(t *testing.T) {
+			iter := NewMVCCIncrementalIterator(e)
+			defer iter.Close()
+			for iter.Reset(keyMin, keyMax, ts0, ts3); iter.Valid(); iter.Next() {
+				// pass
+			}
+			if err := iter.Error(); !testutils.IsError(err, errString) {
+				t.Fatalf("expected error %q but got %v", errString, err)
+			}
+		})
+	}
+
+	kv1_1_1 := makeKVT(testKey1, testValue1, ts1)
+	kv1_4_4 := makeKVT(testKey1, testValue4, ts4)
+	kv2_2_1 := makeKVT(testKey1, testValue2, ts2)
+	kv2_2_2 := makeKVT(testKey2, testValue3, ts2)
+	kv1_3Deleted := makeKVT(testKey1, nil, ts3)
+	kvs := func(kvs ...engine.MVCCKeyValue) []engine.MVCCKeyValue { return kvs }
+
+	assertEqualKVs(keyMin, keyMax, ts0, ts3, nil)
+
+	for _, kv := range kvs(kv1_1_1, kv2_2_1, kv2_2_2) {
+		v := roachpb.Value{RawBytes: kv.Value}
+		if err := engine.MVCCPut(ctx, e, nil, kv.Key.Key, kv.Key.Timestamp, v, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Exercise time ranges.
+	assertEqualKVs(keyMin, keyMax, ts1, ts1, nil)
+	assertEqualKVs(keyMin, keyMax, ts1, ts2, kvs(kv1_1_1))
+	assertEqualKVs(keyMin, keyMax, ts1, tsMax, kvs(kv2_2_1, kv2_2_2))
+	assertEqualKVs(keyMin, keyMax, ts2, ts2, nil)
+	assertEqualKVs(keyMin, keyMax, ts2, ts3, kvs(kv2_2_1, kv2_2_2))
+	assertEqualKVs(keyMin, keyMax, ts3, ts3, nil)
+
+	// Exercise key ranges.
+	assertEqualKVs(testKey1, testKey1, ts0, tsMax, nil)
+	assertEqualKVs(testKey1, testKey2, ts0, tsMax, kvs(kv2_2_1))
+
+	// Exercise deletion.
+	if err := engine.MVCCDelete(ctx, e, nil, testKey1, ts3, nil); err != nil {
+		t.Fatal(err)
+	}
+	assertEqualKVs(keyMin, keyMax, ts0, tsMax, kvs(kv1_3Deleted, kv2_2_2))
+
+	// Exercise intent handling.
+	txn1ID := uuid.MakeV4()
+	txn1 := roachpb.Transaction{TxnMeta: enginepb.TxnMeta{
+		Key:       testKey1,
+		ID:        &txn1ID,
+		Epoch:     1,
+		Timestamp: ts4,
+	}}
+	txn1Val := roachpb.Value{RawBytes: testValue4}
+	if err := engine.MVCCPut(ctx, e, nil, txn1.TxnMeta.Key, txn1.TxnMeta.Timestamp, txn1Val, &txn1); err != nil {
+		t.Fatal(err)
+	}
+	txn2ID := uuid.MakeV4()
+	txn2 := roachpb.Transaction{TxnMeta: enginepb.TxnMeta{
+		Key:       testKey2,
+		ID:        &txn2ID,
+		Epoch:     1,
+		Timestamp: ts4,
+	}}
+	txn2Val := roachpb.Value{RawBytes: testValue4}
+	if err := engine.MVCCPut(ctx, e, nil, txn2.TxnMeta.Key, txn2.TxnMeta.Timestamp, txn2Val, &txn2); err != nil {
+		t.Fatal(err)
+	}
+	iterateExpectErr(testKey1, testKey1, ts0, tsMax, "conflicting intents")
+	iterateExpectErr(testKey2, testKey2, ts0, tsMax, "conflicting intents")
+	assertEqualKVs(keyMin, keyMax, ts0, ts4, nil)
+
+	intent1 := roachpb.Intent{Span: roachpb.Span{Key: testKey1}, Txn: txn1.TxnMeta, Status: roachpb.COMMITTED}
+	if err := engine.MVCCResolveWriteIntent(ctx, e, nil, intent1); err != nil {
+		t.Fatal(err)
+	}
+	intent2 := roachpb.Intent{Span: roachpb.Span{Key: testKey2}, Txn: txn2.TxnMeta, Status: roachpb.ABORTED}
+	if err := engine.MVCCResolveWriteIntent(ctx, e, nil, intent2); err != nil {
+		t.Fatal(err)
+	}
+	assertEqualKVs(keyMin, keyMax, ts0, tsMax, kvs(kv1_4_4, kv2_2_2))
+}


### PR DESCRIPTION
MVCCIncrementalIterator iterates over the diff of the key range [start,end) and
time range [start,end). If a key was added or modified between startTime and
endTime, the iterator will position at the most recent version (before endTime)
of that key. If the key was most recently deleted, this is signalled with an
empty value.

This implementation was originally based off of MVCCIterate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13088)
<!-- Reviewable:end -->
