### PR TITLE
Makefile: convince GNU tar not to rewrite symlinks in source archives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ export GIT_PAGER :=
 
 # GNU tar and BSD tar both support transforming filenames according to a regular
 # expression, but have different flags to do so.
-TAR_XFORM_FLAG = $(shell $(TAR) --version | grep -q GNU && echo "--xform=s" || echo "-s")
+TAR_XFORM_FLAG = $(shell $(TAR) --version | grep -q GNU && echo "--xform='flags=r;s'" || echo "-s")
 
 GIT_DIR := $(shell git rev-parse --git-dir 2> /dev/null)
 


### PR DESCRIPTION
GNU tar tries to be too helpful by default and applies transformations
to symlinks in source archives. (This broke building from our most recent beta's
source archive.) This commit turns off this symlink rewriting for GNU
tar, which is already the behavior of BSD tar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14343)
<!-- Reviewable:end -->
