### PR TITLE
distsql: avoid unhealthy nodes during planning

### DIFF
--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -160,7 +160,7 @@ func TestHeartbeatHealth(t *testing.T) {
 	// Wait for the connection.
 	testutils.SucceedsSoon(t, func() error {
 		err := clientCtx.ConnHealth(remoteAddr)
-		if err != nil && err != errNotHeartbeated {
+		if err != nil && err != ErrNotHeartbeated {
 			t.Fatal(err)
 		}
 		return err
@@ -196,7 +196,7 @@ func TestHeartbeatHealth(t *testing.T) {
 		return clientCtx.ConnHealth(remoteAddr)
 	})
 
-	if err := clientCtx.ConnHealth("non-existent connection"); err != errNotConnected {
+	if err := clientCtx.ConnHealth("non-existent connection"); err != ErrNotConnected {
 		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -332,6 +332,7 @@ type planningCtx struct {
 	spanIter distsqlplan.SpanResolverIterator
 	// nodeAddresses contains addresses for all NodeIDs that are referenced by any
 	// physicalPlan we generate with this context.
+	// Nodes that fail a health check have empty addresses.
 	nodeAddresses map[roachpb.NodeID]string
 }
 
@@ -390,8 +391,8 @@ func (dsp *distSQLPlanner) partitionSpans(
 		panic("no spans")
 	}
 	ctx := planCtx.ctx
-	splits := make([]spanPartition, 0, 1)
-	// nodeMap maps a nodeID to an index inside the splits array.
+	partitions := make([]spanPartition, 0, 1)
+	// nodeMap maps a nodeID to an index inside the partitions array.
 	nodeMap := make(map[roachpb.NodeID]int)
 	it := planCtx.spanIter
 	for _, span := range spans {
@@ -426,8 +427,8 @@ func (dsp *distSQLPlanner) partitionSpans(
 			if !desc.ContainsKey(lastKey) {
 				// This range must contain the last range's EndKey.
 				log.Fatalf(
-					ctx, "next range %v doesn't cover last end key %v. Splits: %#v",
-					desc.RSpan(), lastKey, splits,
+					ctx, "next range %v doesn't cover last end key %v. Partitions: %#v",
+					desc.RSpan(), lastKey, partitions,
 				)
 			}
 
@@ -438,22 +439,42 @@ func (dsp *distSQLPlanner) partitionSpans(
 			}
 
 			nodeID := replInfo.NodeDesc.NodeID
-			idx, ok := nodeMap[nodeID]
-			if !ok {
-				idx = len(splits)
-				splits = append(splits, spanPartition{node: nodeID})
-				nodeMap[nodeID] = idx
-				if _, ok := planCtx.nodeAddresses[nodeID]; !ok {
-					planCtx.nodeAddresses[nodeID] = replInfo.NodeDesc.Address.String()
+			partitionIdx, inNodeMap := nodeMap[nodeID]
+			if !inNodeMap {
+				// This is the first time we are seeing nodeID for these spans. Check
+				// its health.
+				addr, inAddrMap := planCtx.nodeAddresses[nodeID]
+				if !inAddrMap {
+					addr = replInfo.NodeDesc.Address.String()
+					err := dsp.rpcContext.ConnHealth(addr)
+					if err != nil && err != rpc.ErrNotConnected && err != rpc.ErrNotHeartbeated {
+						// This host is known to be unhealthy. Don't use it (use the gateway
+						// instead). Note: this can never happen for our nodeID (which
+						// always has its address in the nodeMap).
+						addr = ""
+						log.VEventf(ctx, 1, "marking node %d as unhealthy for this plan: %v", nodeID, err)
+					}
+					planCtx.nodeAddresses[nodeID] = addr
+				}
+				if addr == "" {
+					// An empty address indicates an unhealthy host. Use the gateway to
+					// process this span instead of the unhealthy host.
+					nodeID = dsp.nodeDesc.NodeID
+					partitionIdx, inNodeMap = nodeMap[nodeID]
+				}
+				if !inNodeMap {
+					partitionIdx = len(partitions)
+					partitions = append(partitions, spanPartition{node: nodeID})
+					nodeMap[nodeID] = partitionIdx
 				}
 			}
-			split := &splits[idx]
+			partition := &partitions[partitionIdx]
 
 			if lastNodeID == nodeID {
 				// Two consecutive ranges on the same node, merge the spans.
-				split.spans[len(split.spans)-1].EndKey = endKey.AsRawKey()
+				partition.spans[len(partition.spans)-1].EndKey = endKey.AsRawKey()
 			} else {
-				split.spans = append(split.spans, roachpb.Span{
+				partition.spans = append(partition.spans, roachpb.Span{
 					Key:    lastKey.AsRawKey(),
 					EndKey: endKey.AsRawKey(),
 				})
@@ -468,7 +489,7 @@ func (dsp *distSQLPlanner) partitionSpans(
 			lastNodeID = nodeID
 		}
 	}
-	return splits, nil
+	return partitions, nil
 }
 
 // initTableReaderSpec initializes a TableReaderSpec/PostProcessSpec that

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -38,9 +38,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
@@ -446,4 +448,83 @@ func TestDistSQLRangeCachesIntegrationTest(t *testing.T) {
 	if !strings.HasPrefix(json, exp) {
 		t.Fatalf("expected prefix %q, but json is: %s", exp, json)
 	}
+}
+
+func TestDistSQLDeadHosts(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	t.Skip("test is too slow; we need to tweak timeouts so connections die faster (see #14376)")
+
+	const n = 100
+	const numNodes = 5
+
+	tc := serverutils.StartTestCluster(t, numNodes, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+		ServerArgs:      base.TestServerArgs{UseDatabase: "test"},
+	})
+	defer tc.Stopper().Stop(context.TODO())
+
+	r := sqlutils.MakeSQLRunner(t, tc.ServerConn(0))
+	r.DB.SetMaxOpenConns(1)
+	r.Exec("CREATE DATABASE test")
+
+	r.Exec("CREATE TABLE t (x INT PRIMARY KEY, xsquared INT)")
+
+	for i := 0; i < numNodes; i++ {
+		r.Exec(fmt.Sprintf("ALTER TABLE t SPLIT AT VALUES (%d)", n*i/5))
+	}
+
+	for i := 0; i < numNodes; i++ {
+		r.Exec(fmt.Sprintf(
+			"ALTER TABLE t TESTING_RELOCATE VALUES (ARRAY[%d,%d,%d], %d)",
+			i+1, (i+1)%5+1, (i+2)%5+1, n*i/5,
+		))
+	}
+
+	r.Exec(fmt.Sprintf("INSERT INTO t SELECT i, i*i FROM GENERATE_SERIES(1, %d) AS g(i)", n))
+
+	r.Exec("SET DISTSQL = ON")
+
+	// Run a query that uses the entire table and is easy to verify.
+	runQuery := func() error {
+		log.Infof(context.TODO(), "running test query")
+		var res int
+		if err := r.DB.QueryRow("SELECT SUM(xsquared) FROM t").Scan(&res); err != nil {
+			return err
+		}
+		if exp := (n * (n + 1) * (2*n + 1)) / 6; res != exp {
+			t.Fatalf("incorrect result %d, expected %d", res, exp)
+		}
+		log.Infof(context.TODO(), "test query OK")
+		return nil
+	}
+	if err := runQuery(); err != nil {
+		t.Error(err)
+	}
+
+	// Verify the plan (should include all 5 nodes).
+	r.CheckQueryResults(
+		"SELECT URL FROM [EXPLAIN (DISTSQL) SELECT SUM(xsquared) FROM t]",
+		[][]string{{"https://cockroachdb.github.io/distsqlplan/decode.html?eJy8k09LwzAYxu9-CnlOCu9h7bo5e5rHHXQy9SQ91OalFLamJCkoo99d1iDaIskgo8f8-T2_PG1yRC0FP-UH1kjfEYEQgzAHIQFhgYzQKFmw1lKdtlhgIz6RzghV3bTmNJ0RCqkY6RGmMntGitf8Y887zgUrEASbvNr3kkZVh1x9rQ0I29ak1-sYWUeQrflJ6-h8z0NZKi5zI0eal7fHm3V0e3b0b2JbSyVYsRgEZt2F5dFE38_jCakQT1TB4wmpMJ-ogscTUiGZqILHc6mH-E_0jnUja82jBznMywgsSrZvWctWFfysZNGH2-G2391PCNbGrkZ2sKnt0ulYf-HICccDOBrDsdvsUc-ddOKGk5BzL5zw0m1ehpjvnPDKbV6FmO_d_2rmuSbuSzZ2Z93VdwAAAP__XTV6BQ=="}},
+	)
+
+	// Stop node 5.
+	tc.StopServer(4)
+
+	testutils.SucceedsSoon(t, runQuery)
+
+	r.CheckQueryResults(
+		"SELECT URL FROM [EXPLAIN (DISTSQL) SELECT SUM(xsquared) FROM t]",
+		[][]string{{"https://cockroachdb.github.io/distsqlplan/decode.html?eJy8k8FK7DAYhff3KS5npZCF6dRx7KouZ6Ejo64ki9j8lEKnKUkKytB3lzaItkg60qHL5M93vpySHlFpRQ_yQBbJKzgYIjCswBBDMNRGZ2StNt3YH96qdyRXDEVVN67bFgyZNoTkCFe4kpDgWb6VtCepyIBBkZNF2QtqUxyk-UgdGHaNS_6nEUTLoBv3lday0z13eW4ol06PNE8v9xcpvzw5-juxqbRRZEgNAkV7Zjlf6PtNeOZUiBaqMOGZU2G1UIUJz7le8S_Re7K1riyNXvMwTzCQysn_CFY3JqNHo7M-3C93_el-Q5F1fsr9Ylv5UXetnzAPwtEA5mM4CsK3YfMqCMdhOJ5z7esgvA6b13PMN0F4EzZv_mQW7b_PAAAA__-DuA-E"}},
+	)
+
+	// Stop node 2; note that no range had replicas on both 2 and 5.
+	tc.StopServer(1)
+
+	testutils.SucceedsSoon(t, runQuery)
+
+	r.CheckQueryResults(
+		"SELECT URL FROM [EXPLAIN (DISTSQL) SELECT SUM(xsquared) FROM t]",
+		[][]string{{"https://cockroachdb.github.io/distsqlplan/decode.html?eJy8kkFLwzAUx-9-CvmfFHIwXZ3QUz3uoJOpJ8khNo9S6JrykoIy-t2lDaItkk02dkxe_r_fe-Ht0FhDj3pLDtkbJAQWEEihBFq2BTlneSiFhyvzgexGoGrazg_XSqCwTMh28JWvCRle9HtNG9KGGAKGvK7qEd5ytdX8mXsIrDufXeYJVC9gO_9N68XhnvuyZCq1tzPN8-vDVS6vD0b_ELvGsiEmMwGq_sRyeab_2-M5ZoTkTCPs8ZxqBf5Ab8i1tnE0W4UpTwmQKSlskbMdF_TEthjh4bgeX48XhpwPVRkOqyaUhrZ-h2U0nEzCch5OouG7uHkRDafxcHpM27fR8DJuXv7LrPqLrwAAAP__vMyldA=="}},
+	)
 }


### PR DESCRIPTION
Please ignore the first commit (separate PR).

The change is pretty straightforward. However, the test is taking too long (20s+), because it takes a while  until a connection is declared unhealthy. Any suggestions? Is there a way to decrease gRPC timeouts? I could also shorten the test (stop after killing one node) but it's still ~10s.

It's also a bit odd that when running under stress, some runs are a lot faster, I am wondering why in some cases the connection becomes unhealthy much sooner.
```
0 runs so far, 0 failures, over 5s
0 runs so far, 0 failures, over 10s
0 runs so far, 0 failures, over 15s
3 runs so far, 0 failures, over 20s  <---
4 runs so far, 0 failures, over 25s
4 runs so far, 0 failures, over 30s
4 runs so far, 0 failures, over 35s
7 runs so far, 0 failures, over 40s
8 runs so far, 0 failures, over 45s
8 runs so far, 0 failures, over 50s
8 runs so far, 0 failures, over 55s
11 runs so far, 0 failures, over 1m0s <--
```

Fixes #13655.