### PR TITLE
security: use certs-dir for all certificates, redo certs commands

### DIFF
--- a/pkg/acceptance/cli_test.go
+++ b/pkg/acceptance/cli_test.go
@@ -101,8 +101,8 @@ trap finish EXIT
 
 HOST=$(hostname -f)
 $bin start --logtostderr=INFO --background --insecure --host="${HOST}" --port=12345 &> out
-$bin sql --host="${HOST}" --port=12345 -e "show databases"
-$bin quit --host="${HOST}" --port=12345
+$bin sql --insecure --host="${HOST}" --port=12345 -e "show databases"
+$bin quit --insecure --host="${HOST}" --port=12345
 `
 	containerConfig.Cmd = []string{"/bin/bash", "-c", script}
 	if err := testDockerOneShot(ctx, t, "start_flags_test", containerConfig); err != nil {

--- a/pkg/acceptance/reference_test.go
+++ b/pkg/acceptance/reference_test.go
@@ -59,6 +59,7 @@ trap finish EXIT
 export PGHOST=localhost
 export PGPORT=""
 export COCKROACH_SKIP_UPDATE_CHECK=1
+export COCKROACH_CERTS_DIR=/certs/
 
 bin=/%s/cockroach
 # TODO(bdarnell): when --background is in referenceBinPath, use it here and below.
@@ -113,6 +114,7 @@ function finish() {
 }
 trap finish EXIT
 
+export COCKROACH_CERTS_DIR=/certs/
 $bin start --background --logtostderr &> out
 $bin sql -d old -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01-01 00:00:00' + v)) as v, extract(epoch FROM t) as e FROM testing_old" > old.everything
 $bin sql -d old -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01-01 00:00:00' + v)) as v, extract(epoch FROM t) as e FROM testing_new" >> old.everything
@@ -135,6 +137,7 @@ function finish() {
 }
 trap finish EXIT
 
+export COCKROACH_CERTS_DIR=/certs/
 $bin start & &> out
 until $bin sql -e "SELECT 1"; do sleep 1; done
 # grep returns non-zero if it didn't match anything. With set -e above, that would exit here.
@@ -160,6 +163,7 @@ function finish() {
 trap finish EXIT
 
 export COCKROACH_SKIP_UPDATE_CHECK=1
+export COCKROACH_CERTS_DIR=/certs/
 $bin start --logtostderr=INFO --background --store=/cockroach-data-reference-7429 &> out
 $bin debug range ls
 $bin quit

--- a/pkg/base/config_test.go
+++ b/pkg/base/config_test.go
@@ -28,7 +28,8 @@ import (
 func TestClientSSLSettings(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	const assetNotFound = "error setting up client TLS config: Asset .* not found"
+	const clientCertNotFound = "no client certificate found for user .*"
+	const certDirNotFound = "problem loading certs directory"
 
 	testCases := []struct {
 		// args
@@ -43,10 +44,10 @@ func TestClientSSLSettings(t *testing.T) {
 	}{
 		{true, false, security.NodeUser, "http", "", true, false},
 		{true, true, "not-a-user", "http", "", true, false},
-		{false, true, "not-a-user", "https", assetNotFound, true, false},
-		{false, false, security.NodeUser, "https", assetNotFound, false, true},
+		{false, true, "not-a-user", "https", clientCertNotFound, true, false},
+		{false, false, security.NodeUser, "https", certDirNotFound, false, true},
 		{false, true, security.NodeUser, "https", "", false, false},
-		{false, true, "bad-user", "https", assetNotFound, false, false},
+		{false, true, "bad-user", "https", clientCertNotFound, false, false},
 	}
 
 	for tcNum, tc := range testCases {

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -63,9 +63,6 @@ type TestServerArgs struct {
 	SocketFile               string
 	ScanInterval             time.Duration
 	ScanMaxIdleTime          time.Duration
-	SSLCA                    string
-	SSLCert                  string
-	SSLCertKey               string
 	SSLCertsDir              string
 	TimeSeriesQueryWorkerMax int
 	SQLMemoryPoolSize        int64

--- a/pkg/cli/cert.go
+++ b/pkg/cli/cert.go
@@ -19,6 +19,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -28,99 +29,127 @@ import (
 )
 
 const defaultKeySize = 2048
+const defaultCALifetime = 5 * 365 * 24 * time.Hour // five years
+const defaultCertLifetime = 365 * 24 * time.Hour   // one year
 
 var keySize int
+var certificateLifetime time.Duration
+var allowCAKeyReuse bool
+var overwriteFiles bool
 
 // A createCACert command generates a CA certificate and stores it
 // in the cert directory.
 var createCACertCmd = &cobra.Command{
-	Use:   "create-ca --ca-cert=<path-to-ca-cert> --ca-key=<path-to-ca-key>",
-	Short: "create CA cert and key",
+	Use:   "create-ca --certs-dir=<path to cockroach certs dir> --ca-key=<path-to-ca-key>",
+	Short: "create CA certificate and key",
 	Long: `
-Generates CA certificate and key, writing them to --ca-cert and --ca-key.
+Generate a CA certificate "<certs-dir>/ca.crt" and CA key "<ca-key>".
+The certs directory is created if it does not exist.
+
+If the CA key exists and --allow-ca-key-reuse is true, the key is used.
+If the CA certificate exists and --overwrite is true, the new CA certificate is prepended to it.
 `,
 	RunE: MaybeDecorateGRPCError(runCreateCACert),
 }
 
-// runCreateCACert generates key pair and CA certificate and writes them
+// runCreateCACert generates a key and CA certificate and writes them
 // to their corresponding files.
 func runCreateCACert(cmd *cobra.Command, args []string) error {
-	if len(baseCfg.SSLCA) == 0 || len(baseCfg.SSLCAKey) == 0 {
-		return errMissingParams
-	}
-	return errors.Wrap(security.RunCreateCACert(baseCfg.SSLCA, baseCfg.SSLCAKey, keySize), "failed to generate CA certificate")
+	return errors.Wrap(
+		security.CreateCAPair(
+			baseCfg.SSLCertsDir,
+			baseCfg.SSLCAKey,
+			keySize,
+			certificateLifetime,
+			allowCAKeyReuse,
+			overwriteFiles),
+		"failed to generate CA cert and key")
 }
 
 // A createNodeCert command generates a node certificate and stores it
 // in the cert directory.
 var createNodeCertCmd = &cobra.Command{
-	Use:   "create-node --ca-cert=<ca-cert> --ca-key=<ca-key> --cert=<node-cert> --key=<node-key> <host 1> <host 2> ... <host N>",
-	Short: "create node cert and key",
+	Use:   "create-node --certs-dir=<path to cockroach certs dir> --ca-key=<path-to-ca-key> <host 1> <host 2> ... <host N>",
+	Short: "create node certificate and key",
 	Long: `
-Generates node certificate and keys for a given node, writing them to
---cert and --key. CA certificate and key must be passed in.
+Generate a node certificate "<certs-dir>/node.crt" and key "<certs-dir>/node.key".
+
+If --overwrite is true, any existing files are overwritten.
+
 At least one host should be passed in (either IP address or dns name).
+
+Requires a CA cert in "<certs-dir>/ca.crt" and matching key in "--ca-key".
+If "ca.crt" contains more than one certificate, the first is used.
 `,
 	RunE: MaybeDecorateGRPCError(runCreateNodeCert),
 }
 
 // runCreateNodeCert generates key pair and CA certificate and writes them
 // to their corresponding files.
+// TODO(marc): there is currently no way to specify which CA cert to use if more
+// than one is present. We shoult try to load each certificate along with the key
+// and pick the one that works. That way, the key specifies the certificate.
 func runCreateNodeCert(cmd *cobra.Command, args []string) error {
-	if len(baseCfg.SSLCA) == 0 || len(baseCfg.SSLCAKey) == 0 ||
-		len(baseCfg.SSLCert) == 0 || len(baseCfg.SSLCertKey) == 0 {
-		return errMissingParams
-	}
-	return errors.Wrap(security.RunCreateNodeCert(baseCfg.SSLCA, baseCfg.SSLCAKey,
-		baseCfg.SSLCert, baseCfg.SSLCertKey, keySize, args),
-		"failed to generate node certificate",
-	)
+	return errors.Wrap(
+		security.CreateNodePair(
+			baseCfg.SSLCertsDir,
+			baseCfg.SSLCAKey,
+			keySize,
+			certificateLifetime,
+			overwriteFiles,
+			args),
+		"failed to generate node certificate and key")
 }
 
 // A createClientCert command generates a client certificate and stores it
 // in the cert directory under <username>.crt and key under <username>.key.
 var createClientCertCmd = &cobra.Command{
-	Use:   "create-client --ca-cert=<ca-cert> --ca-key=<ca-key> --cert=<node-cert> --key=<node-key> username",
-	Short: "create client cert and key",
+	Use:   "create-client --certs-dir=<path to cockroach certs dir> --ca-key=<path-to-ca-key> <username>",
+	Short: "create client certificate and key",
 	Long: `
