### PR TITLE
sqlccl: add naive progress tracking to backup and restore

### DIFF
--- a/pkg/ccl/sqlccl/backup.go
+++ b/pkg/ccl/sqlccl/backup.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl/intervalccl"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -115,6 +116,21 @@ func allSQLDescriptors(ctx context.Context, txn *client.Txn) ([]sqlbase.Descript
 	return sqlDescs, nil
 }
 
+func allRangeDescriptors(ctx context.Context, txn *client.Txn) ([]roachpb.RangeDescriptor, error) {
+	rows, err := txn.Scan(ctx, keys.Meta2Prefix, keys.MetaMax, 0)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to scan range descriptors")
+	}
+
+	rangeDescs := make([]roachpb.RangeDescriptor, len(rows))
+	for i, row := range rows {
+		if err := row.ValueProto(&rangeDescs[i]); err != nil {
+			return nil, errors.Wrapf(err, "%s: unable to unmarshal range descriptor", row.Key)
+		}
+	}
+	return rangeDescs, nil
+}
+
 // spansForAllTableIndexes returns non-overlapping spans for every index and
 // table passed in. They would normally overlap if any of them are interleaved.
 func spansForAllTableIndexes(tables []*sqlbase.TableDescriptor) []roachpb.Span {
@@ -138,6 +154,49 @@ func spansForAllTableIndexes(tables []*sqlbase.TableDescriptor) []roachpb.Span {
 		return false
 	})
 	return spans
+}
+
+// splitSpansByRanges takes a slice of non-overlapping spans and a slice of
+// range descriptors and returns a new slice of spans in which each span has
+// been split so that no single span extends beyond the boundaries of a range.
+func splitSpansByRanges(spans []roachpb.Span, ranges []roachpb.RangeDescriptor) []roachpb.Span {
+	type spanMarker struct{}
+
+	var spanCovering intervalccl.Covering
+	for _, span := range spans {
+		spanCovering = append(spanCovering, intervalccl.Range{
+			Start:   []byte(span.Key),
+			End:     []byte(span.EndKey),
+			Payload: spanMarker{},
+		})
+	}
+
+	var rangeCovering intervalccl.Covering
+	for _, rangeDesc := range ranges {
+		rangeCovering = append(rangeCovering, intervalccl.Range{
+			Start: []byte(rangeDesc.StartKey),
+			End:   []byte(rangeDesc.EndKey),
+		})
+	}
+
+	splits := intervalccl.OverlapCoveringMerge([]intervalccl.Covering{spanCovering, rangeCovering})
+
+	var splitSpans []roachpb.Span
+	for _, split := range splits {
+		needed := false
+		for _, payload := range split.Payload.([]interface{}) {
+			if _, needed = payload.(spanMarker); needed {
+				break
+			}
+		}
+		if needed {
+			splitSpans = append(splitSpans, roachpb.Span{
+				Key:    roachpb.Key(split.Start),
+				EndKey: roachpb.Key(split.End),
+			})
+		}
+	}
+	return splitSpans
 }
 
 func backupJobDescription(
@@ -247,13 +306,32 @@ func Backup(
 		}
 	}
 
-	spans := spansForAllTableIndexes(tables)
+	var ranges []roachpb.RangeDescriptor
+	if err := db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		var err error
+		// TODO(benesch): limit the range descriptors we fetch to the ranges that
+		// are actually relevant in the backup to speed up small backups on large
+		// clusters.
+		ranges, err = allRangeDescriptors(ctx, txn)
+		return err
+	}); err != nil {
+		return BackupDescriptor{}, err
+	}
+
+	// We split the spans into range-sized pieces so that we can use the number of
+	// completed requests as a rough measure of progress.
+	spans := splitSpansByRanges(spansForAllTableIndexes(tables), ranges)
 
 	mu := struct {
 		syncutil.Mutex
 		files    []BackupDescriptor_File
 		dataSize int64
 	}{}
