### PR TITLE
sql: set up foundations for per-application statistics

### DIFF
--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -1,0 +1,65 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+package sql
+
+import "github.com/cockroachdb/cockroach/pkg/util/syncutil"
+
+// appStats holds per-application statistics.
+type appStats struct {
+	syncutil.Mutex
+
+	stmtCount int
+}
+
+func (a *appStats) recordStatement() {
+	if a == nil {
+		return
+	}
+	a.Lock()
+	a.stmtCount++
+	a.Unlock()
+}
+
+// sqlStats carries per-application statistics for all applications on
+// each node. It hangs off Executor.
+type sqlStats struct {
+	syncutil.Mutex
+
+	// apps is the container for all the per-application statistics
+	// objects.
+	apps map[string]*appStats
+}
+
+// resetApplicationName initializes both Session.ApplicationName and
+// the cached pointer to per-application statistics. It is meant to be
+// used upon session initialization and upon SET APPLICATION_NAME.
+func (s *Session) resetApplicationName(appName string) {
+	s.ApplicationName = appName
+	if s.planner.sqlStats != nil {
+		s.appStats = s.planner.sqlStats.getStatsForApplication(appName)
+	}
+}
+
+func (s *sqlStats) getStatsForApplication(appName string) *appStats {
+	s.Lock()
+	defer s.Unlock()
+	if a, ok := s.apps[appName]; ok {
+		return a
+	}
+	a := &appStats{}
+	s.apps[appName] = a
+	return a
+}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -47,6 +47,7 @@ type planner struct {
 	evalCtx  parser.EvalContext
 	leases   []*LeaseState
 	leaseMgr *LeaseManager
+	sqlStats *sqlStats
 
 	distSQLPlanner *distSQLPlanner
 

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -71,7 +71,7 @@ type Session struct {
 
 	// ApplicationName is the name of the application running the
 	// current session. This can be used for logging and per-application
-	// statistics.
+	// statistics. Change via resetApplicationName().
 	ApplicationName string
 	// Database indicates the "current" database for the purpose of
 	// resolving names. See searchAndQualifyDatabase() for details.
@@ -152,6 +152,8 @@ type Session struct {
 
 	// memMetrics track memory usage by SQL execution.
 	memMetrics *MemoryMetrics
+	// appStats track per-application SQL usage statistics.
+	appStats *appStats
 
 	// phaseTimes contains helps measure the time spent in each phase of
 	// SQL execution. See executor_statement_metrics.go for details.
@@ -176,24 +178,25 @@ func NewSession(
 ) *Session {
 	ctx = e.AnnotateCtx(ctx)
 	s := &Session{
-		ApplicationName: args.ApplicationName,
-		Database:        args.Database,
-		SearchPath:      parser.SearchPath{"pg_catalog"},
-		User:            args.User,
-		Location:        time.UTC,
-		virtualSchemas:  e.virtualSchemas,
-		memMetrics:      memMetrics,
+		Database:       args.Database,
+		SearchPath:     parser.SearchPath{"pg_catalog"},
+		User:           args.User,
+		Location:       time.UTC,
+		virtualSchemas: e.virtualSchemas,
+		memMetrics:     memMetrics,
 	}
 	s.phaseTimes[sessionInit] = timeutil.Now()
 	cfg, cache := e.getSystemConfig()
 	s.planner = planner{
 		leaseMgr:       e.cfg.LeaseManager,
+		sqlStats:       &e.sqlStats,
 		systemConfig:   cfg,
 		databaseCache:  cache,
 		session:        s,
 		execCfg:        &e.cfg,
 		distSQLPlanner: e.distSQLPlanner,
 	}
+	s.resetApplicationName(args.ApplicationName)
 	s.PreparedStatements = makePreparedStatements(s)
 	s.PreparedPortals = makePreparedPortals(s)
 

--- a/pkg/sql/set.go
+++ b/pkg/sql/set.go
@@ -127,7 +127,7 @@ func (p *planner) Set(n *parser.Set) (planNode, error) {
 		if err != nil {
 			return nil, err
 		}
-		p.session.ApplicationName = s
+		p.session.resetApplicationName(s)
 
 	case `CLIENT_ENCODING`:
 		// See https://www.postgresql.org/docs/9.6/static/multibyte.html

--- a/pkg/sql/testdata/crdb_internal
+++ b/pkg/sql/testdata/crdb_internal
@@ -55,3 +55,21 @@ SELECT NAME from crdb_internal.tables WHERE DATABASE_NAME = 'testdb'
 ----
 foo
 "\'
+
+# Check that app_stats report per application
+
+statement ok
+SET APPLICATION_NAME = hello; SELECT 1
+
+statement ok
+SET APPLICATION_NAME = world; SELECT 2
+
+query B
+SELECT statement_count > 0 FROM crdb_internal.app_stats WHERE APPLICATION_NAME IN ('hello', 'world')
+----
+true
+true
+
+# reset for other tests.
+statement ok
+SET APPLICATION_NAME = ''

--- a/pkg/sql/testdata/information_schema
+++ b/pkg/sql/testdata/information_schema
@@ -208,6 +208,7 @@ CREATE VIEW other_db.abc AS SELECT i from other_db.xyz
 query T
 SELECT table_name FROM information_schema.tables
 ----
+app_stats
 leases
 schema_changes
 tables
@@ -303,6 +304,7 @@ query TTTTI colnames
 SELECT * FROM information_schema.tables
 ----
 TABLE_CATALOG  TABLE_SCHEMA        TABLE_NAME         TABLE_TYPE   VERSION
+def            crdb_internal       app_stats          SYSTEM VIEW  1
 def            crdb_internal       leases             SYSTEM VIEW  1
 def            crdb_internal       schema_changes     SYSTEM VIEW  1
 def            crdb_internal       tables             SYSTEM VIEW  1


### PR DESCRIPTION
This patch instruments the SQL executor with a data structure aimed at
collecting per-application statistics, then exposes this data
structure via a new virtual table `crdb_internal.app_stats`.

An "application" is identified by setting the session variable
"application_name".

Each application has a separate instance of a new struct `appStats`.
The pointer to this struct is cached in the session object and updated
only when the application name is modified.

However since there can be multiple sessions updating a single
`appStats` instance concurrently, its fields must be properly
synchronized.

The separation of statistics per application is motivated both by a
user-expressed interest in separating statistics per application, and
by a performance concern -- reducing contention on the mutex on the
map holding all the appStats instances.

Needed for #13968.

(This PR is based off #14089 and will be rebased once #14089 merges.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14092)
<!-- Reviewable:end -->
