### PR TITLE
cli: Skip flaky TestNodeStatus

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1216,6 +1216,7 @@ func TestFreeze(t *testing.T) {
 
 func TestNodeStatus(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("#13394")
 
 	start := timeutil.Now()
 	c := newCLITest(cliTestParams{})


### PR DESCRIPTION
This has gotten pretty bad since it started failing a few days ago (#13394).

@vivekmenezes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13425)
<!-- Reviewable:end -->
