### PR TITLE
sql/parser: fix the pretty-print of several operators

### DIFF
--- a/pkg/sql/parser/expr.go
+++ b/pkg/sql/parser/expr.go
@@ -496,7 +496,7 @@ func (*IsOfTypeExpr) operatorExpr() {}
 
 // Format implements the NodeFormatter interface.
 func (node *IsOfTypeExpr) Format(buf *bytes.Buffer, f FmtFlags) {
-	FormatNode(buf, f, node.Expr)
+	exprFmtWithParen(buf, f, node.Expr)
 	buf.WriteString(" IS")
 	if node.Not {
 		buf.WriteString(" NOT")
@@ -1057,7 +1057,7 @@ func (node *CastExpr) Format(buf *bytes.Buffer, f FmtFlags) {
 		}
 		fallthrough
 	case castShort:
-		FormatNode(buf, f, node.Expr)
+		exprFmtWithParen(buf, f, node.Expr)
 		buf.WriteString("::")
 		FormatNode(buf, f, node.Type)
 	default:
@@ -1143,7 +1143,7 @@ type IndirectionExpr struct {
 
 // Format implements the NodeFormatter interface.
 func (node *IndirectionExpr) Format(buf *bytes.Buffer, f FmtFlags) {
-	FormatNode(buf, f, node.Expr)
+	exprFmtWithParen(buf, f, node.Expr)
 	FormatNode(buf, f, node.Indirection)
 }
 
@@ -1166,7 +1166,7 @@ type AnnotateTypeExpr struct {
 func (node *AnnotateTypeExpr) Format(buf *bytes.Buffer, f FmtFlags) {
 	switch node.syntaxMode {
 	case annotateShort:
-		FormatNode(buf, f, node.Expr)
+		exprFmtWithParen(buf, f, node.Expr)
 		buf.WriteString(":::")
 		FormatNode(buf, f, node.Type)
 
@@ -1198,7 +1198,7 @@ type CollateExpr struct {
 
 // Format implements the NodeFormatter interface.
 func (node *CollateExpr) Format(buf *bytes.Buffer, f FmtFlags) {
-	FormatNode(buf, f, node.Expr)
+	exprFmtWithParen(buf, f, node.Expr)
 	buf.WriteString(" COLLATE ")
 	buf.WriteString(node.Locale)
 }

--- a/pkg/sql/parser/normalize_test.go
+++ b/pkg/sql/parser/normalize_test.go
@@ -161,6 +161,10 @@ func TestNormalizeExpr(t *testing.T) {
 		{`IF((true OR a < 0), (0 + a)::decimal, 2 / (1 - 1))`, `a::DECIMAL`},
 		{`COALESCE(NULL, (NULL < 3), a = 2 - 1, d)`, `COALESCE(a = 1, d)`},
 		{`COALESCE(NULL, a)`, `a`},
+		// #15454: ensure that operators are pretty-printed correctly after normalization.
+		{`(random() + 1.0)::INT`, `(random() + 1.0)::INT`},
+		{`('a' || left('b', random()::INT)) COLLATE en`, `('a' || left('b', random()::INT)) COLLATE en`},
+		{`(1.0 + random()) IS OF (INT)`, `(1.0 + random()) IS OF (INT)`},
 		// #14687: ensure that negative divisors flip the inequality when rotating.
 		{`1 < a / -2`, `a < -2`},
 		{`1 <= a / -2`, `a <= -2`},


### PR DESCRIPTION
Prior to this patch, `(x + 1)::INT` would be pretty-printed as
`x + 1::INT`. This wasn't right! (Especially since distsql uses
the pretty-printer to distribute computations...)

The error also affected COLLATE and IS OF TYPE, which have an impact
on distsql execution, and also `:::` and `x[y]`, which was a muted bug
because `:::` disappears during normalization and there is (currently)
no non-unary expression `x` for which `x[y]` is not a type error.

This patch ensures the parentheses are emitted when necessary.

Fixes #15454.