### PR TITLE
testutils: add QueryInt and QueryStr helpers

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -112,9 +112,7 @@ func backupSQLRunner(t testing.TB, tc *testcluster.TestCluster) *sqlutils.SQLRun
 	show := "SHOW CLUSTER SETTING enterprise.enabled"
 	for _, conn := range tc.Conns {
 		testutils.SucceedsSoon(t, func() error {
-			var enabled string
-			sqlutils.MakeSQLRunner(t, conn).QueryRow(show).Scan(&enabled)
-			if enabled != "true" {
+			if enabled := sqlutils.MakeSQLRunner(t, conn).QueryStr(show); enabled != "true" {
 				return errors.New("enterprise.enabled is not true")
 			}
 			return nil
@@ -304,15 +302,14 @@ func backupAndRestore(
 
 		sqlDBRestore.Exec(`RESTORE bench.* FROM $1`, dest)
 
-		var rowCount int64
-		sqlDBRestore.QueryRow(`SELECT COUNT(*) FROM bench.bank`).Scan(&rowCount)
-		if rowCount != numAccounts {
-			t.Fatalf("expected %d rows but found %d", numAccounts, rowCount)
+		if count := sqlDBRestore.QueryInt(`SELECT COUNT(*) FROM bench.bank`); count != numAccounts {
+			t.Fatalf("expected %d rows but found %d", numAccounts, count)
 		}
 
-		sqlDBRestore.QueryRow(`SELECT COUNT(*) FROM bench.bank@balance_idx`).Scan(&rowCount)
-		if rowCount != numAccounts {
-			t.Fatalf("expected %d rows but found %d", numAccounts, rowCount)
+		if count := sqlDBRestore.QueryInt(
+			`SELECT COUNT(*) FROM bench.bank@balance_idx`,
+		); count != numAccounts {
+			t.Fatalf("expected %d rows but found %d", numAccounts, count)
 		}
 	}
 }
@@ -534,22 +531,17 @@ func TestBackupRestoreInterleaved(t *testing.T) {
 
 		sqlDBRestore.Exec(`RESTORE bench.* FROM $1`, dir)
 
-		var rowCount int64
-		sqlDBRestore.QueryRow(`SELECT COUNT(*) FROM bench.bank`).Scan(&rowCount)
-		if rowCount != numAccounts {
-			t.Errorf("expected %d rows but found %d", numAccounts, rowCount)
+		if count := sqlDBRestore.QueryInt(`SELECT COUNT(*) FROM bench.bank`); count != numAccounts {
+			t.Errorf("expected %d rows but found %d", numAccounts, count)
 		}
-		sqlDBRestore.QueryRow(`SELECT COUNT(*) FROM bench.i0`).Scan(&rowCount)
-		if rowCount != 2*numAccounts {
-			t.Errorf("expected %d rows but found %d", 2*numAccounts, rowCount)
+		if count := sqlDBRestore.QueryInt(`SELECT COUNT(*) FROM bench.i0`); count != 2*numAccounts {
+			t.Errorf("expected %d rows but found %d", 2*numAccounts, count)
 		}
-		sqlDBRestore.QueryRow(`SELECT COUNT(*) FROM bench.i0_0`).Scan(&rowCount)
-		if rowCount != 3*numAccounts {
-			t.Errorf("expected %d rows but found %d", 3*numAccounts, rowCount)
+		if count := sqlDBRestore.QueryInt(`SELECT COUNT(*) FROM bench.i0_0`); count != 3*numAccounts {
+			t.Errorf("expected %d rows but found %d", 3*numAccounts, count)
 		}
-		sqlDBRestore.QueryRow(`SELECT COUNT(*) FROM bench.i1`).Scan(&rowCount)
-		if rowCount != 4*numAccounts {
-			t.Errorf("expected %d rows but found %d", 4*numAccounts, rowCount)
+		if count := sqlDBRestore.QueryInt(`SELECT COUNT(*) FROM bench.i1`); count != 4*numAccounts {
+			t.Errorf("expected %d rows but found %d", 4*numAccounts, count)
 		}
 	})
 
@@ -651,12 +643,12 @@ func TestBackupRestoreCrossTableReferences(t *testing.T) {
 		_ = origDB.Exec(`BACKUP DATABASE store, storestats TO $1`, dir)
 	}
 
-	origCustomers := origDB.QueryStr(`SHOW CONSTRAINTS FROM store.customers`)
-	origOrders := origDB.QueryStr(`SHOW CONSTRAINTS FROM store.orders`)
-	origReceipts := origDB.QueryStr(`SHOW CONSTRAINTS FROM store.receipts`)
+	origCustomers := origDB.QueryResults(`SHOW CONSTRAINTS FROM store.customers`)
+	origOrders := origDB.QueryResults(`SHOW CONSTRAINTS FROM store.orders`)
+	origReceipts := origDB.QueryResults(`SHOW CONSTRAINTS FROM store.receipts`)
 
-	origEarlyCustomers := origDB.QueryStr(`SELECT * from store.early_customers`)
-	origOrderCounts := origDB.QueryStr(`SELECT * from storestats.ordercounts ORDER BY id`)
+	origEarlyCustomers := origDB.QueryResults(`SELECT * from store.early_customers`)
+	origOrderCounts := origDB.QueryResults(`SELECT * from storestats.ordercounts ORDER BY id`)
 
 	t.Run("restore everything to new cluster", func(t *testing.T) {
 		tc := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{})
@@ -1066,7 +1058,7 @@ func TestBackupRestoreWithConcurrentWrites(t *testing.T) {
 	sqlDB.Exec(`RESTORE bench.* FROM $1`, baseDir)
 	atomic.StoreInt32(&allowErrors, 0)
 
-	bad := sqlDB.QueryStr(`SELECT id, balance, payload FROM bench.bank WHERE id != balance`)
+	bad := sqlDB.QueryResults(`SELECT id, balance, payload FROM bench.bank WHERE id != balance`)
 	for _, r := range bad {
 		t.Errorf("bad row ID %s = bal %s (payload: %q)", r[0], r[1], r[2])
 	}
@@ -1083,14 +1075,11 @@ func TestBackupAsOfSystemTime(t *testing.T) {
 	_, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, multiNode, numAccounts)
 	defer cleanupFn()
 
-	var ts string
-	var rowCount int64
+	ts := sqlDB.QueryStr(`SELECT cluster_logical_timestamp()`)
 
-	sqlDB.QueryRow(`SELECT cluster_logical_timestamp()`).Scan(&ts)
 	sqlDB.Exec(`TRUNCATE bench.bank`)
 
-	sqlDB.QueryRow(`SELECT COUNT(*) FROM bench.bank`).Scan(&rowCount)
-	if rowCount != 0 {
+	if rowCount := sqlDB.QueryInt(`SELECT COUNT(*) FROM bench.bank`); rowCount != 0 {
 		t.Fatalf("expected 0 rows but found %d", rowCount)
 	}
 
@@ -1100,8 +1089,7 @@ func TestBackupAsOfSystemTime(t *testing.T) {
 
 	sqlDB.Exec(`RESTORE bench.* FROM $1`, dir)
 
-	sqlDB.QueryRow(`SELECT COUNT(*) FROM bench.bank`).Scan(&rowCount)
-	if rowCount != numAccounts {
+	if rowCount := sqlDB.QueryInt(`SELECT COUNT(*) FROM bench.bank`); rowCount != numAccounts {
 		t.Fatalf("expected %d rows but found %d", numAccounts, rowCount)
 	}
 }
@@ -1343,12 +1331,12 @@ func TestRestoredPrivileges(t *testing.T) {
 	_, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts)
 	defer cleanupFn()
 
-	rootOnly := sqlDB.QueryStr(`SHOW GRANTS ON bench.bank`)
+	rootOnly := sqlDB.QueryResults(`SHOW GRANTS ON bench.bank`)
 
 	sqlDB.Exec(`CREATE USER someone`)
 	sqlDB.Exec(`GRANT SELECT, INSERT, UPDATE, DELETE ON bench.bank TO someone`)
 
-	withGrants := sqlDB.QueryStr(`SHOW GRANTS ON bench.bank`)
+	withGrants := sqlDB.QueryResults(`SHOW GRANTS ON bench.bank`)
 
 	sqlDB.Exec(`BACKUP DATABASE bench TO $1`, dir)
 	sqlDB.Exec(`DROP TABLE bench.bank`)
@@ -1396,7 +1384,7 @@ func TestRestoreInto(t *testing.T) {
 	sqlDB.Exec(`CREATE DATABASE bench2`)
 	sqlDB.Exec(restoreStmt)
 
-	expected := sqlDB.QueryStr(`SELECT * FROM bench.bank`)
+	expected := sqlDB.QueryResults(`SELECT * FROM bench.bank`)
 	sqlDB.CheckQueryResults(`SELECT * FROM bench2.bank`, expected)
 }
 

--- a/pkg/server/settingsworker_test.go
+++ b/pkg/server/settingsworker_test.go
@@ -123,7 +123,7 @@ func TestSettingsRefresh(t *testing.T) {
 	// SET/SHOW work too.
 	db.Exec(fmt.Sprintf(setQ, strKey, "'via-set'"))
 	testutils.SucceedsSoon(t, func() error {
-		if expected, actual := "via-set", db.QueryStr(fmt.Sprintf(showQ, strKey))[0][0]; expected != actual {
+		if expected, actual := "via-set", db.QueryStr(fmt.Sprintf(showQ, strKey)); expected != actual {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}
 		return nil
@@ -132,7 +132,7 @@ func TestSettingsRefresh(t *testing.T) {
 	// SET/SHOW work too.
 	db.Exec(fmt.Sprintf(setQ, intKey, "5"))
 	testutils.SucceedsSoon(t, func() error {
-		if expected, actual := "5", db.QueryStr(fmt.Sprintf(showQ, intKey))[0][0]; expected != actual {
+		if expected, actual := "5", db.QueryStr(fmt.Sprintf(showQ, intKey)); expected != actual {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}
 		return nil

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -130,7 +130,7 @@ func TestDistBackfill(t *testing.T) {
 		t.Fatal(err)
 	}
 	r.Exec("SET DISTSQL = ALWAYS")
-	res := r.QueryStr("SELECT str FROM NumToStr@foo")
+	res := r.QueryResults("SELECT str FROM NumToStr@foo")
 	if len(res) != n*n {
 		t.Errorf("expected %d entries, got %d", n*n, len(res))
 	}

--- a/pkg/sql/upsert_test.go
+++ b/pkg/sql/upsert_test.go
@@ -180,8 +180,8 @@ SELECT * FROM d.t@primary = %s
 SELECT * FROM d.t@b_idx   = %s
 `,
 					err,
-					sqlDB.QueryStr(`SELECT * FROM d.t@primary`),
-					sqlDB.QueryStr(`SELECT * FROM d.t@b_idx`),
+					sqlDB.QueryResults(`SELECT * FROM d.t@primary`),
+					sqlDB.QueryResults(`SELECT * FROM d.t@b_idx`),
 				)
 			}
 		})


### PR DESCRIPTION
Lots of our tests use `var x … QueryRow().Scan(x) .. x ==` constructions.
These add boiler plate and worse reuse vars to mean different things, by mutating them in place.

Adding helpers that simply return the desired value allows using the much preferred `if x := f(); x != ` inline def-and-test pattern, which helps prevent any scope / mutation order mistakes.