### PR TITLE
distsql: wrap error signaled by consumer to producer

### DIFF
--- a/pkg/sql/distsqlrun/outbox.go
+++ b/pkg/sql/distsqlrun/outbox.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/pkg/errors"
 )
 
 const outboxBufRows = 16
@@ -183,7 +184,7 @@ func (m *outbox) run() {
 			if recvErr != nil {
 				err = recvErr
 			} else if resp.Error != nil {
-				err = resp.Error.GoError()
+				err = errors.Wrap(resp.Error.GoError(), "consumer signaled error")
 			}
 		}
 	}


### PR DESCRIPTION
This is just a minor improvement for clarity.
I don't think this error is actually used, since it's only set in case
this is not a "SyncFlowStream" and only read in case it is a
"SyncFlowStream".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13491)
<!-- Reviewable:end -->


Jira issue: CRDB-14778

Jira issue: CRDB-14779