### PR TITLE
distsql: change logic to set distsql mode

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -42,7 +42,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
-	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -78,52 +77,6 @@ var (
 	MetaMisc               = metric.Metadata{Name: "sql.misc.count"}
 	MetaQuery              = metric.Metadata{Name: "sql.query.count"}
 )
-
-// distSQLExecMode controls if and when the Executor uses DistSQL.
-type distSQLExecMode int
-
-const (
-	// distSQLOff means that we never use distSQL.
-	distSQLOff distSQLExecMode = iota
-	// distSQLAuto means that we automatically decide on a case-by-case basis if
-	// we use distSQL.
-	distSQLAuto
-	// distSQLOn means that we use distSQL for queries that are supported.
-	distSQLOn
-	// distSQLAlways means that we only use distSQL; unsupported queries fail.
-	distSQLAlways
-)
-
-func distSQLExecModeFromString(val string) distSQLExecMode {
-	switch strings.ToUpper(val) {
-	case "OFF":
-		return distSQLOff
-	case "AUTO":
-		return distSQLAuto
-	case "ON":
-		return distSQLOn
-	case "ALWAYS":
-		return distSQLAlways
-	default:
-		panic(fmt.Sprintf("unknown DistSQL mode %s", val))
-	}
-}
-
-// defaultDistSQLMode controls the default DistSQL mode (see above). It can
-// still be overridden per-session using `SET DIST_SQL = ...`.
-var defaultDistSQLMode = distSQLExecModeFromString(
-	envutil.EnvOrDefaultString("COCKROACH_DISTSQL_MODE", "OFF"),
-)
-
-// SetDefaultDistSQLMode changes the default DistSQL mode; returns a function
-// that can be used to restore the previous mode.
-func SetDefaultDistSQLMode(mode string) func() {
-	prevMode := defaultDistSQLMode
-	defaultDistSQLMode = distSQLExecModeFromString(mode)
-	return func() {
-		defaultDistSQLMode = prevMode
-	}
-}
 
 type traceResult struct {
 	tag   string
@@ -1392,11 +1345,7 @@ func (e *Executor) execClassic(planner *planner, plan planNode, result *Result) 
 // shouldUseDistSQL determines whether we should use DistSQL for a plan, based
 // on the session settings.
 func (e *Executor) shouldUseDistSQL(planner *planner, plan planNode) (bool, error) {
-	distSQLMode := defaultDistSQLMode
-	if planner.session.DistSQLMode != distSQLOff {
-		distSQLMode = planner.session.DistSQLMode
-	}
-
+	distSQLMode := planner.session.DistSQLMode
 	if distSQLMode == distSQLOff {
 		return false, nil
 	}

--- a/pkg/sql/helpers_test.go
+++ b/pkg/sql/helpers_test.go
@@ -98,3 +98,13 @@ func (m *LeaseManager) ExpireLeases(clock *hlc.Clock) {
 	}
 	m.tableNames.mu.Unlock()
 }
+
+// SetDefaultDistSQLMode changes the default DistSQL mode; returns a function
+// that can be used to restore the previous mode.
+func SetDefaultDistSQLMode(mode string) func() {
+	prevMode := defaultDistSQLMode
+	defaultDistSQLMode = distSQLExecModeFromString(mode)
+	return func() {
+		defaultDistSQLMode = prevMode
+	}
+}

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -20,6 +20,7 @@ package sql
 import (
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	opentracing "github.com/opentracing/opentracing-go"
@@ -62,6 +63,42 @@ var traceSQLFor7881 = envutil.EnvOrDefaultBool("COCKROACH_TRACE_7881", false)
 
 // span baggage key used for marking a span
 const keyFor7881Sample = "found#7881"
+
+// distSQLExecMode controls if and when the Executor uses DistSQL.
+type distSQLExecMode int
+
+const (
+	// distSQLOff means that we never use distSQL.
+	distSQLOff distSQLExecMode = iota
+	// distSQLAuto means that we automatically decide on a case-by-case basis if
+	// we use distSQL.
+	distSQLAuto
+	// distSQLOn means that we use distSQL for queries that are supported.
+	distSQLOn
+	// distSQLAlways means that we only use distSQL; unsupported queries fail.
+	distSQLAlways
+)
+
+func distSQLExecModeFromString(val string) distSQLExecMode {
+	switch strings.ToUpper(val) {
+	case "OFF":
+		return distSQLOff
+	case "AUTO":
+		return distSQLAuto
+	case "ON":
+		return distSQLOn
+	case "ALWAYS":
+		return distSQLAlways
+	default:
+		panic(fmt.Sprintf("unknown DistSQL mode %s", val))
+	}
+}
+
+// defaultDistSQLMode controls the default DistSQL mode (see above). It can
+// still be overridden per-session using `SET DIST_SQL = ...`.
+var defaultDistSQLMode = distSQLExecModeFromString(
+	envutil.EnvOrDefaultString("COCKROACH_DISTSQL_MODE", "OFF"),
+)
 
 // Session contains the state of a SQL client connection.
 // Create instances using NewSession().
@@ -216,6 +253,7 @@ func NewSession(
 	ctx = e.AnnotateCtx(ctx)
 	s := &Session{
 		Database:       args.Database,
+		DistSQLMode:    defaultDistSQLMode,
 		SearchPath:     parser.SearchPath{"pg_catalog"},
 		Location:       time.UTC,
 		User:           args.User,

--- a/pkg/sql/testdata/logic_test/join
+++ b/pkg/sql/testdata/logic_test/join
@@ -620,7 +620,7 @@ statement ok
 CREATE TABLE s(x INT); INSERT INTO s(x) VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10)
 
 # TODO(radu): test case disabled due to lack of memory accounting in distsqlrun
-# (which causes timeout when running with COCKROACH_DISTSQLMODE=on). Reenable
+# (which causes timeout when running with COCKROACH_DISTSQL_MODE=on). Reenable
 # this test when distsqlrun has memory accounting.
 #
 # # The following query demands at least 100GB of RAM if unoptimized.

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -166,7 +166,7 @@ var varGen = map[string]sessionVar{
 			return "auto"
 		},
 		Reset: func(p *planner) error {
-			p.session.DistSQLMode = distSQLExecMode(0)
+			p.session.DistSQLMode = defaultDistSQLMode
 			return nil
 		},
 	},


### PR DESCRIPTION
Our previous logic to run a statement using distsql was to use the
default distsql mode if the session's mode was set to off, resulting in
using distsql in cases where the session might have explicitly set it to
off. This change initializes the session with the server's default mode
and uses whatever the session's setting is.