### PR TITLE
distsql: support passing plan diagrams via URLs

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1886,11 +1886,12 @@ func (dsp *distSQLPlanner) PlanAndRun(
 			nodeNames[i] = n.String()
 		}
 
-		var buf bytes.Buffer
-		if err := distsqlrun.GeneratePlanDiagram(flows, nodeNames, &buf); err != nil {
+		json, url, err := distsqlrun.GeneratePlanDiagramWithURL(flows, nodeNames)
+		if err != nil {
 			log.Infof(ctx, "Error generating diagram: %s", err)
 		} else {
-			log.Infof(ctx, "Plan diagram JSON:\n%s", buf.String())
+			log.Infof(ctx, "Plan diagram JSON:\n%s", json)
+			log.Infof(ctx, "Plan diagram URL:\n%s", url.String())
 		}
 	}
 

--- a/pkg/sql/distsqlrun/flow_diagram.go
+++ b/pkg/sql/distsqlrun/flow_diagram.go
@@ -18,9 +18,12 @@ package distsqlrun
 
 import (
 	"bytes"
+	"compress/zlib"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 
 	humanize "github.com/dustin/go-humanize"
 	"github.com/pkg/errors"
@@ -332,4 +335,36 @@ func GeneratePlanDiagram(flows []FlowSpec, nodeNames []string, w io.Writer) erro
 		return err
 	}
 	return json.NewEncoder(w).Encode(d)
+}
+
+// GeneratePlanDiagramWithURL generates the json data for a flow diagram and a
+// URL which encodes the diagram. There should be one FlowSpec per node. The
+// function assumes that StreamIDs are unique across all flows.
+func GeneratePlanDiagramWithURL(flows []FlowSpec, nodeNames []string) (string, url.URL, error) {
+	var json, compressed bytes.Buffer
+	if err := GeneratePlanDiagram(flows, nodeNames, &json); err != nil {
+		return "", url.URL{}, err
+	}
+	jsonStr := json.String()
+
+	encoder := base64.NewEncoder(base64.URLEncoding, &compressed)
+	compressor := zlib.NewWriter(encoder)
+	if _, err := json.WriteTo(compressor); err != nil {
+		return "", url.URL{}, err
+	}
+	if err := compressor.Close(); err != nil {
+		return "", url.URL{}, err
+	}
+	if err := encoder.Close(); err != nil {
+		return "", url.URL{}, err
+	}
+	// TODO(radu): using raduberinde.github.io is temporary.
+	url := url.URL{
+		Scheme:   "https",
+		Host:     "raduberinde.github.io",
+		Path:     "decode.html",
+		RawQuery: compressed.String(),
+	}
+
+	return jsonStr, url, nil
 }

--- a/pkg/sql/distsqlrun/flow_diagram_test.go
+++ b/pkg/sql/distsqlrun/flow_diagram_test.go
@@ -33,7 +33,7 @@ func compareDiagrams(t *testing.T, result string, expected string) {
 	dec := json.NewDecoder(strings.NewReader(result))
 	var resData, expData diagramData
 	if err := dec.Decode(&resData); err != nil {
-		t.Fatal(err)
+		t.Fatalf("error decoding '%s': %s", result, err)
 	}
 	dec = json.NewDecoder(strings.NewReader(expected))
 	if err := dec.Decode(&expData); err != nil {
@@ -122,10 +122,8 @@ func TestPlanDiagramIndexJoin(t *testing.T) {
 		},
 	}
 
-	var buf bytes.Buffer
-	if err := GeneratePlanDiagram(
-		[]FlowSpec{f1, f2, f3}, []string{"1", "2", "3"}, &buf,
-	); err != nil {
+	json, url, err := GeneratePlanDiagramWithURL([]FlowSpec{f1, f2, f3}, []string{"1", "2", "3"})
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -148,7 +146,12 @@ func TestPlanDiagramIndexJoin(t *testing.T) {
 	  }
 	`
 
-	compareDiagrams(t, buf.String(), expected)
+	compareDiagrams(t, json, expected)
+
+	expectedURL := "https://raduberinde.github.io/decode.html?eJzEkk9L9DAQxu_vp3h5rptDm3jqKSehHlxZvWkOtRkk0CZlksLK0u8uTXHdyuKloMeZef78WnKCD5bum54iqmeUEJAQUDACA4eWYgw8nxZhbY-oCgHnhzHNayPQBiZUJySXOkKFp-a1owM1lhgCllLjuhz-GHqqvaWjzhII7MdU_del0BJmEghj-oydxEVh-duF8i8Lv3oCW2Ky6w4tdzDTFaq74Pw1qIFd3_D7GenWdYl4ptpp-TIWhWq1OqOqLT_mQHEIPtIK4HueESD7RsunxjBySw8c2vyulnGf1XlhKablqpah9vlUzliX5nKLWW4xqx_NNytzMZnp30cAAAD__-sRIow="
+	if url.String() != expectedURL {
+		t.Errorf("expected `%s` got `%s`", expectedURL, &url)
+	}
 }
 
 func TestPlanDiagramJoin(t *testing.T) {


### PR DESCRIPTION
Add support for passing a plan diagram directly as part of a URL (after zlib
compression + base64 encoding). Example:

https://raduberinde.github.io/decode.html?eJzEkk9L9DAQxu_vp3h5rptDm3jqKSehHlxZvWkOtRkk0CZlksLK0u8uTXHdyuKloMeZef78WnKCD5bum54iqmeUEJAQUDACA4eWYgw8nxZhbY-oCgHnhzHNayPQBiZUJySXOkKFp-a1owM1lhgCllLjuhz-GHqqvaWjzhII7MdU_del0BJmEghj-oydxEVh-duF8i8Lv3oCW2Ky6w4tdzDTFaq74Pw1qIFd3_D7GenWdYl4ptpp-TIWhWq1OqOqLT_mQHEIPtIK4HueESD7RsunxjBySw8c2vyulnGf1XlhKablqpah9vlUzliX5nKLWW4xqx_NNytzMZnp30cAAAD__-sRIow=

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13521)
<!-- Reviewable:end -->
