### PR TITLE
storage: RequestLease commands again bypass the command queue

### DIFF
--- a/pkg/cli/interactive_tests/test_log_flags.tcl
+++ b/pkg/cli/interactive_tests/test_log_flags.tcl
@@ -15,8 +15,7 @@ eexpect ":/# "
 # Check that log files are created by default in the store directory.
 send "$argv start --insecure --store=path=mystore\r"
 eexpect "node starting"
-interrupt
-interrupt
+send "\003"
 eexpect ":/# "
 send "ls mystore/logs\r"
 eexpect "cockroach.log"
@@ -25,8 +24,7 @@ eexpect ":/# "
 # Check that an empty `-log-dir` disables file logging.
 send "$argv start --insecure --store=path=mystore2 --log-dir=\r"
 eexpect "node starting"
-interrupt
-interrupt
+send "\003"
 eexpect ":/# "
 send "ls mystore2/logs 2>/dev/null | wc -l\r"
 eexpect "0"
@@ -40,29 +38,22 @@ eexpect ":/# "
 # Check that the user can override.
 send "$argv start --insecure --log-dir=blah/\~/blah\r"
 eexpect "logs: *blah/~/blah"
-interrupt
-interrupt
+send "\003"
 eexpect ":/# "
 
 # Check that TRUE and FALSE are valid values for the severity flags.
 send "$argv start --insecure --logtostderr=false\r"
 eexpect "node starting"
-interrupt
-interrupt
+send "\003"
 eexpect ":/# "
-
 send "$argv start --insecure --logtostderr=true\r"
 eexpect "node starting"
-interrupt
-interrupt
+send "\003"
 eexpect ":/# "
-
 send "$argv start --insecure --logtostderr=2\r"
 eexpect "node starting"
-interrupt
-interrupt
+send "\003"
 eexpect ":/# "
-
 send "$argv start --insecure --logtostderr=cantparse\r"
 eexpect "parsing \"cantparse\": invalid syntax"
 eexpect ":/# "

--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -2,9 +2,6 @@
 
 source [file join [file dirname $argv0] common.tcl]
 
-# flaky: #15391
-exit 0
-
 spawn /bin/bash
 send "PS1=':''/# '\r"
 eexpect ":/# "

--- a/pkg/cli/interactive_tests/test_server_restart.tcl
+++ b/pkg/cli/interactive_tests/test_server_restart.tcl
@@ -2,9 +2,6 @@
 #
 source [file join [file dirname $argv0] common.tcl]
 
-# flaky: #15391
-exit 0
-
 start_server $argv
 
 spawn /bin/bash


### PR DESCRIPTION
Restores the pre-#15355 behavior for this command. RequestLease
is unique in that it is evaluated on followers too, where the command
queue is at best meaningless, and at worst can cause hangs and
possibly deadlocks.

Fixes #15391

I couldn't see an easy way to test this in isolation, but it deflakes the CLI tests. 