### PR TITLE
sql: allow imprecise pgwire type hints

### DIFF
--- a/pkg/acceptance/java_test.go
+++ b/pkg/acceptance/java_test.go
@@ -136,6 +136,30 @@ public class main {
 		if (nCols != 0) {
 		    throw new Exception("unexpected: SELECT returns " + nCols + " columns, expected 0");
 		}
+
+		// Check that imprecise placeholder typing works correctly. See issues
+		// #14245 and #14311 for more detail.
+		stmt = conn.prepareStatement("CREATE TABLE test.t (price decimal(5,2) NOT NULL)");
+		res = stmt.executeUpdate();
+		if (res != 0) {
+		    throw new Exception("unexpected: CREATE TABLE test.t " + res + " rows changed, expecting 0");
+		}
+
+		stmt = conn.prepareStatement("INSERT INTO test.t VALUES (?)");
+		stmt.setFloat(1, 3.3f);
+		res = stmt.executeUpdate();
+		if (res != 1) {
+		    throw new Exception("unexpected: INSERT INTO test.t " + res + " rows changed, expecting 0");
+		}
+
+		stmt = conn.prepareStatement("SELECT nspname FROM pg_catalog.pg_namespace WHERE oid=?");
+		stmt.setLong(1, 1782195457);
+		rs = stmt.executeQuery();
+		rs.next();
+		String nspName = rs.getString(1);
+		if (!"pg_catalog".equals(nspName)) {
+		    throw new Exception("unexpected: SELECT can't find pg_catalog database: found " + nspName);
+		}
 	}
 }
 EOF


### PR DESCRIPTION
Previously, if a prepared query was created with a pgwire type hint for
a placeholder that didn't precisely match the desired type for that
placeholder, the prepared query would fail during type checking. This is
contrary to the Postgres implementation of placeholder typing, which
casts placeholders to their expected types if the placeholder type hints
do not match. Clients seem to commonly send pgwire type hints that don't
precisely match, for instance sending an integer type hint for an OID
value, so this was a source of incompatibility for us.

Now, we insert a cast into the expression tree during typechecking if
the pgwire type hint doesn't match the desired type for the expression.

This needs to be done both when typing placeholders during the prepare
phase, when only the type hint for the placeholder is available, and
during the execution phase, when the value for the placeholder is
available as well. That's because in certain circumstances, such as
`INSERT`ing a placeholder value, the desired type for the placeholder is
only available during the execution phase. In other circumstances, such
as using a placeholder in a comparison, the desired type for the
placeholder is available during the prepare phase so the expression
must be correctly typed at that point.

Resolves #14311.
Resolves #14245.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14387)
<!-- Reviewable:end -->
