### PR TITLE
sql: permit using set-returning functions in render list

### DIFF
--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -519,13 +519,12 @@ func (p *planner) getSubqueryPlan(
 }
 
 func (p *planner) getGeneratorPlan(t *parser.FuncExpr) (planDataSource, error) {
-	plan, name, err := p.makeGenerator(t)
+	plan, err := p.makeGenerator(t)
 	if err != nil {
 		return planDataSource{}, err
 	}
-	tn := parser.TableName{TableName: parser.Name(name)}
 	return planDataSource{
-		info: newSourceInfoForSingleTable(tn, plan.Columns()),
+		info: newSourceInfoForSingleTable(anonymousTable, plan.Columns()),
 		plan: plan,
 	}, nil
 }

--- a/pkg/sql/generator.go
+++ b/pkg/sql/generator.go
@@ -47,23 +47,23 @@ type valueGenerator struct {
 
 // makeGenerator creates a valueGenerator instance that wraps a call to a
 // generator function.
-func (p *planner) makeGenerator(t *parser.FuncExpr) (planNode, string, error) {
+func (p *planner) makeGenerator(t *parser.FuncExpr) (planNode, error) {
 	origName := t.Func.String()
 
 	if err := p.parser.AssertNoAggregationOrWindowing(t, "FROM", p.session.SearchPath); err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	normalized, err := p.analyzeExpr(
 		t, multiSourceInfo{}, parser.IndexedVarHelper{}, parser.TypeAny, false, "FROM",
 	)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	tType, ok := normalized.ResolvedType().(parser.TTable)
 	if !ok {
-		return nil, "", errors.Errorf("FROM expression is not a generator: %s", t)
+		return nil, errors.Errorf("FROM expression is not a generator: %s", t)
 	}
 
 	var columns ResultColumns
@@ -83,7 +83,7 @@ func (p *planner) makeGenerator(t *parser.FuncExpr) (planNode, string, error) {
 		p:       p,
 		expr:    normalized,
 		columns: columns,
-	}, origName, nil
+	}, nil
 }
 
 func (n *valueGenerator) Start() error {

--- a/pkg/sql/testdata/generators
+++ b/pkg/sql/testdata/generators
@@ -57,7 +57,60 @@ x y
 query error argument of LIMIT must be type int, not type setof
 SELECT * FROM (VALUES (1)) LIMIT GENERATE_SERIES(1, 3)
 
-# Not supported yet: transforming a generator given in render position
-# to a cross join.
-query error unsupported result type: setof
+query I colnames
 SELECT GENERATE_SERIES(1, 2)
+----
+pg_catalog.generate_series
+1
+2
+
+query II colnames
+SELECT GENERATE_SERIES(1, 2), GENERATE_SERIES(3, 4)
+----
+pg_catalog.generate_series  pg_catalog.generate_series
+1                           3
+1                           4
+2                           3
+2                           4
+
+statement ok
+CREATE TABLE t (a string)
+
+statement ok
+CREATE TABLE u (b string)
+
+statement ok
+INSERT INTO t VALUES ('cat')
+
+statement ok
+INSERT INTO u VALUES ('bird')
+
+# The following two queries should have the same result. This exercises the
+# transformation that moves generator expressions in render positions to cross
+# joins.
+query TTII
+SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) FROM t, u
+----
+cat  bird  1  3
+cat  bird  1  4
+cat  bird  2  3
+cat  bird  2  4
+
+query TTII
+SELECT t.*, u.*, a.*, b.* FROM t, u, generate_series(1, 2) AS a, generate_series(3, 4) AS b
+----
+cat  bird  1  3
+cat  bird  1  4
+cat  bird  2  3
+cat  bird  2  4
+
+query I
+SELECT 3 + x FROM generate_series(1,2) AS a(x)
+----
+4
+5
+
+# Not supported yet: transforming set-returning functions that aren't top-level
+# render expressions into cross joins.
+query error pq: unsupported binary operator: <int> \+ <setof tuple\{int\}>
+SELECT 3 + generate_series(1,2)

--- a/pkg/sql/testdata/generators
+++ b/pkg/sql/testdata/generators
@@ -6,6 +6,15 @@ GENERATE_SERIES
 2
 3
 
+query II colnames
+SELECT * FROM GENERATE_SERIES(1, 2), GENERATE_SERIES(1, 2)
+----
+GENERATE_SERIES  GENERATE_SERIES
+1                1
+1                2
+2                1
+2                2
+
 query I
 SELECT * FROM GENERATE_SERIES(3, 1, -1)
 ----


### PR DESCRIPTION
Using set-returning functions in the render list is now supported, by cross-joining their result with the rest of the query. For example, `SELECT generate_series(1, 2);` will output `1` and `2` in two separate rows.

Resolves #11215.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13140)
<!-- Reviewable:end -->
