### PR TITLE
storage: default kv.raft_log_synchronize to true

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -98,7 +98,7 @@ var tickQuiesced = envutil.EnvOrDefaultBool("COCKROACH_TICK_QUIESCED", true)
 var syncRaftLog = settings.RegisterBoolSetting(
 	"kv.raft_log.synchronize",
 	"set to true to synchronize on Raft log writes to persistent storage",
-	false)
+	true)
 
 var maxCommandSize = settings.RegisterByteSizeSetting(
 	"kv.raft.command.max_size",


### PR DESCRIPTION
Prioritize safety over performance.

Fixes #15245