### PR TITLE
Makefile: perform Go version check earlier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,15 @@ export MACOSX_DEPLOYMENT_TARGET=10.9
 
 -include customenv.mk
 
+# We used to check the Go version in a .PHONY .go-version target, but the error
+# message, if any, would get mixed in with noise from other targets if Make was
+# executed in parallel job mode. This check, by contrast, is guaranteed to print
+# its error message before any noisy output.
+include .go-version
+ifeq ($(shell $(GO) version | grep -q -E '\b$(GOVERS)\b' && echo y),)
+$(error "$(GOVERS) required (see CONTRIBUTING.md): $(shell $(GO) version)")
+endif
+
 # Tell Make to delete the target if its recipe fails. Otherwise, if a recipe
 # modifies its target before failing, the target's timestamp will make it appear
 # up-to-date on the next invocation of Make, even though it is likely corrupt.
@@ -310,15 +319,6 @@ ifneq ($(GIT_DIR),)
 .buildinfo/tag: .ALWAYS_REBUILD
 .buildinfo/rev: .ALWAYS_REBUILD
 endif
-
-# The .go-version target is phony so that it is rebuilt every time.
-.PHONY: .go-version
-.go-version:
-	@actual=$$($(GO) version); \
-	echo "$${actual}" | grep -q -E '\b$(GOVERS)\b' || \
-	  (echo "$(GOVERS) required (see CONTRIBUTING.md): $${actual}" >&2 && false)
-
-include .go-version
 
 ifneq ($(GIT_DIR),)
 # If we're in a git worktree, the git hooks directory may not be in our root,


### PR DESCRIPTION
In cockroachdb/homebrew-cockroach#3, the Go version error was nearly
impossible to discern amongst the noise printed by the .bootstrap
recipe. This occurs because Homebrew passes `-jNCPUS` to Make by
default, so the .bootstrap recipe and the .go-version recipe are
executed concurrently. This commit moves the .go-version out of the
.go-version recipe and into the Makefile proper so that it executes
before any recipes and prints its error message before any noise.

While you could argue that we should instead instruct Homebrew not to
pass `-jNCPUS`, since `go build` is responsible for managing the
parallelization of the build anyway, it's quite likely that other users
have `MAKEFLAGS=-jN` set in their environment and are subject to the
same noisy-output problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14252)
<!-- Reviewable:end -->
