### PR TITLE
sql: integer to OID casts query pg_catalog

### DIFF
--- a/pkg/sql/testdata/orms
+++ b/pkg/sql/testdata/orms
@@ -3,7 +3,7 @@
 
 ## 12151
 statement ok
-CREATE TABLE a (id int, name string)
+CREATE TABLE a (id int UNIQUE, name string)
 
 query TTTBOI
 SELECT a.attname, format_type(a.atttypid, a.atttypmod), pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod
@@ -79,3 +79,23 @@ JOIN   pg_attribute a ON a.attrelid = i.indrelid
                      AND    i.indisprimary
 ----
 attname  data_type
+
+statement ok
+CREATE TABLE b (id INT, a_id INT, FOREIGN KEY (a_id) REFERENCES a (id))
+
+# ActiveRecord query for foreign keys
+# https://github.com/rails/rails/blob/355a2fcf/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb#L583
+query TTTTTT
+SELECT t2.oid::regclass::text AS to_table, a1.attname AS column, a2.attname AS primary_key, c.conname AS name, c.confupdtype AS on_update, c.confdeltype AS on_delete
+FROM pg_constraint c
+JOIN pg_class t1 ON c.conrelid = t1.oid
+JOIN pg_class t2 ON c.confrelid = t2.oid
+JOIN pg_attribute a1 ON a1.attnum = c.conkey[1] AND a1.attrelid = t1.oid
+JOIN pg_attribute a2 ON a2.attnum = c.confkey[1] AND a2.attrelid = t2.oid
+JOIN pg_namespace t3 ON c.connamespace = t3.oid
+WHERE c.contype = 'f'
+AND t1.relname ='b'
+AND t3.nspname = ANY (current_schemas(false))
+ORDER BY c.conname
+----
+a  a_id  id  fk_a_id_ref_a  a  a

--- a/pkg/sql/testdata/pgoidtype
+++ b/pkg/sql/testdata/pgoidtype
@@ -33,6 +33,18 @@ SELECT 'pg_constraint '::REGCLASS, '"pg_constraint"'::REGCLASS::OID
 ----
 pg_constraint  402060402
 
+query O
+SELECT 402060402::REGCLASS
+----
+pg_constraint
+
+query OOIOT
+SELECT oid, oid::regclass, oid::regclass::int, oid::regclass::int::regclass, oid::regclass::text
+FROM pg_class
+WHERE relname = 'pg_constraint'
+----
+402060402  pg_constraint  402060402  pg_constraint  pg_constraint
+
 query OOO
 SELECT 'upper'::REGPROC, 'upper'::REGPROCEDURE, 'upper'::REGPROC::OID
 ----


### PR DESCRIPTION
Previously, casting an integer or raw OID to a typed OID like `regclass`
would return a typed OID without a name, which displays as an integer.
Now, such casts will properly query the relevant `pg_catalog` table and
return an OID with a name.

This results in queries like `SELECT oid::regclass FROM pg_class`
returning string payloads instead of integer payloads, which some ORMs
expect.

Resolves #13567.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13965)
<!-- Reviewable:end -->
