### PR TITLE
sql: place generate_series in the same namespace as the rest.

### DIFF
--- a/pkg/sql/parser/generator_builtins.go
+++ b/pkg/sql/parser/generator_builtins.go
@@ -98,7 +98,7 @@ func initGeneratorBuiltins() {
 }
 
 var generators = map[string][]Builtin{
-	"pg_catalog.generate_series": {
+	"generate_series": {
 		makeGeneratorBuiltin(
 			ArgTypes{{"start", TypeInt}, {"end", TypeInt}},
 			TTuple{TypeInt},

--- a/pkg/sql/testdata/generators
+++ b/pkg/sql/testdata/generators
@@ -60,14 +60,14 @@ SELECT * FROM (VALUES (1)) LIMIT GENERATE_SERIES(1, 3)
 query I colnames
 SELECT GENERATE_SERIES(1, 2)
 ----
-pg_catalog.generate_series
+generate_series
 1
 2
 
 query II colnames
 SELECT GENERATE_SERIES(1, 2), GENERATE_SERIES(3, 4)
 ----
-pg_catalog.generate_series  pg_catalog.generate_series
+generate_series             generate_series
 1                           3
 1                           4
 2                           3


### PR DESCRIPTION
The changes in 4ee37ed0e5d29f2384849166d51c3a982bb71949 forgot to
rename `generate_series`. This patch completes the change.

Fixes #13953.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13960)
<!-- Reviewable:end -->
