### PR TITLE
ui: Fix position of Linked Guideline on graphs

### DIFF
--- a/pkg/ui/app/components/graphs.tsx
+++ b/pkg/ui/app/components/graphs.tsx
@@ -541,47 +541,66 @@ export class TextGraph extends React.Component<MetricsDataComponentProps, {}> {
   }
 }
 
-/**
- * mouseEnter, mouseMove, and mouseLeave are helper functions used by LineChart
- * and StackedAreaChart to show/hide lines on all the graphs when hovering over
- * a specific graph.
- */
+// updateLinkedGuidelines should be invoked whenever a user hovers over an NVD3
+// graph. When this occurs, NVD3 displays an "interactive guideline", which is a
+// vertical line that highlights the X-axis coordinate the mouse is currently
+// over.
+//
+// This function is responsible for maintaining "linked" guidelines on all other
+// graphs on the page; a "linked" guideline highlights the same X-axis
+// coordinate on different graphs currently visible on the same page. This
+// allows the user to visually correlate a single X-axis coordinate across
+// multiple visible graphs.
+export function updateLinkedGuidelines(hoverGraph: SVGElement) {
+  // Select the interactive guideline being displayed by NVD3 on the currently
+  // hovered graph, if it exists. Construct a data array for use by d3; this
+  // allows us to use d3's "enter()/exit()" functions to cleanly add and remove
+  // the guideline from other graphs.
+  const sourceGuideline = d3.select(hoverGraph).select("line.nv-guideline");
+  const data = !sourceGuideline.empty() ? [sourceGuideline] : [];
 
-// GraphLineState is a shared state that indicates whether the current graph is
-// receiving the mousemove events. This is used to hide the guideline for the
-// current graph.
-export class GraphLineState {
-  mouseIn: boolean = false;
+  // Select all other graphs on the page. A linked guideline will be applied
+  // to these.
+  const otherGraphs = d3.selectAll(".linked-guideline").filter(function () {
+    return this !== hoverGraph;
+  });
+
+  otherGraphs.each(function () {
+    // Linked guideline will be inserted inside of the "nv-wrap" element of the
+    // nvd3 graph. This element has several translations applied to it by nvd3
+    // which allow us to easily display the linked guideline at the correct
+    // position.
+    const wrapper = d3.select(this).select(".nv-wrap");
+    if (wrapper.empty()) {
+      // In cases where no data is available for a chart, it will not have
+      // an "nv-wrap" element and thus should not get a linked guideline.
+      return;
+    }
+
+    const container = wrapper.selectAll("g.linked-guideline__container")
+      .data(data);
+
+    // If there is no guideline on the currently hovered graph, data is empty
+    // and this exit statement will remove the linked guideline from this graph
+    // if it is already present. This occurs, for example, when the user moves
+    // the mouse off of a graph.
+    container.exit().remove();
+
+    // If there is a guideline on the currently hovered graph, this enter
+    // statement will add a linked guideline element to the current graph (if it
+    // does not already exist).
+    container.enter()
+      .append("g")
+        .attr("class", "linked-guideline__container")
+        .append("line")
+          .attr("class", "linked-guideline__line");
+
+    // Update linked guideline (if present) to match the necessary attributes of
+    // the current guideline.
+    container.select(".linked-guideline__line")
+      .attr("x1", (d) => d.attr("x1"))
+      .attr("x2", (d) => d.attr("x2"))
+      .attr("y1", (d) => d.attr("y1"))
+      .attr("y2", (d) => d.attr("y2"));
+  });
 }
-
-// mouseEnter sets the graph-lines--show class on the element with the
-// .graph-lines class, which should be a parent element of all graphs which need
-// graph lines. This will cause all the graph lines to appear. It also sets the
-// mouseIn state to true which is used to hide the guideline on the current
-// graph in favor of the nvd3 line.
-export function mouseEnter(node: React.Component<any, GraphLineState>) {
-  node.setState({
-    mouseIn: true,
-  });
-  d3.select(".graph-lines").classed("graph-lines--show", true);
-};
-
-// mouseMove changes the graph line positions based on the mouse position.
-export function mouseMove() {
-  let currentGuideline = d3.select("line.nv-guideline");
-  // HACK: Gets x value of the currently visible guideline.
-  // TODO: set this based on the chart axis, not based on the guideline.
-  let x = currentGuideline && currentGuideline.data()[0] || 0;
-  d3.selectAll(".graph-lines__line").style("left", (x + CHART_MARGINS.left) + "px");
-};
-
-// mouseLeave removes the graph-line--show class on the element with the
-// .graph-lines class which will cause all the graph lines to be hidden. It also
-// sets the mouseIn state to false so that the current graph's guideline will
-// appear when hovering over a different graph.
-export function mouseLeave(node: React.Component<any, GraphLineState>) {
-  node.setState({
-    mouseIn: false,
-  });
-  d3.select(".graph-lines").classed("graph-lines--show", false);
-};

--- a/pkg/ui/app/components/linegraph.tsx
+++ b/pkg/ui/app/components/linegraph.tsx
@@ -5,7 +5,7 @@ import { createSelector } from "reselect";
 import { findChildrenOfType } from "../util/find";
 import {
   MetricsDataComponentProps, Axis, AxisProps, ConfigureLineChart, InitLineChart,
-  GraphLineState, mouseEnter, mouseMove, mouseLeave,
+  updateLinkedGuidelines,
 } from "./graphs";
 import { Metric, MetricProps } from "./metric";
 import Visualization from "./visualization";
@@ -23,11 +23,9 @@ interface LineGraphProps extends MetricsDataComponentProps {
  * supports a single Y-axis, but multiple metrics can be graphed on the same
  * axis.
  */
-export class LineGraph extends React.Component<LineGraphProps, GraphLineState> {
+export class LineGraph extends React.Component<LineGraphProps, {}> {
   // The SVG Element in the DOM used to render the graph.
-  svgEl: SVGElement;
-
-  state = new GraphLineState();
+  graphEl: SVGElement;
 
   // A configured NVD3 chart used to render the chart.
   chart: nvd3.LineChart;
@@ -67,6 +65,10 @@ export class LineGraph extends React.Component<LineGraphProps, GraphLineState> {
     }
   }
 
+  mouseMove = () => {
+    updateLinkedGuidelines(this.graphEl);
+  }
+
   drawChart = () => {
     // If the document is not visible (e.g. if the window is minimized) we don't
     // attempt to redraw the chart. Redrawing the chart uses
@@ -84,7 +86,7 @@ export class LineGraph extends React.Component<LineGraphProps, GraphLineState> {
         return;
       }
 
-      ConfigureLineChart(this.chart, this.svgEl, metrics, axis, this.props.data, this.props.timeInfo, false);
+      ConfigureLineChart(this.chart, this.graphEl, metrics, axis, this.props.data, this.props.timeInfo, false);
     }
   }
 
@@ -107,18 +109,10 @@ export class LineGraph extends React.Component<LineGraphProps, GraphLineState> {
 
   render() {
     let { title, subtitle, tooltip, data } = this.props;
-    let graphLineClass = "graph-lines__line";
-    if (this.state.mouseIn) {
-      graphLineClass += " graph-lines__line--hidden";
-    }
-
-    let mouseEnterBound = () => mouseEnter(this);
-    let mouseLeaveBound = () => mouseLeave(this);
 
     return <Visualization title={title} subtitle={subtitle} tooltip={tooltip} loading={!data} >
       <div className="linegraph">
-        <div className={graphLineClass}></div>
-        <svg className="graph" ref={(svg) => this.svgEl = svg} onMouseMove={mouseMove} onMouseEnter={mouseEnterBound} onMouseLeave={mouseLeaveBound} />
+        <svg className="graph linked-guideline" ref={(svg) => this.graphEl = svg} onMouseMove={this.mouseMove} onMouseLeave={this.mouseMove} />
       </div>
     </Visualization>;
   }

--- a/pkg/ui/app/containers/nodeGraphs.tsx
+++ b/pkg/ui/app/containers/nodeGraphs.tsx
@@ -102,7 +102,7 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
     let capacityUsed = capacityTotal - capacityAvailable;
     let capacityPercent = capacityTotal !== 0 ? (capacityUsed / capacityTotal * 100) : 100;
 
-    return <div className="section l-columns graph-lines">
+    return <div className="section l-columns">
       <div className="chart-group l-columns__left">
         <GraphGroup groupId="node.overview" hide={dashboard !== "overview"}>
           <LineGraph title="SQL Queries" sources={nodeSources} tooltip={`The average number of SELECT, INSERT, UPDATE, and DELETE statements per second across ${specifier}.`}>

--- a/pkg/ui/styl/components/visualizations.styl
+++ b/pkg/ui/styl/components/visualizations.styl
@@ -76,18 +76,5 @@ $viz-sides = 62px
   .nv-areaWrap
     opacity .2
 
-.graph-lines__line
-  width 1px
-  background-color $glow-blue
-  border 0
-  padding 0
-  margin 0
-  height 50%
-  position absolute
-  top 83px
-  visibility hidden
-
-.graph-lines--show .graph-lines__line
-  visibility visible
-  &.graph-lines__line--hidden
-    visibility hidden
+.linked-guideline__line
+  stroke $glow-blue


### PR DESCRIPTION
On our current cluster overview page, we display a "linked guideline" across all
line graphs on the page whenever the user hovers their mouse over any graph;
this allows the user to visually correlate the guideline on the current graph
(provided by NVD3) with the same position on other graphs visible on the page.
However, the previous implementation's linked guideline was slightly out of
position, as well as too short.

This fix changes the method used to display the linked guideline; the new method
uses pure d3 to place a new line directly into the SVG structure rendered by
NVD3; this allows us to use translational "wrapper" elements already created by
NVD3, and places the linked guideline with exact accuracy.  This method is also
more efficient, because it no longer needs to consult the rendered DOM to get
coordinates; instead, attributes can be copied directly from the interactive
guideline element of the active chart.

The new method also maintains no state in the charts; previously, a css class
was used to hide the linked guideline when no graphs are hovering. The new
method completely removes the linked guidelines using d3's exit() function.

Fixes #13001

![screen shot 2017-03-08 at 7 17 57 pm](https://cloud.githubusercontent.com/assets/6969858/23731565/63b8e70a-043c-11e7-8cb4-08ade7030862.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14008)
<!-- Reviewable:end -->
