### PR TITLE
sql, storage: tolerate existing splits in AdminSplit and SPLIT AT

### DIFF
--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -9,8 +9,6 @@
 package sqlccl
 
 import (
-	"strings"
-
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
@@ -470,9 +468,7 @@ func presplitRanges(baseCtx context.Context, db client.DB, input []roachpb.Key) 
 		splitKey := append([]byte(nil), splitPoints[splitIdx]...)
 		splitKey = keys.MakeRowSentinelKey(splitKey)
 		if err := db.AdminSplit(ctx, splitKey); err != nil {
-			if !strings.Contains(err.Error(), "range is already split at key") {
-				return err
-			}
+			return err
 		}
 
 		splitPointsLeft, splitPointsRight := splitPoints[:splitIdx], splitPoints[splitIdx+1:]

--- a/pkg/cmd/zerosum/main.go
+++ b/pkg/cmd/zerosum/main.go
@@ -226,9 +226,6 @@ func (z *zeroSum) monkey(tableID uint32, d time.Duration) {
 		switch r.Intn(2) {
 		case 0:
 			if err := z.Split(z.RandNode(r.Intn), key); err != nil {
-				if strings.Contains(err.Error(), "range is already split at key") {
-					continue
-				}
 				z.maybeLogError(err)
 			} else {
 				atomic.AddUint64(&z.stats.splits, 1)

--- a/pkg/kv/split_test.go
+++ b/pkg/kv/split_test.go
@@ -221,7 +221,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 }
 
 // TestRangeSplitsWithSameKeyTwice check that second range split
-// on the same splitKey should not cause infinite retry loop.
+// on the same splitKey succeeds.
 func TestRangeSplitsWithSameKeyTwice(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _ := createTestDB(t)
@@ -233,13 +233,7 @@ func TestRangeSplitsWithSameKeyTwice(t *testing.T) {
 		t.Fatal(err)
 	}
 	log.Infof(context.Background(), "split at key %q first time complete", splitKey)
-	ch := make(chan error)
-	go func() {
-		// should return error other than infinite loop
-		ch <- s.DB.AdminSplit(context.TODO(), splitKey)
-	}()
-
-	if err := <-ch; err == nil {
-		t.Error("range split on same splitKey should fail")
+	if err := s.DB.AdminSplit(context.TODO(), splitKey); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/pkg/sql/split_at_test.go
+++ b/pkg/sql/split_at_test.go
@@ -55,8 +55,8 @@ func TestSplitAt(t *testing.T) {
 			in: "ALTER TABLE d.t SPLIT AT (2, 'b')",
 		},
 		{
-			in:    "ALTER TABLE d.t SPLIT AT (2, 'b')",
-			error: "range is already split",
+			// Splitting at an existing split is a silent no-op.
+			in: "ALTER TABLE d.t SPLIT AT (2, 'b')",
 		},
 		{
 			in:    "ALTER TABLE d.t SPLIT AT ('c', 3)",

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -2572,7 +2572,8 @@ func (r *Replica) adminSplitWithDescriptor(
 	// roachpb.NewRangeKeyMismatchError if splitKey equals to desc.EndKey,
 	// otherwise it will cause infinite retry loop.
 	if desc.StartKey.Equal(splitKey) || desc.EndKey.Equal(splitKey) {
-		return reply, roachpb.NewErrorf("range is already split at key %s", splitKey)
+		log.Event(ctx, "range already split")
+		return reply, nil
 	}
 	log.Event(ctx, "found split key")
 

--- a/pkg/storage/replicate_queue_test.go
+++ b/pkg/storage/replicate_queue_test.go
@@ -62,10 +62,6 @@ func TestReplicateQueueRebalance(t *testing.T) {
 		tableID := keys.MaxReservedDescID + i + 1
 		splitKey := keys.MakeRowSentinelKey(keys.MakeTablePrefix(uint32(tableID)))
 		if _, _, err := tc.SplitRange(splitKey); err != nil {
-			// TODO(peter): Remove when #11592 is fixed.
-			if testutils.IsError(err, "range is already split at key") {
-				continue
-			}
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
This error is not useful; indeed many callers go through hoops to ignore it.
Extending SPLIT AT to handle multiple split points makes this error even more
annoying. Removing this error in favor of a silent no-op (based on discussion
in #14146).

The backup test is changed to read the meta descriptor instead on relying on
the old behavior to verify splits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14273)
<!-- Reviewable:end -->
