### PR TITLE
sql + pgwire: provide ways for clients to discover the CockroachDB version

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -17,11 +17,13 @@
 package sql
 
 import (
+	"reflect"
 	"sort"
 	"time"
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -31,10 +33,39 @@ import (
 var crdbInternal = virtualSchema{
 	name: "crdb_internal",
 	tables: []virtualSchemaTable{
+		crdbInternalBuildInfoTable,
 		crdbInternalTablesTable,
 		crdbInternalLeasesTable,
 		crdbInternalSchemaChangesTable,
 		crdbInternalAppStatsTable,
+	},
+}
+
+var crdbInternalBuildInfoTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE crdb_internal.build_info (
+  FIELD STRING NOT NULL,
+  VALUE STRING NOT NULL
+);
+`,
+	populate: func(_ context.Context, _ *planner, addRow func(...parser.Datum) error) error {
+		if err := addRow(parser.NewDString("Name"), parser.NewDString("CockroachDB")); err != nil {
+			return err
+		}
+
+		info := build.GetInfo()
+		s := reflect.ValueOf(&info).Elem()
+		t := s.Type()
+		for i := 0; i < s.NumField(); i++ {
+			f := s.Field(i)
+			if sv, ok := f.Interface().(string); ok {
+				fname := t.Field(i).Name
+				if err := addRow(parser.NewDString(fname), parser.NewDString(sv)); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
 	},
 }
 

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -1313,7 +1313,7 @@ func TestSQLNetworkMetrics(t *testing.T) {
 	defer cleanupFn()
 
 	const minbytes = 20
-	const maxbytes = 350
+	const maxbytes = 450
 
 	// Make sure we're starting at 0.
 	if _, _, err := checkSQLNetworkMetrics(s, 0, 0, 0, 0); err != nil {

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/mon"
@@ -252,6 +253,11 @@ var statusReportParams = map[string]string{
 	// code paths which various client tools fall back to if they can't
 	// determine that the server is new enough.
 	"server_version": sql.PgServerVersion,
+	// The current CockroachDB version string.
+	"crdb_version": func() string {
+		info := build.GetInfo()
+		return fmt.Sprintf("CockroachDB %s %s", info.Distribution, info.Tag)
+	}(),
 }
 
 // handleAuthentication should discuss with the client to arrange

--- a/pkg/sql/testdata/crdb_internal
+++ b/pkg/sql/testdata/crdb_internal
@@ -73,3 +73,22 @@ true
 # reset for other tests.
 statement ok
 SET APPLICATION_NAME = ''
+
+query TT colnames
+SELECT * FROM crdb_internal.build_info WHERE field ILIKE 'name'
+----
+FIELD VALUE
+Name CockroachDB
+
+query T
+SELECT field FROM crdb_internal.build_info
+----
+Name
+GoVersion
+Tag
+Time
+Revision
+CgoCompiler
+Platform
+Distribution
+Type

--- a/pkg/sql/testdata/information_schema
+++ b/pkg/sql/testdata/information_schema
@@ -209,6 +209,7 @@ query T
 SELECT table_name FROM information_schema.tables
 ----
 app_stats
+build_info
 leases
 schema_changes
 tables
@@ -305,6 +306,7 @@ SELECT * FROM information_schema.tables
 ----
 TABLE_CATALOG  TABLE_SCHEMA        TABLE_NAME         TABLE_TYPE   VERSION
 def            crdb_internal       app_stats          SYSTEM VIEW  1
+def            crdb_internal       build_info         SYSTEM VIEW  1
 def            crdb_internal       leases             SYSTEM VIEW  1
 def            crdb_internal       schema_changes     SYSTEM VIEW  1
 def            crdb_internal       tables             SYSTEM VIEW  1


### PR DESCRIPTION
Fixes #14142.

**sql/pgwire: report the CockroachDB version in the pgwire parameter message.**

Discussed in  https://github.com/MagicStack/asyncpg/issues/87#issuecomment-286529121

It is useful for clients to know that they are actually talking to a
CockroachDB SQL node, as opposed to a real PostgreSQL server. At this
point there is no way to determine a client is connected to
CockroachDB using a SQL statement/query that would not otherwise
*fail* in PostgreSQL.

This patch addresses this limitation by returning a new `crdb_version`
parameter in the ParameterStatus
message. (https://www.postgresql.org/docs/9.5/static/protocol-message-formats.html)

This is safe because as explained in
https://www.postgresql.org/docs/9.5/static/protocol-flow.html#PROTOCOL-ASYNC
"This set might change in the future, or even become
configurable. Accordingly, a frontend should simply ignore
ParameterStatus for parameters that it does not understand or care
about."

**sql: report the CockroachDB information details also in a virtual table.**

The changes in the previous commit have enabled pgwire clients to
inspect the CockroachDB version from the parameter status message.
However this is only reported during connection start-up, and client
drivers may not be able to save this information (e.g. Go's lib/pq
doesn't).

This patch complements the previous change by reporting the version
details also in a new virtual table `crdb_internal.local_version`.  A
client that wants to disambiguate between pg and CockroachDB can
select into that table. To avoid this query to fail on pg, the client
may first check using `information_schema.schemata` whether this table
exists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14145)
<!-- Reviewable:end -->
