### PR TITLE
engine: Make Iterator.Valid interface less error-prone

### DIFF
--- a/pkg/ccl/storageccl/engineccl/multi_iterator.go
+++ b/pkg/ccl/storageccl/engineccl/multi_iterator.go
@@ -113,11 +113,10 @@ func (f *MultiIterator) advance() {
 		// If this iterator is exhausted skip it (or error if it's errored).
 		// TODO(dan): Iterators that are exhausted could be removed to save
 		// having to check them on all future calls to advance.
-		if !iter.Valid() {
-			if err := iter.Error(); err != nil {
-				f.err = err
-				return
-			}
+		if ok, err := iter.Valid(); err != nil {
+			f.err = err
+			return
+		} else if !ok {
 			continue
 		}
 

--- a/pkg/ccl/storageccl/engineccl/mvcc.go
+++ b/pkg/ccl/storageccl/engineccl/mvcc.go
@@ -77,8 +77,8 @@ func (i *MVCCIncrementalIterator) Next() {
 		if !i.valid {
 			return
 		}
-		if !i.iter.Valid() {
-			i.err = i.iter.Error()
+		if ok, err := i.iter.Valid(); !ok {
+			i.err = err
 			i.valid = false
 			return
 		}

--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -73,11 +73,13 @@ func slurpSSTablesLatestKey(
 	var kvs []engine.MVCCKeyValue
 	it := batch.NewIterator(false)
 	defer it.Close()
-	for it.Seek(start); it.Valid() && it.UnsafeKey().Less(end); it.NextKey() {
+	for it.Seek(start); ; it.NextKey() {
+		if ok, err := it.Valid(); err != nil {
+			return nil, err
+		} else if !ok || !it.UnsafeKey().Less(end) {
+			break
+		}
 		kvs = append(kvs, engine.MVCCKeyValue{Key: it.Key(), Value: it.Value()})
-	}
-	if err := it.Error(); err != nil {
-		return nil, err
 	}
 	return kvs, nil
 }

--- a/pkg/ccl/storageccl/writebatch.go
+++ b/pkg/ccl/storageccl/writebatch.go
@@ -75,7 +75,9 @@ func evalWriteBatch(
 	iter := batch.NewIterator(false)
 	defer iter.Close()
 	iter.Seek(mvccStartKey)
-	if iter.Valid() && iter.Key().Less(mvccEndKey) {
+	if ok, err := iter.Valid(); err != nil {
+		return storage.EvalResult{}, err
+	} else if ok && iter.Key().Less(mvccEndKey) {
 		existingStats, err := iter.ComputeStats(mvccStartKey, mvccEndKey, h.Timestamp.WallTime)
 		if err != nil {
 			return storage.EvalResult{}, err

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -179,7 +179,12 @@ func runDebugRangeData(cmd *cobra.Command, args []string) error {
 	}
 
 	iter := storage.NewReplicaDataIterator(&desc, db, debugCtx.replicated)
-	for ; iter.Valid(); iter.Next() {
+	for ; ; iter.Next() {
+		if ok, err := iter.Valid(); err != nil {
+			return err
+		} else if !ok {
+			break
+		}
 		if _, err := printKeyValue(engine.MVCCKeyValue{
 			Key:   iter.Key(),
 			Value: iter.Value(),
@@ -187,7 +192,7 @@ func runDebugRangeData(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	return iter.Error()
+	return nil
 }
 
 var debugRangeDescriptorsCmd = &cobra.Command{

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -253,7 +253,13 @@ func TestStoreRangeSplitIntents(t *testing.T) {
 	iter := store.Engine().NewIterator(false)
 
 	defer iter.Close()
-	for iter.Seek(start); iter.Valid() && iter.Less(end); iter.Next() {
+	for iter.Seek(start); ; iter.Next() {
+		if ok, err := iter.Valid(); err != nil {
+			t.Fatal(err)
+		} else if !ok || !iter.Less(end) {
+			break
+		}
+
 		if bytes.HasPrefix([]byte(iter.Key().Key), txnPrefix(roachpb.KeyMin)) ||
 			bytes.HasPrefix([]byte(iter.Key().Key), txnPrefix(splitKey)) {
 			t.Errorf("unexpected system key: %s; txn record should have been cleaned up", iter.Key())

--- a/pkg/storage/engine/batch_test.go
+++ b/pkg/storage/engine/batch_test.go
@@ -767,8 +767,8 @@ func TestBatchDistinct(t *testing.T) {
 	// batch.
 	iter := distinct.NewIterator(false)
 	iter.Seek(mvccKey("a"))
-	if !iter.Valid() {
-		t.Fatalf("expected iterator to be valid")
+	if ok, err := iter.Valid(); !ok {
+		t.Fatalf("expected iterator to be valid; err=%v", err)
 	}
 	if string(iter.Key().Key) != "a" {
 		t.Fatalf("expected a, but got %s", iter.Key())
@@ -818,8 +818,8 @@ func TestWriteOnlyBatchDistinct(t *testing.T) {
 	// to the write-only batch.
 	iter := distinct.NewIterator(false)
 	iter.Seek(mvccKey("a"))
-	if !iter.Valid() {
-		t.Fatalf("expected iterator to be valid")
+	if ok, err := iter.Valid(); !ok {
+		t.Fatalf("expected iterator to be valid, err=%v", err)
 	}
 	if string(iter.Key().Key) != "b" {
 		t.Fatalf("expected b, but got %s", iter.Key())
@@ -906,8 +906,8 @@ func TestBatchIteration(t *testing.T) {
 
 	// Forward iteration
 	iter.Seek(k1)
-	if !iter.Valid() {
-		t.Fatal(iter.Error())
+	if ok, err := iter.Valid(); !ok {
+		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(iter.Key(), k1) {
 		t.Fatalf("expected %s, got %s", k1, iter.Key())
@@ -916,8 +916,8 @@ func TestBatchIteration(t *testing.T) {
 		t.Fatalf("expected %s, got %s", v1, iter.Value())
 	}
 	iter.Next()
-	if !iter.Valid() {
-		t.Fatal(iter.Error())
+	if ok, err := iter.Valid(); !ok {
+		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(iter.Key(), k2) {
 		t.Fatalf("expected %s, got %s", k2, iter.Key())
@@ -926,14 +926,16 @@ func TestBatchIteration(t *testing.T) {
 		t.Fatalf("expected %s, got %s", v2, iter.Value())
 	}
 	iter.Next()
-	if iter.Valid() {
+	if ok, err := iter.Valid(); err != nil {
+		t.Fatal(err)
+	} else if ok {
 		t.Fatalf("expected invalid, got valid at key %s", iter.Key())
 	}
 
 	// SeekReverse works, but reverse iteration is not supported.
 	iter.SeekReverse(k2)
-	if !iter.Valid() {
-		t.Fatal(iter.Error())
+	if ok, err := iter.Valid(); !ok {
+		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(iter.Key(), k2) {
 		t.Fatalf("expected %s, got %s", k2, iter.Key())
@@ -942,11 +944,10 @@ func TestBatchIteration(t *testing.T) {
 		t.Fatalf("expected %s, got %s", v2, iter.Value())
 	}
 	iter.Prev()
-	if iter.Valid() {
+	if ok, err := iter.Valid(); ok {
 		t.Fatalf("expected invalid, got valid at key %s", iter.Key())
-	}
-	if !testutils.IsError(iter.Error(), "Prev\\(\\) not supported") {
-		t.Fatalf("expected 'Prev() not supported', got %s", iter.Error())
+	} else if !testutils.IsError(err, "Prev\\(\\) not supported") {
+		t.Fatalf("expected 'Prev() not supported', got %s", err)
 	}
 }
 

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -38,10 +38,14 @@ type Iterator interface {
 	// SeekReverse advances the iterator to the first key in the engine which
 	// is <= the provided key.
 	SeekReverse(key MVCCKey)
-	// Valid returns true if the iterator is currently valid. An iterator that
-	// hasn't had Seek called on it or has gone past the end of the key range
-	// is invalid.
-	Valid() bool
+	// Valid must be called after any call to Seek(), Next(), Prev(), or
+	// similar methods. It returns (true, nil) if the iterator points to
+	// a valid key (it is undefined to call Key(), Value(), or similar
+	// methods unless Valid() has returned (true, nil)). It returns
+	// (false, nil) if the iterator has moved past the end of the valid
+	// range, or (false, err) if an error has occurred. Valid() will
+	// never return true with a non-nil error.
+	Valid() (bool, error)
 	// Next advances the iterator to the next key/value in the
 	// iteration. After this call, Valid() will be true if the
 	// iterator was not positioned at the last key.
@@ -76,8 +80,6 @@ type Iterator interface {
 	// Less returns true if the key the iterator is currently positioned at is
 	// less than the specified key.
 	Less(key MVCCKey) bool
-	// Error returns the error, if any, which the iterator encountered.
-	Error() error
 	// ComputeStats scans the underlying engine from start to end keys and
 	// computes stats counters based on the values. This method is used after a
 	// range is split to recompute stats for each subrange. The start key is

--- a/pkg/storage/engine/engine_test.go
+++ b/pkg/storage/engine/engine_test.go
@@ -152,7 +152,9 @@ func TestEngineBatchStaleCachedIterator(t *testing.T) {
 			// Iterator should not reuse its cached result.
 			iter.Seek(key)
 
-			if iter.Valid() {
+			if ok, err := iter.Valid(); err != nil {
+				t.Fatal(err)
+			} else if ok {
 				t.Fatalf("iterator unexpectedly valid: %v -> %v",
 					iter.UnsafeKey(), iter.UnsafeValue())
 			}
@@ -299,9 +301,9 @@ func TestEngineBatch(t *testing.T) {
 			// Try using an iterator to get the value from the batch.
 			iter := b.NewIterator(false)
 			iter.Seek(key)
-			if !iter.Valid() {
+			if ok, err := iter.Valid(); !ok {
 				if currentBatch[len(currentBatch)-1].value != nil {
-					t.Errorf("%d: batch seek invalid", i)
+					t.Errorf("%d: batch seek invalid, err=%v", i, err)
 				}
 			} else if !iter.Key().Equal(key) {
 				t.Errorf("%d: batch seek expected key %s, but got %s", i, key, iter.Key())
@@ -763,7 +765,9 @@ func TestSnapshotMethods(t *testing.T) {
 		// Verify NewIterator still iterates over original snapshot.
 		iter := snap.NewIterator(false)
 		iter.Seek(newKey)
-		if iter.Valid() {
+		if ok, err := iter.Valid(); err != nil {
+			t.Fatal(err)
+		} else if ok {
 			t.Error("expected invalid iterator when seeking to element which shouldn't be visible to snapshot")
 		}
 		iter.Close()

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -622,8 +622,8 @@ func mvccGetMetadata(
 		return false, 0, 0, nil
 	}
 	iter.Seek(metaKey)
-	if !iter.Valid() {
-		return false, 0, 0, nil
+	if ok, err := iter.Valid(); !ok {
+		return false, 0, 0, err
 	}
 
 	unsafeKey := iter.UnsafeKey()
@@ -765,10 +765,9 @@ func mvccGetInternal(
 	}
 
 	iter.Seek(seekKey)
-	if !iter.Valid() {
-		if err := iter.Error(); err != nil {
-			return nil, nil, safeValue, err
-		}
+	if ok, err := iter.Valid(); err != nil {
+		return nil, nil, safeValue, err
+	} else if !ok {
 		return nil, ignoredIntents, safeValue, nil
 	}
 
@@ -1430,7 +1429,8 @@ func MVCCDeleteRange(
 func getScanMeta(iter Iterator, encEndKey MVCCKey, meta *enginepb.MVCCMetadata) (MVCCKey, error) {
 	metaKey := iter.UnsafeKey()
 	if !metaKey.Less(encEndKey) {
-		return NilKey, iter.Error()
+		_, err := iter.Valid()
+		return NilKey, err
 	}
 	if metaKey.IsValue() {
 		meta.Reset()
@@ -1459,7 +1459,8 @@ func getReverseScanMeta(
 	metaKey := iter.UnsafeKey()
 	// The metaKey < encEndKey is exceeding the boundary.
 	if metaKey.Less(encEndKey) {
-		return NilKey, iter.Error()
+		_, err := iter.Valid()
+		return NilKey, err
 	}
 
 	// If this isn't the meta key yet, scan again to get the meta key.
@@ -1471,8 +1472,8 @@ func getReverseScanMeta(
 		// The row with oldest version will be got by seeking reversely. We use the
 		// key of this row to get the MVCC metadata key.
 		iter.Seek(MakeMVCCMetadataKey(metaKey.Key))
-		if !iter.Valid() {
-			return NilKey, iter.Error()
+		if ok, err := iter.Valid(); !ok {
+			return NilKey, err
 		}
 
 		meta.Reset()
@@ -1620,8 +1621,8 @@ func MVCCIterate(
 	// Seeking for the first defined position.
 	if reverse {
 		iter.SeekReverse(encKey)
-		if !iter.Valid() {
-			return nil, iter.Error()
+		if ok, err := iter.Valid(); !ok {
+			return nil, err
 		}
 
 		// If the key doesn't exist, the iterator is at the next key that does
@@ -1634,8 +1635,8 @@ func MVCCIterate(
 		iter.Seek(encKey)
 	}
 
-	if !iter.Valid() {
-		return nil, iter.Error()
+	if ok, err := iter.Valid(); !ok {
+		return nil, err
 	}
 
 	// A slice to gather all encountered intents we skipped, in case of
@@ -1691,7 +1692,9 @@ func MVCCIterate(
 		}
 
 		if reverse {
-			if iter.Valid() {
+			if ok, err := iter.Valid(); err != nil {
+				return nil, err
+			} else if ok {
 				if buf.meta.IsInline() {
 					// The current entry is an inline value. We can reach the previous
 					// entry using Prev() which is slightly faster than PrevKey().
@@ -1701,7 +1704,9 @@ func MVCCIterate(
 					// next key in which case we have to reset our position.
 					if !iter.UnsafeKey().Key.Equal(metaKey.Key) {
 						iter.Seek(metaKey)
-						if iter.Valid() {
+						if ok, err := iter.Valid(); err != nil {
+							return nil, err
+						} else if ok {
 							iter.Prev()
 						}
 					} else {
@@ -1710,7 +1715,9 @@ func MVCCIterate(
 				}
 			}
 		} else {
-			if iter.Valid() {
+			if ok, err := iter.Valid(); err != nil {
+				return nil, err
+			} else if ok {
 				if buf.meta.IsInline() {
 					// The current entry is an inline value. We can reach the next entry
 					// using Next() which is slightly faster than NextKey().
@@ -1727,10 +1734,9 @@ func MVCCIterate(
 			}
 		}
 
-		if !iter.Valid() {
-			if err := iter.Error(); err != nil {
-				return nil, err
-			}
+		if ok, err := iter.Valid(); err != nil {
+			return nil, err
+		} else if !ok {
 			break
 		}
 	}
@@ -1936,7 +1942,9 @@ func mvccResolveWriteIntent(
 	iter.Seek(nextKey)
 
 	// If there is no other version, we should just clean up the key entirely.
-	if !iter.Valid() || !iter.UnsafeKey().Key.Equal(intent.Key) {
+	if ok, err := iter.Valid(); err != nil {
+		return err
+	} else if !ok || !iter.UnsafeKey().Key.Equal(intent.Key) {
 		if err = engine.Clear(metaKey); err != nil {
 			return err
 		}
@@ -2031,7 +2039,9 @@ func MVCCResolveWriteIntentRangeUsingIter(
 
 	for num < max {
 		iterAndBuf.iter.Seek(nextKey)
-		if !iterAndBuf.iter.Valid() || !iterAndBuf.iter.UnsafeKey().Less(encEndKey) {
+		if ok, err := iterAndBuf.iter.Valid(); err != nil {
+			return 0, err
+		} else if !ok || !iterAndBuf.iter.UnsafeKey().Less(encEndKey) {
 			// No more keys exists in the given range.
 			break
 		}
@@ -2121,7 +2131,12 @@ func MVCCGarbageCollect(
 		}
 
 		// Now, iterate through all values, GC'ing ones which have expired.
-		for ; iter.Valid(); iter.Next() {
+		for ; ; iter.Next() {
+			if ok, err := iter.Valid(); err != nil {
+				return err
+			} else if !ok {
+				break
+			}
 			unsafeIterKey := iter.UnsafeKey()
 			if !unsafeIterKey.Key.Equal(encKey.Key) {
 				break

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -885,7 +885,7 @@ func (r *rocksDBBatchIterator) SeekReverse(key MVCCKey) {
 	r.iter.SeekReverse(key)
 }
 
-func (r *rocksDBBatchIterator) Valid() bool {
+func (r *rocksDBBatchIterator) Valid() (bool, error) {
 	return r.iter.Valid()
 }
 
@@ -934,10 +934,6 @@ func (r *rocksDBBatchIterator) UnsafeKey() MVCCKey {
 
 func (r *rocksDBBatchIterator) UnsafeValue() []byte {
 	return r.iter.UnsafeValue()
-}
-
-func (r *rocksDBBatchIterator) Error() error {
-	return r.iter.Error()
 }
 
 func (r *rocksDBBatchIterator) Less(key MVCCKey) bool {
@@ -1347,10 +1343,10 @@ func (r *rocksDBIterator) SeekReverse(key MVCCKey) {
 		}
 		r.setState(C.DBIterSeek(r.iter, goToCKey(key)))
 		// Maybe the key sorts after the last key in RocksDB.
-		if !r.Valid() {
+		if ok, _ := r.Valid(); !ok {
 			r.setState(C.DBIterSeekToLast(r.iter))
 		}
-		if !r.Valid() {
+		if ok, _ := r.Valid(); !ok {
 			return
 		}
 		// Make sure the current key is <= the provided key.
@@ -1360,8 +1356,8 @@ func (r *rocksDBIterator) SeekReverse(key MVCCKey) {
 	}
 }
 
-func (r *rocksDBIterator) Valid() bool {
-	return r.valid
+func (r *rocksDBIterator) Valid() (bool, error) {
+	return r.valid, statusToError(C.DBIterError(r.iter))
 }
 
 func (r *rocksDBIterator) Next() {
@@ -1408,10 +1404,6 @@ func (r *rocksDBIterator) UnsafeKey() MVCCKey {
 
 func (r *rocksDBIterator) UnsafeValue() []byte {
 	return cSliceToUnsafeGoBytes(r.value)
-}
-
-func (r *rocksDBIterator) Error() error {
-	return statusToError(C.DBIterError(r.iter))
 }
 
 func (r *rocksDBIterator) Less(key MVCCKey) bool {
@@ -1663,7 +1655,12 @@ func dbIterate(
 	defer it.Close()
 
 	it.Seek(start)
-	for ; it.Valid(); it.Next() {
+	for ; ; it.Next() {
+		if ok, err := it.Valid(); err != nil {
+			return err
+		} else if !ok {
+			break
+		}
 		k := it.Key()
 		if !k.Less(end) {
 			break
@@ -1672,8 +1669,7 @@ func dbIterate(
 			return err
 		}
 	}
-	// Check for any errors during iteration.
-	return it.Error()
+	return nil
 }
 
 // TODO(dan): Rename this to RocksDBSSTFileReader and RocksDBSSTFileWriter.

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -66,13 +66,18 @@ func TestBatchIterReadOwnWrite(t *testing.T) {
 	after := b.NewIterator(true /* prefix */)
 	defer after.Close()
 
-	if after.Seek(k); !after.Valid() {
-		t.Fatal("write missing on batch iter created after write")
+	after.Seek(k)
+	if ok, err := after.Valid(); !ok {
+		t.Fatalf("write missing on batch iter created after write, err=%v", err)
 	}
-	if before.Seek(k); !before.Valid() {
-		t.Fatal("write missing on batch iter created before write")
+	before.Seek(k)
+	if ok, err := before.Valid(); !ok {
+		t.Fatalf("write missing on batch iter created before write, err=%v", err)
 	}
-	if nonBatchBefore.Seek(k); nonBatchBefore.Valid() {
+	nonBatchBefore.Seek(k)
+	if ok, err := nonBatchBefore.Valid(); err != nil {
+		t.Fatal(err)
+	} else if ok {
 		t.Fatal("uncommitted write seen by non-batch iter")
 	}
 
@@ -83,11 +88,15 @@ func TestBatchIterReadOwnWrite(t *testing.T) {
 	nonBatchAfter := db.NewIterator(false)
 	defer nonBatchAfter.Close()
 
-	if nonBatchBefore.Seek(k); nonBatchBefore.Valid() {
+	nonBatchBefore.Seek(k)
+	if ok, err := nonBatchBefore.Valid(); err != nil {
+		t.Fatal(err)
+	} else if ok {
 		t.Fatal("committed write seen by non-batch iter created before commit")
 	}
-	if nonBatchAfter.Seek(k); !nonBatchAfter.Valid() {
-		t.Fatal("committed write missing by non-batch iter created after commit")
+	nonBatchAfter.Seek(k)
+	if ok, err := nonBatchAfter.Valid(); !ok {
+		t.Fatalf("committed write missing by non-batch iter created after commit, err=%v", err)
 	}
 
 	// `Commit` frees the batch, so iterators backed by it should panic.
@@ -129,10 +138,14 @@ func TestBatchPrefixIter(t *testing.T) {
 	iter := b.NewIterator(true /* prefix */)
 	defer iter.Close()
 
-	if iter.Seek(mvccKey("b")); !iter.Valid() {
-		t.Fatalf("expected to find \"b\"")
+	iter.Seek(mvccKey("b"))
+	if ok, err := iter.Valid(); !ok {
+		t.Fatalf("expected to find \"b\", err=%v", err)
 	}
-	if iter.Seek(mvccKey("a")); iter.Valid() {
+	iter.Seek(mvccKey("a"))
+	if ok, err := iter.Valid(); err != nil {
+		t.Fatal(err)
+	} else if ok {
 		t.Fatalf("expected to not find anything, found %s -> %q", iter.Key(), iter.Value())
 	}
 }

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -541,7 +541,12 @@ func RunGC(
 	}
 
 	// Iterate through the keys and values of this replica's range.
-	for ; iter.Valid(); iter.Next() {
+	for ; ; iter.Next() {
+		if ok, err := iter.Valid(); err != nil {
+			return nil, GCInfo{}, err
+		} else if !ok {
+			break
+		}
 		iterKey := iter.Key()
 		if !iterKey.IsValue() || !iterKey.Key.Equal(expBaseKey) {
 			// Moving to the next key (& values).
@@ -561,9 +566,6 @@ func RunGC(
 		}
 		keys = append(keys, iter.Key())
 		vals = append(vals, iter.Value())
-	}
-	if iter.Error() != nil {
-		return nil, GCInfo{}, iter.Error()
 	}
 	// Handle last collected set of keys/vals.
 	processKeysAndValues()

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4307,7 +4307,12 @@ func optimizePuts(
 	// Find the first non-empty key in the run.
 	iter.Seek(engine.MakeMVCCMetadataKey(minKey))
 	var iterKey roachpb.Key
-	if iter.Valid() && bytes.Compare(iter.Key().Key, maxKey) <= 0 {
+	if ok, err := iter.Valid(); err != nil {
+		// TODO(bdarnell): return an error here instead of silently
+		// running without the optimization?
+		log.Errorf(context.TODO(), "Seek returned error; disabling blind-put optimization: %s", err)
+		return origReqs
+	} else if ok && bytes.Compare(iter.Key().Key, maxKey) <= 0 {
 		iterKey = iter.Key().Key
 	}
 	// Set the prefix of the run which is being written to virgin

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -2244,7 +2244,12 @@ func (r *Replica) sha512(
 	iter := NewReplicaDataIterator(&desc, snap, true /* replicatedOnly */)
 	defer iter.Close()
 
-	for ; iter.Valid(); iter.Next() {
+	for ; ; iter.Next() {
+		if ok, err := iter.Valid(); err != nil {
+			return nil, err
+		} else if !ok {
+			break
+		}
 		key := iter.Key()
 		if key.Equal(tombstoneKey) {
 			// Skip the tombstone key which is marked as replicated even though it

--- a/pkg/storage/replica_data_iter.go
+++ b/pkg/storage/replica_data_iter.go
@@ -115,7 +115,7 @@ func (ri *ReplicaDataIterator) Next() {
 // invalid.
 func (ri *ReplicaDataIterator) advance() {
 	for {
-		if !ri.Valid() || ri.iterator.Less(ri.ranges[ri.curIndex].end) {
+		if ok, _ := ri.Valid(); !ok || ri.iterator.Less(ri.ranges[ri.curIndex].end) {
 			return
 		}
 		ri.curIndex++
@@ -130,7 +130,7 @@ func (ri *ReplicaDataIterator) advance() {
 }
 
 // Valid returns true if the iterator currently points to a valid value.
-func (ri *ReplicaDataIterator) Valid() bool {
+func (ri *ReplicaDataIterator) Valid() (bool, error) {
 	return ri.iterator.Valid()
 }
 
@@ -142,11 +142,6 @@ func (ri *ReplicaDataIterator) Key() engine.MVCCKey {
 // Value returns the current value.
 func (ri *ReplicaDataIterator) Value() []byte {
 	return ri.iterator.Value()
-}
-
-// Error returns the error, if any, which the iterator encountered.
-func (ri *ReplicaDataIterator) Error() error {
-	return ri.iterator.Error()
 }
 
 // allocIterKeyValue returns ri.Key() and ri.Value() with the underlying

--- a/pkg/storage/span_set.go
+++ b/pkg/storage/span_set.go
@@ -155,8 +155,15 @@ func (s *SpanSetIterator) SeekReverse(key engine.MVCCKey) {
 }
 
 // Valid implements engine.Iterator.
-func (s *SpanSetIterator) Valid() bool {
-	return !s.invalid && s.err == nil && s.i.Valid()
+func (s *SpanSetIterator) Valid() (bool, error) {
+	if s.err != nil {
+		return false, s.err
+	}
+	ok, err := s.i.Valid()
+	if err != nil {
+		return false, s.err
+	}
+	return ok && !s.invalid, nil
 }
 
 // Next implements engine.Iterator.
@@ -219,14 +226,6 @@ func (s *SpanSetIterator) UnsafeValue() []byte {
 // Less implements engine.Iterator.
 func (s *SpanSetIterator) Less(key engine.MVCCKey) bool {
 	return s.i.Less(key)
-}
-
-// Error implements engine.Iterator.
-func (s *SpanSetIterator) Error() error {
-	if s.err != nil {
-		return s.err
-	}
-	return s.i.Error()
 }
 
 // ComputeStats implements engine.Iterator.

--- a/pkg/storage/span_set_test.go
+++ b/pkg/storage/span_set_test.go
@@ -231,32 +231,31 @@ func TestSpanSetBatch(t *testing.T) {
 
 		// Iterators check boundaries on seek and next/prev
 		iter.Seek(outsideKey)
-		if iter.Valid() {
-			t.Fatalf("expected invalid iterator; found valid at key %s", iter.Key())
+		if _, err := iter.Valid(); !isReadSpanErr(err) {
+			t.Fatalf("Seek: unexpected error %v", err)
 		}
 		// Seeking back in bounds restores validity.
 		iter.Seek(insideKey)
-		if !iter.Valid() {
-			t.Fatalf("expected valid iterator")
+		if ok, err := iter.Valid(); !ok {
+			t.Fatalf("expected valid iterator, err=%v", err)
 		}
 		if !reflect.DeepEqual(iter.Key(), insideKey) {
 			t.Fatalf("expected key %s, got %s", insideKey, iter.Key())
 		}
 		iter.Next()
-		if !iter.Valid() {
-			t.Fatalf("expected valid iterator")
+		if ok, err := iter.Valid(); !ok {
+			t.Fatalf("expected valid iterator, err=%v", err)
 		}
 		if !reflect.DeepEqual(iter.Key(), insideKey2) {
 			t.Fatalf("expected key %s, got %s", insideKey2, iter.Key())
 		}
 		// Scan out of bounds.
 		iter.Next()
-		if iter.Valid() {
+		if ok, err := iter.Valid(); ok {
 			t.Fatalf("expected invalid iterator; found valid at key %s", iter.Key())
-		}
-		// Scanning out of bounds sets Valid() to false but is not an error.
-		if iter.Error() != nil {
-			t.Errorf("unexpected error on iterator: %s", iter.Error())
+		} else if err != nil {
+			// Scanning out of bounds sets Valid() to false but is not an error.
+			t.Errorf("unexpected error on iterator: %s", err)
 		}
 	}()
 
@@ -269,35 +268,34 @@ func TestSpanSetBatch(t *testing.T) {
 	iter := &SpanSetIterator{eng.NewIterator(false), &ss, nil, false}
 	defer iter.Close()
 	iter.SeekReverse(outsideKey)
-	if iter.Valid() {
-		t.Fatalf("expected invalid iterator; found valid at key %s", iter.Key())
+	if _, err := iter.Valid(); !isReadSpanErr(err) {
+		t.Fatalf("SeekReverse: unexpected error %v", err)
 	}
 	// Seeking back in bounds restores validity.
 	iter.SeekReverse(insideKey2)
-	if !iter.Valid() {
-		t.Fatalf("expected valid iterator")
+	if ok, err := iter.Valid(); !ok {
+		t.Fatalf("expected valid iterator, err=%v", err)
 	}
 	if !reflect.DeepEqual(iter.Key(), insideKey2) {
 		t.Fatalf("expected key %s, got %s", insideKey2, iter.Key())
 	}
 	iter.Prev()
-	if !iter.Valid() {
-		t.Fatalf("expected valid iterator")
+	if ok, err := iter.Valid(); !ok {
+		t.Fatalf("expected valid iterator, err=%v", err)
 	}
 	if !reflect.DeepEqual(iter.Key(), insideKey) {
 		t.Fatalf("expected key %s, got %s", insideKey, iter.Key())
 	}
 	// Scan out of bounds.
 	iter.Prev()
-	if iter.Valid() {
+	if ok, err := iter.Valid(); ok {
 		t.Fatalf("expected invalid iterator; found valid at key %s", iter.Key())
-	}
-	if iter.Error() != nil {
-		t.Errorf("unexpected error on iterator: %s", iter.Error())
+	} else if err != nil {
+		t.Errorf("unexpected error on iterator: %s", err)
 	}
 	// Seeking back in bounds restores validity.
 	iter.SeekReverse(insideKey)
-	if !iter.Valid() {
-		t.Fatalf("expected valid iterator")
+	if ok, err := iter.Valid(); !ok {
+		t.Fatalf("expected valid iterator, err=%v", err)
 	}
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3289,7 +3289,12 @@ func sendSnapshot(
 	const batchSize = 1 << 20
 	n := 0
 	var b engine.Batch
-	for ; snap.Iter.Valid(); snap.Iter.Next() {
+	for ; ; snap.Iter.Next() {
+		if ok, err := snap.Iter.Valid(); err != nil {
+			return err
+		} else if !ok {
+			break
+		}
 		var key engine.MVCCKey
 		var value []byte
 		alloc, key, value = snap.Iter.allocIterKeyValue(alloc)

--- a/pkg/ts/pruning.go
+++ b/pkg/ts/pruning.go
@@ -107,7 +107,12 @@ func findTimeSeries(
 
 	thresholds := computeThresholds(now.WallTime)
 
-	for iter.Seek(next); iter.Valid() && iter.Less(end); iter.Seek(next) {
+	for iter.Seek(next); ; iter.Seek(next) {
+		if ok, err := iter.Valid(); err != nil {
+			return nil, err
+		} else if !ok || !iter.Less(end) {
+			break
+		}
 		foundKey := iter.Key().Key
 
 		// Extract the name and resolution from the discovered key.


### PR DESCRIPTION
A false return valid from Iterator.Valid() could mean either "key not
found" or an error; callers must examine Iterator.Error() to
distinguish the two cases. However, many callers of Valid() did not
proceed to call Error(), leading to at least one bug (in
mvccGetMetadata).

Since there should be a one-to-one correspondence between calls to
Valid and calls to Error, this commit combines the two into a single
Valid() method that returns both a bool and an error. It's a little
more awkward to use in a for loop, but avoids the (common) mistake of
failing to check the error.

(We lack the testing/mocking infrastructure to easily test for the
mvccGetMetadata bug, but I have a change in another branch that fails
without this fix)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14549)
<!-- Reviewable:end -->
