### PR TITLE
roachpb: respond to further comments from #14952

### DIFF
--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -179,21 +179,21 @@ func (r RangeDescriptor) String() string {
 	if !r.IsInitialized() {
 		buf.WriteString("{-}")
 	} else {
-		buf.WriteString(RSpan{r.StartKey, r.EndKey}.String())
+		buf.WriteString(r.RSpan().String())
 	}
 	buf.WriteString(" [")
 
-	for i, rep := range r.Replicas {
-		if i > 0 {
-			buf.WriteString(", ")
-		}
-		fmt.Fprintf(&buf, "r%d(n%d,s%d)", rep.ReplicaID, rep.NodeID, rep.StoreID)
-	}
 	if len(r.Replicas) > 0 {
-		fmt.Fprintf(&buf, ", next=%d]", r.NextReplicaID)
+		for i, rep := range r.Replicas {
+			if i > 0 {
+				buf.WriteString(", ")
+			}
+			fmt.Fprintf(&buf, "r%d(n%d,s%d)", rep.ReplicaID, rep.NodeID, rep.StoreID)
+		}
 	} else {
-		buf.WriteString("<no replicas>]")
+		buf.WriteString("<no replicas>")
 	}
+	fmt.Fprintf(&buf, ", next=%d]", r.NextReplicaID)
 
 	return buf.String()
 }


### PR DESCRIPTION
@tamird: note that I could not make the suggested changes to
`Replica` because the maximum number of characters to use when
displaying the pretty-printed range descriptor span is non-standard.