### PR TITLE
sql: enable running some statements after a schema change

### DIFF
--- a/pkg/sql/parser/stmt.go
+++ b/pkg/sql/parser/stmt.go
@@ -87,6 +87,13 @@ type IndependentFromParallelizedPriors interface {
 	independentFromParallelizedPriors()
 }
 
+// ValidAfterSchemaUpdateStatement is a pseudo-interface to be implemented by
+// statements which do not risk conflicting with an earlier schema change
+// operation issued previously within the same transaction.
+type ValidAfterSchemaUpdateStatement interface {
+	validAfterSchemaUpdateStatement()
+}
+
 // StatementType implements the Statement interface.
 func (*AlterTable) StatementType() StatementType { return DDL }
 
@@ -107,6 +114,8 @@ func (*BeginTransaction) StatementTag() string { return "BEGIN" }
 
 func (*BeginTransaction) hiddenFromStats() {}
 
+func (*BeginTransaction) validAfterSchemaUpdateStatement() {}
+
 // StatementType implements the Statement interface.
 func (*CommitTransaction) StatementType() StatementType { return Ack }
 
@@ -114,6 +123,8 @@ func (*CommitTransaction) StatementType() StatementType { return Ack }
 func (*CommitTransaction) StatementTag() string { return "COMMIT" }
 
 func (*CommitTransaction) hiddenFromStats() {}
+
+func (*CommitTransaction) validAfterSchemaUpdateStatement() {}
 
 // StatementType implements the Statement interface.
 func (*CopyFrom) StatementType() StatementType { return CopyIn }
@@ -150,6 +161,8 @@ func (*CreateUser) StatementType() StatementType { return Ack }
 // StatementTag returns a short string identifying the type of statement.
 func (*CreateUser) StatementTag() string { return "CREATE USER" }
 
+func (*CreateUser) validAfterSchemaUpdateStatement() {}
+
 // StatementType implements the Statement interface.
 func (*CreateView) StatementType() StatementType { return DDL }
 
@@ -169,6 +182,8 @@ func (n *Deallocate) StatementTag() string {
 }
 
 func (*Deallocate) hiddenFromStats() {}
+
+func (*Deallocate) validAfterSchemaUpdateStatement() {}
 
 // StatementType implements the Statement interface.
 func (n *Delete) StatementType() StatementType { return n.Returning.statementType() }
@@ -214,6 +229,8 @@ func (*Explain) StatementTag() string { return "EXPLAIN" }
 
 func (*Explain) hiddenFromStats() {}
 
+func (*Explain) validAfterSchemaUpdateStatement() {}
+
 // StatementType implements the Statement interface.
 func (*Grant) StatementType() StatementType { return DDL }
 
@@ -221,6 +238,8 @@ func (*Grant) StatementType() StatementType { return DDL }
 func (*Grant) StatementTag() string { return "GRANT" }
 
 func (*Grant) hiddenFromStats() {}
+
+func (*Grant) validAfterSchemaUpdateStatement() {}
 
 // StatementType implements the Statement interface.
 func (n *Insert) StatementType() StatementType { return n.Returning.statementType() }
@@ -242,6 +261,8 @@ func (*Prepare) StatementTag() string { return "PREPARE" }
 
 func (*Prepare) hiddenFromStats() {}
 
+func (*Prepare) validAfterSchemaUpdateStatement() {}
+
 // StatementType implements the Statement interface.
 func (*ReleaseSavepoint) StatementType() StatementType { return Ack }
 
@@ -249,6 +270,8 @@ func (*ReleaseSavepoint) StatementType() StatementType { return Ack }
 func (*ReleaseSavepoint) StatementTag() string { return "RELEASE" }
 
 func (*ReleaseSavepoint) hiddenFromStats() {}
+
+func (*ReleaseSavepoint) validAfterSchemaUpdateStatement() {}
 
 // StatementType implements the Statement interface.
 func (*RenameColumn) StatementType() StatementType { return DDL }
@@ -299,6 +322,8 @@ func (*Revoke) StatementTag() string { return "REVOKE" }
 
 func (*Revoke) hiddenFromStats() {}
 
+func (*Revoke) validAfterSchemaUpdateStatement() {}
+
 // StatementType implements the Statement interface.
 func (*RollbackToSavepoint) StatementType() StatementType { return Ack }
 
@@ -307,6 +332,8 @@ func (*RollbackToSavepoint) StatementTag() string { return "ROLLBACK" }
 
 func (*RollbackToSavepoint) hiddenFromStats() {}
 
