### PR TITLE
sqlccl: clear schema change lease if present during restore

### DIFF
--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -287,6 +287,10 @@ func reassignReferencedTables(
 				table.DependedOnBy = append(table.DependedOnBy, ref)
 			}
 		}
+
+		// since this is a "new" table in eyes of new cluster, any leftover change
+		// lease is obviously bogus (plus the nodeID is relative to backup cluster).
+		table.Lease = nil
 	}
 	return nil
 }


### PR DESCRIPTION
the lease was on the backed up table, in the backup cluster, and is invalid in the restored one. it should expire eventually on its own, but we can do better than that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14604)
<!-- Reviewable:end -->
