### PR TITLE
sql: fix/complete the behavior of EXPLAIN(PLAN).

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -723,9 +723,10 @@ func Example_sql() {
 	// system
 	// t
 	// sql -e explain select 3
-	// 1 row
+	// 2 rows
 	// Level	Type	Field	Description
-	// 0	nullrow
+	// 0	render
+	// 1	nullrow
 	// sql -e select 1; select 2
 	// 1 row
 	// 1
@@ -871,16 +872,18 @@ func Example_sql_format() {
 	// +-------+
 	// (1 row)
 	// sql --pretty -e explain(indent) select s from t.t union all select s from t.t
-	// +-------+--------+-------+-----------------+
-	// | Level |  Type  | Field |   Description   |
-	// +-------+--------+-------+-----------------+
-	// |     0 | append |       |  -> append      |
-	// |     1 | scan   |       |    -> scan      |
-	// |     1 |        | table |       t@primary |
-	// |     1 | scan   |       |    -> scan      |
-	// |     1 |        | table |       t@primary |
-	// +-------+--------+-------+-----------------+
-	// (5 rows)
+	// +-------+--------+-------+--------------------+
+	// | Level |  Type  | Field |    Description     |
+	// +-------+--------+-------+--------------------+
+	// |     0 | append |       |  -> append         |
+	// |     1 | render |       |    -> render       |
+	// |     2 | scan   |       |       -> scan      |
+	// |     2 |        | table |          t@primary |
+	// |     1 | render |       |    -> render       |
+	// |     2 | scan   |       |       -> scan      |
+	// |     2 |        | table |          t@primary |
+	// +-------+--------+-------+--------------------+
+	// (7 rows)
 }
 
 func Example_user() {

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -48,11 +48,10 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, error) 
 	expanded := true
 	normalizeExprs := true
 	explainer := explainer{
-		showMetadata:  false,
-		showSelectTop: false,
-		showExprs:     false,
-		showTypes:     false,
-		doIndent:      false,
+		showMetadata: false,
+		showExprs:    false,
+		showTypes:    false,
+		doIndent:     false,
 	}
 
 	for _, opt := range n.Options {
@@ -68,14 +67,12 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, error) 
 			explainer.showExprs = true
 			explainer.showTypes = true
 			// TYPES implies METADATA.
-			explainer.showSelectTop = true
 			explainer.showMetadata = true
 		} else if strings.EqualFold(opt, "INDENT") {
 			explainer.doIndent = true
 		} else if strings.EqualFold(opt, "SYMVARS") {
 			explainer.symbolicVars = true
 		} else if strings.EqualFold(opt, "METADATA") {
-			explainer.showSelectTop = true
 			explainer.showMetadata = true
 		} else if strings.EqualFold(opt, "QUALIFY") {
 			explainer.qualifyNames = true
@@ -85,7 +82,6 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, error) 
 			// VERBOSE implies QUALIFY.
 			explainer.qualifyNames = true
 			// VERBOSE implies METADATA.
