### PR TITLE
.gitignore: ignore builds.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 artifacts
 /bin
 /bin.*
+# TeamCity sometimes creates this file during builds.
+builds.xml
 .buildinfo
 /cockroach
 /cockroach-data


### PR DESCRIPTION
This file sometimes gets created by TeamCity. Easiest to just .gitignore
it to prevent a dirty work dir when building a release.

Fixes #14916.
Fixes #14284.