### PR TITLE
sqlccl: add warning against cargo-culting nonstandard benchmarks

### DIFF
--- a/pkg/ccl/sqlccl/bench_test.go
+++ b/pkg/ccl/sqlccl/bench_test.go
@@ -32,6 +32,9 @@ func bankStatementBuf(numAccounts int) *bytes.Buffer {
 }
 
 func BenchmarkClusterBackup(b *testing.B) {
+	// NB: This benchmark takes liberties in how b.N is used compared to the go
+	// documentation's description. We're getting useful information out of it,
+	// but this is not a pattern to cargo-cult.
 	if !storage.ProposerEvaluatedKVEnabled() {
 		b.Skip("command WriteBatch is not allowed without proposer evaluated KV")
 	}
@@ -64,6 +67,9 @@ func BenchmarkClusterBackup(b *testing.B) {
 }
 
 func BenchmarkClusterRestore(b *testing.B) {
+	// NB: This benchmark takes liberties in how b.N is used compared to the go
+	// documentation's description. We're getting useful information out of it,
+	// but this is not a pattern to cargo-cult.
 	if !storage.ProposerEvaluatedKVEnabled() {
 		b.Skip("command WriteBatch is not allowed without proposer evaluated KV")
 	}
@@ -84,6 +90,9 @@ func BenchmarkClusterRestore(b *testing.B) {
 }
 
 func BenchmarkLoadRestore(b *testing.B) {
+	// NB: This benchmark takes liberties in how b.N is used compared to the go
+	// documentation's description. We're getting useful information out of it,
+	// but this is not a pattern to cargo-cult.
 	if !storage.ProposerEvaluatedKVEnabled() {
 		b.Skip("command WriteBatch is not allowed without proposer evaluated KV")
 	}
@@ -104,6 +113,9 @@ func BenchmarkLoadRestore(b *testing.B) {
 }
 
 func BenchmarkLoadSQL(b *testing.B) {
+	// NB: This benchmark takes liberties in how b.N is used compared to the go
+	// documentation's description. We're getting useful information out of it,
+	// but this is not a pattern to cargo-cult.
 	_, _, _, sqlDB, cleanup := backupRestoreTestSetup(b, multiNode, 0)
 	defer cleanup()
 

--- a/pkg/ccl/sqlccl/load_test.go
+++ b/pkg/ccl/sqlccl/load_test.go
@@ -53,6 +53,9 @@ func TestImportOutOfOrder(t *testing.T) {
 }
 
 func BenchmarkImport(b *testing.B) {
+	// NB: This benchmark takes liberties in how b.N is used compared to the go
+	// documentation's description. We're getting useful information out of it,
+	// but this is not a pattern to cargo-cult.
 	defer tracing.Disable()()
 	ctx, dir, _, sqlDB, cleanup := backupRestoreTestSetup(b, multiNode, 0)
 	defer cleanup()


### PR DESCRIPTION
@tamird noticed that several backup/restore/load benchmarks don't
conform to the go documentation's description of b.N. The idiomatic way
to write a benchmark is running the code in a `for i := 0; i < b.N; i++`
loop. Several other benchmarks in our codebase do this for various
workloads (e.g. 100, 1000, 10000 rows) as sub-benchmarks. We'll may also
do this eventually, but for now, these autosizing benchmarks are quite
useful to us. OTOH, this pattern is nonstandard and shouldn't spread.
Hence this commit's warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13775)
<!-- Reviewable:end -->
