### PR TITLE
storage: Enable propEvalKV and burn the boats

### DIFF
--- a/pkg/ccl/sqlccl/backup_cloud_test.go
+++ b/pkg/ccl/sqlccl/backup_cloud_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -35,9 +34,6 @@ import (
 // only run if the AWS_S3_BUCKET environment var is set.
 func TestCloudBackupRestoreS3(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	if !storage.ProposerEvaluatedKVEnabled() {
-		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
 	s3Keys, err := s3gof3r.EnvKeys()
 	if err != nil {
 		t.Skipf("No AWS env keys (%v)", err)
@@ -67,9 +63,6 @@ func TestCloudBackupRestoreS3(t *testing.T) {
 // occasionally be flaky. It's only run if the GS_BUCKET environment var is set.
 func TestCloudBackupRestoreGoogleCloudStorage(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	if !storage.ProposerEvaluatedKVEnabled() {
-		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
 	bucket := os.Getenv("GS_BUCKET")
 	if bucket == "" {
 		t.Skip("GS_BUCKET env var must be set")
@@ -99,9 +92,6 @@ func TestCloudBackupRestoreGoogleCloudStorage(t *testing.T) {
 // AZURE_ACCOUNT_KEY environment vars are set.
 func TestCloudBackupRestoreAzure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	if !storage.ProposerEvaluatedKVEnabled() {
-		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
 	accountName := os.Getenv("AZURE_ACCOUNT_NAME")
 	accountKey := os.Getenv("AZURE_ACCOUNT_KEY")
 	if accountName == "" || accountKey == "" {

--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -249,9 +249,6 @@ func TestBackupStatementResult(t *testing.T) {
 
 func TestBackupRestoreLocal(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	if !storage.ProposerEvaluatedKVEnabled() {
-		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
 
 	const numAccounts = 1000
 
@@ -389,9 +386,6 @@ func verifySystemJobProgress(
 
 func TestBackupRestoreSystemJobs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	if !storage.ProposerEvaluatedKVEnabled() {
-		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
 
 	const expectedProgressUpdateCount = backupRestoreDefaultRanges
 
@@ -501,10 +495,6 @@ func TestBackupRestoreSystemJobs(t *testing.T) {
 
 func TestBackupRestoreInterleaved(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	if !storage.ProposerEvaluatedKVEnabled() {
-		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
-
 	const numAccounts = 10
 
 	_, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts)
@@ -580,9 +570,6 @@ func TestBackupRestoreInterleaved(t *testing.T) {
 
 func TestBackupRestoreCrossTableReferences(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	if !storage.ProposerEvaluatedKVEnabled() {
-		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
 
 	const numAccounts = 30
 	const createStore = "CREATE DATABASE store"
@@ -887,9 +874,6 @@ func checksumBankPayload(t *testing.T, sqlDB *sqlutils.SQLRunner) uint32 {
 
 func TestBackupRestoreIncremental(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	if !storage.ProposerEvaluatedKVEnabled() {
-		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
 
 	const numAccounts = 10
 	const numBackups = 4
@@ -1018,9 +1002,6 @@ func startBackgroundWrites(
 
 func TestBackupRestoreWithConcurrentWrites(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	if !storage.ProposerEvaluatedKVEnabled() {
-		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
 
 	const rows = 10
 	const numBackgroundTasks = multiNode
@@ -1074,9 +1055,6 @@ func TestBackupRestoreWithConcurrentWrites(t *testing.T) {
 
 func TestBackupAsOfSystemTime(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	if !storage.ProposerEvaluatedKVEnabled() {
-		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
 
 	const numAccounts = 1000
 
@@ -1108,9 +1086,6 @@ func TestBackupAsOfSystemTime(t *testing.T) {
 
 func TestBackupRestoreChecksum(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	if !storage.ProposerEvaluatedKVEnabled() {
-		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
 
 	const numAccounts = 1000
 	_, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts)
@@ -1335,9 +1310,6 @@ func TestBackupLevelDB(t *testing.T) {
 
 func TestRestoredPrivileges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	if !storage.ProposerEvaluatedKVEnabled() {
-		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
 
 	const numAccounts = 1
 	_, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts)
@@ -1376,9 +1348,6 @@ func TestRestoredPrivileges(t *testing.T) {
 
 func TestRestoreInto(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	if !storage.ProposerEvaluatedKVEnabled() {
-		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
 
 	const numAccounts = 1
 	_, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts)
@@ -1402,9 +1371,6 @@ func TestRestoreInto(t *testing.T) {
 
 func TestBackupRestorePermissions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	if !storage.ProposerEvaluatedKVEnabled() {
-		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
 
 	const numAccounts = 1
 	_, dir, tc, sqlDB, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts)

--- a/pkg/ccl/sqlccl/bench_test.go
+++ b/pkg/ccl/sqlccl/bench_test.go
@@ -14,7 +14,6 @@ import (
 	"io"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
@@ -35,9 +34,6 @@ func BenchmarkClusterBackup(b *testing.B) {
 	// NB: This benchmark takes liberties in how b.N is used compared to the go
 	// documentation's description. We're getting useful information out of it,
 	// but this is not a pattern to cargo-cult.
-	if !storage.ProposerEvaluatedKVEnabled() {
-		b.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
 	defer tracing.Disable()()
 
 	ctx, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(b, multiNode, 0)
@@ -70,9 +66,6 @@ func BenchmarkClusterRestore(b *testing.B) {
 	// NB: This benchmark takes liberties in how b.N is used compared to the go
 	// documentation's description. We're getting useful information out of it,
 	// but this is not a pattern to cargo-cult.
-	if !storage.ProposerEvaluatedKVEnabled() {
-		b.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
 	defer tracing.Disable()()
 
 	ctx, dir, _, sqlDB, cleanup := backupRestoreTestSetup(b, multiNode, 0)
@@ -93,9 +86,6 @@ func BenchmarkLoadRestore(b *testing.B) {
 	// NB: This benchmark takes liberties in how b.N is used compared to the go
 	// documentation's description. We're getting useful information out of it,
 	// but this is not a pattern to cargo-cult.
-	if !storage.ProposerEvaluatedKVEnabled() {
-		b.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
 	defer tracing.Disable()()
 
 	ctx, dir, _, sqlDB, cleanup := backupRestoreTestSetup(b, multiNode, 0)

--- a/pkg/ccl/sqlccl/kv_test.go
+++ b/pkg/ccl/sqlccl/kv_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -42,10 +41,6 @@ type kvWriteBatch struct {
 }
 
 func newKVWriteBatch(b *testing.B) kvInterface {
-	if !storage.ProposerEvaluatedKVEnabled() {
-		b.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
-
 	enableTracing := tracing.Disable()
 	s, _, _ := serverutils.StartServer(b, base.TestServerArgs{})
 

--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -113,9 +112,6 @@ func clientKVsToEngineKVs(kvs []client.KeyValue) []engine.MVCCKeyValue {
 
 func TestImport(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	if !storage.ProposerEvaluatedKVEnabled() {
-		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
 
 	dir, dirCleanupFn := testutils.TempDir(t)
 	defer dirCleanupFn()

--- a/pkg/ccl/storageccl/writebatch.go
+++ b/pkg/ccl/storageccl/writebatch.go
@@ -35,11 +35,6 @@ func init() {
 func evalWriteBatch(
 	ctx context.Context, batch engine.ReadWriter, cArgs storage.CommandArgs, _ roachpb.Response,
 ) (storage.EvalResult, error) {
-	if !storage.ProposerEvaluatedKVEnabled() {
-		// To reduce the footprint of things that have ever been downstream of
-		// raft, forbid this command from running without proposer evaluated kv.
-		panic("command WriteBatch is not allowed without proposer evaluated KV")
-	}
 
 	args := cArgs.Args.(*roachpb.WriteBatchRequest)
 	h := cArgs.Header

--- a/pkg/ccl/storageccl/writebatch_test.go
+++ b/pkg/ccl/storageccl/writebatch_test.go
@@ -35,9 +35,6 @@ import (
 
 func TestDBWriteBatch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	if !storage.ProposerEvaluatedKVEnabled() {
-		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
 
 	s, _, db := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
 	defer s.Stopper().Stop()
@@ -119,9 +116,6 @@ func TestDBWriteBatch(t *testing.T) {
 
 func TestWriteBatchMVCCStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	if !storage.ProposerEvaluatedKVEnabled() {
-		t.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
 
 	ctx := context.Background()
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
@@ -188,9 +182,6 @@ func TestWriteBatchMVCCStats(t *testing.T) {
 }
 
 func BenchmarkWriteBatch(b *testing.B) {
-	if !storage.ProposerEvaluatedKVEnabled() {
-		b.Skip("command WriteBatch is not allowed without proposer evaluated KV")
-	}
 	rng, _ := randutil.NewPseudoRand()
 	const payloadSize = 100
 	v := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, payloadSize))

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2079,22 +2079,10 @@ func (ncc *noConfChangeTestHandler) HandleRaftRequest(
 				panic(err)
 			}
 			if req.RangeID == ncc.rangeID {
-				if command.BatchRequest != nil { // !propEvalKV
-					if ba, ok := command.BatchRequest.GetArg(roachpb.EndTransaction); ok {
-						et := ba.(*roachpb.EndTransactionRequest)
-						if crt := et.InternalCommitTrigger.GetChangeReplicasTrigger(); crt != nil {
-							// We found a configuration change headed for our victim range;
-							// sink it.
-							req.Message.Entries = req.Message.Entries[:i]
-							break
-						}
-					}
-				} else { // propEvalKV
-					if command.ReplicatedEvalResult.ChangeReplicas != nil {
-						// We found a configuration change headed for our victim range;
-						// sink it.
-						req.Message.Entries = req.Message.Entries[:i]
-					}
+				if command.ReplicatedEvalResult.ChangeReplicas != nil {
+					// We found a configuration change headed for our victim range;
+					// sink it.
+					req.Message.Entries = req.Message.Entries[:i]
 				}
 			}
 		}

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -97,7 +97,7 @@ var tickQuiesced = envutil.EnvOrDefaultBool("COCKROACH_TICK_QUIESCED", true)
 var syncRaftLog = envutil.EnvOrDefaultBool("COCKROACH_SYNC_RAFT_LOG", false)
 
 // Whether to enable experimental support for proposer-evaluated KV.
-var propEvalKV = envutil.EnvOrDefaultBool("COCKROACH_PROPOSER_EVALUATED_KV", false)
+var propEvalKV = envutil.EnvOrDefaultBool("COCKROACH_PROPOSER_EVALUATED_KV", true)
 
 // ProposerEvaluatedKVEnabled returns whether experimental support for
 // proposer-evaluated KV is enabled.

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -75,10 +75,9 @@ type ProposalData struct {
 	// proposalResult come from LocalEvalResult)
 	doneCh chan proposalResult
 
-	// Local contains the results of evaluating the request in
-	// propEvalKV, tying the upstream evaluation of the request to the
-	// downstream application of the command. If propEvalKV is false,
-	// Local is nil.
+	// Local contains the results of evaluating the request
+	// tying the upstream evaluation of the request to the
+	// downstream application of the command.
 	Local *LocalEvalResult
 
 	// Request is the client's original BatchRequest.

--- a/pkg/storage/replica_state.go
+++ b/pkg/storage/replica_state.go
@@ -117,18 +117,6 @@ func (rsl replicaStateLoader) save(
 	); err != nil {
 		return enginepb.MVCCStats{}, err
 	}
-	// Freeze-related functionality was removed in #14779 but we must
-	// continue to write a value to this key to avoid inconsistencies
-	// during upgrades.
-	//
-	// TODO(bdarnell): this can be safely removed after propEvalKV is
-	// fully rolled out.
-	var falseVal roachpb.Value
-	falseVal.SetBool(false)
-	if err := engine.MVCCPut(ctx, eng, ms, rsl.RangeFrozenStatusKey(),
-		hlc.Timestamp{}, falseVal, nil); err != nil {
-		return enginepb.MVCCStats{}, err
-	}
 	if err := rsl.setGCThreshold(ctx, eng, ms, &state.GCThreshold); err != nil {
 		return enginepb.MVCCStats{}, err
 	}

--- a/pkg/storage/stats_test.go
+++ b/pkg/storage/stats_test.go
@@ -33,8 +33,8 @@ import (
 // writeInitialState().
 func initialStats() enginepb.MVCCStats {
 	return enginepb.MVCCStats{
-		SysBytes: 237,
-		SysCount: 7,
+		SysBytes: 208,
+		SysCount: 6,
 	}
 }
 func TestRangeStatsEmpty(t *testing.T) {


### PR DESCRIPTION
We could hold off on the second commit for a few days if we want to do more comparative benchmarking, but I intend to remove the option in time for the next beta. 