### PR TITLE
util/timedutil: add sync.Pools for *time.Timer and *timeutil.Timer

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -1138,8 +1138,8 @@ func (ds *DistSender) sendToReplicas(
 	// Wait for completions. This loop will retry operations that fail
 	// with errors that reflect per-replica state and may succeed on
 	// other replicas.
-	var sendNextTimer timeutil.Timer
-	var slowTimer timeutil.Timer
+	sendNextTimer := timeutil.NewTimer()
+	slowTimer := timeutil.NewTimer()
 	defer sendNextTimer.Stop()
 	defer slowTimer.Stop()
 	slowTimer.Reset(base.SlowRequestThreshold)

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1045,7 +1045,7 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) (LeaseStatus, *r
 
 		// Wait for the range lease to finish, or the context to expire.
 		pErr = func() *roachpb.Error {
-			var slowTimer timeutil.Timer
+			slowTimer := timeutil.NewTimer()
 			defer slowTimer.Stop()
 			slowTimer.Reset(base.SlowRequestThreshold)
 			for {
@@ -1676,7 +1676,7 @@ func (r *Replica) beginCmds(ctx context.Context, ba *roachpb.BatchRequest) (*end
 					// However, the command queue assumes that commands don't drop
 					// out before their prerequisites, so we still have to wait it
 					// out.
-					var slowTimer timeutil.Timer
+					slowTimer := timeutil.NewTimer()
 					defer slowTimer.Stop()
 					slowTimer.Reset(base.SlowRequestThreshold)
 					for _, ch := range chans {
@@ -2158,7 +2158,7 @@ func (r *Replica) tryAddWriteCmd(
 	// If the command was accepted by raft, wait for the range to apply it.
 	ctxDone := ctx.Done()
 	shouldQuiesce := r.store.stopper.ShouldQuiesce()
-	var slowTimer timeutil.Timer
+	slowTimer := timeutil.NewTimer()
 	defer slowTimer.Stop()
 	slowTimer.Reset(base.SlowRequestThreshold)
 	for {


### PR DESCRIPTION
We're allocating these timers frequently in hot code-paths. This reduces
channel allocation (i.e. time.Timer.C) from 3% of total allocations to
2%.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13466)
<!-- Reviewable:end -->
