### PR TITLE
rpc: disable heartbeat timeout completely in test

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -117,8 +117,8 @@ type Context struct {
 	RemoteClocks *RemoteClockMonitor
 	masterCtx    context.Context
 
-	HeartbeatInterval time.Duration
-	HeartbeatTimeout  time.Duration
+	heartbeatInterval time.Duration
+	heartbeatTimeout  time.Duration
 	HeartbeatCB       func()
 
 	localInternalServer roachpb.InternalServer
@@ -151,8 +151,8 @@ func NewContext(
 	ctx.Stopper = stopper
 	ctx.RemoteClocks = newRemoteClockMonitor(
 		ctx.LocalClock, 10*defaultHeartbeatInterval, baseCtx.HistogramWindowInterval)
-	ctx.HeartbeatInterval = defaultHeartbeatInterval
-	ctx.HeartbeatTimeout = 2 * defaultHeartbeatInterval
+	ctx.heartbeatInterval = defaultHeartbeatInterval
+	ctx.heartbeatTimeout = 2 * defaultHeartbeatInterval
 	ctx.conns.cache = make(map[string]*connMeta)
 
 	stopper.RunWorker(func() {
@@ -328,7 +328,7 @@ func (ctx *Context) runHeartbeat(meta *connMeta, remoteAddr string) error {
 
 		goCtx := ctx.masterCtx
 		var cancel context.CancelFunc
-		if hbTimeout := ctx.HeartbeatTimeout; hbTimeout > 0 {
+		if hbTimeout := ctx.heartbeatTimeout; hbTimeout > 0 {
 			goCtx, cancel = context.WithTimeout(goCtx, hbTimeout)
 		}
 		sendTime := ctx.LocalClock.PhysicalTime()
@@ -395,6 +395,6 @@ func (ctx *Context) runHeartbeat(meta *connMeta, remoteAddr string) error {
 			}
 		}
 
-		heartbeatTimer.Reset(ctx.HeartbeatInterval)
+		heartbeatTimer.Reset(ctx.heartbeatInterval)
 	}
 }

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -38,15 +38,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
-// newNodeTestContext returns a rpc.Context for testing.
-// It is meant to be used by nodes.
-func newNodeTestContext(clock *hlc.Clock, stopper *stop.Stopper) *Context {
-	ctx := NewContext(log.AmbientContext{}, testutils.NewNodeTestBaseContext(), clock, stopper)
-	ctx.HeartbeatInterval = 10 * time.Millisecond
-	ctx.HeartbeatTimeout = 2 * defaultHeartbeatInterval
-	return ctx
-}
-
 func newTestServer(t *testing.T, ctx *Context, manual bool) (*grpc.Server, net.Listener) {
 	tlsConfig, err := ctx.GetServerTLSConfig()
 	if err != nil {
@@ -69,7 +60,7 @@ func TestHeartbeatCB(t *testing.T) {
 	defer stopper.Stop()
 
 	clock := hlc.NewClock(time.Unix(0, 20).UnixNano, time.Nanosecond)
-	serverCtx := newNodeTestContext(clock, stopper)
+	serverCtx := NewContext(log.AmbientContext{}, testutils.NewNodeTestBaseContext(), clock, stopper)
 	s, ln := newTestServer(t, serverCtx, true)
 	remoteAddr := ln.Addr().String()
 
@@ -79,7 +70,7 @@ func TestHeartbeatCB(t *testing.T) {
 	})
 
 	// Clocks don't matter in this test.
-	clientCtx := newNodeTestContext(clock, stopper)
+	clientCtx := NewContext(log.AmbientContext{}, testutils.NewNodeTestBaseContext(), clock, stopper)
 
 	var once sync.Once
 	ch := make(chan struct{})
@@ -109,7 +100,7 @@ func TestHeartbeatHealth(t *testing.T) {
 	// Can't be zero because that'd be an empty offset.
 	clock := hlc.NewClock(time.Unix(0, 1).UnixNano, time.Nanosecond)
 
-	serverCtx := newNodeTestContext(clock, stopper)
+	serverCtx := NewContext(log.AmbientContext{}, testutils.NewNodeTestBaseContext(), clock, stopper)
 	s, ln := newTestServer(t, serverCtx, true)
 	remoteAddr := ln.Addr().String()
 
@@ -121,9 +112,9 @@ func TestHeartbeatHealth(t *testing.T) {
 	}
 	RegisterHeartbeatServer(s, heartbeat)
 
-	clientCtx := newNodeTestContext(clock, stopper)
-	// Make the intervals and timeouts shorter to speed up the tests.
-	clientCtx.HeartbeatInterval = 1 * time.Millisecond
+	clientCtx := NewContext(log.AmbientContext{}, testutils.NewNodeTestBaseContext(), clock, stopper)
+	// Make the interval shorter to speed up the test.
+	clientCtx.heartbeatInterval = 1 * time.Millisecond
 	if _, err := clientCtx.GRPCDial(remoteAddr); err != nil {
 		t.Fatal(err)
 	}
@@ -216,7 +207,7 @@ func TestHeartbeatHealthTransport(t *testing.T) {
 	// Can't be zero because that'd be an empty offset.
 	clock := hlc.NewClock(time.Unix(0, 1).UnixNano, time.Nanosecond)
 
-	serverCtx := newNodeTestContext(clock, stopper)
+	serverCtx := NewContext(log.AmbientContext{}, testutils.NewNodeTestBaseContext(), clock, stopper)
 	// newTestServer with a custom listener.
 	tlsConfig, err := serverCtx.GetServerTLSConfig()
 	if err != nil {
@@ -254,9 +245,9 @@ func TestHeartbeatHealthTransport(t *testing.T) {
 		remoteClockMonitor: serverCtx.RemoteClocks,
 	})
 
-	clientCtx := newNodeTestContext(clock, stopper)
-	// Make the intervals shorter to speed up the tests.
-	clientCtx.HeartbeatInterval = 1 * time.Millisecond
+	clientCtx := NewContext(log.AmbientContext{}, testutils.NewNodeTestBaseContext(), clock, stopper)
+	// Make the interval shorter to speed up the test.
+	clientCtx.heartbeatInterval = 1 * time.Millisecond
 	if _, err := clientCtx.GRPCDial(remoteAddr); err != nil {
 		t.Fatal(err)
 	}
@@ -318,7 +309,7 @@ func TestHeartbeatHealthTransport(t *testing.T) {
 
 	// Should stay unhealthy despite reconnection attempts.
 	errUnhealthy := errors.New("connection is still unhealthy")
-	if err := util.RetryForDuration(100*clientCtx.HeartbeatInterval, func() error {
+	if err := util.RetryForDuration(100*clientCtx.heartbeatInterval, func() error {
 		if err := clientCtx.ConnHealth(remoteAddr); grpc.Code(err) != codes.Unavailable {
 			return errors.Errorf("unexpected error: %v", err)
 		}
@@ -336,7 +327,7 @@ func TestOffsetMeasurement(t *testing.T) {
 
 	serverTime := time.Unix(0, 20)
 	serverClock := hlc.NewClock(serverTime.UnixNano, time.Nanosecond)
-	serverCtx := newNodeTestContext(serverClock, stopper)
+	serverCtx := NewContext(log.AmbientContext{}, testutils.NewNodeTestBaseContext(), serverClock, stopper)
 	s, ln := newTestServer(t, serverCtx, true)
 	remoteAddr := ln.Addr().String()
 
@@ -348,7 +339,9 @@ func TestOffsetMeasurement(t *testing.T) {
 	// Create a client clock that is behind the server clock.
 	clientAdvancing := AdvancingClock{time: time.Unix(0, 10)}
 	clientClock := hlc.NewClock(clientAdvancing.UnixNano, time.Nanosecond)
-	clientCtx := newNodeTestContext(clientClock, stopper)
+	clientCtx := NewContext(log.AmbientContext{}, testutils.NewNodeTestBaseContext(), clientClock, stopper)
+	// Make the interval shorter to speed up the test.
+	clientCtx.heartbeatInterval = 1 * time.Millisecond
 	clientCtx.RemoteClocks.offsetTTL = 5 * clientAdvancing.getAdvancementInterval()
 	if _, err := clientCtx.GRPCDial(remoteAddr); err != nil {
 		t.Fatal(err)
@@ -392,7 +385,7 @@ func TestFailedOffsetMeasurement(t *testing.T) {
 	// Can't be zero because that'd be an empty offset.
 	clock := hlc.NewClock(time.Unix(0, 1).UnixNano, time.Nanosecond)
 
-	serverCtx := newNodeTestContext(clock, stopper)
+	serverCtx := NewContext(log.AmbientContext{}, testutils.NewNodeTestBaseContext(), clock, stopper)
 	s, ln := newTestServer(t, serverCtx, true)
 	remoteAddr := ln.Addr().String()
 
@@ -405,10 +398,10 @@ func TestFailedOffsetMeasurement(t *testing.T) {
 	RegisterHeartbeatServer(s, heartbeat)
 
 	// Create a client that never receives a heartbeat after the first.
-	clientCtx := newNodeTestContext(clock, stopper)
+	clientCtx := NewContext(log.AmbientContext{}, testutils.NewNodeTestBaseContext(), clock, stopper)
 	// Remove the timeout so that failure arises from exceeding the maximum
 	// clock reading delay, not the timeout.
-	clientCtx.HeartbeatTimeout = 0
+	clientCtx.heartbeatTimeout = 0
 	if _, err := clientCtx.GRPCDial(remoteAddr); err != nil {
 		t.Fatal(err)
 	}
@@ -488,8 +481,8 @@ func TestRemoteOffsetUnhealthy(t *testing.T) {
 	for i := range nodeCtxs {
 		clock := hlc.NewClock(start.Add(nodeCtxs[i].offset).UnixNano, maxOffset)
 		nodeCtxs[i].errChan = make(chan error, 1)
-		nodeCtxs[i].ctx = newNodeTestContext(clock, stopper)
-		nodeCtxs[i].ctx.HeartbeatInterval = maxOffset
+		nodeCtxs[i].ctx = NewContext(log.AmbientContext{}, testutils.NewNodeTestBaseContext(), clock, stopper)
+		nodeCtxs[i].ctx.heartbeatInterval = maxOffset
 
 		s, ln := newTestServer(t, nodeCtxs[i].ctx, true)
 		RegisterHeartbeatServer(s, &HeartbeatService{

--- a/pkg/rpc/main_test.go
+++ b/pkg/rpc/main_test.go
@@ -17,14 +17,8 @@
 package rpc
 
 import (
-	"time"
-
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
-	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
 func init() {
@@ -32,12 +26,3 @@ func init() {
 }
 
 //go:generate ../util/leaktest/add-leaktest.sh *_test.go
-
-// newNodeTestContext returns a rpc.Context for testing.
-// It is meant to be used by nodes.
-func newNodeTestContext(clock *hlc.Clock, stopper *stop.Stopper) *Context {
-	ctx := NewContext(log.AmbientContext{}, testutils.NewNodeTestBaseContext(), clock, stopper)
-	ctx.HeartbeatInterval = 10 * time.Millisecond
-	ctx.HeartbeatTimeout = 2 * defaultHeartbeatInterval
-	return ctx
-}


### PR DESCRIPTION
See commits.

@petermattis and @RaduBerinde because Github suggested y'all 😉

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14433)
<!-- Reviewable:end -->
