### PR TITLE
storage: ensure that the push txn queue is cleared on splits and merges

### DIFF
--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1925,3 +1925,118 @@ func TestUnsplittableRange(t *testing.T) {
 			origMaxBytes, repl.GetMaxBytes())
 	})
 }
+
+// TestPushTxnQueueDependencyCycleWithRangeSplit verifies that a range
+// split which occurs while a dependency cycle is partially underway
+// will cause the pending push txns to be retried such that they
+// relocate to the appropriate new range.
+func TestPushTxnQueueDependencyCycleWithRangeSplit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	for _, read2ndPass := range []bool{false, true} {
+		t.Run(fmt.Sprintf("read-2nd-pass:%t", read2ndPass), func(t *testing.T) {
+			var pushCount int32
+			firstPush := make(chan struct{})
+
+			storeCfg := storage.TestStoreConfig(nil)
+			storeCfg.TestingKnobs.DisableSplitQueue = true
+			storeCfg.TestingKnobs.TestingEvalFilter =
+				func(filterArgs storagebase.FilterArgs) *roachpb.Error {
+					if _, ok := filterArgs.Req.(*roachpb.PushTxnRequest); ok {
+						if atomic.AddInt32(&pushCount, 1) == 1 {
+							close(firstPush)
+						}
+					}
+					return nil
+				}
+			stopper := stop.NewStopper()
+			defer stopper.Stop()
+			store := createTestStoreWithConfig(t, stopper, storeCfg)
+
+			lhsKey := roachpb.Key("a")
+			rhsKey := roachpb.Key("b")
+
+			// Split at "a".
+			args := adminSplitArgs(lhsKey, lhsKey)
+			if _, pErr := client.SendWrapped(context.Background(), rg1(store), args); pErr != nil {
+				t.Fatalf("split at %q: %s", lhsKey, pErr)
+			}
+			lhs := store.LookupReplica(roachpb.RKey("a"), nil)
+
+			var txnACount, txnBCount int32
+
+			txnAWritesA := make(chan struct{})
+			txnAProceeds := make(chan struct{})
+			txnBWritesB := make(chan struct{})
+			txnBProceeds := make(chan struct{})
+
+			// Start txn to write key a.
+			txnACh := make(chan error)
+			go func() {
+				txnACh <- store.DB().Txn(context.Background(), func(ctx context.Context, txn *client.Txn) error {
+					if err := txn.Put(ctx, lhsKey, "value"); err != nil {
+						return err
+					}
+					if atomic.LoadInt32(&txnACount) == 0 {
+						close(txnAWritesA)
+						<-txnAProceeds
+					}
+					atomic.AddInt32(&txnACount, 1)
+					return txn.Put(ctx, rhsKey, "value-from-A")
+				})
+			}()
+			<-txnAWritesA
+
+			// Start txn to write key b.
+			txnBCh := make(chan error)
+			go func() {
+				txnBCh <- store.DB().Txn(context.Background(), func(ctx context.Context, txn *client.Txn) error {
+					if err := txn.Put(ctx, rhsKey, "value"); err != nil {
+						return err
+					}
+					if atomic.LoadInt32(&txnBCount) == 0 {
+						close(txnBWritesB)
+						<-txnBProceeds
+					}
+					atomic.AddInt32(&txnBCount, 1)
+					// Read instead of write key "a" if directed. This caused a
+					// PUSH_TIMESTAMP to be issued from txn B instead of PUSH_ABORT.
+					if read2ndPass {
+						if _, err := txn.Get(ctx, lhsKey); err != nil {
+							return err
+						}
+					} else {
+						if err := txn.Put(ctx, lhsKey, "value-from-B"); err != nil {
+							return err
+						}
+					}
+					return nil
+				})
+			}()
+			<-txnBWritesB
+
+			// Now, let txnA proceed before splitting.
+			close(txnAProceeds)
+			// Wait for the push to occur.
+			<-firstPush
+
+			// Split at "b".
+			args = adminSplitArgs(rhsKey, rhsKey)
+			if _, pErr := client.SendWrappedWith(context.Background(), store, roachpb.Header{
+				RangeID: lhs.RangeID,
+			}, args); pErr != nil {
+				t.Fatalf("split at %q: %s", rhsKey, pErr)
+			}
+
+			// Now that we've split, allow txnB to proceed.
+			close(txnBProceeds)
+
+			// Verify that both complete.
+			for i, ch := range []chan error{txnACh, txnBCh} {
+				if err := <-ch; err != nil {
+					t.Fatalf("%d: txn failure: %v", i, err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/storage/push_txn_queue.go
+++ b/pkg/storage/push_txn_queue.go
@@ -91,6 +91,10 @@ type pendingTxn struct {
 	waiters []*waitingPush
 }
 
+func (pt *pendingTxn) getTxn() *roachpb.Transaction {
+	return pt.txn.Load().(*roachpb.Transaction)
+}
+
 // A pushTxnQueue enqueues PushTxn requests which are waiting on
 // extant txns with conflicting intents to abort or commit.
 //
@@ -123,21 +127,31 @@ func (ptq *pushTxnQueue) Enable() {
 	}
 }
 
-// ClearAndDisable empties the queue and returns all waiters. This
-// method should be invoked when the replica loses or transfers its
-// lease. Once invoked, no transaction may be enqueued or waiting
-// pushers added. Call Enable() when the lease is again acquired by
-// the replica.
-func (ptq *pushTxnQueue) ClearAndDisable() {
+// Clear empties the queue and returns all waiters. This method should
+// be invoked when the replica loses or transfers its lease. If
+// `disable` is true, future transactions may not be enqueued or
+// waiting pushers added. Call Enable() once the lease is again
+// acquired by the replica.
+func (ptq *pushTxnQueue) Clear(disable bool) {
 	ptq.mu.Lock()
 	var allWaiters []chan *roachpb.Transaction
 	for _, pt := range ptq.mu.txns {
 		for _, w := range pt.waiters {
 			allWaiters = append(allWaiters, w.pending)
 		}
+		if log.V(1) {
+			log.Infof(
+				context.Background(),
+				"clearing %d waiters for %s",
+				len(pt.waiters),
+				pt.getTxn().ID.Short(),
+			)
+		}
 		pt.waiters = nil
 	}
-	ptq.mu.txns = nil
+	if disable {
+		ptq.mu.txns = nil
+	}
 	ptq.mu.Unlock()
 
 	// Send on the pending waiter channels outside of the mutex lock.
@@ -194,6 +208,9 @@ func (ptq *pushTxnQueue) UpdateTxn(txn *roachpb.Transaction) {
 	delete(ptq.mu.txns, *txn.ID)
 	ptq.mu.Unlock()
 
+	if log.V(1) {
+		log.Infof(context.Background(), "updating %d waiters for %s", len(waiters), txn.ID.Short())
+	}
 	// Send on pending waiter channels outside of the mutex lock.
 	for _, w := range waiters {
 		w.pending <- txn
@@ -245,15 +262,19 @@ var errDeadlock = roachpb.NewErrorf("deadlock detected")
 // In the event of a dependency cycle of pushers leading to deadlock,
 // this method will return an errDeadlock error.
 func (ptq *pushTxnQueue) MaybeWait(
-	ctx context.Context, req *roachpb.PushTxnRequest,
+	ctx context.Context, repl *Replica, req *roachpb.PushTxnRequest,
 ) (*roachpb.PushTxnResponse, *roachpb.Error) {
 	if shouldPushImmediately(req) {
 		return nil, nil
 	}
 
 	ptq.mu.Lock()
-	if ptq.mu.txns == nil {
-		// Not enabled; do nothing.
+	// If the push txn queue is not enabled or if the request is not
+	// contained within the replica, do nothing. The request can fall
+	// outside of the replica after a split or merge. Note that the
+	// ContainsKey check is done under the push txn queue's lock to
+	// ensure that it's not cleared before an incorrect insertion happens.
+	if ptq.mu.txns == nil || !repl.ContainsKey(req.Key) {
 		ptq.mu.Unlock()
 		return nil, nil
 	}
@@ -265,7 +286,7 @@ func (ptq *pushTxnQueue) MaybeWait(
 		ptq.mu.Unlock()
 		return nil, nil
 	}
-	if txn := pending.txn.Load().(*roachpb.Transaction); isPushed(req, txn) {
+	if txn := pending.getTxn(); isPushed(req, txn) {
 		ptq.mu.Unlock()
 		return createPushTxnResponse(txn), nil
 	}
@@ -275,7 +296,19 @@ func (ptq *pushTxnQueue) MaybeWait(
 		pending: make(chan *roachpb.Transaction, 1),
 	}
 	pending.waiters = append(pending.waiters, push)
-
+	if log.V(2) {
+		if req.PusherTxn.ID != nil {
+			log.Infof(
+				ctx,
+				"%s pushing %s (%d pending)",
+				req.PusherTxn.ID.Short(),
+				req.PusheeTxn.ID.Short(),
+				len(pending.waiters),
+			)
+		} else {
+			log.Infof(ctx, "pushing %s (%d pending)", req.PusheeTxn.ID.Short(), len(pending.waiters))
+		}
+	}
 	ptq.mu.Unlock()
 
 	// Periodically refresh the pusher and pushee txns (with an
@@ -284,10 +317,6 @@ func (ptq *pushTxnQueue) MaybeWait(
 	// transactions.
 	r := retry.Start(ptq.store.cfg.RangeRetryOptions)
 	queryCh := r.NextCh()
-
-	// Keep local values for the pusher and pushee priorities to avoid
-	// modifying values in the original request on QueryTxn updates.
-	pusheePriority := req.PusheeTxn.Priority
 
 	for {
 		select {
@@ -317,15 +346,17 @@ func (ptq *pushTxnQueue) MaybeWait(
 			updatedPushee, _, pErr := ptq.queryTxnStatus(ctx, req.PusheeTxn, ptq.store.Clock().Now())
 			if pErr != nil {
 				return nil, pErr
-			} else if updatedPushee != nil {
-				pusheePriority = updatedPushee.Priority
-				pending.txn.Store(updatedPushee)
-				if isExpired(ptq.store.Clock().Now(), updatedPushee) {
-					if log.V(1) {
-						log.Warningf(ctx, "%s pushing expired txn %s", req.PusherTxn.ID.Short(), req.PusheeTxn.ID.Short())
-					}
-					return nil, nil
+			} else if updatedPushee == nil {
+				// Continue with push.
+				return nil, nil
+			}
+			pusheePriority := updatedPushee.Priority
+			pending.txn.Store(updatedPushee)
+			if isExpired(ptq.store.Clock().Now(), updatedPushee) {
+				if log.V(1) {
+					log.Warningf(ctx, "pushing expired txn %s", req.PusheeTxn.ID.Short())
 				}
+				return nil, nil
 			}
 
 			if req.PusherTxn.ID != nil {
@@ -355,7 +386,15 @@ func (ptq *pushTxnQueue) MaybeWait(
 						dependents = append(dependents, id.Short())
 					}
 					if log.V(2) {
-						log.Infof(ctx, "%s has dependencies=%s", req.PusherTxn.ID.Short(), dependents)
+						log.Infof(
+							ctx,
+							"%s (%d), pushing %s (%d), has dependencies=%s",
+							req.PusherTxn.ID.Short(),
+							pusherPriority,
+							req.PusheeTxn.ID.Short(),
+							pusheePriority,
+							dependents,
+						)
 					}
 					push.mu.Unlock()
 
@@ -364,7 +403,7 @@ func (ptq *pushTxnQueue) MaybeWait(
 						p1, p2 := pusheePriority, pusherPriority
 						if p1 < p2 || (p1 == p2 && bytes.Compare(req.PusheeTxn.ID.GetBytes(), req.PusherTxn.ID.GetBytes()) < 0) {
 							if log.V(1) {
-								log.Warningf(
+								log.Infof(
 									ctx,
 									"%s breaking deadlock by force push of %s; dependencies=%s",
 									req.PusherTxn.ID.Short(),

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1554,7 +1554,9 @@ func evalPushTxn(
 		reply.PusheeTxn.Timestamp = args.Now // see method comment
 		// Setting OrigTimestamp bumps LastActive(); see #9265.
 		reply.PusheeTxn.OrigTimestamp = args.Now
-		return EvalResult{}, engine.MVCCPutProto(ctx, batch, cArgs.Stats, key, hlc.Timestamp{}, nil, &reply.PusheeTxn)
+		result := EvalResult{}
+		result.Local.updatedTxn = &reply.PusheeTxn
+		return result, engine.MVCCPutProto(ctx, batch, cArgs.Stats, key, hlc.Timestamp{}, nil, &reply.PusheeTxn)
 	}
 	// Start with the persisted transaction record as final transaction.
 	reply.PusheeTxn = existTxn.Clone()
@@ -1600,7 +1602,7 @@ func evalPushTxn(
 		reason = "pusher has priority"
 		pusherWins = true
 	case args.Force:
-		reason = "forced txn abort"
+		reason = "forced push"
 		pusherWins = true
 	}
 

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -424,7 +424,7 @@ func (r *Replica) leasePostApply(
 	if leaseChangingHands && !iAmTheLeaseHolder {
 		// Also clear and disable the push transaction queue. Any waiters
 		// must be redirected to the new lease holder.
-		r.pushTxnQueue.ClearAndDisable()
+		r.pushTxnQueue.Clear(true /* disable */)
 	}
 
 	if !iAmTheLeaseHolder && r.IsLeaseValid(newLease, r.store.Clock().Now()) {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1915,6 +1915,12 @@ func (s *Store) SplitRange(ctx context.Context, origRng, newRng *Replica) error 
 	copyDesc.EndKey = append([]byte(nil), newDesc.StartKey...)
 	origRng.setDescWithoutProcessUpdate(&copyDesc)
 
+	// Clear the LHS push txn queue, to redirect to the RHS if
+	// appropriate. We do this after setDescWithoutProcessUpdate
+	// to ensure that no pre-split commands are inserted into the
+	// pushTxnQueue after we clear it.
+	origRng.pushTxnQueue.Clear(false /* disable */)
+
 	if kr := s.mu.replicasByKey.ReplaceOrInsert(origRng); kr != nil {
 		return errors.Errorf("replicasByKey unexpectedly contains %s when inserting replica %s", kr, origRng)
 	}
@@ -1980,6 +1986,10 @@ func (s *Store) MergeRange(
 	if err := s.removeReplicaImpl(ctx, subsumedRng, *subsumedDesc, false); err != nil {
 		return errors.Errorf("cannot remove range %s", err)
 	}
+
+	// Clear the RHS push txn queue, to redirect to the LHS if
+	// appropriate.
+	subsumedRng.pushTxnQueue.Clear(false /* disable */)
 
 	// Update the end key of the subsuming range.
 	copy := *subsumingDesc
@@ -2521,7 +2531,7 @@ func (s *Store) Send(
 		// txn response or else allow this request to proceed.
 		if ba.IsSinglePushTxnRequest() {
 			pushReq := ba.Requests[0].GetInner().(*roachpb.PushTxnRequest)
-			pushResp, pErr := repl.pushTxnQueue.MaybeWait(ctx, pushReq)
+			pushResp, pErr := repl.pushTxnQueue.MaybeWait(repl.AnnotateCtx(ctx), repl, pushReq)
 			// Copy the request in anticipation of setting the force arg and
 			// updating the Now timestamp (see below).
 			pushReqCopy := *pushReq
@@ -2540,7 +2550,7 @@ func (s *Store) Send(
 			// request may have been waiting to push the txn. If we don't
 			// move the timestamp forward to the current time, we may fail
 			// to push a txn which has expired.
-			pushReqCopy.Now = s.Clock().Now()
+			pushReqCopy.Now.Forward(s.Clock().Now())
 			ba.Requests = nil
 			ba.Add(&pushReqCopy)
 		}


### PR DESCRIPTION
Splits occurring concurrently with transactions establishing circular
dependencies must clear out the txn push queue in order to redirect
`PushTxn` requests to the correct new range replica.

Fixes #13784
Fixes #14911
