### PR TITLE
rpc: make rpc.Context configurable

### DIFF
--- a/pkg/acceptance/terrafarm/farmer.go
+++ b/pkg/acceptance/terrafarm/farmer.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/pkg/errors"
 )
@@ -74,6 +75,8 @@ type Farmer struct {
 	// RPCContext is used to open an ExternalClient which provides a KV connection
 	// to the cluster by gRPC.
 	RPCContext *rpc.Context
+	// ClientClock is used by the cluster's gRPC client.
+	ClientClock *hlc.Clock
 }
 
 func (f *Farmer) refresh() {
@@ -232,7 +235,7 @@ func (f *Farmer) NewClient(ctx context.Context, i int) (*client.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	return client.NewDB(client.NewSender(conn), f.RPCContext.LocalClock), nil
+	return client.NewDB(client.NewSender(conn), f.ClientClock), nil
 }
 
 // PGUrl returns a URL string for the given node postgres server.

--- a/pkg/base/testing_knobs.go
+++ b/pkg/base/testing_knobs.go
@@ -30,4 +30,5 @@ type TestingKnobs struct {
 	SQLLeaseManager  ModuleTestingKnobs
 	SQLSchemaChanger ModuleTestingKnobs
 	DistSQL          ModuleTestingKnobs
+	RPCContext       ModuleTestingKnobs
 }

--- a/pkg/ccl/sqlccl/kv_test.go
+++ b/pkg/ccl/sqlccl/kv_test.go
@@ -55,7 +55,7 @@ func newKVWriteBatch(b *testing.B) kvInterface {
 	}
 
 	return &kvWriteBatch{
-		db: client.NewDB(client.NewSender(conn), rpcContext.LocalClock),
+		db: client.NewDB(client.NewSender(conn), s.Clock()),
 		doneFn: func() {
 			s.Stopper().Stop(context.TODO())
 			enableTracing()

--- a/pkg/gossip/client_test.go
+++ b/pkg/gossip/client_test.go
@@ -49,12 +49,14 @@ func startGossip(
 }
 
 func newInsecureRPCContext(stopper *stop.Stopper) *rpc.Context {
-	return rpc.NewContext(
-		log.AmbientContext{},
-		&base.Config{Insecure: true},
-		hlc.NewClock(hlc.UnixNano, time.Nanosecond),
-		stopper,
-	)
+	cfg := rpc.Config{
+		Config:                &base.Config{Insecure: true},
+		Clock:                 hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		HeartbeatInterval:     rpc.ArbitraryServerHeartbeatInterval,
+		HeartbeatTimeout:      rpc.ArbitraryServerHeartbeatTimeout,
+		EnableClockSkewChecks: true,
+	}
+	return rpc.NewContext(log.AmbientContext{}, cfg, stopper)
 }
 
 func startGossipAtAddr(

--- a/pkg/gossip/simulation/network.go
+++ b/pkg/gossip/simulation/network.go
@@ -73,14 +73,16 @@ func NewNetwork(stopper *stop.Stopper, nodeCount int, createResolvers bool) *Net
 		Nodes:   []*Node{},
 		Stopper: stopper,
 	}
-	n.rpcContext = rpc.NewContext(
-		log.AmbientContext{},
-		&base.Config{Insecure: true},
-		hlc.NewClock(hlc.UnixNano, time.Nanosecond),
-		n.Stopper,
-	)
+	cfg := rpc.Config{
+		Config: &base.Config{Insecure: true},
+		Clock:  hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		// Disable heartbeats.
+		HeartbeatInterval:     0,
+		EnableClockSkewChecks: false,
+	}
+	n.rpcContext = rpc.NewContext(log.AmbientContext{}, cfg, n.Stopper)
 	var err error
-	n.tlsConfig, err = n.rpcContext.GetServerTLSConfig()
+	n.tlsConfig, err = cfg.GetServerTLSConfig()
 	if err != nil {
 		log.Fatal(context.TODO(), err)
 	}

--- a/pkg/kv/db_test.go
+++ b/pkg/kv/db_test.go
@@ -51,7 +51,14 @@ func createTestClientForUser(
 	ctx.User = user
 	testutils.FillCerts(&ctx)
 
-	conn, err := rpc.NewContext(log.AmbientContext{}, &ctx, s.Clock(), s.Stopper()).GRPCDial(s.ServingAddr())
+	cfg := rpc.Config{
+		Config: &ctx,
+		Clock:  s.Clock(),
+		// Disable heartbeats for this client that's external to the cluster.
+		HeartbeatInterval:     0,
+		EnableClockSkewChecks: false,
+	}
+	conn, err := rpc.NewContext(log.AmbientContext{}, cfg, s.Stopper()).GRPCDial(s.ServingAddr())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -617,12 +617,14 @@ func TestRetryOnDescriptorLookupError(t *testing.T) {
 
 func makeGossip(t *testing.T, stopper *stop.Stopper) (*gossip.Gossip, *hlc.Clock) {
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	rpcContext := rpc.NewContext(
-		log.AmbientContext{},
-		&base.Config{Insecure: true},
-		clock,
-		stopper,
-	)
+	cfg := rpc.Config{
+		Config:                &base.Config{Insecure: true},
+		Clock:                 clock,
+		HeartbeatInterval:     rpc.ArbitraryServerHeartbeatInterval,
+		HeartbeatTimeout:      rpc.ArbitraryServerHeartbeatTimeout,
+		EnableClockSkewChecks: true,
+	}
+	rpcContext := rpc.NewContext(log.AmbientContext{}, cfg, stopper)
 	server := rpc.NewServer(rpcContext)
 
 	const nodeID = 1

--- a/pkg/kv/send_test.go
+++ b/pkg/kv/send_test.go
@@ -75,19 +75,25 @@ func TestInvalidAddrLength(t *testing.T) {
 }
 
 // TestSendToOneClient verifies that Send correctly sends a request
-// to one server using the heartbeat RPC.
+// to one server by RPC.
 func TestSendToOneClient(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
 
-	rpcContext := rpc.NewContext(
-		log.AmbientContext{},
-		testutils.NewNodeTestBaseContext(),
-		hlc.NewClock(hlc.UnixNano, time.Nanosecond),
-		stopper,
-	)
+	// We're going to share an rpc.Context for both the server and the "client".
+	// That's because the client in this test is conceptually also a node from the
+	// cluster (i.e. the client uses internal interfaces to communicate with the
+	// server).
+	cfg := rpc.Config{
+		Config:                testutils.NewNodeTestBaseConfig(),
+		Clock:                 hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		HeartbeatInterval:     rpc.ArbitraryServerHeartbeatInterval,
+		HeartbeatTimeout:      rpc.ArbitraryServerHeartbeatTimeout,
+		EnableClockSkewChecks: true,
+	}
+	rpcContext := rpc.NewContext(log.AmbientContext{}, cfg, stopper)
 	s, ln := newTestServer(t, rpcContext)
 	roachpb.RegisterInternalServer(s, Node(0))
 
@@ -145,12 +151,14 @@ func (*channelSaveTransport) Close() {
 // distinguishing them and just send a single channel.
 func setupSendNextTest(t *testing.T) ([]chan<- BatchCall, chan BatchCall, *stop.Stopper) {
 	stopper := stop.NewStopper()
-	nodeContext := rpc.NewContext(
-		log.AmbientContext{},
-		testutils.NewNodeTestBaseContext(),
-		hlc.NewClock(hlc.UnixNano, time.Nanosecond),
-		stopper,
-	)
+	cfg := rpc.Config{
+		Config:                testutils.NewNodeTestBaseConfig(),
+		Clock:                 hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		HeartbeatInterval:     rpc.ArbitraryServerHeartbeatInterval,
+		HeartbeatTimeout:      rpc.ArbitraryServerHeartbeatTimeout,
+		EnableClockSkewChecks: true,
+	}
+	nodeContext := rpc.NewContext(log.AmbientContext{}, cfg, stopper)
 
 	addrs := []net.Addr{
 		util.NewUnresolvedAddr("dummy", "1"),
@@ -413,12 +421,14 @@ func TestComplexScenarios(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
 
-	nodeContext := rpc.NewContext(
-		log.AmbientContext{},
-		testutils.NewNodeTestBaseContext(),
-		hlc.NewClock(hlc.UnixNano, time.Nanosecond),
-		stopper,
-	)
+	cfg := rpc.Config{
+		Config:                testutils.NewNodeTestBaseConfig(),
+		Clock:                 hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		HeartbeatInterval:     rpc.ArbitraryServerHeartbeatInterval,
+		HeartbeatTimeout:      rpc.ArbitraryServerHeartbeatTimeout,
+		EnableClockSkewChecks: true,
+	}
+	nodeContext := rpc.NewContext(log.AmbientContext{}, cfg, stopper)
 
 	// TODO(bdarnell): the retryable flag is no longer used for RPC errors.
 	// Rework this test to incorporate application-level errors carried in

--- a/pkg/kv/split_test.go
+++ b/pkg/kv/split_test.go
@@ -190,7 +190,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 			DisableScanner: true,
 		},
 	}
-	s.Start(t, testutils.NewNodeTestBaseContext(), InitSenderForLocalTestCluster)
+	s.Start(t, testutils.NewNodeTestBaseConfig(), InitSenderForLocalTestCluster)
 
 	// This is purely to silence log spam.
 	config.TestingSetupZoneConfigHook(s.Stopper)

--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -74,7 +74,7 @@ func createTestDBWithContext(
 	s := &localtestcluster.LocalTestCluster{
 		DBContext: &dbCtx,
 	}
-	s.Start(t, testutils.NewNodeTestBaseContext(), InitSenderForLocalTestCluster)
+	s.Start(t, testutils.NewNodeTestBaseConfig(), InitSenderForLocalTestCluster)
 	return s, s.Sender.(*TxnCoordSender)
 }
 

--- a/pkg/kv/txn_correctness_test.go
+++ b/pkg/kv/txn_correctness_test.go
@@ -895,7 +895,7 @@ func checkConcurrency(
 	s := &localtestcluster.LocalTestCluster{
 		DontRetryPushTxnFailures: true,
 	}
-	s.Start(t, testutils.NewNodeTestBaseContext(), InitSenderForLocalTestCluster)
+	s.Start(t, testutils.NewNodeTestBaseConfig(), InitSenderForLocalTestCluster)
 	defer s.Stop()
 	verifier.run(isolations, s.DB, t)
 }

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -111,7 +111,7 @@ func BenchmarkSingleRoundtripWithLatency(b *testing.B) {
 		b.Run(latency.String(), func(b *testing.B) {
 			var s localtestcluster.LocalTestCluster
 			s.Latency = latency
-			s.Start(b, testutils.NewNodeTestBaseContext(), InitSenderForLocalTestCluster)
+			s.Start(b, testutils.NewNodeTestBaseConfig(), InitSenderForLocalTestCluster)
 			defer s.Stop()
 			defer b.StopTimer()
 			key := roachpb.Key("key")
@@ -387,7 +387,7 @@ func TestUncertaintyRestart(t *testing.T) {
 		Clock:     hlc.NewClock(hlc.UnixNano, maxOffset),
 		DBContext: &dbCtx,
 	}
-	s.Start(t, testutils.NewNodeTestBaseContext(), InitSenderForLocalTestCluster)
+	s.Start(t, testutils.NewNodeTestBaseConfig(), InitSenderForLocalTestCluster)
 	defer s.Stop()
 	if err := disableOwnNodeCertain(s); err != nil {
 		t.Fatal(err)
@@ -445,7 +445,7 @@ func TestUncertaintyMaxTimestampForwarding(t *testing.T) {
 		Clock:     hlc.NewClock(hlc.UnixNano, 50*time.Second),
 		DBContext: &dbCtx,
 	}
-	s.Start(t, testutils.NewNodeTestBaseContext(), InitSenderForLocalTestCluster)
+	s.Start(t, testutils.NewNodeTestBaseConfig(), InitSenderForLocalTestCluster)
 	defer s.Stop()
 	if err := disableOwnNodeCertain(s); err != nil {
 		t.Fatal(err)

--- a/pkg/rpc/clock_offset.go
+++ b/pkg/rpc/clock_offset.go
@@ -127,6 +127,9 @@ func (r *RemoteClockMonitor) Latency(addr string) (time.Duration, bool) {
 func (r *RemoteClockMonitor) UpdateOffset(
 	ctx context.Context, addr string, offset RemoteOffset, roundTripLatency time.Duration,
 ) {
+	if addr == "127.0.0.1:0" {
+		log.Fatal(ctx, "uninitialized address in UpdateOffset call")
+	}
 	emptyOffset := offset == RemoteOffset{}
 
 	r.mu.Lock()

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -52,7 +52,17 @@ func init() {
 }
 
 const (
-	defaultHeartbeatInterval = 3 * time.Second
+	defaultKeepaliveInterval = 3 * time.Second
+	defaultKeepaliveTimeout  = 2 * defaultKeepaliveInterval
+
+	// ArbitraryServerHeartbeatInterval can be used by clients to indicate that
+	// they want heartbeats on their connections but don't particularly care about
+	// the interval.
+	ArbitraryServerHeartbeatInterval = 3 * time.Second
+	// ArbitraryServerHeartbeatTimeout can be used in conjunction with
+	// ArbitraryServerHeartbeatInterval.
+	ArbitraryServerHeartbeatTimeout = 3 * time.Second
+
 	// The coefficient by which the maximum offset is multiplied to determine the
 	// maximum acceptable measurement latency.
 	maximumPingDurationMult = 2
@@ -87,8 +97,6 @@ var sourceAddr = func() net.Addr {
 	return nil
 }()
 
-var enableRPCCompression = envutil.EnvOrDefaultBool("COCKROACH_ENABLE_RPC_COMPRESSION", false)
-
 // NewServer is a thin wrapper around grpc.NewServer that registers a heartbeat
 // service.
 func NewServer(ctx *Context) *grpc.Server {
@@ -108,11 +116,18 @@ func NewServer(ctx *Context) *grpc.Server {
 	}
 	// Compression is enabled separately from decompression to allow staged
 	// rollout.
-	if ctx.rpcCompression {
+	switch ctx.cfg.RPCCompression {
+	case SnappyCompression:
 		opts = append(opts, grpc.RPCCompressor(snappyCompressor{}))
+	case NoCompression:
+	default:
+		// The UseDefault setting should have been resolved to one of the other
+		// options by now.
+		panic(fmt.Sprintf("unsupported compression option: %d", ctx.cfg.RPCCompression))
 	}
-	if !ctx.Insecure {
-		tlsConfig, err := ctx.GetServerTLSConfig()
+
+	if !ctx.cfg.Insecure {
+		tlsConfig, err := ctx.cfg.GetServerTLSConfig()
 		if err != nil {
 			panic(err)
 		}
@@ -120,7 +135,7 @@ func NewServer(ctx *Context) *grpc.Server {
 	}
 	s := grpc.NewServer(opts...)
 	RegisterHeartbeatServer(s, &HeartbeatService{
-		clock:              ctx.LocalClock,
+		clock:              ctx.cfg.Clock,
 		remoteClockMonitor: ctx.RemoteClocks,
 	})
 	return s
@@ -133,21 +148,82 @@ type connMeta struct {
 	heartbeatErr error
 }
 
-// Context contains the fields required by the rpc framework.
-type Context struct {
+// ContextTestingKnobs are the testing knobs for a Context.
+type ContextTestingKnobs struct {
+	BreakerFactory func() *circuit.Breaker
+	// PeriodicClockCheckHook is used to override the default clock offset check
+	// on connections. If an error is returned, the node will panic.
+	PeriodicClockCheckHook func() error
+}
+
+// ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.
+func (*ContextTestingKnobs) ModuleTestingKnobs() {}
+
+var _ base.ModuleTestingKnobs = &ContextTestingKnobs{}
+
+// Config contains parameters for creating a Context.
+type Config struct {
+	// The base.Config used to open gRPC connections.
 	*base.Config
 
-	LocalClock   *hlc.Clock
+	// KeepaliveParams controls the interval at which gRPC will perform HTTP2
+	// pings to check that the connection is still alive. If not populated, the
+	// default will be as below (note that this is different than the gRPC
+	// default). If the client wants to set any fields, it has to set all of them.
+	//
+	// Default:
+	// keepalive.ClientParameters{
+	//     Time:                defaultKeepaliveInterval,
+	//     Timeout:             defaultKeepaliveTimeout,
+	//     PermitWithoutStream: true,
+	// }
+	KeepaliveParams keepalive.ClientParameters
+
+	// HeartbeatInterval is the period on which the health status of a node is
+	// tested. A Heartbeat RPC is sent periodically and, if it fails or times out,
+	// the remote host is considered to be unhealthy (see ConnHealth(remoteAddr)).
+	// Set to 0 to disable.
+	//
+	// Heartbeats are different from the gRPC pings configured through
+	// KeepaliveInterval. Those fail in-flight RPCs and cause gRPC to reconnect,
+	// but otherwise their failure is not exposed to the application.
+	//
+	// Heartbeats can also be piggy-backed by clock skew checks; see
+	// EnableClockSkewCheck.
+	HeartbeatInterval time.Duration
+	// HeartbeatTimeout specifies the timeout of the Heartbeat RPCs. If a
+	// heartbeat times out, the remote node is considered to be unhealthy.
+	// Set to math.MaxInt64 to disable the timeout.
+	HeartbeatTimeout time.Duration
+
+	// EnableClockSkewChecks, if set, makes the Heartbeat RPCs also perform clock
+	// skew checks. If an unacceptable clock skew is detected, the node kills
+	// itself.
+	// If set, HeartbeatInterval must also be set.
+	EnableClockSkewChecks bool
+
+	// Clock is the clock used for reporting the the node's clock with
+	// heartbeats, and also for the circuit breaker.
+	Clock *hlc.Clock
+
+	// RPCCompression specifies whether compressions is going to be used or not.
+	RPCCompression Compression
+
+	TestingKnobs ContextTestingKnobs
+}
+
+// Context allows clients to open gRPC connections to remote hosts. It also
+// optionally performs health checks on those connections and checks for clock
+// skew between nodes.
+type Context struct {
+	cfg Config
+
 	breakerClock breakerClock
 	Stopper      *stop.Stopper
+	// RemoteClocks is used to perform periodic clock offset checks on all
+	// connections.
 	RemoteClocks *RemoteClockMonitor
 	masterCtx    context.Context
-
-	heartbeatInterval time.Duration
-	heartbeatTimeout  time.Duration
-	HeartbeatCB       func()
-
-	rpcCompression bool
 
 	localInternalServer roachpb.InternalServer
 
@@ -155,34 +231,56 @@ type Context struct {
 		syncutil.Mutex
 		cache map[string]*connMeta
 	}
-
-	// For unittesting.
-	BreakerFactory func() *circuit.Breaker
 }
 
 // NewContext creates an rpc Context with the supplied values.
-func NewContext(
-	ambient log.AmbientContext, baseCtx *base.Config, hlcClock *hlc.Clock, stopper *stop.Stopper,
-) *Context {
-	if hlcClock == nil {
+func NewContext(ambient log.AmbientContext, cfg Config, stopper *stop.Stopper) *Context {
+	if cfg.Clock == nil {
 		panic("nil clock is forbidden")
 	}
 	ctx := &Context{
-		Config:     baseCtx,
-		LocalClock: hlcClock,
+		cfg: cfg,
 		breakerClock: breakerClock{
-			clock: hlcClock,
+			clock: cfg.Clock,
 		},
-		rpcCompression: enableRPCCompression,
 	}
 	var cancel context.CancelFunc
 	ctx.masterCtx, cancel = context.WithCancel(ambient.AnnotateCtx(context.Background()))
 	ctx.Stopper = stopper
-	ctx.RemoteClocks = newRemoteClockMonitor(
-		ctx.LocalClock, 10*defaultHeartbeatInterval, baseCtx.HistogramWindowInterval)
-	ctx.heartbeatInterval = defaultHeartbeatInterval
-	ctx.heartbeatTimeout = 2 * defaultHeartbeatInterval
+	if ctx.cfg.EnableClockSkewChecks {
+		if ctx.cfg.HeartbeatInterval == 0 {
+			log.Fatal(ctx.masterCtx, "specified EnableClockSkewChecks but not HeartbeatInterval")
+		}
+		if ctx.cfg.Clock.MaxOffset() == 0 {
+			log.Fatal(ctx.masterCtx, "specified EnabledClockSkewChecks but supplied a "+
+				"clock without MaxOffset configured")
+		}
+		ctx.RemoteClocks = newRemoteClockMonitor(
+			ctx.cfg.Clock, 10*ctx.cfg.HeartbeatInterval /* offsetTTL */, ctx.cfg.HistogramWindowInterval)
+	}
+	if ctx.cfg.KeepaliveParams == (keepalive.ClientParameters{}) {
+		ctx.cfg.KeepaliveParams = keepalive.ClientParameters{
+			Time:                defaultKeepaliveInterval,
+			Timeout:             defaultKeepaliveTimeout,
+			PermitWithoutStream: true,
+		}
+	}
+	if ctx.cfg.HeartbeatInterval != 0 {
+		if ctx.cfg.HeartbeatTimeout == 0 {
+			log.Fatal(ctx.masterCtx, "invalid HeartbeatTimeout: 0")
+		}
+	} else if ctx.cfg.HeartbeatTimeout != 0 {
+		log.Fatal(ctx.masterCtx, "specified HeartbeatTimeout but not HeartbeatInterval")
+	}
 	ctx.conns.cache = make(map[string]*connMeta)
+
+	if ctx.cfg.RPCCompression == UseDefault {
+		if defaultEnableRPCCompression {
+			ctx.cfg.RPCCompression = SnappyCompression
+		} else {
+			ctx.cfg.RPCCompression = NoCompression
+		}
+	}
 
 	stopper.RunWorker(ctx.masterCtx, func(context.Context) {
 		<-stopper.ShouldQuiesce()
@@ -209,7 +307,7 @@ func NewContext(
 // GetLocalInternalServerForAddr returns the context's internal batch server
 // for addr, if it exists.
 func (ctx *Context) GetLocalInternalServerForAddr(addr string) roachpb.InternalServer {
-	if addr == ctx.Addr {
+	if addr == ctx.cfg.Addr {
 		return ctx.localInternalServer
 	}
 	return nil
@@ -254,10 +352,10 @@ func (ctx *Context) GRPCDial(target string, opts ...grpc.DialOption) (*grpc.Clie
 
 	meta.Do(func() {
 		var dialOpt grpc.DialOption
-		if ctx.Insecure {
+		if ctx.cfg.Insecure {
 			dialOpt = grpc.WithInsecure()
 		} else {
-			tlsConfig, err := ctx.GetClientTLSConfig()
+			tlsConfig, err := ctx.cfg.GetClientTLSConfig()
 			if err != nil {
 				meta.dialErr = err
 				return
@@ -271,20 +369,16 @@ func (ctx *Context) GRPCDial(target string, opts ...grpc.DialOption) (*grpc.Clie
 		dialOpts = append(dialOpts, grpc.WithDecompressor(snappyDecompressor{}))
 		// Compression is enabled separately from decompression to allow staged
 		// rollout.
-		if ctx.rpcCompression {
+		switch ctx.cfg.RPCCompression {
+		case SnappyCompression:
 			dialOpts = append(dialOpts, grpc.WithCompressor(snappyCompressor{}))
+		case NoCompression:
+		default:
+			// The UseDefault setting should have been resolved to one of the other
+			// options by now.
+			panic(fmt.Sprintf("unsupported compression option: %d", ctx.cfg.RPCCompression))
 		}
-		dialOpts = append(dialOpts, grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			// Send periodic pings on the connection.
-			Time: base.NetworkTimeout,
-			// If the pings don't get a response within the timeout, we might be
-			// experiencing a network partition. gRPC will close the transport-level
-			// connection and all the pending RPCs (which may not have timeouts) will
-			// fail eagerly. gRPC will then reconnect the transport transparently.
-			Timeout: base.NetworkTimeout,
-			// Do the pings even when there are no ongoing RPCs.
-			PermitWithoutStream: true,
-		}))
+		dialOpts = append(dialOpts, grpc.WithKeepaliveParams(ctx.cfg.KeepaliveParams))
 		dialOpts = append(dialOpts, opts...)
 
 		if sourceAddr != nil {
@@ -303,14 +397,10 @@ func (ctx *Context) GRPCDial(target string, opts ...grpc.DialOption) (*grpc.Clie
 			log.Infof(ctx.masterCtx, "dialing %s", target)
 		}
 		meta.conn, meta.dialErr = grpc.DialContext(ctx.masterCtx, target, dialOpts...)
-		if meta.dialErr == nil {
+		if meta.dialErr == nil && ctx.cfg.HeartbeatInterval != 0 {
 			if err := ctx.Stopper.RunTask(ctx.masterCtx, func(masterCtx context.Context) {
 				ctx.Stopper.RunWorker(masterCtx, func(masterCtx context.Context) {
-					err := ctx.runHeartbeat(meta, target)
-					if err != nil && !grpcutil.IsClosedConnection(err) {
-						log.Errorf(masterCtx, "removing connection to %s due to error: %s", target, err)
-					}
-					ctx.removeConn(target, meta)
+					ctx.runPeriodicHeartbeats(meta, target)
 				})
 			}); err != nil {
 				meta.dialErr = err
@@ -329,8 +419,8 @@ func (ctx *Context) GRPCDial(target string, opts ...grpc.DialOption) (*grpc.Clie
 // NewBreaker creates a new circuit breaker properly configured for RPC
 // connections.
 func (ctx *Context) NewBreaker() *circuit.Breaker {
-	if ctx.BreakerFactory != nil {
-		return ctx.BreakerFactory()
+	if ctx.cfg.TestingKnobs.BreakerFactory != nil {
+		return ctx.cfg.TestingKnobs.BreakerFactory()
 	}
 	return newBreaker(&ctx.breakerClock)
 }
@@ -355,41 +445,43 @@ func (ctx *Context) ConnHealth(remoteAddr string) error {
 	return ErrNotConnected
 }
 
-func (ctx *Context) runHeartbeat(meta *connMeta, remoteAddr string) error {
-	maxOffset := ctx.LocalClock.MaxOffset()
+func (ctx *Context) runPeriodicHeartbeats(meta *connMeta, remoteAddr string) {
+	if ctx.cfg.HeartbeatInterval == 0 {
+		log.Fatal(ctx.masterCtx, "invalid HeartbeatInterval: 0")
+	}
+	maxOffset := ctx.cfg.Clock.MaxOffset()
 
 	request := PingRequest{
-		Addr:           ctx.Addr,
+		Addr:           ctx.cfg.Addr,
 		MaxOffsetNanos: maxOffset.Nanoseconds(),
 	}
 	heartbeatClient := NewHeartbeatClient(meta.conn)
 
-	var heartbeatTimer timeutil.Timer
-	defer heartbeatTimer.Stop()
+	var clockCheckTimer timeutil.Timer
+	defer clockCheckTimer.Stop()
 
 	// Give the first iteration a wait-free heartbeat attempt.
-	heartbeatTimer.Reset(0)
+	clockCheckTimer.Reset(0)
 	for {
 		select {
 		case <-ctx.Stopper.ShouldStop():
-			return nil
-		case <-heartbeatTimer.C:
-			heartbeatTimer.Read = true
+			return
+		case <-clockCheckTimer.C:
+			clockCheckTimer.Read = true
 		}
 
 		goCtx := ctx.masterCtx
 		var cancel context.CancelFunc
-		if hbTimeout := ctx.heartbeatTimeout; hbTimeout > 0 {
+		if hbTimeout := ctx.cfg.HeartbeatTimeout; hbTimeout != math.MaxInt64 {
 			goCtx, cancel = context.WithTimeout(goCtx, hbTimeout)
 		}
-		sendTime := ctx.LocalClock.PhysicalTime()
-		// NB: We want the request to fail-fast (the default), otherwise we won't
-		// be notified of transport failures.
+		sendTime := ctx.cfg.Clock.PhysicalTime()
 		response, err := heartbeatClient.Ping(goCtx, &request)
 		if cancel != nil {
 			cancel()
 		}
 		ctx.conns.Lock()
+		// Consider the remote node unhealthy in case of an error.
 		meta.heartbeatErr = err
 		ctx.conns.Unlock()
 
@@ -399,23 +491,23 @@ func (ctx *Context) runHeartbeat(meta *connMeta, remoteAddr string) error {
 		// broken.
 		// TODO(bdarnell): remove this when the upstream bug is fixed.
 		if err != nil && strings.Contains(err.Error(), "write: connection refused") {
-			return nil
+			return
 		}
 
-		if err == nil {
-			receiveTime := ctx.LocalClock.PhysicalTime()
+		if err == nil && ctx.cfg.EnableClockSkewChecks {
+			receiveTime := ctx.cfg.Clock.PhysicalTime()
 
 			// Only update the clock offset measurement if we actually got a
-			// successful response from the server.
+			// successful response from the server and the measurement didn't take too
+			// long.
 			pingDuration := receiveTime.Sub(sendTime)
-			if pingDuration > maximumPingDurationMult*ctx.LocalClock.MaxOffset() {
+			if pingDuration > maximumPingDurationMult*ctx.cfg.Clock.MaxOffset() {
+				// The empty offset will not be recorded.
 				request.Offset.Reset()
 			} else {
-				// Offset and error are measured using the remote clock reading
-				// technique described in
-				// http://se.inf.tu-dresden.de/pubs/papers/SRDS1994.pdf, page 6.
-				// However, we assume that drift and min message delay are 0, for
-				// now.
+				// Offset and error are measured using the remote clock reading technique
+				// described in http://se.inf.tu-dresden.de/pubs/papers/SRDS1994.pdf, page
+				// 6. However, we assume that drift and min message delay are 0, for now.
 				request.Offset.MeasuredAt = receiveTime.UnixNano()
 				request.Offset.Uncertainty = (pingDuration / 2).Nanoseconds()
 				remoteTimeNow := time.Unix(0, response.ServerTime).Add(pingDuration / 2)
@@ -423,11 +515,17 @@ func (ctx *Context) runHeartbeat(meta *connMeta, remoteAddr string) error {
 			}
 			ctx.RemoteClocks.UpdateOffset(ctx.masterCtx, remoteAddr, request.Offset, pingDuration)
 
-			if cb := ctx.HeartbeatCB; cb != nil {
-				cb()
+			if cb := ctx.cfg.TestingKnobs.PeriodicClockCheckHook; cb != nil {
+				if err := cb(); err != nil {
+					log.Fatal(ctx.masterCtx, err)
+				}
+			} else {
+				if err := ctx.RemoteClocks.VerifyClockOffset(ctx.masterCtx); err != nil {
+					log.Fatal(ctx.masterCtx, err)
+				}
 			}
 		}
 
-		heartbeatTimer.Reset(ctx.heartbeatInterval)
+		clockCheckTimer.Reset(ctx.cfg.HeartbeatInterval)
 	}
 }

--- a/pkg/security/certs_rotation_test.go
+++ b/pkg/security/certs_rotation_test.go
@@ -84,9 +84,9 @@ func TestRotateCerts(t *testing.T) {
 	}
 
 	// Test client with the same certs.
-	clientContext := testutils.NewNodeTestBaseContext()
-	clientContext.SSLCertsDir = certsDir
-	firstClient, err := clientContext.GetHTTPClient()
+	clientConfig := testutils.NewNodeTestBaseConfig()
+	clientConfig.SSLCertsDir = certsDir
+	firstClient, err := clientConfig.GetHTTPClient()
 	if err != nil {
 		t.Fatalf("could not create http client: %v", err)
 	}
@@ -107,9 +107,9 @@ func TestRotateCerts(t *testing.T) {
 	// Setup a second http client. It will load the new certs.
 	// We need to use a new context as it keeps the certificate manager around.
 	// Fails on crypto errors.
-	clientContext = testutils.NewNodeTestBaseContext()
-	clientContext.SSLCertsDir = certsDir
-	secondClient, err := clientContext.GetHTTPClient()
+	clientConfig = testutils.NewNodeTestBaseConfig()
+	clientConfig.SSLCertsDir = certsDir
+	secondClient, err := clientConfig.GetHTTPClient()
 	if err != nil {
 		t.Fatalf("could not create http client: %v", err)
 	}
@@ -154,9 +154,9 @@ func TestRotateCerts(t *testing.T) {
 	// Setup a third http client. It will load the new certs.
 	// We need to use a new context as it keeps the certificate manager around.
 	// Fails on crypto errors.
-	clientContext = testutils.NewNodeTestBaseContext()
-	clientContext.SSLCertsDir = certsDir
-	thirdClient, err := clientContext.GetHTTPClient()
+	clientConfig = testutils.NewNodeTestBaseConfig()
+	clientConfig.SSLCertsDir = certsDir
+	thirdClient, err := clientConfig.GetHTTPClient()
 	if err != nil {
 		t.Fatalf("could not create http client: %v", err)
 	}

--- a/pkg/security/certs_test.go
+++ b/pkg/security/certs_test.go
@@ -221,7 +221,7 @@ func TestUseCerts(t *testing.T) {
 	defer s.Stopper().Stop(context.TODO())
 
 	// Insecure mode.
-	clientContext := testutils.NewNodeTestBaseContext()
+	clientContext := testutils.NewNodeTestBaseConfig()
 	clientContext.Insecure = true
 	httpClient, err := clientContext.GetHTTPClient()
 	if err != nil {
@@ -239,7 +239,7 @@ func TestUseCerts(t *testing.T) {
 	}
 
 	// New client. With certs this time.
-	clientContext = testutils.NewNodeTestBaseContext()
+	clientContext = testutils.NewNodeTestBaseConfig()
 	clientContext.SSLCertsDir = certsDir
 	httpClient, err = clientContext.GetHTTPClient()
 	if err != nil {

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -189,7 +189,7 @@ func TestAdminDebugRedirect(t *testing.T) {
 	origURL := expURL + "incorrect"
 
 	// There are no particular permissions on admin endpoints, TestUser is fine.
-	client, err := testutils.NewTestBaseContext(TestUser).GetHTTPClient()
+	client, err := testutils.NewTestBaseConfig(TestUser).GetHTTPClient()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/authentication_test.go
+++ b/pkg/server/authentication_test.go
@@ -91,15 +91,15 @@ func TestSSLEnforcement(t *testing.T) {
 	defer s.Stopper().Stop(context.TODO())
 
 	// HTTPS with client certs for security.RootUser.
-	rootCertsContext := testutils.NewTestBaseContext(security.RootUser)
+	rootCertsContext := testutils.NewTestBaseConfig(security.RootUser)
 	// HTTPS with client certs for security.NodeUser.
-	nodeCertsContext := testutils.NewNodeTestBaseContext()
+	nodeCertsContext := testutils.NewNodeTestBaseConfig()
 	// HTTPS with client certs for TestUser.
-	testCertsContext := testutils.NewTestBaseContext(TestUser)
+	testCertsContext := testutils.NewTestBaseConfig(TestUser)
 	// HTTPS without client certs. The user does not matter.
 	noCertsContext := insecureCtx{}
 	// Plain http.
-	insecureContext := testutils.NewTestBaseContext(TestUser)
+	insecureContext := testutils.NewTestBaseConfig(TestUser)
 	insecureContext.Insecure = true
 
 	kvGet := &roachpb.GetRequest{}

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -66,7 +66,14 @@ func createTestNode(
 	cfg := storage.TestStoreConfig(nil)
 
 	stopper := stop.NewStopper()
-	nodeRPCContext := rpc.NewContext(log.AmbientContext{}, nodeTestBaseContext, cfg.Clock, stopper)
+	rpcCfg := rpc.Config{
+		Config: nodeTestBaseContext,
+		Clock:  cfg.Clock,
+		// Disable heartbeats. Not needed for these tests.
+		HeartbeatInterval:     0,
+		EnableClockSkewChecks: false,
+	}
+	nodeRPCContext := rpc.NewContext(log.AmbientContext{}, rpcCfg, stopper)
 	cfg.ScanInterval = 10 * time.Hour
 	cfg.ConsistencyCheckInterval = 10 * time.Hour
 	grpcServer := rpc.NewServer(nodeRPCContext)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -49,7 +49,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var nodeTestBaseContext = testutils.NewNodeTestBaseContext()
+var nodeTestBaseContext = testutils.NewNodeTestBaseConfig()
 
 // TestSelfBootstrap verifies operation when no bootstrap hosts have
 // been specified.
@@ -119,8 +119,9 @@ func TestPlainHTTPServer(t *testing.T) {
 		return getStatusJSONProto(s, "metrics/local", &data)
 	})
 
-	ctx := s.RPCContext()
-	ctx.Insecure = false
+	// Edit the server's config so that it report its admin url using the https
+	// scheme.
+	s.BaseConfig().Insecure = false
 	if err := getStatusJSONProto(s, "metrics/local", &data); !testutils.IsError(err, "http: server gave HTTP response to HTTPS client") {
 		t.Fatalf("unexpected error %v", err)
 	}

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -553,7 +553,12 @@ func TestSpanStatsGRPCResponse(t *testing.T) {
 
 	rpcStopper := stop.NewStopper()
 	defer rpcStopper.Stop(context.TODO())
-	rpcContext := rpc.NewContext(log.AmbientContext{}, ts.RPCContext().Config, ts.Clock(), rpcStopper)
+
+	rpcCfg := rpc.Config{
+		Config: ts.BaseConfig(),
+		Clock:  ts.clock,
+	}
+	rpcContext := rpc.NewContext(log.AmbientContext{}, rpcCfg, rpcStopper)
 	request := serverpb.SpanStatsRequest{
 		NodeID:   "1",
 		StartKey: []byte(roachpb.RKeyMin),
@@ -585,8 +590,11 @@ func TestNodesGRPCResponse(t *testing.T) {
 	ts := startServer(t)
 	defer ts.Stopper().Stop(context.TODO())
 
-	rootConfig := testutils.NewTestBaseContext(security.RootUser)
-	rpcContext := rpc.NewContext(log.AmbientContext{}, rootConfig, ts.Clock(), ts.Stopper())
+	rpcCfg := rpc.Config{
+		Config: testutils.NewTestBaseConfig(security.RootUser),
+		Clock:  ts.clock,
+	}
+	rpcContext := rpc.NewContext(log.AmbientContext{}, rpcCfg, ts.Stopper())
 	var request serverpb.NodesRequest
 
 	url := ts.ServingAddr()

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -471,6 +471,11 @@ func (ts *TestServer) GetFirstStoreID() roachpb.StoreID {
 	return firstStoreID
 }
 
+// BaseConfig is part of TestServerInterface.
+func (ts *TestServer) BaseConfig() *base.Config {
+	return ts.Cfg.Config
+}
+
 // LookupRange returns the descriptor of the range containing key.
 func (ts *TestServer) LookupRange(key roachpb.Key) (roachpb.RangeDescriptor, error) {
 	rangeLookupReq := roachpb.RangeLookupRequest{

--- a/pkg/sql/distsqlrun/outbox_test.go
+++ b/pkg/sql/distsqlrun/outbox_test.go
@@ -386,12 +386,14 @@ func startMockDistSQLServer(stopper *stop.Stopper) (*MockDistSQLServer, net.Addr
 }
 
 func newInsecureRPCContext(stopper *stop.Stopper) *rpc.Context {
-	return rpc.NewContext(
-		log.AmbientContext{},
-		&base.Config{Insecure: true},
-		hlc.NewClock(hlc.UnixNano, time.Nanosecond),
-		stopper,
-	)
+	rpcCfg := rpc.Config{
+		Config: &base.Config{Insecure: true},
+		Clock:  hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		// Disable heartbeats. Not needed for these tests.
+		HeartbeatInterval:     0,
+		EnableClockSkewChecks: false,
+	}
+	return rpc.NewContext(log.AmbientContext{}, rpcCfg, stopper)
 }
 
 // MockDistSQLServer implements the DistSQLServer (gRPC) interface and allows

--- a/pkg/sql/kv_test.go
+++ b/pkg/sql/kv_test.go
@@ -68,7 +68,7 @@ func newKVNative(b *testing.B) kvInterface {
 	}
 
 	return &kvNative{
-		db: client.NewDB(client.NewSender(conn), rpcContext.LocalClock),
+		db: client.NewDB(client.NewSender(conn), s.Clock()),
 		doneFn: func() {
 			s.Stopper().Stop(context.TODO())
 			enableTracing()

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -2194,12 +2194,14 @@ func Example_rebalancing() {
 
 	// Model a set of stores in a cluster,
 	// randomly adding / removing stores and adding bytes.
-	rpcContext := rpc.NewContext(
-		log.AmbientContext{},
-		&base.Config{Insecure: true},
-		clock,
-		stopper,
-	)
+	cfg := rpc.Config{
+		Config:                &base.Config{Insecure: true},
+		Clock:                 clock,
+		HeartbeatInterval:     rpc.ArbitraryServerHeartbeatInterval,
+		HeartbeatTimeout:      rpc.ArbitraryServerHeartbeatTimeout,
+		EnableClockSkewChecks: true,
+	}
+	rpcContext := rpc.NewContext(log.AmbientContext{}, cfg, stopper)
 	server := rpc.NewServer(rpcContext) // never started
 	g := gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry())
 	// Deterministic must be set as this test is comparing the exact output

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -117,7 +117,14 @@ func createTestStoreWithEngine(
 	ac := log.AmbientContext{Tracer: tracer}
 	storeCfg.AmbientCtx = ac
 
-	rpcContext := rpc.NewContext(ac, &base.Config{Insecure: true}, storeCfg.Clock, stopper)
+	rpcCfg := rpc.Config{
+		Config: &base.Config{Insecure: true},
+		Clock:  storeCfg.Clock,
+		// Disable heartbeats. Not needed for these tests.
+		HeartbeatInterval:     0,
+		EnableClockSkewChecks: false,
+	}
+	rpcContext := rpc.NewContext(ac, rpcCfg, stopper)
 	nodeDesc := &roachpb.NodeDescriptor{NodeID: 1}
 	server := rpc.NewServer(rpcContext) // never started
 	storeCfg.Gossip = gossip.NewTest(
@@ -271,15 +278,23 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 		m.transportStopper = stop.NewStopper()
 	}
 	if m.rpcContext == nil {
-		m.rpcContext = rpc.NewContext(log.AmbientContext{}, &base.Config{Insecure: true}, m.clock,
-			m.transportStopper)
-		// Create a breaker which never trips and never backs off to avoid
-		// introducing timing-based flakes.
-		m.rpcContext.BreakerFactory = func() *circuit.Breaker {
-			return circuit.NewBreakerWithOptions(&circuit.Options{
-				BackOff: &backoff.ZeroBackOff{},
-			})
+		rpcCfg := rpc.Config{
+			Config: &base.Config{Insecure: true},
+			Clock:  m.clock,
+			// Disable heartbeats. Not needed for these tests.
+			HeartbeatInterval:     0,
+			EnableClockSkewChecks: false,
+			TestingKnobs: rpc.ContextTestingKnobs{
+				// Create a breaker which never trips and never backs off to avoid
+				// introducing timing-based flakes.
+				BreakerFactory: func() *circuit.Breaker {
+					return circuit.NewBreakerWithOptions(&circuit.Options{
+						BackOff: &backoff.ZeroBackOff{},
+					})
+				},
+			},
 		}
+		m.rpcContext = rpc.NewContext(log.AmbientContext{}, rpcCfg, m.transportStopper)
 	}
 	m.transport = storage.NewRaftTransport(
 		log.AmbientContext{}, m.getNodeIDAddress, nil, m.rpcContext,

--- a/pkg/storage/raft_transport_test.go
+++ b/pkg/storage/raft_transport_test.go
@@ -111,12 +111,14 @@ func newRaftTransportTestContext(t testing.TB) *raftTransportTestContext {
 		stopper:    stop.NewStopper(),
 		transports: map[roachpb.NodeID]*storage.RaftTransport{},
 	}
-	rttc.nodeRPCContext = rpc.NewContext(
-		log.AmbientContext{},
-		testutils.NewNodeTestBaseContext(),
-		hlc.NewClock(hlc.UnixNano, time.Nanosecond),
-		rttc.stopper,
-	)
+	rpcCfg := rpc.Config{
+		Config: testutils.NewNodeTestBaseConfig(),
+		Clock:  hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		// Disable heartbeats. Not needed for these tests.
+		HeartbeatInterval:     0,
+		EnableClockSkewChecks: false,
+	}
+	rttc.nodeRPCContext = rpc.NewContext(log.AmbientContext{}, rpcCfg, rttc.stopper)
 	server := rpc.NewServer(rttc.nodeRPCContext) // never started
 	rttc.gossip = gossip.NewTest(
 		1, rttc.nodeRPCContext, server, rttc.stopper, metric.NewRegistry(),

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -144,7 +144,14 @@ func (tc *testContext) StartWithStoreConfig(t testing.TB, stopper *stop.Stopper,
 	// Setup fake zone config handler.
 	config.TestingSetupZoneConfigHook(stopper)
 	if tc.gossip == nil {
-		rpcContext := rpc.NewContext(cfg.AmbientCtx, &base.Config{Insecure: true}, cfg.Clock, stopper)
+		rpcCfg := rpc.Config{
+			Config:                &base.Config{Insecure: true},
+			Clock:                 cfg.Clock,
+			HeartbeatInterval:     rpc.ArbitraryServerHeartbeatInterval,
+			HeartbeatTimeout:      rpc.ArbitraryServerHeartbeatTimeout,
+			EnableClockSkewChecks: true,
+		}
+		rpcContext := rpc.NewContext(cfg.AmbientCtx, rpcCfg, stopper)
 		server := rpc.NewServer(rpcContext) // never started
 		tc.gossip = gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry())
 	}

--- a/pkg/storage/store_pool_test.go
+++ b/pkg/storage/store_pool_test.go
@@ -94,7 +94,14 @@ func createTestStorePool(
 	stopper := stop.NewStopper()
 	mc := hlc.NewManualClock(123)
 	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
-	rpcContext := rpc.NewContext(log.AmbientContext{}, &base.Config{Insecure: true}, clock, stopper)
+	cfg := rpc.Config{
+		Config:                &base.Config{Insecure: true},
+		Clock:                 clock,
+		HeartbeatInterval:     rpc.ArbitraryServerHeartbeatInterval,
+		HeartbeatTimeout:      rpc.ArbitraryServerHeartbeatTimeout,
+		EnableClockSkewChecks: true,
+	}
+	rpcContext := rpc.NewContext(log.AmbientContext{}, cfg, stopper)
 	server := rpc.NewServer(rpcContext) // never started
 	g := gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry())
 	mnl := newMockNodeLiveness(defaultNodeStatus)

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -121,7 +121,14 @@ func createTestStoreWithoutStart(t testing.TB, stopper *stop.Stopper, cfg *Store
 	// Setup fake zone config handler.
 	config.TestingSetupZoneConfigHook(stopper)
 
-	rpcContext := rpc.NewContext(log.AmbientContext{}, &base.Config{Insecure: true}, cfg.Clock, stopper)
+	rpcCfg := rpc.Config{
+		Config:                &base.Config{Insecure: true},
+		Clock:                 cfg.Clock,
+		HeartbeatInterval:     rpc.ArbitraryServerHeartbeatInterval,
+		HeartbeatTimeout:      rpc.ArbitraryServerHeartbeatTimeout,
+		EnableClockSkewChecks: true,
+	}
+	rpcContext := rpc.NewContext(log.AmbientContext{}, rpcCfg, stopper)
 	server := rpc.NewServer(rpcContext) // never started
 	cfg.Gossip = gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry())
 	cfg.StorePool = NewTestStorePool(*cfg)

--- a/pkg/testutils/base.go
+++ b/pkg/testutils/base.go
@@ -21,15 +21,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 )
 
-// NewNodeTestBaseContext creates a base context for testing. This uses
-// embedded certs and the default node user. The default node user has both
-// server and client certificates.
-func NewNodeTestBaseContext() *base.Config {
-	return NewTestBaseContext(security.NodeUser)
+// NewNodeTestBaseConfig creates a base config for testing. This uses embedded
+// certs and the default node user. The default node user has both server and
+// client certificates.
+func NewNodeTestBaseConfig() *base.Config {
+	return NewTestBaseConfig(security.NodeUser)
 }
 
-// NewTestBaseContext creates a secure base context for user.
-func NewTestBaseContext(user string) *base.Config {
+// NewTestBaseConfig creates a secure base config for user.
+func NewTestBaseConfig(user string) *base.Config {
 	cfg := &base.Config{
 		Insecure: false,
 		User:     user,

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -97,7 +97,14 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initSende
 	ltc.Manual = hlc.NewManualClock(123)
 	ltc.Clock = hlc.NewClock(ltc.Manual.UnixNano, 50*time.Millisecond)
 	ltc.Stopper = stop.NewStopper()
-	rpcContext := rpc.NewContext(ambient, baseCtx, ltc.Clock, ltc.Stopper)
+	rpcCfg := rpc.Config{
+		Config:                baseCtx,
+		Clock:                 ltc.Clock,
+		HeartbeatInterval:     rpc.ArbitraryServerHeartbeatInterval,
+		HeartbeatTimeout:      rpc.ArbitraryServerHeartbeatTimeout,
+		EnableClockSkewChecks: true,
+	}
+	rpcContext := rpc.NewContext(ambient, rpcCfg, ltc.Stopper)
 	server := rpc.NewServer(rpcContext) // never started
 	ltc.Gossip = gossip.New(ambient, nc, rpcContext, server, ltc.Stopper, metric.NewRegistry())
 	ltc.Eng = engine.NewInMem(roachpb.Attributes{}, 50<<20)

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -102,6 +102,10 @@ type TestServerInterface interface {
 	// context client TLS config.
 	GetHTTPClient() (http.Client, error)
 
+	// BaseConfig returns the server's test config. Useful for tests to establish
+	// connections with the same authentication config.
+	BaseConfig() *base.Config
+
 	// MustGetSQLCounter returns the value of a counter metric from the server's
 	// SQL Executor. Runs in O(# of metrics) time, which is fine for test code.
 	MustGetSQLCounter(name string) int64

--- a/pkg/testutils/testcluster/testcluster_test.go
+++ b/pkg/testutils/testcluster/testcluster_test.go
@@ -211,9 +211,15 @@ func TestStopServer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rpcContext := rpc.NewContext(
-		log.AmbientContext{}, tc.Server(1).RPCContext().Config, tc.Server(1).Clock(), tc.Stopper(),
-	)
+	rpcCfg := rpc.Config{
+		Config: tc.Server(1).BaseConfig(),
+		Clock:  tc.Server(1).Clock(),
+		// Disable heartbeats and clock skew checks for this connection that's
+		// outside the cluster.
+		HeartbeatInterval:     0,
+		EnableClockSkewChecks: false,
+	}
+	rpcContext := rpc.NewContext(log.AmbientContext{}, rpcCfg, tc.Stopper())
 	conn, err := rpcContext.GRPCDial(server1.ServingAddr())
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/ts/db_test.go
+++ b/pkg/ts/db_test.go
@@ -78,7 +78,7 @@ func newTestModel(t *testing.T) testModel {
 // Start constructs and starts the local test server and creates a
 // time series DB.
 func (tm *testModel) Start() {
-	tm.LocalTestCluster.Start(tm.t, testutils.NewNodeTestBaseContext(),
+	tm.LocalTestCluster.Start(tm.t, testutils.NewNodeTestBaseConfig(),
 		kv.InitSenderForLocalTestCluster)
 	tm.DB = NewDB(tm.LocalTestCluster.DB)
 }


### PR DESCRIPTION
The rpc.Context does several things:
1) Acts as a utility for opening and caching gRPC connections.
2) Performs periodic "heartbeats" on the open connections and maintains
a health status for each remote address. That status can be queries and
is used to de-prioritize unhealthy replicas.
3) Performs periodic clock skew detection, piggybacking clock signals on
the heartbeats.

Not all clients of the rpc.Context need 2 and 3. In particular, RPC
clients that are "outside of a cluster" (i.e. are not nodes) don't need
to participate in clock skew detection and may or may not want to do the
heartbeats. The fact that they were always performing clock detection
was leading to corrupted state in the RemoteClockMonitor, which was
recording clock info for an "unresolved" remote address (port=0) for
RPC clients that had not been configured with an address. This patch
asserts that we don't do that any more.

The patch makes everything that the rpc.Context does configurable and
uses proper configurations in tests.