### PR TITLE
sql: lowercase crdb_internal column names

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -44,9 +44,9 @@ var crdbInternal = virtualSchema{
 var crdbInternalBuildInfoTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE crdb_internal.node_build_info (
-  NODE_ID INT NOT NULL,
-  FIELD   STRING NOT NULL,
-  VALUE   STRING NOT NULL
+  node_id INT NOT NULL,
+  field   STRING NOT NULL,
+  value   STRING NOT NULL
 );
 `,
 	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
@@ -80,18 +80,18 @@ CREATE TABLE crdb_internal.node_build_info (
 var crdbInternalTablesTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE crdb_internal.tables (
-  TABLE_ID                 INT NOT NULL,
-  PARENT_ID                INT NOT NULL,
-  NAME                     STRING NOT NULL,
-  DATABASE_NAME            STRING NOT NULL,
-  VERSION                  INT NOT NULL,
-  MOD_TIME                 TIMESTAMP NOT NULL,
-  MOD_TIME_LOGICAL         DECIMAL NOT NULL,
-  FORMAT_VERSION           STRING NOT NULL,
-  STATE                    STRING NOT NULL,
-  SC_LEASE_NODE_ID         INT,
-  SC_LEASE_EXPIRATION_TIME TIMESTAMP,
-  CREATE_TABLE             STRING NOT NULL
+  table_id                 INT NOT NULL,
+  parent_id                INT NOT NULL,
+  name                     STRING NOT NULL,
+  database_name            STRING NOT NULL,
+  version                  INT NOT NULL,
+  mod_time                 TIMESTAMP NOT NULL,
+  mod_time_logical         DECIMAL NOT NULL,
+  format_version           STRING NOT NULL,
+  state                    STRING NOT NULL,
+  sc_lease_node_id         INT,
+  sc_lease_expiration_time TIMESTAMP,
+  create_table             STRING NOT NULL
 );
 `,
 	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {
@@ -154,14 +154,14 @@ CREATE TABLE crdb_internal.tables (
 var crdbInternalSchemaChangesTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE crdb_internal.schema_changes (
-  TABLE_ID      INT NOT NULL,
-  PARENT_ID     INT NOT NULL,
-  NAME          STRING NOT NULL,
-  TYPE          STRING NOT NULL,
-  TARGET_ID     INT,
-  TARGET_NAME   STRING,
-  STATE         STRING NOT NULL,
-  DIRECTION     STRING NOT NULL
+  table_id      INT NOT NULL,
+  parent_id     INT NOT NULL,
+  name          STRING NOT NULL,
+  type          STRING NOT NULL,
+  target_id     INT,
+  target_name   STRING,
+  state         STRING NOT NULL,
+  direction     STRING NOT NULL
 );
 `,
 	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {
@@ -214,13 +214,13 @@ CREATE TABLE crdb_internal.schema_changes (
 var crdbInternalLeasesTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE crdb_internal.leases (
-  NODE_ID     INT NOT NULL,
-  TABLE_ID    INT NOT NULL,
-  NAME        STRING NOT NULL,
-  PARENT_ID   INT NOT NULL,
-  EXPIRATION  TIMESTAMP NOT NULL,
-  RELEASED    BOOL NOT NULL,
-  DELETED     BOOL NOT NULL
+  node_id     INT NOT NULL,
+  table_id    INT NOT NULL,
+  name        STRING NOT NULL,
+  parent_id   INT NOT NULL,
+  expiration  TIMESTAMP NOT NULL,
+  released    BOOL NOT NULL,
+  deleted     BOOL NOT NULL
 );
 `,
 	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
@@ -270,25 +270,25 @@ CREATE TABLE crdb_internal.leases (
 var crdbInternalStmtStatsTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE crdb_internal.node_statement_statistics (
-  NODE_ID             INT NOT NULL,
-  APPLICATION_NAME    STRING NOT NULL,
-  KEY                 STRING NOT NULL,
-  COUNT               INT NOT NULL,
-  FIRST_ATTEMPT_COUNT INT NOT NULL,
-  MAX_RETRIES         INT NOT NULL,
-  LAST_ERROR          STRING,
-  ROWS_AVG            FLOAT NOT NULL,
-  ROWS_VAR            FLOAT NOT NULL,
-  PARSE_LAT_AVG       FLOAT NOT NULL,
-  PARSE_LAT_VAR       FLOAT NOT NULL,
-  PLAN_LAT_AVG        FLOAT NOT NULL,
-  PLAN_LAT_VAR        FLOAT NOT NULL,
-  RUN_LAT_AVG         FLOAT NOT NULL,
-  RUN_LAT_VAR         FLOAT NOT NULL,
-  SERVICE_LAT_AVG     FLOAT NOT NULL,
-  SERVICE_LAT_VAR     FLOAT NOT NULL,
-  OVERHEAD_LAT_AVG    FLOAT NOT NULL,
-  OVERHEAD_LAT_VAR    FLOAT NOT NULL
+  node_id             INT NOT NULL,
+  application_name    STRING NOT NULL,
+  key                 STRING NOT NULL,
+  count               INT NOT NULL,
+  first_attempt_count INT NOT NULL,
+  max_retries         INT NOT NULL,
+  last_error          STRING,
+  rows_avg            FLOAT NOT NULL,
+  rows_var            FLOAT NOT NULL,
+  parse_lat_avg       FLOAT NOT NULL,
+  parse_lat_var       FLOAT NOT NULL,
+  plan_lat_avg        FLOAT NOT NULL,
+  plan_lat_var        FLOAT NOT NULL,
+  run_lat_avg         FLOAT NOT NULL,
+  run_lat_var         FLOAT NOT NULL,
+  service_lat_avg     FLOAT NOT NULL,
+  service_lat_var     FLOAT NOT NULL,
+  overhead_lat_avg    FLOAT NOT NULL,
+  overhead_lat_var    FLOAT NOT NULL
 );
 `,
 	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {

--- a/pkg/sql/testdata/crdb_internal
+++ b/pkg/sql/testdata/crdb_internal
@@ -30,12 +30,12 @@ foo
 query IITTITTT colnames
 SELECT * FROM crdb_internal.schema_changes
 ----
-TABLE_ID PARENT_ID NAME TYPE TARGET_ID TARGET_NAME STATE DIRECTION
+table_id parent_id name type target_id target_name state direction
 
 query IITTITRTTTTT colnames
 SELECT * FROM crdb_internal.tables WHERE NAME = 'namespace'
 ----
-TABLE_ID  PARENT_ID  NAME       DATABASE_NAME  VERSION  MOD_TIME                         MOD_TIME_LOGICAL  FORMAT_VERSION            STATE   SC_LEASE_NODE_ID  SC_LEASE_EXPIRATION_TIME  CREATE_TABLE
+table_id  parent_id  name       database_name  version  mod_time                         mod_time_logical  format_version            state   sc_lease_node_id  sc_lease_expiration_time  create_table
 2         1          namespace  system         1        1970-01-01 00:00:00 +0000 +0000  0.0000000000      InterleavedFormatVersion  PUBLIC  NULL              NULL                      CREATE TABLE namespace (
           parentID INT NOT NULL,
           name STRING NOT NULL,
@@ -59,10 +59,10 @@ foo
 # Check that node_statement_statistics report per application
 
 statement ok
-SET APPLICATION_NAME = hello; SELECT 1
+SET application_name = hello; SELECT 1
 
 statement ok
-SET APPLICATION_NAME = world; SELECT 2
+SET application_name = world; SELECT 2
 
 query B
 SELECT count > 0 FROM crdb_internal.node_statement_statistics WHERE application_name IN ('hello', 'world')
@@ -73,7 +73,7 @@ true
 # Check that node_statement_statistics report per statement
 
 statement ok
-SET APPLICATION_NAME = hello; SELECT 1; SELECT 1,2; SELECT 1
+SET application_name = hello; SELECT 1; SELECT 1,2; SELECT 1
 
 query B
 SELECT count >= 2 FROM crdb_internal.node_statement_statistics WHERE application_name = 'hello' AND key = 'SELECT 1'
@@ -82,7 +82,7 @@ true
 
 # reset for other tests.
 statement ok
-SET APPLICATION_NAME = ''
+SET application_name = ''
 
 query TT colnames
 SELECT field, value FROM crdb_internal.node_build_info WHERE field ILIKE 'name'


### PR DESCRIPTION
This makes crdb_internal columns easier on the eyes, and has the added
benefit of being  more consistent with pg_catalog, which uses all
lowercase column names as well. (pg_catalog also eschews underscores
between words in column names; we preserve them for readability.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14293)
<!-- Reviewable:end -->
