### PR TITLE
cli: Keep client and server flags more separate

### DIFF
--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -128,7 +128,7 @@ func TestHttpHostFlagValue(t *testing.T) {
 
 	for i, td := range testData {
 		// Ensure each test case starts with an empty package-level variable.
-		httpHost = ""
+		serverHTTPHost = ""
 
 		if err := f.Parse(td.args); err != nil {
 			t.Fatal(err)

--- a/pkg/cli/kv.go
+++ b/pkg/cli/kv.go
@@ -47,7 +47,7 @@ func addrWithDefaultHost(addr string) (string, error) {
 
 // MakeDBClient creates a kv client for use in cli tools.
 func MakeDBClient() (*client.DB, *stop.Stopper, error) {
-	conn, clock, stopper, err := getGRPCConn()
+	conn, clock, stopper, err := getClientGRPCConn()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -206,7 +206,7 @@ func init() {
 }
 
 func getStatusClient() (serverpb.StatusClient, *stop.Stopper, error) {
-	conn, _, stopper, err := getGRPCConn()
+	conn, _, stopper, err := getClientGRPCConn()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -180,30 +180,31 @@ func makeSQLConn(url string) *sqlConn {
 // for a password as the only authentication method available for this user is
 // certificate authentication.
 func getPasswordAndMakeSQLClient() (*sqlConn, error) {
-	if len(connURL) != 0 {
-		return makeSQLConn(connURL), nil
+	if len(sqlConnURL) != 0 {
+		return makeSQLConn(sqlConnURL), nil
 	}
 	var user *url.Userinfo
-	if !baseCfg.Insecure && connUser != security.RootUser && baseCfg.SSLCert == "" && baseCfg.SSLCertKey == "" {
+	if !baseCfg.Insecure && sqlConnUser != security.RootUser &&
+		baseCfg.SSLCert == "" && baseCfg.SSLCertKey == "" {
 		pwd, err := security.PromptForPassword()
 		if err != nil {
 			return nil, err
 		}
-		user = url.UserPassword(connUser, pwd)
+		user = url.UserPassword(sqlConnUser, pwd)
 	} else {
-		user = url.User(connUser)
+		user = url.User(sqlConnUser)
 	}
 	return makeSQLClient(user)
 }
 
 func makeSQLClient(user *url.Userinfo) (*sqlConn, error) {
-	sqlURL := connURL
-	if len(connURL) == 0 {
+	sqlURL := sqlConnURL
+	if len(sqlConnURL) == 0 {
 		u, err := sqlCtx.PGURL(user)
 		if err != nil {
 			return nil, err
 		}
-		u.Path = connDBName
+		u.Path = sqlConnDBName
 		sqlURL = u.String()
 	}
 	return makeSQLConn(sqlURL), nil

--- a/pkg/cli/start_test.go
+++ b/pkg/cli/start_test.go
@@ -65,7 +65,7 @@ func TestInitInsecure(t *testing.T) {
 			t.Fatalf("%d: expected %v, but found %v", i, c.insecure, ctx.Insecure)
 		}
 
-		err := initInsecure()
+		err := initInsecureServer()
 		if !testutils.IsError(err, c.expected) {
 			t.Fatalf("%d: expected %q, but found %v", i, c.expected, err)
 		}

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -107,7 +107,7 @@ func runDebugZip(cmd *cobra.Command, args []string) error {
 		return errors.New("exactly one argument is required")
 	}
 
-	conn, _, stopper, err := getGRPCConn()
+	conn, _, stopper, err := getClientGRPCConn()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Prior to this, the client port flag's environment variable could get
pulled in and used by the server even though the server's port flag
isn't supposed to support being set by an env variable.

That's the problem with setting package globals for these. It'd be nice
to only even define the flags for the command being run, but that's
tricky to do with pflags since all of its "PreRun" functionality runs
after flags have already been parsed.

Fixes #8876. cc #9189

@mberhault

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14612)
<!-- Reviewable:end -->
