### PR TITLE
kv,storage: fix slow timer "leak"

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -1139,10 +1139,17 @@ func (ds *DistSender) sendToReplicas(
 	// with errors that reflect per-replica state and may succeed on
 	// other replicas.
 	var sendNextTimer timeutil.Timer
+	var slowTimer timeutil.Timer
 	defer sendNextTimer.Stop()
-	slowTimer := time.After(base.SlowRequestThreshold)
+	defer slowTimer.Stop()
+	slowTimer.Reset(base.SlowRequestThreshold)
 	for {
-		sendNextTimer.Reset(opts.SendNextTimeout)
+		if !transport.IsExhausted() {
+			// Only start the send-next timer if we haven't exhausted the transport
+			// (i.e. there is another replica to send to).
+			sendNextTimer.Reset(opts.SendNextTimeout)
+		}
+
 		select {
 		case <-sendNextTimer.C:
 			sendNextTimer.Read = true
@@ -1154,8 +1161,7 @@ func (ds *DistSender) sendToReplicas(
 				transport.SendNext(ctx, done)
 			}
 
-		case <-slowTimer:
-			slowTimer = nil
+		case <-slowTimer.C:
 			log.Warningf(ctx, "have been waiting %s sending RPC for batch: %s",
 				base.SlowRequestThreshold, args.Summary())
 			ds.metrics.SlowRequestsCount.Inc(1)


### PR DESCRIPTION
Noticed in a heap profile a significant number of timer objects created
by time.After. In a 1m block_writer test, this change reduced the
percent of time spent in GC from 15% to 10% and improved throughput by
11%.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13312)
<!-- Reviewable:end -->
