### PR TITLE
sql: regproc casts handle unqualified fn names

### DIFF
--- a/pkg/sql/testdata/pgoidtype
+++ b/pkg/sql/testdata/pgoidtype
@@ -18,23 +18,33 @@ SELECT 'upper(int)'::REGPROC, 'upper(int)'::REGPROCEDURE
 ----
 1736923753  1736923753
 
-query error function 'blah' does not exist
+query error unknown function: blah\(\)
 SELECT 'blah(ignored, ignored)'::REGPROC, 'blah(ignored, ignored)'::REGPROCEDURE
 
-query error function 'blah' does not exist
+query error unknown function: blah\(\)
 SELECT ' blah ( ignored , ignored ) '::REGPROC
 
-query error function 'blah' does not exist
+query error unknown function: blah\(\)
 SELECT 'blah ()'::REGPROC
 
-query error function 'blah' does not exist
+query error unknown function: blah\(\)
 SELECT 'blah( )'::REGPROC
 
-query error function 'blah\(, \)' does not exist
+query error unknown function: "blah\(, \)"\(\)
 SELECT 'blah(, )'::REGPROC
 
 query error more than one function named 'max'
 SELECT 'max'::REGPROC
+
+query OOOO
+SELECT 'array_in'::REGPROC, 'array_in(a,b,c)'::REGPROC, 'pg_catalog.array_in'::REGPROC, 'pg_catalog.array_in( a ,b, c )'::REGPROC
+----
+2892088402  2892088402  2892088402  2892088402
+
+query OOOO
+SELECT 'array_in'::REGPROCEDURE, 'array_in(a,b,c)'::REGPROCEDURE, 'pg_catalog.array_in'::REGPROCEDURE, 'pg_catalog.array_in( a ,b, c )'::REGPROCEDURE
+----
+2892088402  2892088402  2892088402  2892088402
 
 query O
 SELECT 'public'::REGNAMESPACE
@@ -49,10 +59,10 @@ SELECT 'bool'::REGTYPE
 query error relation 'blah' does not exist
 SELECT 'blah'::REGCLASS
 
-query error function 'blah' does not exist
+query error unknown function: blah\(\)
 SELECT 'blah'::REGPROC
 
-query error function 'blah' does not exist
+query error unknown function: blah\(\)
 SELECT 'blah'::REGPROCEDURE
 
 query error namespace 'blah' does not exist


### PR DESCRIPTION
Previously, `::regproc` casts couldn't handle unqualified references to
qualified functions - like using `array_in` to refer to
`pg_catalog.array_in`. Now the input name is looked up via the function
resolution infrastructure, which allows such references.

cc @nvanbenschoten

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13353)
<!-- Reviewable:end -->
