### PR TITLE
acceptanceccl: add 2tb backup test

### DIFF
--- a/pkg/acceptance/terraform/azure/main.tf
+++ b/pkg/acceptance/terraform/azure/main.tf
@@ -181,7 +181,8 @@ data "template_file" "supervisor" {
     # The value of the --join flag must be empty for the first node,
     # and a running node for all others. We build a list of addresses
     # shifted by one (first element is empty), then take the value at index "instance.index".
-    join_address = "${element(concat(split(",", ""), azurerm_public_ip.cockroach.*.fqdn), count.index == 0 ? 0 : 1)}"
+    # If join_all is true, --join is instead all nodes.
+    join_address = "${var.join_all == "true" ? join(",", azurerm_public_ip.cockroach.*.fqdn) : element(concat(split(",", ""), azurerm_public_ip.cockroach.*.fqdn), count.index == 0 ? 0 : 1)}"
     cockroach_flags = "${var.cockroach_flags}"
     # If the following changes, (*terrafarm.Farmer).Add() must change too.
     cockroach_env = "${var.cockroach_env}"

--- a/pkg/acceptance/terraform/azure/variables.tf
+++ b/pkg/acceptance/terraform/azure/variables.tf
@@ -117,3 +117,8 @@ variable "cockroach_env" {
 variable "benchmark_name" {
   default = "BenchmarkBlockWriter"
 }
+
+# join_all specifies the join behavior.
+variable "join_all" {
+  default = "false"
+}

--- a/pkg/acceptance/terraform/gce/main.tf
+++ b/pkg/acceptance/terraform/gce/main.tf
@@ -56,7 +56,8 @@ data "template_file" "supervisor" {
     # The value of the --join flag must be empty for the first node,
     # and a running node for all others. We build a list of addresses
     # shifted by one (first element is empty), then take the value at index "instance.index".
-    join_address = "${element(concat(split(",", ""), google_compute_instance.cockroach.*.network_interface.0.access_config.0.assigned_nat_ip), count.index == 0 ? 0 : 1)}"
+    # If join_all is true, --join is instead all nodes.
+    join_address = "${var.join_all == "true" ? join(",", google_compute_instance.cockroach.*.network_interface.0.access_config.0.assigned_nat_ip) : element(concat(split(",", ""), google_compute_instance.cockroach.*.network_interface.0.access_config.0.assigned_nat_ip), count.index == 0 ? 0 : 1)}"
     cockroach_flags = "${var.cockroach_flags}"
     # If the following changes, (*terrafarm.Farmer).Add() must change too.
     cockroach_env = "${var.cockroach_env}"

--- a/pkg/acceptance/terraform/gce/variables.tf
+++ b/pkg/acceptance/terraform/gce/variables.tf
@@ -114,3 +114,8 @@ variable "cockroach_env" {
 variable "benchmark_name" {
   default = "BenchmarkBlockWriter"
 }
+
+# join_all specifies the join behavior.
+variable "join_all" {
+  default = "false"
+}

--- a/pkg/ccl/acceptanceccl/backup_test.go
+++ b/pkg/ccl/acceptanceccl/backup_test.go
@@ -37,7 +37,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
-const longWaitTime = 2 * time.Minute
+const (
+	longWaitTime        = 2 * time.Minute
+	bulkArchiveStoreURL = "gs://cockroach-test/bulkops/10nodes-2t-50000ranges"
+)
 
 type benchmarkTest struct {
 	b testing.TB
@@ -51,6 +54,14 @@ type benchmarkTest struct {
 	// Terraform configs. This must be in GB, because Terraform only accepts
 	// disk size for GCE in GB.
 	cockroachDiskSizeGB int
+	// storeURL is the Google Cloud Storage URL from which the test will
+	// download stores. Nothing is downloaded if storeURL is empty.
+	storeURL string
+	// skipClusterInit controls the --join flags for the nodes. If false (the
+	// default), then the first node will be empty and thus init the cluster,
+	// and each node will have the previous node as its join flag. If true,
+	// then all nodes will have all nodes in their join flags.
+	skipClusterInit bool
 
 	f *terrafarm.Farmer
 }
@@ -60,6 +71,8 @@ func (bt *benchmarkTest) Start(ctx context.Context) {
 
 	bt.f.AddFlag("--max-offset=1s")
 
+	bt.f.AddVars["join_all"] = fmt.Sprint(bt.skipClusterInit)
+
 	if bt.cockroachDiskSizeGB != 0 {
 		bt.f.AddVars["cockroach_disk_size"] = strconv.Itoa(bt.cockroachDiskSizeGB)
 	}
@@ -67,6 +80,38 @@ func (bt *benchmarkTest) Start(ctx context.Context) {
 	log.Infof(ctx, "creating cluster with %d node(s)", bt.nodes)
 	if err := bt.f.Resize(bt.nodes); err != nil {
 		bt.b.Fatal(err)
+	}
+
+	if bt.storeURL != "" {
+		// We must stop the cluster because `nodectl` pokes at the data directory.
+		log.Info(ctx, "stopping cluster")
+		for i := 0; i < bt.f.NumNodes(); i++ {
+			if err := bt.f.Kill(ctx, i); err != nil {
+				bt.b.Fatalf("error stopping node %d: %s", i, err)
+			}
+		}
+
+		log.Info(ctx, "downloading archived stores from Google Cloud Storage in parallel")
+		errors := make(chan error, bt.f.NumNodes())
+		for i := 0; i < bt.f.NumNodes(); i++ {
+			go func(nodeNum int) {
+				cmd := fmt.Sprintf(`gsutil -m cp -r "%s/node%d/*" "%s"`, bt.storeURL, nodeNum, "/mnt/data0")
+				log.Infof(ctx, "exec on node %d: %s", nodeNum, cmd)
+				errors <- bt.f.Exec(nodeNum, cmd)
+			}(i)
+		}
+		for i := 0; i < bt.f.NumNodes(); i++ {
+			if err := <-errors; err != nil {
+				bt.b.Fatalf("error downloading store %d: %s", i, err)
+			}
+		}
+
+		log.Info(ctx, "restarting cluster with archived store(s)")
+		for i := 0; i < bt.f.NumNodes(); i++ {
+			if err := bt.f.Restart(ctx, i); err != nil {
+				bt.b.Fatalf("error restarting node %d: %s", i, err)
+			}
+		}
 	}
 	acceptance.CheckGossip(ctx, bt.b, bt.f, longWaitTime, acceptance.HasPeers(bt.nodes))
 	bt.f.Assert(ctx, bt.b)
@@ -105,6 +150,24 @@ const (
 	bankInsert = `INSERT INTO bench.bank VALUES (%d, %d, '%s')`
 )
 
+func getAzureURI(t testing.TB) url.URL {
+	container := os.Getenv("AZURE_CONTAINER")
+	accountName := os.Getenv("AZURE_ACCOUNT_NAME")
+	accountKey := os.Getenv("AZURE_ACCOUNT_KEY")
+	if container == "" || accountName == "" || accountKey == "" {
+		t.Fatal("env variables AZURE_CONTAINER, AZURE_ACCOUNT_NAME, AZURE_ACCOUNT_KEY must be set")
+	}
+
+	return url.URL{
+		Scheme: "azure",
+		Host:   container,
+		RawQuery: url.Values{
+			storageccl.AzureAccountNameParam: []string{accountName},
+			storageccl.AzureAccountKeyParam:  []string{accountKey},
+		}.Encode(),
+	}
+}
+
 // BenchmarkRestoreBig creates a backup via Load with b.N rows then benchmarks
 // the time to restore it. Run with:
 // make bench TESTTIMEOUT=1h PKG=./pkg/ccl/acceptanceccl BENCHES=BenchmarkRestoreBig TESTFLAGS='-v -benchtime 1m -remote -key-name azure -cwd ../../acceptance/terraform/azure'
@@ -112,12 +175,7 @@ func BenchmarkRestoreBig(b *testing.B) {
 	ctx := context.Background()
 	rng, _ := randutil.NewPseudoRand()
 
-	container := os.Getenv("AZURE_CONTAINER")
-	accountName := os.Getenv("AZURE_ACCOUNT_NAME")
-	accountKey := os.Getenv("AZURE_ACCOUNT_KEY")
-	if container == "" || accountName == "" || accountKey == "" {
-		b.Fatal("env variables AZURE_CONTAINER, AZURE_ACCOUNT_NAME, AZURE_ACCOUNT_KEY must be set")
-	}
+	restoreBaseURI := getAzureURI(b)
 
 	bt := benchmarkTest{
 		b:                   b,
@@ -141,17 +199,7 @@ func BenchmarkRestoreBig(b *testing.B) {
 
 	// (mis-)Use a sub benchmark to avoid running the setup code more than once.
 	b.Run("", func(b *testing.B) {
-		restoreBaseURI := &url.URL{
-			Scheme: "azure",
-			Host:   container,
-			Path:   fmt.Sprintf("BenchmarkRestoreBig/%s-%d", timeutil.Now().Format(time.RFC3339Nano), b.N),
-		}
-		log.Infof(ctx, "restore URI: %s", restoreBaseURI)
-
-		restoreBaseURI.RawQuery = url.Values{
-			storageccl.AzureAccountNameParam: []string{accountName},
-			storageccl.AzureAccountKeyParam:  []string{accountKey},
-		}.Encode()
+		restoreBaseURI.Path = fmt.Sprintf("BenchmarkRestoreBig/%s-%d", timeutil.Now().Format(time.RFC3339Nano), b.N)
 
 		var buf bytes.Buffer
 		buf.WriteString(bankCreateTable)
@@ -219,4 +267,48 @@ func BenchmarkRestore2TB(b *testing.B) {
 	if _, err := db.Exec(`RESTORE datablocks.* FROM $1`, backupBaseURI); err != nil {
 		b.Fatal(err)
 	}
+}
+
+func BenchmarkBackup2TB(b *testing.B) {
+	if b.N != 1 {
+		b.Fatal("b.N must be 1")
+	}
+
+	backupBaseURI := getAzureURI(b)
+
+	backupBaseURI = url.URL{
+		Scheme: "gs",
+		Host:   "cockroach-test",
+	}
+
+	bt := benchmarkTest{
+		b:                   b,
+		nodes:               10,
+		storeURL:            bulkArchiveStoreURL,
+		cockroachDiskSizeGB: 250,
+		prefix:              "backup2tb",
+		skipClusterInit:     true,
+	}
+
+	ctx := context.Background()
+	bt.Start(ctx)
+	defer bt.Close(ctx)
+
+	db, err := gosql.Open("postgres", bt.f.PGUrl(ctx, 0))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer db.Close()
+
+	backupBaseURI.Path = fmt.Sprintf("BenchmarkBackup2TB/%s-%d", timeutil.Now().Format(time.RFC3339Nano), b.N)
+
+	log.Infof(ctx, "starting backup")
+	row := db.QueryRow(`BACKUP DATABASE datablocks TO $1`, backupBaseURI.String())
+	var unused string
+	var dataSize int64
+	if err := row.Scan(&unused, &unused, &unused, &dataSize); err != nil {
+		bt.b.Fatal(err)
+	}
+	b.SetBytes(dataSize)
+	log.Infof(ctx, "backed up %s", humanizeutil.IBytes(dataSize))
 }


### PR DESCRIPTION
Refactors the terraform join flags a bit since this test already has
store data, and we have a bug that requires the join flag on these
nodes to be all nodes. We can't use this for other tests, though,
because that will prevent the init step from happening.