### PR TITLE
sql: introduce a new virtual database crdb_internal

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -715,8 +715,9 @@ func Example_sql() {
 	// x	y
 	// 42	69
 	// sql --execute=show databases
-	// 4 rows
+	// 5 rows
 	// Database
+	// crdb_internal
 	// information_schema
 	// pg_catalog
 	// system

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1,0 +1,203 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package sql
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
+
+var crdbInternal = virtualSchema{
+	name: "crdb_internal",
+	tables: []virtualSchemaTable{
+		crdbInternalTablesTable,
+		crdbInternalLeasesTable,
+		crdbInternalSchemaChangesTable,
+	},
+}
+
+var crdbInternalTablesTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE crdb_internal.tables (
+  TABLE_ID                 INT NOT NULL,
+  PARENT_ID                INT NOT NULL,
+  NAME                     STRING NOT NULL,
+  VERSION                  INT NOT NULL,
+  MOD_TIME                 TIMESTAMP NOT NULL,
+  MOD_TIME_LOGICAL         DECIMAL NOT NULL,
+  FORMAT_VERSION           STRING NOT NULL,
+  STATE                    STRING NOT NULL,
+  SC_LEASE_NODE_ID         INT,
+  SC_LEASE_EXPIRATION_TIME TIMESTAMP
+);
+`,
+	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+		descs, err := p.getAllDescriptors()
+		if err != nil {
+			return err
+		}
+		// Note: we do not use forEachTableDesc() here because we want to
+		// include added and dropped descriptors.
+		for _, desc := range descs {
+			table, ok := desc.(*sqlbase.TableDescriptor)
+			if !ok || !userCanSeeDescriptor(table, p.session.User) {
+				continue
+			}
+			leaseNodeDatum := parser.DNull
+			leaseExpDatum := parser.DNull
+			if table.Lease != nil {
+				leaseNodeDatum = parser.NewDInt(parser.DInt(int64(table.Lease.NodeID)))
+				leaseExpDatum = parser.MakeDTimestamp(
+					time.Unix(0, table.Lease.ExpirationTime), time.Nanosecond,
+				)
+			}
+			if err := addRow(
+				parser.NewDInt(parser.DInt(int64(table.ID))),
+				parser.NewDInt(parser.DInt(int64(table.ParentID))),
+				parser.NewDString(parser.Name(table.Name).String()),
+				parser.NewDInt(parser.DInt(int64(table.Version))),
+				parser.MakeDTimestamp(time.Unix(0, table.ModificationTime.WallTime), time.Microsecond),
+				parser.TimestampToDecimal(table.ModificationTime),
+				parser.NewDString(table.FormatVersion.String()),
+				parser.NewDString(table.State.String()),
+				leaseNodeDatum,
+				leaseExpDatum,
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	},
+}
+
+var crdbInternalSchemaChangesTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE crdb_internal.schema_changes (
+  TABLE_ID      INT NOT NULL,
+  PARENT_ID     INT NOT NULL,
+  NAME          STRING NOT NULL,
+  TYPE          STRING NOT NULL,
+  TARGET_ID     INT,
+  TARGET_NAME   STRING,
+  STATE         STRING NOT NULL,
+  DIRECTION     STRING NOT NULL
+);
+`,
+	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+		descs, err := p.getAllDescriptors()
+		if err != nil {
+			return err
+		}
+		// Note: we do not use forEachTableDesc() here because we want to
+		// include added and dropped descriptors.
+		for _, desc := range descs {
+			table, ok := desc.(*sqlbase.TableDescriptor)
+			if !ok || !userCanSeeDescriptor(table, p.session.User) {
+				continue
+			}
+			tableID := parser.NewDInt(parser.DInt(int64(table.ID)))
+			parentID := parser.NewDInt(parser.DInt(int64(table.ParentID)))
+			tableName := parser.NewDString(parser.Name(table.Name).String())
+			for _, mut := range table.Mutations {
+				mutType := "UNKNOWN"
+				targetID := parser.DNull
+				targetName := parser.DNull
+				switch d := mut.Descriptor_.(type) {
+				case *sqlbase.DescriptorMutation_Column:
+					mutType = "COLUMN"
+					targetID = parser.NewDInt(parser.DInt(int64(d.Column.ID)))
+					targetName = parser.NewDString(d.Column.Name)
+				case *sqlbase.DescriptorMutation_Index:
+					mutType = "INDEX"
+					targetID = parser.NewDInt(parser.DInt(int64(d.Index.ID)))
+					targetName = parser.NewDString(d.Index.Name)
+				}
+				if err := addRow(
+					tableID,
+					parentID,
+					tableName,
+					parser.NewDString(mutType),
+					targetID,
+					targetName,
+					parser.NewDString(mut.State.String()),
+					parser.NewDString(mut.Direction.String()),
+				); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	},
+}
+
+var crdbInternalLeasesTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE crdb_internal.leases (
+  NODE_ID     INT NOT NULL,
+  TABLE_ID    INT NOT NULL,
+  NAME        STRING NOT NULL,
+  PARENT_ID   INT NOT NULL,
+  EXPIRATION  TIMESTAMP NOT NULL,
+  RELEASED    BOOL NOT NULL,
+  DELETED     BOOL NOT NULL
+);
+`,
+	populate: func(p *planner, addRow func(...parser.Datum) error) error {
+		leaseMgr := p.leaseMgr
+		nodeID := parser.NewDInt(parser.DInt(int64(leaseMgr.nodeID.Get())))
+
+		leaseMgr.mu.Lock()
+		defer leaseMgr.mu.Unlock()
+
+		for tid, ts := range leaseMgr.mu.tables {
+			tableID := parser.NewDInt(parser.DInt(int64(tid)))
+
+			adder := func() error {
+				ts.mu.Lock()
+				defer ts.mu.Unlock()
+
+				deleted := parser.MakeDBool(parser.DBool(ts.deleted))
+
+				for _, state := range ts.active.data {
+					if !userCanSeeDescriptor(&state.TableDescriptor, p.session.User) {
+						continue
+					}
+					expCopy := state.expiration
+					if err := addRow(
+						nodeID,
+						tableID,
+						parser.NewDString(parser.Name(state.Name).String()),
+						parser.NewDInt(parser.DInt(int64(state.ParentID))),
+						&expCopy,
+						parser.MakeDBool(parser.DBool(state.released)),
+						deleted,
+					); err != nil {
+						return err
+					}
+				}
+				return nil
+			}
+
+			if err := adder(); err != nil {
+				return err
+			}
+		}
+		return nil
+	},
+}

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -1778,14 +1778,21 @@ func (ctx *EvalContext) GetClusterTimestamp() *DDecimal {
 		}
 	}
 
+	return TimestampToDecimal(ctx.clusterTimestamp)
+}
+
+// TimestampToDecimal converts the logical timestamp into a decimal
+// value with the number of nanoseconds in the integer part and the
+// logical counter in the decimal part.
+func TimestampToDecimal(ts hlc.Timestamp) *DDecimal {
 	// Compute Walltime * 10^10 + Logical.
 	// We need 10 decimals for the Logical field because its maximum
 	// value is 4294967295 (2^32-1), a value with 10 decimal digits.
 	var res DDecimal
 	val := &res.Coeff
-	val.SetInt64(ctx.clusterTimestamp.WallTime)
+	val.SetInt64(ts.WallTime)
 	val.Mul(val, big10E10)
-	val.Add(val, big.NewInt(int64(ctx.clusterTimestamp.Logical)))
+	val.Add(val, big.NewInt(int64(ts.Logical)))
 
 	// Shift 10 decimals to the right, so that the logical
 	// field appears as fractional part.

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -565,7 +565,7 @@ func TestPGPreparedQuery(t *testing.T) {
 				Results("hashedPassword", "BYTES", true, gosql.NullBool{}, "{}"),
 		},
 		"SHOW DATABASES": {
-			baseTest.Results("d").Results("information_schema").Results("pg_catalog").Results("system"),
+			baseTest.Results("crdb_internal").Results("d").Results("information_schema").Results("pg_catalog").Results("system"),
 		},
 		"SHOW GRANTS ON system.users": {
 			baseTest.Results("users", security.RootUser, "DELETE").

--- a/pkg/sql/testdata/crdb_internal
+++ b/pkg/sql/testdata/crdb_internal
@@ -1,0 +1,39 @@
+query error user root does not have DROP privilege on database crdb_internal
+ALTER DATABASE crdb_internal RENAME TO not_crdb_internal
+
+statement error user root does not have CREATE privilege on database crdb_internal
+CREATE TABLE crdb_internal.t (x INT)
+
+query error user root does not have DROP privilege on database crdb_internal
+DROP DATABASE crdb_internal
+
+statement ok
+CREATE DATABASE testdb; CREATE TABLE testdb.foo(x INT)
+
+query TIT
+SELECT t.name, t.version, t.state FROM crdb_internal.tables AS t JOIN system.namespace AS n ON (n.id = t.parent_id and n.name = 'testdb');
+----
+foo 1 PUBLIC
+
+# Ensure there is a lease taken on foo.
+query I
+SELECT * FROM testdb.foo
+----
+
+# Check the lease.
+query T
+SELECT l.name FROM crdb_internal.leases AS l JOIN system.namespace AS n ON (n.id = l.table_id and n.name = 'foo');
+----
+foo
+
+# We merely check the column list for schema_changes.
+query IITTITTT colnames
+SELECT * FROM crdb_internal.schema_changes
+----
+TABLE_ID PARENT_ID NAME TYPE TARGET_ID TARGET_NAME STATE DIRECTION
+
+query IITITRTTTT colnames
+SELECT * FROM crdb_internal.tables WHERE NAME = 'namespace'
+----
+TABLE_ID  PARENT_ID  NAME       VERSION  MOD_TIME                         MOD_TIME_LOGICAL  FORMAT_VERSION            STATE   SC_LEASE_NODE_ID  SC_LEASE_EXPIRATION_TIME
+2         1          namespace  1        1970-01-01 00:00:00 +0000 +0000  0.0000000000      InterleavedFormatVersion  PUBLIC  NULL              NULL

--- a/pkg/sql/testdata/database
+++ b/pkg/sql/testdata/database
@@ -15,6 +15,7 @@ SHOW DATABASES
 ----
 Database
 a
+crdb_internal
 information_schema
 pg_catalog
 system
@@ -76,6 +77,7 @@ b4
 b5
 b6
 c
+crdb_internal
 information_schema
 pg_catalog
 system
@@ -118,6 +120,7 @@ SHOW DATABASES
 Database
 a
 c
+crdb_internal
 information_schema
 pg_catalog
 system

--- a/pkg/sql/testdata/drop_database
+++ b/pkg/sql/testdata/drop_database
@@ -4,6 +4,7 @@ CREATE DATABASE "foo-bar"
 query T
 SHOW DATABASES
 ----
+crdb_internal
 foo-bar
 information_schema
 pg_catalog
@@ -16,6 +17,7 @@ DROP DATABASE "foo-bar"
 query T
 SHOW DATABASES
 ----
+crdb_internal
 information_schema
 pg_catalog
 system
@@ -27,6 +29,7 @@ CREATE DATABASE "foo bar"
 query T
 SHOW DATABASES
 ----
+crdb_internal
 foo bar
 information_schema
 pg_catalog
@@ -39,6 +42,7 @@ DROP DATABASE "foo bar"
 query T
 SHOW DATABASES
 ----
+crdb_internal
 information_schema
 pg_catalog
 system
@@ -123,6 +127,7 @@ SELECT * FROM d2.v4
 query T
 SHOW DATABASES
 ----
+crdb_internal
 d1
 d2
 information_schema
@@ -136,6 +141,7 @@ DROP DATABASE d1
 query T
 SHOW DATABASES
 ----
+crdb_internal
 d2
 information_schema
 pg_catalog
@@ -164,6 +170,7 @@ DROP DATABASE d2
 query T
 SHOW DATABASES
 ----
+crdb_internal
 information_schema
 pg_catalog
 system
@@ -197,6 +204,7 @@ DROP DATABASE constraint_db
 query T
 SHOW DATABASES
 ----
+crdb_internal
 information_schema
 pg_catalog
 system

--- a/pkg/sql/testdata/explain
+++ b/pkg/sql/testdata/explain
@@ -128,7 +128,7 @@ EXPLAIN SHOW DATABASES
 2  virtual table
 2                 source  information_schema.schemata
 3  values
-3                 size    4 columns, 5 rows
+3                 size    4 columns, 6 rows
 
 query ITTT
 EXPLAIN SHOW TABLES

--- a/pkg/sql/testdata/information_schema
+++ b/pkg/sql/testdata/information_schema
@@ -96,6 +96,7 @@ SET DATABASE = test
 query T
 SHOW DATABASES
 ----
+crdb_internal
 information_schema
 pg_catalog
 system
@@ -160,6 +161,7 @@ query TTTT colnames
 SELECT * FROM information_schema.schemata
 ----
 CATALOG_NAME  SCHEMA_NAME         DEFAULT_CHARACTER_SET_NAME  SQL_PATH
+def           crdb_internal       NULL                        NULL
 def           information_schema  NULL                        NULL
 def           pg_catalog          NULL                        NULL
 def           system              NULL                        NULL
@@ -169,6 +171,7 @@ query TTTT colnames
 SELECT * FROM INFormaTION_SCHEMa.schemata
 ----
 CATALOG_NAME  SCHEMA_NAME         DEFAULT_CHARACTER_SET_NAME  SQL_PATH
+def           crdb_internal       NULL                        NULL
 def           information_schema  NULL                        NULL
 def           pg_catalog          NULL                        NULL
 def           system              NULL                        NULL
@@ -181,6 +184,7 @@ query TTTT colnames
 SELECT * FROM information_schema.schemata
 ----
 CATALOG_NAME  SCHEMA_NAME         DEFAULT_CHARACTER_SET_NAME  SQL_PATH
+def           crdb_internal       NULL                        NULL
 def           information_schema  NULL                        NULL
 def           other_db            NULL                        NULL
 def           pg_catalog          NULL                        NULL
@@ -204,6 +208,9 @@ CREATE VIEW other_db.abc AS SELECT i from other_db.xyz
 query T
 SELECT table_name FROM information_schema.tables
 ----
+leases
+schema_changes
+tables
 columns
 key_column_usage
 schema_privileges
@@ -257,11 +264,13 @@ views
 users
 ui
 tables
+tables
 table_privileges
 table_constraints
 statistics
 schemata
 schema_privileges
+schema_changes
 rangelog
 pg_views
 pg_type
@@ -293,6 +302,9 @@ query TTTTI colnames
 SELECT * FROM information_schema.tables
 ----
 TABLE_CATALOG  TABLE_SCHEMA        TABLE_NAME         TABLE_TYPE   VERSION
+def            crdb_internal       leases             SYSTEM VIEW  1
+def            crdb_internal       schema_changes     SYSTEM VIEW  1
+def            crdb_internal       tables             SYSTEM VIEW  1
 def            information_schema  columns            SYSTEM VIEW  1
 def            information_schema  key_column_usage   SYSTEM VIEW  1
 def            information_schema  schema_privileges  SYSTEM VIEW  1
@@ -500,7 +512,7 @@ DROP DATABASE constraint_db
 query TTTTI colnames
 SELECT table_catalog, table_schema, table_name, column_name, ordinal_position
 FROM information_schema.columns
-WHERE table_schema != 'information_schema' AND table_schema != 'pg_catalog'
+WHERE table_schema != 'information_schema' AND table_schema != 'pg_catalog' AND table_schema != 'crdb_internal'
 ----
 table_catalog  table_schema        table_name  column_name               ordinal_position
 def            system              descriptor  id                        1

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -145,6 +145,7 @@ SELECT * FROM pg_catalog.pg_namespace
 ----
 oid         nspname             nspowner  aclitem
 1708731312  constraint_db       NULL      NULL
+2699457641  crdb_internal       NULL      NULL
 719671438   information_schema  NULL      NULL
 1782195457  pg_catalog          NULL      NULL
 2939540337  system              NULL      NULL
@@ -161,6 +162,7 @@ oid         datname             datdba  encoding  datcollate  datctype    datist
 381876367   system              NULL    6         en_US.utf8  en_US.utf8  false          true
 437457361   constraint_db       NULL    6         en_US.utf8  en_US.utf8  false          true
 1965331359  test                NULL    6         en_US.utf8  en_US.utf8  false          true
+2107984548  crdb_internal       NULL    6         en_US.utf8  en_US.utf8  false          true
 2157629366  pg_catalog          NULL    6         en_US.utf8  en_US.utf8  false          true
 3177026209  information_schema  NULL    6         en_US.utf8  en_US.utf8  false          true
 
@@ -173,6 +175,7 @@ oid         datname             datconnlimit  datlastsysoid  datfrozenxid  datmi
 381876367   system              -1            NULL           NULL          NULL        NULL           NULL
 437457361   constraint_db       -1            NULL           NULL          NULL        NULL           NULL
 1965331359  test                -1            NULL           NULL          NULL        NULL           NULL
+2107984548  crdb_internal       -1            NULL           NULL          NULL        NULL           NULL
 2157629366  pg_catalog          -1            NULL           NULL          NULL        NULL           NULL
 3177026209  information_schema  -1            NULL           NULL          NULL        NULL           NULL
 

--- a/pkg/sql/testdata/rename_database
+++ b/pkg/sql/testdata/rename_database
@@ -1,6 +1,7 @@
 query T
 SHOW DATABASES
 ----
+crdb_internal
 information_schema
 pg_catalog
 system
@@ -41,6 +42,7 @@ SHOW GRANTS ON DATABASE test
 query T
 SHOW DATABASES
 ----
+crdb_internal
 information_schema
 pg_catalog
 system
@@ -89,6 +91,7 @@ ALTER DATABASE t RENAME TO v
 query T
 SHOW DATABASES
 ----
+crdb_internal
 information_schema
 pg_catalog
 t

--- a/pkg/sql/testdata/system
+++ b/pkg/sql/testdata/system
@@ -1,6 +1,7 @@
 query T
 SHOW DATABASES
 ----
+crdb_internal
 information_schema
 pg_catalog
 system

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -54,6 +54,7 @@ type virtualSchemaTable struct {
 var virtualSchemas = []virtualSchema{
 	informationSchema,
 	pgCatalog,
+	crdbInternal,
 }
 
 //


### PR DESCRIPTION
This exposes the following virtual tables:

- `tables`: table descriptor details.
- `schema_changes`: schema changes currently ongoing.
- `leases`: table leases held on the node where the query inspecting
  the `leases` table is ran.

These tables are intended for debugging / troubleshooting purposes,
and to provide additional information not present in pg_catalog or
information_schema.

Closes #10317

Code from @knz but reopened here as a simpler PR than that one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13718)
<!-- Reviewable:end -->
