### PR TITLE
cmd/metacheck: switch to upstream's new monorepo

### DIFF
--- a/build/style_test.go
+++ b/build/style_test.go
@@ -669,9 +669,6 @@ func TestStyle(t *testing.T) {
 				//
 				// TODO(bdarnell): remove when/if #8360 is fixed.
 				"github.com/cockroachdb/cockroach/pkg/storage/intent_resolver.go:SA4009",
-				// Loop intentionally exits unconditionally; it's cleaner than
-				// explicitly checking length and extracting the first element.
-				"github.com/cockroachdb/cockroach/pkg/sql/errors.go:SA4004",
 				// A value assigned to a variable is never read; this might be worth
 				// investigating, but it's cumbersome because the reported file
 				// differs from the source.

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 11665188dd657f4b479ce3c7698b6bb3e2636f0b25570883d67a85bc7520b8d1
-updated: 2017-01-09T11:24:29.408700952-05:00
+updated: 2017-01-27T16:45:08.62946917-05:00
 imports:
 - name: cloud.google.com/go
   version: c96c4486674a140772b9788370fa29898577bc0c
@@ -51,6 +51,8 @@ imports:
   version: f4be2332630e8f33c3262c0d5f0d13d733c8bedf
 - name: github.com/cockroachdb/pq
   version: 44a6473ebbc26e3af09fe57bbdf761475c2c9f7c
+- name: github.com/cockroachdb/returncheck
+  version: f3a399c4b3744afe51001fb5f969bfcb78dc599a
 - name: github.com/cockroachdb/stress
   version: ce09c414594390d1d6432280c7cac55e62c6b0af
 - name: github.com/codahale/hdrhistogram
@@ -199,8 +201,6 @@ imports:
   - internal/errcheck
 - name: github.com/kisielk/gotool
   version: 0de1eaf82fa3f583ce21fde859f1e7e0c5e9b220
-- name: github.com/cockroachdb/returncheck
-  version: f3a399c4b3744afe51001fb5f969bfcb78dc599a
 - name: github.com/kr/pretty
   version: cfb55aafdaf3ec08f0db22699ab822c50091b1c4
 - name: github.com/kr/text
@@ -406,21 +406,18 @@ imports:
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
   version: a5b47d31c556af34a302ce5d659e6fea44d90de0
-- name: honnef.co/go/lint
-  version: 3cb61f0284a50a4f716a0ecd7274e7bc02b40428
+- name: honnef.co/go/tools
+  version: 287365bf3e058d443f33ec1dfe3de9e0ddf29169
   subpackages:
-  - lintutil
-- name: honnef.co/go/simple
-  version: 785f2adbeecfb675c110966bb69792863aa0aa49
-- name: honnef.co/go/ssa
-  version: 1cf7f34afde4f3f9cb9f7b15f8f2727ebcaa179a
-- name: honnef.co/go/staticcheck
-  version: 34cb9e1c04508c1fc4d12a65943aa17531909373
-  subpackages:
-  - pure
-  - vrp
-- name: honnef.co/go/unused
-  version: 33bc4cfe5599e665ab0117ca65e59f254aa6810d
+  - gcsizes
+  - lint
+  - lint/lintutil
+  - simple
+  - ssa
+  - staticcheck
+  - staticcheck/pure
+  - staticcheck/vrp
+  - unused
 testImports:
 - name: github.com/ghemawat/stream
   version: 78e682abcae4f96ac7ddbe39912967a5f7cbbaa6

--- a/pkg/cmd/metacheck/main.go
+++ b/pkg/cmd/metacheck/main.go
@@ -20,11 +20,11 @@ import (
 	"log"
 	"os"
 
-	"honnef.co/go/lint"
-	"honnef.co/go/lint/lintutil"
-	"honnef.co/go/simple"
-	"honnef.co/go/staticcheck"
-	"honnef.co/go/unused"
+	"honnef.co/go/tools/lint"
+	"honnef.co/go/tools/lint/lintutil"
+	"honnef.co/go/tools/simple"
+	"honnef.co/go/tools/staticcheck"
+	"honnef.co/go/tools/unused"
 )
 
 type metaChecker struct {

--- a/pkg/internal/client/lease_test.go
+++ b/pkg/internal/client/lease_test.go
@@ -76,15 +76,14 @@ func TestReacquireLease(t *testing.T) {
 	clock := hlc.NewClock(manual.UnixNano, time.Nanosecond)
 	lm := client.NewLeaseManager(db, clock, client.LeaseManagerOptions{ClientID: clientID1})
 
-	l, err := lm.AcquireLease(ctx, leaseKey)
-	if err != nil {
+	if _, err := lm.AcquireLease(ctx, leaseKey); err != nil {
 		t.Fatal(err)
 	}
 
 	// We allow re-acquiring the same lease as long as the client ID is
 	// the same to allow a client to reacquire its own leases rather than
 	// having to wait them out if it crashes and restarts.
-	l, err = lm.AcquireLease(ctx, leaseKey)
+	l, err := lm.AcquireLease(ctx, leaseKey)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -249,12 +249,10 @@ func doExpandPlan(params expandParameters, plan planNode) (planNode, error) {
 		plan, err = expandRenderNode(params, n)
 
 	case *delayedNode:
-		v, err := n.constructor(params.p)
-		if err != nil {
-			return plan, err
+		n.plan, err = n.constructor(params.p)
+		if err == nil {
+			n.plan, err = doExpandPlan(params, n.plan)
 		}
-		n.plan = v
-		n.plan, err = doExpandPlan(params, n.plan)
 
 	case *valuesNode:
 	case *alterTableNode:

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -337,6 +337,9 @@ func (s *renderNode) initTargets(targets parser.SelectExprs, desiredTypes []pars
 		// function's column in the join.
 		if e := extractSetReturningFunction(exprs); e != nil {
 			cols, exprs, hasStar, err = s.transformToCrossJoin(e, desiredType)
+			if err != nil {
+				return err
+			}
 		}
 
 		s.isStar = s.isStar || hasStar


### PR DESCRIPTION
First commit deals with (another) vendor-skew; @petermattis' recent RocksDB bump got pushed to master before @dt's earlier returncheck change.

Second commit is the important one, and carefully avoids bumping anything other than the linters.

@knz for the sql mistakes caught by this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13207)
<!-- Reviewable:end -->
