### PR TITLE
storageccl: make the WriteBatch command idempotent

### DIFF
--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -82,32 +82,28 @@ func TestImport(t *testing.T) {
 	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop()
 
-	req := &roachpb.ImportRequest{
-		Span:        roachpb.Span{Key: reqStartKey},
-		DataSpan:    roachpb.Span{Key: dataStartKey, EndKey: dataEndKey},
-		KeyRewrites: kr,
-		Files: []roachpb.ImportRequest_File{
-			{Dir: storage, Path: sstName},
-		},
-	}
-	b := &client.Batch{}
-	b.AddRawRequest(req)
-	if err := kvDB.Run(ctx, b); err != nil {
-		t.Fatalf("%+v", err)
-	}
-	kvs, err := kvDB.Scan(ctx, reqStartKey, reqEndKey, 0)
-	if err != nil {
-		t.Fatalf("%+v", err)
-	}
-	if len(kvs) != 1 {
-		t.Fatalf("expected 1 kv got %d", len(kvs))
-	}
-
-	// The previous request already inserted data, but the request keyrange is
-	// required to be empty, so running it again should fail.
-	b = &client.Batch{}
-	b.AddRawRequest(req)
-	if err := kvDB.Run(ctx, b); !testutils.IsError(err, "empty ranges") {
-		t.Fatalf("expected 'empty ranges' error got %+v", err)
+	// Import may be retried by DistSender if it takes too long to return, so
+	// make sure it's idempotent.
+	for i := 0; i < 3; i++ {
+		req := &roachpb.ImportRequest{
+			Span:        roachpb.Span{Key: reqStartKey},
+			DataSpan:    roachpb.Span{Key: dataStartKey, EndKey: dataEndKey},
+			KeyRewrites: kr,
+			Files: []roachpb.ImportRequest_File{
+				{Dir: storage, Path: sstName},
+			},
+		}
+		b := &client.Batch{}
+		b.AddRawRequest(req)
+		if err := kvDB.Run(ctx, b); err != nil {
+			t.Fatalf("%+v", err)
+		}
+		kvs, err := kvDB.Scan(ctx, reqStartKey, reqEndKey, 0)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+		if len(kvs) != 1 {
+			t.Fatalf("expected 1 kv got %d", len(kvs))
+		}
 	}
 }

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -913,6 +913,10 @@ func (r *rocksDBBatchIterator) Less(key MVCCKey) bool {
 	return r.iter.Less(key)
 }
 
+func (r *rocksDBBatchIterator) getIter() *C.DBIterator {
+	return r.iter.iter
+}
+
 type rocksDBBatch struct {
 	parent             *RocksDB
 	batch              *C.DBEngine


### PR DESCRIPTION
Delete any pre-existing data in the affected keyrange. Adjust the mvcc
stats by computing them from scratch for the to-be-deleted data and
substracting that from the total.

This makes it safe to retry the Import command, as DistSender does
(which was causing flakes).

Closes #13906.
Closes #13893.
Closes #13867.
Closes #13866.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13951)
<!-- Reviewable:end -->
