### PR TITLE
sql: regclass casts use the schema search path

### DIFF
--- a/docs/RFCS/table_descriptor_lease.md
+++ b/docs/RFCS/table_descriptor_lease.md
@@ -62,7 +62,7 @@ following steps:
 * Wait for the table descriptor change to propagate to all nodes in
   the cluster and all uses of the previous version to finish.
 
-This RFC is focused on how to wait for the table descriptor change
+This RFC is focused on how to wait for the table descriptor change to
 propagate to all nodes in the cluster. More accurately, it is focused
 on how to determine when the previous version of the descriptor is no
 longer in use. Additionally, we need mechanisms to ensure that

--- a/pkg/sql/testdata/pgoidtype
+++ b/pkg/sql/testdata/pgoidtype
@@ -101,7 +101,7 @@ numeric  numeric
 query error type 'foo.' does not exist
 SELECT 'foo.'::REGTYPE
 
-query error relation 'blah' does not exist
+query error table "blah" does not exist
 SELECT 'blah'::REGCLASS
 
 query error unknown function: blah\(\)
@@ -132,7 +132,7 @@ pg_constraint  402060402
 ## Test visibility of pg_* via oid casts.
 
 statement ok
-CREATE TABLE a (id INT)
+CREATE TABLE a (id INT PRIMARY KEY)
 
 query T
 SELECT relname from pg_class where oid='a'::regclass
@@ -141,6 +141,9 @@ a
 
 # a non-root user with sufficient permissions can get the OID of a table from
 # the current database
+
+statement ok
+GRANT ALL ON DATABASE test TO testuser
 
 statement ok
 GRANT SELECT ON test.* TO testuser
@@ -152,8 +155,6 @@ SELECT relname from pg_class where oid='a'::regclass
 ----
 a
 
-## a non-root user can't get the OID of a table from a different database
-
 user root
 
 statement ok
@@ -162,7 +163,57 @@ CREATE DATABASE otherdb
 statement ok
 SET DATABASE = otherdb
 
+## a non-root user can't get the OID of a table from a different database
+
 user testuser
 
-query error relation 'a' does not exist
+query error table "a" does not exist
 SELECT 'a'::regclass
+
+user root
+
+statement ok
+CREATE TABLE a (id INT PRIMARY KEY, foo STRING)
+
+## There is now a table named 'a' in both the database 'otherdb' and the
+## database 'test'. The following query shows that the root user can still
+## determine the OID of the table 'a' by using a regclass cast, despite the
+## fact that the root user has visibility into both of the tables. The 'a' that
+## gets selected should be the 'a' that exists in the current database.
+## See https://github.com/cockroachdb/cockroach/issues/13695
+
+query OI
+SELECT relname, relnatts FROM pg_class WHERE oid='a'::regclass
+----
+a  2
+
+statement ok
+SET DATABASE = test
+
+query OI
+SELECT relname, relnatts FROM pg_class WHERE oid='a'::regclass
+----
+a  1
+
+statement ok
+CREATE DATABASE thirddb
+
+statement ok
+SET DATABASE = thirddb
+
+# Ensure that if there's no such table in the search path, but it still exists
+# in another database, the query fails.
+
+query error table "a" does not exist
+SELECT relname, relnatts FROM pg_class WHERE oid='a'::regclass
+
+statement ok
+SET SEARCH_PATH = otherdb,test
+
+# Ensure that the search path is respected properly: the table named "a" from
+# otherdb should be selected.
+
+query OI
+SELECT relname, relnatts FROM pg_class WHERE oid='a'::regclass
+----
+a  2


### PR DESCRIPTION
Previously, casting a string to `regclass` would not respect the schema
search path or current database as a filter to resolve the input table
name. This led to various anomalies, such as the root user (who has
visibility of all tables across all databases) being unable to
regclass-cast a table whose name is repeated in more than one database.

Now, we normalize and resolve the table name the proper way before
querying pg_catalog, and constrain the results of the pg_catalog query
to only those tables in the resolved database.

Also correct a very minor typo in the table descriptor RFC.

Resolves #13695.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14115)
<!-- Reviewable:end -->
