### PR TITLE
utilccl: add stubbed helper for gating enterprise features

### DIFF
--- a/pkg/ccl/sqlccl/backup.go
+++ b/pkg/ccl/sqlccl/backup.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl/intervalccl"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -963,6 +964,9 @@ func backupPlanHook(
 	if !ok {
 		return nil, nil, nil
 	}
+	if err := utilccl.CheckEnterpriseEnabled("BACKUP"); err != nil {
+		return nil, nil, err
+	}
 	header := sql.ResultColumns{
 		{Name: "to", Typ: parser.TypeString},
 		{Name: "startTs", Typ: parser.TypeString},
@@ -1011,6 +1015,10 @@ func restorePlanHook(
 	if !ok {
 		return nil, nil, nil
 	}
+	if err := utilccl.CheckEnterpriseEnabled("RESTORE"); err != nil {
+		return nil, nil, err
+	}
+
 	fn := func() ([]parser.Datums, error) {
 		// TODO(dan): Move this span into sql.
 		ctx, span := tracing.ChildSpan(baseCtx, stmt.StatementTag())

--- a/pkg/ccl/sqlccl/main_test.go
+++ b/pkg/ccl/sqlccl/main_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -22,6 +23,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	defer utilccl.TestingEnableEnterprise(true)()
 	security.SetReadFileFn(securitytest.Asset)
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory)

--- a/pkg/ccl/utilccl/license_check.go
+++ b/pkg/ccl/utilccl/license_check.go
@@ -1,0 +1,46 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Cockroach Community Licence (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
+
+package utilccl
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/pkg/errors"
+)
+
+// enterpriseEnabled indicates if the cluster has enterprise features enabled.
+// TODO(dt): this is a stub for now, to be replaced with some sort of runtime
+// configurable license key or other control mechanism.
+var enterpriseEnabled = envutil.EnvOrDefaultBool("COCKROACH_ENTERPRISE_ENABLED", false)
+
+// CheckEnterpriseEnabled returns a non-nil error if the requested enterprise
+// feature is not enabled, including information or a link explaining how to
+// enable it.
+func CheckEnterpriseEnabled(feature string) error {
+	if enterpriseEnabled {
+		return nil
+	}
+	// TODO(dt): link to some stable URL that then redirects to a helpful page
+	// that explains what to do here.
+	link := "https://cockroachlabs.com/pricing"
+	return errors.Errorf(
+		"use of %s requires an enterprise license. "+
+			"see %s for details on how to enable enterprise features",
+		feature,
+		link,
+	)
+}
+
+// TestingEnableEnterprise overrides enterprise feature gating for testing.
+func TestingEnableEnterprise(enabled bool) func() {
+	before := enterpriseEnabled
+	enterpriseEnabled = enabled
+	return func() {
+		enterpriseEnabled = before
+	}
+}


### PR DESCRIPTION
The implementation of `EnterpriseEnabled` is expected to change to some sort of entered key at some point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13619)
<!-- Reviewable:end -->
