### PR TITLE
storage: set the default for epoch range leases to true

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -331,7 +331,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		TimeSeriesDataStore:       s.tsDB,
 
 		EnableEpochRangeLeases: envutil.EnvOrDefaultBool(
-			"COCKROACH_ENABLE_EPOCH_RANGE_LEASES", false),
+			"COCKROACH_ENABLE_EPOCH_RANGE_LEASES", true),
 	}
 	if s.cfg.TestingKnobs.Store != nil {
 		storeCfg.TestingKnobs = *s.cfg.TestingKnobs.Store.(*storage.StoreTestingKnobs)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1358,7 +1358,7 @@ func (s *Store) startGossip() {
 				for r := retry.Start(retryOptions); r.Next(); {
 					if repl := s.LookupReplica(roachpb.RKey(gossipFn.key), nil); repl != nil {
 						if err := gossipFn.fn(ctx, repl); err != nil {
-							log.Errorf(ctx, "error gossiping %s: %s", gossipFn.description, err)
+							log.Warningf(ctx, "could not gossip %s: %s", gossipFn.description, err)
 							if err != errPeriodicGossipsDisabled {
 								continue
 							}


### PR DESCRIPTION
Change error returned when the node is not yet present in the liveness
table to a `LeaseRejectedError` so that the caller will continue to retry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13826)
<!-- Reviewable:end -->
