### PR TITLE
storage: track actual memory usage in TimestampCache

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1583,8 +1583,10 @@ func makeCacheRequest(ba *roachpb.BatchRequest, br *roachpb.BatchResponse) cache
 			case *roachpb.EndTransactionRequest:
 				// EndTransaction adds to the write timestamp cache to ensure replays
 				// create a transaction record with WriteTooOld set.
-				key := keys.TransactionKey(header.Key, *cr.txnID)
-				cr.txn = roachpb.Span{Key: key}
+				//
+				// Note that TimestampCache.ExpandRequests lazily creates the
+				// transaction key from the request key.
+				cr.txn = roachpb.Span{Key: header.Key}
 			case *roachpb.ScanRequest:
 				resp := br.Responses[i].GetInner().(*roachpb.ScanResponse)
 				if ba.Header.MaxSpanRequestKeys != 0 &&

--- a/pkg/storage/timestamp_cache_test.go
+++ b/pkg/storage/timestamp_cache_test.go
@@ -106,7 +106,7 @@ func TestTimestampCacheEviction(t *testing.T) {
 	manual := hlc.NewManualClock(123)
 	clock := hlc.NewClock(manual.UnixNano, time.Nanosecond)
 	tc := newTimestampCache(clock)
-	tc.evictionSizeThreshold = 0
+	tc.maxBytes = 0
 
 	// Increment time to the low water mark + 1.
 	manual.Increment(1)


### PR DESCRIPTION
Replace defaultEvictionSizeThreshold with defaultTimestampCacheSize
which defaults to 64 MB.

Fixes #14508

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14516)
<!-- Reviewable:end -->
