### PR TITLE
sql/parser: Permit placeholders for OID values

### DIFF
--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -735,6 +735,16 @@ func TestPGPreparedQuery(t *testing.T) {
 		"EXPLAIN SELECT 1": {
 			baseTest.SetArgs().Results(0, "render", "", "").Results(1, "nullrow", "", ""),
 		},
+		// #14245
+		"SELECT 1::oid = $1": {
+			baseTest.SetArgs(1).Results(true),
+			baseTest.SetArgs(2).Results(false),
+			baseTest.SetArgs("1").Results(true),
+			baseTest.SetArgs("2").Results(false),
+		},
+		"SELECT * FROM pg_catalog.pg_class WHERE relnamespace = $1": {
+			baseTest.SetArgs(1),
+		},
 
 		// TODO(jordan) blocked on #13651
 		//"SELECT $1::INT[]": {


### PR DESCRIPTION
Part of #14245.

Previously the `tOID` type claimed that it was ambiguous through its
`IsAmbiguous` method. This meant that a `placeholderTypeAmbiguityError`
would be thrown when issuing queries like `SELECT 1::oid = $1`. This was
incorrect, as an OID type is fully defined.

This change fixes this and also improves the `tOid` type slightly. It
gets rid of its redundant `typeName` field. Additionally, it improves
the type's `Equivalent` and `FamilyEqual` methods, which would have
given us issues if one of the "reg oid" variants (`typeRegClass`,
`typeRegProc`, etc.) ever entered our type system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14255)
<!-- Reviewable:end -->
