### PR TITLE
storage: Add env var for tweaking aggressiveness of lease rebalancing

### DIFF
--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -55,7 +55,33 @@ var (
 	// making decisions based on them.
 	// Made configurable for the sake of testing.
 	MinLeaseTransferStatsDuration = time.Minute
+
+	// EnableLeaseRebalancing controls whether lease rebalancing is enabled or
+	// not. Exported for testing.
+	EnableLeaseRebalancing = envutil.EnvOrDefaultBool("COCKROACH_ENABLE_LEASE_REBALANCING", true)
+
+	// EnableLoadBasedLeaseRebalancing controls whether lease rebalancing is done
+	// via the new heuristic based on request load and latency or via the simpler
+	// approach that purely seeks to balance the number of leases per node evenly.
+	EnableLoadBasedLeaseRebalancing = envutil.EnvOrDefaultBool("COCKROACH_ENABLE_LOAD_BASED_LEASE_REBALANCING", false)
+
+	// LeaseRebalancingAggressiveness enables users to tweak how aggressive their
+	// cluster is at moving leases towards the localities where the most requests
+	// are coming from. Settings lower than 1.0 will make the system less
+	// aggressive about moving leases toward requests than the default, while
+	// settings greater than 1.0 will cause more aggressive placement.
+	//
+	// Setting this to 0 effectively disables load-based lease rebalancing, and
+	// settings less than 0 are disallowed.
+	LeaseRebalancingAggressiveness = envutil.EnvOrDefaultFloat("COCKROACH_LEASE_REBALANCING_AGGRESSIVENESS", 1.0)
 )
+
+func init() {
+	if LeaseRebalancingAggressiveness < 0 {
+		panic(fmt.Sprintf("COCKROACH_LEASE_REBALANCING_AGGRESSIVENESS must not be negative, got %f",
+			LeaseRebalancingAggressiveness))
+	}
+}
 
 // AllocatorAction enumerates the various replication adjustments that may be
 // recommended by the allocator.
@@ -453,15 +479,6 @@ func (a *Allocator) TransferLeaseTarget(
 	return candidates[a.randGen.Intn(len(candidates))]
 }
 
-// EnableLeaseRebalancing controls whether lease rebalancing is enabled or
-// not. Exported for testing.
-var EnableLeaseRebalancing = envutil.EnvOrDefaultBool("COCKROACH_ENABLE_LEASE_REBALANCING", true)
-
-// EnableLoadBasedLeaseRebalancing controls whether lease rebalancing is done
-// via the new heuristic based on request load and latency or via the simpler
-// approach that purely seeks to balance the number of leases per node evenly.
-var EnableLoadBasedLeaseRebalancing = envutil.EnvOrDefaultBool("COCKROACH_ENABLE_LOAD_BASED_LEASE_REBALANCING", false)
-
 // ShouldTransferLease returns true if the specified store is overfull in terms
 // of leases with respect to the other stores matching the specified
 // attributes.
@@ -605,8 +622,9 @@ func loadBasedLeaseRebalanceScore(
 	meanLeases float64,
 ) int32 {
 	remoteLatencyMillis := float64(remoteLatency) / float64(time.Millisecond)
-	rebalanceThreshold :=
-		baseRebalanceThreshold - 0.1*math.Log10(remoteWeight/sourceWeight)*math.Log1p(remoteLatencyMillis)
+	rebalanceAdjustment :=
+		LeaseRebalancingAggressiveness * 0.1 * math.Log10(remoteWeight/sourceWeight) * math.Log1p(remoteLatencyMillis)
+	rebalanceThreshold := baseRebalanceThreshold - rebalanceAdjustment
 
 	overfullLeaseThreshold := int32(math.Ceil(meanLeases * (1 + rebalanceThreshold)))
 	overfullScore := source.Capacity.LeaseCount - overfullLeaseThreshold


### PR DESCRIPTION
This makes it easy for users to adjust their risk/throughput threshold for all leases ending up in the same place if their requests are skewed.

For example, using the `node-per-locality-uneven-latency-imbalanced-load2.json` config, with a few different aggressiveness settings we see:

Aggressiveness=1.0 (default):
```
    1m0s   1197.8   1056.0   30.3ms        0      287          96/42/28           96/34/1            95/1/0
    2m0s   1193.8   1156.5   27.6ms        0      615         205/65/63         205/125/3           205/4/0
    3m0s   1038.8   1122.4   28.5ms        0      792         264/72/71         264/178/9           264/9/4
    4m0s    918.8   1060.8   30.2ms        0     1140        380/107/80        380/239/20          380/18/9
    5m0s    547.9    994.1   32.2ms        0     1404       468/119/103        468/303/39         468/37/13
    6m0s    498.8    921.5   34.7ms        0     1536       512/131/123        512/330/55         512/46/25
    7m0s    503.9    865.1   37.0ms        0     1563       521/133/143        521/335/75         521/51/43
```

Aggressiveness=10.0 (very aggressive):
```
    1m0s   1211.8    958.9   33.4ms        0      216          72/39/23           72/28/1            72/1/0
    2m0s   1405.8   1155.9   27.7ms        0      680         225/42/68         230/168/1           225/1/0
    3m0s   1480.7   1262.1   25.4ms        0      824         275/25/96         275/241/1           274/1/0
    4m0s   1572.7   1326.4   24.1ms        0     1533        511/16/117         511/488/1           511/1/0
    5m0s   1506.8   1364.5   23.4ms        0     1563        521/13/123         521/505/1           521/2/0
    6m0s   1427.8   1390.7   23.0ms        0     2064         688/9/126         688/673/1           688/2/0
    7m0s   1504.7   1405.6   22.8ms        0     2895         965/5/130         965/923/1           965/2/0
    8m0s   1523.6   1418.1   22.6ms        0     3096        1032/6/132       1032/1017/1          1032/2/0
    9m0s   1558.7   1418.1   22.6ms        0     3102        1034/4/134       1034/1026/1          1034/2/1
```

Aggressiveness=0.1 (very conservative):
```
    1m0s    998.8   1022.6   31.2ms        0      201          67/30/25           67/27/2            67/4/0
    2m0s    274.0    770.9   41.4ms        0      360         120/42/45         120/41/17          120/33/0
    3m0s    213.0    596.8   53.6ms        0      465         155/52/63         155/53/17          155/46/0
    4m0s    238.0    498.8   64.1ms        0      543         181/58/63         181/66/17          181/54/4
    5m0s    239.9    444.5   71.9ms        0      618         206/66/63         206/75/18          206/61/4
```

@petermattis @BramGruneir

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13963)
<!-- Reviewable:end -->
