### PR TITLE
sql: make whitespace in EXPLAIN tests consistent

### DIFF
--- a/pkg/sql/testdata/aggregate
+++ b/pkg/sql/testdata/aggregate
@@ -490,7 +490,7 @@ SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv
 14.00000000000000000
 
 query ITTT
-EXPLAIN(EXPRS) SELECT COUNT(k) FROM kv
+EXPLAIN (EXPRS) SELECT COUNT(k) FROM kv
 ----
 0  group
 0                 aggregate 0  count(k)
@@ -514,7 +514,7 @@ INSERT INTO abc VALUES ('one', 1.5, true, 5::decimal), ('two', 2.0, false, 1.1::
 
 # Verify we don't try to apply the single-key optimization to the primary index.
 query ITTT
-EXPLAIN(EXPRS) SELECT MIN(a) FROM abc
+EXPLAIN (EXPRS) SELECT MIN(a) FROM abc
 ----
 0  group
 0                 aggregate 0  min(a)
@@ -595,7 +595,7 @@ SELECT MIN(x) FROM xyz
 1
 
 query ITTT
-EXPLAIN(EXPRS) SELECT MIN(x) FROM xyz
+EXPLAIN (EXPRS) SELECT MIN(x) FROM xyz
 ----
 0  group
 0                 aggregate 0  min(x)
@@ -613,7 +613,7 @@ SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
 4
 
 query ITTT
-EXPLAIN(EXPRS) SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
+EXPLAIN (EXPRS) SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
 ----
 0  group
 0                 aggregate 0  min(x)
@@ -631,7 +631,7 @@ SELECT MAX(x) FROM xyz
 7
 
 query ITTT
-EXPLAIN(EXPRS) SELECT MAX(x) FROM xyz
+EXPLAIN (EXPRS) SELECT MAX(x) FROM xyz
 ----
 0  group
 0                 aggregate 0  max(x)
@@ -649,7 +649,7 @@ SELECT MIN(y) FROM xyz WHERE x = 1
 2
 
 query ITTT
-EXPLAIN(EXPRS) SELECT MIN(y) FROM xyz WHERE x = 1
+EXPLAIN (EXPRS) SELECT MIN(y) FROM xyz WHERE x = 1
 ----
 0  group
 0                 aggregate 0  min(y)
@@ -667,7 +667,7 @@ SELECT MAX(y) FROM xyz WHERE x = 1
 2
 
 query ITTT
-EXPLAIN(EXPRS) SELECT MAX(y) FROM xyz WHERE x = 1
+EXPLAIN (EXPRS) SELECT MAX(y) FROM xyz WHERE x = 1
 ----
 0  group
 0                 aggregate 0  max(y)
@@ -685,7 +685,7 @@ SELECT MIN(y) FROM xyz WHERE x = 7
 NULL
 
 query ITTT
-EXPLAIN(EXPRS) SELECT MIN(y) FROM xyz WHERE x = 7
+EXPLAIN (EXPRS) SELECT MIN(y) FROM xyz WHERE x = 7
 ----
 0  group
 0                 aggregate 0  min(y)
@@ -703,7 +703,7 @@ SELECT MAX(y) FROM xyz WHERE x = 7
 NULL
 
 query ITTT
-EXPLAIN(EXPRS) SELECT MAX(y) FROM xyz WHERE x = 7
+EXPLAIN (EXPRS) SELECT MAX(y) FROM xyz WHERE x = 7
 ----
 0  group
 0                 aggregate 0  max(y)
@@ -721,7 +721,7 @@ SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 1
 
 query ITTT
-EXPLAIN(EXPRS) SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
+EXPLAIN (EXPRS) SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 ----
 0  group
 0                 aggregate 0  min(x)
@@ -734,7 +734,7 @@ EXPLAIN(EXPRS) SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 2                 limit        1
 
 query ITTT
-EXPLAIN(DEBUG) SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
+EXPLAIN (DEBUG) SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 ----
 0 /xyz/zyx/3.0/2/1 NULL BUFFERED
 0 0                (1)  ROW
@@ -745,7 +745,7 @@ SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
 1
 
 query ITTT
-EXPLAIN(EXPRS) SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
+EXPLAIN (EXPRS) SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
 ----
 0  group
 0                 aggregate 0  max(x)
@@ -786,7 +786,7 @@ SELECT VARIANCE(x) FROM xyz WHERE x = 1
 NULL
 
 query ITTT
-EXPLAIN(EXPRS) SELECT VARIANCE(x) FROM xyz WHERE x = 1
+EXPLAIN (EXPRS) SELECT VARIANCE(x) FROM xyz WHERE x = 1
 ----
 0  group
 0                 aggregate 0  variance(x)
@@ -900,7 +900,7 @@ INSERT INTO ab VALUES
   (5, 50)
 
 query ITTT
-EXPLAIN(EXPRS) SELECT MIN(a) FROM abc
+EXPLAIN (EXPRS) SELECT MIN(a) FROM abc
 ----
 0  group
 0                 aggregate 0  min(a)
@@ -914,14 +914,14 @@ EXPLAIN(EXPRS) SELECT MIN(a) FROM abc
 
 # Verify we only buffer one row.
 query ITTT
-EXPLAIN(DEBUG) SELECT MIN(a) FROM ab
+EXPLAIN (DEBUG) SELECT MIN(a) FROM ab
 ----
 0 /ab/primary/1   NULL PARTIAL
 0 /ab/primary/1/b 10   BUFFERED
 0 0               (1)  ROW
 
 query ITTT
-EXPLAIN(EXPRS) SELECT MAX(a) FROM abc
+EXPLAIN (EXPRS) SELECT MAX(a) FROM abc
 ----
 0  group
 0                 aggregate 0  max(a)
@@ -942,7 +942,7 @@ EXPLAIN (DEBUG) SELECT MAX(a) FROM ab
 0 0               (5)  ROW
 
 query ITTT
-EXPLAIN(EXPRS) SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
+EXPLAIN (EXPRS) SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
 ----
 0  sort
 0                 order        +"COUNT(k)"
@@ -960,7 +960,7 @@ EXPLAIN(EXPRS) SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
 3                 spans        ALL
 
 query ITTT
-EXPLAIN(EXPRS) SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
+EXPLAIN (EXPRS) SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
 ----
 0  sort
 0                 order        +"COUNT(*)"
@@ -978,7 +978,7 @@ EXPLAIN(EXPRS) SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
 3                 spans        ALL
 
 query ITTT
-EXPLAIN(EXPRS) SELECT v, COUNT(1) FROM kv GROUP BY v ORDER BY COUNT(1)
+EXPLAIN (EXPRS) SELECT v, COUNT(1) FROM kv GROUP BY v ORDER BY COUNT(1)
 ----
 0  sort
 0                 order        +"COUNT(1)"

--- a/pkg/sql/testdata/explain
+++ b/pkg/sql/testdata/explain
@@ -6,14 +6,14 @@ Level  Type    Field Description
 1      nullrow
 
 query ITTTTT colnames
-EXPLAIN (PLAN, METADATA) SELECT 1
+EXPLAIN (PLAN,METADATA) SELECT 1
 ----
 Level  Type    Field Description    Columns Ordering
 0      render                       ("1")
 1      nullrow                      ()
 
 query ITTTTT colnames
-EXPLAIN (METADATA, PLAN) SELECT 1
+EXPLAIN (METADATA,PLAN) SELECT 1
 ----
 Level  Type      Field  Description Columns Ordering
 0      render                       ("1")
@@ -26,7 +26,7 @@ RowIdx  Key  Value  Disposition
 0       NULL NULL   ROW
 
 query ITTT colnames
-EXPLAIN (DEBUG, METADATA) SELECT 1
+EXPLAIN (DEBUG,METADATA) SELECT 1
 ----
 RowIdx  Key  Value  Disposition
 0       NULL NULL   ROW
@@ -47,20 +47,20 @@ Level  Type           Field     Description  Columns    Ordering
 1      nullrow                               ()
 
 statement error cannot set EXPLAIN mode more than once
-EXPLAIN (TRACE, TRACE) SELECT 1
+EXPLAIN (TRACE,TRACE) SELECT 1
 
 statement error cannot set EXPLAIN mode more than once
-EXPLAIN (DEBUG, TRACE) SELECT 1
+EXPLAIN (DEBUG,TRACE) SELECT 1
 
 statement error cannot set EXPLAIN mode more than once
-EXPLAIN (PLAN, DEBUG) SELECT 1
+EXPLAIN (PLAN,DEBUG) SELECT 1
 
 statement error unsupported EXPLAIN option
-EXPLAIN (TRACE, UNKNOWN) SELECT 1
+EXPLAIN (TRACE,UNKNOWN) SELECT 1
 
 # Ensure that tracing results are sorted after gathering
 query ITTTTT
-EXPLAIN(METADATA) EXPLAIN(TRACE) SELECT 1
+EXPLAIN (METADATA) EXPLAIN (TRACE) SELECT 1
 ----
 0  sort                                    ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition)
 0                 order  +Timestamp,+"Span Pos"

