### PR TITLE
sqlccl: fix segfault with RESTORE

### DIFF
--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -63,7 +63,7 @@ func Import(
 		log.Infof(ctx, "import [%s,%s) (%d files)", newStartKey, newEndKey, len(files))
 	}
 	if len(files) == 0 {
-		return nil, nil
+		return &roachpb.ImportResponse{}, nil
 	}
 
 	req := &roachpb.ImportRequest{

--- a/pkg/testutils/sqlutils/pg_url.go
+++ b/pkg/testutils/sqlutils/pg_url.go
@@ -23,11 +23,11 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/util/fileutil"
 )
 
 // PGUrl returns a postgres connection url which connects to this server with the given user, and a
@@ -48,7 +48,9 @@ func PGUrl(t testing.TB, servingAddr, prefix string, user *url.Userinfo) (url.UR
 		t.Fatal(err)
 	}
 
-	tempDir, err := ioutil.TempDir("", strings.Replace(prefix, "/", "_", -1))
+	// TODO(benesch): Audit usage of prefix and replace the following line with
+	// `testutils.TempDir(t)` if prefix can always be `t.Name()`.
+	tempDir, err := ioutil.TempDir("", fileutil.EscapeFilename(prefix))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/fileutil/escape.go
+++ b/pkg/util/fileutil/escape.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The Cockroach Authors.
+// Copyright 2017 The Cockroach Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,29 +12,16 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-// Author: Daniel Harrison (daniel.harrison@gmail.com)
+// Author: Nikhil Benesch (nikhil.benesch@gmail.com)
 
-package testutils
+package fileutil
 
-import (
-	"io/ioutil"
-	"os"
-	"testing"
+import "regexp"
 
-	"github.com/cockroachdb/cockroach/pkg/util/fileutil"
-)
-
-// TempDir creates a directory and a function to clean it up at the end of the
-// test.
-func TempDir(t testing.TB) (string, func()) {
-	dir, err := ioutil.TempDir("", fileutil.EscapeFilename(t.Name()))
-	if err != nil {
-		t.Fatal(err)
-	}
-	cleanup := func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Error(err)
-		}
-	}
-	return dir, cleanup
+// EscapeFilename replaces bad characters in a filename with safe equivalents.
+// The only character disallowed on Unix systems is the path separator "/".
+// Windows is more restrictive; banned characters on Windows are listed here:
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
+func EscapeFilename(s string) string {
+	return regexp.MustCompile(`[<>:"\/|?*\x00-\x1f]`).ReplaceAllString(s, "_")
 }

--- a/pkg/util/log/test_log_scope.go
+++ b/pkg/util/log/test_log_scope.go
@@ -22,7 +22,8 @@ import (
 	"io/ioutil"
 	"os"
 	"runtime"
-	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/util/fileutil"
 )
 
 // TestLogScope represents the lifetime of a logging output.  It
@@ -65,9 +66,7 @@ func Scope(t tShim) *TestLogScope {
 // ScopeWithoutShowLogs ignores the -show-logs flag and should be used for tests
 // that require the logs go to files.
 func ScopeWithoutShowLogs(t tShim) *TestLogScope {
-	// Subtests are slash-delimited, which can confuse things when slash is also
-	// the path separator.
-	tempDir, err := ioutil.TempDir("", "log"+strings.Replace(t.Name(), "/", "_", -1))
+	tempDir, err := ioutil.TempDir("", "log"+fileutil.EscapeFilename(t.Name()))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This fixes a bug I found while working on #15004, and adds a test to prevent regressions.