### PR TITLE
Miscellaneous improvements to the handling of panics during tests.

### DIFF
--- a/pkg/sql/logic_test.go
+++ b/pkg/sql/logic_test.go
@@ -30,6 +30,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -1163,8 +1164,16 @@ func TestLogic(t *testing.T) {
 			l.t = t
 			defer l.close()
 			l.setup()
+
+			defer func() {
+				if r := recover(); r != nil {
+					// Translate panics during the test to test errors.
+					t.Fatalf("panic: %v\n%s", r, string(debug.Stack()))
+				}
+			}()
+
 			if err := l.processTestFile(path); err != nil {
-				t.Error(err)
+				t.Fatal(err)
 			}
 		})
 

--- a/pkg/util/smalltrace.go
+++ b/pkg/util/smalltrace.go
@@ -32,12 +32,12 @@ func GetSmallTrace(skip int) string {
 
 	for i := range callers {
 		f, more := frames.Next()
+		callers[i] = fmt.Sprintf("%s:%d",
+			strings.TrimPrefix(f.Function, "github.com/cockroachdb/cockroach/pkg/"), f.Line)
+
 		if !more {
 			break
 		}
-
-		callers[i] = fmt.Sprintf("%s:%d",
-			strings.TrimPrefix(f.Function, "github.com/cockroachdb/cockroach/pkg/"), f.Line)
 	}
 
 	return strings.Join(callers, ",")


### PR DESCRIPTION
Noteworthy changes:

- test log files preserved also in case of panic
- "test log files left over" now printed on stderr directly, so reduce risk that the message gets lost
- panic during individual TestLogic test doesn't prevent other input files from being processed.

Fixes #13204.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13219)
<!-- Reviewable:end -->
