### PR TITLE
distsql: plumb information about misplanned ranges

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -258,6 +258,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		DB:             s.db,
 		RPCContext:     s.rpcContext,
 		Stopper:        s.stopper,
+		NodeID:         &s.nodeIDContainer,
 	}
 	if s.cfg.TestingKnobs.DistSQL != nil {
 		distSQLCfg.TestingKnobs = *s.cfg.TestingKnobs.DistSQL.(*distsqlrun.TestingKnobs)

--- a/pkg/sql/distsqlrun/cluster_test.go
+++ b/pkg/sql/distsqlrun/cluster_test.go
@@ -237,8 +237,9 @@ func TestClusterFlow(t *testing.T) {
 		}
 		rows, metas = testGetDecodedRows(t, &decoder, rows, metas)
 	}
+	metas = ignoreMisplannedRanges(metas)
 	if len(metas) != 0 {
-		t.Fatalf("unexpected metadata (%d): %v", len(metas), metas)
+		t.Fatalf("unexpected metadata (%d): %+v", len(metas), metas)
 	}
 	// The result should be all the numbers in string form, ordered by the
 	// digit sum (and then by number).
@@ -255,4 +256,16 @@ func TestClusterFlow(t *testing.T) {
 	if rowStr := rows.String(); rowStr != expected {
 		t.Errorf("Result: %s\n Expected: %s\n", rowStr, expected)
 	}
+}
+
+// ignoreMisplannedRanges takes a slice of metadata and returns the entries that
+// are not about range info from mis-planned ranges.
+func ignoreMisplannedRanges(metas []ProducerMetadata) []ProducerMetadata {
+	res := make([]ProducerMetadata, 0)
+	for _, m := range metas {
+		if len(m.Ranges) == 0 {
+			res = append(res, m)
+		}
+	}
+	return res
 }

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -58,7 +58,10 @@ type FlowCtx struct {
 	// in the flow must be performed.
 	txnProto *roachpb.Transaction
 	// clientDB is a handle to the cluster. Used to run transactions.
-	clientDB     *client.DB
+	clientDB *client.DB
+	// nodeID is the ID of the node on which the processors using this FlowCtx
+	// run.
+	nodeID       roachpb.NodeID
 	testingKnobs TestingKnobs
 }
 

--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -141,7 +141,7 @@ func (h *hashJoiner) buildPhase(ctx context.Context) (bool, error) {
 				return true, meta.Err
 			}
 			if !emitHelper(
-				ctx, &h.out, nil /* row */, ProducerMetadata{}, h.leftSource, h.rightSource) {
+				ctx, &h.out, nil /* row */, meta, h.leftSource, h.rightSource) {
 				return false, nil
 			}
 			continue
