### PR TITLE
engine: fix intent detection in MVCCIncrementalIterator

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -12,7 +12,6 @@ import (
 	"bytes"
 	gosql "database/sql"
 	"fmt"
-	"hash/crc32"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -69,7 +68,7 @@ func bankDataInsertStmts(count int) []string {
 				insert.WriteRune(',')
 			}
 			payload := randutil.RandBytes(rng, backupRestoreRowPayloadSize)
-			fmt.Fprintf(&insert, `(%d, %d, '%s')`, j, 0, payload)
+			fmt.Fprintf(&insert, `(%d, %d, 'initial-%s')`, j, 0, payload)
 		}
 		statements = append(statements, insert.String())
 	}
@@ -280,7 +279,9 @@ func TestBackupRestoreInterleaved(t *testing.T) {
 	})
 }
 
-func startBankTransfers(stopper *stop.Stopper, sqlDB *gosql.DB, numAccounts int) error {
+func startBackgroundWrites(
+	stopper *stop.Stopper, sqlDB *gosql.DB, wake chan<- struct{}, maxID int,
+) error {
 	rng, _ := randutil.NewPseudoRand()
 
 	for {
@@ -291,7 +292,7 @@ func startBankTransfers(stopper *stop.Stopper, sqlDB *gosql.DB, numAccounts int)
 			// Keep going.
 		}
 
-		account := rand.Intn(numAccounts)
+		id := rand.Intn(maxID)
 		payload := randutil.RandBytes(rng, backupRestoreRowPayloadSize)
 
 		updateFn := func() error {
@@ -301,12 +302,15 @@ func startBankTransfers(stopper *stop.Stopper, sqlDB *gosql.DB, numAccounts int)
 			default:
 				// Keep going.
 			}
-			_, err := sqlDB.Exec(`UPDATE bench.bank SET payload = $1 WHERE id = $2`,
-				payload, account)
+			_, err := sqlDB.Exec(`UPDATE bench.bank SET payload = $1 WHERE id = $2`, payload, id)
 			return err
 		}
 		if err := util.RetryForDuration(testutils.DefaultSucceedsSoonDuration, updateFn); err != nil {
 			return err
+		}
+		select {
+		case wake <- struct{}{}:
+		default:
 		}
 	}
 }
