### PR TITLE
server: switch reporting store diagnostics by default

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -56,10 +56,6 @@ const (
 	// eventLimit is the maximum number of events returned by any endpoints
 	// returning events.
 	apiEventLimit = 1000
-
-	// serverUIDataKeyPrefix must precede all UIData keys that are read from the
-	// server.
-	serverUIDataKeyPrefix = "server."
 )
 
 // apiServerMessage is the standard body for all HTTP 500 responses.


### PR DESCRIPTION
Simpler env var opt-out for now, might switch to settings later similar to #14901.

Closes #14901.