### PR TITLE
sql: make name resolution ignore nonexistent db names in search path

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -700,6 +700,12 @@ func Example_sql() {
 	c.RunWithArgs([]string{"sql", "--execute=show databases"})
 	c.RunWithArgs([]string{"sql", "-e", "select 1; select 2"})
 	c.RunWithArgs([]string{"sql", "-e", "select 1; select 2 where false"})
+	// It must be possible to access pre-defined/virtual tables even if the current database
+	// does not exist yet.
+	c.RunWithArgs([]string{"sql", "-d", "nonexistent", "-e", "select count(*) from pg_class limit 0"})
+	// It must be possible to create the current database after the
+	// connection was established.
+	c.RunWithArgs([]string{"sql", "-d", "nonexistent", "-e", "create database nonexistent; create table foo(x int); select * from foo"})
 
 	// Output:
 	// sql -e create database t; create table t.f (x int, y int); insert into t.f values (42, 69)
@@ -742,6 +748,12 @@ func Example_sql() {
 	// 1
 	// 0 rows
 	// 2
+	// sql -d nonexistent -e select count(*) from pg_class limit 0
+	// 0 rows
+	// count(*)
+	// sql -d nonexistent -e create database nonexistent; create table foo(x int); select * from foo
+	// 0 rows
+	// x
 }
 
 func Example_sql_format() {

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -133,6 +133,11 @@ func NewUndefinedDatabaseError(name string) error {
 	return pgerror.WithSourceContext(err, 1)
 }
 
+// IsUndefinedDatabaseError returns true if the error is for an undefined database.
+func IsUndefinedDatabaseError(err error) bool {
+	return errHasCode(err, pgerror.CodeInvalidCatalogNameError)
+}
+
 // NewUndefinedTableError creates an error that represents a missing database table.
 func NewUndefinedTableError(name string) error {
 	err := errors.Errorf("table %q does not exist", name)

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -534,11 +534,11 @@ func (p *planner) searchAndQualifyDatabase(tn *parser.TableName) error {
 	if p.session.Database != "" {
 		t.DatabaseName = parser.Name(p.session.Database)
 		desc, err := descFunc(&t)
-		if err != nil && !sqlbase.IsUndefinedTableError(err) {
+		if err != nil && !sqlbase.IsUndefinedTableError(err) && !sqlbase.IsUndefinedDatabaseError(err) {
 			return err
 		}
 		if desc != nil {
-			// Database was found, use this name.
+			// Table was found, use this name.
 			*tn = t
 			return nil
 		}
@@ -549,7 +549,7 @@ func (p *planner) searchAndQualifyDatabase(tn *parser.TableName) error {
 	for _, database := range p.session.SearchPath {
 		t.DatabaseName = parser.Name(database)
 		desc, err := descFunc(&t)
-		if err != nil && !sqlbase.IsUndefinedTableError(err) {
+		if err != nil && !sqlbase.IsUndefinedTableError(err) && !sqlbase.IsUndefinedDatabaseError(err) {
 			return err
 		}
 		if desc != nil {

--- a/pkg/sql/testdata/rename_database
+++ b/pkg/sql/testdata/rename_database
@@ -32,7 +32,7 @@ SELECT * FROM kv
 statement ok
 ALTER DATABASE test RENAME TO u
 
-statement error database "test" does not exist
+statement error table "kv" does not exist
 SELECT * FROM kv
 ----
 


### PR DESCRIPTION
Prior to this patch, name resolution would fail if the search path
included the name of a database that doesn't exist. This is
unfortunate because we also want to make it possible for a user to
connect to a CockroachDB node with a URL that includes the database
name already and enable them to issue simple queries, e.g. those that
use virtual tables.

This patch addresses this issue by simply ignoring invalid database
names.

Fixes #14004.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14006)
<!-- Reviewable:end -->
