### PR TITLE
scripts: Copy parallelbuilds patches to azworkers

### DIFF
--- a/scripts/azworker.sh
+++ b/scripts/azworker.sh
@@ -51,6 +51,7 @@ case ${1-} in
     "$(dirname "${0}")/travis_retry.sh" ssh -o StrictHostKeyChecking=no "${FQDN}" true
 
     rsync -az "$(dirname "${0}")/../build/bootstrap/" "${FQDN}:bootstrap/"
+    rsync -az "$(dirname "${0}")/../build/parallelbuilds-"* "${FQDN}:bootstrap/"
     ssh -A "${FQDN}" ./bootstrap/bootstrap-debian.sh
 
     # TODO(bdarnell): autoshutdown.cron.sh does not work on azure. It


### PR DESCRIPTION
This was being done for gceworkers but not azworkers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14133)
<!-- Reviewable:end -->
