### PR TITLE
storage: re-enable TestReplicateQueueRebalance

### DIFF
--- a/pkg/storage/replicate_queue_test.go
+++ b/pkg/storage/replicate_queue_test.go
@@ -39,7 +39,6 @@ import (
 
 func TestReplicateQueueRebalance(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#13885")
 
 	if testing.Short() {
 		t.Skip("short flag")


### PR DESCRIPTION
Re-enable this test as I was unable to reproduce the failure.

Fixes #13885.

I've run this under stress and stressrace and both failed to reproduce this failure.