### PR TITLE
settings: use registration functions to create accessors.

### DIFF
--- a/pkg/ccl/utilccl/license_check.go
+++ b/pkg/ccl/utilccl/license_check.go
@@ -13,11 +13,15 @@ import (
 	"github.com/pkg/errors"
 )
 
+var enterpriseEnabled = settings.RegisterBoolSetting(
+	"enterprise.enabled", "set to true to enable Enterprise features", false,
+)
+
 // CheckEnterpriseEnabled returns a non-nil error if the requested enterprise
 // feature is not enabled, including information or a link explaining how to
 // enable it.
 func CheckEnterpriseEnabled(feature string) error {
-	if settings.EnterpriseEnabled() {
+	if enterpriseEnabled() {
 		return nil
 	}
 	// TODO(dt): link to some stable URL that then redirects to a helpful page

--- a/pkg/server/settingsworker.go
+++ b/pkg/server/settingsworker.go
@@ -107,6 +107,8 @@ func (s *Server) refreshSettings() {
 	s.stopper.RunWorker(func() {
 		gossipUpdateC := s.gossip.RegisterSystemConfigChannel()
 		ctx := s.AnnotateCtx(context.Background())
+		// No new settings can be defined beyond this point.
+		settings.Freeze()
 		for {
 			select {
 			case <-gossipUpdateC:

--- a/pkg/server/settingsworker_test.go
+++ b/pkg/server/settingsworker_test.go
@@ -28,11 +28,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
+const strKey = "testing.str"
+const intKey = "testing.int"
+
+var strAccessor = settings.RegisterStringSetting(strKey, "", "<default>")
+var intAccessor = settings.RegisterIntSetting(intKey, "", 1)
+
 func TestSettingsRefresh(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-
-	strKey, intKey, cleanup := settings.TestingAddTestVars()
-	defer cleanup()
 
 	s, rawDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop()
@@ -43,10 +46,10 @@ func TestSettingsRefresh(t *testing.T) {
 		VALUES ($1, $2, NOW(), $3)`
 	deleteQ := "DELETE FROM system.settings WHERE name = $1"
 
-	if expected, actual := "<default>", settings.TestingGetString(); expected != actual {
+	if expected, actual := "<default>", strAccessor(); expected != actual {
 		t.Fatalf("expected %v, got %v", expected, actual)
 	}
-	if expected, actual := 1, settings.TestingGetInt(); expected != actual {
+	if expected, actual := 1, intAccessor(); expected != actual {
 		t.Fatalf("expected %v, got %v", expected, actual)
 	}
 
@@ -55,10 +58,10 @@ func TestSettingsRefresh(t *testing.T) {
 	db.Exec(insertQ, intKey, settings.EncodeInt(2), "i")
 	// Wait until we observe the gossip-driven update propagating to cache.
 	testutils.SucceedsSoon(t, func() error {
-		if expected, actual := "foo", settings.TestingGetString(); expected != actual {
+		if expected, actual := "foo", strAccessor(); expected != actual {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := 2, settings.TestingGetInt(); expected != actual {
+		if expected, actual := 2, intAccessor(); expected != actual {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}
 		return nil
@@ -67,7 +70,7 @@ func TestSettingsRefresh(t *testing.T) {
 	// Setting to empty also works.
 	db.Exec(insertQ, strKey, "", "s")
 	testutils.SucceedsSoon(t, func() error {
-		if expected, actual := "", settings.TestingGetString(); expected != actual {
+		if expected, actual := "", strAccessor(); expected != actual {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}
 		return nil
@@ -78,10 +81,10 @@ func TestSettingsRefresh(t *testing.T) {
 	db.Exec(insertQ, strKey, "qux", "s")
 
 	testutils.SucceedsSoon(t, func() error {
-		if expected, actual := "qux", settings.TestingGetString(); expected != actual {
+		if expected, actual := "qux", strAccessor(); expected != actual {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := 2, settings.TestingGetInt(); expected != actual {
+		if expected, actual := 2, intAccessor(); expected != actual {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}
 		return nil
@@ -93,10 +96,10 @@ func TestSettingsRefresh(t *testing.T) {
 	db.Exec(insertQ, strKey, "after-invalid", "s")
 
 	testutils.SucceedsSoon(t, func() error {
-		if expected, actual := 2, settings.TestingGetInt(); expected != actual {
+		if expected, actual := 2, intAccessor(); expected != actual {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := "after-invalid", settings.TestingGetString(); expected != actual {
+		if expected, actual := "after-invalid", strAccessor(); expected != actual {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}
 		return nil
@@ -107,10 +110,10 @@ func TestSettingsRefresh(t *testing.T) {
 	db.Exec(insertQ, strKey, "after-mistype", "s")
 
 	testutils.SucceedsSoon(t, func() error {
-		if expected, actual := 2, settings.TestingGetInt(); expected != actual {
+		if expected, actual := 2, intAccessor(); expected != actual {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := "after-mistype", settings.TestingGetString(); expected != actual {
+		if expected, actual := "after-mistype", strAccessor(); expected != actual {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}
 		return nil
@@ -141,7 +144,7 @@ func TestSettingsRefresh(t *testing.T) {
 	// Deleting a value reverts to default.
 	db.Exec(deleteQ, strKey)
 	testutils.SucceedsSoon(t, func() error {
-		if expected, actual := "<default>", settings.TestingGetString(); expected != actual {
+		if expected, actual := "<default>", strAccessor(); expected != actual {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}
 		return nil

--- a/pkg/settings/cache_test.go
+++ b/pkg/settings/cache_test.go
@@ -22,17 +22,15 @@ import (
 
 var i1, i2 int
 
-func init() {
-	registry = map[string]value{
-		"bool.t":  {typ: BoolValue, b: true},
-		"bool.f":  {typ: BoolValue},
-		"str.foo": {typ: StringValue},
-		"str.bar": {typ: StringValue, s: "bar"},
-		"i.1":     {typ: IntValue},
-		"i.2":     {typ: IntValue, i: 5},
-		"f":       {typ: FloatValue, f: 5.4},
-	}
+var boolTAccessor = RegisterBoolSetting("bool.t", "", true)
+var boolFAccessor = RegisterBoolSetting("bool.f", "", false)
+var strFooAccessor = RegisterStringSetting("str.foo", "", "")
+var strBarAccessor = RegisterStringSetting("str.bar", "", "bar")
+var i1Accessor = RegisterIntSetting("i.1", "", 0)
+var i2Accessor = RegisterIntSetting("i.2", "", 5)
+var fAccessor = RegisterFloatSetting("f", "", 5.4)
 
+func init() {
 	RegisterCallback(func() {
 		i1 = getInt("i.1")
 		i2 = getInt("i.2")
@@ -41,22 +39,22 @@ func init() {
 
 func TestCache(t *testing.T) {
 	t.Run("defaults", func(t *testing.T) {
-		if expected, actual := false, getBool("bool.f"); expected != actual {
+		if expected, actual := false, boolFAccessor(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := true, getBool("bool.t"); expected != actual {
+		if expected, actual := true, boolTAccessor(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := "", getString("str.foo"); expected != actual {
+		if expected, actual := "", strFooAccessor(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := "bar", getString("str.bar"); expected != actual {
+		if expected, actual := "bar", strBarAccessor(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := 0, getInt("i.1"); expected != actual {
+		if expected, actual := 0, i1Accessor(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := 5, getInt("i.2"); expected != actual {
+		if expected, actual := 5, i2Accessor(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 		// registering callback should have also run it initially and set default.
@@ -66,7 +64,7 @@ func TestCache(t *testing.T) {
 		if expected, actual := 5, i2; expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := 5.4, getFloat("f"); expected != actual {
+		if expected, actual := 5.4, fAccessor(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 		if actual, ok := TypeOf("i.1"); !ok || IntValue != actual {
@@ -99,16 +97,16 @@ func TestCache(t *testing.T) {
 		}
 		u.Apply()
 
-		if expected, actual := false, getBool("bool.t"); expected != actual {
+		if expected, actual := false, boolTAccessor(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := true, getBool("bool.f"); expected != actual {
+		if expected, actual := true, boolFAccessor(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := "baz", getString("str.foo"); expected != actual {
+		if expected, actual := "baz", strFooAccessor(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := 3, getInt("i.2"); expected != actual {
+		if expected, actual := 3, i2Accessor(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 		if expected, actual := 0, i1; expected != actual {
@@ -117,12 +115,12 @@ func TestCache(t *testing.T) {
 		if expected, actual := 3, i2; expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := 3.1, getFloat("f"); expected != actual {
+		if expected, actual := 3.1, fAccessor(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 
 		// We didn't change this one, so should still see the default.
-		if expected, actual := "bar", getString("str.bar"); expected != actual {
+		if expected, actual := "bar", strBarAccessor(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 	})
@@ -142,7 +140,7 @@ func TestCache(t *testing.T) {
 			u.Apply()
 		}
 
-		if expected, actual := true, getBool("bool.f"); expected != actual {
+		if expected, actual := true, boolFAccessor(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 		if expected, actual := 1, i1; expected != actual {
@@ -155,7 +153,7 @@ func TestCache(t *testing.T) {
 		// applying it from the cache.
 		MakeUpdater().Apply()
 
-		if expected, actual := false, getBool("bool.f"); expected != actual {
+		if expected, actual := false, boolFAccessor(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 		if expected, actual := 0, i1; expected != actual {
@@ -176,7 +174,7 @@ func TestCache(t *testing.T) {
 			u.Apply()
 		}
 
-		if expected, actual := false, getBool("bool.f"); expected != actual {
+		if expected, actual := false, boolFAccessor(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 	})
@@ -189,7 +187,7 @@ func TestCache(t *testing.T) {
 			}
 			u.Apply()
 		}
-		before := getInt("i.2")
+		before := i2Accessor()
 
 		// Applying after attempting to set with wrong type preserves current value.
 		{
@@ -203,7 +201,7 @@ func TestCache(t *testing.T) {
 			u.Apply()
 		}
 
-		if expected, actual := before, getInt("i.2"); expected != actual {
+		if expected, actual := before, i2Accessor(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 
@@ -218,7 +216,7 @@ func TestCache(t *testing.T) {
 			u.Apply()
 		}
 
-		if expected, actual := before, getInt("i.2"); expected != actual {
+		if expected, actual := before, i2Accessor(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 	})

--- a/pkg/settings/doc.go
+++ b/pkg/settings/doc.go
@@ -25,20 +25,16 @@ state obviously apply, it is needed to make the package's functionality
 available to a wide variety of callsites, that may or may not have a *Server or
 similar available to plumb though.
 
-To add a new setting, update `registry.go` to define it in the `registry` map,
-then add an exported accessor (wrapping one of the `getBool`, `getString`, etc
-helpers).
+To add a new setting, call one of the `Register` methods in `registry.go` and
+save the accessor created by the register function in the package where the setting
+is to be used. For example, to add an "enterprise" flag, adding
+into license_check.go:
 
-For example, to add an "enterprise" flag:
-var registry = map[string]settingValue{
-	....
-+ "enterprise.enabled": {typ: BoolValue},
+var enterpriseEnabled = settings.RegisterBoolSetting(
+   "enterprise.enabled", "some doc for the setting", false,
+)
 
-...
+Then use with `if enterpriseEnabled() ...`
 
-+// GetEnterpriseEnabled returns the enterprise.enabled setting.
-+func GetEnterpriseEnabled() bool {
-+   return getBool("enterprise.enabled")
-+}
 */
 package settings

--- a/pkg/sql/logic_test.go
+++ b/pkg/sql/logic_test.go
@@ -1342,12 +1342,12 @@ func (t *logicTest) setupAndRunFile(path string, config testClusterConfig) {
 	t.logScope.KeepLogs(false)
 }
 
+// Needed for settings logic tests.
+var _ = settings.RegisterStringSetting("testing.str", "", "<default>")
+var _ = settings.RegisterIntSetting("testing.int", "", 1)
+
 func TestLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-
-	// Needed for settings logic tests.
-	_, _, cleanup := settings.TestingAddTestVars()
-	defer cleanup()
 
 	if testutils.Stress() {
 		t.Skip()


### PR DESCRIPTION
This change makes it possible to keep the accessor function for the setting in the package where the setting is useful. 