### PR TITLE
storage: fix 1PC snapshot behavior

### DIFF
--- a/pkg/sql/upsert_test.go
+++ b/pkg/sql/upsert_test.go
@@ -21,6 +21,9 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"golang.org/x/net/context"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -124,5 +127,63 @@ func TestUpsertFastPath(t *testing.T) {
 	}
 	if s := atomic.LoadUint64(&beginTxn); s != 0 {
 		t.Errorf("expected no begin-txn (1PC) but got %d", s)
+	}
+}
+
+func TestConcurrentUpsertWithSnapshotIsolation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s, conn, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop()
+	sqlDB := sqlutils.MakeSQLRunner(t, conn)
+
+	sqlDB.Exec(`CREATE DATABASE d`)
+	sqlDB.Exec(`CREATE TABLE d.t (a INT PRIMARY KEY, b INT, INDEX b_idx (b))`)
+	sqlDB.Exec(`SET DEFAULT_TRANSACTION_ISOLATION TO SNAPSHOT`)
+
+	testCases := []struct {
+		name       string
+		updateStmt string
+	}{
+		// Upsert case.
+		{
+			name:       "upsert",
+			updateStmt: `UPSERT INTO d.t VALUES (1, $1)`,
+		},
+		// Update case.
+		{
+			name:       "update",
+			updateStmt: `UPDATE d.t SET b = $1 WHERE a = 1`,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			g, ctx := errgroup.WithContext(context.Background())
+			for i := 0; i < 2; i++ {
+				g.Go(func() error {
+					for j := 0; j < 100; j++ {
+						if _, err := sqlDB.DB.ExecContext(ctx, test.updateStmt, j); err != nil {
+							return err
+						}
+					}
+					return nil
+				})
+			}
+			// We select on both the primary key and the secondary
+			// index to highlight the lost update anomaly, which used
+			// to occur on 1PC snapshot-isolation upserts (and updates).
+			// See #14099.
+			if err := g.Wait(); err != nil {
+				t.Errorf(`%+v
+SELECT * FROM d.t@primary = %s
+SELECT * FROM d.t@b_idx   = %s
+`,
+					err,
+					sqlDB.QueryStr(`SELECT * FROM d.t@primary`),
+					sqlDB.QueryStr(`SELECT * FROM d.t@b_idx`),
+				)
+			}
+		})
 	}
 }

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4122,8 +4122,10 @@ func (r *Replica) executeWriteBatch(
 		arg, _ := ba.GetArg(roachpb.EndTransaction)
 		etArg := arg.(*roachpb.EndTransactionRequest)
 
-		// Try executing with transaction stripped.
+		// Try executing with transaction stripped. We use the transaction timestamp
+		// to write any values as it may have been advanced by the timestamp cache.
 		strippedBa := ba
+		strippedBa.Timestamp = strippedBa.Txn.Timestamp
 		strippedBa.Txn = nil
 		strippedBa.Requests = ba.Requests[1 : len(ba.Requests)-1] // strip begin/end txn reqs
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -2973,6 +2973,56 @@ func TestEndTransactionDeadline_1PC(t *testing.T) {
 	}
 }
 
+// Test1PCTransactionWriteTimestamp verifies that the transaction's
+// timestamp is used when writing values in a 1PC transaction. We
+// verify this by updating the timestamp cache for the key being
+// written so that the timestamp there is greater than the txn's
+// OrigTimestamp.
+func Test1PCTransactionWriteTimestamp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	tc := testContext{}
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	tc.Start(t, stopper)
+
+	for _, iso := range []enginepb.IsolationType{enginepb.SNAPSHOT, enginepb.SERIALIZABLE} {
+		t.Run(iso.String(), func(t *testing.T) {
+			key := roachpb.Key(iso.String())
+			txn := newTransaction("test", key, 1, iso, tc.Clock())
+			bt, _ := beginTxnArgs(key, txn)
+			put := putArgs(key, []byte("value"))
+			et, etH := endTxnArgs(txn, true)
+
+			// Update the timestamp cache for the key being written.
+			gArgs := getArgs(key)
+			if _, pErr := tc.SendWrapped(&gArgs); pErr != nil {
+				t.Fatal(pErr)
+			}
+
+			// Now verify that the write triggers a retry for SERIALIZABLE and
+			// writes at the higher timestamp for SNAPSHOT.
+			var ba roachpb.BatchRequest
+			ba.Header = etH
+			ba.Add(&bt, &put, &et)
+			br, pErr := tc.Sender().Send(context.Background(), ba)
+			if iso == enginepb.SNAPSHOT {
+				if pErr != nil {
+					t.Fatal(pErr)
+				}
+				if !txn.OrigTimestamp.Less(br.Txn.Timestamp) {
+					t.Errorf(
+						"expected result timestamp %s > txn orig timestamp %s", br.Txn.Timestamp, txn.OrigTimestamp,
+					)
+				}
+			} else {
+				if _, ok := pErr.GetDetail().(*roachpb.TransactionRetryError); !ok {
+					t.Errorf("expected retry error; got %s", pErr)
+				}
+			}
+		})
+	}
+}
+
 // TestEndTransactionWithMalformedSplitTrigger verifies an
 // EndTransaction call with a malformed commit trigger fails.
 func TestEndTransactionWithMalformedSplitTrigger(t *testing.T) {


### PR DESCRIPTION
This change ensures that the forwarded timestamp on the txn (due to newer
timestamp cache entries on affected batch keys) is used to write values
when running the 1PC commit optimization. We were previously writing using
the original timestamp value which would lead to lost update anomalies.

Fixes #14099

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14401)
<!-- Reviewable:end -->
