### PR TITLE
storage: use RWMutex for {Store,Replica}.mu

### DIFF
--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -466,9 +466,9 @@ func evalBeginTransaction(
 		}
 	}
 
-	r.mu.Lock()
+	r.mu.RLock()
 	threshold := r.mu.state.TxnSpanGCThreshold
-	r.mu.Unlock()
+	r.mu.RUnlock()
 
 	// Disallow creation of a transaction record if it's at a timestamp before
 	// the TxnSpanGCThreshold, as in that case our transaction may already have
@@ -1206,14 +1206,14 @@ func evalGC(
 		return EvalResult{}, err
 	}
 
-	r.mu.Lock()
+	r.mu.RLock()
 	newThreshold := r.mu.state.GCThreshold
 	newTxnSpanGCThreshold := r.mu.state.TxnSpanGCThreshold
 	// Protect against multiple GC requests arriving out of order; we track
 	// the maximum timestamps.
 	newThreshold.Forward(args.Threshold)
 	newTxnSpanGCThreshold.Forward(args.TxnSpanGCThreshold)
-	r.mu.Unlock()
+	r.mu.RUnlock()
 
 	var pd EvalResult
 	pd.Replicated.State.GCThreshold = newThreshold
@@ -1937,9 +1937,9 @@ func (r *Replica) getChecksum(ctx context.Context, id uuid.UUID) (replicaChecksu
 	if log.V(1) {
 		log.Infof(ctx, "waited for compute checksum for %s", timeutil.Since(now))
 	}
-	r.mu.Lock()
+	r.mu.RLock()
 	c, ok = r.mu.checksums[id]
-	r.mu.Unlock()
+	r.mu.RUnlock()
 	if !ok {
 		return replicaChecksum{}, errors.Errorf("no map entry for checksum (ID = %s)", id)
 	}

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -506,7 +506,7 @@ func (r *Replica) handleReplicatedEvalResult(
 	if rResult.State.LeaseAppliedIndex != 0 {
 		r.mu.state.LeaseAppliedIndex = rResult.State.LeaseAppliedIndex
 	}
-	needsSplitBySize := r.needsSplitBySizeLocked()
+	needsSplitBySize := r.needsSplitBySizeRLocked()
 	r.mu.Unlock()
 
 	r.store.metrics.addMVCCStats(rResult.Delta)

--- a/pkg/storage/replica_raftstorage_test.go
+++ b/pkg/storage/replica_raftstorage_test.go
@@ -104,7 +104,7 @@ func TestSkipLargeReplicaSnapshot(t *testing.T) {
 		t.Fatalf(
 			"snapshot of a very large range (%d / %d, needsSplit: %v, exceeds snap limit: %v) should fail but got %v",
 			after, rep.GetMaxBytes(),
-			rep.needsSplitBySize(), rep.exceedsDoubleSplitSizeLocked(), err,
+			rep.needsSplitBySize(), rep.exceedsDoubleSplitSizeRLocked(), err,
 		)
 	}
 }

--- a/pkg/storage/replica_range_lease.go
+++ b/pkg/storage/replica_range_lease.go
@@ -390,7 +390,7 @@ func (r *Replica) requestLeaseLocked(ctx context.Context, status LeaseStatus) <-
 		r.store.TestingKnobs().LeaseRequestEvent(status.timestamp)
 	}
 	// Propose a Raft command to get a lease for this replica.
