### PR TITLE
ui: fix font family names

### DIFF
--- a/pkg/ui/styl/components/summarybar.styl
+++ b/pkg/ui/styl/components/summarybar.styl
@@ -6,7 +6,7 @@
   padding 15px 24px 12px
   border-radius 5px
   border 1px solid rgba(0, 0, 0, .1)
-  font-family lato-regular
+  font-family Lato-Regular
 
 .summary-headline
   margin-bottom 12px
@@ -25,8 +25,7 @@
     color $light-blue
 
 .summary-label
-  font-family lato
-  font-weight bold
+  font-family Lato-Bold
   color $light-blue
   padding-bottom 12px
   text-align center

--- a/pkg/ui/styl/components/table.styl
+++ b/pkg/ui/styl/components/table.styl
@@ -27,7 +27,7 @@ $stats-table-tr--bg-alt = $secondary-gray-7
 
 // ---- Data table ----
 .sort-table
-  font-family lato
+  font-family Lato-Regular
   border-collapse collapse
   border $stats-table-cell--border
   width 100%
@@ -73,7 +73,7 @@ $stats-table-tr--bg-alt = $secondary-gray-7
           color $light-blue
           &:after
             content "▲"
-          
+
 
   &__cell
     vertical-align top

--- a/pkg/ui/styl/components/visualizations.styl
+++ b/pkg/ui/styl/components/visualizations.styl
@@ -44,8 +44,7 @@ $viz-sides = 62px
 
   &__title
     font-size 14px
-    font-family lato
-    font-weight bold
+    font-family Lato-Bold
     color $light-blue
     display inline
 
@@ -53,7 +52,7 @@ $viz-sides = 62px
     color $light-gray
     margin-left 5px
     font-size 12px
-    font-family lato
+    font-family Lato-Regular
     display inline
 
   &__spinner

--- a/pkg/ui/styl/layout/layout.styl
+++ b/pkg/ui/styl/layout/layout.styl
@@ -127,7 +127,7 @@ $subnav-background  = $secondary-gray-4
 .parent-link a
   color $glow-blue
   font-size 13px
-  font-family lato
+  font-family Lato-Regular
   text-transform uppercase
   text-decoration none
   letter-spacing 2px
@@ -228,7 +228,7 @@ span.icon
       font-family Lato-Bold
 
 a.toggle
-  font Lato-Bold
+  font-family Lato-Bold
   font-size 1rem
   color $secondary-light-gray
 
@@ -452,4 +452,3 @@ div.raft-filters
 
 .table-stats
   margin-bottom 50px
-

--- a/pkg/ui/styl/shame.styl
+++ b/pkg/ui/styl/shame.styl
@@ -41,7 +41,7 @@
   border none !important
   box-shadow 0 2px 4px rgba(0, 0, 0, .2) !important
   max-height 200px !important
-  font-family Lato
+  font-family Lato-Regular
   font-size 14px
   text-transform none
   letter-spacing 0
@@ -69,7 +69,7 @@
 
 // NVD3 Style overrides.
 .nvtooltip
-  font-family lato !important
+  font-family Lato-Regular !important
   color $light-blue !important
   padding 15px 20px !important
   background rgba(255, 255, 255, .98) !important
@@ -106,12 +106,12 @@
 
   text
     fill $dark-blue
-    font-family lato
+    font-family Lato-Regular
     font-size 11px
 
   .nv-axislabel
     text-transform lowercase
-    font-family lato
+    font-family Lato-Regular
     fill $lighter-blue
 
 .nv-y .nv-axis .domain


### PR DESCRIPTION
This pull request properly resolves #8669 which was closed without appearing to be fixed. I've changed the `Lato` font names to their appropriate `Lato-` font name. I've also changed the capitalisation of some font names such that they are consistent.

I've ran `make` in `pkg/ui` to rebuild `embedded.go` to reflect these changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13539)
<!-- Reviewable:end -->
