### PR TITLE
grpcutil: Catch "closed connection" error when using tls

### DIFF
--- a/pkg/util/grpcutil/grpc_util.go
+++ b/pkg/util/grpcutil/grpc_util.go
@@ -17,6 +17,7 @@
 package grpcutil
 
 import (
+	"io"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
@@ -50,7 +51,10 @@ func IsClosedConnection(err error) bool {
 		grpc.Code(err) == codes.Unavailable ||
 		grpc.ErrorDesc(err) == grpc.ErrClientConnClosing.Error() ||
 		strings.Contains(err.Error(), "is closing") ||
+		strings.Contains(err.Error(), "tls: use of closed connection") ||
 		strings.Contains(err.Error(), "use of closed network connection") ||
+		strings.Contains(err.Error(), io.ErrClosedPipe.Error()) ||
+		strings.Contains(err.Error(), io.EOF.Error()) ||
 		strings.Contains(err.Error(), "node unavailable") {
 		return true
 	}


### PR DESCRIPTION
Since for some reason it's worded slightly differently than the non-tls
error. After securing the acceptance tests,cockroach quit flaked with
Error: Error sending drain request: rpc error: code = Internal desc = transport: tls: use of closed connection

Fixes #15158