### PR TITLE
sql: deflake TestSchemaChangeReverseMutations

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -1476,6 +1476,9 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 
 		// Ensure that sql is using the correct table lease.
 		if len(cols) != len(expectedCols) {
+			if err := rows.Close(); err != nil {
+				t.Fatal(err)
+			}
 			return errors.Errorf("incorrect columns: %v, expected: %v", cols, expectedCols)
 		}
 		if cols[0] != expectedCols[0] || cols[1] != expectedCols[1] {


### PR DESCRIPTION
Need to call sql.Rows.Close to avoid a goroutine leak in go1.8. NB:
sql.Rows are automatically closed when Rows.Next returns false.

See #13753

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13755)
<!-- Reviewable:end -->
