### PR TITLE
server, storage/engine: lower the minimum number of open files per store

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -268,17 +268,16 @@ func GetTotalMemory() (int64, error) {
 // setOpenFileLimit sets the soft limit for open file descriptors to the hard
 // limit if needed. Returns an error if the hard limit is too low. Returns the
 // value to set maxOpenFiles to for each store.
-// Minimum - 256 per store, 256 saved for networking
+// Minimum - 1700 per store, 256 saved for networking
 // Constrained - 256 saved for networking, rest divided evenly per store
-// Constrained (network only) - 5000 per store, rest saved for networking
-// Recommended - 5000 per store, 5000 for network
+// Constrained (network only) - 10000 per store, rest saved for networking
+// Recommended - 10000 per store, 5000 for network
 // Also, please note that current and max limits are commonly referred to as
 // the soft and hard limits respectively.
 func setOpenFileLimit(physicalStoreCount int) (int, error) {
 	minimumOpenFileLimit := uint64(physicalStoreCount*engine.MinimumMaxOpenFiles + minimumNetworkFileDescriptors)
 	networkConstrainedFileLimit := uint64(physicalStoreCount*engine.RecommendedMaxOpenFiles + minimumNetworkFileDescriptors)
 	recommendedOpenFileLimit := uint64(physicalStoreCount*engine.RecommendedMaxOpenFiles + recommendedNetworkFileDescriptors)
-	// TODO(bram): Test this out on windows.
 	var rLimit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit); err != nil {
 		if log.V(1) {

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -69,8 +69,11 @@ const (
 	// recommended number, than the default value is used.
 	RecommendedMaxOpenFiles = 10000
 	// MinimumMaxOpenFiles is The minimum value that rocksDB's max_open_files
-	// option can be set to.
-	MinimumMaxOpenFiles = 2000
+	// option can be set to. While this should be set as high as possible, the
+	// minimum total for a single store node must be under 2048 for Windows
+	// compatibility. See:
+	// https://wpdev.uservoice.com/forums/266908-command-prompt-console-bash-on-ubuntu-on-windo/suggestions/17310124-add-ability-to-change-max-number-of-open-files-for
+	MinimumMaxOpenFiles = 1700
 )
 
 func init() {


### PR DESCRIPTION
This allows cockroach to run in Window's BashForWindows subsystem.
The new minimum for a single store node is now 1700 (per store) + 256 (networking) = 1956

See #12593

cc @jseldess

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13462)
<!-- Reviewable:end -->
