### PR TITLE
sql: Clean up PipelineQueue based on comments

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1513,7 +1513,7 @@ func (e *Executor) execStmtPipelined(stmt parser.Statement, planner *planner) (R
 		return Result{}, err
 	}
 
-	session.pipelineQueue.Add(&plan, func() error {
+	session.pipelineQueue.Add(plan, func(plan planNode) error {
 		defer plan.Close(ctx)
 
 		result, err := makeRes(stmt, planner, plan)


### PR DESCRIPTION
This change addresses the comments from #14188 on the `PipelineQueue`.

The main change here is that everything in the queue operates on
`planNode`s instead of `*planNode`s. This is permitted because all
implementations of the `planNode` interface are implemented on pointer
types, so the equality of the interface does in fact imply pointer
equality. The other changes are fixing minor typos and passing the
`planNode` back into the exec function itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14359)
<!-- Reviewable:end -->
