### PR TITLE
allocsim: Allow for injecting arbitrary inter-node latencies

### DIFF
--- a/pkg/cmd/allocsim/configs/node-per-locality.json
+++ b/pkg/cmd/allocsim/configs/node-per-locality.json
@@ -1,0 +1,46 @@
+{
+  "Localities": [
+    {
+      "Name": "1",
+      "NumNodes": 1,
+      "OutgoingLatencies": [
+        {
+          "Name": "2",
+          "Latency": "50ms"
+        },
+        {
+          "Name": "3",
+          "Latency": "50ms"
+        }
+      ]
+    },
+    {
+      "Name": "2",
+      "NumNodes": 1,
+      "OutgoingLatencies": [
+        {
+          "Name": "1",
+          "Latency": "50ms"
+        },
+        {
+          "Name": "3",
+          "Latency": "50ms"
+        }
+      ]
+    },
+    {
+      "Name": "3",
+      "NumNodes": 1,
+      "OutgoingLatencies": [
+        {
+          "Name": "1",
+          "Latency": "50ms"
+        },
+        {
+          "Name": "2",
+          "Latency": "50ms"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cmd/allocsim/main.go
+++ b/pkg/cmd/allocsim/main.go
@@ -25,6 +25,7 @@ import (
 	"math/rand"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -32,12 +33,15 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/cli"
 	"github.com/cockroachdb/cockroach/pkg/cmd/internal/localcluster"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/pkg/errors"
 )
 
 var workers = flag.Int("w", 1, "number of workers; the i'th worker talks to node i%numNodes")
@@ -50,13 +54,12 @@ func newRand() *rand.Rand {
 	return rand.New(rand.NewSource(timeutil.Now().UnixNano()))
 }
 
-// allocSim is allows investigation of allocation/rebalancing heuristics. A
+// allocSim allows investigation of allocation/rebalancing heuristics. A
 // pool of workers generates block_writer-style load where the i'th worker
 // talks to node i%numNodes. Every second a monitor goroutine outputs status
 // such as the per-node replica and leaseholder counts.
 //
-// TODO(peter): Allow configuration zone-config constraints.
-
+// TODO(peter/a-robinson): Allow configuration of zone-config constraints.
 type allocSim struct {
 	*localcluster.Cluster
 	stats struct {
@@ -277,7 +280,56 @@ func (a *allocSim) finalStatus() {
 	genStats("leases", a.ranges.leases)
 }
 
+func handleStart() bool {
+	if len(os.Args) < 2 || os.Args[1] != "start" {
+		return false
+	}
+
+	// Do our own hacky flag parsing here to get around the fact that the default
+	// flag package complains about any unknown flags while still allowing the
+	// pflags package used by cli.Start to manage the rest of the flags as usual.
+	var latenciesStr string
+	for i, arg := range os.Args {
+		if strings.HasPrefix(arg, "--latencies=") || strings.HasPrefix(arg, "-latencies=") {
+			latenciesStr = strings.SplitAfterN(arg, "=", 2)[1]
+			os.Args = append(os.Args[:i], os.Args[i+1:]...)
+			break
+		}
+	}
+	if latenciesStr != "" {
+		if err := configureArtificialLatencies(latenciesStr); err != nil {
+			log.Fatal(context.Background(), err)
+		}
+	}
+
+	cli.Main()
+	return true
+}
+
+func configureArtificialLatencies(latenciesConfig string) error {
+	delays := make(map[string]time.Duration)
+	for _, latency := range strings.Split(latenciesConfig, ",") {
+		parts := strings.Split(latency, "=")
+		if len(parts) != 2 {
+			return errors.Errorf("unexpected latency config format %q", latency)
+		}
+		addr := parts[0]
+		delay, err := time.ParseDuration(parts[1])
+		if err != nil {
+			return errors.Wrapf(err, "unable to parse %q as a duration", parts[1])
+		}
+		delays[addr] = delay
+		log.Infof(context.Background(), "adding delay %s to address %q", delay, addr)
+	}
+	rpc.ArtificialLatencies = delays
+	return nil
+}
+
 func main() {
+	if handleStart() {
+		return
+	}
+
 	flag.Parse()
 
 	c := localcluster.New(*numNodes)
@@ -308,6 +360,23 @@ func main() {
 			perNodeArgs[i] = []string{fmt.Sprintf("--locality=%s", locality)}
 			a.localities[i] = locality
 		}
+
+		// TODO(a-robinson): Enable actual configuration of this and make it work for
+		// different numbers of nodes.
+		if len(c.Nodes) != 4 {
+			log.Fatal(context.Background(), "localities/latencies are currently only supported for 4 nodes")
+		}
+		if *numLocalities != 2 {
+			log.Fatal(context.Background(), "localities/latencies are currently only supported for 4 nodes and 2 localities")
+		}
+		perNodeArgs[0] = append(perNodeArgs[0],
+			fmt.Sprintf("--latencies=%s=%s,%s=%s,%s=%s", localcluster.RPCAddr(1), 50*time.Millisecond, localcluster.RPCAddr(2), 0*time.Millisecond, localcluster.RPCAddr(3), 50*time.Millisecond))
+		perNodeArgs[1] = append(perNodeArgs[1],
+			fmt.Sprintf("--latencies=%s=%s,%s=%s,%s=%s", localcluster.RPCAddr(0), 50*time.Millisecond, localcluster.RPCAddr(2), 50*time.Millisecond, localcluster.RPCAddr(3), 0*time.Millisecond))
+		perNodeArgs[2] = append(perNodeArgs[2],
+			fmt.Sprintf("--latencies=%s=%s,%s=%s,%s=%s", localcluster.RPCAddr(0), 0*time.Millisecond, localcluster.RPCAddr(1), 50*time.Millisecond, localcluster.RPCAddr(3), 50*time.Millisecond))
+		perNodeArgs[3] = append(perNodeArgs[3],
+			fmt.Sprintf("--latencies=%s=%s,%s=%s,%s=%s", localcluster.RPCAddr(0), 50*time.Millisecond, localcluster.RPCAddr(1), 0*time.Millisecond, localcluster.RPCAddr(2), 50*time.Millisecond))
 	}
 
 	go func() {
@@ -324,7 +393,7 @@ func main() {
 		os.Exit(exitStatus)
 	}()
 
-	c.Start("allocsim", *workers, nil, flag.Args(), perNodeArgs)
+	c.Start("allocsim", *workers, os.Args[0], nil, flag.Args(), perNodeArgs)
 	c.UpdateZoneConfig(1, 1<<20)
 	a.run(*workers)
 }

--- a/pkg/cmd/internal/localcluster/localcluster.go
+++ b/pkg/cmd/internal/localcluster/localcluster.go
@@ -54,12 +54,15 @@ import (
 const basePort = 26257
 const dataDir = "cockroach-data"
 
-var cockroachBin = func() string {
+// CockroachBin is the path to the cockroach binary.
+var CockroachBin = func() string {
 	bin := "./cockroach"
-	if _, err := os.Stat(bin); err == nil {
-		return bin
+	if _, err := os.Stat(bin); os.IsNotExist(err) {
+		bin = "cockroach"
+	} else if err != nil {
+		panic(err)
 	}
-	return "cockroach"
+	return bin
 }()
 
 // IsUnavailableError returns true iff the error corresponds to a GRPC
@@ -97,7 +100,7 @@ func New(size int) *Cluster {
 // can be used to pass extra arguments to an individual node. If not nil, its
 // size must equal the number of nodes.
 func (c *Cluster) Start(
-	db string, numWorkers int, env, allNodeArgs []string, perNodeArgs map[int][]string,
+	db string, numWorkers int, binary string, env, allNodeArgs []string, perNodeArgs map[int][]string,
 ) {
 	c.started = timeutil.Now()
 
@@ -114,7 +117,7 @@ func (c *Cluster) Start(
 	}
 
 	for i := range c.Nodes {
-		c.Nodes[i] = c.makeNode(i, append(append([]string(nil), allNodeArgs...), perNodeArgs[i]...), env)
+		c.Nodes[i] = c.makeNode(i, binary, append(append([]string(nil), allNodeArgs...), perNodeArgs[i]...), env)
 		c.Clients[i] = c.makeClient(i)
 		c.Status[i] = c.makeStatus(i)
 		c.DB[i] = c.makeDB(i, numWorkers, db)
@@ -133,21 +136,21 @@ func (c *Cluster) Close() {
 }
 
 // RPCPort returns the RPC port of the specified node.
-func (c *Cluster) RPCPort(nodeIdx int) int {
+func RPCPort(nodeIdx int) int {
 	return basePort + nodeIdx*2
 }
 
 // RPCAddr returns the RPC address of the specified node.
-func (c *Cluster) RPCAddr(nodeIdx int) string {
-	return fmt.Sprintf("localhost:%d", c.RPCPort(nodeIdx))
+func RPCAddr(nodeIdx int) string {
+	return fmt.Sprintf("localhost:%d", RPCPort(nodeIdx))
 }
 
 // HTTPPort returns the HTTP port of the specified node.
-func (c *Cluster) HTTPPort(nodeIdx int) int {
-	return c.RPCPort(nodeIdx) + 1
+func HTTPPort(nodeIdx int) int {
+	return RPCPort(nodeIdx) + 1
 }
 
-func (c *Cluster) makeNode(nodeIdx int, extraArgs, extraEnv []string) *Node {
+func (c *Cluster) makeNode(nodeIdx int, binary string, extraArgs, extraEnv []string) *Node {
 	name := fmt.Sprintf("%d", nodeIdx+1)
 	dir := filepath.Join(dataDir, name)
 	logDir := filepath.Join(dir, "logs")
@@ -156,17 +159,18 @@ func (c *Cluster) makeNode(nodeIdx int, extraArgs, extraEnv []string) *Node {
 	}
 
 	args := []string{
-		cockroachBin,
+		binary,
 		"start",
 		"--insecure",
-		fmt.Sprintf("--port=%d", c.RPCPort(nodeIdx)),
-		fmt.Sprintf("--http-port=%d", c.HTTPPort(nodeIdx)),
+		"--host=localhost",
+		fmt.Sprintf("--port=%d", RPCPort(nodeIdx)),
+		fmt.Sprintf("--http-port=%d", HTTPPort(nodeIdx)),
 		fmt.Sprintf("--store=%s", dir),
 		fmt.Sprintf("--cache=256MiB"),
 		fmt.Sprintf("--logtostderr"),
 	}
 	if nodeIdx > 0 {
-		args = append(args, fmt.Sprintf("--join=localhost:%d", c.RPCPort(0)))
+		args = append(args, fmt.Sprintf("--join=localhost:%d", RPCPort(0)))
 	}
 	args = append(args, extraArgs...)
 
@@ -180,7 +184,7 @@ func (c *Cluster) makeNode(nodeIdx int, extraArgs, extraEnv []string) *Node {
 }
 
 func (c *Cluster) makeClient(nodeIdx int) *client.DB {
-	conn, err := c.rpcCtx.GRPCDial(c.RPCAddr(nodeIdx))
+	conn, err := c.rpcCtx.GRPCDial(RPCAddr(nodeIdx))
 	if err != nil {
 		log.Fatalf(context.Background(), "failed to initialize KV client: %s", err)
 	}
@@ -188,7 +192,7 @@ func (c *Cluster) makeClient(nodeIdx int) *client.DB {
 }
 
 func (c *Cluster) makeStatus(nodeIdx int) serverpb.StatusClient {
-	conn, err := c.rpcCtx.GRPCDial(c.RPCAddr(nodeIdx))
+	conn, err := c.rpcCtx.GRPCDial(RPCAddr(nodeIdx))
 	if err != nil {
 		log.Fatalf(context.Background(), "failed to initialize status client: %s", err)
 	}
@@ -197,7 +201,7 @@ func (c *Cluster) makeStatus(nodeIdx int) serverpb.StatusClient {
 
 func (c *Cluster) makeDB(nodeIdx, numWorkers int, dbName string) *gosql.DB {
 	url := fmt.Sprintf("postgresql://root@localhost:%d/%s?sslmode=disable",
-		c.RPCPort(nodeIdx), dbName)
+		RPCPort(nodeIdx), dbName)
 	conn, err := gosql.Open("postgres", url)
 	if err != nil {
 		log.Fatal(context.Background(), err)
@@ -324,7 +328,7 @@ func (c *Cluster) lookupRange(nodeIdx int, key roachpb.Key) (*roachpb.RangeDescr
 // Freeze freezes (or thaws) the cluster. The freeze request is sent to the
 // specified node.
 func (c *Cluster) Freeze(nodeIdx int, freeze bool) {
-	addr := c.RPCAddr(nodeIdx)
+	addr := RPCAddr(nodeIdx)
 	conn, err := c.rpcCtx.GRPCDial(addr)
 	if err != nil {
 		log.Fatalf(context.Background(), "unable to dial: %s: %v", addr, err)

--- a/pkg/cmd/zerosum/main.go
+++ b/pkg/cmd/zerosum/main.go
@@ -454,7 +454,7 @@ func main() {
 		os.Exit(1)
 	}()
 
-	c.Start("zerosum", *workers, nil, flag.Args(), nil)
+	c.Start("zerosum", *workers, localcluster.CockroachBin, nil, flag.Args(), nil)
 
 	z := newZeroSum(c, *numAccounts, *chaosType)
 	z.run(*workers, *monkeys)

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -53,6 +53,28 @@ const (
 	maximumPingDurationMult = 2
 )
 
+// ArtificialLatencies provides a way to inject fake latency into requests
+// to/from particular nodes. It should only ever be set by testing code, and
+// is not thread safe (so it must be initialized before the server starts).
+var ArtificialLatencies = make(map[string]time.Duration)
+
+type clientStreamWithDelay struct {
+	grpc.ClientStream
+	delay time.Duration
+}
+
+func (c *clientStreamWithDelay) RecvMsg(m interface{}) error {
+	timer := timeutil.NewTimer()
+	defer timer.Stop()
+	timer.Reset(c.delay)
+	select {
+	case <-timer.C:
+	case <-c.Context().Done():
+		return c.Context().Err()
+	}
+	return c.ClientStream.RecvMsg(m)
+}
+
 // NewServer is a thin wrapper around grpc.NewServer that registers a heartbeat
 // service.
 func NewServer(ctx *Context) *grpc.Server {
@@ -216,6 +238,48 @@ func (ctx *Context) GRPCDial(target string, opts ...grpc.DialOption) (*grpc.Clie
 		dialOpts = append(dialOpts, dialOpt)
 		dialOpts = append(dialOpts, grpc.WithBackoffMaxDelay(maxBackoff))
 		dialOpts = append(dialOpts, opts...)
+
+		if delay, ok := ArtificialLatencies[target]; ok {
+			dialOpts = append(dialOpts, grpc.WithUnaryInterceptor(
+				func(
+					ctx context.Context,
+					method string,
+					req, reply interface{},
+					cc *grpc.ClientConn,
+					invoker grpc.UnaryInvoker,
+					opts ...grpc.CallOption,
+				) error {
+					timer := timeutil.NewTimer()
+					defer timer.Stop()
+					timer.Reset(delay)
+					select {
+					case <-timer.C:
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+					return invoker(ctx, method, req, reply, cc, opts...)
+				},
+			))
+			dialOpts = append(dialOpts, grpc.WithStreamInterceptor(
+				func(
+					ctx context.Context,
+					desc *grpc.StreamDesc,
+					cc *grpc.ClientConn,
+					method string,
+					streamer grpc.Streamer,
+					opts ...grpc.CallOption,
+				) (grpc.ClientStream, error) {
+					s, err := streamer(ctx, desc, cc, method, opts...)
+					if err != nil {
+						return nil, err
+					}
+					return &clientStreamWithDelay{
+						ClientStream: s,
+						delay:        delay,
+					}, nil
+				},
+			))
+		}
 
 		if log.V(1) {
 			log.Infof(ctx.masterCtx, "dialing %s", target)


### PR DESCRIPTION
I've left this a bit rough rather than wasting time perfecting something we don't want to stick with. If it looks reasonable, I'll polish off the configurability a little bit.

I had quite the adventure in stupidity last night with `tc` before switching over to this approach. I got most everything working before realizing I'd have to put each process into its own network namespace and bridge them together to ensure a unique-but-stable source IP or port for `tc` to filter on for each node, which seemed like a little too much complexity even if it would be a more accurate simulation than this.

@petermattis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13534)
<!-- Reviewable:end -->
