### PR TITLE
storage: Fix TestStoreRecoverWithErrors flake

### DIFF
--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -183,7 +183,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 	// key is selected to fall within the meta range in order for the later
 	// routing of requests to range 1 to work properly. Removing the routing
 	// of all requests to range 1 would allow us to make the key more normal.
-	const key = "\x03key"
+	key := rg1Key("key")
 	// Set up a filter to so that the get operation at Step 3 will return an error.
 	var numGets int32
 

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -25,6 +25,7 @@ client_*.go.
 package storage_test
 
 import (
+	"bytes"
 	"fmt"
 	"math/rand"
 	"net"
@@ -77,6 +78,15 @@ func rg1(s *storage.Store) client.Sender {
 		}
 		return ba
 	})
+}
+
+// rg1Key returns a key that will reliably be located within the first range.
+// This is a bit of a bandaid to ensure tests continue working as intended
+// until the rg1 method is removed.
+func rg1Key(key string) roachpb.Key {
+	// Ensure that the key will be located in the first range by giving it the
+	// meta2 prefix. The first range only contains meta keys as of April 2017.
+	return roachpb.Key(bytes.Join([][]byte{keys.Meta2Prefix, []byte(key)}, nil))
 }
 
 // createTestStore creates a test store using an in-memory


### PR DESCRIPTION
Add a function to support tests that expect/require their key(s) to
be located in the first range.

Fixes #14812. I'm also checking whether other uses of `rg1()` in various tests need this.