### PR TITLE
distsql: support composite types

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -110,10 +110,6 @@ func (v *distSQLExprCheckVisitor) VisitPre(expr parser.Expr) (recurse bool, newE
 		v.err = errors.Errorf("subqueries not supported yet")
 		return false, expr
 
-	case *parser.CollateExpr:
-		v.err = errors.Errorf("collations not supported yet (#13496)")
-		return false, expr
-
 	case *parser.FuncExpr:
 		if t.IsContextDependent() {
 			v.err = errors.Errorf("context-dependent function %s not supported", t)
@@ -245,13 +241,6 @@ func (dsp *distSQLPlanner) checkSupportForNode(node planNode) (distRecommendatio
 		return rec, nil
 
 	case *scanNode:
-		// TODO(radu): remove this limitation.
-		for _, id := range n.index.CompositeColumnIDs {
-			idx, ok := n.colIdxMap[id]
-			if ok && n.valNeededForCol[idx] {
-				return 0, errors.Errorf("cannot scan composite column")
-			}
-		}
 		rec := canDistribute
 		if n.hardLimit != 0 || n.softLimit != 0 {
 			// We don't yet recommend distributing plans where limits propagate

--- a/pkg/sql/distsqlrun/stream_encoder.go
+++ b/pkg/sql/distsqlrun/stream_encoder.go
@@ -100,6 +100,10 @@ func (se *StreamEncoder) AddRow(row sqlbase.EncDatumRow) error {
 			if !ok {
 				enc = preferredEncoding
 			}
+			if enc != sqlbase.DatumEncoding_VALUE && sqlbase.HasCompositeKeyEncoding(row[i].Type.Kind) {
+				// Force VALUE encoding for composite types (key encodings may lose data).
+				enc = sqlbase.DatumEncoding_VALUE
+			}
 			se.infos[i].Encoding = enc
 			se.infos[i].Type = row[i].Type
 		}

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -527,8 +527,9 @@ func (desc *TableDescriptor) ensurePrimaryKey() error {
 	return nil
 }
 
-// HasCompositeKeyEncoding returns true if key columns of the given kind have a
-// composite encoding.
+// HasCompositeKeyEncoding returns true if key columns of the given kind can
+// have a composite encoding. For such types, it can be decided on a
+// case-by-base basis whether a given Datum requires the composite encoding.
 func HasCompositeKeyEncoding(kind ColumnType_Kind) bool {
 	switch kind {
 	case ColumnType_COLLATEDSTRING,

--- a/pkg/sql/testdata/logic_test/decimal
+++ b/pkg/sql/testdata/logic_test/decimal
@@ -83,13 +83,13 @@ CREATE TABLE t2 (d decimal, v decimal(3, 1), primary key (d, v))
 
 statement ok
 INSERT INTO t2 VALUES
-	(1.00::decimal, 1.00::decimal),
-	(2.0::decimal, 2.0::decimal),
-	(3::decimal, 3::decimal),
-	('NaN'::decimal, 'NaN'::decimal),
-	('Inf'::decimal, 'Inf'::decimal),
-	('-Inf'::decimal, '-Inf'::decimal),
-	('-0.0000'::decimal, '-0.0000'::decimal)
+  (1.00::decimal, 1.00::decimal),
+  (2.0::decimal, 2.0::decimal),
+  (3::decimal, 3::decimal),
+  ('NaN'::decimal, 'NaN'::decimal),
+  ('Inf'::decimal, 'Inf'::decimal),
+  ('-Inf'::decimal, '-Inf'::decimal),
+  ('-0.0000'::decimal, '-0.0000'::decimal)
 
 query RR
 SELECT * FROM t2 ORDER BY d
@@ -124,14 +124,14 @@ CREATE TABLE s (d decimal null)
 
 statement ok
 INSERT INTO s VALUES
-	(null),
-	('NaN'::decimal),
-	('-NaN'::decimal),
-	('Inf'::decimal),
-	('-Inf'::decimal),
-	('0'::decimal),
-	(1),
-	(-1)
+  (null),
+  ('NaN'::decimal),
+  ('-NaN'::decimal),
+  ('Inf'::decimal),
+  ('-Inf'::decimal),
+  ('0'::decimal),
+  (1),
+  (-1)
 
 query R
 SELECT * FROM s ORDER BY d
@@ -159,11 +159,11 @@ NULL
 
 statement ok
 INSERT INTO s VALUES
-	('-0'::decimal),
-	('-0.0'::decimal),
-	('-0.00'::decimal),
-	('-0.00E-1'::decimal),
-	('-0.0E-3'::decimal)
+  ('-0'::decimal),
+  ('-0.0'::decimal),
+  ('-0.00'::decimal),
+  ('-0.00E-1'::decimal),
+  ('-0.0E-3'::decimal)
 
 query R rowsort
 SELECT * FROM s WHERE d = 0
@@ -185,3 +185,49 @@ query R
 SELECT * FROM s WHERE d = 'inf'::decimal
 ----
 Infinity
+
+# Verify that decimals don't lose trailing 0s even when used for an index.
+statement ok
+CREATE INDEX idx ON s (d)
+
+query R rowsort
+SELECT * FROM s@idx WHERE d = 0
+----
+0
+-0
+-0.0
+-0.00
+-0.000
+-0.0000
+
+statement ok
+INSERT INTO s VALUES
+  ('10'::decimal),
+  ('10.0'::decimal),
+  ('10.00'::decimal),
+  ('10.000'::decimal),
+  ('100000E-4'::decimal),
+  ('1000000E-5'::decimal),
+  ('1.0000000E+1'::decimal)
+
+query R rowsort
+SELECT * FROM s@primary WHERE d = 10
+----
+10
+10.0
+10.00
+10.000
+10.0000
+10.00000
+10.000000
+
+query R rowsort
+SELECT * FROM s@idx WHERE d = 10
+----
+10
+10.0
+10.00
+10.000
+10.0000
+10.00000
+10.000000


### PR DESCRIPTION
Composite types (collated strings, and soon decimals/floats) cannot be fully
represented by a key encoding. Disallow these encodings in distsql.

Changing use of `ORDER BY (a, b)` in some testcases to `ORDER BY a, b`. The
former syntax creates a tuple as a sort key and distsql doesn't (yet) support
tuple renderings.

@mjibson - together with your change #14528, we may be able to remove the "trimdecimals" in tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14531)
<!-- Reviewable:end -->
