### PR TITLE
*: miscellaneous typo and go vet fixes

### DIFF
--- a/pkg/sql/parser/select.go
+++ b/pkg/sql/parser/select.go
@@ -27,7 +27,7 @@ import (
 	"fmt"
 )
 
-// SelectStatement any SELECT statement.
+// SelectStatement represents any SELECT statement.
 type SelectStatement interface {
 	Statement
 	selectStatement()


### PR DESCRIPTION
Go vet doesn't get run correctly at the moment, which causes it to miss a few kinds of issues.

I ran `find pkg -type f -name "*.go" | xargs -n1 -Ixxx bash -c "echo xxx; go tool vet xxx"` to find the `go vet` issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13772)
<!-- Reviewable:end -->
