### PR TITLE
sql: fix panic on unsupported savepoint operations

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1071,6 +1071,7 @@ func (e *Executor) execStmtInOpenTxn(
 			return e.noTransactionHelper(txnState)
 		}
 		if err := parser.ValidateRestartCheckpoint(s.Savepoint); err != nil {
+			txnState.updateStateAndCleanupOnErr(err, e)
 			return Result{}, err
 		}
 		// ReleaseSavepoint is executed fully here; there's no planNode for it
@@ -1094,6 +1095,7 @@ func (e *Executor) execStmtInOpenTxn(
 			return e.noTransactionHelper(txnState)
 		}
 		if err := parser.ValidateRestartCheckpoint(s.Name); err != nil {
+			txnState.updateStateAndCleanupOnErr(err, e)
 			return Result{}, err
 		}
 		// We want to disallow SAVEPOINTs to be issued after a transaction has

--- a/pkg/sql/testdata/txn
+++ b/pkg/sql/testdata/txn
@@ -546,3 +546,31 @@ Open
 
 statement ok
 COMMIT
+
+# General savepoints
+statement ok
+BEGIN TRANSACTION
+
+statement error SAVEPOINT not supported except for COCKROACH_RESTART
+SAVEPOINT other
+
+statement ok
+ROLLBACK
+
+statement ok
+BEGIN TRANSACTION
+
+statement error SAVEPOINT not supported except for COCKROACH_RESTART
+RELEASE SAVEPOINT other
+
+statement ok
+ROLLBACK
+
+statement ok
+BEGIN TRANSACTION
+
+statement error SAVEPOINT not supported except for COCKROACH_RESTART
+ROLLBACK TO SAVEPOINT other
+
+statement ok
+ROLLBACK


### PR DESCRIPTION
Previously, the transaction was not correctly aborted if a savepoint was
created or released that wasn't the special `COCKROACH_RESTART`
savepoint.

Resolves #13545.

cc @tschottdorf

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13694)
<!-- Reviewable:end -->
