### PR TITLE
cli: avoid trying to open empty string

### DIFF
--- a/pkg/util/log/test_log_scope.go
+++ b/pkg/util/log/test_log_scope.go
@@ -128,7 +128,7 @@ func (l *TestLogScope) Close(t tShim) {
 					"Details cannot be printed yet because we are still unwinding.\n"+
 					"Hopefully the test harness prints the panic below, otherwise check the test logs.\n")
 			}
-			fmt.Fprintln(OrigStderr, "test logs left over in:", l)
+			fmt.Fprintln(OrigStderr, "test logs left over in:", l.logDir)
 		} else if !l.keepLogs {
 			// Clean up.
 			if err := os.RemoveAll(l.logDir); err != nil {


### PR DESCRIPTION
Before this change, starting the server without a specified log
directory would immediately produce the log lines

	W170411 17:28:35.423319 1 cli/start.go:135  open : no such file or directory
	W170411 17:28:35.423326 1 cli/start.go:135  open : no such file or directory
	W170411 17:28:35.423340 1 cli/start.go:135  open : no such file or directory