### PR TITLE
build: restore quickness of `make testlogic`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ testrace: TESTTIMEOUT := $(RACETIMEOUT)
 # guaranteed to be irrelevant to save nearly 10s on every Make invocation.
 FIND_RELEVANT := find pkg -name node_modules -prune -o
 
-bin/sql.test: main.go $(shell $(FIND_RELEVANT) -name '*.go')
+bin/sql.test: main.go $(shell $(FIND_RELEVANT) -not -name 'zcgo_flags.go' -name '*.go')
 	$(XGO) test $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -c -o bin/sql.test ./pkg/sql
 
 bench: BENCHES := .


### PR DESCRIPTION
The recent Makefile changes caused `make testlogic` to depend on the
autogenerated zcgo files which removed the test binary caching.

Now, it no longer depends on those. This is technically incorrect, but
since this target is just for local testing ergonomics it shouldn't hurt
anyone.