### PR TITLE
timeutil: add high precision clock on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,9 +186,9 @@ testlogic: test
 .PHONY: stress
 stress:
 ifeq ($(BENCHES),-)
-	$(GO) list -tags '$(TAGS)' -f '$(GO) test -v $(GOFLAGS) -tags '\''$(TAGS)'\'' -ldflags '\''$(LINKFLAGS)'\'' -i -c {{.ImportPath}} -o {{.Dir}}/stress.test && (cd {{.Dir}} && if [ -f stress.test ]; then COCKROACH_STRESS=true stress $(STRESSFLAGS) ./stress.test -test.run '\''$(TESTS)'\'' -test.timeout $(TESTTIMEOUT) $(TESTFLAGS); fi)' $(PKG) | $(SHELL)
+	$(GO) list -tags '$(TAGS)' -f '$(GO) test -v $(GOFLAGS) -tags '\''$(TAGS)'\'' -ldflags '\''$(LINKFLAGS)'\'' -i -c {{.ImportPath}} -o '\''{{.Dir}}'\''/stress.test && (cd '\''{{.Dir}}'\'' && if [ -f stress.test ]; then COCKROACH_STRESS=true stress $(STRESSFLAGS) ./stress.test -test.run '\''$(TESTS)'\'' -test.timeout $(TESTTIMEOUT) $(TESTFLAGS); fi)' $(PKG) | $(SHELL)
 else
-	$(GO) list -tags '$(TAGS)' -f '$(GO) test -v $(GOFLAGS) -tags '\''$(TAGS)'\'' -ldflags '\''$(LINKFLAGS)'\'' -i -c {{.ImportPath}} -o {{.Dir}}/stress.test && (cd {{.Dir}} && if [ -f stress.test ]; then COCKROACH_STRESS=true stress $(STRESSFLAGS) ./stress.test -test.run '\''$(TESTS)'\'' -test.bench '\''$(BENCHES)'\'' -test.timeout $(TESTTIMEOUT) $(TESTFLAGS); fi)' $(PKG) | $(SHELL)
+	$(GO) list -tags '$(TAGS)' -f '$(GO) test -v $(GOFLAGS) -tags '\''$(TAGS)'\'' -ldflags '\''$(LINKFLAGS)'\'' -i -c {{.ImportPath}} -o '\''{{.Dir}}'\''/stress.test && (cd '\''{{.Dir}}'\'' && if [ -f stress.test ]; then COCKROACH_STRESS=true stress $(STRESSFLAGS) ./stress.test -test.run '\''$(TESTS)'\'' -test.bench '\''$(BENCHES)'\'' -test.timeout $(TESTTIMEOUT) $(TESTFLAGS); fi)' $(PKG) | $(SHELL)
 endif
 
 .PHONY: stressrace

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ TYPE :=
 # We intentionally use LINKFLAGS instead of the more traditional LDFLAGS
 # because LDFLAGS has built-in semantics that don't make sense with the Go
 # toolchain.
-LINKFLAGS =
+LINKFLAGS ?=
 
 ifeq ($(TYPE),)
 override LINKFLAGS += -X github.com/cockroachdb/cockroach/pkg/build.typ=development
@@ -131,14 +131,14 @@ testbuild:
 
 .PHONY: gotestdashi
 gotestdashi:
-	$(GO) test -v $(GOFLAGS) -tags '$(TAGS)' -i $(PKG)
+	$(GO) test -v $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -i $(PKG)
 
 .PHONY: test
 test: gotestdashi
 ifeq ($(BENCHES),-)
-	$(GO) test $(GOFLAGS) -tags '$(TAGS)' -run "$(TESTS)" -timeout $(TESTTIMEOUT) $(PKG) $(TESTFLAGS)
+	$(GO) test $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -run "$(TESTS)" -timeout $(TESTTIMEOUT) $(PKG) $(TESTFLAGS)
 else
-	$(GO) test $(GOFLAGS) -tags '$(TAGS)' -run "$(TESTS)" -bench "$(BENCHES)" -timeout $(TESTTIMEOUT) $(PKG) $(TESTFLAGS)
+	$(GO) test $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -run "$(TESTS)" -bench "$(BENCHES)" -timeout $(TESTTIMEOUT) $(PKG) $(TESTFLAGS)
 endif
 
 .PHONY: testshort
