### PR TITLE
ccl: clean up backup/restore logging

### DIFF
--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -63,6 +63,7 @@ func evalExport(
 		return storage.EvalResult{}, err
 	}
 	defer endLimitedRequest()
+	log.Infof(ctx, "export [%s,%s)", args.Key, args.EndKey)
 
 	exportStore, err := MakeExportStorage(ctx, args.Storage)
 	if err != nil {

--- a/pkg/ccl/storageccl/writebatch.go
+++ b/pkg/ccl/storageccl/writebatch.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
@@ -46,6 +47,9 @@ func evalWriteBatch(
 
 	_, span := tracing.ChildSpan(ctx, fmt.Sprintf("WriteBatch [%s,%s)", args.Key, args.EndKey))
 	defer tracing.FinishSpan(span)
+	if log.V(1) {
+		log.Infof(ctx, "writebatch [%s,%s)", args.Key, args.EndKey)
+	}
 
 	// We can't use the normal RangeKeyMismatchError mechanism for dealing with
 	// splits because args.Data should stay an opaque blob to DistSender.


### PR DESCRIPTION
Unconditionally log the beginning of each Import and Export request.
They're expensive enough that it might be nice to see them in the logs
when investigating a performance degradation.

Use the new (rewritten) keys for logging throughout RESTORE so they
agree down the callstack. Also slightly more consistent capitalization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14365)
<!-- Reviewable:end -->
