### PR TITLE
sql: verify X -> int conversions are safe

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -41,7 +41,7 @@ imports:
   subpackages:
   - cmd/misspell
 - name: github.com/cockroachdb/apd
-  version: 4c0c15263a45c631e8f0310f0acbc1e89c722ac2
+  version: 0ccdf9dd91d85d9f95d131fd2420c78c56f76c1f
 - name: github.com/cockroachdb/c-jemalloc
   version: 5fc986390622939c1f0e6df236040deca8c821b0
 - name: github.com/cockroachdb/c-protobuf

--- a/glide.yaml
+++ b/glide.yaml
@@ -27,7 +27,7 @@ import:
 - package: cloud.google.com/go
   version: ed63fb27efcf32e25fe7837e4662457d3da4c4f2
 - package: github.com/cockroachdb/apd
-  version: 4c0c15263a45c631e8f0310f0acbc1e89c722ac2
+  version: 0ccdf9dd91d85d9f95d131fd2420c78c56f76c1f
 - package: github.com/cockroachdb/c-jemalloc
   version: 5fc986390622939c1f0e6df236040deca8c821b0
 - package: github.com/cockroachdb/c-protobuf

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -2020,11 +2020,19 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 		case *DInt:
 			res = v
 		case *DFloat:
-			f, err := round(float64(*v), 0)
-			if err != nil {
-				panic(fmt.Sprintf("round should never fail with digits hardcoded to 0: %s", err))
+			f := float64(*v)
+			// Use `<=` and `>=` here instead of just `<` and `>` because when
+			// math.MaxInt64 and math.MinInt64 are converted to float64s, they are
+			// rounded to numbers with larger absolute values. Note that the first
+			// next FP value after and strictly greater than float64(math.MinInt64)
+			// is -9223372036854774784 (= float64(math.MinInt64)+513) and the first
+			// previous value and strictly smaller than float64(math.MaxInt64)
+			// is 9223372036854774784 (= float64(math.MaxInt64)-513), and both are
+			// convertible to int without overflow.
+			if math.IsNaN(f) || f <= float64(math.MinInt64) || f >= float64(math.MaxInt64) {
+				return nil, errIntOutOfRange
 			}
-			res = NewDInt(DInt(*f.(*DFloat)))
+			res = NewDInt(DInt(f))
 		case *DDecimal:
 			d := ctx.getTmpDec()
 			_, err := DecimalCtx.ToIntegral(d, &v.Decimal)

--- a/pkg/sql/parser/eval_test.go
+++ b/pkg/sql/parser/eval_test.go
@@ -551,6 +551,11 @@ func TestEval(t *testing.T) {
 		{`(1.1::decimal)::float`, `1.1`},
 		{`(1.1::decimal)::boolean`, `true`},
 		{`(0.0::decimal)::boolean`, `false`},
+		{`(1e300::decimal)::float`, `1e+300`},
+		{`(9223372036854775807::decimal)::int`, `9223372036854775807`},
+		// The two largest floats that can be converted to an int, albeit inexactly.
+		{`9223372036854775295::float::int`, `9223372036854774784`},
+		{`-9223372036854775295::float::int`, `-9223372036854774784`},
 		{`1.1::int`, `1`},
 		{`1.5::int`, `2`},
 		{`1.9::int`, `2`},
@@ -791,6 +796,8 @@ func TestEval(t *testing.T) {
 		{`'-Inf'::decimal = '+Inf'::decimal`, `false`},
 		{`'-Inf'::decimal > '+Inf'::decimal`, `false`},
 		{`'-Inf'::decimal >= '+Inf'::decimal`, `false`},
+		{`'Inf'::decimal::float`, `+Inf`},
+		{`'Inf'::float::decimal`, `Infinity`},
 		// NaN
 		{`'NaN'::float`, `NaN`},
 		{`'NaN'::float(4)`, `NaN`},
@@ -838,6 +845,8 @@ func TestEval(t *testing.T) {
 		{`'NaN'::decimal = 'NaN'::decimal`, `false`},
 		{`'NaN'::decimal > 'NaN'::decimal`, `false`},
 		{`'NaN'::decimal >= 'NaN'::decimal`, `false`},
+		{`'NaN'::decimal::float`, `NaN`},
+		{`'NaN'::float::decimal`, `NaN`},
 	}
 	for _, d := range testData {
 		expr, err := ParseExprTraditional(d.expr)
@@ -1052,6 +1061,21 @@ func TestEvalError(t *testing.T) {
 		{`(-9223372036854775807:::int - 1) * -1:::int`, `integer out of range`},
 		{`123 ^ 100`, `integer out of range`},
 		{`power(123, 100)`, `integer out of range`},
+		// Although these next two tests are valid integers, a float cannot represent
+		// them exactly, and so rounds them to a larger number that is out of bounds
+		// for an int. Thus, they should fail during this conversion.
+		{`9223372036854775807::float::int`, `integer out of range`},
+		{`-9223372036854775808::float::int`, `integer out of range`},
+		// The two smallest floats that cannot be converted to an int.
+		{`9223372036854775296::float::int`, `integer out of range`},
+		{`-9223372036854775296::float::int`, `integer out of range`},
+		{`1e500::decimal::int`, `integer out of range`},
+		{`1e500::decimal::float`, `float out of range`},
+		{`1e300::decimal::float::int`, `integer out of range`},
+		{`'Inf'::decimal::int`, `integer out of range`},
+		{`'NaN'::decimal::int`, `integer out of range`},
+		{`'Inf'::float::int`, `integer out of range`},
+		{`'NaN'::float::int`, `integer out of range`},
 	}
 	for _, d := range testData {
 		expr, err := ParseExprTraditional(d.expr)

--- a/pkg/sql/testdata/logic_test/builtin_function
+++ b/pkg/sql/testdata/logic_test/builtin_function
@@ -621,10 +621,13 @@ SELECT pow(-2::int, 3::int), pow(2::int, 3::int)
 statement error integer out of range
 SELECT pow(2::int, -3::int)
 
-query IIII
-SELECT pow(0::int, 3::int), pow(0::int, -3::int), pow(3::int, 0::int), pow(-3::int, 0::int)
+query III
+SELECT pow(0::int, 3::int), pow(3::int, 0::int), pow(-3::int, 0::int)
 ----
-0 0 1 1
+0 1 1
+
+statement error integer out of range
+SELECT pow(0::int, -3::int)
 
 statement error invalid operation
 SELECT pow(0::int, 0::int)


### PR DESCRIPTION
We cannot simply use `f > math.MaxInt64` in the floating -> int
conversion as a check because the MaxInt64 is converted to a float,
which is rounded up, above MaxInt64, and then compared to f. We
instead must convert it to a decimal first.

Also add some tests to check for similar conditions in decimal/float.

Fixes #14947