### PR TITLE
storage: avoid having newly split replicas campaigning to init raft

### DIFF
--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -1205,3 +1205,159 @@ func TestRangeInfo(t *testing.T) {
 		t.Errorf("on scan reply, expected %+v; got %+v", expRangeInfos, reply.Header().RangeInfos)
 	}
 }
+
+// TestCampaignOnLazyRaftGroupInitialization verifies expected
+// behavior for which replicas will campaign on lazy initialization.
+func TestCampaignOnLazyRaftGroupInitialization(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	t.Skip("this test is flaky on the 5m initial stress due to errant Raft messages initializing the Raft group")
+	splitKey := keys.MakeRowSentinelKey(keys.UserTableDataMin)
+	testState := struct {
+		syncutil.Mutex
+		blockingCh chan struct{}
+		campaigns  map[roachpb.ReplicaID]bool // map from ReplicaID -> whether the replica campaigned
+	}{}
+	sc := storage.TestStoreConfig(nil)
+	sc.EnableEpochRangeLeases = false // simpler to test with
+	sc.TestingKnobs.DontPreventUseOfOldLeaseOnStart = true
+	sc.TestingKnobs.OnCampaign = func(r *storage.Replica) {
+		if !r.DescLocked().StartKey.Equal(keys.UserTableDataMin) {
+			return
+		}
+		testState.Lock()
+		if testState.campaigns == nil {
+			testState.Unlock()
+			return
+		}
+		testState.campaigns[r.ReplicaIDLocked()] = true
+		blocking := testState.blockingCh
+		testState.Unlock()
+		<-blocking
+	}
+	mtc := &multiTestContext{storeConfig: &sc}
+	defer mtc.Stop()
+	mtc.Start(t, 3)
+
+	// Split so we can rely on RHS range being quiescent after a restart.
+	// We use UserTableDataMin to avoid having the range activated to
+	// gossip system table data.
+	splitArgs := adminSplitArgs(roachpb.KeyMin, splitKey)
+	if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), splitArgs); err != nil {
+		t.Fatal(err)
+	}
+
+	// Up-replicate to three replicas.
+	repl := mtc.stores[0].LookupReplica(roachpb.RKey(splitKey), nil)
+	if repl == nil {
+		t.Fatal("replica should not be nil for RHS range")
+	}
+	mtc.replicateRange(repl.RangeID, 1, 2)
+
+	testCases := []struct {
+		desc         string
+		prepFn       func(*testing.T)
+		expCampaigns map[roachpb.ReplicaID]bool
+	}{
+		{
+			desc:         "within idle replica campaign timeout",
+			prepFn:       func(t *testing.T) {},
+			expCampaigns: map[roachpb.ReplicaID]bool{},
+		},
+		{
+			desc: "past idle replica campaign timeout",
+			prepFn: func(t *testing.T) {
+				for _, s := range mtc.stores {
+					if err := s.GossipStore(context.TODO()); err != nil {
+						t.Fatal(err)
+					}
+				}
+				mtc.manualClock.Increment(
+					storage.RaftElectionTimeout(sc.RaftTickInterval, sc.RaftElectionTimeoutTicks).Nanoseconds())
+			},
+			expCampaigns: map[roachpb.ReplicaID]bool{
+				1: true,
+			},
+		},
+		{
+			desc: "lease expired all replicas should campaign",
+			prepFn: func(t *testing.T) {
+				for _, s := range mtc.stores {
+					if err := s.GossipStore(context.TODO()); err != nil {
+						t.Fatal(err)
+					}
+				}
+				mtc.manualClock.Increment(mtc.stores[0].LeaseExpiration(mtc.clock))
+			},
+			expCampaigns: map[roachpb.ReplicaID]bool{
+				1: true,
+				2: true,
+				3: true,
+			},
+		},
+	}
+
+	for i, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			// Restart the cluster for lazy initialization of the raft group.
+			mtc.restart()
+			// Clear the campaign map.
+			testState.Lock()
+			testState.blockingCh = make(chan struct{})
+			testState.campaigns = map[roachpb.ReplicaID]bool{}
+			testState.Unlock()
+			// Run whatever preparation is necessary for this test case.
+			test.prepFn(t)
+
+			// Send an increment to all three replicas in parallel.
+			errCh := make(chan error, len(mtc.stores))
+			for _, s := range mtc.stores {
+				go func(s *storage.Store) {
+					incArgs := incrementArgs(splitKey, 1)
+					_, pErr := client.SendWrappedWith(
+						context.Background(), s, roachpb.Header{RangeID: repl.RangeID}, incArgs,
+					)
+					errCh <- pErr.GoError()
+				}(s)
+			}
+
+			// Allow parallel invocations to proceed.
+			testutils.SucceedsSoon(t, func() error {
+				testState.Lock()
+				defer testState.Unlock()
+				if c, ec := len(testState.campaigns), len(test.expCampaigns); c != ec {
+					return errors.Errorf("have seen %d campaigns out of %d expected", c, ec)
+				}
+				return nil
+			})
+			close(testState.blockingCh)
+
+			// We expect not lease holder errors on 2 out of the three replicas.
+			var errCount int
+			for i := 0; i < len(mtc.stores); i++ {
+				if err := <-errCh; err != nil {
+					errCount++
+					if _, ok := err.(*roachpb.NotLeaseHolderError); !ok {
+						t.Errorf("got unexpected error %s", err)
+					}
+				}
+			}
+			if errCount != 2 {
+				t.Errorf("expected 2 errors; got %d", errCount)
+			}
+
+			mtc.waitForValues(splitKey, []int64{int64(i + 1), int64(i + 1), int64(i + 1)})
+
+			testState.Lock()
+			if !reflect.DeepEqual(test.expCampaigns, testState.campaigns) {
+				t.Errorf("expected %+v; got %+v", test.expCampaigns, testState.campaigns)
+			}
+			testState.Unlock()
+
+			// HACK: sleep to process raft leader wakeup proposals. It is
+			// otherwise too difficult to guarantee that the next test cycle
+			// will not have a stray raft request init the raft group after
+			// restart.
+			time.Sleep(100 * time.Millisecond)
+		})
+	}
+}

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -199,6 +199,14 @@ func (s *Store) ReservationCount() int {
 	return len(s.snapshotApplySem)
 }
 
