### PR TITLE
engine: Add missing status check in batch iterator wrapper

### DIFF
--- a/pkg/storage/engine/db.cc
+++ b/pkg/storage/engine/db.cc
@@ -1080,7 +1080,7 @@ class BaseDeltaIterator : public rocksdb::Iterator {
   }
 
   bool Valid() const override {
-    return current_at_base_ ? BaseValid() : DeltaValid();
+    return status_.ok() && (current_at_base_ ? BaseValid() : DeltaValid());
   }
 
   void SeekToFirst() override {


### PR DESCRIPTION
Previously, Prev() would appear to succeed but would not move the
iterator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14139)
<!-- Reviewable:end -->