@@ -217,7 +217,7 @@ func (h *hashJoiner) probePhase(ctx context.Context) (bool, error) {
 				return true, meta.Err
 			}
 			if !emitHelper(
-				ctx, &h.out, nil /* row */, ProducerMetadata{}, h.leftSource, h.rightSource) {
+				ctx, &h.out, nil /* row */, meta, h.leftSource, h.rightSource) {
 				return false, nil
 			}
 			continue

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -17,6 +17,7 @@
 package distsqlrun
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -50,6 +51,9 @@ var _ processor = &tableReader{}
 func newTableReader(
 	flowCtx *FlowCtx, spec *TableReaderSpec, post *PostProcessSpec, output RowReceiver,
 ) (*tableReader, error) {
+	if flowCtx.nodeID == 0 {
+		return nil, errors.Errorf("attempting to create a tableReader with uninitialized NodeID")
+	}
 	tr := &tableReader{
 		flowCtx: flowCtx,
 		tableID: spec.Table.ID,
@@ -144,6 +148,30 @@ func initRowFetcher(
 	return index, isSecondaryIndex, nil
 }
 
+// sendMisplannedRangesMetadata sends information about the non-local ranges
+// that were read by this tableReader. This should be called after the fetcher
+// was used to read everything this tableReader was supposed to read.
+func (tr *tableReader) sendMisplannedRangesMetadata(ctx context.Context) {
+	rangeInfos := tr.fetcher.GetRangeInfo()
+	var misplannedRanges []roachpb.RangeInfo
+	for _, ri := range rangeInfos {
+		if ri.Lease.Replica.NodeID != tr.flowCtx.nodeID {
+			misplannedRanges = append(misplannedRanges, ri)
+		}
+	}
+	if len(misplannedRanges) != 0 {
+		var msg string
+		if len(misplannedRanges) < 3 {
+			msg = fmt.Sprintf("%+v", misplannedRanges[0].Desc)
+		} else {
+			msg = fmt.Sprintf("%+v...", misplannedRanges[:3])
+		}
+		log.VEventf(ctx, 2, "tableReader pushing metadata about misplanned ranges: %s",
+			msg)
+		tr.out.output.Push(nil /* row */, ProducerMetadata{Ranges: misplannedRanges})
+	}
+}
+
 // Run is part of the processor interface.
 func (tr *tableReader) Run(ctx context.Context, wg *sync.WaitGroup) {
 	if wg != nil {
@@ -176,6 +204,7 @@ func (tr *tableReader) Run(ctx context.Context, wg *sync.WaitGroup) {
 			if err != nil {
 				tr.out.output.Push(nil /* row */, ProducerMetadata{Err: err})
 			}
+			tr.sendMisplannedRangesMetadata(ctx)
 			tr.out.close()
 			return
 		}
@@ -185,7 +214,7 @@ func (tr *tableReader) Run(ctx context.Context, wg *sync.WaitGroup) {
 			if err != nil {
 				tr.out.output.Push(nil /* row */, ProducerMetadata{Err: err})
 			}
-			// TODO(andrei): send trailing metadata.
+			tr.sendMisplannedRangesMetadata(ctx)
 			tr.out.close()
 			return
 		}

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -17,11 +17,13 @@
 package distsqlrun
 
 import (
+	"sort"
 	"testing"
 
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -118,6 +120,7 @@ func TestTableReader(t *testing.T) {
 			evalCtx:  parser.EvalContext{},
 			txnProto: &roachpb.Transaction{},
 			clientDB: kvDB,
+			nodeID:   s.NodeID(),
 		}
 
 		out := &RowBuffer{}
@@ -134,7 +137,7 @@ func TestTableReader(t *testing.T) {
 		for {
 			row, meta := out.Next()
 			if !meta.Empty() {
-				t.Fatalf("unexpected metadata: %v", meta)
+				t.Fatalf("unexpected metadata: %+v", meta)
 			}
 			if row == nil {
 				break
@@ -145,5 +148,93 @@ func TestTableReader(t *testing.T) {
 		if result := res.String(); result != c.expected {
 			t.Errorf("invalid results: %s, expected %s'", result, c.expected)
 		}
+	}
+}
+
+// Test that a TableReader outputs metadata about non-local ranges that it read.
+func TestMisplannedRangesMetadata(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tc := serverutils.StartTestCluster(t, 3, /* numNodes */
+		base.TestClusterArgs{
+			ReplicationMode: base.ReplicationManual,
+			ServerArgs: base.TestServerArgs{
+				UseDatabase: "test",
+			},
+		})
+	defer tc.Stopper().Stop()
+
+	db := tc.ServerConn(0)
+	sqlutils.CreateTable(t, db, "t",
+		"num INT PRIMARY KEY",
+		3, /* numRows */
+		sqlutils.ToRowFn(sqlutils.RowIdxFn))
+
+	_, err := db.Exec(`
+ALTER TABLE t SPLIT AT VALUES (1), (2), (3);
+ALTER TABLE t TESTING_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[3], 3);
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kvDB := tc.Server(0).KVClient().(*client.DB)
+	td := sqlbase.GetTableDescriptor(kvDB, "test", "t")
+
+	flowCtx := FlowCtx{
+		evalCtx:  parser.EvalContext{},
+		txnProto: &roachpb.Transaction{},
+		clientDB: kvDB,
+		nodeID:   tc.Server(0).NodeID(),
+	}
+	spec := TableReaderSpec{
+		Spans: []TableReaderSpan{{Span: td.PrimaryIndexSpan()}},
+		Table: *td,
+	}
+	post := PostProcessSpec{
+		OutputColumns: []uint32{0},
+	}
+
+	out := &RowBuffer{}
+	tr, err := newTableReader(&flowCtx, &spec, &post, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr.Run(context.TODO(), nil)
+	if !out.ProducerClosed {
+		t.Fatalf("output RowReceiver not closed")
+	}
+	var res sqlbase.EncDatumRows
+	var metas []ProducerMetadata
+	for {
+		row, meta := out.Next()
+		if !meta.Empty() {
+			metas = append(metas, meta)
+			continue
+		}
+		if row == nil {
+			break
+		}
+		res = append(res, row)
+	}
+	if len(res) != 3 {
+		t.Fatalf("expected 3 rows, got: %s", res)
+	}
+	if len(metas) != 1 {
+		t.Fatalf("expected one meta with misplanned ranges, got: %+v", metas)
+	}
+	misplannedRanges := metas[0].Ranges
+	if len(misplannedRanges) != 2 {
+		t.Fatalf("expected 2 misplanned ranges, got: %+v", misplannedRanges)
+	}
+	// The metadata about misplanned ranges can come in any order (it depends on
+	// the order in which parallel sub-batches complete after having been split by
+	// DistSender).
+	sort.Slice(misplannedRanges, func(i, j int) bool {
+		return misplannedRanges[i].Lease.Replica.NodeID < misplannedRanges[j].Lease.Replica.NodeID
+	})
+	if misplannedRanges[0].Lease.Replica.NodeID != 2 ||
+		misplannedRanges[1].Lease.Replica.NodeID != 3 {
+		t.Fatalf("expected misplanned ranges from nodes 2 and 3, got: %+v", metas[0])
 	}
 }

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -613,7 +613,3 @@ func (rf *RowFetcher) Key() roachpb.Key {
 func (rf *RowFetcher) GetRangeInfo() []roachpb.RangeInfo {
 	return rf.kvFetcher.getRangesInfo()
 }
-
-// TODO(andrei): This is only here so that the unused functions linter doesn't
-// complain. Remove it once GetRangeInfo() starts being used.
-var _ func(*RowFetcher) []roachpb.RangeInfo = (*RowFetcher).GetRangeInfo


### PR DESCRIPTION
... from the tableReader on to consumers as metadata.
Nobody uses this metadata yet; it will be used on the gateway to update
range caches.