### PR TITLE
security: don't compare #client certificates vs #verified chains.

### DIFF
--- a/pkg/security/auth.go
+++ b/pkg/security/auth.go
@@ -42,10 +42,9 @@ func GetCertificateUser(tlsState *tls.ConnectionState) (string, error) {
 	if len(tlsState.PeerCertificates) == 0 {
 		return "", errors.Errorf("no client certificates in request")
 	}
-	if len(tlsState.VerifiedChains) != len(tlsState.PeerCertificates) {
-		// TODO(marc): can this happen? Should we require exactly one?
-		return "", errors.Errorf("client cerficates not verified")
-	}
+	// The go server handshake code verifies the first certificate, using
+	// any following certificates as intermediates. See:
+	// https://github.com/golang/go/blob/go1.8.1/src/crypto/tls/handshake_server.go#L723:L742
 	return tlsState.PeerCertificates[0].Subject.CommonName, nil
 }
 

--- a/pkg/security/auth_test.go
+++ b/pkg/security/auth_test.go
@@ -62,13 +62,15 @@ func TestGetCertificateUser(t *testing.T) {
 		t.Error("unexpected success")
 	}
 
-	// len(certs) != len(chains)
-	if _, err := security.GetCertificateUser(makeFakeTLSState([]string{"foo"}, []int{1, 1})); err == nil {
-		t.Error("unexpected success")
-	}
-
 	// Good request: single certificate.
 	if name, err := security.GetCertificateUser(makeFakeTLSState([]string{"foo"}, []int{2})); err != nil {
+		t.Error(err)
+	} else if name != "foo" {
+		t.Errorf("expected name: foo, got: %s", name)
+	}
+
+	// Request with multiple certs, but only one chain (eg: origin certs are client and CA).
+	if name, err := security.GetCertificateUser(makeFakeTLSState([]string{"foo", "CA"}, []int{2})); err != nil {
 		t.Error(err)
 	} else if name != "foo" {
 		t.Errorf("expected name: foo, got: %s", name)


### PR DESCRIPTION
Fixes #15285

The server handshake code already fails the request if he peer
certificates do not end up with a valid chain ending at our client CAs.
This check fails when using psql which provides both client and CA
certificates in the request, but resulting in only one chain.