### PR TITLE
sql: fix panic during prepared UPDATEs

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -454,6 +454,7 @@ func (e *Executor) Prepare(
 	if err := txn.SetIsolation(session.DefaultIsolationLevel); err != nil {
 		panic(err)
 	}
+	txn.Proto().OrigTimestamp = e.cfg.Clock.Now()
 
 	planner := session.newPlanner(e, txn)
 	planner.semaCtx.Placeholders.SetTypes(pinfo)

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -1014,6 +1015,40 @@ func TestPGPreparedExec(t *testing.T) {
 				),
 			},
 		},
+		// Test for #14473: assert that looking up a table lease for a foreign key
+		// during a prepared update doesn't kill the server. This test requires
+		// the AlwaysAcquireNewLease testing knob be set to true below.
+		{
+			"CREATE TABLE d.t (i INT primary key)",
+			[]preparedExecTest{
+				baseTest,
+			},
+		},
+		{
+			"CREATE TABLE d.u (i INT REFERENCES d.t(i))",
+			[]preparedExecTest{
+				baseTest,
+			},
+		},
+		{
+			"INSERT INTO d.t VALUES($1)",
+			[]preparedExecTest{
+				baseTest.RowsAffected(1).SetArgs(1),
+				baseTest.RowsAffected(1).SetArgs(2),
+			},
+		},
+		{
+			"INSERT INTO d.u VALUES($1)",
+			[]preparedExecTest{
+				baseTest.RowsAffected(1).SetArgs(1),
+			},
+		},
+		{
+			"UPDATE d.u SET i = $1 WHERE i = $2",
+			[]preparedExecTest{
+				baseTest.RowsAffected(1).SetArgs(2, 1),
+			},
+		},
 		{
 			"DROP DATABASE d",
 			[]preparedExecTest{
@@ -1044,7 +1079,17 @@ func TestPGPreparedExec(t *testing.T) {
 		},
 	}
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	// Ensure that leases are always acquired fresh to test that table lease
+	// acquiration works properly during PREPARE.
+	testingKnobs := base.TestingKnobs{
+		SQLLeaseManager: &sql.LeaseManagerTestingKnobs{
+			LeaseStoreTestingKnobs: sql.LeaseStoreTestingKnobs{
+				AlwaysAcquireNewLease: true,
+			},
+		},
+	}
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{Knobs: testingKnobs})
+
 	defer s.Stopper().Stop()
 
 	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), "TestPGPreparedExec", url.User(security.RootUser))


### PR DESCRIPTION
Previously, preparing an `UPDATE` on a table with a foreign key that
referenced a table whose table lease happened to not be cached would
panic the server. The root cause of the panic was a missing
OrigTimestamp on the transaction that's passed into the planner.

This panic is now fixed, by manually setting the OrigTimestamp on the
new transaction used in prepare. A test that failed before the fix is
added, along with a new testing knob that makes sure the lease store
always acquires a new lease and doesn't use a cached one.

cc @arjunravinarayan

Fixes #14473.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14481)
<!-- Reviewable:end -->
