### PR TITLE
util/log: handle common case in log.mergeChains

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -833,7 +833,10 @@ func (n *Node) Batch(
 ) (*roachpb.BatchResponse, error) {
 	growStack()
 
-	ctx = n.AnnotateCtx(ctx)
+	// NB: Node.Batch is called directly for "local" calls. We don't want to
+	// carry the associated log tags forward as doing so makes adding additional
+	// log tags more expensive and makes local calls differ from remote calls.
+	ctx = n.storeCfg.AmbientCtx.ResetAndAnnotateCtx(ctx)
 
 	br, err := n.batchInternal(ctx, args)
 

--- a/pkg/util/log/ambient_context.go
+++ b/pkg/util/log/ambient_context.go
@@ -140,6 +140,29 @@ func (ac *AmbientContext) AnnotateCtx(ctx context.Context) context.Context {
 	}
 }
 
+// ResetAndAnnotateCtx annotates a given context with the information in
+// AmbientContext, but unlike AnnotateCtx, it drops all log tags in the
+// supplied context before adding the ones from the AmbientContext.
+func (ac *AmbientContext) ResetAndAnnotateCtx(ctx context.Context) context.Context {
+	switch ctx {
+	case context.TODO(), context.Background():
+		// NB: context.TODO and context.Background are identical except for their
+		// names.
+		if ac.backgroundCtx != nil {
+			return ac.backgroundCtx
+		}
+		return ctx
+	default:
+		if ac.eventLog != nil && opentracing.SpanFromContext(ctx) == nil && eventLogFromCtx(ctx) == nil {
+			ctx = embedCtxEventLog(ctx, ac.eventLog)
+		}
+		if ac.tags != nil {
+			ctx = context.WithValue(ctx, contextTagKeyType{}, ac.tags)
+		}
+		return ctx
+	}
+}
+
 func (ac *AmbientContext) annotateCtxInternal(ctx context.Context) context.Context {
 	if ac.eventLog != nil && opentracing.SpanFromContext(ctx) == nil && eventLogFromCtx(ctx) == nil {
 		ctx = embedCtxEventLog(ctx, ac.eventLog)

--- a/pkg/util/log/ambient_context_test.go
+++ b/pkg/util/log/ambient_context_test.go
@@ -84,3 +84,36 @@ func TestAnnotateCtxSpan(t *testing.T) {
 		t.Errorf("expected events '%s', got '%v'", expected, traceEv)
 	}
 }
+
+func TestAnnotateCtxNodeStoreReplica(t *testing.T) {
+	// Test the scenario of a context being continually re-annotated as it is
+	// passed down a call stack.
+	n := AmbientContext{}
+	n.AddLogTagInt("n", 1)
+	s := n
+	s.AddLogTagInt("s", 2)
+	r := s
+	r.AddLogTagInt("r", 3)
+
+	ctx := n.AnnotateCtx(context.Background())
+	ctx = s.AnnotateCtx(ctx)
+	ctx = r.AnnotateCtx(ctx)
+	if exp, val := "[n1,s2,r3] test", makeMessage(ctx, "test", nil); val != exp {
+		t.Errorf("expected '%s', got '%s'", exp, val)
+	}
+	if bottom := contextBottomTag(ctx); bottom != r.tags {
+		t.Errorf("expected %p, got %p", r.tags, bottom)
+	}
+}
+
+func TestResetAndAnnotateCtx(t *testing.T) {
+	ac := AmbientContext{}
+	ac.AddLogTagInt("a", 1)
+
+	ctx := context.Background()
+	ctx = WithLogTag(ctx, "b", 2)
+	ctx = ac.ResetAndAnnotateCtx(ctx)
+	if exp, val := "[a1] test", makeMessage(ctx, "test", nil); val != exp {
+		t.Errorf("expected '%s', got '%s'", exp, val)
+	}
+}

--- a/pkg/util/log/log_context.go
+++ b/pkg/util/log/log_context.go
@@ -142,6 +142,13 @@ func augmentTagChain(ctx context.Context, bottomTag *logTag) context.Context {
 // - copying c2
 // - linking c2's copy in front of what's left of c1
 func mergeChains(c1 *logTag, c2 *logTag) *logTag {
+	// Check to see if c1 is already included in c2.
+	for t := c2; t != nil; t = t.parent {
+		if t == c1 {
+			return c2
+		}
+	}
+
 	c1 = subtractChain(c1, c2)
 	bottom, top := copyChain(c2, nil)
 	top.parent = c1


### PR DESCRIPTION
The server and storage packages use a series of 3 ambient contexts:
Node.AmbientContext, Store.AmbientContext and
Replica.AmbientContext. Replica.AmbientContext shares all of the log
tags with Store.AmbientContext which in turn inherits from
Node.AmbientContext. We then annotate RPC contexts 3 times: in
Node.Batch, Store.Send and Replica.Send. Optimize this case by noticing
in mergeChains when the new chain has the old chain as a parent. This
reduces total allocations in a write-only workload by 2%.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13579)
<!-- Reviewable:end -->
