### PR TITLE
storage: comment cloning of txn

### DIFF
--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -205,7 +205,8 @@ func (e *Error) setGoError(err error) {
 	}
 }
 
-// SetTxn sets the txn and resets the error message.
+// SetTxn sets the txn and resets the error message. txn is cloned before being
+// stored in the Error.
 // TODO(kaneda): Unexpose this method and make callers use NewErrorWithTxn.
 func (e *Error) SetTxn(txn *Transaction) {
 	e.UnexposedTxn = txn

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2442,6 +2442,7 @@ func (s *Store) Send(
 			if pErr != nil {
 				pErr.OriginNode = ba.Replica.NodeID
 				if txn := pErr.GetTxn(); txn != nil {
+					// Clone the txn, as we'll modify it.
 					pErr.SetTxn(txn)
 				} else {
 					pErr.SetTxn(ba.Txn)


### PR DESCRIPTION
The pErr.SetTxn(pErr.Txn) line puzzled me.