### PR TITLE
storage: avoid allocations for range-local key generation

### DIFF
--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -97,9 +97,9 @@ func MakeRangeIDReplicatedPrefix(rangeID roachpb.RangeID) roachpb.Key {
 	return makePrefixWithRangeID(LocalRangeIDPrefix, rangeID, localRangeIDReplicatedInfix)
 }
 
-// MakeRangeIDReplicatedKey creates a range-local key based on the range's
+// makeRangeIDReplicatedKey creates a range-local key based on the range's
 // Range ID, metadata key suffix, and optional detail.
-func MakeRangeIDReplicatedKey(rangeID roachpb.RangeID, suffix, detail roachpb.RKey) roachpb.Key {
+func makeRangeIDReplicatedKey(rangeID roachpb.RangeID, suffix, detail roachpb.RKey) roachpb.Key {
 	if len(suffix) != localSuffixLength {
 		panic(fmt.Sprintf("suffix len(%q) != %d", suffix, localSuffixLength))
 	}
@@ -139,9 +139,7 @@ func DecodeRangeIDKey(
 // abort cache entry, with detail specified by encoding the
 // supplied transaction ID.
 func AbortCacheKey(rangeID roachpb.RangeID, txnID uuid.UUID) roachpb.Key {
-	key := MakeRangeIDReplicatedKey(rangeID, LocalAbortCacheSuffix, nil)
-	key = encoding.EncodeBytesAscending(key, txnID.GetBytes())
-	return key
+	return MakeRangeIDPrefixBuf(rangeID).AbortCacheKey(txnID)
 }
 
 // DecodeAbortCacheKey decodes the provided abort cache entry,
@@ -169,49 +167,49 @@ func DecodeAbortCacheKey(key roachpb.Key, dest []byte) (uuid.UUID, error) {
 
 // RaftTombstoneKey returns a system-local key for a raft tombstone.
 func RaftTombstoneKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDReplicatedKey(rangeID, LocalRaftTombstoneSuffix, nil)
+	return MakeRangeIDPrefixBuf(rangeID).RaftTombstoneKey()
 }
 
 // RaftAppliedIndexKey returns a system-local key for a raft applied index.
 func RaftAppliedIndexKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDReplicatedKey(rangeID, LocalRaftAppliedIndexSuffix, nil)
+	return MakeRangeIDPrefixBuf(rangeID).RaftAppliedIndexKey()
 }
 
 // LeaseAppliedIndexKey returns a system-local key for a lease applied index.
 func LeaseAppliedIndexKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDReplicatedKey(rangeID, LocalLeaseAppliedIndexSuffix, nil)
+	return MakeRangeIDPrefixBuf(rangeID).LeaseAppliedIndexKey()
 }
 
 // RaftTruncatedStateKey returns a system-local key for a RaftTruncatedState.
 func RaftTruncatedStateKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDReplicatedKey(rangeID, LocalRaftTruncatedStateSuffix, nil)
+	return MakeRangeIDPrefixBuf(rangeID).RaftTruncatedStateKey()
 }
 
 // RangeFrozenStatusKey returns a system-local key for the frozen status.
 func RangeFrozenStatusKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDReplicatedKey(rangeID, LocalRangeFrozenStatusSuffix, nil)
+	return MakeRangeIDPrefixBuf(rangeID).RangeFrozenStatusKey()
 }
 
 // RangeLeaseKey returns a system-local key for a range lease.
 func RangeLeaseKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDReplicatedKey(rangeID, LocalRangeLeaseSuffix, nil)
+	return MakeRangeIDPrefixBuf(rangeID).RangeLeaseKey()
 }
 
 // RangeStatsKey returns the key for accessing the MVCCStats struct
 // for the specified Range ID.
 func RangeStatsKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDReplicatedKey(rangeID, LocalRangeStatsSuffix, nil)
