### PR TITLE
storage: remove some spurious log messages

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4336,12 +4336,10 @@ func (r *Replica) shouldGossip() bool {
 // (which provide the necessary serialization to avoid data races).
 func (r *Replica) maybeGossipSystemConfig(ctx context.Context) error {
 	if r.store.Gossip() == nil || !r.IsInitialized() {
-		log.Infof(ctx, "gossip not initialized")
 		return nil
 	}
 
 	if !r.ContainsKey(keys.SystemConfigSpan.Key) || !r.shouldGossip() {
-		log.Infof(ctx, "not system config span or lease not held")
 		return nil
 	}
 


### PR DESCRIPTION
Remove some spurious log messages accidentally added in an earlier
commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13292)
<!-- Reviewable:end -->
