### PR TITLE
sqlccl: prevent bogus azure account names from panicing

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -1372,3 +1372,27 @@ func TestBackupRestorePermissions(t *testing.T) {
 		}
 	})
 }
+
+func TestBackupAzureAccountName(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const numAccounts = 1
+	_, _, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts)
+	defer cleanupFn()
+
+	values := url.Values{}
+	values.Set("AZURE_ACCOUNT_KEY", "password")
+	values.Set("AZURE_ACCOUNT_NAME", "\n")
+
+	url := &url.URL{
+		Scheme:   "azure",
+		Host:     "host",
+		Path:     "/backup",
+		RawQuery: values.Encode(),
+	}
+
+	// Verify newlines in the account name cause an error.
+	if _, err := sqlDB.DB.Exec(`backup database d to $1`, url.String()); !testutils.IsError(err, "azure account name invalid") {
+		t.Fatalf("unexpected error, got %v", err)
+	}
+}

--- a/pkg/ccl/storageccl/export_storage.go
+++ b/pkg/ccl/storageccl/export_storage.go
@@ -17,6 +17,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	gcs "cloud.google.com/go/storage"
@@ -375,9 +376,16 @@ type azureStorage struct {
 
 var _ ExportStorage = &azureStorage{}
 
+var azureAccountNameRegex = regexp.MustCompile(`^[a-z0-9]{3,24}$`)
+
 func makeAzureStorage(conf *roachpb.ExportStorage_Azure) (ExportStorage, error) {
 	if conf == nil {
 		return nil, errors.Errorf("azure upload requested but info missing")
+	}
+	// TODO(mjibson): Remove when
+	// https://github.com/Azure/azure-sdk-for-go/issues/584 is fixed.
+	if !azureAccountNameRegex.MatchString(conf.AccountName) {
+		return nil, errors.New("azure account name invalid")
 	}
 	client, err := azr.NewBasicClient(conf.AccountName, conf.AccountKey)
 	if err != nil {


### PR DESCRIPTION
Fixes #14465
See Azure/azure-sdk-for-go#584