### PR TITLE
build: include a Go toolchain in cloud workers

### DIFF
--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -7,16 +7,15 @@ set -euxo pipefail
 
 sudo apt-get update
 sudo apt-get dist-upgrade -y
-sudo apt-get install -y --no-install-recommends docker.io git
+sudo apt-get install -y --no-install-recommends docker.io git golang
 
 sudo adduser "${USER}" docker
 
 # Configure environment variables
 echo 'export GOPATH=${HOME}/go' >> ~/.bashrc_go
+echo 'export PATH=${GOPATH}/bin:${PATH}' >> ~/.bashrc_go
 echo '. ~/.bashrc_go' >> ~/.bashrc
 
 . ~/.bashrc_go
 
-mkdir -p "$GOPATH/src/github.com/cockroachdb"
-
-git clone https://github.com/cockroachdb/cockroach.git "$GOPATH/src/github.com/cockroachdb/cockroach"
+go get -d github.com/cockroachdb/cockroach


### PR DESCRIPTION
Note that this will not install the latest version, but the provided
toolchain can be used to install pre-release toolchains via subpackages
of golang.org/x/build/version, e.g.:

$ go get golang.org/x/build/version/go1.8rc3
$ go1.8rc3 download

Use cases which require the current stable toolchain should typically
continue to use the builder image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13528)
<!-- Reviewable:end -->
