### PR TITLE
sqlccl: deflake TestBackupRestoreBank

### DIFF
--- a/pkg/ccl/sqlccl/backup.go
+++ b/pkg/ccl/sqlccl/backup.go
@@ -102,7 +102,7 @@ func allSQLDescriptors(txn *client.Txn) ([]sqlbase.Descriptor, error) {
 	endKey := startKey.PrefixEnd()
 	rows, err := txn.Scan(startKey, endKey, 0)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to scan SQL descriptors")
+		return nil, err
 	}
 
 	sqlDescs := make([]sqlbase.Descriptor, len(rows))

--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -398,7 +398,6 @@ func startBankTransfers(stopper *stop.Stopper, sqlDB *gosql.DB, numAccounts int)
 
 func TestBackupRestoreBank(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#13189")
 	// TODO(dan): Actually invalidate the descriptor cache and delete this line.
 	defer sql.TestDisableTableLeases()()
 


### PR DESCRIPTION
The db.Txn retryable error mechanism doesn't work with wrapped errors.

Closes #13189.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13454)
<!-- Reviewable:end -->
