### PR TITLE
Various InternalExecutor improvements

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -44,10 +44,24 @@ var _ sqlutil.InternalExecutor = InternalExecutor{}
 func (ie InternalExecutor) ExecuteStatementInTransaction(
 	ctx context.Context, opName string, txn *client.Txn, statement string, qargs ...interface{},
 ) (int, error) {
-	p := makeInternalPlanner(opName, txn, security.RootUser, ie.LeaseManager.memMetrics)
+	p := makeInternalPlanner(opName, txn, security.RootUser, ie.LeaseManager.memMetrics,
+		ie.LeaseManager.clock)
 	defer finishInternalPlanner(p)
 	p.leaseMgr = ie.LeaseManager
 	return p.exec(ctx, statement, qargs...)
+}
+
+// QueryRowInTransaction executes the supplied SQL statement as part of the
+// supplied transaction and returns the result. Statements are currently
+// executed as the root user.
+func (ie InternalExecutor) QueryRowInTransaction(
+	opName string, txn *client.Txn, statement string, qargs ...interface{},
+) (parser.Datums, error) {
+	p := makeInternalPlanner(opName, txn, security.RootUser, ie.LeaseManager.memMetrics,
+		ie.LeaseManager.clock)
+	defer finishInternalPlanner(p)
+	p.leaseMgr = ie.LeaseManager
+	return p.QueryRow(statement, qargs...)
 }
 
 // GetTableSpan gets the key span for a SQL table, including any indices.
