### PR TITLE
build: separate XGOFLAGS from GOFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ BENCHTIMEOUT := 5m
 TESTFLAGS    :=
 STRESSFLAGS  :=
 DUPLFLAGS    := -t 100
+XGOFLAGS     :=
 COCKROACH    := ./cockroach
 ARCHIVE      := cockroach.src.tgz
 STARTFLAGS   := -s type=mem,size=1GiB --logtostderr
@@ -108,7 +109,7 @@ build buildoss install: $(BOOTSTRAP_TARGET) .buildinfo/tag .buildinfo/rev
 
 .PHONY: xgo-build
 xgo-build:
-	$(XGO) -v $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' $(BUILDTARGET)
+	$(XGO) -v $(XGOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' $(BUILDTARGET)
 
 .PHONY: start
 start: build

--- a/build/build-osx.sh
+++ b/build/build-osx.sh
@@ -11,4 +11,4 @@ go get -u github.com/karalabe/xgo
 # We additionally set GOVERS= to disable the Go version check. This allows
 # building in environments without a Go toolchain, like TeamCity build agents.
 # xgo will use the Go toolchain in its Docker image regardless.
-make xgo-build GOVERS= GOFLAGS='--image cockroachdb/xgo:20170218 --targets=darwin-10.9/amd64' TYPE=release
+make xgo-build GOVERS= XGOFLAGS='--image cockroachdb/xgo:20170218 --targets=darwin-10.9/amd64' TYPE=release

--- a/build/variables.mk
+++ b/build/variables.mk
@@ -47,6 +47,7 @@ define VALID_VARS
   TYPE
   UI_ROOT
   XGO
+  XGOFLAGS
   YARN_INSTALLED_TARGET
   space
 endef


### PR DESCRIPTION
xgo does not accept `-installsuffix`, so we need a separate variable for
its flags now that `-installsuffix` is added to GOFLAGS when TYPE is
set.

This should fix the release build.