### PR TITLE
storage: better safety for computing quorum and removal targets

### DIFF
--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -178,7 +178,7 @@ func createTestAllocator(
 	deterministic bool,
 ) (*stop.Stopper, *gossip.Gossip, *StorePool, Allocator, *hlc.ManualClock) {
 	stopper, g, manual, storePool, _ := createTestStorePool(
-		TestTimeUntilStoreDeadOff, deterministic, true /* defaultNodeLiveness */)
+		TestTimeUntilStoreDeadOff, deterministic, nodeStatusLive)
 	a := MakeAllocator(storePool, func(string) (time.Duration, bool) {
 		return 0, true
 	})
@@ -196,10 +196,10 @@ func mockStorePool(
 	storePool.detailsMu.Lock()
 	defer storePool.detailsMu.Unlock()
 
-	liveNodeSet := map[roachpb.NodeID]struct{}{}
+	liveNodeSet := map[roachpb.NodeID]nodeStatus{}
 	storePool.detailsMu.storeDetails = map[roachpb.StoreID]*storeDetail{}
 	for _, storeID := range aliveStoreIDs {
-		liveNodeSet[roachpb.NodeID(storeID)] = struct{}{}
+		liveNodeSet[roachpb.NodeID(storeID)] = nodeStatusLive
 		detail := storePool.getStoreDetailLocked(storeID)
 		detail.desc = &roachpb.StoreDescriptor{
 			StoreID: storeID,
@@ -207,6 +207,7 @@ func mockStorePool(
 		}
 	}
 	for _, storeID := range deadStoreIDs {
+		liveNodeSet[roachpb.NodeID(storeID)] = nodeStatusDead
 		detail := storePool.getStoreDetailLocked(storeID)
 		detail.desc = &roachpb.StoreDescriptor{
 			StoreID: storeID,
@@ -224,9 +225,11 @@ func mockStorePool(
 
 	// Set the node liveness function using the set we constructed.
 	storePool.nodeLivenessFn =
-		func(nodeID roachpb.NodeID, now time.Time, threshold time.Duration) bool {
-			_, ok := liveNodeSet[nodeID]
-			return ok
+		func(nodeID roachpb.NodeID, now time.Time, threshold time.Duration) nodeStatus {
+			if status, ok := liveNodeSet[nodeID]; ok {
+				return status
+			}
+			return nodeStatusUnknown
 		}
 }
 
@@ -1033,7 +1036,7 @@ func TestAllocatorTransferLeaseTargetLoadBased(t *testing.T) {
 	EnableLoadBasedLeaseRebalancing = true
 
 	stopper, g, _, storePool, _ := createTestStorePool(
-		TestTimeUntilStoreDeadOff, true /* deterministic */, true /* defaultNodeLiveness */)
+		TestTimeUntilStoreDeadOff, true /* deterministic */, nodeStatusLive)
 	defer stopper.Stop()
 
 	// 3 stores where the lease count for each store is equal to 10x the store ID.
@@ -1483,35 +1486,6 @@ func TestAllocatorComputeAction(t *testing.T) {
 			},
 			expectedAction: AllocatorAdd,
 		},
-		// Needs three replicas, two are on dead stores.
-		{
-			zone: config.ZoneConfig{
-				NumReplicas:   3,
-				Constraints:   config.Constraints{Constraints: []config.Constraint{{Value: "us-east"}}},
-				RangeMinBytes: 0,
-				RangeMaxBytes: 64000,
-			},
-			desc: roachpb.RangeDescriptor{
-				Replicas: []roachpb.ReplicaDescriptor{
-					{
-						StoreID:   1,
-						NodeID:    1,
-						ReplicaID: 1,
-					},
-					{
-						StoreID:   7,
-						NodeID:    7,
-						ReplicaID: 7,
-					},
-					{
-						StoreID:   6,
-						NodeID:    6,
-						ReplicaID: 6,
-					},
-				},
-			},
-			expectedAction: AllocatorRemoveDead,
-		},
 		// Needs three replicas, one is on a dead store.
 		{
 			zone: config.ZoneConfig{
@@ -1681,6 +1655,37 @@ func TestAllocatorComputeAction(t *testing.T) {
 				},
 			},
 			expectedAction: AllocatorRemove,
+		},
+		// Needs three replicas, two are on dead stores. Should
+		// be a noop because there aren't enough live replicas for
+		// a quorum.
+		{
+			zone: config.ZoneConfig{
+				NumReplicas:   3,
+				Constraints:   config.Constraints{Constraints: []config.Constraint{{Value: "us-east"}}},
+				RangeMinBytes: 0,
+				RangeMaxBytes: 64000,
+			},
+			desc: roachpb.RangeDescriptor{
+				Replicas: []roachpb.ReplicaDescriptor{
+					{
+						StoreID:   1,
+						NodeID:    1,
+						ReplicaID: 1,
+					},
+					{
+						StoreID:   7,
+						NodeID:    7,
+						ReplicaID: 7,
+					},
+					{
+						StoreID:   6,
+						NodeID:    6,
+						ReplicaID: 6,
+					},
+				},
+			},
+			expectedAction: AllocatorNoop,
 		},
 		// Three replicas have three, none of the replicas in the store pool.
 		{
@@ -2126,7 +2131,7 @@ func Example_rebalancing() {
 		log.AmbientContext{},
 		g,
 		clock,
-		newMockNodeLiveness(true /* defaultNodeLiveness */).nodeLivenessFunc,
+		newMockNodeLiveness(nodeStatusLive).nodeLivenessFunc,
 		TestTimeUntilStoreDeadOff,
 		/* deterministic */ true,
 	)

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -146,14 +146,7 @@ func createTestStoreWithEngine(
 		kv.MakeTxnMetrics(metric.TestSampleInterval),
 	)
 	storeCfg.DB = client.NewDB(sender, storeCfg.Clock)
-	storeCfg.StorePool = storage.NewStorePool(
-		log.AmbientContext{},
-		storeCfg.Gossip,
-		storeCfg.Clock,
-		storage.StorePoolNodeLivenessTrue,
-		storage.TestTimeUntilStoreDeadOff,
-		/* deterministic */ false,
-	)
+	storeCfg.StorePool = storage.NewTestStorePool(storeCfg)
 	storeCfg.Transport = storage.NewDummyRaftTransport()
 	// TODO(bdarnell): arrange to have the transport closed.
 	store := storage.NewStore(storeCfg, eng, nodeDesc)

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -203,6 +203,19 @@ func (s *Store) ReservationCount() int {
 	return len(s.snapshotApplySem)
 }
 
+func NewTestStorePool(cfg StoreConfig) *StorePool {
+	return NewStorePool(
+		cfg.AmbientCtx,
+		cfg.Gossip,
+		cfg.Clock,
+		func(roachpb.NodeID, time.Time, time.Duration) nodeStatus {
+			return nodeStatusLive
+		},
+		TestTimeUntilStoreDeadOff,
+		/* deterministic */ false,
+	)
+}
+
 func (r *Replica) ReplicaIDLocked() roachpb.ReplicaID {
 	return r.mu.replicaID
 }
@@ -252,11 +265,6 @@ func (r *Replica) IsRaftGroupInitialized() bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.mu.internalRaftGroup != nil
-}
-
-// StorePoolNodeLivenessTrue is a NodeLivenessFunc which always returns true.
-func StorePoolNodeLivenessTrue(_ roachpb.NodeID, _ time.Time, _ time.Duration) bool {
-	return true
 }
 
 // GetStoreList is the same function as GetStoreList exposed for tests only.

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -160,14 +160,7 @@ func (tc *testContext) StartWithStoreConfig(t testing.TB, stopper *stop.Stopper,
 	if tc.store == nil {
 		cfg.Gossip = tc.gossip
 		cfg.Transport = tc.transport
-		cfg.StorePool = NewStorePool(
-			cfg.AmbientCtx,
-			cfg.Gossip,
-			cfg.Clock,
-			StorePoolNodeLivenessTrue,
-			TestTimeUntilStoreDeadOff,
-			false, /* deterministic */
-		)
+		cfg.StorePool = NewTestStorePool(cfg)
 		// Create a test sender without setting a store. This is to deal with the
 		// circular dependency between the test sender and the store. The actual
 		// store will be passed to the sender after it is created and bootstrapped.

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -243,14 +243,12 @@ func (rq *replicateQueue) processOneChange(
 
 	// Avoid taking action if the range has too many dead replicas to make
 	// quorum.
-	deadReplicas := rq.allocator.storePool.deadReplicas(desc.RangeID, desc.Replicas)
+	liveReplicas, deadReplicas := rq.allocator.storePool.liveAndDeadReplicas(desc.RangeID, desc.Replicas)
 	{
 		quorum := computeQuorum(len(desc.Replicas))
-		liveReplicaCount := len(desc.Replicas) - len(deadReplicas)
-		if liveReplicaCount < quorum {
+		if lr := len(liveReplicas); lr < quorum {
 			return false, errors.Errorf(
-				"range requires a replication change, but lacks a quorum of live replicas (%d/%d)",
-				liveReplicaCount, quorum)
+				"range requires a replication change, but lacks a quorum of live replicas (%d/%d)", lr, quorum)
 		}
 	}
 

--- a/pkg/storage/replicate_test.go
+++ b/pkg/storage/replicate_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -37,15 +38,15 @@ func TestEagerReplication(t *testing.T) {
 	// path that occurs after splits.
 	store.SetReplicaScannerActive(false)
 
-	if err := server.WaitForInitialSplits(store.DB()); err != nil {
+	<-store.Gossip().Connected
+	if err := store.GossipStore(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
-	// WaitForInitialSplits will return as soon as the meta2 span contains the
-	// expected number of descriptors. But the addition of replicas to the
-	// replicateQueue after a split occurs happens after the update of the
-	// descriptors in meta2 leaving a tiny window of time in which the newly
-	// split replica will not have been added to purgatory. Thus we loop.
+	// The addition of replicas to the replicateQueue after a split
+	// occurs happens after the update of the descriptors in meta2
+	// leaving a tiny window of time in which the newly split replica
+	// will not have been added to purgatory. Thus we loop.
 	testutils.SucceedsSoon(t, func() error {
 		// After the initial splits have been performed, all of the resulting ranges
 		// should be present in replicate queue purgatory (because we only have a

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -124,14 +124,7 @@ func createTestStoreWithoutStart(t testing.TB, stopper *stop.Stopper, cfg *Store
 	rpcContext := rpc.NewContext(log.AmbientContext{}, &base.Config{Insecure: true}, cfg.Clock, stopper)
 	server := rpc.NewServer(rpcContext) // never started
 	cfg.Gossip = gossip.NewTest(1, rpcContext, server, nil, stopper, metric.NewRegistry())
-	cfg.StorePool = NewStorePool(
-		log.AmbientContext{},
-		cfg.Gossip,
-		cfg.Clock,
-		StorePoolNodeLivenessTrue,
-		TestTimeUntilStoreDeadOff,
-		/* deterministic */ false,
-	)
+	cfg.StorePool = NewTestStorePool(*cfg)
 	// Many tests using this test harness (as opposed to higher-level
 	// ones like multiTestContext or TestServer) want to micro-manage
 	// replicas and the background queues just get in the way. The


### PR DESCRIPTION
This PR clarifies the node and store status in the `StorePool`. It adds
an "unavailable" state to the node liveness determination, instead of
just a "live" boolean. The overly simplistic `deadReplicas()` method
has been replaced by a `liveAndDeadReplicas` method which separates
a slice of replicas into two slices: one for live and one for dead
replicas, leaving "unavailable" replicas (for which we can't determine
liveness) out of the mix.

The live replicas are used to decide whether quorum is available,
and the dead replicas are used to choose removal targets.

Draining nodes are now considered "unavailable" so they don't count
towards quorum, but they also aren't selected as removal targets.

Fixes #13881

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14206)
<!-- Reviewable:end -->
