### PR TITLE
sql: more helpful error in logic test output

### DIFF
--- a/pkg/sql/logic_test.go
+++ b/pkg/sql/logic_test.go
@@ -830,6 +830,10 @@ func (t *logicTest) verifyError(sql, pos, expectErr, expectErrCode string, err e
 	}
 	if !testutils.IsError(err, expectErr) {
 		t.Errorf("%s: expected %q, but found %v", pos, expectErr, err)
+		if strings.Contains(err.Error(), expectErr) {
+			t.t.Logf("The output string contained the input regexp. Perhaps you meant to write:\n"+
+				"query error %s", regexp.QuoteMeta(err.Error()))
+		}
 		return false
 	}
 	if expectErrCode != "" {


### PR DESCRIPTION
If your `query error` line is identical to the output but fails to match
it as a regex, the LogicTest will inform you that you probably forgot to
escape your string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13145)
<!-- Reviewable:end -->
