### PR TITLE
settings: add the ability to hide settings from SHOW ALL

### DIFF
--- a/pkg/ccl/utilccl/license_check.go
+++ b/pkg/ccl/utilccl/license_check.go
@@ -13,9 +13,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-var enterpriseEnabled = settings.RegisterBoolSetting(
-	"enterprise.enabled", "set to true to enable Enterprise features", false,
-)
+var enterpriseEnabled = func() *settings.BoolSetting {
+	name := "enterprise.enabled"
+	s := settings.RegisterBoolSetting(name, "set to true to enable Enterprise features", false)
+	settings.Hide(name)
+	return s
+}()
 
 // CheckEnterpriseEnabled returns a non-nil error if the requested enterprise
 // feature is not enabled, including information or a link explaining how to

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -32,6 +32,11 @@ var i2A = RegisterIntSetting("i.2", "", 5)
 var fA = RegisterFloatSetting("f", "", 5.4)
 var dA = RegisterDurationSetting("d", "", time.Second)
 var byteSize = RegisterByteSizeSetting("zzz", "", mb)
+var _ = RegisterBoolSetting("sekretz", "", false)
+
+func init() {
+	Hide("sekretz")
+}
 
 func TestCache(t *testing.T) {
 	t.Run("defaults", func(t *testing.T) {
@@ -272,4 +277,17 @@ func TestCache(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestHide(t *testing.T) {
+	keys := make(map[string]struct{})
+	for _, k := range Keys() {
+		keys[k] = struct{}{}
+	}
+	if _, ok := keys["bool.t"]; !ok {
+		t.Errorf("expected 'bool.t' to be unhidden")
+	}
+	if _, ok := keys["sekretz"]; ok {
+		t.Errorf("expected 'sekretz' to be hidden")
+	}
 }


### PR DESCRIPTION
Use it to hide the "hidden" enterprise.enabled setting.

I'm 50/50 on this logic test. Seems like it'll be more burden than help. I'll try and replace it with something more targeted. Please take a look at the rest in the meantime.