### PR TITLE
log: add --show-logs to print logs

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -268,6 +268,8 @@ func init() {
 			flag.Hidden = true
 		} else if flag.Name == "no-redirect-stderr" {
 			flag.Hidden = true
+		} else if flag.Name == "show-logs" {
+			flag.Hidden = true
 		}
 		pf.AddFlag(flag)
 	})

--- a/pkg/sql/logic_test.go
+++ b/pkg/sql/logic_test.go
@@ -166,9 +166,6 @@ import (
 //                "FAIL" to indicate an unexpected/undesired test
 //                failure.
 //
-// -show-logs     shows logs (by default, logs go to temporary files which are
-//                kept only for tests that fail)
-//
 // -error-summary produces a report organized by error message
 //                of all queries that have caused that error.  Useful
 //                with -allow-prepare-fail and/or -flex-types.
@@ -202,8 +199,6 @@ var (
 	// Output parameters
 	showSQL = flag.Bool("show-sql", false,
 		"print the individual SQL statement/queries before processing")
-	showLogs = flag.Bool("show-logs", false,
-		"print logs instead of saving them in files")
 	printErrorSummary = flag.Bool("error-summary", false,
 		"print a per-error summary of failing queries at the end of testing, when -allow-prepare-fail is set")
 	fullMessages = flag.Bool("full-messages", false,
@@ -573,9 +568,7 @@ func (t *logicTest) setUser(user string) func() {
 }
 
 func (t *logicTest) setup() {
-	if !*showLogs {
-		t.logScope = log.Scope(t.t, "TestLogic")
-	}
+	t.logScope = log.Scope(t.t, "TestLogic")
 
 	// TODO(pmattis): Add a flag to make it easy to run the tests against a local
 	// MySQL or Postgres instance.

--- a/pkg/util/log/flags.go
+++ b/pkg/util/log/flags.go
@@ -24,7 +24,7 @@ import (
 
 func init() {
 	logflags.InitFlags(&logging.mu, &logging.toStderr,
-		&logDir, &logging.nocolor, &logging.verbosity,
+		&logDir, &showLogs, &logging.nocolor, &logging.verbosity,
 		&logging.vmodule, &logging.traceLocation)
 	// We define this flag here because stderrThreshold has the type Severity
 	// which we can't pass to logflags without creating an import cycle.

--- a/pkg/util/log/logflags/logflags.go
+++ b/pkg/util/log/logflags/logflags.go
@@ -66,6 +66,7 @@ const (
 	VModuleName         = "vmodule"
 	LogBacktraceAtName  = "log-backtrace-at"
 	LogDirName          = "log-dir"
+	ShowLogs            = "show-logs"
 )
 
 // InitFlags creates logging flags which update the given variables. The passed mutex is
@@ -74,6 +75,7 @@ func InitFlags(
 	mu sync.Locker,
 	toStderr *bool,
 	logDir flag.Value,
+	showLogs *bool,
 	nocolor *bool,
 	verbosity, vmodule, traceLocation flag.Value,
 ) {
@@ -84,4 +86,5 @@ func InitFlags(
 	flag.Var(vmodule, VModuleName, "comma-separated list of pattern=N settings for file-filtered logging")
 	flag.Var(traceLocation, LogBacktraceAtName, "when logging hits line file:N, emit a stack trace")
 	flag.Var(logDir, LogDirName, "if non-empty, write log files in this directory")
+	flag.BoolVar(showLogs, ShowLogs, *showLogs, "print logs instead of saving them in files")
 }

--- a/pkg/util/log/test_log_scope.go
+++ b/pkg/util/log/test_log_scope.go
@@ -43,11 +43,16 @@ type tShim interface {
 	Errorf(fmt string, args ...interface{})
 }
 
+var showLogs bool
+
 // Scope creates a TestLogScope which corresponds to the lifetime of a
 // logging directory. If testName is empty, the logging directory is
 // named after the caller of Scope, up `skip` caller levels. It also
 // disables logging to stderr for severity levels below ERROR.
 func Scope(t tShim, testName string) TestLogScope {
+	if showLogs {
+		return TestLogScope("")
+	}
 	if testName == "" {
 		testName = "logUnknown"
 		if _, _, f := caller.Lookup(1); f != "" {


### PR DESCRIPTION
tests that use log.Scope() can be run using --show-logs
to print the logs to the terminal.

The problem with this PR is that it exposes the --show-logs flag in the cockroach binary. Is there some way to not do that?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14081)
<!-- Reviewable:end -->
