### PR TITLE
Add help strings to metrics.

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -124,13 +124,27 @@ const (
 
 // Gossip metrics counter names.
 var (
-	MetaConnectionsIncomingGauge = metric.Metadata{Name: "gossip.connections.incoming"}
-	MetaConnectionsOutgoingGauge = metric.Metadata{Name: "gossip.connections.outgoing"}
-	MetaConnectionsRefusedRates  = metric.Metadata{Name: "gossip.connections.refused"}
-	MetaInfosSentRates           = metric.Metadata{Name: "gossip.infos.sent"}
-	MetaInfosReceivedRates       = metric.Metadata{Name: "gossip.infos.received"}
-	MetaBytesSentRates           = metric.Metadata{Name: "gossip.bytes.sent"}
-	MetaBytesReceivedRates       = metric.Metadata{Name: "gossip.bytes.received"}
+	MetaConnectionsIncomingGauge = metric.Metadata{
+		Name: "gossip.connections.incoming",
+		Help: "Number of active incoming gossip connections"}
+	MetaConnectionsOutgoingGauge = metric.Metadata{
+		Name: "gossip.connections.outgoing",
+		Help: "Number of active outgoing gossip connections"}
+	MetaConnectionsRefused = metric.Metadata{
+		Name: "gossip.connections.refused",
+		Help: "Number of refused incoming gossip connections"}
+	MetaInfosSent = metric.Metadata{
+		Name: "gossip.infos.sent",
+		Help: "Number of sent gossip Info objects"}
+	MetaInfosReceived = metric.Metadata{
+		Name: "gossip.infos.received",
+		Help: "Number of received gossip Info objects"}
+	MetaBytesSent = metric.Metadata{
+		Name: "gossip.bytes.sent",
+		Help: "Number of sent gossip bytes"}
+	MetaBytesReceived = metric.Metadata{
+		Name: "gossip.bytes.received",
+		Help: "Number of received gossip bytes"}
 )
 
 var (
@@ -1292,10 +1306,10 @@ func (m Metrics) String() string {
 
 func makeMetrics() Metrics {
 	return Metrics{
-		ConnectionsRefused: metric.NewCounter(MetaConnectionsRefusedRates),
-		BytesReceived:      metric.NewCounter(MetaBytesReceivedRates),
-		BytesSent:          metric.NewCounter(MetaBytesSentRates),
-		InfosReceived:      metric.NewCounter(MetaInfosReceivedRates),
-		InfosSent:          metric.NewCounter(MetaInfosSentRates),
+		ConnectionsRefused: metric.NewCounter(MetaConnectionsRefused),
+		BytesReceived:      metric.NewCounter(MetaBytesReceived),
+		BytesSent:          metric.NewCounter(MetaBytesSent),
+		InfosReceived:      metric.NewCounter(MetaInfosReceived),
+		InfosSent:          metric.NewCounter(MetaInfosSent),
 	}
 }

--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -64,36 +64,28 @@ const (
 var (
 	metaDistSenderBatchCount = metric.Metadata{
 		Name: "distsender.batches",
-		Help: "Number of batches processed",
-	}
+		Help: "Number of batches processed"}
 	metaDistSenderPartialBatchCount = metric.Metadata{
 		Name: "distsender.batches.partial",
-		Help: "Number of partial batches processed",
-	}
+		Help: "Number of partial batches processed"}
 	metaTransportSentCount = metric.Metadata{
 		Name: "distsender.rpc.sent",
-		Help: "Number of RPCs sent",
-	}
+		Help: "Number of RPCs sent"}
 	metaTransportLocalSentCount = metric.Metadata{
 		Name: "distsender.rpc.sent.local",
-		Help: "Number of local RPCs sent",
-	}
+		Help: "Number of local RPCs sent"}
 	metaDistSenderSendNextTimeoutCount = metric.Metadata{
 		Name: "distsender.rpc.sent.sendnexttimeout",
-		Help: "Number of RPCs sent due to outstanding RPCs not returning promptly",
-	}
+		Help: "Number of RPCs sent due to outstanding RPCs not returning promptly"}
 	metaDistSenderNextReplicaErrCount = metric.Metadata{
 		Name: "distsender.rpc.sent.nextreplicaerror",
-		Help: "Number of RPCs sent due to per-replica errors",
-	}
+		Help: "Number of RPCs sent due to per-replica errors"}
 	metaDistSenderNotLeaseHolderErrCount = metric.Metadata{
 		Name: "distsender.errors.notleaseholder",
-		Help: "Number of NotLeaseHolderErrors encountered",
-	}
+		Help: "Number of NotLeaseHolderErrors encountered"}
 	metaSlowDistSenderRequests = metric.Metadata{
 		Name: "requests.slow.distsender",
-		Help: "Number of requests that have been stuck for a long time in the dist sender",
-	}
+		Help: "Number of requests that have been stuck for a long time in the dist sender"}
 )
 
 // DistSenderMetrics is the set of metrics for a given distributed sender.

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -115,12 +115,24 @@ type TxnMetrics struct {
 }
 
 var (
-	metaAbortsRates         = metric.Metadata{Name: "txn.aborts"}
-	metaCommitsRates        = metric.Metadata{Name: "txn.commits"}
-	metaCommits1PCRates     = metric.Metadata{Name: "txn.commits1PC"}
-	metaAbandonsRates       = metric.Metadata{Name: "txn.abandons"}
-	metaDurationsHistograms = metric.Metadata{Name: "txn.durations"}
-	metaRestartsHistogram   = metric.Metadata{Name: "txn.restarts"}
+	metaAbortsRates = metric.Metadata{
+		Name: "txn.aborts",
+		Help: "Number of aborted KV transactions"}
+	metaCommitsRates = metric.Metadata{
+		Name: "txn.commits",
+		Help: "Number of committed KV transactions (including 1PC)"}
+	metaCommits1PCRates = metric.Metadata{
+		Name: "txn.commits1PC",
+		Help: "Number of committed one-phase KV transactions"}
+	metaAbandonsRates = metric.Metadata{
+		Name: "txn.abandons",
+		Help: "Number of abandoned KV transactions"}
+	metaDurationsHistograms = metric.Metadata{
+		Name: "txn.durations",
+		Help: "KV transaction durations"}
+	metaRestartsHistogram = metric.Metadata{
+		Name: "txn.restarts",
+		Help: "Number of restarted KV transactions"}
 )
 
 // MakeTxnMetrics returns a TxnMetrics struct that contains metrics whose

