### PR TITLE
sql: try harder to trim the filter expression after processing scanNodes.

### DIFF
--- a/pkg/sql/analyze_test.go
+++ b/pkg/sql/analyze_test.go
@@ -42,6 +42,8 @@ func testTableDesc() *sqlbase.TableDescriptor {
 			{Name: "i", Type: sqlbase.ColumnType{Kind: sqlbase.ColumnType_STRING}},
 			{Name: "j", Type: sqlbase.ColumnType{Kind: sqlbase.ColumnType_INT}},
 			{Name: "k", Type: sqlbase.ColumnType{Kind: sqlbase.ColumnType_BYTES}},
+			{Name: "l", Type: sqlbase.ColumnType{Kind: sqlbase.ColumnType_DECIMAL}},
+			{Name: "m", Type: sqlbase.ColumnType{Kind: sqlbase.ColumnType_DECIMAL}},
 		},
 		PrimaryIndex: sqlbase.IndexDescriptor{
 			Name: "primary", Unique: true, ColumnNames: []string{"a"},

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -693,7 +693,7 @@ func (sc *SchemaChanger) backfillIndexesChunk(
 
 		// We manually invoke selectIndex() because for now expandPlan()
 		// can only do so itself when looking at a renderNode.
-		rows, err := selectIndex(scan, nil, false)
+		rows, err := planner.selectIndex(scan, nil, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -291,7 +291,7 @@ func expandScanNode(params expandParameters, s *scanNode) (planNode, error) {
 		preferOrderMatchingIndex = true
 	}
 
-	plan, err := selectIndex(s, analyzeOrdering, preferOrderMatchingIndex)
+	plan, err := params.p.selectIndex(s, analyzeOrdering, preferOrderMatchingIndex)
 	if err != nil {
 		return s, err
 	}

--- a/pkg/sql/index_selection.go
+++ b/pkg/sql/index_selection.go
@@ -19,7 +19,6 @@ package sql
 import (
 	"bytes"
 	"fmt"
-	"reflect"
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -79,7 +78,7 @@ type analyzeOrderingFn func(indexOrdering orderingInfo) (matchingCols, totalCols
 //
 // If preferOrderMatching is true, we prefer an index that matches the desired
 // ordering completely, even if it is not a covering index.
-func selectIndex(
+func (p *planner) selectIndex(
 	s *scanNode, analyzeOrdering analyzeOrderingFn, preferOrderMatching bool,
 ) (planNode, error) {
 	if s.desc.IsEmpty() || (s.filter == nil && analyzeOrdering == nil && s.specifiedIndex == nil) {
@@ -204,7 +203,24 @@ func selectIndex(
 		// There are no spans to scan.
 		return &emptyNode{}, nil
 	}
+
 	s.filter = applyIndexConstraints(s.filter, c.constraints)
+	if s.filter != nil {
+		// Constraint propagation may have produced new constant sub-expressions.
+		// Propagate them and check if s.filter can be applied prematurely.
+		var err error
+		s.filter, err = p.evalCtx.NormalizeExpr(s.filter)
+		if err != nil {
+			return nil, err
+		}
+		if s.filter == parser.DBoolFalse {
+			return &emptyNode{}, nil
+		}
+		if s.filter == parser.DBoolTrue {
+			s.filter = nil
+		}
+	}
+
 	s.reverse = c.reverse
 
 	var plan planNode
@@ -487,7 +503,7 @@ func (v *indexInfo) makeOrConstraints(orExprs []parser.TypedExprs) error {
 // TODO(pmattis): It would be more obvious to perform this transform in
 // simplifyComparisonExpr, but doing so there eliminates some of the other
 // simplifications. For example, "a < 1 OR a > 1" currently simplifies to "a !=
-// 1", but if we performed this transform in simpilfyComparisonExpr it would
+// 1", but if we performed this transform in simplifyComparisonExpr it would
 // simplify to "a < 1 OR a >= 2" which is also the same as "a != 1", but not so
 // obvious based on comparisons of the constants.
 func (v *indexInfo) makeIndexConstraints(andExprs parser.TypedExprs) (indexConstraints, error) {
@@ -1373,13 +1389,23 @@ func applyIndexConstraints(
 	v := &applyConstraintsVisitor{}
 	expr := typedExpr.(parser.Expr)
 	for _, c := range constraints[0] {
-		v.constraint = c
+		// Apply the start constraint.
+		v.constraints = expandConstraint(v.constraints, c.start, c.tupleMap)
 		expr, _ = parser.WalkExpr(v, expr)
+
+		if c.start != c.end {
+			// If there is a range (x >= 3 AND x <= 10), apply the
+			// end-of-range constraint as well.
+			v.constraints = expandConstraint(v.constraints, c.end, c.tupleMap)
+			expr, _ = parser.WalkExpr(v, expr)
+		}
+
 		// We can only continue to apply the constraints if the constraints we have
 		// applied so far are equality constraints. There are two cases to
-		// consider: the first is that both the start and end constraints are
-		// equality.
+		// consider, both of which satisfy c.start == c.end.
 		if c.start == c.end {
+			// The first is that both the start and end constraints are
+			// equality.
 			if c.start.Operator == parser.EQ {
 				continue
 			}
@@ -1397,102 +1423,99 @@ func applyIndexConstraints(
 	return expr.(parser.TypedExpr)
 }
 
+// expandConstraint transforms a potentially complex constraint
+// expression into one or more simple constraints suitable for the
+// VisitPre() code below.
+// The following are transformed:
+// - (a,b,c) = (x,y,z)    -> [a=x, b=y, c=z]     (same for !=)
+// - (a,b,c) <= (x,y,z)   -> [a<=x]              (same for <=)
+// - (a,b,c) < (x,y,z)    -> [a<=x]              (same for >)
+// - (a,b,c) IN ((x,y,z)) -> [a=x, b=y, c=z] but only for the part
+//                           of the tuple (a,b,c) that was matched by the index.
+// - (a,b,c) IS TRUE, (a,b,c) IS NULL, etc -> constraint ignored
+func expandConstraint(
+	a []*parser.ComparisonExpr, c *parser.ComparisonExpr, tupleMap []int,
+) []*parser.ComparisonExpr {
+	if c == nil {
+		return a
+	}
+	if vars, ok := c.Left.(*parser.Tuple); ok {
+		if c.Operator == parser.Is || c.Operator == parser.IsNot {
+			// The syntax <tuple> IS <val> or <tuple> IS NOT <val> is
+			// always false.
+			return a
+		}
+		vals := *c.Right.(*parser.DTuple)
+
+		switch c.Operator {
+		case parser.NE, parser.EQ:
+			// (a,b,c) != (x,y,z)  ->  [a!=x, b!=y, c!=z]
+			// (a,b,c) = (x,y,z)   ->  [a=x, b=y, c=z]
+			for i, v := range vars.Exprs {
+				a = append(a, &parser.ComparisonExpr{Operator: c.Operator, Left: v, Right: vals.D[i]})
+			}
+
+		case parser.LT:
+			// (a,b,c) < (x,y,z)  -> [a<=x]
+			a = append(a,
+				&parser.ComparisonExpr{Operator: parser.LE, Left: vars.Exprs[0], Right: vals.D[0]})
+		case parser.GT:
+			// (a,b,c) > (x,y,z)  -> [a>=x]
+			a = append(a,
+				&parser.ComparisonExpr{Operator: parser.GE, Left: vars.Exprs[0], Right: vals.D[0]})
+		case parser.LE, parser.GE:
+			// (a,b,c) <= (x,y,z)  -> [a<=x]
+			a = append(a,
+				&parser.ComparisonExpr{Operator: c.Operator, Left: vars.Exprs[0], Right: vals.D[0]})
+
+		case parser.In:
+			// (a,b,c) IN ((x,y,z)) -> [a=x, b=y, c=z]
+			// But beware of which part of the tuple has been matched by the index.
+			if len(vals.D) == 1 {
+				if oneTuplep, ok := vals.D[0].(*parser.DTuple); ok {
+					oneTuple := *oneTuplep
+					for i := range tupleMap {
+						a = append(a,
+							&parser.ComparisonExpr{Operator: parser.EQ, Left: vars.Exprs[i], Right: oneTuple.D[i]})
+					}
+				}
+			}
+		}
+	} else {
+		a = append(a, c)
+	}
+	return a
+}
+
 type applyConstraintsVisitor struct {
-	constraint indexConstraint
+	constraints []*parser.ComparisonExpr
 }
 
 func (v *applyConstraintsVisitor) VisitPre(expr parser.Expr) (recurse bool, newExpr parser.Expr) {
-	switch t := expr.(type) {
-	case *parser.AndExpr, *parser.NotExpr:
-		return true, expr
+	if t, ok := expr.(*parser.ComparisonExpr); ok {
 
-	case *parser.ComparisonExpr:
-		c := v.constraint.start
-		if c == nil {
-			return true, expr
-		}
-		if !varEqual(t.TypedLeft(), c.TypedLeft()) {
-			return true, expr
-		}
-		if !isDatum(t.TypedRight()) || !isDatum(c.TypedRight()) {
-			return true, expr
-		}
-		if tuple, ok := c.Left.(*parser.Tuple); ok {
-			// Do not apply a constraint on a tuple which does not use the entire
-			// tuple.
-			//
-			// TODO(peter): The current code is conservative. We could trim the
-			// tuple instead.
-			if len(tuple.Exprs) != len(v.constraint.tupleMap) {
-				return true, expr
-			}
-		}
-
-		datum := t.Right.(parser.Datum)
-		cdatum := c.Right.(parser.Datum)
-
-		switch t.Operator {
-		case parser.EQ:
-			if v.constraint.start != v.constraint.end {
-				return true, expr
-			}
-
-			switch c.Operator {
-			case parser.EQ:
-				// Expr: "a = <val>", constraint: "a = <val>".
-				if reflect.TypeOf(datum) != reflect.TypeOf(cdatum) {
-					return true, expr
-				}
-				cmp := datum.Compare(cdatum)
-				if cmp == 0 {
-					return false, parser.DBoolTrue
-				}
-			case parser.In:
-				// Expr: "a = <val>", constraint: "a IN (<vals>)".
-				ctuple := cdatum.(*parser.DTuple).D
-				if reflect.TypeOf(datum) != reflect.TypeOf(ctuple[0]) {
-					return true, expr
-				}
-				i := sort.Search(len(ctuple), func(i int) bool {
-					return ctuple[i].(parser.Datum).Compare(datum) >= 0
-				})
-				if i < len(ctuple) && ctuple[i].Compare(datum) == 0 {
-					return false, parser.DBoolTrue
-				}
-			}
-
-		case parser.In:
-			if v.constraint.start != v.constraint.end {
-				return true, expr
-			}
-
-			switch c.Operator {
-			case parser.In:
-				// Expr: "a IN (<vals>)", constraint: "a IN (<vals>)".
-				if reflect.TypeOf(datum) != reflect.TypeOf(cdatum) {
-					return true, expr
-				}
-				diff := datum.(*parser.DTuple).SortedDifference(cdatum.(*parser.DTuple))
-				if len(diff.D) == 0 {
-					return false, parser.DBoolTrue
-				}
-				t.Right = diff
-			}
-
-		case parser.IsNot:
-			switch c.Operator {
-			case parser.IsNot:
-				if datum == parser.DNull && cdatum == parser.DNull {
-					// Expr: "a IS NOT NULL", constraint: "a IS NOT NULL"
-					return false, parser.DBoolTrue
+		// If looking at an expression of the form (a,b,c) IN ((x,y,z)), decompose it.
+		if tLeft, ok2 := t.Left.(*parser.Tuple); ok2 {
+			if tRight, ok3 := t.Right.(*parser.DTuple); ok3 && len(tRight.D) == 1 {
+				if vRight, ok4 := tRight.D[0].(*parser.DTuple); ok4 {
+					andExprs := make([]parser.TypedExpr, len(vRight.D))
+					for i, v := range tLeft.Exprs {
+						tv := v.(parser.TypedExpr)
+						andExprs[i] = parser.NewTypedComparisonExpr(parser.EQ, tv, vRight.D[i])
+					}
+					return true, joinAndExprs(andExprs)
 				}
 			}
 		}
 
-	default:
-		return false, expr
+		for _, c := range v.constraints {
+			expr = applyConstraint(t, c)
+			t, ok = expr.(*parser.ComparisonExpr)
+			if !ok {
+				break
+			}
+		}
 	}
-
 	return true, expr
 }
 
@@ -1507,6 +1530,240 @@ func (v *applyConstraintsVisitor) VisitPost(expr parser.Expr) parser.Expr {
 			return t.Left
 		}
 	}
-
 	return expr
+}
+
+// applyConstraint tries to simplify the expression t on the left
+// assuming that the expression c on the right (the constraint) is
+// true.
+func applyConstraint(t *parser.ComparisonExpr, c *parser.ComparisonExpr) parser.Expr {
+	// Check that both expressions have the same variable on the left.
+	// It is always true for the constraint, and
+	// simplifyExpr() has ensured this is true in most sub-expressions of t.
+	varLeft := c.Left.(*parser.IndexedVar)
+	if varRight, ok := t.Left.(*parser.IndexedVar); !ok || varLeft.Idx != varRight.Idx {
+		return t
+	}
+
+	// applyConstraint() is only defined over comparisons that
+	// have a Datum on the right side.
+	datum, ok := t.Right.(parser.Datum)
+	if !ok {
+		return t
+	}
+	cdatum := c.Right.(parser.Datum)
+
+	switch c.Operator {
+	case parser.IsNot:
+		if cdatum == parser.DNull {
+			switch t.Operator {
+			case parser.Is:
+				return parser.MakeDBool(datum != parser.DNull)
+			case parser.IsNot:
+				return parser.MakeDBool(datum == parser.DNull)
+			}
+		} else {
+			return applyConstraintFlat(t, datum, parser.NE, cdatum)
+		}
+	case parser.Is:
+		if cdatum == parser.DNull {
+			switch t.Operator {
+			case parser.Is:
+				return parser.MakeDBool(datum == parser.DNull)
+			case parser.IsNot:
+				return parser.MakeDBool(datum != parser.DNull)
+			default:
+				// A NULL var compared to anything is always false.
+				return parser.DBoolFalse
+			}
+		} else {
+			return applyConstraintFlat(t, datum, parser.EQ, cdatum)
+		}
+	default:
+		return applyConstraintFlat(t, datum, c.Operator, cdatum)
+	}
+	return t
+}
+
+// applyConstraintFlat is the common branch of applyConstraint().
+// tries to simplify the expression t on the right which has the form
+// [x OP datum] assuming that the expression [x cOp cdatum] (the
+// constraint) is true.
+func applyConstraintFlat(
+	t *parser.ComparisonExpr, datum parser.Datum, cOp parser.ComparisonOperator, cdatum parser.Datum,
+) parser.Expr {
+	// Special casing: expression queries IS NULL or IS NOT NULL.
+	if (t.Operator == parser.Is || t.Operator == parser.IsNot) && datum == parser.DNull {
+		switch cOp {
+		case parser.EQ, parser.GE, parser.GT, parser.IN:
+			// If the constraint says the value is equal to something, it
+			// cannot be NULL.
+			// If the constraint says the value is greater to something, it
+			// cannot be NULL, because NULL sorts before anything else.
+			// If the constraint says the value is smaller than something,
+			// then we don't know, because NULL is smaller than everything
+			// else too.
+			// That's why the cases for parser.LE and parser.LT are missing
+			// above.
+			// This may need to be revisited once NULL
+			// ordering becomes configurable.
+			return parser.MakeDBool(t.Operator == parser.IsNot)
+		}
+		return t
+	}
+
+	// More special casing: constraint says "a IN (x, y, z...)"
+	if cOp == parser.In {
+		ctuple := cdatum.(*parser.DTuple)
+		switch t.Operator {
+		case parser.Is, parser.EQ:
+			// Expr asks "= Cst" or IS TRUE / IS FALSE: check whether the
+			// value is in the IN set. If it is not, we're sure it never
+			// matches. Otherwise we don't know.
+			i := sort.Search(len(ctuple.D), func(i int) bool {
+				return ctuple.D[i].(parser.Datum).Compare(datum) >= 0
+			})
+			if i >= len(ctuple.D) || ctuple.D[i].Compare(datum) != 0 {
+				return parser.DBoolFalse
+			}
+
+		case parser.In:
+			// Expr: "a IN (t, u, v, ...)"
+			// true if (x, y, z, ...) is a subset of (t, u, v, ...)
+			// unknown otherwise
+			if ttuple, ok := datum.(*parser.DTuple); ok {
+				// Note: A is a subset of B iff A \ B == empty.
+				diff := ctuple.SortedDifference(ttuple)
+				if len(diff.D) == 0 {
+					return parser.DBoolTrue
+				}
+			}
+
+		case parser.NotIn:
+			// Expr: "a NOT IN (t, u, v, ...)"
+			// True if none of the values in (x, y, z...) are in (t, u, v, ...)
+			// unknown otherwise
+			if ttuple, ok := datum.(*parser.DTuple); ok {
+				// Note: A inter B is empty iff A \ B == A
+				diff := ctuple.SortedDifference(ttuple)
+				if len(diff.D) < len(ctuple.D) {
+					return parser.DBoolTrue
+				}
+			}
+		}
+
+		return t
+	}
+
+	// More special casing: constraint says [a = value]
+	// and expression is [a != ...], [a IN ...] or [a NOT IN ...].
+	if cOp == parser.EQ {
+		switch t.Operator {
+		case parser.In:
+			// true if the known value is in the IN set, false otherwise.
+			if tuple, ok := datum.(*parser.DTuple); ok {
+				i := sort.Search(len(tuple.D), func(i int) bool {
+					return tuple.D[i].(parser.Datum).Compare(cdatum) >= 0
+				})
+				if i < len(tuple.D) && tuple.D[i].Compare(cdatum) == 0 {
+					return parser.DBoolTrue
+				}
+			}
+			return parser.DBoolFalse
+
+		case parser.NotIn:
+			// false if the known value is in the NOT IN set, true otherwise.
+			if tuple, ok := datum.(*parser.DTuple); ok {
+				i := sort.Search(len(tuple.D), func(i int) bool {
+					return tuple.D[i].(parser.Datum).Compare(cdatum) >= 0
+				})
+				if i < len(tuple.D) && tuple.D[i].Compare(cdatum) == 0 {
+					return parser.DBoolFalse
+				}
+			}
+			return parser.DBoolTrue
+		}
+	}
+
+	// General case: constraint and expression both specify a range.
+
+	// This comparison uses some magic courtesy of Radu.
+	//
+	// We map a few interesting points of the datum space to the integer
+	// axis as follows:
+	//
+	//                  /- the smaller between datum and cdatum
+	//                  |
+	// -infinity        |      /- the larger between datum and cdatum
+	//     |            |      |
+	//     |            |      |            /- +infinity
+	//     v            v      v            v
+	//     |------------|------|------------|
+	//   -100           0      10          100
+	//
+	// If the datums are equal, they both map to 0.
+	//
+	// Constraints become closed intervals on this axis. For example: a
+	// "GT" constraint with the smaller datum becomes [0, 100].  For
+	// exclusive constraints we add or subtract 1 from the datum value:
+	// a "GE" constraint with the smaller datum becomes [1, 100]; a "LE"
+	// constraint becomes [-100, -1].
+	//
+	// Checking for overlap between the constraints then becomes
+	// equivalent to checking for overlap between the closed intervals
+	// (which is easy).
+
+	cmp := datum.Compare(cdatum)
+	tStart, tEnd, tOk := makeComparisonInterval(t.Operator, cmp > 0)
+	cStart, cEnd, cOk := makeComparisonInterval(cOp, cmp < 0)
+
+	disjoint := cStart > tEnd || tStart > cEnd
+	overlapping := tStart <= cStart && cEnd <= tEnd
+
+	if tOk && cOk {
+		if disjoint {
+			return parser.DBoolFalse
+		}
+		if overlapping {
+			return parser.DBoolTrue
+		}
+		return t
+	}
+	// BOOM: just handled 5*5 combinations of operators!
+	//
+	// If the constraint is an interval and the expression is NE/IsNot,
+	// we can till use the intervals (hence the NE case in
+	// makeInterval).
+	if cOk && (t.Operator == parser.NE || t.Operator == parser.IsNot) && disjoint {
+		return parser.DBoolTrue
+	}
+	return t
+}
+
+// makeComparisonInterval supports the range comparison in applyConstraintsFlat above.
+// See the comment at the point of call for more details.
+// The boolean return value indicates whether the comparison actually
+// defines a range.
+func makeComparisonInterval(op parser.ComparisonOperator, largerDatum bool) (int, int, bool) {
+	x := 0
+	if largerDatum {
+		x = 10
+	}
+
+	switch op {
+	case parser.EQ, parser.Is:
+		return x, x, true
+	case parser.LE:
+		return -100, x, true
+	case parser.LT:
+		return -100, x - 1, true
+	case parser.GE:
+		return x, 100, true
+	case parser.GT:
+		return x + 1, 100, true
+	case parser.NE, parser.IsNot:
+		return x, x, false
+	default:
+		return 0, 0, false
+	}
 }

--- a/pkg/sql/index_selection_test.go
+++ b/pkg/sql/index_selection_test.go
@@ -648,8 +648,8 @@ func TestApplyConstraints(t *testing.T) {
 		{`a = 1 AND b = 1`, `a,b`, `<nil>`},
 		{`a = 1 AND b = 1`, `a`, `b = 1`},
 		{`a = 1 AND b = 1`, `b`, `a = 1`},
-		{`a = 1 AND b > 1`, `a,b`, `b > 1`},
-		{`a > 1 AND b = 1`, `a,b`, `(a > 1) AND (b = 1)`},
+		{`a = 1 AND b > 1`, `a,b`, `<nil>`},
+		{`a > 1 AND b = 1`, `a,b`, `b = 1`},
 		{`a IN (1)`, `a`, `<nil>`},
 		{`a IN (1) OR a IN (2)`, `a`, `<nil>`},
 		{`a = 1 OR a = 2`, `a`, `<nil>`},
@@ -658,17 +658,35 @@ func TestApplyConstraints(t *testing.T) {
 		{`a != 1`, `a`, `a != 1`},
 		{`a IS NOT NULL`, `a`, `<nil>`},
 		{`a = 1 AND b IS NOT NULL`, `a,b`, `<nil>`},
-		{`a >= 1 AND b = 2`, `a,b`, `(a >= 1) AND (b = 2)`},
-		{`a >= 1 AND a <= 3 AND b = 2`, `a,b`, `(a >= 1) AND ((a <= 3) AND (b = 2))`},
+		{`a >= 1 AND b = 2`, `a,b`, `b = 2`},
+		{`a >= 1 AND a <= 3 AND b = 2`, `a,b`, `b = 2`},
 		{`(a, b) = (1, 2) AND c IS NOT NULL`, `a,b,c`, `<nil>`},
 		{`a IN (1, 2) AND b = 3`, `a,b`, `b = 3`},
-		{`a <= 5 AND b >= 6 AND (a, b) IN ((1, 2))`, `a,b`, `(a <= 5) AND (b >= 6)`},
+		{`a <= 5 AND b >= 6 AND (a, b) IN ((1, 2))`, `a,b`, `false`},
 		{`a IN (1) AND a = 1`, `a`, `<nil>`},
-		{`(a, b) = (1, 2)`, `a`, `(a, b) IN ((1, 2))`},
-		// Filters that are not trimmed as of Dec 2015, although they could be.
-		// Issue #3473.
-		// {`a > 1`, `a`, `<nil>`},
-		// {`a < 1`, `a`, `<nil>`},
+		{`(a, b) = (1, 2)`, `a`, `b = 2`},
+		{`a > 1`, `a`, `<nil>`},
+		{`a < 1`, `a`, `<nil>`},
+		// The constraint (l, m) < (123, 456) must be treated as implying
+		// l <= 123. This means that l < 123 definitely cannot be
+		// simplified.
+		// Note 1: we use DECIMAL columns so that constraint extraction
+		// cannot change the < constraint on the left <= by applying
+		// Next(). Any column type without a Next() would do.
+		// Note 2: we use a COALESCE expression to make the
+		// sub-expression "l < 123" invisible to constraint analysis; any
+		// function that returns an opaque boolean based on a boolean
+		// argument would do.
+		{`(l, m) < (123, 456) AND COALESCE(l < 123, true)`, `l,m`,
+			`((l, m) < (123, 456)) AND COALESCE(l < 123, true)`},
+		// Same for the other direction.
+		{`(l, m) > (123, 456) AND COALESCE(l > 123, true)`, `l,m`,
+			`((l, m) > (123, 456)) AND COALESCE(l > 123, true)`},
+		// The constraint a <= 1 implies that a != 2 is true.
+		// Note: we use COALESCE so that the sub-expression a != 2 is not
+		// elided during constraint analysis before constraint
+		// propagation.
+		{`a <= 1 AND COALESCE(a != 2, true)`, `a`, `COALESCE(true, true)`},
 	}
 	for _, d := range testData {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
@@ -677,7 +695,7 @@ func TestApplyConstraints(t *testing.T) {
 			constraints, expr := makeConstraints(t, d.expr, desc, index, sel)
 			expr2 := applyIndexConstraints(expr, constraints)
 			if s := fmt.Sprint(expr2); d.expected != s {
-				t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
+				t.Errorf("%s: expected %s, but found %s (constraints %s)", d.expr, d.expected, s, constraints)
 			}
 		})
 	}

--- a/pkg/sql/testdata/explain_types
+++ b/pkg/sql/testdata/explain_types
@@ -254,10 +254,9 @@ EXPLAIN (TYPES) SELECT * FROM tt WHERE x < 10 AND y > 10
 0                 render 0  (x)[int]
 0                 render 1  (y)[int]
 1  index-join                                             (x int, y int, rowid[hidden,omitted] int)   +x,+rowid,unique
-2  scan                                                   (x int, y[omitted] int, rowid[hidden] int)  +x,+rowid,unique
+2  scan                                                   (x[omitted] int, y[omitted] int, rowid[hidden] int)  +x,+rowid,unique
 2                 table     tt@a
 2                 spans     /#-/10
-2                 filter    ((x)[int] < (10)[int])[bool]
 2  scan                                                   (x int, y int, rowid[hidden,omitted] int)   +rowid,unique
 2                 table     tt@primary
 2                 filter    ((y)[int] > (10)[int])[bool]


### PR DESCRIPTION
Fixes #3473.
Fixes #13351.

cc @andreimatei.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13373)
<!-- Reviewable:end -->
