### PR TITLE
internal/client: avoid caller.Lookup call

### DIFF
--- a/pkg/internal/client/client_test.go
+++ b/pkg/internal/client/client_test.go
@@ -680,7 +680,7 @@ func concurrentIncrements(db *client.DB, t *testing.T) {
 			wgStart.Wait()
 
 			if err := db.Txn(context.TODO(), func(txn *client.Txn) error {
-				txn.SetDebugName(fmt.Sprintf("test-%d", i), 0)
+				txn.SetDebugName(fmt.Sprintf("test-%d", i))
 
 				// Retrieve the other key.
 				gr, err := txn.Get(readKey)

--- a/pkg/internal/client/db.go
+++ b/pkg/internal/client/db.go
@@ -470,7 +470,7 @@ func (db *DB) Txn(ctx context.Context, retryable func(txn *Txn) error) error {
 	// TODO(dan): This context should, at longest, live for the lifetime of this
 	// method. Add a defered cancel.
 	txn := NewTxn(ctx, *db)
-	txn.SetDebugName("", 1)
+	txn.SetDebugName("unnamed")
 	err := txn.Exec(TxnExecOptions{AutoRetry: true, AutoCommit: true},
 		func(txn *Txn, _ *TxnExecOptions) error {
 			return retryable(txn)

--- a/pkg/internal/client/db_test.go
+++ b/pkg/internal/client/db_test.go
@@ -19,7 +19,6 @@ package client_test
 import (
 	"bytes"
 	"reflect"
-	"strings"
 	"testing"
 
 	"golang.org/x/net/context"
@@ -27,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/util/caller"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -333,10 +331,10 @@ func TestDebugName(t *testing.T) {
 	s, db := setup(t)
 	defer s.Stopper().Stop()
 
-	file, _, _ := caller.Lookup(0)
 	if err := db.Txn(context.TODO(), func(txn *client.Txn) error {
-		if !strings.HasPrefix(txn.DebugName(), file+":") {
-			t.Fatalf("expected \"%s\" to have the prefix \"%s:\"", txn.DebugName(), file)
+		const expected = "unnamed"
+		if txn.DebugName() != expected {
+			t.Fatalf("expected \"%s\", but found \"%s\"", expected, txn.DebugName())
 		}
 		return nil
 	}); err != nil {

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -18,7 +18,6 @@ package client
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/gogo/protobuf/proto"
 	basictracer "github.com/opentracing/basictracer-go"
@@ -28,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
-	"github.com/cockroachdb/cockroach/pkg/util/caller"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -82,15 +80,9 @@ func (txn *Txn) IsFinalized() bool {
 }
 
 // SetDebugName sets the debug name associated with the transaction which will
-// appear in log files and the web UI. Each transaction starts out with an
-// automatically assigned debug name composed of the file and line number where
-// the transaction was created.
-func (txn *Txn) SetDebugName(name string, depth int) {
-	file, line, fun := caller.Lookup(depth + 1)
-	if name == "" {
-		name = fun
-	}
-	txn.Proto.Name = file + ":" + strconv.Itoa(line) + " " + name
+// appear in log files and the web UI.
+func (txn *Txn) SetDebugName(name string) {
+	txn.Proto.Name = name
 }
 
 // DebugName returns the debug name associated with the transaction.

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -984,7 +984,7 @@ func (tc *TxnCoordSender) resendWithTxn(
 	tmpDB := client.NewDBWithContext(tc, dbCtx)
 	var br *roachpb.BatchResponse
 	err := tmpDB.Txn(ctx, func(txn *client.Txn) error {
-		txn.SetDebugName("auto-wrap", 0)
+		txn.SetDebugName("auto-wrap")
 		b := txn.NewBatch()
 		b.Header = ba.Header
 		for _, arg := range ba.Requests {

--- a/pkg/kv/txn_correctness_test.go
+++ b/pkg/kv/txn_correctness_test.go
@@ -852,7 +852,7 @@ func (hv *historyVerifier) runTxn(
 			cmds[cmdIdx].done(nil)
 		}
 
-		txn.SetDebugName(txnName, 0)
+		txn.SetDebugName(txnName)
 		if isolation == enginepb.SNAPSHOT {
 			if err := txn.SetIsolation(enginepb.SNAPSHOT); err != nil {
 				return err

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -595,9 +595,9 @@ func (e *Executor) execRequest(session *Session, sql string, copymsg copyMsg) St
 			txnState.autoRetry = true
 			txnState.sqlTimestamp = e.cfg.Clock.PhysicalTime()
 			if execOpt.AutoCommit {
-				txnState.txn.SetDebugName(sqlImplicitTxnName, 0)
+				txnState.txn.SetDebugName(sqlImplicitTxnName)
 			} else {
-				txnState.txn.SetDebugName(sqlTxnName, 0)
+				txnState.txn.SetDebugName(sqlTxnName)
 			}
 		} else {
 			txnState.autoRetry = false


### PR DESCRIPTION
Adding the file and line number to the transaction name isn't terribly
useful when ~100% of the calls are from the same 2 lines of code in the
sql package. caller.Lookup is moderately expensive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13409)
<!-- Reviewable:end -->
