### PR TITLE
distsql: don't set trace context if tracing is disabled

### DIFF
--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -604,8 +604,11 @@ func SetFlowRequestTrace(ctx context.Context, req *SetupFlowRequest) error {
 	if sp == nil {
 		return nil
 	}
-	req.TraceContext = &tracing.SpanContextCarrier{}
 	tracer := sp.Tracer()
+	if _, ok := tracer.(opentracing.NoopTracer); ok {
+		return nil
+	}
+	req.TraceContext = &tracing.SpanContextCarrier{}
 	return tracer.Inject(sp.Context(), basictracer.Delegator, req.TraceContext)
 }
 

--- a/pkg/util/log/trace.go
+++ b/pkg/util/log/trace.go
@@ -88,14 +88,12 @@ func FinishEventLog(ctx context.Context) {
 	}
 }
 
-var noopTracer opentracing.NoopTracer
-
 // getSpanOrEventLog returns the current Span. If there is no Span, it returns
 // the current ctxEventLog. If neither (or the Span is NoopTracer), returns
 // false.
 func getSpanOrEventLog(ctx context.Context) (opentracing.Span, *ctxEventLog, bool) {
 	if sp := opentracing.SpanFromContext(ctx); sp != nil {
-		if sp.Tracer() == noopTracer {
+		if _, ok := sp.Tracer().(opentracing.NoopTracer); ok {
 			return nil, nil, false
 		}
 		return sp, nil, true


### PR DESCRIPTION
Tracing is now disabled by default; this is causing "failed to join a remote
trace" logs in distsql. Fixing by not creating a TraceContext in this case.