### PR TITLE
sql: enable 1PC optimization for UPSERT

### DIFF
--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -149,7 +149,11 @@ func (p *planner) Insert(
 			// TODO(dan): Postgres allows ON CONFLICT DO NOTHING without specifying a
 			// conflict index, which means do nothing on any conflict. Support this if
 			// someone needs it.
-			tw = &tableUpserter{ri: ri, conflictIndex: *conflictIndex}
+			tw = &tableUpserter{
+				ri:            ri,
+				autoCommit:    autoCommit,
+				conflictIndex: *conflictIndex,
+			}
 		} else {
 			names, err := p.namesForExprs(updateExprs)
 			if err != nil {
@@ -184,7 +188,14 @@ func (p *planner) Insert(
 			if err := p.fillFKTableMap(fkTables); err != nil {
 				return nil, err
 			}
-			tw = &tableUpserter{ri: ri, fkTables: fkTables, updateCols: updateCols, conflictIndex: *conflictIndex, evaler: helper}
+			tw = &tableUpserter{
+				ri:            ri,
+				autoCommit:    autoCommit,
+				fkTables:      fkTables,
+				updateCols:    updateCols,
+				conflictIndex: *conflictIndex,
+				evaler:        helper,
+			}
 		}
 	}
 

--- a/pkg/sql/upsert_test.go
+++ b/pkg/sql/upsert_test.go
@@ -34,13 +34,18 @@ import (
 func TestUpsertFastPath(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	// This filter increments scans for every ScanRequest that hits user table
-	// data.
+	// This filter increments scans and beginTxn for every ScanRequest and
+	// BeginTransactionRequest that hits user table data.
 	var scans uint64
+	var beginTxn uint64
 	filter := func(filterArgs storagebase.FilterArgs) *roachpb.Error {
-		if filterArgs.Req.Method() == roachpb.Scan &&
-			bytes.Compare(filterArgs.Req.Header().Key, keys.UserTableDataMin) >= 0 {
-			atomic.AddUint64(&scans, 1)
+		if bytes.Compare(filterArgs.Req.Header().Key, keys.UserTableDataMin) >= 0 {
+			switch filterArgs.Req.Method() {
+			case roachpb.Scan:
+				atomic.AddUint64(&scans, 1)
+			case roachpb.BeginTransaction:
+				atomic.AddUint64(&beginTxn, 1)
+			}
 		}
 		return nil
 	}
@@ -57,30 +62,67 @@ func TestUpsertFastPath(t *testing.T) {
 
 	// This should hit the fast path.
 	atomic.StoreUint64(&scans, 0)
+	atomic.StoreUint64(&beginTxn, 0)
 	sqlDB.Exec(`UPSERT INTO d.kv VALUES (1, 1)`)
 	if s := atomic.LoadUint64(&scans); s != 0 {
 		t.Errorf("expected no scans (the upsert fast path) but got %d", s)
 	}
+	if s := atomic.LoadUint64(&beginTxn); s != 0 {
+		t.Errorf("expected no begin-txn (1PC) but got %d", s)
+	}
 
 	// This should hit the fast path.
 	atomic.StoreUint64(&scans, 0)
+	atomic.StoreUint64(&beginTxn, 0)
 	sqlDB.Exec(`INSERT INTO d.kv VALUES (1, 1) ON CONFLICT (k) DO UPDATE SET v=excluded.v`)
 	if s := atomic.LoadUint64(&scans); s != 0 {
 		t.Errorf("expected no scans (the upsert fast path) but got %d", s)
 	}
+	if s := atomic.LoadUint64(&beginTxn); s != 0 {
+		t.Errorf("expected no begin-txn (1PC) but got %d", s)
+	}
 
 	// This should not hit the fast path because it doesn't set every column.
 	atomic.StoreUint64(&scans, 0)
+	atomic.StoreUint64(&beginTxn, 0)
 	sqlDB.Exec(`UPSERT INTO d.kv (k) VALUES (1)`)
 	if s := atomic.LoadUint64(&scans); s != 1 {
 		t.Errorf("expected 1 scans (no upsert fast path) but got %d", s)
+	}
+	if s := atomic.LoadUint64(&beginTxn); s != 0 {
+		t.Errorf("expected no begin-txn (1PC) but got %d", s)
+	}
+
+	// This should hit the fast path, but won't be a 1PC because of the explicit
+	// transaction.
+	atomic.StoreUint64(&scans, 0)
+	atomic.StoreUint64(&beginTxn, 0)
+	tx, err := sqlDB.DB.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(`UPSERT INTO d.kv VALUES (1, 1)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if s := atomic.LoadUint64(&scans); s != 0 {
+		t.Errorf("expected no scans (the upsert fast path) but got %d", s)
+	}
+	if s := atomic.LoadUint64(&beginTxn); s != 1 {
+		t.Errorf("expected 1 begin-txn (no 1PC) but got %d", s)
 	}
 
 	// This should not hit the fast path because kv has a secondary index.
 	sqlDB.Exec(`CREATE INDEX vidx ON d.kv (v)`)
 	atomic.StoreUint64(&scans, 0)
+	atomic.StoreUint64(&beginTxn, 0)
 	sqlDB.Exec(`UPSERT INTO d.kv VALUES (1, 1)`)
 	if s := atomic.LoadUint64(&scans); s != 1 {
 		t.Errorf("expected 1 scans (no upsert fast path) but got %d", s)
+	}
+	if s := atomic.LoadUint64(&beginTxn); s != 0 {
+		t.Errorf("expected no begin-txn (1PC) but got %d", s)
 	}
 }


### PR DESCRIPTION
When an UPSERT is being run as part of an auto-commit transaction,
commit the transaction when running the batch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13500)
<!-- Reviewable:end -->
