### PR TITLE
sql: implement pg_backend_pid builtin

### DIFF
--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -1463,6 +1463,17 @@ var Builtins = map[string][]Builtin{
 
 	// pg_catalog functions.
 	// See https://www.postgresql.org/docs/9.6/static/functions-info.html.
+	"pg_catalog.pg_backend_pid": {
+		Builtin{
+			Types:      NamedArgTypes{},
+			ReturnType: TypeInt,
+			fn: func(_ *EvalContext, _ DTuple) (Datum, error) {
+				return NewDInt(-1), nil
+			},
+			category: categoryCompatibility,
+			Info:     "Not usable; supported only for ORM compatibility",
+		},
+	},
 
 	// Postgres defines pg_get_expr as a function that "decompiles the internal form
 	// of an expression", which is provided in the pg_node_tree type. In Cockroach's


### PR DESCRIPTION
Implement pg_backend_pid as a constant function returning -1. Clients
shouldn't rely on this builtin for anything other than display purposes.
This is implemented for ORM support.

Resolves #12970.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13097)
<!-- Reviewable:end -->
