### PR TITLE
sql: Ensure that views don't leave planner.avoidCachedDescriptors set

### DIFF
--- a/pkg/sql/testdata/views
+++ b/pkg/sql/testdata/views
@@ -344,5 +344,13 @@ CREATE VIEW dt2 AS SELECT d, t FROM t WHERE d > d + INTERVAL '10h'
 statement ok
 SELECT * FROM dt2
 
+# Ensure that creating a view doesn't leak any session-level settings that
+# could affect subsequent AS OF SYSTEM TIME queries (#13547).
+statement ok
+CREATE VIEW v AS SELECT d, t FROM t
+
+statement error pq: unexpected AS OF SYSTEM TIME
+CREATE TABLE t2 AS SELECT d, t FROM t AS OF SYSTEM TIME '2017-02-13 21:30:00'
+
 statement ok
 DROP TABLE t CASCADE


### PR DESCRIPTION
Also ensures that the view's sourcePlan always gets closed, which was
previously getting missed in a couple cases.

Fixes #13547

@mjibson @knz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13554)
<!-- Reviewable:end -->
