### PR TITLE
build: enable nightly bigtest with distsql

### DIFF
--- a/build/teamcity-sqllogictest.sh
+++ b/build/teamcity-sqllogictest.sh
@@ -8,9 +8,11 @@ mkdir -p artifacts
 # TODO(jordan) improve builder.sh to allow partial GOPATH hiding rather than
 # the all-on/all-off strategy BULIDER_HIDE_GOPATH_SRC gives us.
 export BUILDER_HIDE_GOPATH_SRC=0
-build/builder.sh env \
-		 make -C pkg/sql bigtest \
-		 TESTFLAGS='-v' \
-		 2>&1 \
-    | tee artifacts/test.log \
-    | go-test-teamcity
+for target in bigtest bigtest-distsql; do
+    build/builder.sh env \
+             make -C pkg/sql $target \
+             TESTFLAGS='-v' \
+             2>&1 \
+        | tee artifacts/$target.log \
+        | go-test-teamcity
+done

--- a/pkg/sql/Makefile
+++ b/pkg/sql/Makefile
@@ -1,3 +1,7 @@
 .PHONY: bigtest
 bigtest:
 	go test -bigtest -timeout 24h $(TESTFLAGS) -run '^TestLogic$$'
+
+.PHONY: bigtest-distsql
+bigtest-distsql:
+	go test -bigtest -config distsql -timeout 24h $(TESTFLAGS) -run '^TestLogic$$'


### PR DESCRIPTION
bigtest enables us to run a large suite of tests against distsql for
correctness testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14515)
<!-- Reviewable:end -->
