### PR TITLE
cli+log: more UX polishing around logging

### DIFF
--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -33,8 +33,8 @@ eexpect "starting cockroach node"
 interrupt
 eexpect ":/# "
 
-# Check that --logtostderr can override the threshold
-send "echo marker; $argv start --logtostderr=ERROR\r"
+# Check that --logtostderr can override the threshold but no error is printed on startup
+send "echo marker; $argv start --logtostderr=ERROR 2>&1 | grep -v '^\\*'\r"
 eexpect "marker\r\nCockroachDB node starting"
 
 # Stop it.

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -531,25 +531,33 @@ func runStart(cmd *cobra.Command, args []string) error {
 }
 
 // setupAndInitializeLoggingAndProfiling does what it says on the label.
-// Prior to this however it determines suitable defaults for the logging output
-// directory and the verbosity level of stderr logging.
+// Prior to this however it determines suitable defaults for the
+// logging output directory and the verbosity level of stderr logging.
+// We only do this for the "start" command which is why this work
+// occurs here and not in an OnInitialize function.
 func setupAndInitializeLoggingAndProfiling(startCtx context.Context) (*stop.Stopper, error) {
 	// Default the log directory to the "logs" subdirectory of the first
-	// non-memory store. We only do this for the "start" command which is why
-	// this work occurs here and not in an OnInitialize function.
+	// non-memory store. If more than one non-memory stores is detected,
+	// print a warning.
+	ambiguousLogDirs := false
 	pf := cockroachCmd.PersistentFlags()
 	f := pf.Lookup(logflags.LogDirName)
 	if !log.DirSet() && !f.Changed {
 		// We only override the log directory if the user has not explicitly
 		// disabled file logging using --log-dir="".
+		newDir := ""
 		for _, spec := range serverCfg.Stores.Specs {
 			if spec.InMemory {
 				continue
 			}
-			if err := f.Value.Set(filepath.Join(spec.Path, "logs")); err != nil {
-				return nil, err
+			if newDir != "" {
+				ambiguousLogDirs = true
+				break
 			}
-			break
+			newDir = filepath.Join(spec.Path, "logs")
+		}
+		if err := f.Value.Set(newDir); err != nil {
+			return nil, err
 		}
 	}
 
@@ -577,6 +585,13 @@ func setupAndInitializeLoggingAndProfiling(startCtx context.Context) (*stop.Stop
 		// Start the log file GC daemon to remove files that make the log
 		// directory too large.
 		log.StartGCDaemon()
+	}
+
+	if ambiguousLogDirs {
+		// Note that we can't report this message earlier, because the log directory
+		// may not have been ready before the call to MkdirAll() above.
+		log.Shout(startCtx, log.Severity_WARNING, "multiple stores configured"+
+			" and --log-dir not specified, you may want to specify --log-dir to disambiguate.")
 	}
 
 	// We log build information to stdout (for the short summary), but also

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -507,8 +507,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 	select {
 	case sig := <-signalCh:
 		returnErr = fmt.Errorf("received signal '%s' during shutdown, initiating hard shutdown", sig)
-		log.Errorf(shutdownCtx, "%v", returnErr)
-		fmt.Fprintln(os.Stdout, returnErr)
+		log.Shoutf(shutdownCtx, log.Severity_ERROR, "%v", returnErr)
 		// This new signal is not welcome, as it interferes with the graceful
 		// shutdown process. On Unix, a signal that was not handled gracefully by
 		// the application should be visible to other processes as an exit code
@@ -519,8 +518,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 		// NB: we do not return here to go through log.Flush below.
 	case <-time.After(time.Minute):
 		returnErr = errors.New("time limit reached, initiating hard shutdown")
-		log.Errorf(shutdownCtx, "%v", returnErr)
-		fmt.Fprintln(os.Stdout, returnErr)
+		log.Shoutf(shutdownCtx, log.Severity_ERROR, "%v", returnErr)
 		// NB: we do not return here to go through log.Flush below.
 	case <-stopper.IsStopped():
 		const msgDone = "server drained and shutdown completed"

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -573,6 +573,10 @@ func setupAndInitializeLoggingAndProfiling(startCtx context.Context) (*stop.Stop
 			return nil, err
 		}
 		log.Eventf(startCtx, "created log directory %s", logDir)
+
+		// Start the log file GC daemon to remove files that make the log
+		// directory too large.
+		log.StartGCDaemon()
 	}
 
 	// We log build information to stdout (for the short summary), but also
@@ -583,7 +587,6 @@ func setupAndInitializeLoggingAndProfiling(startCtx context.Context) (*stop.Stop
 	initMemProfile(startCtx, outputDirectory)
 	initCPUProfile(startCtx, outputDirectory)
 	initBlockProfile()
-	log.StartGCDaemon()
 
 	// Disable Stopper task tracking as performing that call site tracking is
 	// moderately expensive (certainly outweighing the infrequent benefit it

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -155,7 +155,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 
 	ctx := s.AnnotateCtx(context.Background())
 	if s.cfg.Insecure {
-		log.Warning(ctx, "running in insecure mode, this is strongly discouraged. See --insecure.")
+		log.Shout(ctx, log.Severity_WARNING,
+			"running in insecure mode, this is strongly discouraged. See --insecure.")
 	}
 
 	s.rpcContext = rpc.NewContext(s.cfg.AmbientCtx, s.cfg.Config, s.clock, s.stopper)

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -67,6 +67,24 @@ func logDepth(ctx context.Context, depth int, sev Severity, format string, args 
 	addStructured(ctx, sev, depth+1, format, args)
 }
 
+// Shoutf logs to the specified severity's log, and also to the real
+// stderr if logging is currently redirected to a file.
+func Shoutf(ctx context.Context, sev Severity, format string, args ...interface{}) {
+	logDepth(ctx, 1, sev, format, args)
+	if stderrRedirected {
+		fmt.Fprintf(OrigStderr, "*\n* %s: %s\n*\n", sev.String(), MakeMessage(ctx, format, args))
+	}
+}
+
+// Shout logs to the specified severity's log, and also to the real
+// stderr if logging is currently redirected to a file.
+func Shout(ctx context.Context, sev Severity, args ...interface{}) {
+	logDepth(ctx, 1, sev, "", args)
+	if stderrRedirected {
+		fmt.Fprintf(OrigStderr, "*\n* %s: %s\n*\n", sev.String(), MakeMessage(ctx, "", args))
+	}
+}
+
 // Infof logs to the INFO log.
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf; a newline is


### PR DESCRIPTION
This patch set makes minor changes that will enhance UX:

- it ensures that the warning about using an insecure cluster does show up on stderr even when logging (and stderr) is directed to files
- it also warns when --log-dir is not specified but there are multiple --stores, since this makes the determination of the log directory dependent on the order of the parameters (may be sensitive in case the parameter list is generated automatically)
