### PR TITLE
roachpb: Don't print replica IDs as r%d

### DIFF
--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -188,7 +188,7 @@ func (r RangeDescriptor) String() string {
 			if i > 0 {
 				buf.WriteString(", ")
 			}
-			fmt.Fprintf(&buf, "r%d(n%d,s%d)", rep.ReplicaID, rep.NodeID, rep.StoreID)
+			fmt.Fprintf(&buf, "(n%d,s%d):%d", rep.NodeID, rep.StoreID, rep.ReplicaID)
 		}
 	} else {
 		buf.WriteString("<no replicas>")


### PR DESCRIPTION
It breaks grepping through logs for everything about a range by adding
false hits.

I don't care too much about what we replace it with. If you'd prefer something else, let the bikeshedding begin.