### PR TITLE
build: pass Azure variables through to Docker container

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -149,4 +149,5 @@ docker run --privileged -i ${tty-} --rm \
   --env="GOTRACEBACK=${GOTRACEBACK-all}" \
   --env="COVERALLS_TOKEN=${COVERALLS_TOKEN-}" \
   --env="CODECOV_TOKEN=${CODECOV_TOKEN-}" \
+  --env=ARM_SUBSCRIPTION_ID --env=ARM_CLIENT_ID --env=ARM_CLIENT_SECRET --env=ARM_TENANT_ID \
   "${image}:${version}" "${@-bash}"


### PR DESCRIPTION
TeamCity requires these variables to run nightly tests. Previously they were transmitted from the TC host to the Docker container via command line variables (`make VAR=...`), but this is no longer supported as of 6c425c859a. This commit adjusts build/builder.sh to pass the env vars through from host to container automatically if they exist.

@tamird the approach we talked about via email didn't pan out, as you probably surmised from the failing builds I spawned. Our build/builder.sh exposes no easy way to set one-off environment variables, save for the `make` command-line argument approach that no longer works. This seemed like a better option than `build/builder.sh bash -c "QUOTING NIGHTMARE"`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14358)
<!-- Reviewable:end -->
