### PR TITLE
sql: rename LogicTest subtests to just the file name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,8 +74,12 @@ executable will be in your current directory and can be run as shown in the
   make test
   # Run all tests in ./pkg/storage
   make test PKG=./pkg/storage
-  # Run all kv tests matching `^TestFoo` with a timeout of 10s
+  # Run all kv tests matching '^TestFoo' with a timeout of 10s
   make test PKG=./pkg/kv TESTS='^TestFoo' TESTTIMEOUT=10s
+  # Run the sql logic tests
+  make test PKG=./pkg/sql TESTS='TestLogic$$'
+  # Run a specific sql logic subtest
+  make test PKG=./pkg/sql TESTS='TestLogic$$/select$$'
   ```
 
   When you're ready to commit, be sure to write a Good Commit Message™. Consult

--- a/pkg/sql/logic_test.go
+++ b/pkg/sql/logic_test.go
@@ -1305,7 +1305,7 @@ func (t *logicTest) run() {
 	}
 	topLevelTest := t.t
 	for _, path := range paths {
-		topLevelTest.Run(path, func(tst *testing.T) {
+		topLevelTest.Run(filepath.Base(path), func(tst *testing.T) {
 			// Rebind t.t for the duration of this test, since the framework will
 			// pass us a different testing.T than what we started with.
 			t.t = tst


### PR DESCRIPTION
Having the full path in the subtest name, and it makes it more annoying to run
only a specific subtest. Changing to just the filename. The parallel test
already does that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14321)
<!-- Reviewable:end -->
