### PR TITLE
core: set tcp keep-alive for server-side pgwire connections.

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/net/context"
@@ -533,6 +534,45 @@ func (s *Server) Start(ctx context.Context) error {
 	// traffic until the migrations are done, as indicated by this channel.
 	serveSQL := make(chan bool)
 
+	tcpKeepAlive := envutil.EnvOrDefaultDuration("COCKROACH_SQL_TCP_KEEP_ALIVE", time.Minute)
+	var loggedKeepAliveStatus int32
+
+	// Attempt to set TCP keep-alive on connection. Don't fail on errors.
+	setTCPKeepAlive := func(ctx context.Context, conn net.Conn) {
+		if tcpKeepAlive == 0 {
+			return
+		}
+
+		muxConn, ok := conn.(*cmux.MuxConn)
+		if !ok {
+			return
+		}
+		tcpConn, ok := muxConn.Conn.(*net.TCPConn)
+		if !ok {
+			return
+		}
+
+		// Only log success/failure once.
+		doLog := atomic.CompareAndSwapInt32(&loggedKeepAliveStatus, 0, 1)
+		if err := tcpConn.SetKeepAlive(true); err != nil {
+			if doLog {
+				log.Warningf(ctx, "failed to enable TCP keep-alive for pgwire: %v", err)
+			}
+			return
+
+		}
+		if err := tcpConn.SetKeepAlivePeriod(tcpKeepAlive); err != nil {
+			if doLog {
+				log.Warningf(ctx, "failed to set TCP keep-alive duration for pgwire: %v", err)
+			}
+			return
+		}
+
+		if doLog {
+			log.VEventf(ctx, 2, "setting TCP keep-alive to %s for pgwire", tcpKeepAlive)
+		}
+	}
+
 	s.stopper.RunWorker(func() {
 		select {
 		case <-serveSQL:
@@ -542,6 +582,8 @@ func (s *Server) Start(ctx context.Context) error {
 		pgCtx := s.pgServer.AmbientCtx.AnnotateCtx(context.Background())
 		netutil.FatalIfUnexpected(httpServer.ServeWith(s.stopper, pgL, func(conn net.Conn) {
 			connCtx := log.WithLogTagStr(pgCtx, "client", conn.RemoteAddr().String())
+			setTCPKeepAlive(pgCtx, conn)
+
 			if err := s.pgServer.ServeConn(connCtx, conn); err != nil && !netutil.IsClosedConnection(err) {
 				// Report the error on this connection's context, so that we
 				// know which remote client caused the error when looking at


### PR DESCRIPTION
Sets tcp keep-alive interval on pgwire connections if
COCKROACH_SQL_TCP_KEEP_ALIVE > 0.
That's all we get to set through Go. under linux, that impacts both
the time to first keep-alive and the repeat interval. We don't get to
set the count of keep-alive packets until the connection is considered
dead.

This would get around #13823, without requiring client library support
for keep alive.
We need to figure out if there are downsides to something like this
though.

Testing would kind of suck too. I don't think we can extract this kind
of information from a client connection in progress.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14063)
<!-- Reviewable:end -->
