### PR TITLE
settings: expose primitive callback registration

### DIFF
--- a/pkg/settings/cache.go
+++ b/pkg/settings/cache.go
@@ -138,4 +138,32 @@ func (u Updater) Apply() {
 	cache.Lock()
 	cache.values = u
 	cache.Unlock()
+
+	afterApply.Lock()
+	for _, f := range afterApply.hooks {
+		f()
+	}
+	afterApply.Unlock()
+}
+
+var afterApply struct {
+	syncutil.Mutex
+	hooks []func()
+}
+
+// RegisterCallback registers `f` to be called immediately and then after new
+// settings are read (even if there are no changes).
+//
+// `f` would likely read a setting to update an atomic int or channel, or
+// otherwise trigger additional work. `f` should not block, or otherwise do any
+// lengthy work itself, as it blocks the settings updater.
+//
+// RegisterCallback can (and likely should) be called at `init` -- indeed, the
+// eager call during registration is intended to ensure it initializes defaults
+// even before the first gossip update is received.
+func RegisterCallback(f func()) {
+	f()
+	afterApply.Lock()
+	afterApply.hooks = append(afterApply.hooks, f)
+	afterApply.Unlock()
 }

--- a/pkg/settings/cache_test.go
+++ b/pkg/settings/cache_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 )
 
+var i1, i2 int
 
 func init() {
 	registry = map[string]value{
@@ -31,6 +32,12 @@ func init() {
 		"i.2":     {typ: IntValue, i: 5},
 		"f":       {typ: FloatValue, f: 5.4},
 	}
+
+	RegisterCallback(func() {
+		i1 = getInt("i.1")
+		i2 = getInt("i.2")
+	})
+}
 
 func TestCache(t *testing.T) {
 	t.Run("defaults", func(t *testing.T) {
@@ -50,6 +57,13 @@ func TestCache(t *testing.T) {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 		if expected, actual := 5, getInt("i.2"); expected != actual {
+			t.Fatalf("expected %v, got %v", expected, actual)
+		}
+		// registering callback should have also run it initially and set default.
+		if expected, actual := 0, i1; expected != actual {
+			t.Fatalf("expected %v, got %v", expected, actual)
+		}
+		if expected, actual := 5, i2; expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 		if expected, actual := 5.4, getFloat("f"); expected != actual {
@@ -97,6 +111,12 @@ func TestCache(t *testing.T) {
 		if expected, actual := 3, getInt("i.2"); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
+		if expected, actual := 0, i1; expected != actual {
+			t.Fatalf("expected %v, got %v", expected, actual)
+		}
+		if expected, actual := 3, i2; expected != actual {
+			t.Fatalf("expected %v, got %v", expected, actual)
+		}
 		if expected, actual := 3.1, getFloat("f"); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
@@ -113,10 +133,22 @@ func TestCache(t *testing.T) {
 			if err := u.Add("bool.f", EncodeBool(true), "b"); err != nil {
 				t.Fatal(err)
 			}
+			if err := u.Add("i.1", EncodeInt(1), "i"); err != nil {
+				t.Fatal(err)
+			}
+			if err := u.Add("i.2", EncodeInt(7), "i"); err != nil {
+				t.Fatal(err)
+			}
 			u.Apply()
 		}
 
 		if expected, actual := true, getBool("bool.f"); expected != actual {
+			t.Fatalf("expected %v, got %v", expected, actual)
+		}
+		if expected, actual := 1, i1; expected != actual {
+			t.Fatalf("expected %v, got %v", expected, actual)
+		}
+		if expected, actual := 7, i2; expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 		// If the updater doesn't have a key, e.g. if the setting has been deleted,
@@ -124,6 +156,12 @@ func TestCache(t *testing.T) {
 		MakeUpdater().Apply()
 
 		if expected, actual := false, getBool("bool.f"); expected != actual {
+			t.Fatalf("expected %v, got %v", expected, actual)
+		}
+		if expected, actual := 0, i1; expected != actual {
+			t.Fatalf("expected %v, got %v", expected, actual)
+		}
+		if expected, actual := 5, i2; expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 

--- a/pkg/settings/cache_test.go
+++ b/pkg/settings/cache_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 )
 
-func TestCache(t *testing.T) {
-	defaultsBefore := registry
+
+func init() {
 	registry = map[string]value{
 		"bool.t":  {typ: BoolValue, b: true},
 		"bool.f":  {typ: BoolValue},
@@ -31,18 +31,8 @@ func TestCache(t *testing.T) {
 		"i.2":     {typ: IntValue, i: 5},
 		"f":       {typ: FloatValue, f: 5.4},
 	}
-	cache.Lock()
-	before := cache.values
-	cache.values = nil
-	cache.Unlock()
 
-	defer func() {
-		registry = defaultsBefore
-		cache.Lock()
-		cache.values = before
-		cache.Unlock()
-	}()
-
+func TestCache(t *testing.T) {
 	t.Run("defaults", func(t *testing.T) {
 		if expected, actual := false, getBool("bool.f"); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)


### PR DESCRIPTION
callers might want to just read an atomic int or something that the settings mechanism updates for them.
eventually we might want to polish use cases like that with dedicated wrappers, but we can start with
something simple like this and see what patterns end up proving useful.