### PR TITLE
vendor: switch to pinning more deps

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -41,6 +41,13 @@ and checked out as a sub-module at `./vendor`.
 This snapshot was built and is managed using `glide`.
 
 The [docs](https://github.com/Masterminds/glide) have detailed instructions, but in brief:
+* `go get -u github.com/Masterminds/glide`
+  * If installing from master becomes unstable, you can use the oldest version that correctly handles
+  submodules (`ab0972eb`), e.g.
+  ```
+  git -C $GOPATH/src/github.com/Masterminds/glide checkout ab0972eb && \
+  go install github.com/Masterminds/glide
+  ```
 * run `./scripts/glide.sh` in `cockroachdb/cockroach`.
 * add new dependencies with `./scripts/glide.sh get -s github.com/my/dependency`
 	- Note: if you are adding a non-import dependency (e.g. a binary tool to be used in development),

--- a/build/checkdeps.sh
+++ b/build/checkdeps.sh
@@ -4,8 +4,9 @@ set -exuo pipefail
 # This is intended to run in a CI to ensure dependencies are properly vendored.
 
 echo "installing desired glide version"
-go get github.com/Masterminds/glide
-git -C $GOPATH/src/github.com/Masterminds/glide checkout v0.12.3
+go get -d -u github.com/Masterminds/glide
+# ab0972eb merged our fix for correctly vendoring submodule contents.
+git -C $GOPATH/src/github.com/Masterminds/glide checkout ab0972eb
 go install github.com/Masterminds/glide
 
 echo "checking that 'vendor' matches manifest"

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 11665188dd657f4b479ce3c7698b6bb3e2636f0b25570883d67a85bc7520b8d1
-updated: 2017-01-27T16:45:08.62946917-05:00
+hash: 0ba4cc5ad36884d66ee6111a5bd9bbd50057f50fb90089afa05993ac8ebfff81
+updated: 2017-02-08T15:51:59.5049392Z
 imports:
 - name: cloud.google.com/go
-  version: c96c4486674a140772b9788370fa29898577bc0c
+  version: ce650573d812270c64426f3df9fd220324d24b2f
   subpackages:
   - compute/metadata
   - internal
@@ -17,7 +17,7 @@ imports:
   subpackages:
   - winterm
 - name: github.com/backtrace-labs/go-bcd
-  version: 389d108b62915963d915a02837f0ffc00b759d50
+  version: 4ad9137a248599da4b00da0be6e71a75c9e1b8d9
 - name: github.com/biogo/store
   version: 913427a1d5e89604e50ea1db0f28f34966d61602
   subpackages:
@@ -67,8 +67,9 @@ imports:
   subpackages:
   - md2man
 - name: github.com/docker/distribution
-  version: 7dba427612198a11b161a27f9d40bb2dca1ccd20
+  version: b1993c95303df3d0214129d85382c3c573e4df20
   subpackages:
+  - digestset
   - reference
 - name: github.com/docker/docker
   version: 7248742ae7127347a52ab9d215451c213b7b59da
@@ -97,17 +98,17 @@ imports:
   - pkg/term/windows
   - pkg/tlsconfig
 - name: github.com/docker/go-connections
-  version: eb315e36415380e7c2fdee175262560ff42359da
+  version: 7da10c8c50cad14494ec818dcdfb6506265c0086
   subpackages:
   - nat
   - sockets
   - tlsconfig
 - name: github.com/docker/go-units
-  version: e30f1e79f3cd72542f2026ceec18d3bd67ab859c
+  version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
 - name: github.com/dustin/go-humanize
-  version: 904a49491cd5fb5cba832fac98e7e87d56b690a4
+  version: 7a41df006ff9af79a29f0ffa9c5f21fbe6314a2d
 - name: github.com/elastic/gosigar
-  version: 171a3c9e31dde9688c154ba94be6cd5d8a78bf64
+  version: b49e01eb1e5c68c469392a63feaccae9352ceb12
   subpackages:
   - sys/windows
 - name: github.com/elazarl/go-bindata-assetfs
@@ -151,7 +152,7 @@ imports:
 - name: github.com/golang/glog
   version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
 - name: github.com/golang/lint
-  version: 206c0f020eba0f7fbcfbc467a5eb808037df2ed6
+  version: 5295072ea38460cda1ff822cf6d30a7bf64329bd
   subpackages:
   - golint
 - name: github.com/golang/protobuf
@@ -166,11 +167,11 @@ imports:
 - name: github.com/google/btree
   version: 316fb6d3f031ae8f4d457c6c5186b9e3ded70435
 - name: github.com/google/go-github
-  version: dcda0b96bd591fbeb40dcaddec3fb40a7fcaca34
+  version: 27c7c32b6d369610435bd2ad7b4d8554f235eb01
   subpackages:
   - github
 - name: github.com/google/go-querystring
-  version: 9235644dd9e52eeae6fa48efd539fdc351a0af53
+  version: 53e6ce116135b80d037921a7fdd5138cf32d7a8a
   subpackages:
   - query
 - name: github.com/googleapis/gax-go
@@ -221,9 +222,9 @@ imports:
 - name: github.com/mattn/go-isatty
   version: 30a891c33c7cde7b02a981314b4228ec99380cca
 - name: github.com/mattn/go-runewidth
-  version: 737072b4e32b7a5018b4a7125da8d12de90e8045
+  version: 14207d285c6c197daabb5c9793d63e7af9ab2d50
 - name: github.com/mattn/goveralls
-  version: 61ac1a6b48f7f76ff3d14e00d3192e7dd0b9db91
+  version: 8482d0ebd2a64f95ce02d2b9b7065b0d6fe9151b
 - name: github.com/matttproud/golang_protobuf_extensions
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
@@ -239,24 +240,22 @@ imports:
   - syntax
   - syntax/golang
 - name: github.com/Microsoft/go-winio
-  version: 24a3e3d3fc7451805e09d11e11e95d9a0a4f205e
+  version: fff283ad5116362ca252298cfc9b95828956d85d
 - name: github.com/montanaflynn/stats
   version: f8cd06f93c6c1b06028caafb88b540fc820f77c1
 - name: github.com/olekukonko/tablewriter
   version: a0225b3f23b5ce0cbec6d7a66a968f8a59eca9c4
 - name: github.com/opencontainers/go-digest
-  version: a6d0ee40d4207ea02364bd3b9e8e77b9159ba1eb
+  version: aa2ec055abd10d26d539eb630a92241b781ce4bc
 - name: github.com/opentracing/basictracer-go
   version: 1b32af207119a14b1b231d451df3ed04a72efebf
   subpackages:
   - wire
 - name: github.com/opentracing/opentracing-go
-  version: 5e5abf838007b08f96ae057bc182636a178da0b9
+  version: 6edb48674bd9467b8e91fda004f2bd7202d60ce4
   subpackages:
   - ext
   - log
-- name: github.com/pborman/uuid
-  version: 5007efa264d92316c43112bc573e754bc889b7b1
 - name: github.com/petermattis/goid
   version: caab6446a35a918488a0f52d4b0bd088a60f3511
 - name: github.com/pkg/errors
@@ -290,13 +289,13 @@ imports:
 - name: github.com/shurcooL/sanitized_anchor_name
   version: 1dba4b3954bc059efc3991ec364f9f9a35f597d2
 - name: github.com/Sirupsen/logrus
-  version: 9b48ece7fc373043054858f8c0d362665e866004
+  version: 3f603f494d61c73457fb234161d8982b9f0f0b71
 - name: github.com/spf13/cobra
   version: 1dd5ff2e11b6dca62fdcb275eb804b94607d8b06
   subpackages:
   - doc
 - name: github.com/spf13/pflag
-  version: 25f8b5b07aece3207895bf19f7ab517eb3b22a40
+  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/StackExchange/wmi
   version: e54cbda6595d7293a7a468ccf9525f6bc8887f99
 - name: github.com/tebeka/go2xunit
@@ -326,19 +325,19 @@ imports:
   - proxy
   - trace
 - name: golang.org/x/oauth2
-  version: 314dd2c0bf3ebd592ec0d20847d27e79d0dbe8dd
+  version: 4464e7848382e6f39db55097f70e1460bdf944b3
   subpackages:
   - google
   - internal
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: d75a52659825e75fff6158388dddc6a5b04f9ba5
+  version: 7a6e5648d140666db5d920909e082ca00a87ba2c
   subpackages:
   - unix
   - windows
 - name: golang.org/x/text
-  version: 44f4f658a783b0cee41fe0a23b8fc91d9c120558
+  version: dafb3384ad25363d928a9e97ce4ad3a2f0667e34
   subpackages:
   - collate
   - internal/colltab
@@ -350,7 +349,7 @@ imports:
   - unicode/norm
   - width
 - name: golang.org/x/tools
-  version: 354f9f8b43608012e8192f2e8d9e13c615df5c34
+  version: 19c96be7c450e3dff3797cb1e458414c15010358
   subpackages:
   - cmd/goimports
   - cmd/goyacc
@@ -358,12 +357,13 @@ imports:
   - cover
   - go/ast/astutil
   - go/buildutil
+  - go/gcexportdata
   - go/gcimporter15
   - go/loader
   - go/types/typeutil
   - imports
 - name: google.golang.org/api
-  version: 025e50fdada431a9bc9ef7f06b4d504cd26bfa11
+  version: 3d017632ea100549bbb3ae74c567d59f437ece0f
   subpackages:
   - gensupport
   - googleapi
@@ -375,7 +375,7 @@ imports:
   - storage/v1
   - transport
 - name: google.golang.org/appengine
-  version: 8758a385849434ba5eac8aeedcf5192c5a0f5f10
+  version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
   subpackages:
   - internal
   - internal/app_identity
@@ -407,13 +407,14 @@ imports:
 - name: gopkg.in/yaml.v2
   version: a5b47d31c556af34a302ce5d659e6fea44d90de0
 - name: honnef.co/go/tools
-  version: 287365bf3e058d443f33ec1dfe3de9e0ddf29169
+  version: 401755ce93a601ab446c06d4c387277d426aeab8
   subpackages:
   - gcsizes
   - lint
   - lint/lintutil
   - simple
   - ssa
+  - ssa/ssautil
   - staticcheck
   - staticcheck/pure
   - staticcheck/vrp

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,12 +1,46 @@
 package: github.com/cockroachdb/cockroach
 import:
+# Pins due to known upstream issues that prevent updates.
+# These must stay until the issue is resolved, and should include a comment
+# linking to or summarizing the upstream issue.
+#
 # https://github.com/docker/docker/issues/29362
 - package: github.com/docker/docker
   version: 7248742ae7127347a52ab9d215451c213b7b59da
-# etcd pins this via glide, so we must pin harder.
+# Pins to prevent unintended version changes to libs we care about when adding/
+# removing/changing other deps. These are grouped separately to make it easier
+# to comment them out in bulk when running an across-the-board dep update.
+- package: github.com/cockroachdb/c-jemalloc
+  version: 7eb7980d8a9f68b771568a7eb15196a63a818595
+- package: github.com/cockroachdb/c-protobuf
+  version: 070b64667a22925d971878b61e4f0c1df31e8599
+- package: github.com/cockroachdb/c-rocksdb
+  version: 608bf6179ca8b317e707394d263059a933808e2f
+- package: github.com/cockroachdb/cmux
+  version: 30d10be492927e2dcae0089c374c455d42414fcb
+- package: github.com/cockroachdb/cockroach-go
+  version: ba57380fe1f490388284806affe325d081e62be6
+- package: github.com/coreos/etcd
+  version: f99c76cb4791430a25aaea2e7e44e460a332f261
+- package: github.com/gogo/protobuf
+  version: f9114dace7bd920b32f943b3c73fafbcbab2bf31
+- package: github.com/golang/protobuf
+  version: 8ee79997227bf9b34611aee7946ae64735e6fd93
+- package: github.com/google/btree
+  version: 316fb6d3f031ae8f4d457c6c5186b9e3ded70435
+- package: github.com/grpc-ecosystem/grpc-gateway
+  version: 6193f51e51b0bfea774a33f535bc10e983832710
+- package: github.com/lib/pq
+  version: 8df6253d1317616f36b0c3740eb30c239a7372cb
+- package: github.com/olekukonko/tablewriter
+  version: a0225b3f23b5ce0cbec6d7a66a968f8a59eca9c4
+- package: github.com/spf13/cobra
+  version: 1dd5ff2e11b6dca62fdcb275eb804b94607d8b06
+- package: gopkg.in/yaml.v2
+  version: a5b47d31c556af34a302ce5d659e6fea44d90de0
+- package: golang.org/x/crypto
+  version: c3b1d0d6d8690eaebe3064711b026770cc37efa3
 - package: golang.org/x/net
   version: da2b4fa28524a3baf148c1b94df4440267063c88
-# used by a long-lived branch. TODO(dt): remove when merged.
-- package: cloud.google.com/go
-  subpackages:
-  - storage
+- package: google.golang.org/grpc
+  version: 85497e2c516cd289bce5551b840ee27c2a0d6878

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -786,17 +786,17 @@ func Example_sql_column_labels() {
 	// """foo"	\foo	"""foo\nbar"""	κόσμε	a|b	܈85
 	// 0	0	0	0	0	0
 	// sql --format=pretty -e show columns from t.u
-	// +----------+------+------+---------+---------+
-	// |  Field   | Type | Null | Default | Indices |
-	// +----------+------+------+---------+---------+
-	// | "foo     | INT  | true | NULL    | {}      |
-	// | \foo     | INT  | true | NULL    | {}      |
-	// | foo␤     | INT  | true | NULL    | {}      |
-	// | bar      |      |      |         |         |
-	// | κόσμε    | INT  | true | NULL    | {}      |
-	// | a|b      | INT  | true | NULL    | {}      |
-	// | ܈85      | INT  | true | NULL    | {}      |
-	// +----------+------+------+---------+---------+
+	// +---------+------+------+---------+---------+
+	// |  Field  | Type | Null | Default | Indices |
+	// +---------+------+------+---------+---------+
+	// | "foo    | INT  | true | NULL    | {}      |
+	// | \foo    | INT  | true | NULL    | {}      |
+	// | foo␤    | INT  | true | NULL    | {}      |
+	// | bar     |      |      |         |         |
+	// | κόσμε   | INT  | true | NULL    | {}      |
+	// | a|b     | INT  | true | NULL    | {}      |
+	// | ܈85     | INT  | true | NULL    | {}      |
+	// +---------+------+------+---------+---------+
 	// (6 rows)
 	// sql --format=pretty -e select * from t.u
 	// +------+------+------------+-------+-----+-----+

--- a/pkg/cmd/allocsim/main.go
+++ b/pkg/cmd/allocsim/main.go
@@ -295,7 +295,7 @@ func main() {
 	var perNodeArgs map[int][]string
 	if *numLocalities > 0 {
 		perNodeArgs = make(map[int][]string)
-		a.localities = make([]roachpb.Locality, len(c.Nodes), len(c.Nodes))
+		a.localities = make([]roachpb.Locality, len(c.Nodes))
 		for i := range c.Nodes {
 			locality := roachpb.Locality{
 				Tiers: []roachpb.Tier{

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -61,7 +61,7 @@ func TestKeyNext(t *testing.T) {
 	extraCap[0] = 'x'
 	extraCap[1] = 'o'
 
-	noExtraCap := make([]byte, 2, 2)
+	noExtraCap := make([]byte, 2)
 	noExtraCap[0] = 'x'
 	noExtraCap[1] = 'o'
 

--- a/pkg/sql/parser/overload.go
+++ b/pkg/sql/parser/overload.go
@@ -101,7 +101,7 @@ func (a ArgTypes) Length() int {
 // Types implements the typeList interface.
 func (a ArgTypes) Types() []Type {
 	n := len(a)
-	ret := make([]Type, n, n)
+	ret := make([]Type, n)
 	for i, s := range a {
 		ret[i] = s.Typ
 	}

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -77,7 +77,7 @@ func (pl List) Less(i, j int) bool {
 // names returns a list of privilege names in the same
 // order as 'pl'.
 func (pl List) names() []string {
-	ret := make([]string, len(pl), len(pl))
+	ret := make([]string, len(pl))
 	for i, p := range pl {
 		ret[i] = p.String()
 	}

--- a/pkg/sql/split_test.go
+++ b/pkg/sql/split_test.go
@@ -39,7 +39,7 @@ func getRangeKeys(db *client.DB) ([]roachpb.Key, error) {
 	if err != nil {
 		return nil, err
 	}
-	ret := make([]roachpb.Key, len(rows), len(rows))
+	ret := make([]roachpb.Key, len(rows))
 	for i := 0; i < len(rows); i++ {
 		ret[i] = bytes.TrimPrefix(rows[i].Key, keys.Meta2Prefix)
 	}

--- a/pkg/storage/engine/merge_test.go
+++ b/pkg/storage/engine/merge_test.go
@@ -42,7 +42,7 @@ type tsSample struct {
 }
 
 func gibberishString(n int) string {
-	b := make([]byte, n, n)
+	b := make([]byte, n)
 	for i := 0; i < n; i++ {
 		b[i] = byte(rand.Intn(math.MaxUint8 + 1))
 	}

--- a/pkg/storage/entry_cache_test.go
+++ b/pkg/storage/entry_cache_test.go
@@ -28,7 +28,7 @@ import (
 func newEntry(index, size uint64) raftpb.Entry {
 	return raftpb.Entry{
 		Index: index,
-		Data:  make([]byte, size, size),
+		Data:  make([]byte, size),
 	}
 }
 

--- a/pkg/ts/query_test.go
+++ b/pkg/ts/query_test.go
@@ -688,7 +688,7 @@ func (tm *testModel) assertQuery(
 
 	// Construct an expected result for comparison.
 	var expectedDatapoints []tspb.TimeSeriesDatapoint
-	expectedSources := make([]string, 0, 0)
+	expectedSources := make([]string, 0)
 	dataSpans := make(map[string]*dataSpan)
 
 	// If no specific sources were provided, look for data from every source


### PR DESCRIPTION
This switches to pinning many of our important / direct dependencies to make it easier to make more isolated dependency changes.

As discussed in #13138, this is because glide's re-resolution of all deps to latest in absence of a pin makes it otherwise hard to make smaller, isolated changes.

This also updates a few mostly uninteresting deps -- various docker libs, google cloud libs, and linters being the bulk of them.

Fixes a few new lint violations from unneeded capacity args to make.

https://github.com/GoogleCloudPlatform/google-cloud-go/compare/c96c4486...ce650573
https://github.com/Microsoft/go-winio/compare/24a3e3d3...fff283ad
https://github.com/Sirupsen/logrus/compare/9b48ece7...3f603f49
https://github.com/backtrace-labs/go-bcd/compare/389d108b...4ad9137a
https://github.com/docker/distribution/compare/7dba4276...b1993c95
https://github.com/docker/go-connections/compare/eb315e36...7da10c8c
https://github.com/docker/go-units/compare/e30f1e79...0dadbb03
https://github.com/dustin/go-humanize/compare/904a4949...7a41df00
https://github.com/elastic/gosigar/compare/171a3c9e...b49e01eb
https://github.com/golang/lint/compare/206c0f02...5295072e
https://github.com/google/go-github/compare/dcda0b96...27c7c32b
https://github.com/google/go-querystring/compare/9235644d...53e6ce11
https://github.com/mattn/go-runewidth/compare/737072b4...14207d28
https://github.com/mattn/goveralls/compare/61ac1a6b...8482d0eb
https://github.com/opencontainers/go-digest/compare/a6d0ee40...aa2ec055
https://github.com/opentracing/opentracing-go/compare/5e5abf83...6edb4867
https://github.com/spf13/pflag/compare/25f8b5b0...9ff6c692
https://github.com/golang/oauth2/compare/314dd2c0...4464e784
https://github.com/golang/sys/compare/d75a5265...7a6e5648
https://github.com/golang/text/compare/44f4f658...dafb3384
https://github.com/golang/tools/compare/354f9f8b...19c96be7
https://github.com/google/google-api-go-client/compare/025e50fd...3d017632
https://github.com/golang/appengine/compare/8758a385...2e4a801b
https://github.com/dominikh/go-tools/compare/287365bf...401755ce

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13471)
<!-- Reviewable:end -->