### PR TITLE
sql: introduce spanBasedDependencyAnalyzer for parallel statement execution

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -472,13 +473,14 @@ func (n *alterTableNode) Start(ctx context.Context) error {
 	return nil
 }
 
-func (n *alterTableNode) Next(context.Context) (bool, error) { return false, nil }
-func (n *alterTableNode) Close(context.Context)              {}
-func (n *alterTableNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
-func (n *alterTableNode) Ordering() orderingInfo             { return orderingInfo{} }
-func (n *alterTableNode) Values() parser.Datums              { return parser.Datums{} }
-func (n *alterTableNode) DebugValues() debugValues           { return debugValues{} }
-func (n *alterTableNode) MarkDebug(mode explainMode)         {}
+func (n *alterTableNode) Next(context.Context) (bool, error)                  { return false, nil }
+func (n *alterTableNode) Close(context.Context)                               {}
+func (n *alterTableNode) Columns() ResultColumns                              { return make(ResultColumns, 0) }
+func (n *alterTableNode) Ordering() orderingInfo                              { return orderingInfo{} }
+func (n *alterTableNode) Values() parser.Datums                               { return parser.Datums{} }
+func (n *alterTableNode) DebugValues() debugValues                            { return debugValues{} }
+func (n *alterTableNode) MarkDebug(mode explainMode)                          {}
+func (n *alterTableNode) Spans(context.Context) (_, _ roachpb.Spans, _ error) { panic("unimplemented") }
 
 func applyColumnMutation(
 	col *sqlbase.ColumnDescriptor, mut parser.ColumnMutationCmd, searchPath parser.SearchPath,

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -25,6 +25,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 )
@@ -52,11 +53,12 @@ type copyNode struct {
 	rowsMemAcc    WrappableMemoryAccount
 }
 
-func (n *copyNode) Columns() ResultColumns           { return n.resultColumns }
-func (*copyNode) Ordering() orderingInfo             { return orderingInfo{} }
-func (*copyNode) Values() parser.Datums              { return nil }
-func (*copyNode) MarkDebug(_ explainMode)            {}
-func (*copyNode) Next(context.Context) (bool, error) { return false, nil }
+func (n *copyNode) Columns() ResultColumns                            { return n.resultColumns }
+func (*copyNode) Ordering() orderingInfo                              { return orderingInfo{} }
+func (*copyNode) Values() parser.Datums                               { return nil }
+func (*copyNode) MarkDebug(_ explainMode)                             {}
+func (*copyNode) Next(context.Context) (bool, error)                  { return false, nil }
+func (*copyNode) Spans(context.Context) (_, _ roachpb.Spans, _ error) { panic("unimplemented") }
 
 func (n *copyNode) Close(ctx context.Context) {
 	n.rowsMemAcc.Wsession(n.p.session).Close(ctx)

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -115,13 +116,17 @@ func (n *createDatabaseNode) Start(ctx context.Context) error {
 	return nil
 }
 
-func (n *createDatabaseNode) Next(context.Context) (bool, error) { return false, nil }
-func (n *createDatabaseNode) Close(context.Context)              {}
-func (n *createDatabaseNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
-func (n *createDatabaseNode) Ordering() orderingInfo             { return orderingInfo{} }
-func (n *createDatabaseNode) Values() parser.Datums              { return parser.Datums{} }
-func (n *createDatabaseNode) DebugValues() debugValues           { return debugValues{} }
-func (n *createDatabaseNode) MarkDebug(mode explainMode)         {}
+func (*createDatabaseNode) Next(context.Context) (bool, error) { return false, nil }
+func (*createDatabaseNode) Close(context.Context)              {}
+func (*createDatabaseNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
+func (*createDatabaseNode) Ordering() orderingInfo             { return orderingInfo{} }
+func (*createDatabaseNode) Values() parser.Datums              { return parser.Datums{} }
+func (*createDatabaseNode) DebugValues() debugValues           { return debugValues{} }
+func (*createDatabaseNode) MarkDebug(mode explainMode)         {}
+
+func (*createDatabaseNode) Spans(context.Context) (_, _ roachpb.Spans, _ error) {
+	panic("unimplemented")
+}
 
 type createIndexNode struct {
 	p         *planner
@@ -229,13 +234,17 @@ func (n *createIndexNode) Start(ctx context.Context) error {
 	return nil
 }
 
-func (n *createIndexNode) Next(context.Context) (bool, error) { return false, nil }
-func (n *createIndexNode) Close(context.Context)              {}
-func (n *createIndexNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
-func (n *createIndexNode) Ordering() orderingInfo             { return orderingInfo{} }
-func (n *createIndexNode) Values() parser.Datums              { return parser.Datums{} }
-func (n *createIndexNode) DebugValues() debugValues           { return debugValues{} }
-func (n *createIndexNode) MarkDebug(mode explainMode)         {}
+func (*createIndexNode) Next(context.Context) (bool, error) { return false, nil }
+func (*createIndexNode) Close(context.Context)              {}
+func (*createIndexNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
+func (*createIndexNode) Ordering() orderingInfo             { return orderingInfo{} }
+func (*createIndexNode) Values() parser.Datums              { return parser.Datums{} }
+func (*createIndexNode) DebugValues() debugValues           { return debugValues{} }
+func (*createIndexNode) MarkDebug(mode explainMode)         {}
+
+func (*createIndexNode) Spans(context.Context) (_, _ roachpb.Spans, _ error) {
+	panic("unimplemented")
+}
 
 type createUserNode struct {
 	p        *planner
@@ -332,13 +341,17 @@ func (n *createUserNode) Start(ctx context.Context) error {
 	return nil
 }
 
-func (n *createUserNode) Next(context.Context) (bool, error) { return false, nil }
-func (n *createUserNode) Close(context.Context)              {}
-func (n *createUserNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
-func (n *createUserNode) Ordering() orderingInfo             { return orderingInfo{} }
-func (n *createUserNode) Values() parser.Datums              { return parser.Datums{} }
-func (n *createUserNode) DebugValues() debugValues           { return debugValues{} }
-func (n *createUserNode) MarkDebug(mode explainMode)         {}
+func (*createUserNode) Next(context.Context) (bool, error) { return false, nil }
+func (*createUserNode) Close(context.Context)              {}
+func (*createUserNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
+func (*createUserNode) Ordering() orderingInfo             { return orderingInfo{} }
+func (*createUserNode) Values() parser.Datums              { return parser.Datums{} }
+func (*createUserNode) DebugValues() debugValues           { return debugValues{} }
+func (*createUserNode) MarkDebug(mode explainMode)         {}
+
+func (*createUserNode) Spans(context.Context) (_, _ roachpb.Spans, _ error) {
+	panic("unimplemented")
+}
 
 type createViewNode struct {
 	p           *planner
@@ -509,12 +522,16 @@ func (n *createViewNode) Close(ctx context.Context) {
 	n.p.avoidCachedDescriptors = false
 }
 
-func (n *createViewNode) Next(context.Context) (bool, error) { return false, nil }
-func (n *createViewNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
-func (n *createViewNode) Ordering() orderingInfo             { return orderingInfo{} }
-func (n *createViewNode) Values() parser.Datums              { return parser.Datums{} }
-func (n *createViewNode) DebugValues() debugValues           { return debugValues{} }
-func (n *createViewNode) MarkDebug(mode explainMode)         {}
+func (*createViewNode) Next(context.Context) (bool, error) { return false, nil }
+func (*createViewNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
+func (*createViewNode) Ordering() orderingInfo             { return orderingInfo{} }
+func (*createViewNode) Values() parser.Datums              { return parser.Datums{} }
+func (*createViewNode) DebugValues() debugValues           { return debugValues{} }
+func (*createViewNode) MarkDebug(mode explainMode)         {}
+
+func (*createViewNode) Spans(context.Context) (_, _ roachpb.Spans, _ error) {
+	panic("unimplemented")
+}
 
 type createTableNode struct {
 	p          *planner
@@ -742,12 +759,16 @@ func (n *createTableNode) Close(ctx context.Context) {
 	}
 }
 
-func (n *createTableNode) Next(context.Context) (bool, error) { return false, nil }
-func (n *createTableNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
-func (n *createTableNode) Ordering() orderingInfo             { return orderingInfo{} }
-func (n *createTableNode) Values() parser.Datums              { return parser.Datums{} }
-func (n *createTableNode) DebugValues() debugValues           { return debugValues{} }
-func (n *createTableNode) MarkDebug(mode explainMode)         {}
+func (*createTableNode) Next(context.Context) (bool, error) { return false, nil }
+func (*createTableNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
+func (*createTableNode) Ordering() orderingInfo             { return orderingInfo{} }
+func (*createTableNode) Values() parser.Datums              { return parser.Datums{} }
+func (*createTableNode) DebugValues() debugValues           { return debugValues{} }
+func (*createTableNode) MarkDebug(mode explainMode)         {}
+
+func (*createTableNode) Spans(context.Context) (_, _ roachpb.Spans, _ error) {
+	panic("unimplemented")
+}
 
 type indexMatch bool
 

--- a/pkg/sql/delayed.go
+++ b/pkg/sql/delayed.go
@@ -19,6 +19,7 @@ package sql
 import (
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 )
 
@@ -48,3 +49,6 @@ func (d *delayedNode) Start(ctx context.Context) error        { return d.plan.St
 func (d *delayedNode) Next(ctx context.Context) (bool, error) { return d.plan.Next(ctx) }
 func (d *delayedNode) Values() parser.Datums                  { return d.plan.Values() }
 func (d *delayedNode) DebugValues() debugValues               { return d.plan.DebugValues() }
+func (d *delayedNode) Spans(ctx context.Context) (_, _ roachpb.Spans, _ error) {
+	return d.plan.Spans(ctx)
+}

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -21,6 +21,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -96,7 +97,7 @@ func (p *planner) Delete(
 	}
 
 	if err := dn.run.initEditNode(
-		ctx, &dn.editNodeBase, rows, n.Returning, desiredTypes); err != nil {
+		ctx, &dn.editNodeBase, rows, &dn.tw, n.Returning, desiredTypes); err != nil {
 		return nil, err
 	}
 
@@ -104,7 +105,7 @@ func (p *planner) Delete(
 }
 
 func (d *deleteNode) Start(ctx context.Context) error {
-	if err := d.run.startEditNode(ctx, &d.editNodeBase, &d.tw); err != nil {
+	if err := d.run.startEditNode(ctx, &d.editNodeBase); err != nil {
 		return err
 	}
 
@@ -235,3 +236,7 @@ func (d *deleteNode) DebugValues() debugValues {
 }
 
 func (d *deleteNode) Ordering() orderingInfo { return orderingInfo{} }
+
+func (d *deleteNode) Spans(ctx context.Context) (reads, writes roachpb.Spans, err error) {
+	return d.run.collectSpans(ctx)
+}

--- a/pkg/sql/distinct.go
+++ b/pkg/sql/distinct.go
@@ -22,6 +22,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
@@ -65,6 +66,10 @@ func (n *distinctNode) Start(ctx context.Context) error {
 func (n *distinctNode) Columns() ResultColumns { return n.plan.Columns() }
 func (n *distinctNode) Values() parser.Datums  { return n.plan.Values() }
 func (n *distinctNode) Ordering() orderingInfo { return n.plan.Ordering() }
+
+func (n *distinctNode) Spans(ctx context.Context) (_, _ roachpb.Spans, _ error) {
+	return n.plan.Spans(ctx)
+}
 
 func (n *distinctNode) MarkDebug(mode explainMode) {
 	if mode != explainDebug {

--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -208,13 +208,17 @@ func (n *dropDatabaseNode) Start(ctx context.Context) error {
 	return nil
 }
 
-func (n *dropDatabaseNode) Next(context.Context) (bool, error) { return false, nil }
-func (n *dropDatabaseNode) Close(context.Context)              {}
-func (n *dropDatabaseNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
-func (n *dropDatabaseNode) Ordering() orderingInfo             { return orderingInfo{} }
-func (n *dropDatabaseNode) Values() parser.Datums              { return parser.Datums{} }
-func (n *dropDatabaseNode) DebugValues() debugValues           { return debugValues{} }
-func (n *dropDatabaseNode) MarkDebug(mode explainMode)         {}
+func (*dropDatabaseNode) Next(context.Context) (bool, error) { return false, nil }
+func (*dropDatabaseNode) Close(context.Context)              {}
+func (*dropDatabaseNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
+func (*dropDatabaseNode) Ordering() orderingInfo             { return orderingInfo{} }
+func (*dropDatabaseNode) Values() parser.Datums              { return parser.Datums{} }
+func (*dropDatabaseNode) DebugValues() debugValues           { return debugValues{} }
+func (*dropDatabaseNode) MarkDebug(mode explainMode)         {}
+
+func (*dropDatabaseNode) Spans(context.Context) (_, _ roachpb.Spans, _ error) {
+	panic("unimplemented")
+}
 
 type dropIndexNode struct {
 	p        *planner
@@ -400,13 +404,17 @@ func (p *planner) dropIndexByName(
 	return nil
 }
 
-func (n *dropIndexNode) Next(context.Context) (bool, error) { return false, nil }
-func (n *dropIndexNode) Close(context.Context)              {}
-func (n *dropIndexNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
-func (n *dropIndexNode) Ordering() orderingInfo             { return orderingInfo{} }
-func (n *dropIndexNode) Values() parser.Datums              { return parser.Datums{} }
-func (n *dropIndexNode) DebugValues() debugValues           { return debugValues{} }
-func (n *dropIndexNode) MarkDebug(mode explainMode)         {}
+func (*dropIndexNode) Next(context.Context) (bool, error) { return false, nil }
+func (*dropIndexNode) Close(context.Context)              {}
+func (*dropIndexNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
+func (*dropIndexNode) Ordering() orderingInfo             { return orderingInfo{} }
+func (*dropIndexNode) Values() parser.Datums              { return parser.Datums{} }
+func (*dropIndexNode) DebugValues() debugValues           { return debugValues{} }
+func (*dropIndexNode) MarkDebug(mode explainMode)         {}
+
+func (*dropIndexNode) Spans(context.Context) (_, _ roachpb.Spans, _ error) {
+	panic("unimplemented")
+}
 
 type dropViewNode struct {
 	p  *planner
@@ -509,13 +517,17 @@ func (n *dropViewNode) Start(ctx context.Context) error {
 	return nil
 }
 
-func (n *dropViewNode) Next(context.Context) (bool, error) { return false, nil }
-func (n *dropViewNode) Close(context.Context)              {}
-func (n *dropViewNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
-func (n *dropViewNode) Ordering() orderingInfo             { return orderingInfo{} }
-func (n *dropViewNode) Values() parser.Datums              { return parser.Datums{} }
-func (n *dropViewNode) DebugValues() debugValues           { return debugValues{} }
-func (n *dropViewNode) MarkDebug(mode explainMode)         {}
+func (*dropViewNode) Next(context.Context) (bool, error) { return false, nil }
+func (*dropViewNode) Close(context.Context)              {}
+func (*dropViewNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
+func (*dropViewNode) Ordering() orderingInfo             { return orderingInfo{} }
+func (*dropViewNode) Values() parser.Datums              { return parser.Datums{} }
+func (*dropViewNode) DebugValues() debugValues           { return debugValues{} }
+func (*dropViewNode) MarkDebug(mode explainMode)         {}
+
+func (*dropViewNode) Spans(context.Context) (_, _ roachpb.Spans, _ error) {
+	panic("unimplemented")
+}
 
 type dropTableNode struct {
 	p  *planner
@@ -747,13 +759,17 @@ func (n *dropTableNode) Start(ctx context.Context) error {
 	return nil
 }
 
-func (n *dropTableNode) Next(context.Context) (bool, error) { return false, nil }
-func (n *dropTableNode) Close(context.Context)              {}
-func (n *dropTableNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
-func (n *dropTableNode) Ordering() orderingInfo             { return orderingInfo{} }
-func (n *dropTableNode) Values() parser.Datums              { return parser.Datums{} }
-func (n *dropTableNode) DebugValues() debugValues           { return debugValues{} }
-func (n *dropTableNode) MarkDebug(mode explainMode)         {}
+func (*dropTableNode) Next(context.Context) (bool, error) { return false, nil }
+func (*dropTableNode) Close(context.Context)              {}
+func (*dropTableNode) Columns() ResultColumns             { return make(ResultColumns, 0) }
+func (*dropTableNode) Ordering() orderingInfo             { return orderingInfo{} }
+func (*dropTableNode) Values() parser.Datums              { return parser.Datums{} }
+func (*dropTableNode) DebugValues() debugValues           { return debugValues{} }
+func (*dropTableNode) MarkDebug(mode explainMode)         {}
+
+func (*dropTableNode) Spans(context.Context) (_, _ roachpb.Spans, _ error) {
+	panic("unimplemented")
+}
 
 // dropTableOrViewPrepare/dropTableImpl is used to drop a single table by
 // name, which can result from either a DROP TABLE or DROP DATABASE

--- a/pkg/sql/empty.go
+++ b/pkg/sql/empty.go
@@ -19,6 +19,7 @@ package sql
 import (
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 )
 
@@ -31,12 +32,13 @@ type emptyNode struct {
 	results bool
 }
 
-func (*emptyNode) Columns() ResultColumns      { return nil }
-func (*emptyNode) Ordering() orderingInfo      { return orderingInfo{} }
-func (*emptyNode) Values() parser.Datums       { return nil }
-func (*emptyNode) Start(context.Context) error { return nil }
-func (*emptyNode) MarkDebug(_ explainMode)     {}
-func (*emptyNode) Close(context.Context)       {}
+func (*emptyNode) Columns() ResultColumns                              { return nil }
+func (*emptyNode) Ordering() orderingInfo                              { return orderingInfo{} }
+func (*emptyNode) Values() parser.Datums                               { return nil }
+func (*emptyNode) Start(context.Context) error                         { return nil }
+func (*emptyNode) MarkDebug(_ explainMode)                             {}
+func (*emptyNode) Close(context.Context)                               {}
+func (*emptyNode) Spans(context.Context) (_, _ roachpb.Spans, _ error) { return nil, nil, nil }
 
 func (e *emptyNode) DebugValues() debugValues {
 	return debugValues{

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1480,7 +1480,7 @@ func (e *Executor) execStmtPipelined(stmt parser.Statement, planner *planner) (R
 		return Result{}, err
 	}
 
-	session.pipelineQueue.Add(plan, func(plan planNode) error {
+	session.pipelineQueue.Add(ctx, plan, func(plan planNode) error {
 		defer plan.Close(ctx)
 
 		result, err := makeRes(stmt, planner, plan)

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 )
@@ -253,6 +254,10 @@ func (n *explainDebugNode) Start(ctx context.Context) error        { return n.pl
 func (n *explainDebugNode) Next(ctx context.Context) (bool, error) { return n.plan.Next(ctx) }
 func (n *explainDebugNode) Close(ctx context.Context)              { n.plan.Close(ctx) }
 
+func (n *explainDebugNode) Spans(ctx context.Context) (_, _ roachpb.Spans, _ error) {
+	return n.plan.Spans(ctx)
+}
+
 func (n *explainDebugNode) Values() parser.Datums {
 	vals := n.plan.DebugValues()
 
@@ -291,7 +296,11 @@ type explainDistSQLNode struct {
 func (*explainDistSQLNode) Ordering() orderingInfo   { return orderingInfo{} }
 func (*explainDistSQLNode) MarkDebug(_ explainMode)  {}
 func (*explainDistSQLNode) DebugValues() debugValues { return debugValues{} }
-func (n *explainDistSQLNode) Close(context.Context)  {}
+func (*explainDistSQLNode) Close(context.Context)    {}
+
+func (*explainDistSQLNode) Spans(context.Context) (_, _ roachpb.Spans, _ error) {
+	panic("unimplemented")
+}
 
 var explainDistSQLColumns = ResultColumns{
 	{Name: "Automatic", Typ: parser.TypeBool},

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -21,6 +21,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 )
 
@@ -277,6 +278,11 @@ func (e *explainPlanNode) Ordering() orderingInfo                 { return e.res
 func (e *explainPlanNode) Values() parser.Datums                  { return e.results.Values() }
 func (e *explainPlanNode) DebugValues() debugValues               { return debugValues{} }
 func (e *explainPlanNode) MarkDebug(mode explainMode)             {}
+
+func (e *explainPlanNode) Spans(ctx context.Context) (_, _ roachpb.Spans, _ error) {
+	return e.plan.Spans(ctx)
+}
+
 func (e *explainPlanNode) Start(ctx context.Context) error {
 	// Note that we don't call start on e.plan. That's on purpose, Start() can
 	// have side effects. And it's supposed to not be needed for the way in which

--- a/pkg/sql/filter.go
+++ b/pkg/sql/filter.go
@@ -22,6 +22,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
@@ -112,3 +113,7 @@ func (f *filterNode) Close(ctx context.Context) {
 func (f *filterNode) Values() parser.Datums  { return f.source.plan.Values() }
 func (f *filterNode) Columns() ResultColumns { return f.source.plan.Columns() }
 func (f *filterNode) Ordering() orderingInfo { return f.source.plan.Ordering() }
+
+func (f *filterNode) Spans(ctx context.Context) (_, _ roachpb.Spans, _ error) {
+	return f.source.plan.Spans(ctx)
+}

--- a/pkg/sql/generator.go
+++ b/pkg/sql/generator.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 )
 
@@ -123,6 +124,10 @@ func (n *valueGenerator) DebugValues() debugValues {
 		value:  row.String(),
 		output: debugValueRow,
 	}
+}
+
+func (n *valueGenerator) Spans(context.Context) (_, _ roachpb.Spans, _ error) {
+	return nil, nil, nil
 }
 
 func (n *valueGenerator) Ordering() orderingInfo  { return orderingInfo{} }

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -23,6 +23,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -325,6 +326,10 @@ func (n *groupNode) DebugValues() debugValues {
 		vals.output = debugValueBuffered
 	}
 	return vals
+}
+
+func (n *groupNode) Spans(ctx context.Context) (_, _ roachpb.Spans, _ error) {
+	return n.plan.Spans(ctx)
 }
 
 func (n *groupNode) Start(ctx context.Context) error {

--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/pkg/errors"
 )
 
 const indexJoinBatchSize = 100
@@ -237,6 +238,22 @@ func (n *indexJoinNode) DebugValues() debugValues {
 		panic(fmt.Sprintf("node not in debug mode (mode %d)", n.explain))
 	}
 	return n.debugVals
+}
+
+func (n *indexJoinNode) Spans(ctx context.Context) (reads, writes roachpb.Spans, err error) {
+	indexReads, indexWrites, err := n.index.Spans(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(indexWrites) > 0 {
+		return nil, nil, errors.Errorf("unexpected index scan span writes: %v", indexWrites)
+	}
+	// We can not be sure which spans in the table we will read based only on the
+	// initial index span because we will dynamically lookup rows in the table based
+	// on the result of the index scan. We conservatively report that we will read the
+	// index span and the entire span for the table's primary index.
+	primaryReads := n.table.desc.PrimaryIndexSpan()
+	return append(indexReads, primaryReads), nil, nil
 }
 
 func (n *indexJoinNode) Start(ctx context.Context) error {

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -21,6 +21,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -215,7 +216,7 @@ func (p *planner) Insert(
 	}
 
 	if err := in.run.initEditNode(
-		ctx, &in.editNodeBase, rows, n.Returning, desiredTypes); err != nil {
+		ctx, &in.editNodeBase, rows, in.tw, n.Returning, desiredTypes); err != nil {
 		return nil, err
 	}
 
@@ -288,7 +289,7 @@ func (n *insertNode) Start(ctx context.Context) error {
 		}
 	}
 
-	if err := n.run.startEditNode(ctx, &n.editNodeBase, n.tw); err != nil {
+	if err := n.run.startEditNode(ctx, &n.editNodeBase); err != nil {
 		return err
 	}
 
@@ -530,3 +531,7 @@ func (n *insertNode) DebugValues() debugValues {
 }
 
 func (n *insertNode) Ordering() orderingInfo { return orderingInfo{} }
+
+func (n *insertNode) Spans(ctx context.Context) (reads, writes roachpb.Spans, err error) {
+	return n.run.collectSpans(ctx)
+}

--- a/pkg/sql/limit.go
+++ b/pkg/sql/limit.go
@@ -22,6 +22,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 )
 
@@ -150,6 +151,10 @@ func (n *limitNode) evalLimit() error {
 func (n *limitNode) Columns() ResultColumns { return n.plan.Columns() }
 func (n *limitNode) Values() parser.Datums  { return n.plan.Values() }
 func (n *limitNode) Ordering() orderingInfo { return n.plan.Ordering() }
+
+func (n *limitNode) Spans(ctx context.Context) (_, _ roachpb.Spans, _ error) {
+	return n.plan.Spans(ctx)
+}
 
 func (n *limitNode) MarkDebug(mode explainMode) {
 	if mode != explainDebug {

--- a/pkg/sql/ordinality.go
+++ b/pkg/sql/ordinality.go
@@ -19,6 +19,7 @@ package sql
 import (
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 )
 
@@ -103,3 +104,7 @@ func (o *ordinalityNode) MarkDebug(mode explainMode)      { o.source.MarkDebug(m
 func (o *ordinalityNode) Columns() ResultColumns          { return o.columns }
 func (o *ordinalityNode) Start(ctx context.Context) error { return o.source.Start(ctx) }
 func (o *ordinalityNode) Close(ctx context.Context)       { o.source.Close(ctx) }
+
+func (o *ordinalityNode) Spans(ctx context.Context) (_, _ roachpb.Spans, _ error) {
+	return o.source.Spans(ctx)
+}

--- a/pkg/sql/pipelining.go
+++ b/pkg/sql/pipelining.go
@@ -19,7 +19,11 @@ package sql
 import (
 	"sync"
 
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/util/interval"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
@@ -77,8 +81,8 @@ func MakePipelineQueue(analyzer DependencyAnalyzer) PipelineQueue {
 //
 // Add should not be called concurrently with Wait. See Wait's comment for more
 // details.
-func (pq *PipelineQueue) Add(plan planNode, exec func(planNode) error) {
-	prereqs, finishLocked := pq.insertInQueue(plan)
+func (pq *PipelineQueue) Add(ctx context.Context, plan planNode, exec func(planNode) error) {
+	prereqs, finishLocked := pq.insertInQueue(ctx, plan)
 	pq.runningGroup.Add(1)
 	go func() {
 		defer pq.runningGroup.Done()
@@ -121,12 +125,12 @@ func (pq *PipelineQueue) Add(plan planNode, exec func(planNode) error) {
 // channels of prerequisite blocking the new plan from executing. It also returns a
 // function to call when the new plan has finished executing. This function must be
 // called while pq.mu is held.
-func (pq *PipelineQueue) insertInQueue(newPlan planNode) ([]doneChan, func()) {
+func (pq *PipelineQueue) insertInQueue(ctx context.Context, newPlan planNode) ([]doneChan, func()) {
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
 
 	// Determine the set of prerequisite plans.
-	prereqs := pq.prereqsForPlanLocked(newPlan)
+	prereqs := pq.prereqsForPlanLocked(ctx, newPlan)
 
 	// Insert newPlan in running set.
 	newDoneChan := make(doneChan)
@@ -136,6 +140,10 @@ func (pq *PipelineQueue) insertInQueue(newPlan planNode) ([]doneChan, func()) {
 		// plans that we're done by closing our done channel.
 		delete(pq.plans, newPlan)
 		close(newDoneChan)
+
+		// Remove the current plan from the DependencyAnalyzer, in case it was
+		// caching any state about the plan.
+		pq.analyzer.Clear(newPlan)
 	}
 	return prereqs, finish
 }
@@ -144,11 +152,11 @@ func (pq *PipelineQueue) insertInQueue(newPlan planNode) ([]doneChan, func()) {
 // that a new plan is dependent on. It returns a slice of doneChans for each plan
 // in this set. Returns a nil slice if the plan has no prerequisites and can be run
 // immediately.
-func (pq *PipelineQueue) prereqsForPlanLocked(newPlan planNode) []doneChan {
+func (pq *PipelineQueue) prereqsForPlanLocked(ctx context.Context, newPlan planNode) []doneChan {
 	// Add all plans from the plan set that this new plan is dependent on.
 	var prereqs []doneChan
 	for plan, doneChan := range pq.plans {
-		if !pq.analyzer.Independent(plan, newPlan) {
+		if !pq.analyzer.Independent(ctx, plan, newPlan) {
 			prereqs = append(prereqs, doneChan)
 		}
 	}
@@ -196,19 +204,31 @@ func (pq *PipelineQueue) Err() error {
 // reordered without having an effect on their runtime semantics or on their
 // results. DependencyAnalyzer is used by PipelineQueue to test whether it is
 // safe for multiple statements to be run concurrently.
+//
+// DependencyAnalyzer implementations do not need to be safe to use from multiple
+// goroutines concurrently.
 type DependencyAnalyzer interface {
 	// Independent determines if the provided planNodes are independent from one
 	// another. Implementations of Independent are always commutative.
-	Independent(planNode, planNode) bool
+	Independent(context.Context, planNode, planNode) bool
+	// Clear is a hint to the DependencyAnalyzer that the provided planNode will
+	// no longer be needed. It is useful for DependencyAnalyzers that cache state
+	// on the planNodes.
+	Clear(planNode)
 }
+
+var _ DependencyAnalyzer = dependencyAnalyzerFunc(nil)
+var _ DependencyAnalyzer = &spanBasedDependencyAnalyzer{}
 
 // dependencyAnalyzerFunc is an implementation of DependencyAnalyzer that defers
 // to a function for all dependency decisions.
 type dependencyAnalyzerFunc func(planNode, planNode) bool
 
-func (f dependencyAnalyzerFunc) Independent(p1 planNode, p2 planNode) bool {
+func (f dependencyAnalyzerFunc) Independent(_ context.Context, p1 planNode, p2 planNode) bool {
 	return f(p1, p2)
 }
+
+func (f dependencyAnalyzerFunc) Clear(_ planNode) {}
 
 // NoDependenciesAnalyzer is a DependencyAnalyzer that performs no analysis on
 // planNodes and asserts that all plans are independent.
@@ -217,6 +237,76 @@ var NoDependenciesAnalyzer DependencyAnalyzer = dependencyAnalyzerFunc(func(
 ) bool {
 	return true
 })
+
+// planSpans holds the read and write spans that a planNode will touch during
+// execution. It represents the effect of a plan's execution and is used to
+// determine if two plans are independent.
+type planSpans struct {
+	read  interval.RangeGroup
+	write interval.RangeGroup
+}
+
+// spanBasedDependencyAnalyzer determines planNode independence based off of
+// the read and write spans that a pair of planNodes interact with. The
+// implementation of DependencyAnalyzer expects all planNodes to implement the
+// spanCollector interface, and will panic if they do not.
+type spanBasedDependencyAnalyzer struct {
+	// spanCache caches the read and write spans of all active planNodes, so
+	// that the spans only need to be collected once.
+	spanCache map[planNode]planSpans
+}
+
+// NewSpanBasedDependencyAnalyzer creates a new SpanBasedDependencyAnalyzer.
+func NewSpanBasedDependencyAnalyzer() DependencyAnalyzer {
+	return &spanBasedDependencyAnalyzer{
+		spanCache: make(map[planNode]planSpans),
+	}
+}
+
+func (a *spanBasedDependencyAnalyzer) Independent(
+	ctx context.Context, p1 planNode, p2 planNode,
+) bool {
+	s1, s2 := a.spansForPlan(ctx, p1), a.spansForPlan(ctx, p2)
+	if interval.RangeGroupsOverlap(s1.write, s2.write) {
+		return false
+	}
+	if interval.RangeGroupsOverlap(s1.read, s2.write) {
+		return false
+	}
+	if interval.RangeGroupsOverlap(s1.write, s2.read) {
+		return false
+	}
+	return true
+}
+
+func (a *spanBasedDependencyAnalyzer) spansForPlan(ctx context.Context, p planNode) planSpans {
+	if spans, ok := a.spanCache[p]; ok {
+		return spans
+	}
+
+	readSpans, writeSpans, err := p.Spans(ctx)
+	if err != nil {
+		panic(err)
+	}
+	spans := planSpans{
+		read:  rangeGroupFromSpans(readSpans),
+		write: rangeGroupFromSpans(writeSpans),
+	}
+	a.spanCache[p] = spans
+	return spans
+}
+
+func rangeGroupFromSpans(spans roachpb.Spans) interval.RangeGroup {
+	rg := interval.NewRangeList()
+	for _, s := range spans {
+		rg.Add(s.AsRange())
+	}
+	return rg
+}
+
+func (a *spanBasedDependencyAnalyzer) Clear(p planNode) {
+	delete(a.spanCache, p)
+}
 
 // IsStmtPipelined determines if a given statement's execution should be pipelined.
 // This means that its results should be mocked out, and that it should be run

--- a/pkg/sql/pipelining.go
+++ b/pkg/sql/pipelining.go
@@ -238,12 +238,12 @@ var NoDependenciesAnalyzer DependencyAnalyzer = dependencyAnalyzerFunc(func(
 	return true
 })
 
-// planSpans holds the read and write spans that a planNode will touch during
-// execution. It represents the effect of a plan's execution and is used to
-// determine if two plans are independent.
-type planSpans struct {
-	read  interval.RangeGroup
-	write interval.RangeGroup
+// planAnalysis holds the read and write spans that a planNode will touch during
+// execution, along with other information necessary to determine plan independence.
+type planAnalysis struct {
+	read          interval.RangeGroup
+	write         interval.RangeGroup
+	hasOrderingFn bool
 }
 
 // spanBasedDependencyAnalyzer determines planNode independence based off of
@@ -251,49 +251,76 @@ type planSpans struct {
 // implementation of DependencyAnalyzer expects all planNodes to implement the
 // spanCollector interface, and will panic if they do not.
 type spanBasedDependencyAnalyzer struct {
-	// spanCache caches the read and write spans of all active planNodes, so
-	// that the spans only need to be collected once.
-	spanCache map[planNode]planSpans
+	// spanCache caches the analysis results of all active planNodes, so
+	// that the analysis only needs to be performed once.
+	analysisCache map[planNode]planAnalysis
 }
 
 // NewSpanBasedDependencyAnalyzer creates a new SpanBasedDependencyAnalyzer.
 func NewSpanBasedDependencyAnalyzer() DependencyAnalyzer {
 	return &spanBasedDependencyAnalyzer{
-		spanCache: make(map[planNode]planSpans),
+		analysisCache: make(map[planNode]planAnalysis),
 	}
 }
 
 func (a *spanBasedDependencyAnalyzer) Independent(
 	ctx context.Context, p1 planNode, p2 planNode,
 ) bool {
-	s1, s2 := a.spansForPlan(ctx, p1), a.spansForPlan(ctx, p2)
-	if interval.RangeGroupsOverlap(s1.write, s2.write) {
+	a1, a2 := a.analyzePlan(ctx, p1), a.analyzePlan(ctx, p2)
+	if a1.hasOrderingFn || a2.hasOrderingFn {
 		return false
 	}
-	if interval.RangeGroupsOverlap(s1.read, s2.write) {
+	if interval.RangeGroupsOverlap(a1.write, a2.write) {
 		return false
 	}
-	if interval.RangeGroupsOverlap(s1.write, s2.read) {
+	if interval.RangeGroupsOverlap(a1.read, a2.write) {
+		return false
+	}
+	if interval.RangeGroupsOverlap(a1.write, a2.read) {
 		return false
 	}
 	return true
 }
 
-func (a *spanBasedDependencyAnalyzer) spansForPlan(ctx context.Context, p planNode) planSpans {
-	if spans, ok := a.spanCache[p]; ok {
-		return spans
+func (a *spanBasedDependencyAnalyzer) analyzePlan(ctx context.Context, p planNode) planAnalysis {
+	if a, ok := a.analysisCache[p]; ok {
+		return a
 	}
 
 	readSpans, writeSpans, err := p.Spans(ctx)
 	if err != nil {
 		panic(err)
 	}
-	spans := planSpans{
-		read:  rangeGroupFromSpans(readSpans),
-		write: rangeGroupFromSpans(writeSpans),
+	hasOrderingFn := containsOrderingFunction(ctx, p)
+	analysis := planAnalysis{
+		read:          rangeGroupFromSpans(readSpans),
+		write:         rangeGroupFromSpans(writeSpans),
+		hasOrderingFn: hasOrderingFn,
 	}
-	a.spanCache[p] = spans
-	return spans
+	a.analysisCache[p] = analysis
+	return analysis
+}
+
+// orderingFunctions is a set of all functions that preclude statement independence.
+// These functions are contractually monotonic within a transaction and thus prevents
+// reordering.
+var orderingFunctions = map[string]struct{}{
+	"statement_timestamp": {},
+}
+
+func containsOrderingFunction(ctx context.Context, plan planNode) bool {
+	sawOrderingFn := false
+	po := planObserver{expr: func(_, _ string, n int, expr parser.Expr) {
+		if f, ok := expr.(*parser.FuncExpr); ok {
+			if _, ok := orderingFunctions[f.Func.String()]; ok {
+				sawOrderingFn = true
+			}
+		}
+	}}
+	if err := walkPlan(ctx, plan, po); err != nil {
+		panic(err)
+	}
+	return sawOrderingFn
 }
 
 func rangeGroupFromSpans(spans roachpb.Spans) interval.RangeGroup {
@@ -305,7 +332,7 @@ func rangeGroupFromSpans(spans roachpb.Spans) interval.RangeGroup {
 }
 
 func (a *spanBasedDependencyAnalyzer) Clear(p planNode) {
-	delete(a.spanCache, p)
+	delete(a.analysisCache, p)
 }
 
 // IsStmtPipelined determines if a given statement's execution should be pipelined.

--- a/pkg/sql/pipelining_test.go
+++ b/pkg/sql/pipelining_test.go
@@ -409,21 +409,34 @@ func TestSpanBasedDependencyAnalyzer(t *testing.T) {
 		{`UPDATE bar SET k = 1`, `SELECT * FROM bar@idx`, false},
 		{`UPDATE foo SET k = 1`, `DELETE FROM foo`, false},
 		{`UPDATE foo SET k = 1`, `DELETE FROM bar`, true},
+
+		// Statements like statement_timestamp enforce a strict ordering on
+		// statements, restricting reordering and thus independence.
+		{`SELECT * FROM foo`, `SELECT *, statement_timestamp() FROM bar`, false},
+		{`DELETE FROM foo`, `DELETE FROM bar WHERE '2015-10-01'::TIMESTAMP = statement_timestamp()`, true},
 	} {
-		name := fmt.Sprintf("%s | %s", test.query1, test.query2)
-		t.Run(name, func(t *testing.T) {
-			da := NewSpanBasedDependencyAnalyzer()
-
-			plan1, finish1 := planNodeForQuery(t, s, test.query1)
-			defer finish1()
-			plan2, finish2 := planNodeForQuery(t, s, test.query2)
-			defer finish2()
-
-			indep := da.Independent(context.TODO(), plan1, plan2)
-			if exp := test.independent; indep != exp {
-				t.Errorf("expected da.Independent(%q, %q) = %t, but found %t",
-					test.query1, test.query2, exp, indep)
+		for _, reverse := range []bool{false, true} {
+			q1, q2 := test.query1, test.query2
+			if reverse {
+				// Verify commutativity.
+				q1, q2 = q2, q1
 			}
-		})
+
+			name := fmt.Sprintf("%s | %s", q1, q2)
+			t.Run(name, func(t *testing.T) {
+				da := NewSpanBasedDependencyAnalyzer()
+
+				plan1, finish1 := planNodeForQuery(t, s, q1)
+				defer finish1()
+				plan2, finish2 := planNodeForQuery(t, s, q2)
+				defer finish2()
+
+				indep := da.Independent(context.TODO(), plan1, plan2)
+				if exp := test.independent; indep != exp {
+					t.Errorf("expected da.Independent(%q, %q) = %t, but found %t",
+						q1, q2, exp, indep)
+				}
+			})
+		}
 	}
 }

--- a/pkg/sql/pipelining_test.go
+++ b/pkg/sql/pipelining_test.go
@@ -17,10 +17,18 @@
 package sql
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/pkg/errors"
 )
@@ -68,25 +76,27 @@ func waitAndAssertEmpty(t *testing.T, pq *PipelineQueue) {
 // use channels to guarantee deterministic execution.
 func TestPipelineQueueNoDependencies(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
 	var res []int
 	run1, run2, run3 := make(chan struct{}), make(chan struct{}), make(chan struct{})
 
 	// Executes: plan3 -> plan1 -> plan2.
 	pq := MakePipelineQueue(NoDependenciesAnalyzer)
-	pq.Add(newPlanNode(), func(plan planNode) error {
+	pq.Add(ctx, newPlanNode(), func(plan planNode) error {
 		<-run1
 		res = append(res, 1)
 		assertLen(t, &pq, 3)
 		close(run3)
 		return nil
 	})
-	pq.Add(newPlanNode(), func(plan planNode) error {
+	pq.Add(ctx, newPlanNode(), func(plan planNode) error {
 		<-run2
 		res = append(res, 2)
 		assertLenEventually(t, &pq, 1)
 		return nil
 	})
-	pq.Add(newPlanNode(), func(plan planNode) error {
+	pq.Add(ctx, newPlanNode(), func(plan planNode) error {
 		<-run3
 		res = append(res, 3)
 		assertLenEventually(t, &pq, 2)
@@ -107,6 +117,8 @@ func TestPipelineQueueNoDependencies(t *testing.T) {
 // need no extra synchronization to guarantee deterministic execution.
 func TestPipelineQueueAllDependent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
 	var res []int
 	run := make(chan struct{})
 	analyzer := dependencyAnalyzerFunc(func(p1 planNode, p2 planNode) bool {
@@ -115,18 +127,18 @@ func TestPipelineQueueAllDependent(t *testing.T) {
 
 	// Executes: plan1 -> plan2 -> plan3.
 	pq := MakePipelineQueue(analyzer)
-	pq.Add(newPlanNode(), func(plan planNode) error {
+	pq.Add(ctx, newPlanNode(), func(plan planNode) error {
 		<-run
 		res = append(res, 1)
 		assertLen(t, &pq, 3)
 		return nil
 	})
-	pq.Add(newPlanNode(), func(plan planNode) error {
+	pq.Add(ctx, newPlanNode(), func(plan planNode) error {
 		res = append(res, 2)
 		assertLen(t, &pq, 2)
 		return nil
 	})
-	pq.Add(newPlanNode(), func(plan planNode) error {
+	pq.Add(ctx, newPlanNode(), func(plan planNode) error {
 		res = append(res, 3)
 		assertLen(t, &pq, 1)
 		return nil
@@ -145,6 +157,8 @@ func TestPipelineQueueAllDependent(t *testing.T) {
 // until the prerequisite plan completes execution.
 func TestPipelineQueueSingleDependency(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
 	var res []int
 	plan1, plan2, plan3 := newPlanNode(), newPlanNode(), newPlanNode()
 	run1, run3 := make(chan struct{}), make(chan struct{})
@@ -158,18 +172,18 @@ func TestPipelineQueueSingleDependency(t *testing.T) {
 
 	// Executes: plan3 -> plan1 -> plan2.
 	pq := MakePipelineQueue(analyzer)
-	pq.Add(plan1, func(plan planNode) error {
+	pq.Add(ctx, plan1, func(plan planNode) error {
 		<-run1
 		res = append(res, 1)
 		assertLenEventually(t, &pq, 2)
 		return nil
 	})
-	pq.Add(plan2, func(plan planNode) error {
+	pq.Add(ctx, plan2, func(plan planNode) error {
 		res = append(res, 2)
 		assertLen(t, &pq, 1)
 		return nil
 	})
-	pq.Add(plan3, func(plan planNode) error {
+	pq.Add(ctx, plan3, func(plan planNode) error {
 		<-run3
 		res = append(res, 3)
 		assertLen(t, &pq, 3)
@@ -189,6 +203,8 @@ func TestPipelineQueueSingleDependency(t *testing.T) {
 // and the prerequisite plan throws an error.
 func TestPipelineQueueError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
 	var res []int
 	plan1, plan2, plan3 := newPlanNode(), newPlanNode(), newPlanNode()
 	run1, run3 := make(chan struct{}), make(chan struct{})
@@ -203,19 +219,19 @@ func TestPipelineQueueError(t *testing.T) {
 
 	// Executes: plan3 -> plan1 (error!) -> plan2 (dropped).
 	pq := MakePipelineQueue(analyzer)
-	pq.Add(plan1, func(plan planNode) error {
+	pq.Add(ctx, plan1, func(plan planNode) error {
 		<-run1
 		res = append(res, 1)
 		assertLenEventually(t, &pq, 2)
 		return planErr
 	})
-	pq.Add(plan2, func(plan planNode) error {
+	pq.Add(ctx, plan2, func(plan planNode) error {
 		// Should never be called. We assert this using the res slice, because
 		// we can't call t.Fatalf in a different goroutine.
 		res = append(res, 2)
 		return nil
 	})
-	pq.Add(plan3, func(plan planNode) error {
+	pq.Add(ctx, plan3, func(plan planNode) error {
 		<-run3
 		res = append(res, 3)
 		assertLen(t, &pq, 3)
@@ -241,13 +257,15 @@ func TestPipelineQueueError(t *testing.T) {
 // will be cleared.
 func TestPipelineQueueAddAfterError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
 	var res []int
 	plan1, plan2, plan3 := newPlanNode(), newPlanNode(), newPlanNode()
 	planErr := errors.Errorf("plan1 will throw this error")
 
 	// Executes: plan1 (error!) -> plan2 (dropped) -> plan3.
 	pq := MakePipelineQueue(NoDependenciesAnalyzer)
-	pq.Add(plan1, func(plan planNode) error {
+	pq.Add(ctx, plan1, func(plan planNode) error {
 		res = append(res, 1)
 		assertLen(t, &pq, 1)
 		return planErr
@@ -261,7 +279,7 @@ func TestPipelineQueueAddAfterError(t *testing.T) {
 		return nil
 	})
 
-	pq.Add(plan2, func(plan planNode) error {
+	pq.Add(ctx, plan2, func(plan planNode) error {
 		// Should never be called. We assert this using the res slice, because
 		// we can't call t.Fatalf in a different goroutine.
 		res = append(res, 2)
@@ -275,7 +293,7 @@ func TestPipelineQueueAddAfterError(t *testing.T) {
 		t.Fatalf("expected plan1 to throw error %v, found %v", planErr, resErr)
 	}
 
-	pq.Add(plan3, func(plan planNode) error {
+	pq.Add(ctx, plan3, func(plan planNode) error {
 		// Will be called, because the error is cleared when Wait is called.
 		res = append(res, 3)
 		assertLen(t, &pq, 1)
@@ -286,5 +304,126 @@ func TestPipelineQueueAddAfterError(t *testing.T) {
 	exp := []int{1, 3}
 	if !reflect.DeepEqual(res, exp) {
 		t.Fatalf("expected pipeline side effects %v, found %v", exp, res)
+	}
+}
+
+func planNodeForQuery(
+	t *testing.T, s serverutils.TestServerInterface, sql string,
+) (planNode, func()) {
+	kvDB := s.KVClient().(*client.DB)
+	txn := client.NewTxn(kvDB)
+	txn.Proto().OrigTimestamp = s.Clock().Now()
+	p := makeInternalPlanner("plan", txn, security.RootUser, &MemoryMetrics{})
+	p.session.leases.leaseMgr = s.LeaseManager().(*LeaseManager)
+	p.session.Database = "test"
+
+	stmts, err := p.parser.Parse(sql, parser.Traditional)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stmts) != 1 {
+		t.Fatalf("expected to parse 1 statement, got: %d", len(stmts))
+	}
+	stmt := stmts[0]
+	plan, err := p.makePlan(context.TODO(), stmt, false /* autoCommit */)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return plan, func() {
+		finishInternalPlanner(p)
+	}
+}
+
+func TestSpanBasedDependencyAnalyzer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop()
+
+	if _, err := db.Exec(`CREATE DATABASE test`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`SET DATABASE = test`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE foo (k INT PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`
+		CREATE TABLE bar (
+			k INT PRIMARY KEY, 
+			v INT, 
+			a INT, 
+			UNIQUE INDEX idx(v)
+		)
+	`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE fks (f INT REFERENCES foo)`); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		query1, query2 string
+		independent    bool
+	}{
+		// The dependency analyzer is only used for RETURNING NOTHING statements
+		// at the moment, but it should work on all statement types.
+		{`SELECT * FROM foo`, `SELECT * FROM bar`, true},
+		{`SELECT * FROM foo`, `SELECT * FROM bar@idx`, true},
+		{`SELECT * FROM foo`, `SELECT * FROM foo`, true},
+		{`SELECT * FROM foo`, `SELECT * FROM fks`, true},
+
+		{`DELETE FROM foo`, `DELETE FROM bar`, true},
+		{`DELETE FROM foo`, `DELETE FROM foo`, false},
+		{`DELETE FROM foo`, `DELETE FROM bar WHERE (SELECT k = 1 FROM foo)`, false},
+		{`DELETE FROM foo`, `DELETE FROM bar WHERE (SELECT f = 1 FROM fks)`, true},
+		{`DELETE FROM foo`, `DELETE FROM fks`, false},
+		{`DELETE FROM bar`, `DELETE FROM fks`, true},
+		{`DELETE FROM foo`, `SELECT * FROM foo`, false},
+		{`DELETE FROM foo`, `SELECT * FROM bar`, true},
+		{`DELETE FROM bar`, `SELECT * FROM bar`, false},
+		{`DELETE FROM bar`, `SELECT * FROM bar@idx`, false},
+
+		{`INSERT INTO foo VALUES (1)`, `INSERT INTO bar VALUES (1)`, true},
+		{`INSERT INTO foo VALUES (1)`, `INSERT INTO foo VALUES (1)`, false},
+		{`INSERT INTO foo VALUES (1)`, `INSERT INTO bar SELECT k FROM foo`, false},
+		{`INSERT INTO foo VALUES (1)`, `INSERT INTO bar SELECT f FROM fks`, true},
+		{`INSERT INTO foo VALUES (1)`, `INSERT INTO fks VALUES (1)`, false},
+		{`INSERT INTO bar VALUES (1)`, `INSERT INTO fks VALUES (1)`, true},
+		{`INSERT INTO foo VALUES (1)`, `SELECT * FROM foo`, false},
+		{`INSERT INTO foo VALUES (1)`, `SELECT * FROM bar`, true},
+		{`INSERT INTO bar VALUES (1)`, `SELECT * FROM bar`, false},
+		{`INSERT INTO bar VALUES (1)`, `SELECT * FROM bar@idx`, false},
+		{`INSERT INTO foo VALUES (1)`, `DELETE FROM foo`, false},
+		{`INSERT INTO foo VALUES (1)`, `DELETE FROM bar`, true},
+
+		{`UPDATE foo SET k = 1`, `UPDATE bar SET k = 1`, true},
+		{`UPDATE foo SET k = 1`, `UPDATE foo SET k = 1`, false},
+		{`UPDATE foo SET k = 1`, `UPDATE bar SET k = (SELECT k FROM foo)`, false},
+		{`UPDATE foo SET k = 1`, `UPDATE bar SET k = (SELECT f FROM fks)`, true},
+		{`UPDATE foo SET k = 1`, `INSERT INTO fks VALUES (1)`, false},
+		{`UPDATE bar SET k = 1`, `INSERT INTO fks VALUES (1)`, true},
+		{`UPDATE foo SET k = 1`, `SELECT * FROM foo`, false},
+		{`UPDATE foo SET k = 1`, `SELECT * FROM bar`, true},
+		{`UPDATE bar SET k = 1`, `SELECT * FROM bar`, false},
+		{`UPDATE bar SET k = 1`, `SELECT * FROM bar@idx`, false},
+		{`UPDATE foo SET k = 1`, `DELETE FROM foo`, false},
+		{`UPDATE foo SET k = 1`, `DELETE FROM bar`, true},
+	} {
+		name := fmt.Sprintf("%s | %s", test.query1, test.query2)
+		t.Run(name, func(t *testing.T) {
+			da := NewSpanBasedDependencyAnalyzer()
+
+			plan1, finish1 := planNodeForQuery(t, s, test.query1)
+			defer finish1()
+			plan2, finish2 := planNodeForQuery(t, s, test.query2)
+			defer finish2()
+
+			indep := da.Independent(context.TODO(), plan1, plan2)
+			if exp := test.independent; indep != exp {
+				t.Errorf("expected da.Independent(%q, %q) = %t, but found %t",
+					test.query1, test.query2, exp, indep)
+			}
+		})
 	}
 }

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -143,6 +144,15 @@ type planNode interface {
 	// Available after Next() and MarkDebug(explainDebug), see
 	// explain.go.
 	DebugValues() debugValues
+
+	// Spans collects the upper bound set of read and write spans that the
+	// planNode expects to touch when executed. The two sets do not need to be
+	// disjoint, and any span in the write set will be implicitly considered in
+	// the read set as well. There is also no guarantee that Spans within either
+	// set are disjoint. It is an error for a planNode to touch any span outside
+	// those that it reports from this method, but a planNode is not required to
+	// touch all spans that it reports.
+	Spans(ctx context.Context) (reads, writes roachpb.Spans, err error)
 
 	// Close terminates the planNode execution and releases its resources.
 	// This method should be called if the node has been used in any way (any

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -19,6 +19,7 @@ package sql
 import (
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 )
 
@@ -70,6 +71,10 @@ type hookFnNode struct {
 func (*hookFnNode) Ordering() orderingInfo  { return orderingInfo{} }
 func (*hookFnNode) MarkDebug(_ explainMode) {}
 func (*hookFnNode) Close(context.Context)   {}
+
+func (*hookFnNode) Spans(context.Context) (_, _ roachpb.Spans, _ error) {
+	panic("unimplemented")
+}
 
 func (f *hookFnNode) Start(context.Context) error {
 	var err error

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -22,6 +22,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
@@ -116,6 +117,10 @@ func (s *renderNode) MarkDebug(mode explainMode) {
 
 func (s *renderNode) DebugValues() debugValues {
 	return s.source.plan.DebugValues()
+}
+
+func (s *renderNode) Spans(ctx context.Context) (_, _ roachpb.Spans, _ error) {
+	return s.source.plan.Spans(ctx)
 }
 
 func (s *renderNode) Start(ctx context.Context) error {

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -148,14 +148,6 @@ func (n *scanNode) Close(context.Context) {}
 
 // initScan sets up the rowFetcher and starts a scan.
 func (n *scanNode) initScan(ctx context.Context) error {
-	if len(n.spans) == 0 {
-		// If no spans were specified retrieve all of the keys that start with our
-		// index key prefix. This isn't needed for the fetcher, but it is for
-		// other external users of n.spans.
-		start := roachpb.Key(sqlbase.MakeIndexKeyPrefix(&n.desc, n.index.ID))
-		n.spans = append(n.spans, roachpb.Span{Key: start, EndKey: start.PrefixEnd()})
-	}
-
 	limitHint := n.limitHint()
 	if err := n.fetcher.StartScan(ctx, n.p.txn, n.spans, !n.disableBatchLimits, limitHint); err != nil {
 		return err
@@ -434,6 +426,10 @@ func (n *scanNode) computeOrdering(
 	// We included any implicit columns, so the results are unique.
 	ordering.unique = true
 	return ordering
+}
+
+func (n *scanNode) Spans(ctx context.Context) (reads, writes roachpb.Spans, err error) {
+	return n.spans, nil, nil
 }
 
 // scanNode implements parser.IndexedVarContainer.

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -261,7 +261,7 @@ func NewSession(
 		virtualSchemas: e.virtualSchemas,
 		execCfg:        &e.cfg,
 		distSQLPlanner: e.distSQLPlanner,
-		pipelineQueue:  MakePipelineQueue(NoDependenciesAnalyzer),
+		pipelineQueue:  MakePipelineQueue(NewSpanBasedDependencyAnalyzer()),
 		memMetrics:     memMetrics,
 		sqlStats:       &e.sqlStats,
 		defaults: sessionDefaults{

--- a/pkg/sql/show_ranges.go
+++ b/pkg/sql/show_ranges.go
@@ -174,7 +174,10 @@ func (n *showRangesNode) Close(_ context.Context) {
 	n.descriptorKVs = nil
 }
 
-func (*showRangesNode) Columns() ResultColumns     { return showRangesColumns }
-func (*showRangesNode) Ordering() orderingInfo     { return orderingInfo{} }
-func (*showRangesNode) MarkDebug(_ explainMode)    {}
-func (n *showRangesNode) DebugValues() debugValues { panic("not implemented") }
+func (*showRangesNode) Columns() ResultColumns   { return showRangesColumns }
+func (*showRangesNode) Ordering() orderingInfo   { return orderingInfo{} }
+func (*showRangesNode) MarkDebug(_ explainMode)  {}
+func (*showRangesNode) DebugValues() debugValues { panic("unimplemented") }
+func (*showRangesNode) Spans(context.Context) (_, _ roachpb.Spans, _ error) {
+	panic("unimplemented")
+}

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -351,6 +352,10 @@ func (n *sortNode) DebugValues() debugValues {
 		panic(fmt.Sprintf("node not in debug mode (mode %d)", n.explain))
 	}
 	return n.debugVals
+}
+
+func (n *sortNode) Spans(ctx context.Context) (_, _ roachpb.Spans, _ error) {
+	return n.plan.Spans(ctx)
 }
 
 func (n *sortNode) Start(ctx context.Context) error {

--- a/pkg/sql/split_at.go
+++ b/pkg/sql/split_at.go
@@ -158,6 +158,9 @@ func (*splitNode) Columns() ResultColumns {
 
 func (*splitNode) Ordering() orderingInfo  { return orderingInfo{} }
 func (*splitNode) MarkDebug(_ explainMode) {}
+func (*splitNode) Spans(context.Context) (_, _ roachpb.Spans, _ error) {
+	panic("unimplemented")
+}
 
 func (n *splitNode) DebugValues() debugValues {
 	return debugValues{
@@ -409,6 +412,9 @@ func (*relocateNode) Columns() ResultColumns {
 
 func (*relocateNode) Ordering() orderingInfo  { return orderingInfo{} }
 func (*relocateNode) MarkDebug(_ explainMode) {}
+func (*relocateNode) Spans(context.Context) (_, _ roachpb.Spans, _ error) {
+	panic("unimplemented")
+}
 
 func (n *relocateNode) DebugValues() debugValues {
 	return debugValues{

--- a/pkg/sql/sqlbase/fk.go
+++ b/pkg/sql/sqlbase/fk.go
@@ -143,6 +143,11 @@ func (fks fkInsertHelper) checkIdx(ctx context.Context, idx IndexID, row parser.
 	return nil
 }
 
+// CollectSpans implements the FkSpanCollector interface.
+func (fks fkInsertHelper) CollectSpans() (reads roachpb.Spans, writes roachpb.Spans) {
+	return collectSpansForFKMap(fks)
+}
+
 type fkDeleteHelper map[IndexID][]baseFKHelper
 
 func makeFKDeleteHelper(
@@ -204,6 +209,11 @@ func (fks fkDeleteHelper) checkIdx(ctx context.Context, idx IndexID, row parser.
 	return nil
 }
 
+// CollectSpans implements the FkSpanCollector interface.
+func (fks fkDeleteHelper) CollectSpans() (reads roachpb.Spans, writes roachpb.Spans) {
+	return collectSpansForFKMap(fks)
+}
+
 type fkUpdateHelper struct {
 	inbound  fkDeleteHelper // Check old values are not referenced.
 	outbound fkInsertHelper // Check rows referenced by new values still exist.
@@ -228,6 +238,13 @@ func (fks fkUpdateHelper) checkIdx(
 		return err
 	}
 	return fks.outbound.checkIdx(ctx, idx, newValues)
+}
+
+// CollectSpans implements the FkSpanCollector interface.
+func (fks fkUpdateHelper) CollectSpans() (reads roachpb.Spans, writes roachpb.Spans) {
+	inboundReads, inboundWrites := fks.inbound.CollectSpans()
+	outboundReads, outboundWrites := fks.outbound.CollectSpans()
+	return append(inboundReads, outboundReads...), append(inboundWrites, outboundWrites...)
 }
 
 type baseFKHelper struct {
@@ -309,4 +326,33 @@ func (f baseFKHelper) check(ctx context.Context, values parser.Datums) (parser.D
 		return nil, err
 	}
 	return f.rf.NextRowDecoded(ctx)
+}
+
+// CollectSpans implements the FkSpanCollector interface.
+func (f baseFKHelper) CollectSpans() (reads roachpb.Spans, writes roachpb.Spans) {
+	key := roachpb.Key(f.searchPrefix)
+	return roachpb.Spans{roachpb.Span{Key: key, EndKey: key.PrefixEnd()}}, nil
+}
+
+// FkSpanCollector can collect the spans that foreign key validation will touch.
+type FkSpanCollector interface {
+	CollectSpans() (reads roachpb.Spans, writes roachpb.Spans)
+}
+
+var _ FkSpanCollector = baseFKHelper{}
+var _ FkSpanCollector = fkInsertHelper{}
+var _ FkSpanCollector = fkDeleteHelper{}
+var _ FkSpanCollector = fkUpdateHelper{}
+
+func collectSpansForFKMap(
+	fks map[IndexID][]baseFKHelper,
+) (reads roachpb.Spans, writes roachpb.Spans) {
+	for idx := range fks {
+		for _, fk := range fks[idx] {
+			fkReads, fkWrites := fk.CollectSpans()
+			reads = append(reads, fkReads...)
+			writes = append(writes, fkWrites...)
+		}
+	}
+	return reads, writes
 }

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1856,6 +1856,20 @@ func (desc *TableDescriptor) InvalidateFKConstraints() {
 	}
 }
 
+// AllIndexSpans returns the Spans for each index in the table, including those
+// being added in the mutations.
+func (desc *TableDescriptor) AllIndexSpans() roachpb.Spans {
+	var spans roachpb.Spans
+	err := desc.ForeachNonDropIndex(func(index *IndexDescriptor) error {
+		spans = append(spans, desc.IndexSpan(index.ID))
+		return nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	return spans
+}
+
 // PrimaryIndexSpan returns the Span that corresponds to the entire primary
 // index; can be used for a full table scan.
 func (desc *TableDescriptor) PrimaryIndexSpan() roachpb.Span {

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -66,6 +66,16 @@ type tableWriter interface {
 	// finalize flushes out any remaining writes. It is called after all calls to
 	// row.
 	finalize(ctx context.Context) error
+
+	// spans collects the upper bound set of read and write spans that the
+	// tableWriter will touch when executed. This is contractual, and the
+	// tableWriter will not touch any keys outside of the spans reported here.
+	//
+	// TODO(nvanbenschoten) we are currently pretty pessimistic here, assuming
+	// that table operations will touch the entire table. In cases where we
+	// can determine ahead of time that this isn't true, we should true to
+	// constrain these spans.
+	spans() (reads, writes roachpb.Spans, err error)
 }
 
 var _ tableWriter = (*tableInserter)(nil)
@@ -112,6 +122,10 @@ func (ti *tableInserter) finalize(ctx context.Context) error {
 	return nil
 }
 
+func (ti *tableInserter) spans() (reads, writes roachpb.Spans, err error) {
+	return collectTableWriterSpans(ti.ri.Helper.TableDesc, ti.ri.Fks)
+}
+
 // tableUpdater handles writing kvs and forming table rows for updates.
 type tableUpdater struct {
 	ru         sqlbase.RowUpdater
@@ -151,6 +165,10 @@ func (tu *tableUpdater) finalize(ctx context.Context) error {
 		return sqlbase.ConvertBatchError(tu.ru.Helper.TableDesc, tu.b)
 	}
 	return nil
+}
+
+func (tu *tableUpdater) spans() (reads, writes roachpb.Spans, err error) {
+	return collectTableWriterSpans(tu.ru.Helper.TableDesc, tu.ru.Fks)
 }
 
 type tableUpsertEvaler interface {
@@ -490,6 +508,10 @@ func (tu *tableUpserter) finalize(ctx context.Context) error {
 	return tu.flush(ctx, true /* finalize */)
 }
 
+func (tu *tableUpserter) spans() (reads, writes roachpb.Spans, err error) {
+	return collectTableWriterSpans(tu.ri.Helper.TableDesc, tu.ri.Fks)
+}
+
 // tableDeleter handles writing kvs and forming table rows for deletes.
 type tableDeleter struct {
 	rd         sqlbase.RowDeleter
@@ -773,4 +795,22 @@ func (td *tableDeleter) deleteIndexScan(
 		resume.Key = rf.Key()
 	}
 	return resume, td.finalize(ctx)
+}
+
+func (td *tableDeleter) spans() (reads, writes roachpb.Spans, err error) {
+	return collectTableWriterSpans(td.rd.Helper.TableDesc, td.rd.Fks)
+}
+
+func collectTableWriterSpans(
+	desc *sqlbase.TableDescriptor, fks sqlbase.FkSpanCollector,
+) (reads, writes roachpb.Spans, err error) {
+	// We don't generally know which spans we will be modifying so we must be
+	// conservative and assume anything in the table might change. See TODO on
+	// tableWriter.spans for discussion on constraining spans wherever possible.
+	tableSpans := desc.AllIndexSpans()
+	fkReads, fkWrites := fks.CollectSpans()
+	if len(fkWrites) > 0 {
+		return nil, nil, errors.Errorf("unexpected foreign key span writes: %v", fkWrites)
+	}
+	return fkReads, tableSpans, nil
 }

--- a/pkg/sql/trace.go
+++ b/pkg/sql/trace.go
@@ -26,6 +26,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -83,9 +84,6 @@ func (p *planner) makeTraceNode(plan planNode) planNode {
 		columns: traceColumns,
 	}
 }
-
-func (*explainTraceNode) Columns() ResultColumns { return traceColumnsWithTS }
-func (*explainTraceNode) Ordering() orderingInfo { return orderingInfo{} }
 
 func (n *explainTraceNode) Start(ctx context.Context) error {
 	return n.plan.Start(ctx)
@@ -233,5 +231,11 @@ func (n *explainTraceNode) Values() parser.Datums {
 	return n.rows[0]
 }
 
+func (*explainTraceNode) Columns() ResultColumns   { return traceColumnsWithTS }
+func (*explainTraceNode) Ordering() orderingInfo   { return orderingInfo{} }
 func (*explainTraceNode) MarkDebug(_ explainMode)  {}
 func (*explainTraceNode) DebugValues() debugValues { return debugValues{} }
+
+func (n *explainTraceNode) Spans(ctx context.Context) (_, _ roachpb.Spans, _ error) {
+	return n.plan.Spans(ctx)
+}

--- a/pkg/sql/union.go
+++ b/pkg/sql/union.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
@@ -142,6 +143,18 @@ type unionNode struct {
 
 func (n *unionNode) Columns() ResultColumns { return n.left.Columns() }
 func (n *unionNode) Ordering() orderingInfo { return orderingInfo{} }
+
+func (n *unionNode) Spans(ctx context.Context) (reads, writes roachpb.Spans, err error) {
+	leftReads, leftWrites, err := n.left.Spans(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	rightReads, rightWrites, err := n.right.Spans(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return append(leftReads, rightReads...), append(leftWrites, rightWrites...), nil
+}
 
 func (n *unionNode) Values() parser.Datums {
 	switch {

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -24,6 +24,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -153,8 +154,12 @@ func (n *valuesNode) Columns() ResultColumns {
 	return n.columns
 }
 
-func (n *valuesNode) Ordering() orderingInfo {
+func (*valuesNode) Ordering() orderingInfo {
 	return orderingInfo{}
+}
+
+func (*valuesNode) Spans(context.Context) (_, _ roachpb.Spans, _ error) {
+	return nil, nil, nil
 }
 
 func (n *valuesNode) Values() parser.Datums {

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -385,6 +386,10 @@ func (n *windowNode) Columns() ResultColumns {
 func (n *windowNode) Ordering() orderingInfo {
 	// Window partitions are returned un-ordered.
 	return orderingInfo{}
+}
+
+func (n *windowNode) Spans(ctx context.Context) (_, _ roachpb.Spans, _ error) {
+	return n.plan.Spans(ctx)
 }
 
 func (n *windowNode) Values() parser.Datums {


### PR DESCRIPTION
Dependency analysis portion of #13160.

This change introduces a new `DependencyAnalyzer` implementation called
`spanBasedDependencyAnalyzer`. This analyzer determines `planNode`
dependence by comparing the spans that each `planNode` touches, and
applying the rule that independent plans do not have their write spans
overlapping with any of the other's spans. This is facilitated through
the inclusion of a new method on the `planNode` interface called
`Spans`. This method collects all of the `roachpb.Spans` that a
`planNode` expects to touch during execution. Additionally, the new
`DependencyAnalyzer` implementation is aware of monotonically-constrained
functions like `statement_timestamp`, which prevent statement reordering.

The last commit is experimental, and I'm not sure how people are going to feel about
it. I included it here because I had a feeling the idea would be brought up in the initial
review, but I'll move it to its own PR for a closer look if it's well received. The idea
is to constrain `client.Batches` to the limited set of spans predicted by a `planNode`.
It does so by introducing a `SpanConstraints` field on a `client.Batch`, which asserts
that all read and write operations take place within specified ranges. The ability to
constrain batch operations is then used by the `spanBasedDependencyAnalyzer` to
assert that the `roachpb.Spans` reported by `planNode.Spans` is accurate. This sanity
check assures that no plans have unaccounted for span accesses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14553)
<!-- Reviewable:end -->
