### PR TITLE
cli: disallow --database in dump

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -388,9 +388,11 @@ func init() {
 	for _, cmd := range sqlCmds {
 		f := cmd.PersistentFlags()
 		stringFlag(f, &connURL, cliflags.URL, "")
-
 		stringFlag(f, &connUser, cliflags.User, security.RootUser)
-		stringFlag(f, &connDBName, cliflags.Database, "")
+
+		if cmd == sqlShellCmd {
+			stringFlag(f, &connDBName, cliflags.Database, "")
+		}
 	}
 
 	// Commands that print tables.


### PR DESCRIPTION
Although the proposal in the listed issue discussed different arguments
for dump, for now just drop use of --database since it was incorrectly
being listed.

Fixes #7963

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14579)
<!-- Reviewable:end -->
