### PR TITLE
storageccl: fix a correctness bug in Import

### DIFF
--- a/pkg/ccl/storageccl/engineccl/multi_iterator.go
+++ b/pkg/ccl/storageccl/engineccl/multi_iterator.go
@@ -1,0 +1,163 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+
+package engineccl
+
+import (
+	"bytes"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/pkg/errors"
+)
+
+const invalidIdxSentinel = -1
+
+// MultiIterator multiplexes iteration over a number of engine.Iterators.
+type MultiIterator struct {
+	iters []engine.Iterator
+	// The index into `iters` of the iterator currently being pointed at.
+	currentIdx int
+	// The indexes of every iterator with the same key as the one in currentIdx.
+	itersWithCurrentKey []int
+
+	// err, if non-nil, is an error encountered by one of the underlying
+	// Iterators or in some incompatibility between them. If err is non-nil,
+	// Valid must return false.
+	err error
+}
+
+// TODO(dan): The methods on MultiIterator intentionally have the same
+// signatures as the ones on engine.Iterator, though not all of them are
+// present. Consider making an interface that's a subset (SimpleIterator?) and
+// unexport MultiIterator.
+
+// MakeMultiIterator creates an iterator that multiplexes engine.Iterators.
+func MakeMultiIterator(iters []engine.Iterator) *MultiIterator {
+	return &MultiIterator{
+		iters:               iters,
+		currentIdx:          invalidIdxSentinel,
+		itersWithCurrentKey: make([]int, 0, len(iters)),
+	}
+}
+
+// Seek advances the iterator to the first key in the engine which is >= the
+// provided key.
+func (f *MultiIterator) Seek(key engine.MVCCKey) {
+	for _, iter := range f.iters {
+		iter.Seek(key)
+	}
+	// Each of the iterators now points at the first key >= key. Set currentIdx
+	// and itersWithCurrentKey but don't advance any of the underlying
+	// iterators.
+	f.advance()
+}
+
+// Valid returns true if the iterator is currently valid. An iterator that
+// hasn't had Seek called on it or has gone past the end of the key range is
+// invalid.
+func (f *MultiIterator) Valid() bool {
+	return f.currentIdx != invalidIdxSentinel && f.err == nil
+}
+
+// Error returns the error, if any, which the iterator encountered.
+func (f *MultiIterator) Error() error {
+	return f.err
+}
+
+// UnsafeKey returns the current key, but the memory is invalidated on the next
+// call to {NextKey,Seek}.
+func (f *MultiIterator) UnsafeKey() engine.MVCCKey {
+	return f.iters[f.currentIdx].UnsafeKey()
+}
+
+// UnsafeValue returns the current value as a byte slice, but the memory is
+// invalidated on the next call to {NextKey,Seek}.
+func (f *MultiIterator) UnsafeValue() []byte {
+	return f.iters[f.currentIdx].UnsafeValue()
+}
+
+// Next advances the iterator to the next key/value in the iteration. After this
+// call, Valid() will be true if the iterator was not positioned at the last
+// key.
+func (f *MultiIterator) Next() {
+	// Advance the current iterator one and recompute currentIdx.
+	f.iters[f.currentIdx].Next()
+	f.advance()
+}
+
+// NextKey advances the iterator to the next MVCC key. This operation is
+// distinct from Next which advances to the next version of the current key or
+// the next key if the iterator is currently located at the last version for a
+// key.
+func (f *MultiIterator) NextKey() {
+	// Advance each iterator at the current key to its next key, then recompute
+	// currentIdx.
+	for _, iterIdx := range f.itersWithCurrentKey {
+		f.iters[iterIdx].NextKey()
+	}
+	f.advance()
+}
+
+func (f *MultiIterator) advance() {
+	// Loop through every iterator, storing the best next value for currentIdx
+	// in proposedNextIdx as we go. If it's still invalidIdxSentinel at the end,
+	// then all the underlying iterators are exhausted and so is this one.
+	proposedNextIdx := invalidIdxSentinel
+	for iterIdx, iter := range f.iters {
+		// If this iterator is exhausted skip it (or error if it's errored).
+		// TODO(dan): Iterators that are exhausted could be removed to save
+		// having to check them on all future calls to advance.
+		if !iter.Valid() {
+			if err := iter.Error(); err != nil {
+				f.err = err
+				return
+			}
+			continue
+		}
+
+		// Fill proposedMVCCKey with the mvcc key of the current best for the
+		// next value for currentIdx (or a sentinel that sorts after everything
+		// if this is the first non-exhausted iterator).
+		proposedMVCCKey := engine.MVCCKey{Key: keys.MaxKey}
+		if proposedNextIdx != invalidIdxSentinel {
+			proposedMVCCKey = f.iters[proposedNextIdx].UnsafeKey()
+		}
+
+		iterMVCCKey := iter.UnsafeKey()
+		if cmp := bytes.Compare(iterMVCCKey.Key, proposedMVCCKey.Key); cmp < 0 {
+			// The iterator at iterIdx has a lower key than any seen so far.
+			// Update proposedNextIdx with it and reset itersWithCurrentKey
+			// (because everything seen so for must have had a higher key).
+			f.itersWithCurrentKey = f.itersWithCurrentKey[:0]
+			f.itersWithCurrentKey = append(f.itersWithCurrentKey, iterIdx)
+			proposedNextIdx = iterIdx
+		} else if cmp == 0 {
+			// The iterator at iterIdx has the same key as the current best, add
+			// it to itersWithCurrentKey and check how the timestamps compare.
+			f.itersWithCurrentKey = append(f.itersWithCurrentKey, iterIdx)
+			if proposedMVCCKey.Timestamp.Less(iterMVCCKey.Timestamp) {
+				// This iterator has a greater timestamp and so should sort
+				// first, update the current best.
+				proposedNextIdx = iterIdx
+			} else if proposedMVCCKey.Timestamp == iterMVCCKey.Timestamp {
+				// We have two exactly equal mvcc keys (both key and timestamps
+				// match). It's ambiguous which should sort first, so error.
+				f.err = errors.Errorf(
+					"got two entries for the same key and timestamp %s: %x vs %x",
+					iterMVCCKey, f.iters[proposedNextIdx].UnsafeValue(), f.iters[proposedNextIdx].UnsafeValue(),
+				)
+				return
+			}
+		}
+	}
+
+	// NB: proposedNextIdx will still be invalidIdxSentinel here if this
+	// iterator is exhausted.
+	f.currentIdx = proposedNextIdx
+}

