### PR TITLE
sql: copy the input to (*tableUpserter).row

### DIFF
--- a/pkg/sql/testdata/upsert
+++ b/pkg/sql/testdata/upsert
@@ -188,3 +188,12 @@ query III
 SELECT * FROM issue_13962
 ----
 1 2 1
+
+statement ok
+CREATE TABLE issue_14052 (a INT PRIMARY KEY, b INT, c INT)
+
+statement ok
+INSERT INTO issue_14052 (a, b) VALUES (1, 1), (2, 2)
+
+statement ok
+UPSERT INTO issue_14052 (a, c) (SELECT a, b from issue_14052)


### PR DESCRIPTION
The caller of this method was getting a row from (planNode).Values,
which doesn't guarantee that it will exist after the next call to Next.
Copy it here instead of sql.Insert because tableInserter doesn't need a
copy, so we save the allocations on non-upsert INSERTs.

The existing tests happened to get planNodes that didn't reuse rows, so
they unfortunately didn't catch it.

Closes #14052.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14078)
<!-- Reviewable:end -->
