### PR TITLE
util/interval: create RangeGroupsOverlap function

### DIFF
--- a/pkg/storage/command_queue.go
+++ b/pkg/storage/command_queue.go
@@ -214,15 +214,11 @@ func (cq *CommandQueue) getWait(
 
 	for i := 0; i < len(spans); i++ {
 		span := spans[i]
-		start, end := span.Key, span.EndKey
-		if end == nil {
+		if span.EndKey == nil {
 			panic(fmt.Sprintf("%d: unexpected nil EndKey: %s", i, span))
 		}
-		newCmdRange := interval.Range{
-			Start: interval.Comparable(start),
-			End:   interval.Comparable(end),
-		}
-		overlaps := cq.getOverlaps(readOnly, timestamp, newCmdRange.Start, newCmdRange.End)
+		newCmdRange := span.AsRange()
+		overlaps := cq.getOverlaps(readOnly, timestamp, newCmdRange)
 
 		// Check to see if any of the overlapping entries are "covering"
 		// entries. If we encounter a covering entry, we remove it from the
@@ -416,12 +412,8 @@ func (cq *CommandQueue) getWait(
 // getOverlaps returns a slice of values which overlap the specified
 // interval. The slice is only valid until the next call to GetOverlaps.
 func (cq *CommandQueue) getOverlaps(
-	readOnly bool, timestamp hlc.Timestamp, start, end []byte,
+	readOnly bool, timestamp hlc.Timestamp, rng interval.Range,
 ) []*cmd {
-	rng := interval.Range{
-		Start: interval.Comparable(start),
-		End:   interval.Comparable(end),
-	}
 	if !readOnly {
 		cq.reads.DoMatching(func(i interval.Interface) bool {
 			c := i.(*cmd)
@@ -515,6 +507,10 @@ func (cq *CommandQueue) add(readOnly bool, timestamp hlc.Timestamp, spans []roac
 			maxKey = end
 		}
 	}
+	coveringSpan := roachpb.Span{
+		Key:    minKey,
+		EndKey: maxKey,
+	}
 
 	if keys.IsLocal(minKey) != keys.IsLocal(maxKey) {
 		log.Fatalf(
@@ -533,10 +529,7 @@ func (cq *CommandQueue) add(readOnly bool, timestamp hlc.Timestamp, spans []roac
 	// Create the covering entry.
 	cmd := &cmds[0]
 	cmd.id = cq.nextID()
-	cmd.key = interval.Range{
-		Start: interval.Comparable(minKey),
-		End:   interval.Comparable(maxKey),
-	}
+	cmd.key = coveringSpan.AsRange()
 	cmd.readOnly = readOnly
 	cmd.timestamp = timestamp
 	cmd.expanded = false
@@ -547,10 +540,7 @@ func (cq *CommandQueue) add(readOnly bool, timestamp hlc.Timestamp, spans []roac
 		for i, span := range spans {
 			child := &cmd.children[i]
 			child.id = cq.nextID()
-			child.key = interval.Range{
-				Start: interval.Comparable(span.Key),
-				End:   interval.Comparable(span.EndKey),
-			}
+			child.key = span.AsRange()
 			child.readOnly = readOnly
 			child.timestamp = timestamp
 			child.expanded = true

--- a/pkg/util/interval/interval.go
+++ b/pkg/util/interval/interval.go
@@ -727,3 +727,32 @@ func (n *Node) doMatchReverse(fn Operation, r Range, overlaps func(Range, Range)
 	}
 	return
 }
+
+// TreeIterator iterates over all intervals stored in the Tree, in-order.
+type TreeIterator struct {
+	stack []*Node
+}
+
+// Next moves the iterator to the next Node in the Tree and returns the node's
+// Elem. The method returns false if no Nodes remain in the Tree.
+func (ti *TreeIterator) Next() (i Interface, ok bool) {
+	if len(ti.stack) == 0 {
+		return nil, false
+	}
+	n := ti.stack[len(ti.stack)-1]
+	ti.stack = ti.stack[:len(ti.stack)-1]
+	for r := n.Right; r != nil; r = r.Left {
+		ti.stack = append(ti.stack, r)
+	}
+	return n.Elem, true
+}
+
+// Iterator creates an iterator to iterate over all intervals stored in the
+// tree, in-order.
+func (t *Tree) Iterator() TreeIterator {
+	var ti TreeIterator
+	for n := t.Root; n != nil; n = n.Left {
+		ti.stack = append(ti.stack, n)
+	}
+	return ti
+}


### PR DESCRIPTION
This change adds a function to the interval package that checks if two
`RangeGroups` overlap. It does so efficiently by adding an `Iterator`
method to `RangeGroup`, so that an iterator can be created to walk through
the `Ranges` in a `RangeGroup`, in-order.

This new function will be used by a more intelligent `DependencyAnalyzer`
in the `sql` package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14552)
<!-- Reviewable:end -->
