### PR TITLE
utilccl: rename `GetEnterpriseEnabled` to `EnterpriseEnabled`

### DIFF
--- a/pkg/ccl/utilccl/license_check.go
+++ b/pkg/ccl/utilccl/license_check.go
@@ -17,7 +17,7 @@ import (
 // feature is not enabled, including information or a link explaining how to
 // enable it.
 func CheckEnterpriseEnabled(feature string) error {
-	if settings.GetEnterpriseEnabled() {
+	if settings.EnterpriseEnabled() {
 		return nil
 	}
 	// TODO(dt): link to some stable URL that then redirects to a helpful page

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -44,11 +44,11 @@ func TypeOf(key string) (ValueType, bool) {
 	return d.typ, ok
 }
 
-// GetEnterpriseEnabled returns the "enterprise.enabled" setting.
+// EnterpriseEnabled returns the "enterprise.enabled" setting.
 // "enterprise.enabled" allows the use of the enterprise functionality (which
 // requires an enterprise license).
 // This is a temporary setting and will be replaced in the future.
-func GetEnterpriseEnabled() bool {
+func EnterpriseEnabled() bool {
 	return getBool("enterprise.enabled")
 }
 


### PR DESCRIPTION
As the first setting, we're setting precedent here, and prefixing every method in the package with `Get` seems silly.