### PR TITLE
sql: report precise oid type names to pg_type

### DIFF
--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1412,9 +1412,13 @@ CREATE TABLE pg_catalog.pg_type (
 			if cat == typCategoryArray {
 				typInput = arrayInProcOid
 			}
+			typname := typ.String()
+			if n, ok := aliasedOidToName[oid]; ok {
+				typname = n
+			}
 			if err := addRow(
 				parser.NewDOid(parser.DInt(oid)), // oid
-				parser.NewDName(typ.String()),    // typname
+				parser.NewDName(typname),         // typname
 				pgNamespacePGCatalog.Oid,         // typnamespace
 				parser.DNull,                     // typowner
 				typLen(typ),                      // typlen
@@ -1453,6 +1457,21 @@ CREATE TABLE pg_catalog.pg_type (
 		}
 		return nil
 	},
+}
+
+// aliasedOidToName maps Postgres object IDs to type names for those OIDs that map to
+// Cockroach types that have more than one associated OID, like Int. The name
+// for these OIDs will override the type name of the corresponding type when
+// looking up the display name for an OID.
+var aliasedOidToName = map[oid.Oid]string{
+	oid.T_float4: "float4",
+	oid.T_float8: "float8",
+	oid.T_int2:   "int2",
+	oid.T_int4:   "int4",
+	oid.T_int8:   "int8",
+	oid.T__int2:  "int2[]",
+	oid.T__int4:  "int4[]",
+	oid.T__int8:  "int8[]",
 }
 
 // typOid is the only OID generation approach that does not use oidHasher, because

--- a/pkg/sql/testdata/builtin_function
+++ b/pkg/sql/testdata/builtin_function
@@ -1396,17 +1396,17 @@ SELECT format_type(oid, -1) FROM pg_type WHERE typname='string' LIMIT 1
 text
 
 query T
-SELECT format_type(oid, -1) FROM pg_type WHERE typname='int' LIMIT 1
+SELECT format_type(oid, -1) FROM pg_type WHERE typname='int8' LIMIT 1
 ----
 bigint
 
 query T
-SELECT format_type(oid, -1) FROM pg_type WHERE typname='float' LIMIT 1
+SELECT format_type(oid, -1) FROM pg_type WHERE typname='float8' LIMIT 1
 ----
 double precision
 
 query T
-SELECT format_type(oid, -1) FROM pg_type WHERE typname='int[]' LIMIT 1
+SELECT format_type(oid, -1) FROM pg_type WHERE typname='int8[]' LIMIT 1
 ----
 bigint[]
 

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -653,17 +653,17 @@ oid   typname      typnamespace  typowner  typlen  typbyval  typtype
 16    bool         1782195457    NULL      1       true      b
 17    bytes        1782195457    NULL      -1      false     b
 19    name         1782195457    NULL      -1      false     b
-20    int          1782195457    NULL      8       true      b
-21    int          1782195457    NULL      8       true      b
-23    int          1782195457    NULL      8       true      b
+20    int8         1782195457    NULL      8       true      b
+21    int2         1782195457    NULL      8       true      b
+23    int4         1782195457    NULL      8       true      b
 25    string       1782195457    NULL      -1      false     b
 26    oid          1782195457    NULL      8       true      b
-700   float        1782195457    NULL      8       true      b
-701   float        1782195457    NULL      8       true      b
-1005  int[]        1782195457    NULL      -1      false     b
-1007  int[]        1782195457    NULL      -1      false     b
+700   float4       1782195457    NULL      8       true      b
+701   float8       1782195457    NULL      8       true      b
+1005  int2[]       1782195457    NULL      -1      false     b
+1007  int4[]       1782195457    NULL      -1      false     b
 1009  string[]     1782195457    NULL      -1      false     b
-1016  int[]        1782195457    NULL      -1      false     b
+1016  int8[]       1782195457    NULL      -1      false     b
 1043  string       1782195457    NULL      -1      false     b
 1082  date         1782195457    NULL      8       true      b
 1114  timestamp    1782195457    NULL      24      true      b
@@ -682,17 +682,17 @@ oid   typname      typcategory  typispreferred  typisdefined  typdelim  typrelid
 16    bool         B            false           true          ,         0         0        0
 17    bytes        U            false           true          ,         0         0        0
 19    name         S            false           true          ,         0         0        0
-20    int          N            false           true          ,         0         0        0
-21    int          N            false           true          ,         0         0        0
-23    int          N            false           true          ,         0         0        0
+20    int8         N            false           true          ,         0         0        0
+21    int2         N            false           true          ,         0         0        0
+23    int4         N            false           true          ,         0         0        0
 25    string       S            false           true          ,         0         0        0
 26    oid          N            false           true          ,         0         0        0
-700   float        N            false           true          ,         0         0        0
-701   float        N            false           true          ,         0         0        0
-1005  int[]        A            false           true          ,         0         0        0
-1007  int[]        A            false           true          ,         0         0        0
+700   float4       N            false           true          ,         0         0        0
+701   float8       N            false           true          ,         0         0        0
+1005  int2[]       A            false           true          ,         0         0        0
+1007  int4[]       A            false           true          ,         0         0        0
 1009  string[]     A            false           true          ,         0         0        0
