### PR TITLE
sql: fix newline handling for regexp_replace

### DIFF
--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -1961,7 +1961,7 @@ var flagToNotByte = map[syntax.Flags]byte{
 // http://www.postgresql.org/docs/9.0/static/functions-matching.html#POSIX-EMBEDDED-OPTIONS-TABLE.
 // It then returns an adjusted regexp pattern.
 func regexpEvalFlags(pattern, sqlFlags string) (string, error) {
-	flags := syntax.DotNL
+	flags := syntax.DotNL | syntax.OneLine
 
 	for _, sqlFlag := range sqlFlags {
 		switch sqlFlag {
@@ -1972,12 +1972,12 @@ func regexpEvalFlags(pattern, sqlFlags string) (string, error) {
 		case 'c':
 			flags &^= syntax.FoldCase
 		case 's':
-			flags |= syntax.DotNL
+			flags &^= syntax.DotNL
 		case 'm', 'n':
 			flags &^= syntax.DotNL
-			flags |= syntax.OneLine
+			flags &^= syntax.OneLine
 		case 'p':
-			flags |= syntax.DotNL
+			flags &^= syntax.DotNL
 			flags |= syntax.OneLine
 		case 'w':
 			flags |= syntax.DotNL

--- a/pkg/sql/testdata/logic_test/builtin_function
+++ b/pkg/sql/testdata/logic_test/builtin_function
@@ -874,6 +874,39 @@ query error regexp_replace\(\): invalid regexp flag: 'z'
 SELECT regexp_replace(E'fooBar\nbaz', 'b(..)$', E'X\\&Y', 'z')
 
 query T
+SELECT regexp_replace(E'Foo\nFoo', '^(foo)', 'BAR', 'i')
+----
+BAR
+Foo
+
+query T
+SELECT regexp_replace(e'DOGGIE\ndog \nDOG', '^d.+', 'CAT', 's')
+----
+DOGGIE
+dog
+DOG
+
+query T
+SELECT regexp_replace(e'DOGGIE\ndog \nDOG', '^d.+', 'CAT', 'n');
+----
+DOGGIE
+CAT
+DOG
+
+query T
+SELECT regexp_replace(e'DOGGIE\ndog \nDOG', '^D.+', 'CAT', 'p')
+----
+CAT
+dog
+DOG
+
+query T
+SELECT regexp_replace(e'DOGGIE\ndog \nDOG', '^d.+', 'CAT', 'w')
+----
+DOGGIE
+CAT
+
+query T
 SELECT (timestamp '2016-02-10 19:46:33.306157519')::string
 ----
 2016-02-10 19:46:33.306158+00:00


### PR DESCRIPTION
For the built-in function `regexp_replace`, we were doing the opposite
of what's intended when matching newlines with `.`s and matching across
lines with the `n` flag. Moreover, we were erroneously doing multi-line
matching by default, even when no flags were specified. This change
fixes both issues.

Now the results of our logic tests for `regexp_replace` match the
results given by PostgreSQL 9.6.

Fixes #12362