### PR TITLE
distsql: ordering fixes

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -552,8 +552,8 @@ func (dsp *distSQLPlanner) createTableReaders(
 
 	p := physicalPlan{
 		PhysicalPlan: distsqlplan.PhysicalPlan{
-			Ordering:    ordering,
-			ResultTypes: getTypesForPlanResult(n, planToStreamColMap),
+			MergeOrdering: ordering,
+			ResultTypes:   getTypesForPlanResult(n, planToStreamColMap),
 		},
 		planToStreamColMap: planToStreamColMap,
 	}
@@ -657,8 +657,6 @@ func (dsp *distSQLPlanner) selectRenders(p *physicalPlan, n *renderNode) {
 	for i := range n.render {
 		p.planToStreamColMap = append(p.planToStreamColMap, i)
 	}
-
-	p.Ordering = dsp.convertOrdering(n.ordering.ordering, p.planToStreamColMap)
 }
 
 // addSorters adds sorters corresponding to a sortNode and updates the plan to
@@ -684,8 +682,8 @@ func (dsp *distSQLPlanner) addSorters(p *physicalPlan, n *sortNode) {
 			},
 			distsqlrun.PostProcessSpec{},
 			p.ResultTypes,
+			ordering,
 		)
-		p.Ordering = ordering
 	}
 
 	if len(n.columns) != len(p.planToStreamColMap) {
@@ -695,19 +693,16 @@ func (dsp *distSQLPlanner) addSorters(p *physicalPlan, n *sortNode) {
 		// in the output columns of the sortNode; we set a projection such that the
 		// plan results map 1-to-1 to sortNode columns.
 		//
-		// We can only do this when there is a single result stream. With multiple
-		// result streams, we need the columns to later merge the streams correctly
-		// with an ordered synchronizer.
+		// Note that internally, AddProjection might retain more columns as
+		// necessary so we can preserve the p.Ordering between parallel streams when
+		// they merge later.
 		p.planToStreamColMap = p.planToStreamColMap[:len(n.columns)]
-		if len(p.ResultRouters) == 1 {
-			columns := make([]uint32, len(n.columns))
-			for i, col := range p.planToStreamColMap {
-				columns[i] = uint32(col)
-				p.planToStreamColMap[i] = i
-			}
-			p.AddProjection(columns)
-			p.Ordering = dsp.convertOrdering(n.Ordering().ordering, p.planToStreamColMap)
+		columns := make([]uint32, len(n.columns))
+		for i, col := range p.planToStreamColMap {
+			columns[i] = uint32(col)
+			p.planToStreamColMap[i] = i
 		}
+		p.AddProjection(columns)
 	}
 }
 
@@ -784,15 +779,6 @@ func (dsp *distSQLPlanner) addAggregators(
 		}
 	}
 
