### PR TITLE
sql: fix adding self-ref FK to existing table

### DIFF
--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -826,12 +826,18 @@ func resolveFK(
 			}
 		}
 
-		// If we resolve the same table more than once, we only want to edit a
-		// single instance of it, so replace target with previously resolved table.
-		if prev, ok := backrefs[target.ID]; ok {
-			target = prev
+		// When adding a self-ref FK to an _existing_ table, we want to make sure
+		// we edit the same copy.
+		if target.ID == tbl.ID {
+			target = tbl
 		} else {
-			backrefs[target.ID] = target
+			// If we resolve the same table more than once, we only want to edit a
+			// single instance of it, so replace target with previously resolved table.
+			if prev, ok := backrefs[target.ID]; ok {
+				target = prev
+			} else {
+				backrefs[target.ID] = target
+			}
 		}
 	}
 

--- a/pkg/sql/testdata/logic_test/fk
+++ b/pkg/sql/testdata/logic_test/fk
@@ -576,3 +576,49 @@ INSERT INTO tx_leg VALUES (302, 3);
 
 statement ok
 COMMIT
+
+statement ok
+CREATE TABLE a (id SERIAL NOT NULL, self_id INT, b_id INT NOT NULL, PRIMARY KEY (id))
+
+statement ok
+CREATE TABLE b (id SERIAL NOT NULL, PRIMARY KEY (id))
+
+# Adding a self-ref FK to an _existing_ table also works.
+statement ok
+ALTER TABLE a ADD CONSTRAINT fk_self_id FOREIGN KEY (self_id) REFERENCES a;
+
+statement ok
+ALTER TABLE a ADD CONSTRAINT fk_b FOREIGN KEY (b_id) REFERENCES b;
+
+statement ok
+INSERT INTO b VALUES (1), (2), (3);
+
+statement ok
+INSERT INTO a VALUES (1, NULL, 1)
+
+statement ok
+INSERT INTO a VALUES (2, 1, 1), (3, 1, 2)
+
+statement ok
+INSERT INTO a VALUES (4, 2, 2)
+
+statement ok
+DELETE FROM b WHERE id = 3
+
+statement error foreign key violation
+DELETE FROM b WHERE id = 2
+
+statement error foreign key violation
+DELETE FROM a WHERE id = 1
+
+statement ok
+DELETE FROM a WHERE id > 2
+
+statement ok
+DELETE FROM b WHERE id = 2
+
+statement ok
+DROP TABLE a
+
+statement ok
+DROP TABLE b


### PR DESCRIPTION
when adding a self-ref FK, we need to make sure we edit the same copy of the descriptor when adding both the outbound and inbound refs.

Fixes #14586.