### PR TITLE
acceptance: enforce clock offsets in client

### DIFF
--- a/pkg/acceptance/terrafarm/farmer.go
+++ b/pkg/acceptance/terrafarm/farmer.go
@@ -68,7 +68,9 @@ type Farmer struct {
 	AddVars     map[string]string
 	KeepCluster string
 	nodes       []node
-	RPCContext  *rpc.Context
+	// RPCContext is used to open an ExternalClient which provides a KV connection
+	// to the cluster by gRPC.
+	RPCContext *rpc.Context
 }
 
 func (f *Farmer) refresh() {

--- a/pkg/acceptance/util.go
+++ b/pkg/acceptance/util.go
@@ -276,10 +276,28 @@ func MakeFarmer(t testing.TB, prefix string, stopper *stop.Stopper) *terrafarm.F
 		t.Fatalf("generated cluster name '%s' must match regex %s", name, prefixRE)
 	}
 
+	// We need to configure a MaxOffset on this clock so that the rpc.Context will
+	// enforce the offset. We're going to initialize the client.Txn using the
+	// Context's clock and send them through the ExternalSender, so the client's
+	// clock needs to be synchronized.
+	//
+	// TODO(andrei): It's unfortunate that this client, which is not part of the
+	// cluster, needs to do offset checks. Also, we igore the env variable that
+	// may control a different acceptable offset for the nodes in the cluster. We
+	// should stop creating transaction outside of the cluster.
+	clientClock := hlc.NewClock(hlc.UnixNano, base.DefaultMaxClockOffset)
 	rpcContext := rpc.NewContext(log.AmbientContext{}, &base.Config{
 		Insecure: true,
 		User:     security.NodeUser,
-	}, hlc.NewClock(hlc.UnixNano, 0), stopper)
+		// Set a bogus address, to be used by the clock skew checks as the ID of
+		// this "node". We can't leave it blank.
+		Addr: "acceptance test client",
+	}, clientClock, stopper)
+	rpcContext.HeartbeatCB = func() {
+		if err := rpcContext.RemoteClocks.VerifyClockOffset(context.Background()); err != nil {
+			log.Fatal(context.Background(), err)
+		}
+	}
 
 	f := &terrafarm.Farmer{
 		Output:      os.Stderr,

--- a/pkg/base/constants.go
+++ b/pkg/base/constants.go
@@ -19,6 +19,12 @@ package base
 import "time"
 
 const (
+	// DefaultMaxClockOffset is the default maximum acceptable clock offset value.
+	// On Azure, clock offsets between 250ms and 500ms are common. On AWS and GCE,
+	// clock offsets generally stay below 250ms. See comments on Config.MaxOffset
+	// for more on this setting.
+	DefaultMaxClockOffset = 500 * time.Millisecond
+
 	// DefaultHeartbeatInterval is how often heartbeats are sent from the
 	// transaction coordinator to a live transaction. These keep it from
 	// being preempted by other transactions writing the same keys. If a

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -45,11 +45,6 @@ import (
 
 // Context defaults.
 const (
-	// On Azure, clock offsets between 250ms and 500ms are common. On
-	// AWS and GCE, clock offsets generally stay below 250ms.
-	// See comments on Config.MaxOffset for more on this setting.
-	defaultMaxOffset = 500 * time.Millisecond
-
 	defaultCGroupMemPath            = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
 	defaultCacheSize                = 512 << 20 // 512 MB
 	defaultSQLMemoryPoolSize        = 512 << 20 // 512 MB
@@ -300,7 +295,7 @@ func SetOpenFileLimitForOneStore() (int, error) {
 func MakeConfig() Config {
 	cfg := Config{
 		Config:                   new(base.Config),
-		MaxOffset:                defaultMaxOffset,
+		MaxOffset:                base.DefaultMaxClockOffset,
 		CacheSize:                defaultCacheSize,
 		SQLMemoryPoolSize:        defaultSQLMemoryPoolSize,
 		ScanInterval:             defaultScanInterval,

--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -112,13 +112,14 @@ func UnixNano() int64 {
 	return timeutil.Now().UnixNano()
 }
 
-// NewClock creates a new hybrid logical clock associated
-// with the given physical clock, initializing both wall time
-// and logical time with zero.
+// NewClock creates a new hybrid logical clock associated with the given
+// physical clock. The logical ts is initialized to zero.
 //
-// The physical clock is typically given by the wall time
-// of the local machine in unix epoch nanoseconds, using
-// hlc.UnixNano. This is not a requirement.
+// The physical clock is typically given by the wall time of the local machine
+// in unix epoch nanoseconds, using hlc.UnixNano. This is not a requirement.
+//
+// A value of 0 for maxOffset means that clock skew checking, if performed on
+// this clock by RemoteClockMonitor, is disabled.
 func NewClock(physicalClock func() int64, maxOffset time.Duration) *Clock {
 	return &Clock{
 		physicalClock: physicalClock,


### PR DESCRIPTION
This patch makes the terrafarm Farmer perform clock offset checks
between the cluster's client and the cluster. Unfortunately this is
necessary even through the client is not supposed to be "part of the
cluster" because the client initializes transactions (in particular, the
OrigTimestamp field).