### PR TITLE
sql: add oid() builtin function

### DIFF
--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -1668,6 +1668,17 @@ var Builtins = map[string][]Builtin{
 			Info:     "Not usable; exposed only for ORM compatibility.",
 		},
 	},
+	"oid": {
+		Builtin{
+			Types:      ArgTypes{{"int", TypeInt}},
+			ReturnType: fixedReturnType(TypeOid),
+			fn: func(_ *EvalContext, args Datums) (Datum, error) {
+				return NewDOid(*args[0].(*DInt)), nil
+			},
+			category: categoryCompatibility,
+			Info:     "Converts an integer to an OID.",
+		},
+	},
 	"shobj_description": {
 		Builtin{
 			Types:      ArgTypes{{"object_oid", TypeOid}, {"catalog_name", TypeString}},

--- a/pkg/sql/testdata/builtin_function
+++ b/pkg/sql/testdata/builtin_function
@@ -1458,3 +1458,8 @@ query I
 SELECT pg_catalog.length('hello')
 ----
 5
+
+query OOO
+SELECT oid(3), oid(0), oid(12023948723)
+----
+3  0  12023948723


### PR DESCRIPTION
This builtin casts the input integer to an OID.

Resolves #13998.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14022)
<!-- Reviewable:end -->
