### PR TITLE
sql: minimum support for pg_type queries that look for array_in typinputs

### DIFF
--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -1591,6 +1591,17 @@ var Builtins = map[string][]Builtin{
 				"Currently, CockroachDB does not support adding comments to columns.",
 		},
 	},
+	"pg_catalog.array_in": {
+		Builtin{
+			Types:      NamedArgTypes{{"string", TypeString}, {"element_oid", TypeInt}, {"element_typmod", TypeInt}},
+			ReturnType: TypeString,
+			fn: func(_ *EvalContext, _ DTuple) (Datum, error) {
+				return nil, errors.New("unimplemented")
+			},
+			category: categoryCompatibility,
+			Info:     "array_in is unimplemented and exists for compatibility purposes",
+		},
+	},
 }
 
 var substringImpls = []Builtin{

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -1905,6 +1905,11 @@ func (expr *CaseExpr) Eval(ctx *EvalContext) (Datum, error) {
 	return DNull, nil
 }
 
+// regprocedureRegexp matches a Postgres function type signature, capturing the
+// name of the function into group 1.
+// e.g. function(a, b, c) or function( a )
+var regprocedureRegexp = regexp.MustCompile(`^\s*(\w+)\s*\((?:(?:\s*\w+\s*,)*\s*\w+)?\s*\)\s*$`)
+
 // Eval implements the TypedExpr interface.
 func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 	d, err := expr.Expr.(TypedExpr).Eval(ctx)
@@ -2175,30 +2180,36 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 		case *DInt:
 			return v, nil
 		case *DString:
-			queryOid := func(table_name string, col_name string, obj_name string) (Datum, error) {
+			queryOid := func(s string, table_name string, col_name string, obj_name string) (Datum, error) {
 				results, err := ctx.Planner.QueryRow(
-					fmt.Sprintf("SELECT oid FROM pg_catalog.%s WHERE %s = %s", table_name, col_name, v))
+					fmt.Sprintf("SELECT oid FROM pg_catalog.%s WHERE %s = $1", table_name, col_name), s)
 				if err != nil {
 					if _, ok := err.(*MultipleResultsError); ok {
-						return nil, errors.Errorf("more than one %s named %s", obj_name, v)
+						return nil, errors.Errorf("more than one %s named '%s'", obj_name, s)
 					}
 					return nil, err
 				}
 				if results.Len() == 0 {
-					return nil, errors.Errorf("%s %s does not exist", obj_name, v)
+					return nil, errors.Errorf("%s '%s' does not exist", obj_name, s)
 				}
 				return results[0], nil
 			}
+			s := string(*v)
 
 			switch typ {
 			case oidPseudoTypeRegClass:
-				return queryOid("pg_class", "relname", "relation")
+				return queryOid(s, "pg_class", "relname", "relation")
 			case oidPseudoTypeRegProc:
-				return queryOid("pg_proc", "proname", "function")
+				// Trim procedure type parameters. Postgres only does this when the
+				// cast is ::regprocedure, but we're going to always do it.
+				// We additionally do not yet implement disambiguation based on type
+				// parameters: we return the match iff there is exactly one.
+				s = regprocedureRegexp.ReplaceAllString(s, "$1")
+				return queryOid(s, "pg_proc", "proname", "function")
 			case oidPseudoTypeRegNamespace:
-				return queryOid("pg_namespace", "nspname", "namespace")
+				return queryOid(s, "pg_namespace", "nspname", "namespace")
 			case oidPseudoTypeRegType:
-				return queryOid("pg_type", "typname", "type")
+				return queryOid(s, "pg_type", "typname", "type")
 			}
 		}
 	}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1268,6 +1268,9 @@ var (
 	_ = typCategoryUnknown
 
 	typDelim = parser.NewDString(",")
+
+	arrayInProcName = "pg_catalog.array_in"
+	arrayInProcOid  = makeOidHasher().BuiltinOid(arrayInProcName, &parser.Builtins[arrayInProcName][0])
 )
 
 // See: https://www.postgresql.org/docs/9.6/static/catalog-pg-type.html.
