### PR TITLE
storageccl: correct WriteBatch bounds generated by Import

### DIFF
--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -147,10 +147,12 @@ func evalImport(ctx context.Context, cArgs storage.CommandArgs) error {
 
 			// Update the range currently represented in this batch, as
 			// necessary.
-			if len(b.batchStartKey) == 0 {
-				b.batchStartKey = append(b.batchStartKey, key.Key...)
+			if len(b.batchStartKey) == 0 || bytes.Compare(key.Key, b.batchStartKey) < 0 {
+				b.batchStartKey = append(b.batchStartKey[:0], key.Key...)
 			}
-			b.batchEndKey = append(b.batchEndKey[:0], key.Key...)
+			if len(b.batchEndKey) == 0 || bytes.Compare(key.Key, b.batchEndKey) > 0 {
+				b.batchEndKey = append(b.batchEndKey[:0], key.Key...)
+			}
 
 			if b.batch.Len() > batchSizeBytes {
 				sendWriteBatch()


### PR DESCRIPTION
Import was using the first and last keys it saw as the bounds when
constructing a WriteBatch, but this isn't correct when a later file
contains any key earlier than the first one seen by Import. It is also
incorrect when all keys in a file are less than the greatest in the
previous file.

Found via backup/restore testing on a production cluster with
block_writer. This commit adds a check for the regression in
TestBackupRestoreIncremental. More extensive tests for Import will be
left for #14152.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14153)
<!-- Reviewable:end -->
