### PR TITLE
*: don't include c-* imports on windows

### DIFF
--- a/pkg/ccl/storageccl/engineccl/db.cc
+++ b/pkg/ccl/storageccl/engineccl/db.cc
@@ -16,7 +16,7 @@
 
 extern "C" {
 #include "_cgo_export.h"
-}
+}  // extern "C"
 
 const DBStatus kSuccess = { NULL, 0 };
 

--- a/pkg/ccl/storageccl/engineccl/rocksdb.go
+++ b/pkg/ccl/storageccl/engineccl/rocksdb.go
@@ -20,8 +20,6 @@ import (
 // #cgo CPPFLAGS: -I../../../../vendor/github.com/cockroachdb/c-protobuf/internal/src
 // #cgo CPPFLAGS: -I../../../../vendor/github.com/cockroachdb/c-rocksdb/internal/include
 // #cgo CXXFLAGS: -std=c++11 -Werror -Wall -Wno-sign-compare
-// #cgo darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
-// #cgo !darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all
 // #cgo linux LDFLAGS: -lrt
 //
 // #include <stdlib.h>

--- a/pkg/ccl/storageccl/engineccl/rocksdb.go
+++ b/pkg/ccl/storageccl/engineccl/rocksdb.go
@@ -20,8 +20,8 @@ import (
 // #cgo CPPFLAGS: -I../../../../vendor/github.com/cockroachdb/c-protobuf/internal/src
 // #cgo CPPFLAGS: -I../../../../vendor/github.com/cockroachdb/c-rocksdb/internal/include
 // #cgo CXXFLAGS: -std=c++11 -Werror -Wall -Wno-sign-compare
-// #cgo !strictld,darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
-// #cgo !strictld,!darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all
+// #cgo darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
+// #cgo !darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all
 // #cgo linux LDFLAGS: -lrt
 //
 // #include <stdlib.h>

--- a/pkg/ccl/storageccl/engineccl/rocksdb_unix.go
+++ b/pkg/ccl/storageccl/engineccl/rocksdb_unix.go
@@ -1,0 +1,20 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+
+// +build !windows
+
+package engineccl
+
+import (
+	// This is explicit because these Go libraries do not export any Go symbols.
+	_ "github.com/cockroachdb/c-rocksdb"
+)
+
+// #cgo darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
+// #cgo !darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all
+import "C"

--- a/pkg/cli/jemalloc_unix.go
+++ b/pkg/cli/jemalloc_unix.go
@@ -12,15 +12,15 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// +build !windows
+// +build !stdmalloc,!windows
 
-package log
+package cli
 
 import (
-	"syscall"
+	// This is explicit because this Go library does not export any Go symbols.
+	_ "github.com/cockroachdb/c-jemalloc"
 )
 
-func dupFD(fd uintptr) (uintptr, error) {
-	nfd, err := syscall.Dup(int(fd))
-	return uintptr(nfd), err
-}
+// #cgo darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
+// #cgo !darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all
+import "C"

--- a/pkg/cli/start_jemalloc.go
+++ b/pkg/cli/start_jemalloc.go
@@ -22,8 +22,6 @@ package cli
 // #cgo darwin CPPFLAGS: -I../../vendor/github.com/cockroachdb/c-jemalloc/darwin_includes/internal/include
 // #cgo freebsd CPPFLAGS: -I../../vendor/github.com/cockroachdb/c-jemalloc/freebsd_includes/internal/include
 // #cgo linux CPPFLAGS: -I../../vendor/github.com/cockroachdb/c-jemalloc/linux_includes/internal/include
-// #cgo darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
-// #cgo !darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all
 //
 // #include <jemalloc/jemalloc.h>
 // #include <stddef.h>
@@ -59,9 +57,6 @@ import "C"
 import (
 	"fmt"
 	"unsafe"
-
-	// This is explicit because this Go library does not export any Go symbols.
-	_ "github.com/cockroachdb/c-jemalloc"
 )
 
 func init() {

--- a/pkg/cli/start_jemalloc.go
+++ b/pkg/cli/start_jemalloc.go
@@ -22,8 +22,8 @@ package cli
 // #cgo darwin CPPFLAGS: -I../../vendor/github.com/cockroachdb/c-jemalloc/darwin_includes/internal/include
 // #cgo freebsd CPPFLAGS: -I../../vendor/github.com/cockroachdb/c-jemalloc/freebsd_includes/internal/include
 // #cgo linux CPPFLAGS: -I../../vendor/github.com/cockroachdb/c-jemalloc/linux_includes/internal/include
-// #cgo !strictld,darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
-// #cgo !strictld,!darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all
+// #cgo darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
+// #cgo !darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all
 //
 // #include <jemalloc/jemalloc.h>
 // #include <stddef.h>

--- a/pkg/server/config_unix.go
+++ b/pkg/server/config_unix.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-//+build !windows
+// +build !windows
 
 package server
 

--- a/pkg/server/status/jemalloc_unix.go
+++ b/pkg/server/status/jemalloc_unix.go
@@ -12,15 +12,15 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// +build !windows
+// +build !stdmalloc,!windows
 
-package log
+package status
 
 import (
-	"syscall"
+	// This is explicit because this Go library does not export any Go symbols.
+	_ "github.com/cockroachdb/c-jemalloc"
 )
 
-func dupFD(fd uintptr) (uintptr, error) {
-	nfd, err := syscall.Dup(int(fd))
-	return uintptr(nfd), err
-}
+// #cgo darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
+// #cgo !darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all
+import "C"

--- a/pkg/server/status/runtime_jemalloc.go
+++ b/pkg/server/status/runtime_jemalloc.go
@@ -22,8 +22,8 @@ package status
 // #cgo darwin CPPFLAGS: -I../../../vendor/github.com/cockroachdb/c-jemalloc/darwin_includes/internal/include
 // #cgo freebsd CPPFLAGS: -I../../../vendor/github.com/cockroachdb/c-jemalloc/freebsd_includes/internal/include
 // #cgo linux CPPFLAGS: -I../../../vendor/github.com/cockroachdb/c-jemalloc/linux_includes/internal/include
-// #cgo !strictld,darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
-// #cgo !strictld,!darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all
+// #cgo darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
+// #cgo !darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all
 //
 // #include <jemalloc/jemalloc.h>
 //

--- a/pkg/server/status/runtime_jemalloc.go
+++ b/pkg/server/status/runtime_jemalloc.go
@@ -22,8 +22,6 @@ package status
 // #cgo darwin CPPFLAGS: -I../../../vendor/github.com/cockroachdb/c-jemalloc/darwin_includes/internal/include
 // #cgo freebsd CPPFLAGS: -I../../../vendor/github.com/cockroachdb/c-jemalloc/freebsd_includes/internal/include
 // #cgo linux CPPFLAGS: -I../../../vendor/github.com/cockroachdb/c-jemalloc/linux_includes/internal/include
-// #cgo darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
-// #cgo !darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all
 //
 // #include <jemalloc/jemalloc.h>
 //
@@ -87,9 +85,6 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"golang.org/x/net/context"
-
-	// This is explicit because this Go library does not export any Go symbols.
-	_ "github.com/cockroachdb/c-jemalloc"
 
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )

--- a/pkg/storage/engine/db.cc
+++ b/pkg/storage/engine/db.cc
@@ -39,6 +39,7 @@
 
 extern "C" {
 #include "_cgo_export.h"
+}  // extern "C"
 
 struct DBCache {
   std::shared_ptr<rocksdb::Cache> rep;
@@ -174,8 +175,6 @@ struct DBSnapshot : public DBEngine {
 struct DBIterator {
   std::unique_ptr<rocksdb::Iterator> rep;
 };
-
-}  // extern "C"
 
 // NOTE: these constants must be kept in sync with the values in
 // storage/engine/keys.go. Both kKeyLocalRangeIDPrefix and

--- a/pkg/storage/engine/rocksdb_unix.go
+++ b/pkg/storage/engine/rocksdb_unix.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-//+build !windows
+// +build !windows
 
 package engine
 

--- a/pkg/storage/engine/rocksdb_unix.go
+++ b/pkg/storage/engine/rocksdb_unix.go
@@ -22,6 +22,6 @@ import (
 	_ "github.com/cockroachdb/c-rocksdb"
 )
 
-// #cgo !strictld,darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
-// #cgo !strictld,!darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all
+// #cgo darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
+// #cgo !darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all
 import "C"

--- a/pkg/util/log/stderr_redirect_not_linux_unix.go
+++ b/pkg/util/log/stderr_redirect_not_linux_unix.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-//+build !linux,!windows
+// +build !linux,!windows
 
 package log
 


### PR DESCRIPTION
Extracted from #14466.

@BramGruneir just tripped on the `stdmalloc` thing on Windows, so seems worthwhile to get this in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14487)
<!-- Reviewable:end -->
