### PR TITLE
Backticks around argument names in function descriptions

### DIFF
--- a/pkg/sql/parser/generator_builtins.go
+++ b/pkg/sql/parser/generator_builtins.go
@@ -103,13 +103,13 @@ var generators = map[string][]Builtin{
 			ArgTypes{{"start", TypeInt}, {"end", TypeInt}},
 			TTuple{TypeInt},
 			makeSeriesGenerator,
-			"Produces a virtual table containing the integer values from <start> to <end>, inclusive.",
+			"Produces a virtual table containing the integer values from `start` to `end`, inclusive.",
 		),
 		makeGeneratorBuiltin(
 			ArgTypes{{"start", TypeInt}, {"end", TypeInt}, {"step", TypeInt}},
 			TTuple{TypeInt},
 			makeSeriesGenerator,
-			"Produces a virtual table containing the integer values from <start> to <end>, inclusive, by increment of <step>.",
+			"Produces a virtual table containing the integer values from `start` to `end`, inclusive, by increment of `step`.",
 		),
 	},
 	"unnest": {


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/pull/13280, I formatted argument names incorrectly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13322)
<!-- Reviewable:end -->
