### PR TITLE
Makefile: force C locale when sorting build/variables.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -381,5 +381,5 @@ build/variables.mk: Makefile .go-version
 	@echo 'define VALID_VARS' >> $@
 	@sed -nE -e '/^	/d' -e 's/([^#]*)#.*/\1/' \
 	  -e 's/(^|^[^:]+:)[ ]*(override|export)?[ ]*([^ ]+)[ ]*[:?+]?=.*/  \3/p' $^ \
-	  | sort -u >> $@
+	  | LC_COLLATE=C sort -u >> $@
 	@echo 'endef' >> $@


### PR DESCRIPTION
@RaduBerinde noticed that build/variables.mk was generated with an alternate sort order on his machine. This occurs because the `en_US.UTF-8` locale sorts `GIT_DIR` before `GITHOOKS` on Linux, but not on macOS. Why this happens is rather complicated and somewhat unclear [0​], but it's easily resolved by forcing bytewise comparisons using `LC_COLLATE=C`.  Since we're sorting variable identifiers and not English words, this is actually a more reasonable sort order anyway.

0: http://ask.metafilter.com/130292/CaseInsensitive-LS-on-Mac-OS-X#2280058

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14422)
<!-- Reviewable:end -->