### PR TITLE
main: fix comment typo

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,8 +17,8 @@
 package main
 
 // The ccl hook import below means building this will produce CCL'ed binaries.
-// This file itself reamins Apache2 though to preserve the organization of ccl
-// code under the /pkg/ccl subtree, but is unused for pure FLOSS builds.
+// This file itself remains Apache2 to preserve the organization of ccl code
+// under the /pkg/ccl subtree, but is unused for pure FLOSS builds.
 import (
 	_ "github.com/cockroachdb/cockroach/pkg/ccl" // ccl init hooks
 	"github.com/cockroachdb/cockroach/pkg/cli"


### PR DESCRIPTION
s/reamins/remains/ and remove an unnecessary connecting word.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14242)
<!-- Reviewable:end -->
