### PR TITLE
sql/parser: allow hex-strings to contain non-utf8 characters

### DIFF
--- a/pkg/sql/parser/scan.go
+++ b/pkg/sql/parser/scan.go
@@ -283,7 +283,7 @@ func (s *Scanner) scan(lval *sqlSymType) {
 		if t := s.peek(); t == singleQuote || t == s.stringQuote {
 			// [xX]'[a-f0-9]'
 			s.pos++
-			if s.scanStringOrHex(lval, t, false, true, true) {
+			if s.scanStringOrHex(lval, t, false, false, true) {
 				lval.id = BCONST
 			}
 			return

--- a/pkg/sql/parser/scan_test.go
+++ b/pkg/sql/parser/scan_test.go
@@ -350,7 +350,7 @@ world'`, `hello
 world`},
 		{`x'666f6f'`, `foo`},
 		{`X'626172'`, `bar`},
-		{`X'FF'`, `invalid UTF-8 byte sequence`},
+		{`X'FF'`, "\xff"},
 	}
 	for _, d := range testData {
 		s := MakeScanner(d.sql, Traditional)


### PR DESCRIPTION
Discovered when trying to replace insertion of binary data via a
placeholder with a hex-string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13287)
<!-- Reviewable:end -->
