### PR TITLE
security: Increase default CA/cert lifetime to 10 years

### DIFF
--- a/pkg/cli/cert.go
+++ b/pkg/cli/cert.go
@@ -31,8 +31,8 @@ const defaultKeySize = 2048
 
 // We use 366 days on certificate lifetimes to at least match X years,
 // otherwise leap years risk putting us just under.
-const defaultCALifetime = 5 * 366 * 24 * time.Hour   // five years
-const defaultCertLifetime = 2 * 366 * 24 * time.Hour // two years
+const defaultCALifetime = 10 * 366 * 24 * time.Hour   // ten years
+const defaultCertLifetime = 10 * 366 * 24 * time.Hour // ten years
 
 var keySize int
 var certificateLifetime time.Duration


### PR DESCRIPTION
I have no real expectation of merging this, but am opening it to make sure the conversation from https://github.com/cockroachdb/cockroach/issues/14985#issuecomment-296802856 doesn't get lost.

I'm sorry I didn't chime in last Thursday when it was happening!