### PR TITLE
server: instrument TestStatusLocalLogs with a TestLogScope.

### DIFF
--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -20,8 +20,6 @@ package server
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -192,19 +190,9 @@ func TestStatusLocalLogs(t *testing.T) {
 	if log.V(3) {
 		t.Skip("Test only works with low verbosity levels")
 	}
-	dir, err := ioutil.TempDir("", "local_log_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := log.EnableLogFileOutput(dir, log.Severity_INFO); err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		log.DisableLogFileOutput()
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatal(err)
-		}
-	}()
+
+	s := log.Scope(t, "")
+	defer s.Close(t)
 
 	ts := startServer(t)
 	defer ts.Stopper().Stop()

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -969,21 +969,6 @@ func (sb *syncBuffer) rotateFile(now time.Time) error {
 // on disk I/O. The flushDaemon will block instead.
 const bufferSize = 256 * 1024
 
-func (l *loggingT) removeFilesLocked() error {
-	for s := Severity_FATAL; s >= Severity_INFO; s-- {
-		if sb, ok := l.file[s].(*syncBuffer); ok {
-			if err := sb.file.Close(); err != nil {
-				return err
-			}
-			if err := os.Remove(sb.file.Name()); err != nil {
-				return err
-			}
-		}
-		l.file[s] = nil
-	}
-	return nil
-}
-
 func (l *loggingT) closeFilesLocked() error {
 	for s := Severity_FATAL; s >= Severity_INFO; s-- {
 		if l.file[s] != nil {

--- a/pkg/util/log/file.go
+++ b/pkg/util/log/file.go
@@ -80,13 +80,6 @@ func (l *logDirName) String() string {
 	return l.name
 }
 
-func (l *logDirName) clear() {
-	// For testing only.
-	l.Lock()
-	defer l.Unlock()
-	l.name = ""
-}
-
 func (l *logDirName) get() (string, error) {
 	l.Lock()
 	defer l.Unlock()

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -50,28 +50,6 @@ func FatalOnPanic() {
 	}
 }
 
-// EnableLogFileOutput turns on logging using the specified directory.
-// For unittesting only.
-func EnableLogFileOutput(dir string, stderrSeverity Severity) error {
-	logging.mu.Lock()
-	defer logging.mu.Unlock()
-	logging.toStderr = false
-	logging.stderrThreshold = stderrSeverity
-	return logDir.Set(dir)
-}
-
-// DisableLogFileOutput turns off logging. For unittesting only.
-func DisableLogFileOutput() {
-	logging.mu.Lock()
-	defer logging.mu.Unlock()
-	if err := logging.removeFilesLocked(); err != nil {
-		logging.exit(err)
-	}
-	logDir.clear()
-	logging.toStderr = true
-	logging.stderrThreshold = Severity_NONE
-}
-
 // SetExitFunc allows setting a function that will be called to exit the
 // process when a Fatal message is generated.
 func SetExitFunc(f func(int)) {

--- a/pkg/util/log/test_log_scope.go
+++ b/pkg/util/log/test_log_scope.go
@@ -62,10 +62,20 @@ func Scope(t tShim, testName string) TestLogScope {
 	if err := dirTestOverride(tempDir); err != nil {
 		t.Fatal(err)
 	}
-	if err := EnableLogFileOutput(tempDir, Severity_ERROR); err != nil {
+	if err := enableLogFileOutput(tempDir, Severity_ERROR); err != nil {
 		t.Fatal(err)
 	}
 	return TestLogScope(tempDir)
+}
+
+// enableLogFileOutput turns on logging using the specified directory.
+// For unittesting only.
+func enableLogFileOutput(dir string, stderrSeverity Severity) error {
+	logging.mu.Lock()
+	defer logging.mu.Unlock()
+	logging.toStderr = false
+	logging.stderrThreshold = stderrSeverity
+	return logDir.Set(dir)
 }
 
 // Close cleans up a TestLogScope. The directory and its contents are


### PR DESCRIPTION
This will ensure that log files do not go missing if the test fails or
panics.

Needed to investigate #12750.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13430)
<!-- Reviewable:end -->
