### PR TITLE
sql: clean up nits in collated string logictests

### DIFF
--- a/pkg/sql/testdata/logic_test/collatedstring
+++ b/pkg/sql/testdata/logic_test/collatedstring
@@ -175,25 +175,21 @@ true
 
 
 statement error invalid locale e: language: tag is not well-formed at or near "\)"
-----
 CREATE TABLE e1 (
   a STRING COLLATE e
 )
 
 statement error multiple COLLATE declarations for column "a" at or near "\)"
-----
 CREATE TABLE e2 (
   a STRING COLLATE en COLLATE de
 )
 
 statement error COLLATE declaration for non-string-typed column "a" at or near "\)"
-----
 CREATE TABLE e3 (
   a INT COLLATE en
 )
 
 statement ok
-----
 CREATE TABLE t (
   a STRING COLLATE en
 )
@@ -207,7 +203,6 @@ t  CREATE TABLE t (
    )
 
 statement ok
-----
 INSERT INTO t VALUES
   ('A' COLLATE en),
   ('B' COLLATE en),
@@ -217,7 +212,6 @@ INSERT INTO t VALUES
   ('ü' COLLATE en)
 
 statement error locale "de" doesn't match locale "en" of column "a"
-----
 INSERT INTO t VALUES ('X' COLLATE de)
 
 query T

--- a/pkg/sql/testdata/logic_test/collatedstring_constraint
+++ b/pkg/sql/testdata/logic_test/collatedstring_constraint
@@ -3,100 +3,88 @@
 # English collation chart: http://www.unicode.org/cldr/charts/30/collation/en_US_POSIX.html
 
 statement ok
-----
 CREATE TABLE p (
   a STRING COLLATE en_u_ks_level1 PRIMARY KEY
-);
+)
 
 statement ok
-----
-INSERT INTO p VALUES ('a' COLLATE en_u_ks_level1);
+INSERT INTO p VALUES ('a' COLLATE en_u_ks_level1)
 
 # TODO(eisen): the interactive message is
 # > pq: TODO(eisen): cannot decode collation key: "\x15\xef"
 # Here and below, we can do better.
 #
 # statement error
-# ----
-# INSERT INTO p VALUES ('A' COLLATE en_u_ks_level1);
+# INSERT INTO p VALUES ('A' COLLATE en_u_ks_level1)
 
 statement ok
-----
-INSERT INTO p VALUES ('b' COLLATE en_u_ks_level1);
+INSERT INTO p VALUES ('b' COLLATE en_u_ks_level1)
 
 statement ok
-----
 CREATE TABLE c1 (
   a STRING COLLATE en_u_ks_level1 PRIMARY KEY,
   b STRING COLLATE en_u_ks_level1
-) INTERLEAVE IN PARENT p (a);
+) INTERLEAVE IN PARENT p (a)
 
 statement ok
-----
-INSERT INTO c1 VALUES ('A' COLLATE en_u_ks_level1, 'apple' COLLATE en_u_ks_level1);
+INSERT INTO c1 VALUES ('A' COLLATE en_u_ks_level1, 'apple' COLLATE en_u_ks_level1)
 
 statement ok
-----
-INSERT INTO c1 VALUES ('b' COLLATE en_u_ks_level1, 'banana' COLLATE en_u_ks_level1);
+INSERT INTO c1 VALUES ('b' COLLATE en_u_ks_level1, 'banana' COLLATE en_u_ks_level1)
 
 statement ok
-----
-INSERT INTO c1 VALUES ('p' COLLATE en_u_ks_level1, 'pear' COLLATE en_u_ks_level1);
+INSERT INTO c1 VALUES ('p' COLLATE en_u_ks_level1, 'pear' COLLATE en_u_ks_level1)
 
 query T
-SELECT a FROM p ORDER BY a;
+SELECT a FROM p ORDER BY a
 ----
 a
 b
 
 query T
