### PR TITLE
sql: place index selection into full responsibility of scanNode.

### DIFF
--- a/pkg/sql/testdata/distinct
+++ b/pkg/sql/testdata/distinct
@@ -110,8 +110,7 @@ EXPLAIN SELECT DISTINCT y + z FROM xyz ORDER BY y + z
 1  sort
 1            order  +"y + z"
 2  scan
-2            table  xyz@foo
-2            spans  ALL
+2            table  xyz@primary
 
 query I
 SELECT DISTINCT y AS w FROM xyz ORDER by z

--- a/pkg/sql/testdata/join
+++ b/pkg/sql/testdata/join
@@ -450,6 +450,7 @@ EXPLAIN(EXPRS) SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
 1                 type      cross
 2  scan
 2                 table     twocolumn@primary
+2                 spans     ALL
 2                 filter    x = 44
 2  scan
 2                 table     twocolumn@primary
@@ -617,9 +618,9 @@ EXPLAIN (METADATA) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
 0  render                            (x, y)
 1  join                              (x, y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])
 1          type   cross
-2  scan                              (x, y[omitted], rowid[hidden,omitted])
+2  scan                              (x, y[omitted], rowid[hidden,omitted])                                       +rowid,unique
 2          table  twocolumn@primary
-2  scan                              (x[omitted], y, rowid[hidden,omitted])
+2  scan                              (x[omitted], y, rowid[hidden,omitted])                                       +rowid,unique
 2          table  twocolumn@primary
 
 query ITTTTT
@@ -629,9 +630,9 @@ EXPLAIN (METADATA) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
 1  join                                 (x[omitted], x[hidden,omitted], y[omitted], rowid[hidden,omitted], x[hidden,omitted], y, rowid[hidden,omitted])
 1          type      inner
 1          equality  (x) = (x)
-2  scan                                 (x, y[omitted], rowid[hidden,omitted])
+2  scan                                 (x, y[omitted], rowid[hidden,omitted])                                                                          +rowid,unique
 2          table     twocolumn@primary
-2  scan                                 (x, y, rowid[hidden,omitted])
+2  scan                                 (x, y, rowid[hidden,omitted])                                                                                   +rowid,unique
 2          table     twocolumn@primary
 
 query ITTTTT
@@ -641,9 +642,9 @@ EXPLAIN (METADATA) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = 
 1  join                                 (x[omitted], y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])
 1          type      inner
 1          equality  (x) = (x)
-2  scan                                 (x, y[omitted], rowid[hidden,omitted])
+2  scan                                 (x, y[omitted], rowid[hidden,omitted])                                                  +rowid,unique
 2          table     twocolumn@primary
-2  scan                                 (x, y, rowid[hidden,omitted])
+2  scan                                 (x, y, rowid[hidden,omitted])                                                           +rowid,unique
 2          table     twocolumn@primary
 
 query ITTTTT
@@ -652,9 +653,9 @@ EXPLAIN (METADATA) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < 
 0  render                            (x)
 1  join                              (x, y[omitted], rowid[hidden,omitted], x[omitted], y[omitted], rowid[hidden,omitted])
 1          type   inner
-2  scan                              (x, y[omitted], rowid[hidden,omitted])
+2  scan                              (x, y[omitted], rowid[hidden,omitted])                                                 +rowid,unique
 2          table  twocolumn@primary
-2  scan                              (x[omitted], y, rowid[hidden,omitted])
+2  scan                              (x[omitted], y, rowid[hidden,omitted])                                                 +rowid,unique
 2          table  twocolumn@primary
 
 # Ensure that the ordering information for the result of joins is sane. (#12037)
@@ -922,9 +923,9 @@ EXPLAIN (VERBOSE) SELECT * FROM pairs, square WHERE pairs.a + pairs.b = square.s
 1  join                                                              (a, b, rowid[hidden,omitted], n, sq)
 1          type      inner
 1          pred      (test.pairs.a + test.pairs.b) = test.square.sq
-2  scan                                                              (a, b, rowid[hidden,omitted])
+2  scan                                                              (a, b, rowid[hidden,omitted])          +rowid,unique
 2          table     pairs@primary
-2  scan                                                              (n, sq)
+2  scan                                                              (n, sq)                                +n,unique
 2          table     square@primary
 
 query IIII