--- a/pkg/sql/testdata/explain_plan
+++ b/pkg/sql/testdata/explain_plan
@@ -62,7 +62,7 @@ EXPLAIN VALUES (1)
 0          size  1 column, 1 row
 
 query ITTT
-EXPLAIN(EXPRS) SELECT * FROM t WITH ORDINALITY LIMIT 1 OFFSET 1
+EXPLAIN (EXPRS) SELECT * FROM t WITH ORDINALITY LIMIT 1 OFFSET 1
 ----
 0  limit
 0                 count     1
@@ -83,7 +83,7 @@ EXPLAIN SELECT DISTINCT * FROM t
 1            spans  ALL
 
 query ITTT
-EXPLAIN(EXPRS) SELECT DISTINCT * FROM t LIMIT 1 OFFSET 1
+EXPLAIN (EXPRS) SELECT DISTINCT * FROM t LIMIT 1 OFFSET 1
 ----
 0  limit
 0                 count     1
@@ -98,7 +98,7 @@ statement ok
 CREATE TABLE tc (a INT, b INT, INDEX c(a))
 
 query ITTTTT
-EXPLAIN(METADATA) SELECT * FROM tc WHERE a = 10 ORDER BY b
+EXPLAIN (METADATA) SELECT * FROM tc WHERE a = 10 ORDER BY b
 ----
 0  sort                           (a, b)                                   =a,+b
 0              order  +b

