### PR TITLE
storage/engine: remove DBIterError

### DIFF
--- a/pkg/storage/engine/db.cc
+++ b/pkg/storage/engine/db.cc
@@ -367,6 +367,7 @@ namespace {
 DBIterState DBIterGetState(DBIterator* iter) {
   DBIterState state = {};
   state.valid = iter->rep->Valid();
+  state.status = ToDBStatus(iter->rep->status());
 
   if (state.valid) {
     rocksdb::Slice key;
@@ -2024,10 +2025,9 @@ DBIterState DBIterNext(DBIterator* iter, bool skip_current_key_versions) {
     rocksdb::Slice key;
     rocksdb::Slice ts;
     if (!SplitKey(iter->rep->key(), &key, &ts)) {
-      // TODO(peter): Need to set an error on DBIterator. Currently
-      // DBIterError() returns iter->rep->status().
       DBIterState state = { 0 };
       state.valid = false;
+      state.status = FmtStatus("failed to split mvcc key");
       return state;
     }
     old_key = key.ToString();
@@ -2039,10 +2039,9 @@ DBIterState DBIterNext(DBIterator* iter, bool skip_current_key_versions) {
     rocksdb::Slice key;
     rocksdb::Slice ts;
     if (!SplitKey(iter->rep->key(), &key, &ts)) {
-      // TODO(peter): Need to set an error on DBIterator. Currently
-      // DBIterError() returns iter->rep->status().
       DBIterState state = { 0 };
       state.valid = false;
+      state.status = FmtStatus("failed to split mvcc key");
       return state;
     }
     if (old_key == key) {
@@ -2095,10 +2094,6 @@ DBIterState DBIterPrev(DBIterator* iter, bool skip_current_key_versions){
   }
 
   return DBIterGetState(iter);
-}
-
-DBStatus DBIterError(DBIterator* iter) {
-  return ToDBStatus(iter->rep->status());
 }
 
 DBStatus DBMergeOne(DBSlice existing, DBSlice update, DBString* new_value) {

--- a/pkg/storage/engine/db.h
+++ b/pkg/storage/engine/db.h
@@ -38,6 +38,11 @@ typedef struct {
   int len;
 } DBString;
 
+// A DBStatus is an alias for DBString and is used to indicate that
+// the return value indicates the success or failure of an
+// operation. If DBStatus.data == NULL the operation succeeded.
+typedef DBString DBStatus;
+
 typedef struct {
   DBSlice key;
   int64_t wall_time;
@@ -48,12 +53,8 @@ typedef struct {
   bool valid;
   DBKey key;
   DBSlice value;
+  DBStatus status;
 } DBIterState;
-
-// A DBStatus is an alias for DBString and is used to indicate that
-// the return value indicates the success or failure of an
-// operation. If DBStatus.data == NULL the operation succeeded.
-typedef DBString DBStatus;
 
 typedef struct DBCache DBCache;
 typedef struct DBEngine DBEngine;
@@ -184,9 +185,6 @@ DBIterState DBIterNext(DBIterator* iter, bool skip_current_key_versions);
 // current key are skipped. After this call, DBIterValid() returns 1
 // iff the iterator was not positioned at the first key.
 DBIterState DBIterPrev(DBIterator* iter, bool skip_current_key_versions);
-
-// Returns any error associated with the iterator.
-DBStatus DBIterError(DBIterator* iter);
 
 // Implements the merge operator on a single pair of values. update is
 // merged with existing. This method is provided for invocation from

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1267,6 +1267,7 @@ type rocksDBIterator struct {
 	iter   *C.DBIterator
 	valid  bool
 	reseek bool
+	err    error
 	key    C.DBKey
 	value  C.DBSlice
 }
@@ -1362,7 +1363,7 @@ func (r *rocksDBIterator) SeekReverse(key MVCCKey) {
 }
 
 func (r *rocksDBIterator) Valid() (bool, error) {
-	return r.valid, statusToError(C.DBIterError(r.iter))
+	return r.valid, r.err
 }
 
 func (r *rocksDBIterator) Next() {
@@ -1420,6 +1421,7 @@ func (r *rocksDBIterator) setState(state C.DBIterState) {
 	r.reseek = false
 	r.key = state.key
 	r.value = state.value
+	r.err = statusToError(state.status)
 }
 
 func (r *rocksDBIterator) ComputeStats(


### PR DESCRIPTION
Return the iterator's error (if any) in DBIterState.status. This avoids
2 cgo calls per iterated key in MVCCScan that were coming from calls to
rocksDBIterator.Valid(). This provides a 30% reduction in cgo calls for
a read-only workload, though no measurable improvement in
throughput (which is mildly surprising).