### PR TITLE
sql: more log messages for debugging index backfill

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -617,6 +617,7 @@ func (sc *SchemaChanger) backfillIndexes(
 		if err := sc.ExtendLease(lease); err != nil {
 			return err
 		}
+		log.VEventf(context.TODO(), 2, "index backfill: process %+v spans", spans)
 		if err := sc.db.Txn(context.TODO(), func(txn *client.Txn) error {
 			p := &planner{
 				txn:      txn,

--- a/pkg/sql/distsqlrun/indexbackfiller.go
+++ b/pkg/sql/distsqlrun/indexbackfiller.go
@@ -330,13 +330,13 @@ func WriteResumeSpan(
 				addSpan(sp.Key, origSpan.Key)
 				if resume.Key != nil {
 					addSpan(resume.Key, resume.EndKey)
+				} else {
+					log.VEventf(txn.Context, 2, "completed processing of span: %+v", origSpan)
 				}
 				addSpan(origSpan.EndKey, sp.EndKey)
 				mutation.ResumeSpans = append(before, after...)
 
-				if log.V(2) {
-					log.Infof(txn.Context, "ckpt %+v", mutation.ResumeSpans)
-				}
+				log.VEventf(txn.Context, 2, "ckpt %+v", mutation.ResumeSpans)
 				txn.SetSystemConfigTrigger()
 				return txn.Put(sqlbase.MakeDescMetadataKey(tableDesc.GetID()), sqlbase.WrapDescriptor(tableDesc))
 			}


### PR DESCRIPTION
I'm seeing an index backfill on a GCE cluster not terminating, so I'd like to add these log messages to aid in debugging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13648)
<!-- Reviewable:end -->