--- a/pkg/sql/testdata/explain_types
+++ b/pkg/sql/testdata/explain_types
@@ -33,7 +33,7 @@ EXPLAIN (TYPES) SELECT * FROM t
 0        spans  ALL
 
 query ITTTTT
-EXPLAIN (TYPES, SYMVARS) SELECT k FROM t
+EXPLAIN (TYPES,SYMVARS) SELECT k FROM t
 ----
 0  render                      (k int)
 0         render 0  (@1)[int]
@@ -42,7 +42,7 @@ EXPLAIN (TYPES, SYMVARS) SELECT k FROM t
 1         spans     ALL
 
 query ITTTTT
-EXPLAIN (TYPES, QUALIFY) SELECT k FROM t
+EXPLAIN (TYPES,QUALIFY) SELECT k FROM t
 ----
 0  render                            (k int)
 0         render 0  (test.t.k)[int]
@@ -284,7 +284,7 @@ EXPLAIN (TYPES) SELECT $1 + 2 AS a
 1  nullrow                                               ()
 
 query ITTTTT
-EXPLAIN (TYPES, NONORMALIZE) SELECT ABS(2-3) AS a
+EXPLAIN (TYPES,NONORMALIZE) SELECT ABS(2-3) AS a
 ----
 0  render                                          (a int)
 0                 render 0  (abs((-1)[int]))[int]

--- a/pkg/sql/testdata/join
+++ b/pkg/sql/testdata/join
@@ -407,7 +407,7 @@ x  x  y  b  d  e
 
 # Check EXPLAIN.
 query ITTT
-EXPLAIN(EXPRS) SELECT * FROM onecolumn JOIN twocolumn USING(x)
+EXPLAIN (EXPRS) SELECT * FROM onecolumn JOIN twocolumn USING(x)
 ----
 0  render
 0                 render 0  x
@@ -424,7 +424,7 @@ EXPLAIN(EXPRS) SELECT * FROM onecolumn JOIN twocolumn USING(x)
 
 # Check EXPLAIN.
 query ITTT
-EXPLAIN(EXPRS) SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
+EXPLAIN (EXPRS) SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
 ----
 0  render
 0                 render 0  x
@@ -443,7 +443,7 @@ EXPLAIN(EXPRS) SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
 
 # Check EXPLAIN.
 query ITTT
-EXPLAIN(EXPRS) SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
+EXPLAIN (EXPRS) SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
 ----
 0  render
 0                 render 0  x
@@ -462,7 +462,7 @@ EXPLAIN(EXPRS) SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
 
 # Check EXPLAIN.
 query ITTT
-EXPLAIN(EXPRS) SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
+EXPLAIN (EXPRS) SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
 ----
 0  render
 0                 render 0  x
@@ -480,7 +480,7 @@ EXPLAIN(EXPRS) SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b
 
 # Check EXPLAIN.
 query ITTT
-EXPLAIN(EXPRS) SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
+EXPLAIN (EXPRS) SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
 ----
 0  render
 0                 render 0  x
@@ -498,7 +498,7 @@ EXPLAIN(EXPRS) SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn
 
 
 query ITTT
