### PR TITLE
distsql: fix accidental overwrite of distSQLReceiver.err

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -250,7 +250,9 @@ func (r *distSQLReceiver) Push(
 			r.err = meta.Err
 		}
 		if len(meta.Ranges) > 0 {
-			r.err = r.updateCaches(r.ctx, meta.Ranges)
+			if err := r.updateCaches(r.ctx, meta.Ranges); err != nil && r.err == nil {
+				r.err = err
+			}
 		}
 		return r.status
 	}


### PR DESCRIPTION
I have a test that's triggering this but it is part of another change I'm working on.