### PR TITLE
storage: properly initialize RHS replica post-split

### DIFF
--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -286,6 +286,10 @@ func (r *Replica) IsQuiescent() bool {
 	return r.mu.quiescent
 }
 
+func (r *Replica) IsPushTxnQueueEnabled() bool {
+	return r.pushTxnQueue.isEnabled()
+}
+
 // GetQueueLastProcessed returns the last processed timestamp for the
 // specified queue, or the zero timestamp if not available.
 func (r *Replica) GetQueueLastProcessed(ctx context.Context, queue string) (hlc.Timestamp, error) {

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -377,6 +377,8 @@ func (r *Replica) computeChecksumPostApply(
 	}
 }
 
+// leasePostApply is called when a RequestLease or TransferLease
+// request is executed for a range.
 func (r *Replica) leasePostApply(
 	ctx context.Context,
 	newLease *roachpb.Lease,

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1902,9 +1902,16 @@ func splitPostApply(
 	rightRng.mu.Lock()
 	// Copy the minLeaseProposedTS from the LHS.
 	rightRng.mu.minLeaseProposedTS = r.mu.minLeaseProposedTS
+	rightLease := rightRng.mu.state.Lease
+	rightReplicaID := rightRng.mu.replicaID
 	rightRng.mu.Unlock()
 	r.mu.Unlock()
 	log.Event(ctx, "copied timestamp cache")
+
+	// Invoke the leasePostApply method to ensure we properly initialize
+	// the replica according to whether it holds the lease. This enables
+	// the PushTxnQueue. Note that we pass in an empty lease for prevLease.
+	rightRng.leasePostApply(ctx, rightLease, rightReplicaID, &roachpb.Lease{})
 
 	// Add the RHS replica to the store. This step atomically updates
 	// the EndKey of the LHS replica and also adds the RHS replica


### PR DESCRIPTION
Ensure that the execution pathway used after a new lease is applied to a
range is invoked after splitting a range on the newly created lease for
the RHS of the split.

Fixes #13876
Closes #13875

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14305)
<!-- Reviewable:end -->
