### PR TITLE
scripts: Fix rsync command line in azworker.sh

### DIFF
--- a/scripts/azworker.sh
+++ b/scripts/azworker.sh
@@ -51,7 +51,7 @@ case ${1-} in
     # Retry while vm and sshd to start up.
     "$(dirname "${0}")/travis_retry.sh" ssh -o StrictHostKeyChecking=no "${FQDN}" true
 
-    rsync -az "$(dirname "${0}")/../build/bootstrap" "${FQDN}:bootstrap"
+    rsync -az "$(dirname "${0}")/../build/bootstrap/" "${FQDN}:bootstrap/"
     ssh -A "${FQDN}" "GOVERSION=${GOVERSION} ./bootstrap/bootstrap-debian.sh"
 
     # TODO(bdarnell): autoshutdown.cron.sh does not work on azure. It


### PR DESCRIPTION
Trailing slashes matter to rsync.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13206)
<!-- Reviewable:end -->
