### PR TITLE
SQL support for PREPARE and EXECUTE

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -499,7 +499,7 @@ func applyColumnMutation(
 			col.DefaultExpr = nil
 		} else {
 			colDatumType := col.Type.ToDatumType()
-			if err := sqlbase.SanitizeVarFreeExpr(
+			if _, err := sqlbase.SanitizeVarFreeExpr(
 				t.Default, colDatumType, "DEFAULT", searchPath,
 			); err != nil {
 				return err

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -1543,7 +1543,7 @@ func makeCheckConstraint(
 		return nil, err
 	}
 
-	if err := sqlbase.SanitizeVarFreeExpr(expr, parser.TypeBool, "CHECK", searchPath); err != nil {
+	if _, err := sqlbase.SanitizeVarFreeExpr(expr, parser.TypeBool, "CHECK", searchPath); err != nil {
 		return nil, err
 	}
 	if generateName {

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -39,8 +39,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -54,6 +54,11 @@ var errNoTransactionInProgress = errors.New("there is no transaction in progress
 var errStaleMetadata = errors.New("metadata is still stale")
 var errTransactionInProgress = errors.New("there is already a transaction in progress")
 var errStmtFollowsSchemaChange = errors.New("statement cannot follow a schema change in a transaction")
+
+func errWrongNumberOfPreparedStatements(n int) error {
+	return pgerror.NewErrorf(pgerror.CodeInvalidPreparedStatementDefinitionError,
+		"prepared statement had %d statements, expected 1", n)
+}
 
 const sqlTxnName string = "sql txn"
 const sqlImplicitTxnName string = "sql txn implicit"
@@ -416,7 +421,7 @@ func (e *Executor) Prepare(
 	case 1:
 		// ignore
 	default:
-		return nil, errors.Errorf("expected 1 statement, but found %d", len(stmts))
+		return nil, errWrongNumberOfPreparedStatements(len(stmts))
 	}
 	stmt := stmts[0]
 	prepared.Type = stmt.StatementType()
@@ -1210,11 +1215,51 @@ func (e *Executor) execStmtInOpenTxn(
 		}
 		return Result{}, err
 	case *parser.Prepare:
-		return Result{}, util.UnimplementedWithIssueErrorf(7568,
-			"Prepared statements are supported only via the Postgres wire protocol")
+		name := s.Name.String()
+		if session.PreparedStatements.Exists(name) {
+			return Result{}, pgerror.NewErrorf(pgerror.CodeDuplicateDatabaseError,
+				"prepared statement %q already exists", name)
+		}
+		typeHints := make(parser.PlaceholderTypes, len(s.Types))
+		for i, t := range s.Types {
+			typeHints[strconv.Itoa(i+1)] = parser.CastTargetToDatumType(t)
+		}
+		_, err := session.PreparedStatements.New(e, name, s.Statement.String(), typeHints)
+		return Result{}, err
 	case *parser.Execute:
-		return Result{}, util.UnimplementedWithIssueErrorf(7568,
-			"Executing prepared statements is supported only via the Postgres wire protocol")
+		name := s.Name.String()
+		prepared, ok := session.PreparedStatements.Get(name)
+		if !ok {
+			return Result{}, pgerror.NewErrorf(pgerror.CodeInvalidSQLStatementNameError,
+				"prepared statement %q does not exist", name)
+		}
+		if len(prepared.SQLTypes) != len(s.Params) {
+			return Result{}, pgerror.NewErrorf(pgerror.CodeSyntaxError,
+				"wrong number of parameters for prepared statement %q: expected %d, got %d",
+				name, len(prepared.SQLTypes), len(s.Params))
+		}
+		qArgs := make(parser.QueryArguments, len(s.Params))
+		for i, e := range s.Params {
+			idx := strconv.Itoa(i + 1)
+			typedExpr, err := sqlbase.SanitizeVarFreeExpr(e, prepared.SQLTypes[idx], "EXECUTE parameter", session.SearchPath)
+			if err != nil {
+				return Result{}, pgerror.NewError(pgerror.CodeFeatureNotSupportedError, err.Error())
+			}
+			var p parser.Parser
+			if err := p.AssertNoAggregationOrWindowing(typedExpr, "EXECUTE parameters", session.SearchPath); err != nil {
+				return Result{}, err
+			}
+			qArgs[idx] = typedExpr
+		}
+		results := e.ExecuteStatements(session, prepared.Query, &parser.PlaceholderInfo{Values: qArgs, Types: prepared.SQLTypes})
+		if results.Empty {
+			return Result{}, nil
+		}
+		if len(results.ResultList) > 1 {
+			return Result{}, errWrongNumberOfPreparedStatements(len(results.ResultList))
+		}
+		return results.ResultList[0], nil
+
 	case *parser.Deallocate:
 		if s.Name == "" {
 			session.PreparedStatements.DeleteAll(session.Ctx())
@@ -1222,7 +1267,8 @@ func (e *Executor) execStmtInOpenTxn(
 			if found := session.PreparedStatements.Delete(
 				session.Ctx(), string(s.Name),
 			); !found {
-				return Result{}, errors.Errorf("prepared statement %s does not exist", s.Name)
+				return Result{}, pgerror.NewErrorf(pgerror.CodeInvalidSQLStatementNameError,
+					"prepared statement %q does not exist", s.Name)
 			}
 		}
 		return Result{PGTag: s.StatementTag()}, nil

--- a/pkg/sql/parser/aggregate_builtins.go
+++ b/pkg/sql/parser/aggregate_builtins.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/sql/mon"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )
 
@@ -1017,10 +1018,10 @@ func (p *Parser) IsAggregate(n *SelectClause, searchPath SearchPath) bool {
 // aggregate functions or window functions, returning an error in either case.
 func (p *Parser) AssertNoAggregationOrWindowing(expr Expr, op string, searchPath SearchPath) error {
 	if p.AggregateInExpr(expr, searchPath) {
-		return fmt.Errorf("aggregate functions are not allowed in %s", op)
+		return pgerror.NewErrorf(pgerror.CodeGroupingError, "aggregate functions are not allowed in %s", op)
 	}
 	if p.WindowFuncInExpr(expr) {
-		return fmt.Errorf("window functions are not allowed in %s", op)
+		return pgerror.NewErrorf(pgerror.CodeWindowingError, "window functions are not allowed in %s", op)
 	}
 	return nil
 }

--- a/pkg/sql/parser/placeholders.go
+++ b/pkg/sql/parser/placeholders.go
@@ -28,7 +28,7 @@ import (
 type PlaceholderTypes map[string]Type
 
 // QueryArguments relates placeholder names to their provided query argument.
-type QueryArguments map[string]Datum
+type QueryArguments map[string]TypedExpr
 
 // PlaceholderInfo defines the interface to SQL placeholders.
 type PlaceholderInfo struct {
@@ -98,7 +98,7 @@ func (p *PlaceholderInfo) Type(name string) (Type, bool) {
 
 // Value returns the known value of a placeholder.  Returns false in
 // the 2nd value if the placeholder does not have a value.
-func (p *PlaceholderInfo) Value(name string) (Datum, bool) {
+func (p *PlaceholderInfo) Value(name string) (TypedExpr, bool) {
 	if v, ok := p.Values[name]; ok {
 		return v, true
 	}

--- a/pkg/sql/testdata/logic_test/prepare
+++ b/pkg/sql/testdata/logic_test/prepare
@@ -1,15 +1,171 @@
 # LogicTest: default
 
-statement error unimplemented: Prepared statements are supported only via the Postgres wire protocol \(see issue https://github.com/cockroachdb/cockroach/issues/7568\)
-PREPARE a AS SELECT 1
-
-statement error unimplemented: Executing prepared statements is supported only via the Postgres wire protocol \(see issue https://github.com/cockroachdb/cockroach/issues/7568\)
-EXECUTE a
-
-# TODO(nvanbenschoten) This deserves more robust testing, but that is hard
-# to add until we support the PREPARE statement.
-statement error prepared statement a does not exist
+## Tests for ensuring that prepared statements can't get overwritten and for
+## deallocate and deallocate all.
+statement error prepared statement \"a\" does not exist
 DEALLOCATE a
 
+statement
+PREPARE a AS SELECT 1
+
+query I
+EXECUTE a
+----
+1
+
+query I
+EXECUTE a
+----
+1
+
+statement error prepared statement \"a\" already exists
+PREPARE a AS SELECT 1
+
+statement
+DEALLOCATE a
+
+statement error prepared statement \"a\" does not exist
+DEALLOCATE a
+
+statement error prepared statement \"a\" does not exist
+EXECUTE a
+
+statement
+PREPARE a AS SELECT 1
+
+statement
+PREPARE b AS SELECT 1
+
+query I
+EXECUTE a
+----
+1
+
+query I
+EXECUTE b
+----
+1
+
 statement ok
+DEALLOCATE ALL
+
+statement error prepared statement \"a\" does not exist
+DEALLOCATE a
+
+statement error prepared statement \"a\" does not exist
+EXECUTE a
+
+statement error prepared statement \"b\" does not exist
+DEALLOCATE b
+
+statement error prepared statement \"b\" does not exist
+EXECUTE b
+
+## Typing tests - no type hints
+#
+query error syntax error at or near \"\)\"
+PREPARE a as ()
+
+statement error could not determine data type of placeholder \$1
+PREPARE a AS SELECT $1
+
+statement
+PREPARE a AS SELECT $1:::int + $2
+
+query I
+EXECUTE a(3, 1)
+----
+4
+
+query error incompatible type for EXECUTE parameter expression: int vs string
+EXECUTE a('foo', 1)
+
+query error incompatible type for EXECUTE parameter expression: int vs decimal
+EXECUTE a(3.5, 1)
+
+query error aggregate functions are not allowed in EXECUTE parameters
+EXECUTE a(max(3), 1)
+
+query error window functions are not allowed in EXECUTE parameters
+EXECUTE a(rank() over (partition by 3), 1)
+
+query error EXECUTE parameter expression '\(SELECT 3\)' may not contain variable sub-expressions
+EXECUTE a((SELECT 3), 1)
+
+query error wrong number of parameters for prepared statement \"a\": expected 2, got 3
+EXECUTE a(1, 1, 1)
+
+query error wrong number of parameters for prepared statement \"a\": expected 2, got 0
+EXECUTE a
+
+## Type hints
+
+statement
+PREPARE b (int) AS SELECT $1
+
+query I
+EXECUTE b(3)
+----
+3
+
+query error incompatible type for EXECUTE parameter expression: int vs string
+EXECUTE b('foo')
+
+statement
+PREPARE allTypes(int, float, string, bytea, date, timestamp, timestamptz, bool, decimal) AS
+SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9
+
+query IRTTTTTBR
+EXECUTE allTypes(0, 0.0, 'foo', 'bar', '2017-08-08', '2015-08-30 03:34:45.34567', '2015-08-30 03:34:45.34567', true, 3.4)
+----
+0  0  foo  bar  2017-08-08 00:00:00 +0000 +0000  2015-08-30 03:34:45.34567 +0000 +0000  2015-08-30 03:34:45.34567 +0000 +0000  true  3.4
+
+## Other
+
+statement
+PREPARE c AS SELECT COUNT(*)
+
+query I
+EXECUTE c
+----
+1
+
+statement
+CREATE TABLE t (a int)
+
+statement
+PREPARE i AS INSERT INTO t(a) VALUES($1) RETURNING $1 + 1
+
+statement
+PREPARE s AS SELECT * FROM t
+
+query I
+EXECUTE i(1)
+----
+2
+
+query I
+EXECUTE i(2)
+----
+3
+
+query error incompatible type for EXECUTE parameter expression: int vs string
+EXECUTE i('foo')
+
+query error incompatible type for EXECUTE parameter expression: int vs decimal
+EXECUTE i(2.3)
+
+query I
+EXECUTE i(3.3::int)
+----
+4
+
+query I
+EXECUTE s
+----
+1
+2
+3
+
+statement
 DEALLOCATE ALL


### PR DESCRIPTION
Add support for the `PREPARE` and `EXECUTE` statements in SQL. Previously, `PREPARE` and `EXECUTE` functionality was only available via the wire protocol.

This is a straightforward implementation that's on par with the current implementation of pgwire prepared statements. Significantly, it only caches the text of the query in the session, not the parsed query or the plan.

Fixes #7568.