### PR TITLE
storage: Transfer leases based on request load and latency

### DIFF
--- a/pkg/rpc/clock_offset.go
+++ b/pkg/rpc/clock_offset.go
@@ -96,6 +96,18 @@ func (r *RemoteClockMonitor) Metrics() *RemoteClockMetrics {
 	return &r.metrics
 }
 
+// Latency returns the exponentially weighted moving average latency to the
+// given node address. Returns true if the measurement is valid, or false if
+// we don't have enough samples to compute a reliable average.
+func (r *RemoteClockMonitor) Latency(addr string) (time.Duration, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if avg, ok := r.mu.latenciesNanos[addr]; ok && avg.Value() != 0.0 {
+		return time.Duration(int64(avg.Value())), true
+	}
+	return 0, false
+}
+
 // UpdateOffset is a thread-safe way to update the remote clock and latency
 // measurements.
 //

--- a/pkg/rpc/clock_offset_test.go
+++ b/pkg/rpc/clock_offset_test.go
@@ -227,12 +227,8 @@ func TestLatencies(t *testing.T) {
 		for _, measurement := range tc.measurements {
 			monitor.UpdateOffset(context.Background(), key, RemoteOffset{}, measurement)
 		}
-		monitor.mu.Lock()
-		if l, ok := monitor.mu.latenciesNanos[key]; !ok {
-			t.Errorf("%q: missing latency measurement", key)
-		} else if val := time.Duration(int64(l.Value())); val != tc.expectedAvg {
+		if val, ok := monitor.Latency(key); !ok || val != tc.expectedAvg {
 			t.Errorf("%q: expected latency %d, got %d", key, tc.expectedAvg, val)
 		}
-		monitor.mu.Unlock()
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -313,6 +313,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		Gossip:                         s.gossip,
 		NodeLiveness:                   s.nodeLiveness,
 		Transport:                      s.raftTransport,
+		RPCContext:                     s.rpcContext,
 		RangeRetryOptions:              s.cfg.RetryOptions,
 		RaftTickInterval:               s.cfg.RaftTickInterval,
 		ScanInterval:                   s.cfg.ScanInterval,

--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"time"
 
 	"github.com/coreos/etcd/raft"
 	"github.com/pkg/errors"
@@ -48,6 +49,14 @@ const (
 	removeExtraReplicaPriority float64 = 100
 )
 
+var (
+	// MinLeaseTransferStatsDuration configures the minimum amount of time a
+	// replica must wait for stats about request counts to accumulate before
+	// making decisions based on them.
+	// Made configurable for the sake of testing.
+	MinLeaseTransferStatsDuration = time.Minute
+)
+
 // AllocatorAction enumerates the various replication adjustments that may be
 // recommended by the allocator.
 type AllocatorAction int
@@ -71,6 +80,15 @@ var allocatorActionNames = map[AllocatorAction]string{
 func (a AllocatorAction) String() string {
 	return allocatorActionNames[a]
 }
+
+type transferDecision int
+
+const (
+	_ transferDecision = iota
+	shouldTransfer
+	shouldNotTransfer
+	decideWithoutStats
+)
 
 // allocatorError indicates a retryable error condition which sends replicas
 // being processed through the replicate_queue into purgatory so that they
@@ -123,12 +141,15 @@ func makeAllocatorRand(source rand.Source) allocatorRand {
 // Allocator tries to spread replicas as evenly as possible across the stores
 // in the cluster.
 type Allocator struct {
-	storePool *StorePool
-	randGen   allocatorRand
+	storePool     *StorePool
+	nodeLatencyFn func(addr string) (time.Duration, bool)
+	randGen       allocatorRand
 }
 
 // MakeAllocator creates a new allocator using the specified StorePool.
-func MakeAllocator(storePool *StorePool) Allocator {
+func MakeAllocator(
+	storePool *StorePool, nodeLatencyFn func(addr string) (time.Duration, bool),
+) Allocator {
 	var randSource rand.Source
 	// There are number of test cases that make a test store but don't add
 	// gossip or a store pool. So we can't rely on the existence of the
@@ -139,8 +160,9 @@ func MakeAllocator(storePool *StorePool) Allocator {
 		randSource = rand.NewSource(rand.Int63())
 	}
 	return Allocator{
-		storePool: storePool,
-		randGen:   makeAllocatorRand(randSource),
+		storePool:     storePool,
+		nodeLatencyFn: nodeLatencyFn,
+		randGen:       makeAllocatorRand(randSource),
 	}
 }
 
@@ -341,12 +363,15 @@ func (a Allocator) RebalanceTarget(
 }
 
 // TransferLeaseTarget returns a suitable replica to transfer the range lease
-// to from the provided list. It excludes the current lease holder replica.
+// to from the provided list. It excludes the current lease holder replica
+// unless asked to do otherwise by the checkTransferLeaseSource parameter.
 func (a *Allocator) TransferLeaseTarget(
+	ctx context.Context,
 	constraints config.Constraints,
 	existing []roachpb.ReplicaDescriptor,
 	leaseStoreID roachpb.StoreID,
 	rangeID roachpb.RangeID,
+	stats *replicaStats,
 	checkTransferLeaseSource bool,
 ) roachpb.ReplicaDescriptor {
 	sl, _, _ := a.storePool.getStoreList(rangeID)
@@ -379,10 +404,31 @@ func (a *Allocator) TransferLeaseTarget(
 	if !ok {
 		return roachpb.ReplicaDescriptor{}
 	}
-	if checkTransferLeaseSource && !a.shouldTransferLease(sl, source, existing) {
-		return roachpb.ReplicaDescriptor{}
+
+	// Try to pick a replica to transfer the lease to while also determining
+	// whether we actually should be transferring the lease. The transfer
+	// decision is only needed if we've been asked to check the source.
+	transferDec, repl := a.shouldTransferLeaseUsingStats(ctx, sl, source, existing, stats)
+	if checkTransferLeaseSource {
+		switch transferDec {
+		case shouldNotTransfer:
+			return roachpb.ReplicaDescriptor{}
+		case shouldTransfer:
+		case decideWithoutStats:
+			if !a.shouldTransferLeaseWithoutStats(ctx, sl, source, existing) {
+				return roachpb.ReplicaDescriptor{}
+			}
+		default:
+			log.Fatalf(ctx, "unexpected transfer decision %d with replica %+v", transferDec, repl)
+		}
 	}
 
+	if repl != (roachpb.ReplicaDescriptor{}) {
+		return repl
+	}
+
+	// Fall back to logic that doesn't take request counts and latency into
+	// account if the counts/latency-based logic couldn't pick a best replica.
 	candidates := make([]roachpb.ReplicaDescriptor, 0, len(existing))
 	for _, repl := range existing {
 		if leaseStoreID == repl.StoreID {
@@ -404,15 +450,30 @@ func (a *Allocator) TransferLeaseTarget(
 	return candidates[a.randGen.Intn(len(candidates))]
 }
 
+// EnableLeaseRebalancing controls whether lease rebalancing is enabled or
+// not. Exported for testing.
+var EnableLeaseRebalancing = envutil.EnvOrDefaultBool("COCKROACH_ENABLE_LEASE_REBALANCING", true)
+
+// EnableLoadBasedLeaseRebalancing controls whether lease rebalancing is done
+// via the new heuristic based on request load and latency or via the simpler
+// approach that purely seeks to balance the number of leases per node evenly.
+var EnableLoadBasedLeaseRebalancing = envutil.EnvOrDefaultBool("COCKROACH_ENABLE_LOAD_BASED_LEASE_REBALANCING", false)
+
 // ShouldTransferLease returns true if the specified store is overfull in terms
 // of leases with respect to the other stores matching the specified
 // attributes.
 func (a *Allocator) ShouldTransferLease(
+	ctx context.Context,
 	constraints config.Constraints,
 	existing []roachpb.ReplicaDescriptor,
 	leaseStoreID roachpb.StoreID,
 	rangeID roachpb.RangeID,
+	stats *replicaStats,
 ) bool {
+	if !EnableLeaseRebalancing {
+		return false
+	}
+
 	source, ok := a.storePool.getStoreDescriptor(leaseStoreID)
 	if !ok {
 		return false
@@ -420,24 +481,158 @@ func (a *Allocator) ShouldTransferLease(
 	sl, _, _ := a.storePool.getStoreList(rangeID)
 	sl = sl.filter(constraints)
 	if log.V(3) {
-		log.Infof(context.TODO(), "transfer-lease-source (lease-holder=%d):\n%s", leaseStoreID, sl)
+		log.Infof(ctx, "ShouldTransferLease source (lease-holder=%d):\n%s", leaseStoreID, sl)
 	}
-	return a.shouldTransferLease(sl, source, existing)
+
+	transferDec, _ := a.shouldTransferLeaseUsingStats(ctx, sl, source, existing, stats)
+	switch transferDec {
+	case shouldNotTransfer:
+		return false
+	case shouldTransfer:
+		return true
+	case decideWithoutStats:
+	default:
+		log.Fatalf(ctx, "unexpected transfer decision %d", transferDec)
+	}
+
+	return a.shouldTransferLeaseWithoutStats(ctx, sl, source, existing)
 }
 
-// EnableLeaseRebalancing controls whether lease rebalancing is enabled or
-// not. Exported for testing.
-var EnableLeaseRebalancing = envutil.EnvOrDefaultBool("COCKROACH_ENABLE_LEASE_REBALANCING", true)
-
-func (a Allocator) shouldTransferLease(
-	sl StoreList, source roachpb.StoreDescriptor, existing []roachpb.ReplicaDescriptor,
-) bool {
-	if !EnableLeaseRebalancing {
-		return false
+func (a Allocator) shouldTransferLeaseUsingStats(
+	ctx context.Context,
+	sl StoreList,
+	source roachpb.StoreDescriptor,
+	existing []roachpb.ReplicaDescriptor,
+	stats *replicaStats,
+) (transferDecision, roachpb.ReplicaDescriptor) {
+	if stats == nil || !EnableLoadBasedLeaseRebalancing {
+		return decideWithoutStats, roachpb.ReplicaDescriptor{}
 	}
+	requestCounts, requestCountsDur := stats.getRequestCounts()
+
+	// If we haven't yet accumulated enough data, avoid transferring for now. Do
+	// not fall back to the algorithm that doesn't use stats, since it can easily
+	// start fighting with the stats-based algorithm. This provides some amount of
+	// safety from lease thrashing, since leases cannot transfer more frequently
+	// than this threshold (because replica stats get reset upon lease transfer).
+	if requestCountsDur < MinLeaseTransferStatsDuration {
+		return shouldNotTransfer, roachpb.ReplicaDescriptor{}
+	}
+
+	// On the other hand, if we don't have any stats with associated localities,
+	// then do fall back to the algorithm that doesn't use request stats.
+	delete(requestCounts, "")
+	if len(requestCounts) == 0 {
+		return decideWithoutStats, roachpb.ReplicaDescriptor{}
+	}
+
+	replicaWeights := make(map[roachpb.NodeID]float64)
+	replicaLocalities := a.storePool.getLocalities(existing)
+	for requestLocalityStr, count := range requestCounts {
+		var requestLocality roachpb.Locality
+		if err := requestLocality.Set(requestLocalityStr); err != nil {
+			log.Errorf(ctx, "unable to parse locality string %q: %s", requestLocalityStr, err)
+			continue
+		}
+		for nodeID, replicaLocality := range replicaLocalities {
+			// Add weights to each replica based on the number of requests from
+			// that replica's locality and neighboring localities.
+			replicaWeights[nodeID] += (1 - replicaLocality.DiversityScore(requestLocality)) * count
+		}
+	}
+	sourceWeight := math.Max(1.0, replicaWeights[source.Node.NodeID])
+
+	if log.V(1) {
+		log.Infof(ctx,
+			"shouldTransferLease requestCounts: %+v, replicaLocalities: %+v, replicaWeights: %+v",
+			requestCounts, replicaLocalities, replicaWeights)
+	}
+
+	// TODO(a-robinson): This may not have enough protection against all leases
+	// ending up on a single node in extreme cases. Continue testing against
+	// different situations.
+	var bestRepl roachpb.ReplicaDescriptor
+	bestReplScore := int32(math.MinInt32)
+	for _, repl := range existing {
+		if repl.NodeID == source.Node.NodeID {
+			continue
+		}
+		storeDesc, ok := a.storePool.getStoreDescriptor(repl.StoreID)
+		if !ok {
+			continue
+		}
+		addr, err := a.storePool.gossip.GetNodeIDAddress(repl.NodeID)
+		if err != nil {
+			log.Errorf(ctx, "missing address for node %d: %s", repl.NodeID, err)
+			continue
+		}
+		remoteLatency, ok := a.nodeLatencyFn(addr.String())
+		if !ok {
+			continue
+		}
+
+		remoteWeight := math.Max(1.0, replicaWeights[repl.NodeID])
+		score := loadBasedLeaseRebalanceScore(
+			ctx, remoteWeight, remoteLatency, storeDesc, sourceWeight, source, sl.candidateLeases.mean)
+		if score > bestReplScore {
+			bestReplScore = score
+			bestRepl = repl
+		}
+	}
+
+	// Return the best replica even in cases where transferring is not advised in
+	// order to support forced lease transfers, such as when removing a replica or
+	// draining all leases before shutdown.
+	if bestReplScore > 0 {
+		return shouldTransfer, bestRepl
+	}
+	return shouldNotTransfer, bestRepl
+}
+
+// This is a bit of magic that was determined to work well via a bunch of
+// testing. See #13232 for context.
+// TODO(a-robinson): Document the thinking behind this logic.
+func loadBasedLeaseRebalanceScore(
+	ctx context.Context,
+	remoteWeight float64,
+	remoteLatency time.Duration,
+	remoteStore roachpb.StoreDescriptor,
+	sourceWeight float64,
+	source roachpb.StoreDescriptor,
+	meanLeases float64,
+) int32 {
+	remoteLatencyMillis := float64(remoteLatency) / float64(time.Millisecond)
+	rebalanceThreshold :=
+		baseRebalanceThreshold - 0.1*math.Log10(remoteWeight/sourceWeight)*math.Log1p(remoteLatencyMillis)
+
+	overfullLeaseThreshold := int32(math.Ceil(meanLeases * (1 + rebalanceThreshold)))
+	overfullScore := source.Capacity.LeaseCount - overfullLeaseThreshold
+	underfullLeaseThreshold := int32(math.Ceil(meanLeases * (1 - rebalanceThreshold)))
+	underfullScore := underfullLeaseThreshold - remoteStore.Capacity.LeaseCount
+	totalScore := overfullScore + underfullScore
+
+	if log.V(1) {
+		log.Infof(ctx,
+			"node: %d, remoteWeight: %.2f, sourceWeight: %.2f, remoteLatency: %v, "+
+				"rebalanceThreshold: %.2f, meanLeases: %.2f, remoteLeaseCount: %d, overfullThreshold: %d, "+
+				"sourceLeaseCount: %d, underfullThreshold: %d, totalScore: %d",
+			remoteStore.Node.NodeID, remoteWeight, sourceWeight, remoteLatency,
+			rebalanceThreshold, meanLeases, source.Capacity.LeaseCount, overfullLeaseThreshold,
+			remoteStore.Capacity.LeaseCount, underfullLeaseThreshold, totalScore,
+		)
+	}
+	return totalScore
+}
+
+func (a Allocator) shouldTransferLeaseWithoutStats(
+	ctx context.Context,
+	sl StoreList,
+	source roachpb.StoreDescriptor,
+	existing []roachpb.ReplicaDescriptor,
+) bool {
 	// Allow lease transfer if we're above the overfull threshold, which is
-	// mean*(1+rebalanceThreshold).
-	overfullLeaseThreshold := int32(math.Ceil(sl.candidateLeases.mean * (1 + rebalanceThreshold)))
+	// mean*(1+baseRebalanceThreshold).
+	overfullLeaseThreshold := int32(math.Ceil(sl.candidateLeases.mean * (1 + baseRebalanceThreshold)))
 	minOverfullThreshold := int32(math.Ceil(sl.candidateLeases.mean + 5))
 	if overfullLeaseThreshold < minOverfullThreshold {
 		overfullLeaseThreshold = minOverfullThreshold
@@ -447,7 +642,7 @@ func (a Allocator) shouldTransferLease(
 	}
 
 	if float64(source.Capacity.LeaseCount) > sl.candidateLeases.mean {
-		underfullLeaseThreshold := int32(math.Ceil(sl.candidateLeases.mean * (1 - rebalanceThreshold)))
+		underfullLeaseThreshold := int32(math.Ceil(sl.candidateLeases.mean * (1 - baseRebalanceThreshold)))
 		minUnderfullThreshold := int32(math.Ceil(sl.candidateLeases.mean - 5))
 		if underfullLeaseThreshold > minUnderfullThreshold {
 			underfullLeaseThreshold = minUnderfullThreshold
@@ -466,10 +661,10 @@ func (a Allocator) shouldTransferLease(
 	return false
 }
 
-// rebalanceThreshold is the minimum ratio of a store's range/lease surplus to
+// baseRebalanceThreshold is the minimum ratio of a store's range/lease surplus to
 // the mean range/lease count that permits rebalances/lease-transfers away from
 // that store.
-var rebalanceThreshold = envutil.EnvOrDefaultFloat("COCKROACH_REBALANCE_THRESHOLD", 0.05)
+var baseRebalanceThreshold = envutil.EnvOrDefaultFloat("COCKROACH_REBALANCE_THRESHOLD", 0.05)
 
 // shouldRebalance returns whether the specified store is a candidate for
 // having a replica removed from it given the candidate store list.
@@ -480,16 +675,16 @@ func (a Allocator) shouldRebalance(store roachpb.StoreDescriptor, sl StoreList) 
 	maxCapacityUsed := store.Capacity.FractionUsed() >= maxFractionUsedThreshold
 
 	// Rebalance if we're above the rebalance target, which is
-	// mean*(1+rebalanceThreshold).
-	target := int32(math.Ceil(sl.candidateCount.mean * (1 + rebalanceThreshold)))
+	// mean*(1+baseRebalanceThreshold).
+	target := int32(math.Ceil(sl.candidateCount.mean * (1 + baseRebalanceThreshold)))
 	rangeCountAboveTarget := store.Capacity.RangeCount > target
 
 	// Rebalance if the candidate store has a range count above the mean, and
 	// there exists another store that is underfull: its range count is smaller
-	// than mean*(1-rebalanceThreshold).
+	// than mean*(1-baseRebalanceThreshold).
 	var rebalanceToUnderfullStore bool
 	if float64(store.Capacity.RangeCount) > sl.candidateCount.mean {
-		underfullThreshold := int32(math.Floor(sl.candidateCount.mean * (1 - rebalanceThreshold)))
+		underfullThreshold := int32(math.Floor(sl.candidateCount.mean * (1 - baseRebalanceThreshold)))
 		for _, desc := range sl.stores {
 			if desc.Capacity.RangeCount < underfullThreshold {
 				rebalanceToUnderfullStore = true

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -568,7 +568,7 @@ func newReplica(rangeID roachpb.RangeID, store *Store) *Replica {
 		pushTxnQueue:   newPushTxnQueue(store),
 	}
 	if store.cfg.StorePool != nil {
-		r.stats = newReplicaStats(store.cfg.StorePool.getNodeLocalityString)
+		r.stats = newReplicaStats(store.Clock(), store.cfg.StorePool.getNodeLocalityString)
 	}
 
 	// Init rangeStr with the range ID.

--- a/pkg/storage/replica_stats.go
+++ b/pkg/storage/replica_stats.go
@@ -15,70 +15,115 @@
 package storage
 
 import (
+	"math"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+const (
+	rotateInterval = 5 * time.Minute
+	decayFactor    = 0.8
 )
 
 type localityOracle func(roachpb.NodeID) string
 
 // perLocalityCounts maps from the string representation of a locality to count.
-type perLocalityCounts map[string]int64
+type perLocalityCounts map[string]float64
 
 // replicaStats maintains statistics about the work done by a replica. Its
 // initial use is tracking the number of requests received from each
 // cluster locality in order to inform lease transfer decisions.
 type replicaStats struct {
+	clock           *hlc.Clock
 	getNodeLocality localityOracle
 
+	// We use a set of time windows in order to age out old stats without having
+	// to do hard resets. The `requests` array is a circular buffer of the last
+	// N windows of stats. We rotate through the circular buffer every so often
+	// as determined by `rotateInterval`.
+	//
+	// We could alternatively use a forward decay approach here, but it would
+	// require more memory than this slightly less precise windowing method:
+	//   http://dimacs.rutgers.edu/~graham/pubs/papers/fwddecay.pdf
 	mu struct {
 		syncutil.Mutex
-		// TODO(a-robinson): Use a form of exponential decay on the counts rather
-		// than hard resets back to zero?
-		requests  perLocalityCounts
-		lastReset time.Time
+		idx        int
+		requests   [5]perLocalityCounts
+		lastRotate time.Time
+		lastReset  time.Time
 	}
 }
 
-func newReplicaStats(getNodeLocality localityOracle) *replicaStats {
+func newReplicaStats(clock *hlc.Clock, getNodeLocality localityOracle) *replicaStats {
 	rs := &replicaStats{
+		clock:           clock,
 		getNodeLocality: getNodeLocality,
 	}
-	rs.mu.requests = make(perLocalityCounts)
-	rs.mu.lastReset = timeutil.Now()
+	rs.mu.requests[rs.mu.idx] = make(perLocalityCounts)
+	rs.mu.lastRotate = time.Unix(0, rs.clock.PhysicalNow())
+	rs.mu.lastReset = rs.mu.lastRotate
 	return rs
 }
 
 func (rs *replicaStats) record(nodeID roachpb.NodeID) {
 	locality := rs.getNodeLocality(nodeID)
+	now := time.Unix(0, rs.clock.PhysicalNow())
 
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
-	rs.mu.requests[locality]++
+
+	rs.maybeRotateLocked(now)
+	rs.mu.requests[rs.mu.idx][locality]++
+}
+
+func (rs *replicaStats) maybeRotateLocked(now time.Time) {
+	if now.Sub(rs.mu.lastRotate) >= rotateInterval {
+		rs.rotateLocked()
+		rs.mu.lastRotate = now
+	}
+}
+
+func (rs *replicaStats) rotateLocked() {
+	rs.mu.idx = (rs.mu.idx + 1) % len(rs.mu.requests)
+	rs.mu.requests[rs.mu.idx] = make(perLocalityCounts)
 }
 
 // getRequestCounts returns the current per-locality request counts and the
 // amount of time over which the counts were accumulated.
 func (rs *replicaStats) getRequestCounts() (perLocalityCounts, time.Duration) {
+	now := time.Unix(0, rs.clock.PhysicalNow())
+
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
 
-	dur := timeutil.Now().Sub(rs.mu.lastReset)
+	rs.maybeRotateLocked(now)
 
 	counts := make(perLocalityCounts)
-	for k := range rs.mu.requests {
-		counts[k] = rs.mu.requests[k]
+	for i := range rs.mu.requests {
+		// We have to add len(rs.mu.requests) to the numerator to avoid getting a
+		// negative result from the modulus operation when rs.mu.idx is small.
+		requestsIdx := (rs.mu.idx + len(rs.mu.requests) - i) % len(rs.mu.requests)
+		if cur := rs.mu.requests[requestsIdx]; cur != nil {
+			for k, v := range cur {
+				counts[k] += v * math.Pow(decayFactor, float64(i))
+			}
+		}
 	}
 
-	return counts, dur
+	return counts, now.Sub(rs.mu.lastReset)
 }
 
 func (rs *replicaStats) resetRequestCounts() {
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
 
-	rs.mu.requests = make(perLocalityCounts)
-	rs.mu.lastReset = timeutil.Now()
+	for i := range rs.mu.requests {
+		rs.mu.requests[i] = nil
+	}
+	rs.mu.requests[rs.mu.idx] = make(perLocalityCounts)
+	rs.mu.lastRotate = time.Unix(0, rs.clock.PhysicalNow())
+	rs.mu.lastReset = rs.mu.lastRotate
 }

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -172,7 +172,7 @@ func (rq *replicateQueue) shouldQueue(
 		leaseStoreID = lease.Replica.StoreID
 		if rq.canTransferLease() &&
 			rq.allocator.ShouldTransferLease(
-				zone.Constraints, desc.Replicas, leaseStoreID, desc.RangeID) {
+				ctx, zone.Constraints, desc.Replicas, leaseStoreID, desc.RangeID, repl.stats) {
 			if log.V(2) {
 				log.Infof(ctx, "lease transfer needed, enqueuing")
 			}
@@ -295,7 +295,7 @@ func (rq *replicateQueue) processOneChange(
 		// leases) allow transferring the lease away.
 		leaseHolderStoreID := repl.store.StoreID()
 		if rq.allocator.ShouldTransferLease(
-			zone.Constraints, desc.Replicas, leaseHolderStoreID, desc.RangeID) {
+			ctx, zone.Constraints, desc.Replicas, leaseHolderStoreID, desc.RangeID, repl.stats) {
 			leaseHolderStoreID = 0
 		}
 		removeReplica, err := rq.allocator.RemoveTarget(
@@ -414,10 +414,12 @@ func (rq *replicateQueue) transferLease(
 ) (bool, error) {
 	candidates := filterBehindReplicas(repl.RaftStatus(), desc.Replicas)
 	if target := rq.allocator.TransferLeaseTarget(
+		ctx,
 		zone.Constraints,
 		candidates,
 		repl.store.StoreID(),
 		desc.RangeID,
+		repl.stats,
 		checkTransferLeaseSource,
 	); target != (roachpb.ReplicaDescriptor{}) {
 		rq.metrics.TransferLeaseCount.Inc(1)

--- a/pkg/storage/store_pool.go
+++ b/pkg/storage/store_pool.go
@@ -166,6 +166,7 @@ type StorePool struct {
 	log.AmbientContext
 
 	clock                       *hlc.Clock
+	gossip                      *gossip.Gossip
 	nodeLivenessFn              NodeLivenessFunc
 	timeUntilStoreDead          time.Duration
 	failedReservationsTimeout   time.Duration
@@ -198,6 +199,7 @@ func NewStorePool(
 	sp := &StorePool{
 		AmbientContext:     ambient,
 		clock:              clock,
+		gossip:             g,
 		nodeLivenessFn:     nodeLivenessFn,
 		timeUntilStoreDead: timeUntilStoreDead,
 		failedReservationsTimeout: envutil.EnvOrDefaultDuration("COCKROACH_FAILED_RESERVATION_TIMEOUT",


### PR DESCRIPTION
i.e. "Leaseholders follow the sun"

Performance on my macbook on the four main workloads detailed in #13232, with all workloads involving 32 workers and 3 nodes, each in a different locality:

1. 0ms of latency between each node, round-robin balanced load

1a) Without this change (control group):
```
_elapsed__ops/sec__average__latency___errors_replicas_______________1:1_______________2:2_______________3:3
    1m0s   1899.0   2469.2   12.9ms        0      720         240/87/47          240/74/0          240/73/4
    2m0s   1542.7   2348.4   13.6ms        0     1305        435/149/59         435/139/2        435/142/10
    3m0s   1370.3   2287.4   14.0ms        0     1587        529/175/62         529/180/8        529/169/10
    4m0s   2257.4   2248.7   14.2ms        0     2439        813/283/63         813/263/8        813/261/21
    5m0s   1790.8   2188.9   14.6ms        0     3084       1028/338/71       1028/356/17       1028/327/21
```

1b) With this change
```
_elapsed__ops/sec__average__latency___errors_replicas_______________1:1_______________2:2_______________3:3
    1m0s   2135.6   2387.1   13.4ms        0      714        238/145/43          238/46/1          238/40/1
    2m0s   1915.7   2214.3   14.4ms        0     1227        409/185/92         409/112/3         409/105/1
    3m0s   2105.5   2194.5   14.6ms        0     1560       520/197/133         520/156/7         520/159/1
    4m0s   1767.6   2149.7   14.9ms        0     2250       750/256/156         750/244/7         750/239/1
    5m0s   1780.7   2109.3   15.2ms        0     3039      1013/342/161        1013/341/7        1013/323/1
```

2. 50ms of latency between each node, round-robin balanced load

2a) Without this change (control group):
```
_elapsed__ops/sec__average__latency___errors_replicas_______________1:1_______________2:2_______________3:3
    1m0s    851.2    829.0   38.6ms        0      213          71/26/15           71/19/0           71/20/2
    2m0s    905.8    840.0   38.1ms        0      405         135/46/21          135/40/0          135/43/2
    3m0s    855.3    843.2   37.9ms        0      786         262/90/24          262/80/0          262/84/2
    4m0s    877.4    845.5   37.8ms        0      798         266/89/24          266/82/0          266/86/2
    5m0s    875.9    846.4   37.8ms        0     1071        357/114/24         357/116/1         357/114/2
    6m0s    825.7    846.7   37.8ms        0     1545        515/175/26         515/162/1         515/171/2
```

2b) With this change
```
_elapsed__ops/sec__average__latency___errors_replicas_______________1:1_______________2:2_______________3:3
    1m0s    837.9    824.1   38.8ms        0      213          71/21/22           71/22/8           71/22/9
    2m0s    858.8    838.0   38.2ms        0      405         135/44/26         135/43/14         135/43/16
    3m0s    869.8    842.5   38.0ms        0      786         262/84/31         262/87/19         262/86/21
    4m0s    818.8    845.4   37.8ms        0      792         264/86/37         264/86/24         264/86/25
    5m0s    824.5    844.1   37.9ms        0     1077        359/118/39        359/117/28        359/116/26
```

3. 0ms of latency between each node, all workers hitting node 2

3a) Without this change (control group):
```
_elapsed__ops/sec__average__latency___errors_replicas_______________1:1_______________2:2_______________3:3
    1m0s   2375.7   2425.4   13.2ms        0      741        247/129 40          247/39 0          247/75 0
    2m0s   2383.6   2349.5   13.6ms        0     1413        471/180 86         471/138 0         471/147 8
    3m0s   2258.8   2221.4   14.4ms        0     1560        520/177 99         520/166 0        520/172 14
    4m0s   2118.4   2141.9   14.9ms        0     2261       754/257 100         754/239 0        753/248 15
    5m0s   1790.7   2077.2   15.4ms        0     3063      1021/343 105        1021/331 0       1021/341 15
    6m0s   2066.8   2017.6   15.9ms        0     3099      1033/343 105        1033/336 0       1033/348 15
```

3b) With this change
```
_elapsed__ops/sec__average__latency___errors_replicas_______________1:1_______________2:2_______________3:3
    1m0s   2020.9   2268.8   14.1ms        0      648        216/132/43          216/54/2          216/25/3
    2m0s   1917.6   2191.6   14.6ms        0     1224        408/173/93         408/145/4          408/84/7
    3m0s   2120.5   2157.2   14.8ms        0     1560       520/172/137        520/208/10         520/133/7
    4m0s   2357.5   2147.6   14.9ms        0     2319       773/226/161        773/316/14         773/224/7
    5m0s   1948.3   2101.6   15.2ms        0     3051      1017/296/161       1017/440/15        1017/275/7
```

4. 50ms of latency between each node, all workers hitting node 2

4a) Without this change (control group):
```
_elapsed__ops/sec__average__latency___errors_replicas_______________1:1_______________2:2_______________3:3
    1m0s    743.7    659.7   48.5ms        0      213     71/23     71/18     71/25
    2m0s    861.8    728.9   43.9ms        0      405    135/43    135/42    135/44
    3m0s    857.9    765.0   41.8ms        0      699    233/69    233/75    233/75
    4m0s    845.9    786.2   40.7ms        0      792    264/84    264/86    264/87
    5m0s    831.4    797.9   40.1ms        0      897    299/90    299/95   299/100
    6m0s    796.9    805.4   39.7ms        0     1488   496/157   496/168   496/162
```
4b) With this change
```
_elapsed__ops/sec__average__latency___errors_replicas_______________1:1_______________2:2_______________3:3
    1m0s   1809.7   1047.9   30.5ms        0      258          86/12/23           86/51/4           86/11/8
    2m0s   1937.6   1472.3   21.7ms        0      780         260/33/24         260/189/4         260/33/10
    3m0s   1963.9   1629.6   19.6ms        0     1335         445/65/24         445/305/7         445/61/10
    4m0s   1899.9   1690.4   18.9ms        0     1578         526/72/24        526/376/15         526/71/10
    5m0s   1692.7   1707.7   18.7ms        0     2241        747/118/25        747/518/25         747/95/10
    6m0s   1703.5   1709.7   18.7ms        0     2844        948/140/27        948/651/33        948/147/13
```

Other interesting experiments of note:

* Letting the server continue to run for a long time, the performance degrades quite a lot as time goes on. I saw similar degradation without the heuristic, so this may have just been my laptop slowing down as it got hotter and/or ran out of memory. This is with no added latency, imbalanced load, after this change:

```
_elapsed__ops/sec__average__latency___errors_replicas_______________1:1_______________2:2_______________3:3
    1m0s   2076.8   2563.1   12.5ms        0      774        258/165 43          258/67 1          258/22 2
    2m0s   2098.8   2439.2   13.1ms        0     1473        491/235 94         491/165 3          491/84 3
    3m0s   2069.8   2332.2   13.7ms        0     1560       520/211 142         520/187 9         520/119 3
    4m0s   2113.4   2278.4   14.0ms        0     2568       856/285 189        856/339 10         856/221 4
    5m0s   1177.3   2205.6   14.5ms        0     3093      1031/331 199       1031/420 12        1031/273 4
    6m0s   1936.5   2169.5   14.7ms        0     3099      1033/319 213       1033/416 22        1033/290 4
    7m0s   1914.6   2140.8   14.9ms        0     3351      1117/334 227       1117/454 23        1117/321 4
    8m0s   1876.8   2108.3   15.2ms        0     4347      1449/421 249       1449/603 29        1449/413 7
    9m0s   1839.7   2070.9   15.5ms        0     5304      1768/487 250       1768/733 37        1768/487 7
   10m0s   1678.5   2034.2   15.7ms        0     5970      1990/554 250       1990/858 46        1990/552 7
   11m0s   1672.1   2004.7   16.0ms        0     6153      2051/577 250       2051/877 47        2051/577 7
   12m0s   1802.8   1979.1   16.2ms        0     6186      2062/580 250       2062/890 47       2062/568 17
   13m0s   1501.5   1955.5   16.4ms        0     6186      2062/569 254       2062/888 52       2062/570 18
   14m0s   1677.1   1929.0   16.6ms        0     6198      2066/570 260       2066/897 53       2066/574 19
   15m0s   1240.4   1909.5   16.8ms        0     6396      2132/563 283       2132/933 56       2132/596 20
   16m0s   1150.8   1879.2   17.0ms        0     6819      2273/613 283       2273/958 66       2273/632 20
   17m0s   1433.8   1851.3   17.3ms        0     7417      2473/656 283      2471/1026 68       2473/684 20
   18m0s   1334.5   1828.9   17.5ms        0     8277      2759/737 283      2759/1170 69       2759/748 21
   19m0s   1410.5   1807.0   17.7ms        0     8973      2991/756 284      2991/1249 70       2991/767 23
   20m0s   1497.4   1786.2   17.9ms        0     9836      3278/813 290      3279/1386 73       3279/855 23
```

* Completely stopping and restarting a cluster with all the load focused on one node makes for imbalanced leases that never really get rebalanced, even though there's no latency. This is taking the run above and restarting it:

```
_elapsed__ops/sec__average__latency___errors_replicas_______________1:1_______________2:2_______________3:3
    1m0s   1507.8   1626.8   19.7ms        1    11073         3691/65 0      3691/3337 52         3691/59 0
    2m0s   1602.8   1583.8   20.2ms        1    11615         3872/86 0     3872/3308 107         3871/82 0
    3m0s   1621.7   1556.0   20.6ms        3    11982        3994/103 0     3994/3239 161        3994/100 0
    4m0s   1293.8   1540.7   20.8ms        4    12201        4067/140 0     4067/3234 216        4067/140 0
    5m0s   1307.9   1512.2   21.2ms        4    12303        4101/159 0     4101/3317 270        4101/165 0
```

* Running with `MinLeaseTransferStatsDuration` set to 1 minute rather than 10 seconds, with 50ms of latency and skewed load:

```
_elapsed__ops/sec__average__latency___errors_replicas_______________1:1_______________2:2_______________3:3
    1m0s    565.5    550.6   58.1ms        0      156           52/45/0            52/0/0            52/0/0
    2m0s    887.3    621.3   51.5ms        0      402         134/80/31          134/47/0           134/3/0
    3m0s   1385.7    800.8   40.0ms        0      735         245/89/67         245/131/0           245/8/0
    4m0s   1665.5    974.8   32.8ms        0      882        294/75/101         294/195/0          294/10/0
    5m0s   1752.4   1137.5   28.1ms        0     1545       515/112/114         515/371/2          515/24/0
    6m0s   1869.7   1243.0   25.7ms        0     1623       541/105/124         541/388/8          541/40/0
    7m0s   1815.7   1311.0   24.4ms        0     2397       799/159/136         799/555/9          799/72/0
    8m0s   1765.2   1367.5   23.4ms        0     2967       989/169/145        989/709/22         989/103/0
    9m0s   1619.8   1404.7   22.8ms        0     3102      1034/157/156       1034/751/26        1034/119/0
   10m1s   1681.2   1430.3   22.4ms        0     3153      1051/160/156       1051/755/30        1051/126/0
   11m0s   1733.8   1449.5   22.1ms        0     3810      1270/193/156       1270/899/31        1270/159/1
   12m0s   1643.2   1462.7   21.9ms        0     4605      1535/255/156      1535/1065/31        1535/198/1
   13m0s   1437.4   1464.7   21.8ms        0     5268      1756/287/156      1756/1220/32        1756/226/1
```

* Continuing the above (50ms latency, imbalanced load, minimum stats duration of 1 minute) after a full restart of the nodes:

```
_elapsed__ops/sec__average__latency___errors_replicas_______________1:1_______________2:2_______________3:3
    1m0s   1824.8   1847.5   17.3ms        0     6111         2037/13/0       2037/1981/6         2037/14/0
    2m0s   1555.2   1807.0   17.7ms        0     6174         2058/39/0      2058/1949/60         2058/39/0
    3m0s   1696.7   1736.8   18.4ms        0     6189         2063/67/0     2063/1904/111         2063/66/0
    4m0s   1692.2   1706.7   18.7ms        0     6234         2078/94/0     2078/1846/166         2078/96/0
    5m0s   1615.5   1686.3   19.0ms        0     6498        2166/127/0     2166/1856/219        2166/129/0
```

However, now that I've run all these final experiments, I'm realizing there's a big question I should have asked sooner about the latency numbers -- how could writes commit in an average of 38ms (or less) if the round-trip latency between all nodes is 50ms? I'll check into what's going on with that.

I'll also continue testing out some different things (particularly multiple nodes per locality and localities different distances apart) to make sure they behave reasonably and should add a unit test, but the code is ready for review.

@BramGruneir @petermattis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13797)
<!-- Reviewable:end -->
