### PR TITLE
sql: order users in SHOW USERS

### DIFF
--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -816,7 +816,7 @@ func (p *planner) ShowTables(n *parser.ShowTables) (planNode, error) {
 // ShowUsers returns all the users.
 // Privileges: SELECT on system.users.
 func (p *planner) ShowUsers(n *parser.ShowUsers) (planNode, error) {
-	stmt, err := parser.ParseOneTraditional(`SELECT username FROM system.users`)
+	stmt, err := parser.ParseOneTraditional(`SELECT username FROM system.users ORDER BY 1`)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Without DistSQL, these are automatically ordered. With distsql, not necessarily.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13661)
<!-- Reviewable:end -->
