### PR TITLE
sql: incorporate splitNode.rows into plan recursions

### DIFF
--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -248,6 +248,9 @@ func doExpandPlan(
 			n.plan, err = doExpandPlan(ctx, p, params, n.plan)
 		}
 
+	case *splitNode:
+		n.rows, err = doExpandPlan(ctx, p, noParams, n.rows)
+
 	case *valuesNode:
 	case *alterTableNode:
 	case *copyNode:
@@ -260,7 +263,6 @@ func doExpandPlan(
 	case *dropViewNode:
 	case *emptyNode:
 	case *hookFnNode:
-	case *splitNode:
 	case *valueGenerator:
 	case nil:
 
@@ -525,6 +527,9 @@ func simplifyOrderings(plan planNode, usefulOrdering sqlbase.ColumnOrdering) pla
 	case *delayedNode:
 		n.plan = simplifyOrderings(n.plan, usefulOrdering)
 
+	case *splitNode:
+		n.rows = simplifyOrderings(n.rows, nil)
+
 	case *valuesNode:
 	case *alterTableNode:
 	case *copyNode:
@@ -537,7 +542,6 @@ func simplifyOrderings(plan planNode, usefulOrdering sqlbase.ColumnOrdering) pla
 	case *dropViewNode:
 	case *emptyNode:
 	case *hookFnNode:
-	case *splitNode:
 	case *valueGenerator:
 
 	default:

--- a/pkg/sql/filter_opt.go
+++ b/pkg/sql/filter_opt.go
@@ -321,6 +321,11 @@ func (p *planner) propagateFilters(
 			return plan, extraFilter, err
 		}
 
+	case *splitNode:
+		if n.rows, err = p.triggerFilterPropagation(ctx, n.rows); err != nil {
+			return plan, extraFilter, err
+		}
+
 	case *alterTableNode:
 	case *copyNode:
 	case *createDatabaseNode:
@@ -332,7 +337,6 @@ func (p *planner) propagateFilters(
 	case *dropTableNode:
 	case *dropViewNode:
 	case *hookFnNode:
-	case *splitNode:
 	case *valueGenerator:
 	case *valuesNode:
 

--- a/pkg/sql/limit_opt.go
+++ b/pkg/sql/limit_opt.go
@@ -156,6 +156,9 @@ func applyLimit(plan planNode, numRows int64, soft bool) {
 			setUnlimited(n.plan)
 		}
 
+	case *splitNode:
+		setUnlimited(n.rows)
+
 	case *valuesNode:
 	case *alterTableNode:
 	case *copyNode:
@@ -168,7 +171,6 @@ func applyLimit(plan planNode, numRows int64, soft bool) {
 	case *dropViewNode:
 	case *emptyNode:
 	case *hookFnNode:
-	case *splitNode:
 	case *valueGenerator:
 
 	default:

--- a/pkg/sql/needed_columns.go
+++ b/pkg/sql/needed_columns.go
@@ -183,6 +183,9 @@ func setNeededColumns(plan planNode, needed []bool) {
 		// foreign key relations and that are not needed for RETURNING.
 		setNeededColumns(n.run.rows, allColumns(n.run.rows))
 
+	case *splitNode:
+		setNeededColumns(n.rows, allColumns(n.rows))
+
 	case *alterTableNode:
 	case *copyNode:
 	case *createDatabaseNode:
@@ -195,7 +198,6 @@ func setNeededColumns(plan planNode, needed []bool) {
 	case *dropViewNode:
 	case *emptyNode:
 	case *hookFnNode:
-	case *splitNode:
 	case *valueGenerator:
 
 	default:

--- a/pkg/sql/testdata/logic_test/alter_table
+++ b/pkg/sql/testdata/logic_test/alter_table
@@ -560,3 +560,19 @@ ALTER TABLE privsview ADD d INT
 
 statement error pgcode 42809 "privsview" is not a table
 ALTER TABLE privsview SPLIT AT VALUES (42)
+
+statement ok
+CREATE TABLE s (k1 INT, k2 INT, v INT, PRIMARY KEY (k1,k2))
+
+# Verify limits and orderings are propagated correctly to the select.
+query ITTTTT colnames
+EXPLAIN (METADATA) ALTER TABLE s SPLIT AT SELECT k1,k2 FROM s ORDER BY k1 LIMIT 3
+----
+Level  Type    Field  Description  Columns        Ordering
+0      split                       (key, pretty)
+1      limit                       (k1, k2)              +k1
+2      render                      (k1, k2)              +k1
+3      scan                        (k1, k2, v[omitted])  +k1
+3              table  s@primary
+3              spans  ALL
+3              limit  3


### PR DESCRIPTION
When I added support for a SPLIT AT select, I didn't correctly incorporate the
new subnode into the plan recursions (expansion, filter propagation, etc).
Fixing and adding a test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14373)
<!-- Reviewable:end -->
