### PR TITLE
build: add make testlogic target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ PKG          := ./pkg/...
 TAGS         :=
 TESTS        := .
 BENCHES      := -
+FILES        := -
 TESTTIMEOUT  := 3m
 RACETIMEOUT  := 10m
 BENCHTIMEOUT := 5m
@@ -161,6 +162,16 @@ endif
 testraceslow: override GOFLAGS += -race
 testraceslow: TESTTIMEOUT := $(RACETIMEOUT)
 testraceslow: testslow
+
+# This is how you get a literal space into a Makefile.
+space := $(eval) $(eval)
+
+# Run make testlogic FILES="foo bar" to run the logic tests named foo and bar.
+.PHONY: testlogic
+testlogic: PKG := ./pkg/sql
+testlogic: TESTS := TestLogic$$//^$(subst $(space),$$|^,$(FILES))$$
+testlogic: TESTFLAGS := -v -show-sql
+testlogic: test
 
 # Beware! This target is complicated because it needs to handle complexity:
 # - PKG may be specified as relative (e.g. './gossip') or absolute (e.g.

--- a/build/variables.mk
+++ b/build/variables.mk
@@ -12,6 +12,7 @@ define VALID_VARS
   COCKROACH
   CXX
   DUPLFLAGS
+  FILES
   GITHOOKS
   GITHOOKSDIR
   GIT_DIR
@@ -41,4 +42,5 @@ define VALID_VARS
   TYPE
   UI_ROOT
   XGO
+  space
 endef


### PR DESCRIPTION
`make testlogic FILES="foo bar"` now runs LogicTest on the files named
`foo` and `bar`, by default with `TESTFLAGS=-v -show-sql`.
Bikeshed away - I'd just like some kind of in-repo shortcut for running a particular logic test. @RaduBerinde's script is good but it would be nice if everyone could get something like it by default in the repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14569)
<!-- Reviewable:end -->