-	repDesc, err := r.getReplicaDescriptorLocked()
+	repDesc, err := r.getReplicaDescriptorRLocked()
 	if err != nil {
 		llChan := make(chan *roachpb.Error, 1)
 		llChan <- roachpb.NewError(err)
@@ -456,7 +456,7 @@ func (r *Replica) AdminTransferLease(ctx context.Context, target roachpb.StoreID
 
 		if nextLease, ok := r.mu.pendingLeaseRequest.RequestPending(); ok &&
 			nextLease.Replica != nextLeaseHolder {
-			repDesc, err := r.getReplicaDescriptorLocked()
+			repDesc, err := r.getReplicaDescriptorRLocked()
 			if err != nil {
 				return nil, nil, err
 			}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -396,8 +396,6 @@ func TestReplicaContains(t *testing.T) {
 
 	// This test really only needs a hollow shell of a Replica.
 	r := &Replica{}
-	r.mu.timedMutex = makeTimedMutex(defaultMuLogger)
-	r.cmdQMu.timedMutex = makeTimedMutex(defaultMuLogger)
 	r.mu.state.Desc = desc
 	r.rangeStr.store(0, desc)
 
@@ -569,7 +567,7 @@ func TestBehaviorDuringLeaseTransfer(t *testing.T) {
 	<-transferSem
 	// Check that a transfer is indeed on-going.
 	tc.repl.mu.Lock()
-	repDesc, err := tc.repl.getReplicaDescriptorLocked()
+	repDesc, err := tc.repl.getReplicaDescriptorRLocked()
 	if err != nil {
 		tc.repl.mu.Unlock()
 		t.Fatal(err)

--- a/pkg/storage/scanner_test.go
+++ b/pkg/storage/scanner_test.go
@@ -56,8 +56,6 @@ func newTestRangeSet(count int, t *testing.T) *testRangeSet {
 		repl := &Replica{
 			RangeID: desc.RangeID,
 		}
-		repl.mu.timedMutex = makeTimedMutex(defaultMuLogger)
-		repl.cmdQMu.timedMutex = makeTimedMutex(defaultMuLogger)
 		repl.mu.state.Stats = enginepb.MVCCStats{
 			KeyBytes:  1,
 			ValBytes:  2,

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2356,7 +2356,7 @@ func (s *Store) LeaseCount() int {
 
 	var leaseCount int
 	newStoreReplicaVisitor(s).Visit(func(r *Replica) bool {
-		if r.hasLease(now) {
+		if r.ownsValidLease(now) {
 			leaseCount++
 		}
 		return true

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -93,8 +93,6 @@ const (
 
 	defaultGossipWhenCapacityDeltaExceedsFraction = 0.01
 
-	defaultStoreMutexWarnThreshold = 100 * time.Millisecond
-
 	// systemDataGossipInterval is the interval at which range lease
 	// holders verify that the most recent system data is gossiped.
 	// This ensures that system data is always eventually gossiped, even
@@ -323,12 +321,12 @@ func (rs *storeReplicaVisitor) Visit(visitor func(*Replica) bool) {
 	// Copy the range IDs to a slice so that we iterate over some (possibly
 	// stale) consistent view of all Replicas without holding the Store lock.
 	// In particular, no locks are acquired during the copy process.
-	rs.store.mu.Lock()
+	rs.store.mu.RLock()
 	rs.repls = make([]*Replica, 0, len(rs.store.mu.replicas))
 	for _, repl := range rs.store.mu.replicas {
 		rs.repls = append(rs.repls, repl)
 	}
-	rs.store.mu.Unlock()
+	rs.store.mu.RUnlock()
 
 	// The Replicas are already in "unspecified order" due to map iteration,
 	// but we want to make sure it's completely random to prevent issues in
@@ -346,10 +344,10 @@ func (rs *storeReplicaVisitor) Visit(visitor func(*Replica) bool) {
 		// destroyed once we return errors from mutexes (#9190). After all, it
 		// can still happen with this code.
 		rs.visited++
-		repl.mu.Lock()
+		repl.mu.RLock()
 		destroyed := repl.mu.destroyed
-		initialized := repl.isInitializedLocked()
-		repl.mu.Unlock()
+		initialized := repl.isInitializedRLocked()
+		repl.mu.RUnlock()
 		if initialized && destroyed == nil && !visitor(repl) {
 			break
 		}
@@ -363,8 +361,8 @@ func (rs *storeReplicaVisitor) Visit(visitor func(*Replica) bool) {
 // TODO(tschottdorf): this method has highly doubtful semantics.
 func (rs *storeReplicaVisitor) EstimatedCount() int {
 	if rs.visited <= 0 {
-		rs.store.mu.Lock()
-		defer rs.store.mu.Unlock()
+		rs.store.mu.RLock()
+		defer rs.store.mu.RUnlock()
 		return len(rs.store.mu.replicas)
 	}
 	return len(rs.repls) - rs.visited
@@ -527,8 +525,7 @@ type Store struct {
 	// modified by a concurrent HandleRaftRequest. (#4476)
 
 	mu struct {
-		// TODO(peter): evaluate runtime overhead of the timed mutex.
-		timedMutex // Protects all variables in the mu struct.
+		syncutil.RWMutex
 		// Map of replicas by Range ID. This includes `uninitReplicas`.
 		replicas map[roachpb.RangeID]*Replica
 		// A btree key containing objects of type *Replica or
@@ -897,15 +894,6 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 	s.draining.Store(false)
 	s.scheduler = newRaftScheduler(s.cfg.AmbientCtx, s.metrics, s, storeSchedulerConcurrency)
 
-	storeMuLogger := thresholdLogger(
-		s.AnnotateCtx(context.Background()),
-		defaultStoreMutexWarnThreshold,
-		func(ctx context.Context, msg string, args ...interface{}) {
-			log.Warningf(ctx, "storeMu: "+msg, args...)
-		},
-	)
-	s.mu.timedMutex = makeTimedMutex(storeMuLogger)
-
 	s.coalescedMu.Lock()
 	s.coalescedMu.heartbeats = map[roachpb.StoreIdent][]RaftHeartbeat{}
 	s.coalescedMu.heartbeatResponses = map[roachpb.StoreIdent][]RaftHeartbeat{}
@@ -1192,9 +1180,9 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		var wg sync.WaitGroup // wait for unfreeze goroutines
 		var unfrozen int64    // updated atomically
 		newStoreReplicaVisitor(s).Visit(func(r *Replica) bool {
-			r.mu.Lock()
+			r.mu.RLock()
 			frozen := r.mu.state.IsFrozen()
-			r.mu.Unlock()
+			r.mu.RUnlock()
 			if !frozen {
 				return true
 			}
@@ -1613,8 +1601,8 @@ func (s *Store) NotifyBootstrapped() {
 
 // GetReplica fetches a replica by Range ID. Returns an error if no replica is found.
 func (s *Store) GetReplica(rangeID roachpb.RangeID) (*Replica, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.getReplicaLocked(rangeID)
 }
 
@@ -1632,8 +1620,8 @@ func (s *Store) getReplicaLocked(rangeID roachpb.RangeID) (*Replica, error) {
 // using Key.Address() to ensure we lookup replicas correctly for local
 // keys. When end is nil, a replica that contains start is looked up.
 func (s *Store) LookupReplica(start, end roachpb.RKey) *Replica {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
 	var repl *Replica
 	s.visitReplicasLocked(start, roachpb.RKeyMax, func(replIter *Replica) bool {
@@ -1698,8 +1686,8 @@ func (s *Store) visitReplicasLocked(startKey, endKey roachpb.RKey, iterator func
 // RaftStatus returns the current raft status of the local replica of
 // the given range.
 func (s *Store) RaftStatus(rangeID roachpb.RangeID) *raft.Status {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	if r, ok := s.mu.replicas[rangeID]; ok {
 		return r.RaftStatus()
 	}
@@ -2029,13 +2017,13 @@ func (s *Store) maybeMergeTimestampCaches(
 	// lease holders must be colocated and the subsumed range appropriately
 	// quiesced. See also #2433.
 	now := s.Clock().Now()
-	if subsumedRep.isLeaseValidLocked(subsumedLease, now) &&
+	if subsumedRep.isLeaseValidRLocked(subsumedLease, now) &&
 		subsumingLease.Replica.StoreID != subsumedLease.Replica.StoreID {
 		log.Fatalf(ctx, "cannot merge ranges with non-colocated leases. "+
 			"Subsuming lease: %s. Subsumed lease: %s.", subsumingLease, subsumedLease)
 	}
 
-	if subsumingRep.isLeaseValidLocked(subsumingLease, now) &&
+	if subsumingRep.isLeaseValidRLocked(subsumingLease, now) &&
 		subsumingLease.OwnedBy(s.StoreID()) {
 		subsumedRep.mu.tsCache.MergeInto(subsumingRep.mu.tsCache, false /* clear */)
 	}
@@ -2166,6 +2154,7 @@ func (s *Store) removeReplicaImpl(
 			rep, repDesc.ReplicaID, consistentDesc.NextReplicaID)
 	}
 
+	// TODO(peter): Could use s.mu.RLock here?
 	s.mu.Lock()
 	if _, err := s.getReplicaLocked(rep.RangeID); err != nil {
 		s.mu.Unlock()
@@ -2215,6 +2204,7 @@ func (s *Store) removeReplicaImpl(
 		log.Fatalf(ctx, "unexpectedly overlapped by %v", placeholder)
 	}
 	delete(s.mu.replicaPlaceholders, rep.RangeID)
+	// TODO(peter): Could release s.mu.Lock() here.
 	s.maybeGossipOnCapacityChange(ctx, rangeChangeEvent)
 	s.scanner.RemoveReplica(rep)
 	return nil
@@ -2326,19 +2316,19 @@ func (s *Store) deadReplicas() roachpb.StoreDeadReplicas {
 	// processing.
 	// TODO(bram): does this need to visit all the replicas? Could we just use the
 	// store pool to locate any dead replicas on this store directly?
-	s.mu.Lock()
+	s.mu.RLock()
 	replicas := make([]*Replica, 0, len(s.mu.replicas))
 	for _, repl := range s.mu.replicas {
 		replicas = append(replicas, repl)
 	}
-	s.mu.Unlock()
+	s.mu.RUnlock()
 
 	var deadReplicas []roachpb.ReplicaIdent
 	for _, r := range replicas {
-		r.mu.Lock()
+		r.mu.RLock()
 		corrupted := r.mu.corrupted
 		desc := r.mu.state.Desc
-		r.mu.Unlock()
+		r.mu.RUnlock()
 		replicaDesc, ok := desc.GetReplicaDescriptor(s.Ident.StoreID)
 		if ok && corrupted {
 			deadReplicas = append(deadReplicas, roachpb.ReplicaIdent{
@@ -2355,8 +2345,8 @@ func (s *Store) deadReplicas() roachpb.StoreDeadReplicas {
 
 // ReplicaCount returns the number of replicas contained by this store.
 func (s *Store) ReplicaCount() int {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return len(s.mu.replicas)
 }
 
@@ -2513,9 +2503,9 @@ func (s *Store) Send(
 			return nil, roachpb.NewError(err)
 		}
 		if !repl.IsInitialized() {
-			repl.mu.Lock()
+			repl.mu.RLock()
 			replicaID := repl.mu.replicaID
-			repl.mu.Unlock()
+			repl.mu.RUnlock()
 
 			// If we have an uninitialized copy of the range, then we are
 			// probably a valid member of the range, we're just in the
@@ -3405,9 +3395,9 @@ func (s *Store) processRequestQueue(rangeID roachpb.RangeID) {
 func (s *Store) processReady(rangeID roachpb.RangeID) {
 	start := timeutil.Now()
 
-	s.mu.Lock()
+	s.mu.RLock()
 	r, ok := s.mu.replicas[rangeID]
-	s.mu.Unlock()
+	s.mu.RUnlock()
 
 	if ok {
 		stats, err := r.handleRaftReady(IncomingSnapshot{})
@@ -3446,9 +3436,9 @@ func (s *Store) processReady(rangeID roachpb.RangeID) {
 func (s *Store) processTick(rangeID roachpb.RangeID) bool {
 	start := timeutil.Now()
 
-	s.mu.Lock()
+	s.mu.RLock()
 	r, ok := s.mu.replicas[rangeID]
-	s.mu.Unlock()
+	s.mu.RUnlock()
 
 	var exists bool
 	if ok {
@@ -3490,11 +3480,11 @@ func (s *Store) raftTickLoop() {
 			case <-ticker.C:
 				rangeIDs = rangeIDs[:0]
 
-				s.mu.Lock()
+				s.mu.RLock()
 				for rangeID := range s.mu.replicas {
 					rangeIDs = append(rangeIDs, rangeID)
 				}
-				s.mu.Unlock()
+				s.mu.RUnlock()
 
 				s.scheduler.EnqueueRaftTick(rangeIDs...)
 				s.metrics.RaftTicks.Inc(1)
@@ -3566,7 +3556,7 @@ func (s *Store) sendQueuedHeartbeatsToNode(beats, resps []RaftHeartbeat, to roac
 	}
 
 	if !s.cfg.Transport.SendAsync(chReq) {
-		s.mu.Lock()
+		s.mu.RLock()
 		for _, beat := range beats {
 			if replica, ok := s.mu.replicas[beat.RangeID]; ok {
 				replica.addUnreachableRemoteReplica(beat.ToReplicaID)
@@ -3577,7 +3567,7 @@ func (s *Store) sendQueuedHeartbeatsToNode(beats, resps []RaftHeartbeat, to roac
 				replica.addUnreachableRemoteReplica(resp.ToReplicaID)
 			}
 		}
-		s.mu.Unlock()
+		s.mu.RUnlock()
 		return 0
 	}
 	return len(beats) + len(resps)
@@ -3634,9 +3624,9 @@ func (s *Store) tryGetOrCreateReplica(
 	rangeID roachpb.RangeID, replicaID roachpb.ReplicaID, creatingReplica *roachpb.ReplicaDescriptor,
 ) (_ *Replica, created bool, _ error) {
 	// The common case: look up an existing (initialized) replica.
-	s.mu.Lock()
+	s.mu.RLock()
 	repl, ok := s.mu.replicas[rangeID]
-	s.mu.Unlock()
+	s.mu.RUnlock()
 	if ok {
 		if creatingReplica != nil {
 			// Drop messages that come from a node that we believe was once a member of
@@ -3650,9 +3640,9 @@ func (s *Store) tryGetOrCreateReplica(
 		}
 
 		repl.raftMu.Lock()
-		repl.mu.Lock()
+		repl.mu.RLock()
 		destroyed, corrupted := repl.mu.destroyed, repl.mu.corrupted
-		repl.mu.Unlock()
+		repl.mu.RUnlock()
 		if destroyed != nil {
 			repl.raftMu.Unlock()
 			if corrupted {
@@ -4014,9 +4004,7 @@ func (s *Store) ComputeStatsForKeySpan(startKey, endKey roachpb.RKey) (enginepb.
 			return true // continue
 		}
 
-		repl.mu.Lock()
-		output.Add(repl.mu.state.Stats)
-		repl.mu.Unlock()
+		output.Add(repl.GetMVCCStats())
 		count++
 		return true
 	})
@@ -4041,11 +4029,11 @@ func (s *Store) FrozenStatus(collectFrozen bool) (repDescs []roachpb.ReplicaDesc
 			ctx := s.AnnotateCtx(context.TODO())
 			log.Fatalf(ctx, "unexpected error: %s", err)
 		}
-		r.mu.Lock()
+		r.mu.RLock()
 		if r.mu.state.IsFrozen() == collectFrozen {
 			repDescs = append(repDescs, repDesc)
 		}
-		r.mu.Unlock()
+		r.mu.RUnlock()
 		return true // want more
 	})
 	return

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -55,12 +55,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
-var defaultMuLogger = thresholdLogger(
-	context.Background(),
-	10*time.Second,
-	log.Warningf,
-)
-
 var testIdent = roachpb.StoreIdent{
 	ClusterID: uuid.MakeV4(),
 	NodeID:    1,
@@ -667,8 +661,6 @@ func TestProcessRangeDescriptorUpdate(t *testing.T) {
 		store:       store,
 		abortCache:  NewAbortCache(desc.RangeID),
 	}
-	r.mu.timedMutex = makeTimedMutex(defaultMuLogger)
-	r.cmdQMu.timedMutex = makeTimedMutex(defaultMuLogger)
 	if err := r.init(desc, store.Clock(), 0); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/syncutil/mutex_deadlock.go
+++ b/pkg/util/syncutil/mutex_deadlock.go
@@ -33,7 +33,15 @@ type Mutex struct {
 	deadlock.Mutex
 }
 
+// AssertHeld is a no-op for deadlock mutexes.
+func (m *Mutex) AssertHeld() {
+}
+
 // An RWMutex is a reader/writer mutual exclusion lock.
 type RWMutex struct {
 	deadlock.RWMutex
+}
+
+// AssertHeld is a no-op for deadlock mutexes.
+func (m *RWMutex) AssertHeld() {
 }

--- a/pkg/util/syncutil/mutex_sync.go
+++ b/pkg/util/syncutil/mutex_sync.go
@@ -18,14 +18,75 @@
 
 package syncutil
 
-import "sync"
+import (
+	"sync"
+	"sync/atomic"
+)
 
 // A Mutex is a mutual exclusion lock.
 type Mutex struct {
-	sync.Mutex
+	mu       sync.Mutex
+	isLocked int32 // updated atomically
 }
+
+// Lock implements sync.Locker.
+func (m *Mutex) Lock() {
+	m.mu.Lock()
+	atomic.StoreInt32(&m.isLocked, 1)
+}
+
+// Unlock implements sync.Locker.
+func (m *Mutex) Unlock() {
+	atomic.StoreInt32(&m.isLocked, 0)
+	m.mu.Unlock()
+}
+
+// AssertHeld may panic if the mutex is not locked (but it is not required to
+// do so). Functions which require that their callers hold a particular lock
+// may use this to enforce this requirement more directly than relying on the
+// race detector.
+//
+// Note that we do not require the lock to be held by any particular thread,
+// just that some thread holds the lock. This is both more efficient and allows
+// for rare cases where a mutex is locked in one thread and used in another.
+func (m *Mutex) AssertHeld() {
+	if atomic.LoadInt32(&m.isLocked) == 0 {
+		panic("mutex is not locked")
+	}
+}
+
+// TODO(pmattis): Mutex.AssertHeld is neither used or tested. Silence unused
+// warning.
+var _ = (*Mutex).AssertHeld
 
 // An RWMutex is a reader/writer mutual exclusion lock.
 type RWMutex struct {
 	sync.RWMutex
+	isLocked int32 // updated atomically
+}
+
+// Lock implements sync.Locker.
+func (m *RWMutex) Lock() {
+	m.RWMutex.Lock()
+	atomic.StoreInt32(&m.isLocked, 1)
+}
+
+// Unlock implements sync.Locker.
+func (m *RWMutex) Unlock() {
+	atomic.StoreInt32(&m.isLocked, 0)
+	m.RWMutex.Unlock()
+}
+
+// AssertHeld may panic if the mutex is not locked for writing (but it is not
+// required to do so). Functions which require that their callers hold a
+// particular lock may use this to enforce this requirement more directly than
+// relying on the race detector.
+//
+// Note that we do not require the lock to be held by any particular thread,
+// just that some thread holds the lock. This is both more efficient and allows
+// for rare cases where a mutex is locked in one thread and used in another.
+func (m *RWMutex) AssertHeld() {
+	if atomic.LoadInt32(&m.isLocked) == 0 {
+		panic("mutex is not locked")
+	}
 }

--- a/pkg/util/syncutil/mutex_sync_test.go
+++ b/pkg/util/syncutil/mutex_sync_test.go
@@ -1,0 +1,51 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build !deadlock
+
+package syncutil
+
+import "testing"
+
+func TestAssertHeld(t *testing.T) {
+	type mutex interface {
+		Lock()
+		Unlock()
+		AssertHeld()
+	}
+
+	testCases := []struct {
+		m mutex
+	}{
+		{&Mutex{}},
+		{&RWMutex{}},
+	}
+	for _, c := range testCases {
+		// The normal, successful case.
+		c.m.Lock()
+		c.m.AssertHeld()
+		c.m.Unlock()
+
+		func() {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Fatal("did not get expected panic")
+				} else if a, e := r.(string), "mutex is not locked"; a != e {
+					t.Fatalf("got %q, expected %q", a, e)
+				}
+			}()
+			c.m.AssertHeld()
+		}()
+	}
+}


### PR DESCRIPTION
Add syncutil.{,RW}Mutex.AssertHeld.

Use reader-locks when reading Store and Replica state. This avoids
contention during read-only code paths.

Remove usage of timedMutex except for Replica.raftMu.

See #13679

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13697)
<!-- Reviewable:end -->
