### PR TITLE
build: fix sqllogictest; remove pkg/sql/Makefile

### DIFF
--- a/build/teamcity-sqllogictest.sh
+++ b/build/teamcity-sqllogictest.sh
@@ -9,11 +9,9 @@ mkdir -p artifacts
 # the all-on/all-off strategy BULIDER_HIDE_GOPATH_SRC gives us.
 export BUILDER_HIDE_GOPATH_SRC=0
 
-for target in bigtest bigtest-distsql; do
+for config in default distsql; do
     build/builder.sh env \
-             make TYPE=release -C pkg/sql $target \
-             TESTFLAGS='-v' \
-             2>&1 \
-        | tee artifacts/$target.log \
+        make TYPE=release test TESTFLAGS="-v -bigtest -config ${config}" TESTTIMEOUT='24h' PKG='./pkg/sql' TESTS='^TestLogic$$' 2>&1 \
+        | tee "artifacts/${config}.log" \
         | go-test-teamcity
 done

--- a/pkg/sql/Makefile
+++ b/pkg/sql/Makefile
@@ -1,7 +1,0 @@
-.PHONY: bigtest
-bigtest:
-	go test -bigtest -timeout 24h $(TESTFLAGS) -run '^TestLogic$$'
-
-.PHONY: bigtest-distsql
-bigtest-distsql:
-	go test -bigtest -config distsql -timeout 24h $(TESTFLAGS) -run '^TestLogic$$'


### PR DESCRIPTION
`pkg/sql/Makefile` had rotted with the new Makefile changes. Also, it
was unused except for by the nightly sqllogictest job, so its rules are
now embedded in that test script to prevent further rot.