### PR TITLE
sql: pgwire correctly handles zero-column tables

### DIFF
--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -727,6 +727,10 @@ func TestPGPreparedQuery(t *testing.T) {
 		"SELECT s from (VALUES ('foo'), ('bar')) as t(s) WHERE s = ANY($1)": {
 			baseTest.SetArgs(pq.StringArray([]string{"foo"})).Results("foo"),
 		},
+		// #13725
+		"SELECT * FROM d.empty": {
+			baseTest.SetArgs(),
+		},
 
 		// TODO(jordan) blocked on #13651
 		//"SELECT $1::INT[]": {
@@ -832,7 +836,8 @@ INSERT INTO d.t VALUES (10),(11);
 CREATE TABLE d.ts (a TIMESTAMP, b DATE);
 CREATE TABLE d.two (a INT, b INT);
 CREATE TABLE d.intStr (a INT, s STRING);
-CREATE TABLE d.str (s STRING, b BYTES);`
+CREATE TABLE d.str (s STRING, b BYTES);
+CREATE TABLE d.empty ();`
 	if _, err := db.Exec(initStmt); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/testdata/table
+++ b/pkg/sql/testdata/table
@@ -429,3 +429,10 @@ query error pq: unimplemented: VECTOR column types are unsupported \(see issue h
 CREATE TABLE IF NOT EXISTS test.int_array_test (
   arr INT2VECTOR
 )
+
+# Regression test for #13725
+statement ok
+CREATE TABLE test.empty ()
+
+statement ok
+SELECT * FROM test.empty


### PR DESCRIPTION
When returning a selection with 0 columns from a non-prepared query,
pgwire used to incorrectly send a NoData message. This is incompatible
with the pgwire spec, which does not allow such behavior during simple
queries.

cc @benesch 

Resolves #13725.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13765)
<!-- Reviewable:end -->
