### PR TITLE
sql: Sanitize function namespaces.

### DIFF
--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -410,11 +410,7 @@ func (p *planner) QualifyWithDatabase(t *parser.NormalizableTableName) (*parser.
 		return nil, err
 	}
 	if tn.DatabaseName == "" {
-		database, err := p.databaseFromSearchPath(tn)
-		if err != nil {
-			return nil, err
-		}
-		if err := tn.QualifyWithDatabase(database); err != nil {
+		if err := p.searchAndQualifyDatabase(tn); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -1416,34 +1416,30 @@ var Builtins = map[string][]Builtin{
 		},
 	},
 
-	// For now, schemas are the same as databases. So, current_schemas returns the
-	// current database (if one has been set by the user) and, if the passed in
-	// parameter is true, the session's database search path.
+	// For now, schemas are the same as databases. So, current_schemas
+	// returns the current database (if one has been set by the user)
+	// and the session's database search path.
 	"current_schemas": {
 		Builtin{
-			Types:        ArgTypes{{"include_implicit", TypeBool}},
+			Types:        ArgTypes{{"unused", TypeBool}},
 			ReturnType:   fixedReturnType(TypeStringArray),
 			category:     categorySystemInfo,
 			ctxDependent: true,
 			fn: func(ctx *EvalContext, args Datums) (Datum, error) {
 				schemas := NewDArray(TypeString)
-				showImplicitSchemas := args[0].(*DBool)
-				if showImplicitSchemas == DBoolTrue {
-					for _, p := range ctx.SearchPath {
-						if err := schemas.Append(NewDString(p)); err != nil {
-							return nil, err
-						}
-					}
-				}
 				if len(ctx.Database) != 0 {
 					if err := schemas.Append(NewDString(ctx.Database)); err != nil {
 						return nil, err
 					}
 				}
+				for _, p := range ctx.SearchPath {
+					if err := schemas.Append(NewDString(p)); err != nil {
+						return nil, err
+					}
+				}
 				return schemas, nil
 			},
-			Info: "Returns the current database; optionally include implicit schemas (e.g. " +
-				"`pg_catalog`).",
+			Info: "Returns the current search path for unqualified names.",
 		},
 	},
 

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -1487,7 +1487,7 @@ var Builtins = map[string][]Builtin{
 
 	// pg_catalog functions.
 	// See https://www.postgresql.org/docs/9.6/static/functions-info.html.
-	"pg_catalog.pg_backend_pid": {
+	"pg_backend_pid": {
 		Builtin{
 			Types:      ArgTypes{},
 			ReturnType: fixedReturnType(TypeInt),
@@ -1495,7 +1495,7 @@ var Builtins = map[string][]Builtin{
 				return NewDInt(-1), nil
 			},
 			category: categoryCompatibility,
-			Info:     "Not usable; exposed only for ORM compatibility.",
+			Info:     "Not usable; exposed only for ORM compatibility with PostgreSQL.",
 		},
 	},
 
@@ -1505,7 +1505,7 @@ var Builtins = map[string][]Builtin{
 	// corresponding expression as a string, which means that this function can simply
 	// return the first argument directly. It also means we can ignore the second and
 	// optional third argument.
-	"pg_catalog.pg_get_expr": {
+	"pg_get_expr": {
 		Builtin{
 			Types: ArgTypes{
 				{"pg_node_tree", TypeString},
@@ -1516,7 +1516,7 @@ var Builtins = map[string][]Builtin{
 				return args[0], nil
 			},
 			category: categoryCompatibility,
-			Info:     "Not usable; exposed only for ORM compatibility.",
+			Info:     "Not usable; exposed only for ORM compatibility with PostgreSQL.",
 		},
 		Builtin{
 			Types: ArgTypes{
@@ -1529,13 +1529,13 @@ var Builtins = map[string][]Builtin{
 				return args[0], nil
 			},
 			category: categoryCompatibility,
-			Info:     "Not usable; exposed only for ORM compatibility.",
+			Info:     "Not usable; exposed only for ORM compatibility with PostgreSQL.",
 		},
 	},
 
 	// pg_get_indexdef functions like SHOW CREATE INDEX would if we supported that
 	// statement.
-	"pg_catalog.pg_get_indexdef": {
+	"pg_get_indexdef": {
 		Builtin{
 			Types: ArgTypes{
 				{"index_oid", TypeInt},
@@ -1554,14 +1554,14 @@ var Builtins = map[string][]Builtin{
 				return r[0], nil
 			},
 			category: categoryCompatibility,
-			Info:     "Not usable; exposed only for ORM compatibility.",
+			Info:     "Not usable; exposed only for ORM compatibility with PostgreSQL.",
 		},
 		// The other overload for this function, pg_get_indexdef(index_oid,
 		// column_no, pretty_bool), is unimplemented, because it isn't used by
 		// supported ORMs.
 	},
 
-	"pg_catalog.pg_typeof": {
+	"pg_typeof": {
 		// TODO(knz): This is a proof-of-concept until TypeAny works
 		// properly.
 		Builtin{
@@ -1571,10 +1571,10 @@ var Builtins = map[string][]Builtin{
 				return NewDString(args[0].ResolvedType().String()), nil
 			},
 			category: categoryCompatibility,
-			Info:     "Not usable; exposed only for ORM compatibility.",
+			Info:     "Not usable; exposed only for ORM compatibility with PostgreSQL.",
 		},
 	},
-	"pg_catalog.pg_get_userbyid": {
+	"pg_get_userbyid": {
 		Builtin{
 			Types: ArgTypes{
 				{"role_oid", TypeInt},
@@ -1592,10 +1592,10 @@ var Builtins = map[string][]Builtin{
 				return t[0], nil
 			},
 			category: categoryCompatibility,
-			Info:     "Not usable; exposed only for ORM compatibility.",
+			Info:     "Not usable; exposed only for ORM compatibility with PostgreSQL.",
 		},
 	},
-	"pg_catalog.format_type": {
+	"format_type": {
 		Builtin{
 			// TODO(jordan) typemod should be a Nullable TypeInt when supported.
 			Types:      ArgTypes{{"type_oid", TypeInt}, {"typemod", TypeInt}},
@@ -1613,7 +1613,7 @@ var Builtins = map[string][]Builtin{
 				"Currently, the type modifier is ignored.",
 		},
 	},
-	"pg_catalog.col_description": {
+	"col_description": {
 		Builtin{
 			Types:      ArgTypes{{"table_oid", TypeInt}, {"column_number", TypeInt}},
 			ReturnType: fixedReturnType(TypeString),
@@ -1621,10 +1621,10 @@ var Builtins = map[string][]Builtin{
 				return DNull, nil
 			},
 			category: categoryCompatibility,
-			Info:     "Not usable; exposed only for ORM compatibility.",
+			Info:     "Not usable; exposed only for ORM compatibility with PostgreSQL.",
 		},
 	},
-	"pg_catalog.obj_description": {
+	"obj_description": {
 		Builtin{
 			Types:      ArgTypes{{"object_oid", TypeInt}},
 			ReturnType: fixedReturnType(TypeString),
@@ -1632,10 +1632,10 @@ var Builtins = map[string][]Builtin{
 				return DNull, nil
 			},
 			category: categoryCompatibility,
-			Info:     "Not usable; exposed only for ORM compatibility.",
+			Info:     "Not usable; exposed only for ORM compatibility with PostgreSQL.",
 		},
 	},
-	"pg_catalog.shobj_description": {
+	"shobj_description": {
 		Builtin{
 			Types:      ArgTypes{{"object_oid", TypeInt}, {"catalog_name", TypeString}},
 			ReturnType: fixedReturnType(TypeString),
@@ -1643,10 +1643,10 @@ var Builtins = map[string][]Builtin{
 				return DNull, nil
 			},
 			category: categoryCompatibility,
-			Info:     "Not usable; exposed only for ORM compatibility.",
+			Info:     "Not usable; exposed only for ORM compatibility with PostgreSQL.",
 		},
 	},
-	"pg_catalog.array_in": {
+	"array_in": {
 		Builtin{
 			Types:      ArgTypes{{"string", TypeString}, {"element_oid", TypeInt}, {"element_typmod", TypeInt}},
 			ReturnType: fixedReturnType(TypeString),
@@ -1654,7 +1654,7 @@ var Builtins = map[string][]Builtin{
 				return nil, errors.New("unimplemented")
 			},
 			category: categoryCompatibility,
-			Info:     "Not usable; exposed only for ORM compatibility.",
+			Info:     "Not usable; exposed only for ORM compatibility with PostgreSQL.",
 		},
 	},
 }

--- a/pkg/sql/parser/function_definition.go
+++ b/pkg/sql/parser/function_definition.go
@@ -86,9 +86,19 @@ func (n UnresolvedName) ResolveFunction(searchPath SearchPath) (*FunctionDefinit
 	// Name.Normalize(), functions are special in that they are
 	// guaranteed to not contain special Unicode characters. So we can
 	// use ToLower directly.
+	// TODO(knz) this will need to be revisited once we allow
+	// function names to exist in custom namespaces, whose names
+	// may contain special characters.
 	prefix := strings.ToLower(fn.prefix())
 	smallName := strings.ToLower(fn.function())
 	fullName := smallName
+
+	if prefix == "pg_catalog" {
+		// If the user specified e.g. `pg_catalog.max()` we want to find
+		// it in the global namespace.
+		prefix = ""
+	}
+
 	if prefix != "" {
 		fullName = prefix + "." + smallName
 	}

--- a/pkg/sql/parser/function_name_test.go
+++ b/pkg/sql/parser/function_name_test.go
@@ -28,8 +28,7 @@ func TestResolveFunction(t *testing.T) {
 		err     string
 	}{
 		{`count`, `count`, ``},
-		{`pg_catalog.pg_typeof`, `pg_catalog.pg_typeof`, ``},
-		{`pg_typeof`, `pg_catalog.pg_typeof`, ``},
+		{`pg_catalog.pg_typeof`, `pg_typeof`, ``},
 
 		{`foo`, ``, `unknown function: foo`},
 		{`""`, ``, `invalid function name: ""`},

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1362,7 +1362,7 @@ var (
 
 	typDelim = parser.NewDString(",")
 
-	arrayInProcName = "pg_catalog.array_in"
+	arrayInProcName = "array_in"
 	arrayInProcOid  = makeOidHasher().BuiltinOid(arrayInProcName, &parser.Builtins[arrayInProcName][0])
 )
 

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -69,9 +69,6 @@ type Session struct {
 	// SearchPath is a list of databases that will be searched for a table name
 	// before the database. Currently, this is used only for SELECTs.
 	// Names in the search path must have been normalized already.
-	//
-	// NOTE: If we allow the user to set this, we'll need to handle the case where
-	// the session database or pg_catalog are in this path.
 	SearchPath  parser.SearchPath
 	User        string
 	Syntax      int32

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -43,6 +43,7 @@ var varGen = map[string]func(p *planner) string{
 	`MAX_INDEX_KEYS`:                func(_ *planner) string { return "32" },
 	`SEARCH_PATH`:                   func(p *planner) string { return strings.Join(p.session.SearchPath, ", ") },
 	`SERVER_VERSION`:                func(_ *planner) string { return PgServerVersion },
+	`SESSION_USER`:                  func(p *planner) string { return p.session.User },
 }
 var varNames = func() []string {
 	res := make([]string, 0, len(varGen))

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -133,11 +133,6 @@ func NewUndefinedDatabaseError(name string) error {
 	return pgerror.WithSourceContext(err, 1)
 }
 
-// IsUndefinedDatabaseError returns true if the error is for an undefined database.
-func IsUndefinedDatabaseError(err error) bool {
-	return errHasCode(err, pgerror.CodeInvalidCatalogNameError)
-}
-
 // NewUndefinedTableError creates an error that represents a missing database table.
 func NewUndefinedTableError(name string) error {
 	err := errors.Errorf("table %q does not exist", name)

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -513,30 +513,44 @@ func (p *planner) expandTableGlob(pattern parser.TablePattern) (parser.TableName
 	return tableNames, nil
 }
 
-// databaseFromSearchPath returns the first database in the session's SearchPath
-// that contains the specified table. If the table can't be found, we return the
-// session database.
-func (p *planner) databaseFromSearchPath(tn *parser.TableName) (string, error) {
+// searchAndQualifyDatabase augments the table name with the database
+// where it was found. It searches first in the session current
+// database, if that's defined, otherwise the search path.  The
+// provided TableName is modified in-place in case of success, and
+// left unchanged otherwise.
+// The table name must not be qualified already.
+func (p *planner) searchAndQualifyDatabase(tn *parser.TableName) error {
 	t := *tn
+
+	if p.session.Database != "" {
+		t.DatabaseName = parser.Name(p.session.Database)
+		desc, err := p.getTableOrViewDesc(&t)
+		if err != nil && !sqlbase.IsUndefinedTableError(err) {
+			return err
+		}
+		if desc != nil {
+			// Database was found, use this name.
+			*tn = t
+			return nil
+		}
+	}
+
+	// Not found using the current session's database, so try
+	// the search path instead.
 	for _, database := range p.session.SearchPath {
 		t.DatabaseName = parser.Name(database)
 		desc, err := p.getTableOrViewDesc(&t)
-		if err != nil {
-			if sqlbase.IsUndefinedDatabaseError(err) {
-				// Keep iterating through search path if a database in the search path
-				// doesn't exist.
-				continue
-			}
-			return "", err
+		if err != nil && !sqlbase.IsUndefinedTableError(err) {
+			return err
 		}
 		if desc != nil {
 			// The table or view exists in this database, so return it.
-			return t.Database(), nil
+			*tn = t
+			return nil
 		}
 	}
-	// If we couldn't find the table or view in the search path, default to the
-	// database set by the user.
-	return p.session.Database, nil
+
+	return sqlbase.NewUndefinedTableError(string(t.TableName))
 }
 
 // getQualifiedTableName returns the database-qualified name of the table

--- a/pkg/sql/testdata/array
+++ b/pkg/sql/testdata/array
@@ -177,7 +177,7 @@ c
 query T
 SELECT current_schemas(true)[1]
 ----
-pg_catalog
+test
 
 # From a CASE sub-expression.
 query I

--- a/pkg/sql/testdata/builtin_function
+++ b/pkg/sql/testdata/builtin_function
@@ -1436,7 +1436,7 @@ SELECT pg_catalog.pg_get_indexdef((SELECT oid from pg_class WHERE relname='pg_in
 ----
 CREATE INDEX pg_indexdef_idx ON test.pg_indexdef_test (a ASC)
 
-query error pq: unknown signature: pg_catalog.pg_get_indexdef\(int, int, bool\)
+query error pq: unknown signature: pg_get_indexdef\(int, int, bool\)
 SELECT pg_catalog.pg_get_indexdef(0, 0, true)
 
 # This function always returns NULL since we don't support column comments.
@@ -1445,5 +1445,11 @@ SELECT col_description('pg_class'::regclass::oid, 2)
 ----
 NULL
 
-query error pq: pg_catalog.array_in\(\): unimplemented
+query error pq: array_in\(\): unimplemented
 SELECT array_in('foo', 3, -1)
+
+# Check that base function names are also visible in namespace pg_catalog.
+query I
+SELECT pg_catalog.length('hello')
+----
+5

--- a/pkg/sql/testdata/builtin_function
+++ b/pkg/sql/testdata/builtin_function
@@ -1144,12 +1144,12 @@ SELECT foo.* IS NOT TRUE FROM (VALUES (1)) AS foo(x)
 query T
 SELECT CURRENT_SCHEMAS(true)
 ----
-{pg_catalog,test}
+{test,pg_catalog}
 
 query T
 SELECT CURRENT_SCHEMAS(false)
 ----
-{test}
+{test,pg_catalog}
 
 query error pq: unknown signature: current_schemas()
 SELECT CURRENT_SCHEMAS()

--- a/pkg/sql/testdata/namespace
+++ b/pkg/sql/testdata/namespace
@@ -1,0 +1,26 @@
+
+# Unqualified pg_type resolves from pg_catalog.
+query T
+SELECT typname FROM pg_type WHERE typname = 'date'
+----
+date
+
+# Override table and check name resolves properly.
+statement ok
+CREATE TABLE pg_type(x INT);
+
+query I
+SELECT x FROM pg_type
+----
+
+# Leave database, check name resolves to default.
+query T
+SET DATABASE=''; SELECT typname FROM pg_type WHERE typname = 'date'
+----
+date
+
+# Go to different database, check name still resolves to default.
+query T
+CREATE DATABASE foo; SET DATABASE='foo'; SELECT typname FROM pg_type WHERE typname = 'date'
+----
+date

--- a/pkg/sql/testdata/namespace
+++ b/pkg/sql/testdata/namespace
@@ -7,11 +7,12 @@ date
 
 # Override table and check name resolves properly.
 statement ok
-CREATE TABLE pg_type(x INT);
+CREATE TABLE pg_type(x INT); INSERT INTO pg_type VALUES(42)
 
 query I
 SELECT x FROM pg_type
 ----
+42
 
 # Leave database, check name resolves to default.
 query T
@@ -24,3 +25,17 @@ query T
 CREATE DATABASE foo; SET DATABASE='foo'; SELECT typname FROM pg_type WHERE typname = 'date'
 ----
 date
+
+# Now set the search path to the testdb, check that pg_catalog is
+# inserted implicitly at the beginning.
+query T
+SET SEARCH_PATH = test; SELECT typname FROM pg_type WHERE typname = 'date'
+----
+date
+
+# Now set the search path to the testdb, placing pg_catalog explicitly
+# at the end.
+query I
+SET SEARCH_PATH = test,pg_catalog; SELECT x FROM pg_type
+----
+42

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -718,10 +718,10 @@ oid   typname      typinput    typoutput  typreceive  typsend  typmodin  typmodo
 26    oid          0           0          0           0        0         0          0
 700   float4       0           0          0           0        0         0          0
 701   float8       0           0          0           0        0         0          0
-1005  int2[]       2892088402  0          0           0        0         0          0
-1007  int4[]       2892088402  0          0           0        0         0          0
-1009  string[]     2892088402  0          0           0        0         0          0
-1016  int8[]       2892088402  0          0           0        0         0          0
+1005  int2[]       4288767817  0          0           0        0         0          0
+1007  int4[]       4288767817  0          0           0        0         0          0
+1009  string[]     4288767817  0          0           0        0         0          0
+1016  int8[]       4288767817  0          0           0        0         0          0
 1043  string       0           0          0           0        0         0          0
 1082  date         0           0          0           0        0         0          0
 1114  timestamp    0           0          0           0        0         0          0

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -905,6 +905,7 @@ default_transaction_isolation  SERIALIZABLE  NULL      NULL        NULL        s
 max_index_keys                 32            NULL      NULL        NULL        string
 search_path                    pg_catalog    NULL      NULL        NULL        string
 server_version                 9.5.0         NULL      NULL        NULL        string
+session_user                   root          NULL      NULL        NULL        string
 syntax                         Traditional   NULL      NULL        NULL        string
 time zone                      UTC           NULL      NULL        NULL        string
 transaction isolation level    SERIALIZABLE  NULL      NULL        NULL        string
@@ -919,6 +920,7 @@ default_transaction_isolation  SERIALIZABLE  NULL  user     NULL      SERIALIZAB
 max_index_keys                 32            NULL  user     NULL      32            32
 search_path                    pg_catalog    NULL  user     NULL      pg_catalog    pg_catalog
 server_version                 9.5.0         NULL  user     NULL      9.5.0         9.5.0
+session_user                   root          NULL  user     NULL      root          root
 syntax                         Traditional   NULL  user     NULL      Traditional   Traditional
 time zone                      UTC           NULL  user     NULL      UTC           UTC
 transaction isolation level    SERIALIZABLE  NULL  user     NULL      SERIALIZABLE  SERIALIZABLE
@@ -933,6 +935,7 @@ default_transaction_isolation  NULL    NULL     NULL     NULL        NULL
 max_index_keys                 NULL    NULL     NULL     NULL        NULL
 search_path                    NULL    NULL     NULL     NULL        NULL
 server_version                 NULL    NULL     NULL     NULL        NULL
+session_user                   NULL    NULL     NULL     NULL        NULL
 syntax                         NULL    NULL     NULL     NULL        NULL
 time zone                      NULL    NULL     NULL     NULL        NULL
 transaction isolation level    NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/testdata/pgoidtype
+++ b/pkg/sql/testdata/pgoidtype
@@ -39,12 +39,12 @@ SELECT 'sqrt'::REGPROC
 query OOOO
 SELECT 'array_in'::REGPROC, 'array_in(a,b,c)'::REGPROC, 'pg_catalog.array_in'::REGPROC, 'pg_catalog.array_in( a ,b, c )'::REGPROC
 ----
-2892088402  2892088402  2892088402  2892088402
+4288767817  4288767817  4288767817  4288767817
 
 query OOOO
 SELECT 'array_in'::REGPROCEDURE, 'array_in(a,b,c)'::REGPROCEDURE, 'pg_catalog.array_in'::REGPROCEDURE, 'pg_catalog.array_in( a ,b, c )'::REGPROCEDURE
 ----
-2892088402  2892088402  2892088402  2892088402
+4288767817  4288767817  4288767817  4288767817
 
 query O
 SELECT 'public'::REGNAMESPACE

--- a/pkg/sql/testdata/set
+++ b/pkg/sql/testdata/set
@@ -106,6 +106,7 @@ DEFAULT_TRANSACTION_ISOLATION  SERIALIZABLE
 MAX_INDEX_KEYS                 32
 SEARCH_PATH                    pg_catalog
 SERVER_VERSION                 9.5.0
+SESSION_USER                   root
 SYNTAX                         Modern
 TIME ZONE                      UTC
 TRANSACTION ISOLATION LEVEL    SERIALIZABLE


### PR DESCRIPTION
Fixes #13313.

**tl;dr:** this introduces the following user-visible changes:

1. the ability to tweak the search path with `SET SEARCH_PATH = ...`
2. the current user is now reported in the output of `SHOW ALL`
3. `current_schemas()` now behaves the same regardless of which argument is given to it
4. the "`pg_catalog.`" prefix disappears from the built-in function definitions, thus also from the docs generated automatically from them.

Details:

**sql: fix the table namespace resolution order.**

Prior to this patch the table lookup code would search first the
search path and only then the session's current database.

For compatibility with pg the session's database must be searched
first.

**sql: fix the semantics of current_schemas()**

The rest of this commit message uses the following definition: a db
name is in the search path *explicitly* if and only if it is part of
the default search path (the one initialized with the session) or it
has been mentioned explicitly in a `SET SEARCH_PATH = ...` statement.

Some context:

- the (explicit) default search path in PostgreSQL is `{$user,public}`
  (and pg_catalog is not listed in it).

- PostgreSQL does some magic. If the name `pg_catalog` is not
  explicitly in the search path, then PostgreSQL will start all name
  lookups by searching in `pg_catalog`. This special behavior is not
  active if the name `pg_catalog` is mentioned explicitly in the
  search path.

Because of this magic, the idea of a search path entails, *in
PostgreSQL specifically*, a difference between an "explicit search
path" (the list of names that were put in the search path explicitly,
as per the definition above), and an "implicit search path" (the same
list, but with `pg_catalog` prepended to it if not already listed in
the explicit search path). The user can choose which one is returned,
in PostgreSQL, by `current_schemas()` using a boolean argument.

In CockroachDB there is also some magic, but it's different magic.

CockroachDB's magic is twofold.

1. *if a current session database has been set, then that is
   searched first, implicitly, before the explicit search
   path.* That's different from PostgreSQL, as explained below.

2. There is no special treatment for `pg_catalog` during lookups -- or
   rather, we have decided there would be no special treatment,
   because the idea to have to search and check whether `pg_catalog`
   is already in the search path or not (to decide whether to apply
   further magic) on *every lookup* sounds like unwanted overhead.

   Yet we deem it useful for compatibility to have pg-specific names
   searched in `pg_catalog` in similar circumstances. So CockroachDB
   applies different magic to make it work: a) the default search path
   in CockroachDB is `{pg_catalog}` and b) upon encountering `SET
   SEARCH_PATH = ...`, if the statement does not list `pg_catalog`
   explicitly, then it is *prepended* to the values stored in the
   search path.

   (Why prepended? So as to match pg's behavior when `pg_catalog` is
   not listed explicitly.)

(Note: PostgreSQL has no special treatment for the current database --
that's because it does not provide a way to "set the current
database", and instead the idea of "current database" in PostgreSQL is
exactly "the first value in the explicit search path".)

Because of point 2 above, the idea of "explicit" vs "implicit" search
path evaporates in CockroachDB and instead there may or may not be an
extra `pg_catalog` inserted in the search path automatically upon `SET
SEARCH_PATH`. By the time the `current_schemas()` function is
evaluated, the information about whether a leading `pg_catalog`, if
any, was part of the original `SET SEARCH_PATH` statement or was
inserted automatically has been lost already.

So instead this patch drops any pretense that there is a difference
between "implicit" and "explicit", makes `current_schemas()` ignore
its boolean argument entirely and always returns the full value of the
search path -- always containing `pg_catalog`, wherever `SET
SEARCH_PATH` may have decided to put it.

**sql: make the lookup of built-in functions smarter wrt `pg_catalog`.**

Prior to this patch, there were two sorts of functions:

- functions defined with a "`pg_catalog.`" prefix. These functions
  could be found either when used with their prefix, or without their
  prefix as long as `pg_catalog` was in the search path (and the
  session was defined to include `pg_catalog` in the search path by
  default).

- functions defined without a "`pg_catalog.`" prefix. These functions
  could only be found when used without a prefix.

This created a lurking bug with regards to compatibility: in
PostgreSQL, *all* built-in functions reside in namespace `pg_catalog`,
not only those fews that have motivated the "`pg_catalog.`" prefix in
CockroachDB so far. For example, `SELECT pg_catalog.count(*) FROM foo`
is valid, and so is `SELECT pg_catalog.length(name) FROM users`. It
was just a matter of time before a user would demand compatibility
with a tool producing pg queries automatically using this form.

To address this, three solutions were considered:

- move all built-in functions supported by CockroachDB to the
  namespace `pg_catalog`. Since `pg_catalog` is always searched (it's
  always part of the search path), unqualified names would still be
  found. This would achieve compatibility but make the name
  "`pg_catalog`" much more prominent in error messages, which use the
  fully qualified name of the function in all cases.

- move all built-in functions supported by CockroachDB to a new
  namespace with a more generic name, say "`sql`", then tweak the
  lookup rules so that whenever the prefix "`pg_catalog`" is used, it
  would be substituted implicitly by "`sql`". This would achieve
  compatibility and also make the error messages less pg-flavored. The
  drawback of this approach is that it introduces a mandatory prefix
  "`sql.`" in many places in the code and error messages where it was
  not present before.

- move all built-in functions supported by both CockroachDB and
  PostgreSQL to the global namespace (the one with no prefix), then
  tweak the lookup rules so that whenever the prefix "`pg_catalog`" is
  used, it would be removed to look up the remainder of the name in
  the global namespace. This also achieves compatibility and has the
  least impact on the code and error messages. The drawback of this
  approach is that those functions that are really pg-specific and
  merely present to please ORMs looking at `pg_proc` now also appear
  in the auto-generated docs for the global namespace.

The last solution was deemed to offer the best trade-off and was thus
adopted for the time being. Remaining issues with documentation, if
any, can be addressed in a subsequent patch by adding a boolean to
mark the builtin definition of those pg compatibility functions we do
not want to promote.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13404)
<!-- Reviewable:end -->
