### PR TITLE
util/log: fix log file detection on windows

### DIFF
--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -385,7 +385,7 @@ func TestGetLogReader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	relPath, err := filepath.Rel(curDir, info.file.Name())
+	relPathFromCurDir, err := filepath.Rel(curDir, info.file.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -399,6 +399,7 @@ func TestGetLogReader(t *testing.T) {
 		t.Fatal(err)
 	}
 	otherFile.Close()
+	relPathFromLogDir := strings.Join([]string{"..", filepath.Base(dir), infoName}, string(os.PathSeparator))
 
 	testCases := []struct {
 		filename           string
@@ -412,7 +413,7 @@ func TestGetLogReader(t *testing.T) {
 		// Symlink to a log file.
 		{filepath.Join(dir, removePeriods(program)+".log"), "pathnames must be basenames", ""},
 		// Symlink relative to logDir.
-		{removePeriods(program) + ".log", "malformed log filename", ""},
+		{removePeriods(program) + ".log", "symlinks are not allowed", ""},
 		// Non-log file.
 		{"other.txt", "malformed log filename", "malformed log filename"},
 		// Non-existent file matching RE.
@@ -420,7 +421,9 @@ func TestGetLogReader(t *testing.T) {
 		// Base filename is specified.
 		{infoName, "", ""},
 		// Relative path with directory components.
-		{relPath, "pathnames must be basenames", ""},
+		{relPathFromCurDir, "pathnames must be basenames", ""},
+		// Relative path within the logs directory.
+		{relPathFromLogDir, "pathnames must be basenames", ""},
 	}
 
 	for _, test := range testCases {

--- a/pkg/util/log/file.go
+++ b/pkg/util/log/file.go
@@ -230,33 +230,6 @@ func create(
 	return f, updatedRotation, fname, errors.Wrapf(err, "log: cannot create log")
 }
 
-var errNotAFile = errors.New("not a regular file")
-
-// getFileDetails verifies that the file specified by filename is a
-// regular file and filename matches the expected filename pattern.
-// Returns the log file details success; otherwise error.
-func getFileDetails(info os.FileInfo) (FileDetails, error) {
-	if info.Mode()&os.ModeType != 0 {
-		return FileDetails{}, errNotAFile
-	}
-
-	details, err := parseLogFilename(info.Name())
-	if err != nil {
-		return FileDetails{}, err
-	}
-
-	return details, nil
-}
-
-func verifyFile(filename string) error {
-	info, err := os.Stat(filename)
-	if err != nil {
-		return errors.Wrapf(err, "Stat: %s", filename)
-	}
-	_, err = getFileDetails(info)
-	return err
-}
-
 // ListLogFiles returns a slice of FileInfo structs for each log file
 // on the local node, in any of the configured log directories.
 func ListLogFiles() ([]FileInfo, error) {
@@ -272,14 +245,16 @@ func ListLogFiles() ([]FileInfo, error) {
 		return results, err
 	}
 	for _, info := range infos {
-		details, err := getFileDetails(info)
-		if err == nil {
-			results = append(results, FileInfo{
-				Name:         info.Name(),
-				SizeBytes:    info.Size(),
-				ModTimeNanos: info.ModTime().UnixNano(),
-				Details:      details,
-			})
+		if info.Mode().IsRegular() {
+			details, err := parseLogFilename(info.Name())
+			if err == nil {
+				results = append(results, FileInfo{
+					Name:         info.Name(),
+					SizeBytes:    info.Size(),
+					ModTimeNanos: info.ModTime().UnixNano(),
+					Details:      details,
+				})
+			}
 		}
 	}
 	return results, nil
@@ -306,50 +281,68 @@ func GetLogReader(filename string, restricted bool) (io.ReadCloser, error) {
 			return nil, errors.Errorf("pathnames must be basenames only: %s", filename)
 		}
 		filename = filepath.Join(dir, filename)
-
-	case false:
-		if !filepath.IsAbs(filename) {
-			exists, err := fileExists(filename)
-			if err != nil {
-				return nil, err
+		// Symlinks are not followed in restricted mode.
+		info, err := os.Lstat(filename)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil, errors.Errorf("no such file %s in the log directory", filename)
 			}
-			if !exists && filepath.Base(filename) == filename {
-				// If the file name is not absolute and is simple and not
-				// found in the cwd, try to find the file first relative to
-				// the log directory.
-				fileNameAttempt := filepath.Join(dir, filename)
-				exists, err = fileExists(fileNameAttempt)
-				if err != nil {
-					return nil, err
-				}
-				if !exists {
+			return nil, errors.Wrapf(err, "Lstat: %s", filename)
+		}
+		mode := info.Mode()
+		if mode&os.ModeSymlink != 0 {
+			return nil, errors.Errorf("symlinks are not allowed")
+		}
+		if !mode.IsRegular() {
+			return nil, errors.Errorf("not a regular file")
+		}
+	case false:
+		info, err := osStat(filename)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return nil, errors.Wrapf(err, "Stat: %s", filename)
+			}
+			// The absolute filename didn't work, so try within the log
+			// directory if the filename isn't a path.
+			if filepath.IsAbs(filename) {
+				return nil, errors.Errorf("no such file %s", filename)
+			}
+			filenameAttempt := filepath.Join(dir, filename)
+			info, err = osStat(filenameAttempt)
+			if err != nil {
+				if os.IsNotExist(err) {
 					return nil, errors.Errorf("no such file %s either in current directory or in %s", filename, dir)
 				}
-				filename = fileNameAttempt
+				return nil, errors.Wrapf(err, "Stat: %s", filename)
 			}
+			filename = filenameAttempt
 		}
-
-		// Normalize the name to an absolute path without symlinks.
 		filename, err = filepath.EvalSymlinks(filename)
 		if err != nil {
-			return nil, errors.Wrapf(err, "EvalSymLinks: %s", filename)
+			return nil, err
+		}
+		if !info.Mode().IsRegular() {
+			return nil, errors.Errorf("not a regular file")
 		}
 	}
 
-	// Check the file name is valid.
-	if err := verifyFile(filename); err != nil {
+	// Check that the file name is valid.
+	if _, err := parseLogFilename(filepath.Base(filename)); err != nil {
 		return nil, err
 	}
 
 	return os.Open(filename)
 }
 
-func fileExists(path string) (bool, error) {
-	_, err := os.Stat(path)
-	if os.IsNotExist(err) {
-		return false, nil
+// TODO(bram): remove when Go1.9 is required.
+//
+// See https://github.com/golang/go/issues/19870.
+func osStat(path string) (os.FileInfo, error) {
+	path, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return nil, err
 	}
-	return true, err
+	return os.Lstat(path)
 }
 
 // sortableFileInfoSlice is required so we can sort FileInfos.


### PR DESCRIPTION
On Windows, calling os.Stat() on a symlinked file can return a file not found error instead of following the link. This change normalizes the path by calling EvalSymlinks on it first. See https://github.com/golang/go/issues/19870#issuecomment-292394515.

Furthermore, I've cleaned up the code significantly here to be more streamlined and clear.

Fixes #14546.