### PR TITLE
all: add testshort target that skips slow tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ ifeq ($(STATIC),1)
 # https://github.com/golang/go/issues/13470. If a static build is
 # requested, only link libgcc and libstdc++ statically.
 # TODO(peter): Allow this only when `go env CC` reports "gcc".
-LDFLAGS += -extldflags "-static-libgcc -static-libstdc++"
+override LDFLAGS += -extldflags "-static-libgcc -static-libstdc++"
 endif
 
 .PHONY: all
@@ -87,7 +87,7 @@ start:
 # dependencies are rebuilt which is useful when switching between
 # normal and race test builds.
 .PHONY: install
-install: LDFLAGS += $(shell GOPATH=${GOPATH} build/ldflags.sh)
+install: override LDFLAGS += $(shell GOPATH=${GOPATH} build/ldflags.sh)
 install:
 	@echo "GOPATH set to $$GOPATH"
 	@echo "$$GOPATH/bin added to PATH"
@@ -113,12 +113,12 @@ else
 	$(GO) test $(GOFLAGS) -tags '$(TAGS)' -run "$(TESTS)" -bench "$(BENCHES)" -timeout $(TESTTIMEOUT) $(PKG) $(TESTFLAGS)
 endif
 
-testrace: GOFLAGS += -race
+testrace: override GOFLAGS += -race
 testrace: TESTTIMEOUT := $(RACETIMEOUT)
 testrace: test
 
 .PHONY: testslow
-testslow: TESTFLAGS += -v
+testslow: override TESTFLAGS += -v
 testslow: gotestdashi
 ifeq ($(BENCHES),-)
 	$(GO) test $(GOFLAGS) -tags '$(TAGS)' -run "$(TESTS)" -timeout $(TESTTIMEOUT) $(PKG) $(TESTFLAGS) | grep -F ': Test' | sed -E 's/(--- PASS: |\(|\))//g' | awk '{ print $$2, $$1 }' | sort -rn | head -n 10
@@ -127,7 +127,7 @@ else
 endif
 
 .PHONY: testraceslow
-testraceslow: GOFLAGS += -race
+testraceslow: override GOFLAGS += -race
 testraceslow: TESTTIMEOUT := $(RACETIMEOUT)
 testraceslow: testslow
 
@@ -149,7 +149,7 @@ else
 endif
 
 .PHONY: stressrace
-stressrace: GOFLAGS += -race
+stressrace: override GOFLAGS += -race
 stressrace: TESTTIMEOUT := $(RACETIMEOUT)
 stressrace: stress
 
@@ -192,7 +192,7 @@ dupl:
 	| dupl -files $(DUPLFLAGS)
 
 .PHONY: check
-check: TAGS += check
+check: override TAGS += check
 check:
 	$(GO) test ./build -v -tags '$(TAGS)' -run 'TestStyle/$(TESTS)'
 

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,10 @@ else
 	$(GO) test $(GOFLAGS) -tags '$(TAGS)' -run "$(TESTS)" -bench "$(BENCHES)" -timeout $(TESTTIMEOUT) $(PKG) $(TESTFLAGS)
 endif
 
+.PHONY: testshort
+testshort: override TESTFLAGS += -short
+testshort: test
+
 testrace: override GOFLAGS += -race
 testrace: TESTTIMEOUT := $(RACETIMEOUT)
 testrace: test

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,9 @@ endif
 .PHONY: all
 all: build test check
 
+.PHONY: short
+short: build testshort checkshort
+
 .PHONY: buildoss
 buildoss: BUILDTARGET = ./pkg/cmd/cockroach-oss
 buildoss: build
@@ -199,6 +202,11 @@ dupl:
 check: override TAGS += check
 check:
 	$(GO) test ./build -v -tags '$(TAGS)' -run 'TestStyle/$(TESTS)'
+
+.PHONY: checkshort
+checkshort: override TAGS += check
+checkshort:
+	$(GO) test ./build -v -tags '$(TAGS)' -short -run 'TestStyle/$(TESTS)'
 
 .PHONY: clean
 clean:

--- a/build/style_test.go
+++ b/build/style_test.go
@@ -620,6 +620,9 @@ func TestStyle(t *testing.T) {
 	})
 
 	t.Run("TestUnconvert", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("short flag")
+		}
 		t.Parallel()
 		cmd, stderr, filter, err := dirCmd(pkg.Dir, "unconvert", pkgScope)
 		if err != nil {
@@ -647,6 +650,9 @@ func TestStyle(t *testing.T) {
 	})
 
 	t.Run("TestMetacheck", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("short flag")
+		}
 		t.Parallel()
 		cmd, stderr, filter, err := dirCmd(
 			pkg.Dir,

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -259,6 +259,10 @@ func (c cliTest) RunWithArgs(origArgs []string) {
 func TestQuit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	if testing.Short() {
+		t.Skip("short flag")
+	}
+
 	c := newCLITest(cliTestParams{t: t})
 	defer c.cleanup()
 

--- a/pkg/kv/txn_correctness_test.go
+++ b/pkg/kv/txn_correctness_test.go
@@ -947,6 +947,11 @@ func checkConcurrency(
 //    R1(A) R2(B) I2(B) R2(A) I2(A) R1(B) C1 C2
 func TestTxnDBReadSkewAnomaly(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	if testing.Short() {
+		t.Skip("short flag")
+	}
+
 	txn1 := "R(A) R(B) W(C,A+B) C"
 	txn2 := "R(A) R(B) I(A) I(B) C"
 	verify := &verifier{

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -198,6 +198,10 @@ func (ln *interceptingListener) Accept() (net.Conn, error) {
 func TestHeartbeatHealthTransport(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	if testing.Short() {
+		t.Skip("short flag")
+	}
+
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 

--- a/pkg/sql/logic_test.go
+++ b/pkg/sql/logic_test.go
@@ -1187,6 +1187,10 @@ func TestLogic(t *testing.T) {
 func TestLogicDistSQL(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	if testing.Short() {
+		t.Skip("short flag")
+	}
+
 	defer sql.SetDefaultDistSQLMode("ON")()
 
 	TestLogic(t)

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -6643,6 +6643,10 @@ func checkValue(ctx context.Context, tc *testContext, key []byte, expectedVal []
 func TestAmbiguousResultErrorOnRetry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	if testing.Short() {
+		t.Skip("short flag")
+	}
+
 	cfg := TestStoreConfig(nil)
 	tc := testContext{}
 	stopper := stop.NewStopper()

--- a/pkg/storage/replicate_queue_test.go
+++ b/pkg/storage/replicate_queue_test.go
@@ -39,6 +39,10 @@ import (
 func TestReplicateQueueRebalance(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	if testing.Short() {
+		t.Skip("short flag")
+	}
+
 	// Set the gossip stores interval lower to speed up rebalancing. With the
 	// default of 5s we have to wait ~5s for the rebalancing to start.
 	defer func(v time.Duration) {


### PR DESCRIPTION
Adding `make testshort` which adds the `-short` flag to `make test`. Disabling
tests over 10 seconds in this mode (except the main SQL logic test suite).

A reasonable workflow would be to run `make test PKG=./pkg/foo` for whatever
package you're touching and run `make testshort` for the rest.

Fixes #13025.

Also:
Add `make checkshort` which is `make check` with TestMetacheck and TestUnconvert
disabled (these tests are slow and don't uncover issues very frequently).
    
Add `make short` target which does build+testshort+checkshort.


I will send out a PSA when this goes in.
CC @tamird @jordanlewis @petermattis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13136)
<!-- Reviewable:end -->
