### PR TITLE
sql: always generate span in selectIndex

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1026,11 +1026,13 @@ func Example_sql_table() {
 	// |     1 | render |       |    -> render       |
 	// |     2 | scan   |       |       -> scan      |
 	// |     2 |        | table |          t@primary |
+	// |     2 |        | spans |          ALL       |
 	// |     1 | render |       |    -> render       |
 	// |     2 | scan   |       |       -> scan      |
 	// |     2 |        | table |          t@primary |
+	// |     2 |        | spans |          ALL       |
 	// +-------+--------+-------+--------------------+
-	// (7 rows)
+	// (9 rows)
 }
 
 func Example_user() {

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -688,7 +688,6 @@ func (sc *SchemaChanger) backfillIndexesChunk(
 		}
 		scan := planner.Scan()
 		scan.desc = *tableDesc
-		scan.spans = []roachpb.Span{sp}
 		scan.initDescDefaults(publicAndNonPublicColumns)
 
 		// We manually invoke selectIndex() because for now expandPlan()
@@ -697,6 +696,8 @@ func (sc *SchemaChanger) backfillIndexesChunk(
 		if err != nil {
 			return err
 		}
+
+		scan.spans = []roachpb.Span{sp}
 
 		rows = &limitNode{p: planner, plan: rows, countExpr: parser.NewDInt(parser.DInt(chunkSize))}
 

--- a/pkg/sql/distsqlrun/server_test.go
+++ b/pkg/sql/distsqlrun/server_test.go
@@ -52,7 +52,7 @@ func TestServer(t *testing.T) {
 		Table:    *td,
 		IndexIdx: 0,
 		Reverse:  false,
-		Spans:    nil,
+		Spans:    []TableReaderSpan{{Span: td.PrimaryIndexSpan()}},
 	}
 	post := PostProcessSpec{
 		Filter:        Expression{Expr: "@1 != 2"}, // a != 2

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -75,7 +75,9 @@ func TestTableReader(t *testing.T) {
 		expected string
 	}{
 		{
-			spec: TableReaderSpec{},
+			spec: TableReaderSpec{
+				Spans: []TableReaderSpan{{Span: td.PrimaryIndexSpan()}},
+			},
 			post: PostProcessSpec{
 				Filter:        Expression{Expr: "@3 < 5 AND @2 != 3"}, // sum < 5 && b != 3
 				OutputColumns: []uint32{0, 1},
@@ -83,7 +85,9 @@ func TestTableReader(t *testing.T) {
 			expected: "[[0 1] [0 2] [0 4] [1 0] [1 1] [1 2] [2 0] [2 1] [2 2] [3 0] [3 1] [4 0]]",
 		},
 		{
-			spec: TableReaderSpec{},
+			spec: TableReaderSpec{
+				Spans: []TableReaderSpan{{Span: td.PrimaryIndexSpan()}},
+			},
 			post: PostProcessSpec{
 				Filter:        Expression{Expr: "@3 < 5 AND @2 != 3"},
 				OutputColumns: []uint32{3}, // s

--- a/pkg/sql/index_selection.go
+++ b/pkg/sql/index_selection.go
@@ -81,9 +81,16 @@ type analyzeOrderingFn func(indexOrdering orderingInfo) (matchingCols, totalCols
 func (p *planner) selectIndex(
 	s *scanNode, analyzeOrdering analyzeOrderingFn, preferOrderMatching bool,
 ) (planNode, error) {
-	if s.desc.IsEmpty() || (s.filter == nil && analyzeOrdering == nil && s.specifiedIndex == nil) {
-		// No table or no where-clause, no ordering, and no specified index.
+	if s.desc.IsEmpty() {
+		// No table.
 		s.initOrdering(0)
+		return s, nil
+	}
+
+	if s.filter == nil && analyzeOrdering == nil && s.specifiedIndex == nil {
+		// No where-clause, no ordering, and no specified index.
+		s.initOrdering(0)
+		s.spans = makeSpans(nil, &s.desc, s.index)
 		return s, nil
 	}
 

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -164,10 +164,7 @@ func (rf *RowFetcher) StartScan(
 	txn *client.Txn, spans roachpb.Spans, limitBatches bool, limitHint int64,
 ) error {
 	if len(spans) == 0 {
-		// If no spans were specified retrieve all of the keys that start with our
-		// index key prefix.
-		start := roachpb.Key(MakeIndexKeyPrefix(rf.desc, rf.index.ID))
-		spans = []roachpb.Span{{Key: start, EndKey: start.PrefixEnd()}}
+		panic("no spans")
 	}
 
 	rf.indexKey = nil

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/pkg/errors"
@@ -1790,4 +1791,17 @@ func (desc *TableDescriptor) InvalidateFKConstraints() {
 			desc.Indexes[i].ForeignKey.Validity = ConstraintValidity_Unvalidated
 		}
 	}
+}
+
+// PrimaryIndexSpan returns the Span that corresponds to the entire primary
+// index; can be used for a full table scan.
+func (desc *TableDescriptor) PrimaryIndexSpan() roachpb.Span {
+	return desc.IndexSpan(desc.PrimaryIndex.ID)
+}
+
+// IndexSpan returns the Span that corresponds to an entire index; can be used
+// for a full index scan.
+func (desc *TableDescriptor) IndexSpan(indexID IndexID) roachpb.Span {
+	prefix := roachpb.Key(MakeIndexKeyPrefix(desc, indexID))
+	return roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()}
 }

--- a/pkg/sql/testdata/aggregate
+++ b/pkg/sql/testdata/aggregate
@@ -499,6 +499,7 @@ EXPLAIN(EXPRS) SELECT COUNT(k) FROM kv
 1                 render 0     k
 2  scan
 2                 table        kv@primary
+2                 spans        ALL
 
 statement ok
 CREATE TABLE abc (
@@ -956,6 +957,7 @@ EXPLAIN(EXPRS) SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
 2                 render 2     v
 3  scan
 3                 table        kv@primary
+3                 spans        ALL
 
 query ITTT
 EXPLAIN(EXPRS) SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
@@ -973,6 +975,7 @@ EXPLAIN(EXPRS) SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
 2                 render 2     v
 3  scan
 3                 table        kv@primary
+3                 spans        ALL
 
 query ITTT
 EXPLAIN(EXPRS) SELECT v, COUNT(1) FROM kv GROUP BY v ORDER BY COUNT(1)
@@ -990,6 +993,7 @@ EXPLAIN(EXPRS) SELECT v, COUNT(1) FROM kv GROUP BY v ORDER BY COUNT(1)
 2                 render 2     v
 3  scan
 3                 table        kv@primary
+3                 spans        ALL
 
 
 # Verify that FILTER works.
@@ -1052,6 +1056,7 @@ EXPLAIN (exprs) SELECT COUNT(*) FILTER (WHERE k>5), MAX(k>5) FILTER(WHERE k>5) F
 1                 render 2     v
 2  scan
 2                 table        filter_test@primary
+2                 spans        ALL
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT COUNT(*) FILTER (WHERE k > 5) FROM filter_test GROUP BY v
@@ -1065,3 +1070,4 @@ EXPLAIN (TYPES) SELECT COUNT(*) FILTER (WHERE k > 5) FROM filter_test GROUP BY v
 1                 render 2     ((k)[int] > (5)[int])[bool]
 2  scan                                                                                           (k int, v int, mark[omitted] bool, rowid[hidden,omitted] int)  +rowid,unique
 2                 table        filter_test@primary
+2                 spans        ALL

--- a/pkg/sql/testdata/delete
+++ b/pkg/sql/testdata/delete
@@ -140,6 +140,7 @@ Level  Type    Field  Description
 1      render
 2      scan
 2              table  unindexed@primary
+2              spans  ALL
 
 query II colnames
 SELECT k, v FROM unindexed

--- a/pkg/sql/testdata/distinct
+++ b/pkg/sql/testdata/distinct
@@ -37,6 +37,7 @@ EXPLAIN SELECT DISTINCT y, z FROM xyz
 1  render
 2  scan
 2            table  xyz@primary
+2            spans  ALL
 
 query II
 SELECT DISTINCT y, z FROM xyz ORDER BY z
@@ -116,6 +117,7 @@ EXPLAIN SELECT DISTINCT y + z FROM xyz ORDER BY y + z
 2  render
 3  scan
 3            table  xyz@primary
+3            spans  ALL
 
 query I
 SELECT DISTINCT y AS w FROM xyz ORDER by z

--- a/pkg/sql/testdata/explain
+++ b/pkg/sql/testdata/explain
@@ -228,3 +228,4 @@ EXPLAIN SHOW USERS
 0  render
 1  scan
 1        table  users@primary
+1        spans  ALL

--- a/pkg/sql/testdata/explain_plan
+++ b/pkg/sql/testdata/explain_plan
@@ -25,12 +25,14 @@ EXPLAIN SELECT * FROM t
 ----
 0  scan
 0        table  t@primary
+0        spans  ALL
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM t
 ----
 0  scan                      (k, v)  +k,unique
 0          table  t@primary
+0          spans  ALL
 
 query ITTT
 EXPLAIN SELECT * FROM t WHERE k = 1 OR k = 3
@@ -68,6 +70,7 @@ EXPLAIN(EXPRS) SELECT * FROM t WITH ORDINALITY LIMIT 1 OFFSET 1
 1  ordinality
 2  scan
 2                 table     t@primary
+2                 spans     ALL
 2                 limit     2
 
 query ITTT
@@ -77,6 +80,7 @@ EXPLAIN SELECT DISTINCT * FROM t
 0            key    k
 1  scan
 1            table  t@primary
+1            spans  ALL
 
 query ITTT
 EXPLAIN(EXPRS) SELECT DISTINCT * FROM t LIMIT 1 OFFSET 1
@@ -88,6 +92,7 @@ EXPLAIN(EXPRS) SELECT DISTINCT * FROM t LIMIT 1 OFFSET 1
 1                 key       k
 2  scan
 2                 table     t@primary
+2                 spans     ALL
 
 statement ok
 CREATE TABLE tc (a INT, b INT, INDEX c(a))

--- a/pkg/sql/testdata/explain_types
+++ b/pkg/sql/testdata/explain_types
@@ -30,6 +30,7 @@ EXPLAIN (TYPES) SELECT * FROM t
 ----
 0  scan                                (k int, v int)  +k,unique
 0                 table     t@primary
+0                 spans     ALL
 
 query ITTTTT
 EXPLAIN (TYPES, SYMVARS) SELECT k FROM t
@@ -38,6 +39,7 @@ EXPLAIN (TYPES, SYMVARS) SELECT k FROM t
 0         render 0  (@1)[int]
 1  scan                        (k int, v[omitted] int)  +k,unique
 1         table     t@primary
+1         spans     ALL
 
 query ITTTTT
 EXPLAIN (TYPES, QUALIFY) SELECT k FROM t
@@ -46,6 +48,7 @@ EXPLAIN (TYPES, QUALIFY) SELECT k FROM t
 0         render 0  (test.t.k)[int]
 1  scan                              (k int, v[omitted] int)  +k,unique
 1         table     t@primary
+1         spans     ALL
 
 query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT * FROM t WHERE v > 123
@@ -192,6 +195,7 @@ EXPLAIN (TYPES) SELECT DISTINCT k FROM t
 1                 render 0  (k)[int]
 2  scan                                (k int, v[omitted] int)  +k,unique
 2                 table     t@primary
+2                 spans     ALL
 
 query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT DISTINCT k FROM t
@@ -232,6 +236,7 @@ EXPLAIN (TYPES) SELECT v FROM t LIMIT 1
 1                 render 0  (v)[int]
 2  scan                                (k[omitted] int, v int)  +k,unique
 2                 table     t@primary
+2                 spans     ALL
 2                 limit     1
 
 query ITTTTT

--- a/pkg/sql/testdata/insert
+++ b/pkg/sql/testdata/insert
@@ -496,6 +496,7 @@ EXPLAIN (PLAN,EXPRS) INSERT INTO insert_t SELECT * FROM select_t LIMIT 1
 1                 count     1
 2  scan
 2                 table     select_t@primary
+2                 spans     ALL
 2                 limit     1
 
 statement ok

--- a/pkg/sql/testdata/join
+++ b/pkg/sql/testdata/join
@@ -417,8 +417,10 @@ EXPLAIN(EXPRS) SELECT * FROM onecolumn JOIN twocolumn USING(x)
 1                 equality  (x) = (x)
 2  scan
 2                 table     onecolumn@primary
+2                 spans     ALL
 2  scan
 2                 table     twocolumn@primary
+2                 spans     ALL
 
 # Check EXPLAIN.
 query ITTT
@@ -434,8 +436,10 @@ EXPLAIN(EXPRS) SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
 1                 equality  (x) = (y)
 2  scan
 2                 table     twocolumn@primary
+2                 spans     ALL
 2  scan
 2                 table     twocolumn@primary
+2                 spans     ALL
 
 # Check EXPLAIN.
 query ITTT
@@ -454,6 +458,7 @@ EXPLAIN(EXPRS) SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
 2                 filter    x = 44
 2  scan
 2                 table     twocolumn@primary
+2                 spans     ALL
 
 # Check EXPLAIN.
 query ITTT
@@ -468,8 +473,10 @@ EXPLAIN(EXPRS) SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b
 1                 equality  (x) = (y)
 2  scan
 2                 table     onecolumn@primary
+2                 spans     ALL
 2  scan
 2                 table     twocolumn@primary
+2                 spans     ALL
 
 # Check EXPLAIN.
 query ITTT
@@ -484,8 +491,10 @@ EXPLAIN(EXPRS) SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn
 1                 equality  (x) = (y)
 2  scan
 2                 table     onecolumn@primary
+2                 spans     ALL
 2  scan
 2                 table     twocolumn@primary
+2                 spans     ALL
 
 
 query ITTT
@@ -510,12 +519,16 @@ EXPLAIN(EXPRS) SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a
 4                 type      cross
 5  scan
 5                 table     onecolumn@primary
+5                 spans     ALL
 5  scan
 5                 table     twocolumn@primary
+5                 spans     ALL
 4  scan
 4                 table     onecolumn@primary
+4                 spans     ALL
 3  scan
 3                 table     twocolumn@primary
+3                 spans     ALL
 
 # Check sub-queries in ON conditions.
 query III colnames
@@ -620,8 +633,10 @@ EXPLAIN (METADATA) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
 1          type   cross
 2  scan                              (x, y[omitted], rowid[hidden,omitted])                                       +rowid,unique
 2          table  twocolumn@primary
+2          spans  ALL
 2  scan                              (x[omitted], y, rowid[hidden,omitted])                                       +rowid,unique
 2          table  twocolumn@primary
+2          spans  ALL
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
@@ -632,8 +647,10 @@ EXPLAIN (METADATA) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
 1          equality  (x) = (x)
 2  scan                                 (x, y[omitted], rowid[hidden,omitted])                                                                          +rowid,unique
 2          table     twocolumn@primary
+2          spans     ALL
 2  scan                                 (x, y, rowid[hidden,omitted])                                                                                   +rowid,unique
 2          table     twocolumn@primary
+2          spans     ALL
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b.x)
@@ -644,8 +661,10 @@ EXPLAIN (METADATA) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = 
 1          equality  (x) = (x)
 2  scan                                 (x, y[omitted], rowid[hidden,omitted])                                                  +rowid,unique
 2          table     twocolumn@primary
+2          spans     ALL
 2  scan                                 (x, y, rowid[hidden,omitted])                                                           +rowid,unique
 2          table     twocolumn@primary
+2          spans     ALL
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b.y)
@@ -655,8 +674,10 @@ EXPLAIN (METADATA) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < 
 1          type   inner
 2  scan                              (x, y[omitted], rowid[hidden,omitted])                                                 +rowid,unique
 2          table  twocolumn@primary
+2          spans  ALL
 2  scan                              (x[omitted], y, rowid[hidden,omitted])                                                 +rowid,unique
 2          table  twocolumn@primary
+2          spans  ALL
 
 # Ensure that the ordering information for the result of joins is sane. (#12037)
 query ITTTTT
@@ -892,8 +913,10 @@ EXPLAIN SELECT * FROM pairs, square WHERE pairs.b = square.n
 1        equality  (b) = (n)
 2  scan
 2        table     pairs@primary
+2        spans     ALL
 2  scan
 2        table     square@primary
+2        spans     ALL
 
 query IIII
 SELECT * FROM pairs, square WHERE pairs.b = square.n
@@ -928,8 +951,10 @@ EXPLAIN (VERBOSE) SELECT * FROM pairs, square WHERE pairs.a + pairs.b = square.s
 1          pred      (test.pairs.a + test.pairs.b) = test.square.sq
 2  scan                                                              (a, b, rowid[hidden,omitted])          +rowid,unique
 2          table     pairs@primary
+2          spans     ALL
 2  scan                                                              (n, sq)                                +n,unique
 2          table     square@primary
+2          spans     ALL
 
 query IIII
 SELECT * FROM pairs, square WHERE pairs.a + pairs.b = square.sq
@@ -961,8 +986,10 @@ EXPLAIN (VERBOSE) SELECT a, b, n, sq FROM (SELECT a, b, a + b AS sum, n, sq FROM
 3          type      cross
 4  scan                                           (a, b, rowid[hidden,omitted])        +rowid,unique
 4          table     pairs@primary
+4          spans     ALL
 4  scan                                           (n, sq)                              +n,unique
 4          table     square@primary
+4          spans     ALL
 
 query IIII
 SELECT a, b, n, sq FROM (SELECT a, b, a + b AS sum, n, sq FROM pairs, square) WHERE sum = sq
@@ -985,8 +1012,10 @@ EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.
 1          pred      (test.pairs.a + test.pairs.b) = test.square.sq
 2  scan                                                              (a, b, rowid[hidden,omitted])         +rowid,unique
 2          table     pairs@primary
+2          spans     ALL
 2  scan                                                              (n, sq)                               +n,unique
 2          table     square@primary
+2          spans     ALL
 
 query IIII
 SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq
@@ -1026,8 +1055,10 @@ EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.
 2          pred      (test.pairs.a + test.pairs.b) = test.square.sq
 3  scan                                                              (a, b, rowid[hidden,omitted])        +rowid,unique
 3          table     pairs@primary
+3          spans     ALL
 3  scan                                                              (n, sq)                              +n,unique
 3          table     square@primary
+3          spans     ALL
 
 query IIII
 SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq WHERE pairs.b%2 <> square.sq%2

--- a/pkg/sql/testdata/needed_columns
+++ b/pkg/sql/testdata/needed_columns
@@ -111,6 +111,7 @@ EXPLAIN(METADATA) SELECT 1 FROM kv
 0   render                         ("1")
 1   scan                           (k[omitted], v[omitted])   +k,unique
 1            table   kv@primary
+1            spans   ALL
 
 # Propagation through DISTINCT.
 query ITTTTT
@@ -120,6 +121,7 @@ EXPLAIN (METADATA) SELECT DISTINCT v FROM kv;
 1  render                       (v)
 2  scan                         (k[omitted], v)  +k,unique
 2            table  kv@primary
+2            spans  ALL
 
 # Propagation through INSERT.
 query ITTTTT
@@ -163,3 +165,4 @@ EXPLAIN (VERBOSE) SELECT 1 FROM (SELECT k+1 AS x, v-2 AS y FROM kv)
 0          render 0  1
 1  scan                          (k[omitted], v[omitted])  +k,unique
 1          table     kv@primary
+1          spans     ALL

--- a/pkg/sql/testdata/order_by
+++ b/pkg/sql/testdata/order_by
@@ -281,12 +281,14 @@ EXPLAIN SELECT * FROM t ORDER BY 1+2
 ----
 0  scan
 0        table  t@primary
+0        spans  ALL
 
 query ITTT
 EXPLAIN SELECT * FROM t ORDER BY length('abc')
 ----
 0  scan
 0        table  t@primary
+0        spans  ALL
 
 # Check that the sort key reuses the existing render.
 query ITTTTT
@@ -297,6 +299,7 @@ EXPLAIN(METADATA) SELECT b+2 FROM t ORDER BY b+2
 1  render                    ("b + 2")
 2  scan                      (a[omitted], b, c[omitted])  +a,unique
 2          table  t@primary
+2          spans  ALL
 
 # Check that the sort picks up a renamed render properly.
 query ITTTTT
@@ -307,6 +310,7 @@ EXPLAIN(METADATA) SELECT b+2 AS y FROM t ORDER BY y
 1  render                    (y)
 2  scan                      (a[omitted], b, c[omitted])  +a,unique
 2          table  t@primary
+2          spans  ALL
 
 # Check that the sort reuses a render behind a rename properly.
 query ITTTTT
@@ -317,6 +321,7 @@ EXPLAIN(METADATA) SELECT b+2 AS y FROM t ORDER BY b+2
 1  render                    (y)
 2  scan                      (a[omitted], b, c[omitted])  +a,unique
 2          table  t@primary
+2          spans  ALL
 
 statement ok
 CREATE TABLE abc (
@@ -650,3 +655,4 @@ EXPLAIN (METADATA) UPDATE t SET c = TRUE RETURNING b
 1  render                    (a, b, c, "true")  +a,unique
 2  scan                      (a, b, c)          +a,unique
 2          table  t@primary
+2          spans  ALL

--- a/pkg/sql/testdata/ordinality
+++ b/pkg/sql/testdata/ordinality
@@ -97,3 +97,4 @@ EXPLAIN (METADATA) SELECT * FROM foo WITH ORDINALITY WHERE x > 'a';
 1  ordinality                      (x, ordinality)  +x,unique
 2  scan                            (x)              +x,unique
 2              table  foo@primary
+2              spans  ALL

--- a/pkg/sql/testdata/select_index
+++ b/pkg/sql/testdata/select_index
@@ -123,6 +123,7 @@ EXPLAIN SELECT * FROM t x JOIN t y USING(b) WHERE x.b < '3'
 3              table     t@primary
 2  scan
 2              table     t@primary
+2              spans     ALL
 
 statement ok
 TRUNCATE TABLE t

--- a/pkg/sql/testdata/subquery
+++ b/pkg/sql/testdata/subquery
@@ -80,6 +80,7 @@ EXPLAIN SELECT EXISTS (SELECT a FROM abc)
 2  render
 3  scan
 3           table       abc@primary
+3           spans       ALL
 1  nullrow
 
 query I
@@ -349,6 +350,7 @@ EXPLAIN(METADATA) SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz);
 2  render                           (x)                          +x,unique
 3  scan                             (x, y[omitted], z[omitted])  +x,unique
 3          table       xyz@primary
+3          spans       ALL
 
 # This test checks that the double sub-query plan expansion caused by a
 # sub-expression being shared by two or more plan nodes does not

--- a/pkg/sql/testdata/union
+++ b/pkg/sql/testdata/union
@@ -141,9 +141,11 @@ EXPLAIN SELECT v FROM uniontest UNION SELECT k FROM uniontest
 1  render
 2  scan
 2          table  uniontest@primary
+2          spans  ALL
 1  render
 2  scan
 2          table  uniontest@primary
+2          spans  ALL
 
 query ITTT rowsort
 EXPLAIN SELECT v FROM uniontest UNION ALL SELECT k FROM uniontest
@@ -152,9 +154,11 @@ EXPLAIN SELECT v FROM uniontest UNION ALL SELECT k FROM uniontest
 1  render
 2  scan
 2          table  uniontest@primary
+2          spans  ALL
 1  render
 2  scan
 2          table  uniontest@primary
+2          spans  ALL
 
 
 query error each UNION query must have the same number of columns: 2 vs 1


### PR DESCRIPTION
For full-table scans we may or may not generate a span in the scanNode depending
on the code path in selectIndex. The two cases are equivalent and yet the
distinction leaks out via EXPLAIN: in one case we show "spans ALL", in the other
case we don't show spans.

Fixing selectIndex to always generate a span, which means that "spans ALL" will
always show up. The only (desirable) exceptions are: the table node under an
indexJoinNode), and NOEXPAND.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13544)
<!-- Reviewable:end -->
