### PR TITLE
distsql: signal stopping to sources

### DIFF
--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -163,6 +163,7 @@ func (ag *aggregator) Run(wg *sync.WaitGroup) {
 	}
 
 	ag.out.close(nil)
+	ag.input.ConsumerDone()
 }
 
 func (ag *aggregator) accumulateRows() error {

--- a/pkg/sql/distsqlrun/distinct.go
+++ b/pkg/sql/distsqlrun/distinct.go
@@ -70,6 +70,8 @@ func (d *distinct) Run(wg *sync.WaitGroup) {
 		defer log.Infof(ctx, "exiting distinct")
 	}
 
+	defer d.input.ConsumerDone()
+
 	var scratch []byte
 	for {
 		row, err := d.input.NextRow()

--- a/pkg/sql/distsqlrun/flow_registry.go
+++ b/pkg/sql/distsqlrun/flow_registry.go
@@ -263,6 +263,11 @@ func (fr *flowRegistry) finishInboundStreamLocked(is *inboundStreamInfo) {
 	if is.finished {
 		panic("double finish")
 	}
+
+	if is.timedOut {
+		is.receiver.Close(errors.Errorf("inbound stream timed out"))
+	}
+
 	is.finished = true
 	is.waitGroup.Done()
 }

--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -90,6 +90,9 @@ func (h *hashJoiner) Run(wg *sync.WaitGroup) {
 		defer log.Infof(ctx, "exiting hash joiner run")
 	}
 
+	defer h.leftSource.ConsumerDone()
+	defer h.rightSource.ConsumerDone()
+
 	if err := h.buildPhase(ctx); err != nil {
 		h.out.close(err)
 		return

--- a/pkg/sql/distsqlrun/input_sync.go
+++ b/pkg/sql/distsqlrun/input_sync.go
@@ -165,6 +165,22 @@ func (s *orderedSynchronizer) NextRow() (sqlbase.EncDatumRow, error) {
 	return s.sources[s.heap[0]].row, nil
 }
 
+// ConsumerDone is part of the RowSource interface.
+func (s *orderedSynchronizer) ConsumerDone() {
+	if !s.initialized {
+		for i := range s.sources {
+			s.sources[i].src.ConsumerDone()
+		}
+	} else {
+		// The sources that are not in the heap have been consumed already. It would
+		// be ok to call ConsumerDone() on them too, but avoiding the call may be a
+		// bit faster (in most cases there should be no sources left).
+		for _, sIdx := range s.heap {
+			s.sources[sIdx].src.ConsumerDone()
+		}
+	}
+}
+
 func makeOrderedSync(ordering sqlbase.ColumnOrdering, sources []RowSource) (RowSource, error) {
 	if len(sources) < 2 {
 		return nil, errors.Errorf("only %d sources for ordered synchronizer", len(sources))

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -117,6 +117,7 @@ func (jr *joinReader) mainLoop() error {
 	if log.V(1) {
 		defer log.Infof(ctx, "exiting")
 	}
+	defer jr.input.ConsumerDone()
 
 	for {
 		// TODO(radu): figure out how to send smaller batches if the source has

--- a/pkg/sql/distsqlrun/mergejoiner.go
+++ b/pkg/sql/distsqlrun/mergejoiner.go
@@ -82,6 +82,8 @@ func (m *mergeJoiner) Run(wg *sync.WaitGroup) {
 		log.Infof(ctx, "starting merge joiner run")
 		defer log.Infof(ctx, "exiting merge joiner run")
 	}
+	defer m.leftSource.ConsumerDone()
+	defer m.rightSource.ConsumerDone()
 
 	for {
 		batch, err := m.streamMerger.NextBatch()

--- a/pkg/sql/distsqlrun/outbox.go
+++ b/pkg/sql/distsqlrun/outbox.go
@@ -175,12 +175,8 @@ func (m *outbox) mainLoop() error {
 func (m *outbox) run() {
 	err := m.mainLoop()
 
-	m.RowChannel.NoMoreRows()
-	if err != nil {
-		// Drain to allow senders to finish.
-		for range m.dataChan {
-		}
-	}
+	m.RowChannel.ConsumerDone()
+
 	if m.stream != nil {
 		resp, recvErr := m.stream.CloseAndRecv()
 		if err == nil {

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -178,6 +178,7 @@ func (n *noopProcessor) Run(wg *sync.WaitGroup) {
 			return
 		}
 		if !n.out.emitRow(ctx, row) {
+			n.input.ConsumerDone()
 			return
 		}
 	}

--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -119,4 +119,5 @@ func (s *sorter) Run(wg *sync.WaitGroup) {
 		// specified.
 		panic("optimizationt no implemented yet")
 	}
+	s.input.ConsumerDone()
 }


### PR DESCRIPTION
If a processor finishes without consuming its entire input(s), the upstream
processors can block trying to send on the channel. We need to stop accepting
rows and drain the RowChannels.

This was a problem only in error cases; supporting LIMIT would expose it in
non-error cases as well. I am postponing adding some tests for this until then.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13127)
<!-- Reviewable:end -->
