### PR TITLE
storage: disable rebalancing if doing so would violate quorum

### DIFF
--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -661,6 +661,88 @@ func TestAllocatorRebalance(t *testing.T) {
 	}
 }
 
+func TestAllocatorRebalanceDeadNodes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	stopper, _, sp, a, _ := createTestAllocator( /* deterministic */ false)
+	ctx := context.Background()
+	defer stopper.Stop(ctx)
+
+	mockStorePool(sp,
+		[]roachpb.StoreID{1, 2, 3, 4, 5, 6},
+		[]roachpb.StoreID{7, 8},
+		nil)
+
+	ranges := func(rangeCount int32) roachpb.StoreCapacity {
+		return roachpb.StoreCapacity{
+			Capacity:   1000,
+			Available:  1000,
+			RangeCount: rangeCount,
+		}
+	}
+
+	// Initialize 8 stores: where store 6 is the target for rebalancing.
+	sp.detailsMu.Lock()
+	sp.getStoreDetailLocked(1).desc.Capacity = ranges(100)
+	sp.getStoreDetailLocked(2).desc.Capacity = ranges(100)
+	sp.getStoreDetailLocked(3).desc.Capacity = ranges(100)
+	sp.getStoreDetailLocked(4).desc.Capacity = ranges(100)
+	sp.getStoreDetailLocked(5).desc.Capacity = ranges(100)
+	sp.getStoreDetailLocked(6).desc.Capacity = ranges(0)
+	sp.getStoreDetailLocked(7).desc.Capacity = ranges(100)
+	sp.getStoreDetailLocked(8).desc.Capacity = ranges(100)
+	sp.detailsMu.Unlock()
+
+	replicas := func(storeIDs ...roachpb.StoreID) []roachpb.ReplicaDescriptor {
+		res := make([]roachpb.ReplicaDescriptor, len(storeIDs))
+		for i, storeID := range storeIDs {
+			res[i].StoreID = storeID
+		}
+		return res
+	}
+
+	// Each test case should describe a repair situation which has a lower
+	// priority than the previous test case.
+	testCases := []struct {
+		existing []roachpb.ReplicaDescriptor
+		expected roachpb.StoreID
+	}{
+		// 3/3 live -> 3/4 live: ok
+		{replicas(1, 2, 3), 6},
+		// 2/3 live -> 2/4 live: nope
+		{replicas(1, 2, 7), 0},
+		// 4/4 live -> 4/5 live: ok
+		{replicas(1, 2, 3, 4), 6},
+		// 3/4 live -> 3/5 live: ok
+		{replicas(1, 2, 3, 7), 6},
+		// 5/5 live -> 5/6 live: ok
+		{replicas(1, 2, 3, 4, 5), 6},
+		// 4/5 live -> 4/6 live: ok
+		{replicas(1, 2, 3, 4, 7), 6},
+		// 3/5 live -> 3/6 live: nope
+		{replicas(1, 2, 3, 7, 8), 0},
+	}
+
+	for _, c := range testCases {
+		t.Run("", func(t *testing.T) {
+			result, err := a.RebalanceTarget(
+				ctx, config.Constraints{}, c.existing, firstRange)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if c.expected > 0 {
+				if result == nil {
+					t.Fatalf("expected %d, but found nil", c.expected)
+				} else if c.expected != result.StoreID {
+					t.Fatalf("expected %d, but found %d", c.expected, result.StoreID)
+				}
+			} else if result != nil {
+				t.Fatalf("expected nil, but found %d", result.StoreID)
+			}
+		})
+	}
+}
+
 // TestAllocatorRebalanceThrashing tests that the rebalancer does not thrash
 // when replica counts are balanced, within the appropriate thresholds, across
 // stores.

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -17,9 +17,12 @@
 package storage
 
 import (
+	"bytes"
+	"fmt"
 	"sync/atomic"
 	"time"
 
+	"github.com/coreos/etcd/raft"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -284,7 +287,8 @@ func (rq *replicateQueue) processOneChange(
 
 		rq.metrics.AddReplicaCount.Inc(1)
 		if log.V(1) {
-			log.Infof(ctx, "adding replica to %+v due to under-replication", newReplica)
+			log.Infof(ctx, "adding replica %+v due to under-replication: %s",
+				newReplica, rangeRaftProgress(repl.RaftStatus(), desc.Replicas))
 		}
 		if err := rq.addReplica(
 			ctx, repl, newReplica, desc, SnapshotRequest_RECOVERY); err != nil {
@@ -331,7 +335,8 @@ func (rq *replicateQueue) processOneChange(
 		} else {
 			rq.metrics.RemoveReplicaCount.Inc(1)
 			if log.V(1) {
-				log.Infof(ctx, "removing replica %+v due to over-replication", removeReplica)
+				log.Infof(ctx, "removing replica %+v due to over-replication: %s",
+					removeReplica, rangeRaftProgress(repl.RaftStatus(), desc.Replicas))
 			}
 			target := roachpb.ReplicationTarget{
 				NodeID:  removeReplica.NodeID,
@@ -414,7 +419,8 @@ func (rq *replicateQueue) processOneChange(
 		}
 		rq.metrics.RebalanceReplicaCount.Inc(1)
 		if log.V(1) {
-			log.Infof(ctx, "rebalancing to %+v", rebalanceReplica)
+			log.Infof(ctx, "rebalancing to %+v: %s",
+				rebalanceReplica, rangeRaftProgress(repl.RaftStatus(), desc.Replicas))
 		}
 		if err := rq.addReplica(
 			ctx, repl, rebalanceReplica, desc, SnapshotRequest_REBALANCE); err != nil {
@@ -490,4 +496,30 @@ func (*replicateQueue) timer(_ time.Duration) time.Duration {
 // purgatoryChan returns the replicate queue's store update channel.
 func (rq *replicateQueue) purgatoryChan() <-chan struct{} {
 	return rq.updateChan
+}
+
+// rangeRaftStatus pretty-prints the Raft progress (i.e. Raft log position) of
+// the replicas.
+func rangeRaftProgress(raftStatus *raft.Status, replicas []roachpb.ReplicaDescriptor) string {
+	if raftStatus == nil || len(raftStatus.Progress) == 0 {
+		return ""
+	}
+	var buf bytes.Buffer
+	buf.WriteString("[")
+	for i, r := range replicas {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		fmt.Fprintf(&buf, "%d", r.ReplicaID)
+		if uint64(r.ReplicaID) == raftStatus.Lead {
+			buf.WriteString("*")
+		}
+		if progress, ok := raftStatus.Progress[uint64(r.ReplicaID)]; ok {
+			fmt.Fprintf(&buf, ":%d", progress.Match)
+		} else {
+			buf.WriteString(":?")
+		}
+	}
+	buf.WriteString("]")
+	return buf.String()
 }


### PR DESCRIPTION
Tweak Allocator.RebalanceTarget to not generate a rebalance target if
adding a new replica would cause quorum to be violated. For example,
rebalancing a 3 replica range requires temporarily up-relicating to 4
replicas which would violate quorum if one of the replicas is on a down
node. Not rebalancing means we'll have to wait for the node to be
declared dead and then go through the dead replica removal process
before adding a new replica (3->2->3) for which we'll be able to
maintain quorum at all times.

Fixes #15163 (at least part of it)