### PR TITLE
base, cli: ensure all store paths are absolutes

### DIFF
--- a/pkg/base/store_spec.go
+++ b/pkg/base/store_spec.go
@@ -19,12 +19,14 @@ package base
 import (
 	"bytes"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/dustin/go-humanize"
+	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -96,7 +98,7 @@ func (ss StoreSpec) String() string {
 // a separate check.
 var fractionRegex = regexp.MustCompile(`^([0-9]+\.[0-9]*|[0-9]*\.[0-9]+|[0-9]+(\.[0-9]*)?%)$`)
 
-// newStoreSpec parses the string passed into a --store flag and returns a
+// NewStoreSpec parses the string passed into a --store flag and returns a
 // StoreSpec if it is correctly parsed.
 // There are four possible fields that can be passed in, comma separated:
 // - path=xxx The directory in which to the rocks db instance should be
@@ -113,7 +115,7 @@ var fractionRegex = regexp.MustCompile(`^([0-9]+\.[0-9]*|[0-9]*\.[0-9]+|[0-9]+(\
 //   - 0.2             -> 20% of the available space
 // - attrs=xxx:yyy:zzz A colon separated list of optional attributes.
 // Note that commas are forbidden within any field name or value.
-func newStoreSpec(value string) (StoreSpec, error) {
+func NewStoreSpec(value string) (StoreSpec, error) {
 	if len(value) == 0 {
 		return StoreSpec{}, fmt.Errorf("no value specified")
 	}
@@ -150,7 +152,15 @@ func newStoreSpec(value string) (StoreSpec, error) {
 			if value[0] == '~' {
 				return StoreSpec{}, fmt.Errorf("store path cannot start with '~': %s", value)
 			}
-			ss.Path = value
+			// Ensure that the store paths are absolute. This will clarify the
+			// output of the startup messages and ensure that logging doesn't
+			// get confused if the current working directory were to change for
+			// any reason.
+			var err error
+			ss.Path, err = filepath.Abs(value)
+			if err != nil {
+				return StoreSpec{}, errors.Wrapf(err, "could not find absolute path for %s", value)
+			}
 		case "size":
 			if fractionRegex.MatchString(value) {
 				percentFactor := 100.0
@@ -248,7 +258,7 @@ func (ssl *StoreSpecList) Type() string {
 // Set adds a new value to the StoreSpecValue. It is the important part of
 // pflag's value interface.
 func (ssl *StoreSpecList) Set(value string) error {
-	spec, err := newStoreSpec(value)
+	spec, err := NewStoreSpec(value)
 	if err != nil {
 		return err
 	}

--- a/pkg/base/store_spec_test.go
+++ b/pkg/base/store_spec_test.go
@@ -113,7 +113,7 @@ func TestNewStoreSpec(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		storeSpec, err := newStoreSpec(testCase.value)
+		storeSpec, err := NewStoreSpec(testCase.value)
 		if err != nil {
 			if len(testCase.expectedErr) == 0 {
 				t.Errorf("%d(%s): no expected error, got %s", i, testCase.value, err)
@@ -135,7 +135,7 @@ func TestNewStoreSpec(t *testing.T) {
 
 		// Now test String() to make sure the result can be parsed.
 		storeSpecString := storeSpec.String()
-		storeSpec2, err := newStoreSpec(storeSpecString)
+		storeSpec2, err := NewStoreSpec(storeSpecString)
 		if err != nil {
 			t.Errorf("%d(%s): error parsing String() result: %s", i, testCase.value, err)
 			continue

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -304,18 +304,6 @@ func runStart(cmd *cobra.Command, args []string) error {
 	sp := tracer.StartSpan("server start")
 	startCtx := opentracing.ContextWithSpan(context.Background(), sp)
 
-	// Ensure that the store paths are absolute. This will clarify the
-	// output of the startup messages below, and ensure that logging
-	// doesn't get confused if any future change in the code introduces
-	// a call to `os.Chdir`.
-	for i, spec := range serverCfg.Stores.Specs {
-		absPath, err := filepath.Abs(spec.Path)
-		if err != nil {
-			return err
-		}
-		serverCfg.Stores.Specs[i].Path = absPath
-	}
-
 	// Set up the logging and profiling output.
 	// It is important that no logging occurs before this point or the log files
 	// will be created in $TMPDIR instead of their expected location.

--- a/pkg/cli/start_test.go
+++ b/pkg/cli/start_test.go
@@ -105,6 +105,7 @@ func TestStartArgChecking(t *testing.T) {
 		{[]string{`--store=size=123gb`}, `no path specified`},
 		{[]string{`--store=type=mem`}, `size must be specified for an in memory store`},
 		{[]string{`--store=type=mem,path=blah`}, `path specified for in memory store`},
+		{[]string{"--store=type=mem,size=1GiB"}, ``},
 	}
 	for i, c := range testCases {
 		// Reset the context and insecure flag for every test case.

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -25,11 +25,10 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/dustin/go-humanize"
 	"github.com/elastic/gosigar"
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/gossip/resolver"
@@ -293,6 +292,10 @@ func SetOpenFileLimitForOneStore() (int, error) {
 
 // MakeConfig returns a Context with default values.
 func MakeConfig() Config {
+	storeSpec, err := base.NewStoreSpec(defaultStorePath)
+	if err != nil {
+		panic(err)
+	}
 	cfg := Config{
 		Config:                   new(base.Config),
 		MaxOffset:                base.DefaultMaxClockOffset,
@@ -305,7 +308,7 @@ func MakeConfig() Config {
 		TimeUntilStoreDead:       defaultTimeUntilStoreDead,
 		EventLogEnabled:          defaultEventLogEnabled,
 		Stores: base.StoreSpecList{
-			Specs: []base.StoreSpec{{Path: defaultStorePath}},
+			Specs: []base.StoreSpec{storeSpec},
 		},
 	}
 	cfg.Config.InitDefaults()


### PR DESCRIPTION
In windows, calling filepath.abs("") return an error while on unix systems it doesn't. This was causing in-memory stores on windows to fail.  This should never have been called in the first place since it is an in memory store.

This moves the conversion of paths to absolute paths into store_spec.

Fixes #15059.