### PR TITLE
kv: don't update BatchResponse.Txn in TxnCoordSender on success

### DIFF
--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -937,17 +937,7 @@ func (tc *TxnCoordSender) updateState(
 		txnMeta.setLastUpdate(tc.clock.PhysicalNow())
 	}
 
-	if pErr == nil {
-		// For successful transactional requests, always send the updated txn
-		// record back. Note that we make sure not to share data with newTxn
-		// (which may have made it into txnMeta).
-		if br.Txn != nil {
-			br.Txn.Update(&newTxn)
-		} else {
-			clonedTxn := newTxn.Clone()
-			br.Txn = &clonedTxn
-		}
-	} else if pErr.GetTxn() != nil {
+	if pErr != nil && pErr.GetTxn() != nil {
 		// Avoid changing existing errors because sometimes they escape into
 		// goroutines and data races can occur.
 		pErrShallow := *pErr


### PR DESCRIPTION
The TxnCoordSender was updating a response's transaction after the batch
has been executed. In case of successful execution, this amounts to
updating br.Txn with ba.Txn. Updating a response's txn using the
request's txn doesn't seem to make much sense; the server is already
supposed to have returned a transaction based on the request.

This change is done for reducing the involvement of the TxnCoordSender
in transaction updating, as DistSQL doesn't go through it. The cases
where batch execution results in an error will be dealt with separately.