### PR TITLE
storage: Fix ConfChange error handling

### DIFF
--- a/pkg/internal/client/client_test.go
+++ b/pkg/internal/client/client_test.go
@@ -178,7 +178,7 @@ func TestClientRetryNonTxn(t *testing.T) {
 	args := base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &storage.StoreTestingKnobs{
-				TestingCommandFilter: filter,
+				TestingEvalFilter: filter,
 			},
 		},
 	}

--- a/pkg/kv/db_test.go
+++ b/pkg/kv/db_test.go
@@ -294,7 +294,7 @@ func TestTxnDelRangeIntentResolutionCounts(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			Store: &storage.StoreTestingKnobs{
 				NumKeysEvaluatedForRangeIntentResolution: &intentResolutionCount,
-				TestingCommandFilter: func(filterArgs storagebase.FilterArgs) *roachpb.Error {
+				TestingEvalFilter: func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 					req, ok := filterArgs.Req.(*roachpb.ResolveIntentRequest)
 					if ok {
 						key := req.Header().Key.String()

--- a/pkg/kv/dist_sender_server_test.go
+++ b/pkg/kv/dist_sender_server_test.go
@@ -1047,7 +1047,7 @@ func TestPropagateTxnOnError(t *testing.T) {
 	// get a ReadWithinUncertaintyIntervalError.
 	targetKey := roachpb.Key("b")
 	var numGets int32
-	storeKnobs.TestingCommandFilter =
+	storeKnobs.TestingEvalFilter =
 		func(fArgs storagebase.FilterArgs) *roachpb.Error {
 			_, ok := fArgs.Req.(*roachpb.ConditionalPutRequest)
 			if ok && fArgs.Req.Header().Key.Equal(targetKey) {

--- a/pkg/server/intent_test.go
+++ b/pkg/server/intent_test.go
@@ -84,7 +84,7 @@ func TestIntentResolution(t *testing.T) {
 			var mu syncutil.Mutex
 			closer := make(chan struct{}, 2)
 			var done bool
-			storeKnobs.TestingCommandFilter =
+			storeKnobs.TestingEvalFilter =
 				func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 					mu.Lock()
 					defer mu.Unlock()

--- a/pkg/sql/main_test.go
+++ b/pkg/sql/main_test.go
@@ -191,7 +191,7 @@ func createTestServerParams() (base.TestServerArgs, *CommandFilters) {
 	cmdFilters.AppendFilter(checkEndTransactionTrigger, true)
 	params := base.TestServerArgs{}
 	params.Knobs.Store = &storage.StoreTestingKnobs{
-		TestingCommandFilter: cmdFilters.runFilters,
+		TestingEvalFilter: cmdFilters.runFilters,
 	}
 	return params, &cmdFilters
 }

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -1148,7 +1148,7 @@ func TestReacquireLeaseOnRestart(t *testing.T) {
 	var clockUpdate int32
 	testKey := []byte("test_key")
 	testingKnobs := &storage.StoreTestingKnobs{
-		TestingCommandFilter:  cmdFilters.runFilters,
+		TestingEvalFilter:     cmdFilters.runFilters,
 		DisableMaxOffsetCheck: true,
 		ClockBeforeSend: func(c *hlc.Clock, ba roachpb.BatchRequest) {
 			if atomic.LoadInt32(&clockUpdate) > 0 {

--- a/pkg/sql/upsert_test.go
+++ b/pkg/sql/upsert_test.go
@@ -52,7 +52,7 @@ func TestUpsertFastPath(t *testing.T) {
 
 	s, conn, _ := serverutils.StartServer(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{Store: &storage.StoreTestingKnobs{
-			TestingCommandFilter: filter,
+			TestingEvalFilter: filter,
 		}},
 	})
 	defer s.Stopper().Stop()

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -3330,3 +3330,85 @@ func TestInitRaftGroupOnRequest(t *testing.T) {
 		t.Fatal("expected raft group to be initialized")
 	}
 }
+
+// TestFailedConfChange verifies correct behavior after a
+// configuration change experiences an error when applying
+// EndTransaction. Specifically, it verifies that
+// https://github.com/cockroachdb/cockroach/issues/13506 has been
+// fixed.
+func TestFailedConfChange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Trigger errors at apply time so they happen on both leaders and
+	// followers.
+	var filterActive int32
+	sc := storage.TestStoreConfig(nil)
+	sc.TestingKnobs.TestingApplyFilter = func(filterArgs storagebase.ApplyFilterArgs) *roachpb.Error {
+		if atomic.LoadInt32(&filterActive) == 1 && filterArgs.ChangeReplicas != nil {
+			return roachpb.NewErrorf("boom")
+		}
+		return nil
+	}
+	mtc := &multiTestContext{
+		storeConfig: &sc,
+	}
+	defer mtc.Stop()
+	mtc.Start(t, 3)
+	ctx := context.Background()
+
+	// Replicate the range (successfully) to the second node.
+	const rangeID = roachpb.RangeID(1)
+	mtc.replicateRange(rangeID, 1)
+
+	// Try and fail to replicate it to the third node.
+	atomic.StoreInt32(&filterActive, 1)
+	if err := mtc.replicateRangeNonFatal(rangeID, 2); !testutils.IsError(err, "boom") {
+		t.Fatal(err)
+	}
+
+	// Raft state is only exposed on the leader, so we must transfer
+	// leadership and check the stores one at a time.
+	checkLeaderStore := func(i int) error {
+		store := mtc.stores[i]
+		repl, err := store.GetReplica(rangeID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if l := len(repl.Desc().Replicas); l != 2 {
+			return errors.Errorf("store %d: expected 2 replicas in descriptor, found %d in %s",
+				i, l, repl.Desc())
+		}
+		status := repl.RaftStatus()
+		if status.RaftState != raft.StateLeader {
+			return errors.Errorf("store %d: expected StateLeader, was %s", i, status.RaftState)
+		}
+		// In issue #13506, the Progress map would be updated as if the
+		// change had succeeded.
+		if l := len(status.Progress); l != 2 {
+			return errors.Errorf("store %d: expected 2 replicas in raft, found %d in %s", i, l, status)
+		}
+		return nil
+	}
+
+	if err := checkLeaderStore(0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Transfer leadership to the second node and wait for it to become leader.
+	mtc.transferLease(ctx, rangeID, 0, 1)
+	testutils.SucceedsSoon(t, func() error {
+		repl, err := mtc.stores[1].GetReplica(rangeID)
+		if err != nil {
+			return err
+		}
+		status := repl.RaftStatus()
+		if status.RaftState != raft.StateLeader {
+			return errors.Errorf("store %d: expected StateLeader, was %s", 1, status.RaftState)
+		}
+		return nil
+	})
+
+	if err := checkLeaderStore(1); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/storage/client_replica_gc_test.go
+++ b/pkg/storage/client_replica_gc_test.go
@@ -47,7 +47,7 @@ func TestReplicaGCQueueDropReplicaDirect(t *testing.T) {
 	// waits for the first.
 	cfg := storage.TestStoreConfig(nil)
 	mtc.storeConfig = &cfg
-	mtc.storeConfig.TestingKnobs.TestingCommandFilter =
+	mtc.storeConfig.TestingKnobs.TestingEvalFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			et, ok := filterArgs.Req.(*roachpb.EndTransactionRequest)
 			if !ok || filterArgs.Sid != 2 {

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -188,7 +188,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 	defer stopper.Stop()
 	manual := hlc.NewManualClock(123)
 	cfg := storage.TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
-	cfg.TestingKnobs.TestingCommandFilter =
+	cfg.TestingKnobs.TestingEvalFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if _, ok := filterArgs.Req.(*roachpb.GetRequest); ok &&
 				filterArgs.Req.Header().Key.Equal(roachpb.Key(key)) &&
@@ -458,7 +458,7 @@ func TestRangeTransferLease(t *testing.T) {
 	cfg := storage.TestStoreConfig(nil)
 	var filterMu syncutil.Mutex
 	var filter func(filterArgs storagebase.FilterArgs) *roachpb.Error
-	cfg.TestingKnobs.TestingCommandFilter =
+	cfg.TestingKnobs.TestingEvalFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			filterMu.Lock()
 			filterCopy := filter
@@ -676,7 +676,7 @@ func TestLeaseMetricsOnSplitAndTransfer(t *testing.T) {
 	var injectLeaseTransferError atomic.Value
 	sc := storage.TestStoreConfig(nil)
 	sc.TestingKnobs.DisableSplitQueue = true
-	sc.TestingKnobs.TestingCommandFilter =
+	sc.TestingKnobs.TestingEvalFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if args, ok := filterArgs.Req.(*roachpb.TransferLeaseRequest); ok {
 				if val := injectLeaseTransferError.Load(); val != nil && val.(bool) {
@@ -845,7 +845,7 @@ func TestLeaseExtensionNotBlockedByRead(t *testing.T) {
 		base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Store: &storage.StoreTestingKnobs{
-					TestingCommandFilter: cmdFilter,
+					TestingEvalFilter: cmdFilter,
 				},
 			},
 		})
@@ -1026,7 +1026,7 @@ func TestErrorHandlingForNonKVCommand(t *testing.T) {
 		base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Store: &storage.StoreTestingKnobs{
-					TestingCommandFilter: cmdFilter,
+					TestingEvalFilter: cmdFilter,
 				},
 			},
 		})

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1134,7 +1134,7 @@ func TestStoreSplitTimestampCacheReadRace(t *testing.T) {
 	var getStarted sync.WaitGroup
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	storeCfg.TestingKnobs.TestingCommandFilter =
+	storeCfg.TestingKnobs.TestingEvalFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if et, ok := filterArgs.Req.(*roachpb.EndTransactionRequest); ok {
 				st := et.InternalCommitTrigger.GetSplitTrigger()
@@ -1246,7 +1246,7 @@ func TestStoreSplitTimestampCacheDifferentLeaseHolder(t *testing.T) {
 	var args base.TestClusterArgs
 	args.ReplicationMode = base.ReplicationManual
 	args.ServerArgs.Knobs.Store = &storage.StoreTestingKnobs{
-		TestingCommandFilter: filter,
+		TestingEvalFilter: filter,
 	}
 
 	tc := testcluster.StartTestCluster(t, 2, args)
@@ -1381,7 +1381,7 @@ func TestStoreRangeSplitRaceUninitializedRHS(t *testing.T) {
 	}
 	seen.sids = make(map[storagebase.CmdIDKey][2]bool)
 
-	storeCfg.TestingKnobs.TestingCommandFilter = func(args storagebase.FilterArgs) *roachpb.Error {
+	storeCfg.TestingKnobs.TestingEvalFilter = func(args storagebase.FilterArgs) *roachpb.Error {
 		et, ok := args.Req.(*roachpb.EndTransactionRequest)
 		if !ok || et.InternalCommitTrigger == nil {
 			return nil
@@ -1670,7 +1670,7 @@ func TestStoreSplitBeginTxnPushMetaIntentRace(t *testing.T) {
 	manual := hlc.NewManualClock(123)
 	storeCfg := storage.TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
 	storeCfg.TestingKnobs.DisableSplitQueue = true
-	storeCfg.TestingKnobs.TestingCommandFilter = func(filterArgs storagebase.FilterArgs) *roachpb.Error {
+	storeCfg.TestingKnobs.TestingEvalFilter = func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 		startMu.Lock()
 		start := startMu.time
 		startMu.Unlock()

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -1008,6 +1008,13 @@ func (m *multiTestContext) changeReplicasLocked(
 
 // replicateRange replicates the given range onto the given stores.
 func (m *multiTestContext) replicateRange(rangeID roachpb.RangeID, dests ...int) {
+	if err := m.replicateRangeNonFatal(rangeID, dests...); err != nil {
+		m.t.Fatal(err)
+	}
+}
+
+// replicateRangeNonFatal replicates the given range onto the given stores.
+func (m *multiTestContext) replicateRangeNonFatal(rangeID roachpb.RangeID, dests ...int) error {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -1018,12 +1025,12 @@ func (m *multiTestContext) replicateRange(rangeID roachpb.RangeID, dests ...int)
 		var err error
 		expectedReplicaIDs[i], err = m.changeReplicasLocked(rangeID, dest, roachpb.ADD_REPLICA)
 		if err != nil {
-			m.t.Fatal(err)
+			return err
 		}
 	}
 
 	// Wait for the replication to complete on all destination nodes.
-	testutils.SucceedsSoon(m.t, func() error {
+	return util.RetryForDuration(testutils.DefaultSucceedsSoonDuration, func() error {
 		for i, dest := range dests {
 			repl, err := m.stores[dest].GetReplica(rangeID)
 			if err != nil {

--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -439,7 +439,7 @@ func TestGCQueueTransactionTable(t *testing.T) {
 
 	resolved := map[string][]roachpb.Span{}
 
-	tsc.TestingKnobs.TestingCommandFilter =
+	tsc.TestingKnobs.TestingEvalFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if resArgs, ok := filterArgs.Req.(*roachpb.ResolveIntentRequest); ok {
 				id := string(resArgs.IntentTxn.Key)

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -3620,7 +3620,7 @@ func (r *Replica) processRaftCommand(
 		raftCmd.ReplicatedEvalResult.Delta, pErr = r.applyRaftCommand(
 			ctx, idKey, *raftCmd.ReplicatedEvalResult, writeBatch)
 
-		if filter := r.store.cfg.TestingKnobs.TestingApplyFilter; pErr == nil && filter != nil {
+		if filter := r.store.cfg.TestingKnobs.TestingPostApplyFilter; pErr == nil && filter != nil {
 			pErr = filter(storagebase.ApplyFilterArgs{
 				CmdID:                idKey,
 				ReplicatedEvalResult: *raftCmd.ReplicatedEvalResult,

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -150,7 +150,7 @@ func (r *Replica) executeCmd(
 	}
 
 	// If a unittest filter was installed, check for an injected error; otherwise, continue.
-	if filter := r.store.cfg.TestingKnobs.TestingCommandFilter; filter != nil {
+	if filter := r.store.cfg.TestingKnobs.TestingEvalFilter; filter != nil {
 		filterArgs := storagebase.FilterArgs{Ctx: ctx, CmdID: raftCmdID, Index: index,
 			Sid: r.store.StoreID(), Req: args, Hdr: h}
 		if pErr := filter(filterArgs); pErr != nil {

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -525,7 +525,7 @@ func TestBehaviorDuringLeaseTransfer(t *testing.T) {
 		}
 	}
 	transferSem := make(chan struct{})
-	tsc.TestingKnobs.TestingCommandFilter =
+	tsc.TestingKnobs.TestingEvalFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if _, ok := filterArgs.Req.(*roachpb.TransferLeaseRequest); ok {
 				// Notify the test that the transfer has been trapped.
@@ -1976,7 +1976,7 @@ func TestReplicaCommandQueue(t *testing.T) {
 
 						tc := testContext{}
 						tsc := TestStoreConfig(nil)
-						tsc.TestingKnobs.TestingCommandFilter =
+						tsc.TestingKnobs.TestingEvalFilter =
 							func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 								if filterArgs.Hdr.UserPriority == blockingPriority && filterArgs.Index == 0 {
 									blockingStart <- struct{}{}
@@ -2148,7 +2148,7 @@ func TestReplicaCommandQueueInconsistent(t *testing.T) {
 
 	tc := testContext{}
 	tsc := TestStoreConfig(nil)
-	tsc.TestingKnobs.TestingCommandFilter =
+	tsc.TestingKnobs.TestingEvalFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if put, ok := filterArgs.Req.(*roachpb.PutRequest); ok {
 				putBytes, err := put.Value.GetBytes()
@@ -2219,7 +2219,7 @@ func TestReplicaCommandQueueCancellation(t *testing.T) {
 
 	tc := testContext{}
 	tsc := TestStoreConfig(nil)
-	tsc.TestingKnobs.TestingCommandFilter =
+	tsc.TestingKnobs.TestingEvalFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if filterArgs.Hdr.UserPriority == 42 {
 				log.Infof(context.Background(), "starting to block %s", filterArgs.Req)
@@ -3495,7 +3495,7 @@ func TestEndTransactionLocalGC(t *testing.T) {
 	defer setTxnAutoGC(true)()
 	tc := testContext{}
 	tsc := TestStoreConfig(nil)
-	tsc.TestingKnobs.TestingCommandFilter =
+	tsc.TestingKnobs.TestingEvalFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			// Make sure the direct GC path doesn't interfere with this test.
 			if filterArgs.Req.Method() == roachpb.GC {
@@ -3603,7 +3603,7 @@ func TestEndTransactionResolveOnlyLocalIntents(t *testing.T) {
 	tsc := TestStoreConfig(nil)
 	key := roachpb.Key("a")
 	splitKey := roachpb.RKey(key).Next()
-	tsc.TestingKnobs.TestingCommandFilter =
+	tsc.TestingKnobs.TestingEvalFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if filterArgs.Req.Method() == roachpb.ResolveIntent &&
 				filterArgs.Req.Header().Key.Equal(splitKey.AsRawKey()) {
@@ -3711,7 +3711,7 @@ func TestEndTransactionDirectGCFailure(t *testing.T) {
 	splitKey := roachpb.RKey(key).Next()
 	var count int64
 	tsc := TestStoreConfig(nil)
-	tsc.TestingKnobs.TestingCommandFilter =
+	tsc.TestingKnobs.TestingEvalFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if filterArgs.Req.Method() == roachpb.ResolveIntent &&
 				filterArgs.Req.Header().Key.Equal(splitKey.AsRawKey()) {
@@ -3788,7 +3788,7 @@ func TestReplicaResolveIntentNoWait(t *testing.T) {
 	var seen int32
 	key := roachpb.Key("zresolveme")
 	tsc := TestStoreConfig(nil)
-	tsc.TestingKnobs.TestingCommandFilter =
+	tsc.TestingKnobs.TestingEvalFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if filterArgs.Req.Method() == roachpb.ResolveIntent &&
 				filterArgs.Req.Header().Key.Equal(key) {
@@ -4942,7 +4942,7 @@ func TestReplicaCorruption(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	tsc := TestStoreConfig(nil)
-	tsc.TestingKnobs.TestingCommandFilter =
+	tsc.TestingKnobs.TestingEvalFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if filterArgs.Req.Header().Key.Equal(roachpb.Key("boom")) {
 				return roachpb.NewError(NewReplicaCorruptionError(errors.New("boom")))
@@ -5857,7 +5857,7 @@ func TestReplicaCancelRaft(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cfg := TestStoreConfig(nil)
 			if !cancelEarly {
-				cfg.TestingKnobs.TestingCommandFilter =
+				cfg.TestingKnobs.TestingEvalFilter =
 					func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 						if filterArgs.Req.Header().Key.Equal(key) {
 							cancel()

--- a/pkg/storage/storagebase/base.go
+++ b/pkg/storage/storagebase/base.go
@@ -48,16 +48,10 @@ func (f *FilterArgs) InRaftCmd() bool {
 	return f.CmdID != ""
 }
 
-// ReplicaCommandFilter may be used in tests through the StorageTestingMocker to
+// ReplicaCommandFilter may be used in tests through the StoreTestingKnobs to
 // intercept the handling of commands and artificially generate errors. Return
 // nil to continue with regular processing or non-nil to terminate processing
-// with the returned error. Note that in a multi-replica test this filter will
-// be run once for each replica and must produce consistent results each time.
-//
-// TODO(tschottdorf): clean this up. Tests which use this all need to be
-// refactored to use explicitly a proposal-intercepting filter (not written
-// yet, but it's basically this one here when proposer-evaluated KV is on) or
-// a ReplicaApplyFilter (see below).
+// with the returned error.
 type ReplicaCommandFilter func(args FilterArgs) *roachpb.Error
 
 // A ReplicaApplyFilter can be used in testing to influence the error returned

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -706,8 +706,7 @@ type StoreTestingKnobs struct {
 	// not be applied. If it returns an error on some replicas but not
 	// others, the behavior is poorly defined unless that error is a
 	// ReplicaCorruptionError.
-	// TODO(bdarnell): Implement this when a test needs it.
-	//TestingApplyFilter storagebase.ReplicaApplyFilter
+	TestingApplyFilter storagebase.ReplicaApplyFilter
 
 	// TestingPostApplyFilter is called after a command is applied to
 	// rocksdb but before in-memory side effects have been processed.

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -775,7 +775,7 @@ func TestStoreObservedTimestamp(t *testing.T) {
 		func() {
 			manual := hlc.NewManualClock(123)
 			cfg := TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
-			cfg.TestingKnobs.TestingCommandFilter =
+			cfg.TestingKnobs.TestingEvalFilter =
 				func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 					if bytes.Equal(filterArgs.Req.Header().Key, badKey) {
 						return roachpb.NewError(errors.Errorf("boom"))
@@ -838,7 +838,7 @@ func TestStoreAnnotateNow(t *testing.T) {
 		for _, test := range testCases {
 			func() {
 				cfg := TestStoreConfig(nil)
-				cfg.TestingKnobs.TestingCommandFilter =
+				cfg.TestingKnobs.TestingEvalFilter =
 					func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 						if bytes.Equal(filterArgs.Req.Header().Key, badKey) {
 							return roachpb.NewErrorWithTxn(errors.Errorf("boom"), filterArgs.Hdr.Txn)
@@ -1254,7 +1254,7 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	manual := hlc.NewManualClock(123)
 	cfg := TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
-	cfg.TestingKnobs.TestingCommandFilter =
+	cfg.TestingKnobs.TestingEvalFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			pr, ok := filterArgs.Req.(*roachpb.PushTxnRequest)
 			if !ok || pr.PusherTxn.Name != "test" {
@@ -1749,7 +1749,7 @@ func TestStoreScanIntents(t *testing.T) {
 	var count int32
 	countPtr := &count
 
-	cfg.TestingKnobs.TestingCommandFilter =
+	cfg.TestingKnobs.TestingEvalFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if _, ok := filterArgs.Req.(*roachpb.ScanRequest); ok {
 				atomic.AddInt32(countPtr, 1)
@@ -1869,7 +1869,7 @@ func TestStoreScanInconsistentResolvesIntents(t *testing.T) {
 	var intercept atomic.Value
 	intercept.Store(true)
 	cfg := TestStoreConfig(nil)
-	cfg.TestingKnobs.TestingCommandFilter =
+	cfg.TestingKnobs.TestingEvalFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			_, ok := filterArgs.Req.(*roachpb.ResolveIntentRequest)
 			if ok && intercept.Load().(bool) {


### PR DESCRIPTION
Inconsistent error handling between the proposer of a config change
and other replicas could lead to the raft state diverging from the
range descriptor when a ChangeReplicas transaction fails.

Fixes #13506

The first commit is mechanical renaming to help clarify our increasing number of testing filters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13605)
<!-- Reviewable:end -->
