### PR TITLE
storage: Rename functions in the request-processing pipeline

### DIFF
--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -143,12 +143,11 @@ var commands = map[roachpb.Method]Command{
 		}},
 }
 
-// executeCmd switches over the method and multiplexes to execute the appropriate storage API
-// command. It returns the response, an error, and a post commit trigger which
-// may be actionable even in the case of an error.
-// maxKeys is the number of scan results remaining for this batch
-// (MaxInt64 for no limit).
-func executeCmd(
+// evaluateCommand delegates to the eval method for the given
+// roachpb.Request. The returned EvalResult may be partially valid
+// even if an error is returned. maxKeys is the number of scan results
+// remaining for this batch (MaxInt64 for no limit).
+func evaluateCommand(
 	ctx context.Context,
 	raftCmdID storagebase.CmdIDKey,
 	index int,

--- a/pkg/storage/replica_range_lease.go
+++ b/pkg/storage/replica_range_lease.go
@@ -86,7 +86,7 @@ func (p *pendingLeaseRequest) RequestPending() (roachpb.Lease, bool) {
 //
 // Note: Once this function gets a context to be used for cancellation, instead
 // of replica.store.Stopper().ShouldQuiesce(), care will be needed for cancelling
-// the Raft command, similar to replica.addWriteCmd.
+// the Raft command, similar to replica.executeWriteBatch.
 //
 // Requires repl.mu is exclusively locked.
 func (p *pendingLeaseRequest) InitOrJoinRequest(

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -6133,7 +6133,7 @@ func TestReplicaCancelRaft(t *testing.T) {
 			if err := ba.SetActiveTimestamp(tc.Clock().Now); err != nil {
 				t.Fatal(err)
 			}
-			_, pErr := tc.repl.addWriteCmd(ctx, ba)
+			_, pErr := tc.repl.executeWriteBatch(ctx, ba)
 			if cancelEarly {
 				if !testutils.IsPError(pErr, context.Canceled.Error()) {
 					t.Fatalf("expected canceled error; got %v", pErr)
@@ -6190,7 +6190,7 @@ func TestReplicaTryAbandon(t *testing.T) {
 	if err := ba.SetActiveTimestamp(tc.Clock().Now); err != nil {
 		t.Fatal(err)
 	}
-	_, pErr := tc.repl.addWriteCmd(ctx, ba)
+	_, pErr := tc.repl.executeWriteBatch(ctx, ba)
 	if pErr == nil {
 		t.Fatalf("expected failure, but found success")
 	}
@@ -6578,7 +6578,7 @@ func TestReplicaRetryRaftProposal(t *testing.T) {
 	iArg := incrementArgs(roachpb.Key("b"), expInc)
 	ba.Add(&iArg)
 	{
-		br, pErr, retry := tc.repl.tryAddWriteCmd(
+		br, pErr, retry := tc.repl.tryExecuteWriteBatch(
 			context.WithValue(ctx, magicKey{}, "foo"),
 			ba,
 		)
@@ -6592,7 +6592,7 @@ func TestReplicaRetryRaftProposal(t *testing.T) {
 
 	atomic.StoreInt32(&c, 0)
 	{
-		br, pErr := tc.repl.addWriteCmd(
+		br, pErr := tc.repl.executeWriteBatch(
 			context.WithValue(ctx, magicKey{}, "foo"),
 			ba,
 		)
@@ -7240,7 +7240,7 @@ func TestReplicaEvaluationNotTxnMutation(t *testing.T) {
 	ba.Add(&txnPut)
 	ba.Add(&txnPut)
 
-	batch, _, _, _, pErr := tc.repl.executeWriteBatch(ctx, makeIDKey(), ba, nil)
+	batch, _, _, _, pErr := tc.repl.evaluateTxnWriteBatch(ctx, makeIDKey(), ba, nil)
 	defer batch.Close()
 	if pErr != nil {
 		t.Fatal(pErr)

--- a/pkg/storage/track_raft_protos.go
+++ b/pkg/storage/track_raft_protos.go
@@ -34,7 +34,7 @@ import (
 // instrumentation and returns the list of downstream-of-raft protos.
 func TrackRaftProtos() func() []reflect.Type {
 	// Grab the name of the function that roots all raft operations.
-	applyRaftFunc := runtime.FuncForPC(reflect.ValueOf(executeBatch).Pointer()).Name()
+	applyRaftFunc := runtime.FuncForPC(reflect.ValueOf(evaluateBatch).Pointer()).Name()
 	// Some raft operations trigger gossip, but we don't care about proto
 	// serialization in gossip, so we're going to ignore it.
 	addInfoFunc := runtime.FuncForPC(reflect.ValueOf((*gossip.Gossip).AddInfoProto).Pointer()).Name()


### PR DESCRIPTION
The functions and methods involved in processing a request have become
confusing, expecially the evaluateProposal -> applyRaftCommandInBatch
-> executeBatch chain, which uses three different verbs and uses the
word "batch" in two different senses (applyRaftCommandInBatch refers
to a rocksdb batch while executeBatch refers to a
roachpb.BatchRequest). Additionally, applyRaftCommandInBatch is now
far removed from applyRaftCommand, abbreviations are used
inconsistently.

This commit renames methods according to the following principles:
- Use the verb "evaluate" consistently for any function which is
  executed at a different time depending on the propEvalKV setting.
  The verb "execute" is now used for the top-level children of Send.
- "Batch" now always refers to BatchRequests. "Command" is used for
  the elements of a batch (except for "RaftCommand", which I've left
  alone for now).
- Avoid abbreviations (I could go either way on this as long as it's
  consistent).

Summary of the renamed methods in the context of the call tree:

```
Replica.Send                             Replica.Send
  add{ReadOnly,Write,Admin}Cmd             execute{ReadOnly,Write,Admin}Batch

addReadOnlyCmd                           executeReadOnlyBatch
  executeBatch                             evaluateBatch
    executeCmd                               evaluateCommand

addWriteCmd                              executeWriteBatch
  tryAddWriteCmd                           tryExecuteWriteBatch
    propose                                  propose
      requestToProposal                        requestToProposal
        if propEvalKV: evaluateProposal          evaluateProposal

evaluateProposal                         evaluateProposal
  applyRaftCommandInBatch                  evaluateProposalInner
    executeWriteBatch                        evaluteTxnWriteBatch
      executeBatch                             evaluateBatch
        executeCmd                               evaluateCommand

processRaftCommand                       processRaftCommand
  if !propEvalKV: evaluateProposal         evaluateProposal
  applyRaftCommand                         applyRaftCommand
```

All non-comment changes in this commit were made with gorename.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14537)
<!-- Reviewable:end -->
