### PR TITLE
sql: make better use of cached sourceInfo during render

### DIFF
--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -199,7 +199,7 @@ func (p *planner) groupBy(
 	// Add the group-by expressions so they are available for bucketing.
 	for _, g := range groupByExprs {
 		cols, exprs, hasStar, err := s.planner.computeRender(ctx, parser.SelectExpr{Expr: g}, parser.TypeAny,
-			s.source.info, s.ivarHelper, true)
+			s.sourceInfo, s.ivarHelper, true)
 		if err != nil {
 			return nil, err
 		}
@@ -226,7 +226,7 @@ func (p *planner) groupBy(
 
 		cols, exprs, hasStar, err := s.planner.computeRender(
 			ctx, parser.SelectExpr{Expr: f.filter}, parser.TypeAny,
-			s.source.info, s.ivarHelper, true)
+			s.sourceInfo, s.ivarHelper, true)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -336,7 +336,7 @@ func (s *renderNode) initTargets(
 			desiredType = desiredTypes[i]
 		}
 		cols, exprs, hasStar, err := s.planner.computeRender(ctx, target, desiredType,
-			s.source.info, s.ivarHelper, true)
+			s.sourceInfo, s.ivarHelper, true)
 		if err != nil {
 			return err
 		}
@@ -400,7 +400,7 @@ func (s *renderNode) transformToCrossJoin(
 		Expr: s.ivarHelper.IndexedVar(s.ivarHelper.NumVars() - 1),
 	}
 	return s.planner.computeRender(ctx, newTarget, desiredType,
-		s.source.info, s.ivarHelper, true)
+		s.sourceInfo, s.ivarHelper, true)
 }
 
 func (s *renderNode) initWhere(ctx context.Context, where *parser.Where) (*filterNode, error) {

--- a/pkg/sql/returning.go
+++ b/pkg/sql/returning.go
@@ -90,7 +90,7 @@ func (p *planner) newReturningHelper(
 	ivarHelper := parser.MakeIndexedVarHelper(rh, len(tablecols))
 	for _, target := range rExprs {
 		cols, typedExprs, _, err := p.computeRender(
-			ctx, target, parser.TypeAny, rh.source, ivarHelper, true /* allowStars */)
+			ctx, target, parser.TypeAny, multiSourceInfo{rh.source}, ivarHelper, true /* allowStars */)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -201,7 +201,7 @@ func (p *planner) orderBy(
 		if index == -1 && s != nil {
 			cols, exprs, hasStar, err := p.computeRender(
 				ctx, parser.SelectExpr{Expr: expr}, parser.TypeAny,
-				s.source.info, s.ivarHelper, true)
+				s.sourceInfo, s.ivarHelper, true)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/targets.go
+++ b/pkg/sql/targets.go
@@ -30,7 +30,7 @@ func (p *planner) computeRender(
 	ctx context.Context,
 	target parser.SelectExpr,
 	desiredType parser.Type,
-	info *dataSourceInfo,
+	info multiSourceInfo,
 	ivarHelper parser.IndexedVarHelper,
 	allowStars bool,
 ) (columns ResultColumns, exprs []parser.TypedExpr, hasStar bool, err error) {
@@ -52,7 +52,7 @@ func (p *planner) computeRender(
 	outputName := getRenderColName(target)
 
 	normalized, err := p.analyzeExpr(
-		ctx, target.Expr, multiSourceInfo{info}, ivarHelper, desiredType, false, "")
+		ctx, target.Expr, info, ivarHelper, desiredType, false, "")
 	if err != nil {
 		return nil, nil, false, err
 	}
@@ -120,7 +120,7 @@ func (s *renderNode) addOrMergeRenders(
 // pair is returned for each column.
 func checkRenderStar(
 	target parser.SelectExpr,
-	src *dataSourceInfo,
+	info multiSourceInfo,
 	ivarHelper parser.IndexedVarHelper,
 	allowStars bool,
 ) (isStar bool, columns ResultColumns, exprs []parser.TypedExpr, err error) {
@@ -141,6 +141,6 @@ func checkRenderStar(
 		return false, nil, nil, errors.Errorf("\"%s\" cannot be aliased", v)
 	}
 
-	columns, exprs, err = src.expandStar(v, ivarHelper)
+	columns, exprs, err = info[0].expandStar(v, ivarHelper)
 	return true, columns, exprs, err
 }

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -183,7 +183,7 @@ func (n *windowNode) constructWindowDefinitions(
 		// Validate PARTITION BY clause.
 		for _, partition := range windowDef.Partitions {
 			cols, exprs, _, err := s.planner.computeRender(ctx, parser.SelectExpr{Expr: partition},
-				parser.TypeAny, s.source.info, s.ivarHelper, true)
+				parser.TypeAny, s.sourceInfo, s.ivarHelper, true)
 			if err != nil {
 				return err
 			}
@@ -200,7 +200,7 @@ func (n *windowNode) constructWindowDefinitions(
 		// Validate ORDER BY clause.
 		for _, orderBy := range windowDef.OrderBy {
 			cols, exprs, _, err := s.planner.computeRender(ctx, parser.SelectExpr{Expr: orderBy.Expr},
-				parser.TypeAny, s.source.info, s.ivarHelper, true)
+				parser.TypeAny, s.sourceInfo, s.ivarHelper, true)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
The render node goes to some trouble to create a cached `multiSourceInfo` struct, but only uses that cached version in one of the half-dozen or so applicable call sites. The other call sites recreate the `multiSourceInfo` from scratch, defeating the purpose of the cached version. This commit adjusts the misbehaving call sites to used the cached `multiSourceInfo`. Added bonus: the comment above sourceInfo is no longer incorrect.

----

@knz the commit message (above) is worded as if I'm 100% confident, but really I'm only 90% confident that I've done the right thing here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14378)
<!-- Reviewable:end -->
