### PR TITLE
sqlccl: use Export command to implement Backup

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -567,7 +567,7 @@ func TestBackupLevelDB(t *testing.T) {
 func BenchmarkClusterBackup(b *testing.B) {
 	defer tracing.Disable()()
 
-	ctx, dir, tc, sqlDB, cleanupFn := backupRestoreTestSetup(b, multiNode, 0)
+	ctx, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(b, multiNode, 0)
 	defer cleanupFn()
 
 	ts := hlc.Timestamp{WallTime: hlc.UnixNano()}
@@ -576,10 +576,15 @@ func BenchmarkClusterBackup(b *testing.B) {
 	}
 	sqlDB.Exec(fmt.Sprintf(`RESTORE DATABASE bench FROM '%s'`, dir))
 
-	for _, split := range bankSplitStmts(b.N, backupRestoreDefaultRanges) {
-		sqlDB.Exec(split)
-	}
-	rebalanceLeases(b, tc)
+	// TODO(dan): Occasionally, this returns but seems to still be doing work,
+	// which wildly throws off the timing of below and so the results of the
+	// benchmark. When DistSQL improves this infrastructure, use what they've
+	// built.
+	//
+	// for _, split := range bankSplitStmts(b.N, backupRestoreDefaultRanges) {
+	// 	sqlDB.Exec(split)
+	// }
+	// rebalanceLeases(b, tc)
 
 	b.ResetTimer()
 	var unused string

--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -41,7 +41,7 @@ func evalExport(
 	r := cArgs.Repl
 	reply := resp.(*roachpb.ExportResponse)
 
-	ctx, span := tracing.ChildSpan(ctx, fmt.Sprintf("ExportKeys %s-%s", args.Key, args.EndKey))
+	ctx, span := tracing.ChildSpan(ctx, fmt.Sprintf("Export %s-%s", args.Key, args.EndKey))
 	defer tracing.FinishSpan(span)
 
 	// If the startTime is zero, then we're doing a full backup and the gc
@@ -78,7 +78,7 @@ func evalExport(
 	defer func() {
 		if sst != nil {
 			if closeErr := sst.Close(); closeErr != nil {
-				log.Warningf(ctx, "could not close sst writer %s", path)
+				log.Warningf(ctx, "could not close sst writer %s: %+v", path, closeErr)
 			}
 		}
 	}()
@@ -94,7 +94,7 @@ func evalExport(
 		for ; iter.Valid(); iter.Next() {
 			key, value := iter.Key(), iter.Value()
 			if log.V(3) {
-				log.Infof(ctx, "ExportKeys %+v %+v", key, value)
+				log.Infof(ctx, "Export %+v %+v", key, value)
 			}
 			entries++
 			if err := sst.Add(engine.MVCCKeyValue{Key: key, Value: value}); err != nil {
@@ -112,8 +112,11 @@ func evalExport(
 	}
 
 	if entries == 0 {
-		// SSTables require at least one entry. It's silly to save an empty one,
-		// anyway.
+		// The defer above `Close`s sst if it's not nil, which in turn finishes
+		// the SSTable. However, our SSTable library errors if there is not at
+		// least one entry, so set `sst = nil` to avoid the `Close` and the log
+		// spam when it fails.
+		sst = nil
 		reply.Files = []roachpb.ExportResponse_File{}
 		return storage.EvalResult{}, nil
 	}


### PR DESCRIPTION
```
name             old time/op    new time/op     delta
ClusterBackup-8    2.77µs ±26%     1.06µs ±10%   -61.85%  (p=0.008 n=5+5)

name             old speed      new speed       delta
ClusterBackup-8  42.3MB/s ±22%  109.2MB/s ±10%  +157.84%  (p=0.008 n=5+5)

name             old alloc/op   new alloc/op    delta
ClusterBackup-8    1.09kB ± 0%     0.14kB ± 6%   -87.54%  (p=0.016 n=4+5)

name             old allocs/op  new allocs/op   delta
ClusterBackup-8     0.00 ±NaN%       3.00 ± 0%     +Inf%  (p=0.008 n=5+5)
```

cc @bdarnell You mentioned in the original review that `client.SendWrappedWith` wasn't really intended for non-test use. Figured I'd double-check that you haven't changed your mind.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13556)
<!-- Reviewable:end -->
