### PR TITLE
rpc: (re-)enable snappy compression

### DIFF
--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -38,12 +38,19 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
-func newTestServer(t *testing.T, ctx *Context, manual bool) (*grpc.Server, net.Listener) {
+func newTestServer(t *testing.T, ctx *Context, compression bool) (*grpc.Server, net.Listener) {
 	tlsConfig, err := ctx.GetServerTLSConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
-	s := grpc.NewServer(grpc.Creds(credentials.NewTLS(tlsConfig)))
+	opts := []grpc.ServerOption{
+		grpc.Creds(credentials.NewTLS(tlsConfig)),
+		grpc.RPCDecompressor(snappyDecompressor{}),
+	}
+	if compression {
+		opts = append(opts, grpc.RPCCompressor(snappyCompressor{}))
+	}
+	s := grpc.NewServer(opts...)
 
 	ln, err := netutil.ListenAndServeGRPC(ctx.Stopper, s, util.TestAddr)
 	if err != nil {
@@ -56,37 +63,43 @@ func newTestServer(t *testing.T, ctx *Context, manual bool) (*grpc.Server, net.L
 func TestHeartbeatCB(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	for _, compression := range []bool{false, true} {
+		t.Run("", func(t *testing.T) {
+			stopper := stop.NewStopper()
+			defer stopper.Stop()
 
-	clock := hlc.NewClock(time.Unix(0, 20).UnixNano, time.Nanosecond)
-	serverCtx := NewContext(log.AmbientContext{}, testutils.NewNodeTestBaseContext(), clock, stopper)
-	s, ln := newTestServer(t, serverCtx, true)
-	remoteAddr := ln.Addr().String()
+			clock := hlc.NewClock(time.Unix(0, 20).UnixNano, time.Nanosecond)
+			serverCtx := NewContext(log.AmbientContext{}, testutils.NewNodeTestBaseContext(), clock, stopper)
+			serverCtx.rpcCompression = compression
+			s, ln := newTestServer(t, serverCtx, true)
+			remoteAddr := ln.Addr().String()
 
-	RegisterHeartbeatServer(s, &HeartbeatService{
-		clock:              clock,
-		remoteClockMonitor: serverCtx.RemoteClocks,
-	})
+			RegisterHeartbeatServer(s, &HeartbeatService{
+				clock:              clock,
+				remoteClockMonitor: serverCtx.RemoteClocks,
+			})
 
-	// Clocks don't matter in this test.
-	clientCtx := NewContext(log.AmbientContext{}, testutils.NewNodeTestBaseContext(), clock, stopper)
+			// Clocks don't matter in this test.
+			clientCtx := NewContext(log.AmbientContext{}, testutils.NewNodeTestBaseContext(), clock, stopper)
+			clientCtx.rpcCompression = compression
 
-	var once sync.Once
-	ch := make(chan struct{})
+			var once sync.Once
+			ch := make(chan struct{})
 
-	clientCtx.HeartbeatCB = func() {
-		once.Do(func() {
-			close(ch)
+			clientCtx.HeartbeatCB = func() {
+				once.Do(func() {
+					close(ch)
+				})
+			}
+
+			_, err := clientCtx.GRPCDial(remoteAddr)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			<-ch
 		})
 	}
-
-	_, err := clientCtx.GRPCDial(remoteAddr)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	<-ch
 }
 
 // TestHeartbeatHealth verifies that the health status changes after

--- a/pkg/rpc/snappy.go
+++ b/pkg/rpc/snappy.go
@@ -1,0 +1,48 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package rpc
+
+import (
+	"io"
+	"io/ioutil"
+
+	"github.com/golang/snappy"
+)
+
+type snappyCompressor struct {
+}
+
+func (snappyCompressor) Do(w io.Writer, p []byte) error {
+	z := snappy.NewBufferedWriter(w)
+	if _, err := z.Write(p); err != nil {
+		return err
+	}
+	return z.Close()
+}
+
+func (snappyCompressor) Type() string {
+	return "snappy"
+}
+
+type snappyDecompressor struct {
+}
+
+func (snappyDecompressor) Do(r io.Reader) ([]byte, error) {
+	return ioutil.ReadAll(snappy.NewReader(r))
+}
+
+func (snappyDecompressor) Type() string {
+	return "snappy"
+}


### PR DESCRIPTION
Resuscitates the snappy compression from
4f27ef42d59604b6c20685dc0fab6cbd37aee20f that was removed in the
transition to gRPC.

This requires a stop-the-world upgrade as there is nothing in place for
negotiating the compression to use on a connection.

Performance is unaffected in both write-heavy and read-heavy workloads,
though network traffic is reduced by ~10%. For certain
operations (i.e. snapshots) over wide area networks the effect will
likely be much larger.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14239)
<!-- Reviewable:end -->
