### PR TITLE
sql: new built-in force_internal_error for debugging purposes

### DIFF
--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -1521,6 +1522,36 @@ var Builtins = map[string][]Builtin{
 				return schemas, nil
 			},
 			Info: "Returns the current search path for unqualified names.",
+		},
+	},
+
+	"crdb_internal.force_internal_error": {
+		Builtin{
+			Types:      ArgTypes{{"msg", TypeString}},
+			ReturnType: fixedReturnType(TypeInt),
+			impure:     true,
+			privileged: true,
+			fn: func(ctx *EvalContext, args Datums) (Datum, error) {
+				msg := string(*args[0].(*DString))
+				return nil, pgerror.NewError(pgerror.CodeInternalError, msg)
+			},
+			category: categorySystemInfo,
+			Info:     "This function is used only by CockroachDB's developers for testing purposes.",
+		},
+	},
+
+	"crdb_internal.force_panic": {
+		Builtin{
+			Types:      ArgTypes{{"msg", TypeString}},
+			ReturnType: fixedReturnType(TypeInt),
+			impure:     true,
+			privileged: true,
+			fn: func(ctx *EvalContext, args Datums) (Datum, error) {
+				msg := string(*args[0].(*DString))
+				panic(msg)
+			},
+			category: categorySystemInfo,
+			Info:     "This function is used only by CockroachDB's developers for testing purposes.",
 		},
 	},
 

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -113,6 +113,9 @@ type Builtin struct {
 	// variables. Used e.g. by `random` and aggregate functions.
 	needsRepeatedEvaluation bool
 
+	// Set to true when the built-in can only be used by security.RootUser.
+	privileged bool
+
 	class    FunctionClass
 	category string
 
@@ -1526,6 +1529,7 @@ var Builtins = map[string][]Builtin{
 			Types:      ArgTypes{{"val", TypeInterval}},
 			ReturnType: fixedReturnType(TypeInt),
 			impure:     true,
+			privileged: true,
 			fn: func(ctx *EvalContext, args Datums) (Datum, error) {
 				minDuration := args[0].(*DInterval).Duration
 				elapsed := duration.Duration{

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -226,6 +226,8 @@ func init() {
 	}
 }
 
+var digitNames = []string{"zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"}
+
 // Builtins contains the built-in functions indexed by name.
 var Builtins = map[string][]Builtin{
 	// Keep the list of functions sorted.
@@ -1363,6 +1365,35 @@ var Builtins = map[string][]Builtin{
 		}, "Truncates the decimal values of `val`."),
 	},
 
+	"to_english": {
+		Builtin{
+			Types:      ArgTypes{{"val", TypeInt}},
+			ReturnType: fixedReturnType(TypeString),
+			fn: func(_ *EvalContext, args Datums) (Datum, error) {
+				val := int(*args[0].(*DInt))
+				var buf bytes.Buffer
+				if val < 0 {
+					buf.WriteString("minus-")
+				}
+				var digits []string
+				digits = append(digits, digitNames[val%10])
+				for val > 9 {
+					val /= 10
+					digits = append(digits, digitNames[val%10])
+				}
+				for i := len(digits) - 1; i >= 0; i-- {
+					if i < len(digits)-1 {
+						buf.WriteByte('-')
+					}
+					buf.WriteString(digits[i])
+				}
+				return NewDString(buf.String()), nil
+			},
+			category: categoryString,
+			Info:     "This function enunciates the value of its argument using English cardinals.",
+		},
+	},
+
 	// Array functions.
 
 	"array_length": {
@@ -1531,34 +1562,6 @@ var Builtins = map[string][]Builtin{
 			},
 			category: categorySystemInfo,
 			Info:     "This function is used only by CockroachDB's developers for testing purposes.",
-		},
-	},
-
-	// A function used to generate strings for test tables. It takes an integer
-	// and returns a string: 1234 -> "one-two-three-four"
-	"crdb_testing.to_english": {
-		Builtin{
-			Types:      ArgTypes{{"val", TypeInt}},
-			ReturnType: fixedReturnType(TypeString),
-			fn: func(_ *EvalContext, args Datums) (Datum, error) {
-				val := int(*args[0].(*DInt))
-				if val < 0 {
-					return nil, errors.New("negative value")
-				}
-				d := []string{"zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"}
-				var digits []string
-				digits = append(digits, d[val%10])
-				for val > 9 {
-					val /= 10
-					digits = append(digits, d[val%10])
-				}
-				for i, j := 0, len(digits)-1; i < j; i, j = i+1, j-1 {
-					digits[i], digits[j] = digits[j], digits[i]
-				}
-				return NewDString(strings.Join(digits, "-")), nil
-			},
-			category: categoryString,
-			Info:     "Returns an English string derived from a number.",
 		},
 	},
 }

