### PR TITLE
sql: make CREATE TABLE AS accept NULL values.

### DIFF
--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -696,9 +696,13 @@ func (n *createTableNode) Start(ctx context.Context) error {
 		// This loop is done here instead of in the Next method
 		// since CREATE TABLE is a DDL statement and Executor only
 		// runs Next() for statements with type "Rows".
-		for done := true; done; done, err = insertPlan.Next(ctx) {
+		for {
+			hasNext, err := insertPlan.Next(ctx)
 			if err != nil {
 				return err
+			}
+			if !hasNext {
+				break
 			}
 		}
 	}
@@ -1161,6 +1165,7 @@ func makeTableDescIfAs(
 			return desc, err
 		}
 		columnTableDef := parser.ColumnTableDef{Name: parser.Name(colRes.Name), Type: colType}
+		columnTableDef.Nullable.Nullability = parser.SilentNull
 		if len(p.AsColumnNames) > i {
 			columnTableDef.Name = p.AsColumnNames[i]
 		}

--- a/pkg/sql/testdata/create_as
+++ b/pkg/sql/testdata/create_as
@@ -89,3 +89,10 @@ CREATE TABLE foo2 (x) AS (VALUES(generate_series(1,3)))
 
 statement error pq: value type NULL cannot be used for table columns
 CREATE TABLE foo2 (x) AS (VALUES(NULL))
+
+# Check nulls are handled properly (#13921)
+query I
+CREATE TABLE foo3 (x) AS VALUES (1), (NULL); SELECT * FROM foo3 ORDER BY x
+----
+NULL
+1


### PR DESCRIPTION
Prior to this patch, CREATE TABLE AS would fail with the error `null value in column ... violates not-null constraint` upon encountering NULLs in its input. This patch addresses this limitation.

Fixes #13921.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14247)
<!-- Reviewable:end -->
