### PR TITLE
sql: make planhooks work with prepare

### DIFF
--- a/pkg/sql/planhook_test.go
+++ b/pkg/sql/planhook_test.go
@@ -1,0 +1,45 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Daniel Harrison (daniel.harrison@gmail.com)
+
+package sql_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestPlanHookPrepare(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop()
+	sqlDB := tc.Conns[0]
+
+	stmt, err := sqlDB.Prepare(`SHOW planhook`)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	row := stmt.QueryRow()
+	var s string
+	if err := row.Scan(&s); err != nil {
+		t.Fatalf("%+v", err)
+	}
+	if s != `planhook` {
+		t.Errorf("got %s expected planhook", s)
+	}
+}


### PR DESCRIPTION
Found by trying to run BACKUP via the postgres jdbc driver, which caused
a panic in the CockroachDB code that determined which pgwire format to
use for the returned columns.

Closes #13326.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13398)
<!-- Reviewable:end -->
