### PR TITLE
[TEST DONOTMERGE] sql: make CTAS command tag same as postgres.

### DIFF
--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -309,7 +309,7 @@ func sqlRowsToStrings(rows *sqlRows, showMoreChars bool) ([]string, [][]string, 
 	switch tag {
 	case "":
 		tag = "OK"
-	case "DELETE", "INSERT", "UPDATE":
+	case "SELECT", "DELETE", "INSERT", "UPDATE":
 		if n, err := result.RowsAffected(); err == nil {
 			tag = fmt.Sprintf("%s %d", tag, n)
 		}

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1318,6 +1318,10 @@ func (e *Executor) execClassic(planMaker *planner, plan planNode, result *Result
 		if err != nil {
 			return err
 		}
+	case parser.DDL:
+		if n, ok := plan.(*createTableNode); ok && n.n.As() {
+			result.RowsAffected += n.count
+		}
 	}
 	return nil
 }

--- a/pkg/sql/parser/stmt.go
+++ b/pkg/sql/parser/stmt.go
@@ -120,7 +120,12 @@ func (*CreateIndex) StatementTag() string { return "CREATE INDEX" }
 func (*CreateTable) StatementType() StatementType { return DDL }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*CreateTable) StatementTag() string { return "CREATE TABLE" }
+func (n *CreateTable) StatementTag() string {
+	if n.As() {
+		return "SELECT"
+	}
+	return "CREATE TABLE"
+}
 
 // StatementType implements the Statement interface.
 func (*CreateUser) StatementType() StatementType { return Ack }

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -982,6 +982,10 @@ func (c *v3Conn) sendResponse(
 			}
 
 		case parser.Ack, parser.DDL:
+			if result.PGTag == "SELECT" {
+				tag = append(tag, ' ')
+				tag = strconv.AppendInt(tag, int64(result.RowsAffected), 10)
+			}
 			if err := c.sendCommandComplete(tag); err != nil {
 				return err
 			}


### PR DESCRIPTION
Before this commit, CREATE TABLE AS SELECT would return "CREATE TABLE" as its
command tag. This commit changes the tag to reflect the inserted rows number,
which is the same as postgres does.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13917)
<!-- Reviewable:end -->
