### PR TITLE
sql/parser: bugfix in comparison simplification

### DIFF
--- a/pkg/sql/parser/normalize_test.go
+++ b/pkg/sql/parser/normalize_test.go
@@ -161,6 +161,17 @@ func TestNormalizeExpr(t *testing.T) {
 		{`IF((true OR a < 0), (0 + a)::decimal, 2 / (1 - 1))`, `a::DECIMAL`},
 		{`COALESCE(NULL, (NULL < 3), a = 2 - 1, d)`, `COALESCE(a = 1, d)`},
 		{`COALESCE(NULL, a)`, `a`},
+		// #14687: ensure that negative divisors flip the inequality when rotating.
+		{`1 < a / -2`, `a < -2`},
+		{`1 <= a / -2`, `a <= -2`},
+		{`1 > a / -2`, `a > -2`},
+		{`1 >= a / -2`, `a >= -2`},
+		{`1 = a / -2`, `a = -2`},
+		{`1 < a / 2`, `a > 2`},
+		{`1 <= a / 2`, `a >= 2`},
+		{`1 > a / 2`, `a < 2`},
+		{`1 >= a / 2`, `a <= 2`},
+		{`1 = a / 2`, `a = 2`},
 	}
 	for _, d := range testData {
 		expr, err := ParseExprTraditional(d.expr)


### PR DESCRIPTION
Previously, simplifying an inequality with a division on one side that
had a negative divisor and variable dividend resulted in an incorrect
output.

This caused queries like `SELECT 0 < (SELECT 10) / -1` to return an
incorrect result - in this case, `true` instead of `false`.

This bug occurred during the "comparison rotation" phase of expression
simplification that attempts to isolate a variable to the left side of a
comparison between a constant and a binary expression containing the
variable. This phase algebraically transforms an expression like
`0 < x + 1` to `0 - 1 < x` by reversing the binary operator on the right
side and effectively applying the result to both sides.

When it encountered a division like `0 < x / 1`, the algorithm in effect
tried to multiply both sides of the equation by the divisor, which seems
correct. However, it was missing a crucial rule of algebraic
manipulation of inequalities: when multiplying both sides by a negative
number, the direction of the inequality *must be flipped*.

This deficiency is now corrected by flipping the inequality during the
transformation if the divisor is negative.

Fixes #14687.