### PR TITLE
util/tracing: add COCKROACH_DISABLE_TRACING env var

### DIFF
--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -215,8 +215,13 @@ var lightstepToken = envutil.EnvOrDefaultString("COCKROACH_LIGHTSTEP_TOKEN", "")
 // net/trace. If this flag is enabled, we will only trace to Lightstep.
 var lightstepOnly = envutil.EnvOrDefaultBool("COCKROACH_LIGHTSTEP_ONLY", false)
 
+var disableTracing = envutil.EnvOrDefaultBool("COCKROACH_DISABLE_TRACING", false)
+
 // newTracer implements NewTracer and allows that function to be mocked out via Disable().
 var newTracer = func() opentracing.Tracer {
+	if disableTracing {
+		return opentracing.NoopTracer{}
+	}
 	if lightstepToken != "" {
 		lsTr := lightstep.NewTracer(lightstep.Options{
 			AccessToken:    lightstepToken,


### PR DESCRIPTION
For experimentation to easily show performance overhead of having
tracing enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13324)
<!-- Reviewable:end -->
