### PR TITLE
engineccl: add a method to verify batch repr integrity

### DIFF
--- a/pkg/ccl/ccl_init.go
+++ b/pkg/ccl/ccl_init.go
@@ -16,5 +16,7 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/buildccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/sqlccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl/rocksdbccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/utilccl/intervalccl"
 )

--- a/pkg/ccl/storageccl/engineccl/rocksdb.go
+++ b/pkg/ccl/storageccl/engineccl/rocksdb.go
@@ -1,0 +1,111 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Cockroach Community Licence (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+
+package engineccl
+
+import (
+	"errors"
+	"unsafe"
+
+	// rocksdbccl only exports cgo code.
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl/rocksdbccl"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+)
+
+// #cgo darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
+// #cgo !darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all
+// #cgo linux LDFLAGS: -lrt
+//
+// #include <stdlib.h>
+// #include "rocksdbccl/db.h"
+import "C"
+
+// VerifyBatchRepr asserts that all keys in a BatchRepr are between the specified
+// start and end keys and computes the enginepb.MVCCStats for it.
+func VerifyBatchRepr(
+	repr []byte, start, end engine.MVCCKey, nowNanos int64,
+) (enginepb.MVCCStats, error) {
+	var stats C.MVCCStatsResult
+	if err := statusToError(C.DBBatchReprVerify(
+		goToCSlice(repr), goToCKey(start), goToCKey(end), C.int64_t(nowNanos), &stats,
+	)); err != nil {
+		return enginepb.MVCCStats{}, err
+	}
+	return cStatsToGoStats(stats, nowNanos)
+}
+
+// TODO(dan): The following are all duplicated from storage/engine/rocksdb.go,
+// but if you export the ones there and reuse them here, it doesn't work.
+//
+// `cannot use engine.GoToCSlice(repr) (type engine.C.struct___0) as type C.struct___0 in argument to _Cfunc_DBBatchReprVerify`
+//
+// At worst, we could split these out into a separate file in storage/engine and
+// use `go generate` to copy it here so they stay in sync.
+
+// goToCSlice converts a go byte slice to a DBSlice. Note that this is
+// potentially dangerous as the DBSlice holds a reference to the go
+// byte slice memory that the Go GC does not know about. This method
+// is only intended for use in converting arguments to C
+// functions. The C function must copy any data that it wishes to
+// retain once the function returns.
+func goToCSlice(b []byte) C.DBSlice {
+	if len(b) == 0 {
+		return C.DBSlice{data: nil, len: 0}
+	}
+	return C.DBSlice{
+		data: (*C.char)(unsafe.Pointer(&b[0])),
+		len:  C.int(len(b)),
+	}
+}
+
+func goToCKey(key engine.MVCCKey) C.DBKey {
+	return C.DBKey{
+		key:       goToCSlice(key.Key),
+		wall_time: C.int64_t(key.Timestamp.WallTime),
+		logical:   C.int32_t(key.Timestamp.Logical),
+	}
+}
+
+func cStringToGoString(s C.DBString) string {
+	if s.data == nil {
+		return ""
+	}
+	result := C.GoStringN(s.data, s.len)
+	C.free(unsafe.Pointer(s.data))
+	return result
+}
+
+func statusToError(s C.DBStatus) error {
+	if s.data == nil {
+		return nil
+	}
+	return errors.New(cStringToGoString(s))
+}
+
+func cStatsToGoStats(stats C.MVCCStatsResult, nowNanos int64) (enginepb.MVCCStats, error) {
+	ms := enginepb.MVCCStats{}
+	if err := statusToError(stats.status); err != nil {
+		return ms, err
+	}
+	ms.ContainsEstimates = false
+	ms.LiveBytes = int64(stats.live_bytes)
+	ms.KeyBytes = int64(stats.key_bytes)
+	ms.ValBytes = int64(stats.val_bytes)
+	ms.IntentBytes = int64(stats.intent_bytes)
+	ms.LiveCount = int64(stats.live_count)
+	ms.KeyCount = int64(stats.key_count)
+	ms.ValCount = int64(stats.val_count)
+	ms.IntentCount = int64(stats.intent_count)
+	ms.IntentAge = int64(stats.intent_age)
+	ms.GCBytesAge = int64(stats.gc_bytes_age)
+	ms.SysBytes = int64(stats.sys_bytes)
+	ms.SysCount = int64(stats.sys_count)
+	ms.LastUpdateNanos = nowNanos
+	return ms, nil
+}

--- a/pkg/ccl/storageccl/engineccl/rocksdb_test.go
+++ b/pkg/ccl/storageccl/engineccl/rocksdb_test.go
@@ -1,0 +1,51 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Cockroach Community Licence (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+
+package engineccl
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestVerifyBatchRepr(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	keyA := engine.MVCCKey{Key: []byte("a")}
+	keyB := engine.MVCCKey{Key: []byte("b")}
+	keyC := engine.MVCCKey{Key: []byte("c")}
+	keyD := engine.MVCCKey{Key: []byte("d")}
+	keyE := engine.MVCCKey{Key: []byte("e")}
+
+	var batch engine.RocksDBBatchBuilder
+	key := engine.MVCCKey{Key: []byte("bb"), Timestamp: hlc.Timestamp{WallTime: 1}}
+	batch.Put(key, roachpb.MakeValueFromString("1").RawBytes)
+	data := batch.Finish()
+
+	ms, err := VerifyBatchRepr(data, keyB, keyC, 0)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	if ms.KeyCount != 1 {
+		t.Fatalf("got %d expected 1", ms.KeyCount)
+	}
+
+	// Key is before the range in the request span.
+	if _, err := VerifyBatchRepr(data, keyD, keyE, 0); !testutils.IsError(err, "request range") {
+		t.Fatalf("expected request range error got: %+v", err)
+	}
+	// Key is after the range in the request span.
+	if _, err := VerifyBatchRepr(data, keyA, keyB, 0); !testutils.IsError(err, "request range") {
+		t.Fatalf("expected request range error got: %+v", err)
+	}
+}

--- a/pkg/ccl/storageccl/engineccl/rocksdbccl/db.cc
+++ b/pkg/ccl/storageccl/engineccl/rocksdbccl/db.cc
@@ -1,0 +1,57 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Cockroach Community Licence (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
+
+#include <memory>
+#include "rocksdb/iterator.h"
+#include "rocksdb/comparator.h"
+#include "rocksdb/write_batch.h"
+#include "rocksdb/write_batch_base.h"
+#include "rocksdb/utilities/write_batch_with_index.h"
+#include "cockroach/pkg/storage/engine/enginepb/mvcc.pb.h"
+#include "db.h"
+#include "db_internal.h"
+
+#include <iostream>
+
+extern "C" {
+#include "_cgo_export.h"
+}
+
+const DBStatus kSuccess = { NULL, 0 };
+
+DBStatus DBBatchReprVerify(
+  DBSlice repr, DBKey start, DBKey end, int64_t now_nanos, MVCCStatsResult* stats
+) {
+  const rocksdb::Comparator* kComparator = CockroachComparator();
+
+  // TODO(dan): Inserting into a batch just to iterate over it is unfortunate.
+  // Consider replacing this with WriteBatch's Iterate/Handler mechanism and
+  // computing MVCC stats on the post-ApplyBatchRepr engine. splitTrigger does
+  // the latter and it's a headache for propEvalKV, so wait to see how that
+  // settles out before doing it that way.
+  rocksdb::WriteBatchWithIndex batch(kComparator, 0, true);
+  rocksdb::WriteBatch b(ToString(repr));
+  std::unique_ptr<rocksdb::WriteBatch::Handler> inserter(GetDBBatchInserter(&batch));
+  b.Iterate(inserter.get());
+  std::unique_ptr<rocksdb::Iterator> iter;
+  iter.reset(batch.NewIteratorWithBase(rocksdb::NewEmptyIterator()));
+
+  iter->SeekToFirst();
+  if (iter->Valid() && kComparator->Compare(iter->key(), EncodeKey(start)) < 0) {
+    return FmtStatus("key not in request range");
+  }
+  iter->SeekToLast();
+  if (iter->Valid() && kComparator->Compare(iter->key(), EncodeKey(end)) >= 0) {
+    return FmtStatus("key not in request range");
+  }
+
+  *stats = MVCCComputeStatsInternal(iter.get(), start, end, now_nanos);
+
+  return kSuccess;
+}
+

--- a/pkg/ccl/storageccl/engineccl/rocksdbccl/db.h
+++ b/pkg/ccl/storageccl/engineccl/rocksdbccl/db.h
@@ -1,0 +1,31 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Cockroach Community Licence (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
+
+#ifndef ROACHLIBCCL_DB_H
+#define ROACHLIBCCL_DB_H
+
+#include "../../../../storage/engine/rocksdb/db.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// DBBatchReprVerify asserts that all keys in a BatchRepr are between the
+// specified start and end keys and computes the MVCCStatsResult for it.
+DBStatus DBBatchReprVerify(
+  DBSlice repr, DBKey start, DBKey end, int64_t now_nanos, MVCCStatsResult* stats);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif // ROACHLIBCCL_DB_H
+
+// local variables:
+// mode: c++
+// end:

--- a/pkg/ccl/storageccl/engineccl/rocksdbccl/rocksdb.go
+++ b/pkg/ccl/storageccl/engineccl/rocksdbccl/rocksdb.go
@@ -1,0 +1,23 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Cockroach Community Licence (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
+
+package rocksdbccl
+
+import (
+	// Import rocksdb for the cgo headers.
+	_ "github.com/cockroachdb/cockroach/pkg/storage/engine/rocksdb"
+)
+
+// #cgo CPPFLAGS: -I ../../../../../vendor/github.com/cockroachdb/c-protobuf/internal/src
+// #cgo CPPFLAGS: -I ../../../../../vendor/github.com/cockroachdb/c-rocksdb/internal/include
+// #cgo CPPFLAGS: -I ../../../../../pkg/storage/engine/rocksdb
+// #cgo CXXFLAGS: -std=c++11
+// #cgo darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
+// #cgo !darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all
+// #cgo linux LDFLAGS: -lrt
+import "C"

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1299,23 +1299,27 @@ func (r *rocksDBIterator) ComputeStats(
 	start, end MVCCKey, nowNanos int64,
 ) (enginepb.MVCCStats, error) {
 	result := C.MVCCComputeStats(r.iter, goToCKey(start), goToCKey(end), C.int64_t(nowNanos))
+	return cStatsToGoStats(result, nowNanos)
+}
+
+func cStatsToGoStats(stats C.MVCCStatsResult, nowNanos int64) (enginepb.MVCCStats, error) {
 	ms := enginepb.MVCCStats{}
-	if err := statusToError(result.status); err != nil {
+	if err := statusToError(stats.status); err != nil {
 		return ms, err
 	}
 	ms.ContainsEstimates = false
-	ms.LiveBytes = int64(result.live_bytes)
-	ms.KeyBytes = int64(result.key_bytes)
-	ms.ValBytes = int64(result.val_bytes)
-	ms.IntentBytes = int64(result.intent_bytes)
-	ms.LiveCount = int64(result.live_count)
-	ms.KeyCount = int64(result.key_count)
-	ms.ValCount = int64(result.val_count)
-	ms.IntentCount = int64(result.intent_count)
-	ms.IntentAge = int64(result.intent_age)
-	ms.GCBytesAge = int64(result.gc_bytes_age)
-	ms.SysBytes = int64(result.sys_bytes)
-	ms.SysCount = int64(result.sys_count)
+	ms.LiveBytes = int64(stats.live_bytes)
+	ms.KeyBytes = int64(stats.key_bytes)
+	ms.ValBytes = int64(stats.val_bytes)
+	ms.IntentBytes = int64(stats.intent_bytes)
+	ms.LiveCount = int64(stats.live_count)
+	ms.KeyCount = int64(stats.key_count)
+	ms.ValCount = int64(stats.val_count)
+	ms.IntentCount = int64(stats.intent_count)
+	ms.IntentAge = int64(stats.intent_age)
+	ms.GCBytesAge = int64(stats.gc_bytes_age)
+	ms.SysBytes = int64(stats.sys_bytes)
+	ms.SysCount = int64(stats.sys_count)
 	ms.LastUpdateNanos = nowNanos
 	return ms, nil
 }

--- a/pkg/storage/engine/rocksdb/db.h
+++ b/pkg/storage/engine/rocksdb/db.h
@@ -193,6 +193,9 @@ DBStatus DBIterError(DBIterator* iter);
 // Go code.
 DBStatus DBMergeOne(DBSlice existing, DBSlice update, DBString* new_value);
 
+// NB: The function (cStatsToGoStats) that converts these to the go
+// representation is unfortunately duplicated in engine and engineccl. If this
+// struct is changed, both places need to be updated.
 typedef struct {
   DBStatus status;
   int64_t live_bytes;

--- a/pkg/storage/engine/rocksdb/db_internal.h
+++ b/pkg/storage/engine/rocksdb/db_internal.h
@@ -1,0 +1,45 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Daniel Harrison (dan@cockroachlabs.com)
+
+#include "db.h"
+#include "rocksdb/iterator.h"
+#include "rocksdb/comparator.h"
+#include "rocksdb/write_batch.h"
+#include "rocksdb/write_batch_base.h"
+
+// ToString returns a c++ string with the contents of a DBSlice.
+std::string ToString(DBSlice s);
+
+// MVCC keys are encoded as <key>[<wall_time>[<logical>]]<#timestamp-bytes>. A
+// custom RocksDB comparator (DBComparator) is used to maintain the desired
+// ordering as these keys do not sort lexicographically correctly.
+std::string EncodeKey(DBKey k);
+
+// FmtStatus formats the given arguments printf-style into a DBStatus.
+DBStatus FmtStatus(const char *fmt, ...);
+
+// CockroachComparator returns CockroachDB's custom mvcc-aware RocksDB
+// comparator. The caller does not assume ownership.
+const ::rocksdb::Comparator* CockroachComparator();
+
+// GetDBBatchInserter returns a WriteBatch::Handler that operates on a
+// WriteBatchBase. The caller assumes ownership of the returned handler.
+::rocksdb::WriteBatch::Handler* GetDBBatchInserter(::rocksdb::WriteBatchBase* batch);
+
+// MVCCComputeStatsInternal returns the mvcc stats of the data in an iterator.
+// Stats are only computed for keys between the given range.
+MVCCStatsResult MVCCComputeStatsInternal(
+    ::rocksdb::Iterator* const iter_rep, DBKey start, DBKey end, int64_t now_nanos);


### PR DESCRIPTION
VerifyBatchRepr asserts that all keys in a BatchRepr are between the
specified start and end keys and computes the enginepb.MVCCStats for it.

Notably, this is our first ccl'd c++ code. A new header (and namespace
internal) are introduced to allow the ccl tree to use code that we don't
want to be callable from go.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13347)
<!-- Reviewable:end -->
