### PR TITLE
sqlccl: deflake TestBackupAsOfSystemTime and TestExport

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -392,7 +392,6 @@ func TestBackupRestoreBank(t *testing.T) {
 
 func TestBackupAsOfSystemTime(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#13575")
 	if !storage.ProposerEvaluatedKVEnabled() {
 		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
 	}

--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -91,29 +91,23 @@ func evalExport(
 	// TODO(dan): Move all this iteration into cpp to avoid the cgo calls.
 	// TODO(dan): Consider checking ctx periodically during the MVCCIterate call.
 	var entries int64
-	for {
-		entries = 0
-		iter := engineccl.NewMVCCIncrementalIterator(batch)
-		defer iter.Close()
-		iter.Reset(args.Key, args.EndKey, args.StartTime, h.Timestamp)
-		for ; iter.Valid(); iter.Next() {
-			key, value := iter.Key(), iter.Value()
-			if log.V(3) {
-				log.Infof(ctx, "Export %+v %+v", key, value)
-			}
-			entries++
-			if err := sst.Add(engine.MVCCKeyValue{Key: key, Value: value}); err != nil {
-				return storage.EvalResult{}, errors.Wrapf(err, "adding key %s", key)
-			}
+	iter := engineccl.NewMVCCIncrementalIterator(batch)
+	defer iter.Close()
+	iter.Reset(args.Key, args.EndKey, args.StartTime, h.Timestamp)
+	for ; iter.Valid(); iter.Next() {
+		key, value := iter.Key(), iter.Value()
+		if log.V(3) {
+			log.Infof(ctx, "Export %+v %+v", key, value)
 		}
-		err := iter.Error()
-		if _, ok := err.(*roachpb.WriteIntentError); ok {
-			continue
+		entries++
+		if err := sst.Add(engine.MVCCKeyValue{Key: key, Value: value}); err != nil {
+			return storage.EvalResult{}, errors.Wrapf(err, "adding key %s", key)
 		}
-		if err != nil {
-			return storage.EvalResult{}, err
-		}
-		break
+	}
+	if err := iter.Error(); err != nil {
+		// The error may be a WriteIntentError. In which case, returning it will
+		// cause this command to be retried.
+		return storage.EvalResult{}, err
 	}
 
 	if entries == 0 {


### PR DESCRIPTION
The Export command had a tight loop to retry iteration when running into
an unresolved intent. When combined with rate limiting of Export
requests, this created deadlock (or made it more likely). Now it returns
the WriteIntentError and relies on the normal retry mechanism.

Closes #13614. Closes #13575. Closes #13588.

cc @bdarnell

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13650)
<!-- Reviewable:end -->
