### PR TITLE
build: don't hide GOPATH from sqllogictest

### DIFF
--- a/build/teamcity-sqllogictest.sh
+++ b/build/teamcity-sqllogictest.sh
@@ -3,7 +3,11 @@ set -euxo pipefail
 
 mkdir -p artifacts
 
-export BUILDER_HIDE_GOPATH_SRC=1
+# make bigtest needs the sqllogictest repo from the host's GOPATH, so we can't
+# hide it like we do in the other teamcity build scripts.
+# TODO(jordan) improve builder.sh to allow partial GOPATH hiding rather than
+# the all-on/all-off strategy BULIDER_HIDE_GOPATH_SRC gives us.
+export BUILDER_HIDE_GOPATH_SRC=0
 build/builder.sh env \
 		 make -C pkg/sql bigtest \
 		 TESTFLAGS='-v' \


### PR DESCRIPTION
It needs another directory from the host GOPATH that contains the tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14511)
<!-- Reviewable:end -->
