### PR TITLE
config: Support zone configs on the system DB, but not system tables

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -652,6 +652,9 @@ func Example_zone() {
 	c.Run("zone ls")
 	c.Run("zone get system.nonexistent")
 	c.Run("zone get system.lease")
+	c.Run("zone set system.lease --file=./testdata/zone_attrs.yaml")
+	c.Run("zone set system.namespace --file=./testdata/zone_attrs.yaml")
+	c.Run("zone set system.nonexistent --file=./testdata/zone_attrs.yaml")
 	c.Run("zone set system --file=./testdata/zone_range_max_bytes.yaml")
 	c.Run("zone get system")
 	c.Run("zone rm system")
@@ -698,6 +701,12 @@ func Example_zone() {
 	//   ttlseconds: 86400
 	// num_replicas: 1
 	// constraints: [us-east-1a, ssd]
+	// zone set system.lease --file=./testdata/zone_attrs.yaml
+	// setting zone configs for individual system tables is not supported; try setting your config on the entire "system" database instead
+	// zone set system.namespace --file=./testdata/zone_attrs.yaml
+	// setting zone configs for individual system tables is not supported; try setting your config on the entire "system" database instead
+	// zone set system.nonexistent --file=./testdata/zone_attrs.yaml
+	// system.nonexistent not found
 	// zone set system --file=./testdata/zone_range_max_bytes.yaml
 	// range_min_bytes: 1048576
 	// range_max_bytes: 134217728

--- a/pkg/cli/zone.go
+++ b/pkg/cli/zone.go
@@ -493,6 +493,11 @@ func runSetZone(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if len(path) > 2 && path[1] == keys.SystemDatabaseID {
+		return fmt.Errorf("setting zone configs for individual system tables is not supported; " +
+			"try setting your config on the entire \"system\" database instead")
+	}
+
 	_, zone, err := queryZonePath(conn, path)
 	if err != nil {
 		return err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -351,8 +351,11 @@ func (s SystemConfig) GetZoneConfigForKey(key roachpb.RKey) (ZoneConfig, error) 
 		// Not in the structured data namespace.
 		objectID = keys.RootNamespaceID
 	} else if objectID <= keys.MaxReservedDescID {
-		// For now, only user databases and tables get custom zone configs.
-		objectID = keys.RootNamespaceID
+		// For now, you can only set a zone config on the system database as a whole,
+		// not on any of its constituent tables. This is largely because all the
+		// "system config" tables are colocated in the same range by default and
+		// thus couldn't be managed separately.
+		objectID = keys.SystemDatabaseID
 	}
 
 	// Special-case known system ranges to their special zone configs.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -374,8 +374,6 @@ func TestGetZoneConfigForKey(t *testing.T) {
 		key        roachpb.RKey
 		expectedID uint32
 	}{
-		{keys.MakeTablePrefix(keys.MaxReservedDescID + 1), keys.MaxReservedDescID + 1},
-		{keys.MakeTablePrefix(keys.MaxReservedDescID + 23), keys.MaxReservedDescID + 23},
 		{roachpb.RKeyMin, keys.MetaRangesID},
 		{roachpb.RKey(keys.Meta1Prefix), keys.MetaRangesID},
 		{roachpb.RKey(keys.Meta1Prefix.Next()), keys.MetaRangesID},
@@ -395,9 +393,15 @@ func TestGetZoneConfigForKey(t *testing.T) {
 		{roachpb.RKey(keys.TimeseriesPrefix), keys.TimeseriesRangesID},
 		{roachpb.RKey(keys.TimeseriesPrefix.Next()), keys.TimeseriesRangesID},
 		{roachpb.RKey(keys.TimeseriesPrefix.PrefixEnd()), keys.SystemRangesID},
-		{roachpb.RKey(keys.TableDataMin), keys.RootNamespaceID},
-		{roachpb.RKey(keys.SystemConfigSplitKey), keys.RootNamespaceID},
-		{keys.MakeTablePrefix(keys.ZonesTableID), keys.RootNamespaceID},
+		{roachpb.RKey(keys.TableDataMin), keys.SystemDatabaseID},
+		{roachpb.RKey(keys.SystemConfigSplitKey), keys.SystemDatabaseID},
+		{keys.MakeTablePrefix(keys.NamespaceTableID), keys.SystemDatabaseID},
+		{keys.MakeTablePrefix(keys.ZonesTableID), keys.SystemDatabaseID},
+		{keys.MakeTablePrefix(keys.LeaseTableID), keys.SystemDatabaseID},
+		{keys.MakeTablePrefix(keys.JobsTableID), keys.SystemDatabaseID},
+		{keys.MakeTablePrefix(keys.MaxReservedDescID + 1), keys.MaxReservedDescID + 1},
+		{keys.MakeTablePrefix(keys.MaxReservedDescID + 23), keys.MaxReservedDescID + 23},
+		{roachpb.RKeyMax, keys.RootNamespaceID},
 	}
 
 	originalZoneConfigHook := config.ZoneConfigHook


### PR DESCRIPTION
Previously we'd accept zone configs on both but none of them worked. Now
zone configs on the system DB work, and we don't allow more
finely-grained zone configs to be created within the system DB. They
wouldn't work on the system config ranges, and it seems confusing to
expect users to understand that they're different from other system
tables.

Fixes #14790

@BramGruneir @bdarnell 