### PR TITLE
sql: clean up session shutdown in case of panics + misc cleanups

### DIFF
--- a/pkg/sql/mon/mem_usage.go
+++ b/pkg/sql/mon/mem_usage.go
@@ -354,7 +354,7 @@ func (mm *MemoryMonitor) Stop(ctx context.Context) {
 	mm.pool = nil
 
 	// Release the reserved budget to its original pool, if any.
-	mm.reserved.Close(ctx)
+	mm.reserved.Clear(ctx)
 }
 
 // MemoryAccount tracks the cumulated allocations for one client of

--- a/pkg/sql/mon/mem_usage.go
+++ b/pkg/sql/mon/mem_usage.go
@@ -323,8 +323,18 @@ func MakeUnlimitedMonitor(
 	}
 }
 
+// EmergencyStop completes a monitoring region, and disables checking
+// that all accounts have been closed.
+func (mm *MemoryMonitor) EmergencyStop(ctx context.Context) {
+	mm.doStop(ctx, false)
+}
+
 // Stop completes a monitoring region.
 func (mm *MemoryMonitor) Stop(ctx context.Context) {
+	mm.doStop(ctx, true)
+}
+
+func (mm *MemoryMonitor) doStop(ctx context.Context, check bool) {
 	// NB: No need to lock mm.mu here, when StopMonitor() is called the
 	// monitor is not shared any more.
 	if log.V(1) {
@@ -333,7 +343,7 @@ func (mm *MemoryMonitor) Stop(ctx context.Context) {
 			humanizeutil.IBytes(mm.mu.maxAllocated))
 	}
 
-	if mm.mu.curAllocated != 0 {
+	if check && mm.mu.curAllocated != 0 {
 		panic(fmt.Sprintf("%s: unexpected leftover memory: %d bytes",
 			mm.name,
 			mm.mu.curAllocated))

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -347,9 +347,10 @@ func (c *v3Conn) serve(ctx context.Context, draining func() bool, reserved mon.B
 	// this session use Session.Ctx() (which may diverge from this method's ctx).
 
 	defer func() {
-		// If we're panicking, don't bother trying to close the session; it would
-		// pollute the logs.
 		if r := recover(); r != nil {
+			// If we're panicking, use an emergency session shutdown so that
+			// the monitors don't shout that they are unhappy.
+			c.session.EmergencyClose()
 			panic(r)
 		}
 		c.closeSession(ctx)

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -1033,3 +1033,28 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 	}
 	scc.schemaChangers = scc.schemaChangers[:0]
 }
+
+// maybeRecover catches SQL panics and does some log reporting before
+// propagating the panic further.
+// TODO(knz): this is where we can place code to recover from
+// recoverable panics.
+func (s *Session) maybeRecover(action, stmt string) {
+	if r := recover(); r != nil {
+		err := errors.Errorf("panic while %s %q: %s", action, stmt, r)
+
+		// A short warning header guaranteed to go to stderr.
+		log.Shout(s.Ctx(), log.Severity_ERROR,
+			"a SQL panic has occurred!")
+		// TODO(knz): log panic details to logs once panics
+		// are not propagated to the top-level and printed out by the Go runtime.
+
+		// Close the session with force shutdown of the monitors. This is
+		// guaranteed to succeed, or fail with a panic which we can't
+		// recover from: if there's a panic, that means the lease /
+		// tracing / kv subsystem is broken and we can't resume from that.
+		s.EmergencyClose()
+
+		// Propagate the panic further.
+		panic(err)
+	}
+}


### PR DESCRIPTION
This patch does two things:

- ensures that sessions can shut down cleanly in case of panics
- avoids re-stringifying statements to generate erorr messages.

(This is a "light" version of  #15063 which does not  recover from panics)