### PR TITLE
sql: re-enable SHOW TRANSACTION outside of explicit txn blocks

### DIFF
--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -341,7 +341,7 @@ func (p *planner) newPlan(
 	case *parser.SetDefaultIsolation:
 		return p.SetDefaultIsolation(n)
 	case *parser.Show:
-		return p.Show(n, autoCommit)
+		return p.Show(n)
 	case *parser.ShowColumns:
 		return p.ShowColumns(ctx, n)
 	case *parser.ShowConstraints:
@@ -400,7 +400,7 @@ func (p *planner) prepare(ctx context.Context, stmt parser.Statement) (planNode,
 	case *parser.SelectClause:
 		return p.SelectClause(ctx, n, nil, nil, nil, publicColumns)
 	case *parser.Show:
-		return p.Show(n, false)
+		return p.Show(n)
 	case *parser.ShowCreateTable:
 		return p.ShowCreateTable(ctx, n)
 	case *parser.ShowCreateView:

--- a/pkg/sql/testdata/logic_test/explain
+++ b/pkg/sql/testdata/logic_test/explain
@@ -174,33 +174,21 @@ EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
 1 values
 1                 size    1 column, 1 row
 
-statement error there is no transaction in progress
-EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
-
-statement error there is no transaction in progress
-EXPLAIN SHOW TRANSACTION PRIORITY
-
-statement ok
-BEGIN TRANSACTION
-
 query ITTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
 ----
-0  virtual table
+0 virtual table
 0                 source  SHOW TRANSACTION ISOLATION LEVEL
-1  values
+1 values
 1                 size    1 column, 1 row
 
 query ITTT
 EXPLAIN SHOW TRANSACTION PRIORITY
 ----
-0  virtual table
+0 virtual table
 0                 source  SHOW TRANSACTION PRIORITY
-1  values
+1 values
 1                 size    1 column, 1 row
-
-statement ok
-ROLLBACK
 
 query ITTT
 EXPLAIN SHOW COLUMNS FROM foo

--- a/pkg/sql/testdata/logic_test/set
+++ b/pkg/sql/testdata/logic_test/set
@@ -126,34 +126,10 @@ session_user                   root
 standard_conforming_strings    on
 syntax                         Modern
 time zone                      UTC
-
-statement ok
-BEGIN TRANSACTION
-
-query TT
-SHOW ALL
-----
-application_name               helloworld
-client_encoding                UTF8
-client_min_messages
-database                       foo
-default_transaction_isolation  SERIALIZABLE
-distsql                        off
-extra_float_digits
-max_index_keys                 32
-search_path                    pg_catalog
-server_version                 9.5.0
-session_user                   root
-standard_conforming_strings    on
-syntax                         Modern
-time zone                      UTC
 transaction isolation level    SERIALIZABLE
 transaction priority           NORMAL
 
-statement ok
-ROLLBACK
-
-## Test SET ... TO DEFAULT works
+## Test SET ... TO DEFAULT works
 
 statement ok
 SET DISTSQL TO ON

--- a/pkg/sql/testdata/logic_test/txn
+++ b/pkg/sql/testdata/logic_test/txn
@@ -308,9 +308,6 @@ SET TRANSACTION PRIORITY HIGH
 statement ok
 ROLLBACK
 
-statement error there is no transaction in progress
-SHOW TRANSACTION PRIORITY
-
 # User priority default to normal
 
 statement ok
@@ -413,8 +410,11 @@ SHOW DEFAULT_TRANSACTION_ISOLATION
 ----
 SNAPSHOT
 
-statement error there is no transaction in progress
+# SHOW without a transaction should create an auto-transaction with the default level
+query T
 SHOW TRANSACTION ISOLATION LEVEL
+----
+SNAPSHOT
 
 statement ok
 SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -44,8 +44,6 @@ type sessionVar struct {
 	// Reset performs mutations (usually on p.session) to effect the change
 	// desired by RESET commands.
 	Reset func(*planner) error
-
-	requireExplicitTxn bool
 }
 
 // nopVar is a placeholder for a number of settings sent by various client
@@ -243,26 +241,12 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 	},
-	`time zone`: {
-		Get: func(p *planner) string { return p.session.Location.String() },
-	},
-	`transaction isolation level`: {
-		Get:                func(p *planner) string { return p.txn.Isolation().String() },
-		requireExplicitTxn: true,
-	},
-	`transaction priority`: {
-		Get:                func(p *planner) string { return p.txn.UserPriority().String() },
-		requireExplicitTxn: true,
-	},
-	`max_index_keys`: {
-		Get: func(*planner) string { return "32" },
-	},
-	`server_version`: {
-		Get: func(*planner) string { return PgServerVersion },
-	},
-	`session_user`: {
-		Get: func(p *planner) string { return p.session.User },
-	},
+	`time zone`:                   {Get: func(p *planner) string { return p.session.Location.String() }},
+	`transaction isolation level`: {Get: func(p *planner) string { return p.txn.Isolation().String() }},
+	`transaction priority`:        {Get: func(p *planner) string { return p.txn.UserPriority().String() }},
+	`max_index_keys`:              {Get: func(*planner) string { return "32" }},
+	`server_version`:              {Get: func(*planner) string { return PgServerVersion }},
+	`session_user`:                {Get: func(p *planner) string { return p.session.User }},
 
 	// See https://www.postgresql.org/docs/9.6/static/runtime-config-client.html
 	`extra_float_digits`: nopVar,


### PR DESCRIPTION
This partially reverts 536f32a33be1377abf52c51649f6438344f03a4a.

The changes in 536f32a33be1377abf52c51649f6438344f03a4a were motivated by the discussion in https://github.com/cockroachdb/cockroach/issues/6151: since the transaction isolation level & priority cannot be set outside of a txn block, then it seems unintuitive that they can be shown.

Alas, as reported in https://forum.cockroachlabs.com/t/can-not-connect-to-the-server-after-upgrading-to-beta-20170406/547 and tracked in https://github.com/cockroachdb/cockroach/issues/14700, some JDBC clients will use SHOW to enquire these properties even outside of txn blocks in some circumstances. To avoid errors in these clients, the change is reverted so that SHOW still works.

(As expected, SET on these properties still fails outside of txn blocks.)

Fixes #14700.

cc @bdarnell 