### PR TITLE
sql: use column IDs in composite secondary indexes

### DIFF
--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -80,9 +80,6 @@ type RowFetcher struct {
 	// If set, GetRangeInfo() can be used to retrieve the accumulated info.
 	returnRangeInfo bool
 
-	// Types for composite columns.
-	compositeColTypes map[ColumnID]ColumnType
-
 	// -- Fields updated during a scan --
 
 	kvFetcher      kvFetcher
@@ -167,12 +164,6 @@ func (rf *RowFetcher) Init(
 		}
 	}
 
-	rf.compositeColTypes = make(map[ColumnID]ColumnType)
-	for _, col := range desc.Columns {
-		if HasCompositeKeyEncoding(col.Type.Kind) {
-			rf.compositeColTypes[col.ID] = col.Type
-		}
-	}
 	return nil
 }
 
@@ -301,8 +292,18 @@ func (rf *RowFetcher) ProcessKV(
 		}
 	}
 
+	// Composite columns that are not present use the key in the index. Record
+	// those values here for use later on if the datums are not present in
+	// the value.
+	unsetCols := map[int]EncDatum{}
+
 	if !rf.isSecondaryIndex && len(rf.keyRemainingBytes) > 0 {
 		_, familyID, err := encoding.DecodeUvarintAscending(rf.keyRemainingBytes)
+		if err != nil {
+			return "", "", err
+		}
+
+		family, err := rf.desc.FindFamilyByID(FamilyID(familyID))
 		if err != nil {
 			return "", "", err
 		}
@@ -313,19 +314,15 @@ func (rf *RowFetcher) ProcessKV(
 			// a duplicate value.
 			for _, colID := range rf.index.CompositeColumnIDs {
 				if idx, ok := rf.colIdxMap[colID]; ok {
+					unsetCols[idx] = rf.row[idx]
 					rf.row[idx].UnsetDatum()
 				}
 			}
 		}
 
-		family, err := rf.desc.FindFamilyByID(FamilyID(familyID))
-		if err != nil {
-			return "", "", err
-		}
-
 		switch kv.Value.GetTag() {
 		case roachpb.ValueType_TUPLE:
-			prettyKey, prettyValue, err = rf.processValueTuple(family, kv, debugStrings, prettyKey)
+			prettyKey, prettyValue, err = rf.processValueTuple(kv, debugStrings, prettyKey)
 		default:
 			prettyKey, prettyValue, err = rf.processValueSingle(family, kv, debugStrings, prettyKey)
 		}
@@ -333,12 +330,19 @@ func (rf *RowFetcher) ProcessKV(
 			return "", "", err
 		}
 	} else {
-		rvalue := kv.ValueBytes()
+		for _, colID := range rf.index.CompositeColumnIDs {
+			if idx, ok := rf.colIdxMap[colID]; ok {
+				unsetCols[idx] = rf.row[idx]
+				rf.row[idx].UnsetDatum()
+			}
+		}
+
+		valueBytes := kv.ValueBytes()
 		if rf.extraVals != nil {
 			// This is a unique index; decode the extra column values from
 			// the value.
 			var err error
-			rvalue, err = DecodeKeyVals(&rf.alloc, rf.extraVals, nil, rvalue)
+			valueBytes, err = DecodeKeyVals(&rf.alloc, rf.extraVals, nil, valueBytes)
 			if err != nil {
 				return "", "", err
 			}
@@ -352,35 +356,25 @@ func (rf *RowFetcher) ProcessKV(
 			}
 		}
 
-		for _, id := range rf.index.CompositeColumnIDs {
-			d := parser.DNull
-			var isNull bool
-			rvalue, isNull = encoding.DecodeIfNull(rvalue)
-			if !isNull {
-				switch typ := rf.compositeColTypes[id]; typ.Kind {
-				case ColumnType_COLLATEDSTRING:
-					var r string
-					var err error
-					rvalue, r, err = encoding.DecodeUnsafeStringAscending(rvalue, nil)
-					if err != nil {
-						return "", "", err
-					}
-					d = parser.NewDCollatedString(r, *typ.Locale, &rf.alloc.env)
-				default:
-					panic(fmt.Sprintf("unknown composite encoding for kind %d", typ.Kind))
-				}
-			}
-			if idx, ok := rf.colIdxMap[id]; ok && rf.valNeededForCol[idx] {
-				rf.row[idx].Datum = d
-			}
-		}
-
 		if log.V(2) {
 			if rf.extraVals != nil {
 				log.Infof(context.TODO(), "Scan %s -> %s", kv.Key, prettyEncDatums(rf.extraVals))
 			} else {
 				log.Infof(context.TODO(), "Scan %s", kv.Key)
 			}
+		}
+
+		if len(valueBytes) > 0 {
+			prettyKey, prettyValue, err = rf.processValueBytes(kv, valueBytes, debugStrings, prettyKey)
+			if err != nil {
+				return "", "", err
+			}
+		}
+	}
+
+	for idx, ed := range unsetCols {
+		if rf.row[idx].IsUnset() {
+			rf.row[idx] = ed
 		}
 	}
 
