### PR TITLE
adding backup_stmt to docs grammar diagram

### DIFF
--- a/pkg/sql/parser/sql.go
+++ b/pkg/sql/parser/sql.go
@@ -6035,14 +6035,12 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
 		//line sql.y:997
 		{
-			/* SKIP DOC */
 			sqlVAL.union.val = &Backup{Targets: sqlDollar[2].union.targetList(), To: sqlDollar[4].union.expr(), IncrementalFrom: sqlDollar[6].union.exprs(), AsOf: sqlDollar[5].union.asOfClause(), Options: sqlDollar[7].union.kvOptions()}
 		}
 	case 63:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
 		//line sql.y:1001
 		{
-			/* SKIP DOC */
 			sqlVAL.union.val = &Restore{Targets: sqlDollar[2].union.targetList(), From: sqlDollar[4].union.exprs(), AsOf: sqlDollar[5].union.asOfClause(), Options: sqlDollar[6].union.kvOptions()}
 		}
 	case 64:

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -995,12 +995,10 @@ alter_using:
 backup_stmt:
   BACKUP targets TO string_or_placeholder opt_as_of_clause opt_incremental opt_with_options
   {
-    /* SKIP DOC */
     $$.val = &Backup{Targets: $2.targetList(), To: $4.expr(), IncrementalFrom: $6.exprs(), AsOf: $5.asOfClause(), Options: $7.kvOptions()}
   }
 | RESTORE targets FROM string_or_placeholder_list opt_as_of_clause opt_with_options
   {
-    /* SKIP DOC */
     $$.val = &Restore{Targets: $2.targetList(), From: $4.exprs(), AsOf: $5.asOfClause(), Options: $6.kvOptions()}
   }
 


### PR DESCRIPTION
Merged `BACKUP` and `RESTORE` docs in cockroachdb/docs#1239, so these statements can be added to the doc's [SQL grammar diagram](https://www.cockroachlabs.com/docs/sql-grammar.html).