### PR TITLE
sql: retry table lease release txn

### DIFF
--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -224,33 +224,42 @@ func (s LeaseStore) Acquire(
 }
 
 // Release a previously acquired table descriptor lease.
-func (s LeaseStore) Release(lease *LeaseState) error {
-	err := s.db.Txn(context.TODO(), func(txn *client.Txn) error {
-		if log.V(2) {
-			log.Infof(txn.Context, "LeaseStore releasing lease %s", lease)
+func (s LeaseStore) Release(stopper *stop.Stopper, lease *LeaseState) {
+	retryOptions := base.DefaultRetryOptions()
+	retryOptions.Closer = stopper.ShouldQuiesce()
+	firstAttempt := true
+	for r := retry.Start(retryOptions); r.Next(); {
+		// This transaction is idempotent.
+		err := s.db.Txn(context.TODO(), func(txn *client.Txn) error {
+			log.VEventf(txn.Context, 2, "LeaseStore releasing lease %s", lease)
+			nodeID := s.nodeID.Get()
+			if nodeID == 0 {
+				panic("zero nodeID")
+			}
+			p := makeInternalPlanner("lease-release", txn, security.RootUser, s.memMetrics)
+			defer finishInternalPlanner(p)
+			const deleteLease = `DELETE FROM system.lease ` +
+				`WHERE (descID, version, nodeID, expiration) = ($1, $2, $3, $4)`
+			count, err := p.exec(deleteLease, lease.ID, int(lease.Version), nodeID, &lease.expiration)
+			if err != nil {
+				return err
+			}
+			// We allow count == 0 after the first attempt.
+			if count > 1 || (count == 0 && firstAttempt) {
+				log.Warningf(txn.Context, "unexpected results while deleting lease %s: "+
+					"expected 1 result, found %d", lease, count)
+			}
+			return nil
+		})
+		if s.testingKnobs.LeaseReleasedEvent != nil {
+			s.testingKnobs.LeaseReleasedEvent(lease, err)
 		}
-		nodeID := s.nodeID.Get()
-		if nodeID == 0 {
-			panic("zero nodeID")
+		if err == nil {
+			break
 		}
-		p := makeInternalPlanner("lease-release", txn, security.RootUser, s.memMetrics)
-		defer finishInternalPlanner(p)
-		const deleteLease = `DELETE FROM system.lease ` +
-			`WHERE (descID, version, nodeID, expiration) = ($1, $2, $3, $4)`
-		count, err := p.exec(deleteLease, lease.ID, int(lease.Version), nodeID, &lease.expiration)
-		if err != nil {
-			return err
-		}
-		if count != 1 {
-			return errors.Errorf("unexpected results while deleting lease %s: "+
-				"expected 1 result, found %d", lease, count)
-		}
-		return nil
-	})
-	if s.testingKnobs.LeaseReleasedEvent != nil {
-		s.testingKnobs.LeaseReleasedEvent(lease, err)
+		log.Warningf(context.TODO(), "error releasing lease %q: %s", lease, err)
+		firstAttempt = false
 	}
-	return err
 }
 
 // WaitForOneVersion returns once there are no unexpired leases on the
@@ -760,13 +769,10 @@ func (t *tableState) removeLease(lease *LeaseState, store LeaseStore) {
 	t.active.remove(lease)
 	t.tableNameCache.remove(lease)
 	// Release to the store asynchronously, without the tableState lock.
-	err := t.stopper.RunAsyncTask(context.TODO(), func(ctx context.Context) {
-		if err := store.Release(lease); err != nil {
-			log.Warningf(ctx, "error releasing lease %q: %s", lease, err)
-		}
-	})
-	if log.V(1) && err != nil {
-		log.Warningf(context.TODO(), "error removing lease from store: %s", err)
+	if err := t.stopper.RunAsyncTask(context.TODO(), func(ctx context.Context) {
+		store.Release(t.stopper, lease)
+	}); err != nil {
+		log.Warningf(context.TODO(), "error: %s, not releasing lease: %q", err, lease)
 	}
 }
 


### PR DESCRIPTION
Retry the table lease release txn 5 times to increase
the probability that the lease is released.
Leases eventually expire so not releasing them is safe.
Improving the chance of leases getting released improves
the chance that schema changes waiting on the lease
make progress.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13606)
<!-- Reviewable:end -->
