### PR TITLE
server: fix problem range's leader not leaseholder listing

### DIFF
--- a/pkg/server/problem_ranges.go
+++ b/pkg/server/problem_ranges.go
@@ -277,7 +277,7 @@ const debugProblemRangesTemplate = `
         <DIV CLASS="row">
           {{- if $.Unavailable}}
             {{- range $_, $r := $.Unavailable}}
-              <a href="/debug/range?id={{$r}}">{{$r}}</a> &nbsp;
+              <a href="/debug/range?id={{$r}}">{{$r}}</a>&nbsp;
             {{- end}}
           {{- else}}
             None
@@ -289,7 +289,7 @@ const debugProblemRangesTemplate = `
         <DIV CLASS="row">
           {{- if $.LeaderNotLeaseholder}}
             {{- range $_, $r := $.LeaderNotLeaseholder}}
-              <a href="/debug/range?id={{$r}}">{{$r}}</a>
+              <a href="/debug/range?id={{$r}}">{{$r}}</a>&nbsp;
             {{- end}}
           {{- else}}
             None


### PR DESCRIPTION
There was a missing nbsp so the list of ranges didn't wrap correctly and was really tough to read.

Fixes #15440.