### PR TITLE
storage: always update liveness heartbeat success metric

### DIFF
--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -330,6 +330,7 @@ func (nl *NodeLiveness) heartbeatInternal(
 		return errSkippedHeartbeat
 	}); err != nil {
 		if err == errNodeAlreadyLive {
+			nl.metrics.HeartbeatSuccesses.Inc(1)
 			return nil
 		}
 		nl.metrics.HeartbeatFailures.Inc(1)


### PR DESCRIPTION
We were previously not updating it if the heartbeat went through only
to discover that the node is already live (usually due to a concurrent
heartbeat triggered by activity to a replica on the node in question).

Fixes #11652