### PR TITLE
kubernetes: Remove probes to fix recovery from all nodes going down

### DIFF
--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -147,16 +147,6 @@ spec:
           name: grpc
         - containerPort: 8080
           name: http
-        livenessProbe:
-          httpGet:
-            path: /_admin/v1/health
-            port: http
-          initialDelaySeconds: 30
-        readinessProbe:
-          httpGet:
-            path: /_admin/v1/health
-            port: http
-          initialDelaySeconds: 10
         volumeMounts:
         - name: datadir
           mountPath: /cockroach/cockroach-data


### PR DESCRIPTION
This is due to a bad interaction between our health check considering
a node unhealthy if it's in a minority partition and the kubernetes
statefulset logic of bringing each pod up one at a time and waiting
until each is healthy before moving on. More detailed explanation in
https://github.com/kubernetes/test-infra/issues/1740#issuecomment-279555187

The gist of the problem is that if a majority of nodes are brought down, they'll never come back up without this change.

We could alternatively switch to a different endpoint that would at least indicate that our server is responsive, but most of our server endpoints just 404 until the node is done with migrations and properly up-and-running, so just removing the probes seems reasonable to me. If anyone prefers, I can switch this over to something else.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13580)
<!-- Reviewable:end -->
