### PR TITLE
cli/interactive_tests: fix test_missing_local_logs.tcl

### DIFF
--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -22,7 +22,10 @@ set stty_init "cols 80 rows 25"
 proc eexpect {text} {
     expect {
 	$text {}
-	timeout {exit 1}
+	timeout {
+	    system "echo SERVER STDOUT; cat stdout.log; echo SERVER STDERR; cat stderr.log"
+	    exit 1
+	}
     }
 }
 
@@ -36,7 +39,7 @@ proc interrupt {} {
 # Preserves the invariant that the server's PID is saved
 # in `server_pid`.
 proc start_server {argv} {
-    system "mkfifo pid_fifo || true; $argv start --pid-file=pid_fifo --background & cat pid_fifo > server_pid"
+    system "mkfifo pid_fifo || true; $argv start --pid-file=pid_fifo --background >>stdout.log 2>>stderr.log & cat pid_fifo > server_pid"
 }
 proc stop_server {argv} {
     system "set -e; if kill -CONT `cat server_pid`; then $argv quit || true & sleep 1; kill -9 `cat server_pid` || true; else $argv quit || true; fi"

--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -60,10 +60,11 @@ start_server $argv
 
 # Now test `quit` as non-start command, and test that `quit` does not
 # emit logging output between the point the command starts until it
-# prints the final ok message.
-send "echo marker; $argv quit\r"
+# either prints the final ok message or fails with some error
+# (e.g. due to no definite answer from the server).
+send "echo marker; $argv quit 2>&1 | grep '^\\(\[IWEF\]\[0-9\]\\)' \r"
 set timeout 20
-eexpect "marker\r\nok\r\n:/# "
+eexpect "marker\r\n:/# "
 set timeout 5
 
 # Test quit as non-start command, this time with --logtostderr. Test


### PR DESCRIPTION
Prior to this patch, the test would assume that running `cockroach
quit` against a running node would necessarily result in the message
`ok` printed without any error. This assumption is incorrect however,
because the `quit` command has a 2-way handshake with some measure of
undeterminism: there is a race condition between the server shutting
down and `quit` receiving a definite acknowledgement, and it is
possible for `quit` to succeed and yet still receive a TCP
connection/reset error.

This patch fixes the test by removing the assumption. Since the
particular test was that `quit` should not emit *log* messages, a
`grep` filter is added that only captures log messages, and that
output is compared against a reference. TCP connection/reset errors,
if any, become invisible, without altering the value of the test.

Fixes #14286.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14339)
<!-- Reviewable:end -->
