### PR TITLE
build: TC builds only use vendored source code

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -43,16 +43,8 @@ and checked out as a submodule at `./vendor`.
 
 This snapshot was built and is managed using `glide`.
 
-### Installing Glide
-
-Get or update glide with `go get -u github.com/Masterminds/glide`
+Install the pinned version of `glide` with `go install ./vendor/github.com/Masterminds/glide`
 - Note that versions in `brew` or elsewhere are sometimes missing recent fixes.
-- If installing from master becomes unstable, you can use the oldest version that correctly handles
-submodules (`ab0972eb`), e.g.
-```
-git -C $GOPATH/src/github.com/Masterminds/glide checkout ab0972eb && \
-go install github.com/Masterminds/glide
-```
 
 ### Using Glide
 

--- a/build/checkdeps.sh
+++ b/build/checkdeps.sh
@@ -3,40 +3,11 @@ set -exuo pipefail
 
 # This is intended to run in a CI to ensure dependencies are properly vendored.
 
-echo "installing desired glide version"
-go get -d github.com/Masterminds/glide
-# ab0972eb merged our fix for correctly vendoring submodule contents.
-git -C $GOPATH/src/github.com/Masterminds/glide fetch
-git -C $GOPATH/src/github.com/Masterminds/glide checkout ab0972eb
-go install github.com/Masterminds/glide
+echo "installing vendored glide"
+go install ./vendor/github.com/Masterminds/glide
 
 echo "checking that 'vendor' matches manifest"
 ./scripts/glide.sh install
 ! git -C vendor status --porcelain | read || (git -C vendor status; git -C vendor diff -a 1>&2; exit 1)
-
-echo "checking that all deps are in 'vendor''"
-
-top_deps=$(go list -f '{{join .Imports "\n"}}{{"\n"}}{{join .TestImports "\n"}}{{"\n"}}{{join .XTestImports "\n"}}' ./pkg/... | \
-    sort -u | grep -v '^C$')
-cmd_deps=$(sed -n 's,[[:space:]]*_[[:space:]]*"\(.*\)",./vendor/\1,p' build/tool_imports.go)
-
-deps="
-$top_deps
-$cmd_deps
-"
-
-# Note that grep's exit status is ignored here to allow for packages with no
-# dependencies.
-missing=$(echo "$deps" | \
-	xargs go list -f '{{if not .Standard}}{{join .Deps "\n" }}{{end}}' | \
-	sort -u | grep -v '^C$' | \
-	xargs go list -f '{{if not .Standard}}{{.ImportPath}}{{end}}' | \
-	grep -v '^github.com/cockroachdb/cockroach' || true)
-
-if [ -n "$missing" ]; then
-  echo "vendor is missing some 3rd-party dependencies:"
-  echo "$missing"
-  exit 1
-fi
 
 echo "all 3rd-party dependencies appear to be properly vendored."

--- a/build/teamcity-acceptance.sh
+++ b/build/teamcity-acceptance.sh
@@ -4,6 +4,7 @@ set -euxo pipefail
 # Ensure that no stale binary remains.
 rm -f acceptance.test
 
+export BUILDER_HIDE_GOPATH_SRC=1
 build/builder.sh make build
 build/builder.sh make install
 build/builder.sh go test -v -c -tags acceptance ./pkg/acceptance

--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -exuo pipefail
+
 # All packages need to be installed before we can run (some) of the checks
 # and code generators reliably. More precisely, anything that using
 # x/tools/go/loader is fragile (this includes stringer, vet and others).
@@ -7,6 +8,7 @@ set -exuo pipefail
 # The blocking issue is https://github.com/golang/go/issues/14120; see
 # https://github.com/golang/go/issues/10249 for some more concrete discussion
 # on `stringer` and https://github.com/golang/go/issues/16086 for `vet`.
+export BUILDER_HIDE_GOPATH_SRC=1
 build/builder.sh make gotestdashi
 
 mkdir -p artifacts

--- a/build/teamcity-checkdeps.sh
+++ b/build/teamcity-checkdeps.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -exuo pipefail
 
+export BUILDER_HIDE_GOPATH_SRC=1
 exec ./build/builder.sh build/checkdeps.sh

--- a/build/teamcity-release-upload.sh
+++ b/build/teamcity-release-upload.sh
@@ -26,6 +26,7 @@ cat .buildinfo/tag || true
 cat .buildinfo/rev || true
 git status
 
+export BUILDER_HIDE_GOPATH_SRC=1
 build/builder.sh build/build-static-binaries.sh static-tests.tar.gz
 for archive in cockroach-latest "cockroach-${VERSION}"
 do

--- a/build/teamcity-sqllogictest.sh
+++ b/build/teamcity-sqllogictest.sh
@@ -3,6 +3,7 @@ set -euxo pipefail
 
 mkdir -p artifacts
 
+export BUILDER_HIDE_GOPATH_SRC=1
 build/builder.sh env \
 		 make -C pkg/sql bigtest \
 		 TESTFLAGS='-v' \

--- a/build/teamcity-stress-meta.sh
+++ b/build/teamcity-stress-meta.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
+export BUILDER_HIDE_GOPATH_SRC=1
 build/builder.sh make .bootstrap # explicitly recompile teamcity-trigger
 build/builder.sh env TC_API_USER="$TC_API_USER" TC_API_PASSWORD="$TC_API_PASSWORD" TC_SERVER_URL="$TC_SERVER_URL" teamcity-trigger

--- a/build/teamcity-stress.sh
+++ b/build/teamcity-stress.sh
@@ -4,6 +4,7 @@ set -euxo pipefail
 mkdir -p artifacts
 
 exit_status=0
