### PR TITLE
sql: track memory used by builtins

### DIFF
--- a/pkg/sql/analyze_test.go
+++ b/pkg/sql/analyze_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -138,7 +140,8 @@ func TestSplitOrExpr(t *testing.T) {
 	}
 	for _, d := range testData {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
-			evalCtx := &parser.EvalContext{}
+			evalCtx := parser.NewTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
 			sel := makeSelectNode(t)
 			expr := parseAndNormalizeExpr(t, evalCtx, d.expr, sel)
 			exprs := splitOrExpr(evalCtx, expr, nil)
@@ -163,7 +166,8 @@ func TestSplitAndExpr(t *testing.T) {
 	}
 	for _, d := range testData {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
-			evalCtx := &parser.EvalContext{}
+			evalCtx := parser.NewTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
 			sel := makeSelectNode(t)
 			expr := parseAndNormalizeExpr(t, evalCtx, d.expr, sel)
 			exprs := splitAndExpr(evalCtx, expr, nil)
@@ -284,7 +288,8 @@ func TestSimplifyExpr(t *testing.T) {
 	}
 	for _, d := range testData {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
-			evalCtx := &parser.EvalContext{}
+			evalCtx := parser.NewTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
 			sel := makeSelectNode(t)
 			expr := parseAndNormalizeExpr(t, evalCtx, d.expr, sel)
 			expr, equiv := simplifyExpr(evalCtx, expr)
@@ -324,7 +329,8 @@ func TestSimplifyNotExpr(t *testing.T) {
 	}
 	for _, d := range testData {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
-			evalCtx := &parser.EvalContext{}
+			evalCtx := parser.NewTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
 			sel := makeSelectNode(t)
 			expr1 := parseAndNormalizeExpr(t, evalCtx, d.expr, sel)
 			expr2, equiv := simplifyExpr(evalCtx, expr1)
@@ -360,7 +366,8 @@ func TestSimplifyAndExpr(t *testing.T) {
 	}
 	for _, d := range testData {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
-			evalCtx := &parser.EvalContext{}
+			evalCtx := parser.NewTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
 			sel := makeSelectNode(t)
 			expr1 := parseAndNormalizeExpr(t, evalCtx, d.expr, sel)
 			expr2, equiv := simplifyExpr(evalCtx, expr1)
@@ -564,7 +571,8 @@ func TestSimplifyAndExprCheck(t *testing.T) {
 	}
 	for _, d := range testData {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
-			evalCtx := &parser.EvalContext{}
+			evalCtx := parser.NewTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
 			sel := makeSelectNode(t)
 			expr1 := parseAndNormalizeExpr(t, evalCtx, d.expr, sel)
 			expr2, equiv := simplifyExpr(evalCtx, expr1)
@@ -615,7 +623,8 @@ func TestSimplifyOrExpr(t *testing.T) {
 	}
 	for _, d := range testData {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
-			evalCtx := &parser.EvalContext{}
+			evalCtx := parser.NewTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
 			sel := makeSelectNode(t)
 			expr1 := parseAndNormalizeExpr(t, evalCtx, d.expr, sel)
 			expr2, _ := simplifyExpr(evalCtx, expr1)
@@ -789,7 +798,8 @@ func TestSimplifyOrExprCheck(t *testing.T) {
 	}
 	for _, d := range testData {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
-			evalCtx := &parser.EvalContext{}
+			evalCtx := parser.NewTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
 			sel := makeSelectNode(t)
 			expr1 := parseAndNormalizeExpr(t, evalCtx, d.expr, sel)
 			expr2, equiv := simplifyExpr(evalCtx, expr1)

--- a/pkg/sql/analyze_test.go
+++ b/pkg/sql/analyze_test.go
@@ -291,6 +291,9 @@ func TestSimplifyExpr(t *testing.T) {
 			evalCtx := parser.NewTestingEvalContext()
 			defer evalCtx.Stop(context.Background())
 			sel := makeSelectNode(t)
+			// We need to manually close this memory account because we're doing the
+			// evals ourselves here.
+			defer evalCtx.ActiveMemAcc.Close(context.Background())
 			expr := parseAndNormalizeExpr(t, evalCtx, d.expr, sel)
 			expr, equiv := simplifyExpr(evalCtx, expr)
 			if s := expr.String(); d.expected != s {

--- a/pkg/sql/builtin_mem_usage_test.go
+++ b/pkg/sql/builtin_mem_usage_test.go
@@ -18,11 +18,13 @@ package sql
 
 import (
 	gosql "database/sql"
+	"fmt"
 	"testing"
 
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -65,7 +67,7 @@ CREATE TABLE d.t (a STRING)
 }
 
 // TestConcatAggMonitorsMemory verifies that the aggregates incrementally
-// record their memory usage as they builds up their result.
+// record their memory usage as they build up their result.
 func TestAggregatesMonitorMemory(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -90,5 +92,119 @@ func TestAggregatesMonitorMemory(t *testing.T) {
 		if _, err := sqlDB.Exec(statement); err.(*pq.Error).Code != pgerror.CodeOutOfMemoryError {
 			t.Fatalf("Expected \"%s\" to consume too much memory", statement)
 		}
+	}
+}
+
+func TestBuiltinsAccountForMemory(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testData := []struct {
+		builtin            parser.Builtin
+		args               parser.Datums
+		expectedAllocation int64
+	}{
+		{parser.Builtins["repeat"][0],
+			parser.Datums{
+				parser.NewDString("abc"),
+				parser.NewDInt(123),
+			},
+			int64(3 * 123)},
+		{parser.Builtins["concat"][0],
+			parser.Datums{
+				parser.NewDString("abc"),
+				parser.NewDString("abc"),
+			},
+			int64(3 + 3)},
+		{parser.Builtins["concat_ws"][0],
+			parser.Datums{
+				parser.NewDString("!"),
+				parser.NewDString("abc"),
+				parser.NewDString("abc"),
+			},
+			int64(3 + 1 + 3)},
+		{parser.Builtins["lower"][0],
+			parser.Datums{
+				parser.NewDString("ABC"),
+			},
+			int64(3)},
+	}
+
+	for _, test := range testData {
+		t.Run("", func(t *testing.T) {
+			evalCtx := parser.NewTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
+			defer evalCtx.ActiveMemAcc.Close(context.Background())
+			previouslyAllocated := evalCtx.Mon.GetCurrentAllocationForTesting()
+			_, err := test.builtin.Fn()(evalCtx, test.args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			deltaAllocated := evalCtx.Mon.GetCurrentAllocationForTesting() - previouslyAllocated
+			if deltaAllocated != test.expectedAllocation {
+				t.Errorf("Expected to allocate %d, actually allocated %d", test.expectedAllocation, deltaAllocated)
+			}
+		})
+	}
+}
+
+func TestEvaluatedMemoryIsChecked(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	// We select the LENGTH here and elsewhere because if we passed the result of
+	// REPEAT up as a result, the memory error would be caught there even if
+	// REPEAT was not doing its accounting.
+	testData := []string{
+		`SELECT LENGTH(REPEAT('abc', 300000))`,
+		`SELECT crdb_internal.no_constant_folding(LENGTH(REPEAT('abc', 300000)))`,
+	}
+
+	for _, statement := range testData {
+		t.Run("", func(t *testing.T) {
+			s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+				SQLMemoryPoolSize: lowMemoryBudget,
+			})
+			defer s.Stopper().Stop(context.Background())
+
+			if _, err := sqlDB.Exec(
+				statement,
+			); err.(*pq.Error).Code != pgerror.CodeOutOfMemoryError {
+				t.Errorf("Expected \"%s\" to OOM, but it didn't", statement)
+			}
+		})
+	}
+}
+
+func TestMemoryGetsFreedOnEachRow(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	// This test verifies that the memory allocated during the computation of a
+	// row gets freed before moving on to subsequent rows.
+
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		SQLMemoryPoolSize: lowMemoryBudget,
+	})
+	defer s.Stopper().Stop(context.Background())
+
+	stringLength := 300000
+	numRows := 100
+
+	// Check that if this string is allocated per-row, we don't OOM.
+	if _, err := sqlDB.Exec(
+		fmt.Sprintf(
+			`SELECT crdb_internal.no_constant_folding(LENGTH(REPEAT('a', %d))) FROM GENERATE_SERIES(1, %d)`,
+			stringLength,
+			numRows,
+		),
+	); err != nil {
+		t.Fatalf("Expected statement to run successfully, but got %s", err)
+	}
+
+	// Ensure that if this memory is all allocated at once, we OOM.
+	if _, err := sqlDB.Exec(
+		fmt.Sprintf(
+			`SELECT crdb_internal.no_constant_folding(LENGTH(REPEAT('a', %d * %d)))`,
+			stringLength,
+			numRows,
+		),
+	); err.(*pq.Error).Code != pgerror.CodeOutOfMemoryError {
+		t.Fatalf("Expected statement to OOM, but it didn't")
 	}
 }

--- a/pkg/sql/distsqlrun/aggregator_test.go
+++ b/pkg/sql/distsqlrun/aggregator_test.go
@@ -305,7 +305,7 @@ func TestAggregator(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		func() {
+		t.Run("", func(t *testing.T) {
 			ags := c.spec
 
 			var types []sqlbase.ColumnType
@@ -352,6 +352,6 @@ func TestAggregator(t *testing.T) {
 				t.Errorf("invalid results; expected:\n   %s\ngot:\n   %s",
 					expStr, retStr)
 			}
-		}()
+		})
 	}
 }

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -333,8 +333,9 @@ func (f *Flow) Cleanup(ctx context.Context) {
 	if f.status == FlowFinished {
 		panic("flow cleanup called twice")
 	}
-	// This closes the account and monitor opened in ServerImpl.setupFlow
-	f.evalCtx.Mon.Stop(ctx)
+	// This closes the account and monitor opened in ServerImpl.setupFlow.
+	f.evalCtx.ActiveMemAcc.Close(ctx)
+	f.evalCtx.Stop(ctx)
 	if log.V(1) {
 		log.Infof(ctx, "cleaning up")
 	}

--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -17,14 +17,12 @@
 package distsqlrun
 
 import (
-	"math"
 	"sort"
 	"strings"
 	"testing"
 
 	"golang.org/x/net/context"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/mon"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -485,8 +483,6 @@ func TestHashJoiner(t *testing.T) {
 		},
 	}
 
-	monitor := mon.MakeUnlimitedMonitor(context.Background(), "test", nil, nil, math.MaxInt64)
-	defer monitor.Stop(context.Background())
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
 			hs := c.spec

--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -493,7 +493,9 @@ func TestHashJoiner(t *testing.T) {
 			leftInput := NewRowBuffer(nil /* types */, c.inputs[0], RowBufferArgs{})
 			rightInput := NewRowBuffer(nil /* types */, c.inputs[1], RowBufferArgs{})
 			out := &RowBuffer{}
-			flowCtx := FlowCtx{evalCtx: parser.EvalContext{Mon: &monitor}}
+			evalCtx := parser.MakeTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
+			flowCtx := FlowCtx{evalCtx: evalCtx}
 
 			post := PostProcessSpec{Projection: true, OutputColumns: c.outCols}
 			h, err := newHashJoiner(&flowCtx, &hs, leftInput, rightInput, &post, out)
@@ -599,9 +601,9 @@ func TestHashJoinerDrain(t *testing.T) {
 	out := NewRowBuffer(
 		nil /* types */, nil, /* rows */
 		RowBufferArgs{AccumulateRowsWhileDraining: true})
-	monitor := mon.MakeUnlimitedMonitor(context.Background(), "test", nil, nil, math.MaxInt64)
-	defer monitor.Stop(context.Background())
-	flowCtx := FlowCtx{evalCtx: parser.EvalContext{Mon: &monitor}}
+	evalCtx := parser.MakeTestingEvalContext()
+	defer evalCtx.Stop(context.Background())
+	flowCtx := FlowCtx{evalCtx: evalCtx}
 
 	post := PostProcessSpec{Projection: true, OutputColumns: outCols}
 	h, err := newHashJoiner(&flowCtx, &spec, leftInput, rightInput, &post, out)
@@ -708,9 +710,9 @@ func TestHashJoinerDrainAfterBuildPhaseError(t *testing.T) {
 	out := NewRowBuffer(
 		nil /* types */, nil, /* rows */
 		RowBufferArgs{})
-	monitor := mon.MakeUnlimitedMonitor(context.Background(), "test", nil, nil, math.MaxInt64)
-	defer monitor.Stop(context.Background())
-	flowCtx := FlowCtx{evalCtx: parser.EvalContext{Mon: &monitor}}
+	evalCtx := parser.MakeTestingEvalContext()
+	defer evalCtx.Stop(context.Background())
+	flowCtx := FlowCtx{evalCtx: evalCtx}
 
 	post := PostProcessSpec{Projection: true, OutputColumns: outCols}
 	h, err := newHashJoiner(&flowCtx, &spec, leftInput, rightInput, &post, out)

--- a/pkg/sql/distsqlrun/input_sync_test.go
+++ b/pkg/sql/distsqlrun/input_sync_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -113,7 +115,9 @@ func TestOrderedSync(t *testing.T) {
 			rowBuf := NewRowBuffer(nil /* types */, srcRows, RowBufferArgs{})
 			sources = append(sources, rowBuf)
 		}
-		src, err := makeOrderedSync(c.ordering, &parser.EvalContext{}, sources)
+		evalCtx := parser.NewTestingEvalContext()
+		defer evalCtx.Stop(context.Background())
+		src, err := makeOrderedSync(c.ordering, evalCtx, sources)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/distsqlrun/joinreader_test.go
+++ b/pkg/sql/distsqlrun/joinreader_test.go
@@ -99,8 +99,10 @@ func TestJoinReader(t *testing.T) {
 		},
 	}
 	for _, c := range testCases {
+		evalCtx := parser.MakeTestingEvalContext()
+		defer evalCtx.Stop(context.Background())
 		flowCtx := FlowCtx{
-			evalCtx:  parser.EvalContext{},
+			evalCtx:  evalCtx,
 			txnProto: &roachpb.Transaction{},
 			// Pass a DB without a TxnCoordSender.
 			remoteTxnDB: client.NewDB(s.DistSender(), s.Clock()),
@@ -168,8 +170,10 @@ func TestJoinReaderDrain(t *testing.T) {
 	)
 	td := sqlbase.GetTableDescriptor(kvDB, "test", "t")
 
+	evalCtx := parser.MakeTestingEvalContext()
+	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
-		evalCtx:  parser.EvalContext{},
+		evalCtx:  evalCtx,
 		txnProto: &roachpb.Transaction{},
 		// Pass a DB without a TxnCoordSender.
 		remoteTxnDB: client.NewDB(s.DistSender(), s.Clock()),

--- a/pkg/sql/distsqlrun/mergejoiner_test.go
+++ b/pkg/sql/distsqlrun/mergejoiner_test.go
@@ -290,7 +290,9 @@ func TestMergeJoiner(t *testing.T) {
 			leftInput := NewRowBuffer(nil /* types */, c.inputs[0], RowBufferArgs{})
 			rightInput := NewRowBuffer(nil /* types */, c.inputs[1], RowBufferArgs{})
 			out := &RowBuffer{}
-			flowCtx := FlowCtx{evalCtx: parser.EvalContext{}}
+			evalCtx := parser.MakeTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
+			flowCtx := FlowCtx{evalCtx: evalCtx}
 
 			post := PostProcessSpec{Projection: true, OutputColumns: c.outCols}
 			m, err := newMergeJoiner(&flowCtx, &ms, leftInput, rightInput, &post, out)

--- a/pkg/sql/distsqlrun/outbox_test.go
+++ b/pkg/sql/distsqlrun/outbox_test.go
@@ -51,9 +51,10 @@ func TestOutbox(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
+	evalCtx := parser.MakeTestingEvalContext()
+	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
-		evalCtx: parser.EvalContext{},
+		evalCtx: evalCtx,
 		rpcCtx:  newInsecureRPCContext(stopper),
 	}
 	flowID := FlowID{uuid.MakeV4()}
@@ -204,8 +205,10 @@ func TestOutboxInitializesStreamBeforeRecevingAnyRows(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	evalCtx := parser.MakeTestingEvalContext()
+	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
-		evalCtx: parser.EvalContext{},
+		evalCtx: evalCtx,
 		rpcCtx:  newInsecureRPCContext(stopper),
 	}
 	flowID := FlowID{uuid.MakeV4()}
@@ -266,8 +269,10 @@ func TestOutboxClosesWhenConsumerCloses(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			evalCtx := parser.MakeTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
-				evalCtx: parser.EvalContext{},
+				evalCtx: evalCtx,
 				rpcCtx:  newInsecureRPCContext(stopper),
 			}
 			flowID := FlowID{uuid.MakeV4()}

--- a/pkg/sql/distsqlrun/processors_test.go
+++ b/pkg/sql/distsqlrun/processors_test.go
@@ -237,7 +237,9 @@ func TestPostProcess(t *testing.T) {
 			outBuf := &RowBuffer{}
 
 			var out procOutputHelper
-			if err := out.init(&tc.post, inBuf.Types(), &parser.EvalContext{}, outBuf); err != nil {
+			evalCtx := parser.NewTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
+			if err := out.init(&tc.post, inBuf.Types(), evalCtx, outBuf); err != nil {
 				t.Fatal(err)
 			}
 

--- a/pkg/sql/distsqlrun/routers_test.go
+++ b/pkg/sql/distsqlrun/routers_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -37,7 +38,8 @@ func TestHashRouter(t *testing.T) {
 
 	rng, _ := randutil.NewPseudoRand()
 	alloc := &sqlbase.DatumAlloc{}
-	evalCtx := &parser.EvalContext{}
+	evalCtx := parser.NewTestingEvalContext()
+	defer evalCtx.Stop(context.Background())
 
 	// Generate tables of possible values for each column; we have fewer possible
 	// values than rows to guarantee many occurrences of each value.
@@ -140,7 +142,8 @@ func TestMirrorRouter(t *testing.T) {
 
 	rng, _ := randutil.NewPseudoRand()
 	alloc := &sqlbase.DatumAlloc{}
-	evalCtx := &parser.EvalContext{}
+	evalCtx := parser.NewTestingEvalContext()
+	defer evalCtx.Stop(context.Background())
 
 	vals := sqlbase.RandEncDatumSlices(rng, numCols, numRows)
 

--- a/pkg/sql/distsqlrun/sorter_test.go
+++ b/pkg/sql/distsqlrun/sorter_test.go
@@ -17,10 +17,8 @@
 package distsqlrun
 
 import (
-	"math"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/mon"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -170,46 +168,48 @@ func TestSorter(t *testing.T) {
 		},
 	}
 
-	monitor := mon.MakeUnlimitedMonitor(context.Background(), "test", nil, nil, math.MaxInt64)
-	defer monitor.Stop(context.Background())
 	for _, c := range testCases {
-		ss := c.spec
-		types := make([]sqlbase.ColumnType, len(c.input[0]))
-		for i := range types {
-			types[i] = columnTypeInt
-		}
-		in := NewRowBuffer(types, c.input, RowBufferArgs{})
-		out := &RowBuffer{}
-		flowCtx := FlowCtx{
-			evalCtx: parser.EvalContext{Mon: &monitor},
-		}
-
-		s, err := newSorter(&flowCtx, &ss, in, &c.post, out)
-		if err != nil {
-			t.Fatal(err)
-		}
-		s.Run(context.Background(), nil)
-		if !out.ProducerClosed {
-			t.Fatalf("output RowReceiver not closed")
-		}
-
-		var retRows sqlbase.EncDatumRows
-		for {
-			row, meta := out.Next()
-			if !meta.Empty() {
-				t.Fatalf("unexpected metadata: %v", meta)
+		t.Run("", func(t *testing.T) {
+			ss := c.spec
+			types := make([]sqlbase.ColumnType, len(c.input[0]))
+			for i := range types {
+				types[i] = columnTypeInt
 			}
-			if row == nil {
-				break
+			in := NewRowBuffer(types, c.input, RowBufferArgs{})
+			out := &RowBuffer{}
+			evalCtx := parser.MakeTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
+			flowCtx := FlowCtx{
+				evalCtx: evalCtx,
 			}
-			retRows = append(retRows, row)
-		}
 
-		expStr := c.expected.String()
-		retStr := retRows.String()
-		if expStr != retStr {
-			t.Errorf("invalid results; expected:\n   %s\ngot:\n   %s",
-				expStr, retStr)
-		}
+			s, err := newSorter(&flowCtx, &ss, in, &c.post, out)
+			if err != nil {
+				t.Fatal(err)
+			}
+			s.Run(context.Background(), nil)
+			if !out.ProducerClosed {
+				t.Fatalf("output RowReceiver not closed")
+			}
+
+			var retRows sqlbase.EncDatumRows
+			for {
+				row, meta := out.Next()
+				if !meta.Empty() {
+					t.Fatalf("unexpected metadata: %v", meta)
+				}
+				if row == nil {
+					break
+				}
+				retRows = append(retRows, row)
+			}
+
+			expStr := c.expected.String()
+			retStr := retRows.String()
+			if expStr != retStr {
+				t.Errorf("invalid results; expected:\n   %s\ngot:\n   %s",
+					expStr, retStr)
+			}
+		})
 	}
 }

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -119,8 +119,10 @@ func TestTableReader(t *testing.T) {
 		ts := c.spec
 		ts.Table = *td
 
+		evalCtx := parser.MakeTestingEvalContext()
+		defer evalCtx.Stop(context.Background())
 		flowCtx := FlowCtx{
-			evalCtx:  parser.EvalContext{},
+			evalCtx:  evalCtx,
 			txnProto: &roachpb.Transaction{},
 			// Pass a DB without a TxnCoordSender.
 			remoteTxnDB: client.NewDB(s.DistSender(), s.Clock()),
@@ -185,8 +187,10 @@ ALTER TABLE t TESTING_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[3], 3
 	kvDB := tc.Server(0).KVClient().(*client.DB)
 	td := sqlbase.GetTableDescriptor(kvDB, "test", "t")
 
+	evalCtx := parser.MakeTestingEvalContext()
+	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
-		evalCtx:  parser.EvalContext{},
+		evalCtx:  evalCtx,
 		txnProto: &roachpb.Transaction{},
 		// Pass a DB without a TxnCoordSender.
 		remoteTxnDB: client.NewDB(tc.Server(0).DistSender(), tc.Server(0).Clock()),

--- a/pkg/sql/distsqlrun/values_test.go
+++ b/pkg/sql/distsqlrun/values_test.go
@@ -96,7 +96,8 @@ func TestValues(t *testing.T) {
 						t.Fatalf("incorrect number of rows %d, expected %d", len(res), numRows)
 					}
 
-					evalCtx := &parser.EvalContext{}
+					evalCtx := parser.NewTestingEvalContext()
+					defer evalCtx.Stop(context.Background())
 					for i := 0; i < numRows; i++ {
 						if len(res[i]) != numCols {
 							t.Fatalf("row %d incorrect length %d, expected %d", i, len(res[i]), numCols)

--- a/pkg/sql/expr_filter_test.go
+++ b/pkg/sql/expr_filter_test.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
@@ -119,7 +121,8 @@ func TestSplitFilter(t *testing.T) {
 
 	for _, d := range testData {
 		t.Run(fmt.Sprintf("%s~(%s, %s)", d.expr, d.expectedRes, d.expectedRem), func(t *testing.T) {
-			evalCtx := &parser.EvalContext{}
+			evalCtx := parser.NewTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
 			sel := makeSelectNode(t)
 			// A function that "converts" only vars in the list.
 			conv := func(expr parser.VariableExpr) (bool, parser.Expr) {

--- a/pkg/sql/group_test.go
+++ b/pkg/sql/group_test.go
@@ -50,6 +50,8 @@ func TestDesiredAggregateOrder(t *testing.T) {
 	}
 	p := makeTestPlanner()
 	for _, d := range testData {
+		evalCtx := parser.NewTestingEvalContext()
+		defer evalCtx.Stop(context.Background())
 		sel := makeSelectNode(t)
 		expr := parseAndNormalizeExpr(t, &p.evalCtx, d.expr, sel)
 		group := &groupNode{planner: p}

--- a/pkg/sql/index_selection_test.go
+++ b/pkg/sql/index_selection_test.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -313,7 +315,8 @@ func TestMakeConstraints(t *testing.T) {
 	}
 	for _, d := range testData {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
-			evalCtx := &parser.EvalContext{}
+			evalCtx := parser.NewTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
 			sel := makeSelectNode(t)
 			desc, index := makeTestIndexFromStr(t, d.columns)
 			constraints, _ := makeConstraints(t, evalCtx, d.expr, desc, index, sel)
@@ -509,7 +512,8 @@ func TestMakeSpans(t *testing.T) {
 				expected = d.expectedDesc
 			}
 			t.Run(d.expr+"~"+expected, func(t *testing.T) {
-				evalCtx := &parser.EvalContext{}
+				evalCtx := parser.NewTestingEvalContext()
+				defer evalCtx.Stop(context.Background())
 				sel := makeSelectNode(t)
 				columns := strings.Split(d.columns, ",")
 				dirs := make([]encoding.Direction, 0, len(columns))
@@ -557,7 +561,8 @@ func TestMakeSpans(t *testing.T) {
 	}
 	for _, d := range testData2 {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
-			evalCtx := &parser.EvalContext{}
+			evalCtx := parser.NewTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
 			sel := makeSelectNode(t)
 			desc, index := makeTestIndexFromStr(t, d.columns)
 			constraints, _ := makeConstraints(t, evalCtx, d.expr, desc, index, sel)
@@ -636,7 +641,8 @@ func TestExactPrefix(t *testing.T) {
 	}
 	for _, d := range testData {
 		t.Run(fmt.Sprintf("%s~%d", d.expr, d.expected), func(t *testing.T) {
-			evalCtx := &parser.EvalContext{}
+			evalCtx := parser.NewTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
 			sel := makeSelectNode(t)
 			desc, index := makeTestIndexFromStr(t, d.columns)
 			constraints, _ := makeConstraints(t, evalCtx, d.expr, desc, index, sel)
@@ -712,7 +718,8 @@ func TestApplyConstraints(t *testing.T) {
 	}
 	for _, d := range testData {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
-			evalCtx := &parser.EvalContext{}
+			evalCtx := parser.NewTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
 			sel := makeSelectNode(t)
 			desc, index := makeTestIndexFromStr(t, d.columns)
 			constraints, expr := makeConstraints(t, evalCtx, d.expr, desc, index, sel)

--- a/pkg/sql/logic_test.go
+++ b/pkg/sql/logic_test.go
@@ -652,7 +652,7 @@ func (t *logicTest) setup(
 		ServerArgs: base.TestServerArgs{
 			// Specify a fixed memory limit (some test cases verify OOM conditions; we
 			// don't want those to take long on large machines).
-			SQLMemoryPoolSize: 128 * 1024 * 1024,
+			SQLMemoryPoolSize: 192 * 1024 * 1024,
 			Knobs: base.TestingKnobs{
 				SQLExecutor: &sql.ExecutorTestingKnobs{
 					WaitForGossipUpdate:   true,

--- a/pkg/sql/mon/mem_usage.go
+++ b/pkg/sql/mon/mem_usage.go
@@ -609,3 +609,9 @@ func (mm *MemoryMonitor) adjustBudget(ctx context.Context) {
 		mm.pool.ShrinkAccount(ctx, &mm.mu.curBudget, mm.mu.curBudget.curAllocated-neededBytes)
 	}
 }
+
+// GetCurrentAllocationForTesting returns the number of bytes that have
+// currently been allocated in the MemoryMonitor. Intended for use in testing.
+func (mm *MemoryMonitor) GetCurrentAllocationForTesting() int64 {
+	return mm.mu.curAllocated
+}

--- a/pkg/sql/parser/aggregate_builtins_test.go
+++ b/pkg/sql/parser/aggregate_builtins_test.go
@@ -33,7 +33,8 @@ import (
 func testAggregateResultDeepCopy(
 	t *testing.T, aggFunc func([]Type, *EvalContext) AggregateFunc, vals []Datum,
 ) {
-	evalCtx := &EvalContext{}
+	evalCtx := NewTestingEvalContext()
+	defer evalCtx.Stop(context.Background())
 	aggImpl := aggFunc([]Type{vals[0].ResolvedType()}, evalCtx)
 	runningDatums := make([]Datum, len(vals))
 	runningStrings := make([]string, len(vals))
@@ -237,7 +238,8 @@ func makeIntervalTestDatum(count int) []Datum {
 func runBenchmarkAggregate(
 	b *testing.B, aggFunc func([]Type, *EvalContext) AggregateFunc, vals []Datum,
 ) {
-	evalCtx := &EvalContext{}
+	evalCtx := NewTestingEvalContext()
+	defer evalCtx.Stop(context.Background())
 	params := []Type{vals[0].ResolvedType()}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -202,6 +202,11 @@ func (b Builtin) DistSQLBlacklist() bool {
 	return b.distsqlBlacklist
 }
 
+// Fn returns the Go function which implements the builtin.
+func (b Builtin) Fn() func(*EvalContext, Datums) (Datum, error) {
+	return b.fn
+}
+
 // FixedReturnType returns a fixed type that the function returns, returning Any
 // if the return type is based on the function's arguments.
 func (b Builtin) FixedReturnType() Type {
@@ -245,30 +250,36 @@ var digitNames = []string{"zero", "one", "two", "three", "four", "five", "six", 
 var Builtins = map[string][]Builtin{
 	// TODO(XisiHuang): support encoding, i.e., length(str, encoding).
 	"length": {
-		stringBuiltin1(func(s string) (Datum, error) {
+		stringBuiltin1(func(_ *EvalContext, s string) (Datum, error) {
 			return NewDInt(DInt(utf8.RuneCountInString(s))), nil
 		}, TypeInt, "Calculates the number of characters in `val`."),
-		bytesBuiltin1(func(s string) (Datum, error) {
+		bytesBuiltin1(func(_ *EvalContext, s string) (Datum, error) {
 			return NewDInt(DInt(len(s))), nil
 		}, TypeInt, "Calculates the number of bytes in `val`."),
 	},
 
 	"octet_length": {
-		stringBuiltin1(func(s string) (Datum, error) {
+		stringBuiltin1(func(_ *EvalContext, s string) (Datum, error) {
 			return NewDInt(DInt(len(s))), nil
 		}, TypeInt, "Calculates the number of bytes used to represent `val`."),
-		bytesBuiltin1(func(s string) (Datum, error) {
+		bytesBuiltin1(func(_ *EvalContext, s string) (Datum, error) {
 			return NewDInt(DInt(len(s))), nil
 		}, TypeInt, "Calculates the number of bytes in `val`."),
 	},
 
 	// TODO(pmattis): What string functions should also support TypeBytes?
 
-	"lower": {stringBuiltin1(func(s string) (Datum, error) {
+	"lower": {stringBuiltin1(func(evalCtx *EvalContext, s string) (Datum, error) {
+		if err := evalCtx.ActiveMemAcc.Grow(evalCtx.Ctx(), int64(len(s))); err != nil {
+			return nil, err
+		}
 		return NewDString(strings.ToLower(s)), nil
 	}, TypeString, "Converts all characters in `val`to their lower-case equivalents.")},
 
-	"upper": {stringBuiltin1(func(s string) (Datum, error) {
+	"upper": {stringBuiltin1(func(evalCtx *EvalContext, s string) (Datum, error) {
+		if err := evalCtx.ActiveMemAcc.Grow(evalCtx.Ctx(), int64(len(s))); err != nil {
+			return nil, err
+		}
 		return NewDString(strings.ToUpper(s)), nil
 	}, TypeString, "Converts all characters in `val`to their to their upper-case equivalents.")},
 
@@ -281,11 +292,15 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      VariadicType{TypeString},
 			ReturnType: fixedReturnType(TypeString),
-			fn: func(_ *EvalContext, args Datums) (Datum, error) {
+			fn: func(evalCtx *EvalContext, args Datums) (Datum, error) {
 				var buffer bytes.Buffer
 				for _, d := range args {
 					if d == DNull {
 						continue
+					}
+					nextLength := len(string(MustBeDString(d)))
+					if err := evalCtx.ActiveMemAcc.Grow(evalCtx.Ctx(), int64(nextLength)); err != nil {
+						return nil, err
 					}
 					buffer.WriteString(string(MustBeDString(d)))
 				}
@@ -299,7 +314,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      VariadicType{TypeString},
 			ReturnType: fixedReturnType(TypeString),
-			fn: func(_ *EvalContext, args Datums) (Datum, error) {
+			fn: func(evalCtx *EvalContext, args Datums) (Datum, error) {
 				if len(args) == 0 {
 					return nil, errInsufficientArgs
 				}
@@ -312,6 +327,11 @@ var Builtins = map[string][]Builtin{
 				for _, d := range args[1:] {
 					if d == DNull {
 						continue
+					}
+					nextLength := len(prefix) + len(string(MustBeDString(d)))
+					if err := evalCtx.ActiveMemAcc.Grow(
+						evalCtx.Ctx(), int64(nextLength)); err != nil {
+						return nil, err
 					}
 					// Note: we can't use the range index here because that
 					// would break when the 2nd argument is NULL.
@@ -433,20 +453,17 @@ var Builtins = map[string][]Builtin{
 			Types:            ArgTypes{{"input", TypeString}, {"repeat_counter", TypeInt}},
 			distsqlBlacklist: true,
 			ReturnType:       fixedReturnType(TypeString),
-			fn: func(_ *EvalContext, args Datums) (_ Datum, err error) {
+			fn: func(evalCtx *EvalContext, args Datums) (_ Datum, err error) {
 				s := string(MustBeDString(args[0]))
 				count := int(MustBeDInt(args[1]))
+
 				if count < 0 {
 					count = 0
 				}
-				// Repeat can overflow if len(s) * count is very large. The computation
-				// for the limit about what make can allocate is not trivial, so it's most
-				// accurate to detect it with a recover.
-				defer func() {
-					if r := recover(); r != nil {
-						err = fmt.Errorf("%s", r)
-					}
-				}()
+
+				if err := evalCtx.ActiveMemAcc.Grow(evalCtx.Ctx(), int64(len(s)*count)); err != nil {
+					return nil, err
+				}
 				return NewDString(strings.Repeat(s, count)), nil
 			},
 			Info: "Concatenates `input` `repeat_counter` number of times.<br/><br/>For example, " +
@@ -454,7 +471,7 @@ var Builtins = map[string][]Builtin{
 		},
 	},
 
-	"ascii": {stringBuiltin1(func(s string) (Datum, error) {
+	"ascii": {stringBuiltin1(func(_ *EvalContext, s string) (Datum, error) {
 		for _, ch := range s {
 			return NewDInt(DInt(ch)), nil
 		}
@@ -532,7 +549,7 @@ var Builtins = map[string][]Builtin{
 	},
 
 	// The SQL parser coerces POSITION to STRPOS.
-	"strpos": {stringBuiltin2("input", "find", func(s, substring string) (Datum, error) {
+	"strpos": {stringBuiltin2("input", "find", func(_ *EvalContext, s, substring string) (Datum, error) {
 		index := strings.Index(s, substring)
 		if index < 0 {
 			return DZero, nil
@@ -583,41 +600,44 @@ var Builtins = map[string][]Builtin{
 
 	// The SQL parser coerces TRIM(...) and TRIM(BOTH ...) to BTRIM(...).
 	"btrim": {
-		stringBuiltin2("input", "trim_chars", func(s, chars string) (Datum, error) {
+		stringBuiltin2("input", "trim_chars", func(_ *EvalContext, s, chars string) (Datum, error) {
 			return NewDString(strings.Trim(s, chars)), nil
 		}, TypeString, "Removes any characters included in `trim_chars` from the beginning or end"+
 			" of `input` (applies recursively). <br/><br/>For example, `btrim('doggie', 'eod')` "+
 			"returns `ggi`."),
-		stringBuiltin1(func(s string) (Datum, error) {
+		stringBuiltin1(func(_ *EvalContext, s string) (Datum, error) {
 			return NewDString(strings.TrimSpace(s)), nil
 		}, TypeString, "Removes all spaces from the beginning and end of `val`."),
 	},
 
 	// The SQL parser coerces TRIM(LEADING ...) to LTRIM(...).
 	"ltrim": {
-		stringBuiltin2("input", "trim_chars", func(s, chars string) (Datum, error) {
+		stringBuiltin2("input", "trim_chars", func(_ *EvalContext, s, chars string) (Datum, error) {
 			return NewDString(strings.TrimLeft(s, chars)), nil
 		}, TypeString, "Removes any characters included in `trim_chars` from the beginning "+
 			"(left-hand side) of `input` (applies recursively). <br/><br/>For example, "+
 			"`ltrim('doggie', 'od')` returns `ggie`."),
-		stringBuiltin1(func(s string) (Datum, error) {
+		stringBuiltin1(func(_ *EvalContext, s string) (Datum, error) {
 			return NewDString(strings.TrimLeftFunc(s, unicode.IsSpace)), nil
 		}, TypeString, "Removes all spaces from the beginning (left-hand side) of `val`."),
 	},
 
 	// The SQL parser coerces TRIM(TRAILING ...) to RTRIM(...).
 	"rtrim": {
-		stringBuiltin2("input", "trim_chars", func(s, chars string) (Datum, error) {
+		stringBuiltin2("input", "trim_chars", func(_ *EvalContext, s, chars string) (Datum, error) {
 			return NewDString(strings.TrimRight(s, chars)), nil
 		}, TypeString, "Removes any characters included in `trim_chars` from the end (right-hand "+
 			"side) of `input` (applies recursively). <br/><br/>For example, `rtrim('doggie', 'ei')` "+
 			"returns `dogg`."),
-		stringBuiltin1(func(s string) (Datum, error) {
+		stringBuiltin1(func(_ *EvalContext, s string) (Datum, error) {
 			return NewDString(strings.TrimRightFunc(s, unicode.IsSpace)), nil
 		}, TypeString, "Removes all spaces from the end (right-hand side) of `val`."),
 	},
 
-	"reverse": {stringBuiltin1(func(s string) (Datum, error) {
+	"reverse": {stringBuiltin1(func(evalCtx *EvalContext, s string) (Datum, error) {
+		if err := evalCtx.ActiveMemAcc.Grow(evalCtx.Ctx(), int64(len(s))); err != nil {
+			return nil, err
+		}
 		runes := []rune(s)
 		for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
 			runes[i], runes[j] = runes[j], runes[i]
@@ -627,8 +647,12 @@ var Builtins = map[string][]Builtin{
 
 	"replace": {stringBuiltin3(
 		"input", "find", "replace",
-		func(input, from, to string) (Datum, error) {
-			return NewDString(strings.Replace(input, from, to, -1)), nil
+		func(evalCtx *EvalContext, input, from, to string) (Datum, error) {
+			result := strings.Replace(input, from, to, -1)
+			if err := evalCtx.ActiveMemAcc.Grow(evalCtx.Ctx(), int64(len(result))); err != nil {
+				return nil, err
+			}
+			return NewDString(result), nil
 		},
 		TypeString,
 		"Replaces all occurrences of `find` with `replace` in `input`",
@@ -636,7 +660,10 @@ var Builtins = map[string][]Builtin{
 
 	"translate": {stringBuiltin3(
 		"input", "find", "replace",
-		func(s, from, to string) (Datum, error) {
+		func(evalCtx *EvalContext, s, from, to string) (Datum, error) {
+			if err := evalCtx.ActiveMemAcc.Grow(evalCtx.Ctx(), int64(len(s))); err != nil {
+				return nil, err
+			}
 			const deletionRune = utf8.MaxRune + 1
 			translation := make(map[rune]rune, len(from))
 			for _, fromRune := range from {
@@ -685,11 +712,18 @@ var Builtins = map[string][]Builtin{
 				{"replace", TypeString},
 			},
 			ReturnType: fixedReturnType(TypeString),
-			fn: func(ctx *EvalContext, args Datums) (Datum, error) {
+			fn: func(evalCtx *EvalContext, args Datums) (Datum, error) {
 				s := string(MustBeDString(args[0]))
 				pattern := string(MustBeDString(args[1]))
 				to := string(MustBeDString(args[2]))
-				return regexpReplace(ctx, s, pattern, to, "")
+				result, err := regexpReplace(evalCtx, s, pattern, to, "")
+				if err != nil {
+					return nil, err
+				}
+				if err := evalCtx.ActiveMemAcc.Grow(evalCtx.Ctx(), int64(len(string(MustBeDString(result))))); err != nil {
+					return nil, err
+				}
+				return result, nil
 			},
 			Info: "Replaces matches for the Regular Expression `regex` in `input` with the " +
 				"Regular Expression `replace`.",
@@ -702,12 +736,19 @@ var Builtins = map[string][]Builtin{
 				{"flags", TypeString},
 			},
 			ReturnType: fixedReturnType(TypeString),
-			fn: func(ctx *EvalContext, args Datums) (Datum, error) {
+			fn: func(evalCtx *EvalContext, args Datums) (Datum, error) {
 				s := string(MustBeDString(args[0]))
 				pattern := string(MustBeDString(args[1]))
 				to := string(MustBeDString(args[2]))
 				sqlFlags := string(MustBeDString(args[3]))
-				return regexpReplace(ctx, s, pattern, to, sqlFlags)
+				result, err := regexpReplace(evalCtx, s, pattern, to, sqlFlags)
+				if err != nil {
+					return nil, err
+				}
+				if err := evalCtx.ActiveMemAcc.Grow(evalCtx.Ctx(), int64(len(string(MustBeDString(result))))); err != nil {
+					return nil, err
+				}
+				return result, nil
 			},
 			Info: "Replaces matches for the Regular Expression `regex` in `input` with the Regular " +
 				"Expression `replace` using `flags`.<br/><br/>CockroachDB supports the following " +
@@ -729,7 +770,10 @@ var Builtins = map[string][]Builtin{
 		},
 	},
 
-	"initcap": {stringBuiltin1(func(s string) (Datum, error) {
+	"initcap": {stringBuiltin1(func(evalCtx *EvalContext, s string) (Datum, error) {
+		if err := evalCtx.ActiveMemAcc.Grow(evalCtx.Ctx(), int64(len(s))); err != nil {
+			return nil, err
+		}
 		return NewDString(strings.Title(strings.ToLower(s))), nil
 	}, TypeString, "Capitalizes the first letter of `val`.")},
 
@@ -1687,6 +1731,20 @@ var Builtins = map[string][]Builtin{
 			Info:     "This function is used only by CockroachDB's developers for testing purposes.",
 		},
 	},
+
+	// Identity function which is marked as impure to avoid constant folding.
+	"crdb_internal.no_constant_folding": {
+		Builtin{
+			Types:      ArgTypes{{"input", TypeAny}},
+			ReturnType: identityReturnType(0),
+			impure:     true,
+			fn: func(_ *EvalContext, args Datums) (Datum, error) {
+				return args[0], nil
+			},
+			category: categorySystemInfo,
+			Info:     "This function is used only by CockroachDB's developers for testing purposes.",
+		},
+	},
 }
 
 var substringImpls = []Builtin{
@@ -1912,50 +1970,57 @@ func decimalBuiltin2(
 	}
 }
 
-func stringBuiltin1(f func(string) (Datum, error), returnType Type, info string) Builtin {
+func stringBuiltin1(
+	f func(*EvalContext, string) (Datum, error), returnType Type, info string,
+) Builtin {
 	return Builtin{
 		Types:      ArgTypes{{"val", TypeString}},
 		ReturnType: fixedReturnType(returnType),
-		fn: func(_ *EvalContext, args Datums) (Datum, error) {
-			return f(string(MustBeDString(args[0])))
+		fn: func(evalCtx *EvalContext, args Datums) (Datum, error) {
+			return f(evalCtx, string(MustBeDString(args[0])))
 		},
 		Info: info,
 	}
 }
 
 func stringBuiltin2(
-	a, b string, f func(string, string) (Datum, error), returnType Type, info string,
+	a, b string, f func(*EvalContext, string, string) (Datum, error), returnType Type, info string,
 ) Builtin {
 	return Builtin{
 		Types:      ArgTypes{{a, TypeString}, {b, TypeString}},
 		ReturnType: fixedReturnType(returnType),
 		category:   categorizeType(TypeString),
-		fn: func(_ *EvalContext, args Datums) (Datum, error) {
-			return f(string(MustBeDString(args[0])), string(MustBeDString(args[1])))
+		fn: func(evalCtx *EvalContext, args Datums) (Datum, error) {
+			return f(evalCtx, string(MustBeDString(args[0])), string(MustBeDString(args[1])))
 		},
 		Info: info,
 	}
 }
 
 func stringBuiltin3(
-	a, b, c string, f func(string, string, string) (Datum, error), returnType Type, info string,
+	a, b, c string,
+	f func(*EvalContext, string, string, string) (Datum, error),
+	returnType Type,
+	info string,
 ) Builtin {
 	return Builtin{
 		Types:      ArgTypes{{a, TypeString}, {b, TypeString}, {c, TypeString}},
 		ReturnType: fixedReturnType(returnType),
-		fn: func(_ *EvalContext, args Datums) (Datum, error) {
-			return f(string(MustBeDString(args[0])), string(MustBeDString(args[1])), string(MustBeDString(args[2])))
+		fn: func(evalCtx *EvalContext, args Datums) (Datum, error) {
+			return f(evalCtx, string(MustBeDString(args[0])), string(MustBeDString(args[1])), string(MustBeDString(args[2])))
 		},
 		Info: info,
 	}
 }
 
-func bytesBuiltin1(f func(string) (Datum, error), returnType Type, info string) Builtin {
+func bytesBuiltin1(
+	f func(*EvalContext, string) (Datum, error), returnType Type, info string,
+) Builtin {
 	return Builtin{
 		Types:      ArgTypes{{"val", TypeBytes}},
 		ReturnType: fixedReturnType(returnType),
-		fn: func(_ *EvalContext, args Datums) (Datum, error) {
-			return f(string(*args[0].(*DBytes)))
+		fn: func(evalCtx *EvalContext, args Datums) (Datum, error) {
+			return f(evalCtx, string(*args[0].(*DBytes)))
 		},
 		Info: info,
 	}

--- a/pkg/sql/parser/constant_test.go
+++ b/pkg/sql/parser/constant_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/apd"
 )
 
@@ -318,7 +320,9 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 					i, availType, test.c, res)
 			} else {
 				expectedDatum := parseFuncs[availType](t, test.c.s)
-				if res.Compare(&EvalContext{}, expectedDatum) != 0 {
+				evalCtx := NewTestingEvalContext()
+				defer evalCtx.Stop(context.Background())
+				if res.Compare(evalCtx, expectedDatum) != 0 {
 					t.Errorf("%d: type %s expected to be resolved from the StrVal %v to Datum %v"+
 						", found %v",
 						i, availType, test.c, expectedDatum, res)

--- a/pkg/sql/parser/datum_test.go
+++ b/pkg/sql/parser/datum_test.go
@@ -20,6 +20,8 @@ import (
 	"math"
 	"testing"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 func prepareExpr(t *testing.T, datumExpr string) TypedExpr {
@@ -34,8 +36,9 @@ func prepareExpr(t *testing.T, datumExpr string) TypedExpr {
 		t.Fatalf("%s: %v", datumExpr, err)
 	}
 	// Normalization ensures that casts are processed.
-	ctx := &EvalContext{}
-	typedExpr, err = ctx.NormalizeExpr(typedExpr)
+	evalCtx := NewTestingEvalContext()
+	defer evalCtx.Stop(context.Background())
+	typedExpr, err = evalCtx.NormalizeExpr(typedExpr)
 	if err != nil {
 		t.Fatalf("%s: %v", datumExpr, err)
 	}
@@ -281,7 +284,9 @@ func TestDFloatCompare(t *testing.T) {
 			} else if i > j {
 				expected = 1
 			}
-			got := x.Compare(&EvalContext{}, y)
+			evalCtx := NewTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
+			got := x.Compare(evalCtx, y)
 			if got != expected {
 				t.Errorf("comparing DFloats %s and %s: expected %d, got %d", x, y, expected, got)
 			}
@@ -329,7 +334,9 @@ func TestParseDIntervalWithField(t *testing.T) {
 			t.Errorf("unexpected error while parsing expected value INTERVAL %s: %s", td.expected, err)
 			continue
 		}
-		if expected.Compare(&EvalContext{}, actual) != 0 {
+		evalCtx := NewTestingEvalContext()
+		defer evalCtx.Stop(context.Background())
+		if expected.Compare(evalCtx, actual) != 0 {
 			t.Errorf("INTERVAL %s %v: got %s, expected %s", td.str, td.field, actual, expected)
 		}
 	}
@@ -368,7 +375,9 @@ func TestParseDDate(t *testing.T) {
 			t.Errorf("unexpected error while parsing expected value DATE %s: %s", td.expected, err)
 			continue
 		}
-		if expected.Compare(&EvalContext{}, actual) != 0 {
+		evalCtx := NewTestingEvalContext()
+		defer evalCtx.Stop(context.Background())
+		if expected.Compare(evalCtx, actual) != 0 {
 			t.Errorf("DATE %s: got %s, expected %s", td.str, actual, expected)
 		}
 	}

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -1781,6 +1781,18 @@ func MakeTestingEvalContext() EvalContext {
 	return ctx
 }
 
+// NewTestingEvalContext is a convenience version of MakeTestingEvalContext
+// that returns a pointer.
+func NewTestingEvalContext() *EvalContext {
+	ctx := MakeTestingEvalContext()
+	return &ctx
+}
+
+// Stop closes out the EvalContext and must be called once it is no longer in use.
+func (ctx *EvalContext) Stop(c context.Context) {
+	ctx.Mon.Stop(c)
+}
+
 // GetStmtTimestamp retrieves the current statement timestamp as per
 // the evaluation context. The timestamp is guaranteed to be nonzero.
 func (ctx *EvalContext) GetStmtTimestamp() time.Time {

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -1759,6 +1759,11 @@ type EvalContext struct {
 	collationEnv CollationEnvironment
 
 	Mon *mon.MemoryMonitor
+
+	// ActiveMemAcc is the account to which values are allocated during
+	// evaluation. It can change over the course of evaluation, such as on a
+	// per-row basis.
+	ActiveMemAcc *mon.BoundAccount
 }
 
 // MakeTestingEvalContext returns an EvalContext that includes a MemoryMonitor.
@@ -1774,6 +1779,8 @@ func MakeTestingEvalContext() EvalContext {
 	monitor.Start(context.Background(), nil, mon.MakeStandaloneBudget(math.MaxInt64))
 	ctx.Mon = &monitor
 	ctx.Ctx = context.Background
+	acc := monitor.MakeBoundAccount()
+	ctx.ActiveMemAcc = &acc
 	now := timeutil.Now()
 	ctx.SetTxnTimestamp(now)
 	ctx.SetStmtTimestamp(now)
@@ -2617,7 +2624,7 @@ func (expr *FuncExpr) Eval(ctx *EvalContext) (Datum, error) {
 		if _, ok := err.(*roachpb.HandledRetryableTxnError); ok {
 			return nil, err
 		}
-		return nil, fmt.Errorf("%s(): %v", expr.Func, err)
+		return nil, pgerror.AnnotateError(fmt.Sprintf("%s():", expr.Func), err)
 	}
 	return res, nil
 }

--- a/pkg/sql/parser/eval_test.go
+++ b/pkg/sql/parser/eval_test.go
@@ -853,6 +853,9 @@ func TestEval(t *testing.T) {
 		{`'NaN'::decimal::float`, `NaN`},
 		{`'NaN'::float::decimal`, `NaN`},
 	}
+	ctx := NewTestingEvalContext()
+	defer ctx.Mon.Stop(context.Background())
+	defer ctx.ActiveMemAcc.Close(context.Background())
 	for _, d := range testData {
 		expr, err := ParseExpr(d.expr)
 		if err != nil {
@@ -863,8 +866,8 @@ func TestEval(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
-		ctx := NewTestingEvalContext()
-		defer ctx.Mon.Stop(context.Background())
+		// We have to manually close this account because we're doing the evaluations
+		// ourselves.
 		if typedExpr, err = ctx.NormalizeExpr(typedExpr); err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}

--- a/pkg/sql/parser/eval_test.go
+++ b/pkg/sql/parser/eval_test.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
@@ -861,7 +863,8 @@ func TestEval(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
-		ctx := &EvalContext{}
+		ctx := NewTestingEvalContext()
+		defer ctx.Mon.Stop(context.Background())
 		if typedExpr, err = ctx.NormalizeExpr(typedExpr); err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
@@ -952,7 +955,8 @@ func TestTimeConversion(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		ctx := &EvalContext{}
+		ctx := NewTestingEvalContext()
+		defer ctx.Mon.Stop(context.Background())
 		exprStr := fmt.Sprintf("experimental_strptime('%s', '%s')", test.start, test.format)
 		expr, err := ParseExpr(exprStr)
 		if err != nil {
@@ -1089,7 +1093,9 @@ func TestEvalError(t *testing.T) {
 		}
 		typedExpr, err := TypeCheck(expr, nil, TypeAny)
 		if err == nil {
-			_, err = typedExpr.Eval(&EvalContext{})
+			evalCtx := NewTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
+			_, err = typedExpr.Eval(evalCtx)
 		}
 		if !testutils.IsError(err, strings.Replace(regexp.QuoteMeta(d.expected), `\.\*`, `.*`, -1)) {
 			t.Errorf("%s: expected %s, but found %v", d.expr, d.expected, err)
@@ -1127,7 +1133,8 @@ func TestEvalComparisonExprCaching(t *testing.T) {
 			Left:     NewDString(d.left),
 			Right:    NewDString(d.right),
 		}
-		ctx := &EvalContext{}
+		ctx := NewTestingEvalContext()
+		defer ctx.Mon.Stop(context.Background())
 		ctx.ReCache = NewRegexpCache(8)
 		typedExpr, err := TypeCheck(expr, nil, TypeAny)
 		if err != nil {
@@ -1181,7 +1188,8 @@ func TestClusterTimestampConversion(t *testing.T) {
 		{9223372036854775807, 2147483647, "9223372036854775807.2147483647"},
 	}
 
-	ctx := &EvalContext{}
+	ctx := NewTestingEvalContext()
+	defer ctx.Mon.Stop(context.Background())
 	ctx.PrepareOnly = true
 	for _, d := range testData {
 		ts := hlc.Timestamp{WallTime: d.walltime, Logical: d.logical}
@@ -1212,7 +1220,9 @@ func TestCastToCollatedString(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			val, err := typedexpr.Eval(&EvalContext{})
+			evalCtx := NewTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
+			val, err := typedexpr.Eval(evalCtx)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1265,17 +1275,31 @@ func benchmarkLike(b *testing.B, ctx *EvalContext, caseInsensitive bool) {
 }
 
 func BenchmarkLikeWithCache(b *testing.B) {
-	benchmarkLike(b, &EvalContext{ReCache: NewRegexpCache(len(benchmarkLikePatterns))}, false)
+	ctx := NewTestingEvalContext()
+	ctx.ReCache = NewRegexpCache(len(benchmarkLikePatterns))
+	defer ctx.Mon.Stop(context.Background())
+
+	benchmarkLike(b, ctx, false)
 }
 
 func BenchmarkLikeWithoutCache(b *testing.B) {
-	benchmarkLike(b, &EvalContext{}, false)
+	evalCtx := NewTestingEvalContext()
+	defer evalCtx.Stop(context.Background())
+
+	benchmarkLike(b, evalCtx, false)
 }
 
 func BenchmarkILikeWithCache(b *testing.B) {
-	benchmarkLike(b, &EvalContext{ReCache: NewRegexpCache(len(benchmarkLikePatterns))}, true)
+	ctx := NewTestingEvalContext()
+	ctx.ReCache = NewRegexpCache(len(benchmarkLikePatterns))
+	defer ctx.Mon.Stop(context.Background())
+
+	benchmarkLike(b, ctx, true)
 }
 
 func BenchmarkILikeWithoutCache(b *testing.B) {
-	benchmarkLike(b, &EvalContext{}, true)
+	evalCtx := NewTestingEvalContext()
+	defer evalCtx.Stop(context.Background())
+
+	benchmarkLike(b, evalCtx, true)
 }

--- a/pkg/sql/parser/expr_test.go
+++ b/pkg/sql/parser/expr_test.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 )
 
@@ -178,7 +180,8 @@ func TestExprString(t *testing.T) {
 			t.Errorf("Print/parse/print cycle changes the string: `%s` vs `%s`", str, str2)
 		}
 		// Compare the normalized expressions.
-		ctx := &EvalContext{}
+		ctx := NewTestingEvalContext()
+		defer ctx.Mon.Stop(context.Background())
 		normalized, err := ctx.NormalizeExpr(typedExpr)
 		if err != nil {
 			t.Fatalf("%s: %v", exprStr, err)

--- a/pkg/sql/parser/indexed_vars_test.go
+++ b/pkg/sql/parser/indexed_vars_test.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"fmt"
 	"testing"
+
+	"golang.org/x/net/context"
 )
 
 type testVarContainer []Datum
@@ -93,7 +95,8 @@ func TestIndexedVars(t *testing.T) {
 	if !typ.Equivalent(TypeInt) {
 		t.Errorf("invalid expression type %s", typ)
 	}
-	evalCtx := &EvalContext{}
+	evalCtx := NewTestingEvalContext()
+	defer evalCtx.Stop(context.Background())
 	d, err := typedExpr.Eval(evalCtx)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/parser/normalize.go
+++ b/pkg/sql/parser/normalize.go
@@ -16,7 +16,9 @@
 
 package parser
 
-import "github.com/pkg/errors"
+import (
+	"github.com/pkg/errors"
+)
 
 type normalizableExpr interface {
 	Expr
@@ -612,6 +614,9 @@ func (v *normalizeVisitor) VisitPost(expr Expr) Expr {
 	if v.err != nil {
 		return expr
 	}
+	// We don't propagate errors during this step because errors might involve a
+	// branch of code that isn't traversed by normal execution (for example,
+	// IF(2 = 2, 1, 1 / 0)).
 
 	// Normalize expressions that know how to normalize themselves.
 	if normalizable, ok := expr.(normalizableExpr); ok {

--- a/pkg/sql/parser/normalize_test.go
+++ b/pkg/sql/parser/normalize_test.go
@@ -16,8 +16,13 @@
 
 package parser
 
-import "testing"
-import "github.com/cockroachdb/cockroach/pkg/util/leaktest"
+import (
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
 
 func TestReNormalizeName(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -191,7 +196,8 @@ func TestNormalizeExpr(t *testing.T) {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
 		rOrig := typedExpr.String()
-		ctx := &EvalContext{}
+		ctx := NewTestingEvalContext()
+		defer ctx.Mon.Stop(context.Background())
 		r, err := ctx.NormalizeExpr(typedExpr)
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)

--- a/pkg/sql/parser/normalize_test.go
+++ b/pkg/sql/parser/normalize_test.go
@@ -198,6 +198,7 @@ func TestNormalizeExpr(t *testing.T) {
 		rOrig := typedExpr.String()
 		ctx := NewTestingEvalContext()
 		defer ctx.Mon.Stop(context.Background())
+		defer ctx.ActiveMemAcc.Close(context.Background())
 		r, err := ctx.NormalizeExpr(typedExpr)
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)

--- a/pkg/sql/parser/type_check_test.go
+++ b/pkg/sql/parser/type_check_test.go
@@ -23,6 +23,8 @@ import (
 	"regexp"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 )
 
@@ -146,7 +148,8 @@ func TestTypeCheckNormalize(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			evalCtx := &EvalContext{}
+			evalCtx := NewTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
 			typedExpr, err := evalCtx.NormalizeExpr(typeChecked)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/sql/pgwire/binary_test.go
+++ b/pkg/sql/pgwire/binary_test.go
@@ -29,6 +29,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -70,11 +72,13 @@ func testBinaryDatumType(t *testing.T, typ string, datumConstructor func(val str
 			if buf.err != nil {
 				t.Fatal(buf.err)
 			}
+			evalCtx := parser.NewTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
 			if got := buf.wrapped.Bytes(); !bytes.Equal(got, test.Expect) {
 				t.Errorf("%q:\n\t%v found,\n\t%v expected", test.In, got, test.Expect)
 			} else if datum, err := decodeOidDatum(oid, formatBinary, got[4:]); err != nil {
 				t.Fatalf("unable to decode %v: %s", got[4:], err)
-			} else if d.Compare(&parser.EvalContext{}, datum) != 0 {
+			} else if d.Compare(evalCtx, datum) != 0 {
 				t.Errorf("expected %s, got %s", d, datum)
 			}
 		}()
@@ -142,7 +146,9 @@ func TestBinaryIntArray(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Compare(&parser.EvalContext{}, d) != 0 {
+	evalCtx := parser.NewTestingEvalContext()
+	defer evalCtx.Stop(context.Background())
+	if got.Compare(evalCtx, d) != 0 {
 		t.Fatalf("expected %s, got %s", d, got)
 	}
 }
@@ -204,13 +210,15 @@ func TestRandomBinaryDecimal(t *testing.T) {
 		if buf.err != nil {
 			t.Fatal(buf.err)
 		}
+		evalCtx := parser.NewTestingEvalContext()
 		if got := buf.wrapped.Bytes(); !bytes.Equal(got, test.Expect) {
 			t.Errorf("%q:\n\t%v found,\n\t%v expected", test.In, got, test.Expect)
 		} else if datum, err := decodeOidDatum(oid.T_numeric, formatBinary, got[4:]); err != nil {
 			t.Errorf("%q: unable to decode %v: %s", test.In, got[4:], err)
-		} else if dec.Compare(&parser.EvalContext{}, datum) != 0 {
+		} else if dec.Compare(evalCtx, datum) != 0 {
 			t.Errorf("%q: expected %s, got %s", test.In, dec, datum)
 		}
+		evalCtx.Stop(context.Background())
 	}
 }
 

--- a/pkg/sql/pgwire/pgerror/errors.go
+++ b/pkg/sql/pgwire/pgerror/errors.go
@@ -44,6 +44,19 @@ func NewErrorf(code string, format string, args ...interface{}) *Error {
 	}
 }
 
+// AnnotateError adds a prefix to the message of an error, maintaining its pg
+// error code and source if it is a pgerror.Error.
+func AnnotateError(prefix string, err error) error {
+	if e, ok := err.(*Error); ok {
+		return &Error{
+			Message: fmt.Sprintf("%s %v", prefix, e.Message),
+			Code:    e.Code,
+			Source:  e.Source,
+		}
+	}
+	return fmt.Errorf("%s %v", prefix, err)
+}
+
 // makeSrcCtx creates a Error_Source value with contextual information
 // about the caller at the requested depth.
 func makeSrcCtx(depth int) Error_Source {

--- a/pkg/sql/pgwire/types_test.go
+++ b/pkg/sql/pgwire/types_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/lib/pq/oid"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -101,7 +103,9 @@ func TestIntArrayRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Compare(&parser.EvalContext{}, d) != 0 {
+	evalCtx := parser.NewTestingEvalContext()
+	defer evalCtx.Stop(context.Background())
+	if got.Compare(evalCtx, d) != 0 {
 		t.Fatalf("expected %s, got %s", d, got)
 	}
 }
@@ -308,9 +312,11 @@ func BenchmarkDecodeBinaryDecimal(b *testing.B) {
 		b.StartTimer()
 		got, err := decodeOidDatum(oid.T_numeric, formatBinary, bytes)
 		b.StopTimer()
+		evalCtx := parser.NewTestingEvalContext()
+		defer evalCtx.Stop(context.Background())
 		if err != nil {
 			b.Fatal(err)
-		} else if got.Compare(&parser.EvalContext{}, expected) != 0 {
+		} else if got.Compare(evalCtx, expected) != 0 {
 			b.Fatalf("expected %s, got %s", expected, got)
 		}
 	}

--- a/pkg/sql/sqlbase/encoded_datum_test.go
+++ b/pkg/sql/sqlbase/encoded_datum_test.go
@@ -19,6 +19,8 @@ package sqlbase
 import (
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -29,7 +31,8 @@ func TestEncDatum(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	a := &DatumAlloc{}
-	evalCtx := &parser.EvalContext{}
+	evalCtx := parser.NewTestingEvalContext()
+	defer evalCtx.Stop(context.Background())
 	v := EncDatum{}
 	if !v.IsUnset() {
 		t.Errorf("empty EncDatum should be unset")
@@ -160,7 +163,8 @@ func checkEncDatumCmp(
 
 	dec2 := EncDatumFromEncoded(v2.Type, enc2, buf2)
 
-	evalCtx := &parser.EvalContext{}
+	evalCtx := parser.NewTestingEvalContext()
+	defer evalCtx.Stop(context.Background())
 	if val, err := dec1.Compare(a, evalCtx, &dec2); err != nil {
 		t.Fatal(err)
 	} else if val != expectedCmp {
@@ -183,7 +187,8 @@ func TestEncDatumCompare(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	a := &DatumAlloc{}
-	evalCtx := &parser.EvalContext{}
+	evalCtx := parser.NewTestingEvalContext()
+	defer evalCtx.Stop(context.Background())
 	rng, _ := randutil.NewPseudoRand()
 
 	for kind := range ColumnType_Kind_name {
@@ -248,7 +253,8 @@ func TestEncDatumFromBuffer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	var alloc DatumAlloc
-	evalCtx := &parser.EvalContext{}
+	evalCtx := parser.NewTestingEvalContext()
+	defer evalCtx.Stop(context.Background())
 	rng, _ := randutil.NewPseudoRand()
 	for test := 0; test < 20; test++ {
 		var err error
@@ -395,7 +401,8 @@ func TestEncDatumRowCompare(t *testing.T) {
 	}
 
 	a := &DatumAlloc{}
-	evalCtx := &parser.EvalContext{}
+	evalCtx := parser.NewTestingEvalContext()
+	defer evalCtx.Stop(context.Background())
 	for _, c := range testCases {
 		cmp, err := c.row1.Compare(a, c.ord, evalCtx, c.row2)
 		if err != nil {
@@ -410,7 +417,8 @@ func TestEncDatumRowCompare(t *testing.T) {
 func TestEncDatumRowAlloc(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	evalCtx := &parser.EvalContext{}
+	evalCtx := parser.NewTestingEvalContext()
+	defer evalCtx.Stop(context.Background())
 	rng, _ := randutil.NewPseudoRand()
 	for _, cols := range []int{1, 2, 4, 10, 40, 100} {
 		for _, rows := range []int{1, 2, 3, 5, 10, 20} {

--- a/pkg/sql/sqlbase/table_test.go
+++ b/pkg/sql/sqlbase/table_test.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/pkg/errors"
 
@@ -184,7 +186,8 @@ func TestIndexKey(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		evalCtx := &parser.EvalContext{}
+		evalCtx := parser.NewTestingEvalContext()
+		defer evalCtx.Stop(context.Background())
 		tableDesc, colMap := makeTableDescForTest(test)
 		testValues := append(test.primaryValues, test.secondaryValues...)
 

--- a/pkg/sql/testdata/logic_test/builtin_function
+++ b/pkg/sql/testdata/logic_test/builtin_function
@@ -200,7 +200,7 @@ SELECT repeat('Pg', -1) || 'empty'
 ----
 empty
 
-statement error pq: repeat\(\): runtime error: makeslice: len out of range
+statement error pq: repeat\(\): .* memory budget exceeded
 SELECT repeat('s', 9223372036854775807)
 
 query I


### PR DESCRIPTION
Up until now, testing EvalContexts have been created ad-hoc and inline.
With the introduction of more memory tracking and the inclusion of a
MemoryMonitor in EvalContext, it's become more important to make sure
that an EvalContext for testing is properly initialized. The changes in the first
commit are necessary for the second commit (because various tests
call functions which allocate memory as of the second commit and
require a valid monitor)

The second commit introduces memory tracking for various builtin functions.
The functions which allocate memory and thus currently track it are
LOWER, UPPER, CONCAT, CONCAT_WS, REPEAT, REVERSE, REPLACE, TRANSLATE,
REGEXP_REPLACE, and INITCAP.

It's worth noting that many functions, such as SPLIT_PART, that return
strings return a slice of the input, and so do not need to track that
memory.

This is related to #15295, but is a simplified version of a more
complete solution (it's option 2 on that list).

A drawback of the current use of ActiveMemAcc is that it's only set in
the executor and tracks allocations on a per-output-row basis. This
means that nodes that take in multiple input rows per output row can
overcount their memory. However, with the current setup the only way to
address this would be to swap out the ActiveMemAcc on the nodes which do
that prior to them grabbing their next row, and then replacing the old
one after. A more correct solution might be to create a new function
which pushes a fresh memory account onto a stack, evaluates the
next row, and then closes that account, but I've gone with this for now
since it's simpler and errs on the safe side of memory accounting.

Due to the overcounting, I had to hackily bump up the memory used
in the logic tests. I don't suspect this will be a significant issue in real-world
applications that aren't generating large strings by using `REPEAT` or similar.

I added a somewhat relevant comment to the constant folding step, but
somewhat worth noting that #15055 implies we don't care so much about
being ok in errors during constant folding.