### PR TITLE
sql: more pg_catalog compatibility features

### DIFF
--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -1620,6 +1620,31 @@ var Builtins = map[string][]Builtin{
 				"Currently, CockroachDB does not support adding comments to columns.",
 		},
 	},
+	"pg_catalog.obj_description": {
+		Builtin{
+			Types:      ArgTypes{{"object_oid", TypeInt}},
+			ReturnType: TypeString,
+			fn: func(_ *EvalContext, _ DTuple) (Datum, error) {
+				return DNull, nil
+			},
+			category: categoryCompatibility,
+			Info: "obj_description returns the comment for a database object. " +
+				"Currently, CockroachDB does not support database object comments.",
+		},
+	},
+	"pg_catalog.shobj_description": {
+		Builtin{
+			Types:      ArgTypes{{"object_oid", TypeInt}, {"catalog_name", TypeString}},
+			ReturnType: TypeString,
+			fn: func(_ *EvalContext, _ DTuple) (Datum, error) {
+				return DNull, nil
+			},
+			category: categoryCompatibility,
+			Info: "shobj_description returns the comment for a shared database " +
+				"object. Currently, CockroachDB does not support database object " +
+				"comments.",
+		},
+	},
 	"pg_catalog.array_in": {
 		Builtin{
 			Types:      ArgTypes{{"string", TypeString}, {"element_oid", TypeInt}, {"element_typmod", TypeInt}},

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -61,8 +61,11 @@ var pgCatalog = virtualSchema{
 		pgCatalogDependTable,
 		pgCatalogDescriptionTable,
 		pgCatalogEnumTable,
+		pgCatalogForeignServerTable,
+		pgCatalogForeignTableTable,
 		pgCatalogIndexTable,
 		pgCatalogIndexesTable,
+		pgCatalogInheritsTable,
 		pgCatalogNamespaceTable,
 		pgCatalogProcTable,
 		pgCatalogRangeTable,
@@ -743,6 +746,41 @@ CREATE TABLE pg_catalog.pg_enum (
 	},
 }
 
+// See: https://www.postgresql.org/docs/9.6/static/catalog-pg-foreign-server.html.
+var pgCatalogForeignServerTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE pg_catalog.pg_foreign_server (
+  oid OID,
+  srvname NAME,
+  srvowner OID,
+  srvfdw OID,
+  srvtype STRING,
+  srvversion STRING,
+  srvacl STRING,
+  srvoptions STRING
+);
+`,
+	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+		// Foreign servers are not supported.
+		return nil
+	},
+}
+
+// See: https://www.postgresql.org/docs/9.6/static/catalog-pg-foreign-table.html.
+var pgCatalogForeignTableTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE pg_catalog.pg_foreign_table (
+  ftrelid OID,
+  ftserver OID,
+  ftoptions STRING
+);
+`,
+	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+		// Foreign tables are not supported.
+		return nil
+	},
+}
+
 // See: https://www.postgresql.org/docs/9.6/static/catalog-pg-index.html.
 var pgCatalogIndexTable = virtualSchemaTable{
 	schema: `
@@ -915,6 +953,21 @@ func indexDefFromDescriptor(
 		indexDef.Interleave = intlDef
 	}
 	return indexDef.String(), nil
+}
+
+// See: https://www.postgresql.org/docs/9.6/static/catalog-pg-inherits.html.
+var pgCatalogInheritsTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE pg_catalog.pg_inherits (
+	inhrelid OID,
+	inhparent OID,
+	inhseqno INT
+);
+`,
+	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+		// Table inheritance is not supported.
+		return nil
+	},
 }
 
 // See: https://www.postgresql.org/docs/9.6/static/catalog-pg-namespace.html.

--- a/pkg/sql/testdata/information_schema
+++ b/pkg/sql/testdata/information_schema
@@ -225,8 +225,11 @@ pg_database
 pg_depend
 pg_description
 pg_enum
+pg_foreign_server
+pg_foreign_table
 pg_index
 pg_indexes
+pg_inherits
 pg_namespace
 pg_proc
 pg_range
@@ -267,8 +270,11 @@ pg_roles
 pg_range
 pg_proc
 pg_namespace
+pg_inherits
 pg_indexes
 pg_index
+pg_foreign_table
+pg_foreign_server
 pg_enum
 pg_description
 pg_depend
@@ -306,8 +312,11 @@ def            pg_catalog          pg_database        SYSTEM VIEW  1
 def            pg_catalog          pg_depend          SYSTEM VIEW  1
 def            pg_catalog          pg_description     SYSTEM VIEW  1
 def            pg_catalog          pg_enum            SYSTEM VIEW  1
+def            pg_catalog          pg_foreign_server  SYSTEM VIEW  1
+def            pg_catalog          pg_foreign_table   SYSTEM VIEW  1
 def            pg_catalog          pg_index           SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
+def            pg_catalog          pg_inherits        SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_proc            SYSTEM VIEW  1
 def            pg_catalog          pg_range           SYSTEM VIEW  1
@@ -360,8 +369,11 @@ def            pg_catalog          pg_database        SYSTEM VIEW  1
 def            pg_catalog          pg_depend          SYSTEM VIEW  1
 def            pg_catalog          pg_description     SYSTEM VIEW  1
 def            pg_catalog          pg_enum            SYSTEM VIEW  1
+def            pg_catalog          pg_foreign_server  SYSTEM VIEW  1
+def            pg_catalog          pg_foreign_table   SYSTEM VIEW  1
 def            pg_catalog          pg_index           SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
+def            pg_catalog          pg_inherits        SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_proc            SYSTEM VIEW  1
 def            pg_catalog          pg_range           SYSTEM VIEW  1
@@ -405,8 +417,11 @@ def            pg_catalog          pg_database        SYSTEM VIEW  1
 def            pg_catalog          pg_depend          SYSTEM VIEW  1
 def            pg_catalog          pg_description     SYSTEM VIEW  1
 def            pg_catalog          pg_enum            SYSTEM VIEW  1
+def            pg_catalog          pg_foreign_server  SYSTEM VIEW  1
+def            pg_catalog          pg_foreign_table   SYSTEM VIEW  1
 def            pg_catalog          pg_index           SYSTEM VIEW  1
 def            pg_catalog          pg_indexes         SYSTEM VIEW  1
+def            pg_catalog          pg_inherits        SYSTEM VIEW  1
 def            pg_catalog          pg_namespace       SYSTEM VIEW  1
 def            pg_catalog          pg_proc            SYSTEM VIEW  1
 def            pg_catalog          pg_range           SYSTEM VIEW  1

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -54,8 +54,11 @@ pg_database
 pg_depend
 pg_description
 pg_enum
+pg_foreign_server
+pg_foreign_table
 pg_index
 pg_indexes
+pg_inherits
 pg_namespace
 pg_proc
 pg_range


### PR DESCRIPTION
Adds tables `pg_inherits`, `pg_foreign_table`, and `pg_foreign_server`. We don't support any of these features so the tables are left empty.

Adds builtins `obj_description` and `shobj_description`. These builtins look up comments on database objects. We don't support comments on database objects, so they always return `NULL`.

Update #5583.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13181)
<!-- Reviewable:end -->
