### PR TITLE
sql: force index usage in collatedstring index tests

### DIFF
--- a/pkg/sql/testdata/logic_test/collatedstring_index1
+++ b/pkg/sql/testdata/logic_test/collatedstring_index1
@@ -26,7 +26,7 @@ INSERT INTO t VALUES
   ('x' COLLATE da, 5, FALSE)
 
 query TI
-SELECT a, b FROM t ORDER BY (a, b)
+SELECT a, b FROM t ORDER BY a, b
 ----
 a  2
 a  3
@@ -39,7 +39,7 @@ x  5
 ü  6
 
 query IT
-SELECT b, a FROM t ORDER BY (b, a)
+SELECT b, a FROM t ORDER BY b, a
 ----
 1  A
 2  a
@@ -69,10 +69,20 @@ SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 # Create an index and try again.
 
 statement ok
-CREATE INDEX ON t (b, a) STORING (c)
+CREATE INDEX ON t (b, a)
+
+# TODO(#14533): add STORING (c)
+
+query ITTT
+EXPLAIN SELECT a, b FROM t ORDER BY a, b
+----
+0  render
+1  scan
+1          table  t@primary
+1          spans  ALL
 
 query TI
-SELECT a, b FROM t ORDER BY (a, b)
+SELECT a, b FROM t ORDER BY a, b
 ----
 a  2
 a  3
@@ -84,8 +94,16 @@ x  5
 ü  5
 ü  6
 
+query ITTT
+EXPLAIN SELECT b, a FROM t ORDER BY b, a
+----
+0  render
+1  scan
+1          table  t@t_b_a_idx
+1          spans  ALL
+
 query IT
-SELECT b, a FROM t ORDER BY (b, a)
+SELECT b, a FROM t ORDER BY b, a
 ----
 1  A
 2  a
@@ -117,8 +135,16 @@ SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 statement ok
 UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE da
 
+query ITTT
+EXPLAIN SELECT a, b FROM t ORDER BY a, b
+----
+0  render
+1  scan
+1          table  t@primary
+1          spans  ALL
+
 query TI
-SELECT a, b FROM t ORDER BY (a, b)
+SELECT a, b FROM t ORDER BY a, b
 ----
 bb  4
 BB  3
@@ -130,8 +156,16 @@ aa  3
 AA  1
 AA  2
 
+query ITTT
+EXPLAIN SELECT b, a FROM t ORDER BY b, a
+----
+0  render
+1  scan
+1          table  t@t_b_a_idx
+1          spans  ALL
+
 query IT
-SELECT b, a FROM t ORDER BY (b, a)
+SELECT b, a FROM t ORDER BY b, a
 ----
 1  AA
 2  aa
@@ -148,8 +182,16 @@ SELECT b, a FROM t ORDER BY (b, a)
 statement ok
 DELETE FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 
+query ITTT
+EXPLAIN SELECT a, b FROM t ORDER BY a, b
+----
+0  render
+1  scan
+1          table  t@primary
+1          spans  ALL
+
 query TI
-SELECT a, b FROM t ORDER BY (a, b)
+SELECT a, b FROM t ORDER BY a, b
 ----
 xx  5
 üü  5
@@ -159,8 +201,16 @@ aa  3
 AA  1
 AA  2
 
+query ITTT
+EXPLAIN SELECT b, a FROM t ORDER BY b, a
+----
+0  render
+1  scan
+1          table  t@t_b_a_idx
+1          spans  ALL
+
 query IT
-SELECT b, a FROM t ORDER BY (b, a)
+SELECT b, a FROM t ORDER BY b, a
 ----
 1  AA
 2  aa

--- a/pkg/sql/testdata/logic_test/collatedstring_index2
+++ b/pkg/sql/testdata/logic_test/collatedstring_index2
@@ -26,7 +26,7 @@ INSERT INTO t VALUES
   ('x' COLLATE de, 5, FALSE)
 
 query TI
-SELECT a, b FROM t ORDER BY (a, b)
+SELECT a, b FROM t ORDER BY a, b
 ----
 a  2
 a  3
@@ -39,7 +39,7 @@ B  3
 x  5
 
 query IT
-SELECT b, a FROM t ORDER BY (b, a)
+SELECT b, a FROM t ORDER BY b, a
 ----
 1  A
 2  a
@@ -69,10 +69,20 @@ SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 # Create an index and try again.
 
 statement ok
