### PR TITLE
ui: Liveness info on Nodes List page

### DIFF
--- a/pkg/ui/src/containers/nodesOverview.tsx
+++ b/pkg/ui/src/containers/nodesOverview.tsx
@@ -2,20 +2,26 @@ import * as React from "react";
 import { Link } from "react-router";
 import { connect } from "react-redux";
 import moment from "moment";
+import { createSelector } from "reselect";
+import _ from "lodash";
 
-import { nodeSums } from "./nodeGraphs";
+import {
+  NodesSummary, nodesSummarySelector, LivenessStatus, deadTimeout, suspectTimeout,
+} from "../redux/nodes";
 import { SummaryBar, SummaryHeadlineStat } from "../components/summaryBar";
 import { AdminUIState } from "../redux/state";
-import { refreshNodes } from "../redux/apiReducers";
+import { refreshNodes, refreshLiveness } from "../redux/apiReducers";
 import { setUISetting } from "../redux/ui";
 import { SortSetting } from "../components/sortabletable";
 import { SortedTable } from "../components/sortedtable";
-import { NanoToMilli } from "../util/convert";
+import { NanoToMilli, LongToMoment } from "../util/convert";
 import { Bytes } from "../util/format";
 import { NodeStatus, MetricConstants, BytesUsed } from  "../util/proto";
 
 // Constant used to store sort settings in the redux UI store.
-const UI_NODES_SORT_SETTING_KEY = "nodes/sort_setting";
+const UI_NODES_LIVE_SORT_SETTING_KEY = "nodes/live_sort_setting";
+// Constant used to store sort settings in the redux UI store.
+const UI_NODES_DEAD_SORT_SETTING_KEY = "nodes/dead_sort_setting";
 
 // Specialization of generic SortedTable component:
 //   https://github.com/Microsoft/TypeScript/issues/3960
@@ -26,102 +32,57 @@ const UI_NODES_SORT_SETTING_KEY = "nodes/sort_setting";
 const NodeSortedTable = SortedTable as new () => SortedTable<Proto2TypeScript.cockroach.server.status.NodeStatus>;
 
 /**
- * NodesMainData are the data properties which should be passed to the NodesMain
- * container.
+ * NodeCategoryListProps are the properties shared by both LiveNodeList and
+ * DeadNodeList.
  */