-SELECT a FROM c1 ORDER BY a;
+SELECT a FROM c1 ORDER BY a
 ----
 A
 b
 p
 
 query T
-SELECT b FROM c1 ORDER BY a;
+SELECT b FROM c1 ORDER BY a
 ----
 apple
 banana
 pear
 
 statement ok
-----
 CREATE TABLE c2 (
   a STRING COLLATE en_u_ks_level1 PRIMARY KEY,
   b STRING COLLATE en_u_ks_level1,
   CONSTRAINT fk_p FOREIGN KEY (a) REFERENCES p
-) INTERLEAVE IN PARENT p (a);
+) INTERLEAVE IN PARENT p (a)
 
 statement ok
-----
-INSERT INTO c2 VALUES ('A' COLLATE en_u_ks_level1, 'apple' COLLATE en_u_ks_level1);
+INSERT INTO c2 VALUES ('A' COLLATE en_u_ks_level1, 'apple' COLLATE en_u_ks_level1)
 
 statement ok
-----
-INSERT INTO c2 VALUES ('b' COLLATE en_u_ks_level1, 'banana' COLLATE en_u_ks_level1);
+INSERT INTO c2 VALUES ('b' COLLATE en_u_ks_level1, 'banana' COLLATE en_u_ks_level1)
 
 statement error foreign key violation: value \['p' COLLATE en_u_ks_level1\] not found in p@primary \[a\]
-----
-INSERT INTO c2 VALUES ('p' COLLATE en_u_ks_level1, 'pear' COLLATE en_u_ks_level1);
+INSERT INTO c2 VALUES ('p' COLLATE en_u_ks_level1, 'pear' COLLATE en_u_ks_level1)
 
 query T
-SELECT a FROM p ORDER BY a;
+SELECT a FROM p ORDER BY a
 ----
 a
 b
 
 query T
-SELECT a FROM c2 ORDER BY a;
+SELECT a FROM c2 ORDER BY a
 ----
 A
 b
 
 query T
-SELECT b FROM c2 ORDER BY a;
+SELECT b FROM c2 ORDER BY a
 ----
 apple
 banana

--- a/pkg/sql/testdata/logic_test/collatedstring_index1
+++ b/pkg/sql/testdata/logic_test/collatedstring_index1
@@ -6,16 +6,14 @@
 # Danish collation chart: http://www.unicode.org/cldr/charts/30/collation/da.html
 
 statement ok
-----
 CREATE TABLE t (
   a STRING COLLATE da,
   b INT,
   c BOOL,
   PRIMARY KEY (a, b)
-);
+)
 
 statement ok
-----
 INSERT INTO t VALUES
   ('A' COLLATE da, 1, TRUE),
   ('A' COLLATE da, 2, NULL),
@@ -25,10 +23,10 @@ INSERT INTO t VALUES
   ('b' COLLATE da, 4, FALSE),
   ('ü' COLLATE da, 6, TRUE),
   ('ü' COLLATE da, 5, NULL),
-  ('x' COLLATE da, 5, FALSE);
+  ('x' COLLATE da, 5, FALSE)
 
 query TI
-SELECT a, b FROM t ORDER BY (a, b);
+SELECT a, b FROM t ORDER BY (a, b)
 ----
 a  2
 a  3
@@ -41,7 +39,7 @@ x  5
 ü  6
 
 query IT
-SELECT b, a FROM t ORDER BY (b, a);
+SELECT b, a FROM t ORDER BY (b, a)
 ----
 1  A
 2  a
@@ -54,28 +52,27 @@ SELECT b, a FROM t ORDER BY (b, a);
 6  ü
 
 query I
-SELECT COUNT (a) FROM t WHERE a = ('a' COLLATE da);
+SELECT COUNT (a) FROM t WHERE a = ('a' COLLATE da)
 ----
 2
 
 query I
-SELECT COUNT (a) FROM t WHERE a = ('y' COLLATE da);
+SELECT COUNT (a) FROM t WHERE a = ('y' COLLATE da)
 ----
 0
 
 query I
-SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da);
+SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 ----
 4
 
 # Create an index and try again.
 
 statement ok
-----
-CREATE INDEX ON t (b, a) STORING (c);
+CREATE INDEX ON t (b, a) STORING (c)
 
 query TI
-SELECT a, b FROM t ORDER BY (a, b);
+SELECT a, b FROM t ORDER BY (a, b)
 ----
 a  2
 a  3
@@ -88,7 +85,7 @@ x  5
 ü  6
 
 query IT
-SELECT b, a FROM t ORDER BY (b, a);
+SELECT b, a FROM t ORDER BY (b, a)
 ----
 1  A
 2  a
@@ -101,28 +98,27 @@ SELECT b, a FROM t ORDER BY (b, a);
 6  ü
 
 query I
-SELECT COUNT (a) FROM t WHERE a = ('a' COLLATE da);
+SELECT COUNT (a) FROM t WHERE a = ('a' COLLATE da)
 ----
 2
 
 query I
-SELECT COUNT (a) FROM t WHERE a = ('y' COLLATE da);
+SELECT COUNT (a) FROM t WHERE a = ('y' COLLATE da)
 ----
 0
 
 query I
-SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da);
+SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 ----
 4
 
 # Update and try again.
 
 statement ok
-----
-UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE da;
+UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE da
 
 query TI
-SELECT a, b FROM t ORDER BY (a, b);
+SELECT a, b FROM t ORDER BY (a, b)
 ----
 bb  4
 BB  3
@@ -135,7 +131,7 @@ AA  1
 AA  2
 
 query IT
-SELECT b, a FROM t ORDER BY (b, a);
+SELECT b, a FROM t ORDER BY (b, a)
 ----
 1  AA
 2  aa
@@ -150,11 +146,10 @@ SELECT b, a FROM t ORDER BY (b, a);
 # Delete and try again
 
 statement ok
-----
-DELETE FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da);
+DELETE FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 
 query TI
-SELECT a, b FROM t ORDER BY (a, b);
+SELECT a, b FROM t ORDER BY (a, b)
 ----
 xx  5
 üü  5
@@ -165,7 +160,7 @@ AA  1
 AA  2
 
 query IT
-SELECT b, a FROM t ORDER BY (b, a);
+SELECT b, a FROM t ORDER BY (b, a)
 ----
 1  AA
 2  aa

--- a/pkg/sql/testdata/logic_test/collatedstring_index2
+++ b/pkg/sql/testdata/logic_test/collatedstring_index2
@@ -6,16 +6,14 @@
 # German collation chart: http://www.unicode.org/cldr/charts/30/collation/de.html
 
 statement ok
-----
 CREATE TABLE t (
   a STRING COLLATE de,
   b INT,
   c BOOL,
   PRIMARY KEY (b, a)
-);
+)
 
 statement ok
-----
 INSERT INTO t VALUES
   ('A' COLLATE de, 1, TRUE),
   ('A' COLLATE de, 2, NULL),
@@ -25,10 +23,10 @@ INSERT INTO t VALUES
   ('b' COLLATE de, 4, FALSE),
   ('ü' COLLATE de, 6, TRUE),
   ('ü' COLLATE de, 5, NULL),
-  ('x' COLLATE de, 5, FALSE);
+  ('x' COLLATE de, 5, FALSE)
 
 query TI
-SELECT a, b FROM t ORDER BY (a, b);
+SELECT a, b FROM t ORDER BY (a, b)
 ----
 a  2
 a  3
@@ -41,7 +39,7 @@ B  3
 x  5
 
 query IT
-SELECT b, a FROM t ORDER BY (b, a);
+SELECT b, a FROM t ORDER BY (b, a)
 ----
 1  A
 2  a
@@ -54,28 +52,27 @@ SELECT b, a FROM t ORDER BY (b, a);
 6  ü
 
 query I
