### PR TITLE
sql,util/tracing: disable tracing/event-logging by default

### DIFF
--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -51,10 +51,11 @@ import (
 var traceSQLDuration = envutil.EnvOrDefaultDuration("COCKROACH_TRACE_SQL", 0)
 var traceSQL = traceSQLDuration > 0
 
-// COCKROACH_DISABLE_SQL_EVENT_LOG can be used to disable the event log that is
+// COCKROACH_ENABLE_SQL_EVENT_LOG can be used to enable the event log that is
 // normally kept for every SQL connection. The event log has a non-trivial
-// performance impact.
-var disableSQLEventLog = envutil.EnvOrDefaultBool("COCKROACH_DISABLE_SQL_EVENT_LOG", false)
+// performance impact and also reveals SQL statements which may be a privacy
+// concern.
+var enableSQLEventLog = envutil.EnvOrDefaultBool("COCKROACH_ENABLE_SQL_EVENT_LOG", false)
 
 // COCKROACH_TRACE_7881 can be used to trace all SQL transactions, in the hope
 // that we'll catch #7881 and dump the current trace for debugging.
@@ -239,7 +240,7 @@ func NewSession(
 	s.PreparedStatements = makePreparedStatements(s)
 	s.PreparedPortals = makePreparedPortals(s)
 
-	if !disableSQLEventLog && opentracing.SpanFromContext(ctx) == nil {
+	if enableSQLEventLog && opentracing.SpanFromContext(ctx) == nil {
 		remoteStr := "<admin>"
 		if remote != nil {
 			remoteStr = remote.String()

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -174,11 +174,11 @@ var lightstepToken = envutil.EnvOrDefaultString("COCKROACH_LIGHTSTEP_TOKEN", "")
 // net/trace. If this flag is enabled, we will only trace to Lightstep.
 var lightstepOnly = envutil.EnvOrDefaultBool("COCKROACH_LIGHTSTEP_ONLY", false)
 
-var disableTracing = envutil.EnvOrDefaultBool("COCKROACH_DISABLE_TRACING", false)
+var enableTracing = envutil.EnvOrDefaultBool("COCKROACH_ENABLE_TRACING", false)
 
 // newTracer implements NewTracer and allows that function to be mocked out via Disable().
 var newTracer = func() opentracing.Tracer {
-	if disableTracing {
+	if !enableTracing {
 		return opentracing.NoopTracer{}
 	}
 	if lightstepToken != "" {


### PR DESCRIPTION
Invert COCKROACH_DISABLE_SQL_EVENT_LOG to
COCKROACH_ENABLE_SQL_EVENT_LOG (default false).

Invert COCKROACH_DISABLE_TRACING to COCKROACH_ENABLE_TRACING (default
false).

Fixes #14589