### PR TITLE
internal/rsg: add regfoo types

### DIFF
--- a/pkg/internal/rsg/rsg.go
+++ b/pkg/internal/rsg/rsg.go
@@ -207,6 +207,11 @@ func (r *RSG) GenerateRandomArg(typ parser.Type) string {
 	case parser.TypeIntArray,
 		parser.TypeStringArray,
 		parser.TypeOid,
+		parser.TypeRegClass,
+		parser.TypeRegNamespace,
+		parser.TypeRegProc,
+		parser.TypeRegProcedure,
+		parser.TypeRegType,
 		parser.TypeAnyArray,
 		parser.TypeAny:
 		v = "NULL"


### PR DESCRIPTION
The new regfoo postgres types were never added to RSG's switch
statement.

Fixes #14571.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14572)
<!-- Reviewable:end -->
