### PR TITLE
sql: introduce system.settings table

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1667,6 +1667,7 @@ writing ` + os.DevNull + `
   debug/schema/system/lease
   debug/schema/system/namespace
   debug/schema/system/rangelog
+  debug/schema/system/settings
   debug/schema/system/ui
   debug/schema/system/users
   debug/schema/system/zones

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -286,6 +286,7 @@ const (
 	DescriptorTableID = 3
 	UsersTableID      = 4
 	ZonesTableID      = 5
+	SettingsTableID   = 6
 
 	// Reserved IDs for other system tables. If you're adding a new system table,
 	// it probably belongs here.

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -54,6 +54,12 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		newDescriptors: 1,
 		newRanges:      1,
 	},
+	{
+		name:           "create system.settings table",
+		workFn:         createSettingsTable,
+		newDescriptors: 1,
+		newRanges:      0, // it lives in gossip range.
+	},
 }
 
 // migrationDescriptor describes a single migration hook that's used to modify
@@ -326,6 +332,21 @@ func createJobsTable(ctx context.Context, r runner) error {
 	return r.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		b := txn.NewBatch()
 		desc := sqlbase.JobsTable
+		b.CPut(sqlbase.MakeNameMetadataKey(desc.GetParentID(), desc.GetName()), desc.GetID(), nil)
+		b.CPut(sqlbase.MakeDescMetadataKey(desc.GetID()), sqlbase.WrapDescriptor(&desc), nil)
+		if err := txn.SetSystemConfigTrigger(); err != nil {
+			return err
+		}
+		return txn.Run(ctx, b)
+	})
+}
+
+func createSettingsTable(ctx context.Context, r runner) error {
+	// We install the table at the KV layer so that we can choose a known ID in
+	// the reserved ID space. (The SQL layer doesn't allow this.)
+	return r.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		b := txn.NewBatch()
+		desc := sqlbase.SettingsTable
 		b.CPut(sqlbase.MakeNameMetadataKey(desc.GetParentID(), desc.GetName()), desc.GetID(), nil)
 		b.CPut(sqlbase.MakeDescMetadataKey(desc.GetID()), sqlbase.WrapDescriptor(&desc), nil)
 		if err := txn.SetSystemConfigTrigger(); err != nil {

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -579,7 +579,7 @@ func TestPGPreparedQuery(t *testing.T) {
 			baseTest.Results("users", "primary", true, 1, "username", "ASC", false, false),
 		},
 		"SHOW TABLES FROM system": {
-			baseTest.Results("descriptor").Others(8),
+			baseTest.Results("descriptor").Others(9),
 		},
 		"SHOW CONSTRAINTS FROM system.users": {
 			baseTest.Results("users", "primary", "PRIMARY KEY", "username", gosql.NullString{}),

--- a/pkg/sql/system_table_test.go
+++ b/pkg/sql/system_table_test.go
@@ -118,6 +118,7 @@ func TestSystemTableLiterals(t *testing.T) {
 		{keys.RangeEventTableID, sqlbase.RangeEventTableSchema, sqlbase.RangeEventTable},
 		{keys.UITableID, sqlbase.UITableSchema, sqlbase.UITable},
 		{keys.JobsTableID, sqlbase.JobsTableSchema, sqlbase.JobsTable},
+		{keys.SettingsTableID, sqlbase.SettingsTableSchema, sqlbase.SettingsTable},
 	} {
 		gen, err := sql.CreateTestTableDescriptor(
 			context.TODO(),

--- a/pkg/sql/testdata/logic_test/information_schema
+++ b/pkg/sql/testdata/logic_test/information_schema
@@ -257,6 +257,7 @@ jobs
 lease
 namespace
 rangelog
+settings
 ui
 users
 zones
@@ -274,6 +275,7 @@ tables
 table_privileges
 table_constraints
 statistics
+settings
 schemata
 schema_privileges
 schema_changes
@@ -357,6 +359,7 @@ def            system              jobs               BASE TABLE   1
 def            system              lease              BASE TABLE   1
 def            system              namespace          BASE TABLE   1
 def            system              rangelog           BASE TABLE   1
+def            system              settings           BASE TABLE   1
 def            system              ui                 BASE TABLE   1
 def            system              users              BASE TABLE   1
 def            system              zones              BASE TABLE   1
@@ -482,6 +485,7 @@ def                 system             primary          system        jobs      
 def                 system             primary          system        lease       PRIMARY KEY
 def                 system             primary          system        namespace   PRIMARY KEY
 def                 system             primary          system        rangelog    PRIMARY KEY
+def                 system             primary          system        settings    PRIMARY KEY
 def                 system             primary          system        ui          PRIMARY KEY
 def                 system             primary          system        users       PRIMARY KEY
 def                 system             primary          system        zones       PRIMARY KEY
@@ -553,6 +557,10 @@ def            system              rangelog    eventType                 4
 def            system              rangelog    otherRangeID              5
 def            system              rangelog    info                      6
 def            system              rangelog    uniqueID                  7
+def            system              settings    name                      1
+def            system              settings    value                     2
+def            system              settings    lastUpdated               3
+def            system              settings    valueType                 4
 def            system              ui          key                       1
 def            system              ui          value                     2
 def            system              ui          lastUpdated               3
@@ -756,6 +764,11 @@ NULL     root     def            system             rangelog    GRANT           
 NULL     root     def            system             rangelog    INSERT          NULL          NULL
 NULL     root     def            system             rangelog    SELECT          NULL          NULL
 NULL     root     def            system             rangelog    UPDATE          NULL          NULL
+NULL     root     def            system             settings    DELETE          NULL          NULL
+NULL     root     def            system             settings    GRANT           NULL          NULL
+NULL     root     def            system             settings    INSERT          NULL          NULL
+NULL     root     def            system             settings    SELECT          NULL          NULL
+NULL     root     def            system             settings    UPDATE          NULL          NULL
 NULL     root     def            system             ui          DELETE          NULL          NULL
 NULL     root     def            system             ui          GRANT           NULL          NULL
 NULL     root     def            system             ui          INSERT          NULL          NULL

--- a/pkg/sql/testdata/logic_test/system
+++ b/pkg/sql/testdata/logic_test/system
@@ -18,6 +18,7 @@ jobs
 lease
 namespace
 rangelog
+settings
 ui
 users
 zones
@@ -33,9 +34,10 @@ EXPLAIN (DEBUG) SELECT * FROM system.namespace
 5  /namespace/primary/1/'lease'/id      11   ROW
 6  /namespace/primary/1/'namespace'/id  2    ROW
 7  /namespace/primary/1/'rangelog'/id   13   ROW
-8  /namespace/primary/1/'ui'/id         14   ROW
-9  /namespace/primary/1/'users'/id      4    ROW
-10 /namespace/primary/1/'zones'/id      5    ROW
+8  /namespace/primary/1/'settings'/id   6    ROW
+9  /namespace/primary/1/'ui'/id         14   ROW
+10 /namespace/primary/1/'users'/id      4    ROW
+11 /namespace/primary/1/'zones'/id      5    ROW
 
 query ITI rowsort
 SELECT * FROM system.namespace
@@ -48,6 +50,7 @@ SELECT * FROM system.namespace
 1 lease      11
 1 namespace  2
 1 rangelog   13
+1 settings   6
 1 ui         14
 1 users      4
 1 zones      5
@@ -60,6 +63,7 @@ SELECT id FROM system.descriptor
 3
 4
 5
+6
 11
 12
 13
@@ -143,6 +147,14 @@ status   STRING     false  NULL            {jobs_status_created_idx}
 created  TIMESTAMP  false  now()           {jobs_status_created_idx}
 payload  BYTES      false  NULL            {}
 
+query TTBTT
+SHOW COLUMNS FROM system.settings
+----
+name         STRING     false  NULL   {primary}
+value        STRING     false  NULL   {}
+lastUpdated  TIMESTAMP  false  now()  {}
+valueType    STRING     true   NULL   {}
+
 # Verify default privileges on system tables.
 query TTT
 SHOW GRANTS ON DATABASE system
@@ -225,6 +237,15 @@ jobs  root  INSERT
 jobs  root  SELECT
 jobs  root  UPDATE
 
+query TTT
+SHOW GRANTS ON system.settings
+----
+settings  root  DELETE
+settings  root  GRANT
+settings  root  INSERT
+settings  root  SELECT
+settings  root  UPDATE
+
 statement error user root does not have DROP privilege on database system
 ALTER DATABASE system RENAME TO not_system
 
@@ -292,3 +313,16 @@ GRANT ALL ON system.lease TO root
 
 statement ok
 GRANT ALL ON system.lease TO testuser
+
+query TTTT
+select * from system.settings
+----
+
+statement ok
+INSERT INTO system.settings (name, value) VALUES ('somesetting', 'somevalue')
+
+query TT
+select name, value from system.settings
+----
+somesetting   somevalue
+


### PR DESCRIPTION
this will be used to store and manage cluster-wide, runtime changable settings.
this introduces the new table via a migration -- later work will use it to provide
settings accessors for calling code.