### PR TITLE
storage: bump the default COCKROACH_SCHEDULER_CONCURRENCY to 8*NumCPU

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -114,7 +114,7 @@ var changeTypeInternalToRaft = map[roachpb.ReplicaChangeType]raftpb.ConfChangeTy
 }
 
 var storeSchedulerConcurrency = envutil.EnvOrDefaultInt(
-	"COCKROACH_SCHEDULER_CONCURRENCY", 2*runtime.NumCPU())
+	"COCKROACH_SCHEDULER_CONCURRENCY", 8*runtime.NumCPU())
 
 var enablePreVote = envutil.EnvOrDefaultBool(
 	"COCKROACH_ENABLE_PREVOTE", false)


### PR DESCRIPTION
The COCKROACH_SCHEDULER_CONCURRENCY env var controls the number of
scheduler goroutines used for Raft processing. In testing, the previous
default of `2*NumCPU` proved to be too low to achieve good parallelization
of batch commits. Even with proposer-evalued-KV landing, we want lots of
concurrent batch commits so they can be grouped and written to RocksDB
more efficiently. The new default of `8*NumCPU` was determined
experimentally on 8 CPU machines.

Fixes #7596