### PR TITLE
gossip: Go back to not considering slow convergence tests a failure

### DIFF
--- a/pkg/gossip/convergence_test.go
+++ b/pkg/gossip/convergence_test.go
@@ -70,13 +70,14 @@ func TestConvergence(t *testing.T) {
 
 	const maxCycles = 100
 	if connectedCycle := network.RunUntilFullyConnected(); connectedCycle > maxCycles {
-		t.Errorf("expected a fully-connected network within %d cycles; took %d",
+		log.Warningf(context.Background(), "expected a fully-connected network within %d cycles; took %d",
 			maxCycles, connectedCycle)
 	}
 
 	const maxConnsRefused = 50
 	if connsRefused := connectionsRefused(network); connsRefused > maxConnsRefused {
-		t.Errorf("expected network to fully connect with <= %d connections refused; took %d",
+		log.Warningf(context.Background(),
+			"expected network to fully connect with <= %d connections refused; took %d",
 			maxConnsRefused, connsRefused)
 	}
 }
@@ -121,12 +122,14 @@ func TestNetworkReachesEquilibrium(t *testing.T) {
 
 	const maxCycles = 200
 	if numCycles > maxCycles {
-		t.Errorf("expected a non-thrashing network within %d cycles; took %d", maxCycles, numCycles)
+		log.Warningf(context.Background(), "expected a non-thrashing network within %d cycles; took %d",
+			maxCycles, numCycles)
 	}
 
 	const maxConnsRefused = 500
 	if connsRefused > maxConnsRefused {
-		t.Errorf("expected thrashing to die down with <= %d connections refused; took %d",
+		log.Warningf(context.Background(),
+			"expected thrashing to die down with <= %d connections refused; took %d",
 			maxConnsRefused, connsRefused)
 	}
 }


### PR DESCRIPTION
Fixes #15169, undoing half of #15159 in the process.