### PR TITLE
ui: Display graph tooltips

### DIFF
--- a/pkg/ui/src/components/toolTip.tsx
+++ b/pkg/ui/src/components/toolTip.tsx
@@ -1,27 +1,60 @@
 import * as React from "react";
 import classNames from "classnames";
 
-interface ToolTipProps {
+interface ToolTipWrapperProps {
   text: React.ReactNode;
-  title: string;
-  warningTitle?: string;
-  warning?: React.ReactNode;
 }
 
-export class ToolTip extends React.Component<ToolTipProps, {}> {
+interface ToolTipWrapperState {
+  hovered: boolean;
+}
+
+/**
+ * ToolTipWrapper wraps its children with an area that detects mouseover events
+ * and, when hovered, displays a floating tooltip to the immediate right of
+ * the wrapped element.
+ *
+ * Note that the child element itself must be wrappable; certain CSS attributes
+ * such as "float" will render parent elements unable to properly wrap their
+ * contents.
+ */
+export class ToolTipWrapper extends React.Component<ToolTipWrapperProps, ToolTipWrapperState> {
+  constructor(props?: ToolTipWrapperProps, context?: any) {
+    super(props, context);
+    this.state = {
+      hovered: false,
+    };
+  }
+
+  onMouseEnter = () => {
+    this.setState({hovered: true});
+  }
+
+  onMouseLeave = () => {
+    this.setState({hovered: false});
+  }
 
   render() {
-    let { title, text, warning, warningTitle } = this.props;
-    return <div className={ classNames("tooltip", "viz-tooltip") }>
-      <div className="title">{ title }</div>
-      <div className="content">{ text }</div>
-      {(warning || warningTitle) ?
-        <div className="warning">
-          <div className="icon-warning" />
-          <div className="warning-title">{ warningTitle }</div>
-          <div className="warningContent">{ warning }</div>
+    const { text } = this.props;
+    const { hovered } = this.state;
+    const tooltipClassNames = classNames({
+      "hover-tooltip": true,
+      "hover-tooltip--hovered": hovered,
+    });
+
+    return (
+      <div
+        className={tooltipClassNames}
+        onMouseEnter={this.onMouseEnter}
+        onMouseLeave={this.onMouseLeave}
+      >
+        <div className="hover-tooltip__text">
+          { text }
         </div>
-        : null }
-    </div>;
+        <div className="hover-tooltip__content">
+          { this.props.children }
+        </div>
+      </div>
+    );
   }
 }

--- a/pkg/ui/src/components/visualization.tsx
+++ b/pkg/ui/src/components/visualization.tsx
@@ -3,7 +3,7 @@ const spinner = require<string>("../../assets/spinner.gif");
 
 import * as React from "react";
 import classNames from "classnames";
-import { ToolTip } from "./toolTip";
+import { ToolTipWrapper } from "./toolTip";
 
 interface VisualizationProps {
   title: string;
@@ -27,38 +27,44 @@ interface VisualizationProps {
  */
 export default class extends React.Component<VisualizationProps, {}> {
   render() {
-    let { title, tooltip, stale, warning, warningTitle } = this.props;
+    let { title, tooltip, stale } = this.props;
     let vizClasses = classNames({
       "visualization": true,
       "visualization--faded": stale || false,
     });
 
-    let icon = (stale || warning || warningTitle) ? "warning" : "info";
-
-    return <div className={vizClasses}>
-      <div className="visualization__header">
-        <div className="visualization__title">
-          {this.props.title}
+    let tooltipNode: React.ReactNode = "";
+    if (tooltip) {
+      tooltipNode = (
+        <div className="visualization__tooltip">
+          <ToolTipWrapper text={tooltip}>
+            <div className="visualization__tooltip-hover-area">
+              <div className="visualization__info-icon">!</div>
+            </div>
+          </ToolTipWrapper>
         </div>
-        {
-          this.props.subtitle ?
-            <div className="visualization__subtitle">{this.props.subtitle}</div>
-            : null
-        }
-        <div className="visualization__info-icon">
+      );
+    }
+
+    return (
+      <div className={vizClasses}>
+        <div className="visualization__header">
+          <div className="visualization__title">
+            {title}
+          </div>
           {
-            // Display an icon if there is either a tooltip or if data is stale.
-            (tooltip || stale) ? <div className={`icon-${icon}`} /> : ""
+            this.props.subtitle ?
+              <div className="visualization__subtitle">{this.props.subtitle}</div>
+              : null
+          }
+          {
+            tooltipNode
           }
         </div>
-        {
-          // Display tooltip if specified.
-          (tooltip) ? <ToolTip text={tooltip} title={title} warning={warning} warningTitle={warningTitle} /> : ""
-        }
+        <div className={"visualization__content" + (this.props.loading ? " visualization--loading" : "")}>
+          {this.props.loading ? <img className="visualization__spinner" src={spinner} /> :  this.props.children }
+        </div>
       </div>
-      <div className={"visualization__content" + (this.props.loading ? " visualization--loading" : "")}>
-        {this.props.loading ? <img className="visualization__spinner" src={spinner} /> :  this.props.children }
-      </div>
-    </div>;
+    );
   }
 }

--- a/pkg/ui/src/containers/nodeGraphs.tsx
+++ b/pkg/ui/src/containers/nodeGraphs.tsx
@@ -138,7 +138,7 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
     return <div className="section l-columns">
       <div className="chart-group l-columns__left">
         <GraphGroup groupId="node.overview" hide={dashboard !== "overview"}>
-          <LineGraph title="SQL Queries" sources={nodeSources} tooltip={`The average number of SELECT, INSERT, UPDATE, and DELETE statements per second across ${specifier}.`}>
+          <LineGraph title="SQL Queries" sources={nodeSources} tooltip={`The average number of SELECT, INSERT, UPDATE, and DELETE statements per second ${specifier}.`}>
             <Axis>
               <Metric name="cr.node.sql.select.count" title="Total Reads" nonNegativeRate />
               <Metric name="cr.node.sql.distsql.select.count" title="DistSQL Reads" nonNegativeRate />
@@ -179,8 +179,8 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
               }
             </Axis>
           </LineGraph>
-          <LineGraph title="Replicas per Store"
-                    tooltip={`The number of replicas on each store.`}>
+          <LineGraph title="Replicas per Node"
+                    tooltip={`The number of replicas on each node.`}>
             <Axis>
               {
                 _.map(nodeIDs, (nid) =>
@@ -213,13 +213,27 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
             </Axis>
           </LineGraph>
 
-          <LineGraph title="Memory Usage" sources={nodeSources} tooltip={<div>{`Memory in use ${specifier}:`}<dl>
-            <dt>RSS</dt><dd>Total memory in use by CockroachDB</dd>
-            <dt>Go Allocated</dt><dd>Memory allocated by the Go layer</dd>
-            <dt>Go Total</dt><dd>Total memory managed by the Go layer</dd>
-            <dt>C Allocated</dt><dd>Memory allocated by the C layer</dd>
-            <dt>C Total</dt><dd>Total memory managed by the C layer</dd>
-            </dl></div>}>
+          <LineGraph
+            title="Memory Usage"
+            sources={nodeSources}
+            tooltip={(
+              <div>
+                {`Memory in use ${specifier}:`}
+                <dl>
+                  <dt>RSS</dt>
+                  <dd>Total memory in use by CockroachDB</dd>
+                  <dt>Go Allocated</dt>
+                  <dd>Memory allocated by the Go layer</dd>
+                  <dt>Go Total</dt>
+                  <dd>Total memory managed by the Go layer</dd>
+                  <dt>C Allocated</dt>
+                  <dd>Memory allocated by the C layer</dd>
+                  <dt>C Total</dt>
+                  <dd>Total memory managed by the C layer</dd>
+                </dl>
+              </div>
+            )}
+          >
             <Axis units={ AxisUnits.Bytes }>
               <Metric name="cr.node.sys.rss" title="Total memory (RSS)" />
               <Metric name="cr.node.sys.go.allocbytes" title="Go Allocated" />
@@ -255,6 +269,7 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
             <Axis units={ AxisUnits.Duration }>
               <Metric name="cr.node.sys.cpu.user.ns" title="User CPU Time" nonNegativeRate />
               <Metric name="cr.node.sys.cpu.sys.ns" title="Sys CPU Time" nonNegativeRate />
+              <Metric name="cr.node.sys.gc.pause.ns" title="GC Pause Time" nonNegativeRate />
             </Axis>
           </LineGraph>
 
@@ -267,14 +282,14 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
             </Axis>
           </LineGraph>
 
-          <LineGraph title="SQL Byte Traffic" sources={nodeSources} tooltip={`The average amount of SQL client network traffic in bytes per second ${specifier}.`}>
+          <LineGraph title="SQL Byte Traffic" sources={nodeSources} tooltip={`The total amount of SQL client network traffic in bytes per second ${specifier}.`}>
             <Axis units={ AxisUnits.Bytes }>
               <Metric name="cr.node.sql.bytesin" title="Bytes In" nonNegativeRate />
               <Metric name="cr.node.sql.bytesout" title="Bytes Out" nonNegativeRate />
             </Axis>
           </LineGraph>
 
-          <LineGraph title="SQL Queries" sources={nodeSources} tooltip={`The average number of SELECT, INSERT, UPDATE, and DELETE statements per second ${specifier}.`}>
+          <LineGraph title="SQL Queries" sources={nodeSources} tooltip={`The total number of SELECT, INSERT, UPDATE, and DELETE statements per second ${specifier}.`}>
             <Axis>
               <Metric name="cr.node.sql.select.count" title="Total Reads" nonNegativeRate />
               <Metric name="cr.node.sql.distsql.select.count" title="DistSQL Reads" nonNegativeRate />
@@ -378,7 +393,7 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
             </Axis>
           </LineGraph>
 
-          <LineGraph title="Transactions" sources={nodeSources} tooltip={`The average number of transactions opened, committed, rolled back, or aborted per second ${specifier}.`}>
+          <LineGraph title="Transactions" sources={nodeSources} tooltip={`The total number of transactions opened, committed, rolled back, or aborted per second ${specifier}.`}>
             <Axis>
               <Metric name="cr.node.sql.txn.begin.count" title="Begin" nonNegativeRate />
               <Metric name="cr.node.sql.txn.commit.count" title="Commits" nonNegativeRate />
@@ -387,7 +402,7 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
             </Axis>
           </LineGraph>
 
-          <LineGraph title="Schema Changes" sources={nodeSources} tooltip={`The average number of DDL statements per second ${specifier}.`}>
+          <LineGraph title="Schema Changes" sources={nodeSources} tooltip={`The total number of DDL statements per second ${specifier}.`}>
             <Axis>
               <Metric name="cr.node.sql.ddl.count" title="DDL Statements" nonNegativeRate />
             </Axis>

--- a/pkg/ui/src/containers/raftRanges.tsx
+++ b/pkg/ui/src/containers/raftRanges.tsx
@@ -9,7 +9,7 @@ import * as protos from "../js/protos";
 import { AdminUIState } from "../redux/state";
 import { refreshRaft } from "../redux/apiReducers";
 import { CachedDataReducerState } from "../redux/cachedDataReducer";
-import { ToolTip } from "../components/toolTip";
+import { ToolTipWrapper } from "../components/toolTip";
 
 /******************************
  *   RAFT RANGES MAIN COMPONENT
@@ -168,12 +168,15 @@ class RangesMain extends React.Component<RangesMainProps, RangesMainState> {
         let row = [<td key={-1}>
             {key}
             {
-              (hasErrors) ? (<span style={{position: "relative"}}>
-                <div className="viz-info-icon">
-                  <div className="icon-warning" />
-                </div>
-                <ToolTip title="Errors" text={rangeErrors} />
-              </span>) : ""
+              (hasErrors) ? (
+                <span style={{position: "relative"}}>
+                  <ToolTipWrapper text={rangeErrors}>
+                    <div className="viz-info-icon">
+                      <div className="icon-warning" />
+                    </div>
+                  </ToolTipWrapper>
+                </span>
+              ) : ""
             }
           </td>];
         rows[i] = row;

--- a/pkg/ui/src/containers/timewindow.tsx
+++ b/pkg/ui/src/containers/timewindow.tsx
@@ -26,8 +26,8 @@ interface TimeWindowManagerState {
  * expired.
  */
 class TimeWindowManager extends React.Component<TimeWindowManagerProps, TimeWindowManagerState> {
-  constructor() {
-    super();
+  constructor(props?: TimeWindowManagerProps, context?: any) {
+    super(props, context);
     this.state = { timeout: null };
   }
 

--- a/pkg/ui/styl/components/tooltip.styl
+++ b/pkg/ui/styl/components/tooltip.styl
@@ -45,3 +45,31 @@
   visibility visible
   opacity 1
   transition-duration 0s
+
+.hover-tooltip
+  position relative
+  z-index 1
+
+  &__text
+    visibility hidden
+    position absolute
+    top -10px
+    left 100%
+    width 300px
+    padding 10px
+    border-radius 5px
+    border 1px solid rgba(0, 0, 0, .1)
+    box-shadow 0 0 4px rgba(0, 0, 0, .2)
+    background rgba(255, 255, 255, .98)
+    font-family Lato-Regular
+    text-align left
+    color $light-blue
+
+  &--hovered &__text
+    visibility visible
+
+  dt
+    font-weight bold
+
+  dd
+    padding-left 5px

--- a/pkg/ui/styl/components/visualizations.styl
+++ b/pkg/ui/styl/components/visualizations.styl
@@ -59,10 +59,24 @@ $viz-sides = 62px
     width 40px
     height 40px
 
-  &__info-icon
+  &__tooltip
     float right
-    color $secondary-gray-5
-    display none
+
+  &__tooltip-hover-area
+    padding 5px 10px
+
+  &__info-icon
+    width 12px
+    height 12px
+    border-radius 50%
+    border 1px solid $light-gray
+    font-size 10px
+    color $light-gray
+    line-height 10px
+
+  .hover-tooltip--hovered &__info-icon
+    border-color $light-blue
+    color $light-blue
 
   .icon-warning
     color $secondary-gold


### PR DESCRIPTION
Tooltip text for our graphs has been disabled for some time; this commit
refactors the existing tooltip functionality to better align with our current
needs and restores tooltips to all graphs that have tooltip text defined.

Included are a small number of grammatical fixes to a few specific tooltips that
I noticed while testing this commit.

<img width="1080" alt="screen shot 2017-04-24 at 2 31 17 am" src="https://cloud.githubusercontent.com/assets/6969858/25324932/96b7e402-2896-11e7-93ec-f23130b9068d.png">
