### PR TITLE
rpc: Measure inter-node round trip latency of heartbeats

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -111,6 +111,12 @@ type Config struct {
 
 	// httpClient uses the client TLS config. It is initialized lazily.
 	httpClient lazyHTTPClient
+
+	// HistogramWindowInterval is used to determine the approximate length of time
+	// that individual samples are retained in in-memory histograms. Currently,
+	// it is set to the arbitrary length of six times the Metrics sample interval.
+	// See the comment in server.Config for more details.
+	HistogramWindowInterval time.Duration
 }
 
 // InitDefaults sets up the default values for a config.

--- a/pkg/rpc/clock_offset.go
+++ b/pkg/rpc/clock_offset.go
@@ -21,6 +21,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/VividCortex/ewma"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -30,10 +31,20 @@ import (
 )
 
 // RemoteClockMetrics is the collection of metrics for the clock monitor.
+//
+// TODO(a-robinson): Better expose per-node latency for debugging purposes
+// in addition to this aggregated metric.
 type RemoteClockMetrics struct {
 	ClockOffsetMeanNanos   *metric.Gauge
 	ClockOffsetStdDevNanos *metric.Gauge
 }
+
+// avgLatencyMeasurementAge determines how to exponentially weight the
+// moving average of latency measurements. This means that the weight
+// will center around the 20th oldest measurement, such that for measurements
+// that are made every 3 seconds, the average measurement will be about one
+// minute old.
+const avgLatencyMeasurementAge = 20.0
 
 var (
 	metaClockOffsetMeanNanos   = metric.Metadata{Name: "clock-offset.meannanos"}
@@ -41,14 +52,15 @@ var (
 )
 
 // RemoteClockMonitor keeps track of the most recent measurements of remote
-// offsets from this node to connected nodes.
+// offsets and round-trip latency from this node to connected nodes.
 type RemoteClockMonitor struct {
 	clock     *hlc.Clock
 	offsetTTL time.Duration
 
 	mu struct {
 		syncutil.Mutex
-		offsets map[string]RemoteOffset
+		offsets        map[string]RemoteOffset
+		latenciesNanos map[string]ewma.MovingAverage
 	}
 
 	metrics RemoteClockMetrics
@@ -61,6 +73,7 @@ func newRemoteClockMonitor(clock *hlc.Clock, offsetTTL time.Duration) *RemoteClo
 		offsetTTL: offsetTTL,
 	}
 	r.mu.offsets = make(map[string]RemoteOffset)
+	r.mu.latenciesNanos = make(map[string]ewma.MovingAverage)
 	r.metrics = RemoteClockMetrics{
 		ClockOffsetMeanNanos:   metric.NewGauge(metaClockOffsetMeanNanos),
 		ClockOffsetStdDevNanos: metric.NewGauge(metaClockOffsetStdDevNanos),
@@ -74,14 +87,19 @@ func (r *RemoteClockMonitor) Metrics() *RemoteClockMetrics {
 	return &r.metrics
 }
 
-// UpdateOffset is a thread-safe way to update the remote clock measurements.
+// UpdateOffset is a thread-safe way to update the remote clock and latency
+// measurements.
 //
 // It only updates the offset for addr if one of the following cases holds:
 // 1. There is no prior offset for that address.
 // 2. The old offset for addr was measured long enough ago to be considered
 // stale.
 // 3. The new offset's error is smaller than the old offset's error.
-func (r *RemoteClockMonitor) UpdateOffset(ctx context.Context, addr string, offset RemoteOffset) {
+//
+// Pass a roundTripLatency of 0 or less to avoid recording the latency.
+func (r *RemoteClockMonitor) UpdateOffset(
+	ctx context.Context, addr string, offset RemoteOffset, roundTripLatency time.Duration,
+) {
 	emptyOffset := offset == RemoteOffset{}
 
 	r.mu.Lock()
@@ -107,6 +125,15 @@ func (r *RemoteClockMonitor) UpdateOffset(ctx context.Context, addr string, offs
 		if !emptyOffset {
 			r.mu.offsets[addr] = offset
 		}
+	}
+
+	if roundTripLatency > 0 {
+		latencyAvg, ok := r.mu.latenciesNanos[addr]
+		if !ok {
+			latencyAvg = ewma.NewMovingAverage(avgLatencyMeasurementAge)
+			r.mu.latenciesNanos[addr] = latencyAvg
+		}
+		latencyAvg.Add(float64(roundTripLatency.Nanoseconds()))
 	}
 
 	if log.V(2) {
@@ -149,12 +176,11 @@ func (r *RemoteClockMonitor) VerifyClockOffset(ctx context.Context) error {
 		if err != nil && err != stats.EmptyInput {
 			return err
 		}
-		r.metrics.ClockOffsetMeanNanos.Update(int64(mean))
-
 		stdDev, err := offsets.StandardDeviation()
 		if err != nil && err != stats.EmptyInput {
 			return err
 		}
+		r.metrics.ClockOffsetMeanNanos.Update(int64(mean))
 		r.metrics.ClockOffsetStdDevNanos.Update(int64(stdDev))
 
 		if numClocks > 0 && healthyOffsetCount <= numClocks/2 {

--- a/pkg/rpc/clock_offset_test.go
+++ b/pkg/rpc/clock_offset_test.go
@@ -17,6 +17,7 @@
 package rpc
 
 import (
+	"fmt"
 	"math"
 	"strconv"
 	"testing"
@@ -41,6 +42,7 @@ func TestUpdateOffset(t *testing.T) {
 	monitor := newRemoteClockMonitor(clock, time.Hour)
 
 	const key = "addr"
+	const latency = 10 * time.Millisecond
 
 	// Case 1: There is no prior offset for the address.
 	offset1 := RemoteOffset{
@@ -48,7 +50,7 @@ func TestUpdateOffset(t *testing.T) {
 		Uncertainty: 20,
 		MeasuredAt:  monitor.clock.PhysicalTime().Add(-(monitor.offsetTTL + 1)).UnixNano(),
 	}
-	monitor.UpdateOffset(context.TODO(), key, offset1)
+	monitor.UpdateOffset(context.TODO(), key, offset1, latency)
 	monitor.mu.Lock()
 	if o, ok := monitor.mu.offsets[key]; !ok {
 		t.Errorf("expected key %s to be set in %v, but it was not", key, monitor.mu.offsets)
@@ -63,7 +65,7 @@ func TestUpdateOffset(t *testing.T) {
 		Uncertainty: 20,
 		MeasuredAt:  monitor.clock.PhysicalTime().Add(-(monitor.offsetTTL + 1)).UnixNano(),
 	}
-	monitor.UpdateOffset(context.TODO(), key, offset2)
+	monitor.UpdateOffset(context.TODO(), key, offset2, latency)
 	monitor.mu.Lock()
 	if o, ok := monitor.mu.offsets[key]; !ok {
 		t.Errorf("expected key %s to be set in %v, but it was not", key, monitor.mu.offsets)
@@ -78,7 +80,7 @@ func TestUpdateOffset(t *testing.T) {
 		Uncertainty: 10,
 		MeasuredAt:  offset2.MeasuredAt + 1,
 	}
-	monitor.UpdateOffset(context.TODO(), key, offset3)
+	monitor.UpdateOffset(context.TODO(), key, offset3, latency)
 	monitor.mu.Lock()
 	if o, ok := monitor.mu.offsets[key]; !ok {
 		t.Errorf("expected key %s to be set in %v, but it was not", key, monitor.mu.offsets)
@@ -88,7 +90,7 @@ func TestUpdateOffset(t *testing.T) {
 	monitor.mu.Unlock()
 
 	// Larger error and offset3 is not stale, so no update.
-	monitor.UpdateOffset(context.TODO(), key, offset2)
+	monitor.UpdateOffset(context.TODO(), key, offset2, latency)
 	monitor.mu.Lock()
 	if o, ok := monitor.mu.offsets[key]; !ok {
 		t.Errorf("expected key %s to be set in %v, but it was not", key, monitor.mu.offsets)
@@ -185,5 +187,52 @@ func TestClockOffsetMetrics(t *testing.T) {
 	}
 	if a, e := monitor.Metrics().ClockOffsetStdDevNanos.Value(), int64(7); a != e {
 		t.Errorf("stdDev %d != expected %d", a, e)
+	}
+}
+
+// TestLatencies tests the tracking of round-trip latency between nodes.
+func TestLatencies(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	clock := hlc.NewClock(hlc.NewManualClock(123).UnixNano, time.Nanosecond)
+	monitor := newRemoteClockMonitor(clock, time.Hour)
+
+	// All test cases have to have at least 11 measurement values in order for
+	// the exponentially-weighted moving average to work properly. See the
+	// comment on the WARMUP_SAMPLES const in the ewma package for details.
+	const emptyKey = "no measurements"
+	for i := 0; i < 11; i++ {
+		monitor.UpdateOffset(context.Background(), emptyKey, RemoteOffset{}, 0)
+	}
+	if l, ok := monitor.mu.latenciesNanos[emptyKey]; ok {
+		t.Errorf("expected no latency measurement for %q, got %v", emptyKey, l.Value())
+	}
+
+	testCases := []struct {
+		measurements []time.Duration
+		expectedAvg  time.Duration
+	}{
+		{[]time.Duration{10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10}, 10},
+		{[]time.Duration{10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 0}, 10},
+		{[]time.Duration{0, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10}, 10},
+		{[]time.Duration{10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 99}, 18},
+		{[]time.Duration{99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 10}, 90},
+		{[]time.Duration{10, 10, 10, 10, 10, 10, 99, 99, 99, 99, 99}, 50},
+		{[]time.Duration{99, 99, 99, 99, 99, 99, 10, 10, 10, 10, 10}, 58},
+		{[]time.Duration{10, 10, 10, 10, 10, 99, 99, 99, 99, 99, 99}, 58},
+		{[]time.Duration{99, 99, 99, 99, 99, 10, 10, 10, 10, 10, 10}, 50},
+	}
+	for _, tc := range testCases {
+		key := fmt.Sprintf("%v", tc.measurements)
+		for _, measurement := range tc.measurements {
+			monitor.UpdateOffset(context.Background(), key, RemoteOffset{}, measurement)
+		}
+		monitor.mu.Lock()
+		if l, ok := monitor.mu.latenciesNanos[key]; !ok {
+			t.Errorf("%q: missing latency measurement", key)
+		} else if val := time.Duration(int64(l.Value())); val != tc.expectedAvg {
+			t.Errorf("%q: expected latency %d, got %d", key, tc.expectedAvg, val)
+		}
+		monitor.mu.Unlock()
 	}
 }

--- a/pkg/rpc/clock_offset_test.go
+++ b/pkg/rpc/clock_offset_test.go
@@ -39,7 +39,7 @@ func TestUpdateOffset(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	clock := hlc.NewClock(hlc.NewManualClock(123).UnixNano, time.Nanosecond)
-	monitor := newRemoteClockMonitor(clock, time.Hour)
+	monitor := newRemoteClockMonitor(clock, time.Hour, 0)
 
 	const key = "addr"
 	const latency = 10 * time.Millisecond
@@ -104,7 +104,7 @@ func TestVerifyClockOffset(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	clock := hlc.NewClock(hlc.NewManualClock(123).UnixNano, 50*time.Nanosecond)
-	monitor := newRemoteClockMonitor(clock, time.Hour)
+	monitor := newRemoteClockMonitor(clock, time.Hour, 0)
 
 	for idx, tc := range []struct {
 		offsets       []RemoteOffset
@@ -169,7 +169,7 @@ func TestClockOffsetMetrics(t *testing.T) {
 	defer stopper.Stop()
 
 	clock := hlc.NewClock(hlc.NewManualClock(123).UnixNano, 20*time.Nanosecond)
-	monitor := newRemoteClockMonitor(clock, time.Hour)
+	monitor := newRemoteClockMonitor(clock, time.Hour, 0)
 	monitor.mu.offsets = map[string]RemoteOffset{
 		"0": {
 			Offset:      13,
@@ -195,7 +195,7 @@ func TestLatencies(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	clock := hlc.NewClock(hlc.NewManualClock(123).UnixNano, time.Nanosecond)
-	monitor := newRemoteClockMonitor(clock, time.Hour)
+	monitor := newRemoteClockMonitor(clock, time.Hour, 0)
 
 	// All test cases have to have at least 11 measurement values in order for
 	// the exponentially-weighted moving average to work properly. See the

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -303,7 +303,8 @@ func (ctx *Context) runHeartbeat(cc *grpc.ClientConn, remoteAddr string) error {
 
 			// Only update the clock offset measurement if we actually got a
 			// successful response from the server.
-			if pingDuration := receiveTime.Sub(sendTime); pingDuration > maximumPingDurationMult*ctx.localClock.MaxOffset() {
+			pingDuration := receiveTime.Sub(sendTime)
+			if pingDuration > maximumPingDurationMult*ctx.localClock.MaxOffset() {
 				request.Offset.Reset()
 			} else {
 				// Offset and error are measured using the remote clock reading
@@ -316,7 +317,7 @@ func (ctx *Context) runHeartbeat(cc *grpc.ClientConn, remoteAddr string) error {
 				remoteTimeNow := time.Unix(0, response.ServerTime).Add(pingDuration / 2)
 				request.Offset.Offset = remoteTimeNow.Sub(receiveTime).Nanoseconds()
 			}
-			ctx.RemoteClocks.UpdateOffset(ctx.masterCtx, remoteAddr, request.Offset)
+			ctx.RemoteClocks.UpdateOffset(ctx.masterCtx, remoteAddr, request.Offset, pingDuration)
 
 			if cb := ctx.HeartbeatCB; cb != nil {
 				cb()

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -127,7 +127,8 @@ func NewContext(
 	var cancel context.CancelFunc
 	ctx.masterCtx, cancel = context.WithCancel(ambient.AnnotateCtx(context.Background()))
 	ctx.Stopper = stopper
-	ctx.RemoteClocks = newRemoteClockMonitor(ctx.localClock, 10*defaultHeartbeatInterval)
+	ctx.RemoteClocks = newRemoteClockMonitor(
+		ctx.localClock, 10*defaultHeartbeatInterval, baseCtx.HistogramWindowInterval)
 	ctx.HeartbeatInterval = defaultHeartbeatInterval
 	ctx.HeartbeatTimeout = 2 * defaultHeartbeatInterval
 	ctx.conns.cache = make(map[string]*connMeta)

--- a/pkg/rpc/heartbeat.go
+++ b/pkg/rpc/heartbeat.go
@@ -73,7 +73,7 @@ func (hs *HeartbeatService) Ping(ctx context.Context, args *PingRequest) (*PingR
 	serverOffset := args.Offset
 	// The server offset should be the opposite of the client offset.
 	serverOffset.Offset = -serverOffset.Offset
-	hs.remoteClockMonitor.UpdateOffset(ctx, args.Addr, serverOffset)
+	hs.remoteClockMonitor.UpdateOffset(ctx, args.Addr, serverOffset, 0 /* roundTripLatency */)
 	return &PingResponse{
 		Pong:       args.Ping,
 		ServerTime: hs.clock.PhysicalNow(),

--- a/pkg/rpc/heartbeat_test.go
+++ b/pkg/rpc/heartbeat_test.go
@@ -47,7 +47,7 @@ func TestHeartbeatReply(t *testing.T) {
 	clock := hlc.NewClock(manual.UnixNano, time.Nanosecond)
 	heartbeat := &HeartbeatService{
 		clock:              clock,
-		remoteClockMonitor: newRemoteClockMonitor(clock, time.Hour),
+		remoteClockMonitor: newRemoteClockMonitor(clock, time.Hour, 0),
 	}
 
 	request := &PingRequest{
@@ -73,12 +73,12 @@ func TestManualHeartbeat(t *testing.T) {
 	clock := hlc.NewClock(manual.UnixNano, time.Nanosecond)
 	manualHeartbeat := &ManualHeartbeatService{
 		clock:              clock,
-		remoteClockMonitor: newRemoteClockMonitor(clock, time.Hour),
+		remoteClockMonitor: newRemoteClockMonitor(clock, time.Hour, 0),
 		ready:              make(chan struct{}, 1),
 	}
 	regularHeartbeat := &HeartbeatService{
 		clock:              clock,
-		remoteClockMonitor: newRemoteClockMonitor(clock, time.Hour),
+		remoteClockMonitor: newRemoteClockMonitor(clock, time.Hour, 0),
 	}
 
 	request := &PingRequest{
@@ -120,7 +120,7 @@ func TestClockOffsetMismatch(t *testing.T) {
 	clock := hlc.NewClock(hlc.UnixNano, 250*time.Millisecond)
 	hs := &HeartbeatService{
 		clock:              clock,
-		remoteClockMonitor: newRemoteClockMonitor(clock, time.Hour),
+		remoteClockMonitor: newRemoteClockMonitor(clock, time.Hour, 0),
 	}
 
 	request := &PingRequest{

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -496,6 +496,10 @@ func (cfg *Config) InitNode() error {
 	// Initialize attributes.
 	cfg.NodeAttributes = parseAttributes(cfg.Attrs)
 
+	// Expose HistogramWindowInterval to parts of the code that can't import the
+	// server package. This code should be cleaned up within a month or two.
+	cfg.Config.HistogramWindowInterval = cfg.HistogramWindowInterval()
+
 	// Get the gossip bootstrap resolvers.
 	resolvers, err := cfg.parseGossipBootstrapResolvers()
 	if err != nil {


### PR DESCRIPTION
Will be used to inform locality-based leaseholder placement, as
described in docs/RFCs/leaseholder_locality.md

@tamird @petermattis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13533)
<!-- Reviewable:end -->
