### PR TITLE
sql: don't escape names in crdb_internal rows

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -89,8 +89,8 @@ CREATE TABLE crdb_internal.tables (
 			if err := addRow(
 				parser.NewDInt(parser.DInt(int64(table.ID))),
 				parser.NewDInt(parser.DInt(int64(table.ParentID))),
-				parser.NewDString(parser.Name(table.Name).String()),
-				parser.NewDString(parser.Name(dbName).String()),
+				parser.NewDString(table.Name),
+				parser.NewDString(dbName),
 				parser.NewDInt(parser.DInt(int64(table.Version))),
 				parser.MakeDTimestamp(time.Unix(0, table.ModificationTime.WallTime), time.Microsecond),
 				parser.TimestampToDecimal(table.ModificationTime),
@@ -134,7 +134,7 @@ CREATE TABLE crdb_internal.schema_changes (
 			}
 			tableID := parser.NewDInt(parser.DInt(int64(table.ID)))
 			parentID := parser.NewDInt(parser.DInt(int64(table.ParentID)))
-			tableName := parser.NewDString(parser.Name(table.Name).String())
+			tableName := parser.NewDString(table.Name)
 			for _, mut := range table.Mutations {
 				mutType := "UNKNOWN"
 				targetID := parser.DNull
@@ -203,7 +203,7 @@ CREATE TABLE crdb_internal.leases (
 					if err := addRow(
 						nodeID,
 						tableID,
-						parser.NewDString(parser.Name(state.Name).String()),
+						parser.NewDString(state.Name),
 						parser.NewDInt(parser.DInt(int64(state.ParentID))),
 						&expCopy,
 						parser.MakeDBool(parser.DBool(state.released)),

--- a/pkg/sql/testdata/crdb_internal
+++ b/pkg/sql/testdata/crdb_internal
@@ -44,3 +44,14 @@ TABLE_ID  PARENT_ID  NAME       DATABASE_NAME  VERSION  MOD_TIME                
           FAMILY "primary" (parentID, name),
           FAMILY fam_3_id (id)
 )
+
+# Verify that table names are not double escaped.
+
+statement ok
+CREATE TABLE testdb." ""\'" (i int)
+
+query T
+SELECT NAME from crdb_internal.tables WHERE DATABASE_NAME = 'testdb'
+----
+foo
+"\'


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13854)
<!-- Reviewable:end -->
