### PR TITLE
sql: make the backfill code use a limitNode for chunking.

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -697,7 +697,9 @@ func (sc *SchemaChanger) backfillIndexesChunk(
 			return err
 		}
 
-		if err := planner.startPlanWithLimit(rows, chunkSize); err != nil {
+		rows = &limitNode{p: planner, plan: rows, countExpr: parser.NewDInt(parser.DInt(chunkSize))}
+
+		if err := planner.startPlan(rows); err != nil {
 			return err
 		}
 

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -17,8 +17,6 @@
 package sql
 
 import (
-	"math"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -211,10 +209,6 @@ func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, er
 
 // startPlan starts the plan and all its sub-query nodes.
 func (p *planner) startPlan(plan planNode) error {
-	return p.startPlanWithLimit(plan, math.MaxInt64)
-}
-
-func (p *planner) startPlanWithLimit(plan planNode, numRowsNeeded int64) error {
 	if err := p.startSubqueryPlans(plan); err != nil {
 		return err
 	}
@@ -222,7 +216,7 @@ func (p *planner) startPlanWithLimit(plan planNode, numRowsNeeded int64) error {
 		return err
 	}
 	// Trigger limit propagation through the plan and sub-queries.
-	applyLimit(plan, numRowsNeeded, false /* !soft */)
+	setUnlimited(plan)
 	return nil
 }
 


### PR DESCRIPTION
By making the limit part of the semantic plan, distSQL will be able to use it.
(Not yet tested since distSQL is not yet activated for backfilling.)

Fixes #13368.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13374)
<!-- Reviewable:end -->
