### PR TITLE
sql: disable fast path for some upsert queries

### DIFF
--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -199,6 +199,7 @@ func (p *planner) Insert(
 				updateCols:    updateCols,
 				conflictIndex: *conflictIndex,
 				evaler:        helper,
+				isUpsertAlias: n.OnConflict.IsUpsertAlias(),
 			}
 		}
 	}

--- a/pkg/sql/testdata/logic_test/upsert
+++ b/pkg/sql/testdata/logic_test/upsert
@@ -197,3 +197,51 @@ INSERT INTO issue_14052 (a, b) VALUES (1, 1), (2, 2)
 
 statement ok
 UPSERT INTO issue_14052 (a, c) (SELECT a, b from issue_14052)
+
+statement ok
+CREATE TABLE issue_14052_2 (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(255),
+  createdAt INT,
+  updatedAt INT
+)
+
+statement ok
+INSERT INTO issue_14052_2 (id, name, createdAt, updatedAt) VALUES
+  (1, 'original', 1, 1)
+
+# Make sure the fast path isn't taken (createdAt is not in the ON CONFLICT clause)
+statement ok
+INSERT INTO issue_14052_2 (id, name, createdAt, updatedAt) VALUES
+  (1, 'UPDATED', 2, 2)
+ON CONFLICT (id) DO UPDATE
+  SET id = excluded.id, name = excluded.name, updatedAt = excluded.updatedAt
+
+query ITII
+SELECT * FROM issue_14052_2;
+----
+1  UPDATED  1  2
+
+# Make sure the fast path isn't taken (repeating a column in the ON CONFLICT clause doesn't do anything)
+statement ok
+INSERT INTO issue_14052_2 (id, name, createdAt, updatedAt) VALUES
+  (1, 'FOO', 3, 3)
+ON CONFLICT (id) DO UPDATE
+  SET id = excluded.id, name = excluded.name, name = excluded.name, name = excluded.name
+
+query ITII
+SELECT * FROM issue_14052_2;
+----
+1  FOO  1  2
+
+# Make sure the fast path isn't taken (all clauses in the set must be of the form x = excluded.x)
+statement ok
+INSERT INTO issue_14052_2 (id, name, createdAt, updatedAt) VALUES
+  (1, 'BAR', 4, 5)
+ON CONFLICT (id) DO UPDATE
+  SET name = excluded.name, createdAt = excluded.updatedAt, updatedAt = excluded.updatedAt
+
+query ITII
+SELECT * FROM issue_14052_2;
+----
+1  BAR  5  5

--- a/pkg/sql/upsert_test.go
+++ b/pkg/sql/upsert_test.go
@@ -74,12 +74,12 @@ func TestUpsertFastPath(t *testing.T) {
 		t.Errorf("expected no begin-txn (1PC) but got %d", s)
 	}
 
-	// This should hit the fast path.
+	// This could hit the fast path, but doesn't right now because of #14482.
 	atomic.StoreUint64(&scans, 0)
 	atomic.StoreUint64(&beginTxn, 0)
 	sqlDB.Exec(`INSERT INTO d.kv VALUES (1, 1) ON CONFLICT (k) DO UPDATE SET v=excluded.v`)
-	if s := atomic.LoadUint64(&scans); s != 0 {
-		t.Errorf("expected no scans (the upsert fast path) but got %d", s)
+	if s := atomic.LoadUint64(&scans); s != 1 {
+		t.Errorf("expected 1 scans (no upsert fast path) but got %d", s)
 	}
 	if s := atomic.LoadUint64(&beginTxn); s != 0 {
 		t.Errorf("expected no begin-txn (1PC) but got %d", s)


### PR DESCRIPTION
`INSERT .. ON CONFLICT ..` is temporarily no longer eligible for fast path.

The fast path is currently only enabled when the UPSERT alias is
explicitly selected by the user. It's possible to fast path some queries
of the form INSERT ... ON CONFLICT, but the utility is low and there are
lots of edge cases (that caused real correctness bugs #13437 #13962). As
a result, we've decided to remove this until after 1.0 and re-enable it
then. See #14482.

Closes #13962.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14485)
<!-- Reviewable:end -->
