### PR TITLE
ui: Node List Improvements

### DIFF
--- a/pkg/ui/src/components/summaryBar.tsx
+++ b/pkg/ui/src/components/summaryBar.tsx
@@ -1,14 +1,30 @@
 import _ from "lodash";
 import * as React from "react";
+import classNames from "classnames";
 
 import { MetricsDataProvider } from "../containers/metricsDataProvider";
 import { MetricsDataComponentProps } from "../components/graphs";
 
 interface SummaryStatProps {
   title: React.ReactNode;
+  value?: number;
+  format?: (i: number) => string;
+}
+
+interface SummaryHeadlineStatProps extends SummaryStatProps {
+  tooltip?: string;
+}
+
+interface SummaryStatMessageProps {
+  message: string;
+}
+
+interface SummaryStatBreakdownProps {
+  title: React.ReactNode;
   tooltip?: string;
   value?: number;
   format?: (i: number) => string;
+  modifier?: "dead" | "suspect" | "healthy";
 }
 
 function numberToString(n: number) {
@@ -22,52 +38,95 @@ function computeValue(value: number, format: (n: number) => string = numberToStr
   return format(value);
 }
 
-// SummaryBar is a simple component backing a common motif in our UI: a
-// collection of summarized statistics.
-// TODO(mrtracy): Add tooltip support.
+/**
+ * SummaryBar is a simple component backing a common motif in our UI - a
+ * collection of summarized statistics.
+ */
 export function SummaryBar(props: { children?: React.ReactNode }) {
   return <div className="summary-section">
     { props.children }
   </div>;
 }
 
+/**
+ * SummaryStat places a single labeled statistic onto a summary bar; this
+ * consists of a label and a formatted value. Summary stats are visually
+ * separated from other summary stats. A summary stat can contain children, such
+ * as messages and breakdowns.
+ */
+export function SummaryStat(props: SummaryStatProps & {children?: React.ReactNode}) {
+  return <div className="summary-stat">
+    <div className="summary-stat__body">
+      <span className="summary-stat__title">
+        { props.title }
+      </span>
+      <span className="summary-stat__value">
+        { computeValue(props.value, props.format) }
+      </span>
+    </div>
+    { props.children }
+  </div>;
+}
+
+/**
+ * SummaryLabel places a label onto a SummaryBar without a corresponding
+ * statistic. This can be used to label a section of the bar.
+ */
 export function SummaryLabel(props: {children?: React.ReactNode}) {
   return <div className="summary-label">
     { props.children }
   </div>;
 }
 
-export function SummaryStat(props: SummaryStatProps & {children?: React.ReactNode}) {
-  return <div className="summary-stat">
-    <span className="summary-stat__title">
-      { props.title }
-    </span>
-    <span className="summary-stat__value">
-      { computeValue(props.value, props.format) }
-    </span>
-    {
-      !!props.tooltip ?
-        <span className="summary-stat__tooltip">{ props.tooltip }</span>
-        : null
-    }
+/**
+ * SummaryStatMessage can be placed inside of a SummaryStat to provide visible
+ * descriptive information about that statistic.
+ */
+export function SummaryStatMessage(props: SummaryStatMessageProps & {children?: React.ReactNode}) {
+  return <span className="summary-stat__tooltip">{ props.message }</span>;
+}
+
+/**
+ * SummaryStatBreakdown can be placed inside of a SummaryStat to provide
+ * a detailed breakdown of the main statistic. Each breakdown contains a label
+ * and numeric statistic.
+ */
+export function SummaryStatBreakdown(props: SummaryStatBreakdownProps & {children?: React.ReactNode}) {
+  const modifierClass = props.modifier ? `summary-stat-breakdown--${props.modifier}` : null;
+  return <div className={classNames("summary-stat-breakdown", modifierClass)}>
+    <div className="summary-stat-breakdown__body">
+      <span className="summary-stat-breakdown__title">
+        { props.title }
+      </span>
+      <span className="summary-stat-breakdown__value">
+        { computeValue(props.value, props.format) }
+      </span>
+    </div>
   </div>;
 }
 
-function SummaryMetricStatHelper(props: MetricsDataComponentProps & SummaryStatProps & { children?: React.ReactNode }) {
-  let datapoints = props.data && props.data.results && props.data.results[0] && props.data.results[0].datapoints;
-  let value = datapoints && datapoints[0] && _.last(datapoints).value;
-  return <SummaryStat {...props} value={_.isNumber(value) ? value : props.value} />;
-}
-
+/**
+ * SummaryMetricStat is a helpful component that creates a SummaryStat where
+ * metric data is automatically derived from a metric component.
+ */
 export function SummaryMetricStat(props: SummaryStatProps & { id: string } & { children?: React.ReactNode }) {
   return <MetricsDataProvider current id={props.id} >
     <SummaryMetricStatHelper {...props} />
   </MetricsDataProvider>;
 }
 
-// SummaryHeadlineStat displays a single item in a summary bar as a "Headline
-// Stat", which is formatted to place attention on the number.
-export class SummaryHeadlineStat extends React.Component<SummaryStatProps, {}> {
+function SummaryMetricStatHelper(props: MetricsDataComponentProps & SummaryStatProps & { children?: React.ReactNode }) {
+  const datapoints = props.data && props.data.results && props.data.results[0] && props.data.results[0].datapoints;
+  const value = datapoints && datapoints[0] && _.last(datapoints).value;
+  const {title, format} = props;
+  return <SummaryStat title={title} format={format} value={_.isNumber(value) ? value : props.value} />;
+}
+
+/**
+ * SummaryHeadlineStat is similar to a normal SummaryStat, but is visually laid
+ * out to draw attention to the numerical statistic.
+ */
+export class SummaryHeadlineStat extends React.Component<SummaryHeadlineStatProps, {}> {
   render() {
     return <div className="summary-headline">
       <div className="summary-headline__value">{computeValue(this.props.value, this.props.format)}</div>

--- a/pkg/ui/src/containers/nodesOverview.tsx
+++ b/pkg/ui/src/containers/nodesOverview.tsx
@@ -6,7 +6,7 @@ import { createSelector } from "reselect";
 import _ from "lodash";
 
 import {
-  NodesSummary, nodesSummarySelector, LivenessStatus, deadTimeout, suspectTimeout,
+  NodesSummary, nodesSummarySelector, LivenessStatus, deadTimeout,
 } from "../redux/nodes";
 import { SummaryBar, SummaryHeadlineStat } from "../components/summaryBar";
 import { AdminUIState } from "../redux/state";
@@ -70,16 +70,23 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
             sortSetting={sortSetting}
             onChangeSortSetting={(setting) => this.changeSortSetting(setting)}
             columns={[
-              // Node column - displays the node ID, links to the node-specific page for
-              // this node.
+              // Node ID column.
               {
-                title: "Node",
+                title: "ID",
+                cell: (ns) => ns.desc.node_id,
+                sort: (ns) => ns.desc.node_id,
+              },
+              // Node address column - displays the node address, links to the
+              // node-specific page for this node.
+              {
+                title: "Address",
                 cell: (ns) => {
                   const status = nodesSummary.livenessStatusByNodeID[ns.desc.node_id] || 0;
                   const s = LivenessStatus[status].toLowerCase();
                   const tooltip = (status === LivenessStatus.HEALTHY) ?
                     "This node is currently healthy." :
-                    `This node has not reported as being live for over ${suspectTimeout.humanize()}.`;
+                    "This node has not recently reported as being live. " +
+                    "It may not be functioning correctly, but no automatic action has yet been taken.";
                   return <div>
                     <Link to={"/nodes/" + ns.desc.node_id}>{ns.desc.address.address_field}</Link>
                     <div className={"icon-circle-filled node-status-icon node-status-icon--" + s} title={tooltip} />
@@ -180,15 +187,21 @@ class DeadNodeList extends React.Component<NodeCategoryListProps, {}> {
             sortSetting={sortSetting}
             onChangeSortSetting={(setting) => this.changeSortSetting(setting)}
             columns={[
-              // Node column - displays the node ID, links to the node-specific page for
-              // this node.
+              // Node ID column.
               {
-                title: "Node",
+                title: "ID",
+                cell: (ns) => ns.desc.node_id,
+                sort: (ns) => ns.desc.node_id,
+              },
+              // Node address column - displays the node address, links to the
+              // node-specific page for this node.
+              {
+                title: "Address",
                 cell: (ns) => {
                   return <div>
                     <Link to={"/nodes/" + ns.desc.node_id}>{ns.desc.address.address_field}</Link>
                     <div className="icon-circle-filled node-status-icon node-status-icon--dead"
-                         title={`This node has not reported as being live for over ${deadTimeout.humanize()} and is considered dead.`}
+                         title={`This node has not reported as live for over ${deadTimeout.humanize()} and is considered dead.`}
                          />
                   </div>;
                 },

--- a/pkg/ui/styl/components/summarybar.styl
+++ b/pkg/ui/styl/components/summarybar.styl
@@ -35,6 +35,9 @@
   padding 10px 0
   line-height 18px
 
+  &__body
+    clearfix()
+
   &__title
     color $light-blue
     float left
@@ -58,3 +61,25 @@
 
   & + .summary-stat
     border-top 1px solid rgb(242, 242, 242)
+
+.summary-stat-breakdown
+  padding 2px 0
+
+  &--dead
+    color $secondary-red
+
+  &--suspect
+    color $secondary-gold
+
+  &--healthy
+    color $main-green
+
+  &__body
+    clearfix()
+
+  &__title
+    float left
+    margin-right 2em
+
+  &__value
+    float right


### PR DESCRIPTION
The "Node Totals" on the cluster overview page, which links to the Node List,
now provides a detailed breakdown whenever any nodes in the cluster are in the
suspect or dead state.
Resolves #5303
Resolves #13895

A "Node ID" column has been added to the tables on the Node List page; this
allows us to disambiguate between nodes with the same address, an apparently
common occurrence in early clusters.
Resolves #12587

Finally, the cutoff for marking a node in the "Suspect" state has been changed;
rather than an arbitrary 1-minute timeout for expiration, nodes are now
considered suspect immediately if their liveness record is expired. This allows
for much more rapid updates in the UI when a node is take offline, something
that will improve our demoability considerably. This does not fix a specific
issue, but is something I have been considering since adding the suspect
timeout.

![screen shot 2017-03-22 at 4 03 08 pm](https://cloud.githubusercontent.com/assets/6969858/24377147/535844da-130c-11e7-96ec-38a960af39c3.png)

![screen shot 2017-03-27 at 4 25 20 pm](https://cloud.githubusercontent.com/assets/6969858/24377155/56134f08-130c-11e7-8187-60452625ef78.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14395)
<!-- Reviewable:end -->
