### PR TITLE
build: Makefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,9 +136,6 @@ testrace: override GOFLAGS += -race
 testrace: GORACE := halt_on_error=1
 testrace: TESTTIMEOUT := $(RACETIMEOUT)
 
-# This is how you get a literal space into a Makefile.
-space := $(eval) $(eval)
-
 # Run make testlogic to run all of the logic tests. Specify test files to run
 # with make testlogic FILES="foo bar".
 testlogic: PKG := ./pkg/sql

--- a/build/common.mk
+++ b/build/common.mk
@@ -90,6 +90,9 @@ $(call make-lazy,TAR_XFORM_FLAG)
 SED_INPLACE = sed $(shell sed --version 2>&1 | grep -q GNU && echo -i || echo "-i ''")
 $(call make-lazy,SED_INPLACE)
 
+# This is how you get a literal space into a Makefile.
+space := $(eval) $(eval)
+
 # We used to check the Go version in a .PHONY .go-version target, but the error
 # message, if any, would get mixed in with noise from other targets if Make was
 # executed in parallel job mode. This check, by contrast, is guaranteed to print


### PR DESCRIPTION
See commit messages for details. The highlight is really the first commit, whose message is reproduced below.

---

Consider `test` and `testshort`, which have near-identical command invocations. `testshort` simply appends `-short` to the `TESTFLAGS`. Previously, `testshort` depended on `test`, which meant executing e.g.

    $ make test testshort

would only execute `go test` and not `go test -short`, because Make executes a target recipe at most once per invocation. When Make evaluated the `testshort` goal, it would skip running its `test` dependency, because the recipe had already run while evaluating the `test` goal.

We can get around this by having `test` and `testshort` share a recipe instead of having one depend on the other. This allows us to share the recipe code between the targets while still having Make consider them to be separate targets. So `make test testshort` will properly execute both `go test` and `go test -short`.

This commit applies this approach to all recipe-sharing targets in the Makefile:

  * build/buildoss/xgo-build/install,
  * test/testshort/testrace/testlogic,
  * testslow/testraceslow, and
  * stress/stressrace.