### PR TITLE
sql: add system.jobs table to track progress of long-running jobs

### DIFF
--- a/pkg/acceptance/freeze_test.go
+++ b/pkg/acceptance/freeze_test.go
@@ -76,7 +76,7 @@ func postFreeze(
 func testFreezeClusterInner(
 	ctx context.Context, t *testing.T, c cluster.Cluster, cfg cluster.TestConfig,
 ) {
-	minAffected := int64(server.ExpectedInitialRangeCount())
+	minAffected := int64(server.ExpectedInitialRangeCountWithoutMigrations())
 
 	const long = time.Minute
 	const short = 10 * time.Second

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -463,19 +463,21 @@ func Example_ranges() {
 	// debug range ls
 	// /Min-"ranges3" [1]
 	// 	0: node-id=1 store-id=1
-	// "ranges3"-/Table/0 [7]
+	// "ranges3"-/Table/0 [8]
 	// 	0: node-id=1 store-id=1
 	// /Table/0-/Table/11 [2]
 	// 	0: node-id=1 store-id=1
 	// /Table/11-/Table/12 [3]
 	// 	0: node-id=1 store-id=1
 	// /Table/12-/Table/13 [4]
-	//	0: node-id=1 store-id=1
+	// 	0: node-id=1 store-id=1
 	// /Table/13-/Table/14 [5]
-	//	0: node-id=1 store-id=1
-	// /Table/14-/Max [6]
-	//	0: node-id=1 store-id=1
-	// 7 result(s)
+	// 	0: node-id=1 store-id=1
+	// /Table/14-/Table/15 [6]
+	// 	0: node-id=1 store-id=1
+	// /Table/15-/Max [7]
+	// 	0: node-id=1 store-id=1
+	// 8 result(s)
 	// debug kv scan
 	// "ranges1"	"1"
 	// "ranges2"	"2"
@@ -589,7 +591,7 @@ func Example_max_results() {
 	// debug range ls --max-results=2
 	// /Min-"max_results3" [1]
 	// 	0: node-id=1 store-id=1
-	// "max_results3"-"max_results4" [7]
+	// "max_results3"-"max_results4" [8]
 	// 	0: node-id=1 store-id=1
 	// 2 result(s)
 }

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -294,4 +294,5 @@ const (
 	EventLogTableID   = 12
 	RangeEventTableID = 13
 	UITableID         = 14
+	JobsTableID       = 15
 )

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -58,6 +58,10 @@ type migrationDescriptor struct {
 	// workFn must be idempotent so that we can safely re-run it if a node failed
 	// while running it.
 	workFn func(context.Context, runner) error
+	// newDescriptors is the number of additional descriptors that would be added
+	// by this migration in a fresh cluster. This is needed to automate certain
+	// tests, which check the number of ranges present on server bootup.
+	newDescriptors int
 }
 
 type runner struct {
@@ -106,12 +110,34 @@ func NewManager(
 	}
 }
 
+// AdditionalInitialDescriptors returns the number of system descriptors that
+// have been added by migrations. This is needed for certain tests, which check
+// the number of ranges at node startup.
+//
+// NOTE: This value may be out-of-date if another node is actively running
+// migrations, and so should only be used in test code where the migration
+// lifecycle is tightly controlled.
+func AdditionalInitialDescriptors(ctx context.Context, db db) (int, error) {
+	completedMigrations, err := getCompletedMigrations(ctx, db)
+	if err != nil {
+		return 0, err
+	}
+	n := 0
+	for _, migration := range backwardCompatibleMigrations {
+		key := migrationKey(migration)
+		if _, ok := completedMigrations[string(key)]; ok {
+			n += migration.newDescriptors
+		}
+	}
+	return n, nil
+}
+
 // EnsureMigrations should be run during node startup to ensure that all
 // required migrations have been run (and running all those that are definitely
 // safe to run).
 func (m *Manager) EnsureMigrations(ctx context.Context) error {
 	// First, check whether there are any migrations that need to be run.
-	completedMigrations, err := m.getCompletedMigrations(ctx)
+	completedMigrations, err := getCompletedMigrations(ctx, m.db)
 	if err != nil {
 		return err
 	}
@@ -179,7 +205,7 @@ func (m *Manager) EnsureMigrations(ctx context.Context) error {
 
 	// Re-get the list of migrations in case any of them were completed between
 	// our initial check and our grabbing of the lease.
-	completedMigrations, err = m.getCompletedMigrations(ctx)
+	completedMigrations, err = getCompletedMigrations(ctx, m.db)
 	if err != nil {
 		return err
 	}
@@ -214,11 +240,11 @@ func (m *Manager) EnsureMigrations(ctx context.Context) error {
 	return nil
 }
 
-func (m *Manager) getCompletedMigrations(ctx context.Context) (map[string]struct{}, error) {
+func getCompletedMigrations(ctx context.Context, db db) (map[string]struct{}, error) {
 	if log.V(1) {
 		log.Info(ctx, "trying to get the list of completed migrations")
 	}
-	keyvals, err := m.db.Scan(ctx, keys.MigrationPrefix, keys.MigrationKeyMax, 0 /* maxRows */)
+	keyvals, err := db.Scan(ctx, keys.MigrationPrefix, keys.MigrationKeyMax, 0 /* maxRows */)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get list of completed migrations")
 	}

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -46,6 +47,11 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 	{
 		name:   "default UniqueID to uuid_v4 in system.eventlog",
 		workFn: eventlogUniqueIDDefault,
+	},
+	{
+		name:           "create system.jobs table",
+		workFn:         createJobsTable,
+		newDescriptors: 1,
 	},
 }
 
@@ -83,6 +89,7 @@ type leaseManager interface {
 type db interface {
 	Scan(ctx context.Context, begin, end interface{}, maxRows int64) ([]client.KeyValue, error)
 	Put(ctx context.Context, key, value interface{}) error
+	Txn(ctx context.Context, retryable func(txn *client.Txn) error) error
 }
 
 // Manager encapsulates the necessary functionality for handling migrations
@@ -291,4 +298,17 @@ func eventlogUniqueIDDefault(ctx context.Context, r runner) error {
 		log.Warningf(ctx, "failed attempt to update system.eventlog schema: %s", err)
 	}
 	return err
+}
+
+func createJobsTable(ctx context.Context, r runner) error {
+	// We install the table at the KV layer so that we can choose a known ID in
+	// the reserved ID space. (The SQL layer doesn't allow this.)
+	return r.db.Txn(ctx, func(txn *client.Txn) error {
+		b := txn.NewBatch()
+		desc := sqlbase.JobsTable
+		b.CPut(sqlbase.MakeNameMetadataKey(desc.GetParentID(), desc.GetName()), desc.GetID(), nil)
+		b.CPut(sqlbase.MakeDescMetadataKey(desc.GetID()), sqlbase.WrapDescriptor(&desc), nil)
+		txn.SetSystemConfigTrigger()
+		return txn.Run(b)
+	})
 }

--- a/pkg/migrations/migrations_test.go
+++ b/pkg/migrations/migrations_test.go
@@ -125,6 +125,10 @@ func (f *fakeDB) Put(ctx context.Context, key, value interface{}) error {
 	return nil
 }
 
+func (f *fakeDB) Txn(context.Context, func(txn *client.Txn) error) error {
+	return errors.New("unimplemented")
+}
+
 func TestEnsureMigrations(t *testing.T) {
 	db := &fakeDB{}
 	mgr := Manager{

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -527,7 +527,10 @@ func TestStatusSummaries(t *testing.T) {
 	}
 
 	// Wait for full replication of initial ranges.
-	initialRanges := ExpectedInitialRangeCount()
+	initialRanges, err := ExpectedInitialRangeCount(kvDB)
+	if err != nil {
+		t.Fatal(err)
+	}
 	testutils.SucceedsSoon(t, func() error {
 		for i := 1; i <= int(initialRanges); i++ {
 			if s.RaftStatus(roachpb.RangeID(i)) == nil {

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -534,7 +534,11 @@ func TestSpanStatsResponse(t *testing.T) {
 	if err := httputil.PostJSON(httpClient, url, &request, &response); err != nil {
 		t.Fatal(err)
 	}
-	if a, e := int(response.RangeCount), ExpectedInitialRangeCount(); a != e {
+	initialRanges, err := ts.ExpectedInitialRangeCount()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a, e := int(response.RangeCount), initialRanges; a != e {
 		t.Errorf("expected %d ranges, found %d", e, a)
 	}
 }
@@ -564,7 +568,11 @@ func TestSpanStatsGRPCResponse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if a, e := int(response.RangeCount), ExpectedInitialRangeCount(); a != e {
+	initialRanges, err := ts.ExpectedInitialRangeCount()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a, e := int(response.RangeCount), initialRanges; a != e {
 		t.Errorf("expected %d ranges, found %d", e, a)
 	}
 }

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -578,7 +578,7 @@ func TestPGPreparedQuery(t *testing.T) {
 			baseTest.Results("users", "primary", true, 1, "username", "ASC", false, false),
 		},
 		"SHOW TABLES FROM system": {
-			baseTest.Results("descriptor").Others(7),
+			baseTest.Results("descriptor").Others(8),
 		},
 		"SHOW CONSTRAINTS FROM system.users": {
 			baseTest.Results("users", "primary", "PRIMARY KEY", "username", gosql.NullString{}),

--- a/pkg/sql/split_test.go
+++ b/pkg/sql/split_test.go
@@ -78,7 +78,10 @@ func TestSplitOnTableBoundaries(t *testing.T) {
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop()
 
-	expectedInitialRanges := server.ExpectedInitialRangeCount()
+	expectedInitialRanges, err := server.ExpectedInitialRangeCount(kvDB)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if _, err := sqlDB.Exec(`CREATE DATABASE test`); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/system_table_test.go
+++ b/pkg/sql/system_table_test.go
@@ -114,6 +114,7 @@ func TestSystemTableLiterals(t *testing.T) {
 		{keys.EventLogTableID, sqlbase.EventLogTableSchema, sqlbase.EventLogTable},
 		{keys.RangeEventTableID, sqlbase.RangeEventTableSchema, sqlbase.RangeEventTable},
 		{keys.UITableID, sqlbase.UITableSchema, sqlbase.UITable},
+		{keys.JobsTableID, sqlbase.JobsTableSchema, sqlbase.JobsTable},
 	} {
 		gen, err := sql.CreateTestTableDescriptor(
 			keys.SystemDatabaseID,

--- a/pkg/sql/testdata/information_schema
+++ b/pkg/sql/testdata/information_schema
@@ -248,6 +248,7 @@ pg_type
 pg_views
 descriptor
 eventlog
+jobs
 lease
 namespace
 rangelog
@@ -342,6 +343,7 @@ def            pg_catalog          pg_type            SYSTEM VIEW  1
 def            pg_catalog          pg_views           SYSTEM VIEW  1
 def            system              descriptor         BASE TABLE   1
 def            system              eventlog           BASE TABLE   2
+def            system              jobs               BASE TABLE   1
 def            system              lease              BASE TABLE   1
 def            system              namespace          BASE TABLE   1
 def            system              rangelog           BASE TABLE   1
@@ -466,6 +468,7 @@ ORDER BY TABLE_NAME, CONSTRAINT_TYPE, CONSTRAINT_NAME
 CONSTRAINT_CATALOG  CONSTRAINT_SCHEMA  CONSTRAINT_NAME  TABLE_SCHEMA  TABLE_NAME  CONSTRAINT_TYPE
 def                 system             primary          system        descriptor  PRIMARY KEY
 def                 system             primary          system        eventlog    PRIMARY KEY
+def                 system             primary          system        jobs        PRIMARY KEY
 def                 system             primary          system        lease       PRIMARY KEY
 def                 system             primary          system        namespace   PRIMARY KEY
 def                 system             primary          system        rangelog    PRIMARY KEY
@@ -522,6 +525,10 @@ def            system              eventlog    targetID                  3
 def            system              eventlog    reportingID               4
 def            system              eventlog    info                      5
 def            system              eventlog    uniqueID                  6
+def            system              jobs        id                        1
+def            system              jobs        status                    2
+def            system              jobs        created                   3
+def            system              jobs        payload                   4
 def            system              lease       descID                    1
 def            system              lease       version                   2
 def            system              lease       nodeID                    3
@@ -722,6 +729,11 @@ NULL     root     def            system             eventlog    GRANT           
 NULL     root     def            system             eventlog    INSERT          NULL          NULL
 NULL     root     def            system             eventlog    SELECT          NULL          NULL
 NULL     root     def            system             eventlog    UPDATE          NULL          NULL
+NULL     root     def            system             jobs        DELETE          NULL          NULL
+NULL     root     def            system             jobs        GRANT           NULL          NULL
+NULL     root     def            system             jobs        INSERT          NULL          NULL
+NULL     root     def            system             jobs        SELECT          NULL          NULL
+NULL     root     def            system             jobs        UPDATE          NULL          NULL
 NULL     root     def            system             lease       DELETE          NULL          NULL
 NULL     root     def            system             lease       GRANT           NULL          NULL
 NULL     root     def            system             lease       INSERT          NULL          NULL

--- a/pkg/sql/testdata/pg_catalog
+++ b/pkg/sql/testdata/pg_catalog
@@ -447,6 +447,7 @@ indexrelid  indrelid    indnatts  indisunique  indisprimary  indisexclusion
 335779560   2876473678  2         true         false         false
 624432001   3211628798  2         false        false         false
 724530982   908875140   2         true         true          false
+2557995824  780323485   2         false        false         false
 3505585425  2199392917  2         true         true          false
 3491800018  3270885600  2         true         true          false
 
@@ -459,6 +460,7 @@ indexrelid  indimmediate  indisclustered  indisvalid  indcheckxmin  indisready
 335779560   true          false           true        false         false
 624432001   false         false           true        false         false
 724530982   true          false           true        false         false
+2557995824  false         false           true        false         false
 3505585425  true          false           true        false         false
 3491800018  true          false           true        false         false
 
@@ -471,6 +473,7 @@ indexrelid  indrelid    indislive  indisreplident  indkey  indcollation  indclas
 335779560   2876473678  true       false           3 4     0             0         0          NULL      NULL
 624432001   3211628798  true       false           1 2     0             0         0          NULL      NULL
 724530982   908875140   true       false           1 6     0             0         0          NULL      NULL
+2557995824  780323485   true       false           2 3     0             0         0          NULL      NULL
 3505585425  2199392917  true       false           1 2     0             0         0          NULL      NULL
 3491800018  3270885600  true       false           1 7     0             0         0          NULL      NULL
 

--- a/pkg/sql/testdata/system
+++ b/pkg/sql/testdata/system
@@ -12,6 +12,7 @@ SHOW TABLES FROM system
 ----
 descriptor
 eventlog
+jobs
 lease
 namespace
 rangelog
@@ -22,16 +23,17 @@ zones
 query ITTT
 EXPLAIN (DEBUG) SELECT * FROM system.namespace
 ----
-0 /namespace/primary/0/'system'/id     1    ROW
-1 /namespace/primary/0/'test'/id       50   ROW
-2 /namespace/primary/1/'descriptor'/id 3    ROW
-3 /namespace/primary/1/'eventlog'/id   12   ROW
-4 /namespace/primary/1/'lease'/id      11   ROW
-5 /namespace/primary/1/'namespace'/id  2    ROW
-6 /namespace/primary/1/'rangelog'/id   13   ROW
-7 /namespace/primary/1/'ui'/id         14   ROW
-8 /namespace/primary/1/'users'/id      4    ROW
-9 /namespace/primary/1/'zones'/id      5    ROW
+0  /namespace/primary/0/'system'/id     1    ROW
+1  /namespace/primary/0/'test'/id       50   ROW
+2  /namespace/primary/1/'descriptor'/id 3    ROW
+3  /namespace/primary/1/'eventlog'/id   12   ROW
+4  /namespace/primary/1/'jobs'/id       15   ROW
+5  /namespace/primary/1/'lease'/id      11   ROW
+6  /namespace/primary/1/'namespace'/id  2    ROW
+7  /namespace/primary/1/'rangelog'/id   13   ROW
+8  /namespace/primary/1/'ui'/id         14   ROW
+9  /namespace/primary/1/'users'/id      4    ROW
+10 /namespace/primary/1/'zones'/id      5    ROW
 
 query ITI rowsort
 SELECT * FROM system.namespace
@@ -40,6 +42,7 @@ SELECT * FROM system.namespace
 0 test       50
 1 descriptor 3
 1 eventlog   12
+1 jobs       15
 1 lease      11
 1 namespace  2
 1 rangelog   13
@@ -59,6 +62,7 @@ SELECT id FROM system.descriptor
 12
 13
 14
+15
 50
 
 # Verify we can read "protobuf" columns.
@@ -128,6 +132,14 @@ SHOW COLUMNS FROM system.ui
 key          STRING     false  NULL {primary}
 value        BYTES      true   NULL {}
 lastUpdated  TIMESTAMP  false  NULL {}
+
+query TTBTT
+SHOW COLUMNS FROM system.jobs
+----
+id       INT        false  unique_rowid()  {primary,jobs_status_created_idx}
+status   STRING     false  NULL            {jobs_status_created_idx}
+created  TIMESTAMP  false  now()           {jobs_status_created_idx}
+payload  BYTES      false  NULL            {}
 
 # Verify default privileges on system tables.
 query TTT
@@ -201,6 +213,15 @@ ui  root  GRANT
 ui  root  INSERT
 ui  root  SELECT
 ui  root  UPDATE
+
+query TTT
+SHOW GRANTS ON system.jobs
+----
+jobs  root  DELETE
+jobs  root  GRANT
+jobs  root  INSERT
+jobs  root  SELECT
+jobs  root  UPDATE
 
 statement error user root does not have DROP privilege on database system
 ALTER DATABASE system RENAME TO not_system

--- a/pkg/sql/testdata/system
+++ b/pkg/sql/testdata/system
@@ -82,32 +82,6 @@ id         INT   false NULL {primary}
 descriptor BYTES true  NULL {}
 
 query TTBTT
-SHOW COLUMNS FROM system.lease
-----
-descID     INT       false NULL {primary}
-version    INT       false NULL {primary}
-nodeID     INT       false NULL {primary}
-expiration TIMESTAMP false NULL {primary}
-
-query TTBTT
-SHOW COLUMNS FROM system.ui
-----
-key          STRING     false  NULL {primary}
-value        BYTES      true   NULL {}
-lastUpdated  TIMESTAMP  false  NULL {}
-
-query TTBTT
-SHOW COLUMNS FROM system.rangelog
-----
-timestamp     TIMESTAMP  false  NULL           {primary}
-rangeID       INT        false  NULL           {}
-storeID       INT        false  NULL		   {}
-eventType     STRING     false  NULL		   {}
-otherRangeID  INT        true   NULL		   {}
-info          STRING     true   NULL           {}
-uniqueID      INT        false  unique_rowid() {primary}
-
-query TTBTT
 SHOW COLUMNS FROM system.users
 ----
 username       STRING false NULL {primary}
@@ -118,6 +92,42 @@ SHOW COLUMNS FROM system.zones
 ----
 id     INT   false NULL {primary}
 config BYTES true  NULL {}
+
+query TTBTT
+SHOW COLUMNS FROM system.lease
+----
+descID     INT       false NULL {primary}
+version    INT       false NULL {primary}
+nodeID     INT       false NULL {primary}
+expiration TIMESTAMP false NULL {primary}
+
+query TTBTT
+SHOW COLUMNS FROM system.eventlog
+----
+timestamp    TIMESTAMP  false  NULL      {primary}
+eventType    STRING     false  NULL      {}
+targetID     INT        false  NULL      {}
+reportingID  INT        false  NULL      {}
+info         STRING     true   NULL      {}
+uniqueID     BYTES      false  uuid_v4() {primary}
+
+query TTBTT
+SHOW COLUMNS FROM system.rangelog
+----
+timestamp     TIMESTAMP  false  NULL           {primary}
+rangeID       INT        false  NULL           {}
+storeID       INT        false  NULL		       {}
+eventType     STRING     false  NULL		       {}
+otherRangeID  INT        true   NULL		       {}
+info          STRING     true   NULL           {}
+uniqueID      INT        false  unique_rowid() {primary}
+
+query TTBTT
+SHOW COLUMNS FROM system.ui
+----
+key          STRING     false  NULL {primary}
+value        BYTES      true   NULL {}
+lastUpdated  TIMESTAMP  false  NULL {}
 
 # Verify default privileges on system tables.
 query TTT
@@ -166,13 +176,13 @@ lease  root  SELECT
 lease  root  UPDATE
 
 query TTT
-SHOW GRANTS ON system.ui
+SHOW GRANTS ON system.eventlog
 ----
-ui  root  DELETE
-ui  root  GRANT
-ui  root  INSERT
-ui  root  SELECT
-ui  root  UPDATE
+eventlog  root  DELETE
+eventlog  root  GRANT
+eventlog  root  INSERT
+eventlog  root  SELECT
+eventlog  root  UPDATE
 
 query TTT
 SHOW GRANTS ON system.rangelog
@@ -182,6 +192,15 @@ rangelog  root  GRANT
 rangelog  root  INSERT
 rangelog  root  SELECT
 rangelog  root  UPDATE
+
+query TTT
+SHOW GRANTS ON system.ui
+----
+ui  root  DELETE
+ui  root  GRANT
+ui  root  INSERT
+ui  root  SELECT
+ui  root  UPDATE
 
 statement error user root does not have DROP privilege on database system
 ALTER DATABASE system RENAME TO not_system

--- a/pkg/storage/log_test.go
+++ b/pkg/storage/log_test.go
@@ -55,7 +55,11 @@ func TestLogSplits(t *testing.T) {
 	}
 
 	// Count the number of split events.
-	initialSplits := server.ExpectedInitialRangeCount() - 1
+	initialRanges, err := server.ExpectedInitialRangeCount(kvDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initialSplits := initialRanges - 1
 	if a, e := countSplits(), initialSplits; a != e {
 		t.Fatalf("expected %d initial splits, found %d", e, a)
 	}
@@ -66,7 +70,7 @@ func TestLogSplits(t *testing.T) {
 	}
 
 	// verify that every the count has increased by one.
-	if a, e := countSplits(), initialSplits+1; a != e {
+	if a, e := countSplits(), initialRanges; a != e {
 		t.Fatalf("expected %d splits, found %d", e, a)
 	}
 

--- a/pkg/storage/replicate_queue_test.go
+++ b/pkg/storage/replicate_queue_test.go
@@ -83,7 +83,11 @@ func TestReplicateQueueRebalance(t *testing.T) {
 		return counts
 	}
 
-	numRanges := newRanges + server.ExpectedInitialRangeCount()
+	initialRanges, err := server.ExpectedInitialRangeCount(tc.Servers[0].DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	numRanges := newRanges + initialRanges
 	numReplicas := numRanges * 3
 	const minThreshold = 0.9
 	minReplicas := int(math.Floor(minThreshold * (float64(numReplicas) / numNodes)))

--- a/pkg/storage/replicate_test.go
+++ b/pkg/storage/replicate_test.go
@@ -50,7 +50,10 @@ func TestEagerReplication(t *testing.T) {
 		// After the initial splits have been performed, all of the resulting ranges
 		// should be present in replicate queue purgatory (because we only have a
 		// single store in the test and thus replication cannot succeed).
-		expected := server.ExpectedInitialRangeCount()
+		expected, err := server.ExpectedInitialRangeCount(store.DB())
+		if err != nil {
+			return err
+		}
 		if n := store.ReplicateQueuePurgatoryLength(); expected != n {
 			return errors.Errorf("expected %d replicas in purgatory, but found %d", expected, n)
 		}


### PR DESCRIPTION
Add a migration to inject a system.jobs table into both new and existing
clusters. This table will track the status (pending, running, succeeded,
failed) and completion percentage of long-running jobs. Work to a) log
job status to the table, and b) expose this job status via the admin UI
and SQL console is forthcoming.

The specification of this table is more-completely described in the
System Jobs RFC, docs/RFCS/system_jobs.md.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13995)
<!-- Reviewable:end -->
