### PR TITLE
build: add runner for LogicTest's bigtest config

### DIFF
--- a/build/teamcity-sqllogictest.sh
+++ b/build/teamcity-sqllogictest.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+mkdir -p artifacts
+
+build/builder.sh env \
+		 make -C pkg/sql bigtest \
+		 TESTFLAGS='-v' \
+		 2>&1 \
+    | tee artifacts/test.log \
+    | go-test-teamcity


### PR DESCRIPTION
We used to run this by spinning up a GCE cluster. It'll be simpler to just run it serially on a build agent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13727)
<!-- Reviewable:end -->
