### PR TITLE
ui: Various Bugfixes

### DIFF
--- a/pkg/ui/src/components/graphs.tsx
+++ b/pkg/ui/src/components/graphs.tsx
@@ -197,7 +197,20 @@ function ComputeCountAxisDomain(
   } else {
       axisDomain.tickFormat = d3.format("s");
   }
-  axisDomain.guideFormat = d3.format(".4s");
+
+  // For numbers larger than 1, the tooltip displays fractional values with
+  // metric multiplicative prefixes (e.g. Kilo, Mega, Giga). For numbers smaller
+  // than 1, we simply display the fractional value without converting to a
+  // fractional metric prefix; this is because the use of fractional metric
+  // prefixes (i.e. milli, micro, nano) have proved confusing to users.
+  const metricFormat = d3.format(".4s");
+  const decimalFormat = d3.format(".4f");
+  axisDomain.guideFormat = (n: number) => {
+    if (n < 1) {
+      return decimalFormat(n);
+    }
+    return metricFormat(n);
+  };
   axisDomain.label = "count";
   return axisDomain;
 }

--- a/pkg/ui/src/containers/events.spec.tsx
+++ b/pkg/ui/src/containers/events.spec.tsx
@@ -16,7 +16,13 @@ function makeEventBox(
   events: protos.cockroach.server.serverpb.EventsResponse.Event$Properties[],
   refreshEventsFn: typeof refreshEvents,
 ) {
-  return shallow(<EventBox events={events} refreshEvents={refreshEventsFn}></EventBox>);
+  return shallow(
+    <EventBox
+      events={events}
+      refreshEvents={refreshEventsFn}
+      eventsValid={true}
+    />,
+  );
 }
 
 function makeEvent(event: Event) {

--- a/pkg/ui/src/containers/events.tsx
+++ b/pkg/ui/src/containers/events.tsx
@@ -131,6 +131,9 @@ export class EventRow extends React.Component<EventRowProps, {}> {
 
 export interface EventBoxProps {
   events: Event$Properties[];
+  // eventsValid is needed so that this component will re-render when the events
+  // data becomes invalid, and thus trigger a refresh.
+  eventsValid: boolean;
   refreshEvents: typeof refreshEvents;
 }
 
@@ -139,6 +142,11 @@ export class EventBoxUnconnected extends React.Component<EventBoxProps, {}> {
   componentWillMount() {
     // Refresh events when mounting.
     this.props.refreshEvents();
+  }
+
+  componentWillReceiveProps(props: EventPageProps) {
+    // Refresh events when props change.
+    props.refreshEvents();
   }
 
   render() {
@@ -160,6 +168,9 @@ export class EventBoxUnconnected extends React.Component<EventBoxProps, {}> {
 
 export interface EventPageProps {
   events: Event$Properties[];
+  // eventsValid is needed so that this component will re-render when the events
+  // data becomes invalid, and thus trigger a refresh.
+  eventsValid: boolean;
   refreshEvents: typeof refreshEvents;
   sortSetting: SortSetting;
   setSort: typeof eventsSortSetting.set;
@@ -169,6 +180,11 @@ export class EventPageUnconnected extends React.Component<EventPageProps, {}> {
   componentWillMount() {
     // Refresh events when mounting.
     this.props.refreshEvents();
+  }
+
+  componentWillReceiveProps(props: EventPageProps) {
+    // Refresh events when props change.
+    props.refreshEvents();
   }
 
   render() {
@@ -211,13 +227,20 @@ export class EventPageUnconnected extends React.Component<EventPageProps, {}> {
   }
 }
 
-let events = (state: AdminUIState): Event$Properties[] => state.cachedData.events.data && state.cachedData.events.data.events;
+const eventsSelector = (state: AdminUIState) => {
+  return state.cachedData.events.data && state.cachedData.events.data.events;
+};
+
+const eventsValidSelector = (state: AdminUIState) => {
+  return state.cachedData.events.valid;
+};
 
 // Connect the EventsList class with our redux store.
-let eventBoxConnected = connect(
+const eventBoxConnected = connect(
   (state: AdminUIState) => {
     return {
-      events: events(state),
+      events: eventsSelector(state),
+      eventsValid: eventsValidSelector(state),
     };
   },
   {
@@ -226,10 +249,11 @@ let eventBoxConnected = connect(
 )(EventBoxUnconnected);
 
 // Connect the EventsList class with our redux store.
-let eventPageConnected = connect(
+const eventPageConnected = connect(
   (state: AdminUIState) => {
     return {
-      events: events(state),
+      events: eventsSelector(state),
+      eventsValid: eventsValidSelector(state),
       sortSetting: eventsSortSetting.selector(state),
     };
   },


### PR DESCRIPTION
Graph tooltips for "count" axes no longer display fractional metric
prefixes.

Fixes #14316

Events are now refreshed automatically on the cluster page and the
events page.

Fixes #14164