### PR TITLE
distsqlrun: small fix to TestStreamEncodeDecode

### DIFF
--- a/pkg/sql/distsqlrun/stream_data_test.go
+++ b/pkg/sql/distsqlrun/stream_data_test.go
@@ -60,7 +60,11 @@ func testRowStream(t *testing.T, rng *rand.Rand, rows sqlbase.EncDatumRows, trai
 		// "Send" a message every now and then and once at the end.
 		final := (rowIdx == len(rows))
 		if final || (rowIdx > 0 && rng.Intn(10) == 0) {
-			msg := se.FormMessage(final, trailerErr)
+			var msgErr error
+			if final {
+				msgErr = trailerErr
+			}
+			msg := se.FormMessage(final, msgErr)
 			// Make a copy of the data buffer.
 			msg.Data.RawBytes = append([]byte(nil), msg.Data.RawBytes...)
 			err := sd.AddMessage(msg)


### PR DESCRIPTION
The test was not respecting the interface: you're only supposed to pass
an error to the StreamEncoder on the last message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13569)
<!-- Reviewable:end -->
