### PR TITLE
sql: make column family allocation more aggressive

### DIFF
--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -59,7 +59,11 @@ func TestDumpRow(t *testing.T) {
 		tz timestamptz,
 		e1 decimal(2),
 		e2 decimal(2, 1),
-		s1 string(1)
+		s1 string(1),
+		FAMILY "primary" (i, f, d, t, n, o, tz, e1, e2, s1, rowid),
+		FAMILY fam_1_s (s),
+		FAMILY fam_2_b (b),
+		FAMILY fam_3_e (e)
 	);
 	INSERT INTO d.t VALUES (
 		1,

--- a/pkg/sql/bench_test.go
+++ b/pkg/sql/bench_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"strconv"
 	"sync/atomic"
 	"testing"
 
@@ -30,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	_ "github.com/lib/pq"
 )
@@ -1259,14 +1261,23 @@ func BenchmarkInsertDistinct100Multinode_Cockroach(b *testing.B) {
 }
 
 // runBenchmarkWideTable measures performance on a table with a large number of
-// columns (20).
-func runBenchmarkWideTable(b *testing.B, db *gosql.DB, count int) {
+// columns (20), half of which are fixed size, half of which are variable sized
+// and presumed small. 1 of the presumed small columns is actually large.
+//
+// This benchmark tracks the tradeoff in column family allocation at table
+// creation. Fewer column families mean fewer kv entries, which is faster. But
+// fewer column families mean updates are less targeted, which means large
+// columns in a family may be copied unnecessarily when it's updated. Perfect
+// knowledge of traffic patterns can result in much better heuristics, but we
+// don't have that information at table creation.
+func runBenchmarkWideTable(b *testing.B, db *gosql.DB, count int, bigColumnBytes int) {
 	if _, err := db.Exec(`DROP TABLE IF EXISTS bench.widetable`); err != nil {
 		b.Fatal(err)
 	}
 	const schema = `CREATE TABLE bench.widetable (
     f1 INT, f2 INT, f3 INT, f4 INT, f5 INT, f6 INT, f7 INT, f8 INT, f9 INT, f10 INT,
-    f11 INT, f12 INT, f13 INT, f14 INT, f15 INT, f16 INT, f17 INT, f18 INT, f19 INT, f20 INT,
+    f11 TEXT, f12 TEXT, f13 TEXT, f14 TEXT, f15 TEXT, f16 TEXT, f17 TEXT, f18 TEXT, f19 TEXT,
+	f20 TEXT,
     PRIMARY KEY (f1, f2, f3)
   )`
 	if _, err := db.Exec(schema); err != nil {
@@ -1290,14 +1301,29 @@ func runBenchmarkWideTable(b *testing.B, db *gosql.DB, count int) {
 		fmt.Fprintf(&buf, `INSERT INTO bench.widetable VALUES`)
 		for j := 0; j < count; j++ {
 			if j != 0 {
-				buf.WriteString(`,`)
+				if j%3 == 0 {
+					buf.WriteString(`;`)
+					if _, err := db.Exec(buf.String()); err != nil {
+						b.Fatal(err)
+					}
+					buf.Reset()
+					fmt.Fprintf(&buf, `INSERT INTO bench.widetable VALUES `)
+				} else {
+					buf.WriteString(`,`)
+				}
 			}
 			buf.WriteString(`(`)
 			for k := 0; k < 20; k++ {
 				if k != 0 {
 					buf.WriteString(`,`)
 				}
-				fmt.Fprintf(&buf, "%d", i*count+j)
+				if k < 10 {
+					fmt.Fprintf(&buf, "%d", i*count+j)
+				} else if k < 19 {
+					fmt.Fprintf(&buf, "'%d'", i*count+j)
+				} else {
+					fmt.Fprintf(&buf, "'%x'", randutil.RandBytes(s, bigColumnBytes))
+				}
 			}
 			buf.WriteString(`)`)
 		}
@@ -1336,34 +1362,24 @@ func runBenchmarkWideTable(b *testing.B, db *gosql.DB, count int) {
 	b.StopTimer()
 }
 
-func BenchmarkWideTable1_Cockroach(b *testing.B) {
-	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkWideTable(b, db, 1) })
+func BenchmarkWideTable_Cockroach(b *testing.B) {
+	const count = 10
+	for _, bigColumnBytes := range []int{10, 100, 1000, 10000, 100000, 1000000} {
+		b.Run(strconv.Itoa(bigColumnBytes), func(b *testing.B) {
+			benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) {
+				runBenchmarkWideTable(b, db, count, bigColumnBytes)
+			})
+		})
+	}
 }
 
-func BenchmarkWideTable10_Cockroach(b *testing.B) {
-	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkWideTable(b, db, 10) })
-}
-
-func BenchmarkWideTable100_Cockroach(b *testing.B) {
-	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkWideTable(b, db, 100) })
-}
-
-func BenchmarkWideTable1000_Cockroach(b *testing.B) {
-	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkWideTable(b, db, 1000) })
-}
-
-func BenchmarkWideTable1Multinode_Cockroach(b *testing.B) {
-	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkWideTable(b, db, 1) })
-}
-
-func BenchmarkWideTable10Multinode_Cockroach(b *testing.B) {
-	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkWideTable(b, db, 10) })
-}
-
-func BenchmarkWideTable100Multinode_Cockroach(b *testing.B) {
-	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkWideTable(b, db, 100) })
-}
-
-func BenchmarkWideTable1000Multinode_Cockroach(b *testing.B) {
-	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkWideTable(b, db, 1000) })
+func BenchmarkWideTableMultinode_Cockroach(b *testing.B) {
+	const count = 10
+	for _, bigColumnBytes := range []int{10, 100, 1000, 10000, 100000, 1000000} {
+		b.Run(strconv.Itoa(bigColumnBytes), func(b *testing.B) {
+			benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) {
+				runBenchmarkWideTable(b, db, count, bigColumnBytes)
+			})
+		})
+	}
 }

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -579,11 +579,11 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
 	tablePrefix := roachpb.Key(keys.MakeTablePrefix(uint32(tableDesc.ID)))
 	tableEnd := tablePrefix.PrefixEnd()
