### PR TITLE
roachpb,storage: Remove the IsNonKV flag

### DIFF
--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -78,11 +78,6 @@ const (
 	isRange                // range commands may span multiple keys
 	isReverse              // reverse commands traverse ranges in descending direction
 	isAlone                // requests which must be alone in a batch
-	// Some commands can skip interacting with the command queue and the timestamp
-	// cache. For example, RequestLeaseRequest is sequenced exclusively by Raft.
-	// These requests still have keys in their header, but those keys are used
-	// exclusively for routing the request to the right range.
-	isNonKV
 	// Requests for acquiring a lease skip the (proposal-time) check that the
 	// proposing replica has a valid lease.
 	skipLeaseCheck
@@ -900,20 +895,16 @@ func (*RangeLookupRequest) flags() int         { return isRead }
 func (*ResolveIntentRequest) flags() int       { return isWrite }
 func (*ResolveIntentRangeRequest) flags() int  { return isWrite | isRange }
 func (*NoopRequest) flags() int                { return isRead } // slightly special
-func (*TruncateLogRequest) flags() int         { return isWrite | isNonKV }
-
-// MergeRequests are considered "non KV" because they do not need to be gated
-// by the command queue (reordering is ok) and they operate on non-MVCC data so
-// the timestamp cache is also unnecessary.
-func (*MergeRequest) flags() int { return isWrite | isNonKV }
+func (*TruncateLogRequest) flags() int         { return isWrite }
+func (*MergeRequest) flags() int               { return isWrite }
 
 func (*RequestLeaseRequest) flags() int {
-	return isWrite | isAlone | isNonKV | skipLeaseCheck
+	return isWrite | isAlone | skipLeaseCheck
 }
 
 // LeaseInfoRequest is usually executed in an INCONSISTENT batch, which has the
 // effect of the `skipLeaseCheck` flag that lease write operations have.
-func (*LeaseInfoRequest) flags() int { return isRead | isNonKV | isAlone }
+func (*LeaseInfoRequest) flags() int { return isRead | isAlone }
 func (*TransferLeaseRequest) flags() int {
 	// TODO(andrei): update this comment.
 	// TransferLeaseRequest requires the lease, which is checked in
@@ -924,9 +915,9 @@ func (*TransferLeaseRequest) flags() int {
 	// replica has registered that a transfer is in progress and
 	// `redirectOnOrAcquireLease` already tentatively redirects to the
 	// future lease holder.
-	return isWrite | isAlone | isNonKV | skipLeaseCheck
+	return isWrite | isAlone | skipLeaseCheck
 }
-func (*ComputeChecksumRequest) flags() int          { return isWrite | isNonKV | isRange }
+func (*ComputeChecksumRequest) flags() int          { return isWrite | isRange }
 func (*DeprecatedVerifyChecksumRequest) flags() int { return isWrite }
 func (*CheckConsistencyRequest) flags() int         { return isAdmin | isRange }
 func (*WriteBatchRequest) flags() int               { return isWrite | isRange }

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -115,17 +115,6 @@ func (ba *BatchRequest) IsSingleRequest() bool {
 	return len(ba.Requests) == 1
 }
 
-// IsNonKV returns true iff all of the requests in the batch have the non-KV
-// flag set.
-func (ba *BatchRequest) IsNonKV() bool {
-	for _, union := range ba.Requests {
-		if (union.GetInner().flags() & isNonKV) == 0 {
-			return false
-		}
-	}
-	return true
-}
-
 // IsSingleSkipLeaseCheckRequest returns true iff the batch contains a single
 // request, and that request has the skipLeaseCheck flag set.
 func (ba *BatchRequest) IsSingleSkipLeaseCheckRequest() bool {


### PR DESCRIPTION
With the move to propEvalKV, the command queue is critical for correct
operation and all commands, even non-KV ones, need to go through it.
The original motivation for this flag (in #8130) was that non-KV
commands were inappropriately synchronizing on the start key of their
range; this is no longer true with the move to per-command DeclareKeys
functions.

This is expected to reduce Merge (timeseries) performance somewhat
because it reverts #9889.

Fixes #15003