### PR TITLE
sql: refactor uses of MakeIndexKeyPrefix

### DIFF
--- a/pkg/sql/distsqlplan/fake_span_resolver_test.go
+++ b/pkg/sql/distsqlplan/fake_span_resolver_test.go
@@ -61,8 +61,7 @@ func TestFakeSpanResolver(t *testing.T) {
 
 	desc := sqlbase.GetTableDescriptor(db, "test", "t")
 
-	prefix := roachpb.Key(sqlbase.MakeIndexKeyPrefix(desc, desc.PrimaryIndex.ID))
-	span := roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()}
+	span := desc.PrimaryIndexSpan()
 
 	// Make sure we see all the nodes. It will not always happen (due to
 	// randomness) but it should happen most of the time.
@@ -85,7 +84,7 @@ func TestFakeSpanResolver(t *testing.T) {
 			t.Logf("%d %s %s", rinfo.NodeID, prettyStart, prettyEnd)
 
 			if !lastKey.Equal(desc.StartKey.AsRawKey()) {
-				t.Errorf("unexpected start key %s, should be %s", prettyStart, keys.PrettyPrint(prefix))
+				t.Errorf("unexpected start key %s, should be %s", prettyStart, keys.PrettyPrint(span.Key))
 			}
 			if !desc.StartKey.Less(desc.EndKey) {
 				t.Errorf("invalid range %s to %s", prettyStart, prettyEnd)

--- a/pkg/sql/show_ranges.go
+++ b/pkg/sql/show_ranges.go
@@ -44,13 +44,9 @@ func (p *planner) ShowRanges(ctx context.Context, n *parser.ShowRanges) (planNod
 	}
 	// Note: for interleaved tables, the ranges we report will include rows from
 	// interleaving.
-	keyPrefix := roachpb.Key(sqlbase.MakeIndexKeyPrefix(tableDesc, index.ID))
 	return &showRangesNode{
-		p: p,
-		span: roachpb.Span{
-			Key:    keyPrefix,
-			EndKey: keyPrefix.PrefixEnd(),
-		},
+		p:      p,
+		span:   tableDesc.IndexSpan(index.ID),
 		values: make([]parser.Datum, len(showRangesColumns)),
 	}, nil
 }

--- a/pkg/sql/split_at.go
+++ b/pkg/sql/split_at.go
@@ -441,8 +441,7 @@ func (p *planner) Scatter(ctx context.Context, n *parser.Scatter) (planNode, err
 	var span roachpb.Span
 	if n.From == nil {
 		// No FROM/TO specified; the span is the entire table/index.
-		span.Key = roachpb.Key(sqlbase.MakeIndexKeyPrefix(tableDesc, index.ID))
-		span.EndKey = span.Key.PrefixEnd()
+		span = tableDesc.IndexSpan(index.ID)
 	} else {
 		switch {
 		case len(n.From) == 0:

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1546,8 +1546,7 @@ func (desc *TableDescriptor) AddColumnMutation(
 	c ColumnDescriptor, direction DescriptorMutation_Direction,
 ) {
 	m := DescriptorMutation{Descriptor_: &DescriptorMutation_Column{Column: &c}, Direction: direction}
-	prefix := roachpb.Key(MakeIndexKeyPrefix(desc, desc.PrimaryIndex.ID))
-	m.ResumeSpans = append(m.ResumeSpans, roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()})
+	m.ResumeSpans = append(m.ResumeSpans, desc.PrimaryIndexSpan())
 	desc.addMutation(m)
 }
 
@@ -1556,8 +1555,7 @@ func (desc *TableDescriptor) AddIndexMutation(
 	idx IndexDescriptor, direction DescriptorMutation_Direction,
 ) {
 	m := DescriptorMutation{Descriptor_: &DescriptorMutation_Index{Index: &idx}, Direction: direction}
-	prefix := roachpb.Key(MakeIndexKeyPrefix(desc, desc.PrimaryIndex.ID))
-	m.ResumeSpans = append(m.ResumeSpans, roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()})
+	m.ResumeSpans = append(m.ResumeSpans, desc.PrimaryIndexSpan())
 	desc.addMutation(m)
 }
 
@@ -1915,6 +1913,12 @@ func (desc *TableDescriptor) PrimaryIndexSpan() roachpb.Span {
 // for a full index scan.
 func (desc *TableDescriptor) IndexSpan(indexID IndexID) roachpb.Span {
 	prefix := roachpb.Key(MakeIndexKeyPrefix(desc, indexID))
+	return roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()}
+}
+
+// TableSpan returns the Span that corresponds to the entire table.
+func (desc *TableDescriptor) TableSpan() roachpb.Span {
+	prefix := roachpb.Key(keys.MakeTablePrefix(uint32(desc.ID)))
 	return roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()}
 }
 

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -189,7 +189,9 @@ func MakeColumnDefDescs(
 	return col, idx, nil
 }
 
-// MakeIndexKeyPrefix returns the key prefix used for the index's data.
+// MakeIndexKeyPrefix returns the key prefix used for the index's data. If you
+// need the corresponding Span, prefer desc.IndexSpan(indexID) or
+// desc.PrimaryIndexSpan().
 func MakeIndexKeyPrefix(desc *TableDescriptor, indexID IndexID) []byte {
 	var key []byte
 	if i, err := desc.FindIndexByID(indexID); err == nil && len(i.Interleave.Ancestors) > 0 {

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -662,9 +662,7 @@ func (td *tableDeleter) deleteAllRowsScan(
 	ctx context.Context, resume roachpb.Span, limit int64,
 ) (roachpb.Span, error) {
 	if resume.Key == nil {
-		tablePrefix := sqlbase.MakeIndexKeyPrefix(
-			td.rd.Helper.TableDesc, td.rd.Helper.TableDesc.PrimaryIndex.ID)
-		resume = roachpb.Span{Key: roachpb.Key(tablePrefix), EndKey: roachpb.Key(tablePrefix).PrefixEnd()}
+		resume = td.rd.Helper.TableDesc.PrimaryIndexSpan()
 	}
 	valNeededForCol := make([]bool, len(td.rd.Helper.TableDesc.Columns))
 	for _, idx := range td.rd.FetchColIDtoRowIndex {
@@ -730,11 +728,7 @@ func (td *tableDeleter) deleteIndexFast(
 	ctx context.Context, idx *sqlbase.IndexDescriptor, resume roachpb.Span, limit int64,
 ) (roachpb.Span, error) {
 	if resume.Key == nil {
-		indexPrefix := roachpb.Key(sqlbase.MakeIndexKeyPrefix(td.rd.Helper.TableDesc, idx.ID))
-		resume = roachpb.Span{
-			Key:    indexPrefix,
-			EndKey: indexPrefix.PrefixEnd(),
-		}
+		resume = td.rd.Helper.TableDesc.IndexSpan(idx.ID)
 	}
 
 	if log.V(2) {
@@ -755,9 +749,7 @@ func (td *tableDeleter) deleteIndexScan(
 	ctx context.Context, idx *sqlbase.IndexDescriptor, resume roachpb.Span, limit int64,
 ) (roachpb.Span, error) {
 	if resume.Key == nil {
-		tablePrefix := sqlbase.MakeIndexKeyPrefix(
-			td.rd.Helper.TableDesc, td.rd.Helper.TableDesc.PrimaryIndex.ID)
-		resume = roachpb.Span{Key: roachpb.Key(tablePrefix), EndKey: roachpb.Key(tablePrefix).PrefixEnd()}
+		resume = td.rd.Helper.TableDesc.PrimaryIndexSpan()
 	}
 	valNeededForCol := make([]bool, len(td.rd.Helper.TableDesc.Columns))
 	for _, idx := range td.rd.FetchColIDtoRowIndex {


### PR DESCRIPTION
desc.IndexSpan and desc.PrimaryIndexSpan are more concise than the
equivalent constructions with MakeIndexKeyPrefix, and MakeIndexKeyPrefix
call sites require auditing when there are problems with interleaved
tables (e.g., #13451). Use IndexSpan, PrimaryIndexSpan, and the new
method TableSpan consistently.