### PR TITLE
sql: remove extra semicolons from logic tests

### DIFF
--- a/pkg/sql/testdata/aggregate
+++ b/pkg/sql/testdata/aggregate
@@ -102,7 +102,7 @@ SELECT 1 FROM kv GROUP BY v
 
 # Presence of HAVING triggers aggregation, reducing results to one row (even without GROUP BY).
 query I rowsort
-SELECT 3 FROM kv HAVING TRUE;
+SELECT 3 FROM kv HAVING TRUE
 ----
 3
 
@@ -317,11 +317,11 @@ query error aggregate function calls cannot be nested under max()
 SELECT MAX(k), MIN(v) FROM kv HAVING MAX(MIN(v)) > 2
 
 query error argument of HAVING must be type bool, not type int
-SELECT MAX(k), MIN(v) FROM kv HAVING k;
+SELECT MAX(k), MIN(v) FROM kv HAVING k
 
 # Expressions listed in the HAVING clause must conform to same validation as the SELECT clause (grouped or aggregated).
 query error column "k" must appear in the GROUP BY clause or be used in an aggregate function
-SELECT 3 FROM kv GROUP BY v HAVING k > 5;
+SELECT 3 FROM kv GROUP BY v HAVING k > 5
 
 # pg has a special case for grouping on primary key, which would allow this, but we do not.
 # See http://www.postgresql.org/docs/current/static/sql-select.html#SQL-GROUPBY
@@ -329,28 +329,28 @@ query error column "v" must appear in the GROUP BY clause or be used in an aggre
 SELECT 3 FROM kv GROUP BY k HAVING v > 2
 
 query error column "k" must appear in the GROUP BY clause or be used in an aggregate function
-SELECT k FROM kv HAVING k > 7;
+SELECT k FROM kv HAVING k > 7
 
 query error syntax error at or near ","
 SELECT COUNT(*, 1) FROM kv
 
 query I
-SELECT COUNT(*);
+SELECT COUNT(*)
 ----
 1
 
 query I
-SELECT COUNT(k) from kv;
+SELECT COUNT(k) from kv
 ----
 6
 
 query I
-SELECT COUNT(1);
+SELECT COUNT(1)
 ----
 1
 
 query I
-SELECT COUNT(1) from kv;
+SELECT COUNT(1) from kv
 ----
 6
 

--- a/pkg/sql/testdata/builtin_function
+++ b/pkg/sql/testdata/builtin_function
@@ -19,7 +19,7 @@ statement error unknown signature: length\(int\)
 SELECT LENGTH(23)
 
 query II
-SELECT octet_length('Hello'), octet_length(b'世界');
+SELECT octet_length('Hello'), octet_length(b'世界')
 ----
 5 6
 
@@ -207,12 +207,12 @@ SELECT ascii('x')
 120
 
 query I
-select ascii('禅');
+select ascii('禅')
 ----
 31109
 
 query error ascii\(\): the input string must not be empty
-select ascii('');
+select ascii('')
 
 query T
 SELECT md5('abc')
@@ -263,47 +263,47 @@ query error unknown signature: strpos\(\)
 SELECT position()
 
 query T
-SELECT overlay('123456789' placing 'xxxx' from 3);
+SELECT overlay('123456789' placing 'xxxx' from 3)
 ----
 12xxxx789
 
 query T
-SELECT overlay('123456789' placing 'xxxx' from 3 for 2);
+SELECT overlay('123456789' placing 'xxxx' from 3 for 2)
 ----
 12xxxx56789
 
 query T
-SELECT overlay('123456789' placing 'xxxx' from 3 for 6);
+SELECT overlay('123456789' placing 'xxxx' from 3 for 6)
 ----
 12xxxx9
 
 query T
-SELECT overlay('123456789' placing 'xxxx' from 15 for 6);
+SELECT overlay('123456789' placing 'xxxx' from 15 for 6)
 ----
 123456789xxxx
 
 query T
-SELECT overlay('123456789' placing 'xxxx' from 3 for 10);
+SELECT overlay('123456789' placing 'xxxx' from 3 for 10)
 ----
 12xxxx
 
 query T
-SELECT overlay('123456789' placing 'xxxx' from 3 for -1);
+SELECT overlay('123456789' placing 'xxxx' from 3 for -1)
 ----
 12xxxx23456789
 
 query T
-SELECT overlay('123456789' placing 'xxxx' from 3 for -8);
+SELECT overlay('123456789' placing 'xxxx' from 3 for -8)
 ----
 12xxxx123456789
 
 query T
-SELECT overlay('💩123456789' placing 'xxxxÂ' from 3 for 3);
+SELECT overlay('💩123456789' placing 'xxxxÂ' from 3 for 3)
 ----
 💩1xxxxÂ56789
 
 query error non-positive substring length not allowed: -1
-SELECT overlay('123456789' placing 'xxxx' from -1 for 6);
+SELECT overlay('123456789' placing 'xxxx' from -1 for 6)
 
 query T
 SELECT btrim('xyxtrimyyx', 'xy')
