### PR TITLE
distsql: fix nosort case

### DIFF
--- a/pkg/testutils/sqlutils/sql_runner.go
+++ b/pkg/testutils/sqlutils/sql_runner.go
@@ -37,6 +37,14 @@ func MakeSQLRunner(tb testing.TB, db *gosql.DB) *SQLRunner {
 	return &SQLRunner{TB: tb, DB: db}
 }
 
+// Subtest returns a copy of SQLRunner which can be used with a subtest
+// (different testing.T or testing.B instance).
+func (sr *SQLRunner) Subtest(tb testing.TB) *SQLRunner {
+	copy := *sr
+	copy.TB = tb
+	return &copy
+}
+
 // Exec is a wrapper around gosql.Exec that kills the test on error.
 func (sr *SQLRunner) Exec(query string, args ...interface{}) gosql.Result {
 	r, err := sr.DB.Exec(query, args...)


### PR DESCRIPTION
We have cases where sortNode doesn't actually sort, but is there to remove a
column from the plan (e.g. `SELECT x FROM t ORDER BY y`). In this case we were
using a Sorter that wasn't doing much. Fixing to just set a projection.
Verified the plan for `TestDistSQLPlanner/Basic`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13315)
<!-- Reviewable:end -->
