### PR TITLE
build: use trivial `#include`s rather than symlinks

### DIFF
--- a/pkg/storage/engine/cockroach_pkg_roachpb_data.pb.cc
+++ b/pkg/storage/engine/cockroach_pkg_roachpb_data.pb.cc
@@ -1,0 +1,1 @@
+#include "cockroach/pkg/roachpb/data.pb.cc"

--- a/pkg/storage/engine/cockroach_pkg_roachpb_internal.pb.cc
+++ b/pkg/storage/engine/cockroach_pkg_roachpb_internal.pb.cc
@@ -1,0 +1,1 @@
+#include "cockroach/pkg/roachpb/internal.pb.cc"

--- a/pkg/storage/engine/cockroach_pkg_roachpb_metadata.pb.cc
+++ b/pkg/storage/engine/cockroach_pkg_roachpb_metadata.pb.cc
@@ -1,0 +1,1 @@
+#include "cockroach/pkg/roachpb/metadata.pb.cc"

--- a/pkg/storage/engine/cockroach_pkg_storage_engine_enginepb_mvcc.pb.cc
+++ b/pkg/storage/engine/cockroach_pkg_storage_engine_enginepb_mvcc.pb.cc
@@ -1,0 +1,1 @@
+#include "cockroach/pkg/storage/engine/enginepb/mvcc.pb.cc"

--- a/pkg/storage/engine/cockroach_pkg_storage_engine_enginepb_rocksdb.pb.cc
+++ b/pkg/storage/engine/cockroach_pkg_storage_engine_enginepb_rocksdb.pb.cc
@@ -1,0 +1,1 @@
+#include "cockroach/pkg/storage/engine/enginepb/rocksdb.pb.cc"

--- a/pkg/storage/engine/cockroach_pkg_util_hlc_timestamp.pb.cc
+++ b/pkg/storage/engine/cockroach_pkg_util_hlc_timestamp.pb.cc
@@ -1,0 +1,1 @@
+#include "cockroach/pkg/util/hlc/timestamp.pb.cc"

--- a/pkg/storage/engine/cockroach_pkg_util_unresolved_addr.pb.cc
+++ b/pkg/storage/engine/cockroach_pkg_util_unresolved_addr.pb.cc
@@ -1,0 +1,1 @@
+#include "cockroach/pkg/util/unresolved_addr.pb.cc"

--- a/pkg/storage/engine/data.pb.cc
+++ b/pkg/storage/engine/data.pb.cc
@@ -1,1 +1,0 @@
-./cockroach/pkg/roachpb/data.pb.cc

--- a/pkg/storage/engine/internal.pb.cc
+++ b/pkg/storage/engine/internal.pb.cc
@@ -1,1 +1,0 @@
-./cockroach/pkg/roachpb/internal.pb.cc

--- a/pkg/storage/engine/metadata.pb.cc
+++ b/pkg/storage/engine/metadata.pb.cc
@@ -1,1 +1,0 @@
-./cockroach/pkg/roachpb/metadata.pb.cc

--- a/pkg/storage/engine/mvcc.pb.cc
+++ b/pkg/storage/engine/mvcc.pb.cc
@@ -1,1 +1,0 @@
-./cockroach/pkg/storage/engine/enginepb/mvcc.pb.cc

--- a/pkg/storage/engine/rocksdb.pb.cc
+++ b/pkg/storage/engine/rocksdb.pb.cc
@@ -1,1 +1,0 @@
-./cockroach/pkg/storage/engine/enginepb/rocksdb.pb.cc

--- a/pkg/storage/engine/timestamp.pb.cc
+++ b/pkg/storage/engine/timestamp.pb.cc
@@ -1,1 +1,0 @@
-./cockroach/pkg/util/hlc/timestamp.pb.cc

--- a/pkg/storage/engine/unresolved_addr.pb.cc
+++ b/pkg/storage/engine/unresolved_addr.pb.cc
@@ -1,1 +1,0 @@
-./cockroach/pkg/util/unresolved_addr.pb.cc


### PR DESCRIPTION
Symlinks are not well supported by MSYS2 on Windows.

Also take care to avoid filename collisions while I'm here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14445)
<!-- Reviewable:end -->