-SELECT COUNT (a) FROM t WHERE a = ('a' COLLATE de);
+SELECT COUNT (a) FROM t WHERE a = ('a' COLLATE de)
 ----
 2
 
 query I
-SELECT COUNT (a) FROM t WHERE a = ('y' COLLATE de);
+SELECT COUNT (a) FROM t WHERE a = ('y' COLLATE de)
 ----
 0
 
 query I
-SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de);
+SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 ----
 4
 
 # Create an index and try again.
 
 statement ok
-----
-CREATE INDEX ON t (a, b) STORING (c);
+CREATE INDEX ON t (a, b) STORING (c)
 
 query TI
-SELECT a, b FROM t ORDER BY (a, b);
+SELECT a, b FROM t ORDER BY (a, b)
 ----
 a  2
 a  3
@@ -88,7 +85,7 @@ B  3
 x  5
 
 query IT
-SELECT b, a FROM t ORDER BY (b, a);
+SELECT b, a FROM t ORDER BY (b, a)
 ----
 1  A
 2  a
@@ -101,28 +98,27 @@ SELECT b, a FROM t ORDER BY (b, a);
 6  ü
 
 query I
-SELECT COUNT (a) FROM t WHERE a = ('a' COLLATE de);
+SELECT COUNT (a) FROM t WHERE a = ('a' COLLATE de)
 ----
 2
 
 query I
-SELECT COUNT (a) FROM t WHERE a = ('y' COLLATE de);
+SELECT COUNT (a) FROM t WHERE a = ('y' COLLATE de)
 ----
 0
 
 query I
-SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de);
+SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 ----
 4
 
 # Update and try again.
 
 statement ok
-----
-UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE de;
+UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE de
 
 query TI
-SELECT a, b FROM t ORDER BY (a, b);
+SELECT a, b FROM t ORDER BY (a, b)
 ----
 aa  2
 aa  3
@@ -135,7 +131,7 @@ BB  3
 xx  5
 
 query IT
-SELECT b, a FROM t ORDER BY (b, a);
+SELECT b, a FROM t ORDER BY (b, a)
 ----
 1  AA
 2  aa
@@ -150,18 +146,17 @@ SELECT b, a FROM t ORDER BY (b, a);
 # Delete and try again
 
 statement ok
-----
-DELETE FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de);
+DELETE FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 
 query TI
-SELECT a, b FROM t ORDER BY (a, b);
+SELECT a, b FROM t ORDER BY (a, b)
 ----
 üü  5
 üü  6
 xx  5
 
 query IT
-SELECT b, a FROM t ORDER BY (b, a);
+SELECT b, a FROM t ORDER BY (b, a)
 ----
 5  üü
 5  xx

--- a/pkg/sql/testdata/logic_test/collatedstring_normalization
+++ b/pkg/sql/testdata/logic_test/collatedstring_normalization
@@ -1,33 +1,29 @@
 # LogicTest: default distsql
 
 statement ok
-----
 CREATE TABLE t (
   a STRING COLLATE fr PRIMARY KEY
-);
+)
 
 # Insert Amélie in NFD form.
 statement ok
-----
-INSERT INTO t VALUES (b'Ame\xcc\x81lie' COLLATE fr);
+INSERT INTO t VALUES (b'Ame\xcc\x81lie' COLLATE fr)
 
 # Retrieve Amélie in NFC form.
 query T
-SELECT a FROM t WHERE a = (b'Am\xc3\xa9lie' COLLATE fr);
+SELECT a FROM t WHERE a = (b'Am\xc3\xa9lie' COLLATE fr)
 ----
 Amélie
 
 statement ok
-----
-DELETE FROM t;
+DELETE FROM t
 
 # Insert Amélie in NFC form.
 statement ok
-----
-INSERT INTO t VALUES (b'Am\xc3\xa9lie' COLLATE fr);
+INSERT INTO t VALUES (b'Am\xc3\xa9lie' COLLATE fr)
 
 # Retrieve Amélie in NFD form.
 query T
