### PR TITLE
storage: fix command queue dependencies where candidate span is enclosed

### DIFF
--- a/pkg/sql/parallel_test.go
+++ b/pkg/sql/parallel_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -234,10 +233,6 @@ func (t *parallelTest) setup(spec *parTestSpec) {
 
 func TestParallel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-
-	if testutils.Stress() {
-		t.Skip()
-	}
 
 	glob := string(*paralleltestdata)
 	paths, err := filepath.Glob(glob)

--- a/pkg/sql/testdata/parallel_test/subquery_retry_multinode/test.yaml
+++ b/pkg/sql/testdata/parallel_test/subquery_retry_multinode/test.yaml
@@ -1,6 +1,3 @@
-# Test is temporarily disabled.
-skip_reason: "#8057"
-
 cluster_size: 5
 
 range_split_size: 32768

--- a/pkg/storage/command_queue_test.go
+++ b/pkg/storage/command_queue_test.go
@@ -468,6 +468,39 @@ func TestCommandQueueTimestamps(t *testing.T) {
 	}
 }
 
+// TestCommandQueueEnclosed verifies that the command queue doesn't
+// fail to return read-only dependencies that a candidate read/write
+// span depends on, despite there being an overlapping span which
+// completely encloses the candidate. See #14434.
+//
+//      Span  TS  RO  a  b  depends
+//         1   2   T  -     n/a
+//         2   3   F  ---   n/a
+// Candidate   1   F  -     spans 1, 2
+func TestCommandQueueEnclosed(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	cq := NewCommandQueue(true)
+
+	spans1 := []roachpb.Span{
+		mkSpan("a", ""),
+	}
+	spans2 := []roachpb.Span{
+		mkSpan("a", "b"),
+	}
+	spansCandidate := []roachpb.Span{
+		mkSpan("a", ""),
+	}
+
+	cmd1 := cq.add(true, makeTS(2, 0), spans1)
+	cmd2 := cq.add(false, makeTS(3, 0), spans2)
+
+	w := cq.getWait(false, makeTS(1, 0), spansCandidate)
+	expW := []<-chan struct{}{cmd2.pending, cmd1.pending}
+	if !reflect.DeepEqual(w, expW) {
+		t.Errorf("expected wait channels %+v; got %+v", expW, w)
+	}
+}
+
 // TestCommandQueueTimestampsEmpty verifies command queue wait
 // behavior when added commands have zero timestamps and when
 // the waiter has a zero timestamp.


### PR DESCRIPTION
Change #14342 had a bug in that it did not remove the optimization to stop
checking dependencies in the event that the range group being built up
completely enclosed the candidate span. Bailing out early is no longer
allowed because we must additionally include any read-only spans which
might not be transitively depended on by the enclosing read-write span(s).

This bug applies to both prop-eval-KV as well as non-prop-eval-KV, but
manifested much more readily with prop-eval-KV due to the massively
enclosing span which is added to provide linearizability across all ops
hitting the range's command queue.

Fixes #14434
Fixes #8057