### PR TITLE
build: create a Make target for `go generate`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,19 +37,19 @@ executable will be in your current directory and can be run as shown in the
   [blog post]: https://www.cockroachlabs.com/blog/how-were-building-a-business-to-last/
 
 - If you edit a `.proto` or `.ts` file, you will need to manually regenerate
-  the associated `.pb.{go,cc,h}` or `.js` files using `go generate ./pkg/...`.
+  the associated `.pb.{go,cc,h}` or `.js` files using `make generate`.
 
-- We advise to run `go generate` using our embedded Docker setup.
+- We advise to run `make generate` using our embedded Docker setup.
   `build/builder.sh` is a wrapper script designed to make this convenient. You
-  can run `build/builder.sh go generate ./pkg/...` from the repository root to
-  get the intended result.
+  can run `build/builder.sh make generate` from the repository root to get the
+  intended result.
 
 - If you plan on working on the UI, check out [the UI README](pkg/ui).
 
 - To add or update a Go dependency:
   - See [`build/README.md`](build/README.md) for details on adding or updating
     dependencies.
-  - Run `go generate ./pkg/...` to update generated files.
+  - Run `make generate` to update generated files.
   - Create a PR with all the changes.
 
 ## Style Guide
@@ -108,7 +108,7 @@ executable will be in your current directory and can be run as shown in the
 
 + Run the test suite locally:
 
-  `go generate ./pkg/... && make check test testrace`
+  `make generate check test testrace`
 
 + When you’re ready for review, groom your work: each commit should pass tests
   and contain a substantial (but not overwhelming) unit of work. You may also

--- a/Makefile
+++ b/Makefile
@@ -236,14 +236,27 @@ dupl:
 	       -not -name 'sql.go'      \
 	| dupl -files $(DUPLFLAGS)
 
+# All packages need to be installed before we can run (some) of the checks and
+# code generators reliably. More precisely, anything that uses x/tools/go/loader
+# is fragile (this includes stringer, vet and others). The blocking issue is
+# https://github.com/golang/go/issues/14120.
+
+# `go generate` uses stringer and so must depend on gotestdashi per the above
+# comment. See https://github.com/golang/go/issues/10249 for details.
+.PHONY: generate
+generate: gotestdashi
+	$(GO) generate $(PKG)
+
+# The style checks depend on `go vet` and so must depend on gotestdashi per the
+# above comment. See https://github.com/golang/go/issues/16086 for details.
 .PHONY: check
 check: override TAGS += check
-check:
+check: gotestdashi
 	$(GO) test ./build -v -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -run 'TestStyle/$(TESTS)'
 
 .PHONY: checkshort
 checkshort: override TAGS += check
-checkshort:
+checkshort: gotestdashi
 	$(GO) test ./build -v -tags '$(TAGS)' -short -run 'TestStyle/$(TESTS)'
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ check: gotestdashi
 .PHONY: checkshort
 checkshort: override TAGS += check
 checkshort: gotestdashi
-	$(GO) test ./build -v -tags '$(TAGS)' -short -run 'TestStyle/$(TESTS)'
+	$(GO) test ./build -v -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -short -run 'TestStyle/$(TESTS)'
 
 .PHONY: clean
 clean:

--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -1,25 +1,16 @@
 #!/usr/bin/env bash
 set -exuo pipefail
 
-# All packages need to be installed before we can run (some) of the checks
-# and code generators reliably. More precisely, anything that using
-# x/tools/go/loader is fragile (this includes stringer, vet and others).
-#
-# The blocking issue is https://github.com/golang/go/issues/14120; see
-# https://github.com/golang/go/issues/10249 for some more concrete discussion
-# on `stringer` and https://github.com/golang/go/issues/16086 for `vet`.
 export BUILDER_HIDE_GOPATH_SRC=1
-build/builder.sh make gotestdashi
 
 mkdir -p artifacts
 
 build/builder.sh make check 2>&1 | tee artifacts/check.log | go-test-teamcity
 
-build/builder.sh go generate ./pkg/...
+build/builder.sh make generate
 build/builder.sh /bin/bash -c '! git status --porcelain | read || (git status; git diff -a 1>&2; exit 1)'
 
-# If the code is new enough to have go generate not
-# run the ui tests, run the ui tests.
-if grep "make generate" pkg/ui/ui.go; then
-    build/builder.sh make -C pkg/ui
-fi
+# Run the UI tests. This logically belongs in teamcity-test.sh, but we do it
+# here to minimize total build time since the rest of this script completes
+# faster than the non-UI tests.
+build/builder.sh make -C pkg/ui test

--- a/pkg/security/securitytest/test_certs/README.md
+++ b/pkg/security/securitytest/test_certs/README.md
@@ -24,5 +24,5 @@ rm -f pkg/security/securitytest/test_certs/*.{crt,key}
 ./cockroach cert --ca-cert=pkg/security/securitytest/test_certs/ca.crt --ca-key=pkg/security/securitytest/test_certs/ca.key --cert=pkg/security/securitytest/test_certs/node.crt --key=pkg/security/securitytest/test_certs/node.key create-node 127.0.0.1 ::1 localhost *.local
 ./cockroach cert --ca-cert=pkg/security/securitytest/test_certs/ca.crt --ca-key=pkg/security/securitytest/test_certs/ca.key --cert=pkg/security/securitytest/test_certs/client.root.crt --key=pkg/security/securitytest/test_certs/client.root.key create-client root
 ./cockroach cert --ca-cert=pkg/security/securitytest/test_certs/ca.crt --ca-key=pkg/security/securitytest/test_certs/ca.key --cert=pkg/security/securitytest/test_certs/client.testuser.crt --key=pkg/security/securitytest/test_certs/client.testuser.key create-client testuser
-go generate ./pkg/security/securitytest
+make generate PKG=./pkg/security/securitytest
 ```

--- a/pkg/ui/Makefile
+++ b/pkg/ui/Makefile
@@ -27,8 +27,8 @@ all: lint test $(GOBINDATA_TARGET)
 protos:
 	$(MAKE) -C $(ORG_ROOT) -f cockroach/build/protobuf.mk
 
-# Running `go generate` will call this target. Update this if you add new
-# generated files.
+# Running `make generate` from the root will call this target via `go generate`.
+# Update this if you add new generated files.
 .PHONY: generate
 generate: $(GOBINDATA_TARGET)
 


### PR DESCRIPTION
PR #14629 adjusted our Makefile to install tools into REPO_ROOT/bin
instead of GOBIN. This change appears to have broken builds on fresh
TeamCity agents. Because `go generate` was previously invoked outside
the Makefile, `go generate` ran with a PATH that did not include
REPO_ROOT/bin.

This commit adds a `generate` target to the Makefile that ensures `go
generate` is run with the correct PATH. It has the added benefit of
symmetry with the other Make targets that shadow Go tools, like `make
build`, `make install`, and `make test`.

This commit additionally adjusts `make check` and `make generate` to
depend on `gotestdashi`; there was previously an implicit dependency
here that could lead to hard-to-track-down failures. (See the comment
that was moved from teamcity-check.sh to the Makefile for details.)