### PR TITLE
build: install builder container binaries into separate bin dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@
 
 artifacts
 /bin
-.bootstrap
+/bin.*
 .buildinfo
 /cockroach
 /cockroach-data
@@ -23,6 +23,11 @@ artifacts
 *.test*
 # Various `sed -i~` invocations in our scripts.
 *~
+
+# TODO(benesch): the .bootstrap file has moved into the bin directory; remove
+# this entry once it's unlikely developers have branches that straddle this
+# change (a few weeks after 4/7/2017).
+.bootstrap
 
 # Custom or private env vars (e.g. internal keys, access tokens, etc).
 customenv.mk

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -77,7 +77,7 @@ echo "${username}:x:${uid_gid}::${container_home}:/bin/bash" > "${passwd_file}"
 # created as the invoking user. Docker would otherwise create them when
 # mounting, but that would deny write access to the invoking user since docker
 # runs as root.
-mkdir -p "${HOME}"/.yarn-cache "${gocache}"/pkg/docker_amd64{,_msan,_musl,_race} "${gocache}/bin/docker_amd64"
+mkdir -p "${HOME}"/.yarn-cache "${gocache}"/pkg/docker_amd64{,_msan,_musl,_race} "${gocache}/bin/docker_amd64" "${cockroach_toplevel}/bin.docker_amd64"
 
 # Since we're mounting both /root and its subdirectories in our container,
 # Docker will create the subdirectories on the host side under the directory
@@ -120,6 +120,7 @@ if [ "${BUILDER_HIDE_GOPATH_SRC:-}" != "1" ]; then
   vols="${vols} --volume=${gopath0}/src:/go/src"
 fi
 vols="${vols} --volume=${cockroach_toplevel}:/go/src/github.com/cockroachdb/cockroach"
+vols="${vols} --volume=${cockroach_toplevel}/bin.docker_amd64:/go/src/github.com/cockroachdb/cockroach/bin"
 vols="${vols} --volume=${gocache}/pkg/docker_amd64:/go/pkg/linux_amd64"
 vols="${vols} --volume=${gocache}/pkg/docker_amd64_msan:/go/pkg/linux_amd64_msan"
 vols="${vols} --volume=${gocache}/pkg/docker_amd64_musl:/go/pkg/linux_amd64_musl"

--- a/build/common.mk
+++ b/build/common.mk
@@ -143,12 +143,17 @@ endif
 # with different CWDs decreases the chance of accidentally using the wrong path
 # to a target.
 YARN_INSTALLED_TARGET := $(UI_ROOT)/yarn.installed
-BOOTSTRAP_TARGET := $(REPO_ROOT)/.bootstrap
 
 $(YARN_INSTALLED_TARGET): $(BOOTSTRAP_TARGET) $(UI_ROOT)/package.json $(UI_ROOT)/yarn.lock
 	cd $(UI_ROOT) && yarn install
 	rm -rf $(UI_ROOT)/node_modules/@types/node # https://github.com/yarnpkg/yarn/issues/2987
 	touch $@
+
+# We store the bootstrap marker file in the bin directory so that remapping bin,
+# like we do in the builder container to allow for different host and guest
+# systems, will trigger bootstrapping in the container as necessary. This is
+# extracted into a variable for the same reasons as YARN_INSTALLED_TARGET.
+BOOTSTRAP_TARGET := $(REPO_ROOT)/bin/.bootstrap
 
 # Update the git hooks and install commands from dependencies whenever they
 # change.


### PR DESCRIPTION
Our repository-local GOBIN means it's no longer possible to have
binaries built for the host machine and builder image at the same time,
because the binaries collide in REPO_ROOT/bin. This commit remounts
REPO_ROOT/bin as REPO_ROOT/bin.docker_amd64 within the builder image to
prevent the collision.

---

This is an alternative to #14696 per @tamird's suggestions.