### PR TITLE
sql: add CREATE_TABLE to crdb_internal.tables

### DIFF
--- a/pkg/sql/testdata/crdb_internal
+++ b/pkg/sql/testdata/crdb_internal
@@ -32,8 +32,15 @@ SELECT * FROM crdb_internal.schema_changes
 ----
 TABLE_ID PARENT_ID NAME TYPE TARGET_ID TARGET_NAME STATE DIRECTION
 
-query IITITRTTTT colnames
+query IITITRTTTTT colnames
 SELECT * FROM crdb_internal.tables WHERE NAME = 'namespace'
 ----
-TABLE_ID  PARENT_ID  NAME       VERSION  MOD_TIME                         MOD_TIME_LOGICAL  FORMAT_VERSION            STATE   SC_LEASE_NODE_ID  SC_LEASE_EXPIRATION_TIME
-2         1          namespace  1        1970-01-01 00:00:00 +0000 +0000  0.0000000000      InterleavedFormatVersion  PUBLIC  NULL              NULL
+TABLE_ID  PARENT_ID  NAME       VERSION  MOD_TIME                         MOD_TIME_LOGICAL  FORMAT_VERSION            STATE   SC_LEASE_NODE_ID  SC_LEASE_EXPIRATION_TIME  CREATE_TABLE
+2         1          namespace  1        1970-01-01 00:00:00 +0000 +0000  0.0000000000      InterleavedFormatVersion  PUBLIC  NULL              NULL                      CREATE TABLE namespace (
+          parentID INT NOT NULL,
+          name STRING NOT NULL,
+          id INT NULL,
+          CONSTRAINT "primary" PRIMARY KEY (parentID, name),
+          FAMILY "primary" (parentID, name),
+          FAMILY fam_3_id (id)
+)

--- a/pkg/sql/testdata/information_schema
+++ b/pkg/sql/testdata/information_schema
@@ -119,7 +119,7 @@ query TT colnames
 SHOW CREATE TABLE information_schema.tables
 ----
 Table                      CreateTable
-information_schema.tables  CREATE TABLE "information_schema.tables" (
+information_schema.tables  CREATE TABLE tables (
                                TABLE_CATALOG STRING NOT NULL DEFAULT '',
                                TABLE_SCHEMA STRING NOT NULL DEFAULT '',
                                TABLE_NAME STRING NOT NULL DEFAULT '',

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -73,7 +73,7 @@ query TT colnames
 SHOW CREATE TABLE pg_catalog.pg_namespace
 ----
 Table                    CreateTable
-pg_catalog.pg_namespace  CREATE TABLE "pg_catalog.pg_namespace" (
+pg_catalog.pg_namespace  CREATE TABLE pg_namespace (
                              oid OID NULL,
                              nspname NAME NOT NULL,
                              nspowner OID NULL,

--- a/pkg/sql/testdata/table
+++ b/pkg/sql/testdata/table
@@ -184,7 +184,7 @@ CREATE TABLE test.precision (x DECIMAL(2, 4))
 query TT
 SHOW CREATE TABLE test.users
 ----
-test.users CREATE TABLE "test.users"
+test.users CREATE TABLE users
 (
   id        INT NOT NULL,
   name      STRING NOT NULL,
@@ -242,7 +242,7 @@ CREATE TABLE test.named_constraints (
 query TT
 SHOW CREATE TABLE test.named_constraints
 ----
-test.named_constraints  CREATE TABLE "test.named_constraints" (
+test.named_constraints  CREATE TABLE named_constraints (
                         id INT NOT NULL,
                         name STRING NOT NULL,
                         title STRING NULL DEFAULT 'VP of Something',

--- a/pkg/sql/testdata/views
+++ b/pkg/sql/testdata/views
@@ -140,7 +140,7 @@ v6 CREATE VIEW v6 (x, y) AS SELECT a, b FROM test.v1
 query TT
 SHOW CREATE VIEW test2.v1
 ----
-test2.v1 CREATE VIEW "test2.v1" AS SELECT x, y FROM test.v2
+test2.v1 CREATE VIEW v1 AS SELECT x, y FROM test.v2
 
 statement ok
 GRANT SELECT ON t TO testuser


### PR DESCRIPTION
Make that and SHOW CREATE TABLE only print the table name (and not the
database name) in the CREATE TABLE statement. This is because these
statements are intended to use to create new tables in any database, so
we don't want to tie the output to a single database.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13795)
<!-- Reviewable:end -->
