### PR TITLE
server,distsqlrun: don't try to join a non-existent remote trace

### DIFF
--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -413,6 +413,10 @@ func (tc *TxnCoordSender) Send(
 	if err := tracer.Inject(sp.Context(), basictracer.Delegator, ba.TraceContext); err != nil {
 		return nil, roachpb.NewError(err)
 	}
+	// Clear the trace context if it wasn't initialized.
+	if ba.TraceContext.TraceID == 0 {
+		ba.TraceContext = nil
+	}
 
 	// Send the command through wrapped sender, taking appropriate measures
 	// on error.

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -910,7 +910,7 @@ func (n *Node) setupSpanForIncomingRPC(
 		} else {
 			// Child span of remote parent.
 			var err error
-			ctx, recordedTrace, err = tracing.JoinRemoteTrace(ctx, tr, *remoteTraceContext, opName)
+			ctx, recordedTrace, err = tracing.JoinRemoteTrace(ctx, tr, remoteTraceContext, opName)
 			if err != nil {
 				// Fallback to root span.
 				log.Warningf(ctx, "failed to join remote trace: %s", err)

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -86,7 +86,7 @@ func (ds *ServerImpl) setupFlow(
 		// TODO(andrei): in the following call we're ignoring the returned
 		// recordedTrace. Figure out how to return the recording to the remote
 		// caller after the flow is done.
-		ctx, _, err = tracing.JoinRemoteTrace(ctx, ds.Tracer, *req.TraceContext, opName)
+		ctx, _, err = tracing.JoinRemoteTrace(ctx, ds.Tracer, req.TraceContext, opName)
 		if err != nil {
 			sp = ds.Tracer.StartSpan(opName)
 			ctx = opentracing.ContextWithSpan(ctx, sp)

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -490,14 +490,14 @@ func StartSnowballTrace(
 // closed, the caller should serialize the RecordedTrace and send it over the
 // wire to the remote party.
 func JoinRemoteTrace(
-	ctx context.Context, tr opentracing.Tracer, carrier SpanContextCarrier, opName string,
+	ctx context.Context, tr opentracing.Tracer, carrier *SpanContextCarrier, opName string,
 ) (context.Context, *RecordedTrace, error) {
 	if tr == nil {
 		return ctx, nil, errors.Errorf("JoinRemoteTrace called with nil Tracer")
 	}
 
 	var sp opentracing.Span
-	wireContext, err := tr.Extract(basictracer.Delegator, &carrier)
+	wireContext, err := tr.Extract(basictracer.Delegator, carrier)
 	switch err {
 	case nil:
 		sp = tr.StartSpan(opName, opentracing.FollowsFrom(wireContext))


### PR DESCRIPTION
If tracing is disabled, we'll still send a SpanContextCarrier in the
request, but it will have a 0 TraceID. Don't try to join the remote
trace which has the side-effect of not logging a warning when that
fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13990)
<!-- Reviewable:end -->
