### PR TITLE
storage: Move Replica.mu.tsCache to Replica.tsCacheMu.

### DIFF
--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -235,9 +235,9 @@ func (r *Replica) GetLease() (*roachpb.Lease, *roachpb.Lease) {
 
 // GetTimestampCacheLowWater returns the timestamp cache low water mark.
 func (r *Replica) GetTimestampCacheLowWater() hlc.Timestamp {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.mu.tsCache.lowWater
+	r.tsCacheMu.Lock()
+	defer r.tsCacheMu.Unlock()
+	return r.tsCacheMu.cache.lowWater
 }
 
 // GetRaftLogSize returns the raft log size.

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -96,9 +96,7 @@ type ProposalData struct {
 // invoked here in order to allow the original client to be cancelled
 // and possibly no longer listening to this done channel, and so can't
 // be counted on to invoke endCmds itself.
-// replica.mu needs to be held for the replica that's waiting for the
-// application of this proposal.
-func (proposal *ProposalData) finishLocked(pr proposalResult) {
+func (proposal *ProposalData) finish(pr proposalResult) {
 	if proposal.endCmds != nil {
 		proposal.endCmds.done(pr.Reply, pr.Err, pr.ProposalRetry)
 		proposal.endCmds = nil

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -100,7 +100,7 @@ type ProposalData struct {
 // application of this proposal.
 func (proposal *ProposalData) finishLocked(pr proposalResult) {
 	if proposal.endCmds != nil {
-		proposal.endCmds.doneLocked(pr.Reply, pr.Err, pr.ProposalRetry)
+		proposal.endCmds.done(pr.Reply, pr.Err, pr.ProposalRetry)
 		proposal.endCmds = nil
 	}
 	proposal.doneCh <- pr
@@ -404,9 +404,9 @@ func (r *Replica) leasePostApply(
 			log.Infof(ctx, "new range lease %s following %s [physicalTime=%s]",
 				newLease, prevLease, r.store.Clock().PhysicalTime())
 		}
-		r.mu.Lock()
-		r.mu.tsCache.SetLowWater(newLease.Start)
-		r.mu.Unlock()
+		r.tsCacheMu.Lock()
+		r.tsCacheMu.cache.SetLowWater(newLease.Start)
+		r.tsCacheMu.Unlock()
 
 		// Gossip the first range whenever its lease is acquired. We check to
 		// make sure the lease is active so that a trailing replica won't process
@@ -420,9 +420,9 @@ func (r *Replica) leasePostApply(
 		// anything currently cached. The timestamp cache is only used by the
 		// lease holder. Note that we'll call SetLowWater when we next acquire
 		// the lease.
-		r.mu.Lock()
-		r.mu.tsCache.Clear(r.store.Clock().Now())
-		r.mu.Unlock()
+		r.tsCacheMu.Lock()
+		r.tsCacheMu.cache.Clear(r.store.Clock().Now())
+		r.tsCacheMu.Unlock()
 		// Also clear and disable the push transaction queue. Any waiters
 		// must be redirected to the new lease holder.
 		r.pushTxnQueue.ClearAndDisable()

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -1070,10 +1070,10 @@ func TestReplicaTSCacheLowWaterOnLease(t *testing.T) {
 			t.Fatalf("%d: unexpected error %v", i, err)
 		}
 		// Verify expected low water mark.
-		tc.repl.mu.Lock()
-		rTS, _, _ := tc.repl.mu.tsCache.GetMaxRead(roachpb.Key("a"), nil)
-		wTS, _, _ := tc.repl.mu.tsCache.GetMaxWrite(roachpb.Key("a"), nil)
-		tc.repl.mu.Unlock()
+		tc.repl.tsCacheMu.Lock()
+		rTS, _, _ := tc.repl.tsCacheMu.cache.GetMaxRead(roachpb.Key("a"), nil)
+		wTS, _, _ := tc.repl.tsCacheMu.cache.GetMaxWrite(roachpb.Key("a"), nil)
+		tc.repl.tsCacheMu.Unlock()
 
 		if test.expLowWater == 0 {
 			continue
@@ -1887,28 +1887,28 @@ func TestReplicaUpdateTSCache(t *testing.T) {
 		t.Error(pErr)
 	}
 	// Verify the timestamp cache has rTS=1s and wTS=0s for "a".
-	tc.repl.mu.Lock()
-	defer tc.repl.mu.Unlock()
-	_, _, rOK := tc.repl.mu.tsCache.GetMaxRead(roachpb.Key("a"), nil)
-	_, _, wOK := tc.repl.mu.tsCache.GetMaxWrite(roachpb.Key("a"), nil)
+	tc.repl.tsCacheMu.Lock()
+	defer tc.repl.tsCacheMu.Unlock()
+	_, _, rOK := tc.repl.tsCacheMu.cache.GetMaxRead(roachpb.Key("a"), nil)
+	_, _, wOK := tc.repl.tsCacheMu.cache.GetMaxWrite(roachpb.Key("a"), nil)
 	if rOK || wOK {
 		t.Errorf("expected rOK=false and wOK=false; rOK=%t, wOK=%t", rOK, wOK)
 	}
-	tc.repl.mu.tsCache.ExpandRequests(hlc.Timestamp{})
-	rTS, _, rOK := tc.repl.mu.tsCache.GetMaxRead(roachpb.Key("a"), nil)
-	wTS, _, wOK := tc.repl.mu.tsCache.GetMaxWrite(roachpb.Key("a"), nil)
+	tc.repl.tsCacheMu.cache.ExpandRequests(hlc.Timestamp{})
+	rTS, _, rOK := tc.repl.tsCacheMu.cache.GetMaxRead(roachpb.Key("a"), nil)
+	wTS, _, wOK := tc.repl.tsCacheMu.cache.GetMaxWrite(roachpb.Key("a"), nil)
 	if rTS.WallTime != t0.Nanoseconds() || wTS.WallTime != startNanos || !rOK || wOK {
 		t.Errorf("expected rTS=1s and wTS=0s, but got %s, %s; rOK=%t, wOK=%t", rTS, wTS, rOK, wOK)
 	}
 	// Verify the timestamp cache has rTS=0s and wTS=2s for "b".
-	rTS, _, rOK = tc.repl.mu.tsCache.GetMaxRead(roachpb.Key("b"), nil)
-	wTS, _, wOK = tc.repl.mu.tsCache.GetMaxWrite(roachpb.Key("b"), nil)
+	rTS, _, rOK = tc.repl.tsCacheMu.cache.GetMaxRead(roachpb.Key("b"), nil)
+	wTS, _, wOK = tc.repl.tsCacheMu.cache.GetMaxWrite(roachpb.Key("b"), nil)
 	if rTS.WallTime != startNanos || wTS.WallTime != t1.Nanoseconds() || rOK || !wOK {
 		t.Errorf("expected rTS=0s and wTS=2s, but got %s, %s; rOK=%t, wOK=%t", rTS, wTS, rOK, wOK)
 	}
 	// Verify another key ("c") has 0sec in timestamp cache.
-	rTS, _, rOK = tc.repl.mu.tsCache.GetMaxRead(roachpb.Key("c"), nil)
-	wTS, _, wOK = tc.repl.mu.tsCache.GetMaxWrite(roachpb.Key("c"), nil)
+	rTS, _, rOK = tc.repl.tsCacheMu.cache.GetMaxRead(roachpb.Key("c"), nil)
+	wTS, _, wOK = tc.repl.tsCacheMu.cache.GetMaxWrite(roachpb.Key("c"), nil)
 	if rTS.WallTime != startNanos || wTS.WallTime != startNanos || rOK || wOK {
 		t.Errorf("expected rTS=0s and wTS=0s, but got %s %s; rOK=%t, wOK=%t", rTS, wTS, rOK, wOK)
 	}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -1799,7 +1799,7 @@ func TestLeaseConcurrent(t *testing.T) {
 						// otherwise its context (and tracing span) may be used after the
 						// client cleaned up.
 						delete(tc.repl.mu.proposals, proposal.idKey)
-						proposal.finishLocked(proposalResult{Err: roachpb.NewErrorf(origMsg)})
+						proposal.finish(proposalResult{Err: roachpb.NewErrorf(origMsg)})
 						return
 					}
 					if err := defaultSubmitProposalLocked(tc.repl, proposal); err != nil {


### PR DESCRIPTION
Providing a separate mutex for the per-Replica timestamp cache
simplifies the locking in endCmds.done, avoids holding Replica.mu while
manipulating the command queue (in the read-only path) and paves the way
for moving away from a per-replica timestamp cache structure (see #9423).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13741)
<!-- Reviewable:end -->
