### PR TITLE
storage: fix deadlock breaking heuristic

### DIFF
--- a/pkg/sql/monotonic_insert_test.go
+++ b/pkg/sql/monotonic_insert_test.go
@@ -81,7 +81,6 @@ type mtClient struct {
 func TestMonotonicInserts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	t.Skip("#13759")
 	if testing.Short() {
 		t.Skip("short flag")
 	}


### PR DESCRIPTION
When deciding whether to break a deadlock, we need to use the current
pusher and pushee priorities, not the priorities that were present when
the PushTxnRequest was sent.

Fixes #13759

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13774)
<!-- Reviewable:end -->
