### PR TITLE
sql: planVisitor should recurse into child nodes by default

### DIFF
--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -86,7 +86,7 @@ func (v *planVisitor) visit(plan planNode) {
 	}
 
 	name := nodeName(plan)
-	var recurse bool
+	recurse := true
 	if v.observer.enterNode != nil {
 		recurse = v.observer.enterNode(v.ctx, name, plan)
 	}


### PR DESCRIPTION
When working on a new `planObserver` to collect subquery spans
I noticed that it was never being called. I spent about an hour completely
baffled before realizing the default behavior when the optional
`enterNode` callback was not defined was incorrect. It turns out that
all other `planObservers` happened to define an `enterNode` callback,
which returns whether to continue the `planNode` tree recursion or
not. Because every other visitor needed to define this optional
function for their own reasons, the default behavior when it wasn't
defined was untested, and stopped recursion immediately, long before
reaching any `subquerys`.

Reviewed in #14471.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14550)
<!-- Reviewable:end -->
