### PR TITLE
makefile: inject private env vars via gitignored include

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ artifacts
 *.test*
 # Various `sed -i~` invocations in our scripts.
 *~
+
+# Custom or private env vars (e.g. internal keys, access tokens, etc).
+customenv.mk

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,8 @@ else
 $(error unknown build type $(TYPE))
 endif
 
+-include customenv.mk
+
 .PHONY: all
 all: build test check
 

--- a/build/style_test.go
+++ b/build/style_test.go
@@ -141,7 +141,7 @@ func TestStyle(t *testing.T) {
 		if err := stream.ForEach(stream.Sequence(
 			filter,
 			stream.GrepNot(`^cmd/`),
-			stream.GrepNot(`^(build/style_test\.go|ccl/sqlccl/backup_test\.go|ccl/storageccl/export_storage_test\.go|acceptance(/.*)?/\w+\.go)\b`),
+			stream.GrepNot(`^(build/style_test\.go|ccl/sqlccl/backup_cloud_test\.go|ccl/storageccl/export_storage_test\.go|acceptance(/.*)?/\w+\.go)\b`),
 			stream.GrepNot(`^util/(log|envutil|sdnotify)/\w+\.go\b`),
 		), func(s string) {
 			t.Errorf(`%s <- forbidden; use "envutil" instead`, s)

--- a/pkg/ccl/sqlccl/backup_cloud_test.go
+++ b/pkg/ccl/sqlccl/backup_cloud_test.go
@@ -1,0 +1,135 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Cockroach Community Licence (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+
+package sqlccl
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/rlmcpherson/s3gof3r"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// The tests in this file talk to remote APIs which require credentials.
+// To run these tests, you need to supply credentials via env vars (the tests
+// skip themselves if they are not set). Obtain these credentials from the
+// admin consoles of the various cloud providers.
+// customenv.mak (gitignored) may be a useful place to record these.
+// Cockroach Labs Employees: symlink customenv.mk to copy in `production`.
+
+// TestBackupRestoreS3 hits the real S3 and so could occasionally be flaky. It's
+// only run if the AWS_S3_BUCKET environment var is set.
+func TestBackupRestoreS3(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	if !storage.ProposerEvaluatedKVEnabled() {
+		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
+	}
+	s3Keys, err := s3gof3r.EnvKeys()
+	if err != nil {
+		t.Skipf("No AWS env keys (%v)", err)
+	}
+	bucket := os.Getenv("AWS_S3_BUCKET")
+	if bucket == "" {
+		t.Skip("AWS_S3_BUCKET env var must be set")
+	}
+
+	// TODO(dan): Actually invalidate the descriptor cache and delete this line.
+	defer sql.TestDisableTableLeases()()
+	const numAccounts = 1000
+
+	ctx, _, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, 1, numAccounts)
+	defer cleanupFn()
+	prefix := fmt.Sprintf("TestBackupRestoreS3-%d", timeutil.Now().UnixNano())
+	uri := url.URL{Scheme: "s3", Host: bucket, Path: prefix}
+	values := uri.Query()
+	values.Add(storageccl.S3AccessKeyParam, s3Keys.AccessKey)
+	values.Add(storageccl.S3SecretParam, s3Keys.SecretKey)
+	uri.RawQuery = values.Encode()
+
+	backupAndRestore(ctx, t, sqlDB, uri.String(), numAccounts)
+}
+
+// TestBackupRestoreGoogleCloudStorage hits the real GCS and so could
+// occasionally be flaky. It's only run if the GS_BUCKET environment var is set.
+func TestBackupRestoreGoogleCloudStorage(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	if !storage.ProposerEvaluatedKVEnabled() {
+		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
+	}
+	bucket := os.Getenv("GS_BUCKET")
+	if bucket == "" {
+		t.Skip("GS_BUCKET env var must be set")
+	}
+
+	// TODO(dan): Actually invalidate the descriptor cache and delete this line.
+	defer sql.TestDisableTableLeases()()
+	const numAccounts = 1000
+
+	// TODO(dt): this prevents leaking an http conn goroutine -- presumably the
+	// conn is held open for reuse until the idle timeout. Ideally we'd test with
+	// conn reuse enabled though, to match expected production behavior.
+	defer func(disableKeepAlives bool) {
+		http.DefaultTransport.(*http.Transport).DisableKeepAlives = disableKeepAlives
+	}(http.DefaultTransport.(*http.Transport).DisableKeepAlives)
+	http.DefaultTransport.(*http.Transport).DisableKeepAlives = true
+
+	ctx, _, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, 1, numAccounts)
+	defer cleanupFn()
+	prefix := fmt.Sprintf("TestBackupRestoreGoogleCloudStorage-%d", timeutil.Now().UnixNano())
+	uri := url.URL{Scheme: "gs", Host: bucket, Path: prefix}
+	backupAndRestore(ctx, t, sqlDB, uri.String(), numAccounts)
+}
+
+// TestBackupRestoreAzure hits the real Azure Blob Storage and so could
+// occasionally be flaky. It's only run if the AZURE_ACCOUNT_NAME and
+// AZURE_ACCOUNT_KEY environment vars are set.
+func TestBackupRestoreAzure(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	if !storage.ProposerEvaluatedKVEnabled() {
+		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
+	}
+	accountName := os.Getenv("AZURE_ACCOUNT_NAME")
+	accountKey := os.Getenv("AZURE_ACCOUNT_KEY")
+	if accountName == "" || accountKey == "" {
+		t.Skip("AZURE_ACCOUNT_NAME and AZURE_ACCOUNT_KEY env vars must be set")
+	}
+	bucket := os.Getenv("AZURE_CONTAINER")
+	if bucket == "" {
+		t.Skip("AZURE_CONTAINER env var must be set")
+	}
+
+	// TODO(dan): Actually invalidate the descriptor cache and delete this line.
+	defer sql.TestDisableTableLeases()()
+	const numAccounts = 1000
+
+	// TODO(dt): this prevents leaking an http conn goroutine.
+	defer func(disableKeepAlives bool) {
+		http.DefaultTransport.(*http.Transport).DisableKeepAlives = disableKeepAlives
+	}(http.DefaultTransport.(*http.Transport).DisableKeepAlives)
+	http.DefaultTransport.(*http.Transport).DisableKeepAlives = true
+
+	ctx, _, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, 1, numAccounts)
+	defer cleanupFn()
+	prefix := fmt.Sprintf("TestBackupRestoreAzure-%d", timeutil.Now().UnixNano())
+	uri := url.URL{Scheme: "azure", Host: bucket, Path: prefix}
+	values := uri.Query()
+	values.Add(storageccl.AzureAccountNameParam, accountName)
+	values.Add(storageccl.AzureAccountKeyParam, accountKey)
+	uri.RawQuery = values.Encode()
+
+	backupAndRestore(ctx, t, sqlDB, uri.String(), numAccounts)
+}

--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -15,19 +15,15 @@ import (
 	"hash/crc32"
 	"io/ioutil"
 	"math/rand"
-	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
 
 	"github.com/pkg/errors"
-	"github.com/rlmcpherson/s3gof3r"
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -41,7 +37,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 const (
@@ -157,105 +152,6 @@ func TestBackupRestoreLocal(t *testing.T) {
 	backupAndRestore(ctx, t, sqlDB, dir, numAccounts)
 }
 
-// TestBackupRestoreS3 hits the real S3 and so could occasionally be flaky. It's
-// only run if the AWS_S3_BUCKET environment var is set.
-func TestBackupRestoreS3(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	s3Keys, err := s3gof3r.EnvKeys()
-	if err != nil {
-		s3Keys, err = s3gof3r.InstanceKeys()
-		if err != nil {
-			t.Skip("No AWS keys instance or env keys")
-		}
-	}
-	bucket := os.Getenv("AWS_S3_BUCKET")
-	if bucket == "" {
-		// CRL uses a bucket `cockroach-backup-tests` that has a 24h TTL policy.
-		t.Skip("AWS_S3_BUCKET env var must be set")
-	}
-
-	// TODO(dan): Actually invalidate the descriptor cache and delete this line.
-	defer sql.TestDisableTableLeases()()
-	const numAccounts = 1000
-
-	ctx, _, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, 1, numAccounts)
-	defer cleanupFn()
-	prefix := fmt.Sprintf("TestBackupRestoreS3-%d", timeutil.Now().UnixNano())
-	uri := url.URL{Scheme: "s3", Host: bucket, Path: prefix}
-	values := uri.Query()
-	values.Add(storageccl.S3AccessKeyParam, s3Keys.AccessKey)
-	values.Add(storageccl.S3SecretParam, s3Keys.SecretKey)
-	uri.RawQuery = values.Encode()
-
-	backupAndRestore(ctx, t, sqlDB, uri.String(), numAccounts)
-}
-
-// TestBackupRestoreGoogleCloudStorage hits the real GCS and so could
-// occasionally be flaky. It's only run if the GS_BUCKET environment var is set.
-func TestBackupRestoreGoogleCloudStorage(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	if !storage.ProposerEvaluatedKVEnabled() {
-		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
-
-	bucket := os.Getenv("GS_BUCKET")
-	if bucket == "" {
-		t.Skip("GS_BUCKET env var must be set")
-	}
-
-	// TODO(dan): Actually invalidate the descriptor cache and delete this line.
-	defer sql.TestDisableTableLeases()()
-	const numAccounts = 1000
-
-	// TODO(dt): this prevents leaking an http conn goroutine.
-	http.DefaultTransport.(*http.Transport).DisableKeepAlives = true
-
-	ctx, _, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, 1, numAccounts)
-	defer cleanupFn()
-	prefix := fmt.Sprintf("TestBackupRestoreGoogleCloudStorage-%d", timeutil.Now().UnixNano())
-	uri := url.URL{Scheme: "gs", Host: bucket, Path: prefix}
-	backupAndRestore(ctx, t, sqlDB, uri.String(), numAccounts)
-}
-
-// TestBackupRestoreAzure hits the real Azure Blob Storage and so could
-// occasionally be flaky. It's only run if the AZURE_ACCOUNT_NAME and
-// AZURE_ACCOUNT_KEY environment vars are set.
-func TestBackupRestoreAzure(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	if !storage.ProposerEvaluatedKVEnabled() {
-		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
-
-	accountName := os.Getenv("AZURE_ACCOUNT_NAME")
-	accountKey := os.Getenv("AZURE_ACCOUNT_KEY")
-	if accountName == "" || accountKey == "" {
-		t.Skip("AZURE_ACCOUNT_NAME and AZURE_ACCOUNT_KEY env vars must be set")
-	}
-	bucket := os.Getenv("AZURE_CONTAINER")
-	if bucket == "" {
-		t.Skip("AZURE_CONTAINER env var must be set")
-	}
-
-	// TODO(dan): Actually invalidate the descriptor cache and delete this line.
-	defer sql.TestDisableTableLeases()()
-	const numAccounts = 1000
-
-	// TODO(dt): this prevents leaking an http conn goroutine.
-	http.DefaultTransport.(*http.Transport).DisableKeepAlives = true
-
-	ctx, _, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, 1, numAccounts)
-	defer cleanupFn()
-	prefix := fmt.Sprintf("TestBackupRestoreAzure-%d", timeutil.Now().UnixNano())
-	uri := url.URL{Scheme: "azure", Host: bucket, Path: prefix}
-	values := uri.Query()
-	values.Add(storageccl.AzureAccountNameParam, accountName)
-	values.Add(storageccl.AzureAccountKeyParam, accountKey)
-	uri.RawQuery = values.Encode()
-
-	backupAndRestore(ctx, t, sqlDB, uri.String(), numAccounts)
-}
-
 func backupAndRestore(
 	ctx context.Context, t *testing.T, sqlDB *sqlutils.SQLRunner, dest string, numAccounts int64,
 ) {
@@ -266,7 +162,7 @@ func backupAndRestore(
 			&unused, &unused, &unused, &dataSize,
 		)
 		approxDataSize := int64(backupRestoreRowPayloadSize) * numAccounts
-		if max := approxDataSize * 2; dataSize < approxDataSize || dataSize > 2*max {
+		if max := approxDataSize * 2; dataSize < approxDataSize || dataSize > max {
 			t.Errorf("expected data size in [%d,%d] but was %d", approxDataSize, max, dataSize)
 		}
 	}


### PR DESCRIPTION
The cloud provider tests require credentials, which should not be committed to a public repo, to run.

To make it easier record these for reuse in later runs or share them between a group of developers such that each doesn't need to individually create keys, we allow injecting env vars via the makefile, from a gitignored path.

Also moved all the cloud interaction tests into their own file for demarcation. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13621)
<!-- Reviewable:end -->
