### PR TITLE
storage: remove replica pointer tag

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -513,8 +513,9 @@ func newReplica(rangeID roachpb.RangeID, store *Store) *Replica {
 	r.rangeStr.store(0, &roachpb.RangeDescriptor{RangeID: rangeID})
 	// Add replica log tag - the value is rangeStr.String().
 	r.AmbientContext.AddLogTag("r", &r.rangeStr)
-	// Add replica pointer value.
-	r.AmbientContext.AddLogTagStr("@", fmt.Sprintf("%x", unsafe.Pointer(r)))
+	// Add replica pointer value. NB: this was historically useful for debugging
+	// replica GC issues, but is a distraction at the moment.
+	// r.AmbientContext.AddLogTagStr("@", fmt.Sprintf("%x", unsafe.Pointer(r)))
 
 	raftMuLogger := thresholdLogger(
 		r.AnnotateCtx(context.Background()),


### PR DESCRIPTION
The replica pointer tag was used for debugging #11591, which has been
long since fixed.