### PR TITLE
sql: fix a broken applyConstraints

### DIFF
--- a/pkg/sql/index_selection.go
+++ b/pkg/sql/index_selection.go
@@ -1619,54 +1619,60 @@ func applyConstraintFlat(
 		return t
 	}
 
-	// More special casing: constraint says "a IN (x, y, z...)"
-	if cOp == parser.In {
-		ctuple := cdatum.(*parser.DTuple)
-		switch t.Operator {
-		case parser.Is, parser.EQ:
+	// Additional special casing.
+	switch t.Operator {
+	case parser.LE, parser.LT, parser.GE,
+		parser.GT, parser.NE, parser.IsNot:
+		if cOp == parser.In {
+			// The general case only handles range constraints.
+			// Stop here.
+
+			// Note: if we ever support other constraints than IN and the
+			// range operators, the condition on cOp here must be extended.
+			return t
+		}
+
+		// Otherwise, the general case below knows about all these
+		// cases. Go forward.
+
+	case parser.Is, parser.EQ:
+		// (Expr IS ...) / (Expr = ...)
+
+		if cOp == parser.In {
+			// constraint says "a IN (x, y, z...)"
 			// Expr asks "= Cst" or IS TRUE / IS FALSE: check whether the
 			// value is in the IN set. If it is not, we're sure it never
 			// matches. Otherwise we don't know.
+			ctuple := cdatum.(*parser.DTuple)
 			i := sort.Search(len(ctuple.D), func(i int) bool {
 				return ctuple.D[i].(parser.Datum).Compare(datum) >= 0
 			})
-			if i >= len(ctuple.D) || ctuple.D[i].Compare(datum) != 0 {
+			if i == len(ctuple.D) || ctuple.D[i].Compare(datum) != 0 {
 				return parser.DBoolFalse
 			}
+			return t
+		}
+		// Continue to the general case below.
 
+	case parser.In:
+		// Expr: "a IN (t, u, v, ...)"
+
+		switch cOp {
 		case parser.In:
-			// Expr: "a IN (t, u, v, ...)"
+			// constraint says "a IN (x, y, z...)"
 			// true if (x, y, z, ...) is a subset of (t, u, v, ...)
 			// unknown otherwise
 			if ttuple, ok := datum.(*parser.DTuple); ok {
 				// Note: A is a subset of B iff A \ B == empty.
+				ctuple := cdatum.(*parser.DTuple)
 				diff := ctuple.SortedDifference(ttuple)
 				if len(diff.D) == 0 {
 					return parser.DBoolTrue
 				}
 			}
 
-		case parser.NotIn:
-			// Expr: "a NOT IN (t, u, v, ...)"
-			// True if none of the values in (x, y, z...) are in (t, u, v, ...)
-			// unknown otherwise
-			if ttuple, ok := datum.(*parser.DTuple); ok {
-				// Note: A inter B is empty iff A \ B == A
-				diff := ctuple.SortedDifference(ttuple)
-				if len(diff.D) < len(ctuple.D) {
-					return parser.DBoolTrue
-				}
-			}
-		}
-
-		return t
-	}
-
-	// More special casing: constraint says [a = value]
-	// and expression is [a != ...], [a IN ...] or [a NOT IN ...].
-	if cOp == parser.EQ {
-		switch t.Operator {
-		case parser.In:
+		case parser.EQ:
+			// constraint says "a = Cst"
 			// true if the known value is in the IN set, false otherwise.
 			if tuple, ok := datum.(*parser.DTuple); ok {
 				i := sort.Search(len(tuple.D), func(i int) bool {
@@ -1677,8 +1683,31 @@ func applyConstraintFlat(
 				}
 			}
 			return parser.DBoolFalse
+		}
 
-		case parser.NotIn:
+		// The general case below doesn't know about
+		// IN expressions. Can't go further.
+		return t
+
+	case parser.NotIn:
+		// Expr: "a NOT IN (t, u, v, ...)"
+
+		switch cOp {
+		case parser.In:
+			// constraint says "a IN (x, y, z...)"
+			// True if none of the values in (x, y, z...) are in (t, u, v, ...)
+			// unknown otherwise
+			if ttuple, ok := datum.(*parser.DTuple); ok {
+				// Note: A inter B is empty iff A \ B == A
+				ctuple := cdatum.(*parser.DTuple)
+				diff := ctuple.SortedDifference(ttuple)
+				if len(diff.D) < len(ctuple.D) {
+					return parser.DBoolTrue
+				}
+			}
+
+		case parser.EQ:
+			// constraint says "a = Cst"
 			// false if the known value is in the NOT IN set, true otherwise.
 			if tuple, ok := datum.(*parser.DTuple); ok {
 				i := sort.Search(len(tuple.D), func(i int) bool {
@@ -1690,6 +1719,15 @@ func applyConstraintFlat(
 			}
 			return parser.DBoolTrue
 		}
+
+		// The general case below doesn't know about
+		// NOT IN expressions. Can't go further.
+		return t
+
+	default:
+		// We have a comparison expression with a comparator which
+		// is not handled below (IN, = ANY, etc). Can't go further.
+		return t
 	}
 
 	// General case: constraint and expression both specify a range.

--- a/pkg/sql/index_selection_test.go
+++ b/pkg/sql/index_selection_test.go
@@ -688,6 +688,16 @@ func TestApplyConstraints(t *testing.T) {
 		// elided during constraint analysis before constraint
 		// propagation.
 		{`a <= 1 AND COALESCE(a != 2, true)`, `a`, `COALESCE(true, true)`},
+		// Regression tests: #13707
+		// The following tests must achieve a constraint on `a` and an
+		// expression to simplify that contains `a` in a previously
+		// unhandled comparison operator. We use OR so that analyzeExpr
+		// doesn't decompose further.
+		{`a < 3 AND (b < 2 OR a IN (0,1,2))`, `a`, `(b < 2) OR (a IN (0, 1, 2))`},
+		{`a < 3 AND (b < 2 OR a NOT IN (0,1,2))`, `a`, `(b < 2) OR (a NOT IN (0, 1, 2))`},
+		{`a < 3 AND (b < 2 OR a = ANY ARRAY[0,1,2])`, `a`, `(b < 2) OR (a = ANY {0,1,2})`},
+		{`a IN (0, 2, 3) AND (b < 2 OR a <= 4)`, `a`, `(b < 2) OR (a <= 4)`},
+		{`a IN (0, 2, 3) AND (b < 2 OR a = 2)`, `a`, `(b < 2) OR (a = 2)`},
 	}
 	for _, d := range testData {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {


### PR DESCRIPTION
The changes to applyConstraints introduced in
ec76cb99535ba053bd001822e4951635eccf8a4a were missing a couple of
cases -- leaving expressions comparing to something non-scalar fall
through to the general case that only knows about scalar/scalar
comparisons (and panics otherwise).

Thanks to @jordanlewis for finding the issue and determining the exact
location of the bug in the source.

Fixes #13707.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13719)
<!-- Reviewable:end -->
