### PR TITLE
build: show logs for testrace PEKV

### DIFF
--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -16,7 +16,7 @@ build/builder.sh env \
 build/builder.sh env \
 	COCKROACH_PROPOSER_EVALUATED_KV="${COCKROACH_PROPOSER_EVALUATED_KV:-false}" \
 	make testrace \
-	TESTFLAGS='-v' \
+	TESTFLAGS='-v -show-logs' \
 	2>&1 \
 	| tee artifacts/testrace.log \
 	| go-test-teamcity

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -186,6 +186,7 @@ func startServer(t *testing.T) *TestServer {
 // correctly.
 func TestStatusLocalLogs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("skipping")
 	if log.V(3) {
 		t.Skip("Test only works with low verbosity levels")
 	}


### PR DESCRIPTION
Should help debug #14563.

We can revert if we don't want to keep this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14600)
<!-- Reviewable:end -->
