### PR TITLE
client: auto-assign db.Txn's transaction timestamp

### DIFF
--- a/pkg/internal/client/db.go
+++ b/pkg/internal/client/db.go
@@ -471,10 +471,14 @@ func (db *DB) Txn(ctx context.Context, retryable func(txn *Txn) error) error {
 	// method. Add a defered cancel.
 	txn := NewTxn(ctx, *db)
 	txn.SetDebugName("unnamed")
-	err := txn.Exec(TxnExecOptions{AutoRetry: true, AutoCommit: true},
-		func(txn *Txn, _ *TxnExecOptions) error {
-			return retryable(txn)
-		})
+	opts := TxnExecOptions{
+		AutoCommit:                 true,
+		AutoRetry:                  true,
+		AssignTimestampImmediately: true,
+	}
+	err := txn.Exec(opts, func(txn *Txn, _ *TxnExecOptions) error {
+		return retryable(txn)
+	})
 	if err != nil {
 		txn.CleanupOnError(err)
 	}


### PR DESCRIPTION
We currently have code that executes a SQL statement inside of a
`db.Txn` callback that depends on the `now()` SQL function. This
function requires that the transaction have its timestamps assigned
before the first KV operation. Thus, it seems reasonable for `db.Txn` to
execute transactions with the `AssignTimestampImmediately` flag set to
true.

Needed for #13933.

/cc @knz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14119)
<!-- Reviewable:end -->