-	// number of keys == 3 * number of rows; 2 column families and 1 index entry
+	// number of keys == 2 * number of rows; 1 column family and 1 index entry
 	// for each row.
 	if kvs, err := kvDB.Scan(context.TODO(), tablePrefix, tableEnd, 0); err != nil {
 		t.Fatal(err)
-	} else if e := 3 * (maxValue + 1); len(kvs) != e {
+	} else if e := 2 * (maxValue + 1); len(kvs) != e {
 		t.Fatalf("expected %d key value pairs, but got %d", e, len(kvs))
 	}
 
@@ -597,7 +597,7 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 		kvDB,
 		"ALTER TABLE t.test ADD COLUMN x DECIMAL DEFAULT (DECIMAL '1.4')",
 		maxValue,
-		4,
+		2,
 		backfillNotification)
 
 	// Drop column.
@@ -608,7 +608,7 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 		kvDB,
 		"ALTER TABLE t.test DROP pi",
 		maxValue,
-		3,
+		2,
 		backfillNotification)
 
 	// Add index.
@@ -619,7 +619,7 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 		kvDB,
 		"CREATE UNIQUE INDEX foo ON t.test (v)",
 		maxValue,
-		4,
+		3,
 		backfillNotification)
 
 	// Drop index.
@@ -630,7 +630,7 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 		kvDB,
 		"DROP INDEX t.test@vidx",
 		maxValue,
-		3,
+		2,
 		backfillNotification)
 
 	// Verify that the index foo over v is consistent, and that column x has
