### PR TITLE
sql: backfillers can use txn.CommitInBatch

### DIFF
--- a/pkg/sql/distsqlrun/columnbackfiller.go
+++ b/pkg/sql/distsqlrun/columnbackfiller.go
@@ -211,7 +211,7 @@ func (cb *columnBackfiller) runChunk(
 		}
 
 		oldValues := make(parser.Datums, len(ru.FetchCols))
-		b := &client.Batch{}
+		b := txn.NewBatch()
 		rowLength := 0
 		for i := int64(0); i < chunkSize; i++ {
 			row, err := cb.fetcher.NextRowDecoded(ctx)
@@ -240,7 +240,7 @@ func (cb *columnBackfiller) runChunk(
 			}
 		}
 		// Write the new row values.
-		if err := txn.Run(ctx, b); err != nil {
+		if err := txn.CommitInBatch(ctx, b); err != nil {
 			return ConvertBackfillError(&cb.spec.Table, b)
 		}
 		return nil

--- a/pkg/sql/distsqlrun/indexbackfiller.go
+++ b/pkg/sql/distsqlrun/indexbackfiller.go
@@ -138,7 +138,7 @@ func (ib *indexBackfiller) runChunk(
 			return err
 		}
 
-		b := &client.Batch{}
+		b := txn.NewBatch()
 		for i := int64(0); i < chunkSize; i++ {
 			encRow, err := ib.fetcher.NextRow(ctx)
 			if err != nil {
@@ -165,7 +165,7 @@ func (ib *indexBackfiller) runChunk(
 			}
 		}
 		// Write the new index values.
-		if err := txn.Run(ctx, b); err != nil {
+		if err := txn.CommitInBatch(ctx, b); err != nil {
 			return ConvertBackfillError(&ib.spec.Table, b)
 		}
 		return nil

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -1003,23 +1003,6 @@ COMMIT;
 
 			wg.Wait() // for schema change to complete
 
-			// Backfill retry happened.
-			if count, e := atomic.SwapInt64(&retriedBackfill, 0), int64(1); count != e {
-				t.Fatalf("expected = %d, found = %d", e, count)
-			}
-			// 1 failed + 2 retried backfill chunks.
-			expectNumBackfills := int64(3)
-			if testCase == testCases[len(testCases)-1] {
-				// The DROP INDEX case: The above INSERTs do not add any index
-				// entries for the inserted rows, so the index remains smaller
-				// than a backfill chunk and is dropped in a single retried
-				// backfill chunk.
-				expectNumBackfills = 2
-			}
-			if count := atomic.SwapInt64(&backfillCount, 0); count != expectNumBackfills {
-				t.Fatalf("expected = %d, found = %d", expectNumBackfills, count)
-			}
-
 			ctx := context.TODO()
 
 			// Verify the number of keys left behind in the table to validate


### PR DESCRIPTION
Previously, the column and index backfillers wrote their values using
`txn.Run`, which prevents the 1PC fast-path for transactions from being
taken.

Since we're closing the transaction immediately after writing, it's
legal to use `txn.CommitInBatch` instead. This should improve performance of
both index and column backfills.

Updates #12424.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14633)
<!-- Reviewable:end -->
