### PR TITLE
Add `gen haproxy` command.

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -351,6 +351,7 @@ func init() {
 	clientCmds = append(clientCmds, zoneCmds...)
 	clientCmds = append(clientCmds, nodeCmds...)
 	clientCmds = append(clientCmds, debugZipCmd)
+	clientCmds = append(clientCmds, genHAProxyCmd)
 	for _, cmd := range clientCmds {
 		f := cmd.PersistentFlags()
 		stringFlag(f, &connHost, cliflags.ClientHost, "")
@@ -381,6 +382,7 @@ func init() {
 	simpleCmds = append(simpleCmds, rangeCmds...)
 	simpleCmds = append(simpleCmds, nodeCmds...)
 	simpleCmds = append(simpleCmds, debugZipCmd)
+	simpleCmds = append(simpleCmds, genHAProxyCmd)
 	for _, cmd := range simpleCmds {
 		f := cmd.PersistentFlags()
 		stringFlag(f, &connPort, cliflags.ClientPort, base.DefaultPort)

--- a/pkg/cli/gen.go
+++ b/pkg/cli/gen.go
@@ -119,6 +119,7 @@ var genCmds = []*cobra.Command{
 	genManCmd,
 	genAutocompleteCmd,
 	genExamplesCmd,
+	genHAProxyCmd,
 }
 
 func init() {
@@ -126,6 +127,8 @@ func init() {
 		"path where man pages will be outputted")
 	genAutocompleteCmd.PersistentFlags().StringVar(&autoCompletePath, "out", "cockroach.bash",
 		"path to generated autocomplete file")
+	genHAProxyCmd.PersistentFlags().StringVar(&haProxyPath, "out", "haproxy.cfg",
+		"path to generated haproxy configuration file")
 
 	genCmd.AddCommand(genCmds...)
 }

--- a/pkg/cli/haproxy.go
+++ b/pkg/cli/haproxy.go
@@ -1,0 +1,105 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package cli
+
+import (
+	"html/template"
+	"io"
+	"os"
+
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/spf13/cobra"
+)
+
+var haProxyPath string
+
+var genHAProxyCmd = &cobra.Command{
+	Use:   "haproxy",
+	Short: "generate haproxy.cfg for the connected cluster",
+	Long: `This command generates a minimal haproxy configuration file for the cluster
+reached through the client flags.
+The file is written to --out. Use "--out -" for stdout.
+
+The addresses used are those advertized by the nodes themselves. Make sure haproxy
+can resolve the hostnames in the configuration file, either by using full-qualified names, or
+running haproxy in the same network.
+`,
+	RunE: MaybeDecorateGRPCError(runGenHAProxyCmd),
+}
+
+func runGenHAProxyCmd(cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		return usageAndError(cmd)
+	}
+
+	configTemplate, err := template.New("haproxy template").Parse(haProxyTemplate)
+	if err != nil {
+		return err
+	}
+
+	c, stopper, err := getStatusClient()
+	if err != nil {
+		return err
+	}
+	defer stopper.Stop()
+
+	nodeStatuses, err := c.Nodes(stopperContext(stopper), &serverpb.NodesRequest{})
+	if err != nil {
+		return err
+	}
+
+	var w io.Writer
+	var f *os.File
+	if haProxyPath == "-" {
+		w = os.Stdout
+	} else if f, err = os.OpenFile(haProxyPath, os.O_RDWR|os.O_CREATE, 0755); err != nil {
+		return err
+	} else {
+		w = f
+	}
+
+	err = configTemplate.Execute(w, nodeStatuses.Nodes)
+	if err != nil {
+		// Return earliest error, but still close the file.
+		_ = f.Close()
+		return err
+	}
+
+	if f != nil {
+		return f.Close()
+	}
+
+	return nil
+}
+
+const haProxyTemplate = `
+global
+  maxconn 4096
+
+defaults
+    mode                tcp
+    timeout connect     10s
+    timeout client      1m
+    timeout server      1m
+
+listen psql
+    bind :26257
+    mode tcp
+    balance roundrobin
+{{range .}}    server cockroach{{.Desc.NodeID}} {{.Desc.Address.AddressField}}
+{{end}}
+`


### PR DESCRIPTION
Generates a minimal haproxy config from the cluster specified by the
client flags.

Fixes #14194

Sample command with a real cluster:
```
$ cockroach gen haproxy --host=indigo.crdb.io --ca-cert=ca.crt --cert=root.crt --key=root.key --out -

global
  maxconn 4096

defaults
    mode                tcp
    timeout connect     10s
    timeout client      1m
    timeout server      1m

listen psql
    bind :26257
    mode tcp
    balance roundrobin
    server cockroach1 cockroach-indigo-0001.crdb.io:26257
    server cockroach2 cockroach-indigo-0003.crdb.io:26257
    server cockroach3 cockroach-indigo-0004.crdb.io:26257
    server cockroach4 cockroach-indigo-0006.crdb.io:26257
    server cockroach5 cockroach-indigo-0005.crdb.io:26257
    server cockroach6 cockroach-indigo-0009.crdb.io:26257
    server cockroach7 cockroach-indigo-0007.crdb.io:26257
    server cockroach8 cockroach-indigo-0008.crdb.io:26257
    server cockroach9 cockroach-indigo-0002.crdb.io:26257
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14205)
<!-- Reviewable:end -->
