### PR TITLE
Gossip: avoid using any self-referential resolvers

### DIFF
--- a/pkg/gossip/simulation/network.go
+++ b/pkg/gossip/simulation/network.go
@@ -43,10 +43,11 @@ import (
 // about the node's gossip instance, network address, and underlying
 // server.
 type Node struct {
-	Gossip   *gossip.Gossip
-	Server   *grpc.Server
-	Listener net.Listener
-	Registry *metric.Registry
+	Gossip    *gossip.Gossip
+	Server    *grpc.Server
+	Listener  net.Listener
+	Registry  *metric.Registry
+	Resolvers []resolver.Resolver
 }
 
 // Addr returns the address of the connected listener.
@@ -95,7 +96,7 @@ func NewNetwork(stopper *stop.Stopper, nodeCount int, createResolvers bool) *Net
 			if err != nil {
 				log.Fatalf(context.TODO(), "bad gossip address %s: %s", n.Nodes[0].Addr(), err)
 			}
-			node.Gossip.SetResolvers([]resolver.Resolver{r})
+			node.Resolvers = []resolver.Resolver{r}
 		}
 	}
 	return n
@@ -109,7 +110,7 @@ func (n *Network) CreateNode() (*Node, error) {
 		return nil, err
 	}
 	node := &Node{Server: server, Listener: ln, Registry: metric.NewRegistry()}
