### PR TITLE
storage: Annotate contexts in lease acquisition code

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1400,7 +1400,6 @@ func (s *Store) startGossip() {
 	for _, gossipFn := range gossipFns {
 		gossipFn := gossipFn // per-iteration copy
 		s.stopper.RunWorker(func() {
-			ctx := s.AnnotateCtx(context.Background())
 			ticker := time.NewTicker(gossipFn.interval)
 			defer ticker.Stop()
 			for first := true; ; {
@@ -1412,6 +1411,7 @@ func (s *Store) startGossip() {
 				retryOptions.Closer = s.stopper.ShouldStop()
 				for r := retry.Start(retryOptions); r.Next(); {
 					if repl := s.LookupReplica(roachpb.RKey(gossipFn.key), nil); repl != nil {
+						ctx := repl.AnnotateCtx(context.Background())
 						if err := gossipFn.fn(ctx, repl); err != nil {
 							log.Warningf(ctx, "could not gossip %s: %s", gossipFn.description, err)
 							if err != errPeriodicGossipsDisabled {


### PR DESCRIPTION
This makes it clear which range we're trying to acquire the lease for,
which is particularly useful for the "have been waiting 1m attempting
to acquire lease" error logs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14617)
<!-- Reviewable:end -->
