### PR TITLE
server: Serve UI endpoints while waiting for migrations to run

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -677,19 +677,6 @@ func (s *Server) Start(ctx context.Context) error {
 
 	s.nodeLiveness.StartHeartbeat(ctx, s.stopper)
 
-	// Before serving SQL requests, we have to make sure the database is
-	// in an acceptable form for this version of the software.
-	// We have to do this after actually starting up the server to be able to
-	// seamlessly use the kv client against other nodes in the cluster.
-	migMgr := migrations.NewManager(
-		s.stopper, s.db, s.sqlExecutor, s.clock, s.NodeID().String())
-	if err := migMgr.EnsureMigrations(ctx); err != nil {
-		log.Fatal(ctx, err)
-	}
-	log.Infof(ctx, "done ensuring all necessary migrations have run")
-	close(serveSQL)
-	log.Info(ctx, "serving sql connections")
-
 	// Initialize grpc-gateway mux and context.
 	jsonpb := &protoutil.JSONPb{
 		EnumsAsInts:  true,
@@ -751,6 +738,19 @@ func (s *Server) Start(ctx context.Context) error {
 	s.mux.Handle("/health", gwMux)
 	s.mux.Handle(statusVars, http.HandlerFunc(s.status.handleVars))
 	log.Event(ctx, "added http endpoints")
+
+	// Before serving SQL requests, we have to make sure the database is
+	// in an acceptable form for this version of the software.
+	// We have to do this after actually starting up the server to be able to
+	// seamlessly use the kv client against other nodes in the cluster.
+	migMgr := migrations.NewManager(
+		s.stopper, s.db, s.sqlExecutor, s.clock, s.NodeID().String())
+	if err := migMgr.EnsureMigrations(ctx); err != nil {
+		log.Fatal(ctx, err)
+	}
+	log.Infof(ctx, "done ensuring all necessary migrations have run")
+	close(serveSQL)
+	log.Info(ctx, "serving sql connections")
 
 	if err := sdnotify.Ready(); err != nil {
 		log.Errorf(ctx, "failed to signal readiness using systemd protocol: %s", err)


### PR DESCRIPTION
It was annoying that the debug endpoints weren't available if something
was going wrong with migrations.

This seemed to work fine both on servers blocked on migrations and in the normal case where they run quickly, but are you aware of any potential issues with this, @tamird?

This would also allow us more freedom in picking a different liveness probe endpoint for kubernetes if we want (#13580).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13581)
<!-- Reviewable:end -->
