### PR TITLE
sqlccl: skip flaky BackupRestoreBank test

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -392,6 +392,7 @@ func startBankTransfers(stopper *stop.Stopper, sqlDB *gosql.DB, numAccounts int)
 
 func TestBackupRestoreBank(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("#13189")
 	// TODO(dan): Actually invalidate the descriptor cache and delete this line.
 	defer sql.TestDisableTableLeases()()
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13597)
<!-- Reviewable:end -->