+	return MakeRangeIDPrefixBuf(rangeID).RangeStatsKey()
 }
 
 // RangeLastGCKey returns a system-local key for the last GC.
 func RangeLastGCKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDReplicatedKey(rangeID, LocalRangeLastGCSuffix, nil)
+	return MakeRangeIDPrefixBuf(rangeID).RangeLastGCKey()
 }
 
 // RangeTxnSpanGCThresholdKey returns a system-local key for last used GC
 // threshold on the txn span.
 func RangeTxnSpanGCThresholdKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDReplicatedKey(rangeID, LocalTxnSpanGCThresholdSuffix, nil)
+	return MakeRangeIDPrefixBuf(rangeID).RangeTxnSpanGCThresholdKey()
 }
 
 // MakeRangeIDUnreplicatedPrefix creates a range-local key prefix from
@@ -220,9 +218,9 @@ func MakeRangeIDUnreplicatedPrefix(rangeID roachpb.RangeID) roachpb.Key {
 	return makePrefixWithRangeID(LocalRangeIDPrefix, rangeID, localRangeIDUnreplicatedInfix)
 }
 
-// MakeRangeIDUnreplicatedKey creates a range-local unreplicated key based
+// makeRangeIDUnreplicatedKey creates a range-local unreplicated key based
 // on the range's Range ID, metadata key suffix, and optional detail.
-func MakeRangeIDUnreplicatedKey(
+func makeRangeIDUnreplicatedKey(
 	rangeID roachpb.RangeID, suffix roachpb.RKey, detail roachpb.RKey,
 ) roachpb.Key {
 	if len(suffix) != localSuffixLength {
@@ -237,44 +235,36 @@ func MakeRangeIDUnreplicatedKey(
 
 // RaftHardStateKey returns a system-local key for a Raft HardState.
 func RaftHardStateKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDUnreplicatedKey(rangeID, LocalRaftHardStateSuffix, nil)
+	return MakeRangeIDPrefixBuf(rangeID).RaftHardStateKey()
 }
 
 // RaftLastIndexKey returns a system-local key for the last index of the
 // Raft log.
 func RaftLastIndexKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDUnreplicatedKey(rangeID, LocalRaftLastIndexSuffix, nil)
+	return MakeRangeIDPrefixBuf(rangeID).RaftLastIndexKey()
 }
 
 // RaftLogPrefix returns the system-local prefix shared by all entries
 // in a Raft log.
 func RaftLogPrefix(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDUnreplicatedKey(rangeID, LocalRaftLogSuffix, nil)
+	return MakeRangeIDPrefixBuf(rangeID).RaftLogPrefix()
 }
 
 // RaftLogKey returns a system-local key for a Raft log entry.
 func RaftLogKey(rangeID roachpb.RangeID, logIndex uint64) roachpb.Key {
-	key := RaftLogPrefix(rangeID)
-	key = encoding.EncodeUint64Ascending(key, logIndex)
-	return key
+	return MakeRangeIDPrefixBuf(rangeID).RaftLogKey(logIndex)
 }
 
 // RangeLastReplicaGCTimestampKey returns a range-local key for
 // the range's last replica GC timestamp.
 func RangeLastReplicaGCTimestampKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDUnreplicatedKey(rangeID, LocalRangeLastReplicaGCTimestampSuffix, nil)
+	return MakeRangeIDPrefixBuf(rangeID).RangeLastReplicaGCTimestampKey()
 }
 
 // RangeLastVerificationTimestampKeyDeprecated returns a range-local
 // key for the range's last verification timestamp.
 func RangeLastVerificationTimestampKeyDeprecated(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDUnreplicatedKey(rangeID, LocalRangeLastVerificationTimestampSuffixDeprecated, nil)
-}
-
-// RangeReplicaDestroyedErrorKey returns a range-local key for
-// the range's replica destroyed error.
-func RangeReplicaDestroyedErrorKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDUnreplicatedKey(rangeID, LocalRangeReplicaDestroyedErrorSuffix, nil)
+	return MakeRangeIDPrefixBuf(rangeID).RangeLastVerificationTimestampKeyDeprecated()
 }
 
 // MakeRangeKey creates a range-local key based on the range
