### PR TITLE
migrations: split up newDescriptors vs newRanges

### DIFF
--- a/pkg/acceptance/freeze_test.go
+++ b/pkg/acceptance/freeze_test.go
@@ -76,7 +76,7 @@ func postFreeze(
 func testFreezeClusterInner(
 	ctx context.Context, t *testing.T, c cluster.Cluster, cfg cluster.TestConfig,
 ) {
-	minAffected := int64(server.ExpectedInitialRangeCountWithoutMigrations())
+	minAffected := int64(server.GetBootstrapSchema().InitialRangeCount())
 
 	const long = time.Minute
 	const short = 10 * time.Second

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -52,6 +52,7 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		name:           "create system.jobs table",
 		workFn:         createJobsTable,
 		newDescriptors: 1,
+		newRanges:      1,
 	},
 }
 
@@ -64,10 +65,11 @@ type migrationDescriptor struct {
 	// workFn must be idempotent so that we can safely re-run it if a node failed
 	// while running it.
 	workFn func(context.Context, runner) error
-	// newDescriptors is the number of additional descriptors that would be added
-	// by this migration in a fresh cluster. This is needed to automate certain
-	// tests, which check the number of ranges present on server bootup.
-	newDescriptors int
+	// newRanges and descriptors are the number of additional ranges/descriptors
+	// that would be added by this migration in a fresh cluster. This is needed to
+	// automate certain tests, which check the number of ranges/descriptors
+	// present on server bootup.
+	newRanges, newDescriptors int
 }
 
 type runner struct {
@@ -132,26 +134,28 @@ func NewManager(
 	}
 }
 
-// AdditionalInitialDescriptors returns the number of system descriptors that
-// have been added by migrations. This is needed for certain tests, which check
-// the number of ranges at node startup.
+// AdditionalInitialDescriptors returns the number of system descriptors and
+// ranges that have been added by migrations. This is needed for certain tests,
+// which check the number of ranges at node startup.
 //
 // NOTE: This value may be out-of-date if another node is actively running
 // migrations, and so should only be used in test code where the migration
 // lifecycle is tightly controlled.
-func AdditionalInitialDescriptors(ctx context.Context, db db) (int, error) {
+func AdditionalInitialDescriptors(
+	ctx context.Context, db db,
+) (descriptors int, ranges int, _ error) {
 	completedMigrations, err := getCompletedMigrations(ctx, db)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
-	n := 0
 	for _, migration := range backwardCompatibleMigrations {
 		key := migrationKey(migration)
 		if _, ok := completedMigrations[string(key)]; ok {
-			n += migration.newDescriptors
+			descriptors += migration.newDescriptors
+			ranges += migration.newRanges
 		}
 	}
-	return n, nil
+	return descriptors, ranges, nil
 }
 
 // EnsureMigrations should be run during node startup to ensure that all

--- a/pkg/sql/create_test.go
+++ b/pkg/sql/create_test.go
@@ -92,7 +92,7 @@ func TestDatabaseDescriptor(t *testing.T) {
 	if kvs, err := kvDB.Scan(ctx, start, start.PrefixEnd(), 0); err != nil {
 		t.Fatal(err)
 	} else {
-		migrationDescriptors, err := migrations.AdditionalInitialDescriptors(ctx, kvDB)
+		migrationDescriptors, _, err := migrations.AdditionalInitialDescriptors(ctx, kvDB)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/sqlbase/metadata.go
+++ b/pkg/sql/sqlbase/metadata.go
@@ -176,3 +176,14 @@ func (ms MetadataSchema) GetInitialValues() []roachpb.KeyValue {
 	sort.Sort(roachpb.KeyValueByKey(ret))
 	return ret
 }
+
+// InitialRangeCount returns the number of ranges that would be installed if
+// this metadata schema were installed on a fresh cluster and nothing else. Most
+// clusters will have additional ranges installed by migrations, so this
+// function should be used when only a lower bound, and not an exact count, is
+// needed. See server.ExpectedInitialRangeCount() for a count that includes
+// migrations.
+func (ms MetadataSchema) InitialRangeCount() int {
+	const fixedRanges = 2 /* first-range + system-config-range */
+	return len(ms.descs) - ms.configs + fixedRanges
+}


### PR DESCRIPTION
They’re *usually* the same thing, but when they’re not, we need to track
them separately for the tests that care about one or the other.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14402)
<!-- Reviewable:end -->