-EXPLAIN(EXPRS) SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twocolumn.x JOIN twocolumn AS c(d,e) ON a.b=c.d AND c.d=onecolumn.x) LIMIT 1
+EXPLAIN (EXPRS) SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twocolumn.x JOIN twocolumn AS c(d,e) ON a.b=c.d AND c.d=onecolumn.x) LIMIT 1
 ----
 0  limit
 0                 count     1

--- a/pkg/sql/testdata/needed_columns
+++ b/pkg/sql/testdata/needed_columns
@@ -1,5 +1,5 @@
 query ITTTTT
-EXPLAIN (METADATA, NOOPTIMIZE) SELECT 1 FROM (SELECT 2 AS s)
+EXPLAIN (METADATA,NOOPTIMIZE) SELECT 1 FROM (SELECT 2 AS s)
 ----
 0   render                          ("1")
 1   render                          (s)
@@ -106,7 +106,7 @@ statement ok
 CREATE TABLE kv(k INT PRIMARY KEY, v INT)
 
 query ITTTTT
-EXPLAIN(METADATA) SELECT 1 FROM kv
+EXPLAIN (METADATA) SELECT 1 FROM kv
 ----
 0   render                         ("1")
 1   scan                           (k[omitted], v[omitted])
@@ -125,7 +125,7 @@ EXPLAIN (METADATA) SELECT DISTINCT v FROM kv
 
 # Propagation through INSERT.
 query ITTTTT
-EXPLAIN(METADATA) INSERT INTO kv(k, v) SELECT 1, 2 FROM (SELECT 3 AS x, 4 AS y)
+EXPLAIN (METADATA) INSERT INTO kv(k, v) SELECT 1, 2 FROM (SELECT 3 AS x, 4 AS y)
 ----
 0   insert                          ()
 0             into    kv(k, v)

--- a/pkg/sql/testdata/order_by
+++ b/pkg/sql/testdata/order_by
@@ -292,7 +292,7 @@ EXPLAIN SELECT * FROM t ORDER BY length('abc')
 
 # Check that the sort key reuses the existing render.
 query ITTTTT
-EXPLAIN(METADATA) SELECT b+2 FROM t ORDER BY b+2
+EXPLAIN (METADATA) SELECT b+2 FROM t ORDER BY b+2
 ----
 0  sort                      ("b + 2")                    +"b + 2"
 0          order  +"b + 2"
@@ -303,7 +303,7 @@ EXPLAIN(METADATA) SELECT b+2 FROM t ORDER BY b+2
 
 # Check that the sort picks up a renamed render properly.
 query ITTTTT
-EXPLAIN(METADATA) SELECT b+2 AS y FROM t ORDER BY y
+EXPLAIN (METADATA) SELECT b+2 AS y FROM t ORDER BY y
 ----
 0  sort                      (y)                          +y
 0          order  +y
@@ -314,7 +314,7 @@ EXPLAIN(METADATA) SELECT b+2 AS y FROM t ORDER BY y
 
 # Check that the sort reuses a render behind a rename properly.
 query ITTTTT
-EXPLAIN(METADATA) SELECT b+2 AS y FROM t ORDER BY b+2
+EXPLAIN (METADATA) SELECT b+2 AS y FROM t ORDER BY b+2
 ----
 0  sort                      (y)                          +y
 0          order  +y
@@ -420,7 +420,7 @@ EXPLAIN SELECT a, b FROM abc ORDER BY b, c
 2          spans  ALL
 
 query ITTTTT
-EXPLAIN(VERBOSE) SELECT a, b FROM abc ORDER BY b, c
+EXPLAIN (VERBOSE) SELECT a, b FROM abc ORDER BY b, c
 ----
 0  nosort                        (a, b)                 +b
 0          order     +b,+c
@@ -595,7 +595,7 @@ NaN
 1
 
 query ITTTTT
-EXPLAIN(METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x)
+EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x)
 ----
 0  sort                             (x)        +x
 0          order  +x
@@ -620,7 +620,7 @@ EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordi
 2              size   1 column, 3 rows
 
 query ITTTTT