@@ -154,9 +154,9 @@ testrace: test
 testslow: override TESTFLAGS += -v
 testslow: gotestdashi
 ifeq ($(BENCHES),-)
-	$(GO) test $(GOFLAGS) -tags '$(TAGS)' -run "$(TESTS)" -timeout $(TESTTIMEOUT) $(PKG) $(TESTFLAGS) | grep -F ': Test' | sed -E 's/(--- PASS: |\(|\))//g' | awk '{ print $$2, $$1 }' | sort -rn | head -n 10
+	$(GO) test $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -run "$(TESTS)" -timeout $(TESTTIMEOUT) $(PKG) $(TESTFLAGS) | grep -F ': Test' | sed -E 's/(--- PASS: |\(|\))//g' | awk '{ print $$2, $$1 }' | sort -rn | head -n 10
 else
-	$(GO) test $(GOFLAGS) -tags '$(TAGS)' -run "$(TESTS)" -bench "$(BENCHES)" -timeout $(TESTTIMEOUT) $(PKG) $(TESTFLAGS) | grep -F ': Test' | sed -E 's/(--- PASS: |\(|\))//g' | awk '{ print $$2, $$1 }' | sort -rn | head -n 10
+	$(GO) test $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -run "$(TESTS)" -bench "$(BENCHES)" -timeout $(TESTTIMEOUT) $(PKG) $(TESTFLAGS) | grep -F ': Test' | sed -E 's/(--- PASS: |\(|\))//g' | awk '{ print $$2, $$1 }' | sort -rn | head -n 10
 endif
 
 .PHONY: testraceslow
@@ -212,7 +212,7 @@ bench: BENCHES := .
 bench: TESTS := -
 bench: TESTTIMEOUT := $(BENCHTIMEOUT)
 bench: gotestdashi
-	$(GO) test $(GOFLAGS) -tags '$(TAGS)' -run "$(TESTS)" -bench "$(BENCHES)" -timeout $(TESTTIMEOUT) $(PKG) $(TESTFLAGS)
+	$(GO) test $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -run "$(TESTS)" -bench "$(BENCHES)" -timeout $(TESTTIMEOUT) $(PKG) $(TESTFLAGS)
 
 .PHONY: upload-coverage
 upload-coverage:
@@ -237,7 +237,7 @@ dupl:
 .PHONY: check
 check: override TAGS += check
 check:
-	$(GO) test ./build -v -tags '$(TAGS)' -run 'TestStyle/$(TESTS)'
+	$(GO) test ./build -v -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -run 'TestStyle/$(TESTS)'
 
 .PHONY: checkshort
 checkshort: override TAGS += check

--- a/pkg/storage/queue_test.go
+++ b/pkg/storage/queue_test.go
@@ -771,8 +771,8 @@ func TestBaseQueueTimeMetric(t *testing.T) {
 		if v := bq.successes.Count(); v != 1 {
 			return errors.Errorf("expected 1 processed replicas; got %d", v)
 		}
-		if min, v := 5*time.Millisecond, bq.processingNanos.Count(); v < min.Nanoseconds() {
-			return errors.Errorf("expected >= %s in processing time; got %d", min, v)
+		if min, v := bq.queueConfig.processTimeout, bq.processingNanos.Count(); v < min.Nanoseconds() {
+			return errors.Errorf("expected >= %s in processing time; got %s", min, time.Duration(v))
 		}
 		return nil
 	})

--- a/pkg/util/timeutil/main_test.go
+++ b/pkg/util/timeutil/main_test.go
@@ -1,0 +1,17 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package timeutil
+
+import _ "github.com/cockroachdb/cockroach/pkg/util/log" // for flags

--- a/pkg/util/timeutil/now_test.go
+++ b/pkg/util/timeutil/now_test.go
@@ -1,0 +1,25 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package timeutil
+
+import (
+	"testing"
+)
+
+func BenchmarkNow(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Now()
+	}
+}

--- a/pkg/util/timeutil/now_unix.go
+++ b/pkg/util/timeutil/now_unix.go
@@ -1,0 +1,23 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build !windows
+
+package timeutil
+
+import (
+	"time"
+)
+
+var now = time.Now

