### PR TITLE
sqlbase: pipe range information through RowFetcher

### DIFF
--- a/pkg/internal/client/batch.go
+++ b/pkg/internal/client/batch.go
@@ -262,6 +262,10 @@ func (b *Batch) fillResults() error {
 			if result.Err == nil && reply != nil && reply.Header().ResumeSpan != nil {
 				result.ResumeSpan = *reply.Header().ResumeSpan
 			}
+			// Fill up the RangeInfos, in case we got any.
+			if result.Err == nil && reply != nil {
+				result.RangeInfos = reply.Header().RangeInfos
+			}
 		}
 		offset += result.calls
 	}

--- a/pkg/internal/client/db.go
+++ b/pkg/internal/client/db.go
@@ -139,6 +139,12 @@ type Result struct {
 	// a new shorter span of keys. An empty span is returned when the
 	// operation has successfully completed running through the span.
 	ResumeSpan roachpb.Span
+
+	// RangeInfos contains information about the replicas that produced this
+	// result.
+	// This is only populated if Err == nil and if ReturnRangeInfo has been set on
+	// the request.
+	RangeInfos []roachpb.RangeInfo
 }
 
 func (r Result) String() string {

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -879,3 +879,16 @@ func (b *ExportStorage_S3) Keys() s3gof3r.Keys {
 		SecretKey: b.Secret,
 	}
 }
+
+// InsertRangeInfo inserts ri into a slice of RangeInfo's if a descriptor for
+// the same range is not already present. If it is present, it's overwritten;
+// the rationale being that ri is newer information than what we had before.
+func InsertRangeInfo(ris []RangeInfo, ri RangeInfo) []RangeInfo {
+	for i := range ris {
+		if ris[i].Desc.RangeID == ri.Desc.RangeID {
+			ris[i] = ri
+			return ris
+		}
+	}
+	return append(ris, ri)
+}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -462,8 +462,9 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 			_, valNeededForCol[i] = ru.fetchColIDtoRowIndex[tableDesc.Columns[i].ID]
 		}
 		if err := rf.Init(
-			tableDesc, colIDtoRowIndex, &tableDesc.PrimaryIndex, false, false,
-			tableDesc.Columns, valNeededForCol,
+			tableDesc, colIDtoRowIndex, &tableDesc.PrimaryIndex,
+			false /* reverse */, false, /* isSecondaryIndex */
+			tableDesc.Columns, valNeededForCol, false, /* returnRangeInfo */
 		); err != nil {
 			return err
 		}

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -112,7 +112,7 @@ func initRowFetcher(
 	}
 	if err := fetcher.Init(
 		desc, colIdxMap, index, reverseScan, isSecondaryIndex,
-		desc.Columns, valNeededForCol,
+		desc.Columns, valNeededForCol, true, /* returnRangeInfo */
 	); err != nil {
 		return nil, false, err
 	}

--- a/pkg/sql/fk.go
+++ b/pkg/sql/fk.go
@@ -270,7 +270,9 @@ func makeBaseFKHelper(
 		needed[ids[i]] = true
 	}
 	isSecondary := b.searchTable.PrimaryIndex.ID != searchIdx.ID
-	err = b.rf.Init(b.searchTable, ids, searchIdx, false, isSecondary, b.searchTable.Columns, needed)
+	err = b.rf.Init(b.searchTable, ids, searchIdx, false, /* reverse */
+		isSecondary, b.searchTable.Columns, needed,
+		false /* returnRangeInfo */)
 	if err != nil {
 		return b, err
 	}

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -131,7 +131,7 @@ func (n *scanNode) disableBatchLimit() {
 
 func (n *scanNode) Start() error {
 	return n.fetcher.Init(&n.desc, n.colIdxMap, n.index, n.reverse, n.isSecondaryIndex, n.cols,
-		n.valNeededForCol)
+		n.valNeededForCol, false /* returnRangeInfo */)
 }
 
 func (n *scanNode) Close() {}

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -266,8 +266,9 @@ func (tu *tableUpserter) init(txn *client.Txn) error {
 	}
 
 	return tu.fetcher.Init(
-		tu.tableDesc, tu.fetchColIDtoRowIndex, &tu.tableDesc.PrimaryIndex, false, false,
-		tu.fetchCols, valNeededForCol)
+		tu.tableDesc, tu.fetchColIDtoRowIndex, &tu.tableDesc.PrimaryIndex,
+		false /* reverse */, false, /* isSecondaryIndex */
+		tu.fetchCols, valNeededForCol, false /*returnRangeInfo*/)
 }
 
 func (tu *tableUpserter) row(ctx context.Context, row parser.DTuple) (parser.DTuple, error) {
@@ -618,7 +619,8 @@ func (td *tableDeleter) deleteAllRowsScan(
 	var rf sqlbase.RowFetcher
 	err := rf.Init(
 		td.rd.helper.tableDesc, td.rd.fetchColIDtoRowIndex, &td.rd.helper.tableDesc.PrimaryIndex,
-		false, false, td.rd.fetchCols, valNeededForCol)
+		false /*reverse*/, false, /*isSecondaryIndex*/
+		td.rd.fetchCols, valNeededForCol, false /* returnRangeInfo */)
 	if err != nil {
 		return resume, err
 	}
@@ -710,7 +712,8 @@ func (td *tableDeleter) deleteIndexScan(
 	var rf sqlbase.RowFetcher
 	err := rf.Init(
 		td.rd.helper.tableDesc, td.rd.fetchColIDtoRowIndex, &td.rd.helper.tableDesc.PrimaryIndex,
-		false, false, td.rd.fetchCols, valNeededForCol)
+		false /* reverse */, false, /*isSecondaryIndex */
+		td.rd.fetchCols, valNeededForCol, false /* returnRangeInfo */)
 	if err != nil {
 		return resume, err
 	}


### PR DESCRIPTION
This patch makes the kvFetcher ask for range information to be filled in
the responses to the kv batches it sends. This information is exposed by
the RowFetcher.
To be used by DistSQL to propagate range-cache invalidation messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13185)
<!-- Reviewable:end -->
