### PR TITLE
cli: fix TestNodeStatus

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1254,7 +1254,6 @@ func Example_node() {
 
 func TestNodeStatus(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#13394")
 
 	start := timeutil.Now()
 	c := newCLITest(cliTestParams{})
@@ -1342,9 +1341,9 @@ func checkNodeStatus(t *testing.T, c cliTest, output string, start time.Time) {
 		idx    int
 		maxval int64
 	}{
-		{"live_bytes", 5, 40000},
+		{"live_bytes", 5, 50000},
 		{"key_bytes", 6, 30000},
-		{"value_bytes", 7, 40000},
+		{"value_bytes", 7, 50000},
 		{"intent_bytes", 8, 30000},
 		{"system_bytes", 9, 30000},
 		{"leader_ranges", 10, 3},


### PR DESCRIPTION
With the additional stuff going on in the product world it's normal to
see baseline memory usage grow.

Fixes #13394.
Reverts #13425.