### PR TITLE
sql: fix CREATE TABLE AS when applied to non-storable data types.

### DIFF
--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -1119,8 +1119,8 @@ func makeTableDescIfAs(
 	parentID, id sqlbase.ID,
 	resultColumns []ResultColumn,
 	privileges *sqlbase.PrivilegeDescriptor,
-) (sqlbase.TableDescriptor, error) {
-	desc := sqlbase.TableDescriptor{
+) (desc sqlbase.TableDescriptor, err error) {
+	desc = sqlbase.TableDescriptor{
 		ID:            id,
 		ParentID:      parentID,
 		FormatVersion: sqlbase.InterleavedFormatVersion,
@@ -1133,7 +1133,10 @@ func makeTableDescIfAs(
 	}
 	desc.Name = tableName.Table()
 	for i, colRes := range resultColumns {
-		colType, _ := parser.DatumTypeToColumnType(colRes.Typ)
+		colType, err := parser.DatumTypeToColumnType(colRes.Typ)
+		if err != nil {
+			return desc, err
+		}
 		columnTableDef := parser.ColumnTableDef{Name: parser.Name(colRes.Name), Type: colType}
 		if len(p.AsColumnNames) > i {
 			columnTableDef.Name = p.AsColumnNames[i]

--- a/pkg/sql/parser/col_types.go
+++ b/pkg/sql/parser/col_types.go
@@ -430,7 +430,7 @@ func DatumTypeToColumnType(t Type) (ColumnType, error) {
 			return &CollatedStringColType{Name: "STRING", Locale: typ.Locale}, nil
 		}
 	}
-	return nil, errors.Errorf("internal error: unknown Datum type %s", t)
+	return nil, errors.Errorf("value type %s cannot be used for table columns", t)
 }
 
 // CastTargetToDatumType produces a Type equivalent to the given

--- a/pkg/sql/testdata/create_as
+++ b/pkg/sql/testdata/create_as
@@ -80,3 +80,12 @@ CREATE TABLE foo (x, y, z) AS SELECT catalog_name, schema_name, sql_path FROM in
 
 statement error pq: relation "foo" already exists
 CREATE TABLE foo (x, y, z) AS SELECT catalog_name, schema_name, sql_path FROM information_schema.schemata
+
+statement error pq: value type tuple{} cannot be used for table columns
+CREATE TABLE foo2 (x) AS (VALUES(ROW()))
+
+statement error pq: value type setof tuple{int} cannot be used for table columns
+CREATE TABLE foo2 (x) AS (VALUES(generate_series(1,3)))
+
+statement error pq: value type NULL cannot be used for table columns
+CREATE TABLE foo2 (x) AS (VALUES(NULL))


### PR DESCRIPTION
Prior to this patch CREATE TABLE AS would blindly convert the data
type resulting from type checking its data source operand to a column
type. Unfortunately we have a couple of types which do not have
equivalent column types, like arrays or tuples.

This patch ensures that an error resulting from the conversion, if
any, is not ignored.

Fixes #13738.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13751)
<!-- Reviewable:end -->
