### PR TITLE
sql: propagate desired ordering through sortNode when possible

### DIFF
--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -182,7 +182,9 @@ func doExpandPlan(p *planner, params expandParameters, plan planNode) (planNode,
 		n.plan, err = doExpandPlan(p, noParams, n.plan)
 
 	case *sortNode:
-		params.desiredOrdering = n.ordering
+		if !n.ordering.IsPrefixOf(params.desiredOrdering) {
+			params.desiredOrdering = n.ordering
+		}
 		n.plan, err = doExpandPlan(p, params, n.plan)
 		if err != nil {
 			return plan, err

--- a/pkg/sql/sqlbase/ordering.go
+++ b/pkg/sql/sqlbase/ordering.go
@@ -29,3 +29,18 @@ type ColumnOrderInfo struct {
 //     []ColumnOrderInfo{ {3, true}, {1, false} }
 // represents an ordering first by column 3 (descending), then by column 1 (ascending).
 type ColumnOrdering []ColumnOrderInfo
+
+// IsPrefixOf returns true if the receiver ordering matches a prefix of the
+// given ordering. In this case, rows with an order conforming to b
+// automatically conform to a.
+func (a ColumnOrdering) IsPrefixOf(b ColumnOrdering) bool {
+	if len(a) > len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/sql/testdata/order_by
+++ b/pkg/sql/testdata/order_by
@@ -667,3 +667,25 @@ EXPLAIN (METADATA) UPDATE t SET c = TRUE RETURNING b
 2  scan                      (a, b, c)          +a,unique
 2          table  t@primary
 2          spans  ALL
+
+statement ok
+CREATE TABLE uvwxyz (
+  u INT,
+  v INT,
+  w INT,
+  x INT,
+  y INT,
+  z INT,
+  INDEX ywxz (y, w, x, z, u, v),
+  INDEX ywz (y, w, z, x)
+)
+
+# Verify that the outer ordering is propagated to index selection and we choose
+# the index that avoids any sorting.
+query ITTTTT
+EXPLAIN (METADATA) SELECT * FROM (SELECT y, w, x FROM uvwxyz WHERE y = 1 ORDER BY w) ORDER BY w, x
+----
+0  render                      (y, w, x)                                                             =y,+w,+x
+1  scan                        (u[omitted], v[omitted], w, x, y, z[omitted], rowid[hidden,omitted])  =y,+w,+x,+z,+u,+v,+rowid,unique
+1          table  uvwxyz@ywxz
+1          spans  /1-/2


### PR DESCRIPTION
During expand plan, if the ordering of a sortNode is a prefix of the desired
ordering, we can propagate the desired ordering. This may result in a better
subplan, as shown in the new testcase.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13573)
<!-- Reviewable:end -->
