### PR TITLE
sql: fix ARRAY serialization

### DIFF
--- a/pkg/sql/index_selection_test.go
+++ b/pkg/sql/index_selection_test.go
@@ -706,7 +706,7 @@ func TestApplyConstraints(t *testing.T) {
 		// doesn't decompose further.
 		{`a < 3 AND (b < 2 OR a IN (0,1,2))`, `a`, `(b < 2) OR (a IN (0, 1, 2))`},
 		{`a < 3 AND (b < 2 OR a NOT IN (0,1,2))`, `a`, `(b < 2) OR (a NOT IN (0, 1, 2))`},
-		{`a < 3 AND (b < 2 OR a = ANY ARRAY[0,1,2])`, `a`, `(b < 2) OR (a = ANY {0,1,2})`},
+		{`a < 3 AND (b < 2 OR a = ANY ARRAY[0,1,2])`, `a`, `(b < 2) OR (a = ANY ARRAY[0,1,2])`},
 		{`a IN (0, 2, 3) AND (b < 2 OR a <= 4)`, `a`, `(b < 2) OR (a <= 4)`},
 		{`a IN (0, 2, 3) AND (b < 2 OR a = 2)`, `a`, `(b < 2) OR (a = 2)`},
 	}

--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -2001,14 +2001,14 @@ func (*DArray) AmbiguousFormat() bool { return false }
 
 // Format implements the NodeFormatter interface.
 func (d *DArray) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteByte('{')
+	buf.WriteString("ARRAY[")
 	for i, v := range d.Array {
 		if i > 0 {
 			buf.WriteString(",")
 		}
 		FormatNode(buf, f, v)
 	}
-	buf.WriteByte('}')
+	buf.WriteByte(']')
 }
 
 // Len returns the length of the Datum array.

