### PR TITLE
kv: wait for pending RPCs to avoid ambiguous result errors

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -46,8 +46,9 @@ import (
 const (
 	// TODO(bdarnell): make SendNextTimeout configurable.
 	// https://github.com/cockroachdb/cockroach/issues/6719
-	defaultSendNextTimeout = 500 * time.Millisecond
-	defaultClientTimeout   = 10 * time.Second
+	defaultSendNextTimeout   = 500 * time.Millisecond
+	defaultClientTimeout     = 10 * time.Second
+	defaultPendingRPCTimeout = 500 * time.Millisecond
 
 	// The default maximum number of ranges to return from a range
 	// lookup.
@@ -1201,10 +1202,30 @@ func (ds *DistSender) sendToReplicas(
 					// was already received, we must return an ambiguous commit
 					// error instead of returned error.
 					log.ErrEventf(ctx, "application error: %s", call.Reply.Error)
-					if haveCommit && (pending > 0 || ambiguousResult) {
-						log.ErrEventf(ctx, "returning ambiguous result (pending=%d)", pending)
-						return nil, roachpb.NewAmbiguousResultError(
-							fmt.Sprintf("error=%s, pending RPCs=%d", call.Reply.Error, pending))
+					if haveCommit {
+						timer := time.NewTimer(defaultPendingRPCTimeout)
+						defer timer.Stop()
+						// If there are still pending RPC(s), try to wait them out.
+						for timedOut := false; pending > 0 && !timedOut; {
+							select {
+							case pendingCall := <-done:
+								pending--
+								if err := pendingCall.Err; err != nil {
+									if grpc.Code(err) != codes.Unavailable {
+										ambiguousResult = true
+									}
+								} else if pendingCall.Reply.Error == nil {
+									return pendingCall.Reply, nil
+								}
+							case <-timer.C:
+								timedOut = true
+							}
+						}
+						if pending > 0 || ambiguousResult {
+							log.ErrEventf(ctx, "returning ambiguous result (pending=%d)", pending)
+							return nil, roachpb.NewAmbiguousResultError(
+								fmt.Sprintf("error=%s, pending RPCs=%d", call.Reply.Error, pending))
+						}
 					}
 					return call.Reply, nil
 				}


### PR DESCRIPTION
Previously, on an unrecoverable error, we were immediately returning
an `AmbiguousResultError` if there were any still-pending RPCs in
flight, in case that pending RPC had successfully completed, unbeknownst
to the caller.

This change waits up to 500ms for any still-pending RPCs to have a
chance to complete. This is the same amount of time the caller had
already had to wait in order to have a pending RPC still in flight in
the first place.

This showed up frequently in certain benchmarks which were heavily
loading the system and also causing splits which would result in
`RangeKeyMismatchErrors`, which would then be upgraded to
`AmbiguousResultErrors` in the event that the loaded system had
allowed two RPCs to get airborne.

Fixes #13746
Fixes #13220

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13800)
<!-- Reviewable:end -->
