### PR TITLE
sql/parser: Define overload returnType interface and cleanup builtins

### DIFF
--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -43,7 +43,10 @@ func GetAggregateInfo(
 		for _, t := range b.Types.Types() {
 			if inputDatumType.Equivalent(t) {
 				// Found!
-				return b.AggregateFunc, sqlbase.DatumTypeToColumnType(b.FixedReturnType()), nil
+				constructAgg := func() parser.AggregateFunc {
+					return b.AggregateFunc([]parser.Type{inputDatumType})
+				}
+				return constructAgg, sqlbase.DatumTypeToColumnType(b.FixedReturnType()), nil
 			}
 		}
 	}

--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -43,7 +43,7 @@ func GetAggregateInfo(
 		for _, t := range b.Types.Types() {
 			if inputDatumType.Equivalent(t) {
 				// Found!
-				return b.AggregateFunc, sqlbase.DatumTypeToColumnType(b.ReturnType), nil
+				return b.AggregateFunc, sqlbase.DatumTypeToColumnType(b.FixedReturnType()), nil
 			}
 		}
 	}

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1482,6 +1482,7 @@ func checkResultType(typ parser.Type) error {
 	case parser.TypeTimestampTZ:
 	case parser.TypeInterval:
 	case parser.TypeStringArray:
+	case parser.TypeNameArray:
 	case parser.TypeIntArray:
 	default:
 		// Compare all types that cannot rely on == equality.

--- a/pkg/sql/parser/aggregate_builtins_test.go
+++ b/pkg/sql/parser/aggregate_builtins_test.go
@@ -29,8 +29,8 @@ import (
 // printing all values to strings once the accumulation has finished. If the string
 // slices are not equal, it means that the result Datums were modified during later
 // accumulation, which violates the "deep copy of any internal state" condition.
-func testAggregateResultDeepCopy(t *testing.T, aggFunc func() AggregateFunc, vals []Datum) {
-	aggImpl := aggFunc()
+func testAggregateResultDeepCopy(t *testing.T, aggFunc func([]Type) AggregateFunc, vals []Datum) {
+	aggImpl := aggFunc([]Type{vals[0].ResolvedType()})
 	runningDatums := make([]Datum, len(vals))
 	runningStrings := make([]string, len(vals))
 	for i := range vals {
@@ -223,10 +223,11 @@ func makeIntervalTestDatum(count int) []Datum {
 	return vals
 }
 
-func runBenchmarkAggregate(b *testing.B, aggFunc func() AggregateFunc, vals []Datum) {
+func runBenchmarkAggregate(b *testing.B, aggFunc func([]Type) AggregateFunc, vals []Datum) {
+	params := []Type{vals[0].ResolvedType()}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		aggImpl := aggFunc()
+		aggImpl := aggFunc(params)
 		for i := range vals {
 			aggImpl.Add(vals[i])
 		}

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -89,7 +89,7 @@ const (
 // Builtin is a built-in function.
 type Builtin struct {
 	Types      typeList
-	ReturnType returnType
+	ReturnType returnTyper
 
 	// When multiple overloads are eligible based on types even after all of of
 	// the heuristics to pick one have been used, if one of the overloads is a
@@ -136,7 +136,7 @@ func (b Builtin) params() typeList {
 	return b.Types
 }
 
-func (b Builtin) returnType() returnType {
+func (b Builtin) returnType() returnTyper {
 	return b.ReturnType
 }
 
@@ -270,7 +270,7 @@ var Builtins = map[string][]Builtin{
 	"concat": {
 		Builtin{
 			Types:      VariadicType{TypeString},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				var buffer bytes.Buffer
 				for _, d := range args {
@@ -288,7 +288,7 @@ var Builtins = map[string][]Builtin{
 	"concat_ws": {
 		Builtin{
 			Types:      VariadicType{TypeString},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				if len(args) == 0 {
 					return nil, errInsufficientArgs
@@ -320,7 +320,7 @@ var Builtins = map[string][]Builtin{
 	"to_uuid": {
 		Builtin{
 			Types:      ArgTypes{{"val", TypeString}},
-			ReturnType: fixedReturnType{TypeBytes},
+			ReturnType: fixedReturnType(TypeBytes),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				s := string(MustBeDString(args[0]))
 				uv, err := uuid.FromString(s)
@@ -337,7 +337,7 @@ var Builtins = map[string][]Builtin{
 	"from_uuid": {
 		Builtin{
 			Types:      ArgTypes{{"val", TypeBytes}},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				b := []byte(*args[0].(*DBytes))
 				uv, err := uuid.FromBytes(b)
@@ -354,7 +354,7 @@ var Builtins = map[string][]Builtin{
 	"from_ip": {
 		Builtin{
 			Types:      ArgTypes{{"val", TypeBytes}},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				ipstr := args[0].(*DBytes)
 				nboip := net.IP(*ipstr)
@@ -373,7 +373,7 @@ var Builtins = map[string][]Builtin{
 	"to_ip": {
 		Builtin{
 			Types:      ArgTypes{{"val", TypeString}},
-			ReturnType: fixedReturnType{TypeBytes},
+			ReturnType: fixedReturnType(TypeBytes),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				ipdstr := MustBeDString(args[0])
 				ip := net.ParseIP(string(ipdstr))
@@ -396,7 +396,7 @@ var Builtins = map[string][]Builtin{
 				{"delimiter", TypeString},
 				{"return_index_pos", TypeInt},
 			},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				text := string(MustBeDString(args[0]))
 				sep := string(MustBeDString(args[1]))
@@ -421,7 +421,7 @@ var Builtins = map[string][]Builtin{
 	"repeat": {
 		Builtin{
 			Types:      ArgTypes{{"input", TypeString}, {"repeat_counter", TypeInt}},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, args DTuple) (_ Datum, err error) {
 				s := string(MustBeDString(args[0]))
 				count := int(MustBeDInt(args[1]))
@@ -465,7 +465,7 @@ var Builtins = map[string][]Builtin{
 	"to_hex": {
 		Builtin{
 			Types:      ArgTypes{{"val", TypeInt}},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return NewDString(fmt.Sprintf("%x", int64(MustBeDInt(args[0])))), nil
 			},
@@ -491,7 +491,7 @@ var Builtins = map[string][]Builtin{
 				{"overlay_val", TypeString},
 				{"start_pos", TypeInt},
 			},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				s := string(MustBeDString(args[0]))
 				to := string(MustBeDString(args[1]))
@@ -510,7 +510,7 @@ var Builtins = map[string][]Builtin{
 				{"start_pos", TypeInt},
 				{"end_pos", TypeInt},
 			},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				s := string(MustBeDString(args[0]))
 				to := string(MustBeDString(args[1]))
@@ -609,7 +609,7 @@ var Builtins = map[string][]Builtin{
 	"regexp_extract": {
 		Builtin{
 			Types:      ArgTypes{{"input", TypeString}, {"regex", TypeString}},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				s := string(MustBeDString(args[0]))
 				pattern := string(MustBeDString(args[1]))
@@ -626,7 +626,7 @@ var Builtins = map[string][]Builtin{
 				{"regex", TypeString},
 				{"replace", TypeString},
 			},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				s := string(MustBeDString(args[0]))
 				pattern := string(MustBeDString(args[1]))
@@ -643,7 +643,7 @@ var Builtins = map[string][]Builtin{
 				{"replace", TypeString},
 				{"flags", TypeString},
 			},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				s := string(MustBeDString(args[0]))
 				pattern := string(MustBeDString(args[1]))
@@ -678,7 +678,7 @@ var Builtins = map[string][]Builtin{
 	"left": {
 		Builtin{
 			Types:      ArgTypes{{"input", TypeBytes}, {"return_set", TypeInt}},
-			ReturnType: fixedReturnType{TypeBytes},
+			ReturnType: fixedReturnType(TypeBytes),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				bytes := []byte(*args[0].(*DBytes))
 				n := int(MustBeDInt(args[1]))
@@ -696,7 +696,7 @@ var Builtins = map[string][]Builtin{
 		},
 		Builtin{
 			Types:      ArgTypes{{"input", TypeString}, {"return_set", TypeInt}},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				runes := []rune(string(MustBeDString(args[0])))
 				n := int(MustBeDInt(args[1]))
@@ -717,7 +717,7 @@ var Builtins = map[string][]Builtin{
 	"right": {
 		Builtin{
 			Types:      ArgTypes{{"input", TypeBytes}, {"return_set", TypeInt}},
-			ReturnType: fixedReturnType{TypeBytes},
+			ReturnType: fixedReturnType(TypeBytes),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				bytes := []byte(*args[0].(*DBytes))
 				n := int(MustBeDInt(args[1]))
@@ -735,7 +735,7 @@ var Builtins = map[string][]Builtin{
 		},
 		Builtin{
 			Types:      ArgTypes{{"input", TypeString}, {"return_set", TypeInt}},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				runes := []rune(string(MustBeDString(args[0])))
 				n := int(MustBeDInt(args[1]))
@@ -756,7 +756,7 @@ var Builtins = map[string][]Builtin{
 	"random": {
 		Builtin{
 			Types:                   ArgTypes{},
-			ReturnType:              fixedReturnType{TypeFloat},
+			ReturnType:              fixedReturnType(TypeFloat),
 			impure:                  true,
 			needsRepeatedEvaluation: true,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
@@ -769,7 +769,7 @@ var Builtins = map[string][]Builtin{
 	"unique_rowid": {
 		Builtin{
 			Types:      ArgTypes{},
-			ReturnType: fixedReturnType{TypeInt},
+			ReturnType: fixedReturnType(TypeInt),
 			category:   categoryIDGeneration,
 			impure:     true,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
@@ -788,7 +788,7 @@ var Builtins = map[string][]Builtin{
 	"greatest": {
 		Builtin{
 			Types:      HomogeneousType{},
-			ReturnType: identityReturnType{0},
+			ReturnType: identityReturnType(0),
 			category:   categoryComparison,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return pickFromTuple(ctx, true /* greatest */, args)
@@ -800,7 +800,7 @@ var Builtins = map[string][]Builtin{
 	"least": {
 		Builtin{
 			Types:      HomogeneousType{},
-			ReturnType: identityReturnType{0},
+			ReturnType: identityReturnType(0),
 			category:   categoryComparison,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return pickFromTuple(ctx, false /* !greatest */, args)
@@ -814,7 +814,7 @@ var Builtins = map[string][]Builtin{
 	"experimental_strftime": {
 		Builtin{
 			Types:      ArgTypes{{"input", TypeTimestamp}, {"extract_format", TypeString}},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				fromTime := args[0].(*DTimestamp).Time
 				format := string(MustBeDString(args[1]))
@@ -829,7 +829,7 @@ var Builtins = map[string][]Builtin{
 		},
 		Builtin{
 			Types:      ArgTypes{{"input", TypeDate}, {"extract_format", TypeString}},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				fromTime := time.Unix(int64(*args[0].(*DDate))*secondsInDay, 0).UTC()
 				format := string(MustBeDString(args[1]))
@@ -844,7 +844,7 @@ var Builtins = map[string][]Builtin{
 		},
 		Builtin{
 			Types:      ArgTypes{{"input", TypeTimestampTZ}, {"extract_format", TypeString}},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				fromTime := args[0].(*DTimestampTZ).Time
 				format := string(MustBeDString(args[1]))
@@ -862,7 +862,7 @@ var Builtins = map[string][]Builtin{
 	"experimental_strptime": {
 		Builtin{
 			Types:      ArgTypes{{"format", TypeString}, {"input", TypeString}},
-			ReturnType: fixedReturnType{TypeTimestampTZ},
+			ReturnType: fixedReturnType(TypeTimestampTZ),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				format := string(MustBeDString(args[0]))
 				toParse := string(MustBeDString(args[1]))
@@ -880,7 +880,7 @@ var Builtins = map[string][]Builtin{
 	"age": {
 		Builtin{
 			Types:        ArgTypes{{"val", TypeTimestampTZ}},
-			ReturnType:   fixedReturnType{TypeInterval},
+			ReturnType:   fixedReturnType(TypeInterval),
 			ctxDependent: true,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return timestampMinusBinOp.fn(ctx, ctx.GetTxnTimestamp(time.Microsecond), args[0])
@@ -889,7 +889,7 @@ var Builtins = map[string][]Builtin{
 		},
 		Builtin{
 			Types:      ArgTypes{{"begin", TypeTimestampTZ}, {"end", TypeTimestampTZ}},
-			ReturnType: fixedReturnType{TypeInterval},
+			ReturnType: fixedReturnType(TypeInterval),
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return timestampMinusBinOp.fn(ctx, args[0], args[1])
 			},
@@ -900,7 +900,7 @@ var Builtins = map[string][]Builtin{
 	"current_date": {
 		Builtin{
 			Types:        ArgTypes{},
-			ReturnType:   fixedReturnType{TypeDate},
+			ReturnType:   fixedReturnType(TypeDate),
 			ctxDependent: true,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				t := ctx.GetTxnTimestamp(time.Microsecond).Time
@@ -917,7 +917,7 @@ var Builtins = map[string][]Builtin{
 	"statement_timestamp": {
 		Builtin{
 			Types:             ArgTypes{},
-			ReturnType:        fixedReturnType{TypeTimestampTZ},
+			ReturnType:        fixedReturnType(TypeTimestampTZ),
 			preferredOverload: true,
 			impure:            true,
 			ctxDependent:      true,
@@ -928,7 +928,7 @@ var Builtins = map[string][]Builtin{
 		},
 		Builtin{
 			Types:        ArgTypes{},
-			ReturnType:   fixedReturnType{TypeTimestamp},
+			ReturnType:   fixedReturnType(TypeTimestamp),
 			impure:       true,
 			ctxDependent: true,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
@@ -941,7 +941,7 @@ var Builtins = map[string][]Builtin{
 	"cluster_logical_timestamp": {
 		Builtin{
 			Types:        ArgTypes{},
-			ReturnType:   fixedReturnType{TypeDecimal},
+			ReturnType:   fixedReturnType(TypeDecimal),
 			category:     categorySystemInfo,
 			impure:       true,
 			ctxDependent: true,
@@ -955,7 +955,7 @@ var Builtins = map[string][]Builtin{
 	"clock_timestamp": {
 		Builtin{
 			Types:             ArgTypes{},
-			ReturnType:        fixedReturnType{TypeTimestampTZ},
+			ReturnType:        fixedReturnType(TypeTimestampTZ),
 			preferredOverload: true,
 			impure:            true,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
@@ -965,7 +965,7 @@ var Builtins = map[string][]Builtin{
 		},
 		Builtin{
 			Types:      ArgTypes{},
-			ReturnType: fixedReturnType{TypeTimestamp},
+			ReturnType: fixedReturnType(TypeTimestamp),
 			impure:     true,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return MakeDTimestamp(timeutil.Now(), time.Microsecond), nil
@@ -977,7 +977,7 @@ var Builtins = map[string][]Builtin{
 	"extract": {
 		Builtin{
 			Types:      ArgTypes{{"element", TypeString}, {"input", TypeTimestamp}},
-			ReturnType: fixedReturnType{TypeInt},
+			ReturnType: fixedReturnType(TypeInt),
 			category:   categoryDateAndTime,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				// extract timeSpan fromTime.
@@ -992,7 +992,7 @@ var Builtins = map[string][]Builtin{
 		},
 		Builtin{
 			Types:      ArgTypes{{"element", TypeString}, {"input", TypeDate}},
-			ReturnType: fixedReturnType{TypeInt},
+			ReturnType: fixedReturnType(TypeInt),
 			category:   categoryDateAndTime,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				timeSpan := strings.ToLower(string(MustBeDString(args[0])))
@@ -1010,7 +1010,7 @@ var Builtins = map[string][]Builtin{
 	"extract_duration": {
 		Builtin{
 			Types:      ArgTypes{{"element", TypeString}, {"input", TypeInterval}},
-			ReturnType: fixedReturnType{TypeInt},
+			ReturnType: fixedReturnType(TypeInt),
 			category:   categoryDateAndTime,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				// extract timeSpan fromTime.
@@ -1055,7 +1055,7 @@ var Builtins = map[string][]Builtin{
 		}, "Calculates the absolute value of `val`."),
 		Builtin{
 			Types:      ArgTypes{{"val", TypeInt}},
-			ReturnType: fixedReturnType{TypeInt},
+			ReturnType: fixedReturnType(TypeInt),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				x := MustBeDInt(args[0])
 				switch {
@@ -1140,7 +1140,7 @@ var Builtins = map[string][]Builtin{
 		}, "Calculates the integer quotient of `x`/`y`."),
 		{
 			Types:      ArgTypes{{"x", TypeInt}, {"y", TypeInt}},
-			ReturnType: fixedReturnType{TypeInt},
+			ReturnType: fixedReturnType(TypeInt),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				y := MustBeDInt(args[1])
 				if y == 0 {
@@ -1201,7 +1201,7 @@ var Builtins = map[string][]Builtin{
 		}, "Calculates `x`%`y`."),
 		Builtin{
 			Types:      ArgTypes{{"x", TypeInt}, {"y", TypeInt}},
-			ReturnType: fixedReturnType{TypeInt},
+			ReturnType: fixedReturnType(TypeInt),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				y := MustBeDInt(args[1])
 				if y == 0 {
@@ -1217,7 +1217,7 @@ var Builtins = map[string][]Builtin{
 	"pi": {
 		Builtin{
 			Types:      ArgTypes{},
-			ReturnType: fixedReturnType{TypeFloat},
+			ReturnType: fixedReturnType(TypeFloat),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return NewDFloat(math.Pi), nil
 			},
@@ -1243,7 +1243,7 @@ var Builtins = map[string][]Builtin{
 		}, "Rounds `val` to the nearest integer."),
 		Builtin{
 			Types:      ArgTypes{{"input", TypeFloat}, {"decimal_accuracy", TypeInt}},
-			ReturnType: fixedReturnType{TypeFloat},
+			ReturnType: fixedReturnType(TypeFloat),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return round(float64(*args[0].(*DFloat)), int64(MustBeDInt(args[1])))
 			},
@@ -1252,7 +1252,7 @@ var Builtins = map[string][]Builtin{
 		},
 		Builtin{
 			Types:      ArgTypes{{"input", TypeDecimal}, {"decimal_accuracy", TypeInt}},
-			ReturnType: fixedReturnType{TypeDecimal},
+			ReturnType: fixedReturnType(TypeDecimal),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				scale := int64(MustBeDInt(args[1]))
 				return roundDecimal(&args[0].(*DDecimal).Dec, scale)
@@ -1287,7 +1287,7 @@ var Builtins = map[string][]Builtin{
 			"negative."),
 		Builtin{
 			Types:      ArgTypes{{"val", TypeInt}},
-			ReturnType: fixedReturnType{TypeInt},
+			ReturnType: fixedReturnType(TypeInt),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				x := MustBeDInt(args[0])
 				switch {
@@ -1342,7 +1342,7 @@ var Builtins = map[string][]Builtin{
 	"array_length": {
 		Builtin{
 			Types:      ArgTypes{{"input", TypeAnyArray}, {"array_dimension", TypeInt}},
-			ReturnType: fixedReturnType{TypeInt},
+			ReturnType: fixedReturnType(TypeInt),
 			category:   categorySystemInfo,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				arr := args[0].(*DArray)
@@ -1358,7 +1358,7 @@ var Builtins = map[string][]Builtin{
 	"array_lower": {
 		Builtin{
 			Types:      ArgTypes{{"input", TypeAnyArray}, {"array_dimension", TypeInt}},
-			ReturnType: fixedReturnType{TypeInt},
+			ReturnType: fixedReturnType(TypeInt),
 			category:   categorySystemInfo,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				arr := args[0].(*DArray)
@@ -1374,7 +1374,7 @@ var Builtins = map[string][]Builtin{
 	"array_upper": {
 		Builtin{
 			Types:      ArgTypes{{"input", TypeAnyArray}, {"array_dimension", TypeInt}},
-			ReturnType: fixedReturnType{TypeInt},
+			ReturnType: fixedReturnType(TypeInt),
 			category:   categorySystemInfo,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				arr := args[0].(*DArray)
@@ -1392,7 +1392,7 @@ var Builtins = map[string][]Builtin{
 	"version": {
 		Builtin{
 			Types:      ArgTypes{},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			category:   categorySystemInfo,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return NewDString(build.GetInfo().Short()), nil
@@ -1404,7 +1404,7 @@ var Builtins = map[string][]Builtin{
 	"current_schema": {
 		Builtin{
 			Types:      ArgTypes{},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			category:   categorySystemInfo,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				if len(ctx.Database) == 0 {
@@ -1422,7 +1422,7 @@ var Builtins = map[string][]Builtin{
 	"current_schemas": {
 		Builtin{
 			Types:        ArgTypes{{"include_implicit", TypeBool}},
-			ReturnType:   fixedReturnType{TypeStringArray},
+			ReturnType:   fixedReturnType(TypeStringArray),
 			category:     categorySystemInfo,
 			ctxDependent: true,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
@@ -1450,7 +1450,7 @@ var Builtins = map[string][]Builtin{
 	"crdb_internal.force_retry": {
 		Builtin{
 			Types:      ArgTypes{{"val", TypeInterval}},
-			ReturnType: fixedReturnType{TypeInt},
+			ReturnType: fixedReturnType(TypeInt),
 			impure:     true,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				minDuration := args[0].(*DInterval).Duration
@@ -1468,7 +1468,7 @@ var Builtins = map[string][]Builtin{
 			Types: ArgTypes{
 				{"val", TypeInterval},
 				{"txnID", TypeString}},
-			ReturnType: fixedReturnType{TypeInt},
+			ReturnType: fixedReturnType(TypeInt),
 			impure:     true,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				minDuration := args[0].(*DInterval).Duration
@@ -1494,7 +1494,7 @@ var Builtins = map[string][]Builtin{
 	"pg_catalog.pg_backend_pid": {
 		Builtin{
 			Types:      ArgTypes{},
-			ReturnType: fixedReturnType{TypeInt},
+			ReturnType: fixedReturnType(TypeInt),
 			fn: func(_ *EvalContext, _ DTuple) (Datum, error) {
 				return NewDInt(-1), nil
 			},
@@ -1515,7 +1515,7 @@ var Builtins = map[string][]Builtin{
 				{"pg_node_tree", TypeString},
 				{"relation_oid", TypeInt},
 			},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return args[0], nil
 			},
@@ -1528,7 +1528,7 @@ var Builtins = map[string][]Builtin{
 				{"relation_oid", TypeInt},
 				{"pretty_bool", TypeBool},
 			},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return args[0], nil
 			},
@@ -1544,7 +1544,7 @@ var Builtins = map[string][]Builtin{
 			Types: ArgTypes{
 				{"index_oid", TypeInt},
 			},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				oid := args[0]
 				r, err := ctx.Planner.QueryRow(
@@ -1570,7 +1570,7 @@ var Builtins = map[string][]Builtin{
 		// properly.
 		Builtin{
 			Types:      ArgTypes{{"val", TypeAny}},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return NewDString(args[0].ResolvedType().String()), nil
 			},
@@ -1583,7 +1583,7 @@ var Builtins = map[string][]Builtin{
 			Types: ArgTypes{
 				{"role_oid", TypeInt},
 			},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				oid := args[0]
 				t, err := ctx.Planner.QueryRow("SELECT rolname FROM pg_catalog.pg_roles WHERE oid=$1", oid)
@@ -1603,7 +1603,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			// TODO(jordan) typemod should be a Nullable TypeInt when supported.
 			Types:      ArgTypes{{"type_oid", TypeInt}, {"typemod", TypeInt}},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				typ, ok := OidToType[oid.Oid(int(MustBeDInt(args[0])))]
 				if !ok {
@@ -1620,7 +1620,7 @@ var Builtins = map[string][]Builtin{
 	"pg_catalog.col_description": {
 		Builtin{
 			Types:      ArgTypes{{"table_oid", TypeInt}, {"column_number", TypeInt}},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, _ DTuple) (Datum, error) {
 				return DNull, nil
 			},
@@ -1631,7 +1631,7 @@ var Builtins = map[string][]Builtin{
 	"pg_catalog.obj_description": {
 		Builtin{
 			Types:      ArgTypes{{"object_oid", TypeInt}},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, _ DTuple) (Datum, error) {
 				return DNull, nil
 			},
@@ -1642,7 +1642,7 @@ var Builtins = map[string][]Builtin{
 	"pg_catalog.shobj_description": {
 		Builtin{
 			Types:      ArgTypes{{"object_oid", TypeInt}, {"catalog_name", TypeString}},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, _ DTuple) (Datum, error) {
 				return DNull, nil
 			},
@@ -1653,7 +1653,7 @@ var Builtins = map[string][]Builtin{
 	"pg_catalog.array_in": {
 		Builtin{
 			Types:      ArgTypes{{"string", TypeString}, {"element_oid", TypeInt}, {"element_typmod", TypeInt}},
-			ReturnType: fixedReturnType{TypeString},
+			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, _ DTuple) (Datum, error) {
 				return nil, errors.New("unimplemented")
 			},
@@ -1669,7 +1669,7 @@ var substringImpls = []Builtin{
 			{"input", TypeString},
 			{"substr_pos", TypeInt},
 		},
-		ReturnType: fixedReturnType{TypeString},
+		ReturnType: fixedReturnType(TypeString),
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			runes := []rune(string(MustBeDString(args[0])))
 			// SQL strings are 1-indexed.
@@ -1691,7 +1691,7 @@ var substringImpls = []Builtin{
 			{"start_pos", TypeInt},
 			{"end_pos", TypeInt},
 		},
-		ReturnType: fixedReturnType{TypeString},
+		ReturnType: fixedReturnType(TypeString),
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			runes := []rune(string(MustBeDString(args[0])))
 			// SQL strings are 1-indexed.
@@ -1727,7 +1727,7 @@ var substringImpls = []Builtin{
 			{"input", TypeString},
 			{"regex", TypeString},
 		},
-		ReturnType: fixedReturnType{TypeString},
+		ReturnType: fixedReturnType(TypeString),
 		fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 			s := string(MustBeDString(args[0]))
 			pattern := string(MustBeDString(args[1]))
@@ -1741,7 +1741,7 @@ var substringImpls = []Builtin{
 			{"regex", TypeString},
 			{"escape_char", TypeString},
 		},
-		ReturnType: fixedReturnType{TypeString},
+		ReturnType: fixedReturnType(TypeString),
 		fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 			s := string(MustBeDString(args[0]))
 			pattern := string(MustBeDString(args[1]))
@@ -1755,7 +1755,7 @@ var substringImpls = []Builtin{
 
 var uuidV4Impl = Builtin{
 	Types:      ArgTypes{},
-	ReturnType: fixedReturnType{TypeBytes},
+	ReturnType: fixedReturnType(TypeBytes),
 	category:   categoryIDGeneration,
 	impure:     true,
 	fn: func(_ *EvalContext, args DTuple) (Datum, error) {
@@ -1778,7 +1778,7 @@ var ceilImpl = []Builtin{
 var txnTSImpl = []Builtin{
 	{
 		Types:             ArgTypes{},
-		ReturnType:        fixedReturnType{TypeTimestampTZ},
+		ReturnType:        fixedReturnType(TypeTimestampTZ),
 		preferredOverload: true,
 		impure:            true,
 		ctxDependent:      true,
@@ -1789,7 +1789,7 @@ var txnTSImpl = []Builtin{
 	},
 	{
 		Types:        ArgTypes{},
-		ReturnType:   fixedReturnType{TypeTimestamp},
+		ReturnType:   fixedReturnType(TypeTimestamp),
 		impure:       true,
 		ctxDependent: true,
 		fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
@@ -1813,7 +1813,7 @@ var powImpls = []Builtin{
 			{"x", TypeInt},
 			{"y", TypeInt},
 		},
-		ReturnType: fixedReturnType{TypeInt},
+		ReturnType: fixedReturnType(TypeInt),
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			x := int64(MustBeDInt(args[0]))
 			y := int64(MustBeDInt(args[1]))
@@ -1840,7 +1840,7 @@ func decimalLogFn(logFn func(*inf.Dec, *inf.Dec, inf.Scale) (*inf.Dec, error), i
 func floatBuiltin1(f func(float64) (Datum, error), info string) Builtin {
 	return Builtin{
 		Types:      ArgTypes{{"val", TypeFloat}},
-		ReturnType: fixedReturnType{TypeFloat},
+		ReturnType: fixedReturnType(TypeFloat),
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(float64(*args[0].(*DFloat)))
 		},
@@ -1851,7 +1851,7 @@ func floatBuiltin1(f func(float64) (Datum, error), info string) Builtin {
 func floatBuiltin2(a, b string, f func(float64, float64) (Datum, error), info string) Builtin {
 	return Builtin{
 		Types:      ArgTypes{{a, TypeFloat}, {b, TypeFloat}},
-		ReturnType: fixedReturnType{TypeFloat},
+		ReturnType: fixedReturnType(TypeFloat),
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(float64(*args[0].(*DFloat)),
 				float64(*args[1].(*DFloat)))
@@ -1863,7 +1863,7 @@ func floatBuiltin2(a, b string, f func(float64, float64) (Datum, error), info st
 func decimalBuiltin1(f func(*inf.Dec) (Datum, error), info string) Builtin {
 	return Builtin{
 		Types:      ArgTypes{{"val", TypeDecimal}},
-		ReturnType: fixedReturnType{TypeDecimal},
+		ReturnType: fixedReturnType(TypeDecimal),
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			dec := &args[0].(*DDecimal).Dec
 			return f(dec)
@@ -1875,7 +1875,7 @@ func decimalBuiltin1(f func(*inf.Dec) (Datum, error), info string) Builtin {
 func decimalBuiltin2(a, b string, f func(*inf.Dec, *inf.Dec) (Datum, error), info string) Builtin {
 	return Builtin{
 		Types:      ArgTypes{{a, TypeDecimal}, {b, TypeDecimal}},
-		ReturnType: fixedReturnType{TypeDecimal},
+		ReturnType: fixedReturnType(TypeDecimal),
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			dec1 := &args[0].(*DDecimal).Dec
 			dec2 := &args[1].(*DDecimal).Dec
@@ -1888,7 +1888,7 @@ func decimalBuiltin2(a, b string, f func(*inf.Dec, *inf.Dec) (Datum, error), inf
 func stringBuiltin1(f func(string) (Datum, error), returnType Type, info string) Builtin {
 	return Builtin{
 		Types:      ArgTypes{{"val", TypeString}},
-		ReturnType: fixedReturnType{returnType},
+		ReturnType: fixedReturnType(returnType),
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(string(MustBeDString(args[0])))
 		},
@@ -1901,7 +1901,7 @@ func stringBuiltin2(
 ) Builtin {
 	return Builtin{
 		Types:      ArgTypes{{a, TypeString}, {b, TypeString}},
-		ReturnType: fixedReturnType{returnType},
+		ReturnType: fixedReturnType(returnType),
 		category:   categorizeType(TypeString),
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(string(MustBeDString(args[0])), string(MustBeDString(args[1])))
@@ -1915,7 +1915,7 @@ func stringBuiltin3(
 ) Builtin {
 	return Builtin{
 		Types:      ArgTypes{{a, TypeString}, {b, TypeString}, {c, TypeString}},
-		ReturnType: fixedReturnType{returnType},
+		ReturnType: fixedReturnType(returnType),
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(string(MustBeDString(args[0])), string(MustBeDString(args[1])), string(MustBeDString(args[2])))
 		},
@@ -1926,7 +1926,7 @@ func stringBuiltin3(
 func bytesBuiltin1(f func(string) (Datum, error), returnType Type, info string) Builtin {
 	return Builtin{
 		Types:      ArgTypes{{"val", TypeBytes}},
-		ReturnType: fixedReturnType{returnType},
+		ReturnType: fixedReturnType(returnType),
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(string(*args[0].(*DBytes)))
 		},

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -127,8 +127,8 @@ type Builtin struct {
 	// might be more appropriate.
 	Info string
 
-	AggregateFunc func() AggregateFunc
-	WindowFunc    func() WindowFunc
+	AggregateFunc func([]Type) AggregateFunc
+	WindowFunc    func([]Type) WindowFunc
 	fn            func(*EvalContext, DTuple) (Datum, error)
 }
 

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -89,7 +89,7 @@ const (
 // Builtin is a built-in function.
 type Builtin struct {
 	Types      typeList
-	ReturnType Type
+	ReturnType returnType
 
 	// When multiple overloads are eligible based on types even after all of of
 	// the heuristics to pick one have been used, if one of the overloads is a
@@ -136,7 +136,7 @@ func (b Builtin) params() typeList {
 	return b.Types
 }
 
-func (b Builtin) returnType() Type {
+func (b Builtin) returnType() returnType {
 	return b.ReturnType
 }
 
@@ -171,8 +171,8 @@ func (b Builtin) Category() string {
 		}
 	}
 	// Fall back to categorizing by return type.
-	if b.ReturnType != nil {
-		return categorizeType(b.ReturnType)
+	if retType := b.FixedReturnType(); retType != nil {
+		return categorizeType(retType)
 	}
 	return ""
 }
@@ -193,9 +193,18 @@ func (b Builtin) ContextDependent() bool {
 	return b.ctxDependent
 }
 
+// FixedReturnType returns a fixed type that the function returns, returning Any
+// if the return type is based on the function's arguments.
+func (b Builtin) FixedReturnType() Type {
+	if b.ReturnType == nil {
+		return nil
+	}
+	return returnTypeToFixedType(b.ReturnType)
+}
+
 // Signature returns a human-readable signature.
 func (b Builtin) Signature() string {
-	return fmt.Sprintf("(%s) -> %s", b.Types.String(), b.ReturnType)
+	return fmt.Sprintf("(%s) -> %s", b.Types.String(), b.FixedReturnType())
 }
 
 func init() {
@@ -261,7 +270,7 @@ var Builtins = map[string][]Builtin{
 	"concat": {
 		Builtin{
 			Types:      VariadicType{TypeString},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				var buffer bytes.Buffer
 				for _, d := range args {
@@ -279,7 +288,7 @@ var Builtins = map[string][]Builtin{
 	"concat_ws": {
 		Builtin{
 			Types:      VariadicType{TypeString},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				if len(args) == 0 {
 					return nil, errInsufficientArgs
@@ -311,7 +320,7 @@ var Builtins = map[string][]Builtin{
 	"to_uuid": {
 		Builtin{
 			Types:      ArgTypes{{"val", TypeString}},
-			ReturnType: TypeBytes,
+			ReturnType: fixedReturnType{TypeBytes},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				s := string(MustBeDString(args[0]))
 				uv, err := uuid.FromString(s)
@@ -328,7 +337,7 @@ var Builtins = map[string][]Builtin{
 	"from_uuid": {
 		Builtin{
 			Types:      ArgTypes{{"val", TypeBytes}},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				b := []byte(*args[0].(*DBytes))
 				uv, err := uuid.FromBytes(b)
@@ -345,7 +354,7 @@ var Builtins = map[string][]Builtin{
 	"from_ip": {
 		Builtin{
 			Types:      ArgTypes{{"val", TypeBytes}},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				ipstr := args[0].(*DBytes)
 				nboip := net.IP(*ipstr)
@@ -364,7 +373,7 @@ var Builtins = map[string][]Builtin{
 	"to_ip": {
 		Builtin{
 			Types:      ArgTypes{{"val", TypeString}},
-			ReturnType: TypeBytes,
+			ReturnType: fixedReturnType{TypeBytes},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				ipdstr := MustBeDString(args[0])
 				ip := net.ParseIP(string(ipdstr))
@@ -387,7 +396,7 @@ var Builtins = map[string][]Builtin{
 				{"delimiter", TypeString},
 				{"return_index_pos", TypeInt},
 			},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				text := string(MustBeDString(args[0]))
 				sep := string(MustBeDString(args[1]))
@@ -412,7 +421,7 @@ var Builtins = map[string][]Builtin{
 	"repeat": {
 		Builtin{
 			Types:      ArgTypes{{"input", TypeString}, {"repeat_counter", TypeInt}},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(_ *EvalContext, args DTuple) (_ Datum, err error) {
 				s := string(MustBeDString(args[0]))
 				count := int(MustBeDInt(args[1]))
@@ -456,7 +465,7 @@ var Builtins = map[string][]Builtin{
 	"to_hex": {
 		Builtin{
 			Types:      ArgTypes{{"val", TypeInt}},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return NewDString(fmt.Sprintf("%x", int64(MustBeDInt(args[0])))), nil
 			},
@@ -482,7 +491,7 @@ var Builtins = map[string][]Builtin{
 				{"overlay_val", TypeString},
 				{"start_pos", TypeInt},
 			},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				s := string(MustBeDString(args[0]))
 				to := string(MustBeDString(args[1]))
@@ -501,7 +510,7 @@ var Builtins = map[string][]Builtin{
 				{"start_pos", TypeInt},
 				{"end_pos", TypeInt},
 			},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				s := string(MustBeDString(args[0]))
 				to := string(MustBeDString(args[1]))
@@ -600,7 +609,7 @@ var Builtins = map[string][]Builtin{
 	"regexp_extract": {
 		Builtin{
 			Types:      ArgTypes{{"input", TypeString}, {"regex", TypeString}},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				s := string(MustBeDString(args[0]))
 				pattern := string(MustBeDString(args[1]))
@@ -617,7 +626,7 @@ var Builtins = map[string][]Builtin{
 				{"regex", TypeString},
 				{"replace", TypeString},
 			},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				s := string(MustBeDString(args[0]))
 				pattern := string(MustBeDString(args[1]))
@@ -634,7 +643,7 @@ var Builtins = map[string][]Builtin{
 				{"replace", TypeString},
 				{"flags", TypeString},
 			},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				s := string(MustBeDString(args[0]))
 				pattern := string(MustBeDString(args[1]))
@@ -669,7 +678,7 @@ var Builtins = map[string][]Builtin{
 	"left": {
 		Builtin{
 			Types:      ArgTypes{{"input", TypeBytes}, {"return_set", TypeInt}},
-			ReturnType: TypeBytes,
+			ReturnType: fixedReturnType{TypeBytes},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				bytes := []byte(*args[0].(*DBytes))
 				n := int(MustBeDInt(args[1]))
@@ -687,7 +696,7 @@ var Builtins = map[string][]Builtin{
 		},
 		Builtin{
 			Types:      ArgTypes{{"input", TypeString}, {"return_set", TypeInt}},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				runes := []rune(string(MustBeDString(args[0])))
 				n := int(MustBeDInt(args[1]))
@@ -708,7 +717,7 @@ var Builtins = map[string][]Builtin{
 	"right": {
 		Builtin{
 			Types:      ArgTypes{{"input", TypeBytes}, {"return_set", TypeInt}},
-			ReturnType: TypeBytes,
+			ReturnType: fixedReturnType{TypeBytes},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				bytes := []byte(*args[0].(*DBytes))
 				n := int(MustBeDInt(args[1]))
@@ -726,7 +735,7 @@ var Builtins = map[string][]Builtin{
 		},
 		Builtin{
 			Types:      ArgTypes{{"input", TypeString}, {"return_set", TypeInt}},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				runes := []rune(string(MustBeDString(args[0])))
 				n := int(MustBeDInt(args[1]))
@@ -747,7 +756,7 @@ var Builtins = map[string][]Builtin{
 	"random": {
 		Builtin{
 			Types:                   ArgTypes{},
-			ReturnType:              TypeFloat,
+			ReturnType:              fixedReturnType{TypeFloat},
 			impure:                  true,
 			needsRepeatedEvaluation: true,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
@@ -760,7 +769,7 @@ var Builtins = map[string][]Builtin{
 	"unique_rowid": {
 		Builtin{
 			Types:      ArgTypes{},
-			ReturnType: TypeInt,
+			ReturnType: fixedReturnType{TypeInt},
 			category:   categoryIDGeneration,
 			impure:     true,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
@@ -778,8 +787,8 @@ var Builtins = map[string][]Builtin{
 
 	"greatest": {
 		Builtin{
-			Types:      AnyType{},
-			ReturnType: TypeAny,
+			Types:      HomogeneousType{},
+			ReturnType: identityReturnType{0},
 			category:   categoryComparison,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return pickFromTuple(ctx, true /* greatest */, args)
@@ -790,8 +799,8 @@ var Builtins = map[string][]Builtin{
 
 	"least": {
 		Builtin{
-			Types:      AnyType{},
-			ReturnType: TypeAny,
+			Types:      HomogeneousType{},
+			ReturnType: identityReturnType{0},
 			category:   categoryComparison,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return pickFromTuple(ctx, false /* !greatest */, args)
@@ -805,7 +814,7 @@ var Builtins = map[string][]Builtin{
 	"experimental_strftime": {
 		Builtin{
 			Types:      ArgTypes{{"input", TypeTimestamp}, {"extract_format", TypeString}},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				fromTime := args[0].(*DTimestamp).Time
 				format := string(MustBeDString(args[1]))
@@ -820,7 +829,7 @@ var Builtins = map[string][]Builtin{
 		},
 		Builtin{
 			Types:      ArgTypes{{"input", TypeDate}, {"extract_format", TypeString}},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				fromTime := time.Unix(int64(*args[0].(*DDate))*secondsInDay, 0).UTC()
 				format := string(MustBeDString(args[1]))
@@ -835,7 +844,7 @@ var Builtins = map[string][]Builtin{
 		},
 		Builtin{
 			Types:      ArgTypes{{"input", TypeTimestampTZ}, {"extract_format", TypeString}},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				fromTime := args[0].(*DTimestampTZ).Time
 				format := string(MustBeDString(args[1]))
@@ -853,7 +862,7 @@ var Builtins = map[string][]Builtin{
 	"experimental_strptime": {
 		Builtin{
 			Types:      ArgTypes{{"format", TypeString}, {"input", TypeString}},
-			ReturnType: TypeTimestampTZ,
+			ReturnType: fixedReturnType{TypeTimestampTZ},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				format := string(MustBeDString(args[0]))
 				toParse := string(MustBeDString(args[1]))
@@ -871,7 +880,7 @@ var Builtins = map[string][]Builtin{
 	"age": {
 		Builtin{
 			Types:        ArgTypes{{"val", TypeTimestampTZ}},
-			ReturnType:   TypeInterval,
+			ReturnType:   fixedReturnType{TypeInterval},
 			ctxDependent: true,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return timestampMinusBinOp.fn(ctx, ctx.GetTxnTimestamp(time.Microsecond), args[0])
@@ -880,7 +889,7 @@ var Builtins = map[string][]Builtin{
 		},
 		Builtin{
 			Types:      ArgTypes{{"begin", TypeTimestampTZ}, {"end", TypeTimestampTZ}},
-			ReturnType: TypeInterval,
+			ReturnType: fixedReturnType{TypeInterval},
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return timestampMinusBinOp.fn(ctx, args[0], args[1])
 			},
@@ -891,7 +900,7 @@ var Builtins = map[string][]Builtin{
 	"current_date": {
 		Builtin{
 			Types:        ArgTypes{},
-			ReturnType:   TypeDate,
+			ReturnType:   fixedReturnType{TypeDate},
 			ctxDependent: true,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				t := ctx.GetTxnTimestamp(time.Microsecond).Time
@@ -908,7 +917,7 @@ var Builtins = map[string][]Builtin{
 	"statement_timestamp": {
 		Builtin{
 			Types:             ArgTypes{},
-			ReturnType:        TypeTimestampTZ,
+			ReturnType:        fixedReturnType{TypeTimestampTZ},
 			preferredOverload: true,
 			impure:            true,
 			ctxDependent:      true,
@@ -919,7 +928,7 @@ var Builtins = map[string][]Builtin{
 		},
 		Builtin{
 			Types:        ArgTypes{},
-			ReturnType:   TypeTimestamp,
+			ReturnType:   fixedReturnType{TypeTimestamp},
 			impure:       true,
 			ctxDependent: true,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
@@ -932,7 +941,7 @@ var Builtins = map[string][]Builtin{
 	"cluster_logical_timestamp": {
 		Builtin{
 			Types:        ArgTypes{},
-			ReturnType:   TypeDecimal,
+			ReturnType:   fixedReturnType{TypeDecimal},
 			category:     categorySystemInfo,
 			impure:       true,
 			ctxDependent: true,
@@ -946,7 +955,7 @@ var Builtins = map[string][]Builtin{
 	"clock_timestamp": {
 		Builtin{
 			Types:             ArgTypes{},
-			ReturnType:        TypeTimestampTZ,
+			ReturnType:        fixedReturnType{TypeTimestampTZ},
 			preferredOverload: true,
 			impure:            true,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
@@ -956,7 +965,7 @@ var Builtins = map[string][]Builtin{
 		},
 		Builtin{
 			Types:      ArgTypes{},
-			ReturnType: TypeTimestamp,
+			ReturnType: fixedReturnType{TypeTimestamp},
 			impure:     true,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return MakeDTimestamp(timeutil.Now(), time.Microsecond), nil
@@ -968,7 +977,7 @@ var Builtins = map[string][]Builtin{
 	"extract": {
 		Builtin{
 			Types:      ArgTypes{{"element", TypeString}, {"input", TypeTimestamp}},
-			ReturnType: TypeInt,
+			ReturnType: fixedReturnType{TypeInt},
 			category:   categoryDateAndTime,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				// extract timeSpan fromTime.
@@ -983,7 +992,7 @@ var Builtins = map[string][]Builtin{
 		},
 		Builtin{
 			Types:      ArgTypes{{"element", TypeString}, {"input", TypeDate}},
-			ReturnType: TypeInt,
+			ReturnType: fixedReturnType{TypeInt},
 			category:   categoryDateAndTime,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				timeSpan := strings.ToLower(string(MustBeDString(args[0])))
@@ -1001,7 +1010,7 @@ var Builtins = map[string][]Builtin{
 	"extract_duration": {
 		Builtin{
 			Types:      ArgTypes{{"element", TypeString}, {"input", TypeInterval}},
-			ReturnType: TypeInt,
+			ReturnType: fixedReturnType{TypeInt},
 			category:   categoryDateAndTime,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				// extract timeSpan fromTime.
@@ -1046,7 +1055,7 @@ var Builtins = map[string][]Builtin{
 		}, "Calculates the absolute value of `val`."),
 		Builtin{
 			Types:      ArgTypes{{"val", TypeInt}},
-			ReturnType: TypeInt,
+			ReturnType: fixedReturnType{TypeInt},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				x := MustBeDInt(args[0])
 				switch {
@@ -1131,7 +1140,7 @@ var Builtins = map[string][]Builtin{
 		}, "Calculates the integer quotient of `x`/`y`."),
 		{
 			Types:      ArgTypes{{"x", TypeInt}, {"y", TypeInt}},
-			ReturnType: TypeInt,
+			ReturnType: fixedReturnType{TypeInt},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				y := MustBeDInt(args[1])
 				if y == 0 {
@@ -1192,7 +1201,7 @@ var Builtins = map[string][]Builtin{
 		}, "Calculates `x`%`y`."),
 		Builtin{
 			Types:      ArgTypes{{"x", TypeInt}, {"y", TypeInt}},
-			ReturnType: TypeInt,
+			ReturnType: fixedReturnType{TypeInt},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				y := MustBeDInt(args[1])
 				if y == 0 {
@@ -1208,7 +1217,7 @@ var Builtins = map[string][]Builtin{
 	"pi": {
 		Builtin{
 			Types:      ArgTypes{},
-			ReturnType: TypeFloat,
+			ReturnType: fixedReturnType{TypeFloat},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return NewDFloat(math.Pi), nil
 			},
@@ -1234,7 +1243,7 @@ var Builtins = map[string][]Builtin{
 		}, "Rounds `val` to the nearest integer."),
 		Builtin{
 			Types:      ArgTypes{{"input", TypeFloat}, {"decimal_accuracy", TypeInt}},
-			ReturnType: TypeFloat,
+			ReturnType: fixedReturnType{TypeFloat},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return round(float64(*args[0].(*DFloat)), int64(MustBeDInt(args[1])))
 			},
@@ -1243,7 +1252,7 @@ var Builtins = map[string][]Builtin{
 		},
 		Builtin{
 			Types:      ArgTypes{{"input", TypeDecimal}, {"decimal_accuracy", TypeInt}},
-			ReturnType: TypeDecimal,
+			ReturnType: fixedReturnType{TypeDecimal},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				scale := int64(MustBeDInt(args[1]))
 				return roundDecimal(&args[0].(*DDecimal).Dec, scale)
@@ -1278,7 +1287,7 @@ var Builtins = map[string][]Builtin{
 			"negative."),
 		Builtin{
 			Types:      ArgTypes{{"val", TypeInt}},
-			ReturnType: TypeInt,
+			ReturnType: fixedReturnType{TypeInt},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				x := MustBeDInt(args[0])
 				switch {
@@ -1333,7 +1342,7 @@ var Builtins = map[string][]Builtin{
 	"array_length": {
 		Builtin{
 			Types:      ArgTypes{{"input", TypeAnyArray}, {"array_dimension", TypeInt}},
-			ReturnType: TypeInt,
+			ReturnType: fixedReturnType{TypeInt},
 			category:   categorySystemInfo,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				arr := args[0].(*DArray)
@@ -1349,7 +1358,7 @@ var Builtins = map[string][]Builtin{
 	"array_lower": {
 		Builtin{
 			Types:      ArgTypes{{"input", TypeAnyArray}, {"array_dimension", TypeInt}},
-			ReturnType: TypeInt,
+			ReturnType: fixedReturnType{TypeInt},
 			category:   categorySystemInfo,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				arr := args[0].(*DArray)
@@ -1365,7 +1374,7 @@ var Builtins = map[string][]Builtin{
 	"array_upper": {
 		Builtin{
 			Types:      ArgTypes{{"input", TypeAnyArray}, {"array_dimension", TypeInt}},
-			ReturnType: TypeInt,
+			ReturnType: fixedReturnType{TypeInt},
 			category:   categorySystemInfo,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				arr := args[0].(*DArray)
@@ -1383,7 +1392,7 @@ var Builtins = map[string][]Builtin{
 	"version": {
 		Builtin{
 			Types:      ArgTypes{},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			category:   categorySystemInfo,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return NewDString(build.GetInfo().Short()), nil
@@ -1395,7 +1404,7 @@ var Builtins = map[string][]Builtin{
 	"current_schema": {
 		Builtin{
 			Types:      ArgTypes{},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			category:   categorySystemInfo,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				if len(ctx.Database) == 0 {
@@ -1413,7 +1422,7 @@ var Builtins = map[string][]Builtin{
 	"current_schemas": {
 		Builtin{
 			Types:        ArgTypes{{"include_implicit", TypeBool}},
-			ReturnType:   TypeStringArray,
+			ReturnType:   fixedReturnType{TypeStringArray},
 			category:     categorySystemInfo,
 			ctxDependent: true,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
@@ -1441,7 +1450,7 @@ var Builtins = map[string][]Builtin{
 	"crdb_internal.force_retry": {
 		Builtin{
 			Types:      ArgTypes{{"val", TypeInterval}},
-			ReturnType: TypeInt,
+			ReturnType: fixedReturnType{TypeInt},
 			impure:     true,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				minDuration := args[0].(*DInterval).Duration
@@ -1459,7 +1468,7 @@ var Builtins = map[string][]Builtin{
 			Types: ArgTypes{
 				{"val", TypeInterval},
 				{"txnID", TypeString}},
-			ReturnType: TypeInt,
+			ReturnType: fixedReturnType{TypeInt},
 			impure:     true,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				minDuration := args[0].(*DInterval).Duration
@@ -1485,7 +1494,7 @@ var Builtins = map[string][]Builtin{
 	"pg_catalog.pg_backend_pid": {
 		Builtin{
 			Types:      ArgTypes{},
-			ReturnType: TypeInt,
+			ReturnType: fixedReturnType{TypeInt},
 			fn: func(_ *EvalContext, _ DTuple) (Datum, error) {
 				return NewDInt(-1), nil
 			},
@@ -1506,7 +1515,7 @@ var Builtins = map[string][]Builtin{
 				{"pg_node_tree", TypeString},
 				{"relation_oid", TypeInt},
 			},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return args[0], nil
 			},
@@ -1519,7 +1528,7 @@ var Builtins = map[string][]Builtin{
 				{"relation_oid", TypeInt},
 				{"pretty_bool", TypeBool},
 			},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return args[0], nil
 			},
@@ -1535,7 +1544,7 @@ var Builtins = map[string][]Builtin{
 			Types: ArgTypes{
 				{"index_oid", TypeInt},
 			},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				oid := args[0]
 				r, err := ctx.Planner.QueryRow(
@@ -1561,7 +1570,7 @@ var Builtins = map[string][]Builtin{
 		// properly.
 		Builtin{
 			Types:      ArgTypes{{"val", TypeAny}},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return NewDString(args[0].ResolvedType().String()), nil
 			},
@@ -1574,7 +1583,7 @@ var Builtins = map[string][]Builtin{
 			Types: ArgTypes{
 				{"role_oid", TypeInt},
 			},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				oid := args[0]
 				t, err := ctx.Planner.QueryRow("SELECT rolname FROM pg_catalog.pg_roles WHERE oid=$1", oid)
@@ -1594,7 +1603,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			// TODO(jordan) typemod should be a Nullable TypeInt when supported.
 			Types:      ArgTypes{{"type_oid", TypeInt}, {"typemod", TypeInt}},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				typ, ok := OidToType[oid.Oid(int(MustBeDInt(args[0])))]
 				if !ok {
@@ -1611,7 +1620,7 @@ var Builtins = map[string][]Builtin{
 	"pg_catalog.col_description": {
 		Builtin{
 			Types:      ArgTypes{{"table_oid", TypeInt}, {"column_number", TypeInt}},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(_ *EvalContext, _ DTuple) (Datum, error) {
 				return DNull, nil
 			},
@@ -1622,7 +1631,7 @@ var Builtins = map[string][]Builtin{
 	"pg_catalog.obj_description": {
 		Builtin{
 			Types:      ArgTypes{{"object_oid", TypeInt}},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(_ *EvalContext, _ DTuple) (Datum, error) {
 				return DNull, nil
 			},
@@ -1633,7 +1642,7 @@ var Builtins = map[string][]Builtin{
 	"pg_catalog.shobj_description": {
 		Builtin{
 			Types:      ArgTypes{{"object_oid", TypeInt}, {"catalog_name", TypeString}},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(_ *EvalContext, _ DTuple) (Datum, error) {
 				return DNull, nil
 			},
@@ -1644,7 +1653,7 @@ var Builtins = map[string][]Builtin{
 	"pg_catalog.array_in": {
 		Builtin{
 			Types:      ArgTypes{{"string", TypeString}, {"element_oid", TypeInt}, {"element_typmod", TypeInt}},
-			ReturnType: TypeString,
+			ReturnType: fixedReturnType{TypeString},
 			fn: func(_ *EvalContext, _ DTuple) (Datum, error) {
 				return nil, errors.New("unimplemented")
 			},
@@ -1660,7 +1669,7 @@ var substringImpls = []Builtin{
 			{"input", TypeString},
 			{"substr_pos", TypeInt},
 		},
-		ReturnType: TypeString,
+		ReturnType: fixedReturnType{TypeString},
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			runes := []rune(string(MustBeDString(args[0])))
 			// SQL strings are 1-indexed.
@@ -1682,7 +1691,7 @@ var substringImpls = []Builtin{
 			{"start_pos", TypeInt},
 			{"end_pos", TypeInt},
 		},
-		ReturnType: TypeString,
+		ReturnType: fixedReturnType{TypeString},
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			runes := []rune(string(MustBeDString(args[0])))
 			// SQL strings are 1-indexed.
@@ -1718,7 +1727,7 @@ var substringImpls = []Builtin{
 			{"input", TypeString},
 			{"regex", TypeString},
 		},
-		ReturnType: TypeString,
+		ReturnType: fixedReturnType{TypeString},
 		fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 			s := string(MustBeDString(args[0]))
 			pattern := string(MustBeDString(args[1]))
@@ -1732,7 +1741,7 @@ var substringImpls = []Builtin{
 			{"regex", TypeString},
 			{"escape_char", TypeString},
 		},
-		ReturnType: TypeString,
+		ReturnType: fixedReturnType{TypeString},
 		fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 			s := string(MustBeDString(args[0]))
 			pattern := string(MustBeDString(args[1]))
@@ -1746,7 +1755,7 @@ var substringImpls = []Builtin{
 
 var uuidV4Impl = Builtin{
 	Types:      ArgTypes{},
-	ReturnType: TypeBytes,
+	ReturnType: fixedReturnType{TypeBytes},
 	category:   categoryIDGeneration,
 	impure:     true,
 	fn: func(_ *EvalContext, args DTuple) (Datum, error) {
@@ -1769,7 +1778,7 @@ var ceilImpl = []Builtin{
 var txnTSImpl = []Builtin{
 	{
 		Types:             ArgTypes{},
-		ReturnType:        TypeTimestampTZ,
+		ReturnType:        fixedReturnType{TypeTimestampTZ},
 		preferredOverload: true,
 		impure:            true,
 		ctxDependent:      true,
@@ -1780,7 +1789,7 @@ var txnTSImpl = []Builtin{
 	},
 	{
 		Types:        ArgTypes{},
-		ReturnType:   TypeTimestamp,
+		ReturnType:   fixedReturnType{TypeTimestamp},
 		impure:       true,
 		ctxDependent: true,
 		fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
@@ -1804,7 +1813,7 @@ var powImpls = []Builtin{
 			{"x", TypeInt},
 			{"y", TypeInt},
 		},
-		ReturnType: TypeInt,
+		ReturnType: fixedReturnType{TypeInt},
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			x := int64(MustBeDInt(args[0]))
 			y := int64(MustBeDInt(args[1]))
@@ -1831,7 +1840,7 @@ func decimalLogFn(logFn func(*inf.Dec, *inf.Dec, inf.Scale) (*inf.Dec, error), i
 func floatBuiltin1(f func(float64) (Datum, error), info string) Builtin {
 	return Builtin{
 		Types:      ArgTypes{{"val", TypeFloat}},
-		ReturnType: TypeFloat,
+		ReturnType: fixedReturnType{TypeFloat},
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(float64(*args[0].(*DFloat)))
 		},
@@ -1842,7 +1851,7 @@ func floatBuiltin1(f func(float64) (Datum, error), info string) Builtin {
 func floatBuiltin2(a, b string, f func(float64, float64) (Datum, error), info string) Builtin {
 	return Builtin{
 		Types:      ArgTypes{{a, TypeFloat}, {b, TypeFloat}},
-		ReturnType: TypeFloat,
+		ReturnType: fixedReturnType{TypeFloat},
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(float64(*args[0].(*DFloat)),
 				float64(*args[1].(*DFloat)))
@@ -1854,7 +1863,7 @@ func floatBuiltin2(a, b string, f func(float64, float64) (Datum, error), info st
 func decimalBuiltin1(f func(*inf.Dec) (Datum, error), info string) Builtin {
 	return Builtin{
 		Types:      ArgTypes{{"val", TypeDecimal}},
-		ReturnType: TypeDecimal,
+		ReturnType: fixedReturnType{TypeDecimal},
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			dec := &args[0].(*DDecimal).Dec
 			return f(dec)
@@ -1866,7 +1875,7 @@ func decimalBuiltin1(f func(*inf.Dec) (Datum, error), info string) Builtin {
 func decimalBuiltin2(a, b string, f func(*inf.Dec, *inf.Dec) (Datum, error), info string) Builtin {
 	return Builtin{
 		Types:      ArgTypes{{a, TypeDecimal}, {b, TypeDecimal}},
-		ReturnType: TypeDecimal,
+		ReturnType: fixedReturnType{TypeDecimal},
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			dec1 := &args[0].(*DDecimal).Dec
 			dec2 := &args[1].(*DDecimal).Dec
@@ -1879,7 +1888,7 @@ func decimalBuiltin2(a, b string, f func(*inf.Dec, *inf.Dec) (Datum, error), inf
 func stringBuiltin1(f func(string) (Datum, error), returnType Type, info string) Builtin {
 	return Builtin{
 		Types:      ArgTypes{{"val", TypeString}},
-		ReturnType: returnType,
+		ReturnType: fixedReturnType{returnType},
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(string(MustBeDString(args[0])))
 		},
@@ -1892,7 +1901,7 @@ func stringBuiltin2(
 ) Builtin {
 	return Builtin{
 		Types:      ArgTypes{{a, TypeString}, {b, TypeString}},
-		ReturnType: returnType,
+		ReturnType: fixedReturnType{returnType},
 		category:   categorizeType(TypeString),
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(string(MustBeDString(args[0])), string(MustBeDString(args[1])))
@@ -1906,7 +1915,7 @@ func stringBuiltin3(
 ) Builtin {
 	return Builtin{
 		Types:      ArgTypes{{a, TypeString}, {b, TypeString}, {c, TypeString}},
-		ReturnType: returnType,
+		ReturnType: fixedReturnType{returnType},
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(string(MustBeDString(args[0])), string(MustBeDString(args[1])), string(MustBeDString(args[2])))
 		},
@@ -1917,7 +1926,7 @@ func stringBuiltin3(
 func bytesBuiltin1(f func(string) (Datum, error), returnType Type, info string) Builtin {
 	return Builtin{
 		Types:      ArgTypes{{"val", TypeBytes}},
-		ReturnType: returnType,
+		ReturnType: fixedReturnType{returnType},
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(string(*args[0].(*DBytes)))
 		},

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -55,15 +55,17 @@ type UnaryOp struct {
 	Typ        Type
 	ReturnType Type
 	fn         func(*EvalContext, Datum) (Datum, error)
-	types      typeList
+
+	types   typeList
+	retType returnType
 }
 
 func (op UnaryOp) params() typeList {
 	return op.types
 }
 
-func (op UnaryOp) returnType() Type {
-	return op.ReturnType
+func (op UnaryOp) returnType() returnType {
+	return op.retType
 }
 
 func (UnaryOp) preferred() bool {
@@ -74,6 +76,7 @@ func init() {
 	for op, overload := range UnaryOps {
 		for i, impl := range overload {
 			impl.types = ArgTypes{{"arg", impl.Typ}}
+			impl.retType = fixedReturnType{impl.ReturnType}
 			UnaryOps[op][i] = impl
 		}
 	}
@@ -163,7 +166,9 @@ type BinOp struct {
 	RightType  Type
 	ReturnType Type
 	fn         func(*EvalContext, Datum, Datum) (Datum, error)
-	types      typeList
+
+	types   typeList
+	retType returnType
 }
 
 func (op BinOp) params() typeList {
@@ -174,8 +179,8 @@ func (op BinOp) matchParams(l, r Type) bool {
 	return op.params().matchAt(l, 0) && op.params().matchAt(r, 1)
 }
 
-func (op BinOp) returnType() Type {
-	return op.ReturnType
+func (op BinOp) returnType() returnType {
+	return op.retType
 }
 
 func (BinOp) preferred() bool {
@@ -186,6 +191,7 @@ func init() {
 	for op, overload := range BinOps {
 		for i, impl := range overload {
 			impl.types = ArgTypes{{"left", impl.LeftType}, {"right", impl.RightType}}
+			impl.retType = fixedReturnType{impl.ReturnType}
 			BinOps[op][i] = impl
 		}
 	}
@@ -876,7 +882,8 @@ type CmpOp struct {
 	LeftType  Type
 	RightType Type
 	fn        func(*EvalContext, Datum, Datum) (DBool, error)
-	types     typeList
+
+	types typeList
 }
 
 func (op CmpOp) params() typeList {
@@ -887,8 +894,10 @@ func (op CmpOp) matchParams(l, r Type) bool {
 	return op.params().matchAt(l, 0) && op.params().matchAt(r, 1)
 }
 
-func (op CmpOp) returnType() Type {
-	return TypeBool
+var cmpOpReturnType = fixedReturnType{TypeBool}
+
+func (op CmpOp) returnType() returnType {
+	return cmpOpReturnType
 }
 
 func (CmpOp) preferred() bool {

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -57,14 +57,14 @@ type UnaryOp struct {
 	fn         func(*EvalContext, Datum) (Datum, error)
 
 	types   typeList
-	retType returnType
+	retType returnTyper
 }
 
 func (op UnaryOp) params() typeList {
 	return op.types
 }
 
-func (op UnaryOp) returnType() returnType {
+func (op UnaryOp) returnType() returnTyper {
 	return op.retType
 }
 
@@ -76,7 +76,7 @@ func init() {
 	for op, overload := range UnaryOps {
 		for i, impl := range overload {
 			impl.types = ArgTypes{{"arg", impl.Typ}}
-			impl.retType = fixedReturnType{impl.ReturnType}
+			impl.retType = fixedReturnType(impl.ReturnType)
 			UnaryOps[op][i] = impl
 		}
 	}
@@ -168,7 +168,7 @@ type BinOp struct {
 	fn         func(*EvalContext, Datum, Datum) (Datum, error)
 
 	types   typeList
-	retType returnType
+	retType returnTyper
 }
 
 func (op BinOp) params() typeList {
@@ -179,7 +179,7 @@ func (op BinOp) matchParams(l, r Type) bool {
 	return op.params().matchAt(l, 0) && op.params().matchAt(r, 1)
 }
 
-func (op BinOp) returnType() returnType {
+func (op BinOp) returnType() returnTyper {
 	return op.retType
 }
 
@@ -191,7 +191,7 @@ func init() {
 	for op, overload := range BinOps {
 		for i, impl := range overload {
 			impl.types = ArgTypes{{"left", impl.LeftType}, {"right", impl.RightType}}
-			impl.retType = fixedReturnType{impl.ReturnType}
+			impl.retType = fixedReturnType(impl.ReturnType)
 			BinOps[op][i] = impl
 		}
 	}
@@ -894,9 +894,9 @@ func (op CmpOp) matchParams(l, r Type) bool {
 	return op.params().matchAt(l, 0) && op.params().matchAt(r, 1)
 }
 
-var cmpOpReturnType = fixedReturnType{TypeBool}
+var cmpOpReturnType = fixedReturnType(TypeBool)
 
-func (op CmpOp) returnType() returnType {
+func (op CmpOp) returnType() returnTyper {
 	return cmpOpReturnType
 }
 

--- a/pkg/sql/parser/expr.go
+++ b/pkg/sql/parser/expr.go
@@ -815,7 +815,7 @@ func newBinExprIfValidOverload(op BinaryOperator, left TypedExpr, right TypedExp
 			Right:    right,
 			fn:       fn,
 		}
-		expr.typ = fn.returnType()
+		expr.typ = returnTypeToFixedType(fn.returnType())
 		return expr
 	}
 	return nil

--- a/pkg/sql/parser/generator_builtins.go
+++ b/pkg/sql/parser/generator_builtins.go
@@ -133,7 +133,7 @@ func makeGeneratorBuiltin(in ArgTypes, ret TTuple, g generatorFactory, info stri
 		impure:     true,
 		class:      GeneratorClass,
 		Types:      in,
-		ReturnType: TTable{Cols: ret},
+		ReturnType: fixedReturnType{TTable{Cols: ret}},
 		fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 			gen, err := g(ctx, args)
 			if err != nil {

--- a/pkg/sql/parser/overload_test.go
+++ b/pkg/sql/parser/overload_test.go
@@ -34,8 +34,8 @@ func (to *testOverload) params() typeList {
 	return to.paramTypes
 }
 
-func (to *testOverload) returnType() Type {
-	return to.retType
+func (to *testOverload) returnType() returnType {
+	return fixedReturnType{to.retType}
 }
 
 func (to testOverload) preferred() bool {

--- a/pkg/sql/parser/overload_test.go
+++ b/pkg/sql/parser/overload_test.go
@@ -34,8 +34,8 @@ func (to *testOverload) params() typeList {
 	return to.paramTypes
 }
 
-func (to *testOverload) returnType() returnType {
-	return fixedReturnType{to.retType}
+func (to *testOverload) returnType() returnTyper {
+	return fixedReturnType(to.retType)
 }
 
 func (to testOverload) preferred() bool {

--- a/pkg/sql/parser/type.go
+++ b/pkg/sql/parser/type.go
@@ -114,6 +114,20 @@ var (
 	// TypeName is a type-alias for TypeString with a different OID. Can be
 	// compared with ==.
 	TypeName = wrapTypeWithOid(TypeString, oid.T_name)
+
+	// TypesAnyNonArray contains all non-array types.
+	TypesAnyNonArray = []Type{
+		TypeBool,
+		TypeInt,
+		TypeFloat,
+		TypeDecimal,
+		TypeString,
+		TypeBytes,
+		TypeDate,
+		TypeTimestamp,
+		TypeTimestampTZ,
+		TypeInterval,
+	}
 )
 
 // OidToType maps Postgres object IDs to CockroachDB types.

--- a/pkg/sql/parser/type.go
+++ b/pkg/sql/parser/type.go
@@ -114,6 +114,9 @@ var (
 	// TypeName is a type-alias for TypeString with a different OID. Can be
 	// compared with ==.
 	TypeName = wrapTypeWithOid(TypeString, oid.T_name)
+	// TypeNameArray is the type family of a DArray containing the Name alias type.
+	// Can be compared with ==.
+	TypeNameArray Type = tArray{TypeName}
 
 	// TypesAnyNonArray contains all non-array types.
 	TypesAnyNonArray = []Type{
@@ -453,16 +456,19 @@ func (tArray) Size() (uintptr, bool) {
 	return unsafe.Sizeof(DString("")), variableSize
 }
 
+// oidToArrayOid maps scalar type Oids to their corresponding array type Oid.
+var oidToArrayOid = map[oid.Oid]oid.Oid{
+	oid.T_int8: oid.T__int8,
+	oid.T_text: oid.T__text,
+	oid.T_name: oid.T__name,
+}
+
 // Oid implements the Type interface.
 func (a tArray) Oid() oid.Oid {
-	switch a.Typ {
-	case TypeInt:
-		return oid.T__int8
-	case TypeString:
-		return oid.T__text
-	default:
-		return oid.T_anyarray
+	if o, ok := oidToArrayOid[a.Typ.Oid()]; ok {
+		return o
 	}
+	return oid.T_anyarray
 }
 
 // SQLName implements the Type interface.

--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -135,7 +135,7 @@ func (expr *BinaryExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, er
 	}
 	expr.Left, expr.Right = leftTyped, rightTyped
 	expr.fn = fn.(BinOp)
-	expr.typ = fn.returnType()
+	expr.typ = overloadReturnTypeGivenArgs(fn, typedSubExprs)
 	return expr, nil
 }
 
@@ -450,15 +450,7 @@ func (expr *FuncExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, erro
 		expr.Exprs[i] = subExpr
 	}
 	expr.fn = builtin
-	returnType := fn.returnType()
-	if _, ok := expr.fn.params().(AnyType); ok {
-		if len(typedSubExprs) > 0 {
-			returnType = typedSubExprs[0].ResolvedType()
-		} else {
-			returnType = TypeNull
-		}
-	}
-	expr.typ = returnType
+	expr.typ = overloadReturnTypeGivenArgs(builtin, typedSubExprs)
 	return expr, nil
 }
 
@@ -627,7 +619,7 @@ func (expr *UnaryExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, err
 	}
 	expr.Expr = exprTyped
 	expr.fn = fn.(UnaryOp)
-	expr.typ = fn.returnType()
+	expr.typ = overloadReturnTypeGivenArgs(fn, typedSubExprs)
 	return expr, nil
 }
 

--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -135,7 +135,7 @@ func (expr *BinaryExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, er
 	}
 	expr.Left, expr.Right = leftTyped, rightTyped
 	expr.fn = fn.(BinOp)
-	expr.typ = overloadReturnTypeGivenArgs(fn, typedSubExprs)
+	expr.typ = fn.returnType()(typedSubExprs)
 	return expr, nil
 }
 
@@ -450,7 +450,7 @@ func (expr *FuncExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, erro
 		expr.Exprs[i] = subExpr
 	}
 	expr.fn = builtin
-	expr.typ = overloadReturnTypeGivenArgs(builtin, typedSubExprs)
+	expr.typ = builtin.returnType()(typedSubExprs)
 	return expr, nil
 }
 
@@ -619,7 +619,7 @@ func (expr *UnaryExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, err
 	}
 	expr.Expr = exprTyped
 	expr.fn = fn.(UnaryOp)
-	expr.typ = overloadReturnTypeGivenArgs(fn, typedSubExprs)
+	expr.typ = fn.returnType()(typedSubExprs)
 	return expr, nil
 }
 

--- a/pkg/sql/parser/window_builtins.go
+++ b/pkg/sql/parser/window_builtins.go
@@ -165,7 +165,7 @@ func makeWindowBuiltin(in ArgTypes, ret Type, f func([]Type) WindowFunc) Builtin
 		impure:     true,
 		class:      WindowClass,
 		Types:      in,
-		ReturnType: fixedReturnType{ret},
+		ReturnType: fixedReturnType(ret),
 		WindowFunc: f,
 	}
 }

--- a/pkg/sql/parser/window_builtins.go
+++ b/pkg/sql/parser/window_builtins.go
@@ -160,7 +160,7 @@ var windows = map[string][]Builtin{
 	}, TypesAnyNonArray...),
 }
 
-func makeWindowBuiltin(in ArgTypes, ret Type, f func() WindowFunc) Builtin {
+func makeWindowBuiltin(in ArgTypes, ret Type, f func([]Type) WindowFunc) Builtin {
 	return Builtin{
 		impure:     true,
 		class:      WindowClass,
@@ -229,7 +229,7 @@ func (w *aggregateWindowFunc) Compute(wf WindowFrame) (Datum, error) {
 // counting from 1.
 type rowNumberWindow struct{}
 
-func newRowNumberWindow() WindowFunc {
+func newRowNumberWindow(_ []Type) WindowFunc {
 	return &rowNumberWindow{}
 }
 
@@ -242,7 +242,7 @@ type rankWindow struct {
 	peerRes *DInt
 }
 
-func newRankWindow() WindowFunc {
+func newRankWindow(_ []Type) WindowFunc {
 	return &rankWindow{}
 }
 
@@ -259,7 +259,7 @@ type denseRankWindow struct {
 	peerRes   *DInt
 }
 
-func newDenseRankWindow() WindowFunc {
+func newDenseRankWindow(_ []Type) WindowFunc {
 	return &denseRankWindow{}
 }
 
@@ -277,7 +277,7 @@ type percentRankWindow struct {
 	peerRes *DFloat
 }
 
-func newPercentRankWindow() WindowFunc {
+func newPercentRankWindow(_ []Type) WindowFunc {
 	return &percentRankWindow{}
 }
 
@@ -302,7 +302,7 @@ type cumulativeDistWindow struct {
 	peerRes *DFloat
 }
 
-func newCumulativeDistWindow() WindowFunc {
+func newCumulativeDistWindow(_ []Type) WindowFunc {
 	return &cumulativeDistWindow{}
 }
 
@@ -323,7 +323,7 @@ type ntileWindow struct {
 	remainder      int   // (total rows) % (bucket num)
 }
 
-func newNtileWindow() WindowFunc {
+func newNtileWindow(_ []Type) WindowFunc {
 	return &ntileWindow{}
 }
 
@@ -387,8 +387,8 @@ func newLeadLagWindow(forward, withOffset, withDefault bool) WindowFunc {
 	}
 }
 
-func makeLeadLagWindowConstructor(forward, withOffset, withDefault bool) func() WindowFunc {
-	return func() WindowFunc {
+func makeLeadLagWindowConstructor(forward, withOffset, withDefault bool) func(_ []Type) WindowFunc {
+	return func(_ []Type) WindowFunc {
 		return newLeadLagWindow(forward, withOffset, withDefault)
 	}
 }
@@ -421,7 +421,7 @@ func (w *leadLagWindow) Compute(wf WindowFrame) (Datum, error) {
 // firstValueWindow returns value evaluated at the row that is the first row of the window frame.
 type firstValueWindow struct{}
 
-func newFirstValueWindow() WindowFunc {
+func newFirstValueWindow(_ []Type) WindowFunc {
 	return &firstValueWindow{}
 }
 
@@ -432,7 +432,7 @@ func (firstValueWindow) Compute(wf WindowFrame) (Datum, error) {
 // lastValueWindow returns value evaluated at the row that is the last row of the window frame.
 type lastValueWindow struct{}
 
-func newLastValueWindow() WindowFunc {
+func newLastValueWindow(_ []Type) WindowFunc {
 	return &lastValueWindow{}
 }
 
@@ -444,7 +444,7 @@ func (lastValueWindow) Compute(wf WindowFrame) (Datum, error) {
 // (counting from 1). Returns null if no such row.
 type nthValueWindow struct{}
 
-func newNthValueWindow() WindowFunc {
+func newNthValueWindow(_ []Type) WindowFunc {
 	return &nthValueWindow{}
 }
 

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1071,9 +1071,9 @@ CREATE TABLE pg_catalog.pg_proc (
 
 				var retType parser.Datum
 				isRetSet := false
-				if builtin.ReturnType != nil {
+				if fixedRetType := builtin.FixedReturnType(); fixedRetType != nil {
 					var retOid oid.Oid
-					if t, ok := builtin.ReturnType.(parser.TTable); ok {
+					if t, ok := fixedRetType.(parser.TTable); ok {
 						isRetSet = true
 						// Functions returning tables with zero, or more than one
 						// columns are marked to return "anyelement"
@@ -1086,7 +1086,7 @@ CREATE TABLE pg_catalog.pg_proc (
 							retOid = t.Cols[0].Oid()
 						}
 					} else {
-						retOid = builtin.ReturnType.Oid()
+						retOid = fixedRetType.Oid()
 					}
 					retType = parser.NewDOid(parser.DInt(retOid))
 				}
@@ -1107,12 +1107,11 @@ CREATE TABLE pg_catalog.pg_proc (
 					argType := argTypes.Types()[0]
 					oid := argType.Oid()
 					variadicType = parser.NewDOid(parser.DInt(oid))
-				case parser.AnyType:
+				case parser.HomogeneousType:
 					argmodes = proArgModeVariadic
 					argType := parser.TypeAny
 					oid := argType.Oid()
 					variadicType = parser.NewDOid(parser.DInt(oid))
-
 				default:
 					argmodes = parser.DNull
 					variadicType = oidZero

--- a/pkg/sql/rsg_test.go
+++ b/pkg/sql/rsg_test.go
@@ -128,7 +128,7 @@ func TestRandomSyntaxFunctions(t *testing.T) {
 			for _, arg := range ft {
 				args = append(args, r.GenerateRandomArg(arg.Typ))
 			}
-		case parser.AnyType:
+		case parser.HomogeneousType:
 			for i := r.Intn(5); i > 0; i-- {
 				var typ parser.Type
 				switch r.Intn(4) {

--- a/pkg/sql/testdata/orms
+++ b/pkg/sql/testdata/orms
@@ -28,3 +28,43 @@ SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_v
     WHERE n.nspname = 'public'
     GROUP BY 1;
 ----
+
+
+## 12207
+statement ok
+CREATE TABLE customers (
+    name STRING PRIMARY KEY, 
+    id INT, 
+    INDEX (id)
+)
+
+statement ok 
+INSERT INTO customers VALUES ('jordan', 12), ('cuong', 13)
+
+query TBBTTTT colnames
+SELECT i.relname AS name,
+       ix.indisprimary AS PRIMARY,
+       ix.indisunique AS UNIQUE,
+       ix.indkey AS indkey,
+       ARRAY_AGG(a.attnum) AS column_indexes,
+       ARRAY_AGG(a.attname) AS column_names,
+       pg_get_indexdef(ix.indexrelid) AS definition
+FROM pg_class t,
+     pg_class i,
+     pg_index ix,
+     pg_attribute a
+WHERE t.oid = ix.indrelid
+AND   i.oid = ix.indexrelid
+AND   a.attrelid = t.oid
+AND   t.relkind = 'r'
+AND   t.relname = 'customers' -- this query is run once for each table
+GROUP BY i.relname,
+         ix.indexrelid,
+         ix.indisprimary,
+         ix.indisunique,
+         ix.indkey
+ORDER BY i.relname
+----
+name              PRIMARY  UNIQUE  indkey  column_indexes  column_names  definition
+customers_id_idx  false    false   {2}     {1,2}           {name,id}     CREATE INDEX customers_id_idx ON test.customers (id ASC)
+primary           true     true    {1}     {1,2}           {name,id}     CREATE UNIQUE INDEX "primary" ON test.customers (name ASC)

--- a/pkg/sql/testdata/pgoidtype
+++ b/pkg/sql/testdata/pgoidtype
@@ -33,8 +33,8 @@ SELECT 'blah( )'::REGPROC
 query error unknown function: "blah\(, \)"\(\)
 SELECT 'blah(, )'::REGPROC
 
-query error more than one function named 'max'
-SELECT 'max'::REGPROC
+query error more than one function named 'sqrt'
+SELECT 'sqrt'::REGPROC
 
 query OOOO
 SELECT 'array_in'::REGPROC, 'array_in(a,b,c)'::REGPROC, 'pg_catalog.array_in'::REGPROC, 'pg_catalog.array_in( a ,b, c )'::REGPROC


### PR DESCRIPTION
Supersedes #12644 and addresses all comments.

Fixes #12207.

This change introduces the notion of a `returnTyper` type-level function for
overload implementations. The purpose of this is to more clearly express cases
where overloads return types are based on their input argument types.
This was previously possible but was messy and inextensible.

The change also adjusts aggregate constructors take their parameter types.
This is useful for when aggregate behavior needs to change depending on
the input parameters. For instance, the same constructor needs to be
used for `array_agg(string)` and `array_agg(name)`, but their runtime
behavior needs to be different.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13209)
<!-- Reviewable:end -->
