### PR TITLE
sql: don't require newline at EOF during COPY

### DIFF
--- a/pkg/acceptance/psql_test.go
+++ b/pkg/acceptance/psql_test.go
@@ -57,5 +57,18 @@ EOF
 # that the value was inserted explicitly.
 psql -d testdb -c "SELECT * FROM playground"  | grep blue
 
+# Test lack of newlines at EOF with no slash-dot.
+echo 'COPY playground (equip_id, type, color, location, install_date) FROM stdin;' > import.sql
+echo -n -e '3\trope\tgreen\teast\t2015-01-02' >> import.sql
+psql -d testdb < import.sql
+psql -d testdb -c "SELECT * FROM playground"  | grep green
+
+# Test lack of newlines at EOF with slash-dot.
+echo 'COPY playground (equip_id, type, color, location, install_date) FROM stdin;' > import.sql
+echo -e '4\tsand\tbrown\twest\t2016-03-04' >> import.sql
+echo -n '\.' >> import.sql
+psql -d testdb < import.sql
+psql -d testdb -c "SELECT * FROM playground"  | grep brown
+
 exit 0
 `

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -19,6 +19,7 @@ package sql
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"time"
 	"unsafe"
 
@@ -153,21 +154,18 @@ func (p *planner) ProcessCopyData(data string, msg copyMsg) (parser.StatementLis
 
 	buf.WriteString(data)
 	for buf.Len() > 0 {
-		b := buf.Bytes()
-		// Don't blindly use buf.ReadBytes because if lineDelim is not present we
-		// must rewrite the bytes to buf. Instead check if lineDelim is present.
-		if bytes.IndexByte(b, lineDelim) == -1 {
-			continue
-		}
 		line, err := buf.ReadBytes(lineDelim)
 		if err != nil {
-			return nil, err
-		}
-		// Remove lineDelim from end.
-		line = line[:len(line)-1]
-		// Remove a single '\r' at EOL, if present.
-		if len(line) > 0 && line[len(line)-1] == '\r' {
+			if err != io.EOF {
+				return nil, err
+			}
+		} else {
+			// Remove lineDelim from end.
 			line = line[:len(line)-1]
+			// Remove a single '\r' at EOL, if present.
+			if len(line) > 0 && line[len(line)-1] == '\r' {
+				line = line[:len(line)-1]
+			}
 		}
 		if buf.Len() == 0 && bytes.Equal(line, []byte(`\.`)) {
 			break


### PR DESCRIPTION
The comment being removed about blindly using ReadBytes may have been
incorrect. I'm not able to think through a case where it makes sense,
nor can I find a test case that fails when removing that check. And
there are some easy-to-produce failures with that check present.

Fixes #13847

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13858)
<!-- Reviewable:end -->
