### PR TITLE
storage: Refactor span collection for command queue

### DIFF
--- a/pkg/ccl/storageccl/writebatch.go
+++ b/pkg/ccl/storageccl/writebatch.go
@@ -22,7 +22,10 @@ import (
 )
 
 func init() {
-	storage.SetWriteBatchCmd(storage.Command{Eval: evalWriteBatch})
+	storage.SetWriteBatchCmd(storage.Command{
+		DeclareKeys: storage.DefaultDeclareKeys,
+		Eval:        evalWriteBatch,
+	})
 }
 
 // evalWriteBatch applies the operations encoded in a BatchRepr.

--- a/pkg/storage/command_queue.go
+++ b/pkg/storage/command_queue.go
@@ -156,7 +156,7 @@ func (cq *CommandQueue) String() string {
 
 // prepareSpans ensures the spans all have an end key. Note that this function
 // mutates its arguments.
-func prepareSpans(spans ...roachpb.Span) {
+func prepareSpans(spans []roachpb.Span) {
 	for i, span := range spans {
 		// This gives us a memory-efficient end key if end is empty.
 		if len(span.EndKey) == 0 {
@@ -195,8 +195,8 @@ func (cq *CommandQueue) expand(c *cmd, isInserted bool) bool {
 // that all gating commands have completed or failed, and then call add() to
 // add the keys to the command queue. readOnly is true if the requester is a
 // read-only command; false for read-write.
-func (cq *CommandQueue) getWait(readOnly bool, spans ...roachpb.Span) (chans []<-chan struct{}) {
-	prepareSpans(spans...)
+func (cq *CommandQueue) getWait(readOnly bool, spans []roachpb.Span) (chans []<-chan struct{}) {
+	prepareSpans(spans)
 
 	for i := 0; i < len(spans); i++ {
 		span := spans[i]
@@ -445,11 +445,11 @@ func (o *overlapHeap) PopOverlap() *cmd {
 //
 // add should be invoked after waiting on already-executing, overlapping
 // commands via the WaitGroup initialized through getWait().
-func (cq *CommandQueue) add(readOnly bool, spans ...roachpb.Span) *cmd {
+func (cq *CommandQueue) add(readOnly bool, spans []roachpb.Span) *cmd {
 	if len(spans) == 0 {
 		return nil
 	}
-	prepareSpans(spans...)
+	prepareSpans(spans)
 
 	// Compute the min and max key that covers all of the spans.
 	minKey, maxKey := spans[0].Key, spans[0].EndKey

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1606,10 +1606,10 @@ func (r *Replica) beginCmds(ctx context.Context, ba *roachpb.BatchRequest) (*end
 			if _, ok := inner.(*roachpb.NoopRequest); ok {
 				continue
 			}
-			if roachpb.IsReadOnly(inner) {
-				spans.Add(SpanReadOnly, inner.Header())
+			if cmd, ok := commands[inner.Method()]; ok {
+				cmd.DeclareKeys(ba.Header, inner, &spans)
 			} else {
-				spans.Add(SpanReadWrite, inner.Header())
+				return nil, errors.Errorf("unrecognized command %s", inner.Method())
 			}
 		}
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -1993,14 +1993,26 @@ func TestReplicaCommandQueue(t *testing.T) {
 
 	tooLong := 5 * time.Second
 
+	uniqueKeyCounter := int32(0)
+
 	for _, test := range testCases {
-		for _, addNoop := range []bool{false, true} {
+		for _, addReq := range []string{"", "noop", "read", "write"} {
+			if addReq == "write" && propEvalKV {
+				// adding a write changes behavior in propEvalKV until the command
+				// queue changes are all done.
+				continue
+			}
 			for _, localKey := range []bool{false, true} {
 				readWriteLabels := map[bool]string{true: "read", false: "write"}
 				testName := fmt.Sprintf("%s-%s", readWriteLabels[test.cmd1Read],
 					readWriteLabels[test.cmd2Read])
-				if addNoop {
+				switch addReq {
+				case "noop":
 					testName += "-noop"
+				case "read":
+					testName += "-addRead"
+				case "write":
+					testName += "-addWrite"
 				}
 				if localKey {
 					testName += "-local"
@@ -2022,7 +2034,7 @@ func TestReplicaCommandQueue(t *testing.T) {
 						tsc := TestStoreConfig(nil)
 						tsc.TestingKnobs.TestingCommandFilter =
 							func(filterArgs storagebase.FilterArgs) *roachpb.Error {
-								if filterArgs.Hdr.UserPriority == blockingPriority {
+								if filterArgs.Hdr.UserPriority == blockingPriority && filterArgs.Index == 0 {
 									blockingStart <- struct{}{}
 									<-blockingDone
 								}
@@ -2039,8 +2051,27 @@ func TestReplicaCommandQueue(t *testing.T) {
 							ba.Header = header
 							ba.Add(args)
 
-							if addNoop {
-								ba.Add(&roachpb.NoopRequest{})
+							if header.UserPriority == blockingPriority {
+								switch addReq {
+								case "noop":
+									// Add a noop request to make sure that its empty key
+									// doesn't cause additional blocking.
+									ba.Add(&roachpb.NoopRequest{})
+
+								case "read", "write":
+									// Additional reads and writes to unique keys do not
+									// cause additional blocking; the read/write nature of
+									// the keys in the command queue is determined on a
+									// per-request basis.
+									key := roachpb.Key(fmt.Sprintf("unique-key-%s-%d", testName, atomic.AddInt32(&uniqueKeyCounter, 1)))
+									if addReq == "read" {
+										req := getArgs(key)
+										ba.Add(&req)
+									} else {
+										req := putArgs(key, []byte{})
+										ba.Add(&req)
+									}
+								}
 							}
 
 							_, pErr := tc.Sender().Send(context.Background(), ba)
@@ -2325,6 +2356,42 @@ func TestReplicaCommandQueueCancellation(t *testing.T) {
 	blockingDone <- struct{}{}
 	if pErr := <-cmd1Done; pErr != nil {
 		t.Fatal(pErr)
+	}
+}
+
+// TestReplicaCommandQueueSelfOverlap verifies that self-overlapping
+// batches are allowed, and in particular do not deadlock by
+// introducing command-queue dependencies between the parts of the
+// batch.
+func TestReplicaCommandQueueSelfOverlap(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	tc := testContext{}
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	tc.Start(t, stopper)
+
+	for _, cmd1Read := range []bool{false, true} {
+		for _, cmd2Read := range []bool{false, true} {
+			name := fmt.Sprintf("%v,%v", cmd1Read, cmd2Read)
+			t.Run(name, func(t *testing.T) {
+				ba := roachpb.BatchRequest{}
+				ba.Add(readOrWriteArgs(roachpb.Key(name), cmd1Read))
+				ba.Add(readOrWriteArgs(roachpb.Key(name), cmd2Read))
+
+				// Set a deadline for nicer error behavior on deadlock.
+				ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
+				defer cancel()
+				_, pErr := tc.Sender().Send(ctx, ba)
+				if pErr != nil {
+					if _, ok := pErr.GetDetail().(*roachpb.WriteTooOldError); ok && !cmd1Read && !cmd2Read {
+						// WriteTooOldError is expected in the write/write case because we don't
+						// allow self-overlapping non-transactional batches.
+					} else {
+						t.Fatal(pErr)
+					}
+				}
+			})
+		}
 	}
 }
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -2306,7 +2306,7 @@ func TestReplicaCommandQueueCancellation(t *testing.T) {
 	// Wait until both commands are in the command queue.
 	testutils.SucceedsSoon(t, func() error {
 		tc.repl.cmdQMu.Lock()
-		chans := tc.repl.cmdQMu.global.getWait(false, roachpb.Span{Key: key1}, roachpb.Span{Key: key2})
+		chans := tc.repl.cmdQMu.global.getWait(false, []roachpb.Span{{Key: key1}, {Key: key2}})
 		tc.repl.cmdQMu.Unlock()
 		if a, e := len(chans), 2; a < e {
 			return errors.Errorf("%d of %d commands in the command queue", a, e)

--- a/pkg/storage/span_set.go
+++ b/pkg/storage/span_set.go
@@ -1,0 +1,70 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Ben Darnell
+
+package storage
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
+
+// SpanAccess records the intended mode of access in SpanSet.
+type SpanAccess int
+
+// Constants for SpanAccess.
+const (
+	SpanReadOnly SpanAccess = iota
+	SpanReadWrite
+	numSpanAccess
+)
+
+type spanScope int
+
+const (
+	spanGlobal spanScope = iota
+	spanLocal
+	numSpanScope
+)
+
+// SpanSet tracks the set of key spans touched by a command. The set
+// is divided into subsets for access type (read-only or read/write)
+// and key scope (local or global; used to facilitate use by the
+// separate local and global command queues).
+type SpanSet struct {
+	spans [numSpanAccess][numSpanScope][]roachpb.Span
+}
+
+// reserve space for N additional keys.
+func (ss *SpanSet) reserve(access SpanAccess, scope spanScope, n int) {
+	existing := ss.spans[access][scope]
+	ss.spans[access][scope] = make([]roachpb.Span, len(existing), n+cap(existing))
+	copy(ss.spans[access][scope], existing)
+}
+
+// Add a span to the set.
+func (ss *SpanSet) Add(access SpanAccess, span roachpb.Span) {
+	scope := spanGlobal
+	if keys.IsLocal(span.Key) {
+		scope = spanLocal
+	}
+	ss.spans[access][scope] = append(ss.spans[access][scope], span)
+}
+
+// getSpans returns a slice of spans with the given parameters.
+func (ss *SpanSet) getSpans(access SpanAccess, scope spanScope) []roachpb.Span {
+	return ss.spans[access][scope]
+}


### PR DESCRIPTION
Command implementations are now responsible for reporting which keys they touch. This is a precursor to reintroducing a cleaned-up version of #10084 and addressing #10413.

The first and third commits are refactorings with no behavior change; the second commit changes the behavior of batches that mix read and write commands (although these batches are rare in our current usage; perhaps non-existent outside of tests). Previously, all requests in mixed batches would be treated as writes; now read-only requests in mixed batches are recognized as such. (this will be important when we add reads on high-contention keys)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13418)
<!-- Reviewable:end -->
