### PR TITLE
Fix path to .dockercfg.in.

### DIFF
--- a/build/teamcity-release-upload.sh
+++ b/build/teamcity-release-upload.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-sed "s/<EMAIL>/$DOCKER_EMAIL/;s/<AUTH>/$DOCKER_AUTH/" < .dockercfg.in > ~/.dockercfg
+sed "s/<EMAIL>/$DOCKER_EMAIL/;s/<AUTH>/$DOCKER_AUTH/" < build/.dockercfg.in > ~/.dockercfg
 
 case "$TC_BUILD_BRANCH" in
   master)


### PR DESCRIPTION
This has been broken since fc543a4c879b83ba1dee7ddfc361545df2827fcd and
has prevented master builds since.

It would be best to build the local path (eg: `dirname $0`), but we're
already using a fixed relative path everywhere else in this script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13338)
<!-- Reviewable:end -->
