### PR TITLE
sql: Create new PipelineQueue and DependencyAnalyzer types

### DIFF
--- a/pkg/sql/pipelining.go
+++ b/pkg/sql/pipelining.go
@@ -1,0 +1,211 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nathan VanBenschoten (nvanbenschoten@gmail.com)
+
+package sql
+
+import (
+	"sync"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// PipelineQueue maintains a set of planNodes running with pipelined execution.
+// It uses a DependencyAnalyzer to determine dependencies between plans. Using
+// this knowledge, the queue provides the following guarantees about the execution
+// of plans:
+// 1. No two plans will ever be run concurrently if they are dependent of one another.
+// 2. If two dependent plans are added to the queue, the plan added first will be
+//    executed before the plan added second.
+// 3. No plans will begin execution once an error has been seen until Wait is
+//    called to drain the plans and reset the error state.
+//
+// The queue performs all computation on pointers to planNode interfaces. This is
+// because it wants to operate on unique objects, and equality of interfaces does
+// not necessarily imply pointer equality.
+type PipelineQueue struct {
+	// analyzer is a DependencyAnalyzer that computes when certain plans are dependent
+	// on one another. It determines if it is safe to run plans concurrently.
+	analyzer DependencyAnalyzer
+
+	// plans is a set of all running and pending plans, with their corresponding "done"
+	// channels. These channels are closed when the plan has finished executing.
+	plans map[*planNode]doneChan
+
+	// err is the first error seen since the last call to PipelineQueue.Wait. Referred to
+	// as the current "pipeline batch's error".
+	err error
+
+	mu           syncutil.Mutex
+	runningGroup sync.WaitGroup
+}
+
+// doneChan is a channel that is closed when a plan finishes execution.
+type doneChan chan struct{}
+
+// MakePipelineQueue creates a new empty PipelineQueue that uses the provided
+// DependencyAnalyzer to determine plan dependencies.
+func MakePipelineQueue(analyzer DependencyAnalyzer) PipelineQueue {
+	return PipelineQueue{
+		plans:    make(map[*planNode]doneChan),
+		analyzer: analyzer,
+	}
+}
+
+// Add inserts a new plan in the queue and executes the provided function when
+// appropriate, obeying the guarantees made by the PipelineQueue.
+//
+// Add should not be called concurrently with Wait. See Wait's comment for more
+// details.
+func (pq *PipelineQueue) Add(plan *planNode, exec func() error) {
+	prereqs, finishLocked := pq.insertInQueue(plan)
+	pq.runningGroup.Add(1)
+	go func() {
+		defer pq.runningGroup.Done()
+
+		// Block on the execution of each prerequisite plan blocking us.
+		for _, prereq := range prereqs {
+			<-prereq
+		}
+
+		// Don't bother executing if an error has already been set.
+		if abort := func() bool {
+			pq.mu.Lock()
+			defer pq.mu.Unlock()
+			if pq.err != nil {
+				finishLocked()
+				return true
+			}
+			return false
+		}(); abort {
+			return
+		}
+
+		// Execute the plan.
+		err := exec()
+
+		pq.mu.Lock()
+		defer pq.mu.Unlock()
+
+		if pq.err == nil {
+			// If we have not already seen an error since the last Wait, set the
+			// error state.
+			pq.err = err
+		}
+
+		finishLocked()
+	}()
+}
+
+// insertInQueue inserts the planNode in the queue. It returns a list of the "done"
+// channels of prerequisite blocking the new plan from executing. It also returns a
+// function to call when the new plan has finished executing. This function must be
+// called while pq.mu is held.
+func (pq *PipelineQueue) insertInQueue(newPlan *planNode) ([]doneChan, func()) {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+
+	// Determine the set of prerequisite plans.
+	prereqs := pq.prereqsForPlanLocked(newPlan)
+
+	// Insert newPlan in running set.
+	newDoneChan := make(doneChan)
+	pq.plans[newPlan] = newDoneChan
+	finish := func() {
+		// Remove the current plan from the running set and signal to dependent
+		// plans that we're done by closing our done channel.
+		delete(pq.plans, newPlan)
+		close(newDoneChan)
+	}
+	return prereqs, finish
+}
+
+// prereqsForPlanLocked determines the set of plans currently running and pending
+// that a new plan is dependent on, It returns a slice of doneChans for each plan
+// in this set. Returns a nil slice if the plan has no prerequisites and can be run
+// immediately.
+func (pq *PipelineQueue) prereqsForPlanLocked(newPlan *planNode) []doneChan {
+	// Add all plans from the plan set that this new plan is dependent on.
+	var prereqs []doneChan
+	for plan, doneChan := range pq.plans {
+		if !pq.analyzer.Independent(plan, newPlan) {
+			prereqs = append(prereqs, doneChan)
+		}
+	}
+	return prereqs
+}
+
+// Len returns the number of plans in the PipelineQueue.
+func (pq *PipelineQueue) Len() int {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+	return len(pq.plans)
+}
+
+// Wait blocks until the PipelineQueue finishes executing all plans. It then
+// returns the error of the last batch of pipelined execution before reseting
+// the error to allow for future use.
+//
+// Wait can not be called concurrently with Add. If we need to lift this
+// restriction, consider replacing the sync.WaitGroup with a syncutil.RWMutex,
+// which will provide the desired starvation and ordering properties. Those
+// being that once Wait is called, future Adds will not be reordered ahead
+// of Waits attempts to drain all running and pending plans.
+func (pq *PipelineQueue) Wait() error {
+	pq.runningGroup.Wait()
+
+	// There is no race condition between waiting on the WaitGroup and locking
+	// the mutex because PipelineQueue.Wait cannot be called concurrently with
+	// Add. We lock only because Err may be called concurrently.
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+	err := pq.err
+	pq.err = nil
+	return err
+}
+
+// Err returns the PipelineQueue's error.
+func (pq *PipelineQueue) Err() error {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+	return pq.err
+}
+
+// DependencyAnalyzer determines if plans are independent of one another, where
+// independent plans are defined by whether their execution could be safely reordered
+// without having an effect on their runtime semantics or on their results. This
+// means that DependencyAnalyzer can be used to test whether it is safe for multiple
+// statements to be run concurrently by the PipelineQueue.
+type DependencyAnalyzer interface {
+	// Independent determines if the provided planNodes are independent from one
+	// another. Implementations of Independent are always commutative.
+	Independent(*planNode, *planNode) bool
+}
+
+// dependencyAnalyzerFunc is an implementation of DependencyAnalyzer that defers
+// to a function for all dependency decisions.
+type dependencyAnalyzerFunc func(*planNode, *planNode) bool
+
+func (f dependencyAnalyzerFunc) Independent(p1 *planNode, p2 *planNode) bool {
+	return f(p1, p2)
+}
+
+// NoDependenciesAnalyzer is a DependencyAnalyzer that performs no analysis on
+// planNodes and asserts that all plans are independent.
+var NoDependenciesAnalyzer DependencyAnalyzer = dependencyAnalyzerFunc(func(
+	_ *planNode, _ *planNode,
+) bool {
+	return true
+})

--- a/pkg/sql/pipelining_test.go
+++ b/pkg/sql/pipelining_test.go
@@ -1,0 +1,291 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nathan VanBenschoten (nvanbenschoten@gmail.com)
+
+package sql
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/pkg/errors"
+)
+
+func newPlanNode() *planNode {
+	var plan planNode = &emptyNode{}
+	return &plan
+}
+
+// assertLen asserts the number of plans in the PipelineQueue.
+func assertLen(t *testing.T, pq *PipelineQueue, exp int) {
+	if l := pq.Len(); l != exp {
+		t.Errorf("expected plan count of %d, found %d", exp, l)
+	}
+}
+
+// assertLenEventually is like assertLen, but can be used in racy situations
+// where proper synchronization can not be performed.
+func assertLenEventually(t *testing.T, pq *PipelineQueue, exp int) {
+	testutils.SucceedsSoon(t, func() error {
+		if l := pq.Len(); l != exp {
+			return errors.Errorf("expected plan count of %d, found %d", exp, l)
+		}
+		return nil
+	})
+}
+
+// waitAndAssertEmptyWithErr waits for the PipelineQueue to drain, then asserts
+// that the queue is empty. It returns the error produced by PipelineQueue.Wait.
+func waitAndAssertEmptyWithErr(t *testing.T, pq *PipelineQueue) error {
+	err := pq.Wait()
+	if l := pq.Len(); l != 0 {
+		t.Errorf("expected empty PipelineQueue, found %d plans remaining", l)
+	}
+	return err
+}
+
+func waitAndAssertEmpty(t *testing.T, pq *PipelineQueue) {
+	if err := waitAndAssertEmptyWithErr(t, pq); err != nil {
+		t.Fatalf("unexpected error waiting for pipeline queue to drain: %v", err)
+	}
+}
+
+// TestPipelineQueueNoDependencies tests three plans run through a PipelineQueue when
+// none of the plans are dependent on each other. Because of their independence, we
+// use channels to guarantee deterministic execution.
+func TestPipelineQueueNoDependencies(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var res []int
+	run1, run2, run3 := make(chan struct{}), make(chan struct{}), make(chan struct{})
+
+	// Executes: plan3 -> plan1 -> plan2.
+	pq := MakePipelineQueue(NoDependenciesAnalyzer)
+	pq.Add(newPlanNode(), func() error {
+		<-run1
+		res = append(res, 1)
+		assertLen(t, &pq, 3)
+		close(run3)
+		return nil
+	})
+	pq.Add(newPlanNode(), func() error {
+		<-run2
+		res = append(res, 2)
+		assertLenEventually(t, &pq, 1)
+		return nil
+	})
+	pq.Add(newPlanNode(), func() error {
+		<-run3
+		res = append(res, 3)
+		assertLenEventually(t, &pq, 2)
+		close(run2)
+		return nil
+	})
+	close(run1)
+
+	waitAndAssertEmpty(t, &pq)
+	exp := []int{1, 3, 2}
+	if !reflect.DeepEqual(res, exp) {
+		t.Fatalf("expected pipeline side effects %v, found %v", exp, res)
+	}
+}
+
+// TestPipelineQueueAllDependent tests three plans run through a PipelineQueue when
+// all of the plans are dependent on each other. Because of their dependence, we
+// need no extra synchronization to guarantee deterministic execution.
+func TestPipelineQueueAllDependent(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var res []int
+	run := make(chan struct{})
+	analyzer := dependencyAnalyzerFunc(func(p1 *planNode, p2 *planNode) bool {
+		return false
+	})
+
+	// Executes: plan1 -> plan2 -> plan3.
+	pq := MakePipelineQueue(analyzer)
+	pq.Add(newPlanNode(), func() error {
+		<-run
+		res = append(res, 1)
+		assertLen(t, &pq, 3)
+		return nil
+	})
+	pq.Add(newPlanNode(), func() error {
+		res = append(res, 2)
+		assertLen(t, &pq, 2)
+		return nil
+	})
+	pq.Add(newPlanNode(), func() error {
+		res = append(res, 3)
+		assertLen(t, &pq, 1)
+		return nil
+	})
+	close(run)
+
+	waitAndAssertEmpty(t, &pq)
+	exp := []int{1, 2, 3}
+	if !reflect.DeepEqual(res, exp) {
+		t.Fatalf("expected pipeline side effects %v, found %v", exp, res)
+	}
+}
+
+// TestPipelineQueueSingleDependency tests three plans where one is dependent on
+// another. Because one plan is dependent, it will be held in the pending queue
+// until the prerequisite plan completes execution.
+func TestPipelineQueueSingleDependency(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var res []int
+	plan1, plan2, plan3 := newPlanNode(), newPlanNode(), newPlanNode()
+	run1, run3 := make(chan struct{}), make(chan struct{})
+	analyzer := dependencyAnalyzerFunc(func(p1 *planNode, p2 *planNode) bool {
+		if (p1 == plan1 && p2 == plan2) || (p1 == plan2 && p2 == plan1) {
+			// plan1 and plan2 are dependent
+			return false
+		}
+		return true
+	})
+
+	// Executes: plan3 -> plan1 -> plan2.
+	pq := MakePipelineQueue(analyzer)
+	pq.Add(plan1, func() error {
+		<-run1
+		res = append(res, 1)
+		assertLenEventually(t, &pq, 2)
+		return nil
+	})
+	pq.Add(plan2, func() error {
+		res = append(res, 2)
+		assertLen(t, &pq, 1)
+		return nil
+	})
+	pq.Add(plan3, func() error {
+		<-run3
+		res = append(res, 3)
+		assertLen(t, &pq, 3)
+		close(run1)
+		return nil
+	})
+	close(run3)
+
+	waitAndAssertEmpty(t, &pq)
+	exp := []int{3, 1, 2}
+	if !reflect.DeepEqual(res, exp) {
+		t.Fatalf("expected pipeline side effects %v, found %v", exp, res)
+	}
+}
+
+// TestPipelineQueueError tests three plans where one is dependent on another
+// and the prerequisite plan throws an error.
+func TestPipelineQueueError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var res []int
+	plan1, plan2, plan3 := newPlanNode(), newPlanNode(), newPlanNode()
+	run1, run3 := make(chan struct{}), make(chan struct{})
+	planErr := errors.Errorf("plan1 will throw this error")
+	analyzer := dependencyAnalyzerFunc(func(p1 *planNode, p2 *planNode) bool {
+		if (p1 == plan1 && p2 == plan2) || (p1 == plan2 && p2 == plan1) {
+			// plan1 and plan2 are dependent
+			return false
+		}
+		return true
+	})
+
+	// Executes: plan3 -> plan1 (error!) -> plan2 (dropped).
+	pq := MakePipelineQueue(analyzer)
+	pq.Add(plan1, func() error {
+		<-run1
+		res = append(res, 1)
+		assertLenEventually(t, &pq, 2)
+		return planErr
+	})
+	pq.Add(plan2, func() error {
+		// Should never be called. We assert this using the res slice, because
+		// we can't call t.Fatalf in a different goroutine.
+		res = append(res, 2)
+		return nil
+	})
+	pq.Add(plan3, func() error {
+		<-run3
+		res = append(res, 3)
+		assertLen(t, &pq, 3)
+		close(run1)
+		return nil
+	})
+	close(run3)
+
+	resErr := waitAndAssertEmptyWithErr(t, &pq)
+	if resErr != planErr {
+		t.Fatalf("expected plan1 to throw error %v, found %v", planErr, resErr)
+	}
+
+	exp := []int{3, 1}
+	if !reflect.DeepEqual(res, exp) {
+		t.Fatalf("expected pipeline side effects %v, found %v", exp, res)
+	}
+}
+
+// TestPipelineQueueAddAfterError tests that if a plan is added to a PipelineQueue
+// after an error has been produced but before Wait has been called, that the plan
+// will never be run. It then tests that once Wait has been called, the error state
+// will be cleared.
+func TestPipelineQueueAddAfterError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var res []int
+	plan1, plan2, plan3 := newPlanNode(), newPlanNode(), newPlanNode()
+	planErr := errors.Errorf("plan1 will throw this error")
+
+	// Executes: plan1 (error!) -> plan2 (dropped) -> plan3.
+	pq := MakePipelineQueue(NoDependenciesAnalyzer)
+	pq.Add(plan1, func() error {
+		res = append(res, 1)
+		assertLen(t, &pq, 1)
+		return planErr
+	})
+	testutils.SucceedsSoon(t, func() error {
+		// We need this, because any signal from within plan1's execution could
+		// race with the beginning of plan2.
+		if pqErr := pq.Err(); pqErr == nil {
+			return errors.Errorf("plan1 not yet run")
+		}
+		return nil
+	})
+
+	pq.Add(plan2, func() error {
+		// Should never be called. We assert this using the res slice, because
+		// we can't call t.Fatalf in a different goroutine.
+		res = append(res, 2)
+		return nil
+	})
+
+	// Wait for the pipeline queue to clear and assert that we see the
+	// correct error.
+	resErr := waitAndAssertEmptyWithErr(t, &pq)
+	if resErr != planErr {
+		t.Fatalf("expected plan1 to throw error %v, found %v", planErr, resErr)
+	}
+
+	pq.Add(plan3, func() error {
+		// Will be called, because the error is cleared when Wait is called.
+		res = append(res, 3)
+		assertLen(t, &pq, 1)
+		return nil
+	})
+
+	waitAndAssertEmpty(t, &pq)
+	exp := []int{1, 3}
+	if !reflect.DeepEqual(res, exp) {
+		t.Fatalf("expected pipeline side effects %v, found %v", exp, res)
+	}
+}


