### PR TITLE
remove the "comparison with other databases" image

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ groups.
 
 ## Comparison with Other Databases
 
-![SQL - NoSQL - NewSQL Capabilities](docs/media/sql-nosql-newsql.png?raw=true)
+To see how key features of CockroachDB stack up against other databases, 
+visit the [CockroachDB in Comparison](https://www.cockroachlabs.com/docs/cockroachdb-in-comparison.html) page hosted on our docs site. 
 
 ## See Also
 


### PR DESCRIPTION
Replace the "comparison with other databases" image with a link to the comparison page on our docs site. The comparison page on the docs site is better maintained and has the benefit of being searchable.

PTAL: @bdarnell @jseldess @dianasaur323

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13450)
<!-- Reviewable:end -->
