### PR TITLE
sql: use a correct context during decimal datum checking

### DIFF
--- a/pkg/sql/testdata/logic_test/scale
+++ b/pkg/sql/testdata/logic_test/scale
@@ -101,3 +101,20 @@ query RR
 select x, y FROM td2
 ----
 123 123.1415
+
+
+# Ensure decimal columns greater than 16 precision are supported.
+
+statement ok
+CREATE TABLE td3 (a decimal, b decimal(3, 1), c decimal(20, 10))
+
+statement ok
+INSERT INTO td3 VALUES (123456789012.123456789012, 12.3, 1234567890.1234567890)
+
+query RRR
+select * from td3
+----
+123456789012.123456789012 12.3 1234567890.1234567890
+
+statement error too many digits
+INSERT INTO td3 (c) VALUES (12345678901)


### PR DESCRIPTION
Previously we were using parser.DecimalCtx, which has a Precision of
16, and thus prevented any decimal datum from working successfully
with any larger decimal, even if the table column specified a larger
precision. Instead create a custom context of appropriate size. The
error message has been changed to be similar to postgres.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14304)
<!-- Reviewable:end -->