### PR DESCRIPTION
Related to #13160.

These two types will be used for SQL Statement Pipelining by the
`sql.Executor`. The `PipelineQueue` will hang off of a `sql.Session` and
allow the session to track pipelined statements.

The `PipelineQueue` type maintains a set of `planNode`s running with
pipelined execution. It uses a `DependencyAnalyzer` to determine dependencies
between plans. Using this knowledge, the queue provides the following
guarantees about the execution of plans:
- No two plans will ever be run concurrently if they are dependent of
  one another.
- If two dependent plans are added to the queue, the plan added first
  will be executed before the plan added second.
- No plans will begin execution once an error has been seen until Wait
  is called to drain the plans and reset the error state.

The `DependencyAnalyzer` type determines if plans are independent of one
another. It can be used to test whether it is safe for multiple statements
to be run concurrently by the `PipelineQueue`.

For now, the only concrete implementation of `DependencyAnalyzer` is
`NoDependenciesAnalyzer`, which performs no real dependency analysis and
asserts that all plans are independent.

The SQL Pipelining RFC's [algorithm section](https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/sql_pipelining.md#algorithm) discusses in some depth how
a structure like the `PipelineQueue`, in conjunction with a `DependencyAnalyzer`,
will be used by the `sql.Executor`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13865)
<!-- Reviewable:end -->
