### PR TITLE
rpc: fix flaky/racy heartbeats test

### DIFF
--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -92,7 +92,6 @@ func TestHeartbeatCB(t *testing.T) {
 // heartbeats succeed or fail.
 func TestHeartbeatHealth(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#13939")
 
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
@@ -139,11 +138,23 @@ func TestHeartbeatHealth(t *testing.T) {
 		}
 	}()
 
+	// Wait for the connection.
+	testutils.SucceedsSoon(t, func() error {
+		err := clientCtx.ConnHealth(remoteAddr)
+		if err != nil && err != errNotHeartbeated {
+			t.Fatal(err)
+		}
+		return err
+	})
+
 	// Should be unhealthy in the presence of failing heartbeats.
 	hbSuccess.Store(false)
-	if err := clientCtx.ConnHealth(remoteAddr); err != errNotHeartbeated {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	testutils.SucceedsSoon(t, func() error {
+		if err := clientCtx.ConnHealth(remoteAddr); !testutils.IsError(err, errFailedHeartbeat.Error()) {
+			return errors.Errorf("unexpected error: %v", err)
+		}
+		return nil
+	})
 
 	// Should become healthy in the presence of successful heartbeats.
 	hbSuccess.Store(true)


### PR DESCRIPTION
Checking the state of the connection was racing both with setting hbSuccess to
false and with the connection being established.

fixes #13939

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14355)
<!-- Reviewable:end -->
