### PR TITLE
cli: split insecure flag into client/server versions

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -279,7 +279,7 @@ func (cfg *Config) GetServerTLSConfig() (*tls.Config, error) {
 			}
 		} else {
 			cfg.serverTLSConfig.err = errors.Errorf("--%s=false, but --%s is empty. Certificates must be specified.",
-				cliflags.Insecure.Name, cliflags.Cert.Name)
+				cliflags.ServerInsecure.Name, cliflags.Cert.Name)
 		}
 	})
 

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -235,13 +235,19 @@ Note: when given a path to a unix socket, most postgres clients will
 open "<given path>/.s.PGSQL.<server port>"`,
 	}
 
-	Insecure = FlagInfo{
-		Name:   "insecure",
-		EnvVar: "COCKROACH_INSECURE",
+	ServerInsecure = FlagInfo{
+		Name: "insecure",
 		Description: `
 Run over non-encrypted (non-TLS) connections. This is strongly discouraged for
 production usage and this flag must be explicitly specified in order for the
 server to listen on an external address in insecure mode.`,
+	}
+
+	ClientInsecure = FlagInfo{
+		Name:   "insecure",
+		EnvVar: "COCKROACH_INSECURE",
+		Description: `
+Connect to a cluster over non-encrypted (non-TLS) connections.`,
 	}
 
 	KeySize = FlagInfo{

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -70,7 +70,8 @@ func InitCLIDefaults() {
 
 var sqlSize *bytesValue
 var cacheSize *bytesValue
-var insecure *insecureValue
+var serverInsecure *insecureValue
+var clientInsecure *insecureValue
 
 const usageIndentation = 8
 const wrapWidth = 79 - usageIndentation
@@ -285,7 +286,8 @@ func init() {
 
 	// Security flags.
 	baseCfg.Insecure = true
-	insecure = newInsecureValue(baseCfg)
+	serverInsecure = newInsecureValue(baseCfg)
+	clientInsecure = newInsecureValue(baseCfg)
 
 	{
 		f := startCmd.Flags()
@@ -311,9 +313,9 @@ func init() {
 
 		stringFlag(f, &serverCfg.PIDFile, cliflags.PIDFile, "")
 
-		varFlag(f, insecure, cliflags.Insecure)
+		varFlag(f, serverInsecure, cliflags.ServerInsecure)
 		// Allow '--insecure'
-		f.Lookup(cliflags.Insecure.Name).NoOptDefVal = "true"
+		f.Lookup(cliflags.ServerInsecure.Name).NoOptDefVal = "true"
 
 		// Certificate flags.
 		stringFlag(f, &baseCfg.SSLCA, cliflags.CACert, baseCfg.SSLCA)
@@ -365,9 +367,9 @@ func init() {
 		stringFlag(f, &clientConnHost, cliflags.ClientHost, "")
 		stringFlag(f, &clientConnPort, cliflags.ClientPort, base.DefaultPort)
 
-		varFlag(f, insecure, cliflags.Insecure)
+		varFlag(f, clientInsecure, cliflags.ClientInsecure)
 		// Allow '--insecure'
-		f.Lookup(cliflags.Insecure.Name).NoOptDefVal = "true"
+		f.Lookup(cliflags.ClientInsecure.Name).NoOptDefVal = "true"
 
 		// Certificate flags.
 		stringFlag(f, &baseCfg.SSLCA, cliflags.CACert, baseCfg.SSLCA)

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -98,7 +98,7 @@ func setDefaultSizeParameters(ctx *server.Config) {
 }
 
 func initInsecureServer() error {
-	if !serverCfg.Insecure || insecure.isSet {
+	if !serverCfg.Insecure || serverInsecure.isSet {
 		return nil
 	}
 	// The --insecure flag was not specified on the command line, verify that the

--- a/pkg/cli/start_test.go
+++ b/pkg/cli/start_test.go
@@ -63,7 +63,7 @@ func TestInitInsecure(t *testing.T) {
 		// Reset the context and insecure flag for every test case.
 		ctx.InitDefaults()
 		ctx.Insecure = true
-		insecure.isSet = false
+		serverInsecure.isSet = false
 
 		if err := f.Parse(c.args); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
This is to disable the `COCKROACH_INSECURE` env variable on the `start`
command.

Fixes #9189

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14622)
<!-- Reviewable:end -->
