### PR TITLE
sql: enable COPY to run outside of a transaction.

### DIFF
--- a/pkg/acceptance/psql_test.go
+++ b/pkg/acceptance/psql_test.go
@@ -1,0 +1,61 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package acceptance
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"golang.org/x/net/context"
+)
+
+func TestDockerPSQL(t *testing.T) {
+	s := log.Scope(t, "")
+	defer s.Close(t)
+
+	ctx := context.Background()
+	testDockerSuccess(ctx, t, "psql", []string{"/bin/bash", "-c", psql})
+}
+
+const psql = `
+set -xeuo pipefail
+
+# Check that psql works in the first place.
+psql -c "select 1" | grep "1 row"
+
+# Check that COPY works outside of a transaction (#13395)
+psql -d testdb <<EOF
+CREATE DATABASE IF NOT EXISTS testdb;
+CREATE TABLE playground (
+    equip_id integer NOT NULL,
+    type character varying(50) NOT NULL,
+    color character varying(25) NOT NULL,
+    location character varying(25),
+    install_date date
+);
+
+COPY playground (equip_id, type, color, location, install_date) FROM stdin;
+1	slide	blue	south	2014-04-28
+2	swing	yellow	northwest	2010-08-16
+\.
+EOF
+# psql does not report failures properly in its exit code, so we check
+# that the value was inserted explicitly.
+psql -d testdb -c "SELECT * FROM playground"  | grep blue
+
+exit 0
+`

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -56,7 +56,7 @@ func (*copyNode) MarkDebug(_ explainMode)  {}
 func (*copyNode) Next() (bool, error)      { return false, nil }
 
 func (n *copyNode) Close() {
-	n.rowsMemAcc.Wtxn(n.p.session).Close()
+	n.rowsMemAcc.Wsession(n.p.session).Close()
 }
 
 func (*copyNode) DebugValues() debugValues {
@@ -186,7 +186,7 @@ func (n *copyNode) addRow(line []byte) error {
 		return fmt.Errorf("expected %d values, got %d", len(n.resultColumns), len(parts))
 	}
 	exprs := make(parser.Exprs, len(parts))
-	acc := n.rowsMemAcc.Wtxn(n.p.session)
+	acc := n.rowsMemAcc.Wsession(n.p.session)
 	for i, part := range parts {
 		s := string(part)
 		if s == nullString {
@@ -366,7 +366,7 @@ func (p *planner) CopyData(n CopyDataBlock, autoCommit bool) (planNode, error) {
 	vc := &parser.ValuesClause{Tuples: cf.rows}
 	// Reuse the same backing array once the Insert is complete.
 	cf.rows = cf.rows[:0]
-	cf.rowsMemAcc.Wtxn(p.session).Clear()
+	cf.rowsMemAcc.Wsession(p.session).Clear()
 
 	in := parser.Insert{
 		Table:   cf.table,

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -538,6 +538,9 @@ func (e *Executor) execRequest(session *Session, sql string, copymsg copyMsg) St
 		stmts, err = planMaker.parser.Parse(sql, parser.Syntax(session.Syntax))
 	}
 	if err != nil {
+		if log.V(2) {
+			log.Infof(session.Ctx(), "execRequest: error: %v", err)
+		}
 		// A parse error occurred: we can't determine if there were multiple
 		// statements or only one, so just pretend there was one.
 		if txnState.txn != nil {
@@ -660,6 +663,10 @@ func (e *Executor) execRequest(session *Session, sql string, copymsg copyMsg) St
 			// got converted to a non-retryable error when the txn closure was done.
 			lastRes := &results[len(results)-1]
 			lastRes.Err = convertToErrWithPGCode(err)
+		}
+
+		if err != nil && log.V(2) {
+			log.Infof(session.Ctx(), "execRequest: error: %v", err)
 		}
 
 		// Update the Err field of the last result if the error was coming from


### PR DESCRIPTION
Prior to this patch COPY would use the txn-specific memory account to
guard against unbounded server-side memory growth. However, the
executor runs COPY in a different way from other statements, in
particular COPY runs before the code that checks whether a transaction
needs to be opened. This caused the original code to execute properly
if a transaction was already ongoing, but to fail if there wasn't.

Interestingly this wasn't caught in tests because Go's libpq does not
support COPY statements run outside of transactions, so there was no
way to test this in Go in the first place.

This patch corrects the issue by using the session-wide memory account
instead, and adding an acceptance test that uses Postgres' own `psql`
client to run the COPY test outside of a transaction.

Fixes #13395.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13400)
<!-- Reviewable:end -->