-CREATE INDEX ON t (a, b) STORING (c)
+CREATE INDEX ON t (a, b)
+
+# TODO(#14533): add STORING (c)
+
+query ITTT
+EXPLAIN SELECT a, b FROM t ORDER BY a, b
+----
+0  render
+1  scan
+1          table  t@t_a_b_idx
+1          spans  ALL
 
 query TI
-SELECT a, b FROM t ORDER BY (a, b)
+SELECT a, b FROM t ORDER BY a, b
 ----
 a  2
 a  3
@@ -84,8 +94,16 @@ B  3
 ü  6
 x  5
 
+query ITTT
+EXPLAIN SELECT b, a FROM t ORDER BY b, a
+----
+0  render
+1  scan
+1          table  t@primary
+1          spans  ALL
+
 query IT
-SELECT b, a FROM t ORDER BY (b, a)
+SELECT b, a FROM t ORDER BY b, a
 ----
 1  A
 2  a
@@ -117,8 +135,16 @@ SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 statement ok
 UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE de
 
+query ITTT
+EXPLAIN SELECT a, b FROM t ORDER BY a, b
+----
+0  render
+1  scan
+1          table  t@t_a_b_idx
+1          spans  ALL
+
 query TI
-SELECT a, b FROM t ORDER BY (a, b)
+SELECT a, b FROM t ORDER BY a, b
 ----
 aa  2
 aa  3
@@ -130,8 +156,16 @@ BB  3
 üü  6
 xx  5
 
+query ITTT
+EXPLAIN SELECT b, a FROM t ORDER BY b, a
+----
+0  render
+1  scan
+1          table  t@primary
+1          spans  ALL
+
 query IT
-SELECT b, a FROM t ORDER BY (b, a)
+SELECT b, a FROM t ORDER BY b, a
 ----
 1  AA
 2  aa
@@ -148,15 +182,31 @@ SELECT b, a FROM t ORDER BY (b, a)
 statement ok
 DELETE FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 
+query ITTT
+EXPLAIN SELECT a, b FROM t ORDER BY a, b
+----
+0  render
+1  scan
+1          table  t@t_a_b_idx
+1          spans  ALL
+
 query TI
-SELECT a, b FROM t ORDER BY (a, b)
+SELECT a, b FROM t ORDER BY a, b
 ----
 üü  5
 üü  6
 xx  5
 
+query ITTT
+EXPLAIN SELECT b, a FROM t ORDER BY b, a
+----
+0  render
+1  scan
+1          table  t@primary
+1          spans  ALL
+
 query IT
-SELECT b, a FROM t ORDER BY (b, a)
+SELECT b, a FROM t ORDER BY b, a
 ----
 5  üü
 5  xx

--- a/pkg/sql/testdata/logic_test/collatedstring_uniqueindex1
+++ b/pkg/sql/testdata/logic_test/collatedstring_uniqueindex1
@@ -28,8 +28,16 @@ INSERT INTO t VALUES
 statement ok
 CREATE UNIQUE INDEX ON t (b, a)
 
+query ITTT
+EXPLAIN SELECT a, b FROM t ORDER BY a, b
+----
+0  render
+1  scan
+1          table  t@primary
+1          spans  ALL
+
 query TI
-SELECT a, b FROM t ORDER BY (a, b)
+SELECT a, b FROM t ORDER BY a, b
 ----
 a  2
 a  3
@@ -41,8 +49,16 @@ x  5
 ü  5
 ü  6
 
+query ITTT
+EXPLAIN SELECT b, a FROM t ORDER BY b, a
+----
+0  render
+1  scan
+1          table  t@t_b_a_key
+1          spans  ALL
+
 query IT
-SELECT b, a FROM t ORDER BY (b, a)
+SELECT b, a FROM t ORDER BY b, a
 ----
 1  A
 2  a
@@ -74,8 +90,16 @@ SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 statement ok
 UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE da
 
+query ITTT
+EXPLAIN SELECT a, b FROM t ORDER BY a, b
+----
+0  render
+1  scan
+1          table  t@primary
+1          spans  ALL
+
 query TI
-SELECT a, b FROM t ORDER BY (a, b)
+SELECT a, b FROM t ORDER BY a, b
 ----
 bb  4
 BB  3
@@ -87,8 +111,16 @@ aa  3
 AA  1
 AA  2
 
