### PR TITLE
storage: Don't process uninitialized replicas in the queue

### DIFF
--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -573,6 +573,12 @@ func (bq *baseQueue) processReplica(
 		log.Infof(ctx, "processing replica")
 	}
 
+	if !repl.IsInitialized() {
+		// We checked this when adding the replica, but we need to check it again
+		// in case this is a different replica with the same range ID (see #14193).
+		return errors.New("cannot process uninitialized replica")
+	}
+
 	if err := repl.IsDestroyed(); err != nil {
 		if log.V(3) {
 			log.Infof(queueCtx, "replica destroyed (%s); skipping", err)


### PR DESCRIPTION
Protects against races with replicas being added to and processed from the queue as described in https://github.com/cockroachdb/cockroach/issues/14193#issuecomment-288242520.

We may still want to do more (e.g. I'm curious if there's anything that really relies on us storing range IDs in the queue rather than replica pointers), but this should prevent the races that causes the crash we've been seeing in #14193.

Fixes #14193
Fixes #12574

@bdarnell

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14306)
<!-- Reviewable:end -->
