### PR TITLE
storage: Rename misleading preemptiveSnapshotError

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2041,7 +2041,7 @@ func TestRemovePlaceholderRace(t *testing.T) {
 					},
 					repl.Desc(),
 				); err != nil {
-					if storage.IsPreemptiveSnapshotError(err) {
+					if storage.IsSnapshotError(err) {
 						continue
 					} else {
 						t.Fatal(err)
@@ -3142,12 +3142,12 @@ func TestFailedPreemptiveSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	const expErr = "aborted due to failed preemptive snapshot: unknown peer 3"
+	const expErr = "snapshot failed: unknown peer 3"
 	if err := rep.ChangeReplicas(context.Background(), roachpb.ADD_REPLICA,
 		roachpb.ReplicaDescriptor{NodeID: 3, StoreID: 3},
 		rep.Desc()); !testutils.IsError(err, expErr) {
 		t.Fatalf("expected %s; got %v", expErr, err)
-	} else if !storage.IsPreemptiveSnapshotError(err) {
+	} else if !storage.IsSnapshotError(err) {
 		t.Fatalf("expected preemptive snapshot failed error; got %T: %v", err, err)
 	}
 }

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -997,7 +997,7 @@ func (m *multiTestContext) changeReplicasLocked(
 			// and call ChangeReplicas on that replica, instead of calling
 			// it on an arbitrary replica and catching this failure.
 			continue
-		} else if storage.IsPreemptiveSnapshotError(err) {
+		} else if storage.IsSnapshotError(err) {
 			continue
 		} else {
 			return 0, err

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -3064,18 +3064,18 @@ func (r *Replica) changeReplicasTrigger(
 	return pd
 }
 
-type preemptiveSnapshotError struct {
+type snapshotError struct {
 	cause error
 }
 
-func (s *preemptiveSnapshotError) Error() string {
-	return s.cause.Error()
+func (s *snapshotError) Error() string {
+	return fmt.Sprintf("snapshot failed: %s", s.cause.Error())
 }
 
-// IsPreemptiveSnapshotError returns true iff the error indicates a preemptive
+// IsSnapshotError returns true iff the error indicates a preemptive
 // snapshot failed.
-func IsPreemptiveSnapshotError(err error) bool {
-	_, ok := err.(*preemptiveSnapshotError)
+func IsSnapshotError(err error) bool {
+	_, ok := err.(*snapshotError)
 	return ok
 }
 
@@ -3368,9 +3368,7 @@ func (r *Replica) sendSnapshot(
 	}
 	if err := r.store.cfg.Transport.SendSnapshot(
 		ctx, r.store.allocator.storePool, req, snap, r.store.Engine().NewBatch, sent); err != nil {
-		return &preemptiveSnapshotError{
-			errors.Wrapf(err, "%s: change replicas aborted due to failed preemptive snapshot", r),
-		}
+		return &snapshotError{err}
 	}
 	return nil
 }

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -218,7 +218,7 @@ func (rq *replicateQueue) process(
 	// reservation could not be made with the selected target.
 	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 		if requeue, err := rq.processOneChange(ctx, repl, sysCfg); err != nil {
-			if IsPreemptiveSnapshotError(err) {
+			if IsSnapshotError(err) {
 				// If ChangeReplicas failed because the preemptive snapshot failed, we
 				// log the error but then return success indicating we should retry the
 				// operation. The most likely causes of the preemptive snapshot failing are


### PR DESCRIPTION
This error is now used for both raft and preemptive snapshots.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13668)
<!-- Reviewable:end -->
