### PR TITLE
sql: be consistent when mapping ordering columns to render columns

### DIFF
--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -498,8 +498,12 @@ func simplifyOrderings(plan planNode, usefulOrdering sqlbase.ColumnOrdering) pla
 		n.ordering.trim(usefulOrdering)
 
 	case *renderNode:
-		n.ordering.trim(usefulOrdering)
 		n.source.plan = simplifyOrderings(n.source.plan, translateOrdering(usefulOrdering, n))
+		// Recompute r.ordering using the source's simplified ordering.
+		// TODO(radu): in some cases there may be multiple possible n.orderings for
+		// a given source plan ordering; we should pass usefulOrdering to help make
+		// that choice (#13709).
+		n.ordering = n.computeOrdering(n.source.plan.Ordering())
 
 	case *delayedNode:
 		n.plan = simplifyOrderings(n.plan, usefulOrdering)

--- a/pkg/sql/testdata/order_by
+++ b/pkg/sql/testdata/order_by
@@ -700,3 +700,25 @@ EXPLAIN (METADATA) SELECT * FROM (SELECT y, w, x FROM uvwxyz WHERE y = 1 ORDER B
 1  scan                        (u[omitted], v[omitted], w, x, y, z[omitted], rowid[hidden,omitted])  =y,+w,+x
 1          table  uvwxyz@ywxz
 1          spans  /1-/2
+
+
+statement ok
+CREATE TABLE blocks (
+  block_id  INT,
+  writer_id STRING,
+  block_num INT,
+  raw_bytes BYTES,
+  PRIMARY KEY (block_id, writer_id, block_num)
+)
+
+# Test that ordering goes "through" a renderNode that has a duplicate render of
+# an order-by column (#13696).
+query ITTTTT
+EXPLAIN (METADATA) SELECT block_id,writer_id,block_num,block_id FROM blocks ORDER BY block_id, writer_id, block_num LIMIT 1
+----
+0  limit                          (block_id, writer_id, block_num, block_id)            +block_id,+writer_id,+block_num,unique
+1  render                         (block_id, writer_id, block_num, block_id)            +block_id,+writer_id,+block_num,unique
+2  scan                           (block_id, writer_id, block_num, raw_bytes[omitted])  +block_id,+writer_id,+block_num,unique
+2          table  blocks@primary
+2          spans  ALL
+2          limit  1


### PR DESCRIPTION
This is a case that involves a duplicate render column that appears in an ORDER
BY clause.

When processing the clause, we were preferring the last matching column. But
when computing the renderNode's ordering, we are preferring the first matching
column. This mismatch was causing an unnecessary sort step (which blocks limit
optimizations).

Fixes #13696.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13703)
<!-- Reviewable:end -->
