### PR TITLE
*: force zone.o to link on macOS

### DIFF
--- a/pkg/server/status/jemalloc_test.go
+++ b/pkg/server/status/jemalloc_test.go
@@ -1,0 +1,50 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build !stdmalloc
+
+package status
+
+import (
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestJemalloc(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.TODO()
+	cgoAllocated, cgoTotal, err := getJemallocStats(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 10; i++ {
+		allocateMemory()
+		cgoAllocatedN, cgoTotalN, err := getJemallocStats(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cgoAllocatedN == cgoAllocated {
+			t.Errorf("allocated stat not incremented on allocation: %d", cgoAllocated)
+		}
+		if cgoTotalN == cgoTotal {
+			t.Errorf("total stat not incremented on allocation: %d", cgoTotal)
+		}
+		cgoAllocated = cgoAllocatedN
+		cgoTotal = cgoTotalN
+	}
+}


### PR DESCRIPTION
This is the mechanism by which jemalloc hooks into `malloc` on macOS;
without it, jemalloc is not used.

Closes #15272.