### PR TITLE
readme: remove RoachNode terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The primary design goals are support for ACID transactions, horizontal scalabili
 
 It aims to tolerate disk, machine, rack, and even datacenter failures with minimal latency disruption and no manual intervention.
 
-CockroachDB nodes (RoachNodes) are symmetric; a design goal is homogeneous deployment (one binary) with minimal configuration.
+CockroachDB nodes are symmetric; a design goal is homogeneous deployment (one binary) with minimal configuration.
 
 ### How it Works in a Nutshell
 


### PR DESCRIPTION
This is the only use of this term I can find, after discussing in Slack it seems like its use is a historical artifact and probably worth taking out of the README.