### PR TITLE
sql: add and link Postgres type i/o builtins

### DIFF
--- a/pkg/sql/parser/type.go
+++ b/pkg/sql/parser/type.go
@@ -204,6 +204,7 @@ var aliasedOidToName = map[oid.Oid]string{
 	oid.T_bytea:      "bytea",
 	oid.T_varchar:    "varchar",
 	oid.T_numeric:    "numeric",
+	oid.T_record:     "record",
 	oid.T__int2:      "int2[]",
 	oid.T__int4:      "int4[]",
 	oid.T__int8:      "int8[]",

--- a/pkg/sql/parser/type.go
+++ b/pkg/sql/parser/type.go
@@ -189,6 +189,35 @@ var OidToType = map[oid.Oid]Type{
 	oid.T_varchar:      typeVarChar,
 }
 
+// AliasedOidToName maps Postgres object IDs to type names for those OIDs that map to
+// Cockroach types that have more than one associated OID, like Int. The name
+// for these OIDs will override the type name of the corresponding type when
+// looking up the display name for an OID.
+var aliasedOidToName = map[oid.Oid]string{
+	oid.T_float4:     "float4",
+	oid.T_float8:     "float8",
+	oid.T_int2:       "int2",
+	oid.T_int4:       "int4",
+	oid.T_int8:       "int8",
+	oid.T_int2vector: "int2vector",
+	oid.T_text:       "text",
+	oid.T_bytea:      "bytea",
+	oid.T_varchar:    "varchar",
+	oid.T_numeric:    "numeric",
+	oid.T__int2:      "int2[]",
+	oid.T__int4:      "int4[]",
+	oid.T__int8:      "int8[]",
+	oid.T__text:      "text[]",
+}
+
+// PGDisplayName returns the Postgres display name for a given type.
+func PGDisplayName(typ Type) string {
+	if typname, ok := aliasedOidToName[typ.Oid()]; ok {
+		return typname
+	}
+	return typ.String()
+}
+
 // Do not instantiate the tXxx types elsewhere. The variables above are intended
 // to be singletons.
 type tNull struct{}
@@ -488,6 +517,8 @@ func (TArray) Size() (uintptr, bool) {
 
 // oidToArrayOid maps scalar type Oids to their corresponding array type Oid.
 var oidToArrayOid = map[oid.Oid]oid.Oid{
+	oid.T_int2: oid.T__int2,
+	oid.T_int4: oid.T__int4,
 	oid.T_int8: oid.T__int8,
 	oid.T_text: oid.T__text,
 	oid.T_name: oid.T__name,

--- a/pkg/sql/testdata/logic_test/builtin_function
+++ b/pkg/sql/testdata/logic_test/builtin_function
@@ -1459,9 +1459,6 @@ SELECT col_description('pg_class'::regclass::oid, 2),
 ----
 NULL  NULL  NULL  NULL
 
-query error pq: array_in\(\): unimplemented
-SELECT array_in('foo', 3, -1)
-
 # Check that base function names are also visible in namespace pg_catalog.
 query I
 SELECT pg_catalog.length('hello')

--- a/pkg/sql/testdata/logic_test/builtin_function
+++ b/pkg/sql/testdata/logic_test/builtin_function
@@ -1389,7 +1389,7 @@ VALUES (format_type('anyelement'::regtype, -1)),
        (format_type('interval'::regtype, -1)),
        (format_type('timestamp'::regtype, -1)),
        (format_type('timestamptz'::regtype, -1)),
-       (format_type('tuple'::regtype, -1))
+       (format_type('record'::regtype, -1))
 ----
 anyelement
 boolean

--- a/pkg/sql/testdata/logic_test/pg_catalog
+++ b/pkg/sql/testdata/logic_test/pg_catalog
@@ -719,35 +719,35 @@ SELECT oid, typname, typinput, typoutput, typreceive, typsend, typmodin, typmodo
 FROM pg_catalog.pg_type
 ORDER BY oid
 ----
-oid   typname       typinput  typoutput  typreceive  typsend  typmodin  typmodout  typanalyze
-16    bool          0         0          0           0        0         0          0
-17    bytea         0         0          0           0        0         0          0
-19    name          0         0          0           0        0         0          0
-20    int8          0         0          0           0        0         0          0
-21    int2          0         0          0           0        0         0          0
-22    int2vector    array_in  0          0           0        0         0          0
-23    int4          0         0          0           0        0         0          0
-24    regproc       0         0          0           0        0         0          0
-25    text          0         0          0           0        0         0          0
-26    oid           0         0          0           0        0         0          0
-700   float4        0         0          0           0        0         0          0
-701   float8        0         0          0           0        0         0          0
-1005  int2[]        array_in  0          0           0        0         0          0
-1007  int4[]        array_in  0          0           0        0         0          0
-1009  text[]        array_in  0          0           0        0         0          0
-1016  int8[]        array_in  0          0           0        0         0          0
-1043  varchar       0         0          0           0        0         0          0
-1082  date          0         0          0           0        0         0          0
-1114  timestamp     0         0          0           0        0         0          0
-1184  timestamptz   0         0          0           0        0         0          0
-1186  interval      0         0          0           0        0         0          0
-1700  numeric       0         0          0           0        0         0          0
-2202  regprocedure  0         0          0           0        0         0          0
-2205  regclass      0         0          0           0        0         0          0
-2206  regtype       0         0          0           0        0         0          0
-2249  tuple         0         0          0           0        0         0          0
-2283  anyelement    0         0          0           0        0         0          0
-4089  regnamespace  0         0          0           0        0         0          0
+oid   typname       typinput        typoutput        typreceive        typsend           typmodin  typmodout  typanalyze
+16    bool          boolin          boolout          boolrecv          boolsend          0         0          0
+17    bytea         byteain         byteaout         bytearecv         byteasend         0         0          0
+19    name          namein          nameout          namerecv          namesend          0         0          0
+20    int8          int8in          int8out          int8recv          int8send          0         0          0
+21    int2          int2in          int2out          int2recv          int2send          0         0          0
+22    int2vector    NULL            NULL             NULL              NULL              0         0          0
+23    int4          int4in          int4out          int4recv          int4send          0         0          0
+24    regproc       regprocin       regprocout       regprocrecv       regprocsend       0         0          0
+25    text          textin          textout          textrecv          textsend          0         0          0
+26    oid           oidin           oidout           oidrecv           oidsend           0         0          0
+700   float4        float4in        float4out        float4recv        float4send        0         0          0
+701   float8        float8in        float8out        float8recv        float8send        0         0          0
+1005  int2[]        array_in        array_out        array_recv        array_send        0         0          0
+1007  int4[]        array_in        array_out        array_recv        array_send        0         0          0
+1009  text[]        array_in        array_out        array_recv        array_send        0         0          0
+1016  int8[]        array_in        array_out        array_recv        array_send        0         0          0
+1043  varchar       varcharin       varcharout       varcharrecv       varcharsend       0         0          0
+1082  date          date_in         date_out         date_recv         date_send         0         0          0
+1114  timestamp     timestamp_in    timestamp_out    timestamp_recv    timestamp_send    0         0          0
+1184  timestamptz   timestamptz_in  timestamptz_out  timestamptz_recv  timestamptz_send  0         0          0
+1186  interval      interval_in     interval_out     interval_recv     interval_send     0         0          0
+1700  numeric       numeric_in      numeric_out      numeric_recv      numeric_send      0         0          0
+2202  regprocedure  regprocedurein  regprocedureout  regprocedurerecv  regproceduresend  0         0          0
+2205  regclass      regclassin      regclassout      regclassrecv      regclasssend      0         0          0
+2206  regtype       regtypein       regtypeout       regtyperecv       regtypesend       0         0          0
+2249  tuple         tuple_in        tuple_out        tuple_recv        tuple_send       0         0          0
+2283  anyelement    anyelement_in   anyelement_out   anyelement_recv   anyelement_send   0         0          0
+4089  regnamespace  regnamespacein  regnamespaceout  regnamespacerecv  regnamespacesend  0         0          0
 
 query OTTTBOI colnames
 SELECT oid, typname, typalign, typstorage, typnotnull, typbasetype, typtypmod
@@ -1096,4 +1096,4 @@ FROM pg_proc p
 JOIN pg_type t ON t.typinput = p.oid
 WHERE t.typname = 'int4[]'
 ----
-4288767817  array_in  array_in
+2590763490  array_in  array_in

--- a/pkg/sql/testdata/logic_test/pg_catalog
+++ b/pkg/sql/testdata/logic_test/pg_catalog
@@ -675,7 +675,7 @@ oid   typname       typnamespace  typowner  typlen  typbyval  typtype
 2202  regprocedure  1782195457    NULL      8       true      b
 2205  regclass      1782195457    NULL      8       true      b
 2206  regtype       1782195457    NULL      8       true      b
-2249  tuple         1782195457    NULL      0       true      b
+2249  record        1782195457    NULL      0       true      b
 2283  anyelement    1782195457    NULL      -1      false     b
 4089  regnamespace  1782195457    NULL      8       true      b
 
@@ -710,7 +710,7 @@ oid   typname       typcategory  typispreferred  typisdefined  typdelim  typreli
 2202  regprocedure  N            false           true          ,         0         0        0
 2205  regclass      N            false           true          ,         0         0        0
 2206  regtype       N            false           true          ,         0         0        0
-2249  tuple         P            false           true          ,         0         0        0
+2249  record        P            false           true          ,         0         0        0
 2283  anyelement    P            false           true          ,         0         0        0
 4089  regnamespace  N            false           true          ,         0         0        0
 
@@ -745,7 +745,7 @@ oid   typname       typinput        typoutput        typreceive        typsend  
 2202  regprocedure  regprocedurein  regprocedureout  regprocedurerecv  regproceduresend  0         0          0
 2205  regclass      regclassin      regclassout      regclassrecv      regclasssend      0         0          0
 2206  regtype       regtypein       regtypeout       regtyperecv       regtypesend       0         0          0
-2249  tuple         tuple_in        tuple_out        tuple_recv        tuple_send       0         0          0
+2249  record        record_in       record_out       record_recv       record_send       0         0          0
 2283  anyelement    anyelement_in   anyelement_out   anyelement_recv   anyelement_send   0         0          0
 4089  regnamespace  regnamespacein  regnamespaceout  regnamespacerecv  regnamespacesend  0         0          0
 
@@ -780,7 +780,7 @@ oid   typname       typalign  typstorage  typnotnull  typbasetype  typtypmod
 2202  regprocedure  NULL      NULL        false       0            -1
 2205  regclass      NULL      NULL        false       0            -1
 2206  regtype       NULL      NULL        false       0            -1
-2249  tuple         NULL      NULL        false       0            -1
+2249  record        NULL      NULL        false       0            -1
 2283  anyelement    NULL      NULL        false       0            -1
 4089  regnamespace  NULL      NULL        false       0            -1
 
@@ -815,7 +815,7 @@ oid   typname       typndims  typcollation  typdefaultbin  typdefault  typacl
 2202  regprocedure  0         0             NULL           NULL        NULL
 2205  regclass      0         0             NULL           NULL        NULL
 2206  regtype       0         0             NULL           NULL        NULL
-2249  tuple         0         0             NULL           NULL        NULL
+2249  record        0         0             NULL           NULL        NULL
 2283  anyelement    0         0             NULL           NULL        NULL
 4089  regnamespace  0         0             NULL           NULL        NULL
 


### PR DESCRIPTION
In Postgres, every type has 4 i/o builtins that correspond to it. For `int8`, for instance, there's `int8in`, `int8out`, `int8send`, and `int8recv`. We implement these as no-op builtins for ORM compatibility.

Additionally, we link these builtins to their corresponding fields in `pg_type` for all types.

Also, fix the name in `pg_type` for our `Tuple` type, which is called `record` in Postgres.

Fixes #12526.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14529)
<!-- Reviewable:end -->
