### PR TITLE
storage: fix Store.haveGossiped{SystemConfig,NodeLiveness} logic

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -457,17 +457,19 @@ func Example_ranges() {
 	// debug range ls
 	// /Min-"c" [1]
 	// 	0: node-id=1 store-id=1
-	// "c"-/Table/11 [6]
+	// "c"-/Table/0 [7]
+	// 	0: node-id=1 store-id=1
+	// /Table/0-/Table/11 [3]
 	// 	0: node-id=1 store-id=1
 	// /Table/11-/Table/12 [2]
 	// 	0: node-id=1 store-id=1
-	// /Table/12-/Table/13 [3]
+	// /Table/12-/Table/13 [4]
 	//	0: node-id=1 store-id=1
-	// /Table/13-/Table/14 [4]
+	// /Table/13-/Table/14 [5]
 	//	0: node-id=1 store-id=1
-	// /Table/14-/Max [5]
+	// /Table/14-/Max [6]
 	//	0: node-id=1 store-id=1
-	// 6 result(s)
+	// 7 result(s)
 	// debug kv scan
 	// "a"	"1"
 	// "b"	"2"
@@ -581,7 +583,7 @@ func Example_max_results() {
 	// debug range ls --max-results=2
 	// /Min-"c" [1]
 	// 	0: node-id=1 store-id=1
-	// "c"-"d" [6]
+	// "c"-"d" [7]
 	// 	0: node-id=1 store-id=1
 	// 2 result(s)
 }

--- a/pkg/internal/client/db_test.go
+++ b/pkg/internal/client/db_test.go
@@ -394,6 +394,7 @@ func TestCommonMethods(t *testing.T) {
 		{txnType, "SetUserPriority"}:        {},
 		{txnType, "SetSystemConfigTrigger"}: {},
 		{txnType, "SystemConfigTrigger"}:    {},
+		{txnType, "SetTxnAnchorKey"}:        {},
 		{txnType, "UpdateDeadlineMaybe"}:    {},
 		{txnType, "AddCommitTrigger"}:       {},
 	}

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -234,11 +234,14 @@ var (
 	ReportUsagePrefix = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("update-")))
 
 	// TableDataMin is the start of the range of table data keys.
-	TableDataMin = roachpb.Key(encoding.EncodeVarintAscending(nil, math.MinInt64))
+	TableDataMin = roachpb.Key(encoding.EncodeVarintAscending(nil, 0))
 	// TableDataMin is the end of the range of table data keys.
 	TableDataMax = roachpb.Key(encoding.EncodeVarintAscending(nil, math.MaxInt64))
 
-	// SystemConfigTableDataMax is the end key of system config structured data.
+	// SystemConfigSplitKey is the key to split at immediately prior to the
+	// system config span. NB: Split keys need to be valid column keys.
+	SystemConfigSplitKey = MakeRowSentinelKey(TableDataMin)
+	// SystemConfigTableDataMax is the end key of system config span.
 	SystemConfigTableDataMax = roachpb.Key(MakeTablePrefix(MaxSystemConfigDescID + 1))
 
 	// UserTableDataMin is the start key of user structured data.

