### PR TITLE
sql: regtype casts accept types with modifiers

### DIFF
--- a/pkg/sql/testdata/pgoidtype
+++ b/pkg/sql/testdata/pgoidtype
@@ -93,6 +93,14 @@ SELECT 'bool'::REGTYPE, 'bool'::REGTYPE::OID
 ----
 bool  16
 
+query OO
+SELECT 'numeric(10,3)'::REGTYPE, 'numeric( 10, 3 )'::REGTYPE
+----
+numeric  numeric
+
+query error type 'foo.' does not exist
+SELECT 'foo.'::REGTYPE
+
 query error relation 'blah' does not exist
 SELECT 'blah'::REGCLASS
 


### PR DESCRIPTION
Certain types, like `decimal` (`numeric` in Postgres), accept type
modifiers. These appear like function parameters, for example
`decimal(10,3)`. We support this kind of type, but previously passing
this kind of type to a `::regtype` cast would fail. Now, we correctly
strip the type modifiers before query `pg_type` for the input to the
cast.

Resolves #13993.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14030)
<!-- Reviewable:end -->
