### PR TITLE
storage: Don't allow preemptive snapshots on initialized replicas

### DIFF
--- a/pkg/storage/replica_gc_queue.go
+++ b/pkg/storage/replica_gc_queue.go
@@ -231,7 +231,7 @@ func (rgcq *replicaGCQueue) process(
 		// Replica (see #8111) when inactive ones can be starved by
 		// event-driven additions.
 		if log.V(1) {
-			log.Infof(ctx, "not gc'able")
+			log.Infof(ctx, "not gc'able") // TODO(DONOTMERGE): Why is rejecting snapshots sometimes getting us stuck here?
 		}
 		if err := repl.setLastReplicaGCTimestamp(ctx, repl.store.Clock().Now()); err != nil {
 			return err

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2904,6 +2904,7 @@ func (s *Store) processRaftRequest(
 	ctx context.Context, req *RaftMessageRequest, inSnap IncomingSnapshot,
 ) (pErr *roachpb.Error) {
 	// Lazily create the replica.
+	// TODO(DONOTMERGE): Should we not create the replica if the incoming request isn't a snapshot?
 	r, _, err := s.getOrCreateReplica(
 		req.RangeID, req.ToReplica.ReplicaID, &req.FromReplica)
 	if err != nil {


### PR DESCRIPTION
This prevents preemptive snapshots from silently succeeding, allowing a
replica GC to be intertwined with the creation of a new replica such
that the new replica has no local data.

Also add some verbose logging for replica ID changes.

--------------------------

This PR is honestly more questions than changes. The only real change is moving the `r.mu.replicaID > replicaID` check ahead of the `replicaID == 0` check, and beyond that it's just an extra log statement and questions. Even that change requires some more investigation as it's caused the test to start occasionally timing out due to a failure to ever GC the removed replica (with `not gc'able` messages in the logs), which may or may not be an existing issue that rejecting the preemptive snapshots exposes.

I think we also need to do more than this since it's essentially just preventing preemptive snapshots from being applied to existing replicas, but I'm a little wary of making bigger modifications without fully understanding the reasoning/history behind why things are the way they are. In particular, the fact that a `MsgHeartbeat` can seemingly come in and create a replica that doesn't know its own key range which will then fail when it tries to process the heartbeat (as in https://github.com/cockroachdb/cockroach/issues/14231#issuecomment-287596013) seems super dangerous, but there may be some reason for doing so that I haven't thought of.

Once the questions are resolved, this will:
Fix #14193
Fix #14231
Fix #12574

@cockroachdb/stability

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14261)
<!-- Reviewable:end -->
