### PR TITLE
storage: switch from a per-Replica to per-Store TimestampCache

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -1071,10 +1071,10 @@ func TestReplicaTSCacheLowWaterOnLease(t *testing.T) {
 			t.Fatalf("%d: unexpected error %v", i, err)
 		}
 		// Verify expected low water mark.
-		tc.repl.tsCacheMu.Lock()
-		rTS, _, _ := tc.repl.tsCacheMu.cache.GetMaxRead(roachpb.Key("a"), nil)
-		wTS, _, _ := tc.repl.tsCacheMu.cache.GetMaxWrite(roachpb.Key("a"), nil)
-		tc.repl.tsCacheMu.Unlock()
+		tc.repl.store.tsCacheMu.Lock()
+		rTS, _, _ := tc.repl.store.tsCacheMu.cache.GetMaxRead(roachpb.Key("a"), nil)
+		wTS, _, _ := tc.repl.store.tsCacheMu.cache.GetMaxWrite(roachpb.Key("a"), nil)
+		tc.repl.store.tsCacheMu.Unlock()
 
 		if test.expLowWater == 0 {
 			continue
@@ -1861,28 +1861,28 @@ func TestReplicaUpdateTSCache(t *testing.T) {
 		t.Error(pErr)
 	}
 	// Verify the timestamp cache has rTS=1s and wTS=0s for "a".
-	tc.repl.tsCacheMu.Lock()
-	defer tc.repl.tsCacheMu.Unlock()
-	_, _, rOK := tc.repl.tsCacheMu.cache.GetMaxRead(roachpb.Key("a"), nil)
-	_, _, wOK := tc.repl.tsCacheMu.cache.GetMaxWrite(roachpb.Key("a"), nil)
+	tc.repl.store.tsCacheMu.Lock()
+	defer tc.repl.store.tsCacheMu.Unlock()
+	_, _, rOK := tc.repl.store.tsCacheMu.cache.GetMaxRead(roachpb.Key("a"), nil)
+	_, _, wOK := tc.repl.store.tsCacheMu.cache.GetMaxWrite(roachpb.Key("a"), nil)
 	if rOK || wOK {
 		t.Errorf("expected rOK=false and wOK=false; rOK=%t, wOK=%t", rOK, wOK)
 	}
-	tc.repl.tsCacheMu.cache.ExpandRequests(hlc.Timestamp{})
-	rTS, _, rOK := tc.repl.tsCacheMu.cache.GetMaxRead(roachpb.Key("a"), nil)
-	wTS, _, wOK := tc.repl.tsCacheMu.cache.GetMaxWrite(roachpb.Key("a"), nil)
+	tc.repl.store.tsCacheMu.cache.ExpandRequests(hlc.Timestamp{})
+	rTS, _, rOK := tc.repl.store.tsCacheMu.cache.GetMaxRead(roachpb.Key("a"), nil)
+	wTS, _, wOK := tc.repl.store.tsCacheMu.cache.GetMaxWrite(roachpb.Key("a"), nil)
 	if rTS.WallTime != t0.Nanoseconds() || wTS.WallTime != startNanos || !rOK || wOK {
 		t.Errorf("expected rTS=1s and wTS=0s, but got %s, %s; rOK=%t, wOK=%t", rTS, wTS, rOK, wOK)
 	}
 	// Verify the timestamp cache has rTS=0s and wTS=2s for "b".
-	rTS, _, rOK = tc.repl.tsCacheMu.cache.GetMaxRead(roachpb.Key("b"), nil)
-	wTS, _, wOK = tc.repl.tsCacheMu.cache.GetMaxWrite(roachpb.Key("b"), nil)
+	rTS, _, rOK = tc.repl.store.tsCacheMu.cache.GetMaxRead(roachpb.Key("b"), nil)
+	wTS, _, wOK = tc.repl.store.tsCacheMu.cache.GetMaxWrite(roachpb.Key("b"), nil)
 	if rTS.WallTime != startNanos || wTS.WallTime != t1.Nanoseconds() || rOK || !wOK {
 		t.Errorf("expected rTS=0s and wTS=2s, but got %s, %s; rOK=%t, wOK=%t", rTS, wTS, rOK, wOK)
 	}
 	// Verify another key ("c") has 0sec in timestamp cache.
-	rTS, _, rOK = tc.repl.tsCacheMu.cache.GetMaxRead(roachpb.Key("c"), nil)
-	wTS, _, wOK = tc.repl.tsCacheMu.cache.GetMaxWrite(roachpb.Key("c"), nil)
+	rTS, _, rOK = tc.repl.store.tsCacheMu.cache.GetMaxRead(roachpb.Key("c"), nil)
+	wTS, _, wOK = tc.repl.store.tsCacheMu.cache.GetMaxWrite(roachpb.Key("c"), nil)
 	if rTS.WallTime != startNanos || wTS.WallTime != startNanos || rOK || wOK {
 		t.Errorf("expected rTS=0s and wTS=0s, but got %s %s; rOK=%t, wOK=%t", rTS, wTS, rOK, wOK)
 	}

--- a/pkg/storage/timestamp_cache.go
+++ b/pkg/storage/timestamp_cache.go
@@ -20,12 +20,15 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/btree"
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/cache"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
-	"github.com/google/btree"
 )
 
 const (
@@ -36,7 +39,13 @@ const (
 	// timestamp.
 	MinTSCacheWindow = 10 * time.Second
 
-	defaultEvictionSizeThreshold = 512
+	// defaultEvictionSizeThreshold is the number of entries to allow in the
+	// per-Store timestamp cache. A cache entry is ~150-200 bytes with the bulk
+	// of that memory coming from the start and end keys.
+	//
+	// TODO(peter): We should accurately track the memory usage of the timestamp
+	// cache and change to using a cache sized by bytes.
+	defaultEvictionSizeThreshold = 1024 * 1024
 
 	// Max entries in each btree node.
 	// TODO(peter): Not yet tuned.
@@ -115,6 +124,21 @@ type timestampCache struct {
 	evictionSizeThreshold int
 }
 
+// lowWaterTxnIDMarker is a special txn ID that identifies a cache entry as a
+// low water mark. It is specified when a lease is acquired to clear the
+// timestamp cache for a range. Also see timestampCache.getMax where this txn
+// ID is checked in order to return whether the max read/write timestamp came
+// from a regular entry or one of these low water mark entries.
+var lowWaterTxnIDMarker = func() *uuid.UUID {
+	// The specific txn ID used here isn't important. We use something that is a)
+	// non-zero and b) obvious.
+	u, err := uuid.FromString("11111111-1111-1111-1111-111111111111")
+	if err != nil {
+		log.Fatal(context.Background(), err)
+	}
+	return &u
+}()
+
 // A cacheValue combines the timestamp with an optional txn ID.
 type cacheValue struct {
 	timestamp hlc.Timestamp
@@ -162,14 +186,6 @@ func (tc *timestampCache) Clear(lowWater hlc.Timestamp) {
 // TimestampCache.
 func (tc *timestampCache) len() int {
 	return tc.rCache.Len() + tc.wCache.Len() + tc.reqSpans
-}
-
-// SetLowWater sets the cache's low water mark, which is the minimum
-// value the cache will return from calls to GetMax().
-func (tc *timestampCache) SetLowWater(lowWater hlc.Timestamp) {
-	if tc.lowWater.Less(lowWater) {
-		tc.lowWater = lowWater
-	}
 }
 
 // add the specified timestamp to the cache as covering the range of
@@ -630,57 +646,10 @@ func (tc *timestampCache) getMax(
 			maxTxnID = nil
 		}
 	}
-	return maxTS, maxTxnID, ok
-}
-
-// MergeInto merges all entries from this timestamp cache into the
-// dest timestamp cache. The clear parameter, if true, copies the
-// values of lowWater and latest and clears the destination cache
-// before merging in the source.
-func (tc *timestampCache) MergeInto(dest *timestampCache, clear bool) {
-	if clear {
-		dest.Clear(tc.lowWater)
-		dest.latest = tc.latest
-		dest.reqIDAlloc = 0
-
-		// Because we just cleared the destination cache, we can directly
-		// insert entries from this cache.
-		hardMerge := func(srcCache, destCache *cache.IntervalCache) {
-			srcCache.Do(func(k, v interface{}) {
-				// Cache entries are mutable (see Add), so we give each cache its own
-				// unique copy.
-				entry := makeCacheEntry(*k.(*cache.IntervalKey), *v.(*cacheValue))
-				destCache.AddEntry(entry)
-			})
-		}
-		hardMerge(tc.rCache, dest.rCache)
-		hardMerge(tc.wCache, dest.wCache)
-	} else {
-		dest.lowWater.Forward(tc.lowWater)
-		dest.latest.Forward(tc.latest)
-
-		// The cache was not cleared before, so we can't just insert entries because
-		// intervals may need to be adjusted or removed to maintain the non-overlapping
-		// guarantee.
-		softMerge := func(srcCache *cache.IntervalCache, readTSCache bool) {
-			srcCache.Do(func(k, v interface{}) {
-				key, val := *k.(*cache.IntervalKey), *v.(*cacheValue)
-				dest.add(roachpb.Key(key.Start), roachpb.Key(key.End), val.timestamp, val.txnID, readTSCache)
-			})
-		}
-		softMerge(tc.rCache, true)
-		softMerge(tc.wCache, false)
+	if maxTxnID == lowWaterTxnIDMarker {
+		ok = false
 	}
-
-	// Copy the requests.
-	tc.requests.Ascend(func(i btree.Item) bool {
-		req := *(i.(*cacheRequest))
-		dest.reqIDAlloc++
-		req.uniqueID = dest.reqIDAlloc
-		dest.requests.ReplaceOrInsert(&req)
-		dest.reqSpans += req.numSpans()
-		return true
-	})
+	return maxTS, maxTxnID, ok
 }
 
 // shouldEvict returns true if the cache entry's timestamp is no

--- a/pkg/util/cache/cache.go
+++ b/pkg/util/cache/cache.go
@@ -553,11 +553,3 @@ func (ic *IntervalCache) doOverlaps(i interval.Interface) bool {
 	ic.overlaps = append(ic.overlaps, e)
 	return false
 }
-
-// Do invokes f on all of the entries in the cache.
-func (ic *IntervalCache) Do(f func(k, v interface{})) {
-	ic.tree.Do(func(e interval.Interface) (done bool) {
-		f(e.(*Entry).Key, e.(*Entry).Value)
-		return
-	})
-}


### PR DESCRIPTION
Replace the use of TimestampCache::SetLowWater when a lease is acquired
with the addition of a range covering span at the lease start time. We
actually add 4 spans: a read and a write span for both the local and
global replicated key ranges associated with a range.

Fixes #9423
Fixes #14264

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14489)
<!-- Reviewable:end -->
