### PR TITLE
storage: unskip TestStoreRangeSplitRaceUninitializedRHS

### DIFF
--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1370,7 +1370,6 @@ func TestStoreSplitTimestampCacheDifferentLeaseHolder(t *testing.T) {
 // and the uninitialized replica reacting to messages.
 func TestStoreRangeSplitRaceUninitializedRHS(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#10172")
 	mtc := &multiTestContext{}
 	storeCfg := storage.TestStoreConfig(nil)
 	// An aggressive tick interval lets groups communicate more and thus


### PR DESCRIPTION
fixes #10172

Not seeing this on running

```make stress PKG=./pkg/storage TESTS=TestStoreRangeSplitRaceUninitializedRHS -p 10```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14635)
<!-- Reviewable:end -->
