### PR TITLE
sql: encapsulate planner state in struct for planhooks

### DIFF
--- a/pkg/ccl/sqlccl/backup.go
+++ b/pkg/ccl/sqlccl/backup.go
@@ -846,7 +846,7 @@ func Restore(
 }
 
 func backupPlanHook(
-	baseCtx context.Context, stmt parser.Statement, cfg *sql.ExecutorConfig,
+	baseCtx context.Context, stmt parser.Statement, state sql.PlanHookState,
 ) (func() ([]parser.Datums, error), sql.ResultColumns, error) {
 	backup, ok := stmt.(*parser.Backup)
 	if !ok {
@@ -874,14 +874,14 @@ func backupPlanHook(
 				return nil, err
 			}
 		}
-		endTime := cfg.Clock.Now()
+		endTime := state.ExecCfg.Clock.Now()
 		if backup.AsOf.Expr != nil {
 			var err error
 			if endTime, err = sql.EvalAsOfTimestamp(nil, backup.AsOf, endTime); err != nil {
 				return nil, err
 			}
 		}
-		desc, err := Backup(ctx, *cfg.DB, backup.To, backup.Targets, startTime, endTime)
+		desc, err := Backup(ctx, *state.ExecCfg.DB, backup.To, backup.Targets, startTime, endTime)
 		if err != nil {
 			return nil, err
 		}
@@ -897,7 +897,7 @@ func backupPlanHook(
 }
 
 func restorePlanHook(
-	baseCtx context.Context, stmt parser.Statement, cfg *sql.ExecutorConfig,
+	baseCtx context.Context, stmt parser.Statement, state sql.PlanHookState,
 ) (func() ([]parser.Datums, error), sql.ResultColumns, error) {
 	restore, ok := stmt.(*parser.Restore)
 	if !ok {
@@ -912,7 +912,7 @@ func restorePlanHook(
 		ctx, span := tracing.ChildSpan(baseCtx, stmt.StatementTag())
 		defer tracing.FinishSpan(span)
 
-		_, err := Restore(ctx, *cfg.DB, restore.From, restore.Targets)
+		_, err := Restore(ctx, *state.ExecCfg.DB, restore.From, restore.Targets)
 		return nil, err
 	}
 	return fn, nil, nil

--- a/pkg/sql/main_test.go
+++ b/pkg/sql/main_test.go
@@ -201,7 +201,7 @@ func createTestServerParams() (base.TestServerArgs, *CommandFilters) {
 // 'planhook'.
 func init() {
 	testingPlanHook := func(
-		ctx context.Context, stmt parser.Statement, cfg *sql.ExecutorConfig,
+		ctx context.Context, stmt parser.Statement, state sql.PlanHookState,
 	) (func() ([]parser.Datums, error), sql.ResultColumns, error) {
 		show, ok := stmt.(*parser.Show)
 		if !ok || show.Name != "planhook" {

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -31,10 +31,17 @@ import (
 // return (if any). `fn` will be called during the `Start` phase of plan
 // execution.
 type planHookFn func(
-	context.Context, parser.Statement, *ExecutorConfig,
+	context.Context, parser.Statement, PlanHookState,
 ) (fn func() ([]parser.Datums, error), header ResultColumns, err error)
 
 var planHooks []planHookFn
+
+// PlanHookState exposes the internal planner state needed by plan hooks. This
+// state is passed in this struct, rather than directly to hook functions, to
+// avoid rewiring every hook function when more state needs to be exported.
+type PlanHookState struct {
+	ExecCfg *ExecutorConfig
+}
 
 // AddPlanHook adds a hook used to short-circuit creating a planNode from a
 // parser.Statement. If the func returned by the hook is non-nil, it is used to


### PR DESCRIPTION
planhooks need ever more state from the planner, but exporting another
field from the planner currently requires updating the signature of
every hook function. This commit creates a PlanHookState struct so new
fields can be exported without modifying existing hooks.

We may want to ditch this struct in favor of exposing the planner
directly, but this is strictly better than the current setup, I think.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13860)
<!-- Reviewable:end -->
