### PR TITLE
fix indefinite retrying for `cockroach quit` when quorum is lost #14620

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -513,6 +513,10 @@ func runStart(cmd *cobra.Command, args []string) error {
 	case err := <-errChan:
 		return err
 	case <-stopper.ShouldStop():
+		// Server is being stopped externally and our job is finished
+		// here since we don't know if it's a graceful shutdown or not.
+		<-stopper.IsStopped()
+		return nil
 	case sig := <-signalCh:
 		log.Infof(shutdownCtx, "received signal '%s'", sig)
 		if sig == os.Interrupt {
@@ -729,17 +733,22 @@ func runQuit(_ *cobra.Command, _ []string) (err error) {
 	defer stopper.Stop()
 
 	ctx := stopperContext(stopper)
-
-	if err := doShutdown(ctx, c, onModes); err != nil {
-		if _, ok := err.(*errTryHardShutdown); ok {
-			fmt.Fprintf(
-				os.Stdout, "graceful shutdown failed: %s\nproceeding with hard shutdown\n", err,
-			)
-		} else {
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- doShutdown(ctx, c, onModes)
+	}()
+	select {
+	case err := <-errChan:
+		if err != nil {
+			if _, ok := err.(errTryHardShutdown); ok {
+				fmt.Printf("graceful shutdown failed: %s; proceeding with hard shutdown\n", err)
+				break
+			}
 			return err
 		}
-	} else {
 		return nil
+	case <-time.After(time.Minute):
+		fmt.Println("timed out; proceeding with hard shutdown")
 	}
 	// Not passing drain modes tells the server to not bother and go
 	// straight to shutdown.


### PR DESCRIPTION
error log is still misleading, should we call it a graceful shutdown when a hard shutdown has been initiated?

 

```
timed out, trying again
ok
initiating graceful shutdown of server
server drained and shutdown completed
```