### PR TITLE
client: move Transaction initialization into constructor

### DIFF
--- a/pkg/internal/client/db.go
+++ b/pkg/internal/client/db.go
@@ -482,9 +482,8 @@ func (db *DB) Txn(ctx context.Context, retryable func(context.Context, *Txn) err
 	txn := NewTxn(db)
 	txn.SetDebugName("unnamed")
 	opts := TxnExecOptions{
-		AutoCommit:                 true,
-		AutoRetry:                  true,
-		AssignTimestampImmediately: true,
+		AutoCommit: true,
+		AutoRetry:  true,
 	}
 	err := txn.Exec(ctx, opts, func(ctx context.Context, txn *Txn, _ *TxnExecOptions) error {
 		return retryable(ctx, txn)

--- a/pkg/internal/client/db_test.go
+++ b/pkg/internal/client/db_test.go
@@ -332,6 +332,9 @@ func TestDebugName(t *testing.T) {
 	defer s.Stopper().Stop()
 
 	if err := db.Txn(context.TODO(), func(ctx context.Context, txn *client.Txn) error {
+		// Remove the txn ID, which will be added to the name if non-nil.
+		txn.Proto().ID = nil
+
 		const expected = "unnamed"
 		if txn.DebugName() != expected {
 			t.Fatalf("expected \"%s\", but found \"%s\"", expected, txn.DebugName())
@@ -382,6 +385,7 @@ func TestCommonMethods(t *testing.T) {
 		{txnType, "Rollback"}:                  {},
 		{txnType, "CleanupOnError"}:            {},
 		{txnType, "DebugName"}:                 {},
+		{txnType, "ID"}:                        {},
 		{txnType, "InternalSetPriority"}:       {},
 		{txnType, "IsFinalized"}:               {},
 		{txnType, "NewBatch"}:                  {},

--- a/pkg/internal/client/txn_test.go
+++ b/pkg/internal/client/txn_test.go
@@ -217,10 +217,6 @@ func TestTxnResetTxnOnAbort(t *testing.T) {
 	if _, ok := pErr.GetDetail().(*roachpb.TransactionAbortedError); !ok {
 		t.Fatalf("expected TransactionAbortedError, got %v", pErr)
 	}
-
-	if txn.Proto().ID != nil {
-		t.Error("expected txn to be cleared")
-	}
 }
 
 // TestTransactionConfig verifies the proper unwrapping and
@@ -637,9 +633,8 @@ func TestAbortedRetryRenewsTimestamp(t *testing.T) {
 	// Request a client-defined timestamp.
 	refTimestamp := clock.Now()
 	execOpt := TxnExecOptions{
-		AutoRetry:                  true,
-		AutoCommit:                 true,
-		AssignTimestampImmediately: true,
+		AutoRetry:  true,
+		AutoCommit: true,
 	}
 
 	// Perform the transaction.
@@ -770,9 +765,6 @@ func TestTimestampSelectionInOptions(t *testing.T) {
 	db := NewDB(newTestSender(nil), clock)
 	txn := NewTxn(db)
 
-	execOpt := TxnExecOptions{
-		AssignTimestampImmediately: true,
-	}
 	refTimestamp := clock.Now()
 
 	txnClosure := func(ctx context.Context, txn *Txn, opt *TxnExecOptions) error {
@@ -780,7 +772,7 @@ func TestTimestampSelectionInOptions(t *testing.T) {
 		return txn.Put(ctx, "a", "b")
 	}
 
-	if err := txn.Exec(context.Background(), execOpt, txnClosure); err != nil {
+	if err := txn.Exec(context.Background(), TxnExecOptions{}, txnClosure); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -229,38 +229,6 @@ func TestTxnCoordSenderBeginTransaction(t *testing.T) {
 	}
 }
 
-// TestTxnInitialTimestamp verifies that the timestamp requested
-// before the Txn is created is honored.
-func TestTxnInitialTimestamp(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	s, sender := createTestDB(t)
-	defer s.Stop()
-	defer teardownHeartbeats(sender)
-
-	txn := client.NewTxn(s.DB)
-
-	// Request a specific timestamp.
-	refTimestamp := s.Clock.Now().Add(42, 69)
-	txn.Proto().OrigTimestamp = refTimestamp
-
-	// Put request will create a new transaction.
-	key := roachpb.Key("key")
-	txn.InternalSetPriority(10)
-	txn.SetDebugName("test txn")
-	if err := txn.SetIsolation(enginepb.SNAPSHOT); err != nil {
-		t.Fatal(err)
-	}
-	if err := txn.Put(context.TODO(), key, []byte("value")); err != nil {
-		t.Fatal(err)
-	}
-	if txn.Proto().OrigTimestamp != refTimestamp {
-		t.Errorf("expected txn orig ts to be %s; got %s", refTimestamp, txn.Proto().OrigTimestamp)
-	}
-	if txn.Proto().Timestamp != refTimestamp {
-		t.Errorf("expected txn ts to be %s; got %s", refTimestamp, txn.Proto().Timestamp)
-	}
-}
-
 // TestTxnCoordSenderBeginTransactionMinPriority verifies that when starting
 // a new transaction, a non-zero priority is treated as a minimum value.
 func TestTxnCoordSenderBeginTransactionMinPriority(t *testing.T) {
@@ -787,6 +755,7 @@ func TestTxnCoordSenderGCWithCancel(t *testing.T) {
 func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	origTS := makeTS(123, 0)
+	plus1 := origTS.Add(0, 1)
 	plus10 := origTS.Add(10, 10)
 	plus20 := plus10.Add(10, 0)
 	testCases := []struct {
@@ -829,7 +798,9 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 				&roachpb.Transaction{
 					TxnMeta: enginepb.TxnMeta{Timestamp: plus20, Priority: 10},
 				}),
-			expPri: 10,
+			expPri:    10,
+			expTS:     plus1,
+			expOrigTS: plus1,
 		},
 		{
 			// On failed push, new epoch begins just past the pushed timestamp.

--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -53,9 +53,6 @@ var _ error = &RetryableTxnError{}
 // txnID is the id of the transaction that this error is supposed to cause a
 // retry for. Can be nil, in which case it will cause retries for transactions
 // that don't have an ID set.
-// TODO(andrei): this function should really take a transaction as an argument.
-// The caller (crdb_internal.force_retry) should be given access to the current
-// transaction through the EvalContext.
 func NewRetryableTxnError(cause string, txnID *uuid.UUID) *RetryableTxnError {
 	return &RetryableTxnError{
 		message: cause,

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -606,9 +606,7 @@ func (e *Executor) execRequest(
 		// Each iteration consumes a transaction's worth of statements.
 
 		inTxn := txnState.State != NoTxn
-		execOpt := client.TxnExecOptions{
-			AssignTimestampImmediately: true,
-		}
+		execOpt := client.TxnExecOptions{}
 		// Figure out the statements out of which we're going to try to consume
 		// this iteration. If we need to create an implicit txn, only one statement
 		// can be consumed.

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -1516,7 +1516,11 @@ var Builtins = map[string][]Builtin{
 					Nanos: int64(ctx.stmtTimestamp.Sub(ctx.txnTimestamp)),
 				}
 				if elapsed.Compare(minDuration) < 0 {
-					return nil, roachpb.NewRetryableTxnError("forced by crdb_internal.force_retry()", nil /* txnID */)
+					var txnID *uuid.UUID
+					if ctx.Txn != nil {
+						txnID = ctx.Txn.ID()
+					}
+					return nil, roachpb.NewRetryableTxnError("forced by crdb_internal.force_retry()", txnID)
 				}
 				return DZero, nil
 			},

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
@@ -1705,6 +1706,7 @@ type EvalContext struct {
 	Ctx contextHolder
 
 	Planner EvalPlanner
+	Txn     *client.Txn
 
 	ReCache *RegexpCache
 	tmpDec  apd.Decimal

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -148,6 +148,7 @@ func (p *planner) User() string {
 // the new txn object, if any.
 func (p *planner) setTxn(txn *client.Txn) {
 	p.txn = txn
+	p.evalCtx.Txn = txn
 	if txn != nil {
 		p.evalCtx.SetClusterTimestamp(txn.OrigTimestamp())
 	} else {


### PR DESCRIPTION
Fixes #13894.
Related to #14119.

Instead of initializing `Transaction` protos in the first call to
`TxnCoordSender.Send`, we initialize them in the first operation on
`client.Txn`. This initialization includes creating a unique ID for
the transaction and assigning its timestamps. To permit for this change,
we needed to fix a number of places where we assumed that a transaction's
timestamp was set only on the first KV operation.

In doing so, we were able to remove the `AssignOrigTimestamp` option
from `TxnExecOptions`. It is now safe to assume that transactions always
have IDs and timestamps assigned to them.