### PR TITLE
*: Refer to ranges by ID in logs as "r%d" instead of "range %d"

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -381,7 +381,7 @@ func (ds *DistSender) sendRPC(
 ) (*roachpb.BatchResponse, error) {
 	if len(replicas) == 0 {
 		return nil, roachpb.NewSendError(
-			fmt.Sprintf("no replica node addresses available via gossip for range %d", rangeID))
+			fmt.Sprintf("no replica node addresses available via gossip for r%d", rangeID))
 	}
 
 	// TODO(pmattis): This needs to be tested. If it isn't set we'll
@@ -1139,7 +1139,7 @@ func (ds *DistSender) sendToReplicas(
 	// Send the first request.
 	pending := 1
 	if log.V(2) || log.HasSpanOrEvent(ctx) {
-		log.VEventf(ctx, 2, "sending batch %s to range %d", args.Summary(), rangeID)
+		log.VEventf(ctx, 2, "sending batch %s to r%d", args.Summary(), rangeID)
 	}
 	transport.SendNext(ctx, done)
 
@@ -1170,7 +1170,7 @@ func (ds *DistSender) sendToReplicas(
 			}
 
 		case <-slowTimer.C:
-			log.Warningf(ctx, "have been waiting %s sending RPC to range %d for batch: %s",
+			log.Warningf(ctx, "have been waiting %s sending RPC to r%d for batch: %s",
 				base.SlowRequestThreshold, rangeID, args)
 			ds.metrics.SlowRequestsCount.Inc(1)
 			defer ds.metrics.SlowRequestsCount.Dec(1)
@@ -1300,15 +1300,15 @@ func (ds *DistSender) updateLeaseHolderCache(
 	if log.V(1) {
 		if oldLeaseHolder, ok := ds.leaseHolderCache.Lookup(ctx, rangeID); ok {
 			if (newLeaseHolder == roachpb.ReplicaDescriptor{}) {
-				log.Infof(ctx, "range %d: evicting cached lease holder %+v", rangeID, oldLeaseHolder)
+				log.Infof(ctx, "r%d: evicting cached lease holder %+v", rangeID, oldLeaseHolder)
 			} else if newLeaseHolder != oldLeaseHolder {
 				log.Infof(
-					ctx, "range %d: replacing cached lease holder %+v with %+v",
+					ctx, "r%d: replacing cached lease holder %+v with %+v",
 					rangeID, oldLeaseHolder, newLeaseHolder,
 				)
 			}
 		} else {
-			log.Infof(ctx, "range %d: caching new lease holder %+v", rangeID, newLeaseHolder)
+			log.Infof(ctx, "r%d: caching new lease holder %+v", rangeID, newLeaseHolder)
 		}
 	}
 	ds.leaseHolderCache.Update(ctx, rangeID, newLeaseHolder)

--- a/pkg/kv/leaseholder_cache.go
+++ b/pkg/kv/leaseholder_cache.go
@@ -53,12 +53,12 @@ func (lc *leaseHolderCache) Lookup(
 	defer lc.mu.Unlock()
 	if v, ok := lc.cache.Get(rangeID); ok {
 		if log.V(2) {
-			log.Infof(ctx, "lookup lease holder for range %d: %s", rangeID, v)
+			log.Infof(ctx, "lookup lease holder for r%d: %s", rangeID, v)
 		}
 		return v.(roachpb.ReplicaDescriptor), true
 	}
 	if log.V(2) {
-		log.Infof(ctx, "lookup lease holder for range %d: not found", rangeID)
+		log.Infof(ctx, "lookup lease holder for r%d: not found", rangeID)
 	}
 	return roachpb.ReplicaDescriptor{}, false
 }
@@ -73,12 +73,12 @@ func (lc *leaseHolderCache) Update(
 	defer lc.mu.Unlock()
 	if (repDesc == roachpb.ReplicaDescriptor{}) {
 		if log.V(2) {
-			log.Infof(ctx, "evicting lease holder for range %d", rangeID)
+			log.Infof(ctx, "evicting lease holder for r%d", rangeID)
 		}
 		lc.cache.Del(rangeID)
 	} else {
 		if log.V(2) {
-			log.Infof(ctx, "updating lease holder for range %d: %s", rangeID, repDesc)
+			log.Infof(ctx, "updating lease holder for r%d: %s", rangeID, repDesc)
 		}
 		lc.cache.Add(rangeID, repDesc)
 	}

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -1343,7 +1343,7 @@ func TestChangeReplicasDescriptorInvariant(t *testing.T) {
 	before := mtc.stores[2].Metrics().RangeSnapshotsPreemptiveApplied.Count()
 	// Attempt to add replica to the third store with the original descriptor.
 	// This should fail because the descriptor is stale.
-	if err := addReplica(2, origDesc); !testutils.IsError(err, `change replicas of range \d+ failed`) {
+	if err := addReplica(2, origDesc); !testutils.IsError(err, `change replicas of r\d+ failed`) {
 		t.Fatalf("got unexpected error: %v", err)
 	}
 

--- a/pkg/storage/raft_log_queue.go
+++ b/pkg/storage/raft_log_queue.go
@@ -82,7 +82,7 @@ func getTruncatableIndexes(ctx context.Context, r *Replica) (uint64, uint64, err
 	raftStatus := r.RaftStatus()
 	if raftStatus == nil {
 		if log.V(6) {
-			log.Infof(ctx, "the raft group doesn't exist for range %d", rangeID)
+			log.Infof(ctx, "the raft group doesn't exist for r%d", rangeID)
 		}
 		return 0, 0, nil
 	}
@@ -113,7 +113,7 @@ func getTruncatableIndexes(ctx context.Context, r *Replica) (uint64, uint64, err
 	pendingSnapshotIndex := r.mu.pendingSnapshotIndex
 	r.mu.Unlock()
 	if err != nil {
-		return 0, 0, errors.Errorf("error retrieving first index for range %d: %s", rangeID, err)
+		return 0, 0, errors.Errorf("error retrieving first index for r%d: %s", rangeID, err)
 	}
 
 	truncatableIndex := computeTruncatableIndex(

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -3299,12 +3299,12 @@ func (r *Replica) sendRaftMessage(ctx context.Context, msg raftpb.Message) {
 	r.mu.Unlock()
 
 	if fromErr != nil {
-		log.Warningf(ctx, "failed to look up sender replica %d in range %d while sending %s: %s",
+		log.Warningf(ctx, "failed to look up sender replica %d in r%d while sending %s: %s",
 			msg.From, r.RangeID, msg.Type, fromErr)
 		return
 	}
 	if toErr != nil {
-		log.Warningf(ctx, "failed to look up recipient replica %d in range %d while sending %s: %s",
+		log.Warningf(ctx, "failed to look up recipient replica %d in r%d while sending %s: %s",
 			msg.To, r.RangeID, msg.Type, toErr)
 		return
 	}
@@ -4402,7 +4402,7 @@ func (r *Replica) maybeGossipFirstRange(ctx context.Context) *roachpb.Error {
 	// Gossip the cluster ID from all replicas of the first range; there
 	// is no expiration on the cluster ID.
 	if log.V(1) {
-		log.Infof(ctx, "gossiping cluster id %q from store %d, range %d", r.store.ClusterID(),
+		log.Infof(ctx, "gossiping cluster id %q from store %d, r%d", r.store.ClusterID(),
 			r.store.StoreID(), r.RangeID)
 	}
 	if err := r.store.Gossip().AddInfo(
@@ -4434,13 +4434,13 @@ func (r *Replica) gossipFirstRange(ctx context.Context) {
 	}
 	log.Event(ctx, "gossiping sentinel and first range")
 	if log.V(1) {
-		log.Infof(ctx, "gossiping sentinel from store %d, range %d", r.store.StoreID(), r.RangeID)
+		log.Infof(ctx, "gossiping sentinel from store %d, r%d", r.store.StoreID(), r.RangeID)
 	}
 	if err := r.store.Gossip().AddInfo(gossip.KeySentinel, r.store.ClusterID().GetBytes(), sentinelGossipTTL); err != nil {
 		log.Errorf(ctx, "failed to gossip sentinel: %s", err)
 	}
 	if log.V(1) {
-		log.Infof(ctx, "gossiping first range from store %d, range %d: %s",
+		log.Infof(ctx, "gossiping first range from store %d, r%d: %s",
 			r.store.StoreID(), r.RangeID, r.mu.state.Desc.Replicas)
 	}
 	if err := r.store.Gossip().AddInfoProto(

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1593,7 +1593,7 @@ func evalTruncateLog(
 	// range based on the start key. This will cancel the request if this is not
 	// the range specified in the request body.
 	if r.RangeID != args.RangeID {
-		log.Infof(ctx, "attempting to truncate raft logs for another range %d. Normally this is due to a merge and can be ignored.",
+		log.Infof(ctx, "attempting to truncate raft logs for another range: r%d. Normally this is due to a merge and can be ignored.",
 			args.RangeID)
 		return EvalResult{}, nil
 	}
@@ -3365,7 +3365,7 @@ func (r *Replica) ChangeReplicas(
 		return nil
 	}); err != nil {
 		log.Event(ctx, err.Error())
-		return errors.Wrapf(err, "change replicas of range %d failed", rangeID)
+		return errors.Wrapf(err, "change replicas of r%d failed", rangeID)
 	}
 	log.Event(ctx, "txn complete")
 	return nil

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3129,7 +3129,7 @@ func (s *Store) processRaftRequest(
 			log.Infof(ctx, "refusing incoming Raft message %s from %+v to %+v",
 				req.Message.Type, req.FromReplica, req.ToReplica)
 		}
-		return roachpb.NewErrorf("cannot recreate replica that is not a member of its range (StoreID %s not found in range %d)",
+		return roachpb.NewErrorf("cannot recreate replica that is not a member of its range (StoreID %s not found in r%d)",
 			r.store.StoreID(), req.RangeID)
 	}
 
@@ -3195,7 +3195,7 @@ func (s *Store) HandleRaftResponse(ctx context.Context, resp *RaftMessageRespons
 				resp.FromReplica.NodeID, resp.FromReplica.StoreID, resp.FromReplica, val)
 			return val.GetDetail()
 		default:
-			log.Warningf(ctx, "got error from range %d, replica %s: %s",
+			log.Warningf(ctx, "got error from r%d, replica %s: %s",
 				resp.RangeID, resp.FromReplica, val)
 		}
 


### PR DESCRIPTION
I left the error messages in `roachpb/errors.go` alone since those
can make it back to end users and they'd likely benefit from the
extra clarity.

I also didn't bother with updating test error messages.

As suggested in a comment on #14121. I assume we don't really care about the same convention for store IDs being logged since it's rare to have to grep for them?

@petermattis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14134)
<!-- Reviewable:end -->
