### PR TITLE
pgwire: Return standard_conforming_strings=on

### DIFF
--- a/pkg/acceptance/python_test.go
+++ b/pkg/acceptance/python_test.go
@@ -41,8 +41,16 @@ cur = conn.cursor()
 cur.execute("SELECT 1, 2+%v")
 v = cur.fetchall()
 assert v == [(1, 5)]
-# verify #6597 is fixed
+
+# Verify #6597 (timestamp format) is fixed.
 cur = conn.cursor()
 cur.execute("SELECT now()")
 v = cur.fetchall()
+
+# Verify round-trip of strings containing backslashes.
+# https://github.com/cockroachdb/cockroachdb-python/issues/23
+s = ('\\\\',)
+cur.execute("SELECT %s", s)
+v = cur.fetchall()
+assert v == [s], (v, s)
 `

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -1449,7 +1449,7 @@ func TestSQLNetworkMetrics(t *testing.T) {
 	defer cleanupFn()
 
 	const minbytes = 20
-	const maxbytes = 500
+	const maxbytes = 750
 
 	// Make sure we're starting at 0.
 	if _, _, err := checkSQLNetworkMetrics(s, 0, 0, 0, 0); err != nil {

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -255,6 +255,10 @@ var statusReportParams = map[string]string{
 	"server_version": sql.PgServerVersion,
 	// The current CockroachDB version string.
 	"crdb_version": build.GetInfo().Short(),
+	// If this parameter is not present, some drivers (including Python's psycopg2)
+	// will add redundant backslash escapes for compatibility with non-standard
+	// backslash handling in older versions of postgres.
+	"standard_conforming_strings": "on",
 }
 
 // handleAuthentication should discuss with the client to arrange


### PR DESCRIPTION
If this parameter is not present, some drivers (including Python's
psycopg2) will add redundant backslash escapes for compatibility with
non-standard backslash handling in older versions of postgres.

Fixes cockroachdb/cockroachdb-python#23