### PR TITLE
cli: Differentiate between different errors in quit command

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -325,7 +325,7 @@ communicate with a secure cluster\).
 		},
 		// Error returned directly from GRPC.
 		{`quit`, styled(
-			`rpc error: code = Unavailable desc = grpc: the connection is unavailable`),
+			`Error sending drain request: rpc error: code = Unavailable desc = grpc: the connection is unavailable`),
 		},
 		// Going through the SQL client libraries gives a *net.OpError which
 		// we also handle.

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -652,7 +652,7 @@ func doShutdown(ctx context.Context, c serverpb.AdminClient, onModes []int32) er
 			Shutdown: i > 0,
 		})
 		if err != nil {
-			return err
+			return errors.Wrap(err, "Error sending drain request")
 		}
 		// Only signal the caller to try again with a hard shutdown if we're
 		// not already trying to do that, and if the initial connection attempt
@@ -676,7 +676,7 @@ func doShutdown(ctx context.Context, c serverpb.AdminClient, onModes []int32) er
 				}
 				// Case in which we don't even know whether the server is
 				// running. No point in trying again.
-				return err
+				return errors.Wrap(err, "Got unexpected error while receiving on stream")
 			}
 			if i == 0 {
 				// Our liveness probe succeeded.


### PR DESCRIPTION
Hopefully this will provide more insight into debugging test flakes in
the quit command.

As requested by @tamird on #14184, this will allow us to tell whether flaky errors in `quit` are coming from the initial `Drain` request or when listening for further messages on the `stream`.