### PR TITLE
storage: Fix replica tombstone/minReplicaID logic

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -703,8 +703,7 @@ func (r *Replica) destroyDataRaftMuLocked(
 	}
 	clearTime := timeutil.Now()
 
-	// Save a tombstone. The range cannot be re-replicated onto this node
-	// without having a replica ID of at least consistentDesc.NextReplicaID.
+	// Save a tombstone to ensure that replica IDs never get reused.
 	if err := r.setTombstoneKey(ctx, batch, &consistentDesc); err != nil {
 		return err
 	}
@@ -735,18 +734,43 @@ func (r *Replica) cancelPendingCommandsLocked() {
 	r.mu.proposals = map[storagebase.CmdIDKey]*ProposalData{}
 }
 
+// setTombstoneKey writes a tombstone to disk to ensure that replica IDs never
+// get reused. It determines what the minimum next replica ID can be using
+// the provided RangeDescriptor and the Replica's own ID.
+//
+// We have to be careful to set the right key, since a replica can be using an
+// ID that it hasn't yet received a RangeDescriptor for if it receives raft
+// requests for that replica ID (as seen in #14231).
 func (r *Replica) setTombstoneKey(
 	ctx context.Context, eng engine.ReadWriter, desc *roachpb.RangeDescriptor,
 ) error {
 	r.mu.Lock()
-	r.mu.minReplicaID = desc.NextReplicaID
+	nextReplicaID := r.nextReplicaIDLocked(desc)
+	r.mu.minReplicaID = nextReplicaID
 	r.mu.Unlock()
 	tombstoneKey := keys.RaftTombstoneKey(desc.RangeID)
 	tombstone := &roachpb.RaftTombstone{
-		NextReplicaID: desc.NextReplicaID,
+		NextReplicaID: nextReplicaID,
 	}
 	return engine.MVCCPutProto(ctx, eng, nil, tombstoneKey,
 		hlc.Timestamp{}, nil, tombstone)
+}
+
+// nextReplicaIDLocked returns the minimum ID that a new replica can be created
+// with for this replica's range. We have to be very careful to ensure that
+// replica IDs never get re-used because that can cause panics.
+//
+// The externalDesc parameter is an optional way to provide an additional
+// descriptor for the range that was looked up outside the replica code.
+func (r *Replica) nextReplicaIDLocked(externalDesc *roachpb.RangeDescriptor) roachpb.ReplicaID {
+	result := r.mu.state.Desc.NextReplicaID
+	if externalDesc != nil && externalDesc.NextReplicaID > result {
+		result = externalDesc.NextReplicaID
+	}
+	if r.mu.minReplicaID > result {
+		result = r.mu.minReplicaID
+	}
+	return result
 }
 
 func (r *Replica) setReplicaID(replicaID roachpb.ReplicaID) error {
@@ -778,7 +802,10 @@ func (r *Replica) setReplicaIDLocked(replicaID roachpb.ReplicaID) error {
 	// }
 
 	previousReplicaID := r.mu.replicaID
-	r.mu.replicaID = replicaID
+	r.mu.replicaID = replicaID // TODO(DONOTMERGE): Should we update the log string here? Or keep the log string consistent with the descriptor?
+	if replicaID >= r.mu.minReplicaID {
+		r.mu.minReplicaID = replicaID + 1
+	}
 	// Reset the raft group to force its recreation on next usage.
 	r.mu.internalRaftGroup = nil
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3126,7 +3126,7 @@ func (s *Store) processRaftRequest(
 			// Raft has decided the snapshot shouldn't be applied we would be
 			// writing the tombstone key incorrectly.
 			r.mu.Lock()
-			r.mu.minReplicaID = r.mu.state.Desc.NextReplicaID
+			r.mu.minReplicaID = r.nextReplicaIDLocked(nil)
 			r.mu.Unlock()
 		}
 


### PR DESCRIPTION
Previously we didn't take into account a replica's own state when
persisting a tombstone to disk, so it was possible to write a tombstone
that would allow a new replica to be created with the same ID. We want
to make sure that's never allowed, so take the current replica's state
into account when persisting the tombstone, not just the passed-in
RangeDescriptor.

Fixes #14231 

If this fix approach looks reasonable, I'll take a stab at adding a more focused test than `TestRemovePlaceholderRace`, which takes quite a lot of stress to fail.

@cockroachdb/stability

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14344)
<!-- Reviewable:end -->
