### PR TITLE
sql: separately measure the different phases of SQL query processing.

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -479,6 +479,7 @@ func (e *Executor) ExecuteStatements(
 ) StatementResults {
 	session.planner.resetForBatch(e)
 	session.planner.semaCtx.Placeholders.Assign(pinfo)
+	session.phaseTimes[sessionStartBatch] = timeutil.Now()
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -551,6 +552,7 @@ func (e *Executor) execRequest(session *Session, sql string, copymsg copyMsg) St
 		log.Infof(session.Ctx(), "execRequest: %s", sql)
 	}
 
+	session.phaseTimes[sessionStartParse] = timeutil.Now()
 	if session.planner.copyFrom != nil {
 		stmts, err = session.planner.ProcessCopyData(session.Ctx(), sql, copymsg)
 	} else if copymsg != copyMsgNone {
@@ -558,6 +560,8 @@ func (e *Executor) execRequest(session *Session, sql string, copymsg copyMsg) St
 	} else {
 		stmts, err = planMaker.parser.Parse(sql, session.Syntax)
 	}
+	session.phaseTimes[sessionEndParse] = timeutil.Now()
+
 	if err != nil {
 		if log.V(2) {
 			log.Infof(session.Ctx(), "execRequest: error: %v", err)
@@ -636,9 +640,9 @@ func (e *Executor) execRequest(session *Session, sql string, copymsg copyMsg) St
 		origState := txnState.State
 
 		// Track if we are retrying this query, so that we do not double count.
-		isAutomaticRetry := false
+		automaticRetryCount := 0
 		txnClosure := func(txn *client.Txn, opt *client.TxnExecOptions) error {
-			defer func() { isAutomaticRetry = true }()
+			defer func() { automaticRetryCount++ }()
 			if txnState.State == Open && txnState.txn != txn {
 				panic(fmt.Sprintf("closure wasn't called in the txn we set up for it."+
 					"\ntxnState.txn:%+v\ntxn:%+v\ntxnState:%+v", txnState.txn, txn, txnState))
@@ -655,7 +659,7 @@ func (e *Executor) execRequest(session *Session, sql string, copymsg copyMsg) St
 				ResultList(results).Close(session.Ctx())
 			}
 			results, remainingStmts, err = runTxnAttempt(
-				e, planMaker, origState, txnState, opt, stmtsToExec, isAutomaticRetry)
+				e, planMaker, origState, txnState, opt, stmtsToExec, automaticRetryCount)
 
 			// TODO(andrei): Until #7881 fixed.
 			if err == nil && txnState.State == Aborted {
@@ -805,7 +809,7 @@ func runTxnAttempt(
 	txnState *txnState,
 	opt *client.TxnExecOptions,
 	stmts parser.StatementList,
-	isAutomaticRetry bool,
+	automaticRetryCount int,
 ) ([]Result, parser.StatementList, error) {
 
 	// Ignore the state that might have been set by a previous try
@@ -816,7 +820,7 @@ func runTxnAttempt(
 	planMaker.setTxn(txnState.txn)
 	results, remainingStmts, err := e.execStmtsInCurrentTxn(
 		stmts, planMaker, txnState,
-		opt.AutoCommit /* implicitTxn */, opt.AutoRetry /* txnBeginning */, isAutomaticRetry)
+		opt.AutoCommit /* implicitTxn */, opt.AutoRetry /* txnBeginning */, automaticRetryCount)
 	if opt.AutoCommit {
 		if len(remainingStmts) > 0 {
 			panic("implicit txn failed to execute all stmts")
@@ -863,7 +867,7 @@ func (e *Executor) execStmtsInCurrentTxn(
 	txnState *txnState,
 	implicitTxn bool,
 	txnBeginning bool,
-	isAutomaticRetry bool,
+	automaticRetryCount int,
 ) ([]Result, parser.StatementList, error) {
 	var results []Result
 	if txnState.State == NoTxn {
@@ -901,7 +905,7 @@ func (e *Executor) execStmtsInCurrentTxn(
 			case Open:
 				res, err = e.execStmtInOpenTxn(
 					stmt, planMaker, implicitTxn, txnBeginning && (i == 0), /* firstInTxn */
-					txnState, isAutomaticRetry)
+					txnState, automaticRetryCount)
 			case Aborted, RestartWait:
 				res, err = e.execStmtInAbortedTxn(stmt, txnState, planMaker)
 			case CommitWait:
@@ -1034,8 +1038,7 @@ func (e *Executor) execStmtInCommitWaitTxn(
 // firstInTxn: set for the first statement in a transaction. Used
 //  so that nested BEGIN statements are caught.
 // stmtTimestamp: Used as the statement_timestamp().
-// isAutomaticRetry: A boolean that is set for retries so that we don't double
-// count in metrics.
+// automaticRetryCount: increases with each retry; 0 for the first attempt.
 //
 // Returns:
 // - a Result
@@ -1046,9 +1049,8 @@ func (e *Executor) execStmtInOpenTxn(
 	implicitTxn bool,
 	firstInTxn bool,
 	txnState *txnState,
-	isAutomaticRetry bool,
+	automaticRetryCount int,
 ) (Result, error) {
-	tStart := timeutil.Now()
 	if txnState.State != Open {
 		panic("execStmtInOpenTxn called outside of an open txn")
 	}
@@ -1056,14 +1058,15 @@ func (e *Executor) execStmtInOpenTxn(
 		panic("execStmtInOpenTxn called with a txn not set on the planner")
 	}
 
-	planMaker.evalCtx.SetTxnTimestamp(txnState.sqlTimestamp)
-	planMaker.evalCtx.SetStmtTimestamp(e.cfg.Clock.PhysicalTime())
-
 	session := planMaker.session
 	log.Eventf(session.context, "%s", stmt)
 
+	session.phaseTimes[sessionStartExecStmt] = timeutil.Now()
+	planMaker.evalCtx.SetTxnTimestamp(txnState.sqlTimestamp)
+	planMaker.evalCtx.SetStmtTimestamp(e.cfg.Clock.PhysicalTime())
+
 	// Do not double count automatically retried transactions.
-	if !isAutomaticRetry {
+	if automaticRetryCount == 0 {
 		e.updateStmtCounts(stmt)
 	}
 	switch s := stmt.(type) {
@@ -1168,7 +1171,7 @@ func (e *Executor) execStmtInOpenTxn(
 	}
 
 	autoCommit := implicitTxn && !e.cfg.TestingKnobs.DisableAutoCommit
-	result, err := e.execStmt(stmt, planMaker, autoCommit, isAutomaticRetry, tStart)
+	result, err := e.execStmt(stmt, planMaker, autoCommit, automaticRetryCount)
 	if err != nil {
 		if result.Rows != nil {
 			result.Rows.Close(session.Ctx())
@@ -1378,13 +1381,14 @@ func (e *Executor) shouldUseDistSQL(planMaker *planner, plan planNode) (bool, er
 // The current transaction might have been committed/rolled back when this returns.
 // The caller closes result.Rows (even in error cases).
 func (e *Executor) execStmt(
-	stmt parser.Statement,
-	planMaker *planner,
-	autoCommit bool,
-	isAutomaticRetry bool,
-	tStart time.Time,
+	stmt parser.Statement, planMaker *planner, autoCommit bool, automaticRetryCount int,
 ) (Result, error) {
-	plan, err := planMaker.makePlan(planMaker.session.Ctx(), stmt, autoCommit)
+	session := planMaker.session
+
+	session.phaseTimes[sessionStartLogicalPlan] = timeutil.Now()
+	plan, err := planMaker.makePlan(session.Ctx(), stmt, autoCommit)
+	session.phaseTimes[sessionEndLogicalPlan] = timeutil.Now()
+
 	if err != nil {
 		return Result{}, err
 	}
@@ -1409,21 +1413,18 @@ func (e *Executor) execStmt(
 	if err != nil {
 		return result, err
 	}
+
+	session.phaseTimes[sessionStartExecStmt] = timeutil.Now()
 	if useDistSQL {
-		if !isAutomaticRetry {
-			switch stmt.(type) {
-			case *parser.Select:
-				e.DistSQLSelectCount.Inc(1)
-			}
-		}
 		err = e.execDistSQL(planMaker, plan, &result)
-		execDuration := timeutil.Since(tStart).Nanoseconds()
-		e.DistSQLExecLatency.RecordValue(execDuration)
 	} else {
 		err = e.execClassic(planMaker, plan, &result)
-		execDuration := timeutil.Since(tStart).Nanoseconds()
-		e.SQLExecLatency.RecordValue(execDuration)
 	}
+	session.phaseTimes[sessionEndExecStmt] = timeutil.Now()
+	e.recordStatementSummary(
+		session.Ctx(), stmt, &session.phaseTimes, useDistSQL, automaticRetryCount, result, err,
+	)
+
 	return result, err
 }
 

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -1,0 +1,144 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+package sql
+
+import (
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// SQL execution is separated in 3+ phases:
+// - parse/prepare
+// - plan
+// - run
+//
+// The commonly used term "execution latency" encompasses this entire
+// process. However for the purpose of analyzing / optimizing
+// individual parts of the SQL execution engine, it is useful to
+// separate the durations of these individual phases. The code below
+// does this.
+
+// sessionPhase is used to index the Session.phaseTimes array.
+type sessionPhase int
+
+const (
+	// When the session is created (pgwire). Used to compute
+	// the session age.
+	sessionInit sessionPhase = iota
+
+	// When a batch of SQL code is received in pgwire.
+	// Used to compute the batch age.
+	sessionStartBatch
+
+	// Executor phases.
+	sessionStartParse
+	sessionEndParse
+	sessionStartLogicalPlan
+	sessionEndLogicalPlan
+	sessionStartExecStmt
+	sessionEndExecStmt
+
+	// sessionNumPhases must be listed last so that it can be used to
+	// define arrays sufficiently large to hold all the other values.
+	sessionNumPhases
+)
+
+// phaseTimes is the type of the session.phaseTimes array.
+type phaseTimes [sessionNumPhases]time.Time
+
+// recordStatementSummery gathers various details pertaining to the
+// last executed statement/query and performs the associated
+// accounting.
+// - phaseTimes are the timestamps at various stages of processing,
+//   see the comment above for details.
+// - distSQLUsed reports whether the query was distributed.
+// - automaticRetryCount is the count of implicit txn retries
+//   so far.
+// - result is the result set computed by the query/statement.
+// - err is the error encountered, if any.
+func (e *Executor) recordStatementSummary(
+	ctx context.Context,
+	stmt parser.Statement,
+	phaseTimes *phaseTimes,
+	distSQLUsed bool,
+	automaticRetryCount int,
+	result Result,
+	err error,
+) {
+
+	// Compute the run latency. This is always recorded in the
+	// server metrics.
+	runLatRaw := phaseTimes[sessionEndExecStmt].Sub(phaseTimes[sessionStartExecStmt])
+
+	if automaticRetryCount == 0 {
+		if distSQLUsed {
+			if _, ok := stmt.(*parser.Select); ok {
+				e.DistSQLSelectCount.Inc(1)
+			}
+			e.DistSQLExecLatency.RecordValue(runLatRaw.Nanoseconds())
+		} else {
+			e.SQLExecLatency.RecordValue(runLatRaw.Nanoseconds())
+		}
+	}
+
+	// Conditionally report the other metrics.
+	// TODO(knz) #13968.
+	if log.V(2) {
+		runLat := runLatRaw.Seconds()
+
+		parseLat := phaseTimes[sessionEndParse].
+			Sub(phaseTimes[sessionStartParse]).Seconds()
+		planLat := phaseTimes[sessionEndLogicalPlan].
+			Sub(phaseTimes[sessionStartLogicalPlan]).Seconds()
+		// execution latency: start to parse to end of run
+		execLat := phaseTimes[sessionEndExecStmt].
+			Sub(phaseTimes[sessionStartParse]).Seconds()
+
+		// processing latency: the computing work towards SQL results
+		processingLat := parseLat + planLat + runLat
+		// overhead latency: txn/retry management, error checking, etc
+		execOverhead := execLat - processingLat
+
+		// ages since significant epochs
+		batchAge := phaseTimes[sessionEndExecStmt].
+			Sub(phaseTimes[sessionStartBatch]).Seconds()
+		sessionAge := phaseTimes[sessionEndExecStmt].
+			Sub(phaseTimes[sessionInit]).Seconds()
+
+		numRows := result.RowsAffected
+		if result.Type == parser.Rows {
+			numRows = result.Rows.Len()
+		}
+
+		log.Infof(ctx, "query stats: %d rows, %d retries, "+
+			"parse %.2fµs (%.1f%%), "+
+			"plan %.2fµs (%.1f%%), "+
+			"run %.2fµs (%.1f%%), "+
+			"overhead %.2fµs (%.1f%%), "+
+			"batch age %.3fms, session age %.4fs",
+			numRows, automaticRetryCount,
+			parseLat*1e6, 100*parseLat/execLat,
+			planLat*1e6, 100*planLat/execLat,
+			runLat*1e6, 100*runLat/execLat,
+			execOverhead*1e6, 100*execOverhead/execLat,
+			batchAge*1000, sessionAge,
+		)
+	}
+}

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -153,6 +153,10 @@ type Session struct {
 	// memMetrics track memory usage by SQL execution.
 	memMetrics *MemoryMetrics
 
+	// phaseTimes contains helps measure the time spent in each phase of
+	// SQL execution. See executor_statement_metrics.go for details.
+	phaseTimes phaseTimes
+
 	// noCopy is placed here to guarantee that Session objects are not
 	// copied.
 	noCopy util.NoCopy
@@ -180,6 +184,7 @@ func NewSession(
 		virtualSchemas:  e.virtualSchemas,
 		memMetrics:      memMetrics,
 	}
+	s.phaseTimes[sessionInit] = timeutil.Now()
 	cfg, cache := e.getSystemConfig()
 	s.planner = planner{
 		leaseMgr:       e.cfg.LeaseManager,


### PR DESCRIPTION
This patch samples the time at different stages of SQL execution.
The new latencies are reported at verbosity level 2 or above.

Example output, issuing a 4-way cross join from the CLI:
```
I170310 20:30:01.590757 302 sql/query_stats.go:71  [client=127.0.0.1:59248,user=root,n1] query stats: 625 rows, 0 retries, parse 124.76µs (2.9%), plan 149.59µs (3.5%), run 3945.72µs (91.4%), overhead 98.18µs (2.27%), batch age 4.322ms, session age 122.1948s
I170310 20:30:01.649721 302 sql/query_stats.go:71  [client=127.0.0.1:59248,user=root,n1] query stats: 1 rows, 0 retries, parse 5.98µs (6.5%), plan 52.99µs (57.5%), run 6.91µs (7.5%), overhead 26.28µs (28.51%), batch age 0.093ms, session age 122.2538s
```

Fixes #14019.
First step towards #13968.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14080)
<!-- Reviewable:end -->
