### PR TITLE
distsql: exit when ctx is canceled while waiting for a flow

### DIFF
--- a/pkg/sql/distsqlrun/flow_registry.go
+++ b/pkg/sql/distsqlrun/flow_registry.go
@@ -210,7 +210,9 @@ func (fr *flowRegistry) UnregisterFlow(id FlowID) {
 // given timeout. If the timeout elapses, returns nil. It should only be called
 // while holding the mutex. The mutex is temporarily unlocked if we need to
 // wait.
-func (fr *flowRegistry) waitForFlowLocked(id FlowID, timeout time.Duration) *flowEntry {
+func (fr *flowRegistry) waitForFlowLocked(
+	ctx context.Context, id FlowID, timeout time.Duration,
+) *flowEntry {
 	entry := fr.getEntryLocked(id)
 	if entry.flow != nil {
 		return entry
@@ -229,10 +231,10 @@ func (fr *flowRegistry) waitForFlowLocked(id FlowID, timeout time.Duration) *flo
 	entry.refCount++
 	fr.Unlock()
 
-	// Wait until waitCh gets closed or the timeout elapses.
 	select {
 	case <-waitCh:
 	case <-time.After(timeout):
+	case <-ctx.Done():
 	}
 
 	fr.Lock()
@@ -256,11 +258,11 @@ func (fr *flowRegistry) waitForFlowLocked(id FlowID, timeout time.Duration) *flo
 // The cleanup function will decrement the flow's WaitGroup, so that Flow.Wait()
 // is not blocked on this stream any more.
 func (fr *flowRegistry) ConnectInboundStream(
-	flowID FlowID, streamID StreamID, timeout time.Duration,
+	ctx context.Context, flowID FlowID, streamID StreamID, timeout time.Duration,
 ) (*Flow, RowReceiver, func(), error) {
 	fr.Lock()
 	defer fr.Unlock()
-	entry := fr.waitForFlowLocked(flowID, timeout)
+	entry := fr.waitForFlowLocked(ctx, flowID, timeout)
 	if entry == nil {
 		return nil, nil, nil, errors.Errorf("flow %s not found", flowID)
 	}

--- a/pkg/sql/distsqlrun/flow_registry_test.go
+++ b/pkg/sql/distsqlrun/flow_registry_test.go
@@ -36,7 +36,7 @@ import (
 func lookupFlow(fr *flowRegistry, fid FlowID, timeout time.Duration) *Flow {
 	fr.Lock()
 	defer fr.Unlock()
-	entry := fr.waitForFlowLocked(fid, timeout)
+	entry := fr.waitForFlowLocked(context.TODO(), fid, timeout)
 	if entry == nil {
 		return nil
 	}
@@ -213,15 +213,15 @@ func TestStreamConnectionTimeout(t *testing.T) {
 		t.Fatalf("expected consumer to have been closed when the flow timed out")
 	}
 
-	if _, _, _, err := reg.ConnectInboundStream(id1, streamID1, jiffy); !testutils.IsError(
-		err, "came too late") {
+	_, _, _, err := reg.ConnectInboundStream(context.TODO(), id1, streamID1, jiffy)
+	if !testutils.IsError(err, "came too late") {
 		t.Fatalf("expected %q, got: %v", "came too late", err)
 	}
 
 	// Unregister the flow. Subsequent attempts to connect a stream should result
 	// in a different error than before.
 	reg.UnregisterFlow(id1)
-	_, _, _, err := reg.ConnectInboundStream(id1, streamID1, jiffy)
+	_, _, _, err = reg.ConnectInboundStream(context.TODO(), id1, streamID1, jiffy)
 	if !testutils.IsError(err, "not found") {
 		t.Fatalf("expected %q, got: %v", "not found", err)
 	}

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -272,7 +272,7 @@ func (ds *ServerImpl) flowStreamInt(ctx context.Context, stream DistSQL_FlowStre
 		log.Infof(ctx, "connecting inbound stream %s/%d", flowID.Short(), streamID)
 	}
 	f, receiver, cleanup, err := ds.flowRegistry.ConnectInboundStream(
-		flowID, streamID, flowStreamDefaultTimeout)
+		ctx, flowID, streamID, flowStreamDefaultTimeout)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Listening to `ctx.Done()` too when waiting for a flow. This fixes occasional
goroutine leaks reported in a stress test I am working on.