--- a/pkg/sql/parser/datum_test.go
+++ b/pkg/sql/parser/datum_test.go
@@ -166,14 +166,16 @@ func TestDatumOrdering(t *testing.T) {
 
 		// TODO(nathan): Until we support literals for empty arrays, this
 		// is the easiest way to construct one.
-		{`current_schemas(false)`, valIsMin, `{NULL}`, `{}`, noMax},
+		{`current_schemas(false)`, valIsMin, `ARRAY[NULL]`, `ARRAY[]`, noMax},
 
-		{`array[NULL]`, noPrev, `{NULL,NULL}`, `{}`, noMax},
-		{`array[true]`, noPrev, `{true,NULL}`, `{}`, noMax},
+		{`array[NULL]`, noPrev, `ARRAY[NULL,NULL]`, `ARRAY[]`, noMax},
+		{`array[true]`, noPrev, `ARRAY[true,NULL]`, `ARRAY[]`, noMax},
 
 		// Mixed tuple/array datums.
-		{`row(ARRAY[true], row(true))`, `({true}, (false))`, `({true,NULL}, (false))`, `({}, (false))`, noMax},
-		{`row(row(false), ARRAY[true])`, noPrev, `((false), {true,NULL})`, `((false), {})`, noMax},
+		{`row(ARRAY[true], row(true))`, `(ARRAY[true], (false))`, `(ARRAY[true,NULL], (false))`,
+			`(ARRAY[], (false))`, noMax},
+		{`row(row(false), ARRAY[true])`, noPrev, `((false), ARRAY[true,NULL])`,
+			`((false), ARRAY[])`, noMax},
 	}
 	for _, td := range testData {
 		expr := prepareExpr(t, td.datumExpr)

--- a/pkg/sql/parser/eval_test.go
+++ b/pkg/sql/parser/eval_test.go
@@ -502,12 +502,12 @@ func TestEval(t *testing.T) {
 		{`lower('HELLO')`, `'hello'`},
 		{`UPPER('hello')`, `'HELLO'`},
 		// Array constructors.
-		{`ARRAY[]:::int[]`, `{}`},
-		{`ARRAY[NULL]`, `{NULL}`},
-		{`ARRAY[1, 2, 3]`, `{1,2,3}`},
-		{`ARRAY['a', 'b', 'c']`, `{'a','b','c'}`},
-		{`ARRAY[ARRAY[1, 2], ARRAY[2, 3]]`, `{{1,2},{2,3}}`},
-		{`ARRAY[1, NULL]`, `{1,NULL}`},
+		{`ARRAY[]:::int[]`, `ARRAY[]`},
+		{`ARRAY[NULL]`, `ARRAY[NULL]`},
+		{`ARRAY[1, 2, 3]`, `ARRAY[1,2,3]`},
+		{`ARRAY['a', 'b', 'c']`, `ARRAY['a','b','c']`},
+		{`ARRAY[ARRAY[1, 2], ARRAY[2, 3]]`, `ARRAY[ARRAY[1,2],ARRAY[2,3]]`},
+		{`ARRAY[1, NULL]`, `ARRAY[1,NULL]`},
 		// Array sizes.
 		{`array_length(ARRAY[1, 2, 3], 1)`, `3`},
 		{`array_length(ARRAY[1, 2, 3], 2)`, `NULL`},

--- a/pkg/sql/parser/normalize_test.go
+++ b/pkg/sql/parser/normalize_test.go
@@ -114,7 +114,7 @@ func TestNormalizeExpr(t *testing.T) {
 		{`NULL > SOME ARRAY[3, 2, 1]`, `NULL`},
 		{`NULL > ALL ARRAY[3, 2, 1]`, `NULL`},
 		{`4 > ALL ARRAY[3, 2, 1]`, `true`},
-		{`a > ALL ARRAY[3, 2, 1]`, `a > ALL {3,2,1}`},
+		{`a > ALL ARRAY[3, 2, 1]`, `a > ALL ARRAY[3,2,1]`},
 		{`3 > ALL ARRAY[3, 2, a]`, `3 > ALL ARRAY[3, 2, a]`},
 		{`3 > ANY (ARRAY[3, 2, a])`, `3 > ANY ARRAY[3, 2, a]`},
 		{`3 > SOME (((ARRAY[3, 2, a])))`, `3 > SOME ARRAY[3, 2, a]`},

--- a/pkg/sql/testdata/logic_test/array
+++ b/pkg/sql/testdata/logic_test/array
@@ -201,3 +201,16 @@ SELECT conkey FROM pg_catalog.pg_constraint GROUP BY conkey
 
 statement ok
 SELECT indkey[0] FROM pg_catalog.pg_index
+
+# Verify serialization of array in expression (with distsql).
+statement ok
+CREATE TABLE t (k INT)
+
+statement ok
+INSERT INTO t VALUES (1), (2), (3), (4), (5)
+
+query I rowsort
+SELECT k FROM t WHERE k = ANY ARRAY[2,4]
+----
+2
+4

--- a/pkg/sql/testdata/logic_test/explain_types
+++ b/pkg/sql/testdata/logic_test/explain_types
@@ -301,8 +301,9 @@ EXPLAIN (TYPES) SELECT ABS(2-3) AS a
 query ITTTTT
 EXPLAIN (TYPES) SELECT x[1] FROM (SELECT ARRAY[1,2,3] AS x)
 ----
-0  render                                                    ("x[1]" int)
+0  render                                                         ("x[1]" int)
 0           render 0  ((x)[int[]][(1)[int]])[int]
-1  render                                                    (x int[])
-1           render 0  ({(1)[int],(2)[int],(3)[int]})[int[]]
-2  nullrow                                                   ()
+1  render                                                         (x int[])
+1           render 0  (ARRAY[(1)[int],(2)[int],(3)[int]])[int[]]
+2  nullrow                                                        ()
+


### PR DESCRIPTION
We were formatting ARRAY as `{1,2}` which is not valid when we are serializing.
Switching to `ARRAY[1,2]` in this case.

@arjunravinarayan this fixes the `TestPGPreparedQuery` failure when distsql is in auto mode.