@@ -955,9 +956,9 @@ EXPLAIN (VERBOSE) SELECT a, b, n, sq FROM (SELECT a, b, a + b AS sum, n, sq FROM
 2          render 4  test.square.sq
 3  join                                           (a, b, rowid[hidden,omitted], n, sq)
 3          type      cross
-4  scan                                           (a, b, rowid[hidden,omitted])
+4  scan                                           (a, b, rowid[hidden,omitted])        +rowid,unique
 4          table     pairs@primary
-4  scan                                           (n, sq)
+4  scan                                           (n, sq)                              +n,unique
 4          table     square@primary
 
 query IIII
@@ -979,9 +980,9 @@ EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.
 1  join                                                              (a, b, rowid[hidden,omitted], n, sq)
 1          type      full outer
 1          pred      (test.pairs.a + test.pairs.b) = test.square.sq
-2  scan                                                              (a, b, rowid[hidden,omitted])
+2  scan                                                              (a, b, rowid[hidden,omitted])         +rowid,unique
 2          table     pairs@primary
-2  scan                                                              (n, sq)
+2  scan                                                              (n, sq)                               +n,unique
 2          table     square@primary
 
 query IIII
@@ -1020,9 +1021,9 @@ EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.
 2  join                                                              (a, b, rowid[hidden,omitted], n, sq)
 2          type      full outer
 2          pred      (test.pairs.a + test.pairs.b) = test.square.sq
-3  scan                                                              (a, b, rowid[hidden,omitted])
+3  scan                                                              (a, b, rowid[hidden,omitted])        +rowid,unique
 3          table     pairs@primary
-3  scan                                                              (n, sq)
+3  scan                                                              (n, sq)                              +n,unique
 3          table     square@primary
 
 query IIII

--- a/pkg/sql/testdata/order_by
+++ b/pkg/sql/testdata/order_by
@@ -277,7 +277,6 @@ EXPLAIN(METADATA) SELECT b+2 FROM t ORDER BY b+2
 1  render                    ("b + 2")
 2  scan                      (a[omitted], b, c[omitted])  +a,unique
 2          table  t@primary
-2          spans  ALL
 
 # Check that the sort picks up a renamed render properly.
 query ITTTTT
@@ -288,7 +287,6 @@ EXPLAIN(METADATA) SELECT b+2 AS y FROM t ORDER BY y
 1  render                    (y)
 2  scan                      (a[omitted], b, c[omitted])  +a,unique
 2          table  t@primary
-2          spans  ALL
 
 # Check that the sort reuses a render behind a rename properly.
 query ITTTTT
@@ -299,7 +297,6 @@ EXPLAIN(METADATA) SELECT b+2 AS y FROM t ORDER BY b+2
 1  render                    (y)
 2  scan                      (a[omitted], b, c[omitted])  +a,unique
 2          table  t@primary
-2          spans  ALL
 
 statement ok
 CREATE TABLE abc (

--- a/pkg/sql/testdata/ordinality
+++ b/pkg/sql/testdata/ordinality
@@ -93,7 +93,7 @@ EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM foo WHERE x > 'a') WITH ORDINALI
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM foo WITH ORDINALITY WHERE x > 'a';
 ----
-0  filter                          (x, ordinality)  +ordinality,unique
-1  ordinality                      (x, ordinality)  +ordinality,unique
-2  scan                            (x)
+0  filter                          (x, ordinality)  +x,unique
+1  ordinality                      (x, ordinality)  +x,unique
+2  scan                            (x)              +x,unique
 2              table  foo@primary

--- a/pkg/sql/testdata/select_index
+++ b/pkg/sql/testdata/select_index
@@ -107,6 +107,22 @@ EXPLAIN (DEBUG) SELECT a FROM t WHERE a in (2, 3) ORDER BY a DESC
 0  /t/a_desc/3/'three'  NULL  ROW
 1  /t/a_desc/2/'two'    NULL  ROW
 
+# Index selection occurs in direct join operands too.
+query ITTT
+EXPLAIN SELECT * FROM t x JOIN t y USING(b) WHERE x.b < '3'
+----
+0   join
+0                type       inner
+0                equality   (b) = (b)
+1   index-join
+2   scan
+2                table      t@bc
+2                spans      /#-/"3"
+2   scan
+2                table      t@primary
+1   scan
+1                table      t@primary
+
 statement ok
 TRUNCATE TABLE t
 


### PR DESCRIPTION
Prior to this patch, the index selection logic in expandPlan() would
pause at renderNode and reason as follows: "hmm, is my direct source a
scanNode? If so, let's see how to improve it with index selection."
In other words index selection was under the responsibility of
renderNode.

This is a problem in every context where there is no renderNode, for
example for scan operands to joins.

This patch corrects the issue by pushing the responsibility for index
selection to scanNode expansion, which now can operate in any position
where a scanNode is valid.

This way joins can use indices too!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13149)
<!-- Reviewable:end -->
