### PR TITLE
sql: enable subquery_retry_multinode test

### DIFF
--- a/pkg/sql/testdata/parallel_test/subquery_retry_multinode/test.yaml
+++ b/pkg/sql/testdata/parallel_test/subquery_retry_multinode/test.yaml
@@ -1,6 +1,3 @@
-# Test is temporarily disabled.
-skip_reason: "#8057"
-
 cluster_size: 5
 
 range_split_size: 32768

--- a/pkg/sql/testdata/parallel_test/subquery_retry_multinode/txn
+++ b/pkg/sql/testdata/parallel_test/subquery_retry_multinode/txn
@@ -5,6 +5,6 @@
 # We insert a large filler string in the second column to generate range splits
 # quicker.
 
-repeat 2
+repeat 20
 statement ok
 INSERT INTO T VALUES ((SELECT MAX(k+1) FROM T), REPEAT('x', 1000))


### PR DESCRIPTION
The test was disabled because of an occasional timeout during cluster setup; I
can no longer reproduce this.

Closes #8057.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14568)
<!-- Reviewable:end -->