--- a/pkg/rpc/clock_offset.go
+++ b/pkg/rpc/clock_offset.go
@@ -49,9 +49,15 @@ type RemoteClockMetrics struct {
 const avgLatencyMeasurementAge = 20.0
 
 var (
-	metaClockOffsetMeanNanos   = metric.Metadata{Name: "clock-offset.meannanos"}
-	metaClockOffsetStdDevNanos = metric.Metadata{Name: "clock-offset.stddevnanos"}
-	metaLatencyHistogramNanos  = metric.Metadata{Name: "round-trip-latency"}
+	metaClockOffsetMeanNanos = metric.Metadata{
+		Name: "clock-offset.meannanos",
+		Help: "Mean clock offset with other nodes"}
+	metaClockOffsetStdDevNanos = metric.Metadata{
+		Name: "clock-offset.stddevnanos",
+		Help: "Stdddev clock offset with other nodes"}
+	metaLatencyHistogramNanos = metric.Metadata{
+		Name: "round-trip-latency",
+		Help: "Distribution of round-trip latencies with other nodes"}
 )
 
 // RemoteClockMonitor keeps track of the most recent measurements of remote

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -64,9 +64,15 @@ const (
 
 // Metric names.
 var (
-	metaExecLatency = metric.Metadata{Name: "exec.latency"}
-	metaExecSuccess = metric.Metadata{Name: "exec.success"}
-	metaExecError   = metric.Metadata{Name: "exec.error"}
+	metaExecLatency = metric.Metadata{
+		Name: "exec.latency",
+		Help: "Latency of batch KV requests executed on this node"}
+	metaExecSuccess = metric.Metadata{
+		Name: "exec.success",
+		Help: "Number of batch KV requests executed successfully on this node"}
+	metaExecError = metric.Metadata{
+		Name: "exec.error",
+		Help: "Number of batch KV requests that failed to execute on this node"}
 )
 
 // errNeedsBootstrap indicates the node should be used as the seed of

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -62,20 +62,48 @@ const metricsSampleInterval = 10 * time.Second
 
 // Fully-qualified names for metrics.
 var (
-	MetaTxnBegin           = metric.Metadata{Name: "sql.txn.begin.count"}
-	MetaTxnCommit          = metric.Metadata{Name: "sql.txn.commit.count"}
-	MetaTxnAbort           = metric.Metadata{Name: "sql.txn.abort.count"}
-	MetaTxnRollback        = metric.Metadata{Name: "sql.txn.rollback.count"}
-	MetaSelect             = metric.Metadata{Name: "sql.select.count"}
-	MetaSQLExecLatency     = metric.Metadata{Name: "sql.exec.latency"}
-	MetaDistSQLSelect      = metric.Metadata{Name: "sql.distsql.select.count"}
-	MetaDistSQLExecLatency = metric.Metadata{Name: "sql.distsql.exec.latency"}
-	MetaUpdate             = metric.Metadata{Name: "sql.update.count"}
-	MetaInsert             = metric.Metadata{Name: "sql.insert.count"}
-	MetaDelete             = metric.Metadata{Name: "sql.delete.count"}
-	MetaDdl                = metric.Metadata{Name: "sql.ddl.count"}
-	MetaMisc               = metric.Metadata{Name: "sql.misc.count"}
-	MetaQuery              = metric.Metadata{Name: "sql.query.count"}
+	MetaTxnBegin = metric.Metadata{
+		Name: "sql.txn.begin.count",
+		Help: "Number of SQL transaction BEGIN statements"}
+	MetaTxnCommit = metric.Metadata{
+		Name: "sql.txn.commit.count",
+		Help: "Number of SQL transaction COMMIT statements"}
+	MetaTxnAbort = metric.Metadata{
+		Name: "sql.txn.abort.count",
+		Help: "Number of SQL transaction ABORT statements"}
+	MetaTxnRollback = metric.Metadata{
+		Name: "sql.txn.rollback.count",
+		Help: "Number of SQL transaction ROLLBACK statements"}
+	MetaSelect = metric.Metadata{
+		Name: "sql.select.count",
+		Help: "Number of SQL SELECT statements"}
+	MetaSQLExecLatency = metric.Metadata{
+		Name: "sql.exec.latency",
+		Help: "Latency of SQL statement execution"}
+	MetaDistSQLSelect = metric.Metadata{
+		Name: "sql.distsql.select.count",
+		Help: "Number of dist-SQL SELECT statements"}
+	MetaDistSQLExecLatency = metric.Metadata{
+		Name: "sql.distsql.exec.latency",
+		Help: "Latency of dist-SQL statement execution"}
+	MetaUpdate = metric.Metadata{
+		Name: "sql.update.count",
+		Help: "Number of SQL UPDATE statements"}
+	MetaInsert = metric.Metadata{
+		Name: "sql.insert.count",
+		Help: "Number of SQL INSERT statements"}
+	MetaDelete = metric.Metadata{
+		Name: "sql.delete.count",
+		Help: "Number of SQL DELETE statements"}
+	MetaDdl = metric.Metadata{
+		Name: "sql.ddl.count",
+		Help: "Number of SQL DDL statements"}
+	MetaMisc = metric.Metadata{
+		Name: "sql.misc.count",
+		Help: "Number of other SQL statements"}
+	MetaQuery = metric.Metadata{
+		Name: "sql.query.count",
+		Help: "Number of SQL queries"}
 )
 
 type traceResult struct {

--- a/pkg/sql/mem_metrics.go
+++ b/pkg/sql/mem_metrics.go
@@ -59,13 +59,25 @@ const log10int64times1000 = 19 * 1000
 
 // MakeMemMetrics instantiates the metric objects for an SQL endpoint.
 func MakeMemMetrics(endpoint string, histogramWindow time.Duration) MemoryMetrics {
-	prefix := "sql.mon." + endpoint
-	MetaMemMaxBytes := metric.Metadata{Name: prefix + ".max"}
-	MetaMemCurBytes := metric.Metadata{Name: prefix + ".cur"}
-	MetaMemMaxTxnBytes := metric.Metadata{Name: prefix + ".txn.max"}
-	MetaMemTxnCurBytes := metric.Metadata{Name: prefix + ".txn.cur"}
-	MetaMemMaxSessionBytes := metric.Metadata{Name: prefix + ".session.max"}
-	MetaMemSessionCurBytes := metric.Metadata{Name: prefix + ".session.cur"}
+	prefix := "sql.mem." + endpoint
+	MetaMemMaxBytes := metric.Metadata{
+		Name: prefix + ".max",
+		Help: "Memory usage per sql statement for " + endpoint}
+	MetaMemCurBytes := metric.Metadata{
+		Name: prefix + ".current",
+		Help: "Current sql statement memory usage for " + endpoint}
+	MetaMemMaxTxnBytes := metric.Metadata{
+		Name: prefix + ".txn.max",
+		Help: "Memory usage per sql transaction for " + endpoint}
+	MetaMemTxnCurBytes := metric.Metadata{
+		Name: prefix + ".txn.current",
+		Help: "Current sql transaction memory usage for " + endpoint}
+	MetaMemMaxSessionBytes := metric.Metadata{
+		Name: prefix + ".session.max",
+		Help: "Memory usage per sql session for " + endpoint}
+	MetaMemSessionCurBytes := metric.Metadata{
+		Name: prefix + ".session.current",
+		Help: "Current sql session memory usage for " + endpoint}
 	return MemoryMetrics{
 		MaxBytesHist:         metric.NewHistogram(MetaMemMaxBytes, histogramWindow, log10int64times1000, 3),
 		CurBytesCount:        metric.NewCounter(MetaMemCurBytes),

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -48,9 +48,15 @@ const (
 
 // Fully-qualified names for metrics.
 var (
-	MetaConns    = metric.Metadata{Name: "sql.conns"}
-	MetaBytesIn  = metric.Metadata{Name: "sql.bytesin"}
-	MetaBytesOut = metric.Metadata{Name: "sql.bytesout"}
+	MetaConns = metric.Metadata{
+		Name: "sql.conns",
+		Help: "Number of active sql connections"}
+	MetaBytesIn = metric.Metadata{
+		Name: "sql.bytesin",
+		Help: "Number of sql bytes received"}
+	MetaBytesOut = metric.Metadata{
+		Name: "sql.bytesout",
+		Help: "Number of sql bytes sent"}
 )
 
 const (

--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -28,288 +28,424 @@ import (
 
 var (
 	// Replica metrics.
-	metaReplicaCount                  = metric.Metadata{Name: "replicas"}
-	metaReservedReplicaCount          = metric.Metadata{Name: "replicas.reserved"}
-	metaRaftLeaderCount               = metric.Metadata{Name: "replicas.leaders"}
+	metaReplicaCount = metric.Metadata{
+		Name: "replicas",
+		Help: "Number of replicas"}
+	metaReservedReplicaCount = metric.Metadata{
+		Name: "replicas.reserved",
+		Help: "Number of replicas reserved for snapshots"}
+	metaRaftLeaderCount = metric.Metadata{
+		Name: "replicas.leaders",
+		Help: "Number of raft leaders"}
 	metaRaftLeaderNotLeaseHolderCount = metric.Metadata{
 		Name: "replicas.leaders_not_leaseholders",
 		Help: "Number of replicas that are Raft leaders whose range lease is held by another store",
 	}
-	metaLeaseHolderCount = metric.Metadata{Name: "replicas.leaseholders"}
-	metaQuiescentCount   = metric.Metadata{Name: "replicas.quiescent"}
+	metaLeaseHolderCount = metric.Metadata{
+		Name: "replicas.leaseholders",
+		Help: "Number of lease holders"}
+	metaQuiescentCount = metric.Metadata{
+		Name: "replicas.quiescent",
+		Help: "Number of quiesced replicas"}
 
 	// Replica CommandQueue metrics. Max size metrics track the maximum value
 	// seen for all replicas during a single replica scan.
-	metaMaxCommandQueueSize = metric.Metadata{Name: "replicas.commandqueue.maxsize",
+	metaMaxCommandQueueSize = metric.Metadata{
+		Name: "replicas.commandqueue.maxsize",
 		Help: "Largest number of commands in any CommandQueue"}
-	metaMaxCommandQueueWriteCount = metric.Metadata{Name: "replicas.commandqueue.maxwritecount",
+	metaMaxCommandQueueWriteCount = metric.Metadata{
+		Name: "replicas.commandqueue.maxwritecount",
 		Help: "Largest number of read-write commands in any CommandQueue"}
-	metaMaxCommandQueueReadCount = metric.Metadata{Name: "replicas.commandqueue.maxreadcount",
+	metaMaxCommandQueueReadCount = metric.Metadata{
+		Name: "replicas.commandqueue.maxreadcount",
 		Help: "Largest number of read-only commands in any CommandQueue"}
-	metaMaxCommandQueueTreeSize = metric.Metadata{Name: "replicas.commandqueue.maxtreesize",
+	metaMaxCommandQueueTreeSize = metric.Metadata{
+		Name: "replicas.commandqueue.maxtreesize",
 		Help: "Largest number of intervals in any CommandQueue's interval tree"}
-	metaMaxCommandQueueOverlaps = metric.Metadata{Name: "replicas.commandqueue.maxoverlaps",
+	metaMaxCommandQueueOverlaps = metric.Metadata{
+		Name: "replicas.commandqueue.maxoverlaps",
 		Help: "Largest number of overlapping commands seen when adding to any CommandQueue"}
-	metaCombinedCommandQueueSize = metric.Metadata{Name: "replicas.commandqueue.combinedqueuesize",
+	metaCombinedCommandQueueSize = metric.Metadata{
+		Name: "replicas.commandqueue.combinedqueuesize",
 		Help: "Number of commands in all CommandQueues combined"}
-	metaCombinedCommandWriteCount = metric.Metadata{Name: "replicas.commandqueue.combinedwritecount",
+	metaCombinedCommandWriteCount = metric.Metadata{
+		Name: "replicas.commandqueue.combinedwritecount",
 		Help: "Number of read-write commands in all CommandQueues combined"}
-	metaCombinedCommandReadCount = metric.Metadata{Name: "replicas.commandqueue.combinedreadcount",
+	metaCombinedCommandReadCount = metric.Metadata{
+		Name: "replicas.commandqueue.combinedreadcount",
 		Help: "Number of read-only commands in all CommandQueues combined"}
 
 	// Range metrics.
-	metaRangeCount = metric.Metadata{Name: "ranges",
+	metaRangeCount = metric.Metadata{
+		Name: "ranges",
 		Help: "Number of ranges"}
-	metaUnavailableRangeCount = metric.Metadata{Name: "ranges.unavailable",
+	metaUnavailableRangeCount = metric.Metadata{
+		Name: "ranges.unavailable",
 		Help: "Number of ranges with fewer live replicas than needed for quorum"}
-	metaUnderReplicatedRangeCount = metric.Metadata{Name: "ranges.underreplicated",
+	metaUnderReplicatedRangeCount = metric.Metadata{
+		Name: "ranges.underreplicated",
 		Help: "Number of ranges with fewer live replicas than the replication target"}
 
 	// Lease request metrics.
-	metaLeaseRequestSuccessCount  = metric.Metadata{Name: "leases.success"}
-	metaLeaseRequestErrorCount    = metric.Metadata{Name: "leases.error"}
-	metaLeaseTransferSuccessCount = metric.Metadata{Name: "leases.transfers.success"}
-	metaLeaseTransferErrorCount   = metric.Metadata{Name: "leases.transfers.error"}
-	metaLeaseExpirationCount      = metric.Metadata{Name: "leases.expiration"}
-	metaLeaseEpochCount           = metric.Metadata{Name: "leases.epoch"}
+	metaLeaseRequestSuccessCount = metric.Metadata{
+		Name: "leases.success",
+		Help: "Number of successful lease requests"}
+	metaLeaseRequestErrorCount = metric.Metadata{
+		Name: "leases.error",
+		Help: "Number of failed lease requests"}
+	metaLeaseTransferSuccessCount = metric.Metadata{
+		Name: "leases.transfers.success",
+		Help: "Number of successful lease transfers"}
+	metaLeaseTransferErrorCount = metric.Metadata{
+		Name: "leases.transfers.error",
+		Help: "Number of failed lease transfers"}
+	metaLeaseExpirationCount = metric.Metadata{
+		Name: "leases.expiration",
+		Help: "Number of replicas using expiration-based leases"}
+	metaLeaseEpochCount = metric.Metadata{
+		Name: "leases.epoch",
+		Help: "Number of replicas using epoch-based leases"}
 
 	// Storage metrics.
-	metaLiveBytes       = metric.Metadata{Name: "livebytes"}
-	metaKeyBytes        = metric.Metadata{Name: "keybytes"}
-	metaValBytes        = metric.Metadata{Name: "valbytes"}
-	metaIntentBytes     = metric.Metadata{Name: "intentbytes"}
-	metaLiveCount       = metric.Metadata{Name: "livecount"}
-	metaKeyCount        = metric.Metadata{Name: "keycount"}
-	metaValCount        = metric.Metadata{Name: "valcount"}
-	metaIntentCount     = metric.Metadata{Name: "intentcount"}
-	metaIntentAge       = metric.Metadata{Name: "intentage"}
-	metaGcBytesAge      = metric.Metadata{Name: "gcbytesage"}
-	metaLastUpdateNanos = metric.Metadata{Name: "lastupdatenanos"}
-	metaCapacity        = metric.Metadata{Name: "capacity"}
-	metaAvailable       = metric.Metadata{Name: "capacity.available"}
-	metaReserved        = metric.Metadata{Name: "capacity.reserved"}
-	metaSysBytes        = metric.Metadata{Name: "sysbytes"}
-	metaSysCount        = metric.Metadata{Name: "syscount"}
+	metaLiveBytes = metric.Metadata{
+		Name: "livebytes",
+		Help: "Number of bytes of live data (keys plus values)"}
+	metaKeyBytes = metric.Metadata{
+		Name: "keybytes",
+		Help: "Number of bytes taken up by keys"}
+	metaValBytes = metric.Metadata{
+		Name: "valbytes",
+		Help: "Number of bytes taken up by values"}
+	metaIntentBytes = metric.Metadata{
+		Name: "intentbytes",
+		Help: "Number of bytes in intent KV pairs"}
+	metaLiveCount = metric.Metadata{
+		Name: "livecount",
+		Help: "Count of live keys"}
+	metaKeyCount = metric.Metadata{
+		Name: "keycount",
+		Help: "Count of all keys"}
+	metaValCount = metric.Metadata{
+		Name: "valcount",
+		Help: "Count of all values"}
+	metaIntentCount = metric.Metadata{
+		Name: "intentcount",
+		Help: "Count of intent keys"}
+	metaIntentAge = metric.Metadata{
+		Name: "intentage",
+		Help: "Cumulative age of intents"}
+	metaGcBytesAge = metric.Metadata{
+		Name: "gcbytesage",
+		Help: "Cumulative age of non-live data"}
+	metaLastUpdateNanos = metric.Metadata{
+		Name: "lastupdatenanos",
+		Help: "Time at which ages were last updated"}
+	metaCapacity = metric.Metadata{
+		Name: "capacity",
+		Help: "Total storage capacity"}
+	metaAvailable = metric.Metadata{
+		Name: "capacity.available",
+		Help: "Available storage capacity"}
+	metaReserved = metric.Metadata{
+		Name: "capacity.reserved",
+		Help: "Capacity reserved for snapshots"}
+	metaSysBytes = metric.Metadata{
+		Name: "sysbytes",
+		Help: "Number of bytes in system KV pairs"}
+	metaSysCount = metric.Metadata{
+		Name: "syscount",
+		Help: "Count of system KV pairs"}
 
 	// RocksDB metrics.
-	metaRdbBlockCacheHits           = metric.Metadata{Name: "rocksdb.block.cache.hits"}
-	metaRdbBlockCacheMisses         = metric.Metadata{Name: "rocksdb.block.cache.misses"}
-	metaRdbBlockCacheUsage          = metric.Metadata{Name: "rocksdb.block.cache.usage"}
-	metaRdbBlockCachePinnedUsage    = metric.Metadata{Name: "rocksdb.block.cache.pinned-usage"}
-	metaRdbBloomFilterPrefixChecked = metric.Metadata{Name: "rocksdb.bloom.filter.prefix.checked"}
-	metaRdbBloomFilterPrefixUseful  = metric.Metadata{Name: "rocksdb.bloom.filter.prefix.useful"}
-	metaRdbMemtableHits             = metric.Metadata{Name: "rocksdb.memtable.hits"}
-	metaRdbMemtableMisses           = metric.Metadata{Name: "rocksdb.memtable.misses"}
-	metaRdbMemtableTotalSize        = metric.Metadata{Name: "rocksdb.memtable.total-size"}
-	metaRdbFlushes                  = metric.Metadata{Name: "rocksdb.flushes"}
-	metaRdbCompactions              = metric.Metadata{Name: "rocksdb.compactions"}
-	metaRdbTableReadersMemEstimate  = metric.Metadata{Name: "rocksdb.table-readers-mem-estimate"}
-	metaRdbReadAmplification        = metric.Metadata{Name: "rocksdb.read-amplification"}
-	metaRdbNumSSTables              = metric.Metadata{
+	metaRdbBlockCacheHits = metric.Metadata{
+		Name: "rocksdb.block.cache.hits",
+		Help: "Count of block cache hits"}
+	metaRdbBlockCacheMisses = metric.Metadata{
+		Name: "rocksdb.block.cache.misses",
+		Help: "Count of block cache misses"}
+	metaRdbBlockCacheUsage = metric.Metadata{
+		Name: "rocksdb.block.cache.usage",
+		Help: "Bytes used by the block cache"}
+	metaRdbBlockCachePinnedUsage = metric.Metadata{
+		Name: "rocksdb.block.cache.pinned-usage",
+		Help: "Bytes pinned by the block cache"}
+	metaRdbBloomFilterPrefixChecked = metric.Metadata{
+		Name: "rocksdb.bloom.filter.prefix.checked",
+		Help: "Number of times the bloom filter was checked"}
+	metaRdbBloomFilterPrefixUseful = metric.Metadata{
+		Name: "rocksdb.bloom.filter.prefix.useful",
+		Help: "Number of times the bloom filter helped avoid iterator creation"}
+	metaRdbMemtableHits = metric.Metadata{
+		Name: "rocksdb.memtable.hits",
+		Help: "Number of memtable hits"}
+	metaRdbMemtableMisses = metric.Metadata{
+		Name: "rocksdb.memtable.misses",
+		Help: "Number of memtable misses"}
+	metaRdbMemtableTotalSize = metric.Metadata{
+		Name: "rocksdb.memtable.total-size",
+		Help: "Current size of memtable"}
+	metaRdbFlushes = metric.Metadata{
+		Name: "rocksdb.flushes",
+		Help: "Number of table flushes"}
+	metaRdbCompactions = metric.Metadata{
+		Name: "rocksdb.compactions",
+		Help: "Number of table compactions"}
+	metaRdbTableReadersMemEstimate = metric.Metadata{
+		Name: "rocksdb.table-readers-mem-estimate",
+		Help: "Memory used by index and filter blocks"}
+	metaRdbReadAmplification = metric.Metadata{
+		Name: "rocksdb.read-amplification",
+		Help: "Number of disk reads per query"}
+	metaRdbNumSSTables = metric.Metadata{
 		Name: "rocksdb.num-sstables",
-		Help: "Number of rocksdb SSTables",
-	}
+		Help: "Number of rocksdb SSTables"}
 
 	// Range event metrics.
-	metaRangeSplits                     = metric.Metadata{Name: "range.splits"}
-	metaRangeAdds                       = metric.Metadata{Name: "range.adds"}
-	metaRangeRemoves                    = metric.Metadata{Name: "range.removes"}
-	metaRangeSnapshotsGenerated         = metric.Metadata{Name: "range.snapshots.generated"}
-	metaRangeSnapshotsNormalApplied     = metric.Metadata{Name: "range.snapshots.normal-applied"}
-	metaRangeSnapshotsPreemptiveApplied = metric.Metadata{Name: "range.snapshots.preemptive-applied"}
-	metaRangeRaftLeaderTransfers        = metric.Metadata{Name: "range.raftleadertransfers"}
+	metaRangeSplits = metric.Metadata{
+		Name: "range.splits",
+		Help: "Number of range splits"}
+	metaRangeAdds = metric.Metadata{
+		Name: "range.adds",
+		Help: "Number of range additions"}
+	metaRangeRemoves = metric.Metadata{
+		Name: "range.removes",
+		Help: "Number of range removals"}
+	metaRangeSnapshotsGenerated = metric.Metadata{
+		Name: "range.snapshots.generated",
+		Help: "Number of generated snapshots"}
+	metaRangeSnapshotsNormalApplied = metric.Metadata{
+		Name: "range.snapshots.normal-applied",
+		Help: "Number of applied snapshots"}
+	metaRangeSnapshotsPreemptiveApplied = metric.Metadata{
+		Name: "range.snapshots.preemptive-applied",
+		Help: "Number of applied pre-emptive snapshots"}
+	metaRangeRaftLeaderTransfers = metric.Metadata{
+		Name: "range.raftleadertransfers",
+		Help: "Number of raft leader transfers"}
 
 	// Raft processing metrics.
 	metaRaftTicks = metric.Metadata{
 		Name: "raft.ticks",
-		Help: "Number of Raft ticks queued",
-	}
+		Help: "Number of Raft ticks queued"}
 	metaRaftWorkingDurationNanos = metric.Metadata{
 		Name: "raft.process.workingnanos",
-		Help: "Nanoseconds spent in store.processRaft() working",
-	}
+		Help: "Nanoseconds spent in store.processRaft() working"}
 	metaRaftTickingDurationNanos = metric.Metadata{
 		Name: "raft.process.tickingnanos",
-		Help: "Nanoseconds spent in store.processRaft() processing replica.Tick()",
-	}
+		Help: "Nanoseconds spent in store.processRaft() processing replica.Tick()"}
 	metaRaftCommandsApplied = metric.Metadata{
 		Name: "raft.commandsapplied",
-		Help: "Count of Raft commands applied",
-	}
+		Help: "Count of Raft commands applied"}
 
 	// Raft message metrics.
 	metaRaftRcvdProp = metric.Metadata{
 		Name: "raft.rcvd.prop",
-		Help: "Number of MsgProp messages received by this store",
-	}
+		Help: "Number of MsgProp messages received by this store"}
 	metaRaftRcvdApp = metric.Metadata{
 		Name: "raft.rcvd.app",
-		Help: "Number of MsgApp messages received by this store",
-	}
+		Help: "Number of MsgApp messages received by this store"}
 	metaRaftRcvdAppResp = metric.Metadata{
 		Name: "raft.rcvd.appresp",
-		Help: "Number of MsgAppResp messages received by this store",
-	}
+		Help: "Number of MsgAppResp messages received by this store"}
 	metaRaftRcvdVote = metric.Metadata{
 		Name: "raft.rcvd.vote",
-		Help: "Number of MsgVote messages received by this store",
-	}
+		Help: "Number of MsgVote messages received by this store"}
 	metaRaftRcvdVoteResp = metric.Metadata{
 		Name: "raft.rcvd.voteresp",
-		Help: "Number of MsgVoteResp messages received by this store",
-	}
+		Help: "Number of MsgVoteResp messages received by this store"}
 	metaRaftRcvdPreVote = metric.Metadata{
 		Name: "raft.rcvd.prevote",
-		Help: "Number of MsgPreVote messages received by this store",
-	}
+		Help: "Number of MsgPreVote messages received by this store"}
 	metaRaftRcvdPreVoteResp = metric.Metadata{
 		Name: "raft.rcvd.prevoteresp",
-		Help: "Number of MsgPreVoteResp messages received by this store",
-	}
+		Help: "Number of MsgPreVoteResp messages received by this store"}
 	metaRaftRcvdSnap = metric.Metadata{
 		Name: "raft.rcvd.snap",
-		Help: "Number of MsgSnap messages received by this store",
-	}
+		Help: "Number of MsgSnap messages received by this store"}
 	metaRaftRcvdHeartbeat = metric.Metadata{
 		Name: "raft.rcvd.heartbeat",
-		Help: "Number of (coalesced, if enabled) MsgHeartbeat messages received by this store",
-	}
+		Help: "Number of (coalesced, if enabled) MsgHeartbeat messages received by this store"}
 	metaRaftRcvdHeartbeatResp = metric.Metadata{
 		Name: "raft.rcvd.heartbeatresp",
-		Help: "Number of (coalesced, if enabled) MsgHeartbeatResp messages received by this store",
-	}
+		Help: "Number of (coalesced, if enabled) MsgHeartbeatResp messages received by this store"}
 	metaRaftRcvdTransferLeader = metric.Metadata{
 		Name: "raft.rcvd.transferleader",
-		Help: "Number of MsgTransferLeader messages received by this store",
-	}
+		Help: "Number of MsgTransferLeader messages received by this store"}
 	metaRaftRcvdTimeoutNow = metric.Metadata{
 		Name: "raft.rcvd.timeoutnow",
-		Help: "Number of MsgTimeoutNow messages received by this store",
-	}
+		Help: "Number of MsgTimeoutNow messages received by this store"}
 	metaRaftRcvdDropped = metric.Metadata{
 		Name: "raft.rcvd.dropped",
-		Help: "Number of dropped incoming Raft messages",
-	}
+		Help: "Number of dropped incoming Raft messages"}
 	metaRaftEnqueuedPending = metric.Metadata{
 		Name: "raft.enqueued.pending",
-		Help: "Number of pending outgoing messages in the Raft Transport queue",
-	}
+		Help: "Number of pending outgoing messages in the Raft Transport queue"}
 	metaRaftCoalescedHeartbeatsPending = metric.Metadata{
 		Name: "raft.heartbeats.pending",
-		Help: "Number of pending heartbeats and responses waiting to be coalesced",
-	}
+		Help: "Number of pending heartbeats and responses waiting to be coalesced"}
 
 	// Raft log metrics.
-	metaRaftLogFollowerBehindCount = metric.Metadata{Name: "raftlog.behind",
+	metaRaftLogFollowerBehindCount = metric.Metadata{
+		Name: "raftlog.behind",
 		Help: "Number of Raft log entries followers on other stores are behind"}
-	metaRaftLogSelfBehindCount = metric.Metadata{Name: "raftlog.selfbehind",
+	metaRaftLogSelfBehindCount = metric.Metadata{
+		Name: "raftlog.selfbehind",
 		Help: "Number of Raft log entries followers on this store are behind"}
-	metaRaftLogTruncated = metric.Metadata{Name: "raftlog.truncated",
+	metaRaftLogTruncated = metric.Metadata{
+		Name: "raftlog.truncated",
 		Help: "Number of Raft log entries truncated"}
 
 	// Replica queue metrics.
-	metaGCQueueSuccesses = metric.Metadata{Name: "queue.gc.process.success",
+	metaGCQueueSuccesses = metric.Metadata{
+		Name: "queue.gc.process.success",
 		Help: "Number of replicas successfully processed by the GC queue"}
-	metaGCQueueFailures = metric.Metadata{Name: "queue.gc.process.failure",
+	metaGCQueueFailures = metric.Metadata{
+		Name: "queue.gc.process.failure",
 		Help: "Number of replicas which failed processing in the GC queue"}
-	metaGCQueuePending = metric.Metadata{Name: "queue.gc.pending",
+	metaGCQueuePending = metric.Metadata{
+		Name: "queue.gc.pending",
 		Help: "Number of pending replicas in the GC queue"}
-	metaGCQueueProcessingNanos = metric.Metadata{Name: "queue.gc.processingnanos",
+	metaGCQueueProcessingNanos = metric.Metadata{
+		Name: "queue.gc.processingnanos",
 		Help: "Nanoseconds spent processing replicas in the GC queue"}
-	metaRaftLogQueueSuccesses = metric.Metadata{Name: "queue.raftlog.process.success",
+	metaRaftLogQueueSuccesses = metric.Metadata{
+		Name: "queue.raftlog.process.success",
 		Help: "Number of replicas successfully processed by the Raft log queue"}
-	metaRaftLogQueueFailures = metric.Metadata{Name: "queue.raftlog.process.failure",
+	metaRaftLogQueueFailures = metric.Metadata{
+		Name: "queue.raftlog.process.failure",
 		Help: "Number of replicas which failed processing in the Raft log queue"}
-	metaRaftLogQueuePending = metric.Metadata{Name: "queue.raftlog.pending",
+	metaRaftLogQueuePending = metric.Metadata{
+		Name: "queue.raftlog.pending",
 		Help: "Number of pending replicas in the Raft log queue"}
-	metaRaftLogQueueProcessingNanos = metric.Metadata{Name: "queue.raftlog.processingnanos",
+	metaRaftLogQueueProcessingNanos = metric.Metadata{
+		Name: "queue.raftlog.processingnanos",
 		Help: "Nanoseconds spent processing replicas in the Raft log queue"}
-	metaRaftSnapshotQueueSuccesses = metric.Metadata{Name: "queue.raftsnapshot.process.success",
+	metaRaftSnapshotQueueSuccesses = metric.Metadata{
+		Name: "queue.raftsnapshot.process.success",
 		Help: "Number of replicas successfully processed by the Raft repair queue"}
-	metaRaftSnapshotQueueFailures = metric.Metadata{Name: "queue.raftsnapshot.process.failure",
+	metaRaftSnapshotQueueFailures = metric.Metadata{
+		Name: "queue.raftsnapshot.process.failure",
 		Help: "Number of replicas which failed processing in the Raft repair queue"}
-	metaRaftSnapshotQueuePending = metric.Metadata{Name: "queue.raftsnapshot.pending",
+	metaRaftSnapshotQueuePending = metric.Metadata{
+		Name: "queue.raftsnapshot.pending",
 		Help: "Number of pending replicas in the Raft repair queue"}
-	metaRaftSnapshotQueueProcessingNanos = metric.Metadata{Name: "queue.raftsnapshot.processingnanos",
+	metaRaftSnapshotQueueProcessingNanos = metric.Metadata{
+		Name: "queue.raftsnapshot.processingnanos",
 		Help: "Nanoseconds spent processing replicas in the Raft repair queue"}
-	metaConsistencyQueueSuccesses = metric.Metadata{Name: "queue.consistency.process.success",
+	metaConsistencyQueueSuccesses = metric.Metadata{
+		Name: "queue.consistency.process.success",
 		Help: "Number of replicas successfully processed by the consistency checker queue"}
-	metaConsistencyQueueFailures = metric.Metadata{Name: "queue.consistency.process.failure",
+	metaConsistencyQueueFailures = metric.Metadata{
+		Name: "queue.consistency.process.failure",
 		Help: "Number of replicas which failed processing in the consistency checker queue"}
-	metaConsistencyQueuePending = metric.Metadata{Name: "queue.consistency.pending",
+	metaConsistencyQueuePending = metric.Metadata{
+		Name: "queue.consistency.pending",
 		Help: "Number of pending replicas in the consistency checker queue"}
-	metaConsistencyQueueProcessingNanos = metric.Metadata{Name: "queue.consistency.processingnanos",
+	metaConsistencyQueueProcessingNanos = metric.Metadata{
+		Name: "queue.consistency.processingnanos",
 		Help: "Nanoseconds spent processing replicas in the consistency checker queue"}
-	metaReplicaGCQueueSuccesses = metric.Metadata{Name: "queue.replicagc.process.success",
+	metaReplicaGCQueueSuccesses = metric.Metadata{
+		Name: "queue.replicagc.process.success",
 		Help: "Number of replicas successfully processed by the replica GC queue"}
-	metaReplicaGCQueueFailures = metric.Metadata{Name: "queue.replicagc.process.failure",
+	metaReplicaGCQueueFailures = metric.Metadata{
+		Name: "queue.replicagc.process.failure",
 		Help: "Number of replicas which failed processing in the replica GC queue"}
-	metaReplicaGCQueuePending = metric.Metadata{Name: "queue.replicagc.pending",
+	metaReplicaGCQueuePending = metric.Metadata{
+		Name: "queue.replicagc.pending",
 		Help: "Number of pending replicas in the replica GC queue"}
-	metaReplicaGCQueueProcessingNanos = metric.Metadata{Name: "queue.replicagc.processingnanos",
+	metaReplicaGCQueueProcessingNanos = metric.Metadata{
+		Name: "queue.replicagc.processingnanos",
 		Help: "Nanoseconds spent processing replicas in the replica GC queue"}
-	metaReplicateQueueSuccesses = metric.Metadata{Name: "queue.replicate.process.success",
+	metaReplicateQueueSuccesses = metric.Metadata{
+		Name: "queue.replicate.process.success",
 		Help: "Number of replicas successfully processed by the replicate queue"}
-	metaReplicateQueueFailures = metric.Metadata{Name: "queue.replicate.process.failure",
+	metaReplicateQueueFailures = metric.Metadata{
+		Name: "queue.replicate.process.failure",
 		Help: "Number of replicas which failed processing in the replicate queue"}
-	metaReplicateQueuePending = metric.Metadata{Name: "queue.replicate.pending",
+	metaReplicateQueuePending = metric.Metadata{
+		Name: "queue.replicate.pending",
 		Help: "Number of pending replicas in the replicate queue"}
-	metaReplicateQueueProcessingNanos = metric.Metadata{Name: "queue.replicate.processingnanos",
+	metaReplicateQueueProcessingNanos = metric.Metadata{
+		Name: "queue.replicate.processingnanos",
 		Help: "Nanoseconds spent processing replicas in the replicate queue"}
-	metaReplicateQueuePurgatory = metric.Metadata{Name: "queue.replicate.purgatory",
+	metaReplicateQueuePurgatory = metric.Metadata{
+		Name: "queue.replicate.purgatory",
 		Help: "Number of replicas in the replicate queue's purgatory, awaiting allocation options"}
-	metaSplitQueueSuccesses = metric.Metadata{Name: "queue.split.process.success",
+	metaSplitQueueSuccesses = metric.Metadata{
+		Name: "queue.split.process.success",
 		Help: "Number of replicas successfully processed by the split queue"}
-	metaSplitQueueFailures = metric.Metadata{Name: "queue.split.process.failure",
+	metaSplitQueueFailures = metric.Metadata{
+		Name: "queue.split.process.failure",
 		Help: "Number of replicas which failed processing in the split queue"}
-	metaSplitQueuePending = metric.Metadata{Name: "queue.split.pending",
+	metaSplitQueuePending = metric.Metadata{
+		Name: "queue.split.pending",
 		Help: "Number of pending replicas in the split queue"}
-	metaSplitQueueProcessingNanos = metric.Metadata{Name: "queue.split.processingnanos",
+	metaSplitQueueProcessingNanos = metric.Metadata{
+		Name: "queue.split.processingnanos",
 		Help: "Nanoseconds spent processing replicas in the split queue"}
-
-	metaTimeSeriesMaintenanceQueueSuccesses = metric.Metadata{Name: "queue.tsmaintenance.process.success",
+	metaTimeSeriesMaintenanceQueueSuccesses = metric.Metadata{
+		Name: "queue.tsmaintenance.process.success",
 		Help: "Number of replicas successfully processed by the time series maintenance queue"}
-	metaTimeSeriesMaintenanceQueueFailures = metric.Metadata{Name: "queue.tsmaintenance.process.failure",
+	metaTimeSeriesMaintenanceQueueFailures = metric.Metadata{
+		Name: "queue.tsmaintenance.process.failure",
 		Help: "Number of replicas which failed processing in the time series maintenance queue"}
-	metaTimeSeriesMaintenanceQueuePending = metric.Metadata{Name: "queue.tsmaintenance.pending",
+	metaTimeSeriesMaintenanceQueuePending = metric.Metadata{
+		Name: "queue.tsmaintenance.pending",
 		Help: "Number of pending replicas in the time series maintenance queue"}
-	metaTimeSeriesMaintenanceQueueProcessingNanos = metric.Metadata{Name: "queue.tsmaintenance.processingnanos",
+	metaTimeSeriesMaintenanceQueueProcessingNanos = metric.Metadata{
+		Name: "queue.tsmaintenance.processingnanos",
 		Help: "Nanoseconds spent processing replicas in the time series maintenance queue"}
 
 	// GCInfo cumulative totals.
-	metaGCNumKeysAffected = metric.Metadata{Name: "queue.gc.info.numkeysaffected",
+	metaGCNumKeysAffected = metric.Metadata{
+		Name: "queue.gc.info.numkeysaffected",
 		Help: "Number of keys with GC'able data"}
-	metaGCIntentsConsidered = metric.Metadata{Name: "queue.gc.info.intentsconsidered",
+	metaGCIntentsConsidered = metric.Metadata{
+		Name: "queue.gc.info.intentsconsidered",
 		Help: "Number of 'old' intents"}
-	metaGCIntentTxns = metric.Metadata{Name: "queue.gc.info.intenttxns",
+	metaGCIntentTxns = metric.Metadata{
+		Name: "queue.gc.info.intenttxns",
 		Help: "Number of associated distinct transactions"}
-	metaGCTransactionSpanScanned = metric.Metadata{Name: "queue.gc.info.transactionspanscanned",
+	metaGCTransactionSpanScanned = metric.Metadata{
+		Name: "queue.gc.info.transactionspanscanned",
 		Help: "Number of entries in the transaction span scanned from the engine"}
-	metaGCTransactionSpanGCAborted = metric.Metadata{Name: "queue.gc.info.transactionspangcaborted",
+	metaGCTransactionSpanGCAborted = metric.Metadata{
+		Name: "queue.gc.info.transactionspangcaborted",
 		Help: "Number of GC'able entries corresponding to aborted txns"}
-	metaGCTransactionSpanGCCommitted = metric.Metadata{Name: "queue.gc.info.transactionspangccommitted",
+	metaGCTransactionSpanGCCommitted = metric.Metadata{
+		Name: "queue.gc.info.transactionspangccommitted",
 		Help: "Number of GC'able entries corresponding to committed txns"}
-	metaGCTransactionSpanGCPending = metric.Metadata{Name: "queue.gc.info.transactionspangcpending",
+	metaGCTransactionSpanGCPending = metric.Metadata{
+		Name: "queue.gc.info.transactionspangcpending",
 		Help: "Number of GC'able entries corresponding to pending txns"}
-	metaGCAbortSpanScanned = metric.Metadata{Name: "queue.gc.info.abortspanscanned",
+	metaGCAbortSpanScanned = metric.Metadata{
+		Name: "queue.gc.info.abortspanscanned",
 		Help: "Number of transactions present in the abort cache scanned from the engine"}
-	metaGCAbortSpanConsidered = metric.Metadata{Name: "queue.gc.info.abortspanconsidered",
+	metaGCAbortSpanConsidered = metric.Metadata{
+		Name: "queue.gc.info.abortspanconsidered",
 		Help: "Number of abort cache entries old enough to be considered for removal"}
-	metaGCAbortSpanGCNum = metric.Metadata{Name: "queue.gc.info.abortspangcnum",
+	metaGCAbortSpanGCNum = metric.Metadata{
+		Name: "queue.gc.info.abortspangcnum",
 		Help: "Number of abort cache entries fit for removal"}
-	metaGCPushTxn = metric.Metadata{Name: "queue.gc.info.pushtxn",
+	metaGCPushTxn = metric.Metadata{
+		Name: "queue.gc.info.pushtxn",
 		Help: "Number of attempted pushes"}
-	metaGCResolveTotal = metric.Metadata{Name: "queue.gc.info.resolvetotal",
+	metaGCResolveTotal = metric.Metadata{
+		Name: "queue.gc.info.resolvetotal",
 		Help: "Number of attempted intent resolutions"}
-	metaGCResolveSuccess = metric.Metadata{Name: "queue.gc.info.resolvesuccess",
+	metaGCResolveSuccess = metric.Metadata{
+		Name: "queue.gc.info.resolvesuccess",
 		Help: "Number of successful intent resolutions"}
 
 	// Slow request metrics.
-	metaSlowCommandQueueRequests = metric.Metadata{Name: "requests.slow.commandqueue",
+	metaSlowCommandQueueRequests = metric.Metadata{
+		Name: "requests.slow.commandqueue",
 		Help: "Number of requests that have been stuck for a long time in the command queue"}
-	metaSlowLeaseRequests = metric.Metadata{Name: "requests.slow.lease",
+	metaSlowLeaseRequests = metric.Metadata{
+		Name: "requests.slow.lease",
 		Help: "Number of requests that have been stuck for a long time acquiring a lease"}
-	metaSlowRaftRequests = metric.Metadata{Name: "requests.slow.raft",
+	metaSlowRaftRequests = metric.Metadata{
+		Name: "requests.slow.raft",
 		Help: "Number of requests that have been stuck for a long time in raft"}
 )
 

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -51,20 +51,16 @@ var (
 var (
 	metaLiveNodes = metric.Metadata{
 		Name: "liveness.livenodes",
-		Help: "Number of live nodes in the cluster (will be 0 if this node is not itself live)",
-	}
+		Help: "Number of live nodes in the cluster (will be 0 if this node is not itself live)"}
 	metaHeartbeatSuccesses = metric.Metadata{
 		Name: "liveness.heartbeatsuccesses",
-		Help: "Number of successful node liveness heartbeats from this node",
-	}
+		Help: "Number of successful node liveness heartbeats from this node"}
 	metaHeartbeatFailures = metric.Metadata{
 		Name: "liveness.heartbeatfailures",
-		Help: "Number of failed node liveness heartbeats from this node",
-	}
+		Help: "Number of failed node liveness heartbeats from this node"}
 	metaEpochIncrements = metric.Metadata{
 		Name: "liveness.epochincrements",
-		Help: "Number of times this node has incremented its liveness epoch",
-	}
+		Help: "Number of times this node has incremented its liveness epoch"}
 )
 
 func (l *Liveness) isLive(now hlc.Timestamp, maxOffset time.Duration) bool {

--- a/pkg/storage/replica_gc_queue.go
+++ b/pkg/storage/replica_gc_queue.go
@@ -60,7 +60,8 @@ const (
 )
 
 var (
-	metaReplicaGCQueueRemoveReplicaCount = metric.Metadata{Name: "queue.replicagc.removereplica",
+	metaReplicaGCQueueRemoveReplicaCount = metric.Metadata{
+		Name: "queue.replicagc.removereplica",
 		Help: "Number of replica removals attempted by the replica gc queue"}
 )
 

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -45,15 +45,20 @@ const (
 )
 
 var (
-	metaReplicateQueueAddReplicaCount = metric.Metadata{Name: "queue.replicate.addreplica",
+	metaReplicateQueueAddReplicaCount = metric.Metadata{
+		Name: "queue.replicate.addreplica",
 		Help: "Number of replica additions attempted by the replicate queue"}
-	metaReplicateQueueRemoveReplicaCount = metric.Metadata{Name: "queue.replicate.removereplica",
+	metaReplicateQueueRemoveReplicaCount = metric.Metadata{
+		Name: "queue.replicate.removereplica",
 		Help: "Number of replica removals attempted by the replicate queue (typically in response to a rebalancer-initiated addition)"}
-	metaReplicateQueueRemoveDeadReplicaCount = metric.Metadata{Name: "queue.replicate.removedeadreplica",
+	metaReplicateQueueRemoveDeadReplicaCount = metric.Metadata{
+		Name: "queue.replicate.removedeadreplica",
 		Help: "Number of dead replica removals attempted by the replicate queue (typically in response to a node outage)"}
-	metaReplicateQueueRebalanceReplicaCount = metric.Metadata{Name: "queue.replicate.rebalancereplica",
+	metaReplicateQueueRebalanceReplicaCount = metric.Metadata{
+		Name: "queue.replicate.rebalancereplica",
 		Help: "Number of replica rebalancer-initiated additions attempted by the replicate queue"}
-	metaReplicateQueueTransferLeaseCount = metric.Metadata{Name: "queue.replicate.transferlease",
+	metaReplicateQueueTransferLeaseCount = metric.Metadata{
+		Name: "queue.replicate.transferlease",
 		Help: "Number of range lease transfers attempted by the replicate queue"}
 )
 


### PR DESCRIPTION
Work towards #9289

I'd like to add a check for non-empty help strings, but I don't want to to had far as a panic.
Would this be a reasonable `make check` step? Grep wouldn't do it though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14603)
<!-- Reviewable:end -->
