### PR TITLE
pgwire: fix TestPGWireDrainOngoingTxns stress failure

### DIFF
--- a/pkg/sql/pgwire/helpers_test.go
+++ b/pkg/sql/pgwire/helpers_test.go
@@ -16,10 +16,30 @@
 
 package pgwire
 
-import "time"
+import (
+	"time"
+
+	"golang.org/x/net/context"
+)
 
 func (s *Server) SetDrainingImpl(
 	drain bool, drainWait time.Duration, cancelWait time.Duration,
 ) error {
 	return s.setDrainingImpl(drain, drainWait, cancelWait)
+}
+
+// OverwriteCancelMap overwrites all active connections' context.CancelFuncs so
+// that the cancellation of any context.CancelFunc in s.mu.connCancelMap does
+// not trigger a response by the associated connection. A slice of the original
+// context.CancelFuncs is returned.
+func (s *Server) OverwriteCancelMap() []context.CancelFunc {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cancel := func() {}
+	originalCancels := make([]context.CancelFunc, 0, len(s.mu.connCancelMap))
+	for done, originalCancel := range s.mu.connCancelMap {
+		s.mu.connCancelMap[done] = cancel
+		originalCancels = append(originalCancels, originalCancel)
+	}
+	return originalCancels
 }


### PR DESCRIPTION
Fixes #13477, #13478, #13479. The issue was a race condition caused by a
connection closing itself before the pgwire.Server stopped waiting for
connections to respond to cancellation. Fixed by replacing the associated cancel
function with a dummy cancel function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13483)
<!-- Reviewable:end -->
