### PR TITLE
log: Leave empty paths empty

### DIFF
--- a/pkg/util/log/file.go
+++ b/pkg/util/log/file.go
@@ -66,11 +66,13 @@ func (l *logDirName) Set(dir string) error {
 	if len(dir) > 0 && dir[0] == '~' {
 		return fmt.Errorf("log directory cannot start with '~': %s", dir)
 	}
-	absDir, err := filepath.Abs(dir)
-	if err != nil {
-		return err
+	if len(dir) > 0 {
+		absDir, err := filepath.Abs(dir)
+		if err != nil {
+			return err
+		}
+		dir = absDir
 	}
-	dir = absDir
 	l.Lock()
 	defer l.Unlock()
 	l.name = dir


### PR DESCRIPTION
The empty string is interpreted to mean "no log directory"; converting
it to an absolute path to the current directory results in logs being
left in unwanted places (e.g. during tests).