### PR TITLE
sql: hide constraints on hidden-only columns

### DIFF
--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -1562,6 +1562,23 @@ func (desc TableDescriptor) collectConstraintInfo(
 			if _, ok := info[index.Name]; ok {
 				return nil, errors.Errorf("duplicate constraint name: %q", index.Name)
 			}
+			colHiddenMap := make(map[ColumnID]bool, len(desc.Columns))
+			for i, column := range desc.Columns {
+				colHiddenMap[column.ID] = desc.Columns[i].Hidden
+			}
+			// Don't include constraints against only hidden columns.
+			// This prevents the auto-created rowid primary key index from showing up
+			// in show constraints.
+			hidden := true
+			for _, id := range index.ColumnIDs {
+				if !colHiddenMap[id] {
+					hidden = false
+					break
+				}
+			}
+			if hidden {
+				continue
+			}
 			detail := ConstraintDetail{Kind: ConstraintTypePK}
 			if tableLookup != nil {
 				detail.Columns = index.ColumnNames

--- a/pkg/sql/testdata/explain
+++ b/pkg/sql/testdata/explain
@@ -220,7 +220,7 @@ EXPLAIN SHOW CONSTRAINTS FROM foo
 1  sort
 1                 order   +"Table",+Name
 2  values
-2                 size    5 columns, 1 row
+2                 size    5 columns, 0 rows
 
 query ITTT
 EXPLAIN SHOW USERS

--- a/pkg/sql/testdata/fk
+++ b/pkg/sql/testdata/fk
@@ -184,7 +184,6 @@ SHOW CONSTRAINTS FROM delivery
 ----
 delivery  fk_item_ref_products   FOREIGN KEY (UNVALIDATED)  item             products.[upc]
 delivery  fk_order_ref_orders    FOREIGN KEY                order, shipment  orders.[id shipment]
-delivery  primary                PRIMARY KEY                rowid            NULL
 
 statement error foreign key violation: "delivery" row item='885155001450' has no match in "products"
 ALTER TABLE delivery VALIDATE CONSTRAINT fk_item_ref_products
@@ -194,7 +193,6 @@ SHOW CONSTRAINTS FROM delivery
 ----
 delivery  fk_item_ref_products   FOREIGN KEY (UNVALIDATED)  item             products.[upc]
 delivery  fk_order_ref_orders    FOREIGN KEY                order, shipment  orders.[id shipment]
-delivery  primary                PRIMARY KEY                rowid            NULL
 
 statement ok
 UPDATE products SET upc = '885155001450' WHERE sku = '780'
@@ -211,7 +209,6 @@ SHOW CONSTRAINTS FROM delivery
 ----
 delivery  fk_item_ref_products   FOREIGN KEY        item             products.[upc]
 delivery  fk_order_ref_orders    FOREIGN KEY        order, shipment  orders.[id shipment]
-delivery  primary                PRIMARY KEY        rowid            NULL
 
 statement ok
 ALTER TABLE "user content"."customer reviews"

--- a/pkg/sql/testdata/information_schema
+++ b/pkg/sql/testdata/information_schema
@@ -502,7 +502,6 @@ def                 constraint_db      check_a          constraint_db  t1       
 def                 constraint_db      primary          constraint_db  t1          PRIMARY KEY
 def                 constraint_db      t1_a_key         constraint_db  t1          UNIQUE
 def                 constraint_db      fk               constraint_db  t2          FOREIGN KEY
-def                 constraint_db      primary          constraint_db  t2          PRIMARY KEY
 
 statement ok
 DROP DATABASE constraint_db
@@ -678,7 +677,6 @@ def                 constraint_column  fk               def            constrain
 def                 constraint_column  primary          def            constraint_column  t2          t1_ID        1                 NULL
 def                 constraint_column  fk               def            constraint_column  t3          a            1                 1
 def                 constraint_column  fk               def            constraint_column  t3          b            2                 2
-def                 constraint_column  primary          def            constraint_column  t3          rowid        1                 NULL
 
 statement ok
 DROP DATABASE constraint_column

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -500,8 +500,6 @@ oid         conname    connamespace  contype
 229825095   index_key  1708731312    u
 453404206   check_b    1708731312    c
 1201123742  primary    1708731312    p
-2684964110  primary    1708731312    p
-3368586374  primary    1708731312    p
 4150478613  fk         1708731312    f
 4206367032  fk         1708731312    f
 
@@ -517,8 +515,6 @@ t1_a_key   u        false          false        true          2876473678  0     
 index_key  u        false          false        true          2876473678  0         335779560
 check_b    c        false          false        true          3211628798  0         0
 primary    p        false          false        true          2876473678  0         335779562
-primary    p        false          false        true          3110815990  0         4235777034
-primary    p        false          false        true          3211628798  0         624432002
 fk         f        false          false        true          3211628798  0         335779560
 fk         f        false          false        true          3110815990  0         335779561
 
@@ -541,8 +537,6 @@ conname    confrelid  confupdtype  confdeltype  confmatchtype
 t1_a_key   0          NULL         NULL         NULL
 index_key  0          NULL         NULL         NULL
 check_b    0          NULL         NULL         NULL
-primary    0          NULL         NULL         NULL
-primary    0          NULL         NULL         NULL
 primary    0          NULL         NULL         NULL
 
 query TOTTT colnames
@@ -568,8 +562,6 @@ t1_a_key   true        0            true          {2}
 index_key  true        0            true          {3,4}
 check_b    true        0            true          NULL
 primary    true        0            true          {1}
-primary    true        0            true          {2}
-primary    true        0            true          {4}
 fk         true        0            true          {1,2}
 fk         true        0            true          {1}
 
@@ -584,8 +576,6 @@ conname    confkey  conpfeqop  conppeqop  conffeqop  conexclop  conbin  consrc
 t1_a_key   NULL     NULL       NULL       NULL       NULL       NULL    NULL
 index_key  NULL     NULL       NULL       NULL       NULL       NULL    NULL
 check_b    NULL     NULL       NULL       NULL       NULL       b > 11  b > 11
-primary    NULL     NULL       NULL       NULL       NULL       NULL    NULL
-primary    NULL     NULL       NULL       NULL       NULL       NULL    NULL
 primary    NULL     NULL       NULL       NULL       NULL       NULL    NULL
 
 query TTTTTTTT colnames
@@ -1058,7 +1048,7 @@ SELECT COUNT(*) FROM pg_catalog.pg_constraint con
 JOIN pg_catalog.pg_namespace n ON con.connamespace = n.oid
 WHERE n.nspname = 'constraint_db'
 ----
-8
+6
 
 query I
 SELECT COUNT(*) FROM pg_catalog.pg_depend

--- a/pkg/sql/testdata/table
+++ b/pkg/sql/testdata/table
@@ -219,7 +219,6 @@ dupe_generated  check_bar   CHECK        NULL       bar > 2
 dupe_generated  check_foo   CHECK        NULL       foo > 2
 dupe_generated  check_foo1  CHECK        NULL       foo < 10
 dupe_generated  check_foo2  CHECK        NULL       foo > 1
-dupe_generated  primary     PRIMARY KEY  rowid      NULL
 
 statement ok
 CREATE TABLE test.named_constraints (


### PR DESCRIPTION
Hidden columns, such as the auto-created `rowid` column on tables
without primary keys, are not shown in `SHOW COLUMNS` or column metadata
tables in `information_schema` and `pg_catalog`. However, these hidden
columns do show up in `SHOW CONSTRAINTS` and constraint metadata tables.
This is problematic because it introduces broken references in the
metadata tables that can confuse users and ORMs, such as ActiveRecord.

`SHOW CONSTRAINTS` and the constraint tables in `information_schema` and
`pg_catalog` are updated to hide constraints when the constraint columns
are all hidden. This resolves an issue with ActiveRecord's behavior
against tables without primary keys.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13870)
<!-- Reviewable:end -->
