### PR TITLE
server: change updates url to match what server wants

### DIFF
--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -41,7 +41,7 @@ import (
 )
 
 const baseUpdatesURL = `https://register.cockroachdb.com/api/clusters/updates`
-const baseReportingURL = `https://register.cockroachdb.com/api/report`
+const baseReportingURL = `https://register.cockroachdb.com/api/clusters/report`
 
 var updatesURL, reportingURL *url.URL
 


### PR DESCRIPTION
Our tests helpfully override the URL in order to test it, and thus missed this.

Fixes #15334.