### PR TITLE
RFCs: Fix some incorrect statements in RFCs

### DIFF
--- a/docs/RFCS/rebalancing_v2.md
+++ b/docs/RFCS/rebalancing_v2.md
@@ -154,8 +154,7 @@ priority:
 
 - Replicas are moved to where there is demand for them.
 
-  Experiment to see if this would be useful. However, with a proper load balancer, there should be
-  nothing to gain from doing this. There may however be performance gains on keeping replicas of
+  Experiment to see if this would be useful. There may be performance gains on keeping replicas of
   single tables together on the same set of stores.
 
 - Globally distributed data.

--- a/docs/RFCS/stateless_replica_relocation.md
+++ b/docs/RFCS/stateless_replica_relocation.md
@@ -77,8 +77,7 @@ The second piece, the core mechanic, will be performed by the existing
 "replicate queue" which will be renamed the "*replication queue*". This queue is
 already used to add replicas to ranges which are under-replicated; it can be
 enhanced to remove replicas from over-replicated ranges, thus satisfying the
-basic requirements of the core mechanic. Detailed design for these changes are
-in a [separate RFC (#2153)](https://github.com/cockroachdb/cockroach/pull/2153).
+basic requirements of the core mechanic.
 
 The third piece simply informs the design of systems performing relocations; for
 example, the upcoming repair and rebalance systems (still being planned).  After


### PR DESCRIPTION
The rebalancing statement about moving replicas to where there is demand
is incorrect in that there will be latency improvements, and the
stateless replica relocation RFC pointed to a never-merged RFC that it
was eventually combined with.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13278)
<!-- Reviewable:end -->
