### PR TITLE
storage: Consider it a success if the desired replica already exists

### DIFF
--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -3425,7 +3425,8 @@ func (r *Replica) ChangeReplicas(
 		// abort the replica add.
 		if nodeUsed {
 			if repDescIdx != -1 {
-				return errors.Errorf("%s: unable to add replica %v which is already present", r, repDesc)
+				log.Infof(ctx, "unable to add replica %v which is already present", repDesc)
+				return nil
 			}
 			return errors.Errorf("%s: unable to add replica %v; node already has a replica", r, repDesc)
 		}
@@ -3473,7 +3474,8 @@ func (r *Replica) ChangeReplicas(
 		// If that exact node-store combination does not have the replica,
 		// abort the removal.
 		if repDescIdx == -1 {
-			return errors.Errorf("%s: unable to remove replica %v which is not present", r, repDesc)
+			log.Infof(ctx, "unable to remove replica %v which is not present", repDesc)
+			return nil
 		}
 		updatedDesc.Replicas[repDescIdx] = updatedDesc.Replicas[len(updatedDesc.Replicas)-1]
 		updatedDesc.Replicas = updatedDesc.Replicas[:len(updatedDesc.Replicas)-1]


### PR DESCRIPTION
This is actually behaviorally identical to returning an error given that
the queue just logs errors and moves on, but it reduces the severity of
the message for a situation that doesn't really mean anything is wrong.
If the desired target store already has a replica for the range, then
that's effectively a success.

Fixes #13916, although this change is arguably not worth making. None of our prod clusters have seen this error.