### PR TITLE
distsqlrun: always send header msg from outbox quickly

### DIFF
--- a/pkg/sql/distsqlrun/outbox.go
+++ b/pkg/sql/distsqlrun/outbox.go
@@ -205,13 +205,11 @@ func (m *outbox) mainLoop(ctx context.Context) error {
 		m.RowChannel.ConsumerClosed()
 	}()
 
-	if m.stream != nil {
-		// Send a first message that will contain the header (i.e. the StreamID), so
-		// that the stream is properly initialized on the consumer. The consumer has
-		// a timeout in which inbound streams must be established.
-		if err := m.flush(ctx); err != nil {
-			return err
-		}
+	// Send a first message that will contain the header (i.e. the StreamID), so
+	// that the stream is properly initialized on the consumer. The consumer has
+	// a timeout in which inbound streams must be established.
+	if err := m.flush(ctx); err != nil {
+		return err
 	}
 
 	for {


### PR DESCRIPTION
Before, we were only explicitly sending it in case the outbox was the
one connecting to the consumer (i.e. not the RunSyncFlow case).
Otherwise, we were sending the header on the first timer tick.
I don't know why I made the sending conditional, but we should always do
it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14234)
<!-- Reviewable:end -->
