### PR TITLE
log: Include a non-ascii character at the beginning of the log

### DIFF
--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -938,7 +938,9 @@ func (sb *syncBuffer) rotateFile(now time.Time) error {
 		fmt.Sprintf("[config] running on machine: %s\n", host),
 		fmt.Sprintf("[config] binary: %s\n", build.GetInfo().Short()),
 		fmt.Sprintf("[config] arguments: %s\n", os.Args),
-		fmt.Sprintf("line format: [IWEF]yymmdd hh:mm:ss.uuuuuu goid file:line msg\n"),
+		// Including a non-ascii character in the first 1024 bytes of the log helps
+		// viewers that attempt to guess the character encoding.
+		fmt.Sprintf("line format: [IWEF]yymmdd hh:mm:ss.uuuuuu goid file:line msg utf8=\u2713\n"),
 	} {
 		buf := formatLogEntry(Entry{
 			Severity:  sb.sev,


### PR DESCRIPTION
This helps browsers guess the character encoding directly when viewing
the log as plain text (as in teamcity's artifact viewer)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13431)
<!-- Reviewable:end -->