--- a/pkg/sql/parser/overload_test.go
+++ b/pkg/sql/parser/overload_test.go
@@ -166,7 +166,7 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 		{nil, TypeDate, []Expr{decConst("1.0"), NewPlaceholder("b")}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntDateFn},
 	}
 	for i, d := range testData {
-		ctx := MakeSemaContext()
+		ctx := MakeSemaContext(false)
 		ctx.Placeholders.SetTypes(d.ptypes)
 		desired := TypeAny
 		if d.desired != nil {

--- a/pkg/sql/parser/type_check_test.go
+++ b/pkg/sql/parser/type_check_test.go
@@ -115,7 +115,7 @@ func TestTypeCheck(t *testing.T) {
 			t.Errorf("%s: %v", d.expr, err)
 			continue
 		}
-		ctx := MakeSemaContext()
+		ctx := MakeSemaContext(false)
 		typeChecked, err := TypeCheck(expr, &ctx, TypeAny)
 		if err != nil {
 			t.Errorf("%s: unexpected error %s", d.expr, err)
@@ -141,7 +141,7 @@ func TestTypeCheckNormalize(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			ctx := MakeSemaContext()
+			ctx := MakeSemaContext(false)
 			typeChecked, err := TypeCheck(expr, &ctx, TypeAny)
 			if err != nil {
 				t.Fatal(err)
@@ -313,7 +313,7 @@ func attemptTypeCheckSameTypedExprs(t *testing.T, idx int, test sameTypedExprsTe
 		test.expectedPTypes = make(PlaceholderTypes)
 	}
 	forEachPerm(test.exprs, 0, func(exprs []copyableExpr) {
-		ctx := MakeSemaContext()
+		ctx := MakeSemaContext(false)
 		ctx.Placeholders.SetTypes(clonePlaceholderTypes(test.ptypes))
 		desired := TypeAny
 		if test.desired != nil {
@@ -454,7 +454,7 @@ func TestTypeCheckSameTypedExprsError(t *testing.T) {
 		{nil, nil, exprs(placeholder("b"), placeholder("a")), placeholderErr},
 	}
 	for i, d := range testData {
-		ctx := MakeSemaContext()
+		ctx := MakeSemaContext(false)
 		ctx.Placeholders.SetTypes(d.ptypes)
 		desired := TypeAny
 		if d.desired != nil {

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/mon"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -398,7 +399,7 @@ func (s *Session) newPlanner(e *Executor, txn *client.Txn) *planner {
 		phaseTimes: s.phaseTimes,
 	}
 
-	p.semaCtx = parser.MakeSemaContext()
+	p.semaCtx = parser.MakeSemaContext(s.User == security.RootUser)
 	p.semaCtx.Location = &s.Location
 	p.semaCtx.SearchPath = s.SearchPath
 

--- a/pkg/sql/testdata/logic_test/builtin_function
+++ b/pkg/sql/testdata/logic_test/builtin_function
@@ -1513,7 +1513,7 @@ SELECT oid(3), oid(0), oid(12023948723)
 3  0  12023948723
 
 query T
-SELECT crdb_testing.to_english(i) FROM (VALUES (1), (13), (617)) AS a(i)
+SELECT to_english(i) FROM (VALUES (1), (13), (617)) AS a(i)
 ----
 one
 one-three

--- a/pkg/sql/testdata/logic_test/crdb_internal
+++ b/pkg/sql/testdata/logic_test/crdb_internal
@@ -83,6 +83,9 @@ SELECT * FROM crdb_internal.jobs
 ----
 id  type  description  username  descriptor_ids  status  created  started  finished  modified  fraction_completed  error
 
+query error pq: crdb_internal.force_internal_error\(\): foo
+SELECT crdb_internal.force_internal_error('foo')
+
 # Check that privileged builtins are only allowed for 'root'
 query I
 select crdb_internal.force_retry(interval '0s')
@@ -90,5 +93,12 @@ select crdb_internal.force_retry(interval '0s')
 0
 
 user testuser
+
 query error pq: insufficient privilege
 select crdb_internal.force_retry(interval '0s')
+
+query error pq: insufficient privilege
+select crdb_internal.force_internal_error('foo')
+
+query error pq: insufficient privilege
+select crdb_internal.force_panic('foo')

--- a/pkg/sql/testdata/logic_test/crdb_internal
+++ b/pkg/sql/testdata/logic_test/crdb_internal
@@ -82,3 +82,13 @@ query ITTTTTTTTTRT colnames
 SELECT * FROM crdb_internal.jobs
 ----
 id  type  description  username  descriptor_ids  status  created  started  finished  modified  fraction_completed  error
+
+# Check that privileged builtins are only allowed for 'root'
+query I
+select crdb_internal.force_retry(interval '0s')
+----
+0
+
+user testuser
+query error pq: insufficient privilege
+select crdb_internal.force_retry(interval '0s')

--- a/pkg/sql/testdata/logic_test/distsql_numtables
+++ b/pkg/sql/testdata/logic_test/distsql_numtables
@@ -23,7 +23,7 @@ ALTER TABLE NumToStr TESTING_RELOCATE
   SELECT ARRAY[i+1], (i * 100 * 100 / 5)::int FROM GENERATE_SERIES(0, 4) AS g(i)
 
 statement ok
-INSERT INTO NumToStr SELECT i, crdb_testing.to_english(i) FROM GENERATE_SERIES(1, 100*100) AS g(i)
+INSERT INTO NumToStr SELECT i, to_english(i) FROM GENERATE_SERIES(1, 100*100) AS g(i)
 
 # Verify data placement.
 query TTTI colnames
@@ -138,7 +138,7 @@ https://cockroachdb.github.io/distsqlplan/decode.html?eJzUlcFq20AQhu99ijCnBLbgXc
 
 # Save the result of the following statement to a label.
 query IT rowsort label-sq-str
-SELECT i, crdb_testing.to_english(i*i) FROM GENERATE_SERIES(1, 100) AS g(i)
+SELECT i, to_english(i*i) FROM GENERATE_SERIES(1, 100) AS g(i)
 
 # Compare the results of this query to the one above.
 query IT rowsort label-sq-str


### PR DESCRIPTION
Two salient patches:

###  sql: gate 'sensitive' internal built-ins behind a privilege check

Some built-in functions may have sensitive impact on the overall
behavior of the server; this patch introduces a new built-in
flag 'privileged' which causes type checking to fail on the built-in
if the user is not 'root'

### sql: new built-in for debugging purposes

This patch adds a new built-in `crdb_internal.force_internal_error(<string>)` which
by default simply causes a SQL error.

This built-in is privileged: only the 'root' user can use it.

It also introduces a new cluster setting
`sql.builtin.force_internal_error.panic` which, when true, causes the
aforementioned built-in to trigger a panic on the node. (The setting
is disabled by default.)