### PR TITLE
cli: drop COCKROACH_CERTS_DIR env variable for start command.

### DIFF
--- a/pkg/acceptance/reference_test.go
+++ b/pkg/acceptance/reference_test.go
@@ -62,6 +62,7 @@ export COCKROACH_SKIP_UPDATE_CHECK=1
 export COCKROACH_CERTS_DIR=/certs/
 
 bin=/%s/cockroach
+echo "TODO(marc): specify --certs-dir=/certs/ once the binary is upgraded"
 $bin start --background --logtostderr &> oldout
 
 echo "Use the reference binary to write a couple rows, then render its output to a file and shut down."
@@ -73,7 +74,7 @@ $bin sql -d old -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01
 $bin quit && wait # wait will block until all background jobs finish.
 
 bin=/cockroach/cockroach
-$bin start --background --logtostderr &> newout
+$bin start --certs-dir=/certs/ --background --logtostderr &> newout
 echo "Read data written by reference version using new binary"
 $bin sql -d old -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01-01 00:00:00' + v)) as v, extract(epoch FROM t) as e FROM testing_old" > new.everything
 # diff returns non-zero if different. With set -e above, that would exit here.
@@ -115,6 +116,7 @@ function finish() {
 trap finish EXIT
 
 export COCKROACH_CERTS_DIR=/certs/
+echo "TODO(marc): specify --certs-dir=/certs/ once the binary is upgraded"
 $bin start --background --logtostderr &> out
 $bin sql -d old -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01-01 00:00:00' + v)) as v, extract(epoch FROM t) as e FROM testing_old" > old.everything
 $bin sql -d old -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01-01 00:00:00' + v)) as v, extract(epoch FROM t) as e FROM testing_new" >> old.everything
@@ -146,6 +148,7 @@ function finish() {
 trap finish EXIT
 
 export COCKROACH_CERTS_DIR=/certs/
+echo "TODO(marc): specify --certs-dir=/certs/ once the binary is upgraded"
 $bin start --background --logtostderr &> out
 $bin sql -d old -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01-01 00:00:00' + v)) as v, extract(epoch FROM t) as e FROM testing_old" > old.everything
 $bin sql -d old -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01-01 00:00:00' + v)) as v, extract(epoch FROM t) as e FROM testing_new" >> old.everything

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -289,17 +289,24 @@ production usage.`,
 The path to the directory containing SSL certificates and keys.
 <PRE>
 
-Cockroach looks for certificates and keys inside the directory using the following naming scheme:
+Cockroach looks for certificates and keys inside the directory using the
+following naming scheme:
 
   - CA certificate and key: ca.crt, ca.key
   - Server certificate and key: node.crt, node.key
   - Client certificate and key: client.<user>.crt, client.<user>.key
 
 When running client commands, the user can be specified with the --user flag.
-
 </PRE>
-Keys have a minimum permission requirement of 0777 (rwx------). This restriction can be
+
+Keys have a minimum permission requirement of 0700 (rwx------). This restriction can be
 disabled by setting the environment variable COCKROACH_SKIP_KEY_PERMISSION_CHECK to true.`,
+	}
+
+	// Server version of the certs directory flag, cannot be set through environment.
+	ServerCertsDir = FlagInfo{
+		Name:        "certs-dir",
+		Description: CertsDir.Description,
 	}
 
 	CAKey = FlagInfo{

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -50,7 +50,6 @@ var zoneDisableReplication bool
 
 var serverCfg = server.MakeConfig()
 var baseCfg = serverCfg.Config
-var serverInsecure bool
 var cliCtx = cliContext{Config: baseCfg}
 var sqlCtx = sqlContext{cliContext: &cliCtx}
 var dumpCtx = dumpContext{cliContext: &cliCtx, dumpMode: dumpBoth}
@@ -59,6 +58,10 @@ var debugCtx = debugContext{
 	endKey:     engine.MVCCKeyMax,
 	replicated: false,
 }
+
+// server-specific values of some flags.
+var serverInsecure bool
+var serverSSLCertsDir string
 
 // InitCLIDefaults is used for testing.
 func InitCLIDefaults() {
@@ -250,8 +253,9 @@ func init() {
 		// We share the default with the ClientInsecure flag.
 		boolFlag(f, &serverInsecure, cliflags.ServerInsecure, baseCfg.Insecure)
 
-		// Certificate flags.
-		stringFlag(f, &baseCfg.SSLCertsDir, cliflags.CertsDir, base.DefaultCertsDirectory)
+		// Certificates directory. Use a server-specific flag and value to ignore environment
+		// variables, but share the same default.
+		stringFlag(f, &serverSSLCertsDir, cliflags.ServerCertsDir, base.DefaultCertsDirectory)
 
 		// Cluster joining flags.
 		varFlag(f, &serverCfg.JoinList, cliflags.Join)

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -292,9 +292,9 @@ func runStart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Use the server-specific Insecure flag.
+	// Use the server-specific values for some flags and settings.
 	serverCfg.Insecure = serverInsecure
-	// Default user for servers.
+	serverCfg.SSLCertsDir = serverSSLCertsDir
 	serverCfg.User = security.NodeUser
 
 	signalCh := make(chan os.Signal, 1)


### PR DESCRIPTION
Fixes #9189.

Separate certsdir flag for server use, allowing us to drop the env
variable.

Also tweaked a bit of spacing.

the help messages are now:
```
$ cockroach start --help
...
      --certs-dir string
        The path to the directory containing SSL certificates and keys.

        Cockroach looks for certificates and keys inside the directory
using the
        following naming scheme:

          - CA certificate and key: ca.crt, ca.key
          - Server certificate and key: node.crt, node.key
          - Client certificate and key: client.<user>.crt,
            client.<user>.key

        When running client commands, the user can be specified with the
--user flag.
        Keys have a minimum permission requirement of 0777 (rwx------).
        This restriction can be disabled by setting the environment
variable
        COCKROACH_SKIP_KEY_PERMISSION_CHECK to true.
        (default "${HOME}/.cockroach-certs")
...
```

```
$ cockroach sql --help
...
      --certs-dir string
        The path to the directory containing SSL certificates and keys.

        Cockroach looks for certificates and keys inside the directory
using the
        following naming scheme:

          - CA certificate and key: ca.crt, ca.key
          - Server certificate and key: node.crt, node.key
          - Client certificate and key: client.<user>.crt,
            client.<user>.key

        When running client commands, the user can be specified with the
--user flag.
        Keys have a minimum permission requirement of 0777 (rwx------).
        This restriction can be disabled by setting the environment
variable
        COCKROACH_SKIP_KEY_PERMISSION_CHECK to true.
        Environment variable: COCKROACH_CERTS_DIR
        (default "${HOME}/.cockroach-certs")
...
```