### PR TITLE
cli: split client/server --insecure flag.

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -235,11 +235,18 @@ Note: when given a path to a unix socket, most postgres clients will
 open "<given path>/.s.PGSQL.<server port>"`,
 	}
 
-	Insecure = FlagInfo{
+	ClientInsecure = FlagInfo{
 		Name:   "insecure",
 		EnvVar: "COCKROACH_INSECURE",
 		Description: `
-Run over non-encrypted (non-TLS) connections. This is strongly discouraged for
+Connect to an insecure cluster. This is strongly discouraged for
+production usage.`,
+	}
+
+	ServerInsecure = FlagInfo{
+		Name: "insecure",
+		Description: `
+Start an insecure node, using unencrypted (non-TLS) connections. This is strongly discouraged for
 production usage.`,
 	}
 

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -50,6 +50,7 @@ var zoneDisableReplication bool
 
 var serverCfg = server.MakeConfig()
 var baseCfg = serverCfg.Config
+var serverInsecure bool
 var cliCtx = cliContext{Config: baseCfg}
 var sqlCtx = sqlContext{cliContext: &cliCtx}
 var dumpCtx = dumpContext{cliContext: &cliCtx, dumpMode: dumpBoth}
@@ -245,7 +246,9 @@ func init() {
 
 		stringFlag(f, &serverCfg.PIDFile, cliflags.PIDFile, "")
 
-		boolFlag(f, &serverCfg.Insecure, cliflags.Insecure, serverCfg.Insecure)
+		// Use a separate variable to store the value of ServerInsecure.
+		// We share the default with the ClientInsecure flag.
+		boolFlag(f, &serverInsecure, cliflags.ServerInsecure, baseCfg.Insecure)
 
 		// Certificate flags.
 		stringFlag(f, &baseCfg.SSLCertsDir, cliflags.CertsDir, base.DefaultCertsDirectory)
@@ -314,7 +317,7 @@ func init() {
 		stringFlag(f, &clientConnHost, cliflags.ClientHost, "")
 		stringFlag(f, &clientConnPort, cliflags.ClientPort, base.DefaultPort)
 
-		boolFlag(f, &baseCfg.Insecure, cliflags.Insecure, serverCfg.Insecure)
+		boolFlag(f, &baseCfg.Insecure, cliflags.ClientInsecure, baseCfg.Insecure)
 
 		// Certificate flags.
 		stringFlag(f, &baseCfg.SSLCertsDir, cliflags.CertsDir, base.DefaultCertsDirectory)

--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -6,6 +6,7 @@ set env(TERM) vt100
 # developer's own history file.
 set histfile ".cockroachdb_history_test"
 set ::env(COCKROACH_SQL_CLI_HISTORY) $histfile
+# Set client commands as insecure. The server uses --insecure.
 set ::env(COCKROACH_INSECURE) "true"
 system "rm -f $histfile"
 
@@ -40,7 +41,7 @@ proc interrupt {} {
 # Preserves the invariant that the server's PID is saved
 # in `server_pid`.
 proc start_server {argv} {
-    system "mkfifo pid_fifo || true; $argv start --pid-file=pid_fifo --background >>stdout.log 2>>stderr.log & cat pid_fifo > server_pid"
+    system "mkfifo pid_fifo || true; $argv start --insecure --pid-file=pid_fifo --background >>stdout.log 2>>stderr.log & cat pid_fifo > server_pid"
 }
 proc stop_server {argv} {
     system "set -e; if kill -CONT `cat server_pid`; then $argv quit || true & sleep 1; kill -9 `cat server_pid` || true; else $argv quit || true; fi"

--- a/pkg/cli/interactive_tests/test_high_verbosity.tcl
+++ b/pkg/cli/interactive_tests/test_high_verbosity.tcl
@@ -2,7 +2,7 @@
 
 source [file join [file dirname $argv0] common.tcl]
 
-system "mkfifo pid_fifo || true; $argv start --verbosity 3 --pid-file=pid_fifo & cat pid_fifo > server_pid"
+system "mkfifo pid_fifo || true; $argv start --insecure --verbosity 3 --pid-file=pid_fifo & cat pid_fifo > server_pid"
 
 spawn /bin/bash
 send "PS1=':''/# '\r"

--- a/pkg/cli/interactive_tests/test_log_flags.tcl
+++ b/pkg/cli/interactive_tests/test_log_flags.tcl
@@ -13,7 +13,7 @@ eexpect ":/# "
 # to exit entirely (it has errorHandling set to ExitOnError).
 
 # Check that log files are created by default in the store directory.
-send "$argv start --store=path=mystore\r"
+send "$argv start --insecure --store=path=mystore\r"
 eexpect "node starting"
 send "\003"
 eexpect ":/# "
@@ -22,7 +22,7 @@ eexpect "cockroach.log"
 eexpect ":/# "
 
 # Check that an empty `-log-dir` disables file logging.
-send "$argv start --store=path=mystore2 --log-dir=\r"
+send "$argv start --insecure --store=path=mystore2 --log-dir=\r"
 eexpect "node starting"
 send "\003"
 eexpect ":/# "
@@ -31,30 +31,30 @@ eexpect "0"
 eexpect ":/# "
 
 # Check that leading tildes are properly rejected.
-send "$argv start --log-dir=\~/blah\r"
+send "$argv start --insecure --log-dir=\~/blah\r"
 eexpect "log directory cannot start with '~'"
 eexpect ":/# "
 
 # Check that the user can override.
-send "$argv start --log-dir=blah/\~/blah\r"
+send "$argv start --insecure --log-dir=blah/\~/blah\r"
 eexpect "logs: *blah/~/blah"
 send "\003"
 eexpect ":/# "
 
 # Check that TRUE and FALSE are valid values for the severity flags.
-send "$argv start --logtostderr=false\r"
+send "$argv start --insecure --logtostderr=false\r"
 eexpect "node starting"
 send "\003"
 eexpect ":/# "
-send "$argv start --logtostderr=true\r"
+send "$argv start --insecure --logtostderr=true\r"
 eexpect "node starting"
 send "\003"
 eexpect ":/# "
-send "$argv start --logtostderr=2\r"
+send "$argv start --insecure --logtostderr=2\r"
 eexpect "node starting"
 send "\003"
 eexpect ":/# "
-send "$argv start --logtostderr=cantparse\r"
+send "$argv start --insecure --logtostderr=cantparse\r"
 eexpect "parsing \"cantparse\": invalid syntax"
 eexpect ":/# "
 

--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -8,7 +8,7 @@ eexpect ":/# "
 
 # Check that a server started with only in-memory stores automatically
 # logs to stderr.
-send "$argv start --store=type=mem,size=1GiB\r"
+send "$argv start --insecure --store=type=mem,size=1GiB\r"
 eexpect "CockroachDB"
 eexpect "starting cockroach node"
 
@@ -25,7 +25,7 @@ stop_server $argv
 
 # Check that a server started with --logtostderr
 # logs even info messages to stderr.
-send "$argv start --logtostderr\r"
+send "$argv start --insecure --logtostderr\r"
 eexpect "CockroachDB"
 eexpect "starting cockroach node"
 
@@ -34,7 +34,7 @@ interrupt
 eexpect ":/# "
 
 # Check that --logtostderr can override the threshold but no error is printed on startup
-send "echo marker; $argv start --logtostderr=ERROR 2>&1 | grep -v '^\\*'\r"
+send "echo marker; $argv start --insecure --logtostderr=ERROR 2>&1 | grep -v '^\\*'\r"
 eexpect "marker\r\nCockroachDB node starting"
 
 # Stop it.

--- a/pkg/cli/interactive_tests/test_server_sig.tcl
+++ b/pkg/cli/interactive_tests/test_server_sig.tcl
@@ -7,7 +7,7 @@ send "PS1='\\h:''/# '\r"
 eexpect ":/# "
 
 # Check that the server shuts down upon receiving SIGTERM.
-send "$argv start --pid-file=server_pid\r"
+send "$argv start --insecure --pid-file=server_pid\r"
 eexpect "initialized"
 
 system "kill `cat server_pid`"
@@ -21,7 +21,7 @@ eexpect "0\r\n"
 eexpect ":/# "
 
 # Check that the server shuts down upon receiving Ctrl+C.
-send "$argv start --pid-file=server_pid\r"
+send "$argv start --insecure --pid-file=server_pid\r"
 eexpect "restarted"
 
 interrupt
@@ -35,7 +35,7 @@ eexpect "1\r\n"
 eexpect ":/# "
 
 # Check that the server shuts down fast upon receiving Ctrl+C twice.
-send "$argv start --pid-file=server_pid\r"
+send "$argv start --insecure --pid-file=server_pid\r"
 eexpect "restarted"
 interrupt
 eexpect "initiating graceful shutdown"

--- a/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
+++ b/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
@@ -44,7 +44,7 @@ send "ulimit -v [ expr {2*$vmem+400} ]\r"
 eexpect ":/# "
 
 # Start a server with this limit set. The server will now run in the foreground.
-send "$argv start --no-redirect-stderr\r"
+send "$argv start --insecure --no-redirect-stderr\r"
 eexpect "restarted pre-existing node"
 sleep 1
 
@@ -84,7 +84,7 @@ eexpect root@
 
 # Re-launch a server with relatively lower limit for SQL memory
 set spawn_id $shell_spawn_id
-send "$argv start --max-sql-memory=150K --no-redirect-stderr\r"
+send "$argv start --insecure --max-sql-memory=150K --no-redirect-stderr\r"
 eexpect "restarted pre-existing node"
 sleep 2
 

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -292,6 +292,11 @@ func runStart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Use the server-specific Insecure flag.
+	serverCfg.Insecure = serverInsecure
+	// Default user for servers.
+	serverCfg.User = security.NodeUser
+
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 
@@ -310,9 +315,6 @@ func runStart(cmd *cobra.Command, args []string) error {
 		}
 		serverCfg.Stores.Specs[i].Path = absPath
 	}
-
-	// Default user for servers.
-	serverCfg.User = security.NodeUser
 
 	// Set up the logging and profiling output.
 	// It is important that no logging occurs before this point or the log files

--- a/pkg/cli/start_test.go
+++ b/pkg/cli/start_test.go
@@ -34,41 +34,39 @@ func TestInitInsecure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	f := startCmd.Flags()
-	ctx := serverCfg
 
 	testCases := []struct {
 		args     []string
 		insecure bool
 		expected string
 	}{
-		{[]string{}, true, ""},
+		{[]string{}, false, ""},
 		{[]string{"--insecure"}, true, ""},
 		{[]string{"--insecure=true"}, true, ""},
 		{[]string{"--insecure=false"}, false, ""},
-		{[]string{"--host", "localhost"}, true, ""},
-		{[]string{"--host", "127.0.0.1"}, true, ""},
-		{[]string{"--host", "::1"}, true, ""},
-		{[]string{"--host", "192.168.1.1"}, true,
+		{[]string{"--host", "localhost"}, false, ""},
+		{[]string{"--host", "127.0.0.1"}, false, ""},
+		{[]string{"--host", "::1"}, false, ""},
+		{[]string{"--host", "192.168.1.1"}, false,
 			`specify --insecure to listen on external address 192\.168\.1\.1`},
 		{[]string{"--insecure", "--host", "192.168.1.1"}, true, ""},
-		{[]string{"--host", "localhost", "--advertise-host", "192.168.1.1"}, true, ""},
-		{[]string{"--host", "127.0.0.1", "--advertise-host", "192.168.1.1"}, true, ""},
-		{[]string{"--host", "::1", "--advertise-host", "192.168.1.1"}, true, ""},
+		{[]string{"--host", "localhost", "--advertise-host", "192.168.1.1"}, false, ""},
+		{[]string{"--host", "127.0.0.1", "--advertise-host", "192.168.1.1"}, false, ""},
+		{[]string{"--host", "::1", "--advertise-host", "192.168.1.1"}, false, ""},
 		{[]string{"--insecure", "--host", "192.168.1.1", "--advertise-host", "192.168.1.1"}, true, ""},
 		{[]string{"--insecure", "--host", "192.168.1.1", "--advertise-host", "192.168.2.2"}, true, ""},
 		// Clear out the flags when done to avoid affecting other tests that rely on the flag state.
-		{[]string{"--host", "", "--advertise-host", ""}, true, ""},
+		{[]string{"--host", "", "--advertise-host", ""}, false, ""},
 	}
 	for i, c := range testCases {
-		// Reset the context and insecure flag for every test case.
-		ctx.InitDefaults()
-		ctx.Insecure = true
+		// Reset the context and for every test case.
+		serverInsecure = false
 
 		if err := f.Parse(c.args); err != nil {
 			t.Fatal(err)
 		}
-		if c.insecure != ctx.Insecure {
-			t.Fatalf("%d: expected %v, but found %v", i, c.insecure, ctx.Insecure)
+		if c.insecure != serverInsecure {
+			t.Fatalf("%d: expected %v, but found %v", i, c.insecure, serverInsecure)
 		}
 	}
 }


### PR DESCRIPTION
part of #9189

Separate insecure flag for client and server. `start` uses a separate
variable and always overrides `basedCfg.Insecure`. This is to get around
the environment variable automatically set through the client insecure
flag.