### PR TITLE
scripts: remove glide wrapper

### DIFF
--- a/build/checkdeps.sh
+++ b/build/checkdeps.sh
@@ -11,7 +11,7 @@ git -C $GOPATH/src/github.com/Masterminds/glide checkout ab0972eb
 go install github.com/Masterminds/glide
 
 echo "checking that 'vendor' matches manifest"
-./scripts/glide.sh install
+glide install
 ! git -C vendor status --porcelain | read || (git -C vendor status; git -C vendor diff -a 1>&2; exit 1)
 
 echo "checking that all deps are in 'vendor''"

--- a/scripts/glide.sh
+++ b/scripts/glide.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-# Glide *replaces* the vendor directory when it operates on it (e.g. in update
-# or get) which has the side-effect of breaking the .git submodule pointer.
-mv vendor/.git vendorgit
-trap 'mv vendorgit vendor/.git' EXIT
-glide "$@"


### PR DESCRIPTION
they merged vendor/.git preservation upstream, so we no longer need the wrapper

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13531)
<!-- Reviewable:end -->
