### PR TITLE
storage: avoid unsplittable range

### DIFF
--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -2990,8 +2990,11 @@ func TestFindSplitKey(t *testing.T) {
 			t.Fatal(err)
 		}
 		ind, _ := strconv.Atoi(string(humanSplitKey))
+		if ind == 0 {
+			t.Fatalf("%d: should never select first key as split key", i)
+		}
 		if diff := td.splitInd - ind; diff > 1 || diff < -1 {
-			t.Fatalf("%d. wanted key #%d+-1, but got %d (diff %d)", i, td.splitInd, ind, diff)
+			t.Fatalf("%d: wanted key #%d+-1, but got %d (diff %d)", i, td.splitInd, ind, diff)
 		}
 	}
 }
@@ -3014,7 +3017,7 @@ func TestFindValidSplitKeys(t *testing.T) {
 				roachpb.Key("\x02\xff"),
 			},
 			expSplit: nil,
-			expError: true,
+			expError: false,
 		},
 		// All system span cannot be split.
 		{
@@ -3023,7 +3026,7 @@ func TestFindValidSplitKeys(t *testing.T) {
 				roachpb.Key(keys.MakeTablePrefix(keys.MaxSystemConfigDescID)),
 			},
 			expSplit: nil,
-			expError: true,
+			expError: false,
 		},
 		// Between meta1 and meta2, splits at meta2.
 		{
@@ -3081,7 +3084,7 @@ func TestFindValidSplitKeys(t *testing.T) {
 				roachpb.Key("a"),
 			},
 			expSplit: nil,
-			expError: true,
+			expError: false,
 		},
 	}
 

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -2985,7 +2985,8 @@ func TestFindSplitKey(t *testing.T) {
 	}
 
 	for i, td := range testData {
-		humanSplitKey, err := MVCCFindSplitKey(context.Background(), snap, rangeID, roachpb.RKeyMin, roachpb.RKeyMax, td.targetSize, nil)
+		humanSplitKey, err := MVCCFindSplitKey(
+			context.Background(), snap, rangeID, roachpb.RKeyMin, roachpb.RKeyMax, td.targetSize)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3116,7 +3117,8 @@ func TestFindValidSplitKeys(t *testing.T) {
 			t.Fatal(err)
 		}
 		targetSize := (ms.KeyBytes + ms.ValBytes) / 2
-		splitKey, err := MVCCFindSplitKey(context.Background(), snap, rangeID, rangeStartAddr, rangeEndAddr, targetSize, nil)
+		splitKey, err := MVCCFindSplitKey(
+			context.Background(), snap, rangeID, rangeStartAddr, rangeEndAddr, targetSize)
 		if test.expError {
 			if !testutils.IsError(err, "has no valid splits") {
 				t.Errorf("%d: unexpected error: %v", i, err)
@@ -3204,7 +3206,8 @@ func TestFindBalancedSplitKeys(t *testing.T) {
 		snap := engine.NewSnapshot()
 		defer snap.Close()
 		targetSize := (ms.KeyBytes + ms.ValBytes) / 2
-		splitKey, err := MVCCFindSplitKey(context.Background(), snap, rangeID, roachpb.RKey("\x02"), roachpb.RKeyMax, targetSize, nil)
+		splitKey, err := MVCCFindSplitKey(
+			context.Background(), snap, rangeID, roachpb.RKey("\x02"), roachpb.RKeyMax, targetSize)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 			continue

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -2646,7 +2646,8 @@ func (r *Replica) adminSplitWithDescriptor(
 			defer snap.Close()
 			var err error
 			targetSize := r.GetMaxBytes() / 2
-			foundSplitKey, err = engine.MVCCFindSplitKey(ctx, snap, desc.RangeID, desc.StartKey, desc.EndKey, targetSize, nil /* logFn */)
+			foundSplitKey, err = engine.MVCCFindSplitKey(
+				ctx, snap, desc.RangeID, desc.StartKey, desc.EndKey, targetSize)
 			if err != nil {
 				return reply, false, roachpb.NewErrorf("unable to determine split key: %s", err)
 			}

--- a/pkg/storage/split_queue.go
+++ b/pkg/storage/split_queue.go
@@ -77,13 +77,7 @@ func (sq *splitQueue) shouldQueue(
 
 	// Add priority based on the size of range compared to the max
 	// size for the zone it's in.
-	zone, err := sysCfg.GetZoneConfigForKey(desc.StartKey)
-	if err != nil {
-		log.Error(ctx, err)
-		return
-	}
-
-	if ratio := float64(repl.GetMVCCStats().Total()) / float64(zone.RangeMaxBytes); ratio > 1 {
+	if ratio := float64(repl.GetMVCCStats().Total()) / float64(repl.GetMaxBytes()); ratio > 1 {
 		priority += ratio
 		shouldQ = true
 	}
@@ -96,7 +90,7 @@ func (sq *splitQueue) process(ctx context.Context, r *Replica, sysCfg config.Sys
 	desc := r.Desc()
 	if splitKey := sysCfg.ComputeSplitKey(desc.StartKey, desc.EndKey); splitKey != nil {
 		log.Infof(ctx, "splitting at key %v", splitKey)
-		if _, pErr := r.adminSplitWithDescriptor(
+		if _, _, pErr := r.adminSplitWithDescriptor(
 			ctx,
 			roachpb.AdminSplitRequest{
 				SplitKey: splitKey.AsRawKey(),
@@ -109,19 +103,28 @@ func (sq *splitQueue) process(ctx context.Context, r *Replica, sysCfg config.Sys
 	}
 
 	// Next handle case of splitting due to size.
-	zone, err := sysCfg.GetZoneConfigForKey(desc.StartKey)
-	if err != nil {
-		return err
-	}
 	size := r.GetMVCCStats().Total()
-	if float64(size)/float64(zone.RangeMaxBytes) > 1 {
-		log.Infof(ctx, "splitting size=%d max=%d", size, zone.RangeMaxBytes)
-		if _, pErr := r.adminSplitWithDescriptor(
+	maxBytes := r.GetMaxBytes()
+	if float64(size)/float64(maxBytes) > 1 {
+		log.Infof(ctx, "splitting size=%d max=%d", size, maxBytes)
+		if _, validSplitKey, pErr := r.adminSplitWithDescriptor(
 			ctx,
 			roachpb.AdminSplitRequest{},
 			desc,
 		); pErr != nil {
 			return pErr.GoError()
+		} else if !validSplitKey {
+			// If we couldn't find a split key, set the max-bytes for the range to
+			// double its current size to prevent future attempts to split the range
+			// until it grows again.
+			r.SetMaxBytes(size * 2)
+		} else {
+			// We successfully split the range, reset max-bytes to the zone setting.
+			zone, err := sysCfg.GetZoneConfigForKey(desc.StartKey)
+			if err != nil {
+				return err
+			}
+			r.SetMaxBytes(zone.RangeMaxBytes)
 		}
 	}
 	return nil

--- a/pkg/storage/split_queue_test.go
+++ b/pkg/storage/split_queue_test.go
@@ -53,27 +53,28 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 	testCases := []struct {
 		start, end roachpb.RKey
 		bytes      int64
+		maxBytes   int64
 		shouldQ    bool
 		priority   float64
 	}{
 		// No intersection, no bytes.
-		{roachpb.RKeyMin, roachpb.RKey("/"), 0, false, 0},
+		{roachpb.RKeyMin, roachpb.RKey("/"), 0, 64 << 20, false, 0},
 		// Intersection in zone, no bytes.
-		{keys.MakeTablePrefix(2001), roachpb.RKeyMax, 0, true, 1},
+		{keys.MakeTablePrefix(2001), roachpb.RKeyMax, 0, 64 << 20, true, 1},
 		// Already split at largest ID.
-		{keys.MakeTablePrefix(2002), roachpb.RKeyMax, 0, false, 0},
+		{keys.MakeTablePrefix(2002), roachpb.RKeyMax, 0, 32 << 20, false, 0},
 		// Multiple intersections, no bytes.
-		{roachpb.RKeyMin, roachpb.RKeyMax, 0, true, 1},
+		{roachpb.RKeyMin, roachpb.RKeyMax, 0, 64 << 20, true, 1},
 		// No intersection, max bytes.
-		{roachpb.RKeyMin, roachpb.RKey("/"), 64 << 20, false, 0},
+		{roachpb.RKeyMin, roachpb.RKey("/"), 64 << 20, 64 << 20, false, 0},
 		// No intersection, max bytes+1.
-		{roachpb.RKeyMin, roachpb.RKey("/"), 64<<20 + 1, true, 1},
+		{roachpb.RKeyMin, roachpb.RKey("/"), 64<<20 + 1, 64 << 20, true, 1},
 		// No intersection, max bytes * 2.
-		{roachpb.RKeyMin, roachpb.RKey("/"), 64 << 21, true, 2},
+		{roachpb.RKeyMin, roachpb.RKey("/"), 64 << 21, 64 << 20, true, 2},
 		// Intersection, max bytes +1.
-		{keys.MakeTablePrefix(2000), roachpb.RKeyMax, 32<<20 + 1, true, 2},
+		{keys.MakeTablePrefix(2000), roachpb.RKeyMax, 32<<20 + 1, 32 << 20, true, 2},
 		// Split needed at table boundary, but no zone config.
-		{keys.MakeTablePrefix(2001), roachpb.RKeyMax, 32<<20 + 1, true, 1},
+		{keys.MakeTablePrefix(2001), roachpb.RKeyMax, 32<<20 + 1, 64 << 20, true, 1},
 	}
 
 	splitQ := newSplitQueue(tc.store, nil, tc.gossip)
@@ -94,6 +95,7 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 				t.Fatal(err)
 			}
 			tc.repl.mu.state.Stats = ms
+			tc.repl.mu.maxBytes = test.maxBytes
 		}()
 
 		copy := *tc.repl.Desc()


### PR DESCRIPTION
If a range cannot be split because a valid split key cannot be found,
set the max size for the range to the range's current size. When a range
is successfully split, reset the max range size to the zone's max range
size. This avoids situations where a range with a single large row
cannot be split.

Fixes #9555