### PR TITLE
scripts: add blame stats script

### DIFF
--- a/scripts/git-blame-stats.sh
+++ b/scripts/git-blame-stats.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# This script produces the list of authors that are "git blame"d for lines in
+# .go files under the current directory.
+#
+# The regular expression for filenames can be overridden on the command line.
+# To include all files, use a dot:
+#   git-blame-stats.sh .
+
+FILE_REGEXP='\.go$'
+if [ -n "$1" ]; then FILE_REGEXP=$1; fi
+
+git ls-tree -r HEAD \
+  | cut -f 2 \
+  | grep -E "$FILE_REGEXP" \
+  | xargs -n1 git blame --line-porcelain \
+  | grep "author " \
+  | sort \
+  | uniq -c \
+  | sort -nr


### PR DESCRIPTION
Script that lists the authors by # of lines they are blamed for under the
current directory.

Similar to `authors.sh`, except that it counts blamed lines instead of commits,
and it runs on an entire subdir rather than a specific set of files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13396)
<!-- Reviewable:end -->
