### PR TITLE
storage: add the ability to set/adjust zone configs for system ranges

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -654,6 +654,9 @@ func Example_zone() {
 	// Output:
 	// zone ls
 	// .default
+	// .meta
+	// .identifier
+	// .system
 	// zone set system --file=./testdata/zone_attrs.yaml
 	// range_min_bytes: 1048576
 	// range_max_bytes: 67108864
@@ -663,6 +666,9 @@ func Example_zone() {
 	// constraints: [us-east-1a, ssd]
 	// zone ls
 	// .default
+	// .meta
+	// .identifier
+	// .system
 	// system
 	// zone get system.nonexistent
 	// system.nonexistent not found
@@ -693,6 +699,9 @@ func Example_zone() {
 	// DELETE 1
 	// zone ls
 	// .default
+	// .meta
+	// .identifier
+	// .system
 	// zone rm .default
 	// unable to remove .default
 	// zone set .default --file=./testdata/zone_range_max_bytes.yaml

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -654,8 +654,8 @@ func Example_zone() {
 	// Output:
 	// zone ls
 	// .default
-	// .meta
 	// .identifier
+	// .meta
 	// .system
 	// zone set system --file=./testdata/zone_attrs.yaml
 	// range_min_bytes: 1048576
@@ -666,8 +666,8 @@ func Example_zone() {
 	// constraints: [us-east-1a, ssd]
 	// zone ls
 	// .default
-	// .meta
 	// .identifier
+	// .meta
 	// .system
 	// system
 	// zone get system.nonexistent
@@ -699,8 +699,8 @@ func Example_zone() {
 	// DELETE 1
 	// zone ls
 	// .default
-	// .meta
 	// .identifier
+	// .meta
 	// .system
 	// zone rm .default
 	// unable to remove .default

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -497,23 +497,29 @@ func Example_ranges() {
 	// 4 result(s)
 	// debug range split ranges3
 	// debug range ls
-	// /Min-"ranges3" [1]
+	// /Min-/System/"" [1]
 	// 	0: node-id=1 store-id=1
-	// "ranges3"-/Table/0 [8]
+	// /System/""-/System/tsd [2]
 	// 	0: node-id=1 store-id=1
-	// /Table/0-/Table/11 [2]
+	// /System/tsd-/System/"tse" [3]
 	// 	0: node-id=1 store-id=1
-	// /Table/11-/Table/12 [3]
+	// /System/"tse"-"ranges3" [4]
 	// 	0: node-id=1 store-id=1
-	// /Table/12-/Table/13 [4]
+	// "ranges3"-/Table/0 [11]
 	// 	0: node-id=1 store-id=1
-	// /Table/13-/Table/14 [5]
+	// /Table/0-/Table/11 [5]
 	// 	0: node-id=1 store-id=1
-	// /Table/14-/Table/15 [6]
+	// /Table/11-/Table/12 [6]
 	// 	0: node-id=1 store-id=1
-	// /Table/15-/Max [7]
+	// /Table/12-/Table/13 [7]
 	// 	0: node-id=1 store-id=1
-	// 8 result(s)
+	// /Table/13-/Table/14 [8]
+	// 	0: node-id=1 store-id=1
+	// /Table/14-/Table/15 [9]
+	// 	0: node-id=1 store-id=1
+	// /Table/15-/Max [10]
+	// 	0: node-id=1 store-id=1
+	// 11 result(s)
 	// debug kv scan
 	// "ranges1"	"1"
 	// "ranges2"	"2"
@@ -609,7 +615,7 @@ func Example_max_results() {
 	c.Run("debug kv revscan --max-results=2")
 	c.Run("debug range split max_results3")
 	c.Run("debug range split max_results4")
-	c.Run("debug range ls --max-results=2")
+	c.Run("debug range ls --max-results=5")
 
 	// Output:
 	// debug kv put max_results1 1 max_results2 2 max_results3 3 max_results4 4
@@ -624,12 +630,18 @@ func Example_max_results() {
 	// 2 result(s)
 	// debug range split max_results3
 	// debug range split max_results4
-	// debug range ls --max-results=2
-	// /Min-"max_results3" [1]
+	// debug range ls --max-results=5
+	// /Min-/System/"" [1]
 	// 	0: node-id=1 store-id=1
-	// "max_results3"-"max_results4" [8]
+	// /System/""-/System/tsd [2]
 	// 	0: node-id=1 store-id=1
-	// 2 result(s)
+	// /System/tsd-/System/"tse" [3]
+	// 	0: node-id=1 store-id=1
+	// /System/"tse"-"max_results3" [4]
+	// 	0: node-id=1 store-id=1
+	// "max_results3"-"max_results4" [11]
+	// 	0: node-id=1 store-id=1
+	// 5 result(s)
 }
 
 func Example_zone() {
@@ -646,17 +658,27 @@ func Example_zone() {
 	c.Run("zone rm system")
 	c.Run("zone ls")
 	c.Run("zone rm .default")
+	c.Run("zone set .meta --file=./testdata/zone_range_max_bytes.yaml")
+	c.Run("zone set .system --file=./testdata/zone_range_max_bytes.yaml")
+	c.Run("zone set .timeseries --file=./testdata/zone_range_max_bytes.yaml")
+	c.Run("zone get .system")
+	c.Run("zone ls")
 	c.Run("zone set .default --file=./testdata/zone_range_max_bytes.yaml")
 	c.Run("zone get system")
 	c.Run("zone set .default --disable-replication")
 	c.Run("zone get system")
+	c.Run("zone rm .meta")
+	c.Run("zone rm .system")
+	c.Run("zone ls")
+	c.Run("zone rm .timeseries")
+	c.Run("zone ls")
+	c.Run("zone rm .meta")
+	c.Run("zone rm .system")
+	c.Run("zone rm .timeseries")
 
 	// Output:
 	// zone ls
 	// .default
-	// .identifier
-	// .meta
-	// .system
 	// zone set system --file=./testdata/zone_attrs.yaml
 	// range_min_bytes: 1048576
 	// range_max_bytes: 67108864
@@ -666,9 +688,6 @@ func Example_zone() {
 	// constraints: [us-east-1a, ssd]
 	// zone ls
 	// .default
-	// .identifier
-	// .meta
-	// .system
 	// system
 	// zone get system.nonexistent
 	// system.nonexistent not found
@@ -699,11 +718,42 @@ func Example_zone() {
 	// DELETE 1
 	// zone ls
 	// .default
-	// .identifier
+	// zone rm .default
+	// unable to remove special zone .default
+	// zone set .meta --file=./testdata/zone_range_max_bytes.yaml
+	// range_min_bytes: 0
+	// range_max_bytes: 134217728
+	// gc:
+	//   ttlseconds: 0
+	// num_replicas: 3
+	// constraints: []
+	// zone set .system --file=./testdata/zone_range_max_bytes.yaml
+	// range_min_bytes: 0
+	// range_max_bytes: 134217728
+	// gc:
+	//   ttlseconds: 0
+	// num_replicas: 3
+	// constraints: []
+	// zone set .timeseries --file=./testdata/zone_range_max_bytes.yaml
+	// range_min_bytes: 0
+	// range_max_bytes: 134217728
+	// gc:
+	//   ttlseconds: 0
+	// num_replicas: 3
+	// constraints: []
+	// zone get .system
+	// .system
+	// range_min_bytes: 0
+	// range_max_bytes: 134217728
+	// gc:
+	//   ttlseconds: 0
+	// num_replicas: 3
+	// constraints: []
+	// zone ls
+	// .default
 	// .meta
 	// .system
-	// zone rm .default
-	// unable to remove .default
+	// .timeseries
 	// zone set .default --file=./testdata/zone_range_max_bytes.yaml
 	// range_min_bytes: 1048576
 	// range_max_bytes: 134217728
@@ -734,6 +784,23 @@ func Example_zone() {
 	//   ttlseconds: 86400
 	// num_replicas: 1
 	// constraints: []
+	// zone rm .meta
+	// DELETE 1
+	// zone rm .system
+	// DELETE 1
+	// zone ls
+	// .default
+	// .timeseries
+	// zone rm .timeseries
+	// DELETE 1
+	// zone ls
+	// .default
+	// zone rm .meta
+	// DELETE 0
+	// zone rm .system
+	// DELETE 0
+	// zone rm .timeseries
+	// DELETE 0
 }
 
 func Example_sql() {
@@ -1669,6 +1736,9 @@ writing ` + os.DevNull + `
   debug/nodes/1/ranges/5
   debug/nodes/1/ranges/6
   debug/nodes/1/ranges/7
+  debug/nodes/1/ranges/8
+  debug/nodes/1/ranges/9
+  debug/nodes/1/ranges/10
   debug/schema/system@details
   debug/schema/system/descriptor
   debug/schema/system/eventlog

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -412,7 +412,8 @@ func (s SystemConfig) GetZoneConfigForKey(key roachpb.RKey) (ZoneConfig, error) 
 		objectID = keys.MetaSystemID
 	}
 	if bytes.HasPrefix(key, keys.SystemPrefix) {
-		if bytes.HasPrefix(key, keys.TimeseriesPrefix) || bytes.HasPrefix(key, keys.StatusPrefix) || bytes.HasPrefix(key, keys.UpdateCheckPrefix) {
+		if bytes.HasPrefix(key, keys.TimeseriesPrefix) || bytes.HasPrefix(key, keys.StatusPrefix) ||
+			bytes.HasPrefix(key, keys.ReportUsagePrefix) {
 			objectID = keys.NormalSystemID
 		}
 		objectID = keys.IdentifierSystemID

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,39 +53,6 @@ var (
 		},
 	}
 
-	// metaZoneConfig is meta1/meta2 zone configuration used when no custom
-	// config has been specified.
-	metaZoneConfig = ZoneConfig{
-		NumReplicas:   3,
-		RangeMinBytes: 1 << 20,  // 1 MB
-		RangeMaxBytes: 64 << 20, // 64 MB
-		GC: GCPolicy{
-			TTLSeconds: 24 * 60 * 60, // 1 day
-		},
-	}
-
-	// identifierZoneConfig is the default zone configuration for system key which has
-	// prefix 'NodeLivenessPrefix', 'DescIDGenerator', 'NodeIDGenerator', '',
-	// 'RangeIDGenerator', 'StoreIDGenerator' etc.
-	identifierZoneConfig = ZoneConfig{
-		NumReplicas:   5,
-		RangeMinBytes: 1 << 20,  // 1 MB
-		RangeMaxBytes: 64 << 20, // 64 MB
-		GC: GCPolicy{
-			TTLSeconds: 24 * 60 * 60, // 1 day
-		},
-	}
-
-	// systemZoneConfig is the default zone configuration for other system keys.
-	systemZoneConfig = ZoneConfig{
-		NumReplicas:   3,
-		RangeMinBytes: 1 << 20,  // 1 MB
-		RangeMaxBytes: 64 << 20, // 64 MB
-		GC: GCPolicy{
-			TTLSeconds: 24 * 60 * 60, // 1 day
-		},
-	}
-
 	// ZoneConfigHook is a function used to lookup a zone config given a table
 	// or database ID.
 	// This is also used by testing to simplify fake configs.
@@ -169,27 +136,6 @@ func DefaultZoneConfig() ZoneConfig {
 	testingLock.Lock()
 	defer testingLock.Unlock()
 	return defaultZoneConfig
-}
-
-// MetaZoneConfig is the default meta1/meta2 zone configuration.
-func MetaZoneConfig() ZoneConfig {
-	testingLock.Lock()
-	defer testingLock.Unlock()
-	return metaZoneConfig
-}
-
-// IdetifierZoneConfig is a plumb function for idetifierZoneConfig.
-func IdetifierZoneConfig() ZoneConfig {
-	testingLock.Lock()
-	defer testingLock.Unlock()
-	return identifierZoneConfig
-}
-
-// SystemZoneConfig is a plumb function for systemZoneConfig.
-func SystemZoneConfig() ZoneConfig {
-	testingLock.Lock()
-	defer testingLock.Unlock()
-	return systemZoneConfig
 }
 
 // TestingSetDefaultZoneConfig is a testing-only function that changes the
@@ -408,16 +354,16 @@ func (s SystemConfig) GetZoneConfigForKey(key roachpb.RKey) (ZoneConfig, error) 
 		// For now, only user databases and tables get custom zone configs.
 		objectID = keys.RootNamespaceID
 	}
-	if bytes.HasPrefix(key, keys.Meta1Prefix) || bytes.HasPrefix(key, keys.Meta2Prefix) {
-		objectID = keys.MetaSystemID
+
+	// Special-case known system ranges to their special zone configs.
+	if key.Equal(roachpb.RKeyMin) || bytes.HasPrefix(key, keys.Meta1Prefix) || bytes.HasPrefix(key, keys.Meta2Prefix) {
+		objectID = keys.MetaRangesID
+	} else if bytes.HasPrefix(key, keys.TimeseriesPrefix) {
+		objectID = keys.TimeseriesRangesID
+	} else if bytes.HasPrefix(key, keys.SystemPrefix) {
+		objectID = keys.SystemRangesID
 	}
-	if bytes.HasPrefix(key, keys.SystemPrefix) {
-		if bytes.HasPrefix(key, keys.TimeseriesPrefix) || bytes.HasPrefix(key, keys.StatusPrefix) ||
-			bytes.HasPrefix(key, keys.ReportUsagePrefix) {
-			objectID = keys.NormalSystemID
-		}
-		objectID = keys.IdentifierSystemID
-	}
+
 	return s.getZoneConfigForID(objectID)
 }
 
@@ -433,26 +379,64 @@ func (s SystemConfig) getZoneConfigForID(id uint32) (ZoneConfig, error) {
 	return DefaultZoneConfig(), nil
 }
 
+// StaticSplits is the list of pre-defined split points in the beginning of
+// the keyspace that are there to support separate zone configs for different
+// parts of the system / system config ranges.
+// Exposed publicly so that its ordering can be tested.
+var StaticSplits = []struct {
+	SplitPoint roachpb.RKey
+	SplitKey   roachpb.RKey
+}{
+	// End of meta records / start of system ranges
+	{
+		SplitPoint: roachpb.RKey(keys.SystemPrefix),
+		SplitKey:   roachpb.RKey(keys.SystemPrefix),
+	},
+	// Start of timeseries ranges (within system ranges)
+	{
+		SplitPoint: roachpb.RKey(keys.TimeseriesPrefix),
+		SplitKey:   roachpb.RKey(keys.TimeseriesPrefix),
+	},
+	// End of timeseries ranges (continuation of system ranges)
+	{
+		SplitPoint: roachpb.RKey(keys.TimeseriesPrefix.PrefixEnd()),
+		SplitKey:   roachpb.RKey(keys.TimeseriesPrefix.PrefixEnd()),
+	},
+	// System config tables (end of system ranges)
+	{
+		SplitPoint: roachpb.RKey(keys.TableDataMin),
+		SplitKey:   keys.SystemConfigSplitKey,
+	},
+}
+
 // ComputeSplitKey takes a start and end key and returns the first key at which
 // to split the span [start, end). Returns nil if no splits are required.
 //
-// Splits are required between user tables (i.e. /table/<id>) and at the start
-// of the system-config range (i.e. /table/0). The system-config range is
-// somewhat special in that it contains multiple SQL tables
-// (/table/0-/table/<max-system-config-desc>) which must be contained in a
-// single range.
+// Splits are required between user tables (i.e. /table/<id>), at the start
+// of the system-config tables (i.e. /table/0), and at certain points within the
+// system ranges that come before the system tables. The system-config range is
+// somewhat special in that it can contain multiple SQL tables
+// (/table/0-/table/<max-system-config-desc>) within a single range.
 func (s SystemConfig) ComputeSplitKey(startKey, endKey roachpb.RKey) roachpb.RKey {
-	systemConfigStart := roachpb.RKey(keys.TableDataMin)
-	if !systemConfigStart.Less(endKey) {
-		// endKey <= systemConfigStart: no required splits.
-		return nil
-	}
-	if startKey.Less(systemConfigStart) {
-		// startKey < systemConfigStart: split the range at the start of the system
-		// config span.
-		return keys.SystemConfigSplitKey
+	// Before dealing with splits necessitated by SQL tables, handle all of the
+	// static splits earlier in the keyspace. Note that this list must be kept in
+	// the proper order (ascending in the keyspace) for the logic below to work.
+	for _, split := range StaticSplits {
+		if startKey.Less(split.SplitPoint) {
+			if split.SplitPoint.Less(endKey) {
+				// The split point is contained within [startKey, endKey), so we need to
+				// create the split.
+				return split.SplitKey
+			}
+			// [startKey, endKey) is contained between the previous split point and
+			// this split point.
+			return nil
+		}
+		// [startKey, endKey) is somewhere greater than this split point. Continue.
 	}
 
+	// If the above iteration over the static split points didn't decide anything,
+	// the key range must be somewhere in the SQL table part of the keyspace.
 	startID, ok := ObjectIDForKey(startKey)
 	if !ok || startID <= keys.MaxSystemConfigDescID {
 		// The start key is either:
@@ -478,7 +462,7 @@ func (s SystemConfig) ComputeSplitKey(startKey, endKey roachpb.RKey) roachpb.RKe
 		// endID could be smaller than startID if we don't have user tables.
 		for id := startID; id <= endID; id++ {
 			key := roachpb.RKey(keys.MakeRowSentinelKey(keys.MakeTablePrefix(id)))
-			// Skip if this ID matches the startKey passed to ComputeSplitKeys.
+			// Skip if this ID matches the provided startKey.
 			if !startKey.Less(key) {
 				continue
 			}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -209,13 +209,90 @@ func TestGetLargestID(t *testing.T) {
 	}
 }
 
-func TestComputeSplits(t *testing.T) {
+func TestStaticSplits(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	for i := range config.StaticSplits {
+		if config.StaticSplits[i].SplitKey.Less(config.StaticSplits[i].SplitPoint) {
+			t.Errorf("SplitKey %q should not be less than SplitPoint %q",
+				config.StaticSplits[i].SplitKey, config.StaticSplits[i].SplitPoint)
+		}
+		if i == 0 {
+			continue
+		}
+		if !config.StaticSplits[i-1].SplitKey.Less(config.StaticSplits[i].SplitPoint) {
+			t.Errorf("previous SplitKey %q should be less than next SplitPoint %q",
+				config.StaticSplits[i-1].SplitKey, config.StaticSplits[i].SplitPoint)
+		}
+	}
+}
+
+// TestComputeSplitKeyTableIDs tests ComputeSplitKey for cases where the split
+// is within the system ranges. Other cases are tested below by
+// TestComputeSplitKeyTableIDs.
+func TestComputeSplitKeySystemRanges(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		start, end roachpb.RKey
+		split      roachpb.Key
+	}{
+		{roachpb.RKeyMin, roachpb.RKeyMax, keys.SystemPrefix},
+		{roachpb.RKeyMin, keys.MakeTablePrefix(1), keys.SystemPrefix},
+		{roachpb.RKeyMin, roachpb.RKey(keys.TimeseriesPrefix), keys.SystemPrefix},
+		{roachpb.RKeyMin, roachpb.RKey(keys.SystemPrefix.Next()), keys.SystemPrefix},
+		{roachpb.RKeyMin, roachpb.RKey(keys.SystemPrefix), nil},
+		{roachpb.RKeyMin, roachpb.RKey(keys.MetaMax), nil},
+		{roachpb.RKeyMin, roachpb.RKey(keys.Meta2KeyMax), nil},
+		{roachpb.RKeyMin, roachpb.RKey(keys.Meta1KeyMax), nil},
+		{roachpb.RKey(keys.Meta1KeyMax), roachpb.RKey(keys.SystemPrefix), nil},
+		{roachpb.RKey(keys.Meta1KeyMax), roachpb.RKey(keys.SystemPrefix.Next()), keys.SystemPrefix},
+		{roachpb.RKey(keys.Meta1KeyMax), roachpb.RKeyMax, keys.SystemPrefix},
+		{roachpb.RKey(keys.SystemPrefix), roachpb.RKey(keys.SystemPrefix), nil},
+		{roachpb.RKey(keys.SystemPrefix), roachpb.RKey(keys.SystemPrefix.Next()), nil},
+		{roachpb.RKey(keys.SystemPrefix), roachpb.RKeyMax, keys.TimeseriesPrefix},
+		{roachpb.RKey(keys.MigrationPrefix), roachpb.RKey(keys.NodeLivenessPrefix), nil},
+		{roachpb.RKey(keys.MigrationPrefix), roachpb.RKey(keys.NodeLivenessKeyMax), nil},
+		{roachpb.RKey(keys.MigrationPrefix), roachpb.RKey(keys.StoreIDGenerator), nil},
+		{roachpb.RKey(keys.MigrationPrefix), roachpb.RKey(keys.TimeseriesPrefix), nil},
+		{roachpb.RKey(keys.MigrationPrefix), roachpb.RKey(keys.TimeseriesPrefix.Next()), keys.TimeseriesPrefix},
+		{roachpb.RKey(keys.MigrationPrefix), roachpb.RKeyMax, keys.TimeseriesPrefix},
+		{roachpb.RKey(keys.TimeseriesPrefix), roachpb.RKey(keys.TimeseriesPrefix.Next()), nil},
+		{roachpb.RKey(keys.TimeseriesPrefix), roachpb.RKey(keys.TimeseriesPrefix.PrefixEnd()), nil},
+		{roachpb.RKey(keys.TimeseriesPrefix), roachpb.RKey(keys.ReportUsagePrefix), keys.TimeseriesPrefix.PrefixEnd()},
+		{roachpb.RKey(keys.TimeseriesPrefix), roachpb.RKeyMax, keys.TimeseriesPrefix.PrefixEnd()},
+		{roachpb.RKey(keys.TimeseriesPrefix.PrefixEnd()), roachpb.RKey(keys.TimeseriesPrefix.PrefixEnd()), nil},
+		{roachpb.RKey(keys.TimeseriesPrefix.PrefixEnd()), roachpb.RKeyMax, keys.SystemConfigSplitKey},
+	}
+
+	cfg := config.SystemConfig{
+		Values: sqlbase.MakeMetadataSchema().GetInitialValues(),
+	}
+	for tcNum, tc := range testCases {
+		splitKey := cfg.ComputeSplitKey(tc.start, tc.end)
+		expected := roachpb.RKey(tc.split)
+		if !splitKey.Equal(expected) {
+			t.Errorf("#%d: bad split:\ngot: %v\nexpected: %v", tcNum, splitKey, expected)
+		}
+	}
+}
+
+// TestComputeSplitKeyTableIDs tests ComputeSplitKey for cases where the split
+// is at the start of a SQL table. Other cases are tested above by
+// TestComputeSplitKeySystemRanges.
+func TestComputeSplitKeyTableIDs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	const (
 		start         = keys.MaxReservedDescID + 1
 		reservedStart = keys.MaxSystemConfigDescID + 1
 	)
+
+	// Used in place of roachpb.RKeyMin in order to test the behavior of splits
+	// at the start of the system config and user tables rather than within the
+	// system ranges that come earlier in the keyspace. Those splits are tested
+	// separately above.
+	minKey := roachpb.RKey(keys.TimeseriesPrefix.PrefixEnd())
 
 	schema := sqlbase.MakeMetadataSchema()
 	// Real system tables only.
@@ -231,20 +308,20 @@ func TestComputeSplits(t *testing.T) {
 		split      int32 // -1 to indicate no split is expected
 	}{
 		// No data.
-		{nil, roachpb.RKeyMin, roachpb.RKeyMax, 0},
+		{nil, minKey, roachpb.RKeyMax, 0},
 		{nil, keys.MakeTablePrefix(start), roachpb.RKeyMax, -1},
 		{nil, keys.MakeTablePrefix(start), keys.MakeTablePrefix(start + 10), -1},
-		{nil, roachpb.RKeyMin, keys.MakeTablePrefix(start + 10), 0},
+		{nil, minKey, keys.MakeTablePrefix(start + 10), 0},
 
 		// Reserved descriptors.
-		{baseSql, roachpb.RKeyMin, roachpb.RKeyMax, 0},
+		{baseSql, minKey, roachpb.RKeyMax, 0},
 		{baseSql, keys.MakeTablePrefix(start), roachpb.RKeyMax, -1},
 		{baseSql, keys.MakeTablePrefix(start), keys.MakeTablePrefix(start + 10), -1},
-		{baseSql, roachpb.RKeyMin, keys.MakeTablePrefix(start + 10), 0},
+		{baseSql, minKey, keys.MakeTablePrefix(start + 10), 0},
 		{baseSql, keys.MakeTablePrefix(reservedStart), roachpb.RKeyMax, reservedStart + 1},
 		{baseSql, keys.MakeTablePrefix(reservedStart), keys.MakeTablePrefix(start + 10), reservedStart + 1},
-		{baseSql, roachpb.RKeyMin, keys.MakeTablePrefix(reservedStart + 2), 0},
-		{baseSql, roachpb.RKeyMin, keys.MakeTablePrefix(reservedStart + 10), 0},
+		{baseSql, minKey, keys.MakeTablePrefix(reservedStart + 2), 0},
+		{baseSql, minKey, keys.MakeTablePrefix(reservedStart + 10), 0},
 		{baseSql, keys.MakeTablePrefix(reservedStart), keys.MakeTablePrefix(reservedStart + 2), reservedStart + 1},
 		{baseSql, testutils.MakeKey(keys.MakeTablePrefix(reservedStart), roachpb.RKey("foo")),
 			testutils.MakeKey(keys.MakeTablePrefix(start+10), roachpb.RKey("foo")), reservedStart + 1},
@@ -265,10 +342,10 @@ func TestComputeSplits(t *testing.T) {
 			testutils.MakeKey(keys.MakeTablePrefix(start+5), roachpb.RKey("bar")), start + 1},
 		{allSql, testutils.MakeKey(keys.MakeTablePrefix(start), roachpb.RKey("foo")),
 			testutils.MakeKey(keys.MakeTablePrefix(start), roachpb.RKey("morefoo")), -1},
-		{allSql, roachpb.RKeyMin, roachpb.RKeyMax, 0},
+		{allSql, minKey, roachpb.RKeyMax, 0},
 		{allSql, keys.MakeTablePrefix(reservedStart + 1), roachpb.RKeyMax, reservedStart + 2},
 		{allSql, keys.MakeTablePrefix(reservedStart), keys.MakeTablePrefix(start + 10), reservedStart + 1},
-		{allSql, roachpb.RKeyMin, keys.MakeTablePrefix(start + 2), 0},
+		{allSql, minKey, keys.MakeTablePrefix(start + 2), 0},
 		{allSql, testutils.MakeKey(keys.MakeTablePrefix(reservedStart), roachpb.RKey("foo")),
 			testutils.MakeKey(keys.MakeTablePrefix(start+5), roachpb.RKey("foo")), reservedStart + 1},
 	}
@@ -286,6 +363,62 @@ func TestComputeSplits(t *testing.T) {
 		}
 		if !splitKey.Equal(expected) {
 			t.Errorf("#%d: bad split:\ngot: %v\nexpected: %v", tcNum, splitKey, expected)
+		}
+	}
+}
+
+func TestGetZoneConfigForKey(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		key        roachpb.RKey
+		expectedID uint32
+	}{
+		{keys.MakeTablePrefix(keys.MaxReservedDescID + 1), keys.MaxReservedDescID + 1},
+		{keys.MakeTablePrefix(keys.MaxReservedDescID + 23), keys.MaxReservedDescID + 23},
+		{roachpb.RKeyMin, keys.MetaRangesID},
+		{roachpb.RKey(keys.Meta1Prefix), keys.MetaRangesID},
+		{roachpb.RKey(keys.Meta1Prefix.Next()), keys.MetaRangesID},
+		{roachpb.RKey(keys.Meta2Prefix), keys.MetaRangesID},
+		{roachpb.RKey(keys.Meta2Prefix.Next()), keys.MetaRangesID},
+		{roachpb.RKey(keys.MetaMax), keys.SystemRangesID},
+		{roachpb.RKey(keys.SystemPrefix), keys.SystemRangesID},
+		{roachpb.RKey(keys.SystemPrefix.Next()), keys.SystemRangesID},
+		{roachpb.RKey(keys.MigrationLease), keys.SystemRangesID},
+		{roachpb.RKey(keys.NodeLivenessPrefix), keys.SystemRangesID},
+		{roachpb.RKey(keys.DescIDGenerator), keys.SystemRangesID},
+		{roachpb.RKey(keys.NodeIDGenerator), keys.SystemRangesID},
+		{roachpb.RKey(keys.RangeIDGenerator), keys.SystemRangesID},
+		{roachpb.RKey(keys.StoreIDGenerator), keys.SystemRangesID},
+		{roachpb.RKey(keys.StatusPrefix), keys.SystemRangesID},
+		{roachpb.RKey(keys.ReportUsagePrefix), keys.SystemRangesID},
+		{roachpb.RKey(keys.TimeseriesPrefix), keys.TimeseriesRangesID},
+		{roachpb.RKey(keys.TimeseriesPrefix.Next()), keys.TimeseriesRangesID},
+		{roachpb.RKey(keys.TimeseriesPrefix.PrefixEnd()), keys.SystemRangesID},
+		{roachpb.RKey(keys.TableDataMin), keys.RootNamespaceID},
+		{roachpb.RKey(keys.SystemConfigSplitKey), keys.RootNamespaceID},
+		{keys.MakeTablePrefix(keys.ZonesTableID), keys.RootNamespaceID},
+	}
+
+	originalZoneConfigHook := config.ZoneConfigHook
+	defer func() {
+		config.ZoneConfigHook = originalZoneConfigHook
+	}()
+	cfg := config.SystemConfig{
+		Values: sqlbase.MakeMetadataSchema().GetInitialValues(),
+	}
+	for tcNum, tc := range testCases {
+		var objectID uint32
+		config.ZoneConfigHook = func(_ config.SystemConfig, id uint32) (config.ZoneConfig, bool, error) {
+			objectID = id
+			return config.ZoneConfig{}, false, nil
+		}
+		_, err := cfg.GetZoneConfigForKey(tc.key)
+		if err != nil {
+			t.Errorf("#%d: GetZoneConfigForKey(%v) got error: %v", tcNum, tc.key, err)
+		}
+		if objectID != tc.expectedID {
+			t.Errorf("#%d: GetZoneConfigForKey(%v) got %d; want %d", tcNum, tc.key, objectID, tc.expectedID)
 		}
 	}
 }

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -288,10 +288,6 @@ const (
 	ZonesTableID      = 5
 	SettingsTableID   = 6
 
-	MetaSystemID       = 15
-	IdentifierSystemID = 16
-	NormalSystemID     = 17
-
 	// Reserved IDs for other system tables. If you're adding a new system table,
 	// it probably belongs here.
 	// NOTE: IDs must be <= MaxReservedDescID.
@@ -300,4 +296,8 @@ const (
 	RangeEventTableID = 13
 	UITableID         = 14
 	JobsTableID       = 15
+
+	MetaSystemID       = 16
+	IdentifierSystemID = 17
+	NormalSystemID     = 18
 )

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -288,6 +288,10 @@ const (
 	ZonesTableID      = 5
 	SettingsTableID   = 6
 
+	MetaSystemID       = 15
+	IdentifierSystemID = 16
+	NormalSystemID     = 17
+
 	// Reserved IDs for other system tables. If you're adding a new system table,
 	// it probably belongs here.
 	// NOTE: IDs must be <= MaxReservedDescID.

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -297,7 +297,10 @@ const (
 	UITableID         = 14
 	JobsTableID       = 15
 
-	MetaSystemID       = 16
-	IdentifierSystemID = 17
-	NormalSystemID     = 18
+	// Reserved IDs used to refer to certain parts of the system ranges that
+	// come before the system config span and user table ranges.
+	// NOTE: IDs must be <= MaxReservedDescID.
+	MetaRangesID       = 16
+	SystemRangesID     = 17
+	TimeseriesRangesID = 18
 )

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -627,7 +627,7 @@ func EnsureSafeSplitKey(key roachpb.Key) (roachpb.Key, error) {
 		// then we bail. Note that we don't consider this an error because
 		// EnsureSafeSplitKey can be called on keys that look like table
 		// keys but which do not have a column ID length suffix (e.g
-		// SystemConfig.ComputeSplitKeys).
+		// by SystemConfig.ComputeSplitKey).
 		return nil, errors.Errorf("%s: malformed table key", key)
 	}
 	return key[:len(key)-int(colIDLen)-1], nil

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -326,6 +326,7 @@ func eventlogUniqueIDDefault(ctx context.Context, r runner) error {
 	return err
 }
 
+// TODO(a-robinson): Write unit test for this.
 func createJobsTable(ctx context.Context, r runner) error {
 	// We install the table at the KV layer so that we can choose a known ID in
 	// the reserved ID space. (The SQL layer doesn't allow this.)
@@ -341,6 +342,7 @@ func createJobsTable(ctx context.Context, r runner) error {
 	})
 }
 
+// TODO(a-robinson): Write unit test for this.
 func createSettingsTable(ctx context.Context, r runner) error {
 	// We install the table at the KV layer so that we can choose a known ID in
 	// the reserved ID space. (The SQL layer doesn't allow this.)

--- a/pkg/sql/sqlbase/metadata.go
+++ b/pkg/sql/sqlbase/metadata.go
@@ -184,6 +184,10 @@ func (ms MetadataSchema) GetInitialValues() []roachpb.KeyValue {
 // needed. See server.ExpectedInitialRangeCount() for a count that includes
 // migrations.
 func (ms MetadataSchema) InitialRangeCount() int {
-	const fixedRanges = 2 /* first-range + system-config-range */
+	// The number of fixed ranges is determined by the pre-defined split points
+	// in SystemConfig.ComputeSplitKey. The early keyspace is split up in order
+	// to support separate zone configs for different parts of the system ranges.
+	// There are 4 pre-defined split points, so 5 fixed ranges.
+	const fixedRanges = 5
 	return len(ms.descs) - ms.configs + fixedRanges
 }

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -539,6 +539,48 @@ func createDefaultZoneConfig() []roachpb.KeyValue {
 	return ret
 }
 
+func createMetaZoneConfig() []roachpb.KeyValue {
+	var ret []roachpb.KeyValue
+	value := roachpb.Value{}
+	desc := config.MetaZoneConfig()
+	if err := value.SetProto(&desc); err != nil {
+		log.Fatalf(context.TODO(), "could not marshal %v", desc)
+	}
+	ret = append(ret, roachpb.KeyValue{
+		Key:   MakeZoneKey(keys.MetaSystemID),
+		Value: value,
+	})
+	return ret
+}
+
+func createIdentifierZoneConfig() []roachpb.KeyValue {
+	var ret []roachpb.KeyValue
+	value := roachpb.Value{}
+	desc := config.IdetifierZoneConfig()
+	if err := value.SetProto(&desc); err != nil {
+		log.Fatalf(context.TODO(), "could not marshal %v", desc)
+	}
+	ret = append(ret, roachpb.KeyValue{
+		Key:   MakeZoneKey(keys.IdentifierSystemID),
+		Value: value,
+	})
+	return ret
+}
+
+func createSystemZoneConfig() []roachpb.KeyValue {
+	var ret []roachpb.KeyValue
+	value := roachpb.Value{}
+	desc := config.SystemZoneConfig()
+	if err := value.SetProto(&desc); err != nil {
+		log.Fatalf(context.TODO(), "could not marshal %v", desc)
+	}
+	ret = append(ret, roachpb.KeyValue{
+		Key:   MakeZoneKey(keys.NormalSystemID),
+		Value: value,
+	})
+	return ret
+}
+
 // addSystemDatabaseToSchema populates the supplied MetadataSchema with the
 // System database and its tables. The descriptors for these objects exist
 // statically in this file, but a MetadataSchema can be used to persist these
@@ -568,6 +610,9 @@ func addSystemDatabaseToSchema(target *MetadataSchema) {
 	// new system tables you create.
 
 	target.otherKV = append(target.otherKV, createDefaultZoneConfig()...)
+	target.otherKV = append(target.otherKV, createMetaZoneConfig()...)
+	target.otherKV = append(target.otherKV, createIdentifierZoneConfig()...)
+	target.otherKV = append(target.otherKV, createSystemZoneConfig()...)
 }
 
 // IsSystemConfigID returns whether this ID is for a system config object.

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -17,13 +17,13 @@
 package sqlbase
 
 import (
+	"fmt"
+
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"golang.org/x/net/context"
 )
 
 // sql CREATE commands and full schema for each system table.
@@ -524,61 +524,17 @@ var (
 	}
 )
 
-// Create the key/value pairs for the default zone config entry.
-func createDefaultZoneConfig() []roachpb.KeyValue {
-	var ret []roachpb.KeyValue
+// Create the key/value pair for the default zone config entry.
+func createDefaultZoneConfig() roachpb.KeyValue {
+	zoneConfig := config.DefaultZoneConfig()
 	value := roachpb.Value{}
-	desc := config.DefaultZoneConfig()
-	if err := value.SetProto(&desc); err != nil {
-		log.Fatalf(context.TODO(), "could not marshal %v", desc)
+	if err := value.SetProto(&zoneConfig); err != nil {
+		panic(fmt.Sprintf("could not marshal DefaultZoneConfig: %s", err))
 	}
-	ret = append(ret, roachpb.KeyValue{
+	return roachpb.KeyValue{
 		Key:   MakeZoneKey(keys.RootNamespaceID),
 		Value: value,
-	})
-	return ret
-}
-
-func createMetaZoneConfig() []roachpb.KeyValue {
-	var ret []roachpb.KeyValue
-	value := roachpb.Value{}
-	desc := config.MetaZoneConfig()
-	if err := value.SetProto(&desc); err != nil {
-		log.Fatalf(context.TODO(), "could not marshal %v", desc)
 	}
-	ret = append(ret, roachpb.KeyValue{
-		Key:   MakeZoneKey(keys.MetaSystemID),
-		Value: value,
-	})
-	return ret
-}
-
-func createIdentifierZoneConfig() []roachpb.KeyValue {
-	var ret []roachpb.KeyValue
-	value := roachpb.Value{}
-	desc := config.IdetifierZoneConfig()
-	if err := value.SetProto(&desc); err != nil {
-		log.Fatalf(context.TODO(), "could not marshal %v", desc)
-	}
-	ret = append(ret, roachpb.KeyValue{
-		Key:   MakeZoneKey(keys.IdentifierSystemID),
-		Value: value,
-	})
-	return ret
-}
-
-func createSystemZoneConfig() []roachpb.KeyValue {
-	var ret []roachpb.KeyValue
-	value := roachpb.Value{}
-	desc := config.SystemZoneConfig()
-	if err := value.SetProto(&desc); err != nil {
-		log.Fatalf(context.TODO(), "could not marshal %v", desc)
-	}
-	ret = append(ret, roachpb.KeyValue{
-		Key:   MakeZoneKey(keys.NormalSystemID),
-		Value: value,
-	})
-	return ret
 }
 
 // addSystemDatabaseToSchema populates the supplied MetadataSchema with the
@@ -609,10 +565,7 @@ func addSystemDatabaseToSchema(target *MetadataSchema) {
 	// responsible for creating the table. Please follow a similar scheme for any
 	// new system tables you create.
 
-	target.otherKV = append(target.otherKV, createDefaultZoneConfig()...)
-	target.otherKV = append(target.otherKV, createMetaZoneConfig()...)
-	target.otherKV = append(target.otherKV, createIdentifierZoneConfig()...)
-	target.otherKV = append(target.otherKV, createSystemZoneConfig()...)
+	target.otherKV = append(target.otherKV, createDefaultZoneConfig())
 }
 
 // IsSystemConfigID returns whether this ID is for a system config object.

--- a/pkg/sql/system_table_test.go
+++ b/pkg/sql/system_table_test.go
@@ -37,7 +37,7 @@ func TestInitialKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	const keysPerDesc = 2
-	const nonDescKeys = 5
+	const nonDescKeys = 2
 
 	ms := sqlbase.MakeMetadataSchema()
 	kv := ms.GetInitialValues()

--- a/pkg/sql/system_table_test.go
+++ b/pkg/sql/system_table_test.go
@@ -37,7 +37,7 @@ func TestInitialKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	const keysPerDesc = 2
-	const nonDescKeys = 2
+	const nonDescKeys = 5
 
 	ms := sqlbase.MakeMetadataSchema()
 	kv := ms.GetInitialValues()

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -180,7 +180,10 @@ func TestRejectFutureCommand(t *testing.T) {
 func TestTxnPutOutOfOrder(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	const key = "key"
+	// key is selected to fall within the meta range in order for the later
+	// routing of requests to range 1 to work properly. Removing the routing
+	// of all requests to range 1 would allow us to make the key more normal.
+	const key = "\x03key"
 	// Set up a filter to so that the get operation at Step 3 will return an error.
 	var numGets int32
 

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -854,12 +854,15 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 	}
 
 	verifySplitsAtTablePrefixes := func(maxTableID int) {
-		// We expect splits at each of the user tables, but not at the system
-		// tables boundaries.
+		// We expect splits at each of the user tables and at a few fixed system
+		// range boundaries, but not at system table boundaries.
+		expKeys := []roachpb.Key{
+			testutils.MakeKey(keys.Meta2Prefix, keys.SystemPrefix),
+			testutils.MakeKey(keys.Meta2Prefix, keys.TimeseriesPrefix),
+			testutils.MakeKey(keys.Meta2Prefix, keys.TimeseriesPrefix.PrefixEnd()),
+			testutils.MakeKey(keys.Meta2Prefix, keys.TableDataMin),
+		}
 		numReservedTables := schema.SystemDescriptorCount() - schema.SystemConfigDescriptorCount()
-		var expKeys []roachpb.Key
-		expKeys = append(expKeys,
-			testutils.MakeKey(keys.Meta2Prefix, keys.TableDataMin))
 		for i := 1; i <= int(numReservedTables); i++ {
 			expKeys = append(expKeys,
 				testutils.MakeKey(keys.Meta2Prefix,

--- a/pkg/storage/queue_test.go
+++ b/pkg/storage/queue_test.go
@@ -413,7 +413,11 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 	defer stopper.Stop()
 	s, _ := createTestStore(t, stopper)
 
-	dataMaxAddr, err := keys.Addr(keys.TableDataMin)
+	maxWontSplitAddr, err := keys.Addr(keys.SystemPrefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	minWillSplitAddr, err := keys.Addr(keys.TableDataMin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -428,13 +432,13 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 	}
 
 	// This range can never be split due to zone configs boundaries.
-	neverSplits := createReplica(s, 2, roachpb.RKeyMin, dataMaxAddr)
+	neverSplits := createReplica(s, 2, roachpb.RKeyMin, maxWontSplitAddr)
 	if err := s.AddReplica(neverSplits); err != nil {
 		t.Fatal(err)
 	}
 
 	// This range will need to be split after user db/table entries are created.
-	willSplit := createReplica(s, 3, dataMaxAddr, roachpb.RKeyMax)
+	willSplit := createReplica(s, 3, minWillSplitAddr, roachpb.RKeyMax)
 	if err := s.AddReplica(willSplit); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/split_queue_test.go
+++ b/pkg/storage/split_queue_test.go
@@ -52,7 +52,7 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 		priority   float64
 	}{
 		// No intersection, no bytes.
-		{roachpb.RKeyMin, roachpb.RKey("/"), 0, 64 << 20, false, 0},
+		{roachpb.RKeyMin, roachpb.RKey(keys.MetaMax), 0, 64 << 20, false, 0},
 		// Intersection in zone, no bytes.
 		{keys.MakeTablePrefix(2001), roachpb.RKeyMax, 0, 64 << 20, true, 1},
 		// Already split at largest ID.
@@ -60,11 +60,11 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 		// Multiple intersections, no bytes.
 		{roachpb.RKeyMin, roachpb.RKeyMax, 0, 64 << 20, true, 1},
 		// No intersection, max bytes.
-		{roachpb.RKeyMin, roachpb.RKey("/"), 64 << 20, 64 << 20, false, 0},
+		{roachpb.RKeyMin, roachpb.RKey(keys.MetaMax), 64 << 20, 64 << 20, false, 0},
 		// No intersection, max bytes+1.
-		{roachpb.RKeyMin, roachpb.RKey("/"), 64<<20 + 1, 64 << 20, true, 1},
+		{roachpb.RKeyMin, roachpb.RKey(keys.MetaMax), 64<<20 + 1, 64 << 20, true, 1},
 		// No intersection, max bytes * 2.
-		{roachpb.RKeyMin, roachpb.RKey("/"), 64 << 21, 64 << 20, true, 2},
+		{roachpb.RKeyMin, roachpb.RKey(keys.MetaMax), 64 << 21, 64 << 20, true, 2},
 		// Intersection, max bytes +1.
 		{keys.MakeTablePrefix(2000), roachpb.RKeyMax, 32<<20 + 1, 32 << 20, true, 2},
 		// Split needed at table boundary, but no zone config.

--- a/pkg/ts/keys.go
+++ b/pkg/ts/keys.go
@@ -121,7 +121,9 @@ func decodeDataKeySuffix(key roachpb.Key) (string, string, Resolution, int64, er
 func prettyPrintKey(key roachpb.Key) string {
 	name, source, resolution, timestamp, err := decodeDataKeySuffix(key)
 	if err != nil {
-		return "/" + err.Error()
+		// Not a valid timeseries key, fall back to doing the best we can to display
+		// it.
+		return encoding.PrettyPrintValue(key, "/")
 	}
 	return fmt.Sprintf("/%s/%s/%s/%s", name, source, resolution,
 		time.Unix(0, timestamp).UTC().Format(time.RFC3339Nano))


### PR DESCRIPTION
This revives a combination of #12335 and #12513. I've addressed all the feedback on those PRs and reshuffled the new splits as I described in https://github.com/cockroachdb/cockroach/issues/10692#issuecomment-292254647.

It all builds and runs just fine, but has introduced some new test failures I still need to track down. The failure/issue that I have the least context about what to do with is that previously, all splits were at nicely printable keys, but not all the new ones are. For example, the split at the start of the timeseries key range gets printed as `/System/tsd/did not find marker 0x12 in buffer`. Is that something that should be fixed in the pretty-printing logic, or do we need to use a different split key?

Fixes #10692.