### PR TITLE
allocsim: Use tc for fine-grained, correct injection of fake latency

### DIFF
--- a/pkg/cmd/allocsim/configs/multiple-nodes-per-locality-imbalanced-load.json
+++ b/pkg/cmd/allocsim/configs/multiple-nodes-per-locality-imbalanced-load.json
@@ -1,0 +1,49 @@
+{
+  "Localities": [
+    {
+      "Name": "1",
+      "NumNodes": 3,
+      "NumWorkers": 0,
+      "OutgoingLatencies": [
+        {
+          "Name": "2",
+          "Latency": "50ms"
+        },
+        {
+          "Name": "3",
+          "Latency": "50ms"
+        }
+      ]
+    },
+    {
+      "Name": "2",
+      "NumNodes": 3,
+      "NumWorkers": 32,
+      "OutgoingLatencies": [
+        {
+          "Name": "1",
+          "Latency": "50ms"
+        },
+        {
+          "Name": "3",
+          "Latency": "50ms"
+        }
+      ]
+    },
+    {
+      "Name": "3",
+      "NumNodes": 3,
+      "NumWorkers": 0,
+      "OutgoingLatencies": [
+        {
+          "Name": "1",
+          "Latency": "50ms"
+        },
+        {
+          "Name": "2",
+          "Latency": "50ms"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cmd/allocsim/configs/node-per-locality-uneven-latency-imbalanced-load.json
+++ b/pkg/cmd/allocsim/configs/node-per-locality-uneven-latency-imbalanced-load.json
@@ -1,0 +1,49 @@
+{
+  "Localities": [
+    {
+      "Name": "1",
+      "NumNodes": 1,
+      "NumWorkers": 0,
+      "OutgoingLatencies": [
+        {
+          "Name": "2",
+          "Latency": "30ms"
+        },
+        {
+          "Name": "3",
+          "Latency": "60ms"
+        }
+      ]
+    },
+    {
+      "Name": "2",
+      "NumNodes": 1,
+      "NumWorkers": 32,
+      "OutgoingLatencies": [
+        {
+          "Name": "1",
+          "Latency": "30ms"
+        },
+        {
+          "Name": "3",
+          "Latency": "60ms"
+        }
+      ]
+    },
+    {
+      "Name": "3",
+      "NumNodes": 1,
+      "NumWorkers": 0,
+      "OutgoingLatencies": [
+        {
+          "Name": "1",
+          "Latency": "60ms"
+        },
+        {
+          "Name": "2",
+          "Latency": "60ms"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cmd/allocsim/configs/node-per-locality-uneven-latency-imbalanced-load2.json
+++ b/pkg/cmd/allocsim/configs/node-per-locality-uneven-latency-imbalanced-load2.json
@@ -1,0 +1,49 @@
+{
+  "Localities": [
+    {
+      "Name": "1",
+      "NumNodes": 1,
+      "NumWorkers": 0,
+      "OutgoingLatencies": [
+        {
+          "Name": "2",
+          "Latency": "13"
+        },
+        {
+          "Name": "3",
+          "Latency": "220ms"
+        }
+      ]
+    },
+    {
+      "Name": "2",
+      "NumNodes": 1,
+      "NumWorkers": 32,
+      "OutgoingLatencies": [
+        {
+          "Name": "1",
+          "Latency": "13"
+        },
+        {
+          "Name": "3",
+          "Latency": "220ms"
+        }
+      ]
+    },
+    {
+      "Name": "3",
+      "NumNodes": 1,
+      "NumWorkers": 0,
+      "OutgoingLatencies": [
+        {
+          "Name": "1",
+          "Latency": "220ms"
+        },
+        {
+          "Name": "2",
+          "Latency": "220ms"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cmd/internal/localcluster/localcluster.go
+++ b/pkg/cmd/internal/localcluster/localcluster.go
@@ -74,23 +74,27 @@ func IsUnavailableError(err error) bool {
 // Cluster holds the state for a local cluster, providing methods for common
 // operations, access to the underlying nodes and per-node KV and SQL clients.
 type Cluster struct {
-	rpcCtx  *rpc.Context
-	Nodes   []*Node
-	Clients []*client.DB
-	Status  []serverpb.StatusClient
-	DB      []*gosql.DB
-	stopper *stop.Stopper
-	started time.Time
+	rpcCtx        *rpc.Context
+	Nodes         []*Node
+	Clients       []*client.DB
+	Status        []serverpb.StatusClient
+	DB            []*gosql.DB
+	separateAddrs bool
+	stopper       *stop.Stopper
+	started       time.Time
 }
 
 // New creates a cluster of size nodes.
-func New(size int) *Cluster {
+// separateAddrs controls whether all the nodes use the same localhost IP
+// address (127.0.0.1) or separate addresses (e.g. 127.1.1.1, 127.1.1.2, etc).
+func New(size int, separateAddrs bool) *Cluster {
 	return &Cluster{
-		Nodes:   make([]*Node, size),
-		Clients: make([]*client.DB, size),
-		Status:  make([]serverpb.StatusClient, size),
-		DB:      make([]*gosql.DB, size),
-		stopper: stop.NewStopper(),
+		Nodes:         make([]*Node, size),
+		Clients:       make([]*client.DB, size),
+		Status:        make([]serverpb.StatusClient, size),
+		DB:            make([]*gosql.DB, size),
+		separateAddrs: separateAddrs,
+		stopper:       stop.NewStopper(),
 	}
 }
 
@@ -100,7 +104,11 @@ func New(size int) *Cluster {
 // can be used to pass extra arguments to an individual node. If not nil, its
 // size must equal the number of nodes.
 func (c *Cluster) Start(
-	db string, numWorkers int, binary string, env, allNodeArgs []string, perNodeArgs map[int][]string,
+	db string,
+	numWorkers int,
+	binary string,
+	allNodeArgs []string,
+	perNodeArgs, perNodeEnv map[int][]string,
 ) {
 	c.started = timeutil.Now()
 
@@ -117,7 +125,7 @@ func (c *Cluster) Start(
 	}
 
 	for i := range c.Nodes {
-		c.Nodes[i] = c.makeNode(i, binary, append(append([]string(nil), allNodeArgs...), perNodeArgs[i]...), env)
+		c.Nodes[i] = c.makeNode(i, binary, append(append([]string(nil), allNodeArgs...), perNodeArgs[i]...), perNodeEnv[i])
 		c.Clients[i] = c.makeClient(i)
 		c.Status[i] = c.makeStatus(i)
 		c.DB[i] = c.makeDB(i, numWorkers, db)
@@ -135,14 +143,22 @@ func (c *Cluster) Close() {
 	c.stopper.Stop()
 }
 
-// RPCPort returns the RPC port of the specified node.
-func RPCPort(nodeIdx int) int {
-	return basePort + nodeIdx*2
+// IPAddr returns the IP address of the specified node.
+func (c *Cluster) IPAddr(nodeIdx int) string {
+	if c.separateAddrs {
+		return fmt.Sprintf("127.1.1.%d", nodeIdx+1)
+	}
+	return "127.0.0.1"
 }
 
 // RPCAddr returns the RPC address of the specified node.
-func RPCAddr(nodeIdx int) string {
-	return fmt.Sprintf("localhost:%d", RPCPort(nodeIdx))
+func (c *Cluster) RPCAddr(nodeIdx int) string {
+	return fmt.Sprintf("%s:%d", c.IPAddr(nodeIdx), RPCPort(nodeIdx))
+}
+
+// RPCPort returns the RPC port of the specified node.
+func RPCPort(nodeIdx int) int {
+	return basePort + nodeIdx*2
 }
 
 // HTTPPort returns the HTTP port of the specified node.
@@ -162,7 +178,7 @@ func (c *Cluster) makeNode(nodeIdx int, binary string, extraArgs, extraEnv []str
 		binary,
 		"start",
 		"--insecure",
-		"--host=localhost",
+		fmt.Sprintf("--host=%s", c.IPAddr(nodeIdx)),
 		fmt.Sprintf("--port=%d", RPCPort(nodeIdx)),
 		fmt.Sprintf("--http-port=%d", HTTPPort(nodeIdx)),
 		fmt.Sprintf("--store=%s", dir),
@@ -170,7 +186,7 @@ func (c *Cluster) makeNode(nodeIdx int, binary string, extraArgs, extraEnv []str
 		fmt.Sprintf("--logtostderr"),
 	}
 	if nodeIdx > 0 {
-		args = append(args, fmt.Sprintf("--join=localhost:%d", RPCPort(0)))
+		args = append(args, fmt.Sprintf("--join=%s", c.RPCAddr(0)))
 	}
 	args = append(args, extraArgs...)
 
@@ -184,7 +200,7 @@ func (c *Cluster) makeNode(nodeIdx int, binary string, extraArgs, extraEnv []str
 }
 
 func (c *Cluster) makeClient(nodeIdx int) *client.DB {
-	conn, err := c.rpcCtx.GRPCDial(RPCAddr(nodeIdx))
+	conn, err := c.rpcCtx.GRPCDial(c.RPCAddr(nodeIdx))
 	if err != nil {
 		log.Fatalf(context.Background(), "failed to initialize KV client: %s", err)
 	}
@@ -192,7 +208,7 @@ func (c *Cluster) makeClient(nodeIdx int) *client.DB {
 }
 
 func (c *Cluster) makeStatus(nodeIdx int) serverpb.StatusClient {
-	conn, err := c.rpcCtx.GRPCDial(RPCAddr(nodeIdx))
+	conn, err := c.rpcCtx.GRPCDial(c.RPCAddr(nodeIdx))
 	if err != nil {
 		log.Fatalf(context.Background(), "failed to initialize status client: %s", err)
 	}
@@ -200,8 +216,8 @@ func (c *Cluster) makeStatus(nodeIdx int) serverpb.StatusClient {
 }
 
 func (c *Cluster) makeDB(nodeIdx, numWorkers int, dbName string) *gosql.DB {
-	url := fmt.Sprintf("postgresql://root@localhost:%d/%s?sslmode=disable",
-		RPCPort(nodeIdx), dbName)
+	url := fmt.Sprintf("postgresql://root@%s/%s?sslmode=disable",
+		c.RPCAddr(nodeIdx), dbName)
 	conn, err := gosql.Open("postgres", url)
 	if err != nil {
 		log.Fatal(context.Background(), err)
@@ -328,7 +344,7 @@ func (c *Cluster) lookupRange(nodeIdx int, key roachpb.Key) (*roachpb.RangeDescr
 // Freeze freezes (or thaws) the cluster. The freeze request is sent to the
 // specified node.
 func (c *Cluster) Freeze(nodeIdx int, freeze bool) {
-	addr := RPCAddr(nodeIdx)
+	addr := c.RPCAddr(nodeIdx)
 	conn, err := c.rpcCtx.GRPCDial(addr)
 	if err != nil {
 		log.Fatalf(context.Background(), "unable to dial: %s: %v", addr, err)

--- a/pkg/cmd/internal/tc/tc.go
+++ b/pkg/cmd/internal/tc/tc.go
@@ -1,0 +1,117 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package tc contains utility methods for using the Linux tc (traffic control)
+// command to mess with the network links between cockroach nodes running on
+// the local machine.
+//
+// Requires passwordless sudo in order to run tc.
+//
+// Does not work on OS X due to the lack of the tc command (and even an
+// alternative wouldn't work for the current use case of this code, which also
+// requires being able to bind to multiple localhost addresses).
+package tc
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	rootHandle   = 1
+	defaultClass = 1
+)
+
+// Controller provides a way to add artificial latency to local traffic.
+type Controller struct {
+	interfaces []string
+	nextClass  int
+}
+
+// NewController creates and returns a controller that will modify the traffic
+// routing for the provided interfaces.
+func NewController(interfaces ...string) *Controller {
+	return &Controller{
+		interfaces: interfaces,
+		nextClass:  defaultClass + 1,
+	}
+}
+
+// Init prepares the local network interfaces so that we can later add per-node
+// traffic shaping rules.
+func (c *Controller) Init() error {
+	for _, ifce := range c.interfaces {
+		_, _ = exec.Command("sudo", strings.Split(fmt.Sprintf("tc qdisc del dev %s root", ifce), " ")...).Output()
+		out, err := exec.Command("sudo", strings.Split(fmt.Sprintf("tc qdisc add dev %s root handle %d: htb default %d",
+			ifce, rootHandle, defaultClass), " ")...).Output()
+		if err != nil {
+			return errors.Wrapf(err, "failed to create root tc qdisc for %q: %s", ifce, out)
+		}
+		// The 100mbit limitation is because classes of type htb (hierarchy token
+		// bucket) need a bandwidth limit, and we want an arbitrarily high one. Feel
+		// free to bump it up here and below if you think it's limiting you.
+		out, err = exec.Command("sudo", strings.Split(fmt.Sprintf("tc class add dev %s parent %d: classid %d:%d htb rate 100mbit",
+			ifce, rootHandle, rootHandle, defaultClass), " ")...).Output()
+		if err != nil {
+			return errors.Wrapf(err, "failed to create root tc class for %q: %s", ifce, out)
+		}
+	}
+	return nil
+}
+
+// AddLatency adds artificial latency between the specified source and dest
+// addresses.
+func (c *Controller) AddLatency(srcIP, dstIP string, latency time.Duration) error {
+	class := c.nextClass
+	handle := class * 10
+	c.nextClass++
+	for _, ifce := range c.interfaces {
+		out, err := exec.Command("sudo", strings.Split(fmt.Sprintf("tc class add dev %s parent %d: classid %d:%d htb rate 100mbit",
+			ifce, rootHandle, rootHandle, class), " ")...).Output()
+		if err != nil {
+			return errors.Wrapf(err, "failed to add tc class %d: %s", class, out)
+		}
+		out, err = exec.Command("sudo", strings.Split(fmt.Sprintf("tc qdisc add dev %s parent %d:%d handle %d: netem delay %v",
+			ifce, rootHandle, class, handle, latency), " ")...).Output()
+		if err != nil {
+			return errors.Wrapf(err, "failed to add tc netem delay of %v: %s", latency, out)
+		}
+		out, err = exec.Command("sudo", strings.Split(fmt.Sprintf("tc filter add dev %s parent %d: protocol ip u32 match ip src %s/32 match ip dst %s/32 flowid %d:%d",
+			ifce, rootHandle, srcIP, dstIP, rootHandle, class), " ")...).Output()
+		if err != nil {
+			return errors.Wrapf(err, "failed to add tc filter rule between %s and %s: %s", srcIP, dstIP, out)
+		}
+	}
+	return nil
+}
+
+// CleanUp resets all interfaces back to their default tc policies.
+func (c *Controller) CleanUp() error {
+	var errs []string
+	for _, ifce := range c.interfaces {
+		out, err := exec.Command("sudo", strings.Split(fmt.Sprintf("tc qdisc del dev %s root", ifce), " ")...).Output()
+		if err != nil {
+			errs = append(errs, errors.Wrapf(
+				err, "failed to remove tc rules for %q -- you may have to remove them manually: %s", ifce, out).Error())
+		}
+	}
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "; "))
+	}
+	return nil
+}

--- a/pkg/cmd/zerosum/main.go
+++ b/pkg/cmd/zerosum/main.go
@@ -436,7 +436,7 @@ func (z *zeroSum) monitor(d time.Duration) {
 func main() {
 	flag.Parse()
 
-	c := localcluster.New(*numNodes)
+	c := localcluster.New(*numNodes, false /* separateAddrs */)
 	defer c.Close()
 
 	log.SetExitFunc(func(code int) {
@@ -454,7 +454,7 @@ func main() {
 		os.Exit(1)
 	}()
 
-	c.Start("zerosum", *workers, localcluster.CockroachBin, nil, flag.Args(), nil)
+	c.Start("zerosum", *workers, localcluster.CockroachBin, flag.Args(), nil, nil)
 
 	z := newZeroSum(c, *numAccounts, *chaosType)
 	z.run(*workers, *monkeys)


### PR DESCRIPTION
Rip out the outgoing-connection based logic that we couldn't get working
properly. On the good ol' 50ms between nodes setup with all 32 workers
hitting node 2, the code from #13797 does the following on an azworker:

```
_elapsed__ops/sec__average__latency___errors_replicas_______________1:1_______________2:2_______________3:3
    1m0s    493.9    370.1   86.4ms        0      117           39/8/14           39/25/2            39/2/2
    2m0s    486.8    427.3   74.9ms        0      213          71/10/22           71/48/7            71/9/5
    3m0s    470.9    442.5   72.3ms        0      399         133/22/25         133/87/17          133/20/7
    4m0s    471.9    449.4   71.2ms        0      408         136/20/32         136/91/23          136/21/9
    5m0s    461.9    452.5   70.7ms        0      672         224/34/34        224/145/34          224/38/9
    6m0s    465.9    452.5   70.7ms        0      786         262/41/44        262/174/42         262/44/13
```

A more extreme algorithm gets the latency down to the low 50s of
milliseconds per operation.

Also, add a couple additional allocsim workload configs that rely on the new tc mode to work properly.

If you guys are fine with me basically giving up on the previous approach, I'll follow up with a tweak to allow for running the previous uniform latency workloads on MacOS.

@petermattis @bdarnell 

Initial run of the new `uneven-latency` config:

```
_elapsed__ops/sec__average__latency___errors_replicas_______________1:1_______________2:2_______________3:3

    1m0s    736.8    571.2   56.0ms        0      177          59/12/21           59/32/0            59/1/0
    2m0s    610.7    610.6   52.4ms        0      399         133/22/26          133/85/7          133/18/0
    3m0s    599.9    609.8   52.5ms        0      420         140/25/29         140/88/17          140/21/8
    4m0s    633.9    610.8   52.4ms        0      771         257/45/29        257/169/28         257/37/16
    5m0s    605.9    608.3   52.6ms        0      795         265/47/31        265/176/41         265/38/29
```

Initial run of the new `multiple-nodes-per-locality` config:

```
_elapsed__ops/sec__average__latency___errors_replicas_______________1:1_______________2:1_______________3:1_______________4:2_______________5:2_______________6:2_______________7:3_______________8:3_______________9:3
    1m0s    465.9    377.9   84.6ms        0      120           13/3/19            13/4/5            14/4/4            13/5/7            13/5/5            14/7/6            13/4/4            14/2/6            13/5/0
    2m0s    519.8    430.5   74.3ms        0      220           25/4/26           24/4/10            23/5/9          24/15/12          25/14/11          25/16/10            24/5/8           25/5/11            25/5/5
    3m0s    475.9    445.4   71.8ms        0      414           46/8/34           46/9/14           44/7/18          48/29/21          48/30/23          45/28/16          45/10/17           46/8/21            46/7/9
    4m0s    496.9    458.0   69.8ms        0      417           46/7/37           46/8/16           45/8/19          48/31/24          49/32/26          45/30/19           46/8/23           46/7/25            46/8/9
    5m0s    448.9    459.7   69.6ms        0      717          78/15/44          78/16/20          78/16/21          79/47/35          81/46/39          84/49/29          81/14/28          81/15/32          77/17/10
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13902)
<!-- Reviewable:end -->