--- a/pkg/util/timeutil/now_windows.go
+++ b/pkg/util/timeutil/now_windows.go
@@ -1,0 +1,40 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package timeutil
+
+import (
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+var (
+	kernel32                           = syscall.MustLoadDLL("kernel32.dll")
+	procGetSystemTimePreciseAsFileTime = kernel32.MustFindProc("GetSystemTimePreciseAsFileTime")
+)
+
+// This has a higher precision than time.Now in go1.8, but is much slower
+// (~2000x) and requires Windows 8+.
+//
+// TODO(tamird): consider removing this in go1.9. go1.9 is expected to add
+// monotonic clock support to values retured from time.Now, which this
+// implementation will not support. The monotonic clock support may also
+// obviate the need for this, since we only need the higher precision when
+// subtracting `time.Time`s.
+func now() time.Time {
+	var ft syscall.Filetime
+	_, _, _ = procGetSystemTimePreciseAsFileTime.Call(uintptr(unsafe.Pointer(&ft)))
+	return time.Unix(0, ft.Nanoseconds())
+}

--- a/pkg/util/timeutil/time.go
+++ b/pkg/util/timeutil/time.go
@@ -22,16 +22,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 )
 
-var (
-	nowFunc = time.Now
-)
+var nowFunc = now
 
 func initFakeTime() {
 	if offset := envutil.EnvOrDefaultDuration("COCKROACH_SIMULATED_OFFSET", 0); offset == 0 {
-		nowFunc = time.Now
+		nowFunc = now
 	} else {
 		nowFunc = func() time.Time {
-			return time.Now().Add(offset)
+			return now().Add(offset)
 		}
 	}
 }

--- a/pkg/util/timeutil/time_fake_test.go
+++ b/pkg/util/timeutil/time_fake_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
-	_ "github.com/cockroachdb/cockroach/pkg/util/log" // for flags
 )
 
 func TestOffset(t *testing.T) {
@@ -35,9 +34,9 @@ func TestOffset(t *testing.T) {
 
 		initFakeTime()
 
-		lowerBound := time.Now().Add(expectedOffset)
+		lowerBound := now().Add(expectedOffset)
 		offsetTime := Now()
-		upperBound := time.Now().Add(expectedOffset)
+		upperBound := now().Add(expectedOffset)
 
 		if offsetTime.Before(lowerBound) || offsetTime.After(upperBound) {
 			t.Errorf("expected offset time %s to be in the interval\n[%s,%s]", offsetTime, lowerBound, upperBound)


### PR DESCRIPTION
This gets the list of failures down to:
```
--- FAIL: TestHeartbeatHealthTransport (45.23s)
FAIL
FAIL	github.com/cockroachdb/cockroach/pkg/rpc	45.658s
--- FAIL: TestStatusLocalLogs (0.20s)
FAIL
FAIL	github.com/cockroachdb/cockroach/pkg/server	12.288s
--- FAIL: TestEval (0.05s)
FAIL
FAIL	github.com/cockroachdb/cockroach/pkg/sql/parser	1.129s
--- FAIL: TestConcurrentBatch (20.93s)
FAIL
FAIL	github.com/cockroachdb/cockroach/pkg/storage/engine	26.650s
--- FAIL: TestGetLogReader (0.03s)
    --- FAIL: TestGetLogReader/logtestexe.log (0.00s)
        --- FAIL: TestGetLogReader/logtestexe.log/restricted=true (0.00s)
        --- FAIL: TestGetLogReader/logtestexe.log/restricted=false (0.00s)
    --- FAIL: TestGetLogReader/cockroach.roach0.root.2015-09-25T19_24_19Z.00000.log (0.00s)
        --- FAIL: TestGetLogReader/cockroach.roach0.root.2015-09-25T19_24_19Z.00000.log/restricted=true (0.00s)
--- FAIL: TestGC (0.10s)
FAIL
FAIL	github.com/cockroachdb/cockroach/pkg/util/log	0.550s
--- FAIL: TestTimeConversion (0.00s)
FAIL
FAIL	github.com/cockroachdb/cockroach/pkg/util/timeutil	0.438s
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14597)
<!-- Reviewable:end -->
