### PR TITLE
sql: add sql.request.latency metric

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -86,12 +86,18 @@ var (
 	MetaSQLExecLatency = metric.Metadata{
 		Name: "sql.exec.latency",
 		Help: "Latency of SQL statement execution"}
+	MetaSQLServiceLatency = metric.Metadata{
+		Name: "sql.service.latency",
+		Help: "Latency of SQL request execution"}
 	MetaDistSQLSelect = metric.Metadata{
 		Name: "sql.distsql.select.count",
 		Help: "Number of dist-SQL SELECT statements"}
 	MetaDistSQLExecLatency = metric.Metadata{
 		Name: "sql.distsql.exec.latency",
 		Help: "Latency of dist-SQL statement execution"}
+	MetaDistSQLServiceLatency = metric.Metadata{
+		Name: "sql.distsql.service.latency",
+		Help: "Latency of dist-SQL request execution"}
 	MetaUpdate = metric.Metadata{
 		Name: "sql.update.count",
 		Help: "Number of SQL UPDATE statements"}
@@ -188,10 +194,12 @@ type Executor struct {
 	// Transient stats.
 	SelectCount *metric.Counter
 	// The subset of SELECTs that are processed through DistSQL.
-	DistSQLSelectCount *metric.Counter
-	DistSQLExecLatency *metric.Histogram
-	SQLExecLatency     *metric.Histogram
-	TxnBeginCount      *metric.Counter
+	DistSQLSelectCount    *metric.Counter
+	DistSQLExecLatency    *metric.Histogram
+	SQLExecLatency        *metric.Histogram
+	DistSQLServiceLatency *metric.Histogram
+	SQLServiceLatency     *metric.Histogram
+	TxnBeginCount         *metric.Counter
 
 	// txnCommitCount counts the number of times a COMMIT was attempted.
 	TxnCommitCount *metric.Counter
@@ -302,6 +310,10 @@ func NewExecutor(cfg ExecutorConfig, stopper *stop.Stopper) *Executor {
 		DistSQLExecLatency: metric.NewLatency(MetaDistSQLExecLatency,
 			6*metricsSampleInterval),
 		SQLExecLatency: metric.NewLatency(MetaSQLExecLatency,
+			6*metricsSampleInterval),
+		DistSQLServiceLatency: metric.NewLatency(MetaDistSQLServiceLatency,
+			6*metricsSampleInterval),
+		SQLServiceLatency: metric.NewLatency(MetaSQLServiceLatency,
 			6*metricsSampleInterval),
 		UpdateCount: metric.NewCounter(MetaUpdate),
 		InsertCount: metric.NewCounter(MetaInsert),

--- a/pkg/ui/src/containers/nodeGraphs.tsx
+++ b/pkg/ui/src/containers/nodeGraphs.tsx
@@ -299,13 +299,13 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
             </Axis>
           </LineGraph>
 
-          <LineGraph title="Backend Statement Execution Latency: SQL, 99th percentile"
-                       tooltip={`The latency of backend statements executed over 10 second periods ${specifier}.`}>
+          <LineGraph title="Backend Statement Service Latency: SQL, 99th percentile"
+                       tooltip={`The latency of backend statements serviced over 10 second periods ${specifier}.`}>
             <Axis units={ AxisUnits.Duration }>
               {
                 _.map(nodeIDs, (node) =>
                   <Metric key={node}
-                          name="cr.node.sql.exec.latency-p99"
+                          name="cr.node.sql.service.latency-p99"
                           title={this.nodeAddress(node)}
                           sources={[node]}
                           downsampleMax />,
@@ -314,13 +314,13 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
             </Axis>
           </LineGraph>
 
-          <LineGraph title="Backend Statement Execution Latency: SQL, 90th percentile"
-                       tooltip={`The latency of backend statements executed over 10 second periods ${specifier}.`}>
+          <LineGraph title="Backend Statement Service Latency: SQL, 90th percentile"
+                       tooltip={`The latency of backend statements serviced over 10 second periods ${specifier}.`}>
             <Axis units={ AxisUnits.Duration }>
               {
                 _.map(nodeIDs, (node) =>
                   <Metric key={node}
-                          name="cr.node.sql.exec.latency-p90"
+                          name="cr.node.sql.service.latency-p90"
                           title={this.nodeAddress(node)}
                           sources={[node]}
                           downsampleMax />,
@@ -329,13 +329,13 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
             </Axis>
           </LineGraph>
 
-          <LineGraph title="Backend Statement Execution Latency: DistSQL, 99th percentile"
-                       tooltip={`The latency of backend statements executed over 10 second periods ${specifier}.`}>
+          <LineGraph title="Backend Statement Service Latency: DistSQL, 99th percentile"
+                       tooltip={`The latency of backend statements serviced over 10 second periods ${specifier}.`}>
             <Axis units={ AxisUnits.Duration }>
               {
                 _.map(nodeIDs, (node) =>
                   <Metric key={node}
-                          name="cr.node.sql.distsql.exec.latency-p99"
+                          name="cr.node.sql.distsql.service.latency-p99"
                           title={this.nodeAddress(node)}
                           sources={[node]}
                           downsampleMax />,
@@ -344,13 +344,13 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
             </Axis>
           </LineGraph>
 
-          <LineGraph title="Backend Statement Execution Latency: DistSQL, 90th percentile"
-                       tooltip={`The latency of backend statements executed over 10 second periods ${specifier}.`}>
+          <LineGraph title="Backend Statement Service Latency: DistSQL, 90th percentile"
+                       tooltip={`The latency of backend statements serviced over 10 second periods ${specifier}.`}>
             <Axis units={ AxisUnits.Duration }>
               {
                 _.map(nodeIDs, (node) =>
                   <Metric key={node}
-                          name="cr.node.sql.distsql.exec.latency-p90"
+                          name="cr.node.sql.distsql.service.latency-p90"
                           title={this.nodeAddress(node)}
                           sources={[node]}
                           downsampleMax />,


### PR DESCRIPTION
Resolves #14095.

This PR introduces a `sql.request.latency` metric, which is similar to
`sql.exec.latency` but includes parse + plan time as well.

After discussing with @cuongdo and @mrtracy I experimented with but did
not add a graph to the SQL dashboard. My reasoning is that this
information is not especially helpful without being able to compare it
to the exec time on the same axis visually, however, the exec time is
presented on a per-node basis, so adding this to that graph would not
be very readable.

I think if we want to provide information about the cost of parse+plan
it would make more sense to  introduce another metric for just the parse
and/or plan time.

I would have liked to add a test but it's not clear to me how to test
this (`sql.exec.latency` also appears to be untested). But I tested it
manually and everything seems to work fine. If we think testing this
is important then I'm open to ideas for where to put such a test.