### PR TITLE
Revise built-in descriptions

### DIFF
--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -1490,7 +1490,7 @@ var Builtins = map[string][]Builtin{
 				return NewDInt(-1), nil
 			},
 			category: categoryCompatibility,
-			Info:     "Not usable; supported only for ORM compatibility",
+			Info:     "Not usable; exposed only for ORM compatibility.",
 		},
 	},
 
@@ -1511,7 +1511,7 @@ var Builtins = map[string][]Builtin{
 				return args[0], nil
 			},
 			category: categoryCompatibility,
-			Info:     "Not usable; supported only for ORM compatibility",
+			Info:     "Not usable; exposed only for ORM compatibility.",
 		},
 		Builtin{
 			Types: ArgTypes{
@@ -1524,7 +1524,7 @@ var Builtins = map[string][]Builtin{
 				return args[0], nil
 			},
 			category: categoryCompatibility,
-			Info:     "Not usable; supported only for ORM compatibility",
+			Info:     "Not usable; exposed only for ORM compatibility.",
 		},
 	},
 
@@ -1549,7 +1549,7 @@ var Builtins = map[string][]Builtin{
 				return r[0], nil
 			},
 			category: categoryCompatibility,
-			Info:     "Not usable; supported only for ORM compatibility",
+			Info:     "Not usable; exposed only for ORM compatibility.",
 		},
 		// The other overload for this function, pg_get_indexdef(index_oid,
 		// column_no, pretty_bool), is unimplemented, because it isn't used by
@@ -1566,7 +1566,7 @@ var Builtins = map[string][]Builtin{
 				return NewDString(args[0].ResolvedType().String()), nil
 			},
 			category: categoryCompatibility,
-			Info:     "Not usable; supported only for ORM compatibility",
+			Info:     "Not usable; exposed only for ORM compatibility.",
 		},
 	},
 	"pg_catalog.pg_get_userbyid": {
@@ -1587,7 +1587,7 @@ var Builtins = map[string][]Builtin{
 				return t[0], nil
 			},
 			category: categoryCompatibility,
-			Info:     "Not usable; supported only for ORM compatibility",
+			Info:     "Not usable; exposed only for ORM compatibility.",
 		},
 	},
 	"pg_catalog.format_type": {
@@ -1603,7 +1603,7 @@ var Builtins = map[string][]Builtin{
 				return NewDString(typ.SQLName()), nil
 			},
 			category: categoryCompatibility,
-			Info: "format_type returns the SQL name of a data type that is " +
+			Info: "Returns the SQL name of a data type that is " +
 				"identified by its type OID and possibly a type modifier. " +
 				"Currently, the type modifier is ignored.",
 		},
@@ -1616,8 +1616,7 @@ var Builtins = map[string][]Builtin{
 				return DNull, nil
 			},
 			category: categoryCompatibility,
-			Info: "col_description returns the comment for a table column. " +
-				"Currently, CockroachDB does not support adding comments to columns.",
+			Info:     "Not usable; exposed only for ORM compatibility.",
 		},
 	},
 	"pg_catalog.obj_description": {
@@ -1628,8 +1627,7 @@ var Builtins = map[string][]Builtin{
 				return DNull, nil
 			},
 			category: categoryCompatibility,
-			Info: "obj_description returns the comment for a database object. " +
-				"Currently, CockroachDB does not support database object comments.",
+			Info:     "Not usable; exposed only for ORM compatibility.",
 		},
 	},
 	"pg_catalog.shobj_description": {
@@ -1640,9 +1638,7 @@ var Builtins = map[string][]Builtin{
 				return DNull, nil
 			},
 			category: categoryCompatibility,
-			Info: "shobj_description returns the comment for a shared database " +
-				"object. Currently, CockroachDB does not support database object " +
-				"comments.",
+			Info:     "Not usable; exposed only for ORM compatibility.",
 		},
 	},
 	"pg_catalog.array_in": {
@@ -1653,7 +1649,7 @@ var Builtins = map[string][]Builtin{
 				return nil, errors.New("unimplemented")
 			},
 			category: categoryCompatibility,
-			Info:     "array_in is unimplemented and exists for compatibility purposes",
+			Info:     "Not usable; exposed only for ORM compatibility.",
 		},
 	},
 }

--- a/pkg/sql/parser/generator_builtins.go
+++ b/pkg/sql/parser/generator_builtins.go
@@ -100,16 +100,16 @@ func initGeneratorBuiltins() {
 var generators = map[string][]Builtin{
 	"pg_catalog.generate_series": {
 		makeGeneratorBuiltin(
-			ArgTypes{{"a", TypeInt}, {"b", TypeInt}},
+			ArgTypes{{"start", TypeInt}, {"end", TypeInt}},
 			TTuple{TypeInt},
 			makeSeriesGenerator,
-			"Not usable; supported only for ORM compatibility.",
+			"Produces a virtual table containing the integer values from <start> to <end>, inclusive.",
 		),
 		makeGeneratorBuiltin(
-			ArgTypes{{"a", TypeInt}, {"b", TypeInt}, {"c", TypeInt}},
+			ArgTypes{{"start", TypeInt}, {"end", TypeInt}, {"step", TypeInt}},
 			TTuple{TypeInt},
 			makeSeriesGenerator,
-			"Not usable; supported only for ORM compatibility.",
+			"Produces a virtual table containing the integer values from <start> to <end>, inclusive, by increment of <step>.",
 		),
 	},
 	"unnest": {


### PR DESCRIPTION
This PR revises the descriptions for some built-in compatibility functions:

- Simplifies some function descriptions to state that they are for ORM compatibility only and are not usable. 
- Edits to the descriptions for `pg_catalog.format_type()` and `pg_catalog.generate_series()` functions. 
- Renames the arguments for the `pg_catalog.generate_series()` functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13280)
<!-- Reviewable:end -->
