### PR TITLE
sql: switch CREATE DATABASE to same RequireSuperUser helper

### DIFF
--- a/pkg/ccl/sqlccl/backup.go
+++ b/pkg/ccl/sqlccl/backup.go
@@ -372,7 +372,7 @@ func reassignParentIDs(
 			}
 		}
 
-		// set privileges
+		// Check and set privileges.
 		{
 			parentDB, err := sqlbase.GetDatabaseDescFromID(txn, table.ParentID)
 			if err != nil {

--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -790,22 +790,25 @@ func TestBackupRestorePermissions(t *testing.T) {
 	backupStmt := fmt.Sprintf(`BACKUP DATABASE bench TO '%s'`, dir)
 
 	t.Run("root-only", func(t *testing.T) {
-		_, err = testuser.Exec(backupStmt)
-		if !testutils.IsError(err, "only root is allowed to BACKUP") {
+		if _, err := testuser.Exec(backupStmt); !testutils.IsError(
+			err, "only root is allowed to BACKUP",
+		) {
 			t.Fatal(err)
 		}
-		_, err = testuser.Exec(`RESTORE blah FROM 'blah'`)
-		if !testutils.IsError(err, "only root is allowed to RESTORE") {
+		if _, err := testuser.Exec(`RESTORE blah FROM 'blah'`); !testutils.IsError(
+			err, "only root is allowed to RESTORE",
+		) {
 			t.Fatal(err)
 		}
 	})
 
 	t.Run("privs-required", func(t *testing.T) {
 		sqlDB.Exec(backupStmt)
-		_, err = sqlDB.DB.Exec(
+		// Root doesn't have CREATE on `system` DB, so that should fail. Still need
+		// a valid `dir` though, since descriptors are always loaded first.
+		if _, err := sqlDB.DB.Exec(
 			fmt.Sprintf(`RESTORE bench.bank FROM '%s' WITH OPTIONS ('into_db'='system')`, dir),
-		)
-		if !testutils.IsError(err, "user root does not have CREATE privilege") {
+		); !testutils.IsError(err, "user root does not have CREATE privilege") {
 			t.Fatal(err)
 		}
 	})

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -79,8 +79,8 @@ func (p *planner) CreateDatabase(n *parser.CreateDatabase) (planNode, error) {
 		}
 	}
 
-	if p.session.User != security.RootUser {
-		return nil, fmt.Errorf("only %s is allowed to create databases", security.RootUser)
+	if err := p.RequireSuperUser("CREATE DATABASE"); err != nil {
+		return nil, err
 	}
 
 	return &createDatabaseNode{p: p, n: n}, nil

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -36,9 +36,10 @@ type planHookFn func(
 
 var planHooks []planHookFn
 
-// PlanHookState exposes the internal planner state needed by plan hooks. This
-// state is passed in this struct, rather than directly to hook functions, to
-// avoid rewiring every hook function when more state needs to be exported.
+// PlanHookState exposes the subset of planner needed by plan hooks.
+// We pass this as one interface, rather than individually passing each field or
+// interface as we find we need them, to avoid churn in the planHookFn sig and
+// the hooks that implement it.
 type PlanHookState interface {
 	ExecCfg() *ExecutorConfig
 	AuthorizationAccessor

--- a/pkg/sql/rename.go
+++ b/pkg/sql/rename.go
@@ -44,7 +44,7 @@ func (p *planner) RenameDatabase(n *parser.RenameDatabase) (planNode, error) {
 		return nil, errEmptyDatabaseName
 	}
 
-	if err := p.RequireSuperUser("RENAME"); err != nil {
+	if err := p.RequireSuperUser("ALTER DATABASE ... RENAME"); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/testdata/database
+++ b/pkg/sql/testdata/database
@@ -141,7 +141,7 @@ SELECT * FROM b.a
 
 user testuser
 
-statement error only root is allowed to create databases
+statement error only root is allowed to CREATE DATABASE
 CREATE DATABASE privs
 
 user root

--- a/pkg/sql/testdata/privileges_database
+++ b/pkg/sql/testdata/privileges_database
@@ -33,7 +33,7 @@ REVOKE ALL ON DATABASE a FROM bar
 # Switch to a user without any privileges.
 user testuser
 
-statement error only root is allowed to create databases
+statement error only root is allowed to CREATE DATABASE
 CREATE DATABASE b
 
 statement error user testuser does not have DROP privilege on database a
@@ -68,7 +68,7 @@ GRANT SELECT ON DATABASE a TO testuser
 
 user testuser
 
-statement error only root is allowed to create databases
+statement error only root is allowed to CREATE DATABASE
 CREATE DATABASE b
 
 statement error user testuser does not have DROP privilege on database a
@@ -103,7 +103,7 @@ GRANT ALL ON DATABASE a TO testuser
 
 user testuser
 
-statement error only root is allowed to create databases
+statement error only root is allowed to CREATE DATABASE
 CREATE DATABASE b
 
 statement ok

--- a/pkg/sql/testdata/rename_database
+++ b/pkg/sql/testdata/rename_database
@@ -85,7 +85,7 @@ GRANT ALL ON DATABASE t TO testuser
 
 user testuser
 
-statement error only root is allowed to RENAME
+statement error only root is allowed to ALTER DATABASE ... RENAME
 ALTER DATABASE t RENAME TO v
 
 query T


### PR DESCRIPTION
followup fix from #14009

Also fix some `err` scope assignments and update PlanHookState comment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14028)
<!-- Reviewable:end -->
