### PR TITLE
sql: expose table span information in crdb_internal.tables

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -464,19 +464,12 @@ func (s *adminServer) TableDetails(
 	// Get the number of ranges in the table. We get the key span for the table
 	// data. Then, we count the number of ranges that make up that key span.
 	{
-		iexecutor := sql.InternalExecutor{LeaseManager: s.server.leaseMgr}
-		var tableSpan roachpb.Span
-		if err := s.server.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-			var err error
-			tableSpan, err = iexecutor.GetTableSpan(
-				ctx, s.getUser(req), txn, req.Database, req.Table,
-			)
-			return err
-		}); err != nil {
+		tableSpan, err := s.queryTableSpan(ctx, session, req.Database, req.Table)
+		if err != nil {
 			return nil, s.serverError(err)
 		}
+
 		tableRSpan := roachpb.RSpan{}
-		var err error
 		tableRSpan.Key, err = keys.Addr(tableSpan.Key)
 		if err != nil {
 			return nil, s.serverError(err)
@@ -528,19 +521,18 @@ func (s *adminServer) TableDetails(
 func (s *adminServer) TableStats(
 	ctx context.Context, req *serverpb.TableStatsRequest,
 ) (*serverpb.TableStatsResponse, error) {
+	args := sql.SessionArgs{User: s.getUser(req)}
+	ctx, session := s.NewContextAndSessionForRPC(ctx, args)
+	defer session.Finish(s.server.sqlExecutor)
+
 	escDBName := parser.Name(req.Database).String()
 	if err := s.assertNotVirtualSchema(escDBName); err != nil {
 		return nil, err
 	}
 
 	// Get table span.
-	var tableSpan roachpb.Span
-	iexecutor := sql.InternalExecutor{LeaseManager: s.server.leaseMgr}
-	if err := s.server.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		var err error
-		tableSpan, err = iexecutor.GetTableSpan(ctx, s.getUser(req), txn, req.Database, req.Table)
-		return err
-	}); err != nil {
+	tableSpan, err := s.queryTableSpan(ctx, session, req.Database, req.Table)
+	if err != nil {
 		return nil, s.serverError(err)
 	}
 
@@ -1427,6 +1419,40 @@ func (s *adminServer) queryDescriptorIDPath(
 		path = append(path, id)
 	}
 	return path, nil
+}
+
+func (s *adminServer) queryTableSpan(
+	ctx context.Context, session *sql.Session, database, table string,
+) (roachpb.Span, error) {
+	const query = `SELECT start_key, end_key FROM crdb_internal.tables
+		WHERE database_name = $1 AND name = $2`
+	params := parser.MakePlaceholderInfo()
+	params.SetValue(`1`, parser.NewDString(database))
+	params.SetValue(`2`, parser.NewDString(table))
+	r := s.server.sqlExecutor.ExecuteStatements(session, query, &params)
+	defer r.Close(ctx)
+	if err := s.checkQueryResults(r.ResultList, 1); err != nil {
+		return roachpb.Span{}, err
+	}
+
+	results := r.ResultList[0]
+	if results.Rows.Len() != 1 {
+		return roachpb.Span{}, errors.Errorf(
+			"table %s.%s not found in crdb_internal.tables", database, table,
+		)
+	}
+	row := results.Rows.At(0)
+
+	var startKey []byte
+	var endKey []byte
+	scanner := resultScanner{}
+	if err := scanner.ScanIndex(row, 0, &startKey); err != nil {
+		return roachpb.Span{}, err
+	}
+	if err := scanner.ScanIndex(row, 1, &endKey); err != nil {
+		return roachpb.Span{}, err
+	}
+	return roachpb.Span{Key: startKey, EndKey: endKey}, nil
 }
 
 // assertNotVirtualSchema checks if the provided database name corresponds to a

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -25,6 +25,8 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -83,6 +85,8 @@ CREATE TABLE crdb_internal.tables (
   STATE                    STRING NOT NULL,
   SC_LEASE_NODE_ID         INT,
   SC_LEASE_EXPIRATION_TIME TIMESTAMP,
+  START_KEY                BYTES,
+  END_KEY                  BYTES,
   CREATE_TABLE             STRING NOT NULL
 );
 `,
@@ -122,6 +126,7 @@ CREATE TABLE crdb_internal.tables (
 			if err != nil {
 				return err
 			}
+			tablePrefix := roachpb.Key(keys.MakeTablePrefix(uint32(table.ID)))
 			if err := addRow(
 				parser.NewDInt(parser.DInt(int64(table.ID))),
 				parser.NewDInt(parser.DInt(int64(table.ParentID))),
@@ -134,6 +139,8 @@ CREATE TABLE crdb_internal.tables (
 				parser.NewDString(table.State.String()),
 				leaseNodeDatum,
 				leaseExpDatum,
+				parser.NewDBytes(parser.DBytes(tablePrefix)),
+				parser.NewDBytes(parser.DBytes(tablePrefix.PrefixEnd())),
 				parser.NewDString(create),
 			); err != nil {
 				return err

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -1,0 +1,83 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nikhil Benesch (nikhil.benesch@gmail.com)
+
+package sql_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestCRDBInternalTableKeys(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	params, _ := createTestServerParams()
+	s, db, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop()
+
+	const (
+		database = "d"
+		table    = "t"
+	)
+
+	if _, err := db.Exec(
+		fmt.Sprintf(`CREATE DATABASE %[1]s; CREATE TABLE %[1]s.%[2]s ();`, database, table),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := db.Query(
+		`SELECT database_name, name, table_id, start_key, end_key FROM crdb_internal.tables`,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	var seenSentinel bool
+	for rows.Next() {
+		var databaseName string
+		var tableName string
+		var tableID uint32
+		var startKey []byte
+		var endKey []byte
+		if err := rows.Scan(&databaseName, &tableName, &tableID, &startKey, &endKey); err != nil {
+			t.Fatal(err)
+		}
+
+		seenSentinel = seenSentinel || databaseName == database && tableName == table
+
+		expectedPrefix := roachpb.Key(keys.MakeTablePrefix(tableID))
+		expectedSpan := roachpb.Span{
+			Key:    expectedPrefix,
+			EndKey: expectedPrefix.PrefixEnd(),
+		}
+		if a, e := (roachpb.Span{Key: startKey, EndKey: endKey}), expectedSpan; !a.Equal(e) {
+			t.Errorf("expected table ID %d to have span %v, but got %v", tableID, e, a)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if !seenSentinel {
+		t.Fatalf("table %s.%s did not appear in crdb_internal.tables", database, table)
+	}
+}

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -20,11 +20,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
-	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 )
 
@@ -47,57 +43,4 @@ func (ie InternalExecutor) ExecuteStatementInTransaction(
 	defer finishInternalPlanner(p)
 	p.session.leaseMgr = ie.LeaseManager
 	return p.exec(ctx, statement, qargs...)
-}
-
-// GetTableSpan gets the key span for a SQL table, including any indices.
-func (ie InternalExecutor) GetTableSpan(
-	ctx context.Context, user string, txn *client.Txn, dbName, tableName string,
-) (roachpb.Span, error) {
-	// Lookup the table ID.
-	p := makeInternalPlanner("get-table-span", txn, user, ie.LeaseManager.memMetrics)
-	defer finishInternalPlanner(p)
-	p.session.leaseMgr = ie.LeaseManager
-
-	tn := parser.TableName{DatabaseName: parser.Name(dbName), TableName: parser.Name(tableName)}
-	tableID, err := getTableID(ctx, p, &tn)
-	if err != nil {
-		return roachpb.Span{}, err
-	}
-
-	// Determine table data span.
-	tablePrefix := keys.MakeTablePrefix(uint32(tableID))
-	tableStartKey := roachpb.Key(tablePrefix)
-	tableEndKey := tableStartKey.PrefixEnd()
-	return roachpb.Span{Key: tableStartKey, EndKey: tableEndKey}, nil
-}
-
-// getTableID retrieves the table ID for the specified table.
-func getTableID(ctx context.Context, p *planner, tn *parser.TableName) (sqlbase.ID, error) {
-	if err := tn.QualifyWithDatabase(p.session.Database); err != nil {
-		return 0, err
-	}
-
-	virtual, err := p.session.virtualSchemas.getVirtualTableDesc(tn)
-	if err != nil {
-		return 0, err
-	}
-	if virtual != nil {
-		return virtual.GetID(), nil
-	}
-
-	dbID, err := p.getDatabaseID(ctx, tn.Database())
-	if err != nil {
-		return 0, err
-	}
-
-	nameKey := tableKey{dbID, tn.Table()}
-	key := nameKey.Key()
-	gr, err := p.txn.Get(ctx, key)
-	if err != nil {
-		return 0, err
-	}
-	if !gr.Exists() {
-		return 0, sqlbase.NewUndefinedTableError(parser.AsString(tn))
-	}
-	return sqlbase.ID(gr.ValueInt()), nil
 }

--- a/pkg/sql/testdata/crdb_internal
+++ b/pkg/sql/testdata/crdb_internal
@@ -32,11 +32,21 @@ SELECT * FROM crdb_internal.schema_changes
 ----
 TABLE_ID PARENT_ID NAME TYPE TARGET_ID TARGET_NAME STATE DIRECTION
 
-query IITTITRTTTTT colnames
-SELECT * FROM crdb_internal.tables WHERE NAME = 'namespace'
+query IITTITRTTTTTTT colnames
+SELECT * FROM crdb_internal.tables LIMIT 0
 ----
-TABLE_ID  PARENT_ID  NAME       DATABASE_NAME  VERSION  MOD_TIME                         MOD_TIME_LOGICAL  FORMAT_VERSION            STATE   SC_LEASE_NODE_ID  SC_LEASE_EXPIRATION_TIME  CREATE_TABLE
-2         1          namespace  system         1        1970-01-01 00:00:00 +0000 +0000  0.0000000000      InterleavedFormatVersion  PUBLIC  NULL              NULL                      CREATE TABLE namespace (
+TABLE_ID  PARENT_ID  NAME  DATABASE_NAME  VERSION  MOD_TIME  MOD_TIME_LOGICAL  FORMAT_VERSION  STATE  SC_LEASE_NODE_ID  SC_LEASE_EXPIRATION_TIME  START_KEY  END_KEY CREATE_TABLE
+
+# Columns that are tied to our key encoding are tested in crdb_internal_test.go.
+query IITTITRTTTTT colnames
+SELECT
+  TABLE_ID, PARENT_ID, NAME, DATABASE_NAME, VERSION, MOD_TIME, MOD_TIME_LOGICAL,
+  FORMAT_VERSION, STATE, SC_LEASE_NODE_ID, SC_LEASE_EXPIRATION_TIME, CREATE_TABLE
+FROM crdb_internal.tables
+WHERE NAME = 'namespace'
+----
+TABLE_ID  PARENT_ID  NAME       DATABASE_NAME  VERSION  MOD_TIME                         MOD_TIME_LOGICAL  FORMAT_VERSION            STATE   SC_LEASE_NODE_ID  SC_LEASE_EXPIRATION_TIME CREATE_TABLE
+2         1          namespace  system         1        1970-01-01 00:00:00 +0000 +0000  0.0000000000      InterleavedFormatVersion  PUBLIC  NULL              NULL                     CREATE TABLE namespace (
           parentID INT NOT NULL,
           name STRING NOT NULL,
           id INT NULL,


### PR DESCRIPTION
This change removes the GetTableSpan method on the InternalExecutor by
instead exposing table span information in crdb_internal.tables. (This
method was only called by the admin, which has been ported to the new
interface.) I'm hoping to kill the InternalExecutor soon, and, as best
as I can tell, GetTableSpan never truly belonged in the InternalExecutor
anyway; it was just a convenient place to put it. By contrast, the new
crdb_internal database seems like a perfect place to expose this
Cockroach-specific metadata.

It's worth noting table span information is not entirely correct
(consider interleaved children, for example) when used to compute the
number of ranges in a table, as the admin does, but a) fixing this would
require a significant overhaul of how the admin deals with index
statistics, and b) this information is fairly useful as it stands.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14221)
<!-- Reviewable:end -->
