### PR TITLE
cli: add "debug zip" command

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1493,3 +1493,34 @@ func TestJunkPositionalArguments(t *testing.T) {
 		}
 	}
 }
+
+func Example_zip() {
+	c := newCLITest(cliTestParams{})
+	defer c.cleanup()
+
+	c.Run("debug zip /dev/null")
+
+	// Output:
+	// debug zip /dev/null
+	// writing /dev/null
+	//   debug/events
+	//   debug/liveness
+	//   debug/nodes/1/status
+	//   debug/nodes/1/gossip
+	//   debug/nodes/1/stacks
+	//   debug/nodes/1/ranges/1
+	//   debug/nodes/1/ranges/2
+	//   debug/nodes/1/ranges/3
+	//   debug/nodes/1/ranges/4
+	//   debug/nodes/1/ranges/5
+	//   debug/nodes/1/ranges/6
+	//   debug/schema/system@details
+	//   debug/schema/system/descriptor
+	//   debug/schema/system/eventlog
+	//   debug/schema/system/lease
+	//   debug/schema/system/namespace
+	//   debug/schema/system/rangelog
+	//   debug/schema/system/ui
+	//   debug/schema/system/users
+	//   debug/schema/system/zones
+}

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -784,6 +784,7 @@ var debugCmds = []*cobra.Command{
 	kvCmd,
 	rangeCmd,
 	debugEnvCmd,
+	debugZipCmd,
 }
 
 var debugCmd = &cobra.Command{

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -348,6 +348,7 @@ func init() {
 	clientCmds = append(clientCmds, userCmds...)
 	clientCmds = append(clientCmds, zoneCmds...)
 	clientCmds = append(clientCmds, nodeCmds...)
+	clientCmds = append(clientCmds, debugZipCmd)
 	for _, cmd := range clientCmds {
 		f := cmd.PersistentFlags()
 		stringFlag(f, &connHost, cliflags.ClientHost, "")
@@ -377,6 +378,7 @@ func init() {
 	simpleCmds = append(simpleCmds, kvCmds...)
 	simpleCmds = append(simpleCmds, rangeCmds...)
 	simpleCmds = append(simpleCmds, nodeCmds...)
+	simpleCmds = append(simpleCmds, debugZipCmd)
 	for _, cmd := range simpleCmds {
 		f := cmd.PersistentFlags()
 		stringFlag(f, &connPort, cliflags.ClientPort, base.DefaultPort)

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -1,0 +1,262 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package cli
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+)
+
+var debugZipCmd = &cobra.Command{
+	Use:   "zip [file]",
+	Short: "gather cluster debug data into a zip file",
+	Long: `
+
+Gather cluster debug data into a zip file. Data includes cluster events, node
+liveness, node status, range status, node stack traces, log files, and SQL
+schema.
+
+Retrieval of per-node details (status, stack traces, range status) requires the
+node to be live and operating properly. Retrieval of SQL data requires the
+cluster to be live.
+`,
+	RunE: MaybeDecorateGRPCError(runDebugZip),
+}
+
+type zipper struct {
+	f *os.File
+	z *zip.Writer
+}
+
+func newZipper(f *os.File) *zipper {
+	return &zipper{
+		f: f,
+		z: zip.NewWriter(f),
+	}
+}
+
+func (z *zipper) close() {
+	_ = z.z.Close()
+	_ = z.f.Close()
+}
+
+func (z *zipper) create(name string) (io.Writer, error) {
+	fmt.Printf("  %s\n", name)
+	return z.z.Create(name)
+}
+
+func (z *zipper) createRaw(name string, b []byte) error {
+	w, err := z.create(name)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(b)
+	return err
+}
+
+func (z *zipper) createJSON(name string, m interface{}) error {
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return z.createRaw(name, b)
+}
+
+func (z *zipper) createError(name string, e error) error {
+	fmt.Printf("  %s: %s\n", name, e)
+	w, err := z.z.Create(name)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(w, "%s\n", e)
+	return nil
+}
+
+func runDebugZip(cmd *cobra.Command, args []string) error {
+	const (
+		base         = "debug"
+		eventsName   = base + "/events"
+		livenessName = base + "/liveness"
+		nodesPrefix  = base + "/nodes"
+		schemaPrefix = base + "/schema"
+	)
+
+	if len(args) != 1 {
+		return errors.New("exactly one argument is required")
+	}
+
+	conn, stopper, err := getGRPCConn()
+	if err != nil {
+		return err
+	}
+	defer stopper.Stop()
+
+	status := serverpb.NewStatusClient(conn)
+	admin := serverpb.NewAdminClient(conn)
+	ctx := stopperContext(stopper)
+
+	name := args[0]
+	out, err := os.Create(name)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("writing %s\n", name)
+
+	z := newZipper(out)
+	defer z.close()
+
+	if events, err := admin.Events(ctx, &serverpb.EventsRequest{}); err != nil {
+		if err := z.createError(eventsName, err); err != nil {
+			return err
+		}
+	} else {
+		if err := z.createJSON(eventsName, events); err != nil {
+			return err
+		}
+	}
+
+	if liveness, err := admin.Liveness(ctx, &serverpb.LivenessRequest{}); err != nil {
+		if err := z.createError(livenessName, err); err != nil {
+			return err
+		}
+	} else {
+		if err := z.createJSON(livenessName, liveness); err != nil {
+			return err
+		}
+	}
+
+	if nodes, err := status.Nodes(ctx, &serverpb.NodesRequest{}); err != nil {
+		if err := z.createError(nodesPrefix, err); err != nil {
+			return err
+		}
+	} else {
+		for _, node := range nodes.Nodes {
+			id := fmt.Sprintf("%d", node.Desc.NodeID)
+			prefix := fmt.Sprintf("%s/%s", nodesPrefix, id)
+			if err := z.createJSON(prefix+"/status", node); err != nil {
+				return err
+			}
+
+			if gossip, err := status.Gossip(ctx, &serverpb.GossipRequest{NodeId: id}); err != nil {
+				if err := z.createError(prefix+"/gossip", err); err != nil {
+					return err
+				}
+			} else if err := z.createJSON(prefix+"/gossip", gossip); err != nil {
+				return err
+			}
+
+			if stacks, err := status.Stacks(ctx, &serverpb.StacksRequest{NodeId: id}); err != nil {
+				if err := z.createError(prefix+"/stacks", err); err != nil {
+					return err
+				}
+			} else if err := z.createRaw(prefix+"/stacks", stacks.Data); err != nil {
+				return err
+			}
+
+			if logs, err := status.LogFilesList(
+				ctx, &serverpb.LogFilesListRequest{NodeId: id}); err != nil {
+				if err := z.createError(prefix+"/logs", err); err != nil {
+					return err
+				}
+			} else {
+				for _, file := range logs.Files {
+					name := prefix + "/logs/" + file.Name
+					entries, err := status.LogFile(
+						ctx, &serverpb.LogFileRequest{NodeId: id, File: file.Name})
+					if err != nil {
+						if err := z.createError(name, err); err != nil {
+							return err
+						}
+						continue
+					}
+					logOut, err := z.create(name)
+					if err != nil {
+						return err
+					}
+					for _, e := range entries.Entries {
+						if err := e.Format(logOut); err != nil {
+							return err
+						}
+					}
+				}
+			}
+
+			if ranges, err := status.Ranges(ctx, &serverpb.RangesRequest{NodeId: id}); err != nil {
+				if err := z.createError(prefix+"/ranges", err); err != nil {
+					return err
+				}
+			} else {
+				sort.Slice(ranges.Ranges, func(i, j int) bool {
+					return ranges.Ranges[i].State.Desc.RangeID <
+						ranges.Ranges[j].State.Desc.RangeID
+				})
+				for _, r := range ranges.Ranges {
+					name := fmt.Sprintf("%s/ranges/%s", prefix, r.State.Desc.RangeID)
+					if err := z.createJSON(name, r); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+
+	if databases, err := admin.Databases(ctx, &serverpb.DatabasesRequest{}); err != nil {
+		if err := z.createError(schemaPrefix, err); err != nil {
+			return err
+		}
+	} else {
+		for _, dbName := range databases.Databases {
+			prefix := schemaPrefix + "/" + dbName
+			database, err := admin.DatabaseDetails(
+				ctx, &serverpb.DatabaseDetailsRequest{Database: dbName})
+			if err != nil {
+				if err := z.createError(prefix, err); err != nil {
+					return err
+				}
+				continue
+			}
+			if err := z.createJSON(prefix+"@details", database); err != nil {
+				return err
+			}
+
+			for _, tableName := range database.TableNames {
+				name := prefix + "/" + tableName
+				table, err := admin.TableDetails(
+					ctx, &serverpb.TableDetailsRequest{Database: dbName, Table: tableName})
+				if err != nil {
+					if err := z.createError(name, err); err != nil {
+						return err
+					}
+					continue
+				}
+				if err := z.createJSON(name, table); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -18,6 +18,7 @@ package log
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 
 	"golang.org/x/net/context"
@@ -173,4 +174,12 @@ func FatalfDepth(ctx context.Context, depth int, format string, args ...interfac
 // higher.
 func V(level level) bool {
 	return VDepth(level, 1)
+}
+
+// Format writes the log entry to the specified writer.
+func (e Entry) Format(w io.Writer) error {
+	buf := formatLogEntry(e, nil, nil)
+	defer logging.putBuffer(buf)
+	_, err := w.Write(buf.Bytes())
+	return err
 }


### PR DESCRIPTION
Add "debug zip" command which gathers cluster debug data into a zip
file. Data includes cluster events, node liveness, node status, range
status, node stack traces, log files and SQL schema.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14033)
<!-- Reviewable:end -->
