### PR TITLE
pgwire: cancel ongoing txns after drainnMaxWait when draining

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/ts"
@@ -237,6 +238,14 @@ func (ts *TestServer) TsDB() *ts.DB {
 func (ts *TestServer) DB() *client.DB {
 	if ts != nil {
 		return ts.db
+	}
+	return nil
+}
+
+// PGServer returns the pgwire.Server used by the TestServer.
+func (ts *TestServer) PGServer() *pgwire.Server {
+	if ts != nil {
+		return ts.pgServer
 	}
 	return nil
 }

--- a/pkg/sql/pgwire/helpers_test.go
+++ b/pkg/sql/pgwire/helpers_test.go
@@ -1,0 +1,25 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Alfonso Subiotto Marqués (alfonso@cockroachlabs.com)
+
+package pgwire
+
+import "time"
+
+func (s *Server) SetDrainingImpl(
+	drain bool, drainWait time.Duration, cancelWait time.Duration,
+) error {
+	return s.setDrainingImpl(drain, drainWait, cancelWait)
+}

--- a/pkg/sql/pgwire/main_test.go
+++ b/pkg/sql/pgwire/main_test.go
@@ -14,15 +14,29 @@
 //
 // Author: Ben Darnell
 
-package pgwire
+package pgwire_test
 
 import (
+	"os"
+	"testing"
+
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
 func init() {
 	security.SetReadFileFn(securitytest.Asset)
+}
+
+func TestMain(m *testing.M) {
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
 }
 
 //go:generate ../../util/leaktest/add-leaktest.sh *_test.go

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -14,10 +14,11 @@
 //
 // Author: Tamir Duberstein (tamird@gmail.com)
 
-package sql_test
+package pgwire_test
 
 import (
 	gosql "database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -82,8 +83,7 @@ func TestPGWire(t *testing.T) {
 	tempKeyPath := securitytest.RestrictedCopy(t, keyPath, tempDir, "key")
 
 	for _, insecure := range [...]bool{true, false} {
-		params, _ := createTestServerParams()
-		params.Insecure = insecure
+		params := base.TestServerArgs{Insecure: insecure}
 		s, _, _ := serverutils.StartServer(t, params)
 
 		host, port, err := net.SplitHostPort(s.ServingAddr())
@@ -175,12 +175,10 @@ func TestPGWire(t *testing.T) {
 }
 
 // TestPGWireDrainClient makes sure that in draining mode, the server refuses
-// new connections and allows sessions with ongoing transactions to finish
-// before closing them.
+// new connections and allows sessions with ongoing transactions to finish.
 func TestPGWireDrainClient(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	params, _ := createTestServerParams()
-	params.Insecure = true
+	params := base.TestServerArgs{Insecure: true}
 	s, _, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop()
 
@@ -206,8 +204,8 @@ func TestPGWireDrainClient(t *testing.T) {
 	}
 
 	on := []serverpb.DrainMode{serverpb.DrainMode_CLIENT}
-	// Draining runs in a separate goroutine since it won't return until
-	// the connection with an ongoing transaction finishes.
+	// Draining runs in a separate goroutine since it won't return until the
+	// connection with an ongoing transaction finishes.
 	errChan := make(chan error)
 	go func() {
 		defer close(errChan)
@@ -215,7 +213,7 @@ func TestPGWireDrainClient(t *testing.T) {
 			if now, err := s.(*server.TestServer).Drain(on); err != nil {
 				return err
 			} else if !reflect.DeepEqual(on, now) {
-				return fmt.Errorf("expected drain modes %v, got %v", on, now)
+				return errors.Errorf("expected drain modes %v, got %v", on, now)
 			}
 			return nil
 		}()
@@ -224,7 +222,7 @@ func TestPGWireDrainClient(t *testing.T) {
 	// Ensure server is in draining mode and rejects new connections.
 	testutils.SucceedsSoon(t, func() error {
 		if err := trivialQuery(pgBaseURL); !testutils.IsError(err, pgwire.ErrDraining) {
-			return fmt.Errorf("unexpected error: %v", err)
+			return errors.Errorf("unexpected error: %v", err)
 		}
 		return nil
 	})
@@ -245,6 +243,97 @@ func TestPGWireDrainClient(t *testing.T) {
 	if now := s.(*server.TestServer).Undrain(on); len(now) != 0 {
 		t.Fatalf("unexpected active drain modes: %v", now)
 	}
+}
+
+// TestPGWireDrainOngoingTxns tests that connections with open transactions are
+// cancelled when they go on for too long.
+func TestPGWireDrainOngoingTxns(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	params := base.TestServerArgs{Insecure: true}
+	s, _, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop()
+
+	host, port, err := net.SplitHostPort(s.ServingAddr())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pgBaseURL := url.URL{
+		Scheme:   "postgres",
+		Host:     net.JoinHostPort(host, port),
+		RawQuery: "sslmode=disable",
+	}
+
+	db, err := gosql.Open("postgres", pgBaseURL.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	pgServer := s.(*server.TestServer).PGServer()
+
+	// Make sure that the server reports correctly the case in which a
+	// connection did not respond to cancellation in time.
+	t.Run("CancelResponseFailure", func(t *testing.T) {
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Set draining with no drainWait or cancelWait timeout. The expected
+		// behavior is that the ongoing session is immediately cancelled but
+		// pgServer won't wait for the connection to close properly and notify
+		// the caller that a session did not respond to cancellation.
+		if err := pgServer.SetDrainingImpl(
+			true, 0 /* drainWait */, 0, /* cancelWait */
+		); !testutils.IsError(err, "some sessions did not respond to cancellation") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Make sure that the connection was disrupted. A retry loop is needed
+		// because we must wait (since we told the pgServer not to) until the
+		// connection registers the cancellation and closes itself.
+		testutils.SucceedsSoon(t, func() error {
+			if _, err := txn.Exec("SELECT 1"); err != driver.ErrBadConn {
+				return errors.Errorf("unexpected error: %v", err)
+			}
+			return nil
+		})
+
+		if err := txn.Commit(); err != driver.ErrBadConn {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if err := pgServer.SetDraining(false); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// Make sure that a connection gets cancelled and correctly responds to this
+	// cancellation by closing itself.
+	t.Run("CancelResponseSuccess", func(t *testing.T) {
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Set draining with no drainWait timeout and a 1s cancelWait timeout.
+		// The expected behavior is for the pgServer to immediately cancel any
+		// ongoing sessions and wait for 1s for the cancellation to take effect.
+		if err := pgServer.SetDrainingImpl(
+			true, 0 /* drainWait */, 1*time.Second, /* cancelWait */
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := txn.Commit(); err != driver.ErrBadConn {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if err := pgServer.SetDraining(false); err != nil {
+			t.Fatal(err)
+		}
+	})
 }
 
 func TestPGWireDBName(t *testing.T) {
@@ -1308,9 +1397,10 @@ func TestPGWireOverUnixSocket(t *testing.T) {
 
 	socketFile := filepath.Join(tempDir, ".s.PGSQL.123456")
 
-	params, _ := createTestServerParams()
-	params.Insecure = true
-	params.SocketFile = socketFile
+	params := base.TestServerArgs{
+		Insecure:   true,
+		SocketFile: socketFile,
+	}
 	s, _, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop()
 

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -18,7 +18,6 @@ package pgwire
 
 import (
 	"crypto/tls"
-	"fmt"
 	"io"
 	"net"
 	"time"
@@ -30,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/mon"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -60,7 +58,14 @@ const (
 	versionSSL = 80877103
 )
 
-const drainMaxWait = 10 * time.Second
+const (
+	// drainMaxWait is the amount of time a draining server gives to sessions
+	// with ongoing transactions to finish work before cancellation.
+	drainMaxWait = 10 * time.Second
+	// cancelMaxWait is the amount of time a draining server gives to sessions
+	// to react to cancellation and return before a forceful shutdown.
+	cancelMaxWait = 1 * time.Second
+)
 
 // baseSQLMemoryBudget is the amount of memory pre-allocated in each connection.
 var baseSQLMemoryBudget = envutil.EnvOrDefaultInt64("COCKROACH_BASE_SQL_MEMORY_BUDGET",
@@ -75,6 +80,10 @@ var (
 	sslUnsupported = []byte{'N'}
 )
 
+// cancelChanMap keeps track of channels that are closed after the associated
+// cancellation function has been called and the cancellation has taken place.
+type cancelChanMap map[chan struct{}]context.CancelFunc
+
 // Server implements the server side of the PostgreSQL wire protocol.
 type Server struct {
 	AmbientCtx log.AmbientContext
@@ -85,7 +94,12 @@ type Server struct {
 
 	mu struct {
 		syncutil.Mutex
-		draining bool
+		// connCancelMap entries represent connections started when the server
+		// was not draining. Each value is a function that can be called to
+		// cancel the associated connection. The corresponding key is a channel
+		// that is closed when the connection is done.
+		connCancelMap cancelChanMap
+		draining      bool
 	}
 
 	sqlMemoryPool mon.MemoryMonitor
@@ -153,6 +167,10 @@ func MakeServer(
 		int64(connReservationBatchSize)*baseSQLMemoryBudget, noteworthyConnMemoryUsageBytes)
 	server.connMonitor.Start(context.Background(), &server.sqlMemoryPool, mon.BoundAccount{})
 
+	server.mu.Lock()
+	server.mu.connCancelMap = make(cancelChanMap)
+	server.mu.Unlock()
+
 	return server
 }
 
@@ -185,37 +203,123 @@ func (s *Server) Metrics() *ServerMetrics {
 
 // SetDraining (when called with 'true') prevents new connections from being
 // served and waits a reasonable amount of time for open connections to
-// terminate. If an error is returned, the server remains in draining state,
-// though open connections may continue to exist.
+// terminate before canceling them.
+// An error will be returned when connections that have been cancelled have not
+// responded to this cancellation and closed themselves in time. The server
+// will remain in draining state, though open connections may continue to
+// exist.
 // When called with 'false', switches back to the normal mode of operation in
 // which connections are accepted.
+// The RFC on drain modes has more information regarding the specifics of
+// what will happen to connections in different states:
+// https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/drain_modes.md
 func (s *Server) SetDraining(drain bool) error {
-	s.mu.Lock()
-	s.mu.draining = drain
-	s.mu.Unlock()
-	if !drain {
+	return s.setDrainingImpl(drain, drainMaxWait, cancelMaxWait)
+}
+
+func (s *Server) setDrainingImpl(
+	drain bool, drainWait time.Duration, cancelWait time.Duration,
+) error {
+	// This anonymous function returns a copy of s.mu.connCancelMap if there are
+	// any active connections to cancel. We will only attempt to cancel
+	// connections that were active at the moment the draining switch happened.
+	// It is enough to do this because:
+	// 1) If no new connections are added to the original map all connections
+	// will be cancelled.
+	// 2) If new connections are added to the original map, it follows that they
+	// were added when s.mu.draining = false, thus not requiring cancellation.
+	// These connections are not our responsibility and will be handled when the
+	// server starts draining again.
+	connCancelMap := func() cancelChanMap {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if s.mu.draining == drain {
+			return nil
+		}
+		s.mu.draining = drain
+		if !drain {
+			return nil
+		}
+
+		connCancelMap := make(cancelChanMap)
+		for done, cancel := range s.mu.connCancelMap {
+			connCancelMap[done] = cancel
+		}
+		return connCancelMap
+	}()
+	if len(connCancelMap) == 0 {
 		return nil
 	}
-	return util.RetryForDuration(drainMaxWait, func() error {
-		if c := s.metrics.Conns.Count(); c != 0 {
-			// TODO(tschottdorf): Do more plumbing to actively disrupt
-			// connections; see #6283. There isn't much of a point until
-			// we know what load-balanced clients like to see (#6295).
-			return fmt.Errorf("timed out waiting for %d open connections to drain", c)
+
+	// Spin off a goroutine that waits for all connections to signal that they
+	// are done and reports it on allConnsDone. The main goroutine signals this
+	// goroutine to stop work through quitWaitingForConns.
+	allConnsDone := make(chan struct{})
+	quitWaitingForConns := make(chan struct{})
+	defer close(quitWaitingForConns)
+	go func() {
+		defer close(allConnsDone)
+		for done := range connCancelMap {
+			select {
+			case <-done:
+			case <-quitWaitingForConns:
+				return
+			}
 		}
+	}()
+
+	// Wait for all connections to finish up to drainWait.
+	select {
+	case <-time.After(drainWait):
+	case <-allConnsDone:
+	}
+
+	// Cancel the contexts of all sessions if the server is still in draining
+	// mode.
+	if stop := func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if !s.mu.draining {
+			return true
+		}
+		for _, cancel := range connCancelMap {
+			// There is a possibility that different calls to SetDraining have
+			// overlapping connCancelMaps, but context.CancelFunc calls are
+			// idempotent.
+			cancel()
+		}
+		return false
+	}(); stop {
 		return nil
-	})
+	}
+
+	select {
+	case <-time.After(cancelWait):
+		return errors.Errorf("some sessions did not respond to cancellation within %s", cancelWait)
+	case <-allConnsDone:
+	}
+	return nil
 }
 
 // ServeConn serves a single connection, driving the handshake process
 // and delegating to the appropriate connection type.
 func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
-	var draining bool
-	{
-		s.mu.Lock()
-		draining = s.mu.draining
-		s.mu.Unlock()
+	s.mu.Lock()
+	draining := s.mu.draining
+	if !draining {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithCancel(ctx)
+		done := make(chan struct{})
+		s.mu.connCancelMap[done] = cancel
+		defer func() {
+			cancel()
+			close(done)
+			s.mu.Lock()
+			delete(s.mu.connCancelMap, done)
+			s.mu.Unlock()
+		}()
 	}
+	s.mu.Unlock()
 
 	// If the Server is draining, we will use the connection only to send an
 	// error, so we don't count it in the stats. This makes sense since


### PR DESCRIPTION
Instead of simply ignoring ongoing sessions that have not completed by
drainMaxWait, this PR cancels them and waits up to a timeout for this
cancellation to take effect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13274)
<!-- Reviewable:end -->
