### PR TITLE
pgwire: use the standard version string for the crdb_version conn param.

### DIFF
--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -1327,7 +1327,7 @@ func TestSQLNetworkMetrics(t *testing.T) {
 	defer cleanupFn()
 
 	const minbytes = 20
-	const maxbytes = 450
+	const maxbytes = 500
 
 	// Make sure we're starting at 0.
 	if _, _, err := checkSQLNetworkMetrics(s, 0, 0, 0, 0); err != nil {

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -254,10 +254,7 @@ var statusReportParams = map[string]string{
 	// determine that the server is new enough.
 	"server_version": sql.PgServerVersion,
 	// The current CockroachDB version string.
-	"crdb_version": func() string {
-		info := build.GetInfo()
-		return fmt.Sprintf("CockroachDB %s %s", info.Distribution, info.Tag)
-	}(),
+	"crdb_version": build.GetInfo().Short(),
 }
 
 // handleAuthentication should discuss with the client to arrange


### PR DESCRIPTION
Minor simplification to the mechanism introduced in #14145 after a discussion with @dt.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14313)
<!-- Reviewable:end -->