-SELECT a FROM t WHERE a = (b'Ame\xcc\x81lie' COLLATE fr);
+SELECT a FROM t WHERE a = (b'Ame\xcc\x81lie' COLLATE fr)
 ----
 Amélie

--- a/pkg/sql/testdata/logic_test/collatedstring_nullinindex
+++ b/pkg/sql/testdata/logic_test/collatedstring_nullinindex
@@ -1,22 +1,19 @@
 # LogicTest: default distsql
 
 statement ok
-----
 CREATE TABLE t (
   a INT PRIMARY KEY,
   b STRING COLLATE en
-);
+)
 
 statement ok
-----
-INSERT INTO t VALUES (1, 'foo' COLLATE en), (2, NULL), (3, 'bar' COLLATE en);
+INSERT INTO t VALUES (1, 'foo' COLLATE en), (2, NULL), (3, 'bar' COLLATE en)
 
 statement ok
-----
-CREATE INDEX ON t (b, a);
+CREATE INDEX ON t (b, a)
 
 query T
-SELECT b FROM t ORDER BY b;
+SELECT b FROM t ORDER BY b
 ----
 NULL
 bar

--- a/pkg/sql/testdata/logic_test/collatedstring_uniqueindex1
+++ b/pkg/sql/testdata/logic_test/collatedstring_uniqueindex1
@@ -6,16 +6,14 @@
 # Danish collation chart: http://www.unicode.org/cldr/charts/30/collation/da.html
 
 statement ok
-----
 CREATE TABLE t (
   a STRING COLLATE da,
   b INT,
   c BOOL,
   PRIMARY KEY (a, b)
-);
+)
 
 statement ok
-----
 INSERT INTO t VALUES
   ('A' COLLATE da, 1, TRUE),
   ('A' COLLATE da, 2, NULL),
@@ -25,14 +23,13 @@ INSERT INTO t VALUES
   ('b' COLLATE da, 4, FALSE),
   ('ü' COLLATE da, 6, TRUE),
   ('ü' COLLATE da, 5, NULL),
-  ('x' COLLATE da, 5, FALSE);
+  ('x' COLLATE da, 5, FALSE)
 
 statement ok
-----
-CREATE UNIQUE INDEX ON t (b, a);
+CREATE UNIQUE INDEX ON t (b, a)
 
 query TI
-SELECT a, b FROM t ORDER BY (a, b);
+SELECT a, b FROM t ORDER BY (a, b)
 ----
 a  2
 a  3
@@ -45,7 +42,7 @@ x  5
 ü  6
 
 query IT
-SELECT b, a FROM t ORDER BY (b, a);
+SELECT b, a FROM t ORDER BY (b, a)
 ----
 1  A
 2  a
@@ -58,28 +55,27 @@ SELECT b, a FROM t ORDER BY (b, a);
 6  ü
 
 query I
-SELECT COUNT (a) FROM t WHERE a = ('a' COLLATE da);
+SELECT COUNT (a) FROM t WHERE a = ('a' COLLATE da)
 ----
 2
 
 query I
-SELECT COUNT (a) FROM t WHERE a = ('y' COLLATE da);
+SELECT COUNT (a) FROM t WHERE a = ('y' COLLATE da)
 ----
 0
 
 query I
-SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da);
+SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 ----
 4
 
 # Update and try again.
 
 statement ok
-----
-UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE da;
+UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE da
 
 query TI
-SELECT a, b FROM t ORDER BY (a, b);
+SELECT a, b FROM t ORDER BY (a, b)
 ----
 bb  4
 BB  3
@@ -92,7 +88,7 @@ AA  1
 AA  2
 
 query IT
-SELECT b, a FROM t ORDER BY (b, a);
+SELECT b, a FROM t ORDER BY (b, a)
 ----
 1  AA
 2  aa