@@ -703,7 +703,7 @@ SELECT round(-1.7976931348623157e-308::float, 1), round(1.7976931348623157e-308:
 -0 0
 
 query RRRR
-SELECT 1.234567890123456789::float,  round(1.234567890123456789::float,15), round(1.234567890123456789::float,16), round(1.234567890123456789::float,17);
+SELECT 1.234567890123456789::float,  round(1.234567890123456789::float,15), round(1.234567890123456789::float,16), round(1.234567890123456789::float,17)
 ----
 1.2345678901234567 1.234567890123457 1.2345678901234567 1.2345678901234567
 
@@ -1194,92 +1194,92 @@ SELECT current_schema()
 NULL
 
 query I
-SELECT array_length(ARRAY['a', 'b'], 1);
+SELECT array_length(ARRAY['a', 'b'], 1)
 ----
 2
 
 query I
-SELECT array_length(ARRAY['a'], 1);
+SELECT array_length(ARRAY['a'], 1)
 ----
 1
 
 query I
-SELECT array_length(ARRAY['a'], 0);
+SELECT array_length(ARRAY['a'], 0)
 ----
 NULL
 
 query I
-SELECT array_length(ARRAY['a'], 2);
+SELECT array_length(ARRAY['a'], 2)
 ----
 NULL
 
 query I
-SELECT array_lower(ARRAY['a', 'b'], 1);
+SELECT array_lower(ARRAY['a', 'b'], 1)
 ----
 1
 
 query I
-SELECT array_lower(ARRAY['a'], 1);
+SELECT array_lower(ARRAY['a'], 1)
 ----
 1
 
 query I
-SELECT array_lower(ARRAY['a'], 0);
+SELECT array_lower(ARRAY['a'], 0)
 ----
 NULL
 
 query I
-SELECT array_lower(ARRAY['a'], 2);
+SELECT array_lower(ARRAY['a'], 2)
 ----
 NULL
 
 query I
-SELECT array_upper(ARRAY['a', 'b'], 1);
+SELECT array_upper(ARRAY['a', 'b'], 1)
 ----
 2
 
 query I
-SELECT array_upper(ARRAY['a'], 1);
+SELECT array_upper(ARRAY['a'], 1)
 ----
 1
 
 query I
-SELECT array_upper(ARRAY['a'], 0);
+SELECT array_upper(ARRAY['a'], 0)
 ----
 NULL
 
 query I
-SELECT array_upper(ARRAY['a'], 2);
+SELECT array_upper(ARRAY['a'], 2)
 ----
 NULL
 
 query I
-SELECT array_length(ARRAY[]:::int[], 1);
+SELECT array_length(ARRAY[]:::int[], 1)
 ----
 NULL
 
 query I
-SELECT array_lower(ARRAY[]:::int[], 1);
+SELECT array_lower(ARRAY[]:::int[], 1)
 ----
 NULL
 
 query I
-SELECT array_upper(ARRAY[]:::int[], 1);
+SELECT array_upper(ARRAY[]:::int[], 1)
 ----
 NULL
 
 query I
-SELECT array_length(ARRAY[ARRAY[1, 2]], 2);
+SELECT array_length(ARRAY[ARRAY[1, 2]], 2)
 ----
 2
 
 query I
-SELECT array_lower(ARRAY[ARRAY[1, 2]], 2);
+SELECT array_lower(ARRAY[ARRAY[1, 2]], 2)
 ----
 1
 
 query I
-SELECT array_upper(ARRAY[ARRAY[1, 2]], 2);
+SELECT array_upper(ARRAY[ARRAY[1, 2]], 2)
 ----
 2
 
@@ -1429,7 +1429,7 @@ query error unknown index \(OID=0\)
 SELECT pg_catalog.pg_get_indexdef(0)
 
 statement ok
-CREATE TABLE test.pg_indexdef_test (a INT, INDEX pg_indexdef_idx (a ASC), INDEX other (a DESC));
+CREATE TABLE test.pg_indexdef_test (a INT, INDEX pg_indexdef_idx (a ASC), INDEX other (a DESC))
 
 query T
 SELECT pg_catalog.pg_get_indexdef((SELECT oid from pg_class WHERE relname='pg_indexdef_idx'))

--- a/pkg/sql/testdata/check_constraints
+++ b/pkg/sql/testdata/check_constraints
@@ -7,7 +7,7 @@ statement ok
 INSERT INTO t1 VALUES (3, 0, -1)
 
 statement ok
-ALTER TABLE t1 DROP COLUMN to_delete;
+ALTER TABLE t1 DROP COLUMN to_delete
 
 statement ok
 INSERT INTO t1 (a, b) VALUES (4, -2)
@@ -120,72 +120,72 @@ SELECT * from t3
 3 2
 
 statement error failed to satisfy CHECK constraint
-UPDATE t3 SET b = 3 WHERE a = 3;
+UPDATE t3 SET b = 3 WHERE a = 3
 
 statement ok
-UPDATE t3 SET b = 1 WHERE a = 3;
+UPDATE t3 SET b = 1 WHERE a = 3
 
 statement error failed to satisfy CHECK constraint
-UPDATE t4 SET a = 2 WHERE c = 3;
+UPDATE t4 SET a = 2 WHERE c = 3
 
 statement ok
-UPDATE t4 SET a = 0 WHERE c = 3;
+UPDATE t4 SET a = 0 WHERE c = 3
 
 statement ok
-CREATE TABLE t5 (k INT PRIMARY KEY, a INT, b int CHECK (a > b));
+CREATE TABLE t5 (k INT PRIMARY KEY, a INT, b int CHECK (a > b))
 
 statement error failed to satisfy CHECK constraint
-INSERT INTO t5 VALUES (1, 10, 20) ON CONFLICT (k) DO NOTHING;
+INSERT INTO t5 VALUES (1, 10, 20) ON CONFLICT (k) DO NOTHING
 
 statement ok
-INSERT INTO t5 VALUES (1, 10, 9) ON CONFLICT (k) DO NOTHING;
+INSERT INTO t5 VALUES (1, 10, 9) ON CONFLICT (k) DO NOTHING
 
 statement error failed to satisfy CHECK constraint
-INSERT INTO t5 VALUES (1, 10, 20) ON CONFLICT (k) DO NOTHING;
+INSERT INTO t5 VALUES (1, 10, 20) ON CONFLICT (k) DO NOTHING
 
 statement error failed to satisfy CHECK constraint
-INSERT INTO t5 VALUES (2, 11, 12) ON CONFLICT (k) DO UPDATE SET b = 12 WHERE k = 2;
+INSERT INTO t5 VALUES (2, 11, 12) ON CONFLICT (k) DO UPDATE SET b = 12 WHERE k = 2
 
 statement error failed to satisfy CHECK constraint
-UPSERT INTO t5 VALUES (2, 11, 12);
+UPSERT INTO t5 VALUES (2, 11, 12)
 
 statement ok
-UPSERT INTO t5 VALUES (2, 11, 10);
+UPSERT INTO t5 VALUES (2, 11, 10)
 
 query III
-SELECT * FROM t5;
+SELECT * FROM t5
 ----
 1 10  9
 2 11  10
 
 statement ok
-UPSERT INTO t5 VALUES (2, 11, 9);
+UPSERT INTO t5 VALUES (2, 11, 9)
 
 query III
-SELECT * FROM t5;
+SELECT * FROM t5
 ----
 1 10  9
 2 11  9
 
 statement error failed to satisfy CHECK constraint
-INSERT INTO t5 VALUES (2, 11, 12) ON CONFLICT (k) DO UPDATE SET b = 12 WHERE k = 2;
+INSERT INTO t5 VALUES (2, 11, 12) ON CONFLICT (k) DO UPDATE SET b = 12 WHERE k = 2
 
 statement error failed to satisfy CHECK constraint
-UPSERT INTO t5 VALUES (2, 11, 12);
+UPSERT INTO t5 VALUES (2, 11, 12)
 
 statement error failed to satisfy CHECK constraint
-INSERT INTO t5 VALUES (2, 11, 12) ON CONFLICT (k) DO UPDATE SET b = t5.a + 1 WHERE k = 2;
+INSERT INTO t5 VALUES (2, 11, 12) ON CONFLICT (k) DO UPDATE SET b = t5.a + 1 WHERE k = 2
 
 query III
-SELECT * FROM t5;
+SELECT * FROM t5
 ----
 1 10  9
 2 11  9
 
 statement error CHECK expression .* may not contain variable sub-expressions
-CREATE TABLE t6 (x INT CHECK (x = $1));
+CREATE TABLE t6 (x INT CHECK (x = $1))
 
 statement error CHECK expression .* may not contain variable sub-expressions
-CREATE TABLE t6 (x INT CHECK (x = (SELECT 1)));
+CREATE TABLE t6 (x INT CHECK (x = (SELECT 1)))
 
 

--- a/pkg/sql/testdata/collatedstring
+++ b/pkg/sql/testdata/collatedstring
@@ -1,17 +1,17 @@
 statement error pq: invalid locale bad_locale: language: subtag "locale" is well-formed but unknown
-SELECT 'a' COLLATE bad_locale;
+SELECT 'a' COLLATE bad_locale
 
 statement error pq: unsupported comparison operator: <collatedstring{en}> = <string>
-SELECT 'A' COLLATE en = 'a';
+SELECT 'A' COLLATE en = 'a'
 
 statement error pq: unsupported comparison operator: <collatedstring{en}> = <collatedstring{de}>
-SELECT 'A' COLLATE en = 'a' COLLATE de;
+SELECT 'A' COLLATE en = 'a' COLLATE de
 
 statement error pq: unsupported comparison operator: \('a' COLLATE en_u_ks_level1\) IN \('A' COLLATE en_u_ks_level1, 'b' COLLATE en\): expected 'b' COLLATE en to be of type collatedstring{en_u_ks_level1}, found type collatedstring{en}
-SELECT ('a' COLLATE en_u_ks_level1) IN ('A' COLLATE en_u_ks_level1, 'b' COLLATE en);
+SELECT ('a' COLLATE en_u_ks_level1) IN ('A' COLLATE en_u_ks_level1, 'b' COLLATE en)
 
 statement error pq: tuples \('a' COLLATE en_u_ks_level1, 'a' COLLATE en\), \('A' COLLATE en, 'B' COLLATE en\) are not the same type: expected 'A' COLLATE en to be of type collatedstring{en_u_ks_level1}, found type collatedstring{en}
-SELECT ('a' COLLATE en_u_ks_level1, 'a' COLLATE en) < ('A' COLLATE en, 'B' COLLATE en);
+SELECT ('a' COLLATE en_u_ks_level1, 'a' COLLATE en) < ('A' COLLATE en, 'B' COLLATE en)
 
 
 query T
@@ -26,148 +26,148 @@ true
 
 
 query B
-SELECT (1, 'a' COLLATE en) < (1, 'B' COLLATE en);
+SELECT (1, 'a' COLLATE en) < (1, 'B' COLLATE en)
 ----
 true
 
 query B
-SELECT ('a' COLLATE en_u_ks_level1, 'a' COLLATE en) < ('A' COLLATE en_u_ks_level1, 'B' COLLATE en);
+SELECT ('a' COLLATE en_u_ks_level1, 'a' COLLATE en) < ('A' COLLATE en_u_ks_level1, 'B' COLLATE en)
 ----
 true
 
 
 query B
-SELECT 'A' COLLATE en_u_ks_level1 = 'a' COLLATE en_u_ks_level1;
+SELECT 'A' COLLATE en_u_ks_level1 = 'a' COLLATE en_u_ks_level1
 ----
 true
 
 query B
-SELECT 'A' COLLATE en_u_ks_level1 <> 'a' COLLATE en_u_ks_level1;
+SELECT 'A' COLLATE en_u_ks_level1 <> 'a' COLLATE en_u_ks_level1
 ----
 false
 
 query B
-SELECT 'A' COLLATE en_u_ks_level1 < 'a' COLLATE en_u_ks_level1;
+SELECT 'A' COLLATE en_u_ks_level1 < 'a' COLLATE en_u_ks_level1
 ----
 false
 
 query B
-SELECT 'A' COLLATE en_u_ks_level1 >= 'a' COLLATE en_u_ks_level1;
+SELECT 'A' COLLATE en_u_ks_level1 >= 'a' COLLATE en_u_ks_level1
 ----
 true
 
 query B
-SELECT 'A' COLLATE en_u_ks_level1 <= 'a' COLLATE en_u_ks_level1;
+SELECT 'A' COLLATE en_u_ks_level1 <= 'a' COLLATE en_u_ks_level1
 ----
 true
 
 query B
-SELECT 'A' COLLATE en_u_ks_level1 > 'a' COLLATE en_u_ks_level1;
-----
-false
-
-
-query B
-SELECT 'a' COLLATE en_u_ks_level1 = 'B' COLLATE en_u_ks_level1;
-----
-false
-
-query B
-SELECT 'a' COLLATE en_u_ks_level1 <> 'B' COLLATE en_u_ks_level1;
-----
-true
-
-query B
-SELECT 'a' COLLATE en_u_ks_level1 < 'B' COLLATE en_u_ks_level1;
-----
-true
-
-query B
-SELECT 'a' COLLATE en_u_ks_level1 >= 'B' COLLATE en_u_ks_level1;
-----
-false
-
-query B
-SELECT 'a' COLLATE en_u_ks_level1 <= 'B' COLLATE en_u_ks_level1;
-----
-true
-
-query B
-SELECT 'a' COLLATE en_u_ks_level1 > 'B' COLLATE en_u_ks_level1;
+SELECT 'A' COLLATE en_u_ks_level1 > 'a' COLLATE en_u_ks_level1
 ----
 false
 
 
 query B
-SELECT 'B' COLLATE en_u_ks_level1 = 'A' COLLATE en_u_ks_level1;
+SELECT 'a' COLLATE en_u_ks_level1 = 'B' COLLATE en_u_ks_level1
 ----
 false
 
 query B
-SELECT 'B' COLLATE en_u_ks_level1 <> 'A' COLLATE en_u_ks_level1;
+SELECT 'a' COLLATE en_u_ks_level1 <> 'B' COLLATE en_u_ks_level1
 ----
 true
 
 query B
-SELECT 'B' COLLATE en_u_ks_level1 < 'A' COLLATE en_u_ks_level1;
-----
-false
-
-query B
-SELECT 'B' COLLATE en_u_ks_level1 >= 'A' COLLATE en_u_ks_level1;
+SELECT 'a' COLLATE en_u_ks_level1 < 'B' COLLATE en_u_ks_level1
 ----
 true
 
 query B
-SELECT 'B' COLLATE en_u_ks_level1 <= 'A' COLLATE en_u_ks_level1;
+SELECT 'a' COLLATE en_u_ks_level1 >= 'B' COLLATE en_u_ks_level1
 ----
 false
 
 query B
-SELECT 'B' COLLATE en_u_ks_level1 > 'A' COLLATE en_u_ks_level1;
+SELECT 'a' COLLATE en_u_ks_level1 <= 'B' COLLATE en_u_ks_level1
+----
+true
+
+query B
+SELECT 'a' COLLATE en_u_ks_level1 > 'B' COLLATE en_u_ks_level1
+----
+false
+
+
+query B
+SELECT 'B' COLLATE en_u_ks_level1 = 'A' COLLATE en_u_ks_level1
+----
+false
+
+query B
+SELECT 'B' COLLATE en_u_ks_level1 <> 'A' COLLATE en_u_ks_level1
+----
+true
+
+query B
+SELECT 'B' COLLATE en_u_ks_level1 < 'A' COLLATE en_u_ks_level1
+----
+false
+
+query B
+SELECT 'B' COLLATE en_u_ks_level1 >= 'A' COLLATE en_u_ks_level1
+----
+true
+
+query B
+SELECT 'B' COLLATE en_u_ks_level1 <= 'A' COLLATE en_u_ks_level1
+----
+false
+
+query B
+SELECT 'B' COLLATE en_u_ks_level1 > 'A' COLLATE en_u_ks_level1
 ----
 true
 
 
 query B
-SELECT ('a' COLLATE en_u_ks_level1) IN ('A' COLLATE en_u_ks_level1, 'b' COLLATE en_u_ks_level1);
+SELECT ('a' COLLATE en_u_ks_level1) IN ('A' COLLATE en_u_ks_level1, 'b' COLLATE en_u_ks_level1)
 ----
 true
 
 query B
-SELECT ('a' COLLATE en_u_ks_level1) NOT IN ('A' COLLATE en_u_ks_level1, 'b' COLLATE en_u_ks_level1);
+SELECT ('a' COLLATE en_u_ks_level1) NOT IN ('A' COLLATE en_u_ks_level1, 'b' COLLATE en_u_ks_level1)
 ----
 false
 
 query B
-SELECT ('a' COLLATE en) IN ('A' COLLATE en, 'b' COLLATE en);
+SELECT ('a' COLLATE en) IN ('A' COLLATE en, 'b' COLLATE en)
 ----
 false
 
 query B
-SELECT ('a' COLLATE en) NOT IN ('A' COLLATE en, 'b' COLLATE en);
-----
-true
-
-
-query B
-SELECT 'Fussball' COLLATE de = 'Fußball' COLLATE de;
-----
-false
-
-query B
-SELECT 'Fussball' COLLATE de_u_ks_level1 = 'Fußball' COLLATE de_u_ks_level1;
+SELECT ('a' COLLATE en) NOT IN ('A' COLLATE en, 'b' COLLATE en)
 ----
 true
 
 
 query B
-SELECT 'ü' COLLATE da < 'x' COLLATE da;
+SELECT 'Fussball' COLLATE de = 'Fußball' COLLATE de
 ----
 false
 
 query B
-SELECT 'ü' COLLATE de < 'x' COLLATE de;
+SELECT 'Fussball' COLLATE de_u_ks_level1 = 'Fußball' COLLATE de_u_ks_level1
+----
+true
+
+
+query B
+SELECT 'ü' COLLATE da < 'x' COLLATE da
+----
+false
+
+query B
+SELECT 'ü' COLLATE de < 'x' COLLATE de
 ----
 true
 
@@ -176,28 +176,28 @@ statement error invalid locale e: language: tag is not well-formed at or near "\
 ----
 CREATE TABLE e1 (
   a STRING COLLATE e
-);
+)
 
 statement error multiple COLLATE declarations for column "a" at or near "\)"
 ----
 CREATE TABLE e2 (
   a STRING COLLATE en COLLATE de
-);
+)
 
 statement error COLLATE declaration for non-string-typed column "a" at or near "\)"
 ----
 CREATE TABLE e3 (
   a INT COLLATE en
-);
+)
 
 statement ok
 ----
 CREATE TABLE t (
   a STRING COLLATE en
-);
+)
 
 query TT
