### PR TITLE
cli: register single-line multi-statements as a single history entry.

### DIFF
--- a/pkg/cli/interactive_tests/test_history.tcl
+++ b/pkg/cli/interactive_tests/test_history.tcl
@@ -72,6 +72,18 @@ send "\r"
 eexpect "1 row"
 eexpect root@
 
+# Test that two statements on the same line can be recalled together.
+send "select 2; select 3;\r"
+eexpect "1 row"
+eexpect "1 row"
+eexpect root@
+send "\033\[A"
+eexpect "SELECT 2; SELECT 3;"
+send "\r"
+eexpect "1 row"
+eexpect "1 row"
+eexpect root@
+
 # Finally terminate with Ctrl+C
 interrupt
 eexpect eof


### PR DESCRIPTION
Prior to this patch, if the user would enter `select 1; select 2;` on
the same line, the shell would split them as separate statements and
then register them as two separate history entries. This would
inconvenience the user who would then have to navigate to both
statements separately to recall them.

This patch alleviates the inconvenience by ensuring that single-line
multi-statement entries are registered as a single history entry.

Fixes  #13562.