### PR TITLE
build: display Git status during TeamCity release upload

### DIFF
--- a/build/teamcity-release-upload.sh
+++ b/build/teamcity-release-upload.sh
@@ -21,6 +21,11 @@ esac
 
 export VERSION
 echo "Deploying $VERSION..."
+
+cat .buildinfo/tag || true
+cat .buildinfo/rev || true
+git status
+
 build/builder.sh build/build-static-binaries.sh static-tests.tar.gz
 for archive in cockroach-latest "cockroach-${VERSION}"
 do


### PR DESCRIPTION
TeamCity has been building release artifacts with tags set to
"$SHA-dirty", which indicates unmodified files are present in the work
tree. These untracked files disappear (and the artifacts are built
without the "-dirty" suffix) as soon as the build configuration is
changed to investigate, so hopefully changing the underlying script to
print `git status` like this commit does will shed some light.

---

@mberhault @jordanlewis I'm all ears if you have a better means of debugging. Here's [a release build with the bug](https://teamcity.cockroachdb.com/viewLog.html?buildId=187193&buildTypeId=Cockroach_MergeToMaster&tab=buildLog#_focus=424&state=424). Under "Step 3/3: Upload binaries" you'll see that `go build` is invoked with `build.tag=eb320b5-dirty`. I cloned the build configuration and [ran a build](https://teamcity.cockroachdb.com/viewLog.html?buildId=187223&buildTypeId=Cockroach_ScratchProjectPutTcExperimentsInHere_NikhilReleaseBuildTesting&tab=buildLog#_focus=112&state=112) which again suffixed the build tag with `-dirty`. But as soon as I [changed the configuration to print `git status`](https://teamcity.cockroachdb.com/viewLog.html?buildId=187243&buildTypeId=Cockroach_ScratchProjectPutTcExperimentsInHere_NikhilReleaseBuildTesting&tab=buildLog#_state=101,115&focus=115), `git status` reported only untracked files (no modified files), and the build was properly invoked with `build.tag=eb320b5`. What gives?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14259)
<!-- Reviewable:end -->
