### PR TITLE
storage: allocate tmpdir under store path (and plumb it to ccl calls)

### DIFF
--- a/pkg/ccl/sqlccl/bench_test.go
+++ b/pkg/ccl/sqlccl/bench_test.go
@@ -44,7 +44,7 @@ func BenchmarkClusterBackup(b *testing.B) {
 	defer cleanupFn()
 
 	ts := hlc.Timestamp{WallTime: hlc.UnixNano()}
-	if _, err := Load(ctx, sqlDB.DB, bankStatementBuf(b.N), "bench", dir, ts, 0); err != nil {
+	if _, err := Load(ctx, sqlDB.DB, bankStatementBuf(b.N), "bench", dir, ts, 0, dir); err != nil {
 		b.Fatalf("%+v", err)
 	}
 	sqlDB.Exec(fmt.Sprintf(`RESTORE DATABASE bench FROM '%s'`, dir))
@@ -79,7 +79,7 @@ func BenchmarkClusterRestore(b *testing.B) {
 	defer cleanup()
 
 	ts := hlc.Timestamp{WallTime: hlc.UnixNano()}
-	backup, err := Load(ctx, sqlDB.DB, bankStatementBuf(b.N), "bench", dir, ts, 0)
+	backup, err := Load(ctx, sqlDB.DB, bankStatementBuf(b.N), "bench", dir, ts, 0, dir)
 	if err != nil {
 		b.Fatalf("%+v", err)
 	}
@@ -105,7 +105,7 @@ func BenchmarkLoadRestore(b *testing.B) {
 	b.SetBytes(int64(buf.Len() / b.N))
 	ts := hlc.Timestamp{WallTime: hlc.UnixNano()}
 	b.ResetTimer()
-	if _, err := Load(ctx, sqlDB.DB, buf, "bench", dir, ts, 0); err != nil {
+	if _, err := Load(ctx, sqlDB.DB, buf, "bench", dir, ts, 0, dir); err != nil {
 		b.Fatalf("%+v", err)
 	}
 	sqlDB.Exec(fmt.Sprintf(`RESTORE DATABASE bench FROM '%s'`, dir))

--- a/pkg/ccl/sqlccl/load_test.go
+++ b/pkg/ccl/sqlccl/load_test.go
@@ -26,7 +26,7 @@ func TestImportChunking(t *testing.T) {
 	defer cleanupFn()
 
 	ts := hlc.Timestamp{WallTime: hlc.UnixNano()}
-	desc, err := Load(ctx, sqlDB.DB, bankStatementBuf(numAccounts), "bench", dir, ts, chunkSize)
+	desc, err := Load(ctx, sqlDB.DB, bankStatementBuf(numAccounts), "bench", dir, ts, chunkSize, dir)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
@@ -46,7 +46,7 @@ func TestImportOutOfOrder(t *testing.T) {
 	buf.WriteString(stmts[0] + ";\n")
 
 	ts := hlc.Timestamp{WallTime: hlc.UnixNano()}
-	_, err := Load(ctx, sqlDB.DB, &buf, "bench", dir, ts, 0)
+	_, err := Load(ctx, sqlDB.DB, &buf, "bench", dir, ts, 0, dir)
 	if !testutils.IsError(err, "out of order row") {
 		t.Fatalf("expected out of order row, got: %+v", err)
 	}
@@ -64,7 +64,7 @@ func BenchmarkImport(b *testing.B) {
 	ts := hlc.Timestamp{WallTime: hlc.UnixNano()}
 	b.SetBytes(int64(buf.Len() / b.N))
 	b.ResetTimer()
-	if _, err := Load(ctx, sqlDB.DB, buf, "bench", dir, ts, 0); err != nil {
+	if _, err := Load(ctx, sqlDB.DB, buf, "bench", dir, ts, 0, dir); err != nil {
 		b.Fatalf("%+v", err)
 	}
 }

--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -74,12 +74,12 @@ func evalExport(
 	defer exportStore.Close()
 
 	filename := fmt.Sprintf("%d.sst", parser.GenerateUniqueInt(cArgs.EvalCtx.NodeID()))
-	tmp, err := MakeExportFileTmpWriter(ctx, exportStore, filename)
+	temp, err := MakeExportFileTmpWriter(ctx, cArgs.EvalCtx.GetTempPrefix(), exportStore, filename)
 	if err != nil {
 		return storage.EvalResult{}, err
 	}
-	localPath := tmp.LocalFile()
-	defer tmp.Close(ctx)
+	localPath := temp.LocalFile()
+	defer temp.Close(ctx)
 
 	sstWriter := engine.MakeRocksDBSstFileWriter()
 	sst := &sstWriter
@@ -138,7 +138,7 @@ func evalExport(
 		return storage.EvalResult{}, err
 	}
 
-	if err := tmp.Finish(ctx); err != nil {
+	if err := temp.Finish(ctx); err != nil {
 		return storage.EvalResult{}, err
 	}
 

--- a/pkg/ccl/storageccl/export_storage.go
+++ b/pkg/ccl/storageccl/export_storage.go
@@ -503,19 +503,24 @@ func (s *azureStorage) Close() error {
 
 // FetchFile returns the path to a local file containing the content of
 // the requested filename, and a cleanup func to be called when done reading it.
-func FetchFile(ctx context.Context, e ExportStorage, basename string) (string, func(), error) {
+func FetchFile(
+	ctx context.Context, tempPrefix string, e ExportStorage, basename string,
+) (string, func(), error) {
 	cleanup := func() {}
 	// special-case local files to avoid copying to tmp.
 	if loc, ok := e.(*localFileStorage); ok {
 		return filepath.Join(loc.base, basename), cleanup, nil
 	}
 
+	if tempPrefix == "" {
+		return "", cleanup, errors.New("must provide tempdir path")
+	}
 	r, err := e.ReadFile(ctx, basename)
 	if err != nil {
 		return "", cleanup, errors.Wrapf(err, "creating reader for %q", basename)
 	}
 	defer r.Close()
-	f, err := ioutil.TempFile("", basename)
+	f, err := ioutil.TempFile(tempPrefix, basename)
 	if err != nil {
 		return "", cleanup, errors.Wrap(err, "creating tmpfile")
 	}
@@ -563,7 +568,7 @@ var _ ExportFileWriter = &tmpWriter{}
 
 // MakeExportFileTmpWriter returns an ExportFileWriter backed by a tempfile.
 func MakeExportFileTmpWriter(
-	ctx context.Context, store ExportStorage, name string,
+	_ context.Context, tempPrefix string, store ExportStorage, name string,
 ) (ExportFileWriter, error) {
 	// the special-case that allows local stores to rename rather than copy works
 	// only if we alloc the tempfile on same device, so we force dest prefix here.
@@ -578,7 +583,10 @@ func MakeExportFileTmpWriter(
 		return &localTmpWriter{tmpWriter{tmpfile: f}, filepath.Join(loc.base, name)}, nil
 	}
 
-	f, err := ioutil.TempFile("", name)
+	if tempPrefix == "" {
+		return nil, errors.New("must provide tempdir path")
+	}
+	f, err := ioutil.TempFile(tempPrefix, name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/storageccl/export_storage_test.go
+++ b/pkg/ccl/storageccl/export_storage_test.go
@@ -29,6 +29,8 @@ import (
 
 func testExportToTarget(t *testing.T, args roachpb.ExportStorage) {
 	ctx := context.TODO()
+	dir, dirCleanup := testutils.TempDir(t, 0)
+	defer dirCleanup()
 
 	// Setup a sink for the given args.
 	s, err := MakeExportStorage(ctx, args)
@@ -75,13 +77,13 @@ func testExportToTarget(t *testing.T, args roachpb.ExportStorage) {
 		}
 		testingFilename := "testing-123"
 
-		tmp, err := MakeExportFileTmpWriter(ctx, s, testingFilename)
+		temp, err := MakeExportFileTmpWriter(ctx, dir, s, testingFilename)
 		if err != nil {
 			t.Fatal(err)
 		}
 		// Write something to the local file specified by our sink.
-		t.Logf("writing %d bytes to %s", len(testingContent), tmp.LocalFile())
-		reopened, err := os.Create(tmp.LocalFile())
+		t.Logf("writing %d bytes to %s", len(testingContent), temp.LocalFile())
+		reopened, err := os.Create(temp.LocalFile())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -91,7 +93,7 @@ func testExportToTarget(t *testing.T, args roachpb.ExportStorage) {
 		}
 		reopened.Close()
 
-		if err := tmp.Finish(ctx); err != nil {
+		if err := temp.Finish(ctx); err != nil {
 			t.Fatal(err)
 		}
 

--- a/pkg/ccl/storageccl/export_test.go
+++ b/pkg/ccl/storageccl/export_test.go
@@ -59,7 +59,7 @@ func TestExport(t *testing.T) {
 		for _, file := range res.(*roachpb.ExportResponse).Files {
 			paths = append(paths, file.Path)
 
-			sst, err := engine.MakeRocksDBSstFileReader()
+			sst, err := engine.MakeRocksDBSstFileReader(dir)
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -98,8 +98,8 @@ func evalImport(ctx context.Context, cArgs storage.CommandArgs) error {
 				log.Warningf(ctx, "close export storage failed %v", err)
 			}
 		}()
-
-		localPath, cleanup, err := FetchFile(ctx, dir, file.Path)
+		tempPrefix := cArgs.EvalCtx.GetTempPrefix()
+		localPath, cleanup, err := FetchFile(ctx, tempPrefix, dir, file.Path)
 		if err != nil {
 			return err
 		}
@@ -115,7 +115,7 @@ func evalImport(ctx context.Context, cArgs storage.CommandArgs) error {
 			}
 		}
 
-		sst, err := engine.MakeRocksDBSstFileReader()
+		sst, err := engine.MakeRocksDBSstFileReader(tempPrefix)
 		if err != nil {
 			return err
 		}

--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -44,7 +44,7 @@ func slurpSSTablesLatestKey(
 	defer batch.Close()
 
 	for _, path := range paths {
-		sst, err := engine.MakeRocksDBSstFileReader()
+		sst, err := engine.MakeRocksDBSstFileReader(dir)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -180,6 +180,8 @@ type Engine interface {
 	Flush() error
 	// GetStats retrieves stats from the engine.
 	GetStats() (*Stats, error)
+	// GetTempDir returns a path under which tempdirs or tempfiles can be created.
+	GetTempDir() string
 	// NewBatch returns a new instance of a batched engine which wraps
 	// this engine. Batched engines accumulate all mutations and apply
 	// them atomically on a call to Commit().
@@ -199,6 +201,8 @@ type Engine interface {
 	// by invoking Close(). Note that snapshots must not be used after the
 	// original engine has been stopped.
 	NewSnapshot() Reader
+	// SetTempDir overrides the tempdir path returned by GetTempDir.
+	SetTempDir(dir string) error
 }
 
 // Batch is the interface for batch specific operations.

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -287,6 +287,7 @@ type RocksDB struct {
 	rdb          *C.DBEngine
 	attrs        roachpb.Attributes // Attributes for this engine
 	dir          string             // The data directory
+	tempDir      string             // A path for storing temp files (ideally under dir).
 	cache        RocksDBCache       // Shared cache.
 	maxSize      int64              // Used for calculating rebalancing and free space.
 	maxOpenFiles int                // The maximum number of open files this instance will use.
@@ -317,6 +318,7 @@ func NewRocksDB(
 	if dir == "" {
 		panic("dir must be non-empty")
 	}
+
 	r := &RocksDB{
 		attrs:        attrs,
 		dir:          dir,
@@ -325,6 +327,16 @@ func NewRocksDB(
 		maxOpenFiles: maxOpenFiles,
 		deallocated:  make(chan struct{}),
 	}
+
+	temp := filepath.Join(dir, "tmp")
+	if err := os.RemoveAll(temp); err != nil {
+		return nil, err
+	}
+
+	if err := r.SetTempDir(temp); err != nil {
+		return nil, err
+	}
+
 	if err := r.open(); err != nil {
 		return nil, err
 	}
@@ -339,9 +351,15 @@ func newMemRocksDB(attrs roachpb.Attributes, cache RocksDBCache, maxSize int64) 
 		maxSize:     maxSize,
 		deallocated: make(chan struct{}),
 	}
+
+	if err := r.SetTempDir(os.TempDir()); err != nil {
+		return nil, err
+	}
+
 	if err := r.open(); err != nil {
 		return nil, err
 	}
+
 	return r, nil
 }
 
@@ -1674,8 +1692,11 @@ type RocksDBSstFileReader struct {
 
 // MakeRocksDBSstFileReader creates a RocksDBSstFileReader that uses a scratch
 // directory which is cleaned up by `Close`.
-func MakeRocksDBSstFileReader() (RocksDBSstFileReader, error) {
-	dir, err := ioutil.TempDir("", "RocksDBSstFileReader")
+func MakeRocksDBSstFileReader(tempPrefix string) (RocksDBSstFileReader, error) {
+	if tempPrefix == "" {
+		return RocksDBSstFileReader{}, errors.New("must provide a tempdir path")
+	}
+	dir, err := ioutil.TempDir(tempPrefix, "RocksDBSstFileReader")
 	if err != nil {
 		return RocksDBSstFileReader{}, err
 	}
@@ -1789,4 +1810,18 @@ func RunLDB(args []string) {
 	}()
 
 	C.DBRunLDB(C.int(len(argv)), &argv[0])
+}
+
+// GetTempDir returns a temp path (usually under the store directory).
+func (r *RocksDB) GetTempDir() string {
+	return r.tempDir
+}
+
+// SetTempDir allows overriding the tempdir returned by GetTempDir.
+func (r *RocksDB) SetTempDir(d string) error {
+	if err := os.MkdirAll(d, 0755); err != nil {
+		return err
+	}
+	r.tempDir = d
+	return nil
 }

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -502,7 +502,7 @@ func BenchmarkRocksDBSstFileReader(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	sst, err := MakeRocksDBSstFileReader()
+	sst, err := MakeRocksDBSstFileReader(dir)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4918,3 +4918,8 @@ func calcGoodReplicas(
 	}
 	return goodReplicas, behindCount
 }
+
+// GetTempPrefix proxies Store.GetTempPrefix.
+func (r *Replica) GetTempPrefix() string {
+	return r.store.GetTempPrefix()
+}

--- a/pkg/storage/replica_state.go
+++ b/pkg/storage/replica_state.go
@@ -725,3 +725,8 @@ func (rec ReplicaEvalContext) GetLease() (*roachpb.Lease, *roachpb.Lease, error)
 	lease, nextLease := rec.repl.getLease()
 	return lease, nextLease, nil
 }
+
+// GetTempPrefix proxies Replica.GetTempDir
+func (rec ReplicaEvalContext) GetTempPrefix() string {
+	return rec.repl.GetTempPrefix()
+}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -4065,6 +4065,12 @@ func (s *Store) FrozenStatus(collectFrozen bool) (repDescs []roachpb.ReplicaDesc
 	return
 }
 
+// GetTempPrefix returns a path where temporary files and directories can be
+// allocated.
+func (s *Store) GetTempPrefix() string {
+	return s.engine.GetTempDir()
+}
+
 // The methods below can be used to control a store's queues. Stopping a queue
 // is only meant to happen in tests.
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14397)
<!-- Reviewable:end -->
