### PR TITLE
distsqlrun: avoid unnecessary client.NewTxn calls in tests

### DIFF
--- a/pkg/sql/distsqlrun/cluster_test.go
+++ b/pkg/sql/distsqlrun/cluster_test.go
@@ -102,10 +102,9 @@ func TestClusterFlow(t *testing.T) {
 		Spans:    []TableReaderSpan{makeIndexSpan(12, 100)},
 	}
 
-	txn := client.NewTxn(ctx, *kvDB)
 	fid := FlowID{uuid.MakeV4()}
 
-	req1 := &SetupFlowRequest{Txn: txn.Proto}
+	req1 := &SetupFlowRequest{}
 	req1.Flow = FlowSpec{
 		FlowID: fid,
 		Processors: []ProcessorSpec{{
@@ -122,7 +121,7 @@ func TestClusterFlow(t *testing.T) {
 		}},
 	}
 
-	req2 := &SetupFlowRequest{Txn: txn.Proto}
+	req2 := &SetupFlowRequest{}
 	req2.Flow = FlowSpec{
 		FlowID: fid,
 		Processors: []ProcessorSpec{{
@@ -139,7 +138,7 @@ func TestClusterFlow(t *testing.T) {
 		}},
 	}
 
-	req3 := &SetupFlowRequest{Txn: txn.Proto}
+	req3 := &SetupFlowRequest{}
 	req3.Flow = FlowSpec{
 		FlowID: fid,
 		Processors: []ProcessorSpec{

--- a/pkg/sql/distsqlrun/server_test.go
+++ b/pkg/sql/distsqlrun/server_test.go
@@ -23,7 +23,6 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -59,9 +58,7 @@ func TestServer(t *testing.T) {
 		OutputColumns: []uint32{0, 1},              // a
 	}
 
-	txn := client.NewTxn(context.Background(), *kvDB)
-
-	req := &SetupFlowRequest{Txn: txn.Proto}
+	req := &SetupFlowRequest{}
 	req.Flow = FlowSpec{
 		Processors: []ProcessorSpec{{
 			Core: ProcessorCoreUnion{TableReader: &ts},


### PR DESCRIPTION
There were a few places in tests where we would call `client.NewTxn`,
only to retrieve its empty Proto. This was pointless, because
`client.NewTxn` does not perform any initialization of its `.Proto`
field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13704)
<!-- Reviewable:end -->
