### PR TITLE
leaktest: remove ignoring of net.(*netFD).connect

### DIFF
--- a/pkg/util/leaktest/leaktest.go
+++ b/pkg/util/leaktest/leaktest.go
@@ -37,9 +37,6 @@ func interestingGoroutines() map[int64]string {
 
 		if stack == "" ||
 			strings.Contains(stack, "github.com/cockroachdb/cockroach/pkg/util/log.init") ||
-			// Go1.7 added a goroutine to network dialing that doesn't shut down
-			// quickly.
-			strings.Contains(stack, "created by net.(*netFD).connect") ||
 			// Below are the stacks ignored by the upstream leaktest code.
 			strings.Contains(stack, "testing.Main(") ||
 			strings.Contains(stack, "testing.tRunner(") ||


### PR DESCRIPTION
Closes #7760.

This may be platform-specific, so let's see what CI says.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13730)
<!-- Reviewable:end -->
