### PR TITLE
sql: re-enable TestParallelCreateTables

### DIFF
--- a/pkg/sql/create_test.go
+++ b/pkg/sql/create_test.go
@@ -250,7 +250,6 @@ func verifyTables(
 // correctly filled.
 func TestParallelCreateTables(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#13504 Test is flaky under stress.")
 
 	// This number has to be around 10 or else testrace will take too long to
 	// finish.


### PR DESCRIPTION
This test started failing after 9dbce65d0a3f0ad18a0e3467bb069f08c50e913a and has been fixed since.

Fixes #13504.