### PR TITLE
build: restore returncheck linter

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -2,6 +2,7 @@ cmd ./pkg/cmd/github-post
 cmd ./pkg/cmd/github-pull-request-make
 cmd ./pkg/cmd/glock-diff-parser
 cmd ./pkg/cmd/metacheck
+cmd ./pkg/cmd/returncheck
 cmd ./pkg/cmd/teamcity-trigger
 cmd ./vendor/github.com/client9/misspell/cmd/misspell
 cmd ./vendor/github.com/cockroachdb/crlfmt
@@ -9,7 +10,6 @@ cmd ./vendor/github.com/cockroachdb/stress
 cmd ./vendor/github.com/golang/lint/golint
 cmd ./vendor/github.com/jteeuwen/go-bindata/go-bindata
 cmd ./vendor/github.com/kisielk/errcheck
-cmd ./vendor/github.com/kkaneda/returncheck
 cmd ./vendor/github.com/mdempsky/unconvert
 cmd ./vendor/github.com/mibk/dupl
 cmd ./vendor/github.com/robfig/glock

--- a/build/style_test.go
+++ b/build/style_test.go
@@ -568,7 +568,6 @@ func TestStyle(t *testing.T) {
 	})
 
 	t.Run("TestReturnCheck", func(t *testing.T) {
-		t.Skip("TODO(dt): need to update this upstream or pull it into repo")
 		t.Parallel()
 		cmd, stderr, filter, err := dirCmd(pkg.Dir, "returncheck", pkgScope)
 		if err != nil {

--- a/build/tool_imports.go
+++ b/build/tool_imports.go
@@ -36,7 +36,6 @@ import (
 	_ "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway"
 	_ "github.com/jteeuwen/go-bindata/go-bindata"
 	_ "github.com/kisielk/errcheck"
-	_ "github.com/kkaneda/returncheck"
 	_ "github.com/mattn/goveralls"
 	_ "github.com/mdempsky/unconvert"
 	_ "github.com/mibk/dupl"

--- a/glide.lock
+++ b/glide.lock
@@ -199,10 +199,8 @@ imports:
   - internal/errcheck
 - name: github.com/kisielk/gotool
   version: 0de1eaf82fa3f583ce21fde859f1e7e0c5e9b220
-- name: github.com/kkaneda/returncheck
-  version: bf081fa7155e3a27df1f056a49d50685edfa5b1b
-  subpackages:
-  - internal
+- name: github.com/cockroachdb/returncheck
+  version: f3a399c4b3744afe51001fb5f969bfcb78dc599a
 - name: github.com/kr/pretty
   version: cfb55aafdaf3ec08f0db22699ab822c50091b1c4
 - name: github.com/kr/text

--- a/pkg/cmd/returncheck/main.go
+++ b/pkg/cmd/returncheck/main.go
@@ -1,0 +1,30 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"os"
+
+	"github.com/cockroachdb/returncheck"
+	"github.com/kisielk/gotool"
+)
+
+func main() {
+	targetPkg := "github.com/cockroachdb/cockroach/pkg/roachpb"
+	targetTypeName := "Error"
+	if err := returncheck.Run(gotool.ImportPaths(os.Args[1:]), targetPkg, targetTypeName); err != nil {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
this switches us to a fork that doesn't 'internal' the impl and moves the main method into our cmd's, since it has a cockroach-specific path hardcoded.

this change just moves the paths around to get back to where we were before `pkg` rename broke the hardcoded path -- at some point it might be nice to go further and switch this be like our composable linters and fold it in to metacheck.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13176)
<!-- Reviewable:end -->
