### PR TITLE
rpc: allow rpc context to be reset and connections closed

### DIFF
--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -1208,9 +1208,8 @@ func TestRangeInfo(t *testing.T) {
 
 // TestCampaignOnLazyRaftGroupInitialization verifies expected
 // behavior for which replicas will campaign on lazy initialization.
-func TestCampaignOnLazyRaftGroupInitialization(t *testing.T) {
+func TestCampaignOnLazyRaftGroupInitializationRename(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("this test is flaky on the 5m initial stress due to errant Raft messages initializing the Raft group")
 	splitKey := keys.MakeRowSentinelKey(keys.UserTableDataMin)
 	testState := struct {
 		syncutil.Mutex

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -934,6 +934,7 @@ func (m *multiTestContext) restart() {
 	for i := range m.stores {
 		m.stopStore(i)
 	}
+	m.rpcContext.Reset() // clear all RPC connections
 	for i := range m.stores {
 		m.restartStore(i)
 	}


### PR DESCRIPTION
In `multiTestContext`, reset the `rpc.Context` in `restart()`.

Unskip flaky storage test for campaigning on lazy raft group
initialization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13318)
<!-- Reviewable:end -->
