### PR TITLE
sql: provide an anonymized version of the per-statistic collection key

### DIFF
--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -414,16 +414,16 @@ func (p *planner) CreateView(ctx context.Context, n *parser.CreateView) (planNod
 	var fmtErr error
 	n.AsSource.Format(
 		&queryBuf,
-		parser.FmtNormalizeTableNames(
+		parser.FmtReformatTableNames(
 			parser.FmtParsable,
-			func(t *parser.NormalizableTableName) *parser.TableName {
+			func(t *parser.NormalizableTableName, buf *bytes.Buffer, f parser.FmtFlags) {
 				tn, err := p.QualifyWithDatabase(ctx, t)
 				if err != nil {
 					log.Warningf(ctx, "failed to qualify table name %q with database name: %v", t, err)
 					fmtErr = err
-					return nil
+					t.TableNameReference.Format(buf, f)
 				}
-				return tn
+				tn.Format(buf, f)
 			},
 		),
 	)

--- a/pkg/sql/parser/expr.go
+++ b/pkg/sql/parser/expr.go
@@ -961,7 +961,9 @@ func (node *FuncExpr) Format(buf *bytes.Buffer, f FmtFlags) {
 	if node.Type != 0 {
 		typ = funcTypeName[node.Type] + " "
 	}
-	FormatNode(buf, f, node.Func)
+	fmtDisableAnonymize := *f
+	fmtDisableAnonymize.anonymize = false
+	FormatNode(buf, &fmtDisableAnonymize, node.Func)
 	buf.WriteByte('(')
 	buf.WriteString(typ)
 	FormatNode(buf, f, node.Exprs)

--- a/pkg/sql/parser/name_part.go
+++ b/pkg/sql/parser/name_part.go
@@ -65,7 +65,11 @@ type Name string
 
 // Format implements the NodeFormatter interface.
 func (n Name) Format(buf *bytes.Buffer, f FmtFlags) {
-	encodeSQLIdent(buf, string(n))
+	if f.anonymize {
+		buf.WriteByte('_')
+	} else {
+		encodeSQLIdent(buf, string(n))
+	}
 }
 
 // Normalize normalizes to lowercase and Unicode Normalization Form C

--- a/pkg/sql/parser/table_name.go
+++ b/pkg/sql/parser/table_name.go
@@ -38,13 +38,11 @@ type NormalizableTableName struct {
 
 // Format implements the NodeFormatter interface.
 func (nt NormalizableTableName) Format(buf *bytes.Buffer, f FmtFlags) {
-	tnr := nt.TableNameReference
-	if f.tableNameNormalizer != nil {
-		if tn := f.tableNameNormalizer(&nt); tn != nil {
-			tnr = tn
-		}
+	if f.tableNameFormatter != nil {
+		f.tableNameFormatter(&nt, buf, f)
+	} else {
+		nt.TableNameReference.Format(buf, f)
 	}
-	tnr.Format(buf, f)
 }
 func (nt NormalizableTableName) String() string { return AsString(nt) }
 
@@ -111,7 +109,7 @@ type TableName struct {
 
 // Format implements the NodeFormatter interface.
 func (t *TableName) Format(buf *bytes.Buffer, f FmtFlags) {
-	if !t.DBNameOriginallyOmitted || f.tableNameNormalizer != nil {
+	if !t.DBNameOriginallyOmitted || f.tableNameFormatter != nil {
 		FormatNode(buf, f, t.DatabaseName)
 		buf.WriteByte('.')
 	}

--- a/pkg/sql/testdata/logic_test/statement_statistics
+++ b/pkg/sql/testdata/logic_test/statement_statistics
@@ -35,6 +35,17 @@ CREATE TABLE test(x INT, y INT, z INT)
 statement ok
 SET application_name = 'valuetest'
 
+# Check that shortening goes through functions.
+
+statement ok
+SELECT sin(1.23)
+
+
+# Check that shortened queries can use virtual tables.
+
+statement ok
+SELECT key FROM crdb_internal.node_statement_statistics
+
 # Check that multi-value clauses are shortened.
 
 statement ok
@@ -69,7 +80,24 @@ SELECT key FROM crdb_internal.node_statement_statistics WHERE application_name =
 ----
 INSERT INTO test VALUES (_, _, _)
 SELECT ROW(_, _, _, _, _) FROM test WHERE _
+SELECT key FROM crdb_internal.node_statement_statistics
+SELECT sin(_)
 SELECT x FROM (VALUES (_, _, _)) AS t (x)
 SELECT x FROM test WHERE y IN (_, _)
 SELECT x FROM test WHERE y IN (_, _, _ + x, _, _)
 SELECT x FROM test WHERE y NOT IN (_, _)
+
+# Check that names are anonymized properly:
+# - virtual table names are preserved
+# - function names are preserved
+query T
+SELECT anonymized FROM crdb_internal.node_statement_statistics WHERE application_name = 'valuetest' ORDER BY key
+----
+INSERT INTO _ VALUES (_, _, _)
+SELECT ROW(_, _, _, _, _) FROM _ WHERE _
+SELECT _ FROM crdb_internal.node_statement_statistics
+SELECT sin(_)
+SELECT _ FROM (VALUES (_, _, _)) AS _ (_)
+SELECT _ FROM _ WHERE _ IN (_, _)
+SELECT _ FROM _ WHERE _ IN (_, _, _ + _, _, _)
+SELECT _ FROM _ WHERE _ NOT IN (_, _)


### PR DESCRIPTION
(Needed for  #13968)

This patch augments the `crdb_internal.node_statement_statistics` with
a new column `anonymized` which contains a copy of the collection key
devoid of any identifying information. The column is NULL if such an
anonymized version cannot be computed.

Function names and virtual table names are preserved.

For example:

```
> -- not anonymized
> SELECT key FROM crdb_internal.node_statement_statistics
INSERT INTO test VALUES (_, _, _)
SELECT ROW(_, _, _, _, _) FROM test WHERE _
SELECT key FROM crdb_internal.node_statement_statistics
SELECT sin(_)
SELECT x FROM (VALUES (_, _, _)) AS t (x)
SELECT x FROM test WHERE y IN (_, _)
SELECT x FROM test WHERE y IN (_, _, _ + x, _, _)
SELECT x FROM test WHERE y NOT IN (_, _)

> -- anonymized
> SELECT anonymized FROM crdb_internal.node_statement_statistics
INSERT INTO _ VALUES (_, _, _)
SELECT ROW(_, _, _, _, _) FROM _ WHERE _
SELECT _ FROM crdb_internal.node_statement_statistics
SELECT sin(_)
SELECT _ FROM (VALUES (_, _, _)) AS _ (_)
SELECT _ FROM _ WHERE _ IN (_, _)
SELECT _ FROM _ WHERE _ IN (_, _, _ + _, _, _)
SELECT _ FROM _ WHERE _ NOT IN (_, _)
```

cc @petermattis 