### PR TITLE
storage: crash when seeing a lease owned by a missing replica

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -960,15 +960,8 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) (LeaseStatus, *r
 				if !status.lease.OwnedBy(r.store.StoreID()) {
 					_, stillMember := r.mu.state.Desc.GetReplicaDescriptor(status.lease.Replica.StoreID)
 					if !stillMember {
-						// If the leaseholder doesn't have a replica of the range, we should try
-						// to take the lease even if it hasn't actually expired, since the range
-						// won't be able to make progress while the lease is in such a state (and
-						// leases can stay in such a state for a very long time when using epoch-
-						// based range leases, as in #12591).
-						// TODO(a-robinson/#12680): Make occurrences of this more visible.
-						log.Errorf(ctx, "lease owned by replica %+v that no longer exists",
-							status.lease.Replica)
-						return r.requestLeaseLocked(ctx, status), nil
+						log.Fatalf(ctx, "lease %s owned by replica %+v that no longer exists",
+							status.lease, status.lease.Replica)
 					}
 					// Otherwise, if the lease is currently held by another replica, redirect
 					// to the holder.

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -846,62 +846,6 @@ func TestReplicaNotLeaseHolderError(t *testing.T) {
 	}
 }
 
-// TestLeaseOwnedByNodeWithoutReplica verifies that if an epoch-based lease
-// is owned by a node that doesn't hold a replica for the range, the lease will
-// be acquired.
-func TestLeaseOwnedByNodeWithoutReplica(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	tc := testContext{}
-	stopper := stop.NewStopper()
-	defer stopper.Stop()
-	tc.Start(t, stopper)
-	secondReplica, err := tc.addBogusReplicaToRangeDesc(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Set up a fake NodeLiveness instance so that an epoch-based range lease can
-	// function well enough for the sake of the test.
-	tc.store.cfg.NodeLiveness = &NodeLiveness{}
-	liveness := Liveness{
-		Epoch:      1,
-		Expiration: hlc.MaxTimestamp,
-	}
-	tc.store.cfg.NodeLiveness.mu.nodes = map[roachpb.NodeID]Liveness{
-		tc.store.Ident.NodeID: liveness,
-		secondReplica.NodeID:  liveness,
-	}
-
-	tc.manualClock.Set(leaseExpiry(tc.repl))
-	if err := sendLeaseRequest(tc.repl, &roachpb.Lease{
-		Start:   tc.Clock().Now(),
-		Replica: secondReplica,
-		Epoch:   proto.Int64(liveness.Epoch),
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	// Now remove secondReplica from the range descriptor without taking away
-	// its lease.
-	tc.repl.mu.Lock()
-	replicas := tc.repl.mu.state.Desc.Replicas
-	for i := range replicas {
-		if replicas[i] == secondReplica {
-			replicas = append(replicas[:i], replicas[i+1:]...)
-			break
-		}
-	}
-	tc.repl.mu.state.Desc.Replicas = replicas
-	tc.repl.mu.Unlock()
-
-	{
-		_, err := tc.repl.redirectOnOrAcquireLease(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-}
-
 // TestReplicaLeaseCounters verifies leaseRequest metrics counters are updated
 // correctly after a lease request.
 func TestReplicaLeaseCounters(t *testing.T) {


### PR DESCRIPTION
Remove a funky lease acquisition when the current lease holder replica
is no longer part of the descriptor. I think we should't run into this
situation.

The check was added as part of #12598. That PR also fixed the root
cause. In the discussion in that PR it seemed that we all agree that
this code is unsafe, or at least hard to reason about.
https://reviewable.io/reviews/cockroachdb/cockroach/12598#-K_BztukC4vg1Palloht

CC @bdarnell

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13469)
<!-- Reviewable:end -->
