### PR TITLE
storage: Enforce that all keys accessed are declared in SpanSet

### DIFF
--- a/pkg/ccl/storageccl/writebatch.go
+++ b/pkg/ccl/storageccl/writebatch.go
@@ -76,8 +76,14 @@ func evalWriteBatch(
 		if err != nil {
 			return storage.EvalResult{}, err
 		}
+		// If this is a SpanSetIterator, we have to unwrap it because
+		// ClearIterRange needs a plain rocksdb iterator (and can't unwrap
+		// it itself because of import cycles).
 		// TODO(dan): Ideally, this would use `batch.ClearRange` but it doesn't
 		// yet work with read-write batches.
+		if ssi, ok := iter.(*storage.SpanSetIterator); ok {
+			iter = ssi.Iterator()
+		}
 		if err := batch.ClearIterRange(iter, mvccStartKey, mvccEndKey); err != nil {
 			return storage.EvalResult{}, err
 		}

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1050,6 +1050,18 @@ func (s Span) Overlaps(o Span) bool {
 	return bytes.Compare(s.EndKey, o.Key) > 0 && bytes.Compare(s.Key, o.EndKey) < 0
 }
 
+// Contains returns whether the receiver contains the given span.
+func (s Span) Contains(o Span) bool {
+	if len(s.EndKey) == 0 && len(o.EndKey) == 0 {
+		return s.Key.Equal(o.Key)
+	} else if len(s.EndKey) == 0 {
+		return false
+	} else if len(o.EndKey) == 0 {
+		return bytes.Compare(o.Key, s.Key) >= 0 && bytes.Compare(o.Key, s.EndKey) < 0
+	}
+	return bytes.Compare(s.Key, o.Key) <= 0 && bytes.Compare(s.EndKey, o.EndKey) >= 0
+}
+
 // Spans is a slice of spans.
 type Spans []Span
 

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -664,6 +664,41 @@ func TestSpanOverlaps(t *testing.T) {
 	}
 }
 