+
+	progressLogger := jobProgressLogger{
+		jobLogger:   jobLogger,
+		totalChunks: len(spans),
+	}
 
 	for _, desc := range tables {
 		jobLogger.Job.DescriptorIDs = append(jobLogger.Job.DescriptorIDs, desc.GetID())
@@ -280,7 +358,6 @@ func Backup(
 				return pErr.GoError()
 			}
 			mu.Lock()
-			defer mu.Unlock()
 			for _, file := range res.(*roachpb.ExportResponse).Files {
 				mu.files = append(mu.files, BackupDescriptor_File{
 					Span:   file.Span,
@@ -289,10 +366,18 @@ func Backup(
 				})
 				mu.dataSize += file.DataSize
 			}
+			mu.Unlock()
+			if err := progressLogger.chunkFinished(ctx); err != nil {
+				// Errors while updating progress are not important enough to merit
+				// failing the entire backup.
+				log.Errorf(ctx, "BACKUP ignoring error while updating progress on job %d (%s): %+v",
+					jobLogger.JobID(), jobLogger.Job.Description, err)
+			}
 			return nil
 		})
 	}
-	if err := g.Wait(); err != nil {
+
+	if err = g.Wait(); err != nil {
 		return BackupDescriptor{}, errors.Wrapf(err, "exporting %d ranges", len(spans))
 	}
 	files, dataSize := mu.files, mu.dataSize // No more concurrency, so this is safe.

--- a/pkg/ccl/sqlccl/backup.go
+++ b/pkg/ccl/sqlccl/backup.go
@@ -397,8 +397,10 @@ func backupPlanHook(
 			return nil, err
 		}
 		if err := jobLogger.Succeeded(ctx); err != nil {
-			log.Errorf(ctx, "BACKUP ignoring error while marking job '%s' as successful: %+v",
-				description, err)
+			// An error while marking the job as successful is not important enough to
+			// merit failing the entire backup.
+			log.Errorf(ctx, "BACKUP ignoring error while marking job %d (%s) as successful: %+v",
+				jobLogger.JobID(), description, err)
 		}
 		ret := []parser.Datums{{
 			parser.NewDString(to),

--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/kr/pretty"
 	"github.com/lib/pq"
@@ -40,7 +41,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -105,8 +105,8 @@ func bankSplitStmt(numAccounts int, numRanges int) string {
 	return stmt.String()
 }
 
-func backupRestoreTestSetup(
-	t testing.TB, clusterSize int, numAccounts int,
+func backupRestoreTestSetupWithParams(
+	t testing.TB, clusterSize int, numAccounts int, params base.TestClusterArgs,
 ) (
 	ctx context.Context,
 	tempDir string,
@@ -120,7 +120,7 @@ func backupRestoreTestSetup(
 
 	temp := filepath.Join(dir, "must-be-cleaned-up")
 
-	tc = testcluster.StartTestCluster(t, clusterSize, base.TestClusterArgs{})
+	tc = testcluster.StartTestCluster(t, clusterSize, params)
 	for _, s := range tc.Servers {
 		for _, e := range s.Engines() {
 			if err := e.SetTempDir(temp); err != nil {
@@ -160,6 +160,18 @@ func backupRestoreTestSetup(
 	}
 
 	return ctx, dir, tc, sqlDB, cleanupFn
+}
+
+func backupRestoreTestSetup(
+	t testing.TB, clusterSize int, numAccounts int,
+) (
+	ctx context.Context,
+	tempDir string,
+	tc *testcluster.TestCluster,
+	sqlDB *sqlutils.SQLRunner,
+	cleanup func(),
+) {
+	return backupRestoreTestSetupWithParams(t, clusterSize, numAccounts, base.TestClusterArgs{})
 }
 
 func TestBackupRestoreLocal(t *testing.T) {
@@ -272,27 +284,95 @@ func verifySystemJob(
 	return nil
 }
 
+// verifySystemJobProgress asserts that the fractionCompleted of the latest job
+// in the system.jobs table is approximately 0.5 when half of the expected
+// responses have completed.
+func verifySystemJobProgress(
+	sqlDB *sqlutils.SQLRunner, allowResponse chan struct{}, totalExpectedResponses int,
+) error {
+	// Allow half the total expected responses to proceed.
+	for i := 0; i < totalExpectedResponses/2; i++ {
+		allowResponse <- struct{}{}
+	}
+
+	// Ensure the fractionCompleted of the latest job is in the range [0.25, 0.75].
+	err := util.RetryForDuration(time.Second, func() error {
+		var fractionCompleted float32
+		sqlDB.QueryRow(
+			`SELECT fraction_completed FROM crdb_internal.jobs ORDER BY created DESC LIMIT 1`,
+		).Scan(&fractionCompleted)
+		if fractionCompleted < 0.25 || fractionCompleted > 0.75 {
+			return errors.Errorf("expected progress to be in range [0.25, 0.75] after 1s but got %f",
+				fractionCompleted)
+		}
+		return nil
+	})
+
+	// Close the channel to allow future responses to proceed without us
+	// explicitly writing messages to the channel.
+	close(allowResponse)
+	return err
+}
+
 func TestBackupRestoreSystemJobs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	if !storage.ProposerEvaluatedKVEnabled() {
 		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
 	}
 
-	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	const expectedProgressUpdateCount = backupRestoreDefaultRanges
 
-	dir, dirCleanupFn := testutils.TempDir(t, 1)
-	defer dirCleanupFn()
+	// To test incremental progress updates, we install a store response filter,
+	// which runs immediately before a KV command returns its response, in our
+	// test cluster. Whenever we see an Export or Import responses, we do a
+	// blocking read on the allowResponse channel to give the test a chance to
+	// assert the progress of the job.
+	var allowResponse chan struct{}
+	params := base.TestClusterArgs{}
+	params.ServerArgs.Knobs.Store = &storage.StoreTestingKnobs{
+		TestingResponseFilter: func(ba roachpb.BatchRequest, br *roachpb.BatchResponse) *roachpb.Error {
+			hasExportOrImport := false
+			for _, res := range br.Responses {
+				if hasExportOrImport = res.Export != nil || res.Import != nil; hasExportOrImport {
+					break
+				}
+			}
+			if !hasExportOrImport {
+				return nil
+			}
+			<-allowResponse
+			return nil
+		},
+	}
+
+	const numAccounts = 1000
+
+	_, dir, _, sqlDB, cleanupFn := backupRestoreTestSetupWithParams(t, multiNode, numAccounts, params)
+	defer cleanupFn()
 
 	dest := dir + "?secretCredentialsHere"
 	sanitizedDest := dir
 
-	sqlDB := sqlutils.MakeSQLRunner(t, db)
-	sqlDB.Exec(bankCreateDatabase)
-	sqlDB.Exec(bankCreateTable)
+	jobDone := make(chan error)
+
 	{
-		sqlDB.Exec(`BACKUP DATABASE bench TO $1`, dest)
-		tableID, err := sqlutils.QueryTableID(db, "bench", "bank")
+		allowResponse = make(chan struct{})
+		go func() {
+			_, err := sqlDB.DB.Exec(`BACKUP DATABASE bench TO $1`, dest)
+			jobDone <- err
+		}()
+
+		if err := verifySystemJobProgress(
+			sqlDB, allowResponse, expectedProgressUpdateCount,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := <-jobDone; err != nil {
+			t.Fatal(err)
+		}
+
+		tableID, err := sqlutils.QueryTableID(sqlDB.DB, "bench", "bank")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -308,10 +388,27 @@ func TestBackupRestoreSystemJobs(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	sqlDB.Exec(`CREATE DATABASE bench2`)
+
 	{
-		sqlDB.Exec(`RESTORE bench.* FROM $1 WITH OPTIONS ('into_db'='bench2')`, dest)
-		databaseID, err := sqlutils.QueryDatabaseID(db, "bench2")
+		sqlDB.Exec(`CREATE DATABASE bench2`)
+
+		allowResponse = make(chan struct{})
+		go func() {
+			_, err := sqlDB.DB.Exec(`RESTORE bench.* FROM $1 WITH OPTIONS ('into_db'='bench2')`, dest)
+			jobDone <- err
+		}()
+
+		if err := verifySystemJobProgress(
+			sqlDB, allowResponse, expectedProgressUpdateCount,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := <-jobDone; err != nil {
+			t.Fatal(err)
+		}
+
+		databaseID, err := sqlutils.QueryDatabaseID(sqlDB.DB, "bench2")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/ccl/sqlccl/progress.go
+++ b/pkg/ccl/sqlccl/progress.go
@@ -1,0 +1,60 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+
+package sqlccl
+
+import (
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// For both backups and restores, we compute progress as the number of completed
+// export or import requests, respectively, divided by the total number of
+// requests. To avoid hammering the system.jobs table, when a response comes
+// back, we issue a progress update only if a) it's been a duration of
+// progressTimeThreshold since the last update, or b) the difference between the
+// last logged fractionCompleted and the current fractionCompleted is more than
+// progressFractionThreshold.
+const (
+	progressTimeThreshold     = time.Second
+	progressFractionThreshold = 0.05
+)
+
+type jobProgressLogger struct {
+	// These fields must be externally initialized.
+	jobLogger   *sql.JobLogger
+	totalChunks int
+
+	// The remaining fields are for internal use only.
+	mu struct {
+		syncutil.Mutex
+		completedChunks      int
+		lastReportedAt       time.Time
+		lastReportedFraction float32
+	}
+}
+
+func (jpl *jobProgressLogger) chunkFinished(ctx context.Context) error {
+	jpl.mu.Lock()
+	defer jpl.mu.Unlock()
+	jpl.mu.completedChunks++
+	fraction := float32(jpl.mu.completedChunks) / float32(jpl.totalChunks)
+	shouldLogProgress := fraction-jpl.mu.lastReportedFraction > progressFractionThreshold ||
+		jpl.mu.lastReportedAt.Add(progressTimeThreshold).Before(timeutil.Now())
+	if shouldLogProgress {
+		// NOTE: We intentionally hold the lock while updating system.jobs to ensure
+		// progress updates are written in order.
+		return jpl.jobLogger.Progressed(ctx, fraction)
+	}
+	return nil
+}

--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -720,8 +720,10 @@ func restorePlanHook(
 			return nil, err
 		}
 		if err := jobLogger.Succeeded(ctx); err != nil {
-			log.Errorf(ctx, "RESTORE ignoring error while marking job '%s' as successful: %+v",
-				description, err)
+			// An error while marking the job as successful is not important enough to
+			// merit failing the entire restore.
+			log.Errorf(ctx, "RESTORE ignoring error while marking job %d (%s) as successful: %+v",
+				jobLogger.JobID(), description, err)
 		}
 		return nil, nil
 	}

--- a/pkg/sql/jobs.go
+++ b/pkg/sql/jobs.go
@@ -77,6 +77,12 @@ func NewJobLogger(db *client.DB, leaseMgr *LeaseManager, job JobRecord) JobLogge
 	}
 }
 
+// JobID returns the ID of the job that this JobLogger is currently tracking.
+// This will be nil if Created has not yet been called.
+func (jl *JobLogger) JobID() *int64 {
+	return jl.jobID
+}
+
 // Created records the creation of a new job in the system.jobs table and
 // remembers the assigned ID of the job in the JobLogger. The job information is
 // read from the Job field at the time Created is called.

--- a/pkg/sql/jobs_test.go
+++ b/pkg/sql/jobs_test.go
@@ -17,12 +17,12 @@
 package sql_test
 
 import (
-	"errors"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -39,18 +39,18 @@ import (
 // jobExpectation defines the information necessary to determine the validity of
 // a job in the system.jobs table.
 type jobExpectation struct {
-	Offset int
-	Job    sql.JobRecord
-	Type   string
-	Before time.Time
-	Error  string
+	Job               sql.JobRecord
+	Type              string
+	Before            time.Time
+	FractionCompleted float32
+	Error             string
 }
 
 // verifyJobRecord verifies that the jobExpectation matches the job record
 // stored in the system.jobs table.
 func verifyJobRecord(
-	t *testing.T, db *sqlutils.SQLRunner, expectedStatus sql.JobStatus, expected jobExpectation,
-) {
+	db *sqlutils.SQLRunner, expectedStatus sql.JobStatus, expected jobExpectation,
+) error {
 	var actualJob sql.JobRecord
 	var typ string
 	var rawDescriptorIDs pq.Int64Array
@@ -59,18 +59,19 @@ func verifyJobRecord(
 	var started pq.NullTime
 	var finished pq.NullTime
 	var modified pq.NullTime
+	var fractionCompleted float32
 	var err string
 	// We have to query for the nth job created rather than filtering by ID,
 	// because job-generating SQL queries (e.g. BACKUP) do not currently return
 	// the job ID.
 	db.QueryRow(`
 		SELECT type, description, username, descriptor_ids, status,
-			   created, started, finished, modified, error
-		FROM crdb_internal.jobs ORDER BY created LIMIT 1 OFFSET $1`,
-		expected.Offset,
+			   created, started, finished, modified, fraction_completed, error
+		FROM crdb_internal.jobs WHERE created >= $1 ORDER BY created LIMIT 1`,
+		expected.Before,
 	).Scan(
 		&typ, &actualJob.Description, &actualJob.Username, &rawDescriptorIDs, &statusString,
-		&created, &started, &finished, &modified, &err,
+		&created, &started, &finished, &modified, &fractionCompleted, &err,
 	)
 
 	// Verify the upstream-provided fields.
@@ -80,58 +81,59 @@ func verifyJobRecord(
 	}
 	if e, a := expected.Job, actualJob; !reflect.DeepEqual(e, a) {
 		diff := strings.Join(pretty.Diff(e, a), "\n")
-		t.Errorf("job %d: JobRecords do not match:\n%s", expected.Offset, diff)
+		return errors.Errorf("JobRecords do not match:\n%s", diff)
 	}
 
-	// Verify JobLogger-managed text fields.
+	// Verify JobLogger-managed fields.
 	status := sql.JobStatus(statusString)
 	if e, a := expectedStatus, status; e != a {
-		t.Errorf("job %d: expected status %v, got %v", expected.Offset, e, a)
-		return
+		return errors.Errorf("expected status %v, got %v", e, a)
 	}
 	if e, a := expected.Type, typ; e != a {
-		t.Errorf("job %d: expected type %v, got type %v", expected.Offset, e, a)
+		return errors.Errorf("expected type %v, got type %v", e, a)
+	}
+	if e, a := expected.FractionCompleted, fractionCompleted; e != a {
+		return errors.Errorf("expected fraction completed %f, got %f", e, a)
 	}
 
 	// Check JobLogger-managed timestamps for sanity.
-	verifyModifiedAgainst := func(name string, ts time.Time) {
+	verifyModifiedAgainst := func(name string, ts time.Time) error {
 		if modified.Time.Before(ts) {
-			t.Errorf("job %d: modified time %v before %s time %v", expected.Offset, modified, name, ts)
+			return errors.Errorf("modified time %v before %s time %v", modified, name, ts)
 		}
 		if now := timeutil.Now().Round(time.Microsecond); modified.Time.After(now) {
-			t.Errorf("job %d: modified time %v after current time %v", expected.Offset, modified, now)
+			return errors.Errorf("modified time %v after current time %v", modified, now)
 		}
+		return nil
 	}
 
 	if expected.Before.After(created.Time) {
-		t.Errorf(
-			"job %d: created time %v is before expected created time %v",
-			expected.Offset, created, expected.Before,
+		return errors.Errorf(
+			"created time %v is before expected created time %v",
+			created, expected.Before,
 		)
 	}
 	if status == sql.JobStatusPending {
-		verifyModifiedAgainst("created", created.Time)
-		return
+		return verifyModifiedAgainst("created", created.Time)
 	}
 
 	if !started.Valid && status == sql.JobStatusSucceeded {
-		t.Errorf("job %d: started time is NULL but job claims to be successful", expected.Offset)
+		return errors.Errorf("started time is NULL but job claims to be successful")
 	}
 	if started.Valid && created.Time.After(started.Time) {
-		t.Errorf("job %d: created time %v is after started time %v", expected.Offset, created, started)
+		return errors.Errorf("created time %v is after started time %v", created, started)
 	}
 	if status == sql.JobStatusRunning {
-		verifyModifiedAgainst("started", started.Time)
-		return
+		return verifyModifiedAgainst("started", started.Time)
 	}
 
 	if started.Time.After(finished.Time) {
-		t.Errorf("job %d: started time %v is after finished time %v", expected.Offset, started, finished)
+		return errors.Errorf("started time %v is after finished time %v", started, finished)
 	}
-	verifyModifiedAgainst("finished", finished.Time)
 	if e, a := expected.Error, err; e != a {
-		t.Errorf("job %d: expected error %v, got %v", expected.Offset, e, a)
+		return errors.Errorf("expected error %v, got %v", e, a)
 	}
+	return verifyModifiedAgainst("finished", finished.Time)
 }
 
 func TestJobLogger(t *testing.T) {
@@ -157,18 +159,39 @@ func TestJobLogger(t *testing.T) {
 			Before: timeutil.Now(),
 		}
 		woodyLogger := sql.NewJobLogger(kvDB, s.LeaseManager().(*sql.LeaseManager), woodyJob)
+
 		if err := woodyLogger.Created(ctx); err != nil {
 			t.Fatal(err)
 		}
-		verifyJobRecord(t, db, sql.JobStatusPending, woodyExpectation)
+		if err := verifyJobRecord(db, sql.JobStatusPending, woodyExpectation); err != nil {
+			t.Fatal(err)
+		}
+
 		if err := woodyLogger.Started(ctx); err != nil {
 			t.Fatal(err)
 		}
-		verifyJobRecord(t, db, sql.JobStatusRunning, woodyExpectation)
+		if err := verifyJobRecord(db, sql.JobStatusRunning, woodyExpectation); err != nil {
+			t.Fatal(err)
+		}
+
+		// This fraction completed progression is intentionally not strictly
+		// increasing to simulate imprecise progress estimates.
+		for _, f := range []float32{0.0, 0.5, 0.5, 0.4, 0.8, 1.0} {
+			if err := woodyLogger.Progressed(ctx, f); err != nil {
+				t.Fatal(err)
+			}
+			woodyExpectation.FractionCompleted = f
+			if err := verifyJobRecord(db, sql.JobStatusRunning, woodyExpectation); err != nil {
+				t.Fatal(err)
+			}
+		}
+
 		if err := woodyLogger.Succeeded(ctx); err != nil {
 			t.Fatal(err)
 		}
-		verifyJobRecord(t, db, sql.JobStatusSucceeded, woodyExpectation)
+		if err := verifyJobRecord(db, sql.JobStatusSucceeded, woodyExpectation); err != nil {
+			t.Fatal(err)
+		}
 
 		// Buzz fails after it starts running.
 		buzzJob := sql.JobRecord{
@@ -177,27 +200,46 @@ func TestJobLogger(t *testing.T) {
 			DescriptorIDs: []sqlbase.ID{3, 2, 1},
 		}
 		buzzExpectation := jobExpectation{
-			Offset: 1,
 			Job:    buzzJob,
 			Type:   sql.JobTypeRestore,
 			Before: timeutil.Now(),
 			Error:  "Buzz Lightyear can't fly",
 		}
 		buzzLogger := sql.NewJobLogger(kvDB, s.LeaseManager().(*sql.LeaseManager), buzzJob)
+
 		// Test modifying the job details before calling `Created`.
 		buzzLogger.Job.Details = sql.RestoreJobDetails{}
 		if err := buzzLogger.Created(ctx); err != nil {
 			t.Fatal(err)
 		}
-		verifyJobRecord(t, db, sql.JobStatusPending, buzzExpectation)
+		if err := verifyJobRecord(db, sql.JobStatusPending, buzzExpectation); err != nil {
+			t.Fatal(err)
+		}
+
 		if err := buzzLogger.Started(ctx); err != nil {
 			t.Fatal(err)
 		}
-		verifyJobRecord(t, db, sql.JobStatusRunning, buzzExpectation)
+		if err := verifyJobRecord(db, sql.JobStatusRunning, buzzExpectation); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := buzzLogger.Progressed(ctx, .42); err != nil {
+			t.Fatal(err)
+		}
+		buzzExpectation.FractionCompleted = .42
+		if err := verifyJobRecord(db, sql.JobStatusRunning, buzzExpectation); err != nil {
+			t.Fatal(err)
+		}
+
 		buzzLogger.Failed(ctx, errors.New("Buzz Lightyear can't fly"))
-		verifyJobRecord(t, db, sql.JobStatusFailed, buzzExpectation)
+		if err := verifyJobRecord(db, sql.JobStatusFailed, buzzExpectation); err != nil {
+			t.Fatal(err)
+		}
+
 		// Ensure that logging Buzz didn't corrupt Woody.
-		verifyJobRecord(t, db, sql.JobStatusSucceeded, woodyExpectation)
+		if err := verifyJobRecord(db, sql.JobStatusSucceeded, woodyExpectation); err != nil {
+			t.Fatal(err)
+		}
 
 		// Sid fails before it starts running.
 		sidJob := sql.JobRecord{
@@ -207,22 +249,32 @@ func TestJobLogger(t *testing.T) {
 			Details:       sql.RestoreJobDetails{},
 		}
 		sidExpectation := jobExpectation{
-			Offset: 2,
 			Job:    sidJob,
 			Type:   sql.JobTypeRestore,
 			Before: timeutil.Now(),
 			Error:  "Sid is a total failure",
 		}
 		sidLogger := sql.NewJobLogger(kvDB, s.LeaseManager().(*sql.LeaseManager), sidJob)
+
 		if err := sidLogger.Created(ctx); err != nil {
 			t.Fatal(err)
 		}
-		verifyJobRecord(t, db, sql.JobStatusPending, sidExpectation)
+		if err := verifyJobRecord(db, sql.JobStatusPending, sidExpectation); err != nil {
+			t.Fatal(err)
+		}
+
 		sidLogger.Failed(ctx, errors.New("Sid is a total failure"))
-		verifyJobRecord(t, db, sql.JobStatusFailed, sidExpectation)
+		if err := verifyJobRecord(db, sql.JobStatusFailed, sidExpectation); err != nil {
+			t.Fatal(err)
+		}
+
 		// Ensure that logging Sid didn't corrupt Woody or Buzz.
-		verifyJobRecord(t, db, sql.JobStatusSucceeded, woodyExpectation)
-		verifyJobRecord(t, db, sql.JobStatusFailed, buzzExpectation)
+		if err := verifyJobRecord(db, sql.JobStatusSucceeded, woodyExpectation); err != nil {
+			t.Fatal(err)
+		}
+		if err := verifyJobRecord(db, sql.JobStatusFailed, buzzExpectation); err != nil {
+			t.Fatal(err)
+		}
 	})
 
 	t.Run("bad job details fail", func(t *testing.T) {
@@ -241,7 +293,7 @@ func TestJobLogger(t *testing.T) {
 		}
 	})
 
-	t.Run("same status twice fails", func(t *testing.T) {
+	t.Run("same state transition twice fails", func(t *testing.T) {
 		logger := sql.NewJobLogger(kvDB, s.LeaseManager().(*sql.LeaseManager), sql.JobRecord{
 			Details: sql.BackupJobDetails{},
 		})
@@ -262,6 +314,81 @@ func TestJobLogger(t *testing.T) {
 		}
 		if err := logger.Succeeded(ctx); !testutils.IsError(err, `job \d+ already finished`) {
 			t.Fatalf("expected 'job already finished' error, but got %v", err)
+		}
+	})
+
+	t.Run("out of bounds progress fails", func(t *testing.T) {
+		logger := sql.NewJobLogger(kvDB, s.LeaseManager().(*sql.LeaseManager), sql.JobRecord{
+			Details: sql.BackupJobDetails{},
+		})
+		if err := logger.Created(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if err := logger.Started(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if err := logger.Progressed(ctx, -0.1); !testutils.IsError(err, "outside allowable range") {
+			t.Fatalf("expected 'outside allowable range' error, but got %v", err)
+		}
+		if err := logger.Progressed(ctx, 1.1); !testutils.IsError(err, "outside allowable range") {
+			t.Fatalf("expected 'outside allowable range' error, but got %v", err)
+		}
+	})
+
+	t.Run("progress on non-started job fails", func(t *testing.T) {
+		logger := sql.NewJobLogger(kvDB, s.LeaseManager().(*sql.LeaseManager), sql.JobRecord{
+			Details: sql.BackupJobDetails{},
+		})
+		if err := logger.Created(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if err := logger.Progressed(ctx, 0.5); !testutils.IsError(err, `job \d+ not started`) {
+			t.Fatalf("expected 'job not started' error, but got %v", err)
+		}
+	})
+
+	t.Run("progress on finished job fails", func(t *testing.T) {
+		logger := sql.NewJobLogger(kvDB, s.LeaseManager().(*sql.LeaseManager), sql.JobRecord{
+			Details: sql.BackupJobDetails{},
+		})
+		if err := logger.Created(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if err := logger.Started(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if err := logger.Succeeded(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if err := logger.Progressed(ctx, 0.5); !testutils.IsError(err, `job \d+ already finished`) {
+			t.Fatalf("expected 'job already finished' error, but got %v", err)
+		}
+	})
+
+	t.Run("succeeded forces fraction completed to 1.0", func(t *testing.T) {
+		db := sqlutils.MakeSQLRunner(t, rawSQLDB)
+		job := sql.JobRecord{Details: sql.BackupJobDetails{}}
+		expectation := jobExpectation{
+			Job:               job,
+			Type:              sql.JobTypeBackup,
+			Before:            timeutil.Now(),
+			FractionCompleted: 1.0,
+		}
+		logger := sql.NewJobLogger(kvDB, s.LeaseManager().(*sql.LeaseManager), job)
+		if err := logger.Created(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if err := logger.Started(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if err := logger.Progressed(ctx, 0.2); err != nil {
+			t.Fatal(err)
+		}
+		if err := logger.Succeeded(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if err := verifyJobRecord(db, sql.JobStatusSucceeded, expectation); err != nil {
+			t.Fatal(err)
 		}
 	})
 }


### PR DESCRIPTION
See commit messages for details. @danhhz, I wanted to get your approval on the `ErrGroupWithProgress` before I wrote tests for it, but this PR already sports tests for `JobLogger.Progressed()` and backup/restore incremental progress as a whole.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14459)
<!-- Reviewable:end -->
