### PR TITLE
storage/engine: enable -Wall

### DIFF
--- a/pkg/ccl/storageccl/engineccl/db.cc
+++ b/pkg/ccl/storageccl/engineccl/db.cc
@@ -33,7 +33,10 @@ DBStatus DBBatchReprVerify(
   rocksdb::WriteBatchWithIndex batch(kComparator, 0, true);
   rocksdb::WriteBatch b(ToString(repr));
   std::unique_ptr<rocksdb::WriteBatch::Handler> inserter(GetDBBatchInserter(&batch));
-  b.Iterate(inserter.get());
+  rocksdb::Status status = b.Iterate(inserter.get());
+  if (!status.ok()) {
+    return ToDBStatus(status);
+  }
   std::unique_ptr<rocksdb::Iterator> iter;
   iter.reset(batch.NewIteratorWithBase(rocksdb::NewEmptyIterator()));
 
@@ -50,4 +53,3 @@ DBStatus DBBatchReprVerify(
 
   return kSuccess;
 }
-

--- a/pkg/ccl/storageccl/engineccl/rocksdb.go
+++ b/pkg/ccl/storageccl/engineccl/rocksdb.go
@@ -18,7 +18,7 @@ import (
 
 // #cgo CPPFLAGS: -I../../../../vendor/github.com/cockroachdb/c-protobuf/internal/src
 // #cgo CPPFLAGS: -I../../../../vendor/github.com/cockroachdb/c-rocksdb/internal/include
-// #cgo CXXFLAGS: -std=c++11
+// #cgo CXXFLAGS: -std=c++11 -Wall
 // #cgo !strictld,darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
 // #cgo !strictld,!darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all
 // #cgo linux LDFLAGS: -lrt

--- a/pkg/storage/engine/db_internal.h
+++ b/pkg/storage/engine/db_internal.h
@@ -28,6 +28,9 @@ std::string ToString(DBSlice s);
 // ordering as these keys do not sort lexicographically correctly.
 std::string EncodeKey(DBKey k);
 
+// ToDBStatus converts a rocksdb Status to a DBStatus.
+DBStatus ToDBStatus(const rocksdb::Status& status);
+
 // FmtStatus formats the given arguments printf-style into a DBStatus.
 DBStatus FmtStatus(const char *fmt, ...);
 

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -51,7 +51,7 @@ import (
 
 // #cgo CPPFLAGS: -I../../../vendor/github.com/cockroachdb/c-protobuf/internal/src
 // #cgo CPPFLAGS: -I../../../vendor/github.com/cockroachdb/c-rocksdb/internal/include
-// #cgo CXXFLAGS: -std=c++11
+// #cgo CXXFLAGS: -std=c++11 -Wall
 // #cgo linux LDFLAGS: -lrt
 //
 // #include <stdlib.h>


### PR DESCRIPTION
Enable -Wall for compiling our C++ code and fix the associated warnings.

Do not ignore the return value of WriteBatch::Iterate.

See #13101

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14421)
<!-- Reviewable:end -->