-	node.Gossip = gossip.NewTest(0, n.rpcContext, server, nil, n.Stopper, node.Registry)
+	node.Gossip = gossip.NewTest(0, n.rpcContext, server, n.Stopper, node.Registry)
 	n.Stopper.RunWorker(context.TODO(), func(context.Context) {
 		<-n.Stopper.ShouldQuiesce()
 		netutil.FatalIfUnexpected(ln.Close())
@@ -124,7 +125,7 @@ func (n *Network) CreateNode() (*Node, error) {
 // StartNode initializes a gossip instance for the simulation node and
 // starts it.
 func (n *Network) StartNode(node *Node) error {
-	node.Gossip.Start(node.Addr())
+	node.Gossip.Start(node.Addr(), node.Resolvers)
 	node.Gossip.EnableSimulationCycler(true)
 	n.nodeIDAllocator++
 	node.Gossip.NodeID.Set(context.TODO(), n.nodeIDAllocator)

--- a/pkg/gossip/storage_test.go
+++ b/pkg/gossip/storage_test.go
@@ -170,7 +170,7 @@ func TestGossipStorage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	node.Gossip.SetResolvers([]resolver.Resolver{r})
+	node.Resolvers = []resolver.Resolver{r}
 	if err := network.StartNode(node); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -585,7 +585,7 @@ func makeGossip(t *testing.T, stopper *stop.Stopper) (*gossip.Gossip, *hlc.Clock
 	server := rpc.NewServer(rpcContext)
 
 	const nodeID = 1
-	g := gossip.NewTest(nodeID, rpcContext, server, nil, stopper, metric.NewRegistry())
+	g := gossip.NewTest(nodeID, rpcContext, server, stopper, metric.NewRegistry())
 	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{
 		NodeID:  nodeID,
 		Address: util.MakeUnresolvedAddr("tcp", "neverused:9999"),

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -357,18 +357,25 @@ func (n *Node) initNodeID(id roachpb.NodeID) {
 // start starts the node by registering the storage instance for the
 // RPC service "Node" and initializing stores for each specified
 // engine. Launches periodic store gossiping in a goroutine.
+//
+// The canBootstrap parameter indicates whether this node is eligible
+// to bootstrap a new cluster. The -join flag must be empty.
 func (n *Node) start(
 	ctx context.Context,
 	addr net.Addr,
 	engines []engine.Engine,
 	attrs roachpb.Attributes,
 	locality roachpb.Locality,
+	canBootstrap bool,
 ) error {
 	n.initDescriptor(addr, attrs, locality)
 
 	// Initialize stores, including bootstrapping new ones.
 	if err := n.initStores(ctx, engines, n.stopper, false); err != nil {
 		if err == errNeedsBootstrap {
+			if !canBootstrap {
+				return errCannotJoinSelf
+			}
 			n.initialBoot = true
 			// This node has no initialized stores and no way to connect to
 			// an existing cluster, so we bootstrap it.
@@ -460,17 +467,8 @@ func (n *Node) initStores(
 
 	// If there are no initialized stores and no gossip resolvers,
 	// bootstrap this node as the seed of a new cluster.
-	if n.stores.GetStoreCount() == 0 {
-		resolvers := n.storeCfg.Gossip.GetResolvers()
-		// Check for the case of uninitialized node having only itself specified as join host.
-		switch len(resolvers) {
-		case 0:
-			return errNeedsBootstrap
-		case 1:
-			if resolvers[0].Addr() == n.Descriptor.Address.String() {
-				return errCannotJoinSelf
-			}
-		}
+	if n.stores.GetStoreCount() == 0 && len(n.storeCfg.Gossip.GetResolvers()) == 0 {
+		return errNeedsBootstrap
 	}
 
 	// Verify all initialized stores agree on cluster and node IDs.

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -73,7 +73,6 @@ func createTestNode(
 		0,
 		nodeRPCContext,
 		grpcServer,
-		nil,
 		stopper,
 		metric.NewRegistry(),
 	)
@@ -131,8 +130,12 @@ func createTestNode(
 		if err != nil {
 			t.Fatal(err)
 		}
-		cfg.Gossip.SetResolvers([]resolver.Resolver{r})
-		cfg.Gossip.Start(ln.Addr())
+		serverCfg := MakeConfig()
+		serverCfg.GossipBootstrapResolvers = []resolver.Resolver{r}
+		filtered := serverCfg.FilterGossipBootstrapResolvers(
+			context.Background(), ln.Addr(), ln.Addr(),
+		)
+		cfg.Gossip.Start(ln.Addr(), filtered)
 	}
 	return grpcServer, ln.Addr(), cfg.Clock, node, stopper
 }
@@ -145,8 +148,9 @@ func createAndStartTestNode(
 	locality roachpb.Locality,
 	t *testing.T,
 ) (*grpc.Server, net.Addr, *Node, *stop.Stopper) {
+	canBootstrap := gossipBS == nil
 	grpcServer, addr, _, node, stopper := createTestNode(addr, engines, gossipBS, t)
-	if err := node.start(context.Background(), addr, engines, roachpb.Attributes{}, locality); err != nil {
+	if err := node.start(context.Background(), addr, engines, roachpb.Attributes{}, locality, canBootstrap); err != nil {
 		t.Fatal(err)
 	}
 	if err := WaitForInitialSplits(node.storeCfg.DB); err != nil {
@@ -341,7 +345,7 @@ func TestNodeJoinSelf(t *testing.T) {
 	engines := []engine.Engine{e}
 	_, addr, _, node, stopper := createTestNode(util.TestAddr, engines, util.TestAddr, t)
 	defer stopper.Stop(context.TODO())
-	err := node.start(context.Background(), addr, engines, roachpb.Attributes{}, roachpb.Locality{})
+	err := node.start(context.Background(), addr, engines, roachpb.Attributes{}, roachpb.Locality{}, false)
 	if err != errCannotJoinSelf {
 		t.Fatalf("expected err %s; got %s", errCannotJoinSelf, err)
 	}
@@ -373,7 +377,9 @@ func TestCorruptedClusterID(t *testing.T) {
 	engines := []engine.Engine{e}
 	_, serverAddr, _, node, stopper := createTestNode(util.TestAddr, engines, nil, t)
 	stopper.Stop(context.TODO())
-	if err := node.start(context.Background(), serverAddr, engines, roachpb.Attributes{}, roachpb.Locality{}); !testutils.IsError(err, "unidentified store") {
+	if err := node.start(
+		context.Background(), serverAddr, engines, roachpb.Attributes{}, roachpb.Locality{}, true,
+	); !testutils.IsError(err, "unidentified store") {
 		t.Errorf("unexpected error %v", err)
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -172,7 +172,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		&s.nodeIDContainer,
 		s.rpcContext,
 		s.grpc,
-		s.cfg.GossipBootstrapResolvers,
 		s.stopper,
 		s.registry,
 	)
@@ -627,7 +626,10 @@ func (s *Server) Start(ctx context.Context) error {
 	// apply it for all web endpoints.
 	s.mux.HandleFunc(debugEndpoint, http.HandlerFunc(handleDebug))
 
-	s.gossip.Start(unresolvedAdvertAddr)
+	// Filter the gossip bootstrap resolvers based on the listen and
+	// advertise addresses.
+	filtered := s.cfg.FilterGossipBootstrapResolvers(ctx, unresolvedListenAddr, unresolvedAdvertAddr)
+	s.gossip.Start(unresolvedAdvertAddr, filtered)
 	log.Event(ctx, "started gossip")
 
 	s.engines, err = s.cfg.CreateEngines()
@@ -679,6 +681,11 @@ func (s *Server) Start(ctx context.Context) error {
 		s.engines,
 		s.cfg.NodeAttributes,
 		s.cfg.Locality,
+		// If the _unfiltered_ list of hosts from the --join flag is
+		// empty, then this node can bootstrap a new cluster. We disallow
+		// this if this node is being started with itself specified as a
+		// --join host, because that's too likely to be operator error.
+		len(s.cfg.GossipBootstrapResolvers) == 0, /* canBootstrap */
 	)
 	if err != nil {
 		return err

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -2124,7 +2124,7 @@ func Example_rebalancing() {
 		stopper,
 	)
 	server := rpc.NewServer(rpcContext) // never started
-	g := gossip.NewTest(1, rpcContext, server, nil, stopper, metric.NewRegistry())
+	g := gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry())
 	// Deterministic must be set as this test is comparing the exact output
 	// after each rebalance.
 	sp := NewStorePool(

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -120,7 +120,7 @@ func createTestStoreWithEngine(
 	nodeDesc := &roachpb.NodeDescriptor{NodeID: 1}
 	server := rpc.NewServer(rpcContext) // never started
 	storeCfg.Gossip = gossip.NewTest(
-		nodeDesc.NodeID, rpcContext, server, nil, stopper, metric.NewRegistry(),
+		nodeDesc.NodeID, rpcContext, server, stopper, metric.NewRegistry(),
 	)
 	storeCfg.ScanMaxIdleTime = 1 * time.Second
 	stores := storage.NewStores(ac, storeCfg.Clock)
@@ -704,7 +704,6 @@ func (m *multiTestContext) addStore(idx int) {
 		roachpb.NodeID(idx+1),
 		m.rpcContext,
 		grpcServer,
-		resolvers,
 		m.transportStopper,
 		metric.NewRegistry(),
 	)
@@ -785,7 +784,7 @@ func (m *multiTestContext) addStore(idx int) {
 		m.t.Fatal(err)
 	}
 
-	m.gossips[idx].Start(ln.Addr())
+	m.gossips[idx].Start(ln.Addr(), resolvers)
 
 	if err := store.Start(context.Background(), stopper); err != nil {
 		m.t.Fatal(err)

--- a/pkg/storage/raft_transport_test.go
+++ b/pkg/storage/raft_transport_test.go
@@ -119,7 +119,7 @@ func newRaftTransportTestContext(t testing.TB) *raftTransportTestContext {
 	)
 	server := rpc.NewServer(rttc.nodeRPCContext) // never started
 	rttc.gossip = gossip.NewTest(
-		1, rttc.nodeRPCContext, server, nil, rttc.stopper, metric.NewRegistry(),
+		1, rttc.nodeRPCContext, server, rttc.stopper, metric.NewRegistry(),
 	)
 	return rttc
 }

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -147,7 +147,7 @@ func (tc *testContext) StartWithStoreConfig(t testing.TB, stopper *stop.Stopper,
 	if tc.gossip == nil {
 		rpcContext := rpc.NewContext(cfg.AmbientCtx, &base.Config{Insecure: true}, cfg.Clock, stopper)
 		server := rpc.NewServer(rpcContext) // never started
-		tc.gossip = gossip.NewTest(1, rpcContext, server, nil, stopper, metric.NewRegistry())
+		tc.gossip = gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry())
 	}
 	if tc.engine == nil {
 		tc.engine = engine.NewInMem(roachpb.Attributes{Attrs: []string{"dc1", "mem"}}, 1<<20)

--- a/pkg/storage/store_pool_test.go
+++ b/pkg/storage/store_pool_test.go
@@ -95,7 +95,7 @@ func createTestStorePool(
 	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
 	rpcContext := rpc.NewContext(log.AmbientContext{}, &base.Config{Insecure: true}, clock, stopper)
 	server := rpc.NewServer(rpcContext) // never started
-	g := gossip.NewTest(1, rpcContext, server, nil, stopper, metric.NewRegistry())
+	g := gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry())
 	mnl := newMockNodeLiveness(defaultNodeStatus)
 	storePool := NewStorePool(
 		log.AmbientContext{},

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -122,7 +122,7 @@ func createTestStoreWithoutStart(t testing.TB, stopper *stop.Stopper, cfg *Store
 
 	rpcContext := rpc.NewContext(log.AmbientContext{}, &base.Config{Insecure: true}, cfg.Clock, stopper)
 	server := rpc.NewServer(rpcContext) // never started
-	cfg.Gossip = gossip.NewTest(1, rpcContext, server, nil, stopper, metric.NewRegistry())
+	cfg.Gossip = gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry())
 	cfg.StorePool = NewTestStorePool(*cfg)
 	// Many tests using this test harness (as opposed to higher-level
 	// ones like multiTestContext or TestServer) want to micro-manage

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -98,7 +98,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initSende
 	ltc.Stopper = stop.NewStopper()
 	rpcContext := rpc.NewContext(ambient, baseCtx, ltc.Clock, ltc.Stopper)
 	server := rpc.NewServer(rpcContext) // never started
-	ltc.Gossip = gossip.New(ambient, nc, rpcContext, server, nil, ltc.Stopper, metric.NewRegistry())
+	ltc.Gossip = gossip.New(ambient, nc, rpcContext, server, ltc.Stopper, metric.NewRegistry())
 	ltc.Eng = engine.NewInMem(roachpb.Attributes{}, 50<<20)
 	ltc.Stopper.AddCloser(ltc.Eng)
 


### PR DESCRIPTION
Resolvers that point back to the node itself can end up being very
confusing when starting a cluster with bad --join command line flags
specified.

Fixes #9625

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14091)
<!-- Reviewable:end -->
