### PR TITLE
storage: Remove propEvalKV synchronization hack

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1672,21 +1672,6 @@ func collectSpans(desc roachpb.RangeDescriptor, ba *roachpb.BatchRequest) (*Span
 	spans.Add(SpanReadOnly, roachpb.Span{Key: keys.RangeLastGCKey(ba.Header.RangeID)})
 	spans.Add(SpanReadOnly, roachpb.Span{Key: keys.RangeDescriptorKey(desc.StartKey)})
 
-	// When running with experimental proposer-evaluated KV, insert a
-	// span that effectively linearizes evaluation and application of
-	// all commands. This is horrible from a performance perspective
-	// but is required for correctness until work in #6290 is addressed.
-	if propEvalKV {
-		access := SpanReadWrite
-		if ba.IsReadOnly() {
-			access = SpanReadOnly
-		}
-		spans.Add(access, roachpb.Span{
-			Key:    keys.LocalMax,
-			EndKey: keys.MaxKey,
-		})
-	}
-
 	// If any command gave us spans that are invalid, bail out early
 	// (before passing them to the command queue, which may panic).
 	if err := spans.validate(); err != nil {


### PR DESCRIPTION
This is no longer necessary now that everything is properly accounted
for in the command queue.

Fixes #10413 

I had this commit ready to go when #14434 was discovered, but now that that's been fixed with #14733 I think it's ready to go again. This isn't quite the end of command-queue tweaks for propEvalKV, but we're far enough along that we no longer need this hack. (and it's time to start testing without it to validate this assertion)