### PR TITLE
storage: change defaults for range lease and node liveness durations

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -214,10 +214,11 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	)
 	s.db = client.NewDB(s.txnCoordSender, s.clock)
 
-	active, renewal := storage.NodeLivenessDurations(
+	nlActive, nlRenewal := storage.NodeLivenessDurations(
 		storage.RaftElectionTimeout(s.cfg.RaftTickInterval, s.cfg.RaftElectionTimeoutTicks))
+
 	s.nodeLiveness = storage.NewNodeLiveness(
-		s.cfg.AmbientCtx, s.clock, s.db, s.gossip, active, renewal,
+		s.cfg.AmbientCtx, s.clock, s.db, s.gossip, nlActive, nlRenewal,
 	)
 	s.registry.AddMetricStruct(s.nodeLiveness.Metrics())
 
@@ -332,6 +333,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	s.tsDB = ts.NewDB(s.db)
 	s.tsServer = ts.MakeServer(s.cfg.AmbientCtx, s.tsDB, s.cfg.TimeSeriesServerConfig, s.stopper)
 
+	rlActive, rlRenewal := storage.RangeLeaseDurations(
+		storage.RaftElectionTimeout(s.cfg.RaftTickInterval, s.cfg.RaftElectionTimeoutTicks))
+
 	// TODO(bdarnell): make StoreConfig configurable.
 	storeCfg := storage.StoreConfig{
 		AmbientCtx:                     s.cfg.AmbientCtx,
@@ -354,8 +358,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 			LeaseManager: s.leaseMgr,
 		},
 		LogRangeEvents:            s.cfg.EventLogEnabled,
-		RangeLeaseActiveDuration:  active,
-		RangeLeaseRenewalDuration: renewal,
+		RangeLeaseActiveDuration:  rlActive,
+		RangeLeaseRenewalDuration: rlRenewal,
 		TimeSeriesDataStore:       s.tsDB,
 
 		EnableEpochRangeLeases: true,

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -79,11 +79,11 @@ const (
 
 	// rangeLeaseRaftElectionTimeoutMultiplier specifies what multiple the leader
 	// lease active duration should be of the raft election timeout.
-	rangeLeaseRaftElectionTimeoutMultiplier = 3
+	rangeLeaseRaftElectionTimeoutMultiplier = 1.5
 
 	// rangeLeaseRenewalFraction specifies what fraction the range lease renewal
 	// duration should be of the range lease active time.
-	rangeLeaseRenewalFraction = 0.8
+	rangeLeaseRenewalFraction = 0.5
 
 	// livenessRenewalFraction specifies what fraction the node liveness renewal
 	// duration should be of the node liveness duration.
@@ -142,8 +142,8 @@ func RaftElectionTimeout(
 func RangeLeaseDurations(
 	raftElectionTimeout time.Duration,
 ) (rangeLeaseActive time.Duration, rangeLeaseRenewal time.Duration) {
-	rangeLeaseActive = rangeLeaseRaftElectionTimeoutMultiplier * raftElectionTimeout
-	rangeLeaseRenewal = time.Duration(float64(rangeLeaseActive) * (1 - rangeLeaseRenewalFraction))
+	rangeLeaseActive = time.Duration(rangeLeaseRaftElectionTimeoutMultiplier * float64(raftElectionTimeout))
+	rangeLeaseRenewal = time.Duration(float64(rangeLeaseActive) * rangeLeaseRenewalFraction)
 	return
 }
 


### PR DESCRIPTION
Fixed what looks like an inconsistency in how we were computing range lease
renewal expirations, as well as the fact that we weren't specifically using
the range lease durations for range leases, but rather the node liveness
active / renewal values.