### PR TITLE
storageccl: verify key/value checksums in WriteBatch command

### DIFF
--- a/pkg/ccl/storageccl/writebatch_test.go
+++ b/pkg/ccl/storageccl/writebatch_test.go
@@ -101,6 +101,20 @@ func TestDBWriteBatch(t *testing.T) {
 			t.Errorf("expected nil, got \"%s\"", result)
 		}
 	}
+
+	// Invalid key/value entry checksum.
+	{
+		var batch engine.RocksDBBatchBuilder
+		key := engine.MVCCKey{Key: []byte("bb"), Timestamp: hlc.Timestamp{WallTime: 1}}
+		value := roachpb.MakeValueFromString("1")
+		value.InitChecksum([]byte("foo"))
+		batch.Put(key, value.RawBytes)
+		data := batch.Finish()
+
+		if err := db.WriteBatch(ctx, "b", "c", data); !testutils.IsError(err, "invalid checksum") {
+			t.Fatalf("expected 'invalid checksum' error got: %+v", err)
+		}
+	}
 }
 
 func TestWriteBatchMVCCStats(t *testing.T) {

--- a/pkg/storage/engine/batch.go
+++ b/pkg/storage/engine/batch.go
@@ -16,13 +16,34 @@
 
 package engine
 
-import "github.com/cockroachdb/cockroach/pkg/util/hlc"
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/pkg/errors"
+)
+
+// BatchType represents the type of an entry in an encoded RocksDB batch.
+type BatchType byte
+
+// These constants come from rocksdb/db/dbformat.h.
+const (
+	BatchTypeDeletion BatchType = 0x0
+	BatchTypeValue              = 0x1
+	BatchTypeMerge              = 0x2
+	// BatchTypeLogData                    = 0x3
+	// BatchTypeColumnFamilyDeletion       = 0x4
+	// BatchTypeColumnFamilyValue          = 0x5
+	// BatchTypeColumnFamilyMerge          = 0x6
+	// BatchTypeSingleDeletion             = 0x7
+	// BatchTypeColumnFamilySingleDeletion = 0x8
+)
 
 const (
-	batchTypeDeletion byte = 0x0
-	batchTypeValue         = 0x1
-	batchTypeMerge         = 0x2
-
 	// The batch header is composed of an 8-byte sequence number (all zeroes) and
 	// 4-byte count of the number of entries in the batch.
 	headerSize       int = 12
@@ -51,8 +72,8 @@ const (
 //      data: uint8[len]
 //
 // The RocksDBBatchBuilder code currently only supports kTypeValue
-// (batchTypeValue), kTypeDeletion (batchTypeDeletion)and kTypeMerge
-// (batchTypeMerge) operations. Before a batch is written to the RocksDB
+// (BatchTypeValue), kTypeDeletion (BatchTypeDeletion)and kTypeMerge
+// (BatchTypeMerge) operations. Before a batch is written to the RocksDB
 // write-ahead-log, the sequence number is 0. The "fixed32" format is little
 // endian.
 //
@@ -199,7 +220,7 @@ func (b *RocksDBBatchBuilder) encodeKeyValue(key MVCCKey, value []byte, tag byte
 
 // Put sets the given key to the value provided.
 func (b *RocksDBBatchBuilder) Put(key MVCCKey, value []byte) {
-	b.encodeKeyValue(key, value, batchTypeValue)
+	b.encodeKeyValue(key, value, BatchTypeValue)
 }
 
 // Merge is a high-performance write operation used for values which are
@@ -207,7 +228,7 @@ func (b *RocksDBBatchBuilder) Put(key MVCCKey, value []byte) {
 // into a single key; a subsequent read will return a "merged" value which is
 // computed from the original merged values.
 func (b *RocksDBBatchBuilder) Merge(key MVCCKey, value []byte) {
-	b.encodeKeyValue(key, value, batchTypeMerge)
+	b.encodeKeyValue(key, value, BatchTypeMerge)
 }
 
 // Clear removes the item from the db with the given key.
@@ -216,5 +237,196 @@ func (b *RocksDBBatchBuilder) Clear(key MVCCKey) {
 	b.count++
 	pos := len(b.repr)
 	b.encodeKey(key, 0)
-	b.repr[pos] = batchTypeDeletion
+	b.repr[pos] = byte(BatchTypeDeletion)
+}
+
+// DecodeKey decodes an engine.MVCCKey from its serialized representation. This
+// decoding must match engine/db.cc:DecodeKey().
+func DecodeKey(encodedKey []byte) (MVCCKey, error) {
+	tsLen := int(encodedKey[len(encodedKey)-1])
+	keyPartEnd := len(encodedKey) - 1 - tsLen
+	if keyPartEnd < 0 {
+		return MVCCKey{}, errors.Errorf("invalid encoded mvcc key: %x", encodedKey)
+	}
+
+	key := MVCCKey{Key: encodedKey[:keyPartEnd]}
+	encodedTs := encodedKey[keyPartEnd:]
+
+	switch tsLen {
+	case 0:
+		// No-op.
+	case 9:
+		key.Timestamp.WallTime = int64(binary.BigEndian.Uint64(encodedTs[1:9]))
+	case 13:
+		key.Timestamp.WallTime = int64(binary.BigEndian.Uint64(encodedTs[1:9]))
+		key.Timestamp.Logical = int32(binary.BigEndian.Uint32(encodedTs[9:13]))
+	default:
+		return MVCCKey{}, errors.Errorf(
+			"invalid encoded mvcc key: bad timestamp len %d: %x", encodedKey, tsLen)
+	}
+
+	return key, nil
+}
+
+// RocksDBBatchReader is used to iterate the entries in a RocksDB batch
+// representation.
+//
+// Example:
+// r, err := NewRocksDBBatchReader(...)
+// if err != nil {
+//   return err
+// }
+// for r.Next() {
+// 	 switch r.BatchType() {
+// 	 case BatchTypeDeletion:
+// 	   fmt.Printf("delete(%x)", r.UnsafeKey())
+// 	 case BatchTypeValue:
+// 	   fmt.Printf("put(%x,%x)", r.UnsafeKey(), r.UnsafeValue())
+// 	 case BatchTypeMerge:
+// 	   fmt.Printf("merge(%x,%x)", r.UnsafeKey(), r.UnsafeValue())
+// 	 }
+// }
+// if err != nil {
+//   return nil
+// }
+type RocksDBBatchReader struct {
+	buf *bytes.Reader
+
+	// The error encountered during iterator, if any
+	err error
+
+	// The total number of entries, decoded from the batch header
+	count uint32
+
+	// For allocation avoidance
+	alloc bufalloc.ByteAllocator
+
+	// The following all represent the current entry and are updated by Next.
+	// `value` is not applicable for BatchTypeDeletion.
+	offset int
+	typ    BatchType
+	key    []byte
+	value  []byte
+}
+
+// NewRocksDBBatchReader creates a RocksDBBatchReader from the given repr and
+// verifies the header.
+func NewRocksDBBatchReader(repr []byte) (*RocksDBBatchReader, error) {
+	// Set offset to -1 so the first call to Next will increment it to 0.
+	r := RocksDBBatchReader{buf: bytes.NewReader(repr), offset: -1}
+
+	var seq uint64
+	if err := binary.Read(r.buf, binary.LittleEndian, &seq); err != nil {
+		return nil, err
+	}
+	if seq != 0 {
+		return nil, errors.Errorf("bad sequence: expected 0, but found %d", seq)
+	}
+
+	if err := binary.Read(r.buf, binary.LittleEndian, &r.count); err != nil {
+		return nil, err
+	}
+
+	return &r, nil
+}
+
+// Count returns the declared number of entries in the batch.
+func (r *RocksDBBatchReader) Count() int {
+	return int(r.count)
+}
+
+// Error returns the error, if any, which the iterator encountered.
+func (r *RocksDBBatchReader) Error() error {
+	return r.err
+}
+
+// BatchType returns the type of the current batch entry.
+func (r *RocksDBBatchReader) BatchType() BatchType {
+	return r.typ
+}
+
+// UnsafeKey returns the key of the current batch entry. The memory is
+// invalidated on the next call to Next.
+func (r *RocksDBBatchReader) UnsafeKey() []byte {
+	return r.key
+}
+
+// UnsafeValue returns the value of the current batch entry. The memory is
+// invalidated on the next call to Next. UnsafeValue panics if the BatchType is
+// BatchTypeDeleted.
+func (r *RocksDBBatchReader) UnsafeValue() []byte {
+	if r.typ == BatchTypeDeletion {
+		panic("cannot call UnsafeValue on a deletion entry")
+	}
+	return r.value
+}
+
+// Next advances to the next entry in the batch, returning false when the batch
+// is empty.
+func (r *RocksDBBatchReader) Next() bool {
+	if r.err != nil {
+		return false
+	}
+
+	r.offset++
+	typ, err := r.buf.ReadByte()
+	if err == io.EOF {
+		if r.offset < int(r.count) {
+			r.err = errors.Errorf("invalid batch: expected %d entries but found %d", r.count, r.offset)
+		}
+		return false
+	} else if err != nil {
+		r.err = err
+		return false
+	}
+
+	// Reset alloc.
+	r.alloc = r.alloc[:0]
+
+	r.typ = BatchType(typ)
+	switch r.typ {
+	case BatchTypeDeletion:
+		if r.key, r.err = r.varstring(); r.err != nil {
+			return false
+		}
+	case BatchTypeValue:
+		if r.key, r.err = r.varstring(); r.err != nil {
+			return false
+		}
+		if r.value, r.err = r.varstring(); r.err != nil {
+			return false
+		}
+	case BatchTypeMerge:
+		if r.key, r.err = r.varstring(); r.err != nil {
+			return false
+		}
+		if r.value, r.err = r.varstring(); r.err != nil {
+			return false
+		}
+	default:
+		r.err = errors.Errorf("unexpected type %d", typ)
+		return false
+	}
+	return true
+}
+
+func (r *RocksDBBatchReader) varstring() ([]byte, error) {
+	n, err := binary.ReadUvarint(r.buf)
+	if err != nil {
+		return nil, err
+	}
+	if n == 0 {
+		return nil, nil
+	}
+
+	var s []byte
+	r.alloc, s = r.alloc.Alloc(int(n), 0)
+	c, err := r.buf.Read(s)
+	if err != nil {
+		return nil, err
+	}
+	if c != int(n) {
+		return nil, fmt.Errorf("expected %d bytes, but found %d", n, c)
+	}
+	return s, nil
 }

--- a/pkg/storage/engine/batch_test.go
+++ b/pkg/storage/engine/batch_test.go
@@ -18,7 +18,6 @@ package engine
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 	"reflect"
 	"sync/atomic"
@@ -141,90 +140,34 @@ func TestBatchRepr(t *testing.T) {
 	testBatchBasics(t, false /* writeOnly */, func(e Engine, b Batch) error {
 		repr := b.Repr()
 
-		// Simple sanity checks about the format of the batch representation. This
-		// is inefficient decoding code. Do not move outside of test code.
-		buf := bytes.NewReader(repr)
-		var seq uint64
-		var count uint32
-		if err := binary.Read(buf, binary.LittleEndian, &seq); err != nil {
-			t.Fatal(err)
+		r, err := NewRocksDBBatchReader(repr)
+		if err != nil {
+			t.Fatalf("%+v", err)
 		}
-		if seq != 0 {
-			// The sequence number is set when the batch is written.
-			t.Fatalf("bad sequence: expected 0, but found %d", seq)
-		}
-		if err := binary.Read(buf, binary.LittleEndian, &count); err != nil {
-			t.Fatal(err)
-		}
-		if expected := uint32(3); expected != count {
+		if count, expected := r.Count(), 3; count != expected {
 			t.Fatalf("bad count: expected %d, but found %d", expected, count)
 		}
 
-		const (
-			// These constants come from rocksdb/db/dbformat.h.
-			TypeDeletion = 0x0
-			TypeValue    = 0x1
-			TypeMerge    = 0x2
-			// TypeLogData                    = 0x3
-			// TypeColumnFamilyDeletion       = 0x4
-			// TypeColumnFamilyValue          = 0x5
-			// TypeColumnFamilyMerge          = 0x6
-			// TypeSingleDeletion             = 0x7
-			// TypeColumnFamilySingleDeletion = 0x8
-		)
-
-		varstring := func(buf *bytes.Reader) (string, error) {
-			n, err := binary.ReadUvarint(buf)
-			if err != nil {
-				return "", err
-			}
-			s := make([]byte, n)
-			c, err := buf.Read(s)
-			if err != nil {
-				return "", err
-			}
-			if c != int(n) {
-				return "", fmt.Errorf("expected %d, but found %d", n, c)
-			}
-			return string(s), nil
-		}
-
 		var ops []string
-		for i := uint32(0); i < count; i++ {
-			typ, err := buf.ReadByte()
-			if err != nil {
-				t.Fatal(err)
+		for i := 0; i < r.Count(); i++ {
+			if ok := r.Next(); !ok {
+				t.Fatalf("%d: unexpected end of batch", i)
 			}
-			switch typ {
-			case TypeDeletion:
-				k, err := varstring(buf)
-				if err != nil {
-					t.Fatal(err)
-				}
-				ops = append(ops, fmt.Sprintf("delete(%s)", k))
-			case TypeValue:
-				k, err := varstring(buf)
-				if err != nil {
-					t.Fatal(err)
-				}
-				v, err := varstring(buf)
-				if err != nil {
-					t.Fatal(err)
-				}
-				ops = append(ops, fmt.Sprintf("put(%s,%s)", k, v))
-			case TypeMerge:
-				k, err := varstring(buf)
-				if err != nil {
-					t.Fatal(err)
-				}
+			switch r.BatchType() {
+			case BatchTypeDeletion:
+				ops = append(ops, fmt.Sprintf("delete(%s)", string(r.UnsafeKey())))
+			case BatchTypeValue:
+				ops = append(ops, fmt.Sprintf("put(%s,%s)", string(r.UnsafeKey()), string(r.UnsafeValue())))
+			case BatchTypeMerge:
 				// The merge value is a protobuf and not easily displayable.
-				if _, err = varstring(buf); err != nil {
-					t.Fatal(err)
-				}
-				ops = append(ops, fmt.Sprintf("merge(%s)", k))
-			default:
-				t.Fatalf("%d: unexpected type %d", i, typ)
+				ops = append(ops, fmt.Sprintf("merge(%s)", string(r.UnsafeKey())))
 			}
+		}
+		if err != nil {
+			t.Fatalf("unexpected err during iteration: %+v", err)
+		}
+		if ok := r.Next(); ok {
+			t.Errorf("expected end of batch")
 		}
 
 		// The keys in the batch have the internal MVCC encoding applied which for
@@ -1057,5 +1000,44 @@ func TestBatchCombine(t *testing.T) {
 		if err := <-errs; err != nil {
 			t.Error(err)
 		}
+	}
+}
+
+func TestDecodeKey(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	e := NewInMem(roachpb.Attributes{}, 1<<20)
+	defer e.Close()
+
+	tests := []MVCCKey{
+		{Key: []byte{}},
+		{Key: []byte("foo")},
+		{Key: []byte("foo"), Timestamp: hlc.Timestamp{WallTime: 1}},
+		{Key: []byte("foo"), Timestamp: hlc.Timestamp{WallTime: 1, Logical: 1}},
+	}
+	for _, test := range tests {
+		t.Run(test.String(), func(t *testing.T) {
+			b := e.NewBatch()
+			defer b.Close()
+			if err := b.Put(test, nil); err != nil {
+				t.Fatalf("%+v", err)
+			}
+			repr := b.Repr()
+
+			r, err := NewRocksDBBatchReader(repr)
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
+			if !r.Next() {
+				t.Fatalf("could not get the first entry: %+v", r.Error())
+			}
+			decodedKey, err := DecodeKey(r.UnsafeKey())
+			if err != nil {
+				t.Fatalf("unexpected err: %+v", err)
+			}
+			if !reflect.DeepEqual(test, decodedKey) {
+				t.Errorf("expected %+v got %+v", test, decodedKey)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Previously, we weren't checking them, so it was possible for a kv client
to send a WriteBatch with data that would fail on any subsequent read.

Benchmark diffs are in the noise

name                 old time/op    new time/op    delta
WriteBatch/100-8       1.00ms ± 5%    1.06ms ±15%   ~     (p=1.000 n=5+5)
WriteBatch/1000-8      6.26ms ±11%    6.09ms ± 8%   ~     (p=0.690 n=5+5)
WriteBatch/10000-8     74.4ms ±16%    76.7ms ±14%   ~     (p=0.690 n=5+5)
WriteBatch/100000-8     817ms ±13%     836ms ± 6%   ~     (p=0.690 n=5+5)

name                 old speed      new speed      delta
WriteBatch/100-8     12.2MB/s ± 4%  11.6MB/s ±14%   ~     (p=0.881 n=5+5)
WriteBatch/1000-8    19.7MB/s ±11%  20.2MB/s ± 8%   ~     (p=0.690 n=5+5)
WriteBatch/10000-8   16.5MB/s ±14%  16.0MB/s ±13%   ~     (p=0.690 n=5+5)
WriteBatch/100000-8  15.1MB/s ±12%  14.7MB/s ± 6%   ~     (p=0.690 n=5+5)

name                 old alloc/op   new alloc/op   delta
WriteBatch/100-8        727kB ± 2%     717kB ± 3%   ~     (p=0.548 n=5+5)
WriteBatch/1000-8      6.14MB ± 4%    6.02MB ± 6%   ~     (p=0.421 n=5+5)
WriteBatch/10000-8     65.0MB ± 4%    65.0MB ± 1%   ~     (p=0.841 n=5+5)
WriteBatch/100000-8    1.12GB ± 0%    1.10GB ± 4%   ~     (p=0.730 n=4+5)

name                 old allocs/op  new allocs/op  delta
WriteBatch/100-8        1.57k ±42%     1.19k ±57%   ~     (p=0.421 n=5+5)
WriteBatch/1000-8       8.66k ±92%     2.31k ±68%   ~     (p=0.151 n=5+5)
WriteBatch/10000-8     65.2k ±141%    28.2k ±131%   ~     (p=0.841 n=5+5)
WriteBatch/100000-8     19.1k ±24%     17.8k ±23%   ~     (p=0.886 n=4+4)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14449)
<!-- Reviewable:end -->
