### PR TITLE
sql: fix UPSERT fast path check

### DIFF
--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -226,7 +226,11 @@ func (tu *tableUpserter) init(txn *client.Txn) error {
 	tu.tableDesc = tu.ri.helper.tableDesc
 	tu.indexKeyPrefix = sqlbase.MakeIndexKeyPrefix(tu.tableDesc, tu.tableDesc.PrimaryIndex.ID)
 
+	// For the fast path, all columns must be specified in the insert.
 	allColsIdentityExpr := len(tu.ri.insertCols) == len(tu.tableDesc.Columns) &&
+		// Plus, all columns not in the conflict index must be specified in the
+		// DO UPDATE clause and be of the form `x = excluded.x`.
+		len(tu.updateCols) == len(tu.tableDesc.Columns)-len(tu.conflictIndex.ColumnIDs) &&
 		tu.evaler != nil && tu.evaler.isIdentityEvaler()
 	// When adding or removing a column in a schema change (mutation), the user
 	// can't specify it, which means we need to do a lookup and so we can't use

--- a/pkg/sql/testdata/upsert
+++ b/pkg/sql/testdata/upsert
@@ -174,3 +174,17 @@ SELECT a, b from issue_6710
 ----
 1 test1
 2 test2
+
+statement ok
+CREATE TABLE issue_13962 (a INT PRIMARY KEY, b INT, c INT)
+
+statement ok
+INSERT INTO issue_13962 VALUES (1, 1, 1)
+
+statement ok
+INSERT INTO issue_13962 VALUES (1, 2, 2) ON CONFLICT (a) DO UPDATE SET b = excluded.b
+
+query III
+SELECT * FROM issue_13962
+----
+1 2 1


### PR DESCRIPTION
The fast path was incorrectly taken when all columns in the DO UPDATE
clause were of the form `x = excluded.x` but not every column was in the
clause. This led to a correctness issue.

Closes #13962.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14034)
<!-- Reviewable:end -->
