### PR TITLE
storage: Don't remove the leaseholder in filterBehindReplicas

### DIFF
--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -541,8 +541,9 @@ func filterBehindReplicas(
 	candidates := make([]roachpb.ReplicaDescriptor, 0, len(replicas))
 	for _, r := range replicas {
 		if progress, ok := raftStatus.Progress[uint64(r.ReplicaID)]; ok {
-			if progress.State == raft.ProgressStateReplicate &&
-				progress.Match >= raftStatus.Commit {
+			if uint64(r.ReplicaID) == raftStatus.Lead ||
+				(progress.State == raft.ProgressStateReplicate &&
+					progress.Match >= raftStatus.Commit) {
 				candidates = append(candidates, r)
 			}
 		}

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -1566,33 +1566,39 @@ func TestFilterBehindReplicas(t *testing.T) {
 
 	testCases := []struct {
 		commit   uint64
+		leader   uint64
 		progress []uint64
 		expected []uint64
 	}{
-		{0, []uint64{0}, nil},
-		{1, []uint64{1}, []uint64{1}},
-		{2, []uint64{2}, []uint64{2}},
-		{1, []uint64{0, 1}, []uint64{1}},
-		{1, []uint64{1, 2}, []uint64{1, 2}},
-		{2, []uint64{3, 2}, []uint64{3, 2}},
-		{1, []uint64{0, 0, 1}, []uint64{1}},
-		{1, []uint64{0, 1, 2}, []uint64{1, 2}},
-		{2, []uint64{1, 2, 3}, []uint64{2, 3}},
-		{3, []uint64{4, 3, 2}, []uint64{4, 3}},
-		{1, []uint64{1, 1, 1}, []uint64{1, 1, 1}},
-		{1, []uint64{1, 1, 2}, []uint64{1, 1, 2}},
-		{2, []uint64{1, 2, 2}, []uint64{2, 2}},
-		{2, []uint64{0, 1, 2, 3}, []uint64{2, 3}},
-		{2, []uint64{1, 2, 3, 4}, []uint64{2, 3, 4}},
-		{3, []uint64{5, 4, 3, 2}, []uint64{5, 4, 3}},
-		{3, []uint64{1, 2, 3, 4, 5}, []uint64{3, 4, 5}},
-		{4, []uint64{6, 5, 4, 3, 2}, []uint64{6, 5, 4}},
+		{0, 99, []uint64{0}, nil},
+		{1, 99, []uint64{1}, []uint64{1}},
+		{2, 99, []uint64{2}, []uint64{2}},
+		{1, 99, []uint64{0, 1}, []uint64{1}},
+		{1, 99, []uint64{1, 2}, []uint64{1, 2}},
+		{2, 99, []uint64{3, 2}, []uint64{3, 2}},
+		{1, 99, []uint64{0, 0, 1}, []uint64{1}},
+		{1, 99, []uint64{0, 1, 2}, []uint64{1, 2}},
+		{2, 99, []uint64{1, 2, 3}, []uint64{2, 3}},
+		{3, 99, []uint64{4, 3, 2}, []uint64{4, 3}},
+		{1, 99, []uint64{1, 1, 1}, []uint64{1, 1, 1}},
+		{1, 99, []uint64{1, 1, 2}, []uint64{1, 1, 2}},
+		{2, 99, []uint64{1, 2, 2}, []uint64{2, 2}},
+		{2, 99, []uint64{0, 1, 2, 3}, []uint64{2, 3}},
+		{2, 99, []uint64{1, 2, 3, 4}, []uint64{2, 3, 4}},
+		{3, 99, []uint64{5, 4, 3, 2}, []uint64{5, 4, 3}},
+		{3, 99, []uint64{1, 2, 3, 4, 5}, []uint64{3, 4, 5}},
+		{4, 99, []uint64{6, 5, 4, 3, 2}, []uint64{6, 5, 4}},
+		{0, 0, []uint64{0}, []uint64{0}},
+		{0, 0, []uint64{0, 0, 0}, []uint64{0}},
+		{1, 0, []uint64{2, 0, 1}, []uint64{2, 1}},
+		{1, 1, []uint64{0, 2, 1}, []uint64{2, 1}},
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
 			status := &raft.Status{
 				Progress: make(map[uint64]raft.Progress),
 			}
+			status.Lead = c.leader
 			status.Commit = c.commit
 			var replicas []roachpb.ReplicaDescriptor
 			for j, v := range c.progress {


### PR DESCRIPTION
The leaseholder is not behind and thus shouldn't be filtered out.
Not including it causes problems for the new lease balancing logic
when called into from TransferLeaseTarget, because without the
leaseholder included we can't properly compute and compare replica
weights.

cc #13797

@petermattis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13934)
<!-- Reviewable:end -->
