### PR TITLE
storage: Expose a rocksdb commit latency metric

### DIFF
--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
 
@@ -180,6 +181,8 @@ type Engine interface {
 	// Flush causes the engine to write all in-memory data to disk
 	// immediately.
 	Flush() error
+	// SetLatencyMetric initializes the latency metric written to by the Engine.
+	SetLatencyMetric(*metric.Histogram)
 	// GetStats retrieves stats from the engine.
 	GetStats() (*Stats, error)
 	// GetTempDir returns a path under which tempdirs or tempfiles can be created.

--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -199,6 +199,9 @@ var (
 	metaRdbNumSSTables = metric.Metadata{
 		Name: "rocksdb.num-sstables",
 		Help: "Number of rocksdb SSTables"}
+	metaRdbCommitLatencyNanos = metric.Metadata{
+		Name: "rocksdb.commit.latency",
+		Help: "Latency of rocksdb commits in nanoseconds"}
 
 	// Range event metrics.
 	metaRangeSplits = metric.Metadata{
@@ -519,6 +522,7 @@ type StoreMetrics struct {
 	RdbTableReadersMemEstimate  *metric.Gauge
 	RdbReadAmplification        *metric.Gauge
 	RdbNumSSTables              *metric.Gauge
+	RdbCommitLatencyNanos       *metric.Histogram
 
 	// TODO(mrtracy): This should be removed as part of #4465. This is only
 	// maintained to keep the current structure of StatusSummaries; it would be
@@ -700,6 +704,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		RdbTableReadersMemEstimate:  metric.NewGauge(metaRdbTableReadersMemEstimate),
 		RdbReadAmplification:        metric.NewGauge(metaRdbReadAmplification),
 		RdbNumSSTables:              metric.NewGauge(metaRdbNumSSTables),
+		RdbCommitLatencyNanos:       metric.NewLatency(metaRdbCommitLatencyNanos, histogramWindow),
 
 		// Range event metrics.
 		RangeSplits:                     metric.NewCounter(metaRangeSplits),

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -895,6 +895,7 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 		nodeDesc: nodeDesc,
 		metrics:  newStoreMetrics(cfg.HistogramWindowInterval),
 	}
+	s.engine.SetLatencyMetric(s.metrics.RdbCommitLatencyNanos)
 	if cfg.RPCContext != nil {
 		s.allocator = MakeAllocator(cfg.StorePool, cfg.RPCContext.RemoteClocks.Latency)
 	} else {


### PR DESCRIPTION
The approach here is pretty hacky, but getting a metric from an engine
registered with the server any other way seemed even worse. I'm happy to
just shelf this if others don't think the metric is worth the ugliness.

RocksDB has a [huge number of built-in metrics](https://github.com/facebook/rocksdb/blob/master/include/rocksdb/statistics.h) that we're currently only using a small sampling of, but none of them are measuring latency. It might be interesting to have a debug method that dumps all of the known metrics. We're currently paying [the 5-10% overhead](https://github.com/facebook/rocksdb/wiki/Statistics#stats-level-and-performance-costs) without getting a ton out of it.

Inspired by #15341