### PR TITLE
sql: fix analyzeExpr mutation

### DIFF
--- a/pkg/sql/analyze.go
+++ b/pkg/sql/analyze.go
@@ -694,6 +694,8 @@ func simplifyOneAndInExpr(
 		ltuple := left.Right.(*parser.DTuple)
 		ltuple.AssertSorted()
 
+		values := ltuple.D
+
 		switch right.Operator {
 		case parser.Is:
 			if right.Right == parser.DNull {
@@ -715,74 +717,74 @@ func simplifyOneAndInExpr(
 
 			case parser.NE:
 				if found {
-					if len(ltuple.D) < 2 {
+					if len(values) < 2 {
 						return parser.MakeDBool(false), nil
 					}
-					ltuple.D = remove(ltuple.D, i)
+					values = remove(values, i)
 				}
 				return parser.NewTypedComparisonExpr(
 					parser.In,
 					left.TypedLeft(),
-					parser.NewDTuple(ltuple.D...).SetSorted(),
+					parser.NewDTuple(values...).SetSorted(),
 				), nil
 
 			case parser.GT:
-				if i < len(ltuple.D) {
+				if i < len(values) {
 					if found {
-						ltuple.D = ltuple.D[i+1:]
+						values = values[i+1:]
 					} else {
-						ltuple.D = ltuple.D[i:]
+						values = values[i:]
 					}
-					if len(ltuple.D) > 0 {
+					if len(values) > 0 {
 						return parser.NewTypedComparisonExpr(
 							parser.In,
 							left.TypedLeft(),
-							parser.NewDTuple(ltuple.D...).SetSorted(),
+							parser.NewDTuple(values...).SetSorted(),
 						), nil
 					}
 				}
 				return parser.MakeDBool(false), nil
 
 			case parser.GE:
-				if i < len(ltuple.D) {
-					ltuple.D = ltuple.D[i:]
-					if len(ltuple.D) > 0 {
+				if i < len(values) {
+					values = values[i:]
+					if len(values) > 0 {
 						return parser.NewTypedComparisonExpr(
 							parser.In,
 							left.TypedLeft(),
-							parser.NewDTuple(ltuple.D...).SetSorted(),
+							parser.NewDTuple(values...).SetSorted(),
 						), nil
 					}
 				}
 				return parser.MakeDBool(false), nil
 
 			case parser.LT:
-				if i < len(ltuple.D) {
+				if i < len(values) {
 					if i == 0 {
 						return parser.MakeDBool(false), nil
 					}
-					ltuple.D = ltuple.D[:i]
+					values = values[:i]
 					return parser.NewTypedComparisonExpr(
 						parser.In,
 						left.TypedLeft(),
-						parser.NewDTuple(ltuple.D...).SetSorted(),
+						parser.NewDTuple(values...).SetSorted(),
 					), nil
 				}
 				return left, nil
 
 			case parser.LE:
-				if i < len(ltuple.D) {
+				if i < len(values) {
 					if found {
 						i++
 					}
 					if i == 0 {
 						return parser.MakeDBool(false), nil
 					}
-					ltuple.D = ltuple.D[:i]
+					values = values[:i]
 					return parser.NewTypedComparisonExpr(
 						parser.In,
 						left.TypedLeft(),
-						parser.NewDTuple(ltuple.D...).SetSorted(),
+						parser.NewDTuple(values...).SetSorted(),
 					), nil
 				}
 				return left, nil
@@ -791,7 +793,7 @@ func simplifyOneAndInExpr(
 		case parser.In:
 			// Both of our tuples are sorted. Intersect the lists.
 			rtuple := right.Right.(*parser.DTuple)
-			intersection := intersectSorted(evalCtx, ltuple.D, rtuple.D)
+			intersection := intersectSorted(evalCtx, values, rtuple.D)
 			if len(intersection) == 0 {
 				return parser.MakeDBool(false), nil
 			}

--- a/pkg/sql/testdata/logic_test/select_index
+++ b/pkg/sql/testdata/logic_test/select_index
@@ -434,3 +434,26 @@ EXPLAIN SELECT c FROM abz ORDER BY c DESC LIMIT 1
 2          table  abz@abz_c_b_key
 2          spans  ALL
 2          limit            1
+
+# Issue #14426: verify we don't have an internal filter that contains "a IN ()"
+# (which causes an error in DistSQL due to expression serialization).
+statement ok
+CREATE TABLE tab0(
+  k INT PRIMARY KEY,
+  a INT,
+  b INT
+)
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT k FROM tab0 WHERE (a IN (6) AND a > 6) OR b >= 4
+----
+0  render                                                  (k)
+0          render 0  test.tab0.k
+1  scan                                                    (k, a, b)
+1          table     tab0@primary
+1          spans     ALL
+1          filter    ((a IN (6)) AND (a > 6)) OR (b >= 4)
+
+query I
+SELECT k FROM tab0 WHERE (a IN (6) AND a > 6) OR b >= 4
+----


### PR DESCRIPTION
The comments for `analyzeExpr` explain that the original expression is not
modified (and should be used for filtering, as the `analyzeExpr` result can be a
more lenient filter). However, the code was modifying the value set of an `IN`
expression in-place. This doesn't cause any correction issues but it can
lead to an empty set, which results in an invalid serialized expression for
DistSQL.

Fixes #14426. CC @asubiotto

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14430)
<!-- Reviewable:end -->
