### PR TITLE
storage: Fix test flakes by disabling split queue

### DIFF
--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -183,7 +183,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 	// key is selected to fall within the meta range in order for the later
 	// routing of requests to range 1 to work properly. Removing the routing
 	// of all requests to range 1 would allow us to make the key more normal.
-	key := rg1Key("key")
+	const key = "key"
 	// Set up a filter to so that the get operation at Step 3 will return an error.
 	var numGets int32
 
@@ -191,6 +191,10 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 	defer stopper.Stop()
 	manual := hlc.NewManualClock(123)
 	cfg := storage.TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
+	// Splits can cause our chosen key to end up on a range other than range 1,
+	// and trying to handle that complicates the test without providing any
+	// added benefit.
+	cfg.TestingKnobs.DisableSplitQueue = true
 	cfg.TestingKnobs.TestingEvalFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if _, ok := filterArgs.Req.(*roachpb.GetRequest); ok &&

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -25,7 +25,6 @@ client_*.go.
 package storage_test
 
 import (
-	"bytes"
 	"fmt"
 	"math/rand"
 	"net"
@@ -78,15 +77,6 @@ func rg1(s *storage.Store) client.Sender {
 		}
 		return ba
 	})
-}
-
-// rg1Key returns a key that will reliably be located within the first range.
-// This is a bit of a bandaid to ensure tests continue working as intended
-// until the rg1 method is removed.
-func rg1Key(key string) roachpb.Key {
-	// Ensure that the key will be located in the first range by giving it the
-	// meta2 prefix. The first range only contains meta keys as of April 2017.
-	return roachpb.Key(bytes.Join([][]byte{keys.Meta2Prefix, []byte(key)}, nil))
 }
 
 // createTestStore creates a test store using an in-memory


### PR DESCRIPTION
Revert 08e6298d968a6bf6004bd890ca47848d568cfa63 in the process, since
disabling the splits is a better way to resolve the problem than messing
around with meta keys (in an attempt to make the tests work even after
the split).

Fixes #14835