### PR TITLE
sql/parser: improve error on out-of-range integer constants

### DIFF
--- a/pkg/sql/testdata/logic_test/typing
+++ b/pkg/sql/testdata/logic_test/typing
@@ -22,6 +22,9 @@ INSERT INTO i(x) VALUES (4.5)
 statement ok
 INSERT INTO i(x) VALUES (((9 / 3) * (1 / 3))), (2.0), (2.4 + 4.6)
 
+statement error numeric constant out of int64 range
+INSERT INTO i(x) VALUES (9223372036854775809)
+
 query I rowsort
 SELECT * FROM i
 ----


### PR DESCRIPTION
Fixes #5429.

We now specifically mention the integer overflow in cases where an
INTEGER is desired from a numeric constant but a DECIMAL would be used
because of an overflow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14594)
<!-- Reviewable:end -->
