### PR TITLE
sql: propagate simplified orderings

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -665,7 +665,7 @@ func (dsp *distSQLPlanner) selectRenders(p *physicalPlan, n *renderNode) {
 // reflect the sort node.
 func (dsp *distSQLPlanner) addSorters(p *physicalPlan, n *sortNode) {
 
-	matchLen := computeOrderingMatch(n.ordering, n.plan.Ordering(), false /* reverse */)
+	matchLen := n.plan.Ordering().computeMatch(n.ordering)
 
 	if matchLen < len(n.ordering) {
 		// Sorting is needed; we add a stage of sorting processors.

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -192,8 +192,7 @@ func doExpandPlan(p *planner, params expandParameters, plan planNode) (planNode,
 
 		// Check to see if the requested ordering is compatible with the existing
 		// ordering.
-		existingOrdering := n.plan.Ordering()
-		match := computeOrderingMatch(n.ordering, existingOrdering, false)
+		match := n.plan.Ordering().computeMatch(n.ordering)
 		if match < len(n.ordering) {
 			n.needSort = true
 		} else if len(n.columns) < len(n.plan.Columns()) {
@@ -260,7 +259,7 @@ func expandScanNode(p *planner, params expandParameters, s *scanNode) (planNode,
 	var analyzeOrdering analyzeOrderingFn
 	if len(params.desiredOrdering) > 0 {
 		analyzeOrdering = func(indexOrdering orderingInfo) (matchingCols, totalCols int) {
-			match := computeOrderingMatch(params.desiredOrdering, indexOrdering, false)
+			match := indexOrdering.computeMatch(params.desiredOrdering)
 			return match, len(params.desiredOrdering)
 		}
 	}

--- a/pkg/sql/limit_opt.go
+++ b/pkg/sql/limit_opt.go
@@ -93,17 +93,13 @@ func applyLimit(plan planNode, numRows int64, soft bool) {
 		applyLimit(n.plan, numRows, soft)
 
 	case *groupNode:
-		if len(n.desiredOrdering) > 0 {
-			match := n.plan.Ordering().computeMatch(n.desiredOrdering)
-			if match == len(n.desiredOrdering) {
-				// We have a single MIN/MAX function and the underlying plan's
-				// ordering matches the function. We only need to retrieve one row.
-				applyLimit(n.plan, 1, false /* !soft */)
-				n.needOnlyOneRow = true
-				return
-			}
+		if n.needOnlyOneRow {
+			// We have a single MIN/MAX function and the underlying plan's
+			// ordering matches the function. We only need to retrieve one row.
+			applyLimit(n.plan, 1, false /* !soft */)
+		} else {
+			setUnlimited(n.plan)
 		}
-		setUnlimited(n.plan)
 
 	case *indexJoinNode:
 		applyLimit(n.index, numRows, soft)

--- a/pkg/sql/limit_opt.go
+++ b/pkg/sql/limit_opt.go
@@ -94,7 +94,7 @@ func applyLimit(plan planNode, numRows int64, soft bool) {
 
 	case *groupNode:
 		if len(n.desiredOrdering) > 0 {
-			match := computeOrderingMatch(n.desiredOrdering, n.plan.Ordering(), false)
+			match := n.plan.Ordering().computeMatch(n.desiredOrdering)
 			if match == len(n.desiredOrdering) {
 				// We have a single MIN/MAX function and the underlying plan's
 				// ordering matches the function. We only need to retrieve one row.

--- a/pkg/sql/ordering_test.go
+++ b/pkg/sql/ordering_test.go
@@ -17,6 +17,7 @@
 package sql
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -160,6 +161,99 @@ func TestComputeOrderingMatch(t *testing.T) {
 				t.Errorf("Test defined on line %d failed: expected:%d/%d got:%d/%d",
 					tc.line, tc.expected, tc.expectedReverse, res, resRev)
 			}
+		}
+	}
+}
+
+func TestTrimOrdering(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Helper function to create a ColumnOrderInfo. The "simple" composite
+	// literal syntax causes vet to warn about unkeyed literals and the explicit
+	// syntax is too verbose.
+	o := func(colIdx int, direction encoding.Direction) sqlbase.ColumnOrderInfo {
+		return sqlbase.ColumnOrderInfo{ColIdx: colIdx, Direction: direction}
+	}
+
+	e := struct{}{}
+	asc := encoding.Ascending
+	desc := encoding.Descending
+	testCases := []struct {
+		ord      orderingInfo
+		desired  sqlbase.ColumnOrdering
+		expected orderingInfo
+	}{
+		{
+			ord: orderingInfo{
+				exactMatchCols: nil,
+				ordering:       sqlbase.ColumnOrdering{o(1, asc), o(2, desc)},
+				unique:         true,
+			},
+			desired: sqlbase.ColumnOrdering{o(1, asc)},
+			expected: orderingInfo{
+				exactMatchCols: nil,
+				ordering:       sqlbase.ColumnOrdering{o(1, asc)},
+				unique:         false,
+			},
+		},
+		{
+			ord: orderingInfo{
+				exactMatchCols: nil,
+				ordering:       sqlbase.ColumnOrdering{o(1, asc), o(2, desc)},
+				unique:         true,
+			},
+			desired: sqlbase.ColumnOrdering{o(1, desc)},
+			expected: orderingInfo{
+				exactMatchCols: nil,
+				ordering:       sqlbase.ColumnOrdering{},
+				unique:         false,
+			},
+		},
+		{
+			ord: orderingInfo{
+				exactMatchCols: map[int]struct{}{0: e, 5: e, 6: e},
+				ordering:       sqlbase.ColumnOrdering{o(1, desc), o(2, desc)},
+				unique:         true,
+			},
+			desired: sqlbase.ColumnOrdering{o(5, asc), o(1, desc)},
+			expected: orderingInfo{
+				exactMatchCols: map[int]struct{}{0: e, 5: e, 6: e},
+				ordering:       sqlbase.ColumnOrdering{o(1, desc)},
+				unique:         false,
+			},
+		},
+		{
+			ord: orderingInfo{
+				exactMatchCols: map[int]struct{}{0: e, 5: e, 6: e},
+				ordering:       sqlbase.ColumnOrdering{o(1, desc), o(2, desc), o(3, asc)},
+				unique:         true,
+			},
+			desired: sqlbase.ColumnOrdering{o(5, asc), o(1, desc), o(0, desc), o(2, desc)},
+			expected: orderingInfo{
+				exactMatchCols: map[int]struct{}{0: e, 5: e, 6: e},
+				ordering:       sqlbase.ColumnOrdering{o(1, desc), o(2, desc)},
+				unique:         false,
+			},
+		},
+		{
+			ord: orderingInfo{
+				exactMatchCols: map[int]struct{}{0: e, 5: e, 6: e},
+				ordering:       sqlbase.ColumnOrdering{o(1, desc), o(2, desc), o(3, asc)},
+				unique:         true,
+			},
+			desired: sqlbase.ColumnOrdering{o(5, asc), o(4, asc)},
+			expected: orderingInfo{
+				exactMatchCols: map[int]struct{}{0: e, 5: e, 6: e},
+				ordering:       sqlbase.ColumnOrdering{},
+				unique:         false,
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		tc.ord.trim(tc.desired)
+		if !reflect.DeepEqual(tc.ord, tc.expected) {
+			t.Errorf("%d: expected %v, got %v", i, tc.expected, tc.ord)
 		}
 	}
 }

--- a/pkg/sql/ordering_test.go
+++ b/pkg/sql/ordering_test.go
@@ -152,8 +152,10 @@ func TestComputeOrderingMatch(t *testing.T) {
 
 	for _, ts := range testSets {
 		for _, tc := range ts.cases {
-			res := computeOrderingMatch(tc.desired, ts.existing, false)
-			resRev := computeOrderingMatch(tc.desired, ts.existing, true)
+			res := ts.existing.computeMatch(tc.desired)
+			ts.existing.reverse()
+			resRev := ts.existing.computeMatch(tc.desired)
+			ts.existing.reverse()
 			if res != tc.expected || resRev != tc.expectedReverse {
 				t.Errorf("Test defined on line %d failed: expected:%d/%d got:%d/%d",
 					tc.line, tc.expected, tc.expectedReverse, res, resRev)

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -214,11 +214,13 @@ func (s *subquery) subqueryTupleOrdering() (bool, encoding.Direction) {
 
 	// Check Ascending direction.
 	order := s.plan.Ordering()
-	if match := computeOrderingMatch(desired, order, false); match == len(desired) {
+	match := order.computeMatch(desired)
+	if match == len(desired) {
 		return true, encoding.Ascending
 	}
 	// Check Descending direction.
-	if match := computeOrderingMatch(desired, order, true); match == len(desired) {
+	match = order.reverse().computeMatch(desired)
+	if match == len(desired) {
 		return true, encoding.Descending
 	}
 	return false, 0

--- a/pkg/sql/testdata/aggregate
+++ b/pkg/sql/testdata/aggregate
@@ -1068,6 +1068,6 @@ EXPLAIN (TYPES) SELECT COUNT(*) FILTER (WHERE k > 5) FROM filter_test GROUP BY v
 1                 render 0     (*)[int]
 1                 render 1     (v)[int]
 1                 render 2     ((k)[int] > (5)[int])[bool]
-2  scan                                                                                           (k int, v int, mark[omitted] bool, rowid[hidden,omitted] int)  +rowid,unique
+2  scan                                                                                           (k int, v int, mark[omitted] bool, rowid[hidden,omitted] int)
 2                 table        filter_test@primary
 2                 spans        ALL

--- a/pkg/sql/testdata/explain_plan
+++ b/pkg/sql/testdata/explain_plan
@@ -30,7 +30,7 @@ EXPLAIN SELECT * FROM t
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM t
 ----
-0  scan                      (k, v)  +k,unique
+0  scan                      (k, v)
 0          table  t@primary
 0          spans  ALL
 
@@ -44,7 +44,7 @@ EXPLAIN SELECT * FROM t WHERE k = 1 OR k = 3
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE k % 2 = 0
 ----
-0  scan                                  (k, v)  +k,unique
+0  scan                                  (k, v)
 0                 table     t@primary
 0                 spans     ALL
 0                 filter    (k % 2) = 0
@@ -103,9 +103,9 @@ EXPLAIN(METADATA) SELECT * FROM tc WHERE a = 10 ORDER BY b
 0  sort                           (a, b)                                   =a,+b
 0              order  +b
 1  render                         (a, b)                                   =a
-2  index-join                     (a, b, rowid[hidden,omitted])            =a,+rowid,unique
-3  scan                           (a[omitted], b[omitted], rowid[hidden])  =a,+rowid,unique
+2  index-join                     (a, b, rowid[hidden,omitted])            =a
+3  scan                           (a[omitted], b[omitted], rowid[hidden])  =a
 3              table  tc@c
 3              spans  /10-/11
-3  scan                           (a, b, rowid[hidden,omitted])            +rowid,unique
+3  scan                           (a, b, rowid[hidden,omitted])
 3              table  tc@primary

--- a/pkg/sql/testdata/explain_types
+++ b/pkg/sql/testdata/explain_types
@@ -28,25 +28,25 @@ EXPLAIN (TYPES) SELECT 42;
 query ITTTTT
 EXPLAIN (TYPES) SELECT * FROM t
 ----
-0  scan                                (k int, v int)  +k,unique
-0                 table     t@primary
-0                 spans     ALL
+0  scan                    (k int, v int)
+0        table  t@primary
+0        spans  ALL
 
 query ITTTTT
 EXPLAIN (TYPES, SYMVARS) SELECT k FROM t
 ----
-0  render                      (k int)                  +k,unique
+0  render                      (k int)
 0         render 0  (@1)[int]
-1  scan                        (k int, v[omitted] int)  +k,unique
+1  scan                        (k int, v[omitted] int)
 1         table     t@primary
 1         spans     ALL
 
 query ITTTTT
 EXPLAIN (TYPES, QUALIFY) SELECT k FROM t
 ----
-0  render                            (k int)                  +k,unique
+0  render                            (k int)
 0         render 0  (test.t.k)[int]
-1  scan                              (k int, v[omitted] int)  +k,unique
+1  scan                              (k int, v[omitted] int)
 1         table     t@primary
 1         spans     ALL
 
@@ -63,7 +63,7 @@ EXPLAIN (TYPES,NOEXPAND) SELECT * FROM t WHERE v > 123
 query ITTTTT
 EXPLAIN (TYPES) SELECT * FROM t WHERE v > 123
 ----
-0  scan                                                    (k int, v int)  +k,unique
+0  scan                                                    (k int, v int)
 0                 table     t@primary
 0                 spans     ALL
 0                 filter    ((v)[int] > (123)[int])[bool]
@@ -104,24 +104,24 @@ EXPLAIN (TYPES,NOEXPAND) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v
 query ITTTTT
 EXPLAIN (TYPES) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2
 ----
-0  group                                                                 (z int, v int)
-0                 aggregate 0  (2)[int]
-0                 aggregate 1  (count((k)[int]))[int]
-0                 aggregate 2  (v)[int]
-0                 aggregate 3  ((v)[int] < (2)[int])[bool]
-0                 render 0     ((2)[int] * (count((k)[int]))[int])[int]
-0                 render 1     (v)[int]
-0                 having       ((v)[int] < (2)[int])[bool]
-1  render                                                                ("2" int, k int, v int, "v < 2" bool, v int)  +k,unique
-1                 render 0     (2)[int]
-1                 render 1     (k)[int]
-1                 render 2     (v)[int]
-1                 render 3     ((v)[int] < (2)[int])[bool]
-1                 render 4     (v)[int]
-2  scan                                                                  (k int, v int)                                +k,unique
-2                 table        t@primary
-2                 spans        ALL
-2                 filter       ((v)[int] > (123)[int])[bool]
+0  group                                                          (z int, v int)
+0          aggregate 0  (2)[int]
+0          aggregate 1  (count((k)[int]))[int]
+0          aggregate 2  (v)[int]
+0          aggregate 3  ((v)[int] < (2)[int])[bool]
+0          render 0     ((2)[int] * (count((k)[int]))[int])[int]
+0          render 1     (v)[int]
+0          having       ((v)[int] < (2)[int])[bool]
+1  render                                                         ("2" int, k int, v int, "v < 2" bool, v int)
+1          render 0     (2)[int]
+1          render 1     (k)[int]
+1          render 2     (v)[int]
+1          render 3     ((v)[int] < (2)[int])[bool]
+1          render 4     (v)[int]
+2  scan                                                           (k int, v int)
+2          table        t@primary
+2          spans        ALL
+2          filter       ((v)[int] > (123)[int])[bool]
 
 query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) DELETE FROM t WHERE v > 1
@@ -139,9 +139,9 @@ EXPLAIN (TYPES) DELETE FROM t WHERE v > 1
 ----
 0  delete                                                ()
 0                 from      t
-1  render                                                (k int)         +k,unique
+1  render                                                (k int)
 1                 render 0  (k)[int]
-2  scan                                                  (k int, v int)  +k,unique
+2  scan                                                  (k int, v int)
 2                 table     t@primary
 2                 spans     ALL
 2                 filter    ((v)[int] > (1)[int])[bool]
@@ -152,11 +152,11 @@ EXPLAIN (TYPES) UPDATE t SET v = k + 1 WHERE v > 123
 0  update                                                  ()
 0                 table     t
 0                 set       v
-1  render                                                  (k int, v int, "k + 1" int)  +k,unique
+1  render                                                  (k int, v int, "k + 1" int)
 1                 render 0  (k)[int]
 1                 render 1  (v)[int]
 1                 render 2  ((k)[int] + (1)[int])[int]
-2  scan                                                    (k int, v int)               +k,unique
+2  scan                                                    (k int, v int)
 2                 table     t@primary
 2                 spans     ALL
 2                 filter    ((v)[int] > (123)[int])[bool]
@@ -213,7 +213,7 @@ EXPLAIN (TYPES) SELECT v FROM t ORDER BY v
 0                 order     +v
 1  render                              (v int)
 1                 render 0  (v)[int]
-2  scan                                (k[omitted] int, v int)  +k,unique
+2  scan                                (k[omitted] int, v int)
 2                 table     t@primary
 2                 spans     ALL
 
@@ -234,7 +234,7 @@ EXPLAIN (TYPES) SELECT v FROM t LIMIT 1
 0                 count     (1)[int]
 1  render                              (v int)
 1                 render 0  (v)[int]
-2  scan                                (k[omitted] int, v int)  +k,unique
+2  scan                                (k[omitted] int, v int)
 2                 table     t@primary
 2                 spans     ALL
 2                 limit     1
@@ -255,14 +255,14 @@ CREATE TABLE tt (x INT, y INT, INDEX a(x), INDEX b(y))
 query ITTTTT
 EXPLAIN (TYPES) SELECT * FROM tt WHERE x < 10 AND y > 10
 ----
-0  render                                                 (x int, y int)                              +x
+0  render                                                 (x int, y int)
 0                 render 0  (x)[int]
 0                 render 1  (y)[int]
-1  index-join                                             (x int, y int, rowid[hidden,omitted] int)   +x,+rowid,unique
-2  scan                                                   (x[omitted] int, y[omitted] int, rowid[hidden] int)  +x,+rowid,unique
+1  index-join                                             (x int, y int, rowid[hidden,omitted] int)
+2  scan                                                   (x[omitted] int, y[omitted] int, rowid[hidden] int)
 2                 table     tt@a
 2                 spans     /#-/10
-2  scan                                                   (x int, y int, rowid[hidden,omitted] int)   +rowid,unique
+2  scan                                                   (x int, y int, rowid[hidden,omitted] int)
 2                 table     tt@primary
 2                 filter    ((y)[int] > (10)[int])[bool]
 

--- a/pkg/sql/testdata/join
+++ b/pkg/sql/testdata/join
@@ -631,10 +631,10 @@ EXPLAIN (METADATA) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
 0  render                            (x, y)
 1  join                              (x, y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])
 1          type   cross
-2  scan                              (x, y[omitted], rowid[hidden,omitted])                                       +rowid,unique
+2  scan                              (x, y[omitted], rowid[hidden,omitted])
 2          table  twocolumn@primary
 2          spans  ALL
-2  scan                              (x[omitted], y, rowid[hidden,omitted])                                       +rowid,unique
+2  scan                              (x[omitted], y, rowid[hidden,omitted])
 2          table  twocolumn@primary
 2          spans  ALL
 
@@ -645,10 +645,10 @@ EXPLAIN (METADATA) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
 1  join                                 (x[omitted], x[hidden,omitted], y[omitted], rowid[hidden,omitted], x[hidden,omitted], y, rowid[hidden,omitted])
 1          type      inner
 1          equality  (x) = (x)
-2  scan                                 (x, y[omitted], rowid[hidden,omitted])                                                                          +rowid,unique
+2  scan                                 (x, y[omitted], rowid[hidden,omitted])
 2          table     twocolumn@primary
 2          spans     ALL
-2  scan                                 (x, y, rowid[hidden,omitted])                                                                                   +rowid,unique
+2  scan                                 (x, y, rowid[hidden,omitted])
 2          table     twocolumn@primary
 2          spans     ALL
 
@@ -659,10 +659,10 @@ EXPLAIN (METADATA) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = 
 1  join                                 (x[omitted], y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])
 1          type      inner
 1          equality  (x) = (x)
-2  scan                                 (x, y[omitted], rowid[hidden,omitted])                                                  +rowid,unique
+2  scan                                 (x, y[omitted], rowid[hidden,omitted])
 2          table     twocolumn@primary
 2          spans     ALL
-2  scan                                 (x, y, rowid[hidden,omitted])                                                           +rowid,unique
+2  scan                                 (x, y, rowid[hidden,omitted])
 2          table     twocolumn@primary
 2          spans     ALL
 
@@ -672,10 +672,10 @@ EXPLAIN (METADATA) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < 
 0  render                            (x)
 1  join                              (x, y[omitted], rowid[hidden,omitted], x[omitted], y[omitted], rowid[hidden,omitted])
 1          type   inner
-2  scan                              (x, y[omitted], rowid[hidden,omitted])                                                 +rowid,unique
+2  scan                              (x, y[omitted], rowid[hidden,omitted])
 2          table  twocolumn@primary
 2          spans  ALL
-2  scan                              (x[omitted], y, rowid[hidden,omitted])                                                 +rowid,unique
+2  scan                              (x[omitted], y, rowid[hidden,omitted])
 2          table  twocolumn@primary
 2          spans  ALL
 
@@ -949,10 +949,10 @@ EXPLAIN (VERBOSE) SELECT * FROM pairs, square WHERE pairs.a + pairs.b = square.s
 1  join                                                              (a, b, rowid[hidden,omitted], n, sq)
 1          type      inner
 1          pred      (test.pairs.a + test.pairs.b) = test.square.sq
-2  scan                                                              (a, b, rowid[hidden,omitted])          +rowid,unique
+2  scan                                                              (a, b, rowid[hidden,omitted])
 2          table     pairs@primary
 2          spans     ALL
-2  scan                                                              (n, sq)                                +n,unique
+2  scan                                                              (n, sq)
 2          table     square@primary
 2          spans     ALL
 
@@ -984,10 +984,10 @@ EXPLAIN (VERBOSE) SELECT a, b, n, sq FROM (SELECT a, b, a + b AS sum, n, sq FROM
 2          render 4  test.square.sq
 3  join                                           (a, b, rowid[hidden,omitted], n, sq)
 3          type      cross
-4  scan                                           (a, b, rowid[hidden,omitted])        +rowid,unique
+4  scan                                           (a, b, rowid[hidden,omitted])
 4          table     pairs@primary
 4          spans     ALL
-4  scan                                           (n, sq)                              +n,unique
+4  scan                                           (n, sq)
 4          table     square@primary
 4          spans     ALL
 
@@ -1010,10 +1010,10 @@ EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.
 1  join                                                              (a, b, rowid[hidden,omitted], n, sq)
 1          type      full outer
 1          pred      (test.pairs.a + test.pairs.b) = test.square.sq
-2  scan                                                              (a, b, rowid[hidden,omitted])         +rowid,unique
+2  scan                                                              (a, b, rowid[hidden,omitted])
 2          table     pairs@primary
 2          spans     ALL
-2  scan                                                              (n, sq)                               +n,unique
+2  scan                                                              (n, sq)
 2          table     square@primary
 2          spans     ALL
 
@@ -1053,10 +1053,10 @@ EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.
 2  join                                                              (a, b, rowid[hidden,omitted], n, sq)
 2          type      full outer
 2          pred      (test.pairs.a + test.pairs.b) = test.square.sq
-3  scan                                                              (a, b, rowid[hidden,omitted])        +rowid,unique
+3  scan                                                              (a, b, rowid[hidden,omitted])
 3          table     pairs@primary
 3          spans     ALL
-3  scan                                                              (n, sq)                              +n,unique
+3  scan                                                              (n, sq)
 3          table     square@primary
 3          spans     ALL
 

--- a/pkg/sql/testdata/needed_columns
+++ b/pkg/sql/testdata/needed_columns
@@ -109,7 +109,7 @@ query ITTTTT
 EXPLAIN(METADATA) SELECT 1 FROM kv
 ----
 0   render                         ("1")
-1   scan                           (k[omitted], v[omitted])   +k,unique
+1   scan                           (k[omitted], v[omitted])
 1            table   kv@primary
 1            spans   ALL
 
@@ -119,7 +119,7 @@ EXPLAIN (METADATA) SELECT DISTINCT v FROM kv;
 ----
 0  distinct                     (v)
 1  render                       (v)
-2  scan                         (k[omitted], v)  +k,unique
+2  scan                         (k[omitted], v)
 2            table  kv@primary
 2            spans  ALL
 
@@ -139,8 +139,8 @@ EXPLAIN (METADATA) DELETE FROM kv WHERE k = 3
 ----
 0   delete                         ()
 0            from    kv
-1   render                         (k)               +k,unique
-2   scan                           (k, v[omitted])   +k,unique
+1   render                         (k)
+2   scan                           (k, v[omitted])
 2            table   kv@primary
 2            spans   /3-/4
 
@@ -163,6 +163,6 @@ EXPLAIN (VERBOSE) SELECT 1 FROM (SELECT k+1 AS x, v-2 AS y FROM kv)
 ----
 0  render                        ("1")
 0          render 0  1
-1  scan                          (k[omitted], v[omitted])  +k,unique
+1  scan                          (k[omitted], v[omitted])
 1          table     kv@primary
 1          spans     ALL

--- a/pkg/sql/testdata/order_by
+++ b/pkg/sql/testdata/order_by
@@ -297,7 +297,7 @@ EXPLAIN(METADATA) SELECT b+2 FROM t ORDER BY b+2
 0  sort                      ("b + 2")                    +"b + 2"
 0          order  +"b + 2"
 1  render                    ("b + 2")
-2  scan                      (a[omitted], b, c[omitted])  +a,unique
+2  scan                      (a[omitted], b, c[omitted])
 2          table  t@primary
 2          spans  ALL
 
@@ -308,7 +308,7 @@ EXPLAIN(METADATA) SELECT b+2 AS y FROM t ORDER BY y
 0  sort                      (y)                          +y
 0          order  +y
 1  render                    (y)
-2  scan                      (a[omitted], b, c[omitted])  +a,unique
+2  scan                      (a[omitted], b, c[omitted])
 2          table  t@primary
 2          spans  ALL
 
@@ -319,7 +319,7 @@ EXPLAIN(METADATA) SELECT b+2 AS y FROM t ORDER BY b+2
 0  sort                      (y)                          +y
 0          order  +y
 1  render                    (y)
-2  scan                      (a[omitted], b, c[omitted])  +a,unique
+2  scan                      (a[omitted], b, c[omitted])
 2          table  t@primary
 2          spans  ALL
 
@@ -653,7 +653,7 @@ EXPLAIN (METADATA) DELETE FROM t WHERE a = 3 RETURNING b
 ----
 0  delete                    (b)
 0          from   t
-1  scan                      (a, b, c)  +a,unique
+1  scan                      (a, b, c)
 1          table  t@primary
 1          spans  /3-/4
 
@@ -663,8 +663,8 @@ EXPLAIN (METADATA) UPDATE t SET c = TRUE RETURNING b
 0  update                    (b)
 0          table  t
 0          set    c
-1  render                    (a, b, c, "true")  +a,unique
-2  scan                      (a, b, c)          +a,unique
+1  render                    (a, b, c, "true")
+2  scan                      (a, b, c)
 2          table  t@primary
 2          spans  ALL
 
@@ -686,6 +686,6 @@ query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT y, w, x FROM uvwxyz WHERE y = 1 ORDER BY w) ORDER BY w, x
 ----
 0  render                      (y, w, x)                                                             =y,+w,+x
-1  scan                        (u[omitted], v[omitted], w, x, y, z[omitted], rowid[hidden,omitted])  =y,+w,+x,+z,+u,+v,+rowid,unique
+1  scan                        (u[omitted], v[omitted], w, x, y, z[omitted], rowid[hidden,omitted])  =y,+w,+x
 1          table  uvwxyz@ywxz
 1          spans  /1-/2

--- a/pkg/sql/testdata/ordinal_references
+++ b/pkg/sql/testdata/ordinal_references
@@ -53,7 +53,7 @@ EXPLAIN(VERBOSE) SELECT b, a FROM foo ORDER BY @1
 1  render                         (b, a)
 1          render 0  test.foo.b
 1          render 1  test.foo.a
-2  scan                           (a, b, rowid[hidden,omitted])  +rowid,unique
+2  scan                           (a, b, rowid[hidden,omitted])
 2          table     foo@primary
 2          spans     ALL
 
@@ -87,7 +87,7 @@ EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1;
 1  render                                (a, a)
 1          render 0     test.foo.a
 1          render 1     test.foo.a
-2  scan                                  (a, b[omitted], rowid[hidden,omitted])  +rowid,unique
+2  scan                                  (a, b[omitted], rowid[hidden,omitted])
 2          table        foo@primary
 2          spans        ALL
 
@@ -100,7 +100,7 @@ EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2;
 1  render                                (a, b)
 1          render 0     test.foo.a
 1          render 1     test.foo.b
-2  scan                                  (a, b, rowid[hidden,omitted])  +rowid,unique
+2  scan                                  (a, b, rowid[hidden,omitted])
 2          table        foo@primary
 2          spans        ALL
 

--- a/pkg/sql/testdata/select_non_covering_index_filtering
+++ b/pkg/sql/testdata/select_non_covering_index_filtering
@@ -125,11 +125,11 @@ EXPLAIN(VERBOSE) SELECT a FROM t WHERE b = 2 OR ((b BETWEEN 2 AND 1) AND ((s != 
 ----
 0  render                           (a)
 0              render 0  test.t.a
-1  index-join                       (a, b[omitted], c[omitted], s[omitted])  +b,+c,+a,unique
-2  scan                             (a, b[omitted], c[omitted], s[omitted])  +b,+c,+a,unique
+1  index-join                       (a, b[omitted], c[omitted], s[omitted])
+2  scan                             (a, b[omitted], c[omitted], s[omitted])
 2              table     t@bc
 2              spans     /2-/3
-2  scan                             (a, b[omitted], c[omitted], s[omitted])  +a,unique
+2  scan                             (a, b[omitted], c[omitted], s[omitted])
 2              table     t@primary
 
 query I

--- a/pkg/sql/testdata/subquery
+++ b/pkg/sql/testdata/subquery
@@ -342,13 +342,13 @@ true
 query ITTTTT
 EXPLAIN(METADATA) SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz);
 ----
-0  render                           (x)                          +x,unique
-1  scan                             (x, y[omitted], z[omitted])  +x,unique
+0  render                           (x)
+1  scan                             (x, y[omitted], z[omitted])
 1          table       xyz@primary
 1          spans       ALL
 1          subqueries  1
-2  render                           (x)                          +x,unique
-3  scan                             (x, y[omitted], z[omitted])  +x,unique
+2  render                           (x)
+3  scan                             (x, y[omitted], z[omitted])
 3          table       xyz@primary
 3          spans       ALL
 

--- a/pkg/sql/testdata/window
+++ b/pkg/sql/testdata/window
@@ -522,13 +522,13 @@ EXPLAIN (TYPES) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) 
 1          window 1  (variance((d)[decimal]) OVER w)[decimal]
 1          render 1  (stddev((d)[decimal]) OVER w)[decimal]
 1          render 2  (variance((d)[decimal]) OVER w)[decimal]
-2  render                                                      (k int, d decimal, d decimal, v int, v int)                                                      +k,unique
+2  render                                                      (k int, d decimal, d decimal, v int, v int)
 2          render 0  (k)[int]
 2          render 1  (d)[decimal]
 2          render 2  (d)[decimal]
 2          render 3  (v)[int]
 2          render 4  (v)[int]
-3  scan                                                        (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  +k,unique
+3  scan                                                        (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)
 3          table     kv@primary
 3          spans     ALL
 
@@ -542,7 +542,7 @@ EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY 
 1          window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]
 1          render 1  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
 1          render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]
-2  render                                                                                         (k int, d decimal, d decimal, v int, "'a'" string, v int, "100" int)                                       +k,unique
+2  render                                                                                         (k int, d decimal, d decimal, v int, "'a'" string, v int, "100" int)
 2          render 0  (k)[int]
 2          render 1  (d)[decimal]
 2          render 2  (d)[decimal]
@@ -550,7 +550,7 @@ EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY 
 2          render 4  ('a')[string]
 2          render 5  (v)[int]
 2          render 6  (100)[int]
-3  scan                                                                                           (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)            +k,unique
+3  scan                                                                                           (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)
 3          table     kv@primary
 3          spans     ALL
 
@@ -562,12 +562,12 @@ EXPLAIN (TYPES,NONORMALIZE) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM 
 1  window                                                                                         (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)
 1          window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
 1          render 1  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
-2  render                                                                                         (k int, d decimal, v int, "'a'" string)                                                          +k,unique
+2  render                                                                                         (k int, d decimal, v int, "'a'" string)
 2          render 0  (k)[int]
 2          render 1  (d)[decimal]
 2          render 2  (v)[int]
 2          render 3  ('a')[string]
-3  scan                                                                                           (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  +k,unique
+3  scan                                                                                           (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)
 3          table     kv@primary
 3          spans     ALL
 
@@ -581,7 +581,7 @@ EXPLAIN (TYPES) SELECT k, k + stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER
 1          window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]
 1          render 1  ((k)[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]
 1          render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]
-2  render                                                                                                               (k int, d decimal, d decimal, v int, "'a'" string, v int, "100" int, k int)                                    +k,unique
+2  render                                                                                                               (k int, d decimal, d decimal, v int, "'a'" string, v int, "100" int, k int)
 2          render 0  (k)[int]
 2          render 1  (d)[decimal]
 2          render 2  (d)[decimal]
@@ -590,7 +590,7 @@ EXPLAIN (TYPES) SELECT k, k + stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER
 2          render 5  (v)[int]
 2          render 6  (100)[int]
 2          render 7  (k)[int]
-3  scan                                                                                                                 (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)                +k,unique
+3  scan                                                                                                                 (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)
 3          table     kv@primary
 3          spans     ALL
 


### PR DESCRIPTION
A separate recursion after expand plan is used to "trim" down the orderings of
nodes to more specific "useful" orderings. This makes a difference for DistSQL,
where maintaining order between parallel streams is not free.

Fixes #10779.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13577)
<!-- Reviewable:end -->
