### PR TITLE
build/builder: add openssh-client

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -36,6 +36,7 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key ad
 # libtool-bin - crosstool-ng/configure (1.22.0)
 # make - crosstool-ng boostrap / CRDB build system
 # nodejs - ui: all
+# openssh-client - terraform / jepsen
 # patch - crosstool-ng/configure
 # python - msan: libxx
 # texinfo - crosstool-ng/configure
@@ -63,6 +64,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libtool-bin \
     make \
     nodejs \
+    openssh-client \
     patch \
     python \
     texinfo \

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -xeuo pipefail
+set -euo pipefail
 
 image="cockroachdb/builder"
 

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -137,7 +137,7 @@ if test -e "${alternates_file}"; then
 fi
 
 # shellcheck disable=SC2086
-docker run -i ${tty-} --rm \
+docker run --privileged -i ${tty-} --rm \
   -u "${uid_gid}" \
   ${vols} \
   --workdir="/go/src/github.com/cockroachdb/cockroach" \

--- a/glide.lock
+++ b/glide.lock
@@ -32,7 +32,7 @@ imports:
   subpackages:
   - cmd/misspell
 - name: github.com/cockroachdb/c-jemalloc
-  version: 3a779a03c15a0fb38007280fbe33b264c27cfc4f
+  version: 7eb7980d8a9f68b771568a7eb15196a63a818595
 - name: github.com/cockroachdb/c-protobuf
   version: 070b64667a22925d971878b61e4f0c1df31e8599
   subpackages:

--- a/pkg/acceptance/cluster/localcluster.go
+++ b/pkg/acceptance/cluster/localcluster.go
@@ -58,7 +58,7 @@ import (
 
 const (
 	builderImage     = "cockroachdb/builder"
-	builderTag       = "20170202-182003"
+	builderTag       = "20170204-121401"
 	builderImageFull = builderImage + ":" + builderTag
 	networkPrefix    = "cockroachdb_acceptance"
 )


### PR DESCRIPTION
The absence of this package caused many nightly tests to fail.

Includes a few dry-bys as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13414)
<!-- Reviewable:end -->
