### PR TITLE
migrations: assert that client.DB satisfies migrations.db interface

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -100,6 +100,8 @@ type db interface {
 	Txn(ctx context.Context, retryable func(ctx context.Context, txn *client.Txn) error) error
 }
 
+var _ db = &client.DB{}
+
 // Manager encapsulates the necessary functionality for handling migrations
 // of data in the cluster.
 type Manager struct {


### PR DESCRIPTION
@a-robinson wrote this handy interface, `migrations.db`, that allows us
to stub out `client.DB` in the migrations tests. Add an assertion that
the real `client.DB` satisfies this interface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14211)
<!-- Reviewable:end -->
