### PR TITLE
storage: add COCKROACH_ENABLE_QUEUE_EVENT_LOG env var

### DIFF
--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -348,7 +348,9 @@ func (gcq *gcQueue) process(ctx context.Context, repl *Replica, sysCfg config.Sy
 		return err
 	}
 
-	log.VEventf(ctx, 1, "completed with stats %+v", info)
+	if log.V(1) {
+		log.Infof(ctx, "completed with stats %+v", info)
+	}
 
 	info.updateMetrics(gcq.store.metrics)
 

--- a/pkg/storage/raft_log_queue.go
+++ b/pkg/storage/raft_log_queue.go
@@ -229,8 +229,10 @@ func (rlq *raftLogQueue) process(ctx context.Context, r *Replica, _ config.Syste
 		raftLogSize := r.mu.raftLogSize
 		r.mu.Unlock()
 
-		log.VEventf(ctx, 1, "truncating raft log %d-%d: size=%d",
-			oldestIndex-truncatableIndexes, oldestIndex, raftLogSize)
+		if log.V(1) {
+			log.Infof(ctx, "truncating raft log %d-%d: size=%d",
+				oldestIndex-truncatableIndexes, oldestIndex, raftLogSize)
+		}
 		b := &client.Batch{}
 		b.AddRawRequest(&roachpb.TruncateLogRequest{
 			Span:    roachpb.Span{Key: r.Desc().StartKey.AsRawKey()},

--- a/pkg/storage/raft_snapshot_queue.go
+++ b/pkg/storage/raft_snapshot_queue.go
@@ -92,7 +92,9 @@ func (rq *raftSnapshotQueue) process(
 		// raft.Status.Progress is only populated on the Raft group leader.
 		for id, p := range status.Progress {
 			if p.State == raft.ProgressStateSnapshot {
-				log.VEventf(ctx, 1, "sending raft snapshot")
+				if log.V(1) {
+					log.Infof(ctx, "sending raft snapshot")
+				}
 				if err := rq.processRaftSnapshot(ctx, repl, roachpb.ReplicaID(id)); err != nil {
 					return err
 				}

--- a/pkg/storage/replica_gc_queue.go
+++ b/pkg/storage/replica_gc_queue.go
@@ -199,7 +199,9 @@ func (rgcq *replicaGCQueue) process(
 	if _, currentMember := replyDesc.GetReplicaDescriptor(repl.store.StoreID()); !currentMember {
 		// We are no longer a member of this range; clean up our local data.
 		rgcq.metrics.RemoveReplicaCount.Inc(1)
-		log.VEventf(ctx, 1, "destroying local data")
+		if log.V(1) {
+			log.Infof(ctx, "destroying local data")
+		}
 		if err := repl.store.RemoveReplica(ctx, repl, replyDesc, true); err != nil {
 			return err
 		}
@@ -209,7 +211,9 @@ func (rgcq *replicaGCQueue) process(
 		// subsuming range. Shut down raft processing for the former range
 		// and delete any remaining metadata, but do not delete the data.
 		rgcq.metrics.RemoveReplicaCount.Inc(1)
-		log.VEventf(ctx, 1, "removing merged range")
+		if log.V(1) {
+			log.Infof(ctx, "removing merged range")
+		}
 		if err := repl.store.RemoveReplica(ctx, repl, replyDesc, false); err != nil {
 			return err
 		}
@@ -224,7 +228,9 @@ func (rgcq *replicaGCQueue) process(
 		// but also on how good a job the queue does at inspecting every
 		// Replica (see #8111) when inactive ones can be starved by
 		// event-driven additions.
-		log.Event(ctx, "not gc'able")
+		if log.V(1) {
+			log.Infof(ctx, "not gc'able")
+		}
 		if err := repl.setLastReplicaGCTimestamp(ctx, repl.store.Clock().Now()); err != nil {
 			return err
 		}


### PR DESCRIPTION
Default queue eventlogs off as they are mostly filled with spam on real
clusters.

* Does anyone actually use the queue /event info outside of local debugging?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13323)
<!-- Reviewable:end -->
