### PR TITLE
sql: statement statistics, step three

### DIFF
--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -46,11 +46,8 @@ type stmtStats struct {
 
 // StmtStatsEnable determines whether to collect per-statement
 // statistics.
-// Note: in the future we will want to have this collection enabled at
-// all times. We hide it behind an environment variable until further
-// testing confirms it works and is stable.
 var StmtStatsEnable = envutil.EnvOrDefaultBool(
-	"COCKROACH_SQL_STMT_STATS_ENABLE", false,
+	"COCKROACH_SQL_STMT_STATS_ENABLE", true,
 )
 
 // SQLStatsCollectionLatencyThreshold specifies the minimum amount of time

--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -91,7 +91,7 @@ func (a *appStats) recordStatement(
 	if distSQLUsed {
 		buf.WriteByte('+')
 	}
-	parser.FormatNode(&buf, parser.FmtSimple, stmt)
+	parser.FormatNode(&buf, parser.FmtHideConstants, stmt)
 	stmtKey := buf.String()
 
 	// Get the statistics object.

--- a/pkg/sql/parser/format.go
+++ b/pkg/sql/parser/format.go
@@ -25,6 +25,7 @@ type fmtFlags struct {
 	showTypes        bool
 	ShowTableAliases bool
 	symbolicVars     bool
+	hideConstants    bool
 	// tableNameNormalizer will be called on all NormalizableTableNames if it is
 	// non-nil. Its results will be used if they are non-nil, or ignored if they
 	// are nil.
@@ -68,6 +69,10 @@ var FmtBareStrings FmtFlags = &fmtFlags{bareStrings: true}
 // can be parsed into an equivalent expression (useful for serialization of
 // expressions).
 var FmtParsable FmtFlags = &fmtFlags{disambiguateDatumTypes: true}
+
+// FmtHideConstants instructs the pretty-printer to produce a
+// representation that does not disclose query-specific data.
+var FmtHideConstants FmtFlags = &fmtFlags{hideConstants: true}
 
 // FmtNormalizeTableNames returns FmtFlags that instructs the pretty-printer
 // to normalize all table names using the provided function.
@@ -118,7 +123,7 @@ func FormatNode(buf *bytes.Buffer, f FmtFlags, n NodeFormatter) {
 	if f.showTypes {
 		if te, ok := n.(TypedExpr); ok {
 			buf.WriteByte('(')
-			n.Format(buf, f)
+			formatNodeOrHideConstants(buf, f, n)
 			buf.WriteString(")[")
 			if rt := te.ResolvedType(); rt == nil {
 				// An attempt is made to pretty-print an expression that was
@@ -133,7 +138,7 @@ func FormatNode(buf *bytes.Buffer, f FmtFlags, n NodeFormatter) {
 			return
 		}
 	}
-	n.Format(buf, f)
+	formatNodeOrHideConstants(buf, f, n)
 	if f.disambiguateDatumTypes {
 		var typ Type
 		if d, isDatum := n.(Datum); isDatum {

--- a/pkg/sql/parser/hide_constants.go
+++ b/pkg/sql/parser/hide_constants.go
@@ -1,0 +1,103 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//
+
+package parser
+
+import "bytes"
+
+// formatNodeOrHideConstants recurses into a node for pretty-printing,
+// unless hideConstants is set in the flags and the node is a datum or
+// a literal.
+func formatNodeOrHideConstants(buf *bytes.Buffer, f FmtFlags, n NodeFormatter) {
+	if f.hideConstants {
+		switch v := n.(type) {
+		case *ValuesClause:
+			v.formatHideConstants(buf, f)
+			return
+		case *ComparisonExpr:
+			if v.Operator == In || v.Operator == NotIn {
+				if t, ok := v.Right.(*Tuple); ok {
+					v.formatInTupleAndHideConstants(buf, f, t)
+					return
+				}
+			}
+		case Datum, Constant:
+			buf.WriteByte('_')
+			return
+		}
+	}
+	n.Format(buf, f)
+}
+
+// formatInTupleAndHideConstants formats an "a IN (...)" expression
+// and collapses the tuple on the right to contain at most 2 elements
+// if it otherwise only contains literals or placeholders.
+// e.g.:
+//    a IN (1, 2, 3)       -> a IN (_, _)
+//    a IN (x+1, x+2, x+3) -> a IN (x+_, x+_, x+_)
+func (node *ComparisonExpr) formatInTupleAndHideConstants(
+	buf *bytes.Buffer, f FmtFlags, rightTuple *Tuple,
+) {
+	exprFmtWithParen(buf, f, node.Left)
+	buf.WriteByte(' ')
+	buf.WriteString(node.Operator.String())
+	buf.WriteByte(' ')
+	rightTuple.formatHideConstants(buf, f)
+}
+
+// formatHideConstants shortens multi-valued VALUES clauses to a
+// VALUES clause with a single value.
+// e.g. VALUES (a,b,c), (d,e,f) -> VALUES (_, _, _)
+func (node *ValuesClause) formatHideConstants(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("VALUES ")
+	node.Tuples[0].Format(buf, f)
+}
+
+// formatHideConstants formats tuples containing only literals or
+// placeholders and longer than 1 element as a tuple of its first
+// two elements, scrubbed.
+// e.g. (1)               -> (_)
+//      (1, 2)            -> (_, _)
+//      (1, 2, 3)         -> (_, _)
+//      ROW()             -> ROW()
+//      ROW($1, $2, $3)   -> ROW($1, $2)
+//      (1+2, 2+3, 3+4)   -> (_ + _, _ + _, _ + _)
+//      (1+2, b, c)       -> (_ + _, b, c)
+func (node *Tuple) formatHideConstants(buf *bytes.Buffer, f FmtFlags) {
+	if len(node.Exprs) < 2 {
+		node.Format(buf, f)
+		return
+	}
+
+	// First, determine if there are only literals/placeholders.
+	var i int
+	for i = 0; i < len(node.Exprs); i++ {
+		switch node.Exprs[i].(type) {
+		case Datum, Constant, *Placeholder:
+			continue
+		}
+		break
+	}
+	// If so, then use the special representation.
+	if i == len(node.Exprs) {
+		// We copy the node to preserve the "row" boolean flag.
+		v2 := *node
+		v2.Exprs = v2.Exprs[:2]
+		v2.Format(buf, f)
+		return
+	}
+	node.Format(buf, f)
+}

--- a/pkg/sql/testdata/logic_test/crdb_internal
+++ b/pkg/sql/testdata/logic_test/crdb_internal
@@ -58,34 +58,6 @@ SELECT NAME from crdb_internal.tables WHERE DATABASE_NAME = 'testdb'
 foo
 "\'
 
-# Check that node_statement_statistics report per application
-
-statement ok
-SET application_name = hello; SELECT 1
-
-statement ok
-SET application_name = world; SELECT 2
-
-query B
-SELECT count > 0 FROM crdb_internal.node_statement_statistics WHERE application_name IN ('hello', 'world')
-----
-true
-true
-
-# Check that node_statement_statistics report per statement
-
-statement ok
-SET application_name = hello; SELECT 1; SELECT 1,2; SELECT 1
-
-query B
-SELECT count >= 2 FROM crdb_internal.node_statement_statistics WHERE application_name = 'hello' AND key = 'SELECT 1'
-----
-true
-
-# reset for other tests.
-statement ok
-SET application_name = ''
-
 query TT colnames
 SELECT field, value FROM crdb_internal.node_build_info WHERE field ILIKE 'name'
 ----

--- a/pkg/sql/testdata/logic_test/statement_statistics
+++ b/pkg/sql/testdata/logic_test/statement_statistics
@@ -1,0 +1,75 @@
+# LogicTest: default
+
+# Check that node_statement_statistics report per application
+
+statement ok
+SET application_name = hello; SELECT 1
+
+statement ok
+SET application_name = world; SELECT 2
+
+query B
+SELECT count > 0 FROM crdb_internal.node_statement_statistics WHERE application_name IN ('hello', 'world')
+----
+true
+true
+
+# Check that node_statement_statistics report per statement
+
+statement ok
+SET application_name = hello; SELECT 1; SELECT 1,2; SELECT 1
+
+# reset for other tests.
+statement ok
+SET application_name = ''
+
+query TB
+SELECT key, count >= 1 FROM crdb_internal.node_statement_statistics WHERE application_name = 'hello' AND key LIKE 'SELECT%'
+----
+SELECT _    true
+SELECT _, _ true
+
+statement ok
+CREATE TABLE test(x INT, y INT, z INT)
+
+statement ok
+SET application_name = 'valuetest'
+
+# Check that multi-value clauses are shortened.
+
+statement ok
+SELECT x FROM (VALUES (1,2,3), (4,5,6)) AS t(x)
+
+statement ok
+INSERT INTO test VALUES (1, 2, 3), (4, 5, 6)
+
+# Check that the RHS of IN comparisons are shortened.
+
+statement ok
+SELECT x FROM test WHERE y IN (4, 5, 6, 7, 8)
+
+statement ok
+SELECT x FROM test WHERE y NOT IN (4, 5, 6, 7, 8)
+
+# Check that a non-constant prevents shortening.
+
+statement ok
+SELECT x FROM test WHERE y IN (4, 5, 6+x, 7, 8)
+
+# Check that tuples in other positions are not shortened.
+
+statement ok
+SELECT ROW(1,2,3,4,5) FROM test WHERE FALSE
+
+statement ok
+SET application_name = ''
+
+query T
+SELECT key FROM crdb_internal.node_statement_statistics WHERE application_name = 'valuetest' ORDER BY key
+----
+INSERT INTO test VALUES (_, _, _)
+SELECT ROW(_, _, _, _, _) FROM test WHERE _
+SELECT x FROM (VALUES (_, _, _)) AS t (x)
+SELECT x FROM test WHERE y IN (_, _)
+SELECT x FROM test WHERE y IN (_, _, _ + x, _, _)
+SELECT x FROM test WHERE y NOT IN (_, _)


### PR DESCRIPTION
Two patches:

### sql: scrub queries collected fo per-statement statistics

This patch introduces a new AST formatting option `FmtScrubbed` which
causes all datums and literals to be replaced by underscores. This
achieves two goals:

- it removes potentially sensitive information from collected statistics;
- it ensures that statements which are equivalent modulo the constants
  have the same "statistics key" and thus that their statistics are grouped
  together.

One of the side goals when I initially implemented this was to report
the type of the datums and literals in the scrubbed form, so as to
provide more information for offline analysis. This goal cannot be
achieved at this point without a major refactor however: the typing
information is currently not stored back in the AST and thus not
available to the pretty-printer. To achieve this would mandate
rewriting all the AST->planNode constructors.

### sql: enable SQL statement statistics collection by default.

cc @petermattis 

Advances #13968.