### PR TITLE
storage: optimize TimestampCache.ExpandRequests

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1143,6 +1143,21 @@ func (rs RSpan) Intersect(desc *RangeDescriptor) (RSpan, error) {
 	return RSpan{key, endKey}, nil
 }
 
+// asRawSpan returns the RSpan as a Span. This is to be used only in select
+// situations in which an RSpan is known to not contain a wrapped locally-
+// addressed Span. Do not export.
+func (rs RSpan) asRawSpan() Span {
+	return Span{
+		Key:    Key(rs.Key),
+		EndKey: Key(rs.EndKey),
+	}
+}
+
+// Overlaps returns whether the two spans overlap.
+func (rs RSpan) Overlaps(other RSpan) bool {
+	return rs.asRawSpan().Overlaps(other.asRawSpan())
+}
+
 // KeyValueByKey implements sorting of a slice of KeyValues by key.
 type KeyValueByKey []KeyValue
 

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1562,7 +1562,13 @@ func (ec *endCmds) done(br *roachpb.BatchResponse, pErr *roachpb.Error, retry pr
 	// marked as affecting the cache are processed. Inconsistent reads
 	// are excluded.
 	if pErr == nil && retry == proposalNoRetry && ec.ba.ReadConsistency != roachpb.INCONSISTENT {
-		creq := makeCacheRequest(&ec.ba, br)
+		span, err := keys.Range(ec.ba)
+		if err != nil {
+			// This can't happen because we've already called keys.Range before
+			// evaluating the request.
+			log.Fatal(context.Background(), err)
+		}
+		creq := makeCacheRequest(&ec.ba, br, span)
 		ec.repl.store.tsCacheMu.Lock()
 		ec.repl.store.tsCacheMu.cache.AddRequest(creq)
 		ec.repl.store.tsCacheMu.Unlock()
@@ -1576,8 +1582,11 @@ func (ec *endCmds) done(br *roachpb.BatchResponse, pErr *roachpb.Error, retry pr
 	ec.repl.cmdQMu.Unlock()
 }
 
-func makeCacheRequest(ba *roachpb.BatchRequest, br *roachpb.BatchResponse) cacheRequest {
+func makeCacheRequest(
+	ba *roachpb.BatchRequest, br *roachpb.BatchResponse, span roachpb.RSpan,
+) cacheRequest {
 	cr := cacheRequest{
+		span:      span,
 		timestamp: ba.Timestamp,
 		txnID:     ba.GetTxnID(),
 	}
@@ -1851,15 +1860,20 @@ func (r *Replica) beginCmds(
 // will inform the batch response timestamp or batch response txn
 // timestamp.
 func (r *Replica) applyTimestampCache(ba *roachpb.BatchRequest) (bool, *roachpb.Error) {
+	span, err := keys.Range(*ba)
+	if err != nil {
+		return false, roachpb.NewError(err)
+	}
+
 	// TODO(peter): We only need to hold a write lock during the ExpandRequests
 	// calls. Investigate whether using a RWMutex here reduces lock contention.
 	r.store.tsCacheMu.Lock()
 	defer r.store.tsCacheMu.Unlock()
 
 	if ba.Txn != nil {
-		r.store.tsCacheMu.cache.ExpandRequests(ba.Txn.Timestamp)
+		r.store.tsCacheMu.cache.ExpandRequests(ba.Txn.Timestamp, span)
 	} else {
-		r.store.tsCacheMu.cache.ExpandRequests(ba.Timestamp)
+		r.store.tsCacheMu.cache.ExpandRequests(ba.Timestamp, span)
 	}
 
 	var bumped bool

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -1868,7 +1868,7 @@ func TestReplicaUpdateTSCache(t *testing.T) {
 	if rOK || wOK {
 		t.Errorf("expected rOK=false and wOK=false; rOK=%t, wOK=%t", rOK, wOK)
 	}
-	tc.repl.store.tsCacheMu.cache.ExpandRequests(hlc.Timestamp{})
+	tc.repl.store.tsCacheMu.cache.ExpandRequests(hlc.Timestamp{}, tc.repl.Desc().RSpan())
 	rTS, _, rOK := tc.repl.store.tsCacheMu.cache.GetMaxRead(roachpb.Key("a"), nil)
 	wTS, _, wOK := tc.repl.store.tsCacheMu.cache.GetMaxWrite(roachpb.Key("a"), nil)
 	if rTS.WallTime != t0.Nanoseconds() || wTS.WallTime != startNanos || !rOK || wOK {
@@ -7621,7 +7621,7 @@ func TestMakeTimestampCacheRequest(t *testing.T) {
 			ba.Header.MaxSpanRequestKeys = c.maxKeys
 			ba.Add(c.req)
 			br.Add(c.resp)
-			cr := makeCacheRequest(&ba, &br)
+			cr := makeCacheRequest(&ba, &br, roachpb.RSpan{})
 			if !reflect.DeepEqual(c.expected, cr) {
 				t.Fatalf("%s", pretty.Diff(c.expected, cr))
 			}

--- a/pkg/storage/timestamp_cache.go
+++ b/pkg/storage/timestamp_cache.go
@@ -56,6 +56,7 @@ const (
 // populate the read/write interval caches if a potential conflict is detected
 // due to an earlier request (based on timestamp) arriving.
 type cacheRequest struct {
+	span      roachpb.RSpan
 	reads     []roachpb.Span
 	writes    []roachpb.Span
 	txn       roachpb.Span
@@ -615,18 +616,18 @@ func (tc *timestampCache) AddRequest(req cacheRequest) {
 }
 
 // ExpandRequests expands any request that is newer than the specified
-// timestamp.
-func (tc *timestampCache) ExpandRequests(timestamp hlc.Timestamp) {
+// timestamp and which overlaps the specified span.
+func (tc *timestampCache) ExpandRequests(timestamp hlc.Timestamp, span roachpb.RSpan) {
 	// Find all of the requests that have a timestamp greater than or equal to
 	// the specified timestamp. Note that we can't delete the requests during the
 	// btree iteration.
 	var reqs []*cacheRequest
 	tc.tmpReq.timestamp = timestamp
 	tc.requests.AscendGreaterOrEqual(&tc.tmpReq, func(i btree.Item) bool {
-		// TODO(peter): We could be more intelligent about not expanding a request
-		// if there is no possibility of overlap. For example, in workloads where
-		// there are concurrent bulk inserts for completely distinct ranges.
-		reqs = append(reqs, i.(*cacheRequest))
+		cr := i.(*cacheRequest)
+		if cr.span.Overlaps(span) {
+			reqs = append(reqs, cr)
+		}
 		return true
 	})
 


### PR DESCRIPTION
Only expand requests which potentially overlap with the new request
being executed. We do this check at a course-grain right now, comparing
the span of the replica of the replica the cached request was executed
on vs the span of the replica that is executing the new request.

This speeds up a 1-node write-only workload by 42% and makes the
performance much more stable. Previously the performance deteriorated
rapidly as the timestamp cache was expanding most requests and not
hitting the fast path.

Fixes #14509