### PR TITLE
sql: add database name to crdb_internal.tables

### DIFF
--- a/pkg/sql/testdata/crdb_internal
+++ b/pkg/sql/testdata/crdb_internal
@@ -32,11 +32,11 @@ SELECT * FROM crdb_internal.schema_changes
 ----
 TABLE_ID PARENT_ID NAME TYPE TARGET_ID TARGET_NAME STATE DIRECTION
 
-query IITITRTTTTT colnames
+query IITTITRTTTTT colnames
 SELECT * FROM crdb_internal.tables WHERE NAME = 'namespace'
 ----
-TABLE_ID  PARENT_ID  NAME       VERSION  MOD_TIME                         MOD_TIME_LOGICAL  FORMAT_VERSION            STATE   SC_LEASE_NODE_ID  SC_LEASE_EXPIRATION_TIME  CREATE_TABLE
-2         1          namespace  1        1970-01-01 00:00:00 +0000 +0000  0.0000000000      InterleavedFormatVersion  PUBLIC  NULL              NULL                      CREATE TABLE namespace (
+TABLE_ID  PARENT_ID  NAME       DATABASE_NAME  VERSION  MOD_TIME                         MOD_TIME_LOGICAL  FORMAT_VERSION            STATE   SC_LEASE_NODE_ID  SC_LEASE_EXPIRATION_TIME  CREATE_TABLE
+2         1          namespace  system         1        1970-01-01 00:00:00 +0000 +0000  0.0000000000      InterleavedFormatVersion  PUBLIC  NULL              NULL                      CREATE TABLE namespace (
           parentID INT NOT NULL,
           name STRING NOT NULL,
           id INT NULL,


### PR DESCRIPTION
Without this it's not possible to select the correct row from
crdb_internal.tables since there's no non-root way to find out the
database ID of a table by name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13836)
<!-- Reviewable:end -->