@@ -793,7 +793,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 		// number of keys representing a table row.
 		expectedNumKeysPerRow int
 	}{
-		{"ALTER TABLE t.test ADD COLUMN x DECIMAL DEFAULT (DECIMAL '1.4')", 2},
+		{"ALTER TABLE t.test ADD COLUMN x DECIMAL DEFAULT (DECIMAL '1.4')", 1},
 		{"ALTER TABLE t.test DROP x", 1},
 		{"CREATE UNIQUE INDEX foo ON t.test (v)", 2},
 		{"DROP INDEX t.test@foo", 1},
@@ -1032,7 +1032,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 
 	attempts = 0
 	seenSpan = roachpb.Span{}
-	addColumnSchemaChange(t, sqlDB, kvDB, maxValue, 3)
+	addColumnSchemaChange(t, sqlDB, kvDB, maxValue, 2)
 
 	attempts = 0
 	seenSpan = roachpb.Span{}
@@ -1123,7 +1123,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 
 	attempts = 0
 	seenSpan = roachpb.Span{}
-	addColumnSchemaChange(t, sqlDB, kvDB, maxValue, 3)
+	addColumnSchemaChange(t, sqlDB, kvDB, maxValue, 2)
 	if reevaluated := atomic.SwapUint32(&numReevaluated, 0); reevaluated != 1 {
 		t.Fatalf("exected %d reevaluations, but seen %d", 1, reevaluated)
 	}

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -48,7 +48,9 @@ func TestShowCreateTable(t *testing.T) {
 	s STRING NULL,
 	v FLOAT NOT NULL,
 	t TIMESTAMP DEFAULT now(),
-	CHECK (i > 0)
+	CHECK (i > 0),
+	FAMILY "primary" (i, v, t, rowid),
+	FAMILY fam_1_s (s)
 )`,
 			expect: `CREATE TABLE %s (
 	i INT NULL,
@@ -65,7 +67,9 @@ func TestShowCreateTable(t *testing.T) {
 	i INT CHECK (i > 0),
 	s STRING NULL,
 	v FLOAT NOT NULL,
-	t TIMESTAMP DEFAULT now()
+	t TIMESTAMP DEFAULT now(),
+	FAMILY "primary" (i, v, t, rowid),
+	FAMILY fam_1_s (s)
 )`,
 			expect: `CREATE TABLE %s (
 	i INT NULL,
@@ -81,7 +85,9 @@ func TestShowCreateTable(t *testing.T) {
 			stmt: `CREATE TABLE %s (
 	i INT NULL,
 	s STRING NULL,
-	CONSTRAINT ck CHECK (i > 0)
+	CONSTRAINT ck CHECK (i > 0),
+	FAMILY "primary" (i, rowid),
+	FAMILY fam_1_s (s)
 )`,
 			expect: `CREATE TABLE %s (
 	i INT NULL,
@@ -103,7 +109,9 @@ func TestShowCreateTable(t *testing.T) {
 		},
 		{
 			stmt: `
-				CREATE TABLE %s (i INT, f FLOAT, s STRING, d DATE);
+				CREATE TABLE %s (i INT, f FLOAT, s STRING, d DATE,
+				  FAMILY "primary" (i, f, d, rowid),
+				  FAMILY fam_1_s (s));
 				CREATE INDEX idx_if on %[1]s (f, i) STORING (s, d);
 				CREATE UNIQUE INDEX on %[1]s (d);
 			`,

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1096,62 +1096,34 @@ func upperBoundColumnValueEncodedSize(col ColumnDescriptor) (int, bool) {
 // should be put in a new family.
 //
 // Current heuristics:
-// - If the column is unbounded size (bytes, string, decimal) put it in a new
-//   family.
-// - If the column is bounded size (int, float, duration, date, timestamp, bool,
-//   or user bounded string/decimal), find the first family where the storage
-//   size of the existing columns plus the new column is not greater than
-//   FamilyHeuristicTargetBytes. The maximum size of the value encoding is used
-//   as the size of columns.
-// - Otherwise, the column doesn't fit in any existing family, spill it over
-//   into a new family.
-//
-// TODO(dan): Calling this function repeatedly to add columns is N^2. It
-// shouldn't be a problem because the number of columns is small, but if it
-// becomes an issue, make the bookkeeping of the columnSizesByID incremental.
+// - Put all columns in family 0.
 func fitColumnToFamily(desc TableDescriptor, col ColumnDescriptor) (int, bool) {
-	size, isBounded := upperBoundColumnValueEncodedSize(col)
-	if size > FamilyHeuristicTargetBytes {
-		return 0, false
-	}
-
-	primaryIndexColIDs := make(map[ColumnID]struct{}, len(desc.PrimaryIndex.ColumnIDs))
-	for _, colID := range desc.PrimaryIndex.ColumnIDs {
-		primaryIndexColIDs[colID] = struct{}{}
-	}
-
-	columnSizesByID := make(map[ColumnID]int, len(desc.Columns))
-	for _, c := range desc.Columns {
-		if _, ok := primaryIndexColIDs[c.ID]; ok {
-			// Primary key columns are stored in the key, so they don't count
-			// against the heuristic limit.
-			columnSizesByID[c.ID] = 0
-			continue
-		}
-		var bounded bool
-		if columnSizesByID[c.ID], bounded = upperBoundColumnValueEncodedSize(c); !bounded {
-			// Not bounded in size, so exceed the heuristic max to avoid assigning to
-			// a family that this column is in.
-			columnSizesByID[c.ID] = FamilyHeuristicTargetBytes + 1
-		}
-	}
-
-	// TODO(dan): This naively places columns in the first family they'll fit in,
-	// which is likely to lead to fragmentation. Consider something smarter like
-	// picking the most full family that will fit the column.
-	for i, family := range desc.Families {
-		var familySize int
-		for _, colID := range family.ColumnIDs {
-			familySize += columnSizesByID[colID]
-			if familySize > FamilyHeuristicTargetBytes {
-				break
-			}
-		}
-		if familySize == 0 || (isBounded && familySize+size <= FamilyHeuristicTargetBytes) {
-			return i, true
-		}
-	}
-	return 0, false
+	// Fewer column families means fewer kv entries, which is generally faster.
+	// On the other hand, an update to any column in a family requires that they
+	// all are read and rewritten, so large (or numerous) columns that are not
+	// updated at the same time as other columns in the family make things
+	// slower.
+	//
+	// The initial heuristic used for family assignment tried to pack
+	// fixed-width columns into families up to a certain size and would put any
+	// variable-width column into its own family. This was conservative to
+	// guarantee that we avoid the worst-case behavior of a very large immutable
+	// blob in the same family as frequently updated columns.
+	//
+	// However, our initial customers have revealed that this is backward.
+	// Repeatedly, they have recreated existing schemas without any tuning and
+	// found lackluster performance. Each of these has turned out better as a
+	// single family (sometimes 100% faster or more), the most aggressive tuning
+	// possible.
+	//
+	// Further, as the WideTable benchmark shows, even the worst-case isn't that
+	// bad (33% slower with an immutable 1MB blob, which is the upper limit of
+	// what we'd recommend for column size regardless of families). This
+	// situation also appears less frequent than we feared.
+	//
+	// The result is that we put all columns in one family and require the user
+	// to manually specify family assignments when this is incorrect.
+	return 0, true
 }
 
 // AddColumn adds a column to the table.

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -932,7 +932,7 @@ func TestFitColumnToFamily(t *testing.T) {
 		idx              int // not applicable if colFits is false
 	}{
 		// Bounded size column.
-		{colFits: false, idx: -1, newCol: ColumnType{Kind: ColumnType_BOOL},
+		{colFits: true, idx: 0, newCol: ColumnType{Kind: ColumnType_BOOL},
 			existingFamilies: nil,
 		},
 		{colFits: true, idx: 0, newCol: ColumnType{Kind: ColumnType_BOOL},
@@ -941,10 +941,10 @@ func TestFitColumnToFamily(t *testing.T) {
 		{colFits: true, idx: 0, newCol: ColumnType{Kind: ColumnType_BOOL},
 			existingFamilies: [][]ColumnType{partiallyFullFamily},
 		},
-		{colFits: false, idx: -1, newCol: ColumnType{Kind: ColumnType_BOOL},
+		{colFits: true, idx: 0, newCol: ColumnType{Kind: ColumnType_BOOL},
 			existingFamilies: [][]ColumnType{fullFamily},
 		},
-		{colFits: true, idx: 1, newCol: ColumnType{Kind: ColumnType_BOOL},
+		{colFits: true, idx: 0, newCol: ColumnType{Kind: ColumnType_BOOL},
 			existingFamilies: [][]ColumnType{fullFamily, emptyFamily},
 		},
 
@@ -952,16 +952,8 @@ func TestFitColumnToFamily(t *testing.T) {
 		{colFits: true, idx: 0, newCol: ColumnType{Kind: ColumnType_DECIMAL},
 			existingFamilies: [][]ColumnType{emptyFamily},
 		},
-		{colFits: false, idx: -1, newCol: ColumnType{Kind: ColumnType_DECIMAL},
+		{colFits: true, idx: 0, newCol: ColumnType{Kind: ColumnType_DECIMAL},
 			existingFamilies: [][]ColumnType{partiallyFullFamily},
-		},
-
-		// Check FamilyHeuristicMaxBytes boundary.
-		{colFits: true, idx: 0, newCol: ColumnType{Kind: ColumnType_INT},
-			existingFamilies: [][]ColumnType{maxIntsInOneFamily[1:]},
-		},
-		{colFits: false, idx: -1, newCol: ColumnType{Kind: ColumnType_INT},
-			existingFamilies: [][]ColumnType{maxIntsInOneFamily},
 		},
 	}
 	for i, test := range tests {

--- a/pkg/sql/testdata/alias_types
+++ b/pkg/sql/testdata/alias_types
@@ -1,7 +1,9 @@
 statement ok
 CREATE TABLE aliases (
     a OID,
-    b NAME
+    b NAME,
+    FAMILY "primary" (a, rowid),
+    FAMILY fam_1_b (b)
 )
 
 query TT colnames

--- a/pkg/sql/testdata/family
+++ b/pkg/sql/testdata/family
@@ -115,10 +115,9 @@ abcd  CREATE TABLE abcd (
       i INT NULL,
       j INT NULL,
       CONSTRAINT "primary" PRIMARY KEY (a),
-      FAMILY f1 (a, b, e),
+      FAMILY f1 (a, b, e, f),
       FAMILY fam_1_c_d (c, d),
-      FAMILY fam_2_f (f),
-      FAMILY fam_3_g (g),
+      FAMILY fam_2_g (g),
       FAMILY f_h (h, i),
       FAMILY f_j (j)
       )
@@ -135,9 +134,8 @@ abcd  CREATE TABLE abcd (
       f DECIMAL NULL,
       g INT NULL,
       CONSTRAINT "primary" PRIMARY KEY (a),
-      FAMILY f1 (a, b),
-      FAMILY fam_2_f (f),
-      FAMILY fam_3_g (g)
+      FAMILY f1 (a, b, f),
+      FAMILY fam_2_g (g)
       )
 
 statement ok
@@ -151,8 +149,7 @@ f1  CREATE TABLE f1 (
       b STRING NULL,
       c STRING NULL,
       CONSTRAINT "primary" PRIMARY KEY (a),
-      FAMILY "primary" (a, b),
-      FAMILY fam_1_c (c)
+      FAMILY "primary" (a, b, c)
     )
 
 statement ok

--- a/pkg/sql/testdata/interleaved
+++ b/pkg/sql/testdata/interleaved
@@ -10,7 +10,8 @@ CREATE TABLE p1_0 (
   s2 STRING,
   d DECIMAL,
   PRIMARY KEY (i, s1),
-  FAMILY (i, s1, s2)
+  FAMILY (i, s1, s2),
+  FAMILY (d)
 ) INTERLEAVE IN PARENT p2 (i)
 
 statement ok

--- a/pkg/sql/testdata/table
+++ b/pkg/sql/testdata/table
@@ -147,7 +147,11 @@ CREATE TABLE test.users (
   email     VARCHAR(100) NULL,
   INDEX foo (name),
   CHECK (LENGTH(nickname) < LENGTH(name)),
-  UNIQUE INDEX bar (id, name)
+  UNIQUE INDEX bar (id, name),
+  FAMILY "primary" (id, name),
+  FAMILY fam_1_title (title),
+  FAMILY fam_2_nickname (nickname),
+  FAMILY fam_3_username_email (username, email)
 )
 
 query TTBTT colnames
@@ -228,7 +232,11 @@ CREATE TABLE test.named_constraints (
   INDEX foo (name),
   CONSTRAINT uq2 UNIQUE (username),
   CONSTRAINT ck2 CHECK (LENGTH(nickname) < LENGTH(name)),
-  UNIQUE INDEX bar (id, name)
+  UNIQUE INDEX bar (id, name),
+  FAMILY "primary" (id, name),
+  FAMILY fam_1_title (title),
+  FAMILY fam_2_nickname (nickname),
+  FAMILY fam_3_username_email (username, email)
 )
 
 query TT

--- a/pkg/sql/testdata/window
+++ b/pkg/sql/testdata/window
@@ -7,7 +7,10 @@ CREATE TABLE kv (
   f FLOAT,
   d DECIMAL,
   s STRING,
-  b BOOL
+  b BOOL,
+  FAMILY (k, v, w, f, b),
+  FAMILY (d),
+  FAMILY (s)
 )
 
 statement OK


### PR DESCRIPTION
We have seen a number of potential customers try loading data into a
table with many small TEXT columns. Our initial column family heuristics
are conservative in this case and it appears may be too conservative.
This commit introduces new heuristics that assume STRING, CHAR, VARCHAR,
TEXT are small and BLOB, BYTES, BYTEA are big.

New heuristics:
- If the column is bounded size (int, float, duration, date,
  timestamp, bool, or user bounded string/decimal), put it in family 0.
- If the column is unbounded size and string or decimal, put it in family 0.
- If the column is unbounded size and bytes, put it in a new family.

```
name                                    old time/op    new time/op    delta
WideTable_Cockroach/10-8                  5.67ms ± 2%    4.53ms ± 5%  -20.16%  (p=0.008 n=5+5)
WideTable_Cockroach/100-8                 6.08ms ± 5%    4.66ms ± 1%  -23.28%  (p=0.008 n=5+5)
WideTable_Cockroach/1000-8                7.45ms ± 1%    6.28ms ± 2%  -15.68%  (p=0.008 n=5+5)
WideTable_Cockroach/10000-8               20.5ms ± 5%    21.6ms ± 6%     ~     (p=0.095 n=5+5)
WideTable_Cockroach/100000-8               138ms ± 1%     150ms ± 4%   +8.84%  (p=0.008 n=5+5)
WideTable_Cockroach/1000000-8              1.34s ± 3%     1.59s ± 2%  +18.32%  (p=0.008 n=5+5)
WideTableMultinode_Cockroach/10-8         7.89ms ± 1%    6.74ms ±10%  -14.58%  (p=0.016 n=4+5)
WideTableMultinode_Cockroach/100-8        8.14ms ± 3%    6.72ms ± 4%  -17.44%  (p=0.008 n=5+5)
WideTableMultinode_Cockroach/1000-8       10.5ms ±12%     9.7ms ± 9%     ~     (p=0.310 n=5+5)
WideTableMultinode_Cockroach/10000-8      25.9ms ± 8%    29.1ms ± 4%  +12.61%  (p=0.008 n=5+5)
WideTableMultinode_Cockroach/100000-8      168ms ± 9%     213ms ± 6%  +27.12%  (p=0.008 n=5+5)
WideTableMultinode_Cockroach/1000000-8     1.66s ± 5%     2.24s ± 5%  +35.35%  (p=0.008 n=5+5)

name                                    old alloc/op   new alloc/op   delta
WideTable_Cockroach/10-8                  1.35MB ± 0%    0.73MB ± 0%  -45.46%  (p=0.008 n=5+5)
WideTable_Cockroach/100-8                 1.39MB ± 0%    0.82MB ± 0%  -41.21%  (p=0.008 n=5+5)
WideTable_Cockroach/1000-8                1.92MB ± 1%    1.60MB ± 1%  -16.38%  (p=0.008 n=5+5)
WideTable_Cockroach/10000-8               7.12MB ± 1%    9.29MB ± 1%  +30.47%  (p=0.008 n=5+5)
WideTable_Cockroach/100000-8              61.8MB ± 2%    86.2MB ± 2%  +39.60%  (p=0.008 n=5+5)
WideTable_Cockroach/1000000-8              695MB ± 1%     922MB ± 4%  +32.64%  (p=0.008 n=5+5)
WideTableMultinode_Cockroach/10-8         2.51MB ± 1%    1.27MB ± 1%  -49.44%  (p=0.008 n=5+5)
WideTableMultinode_Cockroach/100-8        2.59MB ± 1%    1.45MB ± 0%  -44.11%  (p=0.008 n=5+5)
WideTableMultinode_Cockroach/1000-8       3.63MB ± 1%    3.25MB ± 2%  -10.59%  (p=0.008 n=5+5)
WideTableMultinode_Cockroach/10000-8      13.6MB ± 3%    20.4MB ± 3%  +49.88%  (p=0.008 n=5+5)
WideTableMultinode_Cockroach/100000-8      120MB ± 3%     185MB ± 1%  +54.26%  (p=0.008 n=5+5)
WideTableMultinode_Cockroach/1000000-8    1.48GB ± 2%    2.70GB ± 7%  +82.65%  (p=0.008 n=5+5)

name                                    old allocs/op  new allocs/op  delta
WideTable_Cockroach/10-8                   9.35k ± 4%     7.48k ± 1%  -20.07%  (p=0.008 n=5+5)
WideTable_Cockroach/100-8                  9.23k ± 3%     7.53k ± 1%  -18.37%  (p=0.008 n=5+5)
WideTable_Cockroach/1000-8                 9.24k ± 6%     7.52k ± 0%  -18.63%  (p=0.008 n=5+5)
WideTable_Cockroach/10000-8                9.60k ± 2%     7.80k ± 1%  -18.75%  (p=0.008 n=5+5)
WideTable_Cockroach/100000-8               11.6k ± 3%      9.7k ± 1%  -15.99%  (p=0.008 n=5+5)
WideTable_Cockroach/1000000-8              30.4k ± 2%     28.5k ± 2%   -6.19%  (p=0.008 n=5+5)
WideTableMultinode_Cockroach/10-8          16.2k ±10%     11.5k ± 0%  -28.97%  (p=0.016 n=5+4)
WideTableMultinode_Cockroach/100-8         15.9k ± 8%     11.5k ± 0%  -27.36%  (p=0.008 n=5+5)
WideTableMultinode_Cockroach/1000-8        16.4k ± 7%     11.9k ± 1%  -27.13%  (p=0.008 n=5+5)
WideTableMultinode_Cockroach/10000-8       17.1k ± 9%     12.9k ± 2%  -24.42%  (p=0.008 n=5+5)
WideTableMultinode_Cockroach/100000-8      22.8k ± 6%     23.3k ± 2%     ~     (p=1.000 n=5+5)
WideTableMultinode_Cockroach/1000000-8     86.0k ± 5%    100.9k ± 8%  +17.36%  (p=0.008 n=5+5)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13198)
<!-- Reviewable:end -->
