### PR TITLE
txn: make SetSystemConfigTrigger less surprising

### DIFF
--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -197,13 +197,14 @@ func (txn *Txn) OrigTimestamp() hlc.Timestamp {
 
 // SetTxnAnchorKey sets the key at which to anchor the transaction record. The
 // transaction anchor key defaults to the first key written in a transaction.
-func (txn *Txn) SetTxnAnchorKey(key roachpb.Key) {
+func (txn *Txn) SetTxnAnchorKey(key roachpb.Key) error {
 	txn.mu.Lock()
+	defer txn.mu.Unlock()
 	if txn.mu.Proto.Writing || txn.mu.writingTxnRecord {
-		panic("must set txn anchor key before any txn writes")
+		return errors.Errorf("transaction anchor key already set")
 	}
 	txn.mu.txnAnchorKey = key
-	txn.mu.Unlock()
+	return nil
 }
 
 // SetSystemConfigTrigger sets the system db trigger to true on this transaction.
@@ -215,14 +216,15 @@ func (txn *Txn) SetTxnAnchorKey(key roachpb.Key) {
 // should be ensured that the transaction record itself is on the system span.
 // This can be done by making sure a system key is the first key touched in the
 // transaction.
-func (txn *Txn) SetSystemConfigTrigger() {
+func (txn *Txn) SetSystemConfigTrigger() error {
 	if !txn.systemConfigTrigger {
 		txn.systemConfigTrigger = true
 		// The system-config trigger must be run on the system-config range which
 		// means any transaction with the trigger set needs to be anchored to the
 		// system-config range.
-		txn.SetTxnAnchorKey(keys.SystemConfigSpan.Key)
+		return txn.SetTxnAnchorKey(keys.SystemConfigSpan.Key)
 	}
+	return nil
 }
 
 // Proto returns the transactions underlying protocol buffer. It is not thread-safe,

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -328,7 +328,9 @@ func createJobsTable(ctx context.Context, r runner) error {
 		desc := sqlbase.JobsTable
 		b.CPut(sqlbase.MakeNameMetadataKey(desc.GetParentID(), desc.GetName()), desc.GetID(), nil)
 		b.CPut(sqlbase.MakeDescMetadataKey(desc.GetID()), sqlbase.WrapDescriptor(&desc), nil)
-		txn.SetSystemConfigTrigger()
+		if err := txn.SetSystemConfigTrigger(); err != nil {
+			return err
+		}
 		return txn.Run(ctx, b)
 	})
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -386,7 +386,9 @@ func TestSystemConfigGossip(t *testing.T) {
 
 	// Write a system key with the transaction marked as having a Gossip trigger.
 	if err := kvDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		txn.SetSystemConfigTrigger()
+		if err := txn.SetSystemConfigTrigger(); err != nil {
+			return err
+		}
 		return txn.Put(ctx, key, valAt(2))
 	}); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -254,7 +254,9 @@ func (sc *SchemaChanger) maybeWriteResumeSpan(
 	} else {
 		tableDesc.Mutations[mutationIdx].ResumeSpans = append(tableDesc.Mutations[mutationIdx].ResumeSpans, resume)
 	}
-	txn.SetSystemConfigTrigger()
+	if err := txn.SetSystemConfigTrigger(); err != nil {
+		return err
+	}
 	if err := txn.Put(
 		ctx,
 		sqlbase.MakeDescMetadataKey(tableDesc.GetID()),
@@ -399,7 +401,9 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 		}
 
 		// TODO(vivek): See comment in backfillIndexesChunk.
-		txn.SetSystemConfigTrigger()
+		if err := txn.SetSystemConfigTrigger(); err != nil {
+			return err
+		}
 
 		p := sc.makePlanner(txn)
 		defer p.session.releaseLeases(ctx)
@@ -549,7 +553,9 @@ func (sc *SchemaChanger) truncateIndexes(
 				}
 
 				// TODO(vivek): See comment in backfillIndexesChunk.
-				txn.SetSystemConfigTrigger()
+				if err := txn.SetSystemConfigTrigger(); err != nil {
+					return err
+				}
 
 				p := sc.makePlanner(txn)
 				defer p.session.releaseLeases(ctx)

--- a/pkg/sql/config_test.go
+++ b/pkg/sql/config_test.go
@@ -55,7 +55,9 @@ func forceNewConfig(t *testing.T, s *server.TestServer) config.SystemConfig {
 
 	// This needs to be done in a transaction with the system trigger set.
 	if err := s.DB().Txn(context.TODO(), func(ctx context.Context, txn *client.Txn) error {
-		txn.SetSystemConfigTrigger()
+		if err := txn.SetSystemConfigTrigger(); err != nil {
+			return err
+		}
 		return txn.Put(ctx, configDescKey, configDesc)
 	}); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/distsqlrun/backfiller.go
+++ b/pkg/sql/distsqlrun/backfiller.go
@@ -206,7 +206,9 @@ func WriteResumeSpan(
 				mutation.ResumeSpans = append(before, after...)
 
 				log.VEventf(ctx, 2, "ckpt %+v", mutation.ResumeSpans)
-				txn.SetSystemConfigTrigger()
+				if err := txn.SetSystemConfigTrigger(); err != nil {
+					return err
+				}
 				return txn.Put(ctx, sqlbase.MakeDescMetadataKey(tableDesc.GetID()), sqlbase.WrapDescriptor(tableDesc))
 			}
 		}

--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -1000,7 +1000,9 @@ func truncateAndDropTable(
 		b := &client.Batch{}
 		// Use CPut because we want to remove a specific name -> id map.
 		b.CPut(nameKey, nil, tableDesc.ID)
-		txn.SetSystemConfigTrigger()
+		if err := txn.SetSystemConfigTrigger(); err != nil {
+			return err
+		}
 		err := txn.Run(ctx, b)
 		if _, ok := err.(*roachpb.ConditionFailedError); ok {
 			return nil
@@ -1027,7 +1029,9 @@ func truncateAndDropTable(
 		b.Del(descKey)
 		// Delete the zone config entry for this table.
 		b.Del(zoneKey)
-		txn.SetSystemConfigTrigger()
+		if err := txn.SetSystemConfigTrigger(); err != nil {
+			return err
+		}
 		return txn.Run(ctx, b)
 	})
 }

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -375,7 +375,9 @@ func (s LeaseStore) Publish(
 			}
 
 			// Write the updated descriptor.
-			txn.SetSystemConfigTrigger()
+			if err := txn.SetSystemConfigTrigger(); err != nil {
+				return err
+			}
 			b := txn.NewBatch()
 			b.Put(descKey, desc)
 			if logEvent != nil {

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -265,7 +265,9 @@ func (p *planner) newPlan(
 	// where the table already exists. This will generate some false
 	// refreshes, but that's expected to be quite rare in practice.
 	if stmt.StatementType() == parser.DDL {
-		p.txn.SetSystemConfigTrigger()
+		if err := p.txn.SetSystemConfigTrigger(); err != nil {
+			return nil, err
+		}
 	}
 
 	if plan, err := p.maybePlanHook(ctx, stmt); plan != nil || err != nil {

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -107,7 +107,9 @@ func (sc *SchemaChanger) AcquireLease(
 ) (sqlbase.TableDescriptor_SchemaChangeLease, error) {
 	var lease sqlbase.TableDescriptor_SchemaChangeLease
 	err := sc.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		txn.SetSystemConfigTrigger()
+		if err := txn.SetSystemConfigTrigger(); err != nil {
+			return err
+		}
 		tableDesc, err := sqlbase.GetTableDescFromID(ctx, txn, sc.tableID)
 		if err != nil {
 			return err
@@ -160,7 +162,9 @@ func (sc *SchemaChanger) ReleaseLease(
 			return err
 		}
 		tableDesc.Lease = nil
-		txn.SetSystemConfigTrigger()
+		if err := txn.SetSystemConfigTrigger(); err != nil {
+			return err
+		}
 		return txn.Put(ctx, sqlbase.MakeDescMetadataKey(tableDesc.ID), sqlbase.WrapDescriptor(tableDesc))
 	})
 }
@@ -187,7 +191,9 @@ func (sc *SchemaChanger) ExtendLease(
 
 		lease = sc.createSchemaChangeLease()
 		tableDesc.Lease = &lease
-		txn.SetSystemConfigTrigger()
+		if err := txn.SetSystemConfigTrigger(); err != nil {
+			return err
+		}
 		return txn.Put(ctx, sqlbase.MakeDescMetadataKey(tableDesc.ID), sqlbase.WrapDescriptor(tableDesc))
 	}); err != nil {
 		return err

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -95,7 +95,9 @@ func (r *editNodeRun) initEditNode(
 func (r *editNodeRun) startEditNode(ctx context.Context, en *editNodeBase, tw tableWriter) error {
 	if sqlbase.IsSystemConfigID(en.tableDesc.GetID()) {
 		// Mark transaction as operating on the system DB.
-		en.p.txn.SetSystemConfigTrigger()
+		if err := en.p.txn.SetSystemConfigTrigger(); err != nil {
+			return err
+		}
 	}
 
 	r.tw = tw

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -117,7 +117,9 @@ func TestStoreRangeSplitAtTablePrefix(t *testing.T) {
 
 	// Update SystemConfig to trigger gossip.
 	if err := store.DB().Txn(context.TODO(), func(ctx context.Context, txn *client.Txn) error {
-		txn.SetSystemConfigTrigger()
+		if err := txn.SetSystemConfigTrigger(); err != nil {
+			return err
+		}
 		// We don't care about the values, just the keys.
 		k := sqlbase.MakeDescMetadataKey(sqlbase.ID(keys.MaxReservedDescID + 1))
 		return txn.Put(ctx, k, &desc)
@@ -815,7 +817,9 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 	// We should end up with splits at each user table prefix.
 	if err := store.DB().Txn(context.TODO(), func(ctx context.Context, txn *client.Txn) error {
 		prefix := keys.MakeTablePrefix(keys.DescriptorTableID)
-		txn.SetSystemConfigTrigger()
+		if err := txn.SetSystemConfigTrigger(); err != nil {
+			return err
+		}
 		for i, kv := range initialSystemValues {
 			if !bytes.HasPrefix(kv.Key, prefix) {
 				continue
@@ -884,7 +888,9 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 	// Write another, disjoint (+3) descriptor for a user table.
 	numTotalValues := userTableMax + 3
 	if err := store.DB().Txn(context.TODO(), func(ctx context.Context, txn *client.Txn) error {
-		txn.SetSystemConfigTrigger()
+		if err := txn.SetSystemConfigTrigger(); err != nil {
+			return err
+		}
 		// This time, only write the last table descriptor. Splits
 		// still occur for every intervening ID.
 		// We don't care about the values, just the keys.


### PR DESCRIPTION
return an error from SetSystemConfigTrigger when it
notices that it is being set on a transaction that has
already written.

@bdarnell you already reviewed this change as part of #14368

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14446)
<!-- Reviewable:end -->
