### PR TITLE
cli/interactive_tests: deflake test_missing_log_output.

### DIFF
--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -56,11 +56,7 @@ eexpect "marker\r\nCockroachDB node starting"
 interrupt
 eexpect ":/# "
 
-# Start a regular server
-send "mkfifo pid_fifo || true\r"
-send "$argv start --pid-file=pid_fifo >/dev/null 2>&1 & cat pid_fifo; echo started\r"
-eexpect "\r\nstarted"
-eexpect ":/# "
+start_server $argv
 
 # Now test `quit` as non-start command, and test that `quit` does not
 # emit logging output between the point the command starts until it


### PR DESCRIPTION
I guess I simply forgot about `--background`. That's what `start_server` does.

Fixes #14002. (I hope!)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14199)
<!-- Reviewable:end -->
