### PR TITLE
storage: ensure that the push txn queue notices pushee txn's priority…

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -306,8 +306,8 @@ func DefaultRetryOptions() retry.Options {
 	// Derive the retry options from a configured or measured
 	// estimate of latency.
 	return retry.Options{
-		InitialBackoff: 50 * time.Millisecond,
-		MaxBackoff:     5 * time.Second,
-		Multiplier:     2,
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     1 * time.Second,
+		Multiplier:     1.5,
 	}
 }

--- a/pkg/base/constants.go
+++ b/pkg/base/constants.go
@@ -30,7 +30,7 @@ const (
 	// being preempted by other transactions writing the same keys. If a
 	// transaction fails to be heartbeat within 2x the heartbeat interval,
 	// it may be aborted by conflicting txns.
-	DefaultHeartbeatInterval = 5 * time.Second
+	DefaultHeartbeatInterval = 1 * time.Second
 
 	// SlowRequestThreshold is the amount of time to wait before considering a
 	// request to be "slow".


### PR DESCRIPTION
… upgrade

Previously the pushee txn was only be queried at its expected expiration.
However, this would miss upgrades to its priority since the time the pusher
entered the push txn queue.

Fixes #14670