### PR TITLE
distsqlrun: add test for stream timeout

### DIFF
--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -279,6 +279,9 @@ func (rb *RowBuffer) PushRow(row sqlbase.EncDatumRow) bool {
 
 // Close is part of the RowReceiver interface.
 func (rb *RowBuffer) Close(err error) {
+	if rb.Closed {
+		panic("RowBuffer already closed")
+	}
 	rb.Err = err
 	rb.Closed = true
 }

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -298,7 +298,7 @@ func (f *Flow) Start(ctx context.Context, doneFn func()) {
 	// set up the WaitGroup counter before.
 	f.waitGroup.Add(len(f.inboundStreams) + len(f.outboxes) + len(f.processors))
 
-	f.flowRegistry.RegisterFlow(ctx, f.id, f, f.inboundStreams)
+	f.flowRegistry.RegisterFlow(ctx, f.id, f, f.inboundStreams, flowStreamDefaultTimeout)
 	if log.V(1) {
 		log.Infof(ctx, "registered flow %s", f.id.Short())
 	}

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -190,13 +190,14 @@ func (ds *ServerImpl) flowStreamInt(ctx context.Context, stream DistSQL_FlowStre
 	if log.V(1) {
 		log.Infof(ctx, "connecting inbound stream %s/%d", flowID.Short(), streamID)
 	}
-	f, streamInfo, err := ds.flowRegistry.ConnectInboundStream(flowID, streamID)
+	f, receiver, cleanup, err := ds.flowRegistry.ConnectInboundStream(
+		flowID, streamID, flowStreamDefaultTimeout)
 	if err != nil {
 		return err
 	}
+	defer cleanup()
 	log.VEventf(ctx, 1, "connected inbound stream %s/%d", flowID.Short(), streamID)
-	defer ds.flowRegistry.FinishInboundStream(streamInfo)
-	return ProcessInboundStream(f.AnnotateCtx(ctx), stream, msg, streamInfo.receiver)
+	return ProcessInboundStream(f.AnnotateCtx(ctx), stream, msg, receiver)
 }
 
 // FlowStream is part of the DistSQLServer interface.


### PR DESCRIPTION
We didn't have any tests exercising a stream failing to connect within
the registry's timeout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14132)
<!-- Reviewable:end -->
