### PR TITLE
storage: Indirect all Replica access through a new ReplicaEvalContext

### DIFF
--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -41,7 +41,6 @@ func evalExport(
 ) (pd storage.EvalResult, retErr error) {
 	args := cArgs.Args.(*roachpb.ExportRequest)
 	h := cArgs.Header
-	r := cArgs.Repl
 	reply := resp.(*roachpb.ExportResponse)
 
 	ctx, span := tracing.ChildSpan(ctx, fmt.Sprintf("Export [%s,%s)", args.Key, args.EndKey))
@@ -52,7 +51,10 @@ func evalExport(
 	// threshold. If it's not, the mvcc tombstones could have been deleted and
 	// the resulting RocksDB tombstones compacted, which means we'd miss
 	// deletions in the incremental backup.
-	gcThreshold := r.GCThreshold()
+	gcThreshold, err := cArgs.EvalCtx.GCThreshold()
+	if err != nil {
+		return storage.EvalResult{}, err
+	}
 	if args.StartTime != (hlc.Timestamp{}) {
 		if !gcThreshold.Less(args.StartTime) {
 			return storage.EvalResult{}, errors.Errorf("start timestamp %v must be after replica GC threshold %v", args.StartTime, gcThreshold)
@@ -71,7 +73,7 @@ func evalExport(
 	}
 	defer exportStore.Close()
 
-	filename := fmt.Sprintf("%d.sst", parser.GenerateUniqueInt(r.NodeID()))
+	filename := fmt.Sprintf("%d.sst", parser.GenerateUniqueInt(cArgs.EvalCtx.NodeID()))
 	tmp, err := MakeExportFileTmpWriter(ctx, exportStore, filename)
 	if err != nil {
 		return storage.EvalResult{}, err

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -31,7 +31,7 @@ func init() {
 // evalImport bulk loads key/value entries.
 func evalImport(ctx context.Context, cArgs storage.CommandArgs) error {
 	args := cArgs.Args.(*roachpb.ImportRequest)
-	db := cArgs.Repl.DB()
+	db := cArgs.EvalCtx.DB()
 	kr := KeyRewriter(args.KeyRewrites)
 
 	var importStart, importEnd roachpb.Key

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1489,13 +1489,12 @@ func (r *Replica) Send(
 	return br, pErr
 }
 
-func (r *Replica) checkBatchRange(ba roachpb.BatchRequest) error {
+func checkBatchRange(store *Store, desc *roachpb.RangeDescriptor, ba roachpb.BatchRequest) error {
 	rspan, err := keys.Range(ba)
 	if err != nil {
 		return err
 	}
 
-	desc := r.Desc()
 	if desc.ContainsKeyRange(rspan.Key, rspan.EndKey) {
 		return nil
 	}
@@ -1505,11 +1504,11 @@ func (r *Replica) checkBatchRange(ba roachpb.BatchRequest) error {
 	// Try to suggest the correct range on a key mismatch error where
 	// even the start key of the request went to the wrong range.
 	if !desc.ContainsKey(rspan.Key) {
-		if repl := r.store.LookupReplica(rspan.Key, nil); repl != nil {
+		if repl := store.LookupReplica(rspan.Key, nil); repl != nil {
 			// Only return the correct range descriptor as a hint
 			// if we know the current lease holder for that range, which
 			// indicates that our knowledge is not stale.
-			if lease, _ := repl.getLease(); repl.IsLeaseValid(lease, r.store.Clock().Now()) {
+			if lease, _ := repl.getLease(); repl.IsLeaseValid(lease, store.Clock().Now()) {
 				mismatchErr.SuggestedRange = repl.Desc()
 			}
 		}
@@ -1931,7 +1930,7 @@ func (r *Replica) addAdminCmd(
 		return nil, roachpb.NewErrorf("only single-element admin batches allowed")
 	}
 
-	if err := r.checkBatchRange(ba); err != nil {
+	if err := checkBatchRange(r.store, r.Desc(), ba); err != nil {
 		return nil, roachpb.NewErrorWithTxn(err, ba.Txn)
 	}
 
@@ -1980,9 +1979,9 @@ func (r *Replica) addAdminCmd(
 
 	case *roachpb.ImportRequest:
 		cArgs := CommandArgs{
-			Repl:   r,
-			Header: ba.Header,
-			Args:   args,
+			EvalCtx: ReplicaEvalContext{r, nil},
+			Header:  ba.Header,
+			Args:    args,
 		}
 		resp = &roachpb.ImportResponse{}
 		err := importCmdFn(ctx, cArgs)
@@ -2054,7 +2053,8 @@ func (r *Replica) addReadOnlyCmd(
 	// that holding readMu throughout is important to avoid reads from the
 	// "wrong" key range being served after the range has been split.
 	var result EvalResult
-	br, result, pErr = r.executeBatch(ctx, storagebase.CmdIDKey(""), r.store.Engine(), nil, ba)
+	rec := ReplicaEvalContext{r, spans}
+	br, result, pErr = executeBatch(ctx, storagebase.CmdIDKey(""), r.store.Engine(), rec, nil, ba)
 
 	if pErr == nil && ba.Txn != nil && ba.Txn.Writing {
 		// Checking whether the transaction has been aborted on reads makes sure
@@ -4130,7 +4130,8 @@ func (r *Replica) executeWriteBatch(
 		if spans != nil {
 			batch = makeSpanSetBatch(batch, spans)
 		}
-		br, result, pErr := r.executeBatch(ctx, idKey, batch, &ms, strippedBa)
+		rec := ReplicaEvalContext{r, spans}
+		br, result, pErr := executeBatch(ctx, idKey, batch, rec, &ms, strippedBa)
 		if pErr == nil && ba.Timestamp == br.Timestamp {
 			clonedTxn := ba.Txn.Clone()
 			clonedTxn.Writing = true
@@ -4144,7 +4145,7 @@ func (r *Replica) executeWriteBatch(
 				ms = enginepb.MVCCStats{}
 			} else {
 				// Run commit trigger manually.
-				innerResult, err := r.runCommitTrigger(ctx, batch, &ms, *etArg, &clonedTxn)
+				innerResult, err := runCommitTrigger(ctx, rec, batch, &ms, *etArg, &clonedTxn)
 				if err != nil {
 					return batch, ms, br, result, roachpb.NewErrorf("failed to run commit trigger: %s", err)
 				}
@@ -4193,7 +4194,8 @@ func (r *Replica) executeWriteBatch(
 	if spans != nil {
 		batch = makeSpanSetBatch(batch, spans)
 	}
-	br, result, pErr := r.executeBatch(ctx, idKey, batch, &ms, ba)
+	rec := ReplicaEvalContext{r, spans}
+	br, result, pErr := executeBatch(ctx, idKey, batch, rec, &ms, ba)
 	return batch, ms, br, result, pErr
 }
 
@@ -4307,31 +4309,20 @@ func optimizePuts(
 	return reqs
 }
 
-// GCThreshold returns the GC threshold of the Range, typically updated when
-// keys are garbage collected. Reads and writes at timestamps <= this time will
-// not be served.
-func (r *Replica) GCThreshold() hlc.Timestamp {
-	r.mu.RLock()
-	threshold := r.mu.state.GCThreshold
-	r.mu.RUnlock()
-	return threshold
-}
-
-// DB returns the Replica's client.DB.
-func (r *Replica) DB() *client.DB {
-	return r.store.DB()
-}
-
-func (r *Replica) executeBatch(
+func executeBatch(
 	ctx context.Context,
 	idKey storagebase.CmdIDKey,
 	batch engine.ReadWriter,
+	rec ReplicaEvalContext,
 	ms *enginepb.MVCCStats,
 	ba roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, EvalResult, *roachpb.Error) {
 	br := ba.CreateReply()
 
-	threshold := r.GCThreshold()
+	threshold, err := rec.GCThreshold()
+	if err != nil {
+		return nil, EvalResult{}, roachpb.NewError(err)
+	}
 	if !threshold.Less(ba.Timestamp) {
 		return nil, EvalResult{}, roachpb.NewError(fmt.Errorf("batch timestamp %v must be after replica GC threshold %v", ba.Timestamp, threshold))
 	}
@@ -4348,7 +4339,11 @@ func (r *Replica) executeBatch(
 		ba.Requests = optimizePuts(batch, ba.Requests, ba.Header.DistinctSpans)
 	}
 
-	if err := r.checkBatchRange(ba); err != nil {
+	desc, err := rec.Desc()
+	if err != nil {
+		return nil, EvalResult{}, roachpb.NewError(err)
+	}
+	if err := checkBatchRange(rec.Store(), desc, ba); err != nil {
 		return nil, EvalResult{}, roachpb.NewErrorWithTxn(err, ba.Header.Txn)
 	}
 
@@ -4370,7 +4365,7 @@ func (r *Replica) executeBatch(
 		// Note that responses are populated even when an error is returned.
 		// TODO(tschottdorf): Change that. IIRC there is nontrivial use of it currently.
 		reply := br.Responses[index].GetInner()
-		curResult, pErr := r.executeCmd(ctx, idKey, index, batch, ms, ba.Header, maxKeys, args, reply)
+		curResult, pErr := executeCmd(ctx, idKey, index, batch, rec, ms, ba.Header, maxKeys, args, reply)
 
 		if err := result.MergeAndDestroy(curResult); err != nil {
 			// TODO(tschottdorf): see whether we really need to pass nontrivial
@@ -4623,8 +4618,9 @@ func (r *Replica) maybeGossipNodeLiveness(ctx context.Context, span roachpb.Span
 	ba.Timestamp = r.store.Clock().Now()
 	ba.Add(&roachpb.ScanRequest{Span: span})
 	// Call executeBatch instead of Send to avoid command queue reentrance.
+	rec := ReplicaEvalContext{r, nil}
 	br, result, pErr :=
-		r.executeBatch(ctx, storagebase.CmdIDKey(""), r.store.Engine(), nil, ba)
+		executeBatch(ctx, storagebase.CmdIDKey(""), r.store.Engine(), rec, nil, ba)
 	if pErr != nil {
 		return errors.Wrapf(pErr.GoError(), "couldn't scan node liveness records in span %s", span)
 	}
@@ -4702,8 +4698,9 @@ func (r *Replica) loadSystemConfig(ctx context.Context) (config.SystemConfig, er
 	ba.Timestamp = r.store.Clock().Now()
 	ba.Add(&roachpb.ScanRequest{Span: keys.SystemConfigSpan})
 	// Call executeBatch instead of Send to avoid command queue reentrance.
-	br, result, pErr := r.executeBatch(
-		ctx, storagebase.CmdIDKey(""), r.store.Engine(), nil, ba,
+	rec := ReplicaEvalContext{r, nil}
+	br, result, pErr := executeBatch(
+		ctx, storagebase.CmdIDKey(""), r.store.Engine(), rec, nil, ba,
 	)
 	if pErr != nil {
 		return config.SystemConfig{}, pErr.GoError()

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -64,12 +64,12 @@ const (
 
 // CommandArgs contains all the arguments to a command.
 // TODO(bdarnell): consider merging with storagebase.FilterArgs (which
-// would probably require removing the Repl field due to import order
+// would probably require removing the EvalCtx field due to import order
 // constraints).
 type CommandArgs struct {
-	Repl   *Replica
-	Header roachpb.Header
-	Args   roachpb.Request
+	EvalCtx ReplicaEvalContext
+	Header  roachpb.Header
+	Args    roachpb.Request
 
 	// If MaxKeys is non-zero, span requests should limit themselves to
 	// that many keys. Commands using this feature should also set
@@ -143,11 +143,12 @@ var commands = map[roachpb.Method]Command{
 // may be actionable even in the case of an error.
 // maxKeys is the number of scan results remaining for this batch
 // (MaxInt64 for no limit).
-func (r *Replica) executeCmd(
+func executeCmd(
 	ctx context.Context,
 	raftCmdID storagebase.CmdIDKey,
 	index int,
 	batch engine.ReadWriter,
+	rec ReplicaEvalContext,
 	ms *enginepb.MVCCStats,
 	h roachpb.Header,
 	maxKeys int64,
@@ -160,9 +161,9 @@ func (r *Replica) executeCmd(
 	}
 
 	// If a unittest filter was installed, check for an injected error; otherwise, continue.
-	if filter := r.store.cfg.TestingKnobs.TestingEvalFilter; filter != nil {
+	if filter := rec.StoreTestingKnobs().TestingEvalFilter; filter != nil {
 		filterArgs := storagebase.FilterArgs{Ctx: ctx, CmdID: raftCmdID, Index: index,
-			Sid: r.store.StoreID(), Req: args, Hdr: h}
+			Sid: rec.StoreID(), Req: args, Hdr: h}
 		if pErr := filter(filterArgs); pErr != nil {
 			log.Infof(ctx, "test injecting error: %s", pErr)
 			return EvalResult{}, pErr
@@ -174,8 +175,8 @@ func (r *Replica) executeCmd(
 
 	if cmd, ok := commands[args.Method()]; ok {
 		cArgs := CommandArgs{
-			Repl:   r,
-			Header: h,
+			EvalCtx: rec,
+			Header:  h,
 			// Some commands mutate their arguments, so give each invocation
 			// its own copy (shallow to mimic earlier versions of this code
 			// in which args were passed by value instead of pointer).
@@ -190,10 +191,17 @@ func (r *Replica) executeCmd(
 
 	if h.ReturnRangeInfo {
 		header := reply.Header()
-		lease, _ := r.getLease()
+		lease, _, err := rec.GetLease()
+		if err != nil {
+			return EvalResult{}, roachpb.NewError(err)
+		}
+		desc, err := rec.Desc()
+		if err != nil {
+			return EvalResult{}, roachpb.NewError(err)
+		}
 		header.RangeInfos = []roachpb.RangeInfo{
 			{
-				Desc:  *r.Desc(),
+				Desc:  *desc,
 				Lease: *lease,
 			},
 		}
@@ -433,7 +441,6 @@ func declareKeysWriteTransaction(header roachpb.Header, req roachpb.Request, spa
 func evalBeginTransaction(
 	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (EvalResult, error) {
-	r := cArgs.Repl
 	args := cArgs.Args.(*roachpb.BeginTransactionRequest)
 	h := cArgs.Header
 	reply := resp.(*roachpb.BeginTransactionResponse)
@@ -484,9 +491,10 @@ func evalBeginTransaction(
 		}
 	}
 
-	r.mu.RLock()
-	threshold := r.mu.state.TxnSpanGCThreshold
-	r.mu.RUnlock()
+	threshold, err := cArgs.EvalCtx.TxnSpanGCThreshold()
+	if err != nil {
+		return EvalResult{}, err
+	}
 
 	// Disallow creation of a transaction record if it's at a timestamp before
 	// the TxnSpanGCThreshold, as in that case our transaction may already have
@@ -584,7 +592,6 @@ func declareKeysEndTransaction(header roachpb.Header, req roachpb.Request, spans
 func evalEndTransaction(
 	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (EvalResult, error) {
-	r := cArgs.Repl
 	args := cArgs.Args.(*roachpb.EndTransactionRequest)
 	h := cArgs.Header
 	ms := cArgs.Stats
@@ -624,7 +631,12 @@ func evalEndTransaction(
 			// The transaction has already been aborted by other.
 			// Do not return TransactionAbortedError since the client anyway
 			// wanted to abort the transaction.
-			externalIntents := r.resolveLocalIntents(ctx, batch, ms, *args, reply.Txn)
+			desc, err := cArgs.EvalCtx.Desc()
+			if err != nil {
+				return EvalResult{}, err
+			}
+			externalIntents := resolveLocalIntents(ctx, desc,
+				batch, ms, *args, reply.Txn, cArgs.EvalCtx.StoreTestingKnobs())
 			if err := updateTxnWithExternalIntents(
 				ctx, batch, ms, *args, reply.Txn, externalIntents,
 			); err != nil {
@@ -705,7 +717,12 @@ func evalEndTransaction(
 		reply.Txn.Status = roachpb.ABORTED
 	}
 
-	externalIntents := r.resolveLocalIntents(ctx, batch, ms, *args, reply.Txn)
+	desc, err := cArgs.EvalCtx.Desc()
+	if err != nil {
+		return EvalResult{}, err
+	}
+	externalIntents := resolveLocalIntents(ctx, desc,
+		batch, ms, *args, reply.Txn, cArgs.EvalCtx.StoreTestingKnobs())
 	if err := updateTxnWithExternalIntents(ctx, batch, ms, *args, reply.Txn, externalIntents); err != nil {
 		return EvalResult{}, err
 	}
@@ -714,7 +731,7 @@ func evalEndTransaction(
 	var pd EvalResult
 	if reply.Txn.Status == roachpb.COMMITTED {
 		var err error
-		if pd, err = r.runCommitTrigger(ctx, batch.(engine.Batch), ms, *args, reply.Txn); err != nil {
+		if pd, err = runCommitTrigger(ctx, cArgs.EvalCtx, batch.(engine.Batch), ms, *args, reply.Txn); err != nil {
 			return EvalResult{}, NewReplicaCorruptionError(err)
 		}
 	}
@@ -782,14 +799,15 @@ func isEndTransactionTriggeringRetryError(headerTxn, currentTxn *roachpb.Transac
 // local to this range in the same batch. The remainder are collected
 // and returned so that they can be handed off to asynchronous
 // processing.
-func (r *Replica) resolveLocalIntents(
+func resolveLocalIntents(
 	ctx context.Context,
+	desc *roachpb.RangeDescriptor,
 	batch engine.ReadWriter,
 	ms *enginepb.MVCCStats,
 	args roachpb.EndTransactionRequest,
 	txn *roachpb.Transaction,
+	storeTestingKnobs StoreTestingKnobs,
 ) []roachpb.Intent {
-	desc := r.Desc()
 	var preMergeDesc *roachpb.RangeDescriptor
 	if mergeTrigger := args.InternalCommitTrigger.GetMergeTrigger(); mergeTrigger != nil {
 		// If this is a merge, then use the post-merge descriptor to determine
@@ -835,8 +853,8 @@ func (r *Replica) resolveLocalIntents(
 			if inSpan != nil {
 				intent.Span = *inSpan
 				num, err := engine.MVCCResolveWriteIntentRangeUsingIter(ctx, batch, iterAndBuf, ms, intent, math.MaxInt64)
-				if r.store.cfg.TestingKnobs.NumKeysEvaluatedForRangeIntentResolution != nil {
-					atomic.AddInt64(r.store.cfg.TestingKnobs.NumKeysEvaluatedForRangeIntentResolution, num)
+				if storeTestingKnobs.NumKeysEvaluatedForRangeIntentResolution != nil {
+					atomic.AddInt64(storeTestingKnobs.NumKeysEvaluatedForRangeIntentResolution, num)
 				}
 				return err
 			}
@@ -930,8 +948,9 @@ func intersectSpan(
 	return
 }
 
-func (r *Replica) runCommitTrigger(
+func runCommitTrigger(
 	ctx context.Context,
+	rec ReplicaEvalContext,
 	batch engine.Batch,
 	ms *enginepb.MVCCStats,
 	args roachpb.EndTransactionRequest,
@@ -943,17 +962,17 @@ func (r *Replica) runCommitTrigger(
 	}
 
 	if ct.GetSplitTrigger() != nil {
-		newMS, trigger, err := r.splitTrigger(
-			ctx, batch, *ms, ct.SplitTrigger, txn.Timestamp,
+		newMS, trigger, err := splitTrigger(
+			ctx, rec, batch, *ms, ct.SplitTrigger, txn.Timestamp,
 		)
 		*ms = newMS
 		return trigger, err
 	}
 	if ct.GetMergeTrigger() != nil {
-		return r.mergeTrigger(ctx, batch, ms, ct.MergeTrigger, txn.Timestamp)
+		return mergeTrigger(ctx, rec, batch, ms, ct.MergeTrigger, txn.Timestamp)
 	}
 	if crt := ct.GetChangeReplicasTrigger(); crt != nil {
-		return r.changeReplicasTrigger(ctx, batch, crt), nil
+		return changeReplicasTrigger(ctx, rec, batch, crt), nil
 	}
 	if ct.GetModifiedSpanTrigger() != nil {
 		var pd EvalResult
@@ -966,7 +985,9 @@ func (r *Replica) runCommitTrigger(
 			// the transaction record itself is on the system span. This can
 			// be done by making sure a system key is the first key touched
 			// in the transaction.
-			if r.ContainsKey(keys.SystemConfigSpan.Key) {
+			if ok, err := rec.ContainsKey(keys.SystemConfigSpan.Key); err != nil {
+				return EvalResult{}, err
+			} else if ok {
 				if err := pd.MergeAndDestroy(
 					EvalResult{
 						Local: LocalEvalResult{
@@ -1303,7 +1324,6 @@ func evalGC(
 ) (EvalResult, error) {
 	args := cArgs.Args.(*roachpb.GCRequest)
 	h := cArgs.Header
-	r := cArgs.Repl
 
 	// All keys must be inside the current replica range. Keys outside
 	// of this range in the GC request are dropped silently, which is
@@ -1312,7 +1332,9 @@ func evalGC(
 	// range splitting.
 	keys := make([]roachpb.GCRequest_GCKey, 0, len(args.Keys))
 	for _, k := range args.Keys {
-		if r.ContainsKey(k.Key) {
+		if ok, err := cArgs.EvalCtx.ContainsKey(k.Key); err != nil {
+			return EvalResult{}, err
+		} else if ok {
 			keys = append(keys, k)
 		}
 	}
@@ -1323,24 +1345,28 @@ func evalGC(
 		return EvalResult{}, err
 	}
 
-	r.mu.RLock()
-	newThreshold := r.mu.state.GCThreshold
-	newTxnSpanGCThreshold := r.mu.state.TxnSpanGCThreshold
+	newThreshold, err := cArgs.EvalCtx.GCThreshold()
+	if err != nil {
+		return EvalResult{}, err
+	}
+	newTxnSpanGCThreshold, err := cArgs.EvalCtx.TxnSpanGCThreshold()
+	if err != nil {
+		return EvalResult{}, err
+	}
 	// Protect against multiple GC requests arriving out of order; we track
 	// the maximum timestamps.
 	newThreshold.Forward(args.Threshold)
 	newTxnSpanGCThreshold.Forward(args.TxnSpanGCThreshold)
-	r.mu.RUnlock()
 
 	var pd EvalResult
 	pd.Replicated.State.GCThreshold = newThreshold
 	pd.Replicated.State.TxnSpanGCThreshold = newTxnSpanGCThreshold
 
-	if err := r.stateLoader.setGCThreshold(ctx, batch, cArgs.Stats, &newThreshold); err != nil {
+	if err := cArgs.EvalCtx.stateLoader().setGCThreshold(ctx, batch, cArgs.Stats, &newThreshold); err != nil {
 		return EvalResult{}, err
 	}
 
-	if err := r.stateLoader.setTxnSpanGCThreshold(ctx, batch, cArgs.Stats, &newTxnSpanGCThreshold); err != nil {
+	if err := cArgs.EvalCtx.stateLoader().setTxnSpanGCThreshold(ctx, batch, cArgs.Stats, &newTxnSpanGCThreshold); err != nil {
 		return EvalResult{}, err
 	}
 
@@ -1593,7 +1619,7 @@ func evalQueryTxn(
 		return EvalResult{}, err
 	}
 	// Get the list of txns waiting on this txn.
-	reply.WaitingTxns = cArgs.Repl.pushTxnQueue.GetDependents(*args.Txn.ID)
+	reply.WaitingTxns = cArgs.EvalCtx.pushTxnQueue().GetDependents(*args.Txn.ID)
 	return EvalResult{}, nil
 }
 
@@ -1601,22 +1627,23 @@ func evalQueryTxn(
 // Otherwise, if poison is true, creates an entry for this transaction
 // in the abort cache to prevent future reads or writes from
 // spuriously succeeding on this range.
-func (r *Replica) setAbortCache(
+func setAbortCache(
 	ctx context.Context,
+	rec ReplicaEvalContext,
 	batch engine.ReadWriter,
 	ms *enginepb.MVCCStats,
 	txn enginepb.TxnMeta,
 	poison bool,
 ) error {
 	if !poison {
-		return r.abortCache.Del(ctx, batch, ms, *txn.ID)
+		return rec.AbortCache().Del(ctx, batch, ms, *txn.ID)
 	}
 	entry := roachpb.AbortCacheEntry{
 		Key:       txn.Key,
 		Timestamp: txn.Timestamp,
 		Priority:  txn.Priority,
 	}
-	return r.abortCache.Put(ctx, batch, ms, *txn.ID, &entry)
+	return rec.AbortCache().Put(ctx, batch, ms, *txn.ID, &entry)
 }
 
 func declareKeysResolveIntent(header roachpb.Header, req roachpb.Request, spans *SpanSet) {
@@ -1630,7 +1657,6 @@ func declareKeysResolveIntent(header roachpb.Header, req roachpb.Request, spans 
 func evalResolveIntent(
 	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (EvalResult, error) {
-	r := cArgs.Repl
 	args := cArgs.Args.(*roachpb.ResolveIntentRequest)
 	h := cArgs.Header
 	ms := cArgs.Stats
@@ -1648,7 +1674,7 @@ func evalResolveIntent(
 		return EvalResult{}, err
 	}
 	if intent.Status == roachpb.ABORTED {
-		return EvalResult{}, r.setAbortCache(ctx, batch, ms, args.IntentTxn, args.Poison)
+		return EvalResult{}, setAbortCache(ctx, cArgs.EvalCtx, batch, ms, args.IntentTxn, args.Poison)
 	}
 	return EvalResult{}, nil
 }
@@ -1664,7 +1690,6 @@ func declareKeysResolveIntentRange(header roachpb.Header, req roachpb.Request, s
 func evalResolveIntentRange(
 	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (EvalResult, error) {
-	r := cArgs.Repl
 	args := cArgs.Args.(*roachpb.ResolveIntentRangeRequest)
 	h := cArgs.Header
 	ms := cArgs.Stats
@@ -1683,7 +1708,7 @@ func evalResolveIntentRange(
 		return EvalResult{}, err
 	}
 	if intent.Status == roachpb.ABORTED {
-		return EvalResult{}, r.setAbortCache(ctx, batch, ms, args.IntentTxn, args.Poison)
+		return EvalResult{}, setAbortCache(ctx, cArgs.EvalCtx, batch, ms, args.IntentTxn, args.Poison)
 	}
 	return EvalResult{}, nil
 }
@@ -1715,20 +1740,19 @@ func declareKeysTruncateLog(header roachpb.Header, req roachpb.Request, spans *S
 func evalTruncateLog(
 	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (EvalResult, error) {
-	r := cArgs.Repl
 	args := cArgs.Args.(*roachpb.TruncateLogRequest)
 
 	// After a merge, it's possible that this request was sent to the wrong
 	// range based on the start key. This will cancel the request if this is not
 	// the range specified in the request body.
-	if r.RangeID != args.RangeID {
+	if cArgs.EvalCtx.RangeID() != args.RangeID {
 		log.Infof(ctx, "attempting to truncate raft logs for another range: r%d. Normally this is due to a merge and can be ignored.",
 			args.RangeID)
 		return EvalResult{}, nil
 	}
 
 	// Have we already truncated this log? If so, just return without an error.
-	firstIndex, err := r.FirstIndex()
+	firstIndex, err := cArgs.EvalCtx.FirstIndex()
 	if err != nil {
 		return EvalResult{}, err
 	}
@@ -1742,12 +1766,12 @@ func evalTruncateLog(
 	}
 
 	// args.Index is the first index to keep.
-	term, err := r.Term(args.Index - 1)
+	term, err := cArgs.EvalCtx.Term(args.Index - 1)
 	if err != nil {
 		return EvalResult{}, err
 	}
-	start := keys.RaftLogKey(r.RangeID, 0)
-	end := keys.RaftLogKey(r.RangeID, args.Index)
+	start := keys.RaftLogKey(cArgs.EvalCtx.RangeID(), 0)
+	end := keys.RaftLogKey(cArgs.EvalCtx.RangeID(), args.Index)
 	var diff enginepb.MVCCStats
 	// Passing zero timestamp to MVCCDeleteRange is equivalent to a ranged clear
 	// but it also computes stats.
@@ -1765,7 +1789,7 @@ func evalTruncateLog(
 	pd.Replicated.State.TruncatedState = tState
 	pd.Replicated.RaftLogDelta = &diff.SysBytes
 
-	return pd, r.stateLoader.setTruncatedState(ctx, batch, cArgs.Stats, tState)
+	return pd, cArgs.EvalCtx.stateLoader().setTruncatedState(ctx, batch, cArgs.Stats, tState)
 }
 
 func newFailedLeaseTrigger(isTransfer bool) EvalResult {
@@ -1794,14 +1818,14 @@ func declareKeysRequestLease(header roachpb.Header, req roachpb.Request, spans *
 func evalRequestLease(
 	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (EvalResult, error) {
-	r := cArgs.Repl
 	args := cArgs.Args.(*roachpb.RequestLeaseRequest)
 	// When returning an error from this method, must always return
 	// a newFailedLeaseTrigger() to satisfy stats.
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	prevLease, _, err := cArgs.EvalCtx.GetLease()
+	if err != nil {
+		return EvalResult{}, err
+	}
 
-	prevLease := r.mu.state.Lease
 	rErr := &roachpb.LeaseRejectedError{
 		Existing:  *prevLease,
 		Requested: args.Lease,
@@ -1849,7 +1873,8 @@ func evalRequestLease(
 		return newFailedLeaseTrigger(false /* isTransfer */), rErr
 	}
 	args.Lease.Start = effectiveStart
-	return r.applyNewLeaseLocked(ctx, batch, cArgs.Stats, args.Lease, isExtension, false /* isTransfer */)
+	return applyNewLease(ctx, cArgs.EvalCtx, batch, cArgs.Stats,
+		args.Lease, prevLease, isExtension, false /* isTransfer */)
 }
 
 // TransferLease sets the lease holder for the range.
@@ -1860,21 +1885,22 @@ func evalRequestLease(
 func evalTransferLease(
 	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (EvalResult, error) {
-	r := cArgs.Repl
 	args := cArgs.Args.(*roachpb.TransferLeaseRequest)
 
 	// When returning an error from this method, must always return
 	// a newFailedLeaseTrigger() to satisfy stats.
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	prevLease, _, err := cArgs.EvalCtx.GetLease()
+	if err != nil {
+		return EvalResult{}, err
+	}
 	if log.V(2) {
-		prevLease := r.mu.state.Lease
 		log.Infof(ctx, "lease transfer: prev lease: %+v, new lease: %+v", prevLease, args.Lease)
 	}
-	return r.applyNewLeaseLocked(ctx, batch, cArgs.Stats, args.Lease, false /* isExtension */, true /* isTransfer */)
+	return applyNewLease(ctx, cArgs.EvalCtx, batch, cArgs.Stats,
+		args.Lease, prevLease, false /* isExtension */, true /* isTransfer */)
 }
 
-// applyNewLeaseLocked checks that the lease contains a valid interval and that
+// applyNewLease checks that the lease contains a valid interval and that
 // the new lease holder is still a member of the replica set, and then proceeds
 // to write the new lease to the batch, emitting an appropriate trigger.
 //
@@ -1885,15 +1911,15 @@ func evalTransferLease(
 // lease. If it doesn't change, we don't need a PostCommitTrigger that
 // synchronizes with reads.
 //
-// r.mu needs to be locked.
-//
 // TODO(tschottdorf): refactoring what's returned from the trigger here makes
 // sense to minimize the amount of code intolerant of rolling updates.
-func (r *Replica) applyNewLeaseLocked(
+func applyNewLease(
 	ctx context.Context,
+	rec ReplicaEvalContext,
 	batch engine.ReadWriter,
 	ms *enginepb.MVCCStats,
 	lease roachpb.Lease,
+	prevLease *roachpb.Lease,
 	isExtension bool,
 	isTransfer bool,
 ) (EvalResult, error) {
@@ -1906,7 +1932,7 @@ func (r *Replica) applyNewLeaseLocked(
 		// This amounts to a bug.
 		return newFailedLeaseTrigger(isTransfer),
 			&roachpb.LeaseRejectedError{
-				Existing:  *r.mu.state.Lease,
+				Existing:  *prevLease,
 				Requested: lease,
 				Message: fmt.Sprintf("illegal lease: epoch=%d, interval=[%s, %s)",
 					lease.Epoch, lease.Start, lease.Expiration),
@@ -1914,17 +1940,21 @@ func (r *Replica) applyNewLeaseLocked(
 	}
 
 	// Verify that requesting replica is part of the current replica set.
-	if _, ok := r.mu.state.Desc.GetReplicaDescriptor(lease.Replica.StoreID); !ok {
+	desc, err := rec.Desc()
+	if err != nil {
+		return EvalResult{}, err
+	}
+	if _, ok := desc.GetReplicaDescriptor(lease.Replica.StoreID); !ok {
 		return newFailedLeaseTrigger(isTransfer),
 			&roachpb.LeaseRejectedError{
-				Existing:  *r.mu.state.Lease,
+				Existing:  *prevLease,
 				Requested: lease,
 				Message:   "replica not found",
 			}
 	}
 
 	// Store the lease to disk & in-memory.
-	if err := r.stateLoader.setLease(ctx, batch, ms, &lease); err != nil {
+	if err := rec.stateLoader().setLease(ctx, batch, ms, &lease); err != nil {
 		return newFailedLeaseTrigger(isTransfer), err
 	}
 
@@ -2231,7 +2261,6 @@ func declareKeysChangeFrozen(header roachpb.Header, req roachpb.Request, spans *
 func evalChangeFrozen(
 	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (EvalResult, error) {
-	r := cArgs.Repl
 	args := cArgs.Args.(*roachpb.ChangeFrozenRequest)
 	reply := resp.(*roachpb.ChangeFrozenResponse)
 
@@ -2244,9 +2273,12 @@ func evalChangeFrozen(
 		return EvalResult{}, errors.Errorf("unsupported range-local key")
 	}
 
-	desc := r.Desc()
+	desc, err := cArgs.EvalCtx.Desc()
+	if err != nil {
+		return EvalResult{}, err
+	}
 
-	frozen, err := r.stateLoader.loadFrozenStatus(ctx, batch)
+	frozen, err := cArgs.EvalCtx.stateLoader().loadFrozenStatus(ctx, batch)
 	if err != nil || (frozen == storagebase.ReplicaState_FROZEN) == args.Frozen {
 		// Something went wrong or we're already in the right frozen state. In
 		// the latter case, we avoid writing the "same thing" because "we"
@@ -2301,7 +2333,7 @@ func evalChangeFrozen(
 	if args.Frozen {
 		frozenStatus = storagebase.ReplicaState_FROZEN
 	}
-	if err := r.stateLoader.setFrozenStatus(ctx, batch, cArgs.Stats, frozenStatus); err != nil {
+	if err := cArgs.EvalCtx.stateLoader().setFrozenStatus(ctx, batch, cArgs.Stats, frozenStatus); err != nil {
 		*reply = roachpb.ChangeFrozenResponse{}
 		return EvalResult{}, err
 	}
@@ -2829,8 +2861,9 @@ func (r *Replica) adminSplitWithDescriptor(
 // These stats are suitable for returning up the callstack like those for
 // regular commands; the corresponding delta for the RHS is part of the
 // returned trigger and is handled by the Store.
-func (r *Replica) splitTrigger(
+func splitTrigger(
 	ctx context.Context,
+	rec ReplicaEvalContext,
 	batch engine.Batch,
 	bothDeltaMS enginepb.MVCCStats,
 	split *roachpb.SplitTrigger,
@@ -2838,18 +2871,24 @@ func (r *Replica) splitTrigger(
 ) (enginepb.MVCCStats, EvalResult, error) {
 	// TODO(tschottdorf): should have an incoming context from the corresponding
 	// EndTransaction, but the plumbing has not been done yet.
-	sp := r.store.Tracer().StartSpan("split")
+	sp := rec.Tracer().StartSpan("split")
 	defer sp.Finish()
-	desc := r.Desc()
+	desc, err := rec.Desc()
+	if err != nil {
+		return enginepb.MVCCStats{}, EvalResult{}, err
+	}
 	if !bytes.Equal(desc.StartKey, split.LeftDesc.StartKey) ||
 		!bytes.Equal(desc.EndKey, split.RightDesc.EndKey) {
 		return enginepb.MVCCStats{}, EvalResult{}, errors.Errorf("range does not match splits: (%s-%s) + (%s-%s) != %s",
 			split.LeftDesc.StartKey, split.LeftDesc.EndKey,
-			split.RightDesc.StartKey, split.RightDesc.EndKey, r)
+			split.RightDesc.StartKey, split.RightDesc.EndKey, rec)
 	}
 
 	// Preserve stats for pre-split range, excluding the current batch.
-	origBothMS := r.GetMVCCStats()
+	origBothMS, err := rec.GetMVCCStats()
+	if err != nil {
+		return enginepb.MVCCStats{}, EvalResult{}, err
+	}
 
 	// TODO(d4l3k): we should check which side of the split is smaller
 	// and compute stats for it instead of having a constraint that the
@@ -2866,7 +2905,7 @@ func (r *Replica) splitTrigger(
 	// Copy the last replica GC timestamp. This value is unreplicated,
 	// which is why the MVCC stats are set to nil on calls to
 	// MVCCPutProto.
-	replicaGCTS, err := r.getLastReplicaGCTimestamp(ctx)
+	replicaGCTS, err := rec.GetLastReplicaGCTimestamp(ctx)
 	if err != nil {
 		return enginepb.MVCCStats{}, EvalResult{}, errors.Wrap(err, "unable to fetch last replica GC timestamp")
 	}
@@ -2875,7 +2914,7 @@ func (r *Replica) splitTrigger(
 	}
 
 	// Initialize the RHS range's abort cache by copying the LHS's.
-	seqCount, err := r.abortCache.CopyInto(batch, &bothDeltaMS, split.RightDesc.RangeID)
+	seqCount, err := rec.AbortCache().CopyInto(batch, &bothDeltaMS, split.RightDesc.RangeID)
 	if err != nil {
 		// TODO(tschottdorf): ReplicaCorruptionError.
 		return enginepb.MVCCStats{}, EvalResult{}, errors.Wrap(err, "unable to copy abort cache to RHS split range")
@@ -2957,7 +2996,7 @@ func (r *Replica) splitTrigger(
 		// to not reading from the batch is that we won't see any writes to the
 		// right hand side's hard state that were previously made in the batch
 		// (which should be impossible).
-		oldHS, err := loadHardState(ctx, r.store.Engine(), split.RightDesc.RangeID)
+		oldHS, err := loadHardState(ctx, rec.Engine(), split.RightDesc.RangeID)
 		if err != nil {
 			return enginepb.MVCCStats{}, EvalResult{}, errors.Wrap(err, "unable to load hard state")
 		}
@@ -2980,7 +3019,7 @@ func (r *Replica) splitTrigger(
 		//
 		// TODO(tschottdorf): why would this use r.store.Engine() and not the
 		// batch?
-		leftLease, err := r.stateLoader.loadLease(ctx, r.store.Engine())
+		leftLease, err := rec.stateLoader().loadLease(ctx, rec.Engine())
 		if err != nil {
 			return enginepb.MVCCStats{}, EvalResult{}, errors.Wrap(err, "unable to load lease")
 		}
@@ -3011,9 +3050,13 @@ func (r *Replica) splitTrigger(
 	// Compute how much data the left-hand side has shed by splitting.
 	// We've already recomputed that in absolute terms, so all we need to do is
 	// to turn it into a delta so the upstream machinery can digest it.
-	leftDeltaMS := leftMS                  // start with new left-hand side absolute stats
-	leftDeltaMS.Subtract(r.GetMVCCStats()) // subtract pre-split absolute stats
-	leftDeltaMS.ContainsEstimates = false  // if there were any, recomputation removed them
+	leftDeltaMS := leftMS // start with new left-hand side absolute stats
+	recStats, err := rec.GetMVCCStats()
+	if err != nil {
+		return enginepb.MVCCStats{}, EvalResult{}, err
+	}
+	leftDeltaMS.Subtract(recStats)        // subtract pre-split absolute stats
+	leftDeltaMS.ContainsEstimates = false // if there were any, recomputation removed them
 
 	// Perform a similar computation for the right hand side. The difference
 	// is that there isn't yet a Replica which could apply these stats, so
@@ -3145,14 +3188,18 @@ func (r *Replica) AdminMerge(
 //
 // TODO(tschottdorf): give mergeTrigger more idiomatic stats computation as
 // in splitTrigger.
-func (r *Replica) mergeTrigger(
+func mergeTrigger(
 	ctx context.Context,
+	rec ReplicaEvalContext,
 	batch engine.Batch,
 	ms *enginepb.MVCCStats,
 	merge *roachpb.MergeTrigger,
 	ts hlc.Timestamp,
 ) (EvalResult, error) {
-	desc := r.Desc()
+	desc, err := rec.Desc()
+	if err != nil {
+		return EvalResult{}, err
+	}
 	if !bytes.Equal(desc.StartKey, merge.LeftDesc.StartKey) {
 		return EvalResult{}, errors.Errorf("LHS range start keys do not match: %s != %s",
 			desc.StartKey, merge.LeftDesc.StartKey)
@@ -3169,7 +3216,10 @@ func (r *Replica) mergeTrigger(
 	}
 
 	// Compute stats for premerged range, including current transaction.
-	var mergedMS = r.GetMVCCStats()
+	mergedMS, err := rec.GetMVCCStats()
+	if err != nil {
+		return EvalResult{}, err
+	}
 	mergedMS.Add(*ms)
 	// We will recompute the stats below and update the state, so when the
 	// batch commits it has already taken ms into account.
@@ -3185,7 +3235,7 @@ func (r *Replica) mergeTrigger(
 	mergedMS.Add(rightMS)
 
 	// Copy the RHS range's abort cache to the new LHS one.
-	if _, err := r.abortCache.CopyFrom(ctx, batch, &mergedMS, rightRangeID); err != nil {
+	if _, err := rec.AbortCache().CopyFrom(ctx, batch, &mergedMS, rightRangeID); err != nil {
 		return EvalResult{}, errors.Errorf("unable to copy abort cache to new split range: %s", err)
 	}
 
@@ -3209,7 +3259,7 @@ func (r *Replica) mergeTrigger(
 	mergedMS.Add(msRange)
 
 	// Set stats for updated range.
-	if err := r.stateLoader.setMVCCStats(ctx, batch, &mergedMS); err != nil {
+	if err := rec.stateLoader().setMVCCStats(ctx, batch, &mergedMS); err != nil {
 		return EvalResult{}, errors.Errorf("unable to write MVCC stats: %s", err)
 	}
 
@@ -3218,8 +3268,11 @@ func (r *Replica) mergeTrigger(
 	// caches for efficiency. But it's unlikely and not worth the extra
 	// logic and potential for error.
 
-	*ms = r.GetMVCCStats()
-	mergedMS.Subtract(r.GetMVCCStats())
+	*ms, err = rec.GetMVCCStats()
+	if err != nil {
+		return EvalResult{}, err
+	}
+	mergedMS.Subtract(*ms)
 	*ms = mergedMS
 
 	var pd EvalResult
@@ -3230,8 +3283,11 @@ func (r *Replica) mergeTrigger(
 	return pd, nil
 }
 
-func (r *Replica) changeReplicasTrigger(
-	ctx context.Context, batch engine.Batch, change *roachpb.ChangeReplicasTrigger,
+func changeReplicasTrigger(
+	ctx context.Context,
+	rec ReplicaEvalContext,
+	batch engine.Batch,
+	change *roachpb.ChangeReplicasTrigger,
 ) EvalResult {
 	var pd EvalResult
 	// After a successful replica addition or removal check to see if the
@@ -3248,9 +3304,17 @@ func (r *Replica) changeReplicasTrigger(
 	// replica was being removed. Note that we attempt the gossiping even from
 	// the removed replica in case it was the lease-holder and it is still
 	// holding the lease.
-	pd.Local.gossipFirstRange = r.IsFirstRange()
+	pd.Local.gossipFirstRange = rec.IsFirstRange()
 
-	cpy := *r.Desc()
+	var cpy roachpb.RangeDescriptor
+	{
+		desc, err := rec.Desc()
+		if err != nil {
+			// Only happens if we failed to declare access to the range descriptor key.
+			log.Fatalf(ctx, "failed to retrieve range descriptor: %s", err)
+		}
+		cpy = *desc
+	}
 	cpy.Replicas = change.UpdatedReplicas
 	cpy.NextReplicaID = change.NextReplicaID
 	// TODO(tschottdorf): duplication of Desc with the trigger below, should
@@ -3650,9 +3714,11 @@ func updateRangeDescriptor(
 func evalLeaseInfo(
 	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (EvalResult, error) {
-	r := cArgs.Repl
 	reply := resp.(*roachpb.LeaseInfoResponse)
-	lease, nextLease := r.getLease()
+	lease, nextLease, err := cArgs.EvalCtx.GetLease()
+	if err != nil {
+		return EvalResult{}, err
+	}
 	if nextLease != nil {
 		// If there's a lease request in progress, speculatively return that future
 		// lease.

--- a/pkg/storage/replica_state.go
+++ b/pkg/storage/replica_state.go
@@ -17,6 +17,12 @@
 package storage
 
 import (
+	"github.com/coreos/etcd/raft/raftpb"
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
@@ -25,9 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/coreos/etcd/raft/raftpb"
-	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // replicaStateLoader contains the precomputed range-local replicated and
@@ -579,4 +582,146 @@ func writeInitialState(
 	}
 
 	return newMS, nil
+}
+
+// ReplicaEvalContext is the interface through which command
+// evaluation accesses the in-memory state of a Replica. Any state
+// that corresponds to (mutable) on-disk data must be registered in
+// the SpanSet if one is given.
+type ReplicaEvalContext struct {
+	repl *Replica
+	ss   *SpanSet
+}
+
+// In-memory state, immutable fields, and debugging methods are accessed directly.
+
+// NodeID returns the Replica's NodeID.
+func (rec ReplicaEvalContext) NodeID() roachpb.NodeID {
+	return rec.repl.NodeID()
+}
+
+// StoreID returns the Replica's StoreID.
+func (rec ReplicaEvalContext) StoreID() roachpb.StoreID {
+	return rec.repl.store.StoreID()
+}
+
+// RangeID returns the Replica's RangeID.
+func (rec ReplicaEvalContext) RangeID() roachpb.RangeID {
+	return rec.repl.RangeID
+}
+
+// IsFirstRange returns true if this replica is the first range in the
+// system.
+func (rec ReplicaEvalContext) IsFirstRange() bool {
+	return rec.repl.IsFirstRange()
+}
+
+// String returns a string representation of the Replica.
+func (rec ReplicaEvalContext) String() string {
+	return rec.repl.String()
+}
+
+// StoreTestingKnobs returns the Replica's StoreTestingKnobs.
+func (rec ReplicaEvalContext) StoreTestingKnobs() StoreTestingKnobs {
+	return rec.repl.store.cfg.TestingKnobs
+}
+
+// Tracer returns the Replica's Tracer.
+func (rec ReplicaEvalContext) Tracer() opentracing.Tracer {
+	return rec.repl.store.Tracer()
+}
+
+// DB returns the Replica's client DB.
+func (rec ReplicaEvalContext) DB() *client.DB {
+	return rec.repl.store.DB()
+}
+
+// Store returns the Replica's Store.
+func (rec ReplicaEvalContext) Store() *Store {
+	return rec.repl.store
+}
+
+// Engine returns the Replica's underlying Engine. In most cases the
+// evaluation Batch should be used instead.
+func (rec ReplicaEvalContext) Engine() engine.Engine {
+	return rec.repl.store.Engine()
+}
+
+// AbortCache returns the Replica's AbortCache.
+func (rec ReplicaEvalContext) AbortCache() *AbortCache {
+	// Despite its name, the abort cache doesn't hold on-disk data in
+	// memory. It just provides methods that take a Batch, so SpanSet
+	// declarations are enforced there.
+	return rec.repl.abortCache
+}
+
+// stateLoader returns the Replica's replicaStateLoader.
+func (rec ReplicaEvalContext) stateLoader() replicaStateLoader {
+	// replicaStateLoader's methods take a Batch argument; SpanSet
+	// declarations are enforced there.
+	return rec.repl.stateLoader
+}
+
+// pushTxnQueue returns the Replica's pushTxnQueue.
+func (rec ReplicaEvalContext) pushTxnQueue() *pushTxnQueue {
+	return rec.repl.pushTxnQueue
+}
+
+// FirstIndex returns the oldest index in the raft log.
+func (rec ReplicaEvalContext) FirstIndex() (uint64, error) {
+	return rec.repl.FirstIndex()
+}
+
+// Term returns the term of the given entry in the raft log.
+func (rec ReplicaEvalContext) Term(i uint64) (uint64, error) {
+	return rec.repl.Term(i)
+}
+
+// Fields backed by on-disk data must be registered in the SpanSet.
+// TODO(bdarnell): Add calls to SpanSet.checkAllowed to all of the following.
+
+// Desc returns the Replica's RangeDescriptor.
+func (rec ReplicaEvalContext) Desc() (*roachpb.RangeDescriptor, error) {
+	rec.repl.mu.RLock()
+	defer rec.repl.mu.RUnlock()
+	return rec.repl.mu.state.Desc, nil
+}
+
+// ContainsKey returns true if the given key is within the Replica's range.
+func (rec ReplicaEvalContext) ContainsKey(key roachpb.Key) (bool, error) {
+	return rec.repl.ContainsKey(key), nil
+}
+
+// GetMVCCStats returns the Replica's MVCCStats.
+func (rec ReplicaEvalContext) GetMVCCStats() (enginepb.MVCCStats, error) {
+	return rec.repl.GetMVCCStats(), nil
+}
+
+// GCThreshold returns the GC threshold of the Range, typically updated when
+// keys are garbage collected. Reads and writes at timestamps <= this time will
+// not be served.
+func (rec ReplicaEvalContext) GCThreshold() (hlc.Timestamp, error) {
+	rec.repl.mu.RLock()
+	defer rec.repl.mu.RUnlock()
+	return rec.repl.mu.state.GCThreshold, nil
+}
+
+// TxnSpanGCThreshold returns the time of the Replica's last
+// transaction span GC.
+func (rec ReplicaEvalContext) TxnSpanGCThreshold() (hlc.Timestamp, error) {
+	rec.repl.mu.RLock()
+	defer rec.repl.mu.RUnlock()
+	return rec.repl.mu.state.TxnSpanGCThreshold, nil
+}
+
+// GetLastReplicaGCTimestamp returns the last time the Replica was
+// considered for GC.
+func (rec ReplicaEvalContext) GetLastReplicaGCTimestamp(ctx context.Context) (hlc.Timestamp, error) {
+	return rec.repl.getLastReplicaGCTimestamp(ctx)
+}
+
+// GetLease returns the Replica's current and next lease (if any).
+func (rec ReplicaEvalContext) GetLease() (*roachpb.Lease, *roachpb.Lease, error) {
+	lease, nextLease := rec.repl.getLease()
+	return lease, nextLease, nil
 }

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -734,7 +734,7 @@ func TestReplicaLease(t *testing.T) {
 	} {
 		if _, err := evalRequestLease(context.Background(), tc.store.Engine(),
 			CommandArgs{
-				Repl: tc.repl,
+				EvalCtx: ReplicaEvalContext{tc.repl, nil},
 				Args: &roachpb.RequestLeaseRequest{
 					Lease: lease,
 				},

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -2070,7 +2070,8 @@ func TestStoreChangeFrozen(t *testing.T) {
 		b := tc.store.Engine().NewBatch()
 		defer b.Close()
 		var h roachpb.Header
-		if _, err := evalChangeFrozen(context.Background(), b, CommandArgs{Repl: tc.repl, Header: h, Args: fReqVersMismatch}, &roachpb.ChangeFrozenResponse{}); err != nil {
+		cArgs := CommandArgs{EvalCtx: ReplicaEvalContext{tc.repl, nil}, Header: h, Args: fReqVersMismatch}
+		if _, err := evalChangeFrozen(context.Background(), b, cArgs, &roachpb.ChangeFrozenResponse{}); err != nil {
 			t.Fatal(err)
 		}
 		assertFrozen(no) // since we do not commit the above batch

--- a/pkg/storage/track_raft_protos.go
+++ b/pkg/storage/track_raft_protos.go
@@ -34,7 +34,7 @@ import (
 // instrumentation and returns the list of downstream-of-raft protos.
 func TrackRaftProtos() func() []reflect.Type {
 	// Grab the name of the function that roots all raft operations.
-	applyRaftFunc := runtime.FuncForPC(reflect.ValueOf((*Replica).executeBatch).Pointer()).Name()
+	applyRaftFunc := runtime.FuncForPC(reflect.ValueOf(executeBatch).Pointer()).Name()
 	// Some raft operations trigger gossip, but we don't care about proto
 	// serialization in gossip, so we're going to ignore it.
 	addInfoFunc := runtime.FuncForPC(reflect.ValueOf((*gossip.Gossip).AddInfoProto).Pointer()).Name()


### PR DESCRIPTION
A follow-up change will require that all accesses to the in-memory
fields of the Replica are accompanied by SpanSet declarations for the
corresponding on-disk keys.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14389)
<!-- Reviewable:end -->
