### PR TITLE
cli: Fix server host and port flags

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -580,11 +580,11 @@ func getClientGRPCConn() (*grpc.ClientConn, *hlc.Clock, *stop.Stopper, error) {
 	stopper := stop.NewStopper()
 	rpcContext := rpc.NewContext(
 		log.AmbientContext{},
-		clientCfg.Config,
+		serverCfg.Config,
 		clock,
 		stopper,
 	)
-	addr, err := addrWithDefaultHost(clientCfg.AdvertiseAddr)
+	addr, err := addrWithDefaultHost(serverCfg.AdvertiseAddr)
 	if err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
They were broken by #14612 in a very bad way. We were always resetting
the base.Config's Addr and AdvertiseAddr in the last couple assignments
of `extraFlagInit`, such that the host/advertise-host flags actually
don't do anything, and such that the port flag doesn't do anything when
not running in insecure mode.

I've added some tests, but we'd probably be better off testing this by
going through the entire `cockroach start` machinery with a few
different variations. Does that fit best under the acceptance tests?
Or the cli Example_xxx tests?

Fixes #14681 (once a new "latest" docker image is cut).

@mberhault for review, @bdarnell for debating whether to trash the beta we released earlier today