--- a/pkg/ccl/storageccl/engineccl/multi_iterator_test.go
+++ b/pkg/ccl/storageccl/engineccl/multi_iterator_test.go
@@ -1,0 +1,130 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+
+package engineccl
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestMultiIterator(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	rocksDB := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	defer rocksDB.Close()
+
+	// Each `input` is turned into an iterator and these are passed to a new
+	// MultiIterator, which is fully iterated (using either NextKey or Next) and
+	// turned back into a string in the same format as `input`. This is compared
+	// to expectedNextKey or expectedNext (or if len(errRE) > 0, the expected
+	// string is ignored and an error matching the regex is required.)
+	//
+	// Input is a string containing key, timestamp, value tuples: first a single
+	// character key, then a single character timestamp walltime. If the
+	// character after the timestamp is an X, this entry is a deletion
+	// tombstone, otherwise the value is the same as the timestamp.
+	tests := []struct {
+		inputs          []string
+		expectedNextKey string
+		expectedNext    string
+		errRE           string
+	}{
+		{[]string{}, "", "", ""},
+
+		{[]string{"a1"}, "a1", "a1", ""},
+		{[]string{"a1b1"}, "a1b1", "a1b1", ""},
+		{[]string{"a2a1"}, "a2", "a2a1", ""},
+		{[]string{"a2a1b1"}, "a2b1", "a2a1b1", ""},
+
+		{[]string{"a1", "a2"}, "a2", "a2a1", ""},
+		{[]string{"a2", "a1"}, "a2", "a2a1", ""},
+		{[]string{"a1", "b2"}, "a1b2", "a1b2", ""},
+		{[]string{"b2", "a1"}, "a1b2", "a1b2", ""},
+		{[]string{"a1b2", "b3"}, "a1b3", "a1b3b2", ""},
+		{[]string{"a1c2", "b3"}, "a1b3c2", "a1b3c2", ""},
+
+		{[]string{"a1", "a2X"}, "a2X", "a2Xa1", ""},
+		{[]string{"a1", "a2X", "a3"}, "a3", "a3a2Xa1", ""},
+		{[]string{"a1", "a2Xb2"}, "a2Xb2", "a2Xa1b2", ""},
+		{[]string{"a1b2", "a2X"}, "a2Xb2", "a2Xa1b2", ""},
+
+		{[]string{"a1", "a1"}, "", "", "two entries for the same key and timestamp"},
+	}
+	for _, test := range tests {
+		name := fmt.Sprintf("%q", test.inputs)
+		t.Run(name, func(t *testing.T) {
+			var iters []engine.Iterator
+			for _, input := range test.inputs {
+				batch := rocksDB.NewBatch()
+				defer batch.Close()
+				for i := 0; ; {
+					if i == len(input) {
+						break
+					}
+					k := []byte{input[i]}
+					ts := hlc.Timestamp{WallTime: int64(input[i+1])}
+					var v []byte
+					if i+2 < len(input) && input[i+2] == 'X' {
+						v = nil
+						i++
+					} else {
+						v = []byte{input[i+1]}
+					}
+					i += 2
+					if err := batch.Put(engine.MVCCKey{Key: k, Timestamp: ts}, v); err != nil {
+						t.Fatalf("%+v", err)
+					}
+				}
+				iter := batch.NewIterator(false)
+				defer iter.Close()
+				iters = append(iters, iter)
+			}
+
+			subtests := []struct {
+				name     string
+				expected string
+				fn       func(*MultiIterator)
+			}{
+				{"NextKey", test.expectedNextKey, (*MultiIterator).NextKey},
+				{"Next", test.expectedNext, (*MultiIterator).Next},
+			}
+			for _, subtest := range subtests {
+				t.Run(subtest.name, func(t *testing.T) {
+					var output bytes.Buffer
+					it := MakeMultiIterator(iters)
+					for it.Seek(engine.MVCCKey{Key: keys.MinKey}); it.Valid(); subtest.fn(it) {
+						output.Write(it.UnsafeKey().Key)
+						output.WriteByte(byte(it.UnsafeKey().Timestamp.WallTime))
+						if len(it.UnsafeValue()) == 0 {
+							output.WriteRune('X')
+						}
+					}
+					if err := it.Error(); len(test.errRE) > 0 {
+						if !testutils.IsError(err, test.errRE) {
+							t.Fatalf("expected '%s' error got: %+v", test.errRE, err)
+						}
+					} else if err != nil {
+						t.Fatalf("unexpected error: %+v", err)
+					}
+					if actual := output.String(); actual != subtest.expected {
+						t.Errorf("got %q expected %q", actual, subtest.expected)
+					}
+				})
+			}
+		})
+	}
+}

