### PR TITLE
storage: remove mutex timing histograms

### DIFF
--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -304,17 +304,6 @@ var (
 	metaGCResolveSuccess = metric.Metadata{Name: "queue.gc.info.resolvesuccess",
 		Help: "Number of successful intent resolutions"}
 
-	metaMuReplicaNanos = metric.Metadata{Name: "mutex.replicananos",
-		Help: "Duration of Replica mutex critical sections"}
-	metaMuCommandQueueNanos = metric.Metadata{Name: "mutex.commandqueuenanos",
-		Help: "Duration of Command Queue mutex critical sections"}
-	metaMuRaftNanos = metric.Metadata{Name: "mutex.raftnanos",
-		Help: "Duration of Replica Raft mutex critical sections"}
-	metaMuStoreNanos = metric.Metadata{Name: "mutex.storenanos",
-		Help: "Duration of Store mutex critical sections"}
-	metaMuSchedulerNanos = metric.Metadata{Name: "mutex.schedulernanos",
-		Help: "Duration of Raft Scheduler mutex critical sections"}
-
 	// Slow request metrics.
 	metaSlowCommandQueueRequests = metric.Metadata{Name: "requests.slow.commandqueue",
 		Help: "Number of requests that have been stuck for a long time in the command queue"}
@@ -494,13 +483,6 @@ type StoreMetrics struct {
 	GCResolveTotal               *metric.Counter
 	GCResolveSuccess             *metric.Counter
 
-	// Mutex timing information.
-	MuStoreNanos        *metric.Histogram
-	MuSchedulerNanos    *metric.Histogram
-	MuRaftNanos         *metric.Histogram
-	MuReplicaNanos      *metric.Histogram
-	MuCommandQueueNanos *metric.Histogram
-
 	// Slow request counts.
 	SlowCommandQueueRequests *metric.Gauge
 	SlowLeaseRequests        *metric.Gauge
@@ -674,34 +656,6 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		GCPushTxn:                    metric.NewCounter(metaGCPushTxn),
 		GCResolveTotal:               metric.NewCounter(metaGCResolveTotal),
 		GCResolveSuccess:             metric.NewCounter(metaGCResolveSuccess),
-
-		// Mutex timing.
-		//
-		// TODO(tschottdorf): Histograms don't work very well as they were
-		// inherently built in a windowed (i.e. events-discarding) way, which
-		// is not at all the correct way. Discard at one-minute interval which
-		// gives sane (though mathematically nonsensical) results when exposed
-		// at the moment.
-		MuReplicaNanos: metric.NewHistogram(
-			metaMuReplicaNanos, histogramWindow,
-			time.Second.Nanoseconds(), 1,
-		),
-		MuCommandQueueNanos: metric.NewHistogram(
-			metaMuCommandQueueNanos, histogramWindow,
-			time.Second.Nanoseconds(), 1,
-		),
-		MuRaftNanos: metric.NewHistogram(
-			metaMuRaftNanos, histogramWindow,
-			time.Second.Nanoseconds(), 1,
-		),
-		MuStoreNanos: metric.NewHistogram(
-			metaMuStoreNanos, histogramWindow,
-			time.Second.Nanoseconds(), 1,
-		),
-		MuSchedulerNanos: metric.NewHistogram(
-			metaMuSchedulerNanos, histogramWindow,
-			time.Second.Nanoseconds(), 1,
-		),
 
 		// Wedge request counters.
 		SlowCommandQueueRequests: metric.NewGauge(metaSlowCommandQueueRequests),

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -572,9 +572,6 @@ func newReplica(rangeID roachpb.RangeID, store *Store) *Replica {
 		func(ctx context.Context, msg string, args ...interface{}) {
 			log.Warningf(ctx, "raftMu: "+msg, args...)
 		},
-		func(t time.Duration) {
-			r.store.metrics.MuRaftNanos.RecordValue(t.Nanoseconds())
-		},
 	)
 	r.raftMu = makeTimedMutex(raftMuLogger)
 
@@ -584,9 +581,6 @@ func newReplica(rangeID roachpb.RangeID, store *Store) *Replica {
 		func(ctx context.Context, msg string, args ...interface{}) {
 			log.Warningf(ctx, "replicaMu: "+msg, args...)
 		},
-		func(t time.Duration) {
-			r.store.metrics.MuReplicaNanos.RecordValue(t.Nanoseconds())
-		},
 	)
 	r.mu.timedMutex = makeTimedMutex(replicaMuLogger)
 
@@ -595,9 +589,6 @@ func newReplica(rangeID roachpb.RangeID, store *Store) *Replica {
 		defaultReplicaMuWarnThreshold,
 		func(ctx context.Context, msg string, args ...interface{}) {
 			log.Warningf(ctx, "cmdQMu: "+msg, args...)
-		},
-		func(t time.Duration) {
-			r.store.metrics.MuCommandQueueNanos.RecordValue(t.Nanoseconds())
 		},
 	)
 	r.cmdQMu.timedMutex = makeTimedMutex(cmdQMuLogger)

--- a/pkg/storage/scheduler.go
+++ b/pkg/storage/scheduler.go
@@ -18,7 +18,6 @@ import (
 	"container/list"
 	"fmt"
 	"sync"
-	"time"
 
 	"golang.org/x/net/context"
 
@@ -152,11 +151,6 @@ func newRaftScheduler(
 		defaultReplicaMuWarnThreshold,
 		func(ctx context.Context, msg string, args ...interface{}) {
 			log.Warningf(ctx, "raftScheduler.mu: "+msg, args...)
-		},
-		func(t time.Duration) {
-			if metrics != nil {
-				metrics.MuSchedulerNanos.RecordValue(t.Nanoseconds())
-			}
 		},
 	)
 	s.mu.timedMutex = makeTimedMutex(muLogger)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -865,9 +865,6 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 		func(ctx context.Context, msg string, args ...interface{}) {
 			log.Warningf(ctx, "storeMu: "+msg, args...)
 		},
-		func(t time.Duration) {
-			s.metrics.MuStoreNanos.RecordValue(t.Nanoseconds())
-		},
 	)
 	s.mu.timedMutex = makeTimedMutex(storeMuLogger)
 

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -59,7 +59,6 @@ var defaultMuLogger = thresholdLogger(
 	context.Background(),
 	10*time.Second,
 	log.Warningf,
-	func(time.Duration) {},
 )
 
 var testIdent = roachpb.StoreIdent{

--- a/pkg/storage/timedmutex.go
+++ b/pkg/storage/timedmutex.go
@@ -53,10 +53,8 @@ func thresholdLogger(
 	ctx context.Context,
 	warnDuration time.Duration,
 	printf func(context.Context, string, ...interface{}),
-	record timingFn,
 ) timingFn {
 	return func(heldFor time.Duration) {
-		record(heldFor)
 		if heldFor > warnDuration {
 			// NB: this doesn't use `util/caller.Lookup` because that would result
 			// in an import cycle.

--- a/pkg/storage/timedmutex_test.go
+++ b/pkg/storage/timedmutex_test.go
@@ -39,13 +39,9 @@ func TestTimedMutex(t *testing.T) {
 		formatted := fmt.Sprintf(innerMsg, args...)
 		msgs = append(msgs, formatted)
 	}
-	var numMeasurements int
-	record := func(time.Duration) { numMeasurements++ }
 
 	{
-		cb := thresholdLogger(
-			context.Background(), time.Nanosecond, printf, record,
-		)
+		cb := thresholdLogger(context.Background(), time.Nanosecond, printf)
 
 		// Should fire.
 		tm := makeTimedMutex(cb)
@@ -57,18 +53,12 @@ func TestTimedMutex(t *testing.T) {
 		if len(msgs) != 1 || !re.MatchString(msgs[0]) {
 			t.Fatalf("mutex did not warn as expected: %+v", msgs)
 		}
-		if numMeasurements != 1 {
-			t.Fatalf("expected one measurement, not %d", numMeasurements)
-		}
 	}
 
-	numMeasurements = 0
 	msgs = nil
 
 	{
-		cb := thresholdLogger(
-			context.Background(), time.Duration(math.MaxInt64), printf, record,
-		)
+		cb := thresholdLogger(context.Background(), time.Duration(math.MaxInt64), printf)
 		tm := makeTimedMutex(cb)
 
 		const num = 10
@@ -82,10 +72,6 @@ func TestTimedMutex(t *testing.T) {
 		if len(msgs) != 0 {
 			t.Fatalf("mutex warned erroneously: %+v", msgs)
 		}
-		if numMeasurements != num {
-			t.Fatalf("expected %d measurements not %d", num, numMeasurements)
-		}
-
 	}
 }
 


### PR DESCRIPTION
Unlike the timed mutex logging, I have never found the mutex histograms
useful. We record 8 timeseries keys per histogram, which translates into
this reducing the number of timeseries keys by 40.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13432)
<!-- Reviewable:end -->
