### PR TITLE
Revert "sql: correctly encode decimals in indexes"

### DIFF
--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -366,12 +366,6 @@ func (rf *RowFetcher) ProcessKV(
 						return "", "", err
 					}
 					d = parser.NewDCollatedString(r, *typ.Locale, &rf.alloc.env)
-				case ColumnType_DECIMAL:
-					dec, err := encoding.DecodeNonsortingDecimal(rvalue, nil)
-					if err != nil {
-						return "", "", err
-					}
-					d = &parser.DDecimal{Decimal: *dec}
 				default:
 					panic(fmt.Sprintf("unknown composite encoding for kind %d", typ.Kind))
 				}

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -523,11 +523,7 @@ func (desc *TableDescriptor) ensurePrimaryKey() error {
 // HasCompositeKeyEncoding returns true if key columns of the given kind have a
 // composite encoding.
 func HasCompositeKeyEncoding(kind ColumnType_Kind) bool {
-	switch kind {
-	case ColumnType_COLLATEDSTRING, ColumnType_DECIMAL:
-		return true
-	}
-	return false
+	return kind == ColumnType_COLLATEDSTRING
 }
 
 func (desc *TableDescriptor) allocateIndexIDs(columnNames map[string]ColumnID) error {

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -1212,8 +1212,6 @@ func EncodeSecondaryIndex(
 		switch d := val.(type) {
 		case *parser.DCollatedString:
 			entryValue = encoding.EncodeStringAscending(entryValue, d.Contents)
-		case *parser.DDecimal:
-			entryValue = encoding.EncodeNonsortingDecimal(entryValue, &d.Decimal)
 		default:
 			panic(fmt.Sprintf("unknown composite encoding for datum %s", d))
 		}

--- a/pkg/sql/testdata/logic_test/decimal
+++ b/pkg/sql/testdata/logic_test/decimal
@@ -81,9 +81,10 @@ CREATE TABLE t2 (d decimal, v decimal(3, 1), primary key (d, v))
 statement ok
 INSERT INTO t2 VALUES (1.00::decimal, 1.00::decimal), (2.0::decimal, 2.0::decimal), (3::decimal, 3::decimal)
 
-query RR
-SELECT * FROM t2 ORDER BY d
-----
-1.00 1.0
-2.0  2.0
-3    3.0
+# TODO(mjibson): enable once #13609 is merged with support for different values in index.
+#query RR
+#SELECT * FROM t2 ORDER BY d
+#----
+#1.00 1.0
+#2.0  2.0
+#3    3.0


### PR DESCRIPTION
This reverts commit e23ff991bd0945dce0a7a6a912f3f27ea2ec6d57.

This is being done to avoid a future backward incompatible change
between beta releases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14328)
<!-- Reviewable:end -->
