### PR TITLE
kv: impose timeout on sending KV RPCs

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -67,6 +67,8 @@ type TestServerArgs struct {
 	SSLCertKey               string
 	TimeSeriesQueryWorkerMax int
 	SQLMemoryPoolSize        int64
+	SendNextTimeout          time.Duration
+	SendRPCTimeout           time.Duration
 
 	// If set, this will be appended to the Postgres URL by functions that
 	// automatically open a connection to the server. That's equivalent to running

--- a/pkg/kv/dist_sender_server_test.go
+++ b/pkg/kv/dist_sender_server_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -1112,5 +1113,91 @@ func TestPropagateTxnOnError(t *testing.T) {
 
 	if epoch != 2 {
 		t.Errorf("unexpected epoch; the txn must be retried exactly once, but got %d", epoch)
+	}
+}
+
+// TestDistSenderRequestBlackhole simulates the case of a replica
+// failing to return a request. We verify that if a new leader is
+// elected _after_ all replicas are tried at least once, the request
+// is still retried and processed by the new leader.
+func TestDistSenderRequestBlackhole(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Set up a filter to prevent Get operations from succeeding to the
+	// first replica.
+	params := base.TestServerArgs{}
+	targetKey := roachpb.Key("b")
+	var firstReplica atomic.Value
+	wait := make(chan struct{})
+	defer close(wait)
+
+	params.Knobs.Store = &storage.StoreTestingKnobs{
+		TestingEvalFilter: func(fArgs storagebase.FilterArgs) *roachpb.Error {
+			_, ok := fArgs.Req.(*roachpb.GetRequest)
+			if ok && fArgs.Req.Header().Key.Equal(targetKey) {
+				if val := firstReplica.Load(); val == nil {
+					firstReplica.Store(fArgs.Hdr.Replica)
+				} else if fArgs.Hdr.Replica == val.(roachpb.ReplicaDescriptor) {
+					<-wait
+				}
+			}
+			return nil
+		},
+	}
+	params.SendNextTimeout = 10 * time.Millisecond
+	params.SendRPCTimeout = 100 * time.Millisecond
+	testClusterArgs := base.TestClusterArgs{
+		ReplicationMode: base.ReplicationAuto,
+		ServerArgs:      params,
+	}
+	const numReplicas = 3
+	tc := testcluster.StartTestCluster(t, numReplicas, testClusterArgs)
+	defer tc.Stopper().Stop()
+
+	db := createTestClient(t, tc.Servers[0])
+
+	// Try a conditional put which should stall on first range.
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := db.Get(context.TODO(), targetKey)
+		errCh <- err
+	}()
+
+	// Wait for the first Get to arrive.
+	testutils.SucceedsSoon(t, func() error {
+		if firstReplica.Load() == nil {
+			return errors.Errorf("awaiting Get() to key %q", targetKey)
+		}
+		return nil
+	})
+
+	// Lookup the lease.
+	tableRangeDesc, err := tc.LookupRange(targetKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaseHolder, err := tc.FindRangeLeaseHolder(
+		tableRangeDesc,
+		&base.ReplicationTarget{
+			NodeID:  tc.Servers[0].GetNode().Descriptor.NodeID,
+			StoreID: tc.Servers[0].GetFirstStoreID(),
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Find a node other than the current lease holder to transfer the lease to.
+	for i, s := range tc.Servers {
+		if leaseHolder.StoreID != s.GetFirstStoreID() {
+			if err := tc.TransferRangeLease(tableRangeDesc, tc.Target(i)); err != nil {
+				t.Fatal(err)
+			}
+			break
+		}
+	}
+
+	// Verify that Get() succeeds.
+	if err := <-errCh; err != nil {
+		t.Errorf("expected nil error; got %v", err)
 	}
 }

--- a/pkg/kv/transport_test.go
+++ b/pkg/kv/transport_test.go
@@ -54,54 +54,41 @@ func TestTransportMoveToFront(t *testing.T) {
 
 	// Now replica 3.
 	gt.MoveToFront(rd3)
-	verifyOrder([]roachpb.ReplicaDescriptor{rd3, rd1, rd2})
+	verifyOrder([]roachpb.ReplicaDescriptor{rd3, rd2, rd1})
 
 	// Mark replica 2 pending. Shouldn't be able to move it.
-	clients[2].pending = true
+	gt.orderedClients[1].pending = true
 	gt.MoveToFront(rd2)
-	verifyOrder([]roachpb.ReplicaDescriptor{rd3, rd1, rd2})
+	verifyOrder([]roachpb.ReplicaDescriptor{rd3, rd2, rd1})
 
 	// Advance the client index and move replica 3 back to front.
 	gt.clientIndex++
 	gt.MoveToFront(rd3)
-	verifyOrder([]roachpb.ReplicaDescriptor{rd3, rd1, rd2})
+	verifyOrder([]roachpb.ReplicaDescriptor{rd3, rd2, rd1})
 	if gt.clientIndex != 0 {
 		t.Fatalf("expected cient index 0; got %d", gt.clientIndex)
 	}
 
-	// Advance the client index again and verify replica 3 cannot
-	// be moved to front for a second retry.
+	// Advance the client index again and try to move replica
+	// 3, which should fail because it's already been retried.
 	gt.clientIndex++
 	gt.MoveToFront(rd3)
-	verifyOrder([]roachpb.ReplicaDescriptor{rd3, rd1, rd2})
+	verifyOrder([]roachpb.ReplicaDescriptor{rd3, rd2, rd1})
 	if gt.clientIndex != 1 {
 		t.Fatalf("expected cient index 1; got %d", gt.clientIndex)
 	}
 
 	// Mark replica 2 no longer pending. Should be able to move it.
-	clients[2].pending = false
+	gt.clientIndex++
+	gt.orderedClients[1].pending = false
 	gt.MoveToFront(rd2)
 	verifyOrder([]roachpb.ReplicaDescriptor{rd3, rd2, rd1})
-
-	// Advance client index and move rd1 front; should be no change.
-	gt.clientIndex++
-	gt.MoveToFront(rd1)
-	verifyOrder([]roachpb.ReplicaDescriptor{rd3, rd2, rd1})
-
-	// Advance client index to and and move rd1 to front. Should move
-	// client index back for a retry.
-	gt.clientIndex++
-	gt.MoveToFront(rd1)
-	verifyOrder([]roachpb.ReplicaDescriptor{rd3, rd2, rd1})
-	if gt.clientIndex != 2 {
-		t.Fatalf("expected cient index 2; got %d", gt.clientIndex)
+	if gt.clientIndex != 1 {
+		t.Fatalf("expected cient index 1; got %d", gt.clientIndex)
 	}
 
-	// Advance client index once more; verify no second retry.
+	// Advance client index and move rd1 front.
 	gt.clientIndex++
 	gt.MoveToFront(rd1)
 	verifyOrder([]roachpb.ReplicaDescriptor{rd3, rd2, rd1})
-	if gt.clientIndex != 3 {
-		t.Fatalf("expected cient index 3; got %d", gt.clientIndex)
-	}
 }

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -104,6 +104,16 @@ type Config struct {
 	// used by SQL clients to store row data in server RAM.
 	SQLMemoryPoolSize int64
 
+	// SendNextTimeout is the interval after which a pending RPC is
+	// considered unlikely to return, prompting a send to an alternate
+	// replica, if one is available.
+	SendNextTimeout time.Duration
+
+	// SendRPCTimeout is the timeout for sending an RPC to the KV
+	// API. If this timeout expires, the range descriptor cache is
+	// evicted and the RPC is retried with an exponential backoff.
+	SendRPCTimeout time.Duration
+
 	// Parsed values.
 
 	// NodeAttributes is the parsed representation of Attrs.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -196,6 +196,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		Clock:           s.clock,
 		RPCContext:      s.rpcContext,
 		RPCRetryOptions: &retryOpts,
+		SendNextTimeout: s.cfg.SendNextTimeout,
+		SendRPCTimeout:  s.cfg.SendRPCTimeout,
 	}
 	s.distSender = kv.NewDistSender(distSenderCfg, s.gossip)
 	s.registry.AddMetricStruct(s.distSender.Metrics())

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -135,6 +135,12 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	if params.SQLMemoryPoolSize != 0 {
 		cfg.SQLMemoryPoolSize = params.SQLMemoryPoolSize
 	}
+	if params.SendNextTimeout != 0 {
+		cfg.SendNextTimeout = params.SendNextTimeout
+	}
+	if params.SendRPCTimeout != 0 {
+		cfg.SendRPCTimeout = params.SendRPCTimeout
+	}
 	cfg.JoinList = []string{params.JoinAddr}
 	if cfg.Insecure {
 		// Whenever we can (i.e. in insecure mode), use IsolatedTestAddr

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -3309,7 +3309,7 @@ func (r *Replica) ChangeReplicas(
 		if err := txn.GetProto(descKey, oldDesc); err != nil {
 			return err
 		}
-		log.Infof(ctx, "change replicas (remove %s): read existing descriptor %+v", repDesc, oldDesc)
+		log.Infof(ctx, "%s %s: read existing descriptor %+v", changeType, repDesc, oldDesc)
 
 		{
 			b := txn.NewBatch()


### PR DESCRIPTION
This avoid falling into a situation where the sender could fail to
retry replicas that experienced `NotLeaseHolderErrors` after the
`SendNextTimeout` expired, and then never tried again, even in
cases where the lease might have been transferred on a Raft
reelection.

Added a timeout to the `DistSender.sendToReplicas` context in order
to avoid situations where a black holed RPC could keep the sender
permanently stuck, even though the range's replicas might have
changed. This actually was happening in very rare cases in the
added unittest, where the test would have a stale entry in the
range descriptor cache, leading it to believe there were only two
replicas.

Changed default value for SendNextTimeout to 1s from 500ms to avoid
cases where we'd send two RPCs in the common case where a cluster
had very high latency links. See #6719 for details about reasoning
behind this change.

Fixes #6719

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13889)
<!-- Reviewable:end -->
