### PR TITLE
sql: implement partialsort in logic test

### DIFF
--- a/pkg/sql/testdata/distinct
+++ b/pkg/sql/testdata/distinct
@@ -39,7 +39,7 @@ EXPLAIN SELECT DISTINCT y, z FROM xyz
 2            table  xyz@primary
 2            spans  ALL
 
-query II
+query II partialsort(2)
 SELECT DISTINCT y, z FROM xyz ORDER BY z
 ----
 2 3
@@ -58,8 +58,8 @@ EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY z
 2            table  xyz@foo
 2            spans  ALL
 
-query II
-SELECT DISTINCT y, z FROM xyz ORDER BY y, z
+query II partialsort(1)
+SELECT DISTINCT y, z FROM xyz ORDER BY y
 ----
 2 3
 2 6

--- a/pkg/sql/testdata/select_index_span_ranges
+++ b/pkg/sql/testdata/select_index_span_ranges
@@ -62,7 +62,7 @@ EXPLAIN SELECT * FROM t WHERE (c >= 80) ORDER BY c
 1  scan
 1              table  t@primary
 
-query IIII
+query IIII partialsort(3)
 SELECT * FROM t WHERE (c >= 80) ORDER BY c
 ----
 2   0  80  0


### PR DESCRIPTION
Implementing a sort mode which can be used for queries that guarantee a partial
(but not total) sort order. In this mode, the test infrastructure only sorts
within groups of rows that are "equal" on the ordering columns.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13647)
<!-- Reviewable:end -->
