### PR TITLE
testcluster: avoid hanging WaitForFullReplication

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -102,13 +102,6 @@ func backupRestoreTestSetup(
 
 	dir, dirCleanupFn := testutils.TempDir(t, 1)
 
-	// TODO(dan): Some tests don't need multiple nodes, but the test setup
-	// hangs with 1. Investigate.
-	if numAccounts == 0 && clusterSize < multiNode {
-		clusterSize = multiNode
-		t.Logf("setting cluster size to %d due to a bug", clusterSize)
-	}
-
 	tc = testcluster.StartTestCluster(t, clusterSize, base.TestClusterArgs{})
 	sqlDB = sqlutils.MakeSQLRunner(t, tc.Conns[0])
 


### PR DESCRIPTION
Tests that use testcluster with fewer than 3 nodes but also called WaitForFullReplication would hang forever.

Arguably you could skip TestCluster for a single-node test, but in practice its been easier just to parameterize a reusable helper with a number of nodes, which is sometimes set to 1.

All calls to WaitForFullReplication wanted to be skipped for clusters too small to achieve full replication, so just pulling the check in to WaitForFullReplication makes sense.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13657)
<!-- Reviewable:end -->
