### PR TITLE
sql: improve OID type representation

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1529,6 +1529,7 @@ func checkResultType(typ parser.Type) error {
 	case parser.TypeStringArray:
 	case parser.TypeNameArray:
 	case parser.TypeIntArray:
+	case parser.TypeOid:
 	default:
 		// Compare all types that cannot rely on == equality.
 		istype := typ.FamilyEqual

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -1534,7 +1534,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types: ArgTypes{
 				{"pg_node_tree", TypeString},
-				{"relation_oid", TypeInt},
+				{"relation_oid", TypeOid},
 			},
 			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, args Datums) (Datum, error) {
@@ -1546,7 +1546,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types: ArgTypes{
 				{"pg_node_tree", TypeString},
-				{"relation_oid", TypeInt},
+				{"relation_oid", TypeOid},
 				{"pretty_bool", TypeBool},
 			},
 			ReturnType: fixedReturnType(TypeString),
@@ -1563,13 +1563,12 @@ var Builtins = map[string][]Builtin{
 	"pg_get_indexdef": {
 		Builtin{
 			Types: ArgTypes{
-				{"index_oid", TypeInt},
+				{"index_oid", TypeOid},
 			},
 			ReturnType: fixedReturnType(TypeString),
 			fn: func(ctx *EvalContext, args Datums) (Datum, error) {
-				oid := args[0]
 				r, err := ctx.Planner.QueryRow(
-					"SELECT indexdef FROM pg_catalog.pg_indexes WHERE crdb_oid=$1", oid)
+					"SELECT indexdef FROM pg_catalog.pg_indexes WHERE crdb_oid=$1", args[0])
 				if err != nil {
 					return nil, err
 				}
@@ -1602,7 +1601,7 @@ var Builtins = map[string][]Builtin{
 	"pg_get_userbyid": {
 		Builtin{
 			Types: ArgTypes{
-				{"role_oid", TypeInt},
+				{"role_oid", TypeOid},
 			},
 			ReturnType: fixedReturnType(TypeString),
 			fn: func(ctx *EvalContext, args Datums) (Datum, error) {
@@ -1623,10 +1622,10 @@ var Builtins = map[string][]Builtin{
 	"format_type": {
 		Builtin{
 			// TODO(jordan) typemod should be a Nullable TypeInt when supported.
-			Types:      ArgTypes{{"type_oid", TypeInt}, {"typemod", TypeInt}},
+			Types:      ArgTypes{{"type_oid", TypeOid}, {"typemod", TypeInt}},
 			ReturnType: fixedReturnType(TypeString),
 			fn: func(ctx *EvalContext, args Datums) (Datum, error) {
-				typ, ok := OidToType[oid.Oid(int(MustBeDInt(args[0])))]
+				typ, ok := OidToType[oid.Oid(int(args[0].(*DOid).DInt))]
 				if !ok {
 					return NewDString(fmt.Sprintf("unknown (OID=%s)", args[0])), nil
 				}
@@ -1640,7 +1639,7 @@ var Builtins = map[string][]Builtin{
 	},
 	"col_description": {
 		Builtin{
-			Types:      ArgTypes{{"table_oid", TypeInt}, {"column_number", TypeInt}},
+			Types:      ArgTypes{{"table_oid", TypeOid}, {"column_number", TypeInt}},
 			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, _ Datums) (Datum, error) {
 				return DNull, nil
@@ -1651,7 +1650,7 @@ var Builtins = map[string][]Builtin{
 	},
 	"obj_description": {
 		Builtin{
-			Types:      ArgTypes{{"object_oid", TypeInt}},
+			Types:      ArgTypes{{"object_oid", TypeOid}},
 			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, _ Datums) (Datum, error) {
 				return DNull, nil
@@ -1660,7 +1659,7 @@ var Builtins = map[string][]Builtin{
 			Info:     "Not usable; exposed only for ORM compatibility with PostgreSQL.",
 		},
 		Builtin{
-			Types:      ArgTypes{{"object_oid", TypeInt}, {"catalog_name", TypeString}},
+			Types:      ArgTypes{{"object_oid", TypeOid}, {"catalog_name", TypeString}},
 			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, _ Datums) (Datum, error) {
 				return DNull, nil
@@ -1671,7 +1670,7 @@ var Builtins = map[string][]Builtin{
 	},
 	"shobj_description": {
 		Builtin{
-			Types:      ArgTypes{{"object_oid", TypeInt}, {"catalog_name", TypeString}},
+			Types:      ArgTypes{{"object_oid", TypeOid}, {"catalog_name", TypeString}},
 			ReturnType: fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, _ Datums) (Datum, error) {
 				return DNull, nil

--- a/pkg/sql/parser/constant.go
+++ b/pkg/sql/parser/constant.go
@@ -178,8 +178,8 @@ func (expr *NumVal) asConstantInt() (constant.Value, bool) {
 }
 
 var (
-	numValAvailIntFloatDec = []Type{TypeInt, TypeDecimal, TypeFloat}
-	numValAvailDecFloatInt = []Type{TypeDecimal, TypeFloat, TypeInt}
+	numValAvailIntFloatDec = []Type{TypeInt, TypeDecimal, TypeFloat, TypeOid}
+	numValAvailDecFloatInt = []Type{TypeDecimal, TypeFloat, TypeInt, TypeOid}
 	numValAvailDecFloat    = []Type{TypeDecimal, TypeFloat}
 )
 
@@ -248,7 +248,7 @@ func (expr *NumVal) ResolveAsType(ctx *SemaContext, typ Type) (Datum, error) {
 		if err != nil {
 			return nil, err
 		}
-		return NewDOidFromDInt(d.(*DInt)), nil
+		return NewDOid(*d.(*DInt)), nil
 	default:
 		return nil, fmt.Errorf("could not resolve %T %v into a %T", expr, expr, typ)
 	}

--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -2006,6 +2006,90 @@ func (*DTable) min() (Datum, bool) { return nil, false }
 // Size implements the Datum interface.
 func (*DTable) Size() uintptr { return unsafe.Sizeof(DTable{}) }
 
+// DOid is the Postgres OID datum. It can represent either an OID type or any
+// of the reg* types, such as regproc or regclass.
+type DOid struct {
+	// A DOid embeds a DInt, the underlying integer OID for this OID datum.
+	DInt
+	// kind indicates the particular variety of OID this datum is, whether raw
+	// oid or a reg* type.
+	kind *OidColType
+	// name is set to the resolved name of this OID, if available.
+	name string
+}
+
+// NewDOid is a helper routine to create a *DOid initialized from a DInt.
+func NewDOid(d DInt) Datum {
+	return &DOid{DInt: d, kind: oidColTypeOid, name: ""}
+}
+
+// AmbiguousFormat implements the Datum interface.
+func (*DOid) AmbiguousFormat() bool { return true }
+
+// Compare implements the Datum interface.
+func (d *DOid) Compare(other Datum) int {
+	if other == DNull {
+		// NULL is less than any non-NULL value.
+		return 1
+	}
+	v, ok := other.(*DOid)
+	if !ok {
+		panic(makeUnsupportedComparisonMessage(d, other))
+	}
+	if d.DInt < v.DInt {
+		return -1
+	}
+	if d.DInt > v.DInt {
+		return 1
+	}
+	return 0
+}
+
+// Format implements the Datum interface.
+func (d *DOid) Format(buf *bytes.Buffer, flags FmtFlags) {
+	if d.kind == oidColTypeOid || d.name == "" {
+		d.DInt.Format(buf, flags)
+	} else {
+		encodeSQLStringWithFlags(buf, d.name, FmtBareStrings)
+	}
+}
+
+// IsMax implements the Datum interface.
+func (d *DOid) IsMax() bool { return d.DInt.IsMax() }
+
+// IsMin implements the Datum interface.
+func (d *DOid) IsMin() bool { return d.DInt.IsMin() }
+
+// Next implements the Datum interface.
+func (d *DOid) Next() (Datum, bool) {
+	next, ok := d.DInt.Next()
+	return &DOid{*next.(*DInt), d.kind, ""}, ok
+}
+
+// Prev implements the Datum interface.
+func (d *DOid) Prev() (Datum, bool) {
+	prev, ok := d.DInt.Prev()
+	return &DOid{*prev.(*DInt), d.kind, ""}, ok
+}
+
+// ResolvedType implements the Datum interface.
+func (DOid) ResolvedType() Type { return TypeOid }
+
+// Size implements the Datum interface.
+func (d *DOid) Size() uintptr { return unsafe.Sizeof(*d) }
+
+// max implements the Datum interface.
+func (d *DOid) max() (Datum, bool) {
+	max, ok := d.DInt.max()
+	return &DOid{*max.(*DInt), d.kind, ""}, ok
+}
+
+// min implements the Datum interface.
+func (d *DOid) min() (Datum, bool) {
+	min, ok := d.DInt.min()
+	return &DOid{*min.(*DInt), d.kind, ""}, ok
+}
+
 // DOidWrapper is a Datum implementation which is a wrapper around a Datum, allowing
 // custom Oid values to be attached to the Datum and its Type (see tOidWrapper).
 // The reason the Datum type was introduced was to permit the introduction of Datum
@@ -2024,7 +2108,6 @@ func (*DTable) Size() uintptr { return unsafe.Sizeof(DTable{}) }
 //   additions to typing rules or type-dependent evaluation behavior.
 //
 // Types that currently benefit from DOidWrapper are:
-// - DOid  => DOidWrapper(*DInt,    oid.T_oid)
 // - DName => DOidWrapper(*DString, oid.T_name)
 //
 type DOidWrapper struct {
@@ -2142,18 +2225,6 @@ func NewDNameFromDString(d *DString) Datum {
 // initialized from a string.
 func NewDName(d string) Datum {
 	return NewDNameFromDString(NewDString(d))
-}
-
-// NewDOidFromDInt is a helper routine to create a *DOid (implemented as
-// a *DOidWrapper) initialized from an existing *DInt.
-func NewDOidFromDInt(d *DInt) Datum {
-	return wrapWithOid(d, oid.T_oid)
-}
-
-// NewDOid is a helper routine to create a *DOid (implemented as a *DOidWrapper)
-// initialized from a DInt.
-func NewDOid(d DInt) Datum {
-	return NewDOidFromDInt(NewDInt(d))
 }
 
 // NewDIntVectorFromDArray is a helper routine to create a *DIntVector

--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -2023,6 +2023,14 @@ func NewDOid(d DInt) Datum {
 	return &DOid{DInt: d, kind: oidColTypeOid, name: ""}
 }
 
+// AsRegProc changes the input DOid into a regproc with the given name and
+// returns it.
+func (d *DOid) AsRegProc(name string) *DOid {
+	d.name = name
+	d.kind = oidColTypeRegProc
+	return d
+}
+
 // AmbiguousFormat implements the Datum interface.
 func (*DOid) AmbiguousFormat() bool { return true }
 

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -1097,6 +1097,13 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 				return DBool(c == 0), err
 			},
 		},
+		CmpOp{
+			LeftType:  TypeOid,
+			RightType: TypeOid,
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
+				return DBool(left.(*DOid).DInt == right.(*DOid).DInt), nil
+			},
+		},
 	},
 
 	LT: {
@@ -1978,7 +1985,7 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 			return ParseDBool(v.Contents)
 		}
 
-	case *IntColType, *OidColType:
+	case *IntColType:
 		var res *DInt
 		switch v := d.(type) {
 		case *DBool:
@@ -2024,10 +2031,8 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 			res = NewDInt(DInt(int64(*v)))
 		case *DInterval:
 			res = NewDInt(DInt(v.Nanos / 1000000000))
-		}
-
-		if _, ok := expr.Type.(*OidColType); ok {
-			return NewDOidFromDInt(res), nil
+		case *DOid:
+			res = &v.DInt
 		}
 		return res, nil
 
@@ -2138,6 +2143,8 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 				return nil, fmt.Errorf("invalid utf8: %q", string(*t))
 			}
 			s = string(*t)
+		case *DOid:
+			s = t.name
 		}
 		switch c := expr.Type.(type) {
 		case *StringColType:
@@ -2232,10 +2239,15 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 		case *DInterval:
 			return d, nil
 		}
-	case *OidPseudoType:
+	case *OidColType:
+		ret := &DOid{kind: typ}
 		switch v := d.(type) {
+		case *DOid:
+			ret.DInt = v.DInt
+			return ret, nil
 		case *DInt:
-			return NewDOidFromDInt(v), nil
+			ret.DInt = *v
+			return ret, nil
 		case *DString:
 			queryOid := func(s string, table_name string, col_name string, obj_name string) (Datum, error) {
 				results, err := ctx.Planner.QueryRow(
@@ -2249,7 +2261,8 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 				if results.Len() == 0 {
 					return nil, errors.Errorf("%s '%s' does not exist", obj_name, s)
 				}
-				return results[0], nil
+				ret.DInt = results[0].(*DOid).DInt
+				return ret, nil
 			}
 			s := string(*v)
 			// Trim whitespace and unwrap outer quotes if necessary.
@@ -2258,11 +2271,12 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 			if len(s) > 1 && s[0] == '"' && s[len(s)-1] == '"' {
 				s = s[1 : len(s)-1]
 			}
+			ret.name = s
 
 			switch typ {
-			case oidPseudoTypeRegClass:
+			case oidColTypeRegClass:
 				return queryOid(s, "pg_class", "relname", "relation")
-			case oidPseudoTypeRegProc:
+			case oidColTypeRegProc, oidColTypeRegProcedure:
 				// Trim procedure type parameters. Postgres only does this when the
 				// cast is ::regprocedure, but we're going to always do it.
 				// We additionally do not yet implement disambiguation based on type
@@ -2278,10 +2292,11 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 				if err != nil {
 					return nil, err
 				}
+				ret.name = funcDef.Name
 				return queryOid(funcDef.Name, "pg_proc", "proname", "function")
-			case oidPseudoTypeRegNamespace:
+			case oidColTypeRegNamespace:
 				return queryOid(s, "pg_namespace", "nspname", "namespace")
-			case oidPseudoTypeRegType:
+			case oidColTypeRegType:
 				return queryOid(s, "pg_type", "typname", "type")
 			}
 		}
@@ -2726,6 +2741,11 @@ func (t *DArray) Eval(_ *EvalContext) (Datum, error) {
 
 // Eval implements the TypedExpr interface.
 func (t *DTable) Eval(_ *EvalContext) (Datum, error) {
+	return t, nil
+}
+
+// Eval implements the TypedExpr interface.
+func (t *DOid) Eval(_ *EvalContext) (Datum, error) {
 	return t, nil
 }
 

--- a/pkg/sql/parser/expr.go
+++ b/pkg/sql/parser/expr.go
@@ -1070,17 +1070,18 @@ func (node *CastExpr) castType() Type {
 var (
 	boolCastTypes = []Type{TypeNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString, TypeCollatedString}
 	intCastTypes  = []Type{TypeNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString, TypeCollatedString,
-		TypeTimestamp, TypeTimestampTZ, TypeDate, TypeInterval}
+		TypeTimestamp, TypeTimestampTZ, TypeDate, TypeInterval, TypeOid}
 	floatCastTypes = []Type{TypeNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString, TypeCollatedString,
 		TypeTimestamp, TypeTimestampTZ, TypeDate, TypeInterval}
 	decimalCastTypes = []Type{TypeNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString, TypeCollatedString,
 		TypeTimestamp, TypeTimestampTZ, TypeDate, TypeInterval}
 	stringCastTypes = []Type{TypeNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString, TypeCollatedString,
-		TypeBytes, TypeTimestamp, TypeTimestampTZ, TypeInterval, TypeDate}
+		TypeBytes, TypeTimestamp, TypeTimestampTZ, TypeInterval, TypeDate, TypeOid}
 	bytesCastTypes     = []Type{TypeNull, TypeString, TypeCollatedString, TypeBytes}
 	dateCastTypes      = []Type{TypeNull, TypeString, TypeCollatedString, TypeDate, TypeTimestamp, TypeTimestampTZ, TypeInt}
 	timestampCastTypes = []Type{TypeNull, TypeString, TypeCollatedString, TypeDate, TypeTimestamp, TypeTimestampTZ, TypeInt}
 	intervalCastTypes  = []Type{TypeNull, TypeString, TypeCollatedString, TypeInt, TypeInterval}
+	oidCastTypes       = []Type{TypeNull, TypeString, TypeCollatedString, TypeInt, TypeOid}
 )
 
 // validCastTypes returns a set of types that can be cast into the provided type.
@@ -1104,6 +1105,8 @@ func validCastTypes(t Type) []Type {
 		return timestampCastTypes
 	case TypeInterval:
 		return intervalCastTypes
+	case TypeOid:
+		return oidCastTypes
 	default:
 		// TODO(eisen): currently dead -- there is no syntax yet for casting
 		// directly to collated string.
@@ -1210,6 +1213,7 @@ func (node *DTimestampTZ) String() string     { return AsString(node) }
 func (node *DTuple) String() string           { return AsString(node) }
 func (node *DArray) String() string           { return AsString(node) }
 func (node *DTable) String() string           { return AsString(node) }
+func (node *DOid) String() string             { return AsString(node) }
 func (node *DOidWrapper) String() string      { return AsString(node) }
 func (node *ExistsExpr) String() string       { return AsString(node) }
 func (node Exprs) String() string             { return AsString(node) }

--- a/pkg/sql/parser/sql.go
+++ b/pkg/sql/parser/sql.go
@@ -8615,31 +8615,31 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:3434
 		{
-			sqlVAL.union.val = oidPseudoTypeRegProc
+			sqlVAL.union.val = oidColTypeRegProc
 		}
 	case 550:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:3438
 		{
-			sqlVAL.union.val = oidPseudoTypeRegProc
+			sqlVAL.union.val = oidColTypeRegProcedure
 		}
 	case 551:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:3442
 		{
-			sqlVAL.union.val = oidPseudoTypeRegClass
+			sqlVAL.union.val = oidColTypeRegClass
 		}
 	case 552:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:3446
 		{
-			sqlVAL.union.val = oidPseudoTypeRegType
+			sqlVAL.union.val = oidColTypeRegType
 		}
 	case 553:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:3450
 		{
-			sqlVAL.union.val = oidPseudoTypeRegNamespace
+			sqlVAL.union.val = oidColTypeRegNamespace
 		}
 	case 554:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3438,23 +3438,23 @@ numeric:
 postgres_oid:
   REGPROC
   {
-    $$.val = oidPseudoTypeRegProc
+    $$.val = oidColTypeRegProc
   }
 | REGPROCEDURE
   {
-    $$.val = oidPseudoTypeRegProc
+    $$.val = oidColTypeRegProcedure
   }
 | REGCLASS
   {
-    $$.val = oidPseudoTypeRegClass
+    $$.val = oidColTypeRegClass
   }
 | REGTYPE
   {
-    $$.val = oidPseudoTypeRegType
+    $$.val = oidColTypeRegType
   }
 | REGNAMESPACE
   {
-    $$.val = oidPseudoTypeRegNamespace
+    $$.val = oidColTypeRegNamespace
   }
 
 opt_float:

--- a/pkg/sql/parser/type.go
+++ b/pkg/sql/parser/type.go
@@ -107,10 +107,9 @@ var (
 	TypeAnyArray Type = TArray{TypeAny}
 	// TypeAny can be any type. Can be compared with ==.
 	TypeAny Type = tAny{}
+	// TypeOid is the type of an OID. Can be compared with ==.
+	TypeOid = tOid{oid.T_oid, "oid"}
 
-	// TypeOid is a type-alias for TypeInt with a different OID. Can be
-	// compared with ==.
-	TypeOid = wrapTypeWithOid(TypeInt, oid.T_oid)
 	// TypeName is a type-alias for TypeString with a different OID. Can be
 	// compared with ==.
 	TypeName = wrapTypeWithOid(TypeString, oid.T_name)
@@ -133,44 +132,53 @@ var (
 		TypeTimestamp,
 		TypeTimestampTZ,
 		TypeInterval,
+		TypeOid,
 	}
 )
 
 var (
 	// Unexported wrapper types. These exist for Postgres type compatibility.
-	typeInt2      = wrapTypeWithOid(TypeInt, oid.T_int2)
-	typeInt4      = wrapTypeWithOid(TypeInt, oid.T_int4)
-	typeFloat4    = wrapTypeWithOid(TypeFloat, oid.T_float4)
-	typeVarChar   = wrapTypeWithOid(TypeString, oid.T_varchar)
-	typeInt2Array = TArray{typeInt2}
-	typeInt4Array = TArray{typeInt4}
+	typeInt2         = wrapTypeWithOid(TypeInt, oid.T_int2)
+	typeInt4         = wrapTypeWithOid(TypeInt, oid.T_int4)
+	typeFloat4       = wrapTypeWithOid(TypeFloat, oid.T_float4)
+	typeVarChar      = wrapTypeWithOid(TypeString, oid.T_varchar)
+	typeInt2Array    = TArray{typeInt2}
+	typeInt4Array    = TArray{typeInt4}
+	typeRegClass     = tOid{oid.T_regclass, "regclass"}
+	typeRegProc      = tOid{oid.T_regproc, "regproc"}
+	typeRegProcedure = tOid{oid.T_regprocedure, "regprocedure"}
+	typeRegType      = tOid{oid.T_regtype, "regtype"}
 )
 
 // OidToType maps Postgres object IDs to CockroachDB types.
 var OidToType = map[oid.Oid]Type{
-	oid.T_anyelement:  TypeAny,
-	oid.T_bool:        TypeBool,
-	oid.T_bytea:       TypeBytes,
-	oid.T_date:        TypeDate,
-	oid.T_float4:      typeFloat4,
-	oid.T_float8:      TypeFloat,
-	oid.T_int2:        typeInt2,
-	oid.T_int4:        typeInt4,
-	oid.T_int8:        TypeInt,
-	oid.T_int2vector:  TypeIntVector,
-	oid.T_interval:    TypeInterval,
-	oid.T_name:        TypeName,
-	oid.T_numeric:     TypeDecimal,
-	oid.T_oid:         TypeOid,
-	oid.T_text:        TypeString,
-	oid.T__text:       TypeStringArray,
-	oid.T__int2:       typeInt2Array,
-	oid.T__int4:       typeInt4Array,
-	oid.T__int8:       TypeIntArray,
-	oid.T_record:      TypeTuple,
-	oid.T_timestamp:   TypeTimestamp,
-	oid.T_timestamptz: TypeTimestampTZ,
-	oid.T_varchar:     typeVarChar,
+	oid.T_anyelement:   TypeAny,
+	oid.T_bool:         TypeBool,
+	oid.T_bytea:        TypeBytes,
+	oid.T_date:         TypeDate,
+	oid.T_float4:       typeFloat4,
+	oid.T_float8:       TypeFloat,
+	oid.T_int2:         typeInt2,
+	oid.T_int4:         typeInt4,
+	oid.T_int8:         TypeInt,
+	oid.T_int2vector:   TypeIntVector,
+	oid.T_interval:     TypeInterval,
+	oid.T_name:         TypeName,
+	oid.T_numeric:      TypeDecimal,
+	oid.T_oid:          TypeOid,
+	oid.T_regproc:      typeRegProc,
+	oid.T_regprocedure: typeRegProcedure,
+	oid.T_regclass:     typeRegClass,
+	oid.T_regtype:      typeRegType,
+	oid.T__text:        TypeStringArray,
+	oid.T__int2:        typeInt2Array,
+	oid.T__int4:        typeInt4Array,
+	oid.T__int8:        TypeIntArray,
+	oid.T_record:       TypeTuple,
+	oid.T_text:         TypeString,
+	oid.T_timestamp:    TypeTimestamp,
+	oid.T_timestamptz:  TypeTimestampTZ,
+	oid.T_varchar:      typeVarChar,
 }
 
 // Do not instantiate the tXxx types elsewhere. The variables above are intended
@@ -542,6 +550,19 @@ func (tAny) Oid() oid.Oid                { return oid.T_anyelement }
 func (tAny) SQLName() string             { return "anyelement" }
 func (tAny) IsAmbiguous() bool           { return true }
 
+type tOid struct {
+	oidType  oid.Oid
+	typeName string
+}
+
+func (t tOid) String() string            { return t.typeName }
+func (tOid) Equivalent(other Type) bool  { return UnwrapType(other) == TypeOid || other == TypeAny }
+func (tOid) FamilyEqual(other Type) bool { return other == TypeOid }
+func (tOid) Size() (uintptr, bool)       { return unsafe.Sizeof(DInt(0)), fixedSize }
+func (t tOid) Oid() oid.Oid              { return t.oidType }
+func (t tOid) SQLName() string           { return t.typeName }
+func (tOid) IsAmbiguous() bool           { return true }
+
 // tOidWrapper is a Type implementation which is a wrapper around a Type, allowing
 // custom Oid values to be attached to the Type. The Type is used by DOidWrapper
 // to permit type aliasing with custom Oids without needing to create new typing
@@ -552,7 +573,6 @@ type tOidWrapper struct {
 }
 
 var customOidNames = map[oid.Oid]string{
-	oid.T_oid:  "oid",
 	oid.T_name: "name",
 }
 

--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -792,6 +792,10 @@ func (d *DTable) TypeCheck(_ *SemaContext, _ Type) (TypedExpr, error) { return d
 
 // TypeCheck implements the Expr interface. It is implemented as an idempotent
 // identity function for Datum.
+func (d *DOid) TypeCheck(_ *SemaContext, _ Type) (TypedExpr, error) { return d, nil }
+
+// TypeCheck implements the Expr interface. It is implemented as an idempotent
+// identity function for Datum.
 func (d *DOidWrapper) TypeCheck(_ *SemaContext, _ Type) (TypedExpr, error) { return d, nil }
 
 // TypeCheck implements the Expr interface. It is implemented as an idempotent

--- a/pkg/sql/parser/walk.go
+++ b/pkg/sql/parser/walk.go
@@ -547,6 +547,9 @@ func (expr *DArray) Walk(_ Visitor) Expr { return expr }
 func (expr *DTable) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
+func (expr *DOid) Walk(_ Visitor) Expr { return expr }
+
+// Walk implements the Expr interface.
 func (expr *DOidWrapper) Walk(_ Visitor) Expr { return expr }
 
 // WalkExpr traverses the nodes in an expression.

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1394,7 +1394,8 @@ var (
 	typDelim = parser.NewDString(",")
 
 	arrayInProcName = "array_in"
-	arrayInProcOid  = makeOidHasher().BuiltinOid(arrayInProcName, &parser.Builtins[arrayInProcName][0])
+	arrayInProcOid  = makeOidHasher().BuiltinOid(
+		arrayInProcName, &parser.Builtins[arrayInProcName][0]).(*parser.DOid).AsRegProc(arrayInProcName)
 )
 
 // See: https://www.postgresql.org/docs/9.6/static/catalog-pg-type.html.

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -157,7 +157,7 @@ CREATE TABLE pg_catalog.pg_attribute (
 	attisdropped BOOL,
 	attislocal BOOL,
 	attinhcount INT,
-	attcollation INT,
+	attcollation OID,
 	attacl STRING,
 	attoptions STRING,
 	attfdwoptions STRING
@@ -1561,6 +1561,7 @@ var datumToTypeCategory = map[reflect.Type]*parser.DString{
 	reflect.TypeOf(parser.TypeTimestampTZ): typCategoryDateTime,
 	reflect.TypeOf(parser.TypeTuple):       typCategoryPseudo,
 	reflect.TypeOf(parser.TypeTable):       typCategoryPseudo,
+	reflect.TypeOf(parser.TypeOid):         typCategoryNumeric,
 }
 
 func typCategory(typ parser.Type) parser.Datum {

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -200,6 +200,10 @@ func (b *writeBuffer) writeTextDatum(d parser.Datum, sessionLoc *time.Location) 
 			b.variablePutbuf.WriteString("}")
 			b.writeLengthPrefixedVariablePutbuf()
 		}
+	case *parser.DOid:
+		b.writeLengthPrefixedDatum(v)
+	default:
+		b.setError(errors.Errorf("unsupported type %T", d))
 	}
 }
 
@@ -337,6 +341,9 @@ func (b *writeBuffer) writeBinaryDatum(d parser.Datum, sessionLoc *time.Location
 		}
 		b.variablePutbuf = subWriter.wrapped
 		b.writeLengthPrefixedVariablePutbuf()
+	case *parser.DOid:
+		b.putInt32(4)
+		b.putInt32(int32(v.DInt))
 	default:
 		b.setError(errors.Errorf("unsupported type %T", d))
 	}

--- a/pkg/sql/testdata/alias_types
+++ b/pkg/sql/testdata/alias_types
@@ -21,7 +21,7 @@ statement ok
 INSERT INTO aliases VALUES (100, 'abc')
 
 statement ok
-INSERT INTO aliases VALUES (2::OID, 'def')
+INSERT INTO aliases VALUES (2, 'def')
 
 statement ok
 INSERT INTO aliases VALUES ('bool'::REGTYPE, ('ghi':::STRING)::NAME)
@@ -38,23 +38,23 @@ SELECT pg_typeof(a), pg_typeof(b) FROM aliases LIMIT 1
 ----
 oid  name
 
-query IT
-SELECT a+1, b || 'cat' FROM aliases ORDER BY a
+query T
+SELECT b || 'cat' FROM aliases ORDER BY a
 ----
-3    defcat
-17   ghicat
-101  abccat
+defcat
+ghicat
+abccat
 
-query TT
-SELECT to_hex(a), reverse(b) FROM aliases ORDER BY a
+query T
+SELECT reverse(b) FROM aliases ORDER BY a
 ----
-2   fed
-10  ihg
-64  cba
+fed
+ihg
+cba
 
-query RI
-SELECT sqrt(a::DECIMAL), length(b::BYTES) FROM aliases ORDER BY a
+query I
+SELECT length(b::BYTES) FROM aliases ORDER BY a
 ----
-1.414213562373095   3
-4   3
-10  3
+3
+3
+3

--- a/pkg/sql/testdata/builtin_function
+++ b/pkg/sql/testdata/builtin_function
@@ -1441,11 +1441,14 @@ CREATE INDEX pg_indexdef_idx ON test.pg_indexdef_test (a ASC)
 query error pq: unknown signature: pg_get_indexdef\(int, int, bool\)
 SELECT pg_catalog.pg_get_indexdef(0, 0, true)
 
-# This function always returns NULL since we don't support column comments.
-query T
-SELECT col_description('pg_class'::regclass::oid, 2)
+# These functions always return NULL since we don't support comments.
+query TTTT
+SELECT col_description('pg_class'::regclass::oid, 2),
+       obj_description('pg_class'::regclass::oid, 'pg_class'),
+       obj_description('pg_class'::regclass::oid),
+       shobj_description('pg_class'::regclass::oid, 'pg_class')
 ----
-NULL
+NULL  NULL  NULL  NULL
 
 query error pq: array_in\(\): unimplemented
 SELECT array_in('foo', 3, -1)

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -728,17 +728,17 @@ oid   typname      typinput    typoutput  typreceive  typsend  typmodin  typmodo
 19    name         0           0          0           0        0         0          0
 20    int8         0           0          0           0        0         0          0
 21    int2         0           0          0           0        0         0          0
-22    int2vector   4288767817  0          0           0        0         0          0
+22    int2vector   array_in    0          0           0        0         0          0
 23    int4         0           0          0           0        0         0          0
 24    regproc      0           0          0           0        0         0          0
 25    text         0           0          0           0        0         0          0
 26    oid          0           0          0           0        0         0          0
 700   float4       0           0          0           0        0         0          0
 701   float8       0           0          0           0        0         0          0
-1005  int2[]       4288767817  0          0           0        0         0          0
-1007  int4[]       4288767817  0          0           0        0         0          0
-1009  text[]       4288767817  0          0           0        0         0          0
-1016  int8[]       4288767817  0          0           0        0         0          0
+1005  int2[]       array_in    0          0           0        0         0          0
+1007  int4[]       array_in    0          0           0        0         0          0
+1009  text[]       array_in    0          0           0        0         0          0
+1016  int8[]       array_in    0          0           0        0         0          0
 1043  varchar      0           0          0           0        0         0          0
 1082  date         0           0          0           0        0         0          0
 1114  timestamp    0           0          0           0        0         0          0
@@ -1084,3 +1084,13 @@ query I
 SELECT COUNT(*) FROM pg_catalog.pg_depend
 ----
 2
+
+## #13567
+## regproc columns display as text but can still be joined against oid columns
+query OTO
+SELECT p.oid, p.proname, t.typinput
+FROM pg_proc p
+JOIN pg_type t ON t.typinput = p.oid
+WHERE t.typname = 'int4[]'
+----
+4288767817  array_in  array_in

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -371,7 +371,7 @@ v1            c        false         true        0            NULL    NULL      
 
 
 # Select all columns with collations.
-query TTTIT colnames
+query TTTOT colnames
 SELECT c.relname, attname, t.typname, attcollation, k.collname
 FROM pg_catalog.pg_attribute a
 JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
@@ -662,6 +662,7 @@ oid   typname      typnamespace  typowner  typlen  typbyval  typtype
 21    int2         1782195457    NULL      8       true      b
 22    int2vector   1782195457    NULL      -1      false     b
 23    int4         1782195457    NULL      8       true      b
+24    regproc      1782195457    NULL      8       true      b
 25    text         1782195457    NULL      -1      false     b
 26    oid          1782195457    NULL      8       true      b
 700   float4       1782195457    NULL      8       true      b
@@ -676,6 +677,9 @@ oid   typname      typnamespace  typowner  typlen  typbyval  typtype
 1184  timestamptz  1782195457    NULL      24      true      b
 1186  interval     1782195457    NULL      24      true      b
 1700  numeric      1782195457    NULL      -1      false     b
+2202  regprocedure 1782195457    NULL      8       true      b
+2205  regclass     1782195457    NULL      8       true      b
+2206  regtype      1782195457    NULL      8       true      b
 2249  tuple        1782195457    NULL      0       true      b
 2283  anyelement   1782195457    NULL      -1      false     b
 
@@ -692,6 +696,7 @@ oid   typname      typcategory  typispreferred  typisdefined  typdelim  typrelid
 21    int2         N            false           true          ,         0         0        0
 22    int2vector   A            false           true          ,         0         20       0
 23    int4         N            false           true          ,         0         0        0
+24    regproc      N            false           true          ,         0         0        0
 25    text         S            false           true          ,         0         0        0
 26    oid          N            false           true          ,         0         0        0
 700   float4       N            false           true          ,         0         0        0
@@ -706,6 +711,9 @@ oid   typname      typcategory  typispreferred  typisdefined  typdelim  typrelid
 1184  timestamptz  D            false           true          ,         0         0        0
 1186  interval     T            false           true          ,         0         0        0
 1700  numeric      N            false           true          ,         0         0        0
+2202  regprocedure N            false           true          ,         0         0        0
+2205  regclass     N            false           true          ,         0         0        0
+2206  regtype      N            false           true          ,         0         0        0
 2249  tuple        P            false           true          ,         0         0        0
 2283  anyelement   P            false           true          ,         0         0        0
 
@@ -722,6 +730,7 @@ oid   typname      typinput    typoutput  typreceive  typsend  typmodin  typmodo
 21    int2         0           0          0           0        0         0          0
 22    int2vector   4288767817  0          0           0        0         0          0
 23    int4         0           0          0           0        0         0          0
+24    regproc      0           0          0           0        0         0          0
 25    text         0           0          0           0        0         0          0
 26    oid          0           0          0           0        0         0          0
 700   float4       0           0          0           0        0         0          0
@@ -736,6 +745,9 @@ oid   typname      typinput    typoutput  typreceive  typsend  typmodin  typmodo
 1184  timestamptz  0           0          0           0        0         0          0
 1186  interval     0           0          0           0        0         0          0
 1700  numeric      0           0          0           0        0         0          0
+2202  regprocedure 0           0          0           0        0         0          0
+2205  regclass     0           0          0           0        0         0          0
+2206  regtype      0           0          0           0        0         0          0
 2249  tuple        0           0          0           0        0         0          0
 2283  anyelement   0           0          0           0        0         0          0
 
@@ -752,6 +764,7 @@ oid   typname      typalign  typstorage  typnotnull  typbasetype  typtypmod
 21    int2         NULL      NULL        false       0            -1
 22    int2vector   NULL      NULL        false       0            -1
 23    int4         NULL      NULL        false       0            -1
+24    regproc      NULL      NULL        false       0            -1
 25    text         NULL      NULL        false       0            -1
 26    oid          NULL      NULL        false       0            -1
 700   float4       NULL      NULL        false       0            -1
@@ -766,6 +779,9 @@ oid   typname      typalign  typstorage  typnotnull  typbasetype  typtypmod
 1184  timestamptz  NULL      NULL        false       0            -1
 1186  interval     NULL      NULL        false       0            -1
 1700  numeric      NULL      NULL        false       0            -1
+2202  regprocedure NULL      NULL        false       0            -1
+2205  regclass     NULL      NULL        false       0            -1
+2206  regtype      NULL      NULL        false       0            -1
 2249  tuple        NULL      NULL        false       0            -1
 2283  anyelement   NULL      NULL        false       0            -1
 
@@ -782,6 +798,7 @@ oid   typname      typndims  typcollation  typdefaultbin  typdefault  typacl
 21    int2         0         0             NULL           NULL        NULL
 22    int2vector   0         0             NULL           NULL        NULL
 23    int4         0         0             NULL           NULL        NULL
+24    regproc      0         0             NULL           NULL        NULL
 25    text         0         1661428263    NULL           NULL        NULL
 26    oid          0         0             NULL           NULL        NULL
 700   float4       0         0             NULL           NULL        NULL
@@ -796,6 +813,9 @@ oid   typname      typndims  typcollation  typdefaultbin  typdefault  typacl
 1184  timestamptz  0         0             NULL           NULL        NULL
 1186  interval     0         0             NULL           NULL        NULL
 1700  numeric      0         0             NULL           NULL        NULL
+2202  regprocedure 0         0             NULL           NULL        NULL
+2205  regclass     0         0             NULL           NULL        NULL
+2206  regtype      0         0             NULL           NULL        NULL
 2249  tuple        0         0             NULL           NULL        NULL
 2283  anyelement   0         0             NULL           NULL        NULL
 
@@ -960,10 +980,10 @@ transaction priority           NULL    NULL     NULL     NULL        NULL
 
 # Verify proper functionality of system information functions.
 
-query T
-SELECT pg_catalog.pg_get_expr('1', 0)
+query TT
+SELECT pg_catalog.pg_get_expr('1', 0), pg_catalog.pg_get_expr('1', 0::OID)
 ----
-1
+1  1
 
 query T
 SELECT pg_catalog.pg_get_expr('1', 0, true)

--- a/pkg/sql/testdata/pgoidtype
+++ b/pkg/sql/testdata/pgoidtype
@@ -4,29 +4,44 @@ SELECT 3::OID
 3
 
 query O
+SELECT 3::OID::INT::OID
+----
+3
+
+query T
+SELECT pg_typeof(1:::OID)
+----
+oid
+
+query O
 SELECT 'pg_constraint'::REGCLASS
 ----
-402060402
+pg_constraint
 
 query OO
 SELECT '"pg_constraint"'::REGCLASS, '  "pg_constraint" '::REGCLASS
 ----
-402060402  402060402
+pg_constraint  pg_constraint
 
 query OO
 SELECT 'pg_constraint '::REGCLASS, '  pg_constraint '::REGCLASS
 ----
-402060402  402060402
+pg_constraint  pg_constraint
 
 query OO
-SELECT 'upper'::REGPROC, 'upper'::REGPROCEDURE
+SELECT 'pg_constraint '::REGCLASS, '"pg_constraint"'::REGCLASS::OID
 ----
-1736923753  1736923753
+pg_constraint  402060402
 
-query OO
-SELECT 'upper(int)'::REGPROC, 'upper(int)'::REGPROCEDURE
+query OOO
+SELECT 'upper'::REGPROC, 'upper'::REGPROCEDURE, 'upper'::REGPROC::OID
 ----
-1736923753  1736923753
+upper  upper  1736923753
+
+query OOO
+SELECT 'upper(int)'::REGPROC, 'upper(int)'::REGPROCEDURE, 'upper(int)'::REGPROC::OID
+----
+upper  upper  1736923753
 
 query error unknown function: blah\(\)
 SELECT 'blah(ignored, ignored)'::REGPROC, 'blah(ignored, ignored)'::REGPROCEDURE
@@ -49,22 +64,22 @@ SELECT 'sqrt'::REGPROC
 query OOOO
 SELECT 'array_in'::REGPROC, 'array_in(a,b,c)'::REGPROC, 'pg_catalog.array_in'::REGPROC, 'pg_catalog.array_in( a ,b, c )'::REGPROC
 ----
-4288767817  4288767817  4288767817  4288767817
+array_in  array_in  array_in  array_in
 
 query OOOO
 SELECT 'array_in'::REGPROCEDURE, 'array_in(a,b,c)'::REGPROCEDURE, 'pg_catalog.array_in'::REGPROCEDURE, 'pg_catalog.array_in( a ,b, c )'::REGPROCEDURE
 ----
-4288767817  4288767817  4288767817  4288767817
+array_in  array_in  array_in  array_in
 
-query O
-SELECT 'system'::REGNAMESPACE
+query OO
+SELECT 'system'::REGNAMESPACE, 'system'::REGNAMESPACE::OID
 ----
-2939540337
+system  2939540337
 
-query O
-SELECT 'bool'::REGTYPE
+query OO
+SELECT 'bool'::REGTYPE, 'bool'::REGTYPE::OID
 ----
-16
+bool  16
 
 query error relation 'blah' does not exist
 SELECT 'blah'::REGCLASS
@@ -86,13 +101,13 @@ SELECT 'blah'::REGTYPE
 query O
 SELECT CAST ('pg_constraint' AS REGCLASS)
 ----
-402060402
+pg_constraint
 
 # This forces the b_expr form of the cast syntax.
-query O
-SELECT ('pg_constraint')::REGCLASS
+query OO
+SELECT ('pg_constraint')::REGCLASS, ('pg_constraint')::REGCLASS::OID
 ----
-402060402
+pg_constraint  402060402
 
 ## Test visibility of pg_* via oid casts.
 


### PR DESCRIPTION
Previously, the Postgres OID type was represented as a `DOidTypeWrapper` around a `DInt`. This was a shortcut implementation that satisfied the basic requirements of OIDs and their cast behaviors, but was missing a critical piece: representation as either an integer, the underlying OID, or a string, the name of the entity that the OID represents.

The `OIDTypeWrapper` OID implementation is now removed. It's replaced by a fully-fledged OID datum, `DOid`, which carries the underlying OID integer, the type of the OID (`regproc`, `regclass`, `regtype`, etc), and the optional entity name that it is resolved to.

This opens the door to having OID columns in `pg_catalog` tables appear as strings when selected but still properly join against other OID columns.

The `typinput` field of `pg_type` is updated to take advantage of this new property, and now displays as a string.

Additionally, several builtins that used to accept integers now properly accept OIDs, and numeric constants are now resolvable to OIDs as they should be.

Updates #13567 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13896)
<!-- Reviewable:end -->
