### PR TITLE
server: range page - fix two minor issues with epoch based leases

### DIFF
--- a/pkg/server/debug_range.go
+++ b/pkg/server/debug_range.go
@@ -69,7 +69,7 @@ const (
 
 	debugRangeValueLeaseNone       = "Unknown"
 	debugRangeValueLeaseExpiration = "Expiration"
-	debugRangeValueLeaseEpoch      = "LeaseEpoch"
+	debugRangeValueLeaseEpoch      = "Epoch"
 )
 
 // Returns an HTML page displaying information about all node's view of a
@@ -517,7 +517,8 @@ func (d *debugRangeData) postProcessing() {
 					d.Results[debugRangeHeaderLeaseType][d.HeaderFakeStoreID].Class = debugRangeClassWarning
 					d.Results[debugRangeHeaderLeaseType][info.SourceStoreID].Class = debugRangeClassWarning
 				}
-				if leaderStoreInfo.State.Lease.Epoch != info.State.Lease.Epoch {
+				if d.Results[debugRangeHeaderLeaseEpoch][leaderStoreInfo.SourceStoreID].Value !=
+					d.Results[debugRangeHeaderLeaseEpoch][info.SourceStoreID].Value {
 					d.Results[debugRangeHeaderLeaseEpoch][d.HeaderFakeStoreID].Class = debugRangeClassWarning
 					d.Results[debugRangeHeaderLeaseEpoch][info.SourceStoreID].Class = debugRangeClassWarning
 				}


### PR DESCRIPTION
1 - Display "Epoch" instead of "LeaseEpoch", to match "Expiration".  Lease is redundant here since it's in the row for "Lease Type".
2 - When comparing values for the lease epochs, compare the values not the pointers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13909)
<!-- Reviewable:end -->
