### PR TITLE
syncutil: special case one error in WaitGroupWithError

### DIFF
--- a/pkg/util/syncutil/waitgroup.go
+++ b/pkg/util/syncutil/waitgroup.go
@@ -57,7 +57,9 @@ func (wg *WaitGroupWithError) Add(delta int) {
 func (wg *WaitGroupWithError) Wait() error {
 	wg.wg.Wait()
 	// Locking no longer required at this point; no more concurrent Done() calls.
-	if wg.mu.numErrs > 0 {
+	if wg.mu.numErrs == 1 {
+		return wg.mu.firstErr
+	} else if wg.mu.numErrs > 0 {
 		return errors.Wrapf(wg.mu.firstErr, "first of %d errors", wg.mu.numErrs)
 	}
 	return nil

--- a/pkg/util/syncutil/waitgroup_test.go
+++ b/pkg/util/syncutil/waitgroup_test.go
@@ -43,9 +43,10 @@ func TestWaitGroupNilError(t *testing.T) {
 func TestWaitGroupOneError(t *testing.T) {
 	var wg syncutil.WaitGroupWithError
 	wg.Add(1)
-	wg.Done(errors.New("one"))
-	if err := wg.Wait(); !testutils.IsError(err, "one") {
-		t.Fatalf("expected 'one' error got: %+v", err)
+	origErr := errors.New("one")
+	wg.Done(origErr)
+	if err := wg.Wait(); err != origErr {
+		t.Fatalf("expected the original error got: %+v", err)
 	}
 }
 


### PR DESCRIPTION
This improves readability in chains of error.Wrap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14144)
<!-- Reviewable:end -->
