### PR TITLE
sql: fix crash when assigning DEFAULT

### DIFF
--- a/pkg/sql/testdata/logic_test/default
+++ b/pkg/sql/testdata/logic_test/default
@@ -103,8 +103,15 @@ UPDATE t SET (b) = (DEFAULT), (c) = (DEFAULT)
 statement ok
 CREATE TABLE v (
   a INT PRIMARY KEY,
-  b TIMESTAMP NULL DEFAULT NULL
+  b TIMESTAMP NULL DEFAULT NULL,
+  c INT
 )
+
+statement ok
+UPDATE v SET a = DEFAULT
+
+statement ok
+UPDATE v SET (a, c) = (DEFAULT, DEFAULT)
 
 query TTBTT colnames
 SHOW COLUMNS FROM v
@@ -112,3 +119,4 @@ SHOW COLUMNS FROM v
 Field Type      Null  Default  Indices
 a     INT       false NULL     {primary}
 b     TIMESTAMP true  NULL     {}
+c     INT       true  NULL     {}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -378,6 +378,9 @@ func fillDefault(
 ) parser.Expr {
 	switch expr.(type) {
 	case parser.DefaultVal:
+		if defaultExprs == nil {
+			return parser.DNull
+		}
 		return defaultExprs[index]
 	}
 	return expr


### PR DESCRIPTION
When `makeDefaultExprs` is creating the list of defaults for a set of
columns, it exits early and just returns nil if it sees that none of the
columns being assigned to have an explicit default set (in which case
their default should be NULL). Due to this, fillDefault needs to check
if the `defaultExprs` slice it receives is nil to handle the case where
values are being assigned DEFAULT, but none of the values being assigned
to have an explicit default value set.

It appears that other things depend on this early exit behaviour, in
particular, there are query plans in the tests that become noisier when
it's removed, which is probably why it was implemented this way
originally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/14640)
<!-- Reviewable:end -->
