### PR TITLE
distsql: remove stored context from FlowCtx and processors

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1930,14 +1930,14 @@ func (dsp *distSQLPlanner) PlanAndRun(
 	if err := distsqlrun.SetFlowRequestTrace(ctx, &localReq); err != nil {
 		return err
 	}
-	flow, err := dsp.distSQLSrv.SetupSyncFlow(ctx, &localReq, recv)
+	ctx, flow, err := dsp.distSQLSrv.SetupSyncFlow(ctx, &localReq, recv)
 	if err != nil {
 		return err
 	}
 	// TODO(radu): this should go through the flow scheduler.
-	flow.Start(func() {})
+	flow.Start(ctx, func() {})
 	flow.Wait()
-	flow.Cleanup()
+	flow.Cleanup(ctx)
 
 	return nil
 }

--- a/pkg/sql/distsqlplan/aggregator_funcs_test.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs_test.go
@@ -52,13 +52,13 @@ func runTestFlow(
 
 	var rowBuf distsqlrun.RowBuffer
 
-	flow, err := distSQLSrv.SetupSyncFlow(context.TODO(), &req, &rowBuf)
+	ctx, flow, err := distSQLSrv.SetupSyncFlow(context.TODO(), &req, &rowBuf)
 	if err != nil {
 		t.Fatal(err)
 	}
-	flow.Start(func() {})
+	flow.Start(ctx, func() {})
 	flow.Wait()
-	flow.Cleanup()
+	flow.Cleanup(ctx)
 
 	if rowBuf.Err != nil {
 		t.Fatal(rowBuf.Err)

--- a/pkg/sql/distsqlrun/aggregator_test.go
+++ b/pkg/sql/distsqlrun/aggregator_test.go
@@ -21,10 +21,11 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"golang.org/x/net/context"
 )
 
 // TODO(irfansharif): Add tests to verify the following aggregation functions:
@@ -281,7 +282,6 @@ func TestAggregator(t *testing.T) {
 		out := &RowBuffer{}
 
 		flowCtx := FlowCtx{
-			Context: context.Background(),
 			evalCtx: &parser.EvalContext{},
 		}
 
@@ -290,7 +290,7 @@ func TestAggregator(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		ag.Run(nil)
+		ag.Run(context.Background(), nil)
 
 		var expected []string
 		for _, row := range c.expected {

--- a/pkg/sql/distsqlrun/distinct_test.go
+++ b/pkg/sql/distsqlrun/distinct_test.go
@@ -87,16 +87,14 @@ func TestDistinct(t *testing.T) {
 		in := NewRowBuffer(nil, c.input)
 		out := &RowBuffer{}
 
-		flowCtx := FlowCtx{
-			Context: context.Background(),
-		}
+		flowCtx := FlowCtx{}
 
 		d, err := newDistinct(&flowCtx, &ds, in, &PostProcessSpec{}, out)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		d.Run(nil)
+		d.Run(context.Background(), nil)
 		if out.Err != nil {
 			t.Fatal(out.Err)
 		}

--- a/pkg/sql/distsqlrun/flow_registry.go
+++ b/pkg/sql/distsqlrun/flow_registry.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/pkg/errors"
@@ -121,7 +123,7 @@ func (fr *flowRegistry) releaseEntryLocked(id FlowID) {
 // It is expected that UnregisterFlow will be called at some point to remove the
 // flow from the registry.
 func (fr *flowRegistry) RegisterFlow(
-	id FlowID, f *Flow, inboundStreams map[StreamID]*inboundStreamInfo,
+	ctx context.Context, id FlowID, f *Flow, inboundStreams map[StreamID]*inboundStreamInfo,
 ) {
 	fr.Lock()
 	defer fr.Unlock()
@@ -156,8 +158,12 @@ func (fr *flowRegistry) RegisterFlow(
 				}
 			}
 			if numTimedOut != 0 {
-				log.Errorf(entry.flow.Context, "%d inbound streams timed out after %s; stopping flow",
-					numTimedOut, flowStreamTimeout)
+				log.Errorf(
+					ctx,
+					"%d inbound streams timed out after %s; stopping flow",
+					numTimedOut,
+					flowStreamTimeout,
+				)
 			}
 		})
 	}

--- a/pkg/sql/distsqlrun/flow_registry_test.go
+++ b/pkg/sql/distsqlrun/flow_registry_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
@@ -51,7 +53,8 @@ func TestFlowRegistry(t *testing.T) {
 		t.Error("looked up unregistered flow")
 	}
 
-	reg.RegisterFlow(id1, f1, nil)
+	ctx := context.Background()
+	reg.RegisterFlow(ctx, id1, f1, nil)
 
 	if f := reg.LookupFlow(id1, 0); f != f1 {
 		t.Error("couldn't lookup previously registered flow")
@@ -67,7 +70,7 @@ func TestFlowRegistry(t *testing.T) {
 
 	go func() {
 		time.Sleep(jiffy)
-		reg.RegisterFlow(id1, f1, nil)
+		reg.RegisterFlow(ctx, id1, f1, nil)
 	}()
 
 	if f := reg.LookupFlow(id1, 10*jiffy); f != f1 {
@@ -98,7 +101,7 @@ func TestFlowRegistry(t *testing.T) {
 	}()
 
 	time.Sleep(jiffy)
-	reg.RegisterFlow(id2, f2, nil)
+	reg.RegisterFlow(ctx, id2, f2, nil)
 	wg.Wait()
 
 	// -- Multiple lookups, with the first one failing. --
@@ -123,14 +126,14 @@ func TestFlowRegistry(t *testing.T) {
 	}()
 
 	wg1.Wait()
-	reg.RegisterFlow(id3, f3, nil)
+	reg.RegisterFlow(ctx, id3, f3, nil)
 	wg2.Wait()
 
 	// -- Lookup with huge timeout, register in the meantime. --
 
 	go func() {
 		time.Sleep(jiffy)
-		reg.RegisterFlow(id4, f4, nil)
+		reg.RegisterFlow(ctx, id4, f4, nil)
 	}()
 
 	// This should return in a jiffy.

--- a/pkg/sql/distsqlrun/flow_scheduler.go
+++ b/pkg/sql/distsqlrun/flow_scheduler.go
@@ -19,6 +19,8 @@ package distsqlrun
 import (
 	"container/list"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -42,6 +44,14 @@ type flowScheduler struct {
 	}
 }
 
+// flowWithCtx stores a flow to run and a context to run it with.
+// TODO(asubiotto): Figure out if asynchronous flow execution can be rearranged
+// to avoid the need to store the context.
+type flowWithCtx struct {
+	ctx  context.Context
+	flow *Flow
+}
+
 func newFlowScheduler(ambient log.AmbientContext, stopper *stop.Stopper) *flowScheduler {
 	fs := &flowScheduler{
 		AmbientContext: ambient,
@@ -59,28 +69,31 @@ func (fs *flowScheduler) canRunFlow(_ *Flow) bool {
 }
 
 // runFlowNow starts the given flow; does not wait for the flow to complete.
-func (fs *flowScheduler) runFlowNow(f *Flow) {
+func (fs *flowScheduler) runFlowNow(ctx context.Context, f *Flow) {
 	fs.mu.numRunning++
-	f.Start(func() { fs.flowDoneCh <- f })
+	f.Start(ctx, func() { fs.flowDoneCh <- f })
 	// TODO(radu): we could replace the WaitGroup with a structure that keeps a
 	// refcount and automatically runs Cleanup() when the count reaches 0.
 	go func() {
 		f.Wait()
-		f.Cleanup()
+		f.Cleanup(ctx)
 	}()
 }
 
 // ScheduleFlow is the main interface of the flow scheduler: it runs or enqueues
 // the given flow.
-func (fs *flowScheduler) ScheduleFlow(f *Flow) error {
+func (fs *flowScheduler) ScheduleFlow(ctx context.Context, f *Flow) error {
 	return fs.stopper.RunTask(func() {
 		fs.mu.Lock()
 		defer fs.mu.Unlock()
 
 		if fs.canRunFlow(f) {
-			fs.runFlowNow(f)
+			fs.runFlowNow(ctx, f)
 		} else {
-			fs.mu.queue.PushBack(f)
+			fs.mu.queue.PushBack(&flowWithCtx{
+				ctx:  ctx,
+				flow: f,
+			})
 		}
 	})
 }
@@ -104,9 +117,9 @@ func (fs *flowScheduler) Start() {
 				fs.mu.numRunning--
 				if !stopped {
 					if frElem := fs.mu.queue.Front(); frElem != nil {
-						f := frElem.Value.(*Flow)
+						n := frElem.Value.(*flowWithCtx)
 						fs.mu.queue.Remove(frElem)
-						fs.runFlowNow(f)
+						fs.runFlowNow(n.ctx, n.flow)
 					}
 				}
 

--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -77,12 +77,13 @@ func newHashJoiner(
 }
 
 // Run is part of the processor interface.
-func (h *hashJoiner) Run(wg *sync.WaitGroup) {
+func (h *hashJoiner) Run(ctx context.Context, wg *sync.WaitGroup) {
 	if wg != nil {
 		defer wg.Done()
 	}
 
-	ctx, span := tracing.ChildSpan(h.ctx, "hash joiner")
+	ctx = log.WithLogTag(ctx, "HashJoiner", nil)
+	ctx, span := tracing.ChildSpan(ctx, "hash joiner")
 	defer tracing.FinishSpan(span)
 
 	if log.V(2) {

--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -486,7 +486,7 @@ func TestHashJoiner(t *testing.T) {
 		leftInput := NewRowBuffer(nil, c.inputs[0])
 		rightInput := NewRowBuffer(nil, c.inputs[1])
 		out := &RowBuffer{}
-		flowCtx := FlowCtx{Context: context.Background(), evalCtx: &parser.EvalContext{}}
+		flowCtx := FlowCtx{evalCtx: &parser.EvalContext{}}
 
 		post := PostProcessSpec{OutputColumns: c.outCols}
 		h, err := newHashJoiner(&flowCtx, &hs, leftInput, rightInput, &post, out)
@@ -494,7 +494,7 @@ func TestHashJoiner(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		h.Run(nil)
+		h.Run(context.Background(), nil)
 
 		if out.Err != nil {
 			t.Fatal(out.Err)

--- a/pkg/sql/distsqlrun/inbound.go
+++ b/pkg/sql/distsqlrun/inbound.go
@@ -19,6 +19,8 @@ package distsqlrun
 import (
 	"io"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
@@ -27,9 +29,8 @@ import (
 // already received (because the first message contains the flow and stream IDs,
 // it needs to be received before we can get here).
 func ProcessInboundStream(
-	flowCtx *FlowCtx, stream DistSQL_FlowStreamServer, firstMsg *StreamMessage, dst RowReceiver,
+	ctx context.Context, stream DistSQL_FlowStreamServer, firstMsg *StreamMessage, dst RowReceiver,
 ) error {
-	ctx := flowCtx.Context
 	// Function which we call when we are done.
 	finish := func(err error) error {
 		dst.Close(err)

--- a/pkg/sql/distsqlrun/joinerbase.go
+++ b/pkg/sql/distsqlrun/joinerbase.go
@@ -17,15 +17,11 @@
 package distsqlrun
 
 import (
-	"golang.org/x/net/context"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 type joinerBase struct {
-	ctx                     context.Context
 	leftSource, rightSource RowSource
 
 	joinType    joinType
@@ -48,7 +44,6 @@ func (jb *joinerBase) init(
 ) error {
 	jb.leftSource = leftSource
 	jb.rightSource = rightSource
-	jb.ctx = log.WithLogTag(flowCtx.Context, "Joiner", nil)
 	jb.joinType = joinType(jType)
 
 	leftTypes := leftSource.Types()

--- a/pkg/sql/distsqlrun/joinreader_test.go
+++ b/pkg/sql/distsqlrun/joinreader_test.go
@@ -96,7 +96,6 @@ func TestJoinReader(t *testing.T) {
 	}
 	for _, c := range testCases {
 		flowCtx := FlowCtx{
-			Context:  context.Background(),
 			evalCtx:  &parser.EvalContext{},
 			txnProto: &roachpb.Transaction{},
 			clientDB: kvDB,
@@ -117,7 +116,7 @@ func TestJoinReader(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		jr.Run(nil)
+		jr.Run(context.Background(), nil)
 
 		if out.Err != nil {
 			t.Fatal(out.Err)

--- a/pkg/sql/distsqlrun/mergejoiner.go
+++ b/pkg/sql/distsqlrun/mergejoiner.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"sync"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
@@ -70,12 +72,13 @@ func newMergeJoiner(
 }
 
 // Run is part of the processor interface.
-func (m *mergeJoiner) Run(wg *sync.WaitGroup) {
+func (m *mergeJoiner) Run(ctx context.Context, wg *sync.WaitGroup) {
 	if wg != nil {
 		defer wg.Done()
 	}
 
-	ctx, span := tracing.ChildSpan(m.ctx, "merge joiner")
+	ctx = log.WithLogTag(ctx, "MergeJoiner", nil)
+	ctx, span := tracing.ChildSpan(ctx, "merge joiner")
 	defer tracing.FinishSpan(span)
 
 	if log.V(2) {

--- a/pkg/sql/distsqlrun/mergejoiner_test.go
+++ b/pkg/sql/distsqlrun/mergejoiner_test.go
@@ -289,7 +289,7 @@ func TestMergeJoiner(t *testing.T) {
 		leftInput := NewRowBuffer(nil, c.inputs[0])
 		rightInput := NewRowBuffer(nil, c.inputs[1])
 		out := &RowBuffer{}
-		flowCtx := FlowCtx{Context: context.Background(), evalCtx: &parser.EvalContext{}}
+		flowCtx := FlowCtx{evalCtx: &parser.EvalContext{}}
 
 		post := PostProcessSpec{OutputColumns: c.outCols}
 		m, err := newMergeJoiner(&flowCtx, &ms, leftInput, rightInput, &post, out)
@@ -297,7 +297,7 @@ func TestMergeJoiner(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		m.Run(nil)
+		m.Run(context.Background(), nil)
 
 		if out.Err != nil {
 			t.Fatal(out.Err)

--- a/pkg/sql/distsqlrun/outbox.go
+++ b/pkg/sql/distsqlrun/outbox.go
@@ -79,27 +79,27 @@ func (m *outbox) setFlowCtx(flowCtx *FlowCtx) {
 
 // addRow encodes a row into rowBuf. If enough rows were accumulated
 // calls flush().
-func (m *outbox) addRow(row sqlbase.EncDatumRow) error {
+func (m *outbox) addRow(ctx context.Context, row sqlbase.EncDatumRow) error {
 	err := m.encoder.AddRow(row)
 	if err != nil {
 		return err
 	}
 	m.numRows++
 	if m.numRows >= outboxBufRows {
-		return m.flush(false, nil)
+		return m.flush(ctx, false, nil)
 	}
 	return nil
 }
 
 // flush sends the rows accumulated so far in a StreamMessage.
-func (m *outbox) flush(last bool, err error) error {
+func (m *outbox) flush(ctx context.Context, last bool, err error) error {
 	if !last && m.numRows == 0 {
 		return nil
 	}
 	msg := m.encoder.FormMessage(last, err)
 
 	if log.V(3) {
-		log.Infof(m.flowCtx.Context, "flushing outbox")
+		log.Infof(ctx, "flushing outbox")
 	}
 	var sendErr error
 	if m.stream != nil {
@@ -109,10 +109,10 @@ func (m *outbox) flush(last bool, err error) error {
 	}
 	if sendErr != nil {
 		if log.V(1) {
-			log.Errorf(m.flowCtx.Context, "outbox flush error: %s", sendErr)
+			log.Errorf(ctx, "outbox flush error: %s", sendErr)
 		}
 	} else if log.V(3) {
-		log.Infof(m.flowCtx.Context, "outbox flushed")
+		log.Infof(ctx, "outbox flushed")
 	}
 	if sendErr != nil {
 		return sendErr
@@ -122,7 +122,7 @@ func (m *outbox) flush(last bool, err error) error {
 	return nil
 }
 
-func (m *outbox) mainLoop() error {
+func (m *outbox) mainLoop(ctx context.Context) error {
 	if m.syncFlowStream == nil {
 		conn, err := m.flowCtx.rpcCtx.GRPCDial(m.addr)
 		if err != nil {
@@ -130,17 +130,17 @@ func (m *outbox) mainLoop() error {
 		}
 		client := NewDistSQLClient(conn)
 		if log.V(2) {
-			log.Infof(m.flowCtx.Context, "outbox: calling FlowStream")
+			log.Infof(ctx, "outbox: calling FlowStream")
 		}
 		m.stream, err = client.FlowStream(context.TODO())
 		if err != nil {
 			if log.V(1) {
-				log.Infof(m.flowCtx.Context, "FlowStream error: %s", err)
+				log.Infof(ctx, "FlowStream error: %s", err)
 			}
 			return err
 		}
 		if log.V(2) {
-			log.Infof(m.flowCtx.Context, "outbox: FlowStream returned")
+			log.Infof(ctx, "outbox: FlowStream returned")
 		}
 	}
 
@@ -152,20 +152,20 @@ func (m *outbox) mainLoop() error {
 		case d, ok := <-m.RowChannel.C:
 			if !ok {
 				// No more data.
-				return m.flush(true, nil)
+				return m.flush(ctx, true, nil)
 			}
 			err := d.Err
 			if err == nil {
-				err = m.addRow(d.Row)
+				err = m.addRow(ctx, d.Row)
 			}
 			if err != nil {
 				// Try to flush to send out the error, but ignore any
 				// send error.
-				_ = m.flush(true, err)
+				_ = m.flush(ctx, true, err)
 				return err
 			}
 		case <-flushTicker.C:
-			err := m.flush(false, nil)
+			err := m.flush(ctx, false, nil)
 			if err != nil {
 				return err
 			}
@@ -173,8 +173,8 @@ func (m *outbox) mainLoop() error {
 	}
 }
 
-func (m *outbox) run() {
-	err := m.mainLoop()
+func (m *outbox) run(ctx context.Context) {
+	err := m.mainLoop(ctx)
 
 	m.RowChannel.ConsumerDone()
 
@@ -194,8 +194,8 @@ func (m *outbox) run() {
 	}
 }
 
-func (m *outbox) start(wg *sync.WaitGroup) {
+func (m *outbox) start(ctx context.Context, wg *sync.WaitGroup) {
 	m.wg = wg
 	m.RowChannel.Init(nil)
-	go m.run()
+	go m.run(ctx)
 }

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -34,7 +34,7 @@ import (
 type processor interface {
 	// Run is the main loop of the processor.
 	// If wg is non-nil, wg.Done is called before exiting.
-	Run(wg *sync.WaitGroup)
+	Run(ctx context.Context, wg *sync.WaitGroup)
 }
 
 // procOutputHelper is a helper type that performs filtering and projection on
@@ -235,11 +235,11 @@ func newNoopProcessor(
 }
 
 // Run is part of the processor interface.
-func (n *noopProcessor) Run(wg *sync.WaitGroup) {
+func (n *noopProcessor) Run(ctx context.Context, wg *sync.WaitGroup) {
 	if wg != nil {
 		defer wg.Done()
 	}
-	ctx, span := tracing.ChildSpan(n.flowCtx.Context, "noop")
+	ctx, span := tracing.ChildSpan(ctx, "noop")
 	defer tracing.FinishSpan(span)
 
 	for {

--- a/pkg/sql/distsqlrun/sorter_test.go
+++ b/pkg/sql/distsqlrun/sorter_test.go
@@ -171,13 +171,13 @@ func TestSorter(t *testing.T) {
 		ss := c.spec
 		in := NewRowBuffer(nil, c.input)
 		out := &RowBuffer{}
-		flowCtx := FlowCtx{Context: context.Background()}
+		flowCtx := FlowCtx{}
 
 		s, err := newSorter(&flowCtx, &ss, in, &PostProcessSpec{}, out)
 		if err != nil {
 			t.Fatal(err)
 		}
-		s.Run(nil)
+		s.Run(context.Background(), nil)
 		if out.Err != nil {
 			t.Fatal(out.Err)
 		}

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -111,7 +111,6 @@ func TestTableReader(t *testing.T) {
 		ts.Table = *td
 
 		flowCtx := FlowCtx{
-			Context:  context.Background(),
 			evalCtx:  &parser.EvalContext{},
 			txnProto: &roachpb.Transaction{},
 			clientDB: kvDB,
@@ -122,7 +121,7 @@ func TestTableReader(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		tr.Run(nil)
+		tr.Run(context.Background(), nil)
 		if out.Err != nil {
 			t.Fatal(out.Err)
 		}

--- a/pkg/sql/distsqlrun/values.go
+++ b/pkg/sql/distsqlrun/values.go
@@ -19,6 +19,8 @@ package distsqlrun
 import (
 	"sync"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
@@ -53,12 +55,12 @@ func newValuesProcessor(
 }
 
 // Run is part of the processor interface.
-func (v *valuesProcessor) Run(wg *sync.WaitGroup) {
+func (v *valuesProcessor) Run(ctx context.Context, wg *sync.WaitGroup) {
 	if wg != nil {
 		defer wg.Done()
 	}
 
-	ctx, span := tracing.ChildSpan(v.flowCtx.Context, "values")
+	ctx, span := tracing.ChildSpan(ctx, "values")
 	defer tracing.FinishSpan(span)
 
 	// We reuse the code in StreamDecoder for decoding the raw data. We just need

--- a/pkg/sql/distsqlrun/values_test.go
+++ b/pkg/sql/distsqlrun/values_test.go
@@ -68,13 +68,13 @@ func TestValues(t *testing.T) {
 					}
 
 					out := &RowBuffer{}
-					flowCtx := FlowCtx{Context: context.Background()}
+					flowCtx := FlowCtx{}
 
 					v, err := newValuesProcessor(&flowCtx, &spec, &PostProcessSpec{}, out)
 					if err != nil {
 						t.Fatal(err)
 					}
-					v.Run(nil)
+					v.Run(context.Background(), nil)
 					if out.Err != nil {
 						t.Fatal(out.Err)
 					}


### PR DESCRIPTION
Resolves #12346.

This change results in passing down a context from the server entry
points to the processors instead of storing contexts on structs at
initialization and accessing them later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13514)
<!-- Reviewable:end -->
