### PR TITLE
sqlccl: add a benchmark for WriteBatch

### DIFF
--- a/pkg/ccl/storageccl/writebatch_test.go
+++ b/pkg/ccl/storageccl/writebatch_test.go
@@ -11,11 +11,14 @@ package storageccl
 import (
 	"bytes"
 	"reflect"
+	"strconv"
 	"testing"
+	"time"
 
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -23,8 +26,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
 func TestDBWriteBatch(t *testing.T) {
@@ -164,5 +170,51 @@ func TestWriteBatchMVCCStats(t *testing.T) {
 	}
 	if !reflect.DeepEqual(expectedStats, cArgs.Stats) {
 		t.Errorf("mvcc stats mismatch %+v != %+v", expectedStats, cArgs.Stats)
+	}
+}
+
+func BenchmarkWriteBatch(b *testing.B) {
+	if !storage.ProposerEvaluatedKVEnabled() {
+		b.Skip("command WriteBatch is not allowed without proposer evaluated KV")
+	}
+	rng, _ := randutil.NewPseudoRand()
+	const payloadSize = 100
+	v := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, payloadSize))
+
+	ts := hlc.NewClock(hlc.UnixNano, time.Nanosecond).Now()
+	for _, numEntries := range []int{100, 1000, 10000, 100000} {
+		b.Run(strconv.Itoa(numEntries), func(b *testing.B) {
+			ctx := context.Background()
+			tc := testcluster.StartTestCluster(b, 3, base.TestClusterArgs{})
+			defer tc.Stopper().Stop()
+			kvDB := tc.Server(0).KVClient().(*client.DB)
+
+			id := keys.MaxReservedDescID + 1
+			var batch engine.RocksDBBatchBuilder
+
+			var totalLen int64
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				prefix := roachpb.Key(keys.MakeTablePrefix(uint32(id)))
+				id++
+				for j := 0; j < numEntries; j++ {
+					key := encoding.EncodeUvarintAscending(prefix, uint64(j))
+					v.ClearChecksum()
+					v.InitChecksum(key)
+					batch.Put(engine.MVCCKey{Key: key, Timestamp: ts}, v.RawBytes)
+				}
+				end := prefix.PrefixEnd()
+				repr := batch.Finish()
+				totalLen += int64(len(repr))
+				b.StartTimer()
+
+				if err := kvDB.WriteBatch(ctx, prefix, end, repr); err != nil {
+					b.Fatalf("%+v", err)
+				}
+			}
+			b.StopTimer()
+			b.SetBytes(totalLen / int64(b.N))
+		})
 	}
 }


### PR DESCRIPTION
name                 time/op
WriteBatch/100-8        916µs ±10%
WriteBatch/1000-8      5.25ms ±18%
WriteBatch/10000-8     48.1ms ± 5%
WriteBatch/100000-8     640ms ±11%

name                 speed
WriteBatch/100-8     13.4MB/s ±10%
WriteBatch/1000-8    23.7MB/s ±16%
WriteBatch/10000-8   25.4MB/s ± 5%
WriteBatch/100000-8  19.2MB/s ±11%

name                 alloc/op
WriteBatch/100-8        706kB ± 2%
WriteBatch/1000-8      6.11MB ± 5%
WriteBatch/10000-8     65.0MB ± 3%
WriteBatch/100000-8    1.12GB ± 1%

name                 allocs/op
WriteBatch/100-8          861 ±53%
WriteBatch/1000-8      4.87k ±116%
WriteBatch/10000-8     33.9k ±243%
WriteBatch/100000-8     453k ±158%

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14049)
<!-- Reviewable:end -->
