### PR TITLE
sql: support current_schemas(false)

### DIFF
--- a/pkg/sql/testdata/builtin_function
+++ b/pkg/sql/testdata/builtin_function
@@ -1151,7 +1151,7 @@ SELECT CURRENT_SCHEMAS(true)
 query T
 SELECT CURRENT_SCHEMAS(false)
 ----
-{test,pg_catalog}
+{test}
 
 query error pq: unknown signature: current_schemas()
 SELECT CURRENT_SCHEMAS()


### PR DESCRIPTION
current_schemas(false) is supposed to exclude pg_catalog from its
result. Let's do this as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13820)
<!-- Reviewable:end -->
