### PR TITLE
kv: fix overlapping descriptors in range_cache_test

### DIFF
--- a/pkg/kv/range_cache_test.go
+++ b/pkg/kv/range_cache_test.go
@@ -171,7 +171,7 @@ func newTestDescriptorDB() *testDescriptorDB {
 	})
 	db.data.Insert(testDescriptorNode{
 		&roachpb.RangeDescriptor{
-			StartKey: roachpb.RKeyMin,
+			StartKey: testutils.MakeKey(keys.Meta2Prefix, roachpb.RKeyMax),
 			EndKey:   roachpb.RKeyMax,
 		},
 	})


### PR DESCRIPTION
The descriptor I changed was overlapping the previous one. This was
making tests flaky in face of a different innocuous change I'm making to
the RangeDescriptorCache.

The code used to be OK before #1464; not sure why it was changed.