### PR TITLE
Intentionally break release build to test notifications

### DIFF
--- a/build/build-static-binaries.sh
+++ b/build/build-static-binaries.sh
@@ -16,6 +16,9 @@ time make STATIC=1 testbuild GOFLAGS="${GOFLAGS-}" SUFFIX="${SUFFIX-}" TAGS="${T
 check_static "cockroach${SUFFIX-}"
 check_static "cli/cli.test${SUFFIX-}"
 
+# Try running the cockroach binary.
+MALLOC_CONF=prof:true ./cockroach${SUFFIX-} version
+
 strip -S "cockroach${SUFFIX-}"
 find . -type f -name '*.test*' -exec strip -S {} ';'
 


### PR DESCRIPTION
We had a failing `release build` for 5-6 days, which would easily have been caught had notifications properly been sent.
I'm intentionally re-introducing one of the failures that caused it to fail (the image does not exist) to see if my tweak to notifications helps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13365)
<!-- Reviewable:end -->