@@ -55,7 +69,8 @@ func (ie InternalExecutor) GetTableSpan(
 	ctx context.Context, user string, txn *client.Txn, dbName, tableName string,
 ) (roachpb.Span, error) {
 	// Lookup the table ID.
-	p := makeInternalPlanner("get-table-span", txn, user, ie.LeaseManager.memMetrics)
+	p := makeInternalPlanner("get-table-span", txn, user, ie.LeaseManager.memMetrics,
+		ie.LeaseManager.clock)
 	defer finishInternalPlanner(p)
 	p.leaseMgr = ie.LeaseManager
 

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -39,7 +39,8 @@ type InternalExecutor struct {
 var _ sqlutil.InternalExecutor = InternalExecutor{}
 
 // ExecuteStatementInTransaction executes the supplied SQL statement as part of
-// the supplied transaction. Statements are currently executed as the root user.
+// the supplied transaction and returns the number of rows affected. Statements
+// are currently executed as the root user.
 func (ie InternalExecutor) ExecuteStatementInTransaction(
 	ctx context.Context, opName string, txn *client.Txn, statement string, qargs ...interface{},
 ) (int, error) {

--- a/pkg/sql/internal_test.go
+++ b/pkg/sql/internal_test.go
@@ -1,0 +1,70 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nikhil Benesch (benesch@cockroachlabs.com)
+
+package sql
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+func TestInternalExecutor(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s, _, db := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop()
+	var iex sqlutil.InternalExecutor = InternalExecutor{
+		LeaseManager: s.LeaseManager().(*LeaseManager),
+	}
+	txn := client.NewTxn(context.TODO(), *db)
+
+	t.Run("ExecuteStatement", func(t *testing.T) {
+		n, err := iex.ExecuteStatementInTransaction("select-many", txn, "SELECT * FROM (VALUES (1), (2), (3))")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != 3 {
+			t.Fatalf("expected 3 rows but got %d", n)
+		}
+	})
+
+	t.Run("GetTableSpan", func(t *testing.T) {
+		span, err := iex.GetTableSpan(security.RootUser, txn, "system", "namespace")
+		if err != nil {
+			t.Fatal(err)
+		}
+		tablePrefixKey := roachpb.Key(keys.MakeTablePrefix(keys.NamespaceTableID))
+		expectedSpan := roachpb.Span{
+			Key:    tablePrefixKey,
+			EndKey: tablePrefixKey.PrefixEnd(),
+		}
+		if !reflect.DeepEqual(span, expectedSpan) {
+			t.Fatalf("expected span %v but got %v", expectedSpan, span)
+		}
+	})
+}

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -154,7 +154,7 @@ func (s LeaseStore) Acquire(
 
 	// Use the supplied (user) transaction to look up the descriptor because the
 	// descriptor might have been created within the transaction.
-	p := makeInternalPlanner("lease-acquire", txn, security.RootUser, s.memMetrics)
+	p := makeInternalPlanner("lease-acquire", txn, security.RootUser, s.memMetrics, s.clock)
 	defer finishInternalPlanner(p)
 
 	const getDescriptor = `SELECT descriptor FROM system.descriptor WHERE id = $1`
@@ -208,7 +208,7 @@ func (s LeaseStore) Acquire(
 		if nodeID == 0 {
 			panic("zero nodeID")
 		}
-		p := makeInternalPlanner("lease-insert", txn, security.RootUser, s.memMetrics)
+		p := makeInternalPlanner("lease-insert", txn, security.RootUser, s.memMetrics, s.clock)
 		defer finishInternalPlanner(p)
 		const insertLease = `INSERT INTO system.lease (descID, version, nodeID, expiration) ` +
 			`VALUES ($1, $2, $3, $4)`
@@ -237,7 +237,7 @@ func (s LeaseStore) Release(ctx context.Context, stopper *stop.Stopper, lease *L
 			if nodeID == 0 {
 				panic("zero nodeID")
 			}
-			p := makeInternalPlanner("lease-release", txn, security.RootUser, s.memMetrics)
+			p := makeInternalPlanner("lease-release", txn, security.RootUser, s.memMetrics, s.clock)
 			defer finishInternalPlanner(p)
 			const deleteLease = `DELETE FROM system.lease ` +
 				`WHERE (descID, version, nodeID, expiration) = ($1, $2, $3, $4)`
@@ -415,7 +415,7 @@ func (s LeaseStore) countLeases(
 ) (int, error) {
 	var count int
 	err := s.db.Txn(context.TODO(), func(txn *client.Txn) error {
-		p := makeInternalPlanner("leases-count", txn, security.RootUser, s.memMetrics)
+		p := makeInternalPlanner("leases-count", txn, security.RootUser, s.memMetrics, s.clock)
 		defer finishInternalPlanner(p)
 		const countLeases = `SELECT COUNT(version) FROM system.lease ` +
 			`WHERE descID = $1 AND version = $2 AND expiration > $3`

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -260,7 +260,7 @@ func (p *planner) runShowTransactionState(
 var noteworthyInternalMemoryUsageBytes = envutil.EnvOrDefaultInt64("COCKROACH_NOTEWORTHY_INTERNAL_MEMORY_USAGE", 100*1024)
 
 func makeInternalPlanner(
-	opName string, txn *client.Txn, user string, memMetrics *MemoryMetrics,
+	opName string, txn *client.Txn, user string, memMetrics *MemoryMetrics, clock *hlc.Clock,
 ) *planner {
 	p := makePlanner(opName)
 	p.setTxn(txn)
@@ -283,6 +283,12 @@ func makeInternalPlanner(
 		memMetrics.TxnMaxBytesHist,
 		-1, noteworthyInternalMemoryUsageBytes/5)
 	p.session.TxnState.mon.Start(p.session.context, &p.session.mon, mon.BoundAccount{})
+
+	if txn.Proto.OrigTimestamp == (hlc.Timestamp{}) {
+		now := clock.PhysicalTime()
+		p.evalCtx.SetTxnTimestamp(now)
+		p.evalCtx.SetStmtTimestamp(now)
+	}
 
 	return p
 }

--- a/pkg/sql/sqlutil/internal_executor.go
+++ b/pkg/sql/sqlutil/internal_executor.go
@@ -28,7 +28,8 @@ import (
 // is implemented by sql.InternalExecutor.
 type InternalExecutor interface {
 	// ExecuteStatementInTransaction executes the supplied SQL statement as part of
-	// the supplied transaction. Statements are currently executed as the root user.
+	// the supplied transaction and returns the number of rows affected. Statements
+	// are currently executed as the root user.
 	ExecuteStatementInTransaction(
 		ctx context.Context, opName string, txn *client.Txn, statement string, params ...interface{},
 	) (int, error)

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -38,7 +38,7 @@ func GetUserHashedPassword(
 
 	var hashedPassword []byte
 	if err := executor.cfg.DB.Txn(ctx, func(txn *client.Txn) error {
-		p := makeInternalPlanner("get-pwd", txn, security.RootUser, metrics)
+		p := makeInternalPlanner("get-pwd", txn, security.RootUser, metrics, executor.cfg.Clock)
 		defer finishInternalPlanner(p)
 		const getHashedPassword = `SELECT hashedPassword FROM system.users ` +
 			`WHERE username=$1`

--- a/pkg/sql/values_test.go
+++ b/pkg/sql/values_test.go
@@ -30,12 +30,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 func makeTestPlanner() *planner {
-	return makeInternalPlanner("test", nil, security.RootUser, &MemoryMetrics{})
+	return makeInternalPlanner("test", nil, security.RootUser, &MemoryMetrics{},
+		hlc.NewClock(hlc.UnixNano, time.Nanosecond))
 }
 
 func TestValues(t *testing.T) {


### PR DESCRIPTION
This exposes a new method `QueryRow` method on `InternalExecutor` that allows
one to retrieve the results of queries, rather than just count the number of
rows affected; makes the interface complete; fixes documentation; and adds
tests.

(The `QueryRow` method is used by the upcoming system.jobs table. The other
changes are general cleanup.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13933)
<!-- Reviewable:end -->
