### PR TITLE
sqlccl: imporove incremental backup start/end timestamp matching

### DIFF
--- a/pkg/testutils/sqlutils/sql_runner.go
+++ b/pkg/testutils/sqlutils/sql_runner.go
@@ -49,7 +49,8 @@ func (sr *SQLRunner) Subtest(tb testing.TB) *SQLRunner {
 func (sr *SQLRunner) Exec(query string, args ...interface{}) gosql.Result {
 	r, err := sr.DB.Exec(query, args...)
 	if err != nil {
-		sr.Fatalf("error executing '%s': %s", query, err)
+		file, line, _ := caller.Lookup(1)
+		sr.Fatalf("%s:%d: error executing '%s': %s", file, line, query, err)
 	}
 	return r
 }


### PR DESCRIPTION
The previous ValidatePreviousBackups checks were a subset of what
makeImportRequests verifies, but we want to verify all the same things,
so reuse makeImportRequests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13848)
<!-- Reviewable:end -->
