### PR TITLE
cli: add more choices for formatting table results.

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -147,11 +147,12 @@ with a non-zero status code and further statements are not executed. The
 results of each SQL statement are printed on the standard output.`,
 	}
 
-	Pretty = FlagInfo{
-		Name: "pretty",
+	TableDisplayFormat = FlagInfo{
+		Name: "format",
 		Description: `
-Causes table rows to be formatted as tables using ASCII art.
-When not specified, table rows are printed as tab-separated values (TSV).`,
+Selects how to display table rows in results. Possible values: tsv,
+csv, pretty, records, sql, html. If left unspecified, defaults to tsv
+for non-interactive sessions and pretty for interactive sessions.`,
 	}
 
 	Join = FlagInfo{

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -47,9 +47,62 @@ type cliContext struct {
 	// Embed the base context.
 	*base.Config
 
-	// prettyFmt indicates whether tables should be pretty-formatted in
-	// the output during non-interactive execution.
-	prettyFmt bool
+	// tableDisplayFormat indicates how to format result tables.
+	tableDisplayFormat tableDisplayFormat
+}
+
+type tableDisplayFormat int
+
+const (
+	tableDisplayTSV tableDisplayFormat = iota
+	tableDisplayCSV
+	tableDisplayPretty
+	tableDisplayRecords
+	tableDisplaySQL
+	tableDisplayHTML
+)
+
+// Type implements the pflag.Value interface.
+func (f *tableDisplayFormat) Type() string { return "string" }
+
+// String imlements the pflag.Value itnerface.
+func (f *tableDisplayFormat) String() string {
+	switch *f {
+	case tableDisplayTSV:
+		return "tsv"
+	case tableDisplayCSV:
+		return "csv"
+	case tableDisplayPretty:
+		return "pretty"
+	case tableDisplayRecords:
+		return "records"
+	case tableDisplaySQL:
+		return "sql"
+	case tableDisplayHTML:
+		return "html"
+	}
+	return ""
+}
+
+// Set implements the pflag.Value interface.
+func (f *tableDisplayFormat) Set(s string) error {
+	switch s {
+	case "tsv":
+		*f = tableDisplayTSV
+	case "csv":
+		*f = tableDisplayCSV
+	case "pretty":
+		*f = tableDisplayPretty
+	case "records":
+		*f = tableDisplayRecords
+	case "sql":
+		*f = tableDisplaySQL
+	case "html":
+		*f = tableDisplayHTML
+	default:
+		return fmt.Errorf("invalid value for --format: %s", s)
+	}
+	return nil
 }
 
 type sqlContext struct {

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -61,7 +61,7 @@ var debugCtx = debugContext{
 
 // InitCLIDefaults is used for testing.
 func InitCLIDefaults() {
-	cliCtx.prettyFmt = false
+	cliCtx.tableDisplayFormat = tableDisplayTSV
 	dumpCtx.dumpMode = dumpBoth
 }
 
@@ -394,13 +394,17 @@ func init() {
 	tableOutputCommands := []*cobra.Command{sqlShellCmd}
 	tableOutputCommands = append(tableOutputCommands, userCmds...)
 	tableOutputCommands = append(tableOutputCommands, nodeCmds...)
+
+	// By default, these commands print their output as pretty-formatted
+	// tables on terminals, and TSV when redirected to a file. The user
+	// can override with --format.
+	cliCtx.tableDisplayFormat = tableDisplayTSV
+	if isInteractive {
+		cliCtx.tableDisplayFormat = tableDisplayPretty
+	}
 	for _, cmd := range tableOutputCommands {
 		f := cmd.Flags()
-
-		// By default, these commands print their output as pretty-formatted
-		// tables on terminals, and TSV when redirected to a file. The user
-		// can override with --pretty.
-		boolFlag(f, &cliCtx.prettyFmt, cliflags.Pretty, isInteractive)
+		varFlag(f, &cliCtx.tableDisplayFormat, cliflags.TableDisplayFormat)
 	}
 
 	// Max results flag for scan, reverse scan, and range list.

--- a/pkg/cli/format_table.go
+++ b/pkg/cli/format_table.go
@@ -1,0 +1,137 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package cli
+
+import (
+	"encoding/csv"
+	"fmt"
+	"html"
+	"io"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/olekukonko/tablewriter"
+)
+
+// printQueryOutput takes a list of column names and a list of row contents
+// writes a formatted table to 'w', or simply the tag if empty.
+func printQueryOutput(
+	w io.Writer, cols []string, allRows [][]string, tag string, displayFormat tableDisplayFormat,
+) {
+	if len(cols) == 0 {
+		// This operation did not return rows, just show the tag.
+		fmt.Fprintln(w, tag)
+		return
+	}
+
+	switch displayFormat {
+	case tableDisplayPretty:
+		// Initialize tablewriter and set column names as the header row.
+		table := tablewriter.NewWriter(w)
+		table.SetAutoFormatHeaders(false)
+		table.SetAutoWrapText(false)
+		table.SetHeader(cols)
+		for _, row := range allRows {
+			for i, r := range row {
+				row[i] = expandTabsAndNewLines(r)
+			}
+			table.Append(row)
+		}
+		table.Render()
+		nRows := len(allRows)
+		fmt.Fprintf(w, "(%d row%s)\n", nRows, util.Pluralize(int64(nRows)))
+
+	case tableDisplayTSV:
+		fallthrough
+	case tableDisplayCSV:
+		fmt.Fprintf(w, "%d row%s\n", len(allRows),
+			util.Pluralize(int64(len(allRows))))
+
+		csvWriter := csv.NewWriter(w)
+		if displayFormat == tableDisplayTSV {
+			csvWriter.Comma = '\t'
+		}
+		_ = csvWriter.Write(cols)
+		_ = csvWriter.WriteAll(allRows)
+
+	case tableDisplayHTML:
+		fmt.Fprint(w, "<table>\n<thead><tr>")
+		for _, col := range cols {
+			fmt.Fprintf(w, "<th>%s</th>", html.EscapeString(col))
+		}
+		fmt.Fprint(w, "</tr></head>\n<tbody>\n")
+		for _, row := range allRows {
+			fmt.Fprint(w, "<tr>")
+			for _, r := range row {
+				fmt.Fprintf(w, "<td>%s</td>", strings.Replace(html.EscapeString(r), "\n", "<br/>", -1))
+			}
+			fmt.Fprint(w, "</tr>\n")
+		}
+		fmt.Fprint(w, "</tbody>\n</table>\n")
+
+	case tableDisplayRecords:
+		maxColWidth := 0
+		for _, col := range cols {
+			colLen := utf8.RuneCountInString(col)
+			if colLen > maxColWidth {
+				maxColWidth = colLen
+			}
+		}
+
+		for i, row := range allRows {
+			fmt.Fprintf(w, "-[ RECORD %d ]\n", i+1)
+			for j, r := range row {
+				lines := strings.Split(r, "\n")
+				for l, line := range lines {
+					colLabel := cols[j]
+					if l > 0 {
+						colLabel = ""
+					}
+					// Note: special characters, including a vertical bar, in
+					// the colLabel are not escaped here. This is in accordance
+					// with the same behavior in PostgreSQL.
+					fmt.Fprintf(w, "%-*s | %s\n", maxColWidth, colLabel, line)
+				}
+			}
+		}
+
+	case tableDisplaySQL:
+		fmt.Fprint(w, "CREATE TABLE results (\n")
+		for i, col := range cols {
+			s := parser.Name(col)
+			fmt.Fprintf(w, "  %s STRING", s.String())
+			if i < len(cols)-1 {
+				fmt.Fprint(w, ",")
+			}
+			fmt.Fprint(w, "\n")
+		}
+		fmt.Fprint(w, ");\n\n")
+		for _, row := range allRows {
+			fmt.Fprint(w, "INSERT INTO results VALUES (")
+			for i, r := range row {
+				s := parser.DString(r)
+				fmt.Fprintf(w, "%s", s.String())
+				if i < len(row)-1 {
+					fmt.Fprint(w, ", ")
+				}
+			}
+			fmt.Fprint(w, ");\n")
+		}
+	}
+}

--- a/pkg/cli/interactive_tests/test_local_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_local_cmds.tcl
@@ -50,6 +50,18 @@ send "1;\r"
 eexpect "1 row"
 eexpect root@
 
+# Check that \set without argument prints the current options
+send "\\set\r\n"
+eexpect "4 rows"
+eexpect "display_format\ttsv"
+eexpect root@
+
+# Check that \set can change the display format
+send "\\set display_format csv\r\n\\set\r\n"
+eexpect "4 rows"
+eexpect "display_format,csv"
+eexpect root@
+
 # Check that a built-in command in the middle of a token (eg a string)
 # is processed locally.
 send "select 'hello\r"

--- a/pkg/cli/interactive_tests/test_local_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_local_cmds.tcl
@@ -21,7 +21,7 @@ eexpect "root@"
 # Check that \q terminates the client.
 send "\\q\r"
 eexpect eof
-spawn $argv sql --pretty=false
+spawn $argv sql --format=tsv
 eexpect root@
 
 # Check that \| reads statements.

--- a/pkg/cli/interactive_tests/test_pretty.tcl
+++ b/pkg/cli/interactive_tests/test_pretty.tcl
@@ -8,21 +8,21 @@ spawn /bin/bash
 send "PS1='\\h:''/# '\r"
 eexpect ":/# "
 
-# Check table ASCII art with and without --pretty. (#7268)
+# Check table ASCII art with and without --format=pretty. (#7268)
 
 # Check that tables are pretty-printed when input is not a terminal
-# but --pretty is specified.
-send "echo 'select 1;' | $argv sql --pretty\r"
+# but --format=pretty is specified.
+send "echo 'select 1;' | $argv sql --format=pretty\r"
 eexpect "+-*+\r\n*\r\n+-*+\r\n*1 row"
 eexpect ":/# "
 
 # Check that tables are not pretty-printed when input is not a terminal
-# and --pretty is not speciifed.
+# and --format=pretty is not speciifed.
 send "echo begin; echo 'select 1;' | $argv sql $silence_prop_eval_kv\r"
 eexpect "begin\r\n1 row\r\n1\r\n1\r\n"
 
 # Check that tables are pretty-printed when input is a terminal
-# and --pretty is not specified.
+# and --format=pretty is not specified.
 send "$argv sql\r"
 eexpect root@
 send "select 1;\r"
@@ -31,8 +31,8 @@ send "\\q\r"
 eexpect ":/# "
 
 # Check that tables are not pretty-printed when input is a terminal
-# and --pretty=false is specified.
-send "$argv sql --pretty=false\r"
+# and --format=tsv is specified.
+send "$argv sql --format=tsv\r"
 eexpect root@
 send "select 42; select 1;\r"
 eexpect "42\r\n1 row\r\n1\r\n1\r\n"

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -71,7 +71,7 @@ func runLsNodes(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	printQueryOutput(os.Stdout, lsNodesColumnHeaders, rows, "", cliCtx.prettyFmt)
+	printQueryOutput(os.Stdout, lsNodesColumnHeaders, rows, "", cliCtx.tableDisplayFormat)
 	return nil
 }
 
@@ -140,7 +140,8 @@ func runStatusNode(cmd *cobra.Command, args []string) error {
 		return errors.Errorf("expected no arguments or a single node ID")
 	}
 
-	printQueryOutput(os.Stdout, nodesColumnHeaders, nodeStatusesToRows(nodeStatuses), "", cliCtx.prettyFmt)
+	printQueryOutput(os.Stdout, nodesColumnHeaders, nodeStatusesToRows(nodeStatuses), "",
+		cliCtx.tableDisplayFormat)
 	return nil
 }
 

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -819,7 +819,8 @@ func (c *cliState) doCheckStatement(startState, contState, execState cliStateEnu
 }
 
 func (c *cliState) doRunStatement(nextState cliStateEnum) cliStateEnum {
-	c.exitErr = runQueryAndFormatResults(c.conn, os.Stdout, makeQuery(c.concatLines), cliCtx.prettyFmt)
+	c.exitErr = runQueryAndFormatResults(c.conn, os.Stdout, makeQuery(c.concatLines),
+		cliCtx.tableDisplayFormat)
 	if c.exitErr != nil {
 		fmt.Fprintln(osStderr, c.exitErr)
 		if c.errExit {
@@ -918,9 +919,10 @@ func runInteractive(conn *sqlConn, config *readline.Config) (exitErr error) {
 
 // runOneStatement executes one statement and terminates
 // on error.
-func runStatements(conn *sqlConn, stmts []string, pretty bool) error {
+func runStatements(conn *sqlConn, stmts []string, displayFormat tableDisplayFormat) error {
 	for _, stmt := range stmts {
-		if err := runQueryAndFormatResults(conn, os.Stdout, makeQuery(stmt), pretty); err != nil {
+		if err := runQueryAndFormatResults(conn, os.Stdout, makeQuery(stmt),
+			displayFormat); err != nil {
 			return err
 		}
 	}
@@ -946,7 +948,7 @@ func runTerm(cmd *cobra.Command, args []string) error {
 
 	if len(sqlCtx.execStmts) > 0 {
 		// Single-line sql; run as simple as possible, without noise on stdout.
-		return runStatements(conn, sqlCtx.execStmts, cliCtx.prettyFmt)
+		return runStatements(conn, sqlCtx.execStmts, cliCtx.tableDisplayFormat)
 	}
 	// Use the same as the default global readline config.
 	conf := readline.Config{

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -28,6 +28,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"golang.org/x/net/context"
@@ -224,37 +225,76 @@ func (c *cliState) invalidSyntax(
 	return nextState
 }
 
-func (c *cliState) invalidOption(nextState cliStateEnum, opt string) cliStateEnum {
-	fmt.Fprintf(osStderr, "option not recognized: %s\n", opt)
-	return nextState
-}
-
 func (c *cliState) invalidOptionChange(nextState cliStateEnum, opt string) cliStateEnum {
 	fmt.Fprintf(osStderr, "cannot change option during multi-line editing: %s\n", opt)
 	return nextState
 }
 
+var options = map[string]struct {
+	numExpectedArgs           int
+	validDuringMultilineEntry bool
+	set                       func(c *cliState, args []string) error
+	unset                     func(c *cliState) error
+}{
+	`display_format`: {
+		1,
+		true,
+		func(_ *cliState, args []string) error {
+			return cliCtx.tableDisplayFormat.Set(args[0])
+		},
+		func(_ *cliState) error {
+			displayFormat := tableDisplayTSV
+			if isInteractive {
+				displayFormat = tableDisplayPretty
+			}
+			cliCtx.tableDisplayFormat = displayFormat
+			return nil
+		},
+	},
+	`errexit`: {
+		0,
+		true,
+		func(c *cliState, _ []string) error { c.errExit = true; return nil },
+		func(c *cliState) error { c.errExit = false; return nil },
+	},
+	`check_syntax`: {
+		0,
+		false,
+		func(c *cliState, _ []string) error { c.checkSyntax = true; return nil },
+		func(c *cliState) error { c.checkSyntax = false; return nil },
+	},
+	`normalize_history`: {
+		0,
+		false,
+		func(c *cliState, _ []string) error { c.normalizeHistory = true; return nil },
+		func(c *cliState) error { c.normalizeHistory = false; return nil },
+	},
+}
+
 // handleSet supports the \set client-side command.
 func (c *cliState) handleSet(args []string, nextState, errState cliStateEnum) cliStateEnum {
-	if len(args) != 1 {
+	if len(args) == 0 {
+		printQueryOutput(os.Stdout,
+			[]string{"Option", "Value"},
+			[][]string{
+				{"display_format", cliCtx.tableDisplayFormat.String()},
+				{"errexit", strconv.FormatBool(c.errExit)},
+				{"check_syntax", strconv.FormatBool(c.checkSyntax)},
+				{"normalize_history", strconv.FormatBool(c.normalizeHistory)},
+			},
+			"set", cliCtx.tableDisplayFormat)
+		return nextState
+	}
+	opt, ok := options[args[0]]
+	if !ok || len(args)-1 != opt.numExpectedArgs {
 		return c.invalidSyntax(errState, `\set %s. Try \? for help.`, strings.Join(args, " "))
 	}
-	opt := strings.ToLower(args[0])
-	switch opt {
-	case `errexit`:
-		c.errExit = true
-	case `check_syntax`:
-		if len(c.partialLines) > 0 {
-			return c.invalidOptionChange(errState, opt)
-		}
-		c.checkSyntax = true
-	case `normalize_history`:
-		if len(c.partialLines) > 0 {
-			return c.invalidOptionChange(errState, opt)
-		}
-		c.normalizeHistory = true
-	default:
-		return c.invalidOption(errState, opt)
+	if len(c.partialLines) > 0 && !opt.validDuringMultilineEntry {
+		return c.invalidOptionChange(errState, args[0])
+	}
+	if err := opt.set(c, args[1:]); err != nil {
+		fmt.Fprintf(osStderr, "%v", err)
+		return c.invalidOptionChange(errState, args[0])
 	}
 	return nextState
 }
@@ -264,22 +304,16 @@ func (c *cliState) handleUnset(args []string, nextState, errState cliStateEnum) 
 	if len(args) != 1 {
 		return c.invalidSyntax(errState, `\unset %s. Try \? for help.`, strings.Join(args, " "))
 	}
-	opt := strings.ToLower(args[0])
-	switch opt {
-	case `errexit`:
-		c.errExit = false
-	case `check_syntax`:
-		if len(c.partialLines) > 0 {
-			return c.invalidOptionChange(errState, opt)
-		}
-		c.checkSyntax = false
-	case `normalize_history`:
-		if len(c.partialLines) > 0 {
-			return c.invalidOptionChange(errState, opt)
-		}
-		c.normalizeHistory = false
-	default:
-		return c.invalidOption(errState, opt)
+	opt, ok := options[args[0]]
+	if !ok {
+		return c.invalidSyntax(errState, `\unset %s. Try \? for help.`, strings.Join(args, " "))
+	}
+	if len(c.partialLines) > 0 && !opt.validDuringMultilineEntry {
+		return c.invalidOptionChange(errState, args[0])
+	}
+	if err := opt.unset(c); err != nil {
+		fmt.Fprintf(osStderr, "%v", err)
+		return c.invalidOptionChange(errState, args[0])
 	}
 	return nextState
 }

--- a/pkg/cli/sql_test.go
+++ b/pkg/cli/sql_test.go
@@ -113,7 +113,7 @@ SET
 	}
 
 	// Some other tests (TestDumpRow) mess with this, so make sure it's set.
-	cliCtx.prettyFmt = true
+	cliCtx.tableDisplayFormat = tableDisplayPretty
 
 	for _, test := range tests {
 		conf.Stdin = strings.NewReader(test.in)

--- a/pkg/cli/sql_util_test.go
+++ b/pkg/cli/sql_util_test.go
@@ -44,7 +44,8 @@ func TestRunQuery(t *testing.T) {
 	var b bytes.Buffer
 
 	// Non-query statement.
-	if err := runQueryAndFormatResults(conn, &b, makeQuery(`SET DATABASE=system`), true); err != nil {
+	if err := runQueryAndFormatResults(conn, &b, makeQuery(`SET DATABASE=system`),
+		tableDisplayPretty); err != nil {
 		t.Fatal(err)
 	}
 
@@ -77,7 +78,7 @@ SET
 	}
 
 	if err := runQueryAndFormatResults(conn, &b,
-		makeQuery(`SHOW COLUMNS FROM system.namespace`), true); err != nil {
+		makeQuery(`SHOW COLUMNS FROM system.namespace`), tableDisplayPretty); err != nil {
 		t.Fatal(err)
 	}
 
@@ -99,7 +100,8 @@ SET
 
 	// Test placeholders.
 	if err := runQueryAndFormatResults(conn, &b,
-		makeQuery(`SELECT * FROM system.namespace WHERE name=$1`, "descriptor"), true); err != nil {
+		makeQuery(`SELECT * FROM system.namespace WHERE name=$1`, "descriptor"),
+		tableDisplayPretty); err != nil {
 		t.Fatal(err)
 	}
 
@@ -118,7 +120,7 @@ SET
 
 	// Test multiple results.
 	if err := runQueryAndFormatResults(conn, &b,
-		makeQuery(`SELECT 1; SELECT 2, 3; SELECT 'hello'`), true); err != nil {
+		makeQuery(`SELECT 1; SELECT 2, 3; SELECT 'hello'`), tableDisplayPretty); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/cli/user.go
+++ b/pkg/cli/user.go
@@ -46,7 +46,7 @@ func runGetUser(cmd *cobra.Command, args []string) error {
 	}
 	defer conn.Close()
 	return runQueryAndFormatResults(conn, os.Stdout,
-		makeQuery(`SELECT * FROM system.users WHERE username=$1`, args[0]), cliCtx.prettyFmt)
+		makeQuery(`SELECT * FROM system.users WHERE username=$1`, args[0]), cliCtx.tableDisplayFormat)
 }
 
 // A lsUsersCmd command displays a list of users.
@@ -69,7 +69,7 @@ func runLsUsers(cmd *cobra.Command, args []string) error {
 	}
 	defer conn.Close()
 	return runQueryAndFormatResults(conn, os.Stdout,
-		makeQuery(`SELECT username FROM system.users`), cliCtx.prettyFmt)
+		makeQuery(`SELECT username FROM system.users`), cliCtx.tableDisplayFormat)
 }
 
 // A rmUserCmd command removes the user for the specified username.
@@ -92,7 +92,8 @@ func runRmUser(cmd *cobra.Command, args []string) error {
 	}
 	defer conn.Close()
 	return runQueryAndFormatResults(conn, os.Stdout,
-		makeQuery(`DELETE FROM system.users WHERE username=$1`, args[0]), cliCtx.prettyFmt)
+		makeQuery(`DELETE FROM system.users WHERE username=$1`, args[0]),
+		cliCtx.tableDisplayFormat)
 }
 
 // A setUserCmd command creates a new or updates an existing user.
@@ -131,7 +132,8 @@ func runSetUser(cmd *cobra.Command, args []string) error {
 	// TODO(asubiotto): Implement appropriate server-side authorization rules
 	// for users to be able to change their own passwords.
 	return runQueryAndFormatResults(conn, os.Stdout,
-		makeQuery(`UPSERT INTO system.users VALUES ($1, $2)`, args[0], hashed), cliCtx.prettyFmt)
+		makeQuery(`UPSERT INTO system.users VALUES ($1, $2)`, args[0], hashed),
+		cliCtx.tableDisplayFormat)
 }
 
 var userCmds = []*cobra.Command{

--- a/pkg/cli/zone.go
+++ b/pkg/cli/zone.go
@@ -379,7 +379,7 @@ func runRmZone(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := runQueryAndFormatResults(conn, os.Stdout,
-		makeQuery(`DELETE FROM system.zones WHERE id=$1`, id), cliCtx.prettyFmt); err != nil {
+		makeQuery(`DELETE FROM system.zones WHERE id=$1`, id), cliCtx.tableDisplayFormat); err != nil {
 		return err
 	}
 	return conn.Exec(`COMMIT`, nil)


### PR DESCRIPTION
This patch replaces the boolean flag `--pretty` by a new string-valued
flag `--format`.

Possible values: `tsv`, `pretty`, `csv`, `html`, `records` (PostgreSQL-style), `sql`.

As previously, `--format=tsv` is the default for non-interactive
sessions, and `--format=pretty` is the default for interactive
sessions.

Fixes #12985.

Examples:

```shell
./cockroach sql -e "SELECT 3 AS a, 4 AS b" --format=tsv
```
```
1 row
a	b
3       4
```

```shell
./cockroach sql -e "SELECT 3 AS a, 4 AS b" --format=pretty
```
```
+---+---+
| a | b |
+---+---+
| 3 | 4 |
+---+---+
(1 row)
```

```shell
./cockroach sql -e "SELECT 3 AS a, 4 AS b" --format=csv
```
```csv
1 row
a,b
3,4
```

```shell
./cockroach sql -e "SELECT 3 AS a, 4 AS b" --format=html
```
```html
<table>
<thead><tr><th>a</th><th>b</th></tr></head>
<tbody>
<tr><td>3</td><td>4</td></tr>
</tbody>
</table>
```

```shell
./cockroach sql -e "SELECT 3 AS a, 4 AS b" --format=records
```
```
-[ RECORD 1 ]
a | 3
b | 4
```

```shell
./cockroach sql -e "SELECT 3 AS a, 4 AS b" --format=sql
```
```sql
CREATE TABLE results (
  a STRING,
  b STRING
);

INSERT INTO results VALUES ('3', '4');
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13171)
<!-- Reviewable:end -->
