### PR TITLE
sql: add constant 0-valued DInt

### DIFF
--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -472,7 +472,7 @@ var Builtins = map[string][]Builtin{
 	"strpos": {stringBuiltin2("input", "find", func(s, substring string) (Datum, error) {
 		index := strings.Index(s, substring)
 		if index < 0 {
-			return NewDInt(0), nil
+			return DZero, nil
 		}
 
 		return NewDInt(DInt(utf8.RuneCountInString(s[:index]) + 1)), nil
@@ -1315,7 +1315,7 @@ var Builtins = map[string][]Builtin{
 				case x < 0:
 					return NewDInt(-1), nil
 				case x == 0:
-					return NewDInt(0), nil
+					return DZero, nil
 				}
 				return NewDInt(1), nil
 			},
@@ -1501,7 +1501,7 @@ var Builtins = map[string][]Builtin{
 				if elapsed.Compare(minDuration) < 0 {
 					return nil, roachpb.NewRetryableTxnError("forced by crdb_internal.force_retry()", nil /* txnID */)
 				}
-				return NewDInt(0), nil
+				return DZero, nil
 			},
 			category: categorySystemInfo,
 			Info:     "This function is used only by CockroachDB's developers for testing purposes.",
@@ -1525,7 +1525,7 @@ var Builtins = map[string][]Builtin{
 					}
 					return nil, roachpb.NewRetryableTxnError("forced by crdb_internal.force_retry()", &uuid)
 				}
-				return NewDInt(0), nil
+				return DZero, nil
 			},
 			category: categorySystemInfo,
 			Info:     "This function is used only by CockroachDB's developers for testing purposes.",

--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -51,6 +51,9 @@ var (
 
 	// DNull is the NULL Datum.
 	DNull Datum = dNull{}
+
+	// DZero is the zero-valued integer Datum.
+	DZero = NewDInt(0)
 )
 
 // Datum represents a SQL value.

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -1917,7 +1917,7 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 			if *v {
 				res = NewDInt(1)
 			} else {
-				res = NewDInt(0)
+				res = DZero
 			}
 		case *DInt:
 			res = v

--- a/pkg/sql/parser/normalize.go
+++ b/pkg/sql/parser/normalize.go
@@ -316,7 +316,7 @@ func (expr *ComparisonExpr) normalize(v *normalizeVisitor) TypedExpr {
 							v.err = err
 							return expr
 						}
-						if divisor.Compare(v.ctx, NewDInt(0)) < 0 {
+						if divisor.Compare(v.ctx, DZero) < 0 {
 							if !exprCopied {
 								exprCopy := *expr
 								expr = &exprCopy

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -38,7 +38,7 @@ import (
 
 var (
 	oidZero   = parser.NewDOid(0)
-	zeroVal   = parser.NewDInt(0)
+	zeroVal   = parser.DZero
 	negOneVal = parser.NewDInt(-1)
 )
 


### PR DESCRIPTION
We re-allocate 0-valued DInts a few times throughout the code, might as
well make a constant for them.