### PR TITLE
build: prune unused environment vars from builder

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -144,9 +144,5 @@ docker run --privileged -i ${tty-} --rm \
   --workdir="/go/src/github.com/cockroachdb/cockroach" \
   --env="TMPDIR=/go/src/github.com/cockroachdb/cockroach/artifacts" \
   --env="PAGER=cat" \
-  --env="CLOUDSDK_CORE_PROJECT=${CLOUDSDK_CORE_PROJECT-${GOOGLE_PROJECT-}}" \
-  --env="GOOGLE_CREDENTIALS=${GOOGLE_CREDENTIALS-}" \
   --env="GOTRACEBACK=${GOTRACEBACK-all}" \
-  --env="COVERALLS_TOKEN=${COVERALLS_TOKEN-}" \
-  --env="CODECOV_TOKEN=${CODECOV_TOKEN-}" \
   "${image}:${version}" "${@-bash}"


### PR DESCRIPTION
We've switched to passing environment variables to Docker on TeamCity using env, e.g.

```
build/builder.sh env VAR=VAL VAR2=VAL2 make thingy...
```

so that builder.sh doesn't need to learn about every TC environment variable that needs to be threaded through to the Docker container. This commit removes environment variables from builder.sh that seem to be no longer used, namely, GCE and code coverage configuration variables.

@tamird is there anything else I can do to make sure these variables are actually unused? Also, have we stopped caring about our coverage build? (This change should not further break the coverage build; i've already threaded the necessary env vars through the described `env` trick in the TC coverage build configuration.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14380)
<!-- Reviewable:end -->
