### PR TITLE
gossip: Always use monotonicUnixNano when dealing with infostore TTLs

### DIFF
--- a/pkg/gossip/infostore.go
+++ b/pkg/gossip/infostore.go
@@ -168,7 +168,7 @@ func (is *infoStore) newInfo(val []byte, ttl time.Duration) *Info {
 func (is *infoStore) getInfo(key string) *Info {
 	if info, ok := is.Infos[key]; ok {
 		// Check TTL and discard if too old.
-		if info.expired(timeutil.Now().UnixNano()) {
+		if info.expired(monotonicUnixNano()) {
 			delete(is.Infos, key)
 		} else {
 			return info
@@ -308,7 +308,7 @@ func (is *infoStore) runCallbacks(key string, content roachpb.Value, callbacks .
 // function against each info in turn. Be sure to skip over any expired
 // infos.
 func (is *infoStore) visitInfos(visitInfo func(string, *Info) error) error {
-	now := timeutil.Now().UnixNano()
+	now := monotonicUnixNano()
 
 	if visitInfo != nil {
 		for k, i := range is.Infos {

--- a/pkg/gossip/infostore_test.go
+++ b/pkg/gossip/infostore_test.go
@@ -113,8 +113,8 @@ func TestInfoStoreGetInfoTTL(t *testing.T) {
 		t.Error(err)
 	}
 	time.Sleep(time.Nanosecond)
-	if is.getInfo("a") != nil {
-		t.Error("shouldn't be able to get info with short TTL")
+	if info := is.getInfo("a"); info != nil {
+		t.Errorf("shouldn't be able to get info with short TTL, got %+v", info)
 	}
 }
 


### PR DESCRIPTION
I wasn't able to reproduce the test flake we've been seeing in #12764
(despite trying for 185k stress runs over 15 minutes) and the test
doesn't have any useful log output, but I could conceivably see this
being the problem.

Also add slightly more output to the test in case it somehow flakes
again.

Fixes #12764

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14043)
<!-- Reviewable:end -->
