### PR TITLE
ui: Add events page

### DIFF
--- a/pkg/ui/app/app.tsx
+++ b/pkg/ui/app/app.tsx
@@ -83,6 +83,7 @@ import NodesOverview from "./containers/nodesOverview";
 import NodeOverview from "./containers/nodeOverview";
 import NodeGraphs from "./containers/nodeGraphs";
 import NodeLogs from "./containers/nodeLogs";
+import { EventPage } from "./containers/events";
 import Raft from "./containers/raft";
 import RaftRanges from "./containers/raftRanges";
 import ClusterViz from "./containers/clusterViz";
@@ -108,7 +109,8 @@ ReactDOM.render(
           <Route path={ `node/:${nodeIDAttr}/:${dashboardNameAttr}` } component={NodeGraphs} />
         </Route>
         <Route path="cluster">
-          <Route path="nodes" component={ NodesOverview } />
+          <Route path="nodes" component={NodesOverview} />
+          <Route path="events" component={ EventPage } />
         </Route>
         <Route path="nodes">
           // This path has to match the "nodes" route for the purpose of

--- a/pkg/ui/app/containers/events.tsx
+++ b/pkg/ui/app/containers/events.tsx
@@ -1,55 +1,107 @@
 import * as React from "react";
+import { Link } from "react-router";
 import * as _ from "lodash";
+import { connect } from "react-redux";
+import moment from "moment";
 
 import { AdminUIState } from "../redux/state";
 import { refreshEvents } from "../redux/apiReducers";
-import { connect } from "react-redux";
+import { setUISetting } from "../redux/ui";
 import { TimestampToMoment } from "../util/convert";
 import * as eventTypes from "../util/eventTypes";
+import { SortSetting } from "../components/sortabletable";
+import { SortedTable } from "../components/sortedtable";
 
 type Event = Proto2TypeScript.cockroach.server.serverpb.EventsResponse.Event;
+
+// Constant used to store sort settings in the redux UI store.
+const UI_EVENTS_SORT_SETTING_KEY = "events/sort_setting";
+// Number of events to show in the sidebar.
+const EVENT_BOX_NUM_EVENTS = 10;
+
+export interface SimplifiedEvent {
+   // How long ago the event occurred  (e.g. "10 minutes ago").
+  fromNowString: string;
+  sortableTimestamp: moment.Moment;
+  content: React.ReactNode;
+}
+
+// Specialization of generic SortedTable component:
+//   https://github.com/Microsoft/TypeScript/issues/3960
+//
+// The variable name must start with a capital letter or TSX will not recognize
+// it as a component.
+// tslint:disable-next-line:variable-name
+const EventSortedTable = SortedTable as new () => SortedTable<SimplifiedEvent>;
 
 export interface EventRowProps {
   event: Event;
 }
 
-export function getEventInfo(e: Event) {
-  let info: any = JSON.parse(e.info) || {};
-  let targetId: number = e.target_id.toNumber();
+let s = (v: any) => JSON.stringify(v, undefined, 2);
+
+export function getEventInfo(e: Event): SimplifiedEvent {
+  let info: any = _.isString(e.info) ? JSON.parse(e.info) : {};
+  let targetId: number = e.target_id ? e.target_id.toNumber() : null;
   let content: React.ReactNode;
 
   switch (e.event_type) {
     case eventTypes.CREATE_DATABASE:
-      content = <span>User {info.User} <strong>created database</strong> {info.DatabaseName}</span>;
+      content = <span>Database Created: User {info.User} created database {info.DatabaseName}</span>;
       break;
     case eventTypes.DROP_DATABASE:
+      info.DroppedTables = info.DroppedTables || [];
       let tableDropText: string = `${info.DroppedTables.length} tables were dropped: ${info.DroppedTables.join(", ")}`;
       if (info.DroppedTables.length === 0) {
         tableDropText = "No tables were dropped.";
       } else if (info.DroppedTables.length === 1) {
         tableDropText = `1 table was dropped: ${info.DroppedTables[0]}`;
       }
-      content = <span>User {info.User} <strong>dropped database</strong> {info.DatabaseName}.{tableDropText}</span>;
+      content = <span>Database Dropped: User {info.User} dropped database {info.DatabaseName}.{tableDropText}</span>;
       break;
     case eventTypes.CREATE_TABLE:
-      content = <span>User {info.User} <strong>created table</strong> {info.TableName}</span>;
+      content = <span>Table Created: User {info.User} created table {info.TableName}</span>;
       break;
     case eventTypes.DROP_TABLE:
-      content = <span>User {info.User} <strong>dropped table</strong> {info.TableName}</span>;
+      content = <span>Table Dropped: User {info.User} dropped table {info.TableName}</span>;
+      break;
+    case eventTypes.ALTER_TABLE:
+      content = <span>Schema Change: User {info.User} began a schema change to alter table {info.TableName} with ID {info.MutationID}</span>;
+      break;
+    case eventTypes.CREATE_INDEX:
+      content = <span>Schema Change: User {info.User} began a schema change to create an index {info.IndexName} on table {info.TableName} with ID {info.MutationID}</span>;
+      break;
+    case eventTypes.DROP_INDEX:
+      content = <span>Schema Change: User {info.User} began a schema change to drop index {info.IndexName} on table {info.TableName} with ID {info.MutationID}</span>;
+      break;
+    case eventTypes.CREATE_VIEW:
+      content = <span>View Created: User {info.User} created view {info.ViewName}</span>;
+      break;
+    case eventTypes.DROP_VIEW:
+      content = <span>View Dropped: User {info.User} dropped view {info.ViewName}</span>;
+      break;
+    case eventTypes.REVERSE_SCHEMA_CHANGE:
+      content = <span>Schema Change Reversed: Schema change with ID {info.MutationID} was reversed.</span>;
+      break;
+    case eventTypes.FINISH_SCHEMA_CHANGE:
+      content = <span>Schema Change Finished: Schema Change Completed: Schema change with ID {info.MutationID} was completed.</span>;
       break;
     case eventTypes.NODE_JOIN:
-      content = <span>Node {targetId} <strong>joined the cluster</strong></span>;
+      content = <span>Node Joined: Node {targetId} joined the cluster</span>;
       break;
     case eventTypes.NODE_RESTART:
-      content = <span>Node {targetId} <strong>rejoined the cluster</strong></span>;
+      content = <span>Node Rejoined: Node {targetId} rejoined the cluster</span>;
       break;
     default:
-      content = <span>Unknown event type: {e.event_type}</span>;
+      content = <span>Unknown Event Type: {e.event_type}, content: {s(info)}</span>;
   }
 
   return {
-    timestamp: TimestampToMoment(e.timestamp).fromNow(),
-    content: content,
+    fromNowString: TimestampToMoment(e.timestamp).fromNow()
+      .replace("second", "sec")
+      .replace("minute", "min"),
+    content,
+    sortableTimestamp: TimestampToMoment(e.timestamp),
   };
 }
 
@@ -59,32 +111,21 @@ export class EventRow extends React.Component<EventRowProps, {}> {
     let e = getEventInfo(event);
     return <tr>
       <td><div className="events__message">{e.content}</div></td>
-      <td><div className="events__timestamp">{e.timestamp}</div></td>
+      <td><div className="events__timestamp">{e.fromNowString}</div></td>
     </tr>;
   }
 }
 
-export interface EventListProps {
+export interface EventBoxProps {
   events: Event[];
   refreshEvents: typeof refreshEvents;
 };
 
-class EventListState {
-  numEvents = 10;
-}
-
-export class EventList extends React.Component<EventListProps, EventListState> {
-  state = new EventListState();
+export class EventBoxUnconnected extends React.Component<EventBoxProps, {}> {
 
   componentWillMount() {
     // Refresh events when mounting.
     this.props.refreshEvents();
-  }
-
-  moreEventsClick = () => {
-    this.setState({
-      numEvents: this.state.numEvents + 10,
-    });
   }
 
   render() {
@@ -92,11 +133,11 @@ export class EventList extends React.Component<EventListProps, EventListState> {
     return <div className="events">
       <table>
         <tbody>
-          {_.map(_.take(events, this.state.numEvents), (e: Event, i: number) => {
+          {_.map(_.take(events, EVENT_BOX_NUM_EVENTS), (e: Event, i: number) => {
             return <EventRow event={e} key={i} />;
           })}
           <tr>
-            <td className="events__more-link" colSpan={2} onClick={this.moreEventsClick}>More Events</td>
+            <td className="events__more-link" colSpan={2}><Link to="/cluster/events">View all events</Link></td>
           </tr>
         </tbody>
       </table>
@@ -104,10 +145,68 @@ export class EventList extends React.Component<EventListProps, EventListState> {
   }
 }
 
+export interface EventPageProps {
+  events: Event[];
+  refreshEvents: typeof refreshEvents;
+  sortSetting: SortSetting;
+  setUISetting: typeof setUISetting;
+};
+
+export class EventPageUnconnected extends React.Component<EventPageProps, {}> {
+  // Callback when the user elects to change the sort setting.
+  changeSortSetting(setting: SortSetting) {
+    this.props.setUISetting(UI_EVENTS_SORT_SETTING_KEY, setting);
+  }
+
+  componentWillMount() {
+    // Refresh events when mounting.
+    this.props.refreshEvents();
+  }
+
+  render() {
+    let { events, sortSetting } = this.props;
+
+    let simplifiedEvents = _.map(events, getEventInfo);
+
+    return <div>
+      {
+        // TODO(mrtracy): This currently always links back to the main cluster
+        // page, when it should link back to the dashboard previously visible.
+      }
+      <section className="section parent-link">
+        <Link to="/cluster">&lt; Back to Cluster</Link>
+      </section>
+      <section className="header header--subsection">
+        Events
+      </section>
+      <section className="section l-columns">
+        <div className="l-columns__left events-table">
+          <EventSortedTable
+            data={simplifiedEvents}
+            sortSetting={sortSetting}
+            onChangeSortSetting={(setting) => this.changeSortSetting(setting)}
+            columns={[
+              {
+                title: "Event",
+                cell: (e) => e.content,
+              },
+              {
+                title: "Timestamp",
+                cell: (e) => e.fromNowString,
+                sort: (e) => e.sortableTimestamp,
+              },
+            ]}
+            />
+        </div>
+      </section>
+    </div>;
+  }
+}
+
 let events = (state: AdminUIState): Event[] => state.cachedData.events.data && state.cachedData.events.data.events;
 
 // Connect the EventsList class with our redux store.
-let eventsConnected = connect(
+let eventBoxConnected = connect(
   (state: AdminUIState) => {
     return {
       events: events(state),
@@ -116,6 +215,23 @@ let eventsConnected = connect(
   {
     refreshEvents,
   },
-)(EventList);
+)(EventBoxUnconnected);
 
-export default eventsConnected;
+let sortSetting = (state: AdminUIState): SortSetting => state.ui[UI_EVENTS_SORT_SETTING_KEY] || {};
+
+// Connect the EventsList class with our redux store.
+let eventPageConnected = connect(
+  (state: AdminUIState) => {
+    return {
+      events: events(state),
+      sortSetting: sortSetting(state),
+    };
+  },
+  {
+    refreshEvents,
+    setUISetting,
+  },
+)(EventPageUnconnected);
+
+export { eventBoxConnected as EventBox };
+export { eventPageConnected as EventPage };

--- a/pkg/ui/app/containers/nodeGraphs.tsx
+++ b/pkg/ui/app/containers/nodeGraphs.tsx
@@ -16,7 +16,7 @@ import { SummaryBar, SummaryLabel, SummaryStat, SummaryMetricStat } from "../com
 import { Axis, AxisUnits } from "../components/graphs";
 import { LineGraph } from "../components/linegraph";
 import { Metric } from "../components/metric";
-import Events from "../containers/events";
+import { EventBox } from "../containers/events";
 import { Bytes } from "../util/format";
 import { NanoToMilli } from "../util/convert";
 import { NodeStatus, MetricConstants, BytesUsed } from "../util/proto";
@@ -605,7 +605,7 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
         </SummaryBar>
         <SummaryBar>
           <SummaryLabel>Events</SummaryLabel>
-          <Events />
+          <EventBox />
         </SummaryBar>
       </div>
     </div>;

--- a/pkg/ui/app/util/eventTypes.ts
+++ b/pkg/ui/app/util/eventTypes.ts
@@ -37,6 +37,7 @@ export const nodeEvents = [NODE_JOIN, NODE_RESTART];
 export const databaseEvents = [CREATE_DATABASE, DROP_DATABASE];
 export const tableEvents = [CREATE_TABLE, DROP_TABLE, ALTER_TABLE, CREATE_INDEX,
   DROP_INDEX, CREATE_VIEW, DROP_VIEW, REVERSE_SCHEMA_CHANGE, FINISH_SCHEMA_CHANGE];
+export const allEvents = [...nodeEvents, ...databaseEvents, ...tableEvents];
 
 interface EventSet {
   [key: string]: number;

--- a/pkg/ui/styl/components/events.styl
+++ b/pkg/ui/styl/components/events.styl
@@ -10,13 +10,27 @@
         border 0
     td
       padding-left 0
+      text-overflow ellipsis
+      overflow hidden
+
+      div
+        text-overflow ellipsis
+        overflow hidden
+
 .events__message
   font-size 14
   color $secondary-gray-11
+  text-overflow ellipsis
+  display block
+  white-space nowrap
+  overflow hidden
+  width 180px
 
 .events__timestamp
   font-size 12
   color $light-gray
+  margin-left 20px
+  text-align right
 
 .events__more-link
   text-align center
@@ -26,3 +40,12 @@
   font-size 12px
   letter-spacing 2px
   cursor pointer
+
+  a
+    color $secondary-blue
+    text-decoration none
+
+.events-table .sort-table__cell
+  font-family Lato-Regular
+  font-weight normal
+  letter-spacing normal


### PR DESCRIPTION
Adds back an events page links to it via the "All Events" link in
events box on the cluster page, which replaces the "More Events"
link which used to expand the number of shown events.

The event box is slightly different from the event page in that
the event box doesn't use the sortable table and is slightly
simpler for style reasons. It's possible in the future these two
could be combined, but for now it's easier to keep them separate.

![screen shot 2017-01-23 at 1 07 45 pm](https://cloud.githubusercontent.com/assets/3691886/22216405/f95d3114-e16c-11e6-956d-52f493e701ad.png)
![screen shot 2017-01-23 at 1 07 35 pm](https://cloud.githubusercontent.com/assets/3691886/22216406/f9677200-e16c-11e6-9d32-a031ea8de19a.png)

cc @kuanluo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13093)
<!-- Reviewable:end -->
