### PR TITLE
client: avoid copying Batch Request slice in DB.Run and Txn.Run

### DIFF
--- a/pkg/internal/client/db.go
+++ b/pkg/internal/client/db.go
@@ -424,10 +424,7 @@ func sendAndFill(
 	// here to do because we want to run fillResults() so that the individual
 	// result gets initialized with an error from the corresponding call.
 	var ba roachpb.BatchRequest
-	// TODO(tschottdorf): this nonsensical copy is required since (at least at
-	// the time of writing, the chunking and masking in DistSender operates on
-	// the original data (as attested to by a whole bunch of test failures).
-	ba.Requests = append([]roachpb.RequestUnion(nil), b.reqs...)
+	ba.Requests = b.reqs
 	ba.Header = b.Header
 	b.response, b.pErr = send(ba)
 	if b.pErr != nil {


### PR DESCRIPTION
Since 078f91f we have performed a copy of all `[]roachpb.RequestUnion`s
passed to `client.sendAndFill`. This was because `DistSender` operated
on the original data during its request chunking logic. However, since
c217fce removed support for bounding scan requests, this has no longer
been the case. This copy is safe to take out, as attested to by the passing
tests that used to fail directly prior to c217fce without the copy.

The change reduces allocation count in KV benchmarks by about **.5%**, and
reduce total allocated memory in those benchmarks by anywhere from **1%**
to **6%**.

```
name                    old time/op    new time/op    delta
KVInsert1_Native-4         603µs ± 8%     573µs ± 5%  -5.09%  (p=0.000 n=40+39)
KVInsert1_SQL-4            514µs ±12%     506µs ± 9%    ~     (p=0.494 n=40+40)
KVInsert10_Native-4        661µs ±10%     689µs ± 9%  +4.27%  (p=0.000 n=40+40)
KVInsert10_SQL-4           693µs ± 6%     706µs ± 8%  +1.90%  (p=0.033 n=39+37)
KVInsert100_Native-4      1.67ms ±10%    1.71ms ± 8%  +2.04%  (p=0.025 n=40+40)
KVInsert100_SQL-4         2.25ms ± 6%    2.33ms ±15%    ~     (p=0.097 n=40+40)
KVInsert1000_Native-4     10.6ms ± 5%    10.1ms ± 5%  -4.44%  (p=0.000 n=40+39)
KVInsert1000_SQL-4        17.3ms ± 9%    17.2ms ± 7%    ~     (p=0.717 n=40+38)
KVInsert10000_Native-4     133ms ±11%     143ms ±10%  +7.48%  (p=0.000 n=40+40)
KVInsert10000_SQL-4        199ms ± 8%     202ms ±17%    ~     (p=0.429 n=40+40)
KVUpdate1_Native-4         971µs ± 9%     996µs ±12%  +2.57%  (p=0.041 n=38+40)
KVUpdate1_SQL-4            743µs ± 8%     735µs ± 6%    ~     (p=0.598 n=39+39)
KVUpdate10_Native-4       1.31ms ±10%    1.24ms ± 7%  -5.44%  (p=0.000 n=40+39)
KVUpdate10_SQL-4          1.08ms ±11%    1.12ms ± 9%  +3.35%  (p=0.001 n=40+40)
KVUpdate100_Native-4      3.71ms ± 4%    3.86ms ± 7%  +4.06%  (p=0.000 n=39+40)
KVUpdate100_SQL-4         3.95ms ± 9%    3.95ms ±13%    ~     (p=0.642 n=40+40)
KVUpdate1000_Native-4     27.6ms ± 8%    28.4ms ±16%    ~     (p=0.140 n=40+40)
KVUpdate1000_SQL-4        31.5ms ± 7%    30.7ms ± 4%  -2.53%  (p=0.000 n=38+40)
KVUpdate10000_Native-4     363ms ±15%     358ms ±10%    ~     (p=0.345 n=40+40)
KVUpdate10000_SQL-4        325ms ± 6%     327ms ± 7%    ~     (p=0.792 n=40+40)
KVDelete1_Native-4         584µs ±10%     579µs ± 9%    ~     (p=0.629 n=40+39)
KVDelete1_SQL-4            667µs ± 8%     654µs ± 5%  -2.00%  (p=0.029 n=40+30)
KVDelete10_Native-4        710µs ±11%     680µs ± 3%  -4.22%  (p=0.000 n=39+38)
KVDelete10_SQL-4           961µs ± 9%     932µs ± 7%  -3.09%  (p=0.004 n=40+39)
KVDelete100_Native-4      1.89ms ± 4%    1.96ms ±10%  +3.65%  (p=0.000 n=40+40)
KVDelete100_SQL-4         3.20ms ±10%    3.04ms ± 6%  -4.91%  (p=0.000 n=40+35)
KVDelete1000_Native-4     13.0ms ± 9%    12.5ms ± 8%  -3.35%  (p=0.000 n=40+40)
KVDelete1000_SQL-4        24.2ms ± 7%    24.2ms ± 9%    ~     (p=0.741 n=40+40)
KVDelete10000_Native-4     173ms ±11%     164ms ±13%  -4.93%  (p=0.000 n=39+40)
KVDelete10000_SQL-4        270ms ± 9%     266ms ±10%    ~     (p=0.143 n=40+40)
KVScan1_Native-4           357µs ± 6%     387µs ±15%  +8.24%  (p=0.001 n=40+40)
KVScan1_SQL-4              369µs ± 9%     361µs ± 6%  -2.06%  (p=0.005 n=37+37)
KVScan10_Native-4          397µs ±13%     402µs ±16%    ~     (p=0.531 n=39+39)
KVScan10_SQL-4             395µs ± 8%     383µs ± 6%  -2.99%  (p=0.000 n=37+34)
KVScan100_Native-4         610µs ± 9%     582µs ± 7%  -4.59%  (p=0.000 n=39+37)
KVScan100_SQL-4            676µs ± 9%     668µs ± 6%    ~     (p=0.550 n=40+40)
KVScan1000_Native-4       1.96ms ± 4%    2.03ms ± 7%  +3.76%  (p=0.000 n=40+40)
KVScan1000_SQL-4          2.99ms ± 7%    2.95ms ± 6%  -1.31%  (p=0.036 n=39+36)
KVScan10000_Native-4      20.0ms ± 4%    20.0ms ±10%    ~     (p=0.681 n=37+40)
KVScan10000_SQL-4         26.6ms ± 6%    26.1ms ± 4%  -1.76%  (p=0.001 n=39+39)

name                    old alloc/op   new alloc/op   delta
KVInsert1_Native-4        39.6kB ± 0%    39.0kB ± 0%  -1.40%  (p=0.000 n=40+31)
KVInsert1_SQL-4           46.0kB ± 0%    45.5kB ± 0%  -1.13%  (p=0.000 n=39+40)
KVInsert10_Native-4       96.2kB ± 0%    93.2kB ± 0%  -3.20%  (p=0.000 n=38+40)
KVInsert10_SQL-4           142kB ± 0%     139kB ± 1%  -2.28%  (p=0.000 n=40+40)
KVInsert100_Native-4       690kB ± 0%     662kB ± 0%  -3.97%  (p=0.000 n=40+40)
KVInsert100_SQL-4         1.12MB ± 0%    1.09MB ± 1%  -2.52%  (p=0.000 n=40+40)
KVInsert1000_Native-4     5.92MB ± 0%    5.66MB ± 0%  -4.44%  (p=0.000 n=37+32)
KVInsert1000_SQL-4        10.4MB ± 1%    10.2MB ± 1%  -2.52%  (p=0.000 n=40+40)
KVInsert10000_Native-4    95.7MB ± 0%    93.2MB ± 0%  -2.68%  (p=0.000 n=40+39)
KVInsert10000_SQL-4        132MB ± 2%     130MB ± 2%  -1.72%  (p=0.000 n=40+40)
KVUpdate1_Native-4        58.7kB ± 0%    57.9kB ± 0%  -1.32%  (p=0.000 n=40+39)
KVUpdate1_SQL-4           70.7kB ± 0%    69.9kB ± 0%  -1.09%  (p=0.000 n=40+39)
KVUpdate10_Native-4        154kB ± 0%     148kB ± 0%  -3.83%  (p=0.000 n=34+40)
KVUpdate10_SQL-4           147kB ± 0%     141kB ± 0%  -3.88%  (p=0.000 n=40+40)
KVUpdate100_Native-4      1.11MB ± 0%    1.06MB ± 0%  -4.95%  (p=0.000 n=35+40)
KVUpdate100_SQL-4          940kB ± 1%     885kB ± 1%  -5.86%  (p=0.000 n=40+40)
KVUpdate1000_Native-4     9.46MB ± 0%    8.94MB ± 0%  -5.55%  (p=0.000 n=39+39)
KVUpdate1000_SQL-4        8.21MB ± 1%    7.68MB ± 1%  -6.41%  (p=0.000 n=40+40)
KVUpdate10000_Native-4     157MB ± 0%     152MB ± 0%  -3.26%  (p=0.000 n=40+40)
KVUpdate10000_SQL-4        113MB ± 1%     108MB ± 1%  -4.43%  (p=0.000 n=40+40)
KVDelete1_Native-4        39.1kB ± 0%    38.6kB ± 0%  -1.31%  (p=0.000 n=40+40)
KVDelete1_SQL-4           60.7kB ± 0%    60.0kB ± 0%  -1.27%  (p=0.000 n=40+40)
KVDelete10_Native-4       88.5kB ± 0%    85.4kB ± 0%  -3.48%  (p=0.000 n=38+38)
KVDelete10_SQL-4           132kB ± 0%     126kB ± 0%  -4.38%  (p=0.000 n=40+40)
KVDelete100_Native-4       602kB ± 0%     574kB ± 0%  -4.54%  (p=0.000 n=37+38)
KVDelete100_SQL-4          874kB ± 0%     819kB ± 0%  -6.26%  (p=0.000 n=40+40)
KVDelete1000_Native-4     5.05MB ± 0%    4.79MB ± 0%  -5.19%  (p=0.000 n=37+37)
KVDelete1000_SQL-4        7.59MB ± 1%    7.05MB ± 1%  -7.09%  (p=0.000 n=39+39)
KVDelete10000_Native-4    87.0MB ± 0%    84.4MB ± 0%  -2.95%  (p=0.000 n=39+39)
KVDelete10000_SQL-4        115MB ± 0%     110MB ± 0%  -4.45%  (p=0.000 n=39+39)
KVScan1_Native-4          20.9kB ± 0%    20.6kB ± 0%  -1.16%  (p=0.000 n=40+40)
KVScan1_SQL-4             32.1kB ± 0%    31.9kB ± 0%  -0.80%  (p=0.000 n=38+40)
KVScan10_Native-4         26.8kB ± 0%    26.5kB ± 0%  -1.01%  (p=0.000 n=38+40)
KVScan10_SQL-4            35.0kB ± 0%    34.7kB ± 0%  -0.74%  (p=0.000 n=35+40)
KVScan100_Native-4        77.8kB ± 0%    77.5kB ± 0%  -0.37%  (p=0.000 n=30+40)
KVScan100_SQL-4           67.5kB ± 0%    67.2kB ± 0%  -0.38%  (p=0.000 n=37+38)
KVScan1000_Native-4        534kB ± 0%     534kB ± 0%  -0.05%  (p=0.000 n=38+39)
KVScan1000_SQL-4           365kB ± 0%     365kB ± 0%  -0.09%  (p=0.000 n=32+39)
KVScan10000_Native-4      8.86MB ± 0%    8.86MB ± 0%    ~     (p=0.888 n=36+36)
KVScan10000_SQL-4         5.26MB ± 0%    5.26MB ± 0%  -0.04%  (p=0.005 n=40+40)

name                    old allocs/op  new allocs/op  delta
KVInsert1_Native-4           322 ± 0%       320 ± 0%  -0.52%  (p=0.000 n=40+31)
KVInsert1_SQL-4              335 ± 1%       334 ± 1%    ~     (p=0.168 n=40+40)
KVInsert10_Native-4          515 ± 0%       514 ± 0%  -0.23%  (p=0.000 n=26+40)
KVInsert10_SQL-4             649 ± 6%       638 ± 7%  -1.79%  (p=0.029 n=40+40)
KVInsert100_Native-4       2.23k ± 1%     2.22k ± 0%    ~     (p=0.066 n=40+39)
KVInsert100_SQL-4          3.49k ±11%     3.42k ±12%    ~     (p=0.124 n=40+40)
KVInsert1000_Native-4      19.4k ± 1%     19.3k ± 2%  -0.93%  (p=0.006 n=40+40)
KVInsert1000_SQL-4         31.4k ±12%     31.5k ±12%    ~     (p=0.844 n=40+40)
KVInsert10000_Native-4      190k ± 0%      190k ± 0%  +0.02%  (p=0.001 n=40+36)
KVInsert10000_SQL-4         309k ±13%      310k ±13%    ~     (p=0.851 n=40+40)
KVUpdate1_Native-4           539 ± 0%       537 ± 0%  -0.37%  (p=0.000 n=40+40)
KVUpdate1_SQL-4              636 ± 1%       635 ± 1%  -0.28%  (p=0.005 n=40+40)
KVUpdate10_Native-4          869 ± 0%       864 ± 1%  -0.62%  (p=0.000 n=34+40)
KVUpdate10_SQL-4           1.01k ± 4%     1.01k ± 4%    ~     (p=0.126 n=40+40)
KVUpdate100_Native-4       3.78k ± 0%     3.77k ± 0%  -0.12%  (p=0.000 n=39+35)
KVUpdate100_SQL-4          4.50k ± 8%     4.47k ± 9%    ~     (p=0.488 n=40+40)
KVUpdate1000_Native-4      32.8k ± 1%     32.8k ± 1%  -0.07%  (p=0.001 n=40+40)
KVUpdate1000_SQL-4         39.1k ±10%     38.7k ±10%    ~     (p=0.532 n=40+40)
KVUpdate10000_Native-4      331k ± 5%      332k ± 5%    ~     (p=0.419 n=40+40)
KVUpdate10000_SQL-4         405k ±11%      411k ±12%    ~     (p=0.564 n=40+40)
KVDelete1_Native-4           318 ± 0%       317 ± 1%  -0.29%  (p=0.000 n=40+40)
KVDelete1_SQL-4              501 ± 0%       499 ± 0%  -0.39%  (p=0.000 n=40+40)
KVDelete10_Native-4          473 ± 0%       472 ± 0%  -0.14%  (p=0.000 n=39+33)
KVDelete10_SQL-4             846 ± 0%       844 ± 0%  -0.25%  (p=0.000 n=40+40)
KVDelete100_Native-4       1.81k ± 0%     1.81k ± 0%  -0.16%  (p=0.000 n=38+39)
KVDelete100_SQL-4          3.98k ± 0%     3.97k ± 0%  -0.09%  (p=0.000 n=39+39)
KVDelete1000_Native-4      15.2k ± 1%     15.2k ± 1%    ~     (p=0.418 n=39+39)
KVDelete1000_SQL-4         34.9k ± 0%     34.9k ± 0%  -0.12%  (p=0.021 n=40+40)
KVDelete10000_Native-4      149k ± 0%      149k ± 0%  -0.00%  (p=0.001 n=39+36)
KVDelete10000_SQL-4         354k ± 0%      354k ± 0%    ~     (p=0.396 n=40+39)
KVScan1_Native-4             229 ± 0%       229 ± 0%  -0.31%  (p=0.000 n=40+40)
KVScan1_SQL-4                268 ± 1%       267 ± 0%  -0.49%  (p=0.000 n=40+33)
KVScan10_Native-4            256 ± 0%       255 ± 0%  -0.49%  (p=0.000 n=38+40)
KVScan10_SQL-4               309 ± 0%       307 ± 0%  -0.44%  (p=0.000 n=40+40)
KVScan100_Native-4           446 ± 0%       445 ± 0%  -0.31%  (p=0.000 n=31+40)
KVScan100_SQL-4              695 ± 0%       693 ± 0%  -0.16%  (p=0.000 n=40+40)
KVScan1000_Native-4        2.28k ± 0%     2.28k ± 0%  -0.04%  (p=0.000 n=40+39)
KVScan1000_SQL-4           4.53k ± 0%     4.53k ± 0%  -0.03%  (p=0.000 n=31+31)
KVScan10000_Native-4       20.6k ± 1%     20.6k ± 2%    ~     (p=0.303 n=35+35)
KVScan10000_SQL-4          44.0k ± 3%     43.9k ± 3%    ~     (p=0.191 n=40+40)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13660)
<!-- Reviewable:end -->
