### PR TITLE
ui: add "overview" dashboard

### DIFF
--- a/pkg/ui/app/app.tsx
+++ b/pkg/ui/app/app.tsx
@@ -103,7 +103,7 @@ ReactDOM.render(
       <Route path="/" component={Layout}>
         <IndexRedirect to="cluster" />
         <Route path="cluster" component={ Nodes }>
-          <IndexRedirect to="all/runtime" />
+          <IndexRedirect to="all/overview" />
           <Route path={`all/:${dashboardNameAttr}`} component={NodeGraphs} />
           <Route path={ `node/:${nodeIDAttr}/:${dashboardNameAttr}` } component={NodeGraphs} />
         </Route>

--- a/pkg/ui/app/containers/nodeGraphs.tsx
+++ b/pkg/ui/app/containers/nodeGraphs.tsx
@@ -104,6 +104,75 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
 
     return <div className="section l-columns graph-lines">
       <div className="chart-group l-columns__left">
+        <GraphGroup groupId="node.overview" hide={dashboard !== "overview"}>
+          <LineGraph title="SQL Queries" sources={nodeSources} tooltip={`The average number of SELECT, INSERT, UPDATE, and DELETE statements per second across ${specifier}.`}>
+            <Axis>
+              <Metric name="cr.node.sql.select.count" title="Total Reads" nonNegativeRate />
+              <Metric name="cr.node.sql.distsql.select.count" title="DistSQL Reads" nonNegativeRate />
+              <Metric name="cr.node.sql.update.count" title="Updates" nonNegativeRate />
+              <Metric name="cr.node.sql.insert.count" title="Inserts" nonNegativeRate />
+              <Metric name="cr.node.sql.delete.count" title="Deletes" nonNegativeRate />
+            </Axis>
+          </LineGraph>
+          <LineGraph title="Exec Latency: 99th percentile"
+          tooltip={`The 99th percentile of latency between query requests and responses
+                    over a 1 minute period.
+                    Values are displayed individually for each node on each node.`}>
+            <Axis units={ AxisUnits.Duration }>
+              {
+                _.map(nodeIds, (node) =>
+                  <Metric key={node}
+                          name="cr.node.exec.latency-p99"
+                          title={this.nodeAddress(node)}
+                          sources={[node]}
+                          downsampleMax />,
+                )
+              }
+            </Axis>
+          </LineGraph>
+          <LineGraph title="Exec Latency: 90th percentile"
+                    tooltip={`The 90th percentile of latency between query requests and responses
+                              over a 1 minute period.
+                              Values are displayed individually for each node on each node.`}>
+            <Axis units={ AxisUnits.Duration }>
+              {
+                _.map(nodeIds, (node) =>
+                  <Metric key={node}
+                          name="cr.node.exec.latency-p90"
+                          title={this.nodeAddress(node)}
+                          sources={[node]}
+                          downsampleMax />,
+                )
+              }
+            </Axis>
+          </LineGraph>
+          <LineGraph title="Replicas per Store"
+                    tooltip={`The number of replicas on each store.`}>
+            <Axis>
+              {
+                _.map(nodeIds, (nid) =>
+                  <Metric key={nid}
+                          name="cr.store.replicas"
+                          title={this.nodeAddress(nid)}
+                          sources={this.storeIDsForNode(nid)}/>,
+                )
+              }
+            </Axis>
+          </LineGraph>
+          <LineGraph title="Capacity" sources={storeSources} tooltip={`Summary of total and available capacity ${specifier}.`}>
+            <Axis>
+              <Metric name="cr.store.capacity" title="Capacity" />
+              {
+                // TODO(mrtracy): We really want to display a used capacity
+                // stat, but that is not directly recorded. We either need to
+                // start directly recording it, or add the ability to create
+                // derived series.
+              }
+              <Metric name="cr.store.capacity.available" title="Available" />
+            </Axis>
+          </LineGraph>
+        </GraphGroup>
+
         <GraphGroup groupId="node.runtime" hide={dashboard !== "runtime"}>
           <LineGraph title="Node Count" tooltip="The number of nodes active on the cluster.">
             <Axis>

--- a/pkg/ui/app/containers/nodes.tsx
+++ b/pkg/ui/app/containers/nodes.tsx
@@ -26,6 +26,7 @@ interface ClusterOverviewState {
 }
 
 let dashboards = [
+  { value: "overview", label: "Overview" },
   { value: "runtime", label: "Runtime" },
   { value: "sql", label: "SQL" },
   { value: "storage", label: "Storage" },


### PR DESCRIPTION
This adds an overview dashboard with some stats that draw from
the other dashboards. It's meant to be a better landing dashboard
than any of the other, more specific, dashboards. It's also now
the new default dashboard.

Fixes #13163 

cc @vivekmenezes @kuanluo

![screen shot 2017-02-01 at 3 00 25 pm](https://cloud.githubusercontent.com/assets/3691886/22524274/957b9520-e890-11e6-8aa1-19ada82ff282.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13348)
<!-- Reviewable:end -->
