### PR TITLE
build: use git ls-files instead of find for performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,10 @@ testrace: override GOFLAGS += -race
 testrace: export GORACE := halt_on_error=1
 testrace: TESTTIMEOUT := $(RACETIMEOUT)
 
-bin/sql.test: main.go $(shell find pkg -type f -name "*.go")
+# Directory scans in the builder image are excruciatingly slow when running
+# Docker for Mac, so we filter out the 20k+ UI dependencies that are guaranteed
+# to be irrelevant to save nearly 10s on every Make invocation.
+bin/sql.test: main.go $(shell find pkg -name 'node_modules' -prune -o -name '*.go')
 	$(GO) test $(GOFLAGS) -c -o bin/sql.test -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' ./pkg/sql
 
 bench: BENCHES := .


### PR DESCRIPTION
The newly-added bin/sql.test target (9d2a7e4) needs to depend on all .go
files in the repository. `find` is unfortunately far too slow for this
task; it takes upwards of 5s in the builder container when running
Docker for Mac. (Shared file systems have known performance issues with
Docker for Mac.) In this case, there's an easy workaround: use `git
ls-files`, which avoids the slow scan of the entire directory tree by
reading the paths directoy out of the Git index instead.

This commit brings `time build/builder.sh make bin/.bootstrap` down from
~10s to ~1.5s on my machine, which is as fast as it was pre-9d2a7e4.

---

FYI:

```
$ diff <(find pkg -type f -name '*.go' | sort) <(git ls-files '*.go' | sort)
0a1,3
> build/style_test.go
> build/tool_imports.go
> main.go
```

In the interest of simplicity, it seems fine to me that we now depend on the two Go files in `build`.