### PR TITLE
sql: arrays in pg_type get nonzero typelem columns

### DIFF
--- a/pkg/sql/parser/aggregate_builtins.go
+++ b/pkg/sql/parser/aggregate_builtins.go
@@ -87,7 +87,7 @@ var Aggregates = map[string][]Builtin{
 				if len(args) == 0 {
 					return unknownReturnType
 				}
-				return tArray{args[0].ResolvedType()}
+				return TArray{args[0].ResolvedType()}
 			},
 			newArrayAggregate,
 			"Aggregates the selected values into an array.",

--- a/pkg/sql/parser/col_types.go
+++ b/pkg/sql/parser/col_types.go
@@ -462,7 +462,7 @@ func CastTargetToDatumType(t CastTargetType) Type {
 	case *CollatedStringColType:
 		return TCollatedString{Locale: ct.Locale}
 	case *ArrayColType:
-		return tArray{CastTargetToDatumType(ct.ParamType)}
+		return TArray{CastTargetToDatumType(ct.ParamType)}
 	case *VectorColType:
 		return TypeIntVector
 	case *OidColType:

--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -1815,7 +1815,7 @@ func MustBeDArray(e Expr) *DArray {
 
 // ResolvedType implements the TypedExpr interface.
 func (d *DArray) ResolvedType() Type {
-	return tArray{Typ: d.ParamTyp}
+	return TArray{Typ: d.ParamTyp}
 }
 
 // Compare implements the Datum interface.
@@ -1926,7 +1926,7 @@ func (d *DArray) Append(v Datum) error {
 		return errors.Errorf("cannot append %s to array containing %s", d.ParamTyp,
 			v.ResolvedType())
 	}
-	if _, ok := d.ParamTyp.(tArray); ok {
+	if _, ok := d.ParamTyp.(TArray); ok {
 		if v == DNull {
 			return errNonHomogeneousArray
 		}

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -2602,9 +2602,9 @@ func (t *Tuple) Eval(ctx *EvalContext) (Datum, error) {
 
 // arrayOfType returns a fresh DArray of the input type.
 func arrayOfType(typ Type) (*DArray, error) {
-	arrayTyp, ok := typ.(tArray)
+	arrayTyp, ok := typ.(TArray)
 	if !ok {
-		return nil, errors.Errorf("array node type (%v) is not tArray", typ)
+		return nil, errors.Errorf("array node type (%v) is not TArray", typ)
 	}
 	return NewDArray(arrayTyp.Typ), nil
 }

--- a/pkg/sql/parser/expr.go
+++ b/pkg/sql/parser/expr.go
@@ -399,7 +399,7 @@ func (node *ComparisonExpr) memoizeFn() {
 	case Any, Some, All:
 		// Array operators memoize the SubOperator's CmpOp.
 		fOp, _, _, _, _ = foldComparisonExpr(node.SubOperator, nil, nil)
-		rightRet = rightRet.(tArray).Typ
+		rightRet = rightRet.(TArray).Typ
 	}
 
 	fn, ok := CmpOps[fOp].lookupImpl(leftRet, rightRet)
@@ -433,7 +433,7 @@ func (node *ComparisonExpr) IsMixedTypeComparison() bool {
 		}
 		return false
 	case Any, Some, All:
-		array := node.TypedRight().ResolvedType().(tArray)
+		array := node.TypedRight().ResolvedType().(TArray)
 		return !sameTypeOrNull(node.TypedLeft().ResolvedType(), array.Typ)
 	default:
 		return !sameTypeOrNull(node.TypedLeft().ResolvedType(), node.TypedRight().ResolvedType())

--- a/pkg/sql/parser/generator_builtins.go
+++ b/pkg/sql/parser/generator_builtins.go
@@ -119,7 +119,7 @@ var generators = map[string][]Builtin{
 				if len(args) == 0 {
 					return unknownReturnType
 				}
-				return TTable{Cols: TTuple{args[0].ResolvedType().(tArray).Typ}}
+				return TTable{Cols: TTuple{args[0].ResolvedType().(TArray).Typ}}
 			},
 			makeArrayGenerator,
 			"Returns the input array as a set of rows",

--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -260,12 +260,12 @@ func (expr *IndirectionExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExp
 		}
 	}
 
-	subExpr, err := expr.Expr.TypeCheck(ctx, tArray{desired})
+	subExpr, err := expr.Expr.TypeCheck(ctx, TArray{desired})
 	if err != nil {
 		return nil, err
 	}
 	typ := subExpr.ResolvedType()
-	arrType, ok := typ.(tArray)
+	arrType, ok := typ.(TArray)
 	if !ok {
 		return nil, errors.Errorf("cannot subscript type %s because it is not an array", typ)
 	}
@@ -664,7 +664,7 @@ var errAmbiguousArrayType = errors.Errorf("cannot determine type of empty array.
 // TypeCheck implements the Expr interface.
 func (expr *Array) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, error) {
 	desiredParam := TypeAny
-	if arr, ok := desired.(tArray); ok {
+	if arr, ok := desired.(TArray); ok {
 		desiredParam = arr.Typ
 	}
 
@@ -672,7 +672,7 @@ func (expr *Array) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, error) 
 		if desiredParam == TypeAny {
 			return nil, errAmbiguousArrayType
 		}
-		expr.typ = tArray{desiredParam}
+		expr.typ = TArray{desiredParam}
 		return expr, nil
 	}
 
@@ -681,7 +681,7 @@ func (expr *Array) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, error) 
 		return nil, err
 	}
 
-	expr.typ = tArray{typ}
+	expr.typ = TArray{typ}
 	for i := range typedSubExprs {
 		expr.Exprs[i] = typedSubExprs[i]
 	}
@@ -691,7 +691,7 @@ func (expr *Array) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, error) 
 // TypeCheck implements the Expr interface.
 func (expr *ArrayFlatten) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, error) {
 	desiredParam := TypeAny
-	if arr, ok := desired.(tArray); ok {
+	if arr, ok := desired.(TArray); ok {
 		desiredParam = arr.Typ
 	}
 
@@ -852,7 +852,7 @@ func typeCheckComparisonOpWithSubOperator(
 		for i, typedExpr := range typedSubExprs[1:] {
 			array.Exprs[i] = typedExpr
 		}
-		array.typ = tArray{retType}
+		array.typ = TArray{retType}
 
 		rightParen := right
 		for {
@@ -881,7 +881,7 @@ func typeCheckComparisonOpWithSubOperator(
 		cmpTypeLeft = leftTyped.ResolvedType()
 
 		// We then type the right expression desiring an array of the left's type.
-		rightTyped, err = right.TypeCheck(ctx, tArray{cmpTypeLeft})
+		rightTyped, err = right.TypeCheck(ctx, TArray{cmpTypeLeft})
 		if err != nil {
 			return nil, nil, CmpOp{}, err
 		}
@@ -891,7 +891,7 @@ func typeCheckComparisonOpWithSubOperator(
 			return leftTyped, rightTyped, CmpOp{}, nil
 		}
 
-		rightArr, ok := rightReturn.(tArray)
+		rightArr, ok := rightReturn.(TArray)
 		if !ok {
 			return nil, nil, CmpOp{},
 				errors.Errorf(unsupportedCompErrFmtWithExprsAndSubOp, left, subOp, op, right,
@@ -903,7 +903,7 @@ func typeCheckComparisonOpWithSubOperator(
 	fn, ok := ops.lookupImpl(cmpTypeLeft, cmpTypeRight)
 	if !ok {
 		return nil, nil, CmpOp{}, fmt.Errorf(unsupportedCompErrFmtWithTypesAndSubOp,
-			cmpTypeLeft, subOp, op, tArray{cmpTypeRight})
+			cmpTypeLeft, subOp, op, TArray{cmpTypeRight})
 	}
 	return leftTyped, rightTyped, fn, nil
 }

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1439,8 +1439,10 @@ CREATE TABLE pg_catalog.pg_type (
 		for oid, typ := range parser.OidToType {
 			cat := typCategory(typ)
 			typInput := oidZero
+			typElem := oidZero
 			if cat == typCategoryArray {
 				typInput = arrayInProcOid
+				typElem = parser.NewDOid(parser.DInt(typ.(parser.TArray).Typ.Oid()))
 			}
 			typname := typ.String()
 			if n, ok := aliasedOidToName[oid]; ok {
@@ -1459,7 +1461,7 @@ CREATE TABLE pg_catalog.pg_type (
 				parser.MakeDBool(true),  // typisdefined
 				typDelim,                // typdelim
 				oidZero,                 // typrelid
-				oidZero,                 // typelem
+				typElem,                 // typelem
 				oidZero,                 // typarray
 
 				// regproc references

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -691,10 +691,10 @@ oid   typname      typcategory  typispreferred  typisdefined  typdelim  typrelid
 26    oid          N            false           true          ,         0         0        0
 700   float4       N            false           true          ,         0         0        0
 701   float8       N            false           true          ,         0         0        0
-1005  int2[]       A            false           true          ,         0         0        0
-1007  int4[]       A            false           true          ,         0         0        0
-1009  text[]       A            false           true          ,         0         0        0
-1016  int8[]       A            false           true          ,         0         0        0
+1005  int2[]       A            false           true          ,         0         21       0
+1007  int4[]       A            false           true          ,         0         23       0
+1009  text[]       A            false           true          ,         0         25       0
+1016  int8[]       A            false           true          ,         0         20       0
 1043  varchar      S            false           true          ,         0         0        0
 1082  date         D            false           true          ,         0         0        0
 1114  timestamp    D            false           true          ,         0         0        0


### PR DESCRIPTION
Arrays now have the `typelem` column of their entry in `pg_type` set to the oid of their element type. For instance, the `_int8` type (array of `int8`) has its `typelem` set to `int8`.

Resolves #13524.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13535)
<!-- Reviewable:end -->
