### PR TITLE
util/tracer: pass the span name to EnsureContext

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -596,7 +596,7 @@ func (ds *DistSender) Send(
 	}
 
 	ctx = ds.AnnotateCtx(ctx)
-	ctx, cleanup := tracing.EnsureContext(ctx, ds.AmbientContext.Tracer)
+	ctx, cleanup := tracing.EnsureContext(ctx, ds.AmbientContext.Tracer, "dist sender")
 	defer cleanup()
 
 	var rplChunks []*roachpb.BatchResponse

--- a/pkg/storage/intent_resolver.go
+++ b/pkg/storage/intent_resolver.go
@@ -418,7 +418,7 @@ func (ir *intentResolver) resolveIntents(
 		return nil
 	}
 	// We're doing async stuff below; those need new traces.
-	ctx, cleanup := tracing.EnsureContext(ctx, ir.store.Tracer())
+	ctx, cleanup := tracing.EnsureContext(ctx, ir.store.Tracer(), "resolve intents")
 	defer cleanup()
 	log.Eventf(ctx, "resolving intents [wait=%t]", wait)
 

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1387,7 +1387,7 @@ func (r *Replica) Send(
 	}
 	// Add the range log tag.
 	ctx = r.AnnotateCtx(ctx)
-	ctx, cleanup := tracing.EnsureContext(ctx, r.AmbientContext.Tracer)
+	ctx, cleanup := tracing.EnsureContext(ctx, r.AmbientContext.Tracer, "replica send")
 	defer cleanup()
 
 	// If the internal Raft group is not initialized, create it and wake the leader.

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -24,7 +24,6 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/net/trace"
 
-	"github.com/cockroachdb/cockroach/pkg/util/caller"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/lightstep/lightstep-tracer-go"
 	basictracer "github.com/opentracing/basictracer-go"
@@ -249,10 +248,11 @@ func NewTracer() opentracing.Tracer {
 // not, it creates one using the provided Tracer and wraps it in the returned
 // Span. The returned closure must be called after the request has been fully
 // processed.
-func EnsureContext(ctx context.Context, tracer opentracing.Tracer) (context.Context, func()) {
-	_, _, funcName := caller.Lookup(1)
+func EnsureContext(
+	ctx context.Context, tracer opentracing.Tracer, name string,
+) (context.Context, func()) {
 	if opentracing.SpanFromContext(ctx) == nil {
-		sp := tracer.StartSpan(funcName)
+		sp := tracer.StartSpan(name)
 		return opentracing.ContextWithSpan(ctx, sp), sp.Finish
 	}
 	return ctx, func() {}


### PR DESCRIPTION
Pass an explicit span name to EnsureContext instead of using the
function name of the caller. The convenience of automatically
determining the span name is small given the handful of call
sites. caller.Lookup is moderately expensive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13410)
<!-- Reviewable:end -->
