### PR TITLE
*: report panics in context; more context plumbing

### DIFF
--- a/pkg/acceptance/partition_test.go
+++ b/pkg/acceptance/partition_test.go
@@ -40,7 +40,7 @@ func TestPartitionNemesis(t *testing.T) {
 	defer s.Close(t)
 
 	runTestOnConfigs(t, func(ctx context.Context, t *testing.T, c cluster.Cluster, cfg cluster.TestConfig) {
-		stopper.RunWorker(func() {
+		stopper.RunWorker(ctx, func() {
 			BidirectionalPartitionNemesis(ctx, t, c, stopper)
 		})
 		select {
@@ -191,10 +191,10 @@ func runTransactionsAndNemeses(
 	// We're going to run the nemeses for the duration of this function, which may
 	// return before `stopper` is stopped.
 	nemesesStopper := stop.NewStopper()
-	defer nemesesStopper.Stop()
+	defer nemesesStopper.Stop(ctx)
 	const concurrency = 5
 	for _, nemesis := range nemeses {
-		stopper.RunWorker(func() {
+		stopper.RunWorker(ctx, func() {
 			nemesis(ctx, t, c, nemesesStopper)
 		})
 	}

--- a/pkg/acceptance/partition_test.go
+++ b/pkg/acceptance/partition_test.go
@@ -40,7 +40,7 @@ func TestPartitionNemesis(t *testing.T) {
 	defer s.Close(t)
 
 	runTestOnConfigs(t, func(ctx context.Context, t *testing.T, c cluster.Cluster, cfg cluster.TestConfig) {
-		stopper.RunWorker(ctx, func() {
+		stopper.RunWorker(ctx, func(ctx context.Context) {
 			BidirectionalPartitionNemesis(ctx, t, c, stopper)
 		})
 		select {
@@ -194,7 +194,7 @@ func runTransactionsAndNemeses(
 	defer nemesesStopper.Stop(ctx)
 	const concurrency = 5
 	for _, nemesis := range nemeses {
-		stopper.RunWorker(ctx, func() {
+		stopper.RunWorker(ctx, func(ctx context.Context) {
 			nemesis(ctx, t, c, nemesesStopper)
 		})
 	}

--- a/pkg/acceptance/repair_test.go
+++ b/pkg/acceptance/repair_test.go
@@ -46,7 +46,7 @@ func testRepairInner(ctx context.Context, t *testing.T, c cluster.Cluster, cfg c
 	// Add some loads.
 	for i := 0; i < c.NumNodes()*2; i++ {
 		ID := i
-		stopper.RunWorker(ctx, func() {
+		stopper.RunWorker(ctx, func(ctx context.Context) {
 			insertLoad(ctx, t, dc, ID)
 		})
 	}

--- a/pkg/acceptance/repair_test.go
+++ b/pkg/acceptance/repair_test.go
@@ -46,7 +46,7 @@ func testRepairInner(ctx context.Context, t *testing.T, c cluster.Cluster, cfg c
 	// Add some loads.
 	for i := 0; i < c.NumNodes()*2; i++ {
 		ID := i
-		stopper.RunWorker(func() {
+		stopper.RunWorker(ctx, func() {
 			insertLoad(ctx, t, dc, ID)
 		})
 	}

--- a/pkg/acceptance/util.go
+++ b/pkg/acceptance/util.go
@@ -149,7 +149,7 @@ func RunTests(m *testing.M) {
 		default:
 			// There is a very tiny race here: the cluster might be closing
 			// the stopper simultaneously.
-			stopper.Stop()
+			stopper.Stop(context.TODO())
 		}
 	}()
 	os.Exit(m.Run())

--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -177,7 +177,7 @@ func backupRestoreTestSetupWithParams(
 			}
 			return nil
 		})
-		tc.Stopper().Stop()
+		tc.Stopper().Stop(context.TODO())
 		dirCleanupFn()
 	}
 
@@ -312,7 +312,7 @@ func backupAndRestore(
 	// Start a new cluster to restore into.
 	{
 		tcRestore := testcluster.StartTestCluster(t, multiNode, base.TestClusterArgs{})
-		defer tcRestore.Stopper().Stop()
+		defer tcRestore.Stopper().Stop(ctx)
 		sqlDBRestore := backupSQLRunner(t, tcRestore)
 
 		// Create some other descriptors to change up IDs
@@ -552,7 +552,7 @@ func TestBackupRestoreInterleaved(t *testing.T) {
 
 	t.Run("all tables in interleave hierarchy", func(t *testing.T) {
 		tcRestore := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{})
-		defer tcRestore.Stopper().Stop()
+		defer tcRestore.Stopper().Stop(context.TODO())
 		sqlDBRestore := backupSQLRunner(t, tcRestore)
 		sqlDBRestore.Exec(bankCreateDatabase)
 
@@ -579,7 +579,7 @@ func TestBackupRestoreInterleaved(t *testing.T) {
 
 	t.Run("interleaved table without parent", func(t *testing.T) {
 		tcRestore := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{})
-		defer tcRestore.Stopper().Stop()
+		defer tcRestore.Stopper().Stop(context.TODO())
 		sqlDBRestore := backupSQLRunner(t, tcRestore)
 		sqlDBRestore.Exec(bankCreateDatabase)
 
@@ -591,7 +591,7 @@ func TestBackupRestoreInterleaved(t *testing.T) {
 
 	t.Run("interleaved table without child", func(t *testing.T) {
 		tcRestore := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{})
-		defer tcRestore.Stopper().Stop()
+		defer tcRestore.Stopper().Stop(context.TODO())
 		sqlDBRestore := backupSQLRunner(t, tcRestore)
 		sqlDBRestore.Exec(bankCreateDatabase)
 
@@ -681,7 +681,7 @@ func TestBackupRestoreCrossTableReferences(t *testing.T) {
 
 	t.Run("restore everything to new cluster", func(t *testing.T) {
 		tc := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{})
-		defer tc.Stopper().Stop()
+		defer tc.Stopper().Stop(context.TODO())
 		db := backupSQLRunner(t, tc)
 
 		db.Exec(createStore)
@@ -724,7 +724,7 @@ func TestBackupRestoreCrossTableReferences(t *testing.T) {
 
 	t.Run("restore customers to new cluster", func(t *testing.T) {
 		tc := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{})
-		defer tc.Stopper().Stop()
+		defer tc.Stopper().Stop(context.TODO())
 		db := backupSQLRunner(t, tc)
 		db.Exec(createStore)
 		db.Exec(`RESTORE store.customers, store.orders FROM $1`, dir)
@@ -743,7 +743,7 @@ func TestBackupRestoreCrossTableReferences(t *testing.T) {
 
 	t.Run("restore orders to new cluster", func(t *testing.T) {
 		tc := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{})
-		defer tc.Stopper().Stop()
+		defer tc.Stopper().Stop(context.TODO())
 		db := backupSQLRunner(t, tc)
 		db.Exec(createStore)
 
@@ -766,7 +766,7 @@ func TestBackupRestoreCrossTableReferences(t *testing.T) {
 
 	t.Run("restore receipts to new cluster", func(t *testing.T) {
 		tc := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{})
-		defer tc.Stopper().Stop()
+		defer tc.Stopper().Stop(context.TODO())
 		db := backupSQLRunner(t, tc)
 		db.Exec(createStore)
 		db.Exec(`RESTORE store.receipts FROM $1 WITH OPTIONS ('skip_missing_foreign_keys')`, dir)
@@ -785,7 +785,7 @@ func TestBackupRestoreCrossTableReferences(t *testing.T) {
 
 	t.Run("restore receipts and customers to new cluster", func(t *testing.T) {
 		tc := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{})
-		defer tc.Stopper().Stop()
+		defer tc.Stopper().Stop(context.TODO())
 		db := backupSQLRunner(t, tc)
 		db.Exec(createStore)
 		db.Exec(`RESTORE store.receipts, store.customers FROM $1 WITH OPTIONS ('skip_missing_foreign_keys')`, dir)
@@ -818,7 +818,7 @@ func TestBackupRestoreCrossTableReferences(t *testing.T) {
 
 	t.Run("restore simple view", func(t *testing.T) {
 		tc := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{})
-		defer tc.Stopper().Stop()
+		defer tc.Stopper().Stop(context.TODO())
 		db := backupSQLRunner(t, tc)
 		db.Exec(createStore)
 		if _, err := db.DB.Exec(`RESTORE store.early_customers FROM $1`, dir); !testutils.IsError(err,
@@ -848,7 +848,7 @@ func TestBackupRestoreCrossTableReferences(t *testing.T) {
 
 	t.Run("restore multi-table view", func(t *testing.T) {
 		tc := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{})
-		defer tc.Stopper().Stop()
+		defer tc.Stopper().Stop(context.TODO())
 		db := backupSQLRunner(t, tc)
 		db.Exec(createStore)
 		db.Exec(createStoreStats)
@@ -967,7 +967,7 @@ func TestBackupRestoreIncremental(t *testing.T) {
 	// Start a new cluster to restore into.
 	{
 		tc := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{})
-		defer tc.Stopper().Stop()
+		defer tc.Stopper().Stop(context.TODO())
 		sqlDBRestore := backupSQLRunner(t, tc)
 
 		sqlDBRestore.Exec(`CREATE DATABASE bench`)
@@ -1049,7 +1049,7 @@ func TestBackupRestoreWithConcurrentWrites(t *testing.T) {
 	var allowErrors int32
 	for task := 0; task < numBackgroundTasks; task++ {
 		taskNum := task
-		tc.Stopper().RunWorker(func() {
+		tc.Stopper().RunWorker(context.TODO(), func() {
 			conn := tc.Conns[taskNum%len(tc.Conns)]
 			// Use different sql gateways to make sure leasing is right.
 			if err := startBackgroundWrites(tc.Stopper(), conn, rows, bgActivity, &allowErrors); err != nil {
@@ -1361,7 +1361,7 @@ func TestRestoredPrivileges(t *testing.T) {
 
 	t.Run("into fresh db", func(t *testing.T) {
 		tc := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{})
-		defer tc.Stopper().Stop()
+		defer tc.Stopper().Stop(context.TODO())
 		sqlDBRestore := backupSQLRunner(t, tc)
 		sqlDBRestore.Exec(`CREATE DATABASE bench`)
 		sqlDBRestore.Exec(`RESTORE bench.bank FROM $1`, dir)
@@ -1370,7 +1370,7 @@ func TestRestoredPrivileges(t *testing.T) {
 
 	t.Run("into db with added grants", func(t *testing.T) {
 		tc := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{})
-		defer tc.Stopper().Stop()
+		defer tc.Stopper().Stop(context.TODO())
 		sqlDBRestore := backupSQLRunner(t, tc)
 		sqlDBRestore.Exec(`CREATE DATABASE bench`)
 		sqlDBRestore.Exec(`CREATE USER someone`)

--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -1049,7 +1049,7 @@ func TestBackupRestoreWithConcurrentWrites(t *testing.T) {
 	var allowErrors int32
 	for task := 0; task < numBackgroundTasks; task++ {
 		taskNum := task
-		tc.Stopper().RunWorker(context.TODO(), func() {
+		tc.Stopper().RunWorker(context.TODO(), func(context.Context) {
 			conn := tc.Conns[taskNum%len(tc.Conns)]
 			// Use different sql gateways to make sure leasing is right.
 			if err := startBackgroundWrites(tc.Stopper(), conn, rows, bgActivity, &allowErrors); err != nil {

--- a/pkg/ccl/sqlccl/kv_test.go
+++ b/pkg/ccl/sqlccl/kv_test.go
@@ -57,7 +57,7 @@ func newKVWriteBatch(b *testing.B) kvInterface {
 	return &kvWriteBatch{
 		db: client.NewDB(client.NewSender(conn), rpcContext.LocalClock),
 		doneFn: func() {
-			s.Stopper().Stop()
+			s.Stopper().Stop(context.TODO())
 			enableTracing()
 		},
 	}

--- a/pkg/ccl/storageccl/export_test.go
+++ b/pkg/ccl/storageccl/export_test.go
@@ -36,7 +36,7 @@ func TestExport(t *testing.T) {
 	dir, dirCleanupFn := testutils.TempDir(t)
 	defer dirCleanupFn()
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(t, tc.Conns[0])
 	kvDB := tc.Server(0).KVClient().(*client.DB)
 
@@ -139,7 +139,7 @@ func TestExportGCThreshold(t *testing.T) {
 
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(ctx)
 	kvDB := tc.Server(0).KVClient().(*client.DB)
 
 	req := &roachpb.ExportRequest{

--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -189,7 +189,7 @@ func TestImport(t *testing.T) {
 
 	ctx := context.Background()
 	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{Knobs: knobs})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(ctx)
 
 	storage, err := ExportStorageConfFromURI("nodelocal://" + dir)
 	if err != nil {

--- a/pkg/ccl/storageccl/writebatch_test.go
+++ b/pkg/ccl/storageccl/writebatch_test.go
@@ -37,8 +37,8 @@ func TestDBWriteBatch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	s, _, db := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
-	defer s.Stopper().Stop()
 	ctx := context.Background()
+	defer s.Stopper().Stop(ctx)
 
 	// Key range in request spans multiple ranges.
 	if err := db.WriteBatch(
@@ -191,7 +191,7 @@ func BenchmarkWriteBatch(b *testing.B) {
 		b.Run(strconv.Itoa(numEntries), func(b *testing.B) {
 			ctx := context.Background()
 			tc := testcluster.StartTestCluster(b, 3, base.TestClusterArgs{})
-			defer tc.Stopper().Stop()
+			defer tc.Stopper().Stop(ctx)
 			kvDB := tc.Server(0).KVClient().(*client.DB)
 
 			id := keys.MaxReservedDescID + 1

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -22,6 +22,8 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -40,7 +42,7 @@ func Main() {
 		os.Args = append(os.Args, "help")
 	}
 
-	defer log.RecoverAndReportPanic()
+	defer log.RecoverAndReportPanic(context.Background())
 
 	if err := Run(os.Args[1:]); err != nil {
 		fmt.Fprintf(stderr, "Failed running %q\n", os.Args[1])

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -160,7 +160,7 @@ func (c cliTest) cleanup() {
 			// called Stop(). We just need to wait.
 			<-c.Stopper().IsStopped()
 		default:
-			c.Stopper().Stop()
+			c.Stopper().Stop(context.TODO())
 		}
 	}
 

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -125,7 +125,7 @@ func printKeyValue(kv engine.MVCCKeyValue) (bool, error) {
 
 func runDebugKeys(cmd *cobra.Command, args []string) error {
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(stopperContext(stopper))
 
 	if len(args) != 1 {
 		return errors.New("one argument required: dir")
@@ -157,7 +157,7 @@ state like the raft HardState. With --replicated, only includes data covered by
 
 func runDebugRangeData(cmd *cobra.Command, args []string) error {
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(stopperContext(stopper))
 
 	if len(args) != 2 {
 		return errors.New("two arguments required: dir range_id")
@@ -395,7 +395,7 @@ func loadRangeDescriptor(
 
 func runDebugRangeDescriptors(cmd *cobra.Command, args []string) error {
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(stopperContext(stopper))
 
 	if len(args) != 1 {
 		return errors.New("one argument required: dir")
@@ -467,7 +467,7 @@ func printRaftLogEntry(kv engine.MVCCKeyValue) (bool, error) {
 
 func runDebugRaftLog(cmd *cobra.Command, args []string) error {
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(stopperContext(stopper))
 
 	if len(args) != 2 {
 		return errors.New("two arguments required: dir range_id")
@@ -506,7 +506,7 @@ Uses a hard-coded GC policy with a 24 hour TTL for old versions.
 
 func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(stopperContext(stopper))
 
 	if len(args) != 1 {
 		return errors.New("one argument required: dir")
@@ -592,7 +592,7 @@ type replicaCheckInfo struct {
 
 func runDebugCheckStoreCmd(cmd *cobra.Command, args []string) error {
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(stopperContext(stopper))
 
 	if len(args) != 1 {
 		return errors.New("one required argument: dir")
@@ -714,7 +714,7 @@ Compact the sstables in a store.
 
 func runDebugCompact(cmd *cobra.Command, args []string) error {
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(stopperContext(stopper))
 
 	if len(args) != 1 {
 		return errors.New("one argument is required")
@@ -757,7 +757,7 @@ and TiB.
 
 func runDebugSSTables(cmd *cobra.Command, args []string) error {
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(stopperContext(stopper))
 
 	if len(args) != 1 {
 		return errors.New("one argument is required")

--- a/pkg/cli/haproxy.go
+++ b/pkg/cli/haproxy.go
@@ -55,7 +55,7 @@ func runGenHAProxyCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer stopper.Stop()
+	defer stopper.Stop(stopperContext(stopper))
 
 	nodeStatuses, err := c.Nodes(stopperContext(stopper), &serverpb.NodesRequest{})
 	if err != nil {

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -57,7 +57,7 @@ func runLsNodes(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer stopper.Stop()
+	defer stopper.Stop(stopperContext(stopper))
 
 	nodeStatuses, err := c.Nodes(stopperContext(stopper), &serverpb.NodesRequest{})
 	if err != nil {
@@ -110,12 +110,13 @@ func runStatusNode(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer stopper.Stop()
+	ctx := stopperContext(stopper)
+	defer stopper.Stop(ctx)
 
 	switch len(args) {
 	case 0:
 		// Show status for all nodes.
-		nodes, err := c.Nodes(stopperContext(stopper), &serverpb.NodesRequest{})
+		nodes, err := c.Nodes(ctx, &serverpb.NodesRequest{})
 		if err != nil {
 			return err
 		}
@@ -123,7 +124,7 @@ func runStatusNode(cmd *cobra.Command, args []string) error {
 
 	case 1:
 		nodeID := args[0]
-		nodeStatus, err := c.Node(stopperContext(stopper), &serverpb.NodeRequest{NodeId: nodeID})
+		nodeStatus, err := c.Node(ctx, &serverpb.NodeRequest{NodeId: nodeID})
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/range.go
+++ b/pkg/cli/range.go
@@ -74,7 +74,7 @@ func runLsRanges(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer stopper.Stop()
+	defer stopper.Stop(stopperContext(stopper))
 
 	rows, err := kvDB.Scan(context.Background(), startKey, endKey, maxResults)
 	if err != nil {
@@ -117,7 +117,7 @@ func runSplitRange(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer stopper.Stop()
+	defer stopper.Stop(stopperContext(stopper))
 	return errors.Wrap(kvDB.AdminSplit(context.Background(), key), "split failed")
 }
 

--- a/pkg/cli/sql_test.go
+++ b/pkg/cli/sql_test.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/chzyer/readline"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -34,7 +36,7 @@ func TestSQLLex(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	pgurl, err := s.(*server.TestServer).Cfg.PGURL(url.User(security.RootUser))
 	if err != nil {

--- a/pkg/cli/sql_util_test.go
+++ b/pkg/cli/sql_util_test.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -32,7 +34,7 @@ import (
 func TestRunQuery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	url, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), "TestRunQuery", url.User(security.RootUser))
 	defer cleanup()

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -214,7 +214,7 @@ func initCPUProfile(ctx context.Context, dir string) {
 	}
 
 	go func() {
-		defer log.RecoverAndReportPanic()
+		defer log.RecoverAndReportPanic(ctx)
 
 		ctx := context.Background()
 
@@ -336,7 +336,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 	var s *server.Server
 	errChan := make(chan error, 1)
 	go func() {
-		defer log.RecoverAndReportPanic()
+		defer log.RecoverAndReportPanic(startCtx)
 
 		defer sp.Finish()
 		if err := func() error {
@@ -459,7 +459,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 					log.Warning(shutdownCtx, err)
 				}
 			}
-			stopper.Stop()
+			stopper.Stop(shutdownCtx)
 		}()
 	}
 
@@ -729,9 +729,9 @@ func runQuit(_ *cobra.Command, _ []string) (err error) {
 	if err != nil {
 		return err
 	}
-	defer stopper.Stop()
-
 	ctx := stopperContext(stopper)
+	defer stopper.Stop(ctx)
+
 	errChan := make(chan error, 1)
 	go func() {
 		errChan <- doShutdown(ctx, c, onModes)

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -111,11 +111,11 @@ func runDebugZip(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer stopper.Stop()
+	ctx := stopperContext(stopper)
+	defer stopper.Stop(ctx)
 
 	status := serverpb.NewStatusClient(conn)
 	admin := serverpb.NewAdminClient(conn)
-	ctx := stopperContext(stopper)
 
 	name := args[0]
 	out, err := os.Create(name)

--- a/pkg/cmd/gossipsim/main.go
+++ b/pkg/cmd/gossipsim/main.go
@@ -307,7 +307,7 @@ func main() {
 	edgeSet := make(map[string]edge)
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	n := simulation.NewNetwork(stopper, nodeCount, true)
 	n.SimulateNetwork(

--- a/pkg/cmd/internal/localcluster/localcluster.go
+++ b/pkg/cmd/internal/localcluster/localcluster.go
@@ -138,7 +138,7 @@ func (c *Cluster) Close() {
 	for _, n := range c.Nodes {
 		n.Kill()
 	}
-	c.stopper.Stop()
+	c.stopper.Stop(context.Background())
 }
 
 // IPAddr returns the IP address of the specified node.

--- a/pkg/gossip/client.go
+++ b/pkg/gossip/client.go
@@ -87,8 +87,8 @@ func (c *client) startLocked(
 	// (*client).handleResponse once we know the ID.
 	g.outgoing.addPlaceholder()
 
-	stopper.RunWorker(func() {
-		ctx, cancel := context.WithCancel(c.AnnotateCtx(context.Background()))
+	ctx, cancel := context.WithCancel(c.AnnotateCtx(context.Background()))
+	stopper.RunWorker(ctx, func() {
 		var wg sync.WaitGroup
 		defer func() {
 			// This closes the outgoing stream, causing any attempt to send or
@@ -305,7 +305,7 @@ func (c *client) gossip(
 	// This wait group is used to allow the caller to wait until gossip
 	// processing is terminated.
 	wg.Add(1)
-	stopper.RunWorker(func() {
+	stopper.RunWorker(ctx, func() {
 		defer wg.Done()
 
 		errCh <- func() error {

--- a/pkg/gossip/client.go
+++ b/pkg/gossip/client.go
@@ -88,7 +88,7 @@ func (c *client) startLocked(
 	g.outgoing.addPlaceholder()
 
 	ctx, cancel := context.WithCancel(c.AnnotateCtx(context.Background()))
-	stopper.RunWorker(ctx, func() {
+	stopper.RunWorker(ctx, func(ctx context.Context) {
 		var wg sync.WaitGroup
 		defer func() {
 			// This closes the outgoing stream, causing any attempt to send or
@@ -305,7 +305,7 @@ func (c *client) gossip(
 	// This wait group is used to allow the caller to wait until gossip
 	// processing is terminated.
 	wg.Add(1)
-	stopper.RunWorker(ctx, func() {
+	stopper.RunWorker(ctx, func(ctx context.Context) {
 		defer wg.Done()
 
 		errCh <- func() error {

--- a/pkg/gossip/client_test.go
+++ b/pkg/gossip/client_test.go
@@ -185,7 +185,7 @@ func TestClientGossip(t *testing.T) {
 	c := newClient(log.AmbientContext{}, remote.GetNodeAddr(), makeMetrics())
 
 	defer func() {
-		stopper.Stop()
+		stopper.Stop(context.TODO())
 		if c != <-disconnected {
 			t.Errorf("expected client disconnect after remote close")
 		}
@@ -215,7 +215,7 @@ func TestClientGossip(t *testing.T) {
 func TestClientGossipMetrics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	local := startGossip(1, stopper, t, metric.NewRegistry())
 	remote := startGossip(2, stopper, t, metric.NewRegistry())
 
@@ -284,7 +284,7 @@ func TestClientNodeID(t *testing.T) {
 	disconnected <- c
 
 	defer func() {
-		stopper.Stop()
+		stopper.Stop(context.TODO())
 		if c != <-disconnected {
 			t.Errorf("expected client disconnect after remote close")
 		}
@@ -322,7 +322,7 @@ func verifyServerMaps(g *Gossip, expCount int) bool {
 func TestClientDisconnectLoopback(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	local := startGossip(1, stopper, t, metric.NewRegistry())
 	local.mu.Lock()
 	lAddr := local.mu.is.NodeAddr
@@ -344,7 +344,7 @@ func TestClientDisconnectLoopback(t *testing.T) {
 func TestClientDisconnectRedundant(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	local := startGossip(1, stopper, t, metric.NewRegistry())
 	remote := startGossip(2, stopper, t, metric.NewRegistry())
 	local.mu.Lock()
@@ -381,7 +381,7 @@ func TestClientDisconnectRedundant(t *testing.T) {
 func TestClientDisallowMultipleConns(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	local := startGossip(1, stopper, t, metric.NewRegistry())
 	remote := startGossip(2, stopper, t, metric.NewRegistry())
 	local.mu.Lock()
@@ -417,7 +417,7 @@ func TestClientDisallowMultipleConns(t *testing.T) {
 func TestClientRegisterWithInitNodeID(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	// Create three gossip nodes, and connect to the first with NodeID 0.
 	var g []*Gossip
@@ -488,7 +488,7 @@ func (tr *testResolver) GetAddress() (net.Addr, error) {
 func TestClientRetryBootstrap(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	local := startGossip(1, stopper, t, metric.NewRegistry())
 	remote := startGossip(2, stopper, t, metric.NewRegistry())
 
@@ -514,7 +514,7 @@ func TestClientRetryBootstrap(t *testing.T) {
 func TestClientForwardUnresolved(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	const nodeID = 1
 	local := startGossip(nodeID, stopper, t, metric.NewRegistry())
 	addr := local.GetNodeAddr()

--- a/pkg/gossip/convergence_test.go
+++ b/pkg/gossip/convergence_test.go
@@ -64,7 +64,7 @@ func TestConvergence(t *testing.T) {
 	}
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	network := simulation.NewNetwork(stopper, testConvergenceSize, true)
 
@@ -97,7 +97,7 @@ func TestNetworkReachesEquilibrium(t *testing.T) {
 	}
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	network := simulation.NewNetwork(stopper, testReachesEquilibriumSize, true)
 

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1015,12 +1015,12 @@ func (g *Gossip) getNextBootstrapAddressLocked() net.Addr {
 // lost and requires re-bootstrapping.
 func (g *Gossip) bootstrap() {
 	ctx := g.AnnotateCtx(context.Background())
-	g.server.stopper.RunWorker(ctx, func() {
+	g.server.stopper.RunWorker(ctx, func(ctx context.Context) {
 		ctx = log.WithLogTag(ctx, "bootstrap", nil)
 		var bootstrapTimer timeutil.Timer
 		defer bootstrapTimer.Stop()
 		for {
-			if g.server.stopper.RunTask(ctx, func() {
+			if g.server.stopper.RunTask(ctx, func(ctx context.Context) {
 				g.mu.Lock()
 				defer g.mu.Unlock()
 				haveClients := g.outgoing.len() > 0
@@ -1080,7 +1080,7 @@ func (g *Gossip) bootstrap() {
 // is notified via the stalled conditional variable.
 func (g *Gossip) manage() {
 	ctx := g.AnnotateCtx(context.Background())
-	g.server.stopper.RunWorker(ctx, func() {
+	g.server.stopper.RunWorker(ctx, func(ctx context.Context) {
 		cullTicker := time.NewTicker(g.jitteredInterval(g.cullInterval))
 		stallTicker := time.NewTicker(g.jitteredInterval(g.stallInterval))
 		defer cullTicker.Stop()

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1014,13 +1014,13 @@ func (g *Gossip) getNextBootstrapAddressLocked() net.Addr {
 // receives notifications that gossip network connectivity has been
 // lost and requires re-bootstrapping.
 func (g *Gossip) bootstrap() {
-	g.server.stopper.RunWorker(func() {
-		ctx := g.AnnotateCtx(context.Background())
+	ctx := g.AnnotateCtx(context.Background())
+	g.server.stopper.RunWorker(ctx, func() {
 		ctx = log.WithLogTag(ctx, "bootstrap", nil)
 		var bootstrapTimer timeutil.Timer
 		defer bootstrapTimer.Stop()
 		for {
-			if g.server.stopper.RunTask(func() {
+			if g.server.stopper.RunTask(ctx, func() {
 				g.mu.Lock()
 				defer g.mu.Unlock()
 				haveClients := g.outgoing.len() > 0
@@ -1079,8 +1079,8 @@ func (g *Gossip) bootstrap() {
 // connections or the sentinel gossip is unavailable, the bootstrapper
 // is notified via the stalled conditional variable.
 func (g *Gossip) manage() {
-	g.server.stopper.RunWorker(func() {
-		ctx := g.AnnotateCtx(context.Background())
+	ctx := g.AnnotateCtx(context.Background())
+	g.server.stopper.RunWorker(ctx, func() {
 		cullTicker := time.NewTicker(g.jitteredInterval(g.cullInterval))
 		stallTicker := time.NewTicker(g.jitteredInterval(g.stallInterval))
 		defer cullTicker.Stop()

--- a/pkg/gossip/gossip_test.go
+++ b/pkg/gossip/gossip_test.go
@@ -45,7 +45,7 @@ import (
 func TestGossipInfoStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	rpcContext := newInsecureRPCContext(stopper)
 	g := NewTest(1, rpcContext, rpc.NewServer(rpcContext), nil, stopper, metric.NewRegistry())
 	slice := []byte("b")
@@ -65,7 +65,7 @@ func TestGossipInfoStore(t *testing.T) {
 func TestGossipOverwriteNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	rpcContext := newInsecureRPCContext(stopper)
 	g := NewTest(1, rpcContext, rpc.NewServer(rpcContext), nil, stopper, metric.NewRegistry())
 	node1 := &roachpb.NodeDescriptor{NodeID: 1, Address: util.MakeUnresolvedAddr("tcp", "1.1.1.1:1")}
@@ -101,7 +101,7 @@ func TestGossipOverwriteNode(t *testing.T) {
 
 	// Quiesce the stopper now to ensure that the update has propagated before
 	// checking whether node 1 has been removed from the infoStore.
-	stopper.Quiesce()
+	stopper.Quiesce(context.TODO())
 	expectedErr := "unable to look up descriptor for node"
 	if val, err := g.GetNodeDescriptor(node1.NodeID); !testutils.IsError(err, expectedErr) {
 		t.Errorf("expected error %q fetching node %d; got error %v and node %+v",
@@ -112,7 +112,7 @@ func TestGossipOverwriteNode(t *testing.T) {
 func TestGossipGetNextBootstrapAddress(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	resolverSpecs := []string{
 		"127.0.0.1:9000",
@@ -155,7 +155,7 @@ func TestGossipRaceLogStatus(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	local := startGossip(1, stopper, t, metric.NewRegistry())
 
 	local.mu.Lock()
@@ -192,7 +192,7 @@ func TestGossipOutgoingLimitEnforced(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	// This test has an implicit dependency on the maxPeers logic deciding that
 	// maxPeers is 3 for a 5-node cluster, so let's go ahead and make that
@@ -275,7 +275,7 @@ func TestGossipNoForwardSelf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	local := startGossip(1, stopper, t, metric.NewRegistry())
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -355,7 +355,7 @@ func TestGossipCullNetwork(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	local := startGossip(1, stopper, t, metric.NewRegistry())
 	local.SetCullInterval(5 * time.Millisecond)
 
@@ -394,7 +394,7 @@ func TestGossipOrphanedStallDetection(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	local := startGossip(1, stopper, t, metric.NewRegistry())
 	local.SetStallInterval(5 * time.Millisecond)
 
@@ -436,7 +436,7 @@ func TestGossipOrphanedStallDetection(t *testing.T) {
 	local.bootstrap()
 	local.manage()
 
-	peerStopper.Stop()
+	peerStopper.Stop(context.TODO())
 
 	testutils.SucceedsSoon(t, func() error {
 		for _, peerID := range local.Outgoing() {
@@ -448,7 +448,7 @@ func TestGossipOrphanedStallDetection(t *testing.T) {
 	})
 
 	peerStopper = stop.NewStopper()
-	defer peerStopper.Stop()
+	defer peerStopper.Stop(context.TODO())
 	startGossipAtAddr(peerNodeID, peerAddr, peerStopper, t, metric.NewRegistry())
 
 	testutils.SucceedsSoon(t, func() error {
@@ -489,7 +489,7 @@ func TestGossipJoinTwoClusters(t *testing.T) {
 			select {
 			case <-stopper.ShouldQuiesce():
 			default:
-				stopper.Stop()
+				stopper.Stop(context.TODO())
 			}
 		}()
 		rpcCtx := newInsecureRPCContext(stopper)
@@ -546,7 +546,7 @@ func TestGossipJoinTwoClusters(t *testing.T) {
 	})
 
 	// Kill node 0 to force node 2 to bootstrap with node 1.
-	stoppers[0].Stop()
+	stoppers[0].Stop(context.TODO())
 	// Wait for twice the bootstrap interval, and verify that
 	// node 2 still has not connected to node 1.
 	time.Sleep(2 * interval)

--- a/pkg/gossip/infostore_test.go
+++ b/pkg/gossip/infostore_test.go
@@ -53,7 +53,7 @@ func newTestInfoStore() (*infoStore, *stop.Stopper) {
 func TestZeroDuration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	is, stopper := newTestInfoStore()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	info := is.newInfo(nil, 0)
 	if info.TTLStamp != math.MaxInt64 {
 		t.Errorf("expected zero duration to get max TTLStamp: %d", info.TTLStamp)
@@ -64,7 +64,7 @@ func TestZeroDuration(t *testing.T) {
 func TestNewInfo(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	is, stopper := newTestInfoStore()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	info1 := is.newInfo(nil, time.Second)
 	info2 := is.newInfo(nil, time.Second)
 	if err := is.addInfo("a", info1); err != nil {
@@ -83,7 +83,7 @@ func TestNewInfo(t *testing.T) {
 func TestInfoStoreGetInfo(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	is, stopper := newTestInfoStore()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	i := is.newInfo(nil, time.Second)
 	i.NodeID = 1
 	if err := is.addInfo("a", i); err != nil {
@@ -107,7 +107,7 @@ func TestInfoStoreGetInfo(t *testing.T) {
 func TestInfoStoreGetInfoTTL(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	is, stopper := newTestInfoStore()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	i := is.newInfo(nil, time.Nanosecond)
 	if err := is.addInfo("a", i); err != nil {
 		t.Error(err)
@@ -123,7 +123,7 @@ func TestInfoStoreGetInfoTTL(t *testing.T) {
 func TestAddInfoSameKeyLessThanEqualTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	is, stopper := newTestInfoStore()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	info1 := is.newInfo(nil, time.Second)
 	if err := is.addInfo("a", info1); err != nil {
 		t.Error(err)
@@ -147,7 +147,7 @@ func TestAddInfoSameKeyLessThanEqualTimestamp(t *testing.T) {
 func TestAddInfoSameKeyGreaterTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	is, stopper := newTestInfoStore()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	info1 := is.newInfo(nil, time.Second)
 	info2 := is.newInfo(nil, time.Second)
 	if err1, err2 := is.addInfo("a", info1), is.addInfo("a", info2); err1 != nil || err2 != nil {
@@ -160,7 +160,7 @@ func TestAddInfoSameKeyGreaterTimestamp(t *testing.T) {
 func TestAddInfoSameKeyDifferentHops(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	is, stopper := newTestInfoStore()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	info1 := is.newInfo(nil, time.Second)
 	info1.Hops = 1
 	info2 := is.newInfo(nil, time.Second)
@@ -192,7 +192,7 @@ func TestAddInfoSameKeyDifferentHops(t *testing.T) {
 // Helper method creates an infostore with 10 infos.
 func createTestInfoStore(t *testing.T) *infoStore {
 	is, stopper := newTestInfoStore()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	for i := 0; i < 10; i++ {
 		infoA := is.newInfo(nil, time.Second)
@@ -268,7 +268,7 @@ func TestInfoStoreMostDistant(t *testing.T) {
 		roachpb.NodeID(3),
 	}
 	is, stopper := newTestInfoStore()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	// Add info from each address, with hop count equal to index+1.
 	for i := 0; i < len(nodes); i++ {
 		inf := is.newInfo(nil, time.Second)
@@ -312,7 +312,7 @@ func TestLeastUseful(t *testing.T) {
 		roachpb.NodeID(2),
 	}
 	is, stopper := newTestInfoStore()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	set := makeNodeSet(3, metric.NewGauge(metric.Metadata{Name: ""}))
 	if is.leastUseful(set) != 0 {
@@ -382,7 +382,7 @@ func (cr *callbackRecord) Keys() []string {
 func TestCallbacks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	is, stopper := newTestInfoStore()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	wg := &sync.WaitGroup{}
 	cb1 := callbackRecord{wg: wg}
 	cb2 := callbackRecord{wg: wg}
@@ -488,7 +488,7 @@ func TestCallbacks(t *testing.T) {
 func TestRegisterCallback(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	is, stopper := newTestInfoStore()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	wg := &sync.WaitGroup{}
 	cb := callbackRecord{wg: wg}
 

--- a/pkg/gossip/server.go
+++ b/pkg/gossip/server.go
@@ -158,8 +158,8 @@ func (s *server) Gossip(stream Gossip_GossipServer) error {
 	errCh := make(chan error, 1)
 
 	// Starting workers in a task prevents data races during shutdown.
-	if err := s.stopper.RunTask(func() {
-		s.stopper.RunWorker(func() {
+	if err := s.stopper.RunTask(ctx, func() {
+		s.stopper.RunWorker(ctx, func() {
 			errCh <- s.gossipReceiver(ctx, &args, send, stream.Recv)
 		})
 	}); err != nil {
@@ -382,7 +382,7 @@ func (s *server) start(addr net.Addr) {
 		broadcast()
 	})
 
-	s.stopper.RunWorker(func() {
+	s.stopper.RunWorker(context.TODO(), func() {
 		<-s.stopper.ShouldQuiesce()
 
 		s.mu.Lock()

--- a/pkg/gossip/server.go
+++ b/pkg/gossip/server.go
@@ -158,8 +158,8 @@ func (s *server) Gossip(stream Gossip_GossipServer) error {
 	errCh := make(chan error, 1)
 
 	// Starting workers in a task prevents data races during shutdown.
-	if err := s.stopper.RunTask(ctx, func() {
-		s.stopper.RunWorker(ctx, func() {
+	if err := s.stopper.RunTask(ctx, func(ctx context.Context) {
+		s.stopper.RunWorker(ctx, func(ctx context.Context) {
 			errCh <- s.gossipReceiver(ctx, &args, send, stream.Recv)
 		})
 	}); err != nil {
@@ -382,7 +382,7 @@ func (s *server) start(addr net.Addr) {
 		broadcast()
 	})
 
-	s.stopper.RunWorker(context.TODO(), func() {
+	s.stopper.RunWorker(context.TODO(), func(context.Context) {
 		<-s.stopper.ShouldQuiesce()
 
 		s.mu.Lock()

--- a/pkg/gossip/simulation/network.go
+++ b/pkg/gossip/simulation/network.go
@@ -110,7 +110,7 @@ func (n *Network) CreateNode() (*Node, error) {
 	}
 	node := &Node{Server: server, Listener: ln, Registry: metric.NewRegistry()}
 	node.Gossip = gossip.NewTest(0, n.rpcContext, server, nil, n.Stopper, node.Registry)
-	n.Stopper.RunWorker(func() {
+	n.Stopper.RunWorker(context.TODO(), func() {
 		<-n.Stopper.ShouldQuiesce()
 		netutil.FatalIfUnexpected(ln.Close())
 		<-n.Stopper.ShouldStop()
@@ -138,7 +138,7 @@ func (n *Network) StartNode(node *Node) error {
 		encoding.EncodeUint64Ascending(nil, 0), time.Hour); err != nil {
 		return err
 	}
-	n.Stopper.RunWorker(func() {
+	n.Stopper.RunWorker(context.TODO(), func() {
 		netutil.FatalIfUnexpected(node.Server.Serve(node.Listener))
 	})
 	return nil

--- a/pkg/gossip/simulation/network.go
+++ b/pkg/gossip/simulation/network.go
@@ -110,7 +110,7 @@ func (n *Network) CreateNode() (*Node, error) {
 	}
 	node := &Node{Server: server, Listener: ln, Registry: metric.NewRegistry()}
 	node.Gossip = gossip.NewTest(0, n.rpcContext, server, nil, n.Stopper, node.Registry)
-	n.Stopper.RunWorker(context.TODO(), func() {
+	n.Stopper.RunWorker(context.TODO(), func(context.Context) {
 		<-n.Stopper.ShouldQuiesce()
 		netutil.FatalIfUnexpected(ln.Close())
 		<-n.Stopper.ShouldStop()
@@ -138,7 +138,7 @@ func (n *Network) StartNode(node *Node) error {
 		encoding.EncodeUint64Ascending(nil, 0), time.Hour); err != nil {
 		return err
 	}
-	n.Stopper.RunWorker(context.TODO(), func() {
+	n.Stopper.RunWorker(context.TODO(), func(context.Context) {
 		netutil.FatalIfUnexpected(node.Server.Serve(node.Listener))
 	})
 	return nil

--- a/pkg/gossip/storage_test.go
+++ b/pkg/gossip/storage_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/gossip/resolver"
@@ -100,7 +101,7 @@ func (s unresolvedAddrSlice) Swap(i, j int) {
 func TestGossipStorage(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	network := simulation.NewNetwork(stopper, 3, true)
 
@@ -217,7 +218,7 @@ func TestGossipStorage(t *testing.T) {
 func TestGossipStorageCleanup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	const numNodes = 3
 	network := simulation.NewNetwork(stopper, numNodes, false)

--- a/pkg/internal/client/client_test.go
+++ b/pkg/internal/client/client_test.go
@@ -182,7 +182,7 @@ func TestClientRetryNonTxn(t *testing.T) {
 		},
 	}
 	s, _, _ := serverutils.StartServer(t, args)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	testCases := []struct {
 		args        roachpb.Request
@@ -307,7 +307,7 @@ func TestClientRetryNonTxn(t *testing.T) {
 func TestClientRunTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	dbCtx := client.DefaultDBContext()
 	db := createTestClientForUser(t, s, security.NodeUser, dbCtx)
 
@@ -368,7 +368,7 @@ func TestClientRunTransaction(t *testing.T) {
 func TestClientRunConcurrentTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	dbCtx := client.DefaultDBContext()
 	db := createTestClientForUser(t, s, security.NodeUser, dbCtx)
 
@@ -466,7 +466,7 @@ func TestClientRunConcurrentTransaction(t *testing.T) {
 func TestClientGetAndPutProto(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	db := createTestClient(t, s)
 
 	zoneConfig := config.ZoneConfig{
@@ -495,7 +495,7 @@ func TestClientGetAndPutProto(t *testing.T) {
 func TestClientGetAndPut(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	db := createTestClient(t, s)
 
 	value := []byte("value")
@@ -517,7 +517,7 @@ func TestClientGetAndPut(t *testing.T) {
 func TestClientPutInline(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	db := createTestClient(t, s)
 
 	value := []byte("value")
@@ -544,7 +544,7 @@ func TestClientPutInline(t *testing.T) {
 func TestClientEmptyValues(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	db := createTestClient(t, s)
 
 	if err := db.Put(context.TODO(), testUser+"/a", []byte{}); err != nil {
@@ -573,7 +573,7 @@ func TestClientEmptyValues(t *testing.T) {
 func TestClientBatch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	db := createTestClient(t, s)
 	ctx := context.TODO()
 
@@ -829,7 +829,7 @@ func concurrentIncrements(db *client.DB, t *testing.T) {
 func TestConcurrentIncrements(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	db := createTestClient(t, s)
 
 	// Convenience loop: Crank up this number for testing this
@@ -846,7 +846,7 @@ func TestConcurrentIncrements(t *testing.T) {
 func TestClientPermissions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	// NodeUser certs are required for all KV operations.
 	// RootUser has no KV privileges whatsoever.
@@ -947,7 +947,7 @@ func TestInconsistentReads(t *testing.T) {
 func TestReadOnlyTxnObeysDeadline(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	db := createTestClient(t, s)
 
 	if err := db.Put(context.TODO(), "k", "v"); err != nil {
@@ -973,7 +973,7 @@ func TestReadOnlyTxnObeysDeadline(t *testing.T) {
 func TestTxn_ReverseScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	db := createTestClient(t, s)
 
 	keys := []roachpb.Key{}

--- a/pkg/internal/client/db_test.go
+++ b/pkg/internal/client/db_test.go
@@ -77,7 +77,7 @@ func checkLen(t *testing.T, expected, count int) {
 func TestDB_Get(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	result, err := db.Get(context.TODO(), "aa")
 	if err != nil {
@@ -89,7 +89,7 @@ func TestDB_Get(t *testing.T) {
 func TestDB_Put(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	ctx := context.TODO()
 
 	if err := db.Put(context.TODO(), "aa", "1"); err != nil {
@@ -105,7 +105,7 @@ func TestDB_Put(t *testing.T) {
 func TestDB_CPut(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	ctx := context.TODO()
 
 	if err := db.Put(ctx, "aa", "1"); err != nil {
@@ -151,7 +151,7 @@ func TestDB_CPut(t *testing.T) {
 func TestDB_InitPut(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	ctx := context.TODO()
 
 	if err := db.InitPut(ctx, "aa", "1"); err != nil {
@@ -173,7 +173,7 @@ func TestDB_InitPut(t *testing.T) {
 func TestDB_Inc(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	ctx := context.TODO()
 
 	if _, err := db.Inc(ctx, "aa", 100); err != nil {
@@ -189,7 +189,7 @@ func TestDB_Inc(t *testing.T) {
 func TestBatch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	b := &client.Batch{}
 	b.Get("aa")
@@ -208,7 +208,7 @@ func TestBatch(t *testing.T) {
 func TestDB_Scan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	b := &client.Batch{}
 	b.Put("aa", "1")
@@ -233,7 +233,7 @@ func TestDB_Scan(t *testing.T) {
 func TestDB_ReverseScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	b := &client.Batch{}
 	b.Put("aa", "1")
@@ -258,7 +258,7 @@ func TestDB_ReverseScan(t *testing.T) {
 func TestDB_Del(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	b := &client.Batch{}
 	b.Put("aa", "1")
@@ -285,7 +285,7 @@ func TestDB_Del(t *testing.T) {
 func TestTxn_Commit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	err := db.Txn(context.TODO(), func(ctx context.Context, txn *client.Txn) error {
 		b := txn.NewBatch()
@@ -313,7 +313,7 @@ func TestTxn_Commit(t *testing.T) {
 func TestDB_Put_insecure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, db := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	ctx := context.TODO()
 
 	if err := db.Put(context.TODO(), "aa", "1"); err != nil {
@@ -329,7 +329,7 @@ func TestDB_Put_insecure(t *testing.T) {
 func TestDebugName(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if err := db.Txn(context.TODO(), func(ctx context.Context, txn *client.Txn) error {
 		const expected = "unnamed"

--- a/pkg/internal/client/lease_test.go
+++ b/pkg/internal/client/lease_test.go
@@ -39,7 +39,7 @@ var (
 func TestAcquireAndRelease(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	ctx := context.Background()
 	manual := hlc.NewManualClock(123)
@@ -69,7 +69,7 @@ func TestAcquireAndRelease(t *testing.T) {
 func TestReacquireLease(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	ctx := context.Background()
 	manual := hlc.NewManualClock(123)
@@ -95,7 +95,7 @@ func TestReacquireLease(t *testing.T) {
 func TestExtendLease(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	ctx := context.Background()
 	manual := hlc.NewManualClock(123)
@@ -134,7 +134,7 @@ func TestExtendLease(t *testing.T) {
 func TestLeasesMultipleClients(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	ctx := context.Background()
 	manual1 := hlc.NewManualClock(123)

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -110,12 +110,13 @@ func (s *DBServer) Batch(
 		return br, err
 	}
 
-	err = s.stopper.RunTask(func() {
+	taskCtx := context.TODO()
+	err = s.stopper.RunTask(taskCtx, func() {
 		var pErr *roachpb.Error
 		// TODO(wiz): This is required to be a different context from the one
 		// provided by grpc since it has to last for the entire transaction and not
 		// just this one RPC call. See comment for (*TxnCoordSender).hearbeatLoop.
-		br, pErr = s.sender.Send(context.TODO(), *args)
+		br, pErr = s.sender.Send(taskCtx, *args)
 		if pErr != nil {
 			br = &roachpb.BatchResponse{}
 		}

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -111,7 +111,7 @@ func (s *DBServer) Batch(
 	}
 
 	taskCtx := context.TODO()
-	err = s.stopper.RunTask(taskCtx, func() {
+	err = s.stopper.RunTask(taskCtx, func(taskCtx context.Context) {
 		var pErr *roachpb.Error
 		// TODO(wiz): This is required to be a different context from the one
 		// provided by grpc since it has to last for the entire transaction and not

--- a/pkg/kv/db_test.go
+++ b/pkg/kv/db_test.go
@@ -63,7 +63,7 @@ func createTestClientForUser(
 func TestKVDBCoverage(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	ctx := context.TODO()
 
 	db := createTestClient(t, s)
@@ -169,7 +169,7 @@ func TestKVDBCoverage(t *testing.T) {
 func TestKVDBInternalMethods(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	testCases := []roachpb.Request{
 		&roachpb.HeartbeatTxnRequest{},
@@ -213,7 +213,7 @@ func TestKVDBInternalMethods(t *testing.T) {
 func TestKVDBTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	db := createTestClient(t, s)
 
@@ -260,7 +260,7 @@ func TestKVDBTransaction(t *testing.T) {
 func TestAuthentication(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	b1 := &client.Batch{}
 	b1.Put("a", "b")
@@ -309,7 +309,7 @@ func TestTxnDelRangeIntentResolutionCounts(t *testing.T) {
 		},
 	}
 	s, _, db := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	for _, abortTxn := range []bool{false, true} {
 		spanSize := int64(10)

--- a/pkg/kv/dist_sender_server_test.go
+++ b/pkg/kv/dist_sender_server_test.go
@@ -54,7 +54,7 @@ import (
 func TestRangeLookupWithOpenTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	db := createTestClient(t, s)
 
 	// Create an intent on the meta1 record by writing directly to the
@@ -220,7 +220,7 @@ func checkReverseScanResults(
 func TestMultiRangeBoundedBatchScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	ctx := context.TODO()
 
 	db := setupMultipleRanges(t, s, "a", "b", "c", "d", "e", "f")
@@ -291,7 +291,7 @@ func TestMultiRangeBoundedBatchScan(t *testing.T) {
 func TestMultiRangeBoundedBatchReverseScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	ctx := context.TODO()
 
 	db := setupMultipleRanges(t, s, "a", "b", "c", "d", "e", "f")
@@ -365,7 +365,7 @@ func TestMultiRangeBoundedBatchReverseScan(t *testing.T) {
 func TestMultiRangeBoundedBatchScanUnsortedOrder(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	db := setupMultipleRanges(t, s, "a", "b", "c", "d", "e", "f")
 	for _, key := range []string{"a1", "a2", "a3", "b1", "b2", "b3", "b4", "b5", "c1", "c2", "d1", "f1", "f2", "f3"} {
@@ -399,7 +399,7 @@ func TestMultiRangeBoundedBatchScanUnsortedOrder(t *testing.T) {
 func TestMultiRangeBoundedBatchScanSortedOverlapping(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	db := setupMultipleRanges(t, s, "a", "b", "c", "d", "e", "f")
 	for _, key := range []string{"a1", "a2", "a3", "b1", "b2", "c1", "c2", "d1", "f1", "f2", "f3"} {
@@ -463,7 +463,7 @@ func checkResumeSpanDelRangeResults(
 func TestMultiRangeBoundedBatchDelRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	db := setupMultipleRanges(t, s, "a", "b", "c", "d", "e", "f", "g", "h")
 
@@ -527,7 +527,7 @@ func TestMultiRangeBoundedBatchDelRange(t *testing.T) {
 func TestMultiRangeBoundedBatchDelRangeBoundary(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	db := setupMultipleRanges(t, s, "a", "b")
 	// Check that a
@@ -569,7 +569,7 @@ func TestMultiRangeBoundedBatchDelRangeBoundary(t *testing.T) {
 func TestMultiRangeBoundedBatchDelRangeOverlappingKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	db := setupMultipleRanges(t, s, "a", "b", "c", "d", "e", "f")
 
@@ -631,7 +631,7 @@ func TestMultiRangeBoundedBatchDelRangeOverlappingKeys(t *testing.T) {
 func TestMultiRangeEmptyAfterTruncate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	db := setupMultipleRanges(t, s, "c", "d")
 
 	// Delete the keys within a transaction. The range [c,d) doesn't have
@@ -650,7 +650,7 @@ func TestMultiRangeEmptyAfterTruncate(t *testing.T) {
 func TestMultiRequestBatchWithFwdAndReverseRequests(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	db := setupMultipleRanges(t, s, "a", "b")
 	b := &client.Batch{}
 	b.Header.MaxSpanRequestKeys = 100
@@ -668,7 +668,7 @@ func TestMultiRequestBatchWithFwdAndReverseRequests(t *testing.T) {
 func TestMultiRangeScanReverseScanDeleteResolve(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	db := setupMultipleRanges(t, s, "b")
 
 	// Write keys before, at, and after the split key.
@@ -723,7 +723,7 @@ func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	db := setupMultipleRanges(t, s, "b")
 
 	// Write keys "a" and "b", the latter of which is the first key in the
@@ -799,7 +799,7 @@ func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 func TestParallelSender(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	ctx := context.TODO()
 
 	db := createTestClient(t, s)
@@ -867,7 +867,7 @@ func initReverseScanTestEnv(s serverutils.TestServerInterface, t *testing.T) *cl
 func TestSingleRangeReverseScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	db := initReverseScanTestEnv(s, t)
 	ctx := context.TODO()
 
@@ -912,7 +912,7 @@ func TestSingleRangeReverseScan(t *testing.T) {
 func TestMultiRangeReverseScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	db := initReverseScanTestEnv(s, t)
 	ctx := context.TODO()
 
@@ -942,7 +942,7 @@ func TestMultiRangeReverseScan(t *testing.T) {
 func TestBatchPutWithConcurrentSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	db := createTestClient(t, s)
 
@@ -993,7 +993,7 @@ func TestBatchPutWithConcurrentSplit(t *testing.T) {
 func TestReverseScanWithSplitAndMerge(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	db := initReverseScanTestEnv(s, t)
 
 	// Case 1: An encounter with a range split.
@@ -1024,7 +1024,7 @@ func TestReverseScanWithSplitAndMerge(t *testing.T) {
 func TestBadRequest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	db := createTestClient(t, s)
 	ctx := context.TODO()
 
@@ -1056,7 +1056,7 @@ func TestBadRequest(t *testing.T) {
 func TestNoSequenceCachePutOnRangeMismatchError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	db := setupMultipleRanges(t, s, "b", "c")
 
 	// The requests in the transaction below will be chunked and
@@ -1112,7 +1112,7 @@ func TestPropagateTxnOnError(t *testing.T) {
 		}
 	s, _, _ := serverutils.StartServer(t,
 		base.TestServerArgs{Knobs: base.TestingKnobs{Store: &storeKnobs}})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	db := setupMultipleRanges(t, s, "b")
 

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -134,7 +134,7 @@ func (*legacyTransportAdapter) Close() {
 func TestSendRPCOrder(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 	rangeID := roachpb.RangeID(99)
@@ -368,7 +368,7 @@ var defaultMockRangeDescriptorDB = MockRangeDescriptorDB(func(key roachpb.RKey, 
 func TestOwnNodeCertain(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 	const expNodeID = 42
@@ -425,7 +425,7 @@ func TestOwnNodeCertain(t *testing.T) {
 func TestImmutableBatchArgs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 	var testFn rpcSendFn = func(
@@ -475,7 +475,7 @@ func TestImmutableBatchArgs(t *testing.T) {
 func TestRetryOnNotLeaseHolderError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 	leaseHolder := roachpb.ReplicaDescriptor{
@@ -528,7 +528,7 @@ func TestRetryOnNotLeaseHolderError(t *testing.T) {
 func TestRetryOnDescriptorLookupError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 	var testFn rpcSendFn = func(
@@ -607,7 +607,7 @@ func TestEvictOnFirstRangeGossip(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 
@@ -703,7 +703,7 @@ func TestEvictCacheOnError(t *testing.T) {
 
 	for i, tc := range testCases {
 		stopper := stop.NewStopper()
-		defer stopper.Stop()
+		defer stopper.Stop(context.TODO())
 
 		g, clock := makeGossip(t, stopper)
 		leaseHolder := roachpb.ReplicaDescriptor{
@@ -767,7 +767,7 @@ func TestEvictCacheOnError(t *testing.T) {
 func TestRetryOnWrongReplicaError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 	if err := g.AddInfoProto(gossip.KeyFirstRangeDescriptor, &testRangeDescriptor, time.Hour); err != nil {
@@ -850,7 +850,7 @@ func TestRetryOnWrongReplicaError(t *testing.T) {
 func TestRetryOnWrongReplicaErrorWithSuggestion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 	if err := g.AddInfoProto(gossip.KeyFirstRangeDescriptor, &testRangeDescriptor, time.Hour); err != nil {
@@ -926,7 +926,7 @@ func TestRetryOnWrongReplicaErrorWithSuggestion(t *testing.T) {
 func TestGetFirstRangeDescriptor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	n := simulation.NewNetwork(stopper, 3, true)
 	for _, node := range n.Nodes {
@@ -972,7 +972,7 @@ func TestGetFirstRangeDescriptor(t *testing.T) {
 func TestSendRPCRetry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{NodeID: 1}); err != nil {
@@ -1038,7 +1038,7 @@ func TestSendRPCRetry(t *testing.T) {
 func TestGetNodeDescriptor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 	ds := NewDistSender(DistSenderConfig{
@@ -1065,7 +1065,7 @@ func TestGetNodeDescriptor(t *testing.T) {
 func TestMultiRangeMergeStaleDescriptor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 	// Assume we have two ranges, [a-b) and [b-KeyMax).
@@ -1163,7 +1163,7 @@ func TestMultiRangeMergeStaleDescriptor(t *testing.T) {
 func TestRangeLookupOptionOnReverseScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 
@@ -1204,7 +1204,7 @@ func TestRangeLookupOptionOnReverseScan(t *testing.T) {
 func TestClockUpdateOnResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 	cfg := DistSenderConfig{
@@ -1255,7 +1255,7 @@ func TestClockUpdateOnResponse(t *testing.T) {
 func TestTruncateWithSpanAndDescriptor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{NodeID: 1}); err != nil {
@@ -1375,7 +1375,7 @@ func TestTruncateWithSpanAndDescriptor(t *testing.T) {
 func TestTruncateWithLocalSpanAndDescriptor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{NodeID: 1}); err != nil {
@@ -1498,7 +1498,7 @@ func TestTruncateWithLocalSpanAndDescriptor(t *testing.T) {
 func TestSequenceUpdate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{NodeID: 1}); err != nil {
@@ -1564,7 +1564,7 @@ func TestSequenceUpdate(t *testing.T) {
 func TestSequenceUpdateOnMultiRangeQueryLoop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{NodeID: 1}); err != nil {
@@ -1680,7 +1680,7 @@ func (s batchMethodsSlice) Less(i, j int) bool {
 func TestMultiRangeSplitEndTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 	testCases := []struct {
@@ -1809,7 +1809,7 @@ func TestMultiRangeSplitEndTransaction(t *testing.T) {
 func TestCountRanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 	// Create a slice of fake descriptors.
@@ -1948,7 +1948,7 @@ func getSlowLeaseHolderTransportFactory() func(SendOptions, *rpc.Context, Replic
 func TestSlowLeaseHolderRetry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	n := simulation.NewNetwork(stopper, 3, true)
 	for _, node := range n.Nodes {
@@ -2023,7 +2023,7 @@ func TestSenderTransport(t *testing.T) {
 func TestGatewayNodeID(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 	const expNodeID = 42

--- a/pkg/kv/range_iter_test.go
+++ b/pkg/kv/range_iter_test.go
@@ -77,7 +77,7 @@ func init() {
 func TestRangeIterForward(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 	ds := NewDistSender(DistSenderConfig{
@@ -107,7 +107,7 @@ func TestRangeIterForward(t *testing.T) {
 func TestRangeIterSeekForward(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 	ds := NewDistSender(DistSenderConfig{
@@ -140,7 +140,7 @@ func TestRangeIterSeekForward(t *testing.T) {
 func TestRangeIterReverse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 	ds := NewDistSender(DistSenderConfig{
@@ -170,7 +170,7 @@ func TestRangeIterReverse(t *testing.T) {
 func TestRangeIterSeekReverse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
 	ds := NewDistSender(DistSenderConfig{

--- a/pkg/kv/send_test.go
+++ b/pkg/kv/send_test.go
@@ -80,7 +80,7 @@ func TestSendToOneClient(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	rpcContext := rpc.NewContext(
 		log.AmbientContext{},
@@ -185,7 +185,7 @@ func TestSendNext_AllSlow(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	doneChans, sendChan, stopper := setupSendNextTest(t)
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	// Now that all replicas have been contacted, let one finish.
 	doneChans[1] <- BatchCall{
@@ -214,7 +214,7 @@ func TestSendNext_RPCErrorThenSuccess(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	doneChans, sendChan, stopper := setupSendNextTest(t)
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	// Now that all replicas have been contacted, let two finish with
 	// retryable errors.
@@ -252,7 +252,7 @@ func TestSendNext_AllRPCErrors(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	doneChans, sendChan, stopper := setupSendNextTest(t)
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	// All replicas finish with RPC errors.
 	for i := 0; i <= 2; i++ {
@@ -273,7 +273,7 @@ func TestSendNext_RetryableApplicationErrorThenSuccess(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	doneChans, sendChan, stopper := setupSendNextTest(t)
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	// One replica finishes with a retryable error.
 	doneChans[1] <- BatchCall{
@@ -303,7 +303,7 @@ func TestSendNext_AllRetryableApplicationErrors(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	doneChans, sendChan, stopper := setupSendNextTest(t)
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	// All replicas finish with a retryable error.
 	for _, ch := range doneChans {
@@ -331,7 +331,7 @@ func TestSendNext_NonRetryableApplicationError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	doneChans, sendChan, stopper := setupSendNextTest(t)
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	// One replica finishes with a non-retryable error.
 	doneChans[1] <- BatchCall{
@@ -389,7 +389,7 @@ func TestComplexScenarios(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	nodeContext := rpc.NewContext(
 		log.AmbientContext{},

--- a/pkg/kv/transport_race.go
+++ b/pkg/kv/transport_race.go
@@ -59,13 +59,13 @@ func grpcTransportFactory(
 	opts SendOptions, rpcContext *rpc.Context, replicas ReplicaSlice, args roachpb.BatchRequest,
 ) (Transport, error) {
 	if atomic.AddInt32(&running, 1) <= 1 {
-		rpcContext.Stopper.RunWorker(context.TODO(), func() {
+		rpcContext.Stopper.RunWorker(context.TODO(), func(ctx context.Context) {
 			var iters int
 			var curIdx int
 			defer func() {
 				atomic.StoreInt32(&running, 0)
 				log.Infof(
-					context.TODO(),
+					ctx,
 					"transport race promotion: ran %d iterations on up to %d requests",
 					iters, curIdx+1,
 				)

--- a/pkg/kv/transport_race.go
+++ b/pkg/kv/transport_race.go
@@ -59,7 +59,7 @@ func grpcTransportFactory(
 	opts SendOptions, rpcContext *rpc.Context, replicas ReplicaSlice, args roachpb.BatchRequest,
 ) (Transport, error) {
 	if atomic.AddInt32(&running, 1) <= 1 {
-		rpcContext.Stopper.RunWorker(func() {
+		rpcContext.Stopper.RunWorker(context.TODO(), func() {
 			var iters int
 			var curIdx int
 			defer func() {

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -199,8 +199,9 @@ func NewTxnCoordSender(
 	}
 	tc.txnMu.txns = map[uuid.UUID]*txnMetadata{}
 
-	tc.stopper.RunWorker(func() {
-		tc.printStatsLoop(tc.AnnotateCtx(context.Background()))
+	ctx := tc.AnnotateCtx(context.Background())
+	tc.stopper.RunWorker(ctx, func() {
+		tc.printStatsLoop(ctx)
 	})
 	return tc
 }

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -200,7 +200,7 @@ func NewTxnCoordSender(
 	tc.txnMu.txns = map[uuid.UUID]*txnMetadata{}
 
 	ctx := tc.AnnotateCtx(context.Background())
-	tc.stopper.RunWorker(ctx, func() {
+	tc.stopper.RunWorker(ctx, func(ctx context.Context) {
 		tc.printStatsLoop(ctx)
 	})
 	return tc

--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -888,7 +888,7 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 		key := roachpb.Key("test-key")
 		_, err := txn.Get(context.TODO(), key)
 		teardownHeartbeats(ts)
-		stopper.Stop()
+		stopper.Stop(context.TODO())
 
 		if test.pErr != nil && err == nil {
 			t.Fatalf("expected an error")
@@ -1024,7 +1024,7 @@ func TestTxnCoordSenderSingleRoundtripTxn(t *testing.T) {
 	// Stop the stopper manually, prior to trying the transaction. This has the
 	// effect of returning a NodeUnavailableError for any attempts at launching
 	// a heartbeat goroutine.
-	stopper.Stop()
+	stopper.Stop(context.TODO())
 
 	var ba roachpb.BatchRequest
 	key := roachpb.Key("test")
@@ -1044,7 +1044,7 @@ func TestTxnCoordSenderSingleRoundtripTxn(t *testing.T) {
 func TestTxnCoordSenderErrorWithIntent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	manual := hlc.NewManualClock(123)
 	clock := hlc.NewClock(manual.UnixNano, 20*time.Nanosecond)
 
@@ -1160,7 +1160,7 @@ func TestTxnCoordSenderNoDuplicateIntents(t *testing.T) {
 		MakeTxnMetrics(metric.TestSampleInterval),
 	)
 
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	defer teardownHeartbeats(ts)
 
 	db := client.NewDB(ts, clock)

--- a/pkg/migrations/migrations_test.go
+++ b/pkg/migrations/migrations_test.go
@@ -146,7 +146,7 @@ func TestEnsureMigrations(t *testing.T) {
 		leaseManager: &fakeLeaseManager{},
 		db:           db,
 	}
-	defer mgr.stopper.Stop()
+	defer mgr.stopper.Stop(context.TODO())
 
 	fnGotCalled := false
 	fnGotCalledDescriptor := migrationDescriptor{
@@ -302,7 +302,7 @@ func TestDBErrors(t *testing.T) {
 		leaseManager: &fakeLeaseManager{},
 		db:           db,
 	}
-	defer mgr.stopper.Stop()
+	defer mgr.stopper.Stop(context.TODO())
 
 	migration := noopMigration1
 	backwardCompatibleMigrations = []migrationDescriptor{migration}
@@ -365,7 +365,7 @@ func TestLeaseErrors(t *testing.T) {
 		},
 		db: db,
 	}
-	defer mgr.stopper.Stop()
+	defer mgr.stopper.Stop(context.TODO())
 
 	migration := noopMigration1
 	backwardCompatibleMigrations = []migrationDescriptor{migration}
@@ -391,7 +391,7 @@ func TestLeaseExpiration(t *testing.T) {
 		leaseManager: &fakeLeaseManager{leaseTimeRemaining: time.Nanosecond},
 		db:           db,
 	}
-	defer mgr.stopper.Stop()
+	defer mgr.stopper.Stop(context.TODO())
 
 	oldLeaseRefreshInterval := leaseRefreshInterval
 	leaseRefreshInterval = time.Microsecond

--- a/pkg/rpc/clock_offset_test.go
+++ b/pkg/rpc/clock_offset_test.go
@@ -166,7 +166,7 @@ func TestIsHealthyOffsetInterval(t *testing.T) {
 func TestClockOffsetMetrics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	clock := hlc.NewClock(hlc.NewManualClock(123).UnixNano, 20*time.Nanosecond)
 	monitor := newRemoteClockMonitor(clock, time.Hour, 0)

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -172,7 +172,7 @@ func NewContext(
 	ctx.heartbeatTimeout = 2 * defaultHeartbeatInterval
 	ctx.conns.cache = make(map[string]*connMeta)
 
-	stopper.RunWorker(ctx.masterCtx, func() {
+	stopper.RunWorker(ctx.masterCtx, func(context.Context) {
 		<-stopper.ShouldQuiesce()
 
 		cancel()
@@ -292,11 +292,11 @@ func (ctx *Context) GRPCDial(target string, opts ...grpc.DialOption) (*grpc.Clie
 		}
 		meta.conn, meta.dialErr = grpc.DialContext(ctx.masterCtx, target, dialOpts...)
 		if meta.dialErr == nil {
-			if err := ctx.Stopper.RunTask(ctx.masterCtx, func() {
-				ctx.Stopper.RunWorker(ctx.masterCtx, func() {
+			if err := ctx.Stopper.RunTask(ctx.masterCtx, func(masterCtx context.Context) {
+				ctx.Stopper.RunWorker(masterCtx, func(masterCtx context.Context) {
 					err := ctx.runHeartbeat(meta, target)
 					if err != nil && !grpcutil.IsClosedConnection(err) {
-						log.Errorf(ctx.masterCtx, "removing connection to %s due to error: %s", target, err)
+						log.Errorf(masterCtx, "removing connection to %s due to error: %s", target, err)
 					}
 					ctx.removeConn(target, meta)
 				})

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -249,14 +249,14 @@ func TestHeartbeatHealthTransport(t *testing.T) {
 		mu.conns = append(mu.conns, conn)
 		mu.Unlock()
 	}}
-	stopper.RunWorker(context.TODO(), func() {
+	stopper.RunWorker(context.TODO(), func(context.Context) {
 		<-stopper.ShouldQuiesce()
 		netutil.FatalIfUnexpected(ln.Close())
 		<-stopper.ShouldStop()
 		s.Stop()
 	})
 
-	stopper.RunWorker(context.TODO(), func() {
+	stopper.RunWorker(context.TODO(), func(context.Context) {
 		netutil.FatalIfUnexpected(s.Serve(ln))
 	})
 

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -71,7 +71,7 @@ func TestHeartbeatCB(t *testing.T) {
 	for _, compression := range []bool{false, true} {
 		t.Run("", func(t *testing.T) {
 			stopper := stop.NewStopper()
-			defer stopper.Stop()
+			defer stopper.Stop(context.TODO())
 
 			clock := hlc.NewClock(time.Unix(0, 20).UnixNano, time.Nanosecond)
 			serverCtx := NewContext(log.AmbientContext{}, testutils.NewNodeTestBaseContext(), clock, stopper)
@@ -113,7 +113,7 @@ func TestHeartbeatHealth(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	// Can't be zero because that'd be an empty offset.
 	clock := hlc.NewClock(time.Unix(0, 1).UnixNano, time.Nanosecond)
@@ -224,7 +224,7 @@ func TestHeartbeatHealthTransport(t *testing.T) {
 	}
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	// Can't be zero because that'd be an empty offset.
 	clock := hlc.NewClock(time.Unix(0, 1).UnixNano, time.Nanosecond)
@@ -249,14 +249,14 @@ func TestHeartbeatHealthTransport(t *testing.T) {
 		mu.conns = append(mu.conns, conn)
 		mu.Unlock()
 	}}
-	stopper.RunWorker(func() {
+	stopper.RunWorker(context.TODO(), func() {
 		<-stopper.ShouldQuiesce()
 		netutil.FatalIfUnexpected(ln.Close())
 		<-stopper.ShouldStop()
 		s.Stop()
 	})
 
-	stopper.RunWorker(func() {
+	stopper.RunWorker(context.TODO(), func() {
 		netutil.FatalIfUnexpected(s.Serve(ln))
 	})
 
@@ -345,7 +345,7 @@ func TestOffsetMeasurement(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	serverTime := time.Unix(0, 20)
 	serverClock := hlc.NewClock(serverTime.UnixNano, time.Nanosecond)
@@ -402,7 +402,7 @@ func TestFailedOffsetMeasurement(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	// Can't be zero because that'd be an empty offset.
 	clock := hlc.NewClock(time.Unix(0, 1).UnixNano, time.Nanosecond)
@@ -480,7 +480,7 @@ func TestRemoteOffsetUnhealthy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	const maxOffset = 100 * time.Millisecond
 
@@ -564,7 +564,7 @@ func TestGRPCKeepaliveFailureFailsInflightRPCs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	clock := hlc.NewClock(time.Unix(0, 20).UnixNano, time.Nanosecond)
 	serverCtx := NewContext(

--- a/pkg/security/certs_rotation_test.go
+++ b/pkg/security/certs_rotation_test.go
@@ -26,6 +26,8 @@ import (
 	"syscall"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -61,7 +63,7 @@ func TestRotateCerts(t *testing.T) {
 		SSLCertsDir: certsDir,
 	}
 	s, _, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	// Client test function.
 	clientTest := func(httpClient http.Client) error {

--- a/pkg/security/certs_test.go
+++ b/pkg/security/certs_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -216,7 +218,7 @@ func TestUseCerts(t *testing.T) {
 		SSLCertsDir: certsDir,
 	}
 	s, _, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	// Insecure mode.
 	clientContext := testutils.NewNodeTestBaseContext()

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -909,9 +909,9 @@ func (s *adminServer) Drain(req *serverpb.DrainRequest, stream serverpb.Admin_Dr
 	}
 
 	s.server.grpc.Stop()
-	go s.server.stopper.Stop()
 
 	ctx := stream.Context()
+	go s.server.stopper.Stop(ctx)
 
 	select {
 	case <-s.server.stopper.IsStopped():

--- a/pkg/server/admin_cluster_test.go
+++ b/pkg/server/admin_cluster_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -45,7 +46,7 @@ func TestAdminAPITableStats(t *testing.T) {
 			ScanMaxIdleTime: time.Millisecond,
 		},
 	})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 	server0 := tc.Server(0)
 
 	// Create clients (SQL, HTTP) connected to server 0.
@@ -147,7 +148,7 @@ func TestAdminAPITableStats(t *testing.T) {
 func TestLivenessAPI(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 
 	startTime := tc.Server(0).Clock().PhysicalNow()
 

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -101,7 +101,7 @@ func debugURL(s serverutils.TestServerInterface) string {
 func TestAdminDebugExpVar(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	jI, err := getJSON(s, debugURL(s)+"vars")
 	if err != nil {
@@ -121,7 +121,7 @@ func TestAdminDebugExpVar(t *testing.T) {
 func TestAdminDebugMetrics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	jI, err := getJSON(s, debugURL(s)+"metrics")
 	if err != nil {
@@ -141,7 +141,7 @@ func TestAdminDebugMetrics(t *testing.T) {
 func TestAdminDebugPprof(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	body, err := getText(s, debugURL(s)+"pprof/block")
 	if err != nil {
@@ -157,7 +157,7 @@ func TestAdminDebugPprof(t *testing.T) {
 func TestAdminDebugTrace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	tc := []struct {
 		segment, search string
@@ -182,7 +182,7 @@ func TestAdminDebugTrace(t *testing.T) {
 func TestAdminDebugRedirect(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	expURL := debugURL(s)
 	origURL := expURL + "incorrect"
@@ -222,7 +222,7 @@ func TestAdminDebugRedirect(t *testing.T) {
 func TestAdminAPIDatabases(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	ts := s.(*TestServer)
 
 	ac := log.AmbientContext{Tracer: tracing.NewTracer()}
@@ -317,7 +317,7 @@ func TestAdminAPIDatabases(t *testing.T) {
 func TestAdminAPIDatabaseDoesNotExist(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	const errPattern = "database.+does not exist"
 	if err := getAdminJSONProto(s, "databases/I_DO_NOT_EXIST", nil); !testutils.IsError(err, errPattern) {
@@ -328,7 +328,7 @@ func TestAdminAPIDatabaseDoesNotExist(t *testing.T) {
 func TestAdminAPIDatabaseVirtual(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	const errPattern = `\\"information_schema\\" is a virtual schema`
 	if err := getAdminJSONProto(s, "databases/information_schema", nil); !testutils.IsError(err, errPattern) {
@@ -339,7 +339,7 @@ func TestAdminAPIDatabaseVirtual(t *testing.T) {
 func TestAdminAPIDatabaseSQLInjection(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	const fakedb = "system;DROP DATABASE system;"
 	const path = "databases/" + fakedb
@@ -352,7 +352,7 @@ func TestAdminAPIDatabaseSQLInjection(t *testing.T) {
 func TestAdminAPITableDoesNotExist(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	const fakename = "I_DO_NOT_EXIST"
 	const badDBPath = "databases/" + fakename + "/tables/foo"
@@ -371,7 +371,7 @@ func TestAdminAPITableDoesNotExist(t *testing.T) {
 func TestAdminAPITableVirtual(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	const virtual = "information_schema"
 	const badDBPath = "databases/" + virtual + "/tables/tables"
@@ -384,7 +384,7 @@ func TestAdminAPITableVirtual(t *testing.T) {
 func TestAdminAPITableSQLInjection(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	const fakeTable = "users;DROP DATABASE system;"
 	const path = "databases/system/tables/" + fakeTable
@@ -406,7 +406,7 @@ func TestAdminAPITableDetails(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-			defer s.Stopper().Stop()
+			defer s.Stopper().Stop(context.TODO())
 			ts := s.(*TestServer)
 
 			escDBName := parser.Name(tc.dbName).String()
@@ -550,7 +550,7 @@ func TestAdminAPITableDetails(t *testing.T) {
 func TestAdminAPIZoneDetails(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	ts := s.(*TestServer)
 
 	// Create database and table.
@@ -660,7 +660,7 @@ func TestAdminAPIZoneDetails(t *testing.T) {
 func TestAdminAPIUsers(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	ts := s.(*TestServer)
 
 	// Create sample users.
@@ -706,7 +706,7 @@ VALUES ('admin', 'abc'), ('bob', 'xyz')`
 func TestAdminAPIEvents(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	ts := s.(*TestServer)
 
 	ac := log.AmbientContext{Tracer: tracing.NewTracer()}
@@ -808,7 +808,7 @@ func TestAdminAPIEvents(t *testing.T) {
 func TestAdminAPIUIData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	start := timeutil.Now()
 
@@ -911,7 +911,7 @@ func TestAdminAPIUIData(t *testing.T) {
 func TestClusterAPI(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	// We need to retry, because the cluster ID isn't set until after
 	// bootstrapping.
@@ -930,7 +930,7 @@ func TestClusterAPI(t *testing.T) {
 func TestHealthAPI(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	// We need to retry because the node ID isn't set until after
 	// bootstrapping.

--- a/pkg/server/authentication_test.go
+++ b/pkg/server/authentication_test.go
@@ -24,6 +24,8 @@ import (
 	"net/http"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -86,7 +88,7 @@ func (insecureCtx) HTTPRequestScheme() string {
 func TestSSLEnforcement(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	// HTTPS with client certs for security.RootUser.
 	rootCertsContext := testutils.NewTestBaseContext(security.RootUser)

--- a/pkg/server/debug_test.go
+++ b/pkg/server/debug_test.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -33,7 +35,7 @@ func TestDebugRemote(t *testing.T) {
 	// force listening on a non-local address. We can't use certs because the
 	// test certs are only valid for localhost.
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{HTTPAddr: ":0", Insecure: true})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	ts := s.(*TestServer)
 
 	httpClient, err := ts.GetHTTPClient()

--- a/pkg/server/intent_test.go
+++ b/pkg/server/intent_test.go
@@ -117,7 +117,7 @@ func TestIntentResolution(t *testing.T) {
 
 			s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{
 				Knobs: base.TestingKnobs{Store: &storeKnobs}})
-			defer s.Stopper().Stop()
+			defer s.Stopper().Stop(context.TODO())
 			// Split the Range. This should not have any asynchronous intents.
 			if err := kvDB.AdminSplit(context.TODO(), splitKey); err != nil {
 				t.Fatal(err)

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -195,7 +195,7 @@ func bootstrapCluster(
 ) (uuid.UUID, error) {
 	clusterID := uuid.MakeV4()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	// Make sure that the store config has a valid clock and that it doesn't
 	// try to use gossip, since that can introduce race conditions.
@@ -636,8 +636,8 @@ func (n *Node) connectGossip(ctx context.Context) error {
 // startGossip loops on a periodic ticker to gossip node-related
 // information. Starts a goroutine to loop until the node is closed.
 func (n *Node) startGossip(stopper *stop.Stopper) {
-	stopper.RunWorker(func() {
-		ctx := n.AnnotateCtx(context.Background())
+	ctx := n.AnnotateCtx(context.Background())
+	stopper.RunWorker(ctx, func() {
 		// This should always return immediately and acts as a sanity check that we
 		// don't try to gossip before we're connected.
 		select {
@@ -692,8 +692,8 @@ func (n *Node) gossipStores(ctx context.Context) {
 // store to compute the value of metrics which cannot be incrementally
 // maintained.
 func (n *Node) startComputePeriodicMetrics(stopper *stop.Stopper, interval time.Duration) {
-	stopper.RunWorker(func() {
-		ctx := n.AnnotateCtx(context.Background())
+	ctx := n.AnnotateCtx(context.Background())
+	stopper.RunWorker(ctx, func() {
 		// Compute periodic stats at the same frequency as metrics are sampled.
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
@@ -726,7 +726,7 @@ func (n *Node) computePeriodicMetrics(ctx context.Context, tick int) error {
 func (n *Node) startWriteSummaries(frequency time.Duration) {
 	ctx := log.WithLogTag(n.AnnotateCtx(context.Background()), "summaries", nil)
 	// Immediately record summaries once on server startup.
-	n.stopper.RunWorker(func() {
+	n.stopper.RunWorker(ctx, func() {
 		// Write a status summary immediately; this helps the UI remain
 		// responsive when new nodes are added.
 		if err := n.writeSummaries(ctx); err != nil {
@@ -751,7 +751,7 @@ func (n *Node) startWriteSummaries(frequency time.Duration) {
 // NodeStatusRecorder and persists them to the cockroach data store.
 func (n *Node) writeSummaries(ctx context.Context) error {
 	var err error
-	if runErr := n.stopper.RunTask(func() {
+	if runErr := n.stopper.RunTask(ctx, func() {
 		err = n.recorder.WriteStatusSummary(ctx, n.storeCfg.DB)
 	}); runErr != nil {
 		err = runErr
@@ -774,7 +774,7 @@ func (n *Node) recordJoinEvent() {
 		lastUp = n.startedAt
 	}
 
-	n.stopper.RunWorker(func() {
+	n.stopper.RunWorker(context.TODO(), func() {
 		ctx, span := n.AnnotateCtxWithSpan(context.Background(), "record-join-event")
 		defer span.Finish()
 		retryOpts := base.DefaultRetryOptions()
@@ -826,7 +826,7 @@ func (n *Node) batchInternal(
 
 	var br *roachpb.BatchResponse
 
-	if err := n.stopper.RunTaskWithErr(func() error {
+	if err := n.stopper.RunTaskWithErr(ctx, func() error {
 		var finishSpan func(*roachpb.BatchResponse)
 		// Shadow ctx from the outer function. Written like this to pass the linter.
 		ctx := ctx

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -175,7 +175,7 @@ func (s keySlice) Less(i, j int) bool { return bytes.Compare(s[i], s[j]) < 0 }
 func TestBootstrapCluster(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 	stopper.AddCloser(e)
 	if _, err := bootstrapCluster(
@@ -239,7 +239,7 @@ func TestBootstrapNewStore(t *testing.T) {
 		roachpb.Locality{},
 		t,
 	)
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	// Non-initialized stores (in this case the new in-memory-based
 	// store) will be bootstrapped by the node upon start. This happens
@@ -268,7 +268,7 @@ func TestBootstrapNewStore(t *testing.T) {
 func TestNodeJoin(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	engineStopper := stop.NewStopper()
-	defer engineStopper.Stop()
+	defer engineStopper.Stop(context.TODO())
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 	engineStopper.AddCloser(e)
 	if _, err := bootstrapCluster(
@@ -286,7 +286,7 @@ func TestNodeJoin(t *testing.T) {
 		roachpb.Locality{},
 		t,
 	)
-	defer stopper1.Stop()
+	defer stopper1.Stop(context.TODO())
 
 	// Create a new node.
 	e2 := engine.NewInMem(roachpb.Attributes{}, 1<<20)
@@ -299,7 +299,7 @@ func TestNodeJoin(t *testing.T) {
 		roachpb.Locality{},
 		t,
 	)
-	defer stopper2.Stop()
+	defer stopper2.Stop(context.TODO())
 
 	// Verify new node is able to bootstrap its store.
 	testutils.SucceedsSoon(t, func() error {
@@ -340,7 +340,7 @@ func TestNodeJoinSelf(t *testing.T) {
 	defer e.Close()
 	engines := []engine.Engine{e}
 	_, addr, _, node, stopper := createTestNode(util.TestAddr, engines, util.TestAddr, t)
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	err := node.start(context.Background(), addr, engines, roachpb.Attributes{}, roachpb.Locality{})
 	if err != errCannotJoinSelf {
 		t.Fatalf("expected err %s; got %s", errCannotJoinSelf, err)
@@ -372,7 +372,7 @@ func TestCorruptedClusterID(t *testing.T) {
 
 	engines := []engine.Engine{e}
 	_, serverAddr, _, node, stopper := createTestNode(util.TestAddr, engines, nil, t)
-	stopper.Stop()
+	stopper.Stop(context.TODO())
 	if err := node.start(context.Background(), serverAddr, engines, roachpb.Attributes{}, roachpb.Locality{}); !testutils.IsError(err, "unidentified store") {
 		t.Errorf("unexpected error %v", err)
 	}
@@ -506,7 +506,7 @@ func TestStatusSummaries(t *testing.T) {
 	srv, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{
 		DisableEventLog: true,
 	})
-	defer srv.Stopper().Stop()
+	defer srv.Stopper().Stop(context.TODO())
 	ts := srv.(*TestServer)
 	ctx := context.TODO()
 
@@ -694,7 +694,7 @@ func TestStartNodeWithLocality(t *testing.T) {
 			locality,
 			t,
 		)
-		defer stopper.Stop()
+		defer stopper.Stop(context.TODO())
 
 		// Check the node to make sure the locality was propagated to its
 		// nodeDescriptor.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -493,7 +493,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 	workersCtx := s.AnnotateCtx(context.Background())
 
-	s.stopper.RunWorker(func() {
+	s.stopper.RunWorker(workersCtx, func() {
 		<-s.stopper.ShouldQuiesce()
 		if err := httpLn.Close(); err != nil {
 			log.Fatal(workersCtx, err)
@@ -505,22 +505,22 @@ func (s *Server) Start(ctx context.Context) error {
 		clearL := httpMux.Match(cmux.HTTP1())
 		tlsL := httpMux.Match(cmux.Any())
 
-		s.stopper.RunWorker(func() {
+		s.stopper.RunWorker(workersCtx, func() {
 			netutil.FatalIfUnexpected(httpMux.Serve())
 		})
 
-		s.stopper.RunWorker(func() {
+		s.stopper.RunWorker(workersCtx, func() {
 			netutil.FatalIfUnexpected(plainRedirectServer.Serve(clearL))
 		})
 
 		httpLn = tls.NewListener(tlsL, tlsConfig)
 	}
 
-	s.stopper.RunWorker(func() {
+	s.stopper.RunWorker(workersCtx, func() {
 		netutil.FatalIfUnexpected(httpServer.Serve(httpLn))
 	})
 
-	s.stopper.RunWorker(func() {
+	s.stopper.RunWorker(workersCtx, func() {
 		<-s.stopper.ShouldQuiesce()
 		netutil.FatalIfUnexpected(anyL.Close())
 		<-s.stopper.ShouldStop()
@@ -531,7 +531,7 @@ func (s *Server) Start(ctx context.Context) error {
 		})
 	})
 
-	s.stopper.RunWorker(func() {
+	s.stopper.RunWorker(workersCtx, func() {
 		netutil.FatalIfUnexpected(s.grpc.Serve(anyL))
 	})
 
@@ -579,16 +579,16 @@ func (s *Server) Start(ctx context.Context) error {
 		}
 	}
 
-	s.stopper.RunWorker(func() {
+	pgCtx := s.pgServer.AmbientCtx.AnnotateCtx(context.Background())
+	s.stopper.RunWorker(pgCtx, func() {
 		select {
 		case <-serveSQL:
 		case <-s.stopper.ShouldQuiesce():
 			return
 		}
-		pgCtx := s.pgServer.AmbientCtx.AnnotateCtx(context.Background())
-		netutil.FatalIfUnexpected(httpServer.ServeWith(s.stopper, pgL, func(conn net.Conn) {
+		netutil.FatalIfUnexpected(httpServer.ServeWith(pgCtx, s.stopper, pgL, func(conn net.Conn) {
 			connCtx := log.WithLogTagStr(pgCtx, "client", conn.RemoteAddr().String())
-			setTCPKeepAlive(pgCtx, conn)
+			setTCPKeepAlive(connCtx, conn)
 
 			if err := s.pgServer.ServeConn(connCtx, conn); err != nil && !netutil.IsClosedConnection(err) {
 				// Report the error on this connection's context, so that we
@@ -701,7 +701,7 @@ func (s *Server) Start(ctx context.Context) error {
 	log.Infof(ctx, "starting %s server at %s", s.cfg.HTTPRequestScheme(), unresolvedHTTPAddr)
 	log.Infof(ctx, "starting grpc/postgres server at %s", unresolvedListenAddr)
 	log.Infof(ctx, "advertising CockroachDB node at %s", unresolvedAdvertAddr)
-	s.stopper.RunWorker(func() {
+	s.stopper.RunWorker(workersCtx, func() {
 		serveOnMux.Do(func() {
 			netutil.FatalIfUnexpected(m.Serve())
 		})
@@ -716,23 +716,24 @@ func (s *Server) Start(ctx context.Context) error {
 			return err
 		}
 
-		s.stopper.RunWorker(func() {
+		s.stopper.RunWorker(workersCtx, func() {
 			<-s.stopper.ShouldQuiesce()
 			if err := unixLn.Close(); err != nil {
 				log.Fatal(workersCtx, err)
 			}
 		})
 
-		s.stopper.RunWorker(func() {
+		pgCtx := s.pgServer.AmbientCtx.AnnotateCtx(context.Background())
+		s.stopper.RunWorker(pgCtx, func() {
 			select {
 			case <-serveSQL:
 			case <-s.stopper.ShouldQuiesce():
 				return
 			}
-			pgCtx := s.pgServer.AmbientCtx.AnnotateCtx(context.Background())
-			netutil.FatalIfUnexpected(httpServer.ServeWith(s.stopper, unixLn, func(conn net.Conn) {
+			netutil.FatalIfUnexpected(httpServer.ServeWith(pgCtx, s.stopper, unixLn, func(conn net.Conn) {
 				connCtx := log.WithLogTagStr(pgCtx, "client", conn.RemoteAddr().String())
-				if err := s.pgServer.ServeConn(connCtx, conn); err != nil && !netutil.IsClosedConnection(err) {
+				if err := s.pgServer.ServeConn(connCtx, conn); err != nil &&
+					!netutil.IsClosedConnection(err) {
 					// Report the error on this connection's context, so that we
 					// know which remote client caused the error when looking at
 					// the logs.
@@ -888,9 +889,8 @@ func (s *Server) Undrain(off []serverpb.DrainMode) []serverpb.DrainMode {
 // runtime stat sampler to sample the environment.
 func (s *Server) startSampleEnvironment(frequency time.Duration) {
 	// Immediately record summaries once on server startup.
-	s.stopper.RunWorker(func() {
-		ctx := s.AnnotateCtx(context.Background())
-
+	ctx := s.AnnotateCtx(context.Background())
+	s.stopper.RunWorker(ctx, func() {
 		ticker := time.NewTicker(frequency)
 		defer ticker.Stop()
 		for {
@@ -906,7 +906,7 @@ func (s *Server) startSampleEnvironment(frequency time.Duration) {
 
 // Stop stops the server.
 func (s *Server) Stop() {
-	s.stopper.Stop()
+	s.stopper.Stop(context.TODO())
 }
 
 // ServeHTTP is necessary to implement the http.Handler interface.

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -58,7 +58,7 @@ func TestSelfBootstrap(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 }
 
 // TestServerStartClock tests that a server's clock is not pushed out of thin
@@ -79,7 +79,7 @@ func TestServerStartClock(t *testing.T) {
 		},
 	}
 	s, _, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	// Run a command so that we are sure to touch the timestamp cache. This is
 	// actually not needed because other commands run during server
@@ -111,7 +111,7 @@ func TestPlainHTTPServer(t *testing.T) {
 		// The default context uses embedded certs.
 		Insecure: true,
 	})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	var data serverpb.JSONResponse
 	testutils.SucceedsSoon(t, func() error {
@@ -128,7 +128,7 @@ func TestPlainHTTPServer(t *testing.T) {
 func TestSecureHTTPRedirect(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	ts := s.(*TestServer)
 
 	httpClient, err := s.GetHTTPClient()
@@ -178,7 +178,7 @@ func TestSecureHTTPRedirect(t *testing.T) {
 func TestAcceptEncoding(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	client, err := s.GetHTTPClient()
 	if err != nil {
 		t.Fatal(err)
@@ -232,7 +232,7 @@ func TestAcceptEncoding(t *testing.T) {
 func TestMultiRangeScanDeleteRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, db := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	ts := s.(*TestServer)
 	tds := db.GetSender()
 
@@ -320,7 +320,7 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 
 	for i, tc := range testCases {
 		s, _, db := serverutils.StartServer(t, base.TestServerArgs{})
-		defer s.Stopper().Stop()
+		defer s.Stopper().Stop(context.TODO())
 		ts := s.(*TestServer)
 		tds := db.GetSender()
 
@@ -364,7 +364,7 @@ func TestSystemConfigGossip(t *testing.T) {
 	t.Skip("#12351")
 
 	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	ts := s.(*TestServer)
 	ctx := context.TODO()
 
@@ -461,7 +461,7 @@ func TestOfficializeAddr(t *testing.T) {
 func TestClusterStores(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := serverutils.StartTestCluster(t, 2, base.TestClusterArgs{})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 
 	testutils.SucceedsSoon(t, func() error {
 		stores := tc.Server(0).(*TestServer).ClusterStores()

--- a/pkg/server/settingsworker.go
+++ b/pkg/server/settingsworker.go
@@ -104,9 +104,9 @@ func (s *Server) refreshSettings() {
 		return nil
 	}
 
-	s.stopper.RunWorker(func() {
+	ctx := s.AnnotateCtx(context.Background())
+	s.stopper.RunWorker(ctx, func() {
 		gossipUpdateC := s.gossip.RegisterSystemConfigChannel()
-		ctx := s.AnnotateCtx(context.Background())
 		// No new settings can be defined beyond this point.
 		settings.Freeze()
 		for {

--- a/pkg/server/settingsworker.go
+++ b/pkg/server/settingsworker.go
@@ -105,7 +105,7 @@ func (s *Server) refreshSettings() {
 	}
 
 	ctx := s.AnnotateCtx(context.Background())
-	s.stopper.RunWorker(ctx, func() {
+	s.stopper.RunWorker(ctx, func(ctx context.Context) {
 		gossipUpdateC := s.gossip.RegisterSystemConfigChannel()
 		// No new settings can be defined beyond this point.
 		settings.Freeze()

--- a/pkg/server/settingsworker_test.go
+++ b/pkg/server/settingsworker_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -38,7 +39,7 @@ func TestSettingsRefresh(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	s, rawDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	db := sqlutils.MakeSQLRunner(t, rawDB)
 

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -60,7 +60,7 @@ func getStatusJSONProto(
 func TestStatusLocalStacks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	// Verify match with at least two goroutine stacks.
 	re := regexp.MustCompile("(?s)goroutine [0-9]+.*goroutine [0-9]+.*")
@@ -81,7 +81,7 @@ func TestStatusLocalStacks(t *testing.T) {
 func TestStatusJson(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	ts := s.(*TestServer)
 
 	nodeID := ts.Gossip().NodeID.Get()
@@ -128,7 +128,7 @@ func TestStatusJson(t *testing.T) {
 func TestStatusGossipJson(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	var data gossip.InfoStatus
 	if err := getStatusJSONProto(s, "gossip/local", &data); err != nil {
@@ -195,7 +195,7 @@ func TestStatusLocalLogs(t *testing.T) {
 	defer s.Close(t)
 
 	ts := startServer(t)
-	defer ts.Stopper().Stop()
+	defer ts.Stopper().Stop(context.TODO())
 
 	// Log an error of each main type which we expect to be able to retrieve.
 	// The resolution of our log timestamps is such that it's possible to get
@@ -338,7 +338,7 @@ func TestStatusLocalLogs(t *testing.T) {
 func TestNodeStatusResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := startServer(t)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	// First fetch all the node statuses.
 	wrapper := serverpb.NodesResponse{}
@@ -373,7 +373,7 @@ func TestMetricsRecording(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{
 		MetricsSampleInterval: 5 * time.Millisecond})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	checkTimeSeriesKey := func(now int64, keyName string) error {
 		key := ts.MakeDataKey(keyName, "", ts.Resolution10s, now)
@@ -401,7 +401,7 @@ func TestMetricsRecording(t *testing.T) {
 func TestMetricsEndpoint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := startServer(t)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if _, err := getText(s, s.AdminURL()+statusPrefix+"metrics/"+s.Gossip().NodeID.String()); err != nil {
 		t.Fatal(err)
@@ -411,7 +411,7 @@ func TestMetricsEndpoint(t *testing.T) {
 func TestRangesResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ts := startServer(t)
-	defer ts.Stopper().Stop()
+	defer ts.Stopper().Stop(context.TODO())
 
 	// Perform a scan to ensure that all the raft groups are initialized.
 	if _, err := ts.db.Scan(context.TODO(), keys.LocalMax, roachpb.KeyMax, 0); err != nil {
@@ -451,7 +451,7 @@ func TestRangesResponse(t *testing.T) {
 func TestRaftDebug(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := startServer(t)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	var resp serverpb.RaftDebugResponse
 	if err := getStatusJSONProto(s, "raft", &resp); err != nil {
@@ -502,7 +502,7 @@ func TestRaftDebug(t *testing.T) {
 func TestStatusVars(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if body, err := getText(s, s.AdminURL()+statusPrefix+"vars"); err != nil {
 		t.Fatal(err)
@@ -514,7 +514,7 @@ func TestStatusVars(t *testing.T) {
 func TestSpanStatsResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ts := startServer(t)
-	defer ts.Stopper().Stop()
+	defer ts.Stopper().Stop(context.TODO())
 
 	httpClient, err := ts.GetHTTPClient()
 	if err != nil {
@@ -544,10 +544,10 @@ func TestSpanStatsResponse(t *testing.T) {
 func TestSpanStatsGRPCResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ts := startServer(t)
-	defer ts.Stopper().Stop()
+	defer ts.Stopper().Stop(context.TODO())
 
 	rpcStopper := stop.NewStopper()
-	defer rpcStopper.Stop()
+	defer rpcStopper.Stop(context.TODO())
 	rpcContext := rpc.NewContext(log.AmbientContext{}, ts.RPCContext().Config, ts.Clock(), rpcStopper)
 	request := serverpb.SpanStatsRequest{
 		NodeID:   "1",
@@ -578,7 +578,7 @@ func TestSpanStatsGRPCResponse(t *testing.T) {
 func TestNodesGRPCResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ts := startServer(t)
-	defer ts.Stopper().Stop()
+	defer ts.Stopper().Stop(context.TODO())
 
 	rootConfig := testutils.NewTestBaseContext(security.RootUser)
 	rpcContext := rpc.NewContext(log.AmbientContext{}, rootConfig, ts.Clock(), ts.Stopper())
@@ -604,7 +604,7 @@ func TestNodesGRPCResponse(t *testing.T) {
 func TestHandleDebugRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := startServer(t)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if body, err := getText(s, s.AdminURL()+rangeDebugEndpoint+"?id=1"); err != nil {
 		t.Fatal(err)

--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -101,7 +101,7 @@ type storeInfo struct {
 // PeriodicallyCheckForUpdates starts a background worker that periodically
 // phones home to check for updates and report usage.
 func (s *Server) PeriodicallyCheckForUpdates() {
-	s.stopper.RunWorker(context.TODO(), func() {
+	s.stopper.RunWorker(context.TODO(), func(context.Context) {
 		startup := timeutil.Now()
 		var nextUpdateCheck, nextDiagnosticReport time.Time
 

--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -101,7 +101,7 @@ type storeInfo struct {
 // PeriodicallyCheckForUpdates starts a background worker that periodically
 // phones home to check for updates and report usage.
 func (s *Server) PeriodicallyCheckForUpdates() {
-	s.stopper.RunWorker(func() {
+	s.stopper.RunWorker(context.TODO(), func() {
 		startup := timeutil.Now()
 		var nextUpdateCheck, nextDiagnosticReport time.Time
 

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -62,7 +64,7 @@ func TestCheckVersion(t *testing.T) {
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	s.(*TestServer).checkForUpdates(time.Minute)
 	recorder.Close()
-	s.Stopper().Stop()
+	s.Stopper().Stop(context.TODO())
 
 	if expected, actual := int32(1), atomic.LoadInt32(&updateChecks); actual != expected {
 		t.Fatalf("expected %v update checks, got %v", expected, actual)
@@ -168,6 +170,6 @@ func TestReportUsage(t *testing.T) {
 		return nil
 	})
 
-	ts.Stopper().Stop() // stopper will wait for the update/report loop to finish too.
+	ts.Stopper().Stop(context.TODO()) // stopper will wait for the update/report loop to finish too.
 	recorder.Close()
 }

--- a/pkg/sql/ambiguous_commit_test.go
+++ b/pkg/sql/ambiguous_commit_test.go
@@ -21,6 +21,8 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -80,7 +82,7 @@ func TestAmbiguousCommitDueToLeadershipChange(t *testing.T) {
 	}
 	const numReplicas = 3
 	tc := testcluster.StartTestCluster(t, numReplicas, testClusterArgs)
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 
 	sqlDB := sqlutils.MakeSQLRunner(t, tc.Conns[0])
 

--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -238,7 +238,7 @@ var StmtStatsResetFrequency = envutil.EnvOrDefaultDuration(
 // periodically, so as to avoid memory blow-ups.
 func (s *sqlStats) startResetWorker(stopper *stop.Stopper) {
 	ctx := log.WithLogTag(context.Background(), "sql-stats", nil)
-	stopper.RunWorker(func() {
+	stopper.RunWorker(ctx, func() {
 		ticker := time.NewTicker(StmtStatsResetFrequency)
 		defer ticker.Stop()
 		for {

--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -238,7 +238,7 @@ var StmtStatsResetFrequency = envutil.EnvOrDefaultDuration(
 // periodically, so as to avoid memory blow-ups.
 func (s *sqlStats) startResetWorker(stopper *stop.Stopper) {
 	ctx := log.WithLogTag(context.Background(), "sql-stats", nil)
-	stopper.RunWorker(ctx, func() {
+	stopper.RunWorker(ctx, func(ctx context.Context) {
 		ticker := time.NewTicker(StmtStatsResetFrequency)
 		defer ticker.Stop()
 		for {

--- a/pkg/sql/as_of_test.go
+++ b/pkg/sql/as_of_test.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -40,7 +42,7 @@ func TestAsOfTime(t *testing.T) {
 		AsyncExecNotification: asyncSchemaChangerDisabled,
 	}
 	s, db, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	const val1 = 1
 	const val2 = 2
@@ -196,7 +198,7 @@ func TestAsOfRetry(t *testing.T) {
 	// Disable one phase commits because they cannot be restarted.
 	params.Knobs.Store.(*storage.StoreTestingKnobs).DisableOnePhaseCommits = true
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	const val1 = 1
 	const val2 = 2

--- a/pkg/sql/bench_test.go
+++ b/pkg/sql/bench_test.go
@@ -29,6 +29,8 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
 
@@ -43,7 +45,7 @@ func benchmarkCockroach(b *testing.B, f func(b *testing.B, db *gosql.DB)) {
 	defer tracing.Disable()()
 	s, db, _ := serverutils.StartServer(
 		b, base.TestServerArgs{UseDatabase: "bench"})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if _, err := db.Exec(`CREATE DATABASE IF NOT EXISTS bench`); err != nil {
 		b.Fatal(err)
@@ -64,7 +66,7 @@ func benchmarkMultinodeCockroach(b *testing.B, f func(b *testing.B, db *gosql.DB
 	if _, err := tc.Conns[0].Exec(`CREATE DATABASE bench`); err != nil {
 		b.Fatal(err)
 	}
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 
 	f(b, tc.Conns[0])
 }

--- a/pkg/sql/config_test.go
+++ b/pkg/sql/config_test.go
@@ -91,7 +91,7 @@ func TestGetZoneConfig(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	params, _ := createTestServerParams()
 	srv, sqlDB, _ := serverutils.StartServer(t, params)
-	defer srv.Stopper().Stop()
+	defer srv.Stopper().Stop(context.TODO())
 	s := srv.(*server.TestServer)
 
 	expectedCounter := uint32(keys.MaxReservedDescID)

--- a/pkg/sql/copy_in_test.go
+++ b/pkg/sql/copy_in_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -39,7 +41,7 @@ func TestCopyNullInfNaN(t *testing.T) {
 
 	params, _ := createTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if _, err := db.Exec(`
 		CREATE DATABASE d;
@@ -130,7 +132,7 @@ func TestCopyRandom(t *testing.T) {
 
 	params, _ := createTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if _, err := db.Exec(`
 		CREATE DATABASE d;
@@ -252,7 +254,7 @@ func TestCopyError(t *testing.T) {
 
 	params, _ := createTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if _, err := db.Exec(`
 		CREATE DATABASE d;
@@ -307,7 +309,7 @@ func TestCopyOne(t *testing.T) {
 
 	params, _ := createTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if _, err := db.Exec(`
 		CREATE DATABASE d;
@@ -341,7 +343,7 @@ func TestCopyInProgress(t *testing.T) {
 
 	params, _ := createTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if _, err := db.Exec(`
 		CREATE DATABASE d;
@@ -374,7 +376,7 @@ func TestCopyTransaction(t *testing.T) {
 
 	params, _ := createTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if _, err := db.Exec(`
 		CREATE DATABASE d;

--- a/pkg/sql/create_test.go
+++ b/pkg/sql/create_test.go
@@ -41,7 +41,7 @@ func TestDatabaseDescriptor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	params, _ := createTestServerParams()
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	ctx := context.TODO()
 
 	expectedCounter := int64(keys.MaxReservedDescID + 1)
@@ -258,7 +258,7 @@ func TestParallelCreateTables(t *testing.T) {
 	const numberOfNodes = 3
 
 	tc := testcluster.StartTestCluster(t, numberOfNodes, base.TestClusterArgs{})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 
 	if _, err := tc.ServerConn(0).Exec(`CREATE DATABASE "test"`); err != nil {
 		t.Fatal(err)
@@ -311,7 +311,7 @@ func TestParallelCreateConflictingTables(t *testing.T) {
 	const numberOfNodes = 3
 
 	tc := testcluster.StartTestCluster(t, numberOfNodes, base.TestClusterArgs{})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 
 	if _, err := tc.ServerConn(0).Exec(`CREATE DATABASE "test"`); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -159,7 +159,7 @@ func TestOperationsWithColumnMutation(t *testing.T) {
 		AsyncExecNotification: asyncSchemaChangerDisabled,
 	}
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer server.Stopper().Stop()
+	defer server.Stopper().Stop(context.TODO())
 
 	// Fix the column families so the key counts below don't change if the
 	// family heuristics are updated.
@@ -368,7 +368,7 @@ func TestOperationsWithIndexMutation(t *testing.T) {
 		AsyncExecNotification: asyncSchemaChangerDisabled,
 	}
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer server.Stopper().Stop()
+	defer server.Stopper().Stop(context.TODO())
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
@@ -508,7 +508,7 @@ func TestOperationsWithColumnAndIndexMutation(t *testing.T) {
 		AsyncExecNotification: asyncSchemaChangerDisabled,
 	}
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer server.Stopper().Stop()
+	defer server.Stopper().Stop(context.TODO())
 
 	// Create a table with column i and an index on v and i. Fix the column
 	// families so the key counts below don't change if the family heuristics
@@ -673,7 +673,7 @@ func TestSchemaChangeCommandsWithPendingMutations(t *testing.T) {
 		AsyncExecNotification: asyncSchemaChangerDisabled,
 	}
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer server.Stopper().Stop()
+	defer server.Stopper().Stop(context.TODO())
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
@@ -891,7 +891,7 @@ func TestTableMutationQueue(t *testing.T) {
 		},
 	}
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer server.Stopper().Stop()
+	defer server.Stopper().Stop(context.TODO())
 
 	// Create a table with column i and an index on v and i.
 	if _, err := sqlDB.Exec(`
@@ -986,7 +986,7 @@ func TestAddingFKs(t *testing.T) {
 
 	params, _ := createTestServerParams()
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if _, err := sqlDB.Exec(`
 		CREATE DATABASE t;

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -104,7 +104,7 @@ func TestDistBackfill(t *testing.T) {
 				},
 			},
 		})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 	cdb := tc.Server(0).KVClient().(*client.DB)
 
 	sqlutils.CreateTable(
@@ -234,7 +234,7 @@ func TestDistSQLRangeCachesIntegrationTest(t *testing.T) {
 				UseDatabase: "test",
 			},
 		})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 
 	db0 := tc.ServerConn(0)
 	sqlutils.CreateTable(t, db0, "left",

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -75,7 +75,7 @@ func (dsp *distSQLPlanner) initRunners() {
 	// requests if a worker is actually there to receive them.
 	dsp.runnerChan = make(chan runnerRequest)
 	for i := 0; i < numRunners; i++ {
-		dsp.stopper.RunWorker(context.TODO(), func() {
+		dsp.stopper.RunWorker(context.TODO(), func(context.Context) {
 			runnerChan := dsp.runnerChan
 			stopChan := dsp.stopper.ShouldStop()
 			for {

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -75,7 +75,7 @@ func (dsp *distSQLPlanner) initRunners() {
 	// requests if a worker is actually there to receive them.
 	dsp.runnerChan = make(chan runnerRequest)
 	for i := 0; i < numRunners; i++ {
-		dsp.stopper.RunWorker(func() {
+		dsp.stopper.RunWorker(context.TODO(), func() {
 			runnerChan := dsp.runnerChan
 			stopChan := dsp.stopper.ShouldStop()
 			for {

--- a/pkg/sql/distsqlplan/aggregator_funcs_test.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs_test.go
@@ -265,7 +265,7 @@ func TestDistAggregationTable(t *testing.T) {
 	const numRows = 100
 
 	tc := serverutils.StartTestCluster(t, 1, base.TestClusterArgs{})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 
 	// Create a table with a few columns:
 	//  - random integer values from 0 to numRows

--- a/pkg/sql/distsqlplan/fake_span_resolver_test.go
+++ b/pkg/sql/distsqlplan/fake_span_resolver_test.go
@@ -38,7 +38,7 @@ func TestFakeSpanResolver(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	tc := serverutils.StartTestCluster(t, 3, base.TestClusterArgs{})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 
 	sqlutils.CreateTable(
 		t, tc.ServerConn(0), "t",

--- a/pkg/sql/distsqlplan/span_resolver_test.go
+++ b/pkg/sql/distsqlplan/span_resolver_test.go
@@ -52,7 +52,7 @@ func TestSpanResolverUsesCaches(t *testing.T) {
 				UseDatabase: "t",
 			},
 		})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 
 	rowRanges, _ := setupRanges(
 		tc.Conns[0], tc.Servers[0], tc.Servers[0].KVClient().(*client.DB), t)
@@ -198,7 +198,7 @@ func TestSpanResolver(t *testing.T) {
 	s, db, cdb := serverutils.StartServer(t, base.TestServerArgs{
 		UseDatabase: "t",
 	})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	rowRanges, tableDesc := setupRanges(db, s.(*server.TestServer), cdb, t)
 	lr := distsqlplan.NewSpanResolver(
@@ -291,7 +291,7 @@ func TestMixedDirections(t *testing.T) {
 	s, db, cdb := serverutils.StartServer(t, base.TestServerArgs{
 		UseDatabase: "t",
 	})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	rowRanges, tableDesc := setupRanges(db, s.(*server.TestServer), cdb, t)
 	lr := distsqlplan.NewSpanResolver(

--- a/pkg/sql/distsqlrun/backfiller_test.go
+++ b/pkg/sql/distsqlrun/backfiller_test.go
@@ -46,7 +46,7 @@ func TestWriteResumeSpan(t *testing.T) {
 			},
 		},
 	})
-	defer server.Stopper().Stop()
+	defer server.Stopper().Stop(context.TODO())
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;

--- a/pkg/sql/distsqlrun/cluster_test.go
+++ b/pkg/sql/distsqlrun/cluster_test.go
@@ -45,7 +45,7 @@ func TestClusterFlow(t *testing.T) {
 
 	args := base.TestClusterArgs{ReplicationMode: base.ReplicationManual}
 	tc := serverutils.StartTestCluster(t, 3, args)
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 
 	sumDigitsFn := func(row int) parser.Datum {
 		sum := 0

--- a/pkg/sql/distsqlrun/flow_scheduler.go
+++ b/pkg/sql/distsqlrun/flow_scheduler.go
@@ -83,7 +83,7 @@ func (fs *flowScheduler) runFlowNow(ctx context.Context, f *Flow) {
 // ScheduleFlow is the main interface of the flow scheduler: it runs or enqueues
 // the given flow.
 func (fs *flowScheduler) ScheduleFlow(ctx context.Context, f *Flow) error {
-	return fs.stopper.RunTask(func() {
+	return fs.stopper.RunTask(ctx, func() {
 		fs.mu.Lock()
 		defer fs.mu.Unlock()
 
@@ -100,7 +100,8 @@ func (fs *flowScheduler) ScheduleFlow(ctx context.Context, f *Flow) error {
 
 // Start launches the main loop of the scheduler.
 func (fs *flowScheduler) Start() {
-	fs.stopper.RunWorker(func() {
+	ctx := fs.AnnotateCtx(context.Background())
+	fs.stopper.RunWorker(ctx, func() {
 		stopped := false
 		fs.mu.Lock()
 		defer fs.mu.Unlock()

--- a/pkg/sql/distsqlrun/joinreader_test.go
+++ b/pkg/sql/distsqlrun/joinreader_test.go
@@ -35,7 +35,7 @@ func TestJoinReader(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	// Create a table where each row is:
 	//
@@ -152,7 +152,7 @@ func TestJoinReaderDrain(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	sqlutils.CreateTable(
 		t,

--- a/pkg/sql/distsqlrun/outbox_test.go
+++ b/pkg/sql/distsqlrun/outbox_test.go
@@ -46,7 +46,7 @@ func TestOutbox(t *testing.T) {
 
 	// Create a mock server that the outbox will connect and push rows to.
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	mockServer, addr, err := startMockDistSQLServer(stopper)
 	if err != nil {
 		t.Fatal(err)
@@ -198,7 +198,7 @@ func TestOutboxInitializesStreamBeforeRecevingAnyRows(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	mockServer, addr, err := startMockDistSQLServer(stopper)
 	if err != nil {
 		t.Fatal(err)
@@ -260,7 +260,7 @@ func TestOutboxClosesWhenConsumerCloses(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
 			stopper := stop.NewStopper()
-			defer stopper.Stop()
+			defer stopper.Stop(context.TODO())
 			mockServer, addr, err := startMockDistSQLServer(stopper)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -201,7 +201,7 @@ func (ds *ServerImpl) RunSyncFlow(stream DistSQL_RunSyncFlowServer) error {
 	}
 	mbox.setFlowCtx(&f.FlowCtx)
 
-	if err := ds.Stopper.RunTask(ctx, func() {
+	if err := ds.Stopper.RunTask(ctx, func(ctx context.Context) {
 		f.waitGroup.Add(1)
 		mbox.start(ctx, &f.waitGroup)
 		f.Start(ctx, func() {})

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -201,7 +201,7 @@ func (ds *ServerImpl) RunSyncFlow(stream DistSQL_RunSyncFlowServer) error {
 	}
 	mbox.setFlowCtx(&f.FlowCtx)
 
-	if err := ds.Stopper.RunTask(func() {
+	if err := ds.Stopper.RunTask(ctx, func() {
 		f.waitGroup.Add(1)
 		mbox.start(ctx, &f.waitGroup)
 		f.Start(ctx, func() {})

--- a/pkg/sql/distsqlrun/server_test.go
+++ b/pkg/sql/distsqlrun/server_test.go
@@ -35,7 +35,7 @@ func TestServer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	conn, err := s.RPCContext().GRPCDial(s.ServingAddr())
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -37,7 +37,7 @@ func TestTableReader(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	// Create a table where each row is:
 	//
@@ -162,7 +162,7 @@ func TestMisplannedRangesMetadata(t *testing.T) {
 				UseDatabase: "test",
 			},
 		})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 
 	db := tc.ServerConn(0)
 	sqlutils.CreateTable(t, db, "t",

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -42,7 +42,7 @@ func TestDropDatabase(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	params, _ := createTestServerParams()
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	ctx := context.TODO()
 
 	// Fix the column families so the key counts below don't change if the
@@ -180,7 +180,7 @@ func TestShowTablesAfterRecreateDatabase(t *testing.T) {
 		},
 	}
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
@@ -253,7 +253,7 @@ func TestDropIndex(t *testing.T) {
 		},
 	}
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	numRows := 2*chunkSize + 1
 	if err := createKVTable(sqlDB, numRows); err != nil {
@@ -331,7 +331,7 @@ func TestDropIndexInterleaved(t *testing.T) {
 		},
 	}
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	numRows := 2*chunkSize + 1
 	createKVInterleavedTable(t, sqlDB, numRows)
@@ -379,7 +379,7 @@ func TestDropTable(t *testing.T) {
 		},
 	}
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	ctx := context.TODO()
 
 	numRows := 2*sql.TableTruncateChunkSize + 1
@@ -472,7 +472,7 @@ func TestDropTableInterleaved(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	params, _ := createTestServerParams()
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	numRows := 2*sql.TableTruncateChunkSize + 1
 	createKVInterleavedTable(t, sqlDB, numRows)
@@ -500,7 +500,7 @@ func TestDropAndCreateTable(t *testing.T) {
 	params, _ := createTestServerParams()
 	params.UseDatabase = "test"
 	s, db, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if _, err := db.Exec(`CREATE DATABASE test`); err != nil {
 		t.Fatal(err)
@@ -535,7 +535,7 @@ func TestCommandsWhileTableBeingDropped(t *testing.T) {
 		},
 	}
 	s, db, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	sql := `
 CREATE DATABASE test;

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -332,7 +332,7 @@ func (e *Executor) Start(
 	e.systemConfigCond = sync.NewCond(e.systemConfigMu.RLocker())
 
 	gossipUpdateC := e.cfg.Gossip.RegisterSystemConfigChannel()
-	e.stopper.RunWorker(ctx, func() {
+	e.stopper.RunWorker(ctx, func(ctx context.Context) {
 		for {
 			select {
 			case <-gossipUpdateC:

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -332,7 +332,7 @@ func (e *Executor) Start(
 	e.systemConfigCond = sync.NewCond(e.systemConfigMu.RLocker())
 
 	gossipUpdateC := e.cfg.Gossip.RegisterSystemConfigChannel()
-	e.stopper.RunWorker(func() {
+	e.stopper.RunWorker(ctx, func() {
 		for {
 			select {
 			case <-gossipUpdateC:

--- a/pkg/sql/jobs_test.go
+++ b/pkg/sql/jobs_test.go
@@ -141,7 +141,7 @@ func TestJobLogger(t *testing.T) {
 	ctx := context.TODO()
 	params, _ := createTestServerParams()
 	s, rawSQLDB, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	t.Run("valid job lifecycles succeed", func(t *testing.T) {
 		db := sqlutils.MakeSQLRunner(t, rawSQLDB)

--- a/pkg/sql/kv_test.go
+++ b/pkg/sql/kv_test.go
@@ -70,7 +70,7 @@ func newKVNative(b *testing.B) kvInterface {
 	return &kvNative{
 		db: client.NewDB(client.NewSender(conn), rpcContext.LocalClock),
 		doneFn: func() {
-			s.Stopper().Stop()
+			s.Stopper().Stop(context.TODO())
 			enableTracing()
 		},
 	}
@@ -175,7 +175,7 @@ func newKVSQL(b *testing.B) kvInterface {
 	kv := &kvSQL{}
 	kv.db = db
 	kv.doneFn = func() {
-		s.Stopper().Stop()
+		s.Stopper().Stop(context.TODO())
 		enableTracing()
 	}
 	return kv

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -1239,8 +1239,8 @@ func (m *LeaseManager) findTableState(tableID sqlbase.ID, create bool) *tableSta
 // RefreshLeases starts a goroutine that refreshes the lease manager
 // leases for tables received in the latest system configuration via gossip.
 func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *client.DB, gossip *gossip.Gossip) {
-	s.RunWorker(func() {
-		ctx := context.TODO()
+	ctx := context.TODO()
+	s.RunWorker(ctx, func() {
 		descKeyPrefix := keys.MakeTablePrefix(uint32(sqlbase.DescriptorTable.ID))
 		gossipUpdateC := gossip.RegisterSystemConfigChannel()
 		for {

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -1240,7 +1240,7 @@ func (m *LeaseManager) findTableState(tableID sqlbase.ID, create bool) *tableSta
 // leases for tables received in the latest system configuration via gossip.
 func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *client.DB, gossip *gossip.Gossip) {
 	ctx := context.TODO()
-	s.RunWorker(ctx, func() {
+	s.RunWorker(ctx, func(ctx context.Context) {
 		descKeyPrefix := keys.MakeTablePrefix(uint32(sqlbase.DescriptorTable.ID))
 		gossipUpdateC := gossip.RegisterSystemConfigChannel()
 		for {

--- a/pkg/sql/lease_internal_test.go
+++ b/pkg/sql/lease_internal_test.go
@@ -138,7 +138,7 @@ func TestPurgeOldLeases(t *testing.T) {
 		},
 	}
 	s, db, kvDB := serverutils.StartServer(t, serverParams)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	leaseManager := s.LeaseManager().(*LeaseManager)
 	// Block gossip.
 	gossipSem <- struct{}{}
@@ -198,7 +198,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 func TestNameCacheIsUpdated(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	leaseManager := s.LeaseManager().(*LeaseManager)
 
 	if _, err := db.Exec(`
@@ -269,7 +269,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 func TestNameCacheEntryDoesntReturnExpiredLease(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	leaseManager := s.LeaseManager().(*LeaseManager)
 
 	const tableName = "test"
@@ -310,7 +310,7 @@ CREATE TABLE t.%s (k CHAR PRIMARY KEY, v CHAR);
 func TestTableNameNotCaseSensitive(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	leaseManager := s.LeaseManager().(*LeaseManager)
 
 	if _, err := db.Exec(`
@@ -354,7 +354,7 @@ func TestReleaseAcquireByNameDeadlock(t *testing.T) {
 	}
 	s, sqlDB, kvDB := serverutils.StartServer(
 		t, base.TestServerArgs{Knobs: testingKnobs})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	leaseManager := s.LeaseManager().(*LeaseManager)
 
 	if _, err := sqlDB.Exec(`
@@ -464,7 +464,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 func TestAcquireFreshestFromStoreRaces(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	leaseManager := s.LeaseManager().(*LeaseManager)
 
 	if _, err := db.Exec(`

--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -70,7 +70,7 @@ func newLeaseTest(t *testing.T, params base.TestServerArgs) *leaseTest {
 }
 
 func (t *leaseTest) cleanup() {
-	t.server.Stopper().Stop()
+	t.server.Stopper().Stop(context.TODO())
 }
 
 func (t *leaseTest) getLeases(descID sqlbase.ID) string {
@@ -604,7 +604,7 @@ func TestLeasesOnDeletedTableAreReleasedImmediately(t *testing.T) {
 		},
 	}
 	s, db, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	stmt := `
 CREATE DATABASE test;
@@ -680,7 +680,7 @@ func TestTxnObeysLeaseExpiration(t *testing.T) {
 		},
 	}
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	leaseManager := s.LeaseManager().(*sql.LeaseManager)
 
 	if _, err := sqlDB.Exec(`
@@ -746,7 +746,7 @@ func TestSubqueryLeases(t *testing.T) {
 		},
 	}
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;

--- a/pkg/sql/logic_test.go
+++ b/pkg/sql/logic_test.go
@@ -541,7 +541,7 @@ func (t *logicTest) close() {
 	t.cleanupFuncs = nil
 
 	if t.cluster != nil {
-		t.cluster.Stopper().Stop()
+		t.cluster.Stopper().Stop(context.TODO())
 		t.cluster = nil
 	}
 	if t.clients != nil {

--- a/pkg/sql/metric_test.go
+++ b/pkg/sql/metric_test.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
@@ -46,7 +48,7 @@ func TestQueryCounts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	params, _ := createTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	var testcases = []queryCounter{
 		// The counts are deltas for each query.
@@ -129,7 +131,7 @@ func TestAbortCountConflictingWrites(t *testing.T) {
 
 	params, cmdFilters := createTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if _, err := sqlDB.Exec("CREATE DATABASE db"); err != nil {
 		t.Fatal(err)
@@ -189,7 +191,7 @@ func TestAbortCountErrorDuringTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	params, _ := createTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	txn, err := sqlDB.Begin()
 	if err != nil {

--- a/pkg/sql/monotonic_insert_test.go
+++ b/pkg/sql/monotonic_insert_test.go
@@ -89,7 +89,7 @@ func TestMonotonicInserts(t *testing.T) {
 		base.TestClusterArgs{
 			ReplicationMode: base.ReplicationAuto,
 		})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 	ctx := context.Background()
 
 	var clients []mtClient

--- a/pkg/sql/parallel_stmts_test.go
+++ b/pkg/sql/parallel_stmts_test.go
@@ -336,7 +336,7 @@ func planNodeForQuery(
 func TestSpanBasedDependencyAnalyzer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if _, err := db.Exec(`CREATE DATABASE test`); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/parallel_test.go
+++ b/pkg/sql/parallel_test.go
@@ -64,7 +64,7 @@ type parallelTest struct {
 func (t *parallelTest) close() {
 	t.clients = nil
 	if t.cluster != nil {
-		t.cluster.Stopper().Stop()
+		t.cluster.Stopper().Stop(context.TODO())
 	}
 }
 

--- a/pkg/sql/pgbench_test.go
+++ b/pkg/sql/pgbench_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgbench"
@@ -112,7 +114,7 @@ func execPgbench(b *testing.B, pgURL url.URL) {
 func BenchmarkPgbenchExec_Cockroach(b *testing.B) {
 	defer tracing.Disable()()
 	s, _, _ := serverutils.StartServer(b, base.TestServerArgs{Insecure: true})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	pgURL, cleanupFn := sqlutils.PGUrl(
 		b, s.ServingAddr(), "benchmarkCockroach", url.User(security.RootUser))

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -172,7 +172,7 @@ func TestPGWire(t *testing.T) {
 			}
 		}
 
-		s.Stopper().Stop()
+		s.Stopper().Stop(context.TODO())
 	}
 }
 
@@ -182,7 +182,7 @@ func TestPGWireDrainClient(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	params := base.TestServerArgs{Insecure: true}
 	s, _, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	host, port, err := net.SplitHostPort(s.ServingAddr())
 	if err != nil {
@@ -253,7 +253,7 @@ func TestPGWireDrainOngoingTxns(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	params := base.TestServerArgs{Insecure: true}
 	s, _, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	host, port, err := net.SplitHostPort(s.ServingAddr())
 	if err != nil {
@@ -354,7 +354,7 @@ func TestPGWireDBName(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), t.Name(), url.User(security.RootUser))
 	pgURL.Path = "foo"
@@ -389,7 +389,7 @@ func TestPGPrepareFail(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), t.Name(), url.User(security.RootUser))
 	defer cleanupFn()
@@ -439,7 +439,7 @@ func TestPGPrepareFail(t *testing.T) {
 func TestPGPrepareWithCreateDropInTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), t.Name(), url.User(security.RootUser))
 	defer cleanupFn()
@@ -831,7 +831,7 @@ func TestPGPreparedQuery(t *testing.T) {
 	}
 
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), t.Name(), url.User(security.RootUser))
 	defer cleanupFn()
@@ -1166,7 +1166,7 @@ func TestPGPreparedExec(t *testing.T) {
 	}
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{Knobs: testingKnobs})
 
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), t.Name(), url.User(security.RootUser))
 	defer cleanupFn()
@@ -1226,7 +1226,7 @@ func TestPGPreparedExec(t *testing.T) {
 func TestPGPrepareNameQual(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), t.Name(), url.User(security.RootUser))
 	defer cleanupFn()
@@ -1276,7 +1276,7 @@ func TestPGPrepareNameQual(t *testing.T) {
 func TestCmdCompleteVsEmptyStatements(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	pgURL, cleanupFn := sqlutils.PGUrl(
 		t, s.ServingAddr(), t.Name(), url.User(security.RootUser))
@@ -1320,7 +1320,7 @@ func TestCmdCompleteVsEmptyStatements(t *testing.T) {
 func TestPGCommandTags(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), t.Name(), url.User(security.RootUser))
 	defer cleanupFn()
@@ -1441,7 +1441,7 @@ func TestSQLNetworkMetrics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	// Setup pgwire client.
 	pgURL, cleanupFn := sqlutils.PGUrl(
@@ -1535,7 +1535,7 @@ func TestPGWireOverUnixSocket(t *testing.T) {
 		SocketFile: socketFile,
 	}
 	s, _, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	// We can't pass socket paths as url.Host to libpq, use ?host=/... instead.
 	options := url.Values{
@@ -1556,7 +1556,7 @@ func TestPGWireAuth(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	{
 		unicodeUser := "Ὀδυσσεύς"
 

--- a/pkg/sql/pgwire_internal_test.go
+++ b/pkg/sql/pgwire_internal_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -40,7 +41,7 @@ import (
 func TestPGWireConnectionCloseReleasesLeases(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	url, cleanupConn := sqlutils.PGUrl(t, s.ServingAddr(), "SetupServer", url.User(security.RootUser))
 	defer cleanupConn()
 	conn, err := pq.Open(url.String())

--- a/pkg/sql/planhook_test.go
+++ b/pkg/sql/planhook_test.go
@@ -19,6 +19,8 @@ package sql_test
 import (
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -27,7 +29,7 @@ import (
 func TestPlanHookPrepare(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 	sqlDB := tc.Conns[0]
 
 	stmt, err := sqlDB.Prepare(`SHOW planhook`)

--- a/pkg/sql/rename_test.go
+++ b/pkg/sql/rename_test.go
@@ -37,7 +37,7 @@ import (
 func TestRenameTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	counter := int64(keys.MaxReservedDescID)
 
@@ -160,7 +160,7 @@ func TestTxnCanStillResolveOldName(t *testing.T) {
 			}
 		}
 	s, db, kvDB := serverutils.StartServer(t, serverParams)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	sql := `
 CREATE DATABASE test;

--- a/pkg/sql/rsg_test.go
+++ b/pkg/sql/rsg_test.go
@@ -29,6 +29,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/internal/rsg"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -195,7 +197,7 @@ func testRandomSyntax(
 	// Use a low memory limit to quickly halt runaway functions.
 	params.SQLMemoryPoolSize = 3 * 1024 * 1024 // 3MB
 	s, db, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if setup != nil {
 		err := setup(db)

--- a/pkg/sql/scan_test.go
+++ b/pkg/sql/scan_test.go
@@ -24,6 +24,8 @@ import (
 	"sort"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -131,7 +133,7 @@ func TestScanBatches(t *testing.T) {
 
 	s, db, _ := serverutils.StartServer(
 		t, base.TestServerArgs{UseDatabase: "test"})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if _, err := db.Exec(`CREATE DATABASE IF NOT EXISTS test`); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -749,7 +749,7 @@ func (s *SchemaChangeManager) newTimer() *time.Timer {
 // Start starts a goroutine that runs outstanding schema changes
 // for tables received in the latest system configuration via gossip.
 func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
-	stopper.RunWorker(context.TODO(), func() {
+	stopper.RunWorker(context.TODO(), func(ctx context.Context) {
 		descKeyPrefix := keys.MakeTablePrefix(uint32(sqlbase.DescriptorTable.ID))
 		gossipUpdateC := s.gossip.RegisterSystemConfigChannel()
 		timer := &time.Timer{}
@@ -763,7 +763,7 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 				cfg, _ := s.gossip.GetSystemConfig()
 				// Read all tables and their versions
 				if log.V(2) {
-					log.Info(context.TODO(), "received a new config")
+					log.Info(ctx, "received a new config")
 				}
 				schemaChanger := SchemaChanger{
 					nodeID:         s.leaseMgr.nodeID.Get(),
@@ -786,7 +786,7 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 					// Attempt to unmarshal config into a table/database descriptor.
 					var descriptor sqlbase.Descriptor
 					if err := kv.Value.GetProto(&descriptor); err != nil {
-						log.Warningf(context.TODO(), "%s: unable to unmarshal descriptor %v", kv.Key, kv.Value)
+						log.Warningf(ctx, "%s: unable to unmarshal descriptor %v", kv.Key, kv.Value)
 						continue
 					}
 					switch union := descriptor.Union.(type) {
@@ -794,7 +794,7 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 						table := union.Table
 						table.MaybeUpgradeFormatVersion()
 						if err := table.ValidateTable(); err != nil {
-							log.Errorf(context.TODO(), "%s: received invalid table descriptor: %v", kv.Key, table)
+							log.Errorf(ctx, "%s: received invalid table descriptor: %v", kv.Key, table)
 							continue
 						}
 
@@ -807,7 +807,7 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 						if table.UpVersion || table.Dropped() || table.Adding() ||
 							table.Renamed() || len(table.Mutations) > 0 {
 							if log.V(2) {
-								log.Infof(context.TODO(), "%s: queue up pending schema change; table: %d, version: %d",
+								log.Infof(ctx, "%s: queue up pending schema change; table: %d, version: %d",
 									kv.Key, table.ID, table.Version)
 							}
 
@@ -852,9 +852,9 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 				for tableID, sc := range s.schemaChangers {
 					if timeutil.Since(sc.execAfter) > 0 {
 						// TODO(andrei): create a proper ctx for executing schema changes.
-						if err := sc.exec(context.TODO()); err != nil {
+						if err := sc.exec(ctx); err != nil {
 							if err != errExistingSchemaChangeLease {
-								log.Warningf(context.TODO(), "Error executing schema change: %s", err)
+								log.Warningf(ctx, "Error executing schema change: %s", err)
 							}
 							if err == sqlbase.ErrDescriptorNotFound {
 								// Someone deleted this table. Don't try to run the schema

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -749,7 +749,7 @@ func (s *SchemaChangeManager) newTimer() *time.Timer {
 // Start starts a goroutine that runs outstanding schema changes
 // for tables received in the latest system configuration via gossip.
 func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
-	stopper.RunWorker(func() {
+	stopper.RunWorker(context.TODO(), func() {
 		descKeyPrefix := keys.MakeTablePrefix(uint32(sqlbase.DescriptorTable.ID))
 		gossipUpdateC := s.gossip.RegisterSystemConfigChannel()
 		timer := &time.Timer{}

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -57,7 +57,7 @@ func TestSchemaChangeLease(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	params, _ := createTestServerParams()
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	// Set MinSchemaChangeLeaseDuration to always expire the lease.
 	minLeaseDuration := sql.MinSchemaChangeLeaseDuration
 	sql.MinSchemaChangeLeaseDuration = 2 * sql.SchemaChangeLeaseDuration
@@ -166,7 +166,7 @@ func TestSchemaChangeProcess(t *testing.T) {
 		AsyncExecNotification: asyncSchemaChangerDisabled,
 	}
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	var id = sqlbase.ID(keys.MaxReservedDescID + 2)
 	var node = roachpb.NodeID(2)
@@ -179,7 +179,7 @@ func TestSchemaChangeProcess(t *testing.T) {
 		stopper,
 		&sql.MemoryMetrics{},
 	)
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	changer := sql.NewSchemaChangerForTesting(id, 0, node, *kvDB, leaseMgr)
 
 	if _, err := sqlDB.Exec(`
@@ -318,7 +318,7 @@ func TestAsyncSchemaChanger(t *testing.T) {
 		},
 	}
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
@@ -588,7 +588,7 @@ func TestRaceWithBackfill(t *testing.T) {
 			ReplicationMode: base.ReplicationManual,
 			ServerArgs:      params,
 		})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 	kvDB := tc.Server(0).KVClient().(*client.DB)
 	sqlDB := tc.ServerConn(0)
 
@@ -756,7 +756,7 @@ func TestBackfillErrors(t *testing.T) {
 			ReplicationMode: base.ReplicationManual,
 			ServerArgs:      params,
 		})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 	kvDB := tc.Server(0).KVClient().(*client.DB)
 	sqlDB := tc.ServerConn(0)
 
@@ -916,7 +916,7 @@ func TestAbortSchemaChangeBackfill(t *testing.T) {
 		},
 	}
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer server.Stopper().Stop()
+	defer server.Stopper().Stop(context.TODO())
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
@@ -1182,7 +1182,7 @@ func TestSchemaChangeRetry(t *testing.T) {
 		},
 	}
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
@@ -1263,7 +1263,7 @@ func TestSchemaChangeRetryOnVersionChange(t *testing.T) {
 		},
 	}
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
@@ -1373,7 +1373,7 @@ func TestSchemaChangePurgeFailure(t *testing.T) {
 		},
 	}
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer server.Stopper().Stop()
+	defer server.Stopper().Stop(context.TODO())
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
@@ -1486,7 +1486,7 @@ func TestSchemaChangeReverseMutations(t *testing.T) {
 		},
 	}
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	// Create a k-v table.
 	if _, err := sqlDB.Exec(`
@@ -1655,7 +1655,7 @@ func TestParseSentinelValueWithNewColumnInSentinelFamily(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	params, _ := createTestServerParams()
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer server.Stopper().Stop()
+	defer server.Stopper().Stop(context.TODO())
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
@@ -1776,7 +1776,7 @@ func TestUpdateDuringColumnBackfill(t *testing.T) {
 		},
 	}
 	server, sqlDB, _ := serverutils.StartServer(t, params)
-	defer server.Stopper().Stop()
+	defer server.Stopper().Stop(context.TODO())
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
@@ -1849,7 +1849,7 @@ func TestBackfillCompletesOnChunkBoundary(t *testing.T) {
 			ReplicationMode: base.ReplicationManual,
 			ServerArgs:      params,
 		})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 	kvDB := tc.Server(0).KVClient().(*client.DB)
 	sqlDB := tc.ServerConn(0)
 
@@ -1907,7 +1907,7 @@ func TestSchemaChangeInTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	params, _ := createTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
@@ -1977,7 +1977,7 @@ func TestSecondaryIndexWithOldStoringEncoding(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	params, _ := createTestServerParams()
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer server.Stopper().Stop()
+	defer server.Stopper().Stop(context.TODO())
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE d;

--- a/pkg/sql/session_test.go
+++ b/pkg/sql/session_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/lib/pq"
+	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -42,7 +43,7 @@ func TestSessionFinishRollsBackTxn(t *testing.T) {
 	params, _ := createTestServerParams()
 	params.Knobs.SQLExecutor = aborter.executorKnobs()
 	s, mainDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	{
 		pgURL, cleanup := sqlutils.PGUrl(
 			t, s.ServingAddr(), "TestSessionFinishRollsBackTxn", url.User(security.RootUser))

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
@@ -29,7 +31,7 @@ func TestShowCreateTable(t *testing.T) {
 
 	params, _ := createTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if _, err := sqlDB.Exec(`
 		CREATE DATABASE d;
@@ -219,7 +221,7 @@ func TestShowCreateView(t *testing.T) {
 
 	params, _ := createTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if _, err := sqlDB.Exec(`
 		CREATE DATABASE d;

--- a/pkg/sql/sort_test.go
+++ b/pkg/sql/sort_test.go
@@ -19,6 +19,8 @@ package sql_test
 import (
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
@@ -28,7 +30,7 @@ func TestOrderByRandom(t *testing.T) {
 
 	params, _ := createTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	seenOne := false
 	seenTwo := false

--- a/pkg/sql/split_at_test.go
+++ b/pkg/sql/split_at_test.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -36,7 +38,7 @@ func TestSplitAt(t *testing.T) {
 
 	params, _ := createTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	r := sqlutils.MakeSQLRunner(t, db)
 
@@ -150,7 +152,7 @@ func TestScatter(t *testing.T) {
 		// remove this when that is the case (#15003).
 		ReplicationMode: base.ReplicationManual,
 	})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 
 	sqlutils.CreateTable(
 		t, tc.ServerConn(0), "t",

--- a/pkg/sql/split_test.go
+++ b/pkg/sql/split_test.go
@@ -76,7 +76,7 @@ func TestSplitOnTableBoundaries(t *testing.T) {
 	params.ScanInterval = time.Millisecond
 	params.ScanMaxIdleTime = time.Millisecond
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	expectedInitialRanges, err := server.ExpectedInitialRangeCount(kvDB)
 	if err != nil {

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -601,7 +601,7 @@ func TestValidateTableDesc(t *testing.T) {
 func TestValidateCrossTableReferences(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	tests := []struct {
 		err        string
@@ -1077,7 +1077,7 @@ func TestKeysPerRow(t *testing.T) {
 	// a TableDescriptor. It should be possible to move MakeTableDesc into
 	// sqlbase. If/when that happens, use it here instead of this server.
 	s, conn, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	if _, err := conn.Exec(`CREATE DATABASE d`); err != nil {
 		t.Fatalf("%+v", err)
 	}

--- a/pkg/sql/table_ref_test.go
+++ b/pkg/sql/table_ref_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -30,7 +32,7 @@ func TestTableRefs(t *testing.T) {
 
 	params, _ := createTestServerParams()
 	s, db, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	// Populate the test database.
 	stmt := `

--- a/pkg/sql/table_split_test.go
+++ b/pkg/sql/table_split_test.go
@@ -38,7 +38,7 @@ func TestSplitAtTableBoundary(t *testing.T) {
 		ReplicationMode: base.ReplicationAuto,
 	}
 	tc := testcluster.StartTestCluster(t, 3, testClusterArgs)
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 
 	runner := sqlutils.MakeSQLRunner(t, tc.Conns[0])
 	runner.Exec(`CREATE DATABASE test`)

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"text/tabwriter"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
@@ -84,7 +86,7 @@ func TestExplainTrace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	params, _ := createTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if _, err := sqlDB.Exec(`CREATE DATABASE test; CREATE TABLE test.foo (id INT PRIMARY KEY)`); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -197,7 +197,7 @@ func checkRestarts(t *testing.T, magicVals *filterVals) {
 //		params, cmdFilters := createTestServerParams()
 //		params.Knobs.SQLExecutor = aborter.executorKnobs()
 //		s, sqlDB, _ := serverutils.StartServer(t, params)
-//		defer s.Stopper().Stop()
+//		defer s.Stopper().Stop(context.TODO())
 //		{
 //			pgURL, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), "TestTxnAutoRetry", url.User(security.RootUser)
 //			defer cleanup()
@@ -430,7 +430,7 @@ func TestTxnAutoRetry(t *testing.T) {
 	// Disable one phase commits because they cannot be restarted.
 	params.Knobs.Store.(*storage.StoreTestingKnobs).DisableOnePhaseCommits = true
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	{
 		pgURL, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), "TestTxnAutoRetry", url.User(security.RootUser))
 		defer cleanup()
@@ -588,7 +588,7 @@ func TestAbortedTxnOnlyRetriedOnce(t *testing.T) {
 	// Disable one phase commits because they cannot be restarted.
 	params.Knobs.Store.(*storage.StoreTestingKnobs).DisableOnePhaseCommits = true
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	{
 		pgURL, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), "TestAbortedTxnOnlyRetriedOnce", url.User(security.RootUser))
 		defer cleanup()
@@ -715,7 +715,7 @@ func TestTxnUserRestart(t *testing.T) {
 	params, cmdFilters := createTestServerParams()
 	params.Knobs.SQLExecutor = aborter.executorKnobs()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	{
 		pgURL, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), "TestTxnUserRestart", url.User(security.RootUser))
 		defer cleanup()
@@ -814,7 +814,7 @@ func TestCommitWaitState(t *testing.T) {
 
 	params, _ := createTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t; CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
 `); err != nil {
@@ -850,7 +850,7 @@ func TestErrorOnCommitFinalizesTxn(t *testing.T) {
 	params, _ := createTestServerParams()
 	params.Knobs.SQLExecutor = aborter.executorKnobs()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	{
 		pgURL, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), "TestErrorOnCommitFinalizesTxn", url.User(security.RootUser))
 		defer cleanup()
@@ -931,7 +931,7 @@ func TestRollbackToSavepointStatement(t *testing.T) {
 
 	params, _ := createTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	// ROLLBACK TO SAVEPOINT with a wrong name
 	_, err := sqlDB.Exec("ROLLBACK TO SAVEPOINT foo")
@@ -970,7 +970,7 @@ func TestNonRetriableError(t *testing.T) {
 
 	params, _ := createTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
@@ -1014,7 +1014,7 @@ func TestRollbackInRestartWait(t *testing.T) {
 	params, _ := createTestServerParams()
 	params.Knobs.SQLExecutor = aborter.executorKnobs()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	{
 		pgURL, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), "TestRollbackInRestartWait", url.User(security.RootUser))
 		defer cleanup()
@@ -1063,7 +1063,7 @@ func TestNonRetryableError(t *testing.T) {
 
 	params, cmdFilters := createTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	testKey := []byte("test_key")
 	hitError := false
@@ -1102,7 +1102,7 @@ func TestNonRetryableErrorOnCommit(t *testing.T) {
 
 	params, cmdFilters := createTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	hitError := false
 	cleanupFilter := cmdFilters.AppendFilter(
@@ -1166,7 +1166,7 @@ func TestReacquireLeaseOnRestart(t *testing.T) {
 	params, _ := createTestServerParams()
 	params.Knobs.Store = testingKnobs
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	var restartDone int32
 	cleanupFilter := cmdFilters.AppendFilter(
@@ -1223,7 +1223,7 @@ func TestRetryableErrorForWrongTxn(t *testing.T) {
 
 	params, _ := createTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
 CREATE TABLE t.test (k TEXT PRIMARY KEY, v TEXT);

--- a/pkg/sql/upsert_test.go
+++ b/pkg/sql/upsert_test.go
@@ -58,7 +58,7 @@ func TestUpsertFastPath(t *testing.T) {
 			TestingEvalFilter: filter,
 		}},
 	})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	sqlDB := sqlutils.MakeSQLRunner(t, conn)
 	sqlDB.Exec(`CREATE DATABASE d`)
 	sqlDB.Exec(`CREATE TABLE d.kv (k INT PRIMARY KEY, v INT)`)
@@ -134,7 +134,7 @@ func TestConcurrentUpsertWithSnapshotIsolation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	s, conn, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	sqlDB := sqlutils.MakeSQLRunner(t, conn)
 
 	sqlDB.Exec(`CREATE DATABASE d`)

--- a/pkg/storage/abort_cache_test.go
+++ b/pkg/storage/abort_cache_test.go
@@ -61,7 +61,7 @@ func createTestAbortCache(
 func TestAbortCachePutGetClearData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.Background())
 	sc, e := createTestAbortCache(t, 1, stopper)
 	// Start with a get for an uncached id.
 	entry := roachpb.AbortCacheEntry{}
@@ -102,7 +102,7 @@ func TestAbortCachePutGetClearData(t *testing.T) {
 func TestAbortCacheEmptyParams(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.Background())
 	sc, e := createTestAbortCache(t, 1, stopper)
 
 	entry := roachpb.AbortCacheEntry{
@@ -121,7 +121,7 @@ func TestAbortCacheEmptyParams(t *testing.T) {
 func TestAbortCacheCopyInto(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.Background())
 	rc1, e := createTestAbortCache(t, 1, stopper)
 	rc2, _ := createTestAbortCache(t, 2, stopper)
 
@@ -155,7 +155,7 @@ func TestAbortCacheCopyInto(t *testing.T) {
 func TestAbortCacheCopyFrom(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.Background())
 	rc1, e := createTestAbortCache(t, 1, stopper)
 	rc2, _ := createTestAbortCache(t, 2, stopper)
 

--- a/pkg/storage/addressing_test.go
+++ b/pkg/storage/addressing_test.go
@@ -72,7 +72,7 @@ func metaKey(key roachpb.RKey) []byte {
 func TestUpdateRangeAddressing(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 
 	// When split is false, merging treats the right range as the merged

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -237,7 +237,7 @@ func TestAllocatorSimpleRetrieval(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
-	defer stopper.Stop()
+	defer stopper.Stop(context.Background())
 	gossiputil.NewStoreGossiper(g).GossipStores(singleStore, t)
 	result, err := a.AllocateTarget(
 		context.Background(),
@@ -260,7 +260,7 @@ func TestAllocatorCorruptReplica(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper, g, sp, a, _ := createTestAllocator( /* deterministic */ false)
-	defer stopper.Stop()
+	defer stopper.Stop(context.Background())
 	gossiputil.NewStoreGossiper(g).GossipStores(sameDCStores, t)
 	const store1ID = roachpb.StoreID(1)
 
@@ -292,7 +292,7 @@ func TestAllocatorNoAvailableDisks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper, _, _, a, _ := createTestAllocator( /* deterministic */ false)
-	defer stopper.Stop()
+	defer stopper.Stop(context.Background())
 	result, err := a.AllocateTarget(
 		context.Background(),
 		simpleZoneConfig.Constraints,
@@ -312,7 +312,7 @@ func TestAllocatorTwoDatacenters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
-	defer stopper.Stop()
+	defer stopper.Stop(context.Background())
 	gossiputil.NewStoreGossiper(g).GossipStores(multiDCStores, t)
 	ctx := context.Background()
 	result1, err := a.AllocateTarget(
@@ -369,7 +369,7 @@ func TestAllocatorExistingReplica(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
-	defer stopper.Stop()
+	defer stopper.Stop(context.Background())
 	gossiputil.NewStoreGossiper(g).GossipStores(sameDCStores, t)
 	result, err := a.AllocateTarget(
 		context.Background(),
@@ -403,7 +403,7 @@ func TestAllocatorRelaxConstraints(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
-	defer stopper.Stop()
+	defer stopper.Stop(context.Background())
 	gossiputil.NewStoreGossiper(g).GossipStores(multiDCStores, t)
 
 	testCases := []struct {
@@ -620,7 +620,7 @@ func TestAllocatorRebalance(t *testing.T) {
 	}
 
 	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
-	defer stopper.Stop()
+	defer stopper.Stop(context.Background())
 
 	gossiputil.NewStoreGossiper(g).GossipStores(stores, t)
 	ctx := context.Background()
@@ -744,7 +744,7 @@ func TestAllocatorRebalanceThrashing(t *testing.T) {
 			// Deterministic is required when stressing as test case 8 may rebalance
 			// to different configurations.
 			stopper, g, _, a, _ := createTestAllocator( /* deterministic */ true)
-			defer stopper.Stop()
+			defer stopper.Stop(context.Background())
 
 			// Create stores with the range counts from the test case and gossip them.
 			var stores []*roachpb.StoreDescriptor
@@ -814,7 +814,7 @@ func TestAllocatorRebalanceByCount(t *testing.T) {
 	}
 
 	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
-	defer stopper.Stop()
+	defer stopper.Stop(context.Background())
 
 	gossiputil.NewStoreGossiper(g).GossipStores(stores, t)
 	ctx := context.Background()
@@ -852,7 +852,7 @@ func TestAllocatorRebalanceByCount(t *testing.T) {
 func TestAllocatorTransferLeaseTarget(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ true)
-	defer stopper.Stop()
+	defer stopper.Stop(context.Background())
 
 	// 3 stores where the lease count for each store is equal to 10x the store
 	// ID.
@@ -914,7 +914,7 @@ func TestAllocatorTransferLeaseTarget(t *testing.T) {
 func TestAllocatorTransferLeaseTargetMultiStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ true)
-	defer stopper.Stop()
+	defer stopper.Stop(context.Background())
 
 	// 3 nodes and 6 stores where the lease count for the first store on each
 	// node is equal to 10x the node ID.
@@ -967,7 +967,7 @@ func TestAllocatorTransferLeaseTargetMultiStore(t *testing.T) {
 func TestAllocatorShouldTransferLease(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ true)
-	defer stopper.Stop()
+	defer stopper.Stop(context.Background())
 
 	// 4 stores where the lease count for each store is equal to 10x the store
 	// ID.
@@ -1037,7 +1037,7 @@ func TestAllocatorTransferLeaseTargetLoadBased(t *testing.T) {
 
 	stopper, g, _, storePool, _ := createTestStorePool(
 		TestTimeUntilStoreDeadOff, true /* deterministic */, nodeStatusLive)
-	defer stopper.Stop()
+	defer stopper.Stop(context.Background())
 
 	// 3 stores where the lease count for each store is equal to 10x the store ID.
 	var stores []*roachpb.StoreDescriptor
@@ -1365,11 +1365,11 @@ func TestAllocatorRemoveTarget(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
 	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
-	defer stopper.Stop()
+	defer stopper.Stop(ctx)
 	sg := gossiputil.NewStoreGossiper(g)
 	sg.GossipStores(stores, t)
-	ctx := context.Background()
 
 	// Repeat this test 10 times, it should always be either store 2 or 3.
 	for i := 0; i < 10; i++ {
@@ -1748,7 +1748,8 @@ func TestAllocatorComputeAction(t *testing.T) {
 	}
 
 	stopper, _, sp, a, _ := createTestAllocator( /* deterministic */ false)
-	defer stopper.Stop()
+	ctx := context.Background()
+	defer stopper.Stop(ctx)
 
 	// Set up eight stores. Stores six and seven are marked as dead. Replica eight
 	// is dead.
@@ -1765,7 +1766,6 @@ func TestAllocatorComputeAction(t *testing.T) {
 		}})
 
 	lastPriority := float64(999999999)
-	ctx := context.Background()
 	for i, tcase := range testCases {
 		action, priority := a.ComputeAction(ctx, tcase.zone, &tcase.desc)
 		if tcase.expectedAction != action {
@@ -1839,8 +1839,8 @@ func TestAllocatorThrottled(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
-	defer stopper.Stop()
 	ctx := context.Background()
+	defer stopper.Stop(ctx)
 
 	// First test to make sure we would send the replica to purgatory.
 	_, err := a.AllocateTarget(
@@ -2057,7 +2057,7 @@ func TestAllocatorRebalanceAway(t *testing.T) {
 	}
 
 	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	gossiputil.NewStoreGossiper(g).GossipStores(stores, t)
 	ctx := context.Background()
 
@@ -2111,7 +2111,7 @@ func (ts *testStore) rebalance(ots *testStore, bytes int64) {
 
 func Example_rebalancing() {
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -71,7 +71,7 @@ func TestStoreRangeMergeTwoEmptyRanges(t *testing.T) {
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	if _, _, err := createSplitRanges(store); err != nil {
@@ -101,7 +101,7 @@ func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	scan := func(f func(roachpb.KeyValue) (bool, error)) {
@@ -181,7 +181,7 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	content := roachpb.Key("testing!")
@@ -310,7 +310,7 @@ func TestStoreRangeMergeLastRange(t *testing.T) {
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	// Merge last range.
@@ -379,7 +379,7 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	storeCfg := storage.TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	// Split the range.
@@ -440,7 +440,7 @@ func BenchmarkStoreRangeMerge(b *testing.B) {
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(b, stopper, storeCfg)
 
 	// Perform initial split of ranges.

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -73,7 +73,7 @@ func TestStoreRecoverFromEngine(t *testing.T) {
 	key2 := roachpb.Key("z")
 
 	engineStopper := stop.NewStopper()
-	defer engineStopper.Stop()
+	defer engineStopper.Stop(context.TODO())
 	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 	engineStopper.AddCloser(eng)
 	var rangeID2 roachpb.RangeID
@@ -101,7 +101,7 @@ func TestStoreRecoverFromEngine(t *testing.T) {
 	// that both predate and postdate the split.
 	func() {
 		stopper := stop.NewStopper()
-		defer stopper.Stop()
+		defer stopper.Stop(context.TODO())
 		store := createTestStoreWithEngine(t, eng, true, storeCfg, stopper)
 
 		increment := func(rangeID roachpb.RangeID, key roachpb.Key, value int64) (*roachpb.IncrementResponse, *roachpb.Error) {
@@ -173,7 +173,7 @@ func TestStoreRecoverWithErrors(t *testing.T) {
 
 	func() {
 		stopper := stop.NewStopper()
-		defer stopper.Stop()
+		defer stopper.Stop(context.TODO())
 		keyA := roachpb.Key("a")
 		storeCfg := storeCfg // copy
 		storeCfg.TestingKnobs.TestingEvalFilter =
@@ -205,7 +205,7 @@ func TestStoreRecoverWithErrors(t *testing.T) {
 	}
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	// Recover from the engine.
 	store := createTestStoreWithEngine(t, eng, false, storeCfg, stopper)

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -188,7 +188,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 	var numGets int32
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	manual := hlc.NewManualClock(123)
 	cfg := storage.TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
 	// Splits can cause our chosen key to end up on a range other than range 1,
@@ -329,7 +329,7 @@ func TestRangeLookupUseReverse(t *testing.T) {
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	// Init test ranges:
@@ -947,7 +947,7 @@ func TestLeaseExtensionNotBlockedByRead(t *testing.T) {
 			},
 		})
 	s := srv.(*server.TestServer)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	// Start a read and wait for it to block.
 	key := roachpb.Key("a")
@@ -1024,7 +1024,7 @@ func TestLeaseInfoRequest(t *testing.T) {
 		base.TestClusterArgs{
 			ReplicationMode: base.ReplicationManual,
 		})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 
 	kvDB0 := tc.Servers[0].DB()
 	kvDB1 := tc.Servers[1].DB()
@@ -1128,7 +1128,7 @@ func TestErrorHandlingForNonKVCommand(t *testing.T) {
 			},
 		})
 	s := srv.(*server.TestServer)
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	// Send the lease request.
 	key := roachpb.Key("a")

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -71,7 +71,7 @@ func adminSplitArgs(key, splitKey roachpb.Key) *roachpb.AdminSplitRequest {
 func TestStoreRangeSplitAtIllegalKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	cfg := storage.TestStoreConfig(nil)
 	cfg.TestingKnobs.DisableSplitQueue = true
@@ -99,7 +99,7 @@ func TestStoreRangeSplitAtTablePrefix(t *testing.T) {
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	key := keys.MakeRowSentinelKey(append([]byte(nil), keys.UserTableDataMin...))
@@ -154,7 +154,7 @@ func TestStoreRangeSplitInsideRow(t *testing.T) {
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	// Manually create some the column keys corresponding to the table:
@@ -208,7 +208,7 @@ func TestStoreRangeSplitIntents(t *testing.T) {
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	// First, write some values left and right of the proposed split key.
@@ -276,7 +276,7 @@ func TestStoreRangeSplitAtRangeBounds(t *testing.T) {
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	args := adminSplitArgs(roachpb.KeyMin, []byte("a"))
@@ -302,7 +302,7 @@ func TestStoreRangeSplitConcurrent(t *testing.T) {
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	splitKey := roachpb.Key("a")
@@ -356,7 +356,7 @@ func TestStoreRangeSplitIdempotency(t *testing.T) {
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 	rangeID := roachpb.RangeID(1)
 	splitKey := roachpb.Key("m")
@@ -506,7 +506,7 @@ func TestStoreRangeSplitStats(t *testing.T) {
 	storeCfg := storage.TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	// Split the range after the last table data key.
@@ -616,7 +616,7 @@ func TestStoreRangeSplitStatsWithMerges(t *testing.T) {
 	storeCfg := storage.TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	// Split the range after the last table data key.
@@ -717,7 +717,7 @@ func fillRange(
 func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 	config.TestingSetupZoneConfigHook(stopper)
 
@@ -773,7 +773,7 @@ func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 func TestStoreRangeSplitWithMaxBytesUpdate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 	config.TestingSetupZoneConfigHook(stopper)
 
@@ -808,7 +808,7 @@ func TestStoreRangeSplitWithMaxBytesUpdate(t *testing.T) {
 func TestStoreRangeSystemSplits(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 
 	schema := sqlbase.MakeMetadataSchema()
@@ -1158,7 +1158,7 @@ func TestStoreSplitTimestampCacheDifferentLeaseHolder(t *testing.T) {
 	}
 
 	tc := testcluster.StartTestCluster(t, 2, args)
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 
 	// Split the data range, mainly to avoid other splits getting in our way.
 	for _, k := range []roachpb.Key{leftKey, rightKey} {
@@ -1440,7 +1440,7 @@ func BenchmarkStoreRangeSplit(b *testing.B) {
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(b, stopper, storeCfg)
 
 	// Perform initial split of ranges.
@@ -1605,7 +1605,7 @@ func TestStoreSplitBeginTxnPushMetaIntentRace(t *testing.T) {
 		return nil
 	}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	// Advance the clock past the transaction cleanup expiration.
@@ -1682,7 +1682,7 @@ func TestStoreRangeGossipOnSplits(t *testing.T) {
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	storeCfg.TestingKnobs.DisableScanner = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 	storeKey := gossip.MakeStoreKey(store.StoreID())
 
@@ -1747,7 +1747,7 @@ func TestStorePushTxnQueueEnabledOnSplit(t *testing.T) {
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	key := keys.MakeRowSentinelKey(append([]byte(nil), keys.UserTableDataMin...))
@@ -1769,7 +1769,7 @@ func TestDistributedTxnCleanup(t *testing.T) {
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	// Split at "a".
@@ -1866,7 +1866,7 @@ func TestUnsplittableRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	store := createTestStoreWithConfig(t, stopper, storage.TestStoreConfig(nil))
 	store.ForceSplitScanAndProcess()
@@ -1950,7 +1950,7 @@ func TestPushTxnQueueDependencyCycleWithRangeSplit(t *testing.T) {
 					return nil
 				}
 			stopper := stop.NewStopper()
-			defer stopper.Stop()
+			defer stopper.Stop(context.TODO())
 			store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 			lhsKey := roachpb.Key("a")

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -319,7 +319,7 @@ func (m *multiTestContext) Stop() {
 					// any test (TestRaftAfterRemove is a good example) results
 					// in deadlocks where a task can't finish because of
 					// getting stuck in addWriteCommand.
-					s.Quiesce()
+					s.Quiesce(context.TODO())
 				}
 			}(s)
 		}
@@ -330,13 +330,13 @@ func (m *multiTestContext) Stop() {
 		defer m.mu.RUnlock()
 		for _, stopper := range m.stoppers {
 			if stopper != nil {
-				stopper.Stop()
+				stopper.Stop(context.TODO())
 			}
 		}
-		m.transportStopper.Stop()
+		m.transportStopper.Stop(context.TODO())
 
 		for _, s := range m.engineStoppers {
-			s.Stop()
+			s.Stop(context.TODO())
 		}
 		close(done)
 	}()
@@ -844,7 +844,7 @@ func (m *multiTestContext) stopStore(i int) {
 	stopper := m.stoppers[i]
 	m.mu.RUnlock()
 
-	stopper.Stop()
+	stopper.Stop(context.TODO())
 
 	m.mu.Lock()
 	m.stoppers[i] = nil

--- a/pkg/storage/engine/batch_test.go
+++ b/pkg/storage/engine/batch_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
@@ -53,7 +54,7 @@ func mvccKey(k interface{}) MVCCKey {
 
 func testBatchBasics(t *testing.T, writeOnly bool, commit func(e Engine, b Batch) error) {
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	e := NewInMem(roachpb.Attributes{}, 1<<20)
 	stopper.AddCloser(e)
 
@@ -193,7 +194,7 @@ func TestWriteBatchBasics(t *testing.T) {
 func TestApplyBatchRepr(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	e := NewInMem(roachpb.Attributes{}, 1<<20)
 	stopper.AddCloser(e)
 
@@ -255,7 +256,7 @@ func TestApplyBatchRepr(t *testing.T) {
 func TestBatchGet(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	e := NewInMem(roachpb.Attributes{}, 1<<20)
 	stopper.AddCloser(e)
 
@@ -310,7 +311,7 @@ func compareMergedValues(t *testing.T, result, expected []byte) bool {
 func TestBatchMerge(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	e := NewInMem(roachpb.Attributes{}, 1<<20)
 	stopper.AddCloser(e)
 
@@ -368,7 +369,7 @@ func TestBatchMerge(t *testing.T) {
 func TestBatchProto(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	e := NewInMem(roachpb.Attributes{}, 1<<20)
 	stopper.AddCloser(e)
 
@@ -416,7 +417,7 @@ func TestBatchProto(t *testing.T) {
 func TestBatchScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	e := NewInMem(roachpb.Attributes{}, 1<<20)
 	stopper.AddCloser(e)
 
@@ -510,7 +511,7 @@ func TestBatchScan(t *testing.T) {
 func TestBatchScanWithDelete(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	e := NewInMem(roachpb.Attributes{}, 1<<20)
 	stopper.AddCloser(e)
 
@@ -539,7 +540,7 @@ func TestBatchScanWithDelete(t *testing.T) {
 func TestBatchScanMaxWithDeleted(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	e := NewInMem(roachpb.Attributes{}, 1<<20)
 	stopper.AddCloser(e)
 
@@ -574,7 +575,7 @@ func TestBatchScanMaxWithDeleted(t *testing.T) {
 func TestBatchConcurrency(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	e := NewInMem(roachpb.Attributes{}, 1<<20)
 	stopper.AddCloser(e)
 
@@ -610,7 +611,7 @@ func TestBatchBuilder(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	e := NewInMem(roachpb.Attributes{}, 1<<20)
 	stopper.AddCloser(e)
 
@@ -659,7 +660,7 @@ func TestBatchBuilderStress(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	e := NewInMem(roachpb.Attributes{}, 1<<20)
 	stopper.AddCloser(e)
 
@@ -725,7 +726,7 @@ func TestBatchDistinct(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	e := NewInMem(roachpb.Attributes{}, 1<<20)
 	stopper.AddCloser(e)
 
@@ -797,7 +798,7 @@ func TestWriteOnlyBatchDistinct(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	e := NewInMem(roachpb.Attributes{}, 1<<20)
 	stopper.AddCloser(e)
 
@@ -841,7 +842,7 @@ func TestBatchDistinctPanics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	e := NewInMem(roachpb.Attributes{}, 1<<20)
 	stopper.AddCloser(e)
 
@@ -882,7 +883,7 @@ func TestBatchIteration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	e := NewInMem(roachpb.Attributes{}, 1<<20)
 	defer e.Close()
 
@@ -957,7 +958,7 @@ func TestBatchCombine(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	e := NewInMem(roachpb.Attributes{}, 1<<20)
 	stopper.AddCloser(e)
 

--- a/pkg/storage/engine/engine_test.go
+++ b/pkg/storage/engine/engine_test.go
@@ -60,7 +60,7 @@ var (
 // invokes the supplied test func with each instance.
 func runWithAllEngines(test func(e Engine, t *testing.T), t *testing.T) {
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	inMem := NewInMem(inMemAttrs, testCacheSize)
 	stopper.AddCloser(inMem)
 	test(inMem, t)

--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -56,7 +56,7 @@ func TestGCQueueShouldQueue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	cfg, ok := tc.gossip.GetSystemConfig()
@@ -166,7 +166,7 @@ func TestGCQueueProcess(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	tc.manualClock.Increment(48 * 60 * 60 * 1E9) // 2d past the epoch
@@ -457,7 +457,7 @@ func TestGCQueueTransactionTable(t *testing.T) {
 		}
 	tc := testContext{manualClock: manual}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.StartWithStoreConfig(t, stopper, tsc)
 
 	outsideKey := tc.repl.Desc().EndKey.Next().AsRawKey()
@@ -571,7 +571,7 @@ func TestGCQueueIntentResolution(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	tc.manualClock.Set(48 * 60 * 60 * 1E9) // 2d past the epoch
@@ -636,7 +636,7 @@ func TestGCQueueLastProcessedTimestamps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	// Create two last processed times both at the range start key and

--- a/pkg/storage/gossip_test.go
+++ b/pkg/storage/gossip_test.go
@@ -43,7 +43,7 @@ func TestGossipFirstRange(t *testing.T) {
 		base.TestClusterArgs{
 			ReplicationMode: base.ReplicationManual,
 		})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 
 	errors := make(chan error)
 	descs := make(chan *roachpb.RangeDescriptor)
@@ -159,7 +159,7 @@ func TestGossipHandlesReplacedNode(t *testing.T) {
 			ReplicationMode: base.ReplicationAuto,
 			ServerArgs:      serverArgs,
 		})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 
 	// Take down a node other than the first node and replace it with a new one.
 	// Replacing the first node would be better from an adversarial testing

--- a/pkg/storage/id_alloc.go
+++ b/pkg/storage/id_alloc.go
@@ -92,8 +92,8 @@ func (ia *idAllocator) Allocate() (uint32, error) {
 }
 
 func (ia *idAllocator) start() {
-	ia.stopper.RunWorker(func() {
-		ctx := ia.AnnotateCtx(context.Background())
+	ctx := ia.AnnotateCtx(context.Background())
+	ia.stopper.RunWorker(ctx, func() {
 		defer close(ia.ids)
 
 		for {
@@ -103,7 +103,7 @@ func (ia *idAllocator) start() {
 				var res client.KeyValue
 				for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
 					idKey := ia.idKey.Load().(roachpb.Key)
-					if err := ia.stopper.RunTask(func() {
+					if err := ia.stopper.RunTask(ctx, func() {
 						res, err = ia.db.Inc(ctx, idKey, int64(ia.blockSize))
 					}); err != nil {
 						log.Warning(ctx, err)

--- a/pkg/storage/id_alloc.go
+++ b/pkg/storage/id_alloc.go
@@ -93,7 +93,7 @@ func (ia *idAllocator) Allocate() (uint32, error) {
 
 func (ia *idAllocator) start() {
 	ctx := ia.AnnotateCtx(context.Background())
-	ia.stopper.RunWorker(ctx, func() {
+	ia.stopper.RunWorker(ctx, func(ctx context.Context) {
 		defer close(ia.ids)
 
 		for {
@@ -103,7 +103,7 @@ func (ia *idAllocator) start() {
 				var res client.KeyValue
 				for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
 					idKey := ia.idKey.Load().(roachpb.Key)
-					if err := ia.stopper.RunTask(ctx, func() {
+					if err := ia.stopper.RunTask(ctx, func(ctx context.Context) {
 						res, err = ia.db.Inc(ctx, idKey, int64(ia.blockSize))
 					}); err != nil {
 						log.Warning(ctx, err)

--- a/pkg/storage/id_alloc_test.go
+++ b/pkg/storage/id_alloc_test.go
@@ -42,7 +42,7 @@ import (
 func TestIDAllocator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 	const maxI, maxJ = 10, 10
 	allocd := make(chan uint32, maxI*maxJ)
@@ -95,7 +95,7 @@ func TestIDAllocator(t *testing.T) {
 func TestIDAllocatorNegativeValue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 
 	// Increment our key to a negative value.
@@ -146,7 +146,7 @@ func TestNewIDAllocatorInvalidArgs(t *testing.T) {
 func TestAllocateErrorAndRecovery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 	const routines = 10
 	allocd := make(chan uint32, routines)
@@ -244,7 +244,7 @@ func TestAllocateWithStopper(t *testing.T) {
 	// before the end of the test.
 	idAlloc := func() *idAllocator {
 		stopper := stop.NewStopper()
-		defer stopper.Stop()
+		defer stopper.Stop(context.TODO())
 		store, _ := createTestStore(t, stopper)
 		idAlloc, err := newIDAllocator(
 			log.AmbientContext{}, keys.RangeIDGenerator, store.cfg.DB, 2, 10, stopper,

--- a/pkg/storage/intent_resolver_test.go
+++ b/pkg/storage/intent_resolver_test.go
@@ -35,7 +35,7 @@ func TestPushTransactionsWithNonPendingIntent(t *testing.T) {
 
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	intents := []roachpb.Intent{{Span: roachpb.Span{Key: roachpb.Key("a")}, Status: roachpb.ABORTED}}

--- a/pkg/storage/log_test.go
+++ b/pkg/storage/log_test.go
@@ -41,7 +41,7 @@ import (
 func TestLogSplits(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	countSplits := func() int {
 		var count int
@@ -138,7 +138,7 @@ func TestLogSplits(t *testing.T) {
 func TestLogRebalances(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, db := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 
 	// Use a client to get the RangeDescriptor for the first range. We will use
 	// this range's information to log fake rebalance events.

--- a/pkg/storage/migration_test.go
+++ b/pkg/storage/migration_test.go
@@ -32,7 +32,7 @@ import (
 func TestMigrate7310And6991(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	eng := engine.NewInMem(roachpb.Attributes{}, 1<<10)
 	stopper.AddCloser(eng)
 

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -230,7 +230,7 @@ func (nl *NodeLiveness) StartHeartbeat(
 	nl.mu.heartbeatCallback = alive
 	nl.mu.Unlock()
 
-	stopper.RunWorker(ctx, func() {
+	stopper.RunWorker(ctx, func(context.Context) {
 		ambient := nl.ambientCtx
 		ambient.AddLogTag("hb", nil)
 		ticker := time.NewTicker(nl.heartbeatInterval)

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -230,7 +230,7 @@ func (nl *NodeLiveness) StartHeartbeat(
 	nl.mu.heartbeatCallback = alive
 	nl.mu.Unlock()
 
-	stopper.RunWorker(func() {
+	stopper.RunWorker(ctx, func() {
 		ambient := nl.ambientCtx
 		ambient.AddLogTag("hb", nil)
 		ticker := time.NewTicker(nl.heartbeatInterval)

--- a/pkg/storage/push_txn_queue_test.go
+++ b/pkg/storage/push_txn_queue_test.go
@@ -153,7 +153,7 @@ func TestPushTxnQueueEnableDisable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	txn, err := createTxnForPushQueue(context.Background(), &tc)
@@ -234,7 +234,7 @@ func TestPushTxnQueueCancel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	txn, err := createTxnForPushQueue(context.Background(), &tc)
@@ -283,7 +283,7 @@ func TestPushTxnQueueUpdateTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	txn, err := createTxnForPushQueue(context.Background(), &tc)
@@ -351,7 +351,7 @@ func TestPushTxnQueueUpdateNotPushedTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	txn, err := createTxnForPushQueue(context.Background(), &tc)
@@ -419,7 +419,7 @@ func TestPushTxnQueuePusheeExpires(t *testing.T) {
 			return nil
 		}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.StartWithStoreConfig(t, stopper, tsc)
 
 	pusher1 := newTransaction("pusher1", roachpb.Key("a"), 1, enginepb.SERIALIZABLE, tc.Clock())
@@ -487,7 +487,7 @@ func TestPushTxnQueuePusherUpdate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	txn, err := createTxnForPushQueue(context.Background(), &tc)
@@ -542,7 +542,7 @@ func TestPushTxnQueueDependencyCycle(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	txnA, err := createTxnForPushQueue(context.Background(), &tc)
@@ -617,7 +617,7 @@ func TestPushTxnQueueDependencyCycleWithPriorityInversion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	// Create txnA with a lower priority so it won't think it could push

--- a/pkg/storage/put_test.go
+++ b/pkg/storage/put_test.go
@@ -46,7 +46,7 @@ func TestPut(t *testing.T) {
 		base.TestClusterArgs{
 			ReplicationMode: base.ReplicationAuto,
 		})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 	ctx := context.Background()
 
 	db := tc.Servers[0].DB()

--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -471,8 +471,8 @@ func (bq *baseQueue) MaybeRemove(rangeID roachpb.RangeID) {
 // processLoop processes the entries in the queue until the provided
 // stopper signals exit.
 func (bq *baseQueue) processLoop(clock *hlc.Clock, stopper *stop.Stopper) {
-	stopper.RunWorker(func() {
-		ctx := bq.AnnotateCtx(context.Background())
+	ctx := bq.AnnotateCtx(context.Background())
+	stopper.RunWorker(ctx, func() {
 		defer func() {
 			bq.mu.Lock()
 			bq.mu.stopped = true
@@ -508,8 +508,8 @@ func (bq *baseQueue) processLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 				repl := bq.pop()
 				var duration time.Duration
 				if repl != nil {
-					if stopper.RunTask(func() {
-						annotatedCtx := repl.AnnotateCtx(ctx)
+					annotatedCtx := repl.AnnotateCtx(ctx)
+					if stopper.RunTask(annotatedCtx, func() {
 						start := timeutil.Now()
 						if err := bq.processReplica(annotatedCtx, repl, clock); err != nil {
 							// Maybe add failing replica to purgatory if the queue supports it.
@@ -664,8 +664,9 @@ func (bq *baseQueue) maybeAddToPurgatory(
 		repl.RangeID: triggeringErr,
 	}
 
-	stopper.RunWorker(func() {
-		ctx := bq.AnnotateCtx(context.Background())
+	workerCtx := bq.AnnotateCtx(context.Background())
+	stopper.RunWorker(workerCtx, func() {
+		ctx := workerCtx
 		ticker := time.NewTicker(purgatoryReportInterval)
 		for {
 			select {
@@ -685,8 +686,8 @@ func (bq *baseQueue) maybeAddToPurgatory(
 						log.Errorf(ctx, "range %s no longer exists on store: %s", id, err)
 						return
 					}
-					if stopper.RunTask(func() {
-						annotatedCtx := repl.AnnotateCtx(ctx)
+					annotatedCtx := repl.AnnotateCtx(ctx)
+					if stopper.RunTask(annotatedCtx, func() {
 						if err := bq.processReplica(annotatedCtx, repl, clock); err != nil {
 							bq.maybeAddToPurgatory(annotatedCtx, repl, err, clock, stopper)
 						}

--- a/pkg/storage/queue_test.go
+++ b/pkg/storage/queue_test.go
@@ -131,7 +131,7 @@ func TestBaseQueueAddUpdateAndRemove(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	// Remove replica for range 1 since it encompasses the entire keyspace.
@@ -248,7 +248,7 @@ func TestBaseQueueAdd(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	r, err := tc.store.GetReplica(1)
@@ -285,7 +285,7 @@ func TestBaseQueueProcess(t *testing.T) {
 	tsc := TestStoreConfig(nil)
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.StartWithStoreConfig(t, stopper, tsc)
 
 	// Remove replica for range 1 since it encompasses the entire keyspace.
@@ -368,7 +368,7 @@ func TestBaseQueueAddRemove(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	r, err := tc.store.GetReplica(1)
@@ -410,7 +410,7 @@ func TestBaseQueueAddRemove(t *testing.T) {
 func TestAcceptsUnsplitRanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	s, _ := createTestStore(t, stopper)
 
 	maxWontSplitAddr, err := keys.Addr(keys.SystemPrefix)
@@ -541,7 +541,7 @@ func TestBaseQueuePurgatory(t *testing.T) {
 	tsc := TestStoreConfig(nil)
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.StartWithStoreConfig(t, stopper, tsc)
 
 	testQueue := &testQueueImpl{
@@ -692,7 +692,7 @@ func TestBaseQueueProcessTimeout(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	r, err := tc.store.GetReplica(1)
@@ -749,7 +749,7 @@ func TestBaseQueueTimeMetric(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	r, err := tc.store.GetReplica(1)
@@ -820,7 +820,7 @@ func TestBaseQueueDisable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	r, err := tc.store.GetReplica(1)

--- a/pkg/storage/raft_log_queue_test.go
+++ b/pkg/storage/raft_log_queue_test.go
@@ -116,7 +116,7 @@ func TestComputeTruncatableIndex(t *testing.T) {
 func TestGetTruncatableIndexes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 	store.SetRaftLogQueueActive(false)
 
@@ -230,7 +230,7 @@ func TestProactiveRaftLogTruncate(t *testing.T) {
 	t.Skip("#9772")
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 
 	store.SetReplicaScannerActive(false)
@@ -258,7 +258,7 @@ func TestProactiveRaftLogTruncate(t *testing.T) {
 	}
 
 	// Wait for any asynchronous tasks to finish.
-	stopper.Quiesce()
+	stopper.Quiesce(context.TODO())
 
 	r.mu.Lock()
 	newFirstIndex, err := r.FirstIndex()

--- a/pkg/storage/raft_transport_test.go
+++ b/pkg/storage/raft_transport_test.go
@@ -125,7 +125,7 @@ func newRaftTransportTestContext(t testing.TB) *raftTransportTestContext {
 }
 
 func (rttc *raftTransportTestContext) Stop() {
-	rttc.stopper.Stop()
+	rttc.stopper.Stop(context.TODO())
 }
 
 // AddNode registers a node with the cluster. Nodes must be added
@@ -531,7 +531,7 @@ func TestReopenConnection(t *testing.T) {
 
 	// Take down the old server and start a new one at the same address.
 	serverTransport.Stop(serverReplica.StoreID)
-	serverStopper.Stop()
+	serverStopper.Stop(context.TODO())
 
 	replacementReplica := roachpb.ReplicaDescriptor{
 		NodeID:    3,

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4394,7 +4394,7 @@ func (r *Replica) getLeaseForGossip(ctx context.Context) (bool, *roachpb.Error) 
 	}
 	var hasLease bool
 	var pErr *roachpb.Error
-	if err := r.store.Stopper().RunTask(func() {
+	if err := r.store.Stopper().RunTask(ctx, func() {
 		// Check for or obtain the lease, if none active.
 		_, pErr = r.redirectOnOrAcquireLease(ctx)
 		hasLease = pErr == nil

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4394,7 +4394,7 @@ func (r *Replica) getLeaseForGossip(ctx context.Context) (bool, *roachpb.Error) 
 	}
 	var hasLease bool
 	var pErr *roachpb.Error
-	if err := r.store.Stopper().RunTask(ctx, func() {
+	if err := r.store.Stopper().RunTask(ctx, func(ctx context.Context) {
 		// Check for or obtain the lease, if none active.
 		_, pErr = r.redirectOnOrAcquireLease(ctx)
 		hasLease = pErr == nil

--- a/pkg/storage/replica_data_iter_test.go
+++ b/pkg/storage/replica_data_iter_test.go
@@ -117,7 +117,7 @@ func TestReplicaDataIteratorEmptyRange(t *testing.T) {
 		bootstrapMode: bootstrapRangeOnly,
 	}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	// Adjust the range descriptor to avoid existing data such as meta
@@ -154,7 +154,7 @@ func TestReplicaDataIterator(t *testing.T) {
 		bootstrapMode: bootstrapRangeOnly,
 	}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.StartWithStoreConfig(t, stopper, cfg)
 
 	// See notes in EmptyRange test method for adjustment to descriptor.

--- a/pkg/storage/replica_raftstorage_test.go
+++ b/pkg/storage/replica_raftstorage_test.go
@@ -69,7 +69,7 @@ func TestSkipLargeReplicaSnapshot(t *testing.T) {
 	defer config.TestingSetDefaultZoneConfig(cfg)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, &storeCfg)
 
 	rep, err := store.GetReplica(rangeID)

--- a/pkg/storage/replica_state_test.go
+++ b/pkg/storage/replica_state_test.go
@@ -34,7 +34,7 @@ import (
 func TestSynthesizeHardState(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 	stopper.AddCloser(eng)
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -439,7 +439,7 @@ func TestReplicaReadConsistency(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 	secondReplica, err := tc.addBogusReplicaToRangeDesc(context.TODO())
 	if err != nil {
@@ -538,7 +538,7 @@ func TestBehaviorDuringLeaseTransfer(t *testing.T) {
 			return nil
 		}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.StartWithStoreConfig(t, stopper, tsc)
 	secondReplica, err := tc.addBogusReplicaToRangeDesc(context.TODO())
 	if err != nil {
@@ -649,7 +649,7 @@ func TestApplyCmdLeaseError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 	secondReplica, err := tc.addBogusReplicaToRangeDesc(context.TODO())
 	if err != nil {
@@ -681,7 +681,7 @@ func TestReplicaRangeBoundsChecking(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	key := roachpb.RKey("a")
@@ -719,7 +719,7 @@ func TestReplicaLease(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 	secondReplica, err := tc.addBogusReplicaToRangeDesc(context.TODO())
 	if err != nil {
@@ -799,7 +799,7 @@ func TestReplicaNotLeaseHolderError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 	secondReplica, err := tc.addBogusReplicaToRangeDesc(context.TODO())
 	if err != nil {
@@ -851,7 +851,7 @@ func TestReplicaLeaseCounters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	assert := func(actual, min, max int64) error {
@@ -930,7 +930,7 @@ func TestReplicaGossipConfigsOnLease(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 	secondReplica, err := tc.addBogusReplicaToRangeDesc(context.TODO())
 	if err != nil {
@@ -1011,7 +1011,7 @@ func TestReplicaTSCacheLowWaterOnLease(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 	// Disable raft log truncation which confuses this test.
 	tc.store.SetRaftLogQueueActive(false)
@@ -1093,7 +1093,7 @@ func TestReplicaLeaseRejectUnknownRaftNodeID(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	tc.manualClock.Set(leaseExpiry(tc.repl))
@@ -1129,7 +1129,7 @@ func TestReplicaDrainLease(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	// Acquire initial lease.
@@ -1159,7 +1159,7 @@ func TestReplicaGossipFirstRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 	for _, key := range []string{gossip.KeyClusterID, gossip.KeyFirstRangeDescriptor, gossip.KeySentinel} {
 		bytes, err := tc.gossip.GetInfo(key)
@@ -1186,7 +1186,7 @@ func TestReplicaGossipAllConfigs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 	if _, ok := tc.gossip.GetSystemConfig(); !ok {
 		t.Fatal("config not set")
@@ -1222,7 +1222,7 @@ func TestReplicaNoGossipConfig(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	// Write some arbitrary data in the system span (up to, but not including MaxReservedID+1)
@@ -1268,7 +1268,7 @@ func TestReplicaNoGossipFromNonLeader(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	// Write some arbitrary data in the system span (up to, but not including MaxReservedID+1)
@@ -1483,7 +1483,7 @@ func TestOptimizePuts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	pArgs := make([]roachpb.PutRequest, optimizePutThreshold)
@@ -1716,7 +1716,7 @@ func TestAcquireLease(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			tc := testContext{}
 			stopper := stop.NewStopper()
-			defer stopper.Stop()
+			defer stopper.Stop(context.TODO())
 			tc.Start(t, stopper)
 			// This is a single-replica test; since we're automatically pushing back
 			// the start of a lease as far as possible, and since there is an auto-
@@ -1776,7 +1776,7 @@ func TestLeaseConcurrent(t *testing.T) {
 		func(withError bool) {
 			tc := testContext{}
 			stopper := stop.NewStopper()
-			defer stopper.Stop()
+			defer stopper.Stop(context.TODO())
 			tc.Start(t, stopper)
 
 			var wg sync.WaitGroup
@@ -1872,7 +1872,7 @@ func TestReplicaUpdateTSCache(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	startNanos := tc.Clock().Now().WallTime
@@ -1998,7 +1998,7 @@ func TestReplicaCommandQueue(t *testing.T) {
 								return nil
 							}
 						stopper := stop.NewStopper()
-						defer stopper.Stop()
+						defer stopper.Stop(context.TODO())
 						tc.StartWithStoreConfig(t, stopper, tsc)
 
 						defer close(blockingDone) // make sure teardown can happen
@@ -2169,7 +2169,7 @@ func TestReplicaCommandQueueInconsistent(t *testing.T) {
 			return nil
 		}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.StartWithStoreConfig(t, stopper, tsc)
 	cmd1Done := make(chan *roachpb.Error)
 	go func() {
@@ -2229,7 +2229,7 @@ func TestReplicaCommandQueueCancellation(t *testing.T) {
 			return nil
 		}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.StartWithStoreConfig(t, stopper, tsc)
 
 	defer close(blockingDone) // make sure teardown can happen
@@ -2311,7 +2311,7 @@ func TestReplicaCommandQueueSelfOverlap(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	for _, cmd1Read := range []bool{false, true} {
@@ -2369,7 +2369,7 @@ func TestReplicaCommandQueueTimestampNonInterference(t *testing.T) {
 			return nil
 		}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.StartWithStoreConfig(t, stopper, tsc)
 
 	testCases := []struct {
@@ -2503,7 +2503,7 @@ func TestReplicaUseTSCache(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 	// Set clock to time 1s and do the read.
 	t0 := 1 * time.Second
@@ -2532,7 +2532,7 @@ func TestReplicaNoTSCacheInconsistent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 	// Set clock to time 1s and do the read.
 	t0 := 1 * time.Second
@@ -2566,7 +2566,7 @@ func TestReplicaNoTSCacheUpdateOnFailure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	// Test for both read & write attempts.
@@ -2611,7 +2611,7 @@ func TestReplicaNoTimestampIncrementWithinTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	// Test for both read & write attempts.
@@ -2671,7 +2671,7 @@ func TestReplicaAbortCacheReadError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	k := []byte("a")
@@ -2707,7 +2707,7 @@ func TestReplicaAbortCacheStoredTxnRetryError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	key := []byte("a")
@@ -2776,7 +2776,7 @@ func TestTransactionRetryLeavesIntents(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	key := roachpb.Key("a")
@@ -2820,7 +2820,7 @@ func TestReplicaAbortCacheOnlyWithIntent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	txn := newTransaction("test", []byte("test"), 10, enginepb.SERIALIZABLE, tc.Clock())
@@ -2848,7 +2848,7 @@ func TestEndTransactionDeadline(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	// 4 cases: no deadline, past deadline, equal deadline, future deadline.
@@ -2922,7 +2922,7 @@ func TestEndTransactionTxnSpanGCThreshold(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	key := roachpb.Key("a")
@@ -3006,7 +3006,7 @@ func TestEndTransactionDeadline_1PC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	key := roachpb.Key("a")
@@ -3038,7 +3038,7 @@ func Test1PCTransactionWriteTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	for _, iso := range []enginepb.IsolationType{enginepb.SNAPSHOT, enginepb.SERIALIZABLE} {
@@ -3085,7 +3085,7 @@ func TestEndTransactionWithMalformedSplitTrigger(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	key := roachpb.Key("foo")
@@ -3132,7 +3132,7 @@ func TestEndTransactionBeforeHeartbeat(t *testing.T) {
 	defer setTxnAutoGC(false)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	key := []byte("a")
@@ -3183,7 +3183,7 @@ func TestEndTransactionAfterHeartbeat(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	key := roachpb.Key("a")
@@ -3239,7 +3239,7 @@ func TestEndTransactionWithPushedTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	testCases := []struct {
@@ -3303,7 +3303,7 @@ func TestEndTransactionWithIncrementedEpoch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	key := []byte("a")
@@ -3353,7 +3353,7 @@ func TestEndTransactionWithErrors(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	regressTS := tc.Clock().Now()
@@ -3412,7 +3412,7 @@ func TestEndTransactionRollbackAbortedTransaction(t *testing.T) {
 	defer setTxnAutoGC(false)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	key := []byte("a")
@@ -3469,7 +3469,7 @@ func TestRaftRetryProtectionInTxn(t *testing.T) {
 	cfg := TestStoreConfig(nil)
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.StartWithStoreConfig(t, stopper, cfg)
 
 	key := roachpb.Key("a")
@@ -3521,7 +3521,7 @@ func TestReplicaLaziness(t *testing.T) {
 	testWithAction := func(action func() roachpb.Request) {
 		tc := testContext{bootstrapMode: bootstrapRangeOnly}
 		stopper := stop.NewStopper()
-		defer stopper.Stop()
+		defer stopper.Stop(context.TODO())
 		tc.Start(t, stopper)
 
 		if status := tc.repl.RaftStatus(); status != nil {
@@ -3574,7 +3574,7 @@ func TestRaftRetryCantCommitIntents(t *testing.T) {
 	defer setTxnAutoGC(true)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	testCases := []enginepb.IsolationType{enginepb.SERIALIZABLE, enginepb.SNAPSHOT}
@@ -3669,7 +3669,7 @@ func TestDuplicateBeginTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	key := roachpb.Key("a")
@@ -3706,7 +3706,7 @@ func TestEndTransactionLocalGC(t *testing.T) {
 			return nil
 		}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.StartWithStoreConfig(t, stopper, tsc)
 
 	splitKey := roachpb.RKey("c")
@@ -3816,7 +3816,7 @@ func TestEndTransactionResolveOnlyLocalIntents(t *testing.T) {
 		}
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.StartWithStoreConfig(t, stopper, tsc)
 
 	newRepl, txn := setupResolutionTest(t, tc, key, splitKey, true /* commit */)
@@ -3866,7 +3866,7 @@ func TestEndTransactionDirectGC(t *testing.T) {
 		func() {
 			tc := testContext{}
 			stopper := stop.NewStopper()
-			defer stopper.Stop()
+			defer stopper.Stop(context.TODO())
 			tc.Start(t, stopper)
 
 			ctx := log.WithLogTag(context.Background(), "testcase", i)
@@ -3927,7 +3927,7 @@ func TestEndTransactionDirectGCFailure(t *testing.T) {
 			return nil
 		}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.StartWithStoreConfig(t, stopper, tsc)
 
 	setupResolutionTest(t, tc, key, splitKey, true /* commit */)
@@ -3955,7 +3955,7 @@ func TestEndTransactionDirectGC_1PC(t *testing.T) {
 		func() {
 			tc := testContext{}
 			stopper := stop.NewStopper()
-			defer stopper.Stop()
+			defer stopper.Stop(context.TODO())
 			tc.Start(t, stopper)
 
 			key := roachpb.Key("a")
@@ -4008,7 +4008,7 @@ func TestReplicaTransactionRequires1PC(t *testing.T) {
 		}
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.StartWithStoreConfig(t, stopper, tsc)
 
 	testCases := []struct {
@@ -4075,7 +4075,7 @@ func TestReplicaEndTransactionWithRequire1PC(t *testing.T) {
 
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	key := roachpb.Key("a")
@@ -4116,7 +4116,7 @@ func TestReplicaResolveIntentNoWait(t *testing.T) {
 
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.StartWithStoreConfig(t, stopper, tsc)
 	splitKey := roachpb.RKey("aa")
 	setupResolutionTest(t, tc, roachpb.Key("a") /* irrelevant */, splitKey, true /* commit */)
@@ -4153,7 +4153,7 @@ func TestAbortCachePoisonOnResolve(t *testing.T) {
 	run := func(abort bool, iso enginepb.IsolationType) {
 		tc := testContext{}
 		stopper := stop.NewStopper()
-		defer stopper.Stop()
+		defer stopper.Stop(context.TODO())
 		tc.Start(t, stopper)
 
 		pusher := newTransaction("test", key, 1, enginepb.SERIALIZABLE, tc.Clock())
@@ -4261,7 +4261,7 @@ func TestAbortCacheError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	u := uuid.MakeV4()
@@ -4302,7 +4302,7 @@ func TestPushTxnBadKey(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	pusher := newTransaction("test", roachpb.Key("a"), 1, enginepb.SERIALIZABLE, tc.Clock())
@@ -4328,7 +4328,7 @@ func TestPushTxnAlreadyCommittedOrAborted(t *testing.T) {
 	defer setTxnAutoGC(false)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	for i, status := range []roachpb.TransactionStatus{roachpb.COMMITTED, roachpb.ABORTED} {
@@ -4370,7 +4370,7 @@ func TestPushTxnUpgradeExistingTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	now := tc.Clock().Now()
@@ -4434,7 +4434,7 @@ func TestPushTxnHeartbeatTimeout(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	now := tc.Clock().Now()
@@ -4513,7 +4513,7 @@ func TestResolveIntentPushTxnReplyTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	b := tc.engine.NewBatch()
@@ -4563,7 +4563,7 @@ func TestPushTxnPriorities(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	now := tc.Clock().Now()
@@ -4634,7 +4634,7 @@ func TestPushTxnPushTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	pusher := newTransaction("test", roachpb.Key("a"), 1, enginepb.SERIALIZABLE, tc.Clock())
@@ -4679,7 +4679,7 @@ func TestPushTxnPushTimestampAlreadyPushed(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	pusher := newTransaction("test", roachpb.Key("a"), 1, enginepb.SERIALIZABLE, tc.Clock())
@@ -4722,7 +4722,7 @@ func TestPushTxnSerializableRestart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	key := roachpb.Key("a")
@@ -4788,7 +4788,7 @@ func TestReplicaResolveIntentRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	keys := []roachpb.Key{roachpb.Key("a"), roachpb.Key("b")}
@@ -4850,7 +4850,7 @@ func TestRangeStatsComputation(t *testing.T) {
 		bootstrapMode: bootstrapRangeOnly,
 	}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	baseStats := initialStats()
@@ -4967,7 +4967,7 @@ func TestMerge(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	key := []byte("mergedkey")
@@ -5030,7 +5030,7 @@ func TestTruncateLog(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 	tc.repl.store.SetRaftLogQueueActive(false)
 
@@ -5136,7 +5136,7 @@ func TestConditionFailedError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	key := []byte("k")
@@ -5201,7 +5201,7 @@ func TestAppliedIndex(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	var appliedIndex uint64
@@ -5246,7 +5246,7 @@ func TestReplicaCorruption(t *testing.T) {
 
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.StartWithStoreConfig(t, stopper, tsc)
 
 	// First send a regular command.
@@ -5294,7 +5294,7 @@ func TestChangeReplicasDuplicateError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	if err := tc.repl.ChangeReplicas(
@@ -5329,7 +5329,7 @@ func TestReplicaDanglingMetaIntent(t *testing.T) {
 func testRangeDanglingMetaIntent(t *testing.T, isReverse bool) {
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	key := roachpb.Key("a")
@@ -5433,7 +5433,7 @@ func TestReplicaLookupUseReverseScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	splitRangeBefore := roachpb.RangeDescriptor{RangeID: 3, StartKey: roachpb.RKey("c"), EndKey: roachpb.RKey("h")}
@@ -5557,7 +5557,7 @@ func TestRangeLookup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	expected := []roachpb.RangeDescriptor{*tc.repl.Desc()}
@@ -5607,7 +5607,7 @@ func TestRequestLeaderEncounterGroupDeleteError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	// Mock propose to return an roachpb.RaftGroupDeletedError.
@@ -5705,7 +5705,7 @@ func TestBatchErrorWithIndex(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	ba := roachpb.BatchRequest{}
@@ -5739,7 +5739,7 @@ func TestReplicaLoadSystemConfigSpanIntent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 	scStartSddr, err := keys.Addr(keys.SystemConfigSpan.Key)
 	if err != nil {
@@ -5800,7 +5800,7 @@ func TestReplicaDestroy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	repl, err := tc.store.GetReplica(1)
@@ -5837,7 +5837,7 @@ func TestEntries(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 	tc.repl.store.SetRaftLogQueueActive(false)
 
@@ -6006,7 +6006,7 @@ func TestTerm(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 	tc.repl.store.SetRaftLogQueueActive(false)
 
@@ -6090,7 +6090,7 @@ func TestGCIncorrectRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	// Split range into two ranges.
@@ -6177,7 +6177,7 @@ func TestReplicaCancelRaft(t *testing.T) {
 			}
 			tc := testContext{}
 			stopper := stop.NewStopper()
-			defer stopper.Stop()
+			defer stopper.Stop(context.TODO())
 			tc.StartWithStoreConfig(t, stopper, cfg)
 			if cancelEarly {
 				cancel()
@@ -6217,7 +6217,7 @@ func TestReplicaCancelRaft(t *testing.T) {
 func TestReplicaTryAbandon(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc := testContext{}
 	tc.Start(t, stopper)
 
@@ -6298,7 +6298,7 @@ func TestComputeChecksumVersioning(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	if pct, _ := evalComputeChecksum(context.TODO(), nil,
@@ -6465,7 +6465,7 @@ func TestSyncSnapshot(t *testing.T) {
 	tsc := TestStoreConfig(nil)
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.StartWithStoreConfig(t, stopper, tsc)
 
 	// With enough time in BlockingSnapshotDuration, we succeed on the
@@ -6493,7 +6493,7 @@ func TestReplicaIDChangePending(t *testing.T) {
 	// would pass this test.
 	cfg.RaftTickInterval = math.MaxInt32
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.StartWithStoreConfig(t, stopper, cfg)
 	repl := tc.repl
 
@@ -6543,7 +6543,7 @@ func TestSetReplicaID(t *testing.T) {
 	tsc := TestStoreConfig(nil)
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.StartWithStoreConfig(t, stopper, tsc)
 
 	repl := tc.repl
@@ -6587,7 +6587,7 @@ func TestReplicaRetryRaftProposal(t *testing.T) {
 	ctx := context.TODO()
 	var tc testContext
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	type magicKey struct{}
@@ -6673,7 +6673,7 @@ func TestReplicaCancelRaftCommandProgress(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var tc testContext
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 	repl := tc.repl
 
@@ -6731,7 +6731,7 @@ func TestReplicaBurstPendingCommandsAndRepropose(t *testing.T) {
 
 	var tc testContext
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	const num = 10
@@ -6832,7 +6832,7 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 	// Disable ticks which would interfere with the manual ticking in this test.
 	cfg.RaftTickInterval = math.MaxInt32
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.StartWithStoreConfig(t, stopper, cfg)
 
 	// Grab Replica.raftMu in order to block normal raft replica processing. This
@@ -6983,7 +6983,7 @@ func TestAmbiguousResultErrorOnRetry(t *testing.T) {
 	cfg := TestStoreConfig(nil)
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.StartWithStoreConfig(t, stopper, cfg)
 
 	var baPut roachpb.BatchRequest
@@ -7129,7 +7129,7 @@ func TestCommandTimeThreshold(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	now := tc.Clock().Now()
@@ -7207,7 +7207,7 @@ func TestDeprecatedRequests(t *testing.T) {
 
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	if reply, err := tc.SendWrapped(&roachpb.DeprecatedVerifyChecksumRequest{}); err != nil {
@@ -7222,7 +7222,7 @@ func TestReplicaTimestampCacheBumpNotLost(t *testing.T) {
 
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	ctx := tc.store.AnnotateCtx(context.TODO())
@@ -7277,7 +7277,7 @@ func TestReplicaEvaluationNotTxnMutation(t *testing.T) {
 
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	ctx := tc.repl.AnnotateCtx(context.TODO())
@@ -7550,7 +7550,7 @@ func TestCancelPendingCommands(t *testing.T) {
 
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	// Install a proposal function which drops all increment commands on

--- a/pkg/storage/replicate_queue_test.go
+++ b/pkg/storage/replicate_queue_test.go
@@ -55,7 +55,7 @@ func TestReplicateQueueRebalance(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, numNodes,
 		base.TestClusterArgs{ReplicationMode: base.ReplicationAuto},
 	)
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 
 	const newRanges = 5
 	for i := 0; i < newRanges; i++ {
@@ -113,7 +113,7 @@ func TestReplicateQueueDownReplicate(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, replicaCount+2,
 		base.TestClusterArgs{ReplicationMode: base.ReplicationAuto},
 	)
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 
 	// Split off a range from the initial range for testing; there are
 	// complications if the metadata ranges are moved.

--- a/pkg/storage/replicate_test.go
+++ b/pkg/storage/replicate_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -35,7 +36,7 @@ func TestEagerReplication(t *testing.T) {
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	// Disable the replica scanner so that we rely on the eager replication code

--- a/pkg/storage/scanner.go
+++ b/pkg/storage/scanner.go
@@ -251,8 +251,8 @@ func (rs *replicaScanner) removeReplica(repl *Replica) {
 // the replica set, or until the scanner is stopped. The iteration
 // is paced to complete a full scan in approximately the scan interval.
 func (rs *replicaScanner) scanLoop(clock *hlc.Clock, stopper *stop.Stopper) {
-	stopper.RunWorker(func() {
-		ctx := rs.AnnotateCtx(context.Background())
+	ctx := rs.AnnotateCtx(context.Background())
+	stopper.RunWorker(ctx, func() {
 		start := timeutil.Now()
 
 		// waitTimer is reset in each call to waitAndProcess.
@@ -277,7 +277,7 @@ func (rs *replicaScanner) scanLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 				shouldStop = rs.waitAndProcess(ctx, start, clock, stopper, nil)
 			}
 
-			shouldStop = shouldStop || nil != stopper.RunTask(func() {
+			shouldStop = shouldStop || nil != stopper.RunTask(ctx, func() {
 				// Increment iteration count.
 				rs.mu.Lock()
 				defer rs.mu.Unlock()

--- a/pkg/storage/scanner.go
+++ b/pkg/storage/scanner.go
@@ -252,7 +252,7 @@ func (rs *replicaScanner) removeReplica(repl *Replica) {
 // is paced to complete a full scan in approximately the scan interval.
 func (rs *replicaScanner) scanLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 	ctx := rs.AnnotateCtx(context.Background())
-	stopper.RunWorker(ctx, func() {
+	stopper.RunWorker(ctx, func(ctx context.Context) {
 		start := timeutil.Now()
 
 		// waitTimer is reset in each call to waitAndProcess.
@@ -277,7 +277,7 @@ func (rs *replicaScanner) scanLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 				shouldStop = rs.waitAndProcess(ctx, start, clock, stopper, nil)
 			}
 
-			shouldStop = shouldStop || nil != stopper.RunTask(ctx, func() {
+			shouldStop = shouldStop || nil != stopper.RunTask(ctx, func(ctx context.Context) {
 				// Increment iteration count.
 				rs.mu.Lock()
 				defer rs.mu.Unlock()

--- a/pkg/storage/scanner_test.go
+++ b/pkg/storage/scanner_test.go
@@ -125,7 +125,7 @@ func (tq *testQueue) setDisabled(d bool) {
 }
 
 func (tq *testQueue) Start(clock *hlc.Clock, stopper *stop.Stopper) {
-	stopper.RunWorker(func() {
+	stopper.RunWorker(context.TODO(), func() {
 		for {
 			select {
 			case <-time.After(1 * time.Millisecond):
@@ -223,7 +223,7 @@ func TestScannerAddToQueues(t *testing.T) {
 	})
 
 	// Stop scanner and verify both queues are stopped.
-	stopper.Stop()
+	stopper.Stop(context.TODO())
 	if !q1.isDone() || !q2.isDone() {
 		t.Errorf("expected all queues to stop; got %t, %t", q1.isDone(), q2.isDone())
 	}
@@ -251,7 +251,7 @@ func TestScannerTiming(t *testing.T) {
 			stopper := stop.NewStopper()
 			s.Start(clock, stopper)
 			time.Sleep(runTime)
-			stopper.Stop()
+			stopper.Stop(context.TODO())
 
 			avg := s.avgScan()
 			log.Infof(context.Background(), "%d: average scan: %s", i, avg)
@@ -313,7 +313,7 @@ func TestScannerDisabled(t *testing.T) {
 	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
 	stopper := stop.NewStopper()
 	s.Start(clock, stopper)
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	// Verify queue gets all ranges.
 	testutils.SucceedsSoon(t, func() error {
@@ -375,7 +375,7 @@ func TestScannerEmptyRangeSet(t *testing.T) {
 	mc := hlc.NewManualClock(123)
 	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	s.Start(clock, stopper)
 	time.Sleep(time.Millisecond) // give it some time to (not) busy loop
 	if count := s.scanCount(); count > 1 {

--- a/pkg/storage/scanner_test.go
+++ b/pkg/storage/scanner_test.go
@@ -125,7 +125,7 @@ func (tq *testQueue) setDisabled(d bool) {
 }
 
 func (tq *testQueue) Start(clock *hlc.Clock, stopper *stop.Stopper) {
-	stopper.RunWorker(context.TODO(), func() {
+	stopper.RunWorker(context.TODO(), func(context.Context) {
 		for {
 			select {
 			case <-time.After(1 * time.Millisecond):

--- a/pkg/storage/scheduler.go
+++ b/pkg/storage/scheduler.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"sync"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -151,7 +153,8 @@ func newRaftScheduler(
 }
 
 func (s *raftScheduler) Start(stopper *stop.Stopper) {
-	stopper.RunWorker(func() {
+	ctx := context.TODO()
+	stopper.RunWorker(ctx, func() {
 		<-stopper.ShouldStop()
 		s.mu.Lock()
 		s.mu.stopped = true
@@ -161,7 +164,7 @@ func (s *raftScheduler) Start(stopper *stop.Stopper) {
 
 	s.done.Add(s.numWorkers)
 	for i := 0; i < s.numWorkers; i++ {
-		stopper.RunWorker(func() {
+		stopper.RunWorker(ctx, func() {
 			s.worker(stopper)
 		})
 	}

--- a/pkg/storage/scheduler.go
+++ b/pkg/storage/scheduler.go
@@ -154,7 +154,7 @@ func newRaftScheduler(
 
 func (s *raftScheduler) Start(stopper *stop.Stopper) {
 	ctx := context.TODO()
-	stopper.RunWorker(ctx, func() {
+	stopper.RunWorker(ctx, func(context.Context) {
 		<-stopper.ShouldStop()
 		s.mu.Lock()
 		s.mu.stopped = true
@@ -164,13 +164,13 @@ func (s *raftScheduler) Start(stopper *stop.Stopper) {
 
 	s.done.Add(s.numWorkers)
 	for i := 0; i < s.numWorkers; i++ {
-		stopper.RunWorker(ctx, func() {
+		stopper.RunWorker(ctx, func(context.Context) {
 			s.worker(stopper)
 		})
 	}
 }
 
-func (s *raftScheduler) Wait() {
+func (s *raftScheduler) Wait(context.Context) {
 	s.done.Wait()
 }
 

--- a/pkg/storage/scheduler_test.go
+++ b/pkg/storage/scheduler_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -196,7 +197,7 @@ func TestSchedulerLoop(t *testing.T) {
 	p := newTestProcessor()
 	s := newRaftScheduler(log.AmbientContext{}, nil, p, 1)
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	s.Start(stopper)
 	s.EnqueueRaftTick(1, 2, 3)
 
@@ -217,7 +218,7 @@ func TestSchedulerBuffering(t *testing.T) {
 	p := newTestProcessor()
 	s := newRaftScheduler(log.AmbientContext{}, nil, p, 1)
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	s.Start(stopper)
 
 	testCases := []struct {

--- a/pkg/storage/split_queue_test.go
+++ b/pkg/storage/split_queue_test.go
@@ -37,7 +37,7 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	// Set zone configs.

--- a/pkg/storage/stats_test.go
+++ b/pkg/storage/stats_test.go
@@ -43,7 +43,7 @@ func TestRangeStatsEmpty(t *testing.T) {
 		bootstrapMode: bootstrapRangeOnly,
 	}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
 	ms := tc.repl.GetMVCCStats()
@@ -56,7 +56,7 @@ func TestRangeStatsInit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 	ms := enginepb.MVCCStats{
 		LiveBytes:       1,

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1221,7 +1221,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		// This may trigger splits along structured boundaries,
 		// and update max range bytes.
 		gossipUpdateC := s.cfg.Gossip.RegisterSystemConfigChannel()
-		s.stopper.RunWorker(func() {
+		s.stopper.RunWorker(ctx, func() {
 			for {
 				select {
 				case <-gossipUpdateC:
@@ -1242,7 +1242,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		// Start the scanner. The construction here makes sure that the scanner
 		// only starts after Gossip has connected, and that it does not block Start
 		// from returning (as doing so might prevent Gossip from ever connecting).
-		s.stopper.RunWorker(func() {
+		s.stopper.RunWorker(ctx, func() {
 			select {
 			case <-s.cfg.Gossip.Connected:
 				s.scanner.Start(s.cfg.Clock, s.stopper)
@@ -1326,7 +1326,7 @@ func (s *Store) startGossip() {
 	s.initComplete.Add(len(gossipFns))
 	for _, gossipFn := range gossipFns {
 		gossipFn := gossipFn // per-iteration copy
-		s.stopper.RunWorker(func() {
+		s.stopper.RunWorker(context.Background(), func() {
 			ticker := time.NewTicker(gossipFn.interval)
 			defer ticker.Stop()
 			for first := true; ; {
@@ -3455,14 +3455,14 @@ func (s *Store) processRaft() {
 
 	s.scheduler.Start(s.stopper)
 	// Wait for the scheduler worker goroutines to finish.
-	s.stopper.RunWorker(s.scheduler.Wait)
+	s.stopper.RunWorker(context.TODO(), s.scheduler.Wait)
 
 	s.raftTickLoop()
 	s.startCoalescedHeartbeatsLoop()
 }
 
 func (s *Store) raftTickLoop() {
-	s.stopper.RunWorker(func() {
+	s.stopper.RunWorker(context.TODO(), func() {
 		ticker := time.NewTicker(s.cfg.RaftTickInterval)
 		defer func() {
 			ticker.Stop()
@@ -3496,7 +3496,7 @@ func (s *Store) raftTickLoop() {
 // beneficial to have it run on a faster cycle than once per tick, so that
 // the delay does not impact latency-sensitive features such as quiescence.
 func (s *Store) startCoalescedHeartbeatsLoop() {
-	s.stopper.RunWorker(func() {
+	s.stopper.RunWorker(context.TODO(), func() {
 		ticker := time.NewTicker(s.cfg.CoalescedHeartbeatsInterval)
 		defer func() {
 			ticker.Stop()

--- a/pkg/storage/store_pool_test.go
+++ b/pkg/storage/store_pool_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"
@@ -113,7 +114,7 @@ func TestStorePoolGossipUpdate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper, g, _, sp, _ := createTestStorePool(
 		TestTimeUntilStoreDead, false /* deterministic */, nodeStatusDead)
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	sg := gossiputil.NewStoreGossiper(g)
 
 	sp.detailsMu.RLock()
@@ -169,7 +170,7 @@ func TestStorePoolGetStoreList(t *testing.T) {
 	// We're going to manually mark stores dead in this test.
 	stopper, g, _, sp, mnl := createTestStorePool(
 		TestTimeUntilStoreDead, false /* deterministic */, nodeStatusDead)
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	sg := gossiputil.NewStoreGossiper(g)
 	constraints := config.Constraints{Constraints: []config.Constraint{{Value: "ssd"}, {Value: "dc"}}}
 	required := []string{"ssd", "dc"}
@@ -300,7 +301,7 @@ func TestStorePoolGetStoreDetails(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper, g, _, sp, _ := createTestStorePool(
 		TestTimeUntilStoreDead, false /* deterministic */, nodeStatusDead)
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	sg := gossiputil.NewStoreGossiper(g)
 	sg.GossipStores(uniqueStore, t)
 
@@ -318,7 +319,7 @@ func TestStorePoolFindDeadReplicas(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper, g, _, sp, mnl := createTestStorePool(
 		TestTimeUntilStoreDead, false /* deterministic */, nodeStatusDead)
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	sg := gossiputil.NewStoreGossiper(g)
 
 	stores := []*roachpb.StoreDescriptor{
@@ -419,7 +420,7 @@ func TestStorePoolDefaultState(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper, _, _, sp, _ := createTestStorePool(
 		TestTimeUntilStoreDead, false /* deterministic */, nodeStatusDead)
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	liveReplicas, deadReplicas := sp.liveAndDeadReplicas(0, []roachpb.ReplicaDescriptor{{StoreID: 1}})
 	if len(liveReplicas) != 0 || len(deadReplicas) != 0 {
@@ -442,7 +443,7 @@ func TestStorePoolThrottle(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper, g, _, sp, _ := createTestStorePool(
 		TestTimeUntilStoreDead, false /* deterministic */, nodeStatusDead)
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 
 	sg := gossiputil.NewStoreGossiper(g)
 	sg.GossipStores(uniqueStore, t)
@@ -478,7 +479,7 @@ func TestGetLocalities(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper, g, _, sp, _ := createTestStorePool(
 		TestTimeUntilStoreDead, false /* deterministic */, nodeStatusDead)
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	sg := gossiputil.NewStoreGossiper(g)
 
 	// Creates a node with a locality with the number of tiers passed in. The

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -181,7 +181,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	// We need a fixed clock to avoid LastUpdateNanos drifting on us.
 	cfg := TestStoreConfig(hlc.NewClock(func() int64 { return 123 }, time.Nanosecond))
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 	stopper.AddCloser(eng)
 	cfg.Transport = NewDummyRaftTransport()
@@ -245,7 +245,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 func TestBootstrapOfNonEmptyStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 	stopper.AddCloser(eng)
 
@@ -299,7 +299,7 @@ func createReplica(s *Store, rangeID roachpb.RangeID, start, end roachpb.RKey) *
 func TestStoreAddRemoveRanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 	if _, err := store.GetReplica(0); err == nil {
 		t.Error("expected GetRange to fail on missing range")
@@ -370,7 +370,7 @@ func TestStoreAddRemoveRanges(t *testing.T) {
 func TestReplicasByKey(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 
 	// Shrink the main replica.
@@ -412,7 +412,7 @@ func TestReplicasByKey(t *testing.T) {
 func TestStoreRemoveReplicaOldDescriptor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 
 	rep, err := store.GetReplica(1)
@@ -448,7 +448,7 @@ func TestStoreRemoveReplicaOldDescriptor(t *testing.T) {
 func TestStoreRemoveReplicaDestroy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 
 	repl1, err := store.GetReplica(1)
@@ -486,7 +486,7 @@ func TestStoreRemoveReplicaDestroy(t *testing.T) {
 func TestStoreReplicaVisitor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 
 	// Remove range 1.
@@ -548,7 +548,7 @@ func TestStoreReplicaVisitor(t *testing.T) {
 func TestHasOverlappingReplica(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 	if _, err := store.GetReplica(0); err == nil {
 		t.Error("expected GetRange to fail on missing range")
@@ -606,7 +606,7 @@ func TestHasOverlappingReplica(t *testing.T) {
 func TestProcessRangeDescriptorUpdate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 
 	// Clobber the existing range so we can test overlaps that aren't KeyMin or KeyMax.
@@ -675,7 +675,7 @@ func TestProcessRangeDescriptorUpdate(t *testing.T) {
 func TestStoreSend(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 	gArgs := getArgs([]byte("a"))
 
@@ -754,7 +754,7 @@ func TestStoreObservedTimestamp(t *testing.T) {
 					return nil
 				}
 			stopper := stop.NewStopper()
-			defer stopper.Stop()
+			defer stopper.Stop(context.TODO())
 			store := createTestStoreWithConfig(t, stopper, &cfg)
 			txn := newTransaction("test", test.key, 1, enginepb.SERIALIZABLE, store.cfg.Clock)
 			txn.MaxTimestamp = hlc.MaxTimestamp
@@ -817,7 +817,7 @@ func TestStoreAnnotateNow(t *testing.T) {
 						return nil
 					}
 				stopper := stop.NewStopper()
-				defer stopper.Stop()
+				defer stopper.Stop(context.TODO())
 				store := createTestStoreWithConfig(t, stopper, &cfg)
 				var txn *roachpb.Transaction
 				if useTxn {
@@ -842,7 +842,7 @@ func TestStoreAnnotateNow(t *testing.T) {
 func TestStoreExecuteNoop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 	ba := roachpb.BatchRequest{}
 	ba.RangeID = 1
@@ -865,7 +865,7 @@ func TestStoreExecuteNoop(t *testing.T) {
 func TestStoreVerifyKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 	// Try a start key == KeyMax.
 	gArgs := getArgs(roachpb.KeyMax)
@@ -923,7 +923,7 @@ func TestStoreVerifyKeys(t *testing.T) {
 func TestStoreSendUpdateTime(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 	args := getArgs([]byte("a"))
 	reqTS := store.cfg.Clock.Now().Add(store.cfg.Clock.MaxOffset().Nanoseconds(), 0)
@@ -942,7 +942,7 @@ func TestStoreSendUpdateTime(t *testing.T) {
 func TestStoreSendWithZeroTime(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 	args := getArgs([]byte("a"))
 
@@ -964,7 +964,7 @@ func TestStoreSendWithZeroTime(t *testing.T) {
 func TestStoreSendWithClockOffset(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 	args := getArgs([]byte("a"))
 	// Set args timestamp to exceed max offset.
@@ -979,7 +979,7 @@ func TestStoreSendWithClockOffset(t *testing.T) {
 func TestStoreSendBadRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 	args := getArgs([]byte("0"))
 	if _, pErr := client.SendWrappedWith(context.Background(), store.testSender(), roachpb.Header{
@@ -1025,7 +1025,7 @@ func splitTestRange(store *Store, key, splitKey roachpb.RKey, t *testing.T) *Rep
 func TestStoreSendOutOfRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 
 	repl2 := splitTestRange(store, roachpb.RKeyMin, roachpb.RKey(roachpb.Key("b")), t)
@@ -1052,7 +1052,7 @@ func TestStoreSendOutOfRange(t *testing.T) {
 func TestStoreRangeIDAllocation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 
 	// Range IDs should be allocated from ID 2 (first allocated range)
@@ -1074,7 +1074,7 @@ func TestStoreRangeIDAllocation(t *testing.T) {
 func TestStoreReplicasByKey(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 
 	r0 := store.LookupReplica(roachpb.RKeyMin, nil)
@@ -1118,7 +1118,7 @@ func TestStoreReplicasByKey(t *testing.T) {
 func TestStoreSetRangesMaxBytes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 
 	baseID := uint32(keys.MaxReservedDescID + 1)
@@ -1166,7 +1166,7 @@ func TestStoreLongTxnStarvation(t *testing.T) {
 	storeCfg := TestStoreConfig(nil)
 	storeCfg.DontRetryPushTxnFailures = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, &storeCfg)
 
 	for i, iso := range []enginepb.IsolationType{enginepb.SERIALIZABLE, enginepb.SNAPSHOT} {
@@ -1237,7 +1237,7 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 			return nil
 		}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, &cfg)
 
 	for i, resolvable := range []bool{true, false} {
@@ -1306,7 +1306,7 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 func TestStoreResolveWriteIntentRollback(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 
 	key := roachpb.Key("a")
@@ -1346,7 +1346,7 @@ func TestStoreResolveWriteIntentPushOnRead(t *testing.T) {
 	storeCfg := TestStoreConfig(nil)
 	storeCfg.DontRetryPushTxnFailures = true
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, &storeCfg)
 
 	testCases := []struct {
@@ -1466,7 +1466,7 @@ func TestStoreResolveWriteIntentPushOnRead(t *testing.T) {
 func TestStoreResolveWriteIntentSnapshotIsolation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 
 	key := roachpb.Key("a")
@@ -1521,7 +1521,7 @@ func TestStoreResolveWriteIntentSnapshotIsolation(t *testing.T) {
 func TestStoreResolveWriteIntentNoTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 
 	key := roachpb.Key("a")
@@ -1614,7 +1614,7 @@ func TestStoreReadInconsistent(t *testing.T) {
 	// automatic cleanup for this to work.
 	defer setTxnAutoGC(false)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 
 	for _, canPush := range []bool{true, false} {
@@ -1734,7 +1734,7 @@ func TestStoreScanIntents(t *testing.T) {
 			return nil
 		}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, &cfg)
 
 	testCases := []struct {
@@ -1855,7 +1855,7 @@ func TestStoreScanInconsistentResolvesIntents(t *testing.T) {
 			return nil
 		}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, &cfg)
 
 	// Lay down 10 intents to scan over.
@@ -1904,7 +1904,7 @@ func TestStoreScanInconsistentResolvesIntents(t *testing.T) {
 func TestStoreBadRequests(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, stopper)
 
 	txn := newTransaction("test", roachpb.Key("a"), 1 /* priority */, enginepb.SERIALIZABLE, store.cfg.Clock)
@@ -1991,7 +1991,7 @@ func TestMaybeRemove(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	cfg := TestStoreConfig(nil)
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithoutStart(t, stopper, &cfg)
 
 	// Add a queue to the scanner before starting the store and running the scanner.
@@ -2024,7 +2024,7 @@ func TestStoreGCThreshold(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 	store := tc.store
 
@@ -2074,7 +2074,7 @@ func TestStoreRangePlaceholders(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 	s := tc.store
 
@@ -2173,7 +2173,7 @@ func TestStoreRemovePlaceholderOnError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 	s := tc.store
 	ctx := context.Background()
@@ -2246,7 +2246,7 @@ func TestStoreRemovePlaceholderOnRaftIgnored(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 	s := tc.store
 	ctx := context.Background()
@@ -2365,7 +2365,7 @@ func TestRemovedReplicaTombstone(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			tc := testContext{}
 			stopper := stop.NewStopper()
-			defer stopper.Stop()
+			defer stopper.Stop(context.TODO())
 			tc.Start(t, stopper)
 			s := tc.store
 
@@ -2423,7 +2423,7 @@ func TestCanCampaignIdleReplica(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 	s := tc.store
 	ctx := context.Background()
@@ -2574,7 +2574,7 @@ func TestReserveSnapshotThrottling(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	tc := testContext{}
 	tc.Start(t, stopper)
 	s := tc.store

--- a/pkg/storage/stores_test.go
+++ b/pkg/storage/stores_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
@@ -130,7 +132,7 @@ func TestStoresGetStore(t *testing.T) {
 func TestStoresLookupReplica(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	cfg := TestStoreConfig(nil)
 	ls := NewStores(log.AmbientContext{}, cfg.Clock)
 
@@ -252,7 +254,7 @@ func createStores(count int, t *testing.T) (*hlc.ManualClock, []*Store, *Stores,
 func TestStoresGossipStorage(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	manual, stores, ls, stopper := createStores(2, t)
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	ls.AddStore(stores[0])
 
 	// Verify initial read is empty.
@@ -301,7 +303,7 @@ func TestStoresGossipStorage(t *testing.T) {
 func TestStoresGossipStorageReadLatest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	manual, stores, ls, stopper := createStores(2, t)
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	ls.AddStore(stores[0])
 
 	// Add a fake address and write.

--- a/pkg/storage/ts_maintenance_queue_test.go
+++ b/pkg/storage/ts_maintenance_queue_test.go
@@ -104,7 +104,7 @@ func TestTimeSeriesMaintenanceQueue(t *testing.T) {
 	cfg.TestingKnobs.DisableSplitQueue = true
 
 	stopper := stop.NewStopper()
-	defer stopper.Stop()
+	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, cfg)
 
 	// Generate several splits.
@@ -226,7 +226,7 @@ func TestTimeSeriesMaintenanceQueueServer(t *testing.T) {
 			},
 		},
 	})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	tsrv := s.(*server.TestServer)
 	tsdb := tsrv.TsDB()
 

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -177,5 +177,5 @@ func (ltc *LocalTestCluster) Stop() {
 	if r := recover(); r != nil {
 		panic(r)
 	}
-	ltc.Stopper.Stop()
+	ltc.Stopper.Stop(context.TODO())
 }

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -94,7 +94,7 @@ func (tc *TestCluster) stopServers() {
 		go func(s *stop.Stopper) {
 			defer wg.Done()
 			if s != nil {
-				s.Quiesce()
+				s.Quiesce(context.TODO())
 			}
 		}(s)
 	}
@@ -102,7 +102,7 @@ func (tc *TestCluster) stopServers() {
 
 	for i := range tc.mu.serverStoppers {
 		if tc.mu.serverStoppers[i] != nil {
-			tc.mu.serverStoppers[i].Stop()
+			tc.mu.serverStoppers[i].Stop(context.TODO())
 			tc.mu.serverStoppers[i] = nil
 		}
 	}
@@ -113,7 +113,7 @@ func (tc *TestCluster) StopServer(idx int) {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 	if tc.mu.serverStoppers[idx] != nil {
-		tc.mu.serverStoppers[idx].Stop()
+		tc.mu.serverStoppers[idx].Stop(context.TODO())
 		tc.mu.serverStoppers[idx] = nil
 	}
 }

--- a/pkg/testutils/testcluster/testcluster_test.go
+++ b/pkg/testutils/testcluster/testcluster_test.go
@@ -47,7 +47,7 @@ func TestManualReplication(t *testing.T) {
 				UseDatabase: "t",
 			},
 		})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 
 	s0 := sqlutils.MakeSQLRunner(t, tc.Conns[0])
 	s1 := sqlutils.MakeSQLRunner(t, tc.Conns[1])
@@ -148,7 +148,7 @@ func TestBasicManualReplication(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	tc := StartTestCluster(t, 3, base.TestClusterArgs{ReplicationMode: base.ReplicationManual})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 
 	desc, err := tc.AddReplicas(keys.MinKey, tc.Target(1), tc.Target(2))
 	if err != nil {
@@ -180,7 +180,7 @@ func TestBasicAutoReplication(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	tc := StartTestCluster(t, 3, base.TestClusterArgs{ReplicationMode: base.ReplicationAuto})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 	// NB: StartTestCluster will wait for full replication.
 }
 
@@ -196,7 +196,7 @@ func TestStopServer(t *testing.T) {
 		},
 		ReplicationMode: base.ReplicationAuto,
 	})
-	defer tc.Stopper().Stop()
+	defer tc.Stopper().Stop(context.TODO())
 
 	// Connect to server 1, ensure it is answering requests over HTTP and GRPC.
 	server1 := tc.Server(1)

--- a/pkg/ts/db.go
+++ b/pkg/ts/db.go
@@ -81,7 +81,7 @@ func (db *DB) PollSource(
 // start begins the goroutine for this poller, which will periodically request
 // time series data from the DataSource and store it.
 func (p *poller) start() {
-	p.stopper.RunWorker(func() {
+	p.stopper.RunWorker(context.TODO(), func() {
 		// Poll once immediately.
 		p.poll()
 		ticker := time.NewTicker(p.frequency)
@@ -100,7 +100,7 @@ func (p *poller) start() {
 // poll retrieves data from the underlying DataSource a single time, storing any
 // returned time series data on the server.
 func (p *poller) poll() {
-	if err := p.stopper.RunTask(func() {
+	if err := p.stopper.RunTask(context.TODO(), func() {
 		data := p.source.GetTimeSeriesData()
 		if len(data) == 0 {
 			return

--- a/pkg/ts/db_test.go
+++ b/pkg/ts/db_test.go
@@ -272,7 +272,7 @@ type modelDataSource struct {
 func (mds *modelDataSource) GetTimeSeriesData() []tspb.TimeSeriesData {
 	if len(mds.datasets) == 0 {
 		// Stop on goroutine to prevent deadlock.
-		go mds.once.Do(mds.stopper.Stop)
+		go mds.once.Do(func() { mds.stopper.Stop(context.Background()) })
 		return nil
 	}
 	mds.calledCount++

--- a/pkg/ts/server_test.go
+++ b/pkg/ts/server_test.go
@@ -43,7 +43,7 @@ func TestServerQuery(t *testing.T) {
 			},
 		},
 	})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	tsrv := s.(*server.TestServer)
 
 	// Populate data directly.
@@ -261,7 +261,7 @@ func TestServerQueryStarvation(t *testing.T) {
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
 		TimeSeriesQueryWorkerMax: workerCount,
 	})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	tsrv := s.(*server.TestServer)
 
 	seriesCount := workerCount * 2
@@ -293,7 +293,7 @@ func TestServerQueryStarvation(t *testing.T) {
 
 func BenchmarkServerQuery(b *testing.B) {
 	s, _, _ := serverutils.StartServer(b, base.TestServerArgs{})
-	defer s.Stopper().Stop()
+	defer s.Stopper().Stop(context.TODO())
 	tsrv := s.(*server.TestServer)
 
 	// Populate data for large number of time series.

--- a/pkg/util/log/stderr_redirect.go
+++ b/pkg/util/log/stderr_redirect.go
@@ -54,16 +54,16 @@ func restoreStderr() error {
 // RecoverAndReportPanic can be invoked on goroutines that run with
 // stderr redirected to logs to ensure the user gets informed on the
 // real stderr a panic has occurred.
-func RecoverAndReportPanic() {
+func RecoverAndReportPanic(ctx context.Context) {
 	if r := recover(); r != nil {
-		ReportPanic(r)
+		ReportPanic(ctx, r)
 		panic(r)
 	}
 }
 
 // ReportPanic reports a panic has occurred on the real stderr.
-func ReportPanic(r interface{}) {
-	Shout(context.Background(), Severity_ERROR, "a panic has occurred!")
+func ReportPanic(ctx context.Context, r interface{}) {
+	Shout(ctx, Severity_ERROR, "a panic has occurred!")
 
 	// Ensure that the logs are flushed before letting a panic
 	// terminate the server.

--- a/pkg/util/netutil/net.go
+++ b/pkg/util/netutil/net.go
@@ -47,14 +47,14 @@ func ListenAndServeGRPC(
 
 	ctx := context.TODO()
 
-	stopper.RunWorker(ctx, func() {
+	stopper.RunWorker(ctx, func(context.Context) {
 		<-stopper.ShouldQuiesce()
 		FatalIfUnexpected(ln.Close())
 		<-stopper.ShouldStop()
 		server.Stop()
 	})
 
-	stopper.RunWorker(ctx, func() {
+	stopper.RunWorker(ctx, func(context.Context) {
 		FatalIfUnexpected(server.Serve(ln))
 	})
 	return ln, nil
@@ -98,7 +98,7 @@ func MakeServer(stopper *stop.Stopper, tlsConfig *tls.Config, handler http.Handl
 		log.Fatal(ctx, err)
 	}
 
-	stopper.RunWorker(ctx, func() {
+	stopper.RunWorker(ctx, func(context.Context) {
 		<-stopper.ShouldStop()
 
 		mu.Lock()

--- a/pkg/util/netutil/net.go
+++ b/pkg/util/netutil/net.go
@@ -45,14 +45,16 @@ func ListenAndServeGRPC(
 		return ln, err
 	}
 
-	stopper.RunWorker(func() {
+	ctx := context.TODO()
+
+	stopper.RunWorker(ctx, func() {
 		<-stopper.ShouldQuiesce()
 		FatalIfUnexpected(ln.Close())
 		<-stopper.ShouldStop()
 		server.Stop()
 	})
 
-	stopper.RunWorker(func() {
+	stopper.RunWorker(ctx, func() {
 		FatalIfUnexpected(server.Serve(ln))
 	})
 	return ln, nil
@@ -88,13 +90,15 @@ func MakeServer(stopper *stop.Stopper, tlsConfig *tls.Config, handler http.Handl
 		},
 	}
 
+	ctx := context.TODO()
+
 	// net/http.(*Server).Serve/http2.ConfigureServer are not thread safe with
 	// respect to net/http.(*Server).TLSConfig, so we call it synchronously here.
 	if err := http2.ConfigureServer(server.Server, nil); err != nil {
-		log.Fatal(context.TODO(), err)
+		log.Fatal(ctx, err)
 	}
 
-	stopper.RunWorker(func() {
+	stopper.RunWorker(ctx, func() {
 		<-stopper.ShouldStop()
 
 		mu.Lock()
@@ -108,7 +112,9 @@ func MakeServer(stopper *stop.Stopper, tlsConfig *tls.Config, handler http.Handl
 }
 
 // ServeWith accepts connections on ln and serves them using serveConn.
-func (s *Server) ServeWith(stopper *stop.Stopper, l net.Listener, serveConn func(net.Conn)) error {
+func (s *Server) ServeWith(
+	ctx context.Context, stopper *stop.Stopper, l net.Listener, serveConn func(net.Conn),
+) error {
 	// Inspired by net/http.(*Server).Serve
 	var tempDelay time.Duration // how long to sleep on accept failure
 	for {
@@ -131,7 +137,7 @@ func (s *Server) ServeWith(stopper *stop.Stopper, l net.Listener, serveConn func
 		}
 		tempDelay = 0
 		go func() {
-			defer stopper.Recover()
+			defer stopper.Recover(ctx)
 			s.Server.ConnState(rw, http.StateNew) // before Serve can return
 			serveConn(rw)
 			s.Server.ConnState(rw, http.StateClosed)

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/opentracing/opentracing-go"
 )
 
 // ErrThrottled is returned from RunLimitedAsyncTask in the event that there
@@ -202,12 +203,16 @@ func (s *Stopper) Recover(ctx context.Context) {
 
 // RunWorker runs the supplied function as a "worker" to be stopped
 // by the stopper. The function <f> is run in a goroutine.
-func (s *Stopper) RunWorker(ctx context.Context, f func()) {
+func (s *Stopper) RunWorker(ctx context.Context, f func(context.Context)) {
 	s.stop.Add(1)
 	go func() {
+		// Remove any associated span; we need to ensure this because the
+		// worker may run longer than the caller which presumably closes
+		// any spans it has created.
+		ctx = opentracing.ContextWithSpan(ctx, nil)
 		defer s.Recover(ctx)
 		defer s.stop.Done()
-		f()
+		f(ctx)
 	}()
 }
 
@@ -226,7 +231,7 @@ func (s *Stopper) AddCloser(c Closer) {
 //
 // Returns an error to indicate that the system is currently quiescing and
 // function f was not called.
-func (s *Stopper) RunTask(ctx context.Context, f func()) error {
+func (s *Stopper) RunTask(ctx context.Context, f func(context.Context)) error {
 	key := taskKey{"???", 1}
 	if s.trackTasks {
 		key.file, key.line, _ = caller.Lookup(1)
@@ -234,10 +239,12 @@ func (s *Stopper) RunTask(ctx context.Context, f func()) error {
 	if !s.runPrelude(key) {
 		return errUnavailable
 	}
+
 	// Call f.
 	defer s.Recover(ctx)
 	defer s.runPostlude(key)
-	f()
+
+	f(ctx)
 	return nil
 }
 
@@ -249,7 +256,7 @@ func (s *Stopper) RunTask(ctx context.Context, f func()) error {
 //
 // If the system is currently quiescing and function f was not called, returns
 // an error indicating this condition. Otherwise, returns whatever f returns.
-func (s *Stopper) RunTaskWithErr(ctx context.Context, f func() error) error {
+func (s *Stopper) RunTaskWithErr(ctx context.Context, f func(context.Context) error) error {
 	key := taskKey{"???", 1}
 	if s.trackTasks {
 		key.file, key.line, _ = caller.Lookup(1)
@@ -257,10 +264,12 @@ func (s *Stopper) RunTaskWithErr(ctx context.Context, f func() error) error {
 	if !s.runPrelude(key) {
 		return errUnavailable
 	}
+
 	// Call f.
 	defer s.Recover(ctx)
 	defer s.runPostlude(key)
-	return f()
+
+	return f(ctx)
 }
 
 // RunAsyncTask runs function f in a goroutine. It returns an error when the
@@ -281,6 +290,7 @@ func (s *Stopper) RunAsyncTask(ctx context.Context, f func(context.Context)) err
 		defer s.Recover(ctx)
 		defer s.runPostlude(key)
 		defer tracing.FinishSpan(span)
+
 		f(ctx)
 	}()
 	return nil
@@ -345,6 +355,7 @@ func (s *Stopper) RunLimitedAsyncTask(
 		defer s.runPostlude(key)
 		defer func() { <-sem }()
 		defer tracing.FinishSpan(span)
+
 		f(ctx)
 	}()
 	return nil

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -189,23 +189,23 @@ func NewStopper(options ...Option) *Stopper {
 // panics on goroutines started by the Stopper. It can also be invoked
 // explicitly (via "defer s.Recover()") on goroutines that are created outside
 // of Stopper.
-func (s *Stopper) Recover() {
+func (s *Stopper) Recover(ctx context.Context) {
 	if r := recover(); r != nil {
 		if s.onPanic != nil {
 			s.onPanic(r)
 			return
 		}
-		log.ReportPanic(r)
+		log.ReportPanic(ctx, r)
 		panic(r)
 	}
 }
 
 // RunWorker runs the supplied function as a "worker" to be stopped
 // by the stopper. The function <f> is run in a goroutine.
-func (s *Stopper) RunWorker(f func()) {
+func (s *Stopper) RunWorker(ctx context.Context, f func()) {
 	s.stop.Add(1)
 	go func() {
-		defer s.Recover()
+		defer s.Recover(ctx)
 		defer s.stop.Done()
 		f()
 	}()
@@ -226,7 +226,7 @@ func (s *Stopper) AddCloser(c Closer) {
 //
 // Returns an error to indicate that the system is currently quiescing and
 // function f was not called.
-func (s *Stopper) RunTask(f func()) error {
+func (s *Stopper) RunTask(ctx context.Context, f func()) error {
 	key := taskKey{"???", 1}
 	if s.trackTasks {
 		key.file, key.line, _ = caller.Lookup(1)
@@ -235,7 +235,7 @@ func (s *Stopper) RunTask(f func()) error {
 		return errUnavailable
 	}
 	// Call f.
-	defer s.Recover()
+	defer s.Recover(ctx)
 	defer s.runPostlude(key)
 	f()
 	return nil
@@ -249,7 +249,7 @@ func (s *Stopper) RunTask(f func()) error {
 //
 // If the system is currently quiescing and function f was not called, returns
 // an error indicating this condition. Otherwise, returns whatever f returns.
-func (s *Stopper) RunTaskWithErr(f func() error) error {
+func (s *Stopper) RunTaskWithErr(ctx context.Context, f func() error) error {
 	key := taskKey{"???", 1}
 	if s.trackTasks {
 		key.file, key.line, _ = caller.Lookup(1)
@@ -258,7 +258,7 @@ func (s *Stopper) RunTaskWithErr(f func() error) error {
 		return errUnavailable
 	}
 	// Call f.
-	defer s.Recover()
+	defer s.Recover(ctx)
 	defer s.runPostlude(key)
 	return f()
 }
@@ -278,7 +278,7 @@ func (s *Stopper) RunAsyncTask(ctx context.Context, f func(context.Context)) err
 
 	// Call f.
 	go func() {
-		defer s.Recover()
+		defer s.Recover(ctx)
 		defer s.runPostlude(key)
 		defer tracing.FinishSpan(span)
 		f(ctx)
@@ -341,7 +341,7 @@ func (s *Stopper) RunLimitedAsyncTask(
 	ctx, span := tracing.ForkCtxSpan(ctx, key.String())
 
 	go func() {
-		defer s.Recover()
+		defer s.Recover(ctx)
 		defer s.runPostlude(key)
 		defer func() { <-sem }()
 		defer tracing.FinishSpan(span)
@@ -411,13 +411,13 @@ func (s *Stopper) runningTasksLocked() TaskMap {
 
 // Stop signals all live workers to stop and then waits for each to
 // confirm it has stopped.
-func (s *Stopper) Stop() {
-	defer s.Recover()
+func (s *Stopper) Stop(ctx context.Context) {
+	defer s.Recover(ctx)
 	defer unregister(s)
 
 	if log.V(1) {
 		file, line, _ := caller.Lookup(1)
-		log.Infof(context.TODO(),
+		log.Infof(ctx,
 			"stop has been called from %s:%d, stopping or quiescing all running tasks", file, line)
 	}
 	// Don't bother doing stuff cleanly if we're panicking, that would likely
@@ -425,7 +425,7 @@ func (s *Stopper) Stop() {
 	// avoids stalls and helps some tests in `./cli` finish cleanly (where
 	// panics happen on purpose).
 	if r := recover(); r != nil {
-		go s.Quiesce()
+		go s.Quiesce(ctx)
 		close(s.stopper)
 		close(s.stopped)
 		s.mu.Lock()
@@ -436,7 +436,7 @@ func (s *Stopper) Stop() {
 		panic(r)
 	}
 
-	s.Quiesce()
+	s.Quiesce(ctx)
 	close(s.stopper)
 	s.stop.Wait()
 	s.mu.Lock()
@@ -479,8 +479,8 @@ func (s *Stopper) IsStopped() <-chan struct{} {
 
 // Quiesce moves the stopper to state quiescing and waits until all
 // tasks complete. This is used from Stop() and unittests.
-func (s *Stopper) Quiesce() {
-	defer s.Recover()
+func (s *Stopper) Quiesce(ctx context.Context) {
+	defer s.Recover(ctx)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, cancel := range s.mu.cancels {
@@ -491,7 +491,7 @@ func (s *Stopper) Quiesce() {
 		close(s.quiescer)
 	}
 	for s.mu.numTasks > 0 {
-		log.Infof(context.TODO(), "quiescing; tasks left:\n%s", s.runningTasksLocked())
+		log.Infof(ctx, "quiescing; tasks left:\n%s", s.runningTasksLocked())
 		// Unlock s.mu, wait for the signal, and lock s.mu.
 		s.mu.quiesce.Wait()
 	}

--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -40,13 +40,14 @@ func TestStopper(t *testing.T) {
 	running := make(chan struct{})
 	waiting := make(chan struct{})
 	cleanup := make(chan struct{})
+	ctx := context.Background()
 
-	s.RunWorker(func() {
+	s.RunWorker(ctx, func() {
 		<-running
 	})
 
 	go func() {
-		s.Stop()
+		s.Stop(ctx)
 		close(waiting)
 		<-cleanup
 	}()
@@ -89,7 +90,7 @@ func TestStopperIsStopped(t *testing.T) {
 	s := stop.NewStopper()
 	bc := newBlockingCloser()
 	s.AddCloser(bc)
-	go s.Stop()
+	go s.Stop(context.Background())
 
 	select {
 	case <-s.ShouldStop():
@@ -115,16 +116,17 @@ func TestStopperMultipleStopees(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	const count = 3
 	s := stop.NewStopper()
+	ctx := context.Background()
 
 	for i := 0; i < count; i++ {
-		s.RunWorker(func() {
+		s.RunWorker(ctx, func() {
 			<-s.ShouldStop()
 		})
 	}
 
 	done := make(chan struct{})
 	go func() {
-		s.Stop()
+		s.Stop(ctx)
 		close(done)
 	}()
 
@@ -134,9 +136,10 @@ func TestStopperMultipleStopees(t *testing.T) {
 func TestStopperStartFinishTasks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := stop.NewStopper()
+	ctx := context.Background()
 
-	if err := s.RunTask(func() {
-		go s.Stop()
+	if err := s.RunTask(ctx, func() {
+		go s.Stop(ctx)
 
 		select {
 		case <-s.ShouldStop():
@@ -158,12 +161,13 @@ func TestStopperStartFinishTasks(t *testing.T) {
 func TestStopperRunWorker(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := stop.NewStopper()
-	s.RunWorker(func() {
+	ctx := context.Background()
+	s.RunWorker(ctx, func() {
 		<-s.ShouldStop()
 	})
 	closer := make(chan struct{})
 	go func() {
-		s.Stop()
+		s.Stop(ctx)
 		close(closer)
 	}()
 	select {
@@ -183,6 +187,7 @@ func TestStopperQuiesce(t *testing.T) {
 	}
 	var quiesceDone []chan struct{}
 	var runTaskDone []chan struct{}
+	ctx := context.Background()
 
 	for _, s := range stoppers {
 		thisStopper := s
@@ -190,10 +195,10 @@ func TestStopperQuiesce(t *testing.T) {
 		quiesceDone = append(quiesceDone, qc)
 		sc := make(chan struct{})
 		runTaskDone = append(runTaskDone, sc)
-		thisStopper.RunWorker(func() {
+		thisStopper.RunWorker(ctx, func() {
 			// Wait until Quiesce() is called.
 			<-qc
-			err := thisStopper.RunTask(func() {})
+			err := thisStopper.RunTask(ctx, func() {})
 			if _, ok := err.(*roachpb.NodeUnavailableError); !ok {
 				t.Error(err)
 			}
@@ -206,7 +211,7 @@ func TestStopperQuiesce(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		for _, s := range stoppers {
-			s.Quiesce()
+			s.Quiesce(ctx)
 		}
 		// Make the tasks call RunTask().
 		for _, qc := range quiesceDone {
@@ -219,7 +224,7 @@ func TestStopperQuiesce(t *testing.T) {
 		}
 
 		for _, s := range stoppers {
-			s.Stop()
+			s.Stop(ctx)
 			<-s.IsStopped()
 		}
 		close(done)
@@ -244,7 +249,7 @@ func TestStopperClosers(t *testing.T) {
 	var tc1, tc2 testCloser
 	s.AddCloser(&tc1)
 	s.AddCloser(&tc2)
-	s.Stop()
+	s.Stop(context.Background())
 	if !bool(tc1) || !bool(tc2) {
 		t.Errorf("expected true & true; got %t & %t", tc1, tc2)
 	}
@@ -301,7 +306,7 @@ func TestStopperNumTasks(t *testing.T) {
 	if m := s.RunningTasks(); len(m) != 0 {
 		t.Fatalf("task map not empty: %+v", m)
 	}
-	s.Stop()
+	s.Stop(context.Background())
 }
 
 // TestStopperRunTaskPanic ensures that a panic handler can recover panicking
@@ -315,12 +320,13 @@ func TestStopperRunTaskPanic(t *testing.T) {
 	// If RunTask were not panic-safe, Stop() would deadlock.
 	type testFn func()
 	explode := func() { panic(ch) }
+	ctx := context.Background()
 	for i, test := range []testFn{
 		func() {
-			_ = s.RunTask(explode)
+			_ = s.RunTask(ctx, explode)
 		},
 		func() {
-			_ = s.RunAsyncTask(context.Background(), func(_ context.Context) { explode() })
+			_ = s.RunAsyncTask(ctx, func(_ context.Context) { explode() })
 		},
 		func() {
 			_ = s.RunLimitedAsyncTask(
@@ -331,7 +337,7 @@ func TestStopperRunTaskPanic(t *testing.T) {
 			)
 		},
 		func() {
-			s.RunWorker(explode)
+			s.RunWorker(ctx, explode)
 		},
 	} {
 		go test()
@@ -346,7 +352,7 @@ func TestStopperWithCancel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := stop.NewStopper()
 	ctx := s.WithCancel(context.Background())
-	s.Stop()
+	s.Stop(ctx)
 	if err := ctx.Err(); err != context.Canceled {
 		t.Fatal(err)
 	}
@@ -359,24 +365,25 @@ func TestStopperShouldQuiesce(t *testing.T) {
 	runningTask := make(chan struct{})
 	waiting := make(chan struct{})
 	cleanup := make(chan struct{})
+	ctx := context.Background()
 
-	// Run a worker. A call to stopper.Stop() will not close until all workers
+	// Run a worker. A call to stopper.Stop(context.Background()) will not close until all workers
 	// have completed, and this worker will complete when the "running" channel
 	// is closed.
-	s.RunWorker(func() {
+	s.RunWorker(ctx, func() {
 		<-running
 	})
 	// Run an asynchronous task. A stopper which has been Stop()ed will not
 	// close it's ShouldStop() channel until all tasks have completed. This task
 	// will complete when the "runningTask" channel is closed.
-	if err := s.RunAsyncTask(context.Background(), func(_ context.Context) {
+	if err := s.RunAsyncTask(ctx, func(_ context.Context) {
 		<-runningTask
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	go func() {
-		s.Stop()
+		s.Stop(ctx)
 		close(waiting)
 		<-cleanup
 	}()
@@ -416,7 +423,7 @@ func TestStopperShouldQuiesce(t *testing.T) {
 func TestStopperRunLimitedAsyncTask(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := stop.NewStopper()
-	defer s.Stop()
+	defer s.Stop(context.Background())
 
 	const maxConcurrency = 5
 	const numTasks = maxConcurrency * 3
@@ -460,7 +467,7 @@ func TestStopperRunLimitedAsyncTask(t *testing.T) {
 	for i := 0; i < numTasks; i++ {
 		wg.Add(1)
 		if err := s.RunLimitedAsyncTask(
-			context.TODO(), sem, true /* wait */, f,
+			context.Background(), sem, true /* wait */, f,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -477,7 +484,7 @@ func TestStopperRunLimitedAsyncTask(t *testing.T) {
 	sem = make(chan struct{}, 1)
 	sem <- struct{}{}
 	err := s.RunLimitedAsyncTask(
-		context.TODO(), sem, false /* wait */, func(_ context.Context) {
+		context.Background(), sem, false /* wait */, func(_ context.Context) {
 		},
 	)
 	if err != stop.ErrThrottled {
@@ -488,7 +495,7 @@ func TestStopperRunLimitedAsyncTask(t *testing.T) {
 func TestStopperRunLimitedAsyncTaskCancelContext(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := stop.NewStopper()
-	defer s.Stop()
+	defer s.Stop(context.Background())
 
 	const maxConcurrency = 5
 	sem := make(chan struct{}, maxConcurrency)
@@ -500,7 +507,7 @@ func TestStopperRunLimitedAsyncTaskCancelContext(t *testing.T) {
 	var workersRun int32
 	var workersCancelled int32
 
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancel(context.Background())
 	f := func(ctx context.Context) {
 		atomic.AddInt32(&workersRun, 1)
 		workerStarted <- struct{}{}
@@ -550,7 +557,7 @@ func maybePrint() {
 func BenchmarkDirectCall(b *testing.B) {
 	defer leaktest.AfterTest(b)
 	s := stop.NewStopper()
-	defer s.Stop()
+	defer s.Stop(context.Background())
 	for i := 0; i < b.N; i++ {
 		maybePrint()
 	}
@@ -558,10 +565,11 @@ func BenchmarkDirectCall(b *testing.B) {
 
 func BenchmarkStopper(b *testing.B) {
 	defer leaktest.AfterTest(b)
+	ctx := context.Background()
 	s := stop.NewStopper()
-	defer s.Stop()
+	defer s.Stop(ctx)
 	for i := 0; i < b.N; i++ {
-		if err := s.RunTask(maybePrint); err != nil {
+		if err := s.RunTask(ctx, maybePrint); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -569,7 +577,7 @@ func BenchmarkStopper(b *testing.B) {
 func BenchmarkDirectCallPar(b *testing.B) {
 	defer leaktest.AfterTest(b)
 	s := stop.NewStopper()
-	defer s.Stop()
+	defer s.Stop(context.Background())
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			maybePrint()
@@ -579,11 +587,12 @@ func BenchmarkDirectCallPar(b *testing.B) {
 
 func BenchmarkStopperPar(b *testing.B) {
 	defer leaktest.AfterTest(b)
+	ctx := context.Background()
 	s := stop.NewStopper()
-	defer s.Stop()
+	defer s.Stop(ctx)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			if err := s.RunTask(maybePrint); err != nil {
+			if err := s.RunTask(ctx, maybePrint); err != nil {
 				b.Fatal(err)
 			}
 		}


### PR DESCRIPTION
This patch extends log.ReportPanic() to use a context.Context.
Because of this, the stopper interface (RunTask, RunWorker etc) must
be extended to also accept a context parameter.

Forked off #15063.