### PR TITLE
testutils: use t.Name instead of a depth in TempDir

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -120,7 +120,7 @@ func backupRestoreTestSetupWithParams(
 ) {
 	ctx = context.Background()
 
-	dir, dirCleanupFn := testutils.TempDir(t, 1)
+	dir, dirCleanupFn := testutils.TempDir(t)
 
 	temp := filepath.Join(dir, "must-be-cleaned-up")
 

--- a/pkg/ccl/storageccl/export_storage_test.go
+++ b/pkg/ccl/storageccl/export_storage_test.go
@@ -29,7 +29,7 @@ import (
 
 func testExportToTarget(t *testing.T, args roachpb.ExportStorage) {
 	ctx := context.TODO()
-	dir, dirCleanup := testutils.TempDir(t, 0)
+	dir, dirCleanup := testutils.TempDir(t)
 	defer dirCleanup()
 
 	// Setup a sink for the given args.
@@ -121,7 +121,7 @@ func testExportToTarget(t *testing.T, args roachpb.ExportStorage) {
 func TestPutLocal(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	p, cleanupFn := testutils.TempDir(t, 0)
+	p, cleanupFn := testutils.TempDir(t)
 	defer cleanupFn()
 
 	testExportToTarget(t, roachpb.ExportStorage{
@@ -133,7 +133,7 @@ func TestPutLocal(t *testing.T) {
 func TestPutHttp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	tmp, dirCleanup := testutils.TempDir(t, 0)
+	tmp, dirCleanup := testutils.TempDir(t)
 	defer dirCleanup()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/ccl/storageccl/export_test.go
+++ b/pkg/ccl/storageccl/export_test.go
@@ -33,7 +33,7 @@ func TestExport(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	dir, dirCleanupFn := testutils.TempDir(t, 0)
+	dir, dirCleanupFn := testutils.TempDir(t)
 	defer dirCleanupFn()
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
 	defer tc.Stopper().Stop()

--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -117,7 +117,7 @@ func TestImport(t *testing.T) {
 		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
 	}
 
-	dir, dirCleanupFn := testutils.TempDir(t, 0)
+	dir, dirCleanupFn := testutils.TempDir(t)
 	defer dirCleanupFn()
 
 	writeSST := func(keys ...[]byte) string {

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -553,7 +553,7 @@ func BenchmarkRocksDBSstFileReader(b *testing.B) {
 
 func TestRocksDBTimeBound(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	dir, dirCleanup := testutils.TempDir(t, 0)
+	dir, dirCleanup := testutils.TempDir(t)
 	defer dirCleanup()
 
 	rocksdb, err := NewRocksDB(roachpb.Attributes{}, dir, RocksDBCache{}, 0, DefaultMaxOpenFiles)

--- a/pkg/testutils/dir.go
+++ b/pkg/testutils/dir.go
@@ -20,16 +20,12 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
-
-	"github.com/cockroachdb/cockroach/pkg/util/caller"
 )
 
 // TempDir creates a directory and a function to clean it up at the end of the
-// test. If called directly from a test function, pass 0 for depth (which puts
-// the test name in the directory). Otherwise, offset depth appropriately.
-func TempDir(t testing.TB, depth int) (string, func()) {
-	_, _, name := caller.Lookup(depth + 1)
-	dir, err := ioutil.TempDir("", name)
+// test.
+func TempDir(t testing.TB) (string, func()) {
+	dir, err := ioutil.TempDir("", t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The Name method was added in go 1.8 and accomplishes the same goal as
the depth parameter but with less fiddling.