### PR TITLE
sql: parallelize TestLogic

### DIFF
--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -49,10 +49,6 @@ var (
 	metaFDOpen         = metric.Metadata{Name: "sys.fd.open", Help: "Process open file descriptors"}
 	metaFDSoftLimit    = metric.Metadata{Name: "sys.fd.softlimit", Help: "Process open FD soft limit"}
 	metaUptime         = metric.Metadata{Name: "sys.uptime", Help: "Process uptime in seconds"}
-
-	// Build information. Placed here for lack of a better location.
-	// Labels for this metric get populated in MakeRuntimeStatSampler
-	metaBuildTimestamp = metric.Metadata{Name: "build.timestamp", Help: "Build information"}
 )
 
 // getCgoMemStats is a function that fetches stats for the C++ portion of the code.
@@ -115,6 +111,8 @@ func MakeRuntimeStatSampler(clock *hlc.Clock) RuntimeStatSampler {
 		log.Warningf(context.TODO(), "Could not parse build timestamp: %v", err)
 	}
 
+	// Build information.
+	metaBuildTimestamp := metric.Metadata{Name: "build.timestamp", Help: "Build information"}
 	metaBuildTimestamp.AddLabel("tag", info.Tag)
 	metaBuildTimestamp.AddLabel("go_version", info.GoVersion)
 

--- a/pkg/sql/logic_test.go
+++ b/pkg/sql/logic_test.go
@@ -582,8 +582,6 @@ func (t *logicTest) setUser(user string) func() {
 	t.db = db
 	t.user = user
 
-	t.outf("--- new user: %s", user)
-
 	return cleanupFunc
 }
 
@@ -701,10 +699,10 @@ func (t *logicTest) processTestFile(path string) error {
 	defer file.Close()
 	defer t.traceStop()
 
-	if t.verbose {
+	if *showSQL {
 		t.outf("--- queries start here")
-		defer t.printCompletion(path)
 	}
+	defer t.printCompletion(path)
 
 	t.lastProgress = timeutil.Now()
 

--- a/pkg/util/log/test_log_scope.go
+++ b/pkg/util/log/test_log_scope.go
@@ -44,6 +44,7 @@ type tShim interface {
 	Failed() bool
 	Error(...interface{})
 	Errorf(fmt string, args ...interface{})
+	Name() string
 }
 
 var showLogs bool
@@ -74,7 +75,7 @@ func Scope(t tShim, testName string) *TestLogScope {
 		t.Fatal(err)
 	}
 	if !showLogs {
-		fmt.Fprintln(OrigStderr, "test logs captured to:", tempDir, " (use -show-logs to present inline)")
+		fmt.Fprintf(OrigStderr, "%s logs captured to: %s (use -show-logs to present inline)\n", t.Name(), tempDir)
 	}
 	return &TestLogScope{logDir: tempDir}
 }


### PR DESCRIPTION
Use Go's [`t.Parallel()`](https://golang.org/pkg/testing/#T.Parallel) functionality to run each configuration of the logic tests in parallel when `-show-sql` is disabled. This decreases the running time of the logic tests to about 20 seconds on my machine.

Also, clean up some test logging to make the output more readable in the parallel case.