--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -9,7 +9,10 @@
 package storageccl
 
 import (
+	"fmt"
 	"path/filepath"
+	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -26,22 +29,72 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/pkg/errors"
 )
 
-func writeOneKeySST(path string, key []byte) error {
-	sst := engine.MakeRocksDBSstFileWriter()
-	if err := sst.Open(path); err != nil {
-		_ = sst.Close()
-		return err
+func slurpSSTablesLatestKey(
+	dir string, paths []string, kr KeyRewriter,
+) ([]engine.MVCCKeyValue, error) {
+	start, end := engine.MVCCKey{Key: keys.MinKey}, engine.MVCCKey{Key: keys.MaxKey}
+
+	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	defer e.Close()
+	batch := e.NewBatch()
+	defer batch.Close()
+
+	for _, path := range paths {
+		sst, err := engine.MakeRocksDBSstFileReader()
+		if err != nil {
+			return nil, err
+		}
+		defer sst.Close()
+		if err := sst.AddFile(filepath.Join(dir, path)); err != nil {
+			return nil, err
+		}
+		if err := sst.Iterate(start, end, func(kv engine.MVCCKeyValue) (bool, error) {
+			var ok bool
+			kv.Key.Key, ok = kr.RewriteKey(kv.Key.Key)
+			if !ok {
+				return true, errors.Errorf("could not rewrite key: %s", roachpb.Key(kv.Key.Key))
+			}
+			v := roachpb.Value{RawBytes: kv.Value}
+			v.ClearChecksum()
+			v.InitChecksum(kv.Key.Key)
+			if err := batch.Put(kv.Key, v.RawBytes); err != nil {
+				return true, err
+			}
+			return false, nil
+		}); err != nil {
+			return nil, err
+		}
 	}
-	ts := hlc.NewClock(hlc.UnixNano, time.Nanosecond).Now()
-	value := roachpb.MakeValueFromString("bar")
-	value.InitChecksum(key)
-	kv := engine.MVCCKeyValue{Key: engine.MVCCKey{Key: key, Timestamp: ts}, Value: value.RawBytes}
-	if err := sst.Add(kv); err != nil {
-		return err
+
+	var kvs []engine.MVCCKeyValue
+	it := batch.NewIterator(false)
+	defer it.Close()
+	for it.Seek(start); it.Valid() && it.UnsafeKey().Less(end); it.NextKey() {
+		kvs = append(kvs, engine.MVCCKeyValue{Key: it.Key(), Value: it.Value()})
 	}
-	return sst.Close()
+	if err := it.Error(); err != nil {
+		return nil, err
+	}
+	return kvs, nil
+}
+
+func clientKVsToEngineKVs(kvs []client.KeyValue) []engine.MVCCKeyValue {
+	var ret []engine.MVCCKeyValue
+	for _, kv := range kvs {
+		if kv.Value == nil {
+			continue
+		}
+		k := engine.MVCCKey{
+			Key:       kv.Key,
+			Timestamp: kv.Value.Timestamp,
+		}
+		ret = append(ret, engine.MVCCKeyValue{Key: k, Value: kv.Value.RawBytes})
+	}
+	return ret
 }
 
 func TestImport(t *testing.T) {
@@ -52,20 +105,49 @@ func TestImport(t *testing.T) {
 
 	dir, dirCleanupFn := testutils.TempDir(t, 0)
 	defer dirCleanupFn()
-	ctx := context.Background()
 
-	kr := KeyRewriter([]roachpb.KeyRewrite{
-		{OldPrefix: keys.MakeTablePrefix(0), NewPrefix: keys.MakeTablePrefix(100)},
-	})
+	writeSST := func(keys ...[]byte) string {
+		path := strconv.FormatInt(hlc.UnixNano(), 10)
 
-	const sstName = "data.sst"
-	key := encoding.EncodeBytesAscending(kr[0].OldPrefix, []byte("foo"))
-	if err := writeOneKeySST(filepath.Join(dir, sstName), key); err != nil {
-		t.Fatalf("%+v", err)
+		sst := engine.MakeRocksDBSstFileWriter()
+		if err := sst.Open(filepath.Join(dir, path)); err != nil {
+			_ = sst.Close()
+			t.Fatalf("%+v", err)
+		}
+		ts := hlc.NewClock(hlc.UnixNano, time.Nanosecond).Now()
+		value := roachpb.MakeValueFromString("bar")
+		for _, key := range keys {
+			value.ClearChecksum()
+			value.InitChecksum(key)
+			kv := engine.MVCCKeyValue{Key: engine.MVCCKey{Key: key, Timestamp: ts}, Value: value.RawBytes}
+			if err := sst.Add(kv); err != nil {
+				t.Fatalf("%+v", err)
+			}
+		}
+		if err := sst.Close(); err != nil {
+			t.Fatalf("%+v", err)
+		}
+		return path
 	}
 
-	dataStartKey := roachpb.Key(key)
-	dataEndKey := dataStartKey.PrefixEnd()
+	kr := KeyRewriter([]roachpb.KeyRewrite{
+		{OldPrefix: keys.MakeTablePrefix(51), NewPrefix: keys.MakeTablePrefix(100)},
+	})
+	var keys [][]byte
+	for i := 0; i < 4; i++ {
+		key := append([]byte(nil), kr[0].OldPrefix...)
+		key = encoding.EncodeStringAscending(key, fmt.Sprintf("foo%d", i))
+		keys = append(keys, key)
+	}
+
+	files := []string{
+		writeSST(keys[2], keys[3]),
+		writeSST(keys[0], keys[1]),
+		writeSST(keys[2], keys[3]),
+	}
+
+	dataStartKey := roachpb.Key(keys[0])
+	dataEndKey := roachpb.Key(keys[3]).PrefixEnd()
 	reqStartKey, ok := kr.RewriteKey(append([]byte(nil), dataStartKey...))
 	if !ok {
 		t.Fatalf("failed to rewrite key: %s", reqStartKey)
@@ -74,36 +156,53 @@ func TestImport(t *testing.T) {
 	if !ok {
 		t.Fatalf("failed to rewrite key: %s", reqEndKey)
 	}
+
+	ctx := context.Background()
+	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop()
+
 	storage, err := ExportStorageConfFromURI(dir)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
 
-	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	for i := 0; i <= len(files); i++ {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			req := &roachpb.ImportRequest{
+				Span:        roachpb.Span{Key: reqStartKey},
+				DataSpan:    roachpb.Span{Key: dataStartKey, EndKey: dataEndKey},
+				KeyRewrites: kr,
+			}
 
-	// Import may be retried by DistSender if it takes too long to return, so
-	// make sure it's idempotent.
-	for i := 0; i < 3; i++ {
-		req := &roachpb.ImportRequest{
-			Span:        roachpb.Span{Key: reqStartKey},
-			DataSpan:    roachpb.Span{Key: dataStartKey, EndKey: dataEndKey},
-			KeyRewrites: kr,
-			Files: []roachpb.ImportRequest_File{
-				{Dir: storage, Path: sstName},
-			},
-		}
-		b := &client.Batch{}
-		b.AddRawRequest(req)
-		if err := kvDB.Run(ctx, b); err != nil {
-			t.Fatalf("%+v", err)
-		}
-		kvs, err := kvDB.Scan(ctx, reqStartKey, reqEndKey, 0)
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
-		if len(kvs) != 1 {
-			t.Fatalf("expected 1 kv got %d", len(kvs))
-		}
+			for _, f := range files[:i] {
+				req.Files = append(req.Files, roachpb.ImportRequest_File{Dir: storage, Path: f})
+			}
+			expectedKVs, err := slurpSSTablesLatestKey(dir, files[:i], kr)
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
+
+			// Import may be retried by DistSender if it takes too long to return, so
+			// make sure it's idempotent.
+			for j := 0; j < 3; j++ {
+				b := &client.Batch{}
+				b.AddRawRequest(req)
+				if err := kvDB.Run(ctx, b); err != nil {
+					t.Fatalf("%+v", err)
+				}
+				clientKVs, err := kvDB.Scan(ctx, reqStartKey, reqEndKey, 0)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				kvs := clientKVsToEngineKVs(clientKVs)
+
+				if !reflect.DeepEqual(kvs, expectedKVs) {
+					for _, kv := range append(kvs, expectedKVs...) {
+						log.Info(ctx, kv)
+					}
+					t.Fatalf("got %+v expected %+v", kvs, expectedKVs)
+				}
+			}
+		})
 	}
 }

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -67,11 +67,11 @@ type Iterator interface {
 	// ValueProto unmarshals the value the iterator is currently
 	// pointing to using a protobuf decoder.
 	ValueProto(msg proto.Message) error
-	// unsafeKey returns the same value as Key, but the memory is invalidated on
+	// UnsafeKey returns the same value as Key, but the memory is invalidated on
 	// the next call to {Next,Prev,Seek,SeekReverse,Close}.
 	UnsafeKey() MVCCKey
-	// unsafeKey returns the same value as Value, but the memory is invalidated
-	// on the next call to {Next,Prev,Seek,SeekReverse,Close}.
+	// UnsafeValue returns the same value as Value, but the memory is
+	// invalidated on the next call to {Next,Prev,Seek,SeekReverse,Close}.
 	UnsafeValue() []byte
 	// Less returns true if the key the iterator is currently positioned at is
 	// less than the specified key.


### PR DESCRIPTION
Previously, Import would construct WriteBatches by iterating through
each file in the import and adding keys to the batch. Then it would
periodically send a WriteBatch request when the batch size reached a
threshold. WriteBatch clears any existing data in the affected keyrange
when applied, so later files could overwrite data in earlier ones. This
creates incorrect data at the end of the import.

MultiIterator multiplexes iteration over the sstables in parallel and
returns the latest version of each key (skipping that key if the latest
version is a tombstone). This means each keyrange is only affected by
WriteBatch once.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14203)
<!-- Reviewable:end -->
