### PR TITLE
server: add a new `start` flag `--pid-file` that does the right thing.

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -220,6 +220,13 @@ communication; it must resolve from other nodes in the cluster.`,
 		Description: `The port to bind to for HTTP requests.`,
 	}
 
+	PIDFile = FlagInfo{
+		Name: "pid-file",
+		Description: `
+After the CockroachDB node has started up successfully, it will
+write its process ID to the specified file.`,
+	}
+
 	Socket = FlagInfo{
 		Name:   "socket",
 		EnvVar: "COCKROACH_SOCKET",

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -305,6 +305,8 @@ func init() {
 		stringFlag(f, &serverCfg.SocketFile, cliflags.Socket, "")
 		_ = f.MarkHidden(cliflags.Socket.Name)
 
+		stringFlag(f, &serverCfg.PIDFile, cliflags.PIDFile, "")
+
 		varFlag(f, insecure, cliflags.Insecure)
 		// Allow '--insecure'
 		f.Lookup(cliflags.Insecure.Name).NoOptDefVal = "true"

--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -36,8 +36,7 @@ proc interrupt {} {
 # Preserves the invariant that the server's PID is saved
 # in `server_pid`.
 proc start_server {argv} {
-    system "$argv start & echo \$! > server_pid"
-    sleep 1
+    system "mkfifo pid_fifo || true; $argv start --pid-file=pid_fifo --background & cat pid_fifo > server_pid"
 }
 proc stop_server {argv} {
     system "set -e; if kill -CONT `cat server_pid`; then $argv quit || true & sleep 1; kill -9 `cat server_pid` || true; else $argv quit || true; fi"

--- a/pkg/cli/interactive_tests/test_high_verbosity.tcl
+++ b/pkg/cli/interactive_tests/test_high_verbosity.tcl
@@ -2,8 +2,7 @@
 
 source [file join [file dirname $argv0] common.tcl]
 
-system "$argv start --verbosity 3 & echo \$! > server_pid"
-sleep 1
+system "mkfifo pid_fifo || true; $argv start --verbosity 3 --pid-file=pid_fifo & cat pid_fifo > server_pid"
 
 spawn /bin/bash
 send "PS1=':''/# '\r"

--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -62,7 +62,8 @@ interrupt
 eexpect ":/# "
 
 # Start a regular server
-send "$argv start >/dev/null 2>&1 & sleep 1\r"
+send "mkfifo pid_fifo || true\r"
+send "$argv start --pid-file=pid_fifo >/dev/null 2>&1 & cat pid_fifo\r"
 
 # Now test `quit` as non-start command, and test that `quit` does not
 # emit logging output between the point the command starts until it

--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -9,8 +9,7 @@ set root_crt "/certs/root.crt"
 set root_key "/certs/root.key"
 
 proc start_secure_server {argv ca_crt node_crt node_key} {
-    system "$argv start --ca-cert=$ca_crt --cert=$node_crt --key=$node_key & echo \$! > server_pid"
-    sleep 1
+    system "mkfifo pid_fifo || true; $argv start --ca-cert=$ca_crt --cert=$node_crt --key=$node_key --pid-file=pid_fifo & cat pid_fifo > server_pid"
 }
 
 start_secure_server $argv $ca_crt $node_crt $node_key

--- a/pkg/cli/interactive_tests/test_server_sig.tcl
+++ b/pkg/cli/interactive_tests/test_server_sig.tcl
@@ -7,7 +7,7 @@ send "PS1='\\h:''/# '\r"
 eexpect ":/# "
 
 # Check that the server shuts down upon receiving SIGTERM.
-send "$argv start & echo $! >server_pid; fg\r"
+send "$argv start --pid-file=server_pid\r"
 eexpect "initialized"
 
 system "kill `cat server_pid`"
@@ -21,7 +21,7 @@ eexpect "0\r\n"
 eexpect ":/# "
 
 # Check that the server shuts down upon receiving Ctrl+C.
-send "$argv start & echo $! >server_pid; fg\r"
+send "$argv start --pid-file=server_pid\r"
 eexpect "restarted"
 
 interrupt
@@ -35,7 +35,7 @@ eexpect "1\r\n"
 eexpect ":/# "
 
 # Check that the server shuts down fast upon receiving Ctrl+C twice.
-send "$argv start & echo $! >server_pid; fg\r"
+send "$argv start --pid-file=server_pid\r"
 eexpect "restarted"
 interrupt
 eexpect "initiating graceful shutdown"

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -184,6 +184,10 @@ type Config struct {
 	// actions.
 	EventLogEnabled bool
 
+	// PIDFile indicates the file to which the server writes its PID when
+	// it is ready.
+	PIDFile string
+
 	enginesCreated bool
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -22,6 +22,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -781,6 +782,11 @@ func (s *Server) Start(ctx context.Context) error {
 	close(serveSQL)
 	log.Info(ctx, "serving sql connections")
 
+	if s.cfg.PIDFile != "" {
+		if err := ioutil.WriteFile(s.cfg.PIDFile, []byte(fmt.Sprintf("%d\n", os.Getpid())), 0644); err != nil {
+			log.Error(ctx, err)
+		}
+	}
 	if err := sdnotify.Ready(); err != nil {
 		log.Errorf(ctx, "failed to signal readiness using systemd protocol: %s", err)
 	}


### PR DESCRIPTION
This patch adds support for `--pid-file`: if specified with `start`,
the file is written (and possibly created) upon successful node
startup and its contents are set to the PID of the running process.

This is meant to play well with process managers that want the real
PID of the server process (as opposed to the PID of the first process
launched by the shell, which will be different from the real PID when
`--background` is also specified).

It also makes it possible to reliably wait for server startup in
scripts etc. by specifying a named FIFO as parameter to this
flag. Thanks to this opportunity the CLI interactive tests can now
avoid a sleep upon each server start.

Fixes  #13992.
Fixes #13987.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/13996)
<!-- Reviewable:end -->
