### PR TITLE
util/log: add HasSpanOrEvent

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -1137,7 +1137,9 @@ func (ds *DistSender) sendToReplicas(
 
 	// Send the first request.
 	pending := 1
-	log.VEventf(ctx, 2, "sending batch %s to range %d", args.Summary(), rangeID)
+	if log.V(2) || log.HasSpanOrEvent(ctx) {
+		log.VEventf(ctx, 2, "sending batch %s to range %d", args.Summary(), rangeID)
+	}
 	transport.SendNext(ctx, done)
 
 	// Wait for completions. This loop will retry operations that fail

--- a/pkg/kv/range_iter.go
+++ b/pkg/kv/range_iter.go
@@ -143,7 +143,9 @@ func (ri *RangeIterator) Next(ctx context.Context) {
 
 // Seek positions the iterator at the specified key.
 func (ri *RangeIterator) Seek(ctx context.Context, key roachpb.RKey, scanDir ScanDirection) {
-	log.Eventf(ctx, "querying next range at %s", key)
+	if log.HasSpanOrEvent(ctx) {
+		log.Eventf(ctx, "querying next range at %s", key)
+	}
 	ri.scanDir = scanDir
 	ri.init = true // the iterator is now initialized
 	ri.pErr = nil  // clear any prior error

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -806,7 +806,9 @@ func (n *Node) batchInternal(
 		defer func(br **roachpb.BatchResponse) {
 			finishSpan(*br)
 		}(&br)
-		log.Event(ctx, args.Summary())
+		if log.HasSpanOrEvent(ctx) {
+			log.Event(ctx, args.Summary())
+		}
 
 		tStart := timeutil.Now()
 		var pErr *roachpb.Error

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -861,7 +861,9 @@ func (e *Executor) execStmtsInCurrentTxn(
 
 	for i, stmt := range stmts {
 		ctx := planMaker.session.Ctx()
-		log.VEventf(ctx, 2, "executing %d/%d: %s", i+1, len(stmts), stmt)
+		if log.V(2) || log.HasSpanOrEvent(ctx) {
+			log.VEventf(ctx, 2, "executing %d/%d: %s", i+1, len(stmts), stmt)
+		}
 		txnState.schemaChangers.curStatementIdx = i
 
 		var stmtStrBefore string

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1434,7 +1434,7 @@ func golangFillQueryArguments(pinfo *parser.PlaceholderInfo, args []interface{})
 	pinfo.Clear()
 
 	for i, arg := range args {
-		k := fmt.Sprint(i + 1)
+		k := strconv.Itoa(i + 1)
 		if arg == nil {
 			pinfo.SetValue(k, parser.DNull)
 			continue

--- a/pkg/sql/mon/mem_usage.go
+++ b/pkg/sql/mon/mem_usage.go
@@ -551,8 +551,10 @@ func (mm *MemoryMonitor) increaseBudget(ctx context.Context, minExtra int64) err
 			mm.name, minExtra, mm.reserved.curAllocated)
 	}
 	minExtra = mm.roundSize(minExtra)
-	log.VEventf(ctx, 2, "%s: requesting %d bytes from the pool",
-		mm.name, minExtra)
+	if log.V(2) || log.HasSpanOrEvent(ctx) {
+		log.VEventf(ctx, 2, "%s: requesting %d bytes from the pool",
+			mm.name, minExtra)
+	}
 
 	return mm.pool.GrowAccount(ctx, &mm.mu.curBudget, minExtra)
 }
@@ -568,7 +570,10 @@ func (mm *MemoryMonitor) roundSize(sz int64) int64 {
 // pool.
 func (mm *MemoryMonitor) releaseBudget(ctx context.Context) {
 	// NB: mm.mu need not be locked here, as this is only called from StopMonitor().
-	log.VEventf(ctx, 2, "%s: releasing %d bytes to the pool", mm.name, mm.mu.curBudget.curAllocated)
+	if log.V(2) || log.HasSpanOrEvent(ctx) {
+		log.VEventf(ctx, 2, "%s: releasing %d bytes to the pool",
+			mm.name, mm.mu.curBudget.curAllocated)
+	}
 	mm.pool.ClearAccount(ctx, &mm.mu.curBudget)
 }
 

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -532,7 +532,7 @@ func (c *v3Conn) handleParse(ctx context.Context, buf *readBuffer) error {
 		if !ok {
 			return c.sendInternalError(fmt.Sprintf("unknown oid type: %v", t))
 		}
-		sqlTypeHints[fmt.Sprint(i+1)] = v
+		sqlTypeHints[strconv.Itoa(i+1)] = v
 	}
 	// Create the new PreparedStatement in the connection's Session.
 	stmt, err := c.session.PreparedStatements.New(ctx, c.executor, name, query, sqlTypeHints)
@@ -709,7 +709,7 @@ func (c *v3Conn) handleBind(buf *readBuffer) error {
 		if err != nil {
 			return err
 		}
-		k := fmt.Sprint(i + 1)
+		k := strconv.Itoa(i + 1)
 		if int32(plen) == -1 {
 			// The argument is a NULL value.
 			qargs[k] = parser.DNull

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2429,7 +2429,7 @@ func (s *Store) Send(
 
 	if log.V(1) {
 		log.Eventf(ctx, "executing %s", ba)
-	} else {
+	} else if log.HasSpanOrEvent(ctx) {
 		log.Eventf(ctx, "executing %d requests", len(ba.Requests))
 	}
 	// Backoff and retry loop for handling errors. Backoff times are measured

--- a/pkg/util/log/trace.go
+++ b/pkg/util/log/trace.go
@@ -203,3 +203,10 @@ func VEventf(ctx context.Context, level level, format string, args ...interface{
 		eventInternal(ctx, false /*isErr*/, true /*withTags*/, format, args...)
 	}
 }
+
+// HasSpanOrEvent returns true if the context has a span or event that should
+// be logged to.
+func HasSpanOrEvent(ctx context.Context) bool {
+	_, _, ok := getSpanOrEventLog(ctx)
+	return ok
+}


### PR DESCRIPTION
Add log.HasSpanOrEvent which returns true if the supplied context has a
span or event that needs to be logged to. Used in a handful of hot code
paths to avoid unnecessary formatting and allocations (e.g. calls to
BatchRequest.Summary).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13578)
<!-- Reviewable:end -->
