### PR TITLE
security: Fix README about cert regeneration

### DIFF
--- a/pkg/security/securitytest/test_certs/README.md
+++ b/pkg/security/securitytest/test_certs/README.md
@@ -24,5 +24,5 @@ rm -f pkg/security/securitytest/test_certs/*.{crt,key}
 ./cockroach cert --ca-cert=pkg/security/securitytest/test_certs/ca.crt --ca-key=pkg/security/securitytest/test_certs/ca.key --cert=pkg/security/securitytest/test_certs/node.crt --key=pkg/security/securitytest/test_certs/node.key create-node 127.0.0.1 ::1 localhost *.local
 ./cockroach cert --ca-cert=pkg/security/securitytest/test_certs/ca.crt --ca-key=pkg/security/securitytest/test_certs/ca.key --cert=pkg/security/securitytest/test_certs/root.crt --key=pkg/security/securitytest/test_certs/root.key create-client root
 ./cockroach cert --ca-cert=pkg/security/securitytest/test_certs/ca.crt --ca-key=pkg/security/securitytest/test_certs/ca.key --cert=pkg/security/securitytest/test_certs/testuser.crt --key=pkg/security/securitytest/test_certs/testuser.key create-client testuser
-go generate security/securitytest/securitytest.go
+go generate ./pkg/security/securitytest
 ```


### PR DESCRIPTION
The README had a line for calling `go generate`, but pointed to the wrong
file. This change fixes that.

Discovered while investigating the issue solved by 86f3e73.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14490)
<!-- Reviewable:end -->
