### PR TITLE
sql: Move session-related fields from the planner to the Session

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -814,10 +814,10 @@ func (s *adminServer) SetUIData(
 		// Do an upsert of the key. We update each key in a separate transaction to
 		// avoid long-running transactions and possible deadlocks.
 		query := "UPSERT INTO system.ui (key, value, lastUpdated) VALUES ($1, $2, NOW())"
-		qargs := parser.NewPlaceholderInfo()
+		qargs := parser.MakePlaceholderInfo()
 		qargs.SetValue(`1`, parser.NewDString(key))
 		qargs.SetValue(`2`, parser.NewDBytes(parser.DBytes(val)))
-		r := s.server.sqlExecutor.ExecuteStatements(session, query, qargs)
+		r := s.server.sqlExecutor.ExecuteStatements(session, query, &qargs)
 		defer r.Close(ctx)
 		if err := s.checkQueryResults(r.ResultList, 1); err != nil {
 			return nil, s.serverError(err)
@@ -1339,9 +1339,9 @@ func (s *adminServer) queryZone(
 	ctx context.Context, session *sql.Session, id sqlbase.ID,
 ) (config.ZoneConfig, bool, error) {
 	const query = `SELECT config FROM system.zones WHERE id = $1`
-	params := parser.NewPlaceholderInfo()
+	params := parser.MakePlaceholderInfo()
 	params.SetValue(`1`, parser.NewDInt(parser.DInt(id)))
-	r := s.server.sqlExecutor.ExecuteStatements(session, query, params)
+	r := s.server.sqlExecutor.ExecuteStatements(session, query, &params)
 	defer r.Close(ctx)
 	if err := s.checkQueryResults(r.ResultList, 1); err != nil {
 		return config.ZoneConfig{}, false, err
@@ -1387,10 +1387,10 @@ func (s *adminServer) queryNamespaceID(
 	ctx context.Context, session *sql.Session, parentID sqlbase.ID, name string,
 ) (sqlbase.ID, error) {
 	const query = `SELECT id FROM system.namespace WHERE parentID = $1 AND name = $2`
-	params := parser.NewPlaceholderInfo()
+	params := parser.MakePlaceholderInfo()
 	params.SetValue(`1`, parser.NewDInt(parser.DInt(parentID)))
 	params.SetValue(`2`, parser.NewDString(name))
-	r := s.server.sqlExecutor.ExecuteStatements(session, query, params)
+	r := s.server.sqlExecutor.ExecuteStatements(session, query, &params)
 	defer r.Close(ctx)
 	if err := s.checkQueryResults(r.ResultList, 1); err != nil {
 		return 0, err

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -618,10 +618,10 @@ func TestAdminAPIZoneDetails(t *testing.T) {
 			t.Fatal(err)
 		}
 		const query = `INSERT INTO system.zones VALUES($1, $2)`
-		params := parser.NewPlaceholderInfo()
+		params := parser.MakePlaceholderInfo()
 		params.SetValue(`1`, parser.NewDInt(parser.DInt(id)))
 		params.SetValue(`2`, parser.NewDBytes(parser.DBytes(zoneBytes)))
-		res := ts.sqlExecutor.ExecuteStatements(session, query, params)
+		res := ts.sqlExecutor.ExecuteStatements(session, query, &params)
 		defer res.Close(ctx)
 		if res.ResultList[0].Err != nil {
 			t.Fatalf("error executing '%s': %s", query, res.ResultList[0].Err)

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -450,7 +450,7 @@ func (n *alterTableNode) Start(ctx context.Context) error {
 	// Record this table alteration in the event log. This is an auditable log
 	// event and is recorded in the same transaction as the table descriptor
 	// update.
-	if err := MakeEventLogger(n.p.leaseMgr).InsertEventRecord(
+	if err := MakeEventLogger(n.p.session.leaseMgr).InsertEventRecord(
 		ctx,
 		n.p.txn,
 		EventLogAlterTable,

--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -48,8 +48,8 @@ type sqlStats struct {
 // used upon session initialization and upon SET APPLICATION_NAME.
 func (s *Session) resetApplicationName(appName string) {
 	s.ApplicationName = appName
-	if s.planner.sqlStats != nil {
-		s.appStats = s.planner.sqlStats.getStatsForApplication(appName)
+	if s.sqlStats != nil {
+		s.appStats = s.sqlStats.getStatsForApplication(appName)
 	}
 }
 

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -268,9 +268,10 @@ func (sc *SchemaChanger) maybeWriteResumeSpan(
 
 func (sc *SchemaChanger) makePlanner(txn *client.Txn) *planner {
 	return &planner{
-		txn:      txn,
-		leaseMgr: sc.leaseMgr,
-		session:  new(Session),
+		txn: txn,
+		session: &Session{
+			leaseMgr: sc.leaseMgr,
+		},
 	}
 }
 

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -106,10 +106,10 @@ func (p *planner) CopyFrom(
 func (n *copyNode) Start(context.Context) error {
 	// Should never happen because the executor prevents non-COPY messages during
 	// a COPY.
-	if n.p.copyFrom != nil {
+	if n.p.session.copyFrom != nil {
 		return fmt.Errorf("COPY already in progress")
 	}
-	n.p.copyFrom = n
+	n.p.session.copyFrom = n
 	return nil
 }
 
@@ -141,7 +141,7 @@ var (
 func (p *planner) ProcessCopyData(
 	ctx context.Context, data string, msg copyMsg,
 ) (parser.StatementList, error) {
-	cf := p.copyFrom
+	cf := p.session.copyFrom
 	buf := cf.buf
 
 	switch msg {
@@ -360,7 +360,7 @@ func (p *planner) CopyData(ctx context.Context, n CopyDataBlock, autoCommit bool
 	// When this many rows are in the copy buffer, they are inserted.
 	const copyRowSize = 100
 
-	cf := p.copyFrom
+	cf := p.session.copyFrom
 
 	// Only do work if we have lots of rows or this is the end.
 	if ln := len(cf.rows); ln == 0 || (ln < copyRowSize && !n.Done) {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -216,7 +216,7 @@ CREATE TABLE crdb_internal.leases (
 );
 `,
 	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
-		leaseMgr := p.leaseMgr
+		leaseMgr := p.session.leaseMgr
 		nodeID := parser.NewDInt(parser.DInt(int64(leaseMgr.nodeID.Get())))
 
 		leaseMgr.mu.Lock()
@@ -271,7 +271,7 @@ CREATE TABLE crdb_internal.app_stats (
 			return errors.New("only root can access application statistics")
 		}
 
-		sqlStats := p.sqlStats
+		sqlStats := p.session.sqlStats
 		if sqlStats == nil {
 			return errors.New("cannot access sql statistics from this context")
 		}

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -96,7 +96,7 @@ func (n *createDatabaseNode) Start(ctx context.Context) error {
 	if created {
 		// Log Create Database event. This is an auditable log event and is
 		// recorded in the same transaction as the table descriptor update.
-		if err := MakeEventLogger(n.p.leaseMgr).InsertEventRecord(
+		if err := MakeEventLogger(n.p.session.leaseMgr).InsertEventRecord(
 			ctx,
 			n.p.txn,
 			EventLogCreateDatabase,
@@ -207,7 +207,7 @@ func (n *createIndexNode) Start(ctx context.Context) error {
 	// Record index creation in the event log. This is an auditable log
 	// event and is recorded in the same transaction as the table descriptor
 	// update.
-	if err := MakeEventLogger(n.p.leaseMgr).InsertEventRecord(
+	if err := MakeEventLogger(n.p.session.leaseMgr).InsertEventRecord(
 		ctx,
 		n.p.txn,
 		EventLogCreateIndex,
@@ -283,7 +283,7 @@ func (n *createUserNode) Start(ctx context.Context) error {
 
 	normalizedUsername := n.n.Name.Normalize()
 
-	internalExecutor := InternalExecutor{LeaseManager: n.p.leaseMgr}
+	internalExecutor := InternalExecutor{LeaseManager: n.p.session.leaseMgr}
 	rowsAffected, err := internalExecutor.ExecuteStatementInTransaction(
 		ctx,
 		"create-user",
@@ -459,7 +459,7 @@ func (n *createViewNode) Start(ctx context.Context) error {
 
 	// Log Create View event. This is an auditable log event and is
 	// recorded in the same transaction as the table descriptor update.
-	if err := MakeEventLogger(n.p.leaseMgr).InsertEventRecord(
+	if err := MakeEventLogger(n.p.session.leaseMgr).InsertEventRecord(
 		ctx,
 		n.p.txn,
 		EventLogCreateView,
@@ -649,7 +649,7 @@ func (n *createTableNode) Start(ctx context.Context) error {
 
 	// Log Create Table event. This is an auditable log event and is
 	// recorded in the same transaction as the table descriptor update.
-	if err := MakeEventLogger(n.p.leaseMgr).InsertEventRecord(
+	if err := MakeEventLogger(n.p.session.leaseMgr).InsertEventRecord(
 		ctx,
 		n.p.txn,
 		EventLogCreateTable,

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -177,7 +177,7 @@ func (p *planner) getCachedDatabaseDesc(name string) (*sqlbase.DatabaseDescripto
 	}
 
 	nameKey := databaseKey{name}
-	nameVal := p.systemConfig.GetValue(nameKey.Key())
+	nameVal := p.session.systemConfig.GetValue(nameKey.Key())
 	if nameVal == nil {
 		return nil, fmt.Errorf("database %q does not exist in system cache", name)
 	}
@@ -188,7 +188,7 @@ func (p *planner) getCachedDatabaseDesc(name string) (*sqlbase.DatabaseDescripto
 	}
 
 	descKey := sqlbase.MakeDescMetadataKey(sqlbase.ID(id))
-	descVal := p.systemConfig.GetValue(descKey)
+	descVal := p.session.systemConfig.GetValue(descKey)
 	if descVal == nil {
 		return nil, fmt.Errorf("database %q has name entry, but no descriptor in system cache", name)
 	}
@@ -228,7 +228,7 @@ func (p *planner) getDatabaseID(ctx context.Context, name string) (sqlbase.ID, e
 		return virtual.GetID(), nil
 	}
 
-	if id := p.databaseCache.getID(name); id != 0 {
+	if id := p.session.databaseCache.getID(name); id != 0 {
 		return id, nil
 	}
 
@@ -247,7 +247,7 @@ func (p *planner) getDatabaseID(ctx context.Context, name string) (sqlbase.ID, e
 		}
 	}
 
-	p.databaseCache.setID(name, desc.ID)
+	p.session.databaseCache.setID(name, desc.ID)
 	return desc.ID, nil
 }
 

--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -191,7 +191,7 @@ func (n *dropDatabaseNode) Start(ctx context.Context) error {
 
 	// Log Drop Database event. This is an auditable log event and is recorded
 	// in the same transaction as the table descriptor update.
-	if err := MakeEventLogger(n.p.leaseMgr).InsertEventRecord(
+	if err := MakeEventLogger(n.p.session.leaseMgr).InsertEventRecord(
 		ctx,
 		n.p.txn,
 		EventLogDropDatabase,
@@ -378,7 +378,7 @@ func (p *planner) dropIndexByName(
 	// Record index drop in the event log. This is an auditable log event
 	// and is recorded in the same transaction as the table descriptor
 	// update.
-	if err := MakeEventLogger(p.leaseMgr).InsertEventRecord(
+	if err := MakeEventLogger(p.session.leaseMgr).InsertEventRecord(
 		ctx,
 		p.txn,
 		EventLogDropIndex,
@@ -491,7 +491,7 @@ func (n *dropViewNode) Start(ctx context.Context) error {
 		// Log a Drop View event for this table. This is an auditable log event
 		// and is recorded in the same transaction as the table descriptor
 		// update.
-		if err := MakeEventLogger(n.p.leaseMgr).InsertEventRecord(
+		if err := MakeEventLogger(n.p.session.leaseMgr).InsertEventRecord(
 			ctx,
 			n.p.txn,
 			EventLogDropView,
@@ -729,7 +729,7 @@ func (n *dropTableNode) Start(ctx context.Context) error {
 		// Log a Drop Table event for this table. This is an auditable log event
 		// and is recorded in the same transaction as the table descriptor
 		// update.
-		if err := MakeEventLogger(n.p.leaseMgr).InsertEventRecord(
+		if err := MakeEventLogger(n.p.session.leaseMgr).InsertEventRecord(
 			ctx,
 			n.p.txn,
 			EventLogDropTable,

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -484,7 +484,7 @@ func (e *Executor) ExecuteStatements(
 ) StatementResults {
 	session.planner.resetForBatch(e)
 	session.planner.semaCtx.Placeholders.Assign(pinfo)
-	session.phaseTimes[sessionStartBatch] = timeutil.Now()
+	session.planner.phaseTimes[sessionStartBatch] = timeutil.Now()
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -557,7 +557,7 @@ func (e *Executor) execRequest(session *Session, sql string, copymsg copyMsg) St
 		log.Infof(session.Ctx(), "execRequest: %s", sql)
 	}
 
-	session.phaseTimes[sessionStartParse] = timeutil.Now()
+	planMaker.phaseTimes[sessionStartParse] = timeutil.Now()
 	if session.copyFrom != nil {
 		stmts, err = session.planner.ProcessCopyData(session.Ctx(), sql, copymsg)
 	} else if copymsg != copyMsgNone {
@@ -565,7 +565,7 @@ func (e *Executor) execRequest(session *Session, sql string, copymsg copyMsg) St
 	} else {
 		stmts, err = planMaker.parser.Parse(sql, session.Syntax)
 	}
-	session.phaseTimes[sessionEndParse] = timeutil.Now()
+	planMaker.phaseTimes[sessionEndParse] = timeutil.Now()
 
 	if err != nil {
 		if log.V(2) {
@@ -1066,7 +1066,7 @@ func (e *Executor) execStmtInOpenTxn(
 	session := planMaker.session
 	log.Eventf(session.context, "%s", stmt)
 
-	session.phaseTimes[sessionStartExecStmt] = timeutil.Now()
+	planMaker.phaseTimes[sessionStartExecStmt] = timeutil.Now()
 	planMaker.evalCtx.SetTxnTimestamp(txnState.sqlTimestamp)
 	planMaker.evalCtx.SetStmtTimestamp(e.cfg.Clock.PhysicalTime())
 
@@ -1384,10 +1384,9 @@ func (e *Executor) execStmt(
 ) (Result, error) {
 	session := planMaker.session
 
-	session.phaseTimes[sessionStartLogicalPlan] = timeutil.Now()
+	planMaker.phaseTimes[sessionStartLogicalPlan] = timeutil.Now()
 	plan, err := planMaker.makePlan(session.Ctx(), stmt, autoCommit)
-	session.phaseTimes[sessionEndLogicalPlan] = timeutil.Now()
-
+	planMaker.phaseTimes[sessionEndLogicalPlan] = timeutil.Now()
 	if err != nil {
 		return Result{}, err
 	}
@@ -1413,15 +1412,15 @@ func (e *Executor) execStmt(
 		return result, err
 	}
 
-	session.phaseTimes[sessionStartExecStmt] = timeutil.Now()
+	planMaker.phaseTimes[sessionStartExecStmt] = timeutil.Now()
 	if useDistSQL {
 		err = e.execDistSQL(planMaker, plan, &result)
 	} else {
 		err = e.execClassic(planMaker, plan, &result)
 	}
-	session.phaseTimes[sessionEndExecStmt] = timeutil.Now()
+	planMaker.phaseTimes[sessionEndExecStmt] = timeutil.Now()
 	e.recordStatementSummary(
-		session, stmt, useDistSQL, automaticRetryCount, result, err,
+		planMaker, stmt, useDistSQL, automaticRetryCount, result, err,
 	)
 	return result, err
 }

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -510,8 +510,8 @@ func (e *Executor) CopyDone(session *Session) StatementResults {
 
 // CopyEnd ends the COPY mode. Any buffered data is discarded.
 func (session *Session) CopyEnd(ctx context.Context) {
-	session.planner.copyFrom.Close(ctx)
-	session.planner.copyFrom = nil
+	session.copyFrom.Close(ctx)
+	session.copyFrom = nil
 }
 
 // blockConfigUpdates blocks any gossip updates to the system config
@@ -558,7 +558,7 @@ func (e *Executor) execRequest(session *Session, sql string, copymsg copyMsg) St
 	}
 
 	session.phaseTimes[sessionStartParse] = timeutil.Now()
-	if session.planner.copyFrom != nil {
+	if session.copyFrom != nil {
 		stmts, err = session.planner.ProcessCopyData(session.Ctx(), sql, copymsg)
 	} else if copymsg != copyMsgNone {
 		err = fmt.Errorf("unexpected copy command")

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -70,16 +70,16 @@ type phaseTimes [sessionNumPhases]time.Time
 // - result is the result set computed by the query/statement.
 // - err is the error encountered, if any.
 func (e *Executor) recordStatementSummary(
-	session *Session,
+	planner *planner,
 	stmt parser.Statement,
 	distSQLUsed bool,
 	automaticRetryCount int,
 	result Result,
 	err error,
 ) {
-	session.appStats.recordStatement()
+	planner.session.appStats.recordStatement()
 
-	phaseTimes := &session.phaseTimes
+	phaseTimes := &planner.phaseTimes
 
 	// Compute the run latency. This is always recorded in the
 	// server metrics.
@@ -125,7 +125,7 @@ func (e *Executor) recordStatementSummary(
 			numRows = result.Rows.Len()
 		}
 
-		log.Infof(session.Ctx(),
+		log.Infof(planner.session.Ctx(),
 			"query stats: %d rows, %d retries, "+
 				"parse %.2fµs (%.1f%%), "+
 				"plan %.2fµs (%.1f%%), "+

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -145,7 +145,7 @@ func (p *planner) Explain(
 	case explainDistSQL:
 		return &explainDistSQLNode{
 			plan:           plan,
-			distSQLPlanner: p.distSQLPlanner,
+			distSQLPlanner: p.session.distSQLPlanner,
 			txn:            p.txn,
 		}, nil
 

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -45,7 +45,7 @@ func (ie InternalExecutor) ExecuteStatementInTransaction(
 ) (int, error) {
 	p := makeInternalPlanner(opName, txn, security.RootUser, ie.LeaseManager.memMetrics)
 	defer finishInternalPlanner(p)
-	p.leaseMgr = ie.LeaseManager
+	p.session.leaseMgr = ie.LeaseManager
 	return p.exec(ctx, statement, qargs...)
 }
 
@@ -56,7 +56,7 @@ func (ie InternalExecutor) GetTableSpan(
 	// Lookup the table ID.
 	p := makeInternalPlanner("get-table-span", txn, user, ie.LeaseManager.memMetrics)
 	defer finishInternalPlanner(p)
-	p.leaseMgr = ie.LeaseManager
+	p.session.leaseMgr = ie.LeaseManager
 
 	tn := parser.TableName{DatabaseName: parser.Name(dbName), TableName: parser.Name(tableName)}
 	tableID, err := getTableID(ctx, p, &tn)

--- a/pkg/sql/parser/placeholders.go
+++ b/pkg/sql/parser/placeholders.go
@@ -36,9 +36,9 @@ type PlaceholderInfo struct {
 	Types  PlaceholderTypes
 }
 
-// NewPlaceholderInfo constructs an empty PlaceholderInfo.
-func NewPlaceholderInfo() *PlaceholderInfo {
-	res := &PlaceholderInfo{}
+// MakePlaceholderInfo constructs an empty PlaceholderInfo.
+func MakePlaceholderInfo() PlaceholderInfo {
+	res := PlaceholderInfo{}
 	res.Clear()
 	return res
 }

--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -31,7 +31,7 @@ import (
 // expression syntax tree.
 type SemaContext struct {
 	// Placeholders relates placeholder names to their type and, later, value.
-	Placeholders *PlaceholderInfo
+	Placeholders PlaceholderInfo
 
 	// Location references the *Location on the current Session.
 	Location **time.Location
@@ -46,7 +46,7 @@ type SemaContext struct {
 // for "lightweight" type checking such as the one performed for default
 // expressions.
 func MakeSemaContext() SemaContext {
-	return SemaContext{Placeholders: NewPlaceholderInfo()}
+	return SemaContext{Placeholders: MakePlaceholderInfo()}
 }
 
 // isUnresolvedPlaceholder provides a nil-safe method to determine whether expr is an

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -330,7 +330,7 @@ func (p *planner) query(ctx context.Context, sql string, args ...interface{}) (p
 	if err != nil {
 		return nil, err
 	}
-	golangFillQueryArguments(p.semaCtx.Placeholders, args)
+	golangFillQueryArguments(&p.semaCtx.Placeholders, args)
 	return p.makePlan(ctx, stmt, false)
 }
 

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -62,6 +62,10 @@ type planner struct {
 	// initializing plans to read from a table. This should be used with care.
 	skipSelectPrivilegeChecks bool
 
+	// phaseTimes helps measure the time spent in each phase of SQL execution.
+	// See executor_statement_metrics.go for details.
+	phaseTimes phaseTimes
+
 	// Avoid allocations by embedding commonly used objects and visitors.
 	parser                parser.Parser
 	subqueryVisitor       subqueryVisitor

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -35,32 +35,22 @@ import (
 
 // planner is the centerpiece of SQL statement execution combining session
 // state and database state with the logic for SQL execution.
-// A planner is generally part of a Session object. If one needs to be created
-// outside of a Session, use makePlanner().
+//
+// A planner is generally part of a Session object. It is logically scoped
+// to the execution of a single statement, but can be reused after a statement's
+// execution completes. It is not safe to use the same planner from multiple
+// goroutines concurrently.
+//
+// If one needs to be created outside of a Session, use makePlanner().
 type planner struct {
 	txn *client.Txn
+
 	// As the planner executes statements, it may change the current user session.
-	// TODO(andrei): see if the circular dependency between planner and Session
-	// can be broken if we move the User and Database here from the Session.
-	session  *Session
-	semaCtx  parser.SemaContext
-	evalCtx  parser.EvalContext
-	leases   []*LeaseState
-	leaseMgr *LeaseManager
-	sqlStats *sqlStats
+	session *Session
 
-	distSQLPlanner *distSQLPlanner
-
-	// This is used as a cache for database names.
-	// TODO(andrei): get rid of it and replace it with a leasing system for
-	// database descriptors.
-	systemConfig  config.SystemConfig
-	databaseCache *databaseCache
-
-	testingVerifyMetadataFn func(config.SystemConfig) error
-	verifyFnCheckedOnce     bool
-
-	parser parser.Parser
+	// Contexts for different stages of planning and execution.
+	semaCtx parser.SemaContext
+	evalCtx parser.EvalContext
 
 	// If set, table descriptors will only be fetched at the time of the
 	// transaction, not leased. This is used for things like AS OF SYSTEM TIME
@@ -72,15 +62,18 @@ type planner struct {
 	// initializing plans to read from a table. This should be used with care.
 	skipSelectPrivilegeChecks bool
 
-	// If set, contains the in progress COPY FROM columns.
-	copyFrom *copyNode
-
-	// Avoid allocations by embedding commonly used visitors.
+	// Avoid allocations by embedding commonly used objects and visitors.
+	parser                parser.Parser
 	subqueryVisitor       subqueryVisitor
 	subqueryPlanVisitor   subqueryPlanVisitor
 	nameResolutionVisitor nameResolutionVisitor
 
-	execCfg *ExecutorConfig
+	// If set, called after the planner is done executing the current SQL statement.
+	// It can be used to verify assumptions about how metadata will be asynchronously
+	// updated. Note that this can overwrite a previous callback that was waiting to be
+	// verified, which is not ideal.
+	testingVerifyMetadataFn func(config.SystemConfig) error
+	verifyFnCheckedOnce     bool
 
 	noCopy util.NoCopy
 }
@@ -226,23 +219,7 @@ type queryRunner interface {
 var _ queryRunner = &planner{}
 
 func (p *planner) ExecCfg() *ExecutorConfig {
-	return p.execCfg
-}
-
-// hijackCtx changes the current transaction's context to the provided one and
-// returns a cleanup function to be used to restore the original context when
-// the hijack is no longer needed.
-// TODO(andrei): delete this when EXPLAIN(TRACE) goes away
-func (p *planner) hijackCtx(ctx context.Context) func() {
-	if p.session.TxnState.State != Open {
-		// This hijacking is dubious to begin with. Let's at least assert it's being
-		// done when the TxnState is in an expected state. In particular, if the
-		// state would be NoTxn, then we'd need to hijack session.Ctx instead of the
-		// txnState's context.
-		log.Fatalf(ctx, "can only hijack while a SQL txn is Open. txnState: %+v",
-			&p.session.TxnState)
-	}
-	return p.session.TxnState.hijackCtx(ctx)
+	return p.session.execCfg
 }
 
 // setTxn implements the queryRunner interface.
@@ -309,8 +286,8 @@ func (p *planner) resetForBatch(e *Executor) {
 	// Update the systemConfig to a more recent copy, so that we can use tables
 	// that we created in previus batches of the same transaction.
 	cfg, cache := e.getSystemConfig()
-	p.systemConfig = cfg
-	p.databaseCache = cache
+	p.session.systemConfig = cfg
+	p.session.databaseCache = cache
 	p.session.TxnState.schemaChangers.curGroupNum++
 	p.resetContexts()
 	p.evalCtx.NodeID = e.cfg.NodeID.Get()
@@ -425,7 +402,7 @@ func (p *planner) blockConfigUpdatesMaybe(e *Executor) func() {
 
 // checkTestingVerifyMetadataInitialOrDie implements the queryRunner interface.
 func (p *planner) checkTestingVerifyMetadataInitialOrDie(e *Executor, stmts parser.StatementList) {
-	if !p.execCfg.TestingKnobs.WaitForGossipUpdate {
+	if !p.session.execCfg.TestingKnobs.WaitForGossipUpdate {
 		return
 	}
 	// If there's nothinging to verify, or we've already verified the initial
@@ -443,7 +420,7 @@ func (p *planner) checkTestingVerifyMetadataInitialOrDie(e *Executor, stmts pars
 
 // checkTestingVerifyMetadataOrDie implements the queryRunner interface.
 func (p *planner) checkTestingVerifyMetadataOrDie(e *Executor, stmts parser.StatementList) {
-	if !p.execCfg.TestingKnobs.WaitForGossipUpdate ||
+	if !p.session.execCfg.TestingKnobs.WaitForGossipUpdate ||
 		p.testingVerifyMetadataFn == nil {
 		return
 	}

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -181,9 +181,6 @@ type Session struct {
 	sqlStats *sqlStats
 	// appStats track per-application SQL usage statistics.
 	appStats *appStats
-	// phaseTimes contains helps measure the time spent in each phase of
-	// SQL execution. See executor_statement_metrics.go for details.
-	phaseTimes phaseTimes
 
 	// noCopy is placed here to guarantee that Session objects are not
 	// copied.
@@ -218,10 +215,10 @@ func NewSession(
 		memMetrics:     memMetrics,
 		sqlStats:       &e.sqlStats,
 	}
-	s.phaseTimes[sessionInit] = timeutil.Now()
 	s.planner = planner{
 		session: s,
 	}
+	s.planner.phaseTimes[sessionInit] = timeutil.Now()
 	s.resetApplicationName(args.ApplicationName)
 	s.PreparedStatements = makePreparedStatements(s)
 	s.PreparedPortals = makePreparedPortals(s)

--- a/pkg/sql/split.go
+++ b/pkg/sql/split.go
@@ -125,7 +125,7 @@ func (n *splitNode) Start(context.Context) error {
 	}
 	n.key = keys.MakeRowSentinelKey(key)
 
-	return n.p.execCfg.DB.AdminSplit(context.TODO(), n.key)
+	return n.p.session.execCfg.DB.AdminSplit(context.TODO(), n.key)
 }
 
 func (n *splitNode) Next(context.Context) (bool, error) {

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -310,7 +310,7 @@ func (p *planner) getTableLease(
 	// continue to use N to refer to X even if N is renamed during the
 	// transaction.
 	var lease *LeaseState
-	for _, l := range p.leases {
+	for _, l := range p.session.leases {
 		if parser.ReNormalizeName(l.Name) == tn.TableName.Normalize() &&
 			l.ParentID == dbID {
 			lease = l
@@ -324,7 +324,7 @@ func (p *planner) getTableLease(
 	// If we didn't find a lease or the lease is about to expire, acquire one.
 	if lease == nil || p.removeLeaseIfExpiring(ctx, lease) {
 		var err error
-		lease, err = p.leaseMgr.AcquireByName(ctx, p.txn, dbID, tn.Table())
+		lease, err = p.session.leaseMgr.AcquireByName(ctx, p.txn, dbID, tn.Table())
 		if err != nil {
 			if err == sqlbase.ErrDescriptorNotFound {
 				// Transform the descriptor error into an error that references the
@@ -333,7 +333,7 @@ func (p *planner) getTableLease(
 			}
 			return nil, err
 		}
-		p.leases = append(p.leases, lease)
+		p.session.leases = append(p.session.leases, lease)
 		if log.V(2) {
 			log.Infof(ctx, "added lease on table '%s' to planner cache", tn)
 		}
@@ -366,7 +366,7 @@ func (p *planner) getTableLeaseByID(
 	// First, look to see if we already have a lease for this table -- including
 	// leases acquired via `getTableLease`.
 	var lease *LeaseState
-	for _, l := range p.leases {
+	for _, l := range p.session.leases {
 		if l.ID == tableID {
 			lease = l
 			if log.V(2) {
@@ -379,7 +379,7 @@ func (p *planner) getTableLeaseByID(
 	// If we didn't find a lease or the lease is about to expire, acquire one.
 	if lease == nil || p.removeLeaseIfExpiring(ctx, lease) {
 		var err error
-		lease, err = p.leaseMgr.Acquire(ctx, p.txn, tableID, 0)
+		lease, err = p.session.leaseMgr.Acquire(ctx, p.txn, tableID, 0)
 		if err != nil {
 			if err == sqlbase.ErrDescriptorNotFound {
 				// Transform the descriptor error into an error that references the
@@ -388,7 +388,7 @@ func (p *planner) getTableLeaseByID(
 			}
 			return nil, err
 		}
-		p.leases = append(p.leases, lease)
+		p.session.leases = append(p.session.leases, lease)
 		// If the lease we just acquired expires before the txn's deadline, reduce
 		// the deadline.
 		p.txn.UpdateDeadlineMaybe(hlc.Timestamp{WallTime: lease.Expiration().UnixNano()})
@@ -399,13 +399,14 @@ func (p *planner) getTableLeaseByID(
 // removeLeaseIfExpiring removes a lease and returns true if it is about to expire.
 // The method also resets the transaction deadline.
 func (p *planner) removeLeaseIfExpiring(ctx context.Context, lease *LeaseState) bool {
-	if lease == nil || lease.hasSomeLifeLeft(p.leaseMgr.clock) {
+	session := p.session
+	if lease == nil || lease.hasSomeLifeLeft(session.leaseMgr.clock) {
 		return false
 	}
 
-	// Remove the lease from p.leases.
+	// Remove the lease from session.leases.
 	idx := -1
-	for i, l := range p.leases {
+	for i, l := range session.leases {
 		if l == lease {
 			idx = i
 			break
@@ -415,17 +416,17 @@ func (p *planner) removeLeaseIfExpiring(ctx context.Context, lease *LeaseState) 
 		log.Warningf(ctx, "lease (%s) not found", lease)
 		return false
 	}
-	p.leases[idx] = p.leases[len(p.leases)-1]
-	p.leases[len(p.leases)-1] = nil
-	p.leases = p.leases[:len(p.leases)-1]
+	session.leases[idx] = session.leases[len(session.leases)-1]
+	session.leases[len(session.leases)-1] = nil
+	session.leases = session.leases[:len(session.leases)-1]
 
-	if err := p.leaseMgr.Release(lease); err != nil {
+	if err := session.leaseMgr.Release(lease); err != nil {
 		log.Warning(ctx, err)
 	}
 
 	// Reset the deadline so that a new deadline will be set after the lease is acquired.
 	p.txn.ResetDeadline()
-	for _, l := range p.leases {
+	for _, l := range session.leases {
 		p.txn.UpdateDeadlineMaybe(hlc.Timestamp{WallTime: l.Expiration().UnixNano()})
 	}
 	return true
@@ -478,23 +479,24 @@ func (p *planner) notifySchemaChange(id sqlbase.ID, mutationID sqlbase.MutationI
 		tableID:    id,
 		mutationID: mutationID,
 		nodeID:     p.evalCtx.NodeID,
-		leaseMgr:   p.leaseMgr,
+		leaseMgr:   p.session.leaseMgr,
 	}
 	p.session.TxnState.schemaChangers.queueSchemaChanger(sc)
 }
 
 // releaseLeases implements the SchemaAccessor interface.
 func (p *planner) releaseLeases(ctx context.Context) {
-	if p.leases != nil {
+	session := p.session
+	if session.leases != nil {
 		if log.V(2) {
-			log.Infof(ctx, "planner releasing %d leases", len(p.leases))
+			log.Infof(ctx, "planner releasing %d leases", len(session.leases))
 		}
-		for _, lease := range p.leases {
-			if err := p.leaseMgr.Release(lease); err != nil {
+		for _, lease := range session.leases {
+			if err := session.leaseMgr.Release(lease); err != nil {
 				log.Warning(ctx, err)
 			}
 		}
-		p.leases = nil
+		session.leases = nil
 	}
 }
 

--- a/pkg/sql/trace.go
+++ b/pkg/sql/trace.go
@@ -114,7 +114,7 @@ func (n *explainTraceNode) hijackTxnContext(ctx context.Context) error {
 	// Everything running on the planner/session until Close() will be done with
 	// the tracingCtx. More exactly, the inner n.plan will run with this hijacked
 	// context.
-	n.restorePlannerCtx = n.p.hijackCtx(tracingCtx)
+	n.restorePlannerCtx = n.p.session.hijackCtx(tracingCtx)
 	return nil
 }
 

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -245,7 +245,7 @@ func (p *planner) Update(
 		if err != nil {
 			return nil, err
 		}
-		err = sqlbase.CheckColumnType(updateCols[i], typedTarget.ResolvedType(), p.semaCtx.Placeholders)
+		err = sqlbase.CheckColumnType(updateCols[i], typedTarget.ResolvedType(), &p.semaCtx.Placeholders)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Up until now we have stored a number of session-related items in the
`sql.planner` object instead of in the `sql.Session` object itself. This
was not a big issue in the past because both the `Session` and `planner`
almost always shared the same lifetime and have a circular dependency,
meaning that they can reference each other.

Now that we're planning on running multiple statements concurrently, it
is valuable to scope the planner to the execution of exactly one
statement. This will allow us to clone it before executing a statement
in a different goroutine. To do this, we need to move some session-wide
state from the `planner` to the `Session` itself. This state includes
objects dealing with table leases (`LeaseState` and `LeaseManager`), the
`databaseCache`, and the pending `copyNode`.

In general, this distinction means that the planner does not need to be
safe to use concurrently, while the Session should be thread-safe (within
normal operation).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14187)
<!-- Reviewable:end -->
