### PR TITLE
sql: enable limit propagation past "nosort" nodes.

### DIFF
--- a/pkg/sql/limit_opt.go
+++ b/pkg/sql/limit_opt.go
@@ -86,8 +86,8 @@ func applyLimit(plan planNode, numRows int64, soft bool) {
 			// potentially needs all rows.
 			numRows = math.MaxInt64
 			soft = true
-			applyLimit(n.plan, numRows, soft)
 		}
+		applyLimit(n.plan, numRows, soft)
 
 	case *groupNode:
 		if len(n.desiredOrdering) > 0 {

--- a/pkg/sql/testdata/order_by
+++ b/pkg/sql/testdata/order_by
@@ -158,6 +158,19 @@ EXPLAIN SELECT b FROM t ORDER BY a DESC
 2           table  t@primary
 2           spans  ALL
 
+# Check that LIMIT propagates past nosort nodes.
+query ITTT
+EXPLAIN SELECT b FROM t ORDER BY a LIMIT 1
+----
+0  limit
+1  nosort
+1          order  +a
+2  render
+3  scan
+3          table  t@primary
+3          spans  ALL
+3          limit  1
+
 query ITTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b ASC
 ----


### PR DESCRIPTION
An oversight in 81e8f13b70b7e95092b53f65dadda78cc847891c caused limit
propagation to be blocked by "nosort" nodes (sortNode with !needSort).

Found and fixed by @petermattis.

Fixes #13352.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13363)
<!-- Reviewable:end -->
