### PR TITLE
Makefile: fix Git hook installation for Git worktress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,7 +335,11 @@ ifneq ($(GIT_DIR),)
 endif
 
 ifneq ($(GIT_DIR),)
-GITHOOKSDIR := $(GIT_DIR)/hooks
+# If we're in a git worktree, the git hooks directory may not be in our root,
+# so we ask git for the location.
+#
+# Note that `git rev-parse --git-path hooks` requires git 2.5+.
+GITHOOKSDIR := $(shell test -d .git && echo '.git/hooks' || git rev-parse --git-path hooks)
 GITHOOKS := $(subst githooks/,$(GITHOOKSDIR)/,$(wildcard githooks/*))
 $(GITHOOKSDIR)/%: githooks/%
 	@echo installing $<


### PR DESCRIPTION
a3303ba broke Git hook installation in worktrees (#14354). This is my fault for refactoring the logic when I introduced the `GIT_DIR` variable in 37fff5e5. This commit restores the logic from before 37fff5e5, which is tried and true on TeamCity and Git worktrees.

Fixes #14354.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14356)
<!-- Reviewable:end -->
