### PR TITLE
cli: Attempt to remove race causing `cockroach quit` flakes

### DIFF
--- a/pkg/util/grpcutil/grpc_util.go
+++ b/pkg/util/grpcutil/grpc_util.go
@@ -38,6 +38,7 @@ func IsClosedConnection(err error) bool {
 		grpc.Code(err) == codes.Unavailable ||
 		grpc.ErrorDesc(err) == grpc.ErrClientConnClosing.Error() ||
 		strings.Contains(err.Error(), "is closing") ||
+		strings.Contains(err.Error(), "use of closed network connection") ||
 		strings.Contains(err.Error(), "node unavailable") {
 		return true
 	}


### PR DESCRIPTION
I can't say for sure because I haven't been able to reproduce the issue locally, but I believe this fixes #14184.

Suggestions welcome. I know you've dug much farther into this before than me, @tamird

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14587)
<!-- Reviewable:end -->
