### PR TITLE
storage: deflake TestStoreRangeUpReplicate

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -1010,8 +1010,13 @@ func TestRefreshPendingCommands(t *testing.T) {
 // under-replicated ranges and replicate them.
 func TestStoreRangeUpReplicate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#12902")
-	mtc := &multiTestContext{}
+	sc := storage.TestStoreConfig(nil)
+	// Prevent the split queue from creating additional ranges while we're
+	// waiting for replication.
+	sc.TestingKnobs.DisableSplitQueue = true
+	mtc := &multiTestContext{
+		storeConfig: &sc,
+	}
 	defer mtc.Stop()
 	mtc.Start(t, 3)
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3259,12 +3259,15 @@ func sendSnapshot(
 		LogEntries: logEntries,
 		Final:      true,
 	}
+	// Notify the sent callback before the final snapshot request is sent so that
+	// the snapshots generated metric gets incremented before the snapshot is
+	// applied.
+	sent()
 	if err := stream.Send(req); err != nil {
 		return err
 	}
 	log.Infof(ctx, "streamed snapshot: kv pairs: %d, log entries: %d, %0.0fms",
 		n, len(logEntries), timeutil.Since(start).Seconds()*1000)
-	sent()
 
 	resp, err = stream.Recv()
 	if err != nil {


### PR DESCRIPTION
Disable the split queue.

Fixes #12902

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13337)
<!-- Reviewable:end -->
