### PR TITLE
server: Clarify error message you get when rejected by debug pages

### DIFF
--- a/pkg/acceptance/debug_remote_test.go
+++ b/pkg/acceptance/debug_remote_test.go
@@ -56,9 +56,9 @@ func TestDebugRemote(t *testing.T) {
 		{"TRUE", http.StatusOK},
 		{"t", http.StatusOK},
 		{"1", http.StatusOK},
-		{"local", http.StatusUnauthorized},
-		{"false", http.StatusUnauthorized},
-		{"unrecognized", http.StatusUnauthorized},
+		{"local", http.StatusForbidden},
+		{"false", http.StatusForbidden},
+		{"unrecognized", http.StatusForbidden},
 	}
 	for _, c := range testCases {
 		t.Run(c.remoteDebug, func(t *testing.T) {

--- a/pkg/server/debug.go
+++ b/pkg/server/debug.go
@@ -78,7 +78,8 @@ func init() {
 
 	debugServeMux.HandleFunc(debugEndpoint, func(w http.ResponseWriter, r *http.Request) {
 		if any, _ := trace.AuthRequest(r); !any {
-			http.Error(w, "not allowed", http.StatusUnauthorized)
+			http.Error(w, "not allowed (due to the 'server.remote_debugging.mode' setting)",
+				http.StatusForbidden)
 			return
 		}
 


### PR DESCRIPTION
Help nudge the user toward the way to get themselves allowed in.

Also, HTTP status Unauthorized is for situations where the client
is lacking authentication but could come back with proper
authentication. The Forbidden status is for situations where you're
flat out getting rejected and coming back with different
authentication won't help, which seems to be the case here.