### PR TITLE
timeutil: inline github.com/jeffjen/datefmt

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b20a72348a0c3a7ca135d14be1ff5bb8268b8c3867bcb128a966a0c890355fa7
-updated: 2017-02-22T13:01:13.800134121-05:00
+hash: f8b280945f169c45789262e00915cfa207bea48686b38404794918e300de3c34
+updated: 2017-02-23T11:42:45.857302326-05:00
 imports:
 - name: cloud.google.com/go
   version: 1ed2f0abb2869a51b3a5b9daec801bf9791f95d0
@@ -40,7 +40,7 @@ imports:
 - name: github.com/cockroachdb/c-jemalloc
   version: 7eb7980d8a9f68b771568a7eb15196a63a818595
 - name: github.com/cockroachdb/c-protobuf
-  version: 033462a6a2ba42305bd63922bc76cf7b3f834aff
+  version: 323984796a7b4794ee62a00e12456743a5b66765
   subpackages:
   - cmd/protoc
 - name: github.com/cockroachdb/c-rocksdb
@@ -194,8 +194,6 @@ imports:
   - utilities
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
-- name: github.com/jeffjen/datefmt
-  version: 6688647cfa0439b86e09b097cac96ed328d5fa34
 - name: github.com/jteeuwen/go-bindata
   version: a0ff2567cfb70903282db057e799fd826784d41d
   subpackages:
@@ -405,7 +403,7 @@ imports:
   - tap
   - transport
 - name: gopkg.in/yaml.v2
-  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+  version: a3f3340b5840cee44f372bddb5880fcbc419b46a
 - name: honnef.co/go/tools
   version: 0cd9a3997b51c13198691879e13c49da7ba0f8f9
   subpackages:

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -862,7 +862,7 @@ var Builtins = map[string][]Builtin{
 			fn: func(_ *EvalContext, args Datums) (Datum, error) {
 				format := string(MustBeDString(args[0]))
 				toParse := string(MustBeDString(args[1]))
-				t, err := timeutil.Strptime(toParse, format)
+				t, err := timeutil.Strptime(format, toParse)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/util/timeutil/conv.go
+++ b/pkg/util/timeutil/conv.go
@@ -18,20 +18,47 @@ package timeutil
 
 import (
 	"time"
+	"unsafe"
 
-	"github.com/jeffjen/datefmt"
 	"github.com/leekchan/timeutil"
+	"github.com/pkg/errors"
 )
 
+// This is a modified version of github.com/jeffjen/datefmt inlined here until
+// https://github.com/jeffjen/datefmt/pull/3 is merged.
+
+// #include <stdlib.h>
+// #define __USE_XOPEN
+// #include <time.h>
+import "C"
+
 // Strftime converts a time to a string using some C-style format.
-func Strftime(time time.Time, fmt string) (string, error) {
-	return timeutil.Strftime(&time, fmt), nil
+func Strftime(t time.Time, layout string) (string, error) {
+	return timeutil.Strftime(&t, layout), nil
 }
 
 // Strptime converts a string to a time using some C-style format.
-func Strptime(time, fmt string) (time.Time, error) {
-	// TODO(knz) The `datefmt` package uses C's `strptime` which doesn't
+func Strptime(layout, value string) (time.Time, error) {
+	// TODO(knz) this uses C's `strptime` which doesn't
 	// know about microseconds. We may want to change to an
 	// implementation that does this better.
-	return datefmt.Strptime(fmt, time)
+	cLayout := C.CString(layout)
+	defer C.free(unsafe.Pointer(cLayout))
+	cValue := C.CString(value)
+	defer C.free(unsafe.Pointer(cValue))
+
+	var cTime C.struct_tm
+	if _, err := C.strptime(cValue, cLayout, &cTime); err != nil {
+		return time.Time{}, errors.Wrapf(err, "could not parse %s as %s", value, layout)
+	}
+	return time.Date(
+		int(cTime.tm_year)+1900,
+		time.Month(cTime.tm_mon+1),
+		int(cTime.tm_mday),
+		int(cTime.tm_hour),
+		int(cTime.tm_min),
+		int(cTime.tm_sec),
+		0,
+		time.FixedZone("", int(cTime.tm_gmtoff)),
+	), nil
 }

--- a/pkg/util/timeutil/conv_test.go
+++ b/pkg/util/timeutil/conv_test.go
@@ -46,9 +46,9 @@ func TestTimeConversion(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		tm, err := Strptime(test.start, test.format)
+		tm, err := Strptime(test.format, test.start)
 		if err != nil {
-			t.Errorf("strptime(%q, %q): %v", test.start, test.format, err)
+			t.Errorf("strptime(%q, %q): %v", test.format, test.start, err)
 			continue
 		}
 		tm = tm.UTC()


### PR DESCRIPTION
https://github.com/jeffjen/datefmt/pull/3 is needed to support windows
but the author has been slow to respond. Inlining for now (for ever?).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13750)
<!-- Reviewable:end -->
