### PR TITLE
Fix allocsim segfaults

### DIFF
--- a/pkg/cmd/allocsim/main.go
+++ b/pkg/cmd/allocsim/main.go
@@ -255,7 +255,7 @@ func (a *allocSim) rangeInfo() (total int, replicas, leases, leaseTransfers []in
 				if v, ok := storeMetrics["replicas.leaseholders"]; ok {
 					leases[i] += int(v.(float64))
 				}
-				if v, ok := storeMetrics["leasestransfers.success"]; ok {
+				if v, ok := storeMetrics["leases.transfers.success"]; ok {
 					leaseTransfers[i] += int(v.(float64))
 				}
 			}

--- a/pkg/cmd/internal/localcluster/localcluster.go
+++ b/pkg/cmd/internal/localcluster/localcluster.go
@@ -407,7 +407,7 @@ func (n *Node) Start() {
 		return
 	}
 
-	pid := n.cmd.ProcessState.Pid()
+	pid := n.cmd.Process.Pid
 	log.Infof(ctx, "process %d started: %s", pid, n.cmd.Args)
 
 	go func(cmd *exec.Cmd) {

--- a/pkg/util/humanizeutil/humanize.go
+++ b/pkg/util/humanizeutil/humanize.go
@@ -98,6 +98,13 @@ func (b *BytesValue) Type() string {
 
 // String implements the flag.Value and pflag.Value interfaces.
 func (b *BytesValue) String() string {
+	// We need to be able to print the zero value in order for go's flags
+	// package to not choke when comparing values to the zero value,
+	// as it does in isZeroValue as of go1.8:
+	// https://github.com/golang/go/blob/release-branch.go1.8/src/flag/flag.go#L384
+	if b.val == nil {
+		return IBytes(0)
+	}
 	// This uses the MiB, GiB, etc suffixes. If we use humanize.Bytes() we get
 	// the MB, GB, etc suffixes, but the conversion is done in multiples of 1000
 	// vs 1024.


### PR DESCRIPTION
**humanizeutil: Fix segfault when String() is called on a zero value**: Should be explained by the new comment in the code.

**localcluster: Fix segfault from accessing ProcessState of live proc**: `ProcessState` is only usable for exited processes, not running processes (https://golang.org/pkg/os/exec/#Cmd)

Fixes #15184