### PR TITLE
sql+pgwire: report recoverable panics as errors to clients.

### DIFF
--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -237,7 +237,10 @@ func TestAdminAPIDatabases(t *testing.T) {
 	session.StartUnlimitedMonitor()
 	defer session.Finish(ts.sqlExecutor)
 	query := "CREATE DATABASE " + testdb
-	createRes := ts.sqlExecutor.ExecuteStatements(session, query, nil)
+	createRes, panicErr := ts.sqlExecutor.ExecuteStatements(session, query, nil)
+	if panicErr != nil {
+		t.Fatal(panicErr)
+	}
 	defer createRes.Close(ctx)
 
 	if createRes.ResultList[0].Err != nil {
@@ -265,7 +268,10 @@ func TestAdminAPIDatabases(t *testing.T) {
 	privileges := []string{"SELECT", "UPDATE"}
 	testuser := "testuser"
 	grantQuery := "GRANT " + strings.Join(privileges, ", ") + " ON DATABASE " + testdb + " TO " + testuser
-	grantRes := s.(*TestServer).sqlExecutor.ExecuteStatements(session, grantQuery, nil)
+	grantRes, panicErr := s.(*TestServer).sqlExecutor.ExecuteStatements(session, grantQuery, nil)
+	if panicErr != nil {
+		t.Fatal(panicErr)
+	}
 	defer grantRes.Close(ctx)
 	if grantRes.ResultList[0].Err != nil {
 		t.Fatal(grantRes.ResultList[0].Err)
@@ -435,7 +441,10 @@ func TestAdminAPITableDetails(t *testing.T) {
 			}
 
 			for _, q := range setupQueries {
-				res := ts.sqlExecutor.ExecuteStatements(session, q, nil)
+				res, panicErr := ts.sqlExecutor.ExecuteStatements(session, q, nil)
+				if panicErr != nil {
+					t.Fatal(panicErr)
+				}
 				defer res.Close(ctx)
 				if res.ResultList[0].Err != nil {
 					t.Fatalf("error executing '%s': %s", q, res.ResultList[0].Err)
@@ -516,7 +525,10 @@ func TestAdminAPITableDetails(t *testing.T) {
 				const createTableCol = "CreateTable"
 				showCreateTableQuery := fmt.Sprintf("SHOW CREATE TABLE %s.%s", escDBName, escTblName)
 
-				resSet := ts.sqlExecutor.ExecuteStatements(session, showCreateTableQuery, nil)
+				resSet, panicErr := ts.sqlExecutor.ExecuteStatements(session, showCreateTableQuery, nil)
+				if panicErr != nil {
+					t.Fatal(panicErr)
+				}
 				defer resSet.Close(ctx)
 				res := resSet.ResultList[0]
 				if res.Err != nil {
@@ -566,7 +578,10 @@ func TestAdminAPIZoneDetails(t *testing.T) {
 		"CREATE TABLE test.tbl (val STRING)",
 	}
 	for _, q := range setupQueries {
-		res := ts.sqlExecutor.ExecuteStatements(session, q, nil)
+		res, panicErr := ts.sqlExecutor.ExecuteStatements(session, q, nil)
+		if panicErr != nil {
+			t.Fatal(panicErr)
+		}
 		defer res.Close(ctx)
 		if res.ResultList[0].Err != nil {
 			t.Fatalf("error executing '%s': %s", q, res.ResultList[0].Err)
@@ -623,7 +638,10 @@ func TestAdminAPIZoneDetails(t *testing.T) {
 		params := parser.MakePlaceholderInfo()
 		params.SetValue(`1`, parser.NewDInt(parser.DInt(id)))
 		params.SetValue(`2`, parser.NewDBytes(parser.DBytes(zoneBytes)))
-		res := ts.sqlExecutor.ExecuteStatements(session, query, &params)
+		res, panicErr := ts.sqlExecutor.ExecuteStatements(session, query, &params)
+		if panicErr != nil {
+			t.Fatal(panicErr)
+		}
 		defer res.Close(ctx)
 		if res.ResultList[0].Err != nil {
 			t.Fatalf("error executing '%s': %s", query, res.ResultList[0].Err)
@@ -675,7 +693,10 @@ func TestAdminAPIUsers(t *testing.T) {
 	query := `
 INSERT INTO system.users (username, hashedPassword)
 VALUES ('admin', 'abc'), ('bob', 'xyz')`
-	res := ts.sqlExecutor.ExecuteStatements(session, query, nil)
+	res, panicErr := ts.sqlExecutor.ExecuteStatements(session, query, nil)
+	if panicErr != nil {
+		t.Fatal(panicErr)
+	}
 	defer res.Close(ctx)
 	if a, e := len(res.ResultList), 1; a != e {
 		t.Fatalf("len(results) %d != %d", a, e)
@@ -726,7 +747,10 @@ func TestAdminAPIEvents(t *testing.T) {
 		"DROP TABLE api_test.tbl2",
 	}
 	for _, q := range setupQueries {
-		res := ts.sqlExecutor.ExecuteStatements(session, q, nil)
+		res, panicErr := ts.sqlExecutor.ExecuteStatements(session, q, nil)
+		if panicErr != nil {
+			t.Fatal(panicErr)
+		}
 		defer res.Close(ctx)
 		if res.ResultList[0].Err != nil {
 			t.Fatalf("error executing '%s': %s", q, res.ResultList[0].Err)

--- a/pkg/sql/mon/mem_usage.go
+++ b/pkg/sql/mon/mem_usage.go
@@ -323,8 +323,18 @@ func MakeUnlimitedMonitor(
 	}
 }
 
+// EmergencyStop completes a monitoring region, and disables checking
+// that all accounts have been closed.
+func (mm *MemoryMonitor) EmergencyStop(ctx context.Context) {
+	mm.doStop(ctx, false)
+}
+
 // Stop completes a monitoring region.
 func (mm *MemoryMonitor) Stop(ctx context.Context) {
+	mm.doStop(ctx, true)
+}
+
+func (mm *MemoryMonitor) doStop(ctx context.Context, check bool) {
 	// NB: No need to lock mm.mu here, when StopMonitor() is called the
 	// monitor is not shared any more.
 	if log.V(1) {
@@ -333,7 +343,7 @@ func (mm *MemoryMonitor) Stop(ctx context.Context) {
 			humanizeutil.IBytes(mm.mu.maxAllocated))
 	}
 
-	if mm.mu.curAllocated != 0 {
+	if check && mm.mu.curAllocated != 0 {
 		panic(fmt.Sprintf("%s: unexpected leftover memory: %d bytes",
 			mm.name,
 			mm.mu.curAllocated))

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -1490,6 +1490,20 @@ var Builtins = map[string][]Builtin{
 		},
 	},
 
+	"crdb_internal.internal_error": {
+		Builtin{
+			Types:      ArgTypes{{"msg", TypeString}},
+			ReturnType: fixedReturnType(TypeInt),
+			impure:     true,
+			fn: func(_ *EvalContext, args Datums) (Datum, error) {
+				msg := string(*args[0].(*DString))
+				panic(msg)
+			},
+			category: categorySystemInfo,
+			Info:     "This function is used only by CockroachDB's developers for testing purposes.",
+		},
+	},
+
 	"crdb_internal.force_retry": {
 		Builtin{
 			Types:      ArgTypes{{"val", TypeInterval}},

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -182,6 +182,11 @@ type v3Conn struct {
 	metrics *ServerMetrics
 
 	sqlMemoryPool *mon.MemoryMonitor
+
+	// abortErr, if non-nil at the start of an iteration of the
+	// read-execute-response loop, indicates the connection is dead and
+	// should be closed ASAP.
+	abortErr error
 }
 
 func makeV3Conn(
@@ -346,9 +351,10 @@ func (c *v3Conn) serve(ctx context.Context, draining func() bool, reserved mon.B
 	// this session use Session.Ctx() (which may diverge from this method's ctx).
 
 	defer func() {
-		// If we're panicking, don't bother trying to close the session; it would
-		// pollute the logs.
 		if r := recover(); r != nil {
+			// If we're panicking, use an emergency session shutdown so that
+			// the monitors don't shout that they are unhappy.
+			c.session.EmergencyClose()
 			panic(r)
 		}
 		c.closeSession(ctx)
@@ -406,6 +412,16 @@ func (c *v3Conn) serve(ctx context.Context, draining func() bool, reserved mon.B
 			}
 		}
 		typ, n, err := c.readBuf.readTypedMsg(c.rd)
+
+		// Is there a fatal error pending on this connection? If so, stop
+		// the connection here. We cannot do this as early as the point
+		// where the error occurs, because clients get confused if the TCP
+		// connection is closed before the first ready message after the
+		// error has occurred.
+		if c.abortErr != nil {
+			return c.abortErr
+		}
+
 		c.metrics.BytesInCount.Inc(int64(n))
 		if err != nil {
 			return err
@@ -547,8 +563,13 @@ func (c *v3Conn) handleParse(buf *readBuffer) error {
 		sqlTypeHints[strconv.Itoa(i+1)] = v
 	}
 	// Create the new PreparedStatement in the connection's Session.
-	stmt, err := c.session.PreparedStatements.New(c.executor, name, query, sqlTypeHints)
+	stmt, fatalErr, err := c.session.PreparedStatements.New(c.executor, name, query, sqlTypeHints)
 	if err != nil {
+		if fatalErr {
+			// handleRecoveredPanic marks the connection as unusable. It will
+			// fail upon the next message.
+			return c.handleRecoveredPanic(err)
+		}
 		return c.sendError(err)
 	}
 	// Convert the inferred SQL types back to an array of pgwire Oids.
@@ -830,10 +851,19 @@ func (c *v3Conn) executeStatements(
 	limit int,
 ) error {
 	tracing.AnnotateTrace()
+
 	// Note: sql.Executor gets its Context from c.session.context, which
 	// has been bound by v3Conn.setupSession().
-	results := c.executor.ExecuteStatements(c.session, stmts, pinfo)
-	// Delay evaluation of c.session.Ctx().
+	results, err := c.executor.ExecuteStatements(c.session, stmts, pinfo)
+	if err != nil {
+		// handleRecoveredPanic marks the connection as unusable. It will
+		// fail upon the next message.
+		return c.handleRecoveredPanic(err)
+	}
+
+	// We can't do `defer results.Close(c.session.Ctx())` here because
+	// we want the results to be closed using the context at the point
+	// of Close, not at the point of defer.
 	defer func() { results.Close(c.session.Ctx()) }()
 
 	tracing.AnnotateTrace()
@@ -1136,4 +1166,16 @@ func newUnrecognizedMsgTypeErr(typ clientMessageType) error {
 
 func newAdminShutdownErr(err error) error {
 	return pgerror.NewErrorf(pgerror.CodeAdminShutdownError, err.Error())
+}
+
+func (c *v3Conn) handleRecoveredPanic(panicErr error) error {
+	// Save the error in the connection, so that the connection gets
+	// closed at the first next client request. We can't close the
+	// connection right away, because otherwise the client may get
+	// confused and re-open a new connection retry the query blindly
+	// multiple times before giving up.
+	c.abortErr = errors.Errorf("emergency client shutdown: %v", panicErr)
+	return c.sendInternalError(
+		"internal server error during SQL execution; check the server logs for details",
+	)
 }

--- a/pkg/sql/prepare.go
+++ b/pkg/sql/prepare.go
@@ -71,11 +71,11 @@ func (ps PreparedStatements) Exists(name string) bool {
 // ps.session.Ctx() is used as the logging context for the prepare operation.
 func (ps PreparedStatements) New(
 	e *Executor, name, query string, placeholderHints parser.PlaceholderTypes,
-) (*PreparedStatement, error) {
+) (*PreparedStatement, bool, error) {
 	// Prepare the query. This completes the typing of placeholders.
-	stmt, err := e.Prepare(query, ps.session, placeholderHints)
+	stmt, fatalErr, err := e.Prepare(query, ps.session, placeholderHints)
 	if err != nil {
-		return nil, err
+		return nil, fatalErr, err
 	}
 
 	// For now we are just counting the size of the query string and
@@ -83,7 +83,7 @@ func (ps PreparedStatements) New(
 	// during prepare, this should be tallied up to the monitor as well.
 	sz := int64(uintptr(len(query)+len(name)) + unsafe.Sizeof(*stmt))
 	if err := stmt.memAcc.Wsession(ps.session).OpenAndInit(ps.session.Ctx(), sz); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	if prevStmt, ok := ps.Get(name); ok {
@@ -91,7 +91,7 @@ func (ps PreparedStatements) New(
 	}
 
 	ps.stmts[name] = stmt
-	return stmt, nil
+	return stmt, false, nil
 }
 
 // Delete removes the PreparedStatement with the provided name from the PreparedStatements.


### PR DESCRIPTION
Panic recovery is enabled iff the cluster setting
`sql.internal_error_recovery.enabled` is true (it is set to true by
default).

A panic is considered recoverable if it was originally emitted by the `sql` package itself or one of its sub-packages. For example, if the panic originates in the `client` package (e.g. as called by client.Txn() from `sql`), the panic is not considered to be recoverable.

The panic details are logged on the server's logs (and stderr); the client only receives a generic message "internal server error during SQL execution" that invites them to investigate the server (or talk to the DBA).

Fixes #9884.

cc @bdarnell 