### PR TITLE
sql: pg_catalog fixes for int2vector type

### DIFF
--- a/pkg/sql/parser/pg_builtins.go
+++ b/pkg/sql/parser/pg_builtins.go
@@ -66,7 +66,7 @@ func initPGBuiltins() {
 	// Make non-array type i/o builtins.
 	for _, typ := range OidToType {
 		// Skip array types. We're doing them separately below.
-		if typ != TypeAny && typ.Equivalent(TypeAnyArray) {
+		if typ != TypeAny && typ != TypeIntVector && typ.Equivalent(TypeAnyArray) {
 			continue
 		}
 		builtinPrefix := PGIOBuiltinPrefix(typ)

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1467,7 +1467,7 @@ CREATE TABLE pg_catalog.pg_type (
 				// regproc references
 				h.RegProc(builtinPrefix+"in"),   // typinput
 				h.RegProc(builtinPrefix+"out"),  // typoutput
-				h.RegProc(builtinPrefix+"recv"), // typrecv
+				h.RegProc(builtinPrefix+"recv"), // typreceive
 				h.RegProc(builtinPrefix+"send"), // typsend
 				oidZero, // typmodin
 				oidZero, // typmodout

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1428,27 +1428,35 @@ CREATE TABLE pg_catalog.pg_type (
 `,
 	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
-		for oid, typ := range parser.OidToType {
+		for o, typ := range parser.OidToType {
 			cat := typCategory(typ)
 			typElem := oidZero
 			builtinPrefix := parser.PGIOBuiltinPrefix(typ)
 			if cat == typCategoryArray {
-				typElem = parser.NewDOid(parser.DInt(parser.UnwrapType(typ).(parser.TArray).Typ.Oid()))
-				if typ != parser.TypeIntVector {
+				if typ == parser.TypeIntVector {
+					// IntVector needs a special case because its a special snowflake
+					// type. It's just like an Int2Array, but it has its own OID. We
+					// can't just wrap our Int2Array type in an OID wrapper, though,
+					// because Int2Array is not an exported, first-class type - it's an
+					// input-only type that translates immediately to int8array. This
+					// would go away if we decided to export Int2Array as a real type.
+					typElem = parser.NewDOid(parser.DInt(oid.T_int2))
+				} else {
 					builtinPrefix = "array_"
+					typElem = parser.NewDOid(parser.DInt(parser.UnwrapType(typ).(parser.TArray).Typ.Oid()))
 				}
 			}
 			typname := parser.PGDisplayName(typ)
 
 			if err := addRow(
-				parser.NewDOid(parser.DInt(oid)), // oid
-				parser.NewDName(typname),         // typname
-				pgNamespacePGCatalog.Oid,         // typnamespace
-				parser.DNull,                     // typowner
-				typLen(typ),                      // typlen
-				typByVal(typ),                    // typbyval
-				typTypeBase,                      // typtype
-				cat,                              // typcategory
+				parser.NewDOid(parser.DInt(o)), // oid
+				parser.NewDName(typname),       // typname
+				pgNamespacePGCatalog.Oid,       // typnamespace
+				parser.DNull,                   // typowner
+				typLen(typ),                    // typlen
+				typByVal(typ),                  // typbyval
+				typTypeBase,                    // typtype
+				cat,                            // typcategory
 				parser.MakeDBool(false), // typispreferred
 				parser.MakeDBool(true),  // typisdefined
 				typDelim,                // typdelim

--- a/pkg/sql/testdata/logic_test/pg_catalog
+++ b/pkg/sql/testdata/logic_test/pg_catalog
@@ -725,7 +725,7 @@ oid   typname       typinput        typoutput        typreceive        typsend  
 19    name          namein          nameout          namerecv          namesend          0         0          0
 20    int8          int8in          int8out          int8recv          int8send          0         0          0
 21    int2          int2in          int2out          int2recv          int2send          0         0          0
-22    int2vector    NULL            NULL             NULL              NULL              0         0          0
+22    int2vector    int2vectorin    int2vectorout    int2vectorrecv    int2vectorsend    0         0          0
 23    int4          int4in          int4out          int4recv          int4send          0         0          0
 24    regproc       regprocin       regprocout       regprocrecv       regprocsend       0         0          0
 25    text          textin          textout          textrecv          textsend          0         0          0

--- a/pkg/sql/testdata/logic_test/pg_catalog
+++ b/pkg/sql/testdata/logic_test/pg_catalog
@@ -690,7 +690,7 @@ oid   typname       typcategory  typispreferred  typisdefined  typdelim  typreli
 19    name          S            false           true          ,         0         0        0
 20    int8          N            false           true          ,         0         0        0
 21    int2          N            false           true          ,         0         0        0
-22    int2vector    A            false           true          ,         0         20       0
+22    int2vector    A            false           true          ,         0         21       0
 23    int4          N            false           true          ,         0         0        0
 24    regproc       N            false           true          ,         0         0        0
 25    text          S            false           true          ,         0         0        0


### PR DESCRIPTION
- give `int2vector` its correct `typelem` - `int2`, not `int8`.
- give `int2vector` its type IO (typrecv, typsend, etc) functions in `pg_type`

Fixes #14929.
Fixes #14930.