### PR TITLE
storage/engine: ignore sign-comparison warnings

### DIFF
--- a/pkg/ccl/storageccl/engineccl/rocksdb.go
+++ b/pkg/ccl/storageccl/engineccl/rocksdb.go
@@ -18,7 +18,7 @@ import (
 
 // #cgo CPPFLAGS: -I../../../../vendor/github.com/cockroachdb/c-protobuf/internal/src
 // #cgo CPPFLAGS: -I../../../../vendor/github.com/cockroachdb/c-rocksdb/internal/include
-// #cgo CXXFLAGS: -std=c++11 -Wall
+// #cgo CXXFLAGS: -std=c++11 -Werror -Wall -Wno-sign-compare
 // #cgo !strictld,darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
 // #cgo !strictld,!darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all
 // #cgo linux LDFLAGS: -lrt

--- a/pkg/storage/engine/db.cc
+++ b/pkg/storage/engine/db.cc
@@ -1351,12 +1351,12 @@ DBSSTable* DBEngine::GetSSTables(int* n) {
       // This is a bit ugly because we want DBKey.key to be copied and
       // not refer to the memory in metadata[i].smallestkey.
       DBString str = ToDBString(tmp);
-      tables[i].start_key.key = *reinterpret_cast<DBSlice*>(&str);
+      tables[i].start_key.key = DBSlice{str.data, str.len};
     }
     if (DecodeKey(metadata[i].largestkey, &tmp,
                   &tables[i].end_key.wall_time, &tables[i].end_key.logical)) {
       DBString str = ToDBString(tmp);
-      tables[i].end_key.key = *reinterpret_cast<DBSlice*>(&str);
+      tables[i].end_key.key = DBSlice{str.data, str.len};
     }
   }
   return tables;

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -51,7 +51,7 @@ import (
 
 // #cgo CPPFLAGS: -I../../../vendor/github.com/cockroachdb/c-protobuf/internal/src
 // #cgo CPPFLAGS: -I../../../vendor/github.com/cockroachdb/c-rocksdb/internal/include
-// #cgo CXXFLAGS: -std=c++11 -Wall
+// #cgo CXXFLAGS: -std=c++11 -Werror -Wall -Wno-sign-compare
 // #cgo linux LDFLAGS: -lrt
 //
 // #include <stdlib.h>


### PR DESCRIPTION
Fix strict-aliasing warning due to type-punning.

Fixes #14429

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14432)
<!-- Reviewable:end -->