-EXPLAIN(METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY
+EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY
 ----
 0  ordinality                          (x, ordinality)  +ordinality,unique
 1  render                              (x)
@@ -628,7 +628,7 @@ EXPLAIN(METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c
 2              size  1 column, 3 rows
 
 query ITTTTT
-EXPLAIN(METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY
+EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY
 ----
 0  ordinality                           (x, ordinality)  +x
 1  sort                                 (x)              +x

--- a/pkg/sql/testdata/ordinal_references
+++ b/pkg/sql/testdata/ordinal_references
@@ -46,7 +46,7 @@ a 3
 
 # Check that sort by ordinal picks up the existing render.
 query ITTTTT
-EXPLAIN(VERBOSE) SELECT b, a FROM foo ORDER BY @1
+EXPLAIN (VERBOSE) SELECT b, a FROM foo ORDER BY @1
 ----
 0  sort                           (b, a)                         +a
 0          order     +a
@@ -79,7 +79,7 @@ SELECT SUM(a) AS s FROM foo GROUP BY @2 ORDER BY s
 
 # Check that GROUP BY picks up column ordinals.
 query ITTTTT
-EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1
+EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1
 ----
 0  group                                 (m)
 0          aggregate 0  min(test.foo.a)
@@ -92,7 +92,7 @@ EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1
 2          spans        ALL
 
 query ITTTTT
-EXPLAIN(VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2
+EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2
 ----
 0  group                                 (m)
 0          aggregate 0  min(test.foo.a)

--- a/pkg/sql/testdata/select_non_covering_index
+++ b/pkg/sql/testdata/select_non_covering_index
@@ -129,7 +129,7 @@ EXPLAIN SELECT * FROM t ORDER BY c LIMIT 5
 2              table  t@primary
 
 query ITTT
-EXPLAIN(EXPRS) SELECT * FROM t ORDER BY c OFFSET 5
+EXPLAIN (EXPRS) SELECT * FROM t ORDER BY c OFFSET 5
 ----
 0  limit
 0         offset    5
@@ -140,7 +140,7 @@ EXPLAIN(EXPRS) SELECT * FROM t ORDER BY c OFFSET 5
 2         spans     ALL
 
 query ITTT
-EXPLAIN(EXPRS) SELECT * FROM t ORDER BY c LIMIT 5 OFFSET 5
+EXPLAIN (EXPRS) SELECT * FROM t ORDER BY c LIMIT 5 OFFSET 5
 ----
 0  limit
 0              count     5
@@ -154,7 +154,7 @@ EXPLAIN(EXPRS) SELECT * FROM t ORDER BY c LIMIT 5 OFFSET 5
 2              table     t@primary
 
 query ITTT
-EXPLAIN(EXPRS) SELECT * FROM t ORDER BY c LIMIT 1000000
+EXPLAIN (EXPRS) SELECT * FROM t ORDER BY c LIMIT 1000000
 ----
 0  limit
 0          count     1000000

--- a/pkg/sql/testdata/select_non_covering_index_filtering
+++ b/pkg/sql/testdata/select_non_covering_index_filtering
@@ -28,7 +28,7 @@ INSERT INTO t VALUES
   (9, 3, 3, '33')
 
 query ITTT
-EXPLAIN(EXPRS) SELECT * FROM t WHERE b = 2 AND c % 2 = 0
+EXPLAIN (EXPRS) SELECT * FROM t WHERE b = 2 AND c % 2 = 0
 ----
 0  index-join
 1  scan
@@ -51,7 +51,7 @@ EXPLAIN (DEBUG) SELECT * FROM t WHERE b = 2 AND c % 2 = 0
 2 /t/bc/2/3/6    NULL FILTERED
 
 query ITTT
-EXPLAIN(EXPRS) SELECT * FROM t WHERE b = 2 AND c != b
+EXPLAIN (EXPRS) SELECT * FROM t WHERE b = 2 AND c != b
 ----
 0  index-join
 1  scan
@@ -121,7 +121,7 @@ EXPLAIN (DEBUG) SELECT * FROM t WHERE b > 1 AND ((c = b+1 AND s != '23') OR (a >
 # To test this we need an expression containing non-indexed
 # columns that disappears during range simplification.
 query ITTTTT
-EXPLAIN(VERBOSE) SELECT a FROM t WHERE b = 2 OR ((b BETWEEN 2 AND 1) AND ((s != 'a') OR (s = 'a')))
+EXPLAIN (VERBOSE) SELECT a FROM t WHERE b = 2 OR ((b BETWEEN 2 AND 1) AND ((s != 'a') OR (s = 'a')))
 ----
 0  render                           (a)
 0              render 0  test.t.a

--- a/pkg/sql/testdata/subquery
+++ b/pkg/sql/testdata/subquery
@@ -340,7 +340,7 @@ true
 
 # check that residual filters are not expanded twice
 query ITTTTT
-EXPLAIN(METADATA) SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz)
+EXPLAIN (METADATA) SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz)
 ----
 0  render                           (x)
 1  scan                             (x, y[omitted], z[omitted])


### PR DESCRIPTION
This is nitpicky but it felt a bit sloppy that we don't have a consistent
format for EXPLAIN. Changed all instances to `EXPLAIN (X[,Y])`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13729)
<!-- Reviewable:end -->
