### PR TITLE
sql: change TestRaceWithBackfill to run against a cluster

### DIFF
--- a/pkg/sql/as_of_test.go
+++ b/pkg/sql/as_of_test.go
@@ -24,7 +24,7 @@ import (
 	inf "gopkg.in/inf.v0"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	csql "github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -36,7 +36,7 @@ func TestAsOfTime(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	params, _ := createTestServerParams()
-	params.Knobs.SQLSchemaChanger = &csql.SchemaChangerTestingKnobs{
+	params.Knobs.SQLSchemaChanger = &sql.SchemaChangerTestingKnobs{
 		AsyncExecNotification: asyncSchemaChangerDisabled,
 	}
 	s, db, _ := serverutils.StartServer(t, params)

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	csql "github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -152,10 +152,10 @@ func TestOperationsWithColumnMutation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// The descriptor changes made must have an immediate effect
 	// so disable leases on tables.
-	defer csql.TestDisableTableLeases()()
+	defer sql.TestDisableTableLeases()()
 	// Disable external processing of mutations.
 	params, _ := createTestServerParams()
-	params.Knobs.SQLSchemaChanger = &csql.SchemaChangerTestingKnobs{
+	params.Knobs.SQLSchemaChanger = &sql.SchemaChangerTestingKnobs{
 		AsyncExecNotification: asyncSchemaChangerDisabled,
 	}
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)
@@ -361,10 +361,10 @@ func (mt mutationTest) writeIndexMutation(index string, m sqlbase.DescriptorMuta
 func TestOperationsWithIndexMutation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// The descriptor changes made must have an immediate effect.
-	defer csql.TestDisableTableLeases()()
+	defer sql.TestDisableTableLeases()()
 	// Disable external processing of mutations.
 	params, _ := createTestServerParams()
-	params.Knobs.SQLSchemaChanger = &csql.SchemaChangerTestingKnobs{
+	params.Knobs.SQLSchemaChanger = &sql.SchemaChangerTestingKnobs{
 		AsyncExecNotification: asyncSchemaChangerDisabled,
 	}
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)
@@ -501,10 +501,10 @@ func TestOperationsWithColumnAndIndexMutation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// The descriptor changes made must have an immediate effect
 	// so disable leases on tables.
-	defer csql.TestDisableTableLeases()()
+	defer sql.TestDisableTableLeases()()
 	// Disable external processing of mutations.
 	params, _ := createTestServerParams()
-	params.Knobs.SQLSchemaChanger = &csql.SchemaChangerTestingKnobs{
+	params.Knobs.SQLSchemaChanger = &sql.SchemaChangerTestingKnobs{
 		AsyncExecNotification: asyncSchemaChangerDisabled,
 	}
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)
@@ -666,10 +666,10 @@ func TestSchemaChangeCommandsWithPendingMutations(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// The descriptor changes made must have an immediate effect
 	// so disable leases on tables.
-	defer csql.TestDisableTableLeases()()
+	defer sql.TestDisableTableLeases()()
 	// Disable external processing of mutations.
 	params, _ := createTestServerParams()
-	params.Knobs.SQLSchemaChanger = &csql.SchemaChangerTestingKnobs{
+	params.Knobs.SQLSchemaChanger = &sql.SchemaChangerTestingKnobs{
 		AsyncExecNotification: asyncSchemaChangerDisabled,
 	}
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)
@@ -883,8 +883,8 @@ func TestTableMutationQueue(t *testing.T) {
 	// the mutations get queued up.
 	params, _ := createTestServerParams()
 	params.Knobs = base.TestingKnobs{
-		SQLSchemaChanger: &csql.SchemaChangerTestingKnobs{
-			SyncFilter: func(tscc csql.TestingSchemaChangerCollection) {
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+			SyncFilter: func(tscc sql.TestingSchemaChangerCollection) {
 				tscc.ClearSchemaChangers()
 			},
 			AsyncExecNotification: asyncSchemaChangerDisabled,

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -33,6 +33,48 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
+// SplitTable splits a range in the table, with each range having a single
+// replica on a certain node. This forces the querying against the table
+// to be distributed. vals is a list of values forming a primary key for
+// the table. targetNode will own the lease for right side of the split.
+//
+// TODO(radu): this approach should be generalized into test infrastructure
+// (perhaps by adding functionality to logic tests).
+// TODO(radu): we should verify that the plan is indeed distributed as
+// intended.
+func SplitTable(
+	t *testing.T,
+	tc serverutils.TestClusterInterface,
+	desc *sqlbase.TableDescriptor,
+	targetNode int,
+	vals ...interface{},
+) {
+	pik, err := sqlbase.MakePrimaryIndexKey(desc, vals...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	splitKey := keys.MakeRowSentinelKey(pik)
+	_, rightRange, err := tc.Server(0).SplitRange(splitKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	splitKey = rightRange.StartKey.AsRawKey()
+	rightRange, err = tc.AddReplicas(splitKey, tc.Target(targetNode))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// This transfer is necessary to avoid waiting for the lease to expire when
+	// removing the first replica.
+	if err := tc.TransferRangeLease(rightRange, tc.Target(targetNode)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tc.RemoveReplicas(splitKey, tc.Target(0)); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestDistSQLPlanner(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -75,45 +117,11 @@ func TestDistSQLPlanner(t *testing.T) {
 		n*n,
 		sqlutils.ToRowFn(sqlutils.RowIdxFn, sqlutils.RowEnglishFn),
 	)
-	// Split the table into multiple ranges, with each range having a single
-	// replica on a certain node. This forces the query to be distributed.
-	//
-	// TODO(radu): this approach should be generalized into test infrastructure
-	// (perhaps by adding functionality to logic tests).
-	// TODO(radu): we should verify that the plan is indeed distributed as
-	// intended.
+	// Split the table into multiple ranges.
 	descNumToStr := sqlbase.GetTableDescriptor(cdb, "test", "NumToStr")
-
-	// split introduces a split and moves the right range to a given node.
-	split := func(val int, targetNode int) {
-		pik, err := sqlbase.MakePrimaryIndexKey(descNumToStr, val)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		splitKey := keys.MakeRowSentinelKey(pik)
-		_, rightRange, err := tc.Server(0).SplitRange(splitKey)
-		if err != nil {
-			t.Fatal(err)
-		}
-		splitKey = rightRange.StartKey.AsRawKey()
-		rightRange, err = tc.AddReplicas(splitKey, tc.Target(targetNode))
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// This transfer is necessary to avoid waiting for the lease to expire when
-		// removing the first replica.
-		if err := tc.TransferRangeLease(rightRange, tc.Target(targetNode)); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := tc.RemoveReplicas(splitKey, tc.Target(0)); err != nil {
-			t.Fatal(err)
-		}
-	}
-	// split moves the right range, so we split things back to front.
+	// SplitTable moves the right range, so we split things back to front.
 	for i := numNodes - 1; i > 0; i-- {
-		split(n*n/numNodes*i, i)
+		SplitTable(t, tc, descNumToStr, i, n*n/numNodes*i)
 	}
 
 	r := sqlutils.MakeSQLRunner(t, tc.ServerConn(0))

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	csql "github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -58,10 +58,10 @@ func TestSchemaChangeLease(t *testing.T) {
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop()
 	// Set MinSchemaChangeLeaseDuration to always expire the lease.
-	minLeaseDuration := csql.MinSchemaChangeLeaseDuration
-	csql.MinSchemaChangeLeaseDuration = 2 * csql.SchemaChangeLeaseDuration
+	minLeaseDuration := sql.MinSchemaChangeLeaseDuration
+	sql.MinSchemaChangeLeaseDuration = 2 * sql.SchemaChangeLeaseDuration
 	defer func() {
-		csql.MinSchemaChangeLeaseDuration = minLeaseDuration
+		sql.MinSchemaChangeLeaseDuration = minLeaseDuration
 	}()
 
 	if _, err := sqlDB.Exec(`
@@ -74,7 +74,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	var lease sqlbase.TableDescriptor_SchemaChangeLease
 	var id = sqlbase.ID(keys.MaxReservedDescID + 2)
 	var node = roachpb.NodeID(2)
-	changer := csql.NewSchemaChangerForTesting(id, 0, node, *kvDB, nil)
+	changer := sql.NewSchemaChangerForTesting(id, 0, node, *kvDB, nil)
 
 	// Acquire a lease.
 	lease, err := changer.AcquireLease()
@@ -135,7 +135,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	}
 
 	// Set MinSchemaChangeLeaseDuration to not expire the lease.
-	csql.MinSchemaChangeLeaseDuration = minLeaseDuration
+	sql.MinSchemaChangeLeaseDuration = minLeaseDuration
 	oldLease = lease
 	if err := changer.ExtendLease(&lease); err != nil {
 		t.Fatal(err)
@@ -148,18 +148,18 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 
 func validExpirationTime(expirationTime int64) bool {
 	now := timeutil.Now()
-	return expirationTime > now.Add(csql.LeaseDuration/2).UnixNano() && expirationTime < now.Add(csql.LeaseDuration*3/2).UnixNano()
+	return expirationTime > now.Add(sql.LeaseDuration/2).UnixNano() && expirationTime < now.Add(sql.LeaseDuration*3/2).UnixNano()
 }
 
 func TestSchemaChangeProcess(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// The descriptor changes made must have an immediate effect
 	// so disable leases on tables.
-	defer csql.TestDisableTableLeases()()
+	defer sql.TestDisableTableLeases()()
 
 	params, _ := createTestServerParams()
 	// Disable external processing of mutations.
-	params.Knobs.SQLSchemaChanger = &csql.SchemaChangerTestingKnobs{
+	params.Knobs.SQLSchemaChanger = &sql.SchemaChangerTestingKnobs{
 		AsyncExecNotification: asyncSchemaChangerDisabled,
 	}
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
@@ -168,16 +168,16 @@ func TestSchemaChangeProcess(t *testing.T) {
 	var id = sqlbase.ID(keys.MaxReservedDescID + 2)
 	var node = roachpb.NodeID(2)
 	stopper := stop.NewStopper()
-	leaseMgr := csql.NewLeaseManager(
+	leaseMgr := sql.NewLeaseManager(
 		&base.NodeIDContainer{},
 		*kvDB,
 		hlc.NewClock(hlc.UnixNano, time.Nanosecond),
-		csql.LeaseManagerTestingKnobs{},
+		sql.LeaseManagerTestingKnobs{},
 		stopper,
-		&csql.MemoryMetrics{},
+		&sql.MemoryMetrics{},
 	)
 	defer stopper.Stop()
-	changer := csql.NewSchemaChangerForTesting(id, 0, node, *kvDB, leaseMgr)
+	changer := sql.NewSchemaChangerForTesting(id, 0, node, *kvDB, leaseMgr)
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
@@ -248,7 +248,7 @@ INSERT INTO t.test VALUES ('a', 'b'), ('c', 'd');
 	index.Name = "bar"
 	index.ID = tableDesc.NextIndexID
 	tableDesc.NextIndexID++
-	changer = csql.NewSchemaChangerForTesting(id, tableDesc.NextMutationID, node, *kvDB, leaseMgr)
+	changer = sql.NewSchemaChangerForTesting(id, tableDesc.NextMutationID, node, *kvDB, leaseMgr)
 	tableDesc.Mutations = append(tableDesc.Mutations, sqlbase.DescriptorMutation{
 		Descriptor_: &sqlbase.DescriptorMutation_Index{Index: index},
 		Direction:   sqlbase.DescriptorMutation_ADD,
@@ -301,13 +301,13 @@ func TestAsyncSchemaChanger(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// The descriptor changes made must have an immediate effect
 	// so disable leases on tables.
-	defer csql.TestDisableTableLeases()()
+	defer sql.TestDisableTableLeases()()
 	// Disable synchronous schema change execution so the asynchronous schema
 	// changer executes all schema changes.
 	params, _ := createTestServerParams()
 	params.Knobs = base.TestingKnobs{
-		SQLSchemaChanger: &csql.SchemaChangerTestingKnobs{
-			SyncFilter: func(tscc csql.TestingSchemaChangerCollection) {
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+			SyncFilter: func(tscc sql.TestingSchemaChangerCollection) {
 				tscc.ClearSchemaChangers()
 			},
 			AsyncExecQuickly: true,
@@ -434,7 +434,7 @@ func runSchemaChangeWithOperations(
 
 	// Grabbing a schema change lease on the table will fail, disallowing
 	// another schema change from being simultaneously executed.
-	sc := csql.NewSchemaChangerForTesting(tableDesc.ID, 0, 0, *kvDB, nil)
+	sc := sql.NewSchemaChangerForTesting(tableDesc.ID, 0, 0, *kvDB, nil)
 	if l, err := sc.AcquireLease(); err == nil {
 		t.Fatalf("schema change lease acquisition on table %d succeeded: %v", tableDesc.ID, l)
 	}
@@ -534,7 +534,7 @@ func TestRaceWithBackfill(t *testing.T) {
 	// Disable asynchronous schema change execution to allow synchronous path
 	// to trigger start of backfill notification.
 	params.Knobs = base.TestingKnobs{
-		SQLSchemaChanger: &csql.SchemaChangerTestingKnobs{
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			RunBeforeBackfillChunk: func(sp roachpb.Span) error {
 				if !partialBackfill {
 					notifyBackfill()
@@ -588,7 +588,7 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
 	// SplitTable moves the right range, so we split things back to front.
 	for i := numNodes - 1; i > 0; i-- {
-		csql.SplitTable(t, tc, tableDesc, i, maxValue/numNodes*i)
+		sql.SplitTable(t, tc, tableDesc, i, maxValue/numNodes*i)
 	}
 
 	// Read table descriptor for version.
@@ -737,12 +737,12 @@ func TestAbortSchemaChangeBackfill(t *testing.T) {
 	// Disable asynchronous schema change execution to allow synchronous path
 	// to trigger start of backfill notification.
 	params.Knobs = base.TestingKnobs{
-		SQLExecutor: &csql.ExecutorTestingKnobs{
+		SQLExecutor: &sql.ExecutorTestingKnobs{
 			// Fix the priority to guarantee that a high priority transaction
 			// pushes a lower priority one.
 			FixTxnPriority: true,
 		},
-		SQLSchemaChanger: &csql.SchemaChangerTestingKnobs{
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			RunBeforeBackfillChunk: func(sp roachpb.Span) error {
 				switch atomic.LoadInt64(&backfillCount) {
 				case 0:
@@ -1029,7 +1029,7 @@ func TestSchemaChangeRetry(t *testing.T) {
 	attempts := 0
 	seenSpan := roachpb.Span{}
 	params.Knobs = base.TestingKnobs{
-		SQLSchemaChanger: &csql.SchemaChangerTestingKnobs{
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			RunBeforeBackfillChunk: func(sp roachpb.Span) error {
 				attempts++
 				// Fail somewhere in the middle.
@@ -1115,7 +1115,7 @@ func TestSchemaChangeRetryOnVersionChange(t *testing.T) {
 	var numBackfills uint32
 	seenSpan := roachpb.Span{}
 	params.Knobs = base.TestingKnobs{
-		SQLSchemaChanger: &csql.SchemaChangerTestingKnobs{
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			RunBeforeBackfill: func() error {
 				atomic.AddUint32(&numBackfills, 1)
 				return nil
@@ -1180,7 +1180,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	id := tableDesc.ID
 
 	upTableVersion = func() {
-		leaseMgr := s.LeaseManager().(*csql.LeaseManager)
+		leaseMgr := s.LeaseManager().(*sql.LeaseManager)
 		if _, err := leaseMgr.Publish(id,
 			func(table *sqlbase.TableDescriptor) error {
 				table.Version++
@@ -1247,7 +1247,7 @@ func TestSchemaChangePurgeFailure(t *testing.T) {
 	// attempt 3: return an error while purging the schema change.
 	expectedAttempts := 3
 	params.Knobs = base.TestingKnobs{
-		SQLSchemaChanger: &csql.SchemaChangerTestingKnobs{
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			RunBeforeBackfillChunk: func(sp roachpb.Span) error {
 				attempts++
 				// Return a deadline exceeded error during the third attempt
@@ -1383,8 +1383,8 @@ func TestSchemaChangeReverseMutations(t *testing.T) {
 	// processed asynchronously.
 	var enableAsyncSchemaChanges uint32
 	params.Knobs = base.TestingKnobs{
-		SQLSchemaChanger: &csql.SchemaChangerTestingKnobs{
-			SyncFilter: func(tscc csql.TestingSchemaChangerCollection) {
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+			SyncFilter: func(tscc sql.TestingSchemaChangerCollection) {
 				tscc.ClearSchemaChangers()
 			},
 			AsyncExecNotification: func() error {
@@ -1670,7 +1670,7 @@ func TestUpdateDuringColumnBackfill(t *testing.T) {
 	continueBackfillNotification := make(chan bool)
 	params, _ := createTestServerParams()
 	params.Knobs = base.TestingKnobs{
-		SQLSchemaChanger: &csql.SchemaChangerTestingKnobs{
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			RunBeforeBackfillChunk: func(sp roachpb.Span) error {
 				if backfillNotification != nil {
 					// Close channel to notify that the schema change has


### PR DESCRIPTION
The test used to bring up a server and execute a schema change
along with other OLTP operations. It now brings up a cluster and
splits up the test table into many ranges, so that when we transition
the schema change backfill to distsql, this test will also test
OLTP operations in the presence of a distributed execution of the
schema change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13530)
<!-- Reviewable:end -->
