### PR TITLE
settings: align setting names according to RFC.

### DIFF
--- a/pkg/acceptance/debug_remote_test.go
+++ b/pkg/acceptance/debug_remote_test.go
@@ -62,7 +62,8 @@ func TestDebugRemote(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run(c.remoteDebug, func(t *testing.T) {
-			setStmt := fmt.Sprintf("SET CLUSTER SETTING server.debug.remote = '%s'", c.remoteDebug)
+			setStmt := fmt.Sprintf("SET CLUSTER SETTING server.remote_debugging.mode = '%s'",
+				c.remoteDebug)
 			if _, err := db.Exec(setStmt); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/server/debug.go
+++ b/pkg/server/debug.go
@@ -41,8 +41,9 @@ const debugEndpoint = "/debug/"
 // register to that via import, and go-metrics registers to that via exp.Exp())
 var debugServeMux = http.DefaultServeMux
 
+// TODO(arjun): use an Enum setting here.
 var debugRemote = settings.RegisterStringSetting(
-	"server.debug.remote",
+	"server.remote_debugging.mode",
 	"set to enable remote debugging, localhost-only or disable (all, local, false)",
 	"local")
 

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -53,7 +53,7 @@ import (
 // all execution because traces are gathered for all transactions even
 // if they are not output.
 var traceTxnThreshold = settings.RegisterDurationSetting(
-	"sql.trace.txn.threshold",
+	"sql.trace.txn.enable_threshold",
 	"duration beyond which all transactions are traced (set to 0 to disable)", 0)
 
 // traceSessionEventLogEnabled can be used to enable the event log
@@ -61,7 +61,7 @@ var traceTxnThreshold = settings.RegisterDurationSetting(
 // non-trivial performance impact and also reveals SQL statements
 // which may be a privacy concern.
 var traceSessionEventLogEnabled = settings.RegisterBoolSetting(
-	"sql.trace.session.eventlog.enabled",
+	"sql.trace.session_eventlog.enabled",
 	"set to true to enable session tracing", false)
 
 // debugTrace7881Enabled causes all SQL transactions to be traced using their
@@ -72,7 +72,7 @@ var debugTrace7881Enabled = envutil.EnvOrDefaultBool("COCKROACH_TRACE_7881", fal
 // logStatementsExecuteEnabled causes the Executor to log executed
 // statements and, if any, resulting errors.
 var logStatementsExecuteEnabled = settings.RegisterBoolSetting(
-	"sql.log.statements.execute.enabled",
+	"sql.trace.log_statement_execute",
 	"set to true to enable logging of executed statements", false)
 
 // span baggage key used for marking a span

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -96,7 +96,7 @@ var tickQuiesced = envutil.EnvOrDefaultBool("COCKROACH_TICK_QUIESCED", true)
 // TODO(peter): Off by default until we can figure out the performance
 // degradation see on test clusters.
 var syncRaftLog = settings.RegisterBoolSetting(
-	"kv.raft.log.sync.enabled",
+	"kv.raft_log.synchronize",
 	"set to true to synchronize on Raft log writes to persistent storage",
 	false)
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3170,11 +3170,11 @@ type SnapshotStorePool interface {
 }
 
 var rebalanceSnapshotRate = settings.RegisterByteSizeSetting(
-	"kv.snapshot.rebalance.rate",
+	"kv.snapshot_rebalance.max_rate",
 	"the rate limit (bytes/sec) to use for rebalance snapshots",
 	envutil.EnvOrDefaultBytes("COCKROACH_PREEMPTIVE_SNAPSHOT_RATE", 2<<20))
 var recoverySnapshotRate = settings.RegisterByteSizeSetting(
-	"kv.snapshot.recovery.rate",
+	"kv.snapshot_recovery.max_rate",
 	"the rate limit (bytes/sec) to use for recovery snapshots",
 	envutil.EnvOrDefaultBytes("COCKROACH_RAFT_SNAPSHOT_RATE", 8<<20))
 


### PR DESCRIPTION
Following up to #15253.

| Old                                  | New                                   |
|--------------------------------------|---------------------------------------|
| `server.debug.remote`                | `server.remote_debugging.mode`        |
| `sql.trace.txn.threshold`            | `sql.trace.txn.enable_threshold`      |
| `sql.trace.session.eventlog.enabled` | `sql.trace.session_eventlog.enabled`  |
| `sql.log.statements.execute.enabled` | `sql.trace.log_statement_execute`     |
| `kv.raft.log.sync.enabled`           | `kv.raft_log.synchronize`             |
| `kv.snapshot.rebalance.rate`         | `kv.snapshot_rebalance.max_rate`      |
| `kv.snapshot.recovery.rate`          | `kv.snapshot_recovery.max_rate`       |