### PR TITLE
sql: have backfills update descriptor caches

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -412,17 +412,16 @@ func (sc *SchemaChanger) distBackfill(
 					otherTableDescs = append(otherTableDescs, *table)
 				}
 			}
-			// TODO(andrei): pass the right caches. I think this will crash without
-			// them.
 			recv, err := makeDistSQLReceiver(
-				ctx,
-				nil, /* sink */
-				nil, /* rangeCache */
-				nil, /* leaseCache */
+				ctx, 
+				nil /* sink */, 
+				sc.rangeCache, 
+				sc.leaseCache,
 				nil, /* txn - the flow does not run wholly in a txn */
 				// updateClock - the flow will not generate errors with time signal.
 				// TODO(andrei): plumb a clock update handler here regardless of whether
 				// it will actually be used or not.
+				// !!! address this in this PR
 				nil,
 			)
 			if err != nil {

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -78,7 +78,7 @@ type planner struct {
 // growth in the log.
 var noteworthyInternalMemoryUsageBytes = envutil.EnvOrDefaultInt64("COCKROACH_NOTEWORTHY_INTERNAL_MEMORY_USAGE", 100*1024)
 
-// makePlanner creates a new planner instance, referencing a dummy session.
+// makeInternalPlanner creates a new planner instance, referencing a dummy session.
 func makeInternalPlanner(
 	opName string, txn *client.Txn, user string, memMetrics *MemoryMetrics,
 ) *planner {

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -798,7 +798,9 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 		sc := &scEntry.sc
 		sc.testingKnobs = e.cfg.SchemaChangerTestingKnobs
 		for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
-			if err := sc.exec(ctx, *e.cfg.DB, e.distSQLPlanner); err != nil {
+			if err := sc.exec(ctx, *e.cfg.DB, e.distSQLPlanner,
+				e.cfg.DistSender.RangeDescriptorCache(), e.cfg.DistSender.LeaseHolderCache(),
+			); err != nil {
 				if err != errExistingSchemaChangeLease {
 					log.Warningf(ctx, "Error executing schema change: %s", err)
 				}

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -796,11 +796,9 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 	// statements that scheduled them.
 	for _, scEntry := range scc.schemaChangers {
 		sc := &scEntry.sc
-		sc.db = *e.cfg.DB
 		sc.testingKnobs = e.cfg.SchemaChangerTestingKnobs
-		sc.distSQLPlanner = e.distSQLPlanner
 		for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
-			if err := sc.exec(ctx); err != nil {
+			if err := sc.exec(ctx, *e.cfg.DB, e.distSQLPlanner); err != nil {
 				if err != errExistingSchemaChangeLease {
 					log.Warningf(ctx, "Error executing schema change: %s", err)
 				}

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -432,13 +432,8 @@ func (p *planner) getAliasedTableName(n parser.TableExpr) (*parser.TableName, er
 }
 
 // notifySchemaChange implements the SchemaAccessor interface.
-func (p *planner) notifySchemaChange(id sqlbase.ID, mutationID sqlbase.MutationID) {
-	sc := SchemaChanger{
-		tableID:    id,
-		mutationID: mutationID,
-		nodeID:     p.evalCtx.NodeID,
-		leaseMgr:   p.LeaseMgr(),
-	}
+func (p *planner) notifySchemaChange(tableID sqlbase.ID, mutationID sqlbase.MutationID) {
+	sc := MakeSchemaChanger(tableID, mutationID, p.evalCtx.NodeID, p.LeaseMgr())
 	p.session.TxnState.schemaChangers.queueSchemaChanger(sc)
 }
 


### PR DESCRIPTION
The caches weren't correctly plumbed before; a range info metadata would
have probably crashed the server.