### PR TITLE
jepsen: grab more logs in each nightly run

### DIFF
--- a/build/teamcity-jepsen.sh
+++ b/build/teamcity-jepsen.sh
@@ -76,7 +76,7 @@ for test in "${tests[@]}"; do
         else
             # Test passed. grab just the results file.
             echo "Test passed. Grabbing minimal logs..."
-            scp -o "StrictHostKeyChecking no" -ri "$HOME/.ssh/${KEY_NAME}" "ubuntu@${controller}:jepsen/cockroachdb/store/latest/test.fressian" "${artifacts_dir}"
+            scp -o "StrictHostKeyChecking no" -ri "$HOME/.ssh/${KEY_NAME}" "ubuntu@${controller}:jepsen/cockroachdb/store/latest/{test.fressian,results.edn,latency-quantiles.png,latency-raw.png,rate.png}" "${artifacts_dir}"
         fi
         echo "##teamcity[testFinished name='${test} ${nemesis}']"
         echo "##teamcity[publishArtifacts '${LOG_DIR}']"


### PR DESCRIPTION
This adds the results.edn file and some timing visualization pngs to the artifacts for each test configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13494)
<!-- Reviewable:end -->


Jira issue: CRDB-14793

Jira issue: CRDB-14794