### PR TITLE
timeutil: Clear t.C when clearing t.timer

### DIFF
--- a/pkg/util/timeutil/timer.go
+++ b/pkg/util/timeutil/timer.go
@@ -105,8 +105,8 @@ func (t *Timer) Stop() bool {
 			// it. Otherwise, we'd have to read from the channel if !t.Read.
 			timeTimerPool.Put(t.timer)
 		}
-		t.timer = nil
 	}
+	*t = Timer{}
 	timerPool.Put(t)
 	return res
 }


### PR DESCRIPTION
Without this change, if a timer is used without immediately being
Reset, the timer could "fire" immediately if an unconsumed value
has been left in the channel.

This is responsible for the recent increase in flakiness in
TestSplitSnapshotRace_SnapshotWins (#12753), although it doesn't
resolve that issue since there is a separate less-frequent flake.
The issue was discovered while bisecting failures of that test.

I'm currently stressing other tests that became flaky around this time to see if it fixes any of them. (#13502, #13503, #13504, #13508, #13525)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13676)
<!-- Reviewable:end -->
