### PR TITLE
storage: avoid unnecessary abort cache check on reads

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1935,10 +1935,15 @@ func (r *Replica) addReadOnlyCmd(
 	var result EvalResult
 	br, result, pErr = r.executeBatch(ctx, storagebase.CmdIDKey(""), r.store.Engine(), nil, ba)
 
-	if pErr == nil && ba.Txn != nil {
-		// Checking whether the transaction has been aborted on reads
-		// makes sure that we don't experience anomalous conditions as
-		// described in #2231.
+	if pErr == nil && ba.Txn != nil && ba.Txn.Writing {
+		// Checking whether the transaction has been aborted on reads makes sure
+		// that we don't experience anomalous conditions as described in #2231. We
+		// only perform this check for transactional reads in which the transaction
+		// has written a transaction record (Txn.Writing is true). The anomalous
+		// condition being avoided is for an aborted transaction to continue
+		// successfully performing reads. Note that this check doesn't completely
+		// avoid that behavior because we only detect the aborted transaction if
+		// this read is to a range that previously had a write.
 		pErr = r.checkIfTxnAborted(ctx, r.store.Engine(), *ba.Txn)
 	}
 	if intents := result.Local.detachIntents(); len(intents) > 0 {


### PR DESCRIPTION
We check the abort cache on reads in order to avoid the anomalous
condition of an aborted transaction continuing to successfully perform
read requests. The existing check does not catch all such read
operations, only those which touch a range that previously had a write
within the transaction. Now we only perform the check if the transaction
the read is a part of is in the "Writing" state which indicates that it
has performed at least one write.

This provides ~10-15% throughput improvement to a simple read-only
workload.

See #13359

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13367)
<!-- Reviewable:end -->
