### PR TITLE
sql: add COCKROACH_DISABLE_SQL_EVENT_LOG (default false)

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -526,7 +526,9 @@ func (e *Executor) execRequest(session *Session, sql string, copymsg copyMsg) St
 	var stmts parser.StatementList
 	var err error
 
-	log.VEventf(session.Ctx(), 2, "execRequest: %s", sql)
+	if log.V(2) {
+		log.Infof(session.Ctx(), "execRequest: %s", sql)
+	}
 
 	if session.planner.copyFrom != nil {
 		stmts, err = session.planner.ProcessCopyData(sql, copymsg)

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -50,6 +50,11 @@ import (
 var traceSQLDuration = envutil.EnvOrDefaultDuration("COCKROACH_TRACE_SQL", 0)
 var traceSQL = traceSQLDuration > 0
 
+// COCKROACH_DISABLE_SQL_EVENT_LOG can be used to disable the event log that is
+// normally kept for every SQL connection. The event log has a non-trivial
+// performance impact.
+var disableSQLEventLog = envutil.EnvOrDefaultBool("COCKROACH_DISABLE_SQL_EVENT_LOG", false)
+
 // COCKROACH_TRACE_7881 can be used to trace all SQL transactions, in the hope
 // that we'll catch #7881 and dump the current trace for debugging.
 var traceSQLFor7881 = envutil.EnvOrDefaultBool("COCKROACH_TRACE_7881", false)
@@ -142,7 +147,7 @@ func NewSession(
 	s.PreparedStatements = makePreparedStatements(s)
 	s.PreparedPortals = makePreparedPortals(s)
 
-	if opentracing.SpanFromContext(ctx) == nil {
+	if !disableSQLEventLog && opentracing.SpanFromContext(ctx) == nil {
 		remoteStr := "<admin>"
 		if remote != nil {
 			remoteStr = remote.String()


### PR DESCRIPTION
Allow the per-connection SQL eventlog to be disabled for performance
testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13366)
<!-- Reviewable:end -->
