### PR TITLE
storage: Remove logging of prop-eval-kv setting during package init

### DIFF
--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -32,12 +32,6 @@ proc interrupt {} {
     sleep 0.4
 }
 
-# Tests that wish to concatenate a marker with the first line of
-# output need to exclude messages about the env. var
-# PROPOSER_EVALUATED_KV as this may be emitted before the logging
-# flags are handled.
-set silence_prop_eval_kv "2>&1 | grep -v 'running with experimental support for proposer-evaluated KV'"
-
 # Convenience functions to start/shutdown the server.
 # Preserves the invariant that the server's PID is saved
 # in `server_pid`.

--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -37,7 +37,7 @@ eexpect ":/# "
 
 # Check that --alsologtostderr can override the threshold
 # regardless of what --logtostderr has set.
-send "echo marker; $argv start --alsologtostderr=ERROR $silence_prop_eval_kv\r"
+send "echo marker; $argv start --alsologtostderr=ERROR\r"
 eexpect "marker\r\nCockroachDB node starting"
 
 # Stop it.
@@ -45,7 +45,7 @@ interrupt
 interrupt
 eexpect ":/# "
 
-send "echo marker; $argv start --alsologtostderr=ERROR --logtostderr $silence_prop_eval_kv\r"
+send "echo marker; $argv start --alsologtostderr=ERROR --logtostderr\r"
 eexpect "marker\r\nCockroachDB node starting"
 
 # Stop it.
@@ -53,7 +53,7 @@ interrupt
 interrupt
 eexpect ":/# "
 
-send "echo marker; $argv start --alsologtostderr=ERROR --logtostderr=false $silence_prop_eval_kv\r"
+send "echo marker; $argv start --alsologtostderr=ERROR --logtostderr=false\r"
 eexpect "marker\r\nCockroachDB node starting"
 
 # Stop it.
@@ -67,7 +67,7 @@ send "$argv start >/dev/null 2>&1 & sleep 1\r"
 # Now test `quit` as non-start command, and test that `quit` does not
 # emit logging output between the point the command starts until it
 # prints the final ok message.
-send "echo marker; $argv quit $silence_prop_eval_kv\r"
+send "echo marker; $argv quit\r"
 set timeout 20
 eexpect "marker\r\nok\r\n:/# "
 set timeout 5
@@ -76,7 +76,7 @@ set timeout 5
 # that the default logging level is WARNING, so that no INFO messages
 # are printed between the marker and the (first line) error message
 # from quit. Quit will error out because the server is already stopped.
-send "echo marker; $argv quit --logtostderr $silence_prop_eval_kv\r"
+send "echo marker; $argv quit --logtostderr\r"
 eexpect "marker\r\nError"
 eexpect ":/# "
 

--- a/pkg/cli/interactive_tests/test_pretty.tcl
+++ b/pkg/cli/interactive_tests/test_pretty.tcl
@@ -18,7 +18,7 @@ eexpect ":/# "
 
 # Check that tables are not pretty-printed when input is not a terminal
 # and --format=pretty is not speciifed.
-send "echo begin; echo 'select 1;' | $argv sql $silence_prop_eval_kv\r"
+send "echo begin; echo 'select 1;' | $argv sql\r"
 eexpect "begin\r\n1 row\r\n1\r\n1\r\n"
 
 # Check that tables are pretty-printed when input is a terminal

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -92,13 +92,7 @@ var txnAutoGC = true
 var tickQuiesced = envutil.EnvOrDefaultBool("COCKROACH_TICK_QUIESCED", true)
 
 // Whether to enable experimental support for proposer-evaluated KV.
-var propEvalKV = func() bool {
-	enabled := envutil.EnvOrDefaultBool("COCKROACH_PROPOSER_EVALUATED_KV", false)
-	if enabled {
-		log.Warningf(context.Background(), "running with experimental support for proposer-evaluated KV, see #10431")
-	}
-	return enabled
-}()
+var propEvalKV = envutil.EnvOrDefaultBool("COCKROACH_PROPOSER_EVALUATED_KV", false)
 
 // ProposerEvaluatedKVEnabled returns whether experimental support for
 // proposer-evaluated KV is enabled.


### PR DESCRIPTION
Also clean up hack in CLI interactive tests that was working around the
existence of logging during init.

The setting will still be logged during startup due to our logging of
all environment variables affecting configuration, e.g.:

I170208 14:24:13.200762 9 cli/start.go:361  using local environment variables: COCKROACH_PROPOSER_EVALUATED_KV

Probably fixes #13452

@bdarnell @knz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13489)
<!-- Reviewable:end -->


Jira issue: CRDB-14775

Jira issue: CRDB-14776