### PR TITLE
Makefile: make go version errors print to stderr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ endif
 .go-version:
 	@actual=$$($(GO) version); \
 	echo "$${actual}" | grep -q -E '\b$(GOVERS)\b' || \
-	  (echo "$(GOVERS) required (see CONTRIBUTING.md): $${actual}" && false)
+	  (echo "$(GOVERS) required (see CONTRIBUTING.md): $${actual}" >&2 && false)
 
 include .go-version
 


### PR DESCRIPTION
Previously, the Go version error would be hidden away in the TeamCity
build log and not visible in the build summary log because it was
printed on stdout. (This message belongs on stderr anyway.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14201)
<!-- Reviewable:end -->
