### PR TITLE
server: Node Restart Event records Last Up time

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -80,6 +80,12 @@ var (
 	// localStoreGossipSuffix stores gossip bootstrap metadata for this
 	// store, updated any time new gossip hosts are encountered.
 	localStoreGossipSuffix = []byte("goss")
+	// localStoreLastUpSuffix stores the last timestamp that a store's node
+	// acknowledged that it was still running. This value will be regularly
+	// refreshed on all stores for a running node; the intention of this value
+	// is to allow a restarting node to discover approximately how long it has
+	// been down without needing to retrieve liveness records from the cluster.
+	localStoreLastUpSuffix = []byte("uptm")
 
 	// LocalRangeIDPrefix is the prefix identifying per-range data
 	// indexed by Range ID. The Range ID is appended to this prefix,

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -52,6 +52,11 @@ func StoreGossipKey() roachpb.Key {
 	return MakeStoreKey(localStoreGossipSuffix, nil)
 }
 
+// StoreLastUpKey returns the key for the store's "last up" timestamp.
+func StoreLastUpKey() roachpb.Key {
+	return MakeStoreKey(localStoreLastUpSuffix, nil)
+}
+
 // NodeLivenessKey returns the key for the node liveness record.
 func NodeLivenessKey(nodeID roachpb.NodeID) roachpb.Key {
 	key := make(roachpb.Key, 0, len(NodeLivenessPrefix)+9)

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -125,6 +125,7 @@ type Node struct {
 	metrics     nodeMetrics
 	recorder    *status.MetricsRecorder
 	startedAt   int64
+	lastUp      int64
 	initialBoot bool // True if this is the first time this node has started.
 	txnMetrics  kv.TxnMetrics
 
@@ -477,6 +478,23 @@ func (n *Node) initStores(
 	}
 	log.Event(ctx, "validated stores")
 
+	// Compute the time this node was last up; this is done by reading the
+	// "last up time" from every store and choosing the most recent timestamp.
+	mostRecentTimestamp := hlc.ZeroTimestamp
+	if err := n.stores.VisitStores(func(s *storage.Store) error {
+		timestamp, err := s.ReadLastUpTimestamp(ctx)
+		if err != nil {
+			return err
+		}
+		if mostRecentTimestamp.Less(timestamp) {
+			mostRecentTimestamp = timestamp
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrapf(err, "failed to read last up timestamp from stores")
+	}
+	n.lastUp = mostRecentTimestamp.WallTime
+
 	// Set the stores map as the gossip persistent storage, so that
 	// gossip can bootstrap using the most recently persisted set of
 	// node addresses.
@@ -747,8 +765,10 @@ func (n *Node) recordJoinEvent() {
 	}
 
 	logEventType := sql.EventLogNodeRestart
+	lastUp := n.lastUp
 	if n.initialBoot {
 		logEventType = sql.EventLogNodeJoin
+		lastUp = n.startedAt
 	}
 
 	n.stopper.RunWorker(func() {
@@ -766,7 +786,8 @@ func (n *Node) recordJoinEvent() {
 						Descriptor roachpb.NodeDescriptor
 						ClusterID  uuid.UUID
 						StartedAt  int64
-					}{n.Descriptor, n.ClusterID, n.startedAt},
+						LastUp     int64
+					}{n.Descriptor, n.ClusterID, n.startedAt, lastUp},
 				)
 			}); err != nil {
 				log.Warningf(ctx, "%s: unable to log %s event: %s", n, logEventType, err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -687,7 +687,15 @@ func (s *Server) Start(ctx context.Context) error {
 
 	log.Event(ctx, "accepting connections")
 
-	s.nodeLiveness.StartHeartbeat(ctx, s.stopper)
+	// Begin the node liveness heartbeat. Add a callback which records the local
+	// store "last up" timestamp for every store whenever the liveness record
+	// is updated.
+	s.nodeLiveness.StartHeartbeat(ctx, s.stopper, func(ctx context.Context) error {
+		now := s.clock.Now()
+		return s.node.stores.VisitStores(func(s *storage.Store) error {
+			return s.WriteLastUpTimestamp(ctx, now)
+		})
+	})
 
 	// Initialize grpc-gateway mux and context.
 	jsonpb := &protoutil.JSONPb{

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -84,6 +84,10 @@ type LivenessMetrics struct {
 // Callbacks can be registered via NodeLiveness.RegisterCallback().
 type IsLiveCallback func(nodeID roachpb.NodeID)
 
+// HeartbeatCallback is invoked whenever this node updates its own liveness status,
+// indicating that it is alive.
+type HeartbeatCallback func(context.Context) error
+
 // NodeLiveness encapsulates information on node liveness and provides
 // an API for querying, updating, and invalidating node
 // liveness. Nodes periodically "heartbeat" the range holding the node
@@ -102,6 +106,7 @@ type NodeLiveness struct {
 	incrementSem      chan struct{}
 	heartbeatSem      chan struct{}
 	metrics           LivenessMetrics
+	heartbeatCallback HeartbeatCallback
 
 	mu struct {
 		syncutil.Mutex
@@ -164,11 +169,15 @@ func (nl *NodeLiveness) IsLive(nodeID roachpb.NodeID) (bool, error) {
 }
 
 // StartHeartbeat starts a periodic heartbeat to refresh this node's
-// last heartbeat in the node liveness table.
-func (nl *NodeLiveness) StartHeartbeat(ctx context.Context, stopper *stop.Stopper) {
+// last heartbeat in the node liveness table. The optionally provided
+// HeartbeatCallback will be invoked whenever this node updates its own liveness.
+func (nl *NodeLiveness) StartHeartbeat(
+	ctx context.Context, stopper *stop.Stopper, alive HeartbeatCallback,
+) {
 	log.VEventf(ctx, 1, "starting liveness heartbeat")
 	retryOpts := base.DefaultRetryOptions()
 	retryOpts.Closer = stopper.ShouldQuiesce()
+	nl.heartbeatCallback = alive
 
 	stopper.RunWorker(func() {
 		ambient := nl.ambientCtx
@@ -458,6 +467,9 @@ func (nl *NodeLiveness) updateLiveness(
 			return handleCondFailed(actualLiveness)
 		}
 		return err
+	}
+	if nl.heartbeatCallback != nil {
+		return nl.heartbeatCallback(ctx)
 	}
 	return nil
 }

--- a/pkg/storage/node_liveness_test.go
+++ b/pkg/storage/node_liveness_test.go
@@ -139,9 +139,9 @@ func TestNodeLivenessInitialIncrement(t *testing.T) {
 	})
 }
 
-// TestNodeLivenessCallback verifies that the liveness callback for a
+// TestNodeIsLiveCallback verifies that the liveness callback for a
 // node is invoked when it changes from state false to true.
-func TestNodeLivenessCallback(t *testing.T) {
+func TestNodeIsLiveCallback(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	mtc := &multiTestContext{}
 	defer mtc.Stop()
@@ -184,6 +184,55 @@ func TestNodeLivenessCallback(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+// TestNodeHeartbeatCallback verifies that HeartbeatCallback is invoked whenever
+// this node updates its own liveness status.
+func TestNodeHeartbeatCallback(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	mtc := &multiTestContext{}
+	defer mtc.Stop()
+	mtc.Start(t, 3)
+
+	// Verify liveness of all nodes for all nodes.
+	verifyLiveness(t, mtc)
+	pauseNodeLivenessHeartbeats(mtc, true)
+
+	// Verify that last update time has been set for all nodes.
+	verifyUptimes := func() error {
+		expected := mtc.clock.Now()
+		for i, s := range mtc.stores {
+			uptm, err := s.ReadLastUpTimestamp(context.Background())
+			if err != nil {
+				return errors.Wrapf(err, "error reading last up time from store %d", i)
+			}
+			if a, e := uptm.WallTime, expected.WallTime; a != e {
+				return errors.Errorf("store %d last uptime = %d; wanted %d", i, a, e)
+			}
+		}
+		return nil
+	}
+
+	if err := verifyUptimes(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Advance clock past the liveness threshold and force a manual heartbeat on
+	// all node liveness objects, which should update the last up time for each
+	// store.
+	mtc.manualClock.Increment(mtc.nodeLivenesses[0].GetLivenessThreshold().Nanoseconds() + 1)
+	for _, nl := range mtc.nodeLivenesses {
+		l, err := nl.Self()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := nl.Heartbeat(context.Background(), l); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := verifyUptimes(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // TestNodeLivenessEpochIncrement verifies that incrementing the epoch


### PR DESCRIPTION
Augment the "Node Restart" event with an additional information field "LastUp",
which records the last time at which the node was up before it was restarted.
This field can be used with the existing "StartedAt" to determine the
approximate amount of time the node was down.

A new per-store local key is create which contains the last timestamp at which
the store's node was reported to be up. This timestamp is updated (on all stores
of the node) whenever the liveness record is successfully updated.

When a node restarts (and finds previously bootstrapped stores), it reads this
value from all stores, selecting the most recent timestamp from the stores, and
records this time in the "LastUp" field of the Node Restart event.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13382)
<!-- Reviewable:end -->
