### PR TITLE
security: replace syscall.Stdin with os.Stdin

### DIFF
--- a/pkg/security/password.go
+++ b/pkg/security/password.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"fmt"
-	"syscall"
+	"os"
 
 	"github.com/pkg/errors"
 
@@ -51,7 +51,7 @@ func HashPassword(password string) ([]byte, error) {
 // they match, or an error.
 func PromptForPassword() (string, error) {
 	fmt.Print("Enter password: ")
-	one, err := terminal.ReadPassword(syscall.Stdin)
+	one, err := terminal.ReadPassword(int(os.Stdin.Fd()))
 	if err != nil {
 		return "", err
 	}
@@ -59,7 +59,7 @@ func PromptForPassword() (string, error) {
 		return "", ErrEmptyPassword
 	}
 	fmt.Print("\nConfirm password: ")
-	two, err := terminal.ReadPassword(syscall.Stdin)
+	two, err := terminal.ReadPassword(int(os.Stdin.Fd()))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Resolves #14382.

syscall.Stdin is not compatible with Windows and the godocs for syscall
state that it should not be used if other alternatives exist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14384)
<!-- Reviewable:end -->
