### PR TITLE
base: stop sharing base.Config

### DIFF
--- a/pkg/acceptance/cluster/localcluster.go
+++ b/pkg/acceptance/cluster/localcluster.go
@@ -785,7 +785,7 @@ func (l *LocalCluster) stop(ctx context.Context) {
 func (l *LocalCluster) NewClient(ctx context.Context, i int) (*roachClient.DB, error) {
 	clock := hlc.NewClock(hlc.UnixNano, 0)
 	rpcCfg := rpc.ContextConfig{
-		Config: &base.Config{
+		Config: base.Config{
 			User:       security.NodeUser,
 			SSLCA:      filepath.Join(l.CertsDir, security.EmbeddedCACert),
 			SSLCert:    filepath.Join(l.CertsDir, security.EmbeddedNodeCert),

--- a/pkg/acceptance/util.go
+++ b/pkg/acceptance/util.go
@@ -268,7 +268,7 @@ func MakeFarmer(t testing.TB, prefix string, stopper *stop.Stopper) *terrafarm.F
 	}
 
 	rpcCfg := rpc.ContextConfig{
-		Config: &base.Config{
+		Config: base.Config{
 			Insecure: true,
 			User:     security.NodeUser,
 		},

--- a/pkg/acceptance/util.go
+++ b/pkg/acceptance/util.go
@@ -267,10 +267,17 @@ func MakeFarmer(t testing.TB, prefix string, stopper *stop.Stopper) *terrafarm.F
 		t.Fatalf("generated cluster name '%s' must match regex %s", name, prefixRE)
 	}
 
-	rpcContext := rpc.NewContext(log.AmbientContext{}, &base.Config{
-		Insecure: true,
-		User:     security.NodeUser,
-	}, hlc.NewClock(hlc.UnixNano, 0), stopper)
+	rpcCfg := rpc.ContextConfig{
+		Config: &base.Config{
+			Insecure: true,
+			User:     security.NodeUser,
+		},
+		HLCClock:              hlc.NewClock(hlc.UnixNano, 0),
+		HeartbeatInterval:     time.Second,
+		HeartbeatTimeout:      time.Second,
+		EnableClockSkewChecks: true,
+	}
+	rpcContext := rpc.NewContext(log.AmbientContext{}, rpcCfg, stopper)
 
 	f := &terrafarm.Farmer{
 		Output:      os.Stderr,

--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -18,19 +18,14 @@ package base
 
 import (
 	"crypto/tls"
-	"fmt"
 	"net/http"
-	"net/url"
-	"os"
-	"path/filepath"
 	"sync"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/pkg/errors"
 )
 
 // Base config defaults.
@@ -40,35 +35,12 @@ const (
 	httpScheme      = "http"
 	httpsScheme     = "https"
 
-	// From IANA Service Name and Transport Protocol Port Number Registry. See
-	// https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=cockroachdb
-	DefaultPort = "26257"
-
-	// The default port for HTTP-for-humans.
-	DefaultHTTPPort = "8080"
-
-	// NB: net.JoinHostPort is not a constant.
-	defaultAddr     = ":" + DefaultPort
-	defaultHTTPAddr = ":" + DefaultHTTPPort
-
 	// NetworkTimeout is the timeout used for network operations.
 	NetworkTimeout = 3 * time.Second
 
 	// DefaultRaftTickInterval is the default resolution of the Raft timer.
 	DefaultRaftTickInterval = 200 * time.Millisecond
 )
-
-type lazyTLSConfig struct {
-	once      sync.Once
-	tlsConfig *tls.Config
-	err       error
-}
-
-type lazyHTTPClient struct {
-	once       sync.Once
-	httpClient http.Client
-	err        error
-}
 
 // Config is embedded by server.Config. A base config is not meant to be used
 // directly, but embedding configs should call cfg.InitDefaults().
@@ -87,31 +59,6 @@ type Config struct {
 	// the server is running or the user passed in client calls.
 	User string
 
-	// Addr is the address the server is listening on.
-	Addr string
-
-	// AdvertiseAddr is the address advertised by the server to other nodes
-	// in the cluster. It should be reachable by all other nodes and should
-	// route to an interface that Addr is listening on.
-	AdvertiseAddr string
-
-	// HTTPAddr is server's public HTTP address.
-	//
-	// This is temporary, and will be removed when grpc.(*Server).ServeHTTP
-	// performance problems are addressed upstream.
-	//
-	// See https://github.com/grpc/grpc-go/issues/586.
-	HTTPAddr string
-
-	// clientTLSConfig is the loaded client TLS config. It is initialized lazily.
-	clientTLSConfig lazyTLSConfig
-
-	// serverTLSConfig is the loaded server TLS config. It is initialized lazily.
-	serverTLSConfig lazyTLSConfig
-
-	// httpClient uses the client TLS config. It is initialized lazily.
-	httpClient lazyHTTPClient
-
 	// HistogramWindowInterval is used to determine the approximate length of time
 	// that individual samples are retained in in-memory histograms. Currently,
 	// it is set to the arbitrary length of six times the Metrics sample interval.
@@ -123,9 +70,6 @@ type Config struct {
 func (cfg *Config) InitDefaults() {
 	cfg.Insecure = defaultInsecure
 	cfg.User = defaultUser
-	cfg.Addr = defaultAddr
-	cfg.AdvertiseAddr = cfg.Addr
-	cfg.HTTPAddr = defaultHTTPAddr
 }
 
 // HTTPRequestScheme returns "http" or "https" based on the value of Insecure.
@@ -134,132 +78,6 @@ func (cfg *Config) HTTPRequestScheme() string {
 		return httpScheme
 	}
 	return httpsScheme
-}
-
-// AdminURL returns the URL for the admin UI.
-func (cfg *Config) AdminURL() string {
-	return fmt.Sprintf("%s://%s", cfg.HTTPRequestScheme(), cfg.HTTPAddr)
-}
-
-// PGURL returns the URL for the postgres endpoint.
-func (cfg *Config) PGURL(user *url.Userinfo) (*url.URL, error) {
-	// Try to convert path to an absolute path. Failing to do so return path
-	// unchanged.
-	absPath := func(path string) string {
-		r, err := filepath.Abs(path)
-		if err != nil {
-			return path
-		}
-		return r
-	}
-
-	options := url.Values{}
-	if cfg.Insecure {
-		options.Add("sslmode", "disable")
-	} else {
-		if cfg.SSLCA == "" {
-			return nil, fmt.Errorf("missing --%s flag", cliflags.CACert.Name)
-		}
-
-		// Check that cfg.SSLCert and cfg.SSLCertKey are either both empty or
-		// both non-empty.
-		// If both are provided, the server will authenticate the client using
-		// certificate authentication. If not, password authentication will be
-		// used.
-		if cfg.SSLCert == "" && cfg.SSLCertKey != "" {
-			return nil, fmt.Errorf("missing --%s flag", cliflags.Cert.Name)
-		}
-		if cfg.SSLCertKey == "" && cfg.SSLCert != "" {
-			return nil, fmt.Errorf("missing --%s flag", cliflags.Key.Name)
-		}
-
-		options.Add("sslmode", "verify-full")
-		sslFlags := []struct {
-			name     string
-			value    string
-			flagName string
-		}{
-			{"sslcert", cfg.SSLCert, cliflags.Cert.Name},
-			{"sslkey", cfg.SSLCertKey, cliflags.Key.Name},
-			{"sslrootcert", cfg.SSLCA, cliflags.CACert.Name},
-		}
-
-		for _, c := range sslFlags {
-			if c.value == "" {
-				continue
-			}
-			path := absPath(c.value)
-			if _, err := os.Stat(path); err != nil {
-				return nil, fmt.Errorf("file for --%s flag gave error: %v", c.flagName, err)
-			}
-			options.Add(c.name, path)
-		}
-	}
-	return &url.URL{
-		Scheme:   "postgresql",
-		User:     user,
-		Host:     cfg.AdvertiseAddr,
-		RawQuery: options.Encode(),
-	}, nil
-}
-
-// GetClientTLSConfig returns the client TLS config, initializing it if needed.
-// If Insecure is true, return a nil config, otherwise load a config based
-// on the SSLCert file. If SSLCert is empty, use a very permissive config.
-// TODO(marc): empty SSLCert should fail when client certificates are required.
-func (cfg *Config) GetClientTLSConfig() (*tls.Config, error) {
-	// Early out.
-	if cfg.Insecure {
-		return nil, nil
-	}
-
-	cfg.clientTLSConfig.once.Do(func() {
-		cfg.clientTLSConfig.tlsConfig, cfg.clientTLSConfig.err = security.LoadClientTLSConfig(
-			cfg.SSLCA, cfg.SSLCert, cfg.SSLCertKey)
-		if cfg.clientTLSConfig.err != nil {
-			cfg.clientTLSConfig.err = errors.Errorf("error setting up client TLS config: %s", cfg.clientTLSConfig.err)
-		}
-	})
-
-	return cfg.clientTLSConfig.tlsConfig, cfg.clientTLSConfig.err
-}
-
-// GetServerTLSConfig returns the server TLS config, initializing it if needed.
-// If Insecure is true, return a nil config, otherwise load a config based
-// on the SSLCert file. Fails if Insecure=false and SSLCert="".
-func (cfg *Config) GetServerTLSConfig() (*tls.Config, error) {
-	// Early out.
-	if cfg.Insecure {
-		return nil, nil
-	}
-
-	cfg.serverTLSConfig.once.Do(func() {
-		if cfg.SSLCert != "" {
-			cfg.serverTLSConfig.tlsConfig, cfg.serverTLSConfig.err = security.LoadServerTLSConfig(
-				cfg.SSLCA, cfg.SSLCert, cfg.SSLCertKey)
-			if cfg.serverTLSConfig.err != nil {
-				cfg.serverTLSConfig.err = errors.Errorf("error setting up server TLS config: %s", cfg.serverTLSConfig.err)
-			}
-		} else {
-			cfg.serverTLSConfig.err = errors.Errorf("--%s=false, but --%s is empty. Certificates must be specified.",
-				cliflags.Insecure.Name, cliflags.Cert.Name)
-		}
-	})
-
-	return cfg.serverTLSConfig.tlsConfig, cfg.serverTLSConfig.err
-}
-
-// GetHTTPClient returns the http client, initializing it
-// if needed. It uses the client TLS config.
-func (cfg *Config) GetHTTPClient() (http.Client, error) {
-	cfg.httpClient.once.Do(func() {
-		cfg.httpClient.httpClient.Timeout = NetworkTimeout
-		var transport http.Transport
-		cfg.httpClient.httpClient.Transport = &transport
-		transport.TLSClientConfig, cfg.httpClient.err = cfg.GetClientTLSConfig()
-	})
-
-	return cfg.httpClient.httpClient, cfg.httpClient.err
 }
 
 // DefaultRetryOptions should be used for retrying most
@@ -273,4 +91,96 @@ func DefaultRetryOptions() retry.Options {
 		MaxBackoff:     5 * time.Second,
 		Multiplier:     2,
 	}
+}
+
+// ConnectingHelper helps with making network requests using the authentication
+// information from a Config.
+type ConnectingHelper struct {
+	cfg Config
+
+	// clientTLSConfig is the loaded client TLS config. It is initialized lazily.
+	clientTLSConfig lazyTLSConfig
+
+	// serverTLSConfig is the loaded server TLS config. It is initialized lazily.
+	serverTLSConfig lazyTLSConfig
+
+	// httpClient uses the client TLS config. It is initialized lazily.
+	httpClient lazyHTTPClient
+}
+
+// NewConnectingHelper creates a ConnectingHelper.
+func NewConnectingHelper(cfg Config) *ConnectingHelper {
+	return &ConnectingHelper{cfg: cfg}
+}
+
+// GetClientTLSConfig returns the client TLS config, initializing it if needed.
+// If Insecure is true, return a nil config, otherwise load a config based
+// on the SSLCert file. If SSLCert is empty, use a very permissive config.
+// TODO(marc): empty SSLCert should fail when client certificates are required.
+func (c *ConnectingHelper) GetClientTLSConfig() (*tls.Config, error) {
+	// Early out.
+	if c.cfg.Insecure {
+		return nil, nil
+	}
+
+	c.clientTLSConfig.once.Do(func() {
+		c.clientTLSConfig.tlsConfig, c.clientTLSConfig.err = security.LoadClientTLSConfig(
+			c.cfg.SSLCA, c.cfg.SSLCert, c.cfg.SSLCertKey)
+		if c.clientTLSConfig.err != nil {
+			c.clientTLSConfig.err = errors.Errorf(
+				"error setting up client TLS config: %s", c.clientTLSConfig.err)
+		}
+	})
+
+	return c.clientTLSConfig.tlsConfig, c.clientTLSConfig.err
+}
+
+// GetServerTLSConfig returns the server TLS config, initializing it if needed.
+// If Insecure is true, return a nil config, otherwise load a config based
+// on the SSLCert file. Fails if Insecure=false and SSLCert="".
+func (c *ConnectingHelper) GetServerTLSConfig() (*tls.Config, error) {
+	// Early out.
+	if c.cfg.Insecure {
+		return nil, nil
+	}
+
+	c.serverTLSConfig.once.Do(func() {
+		if c.cfg.SSLCert != "" {
+			c.serverTLSConfig.tlsConfig, c.serverTLSConfig.err = security.LoadServerTLSConfig(
+				c.cfg.SSLCA, c.cfg.SSLCert, c.cfg.SSLCertKey)
+			if c.serverTLSConfig.err != nil {
+				c.serverTLSConfig.err = errors.Errorf("error setting up server TLS config: %s", c.serverTLSConfig.err)
+			}
+		} else {
+			c.serverTLSConfig.err = errors.Errorf("--%s=false, but --%s is empty. Certificates must be specified.",
+				cliflags.Insecure.Name, cliflags.Cert.Name)
+		}
+	})
+
+	return c.serverTLSConfig.tlsConfig, c.serverTLSConfig.err
+}
+
+// GetHTTPClient returns the http client, initializing it
+// if needed. It uses the client TLS config.
+func (c *ConnectingHelper) GetHTTPClient() (http.Client, error) {
+	c.httpClient.once.Do(func() {
+		c.httpClient.httpClient.Timeout = NetworkTimeout
+		var transport http.Transport
+		c.httpClient.httpClient.Transport = &transport
+		transport.TLSClientConfig, c.httpClient.err = c.GetClientTLSConfig()
+	})
+
+	return c.httpClient.httpClient, c.httpClient.err
+}
+
+type lazyTLSConfig struct {
+	once      sync.Once
+	tlsConfig *tls.Config
+	err       error
+}
+
+type lazyHTTPClient struct {
+	once       sync.Once
+	httpClient http.Client
+	err        error
 }

--- a/pkg/base/config_test.go
+++ b/pkg/base/config_test.go
@@ -59,14 +59,15 @@ func TestClientSSLSettings(t *testing.T) {
 	}
 
 	for tcNum, tc := range testCases {
-		cfg := &base.Config{Insecure: tc.insecure, User: tc.user}
+		cfg := base.Config{Insecure: tc.insecure, User: tc.user}
 		if tc.hasCerts {
-			fillCertPaths(cfg, tc.user)
+			fillCertPaths(&cfg, tc.user)
 		}
 		if cfg.HTTPRequestScheme() != tc.requestScheme {
 			t.Fatalf("#%d: expected HTTPRequestScheme=%s, got: %s", tcNum, tc.requestScheme, cfg.HTTPRequestScheme())
 		}
-		tlsConfig, err := cfg.GetClientTLSConfig()
+		connHelper := base.NewConnectingHelper(cfg)
+		tlsConfig, err := connHelper.GetClientTLSConfig()
 		if !testutils.IsError(err, tc.configErr) {
 			t.Fatalf("#%d: expected err=%s, got err=%v", tcNum, tc.configErr, err)
 		}
@@ -104,14 +105,15 @@ func TestServerSSLSettings(t *testing.T) {
 	}
 
 	for tcNum, tc := range testCases {
-		cfg := &base.Config{Insecure: tc.insecure, User: security.NodeUser}
+		cfg := base.Config{Insecure: tc.insecure, User: security.NodeUser}
 		if tc.hasCerts {
-			fillCertPaths(cfg, security.NodeUser)
+			fillCertPaths(&cfg, security.NodeUser)
 		}
 		if cfg.HTTPRequestScheme() != tc.requestScheme {
 			t.Fatalf("#%d: expected HTTPRequestScheme=%s, got: %s", tcNum, tc.requestScheme, cfg.HTTPRequestScheme())
 		}
-		tlsConfig, err := cfg.GetServerTLSConfig()
+		connHelper := base.NewConnectingHelper(cfg)
+		tlsConfig, err := connHelper.GetServerTLSConfig()
 		if (err == nil) != tc.configSuccess {
 			t.Fatalf("#%d: expected GetServerTLSConfig success=%t, got err=%v", tcNum, tc.configSuccess, err)
 		}

--- a/pkg/base/constants.go
+++ b/pkg/base/constants.go
@@ -19,6 +19,14 @@ package base
 import "time"
 
 const (
+	// DefaultPort is CRDB's default pgwire and RPC port.
+	// From IANA Service Name and Transport Protocol Port Number Registry. See
+	// https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=cockroachdb
+	DefaultPort = "26257"
+
+	// DefaultHTTPPort is the default port for HTTP-for-humans.
+	DefaultHTTPPort = "8080"
+
 	// DefaultHeartbeatInterval is how often heartbeats are sent from the
 	// transaction coordinator to a live transaction. These keep it from
 	// being preempted by other transactions writing the same keys. If a

--- a/pkg/base/testing_knobs.go
+++ b/pkg/base/testing_knobs.go
@@ -30,4 +30,5 @@ type TestingKnobs struct {
 	SQLLeaseManager  ModuleTestingKnobs
 	SQLSchemaChanger ModuleTestingKnobs
 	DistSQL          ModuleTestingKnobs
+	RPCContext       ModuleTestingKnobs
 }

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 )
 
@@ -44,8 +44,8 @@ func (s *statementsValue) Set(value string) error {
 }
 
 type cliContext struct {
-	// Embed the base context.
-	*base.Config
+	// Embed the server context. The CLI needs to talk to a server.
+	*server.Config
 
 	// tableDisplayFormat indicates how to format result tables.
 	tableDisplayFormat tableDisplayFormat

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -49,8 +49,8 @@ var startBackground bool
 var undoFreezeCluster bool
 
 var serverCfg = server.MakeConfig()
-var baseCfg = serverCfg.Config
-var cliCtx = cliContext{Config: baseCfg}
+var baseCfg = &serverCfg.Config
+var cliCtx = cliContext{Config: &serverCfg}
 var sqlCtx = sqlContext{cliContext: &cliCtx}
 var dumpCtx = dumpContext{cliContext: &cliCtx, dumpMode: dumpBoth}
 var debugCtx = debugContext{

--- a/pkg/cli/kv.go
+++ b/pkg/cli/kv.go
@@ -35,7 +35,7 @@ import (
 )
 
 func addrWithDefaultHost(addr string) (string, error) {
-	host, port, err := net.SplitHostPort(baseCfg.Addr)
+	host, port, err := net.SplitHostPort(serverCfg.Addr)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -537,17 +537,18 @@ func rerunBackground() error {
 }
 
 func getGRPCConn() (*grpc.ClientConn, *hlc.Clock, *stop.Stopper, error) {
-	// 0 to disable max offset checks; this RPC context is not a member of the
-	// cluster, so there's no need to enforce that its max offset is the same
-	// as that of nodes in the cluster.
 	clock := hlc.NewClock(hlc.UnixNano, 0)
 	stopper := stop.NewStopper()
-	rpcContext := rpc.NewContext(
-		log.AmbientContext{},
-		serverCfg.Config,
-		clock,
-		stopper,
-	)
+	rpcContextCfg := rpc.ContextConfig{
+		Config:   serverCfg.Config,
+		HLCClock: clock,
+		// Disable heartbeats and clock skew checks. The CLI is not a member of the
+		// cluster, so there's no need to enforce that its max offset is the same as
+		// that of nodes in the cluster.
+		HeartbeatInterval:     0,
+		EnableClockSkewChecks: false,
+	}
+	rpcContext := rpc.NewContext(log.AmbientContext{}, rpcContextCfg, stopper)
 	addr, err := addrWithDefaultHost(serverCfg.AdvertiseAddr)
 	if err != nil {
 		return nil, nil, nil, err

--- a/pkg/cli/start_test.go
+++ b/pkg/cli/start_test.go
@@ -27,7 +27,7 @@ func TestInitInsecure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	f := startCmd.Flags()
-	ctx := serverCfg
+	ctx := &serverCfg
 
 	testCases := []struct {
 		args     []string
@@ -53,21 +53,23 @@ func TestInitInsecure(t *testing.T) {
 		{[]string{"--host", "", "--advertise-host", ""}, true, ""},
 	}
 	for i, c := range testCases {
-		// Reset the context and insecure flag for every test case.
-		ctx.InitDefaults()
-		ctx.Insecure = true
-		insecure.isSet = false
+		t.Run("", func(t *testing.T) {
+			// Reset the context and insecure flag for every test case.
+			ctx.InitDefaults()
+			ctx.Insecure = true
+			insecure.isSet = false
 
-		if err := f.Parse(c.args); err != nil {
-			t.Fatal(err)
-		}
-		if c.insecure != ctx.Insecure {
-			t.Fatalf("%d: expected %v, but found %v", i, c.insecure, ctx.Insecure)
-		}
+			if err := f.Parse(c.args); err != nil {
+				t.Fatal(err)
+			}
+			if c.insecure != ctx.Insecure {
+				t.Fatalf("%d: expected %v, but found %v", i, c.insecure, ctx.Insecure)
+			}
 
-		err := initInsecure()
-		if !testutils.IsError(err, c.expected) {
-			t.Fatalf("%d: expected %q, but found %v", i, c.expected, err)
-		}
+			err := initInsecure()
+			if !testutils.IsError(err, c.expected) {
+				t.Fatalf("%d: expected %q, but found %v", i, c.expected, err)
+			}
+		})
 	}
 }

--- a/pkg/cmd/internal/localcluster/localcluster.go
+++ b/pkg/cmd/internal/localcluster/localcluster.go
@@ -116,8 +116,14 @@ func (c *Cluster) Start(
 		User:     security.NodeUser,
 		Insecure: true,
 	}
-	c.rpcCtx = rpc.NewContext(log.AmbientContext{}, baseCtx,
-		hlc.NewClock(hlc.UnixNano, 0), c.stopper)
+	rpcCfg := rpc.ContextConfig{
+		Config:                baseCtx,
+		HLCClock:              hlc.NewClock(hlc.UnixNano, 0),
+		HeartbeatInterval:     time.Second,
+		HeartbeatTimeout:      time.Second,
+		EnableClockSkewChecks: true,
+	}
+	c.rpcCtx = rpc.NewContext(log.AmbientContext{}, rpcCfg, c.stopper)
 
 	if perNodeArgs != nil && len(perNodeArgs) != len(c.Nodes) {
 		panic(fmt.Sprintf("there are %d nodes, but perNodeArgs' length is %d",

--- a/pkg/cmd/internal/localcluster/localcluster.go
+++ b/pkg/cmd/internal/localcluster/localcluster.go
@@ -112,16 +112,15 @@ func (c *Cluster) Start(
 ) {
 	c.started = timeutil.Now()
 
-	baseCtx := &base.Config{
-		User:     security.NodeUser,
-		Insecure: true,
-	}
 	rpcCfg := rpc.ContextConfig{
-		Config:                baseCtx,
-		HLCClock:              hlc.NewClock(hlc.UnixNano, 0),
-		HeartbeatInterval:     time.Second,
-		HeartbeatTimeout:      time.Second,
-		EnableClockSkewChecks: true,
+		Config: base.Config{
+			User:     security.NodeUser,
+			Insecure: true,
+		},
+		HLCClock: hlc.NewClock(hlc.UnixNano, 0),
+		// Disable heartbeats for this client external to the cluster.
+		HeartbeatInterval:     0,
+		EnableClockSkewChecks: false,
 	}
 	c.rpcCtx = rpc.NewContext(log.AmbientContext{}, rpcCfg, c.stopper)
 

--- a/pkg/gossip/client_test.go
+++ b/pkg/gossip/client_test.go
@@ -49,12 +49,14 @@ func startGossip(
 }
 
 func newInsecureRPCContext(stopper *stop.Stopper) *rpc.Context {
-	return rpc.NewContext(
-		log.AmbientContext{},
-		&base.Config{Insecure: true},
-		hlc.NewClock(hlc.UnixNano, time.Nanosecond),
-		stopper,
-	)
+	cfg := rpc.ContextConfig{
+		Config:                &base.Config{Insecure: true},
+		HLCClock:              hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		HeartbeatInterval:     time.Second,
+		HeartbeatTimeout:      time.Second,
+		EnableClockSkewChecks: true,
+	}
+	return rpc.NewContext(log.AmbientContext{}, cfg, stopper)
 }
 
 func startGossipAtAddr(

--- a/pkg/gossip/client_test.go
+++ b/pkg/gossip/client_test.go
@@ -50,11 +50,11 @@ func startGossip(
 
 func newInsecureRPCContext(stopper *stop.Stopper) *rpc.Context {
 	cfg := rpc.ContextConfig{
-		Config:                &base.Config{Insecure: true},
-		HLCClock:              hlc.NewClock(hlc.UnixNano, time.Nanosecond),
-		HeartbeatInterval:     time.Second,
-		HeartbeatTimeout:      time.Second,
-		EnableClockSkewChecks: true,
+		Config:   base.Config{Insecure: true},
+		HLCClock: hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		// Disable heartbeats. Not needed for these tests.
+		HeartbeatInterval:     0,
+		EnableClockSkewChecks: false,
 	}
 	return rpc.NewContext(log.AmbientContext{}, cfg, stopper)
 }

--- a/pkg/gossip/simulation/network.go
+++ b/pkg/gossip/simulation/network.go
@@ -72,14 +72,16 @@ func NewNetwork(stopper *stop.Stopper, nodeCount int, createResolvers bool) *Net
 		Nodes:   []*Node{},
 		Stopper: stopper,
 	}
-	n.rpcContext = rpc.NewContext(
-		log.AmbientContext{},
-		&base.Config{Insecure: true},
-		hlc.NewClock(hlc.UnixNano, time.Nanosecond),
-		n.Stopper,
-	)
+	cfg := rpc.ContextConfig{
+		Config:                &base.Config{Insecure: true},
+		HLCClock:              hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		HeartbeatInterval:     time.Second,
+		HeartbeatTimeout:      time.Second,
+		EnableClockSkewChecks: true,
+	}
+	n.rpcContext = rpc.NewContext(log.AmbientContext{}, cfg, n.Stopper)
 	var err error
-	n.tlsConfig, err = n.rpcContext.GetServerTLSConfig()
+	n.tlsConfig, err = cfg.GetServerTLSConfig()
 	if err != nil {
 		log.Fatal(context.TODO(), err)
 	}

--- a/pkg/gossip/simulation/network.go
+++ b/pkg/gossip/simulation/network.go
@@ -73,15 +73,16 @@ func NewNetwork(stopper *stop.Stopper, nodeCount int, createResolvers bool) *Net
 		Stopper: stopper,
 	}
 	cfg := rpc.ContextConfig{
-		Config:                &base.Config{Insecure: true},
-		HLCClock:              hlc.NewClock(hlc.UnixNano, time.Nanosecond),
-		HeartbeatInterval:     time.Second,
-		HeartbeatTimeout:      time.Second,
-		EnableClockSkewChecks: true,
+		Config:   base.Config{Insecure: true},
+		HLCClock: hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		// Disable heartbeats; not needed for simulations and, if we'd enable them,
+		// we'd need to set an Addr.
+		HeartbeatInterval:     0,
+		EnableClockSkewChecks: false,
 	}
 	n.rpcContext = rpc.NewContext(log.AmbientContext{}, cfg, n.Stopper)
 	var err error
-	n.tlsConfig, err = cfg.GetServerTLSConfig()
+	n.tlsConfig, err = base.NewConnectingHelper(cfg.Config).GetServerTLSConfig()
 	if err != nil {
 		log.Fatal(context.TODO(), err)
 	}

--- a/pkg/internal/client/client_test.go
+++ b/pkg/internal/client/client_test.go
@@ -126,16 +126,16 @@ func createTestClientForUser(
 	t *testing.T, s serverutils.TestServerInterface, user string, dbCtx client.DBContext,
 ) *client.DB {
 	rpcCfg := rpc.ContextConfig{
-		Config: &base.Config{
+		Config: base.Config{
 			User:       user,
 			SSLCA:      filepath.Join(security.EmbeddedCertsDir, security.EmbeddedCACert),
 			SSLCert:    filepath.Join(security.EmbeddedCertsDir, fmt.Sprintf("%s.crt", user)),
 			SSLCertKey: filepath.Join(security.EmbeddedCertsDir, fmt.Sprintf("%s.key", user)),
 		},
-		HLCClock:              s.Clock(),
-		HeartbeatInterval:     time.Second,
-		HeartbeatTimeout:      time.Second,
-		EnableClockSkewChecks: true,
+		HLCClock: s.Clock(),
+		// Disable heartbeats. Not needed for these tests.
+		HeartbeatInterval:     0,
+		EnableClockSkewChecks: false,
 	}
 	rpcContext := rpc.NewContext(log.AmbientContext{}, rpcCfg, s.Stopper())
 	conn, err := rpcContext.GRPCDial(s.ServingAddr())

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -54,7 +54,6 @@ var allExternalMethods = [...]roachpb.Request{
 // A DBServer provides an HTTP server endpoint serving the key-value API.
 // It accepts either JSON or serialized protobuf content types.
 type DBServer struct {
-	context *base.Config
 	sender  client.Sender
 	stopper *stop.Stopper
 }
@@ -62,7 +61,6 @@ type DBServer struct {
 // NewDBServer allocates and returns a new DBServer.
 func NewDBServer(ctx *base.Config, sender client.Sender, stopper *stop.Stopper) *DBServer {
 	return &DBServer{
-		context: ctx,
 		sender:  sender,
 		stopper: stopper,
 	}

--- a/pkg/kv/db_test.go
+++ b/pkg/kv/db_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -53,7 +54,14 @@ func createTestClientForUser(
 	ctx.SSLCA = filepath.Join(security.EmbeddedCertsDir, security.EmbeddedCACert)
 	ctx.SSLCert = filepath.Join(security.EmbeddedCertsDir, fmt.Sprintf("%s.crt", user))
 	ctx.SSLCertKey = filepath.Join(security.EmbeddedCertsDir, fmt.Sprintf("%s.key", user))
-	conn, err := rpc.NewContext(log.AmbientContext{}, &ctx, s.Clock(), s.Stopper()).GRPCDial(s.ServingAddr())
+	cfg := rpc.ContextConfig{
+		Config:                &ctx,
+		HLCClock:              s.Clock(),
+		HeartbeatInterval:     time.Second,
+		HeartbeatTimeout:      time.Second,
+		EnableClockSkewChecks: true,
+	}
+	conn, err := rpc.NewContext(log.AmbientContext{}, cfg, s.Stopper()).GRPCDial(s.ServingAddr())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kv/db_test.go
+++ b/pkg/kv/db_test.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"golang.org/x/net/context"
 
@@ -55,11 +54,11 @@ func createTestClientForUser(
 	ctx.SSLCert = filepath.Join(security.EmbeddedCertsDir, fmt.Sprintf("%s.crt", user))
 	ctx.SSLCertKey = filepath.Join(security.EmbeddedCertsDir, fmt.Sprintf("%s.key", user))
 	cfg := rpc.ContextConfig{
-		Config:                &ctx,
-		HLCClock:              s.Clock(),
-		HeartbeatInterval:     time.Second,
-		HeartbeatTimeout:      time.Second,
-		EnableClockSkewChecks: true,
+		Config:   ctx,
+		HLCClock: s.Clock(),
+		// Disable the heartbeats. Not needed for these tests.
+		HeartbeatInterval:     0,
+		EnableClockSkewChecks: false,
 	}
 	conn, err := rpc.NewContext(log.AmbientContext{}, cfg, s.Stopper()).GRPCDial(s.ServingAddr())
 	if err != nil {

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -577,7 +577,7 @@ func TestRetryOnDescriptorLookupError(t *testing.T) {
 func makeGossip(t *testing.T, stopper *stop.Stopper) (*gossip.Gossip, *hlc.Clock) {
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	cfg := rpc.ContextConfig{
-		Config:                &base.Config{Insecure: true},
+		Config:                base.Config{Insecure: true},
 		HLCClock:              clock,
 		HeartbeatInterval:     time.Second,
 		HeartbeatTimeout:      time.Second,

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -576,12 +576,14 @@ func TestRetryOnDescriptorLookupError(t *testing.T) {
 
 func makeGossip(t *testing.T, stopper *stop.Stopper) (*gossip.Gossip, *hlc.Clock) {
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	rpcContext := rpc.NewContext(
-		log.AmbientContext{},
-		&base.Config{Insecure: true},
-		clock,
-		stopper,
-	)
+	cfg := rpc.ContextConfig{
+		Config:                &base.Config{Insecure: true},
+		HLCClock:              clock,
+		HeartbeatInterval:     time.Second,
+		HeartbeatTimeout:      time.Second,
+		EnableClockSkewChecks: true,
+	}
+	rpcContext := rpc.NewContext(log.AmbientContext{}, cfg, stopper)
 	server := rpc.NewServer(rpcContext)
 
 	const nodeID = 1

--- a/pkg/kv/send_test.go
+++ b/pkg/kv/send_test.go
@@ -42,9 +42,14 @@ import (
 // newNodeTestContext returns a rpc.Context for testing.
 // It is meant to be used by nodes.
 func newNodeTestContext(clock *hlc.Clock, stopper *stop.Stopper) *rpc.Context {
-	ctx := rpc.NewContext(log.AmbientContext{}, testutils.NewNodeTestBaseContext(), clock, stopper)
-	ctx.HeartbeatInterval = 10 * time.Millisecond
-	ctx.HeartbeatTimeout = 5 * time.Second
+	cfg := rpc.ContextConfig{
+		Config:                testutils.NewNodeTestBaseConfig(),
+		HLCClock:              clock,
+		HeartbeatInterval:     10 * time.Millisecond,
+		HeartbeatTimeout:      5 * time.Second,
+		EnableClockSkewChecks: true,
+	}
+	ctx := rpc.NewContext(log.AmbientContext{}, cfg, stopper)
 	return ctx
 }
 

--- a/pkg/kv/send_test.go
+++ b/pkg/kv/send_test.go
@@ -43,8 +43,11 @@ import (
 // It is meant to be used by nodes.
 func newNodeTestContext(clock *hlc.Clock, stopper *stop.Stopper) *rpc.Context {
 	cfg := rpc.ContextConfig{
-		Config:                testutils.NewNodeTestBaseConfig(),
-		HLCClock:              clock,
+		Config:   testutils.MakeNodeTestBaseConfig(),
+		HLCClock: clock,
+		// Enable heartbeats. Some of the tests require the health check
+		// functionality. This forces us to set a bogus Addr.
+		Addr:                  "127.0.0.1:4242",
 		HeartbeatInterval:     10 * time.Millisecond,
 		HeartbeatTimeout:      5 * time.Second,
 		EnableClockSkewChecks: true,

--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -73,7 +73,7 @@ func createTestDBWithContext(
 	s := &localtestcluster.LocalTestCluster{
 		DBContext: &dbCtx,
 	}
-	s.Start(t, testutils.NewNodeTestBaseContext(), InitSenderForLocalTestCluster)
+	s.Start(t, testutils.NewNodeTestBaseConfig(), InitSenderForLocalTestCluster)
 	return s, s.Sender.(*TxnCoordSender)
 }
 

--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -73,7 +73,7 @@ func createTestDBWithContext(
 	s := &localtestcluster.LocalTestCluster{
 		DBContext: &dbCtx,
 	}
-	s.Start(t, testutils.NewNodeTestBaseConfig(), InitSenderForLocalTestCluster)
+	s.Start(t, testutils.MakeNodeTestBaseConfig(), InitSenderForLocalTestCluster)
 	return s, s.Sender.(*TxnCoordSender)
 }
 

--- a/pkg/kv/txn_correctness_test.go
+++ b/pkg/kv/txn_correctness_test.go
@@ -895,7 +895,7 @@ func checkConcurrency(
 	s := &localtestcluster.LocalTestCluster{
 		DontRetryPushTxnFailures: true,
 	}
-	s.Start(t, testutils.NewNodeTestBaseContext(), InitSenderForLocalTestCluster)
+	s.Start(t, testutils.NewNodeTestBaseConfig(), InitSenderForLocalTestCluster)
 	defer s.Stop()
 	verifier.run(isolations, s.DB, t)
 }

--- a/pkg/kv/txn_correctness_test.go
+++ b/pkg/kv/txn_correctness_test.go
@@ -895,7 +895,7 @@ func checkConcurrency(
 	s := &localtestcluster.LocalTestCluster{
 		DontRetryPushTxnFailures: true,
 	}
-	s.Start(t, testutils.NewNodeTestBaseConfig(), InitSenderForLocalTestCluster)
+	s.Start(t, testutils.MakeNodeTestBaseConfig(), InitSenderForLocalTestCluster)
 	defer s.Stop()
 	verifier.run(isolations, s.DB, t)
 }

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -111,7 +111,7 @@ func BenchmarkSingleRoundtripWithLatency(b *testing.B) {
 		b.Run(latency.String(), func(b *testing.B) {
 			var s localtestcluster.LocalTestCluster
 			s.Latency = latency
-			s.Start(b, testutils.NewNodeTestBaseContext(), InitSenderForLocalTestCluster)
+			s.Start(b, testutils.NewNodeTestBaseConfig(), InitSenderForLocalTestCluster)
 			defer s.Stop()
 			defer b.StopTimer()
 			key := roachpb.Key("key")
@@ -387,7 +387,7 @@ func TestUncertaintyRestart(t *testing.T) {
 		Clock:     hlc.NewClock(hlc.UnixNano, maxOffset),
 		DBContext: &dbCtx,
 	}
-	s.Start(t, testutils.NewNodeTestBaseContext(), InitSenderForLocalTestCluster)
+	s.Start(t, testutils.NewNodeTestBaseConfig(), InitSenderForLocalTestCluster)
 	defer s.Stop()
 	if err := disableOwnNodeCertain(s); err != nil {
 		t.Fatal(err)
@@ -445,7 +445,7 @@ func TestUncertaintyMaxTimestampForwarding(t *testing.T) {
 		Clock:     hlc.NewClock(hlc.UnixNano, 50*time.Second),
 		DBContext: &dbCtx,
 	}
-	s.Start(t, testutils.NewNodeTestBaseContext(), InitSenderForLocalTestCluster)
+	s.Start(t, testutils.NewNodeTestBaseConfig(), InitSenderForLocalTestCluster)
 	defer s.Stop()
 	if err := disableOwnNodeCertain(s); err != nil {
 		t.Fatal(err)

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -111,7 +111,7 @@ func BenchmarkSingleRoundtripWithLatency(b *testing.B) {
 		b.Run(latency.String(), func(b *testing.B) {
 			var s localtestcluster.LocalTestCluster
 			s.Latency = latency
-			s.Start(b, testutils.NewNodeTestBaseConfig(), InitSenderForLocalTestCluster)
+			s.Start(b, testutils.MakeNodeTestBaseConfig(), InitSenderForLocalTestCluster)
 			defer s.Stop()
 			defer b.StopTimer()
 			key := roachpb.Key("key")
@@ -387,7 +387,7 @@ func TestUncertaintyRestart(t *testing.T) {
 		Clock:     hlc.NewClock(hlc.UnixNano, maxOffset),
 		DBContext: &dbCtx,
 	}
-	s.Start(t, testutils.NewNodeTestBaseConfig(), InitSenderForLocalTestCluster)
+	s.Start(t, testutils.MakeNodeTestBaseConfig(), InitSenderForLocalTestCluster)
 	defer s.Stop()
 	if err := disableOwnNodeCertain(s); err != nil {
 		t.Fatal(err)
@@ -445,7 +445,7 @@ func TestUncertaintyMaxTimestampForwarding(t *testing.T) {
 		Clock:     hlc.NewClock(hlc.UnixNano, 50*time.Second),
 		DBContext: &dbCtx,
 	}
-	s.Start(t, testutils.NewNodeTestBaseConfig(), InitSenderForLocalTestCluster)
+	s.Start(t, testutils.MakeNodeTestBaseConfig(), InitSenderForLocalTestCluster)
 	defer s.Stop()
 	if err := disableOwnNodeCertain(s); err != nil {
 		t.Fatal(err)

--- a/pkg/rpc/clock_offset.go
+++ b/pkg/rpc/clock_offset.go
@@ -121,9 +121,10 @@ func (r *RemoteClockMonitor) Latency(addr string) (time.Duration, bool) {
 func (r *RemoteClockMonitor) UpdateOffset(
 	ctx context.Context, addr string, offset RemoteOffset, roundTripLatency time.Duration,
 ) {
-	if addr == "127.0.0.1:0" {
+	if addr == "" || addr == "127.0.0.1:0" {
 		log.Fatal(context.TODO(), "uninitialized address in UpdateOffset call")
 	}
+
 	emptyOffset := offset == RemoteOffset{}
 
 	r.mu.Lock()

--- a/pkg/rpc/clock_offset.go
+++ b/pkg/rpc/clock_offset.go
@@ -121,6 +121,9 @@ func (r *RemoteClockMonitor) Latency(addr string) (time.Duration, bool) {
 func (r *RemoteClockMonitor) UpdateOffset(
 	ctx context.Context, addr string, offset RemoteOffset, roundTripLatency time.Duration,
 ) {
+	if addr == "127.0.0.1:0" {
+		log.Fatal(context.TODO(), "uninitialized address in UpdateOffset call")
+	}
 	emptyOffset := offset == RemoteOffset{}
 
 	r.mu.Lock()

--- a/pkg/rpc/heartbeat_test.go
+++ b/pkg/rpc/heartbeat_test.go
@@ -52,6 +52,8 @@ func TestHeartbeatReply(t *testing.T) {
 	}
 
 	request := &PingRequest{
+		// Bogus client address.
+		Addr: "127.0.0.1:4242",
 		Ping: "testPing",
 	}
 	response, err := heartbeat.Ping(context.Background(), request)
@@ -112,6 +114,8 @@ func TestManualHeartbeat(t *testing.T) {
 	}
 
 	request := &PingRequest{
+		// Bogus client address.
+		Addr: "127.0.0.1:4242",
 		Ping: "testManual",
 	}
 	manualHeartbeat.ready <- nil

--- a/pkg/rpc/main_test.go
+++ b/pkg/rpc/main_test.go
@@ -17,14 +17,8 @@
 package rpc
 
 import (
-	"time"
-
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
-	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
 func init() {
@@ -32,12 +26,3 @@ func init() {
 }
 
 //go:generate ../util/leaktest/add-leaktest.sh *_test.go
-
-// newNodeTestContext returns a rpc.Context for testing.
-// It is meant to be used by nodes.
-func newNodeTestContext(clock *hlc.Clock, stopper *stop.Stopper) *Context {
-	ctx := NewContext(log.AmbientContext{}, testutils.NewNodeTestBaseContext(), clock, stopper)
-	ctx.HeartbeatInterval = 10 * time.Millisecond
-	ctx.HeartbeatTimeout = 2 * defaultHeartbeatInterval
-	return ctx
-}

--- a/pkg/security/certs_test.go
+++ b/pkg/security/certs_test.go
@@ -161,9 +161,10 @@ func TestUseCerts(t *testing.T) {
 	defer s.Stopper().Stop()
 
 	// Insecure mode.
-	clientContext := testutils.NewNodeTestBaseConfig()
+	clientContext := testutils.MakeNodeTestBaseConfig()
 	clientContext.Insecure = true
-	httpClient, err := clientContext.GetHTTPClient()
+	connHelper := base.NewConnectingHelper(clientContext)
+	httpClient, err := connHelper.GetHTTPClient()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,11 +180,12 @@ func TestUseCerts(t *testing.T) {
 	}
 
 	// New client. With certs this time.
-	clientContext = testutils.NewNodeTestBaseConfig()
+	clientContext = testutils.MakeNodeTestBaseConfig()
 	clientContext.SSLCA = filepath.Join(certsDir, security.EmbeddedCACert)
 	clientContext.SSLCert = filepath.Join(certsDir, security.EmbeddedNodeCert)
 	clientContext.SSLCertKey = filepath.Join(certsDir, security.EmbeddedNodeKey)
-	httpClient, err = clientContext.GetHTTPClient()
+	connHelper = base.NewConnectingHelper(clientContext)
+	httpClient, err = connHelper.GetHTTPClient()
 	if err != nil {
 		t.Fatalf("Expected success, got %v", err)
 	}

--- a/pkg/security/certs_test.go
+++ b/pkg/security/certs_test.go
@@ -161,7 +161,7 @@ func TestUseCerts(t *testing.T) {
 	defer s.Stopper().Stop()
 
 	// Insecure mode.
-	clientContext := testutils.NewNodeTestBaseContext()
+	clientContext := testutils.NewNodeTestBaseConfig()
 	clientContext.Insecure = true
 	httpClient, err := clientContext.GetHTTPClient()
 	if err != nil {
@@ -179,7 +179,7 @@ func TestUseCerts(t *testing.T) {
 	}
 
 	// New client. With certs this time.
-	clientContext = testutils.NewNodeTestBaseContext()
+	clientContext = testutils.NewNodeTestBaseConfig()
 	clientContext.SSLCA = filepath.Join(certsDir, security.EmbeddedCACert)
 	clientContext.SSLCert = filepath.Join(certsDir, security.EmbeddedNodeCert)
 	clientContext.SSLCertKey = filepath.Join(certsDir, security.EmbeddedNodeKey)

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -189,7 +189,8 @@ func TestAdminDebugRedirect(t *testing.T) {
 	origURL := expURL + "incorrect"
 
 	// There are no particular permissions on admin endpoints, TestUser is fine.
-	client, err := testutils.NewTestBaseConfig(TestUser).GetHTTPClient()
+	connHelper := base.NewConnectingHelper(testutils.MakeTestBaseConfig(TestUser))
+	client, err := connHelper.GetHTTPClient()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -189,7 +189,7 @@ func TestAdminDebugRedirect(t *testing.T) {
 	origURL := expURL + "incorrect"
 
 	// There are no particular permissions on admin endpoints, TestUser is fine.
-	client, err := testutils.NewTestBaseContext(TestUser).GetHTTPClient()
+	client, err := testutils.NewTestBaseConfig(TestUser).GetHTTPClient()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/authentication_test.go
+++ b/pkg/server/authentication_test.go
@@ -89,15 +89,15 @@ func TestSSLEnforcement(t *testing.T) {
 	defer s.Stopper().Stop()
 
 	// HTTPS with client certs for security.RootUser.
-	rootCertsContext := testutils.NewTestBaseContext(security.RootUser)
+	rootCertsContext := testutils.NewTestBaseConfig(security.RootUser)
 	// HTTPS with client certs for security.NodeUser.
-	nodeCertsContext := testutils.NewNodeTestBaseContext()
+	nodeCertsContext := testutils.NewNodeTestBaseConfig()
 	// HTTPS with client certs for TestUser.
-	testCertsContext := testutils.NewTestBaseContext(TestUser)
+	testCertsContext := testutils.NewTestBaseConfig(TestUser)
 	// HTTPS without client certs. The user does not matter.
 	noCertsContext := insecureCtx{}
 	// Plain http.
-	insecureContext := testutils.NewTestBaseContext(TestUser)
+	insecureContext := testutils.NewTestBaseConfig(TestUser)
 	insecureContext.Insecure = true
 
 	kvGet := &roachpb.GetRequest{}

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -65,7 +65,14 @@ func createTestNode(
 	cfg := storage.TestStoreConfig(nil)
 
 	stopper := stop.NewStopper()
-	nodeRPCContext := rpc.NewContext(log.AmbientContext{}, nodeTestBaseContext, cfg.Clock, stopper)
+	rpcCfg := rpc.ContextConfig{
+		Config:   nodeTestBaseContext,
+		HLCClock: cfg.Clock,
+		// Disable heartbeats. Not needed for these tests.
+		HeartbeatInterval:     0,
+		EnableClockSkewChecks: false,
+	}
+	nodeRPCContext := rpc.NewContext(log.AmbientContext{}, rpcCfg, stopper)
 	cfg.ScanInterval = 10 * time.Hour
 	cfg.ConsistencyCheckInterval = 10 * time.Hour
 	grpcServer := rpc.NewServer(nodeRPCContext)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -48,7 +48,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var nodeTestBaseContext = testutils.NewNodeTestBaseContext()
+var nodeTestBaseContext = testutils.NewNodeTestBaseConfig()
 
 // TestSelfBootstrap verifies operation when no bootstrap hosts have
 // been specified.
@@ -118,8 +118,9 @@ func TestPlainHTTPServer(t *testing.T) {
 		return getStatusJSONProto(s, "metrics/local", &data)
 	})
 
-	ctx := s.RPCContext()
-	ctx.Insecure = false
+	// Edit the server's config so that it's goint to report its admin url using
+	// the https scheme.
+	s.BaseConfig().Insecure = false
 	if err := getStatusJSONProto(s, "metrics/local", &data); !testutils.IsError(err, "http: server gave HTTP response to HTTPS client") {
 		t.Fatalf("unexpected error %v", err)
 	}

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -532,7 +532,12 @@ func TestSpanStatsGRPCResponse(t *testing.T) {
 
 	rpcStopper := stop.NewStopper()
 	defer rpcStopper.Stop()
-	rpcContext := rpc.NewContext(log.AmbientContext{}, ts.RPCContext().Config, ts.Clock(), rpcStopper)
+
+	rpcCfg := rpc.ContextConfig{
+		Config:   ts.BaseConfig(),
+		HLCClock: ts.clock,
+	}
+	rpcContext := rpc.NewContext(log.AmbientContext{}, rpcCfg, rpcStopper)
 	request := serverpb.SpanStatsRequest{
 		NodeID:   "1",
 		StartKey: []byte(roachpb.RKeyMin),

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -483,6 +483,11 @@ func (ts *TestServer) GetFirstStoreID() roachpb.StoreID {
 	return firstStoreID
 }
 
+// BaseConfig is part of TestServerInterface.
+func (ts *TestServer) BaseConfig() *base.Config {
+	return ts.Cfg.Config
+}
+
 // LookupRange returns the descriptor of the range containing key.
 func (ts *TestServer) LookupRange(key roachpb.Key) (roachpb.RangeDescriptor, error) {
 	rangeLookupReq := roachpb.RangeLookupRequest{

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -398,7 +398,7 @@ func (ts *TestServer) AdminURL() string {
 
 // GetHTTPClient implements TestServerInterface.
 func (ts *TestServer) GetHTTPClient() (http.Client, error) {
-	return ts.Cfg.GetHTTPClient()
+	return ts.connHelper.GetHTTPClient()
 }
 
 // MustGetSQLCounter implements TestServerInterface.
@@ -484,7 +484,7 @@ func (ts *TestServer) GetFirstStoreID() roachpb.StoreID {
 }
 
 // BaseConfig is part of TestServerInterface.
-func (ts *TestServer) BaseConfig() *base.Config {
+func (ts *TestServer) BaseConfig() base.Config {
 	return ts.Cfg.Config
 }
 

--- a/pkg/sql/distsqlrun/outbox_test.go
+++ b/pkg/sql/distsqlrun/outbox_test.go
@@ -392,7 +392,7 @@ func startMockDistSQLServer(stopper *stop.Stopper) (*MockDistSQLServer, net.Addr
 
 func newInsecureRPCContext(stopper *stop.Stopper) *rpc.Context {
 	rpcCfg := rpc.ContextConfig{
-		Config:   &base.Config{Insecure: true},
+		Config:   base.Config{Insecure: true},
 		HLCClock: hlc.NewClock(hlc.UnixNano, time.Nanosecond),
 		// Disable heartbeats. Not needed for these tests.
 		HeartbeatInterval:     0,

--- a/pkg/sql/distsqlrun/outbox_test.go
+++ b/pkg/sql/distsqlrun/outbox_test.go
@@ -391,12 +391,14 @@ func startMockDistSQLServer(stopper *stop.Stopper) (*MockDistSQLServer, net.Addr
 }
 
 func newInsecureRPCContext(stopper *stop.Stopper) *rpc.Context {
-	return rpc.NewContext(
-		log.AmbientContext{},
-		&base.Config{Insecure: true},
-		hlc.NewClock(hlc.UnixNano, time.Nanosecond),
-		stopper,
-	)
+	rpcCfg := rpc.ContextConfig{
+		Config:   &base.Config{Insecure: true},
+		HLCClock: hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		// Disable heartbeats. Not needed for these tests.
+		HeartbeatInterval:     0,
+		EnableClockSkewChecks: false,
+	}
+	return rpc.NewContext(log.AmbientContext{}, rpcCfg, stopper)
 }
 
 // MockDistSQLServer implements the DistSQLServer (gRPC) interface and allows

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -2118,7 +2118,7 @@ func Example_rebalancing() {
 	// Model a set of stores in a cluster,
 	// randomly adding / removing stores and adding bytes.
 	cfg := rpc.ContextConfig{
-		Config:                &base.Config{Insecure: true},
+		Config:                base.Config{Insecure: true},
 		HLCClock:              clock,
 		HeartbeatInterval:     time.Second,
 		HeartbeatTimeout:      time.Second,

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -2117,12 +2117,14 @@ func Example_rebalancing() {
 
 	// Model a set of stores in a cluster,
 	// randomly adding / removing stores and adding bytes.
-	rpcContext := rpc.NewContext(
-		log.AmbientContext{},
-		&base.Config{Insecure: true},
-		clock,
-		stopper,
-	)
+	cfg := rpc.ContextConfig{
+		Config:                &base.Config{Insecure: true},
+		HLCClock:              clock,
+		HeartbeatInterval:     time.Second,
+		HeartbeatTimeout:      time.Second,
+		EnableClockSkewChecks: true,
+	}
+	rpcContext := rpc.NewContext(log.AmbientContext{}, cfg, stopper)
 	server := rpc.NewServer(rpcContext) // never started
 	g := gossip.NewTest(1, rpcContext, server, nil, stopper, metric.NewRegistry())
 	// Deterministic must be set as this test is comparing the exact output

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -117,11 +117,11 @@ func createTestStoreWithEngine(
 	storeCfg.AmbientCtx = ac
 
 	rpcCfg := rpc.ContextConfig{
-		Config:   &base.Config{Insecure: true},
-		HLCClock: storeCfg.Clock,
-		// Disable heartbeats. Not needed for these tests.
-		HeartbeatInterval:     0,
-		EnableClockSkewChecks: false,
+		Config:                base.Config{Insecure: true},
+		HLCClock:              storeCfg.Clock,
+		HeartbeatInterval:     time.Second,
+		HeartbeatTimeout:      time.Second,
+		EnableClockSkewChecks: true,
 	}
 	rpcContext := rpc.NewContext(ac, rpcCfg, stopper)
 	nodeDesc := &roachpb.NodeDescriptor{NodeID: 1}
@@ -263,7 +263,7 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 	}
 	if m.rpcContext == nil {
 		rpcCfg := rpc.ContextConfig{
-			Config:   &base.Config{Insecure: true},
+			Config:   base.Config{Insecure: true},
 			HLCClock: m.clock,
 			// Disable heartbeats. Not needed for these tests.
 			HeartbeatInterval:     0,

--- a/pkg/storage/raft_transport_test.go
+++ b/pkg/storage/raft_transport_test.go
@@ -111,10 +111,16 @@ func newRaftTransportTestContext(t testing.TB) *raftTransportTestContext {
 		stopper:    stop.NewStopper(),
 		transports: map[roachpb.NodeID]*storage.RaftTransport{},
 	}
+	rpcCfg := rpc.ContextConfig{
+		Config:   testutils.NewNodeTestBaseConfig(),
+		HLCClock: hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		// Disable heartbeats. Not needed for these tests.
+		HeartbeatInterval:     0,
+		EnableClockSkewChecks: false,
+	}
 	rttc.nodeRPCContext = rpc.NewContext(
 		log.AmbientContext{},
-		testutils.NewNodeTestBaseContext(),
-		hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		rpcCfg,
 		rttc.stopper,
 	)
 	server := rpc.NewServer(rttc.nodeRPCContext) // never started

--- a/pkg/storage/raft_transport_test.go
+++ b/pkg/storage/raft_transport_test.go
@@ -112,7 +112,7 @@ func newRaftTransportTestContext(t testing.TB) *raftTransportTestContext {
 		transports: map[roachpb.NodeID]*storage.RaftTransport{},
 	}
 	rpcCfg := rpc.ContextConfig{
-		Config:   testutils.NewNodeTestBaseConfig(),
+		Config:   testutils.MakeNodeTestBaseConfig(),
 		HLCClock: hlc.NewClock(hlc.UnixNano, time.Nanosecond),
 		// Disable heartbeats. Not needed for these tests.
 		HeartbeatInterval:     0,

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -146,7 +146,7 @@ func (tc *testContext) StartWithStoreConfig(t testing.TB, stopper *stop.Stopper,
 	config.TestingSetupZoneConfigHook(stopper)
 	if tc.gossip == nil {
 		rpcCfg := rpc.ContextConfig{
-			Config:                &base.Config{Insecure: true},
+			Config:                base.Config{Insecure: true},
 			HLCClock:              cfg.Clock,
 			HeartbeatInterval:     time.Second,
 			HeartbeatTimeout:      time.Second,

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -145,7 +145,14 @@ func (tc *testContext) StartWithStoreConfig(t testing.TB, stopper *stop.Stopper,
 	// Setup fake zone config handler.
 	config.TestingSetupZoneConfigHook(stopper)
 	if tc.gossip == nil {
-		rpcContext := rpc.NewContext(cfg.AmbientCtx, &base.Config{Insecure: true}, cfg.Clock, stopper)
+		rpcCfg := rpc.ContextConfig{
+			Config:                &base.Config{Insecure: true},
+			HLCClock:              cfg.Clock,
+			HeartbeatInterval:     time.Second,
+			HeartbeatTimeout:      time.Second,
+			EnableClockSkewChecks: true,
+		}
+		rpcContext := rpc.NewContext(cfg.AmbientCtx, rpcCfg, stopper)
 		server := rpc.NewServer(rpcContext) // never started
 		tc.gossip = gossip.NewTest(1, rpcContext, server, nil, stopper, metric.NewRegistry())
 	}

--- a/pkg/storage/store_pool_test.go
+++ b/pkg/storage/store_pool_test.go
@@ -93,7 +93,7 @@ func createTestStorePool(
 	mc := hlc.NewManualClock(123)
 	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
 	cfg := rpc.ContextConfig{
-		Config:                &base.Config{Insecure: true},
+		Config:                base.Config{Insecure: true},
 		HLCClock:              clock,
 		HeartbeatInterval:     time.Second,
 		HeartbeatTimeout:      time.Second,

--- a/pkg/storage/store_pool_test.go
+++ b/pkg/storage/store_pool_test.go
@@ -92,7 +92,14 @@ func createTestStorePool(
 	stopper := stop.NewStopper()
 	mc := hlc.NewManualClock(123)
 	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
-	rpcContext := rpc.NewContext(log.AmbientContext{}, &base.Config{Insecure: true}, clock, stopper)
+	cfg := rpc.ContextConfig{
+		Config:                &base.Config{Insecure: true},
+		HLCClock:              clock,
+		HeartbeatInterval:     time.Second,
+		HeartbeatTimeout:      time.Second,
+		EnableClockSkewChecks: true,
+	}
+	rpcContext := rpc.NewContext(log.AmbientContext{}, cfg, stopper)
 	server := rpc.NewServer(rpcContext) // never started
 	g := gossip.NewTest(1, rpcContext, server, nil, stopper, metric.NewRegistry())
 	mnl := newMockNodeLiveness(defaultNodeStatus)

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -121,7 +121,14 @@ func createTestStoreWithoutStart(t testing.TB, stopper *stop.Stopper, cfg *Store
 	// Setup fake zone config handler.
 	config.TestingSetupZoneConfigHook(stopper)
 
-	rpcContext := rpc.NewContext(log.AmbientContext{}, &base.Config{Insecure: true}, cfg.Clock, stopper)
+	rpcCfg := rpc.ContextConfig{
+		Config:                &base.Config{Insecure: true},
+		HLCClock:              cfg.Clock,
+		HeartbeatInterval:     time.Second,
+		HeartbeatTimeout:      time.Second,
+		EnableClockSkewChecks: true,
+	}
+	rpcContext := rpc.NewContext(log.AmbientContext{}, rpcCfg, stopper)
 	server := rpc.NewServer(rpcContext) // never started
 	cfg.Gossip = gossip.NewTest(1, rpcContext, server, nil, stopper, metric.NewRegistry())
 	cfg.StorePool = NewTestStorePool(*cfg)

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -122,7 +122,7 @@ func createTestStoreWithoutStart(t testing.TB, stopper *stop.Stopper, cfg *Store
 	config.TestingSetupZoneConfigHook(stopper)
 
 	rpcCfg := rpc.ContextConfig{
-		Config:                &base.Config{Insecure: true},
+		Config:                base.Config{Insecure: true},
 		HLCClock:              cfg.Clock,
 		HeartbeatInterval:     time.Second,
 		HeartbeatTimeout:      time.Second,

--- a/pkg/testutils/base.go
+++ b/pkg/testutils/base.go
@@ -24,15 +24,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 )
 
-// NewNodeTestBaseContext creates a base context for testing. This uses
-// embedded certs and the default node user. The default node user has both
-// server and client certificates.
-func NewNodeTestBaseContext() *base.Config {
-	return NewTestBaseContext(security.NodeUser)
+// NewNodeTestBaseConfig creates a base config for testing. This uses embedded
+// certs and the default node user. The default node user has both server and
+// client certificates.
+func NewNodeTestBaseConfig() *base.Config {
+	return NewTestBaseConfig(security.NodeUser)
 }
 
-// NewTestBaseContext creates a secure base context for user.
-func NewTestBaseContext(user string) *base.Config {
+// NewTestBaseConfig creates a secure base config for user.
+func NewTestBaseConfig(user string) *base.Config {
 	return &base.Config{
 		Insecure:   false,
 		SSLCA:      filepath.Join(security.EmbeddedCertsDir, security.EmbeddedCACert),

--- a/pkg/testutils/base.go
+++ b/pkg/testutils/base.go
@@ -24,16 +24,16 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 )
 
-// NewNodeTestBaseConfig creates a base config for testing. This uses embedded
-// certs and the default node user. The default node user has both server and
-// client certificates.
-func NewNodeTestBaseConfig() *base.Config {
-	return NewTestBaseConfig(security.NodeUser)
+// MakeNodeTestBaseConfig creates a base config for testing. This uses
+// embedded certs and the default node user. The default node user has both
+// server and client certificates.
+func MakeNodeTestBaseConfig() base.Config {
+	return MakeTestBaseConfig(security.NodeUser)
 }
 
-// NewTestBaseConfig creates a secure base config for user.
-func NewTestBaseConfig(user string) *base.Config {
-	return &base.Config{
+// MakeTestBaseConfig creates a secure base config for user.
+func MakeTestBaseConfig(user string) base.Config {
+	return base.Config{
 		Insecure:   false,
 		SSLCA:      filepath.Join(security.EmbeddedCertsDir, security.EmbeddedCACert),
 		SSLCert:    filepath.Join(security.EmbeddedCertsDir, fmt.Sprintf("%s.crt", user)),

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -95,7 +95,14 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initSende
 	ltc.Manual = hlc.NewManualClock(123)
 	ltc.Clock = hlc.NewClock(ltc.Manual.UnixNano, 50*time.Millisecond)
 	ltc.Stopper = stop.NewStopper()
-	rpcContext := rpc.NewContext(ambient, baseCtx, ltc.Clock, ltc.Stopper)
+	rpcCfg := rpc.ContextConfig{
+		Config:                baseCtx,
+		HLCClock:              ltc.Clock,
+		HeartbeatInterval:     time.Second,
+		HeartbeatTimeout:      time.Second,
+		EnableClockSkewChecks: true,
+	}
+	rpcContext := rpc.NewContext(ambient, rpcCfg, ltc.Stopper)
 	server := rpc.NewServer(rpcContext) // never started
 	ltc.Gossip = gossip.New(ambient, nc, rpcContext, server, nil, ltc.Stopper, metric.NewRegistry())
 	ltc.Eng = engine.NewInMem(roachpb.Attributes{}, 50<<20)

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -83,7 +83,7 @@ type InitSenderFn func(
 // node RPC server and all HTTP endpoints. Use the value of
 // TestServer.Addr after Start() for client connections. Use Stop()
 // to shutdown the server after the test completes.
-func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initSender InitSenderFn) {
+func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx base.Config, initSender InitSenderFn) {
 	ambient := log.AmbientContext{Tracer: tracing.NewTracer()}
 	nc := &base.NodeIDContainer{}
 	ambient.AddLogTag("n", nc)

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -102,6 +102,10 @@ type TestServerInterface interface {
 	// context client TLS config.
 	GetHTTPClient() (http.Client, error)
 
+	// BaseConfig returns a copy of the server's test config. Useful for tests to
+	// establish connections with the same authentication config.
+	BaseConfig() *base.Config
+
 	// MustGetSQLCounter returns the value of a counter metric from the server's
 	// SQL Executor. Runs in O(# of metrics) time, which is fine for test code.
 	MustGetSQLCounter(name string) int64

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -104,7 +104,7 @@ type TestServerInterface interface {
 
 	// BaseConfig returns a copy of the server's test config. Useful for tests to
 	// establish connections with the same authentication config.
-	BaseConfig() *base.Config
+	BaseConfig() base.Config
 
 	// MustGetSQLCounter returns the value of a counter metric from the server's
 	// SQL Executor. Runs in O(# of metrics) time, which is fine for test code.

--- a/pkg/testutils/testcluster/testcluster_test.go
+++ b/pkg/testutils/testcluster/testcluster_test.go
@@ -211,8 +211,16 @@ func TestStopServer(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	rpcCfg := rpc.ContextConfig{
+		Config:   tc.Server(1).BaseConfig(),
+		HLCClock: tc.Server(1).Clock(),
+		// Disable heartbeats and clock skew checks for this connection that's
+		// outside the cluster.
+		HeartbeatInterval:     0,
+		EnableClockSkewChecks: false,
+	}
 	rpcContext := rpc.NewContext(
-		log.AmbientContext{}, tc.Server(1).RPCContext().Config, tc.Server(1).Clock(), tc.Stopper(),
+		log.AmbientContext{}, rpcCfg, tc.Stopper(),
 	)
 	conn, err := rpcContext.GRPCDial(server1.ServingAddr())
 	if err != nil {

--- a/pkg/ts/db_test.go
+++ b/pkg/ts/db_test.go
@@ -78,7 +78,7 @@ func newTestModel(t *testing.T) testModel {
 // Start constructs and starts the local test server and creates a
 // time series DB.
 func (tm *testModel) Start() {
-	tm.LocalTestCluster.Start(tm.t, testutils.NewNodeTestBaseConfig(),
+	tm.LocalTestCluster.Start(tm.t, testutils.MakeNodeTestBaseConfig(),
 		kv.InitSenderForLocalTestCluster)
 	tm.DB = NewDB(tm.LocalTestCluster.DB)
 }

--- a/pkg/ts/db_test.go
+++ b/pkg/ts/db_test.go
@@ -78,7 +78,7 @@ func newTestModel(t *testing.T) testModel {
 // Start constructs and starts the local test server and creates a
 // time series DB.
 func (tm *testModel) Start() {
-	tm.LocalTestCluster.Start(tm.t, testutils.NewNodeTestBaseContext(),
+	tm.LocalTestCluster.Start(tm.t, testutils.NewNodeTestBaseConfig(),
 		kv.InitSenderForLocalTestCluster)
 	tm.DB = NewDB(tm.LocalTestCluster.DB)
 }


### PR DESCRIPTION
base.Config represents configuration params used by different components
of a Server's. The params refer to the Server's authentication
information. The base.Context was embedded in different other configs
(e.g. server.Config and rpc.ContextConfig). Everybody was sharing a
single base.Config, through pointers.
This was bad because the config was mutable - which is surprising for
what's supposed to be constructor params - and mutating through one
component caused changes to unrelated objects.

This patch makes the base.Config unmutable by extracting the one field
that was inteded to be mutable - the Address, which is set to a resolved
port after server construction. Then everybody starts passing the Config
by value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14377)
<!-- Reviewable:end -->
