### PR TITLE
sql: support set-returning functions within other render expressions

### DIFF
--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -203,7 +203,8 @@ func (p *planner) groupBy(
 	group.groupByIdx = make([]int, 0, len(groupByExprs))
 	for _, g := range groupByExprs {
 		cols, exprs, hasStar, err := s.planner.computeRenderAllowingStars(
-			ctx, parser.SelectExpr{Expr: g}, parser.TypeAny, s.sourceInfo, s.ivarHelper)
+			ctx, parser.SelectExpr{Expr: g}, parser.TypeAny, s.sourceInfo, s.ivarHelper,
+			autoGenerateRenderOutputName)
 		if err != nil {
 			return nil, err
 		}
@@ -227,7 +228,7 @@ func (p *planner) groupBy(
 
 		cols, exprs, hasStar, err := s.planner.computeRenderAllowingStars(
 			ctx, parser.SelectExpr{Expr: f.filter}, parser.TypeAny,
-			s.sourceInfo, s.ivarHelper)
+			s.sourceInfo, s.ivarHelper, autoGenerateRenderOutputName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/parser/generator_builtins.go
+++ b/pkg/sql/parser/generator_builtins.go
@@ -83,7 +83,7 @@ var _ ValueGenerator = &arrayValueGenerator{}
 
 func initGeneratorBuiltins() {
 	// Add all windows to the Builtins map after a few sanity checks.
-	for k, v := range generators {
+	for k, v := range Generators {
 		for _, g := range v {
 			if !g.impure {
 				panic(fmt.Sprintf("generator functions should all be impure, found %v", g))
@@ -97,7 +97,9 @@ func initGeneratorBuiltins() {
 	}
 }
 
-var generators = map[string][]Builtin{
+// Generators is a map from name to slice of Builtins for all built-in
+// generators.
+var Generators = map[string][]Builtin{
 	"generate_series": {
 		makeGeneratorBuiltin(
 			ArgTypes{{"start", TypeInt}, {"end", TypeInt}},

--- a/pkg/sql/parser/indexed_vars.go
+++ b/pkg/sql/parser/indexed_vars.go
@@ -140,6 +140,13 @@ func (h *IndexedVarHelper) AssertSameContainer(ivar *IndexedVar) {
 	}
 }
 
+// AppendSlot expands the capacity of this IndexedVarHelper by one and returns
+// the index of the new slot.
+func (h *IndexedVarHelper) AppendSlot() int {
+	h.vars = append(h.vars, IndexedVar{})
+	return len(h.vars) - 1
+}
+
 func (h *IndexedVarHelper) checkIndex(idx int) {
 	if idx < 0 || idx >= len(h.vars) {
 		panic(fmt.Sprintf("invalid var index %d (columns: %d)", idx, len(h.vars)))

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -70,6 +70,7 @@ type planner struct {
 	subqueryVisitor       subqueryVisitor
 	subqueryPlanVisitor   subqueryPlanVisitor
 	nameResolutionVisitor nameResolutionVisitor
+	srfExtractionVisitor  srfExtractionVisitor
 }
 
 // noteworthyInternalMemoryUsageBytes is the minimum size tracked by each

--- a/pkg/sql/returning.go
+++ b/pkg/sql/returning.go
@@ -86,7 +86,8 @@ func (p *planner) newReturningHelper(
 	ivarHelper := parser.MakeIndexedVarHelper(rh, len(tablecols))
 	for _, target := range rExprs {
 		cols, typedExprs, _, err := p.computeRenderAllowingStars(
-			ctx, target, parser.TypeAny, multiSourceInfo{rh.source}, ivarHelper)
+			ctx, target, parser.TypeAny, multiSourceInfo{rh.source}, ivarHelper,
+			autoGenerateRenderOutputName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -202,7 +202,7 @@ func (p *planner) orderBy(
 		if index == -1 && s != nil {
 			cols, exprs, hasStar, err := p.computeRenderAllowingStars(
 				ctx, parser.SelectExpr{Expr: expr}, parser.TypeAny,
-				s.sourceInfo, s.ivarHelper)
+				s.sourceInfo, s.ivarHelper, autoGenerateRenderOutputName)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/targets.go
+++ b/pkg/sql/targets.go
@@ -24,6 +24,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const autoGenerateRenderOutputName = ""
+
 // computeRender expands a target expression into a result column.
 func (p *planner) computeRender(
 	ctx context.Context,
@@ -31,11 +33,17 @@ func (p *planner) computeRender(
 	desiredType parser.Type,
 	info multiSourceInfo,
 	ivarHelper parser.IndexedVarHelper,
+	outputName string,
 ) (column sqlbase.ResultColumn, expr parser.TypedExpr, err error) {
 	// When generating an output column name it should exactly match the original
-	// expression, so determine the output column name before we perform any
-	// manipulations to the expression.
-	outputName := getRenderColName(target)
+	// expression, so if our caller has requested that we generate the output
+	// column name, we determine the name before we perform any manipulations to
+	// the expression.
+	if outputName == autoGenerateRenderOutputName {
+		if outputName, err = getRenderColName(p.session.SearchPath, target); err != nil {
+			return sqlbase.ResultColumn{}, nil, err
+		}
+	}
 
 	normalized, err := p.analyzeExpr(ctx, target.Expr, info, ivarHelper, desiredType, false, "")
 	if err != nil {
@@ -54,6 +62,7 @@ func (p *planner) computeRenderAllowingStars(
 	desiredType parser.Type,
 	info multiSourceInfo,
 	ivarHelper parser.IndexedVarHelper,
+	outputName string,
 ) (columns sqlbase.ResultColumns, exprs []parser.TypedExpr, hasStar bool, err error) {
 	// Pre-normalize any VarName so the work is not done twice below.
 	if err := target.NormalizeTopLevelVarName(); err != nil {
@@ -66,7 +75,7 @@ func (p *planner) computeRenderAllowingStars(
 		return cols, typedExprs, hasStar, nil
 	}
 
-	col, expr, err := p.computeRender(ctx, target, desiredType, info, ivarHelper)
+	col, expr, err := p.computeRender(ctx, target, desiredType, info, ivarHelper, outputName)
 	if err != nil {
 		return nil, nil, false, err
 	}

--- a/pkg/sql/testdata/logic_test/generators
+++ b/pkg/sql/testdata/logic_test/generators
@@ -112,10 +112,20 @@ SELECT 3 + x FROM generate_series(1,2) AS a(x)
 4
 5
 
-# Not supported yet: transforming set-returning functions that aren't top-level
-# render expressions into cross joins.
-query error pq: unsupported binary operator: <int> \+ <setof tuple\{int\}>
+
+query I colnames
 SELECT 3 + generate_series(1,2)
+----
+3 + generate_series(1, 2)
+4
+5
+
+query I
+SELECT 3 + (3 * generate_series(1,3))
+----
+6
+9
+12
 
 query I
 SELECT * from unnest(ARRAY[1,2])
@@ -131,3 +141,32 @@ SELECT unnest(ARRAY[1,2]), unnest(ARRAY['a', 'b'])
 2  a
 2  b
 
+query I
+SELECT unnest(ARRAY[3,4]) - 2
+----
+1
+2
+
+query II
+SELECT 1 + generate_series(0, 1), unnest(ARRAY[2, 4]) - 1
+----
+1  1
+1  3
+2  1
+2  3
+
+query I
+SELECT ascii(unnest(ARRAY['a', 'b', 'c']));
+----
+97
+98
+99
+
+query error pq: cannot specify two set-returning functions in the same SELECT expression
+SELECT generate_series(generate_series(1, 3), 3)
+
+query error pq: cannot specify two set-returning functions in the same SELECT expression
+SELECT generate_series(1, 3) + generate_series(1, 3)
+
+query error pq: column name "generate_series" not found
+SELECT generate_series(1, 3) FROM t WHERE generate_series > 3

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -209,7 +209,7 @@ func addOrMergeExpr(
 	selectExpr := parser.SelectExpr{Expr: e}
 	typ := updateCols[currentUpdateIdx].Type.ToDatumType()
 	col, expr, err := render.planner.computeRender(ctx, selectExpr, typ,
-		render.sourceInfo, render.ivarHelper)
+		render.sourceInfo, render.ivarHelper, autoGenerateRenderOutputName)
 	if err != nil {
 		return -1, err
 	}
@@ -329,7 +329,7 @@ func (p *planner) Update(
 					desiredTupleType[i] = updateCols[currentUpdateIdx+i].Type.ToDatumType()
 				}
 				col, expr, err := render.planner.computeRender(ctx, selectExpr, desiredTupleType,
-					render.sourceInfo, render.ivarHelper)
+					render.sourceInfo, render.ivarHelper, autoGenerateRenderOutputName)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -177,7 +177,8 @@ func (n *windowNode) constructWindowDefinitions(
 		// Validate PARTITION BY clause.
 		for _, partition := range windowDef.Partitions {
 			cols, exprs, _, err := s.planner.computeRenderAllowingStars(ctx,
-				parser.SelectExpr{Expr: partition}, parser.TypeAny, s.sourceInfo, s.ivarHelper)
+				parser.SelectExpr{Expr: partition}, parser.TypeAny, s.sourceInfo, s.ivarHelper,
+				autoGenerateRenderOutputName)
 			if err != nil {
 				return err
 			}
@@ -187,7 +188,8 @@ func (n *windowNode) constructWindowDefinitions(
 		// Validate ORDER BY clause.
 		for _, orderBy := range windowDef.OrderBy {
 			cols, exprs, _, err := s.planner.computeRenderAllowingStars(ctx,
-				parser.SelectExpr{Expr: orderBy.Expr}, parser.TypeAny, s.sourceInfo, s.ivarHelper)
+				parser.SelectExpr{Expr: orderBy.Expr}, parser.TypeAny, s.sourceInfo, s.ivarHelper,
+				autoGenerateRenderOutputName)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
In 0903a36e @jordanlewis added support for set-returning functions (SRFs) within a render expression, like:

    SELECT generate_series(1, 3);

This commit adds support for detecting SRFs in more complicated render expressions, like:

    SELECT 1 + generate_series(1, 3);

Expressions that involve multiple SRFs, like

    SELECT generate_series(generate_series(1, 3), 3);

are still unsupported. (Yes, that really is a query which PostgreSQL supports.) Such queries require lateral correlated subqueries, which are not yet supported, but it should be easy to adapt the infrastructure in this commit when lateral correlated subqueries land.

Fixes #13146.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14369)
<!-- Reviewable:end -->