-1016  int[]        A            false           true          ,         0         0        0
+1016  int8[]       A            false           true          ,         0         0        0
 1043  string       S            false           true          ,         0         0        0
 1082  date         D            false           true          ,         0         0        0
 1114  timestamp    D            false           true          ,         0         0        0
@@ -711,17 +711,17 @@ oid   typname      typinput    typoutput  typreceive  typsend  typmodin  typmodo
 16    bool         0           0          0           0        0         0          0
 17    bytes        0           0          0           0        0         0          0
 19    name         0           0          0           0        0         0          0
-20    int          0           0          0           0        0         0          0
-21    int          0           0          0           0        0         0          0
-23    int          0           0          0           0        0         0          0
+20    int8         0           0          0           0        0         0          0
+21    int2         0           0          0           0        0         0          0
+23    int4         0           0          0           0        0         0          0
 25    string       0           0          0           0        0         0          0
 26    oid          0           0          0           0        0         0          0
-700   float        0           0          0           0        0         0          0
-701   float        0           0          0           0        0         0          0
-1005  int[]        2892088402  0          0           0        0         0          0
-1007  int[]        2892088402  0          0           0        0         0          0
+700   float4       0           0          0           0        0         0          0
+701   float8       0           0          0           0        0         0          0
+1005  int2[]       2892088402  0          0           0        0         0          0
+1007  int4[]       2892088402  0          0           0        0         0          0
 1009  string[]     2892088402  0          0           0        0         0          0
-1016  int[]        2892088402  0          0           0        0         0          0
+1016  int8[]       2892088402  0          0           0        0         0          0
 1043  string       0           0          0           0        0         0          0
 1082  date         0           0          0           0        0         0          0
 1114  timestamp    0           0          0           0        0         0          0
@@ -740,17 +740,17 @@ oid   typname      typalign  typstorage  typnotnull  typbasetype  typtypmod
 16    bool         NULL      NULL        false       0            -1
 17    bytes        NULL      NULL        false       0            -1
 19    name         NULL      NULL        false       0            -1
-20    int          NULL      NULL        false       0            -1
-21    int          NULL      NULL        false       0            -1
-23    int          NULL      NULL        false       0            -1
+20    int8         NULL      NULL        false       0            -1
+21    int2         NULL      NULL        false       0            -1
+23    int4         NULL      NULL        false       0            -1
 25    string       NULL      NULL        false       0            -1
 26    oid          NULL      NULL        false       0            -1
-700   float        NULL      NULL        false       0            -1
-701   float        NULL      NULL        false       0            -1
-1005  int[]        NULL      NULL        false       0            -1
-1007  int[]        NULL      NULL        false       0            -1
+700   float4       NULL      NULL        false       0            -1
+701   float8       NULL      NULL        false       0            -1
+1005  int2[]       NULL      NULL        false       0            -1
+1007  int4[]       NULL      NULL        false       0            -1
 1009  string[]     NULL      NULL        false       0            -1
-1016  int[]        NULL      NULL        false       0            -1
+1016  int8[]       NULL      NULL        false       0            -1
 1043  string       NULL      NULL        false       0            -1
 1082  date         NULL      NULL        false       0            -1
 1114  timestamp    NULL      NULL        false       0            -1
@@ -769,17 +769,17 @@ oid   typname      typndims  typcollation  typdefaultbin  typdefault  typacl
 16    bool         0         0             NULL           NULL        NULL
 17    bytes        0         0             NULL           NULL        NULL
 19    name         0         1661428263    NULL           NULL        NULL
-20    int          0         0             NULL           NULL        NULL
-21    int          0         0             NULL           NULL        NULL
-23    int          0         0             NULL           NULL        NULL
+20    int8         0         0             NULL           NULL        NULL
+21    int2         0         0             NULL           NULL        NULL
+23    int4         0         0             NULL           NULL        NULL
 25    string       0         1661428263    NULL           NULL        NULL
 26    oid          0         0             NULL           NULL        NULL
-700   float        0         0             NULL           NULL        NULL
-701   float        0         0             NULL           NULL        NULL
-1005  int[]        0         0             NULL           NULL        NULL
-1007  int[]        0         0             NULL           NULL        NULL
+700   float4       0         0             NULL           NULL        NULL
+701   float8       0         0             NULL           NULL        NULL
+1005  int2[]       0         0             NULL           NULL        NULL
+1007  int4[]       0         0             NULL           NULL        NULL
 1009  string[]     0         1661428263    NULL           NULL        NULL
-1016  int[]        0         0             NULL           NULL        NULL
+1016  int8[]       0         0             NULL           NULL        NULL
 1043  string       0         1661428263    NULL           NULL        NULL
 1082  date         0         0             NULL           NULL        NULL
 1114  timestamp    0         0             NULL           NULL        NULL


### PR DESCRIPTION
`pg_catalog.pg_type` now reports the postgres-supplied name for oids that
correspond to types such as `int8`, `int4`, and `int2`, despite the fact that
we don't support those names syntactically and represent them all as the
same type internally.

This enables support for various ORMs, such as ActiveRecord, that might
rely on the reported `typname` for each of the rows in `pg_type`.

cc @nvanbenschoten 

Resolves #12145.
Resolves #12530.
Updates #13045.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13355)
<!-- Reviewable:end -->
