### PR TITLE
util/hlc: remove ZeroTimestamp, Timestamp.Equal

### DIFF
--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -55,7 +55,7 @@ func evalExport(
 	// the resulting RocksDB tombstones compacted, which means we'd miss
 	// deletions in the incremental backup.
 	gcThreshold := r.GCThreshold()
-	if !args.StartTime.Equal(hlc.ZeroTimestamp) {
+	if args.StartTime != (hlc.Timestamp{}) {
 		if !gcThreshold.Less(args.StartTime) {
 			return storage.EvalResult{}, errors.Errorf("start timestamp %v must be after replica GC threshold %v", args.StartTime, gcThreshold)
 		}

--- a/pkg/ccl/storageccl/export_test.go
+++ b/pkg/ccl/storageccl/export_test.go
@@ -79,7 +79,7 @@ func TestExport(t *testing.T) {
 	sqlDB.Exec(`CREATE DATABASE export`)
 	sqlDB.Exec(`CREATE TABLE export.export (id INT PRIMARY KEY)`)
 	sqlDB.Exec(`INSERT INTO export.export VALUES (1), (3)`)
-	ts1, paths1, kvs1 := exportAndSlurp(hlc.ZeroTimestamp)
+	ts1, paths1, kvs1 := exportAndSlurp(hlc.Timestamp{})
 	if expected := 1; len(paths1) != expected {
 		t.Fatalf("expected %d files in export got %d", expected, len(paths1))
 	}
@@ -110,7 +110,7 @@ func TestExport(t *testing.T) {
 	}
 
 	sqlDB.Exec(`ALTER TABLE export.export SPLIT AT (2)`)
-	_, paths5, kvs5 := exportAndSlurp(hlc.ZeroTimestamp)
+	_, paths5, kvs5 := exportAndSlurp(hlc.Timestamp{})
 	if expected := 2; len(paths5) != expected {
 		t.Fatalf("expected %d files in export got %d", expected, len(paths5))
 	}

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -95,7 +95,7 @@ func printKey(kv engine.MVCCKeyValue) (bool, error) {
 }
 
 func printKeyValue(kv engine.MVCCKeyValue) (bool, error) {
-	if kv.Key.Timestamp != hlc.ZeroTimestamp {
+	if kv.Key.Timestamp != (hlc.Timestamp{}) {
 		fmt.Printf("%s %s: ", kv.Key.Timestamp, kv.Key.Key)
 	} else {
 		fmt.Printf("%s: ", kv.Key.Key)
@@ -239,7 +239,7 @@ func tryTxn(kv engine.MVCCKeyValue) (string, error) {
 }
 
 func tryRangeIDKey(kv engine.MVCCKeyValue) (string, error) {
-	if kv.Key.Timestamp != hlc.ZeroTimestamp {
+	if kv.Key.Timestamp != (hlc.Timestamp{}) {
 		return "", fmt.Errorf("range ID keys shouldn't have timestamps: %s", kv.Key)
 	}
 	_, _, suffix, _, err := keys.DecodeRangeIDKey(kv.Key.Key)
@@ -359,7 +359,7 @@ func loadRangeDescriptor(
 ) (roachpb.RangeDescriptor, error) {
 	var desc roachpb.RangeDescriptor
 	handleKV := func(kv engine.MVCCKeyValue) (bool, error) {
-		if kv.Key.Timestamp == hlc.ZeroTimestamp {
+		if kv.Key.Timestamp == (hlc.Timestamp{}) {
 			// We only want values, not MVCCMetadata.
 			return false, nil
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -204,7 +204,7 @@ func (s SystemConfig) Equal(other SystemConfig) bool {
 		if !bytes.Equal(leftVal.RawBytes, rightVal.RawBytes) {
 			return false
 		}
-		if !leftVal.Timestamp.Equal(rightVal.Timestamp) {
+		if leftVal.Timestamp != rightVal.Timestamp {
 			return false
 		}
 	}

--- a/pkg/internal/client/client_test.go
+++ b/pkg/internal/client/client_test.go
@@ -415,7 +415,7 @@ func TestClientGetAndPut(t *testing.T) {
 	if !bytes.Equal(value, gr.ValueBytes()) {
 		t.Errorf("expected values equal; %s != %s", value, gr.ValueBytes())
 	}
-	if gr.Value.Timestamp.Equal(hlc.ZeroTimestamp) {
+	if gr.Value.Timestamp == (hlc.Timestamp{}) {
 		t.Fatalf("expected non-zero timestamp; got empty")
 	}
 }
@@ -437,7 +437,7 @@ func TestClientPutInline(t *testing.T) {
 	if !bytes.Equal(value, gr.ValueBytes()) {
 		t.Errorf("expected values equal; %s != %s", value, gr.ValueBytes())
 	}
-	if ts := gr.Value.Timestamp; !ts.Equal(hlc.ZeroTimestamp) {
+	if ts := gr.Value.Timestamp; ts != (hlc.Timestamp{}) {
 		t.Fatalf("expected zero timestamp; got %s", ts)
 	}
 }

--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -477,9 +477,9 @@ func (ds *DistSender) sendSingleRange(
 	}
 
 	// If the reply contains a timestamp, update the local HLC with it.
-	if br.Error != nil && br.Error.Now != hlc.ZeroTimestamp {
+	if br.Error != nil && br.Error.Now != (hlc.Timestamp{}) {
 		ds.clock.Update(br.Error.Now)
-	} else if br.Now != hlc.ZeroTimestamp {
+	} else if br.Now != (hlc.Timestamp{}) {
 		ds.clock.Update(br.Now)
 	}
 
@@ -501,7 +501,7 @@ func (ds *DistSender) initAndVerifyBatch(
 
 	// In the event that timestamp isn't set and read consistency isn't
 	// required, set the timestamp using the local clock.
-	if ba.ReadConsistency == roachpb.INCONSISTENT && ba.Timestamp.Equal(hlc.ZeroTimestamp) {
+	if ba.ReadConsistency == roachpb.INCONSISTENT && ba.Timestamp == (hlc.Timestamp{}) {
 		ba.Timestamp = ds.clock.Now()
 	}
 

--- a/pkg/kv/dist_sender_server_test.go
+++ b/pkg/kv/dist_sender_server_test.go
@@ -1052,8 +1052,7 @@ func TestPropagateTxnOnError(t *testing.T) {
 			_, ok := fArgs.Req.(*roachpb.ConditionalPutRequest)
 			if ok && fArgs.Req.Header().Key.Equal(targetKey) {
 				if atomic.AddInt32(&numGets, 1) == 1 {
-					z := hlc.ZeroTimestamp
-					pErr := roachpb.NewReadWithinUncertaintyIntervalError(z, z)
+					pErr := roachpb.NewReadWithinUncertaintyIntervalError(hlc.Timestamp{}, hlc.Timestamp{})
 					return roachpb.NewErrorWithTxn(pErr, fArgs.Hdr.Txn)
 				}
 			}

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -403,7 +403,7 @@ func TestOwnNodeCertain(t *testing.T) {
 		TransportFactory:  adaptLegacyTransport(testFn),
 		RangeDescriptorDB: defaultMockRangeDescriptorDB,
 	}
-	expTS := hlc.ZeroTimestamp.Add(1, 2)
+	expTS := hlc.Timestamp{WallTime: 1, Logical: 2}
 	ds := NewDistSender(cfg, g)
 	v := roachpb.MakeValueFromString("value")
 	put := roachpb.NewPut(roachpb.Key("a"), v)
@@ -465,7 +465,7 @@ func TestImmutableBatchArgs(t *testing.T) {
 		t.Fatal(pErr)
 	}
 
-	if !txn.Timestamp.Equal(hlc.ZeroTimestamp) {
+	if txn.Timestamp != (hlc.Timestamp{}) {
 		t.Fatal("Transaction was mutated by DistSender")
 	}
 }

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -526,7 +526,7 @@ func (tc *TxnCoordSender) maybeBeginTxn(ba *roachpb.BatchRequest) error {
 		// The initial timestamp may be communicated by a higher layer.
 		// If so, use that. Otherwise make up a new one.
 		timestamp := ba.Txn.OrigTimestamp
-		if timestamp == hlc.ZeroTimestamp {
+		if timestamp == (hlc.Timestamp{}) {
 			timestamp = tc.clock.Now()
 		}
 		newTxn := roachpb.NewTransaction(ba.Txn.Name, nil, ba.UserPriority,

--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -743,7 +743,7 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 			// Timestamp moves ahead of the existing write.
 			pErr: func() *roachpb.Error {
 				pErr := roachpb.NewErrorWithTxn(
-					roachpb.NewReadWithinUncertaintyIntervalError(hlc.ZeroTimestamp, hlc.ZeroTimestamp),
+					roachpb.NewReadWithinUncertaintyIntervalError(hlc.Timestamp{}, hlc.Timestamp{}),
 					&roachpb.Transaction{})
 				const nodeID = 1
 				pErr.GetTxn().UpdateObservedTimestamp(nodeID, plus10)
@@ -835,11 +835,11 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 			t.Errorf("%d: expected priority = %d; got %d",
 				i, test.expPri, txn.Proto.Priority)
 		}
-		if !txn.Proto.Timestamp.Equal(test.expTS) {
+		if txn.Proto.Timestamp != test.expTS {
 			t.Errorf("%d: expected timestamp to be %s; got %s",
 				i, test.expTS, txn.Proto.Timestamp)
 		}
-		if !txn.Proto.OrigTimestamp.Equal(test.expOrigTS) {
+		if txn.Proto.OrigTimestamp != test.expOrigTS {
 			t.Errorf("%d: expected orig timestamp to be %s; got %s",
 				i, test.expOrigTS, txn.Proto.OrigTimestamp)
 		}

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -364,7 +364,7 @@ func TestTransactionObservedTimestamp(t *testing.T) {
 	ids := append([]int{109, 104, 102, 108, 1000}, rand.Perm(100)...)
 	timestamps := make(map[NodeID]hlc.Timestamp, len(ids))
 	for i := 0; i < len(ids); i++ {
-		timestamps[NodeID(i)] = hlc.ZeroTimestamp.Add(rng.Int63(), 0)
+		timestamps[NodeID(i)] = hlc.Timestamp{WallTime: rng.Int63()}
 	}
 	for i, n := range ids {
 		nodeID := NodeID(n)
@@ -379,16 +379,16 @@ func TestTransactionObservedTimestamp(t *testing.T) {
 	}
 	for _, m := range ids {
 		checkID := NodeID(m)
-		exp := timestamps[checkID]
-		if act, _ := txn.GetObservedTimestamp(checkID); !act.Equal(exp) {
-			t.Fatalf("%d: expected %s, got %s", checkID, exp, act)
+		expTS := timestamps[checkID]
+		if actTS, _ := txn.GetObservedTimestamp(checkID); actTS != expTS {
+			t.Fatalf("%d: expected %s, got %s", checkID, expTS, actTS)
 		}
 	}
 
 	var emptyTxn Transaction
-	ts := hlc.ZeroTimestamp.Add(1, 2)
+	ts := hlc.Timestamp{WallTime: 1, Logical: 2}
 	emptyTxn.UpdateObservedTimestamp(NodeID(1), ts)
-	if actTS, _ := emptyTxn.GetObservedTimestamp(NodeID(1)); !actTS.Equal(ts) {
+	if actTS, _ := emptyTxn.GetObservedTimestamp(NodeID(1)); actTS != ts {
 		t.Fatalf("unexpected: %s (wanted %s)", actTS, ts)
 	}
 }

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -480,7 +480,7 @@ func (n *Node) initStores(
 
 	// Compute the time this node was last up; this is done by reading the
 	// "last up time" from every store and choosing the most recent timestamp.
-	mostRecentTimestamp := hlc.ZeroTimestamp
+	var mostRecentTimestamp hlc.Timestamp
 	if err := n.stores.VisitStores(func(s *storage.Store) error {
 		timestamp, err := s.ReadLastUpTimestamp(ctx)
 		if err != nil {

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -366,7 +366,7 @@ func TestCorruptedClusterID(t *testing.T) {
 		NodeID:    1,
 		StoreID:   1,
 	}
-	if err := engine.MVCCPutProto(context.Background(), e, nil, keys.StoreIdentKey(), hlc.ZeroTimestamp, nil, &sIdent); err != nil {
+	if err := engine.MVCCPutProto(context.Background(), e, nil, keys.StoreIdentKey(), hlc.Timestamp{}, nil, &sIdent); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -137,7 +137,7 @@ VALUES(
 // *are* the first action in a transaction, and we must elect to use the store's
 // physical time instead.
 func (ev EventLogger) selectEventTimestamp(input hlc.Timestamp) time.Time {
-	if input == hlc.ZeroTimestamp {
+	if input == (hlc.Timestamp{}) {
 		return ev.LeaseManager.clock.PhysicalTime()
 	}
 	return input.GoTime()

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -1777,7 +1777,7 @@ func (ctx *EvalContext) GetClusterTimestamp() *DDecimal {
 	// TODO(knz) a zero timestamp should never be read, even during
 	// Prepare. This will need to be addressed.
 	if !ctx.PrepareOnly {
-		if ctx.clusterTimestamp == hlc.ZeroTimestamp {
+		if ctx.clusterTimestamp == (hlc.Timestamp{}) {
 			panic("zero cluster timestamp in EvalContext")
 		}
 	}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -201,7 +201,7 @@ func (p *planner) setTxn(txn *client.Txn) {
 	} else {
 		p.evalCtx.SetTxnTimestamp(time.Time{})
 		p.evalCtx.SetStmtTimestamp(time.Time{})
-		p.evalCtx.SetClusterTimestamp(hlc.ZeroTimestamp)
+		p.evalCtx.SetClusterTimestamp(hlc.Timestamp{})
 	}
 }
 

--- a/pkg/sql/table_test.go
+++ b/pkg/sql/table_test.go
@@ -275,8 +275,8 @@ func TestRemoveLeaseIfExpiring(t *testing.T) {
 	if p.removeLeaseIfExpiring(l1) {
 		t.Error("expected false with a non-expiring lease")
 	}
-	if !p.txn.GetDeadline().Equal(et) {
-		t.Errorf("expected deadline %s but got %s", et, p.txn.GetDeadline())
+	if d := *p.txn.GetDeadline(); d != et {
+		t.Errorf("expected deadline %s but got %s", et, d)
 	}
 
 	// Advance the clock so that l1 will be expired.
@@ -295,7 +295,7 @@ func TestRemoveLeaseIfExpiring(t *testing.T) {
 		t.Errorf("expected leases to contain %s but has %s", l2, p.leases)
 	}
 
-	if !p.txn.GetDeadline().Equal(et) {
-		t.Errorf("expected deadline %s, but got %s", et, p.txn.GetDeadline())
+	if d := *p.txn.GetDeadline(); d != et {
+		t.Errorf("expected deadline %s, but got %s", et, d)
 	}
 }

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -117,7 +117,7 @@ func injectErrors(req roachpb.Request, hdr roachpb.Header, magicVals *filterVals
 			if count > 0 && bytes.Contains(req.Value.RawBytes, []byte(key)) {
 				magicVals.restartCounts[key]--
 				err := roachpb.NewReadWithinUncertaintyIntervalError(
-					hlc.ZeroTimestamp, hlc.ZeroTimestamp)
+					hlc.Timestamp{}, hlc.Timestamp{})
 				magicVals.failedValues[string(req.Value.RawBytes)] =
 					failureRecord{err, hdr.Txn}
 				return err

--- a/pkg/storage/abort_cache.go
+++ b/pkg/storage/abort_cache.go
@@ -105,7 +105,7 @@ func (sc *AbortCache) Get(
 
 	// Pull response from disk and read into reply if available.
 	key := keys.AbortCacheKey(sc.rangeID, txnID)
-	ok, err := engine.MVCCGetProto(ctx, e, key, hlc.ZeroTimestamp, true /* consistent */, nil /* txn */, entry)
+	ok, err := engine.MVCCGetProto(ctx, e, key, hlc.Timestamp{}, true /* consistent */, nil /* txn */, entry)
 	return ok, err
 }
 
@@ -116,7 +116,7 @@ func (sc *AbortCache) Get(
 func (sc *AbortCache) Iterate(
 	ctx context.Context, e engine.Reader, f func([]byte, roachpb.AbortCacheEntry),
 ) {
-	_, _ = engine.MVCCIterate(ctx, e, sc.min(), sc.max(), hlc.ZeroTimestamp,
+	_, _ = engine.MVCCIterate(ctx, e, sc.min(), sc.max(), hlc.Timestamp{},
 		true /* consistent */, nil /* txn */, false, /* !reverse */
 		func(kv roachpb.KeyValue) (bool, error) {
 			var entry roachpb.AbortCacheEntry
@@ -205,7 +205,7 @@ func (sc *AbortCache) Del(
 	ctx context.Context, e engine.ReadWriter, ms *enginepb.MVCCStats, txnID uuid.UUID,
 ) error {
 	key := keys.AbortCacheKey(sc.rangeID, txnID)
-	return engine.MVCCDelete(ctx, e, ms, key, hlc.ZeroTimestamp, nil /* txn */)
+	return engine.MVCCDelete(ctx, e, ms, key, hlc.Timestamp{}, nil /* txn */)
 }
 
 // Put writes an entry for the specified transaction ID.
@@ -217,7 +217,7 @@ func (sc *AbortCache) Put(
 	entry *roachpb.AbortCacheEntry,
 ) error {
 	key := keys.AbortCacheKey(sc.rangeID, txnID)
-	return engine.MVCCPutProto(ctx, e, ms, key, hlc.ZeroTimestamp, nil /* txn */, entry)
+	return engine.MVCCPutProto(ctx, e, ms, key, hlc.Timestamp{}, nil /* txn */, entry)
 }
 
 func decodeAbortCacheMVCCKey(encKey engine.MVCCKey, dest []byte) (uuid.UUID, error) {

--- a/pkg/storage/abort_cache_test.go
+++ b/pkg/storage/abort_cache_test.go
@@ -42,7 +42,7 @@ var (
 	testTxnID        = uuidFromString("0ce61c17-5eb4-4587-8c36-dcf4062ada4c")
 	testTxnID2       = uuidFromString("9855a1ef-8eb9-4c06-a106-cab1dda78a2b")
 	testTxnKey       = []byte("a")
-	testTxnTimestamp = hlc.ZeroTimestamp.Add(123, 456)
+	testTxnTimestamp = hlc.Timestamp{WallTime: 123, Logical: 456}
 	testTxnPriority  = int32(123)
 )
 

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -105,7 +105,7 @@ func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	scan := func(f func(roachpb.KeyValue) (bool, error)) {
-		if _, err := engine.MVCCIterate(context.Background(), store.Engine(), roachpb.KeyMin, roachpb.KeyMax, hlc.ZeroTimestamp, true, nil, false, f); err != nil {
+		if _, err := engine.MVCCIterate(context.Background(), store.Engine(), roachpb.KeyMin, roachpb.KeyMax, hlc.Timestamp{}, true, nil, false, f); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2002,7 +2002,7 @@ func TestRaftRemoveRace(t *testing.T) {
 		var tombstone roachpb.RaftTombstone
 		if ok, err := engine.MVCCGetProto(
 			context.Background(), mtc.stores[2].Engine(), tombstoneKey,
-			hlc.ZeroTimestamp, true, nil, &tombstone,
+			hlc.Timestamp{}, true, nil, &tombstone,
 		); err != nil {
 			t.Fatal(err)
 		} else if ok {
@@ -2939,7 +2939,7 @@ func TestCheckInconsistent(t *testing.T) {
 				t.Errorf("diff length = %d, diff = %v", len(diff), diff)
 			}
 			d := diff[0]
-			if d.LeaseHolder || !bytes.Equal(diffKey, d.Key) || !diffTimestamp.Equal(d.Timestamp) {
+			if d.LeaseHolder || !bytes.Equal(diffKey, d.Key) || diffTimestamp != d.Timestamp {
 				t.Errorf("diff = %v", d)
 			}
 			notifyReportDiff <- struct{}{}

--- a/pkg/storage/engine/batch.go
+++ b/pkg/storage/engine/batch.go
@@ -153,7 +153,7 @@ func putUint64(b []byte, v uint64) {
 func (b *RocksDBBatchBuilder) encodeKey(key MVCCKey, extra int) {
 	length := 1 + len(key.Key)
 	timestampLength := 0
-	if key.Timestamp != hlc.ZeroTimestamp {
+	if key.Timestamp != (hlc.Timestamp{}) {
 		timestampLength = 1 + 8
 		if key.Timestamp.Logical != 0 {
 			timestampLength += 4

--- a/pkg/storage/engine/engine_test.go
+++ b/pkg/storage/engine/engine_test.go
@@ -167,7 +167,7 @@ func TestEngineBatchStaleCachedIterator(t *testing.T) {
 
 			// Put a value so that the deletion below finds a value to seek
 			// to.
-			if err := MVCCPut(context.Background(), batch, nil, key, hlc.ZeroTimestamp,
+			if err := MVCCPut(context.Background(), batch, nil, key, hlc.Timestamp{},
 				roachpb.MakeValueFromString("x"), nil); err != nil {
 				t.Fatal(err)
 			}
@@ -175,7 +175,7 @@ func TestEngineBatchStaleCachedIterator(t *testing.T) {
 			// Seek the iterator to `key` and clear the value (but without
 			// telling the iterator about that).
 			if err := MVCCDelete(context.Background(), batch, nil, key,
-				hlc.ZeroTimestamp, nil); err != nil {
+				hlc.Timestamp{}, nil); err != nil {
 				t.Fatal(err)
 			}
 
@@ -187,7 +187,7 @@ func TestEngineBatchStaleCachedIterator(t *testing.T) {
 			// result back, we'll see the (newly deleted) value (due to the
 			// failure mode above).
 			if v, _, err := MVCCGet(context.Background(), batch, key,
-				hlc.ZeroTimestamp, true, nil); err != nil {
+				hlc.Timestamp{}, true, nil); err != nil {
 				t.Fatal(err)
 			} else if v != nil {
 				t.Fatalf("expected no value, got %+v", v)

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -60,13 +60,13 @@ var (
 	testKey4     = roachpb.Key("/db4")
 	testKey5     = roachpb.Key("/db5")
 	testKey6     = roachpb.Key("/db6")
-	txn1         = &roachpb.Transaction{TxnMeta: enginepb.TxnMeta{Key: roachpb.Key("a"), ID: &txn1ID, Epoch: 1, Timestamp: makeTS(0, 1)}}
-	txn1Commit   = &roachpb.Transaction{TxnMeta: enginepb.TxnMeta{Key: roachpb.Key("a"), ID: &txn1ID, Epoch: 1, Timestamp: makeTS(0, 1)}, Status: roachpb.COMMITTED}
+	txn1         = &roachpb.Transaction{TxnMeta: enginepb.TxnMeta{Key: roachpb.Key("a"), ID: &txn1ID, Epoch: 1, Timestamp: hlc.Timestamp{Logical: 1}}}
+	txn1Commit   = &roachpb.Transaction{TxnMeta: enginepb.TxnMeta{Key: roachpb.Key("a"), ID: &txn1ID, Epoch: 1, Timestamp: hlc.Timestamp{Logical: 1}}, Status: roachpb.COMMITTED}
 	txn1Abort    = &roachpb.Transaction{TxnMeta: enginepb.TxnMeta{Key: roachpb.Key("a"), ID: &txn1ID, Epoch: 1}, Status: roachpb.ABORTED}
-	txn1e2       = &roachpb.Transaction{TxnMeta: enginepb.TxnMeta{Key: roachpb.Key("a"), ID: &txn1ID, Epoch: 2, Timestamp: makeTS(0, 1)}}
-	txn1e2Commit = &roachpb.Transaction{TxnMeta: enginepb.TxnMeta{Key: roachpb.Key("a"), ID: &txn1ID, Epoch: 2, Timestamp: makeTS(0, 1)}, Status: roachpb.COMMITTED}
-	txn2         = &roachpb.Transaction{TxnMeta: enginepb.TxnMeta{Key: roachpb.Key("a"), ID: &txn2ID, Timestamp: makeTS(0, 1)}}
-	txn2Commit   = &roachpb.Transaction{TxnMeta: enginepb.TxnMeta{Key: roachpb.Key("a"), ID: &txn2ID, Timestamp: makeTS(0, 1)}, Status: roachpb.COMMITTED}
+	txn1e2       = &roachpb.Transaction{TxnMeta: enginepb.TxnMeta{Key: roachpb.Key("a"), ID: &txn1ID, Epoch: 2, Timestamp: hlc.Timestamp{Logical: 1}}}
+	txn1e2Commit = &roachpb.Transaction{TxnMeta: enginepb.TxnMeta{Key: roachpb.Key("a"), ID: &txn1ID, Epoch: 2, Timestamp: hlc.Timestamp{Logical: 1}}, Status: roachpb.COMMITTED}
+	txn2         = &roachpb.Transaction{TxnMeta: enginepb.TxnMeta{Key: roachpb.Key("a"), ID: &txn2ID, Timestamp: hlc.Timestamp{Logical: 1}}}
+	txn2Commit   = &roachpb.Transaction{TxnMeta: enginepb.TxnMeta{Key: roachpb.Key("a"), ID: &txn2ID, Timestamp: hlc.Timestamp{Logical: 1}}, Status: roachpb.COMMITTED}
 	value1       = roachpb.MakeValueFromString("testValue1")
 	value2       = roachpb.MakeValueFromString("testValue2")
 	value3       = roachpb.MakeValueFromString("testValue3")
@@ -94,14 +94,6 @@ func makeTxn(baseTxn roachpb.Transaction, ts hlc.Timestamp) *roachpb.Transaction
 	txn := baseTxn.Clone()
 	txn.Timestamp = ts
 	return &txn
-}
-
-// makeTS creates a new hybrid logical timestamp.
-func makeTS(nanos int64, logical int32) hlc.Timestamp {
-	return hlc.Timestamp{
-		WallTime: nanos,
-		Logical:  logical,
-	}
 }
 
 type mvccKeys []MVCCKey
@@ -247,13 +239,13 @@ func TestMVCCKeys(t *testing.T) {
 	a0Key := roachpb.Key("a\x00")
 	keys := mvccKeys{
 		mvccKey(aKey),
-		mvccVersionKey(aKey, makeTS(math.MaxInt64, 0)),
-		mvccVersionKey(aKey, makeTS(1, 0)),
-		mvccVersionKey(aKey, makeTS(0, 1)),
+		mvccVersionKey(aKey, hlc.Timestamp{WallTime: math.MaxInt64}),
+		mvccVersionKey(aKey, hlc.Timestamp{WallTime: 1}),
+		mvccVersionKey(aKey, hlc.Timestamp{Logical: 1}),
 		mvccKey(a0Key),
-		mvccVersionKey(a0Key, makeTS(math.MaxInt64, 0)),
-		mvccVersionKey(a0Key, makeTS(1, 0)),
-		mvccVersionKey(a0Key, makeTS(0, 1)),
+		mvccVersionKey(a0Key, hlc.Timestamp{WallTime: math.MaxInt64}),
+		mvccVersionKey(a0Key, hlc.Timestamp{WallTime: 1}),
+		mvccVersionKey(a0Key, hlc.Timestamp{Logical: 1}),
 	}
 	sortKeys := make(mvccKeys, len(keys))
 	copy(sortKeys, keys)
@@ -268,16 +260,16 @@ func TestMVCCEmptyKey(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if _, _, err := MVCCGet(context.Background(), engine, roachpb.Key{}, makeTS(0, 1), true, nil); err == nil {
+	if _, _, err := MVCCGet(context.Background(), engine, roachpb.Key{}, hlc.Timestamp{Logical: 1}, true, nil); err == nil {
 		t.Error("expected empty key error")
 	}
-	if err := MVCCPut(context.Background(), engine, nil, roachpb.Key{}, makeTS(0, 1), value1, nil); err == nil {
+	if err := MVCCPut(context.Background(), engine, nil, roachpb.Key{}, hlc.Timestamp{Logical: 1}, value1, nil); err == nil {
 		t.Error("expected empty key error")
 	}
-	if _, _, _, err := MVCCScan(context.Background(), engine, roachpb.Key{}, testKey1, math.MaxInt64, makeTS(0, 1), true, nil); err != nil {
+	if _, _, _, err := MVCCScan(context.Background(), engine, roachpb.Key{}, testKey1, math.MaxInt64, hlc.Timestamp{Logical: 1}, true, nil); err != nil {
 		t.Errorf("empty key allowed for start key in scan; got %s", err)
 	}
-	if _, _, _, err := MVCCScan(context.Background(), engine, testKey1, roachpb.Key{}, math.MaxInt64, makeTS(0, 1), true, nil); err == nil {
+	if _, _, _, err := MVCCScan(context.Background(), engine, testKey1, roachpb.Key{}, math.MaxInt64, hlc.Timestamp{Logical: 1}, true, nil); err == nil {
 		t.Error("expected empty key error")
 	}
 	if err := MVCCResolveWriteIntent(context.Background(), engine, nil, roachpb.Intent{}); err == nil {
@@ -290,7 +282,7 @@ func TestMVCCGetNotExist(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	value, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(0, 1), true, nil)
+	value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{Logical: 1}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -304,11 +296,11 @@ func TestMVCCPutWithTxn(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(0, 1), value1, txn1); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, txn1); err != nil {
 		t.Fatal(err)
 	}
 
-	for _, ts := range []hlc.Timestamp{makeTS(0, 1), makeTS(0, 2), makeTS(1, 0)} {
+	for _, ts := range []hlc.Timestamp{{Logical: 1}, {Logical: 2}, {WallTime: 1}} {
 		value, _, err := MVCCGet(context.Background(), engine, testKey1, ts, true, txn1)
 		if err != nil {
 			t.Fatal(err)
@@ -325,12 +317,12 @@ func TestMVCCPutWithoutTxn(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(0, 1), value1, nil)
+	err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	for _, ts := range []hlc.Timestamp{makeTS(0, 1), makeTS(0, 2), makeTS(1, 0)} {
+	for _, ts := range []hlc.Timestamp{{Logical: 1}, {Logical: 2}, {WallTime: 1}} {
 		value, _, err := MVCCGet(context.Background(), engine, testKey1, ts, true, nil)
 		if err != nil {
 			t.Fatal(err)
@@ -349,18 +341,18 @@ func TestMVCCPutOutOfOrder(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(2, 1), value1, txn1); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 2, Logical: 1}, value1, txn1); err != nil {
 		t.Fatal(err)
 	}
 
 	// Put operation with earlier wall time. Will NOT be ignored.
 	txn := *txn1
 	txn.Sequence++
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value2, &txn); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value2, &txn); err != nil {
 		t.Fatal(err)
 	}
 
-	value, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(3, 0), true, &txn)
+	value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 3}, true, &txn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -371,11 +363,11 @@ func TestMVCCPutOutOfOrder(t *testing.T) {
 
 	// Another put operation with earlier logical time. Will NOT be ignored.
 	txn.Sequence++
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(2, 0), value2, &txn); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, value2, &txn); err != nil {
 		t.Fatal(err)
 	}
 
-	value, _, err = MVCCGet(context.Background(), engine, testKey1, makeTS(3, 0), true, &txn)
+	value, _, err = MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 3}, true, &txn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -392,14 +384,14 @@ func TestMVCCIncrement(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	newVal, err := MVCCIncrement(context.Background(), engine, nil, testKey1, makeTS(0, 1), nil, 0)
+	newVal, err := MVCCIncrement(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if newVal != 0 {
 		t.Errorf("expected new value of 0; got %d", newVal)
 	}
-	val, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(0, 1), true, nil)
+	val, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{Logical: 1}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -407,7 +399,7 @@ func TestMVCCIncrement(t *testing.T) {
 		t.Errorf("expected increment of 0 to create key/value")
 	}
 
-	newVal, err = MVCCIncrement(context.Background(), engine, nil, testKey1, makeTS(0, 2), nil, 2)
+	newVal, err = MVCCIncrement(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 2}, nil, 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -425,7 +417,7 @@ func TestMVCCIncrementTxn(t *testing.T) {
 	txn := *txn1
 	for i := 1; i <= 2; i++ {
 		txn.Sequence++
-		newVal, err := MVCCIncrement(context.Background(), engine, nil, testKey1, makeTS(0, 1), &txn, 1)
+		newVal, err := MVCCIncrement(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, &txn, 1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -446,25 +438,25 @@ func TestMVCCIncrementOldTimestamp(t *testing.T) {
 	// Write an integer value.
 	val := roachpb.Value{}
 	val.SetInt(1)
-	err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), val, nil)
+	err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, val, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Override value.
 	val.SetInt(2)
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(3, 0), val, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, val, nil); err != nil {
 		t.Fatal(err)
 	}
 
 	// Attempt to increment a value with an older timestamp than
 	// the previous put. This will fail with type mismatch (not
 	// with WriteTooOldError).
-	incVal, err := MVCCIncrement(context.Background(), engine, nil, testKey1, makeTS(2, 0), nil, 1)
+	incVal, err := MVCCIncrement(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, nil, 1)
 	if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok {
 		t.Fatalf("unexpectedly not WriteTooOld: %s", err)
-	} else if !wtoErr.ActualTimestamp.Equal(makeTS(3, 1)) {
-		t.Fatalf("expected write too old error with actual ts %s; got %s", makeTS(1, 1), wtoErr.ActualTimestamp)
+	} else if expTS := (hlc.Timestamp{WallTime: 3, Logical: 1}); wtoErr.ActualTimestamp != (expTS) {
+		t.Fatalf("expected write too old error with actual ts %s; got %s", expTS, wtoErr.ActualTimestamp)
 	}
 	if incVal != 3 {
 		t.Fatalf("expected value=%d; got %d", 3, incVal)
@@ -476,12 +468,12 @@ func TestMVCCUpdateExistingKey(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(0, 1), value1, nil)
+	err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	value, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(1, 0), true, nil)
+	value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 1}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -490,12 +482,12 @@ func TestMVCCUpdateExistingKey(t *testing.T) {
 			value1.RawBytes, value.RawBytes)
 	}
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(2, 0), value2, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, value2, nil); err != nil {
 		t.Fatal(err)
 	}
 
 	// Read the latest version.
-	value, _, err = MVCCGet(context.Background(), engine, testKey1, makeTS(3, 0), true, nil)
+	value, _, err = MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 3}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -505,7 +497,7 @@ func TestMVCCUpdateExistingKey(t *testing.T) {
 	}
 
 	// Read the old version.
-	value, _, err = MVCCGet(context.Background(), engine, testKey1, makeTS(1, 0), true, nil)
+	value, _, err = MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 1}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -520,15 +512,15 @@ func TestMVCCUpdateExistingKeyOldVersion(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 1), value1, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1, Logical: 1}, value1, nil); err != nil {
 		t.Fatal(err)
 	}
 	// Earlier wall time.
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(0, 1), value2, nil); err == nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value2, nil); err == nil {
 		t.Fatal("expected error on old version")
 	}
 	// Earlier logical time.
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value2, nil); err == nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value2, nil); err == nil {
 		t.Fatal("expected error on old version")
 	}
 }
@@ -539,12 +531,12 @@ func TestMVCCUpdateExistingKeyInTxn(t *testing.T) {
 	defer engine.Close()
 
 	txn := *txn1
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(0, 1), value1, &txn); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, &txn); err != nil {
 		t.Fatal(err)
 	}
 
 	txn.Sequence++
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value1, &txn); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, &txn); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -554,11 +546,11 @@ func TestMVCCUpdateExistingKeyDiffTxn(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(0, 1), value1, txn1); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, txn1); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value2, txn2); err == nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value2, txn2); err == nil {
 		t.Fatal("expected error on uncommitted write intent")
 	}
 }
@@ -580,14 +572,14 @@ func TestMVCCGetNoMoreOldVersion(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(3, 0), value1, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, value1, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey2, makeTS(1, 0), value2, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
 		t.Fatal(err)
 	}
 
-	value, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(2, 0), true, nil)
+	value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 2}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -605,17 +597,17 @@ func TestMVCCGetUncertainty(t *testing.T) {
 	defer engine.Close()
 
 	u := uuid.MakeV4()
-	txn := &roachpb.Transaction{TxnMeta: enginepb.TxnMeta{ID: &u, Timestamp: makeTS(5, 0)}, MaxTimestamp: makeTS(10, 0)}
+	txn := &roachpb.Transaction{TxnMeta: enginepb.TxnMeta{ID: &u, Timestamp: hlc.Timestamp{WallTime: 5}}, MaxTimestamp: hlc.Timestamp{WallTime: 10}}
 	// Put a value from the past.
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value1, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
 		t.Fatal(err)
 	}
 	// Put a value that is ahead of MaxTimestamp, it should not interfere.
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(12, 0), value2, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 12}, value2, nil); err != nil {
 		t.Fatal(err)
 	}
 	// Read with transaction, should get a value back.
-	val, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(7, 0), true, txn)
+	val, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 7}, true, txn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -625,42 +617,42 @@ func TestMVCCGetUncertainty(t *testing.T) {
 
 	// Now using testKey2.
 	// Put a value that conflicts with MaxTimestamp.
-	if err := MVCCPut(context.Background(), engine, nil, testKey2, makeTS(9, 0), value2, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey2, hlc.Timestamp{WallTime: 9}, value2, nil); err != nil {
 		t.Fatal(err)
 	}
 	// Read with transaction, should get error back.
-	if _, _, err := MVCCGet(context.Background(), engine, testKey2, makeTS(7, 0), true, txn); err == nil {
+	if _, _, err := MVCCGet(context.Background(), engine, testKey2, hlc.Timestamp{WallTime: 7}, true, txn); err == nil {
 		t.Fatal("wanted an error")
 	} else if e, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
 		t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", e)
 	}
-	if _, _, _, err := MVCCScan(context.Background(), engine, testKey2, testKey2.PrefixEnd(), 10, makeTS(7, 0), true, txn); err == nil {
+	if _, _, _, err := MVCCScan(context.Background(), engine, testKey2, testKey2.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, true, txn); err == nil {
 		t.Fatal("wanted an error")
 	}
 	// Adjust MaxTimestamp and retry.
-	txn.MaxTimestamp = makeTS(7, 0)
-	if _, _, err := MVCCGet(context.Background(), engine, testKey2, makeTS(7, 0), true, txn); err != nil {
+	txn.MaxTimestamp = hlc.Timestamp{WallTime: 7}
+	if _, _, err := MVCCGet(context.Background(), engine, testKey2, hlc.Timestamp{WallTime: 7}, true, txn); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, _, err := MVCCScan(context.Background(), engine, testKey2, testKey2.PrefixEnd(), 10, makeTS(7, 0), true, txn); err != nil {
+	if _, _, _, err := MVCCScan(context.Background(), engine, testKey2, testKey2.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, true, txn); err != nil {
 		t.Fatal(err)
 	}
 
-	txn.MaxTimestamp = makeTS(10, 0)
+	txn.MaxTimestamp = hlc.Timestamp{WallTime: 10}
 	// Now using testKey3.
 	// Put a value that conflicts with MaxTimestamp and another write further
 	// ahead and not conflicting any longer. The first write should still ruin
 	// it.
-	if err := MVCCPut(context.Background(), engine, nil, testKey3, makeTS(9, 0), value2, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey3, hlc.Timestamp{WallTime: 9}, value2, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey3, makeTS(99, 0), value2, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey3, hlc.Timestamp{WallTime: 99}, value2, nil); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, _, err := MVCCScan(context.Background(), engine, testKey3, testKey3.PrefixEnd(), 10, makeTS(7, 0), true, txn); err == nil {
+	if _, _, _, err := MVCCScan(context.Background(), engine, testKey3, testKey3.PrefixEnd(), 10, hlc.Timestamp{WallTime: 7}, true, txn); err == nil {
 		t.Fatal("wanted an error")
 	}
-	if _, _, err := MVCCGet(context.Background(), engine, testKey3, makeTS(7, 0), true, txn); err == nil {
+	if _, _, err := MVCCGet(context.Background(), engine, testKey3, hlc.Timestamp{WallTime: 7}, true, txn); err == nil {
 		t.Fatalf("wanted an error")
 	}
 }
@@ -670,10 +662,10 @@ func TestMVCCGetAndDelete(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value1, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
 		t.Fatal(err)
 	}
-	value, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(2, 0), true, nil)
+	value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 2}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -681,13 +673,13 @@ func TestMVCCGetAndDelete(t *testing.T) {
 		t.Fatal("the value should not be empty")
 	}
 
-	err = MVCCDelete(context.Background(), engine, nil, testKey1, makeTS(3, 0), nil)
+	err = MVCCDelete(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Read the latest version which should be deleted.
-	value, _, err = MVCCGet(context.Background(), engine, testKey1, makeTS(4, 0), true, nil)
+	value, _, err = MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 4}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -697,7 +689,7 @@ func TestMVCCGetAndDelete(t *testing.T) {
 
 	// Read the old version which should still exist.
 	for _, logical := range []int32{0, math.MaxInt32} {
-		value, _, err = MVCCGet(context.Background(), engine, testKey1, makeTS(2, logical), true, nil)
+		value, _, err = MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 2, Logical: logical}, true, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -717,20 +709,20 @@ func TestMVCCWriteWithOlderTimestampAfterDeletionOfNonexistentKey(t *testing.T) 
 	defer engine.Close()
 
 	if err := MVCCDelete(
-		context.Background(), engine, nil, testKey1, makeTS(3, 0), nil,
+		context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, nil,
 	); err != nil {
 		t.Fatal(err)
 	}
 
 	if err := MVCCPut(
-		context.Background(), engine, nil, testKey1, makeTS(1, 0), value1, nil,
+		context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil,
 	); !testutils.IsError(
 		err, "write at timestamp 0.000000001,0 too old; wrote at 0.000000003,1",
 	) {
 		t.Fatal(err)
 	}
 
-	value, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(2, 0), true, nil)
+	value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 2}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -741,7 +733,7 @@ func TestMVCCWriteWithOlderTimestampAfterDeletionOfNonexistentKey(t *testing.T) 
 	}
 
 	// Read the latest version which will be the value written with the timestamp pushed.
-	value, _, err = MVCCGet(context.Background(), engine, testKey1, makeTS(4, 0), true, nil)
+	value, _, err = MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 4}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -751,8 +743,8 @@ func TestMVCCWriteWithOlderTimestampAfterDeletionOfNonexistentKey(t *testing.T) 
 	if !bytes.Equal(value.RawBytes, value1.RawBytes) {
 		t.Errorf("expected %q; got %q", value1.RawBytes, value.RawBytes)
 	}
-	if !value.Timestamp.Equal(makeTS(3, 1)) {
-		t.Fatalf("timestamp was not pushed: %s", value.Timestamp)
+	if expTS := (hlc.Timestamp{WallTime: 3, Logical: 1}); value.Timestamp != expTS {
+		t.Fatalf("timestamp was not pushed: %s, expected %s", value.Timestamp, expTS)
 	}
 }
 
@@ -762,12 +754,12 @@ func TestMVCCInlineWithTxn(t *testing.T) {
 	defer engine.Close()
 
 	// Put an inline value.
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.ZeroTimestamp, value1, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{}, value1, nil); err != nil {
 		t.Fatal(err)
 	}
 
 	// Now verify inline get.
-	value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.ZeroTimestamp, true, nil)
+	value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -777,12 +769,12 @@ func TestMVCCInlineWithTxn(t *testing.T) {
 
 	// Verify inline get with txn does still work (this will happen on a
 	// scan if the distributed sender is forced to wrap it in a txn).
-	if _, _, err = MVCCGet(context.Background(), engine, testKey1, hlc.ZeroTimestamp, true, txn1); err != nil {
+	if _, _, err = MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{}, true, txn1); err != nil {
 		t.Error(err)
 	}
 
 	// Verify inline put with txn is an error.
-	if err = MVCCPut(context.Background(), engine, nil, testKey2, hlc.ZeroTimestamp, value2, txn2); !testutils.IsError(err, "writes not allowed within transactions") {
+	if err = MVCCPut(context.Background(), engine, nil, testKey2, hlc.Timestamp{}, value2, txn2); !testutils.IsError(err, "writes not allowed within transactions") {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
@@ -792,7 +784,7 @@ func TestMVCCDeleteMissingKey(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if err := MVCCDelete(context.Background(), engine, nil, testKey1, makeTS(1, 0), nil); err != nil {
+	if err := MVCCDelete(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, nil); err != nil {
 		t.Fatal(err)
 	}
 	// Verify nothing is written to the engine.
@@ -808,23 +800,23 @@ func TestMVCCGetAndDeleteInTxn(t *testing.T) {
 
 	txn := *txn1
 	txn.Sequence++
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value1, &txn); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, &txn); err != nil {
 		t.Fatal(err)
 	}
 
-	if value, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(2, 0), true, &txn); err != nil {
+	if value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 2}, true, &txn); err != nil {
 		t.Fatal(err)
 	} else if value == nil {
 		t.Fatal("the value should not be empty")
 	}
 
 	txn.Sequence++
-	if err := MVCCDelete(context.Background(), engine, nil, testKey1, makeTS(3, 0), &txn); err != nil {
+	if err := MVCCDelete(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, &txn); err != nil {
 		t.Fatal(err)
 	}
 
 	// Read the latest version which should be deleted.
-	if value, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(4, 0), true, &txn); err != nil {
+	if value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 4}, true, &txn); err != nil {
 		t.Fatal(err)
 	} else if value != nil {
 		t.Fatal("the value should be empty")
@@ -832,7 +824,7 @@ func TestMVCCGetAndDeleteInTxn(t *testing.T) {
 
 	// Read the old version which shouldn't exist, as within a
 	// transaction, we delete previous values.
-	if value, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(2, 0), true, nil); err != nil {
+	if value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 2}, true, nil); err != nil {
 		t.Fatal(err)
 	} else if value != nil {
 		t.Fatalf("expected value nil, got: %s", value)
@@ -844,15 +836,15 @@ func TestMVCCGetWriteIntentError(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(0, 1), value1, txn1); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, txn1); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(1, 0), true, nil); err == nil {
+	if _, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 1}, true, nil); err == nil {
 		t.Fatal("cannot read the value of a write intent without TxnID")
 	}
 
-	if _, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(1, 0), true, txn2); err == nil {
+	if _, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 1}, true, txn2); err == nil {
 		t.Fatal("cannot read the value of a write intent from a different TxnID")
 	}
 }
@@ -868,7 +860,7 @@ func TestMVCCScanWriteIntentError(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	ts := []hlc.Timestamp{makeTS(0, 1), makeTS(0, 2), makeTS(0, 3), makeTS(0, 4), makeTS(0, 5), makeTS(0, 6)}
+	ts := []hlc.Timestamp{{Logical: 1}, {Logical: 2}, {Logical: 3}, {Logical: 4}, {Logical: 5}, {Logical: 6}}
 
 	fixtureKVs := []roachpb.KeyValue{
 		{Key: testKey1, Value: mkVal("testValue1 pre", ts[0])},
@@ -886,7 +878,7 @@ func TestMVCCScanWriteIntentError(t *testing.T) {
 			txn = txn2
 		}
 		v := *protoutil.Clone(&kv.Value).(*roachpb.Value)
-		v.Timestamp = hlc.ZeroTimestamp
+		v.Timestamp = hlc.Timestamp{}
 		if err := MVCCPut(context.Background(), engine, nil, kv.Key, kv.Value.Timestamp, v, txn); err != nil {
 			t.Fatal(err)
 		}
@@ -940,7 +932,7 @@ func TestMVCCScanWriteIntentError(t *testing.T) {
 		if scan.consistent {
 			cStr = "consistent"
 		}
-		kvs, _, intents, err := MVCCScan(context.Background(), engine, testKey1, testKey4.Next(), math.MaxInt64, makeTS(1, 0), scan.consistent, scan.txn)
+		kvs, _, intents, err := MVCCScan(context.Background(), engine, testKey1, testKey4.Next(), math.MaxInt64, hlc.Timestamp{WallTime: 1}, scan.consistent, scan.txn)
 		wiErr, _ := err.(*roachpb.WriteIntentError)
 		if (err == nil) != (wiErr == nil) {
 			t.Errorf("%s(%d): unexpected error: %s", cStr, i, err)
@@ -980,22 +972,22 @@ func TestMVCCGetInconsistent(t *testing.T) {
 	defer engine.Close()
 
 	// Put two values to key 1, the latest with a txn.
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value1, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(2, 0), value2, txn1); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, value2, txn1); err != nil {
 		t.Fatal(err)
 	}
 
 	// A get with consistent=false should fail in a txn.
-	if _, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(1, 0), false, txn1); err == nil {
+	if _, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 1}, false, txn1); err == nil {
 		t.Error("expected an error getting with consistent=false in txn")
 	}
 
 	// Inconsistent get will fetch value1 for any timestamp.
-	for _, ts := range []hlc.Timestamp{makeTS(1, 0), makeTS(2, 0)} {
+	for _, ts := range []hlc.Timestamp{{WallTime: 1}, {WallTime: 2}} {
 		val, intents, err := MVCCGet(context.Background(), engine, testKey1, ts, false, nil)
-		if ts.Less(makeTS(2, 0)) {
+		if ts.Less(hlc.Timestamp{WallTime: 2}) {
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1010,10 +1002,10 @@ func TestMVCCGetInconsistent(t *testing.T) {
 	}
 
 	// Write a single intent for key 2 and verify get returns empty.
-	if err := MVCCPut(context.Background(), engine, nil, testKey2, makeTS(2, 0), value1, txn2); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey2, hlc.Timestamp{WallTime: 2}, value1, txn2); err != nil {
 		t.Fatal(err)
 	}
-	val, intents, err := MVCCGet(context.Background(), engine, testKey2, makeTS(2, 0), false, nil)
+	val, intents, err := MVCCGet(context.Background(), engine, testKey2, hlc.Timestamp{WallTime: 2}, false, nil)
 	if len(intents) == 0 || !intents[0].Key.Equal(testKey2) {
 		t.Fatal(err)
 	}
@@ -1042,15 +1034,15 @@ func TestMVCCGetProtoInconsistent(t *testing.T) {
 	v2 := roachpb.MakeValueFromBytes(bytes2)
 
 	// Put two values to key 1, the latest with a txn.
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), v1, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, v1, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(2, 0), v2, txn1); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, v2, txn1); err != nil {
 		t.Fatal(err)
 	}
 
 	// A get with consistent=false should fail in a txn.
-	if _, err := MVCCGetProto(context.Background(), engine, testKey1, makeTS(1, 0), false, txn1, nil); err == nil {
+	if _, err := MVCCGetProto(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 1}, false, txn1, nil); err == nil {
 		t.Error("expected an error getting with consistent=false in txn")
 	} else if _, ok := err.(*roachpb.WriteIntentError); ok {
 		t.Error("expected non-WriteIntentError with inconsistent read in txn")
@@ -1058,10 +1050,10 @@ func TestMVCCGetProtoInconsistent(t *testing.T) {
 
 	// Inconsistent get will fetch value1 for any timestamp.
 
-	for _, ts := range []hlc.Timestamp{makeTS(1, 0), makeTS(2, 0)} {
+	for _, ts := range []hlc.Timestamp{{WallTime: 1}, {WallTime: 2}} {
 		val := roachpb.Value{}
 		found, err := MVCCGetProto(context.Background(), engine, testKey1, ts, false, nil, &val)
-		if ts.Less(makeTS(2, 0)) {
+		if ts.Less(hlc.Timestamp{WallTime: 2}) {
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1082,11 +1074,11 @@ func TestMVCCGetProtoInconsistent(t *testing.T) {
 
 	{
 		// Write a single intent for key 2 and verify get returns empty.
-		if err := MVCCPut(context.Background(), engine, nil, testKey2, makeTS(2, 0), v1, txn2); err != nil {
+		if err := MVCCPut(context.Background(), engine, nil, testKey2, hlc.Timestamp{WallTime: 2}, v1, txn2); err != nil {
 			t.Fatal(err)
 		}
 		val := roachpb.Value{}
-		found, err := MVCCGetProto(context.Background(), engine, testKey2, makeTS(2, 0), false, nil, &val)
+		found, err := MVCCGetProto(context.Background(), engine, testKey2, hlc.Timestamp{WallTime: 2}, false, nil, &val)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1099,14 +1091,14 @@ func TestMVCCGetProtoInconsistent(t *testing.T) {
 		// Write a malformed value (not an encoded MVCCKeyValue) and a
 		// write intent to key 3; the parse error is returned instead of the
 		// write intent.
-		if err := MVCCPut(context.Background(), engine, nil, testKey3, makeTS(1, 0), value3, nil); err != nil {
+		if err := MVCCPut(context.Background(), engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, value3, nil); err != nil {
 			t.Fatal(err)
 		}
-		if err := MVCCPut(context.Background(), engine, nil, testKey3, makeTS(2, 0), v2, txn1); err != nil {
+		if err := MVCCPut(context.Background(), engine, nil, testKey3, hlc.Timestamp{WallTime: 2}, v2, txn1); err != nil {
 			t.Fatal(err)
 		}
 		val := roachpb.Value{}
-		found, err := MVCCGetProto(context.Background(), engine, testKey3, makeTS(1, 0), false, nil, &val)
+		found, err := MVCCGetProto(context.Background(), engine, testKey3, hlc.Timestamp{WallTime: 1}, false, nil, &val)
 		if err == nil {
 			t.Errorf("expected error reading malformed data")
 		} else if !strings.HasPrefix(err.Error(), "proto: ") {
@@ -1123,32 +1115,32 @@ func TestMVCCScan(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value1, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(2, 0), value4, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, value4, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey2, makeTS(1, 0), value2, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey2, makeTS(3, 0), value3, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey2, hlc.Timestamp{WallTime: 3}, value3, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey3, makeTS(1, 0), value3, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, value3, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey3, makeTS(4, 0), value2, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey3, hlc.Timestamp{WallTime: 4}, value2, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey4, makeTS(1, 0), value4, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, value4, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey4, makeTS(5, 0), value1, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey4, hlc.Timestamp{WallTime: 5}, value1, nil); err != nil {
 		t.Fatal(err)
 	}
 
-	kvs, resumeSpan, _, err := MVCCScan(context.Background(), engine, testKey2, testKey4, math.MaxInt64, makeTS(1, 0), true, nil)
+	kvs, resumeSpan, _, err := MVCCScan(context.Background(), engine, testKey2, testKey4, math.MaxInt64, hlc.Timestamp{WallTime: 1}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1163,7 +1155,7 @@ func TestMVCCScan(t *testing.T) {
 		t.Fatalf("resumeSpan = %+v", resumeSpan)
 	}
 
-	kvs, resumeSpan, _, err = MVCCScan(context.Background(), engine, testKey2, testKey4, math.MaxInt64, makeTS(4, 0), true, nil)
+	kvs, resumeSpan, _, err = MVCCScan(context.Background(), engine, testKey2, testKey4, math.MaxInt64, hlc.Timestamp{WallTime: 4}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1178,7 +1170,7 @@ func TestMVCCScan(t *testing.T) {
 		t.Fatalf("resumeSpan = %+v", resumeSpan)
 	}
 
-	kvs, resumeSpan, _, err = MVCCScan(context.Background(), engine, testKey4, keyMax, math.MaxInt64, makeTS(1, 0), true, nil)
+	kvs, resumeSpan, _, err = MVCCScan(context.Background(), engine, testKey4, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 1}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1191,10 +1183,10 @@ func TestMVCCScan(t *testing.T) {
 		t.Fatalf("resumeSpan = %+v", resumeSpan)
 	}
 
-	if _, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(1, 0), true, txn2); err != nil {
+	if _, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 1}, true, txn2); err != nil {
 		t.Fatal(err)
 	}
-	kvs, _, _, err = MVCCScan(context.Background(), engine, keyMin, testKey2, math.MaxInt64, makeTS(1, 0), true, nil)
+	kvs, _, _, err = MVCCScan(context.Background(), engine, keyMin, testKey2, math.MaxInt64, hlc.Timestamp{WallTime: 1}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1210,20 +1202,20 @@ func TestMVCCScanMaxNum(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value1, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey2, makeTS(1, 0), value2, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey3, makeTS(1, 0), value3, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, value3, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey4, makeTS(1, 0), value4, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, value4, nil); err != nil {
 		t.Fatal(err)
 	}
 
-	kvs, resumeSpan, _, err := MVCCScan(context.Background(), engine, testKey2, testKey4, 1, makeTS(1, 0), true, nil)
+	kvs, resumeSpan, _, err := MVCCScan(context.Background(), engine, testKey2, testKey4, 1, hlc.Timestamp{WallTime: 1}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1236,7 +1228,7 @@ func TestMVCCScanMaxNum(t *testing.T) {
 		t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
 	}
 
-	kvs, resumeSpan, _, err = MVCCScan(context.Background(), engine, testKey2, testKey4, 0, makeTS(1, 0), true, nil)
+	kvs, resumeSpan, _, err = MVCCScan(context.Background(), engine, testKey2, testKey4, 0, hlc.Timestamp{WallTime: 1}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1264,23 +1256,23 @@ func TestMVCCScanWithKeyPrefix(t *testing.T) {
 	// b<T=5>
 	// In this case, if we scan from "a"-"b", we wish to skip
 	// a<T=2> and a<T=1> and find "aa'.
-	if err := MVCCPut(context.Background(), engine, nil, roachpb.Key("/a"), makeTS(1, 0), value1, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, roachpb.Key("/a"), hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, roachpb.Key("/a"), makeTS(2, 0), value2, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, roachpb.Key("/a"), hlc.Timestamp{WallTime: 2}, value2, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, roachpb.Key("/aa"), makeTS(2, 0), value2, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, roachpb.Key("/aa"), hlc.Timestamp{WallTime: 2}, value2, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, roachpb.Key("/aa"), makeTS(3, 0), value3, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, roachpb.Key("/aa"), hlc.Timestamp{WallTime: 3}, value3, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, roachpb.Key("/b"), makeTS(1, 0), value3, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, roachpb.Key("/b"), hlc.Timestamp{WallTime: 1}, value3, nil); err != nil {
 		t.Fatal(err)
 	}
 
-	kvs, _, _, err := MVCCScan(context.Background(), engine, roachpb.Key("/a"), roachpb.Key("/b"), math.MaxInt64, makeTS(2, 0), true, nil)
+	kvs, _, _, err := MVCCScan(context.Background(), engine, roachpb.Key("/a"), roachpb.Key("/b"), math.MaxInt64, hlc.Timestamp{WallTime: 2}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1298,20 +1290,20 @@ func TestMVCCScanInTxn(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value1, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey2, makeTS(1, 0), value2, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey3, makeTS(1, 0), value3, txn1); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, value3, txn1); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey4, makeTS(1, 0), value4, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, value4, nil); err != nil {
 		t.Fatal(err)
 	}
 
-	kvs, _, _, err := MVCCScan(context.Background(), engine, testKey2, testKey4, math.MaxInt64, makeTS(1, 0), true, txn1)
+	kvs, _, _, err := MVCCScan(context.Background(), engine, testKey2, testKey4, math.MaxInt64, hlc.Timestamp{WallTime: 1}, true, txn1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1323,7 +1315,7 @@ func TestMVCCScanInTxn(t *testing.T) {
 		t.Fatal("the value should not be empty")
 	}
 
-	if _, _, _, err := MVCCScan(context.Background(), engine, testKey2, testKey4, math.MaxInt64, makeTS(1, 0), true, nil); err == nil {
+	if _, _, _, err := MVCCScan(context.Background(), engine, testKey2, testKey4, math.MaxInt64, hlc.Timestamp{WallTime: 1}, true, nil); err == nil {
 		t.Fatal("expected error on uncommitted write intent")
 	}
 }
@@ -1336,16 +1328,16 @@ func TestMVCCScanInconsistent(t *testing.T) {
 	defer engine.Close()
 
 	// A scan with consistent=false should fail in a txn.
-	if _, _, _, err := MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(1, 0), false, txn1); err == nil {
+	if _, _, _, err := MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 1}, false, txn1); err == nil {
 		t.Error("expected an error scanning with consistent=false in txn")
 	}
 
-	ts1 := makeTS(1, 0)
-	ts2 := makeTS(2, 0)
-	ts3 := makeTS(3, 0)
-	ts4 := makeTS(4, 0)
-	ts5 := makeTS(5, 0)
-	ts6 := makeTS(6, 0)
+	ts1 := hlc.Timestamp{WallTime: 1}
+	ts2 := hlc.Timestamp{WallTime: 2}
+	ts3 := hlc.Timestamp{WallTime: 3}
+	ts4 := hlc.Timestamp{WallTime: 4}
+	ts5 := hlc.Timestamp{WallTime: 5}
+	ts6 := hlc.Timestamp{WallTime: 6}
 	if err := MVCCPut(context.Background(), engine, nil, testKey1, ts1, value1, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -1369,7 +1361,7 @@ func TestMVCCScanInconsistent(t *testing.T) {
 		{Span: roachpb.Span{Key: testKey1}, Txn: txn1.TxnMeta},
 		{Span: roachpb.Span{Key: testKey3}, Txn: txn2.TxnMeta},
 	}
-	kvs, _, intents, err := MVCCScan(context.Background(), engine, testKey1, testKey4.Next(), math.MaxInt64, makeTS(7, 0), false, nil)
+	kvs, _, intents, err := MVCCScan(context.Background(), engine, testKey1, testKey4.Next(), math.MaxInt64, hlc.Timestamp{WallTime: 7}, false, nil)
 	if !reflect.DeepEqual(intents, expIntents) {
 		t.Fatal(err)
 	}
@@ -1390,7 +1382,7 @@ func TestMVCCScanInconsistent(t *testing.T) {
 
 	// Now try a scan at a historical timestamp.
 	expIntents = expIntents[:1]
-	kvs, _, intents, err = MVCCScan(context.Background(), engine, testKey1, testKey4.Next(), math.MaxInt64, makeTS(3, 0), false, nil)
+	kvs, _, intents, err = MVCCScan(context.Background(), engine, testKey1, testKey4.Next(), math.MaxInt64, hlc.Timestamp{WallTime: 3}, false, nil)
 	if !reflect.DeepEqual(intents, expIntents) {
 		t.Fatal(err)
 	}
@@ -1408,28 +1400,28 @@ func TestMVCCDeleteRange(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value1, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey2, makeTS(1, 0), value2, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey3, makeTS(1, 0), value3, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, value3, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey4, makeTS(1, 0), value4, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, value4, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey5, makeTS(1, 0), value5, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey5, hlc.Timestamp{WallTime: 1}, value5, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey6, makeTS(1, 0), value6, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey6, hlc.Timestamp{WallTime: 1}, value6, nil); err != nil {
 		t.Fatal(err)
 	}
 
 	// Attempt to delete two keys.
 	deleted, resumeSpan, num, err := MVCCDeleteRange(
-		context.Background(), engine, nil, testKey2, testKey6, 2, makeTS(2, 0), nil, false,
+		context.Background(), engine, nil, testKey2, testKey6, 2, hlc.Timestamp{WallTime: 2}, nil, false,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1443,7 +1435,7 @@ func TestMVCCDeleteRange(t *testing.T) {
 	if expected := (roachpb.Span{Key: testKey4, EndKey: testKey6}); !resumeSpan.Equal(expected) {
 		t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
 	}
-	kvs, _, _, _ := MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
+	kvs, _, _, _ := MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2}, true, nil)
 	if len(kvs) != 4 ||
 		!bytes.Equal(kvs[0].Key, testKey1) ||
 		!bytes.Equal(kvs[1].Key, testKey4) ||
@@ -1458,7 +1450,7 @@ func TestMVCCDeleteRange(t *testing.T) {
 
 	// Attempt to delete no keys.
 	deleted, resumeSpan, num, err = MVCCDeleteRange(
-		context.Background(), engine, nil, testKey2, testKey6, 0, makeTS(2, 0), nil, false,
+		context.Background(), engine, nil, testKey2, testKey6, 0, hlc.Timestamp{WallTime: 2}, nil, false,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1472,7 +1464,7 @@ func TestMVCCDeleteRange(t *testing.T) {
 	if expected := (roachpb.Span{Key: testKey2, EndKey: testKey6}); !resumeSpan.Equal(expected) {
 		t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
 	}
-	kvs, _, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
+	kvs, _, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2}, true, nil)
 	if len(kvs) != 4 ||
 		!bytes.Equal(kvs[0].Key, testKey1) ||
 		!bytes.Equal(kvs[1].Key, testKey4) ||
@@ -1486,7 +1478,7 @@ func TestMVCCDeleteRange(t *testing.T) {
 	}
 
 	deleted, resumeSpan, num, err = MVCCDeleteRange(
-		context.Background(), engine, nil, testKey4, keyMax, math.MaxInt64, makeTS(2, 0), nil, false,
+		context.Background(), engine, nil, testKey4, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2}, nil, false,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1500,7 +1492,7 @@ func TestMVCCDeleteRange(t *testing.T) {
 	if resumeSpan != nil {
 		t.Fatalf("wrong resume key: expected nil, found %v", resumeSpan)
 	}
-	kvs, _, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
+	kvs, _, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2}, true, nil)
 	if len(kvs) != 1 ||
 		!bytes.Equal(kvs[0].Key, testKey1) ||
 		!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) {
@@ -1508,7 +1500,7 @@ func TestMVCCDeleteRange(t *testing.T) {
 	}
 
 	deleted, resumeSpan, num, err = MVCCDeleteRange(
-		context.Background(), engine, nil, keyMin, testKey2, math.MaxInt64, makeTS(2, 0), nil, false,
+		context.Background(), engine, nil, keyMin, testKey2, math.MaxInt64, hlc.Timestamp{WallTime: 2}, nil, false,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1522,7 +1514,7 @@ func TestMVCCDeleteRange(t *testing.T) {
 	if resumeSpan != nil {
 		t.Fatalf("wrong resume key: expected nil, found %v", resumeSpan)
 	}
-	kvs, _, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
+	kvs, _, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2}, true, nil)
 	if len(kvs) != 0 {
 		t.Fatal("the value should be empty")
 	}
@@ -1533,28 +1525,28 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value1, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey2, makeTS(1, 0), value2, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey3, makeTS(1, 0), value3, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, value3, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey4, makeTS(1, 0), value4, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, value4, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey5, makeTS(1, 0), value5, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey5, hlc.Timestamp{WallTime: 1}, value5, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey6, makeTS(1, 0), value6, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey6, hlc.Timestamp{WallTime: 1}, value6, nil); err != nil {
 		t.Fatal(err)
 	}
 
 	// Attempt to delete two keys.
 	deleted, resumeSpan, num, err := MVCCDeleteRange(
-		context.Background(), engine, nil, testKey2, testKey6, 2, makeTS(2, 0), nil, true,
+		context.Background(), engine, nil, testKey2, testKey6, 2, hlc.Timestamp{WallTime: 2}, nil, true,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1574,7 +1566,7 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 	if expected := (roachpb.Span{Key: testKey4, EndKey: testKey6}); !resumeSpan.Equal(expected) {
 		t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
 	}
-	kvs, _, _, _ := MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
+	kvs, _, _, _ := MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2}, true, nil)
 	if len(kvs) != 4 ||
 		!bytes.Equal(kvs[0].Key, testKey1) ||
 		!bytes.Equal(kvs[1].Key, testKey4) ||
@@ -1589,7 +1581,7 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 
 	// Attempt to delete no keys.
 	deleted, resumeSpan, num, err = MVCCDeleteRange(
-		context.Background(), engine, nil, testKey2, testKey6, 0, makeTS(2, 0), nil, true,
+		context.Background(), engine, nil, testKey2, testKey6, 0, hlc.Timestamp{WallTime: 2}, nil, true,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1603,7 +1595,7 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 	if expected := (roachpb.Span{Key: testKey2, EndKey: testKey6}); !resumeSpan.Equal(expected) {
 		t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
 	}
-	kvs, _, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
+	kvs, _, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2}, true, nil)
 	if len(kvs) != 4 ||
 		!bytes.Equal(kvs[0].Key, testKey1) ||
 		!bytes.Equal(kvs[1].Key, testKey4) ||
@@ -1617,7 +1609,7 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 	}
 
 	deleted, resumeSpan, num, err = MVCCDeleteRange(
-		context.Background(), engine, nil, testKey4, keyMax, math.MaxInt64, makeTS(2, 0), nil, true,
+		context.Background(), engine, nil, testKey4, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2}, nil, true,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1640,7 +1632,7 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 	if resumeSpan != nil {
 		t.Fatalf("wrong resume key: expected nil, found %v", resumeSpan)
 	}
-	kvs, _, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
+	kvs, _, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2}, true, nil)
 	if len(kvs) != 1 ||
 		!bytes.Equal(kvs[0].Key, testKey1) ||
 		!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) {
@@ -1648,7 +1640,7 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 	}
 
 	deleted, resumeSpan, num, err = MVCCDeleteRange(
-		context.Background(), engine, nil, keyMin, testKey2, math.MaxInt64, makeTS(2, 0), nil, true,
+		context.Background(), engine, nil, keyMin, testKey2, math.MaxInt64, hlc.Timestamp{WallTime: 2}, nil, true,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1665,7 +1657,7 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 	if resumeSpan != nil {
 		t.Fatalf("wrong resume key: %v", resumeSpan)
 	}
-	kvs, _, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
+	kvs, _, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2}, true, nil)
 	if len(kvs) != 0 {
 		t.Fatal("the value should be empty")
 	}
@@ -1677,27 +1669,27 @@ func TestMVCCDeleteRangeFailed(t *testing.T) {
 	defer engine.Close()
 
 	txn := *txn1
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value1, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
 		t.Fatal(err)
 	}
 	txn.Sequence++
-	if err := MVCCPut(context.Background(), engine, nil, testKey2, makeTS(1, 0), value2, &txn); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, &txn); err != nil {
 		t.Fatal(err)
 	}
 	txn.Sequence++
-	if err := MVCCPut(context.Background(), engine, nil, testKey3, makeTS(1, 0), value3, &txn); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, value3, &txn); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey4, makeTS(1, 0), value4, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, value4, nil); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, _, _, err := MVCCDeleteRange(context.Background(), engine, nil, testKey2, testKey4, math.MaxInt64, makeTS(1, 0), nil, false); err == nil {
+	if _, _, _, err := MVCCDeleteRange(context.Background(), engine, nil, testKey2, testKey4, math.MaxInt64, hlc.Timestamp{WallTime: 1}, nil, false); err == nil {
 		t.Fatal("expected error on uncommitted write intent")
 	}
 
 	txn.Sequence++
-	if _, _, _, err := MVCCDeleteRange(context.Background(), engine, nil, testKey2, testKey4, math.MaxInt64, makeTS(1, 0), &txn, false); err != nil {
+	if _, _, _, err := MVCCDeleteRange(context.Background(), engine, nil, testKey2, testKey4, math.MaxInt64, hlc.Timestamp{WallTime: 1}, &txn, false); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1707,20 +1699,20 @@ func TestMVCCDeleteRangeConcurrentTxn(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value1, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey2, makeTS(1, 0), value2, txn1); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, txn1); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey3, makeTS(2, 0), value3, txn2); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey3, hlc.Timestamp{WallTime: 2}, value3, txn2); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey4, makeTS(1, 0), value4, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, value4, nil); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, _, _, err := MVCCDeleteRange(context.Background(), engine, nil, testKey2, testKey4, math.MaxInt64, makeTS(1, 0), txn1, false); err == nil {
+	if _, _, _, err := MVCCDeleteRange(context.Background(), engine, nil, testKey2, testKey4, math.MaxInt64, hlc.Timestamp{WallTime: 1}, txn1, false); err == nil {
 		t.Fatal("expected error on uncommitted write intent")
 	}
 }
@@ -1733,36 +1725,36 @@ func TestMVCCUncommittedDeleteRangeVisible(t *testing.T) {
 	defer engine.Close()
 
 	if err := MVCCPut(
-		context.Background(), engine, nil, testKey1, makeTS(1, 0), value1, nil,
+		context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil,
 	); err != nil {
 		t.Fatal(err)
 	}
 	if err := MVCCPut(
-		context.Background(), engine, nil, testKey2, makeTS(1, 0), value2, nil,
+		context.Background(), engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil,
 	); err != nil {
 		t.Fatal(err)
 	}
 	if err := MVCCPut(
-		context.Background(), engine, nil, testKey3, makeTS(1, 0), value3, nil,
+		context.Background(), engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, value3, nil,
 	); err != nil {
 		t.Fatal(err)
 	}
 
 	if err := MVCCDelete(
-		context.Background(), engine, nil, testKey2, makeTS(2, 1), nil,
+		context.Background(), engine, nil, testKey2, hlc.Timestamp{WallTime: 2, Logical: 1}, nil,
 	); err != nil {
 		t.Fatal(err)
 	}
 
 	txn := txn1.Clone()
 	if _, _, _, err := MVCCDeleteRange(
-		context.Background(), engine, nil, testKey1, testKey4, math.MaxInt64, makeTS(2, 0), &txn, false,
+		context.Background(), engine, nil, testKey1, testKey4, math.MaxInt64, hlc.Timestamp{WallTime: 2}, &txn, false,
 	); err != nil {
 		t.Fatal(err)
 	}
 
 	txn.Epoch++
-	kvs, _, _, _ := MVCCScan(context.Background(), engine, testKey1, testKey4, math.MaxInt64, makeTS(3, 0), true, &txn)
+	kvs, _, _, _ := MVCCScan(context.Background(), engine, testKey1, testKey4, math.MaxInt64, hlc.Timestamp{WallTime: 3}, true, &txn)
 	if e := 2; len(kvs) != e {
 		t.Fatalf("e = %d, got %d", e, len(kvs))
 	}
@@ -1784,19 +1776,19 @@ func TestMVCCDeleteRangeInline(t *testing.T) {
 		{testKey4, value4},
 		{testKey5, value5},
 	} {
-		if err := MVCCPut(context.Background(), engine, nil, kv.key, makeTS(0, 0), kv.value, nil); err != nil {
+		if err := MVCCPut(context.Background(), engine, nil, kv.key, hlc.Timestamp{Logical: 0}, kv.value, nil); err != nil {
 			t.Fatalf("%d: %s", i, err)
 		}
 	}
 
 	// Create one non-inline value (non-zero timestamp).
-	if err := MVCCPut(context.Background(), engine, nil, testKey6, makeTS(1, 0), value6, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey6, hlc.Timestamp{WallTime: 1}, value6, nil); err != nil {
 		t.Fatal(err)
 	}
 
 	// Attempt to delete two inline keys, should succeed.
 	deleted, resumeSpan, num, err := MVCCDeleteRange(
-		context.Background(), engine, nil, testKey2, testKey6, 2, makeTS(0, 0), nil, true,
+		context.Background(), engine, nil, testKey2, testKey6, 2, hlc.Timestamp{Logical: 0}, nil, true,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1815,21 +1807,21 @@ func TestMVCCDeleteRangeInline(t *testing.T) {
 
 	// Attempt to delete inline keys at a timestamp; should fail.
 	if _, _, _, err := MVCCDeleteRange(
-		context.Background(), engine, nil, testKey1, testKey6, 1, makeTS(2, 0), nil, true,
+		context.Background(), engine, nil, testKey1, testKey6, 1, hlc.Timestamp{WallTime: 2}, nil, true,
 	); !testutils.IsError(err, inlineMismatchErrString) {
 		t.Fatalf("got error %v, expected error with text '%s'", err, inlineMismatchErrString)
 	}
 
 	// Attempt to delete non-inline key at zero timestamp; should fail.
 	if _, _, _, err := MVCCDeleteRange(
-		context.Background(), engine, nil, testKey6, keyMax, 1, makeTS(0, 0), nil, true,
+		context.Background(), engine, nil, testKey6, keyMax, 1, hlc.Timestamp{Logical: 0}, nil, true,
 	); !testutils.IsError(err, inlineMismatchErrString) {
 		t.Fatalf("got error %v, expected error with text '%s'", err, inlineMismatchErrString)
 	}
 
 	// Attempt to delete inline keys in a transaction; should fail.
 	if _, _, _, err := MVCCDeleteRange(
-		context.Background(), engine, nil, testKey2, testKey6, 2, makeTS(0, 0), txn1, true,
+		context.Background(), engine, nil, testKey2, testKey6, 2, hlc.Timestamp{Logical: 0}, txn1, true,
 	); !testutils.IsError(err, "writes not allowed within transactions") {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -1853,11 +1845,11 @@ func TestMVCCDeleteRangeInline(t *testing.T) {
 			Value: value6,
 		},
 	}
-	kvs, _, _, _ := MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
+	kvs, _, _, _ := MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, hlc.Timestamp{WallTime: 2}, true, nil)
 	if a, e := len(kvs), len(expectedKvs); a != e {
 		t.Fatalf("engine scan found %d keys; expected %d", a, e)
 	}
-	kvs[3].Value.Timestamp = hlc.ZeroTimestamp
+	kvs[3].Value.Timestamp = hlc.Timestamp{}
 	if !reflect.DeepEqual(expectedKvs, kvs) {
 		t.Fatalf(
 			"engine scan found key/values: %v; expected %v. Diff: %s",
@@ -1999,7 +1991,7 @@ func TestMVCCConditionalPutWithTxn(t *testing.T) {
 		t.Fatalf("expected write too old error; got %s", err)
 	}
 	expTS := txnCommit.Timestamp.Next()
-	if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok || !wtoErr.ActualTimestamp.Equal(expTS) {
+	if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok || wtoErr.ActualTimestamp != expTS {
 		t.Fatalf("expected wto error with actual timestamp = %s; got %s", expTS, wtoErr)
 	}
 }
@@ -2009,19 +2001,19 @@ func TestMVCCInitPut(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	err := MVCCInitPut(context.Background(), engine, nil, testKey1, makeTS(0, 1), value1, nil)
+	err := MVCCInitPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// A repeat of the command will still succeed
-	err = MVCCInitPut(context.Background(), engine, nil, testKey1, makeTS(0, 2), value1, nil)
+	err = MVCCInitPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 2}, value1, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// A repeat of the command with a different value will fail.
-	err = MVCCInitPut(context.Background(), engine, nil, testKey1, makeTS(0, 3), value2, nil)
+	err = MVCCInitPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 3}, value2, nil)
 	switch e := err.(type) {
 	case *roachpb.ConditionFailedError:
 		if !bytes.Equal(e.ActualValue.RawBytes, value1.RawBytes) {
@@ -2034,7 +2026,7 @@ func TestMVCCInitPut(t *testing.T) {
 		t.Fatalf("unexpected error %T", e)
 	}
 
-	for _, ts := range []hlc.Timestamp{makeTS(0, 1), makeTS(0, 2), makeTS(1, 0)} {
+	for _, ts := range []hlc.Timestamp{{Logical: 1}, {Logical: 2}, {WallTime: 1}} {
 		value, _, err := MVCCGet(context.Background(), engine, testKey1, ts, true, nil)
 		if err != nil {
 			t.Fatal(err)
@@ -2044,12 +2036,12 @@ func TestMVCCInitPut(t *testing.T) {
 				value1.RawBytes, value.RawBytes)
 		}
 		// Ensure that the timestamp didn't get updated.
-		if !value.Timestamp.Equal(makeTS(0, 1)) {
-			t.Errorf("value at timestamp %s seen", value.Timestamp)
+		if expTS := (hlc.Timestamp{Logical: 1}); value.Timestamp != expTS {
+			t.Errorf("value at timestamp %s seen, expected %s", value.Timestamp, expTS)
 		}
 	}
 
-	value, _, pErr := MVCCGet(context.Background(), engine, testKey1, makeTS(0, 0), true, nil)
+	value, _, pErr := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{Logical: 0}, true, nil)
 	if pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -2127,26 +2119,28 @@ func TestMVCCConditionalPutWriteTooOld(t *testing.T) {
 	defer engine.Close()
 
 	// Write value1 @t=10ns.
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(10, 0), value1, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 10}, value1, nil); err != nil {
 		t.Fatal(err)
 	}
 	// Try a non-transactional put @t=1ns with expectation of nil; should fail.
-	if err := MVCCConditionalPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value2, nil, nil); err == nil {
+	if err := MVCCConditionalPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value2, nil, nil); err == nil {
 		t.Fatal("expected error on conditional put")
 	}
 	// Now do a non-transactional put @t=1ns with expectation of value1; will succeed @t=10,1.
-	err := MVCCConditionalPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value2, &value1, nil)
-	if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok || !wtoErr.ActualTimestamp.Equal(makeTS(10, 1)) {
-		t.Fatalf("expected WriteTooOldError with actual time = 10,1; got %s", err)
+	err := MVCCConditionalPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value2, &value1, nil)
+	expTS := hlc.Timestamp{WallTime: 10, Logical: 1}
+	if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok || wtoErr.ActualTimestamp != expTS {
+		t.Fatalf("expected WriteTooOldError with actual time = %s; got %s", expTS, err)
 	}
 	// Try a transactional put @t=1ns with expectation of value2; should fail.
-	if err := MVCCConditionalPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value2, &value1, txn1); err == nil {
+	if err := MVCCConditionalPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value2, &value1, txn1); err == nil {
 		t.Fatal("expected error on conditional put")
 	}
 	// Now do a transactional put @t=1ns with expectation of nil; will succeed @t=10,2.
-	err = MVCCConditionalPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value3, nil, txn1)
-	if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok || !wtoErr.ActualTimestamp.Equal(makeTS(10, 2)) {
-		t.Fatalf("expected WriteTooOldError with actual time = 10,2; got %s", err)
+	err = MVCCConditionalPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value3, nil, txn1)
+	expTS = hlc.Timestamp{WallTime: 10, Logical: 2}
+	if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok || wtoErr.ActualTimestamp != expTS {
+		t.Fatalf("expected WriteTooOldError with actual time = %s; got %s", expTS, err)
 	}
 }
 
@@ -2159,24 +2153,26 @@ func TestMVCCIncrementWriteTooOld(t *testing.T) {
 	defer engine.Close()
 
 	// Start with an increment.
-	if val, err := MVCCIncrement(context.Background(), engine, nil, testKey1, makeTS(10, 0), nil, 1); val != 1 || err != nil {
+	if val, err := MVCCIncrement(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 10}, nil, 1); val != 1 || err != nil {
 		t.Fatalf("expected val=1 (got %d): %s", val, err)
 	}
 	// Try a non-transactional increment @t=1ns.
-	val, err := MVCCIncrement(context.Background(), engine, nil, testKey1, makeTS(1, 0), nil, 1)
+	val, err := MVCCIncrement(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, nil, 1)
 	if val != 2 || err == nil {
 		t.Fatalf("expected val=2 (got %d) and nil error: %s", val, err)
 	}
-	if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok || !wtoErr.ActualTimestamp.Equal(makeTS(10, 1)) {
-		t.Fatalf("expected WriteTooOldError with actual time = 10,1; got %s", wtoErr)
+	expTS := hlc.Timestamp{WallTime: 10, Logical: 1}
+	if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok || wtoErr.ActualTimestamp != expTS {
+		t.Fatalf("expected WriteTooOldError with actual time = %s; got %s", expTS, wtoErr)
 	}
 	// Try a transaction increment @t=1ns.
-	val, err = MVCCIncrement(context.Background(), engine, nil, testKey1, makeTS(1, 0), txn1, 1)
+	val, err = MVCCIncrement(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, txn1, 1)
 	if val != 1 || err == nil {
 		t.Fatalf("expected val=1 (got %d) and nil error: %s", val, err)
 	}
-	if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok || !wtoErr.ActualTimestamp.Equal(makeTS(10, 2)) {
-		t.Fatalf("expected WriteTooOldError with actual time = 10,2; got %s", wtoErr)
+	expTS = hlc.Timestamp{WallTime: 10, Logical: 2}
+	if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok || wtoErr.ActualTimestamp != expTS {
+		t.Fatalf("expected WriteTooOldError with actual time = %s; got %s", expTS, wtoErr)
 	}
 }
 
@@ -2187,26 +2183,26 @@ func TestMVCCReverseScan(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value1, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(2, 0), value2, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, value2, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey2, makeTS(1, 0), value3, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value3, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey2, makeTS(3, 0), value4, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey2, hlc.Timestamp{WallTime: 3}, value4, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey3, makeTS(1, 0), value1, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey3, hlc.Timestamp{WallTime: 1}, value1, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey4, makeTS(1, 0), value2, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey4, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
 		t.Fatal(err)
 	}
 
-	kvs, resumeSpan, _, err := MVCCReverseScan(context.Background(), engine, testKey2, testKey4, math.MaxInt64, makeTS(1, 0), true, nil)
+	kvs, resumeSpan, _, err := MVCCReverseScan(context.Background(), engine, testKey2, testKey4, math.MaxInt64, hlc.Timestamp{WallTime: 1}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2221,7 +2217,7 @@ func TestMVCCReverseScan(t *testing.T) {
 		t.Fatalf("resumeSpan = %+v", resumeSpan)
 	}
 
-	kvs, resumeSpan, _, err = MVCCReverseScan(context.Background(), engine, testKey2, testKey4, 1, makeTS(1, 0), true, nil)
+	kvs, resumeSpan, _, err = MVCCReverseScan(context.Background(), engine, testKey2, testKey4, 1, hlc.Timestamp{WallTime: 1}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2233,7 +2229,7 @@ func TestMVCCReverseScan(t *testing.T) {
 	if expected := (roachpb.Span{Key: testKey2, EndKey: testKey2.Next()}); !resumeSpan.Equal(expected) {
 		t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
 	}
-	kvs, resumeSpan, _, err = MVCCReverseScan(context.Background(), engine, testKey2, testKey4, 0, makeTS(1, 0), true, nil)
+	kvs, resumeSpan, _, err = MVCCReverseScan(context.Background(), engine, testKey2, testKey4, 0, hlc.Timestamp{WallTime: 1}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2250,12 +2246,12 @@ func TestMVCCResolveTxn(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(0, 1), value1, txn1); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, txn1); err != nil {
 		t.Fatal(err)
 	}
 
 	{
-		value, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(0, 1), true, txn1)
+		value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{Logical: 1}, true, txn1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2271,7 +2267,7 @@ func TestMVCCResolveTxn(t *testing.T) {
 	}
 
 	{
-		value, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(0, 1), true, nil)
+		value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{Logical: 1}, true, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2295,7 +2291,7 @@ func TestMVCCResolveNewerIntent(t *testing.T) {
 	}
 	// Now, put down an intent which should return a write too old error
 	// (but will still write the intent at tx1Commit.Timestmap+1.
-	err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(0, 1), value2, txn1)
+	err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value2, txn1)
 	if _, ok := err.(*roachpb.WriteTooOldError); !ok {
 		t.Fatalf("expected write too old error; got %s", err)
 	}
@@ -2305,7 +2301,7 @@ func TestMVCCResolveNewerIntent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	value, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(0, 2), true, nil)
+	value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{Logical: 2}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2377,17 +2373,17 @@ func TestMVCCConditionalPutOldTimestamp(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value1, nil)
+	err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = MVCCPut(context.Background(), engine, nil, testKey1, makeTS(3, 0), value2, nil)
+	err = MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 3}, value2, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Check nothing is written if the value doesn't match.
-	err = MVCCConditionalPut(context.Background(), engine, nil, testKey1, makeTS(2, 0), value3, &value1, nil)
+	err = MVCCConditionalPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, value3, &value1, nil)
 	if err == nil {
 		t.Errorf("unexpected success on conditional put")
 	}
@@ -2397,7 +2393,7 @@ func TestMVCCConditionalPutOldTimestamp(t *testing.T) {
 
 	// But if value does match the most recently written version, we'll get
 	// a write too old error but still write updated value.
-	err = MVCCConditionalPut(context.Background(), engine, nil, testKey1, makeTS(2, 0), value3, &value2, nil)
+	err = MVCCConditionalPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, value3, &value2, nil)
 	if err == nil {
 		t.Errorf("unexpected success on conditional put")
 	}
@@ -2405,10 +2401,11 @@ func TestMVCCConditionalPutOldTimestamp(t *testing.T) {
 		t.Errorf("unexpected error on conditional put: %s", err)
 	}
 	// Verify new value was actually written at (3, 1).
-	value, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(3, 1), true, nil)
-	if err != nil || !value.Timestamp.Equal(makeTS(3, 1)) || !bytes.Equal(value3.RawBytes, value.RawBytes) {
+	ts := hlc.Timestamp{WallTime: 3, Logical: 1}
+	value, _, err := MVCCGet(context.Background(), engine, testKey1, ts, true, nil)
+	if err != nil || value.Timestamp != ts || !bytes.Equal(value3.RawBytes, value.RawBytes) {
 		t.Fatalf("expected err=nil (got %s), timestamp=%s (got %s), value=%q (got %q)",
-			err, value.Timestamp, makeTS(1, 1), value3.RawBytes, value.RawBytes)
+			err, value.Timestamp, ts, value3.RawBytes, value.RawBytes)
 	}
 }
 
@@ -2417,18 +2414,18 @@ func TestMVCCAbortTxn(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(0, 1), value1, txn1); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, txn1); err != nil {
 		t.Fatal(err)
 	}
 
 	txn1AbortWithTS := txn1Abort.Clone()
-	txn1AbortWithTS.Timestamp = makeTS(0, 1)
+	txn1AbortWithTS.Timestamp = hlc.Timestamp{Logical: 1}
 
 	if err := MVCCResolveWriteIntent(context.Background(), engine, nil, roachpb.Intent{Span: roachpb.Span{Key: testKey1}, Txn: txn1AbortWithTS.TxnMeta, Status: txn1AbortWithTS.Status}); err != nil {
 		t.Fatal(err)
 	}
 
-	if value, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(1, 0), true, nil); err != nil {
+	if value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 1}, true, nil); err != nil {
 		t.Fatal(err)
 	} else if value != nil {
 		t.Fatalf("expected the value to be empty: %s", value)
@@ -2445,18 +2442,18 @@ func TestMVCCAbortTxnWithPreviousVersion(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(0, 1), value1, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value2, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(2, 0), value3, txn1); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 2}, value3, txn1); err != nil {
 		t.Fatal(err)
 	}
 
 	txn1AbortWithTS := txn1Abort.Clone()
-	txn1AbortWithTS.Timestamp = makeTS(2, 0)
+	txn1AbortWithTS.Timestamp = hlc.Timestamp{WallTime: 2}
 
 	if err := MVCCResolveWriteIntent(context.Background(), engine, nil, roachpb.Intent{Span: roachpb.Span{Key: testKey1}, Status: txn1AbortWithTS.Status, Txn: txn1AbortWithTS.TxnMeta}); err != nil {
 		t.Fatal(err)
@@ -2468,9 +2465,9 @@ func TestMVCCAbortTxnWithPreviousVersion(t *testing.T) {
 		t.Fatalf("expected no more MVCCMetadata, got: %s", meta)
 	}
 
-	if value, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(3, 0), true, nil); err != nil {
+	if value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 3}, true, nil); err != nil {
 		t.Fatal(err)
-	} else if expTS := makeTS(1, 0); !value.Timestamp.Equal(expTS) {
+	} else if expTS := (hlc.Timestamp{WallTime: 1}); value.Timestamp != expTS {
 		t.Fatalf("expected timestamp %+v == %+v", value.Timestamp, expTS)
 	} else if !bytes.Equal(value2.RawBytes, value.RawBytes) {
 		t.Fatalf("the value %q in get result does not match the value %q in request",
@@ -2486,75 +2483,79 @@ func TestMVCCWriteWithDiffTimestampsAndEpochs(t *testing.T) {
 	// Start with epoch 1.
 	txn := *txn1
 	txn.Sequence++
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(0, 1), value1, &txn); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, &txn); err != nil {
 		t.Fatal(err)
 	}
 	// Now write with greater timestamp and epoch 2.
 	txne2 := txn
 	txne2.Sequence++
 	txne2.Epoch = 2
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value2, &txne2); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value2, &txne2); err != nil {
 		t.Fatal(err)
 	}
 	// Try a write with an earlier timestamp; this is just ignored.
 	txne2.Sequence++
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(0, 1), value1, &txne2); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, &txne2); err != nil {
 		t.Fatal(err)
 	}
 	// Try a write with an earlier epoch; again ignored.
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value1, &txn); err == nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, &txn); err == nil {
 		t.Fatal("unexpected success of a write with an earlier epoch")
 	}
 	// Try a write with different value using both later timestamp and epoch.
 	txne2.Sequence++
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value3, &txne2); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value3, &txne2); err != nil {
 		t.Fatal(err)
 	}
 	// Resolve the intent.
 	txne2Commit := txne2
 	txne2Commit.Status = roachpb.COMMITTED
-	txne2Commit.Timestamp = makeTS(1, 0)
+	txne2Commit.Timestamp = hlc.Timestamp{WallTime: 1}
 	if err := MVCCResolveWriteIntent(context.Background(), engine, nil, roachpb.Intent{Span: roachpb.Span{Key: testKey1}, Status: txne2Commit.Status, Txn: txne2Commit.TxnMeta}); err != nil {
 		t.Fatal(err)
 	}
+
+	expTS := txne2Commit.Timestamp.Add(0, 1)
+
 	// Now try writing an earlier value without a txn--should get WriteTooOldError.
-	err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(0, 1), value4, nil)
+	err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value4, nil)
 	if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok {
 		t.Fatal("unexpected success")
-	} else if !wtoErr.ActualTimestamp.Equal(makeTS(1, 1)) {
-		t.Fatalf("expected write too old error with actual ts %s; got %s", makeTS(1, 1), wtoErr.ActualTimestamp)
+	} else if wtoErr.ActualTimestamp != expTS {
+		t.Fatalf("expected write too old error with actual ts %s; got %s", expTS, wtoErr.ActualTimestamp)
 	}
 	// Verify value was actually written at (1, 1).
-	value, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(1, 1), true, nil)
-	if err != nil || !value.Timestamp.Equal(makeTS(1, 1)) || !bytes.Equal(value4.RawBytes, value.RawBytes) {
+	value, _, err := MVCCGet(context.Background(), engine, testKey1, expTS, true, nil)
+	if err != nil || value.Timestamp != expTS || !bytes.Equal(value4.RawBytes, value.RawBytes) {
 		t.Fatalf("expected err=nil (got %s), timestamp=%s (got %s), value=%q (got %q)",
-			err, value.Timestamp, makeTS(1, 1), value4.RawBytes, value.RawBytes)
+			err, value.Timestamp, expTS, value4.RawBytes, value.RawBytes)
 	}
 	// Now write an intent with exactly the same timestamp--ties also get WriteTooOldError.
-	err = MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 1), value5, txn2)
+	err = MVCCPut(context.Background(), engine, nil, testKey1, expTS, value5, txn2)
+	intentTS := expTS.Add(0, 1)
 	if wtoErr, ok := err.(*roachpb.WriteTooOldError); !ok {
 		t.Fatal("unexpected success")
-	} else if !wtoErr.ActualTimestamp.Equal(makeTS(1, 2)) {
-		t.Fatalf("expected write too old error with actual ts %s; got %s", makeTS(1, 2), wtoErr.ActualTimestamp)
+	} else if wtoErr.ActualTimestamp != intentTS {
+		t.Fatalf("expected write too old error with actual ts %s; got %s", intentTS, wtoErr.ActualTimestamp)
 	}
 	// Verify intent value was actually written at (1, 2).
-	value, _, err = MVCCGet(context.Background(), engine, testKey1, makeTS(1, 2), true, txn2)
-	if err != nil || !value.Timestamp.Equal(makeTS(1, 2)) || !bytes.Equal(value5.RawBytes, value.RawBytes) {
+	value, _, err = MVCCGet(context.Background(), engine, testKey1, intentTS, true, txn2)
+	if err != nil || value.Timestamp != intentTS || !bytes.Equal(value5.RawBytes, value.RawBytes) {
 		t.Fatalf("expected err=nil (got %s), timestamp=%s (got %s), value=%q (got %q)",
-			err, value.Timestamp, makeTS(1, 2), value5.RawBytes, value.RawBytes)
+			err, value.Timestamp, intentTS, value5.RawBytes, value.RawBytes)
 	}
 	// Attempt to read older timestamp; should fail.
-	value, _, err = MVCCGet(context.Background(), engine, testKey1, makeTS(0, 0), true, nil)
+	value, _, err = MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{Logical: 0}, true, nil)
 	if value != nil || err != nil {
 		t.Fatalf("expected value nil, err nil; got %+v, %v", value, err)
 	}
 	// Read at correct timestamp.
-	value, _, err = MVCCGet(context.Background(), engine, testKey1, makeTS(1, 0), true, nil)
+	value, _, err = MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 1}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !value.Timestamp.Equal(makeTS(1, 0)) {
-		t.Fatalf("expected timestamp %+v == %+v", value.Timestamp, makeTS(1, 0))
+	if expTS := (hlc.Timestamp{WallTime: 1}); value.Timestamp != expTS {
+		t.Fatalf("expected timestamp %+v == %+v", value.Timestamp, expTS)
 	}
 	if !bytes.Equal(value3.RawBytes, value.RawBytes) {
 		t.Fatalf("the value %s in get result does not match the value %s in request",
@@ -2571,11 +2572,11 @@ func TestMVCCReadWithDiffEpochs(t *testing.T) {
 	defer engine.Close()
 
 	// Write initial value without a txn.
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(0, 1), value1, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, nil); err != nil {
 		t.Fatal(err)
 	}
 	// Now write using txn1, epoch 1.
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value2, txn1); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value2, txn1); err != nil {
 		t.Fatal(err)
 	}
 	// Try reading using different txns & epochs.
@@ -2594,7 +2595,7 @@ func TestMVCCReadWithDiffEpochs(t *testing.T) {
 		{txn2, nil, true},
 	}
 	for i, test := range testCases {
-		value, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(2, 0), true, test.txn)
+		value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 2}, true, test.txn)
 		if test.expErr {
 			if err == nil {
 				t.Errorf("test %d: unexpected success", i)
@@ -2614,10 +2615,10 @@ func TestMVCCReadWithOldEpoch(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value2, txn1e2); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value2, txn1e2); err != nil {
 		t.Fatal(err)
 	}
-	_, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(2, 0), true, txn1)
+	_, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 2}, true, txn1)
 	if err == nil {
 		t.Fatalf("unexpected success of get")
 	}
@@ -2648,7 +2649,7 @@ func TestMVCCWriteWithSequenceAndBatchIndex(t *testing.T) {
 		{3, 2, false}, // new sequence, new batch index
 	}
 
-	ts := makeTS(0, 1)
+	ts := hlc.Timestamp{Logical: 1}
 	for i, tc := range testCases {
 		key := roachpb.Key(fmt.Sprintf("key-%d", i))
 		// Start with sequence 2, batch index 1.
@@ -2682,16 +2683,16 @@ func TestMVCCReadWithPushedTimestamp(t *testing.T) {
 	defer engine.Close()
 
 	// Start with epoch 1.
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(0, 1), value1, txn1); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, txn1); err != nil {
 		t.Fatal(err)
 	}
 	// Resolve the intent, pushing its timestamp forward.
-	txn := makeTxn(*txn1, makeTS(1, 0))
+	txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
 	if err := MVCCResolveWriteIntent(context.Background(), engine, nil, roachpb.Intent{Span: roachpb.Span{Key: testKey1}, Status: txn.Status, Txn: txn.TxnMeta}); err != nil {
 		t.Fatal(err)
 	}
 	// Attempt to read using naive txn's previous timestamp.
-	value, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(0, 1), true, txn1)
+	value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{Logical: 1}, true, txn1)
 	if err != nil || value == nil || !bytes.Equal(value.RawBytes, value1.RawBytes) {
 		t.Errorf("expected value %q, err nil; got %+v, %v", value1.RawBytes, value, err)
 	}
@@ -2702,10 +2703,10 @@ func TestMVCCResolveWithDiffEpochs(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(0, 1), value1, txn1); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, txn1); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey2, makeTS(0, 1), value2, txn1e2); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey2, hlc.Timestamp{Logical: 1}, value2, txn1e2); err != nil {
 		t.Fatal(err)
 	}
 	num, err := MVCCResolveWriteIntentRange(context.Background(), engine, nil, roachpb.Intent{Span: roachpb.Span{Key: testKey1, EndKey: testKey2.Next()}, Txn: txn1e2Commit.TxnMeta, Status: txn1e2Commit.Status}, 2)
@@ -2718,12 +2719,12 @@ func TestMVCCResolveWithDiffEpochs(t *testing.T) {
 
 	// Verify key1 is empty, as resolution with epoch 2 would have
 	// aborted the epoch 1 intent.
-	if value, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(0, 1), true, nil); value != nil || err != nil {
+	if value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{Logical: 1}, true, nil); value != nil || err != nil {
 		t.Errorf("expected value nil, err nil; got %+v, %v", value, err)
 	}
 
 	// Key2 should be committed.
-	value, _, err := MVCCGet(context.Background(), engine, testKey2, makeTS(0, 1), true, nil)
+	value, _, err := MVCCGet(context.Background(), engine, testKey2, hlc.Timestamp{Logical: 1}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2738,11 +2739,11 @@ func TestMVCCResolveWithUpdatedTimestamp(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(0, 1), value1, txn1); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, txn1); err != nil {
 		t.Fatal(err)
 	}
 
-	value, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(1, 0), true, txn1)
+	value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 1}, true, txn1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2753,21 +2754,21 @@ func TestMVCCResolveWithUpdatedTimestamp(t *testing.T) {
 
 	// Resolve with a higher commit timestamp -- this should rewrite the
 	// intent when making it permanent.
-	txn := makeTxn(*txn1Commit, makeTS(1, 0))
+	txn := makeTxn(*txn1Commit, hlc.Timestamp{WallTime: 1})
 	if err = MVCCResolveWriteIntent(context.Background(), engine, nil, roachpb.Intent{Span: roachpb.Span{Key: testKey1}, Status: txn.Status, Txn: txn.TxnMeta}); err != nil {
 		t.Fatal(err)
 	}
 
-	if value, _, err = MVCCGet(context.Background(), engine, testKey1, makeTS(0, 1), true, nil); value != nil || err != nil {
+	if value, _, err = MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{Logical: 1}, true, nil); value != nil || err != nil {
 		t.Fatalf("expected both value and err to be nil: %+v, %v", value, err)
 	}
 
-	value, _, err = MVCCGet(context.Background(), engine, testKey1, makeTS(1, 0), true, nil)
+	value, _, err = MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 1}, true, nil)
 	if err != nil {
 		t.Error(err)
 	}
-	if !value.Timestamp.Equal(makeTS(1, 0)) {
-		t.Fatalf("expected timestamp %+v == %+v", value.Timestamp, makeTS(1, 0))
+	if expTS := (hlc.Timestamp{WallTime: 1}); value.Timestamp != expTS {
+		t.Fatalf("expected timestamp %+v == %+v", value.Timestamp, expTS)
 	}
 	if !bytes.Equal(value1.RawBytes, value.RawBytes) {
 		t.Fatalf("the value %s in get result does not match the value %s in request",
@@ -2780,10 +2781,10 @@ func TestMVCCResolveWithPushedTimestamp(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(0, 1), value1, txn1); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, txn1); err != nil {
 		t.Fatal(err)
 	}
-	value, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(1, 0), true, txn1)
+	value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 1}, true, txn1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2794,22 +2795,22 @@ func TestMVCCResolveWithPushedTimestamp(t *testing.T) {
 
 	// Resolve with a higher commit timestamp, but with still-pending transaction.
 	// This represents a straightforward push (i.e. from a read/write conflict).
-	txn := makeTxn(*txn1, makeTS(1, 0))
+	txn := makeTxn(*txn1, hlc.Timestamp{WallTime: 1})
 	if err = MVCCResolveWriteIntent(context.Background(), engine, nil, roachpb.Intent{Span: roachpb.Span{Key: testKey1}, Status: txn.Status, Txn: txn.TxnMeta}); err != nil {
 		t.Fatal(err)
 	}
 
-	if value, _, err = MVCCGet(context.Background(), engine, testKey1, makeTS(1, 0), true, nil); value != nil || err == nil {
+	if value, _, err = MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 1}, true, nil); value != nil || err == nil {
 		t.Fatalf("expected both value nil and err to be a writeIntentError: %+v", value)
 	}
 
 	// Can still fetch the value using txn1.
-	value, _, err = MVCCGet(context.Background(), engine, testKey1, makeTS(1, 0), true, txn1)
+	value, _, err = MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{WallTime: 1}, true, txn1)
 	if err != nil {
 		t.Error(err)
 	}
-	if !value.Timestamp.Equal(makeTS(1, 0)) {
-		t.Fatalf("expected timestamp %+v == %+v", value.Timestamp, makeTS(1, 0))
+	if expTS := (hlc.Timestamp{WallTime: 1}); value.Timestamp != expTS {
+		t.Fatalf("expected timestamp %+v == %+v", value.Timestamp, expTS)
 	}
 	if !bytes.Equal(value1.RawBytes, value.RawBytes) {
 		t.Fatalf("the value %s in get result does not match the value %s in request",
@@ -2828,7 +2829,7 @@ func TestMVCCResolveTxnNoOps(t *testing.T) {
 	}
 
 	// Add key and resolve despite there being no intent.
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(0, 1), value1, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, nil); err != nil {
 		t.Fatal(err)
 	}
 	if err := MVCCResolveWriteIntent(context.Background(), engine, nil, roachpb.Intent{Span: roachpb.Span{Key: testKey1}, Status: txn2Commit.Status, Txn: txn2Commit.TxnMeta}); err != nil {
@@ -2836,12 +2837,12 @@ func TestMVCCResolveTxnNoOps(t *testing.T) {
 	}
 
 	// Write intent and resolve with different txn.
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(1, 0), value2, txn1); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value2, txn1); err != nil {
 		t.Fatal(err)
 	}
 
 	txn1CommitWithTS := txn2Commit.Clone()
-	txn1CommitWithTS.Timestamp = makeTS(1, 0)
+	txn1CommitWithTS.Timestamp = hlc.Timestamp{WallTime: 1}
 	if err := MVCCResolveWriteIntent(context.Background(), engine, nil, roachpb.Intent{Span: roachpb.Span{Key: testKey1}, Status: txn1CommitWithTS.Status, Txn: txn1CommitWithTS.TxnMeta}); err != nil {
 		t.Fatal(err)
 	}
@@ -2852,16 +2853,16 @@ func TestMVCCResolveTxnRange(t *testing.T) {
 	engine := createTestEngine()
 	defer engine.Close()
 
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(0, 1), value1, txn1); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, txn1); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey2, makeTS(0, 1), value2, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey2, hlc.Timestamp{Logical: 1}, value2, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey3, makeTS(0, 1), value3, txn2); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey3, hlc.Timestamp{Logical: 1}, value3, txn2); err != nil {
 		t.Fatal(err)
 	}
-	if err := MVCCPut(context.Background(), engine, nil, testKey4, makeTS(0, 1), value4, txn1); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey4, hlc.Timestamp{Logical: 1}, value4, txn1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2874,7 +2875,7 @@ func TestMVCCResolveTxnRange(t *testing.T) {
 	}
 
 	{
-		value, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(0, 1), true, nil)
+		value, _, err := MVCCGet(context.Background(), engine, testKey1, hlc.Timestamp{Logical: 1}, true, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2885,7 +2886,7 @@ func TestMVCCResolveTxnRange(t *testing.T) {
 	}
 
 	{
-		value, _, err := MVCCGet(context.Background(), engine, testKey2, makeTS(0, 1), true, nil)
+		value, _, err := MVCCGet(context.Background(), engine, testKey2, hlc.Timestamp{Logical: 1}, true, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2896,7 +2897,7 @@ func TestMVCCResolveTxnRange(t *testing.T) {
 	}
 
 	{
-		value, _, err := MVCCGet(context.Background(), engine, testKey3, makeTS(0, 1), true, txn2)
+		value, _, err := MVCCGet(context.Background(), engine, testKey3, hlc.Timestamp{Logical: 1}, true, txn2)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2908,7 +2909,7 @@ func TestMVCCResolveTxnRange(t *testing.T) {
 
 	// The fourth key is unresolved.
 	{
-		_, _, err := MVCCGet(context.Background(), engine, testKey4, makeTS(0, 1), true, nil)
+		_, _, err := MVCCGet(context.Background(), engine, testKey4, hlc.Timestamp{Logical: 1}, true, nil)
 		if !testutils.IsError(err, "conflicting intents on") {
 			t.Fatal(err)
 		}
@@ -2963,7 +2964,7 @@ func TestFindSplitKey(t *testing.T) {
 		v := strings.Repeat("X", 10-len(k))
 		val := roachpb.MakeValueFromString(v)
 		// Write the key and value through MVCC
-		if err := MVCCPut(context.Background(), engine, ms, []byte(k), makeTS(0, 1), val, nil); err != nil {
+		if err := MVCCPut(context.Background(), engine, ms, []byte(k), hlc.Timestamp{Logical: 1}, val, nil); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -3091,7 +3092,7 @@ func TestFindValidSplitKeys(t *testing.T) {
 		ms := &enginepb.MVCCStats{}
 		val := roachpb.MakeValueFromString(strings.Repeat("X", 10))
 		for _, k := range test.keys {
-			if err := MVCCPut(context.Background(), engine, ms, []byte(k), makeTS(0, 1), val, nil); err != nil {
+			if err := MVCCPut(context.Background(), engine, ms, []byte(k), hlc.Timestamp{Logical: 1}, val, nil); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -3189,7 +3190,7 @@ func TestFindBalancedSplitKeys(t *testing.T) {
 				expKey = key
 			}
 			val := roachpb.MakeValueFromString(strings.Repeat("X", test.valSizes[j]))
-			if err := MVCCPut(context.Background(), engine, ms, key, makeTS(0, 1), val, nil); err != nil {
+			if err := MVCCPut(context.Background(), engine, ms, key, hlc.Timestamp{Logical: 1}, val, nil); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -3276,7 +3277,7 @@ func TestMVCCStatsBasic(t *testing.T) {
 	ms := &enginepb.MVCCStats{}
 
 	// Verify size of mvccVersionTimestampSize.
-	ts := makeTS(1*1E9, 0)
+	ts := hlc.Timestamp{WallTime: 1 * 1E9}
 	key := roachpb.Key("a")
 	keySize := int64(mvccVersionKey(key, ts).EncodedSize() - mvccKey(key).EncodedSize())
 	if keySize != mvccVersionTimestampSize {
@@ -3308,8 +3309,8 @@ func TestMVCCStatsBasic(t *testing.T) {
 
 	// Delete the value using a transaction.
 	u := uuid.MakeV4()
-	txn := &roachpb.Transaction{TxnMeta: enginepb.TxnMeta{ID: &u, Timestamp: makeTS(1*1E9, 0)}}
-	ts2 := makeTS(2*1E9, 0)
+	txn := &roachpb.Transaction{TxnMeta: enginepb.TxnMeta{ID: &u, Timestamp: hlc.Timestamp{WallTime: 1 * 1E9}}}
+	ts2 := hlc.Timestamp{WallTime: 2 * 1E9}
 	if err := MVCCDelete(context.Background(), engine, ms, key, ts2, txn); err != nil {
 		t.Fatal(err)
 	}
@@ -3347,7 +3348,7 @@ func TestMVCCStatsBasic(t *testing.T) {
 
 	// Re-delete, but this time, we're going to commit it.
 	txn.Status = roachpb.PENDING
-	ts3 := makeTS(3*1E9, 0)
+	ts3 := hlc.Timestamp{WallTime: 3 * 1E9}
 	txn.Timestamp.Forward(ts3)
 	if err := MVCCDelete(context.Background(), engine, ms, key, ts3, txn); err != nil {
 		t.Fatal(err)
@@ -3361,7 +3362,7 @@ func TestMVCCStatsBasic(t *testing.T) {
 	}
 
 	// Write a second transactional value (i.e. an intent).
-	ts4 := makeTS(4*1E9, 0)
+	ts4 := hlc.Timestamp{WallTime: 4 * 1E9}
 	txn.Timestamp = ts4
 	key2 := roachpb.Key("b")
 	value2 := roachpb.MakeValueFromString("value")
@@ -3450,7 +3451,7 @@ func TestMVCCStatsBasic(t *testing.T) {
 	}
 
 	// Write over existing value to create GC'able bytes.
-	ts5 := makeTS(10*1E9, 0) // skip ahead 6s
+	ts5 := hlc.Timestamp{WallTime: 10 * 1E9} // skip ahead 6s
 	if err := MVCCPut(context.Background(), engine, ms, key2, ts5, value2, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -3466,7 +3467,7 @@ func TestMVCCStatsBasic(t *testing.T) {
 	// Write a transaction record which is a system-local key.
 	txnKey := keys.TransactionKey(txn.Key, *txn.ID)
 	txnVal := roachpb.MakeValueFromString("txn-data")
-	if err := MVCCPut(context.Background(), engine, ms, txnKey, hlc.ZeroTimestamp, txnVal, nil); err != nil {
+	if err := MVCCPut(context.Background(), engine, ms, txnKey, hlc.Timestamp{}, txnVal, nil); err != nil {
 		t.Fatal(err)
 	}
 	txnKeySize := int64(mvccKey(txnKey).EncodedSize())
@@ -3497,7 +3498,7 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 	var lastWT int64
 	for i := int32(0); i < int32(1000); i++ {
 		// Create random future timestamp, up to a few seconds ahead.
-		ts := makeTS(lastWT+int64(rng.Float32()*4E9), int32(rng.Int()))
+		ts := hlc.Timestamp{WallTime: lastWT + int64(rng.Float32()*4E9), Logical: int32(rng.Int())}
 		lastWT = ts.WallTime
 
 		if log.V(1) {
@@ -3599,13 +3600,13 @@ func TestMVCCGarbageCollect(t *testing.T) {
 	ms := &enginepb.MVCCStats{}
 
 	bytes := []byte("value")
-	ts1 := makeTS(1E9, 0)
-	ts2 := makeTS(2E9, 0)
-	ts3 := makeTS(3E9, 0)
+	ts1 := hlc.Timestamp{WallTime: 1E9}
+	ts2 := hlc.Timestamp{WallTime: 2E9}
+	ts3 := hlc.Timestamp{WallTime: 3E9}
 	val1 := roachpb.MakeValueFromBytesAndTimestamp(bytes, ts1)
 	val2 := roachpb.MakeValueFromBytesAndTimestamp(bytes, ts2)
 	val3 := roachpb.MakeValueFromBytesAndTimestamp(bytes, ts3)
-	valInline := roachpb.MakeValueFromBytesAndTimestamp(bytes, hlc.ZeroTimestamp)
+	valInline := roachpb.MakeValueFromBytesAndTimestamp(bytes, hlc.Timestamp{})
 
 	testData := []struct {
 		key       roachpb.Key
@@ -3632,7 +3633,7 @@ func TestMVCCGarbageCollect(t *testing.T) {
 					continue
 				}
 				valCpy := *protoutil.Clone(&val).(*roachpb.Value)
-				valCpy.Timestamp = hlc.ZeroTimestamp
+				valCpy.Timestamp = hlc.Timestamp{}
 				if err := MVCCPut(context.Background(), engine, ms, test.key, val.Timestamp, valCpy, nil); err != nil {
 					t.Fatal(err)
 				}
@@ -3654,10 +3655,10 @@ func TestMVCCGarbageCollect(t *testing.T) {
 		{Key: roachpb.Key("a-del"), Timestamp: ts2},
 		{Key: roachpb.Key("b"), Timestamp: ts1},
 		{Key: roachpb.Key("b-del"), Timestamp: ts2},
-		{Key: roachpb.Key("inline"), Timestamp: hlc.ZeroTimestamp},
+		{Key: roachpb.Key("inline"), Timestamp: hlc.Timestamp{}},
 		// Keys that don't exist, which should result in a no-op.
 		{Key: roachpb.Key("a-bad"), Timestamp: ts2},
-		{Key: roachpb.Key("inline-bad"), Timestamp: hlc.ZeroTimestamp},
+		{Key: roachpb.Key("inline-bad"), Timestamp: hlc.Timestamp{}},
 	}
 	if err := MVCCGarbageCollect(context.Background(), engine, ms, keys, ts3); err != nil {
 		t.Fatal(err)
@@ -3721,11 +3722,11 @@ func TestMVCCGarbageCollectNonDeleted(t *testing.T) {
 	defer engine.Close()
 
 	s := "string"
-	ts1 := makeTS(1E9, 0)
-	ts2 := makeTS(2E9, 0)
+	ts1 := hlc.Timestamp{WallTime: 1E9}
+	ts2 := hlc.Timestamp{WallTime: 2E9}
 	val1 := mkVal(s, ts1)
 	val2 := mkVal(s, ts2)
-	valInline := mkVal(s, hlc.ZeroTimestamp)
+	valInline := mkVal(s, hlc.Timestamp{})
 
 	testData := []struct {
 		key      roachpb.Key
@@ -3739,7 +3740,7 @@ func TestMVCCGarbageCollectNonDeleted(t *testing.T) {
 	for _, test := range testData {
 		for _, val := range test.vals {
 			valCpy := *protoutil.Clone(&val).(*roachpb.Value)
-			valCpy.Timestamp = hlc.ZeroTimestamp
+			valCpy.Timestamp = hlc.Timestamp{}
 			if err := MVCCPut(context.Background(), engine, nil, test.key, val.Timestamp, valCpy, nil); err != nil {
 				t.Fatal(err)
 			}
@@ -3762,8 +3763,8 @@ func TestMVCCGarbageCollectIntent(t *testing.T) {
 	defer engine.Close()
 
 	bytes := []byte("value")
-	ts1 := makeTS(1E9, 0)
-	ts2 := makeTS(2E9, 0)
+	ts1 := hlc.Timestamp{WallTime: 1E9}
+	ts2 := hlc.Timestamp{WallTime: 2E9}
 	key := roachpb.Key("a")
 	{
 		val1 := roachpb.MakeValueFromBytes(bytes)
@@ -3793,7 +3794,7 @@ func TestResolveIntentWithLowerEpoch(t *testing.T) {
 	defer engine.Close()
 
 	// Lay down an intent with a high epoch.
-	if err := MVCCPut(context.Background(), engine, nil, testKey1, makeTS(0, 1), value1, txn1e2); err != nil {
+	if err := MVCCPut(context.Background(), engine, nil, testKey1, hlc.Timestamp{Logical: 1}, value1, txn1e2); err != nil {
 		t.Fatal(err)
 	}
 	// Resolve the intent with a low epoch.
@@ -3826,23 +3827,10 @@ func TestMVCCTimeSeriesPartialMerge(t *testing.T) {
 	vals := make([]*roachpb.Value, 2)
 
 	for i, k := range []roachpb.Key{testKey1, testKey2} {
-		if err := MVCCMerge(context.Background(), engine, nil, k, makeTS(0, 1), tsvalue1); err != nil {
+		if err := MVCCMerge(context.Background(), engine, nil, k, hlc.Timestamp{Logical: 1}, tsvalue1); err != nil {
 			t.Fatal(err)
 		}
-		if err := MVCCMerge(context.Background(), engine, nil, k, makeTS(0, 2), tsvalue2); err != nil {
-			t.Fatal(err)
-		}
-
-		if i == 1 {
-			if err := engine.(InMem).Compact(); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		if err := MVCCMerge(context.Background(), engine, nil, k, makeTS(0, 2), tsvalue2); err != nil {
-			t.Fatal(err)
-		}
-		if err := MVCCMerge(context.Background(), engine, nil, k, makeTS(0, 1), tsvalue1); err != nil {
+		if err := MVCCMerge(context.Background(), engine, nil, k, hlc.Timestamp{Logical: 2}, tsvalue2); err != nil {
 			t.Fatal(err)
 		}
 
@@ -3852,7 +3840,20 @@ func TestMVCCTimeSeriesPartialMerge(t *testing.T) {
 			}
 		}
 
-		if v, _, err := MVCCGet(context.Background(), engine, k, hlc.ZeroTimestamp, true, nil); err != nil {
+		if err := MVCCMerge(context.Background(), engine, nil, k, hlc.Timestamp{Logical: 2}, tsvalue2); err != nil {
+			t.Fatal(err)
+		}
+		if err := MVCCMerge(context.Background(), engine, nil, k, hlc.Timestamp{Logical: 1}, tsvalue1); err != nil {
+			t.Fatal(err)
+		}
+
+		if i == 1 {
+			if err := engine.(InMem).Compact(); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		if v, _, err := MVCCGet(context.Background(), engine, k, hlc.Timestamp{}, true, nil); err != nil {
 			t.Fatal(err)
 		} else {
 			vals[i] = v

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -567,10 +567,10 @@ func TestRocksDBTimeBound(t *testing.T) {
 		t.Fatalf("expected 1 sstable got %d", len(ssts.Sst))
 	}
 	sst := ssts.Sst[0]
-	if sst.TsMin == nil || !sst.TsMin.Equal(minTimestamp) {
+	if sst.TsMin == nil || *sst.TsMin != minTimestamp {
 		t.Fatalf("got min %v expected %v", sst.TsMin, minTimestamp)
 	}
-	if sst.TsMax == nil || !sst.TsMax.Equal(maxTimestamp) {
+	if sst.TsMax == nil || *sst.TsMax != maxTimestamp {
 		t.Fatalf("got max %v expected %v", sst.TsMax, maxTimestamp)
 	}
 }

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -263,7 +263,7 @@ func processLocalKeyRange(
 	endKey := keys.MakeRangeKeyPrefix(desc.EndKey)
 
 	_, err := engine.MVCCIterate(ctx, snap, startKey, endKey,
-		hlc.ZeroTimestamp, true /* consistent */, nil, /* txn */
+		hlc.Timestamp{}, true /* consistent */, nil, /* txn */
 		false /* !reverse */, func(kv roachpb.KeyValue) (bool, error) {
 			return false, handleOne(kv)
 		})
@@ -530,7 +530,7 @@ func RunGC(
 					startIdx = 2
 				}
 				// See if any values may be GC'd.
-				if gcTS := gc.Filter(keys[startIdx:], vals[startIdx:]); !gcTS.Equal(hlc.ZeroTimestamp) {
+				if gcTS := gc.Filter(keys[startIdx:], vals[startIdx:]); gcTS != (hlc.Timestamp{}) {
 					// TODO(spencer): need to split the requests up into
 					// multiple requests in the event that more than X keys
 					// are added to the request.

--- a/pkg/storage/log.go
+++ b/pkg/storage/log.go
@@ -199,7 +199,7 @@ func (s *Store) logChange(
 // *are* the first action in a transaction, and we must elect to use the store's
 // physical time instead.
 func selectEventTimestamp(s *Store, input hlc.Timestamp) time.Time {
-	if input == hlc.ZeroTimestamp {
+	if input == (hlc.Timestamp{}) {
 		return s.Clock().PhysicalTime()
 	}
 	return input.GoTime()

--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -119,7 +119,7 @@ func isExpectedQueueError(err error) bool {
 // Returns a bool for whether to queue as well as a priority based
 // on how long it's been since last processed.
 func shouldQueueAgain(now, last hlc.Timestamp, minInterval time.Duration) (bool, float64) {
-	if minInterval == 0 || last == hlc.ZeroTimestamp {
+	if minInterval == 0 || last == (hlc.Timestamp{}) {
 		return true, 0
 	}
 	if diff := now.GoTime().Sub(last.GoTime()); diff >= minInterval {
@@ -127,7 +127,7 @@ func shouldQueueAgain(now, last hlc.Timestamp, minInterval time.Duration) (bool,
 		// If there's a non-zero last processed timestamp, adjust the
 		// priority by a multiple of how long it's been since the last
 		// time this replica was processed.
-		if last != hlc.ZeroTimestamp {
+		if last != (hlc.Timestamp{}) {
 			priority = float64(diff.Nanoseconds()) / float64(minInterval.Nanoseconds())
 		}
 		return true, priority

--- a/pkg/storage/queue_test.go
+++ b/pkg/storage/queue_test.go
@@ -167,8 +167,8 @@ func TestBaseQueueAddUpdateAndRemove(t *testing.T) {
 	}
 	bq := makeTestBaseQueue("test", testQueue, tc.store, tc.gossip, queueConfig{maxSize: 2})
 
-	bq.MaybeAdd(r1, hlc.ZeroTimestamp)
-	bq.MaybeAdd(r2, hlc.ZeroTimestamp)
+	bq.MaybeAdd(r1, hlc.Timestamp{})
+	bq.MaybeAdd(r2, hlc.Timestamp{})
 	if bq.Length() != 2 {
 		t.Fatalf("expected length 2; got %d", bq.Length())
 	}
@@ -193,14 +193,14 @@ func TestBaseQueueAddUpdateAndRemove(t *testing.T) {
 
 	// Add again, but this time r2 shouldn't add.
 	shouldAddMap[r2] = false
-	bq.MaybeAdd(r1, hlc.ZeroTimestamp)
-	bq.MaybeAdd(r2, hlc.ZeroTimestamp)
+	bq.MaybeAdd(r1, hlc.Timestamp{})
+	bq.MaybeAdd(r2, hlc.Timestamp{})
 	if bq.Length() != 1 {
 		t.Errorf("expected length 1; got %d", bq.Length())
 	}
 
 	// Try adding same replica twice.
-	bq.MaybeAdd(r1, hlc.ZeroTimestamp)
+	bq.MaybeAdd(r1, hlc.Timestamp{})
 	if bq.Length() != 1 {
 		t.Errorf("expected length 1; got %d", bq.Length())
 	}
@@ -208,8 +208,8 @@ func TestBaseQueueAddUpdateAndRemove(t *testing.T) {
 	// Re-add r2 and update priority of r1.
 	shouldAddMap[r2] = true
 	priorityMap[r1] = 3.0
-	bq.MaybeAdd(r1, hlc.ZeroTimestamp)
-	bq.MaybeAdd(r2, hlc.ZeroTimestamp)
+	bq.MaybeAdd(r1, hlc.Timestamp{})
+	bq.MaybeAdd(r2, hlc.Timestamp{})
 	if bq.Length() != 2 {
 		t.Fatalf("expected length 2; got %d", bq.Length())
 	}
@@ -224,10 +224,10 @@ func TestBaseQueueAddUpdateAndRemove(t *testing.T) {
 	}
 
 	// Set !shouldAdd for r2 and add it; this has effect of removing it.
-	bq.MaybeAdd(r1, hlc.ZeroTimestamp)
-	bq.MaybeAdd(r2, hlc.ZeroTimestamp)
+	bq.MaybeAdd(r1, hlc.Timestamp{})
+	bq.MaybeAdd(r2, hlc.Timestamp{})
 	shouldAddMap[r2] = false
-	bq.MaybeAdd(r2, hlc.ZeroTimestamp)
+	bq.MaybeAdd(r2, hlc.Timestamp{})
 	if bq.Length() != 1 {
 		t.Fatalf("expected length 1; got %d", bq.Length())
 	}
@@ -262,7 +262,7 @@ func TestBaseQueueAdd(t *testing.T) {
 		},
 	}
 	bq := makeTestBaseQueue("test", testQueue, tc.store, tc.gossip, queueConfig{maxSize: 1})
-	bq.MaybeAdd(r, hlc.ZeroTimestamp)
+	bq.MaybeAdd(r, hlc.Timestamp{})
 	if bq.Length() != 0 {
 		t.Fatalf("expected length 0; got %d", bq.Length())
 	}
@@ -317,8 +317,8 @@ func TestBaseQueueProcess(t *testing.T) {
 	bq := makeTestBaseQueue("test", testQueue, tc.store, tc.gossip, queueConfig{maxSize: 2})
 	bq.Start(tc.Clock(), stopper)
 
-	bq.MaybeAdd(r1, hlc.ZeroTimestamp)
-	bq.MaybeAdd(r2, hlc.ZeroTimestamp)
+	bq.MaybeAdd(r1, hlc.Timestamp{})
+	bq.MaybeAdd(r2, hlc.Timestamp{})
 	if pc := testQueue.getProcessed(); pc != 0 {
 		t.Errorf("expected no processed ranges; got %d", pc)
 	}
@@ -389,7 +389,7 @@ func TestBaseQueueAddRemove(t *testing.T) {
 	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
 	bq.Start(clock, stopper)
 
-	bq.MaybeAdd(r, hlc.ZeroTimestamp)
+	bq.MaybeAdd(r, hlc.Timestamp{})
 	bq.MaybeRemove(r.RangeID)
 
 	// Wake the queue
@@ -470,8 +470,8 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 
 	// There are no user db/table entries, everything should be added and
 	// processed as usual.
-	bq.MaybeAdd(neverSplits, hlc.ZeroTimestamp)
-	bq.MaybeAdd(willSplit, hlc.ZeroTimestamp)
+	bq.MaybeAdd(neverSplits, hlc.Timestamp{})
+	bq.MaybeAdd(willSplit, hlc.Timestamp{})
 
 	testutils.SucceedsSoon(t, func() error {
 		if pc := testQueue.getProcessed(); pc != 2 {
@@ -502,8 +502,8 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 		t.Fatal("System config says range does not need to be split")
 	}
 
-	bq.MaybeAdd(neverSplits, hlc.ZeroTimestamp)
-	bq.MaybeAdd(willSplit, hlc.ZeroTimestamp)
+	bq.MaybeAdd(neverSplits, hlc.Timestamp{})
+	bq.MaybeAdd(willSplit, hlc.Timestamp{})
 
 	testutils.SucceedsSoon(t, func() error {
 		if pc := testQueue.getProcessed(); pc != 3 {
@@ -570,7 +570,7 @@ func TestBaseQueuePurgatory(t *testing.T) {
 		if err := tc.store.AddReplica(r); err != nil {
 			t.Fatal(err)
 		}
-		bq.MaybeAdd(r, hlc.ZeroTimestamp)
+		bq.MaybeAdd(r, hlc.Timestamp{})
 	}
 
 	testutils.SucceedsSoon(t, func() error {
@@ -711,7 +711,7 @@ func TestBaseQueueProcessTimeout(t *testing.T) {
 			acceptsUnsplitRanges: true,
 		})
 	bq.Start(tc.Clock(), stopper)
-	bq.MaybeAdd(r, hlc.ZeroTimestamp)
+	bq.MaybeAdd(r, hlc.Timestamp{})
 
 	if l := bq.Length(); l != 1 {
 		t.Errorf("expected one queued replica; got %d", l)
@@ -765,7 +765,7 @@ func TestBaseQueueTimeMetric(t *testing.T) {
 			acceptsUnsplitRanges: true,
 		})
 	bq.Start(tc.Clock(), stopper)
-	bq.MaybeAdd(r, hlc.ZeroTimestamp)
+	bq.MaybeAdd(r, hlc.Timestamp{})
 
 	testutils.SucceedsSoon(t, func() error {
 		if v := bq.successes.Count(); v != 1 {
@@ -836,7 +836,7 @@ func TestBaseQueueDisable(t *testing.T) {
 	bq.Start(clock, stopper)
 
 	bq.SetDisabled(true)
-	bq.MaybeAdd(r, hlc.ZeroTimestamp)
+	bq.MaybeAdd(r, hlc.Timestamp{})
 	if shouldQueueCalled {
 		t.Error("shouldQueue should not have been called")
 	}

--- a/pkg/storage/replica_data_iter_test.go
+++ b/pkg/storage/replica_data_iter_test.go
@@ -62,7 +62,7 @@ func fakePrevKey(k []byte) roachpb.Key {
 // the key space. Returns a slice of the encoded keys of all created
 // data.
 func createRangeData(t *testing.T, r *Replica) []engine.MVCCKey {
-	ts0 := hlc.ZeroTimestamp
+	ts0 := hlc.Timestamp{}
 	ts := hlc.Timestamp{WallTime: 1}
 	desc := r.Desc()
 	keyTSs := []struct {

--- a/pkg/storage/replica_gc_queue.go
+++ b/pkg/storage/replica_gc_queue.go
@@ -121,7 +121,9 @@ func (rgcq *replicaGCQueue) shouldQueue(
 		return false, 0
 	}
 
-	lastActivity := hlc.ZeroTimestamp.Add(repl.store.startedAt, 0)
+	lastActivity := hlc.Timestamp{
+		WallTime: repl.store.startedAt,
+	}
 
 	if lease, _ := repl.getLease(); lease != nil && lease.ProposedTS != nil {
 		lastActivity.Forward(*lease.ProposedTS)

--- a/pkg/storage/replica_gc_queue_test.go
+++ b/pkg/storage/replica_gc_queue_test.go
@@ -28,7 +28,7 @@ func TestReplicaGCShouldQueue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ts := func(t time.Duration) hlc.Timestamp {
-		return hlc.ZeroTimestamp.Add(t.Nanoseconds(), 0)
+		return hlc.Timestamp{WallTime: t.Nanoseconds()}
 	}
 
 	base := 2 * (ReplicaGCQueueCandidateTimeout + ReplicaGCQueueInactivityThreshold)

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -219,9 +219,9 @@ func (p *EvalResult) MergeAndDestroy(q EvalResult) error {
 	q.Replicated.State.TruncatedState = nil
 
 	p.Replicated.State.GCThreshold.Forward(q.Replicated.State.GCThreshold)
-	q.Replicated.State.GCThreshold = hlc.ZeroTimestamp
+	q.Replicated.State.GCThreshold = hlc.Timestamp{}
 	p.Replicated.State.TxnSpanGCThreshold.Forward(q.Replicated.State.TxnSpanGCThreshold)
-	q.Replicated.State.TxnSpanGCThreshold = hlc.ZeroTimestamp
+	q.Replicated.State.TxnSpanGCThreshold = hlc.Timestamp{}
 
 	if (q.Replicated.State.Stats != enginepb.MVCCStats{}) {
 		return errors.New("must not specify Stats")
@@ -488,7 +488,7 @@ func (r *Replica) handleReplicatedEvalResult(
 		rResult.IsLeaseRequest = false
 		rResult.IsConsistencyRelated = false
 		rResult.IsFreeze = false
-		rResult.Timestamp = hlc.ZeroTimestamp
+		rResult.Timestamp = hlc.Timestamp{}
 	}
 
 	if rResult.BlockReads {
@@ -627,18 +627,18 @@ func (r *Replica) handleReplicatedEvalResult(
 		r.store.raftEntryCache.clearTo(r.RangeID, newTruncState.Index+1)
 	}
 
-	if newThresh := rResult.State.GCThreshold; newThresh != hlc.ZeroTimestamp {
+	if newThresh := rResult.State.GCThreshold; newThresh != (hlc.Timestamp{}) {
 		r.mu.Lock()
 		r.mu.state.GCThreshold = newThresh
 		r.mu.Unlock()
-		rResult.State.GCThreshold = hlc.ZeroTimestamp
+		rResult.State.GCThreshold = hlc.Timestamp{}
 	}
 
-	if newThresh := rResult.State.TxnSpanGCThreshold; newThresh != hlc.ZeroTimestamp {
+	if newThresh := rResult.State.TxnSpanGCThreshold; newThresh != (hlc.Timestamp{}) {
 		r.mu.Lock()
 		r.mu.state.TxnSpanGCThreshold = newThresh
 		r.mu.Unlock()
-		rResult.State.TxnSpanGCThreshold = hlc.ZeroTimestamp
+		rResult.State.TxnSpanGCThreshold = hlc.Timestamp{}
 	}
 
 	if rResult.ComputeChecksum != nil {

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -185,7 +185,7 @@ func iterateEntries(
 		ctx, e,
 		keys.RaftLogKey(rangeID, lo),
 		keys.RaftLogKey(rangeID, hi),
-		hlc.ZeroTimestamp,
+		hlc.Timestamp{},
 		true,  /* consistent */
 		nil,   /* txn */
 		false, /* !reverse */
@@ -453,9 +453,9 @@ func (r *Replica) append(
 		value.InitChecksum(key)
 		var err error
 		if ent.Index > prevLastIndex {
-			err = engine.MVCCBlindPut(ctx, batch, &diff, key, hlc.ZeroTimestamp, value, nil /* txn */)
+			err = engine.MVCCBlindPut(ctx, batch, &diff, key, hlc.Timestamp{}, value, nil /* txn */)
 		} else {
-			err = engine.MVCCPut(ctx, batch, &diff, key, hlc.ZeroTimestamp, value, nil /* txn */)
+			err = engine.MVCCPut(ctx, batch, &diff, key, hlc.Timestamp{}, value, nil /* txn */)
 		}
 		if err != nil {
 			return 0, 0, err
@@ -466,7 +466,7 @@ func (r *Replica) append(
 	lastIndex := entries[len(entries)-1].Index
 	for i := lastIndex + 1; i <= prevLastIndex; i++ {
 		err := engine.MVCCDelete(ctx, batch, &diff, r.stateLoader.RaftLogKey(i),
-			hlc.ZeroTimestamp, nil /* txn */)
+			hlc.Timestamp{}, nil /* txn */)
 		if err != nil {
 			return 0, 0, err
 		}

--- a/pkg/storage/replica_state.go
+++ b/pkg/storage/replica_state.go
@@ -141,7 +141,7 @@ func (rsl replicaStateLoader) loadLease(
 ) (roachpb.Lease, error) {
 	var lease roachpb.Lease
 	_, err := engine.MVCCGetProto(ctx, reader, rsl.RangeLeaseKey(),
-		hlc.ZeroTimestamp, true, nil, &lease)
+		hlc.Timestamp{}, true, nil, &lease)
 	return lease, err
 }
 
@@ -152,7 +152,7 @@ func (rsl replicaStateLoader) setLease(
 		return errors.New("cannot persist nil Lease")
 	}
 	return engine.MVCCPutProto(ctx, eng, ms, rsl.RangeLeaseKey(),
-		hlc.ZeroTimestamp, nil, lease)
+		hlc.Timestamp{}, nil, lease)
 }
 
 func loadAppliedIndex(
@@ -168,7 +168,7 @@ func (rsl replicaStateLoader) loadAppliedIndex(
 ) (uint64, uint64, error) {
 	var appliedIndex uint64
 	v, _, err := engine.MVCCGet(ctx, reader, rsl.RaftAppliedIndexKey(),
-		hlc.ZeroTimestamp, true, nil)
+		hlc.Timestamp{}, true, nil)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -182,7 +182,7 @@ func (rsl replicaStateLoader) loadAppliedIndex(
 	// TODO(tschottdorf): code duplication.
 	var leaseAppliedIndex uint64
 	v, _, err = engine.MVCCGet(ctx, reader, rsl.LeaseAppliedIndexKey(),
-		hlc.ZeroTimestamp, true, nil)
+		hlc.Timestamp{}, true, nil)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -210,7 +210,7 @@ func (rsl replicaStateLoader) setAppliedIndex(
 	value.SetInt(int64(appliedIndex))
 	if err := engine.MVCCPut(ctx, eng, ms,
 		rsl.RaftAppliedIndexKey(),
-		hlc.ZeroTimestamp,
+		hlc.Timestamp{},
 		value,
 		nil /* txn */); err != nil {
 		return err
@@ -218,7 +218,7 @@ func (rsl replicaStateLoader) setAppliedIndex(
 	value.SetInt(int64(leaseAppliedIndex))
 	return engine.MVCCPut(ctx, eng, ms,
 		rsl.LeaseAppliedIndexKey(),
-		hlc.ZeroTimestamp,
+		hlc.Timestamp{},
 		value,
 		nil /* txn */)
 }
@@ -239,7 +239,7 @@ func (rsl replicaStateLoader) setAppliedIndexBlind(
 	value.SetInt(int64(appliedIndex))
 	if err := engine.MVCCBlindPut(ctx, eng, ms,
 		rsl.RaftAppliedIndexKey(),
-		hlc.ZeroTimestamp,
+		hlc.Timestamp{},
 		value,
 		nil /* txn */); err != nil {
 		return err
@@ -247,7 +247,7 @@ func (rsl replicaStateLoader) setAppliedIndexBlind(
 	value.SetInt(int64(leaseAppliedIndex))
 	return engine.MVCCBlindPut(ctx, eng, ms,
 		rsl.LeaseAppliedIndexKey(),
-		hlc.ZeroTimestamp,
+		hlc.Timestamp{},
 		value,
 		nil /* txn */)
 }
@@ -282,7 +282,7 @@ func (rsl replicaStateLoader) loadTruncatedState(
 ) (roachpb.RaftTruncatedState, error) {
 	var truncState roachpb.RaftTruncatedState
 	if _, err := engine.MVCCGetProto(ctx, reader,
-		rsl.RaftTruncatedStateKey(), hlc.ZeroTimestamp, true,
+		rsl.RaftTruncatedStateKey(), hlc.Timestamp{}, true,
 		nil, &truncState); err != nil {
 		return roachpb.RaftTruncatedState{}, err
 	}
@@ -299,7 +299,7 @@ func (rsl replicaStateLoader) setTruncatedState(
 		return errors.New("cannot persist empty RaftTruncatedState")
 	}
 	return engine.MVCCPutProto(ctx, eng, ms,
-		rsl.RaftTruncatedStateKey(), hlc.ZeroTimestamp, nil, truncState)
+		rsl.RaftTruncatedStateKey(), hlc.Timestamp{}, nil, truncState)
 }
 
 func (rsl replicaStateLoader) loadGCThreshold(
@@ -307,7 +307,7 @@ func (rsl replicaStateLoader) loadGCThreshold(
 ) (hlc.Timestamp, error) {
 	var t hlc.Timestamp
 	_, err := engine.MVCCGetProto(ctx, reader, rsl.RangeLastGCKey(),
-		hlc.ZeroTimestamp, true, nil, &t)
+		hlc.Timestamp{}, true, nil, &t)
 	return t, err
 }
 
@@ -318,7 +318,7 @@ func (rsl replicaStateLoader) setGCThreshold(
 		return errors.New("cannot persist nil GCThreshold")
 	}
 	return engine.MVCCPutProto(ctx, eng, ms,
-		rsl.RangeLastGCKey(), hlc.ZeroTimestamp, nil, threshold)
+		rsl.RangeLastGCKey(), hlc.Timestamp{}, nil, threshold)
 }
 
 func (rsl replicaStateLoader) loadTxnSpanGCThreshold(
@@ -326,7 +326,7 @@ func (rsl replicaStateLoader) loadTxnSpanGCThreshold(
 ) (hlc.Timestamp, error) {
 	var t hlc.Timestamp
 	_, err := engine.MVCCGetProto(ctx, reader, rsl.RangeTxnSpanGCThresholdKey(),
-		hlc.ZeroTimestamp, true, nil, &t)
+		hlc.Timestamp{}, true, nil, &t)
 	return t, err
 }
 
@@ -338,21 +338,21 @@ func (rsl replicaStateLoader) setTxnSpanGCThreshold(
 	}
 
 	return engine.MVCCPutProto(ctx, eng, ms,
-		rsl.RangeTxnSpanGCThresholdKey(), hlc.ZeroTimestamp, nil, threshold)
+		rsl.RangeTxnSpanGCThresholdKey(), hlc.Timestamp{}, nil, threshold)
 }
 
 func (rsl replicaStateLoader) loadMVCCStats(
 	ctx context.Context, reader engine.Reader,
 ) (enginepb.MVCCStats, error) {
 	var ms enginepb.MVCCStats
-	_, err := engine.MVCCGetProto(ctx, reader, rsl.RangeStatsKey(), hlc.ZeroTimestamp, true, nil, &ms)
+	_, err := engine.MVCCGetProto(ctx, reader, rsl.RangeStatsKey(), hlc.Timestamp{}, true, nil, &ms)
 	return ms, err
 }
 
 func (rsl replicaStateLoader) setMVCCStats(
 	ctx context.Context, eng engine.ReadWriter, newMS *enginepb.MVCCStats,
 ) error {
-	return engine.MVCCPutProto(ctx, eng, nil, rsl.RangeStatsKey(), hlc.ZeroTimestamp, nil, newMS)
+	return engine.MVCCPutProto(ctx, eng, nil, rsl.RangeStatsKey(), hlc.Timestamp{}, nil, newMS)
 }
 
 func (rsl replicaStateLoader) setFrozenStatus(
@@ -366,7 +366,7 @@ func (rsl replicaStateLoader) setFrozenStatus(
 	}
 	var val roachpb.Value
 	val.SetBool(frozen == storagebase.ReplicaState_FROZEN)
-	return engine.MVCCPut(ctx, eng, ms, rsl.RangeFrozenStatusKey(), hlc.ZeroTimestamp, val, nil)
+	return engine.MVCCPut(ctx, eng, ms, rsl.RangeFrozenStatusKey(), hlc.Timestamp{}, val, nil)
 }
 
 func (rsl replicaStateLoader) loadFrozenStatus(
@@ -374,7 +374,7 @@ func (rsl replicaStateLoader) loadFrozenStatus(
 ) (storagebase.ReplicaState_FrozenEnum, error) {
 	var zero storagebase.ReplicaState_FrozenEnum
 	val, _, err := engine.MVCCGet(ctx, reader, rsl.RangeFrozenStatusKey(),
-		hlc.ZeroTimestamp, true, nil)
+		hlc.Timestamp{}, true, nil)
 	if err != nil {
 		return zero, err
 	}
@@ -407,7 +407,7 @@ func (rsl replicaStateLoader) loadLastIndex(
 ) (uint64, error) {
 	var lastIndex uint64
 	v, _, err := engine.MVCCGet(ctx, reader, rsl.RaftLastIndexKey(),
-		hlc.ZeroTimestamp, true /* consistent */, nil)
+		hlc.Timestamp{}, true /* consistent */, nil)
 	if err != nil {
 		return 0, err
 	}
@@ -435,7 +435,7 @@ func (rsl replicaStateLoader) setLastIndex(
 	var value roachpb.Value
 	value.SetInt(int64(lastIndex))
 	return engine.MVCCPut(ctx, eng, nil, rsl.RaftLastIndexKey(),
-		hlc.ZeroTimestamp, value, nil /* txn */)
+		hlc.Timestamp{}, value, nil /* txn */)
 }
 
 // loadReplicaDestroyedError loads the replica destroyed error for the specified
@@ -446,7 +446,7 @@ func (rsl replicaStateLoader) loadReplicaDestroyedError(
 	var v roachpb.Error
 	found, err := engine.MVCCGetProto(ctx, reader,
 		rsl.RangeReplicaDestroyedErrorKey(),
-		hlc.ZeroTimestamp, true /* consistent */, nil, &v)
+		hlc.Timestamp{}, true /* consistent */, nil, &v)
 	if err != nil {
 		return nil, err
 	}
@@ -462,7 +462,7 @@ func (rsl replicaStateLoader) setReplicaDestroyedError(
 	ctx context.Context, eng engine.ReadWriter, err *roachpb.Error,
 ) error {
 	return engine.MVCCPutProto(ctx, eng, nil,
-		rsl.RangeReplicaDestroyedErrorKey(), hlc.ZeroTimestamp, nil /* txn */, err)
+		rsl.RangeReplicaDestroyedErrorKey(), hlc.Timestamp{}, nil /* txn */, err)
 }
 
 func loadHardState(
@@ -478,7 +478,7 @@ func (rsl replicaStateLoader) loadHardState(
 	var hs raftpb.HardState
 	found, err := engine.MVCCGetProto(ctx, reader,
 		rsl.RaftHardStateKey(),
-		hlc.ZeroTimestamp, true, nil, &hs)
+		hlc.Timestamp{}, true, nil, &hs)
 
 	if !found || err != nil {
 		return raftpb.HardState{}, err
@@ -490,7 +490,7 @@ func (rsl replicaStateLoader) setHardState(
 	ctx context.Context, batch engine.ReadWriter, st raftpb.HardState,
 ) error {
 	return engine.MVCCPutProto(ctx, batch, nil,
-		rsl.RaftHardStateKey(), hlc.ZeroTimestamp, nil, &st)
+		rsl.RaftHardStateKey(), hlc.Timestamp{}, nil, &st)
 }
 
 // synthesizeHardState synthesizes a HardState from the given ReplicaState and

--- a/pkg/storage/split_queue_test.go
+++ b/pkg/storage/split_queue_test.go
@@ -102,7 +102,7 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 		if err := tc.repl.setDesc(&copy); err != nil {
 			t.Fatal(err)
 		}
-		shouldQ, priority := splitQ.shouldQueue(context.TODO(), hlc.ZeroTimestamp, tc.repl, cfg)
+		shouldQ, priority := splitQ.shouldQueue(context.TODO(), hlc.Timestamp{}, tc.repl, cfg)
 		if shouldQ != test.shouldQ {
 			t.Errorf("%d: should queue expected %t; got %t", i, test.shouldQ, shouldQ)
 		}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1078,7 +1078,7 @@ func (s *Store) migrate(ctx context.Context, desc roachpb.RangeDescriptor) {
 func ReadStoreIdent(ctx context.Context, eng engine.Engine) (roachpb.StoreIdent, error) {
 	var ident roachpb.StoreIdent
 	ok, err := engine.MVCCGetProto(
-		ctx, eng, keys.StoreIdentKey(), hlc.ZeroTimestamp, true, nil, &ident)
+		ctx, eng, keys.StoreIdentKey(), hlc.Timestamp{}, true, nil, &ident)
 	if err != nil {
 		return roachpb.StoreIdent{}, err
 	} else if !ok {
@@ -1533,7 +1533,7 @@ func (s *Store) Bootstrap(ident roachpb.StoreIdent) error {
 		s.engine,
 		nil,
 		keys.StoreIdentKey(),
-		hlc.ZeroTimestamp,
+		hlc.Timestamp{},
 		nil,
 		&s.Ident,
 	); err != nil {
@@ -1555,7 +1555,7 @@ func (s *Store) WriteLastUpTimestamp(ctx context.Context, time hlc.Timestamp) er
 		s.engine,
 		nil,
 		keys.StoreLastUpKey(),
-		hlc.ZeroTimestamp,
+		hlc.Timestamp{},
 		nil,
 		&time,
 	)
@@ -1569,11 +1569,11 @@ func (s *Store) WriteLastUpTimestamp(ctx context.Context, time hlc.Timestamp) er
 func (s *Store) ReadLastUpTimestamp(ctx context.Context) (hlc.Timestamp, error) {
 	var timestamp hlc.Timestamp
 	ok, err := engine.MVCCGetProto(
-		ctx, s.Engine(), keys.StoreLastUpKey(), hlc.ZeroTimestamp, true, nil, &timestamp)
+		ctx, s.Engine(), keys.StoreLastUpKey(), hlc.Timestamp{}, true, nil, &timestamp)
 	if err != nil {
 		return hlc.Timestamp{}, err
 	} else if !ok {
-		return hlc.ZeroTimestamp, nil
+		return hlc.Timestamp{}, nil
 	}
 	return timestamp, nil
 }
@@ -1743,7 +1743,7 @@ func (s *Store) BootstrapRange(initialValues []roachpb.KeyValue) error {
 		return err
 	}
 	// Replica GC timestamp.
-	if err := engine.MVCCPutProto(ctx, batch, nil /* ms */, keys.RangeLastReplicaGCTimestampKey(desc.RangeID), hlc.ZeroTimestamp, nil, &now); err != nil {
+	if err := engine.MVCCPutProto(ctx, batch, nil /* ms */, keys.RangeLastReplicaGCTimestampKey(desc.RangeID), hlc.Timestamp{}, nil, &now); err != nil {
 		return err
 	}
 	// Range addressing for meta2.
@@ -3668,7 +3668,7 @@ func (s *Store) tryGetOrCreateReplica(
 	tombstoneKey := keys.RaftTombstoneKey(rangeID)
 	var tombstone roachpb.RaftTombstone
 	if ok, err := engine.MVCCGetProto(
-		ctx, s.Engine(), tombstoneKey, hlc.ZeroTimestamp, true, nil, &tombstone,
+		ctx, s.Engine(), tombstoneKey, hlc.Timestamp{}, true, nil, &tombstone,
 	); err != nil {
 		return nil, false, err
 	} else if ok {

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -819,7 +819,7 @@ func TestStoreAnnotateNow(t *testing.T) {
 				if pErr == nil {
 					t.Fatal("expected an error")
 				}
-				if pErr.Now == hlc.ZeroTimestamp {
+				if pErr.Now == (hlc.Timestamp{}) {
 					t.Fatal("timestamp not annotated on error")
 				}
 			}},
@@ -828,7 +828,7 @@ func TestStoreAnnotateNow(t *testing.T) {
 				if pErr != nil {
 					t.Fatal(pErr)
 				}
-				if pReply.Now == hlc.ZeroTimestamp {
+				if pReply.Now == (hlc.Timestamp{}) {
 					t.Fatal("timestamp not annotated on batch response")
 				}
 			}},
@@ -1299,7 +1299,7 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 			}
 			txnKey := keys.TransactionKey(pushee.Key, *pushee.ID)
 			var txn roachpb.Transaction
-			ok, err := engine.MVCCGetProto(context.Background(), store.Engine(), txnKey, hlc.ZeroTimestamp, true, nil, &txn)
+			ok, err := engine.MVCCGetProto(context.Background(), store.Engine(), txnKey, hlc.Timestamp{}, true, nil, &txn)
 			if !ok || err != nil {
 				t.Fatalf("not found or err: %s", err)
 			}
@@ -1585,7 +1585,7 @@ func TestStoreResolveWriteIntentNoTxn(t *testing.T) {
 	// Read pushee's txn.
 	txnKey := keys.TransactionKey(pushee.Key, *pushee.ID)
 	var txn roachpb.Transaction
-	if ok, err := engine.MVCCGetProto(context.Background(), store.Engine(), txnKey, hlc.ZeroTimestamp, true, nil, &txn); !ok || err != nil {
+	if ok, err := engine.MVCCGetProto(context.Background(), store.Engine(), txnKey, hlc.Timestamp{}, true, nil, &txn); !ok || err != nil {
 		t.Fatalf("not found or err: %s", err)
 	}
 	if txn.Status != roachpb.ABORTED {
@@ -2186,12 +2186,11 @@ func TestStoreGCThreshold(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !gcThreshold.Equal(pgcThreshold) {
-			t.Fatal(errors.Errorf("persisted != in-memory threshold: %s vs %s",
-				pgcThreshold, gcThreshold))
+		if gcThreshold != pgcThreshold {
+			t.Fatalf("persisted != in-memory threshold: %s vs %s", pgcThreshold, gcThreshold)
 		}
-		if !pgcThreshold.Equal(ts) {
-			t.Fatal(errors.Errorf("expected timestamp %s, got %s", ts, pgcThreshold))
+		if pgcThreshold != ts {
+			t.Fatalf("expected timestamp %s, got %s", ts, pgcThreshold)
 		}
 	}
 

--- a/pkg/storage/timestamp_cache.go
+++ b/pkg/storage/timestamp_cache.go
@@ -625,7 +625,7 @@ func (tc *timestampCache) getMax(
 			ok = true
 			maxTS = ce.timestamp
 			maxTxnID = ce.txnID
-		} else if maxTS.Equal(ce.timestamp) && maxTxnID != nil &&
+		} else if maxTS == ce.timestamp && maxTxnID != nil &&
 			(ce.txnID == nil || *maxTxnID != *ce.txnID) {
 			maxTxnID = nil
 		}

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -372,7 +372,7 @@ func (tc *TestCluster) FindRangeLease(
 	if hint != nil {
 		var ok bool
 		if _, ok = rangeDesc.GetReplicaDescriptor(hint.StoreID); !ok {
-			return nil, hlc.ZeroTimestamp, errors.Errorf(
+			return nil, hlc.Timestamp{}, errors.Errorf(
 				"bad hint: %+v; store doesn't have a replica of the range", hint)
 		}
 	} else {
@@ -391,7 +391,7 @@ func (tc *TestCluster) FindRangeLease(
 		}
 	}
 	if hintServer == nil {
-		return nil, hlc.ZeroTimestamp, errors.Errorf("bad hint: %+v; no such node", hint)
+		return nil, hlc.Timestamp{}, errors.Errorf("bad hint: %+v; no such node", hint)
 	}
 	leaseReq := roachpb.LeaseInfoRequest{
 		Span: roachpb.Span{
@@ -409,7 +409,7 @@ func (tc *TestCluster) FindRangeLease(
 		},
 		&leaseReq)
 	if pErr != nil {
-		return nil, hlc.ZeroTimestamp, pErr.GoError()
+		return nil, hlc.Timestamp{}, pErr.GoError()
 	}
 	return leaseResp.(*roachpb.LeaseInfoResponse).Lease, hintServer.Clock().Now(), nil
 }

--- a/pkg/util/hlc/hlc_test.go
+++ b/pkg/util/hlc/hlc_test.go
@@ -87,16 +87,16 @@ func TestHLCEqual(t *testing.T) {
 	c := NewClock(m.UnixNano, time.Nanosecond)
 	a := c.Now()
 	b := a
-	if !a.Equal(b) {
+	if a != b {
 		t.Errorf("expected %+v == %+v", a, b)
 	}
 	m.Increment(1)
 	b = c.Now()
-	if a.Equal(b) {
+	if a == b {
 		t.Errorf("expected %+v < %+v", a, b)
 	}
 	a = c.Now() // add one to logical clock from b
-	if b.Equal(a) {
+	if b == a {
 		t.Errorf("expected %+v < %+v", b, a)
 	}
 }
@@ -141,11 +141,11 @@ func TestHLCClock(t *testing.T) {
 		default:
 			previous := c.Now()
 			current = c.Update(*step.input)
-			if current.Equal(previous) {
+			if current == previous {
 				t.Errorf("%d: clock not updated", i)
 			}
 		}
-		if !current.Equal(step.expected) {
+		if current != step.expected {
 			t.Fatalf("HLC error: %d expected %v, got %v", i, step.expected, current)
 		}
 	}

--- a/pkg/util/hlc/timestamp.go
+++ b/pkg/util/hlc/timestamp.go
@@ -28,18 +28,11 @@ var (
 	MaxTimestamp = Timestamp{WallTime: math.MaxInt64, Logical: math.MaxInt32}
 	// MinTimestamp is the min value allowed for Timestamp.
 	MinTimestamp = Timestamp{WallTime: 0, Logical: 1}
-	// ZeroTimestamp is an empty timestamp.
-	ZeroTimestamp = Timestamp{WallTime: 0, Logical: 0}
 )
 
 // Less compares two timestamps.
 func (t Timestamp) Less(s Timestamp) bool {
 	return t.WallTime < s.WallTime || (t.WallTime == s.WallTime && t.Logical < s.Logical)
-}
-
-// Equal returns whether two timestamps are the same.
-func (t Timestamp) Equal(s Timestamp) bool {
-	return t.WallTime == s.WallTime && t.Logical == s.Logical
 }
 
 func (t Timestamp) String() string {

--- a/pkg/util/hlc/timestamp_test.go
+++ b/pkg/util/hlc/timestamp_test.go
@@ -44,22 +44,6 @@ func TestLess(t *testing.T) {
 	}
 }
 
-func TestEqual(t *testing.T) {
-	a := Timestamp{}
-	b := Timestamp{}
-	if !a.Equal(b) {
-		t.Errorf("expected %+v == %+v", a, b)
-	}
-	b = makeTS(1, 0)
-	if a.Equal(b) {
-		t.Errorf("expected %+v < %+v", a, b)
-	}
-	a = makeTS(1, 1)
-	if b.Equal(a) {
-		t.Errorf("expected %+v < %+v", b, a)
-	}
-}
-
 func TestTimestampNext(t *testing.T) {
 	testCases := []struct {
 		ts, expNext Timestamp
@@ -70,7 +54,7 @@ func TestTimestampNext(t *testing.T) {
 		{makeTS(math.MaxInt32, math.MaxInt32), makeTS(math.MaxInt32+1, 0)},
 	}
 	for i, c := range testCases {
-		if next := c.ts.Next(); !next.Equal(c.expNext) {
+		if next := c.ts.Next(); next != c.expNext {
 			t.Errorf("%d: expected %s; got %s", i, c.expNext, next)
 		}
 	}
@@ -85,7 +69,7 @@ func TestTimestampPrev(t *testing.T) {
 		{makeTS(1, 0), makeTS(0, math.MaxInt32)},
 	}
 	for i, c := range testCases {
-		if prev := c.ts.Prev(); !prev.Equal(c.expPrev) {
+		if prev := c.ts.Prev(); prev != c.expPrev {
 			t.Errorf("%d: expected %s; got %s", i, c.expPrev, prev)
 		}
 	}


### PR DESCRIPTION
ZeroTimestamp has no semantic meaning; it is nearly always indicative
of an uninitialized value (the one exception being mvcc inline values).

Timestamp.Equal is replaced with a simple equality check.

For context, I ran into this when I was working with timestamps and was surprised to discover that ZeroTimestamp was almost always indicating a simple zero value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13652)
<!-- Reviewable:end -->
