### PR TITLE
distsqlplan: fake span resolver

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -64,7 +64,7 @@ type distSQLPlanner struct {
 	nodeDesc     roachpb.NodeDescriptor
 	rpcContext   *rpc.Context
 	distSQLSrv   *distsqlrun.ServerImpl
-	spanResolver *distsqlplan.SpanResolver
+	spanResolver distsqlplan.SpanResolver
 }
 
 const resolverPolicy = distsqlplan.BinPackingLeaseHolderChoice
@@ -237,7 +237,7 @@ func (dsp *distSQLPlanner) CheckSupport(tree planNode) (shouldRunDist bool, notS
 // a single query.
 type planningCtx struct {
 	ctx      context.Context
-	spanIter *distsqlplan.SpanResolverIterator
+	spanIter distsqlplan.SpanResolverIterator
 	// nodeAddresses contains addresses for all NodeIDs that are referenced by any
 	// physicalPlan we generate with this context.
 	nodeAddresses map[roachpb.NodeID]string

--- a/pkg/sql/distsqlplan/fake_span_resolver.go
+++ b/pkg/sql/distsqlplan/fake_span_resolver.go
@@ -1,0 +1,182 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package distsqlplan
+
+import (
+	"math/rand"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
+
+const avgRangesPerNode = 5
+
+// fakeSpanResolver is a SpanResovler which splits spans and distributes them to
+// nodes randomly. Each Seek() call generates a random distribution with
+// expected avgRangesPerNode ranges for each node.
+type fakeSpanResolver struct {
+	nodes []*roachpb.NodeDescriptor
+	db    *client.DB
+}
+
+var _ SpanResolver = &fakeSpanResolver{}
+
+// NewFakeSpanResolver creates a fake span resolver.
+func NewFakeSpanResolver(nodes []*roachpb.NodeDescriptor, db *client.DB) SpanResolver {
+	return &fakeSpanResolver{
+		nodes: nodes,
+		db:    db,
+	}
+}
+
+// fakeSplit indicates that a range starting at key is owned by a certain node.
+type fakeSplit struct {
+	key      roachpb.Key
+	nodeDesc *roachpb.NodeDescriptor
+}
+
+type fakeSpanResolverIterator struct {
+	fsr *fakeSpanResolver
+	err error
+	// splits are ordered by the key; the first one is the beginning of the
+	// current range and the last one is the end of the queried span.
+	splits []fakeSplit
+}
+
+// NewSpanResolverIterator is part of the SpanResolver interface.
+func (fsr *fakeSpanResolver) NewSpanResolverIterator() SpanResolverIterator {
+	return &fakeSpanResolverIterator{
+		fsr: fsr,
+	}
+}
+
+// Seek is part of the SpanResolverIterator interface. Each Seek call generates
+// a random distribution of the given span.
+func (fit *fakeSpanResolverIterator) Seek(
+	ctx context.Context, span roachpb.Span, scanDir kv.ScanDirection,
+) {
+	if scanDir != kv.Ascending {
+		panic("descending not implemented")
+	}
+
+	// Scan the range and keep a list of all potential split keys.
+	kvs, err := fit.fsr.db.Scan(ctx, span.Key, span.EndKey, 0)
+	if err != nil {
+		fit.err = err
+		return
+	}
+
+	// Populate splitKeys with potential split keys; all keys are strictly
+	// between span.Key and span.EndKey.
+	var splitKeys []roachpb.Key
+	lastKey := span.Key
+	for _, kv := range kvs {
+		// Extract the key for the row.
+		splitKey, err := keys.EnsureSafeSplitKey(kv.Key)
+		if err != nil {
+			fit.err = err
+			return
+		}
+		if !splitKey.Equal(lastKey) {
+			splitKeys = append(splitKeys, splitKey)
+			lastKey = splitKey
+		}
+	}
+
+	// Generate fake splits. The number of splits is selected randomly between 0
+	// and a maximum value; we want to generate
+	//   x = #nodes * avgRangesPerNode
+	// splits on average, so the maximum number is 2x:
+	//   Expected[ rand(2x+1) ] = (0 + 1 + 2 + .. + 2x) / (2x + 1) = x.
+	maxSplits := 2 * len(fit.fsr.nodes) * avgRangesPerNode
+	if maxSplits > len(splitKeys) {
+		maxSplits = len(splitKeys)
+	}
+	numSplits := rand.Intn(maxSplits + 1)
+
+	// Use Robert Floyd's algorithm to generate numSplits distinct integers
+	// between 0 and len(splitKeys), just because it's so cool!
+	chosen := make(map[int]struct{})
+	for j := len(splitKeys) - numSplits; j < len(splitKeys); j++ {
+		t := rand.Intn(j + 1)
+		if _, alreadyChosen := chosen[t]; !alreadyChosen {
+			// Insert T.
+			chosen[t] = struct{}{}
+		} else {
+			// Insert J.
+			chosen[j] = struct{}{}
+		}
+	}
+
+	fit.splits = make([]fakeSplit, 0, numSplits+2)
+	fit.splits = append(fit.splits, fakeSplit{key: span.Key})
+	for i := range splitKeys {
+		if _, ok := chosen[i]; ok {
+			fit.splits = append(fit.splits, fakeSplit{key: splitKeys[i]})
+		}
+	}
+	fit.splits = append(fit.splits, fakeSplit{key: span.EndKey})
+
+	// Assign nodes randomly.
+	for i := range fit.splits {
+		fit.splits[i].nodeDesc = fit.fsr.nodes[rand.Intn(len(fit.fsr.nodes))]
+	}
+}
+
+// Valid is part of the SpanResolverIterator interface.
+func (fit *fakeSpanResolverIterator) Valid() bool {
+	return fit.err == nil
+}
+
+// Error is part of the SpanResolverIterator interface.
+func (fit *fakeSpanResolverIterator) Error() error {
+	return fit.err
+}
+
+// NeedAnother is part of the SpanResolverIterator interface.
+func (fit *fakeSpanResolverIterator) NeedAnother() bool {
+	return len(fit.splits) > 2
+}
+
+// Next is part of the SpanResolverIterator interface.
+func (fit *fakeSpanResolverIterator) Next(_ context.Context) {
+	if len(fit.splits) <= 2 {
+		panic("Next called with no more ranges")
+	}
+	fit.splits = fit.splits[1:]
+}
+
+// Desc is part of the SpanResolverIterator interface.
+func (fit *fakeSpanResolverIterator) Desc() roachpb.RangeDescriptor {
+	return roachpb.RangeDescriptor{
+		StartKey: roachpb.RKey(fit.splits[0].key),
+		EndKey:   roachpb.RKey(fit.splits[1].key),
+	}
+}
+
+// ReplicaInfo is part of the SpanResolverIterator interface.
+func (fit *fakeSpanResolverIterator) ReplicaInfo(_ context.Context) (kv.ReplicaInfo, error) {
+	n := fit.splits[0].nodeDesc
+	return kv.ReplicaInfo{
+		ReplicaDescriptor: roachpb.ReplicaDescriptor{NodeID: n.NodeID},
+		NodeDesc:          n,
+	}, nil
+}

--- a/pkg/sql/distsqlplan/fake_span_resolver_test.go
+++ b/pkg/sql/distsqlplan/fake_span_resolver_test.go
@@ -1,0 +1,109 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package distsqlplan_test
+
+import (
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestFakeSpanResolver(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tc := serverutils.StartTestCluster(t, 3, base.TestClusterArgs{})
+	defer tc.Stopper().Stop()
+
+	sqlutils.CreateTable(
+		t, tc.ServerConn(0), "t",
+		"k INT PRIMARY KEY, v INT",
+		100,
+		func(row int) []parser.Datum {
+			return []parser.Datum{
+				parser.NewDInt(parser.DInt(row)),
+				parser.NewDInt(parser.DInt(row * row)),
+			}
+		},
+	)
+
+	resolver := distsqlutils.FakeResolverForTestCluster(tc)
+	it := resolver.NewSpanResolverIterator()
+
+	db := tc.Server(0).KVClient().(*client.DB)
+	desc := sqlbase.GetTableDescriptor(db, "test", "t")
+
+	prefix := roachpb.Key(sqlbase.MakeIndexKeyPrefix(desc, desc.PrimaryIndex.ID))
+	span := roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()}
+
+	// Make sure we see all the nodes. It will not always happen (due to
+	// randomness) but it should happen most of the time.
+	for attempt := 0; attempt < 10; attempt++ {
+		nodesSeen := make(map[roachpb.NodeID]struct{})
+		it.Seek(context.TODO(), span, kv.Ascending)
+		lastKey := span.Key
+		for {
+			if !it.Valid() {
+				t.Fatal(it.Error())
+			}
+			desc := it.Desc()
+			rinfo, err := it.ReplicaInfo(context.TODO())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			prettyStart := keys.PrettyPrint(desc.StartKey.AsRawKey())
+			prettyEnd := keys.PrettyPrint(desc.EndKey.AsRawKey())
+			t.Logf("%d %s %s", rinfo.NodeID, prettyStart, prettyEnd)
+
+			if !lastKey.Equal(desc.StartKey.AsRawKey()) {
+				t.Errorf("unexpected start key %s, should be %s", prettyStart, keys.PrettyPrint(prefix))
+			}
+			if !desc.StartKey.Less(desc.EndKey) {
+				t.Errorf("invalid range %s to %s", prettyStart, prettyEnd)
+			}
+			lastKey = desc.EndKey.AsRawKey()
+			nodesSeen[rinfo.NodeID] = struct{}{}
+
+			if !it.NeedAnother() {
+				break
+			}
+			it.Next(context.TODO())
+		}
+
+		if !lastKey.Equal(span.EndKey) {
+			t.Errorf("last key %s, should be %s", keys.PrettyPrint(lastKey), keys.PrettyPrint(span.EndKey))
+		}
+
+		if len(nodesSeen) == tc.NumServers() {
+			// Saw all the nodes.
+			break
+		}
+		t.Logf("not all nodes seen; retrying")
+	}
+}

--- a/pkg/sql/distsqlplan/span_resolver_test.go
+++ b/pkg/sql/distsqlplan/span_resolver_test.go
@@ -388,7 +388,7 @@ type rngInfo struct {
 }
 
 func resolveSpans(
-	ctx context.Context, it *distsqlplan.SpanResolverIterator, spans ...spanWithDir,
+	ctx context.Context, it distsqlplan.SpanResolverIterator, spans ...spanWithDir,
 ) ([][]rngInfo, error) {
 	res := make([][]rngInfo, 0)
 	for _, span := range spans {

--- a/pkg/testutils/distsqlutils/fake_resolver.go
+++ b/pkg/testutils/distsqlutils/fake_resolver.go
@@ -1,0 +1,41 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu.berinde@gmail.com)
+
+package distsqlutils
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlplan"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+// FakeResolverForTestCluster creates a fake span resolver for the nodes in a
+// test cluster.
+func FakeResolverForTestCluster(tc serverutils.TestClusterInterface) distsqlplan.SpanResolver {
+	nodeDescs := make([]*roachpb.NodeDescriptor, tc.NumServers())
+	for i := range nodeDescs {
+		s := tc.Server(i)
+		nodeDescs[i] = &roachpb.NodeDescriptor{
+			NodeID:  s.NodeID(),
+			Address: util.UnresolvedAddr{AddressField: s.ServingAddr()},
+		}
+	}
+
+	db := tc.Server(0).KVClient().(*client.DB)
+	return distsqlplan.NewFakeSpanResolver(nodeDescs, db)
+}

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -52,6 +52,9 @@ type TestServerInterface interface {
 
 	Start(params base.TestServerArgs) error
 
+	// NodeID returns the ID of this node within its cluster.
+	NodeID() roachpb.NodeID
+
 	// ServingAddr returns the server's address.
 	ServingAddr() string
 


### PR DESCRIPTION
Implementation and test of the fake span resolver, which does a key scan in the
queried span and splits it arbitrarily between all the nodes. On average, each
nodes should get around 5 ranges (if there are enough keys).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13186)
<!-- Reviewable:end -->
