### PR TITLE
build: misc fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,8 @@
   - Bash (4+ is preferred)
   - GNU Make (3.81+ is known to work)
   - CMake 2.8.12+
-  - XZ Utils (5.2.3+ is known to work)
+  - XZ Utils (5.2.3+ is known to work), except on macOS, where xz support is
+    built in to `tar`.
   - Optional: NodeJS 6.x and Yarn 0.22.0+. Required when compiling protocol
     buffers.
 

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ testrace: TESTTIMEOUT := $(RACETIMEOUT)
 # guaranteed to be irrelevant to save nearly 10s on every Make invocation.
 FIND_RELEVANT := find pkg -name node_modules -prune -o
 
-bin/sql.test: main.go $(shell $(FIND_RELEVANT) -not -name 'zcgo_flags.go' -name '*.go')
+bin/sql.test: main.go $(shell $(FIND_RELEVANT) ! -name 'zcgo_flags.go' -name '*.go')
 	$(XGO) test $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -c -o bin/sql.test ./pkg/sql
 
 bench: BENCHES := .

--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ $(ARCHIVE): $(ARCHIVE).tmp
 # instead of scripts/ls-files.sh once Git v2.11 is widely deployed.
 .INTERMEDIATE: $(ARCHIVE).tmp
 $(ARCHIVE).tmp: ARCHIVE_BASE = cockroach-$(shell cat .buildinfo/tag)
-$(ARCHIVE).tmp: $(C_LIBS_SRCS) $(CGO_FLAGS_FILES) $(BOOTSTRAP_TARGET) .buildinfo/tag .buildinfo/rev
+$(ARCHIVE).tmp: .buildinfo/tag .buildinfo/rev
 	scripts/ls-files.sh | $(TAR) -cf $@ -T - $(TAR_XFORM_FLAG),^,$(ARCHIVE_BASE)/src/github.com/cockroachdb/cockroach/, $^
 	(cd build/archive/contents && $(TAR) -rf ../../../$@ $(TAR_XFORM_FLAG),^,$(ARCHIVE_BASE)/, *)
 

--- a/build/common.mk
+++ b/build/common.mk
@@ -320,7 +320,7 @@ $(CGO_FLAGS_FILES):
 # NB: `tar -xJ` is not widely supported, so we use `xz` directly instead.
 $(C_DEPS_DIR)/%.src: $(C_DEPS_DIR)/%.src.tar.xz
 	rm -rf $@
-	xz --decompress --stdout $< | tar -C $(C_DEPS_DIR) -xf -
+	$(REPO_ROOT)/scripts/untarxz.sh $< -C $(C_DEPS_DIR)
 	touch $@
 
 $(JEMALLOC_DIR)/Makefile: $(C_DEPS_DIR)/jemalloc.src.tar.xz | $(JEMALLOC_SRC_DIR)

--- a/build/common.mk
+++ b/build/common.mk
@@ -342,7 +342,7 @@ $(ROCKSDB_DIR)/Makefile: $(C_DEPS_DIR)/rocksdb.src.tar.xz | libsnappy libjemallo
 	cd $(ROCKSDB_DIR) && cmake $(CMAKE_FLAGS) $(ROCKSDB_SRC_DIR) \
 	  $(if $(findstring release,$(TYPE)),-DWITH_$(if $(ISWINDOWS),AVX2,SSE42)=ON) \
 	  -DSNAPPY_LIBRARIES=$(SNAPPY_DIR)/.libs/libsnappy.a -DSNAPPY_INCLUDE_DIR=$(SNAPPY_SRC_DIR) -DWITH_SNAPPY=ON \
-	  -DJEMALLOC_ROOT_DIR=$(JEMALLOC_DIR) -DWITH_JEMALLOC=ON
+	  -DJEMALLOC_LIBRARIES=$(JEMALLOC_DIR)/lib/libjemalloc.a -DJEMALLOC_INCLUDE_DIR=$(JEMALLOC_DIR)/include -DWITH_JEMALLOC=ON
 
 $(SNAPPY_DIR)/Makefile: $(C_DEPS_DIR)/snappy.src.tar.xz | $(SNAPPY_SRC_DIR)
 	mkdir -p $(SNAPPY_DIR)

--- a/scripts/untarxz.sh
+++ b/scripts/untarxz.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Uncompress a tar.xz file using tar(1) or xz(1). This avoids a dependency on XZ
+# Utils on macOS, whose tar natively supports xz compression. We can't rely on
+# tar to ask users to install xz when it's missing, because there exist systems
+# where tar refuses to shell out to xz even if it's installed (e.g. OpenBSD).
+
+set -euo pipefail
+
+file="${1:-}"
+if [[ -z "$file" ]]
+then
+  echo "usage: $0 INPUT-FILE [TAR-OPTIONS...]" >&2
+  exit 1
+fi
+shift
+
+if tar -Jxf /dev/null 2> /dev/null
+then
+  exec tar -Jxf "$file" "$@"
+fi
+
+xz --decompress --stdout "$file" | tar -xf - "$@"


### PR DESCRIPTION
This fixes our source archives (they were luckily broken _after_ the beta was cut), drops the dependency on XZ Utils on macOS and Linux, and fixes `brew install cockroach` when jemalloc is already installed. See commit messages for details.