### PR TITLE
sql: fix broken event logging in schema changer

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -56,7 +55,6 @@ type SchemaChanger struct {
 	nodeID     roachpb.NodeID
 	db         client.DB
 	leaseMgr   *LeaseManager
-	evalCtx    parser.EvalContext
 	// The SchemaChangeManager can attempt to execute this schema
 	// changer after this time.
 	execAfter      time.Time
@@ -488,7 +486,7 @@ func (sc *SchemaChanger) done(ctx context.Context) (*sqlbase.Descriptor, error) 
 			txn,
 			EventLogFinishSchemaChange,
 			int32(sc.tableID),
-			int32(sc.evalCtx.NodeID),
+			int32(sc.nodeID),
 			struct {
 				MutationID uint32
 			}{uint32(sc.mutationID)},
@@ -564,7 +562,7 @@ func (sc *SchemaChanger) reverseMutations(ctx context.Context, causingError erro
 			txn,
 			EventLogReverseSchemaChange,
 			int32(sc.tableID),
-			int32(sc.evalCtx.NodeID),
+			int32(sc.nodeID),
 			struct {
 				Error      string
 				MutationID uint32

--- a/pkg/sql/testdata/logic_test/event_log
+++ b/pkg/sql/testdata/logic_test/event_log
@@ -82,7 +82,7 @@ query II
 SELECT targetID, reportingID FROM system.eventlog
 WHERE eventType = 'finish_schema_change'
 ----
-51 0
+51 1
 
 query II
 SELECT targetID, reportingID FROM system.eventlog
@@ -121,14 +121,14 @@ query II rowsort
 SELECT targetID, reportingID FROM system.eventlog
 WHERE eventType = 'finish_schema_change'
 ----
-51 0
-51 0
+51 1
+51 1
 
 query II rowsort
 SELECT targetID, reportingID FROM system.eventlog
 WHERE eventType = 'reverse_schema_change'
 ----
-51 0
+51 1
 
 # Create an Index on the table
 #################
@@ -147,9 +147,9 @@ query II rowsort
 SELECT targetID, reportingID FROM system.eventlog
 WHERE eventType = 'finish_schema_change'
 ----
-51 0
-51 0
-51 0
+51 1
+51 1
+51 1
 
 # Drop the index
 #################
@@ -168,10 +168,10 @@ query II rowsort
 SELECT targetID, reportingID FROM system.eventlog
 WHERE eventType = 'finish_schema_change'
 ----
-51 0
-51 0
-51 0
-51 0
+51 1
+51 1
+51 1
+51 1
 
 # Drop both tables + superfluous "IF EXISTS"
 ##################


### PR DESCRIPTION
The SchemaChanger was using an EvalCtx that was uninitialized since
14331. Even before then, the nodeID which is used was probably
uninitialized.