### PR TITLE
storage: augment command queue with timestamps for non-interfering reads

### DIFF
--- a/pkg/storage/command_queue.go
+++ b/pkg/storage/command_queue.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
@@ -33,7 +34,7 @@ import (
 // executing commands. New commands affecting keys or key ranges must
 // wait on already-executing commands which overlap their key range.
 //
-// Before executing, a command invokes GetWait() to acquire a slice of
+// Before executing, a command invokes getWait() to acquire a slice of
 // channels belonging to overlapping commands which are already
 // running. Each channel is waited on by the caller for confirmation
 // that all overlapping, pending commands have completed and the
@@ -42,7 +43,7 @@ import (
 // After waiting, a command is added to the queue's already-executing
 // set via add(). add accepts a parameter indicating whether the
 // command is read-only. Read-only commands don't need to wait on other
-// read-only commands, so the channels returned via GetWait() don't
+// read-only commands, so the channels returned via getWait() don't
 // include read-only on read-only overlapping commands as an
 // optimization.
 //
@@ -55,8 +56,8 @@ type CommandQueue struct {
 	reads     interval.Tree
 	writes    interval.Tree
 	idAlloc   int64
-	wRg, rwRg interval.RangeGroup // avoids allocating in GetWait
-	oHeap     overlapHeap         // avoids allocating in GetWait
+	wRg, rwRg interval.RangeGroup // avoids allocating in getWait
+	oHeap     overlapHeap         // avoids allocating in getWait
 	overlaps  []*cmd              // avoids allocating in getOverlaps
 
 	coveringOptimization bool // if true, use covering span optimization
@@ -71,12 +72,13 @@ type CommandQueue struct {
 }
 
 type cmd struct {
-	id       int64
-	key      interval.Range
-	readOnly bool
-	expanded bool          // have the children been added
-	pending  chan struct{} // closed when complete
-	children []cmd
+	id        int64
+	key       interval.Range
+	readOnly  bool
+	timestamp hlc.Timestamp
+	expanded  bool          // have the children been added
+	pending   chan struct{} // closed when complete
+	children  []cmd
 }
 
 // ID implements interval.Interface.
@@ -195,13 +197,19 @@ func (cq *CommandQueue) expand(c *cmd, isInserted bool) bool {
 	return true
 }
 
-// GetWait returns a slice of the pending channels of executing commands which
-// overlap the specified key ranges. If an end key is empty, it only affects
-// the start key. The caller should call wg.Wait() to wait for confirmation
-// that all gating commands have completed or failed, and then call add() to
-// add the keys to the command queue. readOnly is true if the requester is a
-// read-only command; false for read-write.
-func (cq *CommandQueue) getWait(readOnly bool, spans []roachpb.Span) (chans []<-chan struct{}) {
+// getWait returns a slice of the pending channels of executing
+// commands which overlap the specified key ranges. The caller should
+// call wg.Wait() to fetch the required wait channels. The caller
+// should then invoke add() to add the keys to the command queue and
+// then wait for confirmation that all gating commands have completed
+// or failed. readOnly is true if the requester is a read-only
+// command; false for read-write. The provided timestamp, if non-zero,
+// is used to allow reads to proceed if they are at earlier timestamps
+// than pending writes, and writes to proceed if they are at later
+// timestamps than pending reads.
+func (cq *CommandQueue) getWait(
+	readOnly bool, timestamp hlc.Timestamp, spans []roachpb.Span,
+) (chans []<-chan struct{}) {
 	prepareSpans(spans)
 
 	for i := 0; i < len(spans); i++ {
@@ -214,7 +222,7 @@ func (cq *CommandQueue) getWait(readOnly bool, spans []roachpb.Span) (chans []<-
 			Start: interval.Comparable(start),
 			End:   interval.Comparable(end),
 		}
-		overlaps := cq.getOverlaps(readOnly, newCmdRange.Start, newCmdRange.End)
+		overlaps := cq.getOverlaps(readOnly, timestamp, newCmdRange.Start, newCmdRange.End)
 
 		// Check to see if any of the overlapping entries are "covering"
 		// entries. If we encounter a covering entry, we remove it from the
@@ -260,7 +268,7 @@ func (cq *CommandQueue) getWait(readOnly bool, spans []roachpb.Span) (chans []<-
 		// Instead of having each command establish explicit dependencies on all previous
 		// overlapping commands, each command only needs to establish explicit dependencies
 		// on the set of overlapping commands closest to the new command that together span
-		// the new commands overlapped range. Following this strategy, the other dependencies
+		// the new command's overlapped range. Following this strategy, the other dependencies
 		// will be implicitly enforced, which reduces memory utilization and synchronization
 		// costs.
 		//
@@ -269,7 +277,7 @@ func (cq *CommandQueue) getWait(readOnly bool, spans []roachpb.Span) (chans []<-
 		// "later" read won't wait for the earlier read to complete). However, if that read is
 		// covered by a "later" write, we don't need to wait because writes can't be reordered.
 		//
-		// Two example of how this logic works are shown below. Notice in the first example how
+		// Two examples of how this logic works are shown below. Notice in the first example how
 		// the overlapping reads do not establish dependencies on each other, and can therefore
 		// be reordered. Also notice in the second example that once read command 4 overlaps
 		// a "later" write, it no longer needs to be a dependency for the new write command 5.
@@ -288,24 +296,64 @@ func (cq *CommandQueue) getWait(readOnly bool, spans []roachpb.Span) (chans []<-
 		//                |      |    |            |           |
 		// cmd 5 [W]:   ====================     ====================
 		//
+		// Things get more interesting with timestamps:
+		// -------------------------------------------
+		// - For a read-only command, overlaps will include only writes which have occurred
+		//   with earlier timestamps. Because writes all must depend on each other, things
+		//   work as expected.
+		//
+		// - Write commands overlap both reads and writes. The writes that a write command
+		//   overlaps will depend reliably on each other if they in turn overlap. However, reads
+		//   that a write command overlaps may not in turn be depended on by overlapping writes,
+		//   if the reads have earlier timestamps. This means that writes don't necessarily
+		//   subsume overlapping reads.
+		//
+		//   We solve this problem by always including read commands with timestamps less than
+		//   the latest write timestamp seen so far, which guarantees that we will wait on any
+		//   reads which might not be dependend on by writes with higher IDs. Similarly, we
+		//   include write commands with timestamps greater than or equal to the earliest
+		//   read timestamp seen so far.
+		//
+		// TODO(spencer): this mechanism is a blunt instrument and will lead to reads rarely
+		//   being consolidated because of range group overlaps.
+		maxWriteTS, minReadTS := hlc.Timestamp{}, hlc.MaxTimestamp
 		cq.oHeap.Init(overlaps)
 		for enclosed := false; cq.oHeap.Len() > 0 && !enclosed; {
 			cmd := cq.oHeap.PopOverlap()
 			keyRange := cmd.key
+			cmdHasTimestamp := cmd.timestamp != hlc.Timestamp{}
+			mustWait := false
+
 			if cmd.readOnly {
+				if cmdHasTimestamp {
+					if cmd.timestamp.Less(minReadTS) {
+						minReadTS = cmd.timestamp
+					}
+					if cmd.timestamp.Less(maxWriteTS) {
+						mustWait = true
+					}
+				}
 				// If the current overlap is a read (meaning we're a write because other reads will
 				// be filtered out if we're a read as well), we only need to wait if the write RangeGroup
 				// doesn't already overlap the read. Otherwise, we know that this current read is a dependent
-				// itself to a command already accounted for in out write RangeGroup. Either way, we need to add
+				// itself to a command already accounted for in our write RangeGroup. Either way, we need to add
 				// this current command to the combined RangeGroup.
 				cq.rwRg.Add(keyRange)
-				if !cq.wRg.Overlaps(keyRange) {
+				if mustWait || !cq.wRg.Overlaps(keyRange) {
 					if cmd.pending == nil {
 						cmd.pending = make(chan struct{})
 					}
 					chans = append(chans, cmd.pending)
 				}
 			} else {
+				if cmdHasTimestamp {
+					if maxWriteTS.Less(cmd.timestamp) {
+						maxWriteTS = cmd.timestamp
+					}
+					if minReadTS.Less(cmd.timestamp) {
+						mustWait = true
+					}
+				}
 				// If the current overlap is a write, pick which RangeGroup will be used to determine necessary
 				// dependencies based on if we are a read or write.
 				overlapRg := cq.wRg
@@ -323,7 +371,7 @@ func (cq *CommandQueue) getWait(readOnly bool, spans []roachpb.Span) (chans []<-
 				// any other reads or writes in its future. If it is overlapping, we know there was already a
 				// dependency established with a dependent of the current overlap, meaning we already established
 				// an implicit transitive dependency to the current overlap.
-				if !overlapRg.Overlaps(keyRange) {
+				if mustWait || !overlapRg.Overlaps(keyRange) {
 					if cmd.pending == nil {
 						cmd.pending = make(chan struct{})
 					}
@@ -367,24 +415,40 @@ func (cq *CommandQueue) getWait(readOnly bool, spans []roachpb.Span) (chans []<-
 
 // getOverlaps returns a slice of values which overlap the specified
 // interval. The slice is only valid until the next call to GetOverlaps.
-func (cq *CommandQueue) getOverlaps(readOnly bool, start, end []byte) []*cmd {
+func (cq *CommandQueue) getOverlaps(
+	readOnly bool, timestamp hlc.Timestamp, start, end []byte,
+) []*cmd {
 	rng := interval.Range{
 		Start: interval.Comparable(start),
 		End:   interval.Comparable(end),
 	}
 	if !readOnly {
-		cq.reads.DoMatching(cq.doOverlaps, rng)
+		cq.reads.DoMatching(func(i interval.Interface) bool {
+			c := i.(*cmd)
+			// Writes only wait on equal or later reads (we always wait
+			// if the pending read didn't have a timestamp specified).
+			if (c.timestamp == hlc.Timestamp{}) || !c.timestamp.Less(timestamp) {
+				cq.overlaps = append(cq.overlaps, c)
+			}
+			return false
+		}, rng)
 	}
-	cq.writes.DoMatching(cq.doOverlaps, rng)
+	// Both reads and writes must wait on other writes, depending on timestamps.
+	cq.writes.DoMatching(func(i interval.Interface) bool {
+		c := i.(*cmd)
+		// Writes always wait on other writes. Reads must wait on writes
+		// which occur at the same or an earlier timestamp. Note that
+		// timestamps for write commands may be pushed forward by the
+		// timestamp cache. This is fine because it doesn't matter how far
+		// forward the timestamp is pushed if it's already ahead of this read.
+		if !readOnly || (timestamp == hlc.Timestamp{}) || !timestamp.Less(c.timestamp) {
+			cq.overlaps = append(cq.overlaps, c)
+		}
+		return false
+	}, rng)
 	overlaps := cq.overlaps
 	cq.overlaps = cq.overlaps[:0]
 	return overlaps
-}
-
-func (cq *CommandQueue) doOverlaps(i interval.Interface) bool {
-	c := i.(*cmd)
-	cq.overlaps = append(cq.overlaps, c)
-	return false
 }
 
 // overlapHeap is a max-heap of cache.Overlaps, sorting the elements
@@ -434,7 +498,7 @@ func (o *overlapHeap) PopOverlap() *cmd {
 //
 // add should be invoked after waiting on already-executing, overlapping
 // commands via the WaitGroup initialized through getWait().
-func (cq *CommandQueue) add(readOnly bool, spans []roachpb.Span) *cmd {
+func (cq *CommandQueue) add(readOnly bool, timestamp hlc.Timestamp, spans []roachpb.Span) *cmd {
 	if len(spans) == 0 {
 		return nil
 	}
@@ -474,6 +538,7 @@ func (cq *CommandQueue) add(readOnly bool, spans []roachpb.Span) *cmd {
 		End:   interval.Comparable(maxKey),
 	}
 	cmd.readOnly = readOnly
+	cmd.timestamp = timestamp
 	cmd.expanded = false
 
 	if len(spans) > 1 {
@@ -487,6 +552,7 @@ func (cq *CommandQueue) add(readOnly bool, spans []roachpb.Span) *cmd {
 				End:   interval.Comparable(span.EndKey),
 			}
 			child.readOnly = readOnly
+			child.timestamp = timestamp
 			child.expanded = true
 		}
 	}

--- a/pkg/storage/command_queue_test.go
+++ b/pkg/storage/command_queue_test.go
@@ -18,23 +18,29 @@ package storage
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
-func getWait(cq *CommandQueue, from, to roachpb.Key, readOnly bool) []<-chan struct{} {
-	return cq.getWait(readOnly, []roachpb.Span{{Key: from, EndKey: to}})
+func getWait(
+	cq *CommandQueue, from, to roachpb.Key, readOnly bool, ts hlc.Timestamp,
+) []<-chan struct{} {
+	return cq.getWait(readOnly, ts, []roachpb.Span{{Key: from, EndKey: to}})
 }
 
-func add(cq *CommandQueue, from, to roachpb.Key, readOnly bool) *cmd {
-	return cq.add(readOnly, []roachpb.Span{{Key: from, EndKey: to}})
+func add(cq *CommandQueue, from, to roachpb.Key, readOnly bool, ts hlc.Timestamp) *cmd {
+	return cq.add(readOnly, ts, []roachpb.Span{{Key: from, EndKey: to}})
 }
 
-func getWaitAndAdd(cq *CommandQueue, from, to roachpb.Key, readOnly bool) ([]<-chan struct{}, *cmd) {
-	return getWait(cq, from, to, readOnly), add(cq, from, to, readOnly)
+func getWaitAndAdd(
+	cq *CommandQueue, from, to roachpb.Key, readOnly bool, ts hlc.Timestamp,
+) ([]<-chan struct{}, *cmd) {
+	return getWait(cq, from, to, readOnly, ts), add(cq, from, to, readOnly, ts)
 }
 
 func waitCmdDone(chans []<-chan struct{}) {
@@ -42,6 +48,8 @@ func waitCmdDone(chans []<-chan struct{}) {
 		<-ch
 	}
 }
+
+var zeroTS = hlc.Timestamp{}
 
 // testCmdDone waits for the cmdDone channel to be closed for at most
 // the specified wait duration. Returns true if the command finished in
@@ -75,12 +83,12 @@ func TestCommandQueue(t *testing.T) {
 	cq := NewCommandQueue(true)
 
 	// Try a command with no overlapping already-running commands.
-	waitCmdDone(getWait(cq, roachpb.Key("a"), nil, false))
-	waitCmdDone(getWait(cq, roachpb.Key("a"), roachpb.Key("b"), false))
+	waitCmdDone(getWait(cq, roachpb.Key("a"), nil, false, zeroTS))
+	waitCmdDone(getWait(cq, roachpb.Key("a"), roachpb.Key("b"), false, zeroTS))
 
 	// Add a command and verify dependency on it.
-	wk := add(cq, roachpb.Key("a"), nil, false)
-	chans := getWait(cq, roachpb.Key("a"), nil, false)
+	wk := add(cq, roachpb.Key("a"), nil, false, zeroTS)
+	chans := getWait(cq, roachpb.Key("a"), nil, false, zeroTS)
 	if !checkCmdDoesNotFinish(t, chans) {
 		t.Fatal("command should not finish with command outstanding")
 	}
@@ -99,13 +107,13 @@ func TestCommandQueueWriteWaitForNonAdjacentRead(t *testing.T) {
 	cq := NewCommandQueue(true)
 	key := roachpb.Key("a")
 	// Add a read-only command.
-	wk1 := add(cq, key, nil, true)
+	wk1 := add(cq, key, nil, true, zeroTS)
 	// Add another one on top.
-	wk2 := add(cq, key, nil, true)
+	wk2 := add(cq, key, nil, true, zeroTS)
 
 	// A write should have to wait for **both** reads, not only the second
 	// one.
-	chans := getWait(cq, key, nil, false /* !readOnly */)
+	chans := getWait(cq, key, nil, false /* !readOnly */, zeroTS)
 
 	// Certainly blocks now.
 	if !checkCmdDoesNotFinish(t, chans) {
@@ -133,11 +141,11 @@ func TestCommandQueueNoWaitOnReadOnly(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	cq := NewCommandQueue(true)
 	// Add a read-only command.
-	chans1, wk := getWaitAndAdd(cq, roachpb.Key("a"), nil, true)
+	chans1, wk := getWaitAndAdd(cq, roachpb.Key("a"), nil, true, zeroTS)
 	// Verify no wait on another read-only command.
 	waitCmdDone(chans1)
 	// Verify wait with a read-write command.
-	chans2 := getWait(cq, roachpb.Key("a"), nil, false)
+	chans2 := getWait(cq, roachpb.Key("a"), nil, false, zeroTS)
 	if !checkCmdDoesNotFinish(t, chans2) {
 		t.Fatal("command should not finish with command outstanding")
 	}
@@ -152,10 +160,10 @@ func TestCommandQueueMultipleExecutingCommands(t *testing.T) {
 	cq := NewCommandQueue(true)
 
 	// Add multiple commands and add a command which overlaps them all.
-	wk1 := add(cq, roachpb.Key("a"), nil, false)
-	wk2 := add(cq, roachpb.Key("b"), roachpb.Key("c"), false)
-	wk3 := add(cq, roachpb.Key("0"), roachpb.Key("d"), false)
-	chans := getWait(cq, roachpb.Key("a"), roachpb.Key("cc"), false)
+	wk1 := add(cq, roachpb.Key("a"), nil, false, zeroTS)
+	wk2 := add(cq, roachpb.Key("b"), roachpb.Key("c"), false, zeroTS)
+	wk3 := add(cq, roachpb.Key("0"), roachpb.Key("d"), false, zeroTS)
+	chans := getWait(cq, roachpb.Key("a"), roachpb.Key("cc"), false, zeroTS)
 	cq.remove(wk1)
 	if !checkCmdDoesNotFinish(t, chans) {
 		t.Fatal("command should not finish with two commands outstanding")
@@ -175,10 +183,10 @@ func TestCommandQueueMultiplePendingCommands(t *testing.T) {
 	cq := NewCommandQueue(true)
 
 	// Add a command which will overlap all commands.
-	wk0 := add(cq, roachpb.Key("a"), roachpb.Key("d"), false)
-	chans1, wk1 := getWaitAndAdd(cq, roachpb.Key("a"), roachpb.Key("b").Next(), false)
-	chans2 := getWait(cq, roachpb.Key("b"), nil, false)
-	chans3 := getWait(cq, roachpb.Key("c"), nil, false)
+	wk0 := add(cq, roachpb.Key("a"), roachpb.Key("d"), false, zeroTS)
+	chans1, wk1 := getWaitAndAdd(cq, roachpb.Key("a"), roachpb.Key("b").Next(), false, zeroTS)
+	chans2 := getWait(cq, roachpb.Key("b"), nil, false, zeroTS)
+	chans3 := getWait(cq, roachpb.Key("c"), nil, false, zeroTS)
 
 	for i, chans := range [][]<-chan struct{}{chans1, chans2, chans3} {
 		if !checkCmdDoesNotFinish(t, chans) {
@@ -207,10 +215,10 @@ func TestCommandQueueRemove(t *testing.T) {
 	cq := NewCommandQueue(true)
 
 	// Add multiple commands and commands which access each.
-	wk1 := add(cq, roachpb.Key("a"), nil, false)
-	wk2 := add(cq, roachpb.Key("b"), nil, false)
-	chans1 := getWait(cq, roachpb.Key("a"), nil, false)
-	chans2 := getWait(cq, roachpb.Key("b"), nil, false)
+	wk1 := add(cq, roachpb.Key("a"), nil, false, zeroTS)
+	wk2 := add(cq, roachpb.Key("b"), nil, false, zeroTS)
+	chans1 := getWait(cq, roachpb.Key("a"), nil, false, zeroTS)
+	chans2 := getWait(cq, roachpb.Key("b"), nil, false, zeroTS)
 
 	// Remove the commands from the queue and verify both commands are signaled.
 	cq.remove(wk1)
@@ -230,11 +238,11 @@ func TestCommandQueueRemove(t *testing.T) {
 func TestCommandQueueExclusiveEnd(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	cq := NewCommandQueue(true)
-	add(cq, roachpb.Key("a"), roachpb.Key("b"), false)
+	add(cq, roachpb.Key("a"), roachpb.Key("b"), false, zeroTS)
 
 	// Verify no wait on the second writer command on "b" since
 	// it does not overlap with the first command on ["a", "b").
-	waitCmdDone(getWait(cq, roachpb.Key("b"), nil, false))
+	waitCmdDone(getWait(cq, roachpb.Key("b"), nil, false, zeroTS))
 }
 
 // TestCommandQueueSelfOverlap makes sure that GetWait adds all of the
@@ -245,8 +253,8 @@ func TestCommandQueueSelfOverlap(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	cq := NewCommandQueue(true)
 	a := roachpb.Key("a")
-	k := add(cq, a, roachpb.Key("b"), false)
-	chans := cq.getWait(false, []roachpb.Span{{Key: a}, {Key: a}, {Key: a}})
+	k := add(cq, a, roachpb.Key("b"), false, zeroTS)
+	chans := cq.getWait(false, zeroTS, []roachpb.Span{{Key: a}, {Key: a}, {Key: a}})
 	cq.remove(k)
 	waitCmdDone(chans)
 }
@@ -261,18 +269,18 @@ func TestCommandQueueCoveringOptimization(t *testing.T) {
 
 	{
 		// Test adding a covering entry and then not expanding it.
-		wk := cq.add(false, []roachpb.Span{a, b})
+		wk := cq.add(false, zeroTS, []roachpb.Span{a, b})
 		if n := cq.treeSize(); n != 1 {
 			t.Fatalf("expected a single covering span, but got %d", n)
 		}
-		waitCmdDone(cq.getWait(false, []roachpb.Span{c}))
+		waitCmdDone(cq.getWait(false, zeroTS, []roachpb.Span{c}))
 		cq.remove(wk)
 	}
 
 	{
 		// Test adding a covering entry and expanding it.
-		wk := cq.add(false, []roachpb.Span{a, b})
-		chans := cq.getWait(false, []roachpb.Span{a})
+		wk := cq.add(false, zeroTS, []roachpb.Span{a, b})
+		chans := cq.getWait(false, zeroTS, []roachpb.Span{a})
 		cq.remove(wk)
 		waitCmdDone(chans)
 	}
@@ -287,7 +295,7 @@ func TestCommandQueueWithoutCoveringOptimization(t *testing.T) {
 	c := roachpb.Span{Key: roachpb.Key("c")}
 
 	{
-		cmd := cq.add(false, []roachpb.Span{a, b})
+		cmd := cq.add(false, zeroTS, []roachpb.Span{a, b})
 		if !cmd.expanded {
 			t.Errorf("expected non-expanded command, not %+v", cmd)
 		}
@@ -301,7 +309,7 @@ func TestCommandQueueWithoutCoveringOptimization(t *testing.T) {
 	}
 
 	{
-		cmd := cq.add(false, []roachpb.Span{c})
+		cmd := cq.add(false, zeroTS, []roachpb.Span{c})
 		if cmd.expanded {
 			t.Errorf("expected unexpanded command, not %+v", cmd)
 		}
@@ -315,6 +323,13 @@ func TestCommandQueueWithoutCoveringOptimization(t *testing.T) {
 	}
 }
 
+func mkSpan(start, end string) roachpb.Span {
+	if len(end) == 0 {
+		return roachpb.Span{Key: roachpb.Key(start)}
+	}
+	return roachpb.Span{Key: roachpb.Key(start), EndKey: roachpb.Key(end)}
+}
+
 // Reconstruct a set of commands that tickled a bug in interval.Tree. See
 // https://github.com/cockroachdb/cockroach/issues/6495 for details.
 func TestCommandQueueIssue6495(t *testing.T) {
@@ -322,9 +337,6 @@ func TestCommandQueueIssue6495(t *testing.T) {
 	cq := NewCommandQueue(true)
 	cq.idAlloc = 1997
 
-	mkSpan := func(start, end string) roachpb.Span {
-		return roachpb.Span{Key: roachpb.Key(start), EndKey: roachpb.Key(end)}
-	}
 	spans1998 := []roachpb.Span{
 		mkSpan("\xbb\x89\x8b\x8a\x89", "\xbb\x89\x8b\x8a\x89\x00"),
 	}
@@ -341,20 +353,173 @@ func TestCommandQueueIssue6495(t *testing.T) {
 		mkSpan("\xbb\x89\x8a\x8a\x89", "\xbb\x89\x8a\x8a\x89\x00"),
 	}
 
-	cq.getWait(false, spans1998)
-	cmd1998 := cq.add(false, spans1998)
+	cq.getWait(false, zeroTS, spans1998)
+	cmd1998 := cq.add(false, zeroTS, spans1998)
 
-	cq.getWait(true, spans1999)
-	cmd1999 := cq.add(true, spans1999)
+	cq.getWait(true, zeroTS, spans1999)
+	cmd1999 := cq.add(true, zeroTS, spans1999)
 
-	cq.getWait(true, spans2002)
-	cq.add(true, spans2002)
+	cq.getWait(true, zeroTS, spans2002)
+	cq.add(true, zeroTS, spans2002)
 
-	cq.getWait(false, spans2003)
-	cq.add(false, spans2003)
+	cq.getWait(false, zeroTS, spans2003)
+	cq.add(false, zeroTS, spans2003)
 
 	cq.remove(cmd1998)
 	cq.remove(cmd1999)
+}
+
+// TestCommandQueueTimestamps creates a command queue with a mix of
+// read and write spans and verifies that writes don't wait on
+// earlier reads and reads don't wait on later writes. The spans
+// are layered as follows (earlier spans have earlier timestamps):
+//
+// Span  TS  RO  a  b  c  d  e  f  g
+//    1   1   T  ------   -
+//    2   2   F     -
+//    3   3   F        -  ------
+//    4   4   T              ------
+func TestCommandQueueTimestamps(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	cq := NewCommandQueue(true)
+
+	spans1 := []roachpb.Span{
+		mkSpan("a", "c"),
+		mkSpan("d", ""),
+	}
+	spans2 := []roachpb.Span{
+		mkSpan("b", ""),
+	}
+	spans3 := []roachpb.Span{
+		mkSpan("c", ""),
+		mkSpan("d", "f"),
+	}
+	spans4 := []roachpb.Span{
+		mkSpan("e", "g"),
+	}
+
+	cmd1 := cq.add(true, makeTS(1, 0), spans1)
+
+	if w := cq.getWait(true, makeTS(2, 0), spans2); w != nil {
+		t.Errorf("expected nil wait slice; got %+v", w)
+	}
+	cmd2 := cq.add(false, makeTS(2, 0), spans2)
+
+	if w := cq.getWait(true, makeTS(3, 0), spans3); w != nil {
+		t.Errorf("expected nil wait slice; got %+v", w)
+	}
+	cmd3 := cq.add(false, makeTS(3, 0), spans3)
+
+	// spans4 should wait on spans3.children[1].pending.
+	w := cq.getWait(true, makeTS(4, 0), spans4)
+	expW := []<-chan struct{}{cmd3.children[1].pending}
+	if !reflect.DeepEqual(w, expW) {
+		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	}
+	cmd4 := cq.add(true, makeTS(4, 0), spans4)
+
+	// Verify that an earlier writer for whole span waits on all commands.
+	w = cq.getWait(false, makeTS(0, 1), []roachpb.Span{mkSpan("a", "g")})
+	allW := []<-chan struct{}{
+		cmd4.pending,
+		// Skip cmd3.children[1].pending here because it's a dependency.
+		cmd3.children[0].pending,
+		cmd2.pending,
+		cmd1.children[1].pending,
+		cmd1.children[0].pending,
+	}
+	expW = allW
+	if !reflect.DeepEqual(expW, w) {
+		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	}
+
+	// Verify that a later writer for whole span. At the same
+	// timestamp, we wait on the latest read.
+	expW = []<-chan struct{}{cmd4.pending, cmd3.children[0].pending, cmd2.pending}
+	if w := cq.getWait(false, makeTS(4, 0), []roachpb.Span{mkSpan("a", "g")}); !reflect.DeepEqual(expW, w) {
+		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	}
+	// At +1 logical tick, we skip the latest read and instead
+	// read the overlapped write just beneath the latest read.
+	expW = []<-chan struct{}{cmd3.children[1].pending, cmd3.children[0].pending, cmd2.pending}
+	if w := cq.getWait(false, makeTS(4, 1), []roachpb.Span{mkSpan("a", "g")}); !reflect.DeepEqual(expW, w) {
+		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	}
+
+	// Verify an earlier reader for whole span doesn't wait.
+	if w := cq.getWait(true, makeTS(0, 1), []roachpb.Span{mkSpan("a", "g")}); w != nil {
+		t.Errorf("expected nil wait slice; got %+v", w)
+	}
+
+	// Verify a later reader for whole span waits on both writers.
+	expW = []<-chan struct{}{cmd3.children[1].pending, cmd3.children[0].pending, cmd2.pending}
+	if w := cq.getWait(true, makeTS(4, 0), []roachpb.Span{mkSpan("a", "g")}); !reflect.DeepEqual(expW, w) {
+		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	}
+
+	// Verify that if no timestamp is specified, we always wait (on writers and readers!).
+	expW = allW
+	if w := cq.getWait(false, hlc.Timestamp{}, []roachpb.Span{mkSpan("a", "g")}); !reflect.DeepEqual(expW, w) {
+		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	}
+	expW = []<-chan struct{}{cmd3.children[1].pending, cmd3.children[0].pending, cmd2.pending}
+	if w := cq.getWait(true, hlc.Timestamp{}, []roachpb.Span{mkSpan("a", "g")}); !reflect.DeepEqual(expW, w) {
+		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	}
+}
+
+// TestCommandQueueTimestampsEmpty verifies command queue wait
+// behavior when added commands have zero timestamps and when
+// the waiter has a zero timestamp.
+func TestCommandQueueTimestampsEmpty(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	cq := NewCommandQueue(true)
+
+	spansR := []roachpb.Span{
+		mkSpan("a", "c"),
+	}
+	spansW := []roachpb.Span{
+		mkSpan("d", "f"),
+	}
+	spansRTS := []roachpb.Span{
+		mkSpan("g", ""),
+	}
+	spansWTS := []roachpb.Span{
+		mkSpan("h", ""),
+	}
+
+	cmd1 := cq.add(true, hlc.Timestamp{}, spansR)
+	cmd2 := cq.add(false, hlc.Timestamp{}, spansW)
+	cmd3 := cq.add(true, makeTS(1, 0), spansRTS)
+	cmd4 := cq.add(false, makeTS(1, 0), spansWTS)
+
+	// A writer will depend on both zero-timestamp spans.
+	w := cq.getWait(false, makeTS(1, 0), []roachpb.Span{mkSpan("a", "f")})
+	expW := []<-chan struct{}{cmd2.pending, cmd1.pending}
+	if !reflect.DeepEqual(w, expW) {
+		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	}
+
+	// A reader will depend on the write span.
+	w = cq.getWait(true, makeTS(1, 0), []roachpb.Span{mkSpan("a", "f")})
+	expW = []<-chan struct{}{cmd2.pending}
+	if !reflect.DeepEqual(w, expW) {
+		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	}
+
+	// A zero-timestamp writer will depend on both ts=1 spans.
+	w = cq.getWait(false, hlc.Timestamp{}, []roachpb.Span{mkSpan("g", "i")})
+	expW = []<-chan struct{}{cmd4.pending, cmd3.pending}
+	if !reflect.DeepEqual(w, expW) {
+		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	}
+
+	// A zero-timestamp reader will depend on the write span.
+	w = cq.getWait(true, hlc.Timestamp{}, []roachpb.Span{mkSpan("g", "i")})
+	expW = []<-chan struct{}{cmd4.pending}
+	if !reflect.DeepEqual(w, expW) {
+		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	}
 }
 
 func BenchmarkCommandQueueGetWait(b *testing.B) {
@@ -370,12 +535,12 @@ func BenchmarkCommandQueueGetWait(b *testing.B) {
 				EndKey: roachpb.Key("aaaaaaaaab"),
 			}}
 			for i := 0; i < size; i++ {
-				cq.add(true, spans)
+				cq.add(true, zeroTS, spans)
 			}
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_ = cq.getWait(true, spans)
+				_ = cq.getWait(true, zeroTS, spans)
 			}
 		})
 	}

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1685,19 +1685,31 @@ func (r *Replica) beginCmds(
 		default:
 		}
 
+		// Get the requested timestamp. This is used for non-interference
+		// of earlier reads with later writes, but only for the global
+		// command queue. Reads and writes to local keys are specified as
+		// having a zero timestamp which will cause them to always
+		// interfere. This is done to avoid confusion with local keys
+		// declared as part of proposer evaluated KV.
+		reqGlobalTS := ba.Timestamp
+		if txn := ba.Txn; txn != nil {
+			reqGlobalTS = txn.OrigTimestamp
+		}
+		var reqLocalTS hlc.Timestamp
+
 		r.cmdQMu.Lock()
 		var chans []<-chan struct{}
 		// Collect all the channels to wait on before adding this batch to the
 		// command queue.
 		for i := SpanAccess(0); i < numSpanAccess; i++ {
 			readOnly := i == SpanReadOnly
-			chans = append(chans, r.cmdQMu.global.getWait(readOnly, spans.getSpans(i, spanGlobal))...)
-			chans = append(chans, r.cmdQMu.local.getWait(readOnly, spans.getSpans(i, spanLocal))...)
+			chans = append(chans, r.cmdQMu.global.getWait(readOnly, reqGlobalTS, spans.getSpans(i, spanGlobal))...)
+			chans = append(chans, r.cmdQMu.local.getWait(readOnly, reqLocalTS, spans.getSpans(i, spanLocal))...)
 		}
 		for i := SpanAccess(0); i < numSpanAccess; i++ {
 			readOnly := i == SpanReadOnly
-			cmds[i].global = r.cmdQMu.global.add(readOnly, spans.getSpans(i, spanGlobal))
-			cmds[i].local = r.cmdQMu.local.add(readOnly, spans.getSpans(i, spanLocal))
+			cmds[i].global = r.cmdQMu.global.add(readOnly, reqGlobalTS, spans.getSpans(i, spanGlobal))
+			cmds[i].local = r.cmdQMu.local.add(readOnly, reqLocalTS, spans.getSpans(i, spanLocal))
 		}
 		r.cmdQMu.Unlock()
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -1897,15 +1897,17 @@ func TestReplicaCommandQueue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// Test all four combinations of reads & writes waiting.
 	testCases := []struct {
-		cmd1Read, cmd2Read bool
-		expWait            bool
+		cmd1Read, cmd2Read    bool
+		expWait, expLocalWait bool
 	}{
 		// Read/read doesn't wait.
-		{true, true, false},
-		// All other combinations must wait.
-		{true, false, true},
-		{false, true, true},
-		{false, false, true},
+		{true, true, false, false},
+		// A write doesn't wait for an earlier read (except for local keys).
+		{true, false, false, true},
+		// A read must wait for an earlier write.
+		{false, true, true, true},
+		// Writes always wait for other writes.
+		{false, false, true, true},
 	}
 
 	tooLong := 5 * time.Second
@@ -1913,16 +1915,27 @@ func TestReplicaCommandQueue(t *testing.T) {
 	uniqueKeyCounter := int32(0)
 
 	for _, test := range testCases {
-		for _, addReq := range []string{"", "noop", "read", "write"} {
+		var addReqs []string
+		if test.cmd1Read {
+			addReqs = []string{"", "noop", "read"}
+		} else {
+			addReqs = []string{"", "noop", "write"}
+		}
+		for _, addReq := range addReqs {
 			if addReq == "write" && propEvalKV {
 				// adding a write changes behavior in propEvalKV until the command
 				// queue changes are all done.
 				continue
 			}
 			for _, localKey := range []bool{false, true} {
+				expWait := test.expWait
+				if localKey {
+					expWait = test.expLocalWait
+				}
 				readWriteLabels := map[bool]string{true: "read", false: "write"}
-				testName := fmt.Sprintf("%s-%s", readWriteLabels[test.cmd1Read],
-					readWriteLabels[test.cmd2Read])
+				testName := fmt.Sprintf(
+					"%s-%s", readWriteLabels[test.cmd1Read], readWriteLabels[test.cmd2Read],
+				)
 				switch addReq {
 				case "noop":
 					testName += "-noop"
@@ -1999,12 +2012,9 @@ func TestReplicaCommandQueue(t *testing.T) {
 						cmd1Done := make(chan *roachpb.Error, 1)
 						if err := stopper.RunAsyncTask(context.Background(), func(_ context.Context) {
 							args := readOrWriteArgs(key1, test.cmd1Read)
-
-							pErr := sendWithHeader(roachpb.Header{
+							cmd1Done <- sendWithHeader(roachpb.Header{
 								UserPriority: blockingPriority,
 							}, args)
-
-							cmd1Done <- pErr
 						}); err != nil {
 							t.Fatal(err)
 						}
@@ -2019,10 +2029,7 @@ func TestReplicaCommandQueue(t *testing.T) {
 						cmd2Done := make(chan *roachpb.Error, 1)
 						if err := stopper.RunAsyncTask(context.Background(), func(_ context.Context) {
 							args := readOrWriteArgs(key1, test.cmd2Read)
-
-							pErr := sendWithHeader(roachpb.Header{}, args)
-
-							cmd2Done <- pErr
+							cmd2Done <- sendWithHeader(roachpb.Header{}, args)
 						}); err != nil {
 							t.Fatal(err)
 						}
@@ -2032,10 +2039,7 @@ func TestReplicaCommandQueue(t *testing.T) {
 						if !propEvalKV {
 							if err := stopper.RunAsyncTask(context.Background(), func(_ context.Context) {
 								args := readOrWriteArgs(key2, true)
-
-								pErr := sendWithHeader(roachpb.Header{}, args)
-
-								cmd3Done <- pErr
+								cmd3Done <- sendWithHeader(roachpb.Header{}, args)
 							}); err != nil {
 								t.Fatal(err)
 							}
@@ -2056,13 +2060,13 @@ func TestReplicaCommandQueue(t *testing.T) {
 							t.Fatalf("waited %s for cmd3 of key2", tooLong)
 						}
 
-						if test.expWait {
+						if expWait {
 							// Ensure that cmd2 didn't finish while cmd1 is still blocked.
 							select {
 							case pErr := <-cmd2Done:
 								t.Fatalf("should not have been able to execute cmd2 (pErr: %v)", pErr)
 							case pErr := <-cmd1Done:
-								t.Fatalf("should not have been able execute cmd1 while blocked (pErr: %v)", pErr)
+								t.Fatalf("should not have been able to execute cmd1 while blocked (pErr: %v)", pErr)
 							default:
 								// success
 							}
@@ -2254,7 +2258,7 @@ func TestReplicaCommandQueueCancellation(t *testing.T) {
 	// Wait until both commands are in the command queue.
 	testutils.SucceedsSoon(t, func() error {
 		tc.repl.cmdQMu.Lock()
-		chans := tc.repl.cmdQMu.global.getWait(false, []roachpb.Span{{Key: key1}, {Key: key2}})
+		chans := tc.repl.cmdQMu.global.getWait(false, hlc.Timestamp{}, []roachpb.Span{{Key: key1}, {Key: key2}})
 		tc.repl.cmdQMu.Unlock()
 		if a, e := len(chans), 2; a < e {
 			return errors.Errorf("%d of %d commands in the command queue", a, e)
@@ -2309,6 +2313,118 @@ func TestReplicaCommandQueueSelfOverlap(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+// TestReplicaCommandQueueTimestampNonInterference verifies that
+// reads with earlier timestamps do not interfere with writes.
+func TestReplicaCommandQueueTimestampNonInterference(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var blockKey, blockReader, blockWriter atomic.Value
+	blockKey.Store(roachpb.Key("a"))
+	blockReader.Store(false)
+	blockWriter.Store(false)
+	blockCh := make(chan struct{}, 1)
+	blockedCh := make(chan struct{}, 1)
+
+	tc := testContext{}
+	tsc := TestStoreConfig(nil)
+	tsc.TestingKnobs.TestingEvalFilter =
+		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
+			// Make sure the direct GC path doesn't interfere with this test.
+			if !filterArgs.Req.Header().Key.Equal(blockKey.Load().(roachpb.Key)) {
+				return nil
+			}
+			if filterArgs.Req.Method() == roachpb.Get && blockReader.Load().(bool) {
+				blockedCh <- struct{}{}
+				<-blockCh
+			} else if filterArgs.Req.Method() == roachpb.Put && blockWriter.Load().(bool) {
+				blockedCh <- struct{}{}
+				<-blockCh
+			}
+			return nil
+		}
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	tc.StartWithStoreConfig(t, stopper, tsc)
+
+	testCases := []struct {
+		readerTS    hlc.Timestamp
+		writerTS    hlc.Timestamp
+		key         roachpb.Key
+		readerFirst bool
+		interferes  bool
+	}{
+		// Reader & writer have same timestamps.
+		{makeTS(1, 0), makeTS(1, 0), roachpb.Key("a"), true, true},
+		{makeTS(1, 0), makeTS(1, 0), roachpb.Key("b"), false, true},
+		// Reader has earlier timestamp.
+		{makeTS(1, 0), makeTS(1, 1), roachpb.Key("c"), true, false},
+		{makeTS(1, 0), makeTS(1, 1), roachpb.Key("d"), false, false},
+		// Writer has earlier timestamp.
+		{makeTS(1, 1), makeTS(1, 0), roachpb.Key("e"), true, true},
+		{makeTS(1, 1), makeTS(1, 0), roachpb.Key("f"), false, true},
+		// Local keys always interfere.
+		{makeTS(1, 0), makeTS(1, 1), keys.RangeDescriptorKey(roachpb.RKey("a")), true, true},
+		{makeTS(1, 0), makeTS(1, 1), keys.RangeDescriptorKey(roachpb.RKey("b")), false, true},
+	}
+	for _, test := range testCases {
+		t.Run(fmt.Sprintf("%+v", test), func(t *testing.T) {
+			blockReader.Store(false)
+			blockWriter.Store(false)
+			blockKey.Store(test.key)
+			errCh := make(chan *roachpb.Error, 2)
+
+			baR := roachpb.BatchRequest{}
+			baR.Timestamp = test.readerTS
+			gArgs := getArgs(test.key)
+			baR.Add(&gArgs)
+			baW := roachpb.BatchRequest{}
+			baW.Timestamp = test.writerTS
+			pArgs := putArgs(test.key, []byte("value"))
+			baW.Add(&pArgs)
+
+			if test.readerFirst {
+				blockReader.Store(true)
+				go func() {
+					_, pErr := tc.Sender().Send(context.Background(), baR)
+					errCh <- pErr
+				}()
+				<-blockedCh
+				go func() {
+					_, pErr := tc.Sender().Send(context.Background(), baW)
+					errCh <- pErr
+				}()
+			} else {
+				blockWriter.Store(true)
+				go func() {
+					_, pErr := tc.Sender().Send(context.Background(), baW)
+					errCh <- pErr
+				}()
+				<-blockedCh
+				go func() {
+					_, pErr := tc.Sender().Send(context.Background(), baR)
+					errCh <- pErr
+				}()
+			}
+
+			if test.interferes {
+				select {
+				case <-time.After(10 * time.Millisecond):
+					// Expected.
+				case pErr := <-errCh:
+					t.Fatalf("expected interference: got error %s", pErr)
+				}
+			}
+			// Verify no errors on waiting read and write.
+			blockCh <- struct{}{}
+			for j := 0; j < 2; j++ {
+				if pErr := <-errCh; pErr != nil {
+					t.Errorf("error %d: unexpected error: %s", j, pErr)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Previously, the command queue considered any two commands to overlap if the
key ranges overlapped, regardless of whether the timestamps on the two
commands guaranteed they were non-overlapping.

Consider the case of a read over key ranges "a" - "z" at timestamp t=1s.
If a write arrives for key "c" at timestamp > t=1s, then it should be
free to proceed regardless of the disposition of the read because the
read cannot affect the write's timestamp.

Similarly, if a write is active for key "c" at timestamp t=1s, a read
that arrives for key range "a" - "z" should be free to proceed as long
as its timestamp is < t=1s.

Note that local keys do not allow non-interference between earlier reads
and overlapping writes.

Fixes #14298

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14342)
<!-- Reviewable:end -->
