### PR TITLE
sql: panic if session.Start[Unlimited]Monitor is not called

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -73,6 +73,14 @@ type migrationDescriptor struct {
 type runner struct {
 	db          db
 	sqlExecutor *sql.Executor
+	memMetrics  *sql.MemoryMetrics
+}
+
+func (r *runner) newRootSession(ctx context.Context) *sql.Session {
+	args := sql.SessionArgs{User: security.NodeUser}
+	s := sql.NewSession(ctx, args, r.sqlExecutor, nil, r.memMetrics)
+	s.StartUnlimitedMonitor()
+	return s
 }
 
 // leaseManager is defined just to allow us to use a fake client.LeaseManager
@@ -99,11 +107,17 @@ type Manager struct {
 	leaseManager leaseManager
 	db           db
 	sqlExecutor  *sql.Executor
+	memMetrics   *sql.MemoryMetrics
 }
 
 // NewManager initializes and returns a new Manager object.
 func NewManager(
-	stopper *stop.Stopper, db *client.DB, executor *sql.Executor, clock *hlc.Clock, clientID string,
+	stopper *stop.Stopper,
+	db *client.DB,
+	executor *sql.Executor,
+	clock *hlc.Clock,
+	memMetrics *sql.MemoryMetrics,
+	clientID string,
 ) *Manager {
 	opts := client.LeaseManagerOptions{
 		ClientID:      clientID,
@@ -114,6 +128,7 @@ func NewManager(
 		leaseManager: client.NewLeaseManager(db, clock, opts),
 		db:           db,
 		sqlExecutor:  executor,
+		memMetrics:   memMetrics,
 	}
 }
 
@@ -221,6 +236,7 @@ func (m *Manager) EnsureMigrations(ctx context.Context) error {
 	r := runner{
 		db:          m.db,
 		sqlExecutor: m.sqlExecutor,
+		memMetrics:  m.memMetrics,
 	}
 	for _, migration := range backwardCompatibleMigrations {
 		key := migrationKey(migration)
@@ -282,7 +298,7 @@ func eventlogUniqueIDDefault(ctx context.Context, r runner) error {
 	const alterStmt = "ALTER TABLE system.eventlog ALTER COLUMN uniqueID SET DEFAULT uuid_v4();"
 
 	// System tables can only be modified by a privileged internal user.
-	session := sql.NewSession(ctx, sql.SessionArgs{User: security.NodeUser}, r.sqlExecutor, nil, nil)
+	session := r.newRootSession(ctx)
 	defer session.Finish(r.sqlExecutor)
 
 	// Retry a limited number of times because returning an error and letting

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -816,7 +816,7 @@ func (s *Server) Start(ctx context.Context) error {
 	// We have to do this after actually starting up the server to be able to
 	// seamlessly use the kv client against other nodes in the cluster.
 	migMgr := migrations.NewManager(
-		s.stopper, s.db, s.sqlExecutor, s.clock, s.NodeID().String())
+		s.stopper, s.db, s.sqlExecutor, s.clock, &s.internalMemMetrics, s.NodeID().String())
 	if err := migMgr.EnsureMigrations(ctx); err != nil {
 		log.Fatal(ctx, err)
 	}

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -360,6 +360,7 @@ func (e *Executor) Start(
 
 	ctx = log.WithLogTag(ctx, "startup", nil)
 	startupSession := NewSession(ctx, SessionArgs{}, e, nil, startupMemMetrics)
+	startupSession.StartUnlimitedMonitor()
 	if err := e.virtualSchemas.init(&startupSession.planner); err != nil {
 		log.Fatal(ctx, err)
 	}

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -216,6 +216,14 @@ func NewSession(
 
 // Finish releases resources held by the Session.
 func (s *Session) Finish(e *Executor) {
+	if s.mon == (mon.MemoryMonitor{}) {
+		// This check won't catch the cases where Finish is never called, but it's
+		// proven to be easier to remember to call Finish than it is to call
+		// StartMonitor.
+		panic("session.Finish: session monitors were never initialized. Missing call " +
+			"to session.StartMonitor?")
+	}
+
 	// If we're inside a txn, roll it back.
 	if s.TxnState.State.kvTxnIsOpen() {
 		s.TxnState.updateStateAndCleanupOnErr(


### PR DESCRIPTION
Failing to start a session's monitor results in hard-to-track-down bugs
while trying to execute a query. This commit fixes the call sites that
failed to start their session's monitor, and adds an assertion to
`session.Finish` to prevent future errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14177)
<!-- Reviewable:end -->
