### PR TITLE
config: rework SystemConfig.ComputeSplits

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -459,9 +459,9 @@ func Example_ranges() {
 	// 	0: node-id=1 store-id=1
 	// "c"-/Table/0 [7]
 	// 	0: node-id=1 store-id=1
-	// /Table/0-/Table/11 [3]
+	// /Table/0-/Table/11 [2]
 	// 	0: node-id=1 store-id=1
-	// /Table/11-/Table/12 [2]
+	// /Table/11-/Table/12 [3]
 	// 	0: node-id=1 store-id=1
 	// /Table/12-/Table/13 [4]
 	//	0: node-id=1 store-id=1

--- a/pkg/storage/queue_test.go
+++ b/pkg/storage/queue_test.go
@@ -705,7 +705,11 @@ func TestBaseQueueProcessTimeout(t *testing.T) {
 		},
 	}
 	bq := makeTestBaseQueue("test", ptQueue, tc.store, tc.gossip,
-		queueConfig{maxSize: 1, processTimeout: 1 * time.Millisecond})
+		queueConfig{
+			maxSize:              1,
+			processTimeout:       time.Millisecond,
+			acceptsUnsplitRanges: true,
+		})
 	bq.Start(tc.Clock(), stopper)
 	bq.MaybeAdd(r, hlc.ZeroTimestamp)
 
@@ -755,7 +759,11 @@ func TestBaseQueueTimeMetric(t *testing.T) {
 		},
 	}
 	bq := makeTestBaseQueue("test", ptQueue, tc.store, tc.gossip,
-		queueConfig{maxSize: 1, processTimeout: 1 * time.Millisecond})
+		queueConfig{
+			maxSize:              1,
+			processTimeout:       time.Millisecond,
+			acceptsUnsplitRanges: true,
+		})
 	bq.Start(tc.Clock(), stopper)
 	bq.MaybeAdd(r, hlc.ZeroTimestamp)
 

--- a/pkg/storage/split_queue.go
+++ b/pkg/storage/split_queue.go
@@ -69,7 +69,7 @@ func (sq *splitQueue) shouldQueue(
 	ctx context.Context, now hlc.Timestamp, repl *Replica, sysCfg config.SystemConfig,
 ) (shouldQ bool, priority float64) {
 	desc := repl.Desc()
-	if len(sysCfg.ComputeSplitKeys(desc.StartKey, desc.EndKey)) > 0 {
+	if sysCfg.NeedsSplit(desc.StartKey, desc.EndKey) {
 		// Set priority to 1 in the event the range is split by zone configs.
 		priority = 1
 		shouldQ = true
@@ -94,19 +94,16 @@ func (sq *splitQueue) shouldQueue(
 func (sq *splitQueue) process(ctx context.Context, r *Replica, sysCfg config.SystemConfig) error {
 	// First handle case of splitting due to zone config maps.
 	desc := r.Desc()
-	splitKeys := sysCfg.ComputeSplitKeys(desc.StartKey, desc.EndKey)
-	if len(splitKeys) > 0 {
-		log.Infof(ctx, "splitting at keys %v", splitKeys)
-		for _, splitKey := range splitKeys {
-			if _, pErr := r.adminSplitWithDescriptor(
-				ctx,
-				roachpb.AdminSplitRequest{
-					SplitKey: splitKey.AsRawKey(),
-				},
-				desc,
-			); pErr != nil {
-				return errors.Wrapf(pErr.GoError(), "unable to split %s at key %q", r, splitKey)
-			}
+	if splitKey := sysCfg.ComputeSplitKey(desc.StartKey, desc.EndKey); splitKey != nil {
+		log.Infof(ctx, "splitting at key %v", splitKey)
+		if _, pErr := r.adminSplitWithDescriptor(
+			ctx,
+			roachpb.AdminSplitRequest{
+				SplitKey: splitKey.AsRawKey(),
+			},
+			desc,
+		); pErr != nil {
+			return errors.Wrapf(pErr.GoError(), "unable to split %s at key %q", r, splitKey)
 		}
 		return nil
 	}

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -111,6 +111,10 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initSende
 	ltc.DB = client.NewDBWithContext(ltc.Sender, *ltc.DBContext)
 	transport := storage.NewDummyRaftTransport()
 	cfg := storage.TestStoreConfig(ltc.Clock)
+	// Disable the replica scanner and split queue, which confuse tests using
+	// LocalTestCluster.
+	cfg.TestingKnobs.DisableScanner = true
+	cfg.TestingKnobs.DisableSplitQueue = true
 	if ltc.RangeRetryOptions != nil {
 		cfg.RangeRetryOptions = *ltc.RangeRetryOptions
 	}


### PR DESCRIPTION
Fix an issue where the split key would try to split a range multiple
times but fail after the first split. Consider splitting a range at the
keys [/Table/0 and /Table/1]. After splitting the range R at /Table/0,
the key /Table/1 is no longer part of the range. We have to split the
right-hand-side of R. Trying to perform multiple splits on each
iteration of the split queue was not necessary because we always
re-enqueue ranges for splitting once a split has complete.

Change SystemConfig.ComputeSplits to
SystemConfig.ComputeSplit (singular) and have it return a single key to
split at. Fix the logic for splitting at the start of the system-config
span so that we choose that split point first.

Fixes #13293

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13331)
<!-- Reviewable:end -->