+export BUILDER_HIDE_GOPATH_SRC=1
 build/builder.sh env \
 		 COCKROACH_PROPOSER_EVALUATED_KV="${COCKROACH_PROPOSER_EVALUATED_KV:-false}" \
 		 make stress \

--- a/build/teamcity-test.sh
+++ b/build/teamcity-test.sh
@@ -3,6 +3,7 @@ set -euxo pipefail
 
 mkdir -p artifacts
 
+export BUILDER_HIDE_GOPATH_SRC=1
 build/builder.sh env \
 		 COCKROACH_PROPOSER_EVALUATED_KV="${COCKROACH_PROPOSER_EVALUATED_KV:-false}" \
 		 make test \

--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -3,6 +3,7 @@ set -euxo pipefail
 
 mkdir -p artifacts
 
+export BUILDER_HIDE_GOPATH_SRC=1
 build/builder.sh env \
 		 COCKROACH_PROPOSER_EVALUATED_KV="${COCKROACH_PROPOSER_EVALUATED_KV:-false}" \
 		 make testrace \

--- a/build/tool_imports.go
+++ b/build/tool_imports.go
@@ -28,6 +28,7 @@ package main
 // this file is build-tagged +glide to prevent attempting to build it.
 
 import (
+	_ "github.com/Masterminds/glide"
 	_ "github.com/client9/misspell/cmd/misspell"
 	_ "github.com/cockroachdb/c-protobuf/cmd/protoc"
 	_ "github.com/cockroachdb/crlfmt"

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 8b6c6c915adbc5c97805111f13154d2d5de0a3266b1237fe904163d343778680
-updated: 2017-03-29T13:42:02.341359385-04:00
+hash: 47cb930494140062e1154da07ed282890c32bcb12861fd464e260c7fa7931181
+updated: 2017-03-29T18:15:09.580089273-04:00
 imports:
 - name: cloud.google.com/go
-  version: 343c80ab593aa89f77de6f29d03929c5bffe9842
+  version: 5fd028f47f3170cfe2a87666eae9ff5595027282
   subpackages:
   - compute/metadata
   - internal
@@ -61,6 +61,8 @@ imports:
   version: ce09c414594390d1d6432280c7cac55e62c6b0af
 - name: github.com/codahale/hdrhistogram
   version: 3a0bb77429bd3a61596f5e8a3172445844342120
+- name: github.com/codegangsta/cli
+  version: 0bdeddeeb0f650497d603c4ad7b20cfe685682f6
 - name: github.com/coreos/etcd
   version: 7b541f90039c625d8242f90816066ecd5cf78744
   subpackages:
@@ -181,7 +183,7 @@ imports:
   subpackages:
   - query
 - name: github.com/google/pprof
-  version: 402739d38bd5f4bd5c0e14131347ce6b9481d1b5
+  version: 5c63cc70220dd56546d4d417f30d5460138b93b5
   subpackages:
   - driver
   - internal/binutils
@@ -242,6 +244,29 @@ imports:
   - lightstep_thrift
   - thrift_0_9_2/lib/go/thrift
   - thrift_rpc
+- name: github.com/Masterminds/glide
+  version: ab0972eb70bbb48926b62b3401b19845b186c3c0
+  subpackages:
+  - action
+  - cache
+  - cfg
+  - dependency
+  - gb
+  - godep
+  - godep/strip
+  - gom
+  - gpm
+  - importer
+  - mirrors
+  - msg
+  - path
+  - repo
+  - tree
+  - util
+- name: github.com/Masterminds/semver
+  version: 59c29afe1a994eacb71c833025ca7acf874bb1da
+- name: github.com/Masterminds/vcs
+  version: 795e20f901c3d561de52811fb3488a2cb2c8588b
 - name: github.com/mattn/go-isatty
   version: fc9e8d8ef48496124e79ae0df75490096eccf6fe
 - name: github.com/mattn/go-runewidth
@@ -266,6 +291,8 @@ imports:
   - syntax/golang
 - name: github.com/Microsoft/go-winio
   version: fff283ad5116362ca252298cfc9b95828956d85d
+- name: github.com/mitchellh/go-homedir
+  version: b8bc1bf767474819792c23f32d8286a45736f1c6
 - name: github.com/montanaflynn/stats
   version: f8cd06f93c6c1b06028caafb88b540fc820f77c1
 - name: github.com/olekukonko/tablewriter

--- a/glide.yaml
+++ b/glide.yaml
@@ -17,6 +17,10 @@ import:
 - package: google.golang.org/grpc
   version: 9d55a95b90eb10d08a07e0213d23797dbd7b7552
   repo: https://github.com/andreimatei/grpc-go
+# We pin glide itself to prevent changes to glide's dependency resolution
+# algorithm from modifying our dependencies unexpectedly.
+- package: github.com/Masterminds/glide
+  version: ab0972eb70bbb48926b62b3401b19845b186c3c0
 # Pins to prevent unintended version changes to libs we care about when adding/
 # removing/changing other deps. These are grouped separately to make it easier
 # to comment them out in bulk when running an across-the-board dep update.


### PR DESCRIPTION
`build/builder.sh` now mounts **only** the `github.com/cockroachdb/cockroach` tree under `$GOPATH/src` when a new environment variable, `BUILDER_HIDE_GOPATH_SRC`, is set to 1.

This option is now set in all TeamCity invocation scripts.

In order to make this work, we also vendor glide itself to prevent needing to `go get` it, which would fetch an outside dependency and spoil our supper.

As a consequence of the above, the segment of checkdeps that asserts there are no unvendored dependencies is rendered redundant, so it's deleted.

Updates #14451.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14454)
<!-- Reviewable:end -->
