### PR TITLE
cli, sql: enforce validation of SQL usernames

### DIFF
--- a/pkg/cli/cert.go
+++ b/pkg/cli/cert.go
@@ -18,6 +18,7 @@ package cli
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -96,8 +97,14 @@ func runCreateClientCert(cmd *cobra.Command, args []string) error {
 		return errMissingParams
 	}
 
+	var err error
+	var username string
+	if username, err = sql.NormalizeAndValidateUsername(args[0]); err != nil {
+		return err
+	}
+
 	return errors.Wrap(security.RunCreateClientCert(baseCfg.SSLCA, baseCfg.SSLCAKey,
-		baseCfg.SSLCert, baseCfg.SSLCertKey, keySize, args[0]),
+		baseCfg.SSLCert, baseCfg.SSLCertKey, keySize, username),
 		"failed to generate clent certificate",
 	)
 }

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -1467,7 +1467,7 @@ func TestPGWireAuth(t *testing.T) {
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop()
 	{
-		unicodeUser := "♫"
+		unicodeUser := "Ὀδυσσεύς"
 
 		t.Run("RootUserAuth", func(t *testing.T) {
 			// Authenticate as root with certificate and expect success.

--- a/pkg/sql/testdata/logic_test/user
+++ b/pkg/sql/testdata/logic_test/user
@@ -22,6 +22,12 @@ CREATE USER user1
 statement error user user1 already exists
 CREATE USER UsEr1
 
+statement ok
+CREATE USER Ομηρος
+
+statement error username "node" reserved
+CREATE USER node
+
 statement error empty passwords are not permitted
 CREATE USER test WITH PASSWORD ''
 
@@ -31,8 +37,8 @@ CREATE USER uSEr2 WITH PASSWORD 'cockroach'
 statement ok
 CREATE USER user3 WITH PASSWORD '蟑螂'
 
-statement ok
-CREATE USER ☂ WITH PASSWORD '☂umbrella'
+statement error pq: username "foo☂" invalid; usernames are case insensitive, must start with a letter or underscore, may contain letters, digits or underscores, and must not exceed 63 characters
+CREATE USER foo☂
 
 query T colnames
 SHOW USERS
@@ -42,7 +48,7 @@ testuser
 user1
 user2
 user3
-☂
+ομηρος
 
 statement error no username specified
 CREATE USER ""


### PR DESCRIPTION
SQL usernames are case-insensitive. They must now start with either a letter
or underscore, contain only letters, numbers, or underscores, and must be
between 1 and 63 characters.

Fixes #2131

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14525)
<!-- Reviewable:end -->
