### PR TITLE
all: audit context.TODO usage

### DIFF
--- a/pkg/acceptance/cluster/docker.go
+++ b/pkg/acceptance/cluster/docker.go
@@ -81,7 +81,7 @@ func hasImage(ctx context.Context, l *LocalCluster, ref string) bool {
 	name := strings.Split(ref, ":")[0]
 	images, err := l.client.ImageList(ctx, types.ImageListOptions{MatchName: name})
 	if err != nil {
-		log.Fatal(context.TODO(), err)
+		log.Fatal(ctx, err)
 	}
 	for _, image := range images {
 		for _, repoTag := range image.RepoTags {
@@ -93,7 +93,7 @@ func hasImage(ctx context.Context, l *LocalCluster, ref string) bool {
 	}
 	for _, image := range images {
 		for _, tag := range image.RepoTags {
-			log.Infof(context.TODO(), "ImageList %s %s", tag, image.ID)
+			log.Infof(ctx, "ImageList %s %s", tag, image.ID)
 		}
 	}
 	return false
@@ -282,7 +282,7 @@ func (c *Container) Inspect(ctx context.Context) (types.ContainerJSON, error) {
 func (c *Container) Addr(ctx context.Context, port nat.Port) *net.TCPAddr {
 	containerInfo, err := c.Inspect(ctx)
 	if err != nil {
-		log.Error(context.TODO(), err)
+		log.Error(ctx, err)
 		return nil
 	}
 	bindings, ok := containerInfo.NetworkSettings.Ports[port]
@@ -291,7 +291,7 @@ func (c *Container) Addr(ctx context.Context, port nat.Port) *net.TCPAddr {
 	}
 	portNum, err := strconv.Atoi(bindings[0].HostPort)
 	if err != nil {
-		log.Error(context.TODO(), err)
+		log.Error(ctx, err)
 		return nil
 	}
 	return &net.TCPAddr{

--- a/pkg/cli/kv.go
+++ b/pkg/cli/kv.go
@@ -225,7 +225,7 @@ func runInc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	key := roachpb.Key(unquoted)
-	r, err := kvDB.Inc(context.TODO(), key, amount)
+	r, err := kvDB.Inc(context.Background(), key, amount)
 	if err != nil {
 		return errors.Wrap(err, "increment failed")
 	}
@@ -302,7 +302,7 @@ func runDelRange(cmd *cobra.Command, args []string) error {
 	}
 
 	return kvDB.DelRange(
-		context.TODO(), roachpb.Key(uqFrom), roachpb.Key(uqTo),
+		context.Background(), roachpb.Key(uqFrom), roachpb.Key(uqTo),
 	)
 }
 
@@ -371,7 +371,7 @@ func runReverseScan(cmd *cobra.Command, args []string) error {
 	}
 	defer stopper.Stop()
 
-	rows, err := kvDB.ReverseScan(context.TODO(), startKey, endKey, maxResults)
+	rows, err := kvDB.ReverseScan(context.Background(), startKey, endKey, maxResults)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 var (
@@ -2464,8 +2463,7 @@ func (expr *ParenExpr) Eval(ctx *EvalContext) (Datum, error) {
 }
 
 // Eval implements the TypedExpr interface.
-func (expr *RangeCond) Eval(_ *EvalContext) (Datum, error) {
-	log.Errorf(context.TODO(), "unhandled type %T passed to Eval", expr)
+func (expr *RangeCond) Eval(ctx *EvalContext) (Datum, error) {
 	return nil, errors.Errorf("unhandled type %T", expr)
 }
 
@@ -2482,32 +2480,27 @@ func (expr *UnaryExpr) Eval(ctx *EvalContext) (Datum, error) {
 }
 
 // Eval implements the TypedExpr interface.
-func (expr DefaultVal) Eval(_ *EvalContext) (Datum, error) {
-	log.Errorf(context.TODO(), "unhandled type %T passed to Eval", expr)
+func (expr DefaultVal) Eval(ctx *EvalContext) (Datum, error) {
 	return nil, errors.Errorf("unhandled type %T", expr)
 }
 
 // Eval implements the TypedExpr interface.
 func (expr UnqualifiedStar) Eval(ctx *EvalContext) (Datum, error) {
-	log.Errorf(context.TODO(), "unhandled type %T passed to Eval", expr)
 	return nil, errors.Errorf("unhandled type %T", expr)
 }
 
 // Eval implements the TypedExpr interface.
 func (expr UnresolvedName) Eval(ctx *EvalContext) (Datum, error) {
-	log.Errorf(context.TODO(), "unhandled type %T passed to Eval", expr)
 	return nil, errors.Errorf("unhandled type %T", expr)
 }
 
 // Eval implements the TypedExpr interface.
 func (expr *AllColumnsSelector) Eval(ctx *EvalContext) (Datum, error) {
-	log.Errorf(context.TODO(), "unhandled type %T passed to Eval", expr)
 	return nil, errors.Errorf("unhandled type %T", expr)
 }
 
 // Eval implements the TypedExpr interface.
 func (expr *ColumnItem) Eval(ctx *EvalContext) (Datum, error) {
-	log.Errorf(context.TODO(), "unhandled type %T passed to Eval", expr)
 	return nil, errors.Errorf("unhandled type %T", expr)
 }
 

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -381,7 +381,7 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 		v3conn := makeV3Conn(conn, &s.metrics, &s.sqlMemoryPool, s.executor)
 		defer v3conn.finish(ctx)
 
-		if v3conn.sessionArgs, err = parseOptions(buf.msg); err != nil {
+		if v3conn.sessionArgs, err = parseOptions(ctx, buf.msg); err != nil {
 			return v3conn.sendInternalError(err.Error())
 		}
 

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -206,7 +206,7 @@ func (c *v3Conn) finish(ctx context.Context) {
 	_ = c.conn.Close()
 }
 
-func parseOptions(data []byte) (sql.SessionArgs, error) {
+func parseOptions(ctx context.Context, data []byte) (sql.SessionArgs, error) {
 	args := sql.SessionArgs{}
 	buf := readBuffer{msg: data}
 	for {
@@ -230,7 +230,7 @@ func parseOptions(data []byte) (sql.SessionArgs, error) {
 			args.ApplicationName = value
 		default:
 			if log.V(1) {
-				log.Warningf(context.TODO(), "unrecognized configuration parameter %q", key)
+				log.Warningf(ctx, "unrecognized configuration parameter %q", key)
 			}
 		}
 	}

--- a/pkg/sql/split.go
+++ b/pkg/sql/split.go
@@ -103,7 +103,7 @@ type splitNode struct {
 	key       []byte
 }
 
-func (n *splitNode) Start(context.Context) error {
+func (n *splitNode) Start(ctx context.Context) error {
 	values := make([]parser.Datum, len(n.exprs))
 	colMap := make(map[sqlbase.ColumnID]int)
 	for i, e := range n.exprs {
@@ -125,7 +125,7 @@ func (n *splitNode) Start(context.Context) error {
 	}
 	n.key = keys.MakeRowSentinelKey(key)
 
-	return n.p.session.execCfg.DB.AdminSplit(context.TODO(), n.key)
+	return n.p.session.execCfg.DB.AdminSplit(ctx, n.key)
 }
 
 func (n *splitNode) Next(context.Context) (bool, error) {

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -312,7 +312,7 @@ func (s *Stopper) RunLimitedAsyncTask(
 		if !wait {
 			return ErrThrottled
 		}
-		log.Infof(context.TODO(), "stopper throttling task from %s due to semaphore", key)
+		log.Infof(ctx, "stopper throttling task from %s due to semaphore", key)
 		// Retry the select without the default.
 		select {
 		case sem <- struct{}{}:


### PR DESCRIPTION
~This change audits our use of  `context.TODO`, bringing down the usage count from **634** to **302**.~

It does so with three changes:
- ~Using `context.Background` in all tests, as suggested by the the [godocs](https://golang.org/pkg/context/#Background). This is the pattern we should use for now on, and we may even want to add a style check to enforce it (@tamird?)~ **Note, this step was reverted because of too much disagreement**
- Using available contexts instead of `context.TODO` in a few places where a context was already available. I assume these were just missed during refactorings.
- Using `context.Background` in cobra.Cmd functions, because these are essentially main functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14128)
<!-- Reviewable:end -->
