### PR TITLE
sql: validate new FK constraints; learn NOT VALID

### DIFF
--- a/pkg/sql/testdata/alter_table
+++ b/pkg/sql/testdata/alter_table
@@ -560,3 +560,6 @@ ALTER TABLE privsview ADD d INT
 
 statement error pgcode 42809 "privsview" is not a table
 ALTER TABLE privsview SPLIT AT (42)
+
+statement error constraint cannot be marked NOT VALID
+ALTER TABLE privs ADD CONSTRAINT bar UNIQUE (c) NOT VALID

--- a/pkg/sql/testdata/fk
+++ b/pkg/sql/testdata/fk
@@ -189,8 +189,11 @@ ALTER TABLE delivery DROP CONSTRAINT fk_item_ref_products
 statement ok
 UPDATE products SET upc = 'blah' WHERE sku = '780'
 
-statement ok
+statement error foreign key violation: "delivery" row item='885155001450' has no match in "products"
 ALTER TABLE delivery ADD FOREIGN KEY (item) REFERENCES products (upc)
+
+statement ok
+ALTER TABLE delivery ADD FOREIGN KEY (item) REFERENCES products (upc) NOT VALID
 
 query TTTTT
 SHOW CONSTRAINTS FROM delivery
@@ -232,7 +235,7 @@ INSERT INTO "user content"."customer reviews" (id, product, body, "order") VALUE
 
 statement ok
 ALTER TABLE "user content"."customer reviews"
-  ADD CONSTRAINT orderfk2 FOREIGN KEY ("order", shipment) REFERENCES orders (id, shipment)
+  ADD CONSTRAINT orderfk2 FOREIGN KEY ("order", shipment) REFERENCES orders (id, shipment) NOT VALID
 
 statement error missing value for column "shipment" in multi-part foreign key
 INSERT INTO "user content"."customer reviews" (id, product, body, "order") VALUES (4, '780', 'i ordered 101 of them', 9)


### PR DESCRIPTION
`ALTER TABLE ADD FOREIGN KEY` now validates the foreign key constraint
before adding it as expected.

In addition, the `NOT VALID` syntax for adding constraints is no longer
ignored - if specified for `ADD FOREIGN KEY`, the constraint will not be
validated like the previous default behavior. `NOT VALID` is only
supported for `ADD FOREIGN KEY` - using it in other add constraint
statements will return a not supported error. More details on this
syntax are available in the PostgreSQL `ALTER TABLE` documentation:
https://www.postgresql.org/docs/9.6/static/sql-altertable.html

cc @nvanbenschoten

Resolves #8855.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13681)
<!-- Reviewable:end -->