--- a/pkg/keys/spans.go
+++ b/pkg/keys/spans.go
@@ -26,7 +26,7 @@ var (
 	NodeLivenessSpan = roachpb.Span{Key: NodeLivenessPrefix, EndKey: NodeLivenessKeyMax}
 
 	// SystemConfigSpan is the range of system objects which will be gossiped.
-	SystemConfigSpan = roachpb.Span{Key: TableDataMin, EndKey: SystemConfigTableDataMax}
+	SystemConfigSpan = roachpb.Span{Key: SystemConfigSplitKey, EndKey: SystemConfigTableDataMax}
 
 	// UserDataSpan is the non-meta and non-structured portion of the key space.
 	UserDataSpan = roachpb.Span{Key: SystemMax, EndKey: TableDataMin}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -301,7 +301,9 @@ func (ts *TestServer) Start(params base.TestServerArgs) error {
 // process.
 func ExpectedInitialRangeCount() int {
 	bootstrap := GetBootstrapSchema()
-	return bootstrap.SystemDescriptorCount() - bootstrap.SystemConfigDescriptorCount() + 1
+	return bootstrap.SystemDescriptorCount() -
+		bootstrap.SystemConfigDescriptorCount() +
+		2 /* first-range + system-config-range */
 }
 
 // WaitForInitialSplits waits for the server to complete its expected initial

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -1112,7 +1112,7 @@ func TestNonRetryableErrorOnCommit(t *testing.T) {
 	cleanupFilter := cmdFilters.AppendFilter(
 		func(args storagebase.FilterArgs) *roachpb.Error {
 			if req, ok := args.Req.(*roachpb.EndTransactionRequest); ok {
-				if bytes.Contains(req.Key, []byte(keys.DescIDGenerator)) {
+				if bytes.Contains(req.Key, []byte(keys.SystemConfigSpan.Key)) {
 					hitError = true
 					return roachpb.NewErrorWithTxn(fmt.Errorf("testError"), args.Hdr.Txn)
 				}

--- a/pkg/storage/client_lease_test.go
+++ b/pkg/storage/client_lease_test.go
@@ -17,14 +17,20 @@
 package storage_test
 
 import (
+	"errors"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -156,4 +162,71 @@ func TestStoreRangeLeaseSwitcheroo(t *testing.T) {
 	if lt := lease.Type(); lt != roachpb.LeaseEpoch {
 		t.Fatalf("expected lease type epoch; got %d", lt)
 	}
+}
+
+// TestStoreGossipSystemData verifies that the system-config and node-liveness
+// data is gossiped at startup.
+func TestStoreGossipSystemData(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	sc := storage.TestStoreConfig(nil)
+	sc.EnableEpochRangeLeases = true
+	mtc := &multiTestContext{storeConfig: &sc}
+	defer mtc.Stop()
+	mtc.Start(t, 1)
+
+	splitKey := keys.SystemConfigSplitKey
+	splitArgs := adminSplitArgs(splitKey, splitKey)
+	if _, pErr := client.SendWrapped(context.Background(), mtc.distSenders[0], splitArgs); pErr != nil {
+		t.Fatal(pErr)
+	}
+	if _, err := mtc.dbs[0].Inc(context.TODO(), splitKey, 1); err != nil {
+		t.Fatalf("failed to increment: %s", err)
+	}
+
+	mtc.stopStore(0)
+
+	getSystemConfig := func() config.SystemConfig {
+		systemConfig, _ := mtc.gossips[0].GetSystemConfig()
+		return systemConfig
+	}
+	getNodeLiveness := func() storage.Liveness {
+		var liveness storage.Liveness
+		if err := mtc.gossips[0].GetInfoProto(gossip.MakeNodeLivenessKey(1), &liveness); err == nil {
+			return liveness
+		}
+		return storage.Liveness{}
+	}
+
+	// Clear the system-config and node liveness gossip data. This is necessary
+	// because multiTestContext.restartStore reuse the Gossip structure.
+	if err := mtc.gossips[0].AddInfoProto(
+		gossip.KeySystemConfig, &config.SystemConfig{}, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := mtc.gossips[0].AddInfoProto(
+		gossip.MakeNodeLivenessKey(1), &storage.Liveness{}, 0); err != nil {
+		t.Fatal(err)
+	}
+	testutils.SucceedsSoon(t, func() error {
+		if !reflect.DeepEqual(getSystemConfig(), config.SystemConfig{}) {
+			return errors.New("system config not empty")
+		}
+		if getNodeLiveness() != (storage.Liveness{}) {
+			return errors.New("node liveness not empty")
+		}
+		return nil
+	})
+
+	// Restart the store and verify that both the system-config and node-liveness
+	// data is gossiped.
+	mtc.restartStore(0)
+	testutils.SucceedsSoon(t, func() error {
+		if reflect.DeepEqual(getSystemConfig(), config.SystemConfig{}) {
+			return errors.New("system config not gossiped")
+		}
+		if getNodeLiveness() == (storage.Liveness{}) {
+			return errors.New("node liveness not gossiped")
+		}
+		return nil
+	})
 }

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -849,7 +849,9 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 		// We expect splits at each of the user tables, but not at the system
 		// tables boundaries.
 		numReservedTables := schema.SystemDescriptorCount() - schema.SystemConfigDescriptorCount()
-		expKeys := make([]roachpb.Key, 0, maxTableID+numReservedTables)
+		var expKeys []roachpb.Key
+		expKeys = append(expKeys,
+			testutils.MakeKey(keys.Meta2Prefix, keys.TableDataMin))
 		for i := 1; i <= int(numReservedTables); i++ {
 			expKeys = append(expKeys,
 				testutils.MakeKey(keys.Meta2Prefix,

--- a/pkg/storage/queue_test.go
+++ b/pkg/storage/queue_test.go
@@ -413,7 +413,7 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 	defer stopper.Stop()
 	s, _ := createTestStore(t, stopper)
 
-	dataMaxAddr, err := keys.Addr(keys.SystemConfigTableDataMax)
+	dataMaxAddr, err := keys.Addr(keys.TableDataMin)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4350,10 +4350,12 @@ func (r *Replica) shouldGossip() bool {
 // (which provide the necessary serialization to avoid data races).
 func (r *Replica) maybeGossipSystemConfig(ctx context.Context) error {
 	if r.store.Gossip() == nil || !r.IsInitialized() {
+		log.Infof(ctx, "gossip not initialized")
 		return nil
 	}
 
 	if !r.ContainsKey(keys.SystemConfigSpan.Key) || !r.shouldGossip() {
+		log.Infof(ctx, "not system config span or lease not held")
 		return nil
 	}
 
@@ -4371,7 +4373,6 @@ func (r *Replica) maybeGossipSystemConfig(ctx context.Context) error {
 	if err := r.store.Gossip().AddInfoProto(gossip.KeySystemConfig, &loadedCfg, 0); err != nil {
 		return errors.Wrap(err, "failed to gossip system config")
 	}
-	atomic.StoreInt32(&r.store.haveGossipedSystemConfig, 1)
 	return nil
 }
 
@@ -4422,7 +4423,6 @@ func (r *Replica) maybeGossipNodeLiveness(ctx context.Context, span roachpb.Span
 			continue
 		}
 	}
-	atomic.StoreInt32(&r.store.haveGossipedNodeLiveness, 1)
 	return nil
 }
 

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4368,8 +4368,11 @@ func (r *Replica) maybeGossipSystemConfig(ctx context.Context) error {
 	}
 
 	log.VEventf(ctx, 2, "gossiping system config")
-
-	return errors.Wrap(r.store.Gossip().AddInfoProto(gossip.KeySystemConfig, &loadedCfg, 0), "failed to gossip system config")
+	if err := r.store.Gossip().AddInfoProto(gossip.KeySystemConfig, &loadedCfg, 0); err != nil {
+		return errors.Wrap(err, "failed to gossip system config")
+	}
+	atomic.StoreInt32(&r.store.haveGossipedSystemConfig, 1)
+	return nil
 }
 
 // maybeGossipNodeLiveness gossips information for all node liveness
@@ -4419,6 +4422,7 @@ func (r *Replica) maybeGossipNodeLiveness(ctx context.Context, span roachpb.Span
 			continue
 		}
 	}
+	atomic.StoreInt32(&r.store.haveGossipedNodeLiveness, 1)
 	return nil
 }
 

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -438,12 +438,12 @@ func (r *Replica) leasePostApply(
 	// or this is the first time that either system data has been
 	// gossiped.
 	if iAmTheLeaseHolder {
-		if leaseChangingHands || atomic.CompareAndSwapInt32(&r.store.haveGossipedSystemConfig, 0, 1) {
+		if leaseChangingHands || atomic.LoadInt32(&r.store.haveGossipedSystemConfig) == 0 {
 			if err := r.maybeGossipSystemConfig(ctx); err != nil {
 				log.Error(ctx, err)
 			}
 		}
-		if leaseChangingHands || atomic.CompareAndSwapInt32(&r.store.haveGossipedNodeLiveness, 0, 1) {
+		if leaseChangingHands || atomic.LoadInt32(&r.store.haveGossipedNodeLiveness) == 0 {
 			if err := r.maybeGossipNodeLiveness(ctx, keys.NodeLivenessSpan); err != nil {
 				log.Error(ctx, err)
 			}

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -17,7 +17,6 @@
 package storage
 
 import (
-	"sync/atomic"
 	"time"
 
 	"golang.org/x/net/context"
@@ -433,20 +432,19 @@ func (r *Replica) leasePostApply(
 		r.store.maybeGossipOnCapacityChange(ctx, leaseChangeEvent)
 	}
 
-	// Potentially re-gossip if the range contains system data (e.g.
-	// system config or node liveness) and the lease is changing hands
-	// or this is the first time that either system data has been
-	// gossiped.
+	// Potentially re-gossip if the range contains system data (e.g. system
+	// config or node liveness). We need to perform this gossip at startup as
+	// soon as possible. Trying to minimize how often we gossip is a fool's
+	// errand. The node liveness info will be gossiped frequently (every few
+	// seconds) in any case due to the liveness heartbeats. And the system config
+	// will be gossiped rarely because it falls on a range with an epoch-based
+	// range lease that is only reacquired extremely infrequently.
 	if iAmTheLeaseHolder {
-		if leaseChangingHands || atomic.LoadInt32(&r.store.haveGossipedSystemConfig) == 0 {
-			if err := r.maybeGossipSystemConfig(ctx); err != nil {
-				log.Error(ctx, err)
-			}
+		if err := r.maybeGossipSystemConfig(ctx); err != nil {
+			log.Error(ctx, err)
 		}
-		if leaseChangingHands || atomic.LoadInt32(&r.store.haveGossipedNodeLiveness) == 0 {
-			if err := r.maybeGossipNodeLiveness(ctx, keys.NodeLivenessSpan); err != nil {
-				log.Error(ctx, err)
-			}
+		if err := r.maybeGossipNodeLiveness(ctx, keys.NodeLivenessSpan); err != nil {
+			log.Error(ctx, err)
 		}
 	}
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1314,14 +1314,26 @@ func (s *Store) startGossip() {
 		gossipFn := gossipFn // per-iteration copy
 		s.stopper.RunWorker(func() {
 			ctx := s.AnnotateCtx(context.Background())
-			// Run the first time without waiting for the Ticker and signal the WaitGroup.
-			if err := gossipFn.fn(ctx); err != nil {
-				log.Warningf(ctx, "error gossiping %s: %s", gossipFn.description, err)
-			}
-			s.initComplete.Done()
 			ticker := time.NewTicker(gossipFn.interval)
 			defer ticker.Stop()
-			for {
+			for first := true; ; {
+				// Retry in a backoff loop until gossipFn succeeds. The gossipFn might
+				// temporarily fail (e.g. because node liveness hasn't initialized yet
+				// making it impossible to get an epoch-based range lease), in which
+				// case we want to retry quickly.
+				retryOptions := base.DefaultRetryOptions()
+				retryOptions.Closer = s.stopper.ShouldStop()
+				for r := retry.Start(retryOptions); r.Next(); {
+					if err := gossipFn.fn(ctx); err != nil {
+						log.Errorf(ctx, "error gossiping %s: %s", gossipFn.description, err)
+						continue
+					}
+					break
+				}
+				if first {
+					first = false
+					s.initComplete.Done()
+				}
 				select {
 				case <-ticker.C:
 					if err := gossipFn.fn(ctx); err != nil {
@@ -1374,6 +1386,7 @@ func (s *Store) maybeGossipSystemData(ctx context.Context, span roachpb.Span) er
 		// This store has no range with this configuration.
 		return nil
 	}
+	ctx = repl.AnnotateCtx(ctx)
 	// Wake up the replica. If it acquires a fresh lease, gossip the
 	// gossip. If an unexpected error occurs (i.e. nobody else seems to
 	// have an active lease but we still failed to obtain it), return

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -440,12 +440,6 @@ type Store struct {
 	// has likely improved).
 	drainLeases atomic.Value
 
-	// These vars are atomically updated from 0 to 1 once per store
-	// lifetime to ensure we gossip system data in the event that the
-	// node ends up owning the relevant range lease on a restart.
-	haveGossipedSystemConfig int32
-	haveGossipedNodeLiveness int32
-
 	// Locking notes: To avoid deadlocks, the following lock order must be
 	// obeyed: Replica.raftMu < Replica.readOnlyCmdMu < Store.mu < Replica.mu
 	// < Replica.unreachablesMu < Store.coalescedMu < Store.scheduler.mu.


### PR DESCRIPTION
I still need to add a test that shows the failure to gossip the system
config with the previous logic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13167)
<!-- Reviewable:end -->
