### PR TITLE
util/{log,tracing}: s/LogFields/LogKV/

### DIFF
--- a/pkg/sql/trace.go
+++ b/pkg/sql/trace.go
@@ -22,7 +22,6 @@ import (
 
 	basictracer "github.com/opentracing/basictracer-go"
 	opentracing "github.com/opentracing/opentracing-go"
-	otlog "github.com/opentracing/opentracing-go/log"
 
 	"golang.org/x/net/context"
 
@@ -151,10 +150,10 @@ func (n *explainTraceNode) Next(ctx context.Context) (bool, error) {
 			n.exhausted = true
 			// Finish the tracing span that we began in Start().
 			if err != nil {
-				sp.LogFields(otlog.String("event", err.Error()))
+				sp.LogKV("event", err)
 				return false, err
 			}
-			sp.LogFields(otlog.String("event", "tracing completed"))
+			sp.LogKV("event", "tracing completed")
 			n.unhijackCtx()
 			sp.Finish()
 		} else {

--- a/pkg/util/log/trace.go
+++ b/pkg/util/log/trace.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	opentracing "github.com/opentracing/opentracing-go"
-	otlog "github.com/opentracing/opentracing-go/log"
 	"golang.org/x/net/context"
 	"golang.org/x/net/trace"
 )
@@ -127,9 +126,7 @@ func eventInternal(ctx context.Context, isErr, withTags bool, format string, arg
 		}
 
 		if sp != nil {
-			// TODO(radu): pass tags directly to sp.LogKV when LightStep supports
-			// that.
-			sp.LogFields(otlog.String("event", msg))
+			sp.LogKV("event", msg)
 			if isErr {
 				// TODO(radu): figure out a way to signal that this is an error. We
 				// could use a different "error" key (provided it shows up in

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -506,7 +506,7 @@ func JoinRemoteTrace(
 			sp.SetTag(k, v)
 			return true
 		})
-		sp.LogFields(otlog.String("event", opName))
+		sp.LogKV("event", opName)
 	case opentracing.ErrSpanContextNotFound:
 		fallthrough
 	default:


### PR DESCRIPTION
Although it seems that LogKV calls LogFields internally so it's not clear that this is better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14150)
<!-- Reviewable:end -->
