### PR TITLE
sql: release table name as soon as it is no longer referenced

### DIFF
--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -965,19 +965,45 @@ func (p *planner) dropViewImpl(
 // can even eliminate the need to use a transaction for each chunk at a later
 // stage if it proves inefficient).
 func truncateAndDropTable(
-	ctx context.Context, tableDesc *sqlbase.TableDescriptor, db *client.DB,
+	ctx context.Context,
+	tableDesc *sqlbase.TableDescriptor,
+	db *client.DB,
+	testingKnobs SchemaChangerTestingKnobs,
 ) error {
+	zoneKey, nameKey, descKey := GetKeysForTableDescriptor(tableDesc)
+	// The table name is no longer in use across the entire cluster.
+	// Delete the namekey so that it can be used by another table.
+	// We do this before truncating the table because the table truncation
+	// takes too much time.
+	if err := db.Txn(ctx, func(txn *client.Txn) error {
+		b := &client.Batch{}
+		// Use CPut because we want to remove a specific name -> id map.
+		b.CPut(nameKey, nil, tableDesc.ID)
+		txn.SetSystemConfigTrigger()
+		err := txn.Run(b)
+		if _, ok := err.(*roachpb.ConditionFailedError); ok {
+			return nil
+		}
+		return err
+	}); err != nil {
+		return err
+	}
+
+	if cb := testingKnobs.RunAfterTableNameDropped; cb != nil {
+		if err := cb(); err != nil {
+			return err
+		}
+	}
+
 	if err := truncateTableInChunks(ctx, tableDesc, db); err != nil {
 		return err
 	}
 
 	// Finished deleting all the table data, now delete the table meta data.
 	return db.Txn(ctx, func(txn *client.Txn) error {
-		zoneKey, nameKey, descKey := GetKeysForTableDescriptor(tableDesc)
 		// Delete table descriptor
 		b := &client.Batch{}
 		b.Del(descKey)
-		b.Del(nameKey)
 		// Delete the zone config entry for this table.
 		b.Del(zoneKey)
 		txn.SetSystemConfigTrigger()

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -72,7 +72,7 @@ func (sc *SchemaChanger) truncateAndDropTable(
 	if err := sc.ExtendLease(lease); err != nil {
 		return err
 	}
-	return truncateAndDropTable(ctx, tableDesc, &sc.db)
+	return truncateAndDropTable(ctx, tableDesc, &sc.db, *sc.testingKnobs)
 }
 
 // NewSchemaChangerForTesting only for tests.
@@ -664,6 +664,11 @@ type SchemaChangerTestingKnobs struct {
 
 	// BackfillChunkSize is to be used for all backfill chunked operations.
 	BackfillChunkSize int64
+
+	// RunAfterTableNameDropped is called when a table is being dropped.
+	// It is called as soon as the table name is released and before the
+	// table is truncated.
+	RunAfterTableNameDropped func() error
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
When dropping a table, the table name would be released only after
the table was truncated. Table truncation can take a long time and
it doesn't make for a good user experience when a user expects a
name for a dropped table to be available almost immediately.

fixes #7348

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13908)
<!-- Reviewable:end -->
