### PR TITLE
storage: transfer away leases when draining

### DIFF
--- a/pkg/cli/interactive_tests/test_server_sig.tcl
+++ b/pkg/cli/interactive_tests/test_server_sig.tcl
@@ -37,11 +37,15 @@ eexpect ":/# "
 # Check that the server shuts down fast upon receiving Ctrl+C twice.
 send "$argv start & echo $! >server_pid; fg\r"
 eexpect "restarted"
-
 interrupt
 eexpect "initiating graceful shutdown"
 interrupt
-eexpect "hard shutdown"
+# The server could finish draining before the second interrupt is sent.
+expect {
+    "hard shutdown" {}
+    "shutdown completed" {}
+    timeout {exit 1}
+}
 eexpect ":/# "
 
 # Ctrl+C twice finishes with exit code 130. (#9051)

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -405,14 +405,11 @@ func (n *Node) IsDraining() bool {
 	return isDraining
 }
 
-// SetDraining called with 'true' waits until all Replicas' range leases
-// have expired or a reasonable amount of time has passed (in which case an
-// error is returned but draining mode is still active).
-// When called with 'false', returns to the normal mode of allowing lease holder
-// lease acquisition and extensions.
+// SetDraining sets the draining mode on all of the node's underlying stores.
 func (n *Node) SetDraining(drain bool) error {
 	return n.stores.VisitStores(func(s *storage.Store) error {
-		return s.SetDraining(drain)
+		s.SetDraining(drain)
+		return nil
 	})
 }
 

