### PR TITLE
acceptance/cli: improve the expect tests

### DIFF
--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -18,21 +18,51 @@ set timeout 30
 # and this confuses readline. Ensure sane defaults here.
 set stty_init "cols 80 rows 25"
 
+# Convenience function to tag what's going on in log files.
+proc report {text} {
+    system "echo; echo \$(date '+.%y%m%d %H:%M:%S.%N') EXPECT TEST: '$text' | tee -a cmd.log"
+}
+
+# Upon termination
+proc report_log_files {} {
+    system "(echo '==COMMAND OUTPUT=='; cat cmd.log; echo '==DB LOG=='; cat cockroach-data/logs/cockroach.log; echo '==END==') || true"
+}
+
+# Catch signals
+proc mysig {} {
+    report "EXPECT KILLED BY SIGNAL"
+    report_log_files
+    exit 130
+}
+trap mysig SIGINT
+trap mysig SIGTERM
+
+# Convenience functions to tag a test
+proc start_test {text} {
+    report "START TEST: $text"
+}
+proc end_test {} {
+    report "END TEST"
+}
+
 # Convenience wrapper function, which ensures that all expects are
 # mandatory (i.e. with a mandatory fail if the expected output doesn't
 # show up fast).
+proc handle_timeout {text} {
+    report "TIMEOUT WAITING FOR \"$text\""
+    report_log_files
+    exit 1
+}
 proc eexpect {text} {
     expect {
 	$text {}
-	timeout {
-	    system "echo SERVER STDOUT; cat stdout.log; echo SERVER STDERR; cat stderr.log"
-	    exit 1
-	}
+	timeout { handle_timeout $text }
     }
 }
 
 # Convenience function that sends Ctrl+C to the monitored process.
 proc interrupt {} {
+    report "INTERRUPT TO FOREGROUND PROCESS"
     send "\003"
     sleep 0.4
 }
