### PR TITLE
storage: Move AbortCache check to evaluateBatch

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -4227,7 +4227,8 @@ func TestAbortCacheError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pErr := tc.repl.checkIfTxnAborted(context.Background(), tc.engine, txn)
+	rec := ReplicaEvalContext{tc.repl, nil}
+	pErr := checkIfTxnAborted(context.Background(), rec, tc.engine, txn)
 	if _, ok := pErr.GetDetail().(*roachpb.TransactionAbortedError); ok {
 		expected := txn.Clone()
 		expected.Timestamp = txn.Timestamp


### PR DESCRIPTION
Access the abort cache through the same batch used for the rest of the
evaluation, instead of going directly to store.Engine (this adds
SpanSet enforcement to it, as discussed in #10084).

This also consolidates two bits of slightly different code on the read
and write paths, and removes a special case that exempted HeartbeatTxn
from abort cache checks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14567)
<!-- Reviewable:end -->
