### PR TITLE
sql: fix EncodePartialIndexKey function

### DIFF
--- a/pkg/sql/testdata/logic_test/ranges
+++ b/pkg/sql/testdata/logic_test/ranges
@@ -155,6 +155,22 @@ NULL           /1             {1}       1
 /7/8/#/52/1/9  /10            {1,2,4}   4
 /10            NULL           {1}       1
 
+statement ok
+ALTER TABLE t0 SPLIT AT VALUES (11)
+
+query TTTI colnames
+SHOW TESTING_RANGES FROM TABLE t0
+----
+Start Key      End Key        Replicas  Lease Holder
+NULL           /1             {1}       1
+/1             /5/1           {3,4}     3
+/5/1           /5/2           {1,2,3}   1
+/5/2           /5/3           {2,3,5}   5
+/5/3           /7/8/#/52/1/9  {1,2,4}   4
+/7/8/#/52/1/9  /10            {1,2,4}   4
+/10            /11            {1}       1
+/11            NULL           {1}       1
+
 query TTTI colnames
 SHOW TESTING_RANGES FROM TABLE t
 ----
@@ -165,7 +181,8 @@ NULL           /1             {1}       1
 /5/2           /5/3           {2,3,5}   5
 /5/3           /7/8/#/52/1/9  {1,2,4}   4
 /7/8/#/52/1/9  /10            {1,2,4}   4
-/10            NULL           {1}       1
+/10            /11            {1}       1
+/11            NULL           {1}       1
 
 statement ok
 CREATE TABLE t1 (k INT PRIMARY KEY, v1 INT, v2 INT, v3 INT)
@@ -184,7 +201,8 @@ NULL           /1             {1}       1
 /5/2           /5/3           {2,3,5}   5
 /5/3           /7/8/#/52/1/9  {1,2,4}   4
 /7/8/#/52/1/9  /10            {1,2,4}   4
-/10            NULL           {1}       1
+/10            /11            {1}       1
+/11            NULL           {1}       1
 
 statement ok
 ALTER INDEX t1@idx SPLIT AT VALUES (15,16)
@@ -199,7 +217,8 @@ NULL           /1             {1}       1
 /5/2           /5/3           {2,3,5}   5
 /5/3           /7/8/#/52/1/9  {1,2,4}   4
 /7/8/#/52/1/9  /10            {1,2,4}   4
-/10            /15/16/#/53/2  {1}       1
+/10            /11            {1}       1
+/11            /15/16/#/53/2  {1}       1
 /15/16/#/53/2  NULL           {1}       1
 
 statement error too many columns in SPLIT AT data


### PR DESCRIPTION
The partial version of EncodeIndexKey wasn't stopping correctly once we encoded
the given columns. Added a testcase that was crashing with the old function.