### PR TITLE
storage: add txn debug names for split/merge, unittest for dist txn cleanup

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -927,6 +927,9 @@ func (t Transaction) String() string {
 	fmt.Fprintf(&buf, "id=%s key=%s rw=%t pri=%.8f iso=%s stat=%s epo=%d ts=%s orig=%s max=%s wto=%t rop=%t",
 		t.Short(), Key(t.Key), t.Writing, floatPri, t.Isolation, t.Status, t.Epoch, t.Timestamp,
 		t.OrigTimestamp, t.MaxTimestamp, t.WriteTooOld, t.RetryOnPush)
+	if ni := len(t.Intents); t.Status != PENDING && ni > 0 {
+		fmt.Fprintf(&buf, " int=%d", ni)
+	}
 	return buf.String()
 }
 

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -19,6 +19,7 @@ package storage_test
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"math/rand"
 	"reflect"
 	"sync"
@@ -1777,8 +1778,6 @@ func TestStoreRangeGossipOnSplits(t *testing.T) {
 	config.TestingSetupZoneConfigHook(stopper)
 	config.TestingSetZoneConfig(0, config.ZoneConfig{NumReplicas: 1})
 
-	<-store.Gossip().Connected
-
 	rangeCountCh := make(chan int32)
 	unregister := store.Gossip().RegisterCallback(storeKey, func(_ string, val roachpb.Value) {
 		var sd roachpb.StoreDescriptor
@@ -1793,6 +1792,9 @@ func TestStoreRangeGossipOnSplits(t *testing.T) {
 	})
 	defer unregister()
 
+	// Pull the first gossiped range count.
+	lastRangeCount := <-rangeCountCh
+
 	splitFunc := func(i int) *roachpb.Error {
 		splitKey := roachpb.Key(fmt.Sprintf("%02d", i))
 		_, pErr := store.LookupReplica(roachpb.RKey(splitKey), nil).AdminSplit(
@@ -1804,44 +1806,22 @@ func TestStoreRangeGossipOnSplits(t *testing.T) {
 		return pErr
 	}
 
-	// Split 9 times; verify range count is gossiped.
-	for i := 0; i < 9; i++ {
+	// Split until we split at least 20 ranges.
+	var rangeCount int32
+	for i := 0; rangeCount < 20; i++ {
 		if pErr := splitFunc(i); pErr != nil {
 			t.Fatal(pErr)
 		}
-	}
-	testutils.SucceedsSoon(t, func() error {
-		if err := store.GossipStore(context.Background()); err != nil {
-			t.Fatal(err)
+		select {
+		case rangeCount = <-rangeCountCh:
+			changeCount := int32(math.Ceil(math.Max(float64(lastRangeCount)*0.5, 1)))
+			diff := rangeCount - (lastRangeCount + changeCount)
+			if diff < -1 || diff > 1 {
+				t.Errorf("gossiped range count %d more than 1 away from expected %d", rangeCount, lastRangeCount+changeCount)
+			}
+			lastRangeCount = rangeCount
+		case <-time.After(10 * time.Millisecond):
 		}
-		if rangeCount := <-rangeCountCh; rangeCount != 10 {
-			return errors.Errorf("expected 10 ranges; got %d", rangeCount)
-		}
-		return nil
-	})
-
-	// Now, since we require 50% of range/lease count to re-gossip, verify
-	// that with 5 more splits, we gossip.
-	for i := 9; i < 14; i++ {
-		if pErr := splitFunc(i); pErr != nil {
-			t.Fatal(pErr)
-		}
-	}
-
-	if rangeCount := <-rangeCountCh; rangeCount != 15 {
-		t.Errorf("expected 15 ranges; got %d", rangeCount)
-	}
-
-	// However, with four more splits, expect no gossip.
-	for i := 14; i < 18; i++ {
-		if pErr := splitFunc(i); pErr != nil {
-			t.Fatal(pErr)
-		}
-	}
-	select {
-	case <-rangeCountCh:
-		t.Errorf("expected no further gossip")
-	default:
 	}
 }
 
@@ -1864,5 +1844,105 @@ func TestStorePushTxnQueueEnabledOnSplit(t *testing.T) {
 	rhsRepl := store.LookupReplica(roachpb.RKey(keys.UserTableDataMin), nil)
 	if !rhsRepl.IsPushTxnQueueEnabled() {
 		t.Errorf("expected RHS replica's push txn queue to be enabled post-split")
+	}
+}
+
+// TestDistributedTxnCleanup verifies that distributed transactions
+// cleanup their txn records after commit or abort.
+func TestDistributedTxnCleanup(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	storeCfg := storage.TestStoreConfig(nil)
+	storeCfg.TestingKnobs.DisableSplitQueue = true
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	store := createTestStoreWithConfig(t, stopper, storeCfg)
+
+	// Split at "a".
+	lhsKey := roachpb.Key("a")
+	args := adminSplitArgs(lhsKey, lhsKey)
+	if _, pErr := client.SendWrapped(context.Background(), rg1(store), args); pErr != nil {
+		t.Fatalf("split at %q: %s", lhsKey, pErr)
+	}
+	lhs := store.LookupReplica(roachpb.RKey("a"), nil)
+
+	// Split at "b".
+	rhsKey := roachpb.Key("b")
+	args = adminSplitArgs(rhsKey, rhsKey)
+	if _, pErr := client.SendWrappedWith(context.Background(), store, roachpb.Header{
+		RangeID: lhs.RangeID,
+	}, args); pErr != nil {
+		t.Fatalf("split at %q: %s", rhsKey, pErr)
+	}
+	rhs := store.LookupReplica(roachpb.RKey("b"), nil)
+
+	if lhs == rhs {
+		t.Errorf("LHS == RHS after split: %s == %s", lhs, rhs)
+	}
+
+	// Test both commit and abort cases.
+	for _, force := range []bool{true, false} {
+		for _, commit := range []bool{true, false} {
+			t.Run(fmt.Sprintf("force=%t,commit=%t", force, commit), func(t *testing.T) {
+				// Run a distributed transaction involving the lhsKey and rhsKey.
+				var txnKey roachpb.Key
+				ctx := context.Background()
+				txn := client.NewTxn(store.DB())
+				opts := client.TxnExecOptions{
+					AutoCommit: true,
+					AutoRetry:  false,
+				}
+				if err := txn.Exec(ctx, opts, func(ctx context.Context, txn *client.Txn, _ *client.TxnExecOptions) error {
+					b := txn.NewBatch()
+					b.Put(fmt.Sprintf("%s.force=%t,commit=%t", string(lhsKey), force, commit), "lhsValue")
+					b.Put(fmt.Sprintf("%s.force=%t,commit=%t", string(rhsKey), force, commit), "rhsValue")
+					if err := txn.Run(ctx, b); err != nil {
+						return err
+					}
+					txnKey = keys.TransactionKey(txn.Proto().Key, *txn.Proto().ID)
+					// If force=true, we're force-aborting the txn out from underneath.
+					// This simulates txn deadlock or a max priority txn aborting a
+					// normal or min priority txn.
+					if force {
+						ba := roachpb.BatchRequest{}
+						ba.RangeID = lhs.RangeID
+						ba.Add(&roachpb.PushTxnRequest{
+							Span: roachpb.Span{
+								Key: txn.Proto().Key,
+							},
+							Now:           store.Clock().Now(),
+							PusheeTxn:     txn.Proto().TxnMeta,
+							PushType:      roachpb.PUSH_ABORT,
+							Force:         true,
+							NewPriorities: true,
+						})
+						_, pErr := store.Send(ctx, ba)
+						if pErr != nil {
+							t.Errorf("failed to abort the txn: %s", pErr)
+						}
+					}
+					if commit {
+						return nil
+					}
+					return errors.New("forced abort")
+				}); err != nil {
+					txn.CleanupOnError(ctx, err)
+					if !force && commit {
+						t.Fatalf("expected success with commit == true; got %v", err)
+					}
+				}
+
+				// Verify that the transaction record is cleaned up.
+				testutils.SucceedsSoon(t, func() error {
+					kv, err := store.DB().Get(ctx, txnKey)
+					if err != nil {
+						return err
+					}
+					if kv.Value != nil {
+						return errors.Errorf("expected txn record %s to have been cleaned", txnKey)
+					}
+					return nil
+				})
+			})
+		}
 	}
 }

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -78,6 +78,8 @@ const (
 	optimizePutThreshold = 10
 
 	replicaChangeTxnName = "change-replica"
+	splitTxnName         = "split"
+	mergeTxnName         = "merge"
 
 	defaultReplicaRaftMuWarnThreshold = 500 * time.Millisecond
 )

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -2598,6 +2598,7 @@ func (r *Replica) adminSplitWithDescriptor(
 	if err := r.store.DB().Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		log.Event(ctx, "split closure begins")
 		defer log.Event(ctx, "split closure ends")
+		txn.SetDebugName(splitTxnName)
 		// Update existing range descriptor for left hand side of
 		// split. Note that we mutate the descriptor for the left hand
 		// side of the split first to locate the txn record there.
@@ -3076,6 +3077,7 @@ func (r *Replica) AdminMerge(
 
 	if err := r.store.DB().Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		log.Event(ctx, "merge closure begins")
+		txn.SetDebugName(mergeTxnName)
 		// Update the range descriptor for the receiving range.
 		{
 			b := txn.NewBatch()

--- a/pkg/storage/replicate_test.go
+++ b/pkg/storage/replicate_test.go
@@ -20,9 +20,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -43,21 +41,7 @@ func TestEagerReplication(t *testing.T) {
 	// Disable the replica scanner so that we rely on the eager replication code
 	// path that occurs after splits.
 	store.SetReplicaScannerActive(false)
-
-	<-store.Gossip().Connected
-	if err := store.GossipStore(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	// Wait for the range to achieve quorum.
-	repl := store.LookupReplica(roachpb.RKeyMin, nil)
-	testutils.SucceedsSoon(t, func() error {
-		if !repl.HasQuorum() {
-			return errors.New("first range has not reached quorum")
-		}
-		return nil
-	})
-
-	// Now enable the split queue and force a scan and process.
+	// Enable the split queue and force a scan and process.
 	store.SetSplitQueueActive(true)
 	store.ForceSplitScanAndProcess()
 


### PR DESCRIPTION
Also, moved initial gossip of store capacity to `client_test.go` setup
for `createTestStore` and fixed associated broken tests.

This PR is exploratory work to address #6693 & #9135

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14375)
<!-- Reviewable:end -->
