### PR TITLE
Makefile: fix Git hook directory detection for Git <2.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,11 +335,7 @@ ifneq ($(GIT_DIR),)
 endif
 
 ifneq ($(GIT_DIR),)
-# If we're in a git worktree, the git hooks directory may not be in our root,
-# so we ask git for the location.
-#
-# Note that `git rev-parse --git-path hooks` requires git 2.5+.
-GITHOOKSDIR := $(shell git rev-parse --git-path hooks 2> /dev/null || echo "$(GIT_DIR)/hooks")
+GITHOOKSDIR := $(GIT_DIR)/hooks
 GITHOOKS := $(subst githooks/,$(GITHOOKSDIR)/,$(wildcard githooks/*))
 $(GITHOOKSDIR)/%: githooks/%
 	@echo installing $<


### PR DESCRIPTION
Git 2.5 introduced a useful `git rev-parse --git-path hooks` command
that, since Git 2.10, takes into account the `core.hooksPath` varible.
This command unfortunately fails with garbage output but a successful
exit code on TeamCity, which runs an older version of Git. The garbage
output contains spaces, which causes Make to print a warning about
"mixed implicit and normal rules", since $(GITHOOKSDIR)/% is used as a
target and Make cannot handle targets with spaces.

So this patch reverts to manually computing the Git hooks directory with
`git rev-parse --git-dir`/hooks, which works on all known versions of
Git.

The more I think about this, the more I think this may have been the
correct behavior all along. The `core.hooksPath` variable applies
globally, so if a user has configured it, s/he probably doesn't want us
installing Cockroach-specific hooks into that directory anyway.

Fixes #14330.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14350)
<!-- Reviewable:end -->
