### PR TITLE
server: deflake server join event logging

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -385,9 +385,6 @@ func (n *Node) start(
 	n.startComputePeriodicMetrics(n.stopper, n.storeCfg.MetricsSampleInterval)
 	n.startGossip(n.stopper)
 
-	// Record node started event.
-	n.recordJoinEvent()
-
 	log.Infof(ctx, "%s: started with %v engine(s) and attributes %v", n, engines, attrs.Attrs)
 	return nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -824,6 +824,10 @@ func (s *Server) Start(ctx context.Context) error {
 	close(serveSQL)
 	log.Info(ctx, "serving sql connections")
 
+	// Record that this node joined the cluster in the event log. Since this
+	// executes a SQL query, this must be done after the SQL layer is ready.
+	s.node.recordJoinEvent()
+
 	if s.cfg.PIDFile != "" {
 		if err := ioutil.WriteFile(s.cfg.PIDFile, []byte(fmt.Sprintf("%d\n", os.Getpid())), 0644); err != nil {
 			log.Error(ctx, err)


### PR DESCRIPTION
TestAdminAPIEvents has been flaky, and this is caused by the node join
event logging being flaky. Because event logging results in a SQL
INSERT, I've delayed it until we start serving SQL connections.

I've also improved the TestAdminAPIEvents test to require less
maintenance when we add system migrations.

Resolves #13785

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14179)
<!-- Reviewable:end -->
