### PR TITLE
build: Don't parallelize memory-intensive style tests

### DIFF
--- a/build/style_test.go
+++ b/build/style_test.go
@@ -538,7 +538,7 @@ func TestStyle(t *testing.T) {
 	}
 
 	t.Run("TestErrCheck", func(t *testing.T) {
-		t.Parallel()
+		// errcheck uses 1GB of ram (as of 2017-02-18), so don't parallelize it.
 		cmd, stderr, filter, err := dirCmd(
 			pkg.Dir,
 			"errcheck",
@@ -568,7 +568,7 @@ func TestStyle(t *testing.T) {
 	})
 
 	t.Run("TestReturnCheck", func(t *testing.T) {
-		t.Parallel()
+		// returncheck uses 1GB of ram (as of 2017-02-18), so don't parallelize it.
 		cmd, stderr, filter, err := dirCmd(pkg.Dir, "returncheck", pkgScope)
 		if err != nil {
 			t.Fatal(err)
@@ -652,7 +652,7 @@ func TestStyle(t *testing.T) {
 		if testing.Short() {
 			t.Skip("short flag")
 		}
-		t.Parallel()
+		// metacheck uses 2.5GB of ram (as of 2017-02-18), so don't parallelize it.
 		cmd, stderr, filter, err := dirCmd(
 			pkg.Dir,
 			"metacheck",


### PR DESCRIPTION
Metacheck uses 2.5GB RAM (!) and errcheck and returncheck are over 1GB each,
so only run one of them at a time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13667)
<!-- Reviewable:end -->
