### PR TITLE
migrations: create new system tables in bootstrap instead

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -173,7 +173,7 @@ func TestGetLargestID(t *testing.T) {
 		}, 12, 0, ""},
 
 		// Real SQL layout.
-		{sqlbase.MakeMetadataSchema().GetInitialValues(), keys.MaxSystemConfigDescID + 4, 0, ""},
+		{sqlbase.MakeMetadataSchema().GetInitialValues(), keys.MaxSystemConfigDescID + 5, 0, ""},
 
 		// Test non-zero max.
 		{[]roachpb.KeyValue{

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -550,12 +550,15 @@ func addSystemDatabaseToSchema(target *MetadataSchema) {
 	target.AddConfigDescriptor(keys.SystemDatabaseID, &DescriptorTable)
 	target.AddConfigDescriptor(keys.SystemDatabaseID, &UsersTable)
 	target.AddConfigDescriptor(keys.SystemDatabaseID, &ZonesTable)
+	target.AddConfigDescriptor(keys.SystemDatabaseID, &SettingsTable)
 
 	// Add all the other system tables.
 	target.AddDescriptor(keys.SystemDatabaseID, &LeaseTable)
 	target.AddDescriptor(keys.SystemDatabaseID, &EventLogTable)
 	target.AddDescriptor(keys.SystemDatabaseID, &RangeEventTable)
 	target.AddDescriptor(keys.SystemDatabaseID, &UITable)
+
+	target.AddDescriptor(keys.SystemDatabaseID, &JobsTable)
 
 	// NOTE(benesch): Installation of the jobs table is intentionally omitted
 	// here; it's added via a migration in both fresh clusters and existing


### PR DESCRIPTION
previous we'd skip the jobs and settings system tables in boostrap and then create them in the migration after bootstrap, but that migraion frequently then led to intent-on-config-range complaints.