### PR TITLE
acceptance: avoid relying on GOPATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,8 @@ artifacts
 # TeamCity sometimes creates this file during builds.
 builds.xml
 .buildinfo
-/cockroach
-/cockroach-data
+# cockroach-data, cockroach{,.race}-{darwin,linux,windows}-*
+/cockroach*
 /certs
 # make stress, acceptance produce stress.test, acceptance.test
 *.test*

--- a/build/teamcity-acceptance.sh
+++ b/build/teamcity-acceptance.sh
@@ -1,14 +1,10 @@
 #!/usr/bin/env bash
+
 set -euxo pipefail
 
 export BUILDER_HIDE_GOPATH_SRC=1
 
-# Ensure that no stale binary remains.
-rm -f pkg/acceptance/acceptance.test
-
-build/builder.sh make TYPE=release-linux-gnu build
-mv cockroach-linux-2.6.32-gnu-amd64 cockroach
-build/builder.sh make TYPE=release-linux-gnu testbuild TAGS=acceptance PKG=./pkg/acceptance
+"$(dirname "${0}")"/../pkg/acceptance/prepare.sh
 
 # The log files that should be created by -l below can only
 # be created if the parent directory already exists. Ensure
@@ -16,5 +12,6 @@ build/builder.sh make TYPE=release-linux-gnu testbuild TAGS=acceptance PKG=./pkg
 mkdir -p artifacts/acceptance
 export TMPDIR=$PWD/artifacts/acceptance
 
+build/builder.sh make TYPE=release-linux-gnu testbuild TAGS=acceptance PKG=./pkg/acceptance
 cd pkg/acceptance
 ./acceptance.test -nodes 3 -l "$TMPDIR" -test.v -test.timeout 10m 2>&1 | tee "$TMPDIR/acceptance.log" | go-test-teamcity

--- a/pkg/acceptance/cluster/localcluster.go
+++ b/pkg/acceptance/cluster/localcluster.go
@@ -81,11 +81,17 @@ var maxRangeBytes = config.DefaultZoneConfig().RangeMaxBytes
 const keyLen = 1024
 
 func defaultBinary() string {
-	gopath := filepath.SplitList(os.Getenv("GOPATH"))
-	if len(gopath) == 0 {
+	dir, err := os.Getwd()
+	if err != nil {
 		return ""
 	}
-	return gopath[0] + "/bin/docker_amd64/cockroach"
+	// The repository root, as seen by the caller.
+	for i := 0; i < 2; i++ {
+		dir = filepath.Dir(dir)
+	}
+	// NB: This is the binary produced by our linux-gnu build target. Changes
+	// to the Makefile must be reflected here.
+	return filepath.Join(dir, "cockroach-linux-2.6.32-gnu-amd64")
 }
 
 func exists(path string) bool {

--- a/pkg/acceptance/prepare.sh
+++ b/pkg/acceptance/prepare.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# Ensure that no stale binary remains.
+rm -f cockroach-linux-2.6.32-gnu-amd64 pkg/acceptance/acceptance.test
+
+# We must make a release build here because the binary needs to work in both
+# the builder image and the postgres-test image, which have different libstc++
+# versions.
+build/builder.sh make build TAGS=clockoffset TYPE=release-linux-gnu

--- a/pkg/acceptance/run.sh
+++ b/pkg/acceptance/run.sh
@@ -2,10 +2,7 @@
 
 set -euxo pipefail
 
-# We must make a release build here because the binary needs to work
-# in both the builder image and the postgres-test image, which have
-# different libstc++ versions.
-"$(dirname "${0}")"/../../build/builder.sh make install TAGS=clockoffset TYPE=release-linux-gnu
+"$(dirname "${0}")"/prepare.sh
 
 # The log files that should be created by -l below can only
 # be created if the parent directory already exists. Ensure


### PR DESCRIPTION
In particular, avoid relying on the host knowing where the container's
$GOPATH/bin is going to end up. Instead, rely on the cwd, which is
always consistent when running acceptance tests.

Also converge TC and the local acceptance runner to avoid similar
shenanigans in the future.