### PR TITLE
sql: bytes type is named bytea in pg_type

### DIFF
--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1495,6 +1495,7 @@ var aliasedOidToName = map[oid.Oid]string{
 	oid.T_int8:       "int8",
 	oid.T_int2vector: "int2vector",
 	oid.T_text:       "text",
+	oid.T_bytea:      "bytea",
 	oid.T_varchar:    "varchar",
 	oid.T_numeric:    "numeric",
 	oid.T__int2:      "int2[]",

--- a/pkg/sql/testdata/logic_test/builtin_function
+++ b/pkg/sql/testdata/logic_test/builtin_function
@@ -1381,7 +1381,7 @@ int[]
 query T
 VALUES (format_type('anyelement'::regtype, -1)),
        (format_type('bool'::regtype, -1)),
-       (format_type('bytes'::regtype, -1)),
+       (format_type('bytea'::regtype, -1)),
        (format_type('date'::regtype, -1)),
        (format_type('numeric'::regtype, -1)),
        (format_type('interval'::regtype, -1)),

--- a/pkg/sql/testdata/logic_test/pg_catalog
+++ b/pkg/sql/testdata/logic_test/pg_catalog
@@ -649,7 +649,7 @@ ORDER BY oid
 ----
 oid   typname       typnamespace  typowner  typlen  typbyval  typtype
 16    bool          1782195457    NULL      1       true      b
-17    bytes         1782195457    NULL      -1      false     b
+17    bytea         1782195457    NULL      -1      false     b
 19    name          1782195457    NULL      -1      false     b
 20    int8          1782195457    NULL      8       true      b
 21    int2          1782195457    NULL      8       true      b
@@ -684,7 +684,7 @@ ORDER BY oid
 ----
 oid   typname       typcategory  typispreferred  typisdefined  typdelim  typrelid  typelem  typarray
 16    bool          B            false           true          ,         0         0        0
-17    bytes         U            false           true          ,         0         0        0
+17    bytea         U            false           true          ,         0         0        0
 19    name          S            false           true          ,         0         0        0
 20    int8          N            false           true          ,         0         0        0
 21    int2          N            false           true          ,         0         0        0
@@ -719,7 +719,7 @@ ORDER BY oid
 ----
 oid   typname       typinput  typoutput  typreceive  typsend  typmodin  typmodout  typanalyze
 16    bool          0         0          0           0        0         0          0
-17    bytes         0         0          0           0        0         0          0
+17    bytea         0         0          0           0        0         0          0
 19    name          0         0          0           0        0         0          0
 20    int8          0         0          0           0        0         0          0
 21    int2          0         0          0           0        0         0          0
@@ -754,7 +754,7 @@ ORDER BY oid
 ----
 oid   typname       typalign  typstorage  typnotnull  typbasetype  typtypmod
 16    bool          NULL      NULL        false       0            -1
-17    bytes         NULL      NULL        false       0            -1
+17    bytea         NULL      NULL        false       0            -1
 19    name          NULL      NULL        false       0            -1
 20    int8          NULL      NULL        false       0            -1
 21    int2          NULL      NULL        false       0            -1
@@ -789,7 +789,7 @@ ORDER BY oid
 ----
 oid   typname       typndims  typcollation  typdefaultbin  typdefault  typacl
 16    bool          0         0             NULL           NULL        NULL
-17    bytes         0         0             NULL           NULL        NULL
+17    bytea         0         0             NULL           NULL        NULL
 19    name          0         1661428263    NULL           NULL        NULL
 20    int8          0         0             NULL           NULL        NULL
 21    int2          0         0             NULL           NULL        NULL


### PR DESCRIPTION
Postgres names this type bytea, so we need to do the same thing in
the `pg_catalog.pg_type` virtual table to provide proper compatibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14495)
<!-- Reviewable:end -->
