### PR TITLE
build: avoid go-get complaining about detached head

### DIFF
--- a/build/checkdeps.sh
+++ b/build/checkdeps.sh
@@ -4,8 +4,9 @@ set -exuo pipefail
 # This is intended to run in a CI to ensure dependencies are properly vendored.
 
 echo "installing desired glide version"
-go get -d -u github.com/Masterminds/glide
+go get -d github.com/Masterminds/glide
 # ab0972eb merged our fix for correctly vendoring submodule contents.
+git -C $GOPATH/src/github.com/Masterminds/glide fetch
 git -C $GOPATH/src/github.com/Masterminds/glide checkout ab0972eb
 go install github.com/Masterminds/glide
 


### PR DESCRIPTION
we can add a git fetch below if/when we need it, but the -u makes go-get unhappy with the detached checkouts (and co mater above would need to be conditional and just more complexity than is justified here)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13513)
<!-- Reviewable:end -->
