### PR TITLE
roachpb: reset the Sequence number on txn restarts

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -853,6 +853,7 @@ func (t *Transaction) Restart(
 	t.UpgradePriority(upgradePriority)
 	t.WriteTooOld = false
 	t.RetryOnPush = false
+	t.Sequence = 0
 }
 
 // Update ratchets priority, timestamp and original timestamp values (among


### PR DESCRIPTION
We used to not reset it; and in fact it sometimes went backwards as an
error from EndTransaction could return a txn with a stale sequence
number. Before #15292 this could have caused problems, as the sequence
number was checked even when looking at an intent from a different
epoch.

We now reset it, as to not cause surprises.

Closes #15278