### PR TITLE
sqlccl: de-flake tempdir cleanup check

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -148,13 +148,16 @@ func backupRestoreTestSetupWithParams(
 	}
 
 	cleanupFn := func() {
-		items, err := ioutil.ReadDir(temp)
-		if err != nil && !os.IsNotExist(err) {
-			t.Fatal(err)
-		}
-		for _, leftover := range items {
-			t.Errorf("found %q remaining in tempdir", leftover.Name())
-		}
+		testutils.SucceedsSoon(t, func() error {
+			items, err := ioutil.ReadDir(temp)
+			if err != nil && !os.IsNotExist(err) {
+				t.Fatal(err)
+			}
+			for _, leftover := range items {
+				return errors.Errorf("found %q remaining in tempdir", leftover.Name())
+			}
+			return nil
+		})
 		tc.Stopper().Stop()
 		dirCleanupFn()
 	}


### PR DESCRIPTION
Adding some logging to the deferred cleanup indicated that it *was* running,
but the leak check was occasionally observing the contents pre-cleanup.

Fixes #14540.
Fixes #14656.
Fixes #14722.