### PR TITLE
sql: add `int2vector` to pg_type

### DIFF
--- a/pkg/sql/parser/type.go
+++ b/pkg/sql/parser/type.go
@@ -157,6 +157,7 @@ var OidToType = map[oid.Oid]Type{
 	oid.T_int2:        typeInt2,
 	oid.T_int4:        typeInt4,
 	oid.T_int8:        TypeInt,
+	oid.T_int2vector:  TypeIntVector,
 	oid.T_interval:    TypeInterval,
 	oid.T_name:        TypeName,
 	oid.T_numeric:     TypeDecimal,

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1442,7 +1442,7 @@ CREATE TABLE pg_catalog.pg_type (
 			typElem := oidZero
 			if cat == typCategoryArray {
 				typInput = arrayInProcOid
-				typElem = parser.NewDOid(parser.DInt(typ.(parser.TArray).Typ.Oid()))
+				typElem = parser.NewDOid(parser.DInt(parser.UnwrapType(typ).(parser.TArray).Typ.Oid()))
 			}
 			typname := typ.String()
 			if n, ok := aliasedOidToName[oid]; ok {
@@ -1496,18 +1496,19 @@ CREATE TABLE pg_catalog.pg_type (
 // for these OIDs will override the type name of the corresponding type when
 // looking up the display name for an OID.
 var aliasedOidToName = map[oid.Oid]string{
-	oid.T_float4:  "float4",
-	oid.T_float8:  "float8",
-	oid.T_int2:    "int2",
-	oid.T_int4:    "int4",
-	oid.T_int8:    "int8",
-	oid.T_text:    "text",
-	oid.T_varchar: "varchar",
-	oid.T_numeric: "numeric",
-	oid.T__int2:   "int2[]",
-	oid.T__int4:   "int4[]",
-	oid.T__int8:   "int8[]",
-	oid.T__text:   "text[]",
+	oid.T_float4:     "float4",
+	oid.T_float8:     "float8",
+	oid.T_int2:       "int2",
+	oid.T_int4:       "int4",
+	oid.T_int8:       "int8",
+	oid.T_int2vector: "int2vector",
+	oid.T_text:       "text",
+	oid.T_varchar:    "varchar",
+	oid.T_numeric:    "numeric",
+	oid.T__int2:      "int2[]",
+	oid.T__int4:      "int4[]",
+	oid.T__int8:      "int8[]",
+	oid.T__text:      "text[]",
 }
 
 // typOid is the only OID generation approach that does not use oidHasher, because

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -660,6 +660,7 @@ oid   typname      typnamespace  typowner  typlen  typbyval  typtype
 19    name         1782195457    NULL      -1      false     b
 20    int8         1782195457    NULL      8       true      b
 21    int2         1782195457    NULL      8       true      b
+22    int2vector   1782195457    NULL      -1      false     b
 23    int4         1782195457    NULL      8       true      b
 25    text         1782195457    NULL      -1      false     b
 26    oid          1782195457    NULL      8       true      b
@@ -689,6 +690,7 @@ oid   typname      typcategory  typispreferred  typisdefined  typdelim  typrelid
 19    name         S            false           true          ,         0         0        0
 20    int8         N            false           true          ,         0         0        0
 21    int2         N            false           true          ,         0         0        0
+22    int2vector   A            false           true          ,         0         20       0
 23    int4         N            false           true          ,         0         0        0
 25    text         S            false           true          ,         0         0        0
 26    oid          N            false           true          ,         0         0        0
@@ -718,6 +720,7 @@ oid   typname      typinput    typoutput  typreceive  typsend  typmodin  typmodo
 19    name         0           0          0           0        0         0          0
 20    int8         0           0          0           0        0         0          0
 21    int2         0           0          0           0        0         0          0
+22    int2vector   4288767817  0          0           0        0         0          0
 23    int4         0           0          0           0        0         0          0
 25    text         0           0          0           0        0         0          0
 26    oid          0           0          0           0        0         0          0
@@ -747,6 +750,7 @@ oid   typname      typalign  typstorage  typnotnull  typbasetype  typtypmod
 19    name         NULL      NULL        false       0            -1
 20    int8         NULL      NULL        false       0            -1
 21    int2         NULL      NULL        false       0            -1
+22    int2vector   NULL      NULL        false       0            -1
 23    int4         NULL      NULL        false       0            -1
 25    text         NULL      NULL        false       0            -1
 26    oid          NULL      NULL        false       0            -1
@@ -776,6 +780,7 @@ oid   typname      typndims  typcollation  typdefaultbin  typdefault  typacl
 19    name         0         1661428263    NULL           NULL        NULL
 20    int8         0         0             NULL           NULL        NULL
 21    int2         0         0             NULL           NULL        NULL
+22    int2vector   0         0             NULL           NULL        NULL
 23    int4         0         0             NULL           NULL        NULL
 25    text         0         1661428263    NULL           NULL        NULL
 26    oid          0         0             NULL           NULL        NULL


### PR DESCRIPTION
`int2vector` was missing from pg_type, which was causing ActiveRecord to be unhappy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13819)
<!-- Reviewable:end -->
