### PR TITLE
storage: Send snapshot messages with the correct term

### DIFF
--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -101,6 +101,13 @@ func (s *Store) ForceTimeSeriesMaintenanceQueueProcess() {
 	forceScanAndProcess(s, s.tsMaintenanceQueue.baseQueue)
 }
 
+// ForceRaftSnapshotQueueProcess iterates over all ranges, enqueuing
+// any that need raft snapshots, then processes the raft snapshot
+// queue.
+func (s *Store) ForceRaftSnapshotQueueProcess() {
+	forceScanAndProcess(s, s.raftSnapshotQueue.baseQueue)
+}
+
 // ConsistencyQueueShouldQueue invokes the shouldQueue method on the
 // store's consistency queue.
 func (s *Store) ConsistencyQueueShouldQueue(
@@ -144,6 +151,11 @@ func (s *Store) SetReplicaGCQueueActive(active bool) {
 // SetSplitQueueActive enables or disables the split queue.
 func (s *Store) SetSplitQueueActive(active bool) {
 	s.setSplitQueueActive(active)
+}
+
+// SetRaftSnapshotQueueActive enables or disables the raft snapshot queue.
+func (s *Store) SetRaftSnapshotQueueActive(active bool) {
+	s.setRaftSnapshotQueueActive(active)
 }
 
 // SetReplicaScannerActive enables or disables the scanner. Note that while

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -3340,6 +3340,11 @@ func (r *Replica) sendSnapshot(
 		}
 	}
 
+	status := r.RaftStatus()
+	if status == nil {
+		return errors.New("raft status not initialized")
+	}
+
 	req := SnapshotRequest_Header{
 		State: snap.State,
 		RaftMessageRequest: RaftMessageRequest{
@@ -3350,7 +3355,7 @@ func (r *Replica) sendSnapshot(
 				Type:     raftpb.MsgSnap,
 				To:       uint64(repDesc.ReplicaID),
 				From:     uint64(fromRepDesc.ReplicaID),
-				Term:     snap.RaftSnap.Metadata.Term,
+				Term:     status.Term,
 				Snapshot: snap.RaftSnap,
 			},
 		},

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -4001,6 +4001,9 @@ func (s *Store) setSplitQueueActive(active bool) {
 func (s *Store) setTimeSeriesMaintenanceQueueActive(active bool) {
 	s.tsMaintenanceQueue.SetDisabled(!active)
 }
+func (s *Store) setRaftSnapshotQueueActive(active bool) {
+	s.raftSnapshotQueue.SetDisabled(!active)
+}
 func (s *Store) setScannerActive(active bool) {
 	s.scanner.SetDisabled(!active)
 }


### PR DESCRIPTION
This fixes a regression in #12686, which meant that a replica that
fell too far behind would be unable to ever catch up because it would
think that it was receiving out-of-date snapshots.

Fixes #13506

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13515)
<!-- Reviewable:end -->