@@ -321,82 +325,59 @@ func TestBackupRestoreBank(t *testing.T) {
 	// TODO(dan): Actually invalidate the descriptor cache and delete this line.
 	defer sql.TestDisableTableLeases()()
 
-	const numAccounts = 10
-	const numTransferTasks = multiNode
+	const rows = 10
+	const numBackgroundTasks = multiNode
 	const backupRestoreIterations = 3
 
-	_, baseDir, tc, sqlDB, cleanupFn := backupRestoreTestSetup(t, multiNode, numAccounts)
+	_, baseDir, tc, sqlDB, cleanupFn := backupRestoreTestSetup(t, multiNode, rows)
 	defer cleanupFn()
 
-	for i := 0; i < numTransferTasks; i++ {
+	bgActivity := make(chan struct{})
+
+	for i := 0; i < numBackgroundTasks; i++ {
 		taskNum := i
 		tc.Stopper().RunWorker(func() {
 			// Use different sql gateways to make sure leasing is right.
-			err := startBankTransfers(tc.Stopper(), tc.Conns[taskNum%len(tc.Conns)], numAccounts)
+			err := startBackgroundWrites(tc.Stopper(), tc.Conns[taskNum%len(tc.Conns)], bgActivity, rows)
 			if err != nil {
 				t.Error(err)
 			}
 		})
 	}
 
-	waitForChecksumChange := func(currentChecksum uint32) uint32 {
-		var newChecksum uint32
-		testutils.SucceedsSoon(t, func() error {
-			crc := crc32.New(crc32.MakeTable(crc32.Castagnoli))
-			rows := sqlDB.Query(`SELECT payload FROM bench.bank`)
-			defer rows.Close()
-			var payload []byte
-			for rows.Next() {
-				if err := rows.Scan(&payload); err != nil {
-					t.Fatal(err)
-				}
-				if _, err := crc.Write(payload); err != nil {
-					t.Fatal(err)
-				}
-			}
-			if err := rows.Err(); err != nil {
-				t.Fatal(err)
-			}
-			newChecksum = crc.Sum32()
-			if newChecksum == currentChecksum {
-				return errors.Errorf("waiting for checksum to change %d", newChecksum)
-			}
-			return nil
-		})
-		return newChecksum
-	}
-
 	// Use the bench.bank table as a key (id), value (balance) table with a
-	// payload. Repeatedly run backups and restores while the transfer tasks are
+	// payload. Repeatedly run backups and restores while the background tasks are
 	// mutating the table concurrently. Wait in between each backup and each
 	// restore for the data to change.
-	var checksum uint32
 	for i := 0; i < backupRestoreIterations; i++ {
 		dir := filepath.Join(baseDir, strconv.Itoa(i))
 
+		<-bgActivity
+
 		// Set the id=balance invariant on each row and back up the table.
-		checksum = waitForChecksumChange(checksum)
-		_ = sqlDB.Exec(`UPDATE bench.bank SET balance = id`)
-		_ = sqlDB.Exec(fmt.Sprintf(`BACKUP DATABASE bench TO '%s'`, dir))
+		sqlDB.Exec(`UPDATE bench.bank SET balance = id`)
+
+		sqlDB.Exec(fmt.Sprintf(`BACKUP DATABASE bench TO '%s'`, dir))
+
+		<-bgActivity
 
 		// Break the id=balance invariant on every row in the current table.
 		// When we restore, it'll blow away this data, but if restore doesn't
 		// work we can tell by looking for these.
-		checksum = waitForChecksumChange(checksum)
-		_ = sqlDB.Exec(`UPDATE bench.bank SET balance = -1`)
+		sqlDB.Exec(`UPDATE bench.bank SET balance = -1`)
 
-		// Restore and wait for the new descriptor to be gossiped out. We can
-		// tell that this happened when id=balance holds again.
-		checksum = waitForChecksumChange(checksum)
-		_ = sqlDB.Exec(fmt.Sprintf(`RESTORE DATABASE bench FROM '%s'`, dir))
-		testutils.SucceedsSoon(t, func() error {
-			var failures int
-			sqlDB.QueryRow(`SELECT COUNT(id) FROM bench.bank WHERE id != balance`).Scan(&failures)
-			if failures > 0 {
-				return errors.Errorf("The bank is not in good order. Total failures: %d", failures)
-			}
-			return nil
-		})
+		<-bgActivity
+
+		// Restore and check id=balance holds again.
+		sqlDB.Exec(fmt.Sprintf(`RESTORE DATABASE bench FROM '%s'`, dir))
+
+		bad := sqlDB.QueryStr(`SELECT id, balance, payload FROM bench.bank WHERE id != balance`)
+		for _, r := range bad {
+			t.Errorf("bad row ID %s = bal %s (payload: %q)", r[0], r[1], r[2])
+		}
+		if len(bad) > 0 {
+			break
+		}
 	}
 }
 

--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -317,7 +317,6 @@ func startBackgroundWrites(
 
 func TestBackupRestoreBank(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#13189")
 	if !storage.ProposerEvaluatedKVEnabled() {
 		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
 	}

--- a/pkg/ccl/storageccl/engineccl/mvcc.go
+++ b/pkg/ccl/storageccl/engineccl/mvcc.go
@@ -16,16 +16,16 @@ import (
 	"github.com/pkg/errors"
 )
 
-// MVCCIncrementalIterator iterates over the diff of the key range [start,end)
-// and time range [start,end). If a key was added or modified between startTime
-// and endTime, the iterator will position at the most recent version (before
-// endTime) of that key. If the key was most recently deleted, this is signalled
-// with an empty value.
+// MVCCIncrementalIterator iterates over the diff of the key range
+// [startKey,endKey) and time range [startTime,endTime). If a key was added or
+// modified between startTime and endTime, the iterator will position at the
+// most recent version (before endTime) of that key. If the key was most
+// recently deleted, this is signalled with an empty value.
 //
 // Expected usage:
 //    iter := NewMVCCIncrementalIterator(e)
 //    defer iter.Close()
-//    for iter.Reset(...); iter.Valid(); iter.Next() {
+//    for iter.Reset(startKey, endKey, ...); iter.Valid(); iter.Next() {
 //        [code using iter.Key() and iter.Value()]
 //    }
 //    if err := iter.Error(); err != nil {
@@ -119,7 +119,7 @@ func (i *MVCCIncrementalIterator) Next() {
 		}
 
 		if i.meta.Txn != nil {
-			if !i.meta.Timestamp.Less(i.endTime) {
+			if !i.endTime.Less(i.meta.Timestamp) {
 				i.err = &roachpb.WriteIntentError{
 					Intents: []roachpb.Intent{{Span: roachpb.Span{Key: metaKey.Key}, Status: roachpb.PENDING, Txn: *i.meta.Txn}},
 				}

--- a/pkg/ccl/storageccl/engineccl/mvcc_test.go
+++ b/pkg/ccl/storageccl/engineccl/mvcc_test.go
@@ -85,7 +85,7 @@ func TestMVCCIterateIncremental(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			iter := NewMVCCIncrementalIterator(e)
 			defer iter.Close()
-			for iter.Reset(keyMin, keyMax, ts0, ts3); iter.Valid(); iter.Next() {
+			for iter.Reset(keyMin, keyMax, startTime, endTime); iter.Valid(); iter.Next() {
 				// pass
 			}
 			if err := iter.Error(); !testutils.IsError(err, errString) {

--- a/pkg/ccl/storageccl/engineccl/mvcc_test.go
+++ b/pkg/ccl/storageccl/engineccl/mvcc_test.go
@@ -24,6 +24,49 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
+func iterateExpectErr(
+	e engine.Engine, startKey, endKey roachpb.Key, startTime, endTime hlc.Timestamp, errString string,
+) func(*testing.T) {
+	return func(t *testing.T) {
+		iter := NewMVCCIncrementalIterator(e)
+		defer iter.Close()
+		for iter.Reset(startKey, endKey, startTime, endTime); iter.Valid(); iter.Next() {
+			// pass
+		}
+		if err := iter.Error(); !testutils.IsError(err, errString) {
+			t.Fatalf("expected error %q but got %v", errString, err)
+		}
+	}
+}
+
+func assertEqualKVs(
+	e engine.Engine,
+	startKey, endKey roachpb.Key,
+	startTime, endTime hlc.Timestamp,
+	expected []engine.MVCCKeyValue,
+) func(*testing.T) {
+	return func(t *testing.T) {
+		iter := NewMVCCIncrementalIterator(e)
+		defer iter.Close()
+		var kvs []engine.MVCCKeyValue
+		for iter.Reset(startKey, endKey, startTime, endTime); iter.Valid(); iter.Next() {
+			kvs = append(kvs, engine.MVCCKeyValue{Key: iter.Key(), Value: iter.Value()})
+		}
+
+		if len(kvs) != len(expected) {
+			t.Fatalf("got %d kvs but expected %d: %v", len(kvs), len(expected), kvs)
+		}
+		for i := range kvs {
+			if !kvs[i].Key.Equal(expected[i].Key) {
+				t.Fatalf("%d key: got %v but expected %v", i, kvs[i].Key, expected[i].Key)
+			}
+			if !bytes.Equal(kvs[i].Value, expected[i].Value) {
+				t.Fatalf("%d value: got %x but expected %x", i, kvs[i].Value, expected[i].Value)
+			}
+		}
+	}
+}
+
 func TestMVCCIterateIncremental(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
@@ -53,57 +96,16 @@ func TestMVCCIterateIncremental(t *testing.T) {
 		return engine.MVCCKeyValue{Key: engine.MVCCKey{Key: key, Timestamp: ts}, Value: value}
 	}
 
-	assertEqualKVs := func(
-		startKey, endKey roachpb.Key, startTime, endTime hlc.Timestamp,
-		expected []engine.MVCCKeyValue,
-	) {
-		t.Run("", func(t *testing.T) {
-			iter := NewMVCCIncrementalIterator(e)
-			defer iter.Close()
-			var kvs []engine.MVCCKeyValue
-			for iter.Reset(startKey, endKey, startTime, endTime); iter.Valid(); iter.Next() {
-				kvs = append(kvs, engine.MVCCKeyValue{Key: iter.Key(), Value: iter.Value()})
-			}
-
-			if len(kvs) != len(expected) {
-				t.Fatalf("got %d kvs but expected %d: %v", len(kvs), len(expected), kvs)
-			}
-			for i := range kvs {
-				if !kvs[i].Key.Equal(expected[i].Key) {
-					t.Fatalf("%d key: got %v but expected %v", i, kvs[i].Key, expected[i].Key)
-				}
-				if !bytes.Equal(kvs[i].Value, expected[i].Value) {
-					t.Fatalf("%d value: got %x but expected %x", i, kvs[i].Value, expected[i].Value)
-				}
-			}
-		})
-	}
-
-	iterateExpectErr := func(
-		startKey, endKey roachpb.Key, startTime, endTime hlc.Timestamp, errString string,
-	) {
-		t.Run("", func(t *testing.T) {
-			iter := NewMVCCIncrementalIterator(e)
-			defer iter.Close()
-			for iter.Reset(keyMin, keyMax, startTime, endTime); iter.Valid(); iter.Next() {
-				// pass
-			}
-			if err := iter.Error(); !testutils.IsError(err, errString) {
-				t.Fatalf("expected error %q but got %v", errString, err)
-			}
-		})
-	}
-
 	kv1_1_1 := makeKVT(testKey1, testValue1, ts1)
 	kv1_4_4 := makeKVT(testKey1, testValue4, ts4)
-	kv2_2_1 := makeKVT(testKey1, testValue2, ts2)
+	kv1_2_2 := makeKVT(testKey1, testValue2, ts2)
 	kv2_2_2 := makeKVT(testKey2, testValue3, ts2)
 	kv1_3Deleted := makeKVT(testKey1, nil, ts3)
 	kvs := func(kvs ...engine.MVCCKeyValue) []engine.MVCCKeyValue { return kvs }
 
-	assertEqualKVs(keyMin, keyMax, ts0, ts3, nil)
+	t.Run("empty", assertEqualKVs(e, keyMin, keyMax, ts0, ts3, nil))
 
-	for _, kv := range kvs(kv1_1_1, kv2_2_1, kv2_2_2) {
+	for _, kv := range kvs(kv1_1_1, kv1_2_2, kv2_2_2) {
 		v := roachpb.Value{RawBytes: kv.Value}
 		if err := engine.MVCCPut(ctx, e, nil, kv.Key.Key, kv.Key.Timestamp, v, nil); err != nil {
 			t.Fatal(err)
@@ -111,22 +113,22 @@ func TestMVCCIterateIncremental(t *testing.T) {
 	}
 
 	// Exercise time ranges.
-	assertEqualKVs(keyMin, keyMax, ts1, ts1, nil)
-	assertEqualKVs(keyMin, keyMax, ts1, ts2, kvs(kv1_1_1))
-	assertEqualKVs(keyMin, keyMax, ts1, tsMax, kvs(kv2_2_1, kv2_2_2))
-	assertEqualKVs(keyMin, keyMax, ts2, ts2, nil)
-	assertEqualKVs(keyMin, keyMax, ts2, ts3, kvs(kv2_2_1, kv2_2_2))
-	assertEqualKVs(keyMin, keyMax, ts3, ts3, nil)
+	t.Run("ts 1-1", assertEqualKVs(e, keyMin, keyMax, ts1, ts1, nil))
+	t.Run("ts 1-2", assertEqualKVs(e, keyMin, keyMax, ts1, ts2, kvs(kv1_1_1)))
+	t.Run("ts 1-∞", assertEqualKVs(e, keyMin, keyMax, ts1, tsMax, kvs(kv1_2_2, kv2_2_2)))
+	t.Run("ts 2-2", assertEqualKVs(e, keyMin, keyMax, ts2, ts2, nil))
+	t.Run("ts 2-3", assertEqualKVs(e, keyMin, keyMax, ts2, ts3, kvs(kv1_2_2, kv2_2_2)))
+	t.Run("ts 3-3", assertEqualKVs(e, keyMin, keyMax, ts3, ts3, nil))
 
 	// Exercise key ranges.
-	assertEqualKVs(testKey1, testKey1, ts0, tsMax, nil)
-	assertEqualKVs(testKey1, testKey2, ts0, tsMax, kvs(kv2_2_1))
+	t.Run("kv 1-1", assertEqualKVs(e, testKey1, testKey1, ts0, tsMax, nil))
+	t.Run("kv 1-2", assertEqualKVs(e, testKey1, testKey2, ts0, tsMax, kvs(kv1_2_2)))
 
 	// Exercise deletion.
 	if err := engine.MVCCDelete(ctx, e, nil, testKey1, ts3, nil); err != nil {
 		t.Fatal(err)
 	}
-	assertEqualKVs(keyMin, keyMax, ts0, tsMax, kvs(kv1_3Deleted, kv2_2_2))
+	t.Run("del", assertEqualKVs(e, keyMin, keyMax, ts0, tsMax, kvs(kv1_3Deleted, kv2_2_2)))
 
 	// Exercise intent handling.
 	txn1ID := uuid.MakeV4()
@@ -151,9 +153,11 @@ func TestMVCCIterateIncremental(t *testing.T) {
 	if err := engine.MVCCPut(ctx, e, nil, txn2.TxnMeta.Key, txn2.TxnMeta.Timestamp, txn2Val, &txn2); err != nil {
 		t.Fatal(err)
 	}
-	iterateExpectErr(testKey1, testKey1, ts0, tsMax, "conflicting intents")
-	iterateExpectErr(testKey2, testKey2, ts0, tsMax, "conflicting intents")
-	assertEqualKVs(keyMin, keyMax, ts0, ts4, nil)
+	t.Run("intents1",
+		iterateExpectErr(e, testKey1, testKey1.PrefixEnd(), ts0, tsMax, "conflicting intents"))
+	t.Run("intents2",
+		iterateExpectErr(e, testKey2, testKey2.PrefixEnd(), ts0, tsMax, "conflicting intents"))
+	t.Run("intents3", assertEqualKVs(e, keyMin, keyMax, ts0, ts4, nil))
 
 	intent1 := roachpb.Intent{Span: roachpb.Span{Key: testKey1}, Txn: txn1.TxnMeta, Status: roachpb.COMMITTED}
 	if err := engine.MVCCResolveWriteIntent(ctx, e, nil, intent1); err != nil {
@@ -163,5 +167,5 @@ func TestMVCCIterateIncremental(t *testing.T) {
 	if err := engine.MVCCResolveWriteIntent(ctx, e, nil, intent2); err != nil {
 		t.Fatal(err)
 	}
-	assertEqualKVs(keyMin, keyMax, ts0, tsMax, kvs(kv1_4_4, kv2_2_2))
+	t.Run("intents4", assertEqualKVs(e, keyMin, keyMax, ts0, tsMax, kvs(kv1_4_4, kv2_2_2)))
 }


### PR DESCRIPTION
looks like we flipped the operands compared to when mvccGetIternal would return an intent err.
we missed it in the mvcc test since we accidentally closed over the wrong time bounds.

Fixes #13189
Fixes #13016
Fixes #13600

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13771)
<!-- Reviewable:end -->