### PR TITLE
sql: Move spammy trace messages for sql memory allocation to V(2)

### DIFF
--- a/pkg/sql/mon/mem_usage.go
+++ b/pkg/sql/mon/mem_usage.go
@@ -551,9 +551,8 @@ func (mm *MemoryMonitor) increaseBudget(ctx context.Context, minExtra int64) err
 			mm.name, minExtra, mm.reserved.curAllocated)
 	}
 	minExtra = mm.roundSize(minExtra)
-	if log.V(2) || log.HasSpanOrEvent(ctx) {
-		log.VEventf(ctx, 2, "%s: requesting %d bytes from the pool",
-			mm.name, minExtra)
+	if log.V(2) {
+		log.Infof(ctx, "%s: requesting %d bytes from the pool", mm.name, minExtra)
 	}
 
 	return mm.pool.GrowAccount(ctx, &mm.mu.curBudget, minExtra)
@@ -570,9 +569,8 @@ func (mm *MemoryMonitor) roundSize(sz int64) int64 {
 // pool.
 func (mm *MemoryMonitor) releaseBudget(ctx context.Context) {
 	// NB: mm.mu need not be locked here, as this is only called from StopMonitor().
-	if log.V(2) || log.HasSpanOrEvent(ctx) {
-		log.VEventf(ctx, 2, "%s: releasing %d bytes to the pool",
-			mm.name, mm.mu.curBudget.curAllocated)
+	if log.V(2) {
+		log.Infof(ctx, "%s: releasing %d bytes to the pool", mm.name, mm.mu.curBudget.curAllocated)
 	}
 	mm.pool.ClearAccount(ctx, &mm.mu.curBudget)
 }


### PR DESCRIPTION
This means that the statements will be both logged and traced if V(2) is
true, but otherwise won't go anywhere (unlike today when they're always
traced).

The `memory usage increases to` messages are still always logged and
traced, which seems fine to me. The general rule is that everything
that's logged also goes to the relevant trace if the context passed to
the log statement has a span associated with it.

Fixes #14020

@knz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14042)
<!-- Reviewable:end -->
