### PR TITLE
distsqlrun: remove BackfillChunkSize from distsql testing knobs

### DIFF
--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -219,9 +219,6 @@ type TestingKnobs struct {
 	// executing the chunk. It is always called even when the backfill
 	// function returns an error, or if the table has already been dropped.
 	RunAfterBackfillChunk func()
-
-	// BackfillChunkSize is to be used for all backfill chunked operations.
-	BackfillChunkSize int64
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -542,6 +542,7 @@ func TestRaceWithBackfill(t *testing.T) {
 				return nil
 			},
 			AsyncExecNotification: asyncSchemaChangerDisabled,
+			BackfillChunkSize:     chunkSize,
 		},
 		DistSQL: &distsqlrun.TestingKnobs{
 			RunBeforeBackfillChunk: func(sp roachpb.Span) error {
@@ -558,7 +559,6 @@ func TestRaceWithBackfill(t *testing.T) {
 				}
 				return nil
 			},
-			BackfillChunkSize: chunkSize,
 		},
 	}
 
@@ -803,7 +803,6 @@ func TestAbortSchemaChangeBackfill(t *testing.T) {
 				// to commit and will abort.
 				<-commandsDone
 			},
-			BackfillChunkSize: maxValue,
 		},
 	}
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)
@@ -1278,7 +1277,6 @@ func TestSchemaChangePurgeFailure(t *testing.T) {
 				}
 				return nil
 			},
-			BackfillChunkSize: chunkSize,
 		},
 	}
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)


### PR DESCRIPTION
This is already defined in the SchemaChangerTestingKnobs
and was actually not being used.

Fix BackfillChunkSize misconfiguration in TestRaceWithBackfill

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13591)
<!-- Reviewable:end -->
