### PR TITLE
storage/engine: add a longer timeout for TestConcurrentBatch on Windows

### DIFF
--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -23,6 +23,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"testing"
@@ -349,6 +350,13 @@ func TestConcurrentBatch(t *testing.T) {
 		t.Skip()
 	}
 
+	maxTime := 10 * time.Second
+	// TODO(bram): #14486 This tests takes a very long time to complete on
+	// windows.
+	if runtime.GOOS == "windows" {
+		maxTime = 30 * time.Second
+	}
+
 	dir, err := ioutil.TempDir("", t.Name())
 	if err != nil {
 		t.Fatal(err)
@@ -412,7 +420,7 @@ func TestConcurrentBatch(t *testing.T) {
 		if err := db.Put(MakeMVCCMetadataKey(key), nil); err != nil {
 			t.Fatal(err)
 		}
-		if elapsed := timeutil.Since(start); elapsed >= 10*time.Second {
+		if elapsed := timeutil.Since(start); elapsed >= maxTime {
 			t.Fatalf("write took %0.1fs\n", elapsed.Seconds())
 		}
 	}


### PR DESCRIPTION
See #14486

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14488)
<!-- Reviewable:end -->
