### PR TITLE
*: make the "TODO" syntax consistent.

### DIFF
--- a/build/style_test.go
+++ b/build/style_test.go
@@ -184,6 +184,30 @@ func TestStyle(t *testing.T) {
 		}
 	})
 
+	t.Run("TestTodoStyle", func(t *testing.T) {
+		t.Parallel()
+		cmd, stderr, filter, err := dirCmd(pkg.Dir, "git", "grep", "-nE", `\sTODO\([^)]*\)[^:]`, "--", "*.go")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := stream.ForEach(filter, func(s string) {
+			t.Errorf(`%s <- use 'TODO(...): ' instead`, s)
+		}); err != nil {
+			t.Error(err)
+		}
+
+		if err := cmd.Wait(); err != nil {
+			if out := stderr.String(); len(out) > 0 {
+				t.Fatalf("err=%s, stderr=%s", err, out)
+			}
+		}
+	})
+
 	t.Run("TestTimeutil", func(t *testing.T) {
 		t.Parallel()
 		cmd, stderr, filter, err := dirCmd(pkg.Dir, "git", "grep", "-nE", `time\.(Now|Since)`, "--", "*.go")

--- a/pkg/acceptance/status_server_test.go
+++ b/pkg/acceptance/status_server_test.go
@@ -43,7 +43,7 @@ var retryOptions = retry.Options{
 
 // get performs an HTTPS GET to the specified path for a specific node.
 func get(ctx context.Context, t *testing.T, base, rel string) []byte {
-	// TODO(bram) #2059: Remove retry logic.
+	// TODO(bram): #2059: Remove retry logic.
 	url := base + rel
 	for r := retry.Start(retryOptions); r.Next(); {
 		resp, err := cluster.HTTPClient.Get(url)

--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -63,7 +63,7 @@ func runDump(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// TODO(knz/mjibson) dump foreign key constraints and dump in
+	// TODO(knz/mjibson): dump foreign key constraints and dump in
 	// topological order to ensure key relationships can be verified
 	// during load.
 

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -75,7 +75,7 @@ type cliState struct {
 	checkSyntax bool
 	// Determines whether to store normalized syntax in the shell history
 	// when check_syntax is set.
-	// TODO(knz) this can possibly be set back to false by default when
+	// TODO(knz): this can possibly be set back to false by default when
 	// the upstream readline library handles multi-line history entries
 	// properly.
 	normalizeHistory bool

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -921,7 +921,7 @@ func (e *Executor) execStmtsInCurrentTxn(
 		txnState.schemaChangers.curStatementIdx = i
 
 		var stmtStrBefore string
-		// TODO(nvanbenschoten) Constant literals can change their representation (1.0000 -> 1) when type checking,
+		// TODO(nvanbenschoten): Constant literals can change their representation (1.0000 -> 1) when type checking,
 		// so we need to reconsider how this works.
 		if (e.cfg.TestingKnobs.CheckStmtStringChange && false) ||
 			(e.cfg.TestingKnobs.StatementFilter != nil) {

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -155,7 +155,7 @@ func doExpandPlan(
 		origOrdering := n.source.Ordering()
 
 		if len(origOrdering.ordering) > 0 {
-			// TODO(knz/radu) we basically have two simultaneous orderings.
+			// TODO(knz/radu): we basically have two simultaneous orderings.
 			// What we really want is something that orderingInfo cannot
 			// currently express: that the rows are ordered by a set of
 			// columns AND at the same time they are also ordered by a
@@ -218,7 +218,7 @@ func doExpandPlan(
 		n.needSort = (match < len(n.ordering))
 
 	case *distinctNode:
-		// TODO(radu/knz) perhaps we can propagate the DISTINCT
+		// TODO(radu/knz): perhaps we can propagate the DISTINCT
 		// clause as desired ordering/exact match for the source node.
 		n.plan, err = doExpandPlan(ctx, p, params, n.plan)
 		if err != nil {
@@ -319,14 +319,14 @@ func expandRenderNode(
 	if len(r.columns) == len(sourceCols) && r.source.info.viewDesc == nil {
 		// 1) we don't drop renderNodes which also interface to a view, because
 		// CREATE VIEW needs it.
-		// TODO(knz) make this optimization conditional on a flag, which can
+		// TODO(knz): make this optimization conditional on a flag, which can
 		// be set to false by CREATE VIEW.
 		//
 		// 2) we don't drop renderNodes which have a different number of
 		// columns than their sources, because some nodes currently assume
 		// the number of source columns doesn't change between
 		// instantiation and Start() (e.g. groupNode).
-		// TODO(knz) investigate this further and enable the optimization fully.
+		// TODO(knz): investigate this further and enable the optimization fully.
 
 		foundNonTrivialRender := false
 		for i, e := range r.render {

--- a/pkg/sql/filter_opt.go
+++ b/pkg/sql/filter_opt.go
@@ -180,7 +180,7 @@ func (p *planner) propagateFilters(
 			// are "already applied". Silently absorb any extra filter.
 			return plan, parser.DBoolTrue, nil
 		}
-		// TODO(knz) We could evaluate the filter here and set/reset
+		// TODO(knz): We could evaluate the filter here and set/reset
 		// n.results accordingly, assuming the filter is not "row
 		// dependent" (cf. resolveNames()).
 
@@ -251,7 +251,7 @@ func (p *planner) propagateFilters(
 		// However we don't do that yet.
 		// For now, simply trigger optimization for the child node.
 		//
-		// TODO(knz) implement the aforementioned optimization.
+		// TODO(knz): implement the aforementioned optimization.
 		//
 		if n.plan, err = p.triggerFilterPropagation(ctx, n.plan); err != nil {
 			return plan, extraFilter, err
@@ -493,7 +493,7 @@ func (p *planner) addRenderFilter(
 func (p *planner) addJoinFilter(
 	ctx context.Context, n *joinNode, extraFilter parser.TypedExpr,
 ) (planNode, parser.TypedExpr, error) {
-	// TODO(knz) support outer joins.
+	// TODO(knz): support outer joins.
 	if n.joinType != joinTypeInner {
 		// Outer joins not supported; simply trigger filter optimization in the sub-nodes.
 		var err error

--- a/pkg/sql/limit_opt.go
+++ b/pkg/sql/limit_opt.go
@@ -38,7 +38,7 @@ import (
 // offset expressions. EXPLAIN also does this, see expandPlan() for
 // explainPlanNode.
 //
-// TODO(radu) Arguably, this interface has room for improvement.  A
+// TODO(radu): Arguably, this interface has room for improvement.  A
 // limitNode may have a hard limit locally which is larger than the
 // soft limit propagated up by nodes downstream. We may want to
 // improve this API to pass both the soft and hard limit.

--- a/pkg/sql/logic_test.go
+++ b/pkg/sql/logic_test.go
@@ -1456,7 +1456,7 @@ func TestLogic(t *testing.T) {
 						// tests in parallel.
 						// Skip parallelizing tests that use the kv-batch-size directive since
 						// the batch size is a global variable.
-						// TODO(jordan, radu) make sqlbase.kvBatchSize non-global to fix this.
+						// TODO(jordan, radu): make sqlbase.kvBatchSize non-global to fix this.
 						if filepath.Base(path) != "select_index_span_ranges" {
 							t.Parallel()
 						}

--- a/pkg/sql/mon/mem_usage.go
+++ b/pkg/sql/mon/mem_usage.go
@@ -342,7 +342,7 @@ func (mm *MemoryMonitor) Stop(ctx context.Context) {
 	mm.releaseBudget(ctx)
 
 	if mm.maxBytesHist != nil && mm.mu.maxAllocated > 0 {
-		// TODO(knz) We record the logarithm because the UI doesn't know
+		// TODO(knz): We record the logarithm because the UI doesn't know
 		// how to do logarithmic y-axes yet. See the explanatory comments
 		// in sql/mem_metrics.go.
 		val := int64(1000 * math.Log(float64(mm.mu.maxAllocated)) / math.Ln10)

--- a/pkg/sql/needed_columns.go
+++ b/pkg/sql/needed_columns.go
@@ -56,7 +56,7 @@ func setNeededColumns(plan planNode, needed []bool) {
 		// Currently all the needed result columns are provided by the
 		// table sub-source; from the index sub-source we only need the PK
 		// columns sufficient to configure the table sub-source.
-		// TODO(radu/knz) see the comments at the start of index_join.go,
+		// TODO(radu/knz): see the comments at the start of index_join.go,
 		// perhaps this can be optimized to utilize the column values
 		// already provided by the index instead of re-retrieving them
 		// using the table scanNode.
@@ -153,33 +153,33 @@ func setNeededColumns(plan planNode, needed []bool) {
 		markOmitted(n.columns, sourceNeeded[:len(n.columns)])
 
 	case *groupNode:
-		// TODO(knz) This can be optimized by removing the aggregation
+		// TODO(knz): This can be optimized by removing the aggregation
 		// results that are not needed, then removing additional renders
 		// from the source that would otherwise only be needed for the
 		// omitted aggregation results.
 		setNeededColumns(n.plan, allColumns(n.plan))
 
 	case *windowNode:
-		// TODO(knz) This can be optimized by removing the window function
+		// TODO(knz): This can be optimized by removing the window function
 		// definitions that are not needed, then removing additional
 		// renders from the source that would otherwise only be needed for
 		// the omitted window definitions.
 		setNeededColumns(n.plan, allColumns(n.plan))
 
 	case *deleteNode:
-		// TODO(knz) This can be optimized by omitting the columns that
+		// TODO(knz): This can be optimized by omitting the columns that
 		// are not part of the primary key, do not participate in
 		// foreign key relations and that are not needed for RETURNING.
 		setNeededColumns(n.run.rows, allColumns(n.run.rows))
 
 	case *updateNode:
-		// TODO(knz) This can be optimized by omitting the columns that
+		// TODO(knz): This can be optimized by omitting the columns that
 		// are not part of the primary key, do not participate in
 		// foreign key relations and that are not needed for RETURNING.
 		setNeededColumns(n.run.rows, allColumns(n.run.rows))
 
 	case *insertNode:
-		// TODO(knz) This can be optimized by omitting the columns that
+		// TODO(knz): This can be optimized by omitting the columns that
 		// are not part of the primary key, do not participate in
 		// foreign key relations and that are not needed for RETURNING.
 		setNeededColumns(n.run.rows, allColumns(n.run.rows))

--- a/pkg/sql/parser/aggregate_builtins.go
+++ b/pkg/sql/parser/aggregate_builtins.go
@@ -121,7 +121,7 @@ var Aggregates = map[string][]Builtin{
 	},
 
 	"concat_agg": {
-		// TODO(knz) When CockroachDB supports STRING_AGG, CONCAT_AGG(X)
+		// TODO(knz): When CockroachDB supports STRING_AGG, CONCAT_AGG(X)
 		// should be substituted to STRING_AGG(X, '') and executed as
 		// such (no need for a separate implementation).
 		makeAggBuiltin(TypeString, TypeString, newStringConcatAggregate,

--- a/pkg/sql/parser/constant.go
+++ b/pkg/sql/parser/constant.go
@@ -228,7 +228,7 @@ func (expr *NumVal) ResolveAsType(ctx *SemaContext, typ Type) (Datum, error) {
 		dd := &expr.resDecimal
 		s := expr.OrigString
 		if s == "" {
-			// TODO(nvanbenschoten) We should propagate width through constant folding so that we
+			// TODO(nvanbenschoten): We should propagate width through constant folding so that we
 			// can control precision on folded values as well.
 			s = expr.ExactString()
 		}
@@ -240,7 +240,7 @@ func (expr *NumVal) ResolveAsType(ctx *SemaContext, typ Type) (Datum, error) {
 				return nil, errors.Wrapf(err, "could not evaluate numerator of %v as Datum type DDecimal "+
 					"from string %q", expr, num)
 			}
-			// TODO(nvanbenschoten) Should we try to avoid this allocation?
+			// TODO(nvanbenschoten): Should we try to avoid this allocation?
 			denDec, err := ParseDDecimal(den)
 			if err != nil {
 				return nil, errors.Wrapf(err, "could not evaluate denominator %v as Datum type DDecimal "+
@@ -577,8 +577,8 @@ func (constantFolderVisitor) VisitPost(expr Expr) (retExpr Expr) {
 
 // foldConstantLiterals folds all constant literals using exact arithmetic.
 //
-// TODO(nvanbenschoten) Can this visitor be preallocated (like normalizeVisitor)?
-// TODO(nvanbenschoten) Investigate normalizing associative operations to group
+// TODO(nvanbenschoten): Can this visitor be preallocated (like normalizeVisitor)?
+// TODO(nvanbenschoten): Investigate normalizing associative operations to group
 //     constants together and permit further numeric constant folding.
 func foldConstantLiterals(expr Expr) (Expr, error) {
 	v := constantFolderVisitor{}

--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -1056,13 +1056,13 @@ func (d *DDate) IsMin() bool {
 
 // max implements the Datum interface.
 func (d *DDate) max() (Datum, bool) {
-	// TODO(knz) figure a good way to find a maximum.
+	// TODO(knz): figure a good way to find a maximum.
 	return nil, false
 }
 
 // min implements the Datum interface.
 func (d *DDate) min() (Datum, bool) {
-	// TODO(knz) figure a good way to find a minimum.
+	// TODO(knz): figure a good way to find a minimum.
 	return nil, false
 }
 
@@ -1236,13 +1236,13 @@ func (d *DTimestamp) IsMin() bool {
 
 // min implements the Datum interface.
 func (d *DTimestamp) min() (Datum, bool) {
-	// TODO(knz) figure a good way to find a minimum.
+	// TODO(knz): figure a good way to find a minimum.
 	return nil, false
 }
 
 // max implements the Datum interface.
 func (d *DTimestamp) max() (Datum, bool) {
-	// TODO(knz) figure a good way to find a minimum.
+	// TODO(knz): figure a good way to find a minimum.
 	return nil, false
 }
 
@@ -1333,13 +1333,13 @@ func (d *DTimestampTZ) IsMin() bool {
 
 // min implements the Datum interface.
 func (d *DTimestampTZ) min() (Datum, bool) {
-	// TODO(knz) figure a good way to find a minimum.
+	// TODO(knz): figure a good way to find a minimum.
 	return nil, false
 }
 
 // max implements the Datum interface.
 func (d *DTimestampTZ) max() (Datum, bool) {
-	// TODO(knz) figure a good way to find a minimum.
+	// TODO(knz): figure a good way to find a minimum.
 	return nil, false
 }
 

--- a/pkg/sql/parser/datum_test.go
+++ b/pkg/sql/parser/datum_test.go
@@ -164,7 +164,7 @@ func TestDatumOrdering(t *testing.T) {
 
 		// Arrays
 
-		// TODO(nathan) Until we support literals for empty arrays, this
+		// TODO(nathan): Until we support literals for empty arrays, this
 		// is the easiest way to construct one.
 		{`current_schemas(false)`, valIsMin, `{NULL}`, `{}`, noMax},
 

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -1737,7 +1737,7 @@ type EvalContext struct {
 // GetStmtTimestamp retrieves the current statement timestamp as per
 // the evaluation context. The timestamp is guaranteed to be nonzero.
 func (ctx *EvalContext) GetStmtTimestamp() time.Time {
-	// TODO(knz) a zero timestamp should never be read, even during
+	// TODO(knz): a zero timestamp should never be read, even during
 	// Prepare. This will need to be addressed.
 	if !ctx.PrepareOnly && ctx.stmtTimestamp.IsZero() {
 		panic("zero statement timestamp in EvalContext")
@@ -1748,7 +1748,7 @@ func (ctx *EvalContext) GetStmtTimestamp() time.Time {
 // GetClusterTimestamp retrieves the current cluster timestamp as per
 // the evaluation context. The timestamp is guaranteed to be nonzero.
 func (ctx *EvalContext) GetClusterTimestamp() *DDecimal {
-	// TODO(knz) a zero timestamp should never be read, even during
+	// TODO(knz): a zero timestamp should never be read, even during
 	// Prepare. This will need to be addressed.
 	if !ctx.PrepareOnly {
 		if ctx.clusterTimestamp == (hlc.Timestamp{}) {
@@ -1781,7 +1781,7 @@ func TimestampToDecimal(ts hlc.Timestamp) *DDecimal {
 // GetTxnTimestamp retrieves the current transaction timestamp as per
 // the evaluation context. The timestamp is guaranteed to be nonzero.
 func (ctx *EvalContext) GetTxnTimestamp(precision time.Duration) *DTimestampTZ {
-	// TODO(knz) a zero timestamp should never be read, even during
+	// TODO(knz): a zero timestamp should never be read, even during
 	// Prepare. This will need to be addressed.
 	if !ctx.PrepareOnly && ctx.txnTimestamp.IsZero() {
 		panic("zero transaction timestamp in EvalContext")
@@ -1792,7 +1792,7 @@ func (ctx *EvalContext) GetTxnTimestamp(precision time.Duration) *DTimestampTZ {
 // GetTxnTimestampNoZone retrieves the current transaction timestamp as per
 // the evaluation context. The timestamp is guaranteed to be nonzero.
 func (ctx *EvalContext) GetTxnTimestampNoZone(precision time.Duration) *DTimestamp {
-	// TODO(knz) a zero timestamp should never be read, even during
+	// TODO(knz): a zero timestamp should never be read, even during
 	// Prepare. This will need to be addressed.
 	if !ctx.PrepareOnly && ctx.txnTimestamp.IsZero() {
 		panic("zero transaction timestamp in EvalContext")
@@ -2236,7 +2236,7 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 		}
 
 	case *TimestampColType:
-		// TODO(knz) Timestamp from float, decimal.
+		// TODO(knz): Timestamp from float, decimal.
 		switch d := d.(type) {
 		case *DString:
 			return ParseDTimestamp(string(*d), time.Microsecond)
@@ -2254,7 +2254,7 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 		}
 
 	case *TimestampTZColType:
-		// TODO(knz) TimestampTZ from float, decimal.
+		// TODO(knz): TimestampTZ from float, decimal.
 		switch d := d.(type) {
 		case *DString:
 			return ParseDTimestampTZ(string(*d), ctx.GetLocation(), time.Microsecond)
@@ -2271,7 +2271,7 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 		}
 
 	case *IntervalColType:
-		// TODO(knz) Interval from float, decimal.
+		// TODO(knz): Interval from float, decimal.
 		switch v := d.(type) {
 		case *DString:
 			return ParseDInterval(string(*v))

--- a/pkg/sql/parser/format.go
+++ b/pkg/sql/parser/format.go
@@ -77,7 +77,7 @@ var FmtHideConstants FmtFlags = &fmtFlags{hideConstants: true}
 
 // FmtAnonymize instructs the pretty-printer to remove
 // any name but function names.
-// TODO(knz) temporary until a better solution is found for #13968
+// TODO(knz): temporary until a better solution is found for #13968
 var FmtAnonymize FmtFlags = &fmtFlags{anonymize: true}
 
 // FmtReformatTableNames returns FmtFlags that instructs the pretty-printer

--- a/pkg/sql/parser/function_definition.go
+++ b/pkg/sql/parser/function_definition.go
@@ -86,7 +86,7 @@ func (n UnresolvedName) ResolveFunction(searchPath SearchPath) (*FunctionDefinit
 	// Name.Normalize(), functions are special in that they are
 	// guaranteed to not contain special Unicode characters. So we can
 	// use ToLower directly.
-	// TODO(knz) this will need to be revisited once we allow
+	// TODO(knz): this will need to be revisited once we allow
 	// function names to exist in custom namespaces, whose names
 	// may contain special characters.
 	prefix := strings.ToLower(fn.prefix())

--- a/pkg/sql/parser/normalize.go
+++ b/pkg/sql/parser/normalize.go
@@ -600,7 +600,7 @@ func (v *normalizeVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 	case *Subquery:
 		// Avoid normalizing subqueries. We need the subquery to be expanded in
 		// order to do so properly.
-		// TODO(knz) This should happen when the prepare and execute phases are
+		// TODO(knz): This should happen when the prepare and execute phases are
 		//     separated for SelectClause.
 		return false, expr
 	}

--- a/pkg/sql/parser/overload.go
+++ b/pkg/sql/parser/overload.go
@@ -338,7 +338,7 @@ func typeCheckOverloadedExprs(
 		})
 	}
 
-	// TODO(nvanbenschoten) We should add a filtering step here to filter
+	// TODO(nvanbenschoten): We should add a filtering step here to filter
 	// out impossible candidates based on identical parameters. For instance,
 	// f(int, float) is not a possible candidate for the expression f($1, $1).
 

--- a/pkg/sql/parser/pg_builtins.go
+++ b/pkg/sql/parser/pg_builtins.go
@@ -216,7 +216,7 @@ var pgBuiltins = map[string][]Builtin{
 	},
 	"format_type": {
 		Builtin{
-			// TODO(jordan) typemod should be a Nullable TypeInt when supported.
+			// TODO(jordan): typemod should be a Nullable TypeInt when supported.
 			Types:      ArgTypes{{"type_oid", TypeOid}, {"typemod", TypeInt}},
 			ReturnType: fixedReturnType(TypeString),
 			fn: func(ctx *EvalContext, args Datums) (Datum, error) {

--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -1044,7 +1044,7 @@ func typeCheckSameTypedExprs(
 	}
 
 	// Hold the resolved type expressions of the provided exprs, in order.
-	// TODO(nvanbenschoten) Look into reducing allocations here.
+	// TODO(nvanbenschoten): Look into reducing allocations here.
 	typedExprs := make([]TypedExpr, len(exprs))
 
 	// Split the expressions into three groups of indexed expressions:
@@ -1254,7 +1254,7 @@ func typeCheckSameTypedTupleExprs(
 	ctx *SemaContext, desired Type, exprs ...Expr,
 ) ([]TypedExpr, Type, error) {
 	// Hold the resolved type expressions of the provided exprs, in order.
-	// TODO(nvanbenschoten) Look into reducing allocations here.
+	// TODO(nvanbenschoten): Look into reducing allocations here.
 	typedExprs := make([]TypedExpr, len(exprs))
 
 	// All other exprs must be tuples.
@@ -1412,7 +1412,7 @@ func (*placeholderAnnotationVisitor) VisitPost(expr Expr) Expr { return expr }
 //   map, no error will be thrown, and the placeholder will keep it's previously
 //   inferred type.
 //
-// TODO(nvanbenschoten) Can this visitor and map be preallocated (like normalizeVisitor)?
+// TODO(nvanbenschoten): Can this visitor and map be preallocated (like normalizeVisitor)?
 func (p PlaceholderTypes) ProcessPlaceholderAnnotations(stmt Statement) error {
 	v := placeholderAnnotationVisitor{make(map[string]annotationState)}
 

--- a/pkg/sql/parser/walk.go
+++ b/pkg/sql/parser/walk.go
@@ -470,7 +470,7 @@ func (expr *AllColumnsSelector) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
 func (expr *ColumnItem) Walk(_ Visitor) Expr {
-	// TODO(knz) When ARRAY is supported, this must be extended
+	// TODO(knz): When ARRAY is supported, this must be extended
 	// to recurse into the index expressions of the ColumnItems' Selector.
 	return expr
 }

--- a/pkg/sql/parser/window_builtins.go
+++ b/pkg/sql/parser/window_builtins.go
@@ -135,7 +135,7 @@ var windows = map[string][]Builtin{
 		collectBuiltins(func(t Type) Builtin {
 			return makeWindowBuiltin(ArgTypes{{"val", t}, {"n", TypeInt}}, t, makeLeadLagWindowConstructor(false, true, false))
 		}, TypesAnyNonArray...),
-		// TODO(nvanbenschoten) We still have no good way to represent two parameters that
+		// TODO(nvanbenschoten): We still have no good way to represent two parameters that
 		// can be any types but must be the same (eg. lag(T, Int, T)).
 		collectBuiltins(func(t Type) Builtin {
 			return makeWindowBuiltin(ArgTypes{{"val", t}, {"n", TypeInt}, {"default", t}},

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -504,7 +504,7 @@ CREATE TABLE pg_catalog.pg_constraint (
 				case sqlbase.ConstraintTypeCheck:
 					oid = h.CheckConstraintOid(db, table, c.CheckConstraint)
 					contype = conTypeCheck
-					// TODO(nvanbenschoten) We currently do not store the referenced columns for a check
+					// TODO(nvanbenschoten): We currently do not store the referenced columns for a check
 					// constraint. We should add an array of column indexes to
 					// sqlbase.TableDescriptor_CheckConstraint and use that here.
 					consrc = parser.NewDString(c.Details)

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -817,12 +817,12 @@ func TestPGPreparedQuery(t *testing.T) {
 			baseTest.SetArgs(1),
 		},
 
-		// TODO(jordan) blocked on #13651
+		// TODO(jordan): blocked on #13651
 		//"SELECT $1::INT[]": {
 		//	baseTest.SetArgs(pq.Array([]int{10})).Results(pq.Array([]int{10})),
 		//},
 
-		// TODO(nvanbenschoten) Same class of limitation as that in logic_test/typing:
+		// TODO(nvanbenschoten): Same class of limitation as that in logic_test/typing:
 		//   Nested constants are not exposed to the same constant type resolution rules
 		//   as top-level constants, and instead are simply resolved to their natural type.
 		//"SELECT (CASE a WHEN 10 THEN 'one' WHEN 11 THEN (CASE 'en' WHEN 'en' THEN $1 END) END) AS ret FROM d.T ORDER BY ret DESC LIMIT 2": {

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -196,7 +196,7 @@ func (p *planner) orderBy(
 
 		// Finally, if we haven't found anything so far, we really
 		// need a new render.
-		// TODO(knz/dan) currently this is only possible for renderNode.
+		// TODO(knz/dan): currently this is only possible for renderNode.
 		// If we are dealing with a UNION or something else we would need
 		// to fabricate an intermediate renderNode to add the new render.
 		if index == -1 && s != nil {
@@ -568,7 +568,7 @@ func (ss *iterativeSortStrategy) Close(ctx context.Context) {
 // The strategy is intended to be used when exactly k values need to be sorted,
 // where k is known before sorting begins.
 //
-// TODO(nvanbenschoten) There are better algorithms that can achieve a sorted
+// TODO(nvanbenschoten): There are better algorithms that can achieve a sorted
 // top k in a worst-case time complexity of O(n + k*log(k)) while maintaining
 // a worst-case space complexity of O(k). For instance, the top k can be found
 // in linear time, and then this can be sorted in linearithmic time.

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -1540,7 +1540,7 @@ func CheckValueWidth(col ColumnDescriptor, val parser.Datum) error {
 				// data is of variable length up to the maximum length n; longer
 				// strings will be rejected."
 				//
-				// TODO(nvanbenschoten) Because we do not propagate the "varying"
+				// TODO(nvanbenschoten): Because we do not propagate the "varying"
 				// flag on the column type, the best we can do here is conservatively
 				// assume the varying bit type and error only on longer bit strings.
 				mostSignificantBit := int32(0)

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -74,7 +74,7 @@ func (s *subquery) Format(buf *bytes.Buffer, f parser.FmtFlags) {
 		buf.WriteString("EXISTS ")
 	}
 	if f == parser.FmtShowTypes {
-		// TODO(knz/nvanbenschoten) It is not possible to extract types
+		// TODO(knz/nvanbenschoten): It is not possible to extract types
 		// from the subquery using Format, because type checking does not
 		// replace the sub-expressions of a SelectClause node in-place.
 		f = parser.FmtSimple
@@ -96,7 +96,7 @@ func (s *subquery) TypeCheck(_ *parser.SemaContext, desired parser.Type) (parser
 	// sub-query. For now, the type is simply derived during the subquery node
 	// creation by looking at the result column types.
 
-	// TODO(nvanbenschoten) Type checking for the comparison operator(s)
+	// TODO(nvanbenschoten): Type checking for the comparison operator(s)
 	// should take this new node into account. In particular it should
 	// check that the tuple types match pairwise.
 	return s, nil

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -71,7 +71,7 @@ type tableWriter interface {
 	// tableWriter will touch when executed. This is contractual, and the
 	// tableWriter will not touch any keys outside of the spans reported here.
 	//
-	// TODO(nvanbenschoten) we are currently pretty pessimistic here, assuming
+	// TODO(nvanbenschoten): we are currently pretty pessimistic here, assuming
 	// that table operations will touch the entire table. In cases where we
 	// can determine ahead of time that this isn't true, we should true to
 	// constrain these spans.

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -510,7 +510,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT, t DECIMAL);
 	// server to panic (and thus the test to fail) when the connection
 	// is closed.
 	//
-	// TODO(knz) This test can be made more robust by exposing the
+	// TODO(knz): This test can be made more robust by exposing the
 	// current allocation count in monitor and checking that it has the
 	// same value at the beginning of each retry.
 	if _, err := sqlDB.Exec(`

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -114,7 +114,7 @@ func (r *editNodeRun) collectSpans(ctx context.Context) (reads, writes roachpb.S
 	if len(scanWrites) > 0 {
 		return nil, nil, errors.Errorf("unexpected scan span writes: %v", scanWrites)
 	}
-	// TODO(nvanbenschoten) if we notice that r.rows is a ValuesClause, we
+	// TODO(nvanbenschoten): if we notice that r.rows is a ValuesClause, we
 	// may be able to contrain the tableWriter Spans.
 	writerReads, writerWrites, err := r.tw.spans()
 	if err != nil {

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -172,7 +172,7 @@ func (n *windowNode) constructWindowDefinitions(
 			return err
 		}
 
-		// TODO(nvanbenschoten) below we add renders to the renderNode for each
+		// TODO(nvanbenschoten): below we add renders to the renderNode for each
 		// partition and order expression. We should handle cases where the expression
 		// is already referenced by the query like sortNode does.
 
@@ -640,7 +640,7 @@ func (n *windowNode) computeWindows(ctx context.Context) error {
 		// Partition rows into separate partitions based on hash values of the
 		// window function's PARTITION BY attribute.
 		//
-		// TODO(nvanbenschoten) Window functions with the same window definition
+		// TODO(nvanbenschoten): Window functions with the same window definition
 		// can share partition and sorting work.
 		// See Cao et al. [http://vldb.org/pvldb/vol5/p1244_yucao_vldb2012.pdf]
 		for rowI := 0; rowI < rowCount; rowI++ {
@@ -683,7 +683,7 @@ func (n *windowNode) computeWindows(ctx context.Context) error {
 		//   * Segment Tree
 		// See Leis et al. [http://www.vldb.org/pvldb/vol8/p1058-leis.pdf]
 		for _, partition := range partitions {
-			// TODO(nvanbenschoten) Handle framing here. Right now we only handle the default
+			// TODO(nvanbenschoten): Handle framing here. Right now we only handle the default
 			// framing option of RANGE UNBOUNDED PRECEDING. With ORDER BY, this sets the frame
 			// to be all rows from the partition start up through the current row's last ORDER BY
 			// peer. Without ORDER BY, all rows of the partition are included in the window frame,

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -454,7 +454,7 @@ func MVCCGetProto(
 	txn *roachpb.Transaction,
 	msg proto.Message,
 ) (bool, error) {
-	// TODO(tschottdorf) Consider returning skipped intents to the caller.
+	// TODO(tschottdorf): Consider returning skipped intents to the caller.
 	value, _, mvccGetErr := MVCCGet(ctx, engine, key, timestamp, consistent, txn)
 	found := value != nil
 	// If we found a result, parse it regardless of the error returned by MVCCGet.

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -950,7 +950,7 @@ func updateTxnWithExternalIntents(
 // A range-local intent range is never split: It's returned as either
 // belonging to or outside of the descriptor's key range, and passing an intent
 // which begins range-local but ends non-local results in a panic.
-// TODO(tschottdorf) move to proto, make more gen-purpose - kv.truncate does
+// TODO(tschottdorf): move to proto, make more gen-purpose - kv.truncate does
 // some similar things.
 func intersectSpan(
 	span roachpb.Span, desc roachpb.RangeDescriptor,
@@ -1232,7 +1232,7 @@ func evalRangeLookup(
 	}
 
 	for _, kv := range kvs {
-		// TODO(tschottdorf) Candidate for a ReplicaCorruptionError.
+		// TODO(tschottdorf): Candidate for a ReplicaCorruptionError.
 		rd, err := checkAndUnmarshal(kv.Value)
 		if err != nil {
 			return EvalResult{}, err

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -829,7 +829,7 @@ func (sc *StoreConfig) Valid() bool {
 
 // SetDefaults initializes unset fields in StoreConfig to values
 // suitable for use on a local network.
-// TODO(tschottdorf) see if this ought to be configurable via flags.
+// TODO(tschottdorf): see if this ought to be configurable via flags.
 func (sc *StoreConfig) SetDefaults() {
 	if (sc.RangeRetryOptions == retry.Options{}) {
 		sc.RangeRetryOptions = base.DefaultRetryOptions()
@@ -882,7 +882,7 @@ func (sc *StoreConfig) LeaseExpiration() int64 {
 
 // NewStore returns a new instance of a store.
 func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescriptor) *Store {
-	// TODO(tschottdorf) find better place to set these defaults.
+	// TODO(tschottdorf): find better place to set these defaults.
 	cfg.SetDefaults()
 
 	if !cfg.Valid() {
@@ -890,7 +890,7 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 	}
 	s := &Store{
 		cfg:      cfg,
-		db:       cfg.DB, // TODO(tschottdorf) remove redundancy.
+		db:       cfg.DB, // TODO(tschottdorf): remove redundancy.
 		engine:   eng,
 		nodeDesc: nodeDesc,
 		metrics:  newStoreMetrics(cfg.HistogramWindowInterval),
@@ -2027,7 +2027,7 @@ func (s *Store) addReplicaInternalLocked(repl *Replica) error {
 		return errors.Errorf("attempted to add uninitialized range %s", repl)
 	}
 
-	// TODO(spencer); will need to determine which range is
+	// TODO(spencer): will need to determine which range is
 	// newer, and keep that one.
 	if err := s.addReplicaToRangeMapLocked(repl); err != nil {
 		return err

--- a/pkg/util/interval/interval.go
+++ b/pkg/util/interval/interval.go
@@ -80,7 +80,7 @@ func (r Range) String() string {
 type Interface interface {
 	Range() Range
 	// Returns a unique ID for the element.
-	// TODO(nvanbenschoten) Should this be changed to an int64?
+	// TODO(nvanbenschoten): Should this be changed to an int64?
 	ID() uintptr
 }
 


### PR DESCRIPTION
(And add a linter.)

Requested by @dt.