### PR TITLE
[DO NOT MERGE] sql: use a cached parsed query for prepared statements

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -408,6 +408,7 @@ func (e *Executor) Prepare(
 	prepared := &PreparedStatement{
 		Query:       query,
 		SQLTypes:    pinfo,
+		Stmts:       stmts,
 		portalNames: make(map[string]struct{}),
 	}
 	switch len(stmts) {
@@ -575,6 +576,11 @@ func (e *Executor) execRequest(
 		stmts, err = session.ProcessCopyData(session.Ctx(), sql, copymsg)
 	} else if copymsg != copyMsgNone {
 		err = fmt.Errorf("unexpected copy command")
+	} else if pinfo != nil && len(pinfo.Stmts) > 0 {
+		// TODO: This doesn't work as query planning and type checking both mutate
+		// the query in place. Specifically, table names are resolved and
+		// expression nodes are given resolved types.
+		stmts = pinfo.Stmts
 	} else {
 		var parser parser.Parser
 		stmts, err = parser.Parse(sql, session.Syntax)

--- a/pkg/sql/parser/placeholders.go
+++ b/pkg/sql/parser/placeholders.go
@@ -34,6 +34,7 @@ type QueryArguments map[string]Datum
 type PlaceholderInfo struct {
 	Values QueryArguments
 	Types  PlaceholderTypes
+	Stmts  StatementList
 }
 
 // MakePlaceholderInfo constructs an empty PlaceholderInfo.

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -813,6 +813,7 @@ func (c *v3Conn) handleExecute(buf *readBuffer) error {
 	pinfo := parser.PlaceholderInfo{
 		Types:  stmt.SQLTypes,
 		Values: portal.Qargs,
+		Stmts:  stmt.Stmts,
 	}
 
 	return c.executeStatements(stmt.Query, &pinfo, portalMeta.outFormats, false, int(limit))

--- a/pkg/sql/prepare.go
+++ b/pkg/sql/prepare.go
@@ -31,6 +31,7 @@ type PreparedStatement struct {
 	Type        parser.StatementType
 	SQLTypes    parser.PlaceholderTypes
 	Columns     ResultColumns
+	Stmts       parser.StatementList
 	portalNames map[string]struct{}
 
 	ProtocolMeta interface{} // a field for protocol implementations to hang metadata off of.


### PR DESCRIPTION
This doesn't actually work properly (see the TestPGPreparedQuery
failures), but was sufficient for verifying the expected benefit to
doing this.

See #13618
See #14927