### PR TITLE
build: disable Go version check on macOS builds for TeamCity

### DIFF
--- a/build/build-osx.sh
+++ b/build/build-osx.sh
@@ -5,6 +5,10 @@ set -eu
 cd "$(dirname "${0}")"/..
 
 go get -u github.com/karalabe/xgo
-# OSX 10.9 is the most recent version available at time of writing.
-# If changing the OS/arch target, adjust the filename in push-aws.sh.
-make xgo-build GOFLAGS='--image cockroachdb/xgo:20170218 --targets=darwin-10.9/amd64' TYPE=release
+# OSX 10.9 is the most recent version available at time of writing. If changing
+# the OS/arch target, adjust the filename in push-aws.sh.
+#
+# We additionally set GOVERS= to disable the Go version check. This allows
+# building in environments without a Go toolchain, like TeamCity build agents.
+# xgo will use the Go toolchain in its Docker image regardless.
+make xgo-build GOVERS= GOFLAGS='--image cockroachdb/xgo:20170218 --targets=darwin-10.9/amd64' TYPE=release


### PR DESCRIPTION
We run `xgo` directly on TeamCity agents (not in a Docker image), which
don't have a Go toolchain. This fails the Makefile's Go version check,
even though we're going to build with the xgo toolchain anyway. So this
commit disable the version check in build/build-osx.sh to unbrick TC
release builds.

Fixes #14104.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14191)
<!-- Reviewable:end -->