@@ -684,4 +674,117 @@ func Range(ba roachpb.BatchRequest) (roachpb.RSpan, error) {
 		}
 	}
 	return roachpb.RSpan{Key: from, EndKey: to}, nil
+}
+
+// RangeIDPrefixBuf provides methods for generating range ID local keys while
+// avoiding an allocation on every key generated. The generated keys are only
+// valid until the next call to one of the key generation methods.
+type RangeIDPrefixBuf roachpb.Key
+
+// MakeRangeIDPrefixBuf creates a new range ID prefix buf suitable for
+// generating the various range ID local keys.
+func MakeRangeIDPrefixBuf(rangeID roachpb.RangeID) RangeIDPrefixBuf {
+	return RangeIDPrefixBuf(MakeRangeIDPrefix(rangeID))
+}
+
+func (b RangeIDPrefixBuf) replicatedPrefix() roachpb.Key {
+	return append(roachpb.Key(b), localRangeIDReplicatedInfix...)
+}
+
+func (b RangeIDPrefixBuf) unreplicatedPrefix() roachpb.Key {
+	return append(roachpb.Key(b), localRangeIDUnreplicatedInfix...)
+}
+
+// AbortCacheKey returns a range-local key by Range ID for an abort cache
+// entry, with detail specified by encoding the supplied transaction ID.
+func (b RangeIDPrefixBuf) AbortCacheKey(txnID uuid.UUID) roachpb.Key {
+	key := append(b.replicatedPrefix(), LocalAbortCacheSuffix...)
+	return encoding.EncodeBytesAscending(key, txnID.GetBytes())
+}
+
+// RaftTombstoneKey returns a system-local key for a raft tombstone.
+func (b RangeIDPrefixBuf) RaftTombstoneKey() roachpb.Key {
+	return append(b.replicatedPrefix(), LocalRaftTombstoneSuffix...)
+}
+
+// RaftAppliedIndexKey returns a system-local key for a raft applied index.
+func (b RangeIDPrefixBuf) RaftAppliedIndexKey() roachpb.Key {
+	return append(b.replicatedPrefix(), LocalRaftAppliedIndexSuffix...)
+}
+
+// LeaseAppliedIndexKey returns a system-local key for a lease applied index.
+func (b RangeIDPrefixBuf) LeaseAppliedIndexKey() roachpb.Key {
+	return append(b.replicatedPrefix(), LocalLeaseAppliedIndexSuffix...)
+}
+
+// RaftTruncatedStateKey returns a system-local key for a RaftTruncatedState.
+func (b RangeIDPrefixBuf) RaftTruncatedStateKey() roachpb.Key {
+	return append(b.replicatedPrefix(), LocalRaftTruncatedStateSuffix...)
+}
+
+// RangeFrozenStatusKey returns a system-local key for the frozen status.
+func (b RangeIDPrefixBuf) RangeFrozenStatusKey() roachpb.Key {
+	return append(b.replicatedPrefix(), LocalRangeFrozenStatusSuffix...)
+}
+
+// RangeLeaseKey returns a system-local key for a range lease.
+func (b RangeIDPrefixBuf) RangeLeaseKey() roachpb.Key {
+	return append(b.replicatedPrefix(), LocalRangeLeaseSuffix...)
+}
+
+// RangeStatsKey returns the key for accessing the MVCCStats struct
+// for the specified Range ID.
+func (b RangeIDPrefixBuf) RangeStatsKey() roachpb.Key {
+	return append(b.replicatedPrefix(), LocalRangeStatsSuffix...)
+}
+
+// RangeLastGCKey returns a system-local key for the last GC.
+func (b RangeIDPrefixBuf) RangeLastGCKey() roachpb.Key {
+	return append(b.replicatedPrefix(), LocalRangeLastGCSuffix...)
+}
+
+// RangeTxnSpanGCThresholdKey returns a system-local key for last used GC
+// threshold on the txn span.
+func (b RangeIDPrefixBuf) RangeTxnSpanGCThresholdKey() roachpb.Key {
+	return append(b.replicatedPrefix(), LocalTxnSpanGCThresholdSuffix...)
+}
+
+// RaftHardStateKey returns a system-local key for a Raft HardState.
+func (b RangeIDPrefixBuf) RaftHardStateKey() roachpb.Key {
+	return append(b.unreplicatedPrefix(), LocalRaftHardStateSuffix...)
+}
+
+// RaftLastIndexKey returns a system-local key for the last index of the
+// Raft log.
+func (b RangeIDPrefixBuf) RaftLastIndexKey() roachpb.Key {
+	return append(b.unreplicatedPrefix(), LocalRaftLastIndexSuffix...)
+}
+
+// RaftLogPrefix returns the system-local prefix shared by all entries
+// in a Raft log.
+func (b RangeIDPrefixBuf) RaftLogPrefix() roachpb.Key {
+	return append(b.unreplicatedPrefix(), LocalRaftLogSuffix...)
+}
+
+// RaftLogKey returns a system-local key for a Raft log entry.
+func (b RangeIDPrefixBuf) RaftLogKey(logIndex uint64) roachpb.Key {
+	return encoding.EncodeUint64Ascending(b.RaftLogPrefix(), logIndex)
+}
+
+// RangeLastReplicaGCTimestampKey returns a range-local key for
+// the range's last replica GC timestamp.
+func (b RangeIDPrefixBuf) RangeLastReplicaGCTimestampKey() roachpb.Key {
+	return append(b.unreplicatedPrefix(), LocalRangeLastReplicaGCTimestampSuffix...)
+}
+
+// RangeLastVerificationTimestampKeyDeprecated returns a range-local
+// key for the range's last verification timestamp.
+func (b RangeIDPrefixBuf) RangeLastVerificationTimestampKeyDeprecated() roachpb.Key {
+	return append(b.unreplicatedPrefix(), LocalRangeLastVerificationTimestampSuffixDeprecated...)
+}
+
+// RangeReplicaDestroyedErrorKey returns a range-local key for
+// the range's replica destroyed error.
+func (b RangeIDPrefixBuf) RangeReplicaDestroyedErrorKey() roachpb.Key {
+	return append(b.unreplicatedPrefix(), LocalRangeReplicaDestroyedErrorSuffix...)
 }

