### PR TITLE
grpcutil: fix broken debouncing logic

### DIFF
--- a/build/tool_imports.go
+++ b/build/tool_imports.go
@@ -43,6 +43,11 @@ import (
 	_ "github.com/wadey/gocovmerge"
 	_ "golang.org/x/tools/cmd/goimports"
 	_ "golang.org/x/tools/cmd/goyacc"
-	_ "golang.org/x/tools/cmd/guru"
 	_ "golang.org/x/tools/cmd/stringer"
+
+	// These dev-only tools would not normally be included in this list, but
+	// they happen to live in the same repository as tools used in CI. We
+	// include them here for the sake of reducing necessary $GOPATH pollution.
+	_ "golang.org/x/tools/cmd/gorename"
+	_ "golang.org/x/tools/cmd/guru"
 )

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 04cc0a18094bdfa1396e60ffa89c8dac83d14844245254335c81bcb3afb6ca01
-updated: 2017-04-25T13:31:41.976821966-04:00
+updated: 2017-04-26T11:05:45.889099956-04:00
 imports:
 - name: cloud.google.com/go
   version: ed63fb27efcf32e25fe7837e4662457d3da4c4f2
@@ -288,7 +288,7 @@ imports:
   - syntax
   - syntax/golang
 - name: github.com/Microsoft/go-winio
-  version: fff283ad5116362ca252298cfc9b95828956d85d
+  version: f3b1913901892ada21d52d0cffe1d4c7080d36b7
 - name: github.com/mitchellh/go-homedir
   version: b8bc1bf767474819792c23f32d8286a45736f1c6
 - name: github.com/mitchellh/reflectwalk
@@ -406,9 +406,10 @@ imports:
   subpackages:
   - rate
 - name: golang.org/x/tools
-  version: 75e5ff36f363f6a84a3dce209446774ff2d13076
+  version: 1b22574ddb1f9559c014d7aa13416bd6f4aba26b
   subpackages:
   - cmd/goimports
+  - cmd/gorename
   - cmd/goyacc
   - cmd/guru
   - cmd/guru/serial
@@ -428,6 +429,8 @@ imports:
   - go/types/typeutil
   - imports
   - refactor/importgraph
+  - refactor/rename
+  - refactor/satisfy
 - name: google.golang.org/api
   version: fbbaff1827317122a8a0e1b24de25df8417ce87b
   subpackages:
@@ -496,6 +499,6 @@ testImports:
 - name: github.com/ghemawat/stream
   version: 78e682abcae4f96ac7ddbe39912967a5f7cbbaa6
 - name: github.com/go-sql-driver/mysql
-  version: 9dee4ca50b83acdf57a35fb9e6fb4be640afa2f3
+  version: 15dbaaedd46b79251eaa9c8ed5f280d28978bb3f
 - name: github.com/termie/go-shutil
   version: bcacb06fecaeec8dc42af03c87c6949f4a05c74c

--- a/pkg/util/grpcutil/log_test.go
+++ b/pkg/util/grpcutil/log_test.go
@@ -1,0 +1,82 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package grpcutil
+
+import (
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+)
+
+func TestShouldPrint(t *testing.T) {
+	const duration = 10 * time.Millisecond
+
+	formatRe, err := regexp.Compile("^foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	argRe, err := regexp.Compile("[a-z][0-9]")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		format      string
+		args        []interface{}
+		alwaysPrint bool
+	}{
+		// format: no match, args: no match
+		{format: "bar=%s", args: []interface{}{errors.New("baz")}, alwaysPrint: true},
+		// format: match, args: no match
+		{format: "foobar=%s", args: []interface{}{errors.New("baz")}, alwaysPrint: true},
+		// format: no match, args: match
+		{format: "bar=%s", args: []interface{}{errors.New("a1")}, alwaysPrint: true},
+		// format: match, args: match
+		{format: "foobar=%s", args: []interface{}{errors.New("a1")}, alwaysPrint: false},
+	} {
+		curriedShouldPrint := func() bool {
+			return shouldPrint(formatRe, argRe, duration, tc.format, tc.args...)
+		}
+
+		// First call should always print.
+		if !curriedShouldPrint() {
+			t.Errorf("expected first call to print: %v", tc)
+		}
+
+		// Call from another goroutine should always print.
+		done := make(chan bool)
+		go func() {
+			done <- curriedShouldPrint()
+		}()
+		if !<-done {
+			t.Errorf("expected other-goroutine call to print: %v", tc)
+		}
+
+		// Should print if non-matching.
+		if didPrint := curriedShouldPrint(); didPrint != tc.alwaysPrint {
+			t.Errorf("expected second call print=%t, got print=%t: %v", tc.alwaysPrint, didPrint, tc)
+		}
+
+		// Should print after sleep.
+		if !tc.alwaysPrint {
+			time.Sleep(duration)
+		}
+		if !curriedShouldPrint() {
+			t.Errorf("expected third call to print: %v", tc)
+		}
+	}
+}


### PR DESCRIPTION
Avoid `defer` and anonymous function and just lock multiple times.
This is safe because each key is only ever used by one goroutine.