### PR TITLE
sql: reject mismatched types in CHECKs

### DIFF
--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -72,9 +72,9 @@ func (c *checkHelper) init(
 // Set values in the IndexedVars used by the CHECK exprs.
 // Any value not passed is set to NULL, unless `merge` is true, in which
 // case it is left unchanged (allowing updating a subset of a row's values).
-func (c *checkHelper) loadRow(colIdx map[sqlbase.ColumnID]int, row parser.Datums, merge bool) {
+func (c *checkHelper) loadRow(colIdx map[sqlbase.ColumnID]int, row parser.Datums, merge bool) error {
 	if len(c.exprs) == 0 {
-		return
+		return nil
 	}
 	// Populate IndexedVars.
 	for _, ivar := range c.ivars {
@@ -83,11 +83,18 @@ func (c *checkHelper) loadRow(colIdx map[sqlbase.ColumnID]int, row parser.Datums
 		}
 		ri, has := colIdx[c.cols[ivar.Idx].ID]
 		if has {
+			if row[ri] != parser.DNull {
+				expected, provided := ivar.ResolvedType(), row[ri].ResolvedType()
+				if !expected.Equivalent(provided) {
+					return errors.Errorf("%s value does not match CHECK expr type %s", provided, expected)
+				}
+			}
 			c.curSourceRow[ivar.Idx] = row[ri]
 		} else if !merge {
 			c.curSourceRow[ivar.Idx] = parser.DNull
 		}
 	}
+	return nil
 }
 
 // IndexedVarEval implements the parser.IndexedVarContainer interface.

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -318,7 +318,9 @@ func (n *insertNode) Next(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
-	n.checkHelper.loadRow(n.insertColIDtoRowIndex, rowVals, false)
+	if err := n.checkHelper.loadRow(n.insertColIDtoRowIndex, rowVals, false); err != nil {
+		return false, err
+	}
 	if err := n.checkHelper.check(&n.p.evalCtx); err != nil {
 		return false, err
 	}

--- a/pkg/sql/testdata/logic_test/check_constraints
+++ b/pkg/sql/testdata/logic_test/check_constraints
@@ -5,6 +5,9 @@
 statement ok
 CREATE TABLE t1 (a INT CHECK (a > 0), to_delete INT, b INT CHECK (b < 0) CHECK (b > -100))
 
+statement error string value does not match CHECK expr type int
+INSERT INTO t1 VALUES ('3', 0, -1)
+
 statement ok
 INSERT INTO t1 VALUES (3, 0, -1)
 

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -437,8 +437,12 @@ func (u *updateNode) Next(ctx context.Context) (bool, error) {
 		}
 	}
 
-	u.checkHelper.loadRow(u.tw.ru.FetchColIDtoRowIndex, oldValues, false)
-	u.checkHelper.loadRow(u.updateColsIdx, updateValues, true)
+	if err := u.checkHelper.loadRow(u.tw.ru.FetchColIDtoRowIndex, oldValues, false); err != nil {
+		return false, err
+	}
+	if err := u.checkHelper.loadRow(u.updateColsIdx, updateValues, true); err != nil {
+		return false, err
+	}
 	if err := u.checkHelper.check(&u.p.evalCtx); err != nil {
 		return false, err
 	}


### PR DESCRIPTION
MarshalColumnValue would likely reject these values later, but we cannot evaluate the CHECK expr if the values do not match its resolved types.

Fixes #14970.