### PR TITLE
sql: support int arrays over text+binary pgwire

### DIFF
--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -1782,6 +1782,9 @@ func (d dNull) Size() uintptr {
 type DArray struct {
 	ParamTyp Type
 	Array    Datums
+	// HasNulls is set to true if any of the datums within the array are null.
+	// This is used in the binary array serialization format.
+	HasNulls bool
 }
 
 // NewDArray returns a DArray containing elements of the specified type.
@@ -1940,6 +1943,9 @@ func (d *DArray) Append(v Datum) error {
 				return errNonHomogeneousArray
 			}
 		}
+	}
+	if v == DNull {
+		d.HasNulls = true
 	}
 	d.Array = append(d.Array, v)
 	return nil

--- a/pkg/sql/pgwire/binary_test.go
+++ b/pkg/sql/pgwire/binary_test.go
@@ -125,6 +125,28 @@ func TestBinaryDate(t *testing.T) {
 	})
 }
 
+func TestBinaryIntArray(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	buf := writeBuffer{bytecount: metric.NewCounter(metric.Metadata{})}
+	d := parser.NewDArray(parser.TypeInt)
+	for i := 0; i < 10; i++ {
+		if err := d.Append(parser.NewDInt(parser.DInt(i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	buf.writeBinaryDatum(d, time.UTC)
+
+	b := buf.wrapped.Bytes()
+
+	got, err := decodeOidDatum(oid.T__int8, formatBinary, b[4:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Compare(d) != 0 {
+		t.Fatalf("expected %s, got %s", d, got)
+	}
+}
+
 var generateBinaryCmd = flag.String("generate-binary", "", "generate-binary command invocation")
 
 func TestRandomBinaryDecimal(t *testing.T) {

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -550,10 +550,9 @@ func TestPGPreparedQuery(t *testing.T) {
 			baseTest.SetArgs(2, 3).Results(2),
 			baseTest.SetArgs(true, 0).Error(`pq: error in argument for $1: strconv.ParseInt: parsing "true": invalid syntax`),
 		},
-		// TODO(nvanbenschoten) Blocked on #10713.
-		// "SELECT $1[2] LIKE 'b'": {
-		// 	baseTest.SetArgs(pq.Array([]string{"a", "b", "c"})).Results(true),
-		// },
+		"SELECT $1[2] LIKE 'b'": {
+			baseTest.SetArgs(pq.Array([]string{"a", "b", "c"})).Results(true),
+		},
 		"SHOW DATABASE": {
 			baseTest.Results(""),
 		},
@@ -722,6 +721,17 @@ func TestPGPreparedQuery(t *testing.T) {
 		"INSERT INTO d.intStr VALUES ($1, 'hello ' || $1::TEXT) RETURNING *": {
 			baseTest.SetArgs(123).Results(123, "hello 123"),
 		},
+		"SELECT * from d.T WHERE a = ANY($1)": {
+			baseTest.SetArgs(pq.Array([]int{10})).Results(10),
+		},
+		"SELECT s from (VALUES ('foo'), ('bar')) as t(s) WHERE s = ANY($1)": {
+			baseTest.SetArgs(pq.StringArray([]string{"foo"})).Results("foo"),
+		},
+
+		// TODO(jordan) blocked on #13651
+		//"SELECT $1::INT[]": {
+		//	baseTest.SetArgs(pq.Array([]int{10})).Results(pq.Array([]int{10})),
+		//},
 	}
 
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -315,6 +315,27 @@ func (b *writeBuffer) writeBinaryDatum(d parser.Datum, sessionLoc *time.Location
 		b.putInt32(4)
 		b.putInt32(dateToPgBinary(v))
 
+	case *parser.DArray:
+		if v.ParamTyp.FamilyEqual(parser.TypeAnyArray) {
+			b.setError(errors.New("unsupported binary serialization of multidimensional arrays"))
+			return
+		}
+		subWriter := &writeBuffer{wrapped: b.variablePutbuf}
+		// Put the number of dimensions. We currently support 1d arrays only.
+		subWriter.putInt32(1)
+		hasNulls := 0
+		if v.HasNulls {
+			hasNulls = 1
+		}
+		subWriter.putInt32(int32(hasNulls))
+		subWriter.putInt32(int32(v.ParamTyp.Oid()))
+		subWriter.putInt32(int32(v.Len()))
+		subWriter.putInt32(int32(v.Len()))
+		for _, elem := range v.Array {
+			subWriter.writeBinaryDatum(elem, sessionLoc)
+		}
+		b.variablePutbuf = subWriter.wrapped
+		b.writeLengthPrefixedVariablePutbuf()
 	default:
 		b.setError(errors.Errorf("unsupported type %T", d))
 	}
@@ -735,8 +756,95 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 		default:
 			return d, errors.Errorf("unsupported interval format code: %d", code)
 		}
+	case oid.T__int2, oid.T__int4, oid.T__int8:
+		switch code {
+		case formatBinary:
+			return decodeBinaryArray(b, code)
+		case formatText:
+			var arr pq.Int64Array
+			if err := (&arr).Scan(b); err != nil {
+				return d, err
+			}
+			out := parser.NewDArray(parser.TypeInt)
+			for _, v := range arr {
+				if err := out.Append(parser.NewDInt(parser.DInt(v))); err != nil {
+					return d, err
+				}
+			}
+			d = out
+		default:
+			return d, errors.Errorf("unsupported array format code: %d", code)
+		}
+	case oid.T__text, oid.T__name:
+		switch code {
+		case formatBinary:
+			return decodeBinaryArray(b, code)
+		case formatText:
+			var arr pq.StringArray
+			if err := (&arr).Scan(b); err != nil {
+				return d, err
+			}
+			out := parser.NewDArray(parser.TypeString)
+			if id == oid.T__name {
+				out.ParamTyp = parser.TypeName
+			}
+			for _, v := range arr {
+				var s parser.Datum = parser.NewDString(v)
+				if id == oid.T__name {
+					s = parser.NewDNameFromDString(s.(*parser.DString))
+				}
+				if err := out.Append(s); err != nil {
+					return d, err
+				}
+			}
+			d = out
+		default:
+			return d, errors.Errorf("unsupported array format code: %d", code)
+		}
+
 	default:
 		return d, errors.Errorf("unsupported OID: %v", id)
 	}
 	return d, nil
+}
+
+func decodeBinaryArray(b []byte, code formatCode) (parser.Datum, error) {
+	hdr := struct {
+		Ndims int32
+		// Nullflag
+		_       int32
+		ElemOid int32
+		// The next two fields should be arrays of size Ndims. However, since
+		// we only support 1-dimensional arrays for now, for convenience we can
+		// leave them in this struct as such for `binary.Read` to parse for us.
+		DimSize int32
+		// Dim lower bound
+		_ int32
+	}{}
+	r := bytes.NewBuffer(b)
+	if err := binary.Read(r, binary.BigEndian, &hdr); err != nil {
+		return nil, err
+	}
+	// Only 1-dimensional arrays are supported for now.
+	if hdr.Ndims != 1 {
+		return nil, errors.Errorf("unsupported number of array dimensions: %d", hdr.Ndims)
+	}
+
+	elemOid := oid.Oid(hdr.ElemOid)
+	arr := parser.NewDArray(parser.OidToType[elemOid])
+	var vlen int32
+	for i := int32(0); i < hdr.DimSize; i++ {
+		if err := binary.Read(r, binary.BigEndian, &vlen); err != nil {
+			return nil, err
+		}
+		buf := r.Next(int(vlen))
+		elem, err := decodeOidDatum(elemOid, code, buf)
+		if err != nil {
+			return nil, err
+		}
+		if err := arr.Append(elem); err != nil {
+			return nil, err
+		}
+	}
+	return arr, nil
 }


### PR DESCRIPTION
Add support for encoding and decoding string and integer arrays in the string and binary pgwire formats.

Resolves #13358.
Resolves #10713.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13636)
<!-- Reviewable:end -->
