### PR TITLE
sql: remove trimdecimals from logic test

### DIFF
--- a/pkg/sql/parser/aggregate_builtins.go
+++ b/pkg/sql/parser/aggregate_builtins.go
@@ -789,6 +789,10 @@ func (a *decimalVarianceAggregate) Result() Datum {
 	if err := a.ed.Err(); err != nil {
 		panic(err)
 	}
+	// Remove trailing zeros. Depending on the order in which the input
+	// is processed, some number of trailing zeros could be added to the
+	// output. Remove them so that the results are the same regardless of order.
+	dd.Decimal.Reduce(&dd.Decimal)
 	return dd
 }
 

--- a/pkg/sql/testdata/logic_test/aggregate
+++ b/pkg/sql/testdata/logic_test/aggregate
@@ -486,7 +486,7 @@ SELECT AVG(DISTINCT k), AVG(DISTINCT v), SUM(DISTINCT k), SUM(DISTINCT v) FROM k
 ----
 5 3 30 6
 
-query R trimdecimals
+query R
 SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv
 ----
 14.0
@@ -759,23 +759,23 @@ EXPLAIN (EXPRS) SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
 2                 spans        /3/2/#-/3/3
 2                 limit        1
 
-query RRR trimdecimals
+query RRR
 SELECT VARIANCE(x), VARIANCE(y::decimal), round(VARIANCE(z), 14) FROM xyz
 ----
-9.00 4.5 6.33333333333333
+9 4.5 6.33333333333333
 
 query ITTT
 EXPLAIN (DEBUG) SELECT VARIANCE(x), VARIANCE(y::decimal), round(VARIANCE(z), 14) FROM xyz
 ----
-0  /xyz/primary/1    NULL                            PARTIAL
-0  /xyz/primary/1/y  2                               PARTIAL
-0  /xyz/primary/1/z  3.0                             BUFFERED
-1  /xyz/primary/4    NULL                            PARTIAL
-1  /xyz/primary/4/y  5                               PARTIAL
-1  /xyz/primary/4/z  6.0                             BUFFERED
-2  /xyz/primary/7    NULL                            PARTIAL
-2  /xyz/primary/7/z  8.0                             BUFFERED
-0  0                 (9.00, 4.5, 6.33333333333333)   ROW
+0  /xyz/primary/1    NULL                        PARTIAL
+0  /xyz/primary/1/y  2                           PARTIAL
+0  /xyz/primary/1/z  3.0                         BUFFERED
+1  /xyz/primary/4    NULL                        PARTIAL
+1  /xyz/primary/4/y  5                           PARTIAL
+1  /xyz/primary/4/z  6.0                         BUFFERED
+2  /xyz/primary/7    NULL                        PARTIAL
+2  /xyz/primary/7/z  8.0                         BUFFERED
+0  0                 (9, 4.5, 6.33333333333333)  ROW
 
 query R
 SELECT VARIANCE(x) FROM xyz WHERE x = 10

--- a/pkg/sql/testdata/logic_test/alter_table
+++ b/pkg/sql/testdata/logic_test/alter_table
@@ -254,7 +254,7 @@ DROP INDEX t@t_f_idx
 statement ok
 ALTER TABLE t DROP COLUMN f
 
-query IITTT colnames,rowsort,trimdecimals
+query IITTT colnames,rowsort
 SELECT * FROM t
 ----
 a   d     x     y     z
@@ -338,7 +338,7 @@ ALTER TABLE t ADD f INT UNIQUE REFERENCES other
 statement ok
 ALTER TABLE t ADD d INT UNIQUE, ADD e INT UNIQUE, ADD f INT
 
-query ITTTIII colnames,rowsort,trimdecimals
+query ITTTIII colnames,rowsort
 SELECT * FROM t
 ----
 a   x     y     z     d     e     f

--- a/pkg/sql/testdata/logic_test/interleaved
+++ b/pkg/sql/testdata/logic_test/interleaved
@@ -132,7 +132,7 @@ query IT rowsort
 SELECT * FROM p2
 ----
 
-query ITTT rowsort,trimdecimals
+query ITTT rowsort
 SELECT * FROM p1_0
 ----
 2  2  2.01  2
@@ -158,7 +158,7 @@ SELECT * FROM p0
 statement ok
 DROP TABLE p0
 
-query ITTT rowsort,trimdecimals
+query ITTT rowsort
 SELECT * FROM p1_0
 ----
 2  2  2.01  2
@@ -173,7 +173,7 @@ DROP TABLE p2
 statement ok
 CREATE INDEX p1_s2 ON p1_1 (s2)
 
-query ITTT rowsort,trimdecimals
+query ITTT rowsort
 SELECT * FROM p1_0
 ----
 2  2  2.01  2


### PR DESCRIPTION
With the included fix to variance to remove trailing zeros, the causal
issues for trimdecimals have been fixed and it's no longer needed.

Fixes #13384

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14638)
<!-- Reviewable:end -->
