### PR TITLE
Makefile: avoid overriding the environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,31 @@
 # Author: Shawn Morel (shawnmorel@gmail.com)
 # Author: Spencer Kimball (spencer.kimball@gmail.com)
 
-# Cockroach build rules.
-GO ?= go
-# Allow setting of go build flags from the command line.
-GOFLAGS :=
+# Variables to be overridden in the environment or on the command line, e.g.
+#
+#   GOFLAGS=-msan make build
+GO      ?= go
+GOFLAGS ?=
+
+# Variables to be overridden on the command line only, e.g.
+#
+#   make test PKG=./pkg/storage TESTFLAGS=--vmodule=raft=1
+PKG          := ./pkg/...
+TAGS         :=
+TESTS        := .
+BENCHES      := -
+TESTTIMEOUT  := 3m
+RACETIMEOUT  := 10m
+BENCHTIMEOUT := 5m
+TESTFLAGS    :=
+STRESSFLAGS  :=
+DUPLFLAGS    := -t 100
+COCKROACH    := ./cockroach
+STARTFLAGS   := -s type=mem,size=1GiB --alsologtostderr
+BUILDMODE    := install
+BUILDTARGET  := .
+SUFFIX       :=
+
 # Possible values:
 # <empty>: use the default toolchain
 # release: target Linux 2.6.32, dynamically link to GLIBC 2.12.2
@@ -36,24 +57,6 @@ GOFLAGS :=
 # https://github.com/crosstool-ng/crosstool-ng/issues/540#issuecomment-276508500.
 TYPE :=
 
-COCKROACH := ./cockroach
-
-# Variables to be overridden on the command line, e.g.
-#   make test PKG=./pkg/storage TESTFLAGS=--vmodule=raft=1
-PKG          := ./pkg/...
-TAGS         :=
-TESTS        := .
-BENCHES      := -
-TESTTIMEOUT  := 3m
-RACETIMEOUT  := 10m
-BENCHTIMEOUT := 5m
-TESTFLAGS    :=
-STRESSFLAGS  :=
-DUPLFLAGS    := -t 100
-STARTFLAGS   := -s type=mem,size=1GiB --alsologtostderr
-BUILDMODE    := install
-BUILDTARGET  := .
-SUFFIX       :=
 export GOPATH := $(realpath ../../../..)
 # Prefer tools from $GOPATH/bin over those elsewhere on the path.
 # This ensures that we get the versions pinned in the GLOCKFILE.

--- a/scripts/with-msan
+++ b/scripts/with-msan
@@ -10,8 +10,8 @@
 
 export CC=clang
 export CXX=clang++
-export GOFLAGS=-msan
-export CGO_CPPFLAGS='-fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer -I/libcxx_msan/include -I/libcxx_msan/include/c++/v1'
-export CGO_LDFLAGS='-fsanitize=memory -stdlib=libc++ -L/libcxx_msan/lib -lc++abi -Wl,-rpath,/libcxx_msan/lib'
+export GOFLAGS="$GOFLAGS -msan"
+export CGO_CPPFLAGS="$CGO_CPPFLAGS -fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer -I/libcxx_msan/include -I/libcxx_msan/include/c++/v1"
+export CGO_LDFLAGS="$CGO_LDFLAGS -fsanitize=memory -stdlib=libc++ -L/libcxx_msan/lib -lc++abi -Wl,-rpath,/libcxx_msan/lib"
 
 exec "$@"


### PR DESCRIPTION
In Make, `?=` must be used if the intention is that FOO=bar make foo
uses the environment's value of FOO.

This fixes scripts/with-msan as-written; its GOFLAGS was not previously
being respected (but the other variables were, because the Makefile
does not redefine them).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13834)
<!-- Reviewable:end -->
