### PR TITLE
sql: support subqueries as the source of UPDATE

### DIFF
--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -206,8 +206,8 @@ func (p *planner) groupBy(
 
 	// Add the group-by expressions so they are available for bucketing.
 	for _, g := range groupByExprs {
-		cols, exprs, hasStar, err := s.planner.computeRender(ctx, parser.SelectExpr{Expr: g}, parser.TypeAny,
-			s.sourceInfo, s.ivarHelper, true)
+		cols, exprs, hasStar, err := s.planner.computeRenderAllowingStars(
+			ctx, parser.SelectExpr{Expr: g}, parser.TypeAny, s.sourceInfo, s.ivarHelper)
 		if err != nil {
 			return nil, err
 		}
@@ -232,9 +232,9 @@ func (p *planner) groupBy(
 			return nil, err
 		}
 
-		cols, exprs, hasStar, err := s.planner.computeRender(
+		cols, exprs, hasStar, err := s.planner.computeRenderAllowingStars(
 			ctx, parser.SelectExpr{Expr: f.filter}, parser.TypeAny,
-			s.sourceInfo, s.ivarHelper, true)
+			s.sourceInfo, s.ivarHelper)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -618,7 +618,7 @@ func (expr *UnaryExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, err
 	return expr, nil
 }
 
-var errInvalidDefaultUsage = errors.New("DEFAULT can only appear in a VALUES list within INSERT")
+var errInvalidDefaultUsage = errors.New("DEFAULT can only appear in a VALUES list within INSERT or on the right side of a SET within UPDATE")
 
 // TypeCheck implements the Expr interface.
 func (expr DefaultVal) TypeCheck(_ *SemaContext, desired Type) (TypedExpr, error) {

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -335,8 +335,8 @@ func (s *renderNode) initTargets(
 		if len(desiredTypes) > i {
 			desiredType = desiredTypes[i]
 		}
-		cols, exprs, hasStar, err := s.planner.computeRender(ctx, target, desiredType,
-			s.sourceInfo, s.ivarHelper, true)
+		cols, exprs, hasStar, err := s.planner.computeRenderAllowingStars(ctx, target, desiredType,
+			s.sourceInfo, s.ivarHelper)
 		if err != nil {
 			return err
 		}
@@ -399,8 +399,8 @@ func (s *renderNode) transformToCrossJoin(
 	newTarget := parser.SelectExpr{
 		Expr: s.ivarHelper.IndexedVar(s.ivarHelper.NumVars() - 1),
 	}
-	return s.planner.computeRender(ctx, newTarget, desiredType,
-		s.sourceInfo, s.ivarHelper, true)
+	return s.planner.computeRenderAllowingStars(ctx, newTarget, desiredType,
+		s.sourceInfo, s.ivarHelper)
 }
 
 func (s *renderNode) initWhere(ctx context.Context, where *parser.Where) (*filterNode, error) {

--- a/pkg/sql/returning.go
+++ b/pkg/sql/returning.go
@@ -83,8 +83,8 @@ func (p *planner) newReturningHelper(
 	rh.exprs = make([]parser.TypedExpr, 0, len(rExprs))
 	ivarHelper := parser.MakeIndexedVarHelper(rh, len(tablecols))
 	for _, target := range rExprs {
-		cols, typedExprs, _, err := p.computeRender(
-			ctx, target, parser.TypeAny, multiSourceInfo{rh.source}, ivarHelper, true /* allowStars */)
+		cols, typedExprs, _, err := p.computeRenderAllowingStars(
+			ctx, target, parser.TypeAny, multiSourceInfo{rh.source}, ivarHelper)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -199,9 +199,9 @@ func (p *planner) orderBy(
 		// If we are dealing with a UNION or something else we would need
 		// to fabricate an intermediate renderNode to add the new render.
 		if index == -1 && s != nil {
-			cols, exprs, hasStar, err := p.computeRender(
+			cols, exprs, hasStar, err := p.computeRenderAllowingStars(
 				ctx, parser.SelectExpr{Expr: expr}, parser.TypeAny,
-				s.sourceInfo, s.ivarHelper, true)
+				s.sourceInfo, s.ivarHelper)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/targets.go
+++ b/pkg/sql/targets.go
@@ -23,43 +23,54 @@ import (
 	"github.com/pkg/errors"
 )
 
-// computeRender expands a target expression into a result column (or more
-// than one, in case there is a star). Whether star expansion occurred
-// is indicated by the third return value.
+// computeRender expands a target expression into a result column.
 func (p *planner) computeRender(
 	ctx context.Context,
 	target parser.SelectExpr,
 	desiredType parser.Type,
 	info multiSourceInfo,
 	ivarHelper parser.IndexedVarHelper,
-	allowStars bool,
+) (column ResultColumn, expr parser.TypedExpr, err error) {
+	// When generating an output column name it should exactly match the original
+	// expression, so determine the output column name before we perform any
+	// manipulations to the expression.
+	outputName := getRenderColName(target)
+
+	normalized, err := p.analyzeExpr(ctx, target.Expr, info, ivarHelper, desiredType, false, "")
+	if err != nil {
+		return ResultColumn{}, nil, err
+	}
+
+	return ResultColumn{Name: outputName, Typ: normalized.ResolvedType()}, normalized, nil
+}
+
+// computeRenderAllowingStars expands a target expression into a result column (or more
+// than one, in case there is a star). Whether star expansion occurred
+// is indicated by the third return value.
+func (p *planner) computeRenderAllowingStars(
+	ctx context.Context,
+	target parser.SelectExpr,
+	desiredType parser.Type,
+	info multiSourceInfo,
+	ivarHelper parser.IndexedVarHelper,
 ) (columns ResultColumns, exprs []parser.TypedExpr, hasStar bool, err error) {
 	// Pre-normalize any VarName so the work is not done twice below.
 	if err := target.NormalizeTopLevelVarName(); err != nil {
 		return nil, nil, false, err
 	}
 
-	if hasStar, cols, typedExprs, err := checkRenderStar(
-		target, info, ivarHelper, allowStars); err != nil {
+	if hasStar, cols, typedExprs, err := checkRenderStar(target, info, ivarHelper); err != nil {
 		return nil, nil, false, err
 	} else if hasStar {
 		return cols, typedExprs, hasStar, nil
 	}
 
-	// When generating an output column name it should exactly match the original
-	// expression, so determine the output column name before we perform any
-	// manipulations to the expression.
-	outputName := getRenderColName(target)
-
-	normalized, err := p.analyzeExpr(
-		ctx, target.Expr, info, ivarHelper, desiredType, false, "")
+	col, expr, err := p.computeRender(ctx, target, desiredType, info, ivarHelper)
 	if err != nil {
 		return nil, nil, false, err
 	}
 
-	return ResultColumns{
-		ResultColumn{Name: outputName, Typ: normalized.ResolvedType()},
-	}, []parser.TypedExpr{normalized}, false, nil
+	return ResultColumns{col}, []parser.TypedExpr{expr}, false, nil
 }
 
 // equivalentRenders returns true if and only if the two render expressions
@@ -79,68 +90,59 @@ func (s *renderNode) isRenderEquivalent(exprStr string, j int) bool {
 // render list and returns their column indices. If an expression is
 // already rendered, and the reuse flag is true, no new render is
 // added and the index of the existing column is returned instead.
+func (s *renderNode) addOrMergeRender(
+	col ResultColumn, expr parser.TypedExpr, reuseExistingRender bool,
+) (colIdx int) {
+	if reuseExistingRender {
+		// Now, try to find an equivalent render. We use the syntax
+		// representation as approximation of equivalence.  At this
+		// point the expressions must have underwent name resolution
+		// already so that comparison occurs after replacing column names
+		// to IndexedVars.
+		exprStr := parser.AsStringWithFlags(expr, parser.FmtSymbolicVars)
+		for j := range s.render {
+			if s.isRenderEquivalent(exprStr, j) {
+				return j
+			}
+		}
+	}
+
+	s.addRenderColumn(expr, col)
+
+	return len(s.render) - 1
+}
+
 func (s *renderNode) addOrMergeRenders(
 	cols ResultColumns, exprs []parser.TypedExpr, reuseExistingRender bool,
 ) (colIdxs []int) {
 	colIdxs = make([]int, len(cols))
 	for i := range cols {
-		index := -1
-
-		if reuseExistingRender {
-			// Now, try to find an equivalent render. We use the syntax
-			// representation as approximation of equivalence.  At this
-			// point the expressions must have underwent name resolution
-			// already so that comparison occurs after replacing column names
-			// to IndexedVars.
-			exprStr := parser.AsStringWithFlags(exprs[i], parser.FmtSymbolicVars)
-			for j := range s.render {
-				if s.isRenderEquivalent(exprStr, j) {
-					index = j
-					break
-				}
-			}
-		}
-
-		if index == -1 {
-			index = len(s.render)
-			s.addRenderColumn(exprs[i], cols[i])
-		}
-		colIdxs[i] = index
+		colIdxs[i] = s.addOrMergeRender(cols[i], exprs[i], reuseExistingRender)
 	}
-
 	return colIdxs
 }
 
-// checkRenderStar handles the case where the target specification
-// contains a SQL star (UnqualifiedStar or AllColumnsSelector).  In
-// the case where the context disallows stars (allowStars false), an
-// error is reported. If star expansion is allowed, we match the
-// prefix of the name to one of the tables in the query and then
-// expand the "*" into a list of columns. A ResultColumns and Expr
-// pair is returned for each column.
+// checkRenderStar handles the case where the target specification contains a
+// SQL star (UnqualifiedStar or AllColumnsSelector). We match the prefix of the
+// name to one of the tables in the query and then expand the "*" into a list
+// of columns. A ResultColumns and Expr pair is returned for each column.
 func checkRenderStar(
-	target parser.SelectExpr,
-	info multiSourceInfo,
-	ivarHelper parser.IndexedVarHelper,
-	allowStars bool,
+	target parser.SelectExpr, info multiSourceInfo, ivarHelper parser.IndexedVarHelper,
 ) (isStar bool, columns ResultColumns, exprs []parser.TypedExpr, err error) {
 	v, ok := target.Expr.(parser.VarName)
 	if !ok {
 		return false, nil, nil, nil
 	}
+
 	switch v.(type) {
 	case parser.UnqualifiedStar, *parser.AllColumnsSelector:
-		if !allowStars {
-			return false, nil, nil, errors.Errorf("\"%s\" is not allowed in this position", v)
+		if target.As != "" {
+			return false, nil, nil, errors.Errorf("\"%s\" cannot be aliased", v)
 		}
+
+		columns, exprs, err = info[0].expandStar(v, ivarHelper)
+		return true, columns, exprs, err
 	default:
 		return false, nil, nil, nil
 	}
-
-	if target.As != "" {
-		return false, nil, nil, errors.Errorf("\"%s\" cannot be aliased", v)
-	}
-
-	columns, exprs, err = info[0].expandStar(v, ivarHelper)
-	return true, columns, exprs, err
 }

--- a/pkg/sql/testdata/logic_test/insert
+++ b/pkg/sql/testdata/logic_test/insert
@@ -550,10 +550,10 @@ EXPLAIN (PLAN) INSERT INTO insert_t (VALUES(1,'AAA'),(2,'BBB') LIMIT 1)
 statement error pq: multiple LIMIT clauses not allowed
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES(1,'AAA'),(2,'BBB') LIMIT 1) LIMIT 1
 
-query error DEFAULT can only appear in a VALUES list within INSERT
+statement error DEFAULT can only appear in a VALUES list within INSERT or on the right side of a SET within UPDATE
 INSERT INTO insert_t (VALUES(1, DEFAULT),(2,'BBB') LIMIT 1)
 
-query error DEFAULT can only appear in a VALUES list within INSERT
+statement error DEFAULT can only appear in a VALUES list within INSERT or on the right side of a SET within UPDATE
 INSERT INTO insert_t (VALUES(1, DEFAULT),(2,'BBB')) LIMIT 1
 
 statement ok

--- a/pkg/sql/testdata/logic_test/update
+++ b/pkg/sql/testdata/logic_test/update
@@ -6,6 +6,18 @@ CREATE TABLE kv (
   v INT
 )
 
+statement error value type tuple{int, int} doesn't match type INT of column "v"
+UPDATE kv SET v = (SELECT (10, 11))
+
+statement error value type decimal doesn't match type INT of column "v"
+UPDATE kv SET v = 3.2
+
+statement error value type decimal doesn't match type INT of column "v"
+UPDATE kv SET (k, v) = (3, 3.2)
+
+statement error value type decimal doesn't match type INT of column "v"
+UPDATE kv SET (k, v) = (SELECT 3, 3.2)
+
 statement ok
 INSERT INTO kv VALUES (1, 2), (3, 4), (5, 6), (7, 8)
 
@@ -185,6 +197,9 @@ INSERT INTO abc VALUES (1, 2, 3)
 statement error number of columns \(2\) does not match number of values \(1\)
 UPDATE abc SET (b, c) = (4)
 
+statement error DEFAULT can only appear in a VALUES list within INSERT or on the right side of a SET within UPDATE
+UPDATE abc SET (b, c) = (SELECT (VALUES (DEFAULT, DEFAULT)))
+
 statement ok
 UPDATE abc SET (b, c) = (4, 5)
 
@@ -192,6 +207,9 @@ query III
 SELECT * FROM abc
 ----
 1 4 5
+
+statement ok
+UPDATE abc SET a = 1, (b, c) = (SELECT 1, 2)
 
 query III colnames
 UPDATE abc SET (b, c) = (8, 9) RETURNING abc.b, c, 4
@@ -276,6 +294,94 @@ UPDATE abc SET (b, b) = (10, 11)
 
 statement error multiple assignments to the same column "b"
 UPDATE abc SET (b, c) = (10, 11), b = 12
+
+statement ok
+CREATE TABLE xyz (
+  x INT PRIMARY KEY,
+  y INT,
+  z INT
+)
+
+statement ok
+INSERT INTO xyz VALUES (111, 222, 333)
+
+statement ok
+UPDATE xyz SET (z, y) = (SELECT 666, 777), x = (SELECT 2)
+
+query III
+SELECT * from xyz
+----
+2 777 666
+
+query ITTT
+EXPLAIN UPDATE xyz SET y = x
+----
+0  update
+0         table  xyz
+0         set    y
+1  scan
+1         table  xyz@primary
+1         spans  ALL
+
+query ITTTTT
+EXPLAIN (METADATA) UPDATE xyz SET (x, y) = (1, 2)
+----
+0  update                      ()
+0          table  xyz
+0          set    x, y
+1  render                      (x, y, z, "1", "2")
+2  scan                        (x, y, z)
+2          table  xyz@primary
+2          spans  ALL
+
+query ITTTTT
+EXPLAIN (METADATA) UPDATE xyz SET (x, y) = (y, x)
+----
+0  update                      ()
+0          table  xyz
+0          set    x, y
+1  scan                        (x, y, z)
+1          table  xyz@primary
+1          spans  ALL
+
+query ITTTTT
+EXPLAIN (METADATA) UPDATE xyz SET (x, y) = (2, 2)
+----
+0  update                      ()
+0          table  xyz
+0          set    x, y
+1  render                      (x, y, z, "2")
+2  scan                        (x, y, z)
+2          table  xyz@primary
+2          spans  ALL
+
+statement ok
+CREATE TABLE lots (
+  k1 INT,
+  k2 INT,
+  k3 INT,
+  k4 INT,
+  k5 INT
+)
+
+statement ok
+INSERT INTO lots VALUES (1, 2, 3, 4, 5)
+
+statement ok
+UPDATE lots SET (k1, k2) = (6, 7), k3 = 8, (k4, k5) = (9, 10)
+
+query IIIII
+SELECT * FROM lots
+----
+6  7  8  9  10
+
+statement ok
+UPDATE lots SET (k5, k4, k3, k2, k1) = (SELECT * FROM lots)
+
+query IIIII
+SELECT * FROM lots
+----
+10  9  8  7  6
 
 statement ok
 CREATE TABLE pks (

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -113,11 +113,86 @@ type updateNode struct {
 	updateColsIdx map[sqlbase.ColumnID]int // index in updateCols slice
 	tw            tableUpdater
 	checkHelper   checkHelper
+	sourceSlots   []sourceSlot
 
 	run struct {
 		// The following fields are populated during Start().
 		editNodeRun
 	}
+}
+
+// sourceSlot abstracts the idea that our update sources can either be tuples
+// or scalars. Tuples are for cases such as SET (a, b) = (1, 2) or SET (a, b) =
+// (SELECT 1, 2), and scalars are for situations like SET a = b. A sourceSlot
+// represents how to extract and type-check the results of the right-hand side
+// of a single SET statement. We could treat everything as tuples, including
+// scalars as tuples of size 1, and eliminate this indirection, but that makes
+// the query plan more complex.
+type sourceSlot interface {
+	// extractValues returns a slice of the values this slot is responsible for,
+	// as extracted from the row of results.
+	extractValues(resultRow parser.Datums) parser.Datums
+	// checkColumnTypes compares the types of the results that this slot refers to to the types of
+	// the columns those values will be assigned to. It returns an error if those types don't match up.
+	// It also populates the types of any placeholders by way of calling into sqlbase.CheckColumnType.
+	checkColumnTypes(row []parser.TypedExpr, pmap *parser.PlaceholderInfo) error
+}
+
+type tupleSlot struct {
+	columns     []sqlbase.ColumnDescriptor
+	sourceIndex int
+}
+
+func (ts tupleSlot) extractValues(row parser.Datums) parser.Datums {
+	return row[ts.sourceIndex].(*parser.DTuple).D
+}
+
+func (ts tupleSlot) checkColumnTypes(row []parser.TypedExpr, pmap *parser.PlaceholderInfo) error {
+	renderedResult := row[ts.sourceIndex]
+	for i, typ := range renderedResult.ResolvedType().(parser.TTuple) {
+		if err := sqlbase.CheckColumnType(ts.columns[i], typ, pmap); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type scalarSlot struct {
+	column      sqlbase.ColumnDescriptor
+	sourceIndex int
+}
+
+func (ss scalarSlot) extractValues(row parser.Datums) parser.Datums {
+	return row[ss.sourceIndex : ss.sourceIndex+1]
+}
+
+func (ss scalarSlot) checkColumnTypes(row []parser.TypedExpr, pmap *parser.PlaceholderInfo) error {
+	renderedResult := row[ss.sourceIndex]
+	typ := renderedResult.ResolvedType()
+	return sqlbase.CheckColumnType(ss.column, typ, pmap)
+}
+
+// addOrMergeExpr inserts an Expr into a renderNode, attempting to reuse
+// previous renders if possible by using render.addOrMergeRender, returning the
+// column index at which the rendered value can be accessed.
+func addOrMergeExpr(
+	ctx context.Context,
+	e parser.Expr,
+	currentUpdateIdx int,
+	updateCols []sqlbase.ColumnDescriptor,
+	defaultExprs []parser.TypedExpr,
+	render *renderNode,
+) (colIdx int, err error) {
+	e = fillDefault(e, currentUpdateIdx, defaultExprs)
+	selectExpr := parser.SelectExpr{Expr: e}
+	typ := updateCols[currentUpdateIdx].Type.ToDatumType()
+	col, expr, err := render.planner.computeRender(ctx, selectExpr, typ,
+		render.sourceInfo, render.ivarHelper)
+	if err != nil {
+		return -1, err
+	}
+
+	return render.addOrMergeRender(col, expr, true), nil
 }
 
 // Update updates columns for a selection of rows from a table.
@@ -140,18 +215,18 @@ func (p *planner) Update(
 		return nil, err
 	}
 
-	exprs := make([]*parser.UpdateExpr, len(n.Exprs))
+	setExprs := make([]*parser.UpdateExpr, len(n.Exprs))
 	for i, expr := range n.Exprs {
 		// Replace the sub-query nodes.
 		newExpr, err := p.replaceSubqueries(ctx, expr.Expr, len(expr.Names))
 		if err != nil {
 			return nil, err
 		}
-		exprs[i] = &parser.UpdateExpr{Tuple: expr.Tuple, Expr: newExpr, Names: expr.Names}
+		setExprs[i] = &parser.UpdateExpr{Tuple: expr.Tuple, Expr: newExpr, Names: expr.Names}
 	}
 
 	// Determine which columns we're inserting into.
-	names, err := p.namesForExprs(exprs)
+	names, err := p.namesForExprs(setExprs)
 	if err != nil {
 		return nil, err
 	}
@@ -185,50 +260,81 @@ func (p *planner) Update(
 
 	tracing.AnnotateTrace()
 
-	// Generate the list of select targets. We need to select all of the columns
-	// plus we select all of the update expressions in case those expressions
-	// reference columns (e.g. "UPDATE t SET v = v + 1"). Note that we flatten
-	// expressions for tuple assignments just as we flattened the column names
-	// above. So "UPDATE t SET (a, b) = (1, 2)" translates into select targets of
-	// "*, 1, 2", not "*, (1, 2)".
-	targets := sqlbase.ColumnsSelectors(ru.FetchCols)
-	i := 0
-	// Remember the index where the targets for exprs start.
-	exprTargetIdx := len(targets)
-	desiredTypesFromSelect := make([]parser.Type, len(targets), len(targets)+len(exprs))
-	for i := range targets {
-		desiredTypesFromSelect[i] = parser.TypeAny
-	}
-	for _, expr := range exprs {
-		if expr.Tuple {
-			switch t := expr.Expr.(type) {
-			case (*parser.Tuple):
-				for _, e := range t.Exprs {
-					typ := updateCols[i].Type.ToDatumType()
-					e = fillDefault(e, typ, i, defaultExprs)
-					targets = append(targets, parser.SelectExpr{Expr: e})
-					desiredTypesFromSelect = append(desiredTypesFromSelect, typ)
-					i++
-				}
-			default:
-				return nil, fmt.Errorf("cannot use this expression to assign multiple columns: %s", expr.Expr)
-			}
-		} else {
-			typ := updateCols[i].Type.ToDatumType()
-			e := fillDefault(expr.Expr, typ, i, defaultExprs)
-			targets = append(targets, parser.SelectExpr{Expr: e})
-			desiredTypesFromSelect = append(desiredTypesFromSelect, typ)
-			i++
-		}
-	}
-
+	// We construct a query containing the columns being updated, and then later merge the values
+	// they are being updated with into that renderNode to ideally reuse some of the queries.
 	rows, err := p.SelectClause(ctx, &parser.SelectClause{
-		Exprs: targets,
+		Exprs: sqlbase.ColumnsSelectors(ru.FetchCols),
 		From:  &parser.From{Tables: []parser.TableExpr{n.Table}},
 		Where: n.Where,
-	}, nil, nil, desiredTypesFromSelect, publicAndNonPublicColumns)
+	}, nil, nil, nil, publicAndNonPublicColumns)
 	if err != nil {
 		return nil, err
+	}
+
+	// This capacity is an overestimate, since subqueries only take up one sourceSlot.
+	sourceSlots := make([]sourceSlot, 0, len(ru.FetchCols))
+
+	// currentUpdateIdx is the index of the first column descriptor in updateCols
+	// that is assigned to by the current setExpr.
+	currentUpdateIdx := 0
+	render := rows.(*renderNode)
+
+	for _, setExpr := range setExprs {
+		if setExpr.Tuple {
+			switch t := setExpr.Expr.(type) {
+			case *parser.Tuple:
+				// The user assigned an explicit set of values to the columns. We can't
+				// treat this case the same as when we have a subquery (and just evaluate
+				// the tuple) because when assigning a literal tuple like this it's valid
+				// to assign DEFAULT to some of the columns, which is not valid generally.
+				for _, e := range t.Exprs {
+					colIdx, err := addOrMergeExpr(ctx, e, currentUpdateIdx, updateCols, defaultExprs, render)
+					if err != nil {
+						return nil, err
+					}
+
+					sourceSlots = append(sourceSlots, scalarSlot{
+						column:      updateCols[currentUpdateIdx],
+						sourceIndex: colIdx,
+					})
+
+					currentUpdateIdx++
+				}
+			case *subquery:
+				selectExpr := parser.SelectExpr{Expr: t}
+				desiredTupleType := make(parser.TTuple, len(setExpr.Names))
+				for i := range setExpr.Names {
+					desiredTupleType[i] = updateCols[currentUpdateIdx+i].Type.ToDatumType()
+				}
+				col, expr, err := render.planner.computeRender(ctx, selectExpr, desiredTupleType,
+					render.sourceInfo, render.ivarHelper)
+				if err != nil {
+					return nil, err
+				}
+
+				colIdx := render.addOrMergeRender(col, expr, false)
+
+				sourceSlots = append(sourceSlots, tupleSlot{
+					columns:     updateCols[currentUpdateIdx : currentUpdateIdx+len(setExpr.Names)],
+					sourceIndex: colIdx,
+				})
+				currentUpdateIdx += len(setExpr.Names)
+			default:
+				panic(fmt.Sprintf("assigning to tuple with expression that is neither a tuple nor a subquery: %s", setExpr.Expr))
+			}
+
+		} else {
+			colIdx, err := addOrMergeExpr(ctx, setExpr.Expr, currentUpdateIdx, updateCols, defaultExprs, render)
+			if err != nil {
+				return nil, err
+			}
+
+			sourceSlots = append(sourceSlots, scalarSlot{
+				column:      updateCols[currentUpdateIdx],
+				sourceIndex: colIdx,
+			})
+			currentUpdateIdx++
+		}
 	}
 
 	// Placeholders have their types populated in the above Select if they are part
@@ -237,18 +343,8 @@ func (p *planner) Update(
 	// using checkColumnType. This step also verifies that the expression
 	// types match the column types.
 	sel := rows.(*renderNode)
-	for i, target := range sel.render[exprTargetIdx:] {
-		// DefaultVal doesn't implement TypeCheck
-		if _, ok := target.(parser.DefaultVal); ok {
-			continue
-		}
-		// TODO(nvanbenschoten) isn't this TypeCheck redundant with the call to SelectClause?
-		typedTarget, err := parser.TypeCheck(target, &p.semaCtx, updateCols[i].Type.ToDatumType())
-		if err != nil {
-			return nil, err
-		}
-		err = sqlbase.CheckColumnType(updateCols[i], typedTarget.ResolvedType(), &p.semaCtx.Placeholders)
-		if err != nil {
+	for _, sourceSlot := range sourceSlots {
+		if err := sourceSlot.checkColumnTypes(sel.render, &p.semaCtx.Placeholders); err != nil {
 			return nil, err
 		}
 	}
@@ -264,6 +360,7 @@ func (p *planner) Update(
 		updateCols:    ru.UpdateCols,
 		updateColsIdx: updateColsIdx,
 		tw:            tw,
+		sourceSlots:   sourceSlots,
 	}
 	if err := un.checkHelper.init(ctx, p, tn, en.tableDesc); err != nil {
 		return nil, err
@@ -302,12 +399,21 @@ func (u *updateNode) Next(ctx context.Context) (bool, error) {
 
 	tracing.AnnotateTrace()
 
-	oldValues := u.run.rows.Values()
+	entireRow := u.run.rows.Values()
 
 	// Our updated value expressions occur immediately after the plain
 	// columns in the output.
-	updateValues := oldValues[len(u.tw.ru.FetchCols):]
-	oldValues = oldValues[:len(u.tw.ru.FetchCols)]
+	oldValues := entireRow[:len(u.tw.ru.FetchCols)]
+
+	updateValues := make(parser.Datums, len(u.tw.ru.UpdateCols))
+	valueIdx := 0
+
+	for _, slot := range u.sourceSlots {
+		for _, value := range slot.extractValues(entireRow) {
+			updateValues[valueIdx] = value
+			valueIdx++
+		}
+	}
 
 	u.checkHelper.loadRow(u.tw.ru.FetchColIDtoRowIndex, oldValues, false)
 	u.checkHelper.loadRow(u.updateColsIdx, updateValues, true)
@@ -322,7 +428,6 @@ func (u *updateNode) Next(ctx context.Context) (bool, error) {
 		}
 	}
 
-	// Update the row values.
 	for i, col := range u.tw.ru.UpdateCols {
 		val := updateValues[i]
 		if !col.Nullable && val == parser.DNull {
@@ -330,6 +435,7 @@ func (u *updateNode) Next(ctx context.Context) (bool, error) {
 		}
 	}
 
+	// Update the row values.
 	newValues, err := u.tw.row(ctx, append(oldValues, updateValues...))
 	if err != nil {
 		return false, err
@@ -373,9 +479,7 @@ func (p *planner) namesForExprs(exprs parser.UpdateExprs) (parser.UnresolvedName
 	return names, nil
 }
 
-func fillDefault(
-	expr parser.Expr, desired parser.Type, index int, defaultExprs []parser.TypedExpr,
-) parser.Expr {
+func fillDefault(expr parser.Expr, index int, defaultExprs []parser.TypedExpr) parser.Expr {
 	switch expr.(type) {
 	case parser.DefaultVal:
 		if defaultExprs == nil {

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -99,15 +99,13 @@ func (p *planner) makeUpsertHelper(
 		if updateExpr.Tuple {
 			if t, ok := updateExpr.Expr.(*parser.Tuple); ok {
 				for _, e := range t.Exprs {
-					typ := updateCols[i].Type.ToDatumType()
-					e = fillDefault(e, typ, i, defaultExprs)
+					e = fillDefault(e, i, defaultExprs)
 					untupledExprs = append(untupledExprs, e)
 					i++
 				}
 			}
 		} else {
-			typ := updateCols[i].Type.ToDatumType()
-			e := fillDefault(updateExpr.Expr, typ, i, defaultExprs)
+			e := fillDefault(updateExpr.Expr, i, defaultExprs)
 			untupledExprs = append(untupledExprs, e)
 			i++
 		}

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -182,8 +182,8 @@ func (n *windowNode) constructWindowDefinitions(
 
 		// Validate PARTITION BY clause.
 		for _, partition := range windowDef.Partitions {
-			cols, exprs, _, err := s.planner.computeRender(ctx, parser.SelectExpr{Expr: partition},
-				parser.TypeAny, s.sourceInfo, s.ivarHelper, true)
+			cols, exprs, _, err := s.planner.computeRenderAllowingStars(ctx,
+				parser.SelectExpr{Expr: partition}, parser.TypeAny, s.sourceInfo, s.ivarHelper)
 			if err != nil {
 				return err
 			}
@@ -199,8 +199,8 @@ func (n *windowNode) constructWindowDefinitions(
 
 		// Validate ORDER BY clause.
 		for _, orderBy := range windowDef.OrderBy {
-			cols, exprs, _, err := s.planner.computeRender(ctx, parser.SelectExpr{Expr: orderBy.Expr},
-				parser.TypeAny, s.sourceInfo, s.ivarHelper, true)
+			cols, exprs, _, err := s.planner.computeRenderAllowingStars(ctx,
+				parser.SelectExpr{Expr: orderBy.Expr}, parser.TypeAny, s.sourceInfo, s.ivarHelper)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes #6852.

The `sourceSlot` interface allows the query plan to not be littered with 1-tuples when doing single-column assignments, at the cost of some additional complexity and indirection. We could also conceivably do a type check on the results from the SELECT to see if we have tuples that we need to descend into to assign to columns, but I think it's cleaner and more explicit to manually keep track of how we need to handle each of the results.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14611)
<!-- Reviewable:end -->