@@ -41,8 +71,12 @@ proc interrupt {} {
 # Preserves the invariant that the server's PID is saved
 # in `server_pid`.
 proc start_server {argv} {
-    system "mkfifo pid_fifo || true; $argv start --insecure --pid-file=pid_fifo --background >>stdout.log 2>>stderr.log & cat pid_fifo > server_pid"
+    report "BEGIN START SERVER"
+    system "mkfifo pid_fifo || true; $argv start --insecure --pid-file=pid_fifo --background >>cmd.log 2>&1 & cat pid_fifo > server_pid"
+    report "START SERVER DONE"
 }
 proc stop_server {argv} {
+    report "BEGIN STOP SERVER"
     system "$argv quit"
+    report "END STOP SERVER"
 }

--- a/pkg/cli/interactive_tests/test_client_side_checking.tcl
+++ b/pkg/cli/interactive_tests/test_client_side_checking.tcl
@@ -7,7 +7,7 @@ start_server $argv
 spawn $argv sql
 eexpect root@
 
-# Check that syntax errors are handled client-side when running interactive.
+start_test "Check that syntax errors are handled client-side when running interactive."
 send "begin;\r\r"
 eexpect BEGIN
 eexpect root@
@@ -23,8 +23,9 @@ eexpect root@
 send "commit;\r"
 eexpect COMMIT
 eexpect root@
+end_test
 
-# Check that the user can force server-side handling.
+start_test "Check that the user can force server-side handling."
 send "\\unset check_syntax\r"
 eexpect root@
 
@@ -45,8 +46,9 @@ eexpect root@
 
 interrupt
 eexpect eof
+end_test
 
-# Check that syntax errors are handled server-side by default when running non-interactive.
+start_test "Check that syntax errors are handled server-side by default when running non-interactive."
 spawn /bin/bash
 send "PS1=':''/# '\r"
 eexpect ":/# "
@@ -65,9 +67,9 @@ eexpect "COMMIT"
 eexpect ":/# "
 send "echo \$?\r"
 eexpect "0\r\n:/# "
+end_test
 
 send "exit 0\r"
 eexpect eof
 
 stop_server $argv
-

--- a/pkg/cli/interactive_tests/test_error_handling.tcl
+++ b/pkg/cli/interactive_tests/test_error_handling.tcl
@@ -8,14 +8,15 @@ spawn /bin/bash
 send "PS1=':''/# '\r"
 eexpect ":/# "
 
-# Check that by default, an error prevents subsequent statements from running.
+start_test "Check that by default, an error prevents subsequent statements from running."
 send "(echo 'select foo;'; echo 'select 1;') | $argv sql\r"
 eexpect "pq: column name \"foo\" not found\r\nError: pq: column name"
 eexpect ":/# "
 send "echo \$?\r"
 eexpect "1\r\n:/# "
+end_test
 
-# Check that a user can request to continue upon failures.
+start_test "Check that a user can request to continue upon failures."
 send "(echo '\\unset errexit'; echo 'select foo;'; echo 'select 1;') | $argv sql\r"
 eexpect "pq: column name \"foo\" not found"
 eexpect "1 row"
@@ -25,13 +26,15 @@ eexpect "0\r\n:/# "
 
 send "$argv sql\r"
 eexpect "root@"
+end_test
 
-# Check that by default, an error does not cause an interactive failure.
+start_test "Check that by default, an error does not cause an interactive failure."
 send "select foo;\r"
 eexpect "pq: column name"
 eexpect "root@"
+end_test
 
-# Check that the user can ask for errors to terminate the interactive client.
+start_test "Check that the user can ask for errors to terminate the interactive client."
 send "\\set errexit\r"
 eexpect "root@"
 send "select foo;\r"
@@ -39,6 +42,7 @@ eexpect "Error: pq: column name"
 eexpect ":/# "
 send "echo \$?\r"
 eexpect "1\r\n:/# "
+end_test
 
 send "exit 0\r"
 eexpect eof

--- a/pkg/cli/interactive_tests/test_example_data.tcl
+++ b/pkg/cli/interactive_tests/test_example_data.tcl
@@ -8,31 +8,35 @@ spawn /bin/bash
 send "PS1=':''/# '\r"
 eexpect ":/# "
 
-# Check that the startrek example can be loaded in the db.
+start_test "Check that the startrek example can be loaded in the db."
 send "$argv gen example-data startrek | $argv sql\r"
 eexpect ":/# "
 send "echo \$?\r"
 eexpect "0\r\n:/# "
+end_test
 
-# Check that the startrek example is loaded.
+start_test "Check that the startrek example is loaded."
 send "$argv sql -e 'SELECT COUNT(*) FROM startrek.quotes'\r"
 eexpect "COUNT"
 eexpect "200"
 eexpect "1 row"
 eexpect ":/# "
+end_test
 
-# Check that the intro example can be loaded in the db.
+start_test "Check that the intro example can be loaded in the db."
 send "$argv gen example-data intro | $argv sql\r"
 eexpect ":/# "
 send "echo \$?\r"
 eexpect "0\r\n:/# "
+end_test
 
-# Check that the startrek example is loaded.
+start_test "Check that the startrek example is loaded."
 send "$argv sql -e 'SELECT COUNT(*) FROM intro.mytable'\r"
 eexpect "COUNT"
 eexpect "42"
 eexpect "1 row"
 eexpect ":/# "
+end_test
 
 # Clean up.
 send "exit 0\r"

--- a/pkg/cli/interactive_tests/test_high_verbosity.tcl
+++ b/pkg/cli/interactive_tests/test_high_verbosity.tcl
@@ -8,19 +8,21 @@ spawn /bin/bash
 send "PS1=':''/# '\r"
 eexpect ":/# "
 
-# Check that queries using tables can complete without error.
+start_test "Check that queries using tables can complete without error."
 send "echo 'create database d; create table d.t(x int); insert into d.t values(1); select x from d.t;' | $argv sql\r"
 eexpect "1 row"
 eexpect ":/# "
 send "echo 'select x\[1\] from (select array\[1,2,3\]) as t(x);' | $argv sql\r"
 eexpect "1 row"
 eexpect ":/# "
+end_test
 
-# Check that the node is alive.
+start_test "Check that the node is alive."
 send "$argv node status\r"
 eexpect ":/# "
 send "echo \$?\r"
 eexpect "\r\n0\r\n"
 eexpect ":/# "
+end_test
 
 stop_server $argv

--- a/pkg/cli/interactive_tests/test_history.tcl
+++ b/pkg/cli/interactive_tests/test_history.tcl
@@ -12,57 +12,63 @@ send "select 1;\r"
 eexpect "1 row"
 eexpect root@
 
-# Test that last line can be recalled with arrow-up
+start_test "Test that last line can be recalled with arrow-up"
 send "\033\[A"
 eexpect "SELECT 1;"
+end_test
 
-# Test that recalled last line can be executed
+start_test "Test that recalled last line can be executed"
 send "\r"
 eexpect "1 row"
 eexpect root@
+end_test
 
-# Test that we can recall a previous line with Ctrl+R
+start_test "Test that we can recall a previous line with Ctrl+R"
 send "foo;\r"
 eexpect "syntax error"
 eexpect root@
 send "\022sel"
 eexpect "SELECT 1;"
+end_test
 
-# Test that recalled previous line can be executed
+start_test "Test that recalled previous line can be executed"
 send "\r"
 eexpect "1 row"
 eexpect root@
+end_test
 
-# Test that last recalled line becomes top of history
+start_test "Test that last recalled line becomes top of history"
 send "\033\[A"
 eexpect "SELECT 1;"
+end_test
 
-# Test that client cannot terminate with Ctrl+D while cursor
-# is on recalled line
+start_test "Test that client cannot terminate with Ctrl+D while cursor is on recalled line"
 send "\004"
 send "\r"
 eexpect "1 row"
 eexpect root@
+end_test
 
-# Test that Ctrl+D does terminate client on empty line
+start_test "Test that Ctrl+D does terminate client on empty line"
 send "\004"
 eexpect eof
+end_test
 
-# Test that history is preserved across runs
+start_test "Test that history is preserved across runs"
 spawn $argv sql
 eexpect root@
 send "\033\[A"
 eexpect "SELECT 1;"
+end_test
 
-# Test that the client cannot terminate with Ctrl+C while
-# cursor is on recalled line
+start_test "Test that the client cannot terminate with Ctrl+C while cursor is on recalled line"
 interrupt
 send "\rselect 1;\r"
 eexpect "1 row"
 eexpect root@
+end_test
 
-# Test that ambiguous datum types are pretty-printed in a parsable
-# form. #14484
+start_test "Test that ambiguous datum types are pretty-printed in a parsable form. #14484"
 send "SELECT INTERVAL '4' SECOND;\r"
 eexpect "1 row"
 eexpect root@
@@ -71,8 +77,9 @@ eexpect "SELECT '4s':::INTERVAL;"
 send "\r"
 eexpect "1 row"
 eexpect root@
+end_test
 
-# Test that two statements on the same line can be recalled together.
+start_test "Test that two statements on the same line can be recalled together."
 send "select 2; select 3;\r"
 eexpect "1 row"
 eexpect "1 row"
@@ -83,6 +90,7 @@ send "\r"
 eexpect "1 row"
 eexpect "1 row"
 eexpect root@
+end_test
 
 # Finally terminate with Ctrl+C
 interrupt

--- a/pkg/cli/interactive_tests/test_last_statement.tcl
+++ b/pkg/cli/interactive_tests/test_last_statement.tcl
@@ -11,7 +11,7 @@ eexpect ":/# "
 send "$argv sql\r"
 eexpect root@
 
-# Check that an error in the last statement is propagated to the shell.
+start_test "Check that an error in the last statement is propagated to the shell."
 send "select ++;\r"
 eexpect "syntax error"
 eexpect root@
@@ -20,9 +20,9 @@ eexpect ":/# "
 send "echo hello \$?\r"
 eexpect "hello 1"
 eexpect ":/# "
+end_test
 
-# Check that an incomplete last statement in interactive mode is not
-# executed.
+start_test "Check that an incomplete last statement in interactive mode is not executed."
 send "$argv sql\r"
 eexpect root@
 send "drop database if exists t; create database t; create table t.foo(x int);\r"
@@ -40,16 +40,15 @@ eexpect "0 rows"
 eexpect root@
 send "\\q\r"
 eexpect ":/# "
+end_test
 
-# Check that an incomplete last statement in non-interactive mode
-# is not executed, and fails with a warning. #8838
+start_test "Check that an incomplete last statement in non-interactive mode is not executed, and fails with a warning. #8838"
 send "echo 'insert into t.foo(x) values (42)' | $argv sql\r"
 eexpect "missing semicolon at end of statement"
 eexpect ":/# "
+end_test
 
-# Check that a final comment after a missing semicolon and without
-# newline is properly ignored when reasoning about the last
-# statement. #9482
+start_test "Check that a final comment after a missing semicolon and without newline is properly ignored. #9482"
 send "echo 'insert into t.foo(x) values (42)--;' | $argv sql\r"
 eexpect "missing semicolon at end of statement"
 eexpect ":/# "
@@ -57,24 +56,26 @@ eexpect ":/# "
 send "echo 'select * from t.foo;' | $argv sql\r"
 eexpect "0 rows"
 eexpect ":/# "
+end_test
 
-# Check that a complete last statement terminated with a semicolon
-# just before EOF and without a newline is properly executed. #7328
+start_test "Check that a complete last statement terminated with a semicolon just before EOF and without a newline is properly executed. #7328"
 send "printf 'insert into t.foo(x) values(42);' | $argv sql\r"
 eexpect "INSERT"
 eexpect ":/# "
 send "echo 'select * from t.foo;' | $argv sql\r"
 eexpect "1 row"
 eexpect ":/# "
+end_test
 
-# Check that a final comment after a final statement does not cause an
-# error message. #9482
+start_test "Check that a final comment after a final statement does not cause an error message. #9482"
 send "printf 'select 1;-- final comment' | $argv sql\r"
 eexpect "1 row\r\n1\r\n1\r\n:/# "
+end_test
 
-# Check that a final comment does not cause an error message. #9243
+start_test "Check that a final comment does not cause an error message. #9243"
 send "printf 'select 1;\\n-- final comment' | $argv sql\r"
 eexpect "1 row\r\n1\r\n1\r\n:/# "
+end_test
 
 # Finally terminate with Ctrl+C
 send "exit\r"

--- a/pkg/cli/interactive_tests/test_local_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_local_cmds.tcl
@@ -7,39 +7,43 @@ start_server $argv
 spawn $argv sql
 eexpect root@
 
-# Check that \? prints the help text.
+start_test "Check that \\? prints the help text."
 send "\\?\r"
 eexpect "You are using"
 eexpect "More documentation"
 eexpect root@
+end_test
 
-# Check that \! invokes external commands.
+start_test "Check that \\! invokes external commands."
 send "\\! echo -n he; echo llo\r"
 eexpect "hello"
 eexpect "root@"
+end_test
 
-# Check that \q terminates the client.
+start_test "Check that \\q terminates the client."
 send "\\q\r"
 eexpect eof
 spawn $argv sql --format=tsv
 eexpect root@
+end_test
 
-# Check that \| reads statements.
+start_test "Check that \\| reads statements."
 send "\\| echo 'select '; echo '38 + 4;'\r"
 eexpect "1 row"
 eexpect 42
 eexpect root@
+end_test
 
-# Check that \| does not execute upon encountering an error.
+start_test "Check that \\| does not execute upon encountering an error."
 send "\\| echo 'create database dontcreate;'; exit 1\r"
 eexpect "error in external command"
 eexpect root@
 send "drop database dontcreate;\r"
 eexpect "database * does not exist"
 eexpect root@
+end_test
 
-# Check that a buit-in command in between tokens of a statement is
-# processed locally.
+start_test "Check that a buit-in command in between tokens of a statement is processed locally."
 send "select\r"
 eexpect " ->"
 
@@ -49,28 +53,31 @@ eexpect " ->"
 send "1;\r"
 eexpect "1 row"
 eexpect root@
+end_test
 
-# Check that \set without argument prints the current options
+start_test "Check that \\set without argument prints the current options"
 send "\\set\r"
 eexpect "4 rows"
 eexpect "display_format\ttsv"
 eexpect root@
+end_test
 
-# Check that \set display_format properly errors out
+start_test "Check that \\set display_format properly errors out"
 send "\\set display_format blabla\r"
 eexpect "invalid table display format"
 # check we don't see a stray "cannot change option during multi-line editing" tacked at the end
 eexpect "html)\r\n"
 eexpect root@
+end_test
 
-# Check that \set can change the display format
+start_test "Check that \\set can change the display format"
 send "\\set display_format csv\r\\set\r"
 eexpect "4 rows"
 eexpect "display_format,csv"
 eexpect root@
+end_test
 
-# Check that a built-in command in the middle of a token (eg a string)
-# is processed locally.
+start_test "Check that a built-in command in the middle of a token (eg a string) is processed locally."
 send "select 'hello\r"
 eexpect " ->"
 send "\\h\r"
@@ -79,6 +86,7 @@ send "world';\r"
 eexpect "1 row"
 eexpect "hello\\\\nworld"
 eexpect root@
+end_test
 
 # Finally terminate with Ctrl+C.
 interrupt
@@ -88,8 +96,7 @@ spawn /bin/bash
 send "PS1=':''/# '\r"
 eexpect ":/# "
 
-# Now check that non-interactive built-in commands are only accepted
-# at the start of a statement.
+start_test "Check that non-interactive built-in commands are only accepted at the start of a statement."
 send "(echo '\\set check_syntax'; echo 'select '; echo '\\help'; echo '1;') | $argv sql\r"
 eexpect "statement ignored"
 eexpect ":/# "
@@ -97,6 +104,7 @@ eexpect ":/# "
 send "(echo '\\unset check_syntax'; echo 'select '; echo '\\help'; echo '1;') | $argv sql\r"
 eexpect "pq: syntax error"
 eexpect ":/# "
+end_test
 
 send "exit 0\r"
 eexpect eof

--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -9,11 +9,11 @@ spawn /bin/bash
 send "PS1=':''/# '\r"
 eexpect ":/# "
 
-# Check that a server started with only in-memory stores automatically
-# logs to stderr.
+start_test "Check that a server started with only in-memory stores automatically logs to stderr."
 send "$argv start --insecure --store=type=mem,size=1GiB\r"
 eexpect "CockroachDB"
 eexpect "starting cockroach node"
+end_test
 
 # Stop it.
 interrupt
@@ -26,19 +26,20 @@ eexpect "num_replicas: 1"
 eexpect ":/# "
 stop_server $argv
 
-# Check that a server started with --logtostderr
-# logs even info messages to stderr.
+start_test "Check that a server started with --logtostderr logs even info messages to stderr."
 send "$argv start --insecure --logtostderr\r"
 eexpect "CockroachDB"
 eexpect "starting cockroach node"
+end_test
 
 # Stop it.
 interrupt
 eexpect ":/# "
 
-# Check that --logtostderr can override the threshold but no error is printed on startup
+start_test "Check that --logtostderr can override the threshold but no error is printed on startup"
 send "echo marker; $argv start --insecure --logtostderr=ERROR 2>&1 | grep -v '^\\*'\r"
 eexpect "marker\r\nCockroachDB node starting"
+end_test
 
 # Stop it.
 interrupt
@@ -46,15 +47,17 @@ eexpect ":/# "
 
 start_server $argv
 
-# Now test `quit` as non-start command, and test that `quit` does not
-# emit logging output between the point the command starts until it
+start_test "Test that quit does not emit unwanted logging output"
+# Unwanted: between the point the command starts until it
 # either prints the final ok message or fails with some error
 # (e.g. due to no definite answer from the server).
 send "echo marker; $argv quit 2>&1 | grep '^\\(\[IWEF\]\[0-9\]\\)' \r"
 set timeout 20
 eexpect "marker\r\n:/# "
 set timeout 5
+end_test
 
+start_test "Test that quit does not show INFO by defaults with --logtostderr"
 # Test quit as non-start command, this time with --logtostderr. Test
 # that the default logging level is WARNING, so that no INFO messages
 # are printed between the marker and the (first line) error message
@@ -62,11 +65,13 @@ set timeout 5
 send "echo marker; $argv quit --logtostderr\r"
 eexpect "marker\r\nError"
 eexpect ":/# "
+end_test
 
-# Now check that `--logtostderr` can override the default
+start_test "Check that `--logtostderr` can override the default"
 send "$argv quit --logtostderr=INFO --vmodule=stopper=1\r"
 eexpect "stop has been called"
 eexpect ":/# "
+end_test
 
 send "exit\r"
 eexpect eof

--- a/pkg/cli/interactive_tests/test_pretty.tcl
+++ b/pkg/cli/interactive_tests/test_pretty.tcl
@@ -10,38 +10,37 @@ eexpect ":/# "
 
 # Check table ASCII art with and without --format=pretty. (#7268)
 
-# Check that tables are pretty-printed when input is not a terminal
-# but --format=pretty is specified.
+start_test "Check that tables are pretty-printed when input is not a terminal but --format=pretty is specified."
 send "echo 'select 1;' | $argv sql --format=pretty\r"
 eexpect "+-*+\r\n*\r\n+-*+\r\n*1 row"
 eexpect ":/# "
+end_test
 
-# Check that tables are not pretty-printed when input is not a terminal
-# and --format=pretty is not speciifed.
+start_test "Check that tables are not pretty-printed when input is not a terminal and --format=pretty is not specified."
 send "echo begin; echo 'select 1;' | $argv sql\r"
 eexpect "begin\r\n1 row\r\n1\r\n1\r\n"
+end_test
 
-# Check that tables are pretty-printed when input is a terminal
-# and --format=pretty is not specified.
+start_test "Check that tables are pretty-printed when input is a terminal and --format=pretty is not specified."
 send "$argv sql\r"
 eexpect root@
 send "select 1;\r"
 eexpect "+-*+\r\n*\r\n+-*+\r\n*1 row"
 send "\\q\r"
 eexpect ":/# "
+end_test
 
-# Check that tables are not pretty-printed when input is a terminal
-# and --format=tsv is specified.
+start_test "Check that tables are not pretty-printed when input is a terminal and --format=tsv is specified."
 send "$argv sql --format=tsv\r"
 eexpect root@
 send "select 42; select 1;\r"
 eexpect "42\r\n1 row\r\n1\r\n1\r\n"
 eexpect root@
 send "\\q\r"
+end_test
 
 eexpect ":/# "
 send "exit\r"
 eexpect eof
 
 stop_server $argv
-

--- a/pkg/cli/interactive_tests/test_reconnect.tcl
+++ b/pkg/cli/interactive_tests/test_reconnect.tcl
@@ -23,7 +23,7 @@ eexpect "opening new connection"
 expect {
     "connection refused" {}
     "connection reset by peer" {}
-    timeout {exit 1}
+    timeout { handle_timeout "connection error" }
 }
 eexpect root@
 

--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -6,11 +6,15 @@ set certs_dir "/certs"
 set ::env(COCKROACH_INSECURE) "false"
 
 proc start_secure_server {argv certs_dir} {
-    system "mkfifo pid_fifo || true; $argv start --certs-dir=$certs_dir --pid-file=pid_fifo >>stdout.log 2>>stderr.log & cat pid_fifo > server_pid"
+    report "BEGIN START SECURE SERVER"
+    system "mkfifo pid_fifo || true; $argv start --certs-dir=$certs_dir --pid-file=pid_fifo >>cmd.log 2>&1 & cat pid_fifo > server_pid"
+    report "END START SECURE SERVER"
 }
 
 proc stop_secure_server {argv certs_dir} {
+    report "BEGIN STOP SECURE SERVER"
     system "set -e; if kill -CONT `cat server_pid`; then $argv quit --certs-dir=$certs_dir || true & sleep 1; kill -9 `cat server_pid` || true; else $argv quit --certs-dir=$certs_dir || true; fi"
+    report "END STOP SECURE SERVER"
 }
 
 start_secure_server $argv $certs_dir
@@ -21,36 +25,40 @@ send "PS1=':''/# '\r"
 set prompt ":/# "
 eexpect $prompt
 
+start_test "Check 'node ls' works with certificates."
 send "$argv node ls --certs-dir=$certs_dir\r"
 eexpect "id"
 eexpect "1"
 eexpect "1 row"
-
 eexpect $prompt
+end_test
 
-# Cannot create users with empty passwords.
+start_test "Cannot create users with empty passwords."
 send "$argv user set carl --password --certs-dir=$certs_dir\r"
 eexpect "Enter password:"
 send "\r"
 eexpect "empty passwords are not permitted"
-
 eexpect $prompt
+end_test
 
+start_test "Check a password can be changed."
 send "$argv user set carl --password --certs-dir=$certs_dir\r"
 eexpect "Enter password:"
 send "woof\r"
 eexpect "Confirm password:"
 send "woof\r"
 eexpect "INSERT 1\r\n"
-
 eexpect $prompt
+end_test
 
+start_test "Check a password is requested by the client."
 send "$argv sql --certs-dir=$certs_dir --user=carl\r"
 eexpect "Enter password:"
 send "woof\r"
 eexpect "Confirm password:"
 send "woof\r"
 eexpect "carl@"
+end_test
 
 # Terminate with Ctrl+C.
 interrupt

--- a/pkg/cli/interactive_tests/test_server_restart.tcl
+++ b/pkg/cli/interactive_tests/test_server_restart.tcl
@@ -11,8 +11,8 @@ spawn /bin/bash
 send "PS1=':''/# '\r"
 eexpect ":/# "
 
-# Test that dropping a table a node held a lease on before a restart doesn't
-# hang. We use a SELECT statement to acquire a lease on the table.
+start_test "Test that dropping a table a node held a lease on before a restart does not hang."
+# We use a SELECT statement to acquire a lease on the table.
 send "$argv sql -e \"create database t; create table t.t (x INT); select * from t.t;\"\r"
 eexpect "(0 rows)"
 
@@ -21,5 +21,7 @@ start_server $argv
 
 send "$argv sql -e \"drop table t.t;\"\r"
 eexpect "DROP TABLE"
+eexpect ":/# "
+end_test
 
 stop_server $argv

--- a/pkg/cli/interactive_tests/test_server_sig.tcl
+++ b/pkg/cli/interactive_tests/test_server_sig.tcl
@@ -9,7 +9,7 @@ spawn /bin/bash
 send "PS1='\\h:''/# '\r"
 eexpect ":/# "
 
-# Check that the server shuts down upon receiving SIGTERM.
+start_test "Check that the server shuts down upon receiving SIGTERM"
 send "$argv start --insecure --pid-file=server_pid\r"
 eexpect "initialized"
 
@@ -17,13 +17,15 @@ system "kill `cat server_pid`"
 eexpect "initiating graceful shutdown"
 eexpect "shutdown completed"
 eexpect ":/# "
+end_test
 
-# SIGTERM finishes with exit code 0. (#9051)
+start_test "Check that server stopped with SIGTERM finishes with exit code 0. (#9051)"
 send "echo \$?\r"
 eexpect "0\r\n"
 eexpect ":/# "
+end_test
 
-# Check that the server shuts down upon receiving Ctrl+C.
+start_test "Check that the server shuts down upon receiving Ctrl+C."
 send "$argv start --insecure --pid-file=server_pid\r"
 eexpect "restarted"
 
@@ -31,13 +33,15 @@ interrupt
 eexpect "initiating graceful shutdown"
 eexpect "shutdown completed"
 eexpect ":/# "
+end_test
 
-# Ctrl+C finishes with exit code 1. (#9051)
+start_test "Check that Ctrl+C finishes with exit code 1. (#9051)"
 send "echo \$?\r"
 eexpect "1\r\n"
 eexpect ":/# "
+end_test
 
-# Check that the server shuts down fast upon receiving Ctrl+C twice.
+start_test "Check that the server shuts down fast upon receiving Ctrl+C twice."
 send "$argv start --insecure --pid-file=server_pid\r"
 eexpect "restarted"
 interrupt
@@ -47,14 +51,16 @@ interrupt
 expect {
     "hard shutdown" {}
     "shutdown completed" {}
-    timeout {exit 1}
+    timeout { handle_timeout "server shutdown message" }
 }
 eexpect ":/# "
+end_test
 
-# Ctrl+C twice finishes with exit code 130. (#9051)
+start_test "Check that Ctrl+C twice finishes with exit code 130. (#9051)"
 send "echo \$?\r"
 eexpect "130\r\n"
 eexpect ":/# "
+end_test
 
 send "exit\r"
 eexpect eof

--- a/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
+++ b/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
@@ -73,7 +73,7 @@ expect {
     "out of memory" {}
     "cannot allocate memory" {}
     "std::bad_alloc" {}
-    timeout {exit 1}
+    timeout { handle_timeout "memory allocation error" }
 }
 eexpect ":/# "
 

--- a/pkg/cli/interactive_tests/test_url_login.tcl
+++ b/pkg/cli/interactive_tests/test_url_login.tcl
@@ -4,12 +4,13 @@ source [file join [file dirname $argv0] common.tcl]
 
 start_server $argv
 
-# Check that the client can start when no username is specified.
+start_test "Check that the client can start when no username is specified."
 # This is run as an acceptance test to ensure that the code path
 # that generates the interactive prompt presented to the user is
 # also exercised by the test.
 spawn $argv sql --url "postgresql://localhost:26257?sslmode=disable"
 eexpect @localhost
+end_test
 
 send "\004"
 eexpect eof


### PR DESCRIPTION
This patch does two things of note:

1. it ensures that `cockroach.log` is also dumped in the test logs in
   case of failures. Prior to this patch, this information was simply
   lost, making issues difficult to troubleshoot.

2. it also creates a log file of the test's progress, and delinates
   the test actions using log messages that go both to this log file
   and the standard output. The log file is also dumped in case of
   failures.

With this patch in, we will get more useful output out of `expect`.

Also, this patch makes it more useful and readable to run `expect -f
...` instead of `expect -d -f ...` as was previously advised.

cc @petermattis 