### PR TITLE
sql: set evalCtx timestamps in internal planners

### DIFF
--- a/pkg/sql/values_test.go
+++ b/pkg/sql/values_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 func makeTestPlanner() *planner {
-	return makeInternalPlanner("test", nil, security.RootUser, &MemoryMetrics{})
+	return makePlanner("test", security.RootUser, &MemoryMetrics{})
 }
 
 func TestValues(t *testing.T) {


### PR DESCRIPTION
In order to call e.g. `now()`, the evalCtx needs timestamp information.
These are set properly by the executor but not internal planners; this
commit fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14180)
<!-- Reviewable:end -->