-SHOW CREATE TABLE t;
+SHOW CREATE TABLE t
 ----
 t  CREATE TABLE t (
      a STRING COLLATE en NULL,
@@ -212,14 +212,14 @@ INSERT INTO t VALUES
   ('a' COLLATE en),
   ('b' COLLATE en),
   ('x' COLLATE en),
-  ('ü' COLLATE en);
+  ('ü' COLLATE en)
 
 statement error locale "de" doesn't match locale "en" of column "a"
 ----
-INSERT INTO t VALUES ('X' COLLATE de);
+INSERT INTO t VALUES ('X' COLLATE de)
 
 query T
-SELECT a FROM t ORDER BY t.a;
+SELECT a FROM t ORDER BY t.a
 ----
 a
 A
@@ -229,7 +229,7 @@ B
 x
 
 query T
-SELECT a FROM t ORDER BY t.a COLLATE da;
+SELECT a FROM t ORDER BY t.a COLLATE da
 ----
 a
 A

--- a/pkg/sql/testdata/create_as
+++ b/pkg/sql/testdata/create_as
@@ -16,7 +16,7 @@ statement ok
 CREATE TABLE itemTypes AS (SELECT item, color FROM stock, itemColors)
 
 query TT
-SELECT * FROM itemTypes;
+SELECT * FROM itemTypes
 ----
 cups blue
 cups red
@@ -32,10 +32,10 @@ statement error pq: unexpected AS OF SYSTEM TIME
 CREATE TABLE t AS SELECT * FROM stock AS OF SYSTEM TIME '2016-01-01'
 
 statement error pgcode 42601 CREATE TABLE specifies 3 column names, but data source has 2 columns
-CREATE TABLE t2 (col1, col2, col3) AS SELECT * FROM stock;
+CREATE TABLE t2 (col1, col2, col3) AS SELECT * FROM stock
 
 statement error pgcode 42601 CREATE TABLE specifies 1 column name, but data source has 2 columns
-CREATE TABLE t2 (col1) AS SELECT * FROM stock;
+CREATE TABLE t2 (col1) AS SELECT * FROM stock
 
 statement ok
 CREATE TABLE unionstock AS SELECT * FROM stock UNION VALUES ('spoons', 25), ('knives', 50)
@@ -58,7 +58,7 @@ SELECT * FROM unionstock ORDER BY quantity LIMIT 1
 cups 10
 
 statement ok
-CREATE DATABASE smtng;
+CREATE DATABASE smtng
 
 statement ok
 CREATE TABLE smtng.something AS SELECT * FROM stock

--- a/pkg/sql/testdata/datetime
+++ b/pkg/sql/testdata/datetime
@@ -231,7 +231,7 @@ SELECT * FROM kv;
 BEGIN;
 SELECT * FROM KV;
 INSERT INTO kv (k,v) VALUES ('i', transaction_timestamp());
-COMMIT;
+COMMIT
 
 query I
 SELECT COUNT(DISTINCT (v)) FROM kv
@@ -246,18 +246,18 @@ DELETE FROM kv
 statement ok
 BEGIN;
 INSERT INTO kv (k,v) VALUES ('a', transaction_timestamp());
-SELECT * FROM kv;
+SELECT * FROM kv
 
 statement ok
 INSERT INTO kv (k,v) VALUES ('b', transaction_timestamp());
 SELECT * FROM kv;
-COMMIT;
+COMMIT
 
 statement ok
 BEGIN;
 SELECT * FROM KV;
 INSERT INTO kv (k,v) VALUES ('c', transaction_timestamp());
-COMMIT;
+COMMIT
 
 query I
 SELECT COUNT(DISTINCT (v)) FROM kv
@@ -278,18 +278,18 @@ CREATE TABLE kv (
 statement ok
 BEGIN;
 INSERT INTO kv (k,v) VALUES (1, cluster_logical_timestamp());
-SELECT * FROM kv;
+SELECT * FROM kv
 
 statement ok
 INSERT INTO kv (k,v) VALUES (2, cluster_logical_timestamp());
 SELECT * FROM kv;
-COMMIT;
+COMMIT
 
 statement ok
 BEGIN;
 SELECT * FROM kv;
 INSERT INTO kv (k,v) VALUES (3, cluster_logical_timestamp());
-COMMIT;
+COMMIT
 
 query I
 SELECT COUNT(DISTINCT (v)) FROM kv
@@ -308,27 +308,27 @@ INSERT INTO m VALUES (cluster_logical_timestamp())
 # Test that cluster_logical_timestamp() is monotonic in transaction order
 statement ok
 INSERT INTO kv (k,v) VALUES (1, cluster_logical_timestamp()-(select mints from m));
-SELECT * FROM kv;
+SELECT * FROM kv
 
 statement ok
 INSERT INTO kv (k,v) VALUES (2, cluster_logical_timestamp()-(select mints from m));
-SELECT * FROM kv;
+SELECT * FROM kv
 
 statement ok
 INSERT INTO kv (k,v) VALUES (3, cluster_logical_timestamp()-(select mints from m));
-SELECT * FROM kv;
+SELECT * FROM kv
 
 statement ok
 INSERT INTO kv (k,v) VALUES (4, cluster_logical_timestamp()-(select mints from m));
-SELECT * FROM kv;
+SELECT * FROM kv
 
 statement ok
 INSERT INTO kv (k,v) VALUES (5, cluster_logical_timestamp()-(select mints from m));
-SELECT * FROM kv;
+SELECT * FROM kv
 
 statement ok
 INSERT INTO kv (k,v) VALUES (6, cluster_logical_timestamp()-(select mints from m));
-SELECT * FROM kv;
+SELECT * FROM kv
 
 query I
 SELECT k FROM kv ORDER BY v
@@ -625,7 +625,7 @@ SELECT d::timestamp FROM u WHERE a = 123
 2015-08-30 00:00:00 +0000 +0000
 
 statement ok
-SET TIME ZONE UTC;
+SET TIME ZONE UTC
 
 statement ok
 CREATE TABLE tz (
@@ -697,7 +697,7 @@ SHOW TIME ZONE
 -5
 
 statement ok
-SET TIME ZONE INTERVAL '+04:00' HOUR TO MINUTE;
+SET TIME ZONE INTERVAL '+04:00' HOUR TO MINUTE
 
 query T
 SELECT '2015-08-24 21:45:45.53453'::timestamptz
@@ -705,7 +705,7 @@ SELECT '2015-08-24 21:45:45.53453'::timestamptz
 2015-08-24 21:45:45.53453 +0400 +0400
 
 statement ok
-SET TIME ZONE INTERVAL '-04:00' MINUTE TO SECOND;
+SET TIME ZONE INTERVAL '-04:00' MINUTE TO SECOND
 
 query T
 SELECT '2015-08-24 21:45:45.53453'::timestamptz
@@ -731,66 +731,66 @@ SELECT INTERVAL '4 minutes' + DATE '1999-01-01'
 1999-01-01 00:04:00 +0000 +0000
 
 query T
-SELECT DATE '1999-01-01' - INTERVAL '4 minutes';
+SELECT DATE '1999-01-01' - INTERVAL '4 minutes'
 ----
 1998-12-31 23:56:00 +0000 +0000
 
 query B
-SELECT DATE '1999-01-02' < TIMESTAMPTZ '1999-01-01';
+SELECT DATE '1999-01-02' < TIMESTAMPTZ '1999-01-01'
 ----
 false
 
 query B
-SELECT DATE '1999-01-02' < TIMESTAMP '1999-01-01';
+SELECT DATE '1999-01-02' < TIMESTAMP '1999-01-01'
 ----
 false
 
 query B
-SELECT DATE '1999-01-02' <= TIMESTAMPTZ '1999-01-01';
+SELECT DATE '1999-01-02' <= TIMESTAMPTZ '1999-01-01'
 ----
 false
 
 query B
-SELECT DATE '1999-01-02' <= TIMESTAMP '1999-01-01';
+SELECT DATE '1999-01-02' <= TIMESTAMP '1999-01-01'
 ----
 false
 
 query B
-SELECT DATE '1999-01-02' <= TIMESTAMPTZ '1999-01-02';
+SELECT DATE '1999-01-02' <= TIMESTAMPTZ '1999-01-02'
 ----
 true
 
 query B
-SELECT DATE '1999-01-02' <= TIMESTAMP '1999-01-02';
+SELECT DATE '1999-01-02' <= TIMESTAMP '1999-01-02'
 ----
 true
 
 query B
-SELECT DATE '1999-01-02' > TIMESTAMPTZ '1999-01-01';
+SELECT DATE '1999-01-02' > TIMESTAMPTZ '1999-01-01'
 ----
 true
 
 query B
-SELECT DATE '1999-01-02' > TIMESTAMP '1999-01-01';
+SELECT DATE '1999-01-02' > TIMESTAMP '1999-01-01'
 ----
 true
 
 query B
-SELECT DATE '1999-01-02' >= TIMESTAMPTZ '1999-01-01';
+SELECT DATE '1999-01-02' >= TIMESTAMPTZ '1999-01-01'
 ----
 true
 
 query B
-SELECT DATE '1999-01-02' >= TIMESTAMP '1999-01-01';
+SELECT DATE '1999-01-02' >= TIMESTAMP '1999-01-01'
 ----
 true
 
 query B
-SELECT DATE '1999-01-02' = TIMESTAMPTZ '1999-01-01';
+SELECT DATE '1999-01-02' = TIMESTAMPTZ '1999-01-01'
 ----
 false
 
 query B
-SELECT DATE '1999-01-01' = TIMESTAMP '1999-01-01';
+SELECT DATE '1999-01-01' = TIMESTAMP '1999-01-01'
 ----
 true

--- a/pkg/sql/testdata/delete
+++ b/pkg/sql/testdata/delete
@@ -164,7 +164,7 @@ SELECT k, v FROM unindexed
 k v
 
 statement ok
-CREATE TABLE indexed (id int primary key, value int, other int, index (value));
+CREATE TABLE indexed (id int primary key, value int, other int, index (value))
 
 statement ok
-DELETE FROM indexed WHERE value = 5;
+DELETE FROM indexed WHERE value = 5

--- a/pkg/sql/testdata/distinct
+++ b/pkg/sql/testdata/distinct
@@ -7,7 +7,7 @@ CREATE TABLE xyz (
 )
 
 statement ok
-INSERT INTO xyz VALUES (1, 2, 3), (2, 5, 6), (3, 2, 3), (4, 5, 6), (5, 2, 6), (6, 3, 5), (7, 2, 9);
+INSERT INTO xyz VALUES (1, 2, 3), (2, 5, 6), (3, 2, 3), (4, 5, 6), (5, 2, 6), (6, 3, 5), (7, 2, 9)
 
 query II
 SELECT y, z FROM xyz

--- a/pkg/sql/testdata/explain_types
+++ b/pkg/sql/testdata/explain_types
@@ -19,7 +19,7 @@ statement ok
 INSERT INTO t VALUES (1, 2)
 
 query ITTTTT
-EXPLAIN (TYPES) SELECT 42;
+EXPLAIN (TYPES) SELECT 42
 ----
 0  render                              ("42" int)
 0                 render 0  (42)[int]

--- a/pkg/sql/testdata/fk
+++ b/pkg/sql/testdata/fk
@@ -44,7 +44,7 @@ CREATE TABLE orders (
   CONSTRAINT fk FOREIGN KEY (product) REFERENCES products,
   INDEX (product),
   INDEX (customer)
-);
+)
 
 statement ok
 CREATE TABLE orders (
@@ -55,10 +55,10 @@ CREATE TABLE orders (
   PRIMARY KEY (id, shipment),
   INDEX (product),
   INDEX (customer)
-);
+)
 
 statement ok
-CREATE DATABASE "user content";
+CREATE DATABASE "user content"
 
 # "reviews" makes "products" have multiple inbound references, as well as making
 # "orders" have both directions, and makes sure that we're handling escaping and
@@ -79,7 +79,7 @@ CREATE TABLE "user content"."customer reviews" (
 )
 
 statement ok
-INSERT INTO orders VALUES (1, 1, '780', 2);
+INSERT INTO orders VALUES (1, 1, '780', 2)
 
 statement error foreign key violation: values \['780'\] in columns \[sku\] referenced in table "orders"
 DELETE FROM products
@@ -88,41 +88,41 @@ statement ok
 INSERT INTO "user content"."customer reviews" VALUES (1, '780', 2, 1, 1, NULL)
 
 statement error foreign key violation: value \['790'\] not found in products@primary \[sku\]
-INSERT INTO "user content"."customer reviews" (id, product, body) VALUES (2, '790', 'would not buy again');
+INSERT INTO "user content"."customer reviews" (id, product, body) VALUES (2, '790', 'would not buy again')
 
 statement ok
-INSERT INTO "user content"."customer reviews" (id, product, body) VALUES (2, '780', 'would not buy again');
+INSERT INTO "user content"."customer reviews" (id, product, body) VALUES (2, '780', 'would not buy again')
 
 statement ok
 DELETE FROM "user content"."customer reviews"
 
 statement error foreign key violation: value \['790'\] not found in products@primary \[sku\]
-INSERT INTO orders VALUES (2, 1, '790', 2);
+INSERT INTO orders VALUES (2, 1, '790', 2)
 
 statement error foreign key violation: value \[43\] not found in customers@primary \[id\]
-INSERT INTO orders VALUES (2, 1, '780', 43);
+INSERT INTO orders VALUES (2, 1, '780', 43)
 
 statement ok
-INSERT INTO orders VALUES (2, 1, '780', 1);
+INSERT INTO orders VALUES (2, 1, '780', 1)
 
 # Try to point to missing FK.
 statement error foreign key violation: value \['790'\] not found in products@primary \[sku\]
-UPDATE orders SET product = '790' WHERE id = 2;
+UPDATE orders SET product = '790' WHERE id = 2
 
 # Try to point to missing fk *while changing PK*.
 statement error foreign key violation: value \['790'\] not found in products@primary \[sku\]
-UPDATE orders SET id = 3, product = '790' WHERE id = 2;
+UPDATE orders SET id = 3, product = '790' WHERE id = 2
 
 # Change PK while leaving everything else is fine though.
 statement ok
-UPDATE orders SET id = 3 WHERE id = 2;
+UPDATE orders SET id = 3 WHERE id = 2
 
 # Change PK and point to different product.
 statement ok
-UPDATE orders SET id = 2, product = 'VP-W9QH-W44L' WHERE id = 3;
+UPDATE orders SET id = 2, product = 'VP-W9QH-W44L' WHERE id = 3
 
 statement ok
-UPDATE orders SET product = '780' WHERE id = 2;
+UPDATE orders SET product = '780' WHERE id = 2
 
 # "delivery" is interesting since it references a secondary index with different col names.
 statement ok
@@ -137,15 +137,15 @@ CREATE TABLE delivery (
 
 statement ok
 INSERT INTO delivery ("order", shipment, item) VALUES
-  (1, 1, '867072000006'), (1, 1, '867072000006'), (1, 1, '885155001450'), (1, 1, '867072000006');
+  (1, 1, '867072000006'), (1, 1, '867072000006'), (1, 1, '885155001450'), (1, 1, '867072000006')
 
 statement error foreign key violation: value \['missing'\] not found in products@products_upc_key \[upc\]
 INSERT INTO delivery ("order", shipment, item) VALUES
-  (1, 1, '867072000006'), (1, 1, 'missing'), (1, 1, '885155001450'), (1, 1, '867072000006');
+  (1, 1, '867072000006'), (1, 1, 'missing'), (1, 1, '885155001450'), (1, 1, '867072000006')
 
 statement error foreign key violation: value \[1 99\] not found in orders@primary \[id shipment\]
 INSERT INTO delivery ("order", shipment, item) VALUES
-  (1, 1, '867072000006'), (1, 99, '867072000006');
+  (1, 1, '867072000006'), (1, 99, '867072000006')
 
 statement error foreign key violation: values \['867072000006'\] in columns \[upc\] referenced in table "delivery"
 DELETE FROM products WHERE sku = 'VP-W9QH-W44L'
@@ -218,20 +218,20 @@ ALTER TABLE "user content"."customer reviews"
   DROP CONSTRAINT orderfk
 
 statement ok
-INSERT INTO "user content"."customer reviews" (id, product, body, "order") VALUES (3, '780', 'i ordered 100 of them', 9);
+INSERT INTO "user content"."customer reviews" (id, product, body, "order") VALUES (3, '780', 'i ordered 100 of them', 9)
 
 statement ok
 ALTER TABLE "user content"."customer reviews"
   ADD CONSTRAINT orderfk2 FOREIGN KEY ("order", shipment) REFERENCES orders (id, shipment)
 
 statement error missing value for column "shipment" in multi-part foreign key
-INSERT INTO "user content"."customer reviews" (id, product, body, "order") VALUES (4, '780', 'i ordered 101 of them', 9);
+INSERT INTO "user content"."customer reviews" (id, product, body, "order") VALUES (4, '780', 'i ordered 101 of them', 9)
 
 statement error foreign key violation: value \[9 1\] not found in orders@primary \[id shipment\]
-INSERT INTO "user content"."customer reviews" (id, product, body, "order", shipment) VALUES (4, '780', 'i ordered 101 of them', 9, 1);
+INSERT INTO "user content"."customer reviews" (id, product, body, "order", shipment) VALUES (4, '780', 'i ordered 101 of them', 9, 1)
 
 statement error foreign key violation: value \[1 9\] not found in orders@primary \[id shipment\]
-INSERT INTO "user content"."customer reviews" (id, product, body, shipment, "order") VALUES (4, '780', 'i ordered 101 of them', 9, 1);
+INSERT INTO "user content"."customer reviews" (id, product, body, shipment, "order") VALUES (4, '780', 'i ordered 101 of them', 9, 1)
 
 statement error foreign key violation: "customer reviews" row order=9, shipment=NULL has no match in "orders"
 ALTER TABLE "user content"."customer reviews"
@@ -325,13 +325,13 @@ statement ok
 DROP TABLE products
 
 statement ok
-CREATE TABLE parent (id int primary key);
+CREATE TABLE parent (id int primary key)
 
 statement ok
-CREATE TABLE child (id INT PRIMARY KEY, parent_id INT UNIQUE REFERENCES parent);
+CREATE TABLE child (id INT PRIMARY KEY, parent_id INT UNIQUE REFERENCES parent)
 
 statement ok
-CREATE TABLE grandchild (id INT PRIMARY KEY, parent_id INT REFERENCES child (parent_id), INDEX (parent_id));
+CREATE TABLE grandchild (id INT PRIMARY KEY, parent_id INT REFERENCES child (parent_id), INDEX (parent_id))
 
 statement error "parent" is referenced by foreign key from table "child"
 DROP TABLE parent
@@ -364,7 +364,7 @@ statement ok
 DROP TABLE grandchild
 
 statement ok
-CREATE TABLE grandchild (id INT PRIMARY KEY, parent_id INT REFERENCES child (parent_id), INDEX (parent_id));
+CREATE TABLE grandchild (id INT PRIMARY KEY, parent_id INT REFERENCES child (parent_id), INDEX (parent_id))
 
 statement error foreign key violation
 INSERT INTO grandchild VALUES (1, 1)
@@ -379,7 +379,7 @@ statement ok
 INSERT INTO grandchild VALUES (1, 1)
 
 statement ok
-CREATE TABLE employees (id INT PRIMARY KEY, manager INT REFERENCES employees, INDEX (manager));
+CREATE TABLE employees (id INT PRIMARY KEY, manager INT REFERENCES employees, INDEX (manager))
 
 statement ok
 INSERT INTO employees VALUES (1, NULL)
@@ -388,7 +388,7 @@ statement ok
 INSERT INTO employees VALUES (2, 1), (3, 1)
 
 statement ok
-INSERT INTO employees VALUES (4, 2), (5, 3);
+INSERT INTO employees VALUES (4, 2), (5, 3)
 
 statement error foreign key violation
 DELETE FROM employees WHERE id = 2
@@ -512,10 +512,10 @@ statement ok
 DROP TABLE otherdb.othertable, crossdb
 
 statement ok
-CREATE TABLE modules (id BIGSERIAL NOT NULL PRIMARY KEY);
+CREATE TABLE modules (id BIGSERIAL NOT NULL PRIMARY KEY)
 
 statement ok
-CREATE TABLE domains (id BIGSERIAL NOT NULL PRIMARY KEY);
+CREATE TABLE domains (id BIGSERIAL NOT NULL PRIMARY KEY)
 
 # We'll use the unique index for the domain fk (since it is a prefix), but we
 # we correctly only mark the prefix as used and thus still allow module_id to be
@@ -528,4 +528,4 @@ CREATE TABLE domain_modules (
   CONSTRAINT domain_modules_domain_id_fk FOREIGN KEY (domain_id) REFERENCES domains (id),
   CONSTRAINT domain_modules_module_id_fk FOREIGN KEY (module_id) REFERENCES modules (id),
   CONSTRAINT domain_modules_uq UNIQUE (domain_id, module_id)
-);
+)

--- a/pkg/sql/testdata/generators
+++ b/pkg/sql/testdata/generators
@@ -116,13 +116,13 @@ query error pq: unsupported binary operator: <int> \+ <setof tuple\{int\}>
 SELECT 3 + generate_series(1,2)
 
 query I
-SELECT * from unnest(ARRAY[1,2]);
+SELECT * from unnest(ARRAY[1,2])
 ----
 1
 2
 
 query IT
-SELECT unnest(ARRAY[1,2]), unnest(ARRAY['a', 'b']);
+SELECT unnest(ARRAY[1,2]), unnest(ARRAY['a', 'b'])
 ----
 1  a
 1  b

--- a/pkg/sql/testdata/join
+++ b/pkg/sql/testdata/join
@@ -288,7 +288,7 @@ CREATE TABLE twocolumn (x INT, y INT); INSERT INTO twocolumn(x, y) VALUES (44,51
 
 # Natural joins with partial match
 query II colnames
-SELECT * FROM onecolumn NATURAL JOIN twocolumn;
+SELECT * FROM onecolumn NATURAL JOIN twocolumn
 ----
 x    y
 44   51
@@ -368,7 +368,7 @@ NULL 4    false
 
 # Full outer join with filter predicate
 query IIB
-SELECT * FROM a FULL OUTER JOIN b ON (a.i = b.i and a.i>2) ORDER BY a.i, b.i;
+SELECT * FROM a FULL OUTER JOIN b ON (a.i = b.i and a.i>2) ORDER BY a.i, b.i
 ----
 NULL 2    true
 NULL 4    false
@@ -381,7 +381,7 @@ statement ok
 INSERT INTO b VALUES (3, false)
 
 query IIB
-SELECT * FROM a RIGHT OUTER JOIN b ON a.i=b.i ORDER BY b.i, b.b;
+SELECT * FROM a RIGHT OUTER JOIN b ON a.i=b.i ORDER BY b.i, b.b
 ----
 2    2 true
 3    3 false
@@ -389,7 +389,7 @@ SELECT * FROM a RIGHT OUTER JOIN b ON a.i=b.i ORDER BY b.i, b.b;
 NULL 4 false
 
 query IIB
-SELECT * FROM a FULL OUTER JOIN b ON a.i=b.i ORDER BY b.i, b.b;
+SELECT * FROM a FULL OUTER JOIN b ON a.i=b.i ORDER BY b.i, b.b
 ----
 1    NULL NULL
 2    2    true
@@ -572,7 +572,7 @@ query error column "x" appears more than once in USING clause
 SELECT * FROM (onecolumn AS a JOIN onecolumn AS b USING(x, x))
 
 statement ok
-CREATE TABLE othertype (x TEXT);
+CREATE TABLE othertype (x TEXT)
 
 query error JOIN/USING types.*cannot be matched
 SELECT * FROM (onecolumn AS a JOIN othertype AS b USING(x))
@@ -599,7 +599,7 @@ NULL   NULL
 
 # Check that anonymous sources are properly looked up without ambiguity.
 query I
-SELECT x FROM (onecolumn JOIN othercolumn USING (x)) JOIN (onecolumn AS a JOIN othercolumn AS b USING(x)) USING(x);
+SELECT x FROM (onecolumn JOIN othercolumn USING (x)) JOIN (onecolumn AS a JOIN othercolumn AS b USING(x)) USING(x)
 ----
 42
 
@@ -622,7 +622,7 @@ CREATE TABLE s(x INT); INSERT INTO s(x) VALUES (1),(2),(3),(4),(5),(6),(7),(8),(
 #
 # # The following query demands at least 100GB of RAM if unoptimized.
 # query error memory budget exceeded
-# SELECT COUNT(*) FROM s AS a, s AS b, s AS c, s AS d, s AS e, s AS f, s AS g, s AS h, s AS i, s AS j, s AS k;
+# SELECT COUNT(*) FROM s AS a, s AS b, s AS c, s AS d, s AS e, s AS f, s AS g, s AS h, s AS i, s AS j, s AS k
 
 # THe following queries verify that only the necessary columns are scanned.
 query ITTTTT
@@ -700,7 +700,7 @@ EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES (9, 1), (8, 2)) AS a (u,
 
 # Ensure that large cross-joins are optimized somehow (#10633)
 statement ok
-CREATE TABLE customers(id INT PRIMARY KEY NOT NULL); CREATE TABLE orders(id INT, cust INT REFERENCES customers(id));
+CREATE TABLE customers(id INT PRIMARY KEY NOT NULL); CREATE TABLE orders(id INT, cust INT REFERENCES customers(id))
 
 query ITTT
 SELECT * FROM [EXPLAIN SELECT

--- a/pkg/sql/testdata/multi_statement
+++ b/pkg/sql/testdata/multi_statement
@@ -51,13 +51,13 @@ c d
 g h
 
 statement error pq: database "x" does not exist
-BEGIN; INSERT INTO x.y(a) VALUES (1); END;
+BEGIN; INSERT INTO x.y(a) VALUES (1); END
 
 statement error pq: current transaction is aborted, commands ignored until end of transaction block
-SELECT * from kv; ROLLBACK;
+SELECT * from kv; ROLLBACK
 
 statement ok
 ROLLBACK
 
 statement error pq: table "system.t" does not exist
-BEGIN TRANSACTION; SELECT * FROM system.t; INSERT INTO t(a) VALUES (1);
+BEGIN TRANSACTION; SELECT * FROM system.t; INSERT INTO t(a) VALUES (1)

--- a/pkg/sql/testdata/needed_columns
+++ b/pkg/sql/testdata/needed_columns
@@ -115,7 +115,7 @@ EXPLAIN(METADATA) SELECT 1 FROM kv
 
 # Propagation through DISTINCT.
 query ITTTTT
-EXPLAIN (METADATA) SELECT DISTINCT v FROM kv;
+EXPLAIN (METADATA) SELECT DISTINCT v FROM kv
 ----
 0  distinct                     (v)
 1  render                       (v)

--- a/pkg/sql/testdata/order_by
+++ b/pkg/sql/testdata/order_by
@@ -527,10 +527,10 @@ statement ok
 CREATE TABLE bar (id INT PRIMARY KEY, baz STRING, UNIQUE INDEX i_bar (baz))
 
 statement ok
-INSERT INTO bar VALUES (0, NULL), (1, NULL);
+INSERT INTO bar VALUES (0, NULL), (1, NULL)
 
 query IT
-SELECT * FROM bar ORDER BY baz, id;
+SELECT * FROM bar ORDER BY baz, id
 ----
 0 NULL
 1 NULL
@@ -581,13 +581,13 @@ EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, c, a
 1        spans  /1/4-/1/5
 
 statement ok
-CREATE TABLE nan (id INT PRIMARY KEY, x REAL);
+CREATE TABLE nan (id INT PRIMARY KEY, x REAL)
 
 statement ok
-INSERT INTO nan VALUES (1, 0/0), (2, -1), (3, 1), (4, 0/0);
+INSERT INTO nan VALUES (1, 0/0), (2, -1), (3, 1), (4, 0/0)
 
 query R
-SELECT x FROM nan ORDER BY x;
+SELECT x FROM nan ORDER BY x
 ----
 NaN
 NaN
@@ -595,7 +595,7 @@ NaN
 1
 
 query ITTTTT
-EXPLAIN(METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x);
+EXPLAIN(METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x)
 ----
 0  sort                             (x)        +x
 0          order  +x
@@ -604,14 +604,14 @@ EXPLAIN(METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c
 2          size   1 column, 3 rows
 
 query ITTT
-EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality ASC;
+EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality ASC
 ----
 0  ordinality
 1  values
 1              size  1 column, 3 rows
 
 query ITTT
-EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality DESC;
+EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality DESC
 ----
 0  sort
 0              order  -ordinality
@@ -620,7 +620,7 @@ EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordi
 2              size   1 column, 3 rows
 
 query ITTTTT
-EXPLAIN(METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY;
+EXPLAIN(METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY
 ----
 0  ordinality                          (x, ordinality)  +ordinality,unique
 1  render                              (x)
@@ -628,7 +628,7 @@ EXPLAIN(METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c
 2              size  1 column, 3 rows
 
 query ITTTTT
-EXPLAIN(METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY;
+EXPLAIN(METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY
 ----
 0  ordinality                           (x, ordinality)  +x
 1  sort                                 (x)              +x

--- a/pkg/sql/testdata/ordinal_references
+++ b/pkg/sql/testdata/ordinal_references
@@ -79,7 +79,7 @@ SELECT SUM(a) AS s FROM foo GROUP BY @2 ORDER BY s
 
 # Check that GROUP BY picks up column ordinals.
 query ITTTTT
-EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1;
+EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1
 ----
 0  group                                 (m)
 0          aggregate 0  min(test.foo.a)
@@ -92,7 +92,7 @@ EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1;
 2          spans        ALL
 
 query ITTTTT
-EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2;
+EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2
 ----
 0  group                                 (m)
 0          aggregate 0  min(test.foo.a)

--- a/pkg/sql/testdata/ordinality
+++ b/pkg/sql/testdata/ordinality
@@ -81,7 +81,7 @@ true
 
 # Show that the primary key is used under ordinalityNode.
 query ITTTTT
-EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM foo WHERE x > 'a') WITH ORDINALITY;
+EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM foo WHERE x > 'a') WITH ORDINALITY
 ----
 0  ordinality                      (x, ordinality)  +x,unique
 1  scan                            (x)              +x,unique
@@ -91,7 +91,7 @@ EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM foo WHERE x > 'a') WITH ORDINALI
 # Show that the primary key cannot be used with a PK predicate
 # outside of ordinalityNode.
 query ITTTTT
-EXPLAIN (METADATA) SELECT * FROM foo WITH ORDINALITY WHERE x > 'a';
+EXPLAIN (METADATA) SELECT * FROM foo WITH ORDINALITY WHERE x > 'a'
 ----
 0  filter                          (x, ordinality)  +x,unique
 1  ordinality                      (x, ordinality)  +x,unique

--- a/pkg/sql/testdata/orms
+++ b/pkg/sql/testdata/orms
@@ -26,7 +26,7 @@ SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_v
     JOIN pg_enum e ON t.oid = e.enumtypid
     JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
     WHERE n.nspname = 'public'
-    GROUP BY 1;
+    GROUP BY 1
 ----
 
 

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -136,7 +136,7 @@ CREATE TABLE constraint_db.t3 (
 )
 
 statement ok
-CREATE VIEW constraint_db.v1 AS SELECT p,a,b,c FROM constraint_db.t1;
+CREATE VIEW constraint_db.v1 AS SELECT p,a,b,c FROM constraint_db.t1
 
 ## pg_catalog.pg_namespace
 
@@ -796,7 +796,7 @@ oid   typname      typndims  typcollation  typdefaultbin  typdefault  typacl
 query TOOOTTO colnames
 SELECT proname, pronamespace, proowner, prolang, procost, prorows, provariadic
 FROM pg_catalog.pg_proc
-WHERE proname='substring';
+WHERE proname='substring'
 ----
 proname    pronamespace  proowner  prolang  procost  prorows  provariadic
 substring  1782195457    NULL      0        NULL     NULL     0
@@ -807,7 +807,7 @@ substring  1782195457    NULL      0        NULL     NULL     0
 query TTBBBB colnames
 SELECT proname, protransform, proisagg, proiswindow, prosecdef, proleakproof
 FROM pg_catalog.pg_proc
-WHERE proname='substring';
+WHERE proname='substring'
 ----
 proname    protransform  proisagg  proiswindow  prosecdef  proleakproof
 substring  NULL          false     false        false      true
@@ -818,7 +818,7 @@ substring  NULL          false     false        false      true
 query TBBTT colnames
 SELECT proname, proisstrict, proretset, provolatile, proparallel
 FROM pg_catalog.pg_proc
-WHERE proname='substring';
+WHERE proname='substring'
 ----
 proname    proisstrict  proretset  provolatile  proparallel
 substring  false        false      NULL         NULL
@@ -829,7 +829,7 @@ substring  false        false      NULL         NULL
 query TIIOTTTT colnames
 SELECT proname, pronargs, pronargdefaults, prorettype, proargtypes, proallargtypes, proargmodes, proargdefaults
 FROM pg_catalog.pg_proc
-WHERE proname='substring';
+WHERE proname='substring'
 ----
 proname    pronargs  pronargdefaults  prorettype  proargtypes  proallargtypes  proargmodes  proargdefaults
 substring  2         0                25          25, 20       NULL            NULL         NULL
@@ -840,7 +840,7 @@ substring  3         0                25          25, 25, 25   NULL            N
 query TTTTTT colnames
 SELECT proname, protrftypes, prosrc, probin, proconfig, proacl
 FROM pg_catalog.pg_proc
-WHERE proname='substring';
+WHERE proname='substring'
 ----
 proname    protrftypes  prosrc     probin  proconfig  proacl
 substring  NULL         substring  NULL    NULL       NULL
@@ -867,7 +867,7 @@ rngtypid  rngsubtype  rngcollation  rngsubopc  rngcanonical  rngsubdiff
 query OTBBBBBBI colnames
 SELECT oid, rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb, rolcatupdate, rolcanlogin, rolconnlimit
 FROM pg_catalog.pg_roles
-ORDER BY rolname;
+ORDER BY rolname
 ----
 oid         rolname   rolsuper  rolinherit  rolcreaterole  rolcreatedb  rolcatupdate  rolcanlogin  rolconnlimit
 2901009604  root      true      false       true           true         false         true         -1
@@ -876,7 +876,7 @@ oid         rolname   rolsuper  rolinherit  rolcreaterole  rolcreatedb  rolcatup
 query OTTTT colnames
 SELECT oid, rolname, rolpassword, rolvaliduntil, rolconfig
 FROM pg_catalog.pg_roles
-ORDER BY rolname;
+ORDER BY rolname
 ----
 oid         rolname   rolpassword  rolvaliduntil  rolconfig
 2901009604  root      ********     NULL           {}
@@ -984,7 +984,7 @@ statement ok
 SET DATABASE = 'constraint_db'
 
 query I
-SELECT COUNT(*) FROM pg_catalog.pg_tables WHERE schemaname='constraint_db';
+SELECT COUNT(*) FROM pg_catalog.pg_tables WHERE schemaname='constraint_db'
 ----
 3
 
@@ -995,12 +995,12 @@ statement ok
 SET DATABASE = ''
 
 query I
-SELECT COUNT(*) FROM pg_catalog.pg_tables WHERE schemaname='constraint_db';
+SELECT COUNT(*) FROM pg_catalog.pg_tables WHERE schemaname='constraint_db'
 ----
 0
 
 query I
-SELECT COUNT(*) FROM pg_catalog.pg_views WHERE schemaname='constraint_db';
+SELECT COUNT(*) FROM pg_catalog.pg_views WHERE schemaname='constraint_db'
 ----
 0
 
@@ -1029,12 +1029,12 @@ SELECT COUNT(*) FROM pg_catalog.pg_depend
 user root
 
 query I
-SELECT COUNT(*) FROM pg_catalog.pg_tables WHERE schemaname='constraint_db';
+SELECT COUNT(*) FROM pg_catalog.pg_tables WHERE schemaname='constraint_db'
 ----
 3
 
 query I
-SELECT COUNT(*) FROM pg_catalog.pg_views WHERE schemaname='constraint_db';
+SELECT COUNT(*) FROM pg_catalog.pg_views WHERE schemaname='constraint_db'
 ----
 1
 

--- a/pkg/sql/testdata/pgoidtype
+++ b/pkg/sql/testdata/pgoidtype
@@ -1,5 +1,5 @@
 query O
-SELECT 3::OID;
+SELECT 3::OID
 ----
 3
 

--- a/pkg/sql/testdata/rename_view
+++ b/pkg/sql/testdata/rename_view
@@ -14,7 +14,7 @@ statement ok
 INSERT INTO kv VALUES (1, 2), (3, 4)
 
 statement ok
-CREATE VIEW v as SELECT k,v FROM kv;
+CREATE VIEW v as SELECT k,v FROM kv
 
 query II
 SELECT * FROM v

--- a/pkg/sql/testdata/select
+++ b/pkg/sql/testdata/select
@@ -184,7 +184,7 @@ CREATE TABLE xyzw (
 )
 
 statement ok
-INSERT INTO xyzw VALUES (4, 5, 6, 7), (1, 2, 3, 4);
+INSERT INTO xyzw VALUES (4, 5, 6, 7), (1, 2, 3, 4)
 
 query error name \"x\" is not defined
 SELECT * FROM xyzw LIMIT x

--- a/pkg/sql/testdata/select_index
+++ b/pkg/sql/testdata/select_index
@@ -378,7 +378,7 @@ statement ok
 CREATE TABLE ab (
   s STRING,
   i INT
-); INSERT INTO ab VALUES ('a', 1), ('b', 1), ('c', 1);
+); INSERT INTO ab VALUES ('a', 1), ('b', 1), ('c', 1)
 
 query IT
 SELECT i, s FROM ab WHERE (i, s) < (1, 'c')

--- a/pkg/sql/testdata/subquery
+++ b/pkg/sql/testdata/subquery
@@ -340,7 +340,7 @@ true
 
 # check that residual filters are not expanded twice
 query ITTTTT
-EXPLAIN(METADATA) SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz);
+EXPLAIN(METADATA) SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz)
 ----
 0  render                           (x)                          +x,unique
 1  scan                             (x, y[omitted], z[omitted])  +x,unique
@@ -359,10 +359,10 @@ statement ok
 CREATE TABLE tab4(col0 INTEGER, col1 FLOAT, col3 INTEGER, col4 FLOAT)
 
 statement ok
-INSERT INTO tab4 VALUES (1,1,1,1);
+INSERT INTO tab4 VALUES (1,1,1,1)
 
 statement ok
-CREATE INDEX idx_tab4_0 ON tab4 (col4,col0);
+CREATE INDEX idx_tab4_0 ON tab4 (col4,col0)
 
 query I
 SELECT col0 FROM tab4 WHERE (col0 <= 0 AND col4 <= 5.38) OR (col4 IN (SELECT col1 FROM tab4 WHERE col1 > 8.27)) AND (col3 <= 5 AND (col3 BETWEEN 7 AND 9))

--- a/pkg/sql/testdata/system
+++ b/pkg/sql/testdata/system
@@ -68,20 +68,20 @@ SELECT length(descriptor) * (id - 1) FROM system.descriptor WHERE id = 1
 
 # Verify format of system tables.
 query TTBTT
-SHOW COLUMNS FROM system.namespace;
+SHOW COLUMNS FROM system.namespace
 ----
 parentID INT    false NULL {primary}
 name     STRING false NULL {primary}
 id       INT    true  NULL {}
 
 query TTBTT
-SHOW COLUMNS FROM system.descriptor;
+SHOW COLUMNS FROM system.descriptor
 ----
 id         INT   false NULL {primary}
 descriptor BYTES true  NULL {}
 
 query TTBTT
-SHOW COLUMNS FROM system.lease;
+SHOW COLUMNS FROM system.lease
 ----
 descID     INT       false NULL {primary}
 version    INT       false NULL {primary}
@@ -89,14 +89,14 @@ nodeID     INT       false NULL {primary}
 expiration TIMESTAMP false NULL {primary}
 
 query TTBTT
-SHOW COLUMNS FROM system.ui;
+SHOW COLUMNS FROM system.ui
 ----
 key          STRING     false  NULL {primary}
 value        BYTES      true   NULL {}
 lastUpdated  TIMESTAMP  false  NULL {}
 
 query TTBTT
-SHOW COLUMNS FROM system.rangelog;
+SHOW COLUMNS FROM system.rangelog
 ----
 timestamp     TIMESTAMP  false  NULL           {primary}
 rangeID       INT        false  NULL           {}
@@ -107,13 +107,13 @@ info          STRING     true   NULL           {}
 uniqueID      INT        false  unique_rowid() {primary}
 
 query TTBTT
-SHOW COLUMNS FROM system.users;
+SHOW COLUMNS FROM system.users
 ----
 username       STRING false NULL {primary}
 hashedPassword BYTES  true  NULL {}
 
 query TTBTT
-SHOW COLUMNS FROM system.zones;
+SHOW COLUMNS FROM system.zones
 ----
 id     INT   false NULL {primary}
 config BYTES true  NULL {}

--- a/pkg/sql/testdata/table
+++ b/pkg/sql/testdata/table
@@ -387,38 +387,38 @@ ak     BYTES                     true   NULL			{}
 al     INTERVAL                  true   NULL            {}
 
 statement ok
-CREATE DATABASE IF NOT EXISTS smtng;
+CREATE DATABASE IF NOT EXISTS smtng
 
 statement ok
 CREATE TABLE IF NOT EXISTS smtng.something (
 ID SERIAL PRIMARY KEY
-);
+)
 
 statement ok
-ALTER TABLE smtng.something ADD COLUMN IF NOT EXISTS OWNER_ID INT;
+ALTER TABLE smtng.something ADD COLUMN IF NOT EXISTS OWNER_ID INT
 
 statement ok
-ALTER TABLE smtng.something ADD COLUMN IF NOT EXISTS MODEL_ID INT;
+ALTER TABLE smtng.something ADD COLUMN IF NOT EXISTS MODEL_ID INT
 
 statement ok
-ALTER TABLE smtng.something ADD COLUMN IF NOT EXISTS NAME STRING;
+ALTER TABLE smtng.something ADD COLUMN IF NOT EXISTS NAME STRING
 
 statement ok
-CREATE DATABASE IF NOT EXISTS smtng;
+CREATE DATABASE IF NOT EXISTS smtng
 
 statement ok
 CREATE TABLE IF NOT EXISTS smtng.something (
 ID SERIAL PRIMARY KEY
-);
+)
 
 statement ok
-ALTER TABLE smtng.something ADD COLUMN IF NOT EXISTS OWNER_ID INT;
+ALTER TABLE smtng.something ADD COLUMN IF NOT EXISTS OWNER_ID INT
 
 statement ok
-ALTER TABLE smtng.something ADD COLUMN IF NOT EXISTS MODEL_ID INT;
+ALTER TABLE smtng.something ADD COLUMN IF NOT EXISTS MODEL_ID INT
 
 statement ok
-ALTER TABLE smtng.something ADD COLUMN IF NOT EXISTS NAME STRING;
+ALTER TABLE smtng.something ADD COLUMN IF NOT EXISTS NAME STRING
 
 query error pq: unimplemented: ARRAY column types are unsupported \(see issue https://github.com/cockroachdb/cockroach/issues/2115\)
 CREATE TABLE IF NOT EXISTS test.int_array_test (

--- a/pkg/sql/testdata/txn
+++ b/pkg/sql/testdata/txn
@@ -116,7 +116,7 @@ statement error duplicate key value \(k\)=\('a'\) violates unique constraint "pr
 INSERT INTO kv VALUES('unique_key', 'some value');
 INSERT INTO kv VALUES('a', 'c');
 INSERT INTO kv VALUES('unique_key2', 'some value');
-COMMIT;
+COMMIT
 
 # Txn is still aborted.
 statement error current transaction is aborted, commands ignored until end of transaction block
@@ -129,7 +129,7 @@ UPDATE kv SET v = 'b' WHERE k in ('a')
 # Now the transaction will be ended. After that, statements execute.
 statement ok
 COMMIT;
-INSERT INTO kv VALUES('x', 'y');
+INSERT INTO kv VALUES('x', 'y')
 
 query TT
 SELECT * FROM kv

--- a/pkg/sql/testdata/typing
+++ b/pkg/sql/testdata/typing
@@ -1,87 +1,87 @@
 statement ok
-CREATE TABLE f (x FLOAT);
+CREATE TABLE f (x FLOAT)
 
 statement ok
-INSERT INTO f(x) VALUES (1e10000 * 1e-9999), (3/2), (1);
+INSERT INTO f(x) VALUES (1e10000 * 1e-9999), (3/2), (1)
 
 query R
-SELECT * FROM f;
+SELECT * FROM f
 ----
 10
 1.5
 1
 
 statement ok
-CREATE TABLE i (x INT);
+CREATE TABLE i (x INT)
 
 statement error value type decimal doesn't match type INT of column "x"
-INSERT INTO i(x) VALUES (4.5);
+INSERT INTO i(x) VALUES (4.5)
 
 statement ok
-INSERT INTO i(x) VALUES (((9 / 3) * (1 / 3))), (2.0), (2.4 + 4.6);
+INSERT INTO i(x) VALUES (((9 / 3) * (1 / 3))), (2.0), (2.4 + 4.6)
 
 query I
-SELECT * FROM i;
+SELECT * FROM i
 ----
 1
 2
 7
 
 statement ok
-CREATE TABLE d (x DECIMAL);
+CREATE TABLE d (x DECIMAL)
 
 statement ok
-INSERT INTO d(x) VALUES (((9 / 3) * (1 / 3))), (2.0), (2.4 + 4.6);
+INSERT INTO d(x) VALUES (((9 / 3) * (1 / 3))), (2.0), (2.4 + 4.6)
 
 query R
-SELECT * FROM d;
+SELECT * FROM d
 ----
 1
 2
 7
 
 statement ok
-UPDATE d SET x = x + 1 WHERE x + SQRT(x) >= 2 + .1;
+UPDATE d SET x = x + 1 WHERE x + SQRT(x) >= 2 + .1
 
 query R
-SELECT * FROM d;
+SELECT * FROM d
 ----
 1
 3
 8
 
 statement ok
-CREATE TABLE s (x STRING);
+CREATE TABLE s (x STRING)
 
 query error unsupported comparison operator: <string> > <bytes>
 SELECT * FROM s WHERE x > b'\x00'
 
 statement ok
-INSERT INTO s(x) VALUES (b'qwe'), ('start' || b'end');
+INSERT INTO s(x) VALUES (b'qwe'), ('start' || b'end')
 
 statement error value type bytes doesn't match type STRING of column "x"
-INSERT INTO s(x) VALUES (b'\xfffefd');
+INSERT INTO s(x) VALUES (b'\xfffefd')
 
 query T
-SELECT * from s;
+SELECT * from s
 ----
 qwe
 startend
 
 statement error incompatible COALESCE expressions: expected 1 to be of type string, found type int
-INSERT INTO s VALUES (COALESCE(1, 'foo'));
+INSERT INTO s VALUES (COALESCE(1, 'foo'))
 
 statement error incompatible COALESCE expressions: expected 1 to be of type string, found type int
-INSERT INTO i VALUES (COALESCE(1, 'foo'));
+INSERT INTO i VALUES (COALESCE(1, 'foo'))
 
 query error incompatible COALESCE expressions: expected 1 to be of type string, found type int
-SELECT COALESCE(1, 'foo');
+SELECT COALESCE(1, 'foo')
 
 query error incompatible COALESCE expressions: expected 'foo' to be of type int, found type string
-SELECT COALESCE(1::INT, 'foo');
+SELECT COALESCE(1::INT, 'foo')
 
 query R
-SELECT GREATEST(-1, 1, 2.3, 123456789, 3 + 5, -(-4));
+SELECT GREATEST(-1, 1, 2.3, 123456789, 3 + 5, -(-4))
 ----
 123456789
 
@@ -93,20 +93,20 @@ SELECT GREATEST(-1, 1, 2.3, 123456789, 3 + 5, -(-4));
 #     of all constants for the first resolvableExpr in typeCheckSameTypedExprs when the parent
 #     expression has no desired type.
 query error greatest\(\): expected -1.123 to be of type int, found type decimal
-SELECT GREATEST(-1.123, 1.21313, 2.3, 123456789.321, 3 + 5.3213, -(-4.3213), ABS(-9));
+SELECT GREATEST(-1.123, 1.21313, 2.3, 123456789.321, 3 + 5.3213, -(-4.3213), ABS(-9))
 
 query R
-SELECT GREATEST(-1, 1, 2.3, 123456789, 3 + 5, -(-4), ABS(-9.0));
+SELECT GREATEST(-1, 1, 2.3, 123456789, 3 + 5, -(-4), ABS(-9.0))
 ----
 123456789
 
 statement ok
-CREATE TABLE time (d DATE, ts TIMESTAMP, tz TIMESTAMPTZ, i INTERVAL);
+CREATE TABLE time (d DATE, ts TIMESTAMP, tz TIMESTAMPTZ, i INTERVAL)
 
 statement ok
-INSERT INTO time VALUES ('2010-09-28', '2010-09-28 12:00:00.1', '2010-09-29 12:00:00.1', 'PT12H2M');
+INSERT INTO time VALUES ('2010-09-28', '2010-09-28 12:00:00.1', '2010-09-29 12:00:00.1', 'PT12H2M')
 
 query TTTT
-SELECT * FROM time;
+SELECT * FROM time
 ----
 2010-09-28 00:00:00 +0000 +0000   2010-09-28 12:00:00.1 +0000 +0000   2010-09-29 12:00:00.1 +0000 +0000   12h2m0s

--- a/pkg/sql/testdata/upsert
+++ b/pkg/sql/testdata/upsert
@@ -170,7 +170,7 @@ statement ok
 UPSERT INTO issue_6710 (a, b) VALUES (1, 'test1'), (2, 'test2')
 
 query IT
-SELECT a, b from issue_6710;
+SELECT a, b from issue_6710
 ----
 1 test1
 2 test2

--- a/pkg/sql/testdata/views
+++ b/pkg/sql/testdata/views
@@ -14,22 +14,22 @@ statement error pgcode 42P07 relation \"t\" already exists
 CREATE VIEW t AS select a, b from t
 
 statement ok
-CREATE VIEW v2 (x, y) AS select a, b from t;
+CREATE VIEW v2 (x, y) AS select a, b from t
 
 statement error pgcode 42601 CREATE VIEW specifies 1 column name, but data source has 2 columns
-CREATE VIEW v3 (x) AS select a, b from t;
+CREATE VIEW v3 (x) AS select a, b from t
 
 statement error pgcode 42601 CREATE VIEW specifies 3 column names, but data source has 2 columns
-CREATE VIEW v4 (x, y, z) AS select a, b from t;
+CREATE VIEW v4 (x, y, z) AS select a, b from t
 
 statement error pgcode 42P01 table "dne" does not exist
-CREATE VIEW v5 AS select a, b from dne;
+CREATE VIEW v5 AS select a, b from dne
 
 statement ok
-CREATE VIEW v6 (x, y) AS select a, b from v1;
+CREATE VIEW v6 (x, y) AS select a, b from v1
 
 query II colnames
-SELECT * FROM v1;
+SELECT * FROM v1
 ----
 a b
 1 99
@@ -37,7 +37,7 @@ a b
 3 97
 
 query II colnames
-SELECT * FROM v2;
+SELECT * FROM v2
 ----
 x y
 1 99
@@ -45,7 +45,7 @@ x y
 3 97
 
 query II colnames
-SELECT * FROM v6;
+SELECT * FROM v6
 ----
 x y
 1 99
@@ -53,39 +53,39 @@ x y
 3 97
 
 query II
-SELECT * FROM v2 ORDER BY x DESC LIMIT 1;
+SELECT * FROM v2 ORDER BY x DESC LIMIT 1
 ----
 3 97
 
 query I
-SELECT x FROM v2;
+SELECT x FROM v2
 ----
 1
 2
 3
 
 query I
-SELECT y FROM v2;
+SELECT y FROM v2
 ----
 99
 98
 97
 
 query IIII
-SELECT * FROM v1 AS v1 INNER JOIN v2 AS v2 ON v1.a = v2.x;
+SELECT * FROM v1 AS v1 INNER JOIN v2 AS v2 ON v1.a = v2.x
 ----
 1 99 1 99
 2 98 2 98
 3 97 3 97
 
 statement ok
-CREATE DATABASE test2;
+CREATE DATABASE test2
 
 statement ok
-SET DATABASE = test2;
+SET DATABASE = test2
 
 query II colnames
-SELECT * FROM test.v1;
+SELECT * FROM test.v1
 ----
 a b
 1 99
@@ -93,7 +93,7 @@ a b
 3 97
 
 query II colnames
-SELECT * FROM test.v2;
+SELECT * FROM test.v2
 ----
 x y
 1 99
@@ -101,7 +101,7 @@ x y
 3 97
 
 query II colnames
-SELECT * FROM test.v6;
+SELECT * FROM test.v6
 ----
 x y
 1 99
@@ -109,10 +109,10 @@ x y
 3 97
 
 statement ok
-CREATE VIEW v1 AS SELECT x, y FROM test.v2;
+CREATE VIEW v1 AS SELECT x, y FROM test.v2
 
 statement ok
-SET DATABASE = test;
+SET DATABASE = test
 
 query II colnames
 SELECT * FROM test2.v1
@@ -123,92 +123,92 @@ x y
 3 97
 
 query TT
-SHOW CREATE VIEW v1;
+SHOW CREATE VIEW v1
 ----
 v1 CREATE VIEW v1 AS SELECT a, b FROM test.t
 
 query TT
-SHOW CREATE VIEW v2;
+SHOW CREATE VIEW v2
 ----
 v2 CREATE VIEW v2 (x, y) AS SELECT a, b FROM test.t
 
 query TT
-SHOW CREATE VIEW v6;
+SHOW CREATE VIEW v6
 ----
 v6 CREATE VIEW v6 (x, y) AS SELECT a, b FROM test.v1
 
 query TT
-SHOW CREATE VIEW test2.v1;
+SHOW CREATE VIEW test2.v1
 ----
 test2.v1 CREATE VIEW "test2.v1" AS SELECT x, y FROM test.v2
 
 statement ok
-GRANT SELECT ON t TO testuser;
+GRANT SELECT ON t TO testuser
 
 user testuser
 
 query II
-SELECT * FROM t;
+SELECT * FROM t
 ----
 1 99
 2 98
 3 97
 
 query error user testuser does not have SELECT privilege on view v1
-SELECT * FROM v1;
+SELECT * FROM v1
 
 query error user testuser does not have SELECT privilege on view v6
-SELECT * FROM v6;
+SELECT * FROM v6
 
 query error user testuser has no privileges on view v1
-SHOW CREATE VIEW v1;
+SHOW CREATE VIEW v1
 
 user root
 
 statement ok
-REVOKE SELECT ON t FROM testuser;
+REVOKE SELECT ON t FROM testuser
 
 statement ok
-GRANT SELECT ON v1 TO testuser;
+GRANT SELECT ON v1 TO testuser
 
 user testuser
 
 query error user testuser does not have SELECT privilege on table t
-SELECT * FROM t;
+SELECT * FROM t
 
 query II
-SELECT * FROM v1;
+SELECT * FROM v1
 ----
 1 99
 2 98
 3 97
 
 query error user testuser does not have SELECT privilege on view v6
-SELECT * FROM v6;
+SELECT * FROM v6
 
 query TT
-SHOW CREATE VIEW v1;
+SHOW CREATE VIEW v1
 ----
 v1 CREATE VIEW v1 AS SELECT a, b FROM test.t
 
 user root
 
 statement ok
-REVOKE SELECT ON v1 FROM testuser;
+REVOKE SELECT ON v1 FROM testuser
 
 statement ok
-GRANT SELECT ON v6 TO testuser;
+GRANT SELECT ON v6 TO testuser
 
 user testuser
 
 query error user testuser does not have SELECT privilege on table t
-SELECT * FROM t;
+SELECT * FROM t
 
 query error user testuser does not have SELECT privilege on view v1
-SELECT * FROM v1;
+SELECT * FROM v1
 
 query II
-SELECT * FROM v6;
+SELECT * FROM v6
 ----
 1 99
 2 98
@@ -217,31 +217,31 @@ SELECT * FROM v6;
 user root
 
 statement error pgcode 42809 "v1" is not a table
-DROP TABLE v1;
+DROP TABLE v1
 
 statement error pgcode 42809 "t" is not a view
-DROP VIEW t;
+DROP VIEW t
 
 statement error cannot drop view "v1" because view "v6" depends on it
-DROP VIEW v1;
+DROP VIEW v1
 
 statement error cannot drop view "v2" because view "test2.v1" depends on it
-DROP VIEW v2;
+DROP VIEW v2
 
 statement ok
-DROP VIEW test2.v1;
+DROP VIEW test2.v1
 
 statement ok
-DROP VIEW v6;
+DROP VIEW v6
 
 statement ok
-DROP VIEW v2;
+DROP VIEW v2
 
 statement ok
-DROP VIEW v1;
+DROP VIEW v1
 
 statement error pgcode 42P01 view "v1" does not exist
-DROP VIEW v1;
+DROP VIEW v1
 
 # Verify correct rejection of star expressions
 # TODO(a-robinson): Support star expressions as soon as we can (#10028)
@@ -307,19 +307,19 @@ statement ok
 create view s4 AS SELECT a, COUNT(*) FROM t GROUP BY a HAVING a > (SELECT COUNT(*) FROM t)
 
 statement ok
-DROP VIEW s4;
+DROP VIEW s4
 
 statement ok
-DROP VIEW s3;
+DROP VIEW s3
 
 statement ok
-DROP VIEW s2;
+DROP VIEW s2
 
 statement ok
-DROP VIEW s1;
+DROP VIEW s1
 
 statement ok
-DROP TABLE t;
+DROP TABLE t
 
 # Check for memory leak (#10466)
 statement ok


### PR DESCRIPTION
The statements in the logic tests don't need a trailing semicolon. A fraction
of them have it and it's sometimes a bit annoying/distracting. Removing all
extra semicolons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13623)
<!-- Reviewable:end -->
