### PR TITLE
sql: permit heterogeneous-typed tuple comparisons

### DIFF
--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -950,11 +950,11 @@ func typeCheckComparisonOp(
 			return nil, nil, CmpOp{}, fmt.Errorf(unsupportedCompErrFmtWithTypes, TypeTuple, op, TypeTuple)
 		}
 		// Using non-folded left and right to avoid having to swap later.
-		typedSubExprs, _, err := typeCheckSameTypedTupleExprs(ctx, TypeAny, left, right)
+		typedLeft, typedRight, err := typeCheckTupleComparison(ctx, op, left.(*Tuple), right.(*Tuple))
 		if err != nil {
 			return nil, nil, CmpOp{}, err
 		}
-		return typedSubExprs[0], typedSubExprs[1], fn, nil
+		return typedLeft, typedRight, fn, nil
 	}
 
 	overloads := make([]overloadImpl, len(ops))
@@ -1173,6 +1173,34 @@ func typeCheckSameTypedExprs(
 	}
 }
 
+// typeCheckTupleComparison type checks a comparison between two tuples,
+// asserting that the elements of the two tuples are comparable at each index.
+func typeCheckTupleComparison(
+	ctx *SemaContext, op ComparisonOperator, left *Tuple, right *Tuple,
+) (TypedExpr, TypedExpr, error) {
+	// All tuples must have the same length.
+	tupLen := len(left.Exprs)
+	if err := checkTupleHasLength(right, tupLen); err != nil {
+		return nil, nil, err
+	}
+	left.types = make(TTuple, tupLen)
+	right.types = make(TTuple, tupLen)
+	for elemIdx := range left.Exprs {
+		leftSubExpr := left.Exprs[elemIdx]
+		rightSubExpr := right.Exprs[elemIdx]
+		leftSubExprTyped, rightSubExprTyped, _, err := typeCheckComparisonOp(ctx, op, leftSubExpr, rightSubExpr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("tuples %s are not comparable at index %d: %s",
+				Exprs([]Expr{left, right}), elemIdx+1, err)
+		}
+		left.Exprs[elemIdx] = leftSubExprTyped
+		left.types[elemIdx] = leftSubExprTyped.ResolvedType()
+		right.Exprs[elemIdx] = rightSubExprTyped
+		right.types[elemIdx] = rightSubExprTyped.ResolvedType()
+	}
+	return left, right, nil
+}
+
 // typeCheckSameTypedTupleExprs type checks a list of expressions, asserting that all
 // are tuples which have the same type. The function expects the first provided expression
 // to be a tuple, and will panic if it is not. However, it does not expect all other
