### PR TITLE
keys: improve UX of pretty-printed keys with decoding errors

### DIFF
--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -627,22 +627,6 @@ func MassagePrettyPrintedSpanForTest(span string, dirs []encoding.Direction) str
 				// We're switching from the start constraints to the end constraints,
 				// or starting another span.
 				colIdx = -1
-			case '<':
-				// This is an error message, like <util/encoding/encoding.go:256: ....>.
-				end := strings.Index(span[i:], ">")
-				if end == -1 {
-					panic("parse error")
-				}
-				errMsg := span[i+1 : i+end+1]
-				lineIdx := strings.Index(errMsg, ":")
-				if lineIdx != -1 {
-					var lineEnd int
-					for lineEnd = lineIdx + 1; errMsg[lineEnd] >= '0' && errMsg[lineEnd] <= '9'; lineEnd++ {
-					}
-					errMsg = errMsg[:lineIdx] + errMsg[lineIdx+(lineEnd-lineIdx):]
-				}
-				r += errMsg
-				i += end
 			}
 		}
 	}

--- a/pkg/keys/printer_test.go
+++ b/pkg/keys/printer_test.go
@@ -151,7 +151,7 @@ func TestPrettyPrint(t *testing.T) {
 		{makeKey([]byte("")), "/Min"},
 		{Meta1KeyMax, "/Meta1/Max"},
 		{Meta2KeyMax, "/Meta2/Max"},
-		{makeKey(MakeTablePrefix(42), roachpb.RKey([]byte{0x12, 'a', 0x00, 0x02})), "/Table/42/<unknown escape sequence: 0x0 0x2>"},
+		{makeKey(MakeTablePrefix(42), roachpb.RKey([]byte{0x12, 'a', 0x00, 0x02})), "/Table/42/???"},
 	}
 	for i, test := range testCases {
 		keyInfo := MassagePrettyPrintedSpanForTest(PrettyPrint(test.key), nil)

--- a/pkg/sql/index_selection_test.go
+++ b/pkg/sql/index_selection_test.go
@@ -483,12 +483,13 @@ func TestMakeSpans(t *testing.T) {
 
 		// When encoding an end constraint for a maximal datum, we use
 		// bytes.PrefixEnd() to go beyond the normal encodings of that datatype.
+		// This is the reason for the "???" suffix of the pretty-printed spans.
 		{fmt.Sprintf(`a = %d`, math.MaxInt64), `a`,
-			`/9223372036854775807-/<varint 9223372036854775808 overflows int64>`,
+			`/9223372036854775807-/???`,
 			`/9223372036854775807-/9223372036854775806`},
 		{fmt.Sprintf(`a = %d`, math.MinInt64), `a`,
 			`/-9223372036854775808-/-9223372036854775807`,
-			`/-9223372036854775808-/<varint 9223372036854775808 overflows int64>`},
+			`/-9223372036854775808-/???`},
 
 		{`(a, b) >= (1, 4)`, `a,b`, `/1/4-`, `-/1/3`},
 		{`(a, b) > (1, 4)`, `a,b`, `/1/5-`, `-/1/4`},

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -957,7 +957,7 @@ func PrettyPrintValue(b []byte, sep string) string {
 	for len(b) > 0 {
 		bb, s, err := prettyPrintFirstValue(b)
 		if err != nil {
-			fmt.Fprintf(&buf, "%s<%v>", sep, err)
+			fmt.Fprintf(&buf, "%s???", sep)
 		} else {
 			fmt.Fprintf(&buf, "%s%s", sep, s)
 		}


### PR DESCRIPTION
Related to #13412.

Previously when we found an error while pretty-printing a key, we would
include the error in the text. This looked surprising and implied that a
serious issue had occurred instead of a known shortcoming (see linked
issue). This commit changes the pretty-printer to print `???` instead of
the error string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13637)
<!-- Reviewable:end -->