-Generates a client certificate and key, writing them to --cert and --key.
-CA certificate and key must be passed in.
-The certs directory should contain a CA cert and key.
+Generate a client certificate "<certs-dir>/client.<username>.crt" and key
+"<certs-dir>/client.<username>.key".
+
+If --overwrite is true, any existing files are overwritten.
+
+Requires a CA cert in "<certs-dir>/ca.crt" and matching key in "--ca-key".
+If "ca.crt" contains more than one certificate, the first is used.
 `,
 	RunE: MaybeDecorateGRPCError(runCreateClientCert),
 }
 
 // runCreateClientCert generates key pair and CA certificate and writes them
 // to their corresponding files.
+// TODO(marc): there is currently no way to specify which CA cert to use if more
+// than one if present.
 func runCreateClientCert(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return usageAndError(cmd)
-	}
-	if len(baseCfg.SSLCA) == 0 || len(baseCfg.SSLCAKey) == 0 ||
-		len(baseCfg.SSLCert) == 0 || len(baseCfg.SSLCertKey) == 0 {
-		return errMissingParams
 	}
 
 	var err error
 	var username string
 	if username, err = sql.NormalizeAndValidateUsername(args[0]); err != nil {
-		return err
+		return errors.Wrap(err, "failed to generate client certificate and key")
 	}
 
-	return errors.Wrap(security.RunCreateClientCert(baseCfg.SSLCA, baseCfg.SSLCAKey,
-		baseCfg.SSLCert, baseCfg.SSLCertKey, keySize, username),
-		"failed to generate client certificate",
-	)
+	return errors.Wrap(
+		security.CreateClientPair(
+			baseCfg.SSLCertsDir,
+			baseCfg.SSLCAKey,
+			keySize,
+			certificateLifetime,
+			overwriteFiles,
+			username),
+		"failed to generate client certificate and key")
 }
 
 // A listCerts command generates a client certificate and stores it
 // in the cert directory under <username>.crt and key under <username>.key.
-// TODO(marc): rename once certificate_manager is being used.
 var listCertsCmd = &cobra.Command{
-	Use:   "debug-list",
-	Short: "DEBUG ONLY: list certs in --certs-dir",
+	Use:   "list",
+	Short: "list certs in --certs-dir",
 	Long: `
