### PR TITLE
sql: Fix panic in logic_ test

### DIFF
--- a/pkg/sql/logic_test.go
+++ b/pkg/sql/logic_test.go
@@ -848,7 +848,7 @@ func (t *logicTest) verifyError(sql, pos, expectErr, expectErrCode string, err e
 	}
 	if !testutils.IsError(err, expectErr) {
 		t.Errorf("%s: expected %q, but found %v", pos, expectErr, err)
-		if strings.Contains(err.Error(), expectErr) {
+		if err != nil && strings.Contains(err.Error(), expectErr) {
 			t.t.Logf("The output string contained the input regexp. Perhaps you meant to write:\n"+
 				"query error %s", regexp.QuoteMeta(err.Error()))
 		}


### PR DESCRIPTION
It triggered when expectErr is non-nil and err is nil.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13564)
<!-- Reviewable:end -->
