### PR TITLE
sql: ignore dropped tables in SHOW TABLES

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -636,7 +636,7 @@ func forEachTableDescWithTableLookup(
 	// Next, iterate through all table descriptors, using the mapping from sqlbase.ID
 	// to database name to add descriptors to a dbDescTables' tables map.
 	for _, desc := range descs {
-		if table, ok := desc.(*sqlbase.TableDescriptor); ok {
+		if table, ok := desc.(*sqlbase.TableDescriptor); ok && !table.Dropped() {
 			dbName, ok := dbIDsToName[table.GetParentID()]
 			if !ok {
 				return errors.Errorf("no database with ID %d found", table.GetParentID())


### PR DESCRIPTION
SHOW TABLES would fail whenever a database was dropped and
recreated while the underlying table data was still being GC-ed.

fixes #14214

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14278)
<!-- Reviewable:end -->
