### PR TITLE
storage: Always write "false" for the frozen key in new ranges

### DIFF
--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -190,6 +190,11 @@ func RaftTruncatedStateKey(rangeID roachpb.RangeID) roachpb.Key {
 	return MakeRangeIDPrefixBuf(rangeID).RaftTruncatedStateKey()
 }
 
+// RangeFrozenStatusKey returns a system-local key for the frozen status.
+func RangeFrozenStatusKey(rangeID roachpb.RangeID) roachpb.Key {
+	return MakeRangeIDPrefixBuf(rangeID).RangeFrozenStatusKey()
+}
+
 // RangeLeaseKey returns a system-local key for a range lease.
 func RangeLeaseKey(rangeID roachpb.RangeID) roachpb.Key {
 	return MakeRangeIDPrefixBuf(rangeID).RangeLeaseKey()
@@ -720,6 +725,11 @@ func (b RangeIDPrefixBuf) LeaseAppliedIndexKey() roachpb.Key {
 // RaftTruncatedStateKey returns a system-local key for a RaftTruncatedState.
 func (b RangeIDPrefixBuf) RaftTruncatedStateKey() roachpb.Key {
 	return append(b.replicatedPrefix(), LocalRaftTruncatedStateSuffix...)
+}
+
+// RangeFrozenStatusKey returns a system-local key for the frozen status.
+func (b RangeIDPrefixBuf) RangeFrozenStatusKey() roachpb.Key {
+	return append(b.replicatedPrefix(), LocalRangeFrozenStatusSuffix...)
 }
 
 // RangeLeaseKey returns a system-local key for a range lease.

--- a/pkg/keys/printer_test.go
+++ b/pkg/keys/printer_test.go
@@ -57,6 +57,7 @@ func TestPrettyPrint(t *testing.T) {
 		{RangeLeaseKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RangeLease"},
 		{RangeStatsKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RangeStats"},
 		{RangeTxnSpanGCThresholdKey(roachpb.RangeID(1000001)), `/Local/RangeID/1000001/r/RangeTxnSpanGCThreshold`},
+		{RangeFrozenStatusKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RangeFrozenStatus"},
 		{RangeLastGCKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RangeLastGC"},
 
 		{RaftHardStateKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/u/RaftHardState"},

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4048,16 +4048,6 @@ func (r *Replica) evaluateProposalInner(
 			// a transaction.
 			if txn := result.Local.Err.GetTxn(); txn != nil && txn.Equal(ba.Txn) {
 				txn.Writing = wasWriting
-				// TODO(tschottdorf): we're mutating the client's original
-				// memory erroneously when proposer-evaluated KV is on, failing
-				// TestTxnDBLostDeleteAnomaly (and likely others).
-				//
-				// TODO(bdarnell): we shouldn't be looking at the propEvalKV
-				// variable downstream of raft, we should look at the request
-				// to see whether this request was proposer-evaluated or not.
-				if propEvalKV {
-					ba.Txn.Writing = wasWriting
-				}
 			}
 			return result
 		}

--- a/pkg/storage/replica_data_iter_test.go
+++ b/pkg/storage/replica_data_iter_test.go
@@ -71,6 +71,7 @@ func createRangeData(t *testing.T, r *Replica) []engine.MVCCKey {
 	}{
 		{keys.AbortCacheKey(r.RangeID, testTxnID), ts0},
 		{keys.AbortCacheKey(r.RangeID, testTxnID2), ts0},
+		{keys.RangeFrozenStatusKey(r.RangeID), ts0},
 		{keys.RangeLastGCKey(r.RangeID), ts0},
 		{keys.RaftAppliedIndexKey(r.RangeID), ts0},
 		{keys.RaftTruncatedStateKey(r.RangeID), ts0},

--- a/pkg/storage/stats_test.go
+++ b/pkg/storage/stats_test.go
@@ -33,8 +33,8 @@ import (
 // writeInitialState().
 func initialStats() enginepb.MVCCStats {
 	return enginepb.MVCCStats{
-		SysBytes: 208,
-		SysCount: 6,
+		SysBytes: 237,
+		SysCount: 7,
 	}
 }
 func TestRangeStatsEmpty(t *testing.T) {


### PR DESCRIPTION
Reverts parts of #14779

If a split (which calls writeInitialState for the new range) straddles
an upgrade to a build which includes #14779, inconsistency could
result as only those replicas which processed the split before the
upgrade would have the frozen field present (and while the frozen
field could easily be ignored in the consistency checker, its impact
on the stats is tricker to back out). This commit reintroduces the
field by always writing a zero to it when creating a range.

Fixes #14891

Also remove several obsolete uses of propEvalKV (one of which is downstream of raft and should be removed for this beta).