### PR TITLE
cli: add health check to haproxy

### DIFF
--- a/pkg/cli/haproxy.go
+++ b/pkg/cli/haproxy.go
@@ -100,6 +100,6 @@ listen psql
     bind :26257
     mode tcp
     balance roundrobin
-{{range .}}    server cockroach{{.Desc.NodeID}} {{.Desc.Address.AddressField}}
+{{range .}}    server cockroach{{.Desc.NodeID}} {{.Desc.Address.AddressField}} check
 {{end}}
 `


### PR DESCRIPTION
This enables health checks on the server.
Defaults with this config are tcp-level checks with:
* interval: 2s
* rise (num successful checks before considering UP): 2
* fall (num failed checks before considering DOWN): 3

Fixes #14071

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14624)
<!-- Reviewable:end -->
