### PR TITLE
ui: use relative URI paths and send cookies in fetch requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ export GIT_PAGER :=
 ifeq ($(TYPE),)
 override LDFLAGS += -X github.com/cockroachdb/cockroach/pkg/build.typ=development
 else ifeq ($(TYPE),release)
-override LDFLAGS += -X github.com/cockroachdb/cockroach/pkg/build.typ=release
+override LDFLAGS += -linkmode external -extldflags "-static-libgcc -static-libstdc++" -X github.com/cockroachdb/cockroach/pkg/build.typ=release
 else ifeq ($(TYPE),musl)
 # This tag disables jemalloc profiling. See https://github.com/jemalloc/jemalloc/issues/585.
 override TAGS += musl

--- a/pkg/ui/app/redux/metrics.spec.ts
+++ b/pkg/ui/app/redux/metrics.spec.ts
@@ -184,7 +184,7 @@ describe("metrics reducer", function() {
       // Mock out fetch server; we are only expecting requests to /ts/query,
       // which we simply reflect with an empty set of datapoints.
       fetchMock.mock({
-        matcher: "/ts/query",
+        matcher: "ts/query",
         method: "POST",
         response: (_url: string, requestObj: RequestInit) => {
           // Assert that metric store's "inFlight" is 1 or 2.
@@ -234,7 +234,7 @@ describe("metrics reducer", function() {
 
       return Promise.all([p1, p2]).then(() => {
         // Assert that the server got the correct number of requests (2).
-        assert.lengthOf(fetchMock.calls("/ts/query"), 3);
+        assert.lengthOf(fetchMock.calls("ts/query"), 3);
         // Assert that the mock metrics state has 5 queries.
         assert.lengthOf(_.keys(mockMetricsState.queries), 6);
         _.each(mockMetricsState.queries, (q) => {
@@ -254,7 +254,7 @@ describe("metrics reducer", function() {
       // an error to the second request.
       let successSent = false;
       fetchMock.mock({
-        matcher: "/ts/query",
+        matcher: "ts/query",
         method: "POST",
         response: (_url: string, requestObj: RequestInit) => {
           // Assert that metric store's "inFlight" is 1.
@@ -296,7 +296,7 @@ describe("metrics reducer", function() {
 
       return p.then(() => {
         // Assert that the server got the correct number of requests (2).
-        assert.lengthOf(fetchMock.calls("/ts/query"), 2);
+        assert.lengthOf(fetchMock.calls("ts/query"), 2);
         // Assert that the mock metrics state has 2 queries.
         assert.lengthOf(_.keys(mockMetricsState.queries), 2);
         // Assert query with id.1 has results.

--- a/pkg/ui/app/redux/uiData.spec.ts
+++ b/pkg/ui/app/redux/uiData.spec.ts
@@ -330,7 +330,7 @@ describe("UIData reducer", function() {
 
     it("correctly saves UIData", function() {
       fetchMock.mock({
-        matcher: "/_admin/v1/uidata",
+        matcher: "_admin/v1/uidata",
         method: "POST",
         response: (_url: string, requestObj: RequestInit) => {
           assert.equal(state[uiKey1].state, uidata.UIDataState.SAVING);
@@ -365,7 +365,7 @@ describe("UIData reducer", function() {
       );
 
       return Promise.all([p, p2]).then(() => {
-        assert.lengthOf(fetchMock.calls("/_admin/v1/uidata"), 1);
+        assert.lengthOf(fetchMock.calls("_admin/v1/uidata"), 1);
         assert.lengthOf(_.keys(state), 2);
         assert.equal(state[uiKey1].data, uiObj1);
         assert.equal(state[uiKey2].data, uiObj2);
@@ -379,7 +379,7 @@ describe("UIData reducer", function() {
     it("correctly reacts to error during save", function (done) {
       this.timeout(2000);
       fetchMock.mock({
-        matcher: "/_admin/v1/uidata",
+        matcher: "_admin/v1/uidata",
         method: "POST",
         response: () => {
           return { throws: new Error(), status: 500};
@@ -392,7 +392,7 @@ describe("UIData reducer", function() {
       );
 
       p.then(() => {
-        assert.lengthOf(fetchMock.calls("/_admin/v1/uidata"), 1);
+        assert.lengthOf(fetchMock.calls("_admin/v1/uidata"), 1);
         assert.lengthOf(_.keys(state), 2);
         assert.equal(state[uiKey1].state, uidata.UIDataState.SAVING);
         assert.equal(state[uiKey2].state, uidata.UIDataState.SAVING);
@@ -416,7 +416,7 @@ describe("UIData reducer", function() {
     });
 
     it("correctly loads UIData", function() {
-      let expectedURL = `/_admin/v1/uidata?keys=${uiKey1}&keys=${uiKey2}`;
+      let expectedURL = `_admin/v1/uidata?keys=${uiKey1}&keys=${uiKey2}`;
 
       fetchMock.mock({
         matcher: expectedURL,
@@ -460,7 +460,7 @@ describe("UIData reducer", function() {
     it("correctly reacts to error during load", function (done) {
       this.timeout(2000);
       fetchMock.mock({
-        matcher: "^/_admin/v1/uidata" /* "^" allows prefix match */,
+        matcher: "^_admin/v1/uidata" /* "^" allows prefix match */,
         response: () => {
           return { throws: new Error() };
         },
@@ -469,7 +469,7 @@ describe("UIData reducer", function() {
       let p = loadUIData(uiKey1, uiKey2);
 
       p.then(() => {
-        assert.lengthOf(fetchMock.calls("^/_admin/v1/uidata"), 1);
+        assert.lengthOf(fetchMock.calls("^_admin/v1/uidata"), 1);
         assert.lengthOf(_.keys(state), 2);
         assert.equal(state[uiKey1].state, uidata.UIDataState.LOADING);
         assert.equal(state[uiKey2].state, uidata.UIDataState.LOADING);
@@ -495,7 +495,7 @@ describe("UIData reducer", function() {
     it("handles missing keys", function () {
       let missingKey = "missingKey";
 
-      let expectedURL = `/_admin/v1/uidata?keys=${missingKey}`;
+      let expectedURL = `_admin/v1/uidata?keys=${missingKey}`;
 
       fetchMock.mock({
         matcher: expectedURL,

--- a/pkg/ui/app/services/registrationService.spec.ts
+++ b/pkg/ui/app/services/registrationService.spec.ts
@@ -13,9 +13,9 @@ import { COCKROACHLABS_ADDR } from "../util/cockroachlabsAPI";
 import fetchMock from "../util/fetch-mock";
 
 const CLUSTER_ID = "10101";
-const uiDataPostFetchURL = "/_admin/v1/uidata";
-const uiDataFetchURL = "/_admin/v1/uidata?keys=registration_synchronized&keys=helpus";
-const clusterFetchURL = "/_admin/v1/cluster";
+const uiDataPostFetchURL = "_admin/v1/uidata";
+const uiDataFetchURL = "_admin/v1/uidata?keys=registration_synchronized&keys=helpus";
+const clusterFetchURL = "_admin/v1/cluster";
 const registrationFetchURLPrefix = `^${COCKROACHLABS_ADDR}`;
 const unregistrationFetchURL = `${COCKROACHLABS_ADDR}/api/clusters/unregister?uuid=${CLUSTER_ID}`;
 const registrationFetchURL = `${COCKROACHLABS_ADDR}/api/clusters/register?uuid=${CLUSTER_ID}`;

--- a/pkg/ui/app/util/api.ts
+++ b/pkg/ui/app/util/api.ts
@@ -54,8 +54,8 @@ export type LogEntriesResponseMessage = Proto2TypeScript.cockroach.server.server
 
 // API constants
 
-export const API_PREFIX = "/_admin/v1";
-export const STATUS_PREFIX = "/_status";
+export const API_PREFIX = "_admin/v1";
+export const STATUS_PREFIX = "_status";
 
 // HELPER FUNCTIONS
 
@@ -102,6 +102,7 @@ function timeoutFetch<TResponse, TResponseMessage, TResponseMessageBuilder exten
         "Grpc-Timeout": timeout ? timeout.asMilliseconds() + "m" : undefined,
       },
       body: req ? req.toArrayBuffer() : undefined,
+      credentials: "same-origin",
     }),
     timeout,
    ).then((res) => {
@@ -159,17 +160,17 @@ export function getEvents(req: EventsRequestMessage, timeout?: moment.Duration):
 
 // getNodes gets node data
 export function getNodes(_req: NodesRequestMessage, timeout?: moment.Duration): Promise<NodesResponseMessage> {
-  return timeoutFetch(serverpb.NodesResponse, `/_status/nodes`, null, timeout);
+  return timeoutFetch(serverpb.NodesResponse, `${STATUS_PREFIX}/nodes`, null, timeout);
 }
 
 export function raftDebug(_req: RaftDebugRequestMessage): Promise<RaftDebugResponseMessage> {
   // NB: raftDebug intentionally does not pass a timeout through.
-  return timeoutFetch(serverpb.RaftDebugResponse, `/_status/raft`);
+  return timeoutFetch(serverpb.RaftDebugResponse, `${STATUS_PREFIX}/raft`);
 }
 
 // queryTimeSeries queries for time series data
 export function queryTimeSeries(req: TimeSeriesQueryRequestMessage, timeout?: moment.Duration): Promise<TimeSeriesQueryResponseMessage> {
-  return timeoutFetch(ts.TimeSeriesQueryResponse, `/ts/query`, req, timeout);
+  return timeoutFetch(ts.TimeSeriesQueryResponse, `ts/query`, req, timeout);
 }
 
 // getHealth gets health data


### PR DESCRIPTION
This change allows the Admin UI to be served at a different base URI path.

For example: https://foo.com/cockroachdb/

This patch also configures the fetch() requests to send cookies to the server.

The combination of these two options allows the CockroachDB Admin UI to be served from behind an authenticating reverse proxy.

Fixes https://github.com/cockroachdb/cockroach/issues/13981

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14017)
<!-- Reviewable:end -->
