### PR TITLE
scripts: use full URL for image

### DIFF
--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -15,7 +15,8 @@ case ${1-} in
            --machine-type "custom-24-32768" \
            --network "default" \
            --maintenance-policy "MIGRATE" \
-           --image "/ubuntu-os-cloud/ubuntu-1604-xenial-v20160830" \
+           --image-project "ubuntu-os-cloud" \
+           --image "ubuntu-1604-xenial-v20170113" \
            --boot-disk-size "100" \
            --boot-disk-type "pd-ssd" \
            --boot-disk-device-name "${name}"


### PR DESCRIPTION
`scripts/gceworker.sh create` fails without this change, complaining
about the `--image` URL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13100)
<!-- Reviewable:end -->
