### PR TITLE
cli: Shout all errors on start command.

### DIFF
--- a/pkg/cli/error.go
+++ b/pkg/cli/error.go
@@ -17,8 +17,11 @@ package cli
 import (
 	"net"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -52,6 +55,19 @@ communicate with a secure cluster).
 %s`
 
 		return errors.Errorf(format, err)
+	}
+}
+
+// MaybeShoutError calls log.Shout on errors, better surfacing problems to the user.
+func MaybeShoutError(
+	wrapped func(*cobra.Command, []string) error,
+) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		err := wrapped(cmd, args)
+		if err != nil {
+			log.Shout(context.Background(), log.Severity_ERROR, err)
+		}
+		return err
 	}
 }
 

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -77,7 +77,7 @@ uninitialized, specify the --join flag to point to any healthy node
 (or list of nodes) already part of the cluster.
 `,
 	Example: `  cockroach start --insecure --store=attrs=ssd,path=/mnt/ssd1 [--join=host:port,[host:port]]`,
-	RunE:    MaybeDecorateGRPCError(runStart),
+	RunE:    MaybeShoutError(MaybeDecorateGRPCError(runStart)),
 }
 
 func setDefaultSizeParameters(ctx *server.Config) {
@@ -479,7 +479,6 @@ func runStart(cmd *cobra.Command, args []string) error {
 	select {
 	case sig := <-signalCh:
 		returnErr = fmt.Errorf("received signal '%s' during shutdown, initiating hard shutdown", sig)
-		log.Shoutf(shutdownCtx, log.Severity_ERROR, "%v", returnErr)
 		// This new signal is not welcome, as it interferes with the graceful
 		// shutdown process. On Unix, a signal that was not handled gracefully by
 		// the application should be visible to other processes as an exit code
@@ -490,7 +489,6 @@ func runStart(cmd *cobra.Command, args []string) error {
 		// NB: we do not return here to go through log.Flush below.
 	case <-time.After(time.Minute):
 		returnErr = errors.New("time limit reached, initiating hard shutdown")
-		log.Shoutf(shutdownCtx, log.Severity_ERROR, "%v", returnErr)
 		// NB: we do not return here to go through log.Flush below.
 	case <-stopper.IsStopped():
 		const msgDone = "server drained and shutdown completed"

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -67,15 +67,6 @@ func logDepth(ctx context.Context, depth int, sev Severity, format string, args 
 	addStructured(ctx, sev, depth+1, format, args)
 }
 
-// Shoutf logs to the specified severity's log, and also to the real
-// stderr if logging is currently redirected to a file.
-func Shoutf(ctx context.Context, sev Severity, format string, args ...interface{}) {
-	logDepth(ctx, 1, sev, format, args)
-	if stderrRedirected {
-		fmt.Fprintf(OrigStderr, "*\n* %s: %s\n*\n", sev.String(), MakeMessage(ctx, format, args))
-	}
-}
-
 // Shout logs to the specified severity's log, and also to the real
 // stderr if logging is currently redirected to a file.
 func Shout(ctx context.Context, sev Severity, args ...interface{}) {


### PR DESCRIPTION
We've had quite a few instances of people being confused by "Failed
running start" being the only thing displayed by default.

This has gotten worse with the `--insecure` flags always false by
default.

Let's surface all errors from the start command, it should make things a
bit clearer. We can consider expanding that to other CLI commands later.