### PR TITLE
sql: TestLogic directives

### DIFF
--- a/pkg/sql/testdata/logic_test/aggregate
+++ b/pkg/sql/testdata/logic_test/aggregate
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,

--- a/pkg/sql/testdata/logic_test/alias_types
+++ b/pkg/sql/testdata/logic_test/alias_types
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE aliases (
     a OID,

--- a/pkg/sql/testdata/logic_test/alter_table
+++ b/pkg/sql/testdata/logic_test/alter_table
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE other (b INT PRIMARY KEY)
 

--- a/pkg/sql/testdata/logic_test/array
+++ b/pkg/sql/testdata/logic_test/array
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # array construction
 
 query error cannot determine type of empty array

--- a/pkg/sql/testdata/logic_test/backup
+++ b/pkg/sql/testdata/logic_test/backup
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 query error unknown statement type
 BACKUP DATABASE foo TO '/bar' INCREMENTAL FROM '/baz'
 

--- a/pkg/sql/testdata/logic_test/builtin_function
+++ b/pkg/sql/testdata/logic_test/builtin_function
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 query error unknown function: foo.bar
 SELECT foo.bar()
 

--- a/pkg/sql/testdata/logic_test/check_constraints
+++ b/pkg/sql/testdata/logic_test/check_constraints
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 #### column CHECK constraints
 
 statement ok

--- a/pkg/sql/testdata/logic_test/collatedstring
+++ b/pkg/sql/testdata/logic_test/collatedstring
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement error pq: invalid locale bad_locale: language: subtag "locale" is well-formed but unknown
 SELECT 'a' COLLATE bad_locale
 

--- a/pkg/sql/testdata/logic_test/collatedstring_constraint
+++ b/pkg/sql/testdata/logic_test/collatedstring_constraint
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # English collation chart: http://www.unicode.org/cldr/charts/30/collation/en_US_POSIX.html
 
 statement ok

--- a/pkg/sql/testdata/logic_test/collatedstring_index1
+++ b/pkg/sql/testdata/logic_test/collatedstring_index1
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 ##
 # Test a primary key with a collated string in first position (can get a key range).
 #

--- a/pkg/sql/testdata/logic_test/collatedstring_index2
+++ b/pkg/sql/testdata/logic_test/collatedstring_index2
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 ##
 # Test a primary key with a collated string in second position (cannot get a key range).
 #

--- a/pkg/sql/testdata/logic_test/collatedstring_normalization
+++ b/pkg/sql/testdata/logic_test/collatedstring_normalization
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 ----
 CREATE TABLE t (

--- a/pkg/sql/testdata/logic_test/collatedstring_nullinindex
+++ b/pkg/sql/testdata/logic_test/collatedstring_nullinindex
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 ----
 CREATE TABLE t (

--- a/pkg/sql/testdata/logic_test/collatedstring_uniqueindex1
+++ b/pkg/sql/testdata/logic_test/collatedstring_uniqueindex1
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 ##
 # Test a primary key with a collated string in first position (can get a key range).
 #

--- a/pkg/sql/testdata/logic_test/collatedstring_uniqueindex2
+++ b/pkg/sql/testdata/logic_test/collatedstring_uniqueindex2
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 ##
 # Test a primary key with a collated string in second position (cannot get a key range).
 #

--- a/pkg/sql/testdata/logic_test/crdb_internal
+++ b/pkg/sql/testdata/logic_test/crdb_internal
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 query error user root does not have DROP privilege on database crdb_internal
 ALTER DATABASE crdb_internal RENAME TO not_crdb_internal
 

--- a/pkg/sql/testdata/logic_test/create_as
+++ b/pkg/sql/testdata/logic_test/create_as
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE stock (item, quantity) AS VALUES ('cups', 10), ('plates', 15), ('forks', 30)
 

--- a/pkg/sql/testdata/logic_test/create_index
+++ b/pkg/sql/testdata/logic_test/create_index
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE t (
   a INT PRIMARY KEY,

--- a/pkg/sql/testdata/logic_test/database
+++ b/pkg/sql/testdata/logic_test/database
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE DATABASE a
 

--- a/pkg/sql/testdata/logic_test/datetime
+++ b/pkg/sql/testdata/logic_test/datetime
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE t (
   a TIMESTAMP PRIMARY KEY,

--- a/pkg/sql/testdata/logic_test/decimal
+++ b/pkg/sql/testdata/logic_test/decimal
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # The following tests have results equivalent to Postgres (differences
 # in string representation and number of decimals returned, but otherwise
 # the same). These do not pass using the inf package. The inf package

--- a/pkg/sql/testdata/logic_test/default
+++ b/pkg/sql/testdata/logic_test/default
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement error incompatible type for DEFAULT expression: int vs bool
 CREATE TABLE t (a INT PRIMARY KEY DEFAULT false)
 

--- a/pkg/sql/testdata/logic_test/delete
+++ b/pkg/sql/testdata/logic_test/delete
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,

--- a/pkg/sql/testdata/logic_test/distinct
+++ b/pkg/sql/testdata/logic_test/distinct
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE xyz (
   x INT PRIMARY KEY,

--- a/pkg/sql/testdata/logic_test/drop_database
+++ b/pkg/sql/testdata/logic_test/drop_database
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE DATABASE "foo-bar"
 

--- a/pkg/sql/testdata/logic_test/drop_index
+++ b/pkg/sql/testdata/logic_test/drop_index
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE users (
   id    INT PRIMARY KEY,

--- a/pkg/sql/testdata/logic_test/drop_table
+++ b/pkg/sql/testdata/logic_test/drop_table
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE a (id INT PRIMARY KEY)
 

--- a/pkg/sql/testdata/logic_test/drop_view
+++ b/pkg/sql/testdata/logic_test/drop_view
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE a (k STRING PRIMARY KEY, v STRING)
 

--- a/pkg/sql/testdata/logic_test/errors
+++ b/pkg/sql/testdata/logic_test/errors
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement error pgcode 42P01 table "fake1" does not exist
 ALTER TABLE fake1 DROP COLUMN a
 

--- a/pkg/sql/testdata/logic_test/event_log
+++ b/pkg/sql/testdata/logic_test/event_log
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 ##################
 # TABLE DDL
 ##################

--- a/pkg/sql/testdata/logic_test/explain
+++ b/pkg/sql/testdata/logic_test/explain
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 query ITTT colnames
 EXPLAIN (PLAN) SELECT 1
 ----

--- a/pkg/sql/testdata/logic_test/explain_debug
+++ b/pkg/sql/testdata/logic_test/explain_debug
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE abc (
   a INT,

--- a/pkg/sql/testdata/logic_test/explain_distsql
+++ b/pkg/sql/testdata/logic_test/explain_distsql
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 #
 # Tests that verify DistSQL support and auto mode determination.
 #

--- a/pkg/sql/testdata/logic_test/explain_plan
+++ b/pkg/sql/testdata/logic_test/explain_plan
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE t (
   k INT PRIMARY KEY,

--- a/pkg/sql/testdata/logic_test/explain_types
+++ b/pkg/sql/testdata/logic_test/explain_types
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE t (
   k INT PRIMARY KEY,

--- a/pkg/sql/testdata/logic_test/family
+++ b/pkg/sql/testdata/logic_test/family
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # a is the primary key so b gets optimized into a one column value. The c, d
 # family has two columns, so it's encoded as a tuple
 statement ok

--- a/pkg/sql/testdata/logic_test/fk
+++ b/pkg/sql/testdata/logic_test/fk
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE customers (id INT PRIMARY KEY, email STRING UNIQUE)
 

--- a/pkg/sql/testdata/logic_test/function_lookup
+++ b/pkg/sql/testdata/logic_test/function_lookup
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE foo(x INT DEFAULT LENGTH(PG_TYPEOF(1234))-1)
 

--- a/pkg/sql/testdata/logic_test/generators
+++ b/pkg/sql/testdata/logic_test/generators
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 query I colnames
 SELECT * FROM GENERATE_SERIES(1, 3)
 ----

--- a/pkg/sql/testdata/logic_test/grant_database
+++ b/pkg/sql/testdata/logic_test/grant_database
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE DATABASE a
 

--- a/pkg/sql/testdata/logic_test/grant_table
+++ b/pkg/sql/testdata/logic_test/grant_table
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE DATABASE a
 

--- a/pkg/sql/testdata/logic_test/help
+++ b/pkg/sql/testdata/logic_test/help
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 query TTTT colnames
 HELP replace
 ----

--- a/pkg/sql/testdata/logic_test/information_schema
+++ b/pkg/sql/testdata/logic_test/information_schema
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # Verify information_schema database handles mutation statements correctly.
 
 query error user root does not have DROP privilege on database information_schema

--- a/pkg/sql/testdata/logic_test/insert
+++ b/pkg/sql/testdata/logic_test/insert
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement error table "kv" does not exist
 INSERT INTO kv VALUES ('a', 'b')
 

--- a/pkg/sql/testdata/logic_test/interleaved
+++ b/pkg/sql/testdata/logic_test/interleaved
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # Grandparent table
 statement ok
 CREATE TABLE p2 (i INT PRIMARY KEY, s STRING)

--- a/pkg/sql/testdata/logic_test/join
+++ b/pkg/sql/testdata/logic_test/join
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # The join condition logic is tricky to get right with NULL
 # values. Simple implementations can deal well with NULLs on the first
 # or last row but fail to handle them in the middle. So the test table

--- a/pkg/sql/testdata/logic_test/manual_retry
+++ b/pkg/sql/testdata/logic_test/manual_retry
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # On an implicit transaction, we retry implicitly and the function
 # eventually returns a result.
 query I

--- a/pkg/sql/testdata/logic_test/multi_statement
+++ b/pkg/sql/testdata/logic_test/multi_statement
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE kv (
   k CHAR PRIMARY KEY,

--- a/pkg/sql/testdata/logic_test/namespace
+++ b/pkg/sql/testdata/logic_test/namespace
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 
 # Unqualified pg_type resolves from pg_catalog.
 query T

--- a/pkg/sql/testdata/logic_test/needed_columns
+++ b/pkg/sql/testdata/logic_test/needed_columns
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 query ITTTTT
 EXPLAIN (METADATA,NOOPTIMIZE) SELECT 1 FROM (SELECT 2 AS s)
 ----

--- a/pkg/sql/testdata/logic_test/no_primary_key
+++ b/pkg/sql/testdata/logic_test/no_primary_key
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 query error duplicate column name: "rowid"
 CREATE TABLE t (
   rowid INT

--- a/pkg/sql/testdata/logic_test/order_by
+++ b/pkg/sql/testdata/logic_test/order_by
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE t (
   a INT PRIMARY KEY,

--- a/pkg/sql/testdata/logic_test/ordinal_references
+++ b/pkg/sql/testdata/logic_test/ordinal_references
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE foo(a INT, b CHAR)
 

--- a/pkg/sql/testdata/logic_test/ordinality
+++ b/pkg/sql/testdata/logic_test/ordinality
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 query TI colnames
 SELECT * FROM (VALUES ('a'), ('b')) WITH ORDINALITY AS X(name, i)
 ----

--- a/pkg/sql/testdata/logic_test/orms
+++ b/pkg/sql/testdata/logic_test/orms
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 ## This test file contains various complex queries that ORMs issue during
 ## startup or general use.
 

--- a/pkg/sql/testdata/logic_test/pg_catalog
+++ b/pkg/sql/testdata/logic_test/pg_catalog
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # Verify pg_catalog database handles mutation statements correctly.
 
 query error user root does not have DROP privilege on database pg_catalog

--- a/pkg/sql/testdata/logic_test/pgoidtype
+++ b/pkg/sql/testdata/logic_test/pgoidtype
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 query OO
 SELECT 3::OID, '3'::OID
 ----

--- a/pkg/sql/testdata/logic_test/pipelining
+++ b/pkg/sql/testdata/logic_test/pipelining
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,

--- a/pkg/sql/testdata/logic_test/planhook
+++ b/pkg/sql/testdata/logic_test/planhook
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # The placeholder returns one row with one value: the string 'planhook'.
 query T
 SHOW planhook

--- a/pkg/sql/testdata/logic_test/poison_after_push
+++ b/pkg/sql/testdata/logic_test/poison_after_push
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # This example session documents that a SERIALIZABLE transaction is
 # not immediately poisoned when it revisits a Range on which one of
 # its intents has had its timestamp pushed. This allows it to continue

--- a/pkg/sql/testdata/logic_test/prepare
+++ b/pkg/sql/testdata/logic_test/prepare
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement error unimplemented: Prepared statements are supported only via the Postgres wire protocol \(see issue https://github.com/cockroachdb/cockroach/issues/7568\)
 PREPARE a AS SELECT 1
 

--- a/pkg/sql/testdata/logic_test/privileges_database
+++ b/pkg/sql/testdata/logic_test/privileges_database
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # Test default database-level permissions.
 # Default user is root.
 statement ok

--- a/pkg/sql/testdata/logic_test/privileges_table
+++ b/pkg/sql/testdata/logic_test/privileges_table
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # Test default table-level permissions.
 # Default user is root.
 statement ok

--- a/pkg/sql/testdata/logic_test/ranges
+++ b/pkg/sql/testdata/logic_test/ranges
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE t (k1 INT, k2 INT, v INT, w INT, PRIMARY KEY (k1, k2))
 

--- a/pkg/sql/testdata/logic_test/rename_column
+++ b/pkg/sql/testdata/logic_test/rename_column
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE users (
   uid    INT PRIMARY KEY,

--- a/pkg/sql/testdata/logic_test/rename_database
+++ b/pkg/sql/testdata/logic_test/rename_database
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 query T
 SHOW DATABASES
 ----

--- a/pkg/sql/testdata/logic_test/rename_index
+++ b/pkg/sql/testdata/logic_test/rename_index
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE users (
   id    INT PRIMARY KEY,

--- a/pkg/sql/testdata/logic_test/rename_table
+++ b/pkg/sql/testdata/logic_test/rename_table
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement error pgcode 42P01 table "foo" does not exist
 ALTER TABLE foo RENAME TO bar
 

--- a/pkg/sql/testdata/logic_test/rename_view
+++ b/pkg/sql/testdata/logic_test/rename_view
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement error pgcode 42P01 view "foo" does not exist
 ALTER VIEW foo RENAME TO bar
 

--- a/pkg/sql/testdata/logic_test/scale
+++ b/pkg/sql/testdata/logic_test/scale
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE test (
   t CHAR(4),

--- a/pkg/sql/testdata/logic_test/select
+++ b/pkg/sql/testdata/logic_test/select
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # SELECT with no table.
 
 query I

--- a/pkg/sql/testdata/logic_test/select_index
+++ b/pkg/sql/testdata/logic_test/select_index
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE t (
   a INT,

--- a/pkg/sql/testdata/logic_test/select_index_hints
+++ b/pkg/sql/testdata/logic_test/select_index_hints
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE abcd (
   a INT PRIMARY KEY,

--- a/pkg/sql/testdata/logic_test/select_index_span_ranges
+++ b/pkg/sql/testdata/logic_test/select_index_span_ranges
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # This test verifies that we correctly perform an index join when the KV
 # batches span ranges. This is testing that SQL disables batch limits for index
 # join; otherwise it can get out of order results from KV that it can't handle.

--- a/pkg/sql/testdata/logic_test/select_non_covering_index
+++ b/pkg/sql/testdata/logic_test/select_non_covering_index
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE t (
   a INT PRIMARY KEY,

--- a/pkg/sql/testdata/logic_test/select_non_covering_index_filtering
+++ b/pkg/sql/testdata/logic_test/select_non_covering_index_filtering
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # These tests verify that while we are joining an index with the table, we
 # evaluate what parts of the filter we can using the columns in the index
 # to avoid unnecessary lookups in the table.

--- a/pkg/sql/testdata/logic_test/select_search_path
+++ b/pkg/sql/testdata/logic_test/select_search_path
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # Test that pg_catalog tables are accessible without qualifying table/view
 # names.
 

--- a/pkg/sql/testdata/logic_test/select_table_alias
+++ b/pkg/sql/testdata/logic_test/select_table_alias
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # Tests for SELECT with table aliasing.
 
 statement ok

--- a/pkg/sql/testdata/logic_test/serial
+++ b/pkg/sql/testdata/logic_test/serial
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE serial (
   a SERIAL PRIMARY KEY,

--- a/pkg/sql/testdata/logic_test/serializable_eager_restart
+++ b/pkg/sql/testdata/logic_test/serializable_eager_restart
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # Demonstrates late restarting of a serializable transaction when its
 # commit timestamp has moved forward.
 # TODO(tschottdorf): implement eager restart for CLI.

--- a/pkg/sql/testdata/logic_test/set
+++ b/pkg/sql/testdata/logic_test/set
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement error unknown variable: "FOO"
 SET FOO = bar
 

--- a/pkg/sql/testdata/logic_test/snapshot_certain_read
+++ b/pkg/sql/testdata/logic_test/snapshot_certain_read
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # This test verifies that when a SNAPSHOT transaction reads without
 # uncertainty, it actually does that. We had a performance bug which caused the
 # MaxTimestamp to be set to the Timestamp instead of OrigTimestamp on such

--- a/pkg/sql/testdata/logic_test/snapshot_issue2861
+++ b/pkg/sql/testdata/logic_test/snapshot_issue2861
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # Run a simple shell session in which a reader conflicts with an open txn in
 # SNAPSHOT isolation by means of a read, which is resolved by a Push. Prevents
 # regression of #2861.

--- a/pkg/sql/testdata/logic_test/snapshot_timestamp_drift
+++ b/pkg/sql/testdata/logic_test/snapshot_timestamp_drift
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # Prevents regression of #4293: We used the commit timestamp candidate instead
 # of the original timestamp for reads, which means that transactions were
 # changing their snapshot while they were active, which is wildly inconsistent.

--- a/pkg/sql/testdata/logic_test/snapshot_unrelated_update
+++ b/pkg/sql/testdata/logic_test/snapshot_unrelated_update
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE t (id INT PRIMARY KEY, v string)
 

--- a/pkg/sql/testdata/logic_test/storing
+++ b/pkg/sql/testdata/logic_test/storing
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE t (
   a INT PRIMARY KEY,

--- a/pkg/sql/testdata/logic_test/subquery
+++ b/pkg/sql/testdata/logic_test/subquery
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # Tests for subqueries (SELECT statements which are part of a bigger statement).
 
 query I

--- a/pkg/sql/testdata/logic_test/syntax
+++ b/pkg/sql/testdata/logic_test/syntax
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 SET SYNTAX = modern
 

--- a/pkg/sql/testdata/logic_test/system
+++ b/pkg/sql/testdata/logic_test/system
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 query T
 SHOW DATABASES
 ----

--- a/pkg/sql/testdata/logic_test/table
+++ b/pkg/sql/testdata/logic_test/table
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 SET DATABASE = ""
 

--- a/pkg/sql/testdata/logic_test/truncate
+++ b/pkg/sql/testdata/logic_test/truncate
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,

--- a/pkg/sql/testdata/logic_test/tuple
+++ b/pkg/sql/testdata/logic_test/tuple
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 query TT
 SELECT (1, 2, 'hello', NULL, NULL), (true, NULL, (false, 6.6, false))
 ----

--- a/pkg/sql/testdata/logic_test/txn
+++ b/pkg/sql/testdata/logic_test/txn
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # Transaction involving schema changes.
 statement ok
 BEGIN TRANSACTION

--- a/pkg/sql/testdata/logic_test/typing
+++ b/pkg/sql/testdata/logic_test/typing
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE f (x FLOAT)
 

--- a/pkg/sql/testdata/logic_test/unimplemented
+++ b/pkg/sql/testdata/logic_test/unimplemented
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement error pq: unimplemented
 WITH a AS (SELECT 1) SELECT *
 

--- a/pkg/sql/testdata/logic_test/union
+++ b/pkg/sql/testdata/logic_test/union
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 query I rowsort
 VALUES (1), (1), (1), (2), (2) UNION VALUES (1), (3), (1)
 ----

--- a/pkg/sql/testdata/logic_test/update
+++ b/pkg/sql/testdata/logic_test/update
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,

--- a/pkg/sql/testdata/logic_test/upsert
+++ b/pkg/sql/testdata/logic_test/upsert
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,

--- a/pkg/sql/testdata/logic_test/user
+++ b/pkg/sql/testdata/logic_test/user
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 query T colnames
 SHOW USERS
 ----

--- a/pkg/sql/testdata/logic_test/values
+++ b/pkg/sql/testdata/logic_test/values
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 query III colnames
 VALUES (1, 2, 3), (4, 5, 6)
 ----

--- a/pkg/sql/testdata/logic_test/views
+++ b/pkg/sql/testdata/logic_test/views
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE t (a INT PRIMARY KEY, b INT)
 

--- a/pkg/sql/testdata/logic_test/where
+++ b/pkg/sql/testdata/logic_test/where
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,

--- a/pkg/sql/testdata/logic_test/window
+++ b/pkg/sql/testdata/logic_test/window
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE kv (
   -- don't add column "a"


### PR DESCRIPTION
Currently we have two logic test variants: `TestLogic` which runs in a single-node
cluster, and `TestLogicDistSQL` which runs in a 3 node cluster with fake span
resolver and distsql on.

This has a few problems:
 - we force all tests to run in both configurations, even though some of them
   don't benefit from both
 - it's not possible add more configurations for specific tests (e.g. distsql
   tests without a fake span resolver).

This change proposes switching back to a single `TestLogic`, and supporting
per-testfile directives that indicate which configuration(s) the file should
run in. If there are multiple configurations, each runs in a subtest.

All test files are switched over to running in the two configurations mentioned
above. We will trim down these configurations as necessary in a separate change.
Test names are of the form:

```
--- PASS: TestLogic (59.07s)
    --- PASS: TestLogic/aggregate (0.27s)
        --- PASS: TestLogic/aggregate/default (0.09s)
        --- PASS: TestLogic/aggregate/distsql (0.18s)
    --- PASS: TestLogic/alias_types (0.12s)
        --- PASS: TestLogic/alias_types/default (0.03s)
        --- PASS: TestLogic/alias_types/distsql (0.08s)
    --- PASS: TestLogic/alter_table (13.46s)
        --- PASS: TestLogic/alter_table/default (6.80s)
        --- PASS: TestLogic/alter_table/distsql (6.66s)
...
```

For files that don't specify a configuration, the configuration can be set via
the command line using -config, for example:
```
go test ./pkg/sql -timeout 2m -v -run '^TestLogic$$' \
  -config "name=distsql nodes=3 fake-span-resolver distsql=on" \
  -d "$GOPATH/src/github.com/cockroachdb/sqllogictest/test/index/between/1/slt_good_0.test"
```


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14425)
<!-- Reviewable:end -->
