### PR TITLE
sql: use table leases in planner.searchAndQualifyDatabase

### DIFF
--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -427,8 +427,8 @@ func (p *planner) getTableScanOrViewPlan(
 	if p.avoidCachedDescriptors {
 		// AS OF SYSTEM TIME queries need to fetch the table descriptor at the
 		// specified time, and never lease anything. The proto transaction already
-		// has its timestamps set correctly so mustGetTableDesc will fetch with the
-		// correct timestamp.
+		// has its timestamps set correctly so mustGetTableOrViewDesc will fetch
+		// with the correct timestamp.
 		descFunc = p.mustGetTableOrViewDesc
 	}
 	desc, err := descFunc(tn)

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -522,9 +522,18 @@ func (p *planner) expandTableGlob(pattern parser.TablePattern) (parser.TableName
 func (p *planner) searchAndQualifyDatabase(tn *parser.TableName) error {
 	t := *tn
 
+	descFunc := p.getTableLease
+	if p.avoidCachedDescriptors {
+		// AS OF SYSTEM TIME queries need to fetch the table descriptor at the
+		// specified time, and never lease anything. The proto transaction already
+		// has its timestamps set correctly so getTableOrViewDesc will fetch with
+		// the correct timestamp.
+		descFunc = p.getTableOrViewDesc
+	}
+
 	if p.session.Database != "" {
 		t.DatabaseName = parser.Name(p.session.Database)
-		desc, err := p.getTableOrViewDesc(&t)
+		desc, err := descFunc(&t)
 		if err != nil && !sqlbase.IsUndefinedTableError(err) {
 			return err
 		}
@@ -539,7 +548,7 @@ func (p *planner) searchAndQualifyDatabase(tn *parser.TableName) error {
 	// the search path instead.
 	for _, database := range p.session.SearchPath {
 		t.DatabaseName = parser.Name(database)
-		desc, err := p.getTableOrViewDesc(&t)
+		desc, err := descFunc(&t)
 		if err != nil && !sqlbase.IsUndefinedTableError(err) {
 			return err
 		}


### PR DESCRIPTION
Use table leases to retrieve table descriptors in
planner.searchAndQualifyDatabase. This avoids 2 KV reads (1 for the
database descriptor, 1 for the table descriptor) for queries that use an
unqualified table name.

Fixes #13632

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13635)
<!-- Reviewable:end -->
