### PR TITLE
sqlccl: return job information in BACKUP

### DIFF
--- a/pkg/ccl/sqlccl/backup.go
+++ b/pkg/ccl/sqlccl/backup.go
@@ -432,10 +432,10 @@ func backupPlanHook(
 	}
 
 	header := sql.ResultColumns{
-		{Name: "to", Typ: parser.TypeString},
-		{Name: "startTs", Typ: parser.TypeString},
-		{Name: "endTs", Typ: parser.TypeString},
-		{Name: "dataSize", Typ: parser.TypeInt},
+		{Name: "job_id", Typ: parser.TypeInt},
+		{Name: "status", Typ: parser.TypeString},
+		{Name: "fraction_completed", Typ: parser.TypeFloat},
+		{Name: "bytes", Typ: parser.TypeInt},
 	}
 	fn := func() ([]parser.Datums, error) {
 		// TODO(dan): Move this span into sql.
@@ -487,10 +487,12 @@ func backupPlanHook(
 			log.Errorf(ctx, "BACKUP ignoring error while marking job %d (%s) as successful: %+v",
 				jobLogger.JobID(), description, err)
 		}
+		// TODO(benesch): emit periodic progress updates once we have the
+		// infrastructure to stream responses.
 		ret := []parser.Datums{{
-			parser.NewDString(to),
-			parser.NewDString(startTime.String()),
-			parser.NewDString(endTime.String()),
+			parser.NewDInt(parser.DInt(*jobLogger.JobID())),
+			parser.NewDString(string(sql.JobStatusSucceeded)),
+			parser.NewDFloat(parser.DFloat(1.0)),
 			parser.NewDInt(parser.DInt(desc.DataSize)),
 		}}
 		return ret, nil

--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -177,6 +177,57 @@ func backupRestoreTestSetup(
 	return backupRestoreTestSetupWithParams(t, clusterSize, numAccounts, base.TestClusterArgs{})
 }
 
+func TestBackupStatementResult(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const numAccounts = 1
+
+	_, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts)
+	defer cleanupFn()
+
+	rows := sqlDB.Query("BACKUP DATABASE bench TO $1", dir)
+
+	columns, err := rows.Columns()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e, a := columns, []string{
+		"job_id", "status", "fraction_completed", "bytes",
+	}; !reflect.DeepEqual(e, a) {
+		t.Fatalf("unexpected backup columns:\n%s", strings.Join(pretty.Diff(e, a), "\n"))
+	}
+
+	type job struct {
+		id                int64
+		status            string
+		fractionCompleted float32
+	}
+
+	var expectedJob job
+	var actualJob job
+	var unused int64
+
+	if !rows.Next() {
+		t.Fatal("zero rows in backup result")
+	}
+	if err := rows.Scan(&actualJob.id, &actualJob.status, &actualJob.fractionCompleted, &unused); err != nil {
+		t.Fatal(err)
+	}
+	if rows.Next() {
+		t.Fatal("more than one row in backup result")
+	}
+
+	sqlDB.QueryRow(
+		`SELECT id, status, fraction_completed FROM crdb_internal.jobs WHERE id = $1`, actualJob.id,
+	).Scan(
+		&expectedJob.id, &expectedJob.status, &expectedJob.fractionCompleted,
+	)
+
+	if e, a := expectedJob, actualJob; !reflect.DeepEqual(e, a) {
+		t.Fatalf("backup output does not match system.jobs:\n%s", strings.Join(pretty.Diff(e, a), "\n"))
+	}
+}
+
 func TestBackupRestoreLocal(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	if !storage.ProposerEvaluatedKVEnabled() {
@@ -206,13 +257,13 @@ func backupAndRestore(
 		})
 
 		var unused string
-		var dataSize int64
+		var bytes int64
 		sqlDB.QueryRow(`BACKUP DATABASE bench TO $1`, dest).Scan(
-			&unused, &unused, &unused, &dataSize,
+			&unused, &unused, &unused, &bytes,
 		)
-		approxDataSize := int64(backupRestoreRowPayloadSize) * numAccounts
-		if max := approxDataSize * 2; dataSize < approxDataSize || dataSize > max {
-			t.Errorf("expected data size in [%d,%d] but was %d", approxDataSize, max, dataSize)
+		approxBytes := int64(backupRestoreRowPayloadSize) * numAccounts
+		if max := approxBytes * 2; bytes < approxBytes || bytes > max {
+			t.Errorf("expected data size in [%d,%d] but was %d", approxBytes, max, bytes)
 		}
 	}
 


### PR DESCRIPTION
Adjust the output from `BACKUP` queries to include `job_id`, `status`, and `fraction_completed` columns instead of `startTs` and `endTs`. Users who wish to determine the start and end timestamp can still do so by querying `crdb_internal.jobs` with the job ID. Additionally rename `dataSize` to `bytes`; a future commit will add a `rows` column as well.  These new field names are snake_cased for consistency with `crdb_internal` tables.

These new fields aren't particularly useful yet, since the job has successfully completed by the time we return. However, once we support streaming responses, we'll use these fields to periodically emit job status information.