### PR TITLE
sql: support RETURNING NOTHING statements outside of transactions

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -51,7 +51,6 @@ import (
 )
 
 var errNoTransactionInProgress = errors.New("there is no transaction in progress")
-var errNoTransactionToPipeline = errors.New("statement pipelining is only allowed in a transaction")
 var errStaleMetadata = errors.New("metadata is still stale")
 var errTransactionInProgress = errors.New("there is already a transaction in progress")
 var errStmtFollowsSchemaChange = errors.New("statement cannot follow a schema change in a transaction")
@@ -1111,9 +1110,6 @@ func (e *Executor) execStmtInOpenTxn(
 	// execution. If neither of these cases are true, we need to synchronize
 	// the pipeline by letting it drain before we can begin executing ourselves.
 	pipelined := IsStmtPipelined(stmt)
-	if pipelined && implicitTxn {
-		return Result{}, errNoTransactionToPipeline
-	}
 	_, independentFromPipelined := stmt.(parser.IndependentFromPipelinedPriors)
 	if !(pipelined || independentFromPipelined) {
 		if err := session.pipelineQueue.Wait(); err != nil {
@@ -1202,11 +1198,16 @@ func (e *Executor) execStmtInOpenTxn(
 	planner.phaseTimes[plannerStartExecStmt] = timeutil.Now()
 
 	var result Result
-	if pipelined {
+	if pipelined && !implicitTxn {
+		// Only run statements asynchronously through the pipeline queue if the
+		// statements are pipelined and we're in a transaction. Pipelined statements
+		// outside of a transaction are run synchronously with mocked results, which
+		// has the same effect as running asynchronously but immediately blocking.
 		result, err = e.execStmtPipelined(stmt, planner)
 	} else {
 		autoCommit := implicitTxn && !e.cfg.TestingKnobs.DisableAutoCommit
-		result, err = e.execStmt(stmt, planner, autoCommit, automaticRetryCount)
+		result, err = e.execStmt(stmt, planner, autoCommit,
+			automaticRetryCount, pipelined /* mockResults */)
 	}
 
 	if err != nil {
@@ -1423,8 +1424,14 @@ func makeRes(stmt parser.Statement, planner *planner, plan planNode) (Result, er
 }
 
 // execStmt executes the statement synchronously and returns the statement's result.
+// If mockResults is set, these results will be replaced by the "zero value" of the
+// statement's result type, identical to the mock results returned by execStmtPipelined.
 func (e *Executor) execStmt(
-	stmt parser.Statement, planner *planner, autoCommit bool, automaticRetryCount int,
+	stmt parser.Statement,
+	planner *planner,
+	autoCommit bool,
+	automaticRetryCount int,
+	mockResults bool,
 ) (Result, error) {
 	session := planner.session
 
@@ -1458,10 +1465,14 @@ func (e *Executor) execStmt(
 	e.recordStatementSummary(
 		planner, stmt, useDistSQL, automaticRetryCount, result, err,
 	)
-
 	if err != nil {
 		result.Close(session.Ctx())
 		return Result{}, err
+	}
+
+	if mockResults {
+		result.Close(session.Ctx())
+		return makeRes(stmt, planner, plan)
 	}
 	return result, nil
 }

--- a/pkg/sql/testdata/logic_test/pipelining
+++ b/pkg/sql/testdata/logic_test/pipelining
@@ -6,19 +6,46 @@ CREATE TABLE kv (
   v INT CHECK (v < 100)
 )
 
-# Pipelining cannot be used outside of a transaction
+statement ok
+CREATE TABLE fk (
+  f INT REFERENCES kv
+)
 
-statement error statement pipelining is only allowed in a transaction
+
+# Pipelining can be used outside of a transaction, but synchronizes immediately
+
+statement ok
 INSERT INTO kv VALUES (1, 2) RETURNING NOTHING
 
-statement error statement pipelining is only allowed in a transaction
-UPSERT INTO kv VALUES (1, 2) RETURNING NOTHING
+statement error duplicate key value \(k\)=\(1\) violates unique constraint "primary"
+INSERT INTO kv VALUES (1, 2) RETURNING NOTHING
 
-statement error statement pipelining is only allowed in a transaction
-UPDATE kv SET v = k WHERE k =3 RETURNING NOTHING
+statement ok
+UPSERT INTO kv VALUES (2, 2) RETURNING NOTHING
 
-statement error statement pipelining is only allowed in a transaction
+statement error failed to satisfy CHECK constraint \(v < 100\)
+UPSERT INTO kv VALUES (2, 500) RETURNING NOTHING
+
+statement ok
+UPDATE kv SET v = k WHERE k = 3 RETURNING NOTHING
+
+statement error duplicate key value \(k\)=\(1\) violates unique constraint "primary"
+UPDATE kv SET k = 1 WHERE k = 2 RETURNING NOTHING
+
+statement ok
 DELETE FROM kv WHERE k = 1 RETURNING NOTHING
+
+statement ok
+INSERT INTO fk VALUES (2)
+
+statement error foreign key violation: values \[2\] in columns \[k\] referenced in table \"fk\"
+DELETE FROM kv WHERE k = 2 RETURNING NOTHING
+
+statement ok
+DELETE FROM fk
+
+statement ok
+DELETE FROM kv
 
 
 # Successfully perform pipelined inserts
@@ -206,12 +233,6 @@ SELECT k, v FROM kv ORDER BY k
 
 # Unsuccessfully perform pipelined deletes
 
-# Temporary table with FK to reference kv
-statement ok
-CREATE TABLE fk (
-  f INT REFERENCES kv
-)
-
 statement ok
 INSERT INTO fk VALUES (2)
 
@@ -241,7 +262,7 @@ SELECT k, v FROM kv ORDER BY k
 4  8
 
 statement ok
-DROP TABLE fk
+DELETE FROM fk
 
 
 # Successfully perform mixed mutations


### PR DESCRIPTION
Fixes #14551.

This change adds support for `RETURNING NOTHING` statements outside of
explicit transactions. Because statements running outside of an explicit
transaction have a transactional scope of exactly one statement,
parallel statement execution semantics would deem that we synchronize
immediately after running the async statement. Instead, we expose
identical behavior by simply running the statement synchronously and
mocking out the results, as is expected from `RETURNING NOTHING`
statements.