-DEBUG ONLY: the certificates listed here are not yet effective.
 List certificates and keys found in the certificate directory.
 `,
 	RunE: MaybeDecorateGRPCError(runListCerts),

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -96,12 +96,6 @@ func newCLITest(params cliTestParams) cliTest {
 	c.cleanupFunc = func() error { return nil }
 
 	if !params.noServer {
-		s, err := serverutils.StartServerRaw(base.TestServerArgs{Insecure: params.insecure})
-		if err != nil {
-			fail(err)
-		}
-		c.TestServer = s.(*server.TestServer)
-
 		if !params.insecure {
 			// Copy these assets to disk from embedded strings, so this test can
 			// run from a standalone binary.
@@ -121,13 +115,25 @@ func newCLITest(params cliTestParams) cliTest {
 			for _, a := range assets {
 				securitytest.RestrictedCopy(nil, a, certsDir, filepath.Base(a))
 			}
+			baseCfg.SSLCertsDir = certsDir
 
 			c.cleanupFunc = func() error {
 				security.SetAssetLoader(securitytest.EmbeddedAssets)
 				return os.RemoveAll(certsDir)
 			}
 		}
+
+		s, err := serverutils.StartServerRaw(base.TestServerArgs{
+			Insecure:    params.insecure,
+			SSLCertsDir: certsDir,
+		})
+		if err != nil {
+			fail(err)
+		}
+		c.TestServer = s.(*server.TestServer)
 	}
+
+	baseCfg.User = security.NodeUser
 
 	// Ensure that CLI error messages and anything meant for the
 	// original stderr is redirected to stdout, where it can be
@@ -243,9 +249,7 @@ func (c cliTest) RunWithArgs(origArgs []string) {
 				args = append(args, "--insecure")
 			} else {
 				args = append(args, "--insecure=false")
-				args = append(args, fmt.Sprintf("--ca-cert=%s", filepath.Join(c.certsDir, security.EmbeddedCACert)))
-				args = append(args, fmt.Sprintf("--cert=%s", filepath.Join(c.certsDir, security.EmbeddedNodeCert)))
-				args = append(args, fmt.Sprintf("--key=%s", filepath.Join(c.certsDir, security.EmbeddedNodeKey)))
+				args = append(args, fmt.Sprintf("--certs-dir=%s", c.certsDir))
 			}
 			args = append(args, fmt.Sprintf("--host=%s", h))
 			args = append(args, fmt.Sprintf("--port=%s", p))
@@ -269,10 +273,8 @@ func (c cliTest) RunWithCAArgs(origArgs []string) {
 	if err := func() error {
 		args := append([]string(nil), origArgs[:1]...)
 		if c.TestServer != nil {
-			args = append(args, fmt.Sprintf("--ca-cert=%s", filepath.Join(c.certsDir, security.EmbeddedCACert)))
 			args = append(args, fmt.Sprintf("--ca-key=%s", filepath.Join(c.certsDir, security.EmbeddedCAKey)))
-			args = append(args, fmt.Sprintf("--cert=%s", filepath.Join(c.certsDir, security.EmbeddedRootCert)))
-			args = append(args, fmt.Sprintf("--key=%s", filepath.Join(c.certsDir, security.EmbeddedRootKey)))
+			args = append(args, fmt.Sprintf("--certs-dir=%s", c.certsDir))
 		}
 		args = append(args, origArgs[1:]...)
 
@@ -1122,7 +1124,7 @@ func Example_cert() {
 	// cert create-client foo
 	// cert create-client Ομηρος
 	// cert create-client 0foo
-	// username "0foo" invalid; usernames are case insensitive, must start with a letter or underscore, may contain letters, digits or underscores, and must not exceed 63 characters
+	// failed to generate client certificate and key: username "0foo" invalid; usernames are case insensitive, must start with a letter or underscore, may contain letters, digits or underscores, and must not exceed 63 characters
 }
 
 // TestFlagUsage is a basic test to make sure the fragile

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -240,13 +240,29 @@ open "<given path>/.s.PGSQL.<server port>"`,
 		EnvVar: "COCKROACH_INSECURE",
 		Description: `
 Run over non-encrypted (non-TLS) connections. This is strongly discouraged for
-production usage and this flag must be explicitly specified in order for the
-server to listen on an external address in insecure mode.`,
+production usage.`,
 	}
 
+	// KeySize, CertificateLifetime, AllowKeyReuse, and OverwriteFiles are used for
+	// certificate generation functions.
 	KeySize = FlagInfo{
 		Name:        "key-size",
 		Description: `Key size in bits for CA/Node/Client certificates.`,
+	}
+
+	CertificateLifetime = FlagInfo{
+		Name:        "lifetime",
+		Description: `Certificate lifetime.`,
+	}
+
+	AllowCAKeyReuse = FlagInfo{
+		Name:        "allow-ca-key-reuse",
+		Description: `Use the CA key if is exists.`,
+	}
+
+	OverwriteFiles = FlagInfo{
+		Name:        "overwrite",
+		Description: `Certificate and key files are overwritten if they exist.`,
 	}
 
 	MaxResults = FlagInfo{
@@ -260,33 +276,44 @@ server to listen on an external address in insecure mode.`,
 	}
 
 	CertsDir = FlagInfo{
-		Name:        "debug-certs-dir",
-		EnvVar:      "COCKROACH_DEBUG_CERTS_DIR",
-		Description: `DEBUG only: Path to the directory containing SSL certificates and keys.`,
-	}
+		Name:   "certs-dir",
+		EnvVar: "COCKROACH_CERTS_DIR",
+		Description: `
+The path to the directory containing SSL certificates and keys.
 
-	CACert = FlagInfo{
-		Name:        "ca-cert",
-		EnvVar:      "COCKROACH_CA_CERT",
-		Description: `Path to the CA certificate. Needed by clients and servers in secure mode.`,
+Cockroach looks for certificates and keys inside the directory using the following naming scheme:
+
+CA certificate and key: ca.crt, ca.key
+Server certificate and key: node.crt, node.key
+Client certificate and key: client.<user>.crt, client.<user>.key
+
+When running client commands, the user can be specified with the --user flag.
+
+Keys have a minimum permission requirement of 0777 (rwx------). This restriction can be
+disabled by setting the environment variable COCKROACH_SKIP_KEY_PERMISSION_CHECK to true.`,
 	}
 
 	CAKey = FlagInfo{
 		Name:        "ca-key",
 		EnvVar:      "COCKROACH_CA_KEY",
-		Description: `Path to the key protecting --ca-cert. Only needed when signing new certificates.`,
+		Description: `Path to the CA key.`,
+	}
+
+	// CACert, Cert, and Key are kept for backwards compatibility in the start command only.
+	// These will be removed soon.
+	CACert = FlagInfo{
+		Name:        "ca-cert",
+		Description: `DEPRECATION WARNING: this will be removed soon, please use --certs-dir`,
 	}
 
 	Cert = FlagInfo{
 		Name:        "cert",
-		EnvVar:      "COCKROACH_CERT",
-		Description: `Path to the client or server certificate. Needed in secure mode.`,
+		Description: `DEPRECATION WARNING: this will be removed soon, please use --certs-dir`,
 	}
 
 	Key = FlagInfo{
 		Name:        "key",
-		EnvVar:      "COCKROACH_KEY",
-		Description: `Path to the key protecting --cert. Needed in secure mode.`,
+		Description: `DEPRECATION WARNING: this will be removed soon, please use --certs-dir`,
 	}
 
 	Store = FlagInfo{

--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -6,6 +6,7 @@ set env(TERM) vt100
 # developer's own history file.
 set histfile ".cockroachdb_history_test"
 set ::env(COCKROACH_SQL_CLI_HISTORY) $histfile
+set ::env(COCKROACH_INSECURE) "true"
 system "rm -f $histfile"
 
 # Everything in this test should be fast. Don't be tolerant for long

--- a/pkg/cli/interactive_tests/test_old_secure.tcl
+++ b/pkg/cli/interactive_tests/test_old_secure.tcl
@@ -1,0 +1,39 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+set certs_dir "/certs"
+set ::env(COCKROACH_INSECURE) "false"
+
+set ca_crt "/certs/ca.crt"
+set node_crt "/certs/node.crt"
+set node_key "/certs/node.key"
+
+proc start_secure_server {argv ca_crt node_crt node_key} {
+    system "mkfifo pid_fifo || true; $argv start --certs-dir= --ca-cert=$ca_crt --cert=$node_crt --key=$node_key --pid-file=pid_fifo & cat pid_fifo > server_pid"
+}
+
+proc stop_secure_server {argv certs_dir} {
+    system "set -e; if kill -CONT `cat server_pid`; then $argv quit --certs-dir=$certs_dir || true & sleep 1; kill -9 `cat server_pid` || true; else $argv quit --certs-dir=$certs_dir || true; fi"
+}
+
+start_secure_server $argv $ca_crt $node_crt $node_key
+
+spawn /bin/bash
+send "PS1=':''/# '\r"
+
+set prompt ":/# "
+eexpect $prompt
+
+send "$argv sql --certs-dir=$certs_dir\r"
+eexpect "root@"
+
+# Terminate with Ctrl+C.
+interrupt
+
+eexpect $prompt
+
+send "exit 0\r"
+eexpect eof
+
+stop_secure_server $argv $certs_dir

--- a/pkg/cli/range.go
+++ b/pkg/cli/range.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -31,6 +32,8 @@ import (
 
 // MakeDBClient creates a kv client for use in cli tools.
 func MakeDBClient() (*client.DB, *stop.Stopper, error) {
+	// The KV endpoints require the node user.
+	baseCfg.User = security.NodeUser
 	conn, clock, stopper, err := getClientGRPCConn()
 	if err != nil {
 		return nil, nil, err

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -239,7 +239,7 @@ func getPasswordAndMakeSQLClient() (*sqlConn, error) {
 	}
 	var user *url.Userinfo
 	if !baseCfg.Insecure && sqlConnUser != security.RootUser &&
-		baseCfg.SSLCert == "" && baseCfg.SSLCertKey == "" {
+		!baseCfg.ClientHasValidCerts(sqlConnUser) {
 		pwd, err := security.PromptForPassword()
 		if err != nil {
 			return nil, err

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -57,8 +57,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
-var errMissingParams = errors.New("missing or invalid parameters")
-
 // jemallocHeapDump is an optional function to be called at heap dump time.
 // This will be non-nil when jemalloc is linked in with profiling enabled.
 // The function takes a filename to write the profile to.
@@ -95,28 +93,6 @@ func setDefaultSizeParameters(ctx *server.Config) {
 		// against OS buffers and decrease overall client throughput.
 		ctx.SQLMemoryPoolSize = size / 4
 	}
-}
-
-func initInsecureServer() error {
-	if !serverCfg.Insecure || insecure.isSet {
-		return nil
-	}
-	// The --insecure flag was not specified on the command line, verify that the
-	// host refers to a loopback address.
-	if serverConnHost != "" {
-		addr, err := net.ResolveIPAddr("ip", serverConnHost)
-		if err != nil {
-			return err
-		}
-		if !addr.IP.IsLoopback() {
-			return fmt.Errorf("specify --insecure to listen on external address %s", serverConnHost)
-		}
-	} else {
-		serverCfg.Addr = net.JoinHostPort("localhost", serverConnPort)
-		serverCfg.AdvertiseAddr = serverCfg.Addr
-		serverCfg.HTTPAddr = net.JoinHostPort("localhost", serverHTTPPort)
-	}
-	return nil
 }
 
 // maxSizePerProfile is the maximum total size in bytes for profiles per
@@ -322,10 +298,6 @@ func runStart(cmd *cobra.Command, args []string) error {
 	tracer := tracing.NewTracer()
 	sp := tracer.StartSpan("server start")
 	startCtx := opentracing.ContextWithSpan(context.Background(), sp)
-
-	if err := initInsecureServer(); err != nil {
-		return err
-	}
 
 	// Ensure that the store paths are absolute. This will clarify the
 	// output of the startup messages below, and ensure that logging

--- a/pkg/cli/start_test.go
+++ b/pkg/cli/start_test.go
@@ -63,18 +63,12 @@ func TestInitInsecure(t *testing.T) {
 		// Reset the context and insecure flag for every test case.
 		ctx.InitDefaults()
 		ctx.Insecure = true
-		insecure.isSet = false
 
 		if err := f.Parse(c.args); err != nil {
 			t.Fatal(err)
 		}
 		if c.insecure != ctx.Insecure {
 			t.Fatalf("%d: expected %v, but found %v", i, c.insecure, ctx.Insecure)
-		}
-
-		err := initInsecureServer()
-		if !testutils.IsError(err, c.expected) {
-			t.Fatalf("%d: expected %q, but found %v", i, c.expected, err)
 		}
 	}
 }

--- a/pkg/security/certificate_loader_test.go
+++ b/pkg/security/certificate_loader_test.go
@@ -45,9 +45,13 @@ func TestLoadEmbeddedCerts(t *testing.T) {
 		t.Errorf("found %d keypairs, but have %d embedded files", act, exp)
 	}
 
-	// Check that all pairs include a key.
+	// Check that all non-CA pairs include a key.
 	for _, c := range certs {
-		if len(c.KeyFilename) == 0 {
+		if c.FileUsage == security.CAPem {
+			if len(c.KeyFilename) != 0 {
+				t.Errorf("CA key was loaded for CertInfo %+v", c)
+			}
+		} else if len(c.KeyFilename) == 0 {
 			t.Errorf("no key found as part of CertInfo %+v", c)
 		}
 	}
@@ -131,6 +135,7 @@ func TestNamingScheme(t *testing.T) {
 		},
 		{
 			// Key files, but wrong permissions.
+			// We don't load CA keys here, so permissions for them don't matter.
 			files: []testFile{
 				{"ca.crt", 0777},
 				{"ca.key", 0777},
@@ -139,7 +144,9 @@ func TestNamingScheme(t *testing.T) {
 				{"client.root.crt", 0777},
 				{"client.root.key", 0740},
 			},
-			certs: []security.CertInfo{},
+			certs: []security.CertInfo{
+				{FileUsage: security.CAPem, Filename: "ca.crt"},
+			},
 		},
 		{
 			// Everything loads.
@@ -152,7 +159,7 @@ func TestNamingScheme(t *testing.T) {
 				{"client.root.key", 0700},
 			},
 			certs: []security.CertInfo{
-				{FileUsage: security.CAPem, Filename: "ca.crt", KeyFilename: "ca.key"},
+				{FileUsage: security.CAPem, Filename: "ca.crt"},
 				{FileUsage: security.ClientPem, Filename: "client.root.crt", KeyFilename: "client.root.key", Name: "root"},
 				{FileUsage: security.NodePem, Filename: "node.crt", KeyFilename: "node.key"},
 			},
@@ -168,7 +175,7 @@ func TestNamingScheme(t *testing.T) {
 				{"client.root.key", 0777},
 			},
 			certs: []security.CertInfo{
-				{FileUsage: security.CAPem, Filename: "ca.crt", KeyFilename: "ca.key"},
+				{FileUsage: security.CAPem, Filename: "ca.crt"},
 				{FileUsage: security.ClientPem, Filename: "client.root.crt", KeyFilename: "client.root.key", Name: "root"},
 				{FileUsage: security.NodePem, Filename: "node.crt", KeyFilename: "node.key"},
 			},

--- a/pkg/security/certs.go
+++ b/pkg/security/certs.go
@@ -18,12 +18,24 @@ package security
 
 import (
 	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"io/ioutil"
 	"os"
+	"time"
 
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/pkg/errors"
+)
+
+const (
+	keyFileMode  = 0600
+	certFileMode = 0644
 )
 
 // loadCACertAndKey loads the certificate and key files,parses them,
@@ -44,121 +56,235 @@ func loadCACertAndKey(sslCA, sslCAKey string) (*x509.Certificate, crypto.Private
 	return x509Cert, caCert.PrivateKey, nil
 }
 
-// writeCertificateAndKey takes a x509 certificate and key and writes
-// them out to the individual files.
-// TODO(marc): figure out how to include the plaintext certificate in the .crt file.
-func writeCertificateAndKey(
-	certFilePath, keyFilePath string, certificate []byte, key crypto.PrivateKey,
+func writeCertificateToFile(certFilePath string, certificate []byte, overwrite bool) error {
+	certBlock := &pem.Block{Type: "CERTIFICATE", Bytes: certificate}
+
+	return WritePEMToFile(certFilePath, certFileMode, overwrite, certBlock)
+}
+
+func writeKeyToFile(keyFilePath string, key crypto.PrivateKey, overwrite bool) error {
+	keyBlock, err := PrivateKeyToPEM(key)
+	if err != nil {
+		return err
+	}
+
+	return WritePEMToFile(keyFilePath, keyFileMode, overwrite, keyBlock)
+}
+
+// CreateCAPair creates a CA key and a CA certificate.
+// If the certs directory does not exist, it is created.
+// If the key does not exist, it is created.
+// The certificate is written to the certs directory. If the file already exists,
+// we append the original certificates to the new certificate.
+func CreateCAPair(
+	certsDir, caKeyPath string,
+	keySize int,
+	lifetime time.Duration,
+	allowKeyReuse bool,
+	overwrite bool,
 ) error {
-	// Get PEM blocks for certificate and private key.
-	certBlock, err := certificatePEMBlock(certificate)
+	if len(caKeyPath) == 0 {
+		return errors.New("the path to the CA key is required")
+	}
+	if len(certsDir) == 0 {
+		return errors.New("the path to the certs directory is required")
+	}
+
+	// The certificate manager expands the env for the certs directory.
+	// For consistency, we need to do this for the key as well.
+	caKeyPath = os.ExpandEnv(caKeyPath)
+
+	// Create a certificate manager with "create dir if not exist".
+	cm, err := NewCertificateManagerFirstRun(certsDir)
 	if err != nil {
 		return err
 	}
 
-	keyBlock, err := privateKeyPEMBlock(key)
+	var key crypto.PrivateKey
+	if _, err := os.Stat(caKeyPath); err != nil {
+		if !os.IsNotExist(err) {
+			return errors.Errorf("could not stat CA key file %s: %v", caKeyPath, err)
+		}
+
+		// The key does not exist: create it.
+		key, err = rsa.GenerateKey(rand.Reader, keySize)
+		if err != nil {
+			return errors.Errorf("could not generate new CA key: %v", err)
+		}
+
+		// overwrite is not technically needed here, but use it in case something else created it.
+		if err := writeKeyToFile(caKeyPath, key, overwrite); err != nil {
+			return errors.Errorf("could not write CA key to file %s: %v", caKeyPath, err)
+		}
+
+		log.Infof(context.Background(), "Generated CA key %s", caKeyPath)
+	} else {
+		if !allowKeyReuse {
+			return errors.Errorf("CA key %s exists, but key reuse is disabled", caKeyPath)
+		}
+		// The key exists, parse it.
+		contents, err := ioutil.ReadFile(caKeyPath)
+		if err != nil {
+			return errors.Errorf("could not read CA key file %s: %v", caKeyPath, err)
+		}
+
+		key, err = PEMToPrivateKey(contents)
+		if err != nil {
+			return errors.Errorf("could not parse CA key file %s: %v", caKeyPath, err)
+		}
+
+		log.Infof(context.Background(), "Using CA key from file %s", caKeyPath)
+	}
+
+	// Generate certificate.
+	certContents, err := GenerateCA(key.(crypto.Signer), lifetime)
 	if err != nil {
-		return err
+		return errors.Errorf("could not generate CA certificate: %v", err)
 	}
 
-	// Write certificate to file.
-	certFile, err := os.OpenFile(certFilePath, os.O_WRONLY|os.O_CREATE, 0644)
-	if err != nil {
-		return errors.Errorf("error creating certificate: %s", err)
+	certPath := cm.CACertPath()
+
+	var existingCertificates []*pem.Block
+	if _, err := os.Stat(certPath); err == nil {
+		// The cert file already exists, load certificates.
+		contents, err := ioutil.ReadFile(certPath)
+		if err != nil {
+			return errors.Errorf("could not read existing CA cert file %s: %v", certPath, err)
+		}
+
+		existingCertificates, err = PEMToCertificates(contents)
+		if err != nil {
+			return errors.Errorf("could not parse existing CA cert file %s: %v", certPath, err)
+		}
+		log.Infof(context.Background(), "Found %d certificates in %s",
+			len(existingCertificates), certPath)
+	} else if !os.IsNotExist(err) {
+		return errors.Errorf("could not stat CA cert file %s: %v", certPath, err)
 	}
 
-	if err := pem.Encode(certFile, certBlock); err != nil {
-		return errors.Errorf("error encoding certificate: %s", err)
+	// Always place the new certificate first.
+	certificates := []*pem.Block{{Type: "CERTIFICATE", Bytes: certContents}}
+	certificates = append(certificates, existingCertificates...)
+
+	if err := WritePEMToFile(certPath, certFileMode, overwrite, certificates...); err != nil {
+		return errors.Errorf("could not write CA certificate file %s: %v", certPath, err)
 	}
 
-	if err := certFile.Close(); err != nil {
-		return errors.Errorf("error closing file %s: %s", certFilePath, err)
-	}
-
-	// Write key to file.
-	keyFile, err := os.OpenFile(keyFilePath, os.O_WRONLY|os.O_CREATE, 0600)
-	if err != nil {
-		return errors.Errorf("error creating key: %s", err)
-	}
-
-	if err := pem.Encode(keyFile, keyBlock); err != nil {
-		return errors.Errorf("error encoding key: %s", err)
-	}
-
-	if err := keyFile.Close(); err != nil {
-		return errors.Errorf("error closing file %s: %s", keyFilePath, err)
-	}
+	log.Infof(context.Background(), "Wrote %d certificates to %s", len(certificates), certPath)
 
 	return nil
 }
 
-// RunCreateCACert is the entry-point from the command-line interface
-// to generate CA cert and key.
-// Takes in:
-// - sslCA: path to the CA certificate
-// - sslCAKey: path to the CA key
-func RunCreateCACert(sslCA, sslCAKey string, keySize int) error {
-	// Generate certificate.
-	certificate, key, err := GenerateCA(keySize)
-	if err != nil {
-		return errors.Errorf("error creating CA certificate and key: %s", err)
+// CreateNodePair creates a node key and certificate.
+// The CA cert and key must load properly. If multiple certificates
+// exist in the CA cert, the first one is used.
+func CreateNodePair(
+	certsDir, caKeyPath string, keySize int, lifetime time.Duration, overwrite bool, hosts []string,
+) error {
+	if len(caKeyPath) == 0 {
+		return errors.New("the path to the CA key is required")
+	}
+	if len(certsDir) == 0 {
+		return errors.New("the path to the certs directory is required")
 	}
 
-	return writeCertificateAndKey(sslCA, sslCAKey, certificate, key)
-}
-
-// RunCreateNodeCert is the entry-point from the command-line interface
-// to generate node certs and keys:
-// - sslCA: path to the CA certificate
-// - sslCAKey: path to the CA key
-// - sslCert: path to the node certificate
-// - sslCertKey: path to the node key
-func RunCreateNodeCert(
-	sslCA, sslCAKey, sslCert, sslCertKey string, keySize int, hosts []string,
-) error {
 	if len(hosts) == 0 {
 		return errors.Errorf("no hosts specified. Need at least one")
 	}
 
-	caCert, caKey, err := loadCACertAndKey(sslCA, sslCAKey)
+	// The certificate manager expands the env for the certs directory.
+	// For consistency, we need to do this for the key as well.
+	caKeyPath = os.ExpandEnv(caKeyPath)
+
+	// Create a certificate manager with "create dir if not exist".
+	cm, err := NewCertificateManagerFirstRun(certsDir)
+	if err != nil {
+		return err
+	}
+
+	// Load the CA pair.
+	caCert, caPrivateKey, err := loadCACertAndKey(cm.CACertPath(), caKeyPath)
 	if err != nil {
 		return err
 	}
 
 	// Generate certificates and keys.
-	serverCert, serverKey, err := GenerateServerCert(caCert, caKey, keySize, hosts)
+	nodeKey, err := rsa.GenerateKey(rand.Reader, keySize)
+	if err != nil {
+		return errors.Errorf("could not generate new node key: %v", err)
+	}
+
+	nodeCert, err := GenerateServerCert(caCert, caPrivateKey, nodeKey.Public(), lifetime, hosts)
 	if err != nil {
 		return errors.Errorf("error creating node server certificate and key: %s", err)
 	}
 
-	// TODO(marc): we fail if files already exist. At this point, we're checking four
-	// different files, and should really make this more atomic (or at least check for existence first).
-	return writeCertificateAndKey(sslCert, sslCertKey, serverCert, serverKey)
+	certPath := cm.NodeCertPath()
+	if err := writeCertificateToFile(certPath, nodeCert, overwrite); err != nil {
+		return errors.Errorf("error writing node server certificate to %s: %v", certPath, err)
+	}
+	log.Infof(context.Background(), "Generated node certificate: %s", certPath)
+
+	keyPath := cm.NodeKeyPath()
+	if err := writeKeyToFile(keyPath, nodeKey, overwrite); err != nil {
+		return errors.Errorf("error writing node server key to %s: %v", keyPath, err)
+	}
+	log.Infof(context.Background(), "Generated node key: %s", certPath)
+
+	return nil
 }
 
-// RunCreateClientCert is the entry-point from the command-line interface
-// to generate a client cert and key.
-// - sslCA: path to the CA certificate
-// - sslCAKey: path to the CA key
-// - sslCert: path to the node certificate
-// - sslCertKey: path to the node key
-func RunCreateClientCert(
-	sslCA, sslCAKey, sslCert, sslCertKey string, keySize int, username string,
+// CreateClientPair creates a node key and certificate.
+// The CA cert and key must load properly. If multiple certificates
+// exist in the CA cert, the first one is used.
+func CreateClientPair(
+	certsDir, caKeyPath string, keySize int, lifetime time.Duration, overwrite bool, user string,
 ) error {
-	if len(username) == 0 {
-		return errors.Errorf("no username specified.")
+	if len(caKeyPath) == 0 {
+		return errors.New("the path to the CA key is required")
+	}
+	if len(certsDir) == 0 {
+		return errors.New("the path to the certs directory is required")
 	}
 
-	caCert, caKey, err := loadCACertAndKey(sslCA, sslCAKey)
+	// The certificate manager expands the env for the certs directory.
+	// For consistency, we need to do this for the key as well.
+	caKeyPath = os.ExpandEnv(caKeyPath)
+
+	// Create a certificate manager with "create dir if not exist".
+	cm, err := NewCertificateManagerFirstRun(certsDir)
 	if err != nil {
 		return err
 	}
 
-	// Generate certificate.
-	certificate, key, err := GenerateClientCert(caCert, caKey, keySize, username)
+	// Load the CA pair.
+	caCert, caPrivateKey, err := loadCACertAndKey(cm.CACertPath(), caKeyPath)
 	if err != nil {
-		return errors.Errorf("error creating client certificate and key: %s", err)
+		return err
 	}
 
-	return writeCertificateAndKey(sslCert, sslCertKey, certificate, key)
+	// Generate certificates and keys.
+	clientKey, err := rsa.GenerateKey(rand.Reader, keySize)
+	if err != nil {
+		return errors.Errorf("could not generate new node key: %v", err)
+	}
+
+	clientCert, err := GenerateClientCert(caCert, caPrivateKey, clientKey.Public(), lifetime, user)
+	if err != nil {
+		return errors.Errorf("error creating node server certificate and key: %s", err)
+	}
+
+	certPath := cm.ClientCertPath(user)
+	if err := writeCertificateToFile(certPath, clientCert, overwrite); err != nil {
+		return errors.Errorf("error writing node server certificate to %s: %v", certPath, err)
+	}
+	log.Infof(context.Background(), "Generated client certificate: %s", certPath)
+
+	keyPath := cm.ClientKeyPath(user)
+	if err := writeKeyToFile(keyPath, clientKey, overwrite); err != nil {
+		return errors.Errorf("error writing node server key to %s: %v", keyPath, err)
+	}
+	log.Infof(context.Background(), "Generated client key: %s", keyPath)
+
+	return nil
 }

--- a/pkg/security/certs_test.go
+++ b/pkg/security/certs_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -30,8 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
-// This is just the mechanics of certs generation.
-func TestGenerateCerts(t *testing.T) {
+func TestGenerateCACert(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// Do not mock cert access for this test.
 	security.ResetAssetLoader()
@@ -47,43 +47,101 @@ func TestGenerateCerts(t *testing.T) {
 		}
 	}()
 
-	// Try certs generation with empty Certs dir argument.
-	if err := security.RunCreateCACert("", "", 512); err == nil {
-		t.Fatalf("Expected error, but got none")
-	}
-	if err := security.RunCreateNodeCert(
-		"", "", "", "",
-		512, []string{"localhost"},
-	); err == nil {
-		t.Fatalf("Expected error, but got none")
+	cm, err := security.NewCertificateManager(certsDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
+	keyPath := filepath.Join(certsDir, "ca.key")
+
+	testCases := []struct {
+		certsDir, caKey       string
+		allowReuse, overwrite bool
+		errStr                string // error string for CreateCAPair, empty for nil.
+		numCerts              int    // number of certificates found in ca.crt
+	}{
+		{"", "ca.key", false, false, "the path to the certs directory is required", 0},
+		{certsDir, "", false, false, "the path to the CA key is required", 0},
+		// New CA key/cert.
+		{certsDir, keyPath, false, false, "", 1},
+		// Files exist, but reuse is disabled.
+		{certsDir, keyPath, false, false, "exists, but key reuse is disabled", 2},
+		// Files exist, but overwrite is off.
+		{certsDir, keyPath, true, false, "file exists", 2},
+		// Files exist and reuse/overwrite is enabled.
+		{certsDir, keyPath, true, true, "", 2},
+		// Cert exists and overwrite is enabled.
+		{certsDir, keyPath + "2", false, true, "", 3}, // Using a new key still keeps the ca.crt
+	}
+
+	for i, tc := range testCases {
+		err := security.CreateCAPair(tc.certsDir, tc.caKey, 512,
+			time.Hour*48, tc.allowReuse, tc.overwrite)
+		if !testutils.IsError(err, tc.errStr) {
+			t.Errorf("#%d: expected error %s but got %+v", i, tc.errStr, err)
+			continue
+		}
+
+		if err != nil {
+			continue
+		}
+
+		// No failures on CreateCAPair, we expect a valid CA cert.
+		err = cm.LoadCertificates()
+		if err != nil {
+			t.Fatalf("#%d: unexpected failure: %v", i, err)
+		}
+
+		ci := cm.CACert()
+		if ci == nil {
+			t.Fatalf("#%d: no CA cert found", i)
+		}
+
+		certs, err := security.PEMToCertificates(ci.FileContents)
+		if err != nil {
+			t.Fatalf("#%d: unexpected parsing error for %+v: %v", i, ci, err)
+		}
+
+		if actual := len(certs); actual != tc.numCerts {
+			t.Errorf("#%d: expected %d certificates, found %d", i, tc.numCerts, actual)
+		}
+	}
+}
+
+func TestGenerateNodeCerts(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	// Do not mock cert access for this test.
+	security.ResetAssetLoader()
+	defer ResetTest()
+
+	certsDir, err := ioutil.TempDir("", "certs_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.RemoveAll(certsDir); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
 	// Try generating node certs without CA certs present.
-	if err := security.RunCreateNodeCert(
-		filepath.Join(certsDir, security.EmbeddedCACert),
-		filepath.Join(certsDir, security.EmbeddedCAKey),
-		filepath.Join(certsDir, security.EmbeddedNodeCert),
-		filepath.Join(certsDir, security.EmbeddedNodeKey),
-		512, []string{"localhost"},
+	if err := security.CreateNodePair(
+		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
+		512, time.Hour*48, false, []string{"localhost"},
 	); err == nil {
 		t.Fatalf("Expected error, but got none")
 	}
 
 	// Now try in the proper order.
-	if err := security.RunCreateCACert(
-		filepath.Join(certsDir, security.EmbeddedCACert),
-		filepath.Join(certsDir, security.EmbeddedCAKey),
-		512,
+	if err := security.CreateCAPair(
+		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey), 512, time.Hour*48, false, false,
 	); err != nil {
 		t.Fatalf("Expected success, got %v", err)
 	}
 
-	if err := security.RunCreateNodeCert(
-		filepath.Join(certsDir, security.EmbeddedCACert),
-		filepath.Join(certsDir, security.EmbeddedCAKey),
-		filepath.Join(certsDir, security.EmbeddedNodeCert),
-		filepath.Join(certsDir, security.EmbeddedNodeKey),
-		512, []string{"localhost"},
+	if err := security.CreateNodePair(
+		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
+		512, time.Hour*48, false, []string{"localhost"},
 	); err != nil {
 		t.Fatalf("Expected success, got %v", err)
 	}
@@ -106,30 +164,22 @@ func TestUseCerts(t *testing.T) {
 		}
 	}()
 
-	if err := security.RunCreateCACert(
-		filepath.Join(certsDir, security.EmbeddedCACert),
-		filepath.Join(certsDir, security.EmbeddedCAKey),
-		512,
+	if err := security.CreateCAPair(
+		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey), 512, time.Hour*48, false, false,
 	); err != nil {
 		t.Fatalf("Expected success, got %v", err)
 	}
 
-	if err := security.RunCreateNodeCert(
-		filepath.Join(certsDir, security.EmbeddedCACert),
-		filepath.Join(certsDir, security.EmbeddedCAKey),
-		filepath.Join(certsDir, security.EmbeddedNodeCert),
-		filepath.Join(certsDir, security.EmbeddedNodeKey),
-		512, []string{"127.0.0.1"},
+	if err := security.CreateNodePair(
+		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
+		512, time.Hour*48, false, []string{"127.0.0.1"},
 	); err != nil {
 		t.Fatalf("Expected success, got %v", err)
 	}
 
-	if err := security.RunCreateClientCert(
-		filepath.Join(certsDir, security.EmbeddedCACert),
-		filepath.Join(certsDir, security.EmbeddedCAKey),
-		filepath.Join(certsDir, security.EmbeddedRootCert),
-		filepath.Join(certsDir, security.EmbeddedRootKey),
-		512, security.RootUser,
+	if err := security.CreateClientPair(
+		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
+		512, time.Hour*48, false, security.RootUser,
 	); err != nil {
 		t.Fatalf("Expected success, got %v", err)
 	}
@@ -153,9 +203,6 @@ func TestUseCerts(t *testing.T) {
 	// Start a test server and override certs.
 	// We use a real context since we want generated certs.
 	params := base.TestServerArgs{
-		SSLCA:       filepath.Join(certsDir, security.EmbeddedCACert),
-		SSLCert:     filepath.Join(certsDir, security.EmbeddedNodeCert),
-		SSLCertKey:  filepath.Join(certsDir, security.EmbeddedNodeKey),
 		SSLCertsDir: certsDir,
 	}
 	s, _, _ := serverutils.StartServer(t, params)
@@ -181,9 +228,6 @@ func TestUseCerts(t *testing.T) {
 
 	// New client. With certs this time.
 	clientContext = testutils.NewNodeTestBaseContext()
-	clientContext.SSLCA = filepath.Join(certsDir, security.EmbeddedCACert)
-	clientContext.SSLCert = filepath.Join(certsDir, security.EmbeddedNodeCert)
-	clientContext.SSLCertKey = filepath.Join(certsDir, security.EmbeddedNodeKey)
 	clientContext.SSLCertsDir = certsDir
 	httpClient, err = clientContext.GetHTTPClient()
 	if err != nil {

--- a/pkg/security/pem.go
+++ b/pkg/security/pem.go
@@ -1,0 +1,127 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package security
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// WritePEMToFile writes an arbitrary number of PEM blocks to a file.
+// The file "path" is created with "mode" and WRONLY|CREATE.
+// If overwrite is true, the file will be overwritten if it exists.
+func WritePEMToFile(path string, mode os.FileMode, overwrite bool, blocks ...*pem.Block) error {
+	flags := os.O_WRONLY | os.O_CREATE
+	if !overwrite {
+		flags |= os.O_EXCL
+	}
+	f, err := os.OpenFile(path, flags, mode)
+	if err != nil {
+		return err
+	}
+
+	for _, p := range blocks {
+		if err := pem.Encode(f, p); err != nil {
+			return errors.Errorf("could not encode PEM block: %v", err)
+		}
+	}
+
+	return f.Close()
+}
+
+// PrivateKeyToPEM generates a PEM block from a private key.
+func PrivateKeyToPEM(key crypto.PrivateKey) (*pem.Block, error) {
+	switch k := key.(type) {
+	case *rsa.PrivateKey:
+		return &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)}, nil
+	case *ecdsa.PrivateKey:
+		bytes, err := x509.MarshalECPrivateKey(k)
+		if err != nil {
+			return nil, errors.Errorf("error marshalling ECDSA key: %s", err)
+		}
+		return &pem.Block{Type: "EC PRIVATE KEY", Bytes: bytes}, nil
+	default:
+		return nil, errors.Errorf("unknown key type: %v", k)
+	}
+}
+
+// PEMToCertificates parses multiple certificate PEM blocks and returns them.
+// Each block must be a certificate.
+// It is allowed to have zero certificates.
+func PEMToCertificates(contents []byte) ([]*pem.Block, error) {
+	certs := make([]*pem.Block, 0)
+	for {
+		var block *pem.Block
+		block, contents = pem.Decode(contents)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			return nil, errors.Errorf("block #%d is of type %s, not CERTIFICATE", len(certs), block.Type)
+		}
+
+		certs = append(certs, block)
+	}
+
+	return certs, nil
+}
+
+// PEMToPrivateKey parses a PEM block and returns the private key.
+func PEMToPrivateKey(contents []byte) (crypto.PrivateKey, error) {
+	keyBlock, remaining := pem.Decode(contents)
+	if keyBlock == nil {
+		return nil, errors.New("no PEM data found")
+	}
+	if len(remaining) != 0 {
+		return nil, errors.New("more than one PEM block found")
+	}
+	if keyBlock.Type != "PRIVATE KEY" && !strings.HasSuffix(keyBlock.Type, " PRIVATE KEY") {
+		return nil, errors.Errorf("PEM block is of type %s", keyBlock.Type)
+	}
+
+	return parsePrivateKey(keyBlock.Bytes)
+}
+
+// Taken straight from: golang.org/src/crypto/tls/tls.go
+// Attempt to parse the given private key DER block. OpenSSL 0.9.8 generates
+// PKCS#1 private keys by default, while OpenSSL 1.0.0 generates PKCS#8 keys.
+// OpenSSL ecparam generates SEC1 EC private keys for ECDSA. We try all three.
+func parsePrivateKey(der []byte) (crypto.PrivateKey, error) {
+	if key, err := x509.ParsePKCS1PrivateKey(der); err == nil {
+		return key, nil
+	}
+	if key, err := x509.ParsePKCS8PrivateKey(der); err == nil {
+		switch key := key.(type) {
+		case *rsa.PrivateKey, *ecdsa.PrivateKey:
+			return key, nil
+		default:
+			return nil, errors.New("found unknown private key type in PKCS#8 wrapping")
+		}
+	}
+	if key, err := x509.ParseECPrivateKey(der); err == nil {
+		return key, nil
+	}
+
+	return nil, errors.New("failed to parse private key")
+}

--- a/pkg/security/securitytest/test_certs/README.md
+++ b/pkg/security/securitytest/test_certs/README.md
@@ -20,9 +20,9 @@ openssl x509 -in node.crt -text
 To regenerate:
 ```bash
 rm -f pkg/security/securitytest/test_certs/*.{crt,key}
-./cockroach cert --ca-cert=pkg/security/securitytest/test_certs/ca.crt --ca-key=pkg/security/securitytest/test_certs/ca.key create-ca
-./cockroach cert --ca-cert=pkg/security/securitytest/test_certs/ca.crt --ca-key=pkg/security/securitytest/test_certs/ca.key --cert=pkg/security/securitytest/test_certs/node.crt --key=pkg/security/securitytest/test_certs/node.key create-node 127.0.0.1 ::1 localhost *.local
-./cockroach cert --ca-cert=pkg/security/securitytest/test_certs/ca.crt --ca-key=pkg/security/securitytest/test_certs/ca.key --cert=pkg/security/securitytest/test_certs/client.root.crt --key=pkg/security/securitytest/test_certs/client.root.key create-client root
-./cockroach cert --ca-cert=pkg/security/securitytest/test_certs/ca.crt --ca-key=pkg/security/securitytest/test_certs/ca.key --cert=pkg/security/securitytest/test_certs/client.testuser.crt --key=pkg/security/securitytest/test_certs/client.testuser.key create-client testuser
+./cockroach cert --certs-dir=pkg/security/securitytest/test_certs --ca-key=pkg/security/securitytest/test_certs/ca.key create-ca
+./cockroach cert --certs-dir=pkg/security/securitytest/test_certs --ca-key=pkg/security/securitytest/test_certs/ca.key create-node 127.0.0.1 ::1 localhost *.local
+./cockroach cert --certs-dir=pkg/security/securitytest/test_certs --ca-key=pkg/security/securitytest/test_certs/ca.key create-client root
+./cockroach cert --certs-dir=pkg/security/securitytest/test_certs --ca-key=pkg/security/securitytest/test_certs/ca.key create-client testuser
 make generate PKG=./pkg/security/securitytest
 ```

--- a/pkg/security/tls.go
+++ b/pkg/security/tls.go
@@ -47,15 +47,15 @@ const (
 // - sslCertKey: path to the server key
 // If the path is prefixed with "embedded=", load the embedded certs.
 func LoadServerTLSConfig(sslCA, sslCert, sslCertKey string) (*tls.Config, error) {
-	certPEM, err := readFileFn(sslCert)
+	certPEM, err := assetLoaderImpl.ReadFile(sslCert)
 	if err != nil {
 		return nil, err
 	}
-	keyPEM, err := readFileFn(sslCertKey)
+	keyPEM, err := assetLoaderImpl.ReadFile(sslCertKey)
 	if err != nil {
 		return nil, err
 	}
-	caPEM, err := readFileFn(sslCA)
+	caPEM, err := assetLoaderImpl.ReadFile(sslCA)
 	if err != nil {
 		return nil, err
 	}
@@ -104,15 +104,15 @@ func newServerTLSConfig(certPEM, keyPEM, caPEM []byte) (*tls.Config, error) {
 // - sslCertKey: path to the client key
 // If the path is prefixed with "embedded=", load the embedded certs.
 func LoadClientTLSConfig(sslCA, sslCert, sslCertKey string) (*tls.Config, error) {
-	certPEM, err := readFileFn(sslCert)
+	certPEM, err := assetLoaderImpl.ReadFile(sslCert)
 	if err != nil {
 		return nil, err
 	}
-	keyPEM, err := readFileFn(sslCertKey)
+	keyPEM, err := assetLoaderImpl.ReadFile(sslCertKey)
 	if err != nil {
 		return nil, err
 	}
-	caPEM, err := readFileFn(sslCA)
+	caPEM, err := assetLoaderImpl.ReadFile(sslCA)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/x509.go
+++ b/pkg/security/x509.go
@@ -18,12 +18,9 @@ package security
 
 import (
 	"crypto"
-	"crypto/ecdsa"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/pem"
 	"math/big"
 	"net"
 	"time"
@@ -40,45 +37,13 @@ const (
 	// Make certs valid a day before to handle clock issues, specifically
 	// boot2docker: https://github.com/boot2docker/boot2docker/issues/69
 	validFrom     = -time.Hour * 24
-	validFor      = time.Hour * 24 * 365
 	maxPathLength = 1
 	caCommonName  = "Cockroach CA"
 )
 
-// generateKeyPair returns a random 'keySize' bit RSA key pair.
-func generateKeyPair(keySize int) (crypto.PrivateKey, crypto.PublicKey, error) {
-	private, err := rsa.GenerateKey(rand.Reader, keySize)
-	if err != nil {
-		return nil, nil, err
-	}
-	public := private.Public()
-	return private, public, err
-}
-
-// privateKeyPEMBlock generates a PEM block from a private key.
-func privateKeyPEMBlock(key crypto.PrivateKey) (*pem.Block, error) {
-	switch k := key.(type) {
-	case *rsa.PrivateKey:
-		return &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)}, nil
-	case *ecdsa.PrivateKey:
-		bytes, err := x509.MarshalECPrivateKey(k)
-		if err != nil {
-			return nil, errors.Errorf("error marshalling ECDSA key: %s", err)
-		}
-		return &pem.Block{Type: "EC PRIVATE KEY", Bytes: bytes}, nil
-	default:
-		return nil, errors.Errorf("unknown key type: %v", k)
-	}
-}
-
-// certificatePEMBlock generates a PEM block from a certificate.
-func certificatePEMBlock(cert []byte) (*pem.Block, error) {
-	return &pem.Block{Type: "CERTIFICATE", Bytes: cert}, nil
-}
-
 // newTemplate returns a partially-filled template.
 // It should be further populated based on whether the cert is for a CA or node.
-func newTemplate(commonName string) (*x509.Certificate, error) {
+func newTemplate(commonName string, lifetime time.Duration) (*x509.Certificate, error) {
 	// Generate a random serial number.
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
@@ -87,7 +52,7 @@ func newTemplate(commonName string) (*x509.Certificate, error) {
 	}
 
 	notBefore := timeutil.Now().Add(validFrom)
-	notAfter := notBefore.Add(validFor)
+	notAfter := notBefore.Add(lifetime)
 
 	cert := &x509.Certificate{
 		SerialNumber: serialNumber,
@@ -104,17 +69,12 @@ func newTemplate(commonName string) (*x509.Certificate, error) {
 	return cert, nil
 }
 
-// GenerateCA generates a CA certificate and returns the cert bytes as
-// well as the private key used to generate the certificate.
-func GenerateCA(keySize int) ([]byte, crypto.PrivateKey, error) {
-	privateKey, publicKey, err := generateKeyPair(keySize)
+// GenerateCA generates a CA certificate and signs it using the signer (a private key).
+// It returns the DER-encoded certificate.
+func GenerateCA(signer crypto.Signer, lifetime time.Duration) ([]byte, error) {
+	template, err := newTemplate(caCommonName, lifetime)
 	if err != nil {
-		return nil, nil, err
-	}
-
-	template, err := newTemplate(caCommonName)
-	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	// Set CA-specific fields.
@@ -124,29 +84,32 @@ func GenerateCA(keySize int) ([]byte, crypto.PrivateKey, error) {
 	template.KeyUsage |= x509.KeyUsageCertSign
 	template.KeyUsage |= x509.KeyUsageContentCommitment
 
-	certBytes, err := x509.CreateCertificate(rand.Reader, template, template, publicKey, privateKey)
+	certBytes, err := x509.CreateCertificate(
+		rand.Reader,
+		template,
+		template,
+		signer.Public(),
+		signer)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return certBytes, privateKey, nil
+	return certBytes, nil
 }
 
-// GenerateServerCert generates a server certificate and returns the cert bytes as
-// well as the private key used to generate the certificate.
-// Takes in the CA cert and key, the size of the key to generate, and the list
-// of hosts/ip addresses this certificate applies to.
+// GenerateServerCert generates a server certificate and returns the cert bytes.
+// Takes in the CA cert and private key, the node public key, the certificate lifetime,
+// and the list of hosts/ip addresses this certificate applies to.
 func GenerateServerCert(
-	caCert *x509.Certificate, caKey crypto.PrivateKey, keySize int, hosts []string,
-) ([]byte, crypto.PrivateKey, error) {
-	privateKey, publicKey, err := generateKeyPair(keySize)
+	caCert *x509.Certificate,
+	caPrivateKey crypto.PrivateKey,
+	nodePublicKey crypto.PublicKey,
+	lifetime time.Duration,
+	hosts []string,
+) ([]byte, error) {
+	template, err := newTemplate(NodeUser, lifetime)
 	if err != nil {
-		return nil, nil, err
-	}
-
-	template, err := newTemplate(NodeUser)
-	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	// Only server authentication is allowed.
@@ -161,45 +124,43 @@ func GenerateServerCert(
 		}
 	}
 
-	certBytes, err := x509.CreateCertificate(rand.Reader, template, caCert, publicKey, caKey)
+	certBytes, err := x509.CreateCertificate(rand.Reader, template, caCert, nodePublicKey, caPrivateKey)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return certBytes, privateKey, nil
+	return certBytes, nil
 }
 
-// GenerateClientCert generates a client certificate and returns the cert bytes as
-// well as the private key used to generate the certificate.
-// The CA cert and private key should be passed in.
-// 'user' is the unique username stored in the Subject.CommonName field.
+// GenerateClientCert generates a client certificate and returns the cert bytes.
+// Takes in the CA cert and private key, the client public key, the certificate lifetime,
+// and the username.
 func GenerateClientCert(
-	caCert *x509.Certificate, caKey crypto.PrivateKey, keySize int, name string,
-) ([]byte, crypto.PrivateKey, error) {
-
-	privateKey, publicKey, err := generateKeyPair(keySize)
-	if err != nil {
-		return nil, nil, err
-	}
+	caCert *x509.Certificate,
+	caPrivateKey crypto.PrivateKey,
+	clientPublicKey crypto.PublicKey,
+	lifetime time.Duration,
+	user string,
+) ([]byte, error) {
 
 	// TODO(marc): should we add extra checks?
-	if len(name) == 0 {
-		return nil, nil, errors.Errorf("name cannot be empty")
+	if len(user) == 0 {
+		return nil, errors.Errorf("user cannot be empty")
 	}
 
-	template, err := newTemplate(name)
+	template, err := newTemplate(user, lifetime)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	// Set client-specific fields.
 	// Client authentication only.
 	template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
 
-	certBytes, err := x509.CreateCertificate(rand.Reader, template, caCert, publicKey, caKey)
+	certBytes, err := x509.CreateCertificate(rand.Reader, template, caCert, clientPublicKey, caPrivateKey)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return certBytes, privateKey, nil
+	return certBytes, nil
 }

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -19,7 +19,6 @@ package server
 import (
 	"fmt"
 	"net/http"
-	"path/filepath"
 	"time"
 
 	"github.com/pkg/errors"
@@ -70,9 +69,6 @@ func makeTestConfig() Config {
 	// in their init to mock out the file system calls for calls to AssetFS,
 	// which has the test certs compiled in. Typically this is done
 	// once per package, in main_test.go.
-	cfg.SSLCA = filepath.Join(security.EmbeddedCertsDir, security.EmbeddedCACert)
-	cfg.SSLCert = filepath.Join(security.EmbeddedCertsDir, security.EmbeddedNodeCert)
-	cfg.SSLCertKey = filepath.Join(security.EmbeddedCertsDir, security.EmbeddedNodeKey)
 	cfg.SSLCertsDir = security.EmbeddedCertsDir
 
 	// Addr defaults to localhost with port set at time of call to
@@ -118,15 +114,6 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	}
 	if params.ScanMaxIdleTime != 0 {
 		cfg.ScanMaxIdleTime = params.ScanMaxIdleTime
-	}
-	if params.SSLCA != "" {
-		cfg.SSLCA = params.SSLCA
-	}
-	if params.SSLCert != "" {
-		cfg.SSLCert = params.SSLCert
-	}
-	if params.SSLCertKey != "" {
-		cfg.SSLCertKey = params.SSLCertKey
 	}
 	if params.SSLCertsDir != "" {
 		cfg.SSLCertsDir = params.SSLCertsDir

--- a/pkg/testutils/base.go
+++ b/pkg/testutils/base.go
@@ -17,9 +17,6 @@
 package testutils
 
 import (
-	"fmt"
-	"path/filepath"
-
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
 )
@@ -43,15 +40,5 @@ func NewTestBaseContext(user string) *base.Config {
 
 // FillCerts sets the certs on a base.Config.
 func FillCerts(cfg *base.Config) {
-	cfg.SSLCA = filepath.Join(security.EmbeddedCertsDir, security.EmbeddedCACert)
-
-	// The NodeUser has a combined server/client certificate/key pair, all other users
-	// need client certs.
-	if cfg.User == security.NodeUser {
-		cfg.SSLCert = filepath.Join(security.EmbeddedCertsDir, security.EmbeddedNodeCert)
-		cfg.SSLCertKey = filepath.Join(security.EmbeddedCertsDir, security.EmbeddedNodeKey)
-	} else {
-		cfg.SSLCert = filepath.Join(security.EmbeddedCertsDir, fmt.Sprintf("client.%s.crt", cfg.User))
-		cfg.SSLCertKey = filepath.Join(security.EmbeddedCertsDir, fmt.Sprintf("client.%s.key", cfg.User))
-	}
+	cfg.SSLCertsDir = security.EmbeddedCertsDir
 }


### PR DESCRIPTION
Part of #1674.

The `--certs-dir` flag replaces all the certs flags, with a naming
scheme used to determine what type each file is.
The user (needed for `client.<user>.{crt,key}`) comes from
`base.Config.User`.