### PR TITLE
storage: Don't record stats for requests that lack a GatewayNodeID

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1405,7 +1405,7 @@ func (r *Replica) Send(
 ) (*roachpb.BatchResponse, *roachpb.Error) {
 	var br *roachpb.BatchResponse
 
-	if r.stats != nil {
+	if r.stats != nil && ba.Header.GatewayNodeID != 0 {
 		r.stats.record(ba.Header.GatewayNodeID)
 	}
 


### PR DESCRIPTION
Based on comment on #13797

@tamird

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13825)
<!-- Reviewable:end -->
