### PR TITLE
sql: trim configurations in logic test files

### DIFF
--- a/pkg/sql/testdata/logic_test/create_as
+++ b/pkg/sql/testdata/logic_test/create_as
@@ -1,4 +1,4 @@
-# LogicTest: default distsql
+# LogicTest: default
 
 statement ok
 CREATE TABLE stock (item, quantity) AS VALUES ('cups', 10), ('plates', 15), ('forks', 30)

--- a/pkg/sql/testdata/logic_test/database
+++ b/pkg/sql/testdata/logic_test/database
@@ -1,4 +1,4 @@
-# LogicTest: default distsql
+# LogicTest: default
 
 statement ok
 CREATE DATABASE a

--- a/pkg/sql/testdata/logic_test/delete
+++ b/pkg/sql/testdata/logic_test/delete
@@ -1,4 +1,4 @@
-# LogicTest: default distsql
+# LogicTest: default
 
 statement ok
 CREATE TABLE kv (

--- a/pkg/sql/testdata/logic_test/drop_database
+++ b/pkg/sql/testdata/logic_test/drop_database
@@ -1,4 +1,4 @@
-# LogicTest: default distsql
+# LogicTest: default
 
 statement ok
 CREATE DATABASE "foo-bar"

--- a/pkg/sql/testdata/logic_test/drop_index
+++ b/pkg/sql/testdata/logic_test/drop_index
@@ -1,4 +1,4 @@
-# LogicTest: default distsql
+# LogicTest: default
 
 statement ok
 CREATE TABLE users (

--- a/pkg/sql/testdata/logic_test/drop_table
+++ b/pkg/sql/testdata/logic_test/drop_table
@@ -1,4 +1,4 @@
-# LogicTest: default distsql
+# LogicTest: default
 
 statement ok
 CREATE TABLE a (id INT PRIMARY KEY)

--- a/pkg/sql/testdata/logic_test/drop_view
+++ b/pkg/sql/testdata/logic_test/drop_view
@@ -1,4 +1,4 @@
-# LogicTest: default distsql
+# LogicTest: default
 
 statement ok
 CREATE TABLE a (k STRING PRIMARY KEY, v STRING)

--- a/pkg/sql/testdata/logic_test/explain_distsql
+++ b/pkg/sql/testdata/logic_test/explain_distsql
@@ -1,7 +1,8 @@
-# LogicTest: default distsql
+# LogicTest: default
 
 #
 # Tests that verify DistSQL support and auto mode determination.
+# The cluster size isn't important for these tests.
 #
 
 statement ok

--- a/pkg/sql/testdata/logic_test/grant_database
+++ b/pkg/sql/testdata/logic_test/grant_database
@@ -1,4 +1,4 @@
-# LogicTest: default distsql
+# LogicTest: default
 
 statement ok
 CREATE DATABASE a

--- a/pkg/sql/testdata/logic_test/grant_table
+++ b/pkg/sql/testdata/logic_test/grant_table
@@ -1,4 +1,4 @@
-# LogicTest: default distsql
+# LogicTest: default
 
 statement ok
 CREATE DATABASE a

--- a/pkg/sql/testdata/logic_test/help
+++ b/pkg/sql/testdata/logic_test/help
@@ -1,4 +1,4 @@
-# LogicTest: default distsql
+# LogicTest: default
 
 query TTTT colnames
 HELP replace

--- a/pkg/sql/testdata/logic_test/information_schema
+++ b/pkg/sql/testdata/logic_test/information_schema
@@ -1,4 +1,4 @@
-# LogicTest: default distsql
+# LogicTest: default
 
 # Verify information_schema database handles mutation statements correctly.
 

--- a/pkg/sql/testdata/logic_test/insert
+++ b/pkg/sql/testdata/logic_test/insert
@@ -1,4 +1,4 @@
-# LogicTest: default distsql
+# LogicTest: default
 
 statement error table "kv" does not exist
 INSERT INTO kv VALUES ('a', 'b')

--- a/pkg/sql/testdata/logic_test/prepare
+++ b/pkg/sql/testdata/logic_test/prepare
@@ -1,4 +1,4 @@
-# LogicTest: default distsql
+# LogicTest: default
 
 statement error unimplemented: Prepared statements are supported only via the Postgres wire protocol \(see issue https://github.com/cockroachdb/cockroach/issues/7568\)
 PREPARE a AS SELECT 1

--- a/pkg/sql/testdata/logic_test/set
+++ b/pkg/sql/testdata/logic_test/set
@@ -1,4 +1,4 @@
-# LogicTest: default distsql
+# LogicTest: default
 
 statement error unknown variable: "FOO"
 SET FOO = bar

--- a/pkg/sql/testdata/logic_test/typing
+++ b/pkg/sql/testdata/logic_test/typing
@@ -1,4 +1,4 @@
-# LogicTest: default distsql
+# LogicTest: default
 
 statement ok
 CREATE TABLE f (x FLOAT)

--- a/pkg/sql/testdata/logic_test/unimplemented
+++ b/pkg/sql/testdata/logic_test/unimplemented
@@ -1,4 +1,4 @@
-# LogicTest: default distsql
+# LogicTest: default
 
 statement error pq: unimplemented
 WITH a AS (SELECT 1) SELECT *

--- a/pkg/sql/testdata/logic_test/update
+++ b/pkg/sql/testdata/logic_test/update
@@ -1,4 +1,4 @@
-# LogicTest: default distsql
+# LogicTest: default
 
 statement ok
 CREATE TABLE kv (

--- a/pkg/sql/testdata/logic_test/user
+++ b/pkg/sql/testdata/logic_test/user
@@ -1,4 +1,4 @@
-# LogicTest: default distsql
+# LogicTest: default
 
 query T colnames
 SHOW USERS


### PR DESCRIPTION
Removing the `distsql` config from a bunch of test files for which testing on
the distsql config is of no benefit. This should speed up the tests a bit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14498)
<!-- Reviewable:end -->
