### PR TITLE
build: use the default toolchain in teamcity-check

### DIFF
--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -5,9 +5,9 @@ export BUILDER_HIDE_GOPATH_SRC=1
 
 mkdir -p artifacts
 
-build/builder.sh make TYPE=release check 2>&1 | tee artifacts/check.log | go-test-teamcity
+build/builder.sh make check 2>&1 | tee artifacts/check.log | go-test-teamcity
 
-build/builder.sh make TYPE=release generate
+build/builder.sh make generate
 build/builder.sh /bin/bash -c '! git status --porcelain | read || (git status; git diff -a 1>&2; exit 1)'
 
 # Run the UI tests. This logically belongs in teamcity-test.sh, but we do it


### PR DESCRIPTION
golang.org/x/tools/cmd/stringer insists on loading packages from the
default GOOS_GOARCH location in $GOPATH/pkg, and can't be disuaded of
that notion. Succumb to its wishes.

`go vet` is exhibiting a similar problem. It is probably possible to
plumb the necessary flags to `go vet` from `make check`, but it's not
trivial, and using the default toolchain for this seems fine.

Closes #14993.
Closes #14997.