### PR TITLE
storage: deflake TestRefreshPendingCommands

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -967,6 +967,27 @@ func TestRefreshPendingCommands(t *testing.T) {
 				return nil
 			})
 
+			// TODO(peter,andrei): This shouldn't be necessary, but removes flakiness
+			// in TestRefreshPendingCommands/#01. The flakiness is caused by the
+			// first NodeLiveness.heartbeatInterval() operation never completing
+			// causing multiTestContext.restartStore(2) below to never return because
+			// the new store is not considered live. Why the heartbeat doesn't
+			// complete is unclear. It looks like the restarted node is able to get
+			// the range lease in order to perform the heartbeat operation, but the
+			// conditional-put for the heartbeat then seems to disappear inside of
+			// the replica.
+			//
+			// Note that node-liveness heartbeats are enabled when a node
+			// restarts. So the line to re-enable them below is present to re-enable
+			// node-liveness heartbeats on nodes 1 and 2. Doing so undoubtedly
+			// affects which node gets the range lease and thus masks the
+			// flakiness. But I suspect the flakiness is due to a real but very rare
+			// bug.
+			//
+			// To reproduce on a GCE worker:
+			//   make stress PKG=./storage/ TESTS='TestRefreshPendingCommands/#01' STRESSFLAGS='-maxfails 1 -stderr -p 64'
+			pauseNodeLivenessHeartbeats(mtc, false)
+
 			// Restart node 2 and wait for the snapshot to be applied. Note that
 			// waitForValues reads directly from the engine and thus isn't executing
 			// a Raft command.


### PR DESCRIPTION
I'm not quite sure why this fixes the flakiness. An expert on leases
needs to take a closer look.

See #12309

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13158)
<!-- Reviewable:end -->
