### PR TITLE
storage: don't sync Raft batches if only HardState.Commit changes

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -62,7 +62,7 @@ imports:
 - name: github.com/codahale/hdrhistogram
   version: 3a0bb77429bd3a61596f5e8a3172445844342120
 - name: github.com/coreos/etcd
-  version: f99c76cb4791430a25aaea2e7e44e460a332f261
+  version: 808ee4e57c4c4f264f3c29a403ad9043234d00cb
   subpackages:
   - raft
   - raft/raftpb

--- a/glide.yaml
+++ b/glide.yaml
@@ -21,7 +21,7 @@ import:
 - package: github.com/cockroachdb/cockroach-go
   version: ba57380fe1f490388284806affe325d081e62be6
 - package: github.com/coreos/etcd
-  version: f99c76cb4791430a25aaea2e7e44e460a332f261
+  version: 808ee4e57c4c4f264f3c29a403ad9043234d00cb
 - package: github.com/gogo/protobuf
   version: f9114dace7bd920b32f943b3c73fafbcbab2bf31
 - package: github.com/golang/protobuf

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2715,7 +2715,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	writer.Close()
 	// Synchronously commit the batch with the Raft log entries and Raft hard
 	// state as we're promising not to lose this data.
-	if err := batch.Commit(syncRaftLog); err != nil {
+	if err := batch.Commit(syncRaftLog && rd.MustSync); err != nil {
 		return stats, err
 	}
 


### PR DESCRIPTION
The heuristics here are taken from
github.com/coreos/etcd/wal/wal.go:mustSync(). This affects multi-replica
ranges and avoids a sync when an entry is being committed but there is
no other Raft update (i.e. no new log entries).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13558)
<!-- Reviewable:end -->