@@ -107,11 +103,10 @@ SELECT b, a FROM t ORDER BY (b, a);
 # Delete and try again
 
 statement ok
-----
-DELETE FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da);
+DELETE FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 
 query TI
-SELECT a, b FROM t ORDER BY (a, b);
+SELECT a, b FROM t ORDER BY (a, b)
 ----
 xx  5
 üü  5
@@ -122,7 +117,7 @@ AA  1
 AA  2
 
 query IT
-SELECT b, a FROM t ORDER BY (b, a);
+SELECT b, a FROM t ORDER BY (b, a)
 ----
 1  AA
 2  aa

--- a/pkg/sql/testdata/logic_test/collatedstring_uniqueindex2
+++ b/pkg/sql/testdata/logic_test/collatedstring_uniqueindex2
@@ -6,16 +6,14 @@
 # German collation chart: http://www.unicode.org/cldr/charts/30/collation/de.html
 
 statement ok
-----
 CREATE TABLE t (
   a STRING COLLATE de,
   b INT,
   c BOOL,
   PRIMARY KEY (b, a)
-);
+)
 
 statement ok
-----
 INSERT INTO t VALUES
   ('A' COLLATE de, 1, TRUE),
   ('A' COLLATE de, 2, NULL),
@@ -25,14 +23,13 @@ INSERT INTO t VALUES
   ('b' COLLATE de, 4, FALSE),
   ('ü' COLLATE de, 6, TRUE),
   ('ü' COLLATE de, 5, NULL),
-  ('x' COLLATE de, 5, FALSE);
+  ('x' COLLATE de, 5, FALSE)
 
 statement ok
-----
-CREATE UNIQUE INDEX ON t (a, b);
+CREATE UNIQUE INDEX ON t (a, b)
 
 query TI
-SELECT a, b FROM t ORDER BY (a, b);
+SELECT a, b FROM t ORDER BY (a, b)
 ----
 a  2
 a  3
@@ -45,7 +42,7 @@ B  3
 x  5
 
 query IT
-SELECT b, a FROM t ORDER BY (b, a);
+SELECT b, a FROM t ORDER BY (b, a)
 ----
 1  A
 2  a
@@ -58,28 +55,27 @@ SELECT b, a FROM t ORDER BY (b, a);
 6  ü
 
 query I
-SELECT COUNT (a) FROM t WHERE a = ('a' COLLATE de);
+SELECT COUNT (a) FROM t WHERE a = ('a' COLLATE de)
 ----
 2
 
 query I
-SELECT COUNT (a) FROM t WHERE a = ('y' COLLATE de);
+SELECT COUNT (a) FROM t WHERE a = ('y' COLLATE de)
 ----
 0
 
 query I
-SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de);
+SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 ----
 4
 
 # Update and try again.
 
 statement ok
-----
-UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE de;
+UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE de
 
 query TI
-SELECT a, b FROM t ORDER BY (a, b);
+SELECT a, b FROM t ORDER BY (a, b)
 ----
 aa  2
 aa  3
@@ -92,7 +88,7 @@ BB  3
 xx  5
 
 query IT
-SELECT b, a FROM t ORDER BY (b, a);
+SELECT b, a FROM t ORDER BY (b, a)
 ----
 1  AA
 2  aa
@@ -107,18 +103,17 @@ SELECT b, a FROM t ORDER BY (b, a);
 # Delete and try again
 
 statement ok
-----
-DELETE FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de);
+DELETE FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 
 query TI
-SELECT a, b FROM t ORDER BY (a, b);
+SELECT a, b FROM t ORDER BY (a, b)
 ----
 üü  5
 üü  6
 xx  5
 
 query IT
-SELECT b, a FROM t ORDER BY (b, a);
+SELECT b, a FROM t ORDER BY (b, a)
 ----
 5  üü
 5  xx


### PR DESCRIPTION
Fixing incorrect delimiters and unnecessary semicolons in collated strings
logictests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14532)
<!-- Reviewable:end -->
