### PR TITLE
kv: Add more info to slow request log message in DistSender

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -1170,8 +1170,8 @@ func (ds *DistSender) sendToReplicas(
 			}
 
 		case <-slowTimer.C:
-			log.Warningf(ctx, "have been waiting %s sending RPC for batch: %s",
-				base.SlowRequestThreshold, args.Summary())
+			log.Warningf(ctx, "have been waiting %s sending RPC to range %d for batch: %s",
+				base.SlowRequestThreshold, rangeID, args)
 			ds.metrics.SlowRequestsCount.Inc(1)
 			defer ds.metrics.SlowRequestsCount.Dec(1)
 


### PR DESCRIPTION
Inspired by the struggle in #13880. The other three slow request log messages already include additional info, despite this seemingly being the most commonly encountered one.

@petermattis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14121)
<!-- Reviewable:end -->
