### PR TITLE
sqlbase: correct keys per row calculation in RowFetcher

### DIFF
--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -167,12 +167,9 @@ func (rf *RowFetcher) StartScan(
 	// a very restrictive filter and actually have to retrieve a lot of rows).
 	firstBatchLimit := limitHint
 	if firstBatchLimit != 0 {
-		// For a secondary index, we have one key per row.
-		if !rf.isSecondaryIndex {
-			// We have a sentinel key per row plus at most one key per non-PK column. Of course, we
-			// may have other keys due to a schema change, but this is only a hint.
-			firstBatchLimit *= int64(1 + len(rf.cols) - len(rf.index.ColumnIDs))
-		}
+		// The limitHint is a row limit, but each row could be made up of more
+		// than one key.
+		firstBatchLimit = limitHint * int64(rf.desc.KeysPerRow(rf.index.ID))
 		// We need an extra key to make sure we form the last row.
 		firstBatchLimit++
 	}

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -294,6 +294,16 @@ func (desc *TableDescriptor) IsPhysicalTable() bool {
 	return desc.IsTable() && !desc.IsVirtualTable()
 }
 
+// KeysPerRow returns the maximum number of keys used to encode a row for the
+// given index. For secondary indexes, we always only use one, but for primary
+// indexes, we can encode up to one kv per column family.
+func (desc *TableDescriptor) KeysPerRow(indexID IndexID) int {
+	if desc.PrimaryIndex.ID == indexID {
+		return len(desc.Families)
+	}
+	return 1
+}
+
 // allNonDropColumns returns all the columns, including those being added
 // in the mutations.
 func (desc *TableDescriptor) allNonDropColumns() []ColumnDescriptor {


### PR DESCRIPTION
Looks like this got missed in the column families work.

Closes #13346.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13458)
<!-- Reviewable:end -->
