### PR TITLE
storageccl: change uri scheme for local file system

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -167,7 +167,7 @@ func backupRestoreTestSetupWithParams(
 		dirCleanupFn()
 	}
 
-	return ctx, dir, tc, sqlDB, cleanupFn
+	return ctx, "nodelocal://" + dir, tc, sqlDB, cleanupFn
 }
 
 func backupRestoreTestSetup(
@@ -1112,11 +1112,14 @@ func TestBackupRestoreChecksum(t *testing.T) {
 	_, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts)
 	defer cleanupFn()
 
+	// The helper helpfully prefixes it, but we're going to do direct file IO.
+	rawDir := strings.TrimPrefix(dir, "nodelocal://")
+
 	sqlDB.Exec(`BACKUP DATABASE bench TO $1`, dir)
 
 	var backupDesc BackupDescriptor
 	{
-		backupDescBytes, err := ioutil.ReadFile(filepath.Join(dir, BackupDescriptorName))
+		backupDescBytes, err := ioutil.ReadFile(filepath.Join(rawDir, BackupDescriptorName))
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
@@ -1126,7 +1129,7 @@ func TestBackupRestoreChecksum(t *testing.T) {
 	}
 
 	// Corrupt one of the files in the backup.
-	f, err := os.OpenFile(filepath.Join(dir, backupDesc.Files[1].Path), os.O_WRONLY, 0)
+	f, err := os.OpenFile(filepath.Join(rawDir, backupDesc.Files[1].Path), os.O_WRONLY, 0)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
@@ -1301,12 +1304,12 @@ func TestBackupLevelDB(t *testing.T) {
 	defer cleanupFn()
 
 	_ = sqlDB.Exec(`BACKUP DATABASE bench TO $1`, dir)
-
+	rawDir := strings.TrimPrefix(dir, "nodelocal://")
 	// Verify that the sstables are in LevelDB format by checking the trailer
 	// magic.
 	var magic = []byte("\x57\xfb\x80\x8b\x24\x75\x47\xdb")
 	foundSSTs := 0
-	if err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+	if err := filepath.Walk(rawDir, func(path string, info os.FileInfo, err error) error {
 		if filepath.Ext(path) == ".sst" {
 			foundSSTs++
 			data, err := ioutil.ReadFile(path)

--- a/pkg/ccl/storageccl/export_storage.go
+++ b/pkg/ccl/storageccl/export_storage.go
@@ -92,7 +92,7 @@ func ExportStorageConfFromURI(path string) (roachpb.ExportStorage, error) {
 	case "http", "https":
 		conf.Provider = roachpb.ExportStorageProvider_Http
 		conf.HttpPath.BaseUri = path
-	case "", "file":
+	case "nodelocal":
 		conf.Provider = roachpb.ExportStorageProvider_LocalFile
 		conf.LocalFile.Path = uri.Path
 	default:

--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -175,7 +175,7 @@ func TestImport(t *testing.T) {
 	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop()
 
-	storage, err := ExportStorageConfFromURI(dir)
+	storage, err := ExportStorageConfFromURI("nodelocal://" + dir)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}


### PR DESCRIPTION
file:// (along with implicit local file when using no scheme) may be *too* easy to find and misunderstand:
one might mistakenly assume it will use the path on the sql gateway, or perhaps even the client.

since backup and restore are *distributed* across all nodes though, using local file system on each node
only makes sense if something (some other tool, nfs, etc) is moving files around, so making it a little
harder to find and giving it a slightly more descriptive name will hopefully minimize confusion.

Fixes #14453.