--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -376,6 +376,7 @@ func (a *Allocator) TransferLeaseTarget(
 	rangeID roachpb.RangeID,
 	stats *replicaStats,
 	checkTransferLeaseSource bool,
+	checkCandidateFullness bool,
 ) roachpb.ReplicaDescriptor {
 	sl, _, _ := a.storePool.getStoreList(rangeID)
 	sl = sl.filter(constraints)
@@ -441,7 +442,7 @@ func (a *Allocator) TransferLeaseTarget(
 		if !ok {
 			continue
 		}
-		if float64(storeDesc.Capacity.LeaseCount) < sl.candidateLeases.mean-0.5 {
+		if !checkCandidateFullness || float64(storeDesc.Capacity.LeaseCount) < sl.candidateLeases.mean-0.5 {
 			candidates = append(candidates, repl)
 		}
 	}

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -894,8 +894,16 @@ func TestAllocatorTransferLeaseTarget(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
-			target := a.TransferLeaseTarget(context.Background(), config.Constraints{},
-				c.existing, c.leaseholder, 0, nil /* replicaStats */, c.check)
+			target := a.TransferLeaseTarget(
+				context.Background(),
+				config.Constraints{},
+				c.existing,
+				c.leaseholder,
+				0,
+				nil, /* replicaStats */
+				c.check,
+				true, /* checkCandidateFullness */
+			)
 			if c.expected != target.StoreID {
 				t.Fatalf("expected %d, but found %d", c.expected, target.StoreID)
 			}
@@ -939,8 +947,16 @@ func TestAllocatorTransferLeaseTargetMultiStore(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
-			target := a.TransferLeaseTarget(context.Background(), config.Constraints{},
-				existing, c.leaseholder, 0, nil /* replicaStats */, c.check)
+			target := a.TransferLeaseTarget(
+				context.Background(),
+				config.Constraints{},
+				existing,
+				c.leaseholder,
+				0,
+				nil, /* replicaStats */
+				c.check,
+				true, /* checkCandidateFullness */
+			)
 			if c.expected != target.StoreID {
 				t.Fatalf("expected %d, but found %d", c.expected, target.StoreID)
 			}
@@ -1165,8 +1181,16 @@ func TestAllocatorTransferLeaseTargetLoadBased(t *testing.T) {
 			a := MakeAllocator(storePool, func(addr string) (time.Duration, bool) {
 				return c.latency[addr], true
 			})
-			target := a.TransferLeaseTarget(context.Background(), config.Constraints{},
-				existing, c.leaseholder, 0, c.stats, c.check)
+			target := a.TransferLeaseTarget(
+				context.Background(),
+				config.Constraints{},
+				existing,
+				c.leaseholder,
+				0,
+				c.stats,
+				c.check,
+				true, /* checkCandidateFullness */
+			)
 			if c.expected != target.StoreID {
 				t.Errorf("expected %d, got %d", c.expected, target.StoreID)
 			}

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -864,6 +864,10 @@ func (r *Replica) IsDestroyed() error {
 func (r *Replica) getLease() (*roachpb.Lease, *roachpb.Lease) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
+	return r.getLeaseRLocked()
+}
+
+func (r *Replica) getLeaseRLocked() (*roachpb.Lease, *roachpb.Lease) {
 	lease := *r.mu.state.Lease
 	if nextLease, ok := r.mu.pendingLeaseRequest.RequestPending(); ok {
 		return &lease, &nextLease

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -160,6 +160,14 @@ func (tc *testContext) StartWithStoreConfig(t testing.TB, stopper *stop.Stopper,
 	if tc.store == nil {
 		cfg.Gossip = tc.gossip
 		cfg.Transport = tc.transport
+		cfg.StorePool = NewStorePool(
+			cfg.AmbientCtx,
+			cfg.Gossip,
+			cfg.Clock,
+			StorePoolNodeLivenessTrue,
+			TestTimeUntilStoreDeadOff,
+			false, /* deterministic */
+		)
 		// Create a test sender without setting a store. This is to deal with the
 		// circular dependency between the test sender and the store. The actual
 		// store will be passed to the sender after it is created and bootstrapped.
@@ -1136,33 +1144,8 @@ func TestReplicaDrainLease(t *testing.T) {
 	if pErr != nil {
 		t.Fatal(pErr)
 	}
-	var slept atomic.Value
-	slept.Store(false)
-	if err := stopper.RunAsyncTask(context.Background(), func(_ context.Context) {
-		// Wait just a bit so that the main thread can check that SetDraining
-		// blocks (false negatives are possible, but 10ms is plenty to make this
-		// fail 99.999% of the time in practice).
-		time.Sleep(10 * time.Millisecond)
-		slept.Store(true)
-		// Expire the lease (and any others that may race in before we drain).
-		for {
-			tc.manualClock.Increment(leaseExpiry(tc.repl))
-			select {
-			case <-time.After(10 * time.Millisecond): // real code would use Ticker
-			case <-stopper.ShouldQuiesce():
-				return
-			}
-		}
-	}); err != nil {
-		t.Fatal(err)
-	}
 
-	if err := tc.store.SetDraining(true); err != nil {
-		t.Fatal(err)
-	}
-	if !slept.Load().(bool) {
-		t.Fatal("SetDraining returned with active lease")
-	}
+	tc.store.SetDraining(true)
 	tc.repl.mu.Lock()
 	pErr = <-tc.repl.requestLeaseLocked(context.Background(), status)
 	tc.repl.mu.Unlock()
@@ -1170,9 +1153,7 @@ func TestReplicaDrainLease(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected NotLeaseHolderError, not %v", pErr)
 	}
-	if err := tc.store.SetDraining(false); err != nil {
-		t.Fatal(err)
-	}
+	tc.store.SetDraining(false)
 	// Newly unfrozen, leases work again.
 	if _, pErr := tc.repl.redirectOnOrAcquireLease(context.Background()); pErr != nil {
 		t.Fatal(pErr)

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -319,7 +319,14 @@ func (rq *replicateQueue) processOneChange(
 			// need to be able to transfer leases in AllocatorRemove in order to get
 			// out of situations where this store is overfull and yet holds all the
 			// leases.
-			transferred, err := rq.transferLease(ctx, repl, desc, zone, false /* checkTransferLeaseSource */)
+			transferred, err := rq.transferLease(
+				ctx,
+				repl,
+				desc,
+				zone,
+				false, /* checkTransferLeaseSource */
+				true,  /* checkCandidateFullness */
+			)
 			if err != nil {
 				return false, err
 			}
@@ -364,7 +371,14 @@ func (rq *replicateQueue) processOneChange(
 		if rq.canTransferLease() {
 			// We require the lease in order to process replicas, so
 			// repl.store.StoreID() corresponds to the lease-holder's store ID.
-			transferred, err := rq.transferLease(ctx, repl, desc, zone, true /* checkTransferLeaseSource */)
+			transferred, err := rq.transferLease(
+				ctx,
+				repl,
+				desc,
+				zone,
+				true, /* checkTransferLeaseSource */
+				true, /* checkCandidateFullness */
+			)
 			if err != nil {
 				return false, err
 			}
@@ -415,6 +429,7 @@ func (rq *replicateQueue) transferLease(
 	desc *roachpb.RangeDescriptor,
 	zone config.ZoneConfig,
 	checkTransferLeaseSource bool,
+	checkCandidateFullness bool,
 ) (bool, error) {
 	candidates := filterBehindReplicas(repl.RaftStatus(), desc.Replicas)
 	if target := rq.allocator.TransferLeaseTarget(
@@ -425,6 +440,7 @@ func (rq *replicateQueue) transferLease(
 		desc.RangeID,
 		repl.stats,
 		checkTransferLeaseSource,
+		checkCandidateFullness,
 	); target != (roachpb.ReplicaDescriptor{}) {
 		rq.metrics.TransferLeaseCount.Inc(1)
 		if log.V(1) {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -45,7 +45,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -975,39 +974,76 @@ func (s *Store) AnnotateCtx(ctx context.Context) context.Context {
 	return s.cfg.AmbientCtx.AnnotateCtx(ctx)
 }
 
-// SetDraining (when called with 'true') prevents all of the Store's
-// Replicas from acquiring or extending range leases and waits until all of
-// them have expired. If an error is returned, the draining state is still
-// active, but there may be active leases held by some of the Store's Replicas.
+// SetDraining (when called with 'true') causes incoming lease transfers to be
+// rejected, prevents all of the Store's Replicas from acquiring or extending
+// range leases, and attempts to transfer away any leases owned.
 // When called with 'false', returns to the normal mode of operation.
-func (s *Store) SetDraining(drain bool) error {
+func (s *Store) SetDraining(drain bool) {
 	s.draining.Store(drain)
 	if !drain {
-		return nil
+		return
 	}
 
-	return util.RetryForDuration(10*s.cfg.RangeLeaseActiveDuration, func() error {
-		var drainingLease *roachpb.Lease
-		now := s.Clock().Now()
-		newStoreReplicaVisitor(s).Visit(func(r *Replica) bool {
-			lease, nextLease := r.getLease()
-			// If we own an active lease or we're trying to obtain a lease
-			// (and that request is fresh enough), wait.
-			switch {
-			case lease.OwnedBy(s.StoreID()) && r.IsLeaseValid(lease, now):
-				drainingLease = lease
-			case nextLease != nil && nextLease.OwnedBy(s.StoreID()) && r.IsLeaseValid(nextLease, now):
-				drainingLease = nextLease
-			default:
-				return true
+	var wg sync.WaitGroup
+
+	ctx := context.TODO()
+	// Limit the number of concurrent lease transfers.
+	sem := make(chan struct{}, 100)
+	sysCfg, sysCfgSet := s.cfg.Gossip.GetSystemConfig()
+	newStoreReplicaVisitor(s).Visit(func(r *Replica) bool {
+		wg.Add(1)
+		if err := s.stopper.RunLimitedAsyncTask(
+			ctx, sem, true /* wait */, func(ctx context.Context) {
+				defer wg.Done()
+				var drainingLease *roachpb.Lease
+				for {
+					var leaseCh <-chan *roachpb.Error
+					r.mu.Lock()
+					lease, nextLease := r.getLeaseRLocked()
+					if nextLease != nil && nextLease.OwnedBy(s.StoreID()) {
+						leaseCh = r.mu.pendingLeaseRequest.JoinRequest()
+					}
+					r.mu.Unlock()
+
+					if leaseCh != nil {
+						<-leaseCh
+						continue
+					}
+					drainingLease = lease
+					break
+				}
+
+				if drainingLease.OwnedBy(s.StoreID()) && r.IsLeaseValid(drainingLease, s.Clock().Now()) {
+					desc := r.Desc()
+					zone := config.DefaultZoneConfig()
+					if sysCfgSet {
+						var err error
+						zone, err = sysCfg.GetZoneConfigForKey(desc.StartKey)
+						if log.V(1) && err != nil {
+							log.Errorf(ctx, "could not get zone config for key %s when draining: %s", desc.StartKey, err)
+						}
+					}
+					if _, err := s.replicateQueue.transferLease(
+						ctx,
+						r,
+						desc,
+						zone,
+						false, /* checkTransferLeaseSource */
+						false, /* checkCandidateFullness */
+					); log.V(1) && err != nil {
+						log.Errorf(ctx, "error transferring lease when draining: %s", err)
+					}
+				}
+			}); err != nil {
+			if log.V(1) {
+				log.Errorf(ctx, "error running draining task: %s", err)
 			}
-			return false // stop
-		})
-		if drainingLease != nil {
-			return errors.Errorf("lease %s is still active", drainingLease)
+			wg.Done()
+			return false
 		}
-		return nil
+		return true
 	})
+	wg.Wait()
 }
 
 // IsStarted returns true if the Store has been started.


### PR DESCRIPTION
When a Store is put into draining mode, it now attempts to transfer away
any leases owned by its Replicas. This avoids the need to wait for
leases to expire while maintaining availability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13792)
<!-- Reviewable:end -->
