### PR TITLE
server: fix retry loop around generating store ids

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -167,7 +167,7 @@ func incVal(ctx context.Context, db *client.DB, key roachpb.Key, inc int64) (int
 	for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
 		res, err = db.Inc(ctx, key, inc)
 		switch err.(type) {
-		case *roachpb.WriteTooOldError, *roachpb.AmbiguousResultError:
+		case *roachpb.RetryableTxnError, *roachpb.AmbiguousResultError:
 			continue
 		}
 		break


### PR DESCRIPTION
It was broken; the db interface never returns WriteTooOldError, it
transforms it into a RetryableTxnError.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13148)
<!-- Reviewable:end -->
