### PR TITLE
sql: sanitize the handling of limits and desired orderings.

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -464,14 +464,13 @@ func (n *alterTableNode) Start() error {
 	return nil
 }
 
-func (n *alterTableNode) Next() (bool, error)          { return false, nil }
-func (n *alterTableNode) Close()                       {}
-func (n *alterTableNode) Columns() ResultColumns       { return make(ResultColumns, 0) }
-func (n *alterTableNode) Ordering() orderingInfo       { return orderingInfo{} }
-func (n *alterTableNode) Values() parser.DTuple        { return parser.DTuple{} }
-func (n *alterTableNode) DebugValues() debugValues     { return debugValues{} }
-func (n *alterTableNode) SetLimitHint(_ int64, _ bool) {}
-func (n *alterTableNode) MarkDebug(mode explainMode)   {}
+func (n *alterTableNode) Next() (bool, error)        { return false, nil }
+func (n *alterTableNode) Close()                     {}
+func (n *alterTableNode) Columns() ResultColumns     { return make(ResultColumns, 0) }
+func (n *alterTableNode) Ordering() orderingInfo     { return orderingInfo{} }
+func (n *alterTableNode) Values() parser.DTuple      { return parser.DTuple{} }
+func (n *alterTableNode) DebugValues() debugValues   { return debugValues{} }
+func (n *alterTableNode) MarkDebug(mode explainMode) {}
 
 func applyColumnMutation(
 	col *sqlbase.ColumnDescriptor, mut parser.ColumnMutationCmd, searchPath parser.SearchPath,

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -674,14 +674,16 @@ func (sc *SchemaChanger) backfillIndexesChunk(
 		scan := planner.Scan()
 		scan.desc = *tableDesc
 		scan.spans = []roachpb.Span{sp}
-		scan.SetLimitHint(chunkSize, false)
 		scan.initDescDefaults(publicAndNonPublicColumns)
+
+		// We manually invoke selectIndex() because for now expandPlan()
+		// can only do so itself when looking at a renderNode.
 		rows, err := selectIndex(scan, nil, false)
 		if err != nil {
 			return err
 		}
 
-		if err := planner.startPlan(rows); err != nil {
+		if err := planner.startPlanWithLimit(rows, chunkSize); err != nil {
 			return err
 		}
 

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -49,12 +49,11 @@ type copyNode struct {
 	rowsMemAcc    WrappableMemoryAccount
 }
 
-func (n *copyNode) Columns() ResultColumns     { return n.resultColumns }
-func (*copyNode) Ordering() orderingInfo       { return orderingInfo{} }
-func (*copyNode) Values() parser.DTuple        { return nil }
-func (*copyNode) SetLimitHint(_ int64, _ bool) {}
-func (*copyNode) MarkDebug(_ explainMode)      {}
-func (*copyNode) Next() (bool, error)          { return false, nil }
+func (n *copyNode) Columns() ResultColumns { return n.resultColumns }
+func (*copyNode) Ordering() orderingInfo   { return orderingInfo{} }
+func (*copyNode) Values() parser.DTuple    { return nil }
+func (*copyNode) MarkDebug(_ explainMode)  {}
+func (*copyNode) Next() (bool, error)      { return false, nil }
 
 func (n *copyNode) Close() {
 	n.rowsMemAcc.Wtxn(n.p.session).Close()

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -112,14 +112,13 @@ func (n *createDatabaseNode) Start() error {
 	return nil
 }
 
-func (n *createDatabaseNode) Next() (bool, error)          { return false, nil }
-func (n *createDatabaseNode) Close()                       {}
-func (n *createDatabaseNode) Columns() ResultColumns       { return make(ResultColumns, 0) }
-func (n *createDatabaseNode) Ordering() orderingInfo       { return orderingInfo{} }
-func (n *createDatabaseNode) Values() parser.DTuple        { return parser.DTuple{} }
-func (n *createDatabaseNode) DebugValues() debugValues     { return debugValues{} }
-func (n *createDatabaseNode) SetLimitHint(_ int64, _ bool) {}
-func (n *createDatabaseNode) MarkDebug(mode explainMode)   {}
+func (n *createDatabaseNode) Next() (bool, error)        { return false, nil }
+func (n *createDatabaseNode) Close()                     {}
+func (n *createDatabaseNode) Columns() ResultColumns     { return make(ResultColumns, 0) }
+func (n *createDatabaseNode) Ordering() orderingInfo     { return orderingInfo{} }
+func (n *createDatabaseNode) Values() parser.DTuple      { return parser.DTuple{} }
+func (n *createDatabaseNode) DebugValues() debugValues   { return debugValues{} }
+func (n *createDatabaseNode) MarkDebug(mode explainMode) {}
 
 type createIndexNode struct {
 	p         *planner
@@ -223,14 +222,13 @@ func (n *createIndexNode) Start() error {
 	return nil
 }
 
-func (n *createIndexNode) Next() (bool, error)          { return false, nil }
-func (n *createIndexNode) Close()                       {}
-func (n *createIndexNode) Columns() ResultColumns       { return make(ResultColumns, 0) }
-func (n *createIndexNode) Ordering() orderingInfo       { return orderingInfo{} }
-func (n *createIndexNode) Values() parser.DTuple        { return parser.DTuple{} }
-func (n *createIndexNode) DebugValues() debugValues     { return debugValues{} }
-func (n *createIndexNode) SetLimitHint(_ int64, _ bool) {}
-func (n *createIndexNode) MarkDebug(mode explainMode)   {}
+func (n *createIndexNode) Next() (bool, error)        { return false, nil }
+func (n *createIndexNode) Close()                     {}
+func (n *createIndexNode) Columns() ResultColumns     { return make(ResultColumns, 0) }
+func (n *createIndexNode) Ordering() orderingInfo     { return orderingInfo{} }
+func (n *createIndexNode) Values() parser.DTuple      { return parser.DTuple{} }
+func (n *createIndexNode) DebugValues() debugValues   { return debugValues{} }
+func (n *createIndexNode) MarkDebug(mode explainMode) {}
 
 type createUserNode struct {
 	p        *planner
@@ -301,14 +299,13 @@ func (n *createUserNode) Start() error {
 	return nil
 }
 
-func (n *createUserNode) Next() (bool, error)          { return false, nil }
-func (n *createUserNode) Close()                       {}
-func (n *createUserNode) Columns() ResultColumns       { return make(ResultColumns, 0) }
-func (n *createUserNode) Ordering() orderingInfo       { return orderingInfo{} }
-func (n *createUserNode) Values() parser.DTuple        { return parser.DTuple{} }
-func (n *createUserNode) DebugValues() debugValues     { return debugValues{} }
-func (n *createUserNode) SetLimitHint(_ int64, _ bool) {}
-func (n *createUserNode) MarkDebug(mode explainMode)   {}
+func (n *createUserNode) Next() (bool, error)        { return false, nil }
+func (n *createUserNode) Close()                     {}
+func (n *createUserNode) Columns() ResultColumns     { return make(ResultColumns, 0) }
+func (n *createUserNode) Ordering() orderingInfo     { return orderingInfo{} }
+func (n *createUserNode) Values() parser.DTuple      { return parser.DTuple{} }
+func (n *createUserNode) DebugValues() debugValues   { return debugValues{} }
+func (n *createUserNode) MarkDebug(mode explainMode) {}
 
 type createViewNode struct {
 	p           *planner
@@ -461,13 +458,12 @@ func (n *createViewNode) Close() {
 	n.sourcePlan = nil
 }
 
-func (n *createViewNode) Next() (bool, error)          { return false, nil }
-func (n *createViewNode) Columns() ResultColumns       { return make(ResultColumns, 0) }
-func (n *createViewNode) Ordering() orderingInfo       { return orderingInfo{} }
-func (n *createViewNode) Values() parser.DTuple        { return parser.DTuple{} }
-func (n *createViewNode) DebugValues() debugValues     { return debugValues{} }
-func (n *createViewNode) SetLimitHint(_ int64, _ bool) {}
-func (n *createViewNode) MarkDebug(mode explainMode)   {}
+func (n *createViewNode) Next() (bool, error)        { return false, nil }
+func (n *createViewNode) Columns() ResultColumns     { return make(ResultColumns, 0) }
+func (n *createViewNode) Ordering() orderingInfo     { return orderingInfo{} }
+func (n *createViewNode) Values() parser.DTuple      { return parser.DTuple{} }
+func (n *createViewNode) DebugValues() debugValues   { return debugValues{} }
+func (n *createViewNode) MarkDebug(mode explainMode) {}
 
 type createTableNode struct {
 	p          *planner
@@ -685,13 +681,12 @@ func (n *createTableNode) Close() {
 	}
 }
 
-func (n *createTableNode) Next() (bool, error)          { return false, nil }
-func (n *createTableNode) Columns() ResultColumns       { return make(ResultColumns, 0) }
-func (n *createTableNode) Ordering() orderingInfo       { return orderingInfo{} }
-func (n *createTableNode) Values() parser.DTuple        { return parser.DTuple{} }
-func (n *createTableNode) DebugValues() debugValues     { return debugValues{} }
-func (n *createTableNode) SetLimitHint(_ int64, _ bool) {}
-func (n *createTableNode) MarkDebug(mode explainMode)   {}
+func (n *createTableNode) Next() (bool, error)        { return false, nil }
+func (n *createTableNode) Columns() ResultColumns     { return make(ResultColumns, 0) }
+func (n *createTableNode) Ordering() orderingInfo     { return orderingInfo{} }
+func (n *createTableNode) Values() parser.DTuple      { return parser.DTuple{} }
+func (n *createTableNode) DebugValues() debugValues   { return debugValues{} }
+func (n *createTableNode) MarkDebug(mode explainMode) {}
 
 type indexMatch bool
 

--- a/pkg/sql/delayed.go
+++ b/pkg/sql/delayed.go
@@ -30,8 +30,6 @@ type delayedNode struct {
 
 type nodeConstructor func(p *planner) (planNode, error)
 
-func (d *delayedNode) SetLimitHint(_ int64, _ bool) {}
-
 func (d *delayedNode) Close() {
 	if d.plan != nil {
 		d.plan.Close()

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -237,5 +237,3 @@ func (d *deleteNode) DebugValues() debugValues {
 }
 
 func (d *deleteNode) Ordering() orderingInfo { return orderingInfo{} }
-
-func (d *deleteNode) SetLimitHint(numRows int64, soft bool) {}

--- a/pkg/sql/distinct.go
+++ b/pkg/sql/distinct.go
@@ -198,11 +198,6 @@ func (n *distinctNode) encodeValues(values parser.DTuple) ([]byte, []byte, error
 	return prefix, suffix, err
 }
 
-func (n *distinctNode) SetLimitHint(numRows int64, soft bool) {
-	// Any limit becomes a "soft" limit underneath.
-	n.plan.SetLimitHint(numRows, true)
-}
-
 func (n *distinctNode) Close() {
 	n.plan.Close()
 	n.prefixSeen = nil

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -20,7 +20,6 @@ package sql
 import (
 	"bytes"
 	"fmt"
-	"math"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/gossip"
@@ -1386,7 +1385,7 @@ func (dsp *distSQLPlanner) PlanAndRun(
 	ctx context.Context, txn *client.Txn, tree planNode, recv *distSQLReceiver,
 ) error {
 	// Trigger limit propagation.
-	tree.SetLimitHint(math.MaxInt64, true)
+	setUnlimited(tree)
 
 	planCtx := planningCtx{
 		ctx:           ctx,

--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -207,14 +207,13 @@ func (n *dropDatabaseNode) Start() error {
 	return nil
 }
 
-func (n *dropDatabaseNode) Next() (bool, error)          { return false, nil }
-func (n *dropDatabaseNode) Close()                       {}
-func (n *dropDatabaseNode) Columns() ResultColumns       { return make(ResultColumns, 0) }
-func (n *dropDatabaseNode) Ordering() orderingInfo       { return orderingInfo{} }
-func (n *dropDatabaseNode) Values() parser.DTuple        { return parser.DTuple{} }
-func (n *dropDatabaseNode) DebugValues() debugValues     { return debugValues{} }
-func (n *dropDatabaseNode) SetLimitHint(_ int64, _ bool) {}
-func (n *dropDatabaseNode) MarkDebug(mode explainMode)   {}
+func (n *dropDatabaseNode) Next() (bool, error)        { return false, nil }
+func (n *dropDatabaseNode) Close()                     {}
+func (n *dropDatabaseNode) Columns() ResultColumns     { return make(ResultColumns, 0) }
+func (n *dropDatabaseNode) Ordering() orderingInfo     { return orderingInfo{} }
+func (n *dropDatabaseNode) Values() parser.DTuple      { return parser.DTuple{} }
+func (n *dropDatabaseNode) DebugValues() debugValues   { return debugValues{} }
+func (n *dropDatabaseNode) MarkDebug(mode explainMode) {}
 
 type dropIndexNode struct {
 	p        *planner
@@ -395,14 +394,13 @@ func (p *planner) dropIndexByName(
 	return nil
 }
 
-func (n *dropIndexNode) Next() (bool, error)          { return false, nil }
-func (n *dropIndexNode) Close()                       {}
-func (n *dropIndexNode) Columns() ResultColumns       { return make(ResultColumns, 0) }
-func (n *dropIndexNode) Ordering() orderingInfo       { return orderingInfo{} }
-func (n *dropIndexNode) Values() parser.DTuple        { return parser.DTuple{} }
-func (n *dropIndexNode) DebugValues() debugValues     { return debugValues{} }
-func (n *dropIndexNode) SetLimitHint(_ int64, _ bool) {}
-func (n *dropIndexNode) MarkDebug(mode explainMode)   {}
+func (n *dropIndexNode) Next() (bool, error)        { return false, nil }
+func (n *dropIndexNode) Close()                     {}
+func (n *dropIndexNode) Columns() ResultColumns     { return make(ResultColumns, 0) }
+func (n *dropIndexNode) Ordering() orderingInfo     { return orderingInfo{} }
+func (n *dropIndexNode) Values() parser.DTuple      { return parser.DTuple{} }
+func (n *dropIndexNode) DebugValues() debugValues   { return debugValues{} }
+func (n *dropIndexNode) MarkDebug(mode explainMode) {}
 
 type dropViewNode struct {
 	p  *planner
@@ -503,14 +501,13 @@ func (n *dropViewNode) Start() error {
 	return nil
 }
 
-func (n *dropViewNode) Next() (bool, error)          { return false, nil }
-func (n *dropViewNode) Close()                       {}
-func (n *dropViewNode) Columns() ResultColumns       { return make(ResultColumns, 0) }
-func (n *dropViewNode) Ordering() orderingInfo       { return orderingInfo{} }
-func (n *dropViewNode) Values() parser.DTuple        { return parser.DTuple{} }
-func (n *dropViewNode) DebugValues() debugValues     { return debugValues{} }
-func (n *dropViewNode) SetLimitHint(_ int64, _ bool) {}
-func (n *dropViewNode) MarkDebug(mode explainMode)   {}
+func (n *dropViewNode) Next() (bool, error)        { return false, nil }
+func (n *dropViewNode) Close()                     {}
+func (n *dropViewNode) Columns() ResultColumns     { return make(ResultColumns, 0) }
+func (n *dropViewNode) Ordering() orderingInfo     { return orderingInfo{} }
+func (n *dropViewNode) Values() parser.DTuple      { return parser.DTuple{} }
+func (n *dropViewNode) DebugValues() debugValues   { return debugValues{} }
+func (n *dropViewNode) MarkDebug(mode explainMode) {}
 
 type dropTableNode struct {
 	p  *planner
@@ -736,14 +733,13 @@ func (n *dropTableNode) Start() error {
 	return nil
 }
 
-func (n *dropTableNode) Next() (bool, error)          { return false, nil }
-func (n *dropTableNode) Close()                       {}
-func (n *dropTableNode) Columns() ResultColumns       { return make(ResultColumns, 0) }
-func (n *dropTableNode) Ordering() orderingInfo       { return orderingInfo{} }
-func (n *dropTableNode) Values() parser.DTuple        { return parser.DTuple{} }
-func (n *dropTableNode) DebugValues() debugValues     { return debugValues{} }
-func (n *dropTableNode) SetLimitHint(_ int64, _ bool) {}
-func (n *dropTableNode) MarkDebug(mode explainMode)   {}
+func (n *dropTableNode) Next() (bool, error)        { return false, nil }
+func (n *dropTableNode) Close()                     {}
+func (n *dropTableNode) Columns() ResultColumns     { return make(ResultColumns, 0) }
+func (n *dropTableNode) Ordering() orderingInfo     { return orderingInfo{} }
+func (n *dropTableNode) Values() parser.DTuple      { return parser.DTuple{} }
+func (n *dropTableNode) DebugValues() debugValues   { return debugValues{} }
+func (n *dropTableNode) MarkDebug(mode explainMode) {}
 
 // dropTableOrViewPrepare/dropTableImpl is used to drop a single table by
 // name, which can result from either a DROP TABLE or DROP DATABASE

--- a/pkg/sql/empty.go
+++ b/pkg/sql/empty.go
@@ -27,13 +27,12 @@ type emptyNode struct {
 	results bool
 }
 
-func (*emptyNode) Columns() ResultColumns       { return nil }
-func (*emptyNode) Ordering() orderingInfo       { return orderingInfo{} }
-func (*emptyNode) Values() parser.DTuple        { return nil }
-func (*emptyNode) Start() error                 { return nil }
-func (*emptyNode) SetLimitHint(_ int64, _ bool) {}
-func (*emptyNode) MarkDebug(_ explainMode)      {}
-func (*emptyNode) Close()                       {}
+func (*emptyNode) Columns() ResultColumns  { return nil }
+func (*emptyNode) Ordering() orderingInfo  { return orderingInfo{} }
+func (*emptyNode) Values() parser.DTuple   { return nil }
+func (*emptyNode) Start() error            { return nil }
+func (*emptyNode) MarkDebug(_ explainMode) {}
+func (*emptyNode) Close()                  {}
 
 func (e *emptyNode) DebugValues() debugValues {
 	return debugValues{

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -30,6 +30,26 @@ import (
 // expansion of sub-queries. Returns an error if the initialization
 // fails.
 func (p *planner) expandPlan(plan planNode) (planNode, error) {
+	params := expandParameters{p: p}
+	return doExpandPlan(params.clear(), plan)
+}
+
+// expandParameters propagates the known row limit and desired ordering at
+// a given level to the levels under it (upstream).
+type expandParameters struct {
+	p               *planner
+	numRowsHint     int64
+	desiredOrdering sqlbase.ColumnOrdering
+}
+
+func (p expandParameters) clear() expandParameters {
+	p.numRowsHint = math.MaxInt64
+	p.desiredOrdering = nil
+	return p
+}
+
+// doExpandPlan is the algorithm that supports expandPlan().
+func doExpandPlan(params expandParameters, plan planNode) (planNode, error) {
 	if plan == nil {
 		return nil, nil
 	}
@@ -37,29 +57,29 @@ func (p *planner) expandPlan(plan planNode) (planNode, error) {
 	var err error
 	switch n := plan.(type) {
 	case *createTableNode:
-		n.sourcePlan, err = p.expandPlan(n.sourcePlan)
+		n.sourcePlan, err = doExpandPlan(params.clear(), n.sourcePlan)
 
 	case *updateNode:
-		n.run.rows, err = p.expandPlan(n.run.rows)
+		n.run.rows, err = doExpandPlan(params.clear(), n.run.rows)
 
 	case *insertNode:
-		n.run.rows, err = p.expandPlan(n.run.rows)
+		n.run.rows, err = doExpandPlan(params.clear(), n.run.rows)
 
 	case *deleteNode:
-		n.run.rows, err = p.expandPlan(n.run.rows)
+		n.run.rows, err = doExpandPlan(params.clear(), n.run.rows)
 
 	case *createViewNode:
-		n.sourcePlan, err = p.expandPlan(n.sourcePlan)
+		n.sourcePlan, err = doExpandPlan(params.clear(), n.sourcePlan)
 
 	case *explainDebugNode:
-		n.plan, err = p.expandPlan(n.plan)
+		n.plan, err = doExpandPlan(params.clear(), n.plan)
 		if err != nil {
 			return plan, err
 		}
 		n.plan.MarkDebug(explainDebug)
 
 	case *explainTraceNode:
-		n.plan, err = p.expandPlan(n.plan)
+		n.plan, err = doExpandPlan(params.clear(), n.plan)
 		if err != nil {
 			return plan, err
 		}
@@ -67,7 +87,7 @@ func (p *planner) expandPlan(plan planNode) (planNode, error) {
 
 	case *explainPlanNode:
 		if n.expanded {
-			n.plan, err = p.expandPlan(n.plan)
+			n.plan, err = doExpandPlan(params.clear(), n.plan)
 			if err != nil {
 				return plan, err
 			}
@@ -80,37 +100,41 @@ func (p *planner) expandPlan(plan planNode) (planNode, error) {
 
 	case *indexJoinNode:
 		// We ignore the return value because we know the scanNode is preserved.
-		_, err = p.expandPlan(n.table)
+		_, err = doExpandPlan(params, n.index)
 		if err != nil {
 			return plan, err
 		}
-		_, err = p.expandPlan(n.index)
+
+		// The row limit and desired ordering, if any, only propagates on
+		// the index side.
+		_, err = doExpandPlan(params.clear(), n.table)
 
 	case *unionNode:
-		n.right, err = p.expandPlan(n.right)
+		n.right, err = doExpandPlan(params, n.right)
 		if err != nil {
 			return plan, err
 		}
-		n.left, err = p.expandPlan(n.left)
+		n.left, err = doExpandPlan(params, n.left)
 
 	case *filterNode:
-		n.source.plan, err = p.expandPlan(n.source.plan)
+		n.source.plan, err = doExpandPlan(params, n.source.plan)
 
 	case *joinNode:
-		n.left.plan, err = p.expandPlan(n.left.plan)
+		params = params.clear()
+		n.left.plan, err = doExpandPlan(params, n.left.plan)
 		if err != nil {
 			return plan, err
 		}
-		n.right.plan, err = p.expandPlan(n.right.plan)
+		n.right.plan, err = doExpandPlan(params, n.right.plan)
 
 	case *ordinalityNode:
-		n.source, err = p.expandPlan(n.source)
+		n.source, err = doExpandPlan(params, n.source)
 		if err != nil {
 			return plan, err
 		}
 
 		// We are going to "optimize" the ordering. We had an ordering
-		// initially from the source, but expandPlan() may have caused it to
+		// initially from the source, but expand() may have caused it to
 		// change. So here retrieve the ordering of the source again.
 		origOrdering := n.source.Ordering()
 
@@ -136,21 +160,21 @@ func (p *planner) expandPlan(plan planNode) (planNode, error) {
 		}
 
 	case *limitNode, *sortNode, *windowNode, *groupNode, *distinctNode:
-		panic(fmt.Sprintf("expandPlan for %T must be handled by selectTopNode", plan))
+		panic(fmt.Sprintf("expand for %T must be handled by selectTopNode", plan))
 
 	case *renderNode:
-		plan, err = p.expandSelectNode(n)
+		plan, err = expandRenderNode(params, n)
 
 	case *selectTopNode:
-		plan, err = p.expandSelectTopNode(n)
+		plan, err = expandSelectTopNode(params, n)
 
 	case *delayedNode:
-		v, err := n.constructor(p)
+		v, err := n.constructor(params.p)
 		if err != nil {
 			return plan, err
 		}
 		n.plan = v
-		n.plan, err = p.expandPlan(n.plan)
+		n.plan, err = doExpandPlan(params, n.plan)
 
 	case *valuesNode:
 	case *scanNode:
@@ -174,14 +198,32 @@ func (p *planner) expandPlan(plan planNode) (planNode, error) {
 	return plan, err
 }
 
-func (p *planner) expandSelectTopNode(n *selectTopNode) (planNode, error) {
+func expandSelectTopNode(params expandParameters, n *selectTopNode) (planNode, error) {
 	if n.plan != nil {
 		// Plan is already expanded. Just elide.
 		return n.plan, nil
 	}
 
+	if n.limit != nil {
+		// Estimate the limit parameters. We can't full eval them just yet,
+		// because evaluation requires running potential sub-queries, which
+		// cannot occur during expand.
+		limitCount, limitOffset := n.limit.estimateLimit()
+		params.numRowsHint = getLimit(limitCount, limitOffset)
+	}
+
+	expandSourceParams := params
+	if n.group != nil {
+		expandSourceParams.desiredOrdering = n.group.desiredOrdering
+		// Under a group node, there may be arbitrarily more rows
+		// than those required by the context.
+		expandSourceParams.numRowsHint = math.MaxInt64
+	} else if n.sort != nil {
+		expandSourceParams.desiredOrdering = n.sort.ordering
+	}
+
 	var err error
-	n.source, err = p.expandPlan(n.source)
+	n.source, err = doExpandPlan(expandSourceParams, n.source)
 	if err != nil {
 		return n, err
 	}
@@ -261,23 +303,7 @@ func (p *planner) expandSelectTopNode(n *selectTopNode) (planNode, error) {
 	return n.plan, nil
 }
 
-func (p *planner) expandSelectNode(s *renderNode) (planNode, error) {
-	// Get the ordering for index selection (if any).
-	var ordering sqlbase.ColumnOrdering
-	var grouping bool
-
-	if s.top.group != nil {
-		ordering = s.top.group.desiredOrdering
-		grouping = true
-	} else if s.top.sort != nil {
-		ordering = s.top.sort.ordering
-	}
-
-	// Estimate the limit parameters. We can't full eval them just yet,
-	// because evaluation requires running potential sub-queries, which
-	// cannot occur during expandPlan.
-	limitCount, limitOffset := s.top.limit.estimateLimit()
-
+func expandRenderNode(params expandParameters, s *renderNode) (planNode, error) {
 	maybeScanNode := s.source.plan
 	if where, ok := maybeScanNode.(*filterNode); ok {
 		maybeScanNode = where.source.plan
@@ -285,10 +311,11 @@ func (p *planner) expandSelectNode(s *renderNode) (planNode, error) {
 
 	if scan, ok := maybeScanNode.(*scanNode); ok {
 		var analyzeOrdering analyzeOrderingFn
-		if ordering != nil {
+		if len(params.desiredOrdering) > 0 {
 			analyzeOrdering = func(indexOrdering orderingInfo) (matchingCols, totalCols int) {
 				selOrder := s.computeOrdering(indexOrdering)
-				return computeOrderingMatch(ordering, selOrder, false), len(ordering)
+				match := computeOrderingMatch(params.desiredOrdering, selOrder, false)
+				return match, len(params.desiredOrdering)
 			}
 		}
 
@@ -296,7 +323,7 @@ func (p *planner) expandSelectNode(s *renderNode) (planNode, error) {
 		// it is not covering - unless we are grouping, in which case the limit
 		// applies to the grouping results and not to the rows we scan.
 		var preferOrderMatchingIndex bool
-		if !grouping && len(ordering) > 0 && limitCount <= 1000-limitOffset {
+		if len(params.desiredOrdering) > 0 && params.numRowsHint <= 1000 {
 			preferOrderMatchingIndex = true
 		}
 
@@ -312,8 +339,11 @@ func (p *planner) expandSelectNode(s *renderNode) (planNode, error) {
 
 	// Expand the source node. We need to do this before computing the
 	// ordering, since expansion may modify the ordering.
+	// The outer desired ordering is not valid for the inner plan,
+	// so we simply discard it.
+	params.desiredOrdering = nil
 	var err error
-	s.source.plan, err = p.expandPlan(s.source.plan)
+	s.source.plan, err = doExpandPlan(params, s.source.plan)
 	if err != nil {
 		return s, err
 	}

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -249,6 +249,5 @@ func (n *explainDebugNode) Values() parser.DTuple {
 	}
 }
 
-func (*explainDebugNode) MarkDebug(_ explainMode)      {}
-func (*explainDebugNode) DebugValues() debugValues     { return debugValues{} }
-func (*explainDebugNode) SetLimitHint(_ int64, _ bool) {}
+func (*explainDebugNode) MarkDebug(_ explainMode)  {}
+func (*explainDebugNode) DebugValues() debugValues { return debugValues{} }

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -279,13 +279,12 @@ type explainPlanNode struct {
 	optimized bool
 }
 
-func (e *explainPlanNode) Next() (bool, error)          { return e.results.Next() }
-func (e *explainPlanNode) Columns() ResultColumns       { return e.results.Columns() }
-func (e *explainPlanNode) Ordering() orderingInfo       { return e.results.Ordering() }
-func (e *explainPlanNode) Values() parser.DTuple        { return e.results.Values() }
-func (e *explainPlanNode) DebugValues() debugValues     { return debugValues{} }
-func (e *explainPlanNode) SetLimitHint(n int64, s bool) { e.results.SetLimitHint(n, s) }
-func (e *explainPlanNode) MarkDebug(mode explainMode)   {}
+func (e *explainPlanNode) Next() (bool, error)        { return e.results.Next() }
+func (e *explainPlanNode) Columns() ResultColumns     { return e.results.Columns() }
+func (e *explainPlanNode) Ordering() orderingInfo     { return e.results.Ordering() }
+func (e *explainPlanNode) Values() parser.DTuple      { return e.results.Values() }
+func (e *explainPlanNode) DebugValues() debugValues   { return debugValues{} }
+func (e *explainPlanNode) MarkDebug(mode explainMode) {}
 func (e *explainPlanNode) Start() error {
 	return e.p.populateExplain(&e.explainer, e.results, e.plan)
 }

--- a/pkg/sql/filter.go
+++ b/pkg/sql/filter.go
@@ -37,11 +37,6 @@ type filterNode struct {
 	debugVals debugValues
 }
 
-// SetLimitHint implements the planNode interface.
-func (f *filterNode) SetLimitHint(numRows int64, soft bool) {
-	f.source.plan.SetLimitHint(numRows, soft || f.filter != nil)
-}
-
 // IndexedVarEval implements the parser.IndexedVarContainer interface.
 func (f *filterNode) IndexedVarEval(idx int, ctx *parser.EvalContext) (parser.Datum, error) {
 	return f.source.plan.Values()[idx].Eval(ctx)

--- a/pkg/sql/generator.go
+++ b/pkg/sql/generator.go
@@ -123,8 +123,7 @@ func (n *valueGenerator) DebugValues() debugValues {
 	}
 }
 
-func (n *valueGenerator) Ordering() orderingInfo       { return orderingInfo{} }
-func (n *valueGenerator) Values() parser.DTuple        { return n.gen.Values() }
-func (n *valueGenerator) MarkDebug(_ explainMode)      {}
-func (n *valueGenerator) Columns() ResultColumns       { return n.columns }
-func (n *valueGenerator) SetLimitHint(_ int64, _ bool) {}
+func (n *valueGenerator) Ordering() orderingInfo  { return orderingInfo{} }
+func (n *valueGenerator) Values() parser.DTuple   { return n.gen.Values() }
+func (n *valueGenerator) MarkDebug(_ explainMode) {}
+func (n *valueGenerator) Columns() ResultColumns  { return n.columns }

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -430,8 +430,6 @@ func (n *groupNode) computeAggregates() error {
 	return nil
 }
 
-func (*groupNode) SetLimitHint(_ int64, _ bool) {}
-
 func (n *groupNode) Close() {
 	n.plan.Close()
 	for _, f := range n.funcs {

--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -314,10 +314,6 @@ func (n *indexJoinNode) Next() (bool, error) {
 	return false, nil
 }
 
-func (n *indexJoinNode) SetLimitHint(numRows int64, soft bool) {
-	n.index.SetLimitHint(numRows, soft)
-}
-
 func (n *indexJoinNode) Close() {
 	n.index.Close()
 	n.table.Close()

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -567,5 +567,3 @@ func (n *insertNode) DebugValues() debugValues {
 }
 
 func (n *insertNode) Ordering() orderingInfo { return orderingInfo{} }
-
-func (n *insertNode) SetLimitHint(numRows int64, soft bool) {}

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -270,9 +270,6 @@ func (p *planner) makeJoin(
 	}, nil
 }
 
-// SetLimitHint implements the planNode interface.
-func (n *joinNode) SetLimitHint(numRows int64, soft bool) {}
-
 // Columns implements the planNode interface.
 func (n *joinNode) Columns() ResultColumns { return n.columns }
 

--- a/pkg/sql/limit_opt.go
+++ b/pkg/sql/limit_opt.go
@@ -1,0 +1,199 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package sql
+
+import (
+	"fmt"
+	"math"
+)
+
+// applyLimit tells this node to optimize things under the assumption that
+// we will only need the first `numRows` rows.
+//
+// The special value math.MaxInt64 indicates "no limit".
+//
+// If soft is true, this is a "soft" limit and is only a hint; the node must
+// still be able to produce all results if requested.
+//
+// If soft is false, this is a "hard" limit and is a promise that Next will
+// never be called more than numRows times.
+//
+// The action of calling this method triggers limit-based query plan
+// optimizations, e.g. in expandSelectNode(). The primary user is
+// limitNode.Start() after it has fully evaluated the limit and
+// offset expressions. EXPLAIN also does this, see expandPlan() for
+// explainPlanNode.
+//
+// TODO(radu) Arguably, this interface has room for improvement.  A
+// limitNode may have a hard limit locally which is larger than the
+// soft limit propagated up by nodes downstream. We may want to
+// improve this API to pass both the soft and hard limit.
+func applyLimit(plan planNode, numRows int64, soft bool) {
+	switch n := plan.(type) {
+	case *scanNode:
+		// Either a limitNode or EXPLAIN is pushing a limit down onto this
+		// node. The special value math.MaxInt64 means "no limit".
+		if !n.disableBatchLimits && numRows != math.MaxInt64 {
+			n.limitHint = numRows
+			// If we have a filter, some of the rows we retrieve may not pass the
+			// filter so the limit becomes "soft".
+			n.limitSoft = soft || !isFilterTrue(n.filter)
+		}
+
+	case *limitNode:
+		// A higher-level limitNode or EXPLAIN is pushing a limit down onto
+		// this node. Accept it unless the local limit is definitely
+		// smaller, in which case we propagate that as a hard limit instead.
+		// TODO(radu): we may get a smaller "soft" limit from the upper node
+		// and we may have a larger "hard" limit locally. In general, it's
+		// not clear which of those results in less work.
+		if !n.evaluated {
+			n.estimateLimit()
+		}
+		hintCount := numRows
+		if hintCount > n.count {
+			hintCount = n.count
+			soft = false
+		}
+		applyLimit(n.plan, getLimit(hintCount, n.offset), soft)
+
+	case *sortNode:
+		if n.needSort && numRows != math.MaxInt64 {
+			v := n.p.newContainerValuesNode(n.plan.Columns(), int(numRows))
+			v.ordering = n.ordering
+			if soft {
+				n.sortStrategy = newIterativeSortStrategy(v)
+			} else {
+				n.sortStrategy = newSortTopKStrategy(v, numRows)
+			}
+		}
+		if n.needSort {
+			// We can't propagate the limit, because the sort
+			// potentially needs all rows.
+			numRows = math.MaxInt64
+			soft = true
+			applyLimit(n.plan, numRows, soft)
+		}
+
+	case *groupNode:
+		if len(n.desiredOrdering) > 0 {
+			match := computeOrderingMatch(n.desiredOrdering, n.plan.Ordering(), false)
+			if match == len(n.desiredOrdering) {
+				// We have a single MIN/MAX function and the underlying plan's
+				// ordering matches the function. We only need to retrieve one row.
+				applyLimit(n.plan, 1, false /* !soft */)
+				n.needOnlyOneRow = true
+				return
+			}
+		}
+		setUnlimited(n.plan)
+
+	case *indexJoinNode:
+		applyLimit(n.index, numRows, soft)
+		setUnlimited(n.table)
+
+	case *unionNode:
+		applyLimit(n.right, numRows, true)
+		applyLimit(n.left, numRows, true)
+
+	case *distinctNode:
+		applyLimit(n.plan, numRows, true)
+
+	case *filterNode:
+		applyLimit(n.source.plan, numRows, soft || !isFilterTrue(n.filter))
+
+	case *renderNode:
+		applyLimit(n.source.plan, numRows, soft)
+
+	case *windowNode:
+		setUnlimited(n.plan)
+
+	case *joinNode:
+		setUnlimited(n.left.plan)
+		setUnlimited(n.right.plan)
+
+	case *ordinalityNode:
+		applyLimit(n.source, numRows, soft)
+
+	case *deleteNode:
+		setUnlimited(n.run.rows)
+	case *updateNode:
+		setUnlimited(n.run.rows)
+	case *insertNode:
+		setUnlimited(n.run.rows)
+	case *createTableNode:
+		if n.sourcePlan != nil {
+			applyLimit(n.sourcePlan, numRows, soft)
+		}
+	case *createViewNode:
+		setUnlimited(n.sourcePlan)
+	case *explainDebugNode:
+		setUnlimited(n.plan)
+	case *explainTraceNode:
+		setUnlimited(n.plan)
+	case *explainPlanNode:
+		setUnlimited(n.plan)
+
+	case *delayedNode:
+		if n.plan != nil {
+			setUnlimited(n.plan)
+		}
+
+	case *selectTopNode:
+		// A selectTopNode can only be encountered here if using
+		// EXPLAIN(NOEXPAND). At this point, the selectTopNode is not
+		// fully connected so we must be naive about limits.
+		if n.limit != nil || n.group != nil || n.distinct != nil || n.sort != nil {
+			numRows = math.MaxInt64
+			soft = true
+		}
+		applyLimit(n.source, numRows, soft)
+
+	case *valuesNode:
+	case *alterTableNode:
+	case *copyNode:
+	case *createDatabaseNode:
+	case *createIndexNode:
+	case *createUserNode:
+	case *dropDatabaseNode:
+	case *dropIndexNode:
+	case *dropTableNode:
+	case *dropViewNode:
+	case *emptyNode:
+	case *hookFnNode:
+	case *splitNode:
+	case *valueGenerator:
+
+	default:
+		panic(fmt.Sprintf("unhandled node type: %T", plan))
+	}
+}
+
+func setUnlimited(plan planNode) {
+	applyLimit(plan, math.MaxInt64, true)
+}
+
+// getLimit computes the actual number of rows to request from the
+// data source to honour both the required count and offset together.
+// This also ensures that the resulting number of rows does not
+// overflow.
+func getLimit(count, offset int64) int64 {
+	if offset > math.MaxInt64-count {
+		count = math.MaxInt64 - offset
+	}
+	return count + offset
+}

--- a/pkg/sql/ordinality.go
+++ b/pkg/sql/ordinality.go
@@ -92,11 +92,10 @@ func (o *ordinalityNode) Next() (bool, error) {
 	return true, nil
 }
 
-func (o *ordinalityNode) Ordering() orderingInfo                { return o.ordering }
-func (o *ordinalityNode) Values() parser.DTuple                 { return o.row }
-func (o *ordinalityNode) DebugValues() debugValues              { return o.source.DebugValues() }
-func (o *ordinalityNode) MarkDebug(mode explainMode)            { o.source.MarkDebug(mode) }
-func (o *ordinalityNode) Columns() ResultColumns                { return o.columns }
-func (o *ordinalityNode) Start() error                          { return o.source.Start() }
-func (o *ordinalityNode) Close()                                { o.source.Close() }
-func (o *ordinalityNode) SetLimitHint(numRows int64, soft bool) { o.source.SetLimitHint(numRows, soft) }
+func (o *ordinalityNode) Ordering() orderingInfo     { return o.ordering }
+func (o *ordinalityNode) Values() parser.DTuple      { return o.row }
+func (o *ordinalityNode) DebugValues() debugValues   { return o.source.DebugValues() }
+func (o *ordinalityNode) MarkDebug(mode explainMode) { o.source.MarkDebug(mode) }
+func (o *ordinalityNode) Columns() ResultColumns     { return o.columns }
+func (o *ordinalityNode) Start() error               { return o.source.Start() }
+func (o *ordinalityNode) Close()                     { o.source.Close() }

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -17,6 +17,8 @@
 package sql
 
 import (
+	"math"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -80,33 +82,9 @@ var _ planMaker = &planner{}
 // - planVisitor.visit()           (walk.go)
 // - planNodeNames                 (walk.go)
 // - planMaker.optimizeFilters()   (filter_opt.go)
+// - setLimitHint()                (limit_hint.go)
 //
 type planNode interface {
-	// SetLimitHint tells this node to optimize things under the assumption that
-	// we will only need the first `numRows` rows.
-	//
-	// The special value math.MaxInt64 indicates "no limit".
-	//
-	// If soft is true, this is a "soft" limit and is only a hint; the node must
-	// still be able to produce all results if requested.
-	//
-	// If soft is false, this is a "hard" limit and is a promise that Next will
-	// never be called more than numRows times.
-	//
-	// The action of calling this method triggers limit-based query plan
-	// optimizations, e.g. in expandSelectNode(). The primary user is
-	// limitNode.Start() after it has fully evaluated the limit and
-	// offset expressions. EXPLAIN also does this, see expandPlan() for
-	// explainPlanNode.
-	//
-	// TODO(radu) Arguably, this interface has room for improvement.  A
-	// limitNode may have a hard limit locally which is larger than the
-	// soft limit propagated up by nodes downstream. We may want to
-	// improve this API to pass both the soft and hard limit.
-	//
-	// Available during/after newPlan().
-	SetLimitHint(numRows int64, soft bool)
-
 	// Columns returns the column names and types. The length of the
 	// returned slice is guaranteed to be equal to the length of the
 	// tuple returned by Values().
@@ -234,10 +212,19 @@ func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, er
 
 // startPlan starts the plan and all its sub-query nodes.
 func (p *planner) startPlan(plan planNode) error {
+	return p.startPlanWithLimit(plan, math.MaxInt64)
+}
+
+func (p *planner) startPlanWithLimit(plan planNode, numRowsNeeded int64) error {
 	if err := p.startSubqueryPlans(plan); err != nil {
 		return err
 	}
-	return plan.Start()
+	if err := plan.Start(); err != nil {
+		return err
+	}
+	// Trigger limit propagation through the plan and sub-queries.
+	applyLimit(plan, numRowsNeeded, false /* !soft */)
+	return nil
 }
 
 // newPlan constructs a planNode from a statement. This is used

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -56,10 +56,9 @@ type hookFnNode struct {
 
 var _ planNode = &hookFnNode{}
 
-func (*hookFnNode) Ordering() orderingInfo       { return orderingInfo{} }
-func (*hookFnNode) SetLimitHint(_ int64, _ bool) {}
-func (*hookFnNode) MarkDebug(_ explainMode)      {}
-func (*hookFnNode) Close()                       {}
+func (*hookFnNode) Ordering() orderingInfo  { return orderingInfo{} }
+func (*hookFnNode) MarkDebug(_ explainMode) {}
+func (*hookFnNode) Close()                  {}
 
 func (f *hookFnNode) Start() error {
 	var err error

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -135,10 +135,6 @@ func (s *renderNode) Next() (bool, error) {
 	return err == nil, err
 }
 
-func (s *renderNode) SetLimitHint(numRows int64, soft bool) {
-	s.source.plan.SetLimitHint(numRows, soft)
-}
-
 func (s *renderNode) Close() {
 	s.source.plan.Close()
 }

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -29,9 +29,6 @@ import (
 type renderNode struct {
 	planner *planner
 
-	// top refers to the surrounding selectTopNode.
-	top *selectTopNode
-
 	// source describes where the data is coming from.
 	// populated initially by initFrom().
 	// potentially modified by index selection.
@@ -287,7 +284,6 @@ func (p *planner) SelectClause(
 		distinct: distinctPlan,
 		limit:    limitPlan,
 	}
-	s.top = result
 	limitPlan.setTop(result)
 	distinctPlan.setTop(result)
 

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -19,7 +19,6 @@ package sql
 import (
 	"bytes"
 	"fmt"
-	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -120,17 +119,6 @@ func (n *scanNode) DebugValues() debugValues {
 		panic(fmt.Sprintf("node not in debug mode (mode %d)", n.explain))
 	}
 	return n.debugVals
-}
-
-func (n *scanNode) SetLimitHint(numRows int64, soft bool) {
-	// Either a limitNode or EXPLAIN is pushing a limit down onto this
-	// node. The special value math.MaxInt64 means "no limit".
-	if !n.disableBatchLimits && numRows != math.MaxInt64 {
-		n.limitHint = numRows
-		// If we have a filter, some of the rows we retrieve may not pass the
-		// filter so the limit becomes "soft".
-		n.limitSoft = soft || n.filter != nil
-	}
 }
 
 // disableBatchLimit disables the kvfetcher batch limits. Used for index-join,

--- a/pkg/sql/select_top.go
+++ b/pkg/sql/select_top.go
@@ -34,12 +34,6 @@ type selectTopNode struct {
 	plan planNode
 }
 
-func (n *selectTopNode) SetLimitHint(numRows int64, soft bool) {
-	if n.plan != nil {
-		n.plan.SetLimitHint(numRows, soft)
-	}
-}
-
 func (n *selectTopNode) Columns() ResultColumns {
 	if n.plan != nil {
 		return n.plan.Columns()

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -19,7 +19,6 @@ package sql
 import (
 	"container/heap"
 	"fmt"
-	"math"
 	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -312,24 +311,6 @@ func (n *sortNode) DebugValues() debugValues {
 		panic(fmt.Sprintf("node not in debug mode (mode %d)", n.explain))
 	}
 	return n.debugVals
-}
-
-func (n *sortNode) SetLimitHint(numRows int64, soft bool) {
-	if !n.needSort {
-		// The limit is only useful to the wrapped node if we don't need to sort.
-		n.plan.SetLimitHint(numRows, soft)
-	} else {
-		// The special value math.MaxInt64 means "no limit".
-		if numRows != math.MaxInt64 {
-			v := n.p.newContainerValuesNode(n.plan.Columns(), int(numRows))
-			v.ordering = n.ordering
-			if soft {
-				n.sortStrategy = newIterativeSortStrategy(v)
-			} else {
-				n.sortStrategy = newSortTopKStrategy(v, numRows)
-			}
-		}
-	}
 }
 
 func (n *sortNode) Start() error {

--- a/pkg/sql/split.go
+++ b/pkg/sql/split.go
@@ -154,10 +154,9 @@ func (*splitNode) Columns() ResultColumns {
 	}
 }
 
-func (*splitNode) Close()                       {}
-func (*splitNode) Ordering() orderingInfo       { return orderingInfo{} }
-func (*splitNode) SetLimitHint(_ int64, _ bool) {}
-func (*splitNode) MarkDebug(_ explainMode)      {}
+func (*splitNode) Close()                  {}
+func (*splitNode) Ordering() orderingInfo  { return orderingInfo{} }
+func (*splitNode) MarkDebug(_ explainMode) {}
 
 func (n *splitNode) DebugValues() debugValues {
 	return debugValues{

--- a/pkg/sql/testdata/insert
+++ b/pkg/sql/testdata/insert
@@ -496,6 +496,7 @@ EXPLAIN (PLAN,EXPRS) INSERT INTO insert_t SELECT * FROM select_t LIMIT 1
 1                 count     1
 2  scan
 2                 table     select_t@primary
+2                 limit     1
 
 statement ok
 INSERT INTO insert_t SELECT * FROM select_t LIMIT 1

--- a/pkg/sql/testdata/needed_columns
+++ b/pkg/sql/testdata/needed_columns
@@ -93,12 +93,13 @@ EXPLAIN (METADATA) SELECT x FROM (SELECT 1 AS x, 2 AS y, 3 AS z) ORDER BY y
 query ITTTTT
 EXPLAIN (METADATA) SELECT 1 = (SELECT 2 AS x FROM (SELECT 3 AS s)) AS y
 ----
-0   render                               (y)
-0             subqueries             1
-1   render                               (x)
-2   render                               (s[omitted])
-3   nullrow                              ()
-1   nullrow                              ()
+0  render                  (y)
+0           subqueries  1
+1  limit                   (x)
+2  render                  (x)
+3  render                  (s[omitted])
+4  nullrow                 ()
+1  nullrow                 ()
 
 # Propagation through table scans.
 statement ok

--- a/pkg/sql/testdata/subquery
+++ b/pkg/sql/testdata/subquery
@@ -45,7 +45,8 @@ EXPLAIN ALTER TABLE abc SPLIT AT ((SELECT 42))
 ----
 0  split
 0           subqueries  1
-1  nullrow
+1  limit
+2  nullrow
 
 statement ok
 ALTER TABLE abc SPLIT AT ((SELECT 1))
@@ -68,6 +69,15 @@ SELECT (SELECT * FROM abc)
 
 query error more than one row returned by a subquery used as an expression
 SELECT (SELECT a FROM abc)
+
+query ITTT
+EXPLAIN SELECT EXISTS (SELECT a FROM abc)
+----
+-1           subqueries  1
+0   limit
+1   scan
+1            table       abc@primary
+0   nullrow
 
 query I
 SELECT (SELECT a FROM abc WHERE false)

--- a/pkg/sql/testdata/values
+++ b/pkg/sql/testdata/values
@@ -32,4 +32,5 @@ EXPLAIN VALUES (1), ((SELECT 2))
 0  values
 0           size        1 column, 2 rows
 0           subqueries  1
-1  nullrow
+1  limit
+2  nullrow

--- a/pkg/sql/trace.go
+++ b/pkg/sql/trace.go
@@ -182,6 +182,5 @@ func (n *explainTraceNode) Values() parser.DTuple {
 	return n.rows[0]
 }
 
-func (*explainTraceNode) MarkDebug(_ explainMode)      {}
-func (*explainTraceNode) DebugValues() debugValues     { return debugValues{} }
-func (*explainTraceNode) SetLimitHint(_ int64, _ bool) {}
+func (*explainTraceNode) MarkDebug(_ explainMode)  {}
+func (*explainTraceNode) DebugValues() debugValues { return debugValues{} }

--- a/pkg/sql/union.go
+++ b/pkg/sql/union.go
@@ -151,10 +151,6 @@ func (n *unionNode) Values() parser.DTuple {
 		return nil
 	}
 }
-func (n *unionNode) SetLimitHint(numRows int64, soft bool) {
-	n.right.SetLimitHint(numRows, true)
-	n.left.SetLimitHint(numRows, true)
-}
 
 func (n *unionNode) MarkDebug(mode explainMode) {
 	if mode != explainDebug {

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -94,7 +94,7 @@ func (r *editNodeRun) startEditNode(en *editNodeBase, tw tableWriter) error {
 
 	r.tw = tw
 
-	return en.p.startPlan(r.rows)
+	return r.rows.Start()
 }
 
 type updateNode struct {
@@ -395,5 +395,3 @@ func (u *updateNode) DebugValues() debugValues {
 }
 
 func (u *updateNode) Ordering() orderingInfo { return orderingInfo{} }
-
-func (u *updateNode) SetLimitHint(numRows int64, soft bool) {}

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -287,5 +287,3 @@ func (n *valuesNode) InitMinHeap() {
 	n.invertSorting = false
 	heap.Init(n)
 }
-
-func (*valuesNode) SetLimitHint(_ int64, _ bool) {}

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -734,8 +734,6 @@ func (n *windowNode) populateValues() error {
 	return nil
 }
 
-func (*windowNode) SetLimitHint(_ int64, _ bool) {}
-
 func (n *windowNode) Close() {
 	n.plan.Close()
 	if n.wrappedRenderVals != nil {


### PR DESCRIPTION
This patchset simplifies the planNode interface and removes the confusing/hard-to-understand `top` field from `renderNode`. It also enables sub-queries to use the surrounding EXISTS clause or their usage in a scalar context as a row limit hint.

cc @vivekmenezes for the change to the backfill code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13118)
<!-- Reviewable:end -->
