### PR TITLE
roachpb: minor optimizations to BatchRequest.Summary

### DIFF
--- a/pkg/roachpb/batch_generated.go
+++ b/pkg/roachpb/batch_generated.go
@@ -5,6 +5,7 @@ package roachpb
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 )
 
 type reqCounts [31]int32
@@ -124,13 +125,18 @@ func (ba *BatchRequest) Summary() string {
 		return "empty batch"
 	}
 	counts := ba.getReqCounts()
-	var buf bytes.Buffer
+	var buf struct {
+		bytes.Buffer
+		tmp [10]byte
+	}
 	for i, v := range counts {
 		if v != 0 {
 			if buf.Len() > 0 {
 				buf.WriteString(", ")
 			}
-			fmt.Fprintf(&buf, "%d %s", v, requestNames[i])
+			buf.Write(strconv.AppendInt(buf.tmp[:0], int64(v), 10))
+			buf.WriteString(" ")
+			buf.WriteString(requestNames[i])
 		}
 	}
 	return buf.String()

--- a/pkg/roachpb/gen_batch.go
+++ b/pkg/roachpb/gen_batch.go
@@ -84,6 +84,7 @@ package roachpb
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 )
 `)
 
@@ -154,13 +155,18 @@ func (ba *BatchRequest) Summary() string {
 		return "empty batch"
 	}
 	counts := ba.getReqCounts()
-	var buf bytes.Buffer
+	var buf struct {
+		bytes.Buffer
+		tmp [10]byte
+	}
 	for i, v := range counts {
 		if v != 0 {
 			if buf.Len() > 0 {
 				buf.WriteString(", ")
 			}
-			fmt.Fprintf(&buf, "%d %s", v, requestNames[i])
+			buf.Write(strconv.AppendInt(buf.tmp[:0], int64(v), 10))
+			buf.WriteString(" ")
+			buf.WriteString(requestNames[i])
 		}
 	}
 	return buf.String()


### PR DESCRIPTION
BatchRequest.Summary is called at least twice on every request, purely
for event/span logging (even when that logging is disabled). Separately
we should find a way to reduce that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13420)
<!-- Reviewable:end -->
