### PR TITLE
ui/Makefile: depend on correct yarn.installed target

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -121,7 +121,14 @@ $(GITHOOKSDIR)/%: githooks/%
 	@ln -s ../../$(basename $<) $(dir $@)
 endif
 
-$(UI_ROOT)/yarn.installed: $(UI_ROOT)/package.json $(UI_ROOT)/yarn.lock
+# Make does textual matching on target names, so e.g. yarn.installed and
+# ../../pkg/ui/yarn.installed are considered different targets even when the CWD
+# is pkg/ui. Introducing a variable for targets that are used across Makefiles
+# with different CWDs decreases the chance of accidentally using the wrong path
+# to a target.
+YARN_INSTALLED_TARGET := $(UI_ROOT)/yarn.installed
+
+$(YARN_INSTALLED_TARGET): $(UI_ROOT)/package.json $(UI_ROOT)/yarn.lock
 	cd $(UI_ROOT) && yarn install
 	rm -rf $(UI_ROOT)/node_modules/@types/node # https://github.com/yarnpkg/yarn/issues/2987
 	touch $@

--- a/build/protobuf.mk
+++ b/build/protobuf.mk
@@ -93,7 +93,7 @@ $(GW_SOURCES) : $(GW_SERVER_PROTOS) $(GW_TS_PROTOS) $(GO_PROTOS) $(GOGOPROTO_PRO
 	$(PROTOC) -I.:$(GOGO_PROTOBUF_PATH):$(PROTOBUF_PATH):$(COREOS_PATH):$(GRPC_GATEWAY_GOOGLEAPIS_PATH) --grpc-gateway_out=logtostderr=true,request_context=true:. $(GW_SERVER_PROTOS)
 	$(PROTOC) -I.:$(GOGO_PROTOBUF_PATH):$(PROTOBUF_PATH):$(COREOS_PATH):$(GRPC_GATEWAY_GOOGLEAPIS_PATH) --grpc-gateway_out=logtostderr=true,request_context=true:. $(GW_TS_PROTOS)
 
-$(UI_JS): $(GO_PROTOS) $(COREOS_RAFT_PROTOS) $(UI_ROOT)/yarn.installed
+$(UI_JS): $(GO_PROTOS) $(COREOS_RAFT_PROTOS) $(YARN_INSTALLED_TARGET)
 	# Add comment recognized by reviewable.
 	echo '// GENERATED FILE DO NOT EDIT' > $@
 	pbjs -t static-module -w es6 --strict-long --keep-case --path $(ORG_ROOT) --path $(GOGO_PROTOBUF_PATH) --path $(COREOS_PATH) --path $(GRPC_GATEWAY_GOOGLEAPIS_PATH) $(GW_PROTOS) >> $@

--- a/build/variables.mk
+++ b/build/variables.mk
@@ -43,5 +43,6 @@ define VALID_VARS
   TYPE
   UI_ROOT
   XGO
+  YARN_INSTALLED_TARGET
   space
 endef

--- a/pkg/ui/Makefile
+++ b/pkg/ui/Makefile
@@ -33,19 +33,19 @@ protos:
 generate: $(GOBINDATA_TARGET)
 
 .PHONY: lint
-lint: yarn.installed
+lint: $(YARN_INSTALLED_TARGET)
 	stylint -c .stylintrc styl
 	tslint -c tslint.json $(shell find src -name '*.tsx' -or -name '*.ts' -not -path 'src/js/*')
 
 .PHONY: test
-test: yarn.installed protos
+test: $(YARN_INSTALLED_TARGET) protos
 	karma start
 
 .PHONY: test-debug
-test-debug: yarn.installed protos
+test-debug: $(YARN_INSTALLED_TARGET) protos
 	karma start --browsers Chrome --no-single-run --reporters mocha
 
-$(GOBINDATA_TARGET): yarn.installed protos
+$(GOBINDATA_TARGET): $(YARN_INSTALLED_TARGET) protos
 	rm -rf dist
 	webpack -p
 	go-bindata -nometadata -pkg ui -o $@ -prefix dist dist


### PR DESCRIPTION
Make considers targets that are textually different to name different
files. This means paths that resolve to the same file, like
yarn.installed and ../../pkg/ui/yarn.installed when the CWD is pkg/ui,
are considered different targets. The UI Makefile is currently unable to
automatically install Yarn dependencies because it spells yarn.installed
differently than build/common.mk.

This commit introduces a variable, YARN_INSTALLED_TARGET, and uses it
consistently across our Makefiles. This fixes the problem and should
make it harder to spell the name of yarn.installed wrong in the future.

This fixes an error surfaced by #14610.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14613)
<!-- Reviewable:end -->
