### PR TITLE
sql: permit columns with NULL default value

### DIFF
--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -57,7 +57,10 @@ func SanitizeVarFreeExpr(
 	if err != nil {
 		return err
 	}
-	if defaultType := typedExpr.ResolvedType(); !expectedType.Equivalent(defaultType) {
+	defaultType := typedExpr.ResolvedType()
+	if !expectedType.Equivalent(defaultType) && typedExpr != parser.DNull {
+		// The DEFAULT expression must match the column type exactly unless it is a
+		// constant NULL value.
 		return incompatibleExprTypeError(context, expectedType, defaultType)
 	}
 	return nil

--- a/pkg/sql/testdata/logic_test/alter_table
+++ b/pkg/sql/testdata/logic_test/alter_table
@@ -423,6 +423,12 @@ ALTER TABLE add_default ALTER COLUMN b DROP DEFAULT
 statement error null value in column "b" violates not-null constraint
 INSERT INTO add_default (a) VALUES (4)
 
+statement ok
+ALTER TABLE add_default ALTER COLUMN b SET DEFAULT NULL
+
+statement error null value in column "b" violates not-null constraint
+INSERT INTO add_default (a) VALUES (4)
+
 # Each row gets the default value from the time it was inserted.
 query II rowsort
 SELECT * FROM add_default
@@ -473,6 +479,17 @@ SELECT a,b FROM add_default WHERE e > d AND e - d < interval '10s'
 2 42
 3 10
 5 NULL
+
+# Add a column with a null-default statement_timestamp()
+statement ok
+ALTER TABLE add_default ADD COLUMN f TIMESTAMP DEFAULT NULL
+
+query IIS rowsort
+SELECT a,b,f FROM add_default
+----
+2 42   NULL
+3 10   NULL
+5 NULL NULL
 
 # Temporarily disabled due to #13646.
 # # Adding a unique column to an existing table with data with a default value

--- a/pkg/sql/testdata/logic_test/default
+++ b/pkg/sql/testdata/logic_test/default
@@ -10,6 +10,10 @@ CREATE TABLE t (a INT PRIMARY KEY DEFAULT (SELECT 1))
 statement error DEFAULT expression .* may not contain variable sub-expressions
 CREATE TABLE t (a INT PRIMARY KEY DEFAULT b)
 
+# Issue #14308: support tables with DEFAULT NULL columns.
+statement ok
+CREATE TABLE null_default (ts TIMESTAMP PRIMARY KEY NULL DEFAULT NULL)
+
 # Aggregate function calls in CHECK are not ok.
 statement error aggregate functions are not allowed in DEFAULT expressions
 CREATE TABLE bad (a INT DEFAULT COUNT(1))
@@ -92,3 +96,17 @@ UPDATE t SET b = DEFAULT, c = DEFAULT
 
 statement ok
 UPDATE t SET (b) = (DEFAULT), (c) = (DEFAULT)
+
+# Test a table without a default and with a null default
+statement ok
+CREATE TABLE v (
+  a INT PRIMARY KEY,
+  b TIMESTAMP NULL DEFAULT NULL
+)
+
+query TTBTT colnames
+SHOW COLUMNS FROM v
+----
+Field Type      Null  Default  Indices
+a     INT       false NULL     {primary}
+b     TIMESTAMP true  NULL     {}

--- a/pkg/sql/testdata/logic_test/table
+++ b/pkg/sql/testdata/logic_test/table
@@ -435,3 +435,18 @@ CREATE TABLE test.empty ()
 
 statement ok
 SELECT * FROM test.empty
+
+# Issue #14308: support tables with DEFAULT NULL columns.
+statement ok
+CREATE TABLE test.null_default (
+  ts timestamp NULL DEFAULT NULL
+)
+
+query TT
+SHOW CREATE TABLE test.null_default
+----
+test.null_default CREATE TABLE null_default
+(
+  ts  TIMESTAMP NULL DEFAULT NULL,
+  FAMILY "primary" (ts, rowid)
+)


### PR DESCRIPTION
Previously, adding a `DEFAULT NULL` column modifier via `CREATE TABLE`,
`ALTER TABLE ADD COLUMN`, or `ALTER TABLE SET DEFAULT` would fail with
an erroneous type error. Columns with a `DEFAULT NULL` modifier should
always be permitted, since columns without a `DEFAULT` statement have a
default value of NULL anyway.

Now, `DEFAULT NULL` column modifiers are always permitted.

Fixes #14308.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14371)
<!-- Reviewable:end -->
