### PR TITLE
security: fix bad merge of new certs_dir loader

### DIFF
--- a/pkg/migrations/main_test.go
+++ b/pkg/migrations/main_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	security.SetReadFileFn(securitytest.Asset)
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
I left this out after the rebase on the last commit.