### PR TITLE
sql: permit anycase postgres-style duration fields

### DIFF
--- a/pkg/sql/parser/eval_test.go
+++ b/pkg/sql/parser/eval_test.go
@@ -353,6 +353,8 @@ func TestEval(t *testing.T) {
 		{`'1-2 4:09:55'::interval IS OF (INTERVAL)`, `true`},
 		{`'1-2 3 4:09:55'::interval IS OF (INTERVAL)`, `true`},
 		{`'1 hour 2 minutes'::interval IS OF (INTERVAL)`, `true`},
+		// #13716
+		{`'1 HOUR 2 MINutES'::interval IS OF (INTERVAL)`, `true`},
 		{`1 IS OF (STRING)`, `false`},
 		{`1 IS OF (BOOL, INT)`, `true`},
 		{`1 IS NOT OF (INT)`, `false`},

--- a/pkg/sql/parser/interval.go
+++ b/pkg/sql/parser/interval.go
@@ -330,6 +330,7 @@ var postgresUnitMap = map[string]duration.Duration{
 
 // Parses a duration in the "traditional" Postgres format.
 func postgresToDuration(s string) (duration.Duration, error) {
+	s = strings.ToLower(s)
 	var d duration.Duration
 	l := intervalLexer{str: s, offset: 0, err: nil}
 	for l.offset != len(l.str) {


### PR DESCRIPTION
We previously only allowed postgres-style duration parsing (e.g.
`1 years 3 months`) when the duration fields were lowercased. Postgres
allows all cases for these; so should we.

Resolves #13716.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13748)
<!-- Reviewable:end -->
