### PR TITLE
ui: Add optional horizontal scrollbar to table create schema field

### DIFF
--- a/pkg/ui/styl/components/codeblock.styl
+++ b/pkg/ui/styl/components/codeblock.styl
@@ -4,10 +4,11 @@
   padding 20px
   display inline-block
   width 100%
-  
+
 pre.sql.hljs
     background-color $main-dark-gray
     color $secondary-gray-12
+    overflow-x auto
 
     .hljs-string
         color $syntax-orange


### PR DESCRIPTION
The create table command query "bleeds out" of its field if the rows are too long like here:

![Too long](http://i.imgur.com/rNlEmB1.png)

The change adds optional horizontal scrollbar to the field if any of the rows are too long for them to fit:

![With scrollbar](http://i.imgur.com/v5A5K66.png)