### PR TITLE
build: fix build on FreeBSD

### DIFF
--- a/pkg/cli/start_jemalloc.go
+++ b/pkg/cli/start_jemalloc.go
@@ -20,6 +20,7 @@ package cli
 
 // #cgo CPPFLAGS: -DJEMALLOC_NO_DEMANGLE
 // #cgo LDFLAGS: -ljemalloc
+// #cgo dragonfly freebsd LDFLAGS: -lm
 // #cgo linux LDFLAGS: -lrt -lm -lpthread
 //
 // #include <jemalloc/jemalloc.h>

--- a/pkg/server/rlimit_bsd.go
+++ b/pkg/server/rlimit_bsd.go
@@ -1,0 +1,47 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build freebsd dragonfly
+
+package server
+
+import (
+	"math"
+
+	"golang.org/x/sys/unix"
+)
+
+func setRlimitNoFile(limits *rlimit) error {
+	rLimit := unix.Rlimit{Cur: int64(limits.Cur), Max: int64(limits.Max)}
+	return unix.Setrlimit(unix.RLIMIT_NOFILE, &rLimit)
+}
+
+func getRlimitNoFile(limits *rlimit) error {
+	var rLimit unix.Rlimit
+	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &rLimit); err != nil {
+		return err
+	}
+	// Some (legacy?) FreeBSD platforms had RLIMIT_INFINITY set to -1.
+	if rLimit.Cur == -1 {
+		limits.Cur = math.MaxUint64
+	} else {
+		limits.Cur = uint64(rLimit.Cur)
+	}
+	if rLimit.Max == -1 {
+		limits.Max = math.MaxUint64
+	} else {
+		limits.Max = uint64(rLimit.Max)
+	}
+	return nil
+}

--- a/pkg/server/rlimit_unix.go
+++ b/pkg/server/rlimit_unix.go
@@ -1,0 +1,27 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build !windows,!freebsd,!dragonfly
+
+package server
+
+import "golang.org/x/sys/unix"
+
+func setRlimitNoFile(limits *rlimit) error {
+	return unix.Setrlimit(unix.RLIMIT_NOFILE, (*unix.Rlimit)(limits))
+}
+
+func getRlimitNoFile(limits *rlimit) error {
+	return unix.Getrlimit(unix.RLIMIT_NOFILE, (*unix.Rlimit)(limits))
+}

--- a/pkg/server/status/runtime_jemalloc.go
+++ b/pkg/server/status/runtime_jemalloc.go
@@ -26,6 +26,7 @@ package status
 // // elsewhere, causing the linker to omit the file's symbols.
 // // Manually force the presence of these symbols on macOS.
 // #cgo darwin LDFLAGS: -u_je_zone_register
+// #cgo dragonfly freebsd LDFLAGS: -lm
 // #cgo linux LDFLAGS: -lrt -lm -lpthread
 //
 // #include <jemalloc/jemalloc.h>


### PR DESCRIPTION
On FreeBSD, rlimit values are signed.

Build was failing due to comparison/assignment between mixed
signed and unsigned types. Forced conversion to the appropriate
type to get build to succeed.

Also added missing -lm.

Supersedes #13809.
