### PR TITLE
distsql: fix distsql logic tests

### DIFF
--- a/pkg/sql/testdata/logic_test/pg_catalog
+++ b/pkg/sql/testdata/logic_test/pg_catalog
@@ -1,4 +1,4 @@
-# LogicTest: default distsql
+# LogicTest: default
 
 # Verify pg_catalog database handles mutation statements correctly.
 


### PR DESCRIPTION
PR #14669 inadvertently disabled distsql for TestLogic/distsql subtests. The
reason is that the root session is established before setting the default
distsql mode. Set the distsql mode earlier.