### PR TITLE
acceptance: enforce environment variables per cloud

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -146,7 +146,7 @@ docker run --privileged -i ${tty-} --rm \
   --env="TMPDIR=/go/src/github.com/cockroachdb/cockroach/artifacts" \
   --env="PAGER=cat" \
   --env="JSPM_GITHUB_AUTH_TOKEN=${JSPM_GITHUB_AUTH_TOKEN-763c42afb2d31eb7bc150da33402a24d0e081aef}" \
-  --env="GOOGLE_PROJECT=${GOOGLE_PROJECT-}" \
+  --env="CLOUDSDK_CORE_PROJECT=${CLOUDSDK_CORE_PROJECT-${GOOGLE_PROJECT-}}" \
   --env="GOOGLE_CREDENTIALS=${GOOGLE_CREDENTIALS-}" \
   --env="GOTRACEBACK=${GOTRACEBACK-all}" \
   --env="COVERALLS_TOKEN=${COVERALLS_TOKEN-}" \

--- a/cloud/gce/README.md
+++ b/cloud/gce/README.md
@@ -18,7 +18,7 @@ For multi-user cooperation, please see [Terraform's documentation on remote stat
 4. Set your credentials in environment variables:
 ```
 $ export GOOGLE_CREDENTIALS="contents of json credentials file"
-$ export GOOGLE_PROJECT="my-google-project"
+$ export CLOUDSDK_CORE_PROJECT="my-google-project"
 ```
 5. Create a new pair of ssh keys `ssh-keygen -t rsa -C "your-email"` for GCE and save them in `~/.ssh/google_compute_engine`,
 or use an existing pair and adjust the `key_name` variable described below. Do not use a passphrase while generating the keys

--- a/cloud/gce/benchmarks/main.tf
+++ b/cloud/gce/benchmarks/main.tf
@@ -5,7 +5,7 @@
 # Run with:
 # # google compute SSH key in ~/.ssh/google_compute_engine{,.pub}
 # $ export GOOGLE_CREDENTIALS="contents of json credentials file"
-# $ export GOOGLE_PROJECT="my-google-project"
+# $ export CLOUDSDK_CORE_PROJECT="my-google-project"
 # $ terraform apply
 #
 # Tear down GCE resources using:

--- a/pkg/acceptance/allocator_test.go
+++ b/pkg/acceptance/allocator_test.go
@@ -29,7 +29,7 @@ package acceptance
 // make test \
 //	 TESTTIMEOUT=48h \
 //	 PKG=./pkg/acceptance \
-//	 TESTS=Rebalance_3To5Small \
+//	 TESTS='^TestRebalance_3To5Small$$' \
 //	 TESTFLAGS='-v -remote -key-name azure -cwd terraform/azure -tf.keep-cluster=failed'
 //
 // Things to note:


### PR DESCRIPTION
Also promote CLOUDSDK_CORE_PROJECT over GOOGLE_PROJECT. The former is
respected by the `gcloud` utility, while the latter is not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13855)
<!-- Reviewable:end -->