@@ -1309,6 +1312,11 @@ CREATE TABLE pg_catalog.pg_type (
 `,
 	populate: func(p *planner, addRow func(...parser.Datum) error) error {
 		for oid, typ := range parser.OidToType {
+			cat := typCategory(typ)
+			typInput := zeroVal
+			if cat == typCategoryArray {
+				typInput = arrayInProcOid
+			}
 			if err := addRow(
 				parser.NewDInt(parser.DInt(oid)), // oid
 				parser.NewDString(typ.String()),  // typname
@@ -1317,22 +1325,22 @@ CREATE TABLE pg_catalog.pg_type (
 				typLen(typ),                      // typlen
 				typByVal(typ),                    // typbyval
 				typTypeBase,                      // typtype
-				typCategory(typ),                 // typcategory
-				parser.MakeDBool(false),          // typispreferred
-				parser.MakeDBool(true),           // typisdefined
-				typDelim,                         // typdelim
-				zeroVal,                          // typrelid
-				zeroVal,                          // typelem
-				zeroVal,                          // typarray
+				cat,                              // typcategory
+				parser.MakeDBool(false), // typispreferred
+				parser.MakeDBool(true),  // typisdefined
+				typDelim,                // typdelim
+				zeroVal,                 // typrelid
+				zeroVal,                 // typelem
+				zeroVal,                 // typarray
 
 				// regproc references
-				zeroVal, // typinput
-				zeroVal, // typoutput
-				zeroVal, // typreceive
-				zeroVal, // typsend
-				zeroVal, // typmodin
-				zeroVal, // typmodout
-				zeroVal, // typanalyze
+				typInput, // typinput
+				zeroVal,  // typoutput
+				zeroVal,  // typreceive
+				zeroVal,  // typsend
+				zeroVal,  // typmodin
+				zeroVal,  // typmodout
+				zeroVal,  // typanalyze
 
 				parser.DNull,            // typalign
 				parser.DNull,            // typstorage

--- a/pkg/sql/testdata/builtin_function
+++ b/pkg/sql/testdata/builtin_function
@@ -1444,3 +1444,6 @@ query T
 SELECT col_description('pg_class'::regclass::oid, 2)
 ----
 NULL
+
+query error pq: pg_catalog.array_in\(\): unimplemented
+SELECT array_in('foo', 3, -1)

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -676,27 +676,27 @@ SELECT oid, typname, typinput, typoutput, typreceive, typsend, typmodin, typmodo
 FROM pg_catalog.pg_type
 ORDER BY oid
 ----
-oid   typname      typinput  typoutput  typreceive  typsend  typmodin  typmodout  typanalyze
-16    bool         0         0          0           0        0         0          0
-17    bytes        0         0          0           0        0         0          0
-20    int          0         0          0           0        0         0          0
-21    int          0         0          0           0        0         0          0
-23    int          0         0          0           0        0         0          0
-25    string       0         0          0           0        0         0          0
-700   float        0         0          0           0        0         0          0
-701   float        0         0          0           0        0         0          0
-1005  int[]        0         0          0           0        0         0          0
-1007  int[]        0         0          0           0        0         0          0
-1009  string[]     0         0          0           0        0         0          0
-1016  int[]        0         0          0           0        0         0          0
-1043  string       0         0          0           0        0         0          0
-1082  date         0         0          0           0        0         0          0
-1114  timestamp    0         0          0           0        0         0          0
-1184  timestamptz  0         0          0           0        0         0          0
-1186  interval     0         0          0           0        0         0          0
-1700  decimal      0         0          0           0        0         0          0
-2249  tuple        0         0          0           0        0         0          0
-2283  anyelement   0         0          0           0        0         0          0
+oid   typname      typinput    typoutput  typreceive  typsend  typmodin  typmodout  typanalyze
+16    bool         0           0          0           0        0         0          0
+17    bytes        0           0          0           0        0         0          0
+20    int          0           0          0           0        0         0          0
+21    int          0           0          0           0        0         0          0
+23    int          0           0          0           0        0         0          0
+25    string       0           0          0           0        0         0          0
+700   float        0           0          0           0        0         0          0
+701   float        0           0          0           0        0         0          0
+1005  int[]        2892088402  0          0           0        0         0          0
+1007  int[]        2892088402  0          0           0        0         0          0
+1009  string[]     2892088402  0          0           0        0         0          0
+1016  int[]        2892088402  0          0           0        0         0          0
+1043  string       0           0          0           0        0         0          0
+1082  date         0           0          0           0        0         0          0
+1114  timestamp    0           0          0           0        0         0          0
+1184  timestamptz  0           0          0           0        0         0          0
+1186  interval     0           0          0           0        0         0          0
+1700  decimal      0           0          0           0        0         0          0
+2249  tuple        0           0          0           0        0         0          0
+2283  anyelement   0           0          0           0        0         0          0
 
 query ITTTBII colnames
 SELECT oid, typname, typalign, typstorage, typnotnull, typbasetype, typtypmod

--- a/pkg/sql/testdata/pgoidtype
+++ b/pkg/sql/testdata/pgoidtype
@@ -13,6 +13,26 @@ SELECT 'upper'::REGPROC, 'upper'::REGPROCEDURE
 ----
 1736923753  1736923753
 
+query II
+SELECT 'upper(int)'::REGPROC, 'upper(int)'::REGPROCEDURE
+----
+1736923753  1736923753
+
+query error function 'blah' does not exist
+SELECT 'blah(ignored, ignored)'::REGPROC, 'blah(ignored, ignored)'::REGPROCEDURE
+
+query error function 'blah' does not exist
+SELECT ' blah ( ignored , ignored ) '::REGPROC
+
+query error function 'blah' does not exist
+SELECT 'blah ()'::REGPROC
+
+query error function 'blah' does not exist
+SELECT 'blah( )'::REGPROC
+
+query error function 'blah\(, \)' does not exist
+SELECT 'blah(, )'::REGPROC
+
 query error more than one function named 'max'
 SELECT 'max'::REGPROC
 


### PR DESCRIPTION
- `::regproc` and `::regprocedure` casts allow but ignore type parameters
- Add no-op implementation of `array_in`
- `pg_type.typinput` for array types is set to to `array_in`'s OID

Resolves #12139.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13096)
<!-- Reviewable:end -->