+func (r *Replica) ReplicaIDLocked() roachpb.ReplicaID {
+	return r.mu.replicaID
+}
+
+func (r *Replica) DescLocked() *roachpb.RangeDescriptor {
+	return r.mu.state.Desc
+}
+
 func (r *Replica) RaftLock() {
 	r.raftMu.Lock()
 }

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -440,13 +440,13 @@ var _ KeyRange = &Replica{}
 // initialized) Raft group. The supplied function should return true for the
 // unquiesceAndWakeLeader argument if the replica should be unquiesced (and the
 // leader awoken). See handleRaftReady for an instance of where this value
-// varies. The shouldCampaign argument indicates whether a new raft group
+// varies. The shouldCampaignOnCreation argument indicates whether a new raft group
 // should be campaigned upon creation and is used to eagerly campaign idle
 // replicas.
 //
 // Requires that both Replica.mu and Replica.raftMu are held.
 func (r *Replica) withRaftGroupLocked(
-	shouldCampaign bool, f func(r *raft.RawNode) (unquiesceAndWakeLeader bool, _ error),
+	shouldCampaignOnCreation bool, f func(r *raft.RawNode) (unquiesceAndWakeLeader bool, _ error),
 ) error {
 	if r.mu.destroyed != nil {
 		// Silently ignore all operations on destroyed replicas. We can't return an
@@ -460,11 +460,11 @@ func (r *Replica) withRaftGroupLocked(
 		return nil
 	}
 
-	if shouldCampaign {
+	if shouldCampaignOnCreation {
 		// Special handling of idle replicas: we campaign their Raft group upon
 		// creation if we gossiped our store descriptor more than the election
 		// timeout in the past.
-		shouldCampaign = (r.mu.internalRaftGroup == nil) && r.store.canCampaignIdleReplica()
+		shouldCampaignOnCreation = (r.mu.internalRaftGroup == nil) && r.store.canCampaignIdleReplica()
 	}
 
 	ctx := r.AnnotateCtx(context.TODO())
@@ -482,7 +482,7 @@ func (r *Replica) withRaftGroupLocked(
 		}
 		r.mu.internalRaftGroup = raftGroup
 
-		if !shouldCampaign {
+		if !shouldCampaignOnCreation {
 			// Automatically campaign and elect a leader for this group if there's
 			// exactly one known node for this group.
 			//
@@ -510,12 +510,15 @@ func (r *Replica) withRaftGroupLocked(
 			// performed. Perhaps we should move the logic for campaigning single
 			// replica ranges there so that normally we only eagerly campaign when
 			// proposing.
-			shouldCampaign = r.isSoloReplicaLocked()
+			shouldCampaignOnCreation = r.isSoloReplicaLocked()
 		}
-		if shouldCampaign {
+		if shouldCampaignOnCreation {
 			log.VEventf(ctx, 3, "campaigning")
 			if err := raftGroup.Campaign(); err != nil {
 				return err
+			}
+			if fn := r.store.cfg.TestingKnobs.OnCampaign; fn != nil {
+				fn(r)
 			}
 		}
 	}
@@ -1332,17 +1335,28 @@ func (r *Replica) assertStateLocked(reader engine.Reader) {
 
 // maybeInitializeRaftGroup check whether the internal Raft group has
 // not yet been initialized. If not, it is created and set to campaign
-// if possible.
+// if this replica is the most recent owner of the range lease.
 func (r *Replica) maybeInitializeRaftGroup(ctx context.Context) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	// If this replica hasn't initialized the Raft group, create it and
+	// unquiesce and wake the leader to ensure the replica comes up to date.
 	if r.mu.internalRaftGroup == nil {
 		// Acquire raftMu, but need to maintain lock ordering (raftMu then mu).
 		r.mu.Unlock()
 		r.raftMu.Lock()
 		defer r.raftMu.Unlock()
 		r.mu.Lock()
-		if err := r.withRaftGroupLocked(true /* shouldCampaign */, func(raftGroup *raft.RawNode) (bool, error) {
+		// Campaign if this replica is the current lease holder to avoid
+		// an election storm after a recent split. If no replica is the
+		// lease holder, all replicas must campaign to avoid waiting for
+		// an election timeout to acquire the lease. In the latter case,
+		// there's less chance of an election storm because this replica
+		// will only campaign if it's been idle for >= election timeout,
+		// so there's most likely been no traffic to the range.
+		shouldCampaignOnCreation := r.mu.state.Lease.OwnedBy(r.store.StoreID()) ||
+			r.leaseStatus(r.mu.state.Lease, r.store.Clock().Now(), r.mu.minLeaseProposedTS).state != leaseValid
+		if err := r.withRaftGroupLocked(shouldCampaignOnCreation, func(raftGroup *raft.RawNode) (bool, error) {
 			return true, nil
 		}); err != nil {
 			log.ErrEventf(ctx, "unable to initialize raft group: %s", err)
@@ -4350,12 +4364,10 @@ func (r *Replica) shouldGossip() bool {
 // (which provide the necessary serialization to avoid data races).
 func (r *Replica) maybeGossipSystemConfig(ctx context.Context) error {
 	if r.store.Gossip() == nil || !r.IsInitialized() {
-		log.Infof(ctx, "gossip not initialized")
 		return nil
 	}
 
 	if !r.ContainsKey(keys.SystemConfigSpan.Key) || !r.shouldGossip() {
-		log.Infof(ctx, "not system config span or lease not held")
 		return nil
 	}
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -702,6 +702,10 @@ type StoreTestingKnobs struct {
 	// TODO(kaneda): This hook is not encouraged to use. Get rid of it once
 	// we make TestServer take a ManualClock.
 	ClockBeforeSend func(*hlc.Clock, roachpb.BatchRequest)
+	// OnCampaign is called if the replica campaigns for Raft leadership
+	// when initializing the Raft group. Note that this method is invoked
+	// with both Replica.raftMu and Replica.mu locked.
+	OnCampaign func(*Replica)
 	// MaxOffset, if set, overrides the server clock's MaxOffset at server
 	// creation time.
 	// See also DisableMaxOffsetCheck.


### PR DESCRIPTION
Fixes #13202

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13208)
<!-- Reviewable:end -->
