### PR TITLE
allocsim: Fix uneven latency config to use milliseconds instead of ns

### DIFF
--- a/pkg/cmd/allocsim/configs/node-per-locality-uneven-latency-imbalanced-load2.json
+++ b/pkg/cmd/allocsim/configs/node-per-locality-uneven-latency-imbalanced-load2.json
@@ -7,7 +7,7 @@
       "OutgoingLatencies": [
         {
           "Name": "2",
-          "Latency": "13"
+          "Latency": "13ms"
         },
         {
           "Name": "3",
@@ -22,7 +22,7 @@
       "OutgoingLatencies": [
         {
           "Name": "1",
-          "Latency": "13"
+          "Latency": "13ms"
         },
         {
           "Name": "3",


### PR DESCRIPTION
I fat-fingered this in 4041c68bee047f6b3d6d2ede1e9356586b57d7b6

@BramGruneir

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13926)
<!-- Reviewable:end -->
