### PR TITLE
util/log: cleanup TestGC

### DIFF
--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"io/ioutil"
 	stdLog "log"
-	"math"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -505,35 +504,69 @@ func TestGC(t *testing.T) {
 	s := Scope(t, "")
 	defer s.Close(t)
 
+	logging.mu.Lock()
+	logging.disableDaemons = true
+	defer func(previous bool) {
+		logging.mu.Lock()
+		logging.disableDaemons = previous
+		logging.mu.Unlock()
+	}(logging.disableDaemons)
+	logging.mu.Unlock()
+
 	setFlags()
-	logging.stderrThreshold.set(Severity_NONE)
+
+	const maxTotalLogFileSize = 1500
+	const singleLineLogFileSize = 650 // This is an approximation.
+	// Since each log file is ~650 bytes in size. GC should always trim the
+	// total log files down to 2.
+	const expectedFilesAfterGC = maxTotalLogFileSize / singleLineLogFileSize
+	const newLogFiles = 20
+
 	// Prevent writes to stderr from being sent to log files which would screw up
 	// the expected number of log file calculation below.
 	logging.noStderrRedirect = true
+
 	defer func(previous uint64) { MaxSize = previous }(MaxSize)
 	MaxSize = 1 // ensure rotation on every log write
 	defer func(previous uint64) {
 		atomic.StoreUint64(&MaxSizePerSeverity, previous)
 	}(MaxSizePerSeverity)
-	atomic.StoreUint64(&MaxSizePerSeverity, 1500)
-	const expectedFiles = 2
+	atomic.StoreUint64(&MaxSizePerSeverity, maxTotalLogFileSize)
 
-	// Empirically, each log file is ~650 bytes in size. Create 20 log files per
-	// level. GC should trim this down to 2.
-	for i := 0; i < expectedFiles*10; i++ {
-		Info(context.Background(), "x")
-	}
-
-	// Ensure the GC has seen the most recent files.
-	logging.gcOldFiles()
-
-	allFiles, err := ListLogFiles()
+	allFilesOriginal, err := ListLogFiles()
 	if err != nil {
 		t.Fatal(err)
 	}
-	files := selectFiles(allFiles, math.MaxInt64)
-	if expectedFiles != len(files) {
-		t.Fatalf("%s: expected %d, but found %d", s.logDir, expectedFiles, len(files))
+	if e, a := 0, len(allFilesOriginal); e != a {
+		t.Fatalf("expected %d files, but found %d", e, a)
+	}
+
+	for i := 0; i < newLogFiles; i++ {
+		Infof(context.Background(), "%d", i)
+		Flush()
+	}
+
+	allFilesBefore, err := ListLogFiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The +1 here is created from clog's createFile(). All subsequent files are
+	// created from clog's write(). Both of these are called from clog's
+	// outputLogEntry, but it's a quirk of this test due to setting MaxSize to
+	// such a low number that the first file is ignored and the 2nd file is
+	// created within the same call.
+	if e, a := newLogFiles+1, len(allFilesBefore); e != a {
+		t.Fatalf("expected %d files, but found %d", e, a)
+	}
+
+	logging.gcOldFiles()
+
+	allFilesAfter, err := ListLogFiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e, a := expectedFilesAfterGC, len(allFilesAfter); e != a {
+		t.Fatalf("expected %d files, but found %d", e, a)
 	}
 }
 


### PR DESCRIPTION
This test was failing on windows with a high regularity due to not flushing the logs before gcing them.
To make this test predictable, a mechanism to disable the gc was added.
