### PR TITLE
sql/rfc: s/statement pipelining/parallel statement execution/

### DIFF
--- a/pkg/sql/parser/stmt.go
+++ b/pkg/sql/parser/stmt.go
@@ -80,11 +80,11 @@ type HiddenFromStats interface {
 	hiddenFromStats()
 }
 
-// IndependentFromPipelinedPriors is a pseudo-interface to be implemented
+// IndependentFromParallelizedPriors is a pseudo-interface to be implemented
 // by statements which do not force parallel statement execution synchronization
 // when they run.
-type IndependentFromPipelinedPriors interface {
-	independentFromPipelinedPriors()
+type IndependentFromParallelizedPriors interface {
+	independentFromParallelizedPriors()
 }
 
 // StatementType implements the Statement interface.
@@ -377,8 +377,8 @@ func (*Show) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*Show) StatementTag() string { return "SHOW" }
 
-func (*Show) hiddenFromStats()                {}
-func (*Show) independentFromPipelinedPriors() {}
+func (*Show) hiddenFromStats()                   {}
+func (*Show) independentFromParallelizedPriors() {}
 
 // StatementType implements the Statement interface.
 func (*ShowColumns) StatementType() StatementType { return Rows }
@@ -386,8 +386,8 @@ func (*ShowColumns) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowColumns) StatementTag() string { return "SHOW COLUMNS" }
 
-func (*ShowColumns) hiddenFromStats()                {}
-func (*ShowColumns) independentFromPipelinedPriors() {}
+func (*ShowColumns) hiddenFromStats()                   {}
+func (*ShowColumns) independentFromParallelizedPriors() {}
 
 // StatementType implements the Statement interface.
 func (*ShowCreateTable) StatementType() StatementType { return Rows }
@@ -395,8 +395,8 @@ func (*ShowCreateTable) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowCreateTable) StatementTag() string { return "SHOW CREATE TABLE" }
 
-func (*ShowCreateTable) hiddenFromStats()                {}
-func (*ShowCreateTable) independentFromPipelinedPriors() {}
+func (*ShowCreateTable) hiddenFromStats()                   {}
+func (*ShowCreateTable) independentFromParallelizedPriors() {}
 
 // StatementType implements the Statement interface.
 func (*ShowCreateView) StatementType() StatementType { return Rows }
@@ -404,8 +404,8 @@ func (*ShowCreateView) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowCreateView) StatementTag() string { return "SHOW CREATE VIEW" }
 
-func (*ShowCreateView) hiddenFromStats()                {}
-func (*ShowCreateView) independentFromPipelinedPriors() {}
+func (*ShowCreateView) hiddenFromStats()                   {}
+func (*ShowCreateView) independentFromParallelizedPriors() {}
 
 // StatementType implements the Statement interface.
 func (*ShowDatabases) StatementType() StatementType { return Rows }
@@ -413,8 +413,8 @@ func (*ShowDatabases) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowDatabases) StatementTag() string { return "SHOW DATABASES" }
 
-func (*ShowDatabases) hiddenFromStats()                {}
-func (*ShowDatabases) independentFromPipelinedPriors() {}
+func (*ShowDatabases) hiddenFromStats()                   {}
+func (*ShowDatabases) independentFromParallelizedPriors() {}
 
 // StatementType implements the Statement interface.
 func (*ShowGrants) StatementType() StatementType { return Rows }
@@ -422,8 +422,8 @@ func (*ShowGrants) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowGrants) StatementTag() string { return "SHOW GRANTS" }
 
-func (*ShowGrants) hiddenFromStats()                {}
-func (*ShowGrants) independentFromPipelinedPriors() {}
+func (*ShowGrants) hiddenFromStats()                   {}
+func (*ShowGrants) independentFromParallelizedPriors() {}
 
 // StatementType implements the Statement interface.
 func (*ShowIndex) StatementType() StatementType { return Rows }
@@ -431,8 +431,8 @@ func (*ShowIndex) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowIndex) StatementTag() string { return "SHOW INDEX" }
 
-func (*ShowIndex) hiddenFromStats()                {}
-func (*ShowIndex) independentFromPipelinedPriors() {}
+func (*ShowIndex) hiddenFromStats()                   {}
+func (*ShowIndex) independentFromParallelizedPriors() {}
 
 // StatementType implements the Statement interface.
 func (*ShowTransactionStatus) StatementType() StatementType { return Rows }
@@ -440,8 +440,8 @@ func (*ShowTransactionStatus) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowTransactionStatus) StatementTag() string { return "SHOW TRANSACTION STATUS" }
 
-func (*ShowTransactionStatus) hiddenFromStats()                {}
-func (*ShowTransactionStatus) independentFromPipelinedPriors() {}
+func (*ShowTransactionStatus) hiddenFromStats()                   {}
+func (*ShowTransactionStatus) independentFromParallelizedPriors() {}
 
 // StatementType implements the Statement interface.
 func (*ShowUsers) StatementType() StatementType { return Rows }
@@ -449,8 +449,8 @@ func (*ShowUsers) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowUsers) StatementTag() string { return "SHOW USERS" }
 
-func (*ShowUsers) hiddenFromStats()                {}
-func (*ShowUsers) independentFromPipelinedPriors() {}
+func (*ShowUsers) hiddenFromStats()                   {}
+func (*ShowUsers) independentFromParallelizedPriors() {}
 
 // StatementType implements the Statement interface.
 func (*ShowRanges) StatementType() StatementType { return Rows }
