### PR TITLE
distsqlrun: remove redundant Close()

### DIFF
--- a/pkg/sql/distsqlrun/flow_registry.go
+++ b/pkg/sql/distsqlrun/flow_registry.go
@@ -270,10 +270,6 @@ func (fr *flowRegistry) finishInboundStreamLocked(is *inboundStreamInfo) {
 		panic("double finish")
 	}
 
-	if is.timedOut {
-		is.receiver.Close(errors.Errorf("inbound stream timed out"))
-	}
-
 	is.finished = true
 	is.waitGroup.Done()
 }


### PR DESCRIPTION
Close() is already called when timedOut is set.

fixes #13989

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14103)
<!-- Reviewable:end -->
