### PR TITLE
sql: rip out the SQL event log from the session context

### DIFF
--- a/pkg/util/log/trace.go
+++ b/pkg/util/log/trace.go
@@ -66,6 +66,8 @@ func WithEventLog(ctx context.Context, family, title string) context.Context {
 	return withEventLogInternal(ctx, trace.NewEventLog(family, title))
 }
 
+var _ = WithEventLog
+
 // WithNoEventLog creates a context which no longer has an embedded event log.
 func WithNoEventLog(ctx context.Context) context.Context {
 	return withEventLogInternal(ctx, nil)


### PR DESCRIPTION
Embedding the event log in the session context doesn't do what we want anymore;
we want to log the SQL statements to the event log even when they go to a
trace. Create the event log separately and write to it the executed statements
and results.

Fixes #15007.