### PR TITLE
sql: check DEFAULT expressions in schema changes earlier.

### DIFF
--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -538,7 +538,7 @@ INSERT INTO t (i) VALUES
 	const want2 = `dump d t
 CREATE TABLE t (
 	i INT NULL,
-	j INT NULL DEFAULT 2,
+	j INT NULL DEFAULT 2:::INT,
 	FAMILY "primary" (i, rowid, j)
 );
 

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -452,9 +452,9 @@ func TestAdminAPITableDetails(t *testing.T) {
 			// Verify columns.
 			expColumns := []serverpb.TableDetailsResponse_Column{
 				{Name: "nulls_allowed", Type: "INT", Nullable: true, DefaultValue: ""},
-				{Name: "nulls_not_allowed", Type: "INT", Nullable: false, DefaultValue: "1000"},
-				{Name: "default2", Type: "INT", Nullable: true, DefaultValue: "2"},
-				{Name: "string_default", Type: "STRING", Nullable: true, DefaultValue: "'default_string'"},
+				{Name: "nulls_not_allowed", Type: "INT", Nullable: false, DefaultValue: "1000:::INT"},
+				{Name: "default2", Type: "INT", Nullable: true, DefaultValue: "2:::INT"},
+				{Name: "string_default", Type: "STRING", Nullable: true, DefaultValue: "'default_string':::STRING"},
 			}
 			testutils.SortStructs(expColumns, "Name")
 			testutils.SortStructs(resp.Columns, "Name")

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -80,7 +80,7 @@ func (n *alterTableNode) Start(ctx context.Context) error {
 			if d.HasFKConstraint() {
 				return errors.Errorf("adding a REFERENCES constraint via ALTER not supported")
 			}
-			col, idx, err := sqlbase.MakeColumnDefDescs(d, n.p.session.SearchPath)
+			col, idx, err := sqlbase.MakeColumnDefDescs(d, n.p.session.SearchPath, &n.p.evalCtx)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -72,7 +72,7 @@ func SanitizeVarFreeExpr(
 // index descriptor if the column is a primary key or unique.
 // The search path is used for name resolution for DEFAULT expressions.
 func MakeColumnDefDescs(
-	d *parser.ColumnTableDef, searchPath parser.SearchPath,
+	d *parser.ColumnTableDef, searchPath parser.SearchPath, evalCtx *parser.EvalContext,
 ) (*ColumnDescriptor, *IndexDescriptor, error) {
 	col := &ColumnDescriptor{
 		Name:     string(d.Name),
@@ -171,6 +171,24 @@ func MakeColumnDefDescs(
 		); err != nil {
 			return nil, nil, err
 		}
+
+		// Type check and simplify: this performs constant folding and reduces the expression.
+		typedExpr, err := parser.TypeCheck(d.DefaultExpr.Expr, nil, col.Type.ToDatumType())
+		if err != nil {
+			return nil, nil, err
+		}
+		if typedExpr, err = p.NormalizeExpr(evalCtx, typedExpr); err != nil {
+			return nil, nil, err
+		}
+		// Try to evaluate once. If it is aimed to succeed during a
+		// backfill, it must succeed here too. This tries to ensure that
+		// we don't end up failing the evaluation during the schema change
+		// proper.
+		if _, err := typedExpr.Eval(evalCtx); err != nil {
+			return nil, nil, err
+		}
+		d.DefaultExpr.Expr = typedExpr
+
 		s := parser.Serialize(d.DefaultExpr.Expr)
 		col.DefaultExpr = &s
 	}

--- a/pkg/sql/table_test.go
+++ b/pkg/sql/table_test.go
@@ -46,6 +46,7 @@ func CreateTestTableDescriptor(
 		return sqlbase.TableDescriptor{}, err
 	}
 	p := planner{session: new(Session)}
+	p.evalCtx = parser.MakeTestingEvalContext()
 	return p.makeTableDesc(ctx, stmt.(*parser.CreateTable), parentID, id, privileges, nil)
 }
 

--- a/pkg/sql/testdata/logic_test/alter_table
+++ b/pkg/sql/testdata/logic_test/alter_table
@@ -384,12 +384,12 @@ ALTER TABLE tt ADD t DECIMAL UNIQUE DEFAULT 4.0
 query TTBTT colnames
 SHOW COLUMNS FROM tt
 ----
-Field  Type     Null   Default Indices
-a      INT      false  NULL    {primary,tt_s_key,tt_t_key}
-q      DECIMAL  false  NULL    {}
-r      DECIMAL  true   NULL    {}
-s      DECIMAL  false  NULL    {tt_s_key}
-t      DECIMAL  true   4.0     {tt_t_key}
+Field  Type     Null   Default       Indices
+a      INT      false  NULL          {primary,tt_s_key,tt_t_key}
+q      DECIMAL  false  NULL          {}
+r      DECIMAL  true   NULL          {}
+s      DECIMAL  false  NULL          {tt_s_key}
+t      DECIMAL  true   4.0:::DECIMAL {tt_t_key}
 
 # Default values can be added and changed after table creation.
 statement ok

--- a/pkg/sql/testdata/logic_test/default
+++ b/pkg/sql/testdata/logic_test/default
@@ -35,7 +35,7 @@ query TTBTT colnames
 SHOW COLUMNS FROM t
 ----
 Field Type      Null  Default  Indices
-a     INT       false 42       {primary}
+a     INT       false 42:::INT {primary}
 b     TIMESTAMP true  now()    {}
 c     FLOAT     true  random() {}
 

--- a/pkg/sql/testdata/logic_test/information_schema
+++ b/pkg/sql/testdata/logic_test/information_schema
@@ -120,24 +120,24 @@ views
 query TT colnames
 SHOW CREATE TABLE information_schema.tables
 ----
-    Table                      CreateTable
-    information_schema.tables  CREATE TABLE tables (
-                               table_catalog STRING NOT NULL DEFAULT '',
-                               table_schema STRING NOT NULL DEFAULT '',
-                               table_name STRING NOT NULL DEFAULT '',
-                               table_type STRING NOT NULL DEFAULT '',
-                               version INT NULL
+Table                      CreateTable
+information_schema.tables  CREATE TABLE tables (
+                           table_catalog STRING NOT NULL DEFAULT '':::STRING,
+                           table_schema STRING NOT NULL DEFAULT '':::STRING,
+                           table_name STRING NOT NULL DEFAULT '':::STRING,
+                           table_type STRING NOT NULL DEFAULT '':::STRING,
+                           version INT NULL
 )
 
 query TTBTT colnames
 SHOW COLUMNS FROM information_schema.tables
 ----
-Field          Type    Null   Default  Indices
-table_catalog  STRING  false  ''       {}
-table_schema   STRING  false  ''       {}
-table_name     STRING  false  ''       {}
-table_type     STRING  false  ''       {}
-version        INT     true   NULL     {}
+Field            Type       Null   Default     Indices
+table_catalog    STRING     false  '':::STRING {}
+table_schema     STRING     false  '':::STRING {}
+table_name       STRING     false  '':::STRING {}
+table_type       STRING     false  '':::STRING {}
+version          INT        true   NULL        {}
 
 query TTBITTBB colnames
 SHOW INDEXES FROM information_schema.tables
@@ -578,8 +578,8 @@ FROM information_schema.columns
 WHERE table_schema = 'test' AND table_name = 'with_defaults'
 ----
 table_name     column_name  column_default
-with_defaults  a            9
-with_defaults  b            'default'
+with_defaults  a            9:::INT
+with_defaults  b            'default':::STRING
 with_defaults  c            NULL
 with_defaults  d            NULL
 

--- a/pkg/sql/testdata/logic_test/pg_catalog
+++ b/pkg/sql/testdata/logic_test/pg_catalog
@@ -404,9 +404,9 @@ JOIN pg_catalog.pg_class c ON ad.adrelid = c.oid
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'constraint_db'
 ----
-oid         relname  adrelid     adnum  adbin  adsrc
-2737381215  t1       2876473678  4      12     12
-2989572986  t3       3211628798  3      'FOO'  'FOO'
+oid         relname  adrelid     adnum  adbin          adsrc
+2737381215  t1       2876473678  4      12:::INT       12:::INT
+2989572986  t3       3211628798  3      'FOO':::STRING 'FOO':::STRING
 
 ## pg_catalog.pg_indexes
 
@@ -1015,8 +1015,8 @@ JOIN pg_catalog.pg_class c ON def.adrelid = c.oid
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'constraint_db'
 ----
-2737381215  t1  12
-2989572986  t3  'FOO'
+2737381215  t1  12:::INT
+2989572986  t3  'FOO':::STRING
 
 # Verify that a set database shows tables from that database for a non-root
 # user, when that user has permissions.

--- a/pkg/sql/testdata/logic_test/table
+++ b/pkg/sql/testdata/logic_test/table
@@ -245,10 +245,10 @@ CREATE TABLE test.named_constraints (
 query TT
 SHOW CREATE TABLE test.named_constraints
 ----
-    test.named_constraints  CREATE TABLE named_constraints (
+test.named_constraints  CREATE TABLE named_constraints (
                             id INT NOT NULL,
                             name STRING NOT NULL,
-                            title STRING NULL DEFAULT 'VP of Something',
+                            title STRING NULL DEFAULT 'VP of Something':::STRING,
                             nickname STRING NULL,
                             username STRING(10) NULL,
                             email STRING(100) NULL,


### PR DESCRIPTION
Prior to this patch, a new DEFAULT expression would only be checked
after the schema change has started, which is typically at the end of
the schema change transaction. An error, if any, would not be reported
immediately upon issuing the ALTER (or CREATE) statement.

This patch improves upon this situation by adding another check
upfront, when the mutation descriptor is initially created.
Note that this check is not sufficient to guarantee the DEFAULT
expression is valid however (i.e. it may have false negatives),
because impure functions can cause the expression to become invalid
non-deterministically (e.g. `1 / (10*(random() - 1))::int`).