+query ITTT
+EXPLAIN SELECT b, a FROM t ORDER BY b, a
+----
+0  render
+1  scan
+1          table  t@t_b_a_key
+1          spans  ALL
+
 query IT
-SELECT b, a FROM t ORDER BY (b, a)
+SELECT b, a FROM t ORDER BY b, a
 ----
 1  AA
 2  aa
@@ -105,8 +137,16 @@ SELECT b, a FROM t ORDER BY (b, a)
 statement ok
 DELETE FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 
+query ITTT
+EXPLAIN SELECT a, b FROM t ORDER BY a, b
+----
+0  render
+1  scan
+1          table  t@primary
+1          spans  ALL
+
 query TI
-SELECT a, b FROM t ORDER BY (a, b)
+SELECT a, b FROM t ORDER BY a, b
 ----
 xx  5
 üü  5
@@ -116,8 +156,16 @@ aa  3
 AA  1
 AA  2
 
+query ITTT
+EXPLAIN SELECT b, a FROM t ORDER BY b, a
+----
+0  render
+1  scan
+1          table  t@t_b_a_key
+1          spans  ALL
+
 query IT
-SELECT b, a FROM t ORDER BY (b, a)
+SELECT b, a FROM t ORDER BY b, a
 ----
 1  AA
 2  aa

--- a/pkg/sql/testdata/logic_test/collatedstring_uniqueindex2
+++ b/pkg/sql/testdata/logic_test/collatedstring_uniqueindex2
@@ -28,8 +28,16 @@ INSERT INTO t VALUES
 statement ok
 CREATE UNIQUE INDEX ON t (a, b)
 
+query ITTT
+EXPLAIN SELECT a, b FROM t ORDER BY a, b
+----
+0  render
+1  scan
+1          table  t@t_a_b_key
+1          spans  ALL
+
 query TI
-SELECT a, b FROM t ORDER BY (a, b)
+SELECT a, b FROM t ORDER BY a, b
 ----
 a  2
 a  3
@@ -41,8 +49,16 @@ B  3
 ü  6
 x  5
 
+query ITTT
+EXPLAIN SELECT b, a FROM t ORDER BY b, a
+----
+0  render
+1  scan
+1          table  t@primary
+1          spans  ALL
+
 query IT
-SELECT b, a FROM t ORDER BY (b, a)
+SELECT b, a FROM t ORDER BY b, a
 ----
 1  A
 2  a
@@ -74,8 +90,16 @@ SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 statement ok
 UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE de
 
+query ITTT
+EXPLAIN SELECT a, b FROM t ORDER BY a, b
+----
+0  render
+1  scan
+1          table  t@t_a_b_key
+1          spans  ALL
+
 query TI
-SELECT a, b FROM t ORDER BY (a, b)
+SELECT a, b FROM t ORDER BY a, b
 ----
 aa  2
 aa  3
@@ -87,8 +111,16 @@ BB  3
 üü  6
 xx  5
 
+query ITTT
+EXPLAIN SELECT b, a FROM t ORDER BY b, a
+----
+0  render
+1  scan
+1          table  t@primary
+1          spans  ALL
+
 query IT
-SELECT b, a FROM t ORDER BY (b, a)
+SELECT b, a FROM t ORDER BY b, a
 ----
 1  AA
 2  aa
@@ -105,15 +137,31 @@ SELECT b, a FROM t ORDER BY (b, a)
 statement ok
 DELETE FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 
+query ITTT
+EXPLAIN SELECT a, b FROM t ORDER BY a, b
+----
+0  render
+1  scan
+1          table  t@t_a_b_key
+1          spans  ALL
+
 query TI
-SELECT a, b FROM t ORDER BY (a, b)
+SELECT a, b FROM t ORDER BY a, b
 ----
 üü  5
 üü  6
 xx  5
 
+query ITTT
+EXPLAIN SELECT b, a FROM t ORDER BY b, a
+----
+0  render
+1  scan
+1          table  t@primary
+1          spans  ALL
+
 query IT
-SELECT b, a FROM t ORDER BY (b, a)
+SELECT b, a FROM t ORDER BY b, a
 ----
 5  üü
 5  xx


### PR DESCRIPTION
These tests were not actually using the index because the ORDER BY
clauses had parentheses, making them use a computed sort key and
bypassing the index. Add EXPLAIN statements to verify the desired index
use.

Delete the STORING clauses for now pending resolution of #14601.

Progress toward fixing #14533.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14618)
<!-- Reviewable:end -->
