### PR TITLE
storage: fix go1.8 vet failure

### DIFF
--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -1333,7 +1333,7 @@ func TestCampaignOnLazyRaftGroupInitialization(t *testing.T) {
 
 			// We expect not lease holder errors on 2 out of the three replicas.
 			var errCount int
-			for i := 0; i < len(mtc.stores); i++ {
+			for range mtc.stores {
 				if err := <-errCh; err != nil {
 					errCount++
 					if _, ok := err.(*roachpb.NotLeaseHolderError); !ok {


### PR DESCRIPTION
storage/client_replica_test.go:1336: declaration of "i" shadows
declaration at storage/client_replica_test.go:1299

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13330)
<!-- Reviewable:end -->
