### PR TITLE
sql: migrate the tracing flags to cluster settings.

### DIFF
--- a/pkg/ccl/utilccl/license_check.go
+++ b/pkg/ccl/utilccl/license_check.go
@@ -21,7 +21,7 @@ var enterpriseEnabled = settings.RegisterBoolSetting(
 // feature is not enabled, including information or a link explaining how to
 // enable it.
 func CheckEnterpriseEnabled(feature string) error {
-	if enterpriseEnabled() {
+	if enterpriseEnabled.Get() {
 		return nil
 	}
 	// TODO(dt): link to some stable URL that then redirects to a helpful page

--- a/pkg/internal/client/txn_test.go
+++ b/pkg/internal/client/txn_test.go
@@ -45,7 +45,7 @@ var (
 
 // An example of snowball tracing being used to dump a trace around a
 // transaction. Use something similar whenever you cannot use
-// COCKROACH_TRACE_SQL.
+// sql.trace.txn.threshold.
 func TestTxnSnowballTrace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 

--- a/pkg/server/settingsworker_test.go
+++ b/pkg/server/settingsworker_test.go
@@ -32,8 +32,8 @@ import (
 const strKey = "testing.str"
 const intKey = "testing.int"
 
-var strAccessor = settings.RegisterStringSetting(strKey, "", "<default>")
-var intAccessor = settings.RegisterIntSetting(intKey, "", 1)
+var strA = settings.RegisterStringSetting(strKey, "", "<default>")
+var intA = settings.RegisterIntSetting(intKey, "", 1)
 
 func TestSettingsRefresh(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -47,10 +47,10 @@ func TestSettingsRefresh(t *testing.T) {
 		VALUES ($1, $2, NOW(), $3)`
 	deleteQ := "DELETE FROM system.settings WHERE name = $1"
 
-	if expected, actual := "<default>", strAccessor(); expected != actual {
+	if expected, actual := "<default>", strA.Get(); expected != actual {
 		t.Fatalf("expected %v, got %v", expected, actual)
 	}
-	if expected, actual := 1, intAccessor(); expected != actual {
+	if expected, actual := 1, intA.Get(); expected != actual {
 		t.Fatalf("expected %v, got %v", expected, actual)
 	}
 
@@ -59,10 +59,10 @@ func TestSettingsRefresh(t *testing.T) {
 	db.Exec(insertQ, intKey, settings.EncodeInt(2), "i")
 	// Wait until we observe the gossip-driven update propagating to cache.
 	testutils.SucceedsSoon(t, func() error {
-		if expected, actual := "foo", strAccessor(); expected != actual {
+		if expected, actual := "foo", strA.Get(); expected != actual {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := 2, intAccessor(); expected != actual {
+		if expected, actual := 2, intA.Get(); expected != actual {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}
 		return nil
@@ -71,7 +71,7 @@ func TestSettingsRefresh(t *testing.T) {
 	// Setting to empty also works.
 	db.Exec(insertQ, strKey, "", "s")
 	testutils.SucceedsSoon(t, func() error {
-		if expected, actual := "", strAccessor(); expected != actual {
+		if expected, actual := "", strA.Get(); expected != actual {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}
 		return nil
@@ -82,10 +82,10 @@ func TestSettingsRefresh(t *testing.T) {
 	db.Exec(insertQ, strKey, "qux", "s")
 
 	testutils.SucceedsSoon(t, func() error {
-		if expected, actual := "qux", strAccessor(); expected != actual {
+		if expected, actual := "qux", strA.Get(); expected != actual {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := 2, intAccessor(); expected != actual {
+		if expected, actual := 2, intA.Get(); expected != actual {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}
 		return nil
@@ -97,10 +97,10 @@ func TestSettingsRefresh(t *testing.T) {
 	db.Exec(insertQ, strKey, "after-invalid", "s")
 
 	testutils.SucceedsSoon(t, func() error {
-		if expected, actual := 2, intAccessor(); expected != actual {
+		if expected, actual := 2, intA.Get(); expected != actual {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := "after-invalid", strAccessor(); expected != actual {
+		if expected, actual := "after-invalid", strA.Get(); expected != actual {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}
 		return nil
@@ -111,10 +111,10 @@ func TestSettingsRefresh(t *testing.T) {
 	db.Exec(insertQ, strKey, "after-mistype", "s")
 
 	testutils.SucceedsSoon(t, func() error {
-		if expected, actual := 2, intAccessor(); expected != actual {
+		if expected, actual := 2, intA.Get(); expected != actual {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := "after-mistype", strAccessor(); expected != actual {
+		if expected, actual := "after-mistype", strA.Get(); expected != actual {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}
 		return nil
@@ -145,7 +145,7 @@ func TestSettingsRefresh(t *testing.T) {
 	// Deleting a value reverts to default.
 	db.Exec(deleteQ, strKey)
 	testutils.SucceedsSoon(t, func() error {
-		if expected, actual := "<default>", strAccessor(); expected != actual {
+		if expected, actual := "<default>", strA.Get(); expected != actual {
 			return errors.Errorf("expected %v, got %v", expected, actual)
 		}
 		return nil

--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -229,7 +229,7 @@ func (s *Server) maybeReportDiagnostics(scheduled time.Time, running time.Durati
 		return scheduled
 	}
 
-	if diagnosticsReportingEnabled() {
+	if diagnosticsReportingEnabled.Get() {
 		s.reportDiagnostics()
 	}
 

--- a/pkg/settings/accessors.go
+++ b/pkg/settings/accessors.go
@@ -1,0 +1,174 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package settings
+
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+	"unsafe"
+)
+
+// The Register functions below return an object of type "Setting".
+// This works differently for "large" (string) and "small" (everything
+// else) types, as follows:
+//
+// For small types,
+// - the Setting object contains a (pointer to an) int variable
+// - the Get accessor uses atomic loads to access the value
+// - the register function all registers an async callback to upload
+//   the variable atomically when the settings change.
+// This mechanism is chosen because an atomic load is inlined
+// by the Go compiler and fast, whereas an access via the corresponding
+// getXXX() methods would need to acquire a lock.
+//
+// For large types,
+// - the Setting object contains a closure that calls the getXXX method.
+//
+
+// BoolSetting is the interface of a setting variable that will be
+// updated automatically when the corresponding cluster-wide setting
+// of type "bool" is updated.
+type BoolSetting struct{ v *int32 }
+
+// Get retrieves the bool value in the setting.
+func (b BoolSetting) Get() bool {
+	return atomic.LoadInt32(b.v) != 0
+}
+
+// IntSetting is the interface of a setting variable that will be
+// updated automatically when the corresponding cluster-wide setting
+// of type "int" is updated.
+type IntSetting struct{ v *int64 }
+
+// Get retrieves the int value in the setting.
+func (i IntSetting) Get() int {
+	return int(atomic.LoadInt64(i.v))
+}
+
+// FloatSetting is the interface of a setting variable that will be
+// updated automatically when the corresponding cluster-wide setting
+// of type "float" is updated.
+type FloatSetting struct{ v *uint64 }
+
+// Get retrieves the float value in the setting.
+func (f FloatSetting) Get() float64 {
+	x := atomic.LoadUint64(f.v)
+	return *(*float64)(unsafe.Pointer(&x))
+}
+
+// DurationSetting is the interface of a setting variable that will be
+// updated automatically when the corresponding cluster-wide setting
+// of type "duration" is updated.
+type DurationSetting struct{ v *int64 }
+
+// Get retrieves the duration value in the setting.
+func (d DurationSetting) Get() time.Duration {
+	return time.Duration(atomic.LoadInt64(d.v))
+}
+
+// StringSetting is the interface of a setting variable that will be
+// updated automatically when the corresponding cluster-wide setting
+// of type "string" is updated.
+type StringSetting struct {
+	// Get retrieves the string value in the setting.
+	Get func() string
+}
+
+// checkAdd validates that it is indeed possible to add a setting with
+// that name to the registry.
+func checkAdd(key string) {
+	if atomic.LoadInt32(&frozen) > 0 {
+		panic(fmt.Sprintf("registration must occur before server start: %s", key))
+	}
+	if _, ok := registry[key]; ok {
+		panic(fmt.Sprintf("setting already defined: %s", key))
+	}
+}
+
+// RegisterBoolSetting defines a new setting with type bool.
+func RegisterBoolSetting(key, desc string, defVal bool) BoolSetting {
+	checkAdd(key)
+
+	v := int32(0)
+	setting := BoolSetting{v: &v}
+	f := func() {
+		b := getBool(key)
+		v := int32(0)
+		if b {
+			v = 1
+		}
+		atomic.StoreInt32(setting.v, v)
+	}
+
+	registry[key] = Value{Typ: BoolValue, Description: desc, B: defVal, asyncUpdate: f}
+	f()
+
+	return setting
+}
+
+// RegisterIntSetting defines a new setting with type int.
+func RegisterIntSetting(key, desc string, defVal int) IntSetting {
+	checkAdd(key)
+
+	v := int64(0)
+	setting := IntSetting{v: &v}
+	f := func() { atomic.StoreInt64(setting.v, int64(getInt(key))) }
+
+	registry[key] = Value{Typ: IntValue, Description: desc, I: defVal, asyncUpdate: f}
+	f()
+
+	return setting
+}
+
+// RegisterStringSetting defines a new setting with type string.
+func RegisterStringSetting(key, desc string, defVal string) StringSetting {
+	checkAdd(key)
+
+	registry[key] = Value{Typ: StringValue, Description: desc, S: defVal}
+
+	return StringSetting{Get: func() string { return getString(key) }}
+}
+
+// RegisterFloatSetting defines a new setting with type float.
+func RegisterFloatSetting(key, desc string, defVal float64) FloatSetting {
+	checkAdd(key)
+
+	v := uint64(0)
+	setting := FloatSetting{v: &v}
+	f := func() {
+		f := getFloat(key)
+		atomic.StoreUint64(setting.v, *(*uint64)(unsafe.Pointer(&f)))
+	}
+
+	registry[key] = Value{Typ: FloatValue, Description: desc, F: defVal, asyncUpdate: f}
+	f()
+
+	return setting
+}
+
+// RegisterDurationSetting defines a new setting with type time.Duration.
+func RegisterDurationSetting(key, desc string, defVal time.Duration) DurationSetting {
+	checkAdd(key)
+
+	v := int64(0)
+	setting := DurationSetting{v: &v}
+
+	f := func() { atomic.StoreInt64(setting.v, getDuration(key).Nanoseconds()) }
+	registry[key] = Value{Typ: DurationValue, Description: desc, D: defVal, asyncUpdate: f}
+	f()
+
+	return setting
+}

--- a/pkg/settings/cache.go
+++ b/pkg/settings/cache.go
@@ -205,11 +205,21 @@ func (u Updater) Apply() {
 	cache.values = u
 	cache.Unlock()
 
+	for _, def := range registry {
+		if def.asyncUpdate != nil {
+			def.asyncUpdate()
+		}
+	}
+
+	// Note: it is useful to run the hooks after the asynchronous
+	// updates above so that the hook can observe the latest values in
+	// the settings variables.
 	afterApply.Lock()
 	for _, f := range afterApply.hooks {
 		f()
 	}
 	afterApply.Unlock()
+
 }
 
 var afterApply struct {

--- a/pkg/settings/cache_test.go
+++ b/pkg/settings/cache_test.go
@@ -23,14 +23,14 @@ import (
 
 var i1, i2 int
 
-var boolTAccessor = RegisterBoolSetting("bool.t", "", true)
-var boolFAccessor = RegisterBoolSetting("bool.f", "", false)
-var strFooAccessor = RegisterStringSetting("str.foo", "", "")
-var strBarAccessor = RegisterStringSetting("str.bar", "", "bar")
-var i1Accessor = RegisterIntSetting("i.1", "", 0)
-var i2Accessor = RegisterIntSetting("i.2", "", 5)
-var fAccessor = RegisterFloatSetting("f", "", 5.4)
-var dAccessor = RegisterDurationSetting("d", "", time.Second)
+var boolTA = RegisterBoolSetting("bool.t", "", true)
+var boolFA = RegisterBoolSetting("bool.f", "", false)
+var strFooA = RegisterStringSetting("str.foo", "", "")
+var strBarA = RegisterStringSetting("str.bar", "", "bar")
+var i1A = RegisterIntSetting("i.1", "", 0)
+var i2A = RegisterIntSetting("i.2", "", 5)
+var fA = RegisterFloatSetting("f", "", 5.4)
+var dA = RegisterDurationSetting("d", "", time.Second)
 
 func init() {
 	RegisterCallback(func() {
@@ -41,22 +41,22 @@ func init() {
 
 func TestCache(t *testing.T) {
 	t.Run("defaults", func(t *testing.T) {
-		if expected, actual := false, boolFAccessor(); expected != actual {
+		if expected, actual := false, boolFA.Get(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := true, boolTAccessor(); expected != actual {
+		if expected, actual := true, boolTA.Get(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := "", strFooAccessor(); expected != actual {
+		if expected, actual := "", strFooA.Get(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := "bar", strBarAccessor(); expected != actual {
+		if expected, actual := "bar", strBarA.Get(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := 0, i1Accessor(); expected != actual {
+		if expected, actual := 0, i1A.Get(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := 5, i2Accessor(); expected != actual {
+		if expected, actual := 5, i2A.Get(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 		// registering callback should have also run it initially and set default.
@@ -66,10 +66,10 @@ func TestCache(t *testing.T) {
 		if expected, actual := 5, i2; expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := 5.4, fAccessor(); expected != actual {
+		if expected, actual := 5.4, fA.Get(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := time.Second, dAccessor(); expected != actual {
+		if expected, actual := time.Second, dA.Get(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 		if actual, ok := TypeOf("i.1"); !ok || IntValue != actual {
@@ -108,16 +108,16 @@ func TestCache(t *testing.T) {
 		}
 		u.Apply()
 
-		if expected, actual := false, boolTAccessor(); expected != actual {
+		if expected, actual := false, boolTA.Get(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := true, boolFAccessor(); expected != actual {
+		if expected, actual := true, boolFA.Get(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := "baz", strFooAccessor(); expected != actual {
+		if expected, actual := "baz", strFooA.Get(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := 3, i2Accessor(); expected != actual {
+		if expected, actual := 3, i2A.Get(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 		if expected, actual := 0, i1; expected != actual {
@@ -126,15 +126,15 @@ func TestCache(t *testing.T) {
 		if expected, actual := 3, i2; expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := 3.1, fAccessor(); expected != actual {
+		if expected, actual := 3.1, fA.Get(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := 2*time.Hour, dAccessor(); expected != actual {
+		if expected, actual := 2*time.Hour, dA.Get(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 
 		// We didn't change this one, so should still see the default.
-		if expected, actual := "bar", strBarAccessor(); expected != actual {
+		if expected, actual := "bar", strBarA.Get(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 	})
@@ -154,7 +154,7 @@ func TestCache(t *testing.T) {
 			u.Apply()
 		}
 
-		if expected, actual := true, boolFAccessor(); expected != actual {
+		if expected, actual := true, boolFA.Get(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 		if expected, actual := 1, i1; expected != actual {
@@ -167,7 +167,7 @@ func TestCache(t *testing.T) {
 		// applying it from the cache.
 		MakeUpdater().Apply()
 
-		if expected, actual := false, boolFAccessor(); expected != actual {
+		if expected, actual := false, boolFA.Get(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 		if expected, actual := 0, i1; expected != actual {
@@ -188,7 +188,7 @@ func TestCache(t *testing.T) {
 			u.Apply()
 		}
 
-		if expected, actual := false, boolFAccessor(); expected != actual {
+		if expected, actual := false, boolFA.Get(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 	})
@@ -201,7 +201,7 @@ func TestCache(t *testing.T) {
 			}
 			u.Apply()
 		}
-		before := i2Accessor()
+		before := i2A.Get()
 
 		// Applying after attempting to set with wrong type preserves current value.
 		{
@@ -215,7 +215,7 @@ func TestCache(t *testing.T) {
 			u.Apply()
 		}
 
-		if expected, actual := before, i2Accessor(); expected != actual {
+		if expected, actual := before, i2A.Get(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 
@@ -230,7 +230,7 @@ func TestCache(t *testing.T) {
 			u.Apply()
 		}
 
-		if expected, actual := before, i2Accessor(); expected != actual {
+		if expected, actual := before, i2A.Get(); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 	})

--- a/pkg/settings/doc.go
+++ b/pkg/settings/doc.go
@@ -34,7 +34,7 @@ var enterpriseEnabled = settings.RegisterBoolSetting(
    "enterprise.enabled", "some doc for the setting", false,
 )
 
-Then use with `if enterpriseEnabled() ...`
+Then use with `if enterpriseEnabled.Get() ...`
 
 Settings should always be defined with "safe" default values -- until a node
 receives values via gossip, or even after that, if it cannot read them for some

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -15,7 +15,6 @@
 package settings
 
 import (
-	"fmt"
 	"sync/atomic"
 	"time"
 )
@@ -52,70 +51,14 @@ type Value struct {
 	I int
 	F float64
 	D time.Duration
+
+	// This is called, if it is defined, whenever the settings are
+	// updated asynchronously.
+	asyncUpdate func()
 }
 
 // TypeOf returns the type of a setting, if it is defined.
 func TypeOf(key string) (ValueType, bool) {
 	d, ok := registry[key]
 	return d.Typ, ok
-}
-
-// RegisterBoolSetting defines a new setting with type bool.
-func RegisterBoolSetting(key, desc string, defVal bool) func() bool {
-	if atomic.LoadInt32(&frozen) > 0 {
-		panic(fmt.Sprintf("registration must occur before server start: %s", key))
-	}
-	if _, ok := registry[key]; ok {
-		panic(fmt.Sprintf("setting already defined: %s", key))
-	}
-	registry[key] = Value{Typ: BoolValue, Description: desc, B: defVal}
-	return func() bool { return getBool(key) }
-}
-
-// RegisterIntSetting defines a new setting with type int.
-func RegisterIntSetting(key, desc string, defVal int) func() int {
-	if atomic.LoadInt32(&frozen) > 0 {
-		panic(fmt.Sprintf("registration must occur before server start: %s", key))
-	}
-	if _, ok := registry[key]; ok {
-		panic(fmt.Sprintf("setting already defined: %s", key))
-	}
-	registry[key] = Value{Typ: IntValue, Description: desc, I: defVal}
-	return func() int { return getInt(key) }
-}
-
-// RegisterStringSetting defines a new setting with type string.
-func RegisterStringSetting(key, desc string, defVal string) func() string {
-	if atomic.LoadInt32(&frozen) > 0 {
-		panic(fmt.Sprintf("registration must occur before server start: %s", key))
-	}
-	if _, ok := registry[key]; ok {
-		panic(fmt.Sprintf("setting already defined: %s", key))
-	}
-	registry[key] = Value{Typ: StringValue, Description: desc, S: defVal}
-	return func() string { return getString(key) }
-}
-
-// RegisterFloatSetting defines a new setting with type float.
-func RegisterFloatSetting(key, desc string, defVal float64) func() float64 {
-	if atomic.LoadInt32(&frozen) > 0 {
-		panic(fmt.Sprintf("registration must occur before server start: %s", key))
-	}
-	if _, ok := registry[key]; ok {
-		panic(fmt.Sprintf("setting already defined: %s", key))
-	}
-	registry[key] = Value{Typ: FloatValue, Description: desc, F: defVal}
-	return func() float64 { return getFloat(key) }
-}
-
-// RegisterDurationSetting defines a new setting with type time.Duration.
-func RegisterDurationSetting(key, desc string, defVal time.Duration) func() time.Duration {
-	if atomic.LoadInt32(&frozen) > 0 {
-		panic(fmt.Sprintf("registration must occur before server start: %s", key))
-	}
-	if _, ok := registry[key]; ok {
-		panic(fmt.Sprintf("setting already defined: %s", key))
-	}
-	registry[key] = Value{Typ: DurationValue, Description: desc, D: defVal}
-	return func() time.Duration { return getDuration(key) }
 }

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -566,7 +566,7 @@ func (e *Executor) execRequest(
 	var err error
 	txnState := &session.TxnState
 
-	if log.V(2) {
+	if log.V(2) || logStatementsExecuteEnabled.Get() {
 		log.Infof(session.Ctx(), "execRequest: %s", sql)
 	}
 
@@ -582,7 +582,7 @@ func (e *Executor) execRequest(
 	session.phaseTimes[sessionEndParse] = timeutil.Now()
 
 	if err != nil {
-		if log.V(2) {
+		if log.V(2) || logStatementsExecuteEnabled.Get() {
 			log.Infof(session.Ctx(), "execRequest: error: %v", err)
 		}
 		// A parse error occurred: we can't determine if there were multiple
@@ -719,7 +719,7 @@ func (e *Executor) execRequest(
 			lastRes.Err = convertToErrWithPGCode(err)
 		}
 
-		if err != nil && log.V(2) {
+		if err != nil && (log.V(2) || logStatementsExecuteEnabled.Get()) {
 			log.Infof(session.Ctx(), "execRequest: error: %v", err)
 		}
 
@@ -918,7 +918,8 @@ func (e *Executor) execStmtsInCurrentTxn(
 	}
 
 	for i, stmt := range stmts {
-		if log.V(2) || log.HasSpanOrEvent(session.Ctx()) {
+		if log.V(2) || logStatementsExecuteEnabled.Get() ||
+			log.HasSpanOrEvent(session.Ctx()) {
 			log.VEventf(session.Ctx(), 2, "executing %d/%d: %s", i+1, len(stmts), stmt)
 		}
 


### PR DESCRIPTION
Prior to this patch CockroachDB supported enabling SQL tracing
via environment variables; this patch replaces this mechanism
by cluster settings.

| Env var (old)                  | Setting (new)                        |
|--------------------------------|--------------------------------------|
| COCKROACH_TRACE_SQL            | `sql.trace.txn.threshold`            |
| COCKROACH_ENABLE_SQL_EVENT_LOG | `sql.trace.session.eventlog.enabled` |


In addition, this patch also introduces a new setting
`sql.log.statements.execute.enabled` which, when set to true, causes
executed statements to be copied to the logging output. This mechanism
is more lightweight than the tracing options above since it does not
need to accumulate state in the session.

Note that `--vmodule=executor=2` still forces statement logging,
regardless of the setting's current value.

Fixes #13851.