### PR TITLE
cli/sql: ensure that statements don't get mangled by history handling

### DIFF
--- a/pkg/cli/interactive_tests/test_history.tcl
+++ b/pkg/cli/interactive_tests/test_history.tcl
@@ -61,6 +61,17 @@ send "\rselect 1;\r"
 eexpect "1 row"
 eexpect root@
 
+# Test that ambiguous datum types are pretty-printed in a parsable
+# form. #14484
+send "SELECT INTERVAL '4' SECOND;\r"
+eexpect "1 row"
+eexpect root@
+send "\033\[A"
+eexpect "SELECT '4s':::INTERVAL;"
+send "\r"
+eexpect "1 row"
+eexpect root@
+
 # Finally terminate with Ctrl+C
 interrupt
 eexpect eof

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -839,8 +839,8 @@ func (c *cliState) doPrepareStatementLine(
 
 func (c *cliState) doCheckStatement(startState, contState, execState cliStateEnum) cliStateEnum {
 	// From here on, client-side syntax checking is enabled.
-	var parser parser.Parser
-	parsedStmts, err := parser.Parse(c.concatLines, c.syntax)
+	var p parser.Parser
+	parsedStmts, err := p.Parse(c.concatLines, c.syntax)
 	if err != nil {
 		_ = c.invalidSyntax(0, "statement ignored: %v", err)
 
@@ -871,7 +871,7 @@ func (c *cliState) doCheckStatement(startState, contState, execState cliStateEnu
 	if c.normalizeHistory {
 		// Add statements, not lines, to the history.
 		for i := c.partialStmtsLen; i < len(parsedStmts); i++ {
-			c.addHistory(parsedStmts[i].String() + ";")
+			c.addHistory(parser.AsStringWithFlags(parsedStmts[i], parser.FmtParsable) + ";")
 		}
 	} else {
 		// Add the last lines received to the history.


### PR DESCRIPTION
Fixes #14484.

cc @cuongdo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14496)
<!-- Reviewable:end -->