@@ -466,8 +466,8 @@ func (*Help) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*Help) StatementTag() string { return "HELP" }
 
-func (*Help) hiddenFromStats()                {}
-func (*Help) independentFromPipelinedPriors() {}
+func (*Help) hiddenFromStats()                   {}
+func (*Help) independentFromParallelizedPriors() {}
 
 // StatementType implements the Statement interface.
 func (*ShowConstraints) StatementType() StatementType { return Rows }
@@ -475,8 +475,8 @@ func (*ShowConstraints) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowConstraints) StatementTag() string { return "SHOW CONSTRAINTS" }
 
-func (*ShowConstraints) hiddenFromStats()                {}
-func (*ShowConstraints) independentFromPipelinedPriors() {}
+func (*ShowConstraints) hiddenFromStats()                   {}
+func (*ShowConstraints) independentFromParallelizedPriors() {}
 
 // StatementType implements the Statement interface.
 func (*ShowTables) StatementType() StatementType { return Rows }
@@ -484,8 +484,8 @@ func (*ShowTables) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowTables) StatementTag() string { return "SHOW TABLES" }
 
-func (*ShowTables) hiddenFromStats()                {}
-func (*ShowTables) independentFromPipelinedPriors() {}
+func (*ShowTables) hiddenFromStats()                   {}
+func (*ShowTables) independentFromParallelizedPriors() {}
 
 // StatementType implements the Statement interface.
 func (*Split) StatementType() StatementType { return Rows }

--- a/pkg/sql/testdata/logic_test/parallel_stmts
+++ b/pkg/sql/testdata/logic_test/parallel_stmts
@@ -12,7 +12,7 @@ CREATE TABLE fk (
 )
 
 
-# Pipelining can be used outside of a transaction, but synchronizes immediately
+# Parallel statements can be run outside of a transaction, but they synchronize immediately
 
 statement ok
 INSERT INTO kv VALUES (1, 2) RETURNING NOTHING
@@ -48,7 +48,7 @@ statement ok
 DELETE FROM kv
 
 
-# Successfully perform pipelined inserts
+# Successfully perform parallelized inserts
 
 statement ok
 BEGIN
@@ -72,7 +72,7 @@ SELECT k, v FROM kv ORDER BY k
 2  3
 3  4
 
-# Unsuccessfully perform pipelined inserts
+# Unsuccessfully perform parallelized inserts
 
 statement ok
 BEGIN
@@ -100,7 +100,7 @@ SELECT k, v FROM kv ORDER BY k
 3  4
 
 
-# Successfully perform pipelined upserts
+# Successfully perform parallelized upserts
 
 statement ok
 BEGIN
@@ -125,7 +125,7 @@ SELECT k, v FROM kv ORDER BY k
 3  9
 4  8
 
-# Unsuccessfully perform pipelined upserts
+# Unsuccessfully perform parallelized upserts
 
 statement ok
 BEGIN
@@ -154,7 +154,7 @@ SELECT k, v FROM kv ORDER BY k
 4  8
 
 
-# Successfully perform pipelined updates
+# Successfully perform parallelized updates
 
 statement ok
 BEGIN
@@ -179,7 +179,7 @@ SELECT k, v FROM kv ORDER BY k
 3  3
 4  8
 
-# Unsuccessfully perform pipelined updates
+# Unsuccessfully perform parallelized updates
 
 statement ok
 BEGIN
@@ -210,7 +210,7 @@ SELECT k, v FROM kv ORDER BY k
 
 
 
-# Successfully perform pipelined deletes
+# Successfully perform parallelized deletes
 
 statement ok
 BEGIN
@@ -231,7 +231,7 @@ SELECT k, v FROM kv ORDER BY k
 3  3
 4  8
 
-# Unsuccessfully perform pipelined deletes
+# Unsuccessfully perform parallelized deletes
 
 statement ok
 INSERT INTO fk VALUES (2)
@@ -352,8 +352,8 @@ statement ok
 ROLLBACK
 
 
-# Statements that are IndependentFromPipelinedPriors should not force a
-# pipeline synchronization.
+# Statements that are IndependentFromParallelizedPriors should not force a
+# parallel execution synchronization.
 
 statement ok
 BEGIN


### PR DESCRIPTION
Fixes #14413.

This change fixes the terminology used for the `RETURNING NOTHING` functionality
from "statement pipelining" to "parallel statement execution". To understand the
motivation for this, see the referenced issue.

It begins by changing the terminology in the `Parallel SQL Statement Execution` RFC and
renaming the file. It then performs the following three global renames:
```
gorename -from '"github.com/cockroachdb/cockroach/pkg/sql".PipelineQueue' -to ParallelizeQueue
gorename -from '"github.com/cockroachdb/cockroach/pkg/sql".IsStmtPipelined' -to IsStmtParallelized
gorename -from '"github.com/cockroachdb/cockroach/pkg/sql/parser".IndependentFromPipelinedPriors' -to IndependentFromParallelizedPriors
```

It follows these changes with corresponding changes to comments and
filenames. There are no longer any references to "pipelining" in our
code related to the `RETURNING NOTHING` syntax.

This new terminology will be used in the associated documentation and blog post.