### PR TITLE
	storageccl: use UnsafeKey in MVCCIncrementalIterator

### DIFF
--- a/pkg/ccl/sqlccl/bench_test.go
+++ b/pkg/ccl/sqlccl/bench_test.go
@@ -47,7 +47,7 @@ func BenchmarkClusterBackup(b *testing.B) {
 	if _, err := Load(ctx, sqlDB.DB, bankStatementBuf(b.N), "bench", dir, ts, 0, dir); err != nil {
 		b.Fatalf("%+v", err)
 	}
-	sqlDB.Exec(fmt.Sprintf(`RESTORE DATABASE bench FROM '%s'`, dir))
+	sqlDB.Exec(fmt.Sprintf(`RESTORE bench.* FROM '%s'`, dir))
 
 	// TODO(dan): Ideally, this would split and rebalance the ranges in a more
 	// controlled way. A previous version of this code did it manually with
@@ -85,7 +85,7 @@ func BenchmarkClusterRestore(b *testing.B) {
 	}
 	b.SetBytes(backup.DataSize / int64(b.N))
 	b.ResetTimer()
-	sqlDB.Exec(fmt.Sprintf(`RESTORE DATABASE bench FROM '%s'`, dir))
+	sqlDB.Exec(fmt.Sprintf(`RESTORE bench.* FROM '%s'`, dir))
 	b.StopTimer()
 }
 
@@ -108,7 +108,7 @@ func BenchmarkLoadRestore(b *testing.B) {
 	if _, err := Load(ctx, sqlDB.DB, buf, "bench", dir, ts, 0, dir); err != nil {
 		b.Fatalf("%+v", err)
 	}
-	sqlDB.Exec(fmt.Sprintf(`RESTORE DATABASE bench FROM '%s'`, dir))
+	sqlDB.Exec(fmt.Sprintf(`RESTORE bench.* FROM '%s'`, dir))
 	b.StopTimer()
 }
 

--- a/pkg/ccl/storageccl/engineccl/mvcc.go
+++ b/pkg/ccl/storageccl/engineccl/mvcc.go
@@ -89,15 +89,14 @@ func (i *MVCCIncrementalIterator) Next() {
 			continue
 		}
 
-		// TODO(dan): iter.unsafeKey() to avoid the allocation.
-		metaKey := i.iter.Key()
-		if !metaKey.Less(i.endKey) {
+		unsafeMetaKey := i.iter.UnsafeKey()
+		if !unsafeMetaKey.Less(i.endKey) {
 			i.valid = false
 			return
 		}
-		if metaKey.IsValue() {
+		if unsafeMetaKey.IsValue() {
 			i.meta.Reset()
-			i.meta.Timestamp = metaKey.Timestamp
+			i.meta.Timestamp = unsafeMetaKey.Timestamp
 		} else {
 			if i.err = i.iter.ValueProto(&i.meta); i.err != nil {
 				i.valid = false
@@ -110,10 +109,10 @@ func (i *MVCCIncrementalIterator) Next() {
 			// up, throw an error so it's obvious something is wrong.
 			i.valid = false
 			i.err = errors.Errorf("inline values are unsupported by MVCCIncrementalIterator: %s",
-				metaKey.Key)
+				unsafeMetaKey.Key)
 			return
 		}
-		if metaKey.Key == nil {
+		if unsafeMetaKey.Key == nil {
 			// iter was pointed after i.endKey.
 			break
 		}
@@ -121,7 +120,11 @@ func (i *MVCCIncrementalIterator) Next() {
 		if i.meta.Txn != nil {
 			if !i.endTime.Less(i.meta.Timestamp) {
 				i.err = &roachpb.WriteIntentError{
-					Intents: []roachpb.Intent{{Span: roachpb.Span{Key: metaKey.Key}, Status: roachpb.PENDING, Txn: *i.meta.Txn}},
+					Intents: []roachpb.Intent{{
+						Span:   roachpb.Span{Key: i.iter.Key().Key},
+						Status: roachpb.PENDING,
+						Txn:    *i.meta.Txn,
+					}},
 				}
 				i.valid = false
 				return
@@ -164,4 +167,16 @@ func (i *MVCCIncrementalIterator) Key() engine.MVCCKey {
 // Value returns the current value as a byte slice.
 func (i *MVCCIncrementalIterator) Value() []byte {
 	return i.iter.Value()
+}
+
+// UnsafeKey returns the same key as Key, but the memory is invalidated on the
+// next call to {Next,Reset,Close}.
+func (i *MVCCIncrementalIterator) UnsafeKey() engine.MVCCKey {
+	return i.iter.UnsafeKey()
+}
+
+// UnsafeValue returns the same value as Value, but the memory is invalidated on
+// the next call to {Next,Reset,Close}.
+func (i *MVCCIncrementalIterator) UnsafeValue() []byte {
+	return i.iter.UnsafeValue()
 }

--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -101,13 +101,13 @@ func evalExport(
 	defer iter.Close()
 	iter.Reset(args.Key, args.EndKey, args.StartTime, h.Timestamp)
 	for ; iter.Valid(); iter.Next() {
-		key, value := iter.Key(), iter.Value()
 		if log.V(3) {
-			log.Infof(ctx, "Export %+v %+v", key, value)
+			v := roachpb.Value{RawBytes: iter.UnsafeValue()}
+			log.Infof(ctx, "Export %s %s", iter.UnsafeKey(), v.PrettyPrint())
 		}
 		entries++
-		if err := sst.Add(engine.MVCCKeyValue{Key: key, Value: value}); err != nil {
-			return storage.EvalResult{}, errors.Wrapf(err, "adding key %s", key)
+		if err := sst.Add(engine.MVCCKeyValue{Key: iter.UnsafeKey(), Value: iter.UnsafeValue()}); err != nil {
+			return storage.EvalResult{}, errors.Wrapf(err, "adding key %s", iter.UnsafeKey())
 		}
 	}
 	if err := iter.Error(); err != nil {


### PR DESCRIPTION
It saves some allocations.

name             old time/op    new time/op    delta
ClusterBackup-8    1.75µs ±34%    1.90µs ±27%     ~     (p=0.690 n=5+5)

name             old speed      new speed      delta
ClusterBackup-8  74.9MB/s ±30%  67.2MB/s ±32%     ~     (p=0.690 n=5+5)

name             old alloc/op   new alloc/op   delta
ClusterBackup-8      200B ±35%       5B ±120%  -97.50%  (p=0.016 n=5+4)

name             old allocs/op  new allocs/op  delta
ClusterBackup-8      3.00 ± 0%     0.00 ±NaN%     ~     (p=0.079 n=4+5)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14573)
<!-- Reviewable:end -->
