### PR TITLE
core: WIP drop permission checks in batchInternal

### DIFF
--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -571,6 +572,34 @@ func TestSpanStatsGRPCResponse(t *testing.T) {
 	}
 	if a, e := int(response.RangeCount), initialRanges; a != e {
 		t.Errorf("expected %d ranges, found %d", e, a)
+	}
+}
+
+func TestNodesGRPCResponse(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ts := startServer(t)
+	defer ts.Stopper().Stop()
+
+	rpcStopper := stop.NewStopper()
+	defer rpcStopper.Stop()
+	rpcContext := rpc.NewContext(log.AmbientContext{}, ts.RPCContext().Config, ts.Clock(), rpcStopper)
+	request := serverpb.NodesRequest{}
+
+	url := ts.ServingAddr()
+	rpcContext.User = security.RootUser
+	conn, err := rpcContext.GRPCDial(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := serverpb.NewStatusClient(conn)
+
+	response, err := client.Nodes(context.Background(), &request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if a, e := len(response.Nodes), 1; a != e {
+		t.Errorf("expected %d node(s), found %d", e, a)
 	}
 }
 


### PR DESCRIPTION
We end up checking the permissions of the original caller (eg: the
client to a status call) when the server is the one doing the operation.

We should decide if we want to lock down the status endpoints instead.

Fixes #14839