### PR TITLE
build: Only push to docker's :latest tag for stable releases

### DIFF
--- a/build/push-docker-deploy.sh
+++ b/build/push-docker-deploy.sh
@@ -10,5 +10,14 @@ time ./acceptance.test -i cockroachdb/cockroach -b /cockroach/cockroach -nodes 3
 docker tag cockroachdb/cockroach cockroachdb/cockroach:"${VERSION}"
 
 # Pushing to the registry just fails sometimes, so for the time
-# being just make this a best-effort action.
-docker push cockroachdb/cockroach || true
+# being just make this a best-effort action. Push with an explicit
+# version to avoid pushing other tags or overwriting ":latest".
+docker push cockroachdb/cockroach:"${VERSION}" || true
+
+# Only update the ":latest" tag for releases that we consider stable.
+if [ "${STABLE_RELEASE}" = true ] ; then
+  # We don't allow such failures on this push, because we care more about
+  # the latest tag being updated properly.
+  docker tag cockroachdb/cockroach cockroachdb/cockroach:latest
+  docker push cockroachdb/cockroach:latest
+fi

--- a/build/teamcity-release-upload.sh
+++ b/build/teamcity-release-upload.sh
@@ -6,11 +6,13 @@ sed "s/<EMAIL>/$DOCKER_EMAIL/;s/<AUTH>/$DOCKER_AUTH/" < build/.dockercfg.in > ~/
 case "$TC_BUILD_BRANCH" in
   master)
     VERSION=$(git describe || git rev-parse --short HEAD)
+    STABLE_RELEASE=false
     push=build/push-aws.sh
     ;;
 
   beta-*)
     VERSION="$TC_BUILD_BRANCH"
+    STABLE_RELEASE=true
     push=build/push-tagged-aws.sh
     ;;
 
@@ -20,6 +22,7 @@ case "$TC_BUILD_BRANCH" in
 esac
 
 export VERSION
+export STABLE_RELEASE
 echo "Deploying $VERSION..."
 
 cat .buildinfo/tag || true


### PR DESCRIPTION
For now that means betas rather than alphas. Soon it will mean
production-ready releases rather than alphas and betas.

Fixes part of #5756, and is something we definitely needed by 1.0 to avoid users mistakenly using potentially bad images.

I've tested this locally to make sure that `master` builds no longer push to `:latest`.