### PR TITLE
sqlccl: use WriteBatch command in Restore implementation

### DIFF
--- a/pkg/ccl/sqlccl/backup.go
+++ b/pkg/ccl/sqlccl/backup.go
@@ -286,62 +286,52 @@ func Import(
 	kr storageccl.KeyRewriter,
 ) error {
 	if log.V(1) {
-		log.Infof(ctx, "Import %s-%s (%d files)", startKey, endKey, len(files))
+		log.Infof(ctx, "import %s-%s (%d files)", startKey, endKey, len(files))
 	}
 	if len(files) == 0 {
 		return nil
 	}
 
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	// Arrived at by tuning and watching the effect on BenchmarkRestore.
 	const batchSizeBytes = 1000000
 
-	b := &client.Batch{}
-	var v roachpb.Value
-	bytes := 0
-
-	writeBatch := func() error {
-		if err := db.Run(ctx, b); err != nil {
-			return err
+	var wg util.WaitGroupWithError
+	b := struct {
+		engine.RocksDBBatchBuilder
+		batchStartKey []byte
+		batchEndKey   []byte
+	}{}
+	sendWriteBatch := func() {
+		batchStartKey := roachpb.Key(b.batchStartKey)
+		// The end key of the WriteBatch request is exclusive, but batchEndKey
+		// is currently the largest key in the batch. Increment it.
+		batchEndKey := roachpb.Key(b.batchEndKey).Next()
+		if log.V(1) {
+			log.Infof(ctx, "writebatch %s-%s", batchStartKey, batchEndKey)
 		}
-		b = &client.Batch{}
-		bytes = 0
-		return nil
-	}
 
-	importFunc := func(kv engine.MVCCKeyValue) (bool, error) {
-		var ok bool
-		kv.Key.Key, ok = kr.RewriteKey(append([]byte(nil), kv.Key.Key...))
-		if !ok {
-			// If the key rewriter didn't match this key, it's not data for the
-			// table(s) we're interested in.
-			if log.V(3) {
-				log.Infof(ctx, "skipping %s\n", kv.Key.Key)
+		wg.Add(1)
+		go func(start, end roachpb.Key, repr []byte) {
+			if err := db.WriteBatch(ctx, start, end, repr); err != nil {
+				log.Errorf(ctx, "writebatch %s-%s: %+v", start, end, err)
+				wg.Done(err)
+				cancel()
+				return
 			}
-			return false, nil
-		}
-
-		// Rewriting the key means the checksum needs to be updated.
-		v = roachpb.Value{RawBytes: kv.Value}
-		v.ClearChecksum()
-
-		if log.V(3) {
-			log.Infof(ctx, "Put %s %s\n", kv.Key.Key, v.PrettyPrint())
-		}
-		b.CPut(kv.Key.Key, &v, nil)
-		bytes += len(kv.Key.Key) + len(v.RawBytes)
-		if bytes > batchSizeBytes {
-			if err := writeBatch(); err != nil {
-				return false, err
-			}
-		}
-
-		return false, nil
+			wg.Done(nil)
+		}(batchStartKey, batchEndKey, b.Finish())
+		b.batchStartKey = nil
+		b.batchEndKey = nil
+		b.RocksDBBatchBuilder = engine.RocksDBBatchBuilder{}
 	}
 
 	startKeyMVCC, endKeyMVCC := engine.MVCCKey{Key: startKey}, engine.MVCCKey{Key: endKey}
 	for _, file := range files {
 		if log.V(1) {
-			log.Infof(ctx, "Import %s-%s %s\n", startKey, endKey, file.Path)
+			log.Infof(ctx, "import file %s-%s %s", startKey, endKey, file.Path)
 		}
 
 		dir, err := storageccl.MakeExportStorage(ctx, file.Dir)
@@ -368,18 +358,57 @@ func Import(
 			return err
 		}
 
-		if err := sst.Iterate(startKeyMVCC, endKeyMVCC, importFunc); err != nil {
+		iter := sst.NewIterator(false)
+		defer iter.Close()
+		iter.Seek(startKeyMVCC)
+		for ; iter.Valid(); iter.Next() {
+			key := iter.Key()
+			if endKeyMVCC.Less(key) {
+				break
+			}
+			value := roachpb.Value{RawBytes: iter.Value()}
+
+			var ok bool
+			key.Key, ok = kr.RewriteKey(key.Key)
+			if !ok {
+				// If the key rewriter didn't match this key, it's not data for the
+				// table(s) we're interested in.
+				if log.V(3) {
+					log.Infof(ctx, "skipping %s %s", key.Key, value.PrettyPrint())
+				}
+				continue
+			}
+
+			// Rewriting the key means the checksum needs to be updated.
+			value.ClearChecksum()
+			value.InitChecksum(key.Key)
+
+			if log.V(3) {
+				log.Infof(ctx, "Put %s -> %s", key.Key, value.PrettyPrint())
+			}
+			b.Put(key, value.RawBytes)
+
+			// Update the range currently represented in this batch, as
+			// necessary.
+			if len(b.batchStartKey) == 0 {
+				b.batchStartKey = append(b.batchStartKey, key.Key...)
+			}
+			b.batchEndKey = append(b.batchEndKey[:0], key.Key...)
+
+			if b.Len() > batchSizeBytes {
+				sendWriteBatch()
+			}
+		}
+		if err := iter.Error(); err != nil {
 			return err
 		}
 	}
-
-	if bytes > 0 {
-		if err := writeBatch(); err != nil {
-			return err
-		}
+	// Flush out the last batch.
+	if b.Len() > 0 {
+		sendWriteBatch()
 	}
 
-	return nil
+	return wg.Wait()
 }
 
 func assertDatabasesExist(

--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
@@ -143,6 +144,10 @@ func backupRestoreTestSetup(
 
 func TestBackupRestoreLocal(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	if !storage.ProposerEvaluatedKVEnabled() {
+		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
+	}
+
 	// TODO(dan): Actually invalidate the descriptor cache and delete this line.
 	defer sql.TestDisableTableLeases()()
 	const numAccounts = 1000
@@ -190,6 +195,9 @@ func TestBackupRestoreS3(t *testing.T) {
 // occasionally be flaky. It's only run if the GS_BUCKET environment var is set.
 func TestBackupRestoreGoogleCloudStorage(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	if !storage.ProposerEvaluatedKVEnabled() {
+		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
+	}
 
 	bucket := os.Getenv("GS_BUCKET")
 	if bucket == "" {
@@ -215,6 +223,9 @@ func TestBackupRestoreGoogleCloudStorage(t *testing.T) {
 // AZURE_ACCOUNT_KEY environment vars are set.
 func TestBackupRestoreAzure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	if !storage.ProposerEvaluatedKVEnabled() {
+		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
+	}
 
 	accountName := os.Getenv("AZURE_ACCOUNT_NAME")
 	accountKey := os.Getenv("AZURE_ACCOUNT_KEY")
@@ -284,6 +295,10 @@ func backupAndRestore(
 
 func TestBackupRestoreInterleaved(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	if !storage.ProposerEvaluatedKVEnabled() {
+		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
+	}
+
 	// TODO(dan): Actually invalidate the descriptor cache and delete this line.
 	defer sql.TestDisableTableLeases()()
 	const numAccounts = 10
@@ -393,6 +408,10 @@ func startBankTransfers(stopper *stop.Stopper, sqlDB *gosql.DB, numAccounts int)
 func TestBackupRestoreBank(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	t.Skip("#13189")
+	if !storage.ProposerEvaluatedKVEnabled() {
+		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
+	}
+
 	// TODO(dan): Actually invalidate the descriptor cache and delete this line.
 	defer sql.TestDisableTableLeases()()
 
@@ -478,6 +497,10 @@ func TestBackupRestoreBank(t *testing.T) {
 func TestBackupAsOfSystemTime(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	t.Skip("#13575")
+	if !storage.ProposerEvaluatedKVEnabled() {
+		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
+	}
+
 	// TODO(dan): Actually invalidate the descriptor cache and delete this line.
 	defer sql.TestDisableTableLeases()()
 	const numAccounts = 1000

--- a/pkg/storage/engine/batch.go
+++ b/pkg/storage/engine/batch.go
@@ -87,6 +87,11 @@ func (b *RocksDBBatchBuilder) Finish() []byte {
 	return repr
 }
 
+// Len returns the number of bytes currently in the under construction repr.
+func (b *RocksDBBatchBuilder) Len() int {
+	return len(b.repr)
+}
+
 // getRepr constructs the batch representation and returns it.
 func (b *RocksDBBatchBuilder) getRepr() []byte {
 	b.maybeInit()

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1615,6 +1615,11 @@ func (fr *RocksDBSstFileReader) Iterate(
 	return fr.rocksDB.Iterate(start, end, f)
 }
 
+// NewIterator returns an iterator over this sst reader.
+func (fr *RocksDBSstFileReader) NewIterator(prefix bool) Iterator {
+	return newRocksDBIterator(fr.rocksDB.rdb, prefix, fr.rocksDB)
+}
+
 // Close finishes the reader.
 func (fr *RocksDBSstFileReader) Close() {
 	if fr.rocksDB == nil {


### PR DESCRIPTION
This is performance work, no (intended) behavior change. The WriteBatch
command allows us to send a batch of Puts at once without all the
serializations & deserializations that would usually happen along the
way.

```
name              old time/op    new time/op     delta
ClusterRestore-8    14.1µs ±20%      7.4µs ±14%  -47.32%  (p=0.008 n=5+5)

name              old speed      new speed       delta
ClusterRestore-8  8.29MB/s ±23%  15.58MB/s ±13%  +87.93%  (p=0.008 n=5+5)

name              old alloc/op   new alloc/op    delta
ClusterRestore-8    19.2kB ± 2%      7.2kB ± 4%  -62.60%  (p=0.016 n=4+5)

name              old allocs/op  new allocs/op   delta
ClusterRestore-8      20.0 ±15%        3.0 ± 0%  -85.00%  (p=0.029 n=4+4)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13586)
<!-- Reviewable:end -->
