### PR TITLE
util/log: fix log file detection on windows

### DIFF
--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -412,7 +412,7 @@ func TestGetLogReader(t *testing.T) {
 		// Symlink to a log file.
 		{filepath.Join(dir, removePeriods(program)+".log"), "pathnames must be basenames", ""},
 		// Symlink relative to logDir.
-		{removePeriods(program) + ".log", "malformed log filename", ""},
+		{removePeriods(program) + ".log", "", ""},
 		// Non-log file.
 		{"other.txt", "malformed log filename", "malformed log filename"},
 		// Non-existent file matching RE.


### PR DESCRIPTION
On Windows, calling os.Stat() on a symlinked file throws a file not found error instead of following the link. This change normalizes the path by calling EvalSymlinks on it first.

This change also alters the behaviour slightly in which we will now allow a symlink to be followed in restrictive mode if it exists within the log directory. This was an unnecessary security feature as if an attacker has access to the log directory, the machine is already compromised.

Furthermore, I've cleaned up the code here to be more streamlined and clear.

Fixes #14546.