-	// The aggregators don't care about the input ordering, so don't guarantee
-	// one (p.Ordering gets factored in when we add stages). This one-off
-	// optimization is a symptom of the larger issue that we don't yet determine
-	// what orderings are actually needed by each node's parent.
-	//
-	// Note that this won't be the case if we implement certain optimizations
-	// (like groupNode.needOnlyOneRow).
-	p.Ordering = distsqlrun.Ordering{}
-
 	var finalAggSpec distsqlrun.AggregatorSpec
 
 	if !multiStage {
@@ -846,9 +832,8 @@ func (dsp *distSQLPlanner) addAggregators(
 			distsqlrun.ProcessorCoreUnion{Aggregator: &localAggSpec},
 			distsqlrun.PostProcessSpec{},
 			intermediateTypes,
+			orderingTerminated, // The local aggregators don't guarantee any output ordering.
 		)
-		// The local aggregators don't guarantee any output ordering.
-		p.Ordering = orderingTerminated
 
 		finalAggSpec = distsqlrun.AggregatorSpec{
 			Aggregations: finalAgg,
@@ -889,12 +874,6 @@ func (dsp *distSQLPlanner) addAggregators(
 	p.planToStreamColMap = p.planToStreamColMap[:0]
 	for i := range n.Columns() {
 		p.planToStreamColMap = append(p.planToStreamColMap, i)
-	}
-
-	// We don't guarantee any ordering. Thankfully the groupNode doesn't either.
-	p.Ordering = orderingTerminated
-	if len(n.Ordering().ordering) != 0 {
-		panic("groupNode promises ordering")
 	}
 	return nil
 }
@@ -1196,7 +1175,7 @@ func (dsp *distSQLPlanner) createPlanForJoin(
 
 	p.planToStreamColMap = joinToStreamColMap
 	p.ResultTypes = getTypesForPlanResult(n, joinToStreamColMap)
-	p.Ordering = dsp.convertOrdering(n.Ordering().ordering, joinToStreamColMap)
+	p.SetMergeOrdering(orderingTerminated)
 	return p, nil
 }
 

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -506,9 +506,7 @@ func (dsp *distSQLPlanner) convertOrdering(
 	for _, col := range planOrdering {
 		streamColIdx := planToStreamColMap[col.ColIdx]
 		if streamColIdx == -1 {
-			// This column is not part of the output. The rest of the ordering is
-			// irrelevant.
-			break
+			panic("column in ordering not part of processor output")
 		}
 		oc := distsqlrun.Ordering_Column{
 			ColIdx:    uint32(streamColIdx),
@@ -533,30 +531,13 @@ func (dsp *distSQLPlanner) createTableReaders(
 		return physicalPlan{}, err
 	}
 
-	if overrideResultColumns != nil {
-		post.OutputColumns = overrideResultColumns
-	} else {
-		post.OutputColumns = getOutputColumnsFromScanNode(n)
-	}
-
-	planToStreamColMap := makePlanToStreamColMap(len(n.resultColumns))
-	for i, col := range post.OutputColumns {
-		planToStreamColMap[col] = i
-	}
-	ordering := dsp.convertOrdering(n.ordering.ordering, planToStreamColMap)
-
 	spanPartitions, err := dsp.partitionSpans(planCtx, n.spans)
 	if err != nil {
 		return physicalPlan{}, err
 	}
 
-	p := physicalPlan{
-		PhysicalPlan: distsqlplan.PhysicalPlan{
-			MergeOrdering: ordering,
-			ResultTypes:   getTypesForPlanResult(n, planToStreamColMap),
-		},
-		planToStreamColMap: planToStreamColMap,
-	}
+	var p physicalPlan
+
 	for _, sp := range spanPartitions {
 		tr := &distsqlrun.TableReaderSpec{}
 		*tr = spec
@@ -569,7 +550,6 @@ func (dsp *distSQLPlanner) createTableReaders(
 			Node: sp.node,
 			Spec: distsqlrun.ProcessorSpec{
 				Core:   distsqlrun.ProcessorCoreUnion{TableReader: tr},
-				Post:   post,
 				Output: []distsqlrun.OutputRouterSpec{{Type: distsqlrun.OutputRouterSpec_PASS_THROUGH}},
 			},
 		}
@@ -577,6 +557,31 @@ func (dsp *distSQLPlanner) createTableReaders(
 		pIdx := p.AddProcessor(proc)
 		p.ResultRouters = append(p.ResultRouters, pIdx)
 	}
+
+	if overrideResultColumns != nil {
+		post.OutputColumns = overrideResultColumns
+	} else {
+		post.OutputColumns = getOutputColumnsFromScanNode(n)
+	}
+
+	planToStreamColMap := makePlanToStreamColMap(len(n.resultColumns))
+	for i, col := range post.OutputColumns {
+		planToStreamColMap[col] = i
+	}
+	if len(p.ResultRouters) > 1 && len(n.ordering.ordering) > 0 {
+		// We have to maintain a certain ordering between the parallel streams. This
+		// might mean we need to add output columns.
+		for _, col := range n.ordering.ordering {
+			if planToStreamColMap[col.ColIdx] == -1 {
+				// This column is not part of the output; add it.
+				planToStreamColMap[col.ColIdx] = len(post.OutputColumns)
+				post.OutputColumns = append(post.OutputColumns, uint32(col.ColIdx))
+			}
+		}
+		p.SetMergeOrdering(dsp.convertOrdering(n.ordering.ordering, planToStreamColMap))
+	}
+	p.SetLastStagePost(post, getTypesForPlanResult(n, planToStreamColMap))
+	p.planToStreamColMap = planToStreamColMap
 	return p, nil
 }
 

--- a/pkg/sql/distsqlplan/physical_plan_test.go
+++ b/pkg/sql/distsqlplan/physical_plan_test.go
@@ -1,0 +1,347 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+// This file defines structures and basic functionality that is useful when
+// building distsql plans. It does not contain the actual physical planning
+// code.
+
+package distsqlplan
+
+import (
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestProjectionAndRendering(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// We don't care about actual types, so we use ColumnType.Locale to store an
+	// arbitrary string.
+	strToType := func(s string) sqlbase.ColumnType {
+		return sqlbase.ColumnType{Locale: &s}
+	}
+
+	// For each test case we set up processors with a certain post-process spec,
+	// run a function that adds a projection or a rendering, and verify the output
+	// post-process spec (as well as ResultTypes, Ordering).
+	testCases := []struct {
+		// post-process spec of the last stage in the plan.
+		post distsqlrun.PostProcessSpec
+		// Comma-separated list of result "types".
+		resultTypes string
+		// ordering in a string like "0,1,-2" (negative values = descending). Can't
+		// express descending on column 0, deal with it.
+		ordering string
+
+		// function that applies a projection or rendering.
+		action func(p *PhysicalPlan)
+
+		// expected post-process spec of the last stage in the resulting plan.
+		expPost distsqlrun.PostProcessSpec
+		// expected result types, same format and strings as resultTypes.
+		expResultTypes string
+		// expected ordeering, same format as ordering.
+		expOrdering string
+	}{
+		{
+			// Simple projection.
+			post:        distsqlrun.PostProcessSpec{},
+			resultTypes: "A,B,C,D",
+
+			action: func(p *PhysicalPlan) {
+				p.AddProjection([]uint32{1, 3, 2})
+			},
+
+			expPost: distsqlrun.PostProcessSpec{
+				OutputColumns: []uint32{1, 3, 2},
+			},
+			expResultTypes: "B,D,C",
+		},
+
+		{
+			// Projection with ordering.
+			post:        distsqlrun.PostProcessSpec{},
+			resultTypes: "A,B,C,D",
+			ordering:    "2",
+
+			action: func(p *PhysicalPlan) {
+				p.AddProjection([]uint32{2})
+			},
+
+			expPost: distsqlrun.PostProcessSpec{
+				OutputColumns: []uint32{2},
+			},
+			expResultTypes: "C",
+			expOrdering:    "0",
+		},
+
+		{
+			// Projection with ordering that refers to non-projected column.
+			post:        distsqlrun.PostProcessSpec{},
+			resultTypes: "A,B,C,D",
+			ordering:    "2,-1,3",
+
+			action: func(p *PhysicalPlan) {
+				p.AddProjection([]uint32{2, 3})
+			},
+
+			expPost: distsqlrun.PostProcessSpec{
+				OutputColumns: []uint32{2, 3, 1},
+			},
+			expResultTypes: "C,D,B",
+			expOrdering:    "0,-2,1",
+		},
+
+		{
+			// Projection after projection.
+			post: distsqlrun.PostProcessSpec{
+				OutputColumns: []uint32{5, 6, 7, 8},
+			},
+			resultTypes: "A,B,C,D",
+			ordering:    "3",
+
+			action: func(p *PhysicalPlan) {
+				p.AddProjection([]uint32{3, 1})
+			},
+
+			expPost: distsqlrun.PostProcessSpec{
+				OutputColumns: []uint32{8, 6},
+			},
+			expResultTypes: "D,B",
+			expOrdering:    "0",
+		},
+
+		{
+			// Projection after projection; ordering refers to non-projected column.
+			post: distsqlrun.PostProcessSpec{
+				OutputColumns: []uint32{5, 6, 7, 8},
+			},
+			resultTypes: "A,B,C,D",
+			ordering:    "0,3",
+
+			action: func(p *PhysicalPlan) {
+				p.AddProjection([]uint32{3, 1})
+			},
+
+			expPost: distsqlrun.PostProcessSpec{
+				OutputColumns: []uint32{8, 6, 5},
+			},
+			expResultTypes: "D,B,A",
+			expOrdering:    "2,0",
+		},
+
+		{
+			// Projection after rendering.
+			post: distsqlrun.PostProcessSpec{
+				RenderExprs: []distsqlrun.Expression{{Expr: "@5"}, {Expr: "@1 + @2"}, {Expr: "@6"}},
+			},
+			resultTypes: "A,B,C",
+			ordering:    "2",
+
+			action: func(p *PhysicalPlan) {
+				p.AddProjection([]uint32{2, 0})
+			},
+
+			expPost: distsqlrun.PostProcessSpec{
+				RenderExprs: []distsqlrun.Expression{{Expr: "@6"}, {Expr: "@5"}},
+			},
+			expResultTypes: "C,A",
+			expOrdering:    "0",
+		},
+
+		{
+			// Projection after rendering; ordering refers to non-projected column.
+			post: distsqlrun.PostProcessSpec{
+				RenderExprs: []distsqlrun.Expression{{Expr: "@5"}, {Expr: "@1 + @2"}, {Expr: "@6"}},
+			},
+			resultTypes: "A,B,C",
+			ordering:    "2,-1",
+
+			action: func(p *PhysicalPlan) {
+				p.AddProjection([]uint32{2})
+			},
+
+			expPost: distsqlrun.PostProcessSpec{
+				RenderExprs: []distsqlrun.Expression{{Expr: "@6"}, {Expr: "@1 + @2"}},
+			},
+			expResultTypes: "C,B",
+			expOrdering:    "0,-1",
+		},
+
+		{
+			// Identity rendering.
+			post:        distsqlrun.PostProcessSpec{},
+			resultTypes: "A,B,C,D",
+
+			action: func(p *PhysicalPlan) {
+				p.AddRendering(
+					[]parser.TypedExpr{
+						&parser.IndexedVar{Idx: 10},
+						&parser.IndexedVar{Idx: 11},
+						&parser.IndexedVar{Idx: 12},
+						&parser.IndexedVar{Idx: 13},
+					},
+					[]int{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 2, 3},
+					[]sqlbase.ColumnType{strToType("A"), strToType("B"), strToType("C"), strToType("D")},
+				)
+			},
+
+			expPost:        distsqlrun.PostProcessSpec{},
+			expResultTypes: "A,B,C,D",
+		},
+
+		{
+			// Rendering that becomes projection.
+			post:        distsqlrun.PostProcessSpec{},
+			resultTypes: "A,B,C,D",
+
+			action: func(p *PhysicalPlan) {
+				p.AddRendering(
+					[]parser.TypedExpr{
+						&parser.IndexedVar{Idx: 11},
+						&parser.IndexedVar{Idx: 13},
+						&parser.IndexedVar{Idx: 12},
+					},
+					[]int{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 2, 3},
+					[]sqlbase.ColumnType{strToType("B"), strToType("D"), strToType("C")},
+				)
+			},
+
+			expPost: distsqlrun.PostProcessSpec{
+				OutputColumns: []uint32{1, 3, 2},
+			},
+			expResultTypes: "B,D,C",
+		},
+
+		{
+			// Rendering with ordering that refers to non-projected column.
+			post:        distsqlrun.PostProcessSpec{},
+			resultTypes: "A,B,C,D",
+			ordering:    "3",
+
+			action: func(p *PhysicalPlan) {
+				p.AddRendering(
+					[]parser.TypedExpr{
+						&parser.BinaryExpr{
+							Operator: parser.Plus,
+							Left:     &parser.IndexedVar{Idx: 1},
+							Right:    &parser.IndexedVar{Idx: 2},
+						},
+					},
+					[]int{0, 1, 2},
+					[]sqlbase.ColumnType{strToType("X")},
+				)
+			},
+
+			expPost: distsqlrun.PostProcessSpec{
+				RenderExprs: []distsqlrun.Expression{{Expr: "@2 + @3"}, {Expr: "@4"}},
+			},
+			expResultTypes: "X,D",
+			expOrdering:    "1",
+		},
+		{
+			// Rendering with ordering that refers to non-projected column after
+			// projection.
+			post: distsqlrun.PostProcessSpec{
+				OutputColumns: []uint32{5, 6, 7, 8},
+			},
+			resultTypes: "A,B,C,D",
+			ordering:    "0,-3",
+
+			action: func(p *PhysicalPlan) {
+				p.AddRendering(
+					[]parser.TypedExpr{
+						&parser.BinaryExpr{
+							Operator: parser.Plus,
+							Left:     &parser.IndexedVar{Idx: 11},
+							Right:    &parser.IndexedVar{Idx: 12},
+						},
+						&parser.IndexedVar{Idx: 10},
+					},
+					[]int{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 2},
+					[]sqlbase.ColumnType{strToType("X"), strToType("A")},
+				)
+			},
+
+			expPost: distsqlrun.PostProcessSpec{
+				RenderExprs: []distsqlrun.Expression{{Expr: "@7 + @8"}, {Expr: "@6"}, {Expr: "@9"}},
+			},
+			expResultTypes: "X,A,D",
+			expOrdering:    "1,-2",
+		},
+	}
+
+	for testIdx, tc := range testCases {
+		p := PhysicalPlan{
+			Processors: []Processor{
+				{Spec: distsqlrun.ProcessorSpec{Post: tc.post}},
+				{Spec: distsqlrun.ProcessorSpec{Post: tc.post}},
+			},
+			ResultRouters: []ProcessorIdx{0, 1},
+		}
+
+		if tc.ordering != "" {
+			for _, s := range strings.Split(tc.ordering, ",") {
+				var o distsqlrun.Ordering_Column
+				col, _ := strconv.Atoi(s)
+				if col >= 0 {
+					o.ColIdx = uint32(col)
+					o.Direction = distsqlrun.Ordering_Column_ASC
+				} else {
+					o.ColIdx = uint32(-col)
+					o.Direction = distsqlrun.Ordering_Column_DESC
+				}
+				p.MergeOrdering.Columns = append(p.MergeOrdering.Columns, o)
+			}
+		}
+
+		for _, s := range strings.Split(tc.resultTypes, ",") {
+			p.ResultTypes = append(p.ResultTypes, strToType(s))
+		}
+
+		tc.action(&p)
+
+		if post := p.GetLastStagePost(); !reflect.DeepEqual(post, tc.expPost) {
+			t.Errorf("%d: incorrect post:\n%s\nexpected:\n%s", testIdx, &post, &tc.expPost)
+		}
+		var resTypes []string
+		for _, t := range p.ResultTypes {
+			resTypes = append(resTypes, *t.Locale)
+		}
+		if r := strings.Join(resTypes, ","); r != tc.expResultTypes {
+			t.Errorf("%d: incorrect result types: %s expected %s", testIdx, r, tc.expResultTypes)
+		}
+
+		var ord []string
+		for _, c := range p.MergeOrdering.Columns {
+			i := int(c.ColIdx)
+			if c.Direction == distsqlrun.Ordering_Column_DESC {
+				i = -i
+			}
+			ord = append(ord, strconv.Itoa(i))
+		}
+		if o := strings.Join(ord, ","); o != tc.expOrdering {
+			t.Errorf("%d: incorrect ordering: '%s' expected '%s'", testIdx, o, tc.expOrdering)
+		}
+	}
+}


### PR DESCRIPTION
These commits fix various logic tests failures seen with fake span resolver on a multi-node cluster. These should fix #13371.

#### distsql: plumb ordering columns through projections and renderings
The distsqlplan code now automatically plumbs through columns that are part of
orderings for all post-processing manipulations (i.e. projections and
renderings).

The semantics of `Ordering` are now clear: if we have multiple streams, when
these streams eventually merge, they will be merged taking this `Ordering` into
account.

Removing the hack in the planning code for sorters where we were trying to do
this for a limited set of cases.

#### distsql: fix index-join ordering in planning
We were only doing a "best effort" attempt at maintaining the ordering exposed
by the index join node, which can lead to incorrectly ordered results. We now
add output columns as needed.

CC @arjunravinarayan, @asubiotto

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13644)
<!-- Reviewable:end -->