@@ -1246,10 +1274,16 @@ func checkAllExprsAreTuples(ctx *SemaContext, exprs []Expr) error {
 
 func checkAllTuplesHaveLength(exprs []Expr, expectedLen int) error {
 	for _, expr := range exprs {
-		t := expr.(*Tuple)
-		if len(t.Exprs) != expectedLen {
-			return fmt.Errorf("expected tuple %v to have a length of %d", t, expectedLen)
+		if err := checkTupleHasLength(expr.(*Tuple), expectedLen); err != nil {
+			return err
 		}
+	}
+	return nil
+}
+
+func checkTupleHasLength(t *Tuple, expectedLen int) error {
+	if len(t.Exprs) != expectedLen {
+		return fmt.Errorf("expected tuple %v to have a length of %d", t, expectedLen)
 	}
 	return nil
 }

--- a/pkg/sql/parser/type_check_test.go
+++ b/pkg/sql/parser/type_check_test.go
@@ -184,7 +184,7 @@ func TestTypeCheckError(t *testing.T) {
 		{`CASE 1 WHEN 1 THEN 'one' WHEN 2 THEN 2 END`, `incompatible value type`},
 		{`CASE 1 WHEN 1 THEN 'one' ELSE 2 END`, `incompatible value type`},
 		{`(1, 2, 3) = (1, 2)`, `expected tuple (1, 2) to have a length of 3`},
-		{`(1, 2) = (1, 'a')`, `tuples (1, 2), (1, 'a') are not the same type: expected 2 to be of type string, found type int`},
+		{`(1, 2) = (1, 'a')`, `tuples (1, 2), (1, 'a') are not comparable at index 2: unsupported comparison operator: <int> = <string>`},
 		{`1 IN ('a', 'b')`, `unsupported comparison operator: 1 IN ('a', 'b'): expected 1 to be of type string, found type int`},
 		{`1 IN (1, 'a')`, `unsupported comparison operator: 1 IN (1, 'a'): expected 1 to be of type string, found type int`},
 		{`1 = ANY 2`, `unsupported comparison operator: 1 = ANY 2: op ANY array requires array on right side`},

--- a/pkg/sql/testdata/logic_test/collatedstring
+++ b/pkg/sql/testdata/logic_test/collatedstring
@@ -12,7 +12,7 @@ SELECT 'A' COLLATE en = 'a' COLLATE de
 statement error pq: unsupported comparison operator: \('a' COLLATE en_u_ks_level1\) IN \('A' COLLATE en_u_ks_level1, 'b' COLLATE en\): expected 'b' COLLATE en to be of type collatedstring{en_u_ks_level1}, found type collatedstring{en}
 SELECT ('a' COLLATE en_u_ks_level1) IN ('A' COLLATE en_u_ks_level1, 'b' COLLATE en)
 
-statement error pq: tuples \('a' COLLATE en_u_ks_level1, 'a' COLLATE en\), \('A' COLLATE en, 'B' COLLATE en\) are not the same type: expected 'A' COLLATE en to be of type collatedstring{en_u_ks_level1}, found type collatedstring{en}
+statement error pq: tuples \('a' COLLATE en_u_ks_level1, 'a' COLLATE en\), \('A' COLLATE en, 'B' COLLATE en\) are not comparable at index 1: unsupported comparison operator: <collatedstring{en_u_ks_level1}> < <collatedstring{en}
 SELECT ('a' COLLATE en_u_ks_level1, 'a' COLLATE en) < ('A' COLLATE en, 'B' COLLATE en)
 
 

--- a/pkg/sql/testdata/logic_test/select_index
+++ b/pkg/sql/testdata/logic_test/select_index
@@ -337,8 +337,13 @@ EXPLAIN SELECT a FROM t WHERE (b, c) = (5.0, 1)
 1        table  t@bc
 1        spans  /5/1-/5/2
 
-query error tuples \(b, c\), \(5.1, 1\) are not the same type: expected 5.1 to be of type int, found type decimal
+query ITTT
 EXPLAIN SELECT a FROM t WHERE (b, c) = (5.1, 1)
+----
+0  render
+1  scan
+1          table  t@bc
+1          spans  ALL
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE b IN (5.0, 1)

--- a/pkg/sql/testdata/logic_test/tuple
+++ b/pkg/sql/testdata/logic_test/tuple
@@ -98,7 +98,7 @@ SELECT
 ----
 true NULL false NULL
 
-statement error pq: tuples \(1, 2\), \(1, 'hi'\) are not the same type: expected 2 to be of type string, found type int
+statement error pq: tuples \(1, 2\), \(1, 'hi'\) are not comparable at index 2: unsupported comparison operator: <int> > <string>
 SELECT (1, 2) > (1, 'hi')
 
 statement error pq: expected tuple \(1, 2, 3\) to have a length of 2
@@ -134,11 +134,16 @@ SELECT ((1, 2), 'equal') = ((1, 2.1), 'equal')
 false
 
 query B
-SELECT (ROW(POW(1, 10.0) + 9), 'a' || 'b') = (ROW(SQRT(100)), 'ab')
+SELECT (ROW(POW(1, 10.0) + 9), 'a' || 'b') = (ROW(SQRT(100.0)), 'ab')
 ----
 true
 
-query error pq: tuples \(\(1, 2\), 'equal'\), \(\(1, 'huh'\), 'equal'\) are not the same type: tuples \(1, 2\), \(1, 'huh'\) are not the same type: expected 2 to be of type string, found type int
+query B
+SELECT (ROW(SQRT(100.0)), 'ab') = (ROW(POW(1, 10.0) + 9), 'a' || 'b')
+----
+true
+
+query error pq: tuples \(\(1, 2\), 'equal'\), \(\(1, 'huh'\), 'equal'\) are not comparable at index 1: tuples \(1, 2\), \(1, 'huh'\) are not comparable at index 2: unsupported comparison operator: <int> = <string>
 SELECT ((1, 2), 'equal') = ((1, 'huh'), 'equal')
 
 # Issue #3568
@@ -205,3 +210,14 @@ query B
 SELECT 1 IN (2, x) FROM (SELECT NULL AS x)
 ----
 NULL
+
+# Issue 10407: tuple comparisons should not require homogeneous types
+query B
+SELECT (now(), 2) = ((now() :: timestamp), 2)
+----
+true
+
+query B
+SELECT (1, 2) > (1.0, 2.0)
+----
+false


### PR DESCRIPTION
Previously, tuples that did not have pointwise identical types were
never comparable. This was inconsistent with Postgres' behavior, and
also causes user confusion: why can you perform `1 < 2.0` and
`(1, 2) < (2, 3)` without a type checking error but not
`(1, 2) < (2.0, 3.0)`?

Now, heterogeneously typed tuples are always comparable if they are
pointwise comparable in their elements, correcting the above
inconsistency.

Resolves #10407.