-interface NodesMainData {
-  // Current sort setting for the table, which is passed on to the sorted table
-  // component.
+interface NodeCategoryListProps {
   sortSetting: SortSetting;
-  // A list of store statuses to display.
-  statuses: NodeStatus[];
-  // Count of replicas across all nodes.
-  replicaCount: number;
-  // Total used bytes across all nodes.
-  usedBytes: number;
-  // Total used memory across all nodes.
-  usedMem: number;
-  // True if current status results are still valid. Needed so that this
-  // component refreshes status query when it becomes invalid.
-  statusesValid: boolean;
-}
-
-/**
- * NodesMainActions are the action dispatchers which should be passed to the
- * NodesMain container.
- */
-interface NodesMainActions {
-  // Call if the nodes statuses are stale and need to be refreshed.
-  refreshNodes: typeof refreshNodes;
-  // Call if the user indicates they wish to change the sort of the table data.
   setUISetting: typeof setUISetting;
+  statuses: NodeStatus[];
+  nodesSummary: NodesSummary;
 }
 
 /**
- * NodesMainProps is the type of the props object that must be passed to
- * NodesMain component.
+ * LiveNodeList displays a sortable table of all "live" nodes, which includes
+ * both healthy and suspect nodes. Included is a side-bar with summary
+ * statistics for these nodes.
  */
-type NodesMainProps = NodesMainData & NodesMainActions;
-
-/**
- * Renders the main content of the nodes page, which is primarily a data table
- * of all nodes.
- */
-class NodesMain extends React.Component<NodesMainProps, {}> {
+class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
   // Callback when the user elects to change the sort setting.
   changeSortSetting(setting: SortSetting) {
-    this.props.setUISetting(UI_NODES_SORT_SETTING_KEY, setting);
-  }
-
-  componentWillMount() {
-    // Refresh nodes status query when mounting.
-    this.props.refreshNodes();
-  }
-
-  componentWillReceiveProps(props: NodesMainProps) {
-    // Refresh nodes status query when props are received; this will immediately
-    // trigger a new request if previous results are invalidated.
-    props.refreshNodes();
-  }
-
-  totalNodes() {
-    if (!this.props.statuses) {
-      return 0;
-    }
-    return this.props.statuses.length;
+    this.props.setUISetting(UI_NODES_LIVE_SORT_SETTING_KEY, setting);
   }
 
   render() {
-    let { statuses, sortSetting } = this.props;
+    const { statuses, nodesSummary, sortSetting } = this.props;
+    if (!statuses || statuses.length === 0) {
+      return null;
+    }
 
     return <div>
-      {
-        // TODO(mrtracy): This currently always links back to the main cluster
-        // page, when it should link back to the dashboard previously visible.
-      }
-      <section className="section parent-link">
-        <Link to="/cluster">&lt; Back to Cluster</Link>
-      </section>
-      <section className="header header--subsection">
-        Nodes Overview
-      </section>
+      <div className="header header--subsection">
+        Live Nodes
+      </div>
       <section className="section l-columns">
         <div className="l-columns__left">
           <NodeSortedTable
             data={statuses}
             sortSetting={sortSetting}
-            onChangeSortSetting={(setting) => this.changeSortSetting(setting) }
+            onChangeSortSetting={(setting) => this.changeSortSetting(setting)}
             columns={[
               // Node column - displays the node ID, links to the node-specific page for
               // this node.
               {
                 title: "Node",
                 cell: (ns) => {
-                  let lastUpdate = moment(NanoToMilli(ns.updated_at.toNumber()));
-                  let s = staleStatus(lastUpdate);
+                  const status = nodesSummary.livenessStatusByNodeID[ns.getDesc().getNodeId()] || 0;
+                  const s = LivenessStatus[status].toLowerCase();
+                  const tooltip = (status === LivenessStatus.HEALTHY) ?
+                    "This node is currently healthy." :
+                    `This node has not reported as being live for over ${suspectTimeout.humanize()}.`;
                   return <div>
                     <Link to={"/nodes/" + ns.desc.node_id}>{ns.desc.address.address_field}</Link>
-                    <div className={"icon-circle-filled node-status-icon node-status-icon--" + s}/>
+                    <div className={"icon-circle-filled node-status-icon node-status-icon--" + s} title={tooltip} />
                   </div>;
                 },
                 sort: (ns) => ns.desc.node_id,
@@ -135,7 +96,7 @@ class NodesMain extends React.Component<NodesMainProps, {}> {
               {
                 title: "Uptime",
                 cell: (ns) => {
-                  let startTime = moment(NanoToMilli(ns.started_at.toNumber()));
+                  const startTime = moment(NanoToMilli(ns.started_at.toNumber()));
                   return moment.duration(startTime.diff(moment())).humanize();
                 },
                 sort: (ns) => ns.started_at,
@@ -164,28 +125,28 @@ class NodesMain extends React.Component<NodesMainProps, {}> {
                 cell: (ns) => <Link to={"/nodes/" + ns.desc.node_id + "/logs"}>Logs</Link>,
                 className: "expand-link",
               },
-            ]}/>
+            ]} />
         </div>
         <div className="l-columns__right">
           <SummaryBar>
             <SummaryHeadlineStat
-              title="Total Nodes"
-              tooltip="Total number of nodes in the cluster."
-              value={ this.totalNodes() }/>
+              title="Total Live Nodes"
+              tooltip="Total number of live nodes in the cluster."
+              value={statuses.length} />
             <SummaryHeadlineStat
-              title={ "Total Bytes" }
-              tooltip="The total number of bytes stored across all nodes."
-              value={ this.props.usedBytes }
-              format={ Bytes } />
+              title={"Total Bytes"}
+              tooltip="The total number of bytes stored across all live nodes."
+              value={nodesSummary.nodeSums.usedBytes}
+              format={Bytes} />
             <SummaryHeadlineStat
               title="Total Replicas"
-              tooltip="The total number of replicas stored across all nodes."
-              value={ this.props.replicaCount }/>
+              tooltip="The total number of replicas stored across all live nodes."
+              value={nodesSummary.nodeSums.replicas} />
             <SummaryHeadlineStat
-              title={ "Total Memory Usage" }
-              tooltip="The total amount of memory used across all nodes."
-              value={ this.props.usedMem }
-              format={ Bytes } />
+              title={"Total Memory Usage"}
+              tooltip="The total amount of memory used across all live nodes."
+              value={nodesSummary.nodeSums.usedMem}
+              format={Bytes} />
           </SummaryBar>
         </div>
       </section>
@@ -193,54 +154,191 @@ class NodesMain extends React.Component<NodesMainProps, {}> {
   }
 }
 
-/******************************
- *         SELECTORS
+/**
+ * DeadNodeList renders a sortable table of all "dead" nodes on the cluster.
  */
+class DeadNodeList extends React.Component<NodeCategoryListProps, {}> {
+  // Callback when the user elects to change the sort setting.
+  changeSortSetting(setting: SortSetting) {
+    this.props.setUISetting(UI_NODES_DEAD_SORT_SETTING_KEY, setting);
+  }
+
+  render() {
+    const { statuses, nodesSummary, sortSetting } = this.props;
+    if (!statuses || statuses.length === 0) {
+      return null;
+    }
+
+    return <div>
+      <section className="header header--subsection">
+        Dead Nodes
+      </section>
+      <section className="section l-columns">
+        <div className="l-columns__left">
+          <NodeSortedTable
+            data={statuses}
+            sortSetting={sortSetting}
+            onChangeSortSetting={(setting) => this.changeSortSetting(setting)}
+            columns={[
+              // Node column - displays the node ID, links to the node-specific page for
+              // this node.
+              {
+                title: "Node",
+                cell: (ns) => {
+                  return <div>
+                    <Link to={"/nodes/" + ns.desc.node_id}>{ns.desc.address.address_field}</Link>
+                    <div className="icon-circle-filled node-status-icon node-status-icon--dead"
+                         title={`This node has not reported as being live for over ${deadTimeout.humanize()} and is considered dead.`}
+                         />
+                  </div>;
+                },
+                sort: (ns) => ns.desc.node_id,
+                // TODO(mrtracy): Consider if there is a better way to use BEM
+                // style CSS in cases like this; it is a bit awkward to write out
+                // the entire modifier class here, but it might not be better to
+                // construct the full BEM class in the table component itself.
+                className: "sort-table__cell--link",
+              },
+              // Down since - displays the time that the node started.
+              {
+                title: "Downtime",
+                cell: (ns) => {
+                  const liveness = nodesSummary.livenessByNodeID[ns.getDesc().getNodeId()];
+                  const deadTime = liveness.expiration.getWallTime();
+                  const deadMoment = LongToMoment(deadTime);
+                  return moment.duration(deadMoment.diff(moment())).humanize();
+                },
+                sort: (ns) => ns.started_at,
+              },
+            ]} />
+        </div>
+        <div className="l-columns__right">
+          <SummaryBar>
+            <SummaryHeadlineStat
+              title="Total Dead Nodes"
+              tooltip="Total number of dead nodes in the cluster."
+              value={statuses.length} />
+          </SummaryBar>
+        </div>
+      </section>
+    </div>;
+  }
+}
 
 // Base selectors to extract data from redux state.
-let nodeQueryValid = (state: AdminUIState): boolean => state.cachedData.nodes.valid;
-let nodeStatuses = (state: AdminUIState): NodeStatus[] => state.cachedData.nodes.data;
-let sortSetting = (state: AdminUIState): SortSetting => state.ui[UI_NODES_SORT_SETTING_KEY] || {};
+const nodeQueryValid = (state: AdminUIState): boolean => state.cachedData.nodes.valid && state.cachedData.liveness.valid;
+const liveSortSetting = (state: AdminUIState): SortSetting => state.ui[UI_NODES_LIVE_SORT_SETTING_KEY] || {};
+const deadSortSetting = (state: AdminUIState): SortSetting => state.ui[UI_NODES_DEAD_SORT_SETTING_KEY] || {};
 
-// Connect the NodesMain class with our redux store.
-let nodesMainConnected = connect(
-  (state: AdminUIState) => {
-    let sums = nodeSums(state);
+/**
+ * partitionedStatuses divides the list of node statuses into "live" and "dead".
+ */
+const partitonedStatuses = createSelector(
+  nodesSummarySelector,
+  (summary) => {
+    const liveOrDead = _.partition(
+      summary.nodeStatuses,
+      (ns) => summary.livenessStatusByNodeID[ns.getDesc().node_id] !== LivenessStatus.DEAD,
+    );
     return {
-      statuses: nodeStatuses(state),
-      sortSetting: sortSetting(state),
-      statusesValid: nodeQueryValid(state),
-      replicaCount: sums.replicas,
-      usedBytes: sums.usedBytes,
-      usedMem: sums.usedMem,
+      live: liveOrDead[0],
+      dead: liveOrDead[1],
+    };
+  },
+);
+
+/**
+ * LiveNodesConnected is a redux-connected HOC of LiveNodes.
+ */
+// tslint:disable-next-line:variable-name
+const LiveNodesConnected = connect(
+  (state: AdminUIState) => {
+    const statuses = partitonedStatuses(state);
+    return {
+      sortSetting: liveSortSetting(state),
+      statuses: statuses.live,
+      nodesSummary: nodesSummarySelector(state),
     };
   },
   {
-    refreshNodes: refreshNodes,
-    setUISetting: setUISetting,
+    setUISetting,
+  },
+)(LiveNodeList);
+
+/**
+ * DeadNodesConnected is a redux-connected HOC of DeadNodes.
+ */
+// tslint:disable-next-line:variable-name
+const DeadNodesConnected = connect(
+  (state: AdminUIState) => {
+    const statuses = partitonedStatuses(state);
+    return {
+      sortSetting: deadSortSetting(state),
+      statuses: statuses.dead,
+      nodesSummary: nodesSummarySelector(state),
+    };
+  },
+  {
+    setUISetting,
+  },
+)(DeadNodeList);
+
+/**
+ * NodesMainProps is the type of the props object that must be passed to
+ * NodesMain component.
+ */
+interface NodesMainProps {
+  // Call if the nodes statuses are stale and need to be refreshed.
+  refreshNodes: typeof refreshNodes;
+  // Call if the liveness statuses are stale and need to be refreshed.
+  refreshLiveness: typeof refreshLiveness;
+  // True if current status results are still valid. Needed so that this
+  // component refreshes status query when it becomes invalid.
+  statusesValid: boolean;
+}
+
+/**
+ * Renders the main content of the nodes page, which is primarily a data table
+ * of all nodes.
+ */
+class NodesMain extends React.Component<NodesMainProps, {}> {
+  componentWillMount() {
+    // Refresh nodes status query when mounting.
+    this.props.refreshNodes();
+    this.props.refreshLiveness();
+  }
+
+  componentWillReceiveProps(props: NodesMainProps) {
+    // Refresh nodes status query when props are received; this will immediately
+    // trigger a new request if previous results are invalidated.
+    props.refreshNodes();
+    props.refreshLiveness();
+  }
+
+  render() {
+    return <div>
+      <section className="section parent-link">
+        <Link to="/cluster">&lt; Back to Cluster</Link>
+      </section>
+      <LiveNodesConnected/>
+      <DeadNodesConnected/>
+    </div>;
+  }
+}
+
+/**
+ * nodesMainConnected is a redux-connected HOC of NodesMain.
+ */
+const nodesMainConnected = connect(
+  (state: AdminUIState) => {
+    return {
+      statusesValid: nodeQueryValid(state),
+    };
+  },
+  {
+    refreshNodes,
+    refreshLiveness,
   },
 )(NodesMain);
 
 export { nodesMainConnected as default };
-
-/******************************
- *    Formatting Functions
- */
-
-/**
- * staleStatus returns the "status" of the node depending on how long ago
- * the last status update was received.
- *
- *   healthy <=1min
- *   stale   <1min & <=10min
- *   missing >10min
- */
-function staleStatus(lastUpdate: moment.Moment): string {
-  if (lastUpdate.isBefore(moment().subtract(10, "minutes"))) {
-    return "missing";
-  }
-  if (lastUpdate.isBefore(moment().subtract(1, "minute"))) {
-    return "stale";
-  }
-  return "healthy";
-}

--- a/pkg/ui/src/redux/apiReducers.ts
+++ b/pkg/ui/src/redux/apiReducers.ts
@@ -59,6 +59,9 @@ export const refreshTableStats = tableStatsReducerObj.refresh;
 const logsReducerObj = new CachedDataReducer(api.getLogs, "logs", moment.duration(10, "s"));
 export const refreshLogs = logsReducerObj.refresh;
 
+const livenessReducerObj = new CachedDataReducer(api.getLiveness, "liveness", moment.duration(10, "s"));
+export const refreshLiveness = livenessReducerObj.refresh;
+
 export interface APIReducersState {
   cluster: CachedDataReducerState<api.ClusterResponseMessage>;
   events: CachedDataReducerState<api.EventsResponseMessage>;
@@ -71,6 +74,7 @@ export interface APIReducersState {
   tableDetails: KeyedCachedDataReducerState<api.TableDetailsResponseMessage>;
   tableStats: KeyedCachedDataReducerState<api.TableStatsResponseMessage>;
   logs: CachedDataReducerState<api.LogEntriesResponseMessage>;
+  liveness: CachedDataReducerState<api.LivenessResponseMessage>;
 }
 
 export default combineReducers<APIReducersState>({
@@ -85,6 +89,7 @@ export default combineReducers<APIReducersState>({
   [tableDetailsReducerObj.actionNamespace]: tableDetailsReducerObj.reducer,
   [tableStatsReducerObj.actionNamespace]: tableStatsReducerObj.reducer,
   [logsReducerObj.actionNamespace]: logsReducerObj.reducer,
+  [livenessReducerObj.actionNamespace]: livenessReducerObj.reducer,
 });
 
 export {CachedDataReducerState, KeyedCachedDataReducerState};

--- a/pkg/ui/src/redux/cachedDataReducer.spec.ts
+++ b/pkg/ui/src/redux/cachedDataReducer.spec.ts
@@ -1,7 +1,7 @@
 import { assert } from "chai";
 import _ from "lodash";
 import { Action } from "redux";
-
+import moment from "moment";
 import { CachedDataReducer, CachedDataReducerState, KeyedCachedDataReducer, KeyedCachedDataReducerState } from "./cachedDataReducer";
 
 describe("basic cachedDataReducer", function () {
@@ -40,6 +40,8 @@ describe("basic cachedDataReducer", function () {
     });
 
     let reducer = testReducerObj.reducer;
+    let testMoment = moment();
+    testReducerObj.setTimeSource(() => testMoment);
 
     describe("reducer", function () {
       let state: CachedDataReducerState<Response>;
@@ -65,6 +67,7 @@ describe("basic cachedDataReducer", function () {
         expected = new CachedDataReducerState<Response>();
         expected.valid = true;
         expected.data = expectedResponse;
+        expected.setAt = testMoment;
         expected.lastError = null;
         assert.deepEqual(state, expected);
       });
@@ -110,6 +113,7 @@ describe("basic cachedDataReducer", function () {
           expected = new CachedDataReducerState<Response>();
           expected.valid = true;
           expected.data = new Response(testString);
+          expected.setAt = testMoment;
           expected.lastError = null;
           assert.deepEqual(state.cachedData.test, expected);
         });
@@ -183,6 +187,8 @@ describe("keyed cachedDataReducer", function () {
     });
 
     let reducer = testReducerObj.reducer;
+    let testMoment = moment();
+    testReducerObj.setTimeSource(() => testMoment);
 
     describe("keyed reducer", function () {
       let state: KeyedCachedDataReducerState<Response>;
@@ -216,6 +222,7 @@ describe("keyed cachedDataReducer", function () {
         expected[id].valid = true;
         expected[id].data = expectedResponse;
         expected[id].lastError = null;
+        expected[id].setAt = testMoment;
         assert.deepEqual(state, expected);
       });
 

--- a/pkg/ui/src/redux/cachedDataReducer.ts
+++ b/pkg/ui/src/redux/cachedDataReducer.ts
@@ -18,6 +18,7 @@ export class CachedDataReducerState<TResponseMessage> {
   data: TResponseMessage; // the latest data received
   inFlight = false; // true if a request is in flight
   valid = false; // true if data has been received and has not been invalidated
+  setAt: moment.Moment; // Timestamp when this data was last updated.
   lastError: Error; // populated with the most recent error, if the last request failed
 }
 
@@ -51,7 +52,11 @@ export class CachedDataReducer<TRequest, TResponseMessage> {
    * invalidationPeriod (optional) - The duration after
    *   data is received after which it will be invalidated.
    */
-  constructor(protected apiEndpoint: APIRequestFn<TRequest, TResponseMessage>, public actionNamespace: string, protected invalidationPeriod?: moment.Duration) {
+  constructor(
+    protected apiEndpoint: APIRequestFn<TRequest, TResponseMessage>,
+    public actionNamespace: string,
+    protected invalidationPeriod?: moment.Duration,
+  ) {
     // check actionNamespace
     assert.notProperty(CachedDataReducer.namespaces, actionNamespace, "Expected actionNamespace to be unique.");
     CachedDataReducer.namespaces[actionNamespace] = true;
@@ -60,6 +65,14 @@ export class CachedDataReducer<TRequest, TResponseMessage> {
     this.RECEIVE = `cockroachui/CachedDataReducer/${actionNamespace}/RECEIVE`;
     this.ERROR = `cockroachui/CachedDataReducer/${actionNamespace}/ERROR`;
     this.INVALIDATE = `cockroachui/CachedDataReducer/${actionNamespace}/INVALIDATE`;
+  }
+
+  /**
+   * setTimeSource overrides the source of timestamps used by this component.
+   * Intended for use in tests only.
+   */
+  setTimeSource(timeSource: {(): moment.Moment}) {
+    this.timeSource = timeSource;
   }
 
   /**
@@ -78,6 +91,7 @@ export class CachedDataReducer<TRequest, TResponseMessage> {
         state = _.clone(state);
         state.inFlight = false;
         state.data = payload.data;
+        state.setAt = this.timeSource();
         state.valid = true;
         state.lastError = null;
         return state;
@@ -172,6 +186,8 @@ export class CachedDataReducer<TRequest, TResponseMessage> {
       });
     };
   }
+
+  private timeSource: {(): moment.Moment} = () => moment();
 }
 
 /**
@@ -200,6 +216,14 @@ export class KeyedCachedDataReducer<TRequest, TResponseMessage> {
    */
   constructor(protected apiEndpoint: (req: TRequest) => Promise<TResponseMessage>, public actionNamespace: string, private requestToID: (req: TRequest) => string, protected invalidationPeriod?: moment.Duration) {
     this.cachedDataReducer = new CachedDataReducer<TRequest, TResponseMessage>(apiEndpoint, actionNamespace, invalidationPeriod);
+  }
+
+  /**
+   * setTimeSource overrides the source of timestamps used by this component.
+   * Intended for use in tests only.
+   */
+  setTimeSource(timeSource: {(): moment.Moment}) {
+    this.cachedDataReducer.setTimeSource(timeSource);
   }
 
   /**

--- a/pkg/ui/src/redux/nodes.ts
+++ b/pkg/ui/src/redux/nodes.ts
@@ -1,0 +1,200 @@
+import moment from "moment";
+import _ from "lodash";
+import { createSelector } from "reselect";
+
+import { AdminUIState } from "./state";
+import { NanoToMilli } from "../util/convert";
+import { NodeStatus, MetricConstants, BytesUsed } from "../util/proto";
+import { nullOfReturnType } from "../util/types";
+
+/**
+ * deadTimeout indicates a grace-period duration where nodes are still
+ * considered to be alive; if more than this duration has passed since the
+ * node's liveness expired, it is considered dead.
+ *
+ * The value of this constant is based on the default value of the server
+ * configuration value "TimeUntilStoreDead". At some point this configuration
+ * value will be moved to a cluster configuration table (#14230), and at that
+ * point it will be appropriate to pull this value from the server directly.
+ */
+export const deadTimeout = moment.duration(5, "m");
+
+/**
+ * suspectTimeout is similar to deadTimeout, but is a shorter duration and only
+ * marks a node as "suspect"; this indicates a node that has an expired
+ * liveness, but is not yet being actively repaired.
+ *
+ * There is no clear server-side analogy to this state, this is simply an
+ * indication to the user that something may be wrong with the server.
+ */
+export const suspectTimeout = moment.duration(1, "m");
+
+/**
+ * LivenessStatus is a convenience enumeration used to bucket node liveness
+ * records into basic states.
+ */
+export enum LivenessStatus {
+  /**
+   * The node's liveness record has been updated recently.
+   */
+  HEALTHY,
+  /**
+   * The node's liveness record has not been updated for a short duration, and
+   * thus this node might be down.
+   */
+  SUSPECT,
+  /**
+   * The node's liveness record has been expired long enough that the node is
+   * considered dead.
+   */
+  DEAD,
+}
+
+// Functions to select data directly from the redux state.
+const nodeStatusesSelector = (state: AdminUIState) => state.cachedData.nodes.data;
+const livenessesSelector = (state: AdminUIState) => state.cachedData.liveness.data;
+const livenessCheckedAtSelector = (state: AdminUIState) => state.cachedData.liveness.setAt;
+
+/**
+ * livenessByNodeIDSelector returns a map from NodeID to the Liveness record for
+ * that node.
+ */
+const livenessByNodeIDSelector = createSelector(
+  livenessesSelector,
+  (livenesses) => {
+    if (livenesses) {
+      return _.keyBy(livenesses.getLivenesses(), (l) => l.getNodeId());
+    }
+    return {};
+  },
+);
+
+/**
+ * livenessStatusByNodeIDSelector returns a map from NodeID to the
+ * LivenessStatus of that node.
+ */
+const livenessStatusByNodeIDSelector = createSelector(
+  livenessByNodeIDSelector,
+  livenessCheckedAtSelector,
+  (livenessByNodeID, livenessCheckedAt) => {
+    if (livenessCheckedAt) {
+      const deadCutoff = livenessCheckedAt.clone().subtract(deadTimeout);
+      const suspectCutoff = livenessCheckedAt.clone().subtract(suspectTimeout);
+      return _.mapValues(livenessByNodeID, (l) => {
+        const expiration = moment(NanoToMilli(l.expiration.getWallTime().toNumber()));
+        if (expiration.isBefore(deadCutoff)) {
+          return LivenessStatus.DEAD;
+        } else if (expiration.isBefore(suspectCutoff)) {
+          return LivenessStatus.SUSPECT;
+        }
+        return LivenessStatus.HEALTHY;
+      });
+    }
+    return {};
+  },
+);
+
+/**
+ * nodeIDsSelector returns the NodeID of all nodes currently on the cluster.
+ */
+const nodeIDsSelector = createSelector(
+  nodeStatusesSelector,
+  (nodeStatuses) => {
+    return _.map(nodeStatuses, (ns) => ns.desc.node_id.toString());
+  },
+);
+
+/**
+ * nodeStatusByIDSelector returns a map from NodeID to a current NodeStatus.
+ */
+const nodeStatusByIDSelector = createSelector(
+  nodeStatusesSelector,
+  (nodeStatuses) => {
+    const statuses: {[s: string]: NodeStatus} = {};
+    _.each(nodeStatuses, (ns) => {
+      statuses[ns.desc.node_id.toString()] = ns;
+    });
+    return statuses;
+  },
+);
+
+/**
+ * nodeSumsSelector returns an object with certain cluster-wide totals which are
+ * used in different places in the UI.
+ */
+const nodeSumsSelector = createSelector(
+  nodeStatusesSelector,
+  livenessStatusByNodeIDSelector,
+  (nodeStatuses, livenessStatusByNodeID) => {
+    const result = {
+      nodeCounts: {
+        total: 0,
+        healthy: 0,
+        suspect: 0,
+        dead: 0,
+      },
+      capacityAvailable: 0,
+      capacityTotal: 0,
+      usedBytes: 0,
+      usedMem: 0,
+      unavailableRanges: 0,
+      replicas: 0,
+    };
+    if (_.isArray(nodeStatuses) && _.isObject(livenessStatusByNodeID)) {
+      nodeStatuses.forEach((n) => {
+        result.nodeCounts.total += 1;
+        const status = livenessStatusByNodeID[n.getDesc().getNodeId()];
+        switch (status) {
+          case LivenessStatus.HEALTHY:
+            result.nodeCounts.healthy++;
+            break;
+          case LivenessStatus.SUSPECT:
+            result.nodeCounts.suspect++;
+            break;
+          case LivenessStatus.DEAD:
+            result.nodeCounts.dead++;
+            break;
+          default:
+            result.nodeCounts.dead++;
+            break;
+        }
+        if (status !== LivenessStatus.DEAD) {
+          result.capacityAvailable += n.metrics.get(MetricConstants.availableCapacity);
+          result.capacityTotal += n.metrics.get(MetricConstants.capacity);
+          result.usedBytes += BytesUsed(n);
+          result.usedMem += n.metrics.get(MetricConstants.rss);
+          result.unavailableRanges += n.metrics.get(MetricConstants.unavailableRanges);
+          result.replicas += n.metrics.get(MetricConstants.replicas);
+        }
+      });
+    }
+    return result;
+  },
+);
+
+/**
+ * nodesSummarySelector returns a directory object containing a variety of
+ * computed information based on the current nodes. This object is easy to
+ * connect to components on child pages.
+ */
+export const nodesSummarySelector = createSelector(
+  nodeStatusesSelector,
+  nodeIDsSelector,
+  nodeStatusByIDSelector,
+  nodeSumsSelector,
+  livenessStatusByNodeIDSelector,
+  livenessByNodeIDSelector,
+  (nodeStatuses, nodeIDs, nodeStatusByID, nodeSums, livenessStatusByNodeID, livenessByNodeID) => {
+    return {
+      nodeStatuses,
+      nodeIDs,
+      nodeStatusByID,
+      nodeSums,
+      livenessStatusByNodeID,
+      livenessByNodeID,
+    };
+  },
+);
+
+const nodesSummaryType = nullOfReturnType(nodesSummarySelector);
+export type NodesSummary = typeof nodesSummaryType;

--- a/pkg/ui/src/util/api.ts
+++ b/pkg/ui/src/util/api.ts
@@ -50,6 +50,9 @@ export type TableStatsResponseMessage = Proto2TypeScript.cockroach.server.server
 export type LogsRequestMessage = Proto2TypeScript.cockroach.server.serverpb.LogsRequestMessage;
 export type LogEntriesResponseMessage = Proto2TypeScript.cockroach.server.serverpb.LogEntriesResponseMessage;
 
+export type LivenessRequestMessage = Proto2TypeScript.cockroach.server.serverpb.LivenessRequestMessage;
+export type LivenessResponseMessage = Proto2TypeScript.cockroach.server.serverpb.LivenessResponseMessage;
+
 // API constants
 
 export const API_PREFIX = "_admin/v1";
@@ -190,4 +193,9 @@ export function getTableStats(req: TableStatsRequestMessage, timeout?: moment.Du
 // getLogs gets the logs for a specific node
 export function getLogs(req: LogsRequestMessage, timeout?: moment.Duration): Promise<LogEntriesResponseMessage> {
   return timeoutFetch(serverpb.LogEntriesResponse, `${STATUS_PREFIX}/logs/${req.node_id}`, null, timeout);
+}
+
+// getLiveness gets cluster liveness information from the current node.
+export function getLiveness(_: LivenessRequestMessage, timeout?: moment.Duration): Promise<LivenessResponseMessage> {
+  return timeoutFetch(serverpb.LivenessResponse, `${API_PREFIX}/liveness`, null, timeout);
 }

--- a/pkg/ui/src/util/types.ts
+++ b/pkg/ui/src/util/types.ts
@@ -1,0 +1,30 @@
+/**
+ * nullOfReturnType allows us to extract the return type of a function; this is
+ * necessary because typescript does not currently have a syntax to directly
+ * extract the return type of a function.
+ *
+ * This is needed in cases where:
+ * 1. A function returns an object with a complex type which is not explicitly
+ * declared. This occurs, for example, when constructing lookup objects that
+ * contain many fields: explicitly declaring the return type results in
+ * significant boilerplate which is unnecessary, because typescript knows the
+ * type of the variable being returned.
+ * 2. We need to declare a variable to hold the output of this function, but
+ * cannot immediately assign the output of the function to the variable.
+ *
+ * The output of nullOfReturnType() cannot be directly fed into a typeof
+ * statement; instead, its result must be stored in a variable, and in turn
+ * that variable can be used with a typeof statement.
+ *
+ * An example of extracting type information using nullOfReturnType():
+ *
+ * function fnWithComplicatedResult() {
+ *  return {...};
+ * }
+ *
+ * const complicatedReturnType = nullOfReturnType(fnWithComplicatedReturn);
+ * let complicatedVariable: typeof complicatedReturnType;
+ */
+export function nullOfReturnType<R> (_: (...args: any[]) => R): R {
+    return null;
+}

--- a/pkg/ui/styl/pages/nodes.styl
+++ b/pkg/ui/styl/pages/nodes.styl
@@ -5,9 +5,9 @@
   line-height 14px
   vertical-align middle
   
-  &--missing
+  &--dead
     color $secondary-red
-  &--stale
+  &--suspect
     color $secondary-gold
   &--healthy
     color $main-green


### PR DESCRIPTION
Two main additions:
+ The Admin UI now queries Liveness data from the backend, and can now use it to better
inform status visuals across the cluster. This data is added to the Redux state;
additionally, numerous selectors have been created in the new `redux/nodes.ts`
which provide useful computed information to various components.
+ This information is now being used by the Nodes List to divide all nodes into
"Live" and "Dead".

The nodes page has been changed to display two tables - one for live nodes, and
another for dead nodes. This fixes #5415, as dead nodes now have a different set
of columns than live nodes and thus we are no longer displaying out-of-date
values for these nodes. This also fixes #12422, as dead nodes are no longer
considered in summation totals. Also makes progress towards #13895.

While overhauling the nodes page, have also added a tooltip to the colored
health indicators on the nodes list to help explain the "healthy", "suspect" and
"dead" states. Fixes #7547.

Division of nodes list:
<img width="1305" alt="screen shot 2017-03-19 at 7 11 34 pm" src="https://cloud.githubusercontent.com/assets/6969858/24085771/246cfbd2-0cd8-11e7-9735-0368c9faeb8e.png">


Tooltip:
<img width="865" alt="screen shot 2017-03-19 at 7 05 06 pm" src="https://cloud.githubusercontent.com/assets/6969858/24085774/28c63cac-0cd8-11e7-9507-4a1c6709acb8.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14258)
<!-- Reviewable:end -->
