### PR TITLE
storage: unflake TestProactiveRaftLogTruncate

### DIFF
--- a/pkg/storage/raft_log_queue_test.go
+++ b/pkg/storage/raft_log_queue_test.go
@@ -227,12 +227,15 @@ func TestGetTruncatableIndexes(t *testing.T) {
 // log even when replica scanning is disabled.
 func TestProactiveRaftLogTruncate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#9772")
 
+	ctx := context.Background()
 	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
+	defer stopper.Stop(ctx)
 	store, _ := createTestStore(t, stopper)
 
+	// Note that turning off the replica scanner does not prevent the queues
+	// from processing entries (in this case specifically the raftLogQueue),
+	// just that the scanner will not try to push all replicas onto the queues.
 	store.SetReplicaScannerActive(false)
 
 	r, err := store.GetReplica(1)
@@ -240,35 +243,33 @@ func TestProactiveRaftLogTruncate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r.mu.Lock()
-	oldFirstIndex, err := r.FirstIndex()
-	r.mu.Unlock()
+	oldFirstIndex, err := r.GetFirstIndex()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Write a few keys to the range. While writing these keys, the raft log
-	// should be proactively truncated even though replica scanning is disabled.
-	for i := 0; i < 2*RaftLogQueueStaleThreshold; i++ {
+	// should be proactively truncated.
+	for i := 0; i < RaftLogQueueStaleThreshold+raftLogCheckFrequency; i++ {
 		key := roachpb.Key(fmt.Sprintf("key%02d", i))
 		args := putArgs(key, []byte(fmt.Sprintf("value%02d", i)))
-		if _, err := client.SendWrapped(context.Background(), store.testSender(), &args); err != nil {
+		if _, err := client.SendWrapped(ctx, store.testSender(), &args); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	// Wait for any asynchronous tasks to finish.
-	stopper.Quiesce(context.TODO())
-
-	r.mu.Lock()
-	newFirstIndex, err := r.FirstIndex()
-	r.mu.Unlock()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if newFirstIndex <= oldFirstIndex {
-		t.Errorf("log was not correctly truncated, old first index:%d, current first index:%d",
-			oldFirstIndex, newFirstIndex)
-	}
+	// Log truncation is an asynchronous process and while it will usually occur
+	// fairly quickly, there is a slight race between this check and the
+	// truncation, especially when under stress.
+	testutils.SucceedsSoon(t, func() error {
+		newFirstIndex, err := r.GetFirstIndex()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if newFirstIndex <= oldFirstIndex {
+			return errors.Errorf("log was not correctly truncated, old first index:%d, current first index:%d",
+				oldFirstIndex, newFirstIndex)
+		}
+		return nil
+	})
 }

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -45,6 +45,8 @@ const (
 	leaseTransferError
 )
 
+const raftLogCheckFrequency = 1 + RaftLogQueueStaleThreshold/4
+
 // ProposalData is data about a command which allows it to be
 // evaluated, proposed to raft, and for the result of the command to
 // be returned to the caller.
@@ -532,7 +534,6 @@ func (r *Replica) handleReplicatedEvalResult(
 	r.store.metrics.addMVCCStats(rResult.Delta)
 	rResult.Delta = enginepb.MVCCStats{}
 
-	const raftLogCheckFrequency = 1 + RaftLogQueueStaleThreshold/4
 	if rResult.State.RaftAppliedIndex%raftLogCheckFrequency == 1 {
 		r.store.raftLogQueue.MaybeAdd(r, r.store.Clock().Now())
 	}


### PR DESCRIPTION
The issue with the test was that calling for the quiescing of all tasks was occasionally cancelling the truncate request. By putting this in a succeeds soon instead, it solves the issue.

The test is also tightened up by instead of writing 2x the Stale Threshold to write exactly the bare minimum required to ensure that it must be proactively truncated (Stale Threshold + Check Frequency).

Fixes #9772.