### PR TITLE
sql: correct pgwire impl of NoData messages

### DIFF
--- a/pkg/acceptance/java_test.go
+++ b/pkg/acceptance/java_test.go
@@ -123,6 +123,19 @@ public class main {
 		stmt.setObject(3, new java.sql.Date(System.currentTimeMillis()));
 
 		stmt.executeUpdate();
+
+		stmt = conn.prepareStatement("CREATE TABLE empty()");
+		res = stmt.executeUpdate();
+		if (res != 0) {
+		    throw new Exception("unexpected: CREATE TABLE reports " + res + " rows changed, expecting 0");
+		}
+
+		stmt = conn.prepareStatement("SELECT * from empty");
+		rs = stmt.executeQuery();
+		int nCols = rs.getMetaData().getColumnCount();
+		if (nCols != 0) {
+		    throw new Exception("unexpected: SELECT returns " + nCols + " columns, expected 0");
+		}
 	}
 }
 EOF

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -577,6 +577,12 @@ func (c *v3Conn) handleParse(ctx context.Context, buf *readBuffer) error {
 	return c.writeBuf.finishMsg(c.wr)
 }
 
+// canSendNoData returns true if describing a result of the input statement
+// type should return NoData.
+func canSendNoData(statementType parser.StatementType) bool {
+	return statementType != parser.Rows
+}
+
 func (c *v3Conn) handleDescribe(ctx context.Context, buf *readBuffer) error {
 	typ, err := buf.getPrepareType()
 	if err != nil {
@@ -603,7 +609,7 @@ func (c *v3Conn) handleDescribe(ctx context.Context, buf *readBuffer) error {
 			return err
 		}
 
-		return c.sendRowDescription(ctx, stmt.Columns, nil, true)
+		return c.sendRowDescription(ctx, stmt.Columns, nil, canSendNoData(stmt.Type))
 	case preparePortal:
 		portal, ok := c.session.PreparedPortals.Get(name)
 		if !ok {
@@ -611,7 +617,7 @@ func (c *v3Conn) handleDescribe(ctx context.Context, buf *readBuffer) error {
 		}
 
 		portalMeta := portal.ProtocolMeta.(preparedPortalMeta)
-		return c.sendRowDescription(ctx, portal.Stmt.Columns, portalMeta.outFormats, true)
+		return c.sendRowDescription(ctx, portal.Stmt.Columns, portalMeta.outFormats, canSendNoData(portal.Stmt.Type))
 	default:
 		return errors.Errorf("unknown describe type: %s", typ)
 	}
@@ -1004,9 +1010,10 @@ func (c *v3Conn) sendResponse(
 // sendRowDescription sends a row description over the wire for the given
 // slice of columns. canSendNoData indicates that the current state of the
 // connection allows for short circuiting by sending the NoData message if
-// there aren't any columns to send. This must be set to false during a
-// "simple query" and true elsewhere. See the last sentence of the final note
-// in the Extended Query section of the docs here:
+// there aren't any columns to send. This must be set to true iff we are
+// responding in the Extended Query protocol and the portal or statement will
+// not return rows. See the notes about the NoData message in the Extended
+// Query section of the docs here:
 // https://www.postgresql.org/docs/9.6/static/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
 func (c *v3Conn) sendRowDescription(
 	ctx context.Context, columns []sql.ResultColumn, formatCodes []formatCode, canSendNoData bool,


### PR DESCRIPTION
pgwire used to erroneously send a NoData message when a prepared
statement with rows had no data to return. In reality, NoData messages
should be only be sent when a prepared statement's return type is not
Rows.

PreparedStatements are now augmented with their StatementType to
facilitate this behavior.

Follows up on #13765. 
Resolves #13725.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13779)
<!-- Reviewable:end -->
