### PR TITLE
storage: add COCKROACH_DISABLE_TIMED_MUTEX env var

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -273,13 +273,13 @@ type Replica struct {
 	// Locking notes: Replica.raftMu < Replica.mu
 	//
 	// TODO(peter): evaluate runtime overhead of the timed mutex.
-	raftMu TimedMutex
+	raftMu timedMutex
 
 	cmdQMu struct {
 		// Protects all fields in the cmdQMu struct.
 		//
 		// Locking notes: Replica.mu < Replica.cmdQMu
-		TimedMutex
+		timedMutex
 		// Enforces at most one command is running per key(s). The global
 		// component tracks user writes (i.e. all keys for which keys.Addr is
 		// the identity), the local component the rest (e.g. RangeDescriptor,
@@ -291,7 +291,7 @@ type Replica struct {
 		// Protects all fields in the mu struct.
 		//
 		// TODO(peter): evaluate runtime overhead of the timed mutex.
-		TimedMutex
+		timedMutex
 		// Has the replica been destroyed.
 		destroyed error
 		// Corrupted persistently (across process restarts) indicates whether the
@@ -560,7 +560,7 @@ func newReplica(rangeID roachpb.RangeID, store *Store) *Replica {
 	// Add replica pointer value.
 	r.AmbientContext.AddLogTagStr("@", fmt.Sprintf("%x", unsafe.Pointer(r)))
 
-	raftMuLogger := ThresholdLogger(
+	raftMuLogger := thresholdLogger(
 		r.AnnotateCtx(context.Background()),
 		defaultReplicaRaftMuWarnThreshold,
 		func(ctx context.Context, msg string, args ...interface{}) {
@@ -570,9 +570,9 @@ func newReplica(rangeID roachpb.RangeID, store *Store) *Replica {
 			r.store.metrics.MuRaftNanos.RecordValue(t.Nanoseconds())
 		},
 	)
-	r.raftMu = MakeTimedMutex(raftMuLogger)
+	r.raftMu = makeTimedMutex(raftMuLogger)
 
-	replicaMuLogger := ThresholdLogger(
+	replicaMuLogger := thresholdLogger(
 		r.AnnotateCtx(context.Background()),
 		defaultReplicaMuWarnThreshold,
 		func(ctx context.Context, msg string, args ...interface{}) {
@@ -582,9 +582,9 @@ func newReplica(rangeID roachpb.RangeID, store *Store) *Replica {
 			r.store.metrics.MuReplicaNanos.RecordValue(t.Nanoseconds())
 		},
 	)
-	r.mu.TimedMutex = MakeTimedMutex(replicaMuLogger)
+	r.mu.timedMutex = makeTimedMutex(replicaMuLogger)
 
-	cmdQMuLogger := ThresholdLogger(
+	cmdQMuLogger := thresholdLogger(
 		r.AnnotateCtx(context.Background()),
 		defaultReplicaMuWarnThreshold,
 		func(ctx context.Context, msg string, args ...interface{}) {
@@ -594,7 +594,7 @@ func newReplica(rangeID roachpb.RangeID, store *Store) *Replica {
 			r.store.metrics.MuCommandQueueNanos.RecordValue(t.Nanoseconds())
 		},
 	)
-	r.cmdQMu.TimedMutex = MakeTimedMutex(cmdQMuLogger)
+	r.cmdQMu.timedMutex = makeTimedMutex(cmdQMuLogger)
 	return r
 }
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -396,8 +396,8 @@ func TestReplicaContains(t *testing.T) {
 
 	// This test really only needs a hollow shell of a Replica.
 	r := &Replica{}
-	r.mu.TimedMutex = syncutil.MakeTimedMutex(defaultMuLogger)
-	r.cmdQMu.TimedMutex = syncutil.MakeTimedMutex(defaultMuLogger)
+	r.mu.TimedMutex = MakeTimedMutex(defaultMuLogger)
+	r.cmdQMu.TimedMutex = MakeTimedMutex(defaultMuLogger)
 	r.mu.state.Desc = desc
 	r.rangeStr.store(0, desc)
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -396,8 +396,8 @@ func TestReplicaContains(t *testing.T) {
 
 	// This test really only needs a hollow shell of a Replica.
 	r := &Replica{}
-	r.mu.TimedMutex = MakeTimedMutex(defaultMuLogger)
-	r.cmdQMu.TimedMutex = MakeTimedMutex(defaultMuLogger)
+	r.mu.timedMutex = makeTimedMutex(defaultMuLogger)
+	r.cmdQMu.timedMutex = makeTimedMutex(defaultMuLogger)
 	r.mu.state.Desc = desc
 	r.rangeStr.store(0, desc)
 

--- a/pkg/storage/scanner_test.go
+++ b/pkg/storage/scanner_test.go
@@ -56,8 +56,8 @@ func newTestRangeSet(count int, t *testing.T) *testRangeSet {
 		repl := &Replica{
 			RangeID: desc.RangeID,
 		}
-		repl.mu.TimedMutex = syncutil.MakeTimedMutex(defaultMuLogger)
-		repl.cmdQMu.TimedMutex = syncutil.MakeTimedMutex(defaultMuLogger)
+		repl.mu.TimedMutex = MakeTimedMutex(defaultMuLogger)
+		repl.cmdQMu.TimedMutex = MakeTimedMutex(defaultMuLogger)
 		repl.mu.state.Stats = enginepb.MVCCStats{
 			KeyBytes:  1,
 			ValBytes:  2,

--- a/pkg/storage/scanner_test.go
+++ b/pkg/storage/scanner_test.go
@@ -56,8 +56,8 @@ func newTestRangeSet(count int, t *testing.T) *testRangeSet {
 		repl := &Replica{
 			RangeID: desc.RangeID,
 		}
-		repl.mu.TimedMutex = MakeTimedMutex(defaultMuLogger)
-		repl.cmdQMu.TimedMutex = MakeTimedMutex(defaultMuLogger)
+		repl.mu.timedMutex = makeTimedMutex(defaultMuLogger)
+		repl.cmdQMu.timedMutex = makeTimedMutex(defaultMuLogger)
 		repl.mu.state.Stats = enginepb.MVCCStats{
 			KeyBytes:  1,
 			ValBytes:  2,

--- a/pkg/storage/scheduler.go
+++ b/pkg/storage/scheduler.go
@@ -130,7 +130,7 @@ type raftScheduler struct {
 	numWorkers int
 
 	mu struct {
-		TimedMutex
+		timedMutex
 		cond    *sync.Cond
 		queue   rangeIDQueue
 		state   map[roachpb.RangeID]raftScheduleState
@@ -147,7 +147,7 @@ func newRaftScheduler(
 		processor:  processor,
 		numWorkers: numWorkers,
 	}
-	muLogger := ThresholdLogger(
+	muLogger := thresholdLogger(
 		ambient.AnnotateCtx(context.Background()),
 		defaultReplicaMuWarnThreshold,
 		func(ctx context.Context, msg string, args ...interface{}) {
@@ -159,8 +159,8 @@ func newRaftScheduler(
 			}
 		},
 	)
-	s.mu.TimedMutex = MakeTimedMutex(muLogger)
-	s.mu.cond = sync.NewCond(&s.mu.TimedMutex)
+	s.mu.timedMutex = makeTimedMutex(muLogger)
+	s.mu.cond = sync.NewCond(&s.mu.timedMutex)
 	s.mu.state = make(map[roachpb.RangeID]raftScheduleState)
 	return s
 }

--- a/pkg/storage/scheduler.go
+++ b/pkg/storage/scheduler.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
 const rangeIDChunkSize = 1000
@@ -131,7 +130,7 @@ type raftScheduler struct {
 	numWorkers int
 
 	mu struct {
-		syncutil.TimedMutex
+		TimedMutex
 		cond    *sync.Cond
 		queue   rangeIDQueue
 		state   map[roachpb.RangeID]raftScheduleState
@@ -148,7 +147,7 @@ func newRaftScheduler(
 		processor:  processor,
 		numWorkers: numWorkers,
 	}
-	muLogger := syncutil.ThresholdLogger(
+	muLogger := ThresholdLogger(
 		ambient.AnnotateCtx(context.Background()),
 		defaultReplicaMuWarnThreshold,
 		func(ctx context.Context, msg string, args ...interface{}) {
@@ -160,7 +159,7 @@ func newRaftScheduler(
 			}
 		},
 	)
-	s.mu.TimedMutex = syncutil.MakeTimedMutex(muLogger)
+	s.mu.TimedMutex = MakeTimedMutex(muLogger)
 	s.mu.cond = sync.NewCond(&s.mu.TimedMutex)
 	s.mu.state = make(map[roachpb.RangeID]raftScheduleState)
 	return s

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -525,7 +525,7 @@ type Store struct {
 
 	mu struct {
 		// TODO(peter): evaluate runtime overhead of the timed mutex.
-		syncutil.TimedMutex // Protects all variables in the mu struct.
+		TimedMutex // Protects all variables in the mu struct.
 		// Map of replicas by Range ID. This includes `uninitReplicas`.
 		replicas map[roachpb.RangeID]*Replica
 		// A btree key containing objects of type *Replica or
@@ -855,7 +855,7 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 	s.drainLeases.Store(false)
 	s.scheduler = newRaftScheduler(s.cfg.AmbientCtx, s.metrics, s, storeSchedulerConcurrency)
 
-	storeMuLogger := syncutil.ThresholdLogger(
+	storeMuLogger := ThresholdLogger(
 		s.AnnotateCtx(context.Background()),
 		defaultStoreMutexWarnThreshold,
 		func(ctx context.Context, msg string, args ...interface{}) {
@@ -865,7 +865,7 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 			s.metrics.MuStoreNanos.RecordValue(t.Nanoseconds())
 		},
 	)
-	s.mu.TimedMutex = syncutil.MakeTimedMutex(storeMuLogger)
+	s.mu.TimedMutex = MakeTimedMutex(storeMuLogger)
 
 	s.coalescedMu.Lock()
 	s.coalescedMu.heartbeats = map[roachpb.StoreIdent][]RaftHeartbeat{}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -525,7 +525,7 @@ type Store struct {
 
 	mu struct {
 		// TODO(peter): evaluate runtime overhead of the timed mutex.
-		TimedMutex // Protects all variables in the mu struct.
+		timedMutex // Protects all variables in the mu struct.
 		// Map of replicas by Range ID. This includes `uninitReplicas`.
 		replicas map[roachpb.RangeID]*Replica
 		// A btree key containing objects of type *Replica or
@@ -855,7 +855,7 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 	s.drainLeases.Store(false)
 	s.scheduler = newRaftScheduler(s.cfg.AmbientCtx, s.metrics, s, storeSchedulerConcurrency)
 
-	storeMuLogger := ThresholdLogger(
+	storeMuLogger := thresholdLogger(
 		s.AnnotateCtx(context.Background()),
 		defaultStoreMutexWarnThreshold,
 		func(ctx context.Context, msg string, args ...interface{}) {
@@ -865,7 +865,7 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 			s.metrics.MuStoreNanos.RecordValue(t.Nanoseconds())
 		},
 	)
-	s.mu.TimedMutex = MakeTimedMutex(storeMuLogger)
+	s.mu.timedMutex = makeTimedMutex(storeMuLogger)
 
 	s.coalescedMu.Lock()
 	s.coalescedMu.heartbeats = map[roachpb.StoreIdent][]RaftHeartbeat{}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -52,11 +52,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
-var defaultMuLogger = syncutil.ThresholdLogger(
+var defaultMuLogger = ThresholdLogger(
 	context.Background(),
 	10*time.Second,
 	log.Warningf,
@@ -668,8 +667,8 @@ func TestProcessRangeDescriptorUpdate(t *testing.T) {
 		store:      store,
 		abortCache: NewAbortCache(desc.RangeID),
 	}
-	r.mu.TimedMutex = syncutil.MakeTimedMutex(defaultMuLogger)
-	r.cmdQMu.TimedMutex = syncutil.MakeTimedMutex(defaultMuLogger)
+	r.mu.TimedMutex = MakeTimedMutex(defaultMuLogger)
+	r.cmdQMu.TimedMutex = MakeTimedMutex(defaultMuLogger)
 	if err := r.init(desc, store.Clock(), 0); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -55,7 +55,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
-var defaultMuLogger = ThresholdLogger(
+var defaultMuLogger = thresholdLogger(
 	context.Background(),
 	10*time.Second,
 	log.Warningf,
@@ -667,8 +667,8 @@ func TestProcessRangeDescriptorUpdate(t *testing.T) {
 		store:      store,
 		abortCache: NewAbortCache(desc.RangeID),
 	}
-	r.mu.TimedMutex = MakeTimedMutex(defaultMuLogger)
-	r.cmdQMu.TimedMutex = MakeTimedMutex(defaultMuLogger)
+	r.mu.timedMutex = makeTimedMutex(defaultMuLogger)
+	r.cmdQMu.timedMutex = makeTimedMutex(defaultMuLogger)
 	if err := r.init(desc, store.Clock(), 0); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/timedmutex.go
+++ b/pkg/storage/timedmutex.go
@@ -20,11 +20,14 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 
 	"golang.org/x/net/context"
 )
+
+var disableTimedMutex = envutil.EnvOrDefaultBool("COCKROACH_DISABLE_TIMED_MUTEX", false)
 
 // timedMutex is a mutex which dumps a stack trace via the supplied callback
 // whenever a lock is unlocked after having been held for longer than the
@@ -74,10 +77,13 @@ func thresholdLogger(
 }
 
 // makeTimedMutex creates a TimedMutex which warns when an Unlock happens more
-// than warnDuration after the corresponding lock. It will use the supplied
-// context and logging callback for the warning message; a nil logger falls
-// back to Fprintf to os.Stderr.
+// than warnDuration after the corresponding lock. If non-nil, it will invoke
+// the supplied timingFn callback after each unlock with the elapsed time that
+// the mutex was held for.
 func makeTimedMutex(cb timingFn) timedMutex {
+	if disableTimedMutex {
+		cb = nil
+	}
 	return timedMutex{
 		cb: cb,
 		mu: &syncutil.Mutex{},

--- a/pkg/storage/timedmutex.go
+++ b/pkg/storage/timedmutex.go
@@ -26,32 +26,32 @@ import (
 	"golang.org/x/net/context"
 )
 
-// TimedMutex is a mutex which dumps a stack trace via the supplied callback
+// timedMutex is a mutex which dumps a stack trace via the supplied callback
 // whenever a lock is unlocked after having been held for longer than the
 // supplied duration, which must be strictly positive.
-type TimedMutex struct {
+type timedMutex struct {
 	mu       *syncutil.Mutex // intentionally pointer to make zero value unusable
 	lockedAt time.Time       // protected by mu
 	isLocked int32           // updated atomically
 
 	// Non-mutable fields.
-	cb TimingFn
+	cb timingFn
 }
 
-// TimingFn is a callback passed to MakeTimedMutex. It is invoked with the
+// timingFn is a callback passed to MakeTimedMutex. It is invoked with the
 // measured duration of the critical section of the associated mutex after
 // each Unlock operation.
-type TimingFn func(heldFor time.Duration)
+type timingFn func(heldFor time.Duration)
 
-// ThresholdLogger returns a timing function which calls 'record' for each
+// thresholdLogger returns a timing function which calls 'record' for each
 // measured duration and, for measurements exceeding 'warnDuration', invokes
 // 'printf' with the passed context and a detailed stack trace.
-func ThresholdLogger(
+func thresholdLogger(
 	ctx context.Context,
 	warnDuration time.Duration,
 	printf func(context.Context, string, ...interface{}),
-	record TimingFn,
-) TimingFn {
+	record timingFn,
+) timingFn {
 	return func(heldFor time.Duration) {
 		record(heldFor)
 		if heldFor > warnDuration {
@@ -73,26 +73,26 @@ func ThresholdLogger(
 	}
 }
 
-// MakeTimedMutex creates a TimedMutex which warns when an Unlock happens more
+// makeTimedMutex creates a TimedMutex which warns when an Unlock happens more
 // than warnDuration after the corresponding lock. It will use the supplied
 // context and logging callback for the warning message; a nil logger falls
 // back to Fprintf to os.Stderr.
-func MakeTimedMutex(cb TimingFn) TimedMutex {
-	return TimedMutex{
+func makeTimedMutex(cb timingFn) timedMutex {
+	return timedMutex{
 		cb: cb,
 		mu: &syncutil.Mutex{},
 	}
 }
 
 // Lock implements sync.Locker.
-func (tm *TimedMutex) Lock() {
+func (tm *timedMutex) Lock() {
 	tm.mu.Lock()
 	atomic.StoreInt32(&tm.isLocked, 1)
 	tm.lockedAt = timeutil.Now()
 }
 
 // Unlock implements sync.Locker.
-func (tm *TimedMutex) Unlock() {
+func (tm *timedMutex) Unlock() {
 	lockedAt := tm.lockedAt
 	atomic.StoreInt32(&tm.isLocked, 0)
 	tm.mu.Unlock()
@@ -113,7 +113,7 @@ func (tm *TimedMutex) Unlock() {
 //
 // TODO(bdarnell): Add an equivalent method to syncutil.Mutex
 // (possibly a no-op depending on a build tag)
-func (tm *TimedMutex) AssertHeld() {
+func (tm *timedMutex) AssertHeld() {
 	isLocked := atomic.LoadInt32(&tm.isLocked)
 	if isLocked == 0 {
 		panic("mutex is not locked")

--- a/pkg/storage/timedmutex_test.go
+++ b/pkg/storage/timedmutex_test.go
@@ -39,12 +39,12 @@ func TestTimedMutex(t *testing.T) {
 	record := func(time.Duration) { numMeasurements++ }
 
 	{
-		cb := ThresholdLogger(
+		cb := thresholdLogger(
 			context.Background(), time.Nanosecond, printf, record,
 		)
 
 		// Should fire.
-		tm := MakeTimedMutex(cb)
+		tm := makeTimedMutex(cb)
 		tm.Lock()
 		time.Sleep(2 * time.Nanosecond)
 		tm.Unlock()
@@ -62,10 +62,10 @@ func TestTimedMutex(t *testing.T) {
 	msgs = nil
 
 	{
-		cb := ThresholdLogger(
+		cb := thresholdLogger(
 			context.Background(), time.Duration(math.MaxInt64), printf, record,
 		)
-		tm := MakeTimedMutex(cb)
+		tm := makeTimedMutex(cb)
 
 		const num = 10
 		for i := 0; i < num; i++ {
@@ -88,7 +88,7 @@ func TestTimedMutex(t *testing.T) {
 func TestAssertHeld(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	tm := MakeTimedMutex(nil)
+	tm := makeTimedMutex(nil)
 
 	// The normal, successful case.
 	tm.Lock()


### PR DESCRIPTION
For performance testing. The first 2 commits are mechanical. The code
movement is to remove the temptation to use TimedMutex in more places.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13356)
<!-- Reviewable:end -->