+// TestSpanContains verifies methods to check whether a key
+// or key range is contained within the span.
+func TestSpanContains(t *testing.T) {
+	s := Span{Key: []byte("a"), EndKey: []byte("b")}
+
+	testData := []struct {
+		start, end []byte
+		contains   bool
+	}{
+		// Single keys.
+		{[]byte("a"), nil, true},
+		{[]byte("aa"), nil, true},
+		{[]byte("`"), nil, false},
+		{[]byte("b"), nil, false},
+		{[]byte("c"), nil, false},
+		// Key ranges.
+		{[]byte("a"), []byte("b"), true},
+		{[]byte("a"), []byte("aa"), true},
+		{[]byte("aa"), []byte("b"), true},
+		{[]byte("0"), []byte("9"), false},
+		{[]byte("`"), []byte("a"), false},
+		{[]byte("b"), []byte("bb"), false},
+		{[]byte("0"), []byte("bb"), false},
+		{[]byte("aa"), []byte("bb"), false},
+		// TODO(bdarnell): check for invalid ranges in Span.Contains?
+		//{[]byte("b"), []byte("a"), false},
+	}
+	for i, test := range testData {
+		if s.Contains(Span{test.start, test.end}) != test.contains {
+			t.Errorf("%d: expected span %q-%q within range to be %v",
+				i, test.start, test.end, test.contains)
+		}
+	}
+}
+
 // TestRSpanContains verifies methods to check whether a key
 // or key range is contained within the span.
 func TestRSpanContains(t *testing.T) {

--- a/pkg/storage/abort_cache.go
+++ b/pkg/storage/abort_cache.go
@@ -75,12 +75,20 @@ func fillUUID(b byte) uuid.UUID {
 var txnIDMin = fillUUID('\x00')
 var txnIDMax = fillUUID('\xff')
 
+func abortCacheMinKey(rangeID roachpb.RangeID) roachpb.Key {
+	return keys.AbortCacheKey(rangeID, txnIDMin)
+}
+
 func (sc *AbortCache) min() roachpb.Key {
-	return keys.AbortCacheKey(sc.rangeID, txnIDMin)
+	return abortCacheMinKey(sc.rangeID)
+}
+
+func abortCacheMaxKey(rangeID roachpb.RangeID) roachpb.Key {
+	return keys.AbortCacheKey(rangeID, txnIDMax)
 }
 
 func (sc *AbortCache) max() roachpb.Key {
-	return keys.AbortCacheKey(sc.rangeID, txnIDMax)
+	return abortCacheMaxKey(sc.rangeID)
 }
 
 // ClearData removes all persisted items stored in the cache.

--- a/pkg/storage/engine/allocator.go
+++ b/pkg/storage/engine/allocator.go
@@ -23,9 +23,9 @@ import "github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 func AllocIterKeyValue(
 	a bufalloc.ByteAllocator, iter Iterator,
 ) (bufalloc.ByteAllocator, MVCCKey, []byte) {
-	key := iter.unsafeKey()
+	key := iter.UnsafeKey()
 	a, key.Key = a.Copy(key.Key, 0)
-	value := iter.unsafeValue()
+	value := iter.UnsafeValue()
 	a, value = a.Copy(value, 0)
 	return a, key, value
 }

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -69,10 +69,10 @@ type Iterator interface {
 	ValueProto(msg proto.Message) error
 	// unsafeKey returns the same value as Key, but the memory is invalidated on
 	// the next call to {Next,Prev,Seek,SeekReverse,Close}.
-	unsafeKey() MVCCKey
+	UnsafeKey() MVCCKey
 	// unsafeKey returns the same value as Value, but the memory is invalidated
 	// on the next call to {Next,Prev,Seek,SeekReverse,Close}.
-	unsafeValue() []byte
+	UnsafeValue() []byte
 	// Less returns true if the key the iterator is currently positioned at is
 	// less than the specified key.
 	Less(key MVCCKey) bool
@@ -95,10 +95,11 @@ type Reader interface {
 	// Distinct() batches release their parent batch for future use while
 	// Engines, Snapshots and Batches free the associated C++ resources.
 	Close()
-	// closed returns true if the reader has been closed or is not usable.
+	// Closed returns true if the reader has been closed or is not usable.
 	// Objects backed by this reader (e.g. Iterators) can check this to ensure
-	// that they are not using a closed engine.
-	closed() bool
+	// that they are not using a closed engine. Intended for use within package
+	// engine; exported to enable wrappers to exist in other packages.
+	Closed() bool
 	// Get returns the value for the given key, nil otherwise.
 	Get(key MVCCKey) ([]byte, error)
 	// GetProto fetches the value at the specified key and unmarshals it

--- a/pkg/storage/engine/engine_test.go
+++ b/pkg/storage/engine/engine_test.go
@@ -154,7 +154,7 @@ func TestEngineBatchStaleCachedIterator(t *testing.T) {
 
 			if iter.Valid() {
 				t.Fatalf("iterator unexpectedly valid: %v -> %v",
-					iter.unsafeKey(), iter.unsafeValue())
+					iter.UnsafeKey(), iter.UnsafeValue())
 			}
 		}
 

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -430,8 +430,8 @@ func (r *RocksDB) Close() {
 	close(r.deallocated)
 }
 
-// closed returns true if the engine is closed.
-func (r *RocksDB) closed() bool {
+// Closed returns true if the engine is closed.
+func (r *RocksDB) Closed() bool {
 	return r.rdb == nil
 }
 
@@ -699,8 +699,8 @@ func (r *rocksDBSnapshot) Close() {
 	r.handle = nil
 }
 
-// closed returns true if the engine is closed.
-func (r *rocksDBSnapshot) closed() bool {
+// Closed returns true if the engine is closed.
+func (r *rocksDBSnapshot) Closed() bool {
 	return r.handle == nil
 }
 
@@ -910,12 +910,12 @@ func (r *rocksDBBatchIterator) ValueProto(msg proto.Message) error {
 	return r.iter.ValueProto(msg)
 }
 
-func (r *rocksDBBatchIterator) unsafeKey() MVCCKey {
-	return r.iter.unsafeKey()
+func (r *rocksDBBatchIterator) UnsafeKey() MVCCKey {
+	return r.iter.UnsafeKey()
 }
 
-func (r *rocksDBBatchIterator) unsafeValue() []byte {
-	return r.iter.unsafeValue()
+func (r *rocksDBBatchIterator) UnsafeValue() []byte {
+	return r.iter.UnsafeValue()
 }
 
 func (r *rocksDBBatchIterator) Error() error {
@@ -970,8 +970,8 @@ func (r *rocksDBBatch) Close() {
 	}
 }
 
-// closed returns true if the engine is closed.
-func (r *rocksDBBatch) closed() bool {
+// Closed returns true if the engine is closed.
+func (r *rocksDBBatch) Closed() bool {
 	return r.batch == nil
 }
 
@@ -1096,7 +1096,7 @@ func (r *rocksDBBatch) NewIterator(prefix bool) Iterator {
 }
 
 func (r *rocksDBBatch) Commit(syncCommit bool) error {
-	if r.closed() {
+	if r.Closed() {
 		panic("this batch was already committed")
 	}
 	r.distinctOpen = false
@@ -1287,7 +1287,7 @@ func (r *rocksDBIterator) init(rdb *C.DBEngine, prefix bool, engine Reader) {
 }
 
 func (r *rocksDBIterator) checkEngineOpen() {
-	if r.engine.closed() {
+	if r.engine.Closed() {
 		panic("iterator used after backing engine closed")
 	}
 }
@@ -1311,7 +1311,7 @@ func (r *rocksDBIterator) Seek(key MVCCKey) {
 		r.setState(C.DBIterSeekToFirst(r.iter))
 	} else {
 		// We can avoid seeking if we're already at the key we seek.
-		if r.valid && !r.reseek && key.Equal(r.unsafeKey()) {
+		if r.valid && !r.reseek && key.Equal(r.UnsafeKey()) {
 			return
 		}
 		r.setState(C.DBIterSeek(r.iter, goToCKey(key)))
@@ -1324,7 +1324,7 @@ func (r *rocksDBIterator) SeekReverse(key MVCCKey) {
 		r.setState(C.DBIterSeekToLast(r.iter))
 	} else {
 		// We can avoid seeking if we're already at the key we seek.
-		if r.valid && !r.reseek && key.Equal(r.unsafeKey()) {
+		if r.valid && !r.reseek && key.Equal(r.UnsafeKey()) {
 			return
 		}
 		r.setState(C.DBIterSeek(r.iter, goToCKey(key)))
@@ -1336,7 +1336,7 @@ func (r *rocksDBIterator) SeekReverse(key MVCCKey) {
 			return
 		}
 		// Make sure the current key is <= the provided key.
-		if key.Less(r.unsafeKey()) {
+		if key.Less(r.UnsafeKey()) {
 			r.Prev()
 		}
 	}
@@ -1381,14 +1381,14 @@ func (r *rocksDBIterator) ValueProto(msg proto.Message) error {
 	if r.value.len <= 0 {
 		return nil
 	}
-	return proto.Unmarshal(r.unsafeValue(), msg)
+	return proto.Unmarshal(r.UnsafeValue(), msg)
 }
 
-func (r *rocksDBIterator) unsafeKey() MVCCKey {
+func (r *rocksDBIterator) UnsafeKey() MVCCKey {
 	return cToUnsafeGoKey(r.key)
 }
 
-func (r *rocksDBIterator) unsafeValue() []byte {
+func (r *rocksDBIterator) UnsafeValue() []byte {
 	return cSliceToUnsafeGoBytes(r.value)
 }
 
@@ -1397,7 +1397,7 @@ func (r *rocksDBIterator) Error() error {
 }
 
 func (r *rocksDBIterator) Less(key MVCCKey) bool {
-	return r.unsafeKey().Less(key)
+	return r.UnsafeKey().Less(key)
 }
 
 func (r *rocksDBIterator) setState(state C.DBIterState) {

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -101,8 +101,8 @@ func TestBatchIterReadOwnWrite(t *testing.T) {
 		t.Fatalf(`Seek on batch-backed iter after batched closed should panic.
 			iter.engine: %T, iter.engine.Closed: %v, batch.Closed %v`,
 			after.(*rocksDBIterator).engine,
-			after.(*rocksDBIterator).engine.closed(),
-			b.closed(),
+			after.(*rocksDBIterator).engine.Closed(),
+			b.Closed(),
 		)
 	}()
 }

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2294,8 +2294,10 @@ func (r *Replica) requestToProposal(
 	var pErr *roachpb.Error
 	if propEvalKV {
 		var result *EvalResult
-		// TODO(bdarnell): pass spans here.
-		result, pErr = r.evaluateProposal(ctx, idKey, ba, nil)
+		// TODO(bdarnell): provide an option to disable spanSet validation
+		// (i.e. pass nil instead of `spans` here) once we're confident our coverage
+		// is good.
+		result, pErr = r.evaluateProposal(ctx, idKey, ba, spans)
 		// Fill out the local results even if pErr != nil; we'll return the error below.
 		proposal.Local = &result.Local
 		proposal.command = storagebase.RaftCommand{

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1595,6 +1595,60 @@ func makeCacheRequest(ba *roachpb.BatchRequest, br *roachpb.BatchResponse) cache
 	return cr
 }
 
+func collectSpans(ba *roachpb.BatchRequest) (*SpanSet, error) {
+	spans := &SpanSet{}
+	// TODO(bdarnell): need to make this less global when the local
+	// command queue is used more heavily. For example, a split will
+	// have a large read-only span but also a write (see #10084).
+	// Currently local spans are the exception, so preallocate for the
+	// common case in which all are global. We rarely mix read and
+	// write commands, so preallocate for writes if there are any
+	// writes present in the batch.
+	//
+	// TODO(bdarnell): revisit as the local portion gets its appropriate
+	// use.
+	if ba.IsReadOnly() {
+		spans.reserve(SpanReadOnly, spanGlobal, len(ba.Requests))
+	} else {
+		spans.reserve(SpanReadWrite, spanGlobal, len(ba.Requests))
+	}
+
+	for _, union := range ba.Requests {
+		inner := union.GetInner()
+		if _, ok := inner.(*roachpb.NoopRequest); ok {
+			continue
+		}
+		if cmd, ok := commands[inner.Method()]; ok {
+			cmd.DeclareKeys(ba.Header, inner, spans)
+		} else {
+			return nil, errors.Errorf("unrecognized command %s", inner.Method())
+		}
+	}
+
+	// When running with experimental proposer-evaluated KV, insert a
+	// span that effectively linearizes evaluation and application of
+	// all commands. This is horrible from a performance perspective
+	// but is required for passing tests until correctness work in
+	// #6290 is addressed.
+	if propEvalKV {
+		access := SpanReadWrite
+		if ba.IsReadOnly() {
+			access = SpanReadOnly
+		}
+		spans.Add(access, roachpb.Span{
+			Key:    keys.LocalMax,
+			EndKey: keys.MaxKey,
+		})
+	}
+
+	// If any command gave us spans that are invalid, bail out early
+	// (before passing them to the command queue, which may panic).
+	if err := spans.validate(); err != nil {
+		return nil, err
+	}
+	return spans, nil
+}
+
 // beginCmds waits for any overlapping, already-executing commands via
 // the command queue and adds itself to queues based on keys affected by the
 // batched commands. This gates subsequent commands with overlapping keys or
@@ -1602,56 +1656,14 @@ func makeCacheRequest(ba *roachpb.BatchRequest, br *roachpb.BatchResponse) cache
 // already in the queue. Returns a cleanup function to be called when the
 // commands are done and can be removed from the queue, and whose returned
 // error is to be used in place of the supplied error.
-func (r *Replica) beginCmds(ctx context.Context, ba *roachpb.BatchRequest) (*endCmds, error) {
+func (r *Replica) beginCmds(
+	ctx context.Context, ba *roachpb.BatchRequest, spans *SpanSet,
+) (*endCmds, error) {
 	var cmds [numSpanAccess]struct {
 		global, local *cmd
 	}
 	// Don't use the command queue for inconsistent reads.
 	if ba.ReadConsistency != roachpb.INCONSISTENT {
-		var spans SpanSet
-		// TODO(bdarnell): need to make this less global when the local
-		// command queue is used more heavily. For example, a split will
-		// have a large read-only span but also a write (see #10084).
-		// Currently local spans are the exception, so preallocate for the
-		// common case in which all are global. We rarely mix read and
-		// write commands, so preallocate for writes if there are any
-		// writes present in the batch.
-		//
-		// TODO(bdarnell): revisit as the local portion gets its appropriate
-		// use.
-		if ba.IsReadOnly() {
-			spans.reserve(SpanReadOnly, spanGlobal, len(ba.Requests))
-		} else {
-			spans.reserve(SpanReadWrite, spanGlobal, len(ba.Requests))
-		}
-
-		for _, union := range ba.Requests {
-			inner := union.GetInner()
-			if _, ok := inner.(*roachpb.NoopRequest); ok {
-				continue
-			}
-			if cmd, ok := commands[inner.Method()]; ok {
-				cmd.DeclareKeys(ba.Header, inner, &spans)
-			} else {
-				return nil, errors.Errorf("unrecognized command %s", inner.Method())
-			}
-		}
-
-		// When running with experimental proposer-evaluated KV, insert a
-		// span that effectively linearizes evaluation and application of
-		// all commands. This is horrible from a performance perspective
-		// but is required for passing tests until correctness work in
-		// #6290 is addressed.
-		if propEvalKV {
-			access := SpanReadWrite
-			if ba.IsReadOnly() {
-				access = SpanReadOnly
-			}
-			spans.Add(access, roachpb.Span{
-				Key:    keys.LocalMax,
-				EndKey: keys.MaxKey,
-			})
-		}
 
 		// Check for context cancellation before inserting into the
 		// command queue (and check again afterward). Once we're in the
@@ -1943,6 +1955,11 @@ func (r *Replica) addReadOnlyCmd(
 		}
 	}
 
+	spans, err := collectSpans(&ba)
+	if err != nil {
+		return nil, roachpb.NewError(err)
+	}
+
 	var endCmds *endCmds
 
 	if !ba.IsNonKV() {
@@ -1950,7 +1967,7 @@ func (r *Replica) addReadOnlyCmd(
 		// overlapping commands until this command completes.
 		log.Event(ctx, "command queue")
 		var err error
-		endCmds, err = r.beginCmds(ctx, &ba)
+		endCmds, err = r.beginCmds(ctx, &ba, spans)
 		if err != nil {
 			return nil, roachpb.NewError(err)
 		}
@@ -2096,6 +2113,12 @@ func (r *Replica) tryAddWriteCmd(
 	ctx context.Context, ba roachpb.BatchRequest,
 ) (br *roachpb.BatchResponse, pErr *roachpb.Error, retry proposalRetryReason) {
 	startTime := timeutil.Now()
+
+	spans, err := collectSpans(&ba)
+	if err != nil {
+		return nil, roachpb.NewError(err), proposalNoRetry
+	}
+
 	isNonKV := ba.IsNonKV()
 	var endCmds *endCmds
 	if !isNonKV {
@@ -2106,7 +2129,7 @@ func (r *Replica) tryAddWriteCmd(
 		// been run to successful completion.
 		log.Event(ctx, "command queue")
 		var err error
-		endCmds, err = r.beginCmds(ctx, &ba)
+		endCmds, err = r.beginCmds(ctx, &ba, spans)
 		if err != nil {
 			return nil, roachpb.NewError(err), proposalNoRetry
 		}
@@ -2183,7 +2206,7 @@ func (r *Replica) tryAddWriteCmd(
 
 	log.Event(ctx, "raft")
 
-	ch, tryAbandon, err := r.propose(ctx, lease, ba, endCmds)
+	ch, tryAbandon, err := r.propose(ctx, lease, ba, endCmds, spans)
 	if err != nil {
 		return nil, roachpb.NewError(err), proposalNoRetry
 	}
@@ -2255,7 +2278,11 @@ func (r *Replica) tryAddWriteCmd(
 // returned ProposalData is partially valid even on a non-nil
 // *roachpb.Error.
 func (r *Replica) requestToProposal(
-	ctx context.Context, idKey storagebase.CmdIDKey, ba roachpb.BatchRequest, endCmds *endCmds,
+	ctx context.Context,
+	idKey storagebase.CmdIDKey,
+	ba roachpb.BatchRequest,
+	endCmds *endCmds,
+	spans *SpanSet,
 ) (*ProposalData, *roachpb.Error) {
 	proposal := &ProposalData{
 		ctx:     ctx,
@@ -2267,7 +2294,8 @@ func (r *Replica) requestToProposal(
 	var pErr *roachpb.Error
 	if propEvalKV {
 		var result *EvalResult
-		result, pErr = r.evaluateProposal(ctx, idKey, ba)
+		// TODO(bdarnell): pass spans here.
+		result, pErr = r.evaluateProposal(ctx, idKey, ba, nil)
 		// Fill out the local results even if pErr != nil; we'll return the error below.
 		proposal.Local = &result.Local
 		proposal.command = storagebase.RaftCommand{
@@ -2298,7 +2326,7 @@ func (r *Replica) requestToProposal(
 //
 // Replica.mu must not be held.
 func (r *Replica) evaluateProposal(
-	ctx context.Context, idKey storagebase.CmdIDKey, ba roachpb.BatchRequest,
+	ctx context.Context, idKey storagebase.CmdIDKey, ba roachpb.BatchRequest, spans *SpanSet,
 ) (*EvalResult, *roachpb.Error) {
 	// Note that we don't hold any locks at this point. This is important
 	// since evaluating a proposal is expensive (at least under proposer-
@@ -2309,7 +2337,7 @@ func (r *Replica) evaluateProposal(
 		return nil, roachpb.NewErrorf("can't propose Raft command with zero timestamp")
 	}
 
-	result = r.applyRaftCommandInBatch(ctx, idKey, ba)
+	result = r.applyRaftCommandInBatch(ctx, idKey, ba, spans)
 
 	if result.Local.Err != nil {
 		// Failed proposals (whether they're failfast or not) can't have any
@@ -2390,7 +2418,11 @@ func makeIDKey() storagebase.CmdIDKey {
 // - any error obtained during the creation or proposal of the command, in
 //   which case the other returned values are zero.
 func (r *Replica) propose(
-	ctx context.Context, lease *roachpb.Lease, ba roachpb.BatchRequest, endCmds *endCmds,
+	ctx context.Context,
+	lease *roachpb.Lease,
+	ba roachpb.BatchRequest,
+	endCmds *endCmds,
+	spans *SpanSet,
 ) (chan proposalResult, func() bool, error) {
 	if err := r.IsDestroyed(); err != nil {
 		return nil, nil, err
@@ -2413,7 +2445,7 @@ func (r *Replica) propose(
 	defer r.raftMu.Unlock()
 
 	idKey := makeIDKey()
-	proposal, pErr := r.requestToProposal(ctx, idKey, ba, endCmds)
+	proposal, pErr := r.requestToProposal(ctx, idKey, ba, endCmds, spans)
 	// An error here corresponds to a failfast-proposal: The command resulted
 	// in an error and did not need to commit a batch (the common error case).
 	if pErr != nil {
@@ -3607,6 +3639,7 @@ func (r *Replica) processRaftCommand(
 				ctx,
 				idKey,
 				*raftCmd.BatchRequest,
+				nil,
 			)
 			// Then, change the raftCmd to reflect the result of the
 			// evaluation, filling in the EvalResult (which is now properly
@@ -3902,7 +3935,7 @@ func (r *Replica) applyRaftCommand(
 // TODO(tschottdorf): rename to evaluateRaftCommandInBatch (or something like
 // that).
 func (r *Replica) applyRaftCommandInBatch(
-	ctx context.Context, idKey storagebase.CmdIDKey, ba roachpb.BatchRequest,
+	ctx context.Context, idKey storagebase.CmdIDKey, ba roachpb.BatchRequest, spans *SpanSet,
 ) EvalResult {
 	// Keep track of original txn Writing state to sanitize txn
 	// reported with any error except TransactionRetryError.
@@ -3918,7 +3951,7 @@ func (r *Replica) applyRaftCommandInBatch(
 		var pErr *roachpb.Error
 		var ms enginepb.MVCCStats
 		var br *roachpb.BatchResponse
-		batch, ms, br, result, pErr = r.executeWriteBatch(ctx, idKey, ba)
+		batch, ms, br, result, pErr = r.executeWriteBatch(ctx, idKey, ba, spans)
 		result.Replicated.Delta = ms
 		result.Local.Reply = br
 		result.Local.Err = pErr
@@ -4017,7 +4050,7 @@ type intentsWithArg struct {
 // cannot all be completed at the intended timestamp, the batch's
 // txn is restored and it's re-executed as transactional.
 func (r *Replica) executeWriteBatch(
-	ctx context.Context, idKey storagebase.CmdIDKey, ba roachpb.BatchRequest,
+	ctx context.Context, idKey storagebase.CmdIDKey, ba roachpb.BatchRequest, spans *SpanSet,
 ) (engine.Batch, enginepb.MVCCStats, *roachpb.BatchResponse, EvalResult, *roachpb.Error) {
 	ms := enginepb.MVCCStats{}
 	// If not transactional or there are indications that the batch's txn will
@@ -4030,6 +4063,9 @@ func (r *Replica) executeWriteBatch(
 
 		// If all writes occurred at the intended timestamp, we've succeeded on the fast path.
 		batch := r.store.Engine().NewBatch()
+		if spans != nil {
+			batch = makeSpanSetBatch(batch, spans)
+		}
 		br, result, pErr := r.executeBatch(ctx, idKey, batch, &ms, strippedBa)
 		if pErr == nil && ba.Timestamp == br.Timestamp {
 			clonedTxn := ba.Txn.Clone()
@@ -4082,6 +4118,9 @@ func (r *Replica) executeWriteBatch(
 	}
 
 	batch := r.store.Engine().NewBatch()
+	if spans != nil {
+		batch = makeSpanSetBatch(batch, spans)
+	}
 	br, result, pErr := r.executeBatch(ctx, idKey, batch, &ms, ba)
 	return batch, ms, br, result, pErr
 }

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -430,7 +430,7 @@ func sendLeaseRequest(r *Replica, l *roachpb.Lease) error {
 	ba.Timestamp = r.store.Clock().Now()
 	ba.Add(&roachpb.RequestLeaseRequest{Lease: *l})
 	exLease, _ := r.getLease()
-	ch, _, err := r.propose(context.TODO(), exLease, ba, nil)
+	ch, _, err := r.propose(context.TODO(), exLease, ba, nil, nil)
 	if err == nil {
 		// Next if the command was committed, wait for the range to apply it.
 		// TODO(bdarnell): refactor this to a more conventional error-handling pattern.
@@ -1118,7 +1118,7 @@ func TestReplicaLeaseRejectUnknownRaftNodeID(t *testing.T) {
 	ba := roachpb.BatchRequest{}
 	ba.Timestamp = tc.repl.store.Clock().Now()
 	ba.Add(&roachpb.RequestLeaseRequest{Lease: *lease})
-	ch, _, err := tc.repl.propose(context.Background(), exLease, ba, nil)
+	ch, _, err := tc.repl.propose(context.Background(), exLease, ba, nil, nil)
 	if err == nil {
 		// Next if the command was committed, wait for the range to apply it.
 		// TODO(bdarnell): refactor to a more conventional error-handling pattern.
@@ -2890,7 +2890,14 @@ func TestEndTransactionWithMalformedSplitTrigger(t *testing.T) {
 	// split of the default range; start key must be "" in this case.
 	args.InternalCommitTrigger = &roachpb.InternalCommitTrigger{
 		SplitTrigger: &roachpb.SplitTrigger{
-			LeftDesc: roachpb.RangeDescriptor{StartKey: roachpb.RKey("bar")},
+			LeftDesc: roachpb.RangeDescriptor{
+				StartKey: roachpb.RKey("bar"),
+				EndKey:   roachpb.RKey("foo"),
+			},
+			RightDesc: roachpb.RangeDescriptor{
+				StartKey: roachpb.RKey("foo"),
+				EndKey:   roachpb.RKeyMax,
+			},
 		},
 	}
 
@@ -3279,7 +3286,7 @@ func TestRaftRetryProtectionInTxn(t *testing.T) {
 		// also avoid updating the timestamp cache.
 		ba.Timestamp = txn.OrigTimestamp
 		lease, _ := tc.repl.getLease()
-		ch, _, err := tc.repl.propose(context.Background(), lease, ba, nil)
+		ch, _, err := tc.repl.propose(context.Background(), lease, ba, nil, nil)
 		if err != nil {
 			t.Fatalf("%d: unexpected error: %s", i, err)
 		}
@@ -6156,7 +6163,7 @@ func TestReplicaIDChangePending(t *testing.T) {
 			Key: roachpb.Key("a"),
 		},
 	})
-	_, _, err := repl.propose(context.Background(), lease, ba, nil)
+	_, _, err := repl.propose(context.Background(), lease, ba, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -6330,7 +6337,7 @@ func TestReplicaCancelRaftCommandProgress(t *testing.T) {
 			ba.Add(&roachpb.PutRequest{Span: roachpb.Span{
 				Key: roachpb.Key(fmt.Sprintf("k%d", i))}})
 			lease, _ := repl.getLease()
-			cmd, pErr := repl.requestToProposal(context.Background(), makeIDKey(), ba, nil)
+			cmd, pErr := repl.requestToProposal(context.Background(), makeIDKey(), ba, nil, nil)
 			if pErr != nil {
 				t.Fatal(pErr)
 			}
@@ -6406,7 +6413,7 @@ func TestReplicaBurstPendingCommandsAndRepropose(t *testing.T) {
 			ba.Timestamp = tc.Clock().Now()
 			ba.Add(&roachpb.PutRequest{Span: roachpb.Span{
 				Key: roachpb.Key(fmt.Sprintf("k%d", i))}})
-			cmd, pErr := tc.repl.requestToProposal(ctx, makeIDKey(), ba, nil)
+			cmd, pErr := tc.repl.requestToProposal(ctx, makeIDKey(), ba, nil, nil)
 			if pErr != nil {
 				t.Fatal(pErr)
 			}
@@ -6525,7 +6532,7 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 		ba.Timestamp = tc.Clock().Now()
 		ba.Add(&roachpb.PutRequest{Span: roachpb.Span{Key: roachpb.Key(id)}})
 		lease, _ := r.getLease()
-		cmd, pErr := r.requestToProposal(context.Background(), storagebase.CmdIDKey(id), ba, nil)
+		cmd, pErr := r.requestToProposal(context.Background(), storagebase.CmdIDKey(id), ba, nil, nil)
 		if pErr != nil {
 			t.Fatal(pErr)
 		}
@@ -6932,7 +6939,7 @@ func TestReplicaEvaluationNotTxnMutation(t *testing.T) {
 	ba.Add(&txnPut)
 	ba.Add(&txnPut)
 
-	batch, _, _, _, pErr := tc.repl.executeWriteBatch(ctx, makeIDKey(), ba)
+	batch, _, _, _, pErr := tc.repl.executeWriteBatch(ctx, makeIDKey(), ba, nil)
 	defer batch.Close()
 	if pErr != nil {
 		t.Fatal(pErr)

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -2801,7 +2801,7 @@ func TestEndTransactionTxnSpanGCThreshold(t *testing.T) {
 			},
 			TxnSpanGCThreshold: tc.Clock().Now(),
 		}
-		if _, pErr := tc.SendWrapped(&gcReq); pErr != nil {
+		if _, pErr := tc.SendWrappedWith(roachpb.Header{RangeID: 1}, &gcReq); pErr != nil {
 			t.Fatal(pErr)
 		}
 	}
@@ -4722,7 +4722,7 @@ func TestTruncateLog(t *testing.T) {
 
 	// Discard the first half of the log.
 	truncateArgs := truncateLogArgs(indexes[5], rangeID)
-	if _, pErr := tc.SendWrapped(&truncateArgs); pErr != nil {
+	if _, pErr := tc.SendWrappedWith(roachpb.Header{RangeID: 1}, &truncateArgs); pErr != nil {
 		t.Fatal(pErr)
 	}
 
@@ -5531,7 +5531,12 @@ func TestEntries(t *testing.T) {
 
 	truncateLogs := func(index int) {
 		truncateArgs := truncateLogArgs(indexes[index], rangeID)
-		if _, err := client.SendWrapped(context.Background(), tc.Sender(), &truncateArgs); err != nil {
+		if _, err := client.SendWrappedWith(
+			context.Background(),
+			tc.Sender(),
+			roachpb.Header{RangeID: 1},
+			&truncateArgs,
+		); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -5693,7 +5698,7 @@ func TestTerm(t *testing.T) {
 
 	// Discard the first half of the log.
 	truncateArgs := truncateLogArgs(indexes[5], rangeID)
-	if _, pErr := tc.SendWrapped(&truncateArgs); pErr != nil {
+	if _, pErr := tc.SendWrappedWith(roachpb.Header{RangeID: 1}, &truncateArgs); pErr != nil {
 		t.Fatal(pErr)
 	}
 
@@ -5769,8 +5774,8 @@ func TestGCIncorrectRange(t *testing.T) {
 	now := tc.Clock().Now()
 	ts1 := now.Add(1, 0)
 	ts2 := now.Add(2, 0)
-	ts1Header := roachpb.Header{Timestamp: ts1}
-	ts2Header := roachpb.Header{Timestamp: ts2}
+	ts1Header := roachpb.Header{RangeID: repl2.RangeID, Timestamp: ts1}
+	ts2Header := roachpb.Header{RangeID: repl2.RangeID, Timestamp: ts2}
 	if _, pErr := client.SendWrappedWith(context.Background(), repl2, ts1Header, &putReq); pErr != nil {
 		t.Errorf("unexpected pError on put key request: %s", pErr)
 	}
@@ -5783,7 +5788,12 @@ func TestGCIncorrectRange(t *testing.T) {
 	// the request for the incorrect key will be silently dropped.
 	gKey := gcKey(key, ts1)
 	gcReq := gcArgs(repl1.Desc().StartKey, repl1.Desc().EndKey, gKey)
-	if _, pErr := client.SendWrappedWith(context.Background(), repl1, roachpb.Header{Timestamp: tc.Clock().Now()}, &gcReq); pErr != nil {
+	if _, pErr := client.SendWrappedWith(
+		context.Background(),
+		repl1,
+		roachpb.Header{RangeID: 1, Timestamp: tc.Clock().Now()},
+		&gcReq,
+	); pErr != nil {
 		t.Errorf("unexpected pError on garbage collection request to incorrect range: %s", pErr)
 	}
 
@@ -5797,7 +5807,12 @@ func TestGCIncorrectRange(t *testing.T) {
 
 	// Send GC request to range 2 for the same key.
 	gcReq = gcArgs(repl2.Desc().StartKey, repl2.Desc().EndKey, gKey)
-	if _, pErr := client.SendWrappedWith(context.Background(), repl2, roachpb.Header{Timestamp: tc.Clock().Now()}, &gcReq); pErr != nil {
+	if _, pErr := client.SendWrappedWith(
+		context.Background(),
+		repl2,
+		roachpb.Header{RangeID: repl2.RangeID, Timestamp: tc.Clock().Now()},
+		&gcReq,
+	); pErr != nil {
 		t.Errorf("unexpected pError on garbage collection request to correct range: %s", pErr)
 	}
 
@@ -6632,12 +6647,14 @@ func TestAmbiguousResultErrorOnRetry(t *testing.T) {
 
 	var baPut roachpb.BatchRequest
 	{
+		baPut.RangeID = 1
 		key := roachpb.Key("put1")
 		put1 := putArgs(key, []byte("value"))
 		baPut.Add(&put1)
 	}
 	var ba1PCTxn roachpb.BatchRequest
 	{
+		ba1PCTxn.RangeID = 1
 		key := roachpb.Key("1pc")
 		txn := newTransaction("1pc", key, -1, enginepb.SERIALIZABLE, tc.Clock())
 		bt, _ := beginTxnArgs(key, txn)
@@ -6811,7 +6828,7 @@ func TestCommandTimeThreshold(t *testing.T) {
 	gcr := roachpb.GCRequest{
 		Threshold: ts2,
 	}
-	if _, err := tc.SendWrapped(&gcr); err != nil {
+	if _, err := tc.SendWrappedWith(roachpb.Header{RangeID: 1}, &gcr); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/storage/span_set.go
+++ b/pkg/storage/span_set.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The Cockroach Authors.
+// Copyright 2017 The Cockroach Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,12 +20,16 @@ package storage
 import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/gogo/protobuf/proto"
+	"github.com/pkg/errors"
 )
 
 // SpanAccess records the intended mode of access in SpanSet.
 type SpanAccess int
 
-// Constants for SpanAccess.
+// Constants for SpanAccess. Higher-valued accesses imply lower-level ones.
 const (
 	SpanReadOnly SpanAccess = iota
 	SpanReadWrite
@@ -67,4 +71,302 @@ func (ss *SpanSet) Add(access SpanAccess, span roachpb.Span) {
 // getSpans returns a slice of spans with the given parameters.
 func (ss *SpanSet) getSpans(access SpanAccess, scope spanScope) []roachpb.Span {
 	return ss.spans[access][scope]
+}
+
+func (ss *SpanSet) checkAllowed(access SpanAccess, span roachpb.Span) error {
+	scope := spanGlobal
+	if keys.IsLocal(span.Key) {
+		scope = spanLocal
+	}
+	for ac := access; ac < numSpanAccess; ac++ {
+		for _, s := range ss.spans[ac][scope] {
+			if s.Key.Equal(keys.LocalMax) && s.EndKey.Equal(roachpb.KeyMax) {
+				continue
+			}
+			if s.Contains(span) {
+				return nil
+			}
+		}
+	}
+	action := "read"
+	if access == SpanReadWrite {
+		action = "write"
+	}
+
+	return errors.Errorf("cannot %s undeclared span %s", action, span)
+}
+
+// validate returns an error if any spans that have been added to the set
+// are invalid.
+func (ss *SpanSet) validate() error {
+	for _, accessSpans := range ss.spans {
+		for _, spans := range accessSpans {
+			for _, span := range spans {
+				if len(span.EndKey) > 0 && span.Key.Compare(span.EndKey) >= 0 {
+					return errors.Errorf("inverted span %s %s", span.Key, span.EndKey)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// SpanSetIterator wraps an engine.Iterator and ensures that it can
+// only be used to access spans in a SpanSet.
+type SpanSetIterator struct {
+	i     engine.Iterator
+	spans *SpanSet
+
+	// Seeking to an invalid key puts the iterator in an error state.
+	err error
+	// Reaching an out-of-bounds key with Next/Prev invalidates the
+	// iterator but does not set err.
+	invalid bool
+}
+
+var _ engine.Iterator = &SpanSetIterator{}
+
+// Close implements engine.Iterator.
+func (s *SpanSetIterator) Close() {
+	s.i.Close()
+}
+
+// Seek implements engine.Iterator.
+func (s *SpanSetIterator) Seek(key engine.MVCCKey) {
+	s.err = s.spans.checkAllowed(SpanReadOnly, roachpb.Span{Key: key.Key})
+	if s.err == nil {
+		s.invalid = false
+	}
+	s.i.Seek(key)
+}
+
+// SeekReverse implements engine.Iterator.
+func (s *SpanSetIterator) SeekReverse(key engine.MVCCKey) {
+	s.err = s.spans.checkAllowed(SpanReadOnly, roachpb.Span{Key: key.Key})
+	if s.err == nil {
+		s.invalid = false
+	}
+	s.i.SeekReverse(key)
+}
+
+// Valid implements engine.Iterator.
+func (s *SpanSetIterator) Valid() bool {
+	return !s.invalid && s.err == nil && s.i.Valid()
+}
+
+// Next implements engine.Iterator.
+func (s *SpanSetIterator) Next() {
+	s.i.Next()
+	if s.spans.checkAllowed(SpanReadOnly, roachpb.Span{Key: s.UnsafeKey().Key}) != nil {
+		s.invalid = true
+	}
+}
+
+// Prev implements engine.Iterator.
+func (s *SpanSetIterator) Prev() {
+	s.i.Prev()
+	if s.spans.checkAllowed(SpanReadOnly, roachpb.Span{Key: s.UnsafeKey().Key}) != nil {
+		s.invalid = true
+	}
+}
+
+// NextKey implements engine.Iterator.
+func (s *SpanSetIterator) NextKey() {
+	s.i.NextKey()
+	if s.spans.checkAllowed(SpanReadOnly, roachpb.Span{Key: s.UnsafeKey().Key}) != nil {
+		s.invalid = true
+	}
+}
+
+// PrevKey implements engine.Iterator.
+func (s *SpanSetIterator) PrevKey() {
+	s.i.PrevKey()
+	if s.spans.checkAllowed(SpanReadOnly, roachpb.Span{Key: s.UnsafeKey().Key}) != nil {
+		s.invalid = true
+	}
+}
+
+// Key implements engine.Iterator.
+func (s *SpanSetIterator) Key() engine.MVCCKey {
+	return s.i.Key()
+}
+
+// Value implements engine.Iterator.
+func (s *SpanSetIterator) Value() []byte {
+	return s.i.Value()
+}
+
+// ValueProto implements engine.Iterator.
+func (s *SpanSetIterator) ValueProto(msg proto.Message) error {
+	return s.i.ValueProto(msg)
+}
+
+// UnsafeKey implements engine.Iterator.
+func (s *SpanSetIterator) UnsafeKey() engine.MVCCKey {
+	return s.i.UnsafeKey()
+}
+
+// UnsafeValue implements engine.Iterator.
+func (s *SpanSetIterator) UnsafeValue() []byte {
+	return s.i.UnsafeValue()
+}
+
+// Less implements engine.Iterator.
+func (s *SpanSetIterator) Less(key engine.MVCCKey) bool {
+	return s.i.Less(key)
+}
+
+// Error implements engine.Iterator.
+func (s *SpanSetIterator) Error() error {
+	if s.err != nil {
+		return s.err
+	}
+	return s.i.Error()
+}
+
+// ComputeStats implements engine.Iterator.
+func (s *SpanSetIterator) ComputeStats(
+	start, end engine.MVCCKey, nowNanos int64,
+) (enginepb.MVCCStats, error) {
+	if err := s.spans.checkAllowed(SpanReadOnly, roachpb.Span{Key: start.Key, EndKey: end.Key}); err != nil {
+		return enginepb.MVCCStats{}, err
+	}
+	return s.i.ComputeStats(start, end, nowNanos)
+}
+
+type spanSetReader struct {
+	r     engine.Reader
+	spans *SpanSet
+}
+
+var _ engine.Reader = spanSetReader{}
+
+func (s spanSetReader) Close() {
+	s.r.Close()
+}
+
+func (s spanSetReader) Closed() bool {
+	return s.r.Closed()
+}
+
+func (s spanSetReader) Get(key engine.MVCCKey) ([]byte, error) {
+	if err := s.spans.checkAllowed(SpanReadOnly, roachpb.Span{Key: key.Key}); err != nil {
+		return nil, err
+	}
+	return s.r.Get(key)
+}
+
+func (s spanSetReader) GetProto(key engine.MVCCKey, msg proto.Message) (bool, int64, int64, error) {
+	if err := s.spans.checkAllowed(SpanReadOnly, roachpb.Span{Key: key.Key}); err != nil {
+		return false, 0, 0, err
+	}
+	return s.r.GetProto(key, msg)
+}
+
+func (s spanSetReader) Iterate(
+	start, end engine.MVCCKey, f func(engine.MVCCKeyValue) (bool, error),
+) error {
+	if err := s.spans.checkAllowed(SpanReadOnly, roachpb.Span{Key: start.Key, EndKey: end.Key}); err != nil {
+		return err
+	}
+	return s.r.Iterate(start, end, f)
+}
+
+func (s spanSetReader) NewIterator(prefix bool) engine.Iterator {
+	return &SpanSetIterator{s.r.NewIterator(prefix), s.spans, nil, false}
+}
+
+type spanSetWriter struct {
+	w     engine.Writer
+	spans *SpanSet
+}
+
+var _ engine.Writer = spanSetWriter{}
+
+func (s spanSetWriter) ApplyBatchRepr(repr []byte, sync bool) error {
+	// Assume that the constructor of the batch has bounded it correctly.
+	return s.w.ApplyBatchRepr(repr, sync)
+}
+
+func (s spanSetWriter) Clear(key engine.MVCCKey) error {
+	if err := s.spans.checkAllowed(SpanReadWrite, roachpb.Span{Key: key.Key}); err != nil {
+		return err
+	}
+	return s.w.Clear(key)
+}
+
+func (s spanSetWriter) ClearRange(start, end engine.MVCCKey) error {
+	if err := s.spans.checkAllowed(SpanReadWrite, roachpb.Span{Key: start.Key, EndKey: end.Key}); err != nil {
+		return err
+	}
+	return s.w.ClearRange(start, end)
+}
+
+func (s spanSetWriter) ClearIterRange(iter engine.Iterator, start, end engine.MVCCKey) error {
+	if err := s.spans.checkAllowed(SpanReadWrite, roachpb.Span{Key: start.Key, EndKey: end.Key}); err != nil {
+		return err
+	}
+	return s.w.ClearIterRange(iter, start, end)
+}
+
+func (s spanSetWriter) Merge(key engine.MVCCKey, value []byte) error {
+	if err := s.spans.checkAllowed(SpanReadWrite, roachpb.Span{Key: key.Key}); err != nil {
+		return err
+	}
+	return s.w.Merge(key, value)
+}
+
+func (s spanSetWriter) Put(key engine.MVCCKey, value []byte) error {
+	if err := s.spans.checkAllowed(SpanReadWrite, roachpb.Span{Key: key.Key}); err != nil {
+		return err
+	}
+	return s.w.Put(key, value)
+}
+
+type spanSetReadWriter struct {
+	spanSetReader
+	spanSetWriter
+}
+
+var _ engine.ReadWriter = spanSetReadWriter{}
+
+func makeSpanSetReadWriter(rw engine.ReadWriter, spans *SpanSet) spanSetReadWriter {
+	return spanSetReadWriter{
+		spanSetReader{
+			r:     rw,
+			spans: spans,
+		},
+		spanSetWriter{
+			w:     rw,
+			spans: spans,
+		},
+	}
+}
+
+type spanSetBatch struct {
+	spanSetReadWriter
+	b     engine.Batch
+	spans *SpanSet
+}
+
+var _ engine.Batch = spanSetBatch{}
+
+func (s spanSetBatch) Commit(sync bool) error {
+	return s.b.Commit(sync)
+}
+
+func (s spanSetBatch) Distinct() engine.ReadWriter {
+	return makeSpanSetReadWriter(s.b.Distinct(), s.spans)
+}
+
+func (s spanSetBatch) Repr() []byte {
+	return s.b.Repr()
+}
+
+func makeSpanSetBatch(b engine.Batch, spans *SpanSet) engine.Batch {
+	return &spanSetBatch{
+		makeSpanSetReadWriter(b, spans),
+		b,
+		spans,
+	}
 }

--- a/pkg/storage/span_set.go
+++ b/pkg/storage/span_set.go
@@ -131,6 +131,11 @@ func (s *SpanSetIterator) Close() {
 	s.i.Close()
 }
 
+// Iterator returns the underlying engine.Iterator.
+func (s *SpanSetIterator) Iterator() engine.Iterator {
+	return s.i
+}
+
 // Seek implements engine.Iterator.
 func (s *SpanSetIterator) Seek(key engine.MVCCKey) {
 	s.err = s.spans.checkAllowed(SpanReadOnly, roachpb.Span{Key: key.Key})

--- a/pkg/storage/span_set_test.go
+++ b/pkg/storage/span_set_test.go
@@ -1,0 +1,303 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Ben Darnell
+
+package storage
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/pkg/errors"
+)
+
+// Test that spans are properly classified as global or local and that
+// getSpans respects the scope argument.
+func TestSpanSetGetSpansScope(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var ss SpanSet
+	ss.Add(SpanReadOnly, roachpb.Span{Key: roachpb.Key("a")})
+	ss.Add(SpanReadOnly, roachpb.Span{Key: keys.RangeLastGCKey(1)})
+	ss.Add(SpanReadOnly, roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")})
+
+	exp := []roachpb.Span{{Key: keys.RangeLastGCKey(1)}}
+	if act := ss.getSpans(SpanReadOnly, spanLocal); !reflect.DeepEqual(act, exp) {
+		t.Errorf("get local spans: got %v, expected %v", act, exp)
+	}
+
+	exp = []roachpb.Span{
+		{Key: roachpb.Key("a")},
+		{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")},
+	}
+
+	if act := ss.getSpans(SpanReadOnly, spanGlobal); !reflect.DeepEqual(act, exp) {
+		t.Errorf("get global spans: got %v, expected %v", act, exp)
+	}
+}
+
+// Test that checkAllowed properly enforces boundaries.
+func TestSpanSetCheckAllowedBoundaries(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var ss SpanSet
+	ss.Add(SpanReadOnly, roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("d")})
+	ss.Add(SpanReadOnly, roachpb.Span{Key: roachpb.Key("g")})
+	ss.Add(SpanReadOnly, roachpb.Span{Key: roachpb.Key("k"), EndKey: roachpb.Key("q")})
+
+	allowed := []roachpb.Span{
+		// Exactly as declared.
+		{Key: roachpb.Key("b"), EndKey: roachpb.Key("d")},
+		{Key: roachpb.Key("g")},
+		{Key: roachpb.Key("k"), EndKey: roachpb.Key("q")},
+
+		// Points within the non-zero-length spans.
+		{Key: roachpb.Key("c")},
+		{Key: roachpb.Key("l")},
+
+		// Sub-spans.
+		{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")},
+		{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")},
+		{Key: roachpb.Key("l"), EndKey: roachpb.Key("m")},
+	}
+	for _, span := range allowed {
+		if err := ss.checkAllowed(SpanReadOnly, span); err != nil {
+			t.Errorf("expected %s to be allowed, but got error: %s", span, err)
+		}
+	}
+
+	disallowed := []roachpb.Span{
+		// Points outside the declared spans, and on the endpoints.
+		{Key: roachpb.Key("a")},
+		{Key: roachpb.Key("d")},
+		{Key: roachpb.Key("h")},
+		{Key: roachpb.Key("v")},
+		{Key: roachpb.Key("q")},
+
+		// Spans outside the declared spans.
+		{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
+		{Key: roachpb.Key("e"), EndKey: roachpb.Key("f")},
+		{Key: roachpb.Key("q"), EndKey: roachpb.Key("z")},
+
+		// Partial overlap.
+		{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
+		{Key: roachpb.Key("c"), EndKey: roachpb.Key("m")},
+		{Key: roachpb.Key("g"), EndKey: roachpb.Key("k")},
+
+		// Just past the end.
+		{Key: roachpb.Key("b"), EndKey: roachpb.Key("d").Next()},
+		{Key: roachpb.Key("g"), EndKey: roachpb.Key("g").Next()},
+		{Key: roachpb.Key("k"), EndKey: roachpb.Key("q").Next()},
+	}
+	for _, span := range disallowed {
+		if err := ss.checkAllowed(SpanReadOnly, span); err == nil {
+			t.Errorf("expected %s to be disallowed", span)
+		}
+	}
+}
+
+// Test that a span declared for write access also implies read
+// access, but not vice-versa.
+func TestSpanSetWriteImpliesRead(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var ss SpanSet
+	roSpan := roachpb.Span{Key: roachpb.Key("read-only")}
+	rwSpan := roachpb.Span{Key: roachpb.Key("read-write")}
+	ss.Add(SpanReadOnly, roSpan)
+	ss.Add(SpanReadWrite, rwSpan)
+
+	if err := ss.checkAllowed(SpanReadOnly, roSpan); err != nil {
+		t.Errorf("expected to be allowed to read roSpan, error: %s", err)
+	}
+	if err := ss.checkAllowed(SpanReadWrite, roSpan); err == nil {
+		t.Errorf("expected not to be allowed to write roSpan")
+	}
+	if err := ss.checkAllowed(SpanReadOnly, rwSpan); err != nil {
+		t.Errorf("expected to be allowed to read rwSpan, error: %s", err)
+	}
+	if err := ss.checkAllowed(SpanReadWrite, rwSpan); err != nil {
+		t.Errorf("expected to be allowed to read rwSpan, error: %s", err)
+	}
+}
+
+func TestSpanSetBatch(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	eng := engine.NewInMem(roachpb.Attributes{}, 10<<20)
+	defer eng.Close()
+
+	var ss SpanSet
+	ss.Add(SpanReadWrite, roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("g")})
+	outsideKey := engine.MakeMVCCMetadataKey(roachpb.Key("a"))
+	outsideKey2 := engine.MakeMVCCMetadataKey(roachpb.Key("b"))
+	outsideKey3 := engine.MakeMVCCMetadataKey(roachpb.Key("m"))
+	insideKey := engine.MakeMVCCMetadataKey(roachpb.Key("c"))
+	insideKey2 := engine.MakeMVCCMetadataKey(roachpb.Key("d"))
+
+	// Write values outside the range that we can try to read later.
+	if err := eng.Put(outsideKey, []byte("value")); err != nil {
+		t.Fatalf("direct write failed: %s", err)
+	}
+	if err := eng.Put(outsideKey3, []byte("value")); err != nil {
+		t.Fatalf("direct write failed: %s", err)
+	}
+
+	batch := makeSpanSetBatch(eng.NewBatch(), &ss)
+	defer batch.Close()
+
+	// Writes inside the range work. Write twice for later read testing.
+	if err := batch.Put(insideKey, []byte("value")); err != nil {
+		t.Fatalf("failed to write inside the range: %s", err)
+	}
+	if err := batch.Put(insideKey2, []byte("value2")); err != nil {
+		t.Fatalf("failed to write inside the range: %s", err)
+	}
+
+	// Writes outside the range fail. We try to cover all write methods
+	// in the failure case to make sure the checkAllowed call is
+	// present, but we don't attempt successful versions of all
+	// methods since those are harder to set up.
+	isWriteSpanErr := func(err error) bool {
+		return testutils.IsError(err, "cannot write undeclared span")
+	}
+	if err := batch.Clear(outsideKey); !isWriteSpanErr(err) {
+		t.Errorf("Clear: unexpected error %v", err)
+	}
+	if err := batch.ClearRange(outsideKey, outsideKey2); !isWriteSpanErr(err) {
+		t.Errorf("ClearRange: unexpected error %v", err)
+	}
+	{
+		iter := batch.NewIterator(false)
+		err := batch.ClearIterRange(iter, outsideKey, outsideKey2)
+		iter.Close()
+		if !isWriteSpanErr(err) {
+			t.Errorf("ClearIterRange: unexpected error %v", err)
+		}
+	}
+	if err := batch.Merge(outsideKey, nil); !isWriteSpanErr(err) {
+		t.Errorf("Merge: unexpected error %v", err)
+	}
+	if err := batch.Put(outsideKey, nil); !isWriteSpanErr(err) {
+		t.Errorf("Put: unexpected error %v", err)
+	}
+
+	// Reads inside the range work.
+	if value, err := batch.Get(insideKey); err != nil {
+		t.Errorf("failed to read inside the range: %s", err)
+	} else if !bytes.Equal(value, []byte("value")) {
+		t.Errorf("failed to read previously written value, got %q", value)
+	}
+
+	// Reads outside the range fail.
+	isReadSpanErr := func(err error) bool {
+		return testutils.IsError(err, "cannot read undeclared span")
+	}
+	if _, err := batch.Get(outsideKey); !isReadSpanErr(err) {
+		t.Errorf("Get: unexpected error %v", err)
+	}
+	if _, _, _, err := batch.GetProto(outsideKey, nil); !isReadSpanErr(err) {
+		t.Errorf("GetProto: unexpected error %v", err)
+	}
+	if err := batch.Iterate(outsideKey, outsideKey2,
+		func(v engine.MVCCKeyValue) (bool, error) {
+			return false, errors.Errorf("unexpected callback: %v", v)
+		},
+	); !isReadSpanErr(err) {
+		t.Errorf("Iterate: unexpected error %v", err)
+	}
+
+	func() {
+		iter := batch.NewIterator(false)
+		defer iter.Close()
+
+		// Iterators check boundaries on seek and next/prev
+		iter.Seek(outsideKey)
+		if iter.Valid() {
+			t.Fatalf("expected invalid iterator; found valid at key %s", iter.Key())
+		}
+		// Seeking back in bounds restores validity.
+		iter.Seek(insideKey)
+		if !iter.Valid() {
+			t.Fatalf("expected valid iterator")
+		}
+		if !reflect.DeepEqual(iter.Key(), insideKey) {
+			t.Fatalf("expected key %s, got %s", insideKey, iter.Key())
+		}
+		iter.Next()
+		if !iter.Valid() {
+			t.Fatalf("expected valid iterator")
+		}
+		if !reflect.DeepEqual(iter.Key(), insideKey2) {
+			t.Fatalf("expected key %s, got %s", insideKey2, iter.Key())
+		}
+		// Scan out of bounds.
+		iter.Next()
+		if iter.Valid() {
+			t.Fatalf("expected invalid iterator; found valid at key %s", iter.Key())
+		}
+		// Scanning out of bounds sets Valid() to false but is not an error.
+		if iter.Error() != nil {
+			t.Errorf("unexpected error on iterator: %s", iter.Error())
+		}
+	}()
+
+	// Same test in reverse. We commit the batch and wrap an iterator on
+	// the raw engine because we don't support bidirectional iteration
+	// over a pending batch.
+	if err := batch.Commit(true); err != nil {
+		t.Fatal(err)
+	}
+	iter := &SpanSetIterator{eng.NewIterator(false), &ss, nil, false}
+	defer iter.Close()
+	iter.SeekReverse(outsideKey)
+	if iter.Valid() {
+		t.Fatalf("expected invalid iterator; found valid at key %s", iter.Key())
+	}
+	// Seeking back in bounds restores validity.
+	iter.SeekReverse(insideKey2)
+	if !iter.Valid() {
+		t.Fatalf("expected valid iterator")
+	}
+	if !reflect.DeepEqual(iter.Key(), insideKey2) {
+		t.Fatalf("expected key %s, got %s", insideKey2, iter.Key())
+	}
+	iter.Prev()
+	if !iter.Valid() {
+		t.Fatalf("expected valid iterator")
+	}
+	if !reflect.DeepEqual(iter.Key(), insideKey) {
+		t.Fatalf("expected key %s, got %s", insideKey, iter.Key())
+	}
+	// Scan out of bounds.
+	iter.Prev()
+	if iter.Valid() {
+		t.Fatalf("expected invalid iterator; found valid at key %s", iter.Key())
+	}
+	if iter.Error() != nil {
+		t.Errorf("unexpected error on iterator: %s", iter.Error())
+	}
+	// Seeking back in bounds restores validity.
+	iter.SeekReverse(insideKey)
+	if !iter.Valid() {
+		t.Fatalf("expected valid iterator")
+	}
+}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -484,7 +484,7 @@ func TestStoreRemoveReplicaDestroy(t *testing.T) {
 	}
 
 	if _, _, err := repl1.propose(
-		context.Background(), lease, roachpb.BatchRequest{}, nil,
+		context.Background(), lease, roachpb.BatchRequest{}, nil, nil,
 	); err != expErr {
 		t.Fatalf("expected error %s, but got %v", expErr, err)
 	}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -2197,7 +2197,7 @@ func TestStoreGCThreshold(t *testing.T) {
 		},
 		Threshold: threshold,
 	}
-	if _, pErr := tc.SendWrapped(&gcr); pErr != nil {
+	if _, pErr := tc.SendWrappedWith(roachpb.Header{RangeID: 1}, &gcr); pErr != nil {
 		t.Fatal(pErr)
 	}
 


### PR DESCRIPTION
Adds DeclareKeys implementations for all commands. Does not yet cover
keys whose use is implied by use of in-memory fields of the replica
state.

This is an updated and cleaned-up version of #10084.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13864)
<!-- Reviewable:end -->
