### PR TITLE
storage: wait on lease renewal when in stasis, kv: retry not leaseholder errors

### DIFF
--- a/pkg/base/constants.go
+++ b/pkg/base/constants.go
@@ -32,6 +32,10 @@ const (
 	// it may be aborted by conflicting txns.
 	DefaultHeartbeatInterval = 1 * time.Second
 
+	// DefaultSendNextTimeout is the duration to wait before trying
+	// another replica to send a KV batch.
+	DefaultSendNextTimeout = 500 * time.Millisecond
+
 	// SlowRequestThreshold is the amount of time to wait before considering a
 	// request to be "slow".
 	SlowRequestThreshold = 60 * time.Second

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -66,6 +66,7 @@ type TestServerArgs struct {
 	SSLCertsDir              string
 	TimeSeriesQueryWorkerMax int
 	SQLMemoryPoolSize        int64
+	SendNextTimeout          time.Duration
 
 	// If set, this will be appended to the Postgres URL by functions that
 	// automatically open a connection to the server. That's equivalent to running

--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -44,9 +44,6 @@ import (
 
 // Default constants for timeouts.
 const (
-	// TODO(bdarnell): make SendNextTimeout configurable.
-	// https://github.com/cockroachdb/cockroach/issues/6719
-	defaultSendNextTimeout   = 500 * time.Millisecond
 	defaultClientTimeout     = 10 * time.Second
 	defaultPendingRPCTimeout = 500 * time.Millisecond
 
@@ -239,7 +236,7 @@ func NewDistSender(cfg DistSenderConfig, g *gossip.Gossip) *DistSender {
 	if cfg.SendNextTimeout != 0 {
 		ds.sendNextTimeout = cfg.SendNextTimeout
 	} else {
-		ds.sendNextTimeout = defaultSendNextTimeout
+		ds.sendNextTimeout = base.DefaultSendNextTimeout
 	}
 	if cfg.SenderConcurrency != 0 {
 		ds.asyncSenderSem = make(chan struct{}, cfg.SenderConcurrency)
@@ -1166,10 +1163,10 @@ func (ds *DistSender) sendToReplicas(
 	defer slowTimer.Stop()
 	slowTimer.Reset(base.SlowRequestThreshold)
 	for {
-		if !transport.IsExhausted() {
+		if timeout, ok := transport.SendNextTimeout(opts.SendNextTimeout); ok {
 			// Only start the send-next timer if we haven't exhausted the transport
 			// (i.e. there is another replica to send to).
-			sendNextTimer.Reset(opts.SendNextTimeout)
+			sendNextTimer.Reset(timeout)
 		}
 
 		select {

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -113,6 +113,15 @@ func (l *legacyTransportAdapter) IsExhausted() bool {
 	return l.called
 }
 
+func (l *legacyTransportAdapter) SendNextTimeout(
+	defaultTimeout time.Duration,
+) (time.Duration, bool) {
+	if l.IsExhausted() {
+		return 0, false
+	}
+	return defaultTimeout, true
+}
+
 func (l *legacyTransportAdapter) SendNext(ctx context.Context, done chan<- BatchCall) {
 	l.called = true
 	br, err := l.fn(ctx, l.opts, l.replicas, l.args, l.rpcContext)
@@ -1902,6 +1911,15 @@ type slowLeaseHolderTransport struct {
 
 func (t *slowLeaseHolderTransport) IsExhausted() bool {
 	return t.sendCount > t.replicaCount
+}
+
+func (t *slowLeaseHolderTransport) SendNextTimeout(
+	defaultTimeout time.Duration,
+) (time.Duration, bool) {
+	if t.IsExhausted() {
+		return 0, false
+	}
+	return defaultTimeout, true
 }
 
 func (t *slowLeaseHolderTransport) SendNext(_ context.Context, done chan<- BatchCall) {

--- a/pkg/kv/send_test.go
+++ b/pkg/kv/send_test.go
@@ -111,6 +111,13 @@ func (c *channelSaveTransport) IsExhausted() bool {
 	return c.remaining <= 0
 }
 
+func (c *channelSaveTransport) SendNextTimeout(defaultTimeout time.Duration) (time.Duration, bool) {
+	if c.IsExhausted() {
+		return 0, false
+	}
+	return defaultTimeout, true
+}
+
 func (c *channelSaveTransport) SendNext(_ context.Context, done chan<- BatchCall) {
 	c.remaining--
 	c.ch <- done
@@ -364,6 +371,13 @@ type firstNErrorTransport struct {
 
 func (f *firstNErrorTransport) IsExhausted() bool {
 	return f.numSent >= len(f.replicas)
+}
+
+func (f *firstNErrorTransport) SendNextTimeout(defaultTimeout time.Duration) (time.Duration, bool) {
+	if f.IsExhausted() {
+		return 0, false
+	}
+	return defaultTimeout, true
 }
 
 func (f *firstNErrorTransport) SendNext(_ context.Context, done chan<- BatchCall) {

--- a/pkg/kv/transport.go
+++ b/pkg/kv/transport.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/opentracing/opentracing-go"
 )
@@ -53,8 +54,9 @@ type batchClient struct {
 	client     roachpb.InternalClient
 	args       roachpb.BatchRequest
 	healthy    bool
-	retried    bool
 	pending    bool
+	retryable  bool
+	deadline   time.Time
 }
 
 // BatchCall contains a response and an RPC error (note that the
@@ -86,6 +88,12 @@ type TransportFactory func(
 type Transport interface {
 	// IsExhausted returns true if there are no more replicas to try.
 	IsExhausted() bool
+
+	// SendNextTimeout returns the timeout after which the next untried,
+	// or retryable, replica may be attempted. Returns a duration
+	// indicating when another replica should be tried, and a bool
+	// indicating whether one should be (if false, duration will be 0).
+	SendNextTimeout(time.Duration) (time.Duration, bool)
 
 	// SendNext sends the rpc (captured at creation time) to the next
 	// replica. May panic if the transport is exhausted. Should not
@@ -148,8 +156,60 @@ type grpcTransport struct {
 	clientPendingMu syncutil.Mutex // protects access to all batchClient pending flags
 }
 
+// IsExhausted returns false if there are any untried replicas
+// remaining. If there are none, it attempts to resurrect replicas
+// which were tried but failed with a retryable error and have a
+// deadline set which has elapsed. If any where resurrected, returns
+// false; true otherwise.
 func (gt *grpcTransport) IsExhausted() bool {
-	return gt.clientIndex == len(gt.orderedClients)
+	gt.clientPendingMu.Lock()
+	defer gt.clientPendingMu.Unlock()
+	if gt.clientIndex < len(gt.orderedClients) {
+		return false
+	}
+	return !gt.maybeResurrectRetryables()
+}
+
+// maybeResurrectRetryables moves already-tried replicas which
+// experienced a retryable error (currently this means a
+// NotLeaseHolderError) into a newly-active state so that they can be
+// retried. Returns true if any replicas were moved to active.
+func (gt *grpcTransport) maybeResurrectRetryables() bool {
+	var resurrect []batchClient
+	for i := 0; i < gt.clientIndex; i++ {
+		if c := gt.orderedClients[i]; !c.pending && c.retryable && timeutil.Since(c.deadline) >= 0 {
+			resurrect = append(resurrect, c)
+		}
+	}
+	for _, c := range resurrect {
+		gt.moveToFrontLocked(c.args.Replica)
+	}
+	return len(resurrect) > 0
+}
+
+// SendNextTimeout returns the default SendOpts.SendNextTimeout if
+// there are any untried replicas in the transport. Otherwise, it
+// returns the earliest deadline of any replicas which experienced
+// retryable errors.
+func (gt *grpcTransport) SendNextTimeout(defaultTimeout time.Duration) (time.Duration, bool) {
+	gt.clientPendingMu.Lock()
+	defer gt.clientPendingMu.Unlock()
+	if gt.clientIndex < len(gt.orderedClients) {
+		return defaultTimeout, true
+	}
+	var deadline time.Time
+	for i := 0; i < gt.clientIndex; i++ {
+		if c := gt.orderedClients[i]; !c.pending && c.retryable {
+			if (deadline == time.Time{}) || c.deadline.Before(deadline) {
+				deadline = c.deadline
+			}
+		}
+	}
+	if (deadline == time.Time{}) {
+		return 0, false
+	}
+	// Returning a negative duration is legal.
+	return deadline.Sub(timeutil.Now()), true
 }
 
 // SendNext invokes the specified RPC on the supplied client when the
@@ -158,7 +218,7 @@ func (gt *grpcTransport) IsExhausted() bool {
 func (gt *grpcTransport) SendNext(ctx context.Context, done chan<- BatchCall) {
 	client := gt.orderedClients[gt.clientIndex]
 	gt.clientIndex++
-	gt.setPending(client.args.Replica, true)
+	gt.setState(client.args.Replica, true /* pending */, false /* retryable */)
 
 	// Fork the original context as this async send may outlast the
 	// caller's context.
@@ -203,7 +263,16 @@ func (gt *grpcTransport) SendNext(ctx context.Context, done chan<- BatchCall) {
 			}
 			return reply, err
 		}()
-		gt.setPending(client.args.Replica, false)
+		// NotLeaseHolderErrors can be retried.
+		var retryable bool
+		if reply != nil && reply.Error != nil {
+			// TODO(spencer): pass the lease expiration when setting the state to
+			// set a more efficient deadline for retrying this replica.
+			if _, ok := reply.Error.GetDetail().(*roachpb.NotLeaseHolderError); ok {
+				retryable = true
+			}
+		}
+		gt.setState(client.args.Replica, false /* pending */, retryable)
 		tracing.FinishSpan(sp)
 		done <- BatchCall{Reply: reply, Err: err}
 	}()
@@ -212,16 +281,22 @@ func (gt *grpcTransport) SendNext(ctx context.Context, done chan<- BatchCall) {
 func (gt *grpcTransport) MoveToFront(replica roachpb.ReplicaDescriptor) {
 	gt.clientPendingMu.Lock()
 	defer gt.clientPendingMu.Unlock()
+	gt.moveToFrontLocked(replica)
+}
+
+func (gt *grpcTransport) moveToFrontLocked(replica roachpb.ReplicaDescriptor) {
 	for i := range gt.orderedClients {
 		if gt.orderedClients[i].args.Replica == replica {
-			// If a call to this replica is active or retried, don't move it.
-			if gt.orderedClients[i].pending || gt.orderedClients[i].retried {
+			// If a call to this replica is active, don't move it.
+			if gt.orderedClients[i].pending {
 				return
 			}
+			// Clear the retryable bit and deadline, as this replica is being made available.
+			gt.orderedClients[i].retryable = false
+			gt.orderedClients[i].deadline = time.Time{}
 			// If we've already processed the replica, decrement the current
 			// index before we swap.
 			if i < gt.clientIndex {
-				gt.orderedClients[i].retried = true
 				gt.clientIndex--
 			}
 			// Swap the client representing this replica to the front.
@@ -242,12 +317,16 @@ func (*grpcTransport) Close() {
 // mutate, but the clients reside in a slice which is shuffled via
 // MoveToFront, making it unsafe to mutate the client through a reference to
 // the slice.
-func (gt *grpcTransport) setPending(replica roachpb.ReplicaDescriptor, pending bool) {
+func (gt *grpcTransport) setState(replica roachpb.ReplicaDescriptor, pending, retryable bool) {
 	gt.clientPendingMu.Lock()
 	defer gt.clientPendingMu.Unlock()
 	for i := range gt.orderedClients {
 		if gt.orderedClients[i].args.Replica == replica {
 			gt.orderedClients[i].pending = pending
+			gt.orderedClients[i].retryable = retryable
+			if retryable {
+				gt.orderedClients[i].deadline = timeutil.Now().Add(gt.opts.SendNextTimeout)
+			}
 			return
 		}
 	}
@@ -297,6 +376,13 @@ type senderTransport struct {
 
 func (s *senderTransport) IsExhausted() bool {
 	return s.called
+}
+
+func (s *senderTransport) SendNextTimeout(defaultTimeout time.Duration) (time.Duration, bool) {
+	if s.IsExhausted() {
+		return 0, false
+	}
+	return defaultTimeout, true
 }
 
 func (s *senderTransport) SendNext(ctx context.Context, done chan<- BatchCall) {

--- a/pkg/kv/transport_test.go
+++ b/pkg/kv/transport_test.go
@@ -69,39 +69,39 @@ func TestTransportMoveToFront(t *testing.T) {
 		t.Fatalf("expected cient index 0; got %d", gt.clientIndex)
 	}
 
-	// Advance the client index again and verify replica 3 cannot
+	// Advance the client index again and verify replica 3 cann
 	// be moved to front for a second retry.
 	gt.clientIndex++
 	gt.MoveToFront(rd3)
 	verifyOrder([]roachpb.ReplicaDescriptor{rd3, rd1, rd2})
-	if gt.clientIndex != 1 {
-		t.Fatalf("expected cient index 1; got %d", gt.clientIndex)
+	if gt.clientIndex != 0 {
+		t.Fatalf("expected cient index 0; got %d", gt.clientIndex)
 	}
 
 	// Mark replica 2 no longer pending. Should be able to move it.
 	clients[2].pending = false
 	gt.MoveToFront(rd2)
-	verifyOrder([]roachpb.ReplicaDescriptor{rd3, rd2, rd1})
+	verifyOrder([]roachpb.ReplicaDescriptor{rd2, rd1, rd3})
 
 	// Advance client index and move rd1 front; should be no change.
 	gt.clientIndex++
 	gt.MoveToFront(rd1)
-	verifyOrder([]roachpb.ReplicaDescriptor{rd3, rd2, rd1})
+	verifyOrder([]roachpb.ReplicaDescriptor{rd2, rd1, rd3})
 
-	// Advance client index to and and move rd1 to front. Should move
+	// Advance client index and and move rd1 to front. Should move
 	// client index back for a retry.
 	gt.clientIndex++
 	gt.MoveToFront(rd1)
-	verifyOrder([]roachpb.ReplicaDescriptor{rd3, rd2, rd1})
-	if gt.clientIndex != 2 {
-		t.Fatalf("expected cient index 2; got %d", gt.clientIndex)
+	verifyOrder([]roachpb.ReplicaDescriptor{rd2, rd1, rd3})
+	if gt.clientIndex != 1 {
+		t.Fatalf("expected cient index 1; got %d", gt.clientIndex)
 	}
 
-	// Advance client index once more; verify no second retry.
+	// Advance client index once more; verify second retry.
 	gt.clientIndex++
-	gt.MoveToFront(rd1)
-	verifyOrder([]roachpb.ReplicaDescriptor{rd3, rd2, rd1})
-	if gt.clientIndex != 3 {
-		t.Fatalf("expected cient index 3; got %d", gt.clientIndex)
+	gt.MoveToFront(rd2)
+	verifyOrder([]roachpb.ReplicaDescriptor{rd1, rd2, rd3})
+	if gt.clientIndex != 1 {
+		t.Fatalf("expected cient index 1; got %d", gt.clientIndex)
 	}
 }

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -163,6 +163,11 @@ type Config struct {
 	// Environment Variable: COCKROACH_TIME_UNTIL_STORE_DEAD
 	TimeUntilStoreDead time.Duration
 
+	// SendNextTimeout is the time after which an alternate replica will
+	// be used to attempt sending a KV batch.
+	// Environment Variable: COCKROACH_SEND_NEXT_TIMEOUT
+	SendNextTimeout time.Duration
+
 	// TestingKnobs is used for internal test controls only.
 	TestingKnobs base.TestingKnobs
 
@@ -303,6 +308,7 @@ func MakeConfig() Config {
 		ConsistencyCheckInterval: defaultConsistencyCheckInterval,
 		MetricsSampleInterval:    defaultMetricsSampleInterval,
 		TimeUntilStoreDead:       defaultTimeUntilStoreDead,
+		SendNextTimeout:          base.DefaultSendNextTimeout,
 		EventLogEnabled:          defaultEventLogEnabled,
 		Stores: base.StoreSpecList{
 			Specs: []base.StoreSpec{{Path: defaultStorePath}},
@@ -445,6 +451,7 @@ func (cfg *Config) readEnvironmentVariables() {
 	cfg.ScanInterval = envutil.EnvOrDefaultDuration("COCKROACH_SCAN_INTERVAL", cfg.ScanInterval)
 	cfg.ScanMaxIdleTime = envutil.EnvOrDefaultDuration("COCKROACH_SCAN_MAX_IDLE_TIME", cfg.ScanMaxIdleTime)
 	cfg.TimeUntilStoreDead = envutil.EnvOrDefaultDuration("COCKROACH_TIME_UNTIL_STORE_DEAD", cfg.TimeUntilStoreDead)
+	cfg.SendNextTimeout = envutil.EnvOrDefaultDuration("COCKROACH_SEND_NEXT_TIMEOUT", cfg.SendNextTimeout)
 	cfg.ConsistencyCheckInterval = envutil.EnvOrDefaultDuration("COCKROACH_CONSISTENCY_CHECK_INTERVAL", cfg.ConsistencyCheckInterval)
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -198,6 +198,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		Clock:           s.clock,
 		RPCContext:      s.rpcContext,
 		RPCRetryOptions: &retryOpts,
+		SendNextTimeout: s.cfg.SendNextTimeout,
 	}
 	s.distSender = kv.NewDistSender(distSenderCfg, s.gossip)
 	s.registry.AddMetricStruct(s.distSender.Metrics())

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -127,6 +127,9 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	if params.SQLMemoryPoolSize != 0 {
 		cfg.SQLMemoryPoolSize = params.SQLMemoryPoolSize
 	}
+	if params.SendNextTimeout != 0 {
+		cfg.SendNextTimeout = params.SendNextTimeout
+	}
 	cfg.JoinList = []string{params.JoinAddr}
 	if cfg.Insecure {
 		// Whenever we can (i.e. in insecure mode), use IsolatedTestAddr

--- a/pkg/sql/ambiguous_commit_test.go
+++ b/pkg/sql/ambiguous_commit_test.go
@@ -18,8 +18,10 @@ package sql_test
 
 import (
 	"bytes"
+	"fmt"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -28,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -47,117 +50,133 @@ import (
 func TestAmbiguousCommitDueToLeadershipChange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	// Create a command filter which prevents EndTransaction from
-	// returning a response.
-	params := base.TestServerArgs{}
-	committed := make(chan struct{})
-	wait := make(chan struct{})
-	var tableStartKey atomic.Value
-	var responseCount int32
+	for _, requireDistSenderRetry := range []bool{true, false} {
+		t.Run(fmt.Sprintf("retry=%t", requireDistSenderRetry), func(t *testing.T) {
+			// Create a command filter which prevents EndTransaction from
+			// returning a response.
+			params := base.TestServerArgs{}
+			committed := make(chan struct{})
+			wait := make(chan struct{})
+			var tableStartKey atomic.Value
+			var responseCount int32
 
-	// Prevent the first conditional put on table 51 from returning to
-	// waiting client in order to simulate a lost update or slow network
-	// link.
-	params.Knobs.Store = &storage.StoreTestingKnobs{
-		TestingResponseFilter: func(ba roachpb.BatchRequest, br *roachpb.BatchResponse) *roachpb.Error {
-			req, ok := ba.GetArg(roachpb.ConditionalPut)
-			tsk := tableStartKey.Load()
-			if tsk == nil {
-				return nil
+			// Prevent the first conditional put on table 51 from returning to
+			// waiting client in order to simulate a lost update or slow network
+			// link.
+			params.Knobs.Store = &storage.StoreTestingKnobs{
+				TestingResponseFilter: func(ba roachpb.BatchRequest, br *roachpb.BatchResponse) *roachpb.Error {
+					req, ok := ba.GetArg(roachpb.ConditionalPut)
+					tsk := tableStartKey.Load()
+					if tsk == nil {
+						return nil
+					}
+					if !ok || !bytes.HasPrefix(req.Header().Key, tsk.([]byte)) {
+						return nil
+					}
+					// If this is the first write to the table, wait to respond to the
+					// client in order to simulate a retry.
+					if atomic.AddInt32(&responseCount, 1) == 1 {
+						close(committed)
+						<-wait
+					}
+					return nil
+				},
 			}
-			if !ok || !bytes.HasPrefix(req.Header().Key, tsk.([]byte)) {
-				return nil
+			params.SendNextTimeout = 50 * time.Millisecond
+			testClusterArgs := base.TestClusterArgs{
+				ReplicationMode: base.ReplicationAuto,
+				ServerArgs:      params,
 			}
-			// If this is the first write to the table, wait to respond to the
-			// client in order to simulate a retry.
-			if atomic.AddInt32(&responseCount, 1) == 1 {
-				close(committed)
-				<-wait
-			}
-			return nil
-		},
-	}
-	testClusterArgs := base.TestClusterArgs{
-		ReplicationMode: base.ReplicationAuto,
-		ServerArgs:      params,
-	}
-	const numReplicas = 3
-	tc := testcluster.StartTestCluster(t, numReplicas, testClusterArgs)
-	defer tc.Stopper().Stop(context.TODO())
+			const numReplicas = 3
+			tc := testcluster.StartTestCluster(t, numReplicas, testClusterArgs)
+			defer tc.Stopper().Stop(context.TODO())
 
-	sqlDB := sqlutils.MakeSQLRunner(t, tc.Conns[0])
+			sqlDB := sqlutils.MakeSQLRunner(t, tc.Conns[0])
 
-	sqlDB.Exec(`CREATE DATABASE test`)
-	sqlDB.Exec(`CREATE TABLE test.t (k SERIAL PRIMARY KEY, v INT)`)
+			sqlDB.Exec(`CREATE DATABASE test`)
+			sqlDB.Exec(`CREATE TABLE test.t (k SERIAL PRIMARY KEY, v INT)`)
 
-	tableID, err := sqlutils.QueryTableID(tc.Conns[0], "test", "t")
-	if err != nil {
-		t.Fatal(err)
-	}
-	tableStartKey.Store(keys.MakeTablePrefix(tableID))
-
-	// Wait for new table to split & replication.
-	if err := tc.WaitForSplitAndReplication(tableStartKey.Load().([]byte)); err != nil {
-		t.Fatal(err)
-	}
-
-	// Lookup the lease.
-	tableRangeDesc, err := tc.LookupRange(keys.MakeRowSentinelKey(tableStartKey.Load().([]byte)))
-	if err != nil {
-		t.Fatal(err)
-	}
-	leaseHolder, err := tc.FindRangeLeaseHolder(
-		tableRangeDesc,
-		&roachpb.ReplicationTarget{
-			NodeID:  tc.Servers[0].GetNode().Descriptor.NodeID,
-			StoreID: tc.Servers[0].GetFirstStoreID(),
-		})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// In a goroutine, send an insert which will commit but not return
-	// from the leader (due to the command filter we installed on node 0).
-	sqlErrCh := make(chan error, 1)
-	go func() {
-		// Use a connection other than through the node which is the current
-		// leaseholder to ensure that we use GRPC instead of the local server.
-		// If we use a local server, the hanging response we simulate takes
-		// up the dist sender thread of execution because local requests are
-		// executed synchronously.
-		sqlConn := tc.Conns[leaseHolder.NodeID%numReplicas]
-		_, err := sqlConn.Exec(`INSERT INTO test.t (v) VALUES (1)`)
-		sqlErrCh <- err
-		close(wait)
-	}()
-	// Wait until the insert has committed.
-	<-committed
-
-	// Find a node other than the current lease holder to transfer the lease to.
-	for i, s := range tc.Servers {
-		if leaseHolder.StoreID != s.GetFirstStoreID() {
-			if err := tc.TransferRangeLease(tableRangeDesc, tc.Target(i)); err != nil {
+			tableID, err := sqlutils.QueryTableID(tc.Conns[0], "test", "t")
+			if err != nil {
 				t.Fatal(err)
 			}
-			break
-		}
-	}
+			tableStartKey.Store(keys.MakeTablePrefix(tableID))
 
-	// Wait for the error from the pending SQL insert.
-	err = <-sqlErrCh
-	if pqErr, ok := err.(*pq.Error); !ok {
-		t.Errorf("expected ambiguous commit error with correct code; got %v", err)
-	} else {
-		if pqErr.Code != pgerror.CodeStatementCompletionUnknownError {
-			t.Errorf("expected code %q, got %q (err: %s)",
-				pgerror.CodeStatementCompletionUnknownError, pqErr.Code, err)
-		}
-	}
+			// Wait for new table to split & replication.
+			if err := tc.WaitForSplitAndReplication(tableStartKey.Load().([]byte)); err != nil {
+				t.Fatal(err)
+			}
 
-	// Verify a single row exists in the table.
-	var rowCount int
-	sqlDB.QueryRow(`SELECT count(*) FROM test.t`).Scan(&rowCount)
-	if rowCount != 1 {
-		t.Errorf("expected 1 row but found %d", rowCount)
+			// Lookup the lease.
+			tableRangeDesc, err := tc.LookupRange(keys.MakeRowSentinelKey(tableStartKey.Load().([]byte)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Loop until we can get the lease holder. We query in the loop to
+			// ensure that the lease is acquired.
+			var leaseHolder roachpb.ReplicationTarget
+			testutils.SucceedsSoon(t, func() error {
+				rows := sqlDB.Query(`SELECT * FROM test.t`)
+				rows.Close()
+				leaseHolder, err = tc.FindRangeLeaseHolder(
+					tableRangeDesc,
+					&roachpb.ReplicationTarget{
+						NodeID:  tc.Servers[0].GetNode().Descriptor.NodeID,
+						StoreID: tc.Servers[0].GetFirstStoreID(),
+					})
+				return err
+			})
+
+			// In a goroutine, send an insert which will commit but not return
+			// from the leader (due to the command filter we installed on node 0).
+			sqlErrCh := make(chan error, 1)
+			go func() {
+				// Use a connection other than through the node which is the current
+				// leaseholder to ensure that we use GRPC instead of the local server.
+				// If we use a local server, the hanging response we simulate takes
+				// up the dist sender thread of execution because local requests are
+				// executed synchronously.
+				sqlConn := tc.Conns[leaseHolder.NodeID%numReplicas]
+				_, err := sqlConn.Exec(`INSERT INTO test.t (v) VALUES (1)`)
+				sqlErrCh <- err
+				close(wait)
+			}()
+			// Wait until the insert has committed.
+			<-committed
+
+			// If requested, wait for two further attempts from the distributed sender.
+			if requireDistSenderRetry {
+				// Wait for twice the send next timeout.
+				time.Sleep(2 * params.SendNextTimeout)
+			}
+
+			// Find a node other than the current lease holder to transfer the lease to.
+			for i, s := range tc.Servers {
+				if leaseHolder.StoreID != s.GetFirstStoreID() {
+					if err := tc.TransferRangeLease(tableRangeDesc, tc.Target(i)); err != nil {
+						t.Fatal(err)
+					}
+					break
+				}
+			}
+
+			// Wait for the error from the pending SQL insert.
+			err = <-sqlErrCh
+			if pqErr, ok := err.(*pq.Error); !ok {
+				t.Errorf("expected ambiguous commit error with correct code; got %v", err)
+			} else {
+				if pqErr.Code != pgerror.CodeStatementCompletionUnknownError {
+					t.Errorf("expected code %q, got %q (err: %s)",
+						pgerror.CodeStatementCompletionUnknownError, pqErr.Code, err)
+				}
+			}
+
+			// Verify a single row exists in the table.
+			var rowCount int
+			sqlDB.QueryRow(`SELECT count(*) FROM test.t`).Scan(&rowCount)
+			if rowCount != 1 {
+				t.Errorf("expected 1 row but found %d", rowCount)
+			}
+		})
 	}
 }

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -436,6 +436,15 @@ func (t *multiTestContextKVTransport) IsExhausted() bool {
 	return t.idx == len(t.replicas)
 }
 
+func (t *multiTestContextKVTransport) SendNextTimeout(
+	defaultTimeout time.Duration,
+) (time.Duration, bool) {
+	if t.IsExhausted() {
+		return 0, false
+	}
+	return defaultTimeout, true
+}
+
 func (t *multiTestContextKVTransport) SendNext(ctx context.Context, done chan<- kv.BatchCall) {
 	rep := t.replicas[t.idx]
 	t.idx++

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -986,6 +986,14 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) (LeaseStatus, *r
 						newNotLeaseHolderError(&transferLease, r.store.StoreID(), r.mu.state.Desc))
 				}
 
+				// If the lease is in stasis, we can't serve requests until we've
+				// renewed the lease, so we return the channel to block on renewal.
+				// Otherwise, we don't need to wait for the extension and simply
+				// ignore the returned channel (which is buffered) and continue.
+				if status.state == leaseStasis {
+					return r.requestLeaseLocked(ctx, status), nil
+				}
+
 				// Extend the lease if this range uses expiration-based
 				// leases, the lease is in need of renewal, and there's not
 				// already an extension pending.
@@ -997,15 +1005,9 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) (LeaseStatus, *r
 							log.Infof(ctx, "extending lease %s at %s", status.lease, timestamp)
 						}
 						// We had an active lease to begin with, but we want to trigger
-						// a lease extension.
-						llChan := r.requestLeaseLocked(ctx, status)
-						// If the lease is in stasis, we can't serve requests until we've
-						// renewed the lease, so we return the channel to block on renewal.
-						// Otherwise, we don't need to wait for the extension and simply
-						// ignore the returned channel (which is buffered) and continue.
-						if status.state == leaseStasis {
-							return llChan, nil
-						}
+						// a lease extension. We explicitly ignore the returned channel
+						// as we won't block on it.
+						_ = r.requestLeaseLocked(ctx, status)
 					}
 				}
 


### PR DESCRIPTION
In storage, discovered a bug where we would fail to wait on a lease renewal
for a range where the existing lease was in state=stasis.

In kv, `DistSender.sendToReplicas` now retries replicas which previously
failed with retryable errors (right now this is just `NotLeaseHolderErrors`).

Fixes #11221