@@ -445,25 +439,18 @@ func (rf *RowFetcher) processValueSingle(
 	return prettyKey, prettyValue, nil
 }
 
-// processValueTuple processes the given values (of columns family.ColumnIDs),
-// setting values in the rf.row accordingly. The key is only used for logging.
-func (rf *RowFetcher) processValueTuple(
-	family *ColumnFamilyDescriptor, kv client.KeyValue, debugStrings bool, prettyKeyPrefix string,
+func (rf *RowFetcher) processValueBytes(
+	kv client.KeyValue, bytes []byte, debugStrings bool, prettyKeyPrefix string,
 ) (prettyKey string, prettyValue string, err error) {
 	prettyKey = prettyKeyPrefix
 	if debugStrings {
 		rf.prettyValueBuf.Reset()
 	}
 
-	tupleBytes, err := kv.Value.GetTuple()
-	if err != nil {
-		return "", "", err
-	}
-
 	var colIDDiff uint32
 	var lastColID ColumnID
-	for len(tupleBytes) > 0 {
-		_, _, colIDDiff, _, err = encoding.DecodeValueTag(tupleBytes)
+	for len(bytes) > 0 {
+		_, _, colIDDiff, _, err = encoding.DecodeValueTag(bytes)
 		if err != nil {
 			return "", "", err
 		}
@@ -472,11 +459,11 @@ func (rf *RowFetcher) processValueTuple(
 		idx, ok := rf.colIdxMap[colID]
 		if !ok || !rf.valNeededForCol[idx] {
 			// This column wasn't requested, so read its length and skip it.
-			_, len, err := encoding.PeekValueLength(tupleBytes)
+			_, len, err := encoding.PeekValueLength(bytes)
 			if err != nil {
 				return "", "", err
 			}
-			tupleBytes = tupleBytes[len:]
+			bytes = bytes[len:]
 			if log.V(3) {
 				log.Infof(context.TODO(), "Scan %s -> [%d] (skipped)", kv.Key, colID)
 			}
@@ -488,8 +475,8 @@ func (rf *RowFetcher) processValueTuple(
 		}
 
 		var encValue EncDatum
-		encValue, tupleBytes, err =
-			EncDatumFromBuffer(rf.cols[idx].Type, DatumEncoding_VALUE, tupleBytes)
+		encValue, bytes, err =
+			EncDatumFromBuffer(rf.cols[idx].Type, DatumEncoding_VALUE, bytes)
 		if err != nil {
 			return "", "", err
 		}
@@ -508,11 +495,22 @@ func (rf *RowFetcher) processValueTuple(
 			log.Infof(context.TODO(), "Scan %d -> %v", idx, encValue)
 		}
 	}
-
 	if debugStrings {
 		prettyValue = rf.prettyValueBuf.String()
 	}
 	return prettyKey, prettyValue, nil
+}
+
+// processValueTuple processes the given values (of columns family.ColumnIDs),
+// setting values in the rf.row accordingly. The key is only used for logging.
+func (rf *RowFetcher) processValueTuple(
+	kv client.KeyValue, debugStrings bool, prettyKeyPrefix string,
+) (prettyKey string, prettyValue string, err error) {
+	tupleBytes, err := kv.Value.GetTuple()
+	if err != nil {
+		return "", "", err
+	}
+	return rf.processValueBytes(kv, tupleBytes, debugStrings, prettyKeyPrefix)
 }
 
 // NextRow processes keys until we complete one row, which is returned as an

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -530,7 +530,13 @@ func (desc *TableDescriptor) ensurePrimaryKey() error {
 // HasCompositeKeyEncoding returns true if key columns of the given kind have a
 // composite encoding.
 func HasCompositeKeyEncoding(kind ColumnType_Kind) bool {
-	return kind == ColumnType_COLLATEDSTRING
+	switch kind {
+	case ColumnType_COLLATEDSTRING,
+		ColumnType_FLOAT,
+		ColumnType_DECIMAL:
+		return true
+	}
+	return false
 }
 
 func (desc *TableDescriptor) allocateIndexIDs(columnNames map[string]ColumnID) error {

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -18,6 +18,7 @@ package sqlbase
 
 import (
 	"fmt"
+	"sort"
 	"time"
 	"unicode/utf8"
 
@@ -394,7 +395,9 @@ func EncodeDatums(b []byte, d parser.Datums) ([]byte, error) {
 	return b, nil
 }
 
-// EncodeTableKey encodes `val` into `b` and returns the new buffer.
+// EncodeTableKey encodes `val` into `b` and returns the new buffer. The
+// encoded value is guaranteed to be lexicographically sortable, but not
+// guaranteed to be round-trippable during decoding.
 func EncodeTableKey(b []byte, val parser.Datum, dir encoding.Direction) ([]byte, error) {
 	if (dir != encoding.Ascending) && (dir != encoding.Descending) {
 		return nil, errors.Errorf("invalid direction: %d", dir)
@@ -497,8 +500,10 @@ func EncodeTableKey(b []byte, val parser.Datum, dir encoding.Direction) ([]byte,
 	return nil, errors.Errorf("unable to encode table key: %T", val)
 }
 
-// EncodeTableValue encodes `val` into `appendTo` using DatumEncoding_VALUE and
-// returns the new buffer.
+// EncodeTableValue encodes `val` into `appendTo` using DatumEncoding_VALUE
+// and returns the new buffer. The encoded value is guaranteed to round
+// trip and decode exactly to its input, but is not guaranteed to be
+// lexicographically sortable.
 func EncodeTableValue(appendTo []byte, colID ColumnID, val parser.Datum) ([]byte, error) {
 	if val == parser.DNull {
 		return encoding.EncodeNullValue(appendTo, uint32(colID)), nil
@@ -702,7 +707,6 @@ func DecodeKeyVals(
 			len(directions), len(vals))
 	}
 	for j := range vals {
-
 		enc := DatumEncoding_ASCENDING_KEY
 		if directions != nil && (directions[j] == encoding.Descending) {
 			enc = DatumEncoding_DESCENDING_KEY
@@ -1209,18 +1213,28 @@ func EncodeSecondaryIndex(
 		// The zero value for an index-key is a 0-length bytes value.
 		entryValue = []byte{}
 	}
+
+	colIDs := append([]ColumnID(nil), secondaryIndex.CompositeColumnIDs...)
+	sort.Sort(columnIDs(colIDs))
+
+	var lastColID ColumnID
 	// Composite columns have their contents at the end of the value.
-	for _, colID := range secondaryIndex.CompositeColumnIDs {
+	for _, colID := range colIDs {
 		val := values[colMap[colID]]
 		if val == parser.DNull {
-			entryValue = encoding.EncodeNullAscending(entryValue)
 			continue
 		}
-		switch d := val.(type) {
-		case *parser.DCollatedString:
-			entryValue = encoding.EncodeStringAscending(entryValue, d.Contents)
-		default:
-			panic(fmt.Sprintf("unknown composite encoding for datum %s", d))
+		if !val.(parser.CompositeDatum).IsComposite() {
+			continue
+		}
+		if lastColID > colID {
+			panic(fmt.Errorf("cannot write column id %d after %d", colID, lastColID))
+		}
+		colIDDiff := colID - lastColID
+		lastColID = colID
+		entryValue, err = EncodeTableValue(entryValue, colIDDiff, val)
+		if err != nil {
+			return IndexEntry{}, err
 		}
 	}
 	entry.Value.SetBytes(entryValue)

--- a/pkg/sql/testdata/logic_test/decimal
+++ b/pkg/sql/testdata/logic_test/decimal
@@ -91,16 +91,15 @@ INSERT INTO t2 VALUES
 	('-Inf'::decimal, '-Inf'::decimal),
 	('-0.0000'::decimal, '-0.0000'::decimal)
 
-# TODO(mjibson): fix removal of trailing zeros
 query RR
 SELECT * FROM t2 ORDER BY d
 ----
 NaN        NaN
 -Infinity  -Infinity
-0          0
-1          1
-2          2
-3          3
+-0.0000    -0.0
+1.00       1.0
+2.0        2.0
+3          3.0
 Infinity   Infinity
 
 # Ensure uniqueness in PK columns with +/- NaN and 0.

--- a/pkg/sql/testdata/logic_test/float
+++ b/pkg/sql/testdata/logic_test/float
@@ -1,0 +1,38 @@
+# LogicTest: default distsql
+
+# -0 and 0 should not be possible in a unique index.
+
+statement ok
+CREATE TABLE p (f float primary key)
+
+statement ok
+INSERT INTO p VALUES ('NaN'::float), ('Inf'::float), ('-Inf'::float), ('0'::float), (1), (-1)
+
+statement error duplicate key value
+INSERT INTO p VALUES ('-0'::float)
+
+# -0 and 0 should both equate to zero with or without an index
+
+statement ok
+CREATE TABLE i (f float)
+
+statement ok
+INSERT INTO i VALUES (0), ('-0'::float)
+
+query R rowsort
+SELECT * FROM i WHERE f = 0
+----
+-0
+0
+
+statement ok
+CREATE INDEX ON i (f)
+
+query R rowsort
+SELECT * FROM i WHERE f = 0
+----
+-0
+0
+
+statement error duplicate key value
+CREATE UNIQUE INDEX ON i (f)

--- a/pkg/util/encoding/float.go
+++ b/pkg/util/encoding/float.go
@@ -42,14 +42,15 @@ import (
 // direction, and that after them a logical ordering is followed.
 func EncodeFloatAscending(b []byte, f float64) []byte {
 	// Handle the simplistic cases first.
-	u := math.Float64bits(f)
 	switch {
 	case math.IsNaN(f):
 		return append(b, floatNaN)
-	case u == 0:
-		// Only special-case positive zero.
+	case f == 0:
+		// This encodes both positive and negative zero the same. Negative zero uses
+		// composite indexes to decode itself correctly.
 		return append(b, floatZero)
 	}
+	u := math.Float64bits(f)
 	if u&(1<<63) != 0 {
 		u = ^u
 		b = append(b, floatNeg)


### PR DESCRIPTION
Change composite index encoding to always be preceeded by the column
ID diff. This allows both primary and secondary keys to use the same
decode path.

Since the column IDs are now known, datums can now also signal if
they need a composite encoding or not, since for many cases the key
encoding is reversible. Floats and decimals only do in the -0 case
or when zeros are truncated during key encoding. Collated strings
are not reversible and always need a composite encoding.

Float encodings have changed so 0 and -0 have the same key encodings
to allow for correct semantics during index operations. Floats have
been added to composite encodings so -0 can round trip in an index.

This is a backward-incompatible change. Any secondary indexes over
collated strings need to be dropped and recreated. They can be
dropped before or after upgrading, but must be recreated on the new
version. Failing to do this will result in an error: "pq: unknown
type NotNull" during a query.

Fixes #14345
See #14328
See 743842997a428cfae6805df114abf075d3b8129d

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14528)
<!-- Reviewable:end -->
