### PR TITLE
cli: add COCKROACH_MUTEX_PROFILE_RATE to enable go1.8 mutex profiles

### DIFF
--- a/pkg/cli/mutex_profile.go
+++ b/pkg/cli/mutex_profile.go
@@ -1,0 +1,37 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+// +build go1.8
+
+package cli
+
+import (
+	"runtime"
+
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+)
+
+func init() {
+	// Enable the mutex profile for a fraction of mutex contention events.
+	// Smaller values provide more accurate profiles but are more expensive. 0
+	// and 1 are special: 0 disables the mutex profile and 1 captures 100% of
+	// mutex contention events. For other values, the profiler will sample on
+	// average 1/X events.
+	//
+	// The mutex profile can be viewed with `go tool pprof
+	// http://HOST:PORT/debug/pprof/mutex`
+	runtime.SetMutexProfileFraction(envutil.EnvOrDefaultInt("COCKROACH_MUTEX_PROFILE_RATE", 0))
+}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13419)
<!-- Reviewable:end -->
