### PR TITLE
Makefile: build without debug symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ GIT_DIR := $(shell git rev-parse --git-dir 2> /dev/null)
 ifeq ($(TYPE),)
 override LINKFLAGS += -X github.com/cockroachdb/cockroach/pkg/build.typ=development
 else ifeq ($(TYPE),release)
-override LINKFLAGS += -X github.com/cockroachdb/cockroach/pkg/build.typ=release
+override LINKFLAGS += -s -w -X github.com/cockroachdb/cockroach/pkg/build.typ=release
 else ifeq ($(TYPE),musl)
 # This tag disables jemalloc profiling. See https://github.com/jemalloc/jemalloc/issues/585.
 override TAGS += musl

--- a/build/build-docker-deploy.sh
+++ b/build/build-docker-deploy.sh
@@ -17,7 +17,6 @@ if [ "${1-}" = "docker" ]; then
     time make TYPE=release build
 
     check_static cockroach
-    strip -S cockroach
 
     mv cockroach build/deploy/cockroach
 

--- a/build/build-static-binaries.sh
+++ b/build/build-static-binaries.sh
@@ -19,8 +19,5 @@ check_static "cli/cli.test${SUFFIX-}"
 # Try running the cockroach binary.
 MALLOC_CONF=prof:true ./cockroach${SUFFIX-} version
 
-strip -S "cockroach${SUFFIX-}"
-find . -type f -name '*.test*' -exec strip -S {} ';'
-
 rm -f "$archive"
 time tar cfz "$archive" -C .. $(git ls-files | sed -r 's,^,cockroach/,') $(find . -type f -name '*.test*' -and -not -name 'acceptance.test*' | sed 's,^\./,cockroach/,')


### PR DESCRIPTION
On Linux this emits a binary of the same size that `strip`
produces. Build times for `make build` are reduced by about half
as well.

Original time for build-static-binaries.sh:
real    3m22.074s
user    3m22.328s
sys     0m36.684s

New time:
real    2m41.766s
user    3m6.156s
sys     0m33.456s

See: https://golang.org/cmd/link/
See: https://github.com/docker/docker/blob/f148ad38e5c555189bed4515657cbb741916b094/project/PACKAGERS.md#stripping-binaries

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14224)
<!-- Reviewable:end -->
