### PR TITLE
distsql: support local aggregation for AVG

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -750,6 +750,8 @@ func (dsp *distSQLPlanner) addAggregators(
 		aggregations[i].ColIdx = uint32(p.planToStreamColMap[i])
 	}
 
+	inputTypes := p.ResultTypes
+
 	// The way our planNode construction currently orders columns between
 	// groupNode and its source is that the first len(n.funcs) columns are the
 	// arguments for the aggregation functions. The remaining columns are
@@ -816,6 +818,7 @@ func (dsp *distSQLPlanner) addAggregators(
 	}
 
 	var finalAggSpec distsqlrun.AggregatorSpec
+	var finalAggPost distsqlrun.PostProcessSpec
 
 	if !multiStage && allDistinct {
 		// We can't do local aggregation, but we can do local distinct processing
@@ -859,40 +862,77 @@ func (dsp *distSQLPlanner) addAggregators(
 			GroupCols:    groupCols,
 		}
 	} else {
-		localAgg := make([]distsqlrun.AggregatorSpec_Aggregation, len(aggregations)+len(groupCols))
-		intermediateTypes := make([]sqlbase.ColumnType, len(aggregations)+len(groupCols))
-		finalAgg := make([]distsqlrun.AggregatorSpec_Aggregation, len(aggregations))
-		finalGroupCols := make([]uint32, len(groupCols))
-
-		for i, e := range aggregations {
+		// Some aggregations might need multiple aggregation as part of their local
+		// and final stages (along with a final render expression to combine the
+		// multiple aggregations into a single result).
+		//
+		// Count the total number of aggregation in the local/final stages and keep
+		// track of whether any of them needs a final rendering.
+		numAgg := 0
+		needRender := false
+		for _, e := range aggregations {
 			info := distsqlplan.DistAggregationTable[e.Func]
-			localAgg[i] = distsqlrun.AggregatorSpec_Aggregation{
-				Func:   info.LocalStage,
-				ColIdx: e.ColIdx,
+			numAgg += len(info.LocalStage)
+			if info.FinalRendering != nil {
+				needRender = true
 			}
-			finalAgg[i] = distsqlrun.AggregatorSpec_Aggregation{
-				Func: info.FinalStage,
-				// The input of the i-th final expression is the output of the i-th
-				// local expression.
-				ColIdx: uint32(i),
-			}
-			var err error
-			_, intermediateTypes[i], err = distsqlrun.GetAggregateInfo(e.Func, p.ResultTypes[e.ColIdx])
-			if err != nil {
-				return err
+		}
+
+		localAgg := make([]distsqlrun.AggregatorSpec_Aggregation, numAgg+len(groupCols))
+		intermediateTypes := make([]sqlbase.ColumnType, numAgg+len(groupCols))
+		finalAgg := make([]distsqlrun.AggregatorSpec_Aggregation, numAgg)
+		finalGroupCols := make([]uint32, len(groupCols))
+		var finalPreRenderTypes []sqlbase.ColumnType
+		if needRender {
+			finalPreRenderTypes = make([]sqlbase.ColumnType, numAgg)
+		}
+
+		// Each aggregation can have multiple aggregations in the local/final
+		// stages. We concatenate all these into localAgg/finalAgg; aIdx is an index
+		// inside localAgg/finalAgg.
+		aIdx := 0
+		for _, e := range aggregations {
+			info := distsqlplan.DistAggregationTable[e.Func]
+			for i, localFunc := range info.LocalStage {
+				localAgg[aIdx] = distsqlrun.AggregatorSpec_Aggregation{
+					Func:   localFunc,
+					ColIdx: e.ColIdx,
+				}
+
+				_, localResultType, err := distsqlrun.GetAggregateInfo(localFunc, inputTypes[e.ColIdx])
+				if err != nil {
+					return err
+				}
+				intermediateTypes[aIdx] = localResultType
+
+				finalAgg[aIdx] = distsqlrun.AggregatorSpec_Aggregation{
+					Func: info.FinalStage[i],
+					// The input of final expression aIdx is the output of the
+					// local expression aIdx.
+					ColIdx: uint32(aIdx),
+				}
+				if needRender {
+					_, finalPreRenderTypes[aIdx], err = distsqlrun.GetAggregateInfo(
+						info.FinalStage[i], localResultType,
+					)
+					if err != nil {
+						return err
+					}
+				}
+				aIdx++
 			}
 		}
 
 		// Add IDENT expressions for the group columns; these need to be part of the
 		// output of the local stage because the final stage needs them.
 		for i, groupColIdx := range groupCols {
-			exprIdx := len(aggregations) + i
-			localAgg[exprIdx] = distsqlrun.AggregatorSpec_Aggregation{
+			localAgg[aIdx] = distsqlrun.AggregatorSpec_Aggregation{
 				Func:   distsqlrun.AggregatorSpec_IDENT,
 				ColIdx: groupColIdx,
 			}
-			intermediateTypes[exprIdx] = p.ResultTypes[groupColIdx]
-			finalGroupCols[i] = uint32(exprIdx)
+			intermediateTypes[aIdx] = inputTypes[groupColIdx]
+			finalGroupCols[i] = uint32(aIdx)
+			aIdx++
 		}
 
 		localAggSpec := distsqlrun.AggregatorSpec{
@@ -911,22 +951,46 @@ func (dsp *distSQLPlanner) addAggregators(
 			Aggregations: finalAgg,
 			GroupCols:    finalGroupCols,
 		}
+
+		if needRender {
+			// Build rendering expressions.
+			renderExprs := make([]distsqlrun.Expression, len(aggregations))
+			h := distsqlplan.MakeTypeIndexedVarHelper(finalPreRenderTypes)
+			// aIdx is an index inside finalAgg. It is used to keep track of the
+			// finalAgg results that correspond to each aggregation.
+			aIdx := 0
+			for i, e := range aggregations {
+				info := distsqlplan.DistAggregationTable[e.Func]
+				if info.FinalRendering == nil {
+					renderExprs[i] = distsqlplan.MakeExpression(h.IndexedVar(aIdx), nil)
+				} else {
+					expr, err := info.FinalRendering(&h, aIdx)
+					if err != nil {
+						return err
+					}
+					renderExprs[i] = distsqlplan.MakeExpression(expr, nil)
+				}
+				aIdx += len(info.LocalStage)
+			}
+			finalAggPost.RenderExprs = renderExprs
+		}
 	}
 
 	// TODO(radu): we could distribute the final stage by hash.
 
-	finalOutTypes := make([]sqlbase.ColumnType, len(finalAggSpec.Aggregations))
-	for i, agg := range finalAggSpec.Aggregations {
+	finalOutTypes := make([]sqlbase.ColumnType, len(aggregations))
+	for i, agg := range aggregations {
 		var err error
-		_, finalOutTypes[i], err = distsqlrun.GetAggregateInfo(agg.Func, p.ResultTypes[agg.ColIdx])
+		_, finalOutTypes[i], err = distsqlrun.GetAggregateInfo(agg.Func, inputTypes[agg.ColIdx])
 		if err != nil {
 			return err
 		}
 	}
+
 	p.AddSingleGroupStage(
 		node,
 		distsqlrun.ProcessorCoreUnion{Aggregator: &finalAggSpec},
-		distsqlrun.PostProcessSpec{},
+		finalAggPost,
 		finalOutTypes,
 	)
 

--- a/pkg/sql/distsqlplan/aggregator_funcs.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs.go
@@ -16,54 +16,163 @@
 
 package distsqlplan
 
-import "github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
+import (
+	"bytes"
+	"fmt"
 
-// DistAggregationInfo describes how we can best compute a distributed
-// aggregation. If we have multiple sources of data, we first compute a function
-// on each group ("local stage") and then we aggregate those results (final
-// "stage").
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
+
+// DistAggregationInfo is a blueprint for planning distributed aggregations. It
+// describes two stages - a local stage performs local aggregations wherever
+// data is available and generates partial results, and a final stage aggregates
+// the partial results from all data "partitions".
+//
+// The simplest example is SUM: the local stage computes the SUM of the items
+// on each node, and a final stage SUMs those partial sums into a final sum.
+// Similar functions are MIN, MAX, BOOL_AND, BOOL_OR.
+//
+// A less trivial example is COUNT: the local stage counts (COUNT), the final stage
+// adds the counts (SUM_INT).
+//
+// A more complex example is AVG, for which we have to do *multiple*
+// aggregations in each stage: we need to get a sum and a count, so the local
+// stage does SUM and COUNT, and the final stage does SUM and SUM_INT. We also
+// need an expression that takes these two values and generates the final AVG
+// result.
 type DistAggregationInfo struct {
-	LocalStage distsqlrun.AggregatorSpec_Func
-	FinalStage distsqlrun.AggregatorSpec_Func
-	// TODO(radu): in some cases (average, standard deviation, variance) we could
-	// benefit from multiple functions per stage plus an additional rendering stage.
+	// The local stage consists of one or more aggregations. All aggregations have
+	// the same input.
+	LocalStage []distsqlrun.AggregatorSpec_Func
+
+	// The final stage consists of the same number of aggregations as the local
+	// stage (the input of each one is the corresponding result from each instance
+	// of the local stage).
+	FinalStage []distsqlrun.AggregatorSpec_Func
+
+	// An optional rendering expression used to obtain the final result; required
+	// if there is more than one aggregation in each of the stages.
+	//
+	// Conceptually this is an expression that has access to the final stage
+	// results (via IndexedVars), to be run as the PostProcessing step of the
+	// final stage processor.  However, there are some complications:
+	//   - this structure is a blueprint for aggregating inputs of different
+	//     types, and in some cases the expression may be different depending on
+	//     the types (see AVG below).
+	//   - we support combining multiple "top level" aggregations into the same
+	//     processors, so the correct indexing of the input variables is not
+	//     predetermined.
+	//
+	// Instead of defining a canonical non-typed expression and then tweaking it
+	// with visitors, we use a function that directly creates a typed expression
+	// on demand. The expression will refer to the final stage results using
+	// IndexedVars, with indices shifted by varIdxOffset.
+	FinalRendering func(h *parser.IndexedVarHelper, varIdxOffset int) (parser.TypedExpr, error)
 }
 
 // DistAggregationTable is DistAggregationInfo look-up table. Functions that
 // don't have an entry in the table are not optimized with a local stage.
 var DistAggregationTable = map[distsqlrun.AggregatorSpec_Func]DistAggregationInfo{
 	distsqlrun.AggregatorSpec_IDENT: {
-		LocalStage: distsqlrun.AggregatorSpec_IDENT,
-		FinalStage: distsqlrun.AggregatorSpec_IDENT,
+		LocalStage: []distsqlrun.AggregatorSpec_Func{distsqlrun.AggregatorSpec_IDENT},
+		FinalStage: []distsqlrun.AggregatorSpec_Func{distsqlrun.AggregatorSpec_IDENT},
 	},
 
 	distsqlrun.AggregatorSpec_BOOL_AND: {
-		LocalStage: distsqlrun.AggregatorSpec_BOOL_AND,
-		FinalStage: distsqlrun.AggregatorSpec_BOOL_AND,
+		LocalStage: []distsqlrun.AggregatorSpec_Func{distsqlrun.AggregatorSpec_BOOL_AND},
+		FinalStage: []distsqlrun.AggregatorSpec_Func{distsqlrun.AggregatorSpec_BOOL_AND},
 	},
 
 	distsqlrun.AggregatorSpec_BOOL_OR: {
-		LocalStage: distsqlrun.AggregatorSpec_BOOL_OR,
-		FinalStage: distsqlrun.AggregatorSpec_BOOL_OR,
+		LocalStage: []distsqlrun.AggregatorSpec_Func{distsqlrun.AggregatorSpec_BOOL_OR},
+		FinalStage: []distsqlrun.AggregatorSpec_Func{distsqlrun.AggregatorSpec_BOOL_OR},
 	},
 
 	distsqlrun.AggregatorSpec_COUNT: {
-		LocalStage: distsqlrun.AggregatorSpec_COUNT,
-		FinalStage: distsqlrun.AggregatorSpec_SUM_INT,
+		LocalStage: []distsqlrun.AggregatorSpec_Func{distsqlrun.AggregatorSpec_COUNT},
+		FinalStage: []distsqlrun.AggregatorSpec_Func{distsqlrun.AggregatorSpec_SUM_INT},
 	},
 
 	distsqlrun.AggregatorSpec_MAX: {
-		LocalStage: distsqlrun.AggregatorSpec_MAX,
-		FinalStage: distsqlrun.AggregatorSpec_MAX,
+		LocalStage: []distsqlrun.AggregatorSpec_Func{distsqlrun.AggregatorSpec_MAX},
+		FinalStage: []distsqlrun.AggregatorSpec_Func{distsqlrun.AggregatorSpec_MAX},
 	},
 
 	distsqlrun.AggregatorSpec_MIN: {
-		LocalStage: distsqlrun.AggregatorSpec_MIN,
-		FinalStage: distsqlrun.AggregatorSpec_MIN,
+		LocalStage: []distsqlrun.AggregatorSpec_Func{distsqlrun.AggregatorSpec_MIN},
+		FinalStage: []distsqlrun.AggregatorSpec_Func{distsqlrun.AggregatorSpec_MIN},
 	},
 
 	distsqlrun.AggregatorSpec_SUM: {
-		LocalStage: distsqlrun.AggregatorSpec_SUM,
-		FinalStage: distsqlrun.AggregatorSpec_SUM,
+		LocalStage: []distsqlrun.AggregatorSpec_Func{distsqlrun.AggregatorSpec_SUM},
+		FinalStage: []distsqlrun.AggregatorSpec_Func{distsqlrun.AggregatorSpec_SUM},
 	},
+
+	// AVG is more tricky than the ones above; we need two intermediate values in
+	// the local and final stages:
+	//  - the local stage accumulates the SUM and the COUNT;
+	//  - the final stage sums these partial results (SUM and SUM_INT);
+	//  - a final rendering then divides the two results.
+	//
+	// At a high level, this is analogous to rewriting AVG(x) as SUM(x)/COUNT(x).
+	distsqlrun.AggregatorSpec_AVG: {
+		LocalStage: []distsqlrun.AggregatorSpec_Func{
+			distsqlrun.AggregatorSpec_SUM,
+			distsqlrun.AggregatorSpec_COUNT,
+		},
+		FinalStage: []distsqlrun.AggregatorSpec_Func{
+			distsqlrun.AggregatorSpec_SUM,
+			distsqlrun.AggregatorSpec_SUM_INT,
+		},
+		FinalRendering: func(h *parser.IndexedVarHelper, varIdxOffset int) (parser.TypedExpr, error) {
+			sum := h.IndexedVar(varIdxOffset)
+			count := h.IndexedVar(varIdxOffset + 1)
+
+			expr := &parser.BinaryExpr{
+				Operator: parser.Div,
+				Left:     sum,
+				Right:    count,
+			}
+
+			// There is no "FLOAT / INT" operator; cast the denominator to float in
+			// this case. Note that there is a "DECIMAL / INT" operator, so we don't
+			// need the same handling for that case.
+			if sum.ResolvedType().Equivalent(parser.TypeFloat) {
+				expr.Right = &parser.CastExpr{
+					Expr: count,
+					Type: parser.NewFloatColType(0 /* prec */, false /* precSpecified */),
+				}
+			}
+			return expr.TypeCheck(nil, parser.TypeAny)
+		},
+	},
+}
+
+// typeContainer is a helper type that implements parser.IndexedVarContainer; it
+// is intended to be used during planning (to back FinalRendering expressions).
+// It does not support evaluation.
+type typeContainer struct {
+	types []sqlbase.ColumnType
+}
+
+var _ parser.IndexedVarContainer = &typeContainer{}
+
+func (tc *typeContainer) IndexedVarEval(idx int, ctx *parser.EvalContext) (parser.Datum, error) {
+	panic("no eval allowed in typeContainer")
+}
+
+func (tc *typeContainer) IndexedVarResolvedType(idx int) parser.Type {
+	return tc.types[idx].ToDatumType()
+}
+
+func (tc *typeContainer) IndexedVarFormat(buf *bytes.Buffer, f parser.FmtFlags, idx int) {
+	fmt.Fprintf(buf, "@%d", idx+1)
+}
+
+// MakeTypeIndexedVarHelper returns an IndexedVarHelper which creates IndexedVars
+// with the given types.
+func MakeTypeIndexedVarHelper(types []sqlbase.ColumnType) parser.IndexedVarHelper {
+	return parser.MakeIndexedVarHelper(&typeContainer{types: types}, len(types))
 }

--- a/pkg/sql/parser/col_types.go
+++ b/pkg/sql/parser/col_types.go
@@ -146,7 +146,9 @@ type FloatColType struct {
 	PrecSpecified bool // true if the value of Prec is not the default
 }
 
-func newFloatColType(prec int, precSpecified bool) *FloatColType {
+// NewFloatColType creates a type representing a FLOAT, optionally with a
+// precision.
+func NewFloatColType(prec int, precSpecified bool) *FloatColType {
 	if prec == 0 && !precSpecified {
 		return floatColTypeFloat
 	}

--- a/pkg/sql/parser/sql.go
+++ b/pkg/sql/parser/sql.go
@@ -8659,7 +8659,7 @@ sqldefault:
 				sqllex.Error(err.Error())
 				return 1
 			}
-			sqlVAL.union.val = newFloatColType(int(prec), len(nv.OrigString) > 0)
+			sqlVAL.union.val = NewFloatColType(int(prec), len(nv.OrigString) > 0)
 		}
 	case 551:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3441,7 +3441,7 @@ numeric:
       sqllex.Error(err.Error())
       return 1
     }
-    $$.val = newFloatColType(int(prec), len(nv.OrigString) > 0)
+    $$.val = NewFloatColType(int(prec), len(nv.OrigString) > 0)
   }
 | DOUBLE PRECISION
   {

--- a/pkg/sql/testdata/logic_test/aggregate
+++ b/pkg/sql/testdata/logic_test/aggregate
@@ -491,6 +491,13 @@ SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv
 ----
 14.0
 
+# Verify things work with distsql when some of the nodes emit no results in the
+# local stage.
+query R
+SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv WHERE w*2 = k
+----
+14.0
+
 query ITTT
 EXPLAIN (EXPRS) SELECT COUNT(k) FROM kv
 ----

--- a/pkg/sql/testdata/logic_test/distsql_agg
+++ b/pkg/sql/testdata/logic_test/distsql_agg
@@ -82,16 +82,60 @@ SELECT SUM(a), MIN(b), MAX(c), COUNT(d) FROM data
 ----
 55000 1 10 10000
 
-# We don't yet support local stages for AVG (or STDDEV, VARIANCE).
+# AVG is more tricky: we do two aggregations (for the sum and for the count)
+# and calculate the average at the end.
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT AVG(a+b+c+d) FROM data]
+----
+https://raduberinde.github.io/decode.html?eJzElE9rq0AUxffvU8hZJbyBl1GTl-fKR1dZJCn5sypSps5FhMSRcYSW4HcvKqWJlDE0KW4G58-5v3Oc4Z6QKUkrcaQCwRM4GFwweGDwwTBFxJBrFVNRKF0faQUL-YpgwpBmeWnq5YghVpoQnGBScyAE2ImXA21ISNJgkGREemgguU6PQr-FUhgBhg1lknTgjEYhd347oTuuR68ZfUQVgyrNB6Zi1xv4nySaEmFUh7_dL0chH4PhYb1f7ZrvazGf1ctMaUma5EXxqPqWke1--byorbjjsz8ScuePE7pWc3zoS-gxcK9LcIfO2WPgXjm9oXP2GLhXTn_onD0GfqJ5fIHZUJGrrKBOE7msFzGQTKjtP4UqdUyPWsVN8Xa6bk43C5IK0-7ydrLI2q3a1rmYW8XuhZh3xa6d3IP2rGrfLvZv8T21imd28uwW8l-reG4nz28h_7Pf1aTnmdgfWZcdVb_eAwAA__9miKtH
+
+query R
+SELECT AVG(a+b+c+d) FROM data
+----
+22
+
+# Test various combinations of aggregation functions and verify that the
+# aggregation processors are set up correctly.
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT SUM(a), AVG(b), SUM(c), AVG(d), SUM(a+b+c+d) FROM data]
+----
+https://raduberinde.github.io/decode.html?eJzMlM-OmzAQxu99CmtOQbXUNRiy5eSqpxx2U-XPqUKVi0cIKcHIGKlVxLtXQJImtDKROIQLGo_9-fsxHs0JCq3wXR6xgvg7MKDgA4UAKHCgEEJCoTQ6xarSpj3SC1bqF8QvFPKirG2bTiik2iDEJ7C5PSDEsJM_D7hBqdAABYVW5ofOpDT5UZrfQkkrgcIGC4UmJoIR4RMREMHJYiEY-UiE77XfoPtySBoKurYXy4Y-DvMlywxm0uoBy3b_thDMA9pHfht9Xe_fd-e4ywbXiN_s82s29B5G-0tUF9ooNKjugJJmIvx2__Zj1eINoC-gNyeia37p_fMOn84vIcI2jIhYOv-RzakXRmCe2Qv-nOo0AvPMOgVzqtMIzDPrxOdUpxGYuczg_6BtsCp1UeFgFt_fl1BAlWE_xitdmxS_GZ12l_fLdXe6SyisbL_L-sWq6LdarFsxc4r9OzEbin2384h14FRzt5hP4Q6d4sjtHE1xXjrFr27n1ynOn91v9TLSJu4mG3onzYc_AQAA__9v-P8L
+
+query RRRRR
+SELECT SUM(a), AVG(b), SUM(c), AVG(d), SUM(a+b+c+d) FROM data
+----
+55000 5.5 55000 5.5 220000
+
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT SUM(a), MIN(b), MAX(c), COUNT(d), AVG(a+b+c+d) FROM data]
 ----
-https://raduberinde.github.io/decode.html?eJzMkzFr8zAQhvfvV5h3Uvg0RLbTwZNCh5IhSUmTUigeVOswhsQykgwtwf-9WKa0CW1KyeJFnHT33D0Y3xG10bRSB3LIniHAEYMjAUcKjhlyjsaagpwzti8ZgIV-RTblqOqm9f1zzlEYS8iO8JXfEzJs1cueNqQ0WXBo8qrahyGNrQ7KvkmtvALHhmpNNoukiGQcySSSacSYFNH_SMaT_kzCmSLvOEzrP0Z2_AeZT4e2NlaTJX1ikHff6M7L0lKpvDmzfdgtmRQTcCwXKybjEM2fmEz66Ha9W22ZTPt4_njH5GxyUVOM6ZvFY5JJxiSTjknmlz3bkGtM7ejsFz_tl3OQLmnYDmdaW9C9NUVoPlzXoTo8aHJ-yIrhsqhDSvRaX2FxEb45gafncHzN5OQaOL0Gnv0Jzrt_7wEAAP__y32t4g==
+https://raduberinde.github.io/decode.html?eJzMlF8LmzAUxd_3KcJ9UhZY4791PqXsyYe2o39gMGRk5iJCayRG2Ch-96GyrZUuFjo6XyS5ycn5eRLuBUolcSPOWEP8BRhQ8ICCDxQCoBBCSqHSKsO6VrrbMggS-R3iBYWirBrTlVMKmdII8QVMYU4IMRzEtxPuUEjUQEGiEcWpN6l0cRb6B5fCCKCww1KijglnhHuE-4QHxHE4I28J99zu6_ffANKWgmrML8uWPg6zynONuTBqxLI_rh3OXKCwTjYO9_rR6rPD_W70cXvcHBwedON-Z3hVDd2Hgf5wNKXSEjXKG4y0_WfI--P6a3IH-nc9cv-SOQ_JO8Ij60-xOV35BMzrr9ybUzoTMK9Px59TOhMwr08nmFM6EzD_t5neAdphXamyxlFTvT0vpYAyx6Ef16rRGX7SKusPH6bbfndfkFibYZUNk6QcljqsazGzir0bMRuLPbvzhLVvVQd2cfAMd2gVR3bn6Bnn91bx0u68fMb5g_2uFhPPxP7Ixt5p--ZnAAAA__8JB_B1
 
 query RIIIR
 SELECT SUM(a), MIN(b), MAX(c), COUNT(d), AVG(a+b+c+d) FROM data
 ----
 55000 1 10 10000 22
+
+# We don't yet support local stages for STDDEV, VARIANCE.
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT SUM(a), round(STDDEV(b), 1) FROM data]
+----
+https://raduberinde.github.io/decode.html?eJzEkjFr8zAQhvfvV5h3cuCGyE6-wZMKyZChaUnSLsWDah3GkEhGkqEl-L8X25TWIQ2UQDqe7p57XsQdYazmtTqwR_YCAUICQgrCDIQ5ckLtbMHeW9eNDMBKvyGbEipTN6F7zgmFdYzsiFCFPSPDTr3uecNKswNBc1DVvpfUrjoo9y61CgqEDRvNLoukiGQSCeQtwTbhc3FLPyi_TI2xTrNjPfLk7ZlQd2XpuFTBnmTaPt3HUkxA2O4Wi-VzLJOuWC2W610s08k4p7ON0bFMKOpalwKL2_9Rcntlenvl7G-P74xyw762xvPJEY735QTWJQ_3623jCn50tuiXD-VDP90_aPZh6IqhWJm-JbpY32FxEf4_gqencHKNOb0Gnl0Dz38F5-2_jwAAAP__E4Saug==
+
+query RR
+SELECT SUM(a), round(STDDEV(b), 1) FROM data
+----
+55000 2.9
+
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT SUM(a), round(VARIANCE(b), 1) FROM data]
+----
+https://raduberinde.github.io/decode.html?eJzEkjFr8zAQhvfvV5h3cuCGyE6-wZNDm8FD0-KmXYoH1TqMIZGMJENL8H8vtimtQxoogXQ83T33vIg7QBvFG7lnh-QFAoQIhBiEBQhLFITGmpKdM7YfGYFMvSGZE2rdtL5_LgilsYzkAF_7HSPBVr7uOGep2IKg2Mt6N0gaW--lfU-V9BKEnLVimwSpCNIoECg6gmn95-KOflB-mVptrGLLauIpuhOhVlVluZLeHGV6fLoLUzED4XmVZ6vNzTpMo77MbtebbZjGs2lSa1qtwjSioG-diyyu_0vR9ZXx9ZWLvz2_E8qcXWO046MznO4rCKwqHi_YmdaW_GBNOSwfy_thenhQ7PzYFWOR6aEl-ljfYXEW_j-B58dwdIk5vgReXAIvfwUX3b-PAAAA__-rZJs5
+
+query RR
+SELECT SUM(a), round(VARIANCE(b), 1) FROM data
+----
+55000 8.3
 
 # planNode recursion figures out that DISTINCT can take advantage of orderings,
 # and so it retains the primary key ordering, which is why we don't need to


### PR DESCRIPTION
One of the powerful aspects of distsql is that it can perform partial
aggregation locally; for example, if we want to get a sum of values, each node
calculates a local partial sum and then a final node adds these up.

The infrastructure for this was simplistic, in that it only allowed a single
intermediary value. `AVG` is a common aggregation for which that is not
sufficient. The lack of support means that any query using `AVG` won't perform
any local partial aggregation.

We improve the infrastructure and the planning to allow multiple aggregations
along with a final rendering expression. For AVG we compute a sum and a count
and divide them at the end.

The new infrastructure can be used for `VARIANCE` and `STDDEV` as well (the
formulas are more complicated); this is left for future work.

Updates #14351.

@arjunravinarayan I will wait for #14300 to go in and merge with that change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14637)
<!-- Reviewable:end -->
