### PR TITLE
sql: access transaction anchor key under lock

### DIFF
--- a/pkg/internal/client/db_test.go
+++ b/pkg/internal/client/db_test.go
@@ -402,6 +402,7 @@ func TestCommonMethods(t *testing.T) {
 		{txnType, "OrigTimestamp"}:             {},
 		{txnType, "Proto"}:                     {},
 		{txnType, "UserPriority"}:              {},
+		{txnType, "AnchorKey"}:                 {},
 	}
 
 	for b := range omittedChecks {

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -199,6 +199,14 @@ func (txn *Txn) OrigTimestamp() hlc.Timestamp {
 	return txn.mu.Proto.OrigTimestamp
 }
 
+// AnchorKey returns the transaction's anchor key. The caller should treat the
+// returned byte slice as immutable.
+func (txn *Txn) AnchorKey() []byte {
+	txn.mu.Lock()
+	defer txn.mu.Unlock()
+	return txn.mu.Proto.Key
+}
+
 // SetTxnAnchorKey sets the key at which to anchor the transaction record. The
 // transaction anchor key defaults to the first key written in a transaction.
 func (txn *Txn) SetTxnAnchorKey(key roachpb.Key) error {

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1369,7 +1369,7 @@ func (e *Executor) shouldUseDistSQL(planner *planner, plan planNode) (bool, erro
 	// Temporary workaround for #13376: if the transaction modified something,
 	// TxnCoordSender will freak out if it sees scans in this txn from other
 	// nodes. We detect this by checking if the transaction's "anchor" key is set.
-	if planner.txn.Proto().TxnMeta.Key != nil {
+	if planner.txn.AnchorKey() != nil {
 		err = errors.New("writing txn")
 	} else {
 		// Trigger limit propagation.


### PR DESCRIPTION
Fixes #14563.

Before `IndependentFromPipelinedPriors` was introduced, no statements
would ever enter `shouldUseDistSQL` when concurrent operations were
working on its `Sessions` transaction. For statements like `SHOW`, this
is now possible. This was causing the race detector to go off. To
address this, we add a thread-safe accessor to a `client.Transaction`'s
anchor key.