+func (*RollbackToSavepoint) validAfterSchemaUpdateStatement() {}
+
 // StatementType implements the Statement interface.
 func (*RollbackTransaction) StatementType() StatementType { return Ack }
 
@@ -314,6 +341,8 @@ func (*RollbackTransaction) StatementType() StatementType { return Ack }
 func (*RollbackTransaction) StatementTag() string { return "ROLLBACK" }
 
 func (*RollbackTransaction) hiddenFromStats() {}
+
+func (*RollbackTransaction) validAfterSchemaUpdateStatement() {}
 
 // StatementType implements the Statement interface.
 func (*Savepoint) StatementType() StatementType { return Ack }
@@ -347,6 +376,8 @@ func (*Set) StatementTag() string { return "SET" }
 
 func (*Set) hiddenFromStats() {}
 
+func (*Set) validAfterSchemaUpdateStatement() {}
+
 // StatementType implements the Statement interface.
 func (*SetTransaction) StatementType() StatementType { return Ack }
 
@@ -363,6 +394,8 @@ func (*SetTimeZone) StatementTag() string { return "SET TIME ZONE" }
 
 func (*SetTimeZone) hiddenFromStats() {}
 
+func (*SetTimeZone) validAfterSchemaUpdateStatement() {}
+
 // StatementType implements the Statement interface.
 func (*SetDefaultIsolation) StatementType() StatementType { return Ack }
 
@@ -370,6 +403,8 @@ func (*SetDefaultIsolation) StatementType() StatementType { return Ack }
 func (*SetDefaultIsolation) StatementTag() string { return "SET" }
 
 func (*SetDefaultIsolation) hiddenFromStats() {}
+
+func (*SetDefaultIsolation) validAfterSchemaUpdateStatement() {}
 
 // StatementType implements the Statement interface.
 func (*Show) StatementType() StatementType { return Rows }
@@ -379,6 +414,8 @@ func (*Show) StatementTag() string { return "SHOW" }
 
 func (*Show) hiddenFromStats()                   {}
 func (*Show) independentFromParallelizedPriors() {}
+
+func (*Show) validAfterSchemaUpdateStatement() {}
 
 // StatementType implements the Statement interface.
 func (*ShowColumns) StatementType() StatementType { return Rows }
@@ -425,6 +462,8 @@ func (*ShowGrants) StatementTag() string { return "SHOW GRANTS" }
 func (*ShowGrants) hiddenFromStats()                   {}
 func (*ShowGrants) independentFromParallelizedPriors() {}
 
+func (*ShowGrants) validAfterSchemaUpdateStatement() {}
+
 // StatementType implements the Statement interface.
 func (*ShowIndex) StatementType() StatementType { return Rows }
 
@@ -443,6 +482,8 @@ func (*ShowTransactionStatus) StatementTag() string { return "SHOW TRANSACTION S
 func (*ShowTransactionStatus) hiddenFromStats()                   {}
 func (*ShowTransactionStatus) independentFromParallelizedPriors() {}
 
+func (*ShowTransactionStatus) validAfterSchemaUpdateStatement() {}
+
 // StatementType implements the Statement interface.
 func (*ShowUsers) StatementType() StatementType { return Rows }
 
@@ -451,6 +492,8 @@ func (*ShowUsers) StatementTag() string { return "SHOW USERS" }
 
 func (*ShowUsers) hiddenFromStats()                   {}
 func (*ShowUsers) independentFromParallelizedPriors() {}
+
+func (*ShowUsers) validAfterSchemaUpdateStatement() {}
 
 // StatementType implements the Statement interface.
 func (*ShowRanges) StatementType() StatementType { return Rows }
@@ -468,6 +511,8 @@ func (*Help) StatementTag() string { return "HELP" }
 
 func (*Help) hiddenFromStats()                   {}
 func (*Help) independentFromParallelizedPriors() {}
+
+func (*Help) validAfterSchemaUpdateStatement() {}
 
 // StatementType implements the Statement interface.
 func (*ShowConstraints) StatementType() StatementType { return Rows }


### PR DESCRIPTION
Prior to this patch the Executor would always abort the transaction
with an error if a statement was issued after some previous statement
caused a schema change.

This was very restrictive, and yielded poor UX in the CLI where the
shell issues SHOW statements in-between lines of input to populate the
prompt.

This patch alleviates the issue by ensuring that "safe" statements
(SET, SHOW, etc) can still be issued even once a schema change has
launched.

Fixes #15283.