### PR TITLE
storage: reject range transfers when draining

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -397,7 +397,7 @@ func (n *Node) start(
 func (n *Node) IsDraining() bool {
 	var isDraining bool
 	if err := n.stores.VisitStores(func(s *storage.Store) error {
-		isDraining = isDraining || s.IsDrainingLeases()
+		isDraining = isDraining || s.IsDraining()
 		return nil
 	}); err != nil {
 		panic(err)
@@ -412,7 +412,7 @@ func (n *Node) IsDraining() bool {
 // lease acquisition and extensions.
 func (n *Node) SetDraining(drain bool) error {
 	return n.stores.VisitStores(func(s *storage.Store) error {
-		return s.DrainLeases(drain)
+		return s.SetDraining(drain)
 	})
 }
 

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -1032,7 +1032,7 @@ func TestRefreshPendingCommands(t *testing.T) {
 			for i := 0; i < 2; i++ {
 				wg.Add(1)
 				go func(i int) {
-					if err := mtc.stores[i].DrainLeases(true); err != nil {
+					if err := mtc.stores[i].SetDraining(true); err != nil {
 						wg.Done(errors.Wrapf(err, "store %d", i))
 						return
 					}
@@ -1042,13 +1042,13 @@ func TestRefreshPendingCommands(t *testing.T) {
 
 			// Wait for the stores 0 and 1 to have entered draining mode, and then
 			// advance the clock. Advancing the clock will leave the liveness records
-			// of draining nodes in an expired state, so the DrainLeases() call above
+			// of draining nodes in an expired state, so the SetDraining() call above
 			// will be able to terminate.
 			draining := false
 			for !draining {
 				draining = true
 				for i := 0; i < 2; i++ {
-					draining = draining && mtc.stores[i].IsDrainingLeases()
+					draining = draining && mtc.stores[i].IsDraining()
 				}
 			}
 			mtc.advanceClock(context.Background())

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -1108,7 +1108,7 @@ func (m *multiTestContext) waitForValues(key roachpb.Key, expected []int64) {
 func (m *multiTestContext) transferLease(
 	ctx context.Context, rangeID roachpb.RangeID, source int, dest int,
 ) {
-	live := m.stores[dest] != nil && !m.stores[dest].IsDrainingLeases()
+	live := m.stores[dest] != nil && !m.stores[dest].IsDraining()
 	if !live {
 		m.t.Fatalf("can't transfer lease to down or draining node at index %d", dest)
 	}

--- a/pkg/storage/replica_range_lease.go
+++ b/pkg/storage/replica_range_lease.go
@@ -402,7 +402,7 @@ func (r *Replica) requestLeaseLocked(ctx context.Context, status LeaseStatus) <-
 			newNotLeaseHolderError(&transferLease, r.store.StoreID(), r.mu.state.Desc))
 		return llChan
 	}
-	if r.store.IsDrainingLeases() {
+	if r.store.IsDraining() {
 		// We've retired from active duty.
 		llChan := make(chan *roachpb.Error, 1)
 		llChan <- roachpb.NewError(newNotLeaseHolderError(nil, r.store.StoreID(), r.mu.state.Desc))

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2726,6 +2726,13 @@ func (s *Store) reserveSnapshot(
 func (s *Store) HandleSnapshot(header *SnapshotRequest_Header, stream SnapshotResponseStream) error {
 	s.metrics.raftRcvdMessages[raftpb.MsgSnap].Inc(1)
 
+	if s.IsDraining() {
+		return stream.Send(&SnapshotResponse{
+			Status:  SnapshotResponse_DECLINED,
+			Message: "store is draining",
+		})
+	}
+
 	ctx := s.AnnotateCtx(stream.Context())
 	cleanup, err := s.reserveSnapshot(ctx, header)
 	if err != nil {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -433,13 +433,13 @@ type Store struct {
 	// being restarted.
 	rebalancesDisabled int32
 
-	// drainLeases holds a bool which indicates whether Replicas should be
-	// allowed to acquire or extend range leases; see DrainLeases().
+	// draining holds a bool which indicates whether this store is draining. See
+	// SetDraining() for a more detailed explanation of behavior changes.
 	//
 	// TODO(bdarnell,tschottdorf): Would look better inside of `mu`, which at
 	// the time of its creation was riddled with deadlock (but that situation
 	// has likely improved).
-	drainLeases atomic.Value
+	draining atomic.Value
 
 	// Locking notes: To avoid deadlocks, the following lock order must be
 	// obeyed: Replica.raftMu < Replica.readOnlyCmdMu < Store.mu < Replica.mu
@@ -894,7 +894,7 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 
 	s.intentResolver = newIntentResolver(s)
 	s.raftEntryCache = newRaftEntryCache(cfg.RaftEntryCacheSize)
-	s.drainLeases.Store(false)
+	s.draining.Store(false)
 	s.scheduler = newRaftScheduler(s.cfg.AmbientCtx, s.metrics, s, storeSchedulerConcurrency)
 
 	storeMuLogger := thresholdLogger(
@@ -981,13 +981,13 @@ func (s *Store) AnnotateCtxWithSpan(
 	return s.cfg.AmbientCtx.AnnotateCtxWithSpan(ctx, opName)
 }
 
-// DrainLeases (when called with 'true') prevents all of the Store's
+// SetDraining (when called with 'true') prevents all of the Store's
 // Replicas from acquiring or extending range leases and waits until all of
 // them have expired. If an error is returned, the draining state is still
 // active, but there may be active leases held by some of the Store's Replicas.
 // When called with 'false', returns to the normal mode of operation.
-func (s *Store) DrainLeases(drain bool) error {
-	s.drainLeases.Store(drain)
+func (s *Store) SetDraining(drain bool) error {
+	s.draining.Store(drain)
 	if !drain {
 		return nil
 	}
@@ -1810,9 +1810,9 @@ func (s *Store) Tracer() opentracing.Tracer { return s.cfg.AmbientCtx.Tracer }
 // TestingKnobs accessor.
 func (s *Store) TestingKnobs() *StoreTestingKnobs { return &s.cfg.TestingKnobs }
 
-// IsDrainingLeases accessor.
-func (s *Store) IsDrainingLeases() bool {
-	return s.drainLeases.Load().(bool)
+// IsDraining accessor.
+func (s *Store) IsDraining() bool {
+	return s.draining.Load().(bool)
 }
 
 // NewRangeDescriptor creates a new descriptor based on start and end


### PR DESCRIPTION
Draining stores now reject preemptive snapshots to avoid a possible loss
of quorum after the node shuts down.

`DrainLeases` and `IsDrainingLeases` have been renamed to `SetDraining`
and `IsDraining` to follow the general draining naming convention and because a
draining store does more than just drain leases now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13601)
<!-- Reviewable:end -->
