### PR TITLE
cli: show the current database name in the prompt.

### DIFF
--- a/pkg/cli/interactive_tests/test_txn_prompt.tcl
+++ b/pkg/cli/interactive_tests/test_txn_prompt.tcl
@@ -8,42 +8,83 @@ spawn /bin/bash
 send "PS1='\\h:''/# '\r"
 eexpect ":/# "
 
-# Test that prompt becomes "OPEN>"
 send "$argv sql\r"
 eexpect root@
-send "begin;\r\r"
-eexpect "begin"
+
+# Create test database, test database prompt.
+send "CREATE DATABASE IF NOT EXISTS testdb;\r"
+eexpect "\nCREATE DATABASE\r\n"
+eexpect root@
+send "SET DATABASE = testdb;\r"
+eexpect "\nSET\r\n"
+eexpect root@
+eexpect "/testdb>"
+send "SET DATABASE = '';\r"
+eexpect "\nSET\r\n"
+eexpect root@
+eexpect "/>"
+
+# Test that prompt becomes "OPEN>"
+send "BEGIN;\r\r"
+
+eexpect "\nBEGIN\r\n"
+eexpect root@
 eexpect "OPEN>"
 
 # Test that prompt becomes "ERROR>"
 send "select a;\r"
 eexpect "pq: column name \"a\""
+eexpect root@
 eexpect "ERROR>"
-send "rollback;\r"
 
 # Test that prompt becomes "DONE>"
-send "begin;SAVEPOINT cockroach_restart;\r\r"
-send "select 1;\r"
+send "ROLLBACK;\r"
+eexpect "\nROLLBACK\r\n"
+eexpect root@
+
+send "BEGIN; SAVEPOINT cockroach_restart;\r\r"
+eexpect OK
+eexpect root@
+send "SELECT 1;\r"
+eexpect "1 row"
+eexpect root@
 send "RELEASE SAVEPOINT cockroach_restart;\r"
+eexpect "\nCOMMIT\r\n"
+eexpect root@
 eexpect "DONE>"
-send "commit;\r"
 
 # Test that prompt becomes "RETRY>"
-send "begin;SAVEPOINT cockroach_restart;\r\r"
+send "COMMIT;\r"
+eexpect root@
+
+send "BEGIN; SAVEPOINT cockroach_restart;\r\r"
+eexpect OK
+eexpect root@
 send "SELECT CRDB_INTERNAL.FORCE_RETRY('1s':::INTERVAL);\r"
+eexpect "pq: restart transaction"
+eexpect root@
 eexpect "RETRY>"
+
 send "ROLLBACK TO SAVEPOINT cockroach_restart;\r"
+eexpect OK
+eexpect root@
 eexpect "OPEN>"
-send "commit;\r"
 
-# Test that prompt becomes "?????>"
-send "begin;\r\r"
+send "COMMIT;\r"
+eexpect root@
+
+# Test that prompt becomes " ?>"
 stop_server $argv
-send "select 1;\r"
-eexpect "?????>"
 
+send "SELECT 1; SELECT 1;\r"
+eexpect "connection lost"
+eexpect root@
+eexpect " \\?>"
+
+# Terminate.
 send "\\q\r"
 eexpect ":/# "
+
 send "exit\r"
 eexpect eof
 


### PR DESCRIPTION
This completes #12747 by adding the missing test.

It also fixes the code to avoid retrieving the db state while a transaction is ongoing and not in a "simple" state.
It also fixes a couple of broken tests in `test_txn_prompts.tcl` that were introduced in 282b76ccebf450613e634ea7df5e768c931a4ea1.

Fixes #12038.

cc @pmamatsis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13379)
<!-- Reviewable:end -->
