### PR TITLE
storage: Don't GC a replica whose ID has been incremented

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -5484,8 +5484,9 @@ func TestReplicaDestroy(t *testing.T) {
 	if err := repl.setDesc(newDesc); err != nil {
 		t.Fatal(err)
 	}
-	if err := tc.store.removeReplicaImpl(context.Background(), tc.repl, *origDesc, true); !testutils.IsError(err, "replica ID has changed") {
-		t.Fatalf("expected error 'replica ID has changed' but got %v", err)
+	expectedErr := "replica descriptor's ID has changed"
+	if err := tc.store.removeReplicaImpl(context.Background(), tc.repl, *origDesc, true); !testutils.IsError(err, expectedErr) {
+		t.Fatalf("expected error %q but got %v", expectedErr, err)
 	}
 
 	// Now try a fresh descriptor and succeed.

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2211,11 +2211,22 @@ func (s *Store) removeReplicaImpl(
 ) error {
 	log.Infof(ctx, "removing replica")
 
-	desc := rep.Desc()
-	if repDesc, ok := desc.GetReplicaDescriptor(s.StoreID()); ok && repDesc.ReplicaID >= consistentDesc.NextReplicaID {
+	// We check both rep.mu.ReplicaID and rep.mu.state.Desc's replica ID because
+	// they can differ in cases when a replica's ID is increased due to an
+	// incoming raft message (see #14231 for background).
+	rep.mu.Lock()
+	if rep.mu.replicaID >= consistentDesc.NextReplicaID {
+		rep.mu.Unlock()
 		return errors.Errorf("cannot remove replica %s; replica ID has changed (%s >= %s)",
+			rep, rep.mu.replicaID, consistentDesc.NextReplicaID)
+	}
+	desc := rep.mu.state.Desc
+	if repDesc, ok := desc.GetReplicaDescriptor(s.StoreID()); ok && repDesc.ReplicaID >= consistentDesc.NextReplicaID {
+		rep.mu.Unlock()
+		return errors.Errorf("cannot remove replica %s; replica descriptor's ID has changed (%s >= %s)",
 			rep, repDesc.ReplicaID, consistentDesc.NextReplicaID)
 	}
+	rep.mu.Unlock()
 
 	// TODO(peter): Could use s.mu.RLock here?
 	s.mu.Lock()


### PR DESCRIPTION
If the ID has changed since replica GC started its processing, then it
has changed its identity within the raft group and might not merit
removal anymore.

Could potentially be worked into a replacement for #14344, but I think it's safer to consider as a supplement given the non-contiguous locking involved. If this looks good to you as a supplement, I'll have to change the new test in #14344 since it was relying on this check not working.

cc #14231 @bdarnell @tamird

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14348)
<!-- Reviewable:end -->
