### PR TITLE
ui: Layout Fixes

### DIFF
--- a/pkg/ui/src/containers/databases/databaseTables.tsx
+++ b/pkg/ui/src/containers/databases/databaseTables.tsx
@@ -68,7 +68,11 @@ class DatabaseSummaryTables extends DatabaseSummaryBase {
               {
                 title: "Table Name",
                 cell: (tableInfo) => {
-                  return <Link to={`databases/database/${dbID}/table/${tableInfo.name}`}>{tableInfo.name}</Link>;
+                  return (
+                    <div className="sort-table__unbounded-column">
+                      <Link to={`databases/database/${dbID}/table/${tableInfo.name}`}>{tableInfo.name}</Link>
+                    </div>
+                  );
                 },
                 sort: (tableInfo) => tableInfo.name,
                 className: "expand-link", // don't pad the td element to allow the link to expand

--- a/pkg/ui/src/containers/nodesOverview.tsx
+++ b/pkg/ui/src/containers/nodesOverview.tsx
@@ -85,10 +85,12 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
                     "This node is currently healthy." :
                     "This node has not recently reported as being live. " +
                     "It may not be functioning correctly, but no automatic action has yet been taken.";
-                  return <div>
-                    <Link to={"/nodes/" + ns.desc.node_id}>{ns.desc.address.address_field}</Link>
-                    <div className={"icon-circle-filled node-status-icon node-status-icon--" + s} title={tooltip} />
-                  </div>;
+                  return (
+                    <div className="sort-table__unbounded-column">
+                      <div className={"icon-circle-filled node-status-icon node-status-icon--" + s} title={tooltip} />
+                      <Link to={"/nodes/" + ns.desc.node_id}>{ns.desc.address.address_field}</Link>
+                    </div>
+                  );
                 },
                 sort: (ns) => ns.desc.node_id,
                 // TODO(mrtracy): Consider if there is a better way to use BEM

--- a/pkg/ui/styl/base/layout-vars.styl
+++ b/pkg/ui/styl/base/layout-vars.styl
@@ -23,4 +23,7 @@ $chart-width    = 1300px
 $footer-height  = 73px
 
 // Z-INDEXES
-$tooltip-layer = 100
+$z-index-tooltip     = 4
+$z-index-banner      = 3
+$z-index-navigation  = 2
+$z-index-page-config = 1

--- a/pkg/ui/styl/components/table.styl
+++ b/pkg/ui/styl/components/table.styl
@@ -91,3 +91,7 @@ $stats-table-tr--bg-alt = $secondary-gray-7
       text-decoration none
       width 100%
       height 100%
+
+  &__unbounded-column
+    whitespace normal
+    word-break break-all

--- a/pkg/ui/styl/components/tooltip.styl
+++ b/pkg/ui/styl/components/tooltip.styl
@@ -1,6 +1,6 @@
 .tooltip, .timescale-selector
   position absolute
-  z-index $tooltip-layer
+  z-index $z-index-tooltip
   padding 35px
   border 1px solid $secondary-gray-1
   box-shadow 2px 2px 0 $secondary-gray-15
@@ -48,10 +48,10 @@
 
 .hover-tooltip
   position relative
-  z-index 1
 
   &__text
     visibility hidden
+    z-index $z-index-tooltip
     position absolute
     top -10px
     left 100%

--- a/pkg/ui/styl/layout/layout.styl
+++ b/pkg/ui/styl/layout/layout.styl
@@ -39,7 +39,7 @@ $subnav-background  = $secondary-gray-4
   padding-top 12px
   padding-bottom 12px
   padding-left 24px
-  z-index 2
+  z-index $z-index-page-config
   position relative
 
   &--fixed
@@ -153,7 +153,7 @@ span.icon
   position absolute
   top 0
   right 0
-  z-index 1
+  z-index $z-index-page-config
 
   h2
     font-size 3rem

--- a/pkg/ui/styl/layout/navigation-bar.styl
+++ b/pkg/ui/styl/layout/navigation-bar.styl
@@ -36,7 +36,7 @@ $subnav-underline-height = 3px
   left 0
   bottom 0
   min-height 350px
-  z-index 1
+  z-index $z-index-navigation
   width $nav-width
   modular-font-size '1'
   background-color $navbar-bg
@@ -109,7 +109,7 @@ $subnav-underline-height = 3px
   top $top-bar-height
   right 0
   width 100%
-  z-index 1
+  z-index $z-index-navigation
 
   ul.nav
     display flex

--- a/pkg/ui/styl/pages/nodes.styl
+++ b/pkg/ui/styl/pages/nodes.styl
@@ -1,6 +1,6 @@
 .node-status-icon
   display inline
-  padding-left 9px
+  padding-right 9px
   font-size 6px
   line-height 14px
   vertical-align middle


### PR DESCRIPTION
Refactor z-indexes of all elements with z-indexes so that there are no
more unexpected overlaps. All z-indexes are set via variable, with all
variables in a single file for easy vertical sorting.

Fixes #12717

<img width="379" alt="screen shot 2017-04-26 at 6 26 08 pm" src="https://cloud.githubusercontent.com/assets/6969858/25459766/dc0dbfae-2aad-11e7-9be3-0728e056c310.png">


Add an "unbounded_column" element class for table columns that may
contain strings of unbounded length in cells. This is intended for
things like table names and node addresses, which will be a single
"word" with no whitespace but may be of unbounded length. The fix is to
allow these columns to "break" the contained text and wrap.

As a related fix, movs the "status" icon in the node address column of
the nodes list in front of the address string (previously it followed
the address string.)

Fixes #13945
Fixes #14772

<img width="1304" alt="screen shot 2017-04-26 at 6 17 13 pm" src="https://cloud.githubusercontent.com/assets/6969858/25459743/c2c60d9e-2aad-11e7-9630-40f61b49bacc.png">
