### PR TITLE
sql: correctly encode decimals in indexes

### DIFF
--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -366,6 +366,12 @@ func (rf *RowFetcher) ProcessKV(
 						return "", "", err
 					}
 					d = parser.NewDCollatedString(r, *typ.Locale, &rf.alloc.env)
+				case ColumnType_DECIMAL:
+					dec, err := encoding.DecodeNonsortingDecimal(rvalue, nil)
+					if err != nil {
+						return "", "", err
+					}
+					d = &parser.DDecimal{Decimal: *dec}
 				default:
 					panic(fmt.Sprintf("unknown composite encoding for kind %d", typ.Kind))
 				}

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -519,7 +519,11 @@ func (desc *TableDescriptor) ensurePrimaryKey() error {
 // HasCompositeKeyEncoding returns true if key columns of the given kind have a
 // composite encoding.
 func HasCompositeKeyEncoding(kind ColumnType_Kind) bool {
-	return kind == ColumnType_COLLATEDSTRING
+	switch kind {
+	case ColumnType_COLLATEDSTRING, ColumnType_DECIMAL:
+		return true
+	}
+	return false
 }
 
 func (desc *TableDescriptor) allocateIndexIDs(columnNames map[string]ColumnID) error {

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -1212,6 +1212,8 @@ func EncodeSecondaryIndex(
 		switch d := val.(type) {
 		case *parser.DCollatedString:
 			entryValue = encoding.EncodeStringAscending(entryValue, d.Contents)
+		case *parser.DDecimal:
+			entryValue = encoding.EncodeNonsortingDecimal(entryValue, &d.Decimal)
 		default:
 			panic(fmt.Sprintf("unknown composite encoding for datum %s", d))
 		}

--- a/pkg/sql/testdata/decimal
+++ b/pkg/sql/testdata/decimal
@@ -81,10 +81,9 @@ CREATE TABLE t2 (d decimal, v decimal(3, 1), primary key (d, v))
 statement ok
 INSERT INTO t2 VALUES (1.00::decimal, 1.00::decimal), (2.0::decimal, 2.0::decimal), (3::decimal, 3::decimal)
 
-# TODO(mjibson): enable once #13609 is merged with support for different values in index.
-#query RR
-#SELECT * FROM t2 ORDER BY d
-#----
-#1.00 1.0
-#2.0  2.0
-#3    3.0
+query RR
+SELECT * FROM t2 ORDER BY d
+----
+1.00 1.0
+2.0  2.0
+3    3.0


### PR DESCRIPTION
Use the new composite index feature to encode the sortable encoding
and value encoding for decimals. The sortable encoding truncates
trailing zeros so that "5.0" and "5.000" compare equal. But users
need to have their data round trip correctly. Putting decimals in
the composite index allows the full values to be retained.

DistSQL still broken and doesn't round trip because it uses the
ascending encoding sometimes. This will be fixed later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14208)
<!-- Reviewable:end -->