-			explainer.showSelectTop = true
 			explainer.showMetadata = true
 		} else if strings.EqualFold(opt, "EXPRS") {
 			explainer.showExprs = true

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -48,10 +48,6 @@ type explainer struct {
 	// expressions and result columns.
 	showTypes bool
 
-	// showSelectTop indicates whether intermediate selectTopNodes
-	// are rendered.
-	showSelectTop bool
-
 	// level is the current depth in the tree of planNodes.
 	level int
 
@@ -140,11 +136,10 @@ func (p *planner) populateExplain(e *explainer, v *valuesNode, plan planNode) er
 func planToString(plan planNode) string {
 	var buf bytes.Buffer
 	e := explainer{
-		showMetadata:  true,
-		showTypes:     true,
-		showExprs:     true,
-		showSelectTop: true,
-		fmtFlags:      parser.FmtExpr(parser.FmtSimple, true, true, true),
+		showMetadata: true,
+		showTypes:    true,
+		showExprs:    true,
+		fmtFlags:     parser.FmtExpr(parser.FmtSimple, true, true, true),
 		makeRow: func(level int, name, field, description string, plan planNode) {
 			if field != "" {
 				field = "." + field
@@ -181,13 +176,6 @@ func (e *explainer) expr(nodeName, fieldName string, n int, expr parser.Expr) {
 
 // enterNode implements the planObserver interface.
 func (e *explainer) enterNode(name string, plan planNode) bool {
-	if !e.showSelectTop && name == "select" {
-		return true
-	}
-	if !e.showExprs && !e.showMetadata && (name == "render" || name == "filter") {
-		return true
-	}
-
 	desc := ""
 	if e.doIndent {
 		desc = fmt.Sprintf("%*s-> %s", e.level*3, " ", name)
@@ -208,12 +196,6 @@ func (e *explainer) attr(nodeName, fieldName, attr string) {
 
 // leaveNode implements the planObserver interface.
 func (e *explainer) leaveNode(name string) {
-	if !e.showSelectTop && name == "select" {
-		return
-	}
-	if !e.showExprs && !e.showMetadata && (name == "render" || name == "filter") {
-		return
-	}
 	e.level--
 }
 

--- a/pkg/sql/testdata/delete
+++ b/pkg/sql/testdata/delete
@@ -137,8 +137,9 @@ EXPLAIN DELETE FROM unindexed
 Level  Type    Field  Description
 0      delete
 0              from   unindexed
-1      scan
-1              table  unindexed@primary
+1      render
+2      scan
+2              table  unindexed@primary
 
 query II colnames
 SELECT k, v FROM unindexed

--- a/pkg/sql/testdata/distinct
+++ b/pkg/sql/testdata/distinct
@@ -34,8 +34,9 @@ query ITTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz
 ----
 0  distinct
-1  scan
-1            table  xyz@primary
+1  render
+2  scan
+2            table  xyz@primary
 
 query II
 SELECT DISTINCT y, z FROM xyz ORDER BY z
@@ -51,9 +52,10 @@ EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY z
 ----
 0  distinct
 0            key    y, z
-1  scan
-1            table  xyz@foo
-1            spans  ALL
+1  render
+2  scan
+2            table  xyz@foo
+2            spans  ALL
 
 query II
 SELECT DISTINCT y, z FROM xyz ORDER BY y, z
@@ -71,9 +73,10 @@ EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y
 0            key    y
 1  sort
 1            order  +y
-2  scan
-2            table  xyz@foo
-2            spans  ALL
+2  render
+3  scan
+3            table  xyz@foo
+3            spans  ALL
 
 query II
 SELECT DISTINCT y, z FROM xyz ORDER BY y, z
@@ -91,9 +94,10 @@ EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y, z
 0            key    y, z
 1  sort
 1            order  +y,+z
-2  scan
-2            table  xyz@foo
-2            spans  ALL
+2  render
+3  scan
+3            table  xyz@foo
+3            spans  ALL
 
 query I
 SELECT DISTINCT y + z FROM xyz ORDER by (y + z)
@@ -109,8 +113,9 @@ EXPLAIN SELECT DISTINCT y + z FROM xyz ORDER BY y + z
 0            key    y + z
 1  sort
 1            order  +"y + z"
-2  scan
-2            table  xyz@primary
+2  render
+3  scan
+3            table  xyz@primary
 
 query I
 SELECT DISTINCT y AS w FROM xyz ORDER by z
@@ -125,9 +130,10 @@ EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY z
 0  distinct
 1  nosort
 1            order  +z
-2  scan
-2            table  xyz@foo
-2            spans  ALL
+2  render
+3  scan
+3            table  xyz@foo
+3            spans  ALL
 
 query I
 SELECT DISTINCT y AS w FROM xyz ORDER by y
@@ -143,9 +149,10 @@ EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY y
 0            key    w
 1  sort
 1            order  +w
-2  scan
-2            table  xyz@foo
-2            spans  ALL
+2  render
+3  scan
+3            table  xyz@foo
+3            spans  ALL
 
 # Insert NULL values for z.
 statement ok

--- a/pkg/sql/testdata/explain
+++ b/pkg/sql/testdata/explain
@@ -2,7 +2,8 @@ query ITTT colnames
 EXPLAIN (PLAN) SELECT 1
 ----
 Level  Type    Field Description
-0      nullrow
+0      render
+1      nullrow
 
 query ITTTTT colnames
 EXPLAIN (PLAN, METADATA) SELECT 1
@@ -123,10 +124,11 @@ EXPLAIN SHOW DATABASES
 ----
 0  sort
 0                 order   +Database
-1  virtual table
-1                 source  information_schema.schemata
-2  values
-2                 size    4 columns, 5 rows
+1  render
+2  virtual table
+2                 source  information_schema.schemata
+3  values
+3                 size    4 columns, 5 rows
 
 query ITTT
 EXPLAIN SHOW TABLES
@@ -223,5 +225,6 @@ EXPLAIN SHOW CONSTRAINTS FROM foo
 query ITTT
 EXPLAIN SHOW USERS
 ----
-0  scan
-0        table  users@primary
+0  render
+1  scan
+1        table  users@primary

--- a/pkg/sql/testdata/join
+++ b/pkg/sql/testdata/join
@@ -661,7 +661,7 @@ EXPLAIN (METADATA) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < 
 # Ensure that the ordering information for the result of joins is sane. (#12037)
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES (9, 1), (8, 2)) AS a (u, k) ORDER BY k)
-                                INNER JOIN (VALUES (1, 1), (2, 2)) AS b (k, w) USING (k) ORDER BY u
+				INNER JOIN (VALUES (1, 1), (2, 2)) AS b (k, w) USING (k) ORDER BY u
 ----
 0  sort                                 (k, u, w)                                        +u
 0          order     +u
@@ -683,49 +683,49 @@ CREATE TABLE customers(id INT PRIMARY KEY NOT NULL); CREATE TABLE orders(id INT,
 
 query ITTT
 SELECT * FROM [EXPLAIN SELECT
-           NULL::text  AS pktable_cat,
-           pkn.nspname AS pktable_schem,
-           pkc.relname AS pktable_name,
-           pka.attname AS pkcolumn_name,
-           NULL::text  AS fktable_cat,
-           fkn.nspname AS fktable_schem,
-           fkc.relname AS fktable_name,
-           fka.attname AS fkcolumn_name,
-           pos.n       AS key_seq,
-           CASE con.confupdtype
-                    WHEN 'c' THEN 0
-                    WHEN 'n' THEN 2
-                    WHEN 'd' THEN 4
-                    WHEN 'r' THEN 1
-                    WHEN 'a' THEN 3
-                    ELSE NULL
-           END AS update_rule,
-           CASE con.confdeltype
-                    WHEN 'c' THEN 0
-                    WHEN 'n' THEN 2
-                    WHEN 'd' THEN 4
-                    WHEN 'r' THEN 1
-                    WHEN 'a' THEN 3
-                    ELSE NULL
-           END          AS delete_rule,
-           con.conname  AS fk_name,
-           pkic.relname AS pk_name,
-           CASE
-                    WHEN con.condeferrable
-                    AND      con.condeferred THEN 5
-                    WHEN con.condeferrable THEN 6
-                    ELSE 7
-           END AS deferrability
+	   NULL::text  AS pktable_cat,
+	   pkn.nspname AS pktable_schem,
+	   pkc.relname AS pktable_name,
+	   pka.attname AS pkcolumn_name,
+	   NULL::text  AS fktable_cat,
+	   fkn.nspname AS fktable_schem,
+	   fkc.relname AS fktable_name,
+	   fka.attname AS fkcolumn_name,
+	   pos.n       AS key_seq,
+	   CASE con.confupdtype
+		    WHEN 'c' THEN 0
+		    WHEN 'n' THEN 2
+		    WHEN 'd' THEN 4
+		    WHEN 'r' THEN 1
+		    WHEN 'a' THEN 3
+		    ELSE NULL
+	   END AS update_rule,
+	   CASE con.confdeltype
+		    WHEN 'c' THEN 0
+		    WHEN 'n' THEN 2
+		    WHEN 'd' THEN 4
+		    WHEN 'r' THEN 1
+		    WHEN 'a' THEN 3
+		    ELSE NULL
+	   END          AS delete_rule,
+	   con.conname  AS fk_name,
+	   pkic.relname AS pk_name,
+	   CASE
+		    WHEN con.condeferrable
+		    AND      con.condeferred THEN 5
+		    WHEN con.condeferrable THEN 6
+		    ELSE 7
+	   END AS deferrability
   FROM     pg_catalog.pg_namespace pkn,
-           pg_catalog.pg_class pkc,
-           pg_catalog.pg_attribute pka,
-           pg_catalog.pg_namespace fkn,
-           pg_catalog.pg_class fkc,
-           pg_catalog.pg_attribute fka,
-           pg_catalog.pg_constraint con,
-           pg_catalog.generate_series(1, 32) pos(n),
-           pg_catalog.pg_depend dep,
-           pg_catalog.pg_class pkic
+	   pg_catalog.pg_class pkc,
+	   pg_catalog.pg_attribute pka,
+	   pg_catalog.pg_namespace fkn,
+	   pg_catalog.pg_class fkc,
+	   pg_catalog.pg_attribute fka,
+	   pg_catalog.pg_constraint con,
+	   pg_catalog.generate_series(1, 32) pos(n),
+	   pg_catalog.pg_depend dep,
+	   pg_catalog.pg_class pkic
   WHERE    pkn.oid = pkc.relnamespace
   AND      pkc.oid = pka.attrelid
   AND      pka.attnum = con.confkey[pos.n]
@@ -743,105 +743,107 @@ SELECT * FROM [EXPLAIN SELECT
   AND      fkn.nspname = 'public'
   AND      fkc.relname = 'orders'
   ORDER BY pkn.nspname,
-           pkc.relname,
-           con.conname,
-           pos.n
+	   pkc.relname,
+	   con.conname,
+	   pos.n
   ] WHERE type <> 'values' AND field <> 'size'
 ----
- 0   sort
- 0                   order      +pktable_schem,+pktable_name,+fk_name,+key_seq
- 1   join
- 1                   type       inner
- 1                   equality   (oid) = (relnamespace)
- 2   virtual table
- 2                   source     pg_catalog.pg_namespace
- 2   join
- 2                   type       inner
- 2                   equality   (oid, oid) = (attrelid, confrelid)
- 3   virtual table
- 3                   source     pg_catalog.pg_class
- 3   join
- 3                   type       inner
- 4   virtual table
- 4                   source     pg_catalog.pg_attribute
- 4   join
- 4                   type       inner
- 4                   equality   (oid) = (relnamespace)
- 5   virtual table
- 5                   source     pg_catalog.pg_namespace
- 5   join
- 5                   type       inner
- 5                   equality   (oid, oid) = (attrelid, conrelid)
- 6   virtual table
- 6                   source     pg_catalog.pg_class
- 6   join
- 6                   type       inner
- 7   virtual table
- 7                   source     pg_catalog.pg_attribute
- 7   join
- 7                   type       inner
- 7                   equality   (oid) = (objid)
- 8   virtual table
- 8                   source     pg_catalog.pg_constraint
- 8   join
- 8                   type       cross
- 9   generator
- 9   join
- 9                   type       inner
- 9                   equality   (refobjid) = (oid)
-10   virtual table
-10                   source     pg_catalog.pg_depend
-10   virtual table
-10                   source     pg_catalog.pg_class
-
-# TODO(knz) Also add a test for the query plan. We can't do this right
-# now, because the plan is very verbose and contains very fragile
-# constants (e.g. the number of rows in pg_catalog tables.
+0   sort
+0                  order     +pktable_schem,+pktable_name,+fk_name,+key_seq
+1   render
+2   join
+2                  type      inner
+2                  equality  (oid) = (relnamespace)
+3   virtual table
+3                  source    pg_catalog.pg_namespace
+3   join
+3                  type      inner
+3                  equality  (oid, oid) = (attrelid, confrelid)
+4   virtual table
+4                  source    pg_catalog.pg_class
+4   join
+4                  type      inner
+5   virtual table
+5                  source    pg_catalog.pg_attribute
+5   join
+5                  type      inner
+5                  equality  (oid) = (relnamespace)
+6   filter
+7   virtual table
+7                  source    pg_catalog.pg_namespace
+6   join
+6                  type      inner
+6                  equality  (oid, oid) = (attrelid, conrelid)
+7   filter
+8   virtual table
+8                  source    pg_catalog.pg_class
+7   join
+7                  type      inner
+8   virtual table
+8                  source    pg_catalog.pg_attribute
+8   join
+8                  type      inner
+8                  equality  (oid) = (objid)
+9   filter
+10  virtual table
+10                 source    pg_catalog.pg_constraint
+9   join
+9                  type      cross
+10  generator
+10  join
+10                 type      inner
+10                 equality  (refobjid) = (oid)
+11  filter
+12  virtual table
+12                 source    pg_catalog.pg_depend
+11  filter
+12  virtual table
+12                 source    pg_catalog.pg_class
 
 query TTTTTTTTIIITTI
 SELECT     NULL::text  AS pktable_cat,
-           pkn.nspname AS pktable_schem,
-           pkc.relname AS pktable_name,
-           pka.attname AS pkcolumn_name,
-           NULL::text  AS fktable_cat,
-           fkn.nspname AS fktable_schem,
-           fkc.relname AS fktable_name,
-           fka.attname AS fkcolumn_name,
-           pos.n       AS key_seq,
-           CASE con.confupdtype
-                    WHEN 'c' THEN 0
-                    WHEN 'n' THEN 2
-                    WHEN 'd' THEN 4
-                    WHEN 'r' THEN 1
-                    WHEN 'a' THEN 3
-                    ELSE NULL
-           END AS update_rule,
-           CASE con.confdeltype
-                    WHEN 'c' THEN 0
-                    WHEN 'n' THEN 2
-                    WHEN 'd' THEN 4
-                    WHEN 'r' THEN 1
-                    WHEN 'a' THEN 3
-                    ELSE NULL
-           END          AS delete_rule,
-           con.conname  AS fk_name,
-           pkic.relname AS pk_name,
-           CASE
-                    WHEN con.condeferrable
-                    AND      con.condeferred THEN 5
-                    WHEN con.condeferrable THEN 6
-                    ELSE 7
-           END AS deferrability
+	   pkn.nspname AS pktable_schem,
+	   pkc.relname AS pktable_name,
+	   pka.attname AS pkcolumn_name,
+	   NULL::text  AS fktable_cat,
+	   fkn.nspname AS fktable_schem,
+	   fkc.relname AS fktable_name,
+	   fka.attname AS fkcolumn_name,
+	   pos.n       AS key_seq,
+	   CASE con.confupdtype
+		    WHEN 'c' THEN 0
+		    WHEN 'n' THEN 2
+		    WHEN 'd' THEN 4
+		    WHEN 'r' THEN 1
+		    WHEN 'a' THEN 3
+		    ELSE NULL
+	   END AS update_rule,
+	   CASE con.confdeltype
+		    WHEN 'c' THEN 0
+		    WHEN 'n' THEN 2
+		    WHEN 'd' THEN 4
+		    WHEN 'r' THEN 1
+		    WHEN 'a' THEN 3
+		    ELSE NULL
+	   END          AS delete_rule,
+	   con.conname  AS fk_name,
+	   pkic.relname AS pk_name,
+	   CASE
+		    WHEN con.condeferrable
+		    AND      con.condeferred THEN 5
+		    WHEN con.condeferrable THEN 6
+		    ELSE 7
+	   END AS deferrability
   FROM     pg_catalog.pg_namespace pkn,
-           pg_catalog.pg_class pkc,
-           pg_catalog.pg_attribute pka,
-           pg_catalog.pg_namespace fkn,
-           pg_catalog.pg_class fkc,
-           pg_catalog.pg_attribute fka,
-           pg_catalog.pg_constraint con,
-           pg_catalog.generate_series(1, 32) pos(n),
-           pg_catalog.pg_depend dep,
-           pg_catalog.pg_class pkic
+	   pg_catalog.pg_class pkc,
+	   pg_catalog.pg_attribute pka,
+	   pg_catalog.pg_namespace fkn,
+	   pg_catalog.pg_class fkc,
+	   pg_catalog.pg_attribute fka,
+	   pg_catalog.pg_constraint con,
+	   pg_catalog.generate_series(1, 32) pos(n),
+	   pg_catalog.pg_depend dep,
+	   pg_catalog.pg_class pkic
   WHERE    pkn.oid = pkc.relnamespace
   AND      pkc.oid = pka.attrelid
   AND      pka.attnum = con.confkey[pos.n]
@@ -859,9 +861,9 @@ SELECT     NULL::text  AS pktable_cat,
   AND      fkn.nspname = 'public'
   AND      fkc.relname = 'orders'
   ORDER BY pkn.nspname,
-           pkc.relname,
-           con.conname,
-           pos.n
+	   pkc.relname,
+	   con.conname,
+	   pos.n
 ----
 NULL public customers id NULL public orders cust 1 3 3 fk_cust_ref_customers primary 7
 
@@ -884,13 +886,14 @@ INSERT INTO pairs VALUES (1,1), (1,2), (1,3), (1,4), (1,5), (1,6), (2,3), (2,4),
 query ITTT
 EXPLAIN SELECT * FROM pairs, square WHERE pairs.b = square.n
 ----
-0  join
-0        type      inner
-0        equality  (b) = (n)
-1  scan
-1        table     pairs@primary
-1  scan
-1        table     square@primary
+0  render
+1  join
+1        type      inner
+1        equality  (b) = (n)
+2  scan
+2        table     pairs@primary
+2  scan
+2        table     square@primary
 
 query IIII
 SELECT * FROM pairs, square WHERE pairs.b = square.n

--- a/pkg/sql/testdata/order_by
+++ b/pkg/sql/testdata/order_by
@@ -43,9 +43,10 @@ EXPLAIN SELECT a, b FROM t ORDER BY b
 ----
 0  sort
 0        order  +b
-1  scan
-1        table  t@primary
-1        spans  ALL
+1  render
+2  scan
+2        table  t@primary
+2        spans  ALL
 
 query II
 SELECT a, b FROM t ORDER BY b DESC
@@ -59,9 +60,10 @@ EXPLAIN SELECT a, b FROM t ORDER BY b DESC
 ----
 0  sort
 0        order  -b
-1  scan
-1        table  t@primary
-1        spans  ALL
+1  render
+2  scan
+2        table  t@primary
+2        spans  ALL
 
 query I
 SELECT a FROM t ORDER BY 1 DESC
@@ -77,9 +79,10 @@ EXPLAIN SELECT a, b FROM t ORDER BY b LIMIT 2
 1  sort
 1         order     +b
 1         strategy  top 2
-2  scan
-2         table     t@primary
-2         spans     ALL
+2  render
+3  scan
+3         table     t@primary
+3         spans     ALL
 
 query II
 SELECT a, b FROM t ORDER BY b DESC LIMIT 2
@@ -95,9 +98,10 @@ EXPLAIN SELECT DISTINCT a FROM t ORDER BY b LIMIT 2
 2  sort
 2            order     +b
 2            strategy  iterative
-3  scan
-3            table     t@primary
-3            spans     ALL
+3  render
+4  scan
+4            table     t@primary
+4            spans     ALL
 
 query I
 SELECT DISTINCT a FROM t ORDER BY b DESC LIMIT 2
@@ -149,27 +153,30 @@ EXPLAIN SELECT b FROM t ORDER BY a DESC
 ----
 0  nosort
 0           order  -a
-1  revscan
-1           table  t@primary
-1           spans  ALL
+1  render
+2  revscan
+2           table  t@primary
+2           spans  ALL
 
 query ITTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b ASC
 ----
 0  nosort
 0           order  -a,+b
-1  revscan
-1           table  t@primary
-1           spans  ALL
+1  render
+2  revscan
+2           table  t@primary
+2           spans  ALL
 
 query ITTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b DESC
 ----
 0  nosort
 0           order  -a,-b
-1  revscan
-1           table  t@primary
-1           spans  ALL
+1  render
+2  revscan
+2           table  t@primary
+2           spans  ALL
 
 statement ok
 INSERT INTO t VALUES (4, 7), (5, 7)
@@ -344,18 +351,20 @@ EXPLAIN (DEBUG) SELECT a, b FROM abc ORDER BY b, a
 query ITTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, a
 ----
-0  scan
-0        table  abc@ba
-0        spans  ALL
+0  render
+1  scan
+1        table  abc@ba
+1        spans  ALL
 
 # The non-unique index ba includes column c (required to make the keys unique)
 # so the results will already be sorted.
 query ITTT
 EXPLAIN SELECT a, b, c FROM abc ORDER BY b, a, c
 ----
-0  scan
-0        table  abc@ba
-0        spans  ALL
+0  render
+1  scan
+1        table  abc@ba
+1        spans  ALL
 
 # We use the WHERE condition to force the use of index ba.
 query ITTT
@@ -387,9 +396,10 @@ EXPLAIN SELECT a, b FROM abc ORDER BY b, c
 ----
 0  nosort
 0          order  +b,+c
-1  scan
-1          table  abc@bc
-1          spans  ALL
+1  render
+2  scan
+2          table  abc@bc
+2          spans  ALL
 
 query ITTTTT
 EXPLAIN(VERBOSE) SELECT a, b FROM abc ORDER BY b, c
@@ -409,18 +419,20 @@ EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a
 ----
 0  nosort
 0          order  +b,+c,+a
-1  scan
-1          table  abc@bc
-1          spans  ALL
+1  render
+2  scan
+2          table  abc@bc
+2          spans  ALL
 
 query ITTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a DESC
 ----
 0  nosort
 0          order  +b,+c,-a
-1  scan
-1          table  abc@bc
-1          spans  ALL
+1  render
+2  scan
+2          table  abc@bc
+2          spans  ALL
 
 query ITTT
 EXPLAIN (DEBUG) SELECT b, c FROM abc ORDER BY b, c
@@ -445,9 +457,10 @@ EXPLAIN (DEBUG) SELECT a FROM abc ORDER BY a DESC
 query ITTT
 EXPLAIN SELECT a FROM abc ORDER BY a DESC
 ----
-0  revscan
-0           table  abc@primary
-0           spans  ALL
+0  render
+1  revscan
+1           table  abc@primary
+1           spans  ALL
 
 query I
 SELECT a FROM abc ORDER BY a DESC
@@ -468,16 +481,18 @@ SELECT a FROM abc ORDER BY a DESC OFFSET 1
 query ITTT
 EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c
 ----
-0  scan
-0        table  abc@bc
-0        spans  /2-/3
+0  render
+1  scan
+1        table  abc@bc
+1        spans  /2-/3
 
 query ITTT
 EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c DESC
 ----
-0  revscan
-0           table  abc@bc
-0           spans  /2-/3
+0  render
+1  revscan
+1           table  abc@bc
+1           spans  /2-/3
 
 statement ok
 CREATE TABLE bar (id INT PRIMARY KEY, baz STRING, UNIQUE INDEX i_bar (baz));
@@ -507,30 +522,34 @@ INSERT INTO abcd VALUES (1, 4, 2, 3), (2, 3, 4, 1), (3, 2, 1, 2), (4, 4, 1, 1)
 query ITTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c
 ----
-0  scan
-0        table  abcd@abc
-0        spans  /1/4-/1/5
+0  render
+1  scan
+1        table  abcd@abc
+1        spans  /1/4-/1/5
 
 query ITTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c, b, a
 ----
-0  scan
-0        table  abcd@abc
-0        spans  /1/4-/1/5
+0  render
+1  scan
+1        table  abcd@abc
+1        spans  /1/4-/1/5
 
 query ITTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, a, c
 ----
-0  scan
-0        table  abcd@abc
-0        spans  /1/4-/1/5
+0  render
+1  scan
+1        table  abcd@abc
+1        spans  /1/4-/1/5
 
 query ITTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, c, a
 ----
-0  scan
-0        table  abcd@abc
-0        spans  /1/4-/1/5
+0  render
+1  scan
+1        table  abcd@abc
+1        spans  /1/4-/1/5
 
 statement ok
 CREATE TABLE nan (id INT PRIMARY KEY, x REAL);

--- a/pkg/sql/testdata/select_index
+++ b/pkg/sql/testdata/select_index
@@ -111,17 +111,18 @@ EXPLAIN (DEBUG) SELECT a FROM t WHERE a in (2, 3) ORDER BY a DESC
 query ITTT
 EXPLAIN SELECT * FROM t x JOIN t y USING(b) WHERE x.b < '3'
 ----
-0   join
-0                type       inner
-0                equality   (b) = (b)
-1   index-join
-2   scan
-2                table      t@bc
-2                spans      /#-/"3"
-2   scan
-2                table      t@primary
-1   scan
-1                table      t@primary
+0  render
+1  join
+1              type      inner
+1              equality  (b) = (b)
+2  index-join
+3  scan
+3              table     t@bc
+3              spans     /#-/"3"
+3  scan
+3              table     t@primary
+2  scan
+2              table     t@primary
 
 statement ok
 TRUNCATE TABLE t
@@ -149,7 +150,8 @@ EXPLAIN (DEBUG) SELECT * FROM t WHERE a > 1 AND b > 'b'
 query ITTT
 EXPLAIN SELECT * FROM t WHERE a > 1 AND a < 2
 ----
-0 empty
+0 render
+1 empty
 
 query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t WHERE a = 1 AND 'a' < b AND 'c' > b
@@ -236,7 +238,8 @@ EXPLAIN (DEBUG) SELECT * FROM t@ab WHERE a + 1 = 4
 query ITTT
 EXPLAIN SELECT * FROM t WHERE a = 1 AND false
 ----
-0 empty
+0 render
+1 empty
 
 # Make sure that mixed type comparison operations are not used
 # for selecting indexes.
@@ -270,58 +273,66 @@ SELECT b FROM t WHERE c > 4.0 AND a < 4
 query ITTT
 EXPLAIN SELECT a FROM t WHERE c > 1
 ----
-0  scan
-0        table  t@bc
-0        spans  ALL
+0  render
+1  scan
+1        table  t@bc
+1        spans  ALL
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE c < 1 AND b < 5
 ----
-0  scan
-0        table  t@bc
-0        spans  /#-/4/1
+0  render
+1  scan
+1        table  t@bc
+1        spans  /#-/4/1
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE c > 1.0
 ----
-0  scan
-0        table  t@bc
-0        spans  ALL
+0  render
+1  scan
+1        table  t@bc
+1        spans  ALL
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE c < 1.0
 ----
-0  scan
-0        table  t@bc
-0        spans  ALL
+0  render
+1  scan
+1        table  t@bc
+1        spans  ALL
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE c > 1.0 AND b < 5
 ----
-0  scan
-0        table  t@bc
-0        spans  /#-/5
+0  render
+1  scan
+1        table  t@bc
+1        spans  /#-/5
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE b < 5.0 AND c < 1
 ----
-0  scan
-0        table  t@bc
-0        spans  /#-/4/1
+0  render
+1  scan
+1        table  t@bc
+1        spans  /#-/4/1
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE (b, c) = (5, 1)
 ----
-0  scan
-0        table  t@bc
-0        spans  /5/1-/5/2
+0  render
+1  scan
+1        table  t@bc
+1        spans  /5/1-/5/2
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE (b, c) = (5.0, 1)
 ----
-0  scan
-0        table  t@bc
-0        spans  /5/1-/5/2
+0  render
+1  scan
+1        table  t@bc
+1        spans  /5/1-/5/2
 
 query error tuples \(b, c\), \(5.1, 1\) are not the same type: expected 5.1 to be of type int, found type decimal
 EXPLAIN SELECT a FROM t WHERE (b, c) = (5.1, 1)
@@ -329,9 +340,10 @@ EXPLAIN SELECT a FROM t WHERE (b, c) = (5.1, 1)
 query ITTT
 EXPLAIN SELECT a FROM t WHERE b IN (5.0, 1)
 ----
-0  scan
-0        table  t@b_desc
-0        spans  /-6-/-5 /-2-/-1
+0  render
+1  scan
+1        table  t@b_desc
+1        spans  /-6-/-5 /-2-/-1
 
 statement ok
 CREATE TABLE abcd (
@@ -348,16 +360,18 @@ CREATE TABLE abcd (
 query ITTT
 EXPLAIN SELECT b FROM abcd WHERE (a, b) = (1, 4)
 ----
-0  scan
-0        table  abcd@abcd
-0        spans  /1/4-/1/5
+0  render
+1  scan
+1        table  abcd@abcd
+1        spans  /1/4-/1/5
 
 query ITTT
 EXPLAIN SELECT b FROM abcd WHERE (a, b) IN ((1, 4), (2, 9))
 ----
-0  scan
-0        table  abcd@abcd
-0        spans  /1/4-/1/5 /2/9-/2/10
+0  render
+1  scan
+1        table  abcd@abcd
+1        spans  /1/4-/1/5 /2/9-/2/10
 
 statement ok
 CREATE TABLE ab (
@@ -383,6 +397,7 @@ SELECT i, s FROM ab@baz WHERE (i, s) < (1, 'c')
 query ITTT
 EXPLAIN SELECT i, s FROM ab@baz WHERE (i, s) < (1, 'c')
 ----
-0  scan
-0        table  ab@baz
-0        spans  /#-/1/"c"
+0  render
+1  scan
+1        table  ab@baz
+1        spans  /#-/1/"c"

--- a/pkg/sql/testdata/select_index_hints
+++ b/pkg/sql/testdata/select_index_hints
@@ -98,21 +98,23 @@ SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
 query ITTT
 EXPLAIN SELECT b FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
-0  scan
-0        table  abcd@b
-0        spans  ALL
+0  render
+1  scan
+1        table  abcd@b
+1        spans  ALL
 
 # Force index b (non-covering due to WHERE clause)
 
 query ITTT
 EXPLAIN SELECT b FROM abcd@b WHERE c >= 20 AND c <= 30
 ----
-0  index-join
-1  scan
-1              table  abcd@b
-1              spans  ALL
-1  scan
-1              table  abcd@primary
+0  render
+1  index-join
+2  scan
+2              table  abcd@b
+2              spans  ALL
+2  scan
+2              table  abcd@primary
 
 # No hint, should be using index cd
 
@@ -125,9 +127,10 @@ SELECT c, d FROM abcd WHERE c >= 20 AND c < 40
 query ITTT
 EXPLAIN SELECT c, d FROM abcd WHERE c >= 20 AND c < 40
 ----
-0  scan
-0        table  abcd@cd
-0        spans  /20-/40
+0  render
+1  scan
+1        table  abcd@cd
+1        spans  /20-/40
 
 # Force no index
 
@@ -140,9 +143,10 @@ SELECT c, d FROM abcd@primary WHERE c >= 20 AND c < 40
 query ITTT
 EXPLAIN SELECT c, d FROM abcd@primary WHERE c >= 20 AND c < 40
 ----
-0  scan
-0        table  abcd@primary
-0        spans  ALL
+0  render
+1  scan
+1        table  abcd@primary
+1        spans  ALL
 
 # Force index b
 
@@ -155,12 +159,13 @@ SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
 query ITTT
 EXPLAIN SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
 ----
-0  index-join
-1  scan
-1              table  abcd@b
-1              spans  ALL
-1  scan
-1              table  abcd@primary
+0  render
+1  index-join
+2  scan
+2              table  abcd@b
+2              spans  ALL
+2  scan
+2              table  abcd@primary
 
 query error index \"badidx\" not found
 SELECT * FROM abcd@badidx
@@ -181,36 +186,40 @@ EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b} WHERE a >= 20 AND a <= 30
 query ITTT
 EXPLAIN SELECT b, c, d FROM abcd WHERE c = 10
 ----
-0  index-join
-1  scan
-1              table  abcd@cd
-1              spans  /10-/11
-1  scan
-1              table  abcd@primary
+0  render                           
+1  index-join                       
+2  scan                             
+2              table  abcd@cd       
+2              spans  /10-/11       
+2  scan                             
+2              table  abcd@primary  
 
 query ITTT
 EXPLAIN SELECT b, c, d FROM abcd@{NO_INDEX_JOIN} WHERE c = 10
 ----
-0  scan
-0        table  abcd@bcd
-0        hint   no index join
-0        spans  ALL
+0  render
+1  scan
+1        table  abcd@bcd
+1        hint   no index join
+1        spans  ALL
 
 query ITTT
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=bcd,NO_INDEX_JOIN} WHERE c = 10
 ----
-0  scan
-0        table  abcd@bcd
-0        hint   no index join
-0        spans  ALL
+0  render
+1  scan
+1        table  abcd@bcd
+1        hint   no index join
+1        spans  ALL
 
 query ITTT
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=primary,NO_INDEX_JOIN} WHERE c = 10
 ----
-0  scan
-0        table  abcd@primary
-0        hint   no index join
-0        spans  ALL
+0  render
+1  scan
+1        table  abcd@primary
+1        hint   no index join
+1        spans  ALL
 
 query error index \"cd\" is not covering and NO_INDEX_JOIN was specified
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=cd,NO_INDEX_JOIN} WHERE c = 10

--- a/pkg/sql/testdata/subquery
+++ b/pkg/sql/testdata/subquery
@@ -46,7 +46,8 @@ EXPLAIN ALTER TABLE abc SPLIT AT ((SELECT 42))
 0  split
 0           subqueries  1
 1  limit
-2  nullrow
+2  render
+3  nullrow
 
 statement ok
 ALTER TABLE abc SPLIT AT ((SELECT 1))
@@ -73,11 +74,13 @@ SELECT (SELECT a FROM abc)
 query ITTT
 EXPLAIN SELECT EXISTS (SELECT a FROM abc)
 ----
--1           subqueries  1
-0   limit
-1   scan
-1            table       abc@primary
-0   nullrow
+0  render
+0           subqueries  1
+1  limit
+2  render
+3  scan
+3           table       abc@primary
+1  nullrow
 
 query I
 SELECT (SELECT a FROM abc WHERE false)
@@ -282,10 +285,12 @@ EXPLAIN SELECT * FROM (SELECT * FROM (VALUES (1, 8, 8), (3, 1, 1), (2, 4, 4)) AS
 ----
 0  sort
 0          order  +foo1
-1  sort
-1          order  +moo2
-2  values
-2          size   3 columns, 3 rows
+1  render
+2  sort
+2          order  +moo2
+3  render
+4  values
+4          size   3 columns, 3 rows
 
 query II colnames
 SELECT a, b FROM (VALUES (1, 2, 3), (3, 4, 7), (5, 6, 10)) AS foo (a, b, c) WHERE a + b = c
@@ -364,17 +369,20 @@ SELECT col0 FROM tab4 WHERE (col0 <= 0 AND col4 <= 5.38) OR (col4 IN (SELECT col
 query ITTT
 EXPLAIN SELECT col0 FROM tab4 WHERE (col0 <= 0 AND col4 <= 5.38) OR (col4 IN (SELECT col1 FROM tab4 WHERE col1 > 8.27)) AND (col3 <= 5 AND (col3 BETWEEN 7 AND 9))
 ----
-0  index-join
-1  scan
-1              table       tab4@idx_tab4_0
-1              spans       /#-/5.38/1
-1              subqueries  1
+0  render
+1  index-join
+2  scan
+2              table       tab4@idx_tab4_0
+2              spans       /#-/5.38/1
+2              subqueries  1
+3  render
+4  scan
+4              table       tab4@primary
+4              spans       ALL
 2  scan
 2              table       tab4@primary
-2              spans       ALL
-1  scan
-1              table       tab4@primary
-1              subqueries  1
-2  scan
-2              table       tab4@primary
-2              spans       ALL
+2              subqueries  1
+3  render
+4  scan
+4              table       tab4@primary
+4              spans       ALL

--- a/pkg/sql/testdata/union
+++ b/pkg/sql/testdata/union
@@ -138,19 +138,23 @@ query ITTT rowsort
 EXPLAIN SELECT v FROM uniontest UNION SELECT k FROM uniontest
 ----
 0  union
-1  scan
-1         table  uniontest@primary
-1  scan
-1         table  uniontest@primary
+1  render
+2  scan
+2          table  uniontest@primary
+1  render
+2  scan
+2          table  uniontest@primary
 
 query ITTT rowsort
 EXPLAIN SELECT v FROM uniontest UNION ALL SELECT k FROM uniontest
 ----
 0  append
-1  scan
-1         table  uniontest@primary
-1  scan
-1         table  uniontest@primary
+1  render
+2  scan
+2          table  uniontest@primary
+1  render
+2  scan
+2          table  uniontest@primary
 
 
 query error each UNION query must have the same number of columns: 2 vs 1

--- a/pkg/sql/testdata/values
+++ b/pkg/sql/testdata/values
@@ -33,4 +33,5 @@ EXPLAIN VALUES (1), ((SELECT 2))
 0           size        1 column, 2 rows
 0           subqueries  1
 1  limit
-2  nullrow
+2  render
+3  nullrow

--- a/pkg/sql/testdata/window
+++ b/pkg/sql/testdata/window
@@ -471,9 +471,10 @@ EXPLAIN SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY
 0  sort
 0          order  +"variance(d) OVER w",+k
 1  window
-2  scan
-2          table  kv@primary
-2          spans  ALL
+2  render
+3  scan
+3          table  kv@primary
+3          spans  ALL
 
 query ITTT
 EXPLAIN (DEBUG) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k


### PR DESCRIPTION
Prior to this patch, EXPLAIN(PLAN) would sometimes hide entries for
"render" (renderNode) and "select" (selectTopNode). This is a remnant
of a time where we didn't optimize these nodes away from the query
plan and even the simplest queries would be littered with intermediate
selectTopNodes/renderNodes, making the output of EXPLAIN difficult to
digest if we printed them all.

With the merging of #12605 and #13192 these motivations are gone and
EXPLAIN can show everything without risking overwhelming the user.
Also it makes its output somewhat more understandable.

Fixes #13203.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13216)
<!-- Reviewable:end -->
