### PR TITLE
RFC: mark online cert rotation rfc as completed

### DIFF
--- a/docs/RFCS/certificate_rotation.md
+++ b/docs/RFCS/certificate_rotation.md
@@ -1,5 +1,5 @@
 - Feature Name: certificate rotation
-- Status: in-progress
+- Status: completed
 - Start Date: 2017-03-18
 - Authors: @mberhault
 - RFC PR: [14254](https://github.com/cockroachdb/cockroach/pull/14254)


### PR DESCRIPTION
This is done in #14703 and #14925.
Issues opened for some "future work" described in this RFC. Monitoring of certificate lifetime did not make the 1.0 feature freeze, but is targeted for 1.1.