### PR TITLE
sql: ANY builtin works with wrapped array types

### DIFF
--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -264,7 +264,7 @@ func (expr *IndirectionExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExp
 	if err != nil {
 		return nil, err
 	}
-	typ := subExpr.ResolvedType()
+	typ := UnwrapType(subExpr.ResolvedType())
 	arrType, ok := typ.(TArray)
 	if !ok {
 		return nil, errors.Errorf("cannot subscript type %s because it is not an array", typ)
@@ -891,7 +891,7 @@ func typeCheckComparisonOpWithSubOperator(
 			return leftTyped, rightTyped, CmpOp{}, nil
 		}
 
-		rightArr, ok := rightReturn.(TArray)
+		rightArr, ok := UnwrapType(rightReturn).(TArray)
 		if !ok {
 			return nil, nil, CmpOp{},
 				errors.Errorf(unsupportedCompErrFmtWithExprsAndSubOp, left, subOp, op, right,

--- a/pkg/sql/testdata/array
+++ b/pkg/sql/testdata/array
@@ -196,3 +196,6 @@ SELECT ROW (1,2,3)[1]
 
 statement ok
 SELECT conkey FROM pg_catalog.pg_constraint GROUP BY conkey
+
+statement ok
+SELECT indkey[0] FROM pg_catalog.pg_index

--- a/pkg/sql/testdata/orms
+++ b/pkg/sql/testdata/orms
@@ -68,3 +68,14 @@ ORDER BY i.relname
 name              PRIMARY  UNIQUE  indkey  column_indexes  column_names  definition
 customers_id_idx  false    false   2       {1,2}           {name,id}     CREATE INDEX customers_id_idx ON test.customers (id ASC)
 primary           true     true    1       {1,2}           {name,id}     CREATE UNIQUE INDEX "primary" ON test.customers (name ASC)
+
+
+query TT colnames
+SELECT a.attname, format_type(a.atttypid, a.atttypmod) AS data_type
+FROM   pg_index i
+JOIN   pg_attribute a ON a.attrelid = i.indrelid
+                     AND a.attnum = ANY(i.indkey)
+                     WHERE  i.indrelid = '"a"'::regclass
+                     AND    i.indisprimary
+----
+attname  data_type


### PR DESCRIPTION
The `int2vector` type is a wrapper around the `int[] `type. `ANY` was
incorrectly asserting that its operand was a raw int array, which
precluded using it on `int2vector` types such as `pg_index.indkey`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13843)
<!-- Reviewable:end -->