--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -289,9 +289,9 @@ func localRangeIDKeyParse(input string) (remainder string, key roachpb.Key) {
 			break
 		}
 	}
-	maker := MakeRangeIDUnreplicatedKey
+	maker := makeRangeIDUnreplicatedKey
 	if replicated {
-		maker = MakeRangeIDReplicatedKey
+		maker = makeRangeIDReplicatedKey
 	}
 	if suffix != nil {
 		if input != "" {

--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -145,7 +145,7 @@ func TestGCQueueShouldQueue(t *testing.T) {
 			// leading to inconsistent state.
 			tc.repl.mu.Lock()
 			defer tc.repl.mu.Unlock()
-			if err := setMVCCStats(context.Background(), tc.repl.store.Engine(), tc.repl.RangeID, ms); err != nil {
+			if err := tc.repl.stateLoader.setMVCCStats(context.Background(), tc.repl.store.Engine(), &ms); err != nil {
 				t.Fatal(err)
 			}
 			tc.repl.mu.state.Stats = ms

--- a/pkg/storage/migration.go
+++ b/pkg/storage/migration.go
@@ -42,7 +42,8 @@ import (
 func migrate7310And6991(
 	ctx context.Context, batch engine.ReadWriter, desc roachpb.RangeDescriptor,
 ) error {
-	state, err := loadState(ctx, batch, &desc)
+	rsl := makeReplicaStateLoader(desc.RangeID)
+	state, err := rsl.load(ctx, batch, &desc)
 	if err != nil {
 		return errors.Wrap(err, "could not migrate TruncatedState: %s")
 	}
@@ -50,13 +51,13 @@ func migrate7310And6991(
 		state.TruncatedState.Term = raftInitialLogTerm
 		state.TruncatedState.Index = raftInitialLogIndex
 		state.RaftAppliedIndex = raftInitialLogIndex
-		if _, err := saveState(ctx, batch, state); err != nil {
+		if _, err := rsl.save(ctx, batch, state); err != nil {
 			return errors.Wrapf(err, "could not migrate TruncatedState to %+v", &state.TruncatedState)
 		}
 		log.Warningf(ctx, "migration: synthesized TruncatedState for %+v", desc)
 	}
 
-	hs, err := loadHardState(ctx, batch, desc.RangeID)
+	hs, err := rsl.loadHardState(ctx, batch)
 	if err != nil {
 		return errors.Wrap(err, "unable to load HardState")
 	}
@@ -65,7 +66,7 @@ func migrate7310And6991(
 	// index (which would error out and fatal us).
 	if hs.Commit == 0 {
 		log.Warningf(ctx, "migration: synthesized HardState for %+v", desc)
-		if err := synthesizeHardState(ctx, batch, state, hs); err != nil {
+		if err := rsl.synthesizeHardState(ctx, batch, state, hs); err != nil {
 			return errors.Wrap(err, "could not migrate HardState")
 		}
 	}

--- a/pkg/storage/migration_test.go
+++ b/pkg/storage/migration_test.go
@@ -42,17 +42,18 @@ func TestMigrate7310And6991(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ts, err := loadTruncatedState(context.Background(), eng, desc.RangeID)
+	rsl := makeReplicaStateLoader(desc.RangeID)
+	ts, err := rsl.loadTruncatedState(context.Background(), eng)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	hs, err := loadHardState(context.Background(), eng, desc.RangeID)
+	hs, err := rsl.loadHardState(context.Background(), eng)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	rApplied, lApplied, err := loadAppliedIndex(context.Background(), eng, desc.RangeID)
+	rApplied, lApplied, err := rsl.loadAppliedIndex(context.Background(), eng)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1219,11 +1219,11 @@ func evalGC(
 	pd.Replicated.State.GCThreshold = newThreshold
 	pd.Replicated.State.TxnSpanGCThreshold = newTxnSpanGCThreshold
 
-	if err := setGCThreshold(ctx, batch, cArgs.Stats, r.Desc().RangeID, &newThreshold); err != nil {
+	if err := r.stateLoader.setGCThreshold(ctx, batch, cArgs.Stats, &newThreshold); err != nil {
 		return EvalResult{}, err
 	}
 
-	if err := setTxnSpanGCThreshold(ctx, batch, cArgs.Stats, r.Desc().RangeID, &newTxnSpanGCThreshold); err != nil {
+	if err := r.stateLoader.setTxnSpanGCThreshold(ctx, batch, cArgs.Stats, &newTxnSpanGCThreshold); err != nil {
 		return EvalResult{}, err
 	}
 
@@ -1593,7 +1593,7 @@ func evalTruncateLog(
 	pd.Replicated.State.TruncatedState = tState
 	pd.Replicated.RaftLogDelta = &diff.SysBytes
 
-	return pd, setTruncatedState(ctx, batch, cArgs.Stats, r.RangeID, tState)
+	return pd, r.stateLoader.setTruncatedState(ctx, batch, cArgs.Stats, tState)
 }
 
 func newFailedLeaseTrigger(isTransfer bool) EvalResult {
@@ -1747,7 +1747,7 @@ func (r *Replica) applyNewLeaseLocked(
 	}
 
 	// Store the lease to disk & in-memory.
-	if err := setLease(ctx, batch, ms, r.RangeID, &lease); err != nil {
+	if err := r.stateLoader.setLease(ctx, batch, ms, &lease); err != nil {
 		return newFailedLeaseTrigger(isTransfer), err
 	}
 
@@ -2062,7 +2062,7 @@ func evalChangeFrozen(
 
 	desc := r.Desc()
 
-	frozen, err := loadFrozenStatus(ctx, batch, desc.RangeID)
+	frozen, err := r.stateLoader.loadFrozenStatus(ctx, batch)
 	if err != nil || (frozen == storagebase.ReplicaState_FROZEN) == args.Frozen {
 		// Something went wrong or we're already in the right frozen state. In
 		// the latter case, we avoid writing the "same thing" because "we"
@@ -2117,7 +2117,7 @@ func evalChangeFrozen(
 	if args.Frozen {
 		frozenStatus = storagebase.ReplicaState_FROZEN
 	}
-	if err := setFrozenStatus(ctx, batch, cArgs.Stats, r.Desc().RangeID, frozenStatus); err != nil {
+	if err := r.stateLoader.setFrozenStatus(ctx, batch, cArgs.Stats, frozenStatus); err != nil {
 		*reply = roachpb.ChangeFrozenResponse{}
 		return EvalResult{}, err
 	}
@@ -2781,7 +2781,7 @@ func (r *Replica) splitTrigger(
 		//
 		// TODO(tschottdorf): why would this use r.store.Engine() and not the
 		// batch?
-		leftLease, err := loadLease(ctx, r.store.Engine(), r.RangeID)
+		leftLease, err := r.stateLoader.loadLease(ctx, r.store.Engine())
 		if err != nil {
 			return enginepb.MVCCStats{}, EvalResult{}, errors.Wrap(err, "unable to load lease")
 		}
@@ -3010,7 +3010,7 @@ func (r *Replica) mergeTrigger(
 	mergedMS.Add(msRange)
 
 	// Set stats for updated range.
-	if err := setMVCCStats(ctx, batch, r.RangeID, mergedMS); err != nil {
+	if err := r.stateLoader.setMVCCStats(ctx, batch, &mergedMS); err != nil {
 		return EvalResult{}, errors.Errorf("unable to write MVCC stats: %s", err)
 	}
 

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -544,7 +544,7 @@ func (r *Replica) handleReplicatedEvalResult(
 			r.mu.state.Stats.ContainsEstimates = false
 			stats := r.mu.state.Stats
 			r.mu.Unlock()
-			if err := setMVCCStats(ctx, r.store.Engine(), r.RangeID, stats); err != nil {
+			if err := r.stateLoader.setMVCCStats(ctx, r.store.Engine(), &stats); err != nil {
 				log.Fatal(ctx, errors.Wrap(err, "unable to write MVCC stats"))
 			}
 		}

--- a/pkg/storage/replica_state_test.go
+++ b/pkg/storage/replica_state_test.go
@@ -65,19 +65,20 @@ func TestSynthesizeHardState(t *testing.T) {
 				TruncatedState:   &roachpb.RaftTruncatedState{Term: test.TruncTerm},
 				RaftAppliedIndex: test.RaftAppliedIndex,
 			}
+			rsl := makeReplicaStateLoader(testState.Desc.RangeID)
 
 			if test.OldHS != nil {
-				if err := setHardState(context.Background(), batch, testState.Desc.RangeID, *test.OldHS); err != nil {
+				if err := rsl.setHardState(context.Background(), batch, *test.OldHS); err != nil {
 					t.Fatal(err)
 				}
 			}
 
-			oldHS, err := loadHardState(context.Background(), batch, testState.Desc.RangeID)
+			oldHS, err := rsl.loadHardState(context.Background(), batch)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			err = synthesizeHardState(context.Background(), batch, testState, oldHS)
+			err = rsl.synthesizeHardState(context.Background(), batch, testState, oldHS)
 			if !testutils.IsError(err, test.Err) {
 				t.Fatalf("%d: expected %q got %v", i, test.Err, err)
 			} else if err != nil {
@@ -85,7 +86,7 @@ func TestSynthesizeHardState(t *testing.T) {
 				return
 			}
 
-			hs, err := loadHardState(context.Background(), batch, testState.Desc.RangeID)
+			hs, err := rsl.loadHardState(context.Background(), batch)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -4983,7 +4983,7 @@ func TestReplicaCorruption(t *testing.T) {
 	}
 
 	// Verify destroyed error was persisted.
-	pErr, err = loadReplicaDestroyedError(context.Background(), r.store.Engine(), r.RangeID)
+	pErr, err = r.stateLoader.loadReplicaDestroyedError(context.Background(), r.store.Engine())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/split_queue_test.go
+++ b/pkg/storage/split_queue_test.go
@@ -90,7 +90,7 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 			tc.repl.mu.Lock()
 			defer tc.repl.mu.Unlock()
 			ms := enginepb.MVCCStats{KeyBytes: test.bytes}
-			if err := setMVCCStats(context.Background(), tc.repl.store.Engine(), tc.repl.RangeID, ms); err != nil {
+			if err := tc.repl.stateLoader.setMVCCStats(context.Background(), tc.repl.store.Engine(), &ms); err != nil {
 				t.Fatal(err)
 			}
 			tc.repl.mu.state.Stats = ms

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3004,7 +3004,7 @@ func (s *Store) processRaftRequest(
 			needTombstone := r.mu.state.Desc.NextReplicaID != 0
 			r.mu.Unlock()
 
-			appliedIndex, _, err := loadAppliedIndex(ctx, r.store.Engine(), r.RangeID)
+			appliedIndex, _, err := r.stateLoader.loadAppliedIndex(ctx, r.store.Engine())
 			if err != nil {
 				return roachpb.NewError(err)
 			}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -662,9 +662,10 @@ func TestProcessRangeDescriptorUpdate(t *testing.T) {
 	}
 
 	r := &Replica{
-		RangeID:    desc.RangeID,
-		store:      store,
-		abortCache: NewAbortCache(desc.RangeID),
+		RangeID:     desc.RangeID,
+		stateLoader: makeReplicaStateLoader(desc.RangeID),
+		store:       store,
+		abortCache:  NewAbortCache(desc.RangeID),
 	}
 	r.mu.timedMutex = makeTimedMutex(defaultMuLogger)
 	r.cmdQMu.timedMutex = makeTimedMutex(defaultMuLogger)
@@ -2058,7 +2059,7 @@ func TestStoreChangeFrozen(t *testing.T) {
 		repl.mu.Lock()
 		frozen := repl.mu.state.Frozen
 		repl.mu.Unlock()
-		pFrozen, err := loadFrozenStatus(context.Background(), store.Engine(), 1)
+		pFrozen, err := repl.stateLoader.loadFrozenStatus(context.Background(), store.Engine())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2181,7 +2182,7 @@ func TestStoreGCThreshold(t *testing.T) {
 		repl.mu.Lock()
 		gcThreshold := repl.mu.state.GCThreshold
 		repl.mu.Unlock()
-		pgcThreshold, err := loadGCThreshold(context.Background(), store.Engine(), 1)
+		pgcThreshold, err := repl.stateLoader.loadGCThreshold(context.Background(), store.Engine())
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Reorganized the range-local key generation code to utilize a new
RangeIDPrefixBuf abstraction. Use this new functionality in
replicaStateKeys to avoid allocations when loading and saving
range-local data.

This removes 2.2% of allocations in a write-only workload.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13455)
<!-- Reviewable:end -->
