### PR TITLE
sql: refactor plan{Visitor,Observer} to avoid unnecessary work

### DIFF
--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -128,7 +128,7 @@ func (p *planner) populateExplain(e *explainer, v *valuesNode, plan planNode) er
 	}
 
 	e.err = nil
-	_ = walkPlan(plan, e)
+	_ = walkPlan(plan, e.observer())
 	return e.err
 }
 
@@ -154,8 +154,17 @@ func planToString(plan planNode) string {
 			}
 		},
 	}
-	_ = walkPlan(plan, &e)
+	_ = walkPlan(plan, e.observer())
 	return buf.String()
+}
+
+func (e *explainer) observer() planObserver {
+	return planObserver{
+		enterNode: e.enterNode,
+		expr:      e.expr,
+		attr:      e.attr,
+		leaveNode: e.leaveNode,
+	}
 }
 
 // expr implements the planObserver interface.
@@ -198,9 +207,6 @@ func (e *explainer) attr(nodeName, fieldName, attr string) {
 func (e *explainer) leaveNode(name string) {
 	e.level--
 }
-
-// subqueryNode implements the planObserver interface.
-func (e *explainer) subqueryNode(sq *subquery) error { return nil }
 
 // formatColumns converts a column signature for a data source /
 // planNode to a string. The column types are printed iff the 2nd


### PR DESCRIPTION
Change planObserver from an interface to a struct containing function
pointers. Only generate the data needed for a particular observer
function if that function pointer is non-nil.

Fixes #13421

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13422)
<!-- Reviewable:end -->
