### PR TITLE
sql: fix a bug causing distsql to not be used on retries

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1409,10 +1409,12 @@ func (e *Executor) execStmt(
 	if err != nil {
 		return result, err
 	}
-	if useDistSQL && !isAutomaticRetry {
-		switch stmt.(type) {
-		case *parser.Select:
-			e.DistSQLSelectCount.Inc(1)
+	if useDistSQL {
+		if !isAutomaticRetry {
+			switch stmt.(type) {
+			case *parser.Select:
+				e.DistSQLSelectCount.Inc(1)
+			}
 		}
 		err = e.execDistSQL(planMaker, plan, &result)
 		execDuration := timeutil.Since(tStart).Nanoseconds()


### PR DESCRIPTION
The erronous condition seems to have been introduced by mistake in
https://reviewable.io/reviews/cockroachdb/cockroach/12299#-KZ2PfBtHBm30NGvjAo0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14116)
<!-- Reviewable:end -->
