### PR TITLE
storage: fix flaky test for eager replication

### DIFF
--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -88,6 +88,12 @@ func (s *Store) ForceReplicaGCScanAndProcess() {
 	forceScanAndProcess(s, s.replicaGCQueue.baseQueue)
 }
 
+// ForceSplitScanAndProcess iterates over all ranges and enqueues any that
+// may need to be split.
+func (s *Store) ForceSplitScanAndProcess() {
+	forceScanAndProcess(s, s.splitQueue.baseQueue)
+}
+
 // ForceRaftLogScanAndProcess iterates over all ranges and enqueues any that
 // need their raft logs truncated and then process each of them.
 func (s *Store) ForceRaftLogScanAndProcess() {
@@ -265,6 +271,15 @@ func (r *Replica) IsRaftGroupInitialized() bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.mu.internalRaftGroup != nil
+}
+
+// HasQuorum returns true iff the range that this replica is part of
+// can achieve quorum.
+func (r *Replica) HasQuorum() bool {
+	desc := r.Desc()
+	liveReplicas, _ := r.store.allocator.storePool.liveAndDeadReplicas(desc.RangeID, desc.Replicas)
+	quorum := computeQuorum(len(desc.Replicas))
+	return len(liveReplicas) >= quorum
 }
 
 // GetStoreList is the same function as GetStoreList exposed for tests only.


### PR DESCRIPTION
Disable the split queue until after the store has connected to gossip and
gossiped the store capacity. Without this change, replicas sometimes ended
up in the split queue before the replica was considered live, so would fail
to end up in the replicate queue's purgatory.

Fixes #14249

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14361)
<!-- Reviewable:end -->
