### PR TITLE
core: skip permission checks for local internal.Batch requests.

### DIFF
--- a/pkg/kv/transport.go
+++ b/pkg/kv/transport.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -181,9 +182,14 @@ func (gt *grpcTransport) SendNext(ctx context.Context, done chan<- BatchCall) {
 					clonedTxn := origTxn.Clone()
 					client.args.Txn = &clonedTxn
 				}
+
+				// Create a new context from the existing one with the "local request" field set.
+				// This tells the handler that this is an in-procress request, bypassing ctx.Peer checks.
+				localCtx := grpcutil.NewLocalRequestContext(ctx)
+
 				gt.opts.metrics.LocalSentCount.Inc(1)
-				log.VEvent(ctx, 2, "sending request to local server")
-				return localServer.Batch(ctx, &client.args)
+				log.VEvent(localCtx, 2, "sending request to local server")
+				return localServer.Batch(localCtx, &client.args)
 			}
 
 			log.VEventf(ctx, 2, "sending request to %s", client.remoteAddr)

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -809,7 +810,9 @@ func (n *Node) batchInternal(
 	// the request handler) doesn't really fit with the current design of the
 	// security package (which assumes that TLS state is only given at connection
 	// time) - that should be fixed.
-	if peer, ok := peer.FromContext(ctx); ok {
+	if grpcutil.IsLocalRequestContext(ctx) {
+		// this is a in-process request, bypass checks.
+	} else if peer, ok := peer.FromContext(ctx); ok {
 		if tlsInfo, ok := peer.AuthInfo.(credentials.TLSInfo); ok {
 			certUser, err := security.GetCertificateUser(&tlsInfo.State)
 			if err != nil {

--- a/pkg/util/grpcutil/grpc_util.go
+++ b/pkg/util/grpcutil/grpc_util.go
@@ -29,6 +29,19 @@ import (
 	"google.golang.org/grpc/transport"
 )
 
+type localRequestKey struct{}
+
+// NewLocalRequestContext takes an existing context which may have the Peer field set,
+// and returns a Context that can be used for local (in-process) request.
+func NewLocalRequestContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, localRequestKey{}, struct{}{})
+}
+
+// IsLocalRequestContext returns true this context is marked for local (in-process) use.
+func IsLocalRequestContext(ctx context.Context) bool {
+	return ctx.Value(localRequestKey{}) != nil
+}
+
 // IsClosedConnection returns true if err's Cause is an error produced by gRPC
 // on closed connections.
 func IsClosedConnection(err error) bool {


### PR DESCRIPTION
Fixes #14839

Local batch requests contain the context.Peer values that were set by
grpc upon receiving the request (meaning this will be the remote
client's TLS info).
Instead, in-process internal batch calls should just be performed, it's
the caller's responsibility to perform the proper permission checks.

This adds a "local request" field on the context. Due to the lack of
removal on contexts, it's easier to add a separate one rather than try
to special-handle Peer.

The test included fails without the local context check since the Peer
in the node.go auth check is for RootUser (the original client).