### PR TITLE
build: add check that floss target doesn't depend on ccl

### DIFF
--- a/pkg/cmd/cockroach-oss/dep_test.go
+++ b/pkg/cmd/cockroach-oss/dep_test.go
@@ -1,0 +1,33 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestNoLinkForbidden(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	// Verify that the cockroach floss binary doesn't depend on certain packages.
+	buildutil.VerifyNoImports(t,
+		"github.com/cockroachdb/cockroach/pkg/cmd/cockroach-oss",
+		true,
+		nil,
+		[]string{"github.com/cockroachdb/cockroach/pkg/ccl"},
+	)
+}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13170)
<!-- Reviewable:end -->
