### PR TITLE
sql: add benchmarks for Add Column/Index

### DIFF
--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -43,7 +43,7 @@ import (
 // TODO(radu): we should verify that the plan is indeed distributed as
 // intended.
 func SplitTable(
-	t *testing.T,
+	tb testing.TB,
 	tc serverutils.TestClusterInterface,
 	desc *sqlbase.TableDescriptor,
 	targetNode int,
@@ -51,27 +51,27 @@ func SplitTable(
 ) {
 	pik, err := sqlbase.MakePrimaryIndexKey(desc, vals...)
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 
 	splitKey := keys.MakeRowSentinelKey(pik)
 	_, rightRange, err := tc.Server(0).SplitRange(splitKey)
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 	splitKey = rightRange.StartKey.AsRawKey()
 	rightRange, err = tc.AddReplicas(splitKey, tc.Target(targetNode))
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 
 	// This transfer is necessary to avoid waiting for the lease to expire when
 	// removing the first replica.
 	if err := tc.TransferRangeLease(rightRange, tc.Target(targetNode)); err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 	if _, err := tc.RemoveReplicas(splitKey, tc.Target(0)); err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 }
 

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -1729,3 +1729,69 @@ INSERT INTO t.test (k, v, length) VALUES (0, 1, 1);
 
 	wg.Wait()
 }
+
+// Create a table with data to be used by benchmarks.
+func initBenchSchemaChange(b *testing.B) serverutils.TestClusterInterface {
+	const numNodes, chunkSize, maxValue = 5, 500, 100000
+	params, _ := createTestServerParams()
+	// Disable asynchronous schema change execution to allow synchronous path
+	// to always execute the schema change.
+	params.Knobs = base.TestingKnobs{
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+			AsyncExecNotification: asyncSchemaChangerDisabled,
+			BackfillChunkSize:     chunkSize,
+		},
+	}
+
+	tc := serverutils.StartTestCluster(b, numNodes,
+		base.TestClusterArgs{
+			ReplicationMode: base.ReplicationManual,
+			ServerArgs:      params,
+		})
+
+	sqlDB := tc.ServerConn(0)
+	kvDB := tc.Server(0).KVClient().(*client.DB)
+	if _, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test (k INT PRIMARY KEY, v INT, pi DECIMAL DEFAULT (DECIMAL '3.14'), created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP());
+CREATE UNIQUE INDEX vidx ON t.test (v);
+`); err != nil {
+		b.Fatal(err)
+	}
+
+	// Bulk insert.
+	if err := bulkInsertIntoTable(sqlDB, maxValue); err != nil {
+		b.Fatal(err)
+	}
+
+	// Split the table into multiple ranges.
+	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
+	// SplitTable moves the right range, so we split things back to front.
+	for i := numNodes - 1; i > 0; i-- {
+		sql.SplitTable(b, tc, tableDesc, i, maxValue/numNodes*i)
+	}
+
+	return tc
+}
+
+func BenchmarkAddColumn(b *testing.B) {
+	tc := initBenchSchemaChange(b)
+	defer tc.Stopper().Stop()
+	sqlDB := tc.ServerConn(0)
+	for n := 0; n < b.N; n++ {
+		if _, err := sqlDB.Exec(fmt.Sprintf(`ALTER TABLE t.test ADD COLUMN x%d DECIMAL DEFAULT (DECIMAL '1.4')`, n)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkCreateIndex(b *testing.B) {
+	tc := initBenchSchemaChange(b)
+	defer tc.Stopper().Stop()
+	sqlDB := tc.ServerConn(0)
+	for n := 0; n < b.N; n++ {
+		if _, err := sqlDB.Exec(fmt.Sprintf(`CREATE UNIQUE INDEX foo%d ON t.test (v)`, n)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
I've added the benchmark results to the commit. As you can see AddColumn is still slow because it is not yet using distsql. These benchmarks will setup a baseline from which we can make improvements


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13563)
<!-- Reviewable:end -->
