### PR TITLE
logging: report absolute store & log dir paths, reject leading tildes

### DIFF
--- a/pkg/cli/interactive_tests/test_log_flags.tcl
+++ b/pkg/cli/interactive_tests/test_log_flags.tcl
@@ -1,0 +1,44 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+spawn /bin/bash
+send "PS1=':''/# '\r"
+eexpect ":/# "
+
+# Perform command-line checking for logging flags. We cannot use a
+# regular unit test for this, because the logging flags are declared
+# for the global `CommandLine` object of package `flag`, and any
+# errors when parsing flags in that context cause the (test) process
+# to exit entirely (it has errorHandling set to ExitOnError).
+
+# Check that leading tildes are properly rejected.
+send "$argv start --log-dir=\~/blah\r"
+eexpect "log directory cannot start with '~'"
+eexpect ":/# "
+
+# Check that the user can override.
+send "$argv start --log-dir=blah/\~/blah\r"
+eexpect "logs: *blah/~/blah"
+send "\003"
+eexpect ":/# "
+
+# Check that TRUE and FALSE are valid values for the severity flags.
+send "$argv start --alsologtostderr=false\r"
+eexpect "node starting"
+send "\003"
+eexpect ":/# "
+send "$argv start --alsologtostderr=true\r"
+eexpect "node starting"
+send "\003"
+eexpect ":/# "
+send "$argv start --alsologtostderr=2\r"
+eexpect "node starting"
+send "\003"
+eexpect ":/# "
+send "$argv start --alsologtostderr=cantparse\r"
+eexpect "parsing \"cantparse\": invalid syntax"
+eexpect ":/# "
+
+send "exit 0\r"
+eexpect eof

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -327,6 +327,18 @@ func runStart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Ensure that the store paths are absolute. This will clarify the
+	// output of the startup messages below, and ensure that logging
+	// doesn't get confused if any future change in the code introduces
+	// a call to `os.Chdir`.
+	for i, spec := range serverCfg.Stores.Specs {
+		absPath, err := filepath.Abs(spec.Path)
+		if err != nil {
+			return err
+		}
+		serverCfg.Stores.Specs[i].Path = absPath
+	}
+
 	// Default the log directory to the "logs" subdirectory of the first
 	// non-memory store. We only do this for the "start" command which is why
 	// this work occurs here and not in an OnInitialize function.

--- a/pkg/util/log/file.go
+++ b/pkg/util/log/file.go
@@ -63,6 +63,14 @@ var logDir logDirName
 
 // Set implements the flag.Value interface.
 func (l *logDirName) Set(dir string) error {
+	if len(dir) > 0 && dir[0] == '~' {
+		return fmt.Errorf("log directory cannot start with '~': %s", dir)
+	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return err
+	}
+	dir = absDir
 	l.Lock()
 	defer l.Unlock()
 	l.name = dir


### PR DESCRIPTION
Two minor tweaks; one suggested in https://forum.cockroachlabs.com/t/total-newbie-issue/550/2 and the other

Fixes #14435.

### cli: disable `~` in store paths, introduce spec parse error tests

Prior to this patch, if a user would specify `--store=~/blah` and the
user's shell does not automatically perform tilde expansion in
command-line arguments (e.g. zsh does, but bash doesn't), the behavior
would be surprising: CockroachDB would create a directory called "~"
and put the files in there.

This patch removes the surprise by reporting an error in this case.
The user can still override the behavior (to store files in a directory
effectively named "~") by specifying e.g. `--store=./~/blah`.

In addition `start` now reports the absolute path to the stores.

Also a few additional test cases for errors during the parsing of the
`--store` command-line flag are introduced.

### log: make --log-dir reject leading tilde characters.

Prior to this patch, if a user would specify `--log-dir=~/blah` and
the user's shell does not automatically perform tilde expansion in
command-line arguments (e.g. zsh does, but bash doesn't), the behavior
would be surprising: CockroachDB would create a directory called "~"
and put the log files in there.

This patch removes the surprise by reporting an error in this case.
The user can still override the behavior (to store log files in a
directory effectively named "~") by specifying
e.g. `--log-dir=./~/blah`.

Also a few additional test cases for errors during the parsing of the
logging command-line flags are introduced.