### PR TITLE
storage: Disable timed mutex by default

### DIFF
--- a/pkg/storage/timedmutex.go
+++ b/pkg/storage/timedmutex.go
@@ -94,7 +94,9 @@ func makeTimedMutex(cb timingFn) timedMutex {
 func (tm *timedMutex) Lock() {
 	tm.mu.Lock()
 	atomic.StoreInt32(&tm.isLocked, 1)
-	tm.lockedAt = timeutil.Now()
+	if tm.cb != nil {
+		tm.lockedAt = timeutil.Now()
+	}
 }
 
 // Unlock implements sync.Locker.

--- a/pkg/storage/timedmutex.go
+++ b/pkg/storage/timedmutex.go
@@ -27,7 +27,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-var disableTimedMutex = envutil.EnvOrDefaultBool("COCKROACH_DISABLE_TIMED_MUTEX", false)
+var enableTimedMutex = envutil.EnvOrDefaultBool("COCKROACH_ENABLE_TIMED_MUTEX", false)
 
 // timedMutex is a mutex which dumps a stack trace via the supplied callback
 // whenever a lock is unlocked after having been held for longer than the
@@ -81,7 +81,7 @@ func thresholdLogger(
 // the supplied timingFn callback after each unlock with the elapsed time that
 // the mutex was held for.
 func makeTimedMutex(cb timingFn) timedMutex {
-	if disableTimedMutex {
+	if !enableTimedMutex {
 		cb = nil
 	}
 	return timedMutex{

--- a/pkg/storage/timedmutex_test.go
+++ b/pkg/storage/timedmutex_test.go
@@ -28,6 +28,10 @@ import (
 
 func TestTimedMutex(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer func(orig bool) {
+		enableTimedMutex = orig
+	}(enableTimedMutex)
+	enableTimedMutex = true
 
 	var msgs []string
 


### PR DESCRIPTION
These messages currently trigger very often and scare users because
they look like exceptions or crashes. We should only have them enabled
on our test clusters where we are watching for them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13388)
<!-- Reviewable:end -->
