### PR TITLE
sql: rollback disallowing statements following schema change

### DIFF
--- a/pkg/sql/parser/stmt.go
+++ b/pkg/sql/parser/stmt.go
@@ -87,13 +87,6 @@ type IndependentFromParallelizedPriors interface {
 	independentFromParallelizedPriors()
 }
 
-// ValidAfterSchemaUpdateStatement is a pseudo-interface to be implemented by
-// statements which do not risk conflicting with an earlier schema change
-// operation issued previously within the same transaction.
-type ValidAfterSchemaUpdateStatement interface {
-	validAfterSchemaUpdateStatement()
-}
-
 // StatementType implements the Statement interface.
 func (*AlterTable) StatementType() StatementType { return DDL }
 
@@ -114,8 +107,6 @@ func (*BeginTransaction) StatementTag() string { return "BEGIN" }
 
 func (*BeginTransaction) hiddenFromStats() {}
 
-func (*BeginTransaction) validAfterSchemaUpdateStatement() {}
-
 // StatementType implements the Statement interface.
 func (*CommitTransaction) StatementType() StatementType { return Ack }
 
@@ -123,8 +114,6 @@ func (*CommitTransaction) StatementType() StatementType { return Ack }
 func (*CommitTransaction) StatementTag() string { return "COMMIT" }
 
 func (*CommitTransaction) hiddenFromStats() {}
-
-func (*CommitTransaction) validAfterSchemaUpdateStatement() {}
 
 // StatementType implements the Statement interface.
 func (*CopyFrom) StatementType() StatementType { return CopyIn }
@@ -161,8 +150,6 @@ func (*CreateUser) StatementType() StatementType { return Ack }
 // StatementTag returns a short string identifying the type of statement.
 func (*CreateUser) StatementTag() string { return "CREATE USER" }
 
-func (*CreateUser) validAfterSchemaUpdateStatement() {}
-
 // StatementType implements the Statement interface.
 func (*CreateView) StatementType() StatementType { return DDL }
 
@@ -182,8 +169,6 @@ func (n *Deallocate) StatementTag() string {
 }
 
 func (*Deallocate) hiddenFromStats() {}
-
-func (*Deallocate) validAfterSchemaUpdateStatement() {}
 
 // StatementType implements the Statement interface.
 func (n *Delete) StatementType() StatementType { return n.Returning.statementType() }
@@ -229,8 +214,6 @@ func (*Explain) StatementTag() string { return "EXPLAIN" }
 
 func (*Explain) hiddenFromStats() {}
 
-func (*Explain) validAfterSchemaUpdateStatement() {}
-
 // StatementType implements the Statement interface.
 func (*Grant) StatementType() StatementType { return DDL }
 
@@ -238,8 +221,6 @@ func (*Grant) StatementType() StatementType { return DDL }
 func (*Grant) StatementTag() string { return "GRANT" }
 
 func (*Grant) hiddenFromStats() {}
-
-func (*Grant) validAfterSchemaUpdateStatement() {}
 
 // StatementType implements the Statement interface.
 func (n *Insert) StatementType() StatementType { return n.Returning.statementType() }
@@ -261,8 +242,6 @@ func (*Prepare) StatementTag() string { return "PREPARE" }
 
 func (*Prepare) hiddenFromStats() {}
 
-func (*Prepare) validAfterSchemaUpdateStatement() {}
-
 // StatementType implements the Statement interface.
 func (*ReleaseSavepoint) StatementType() StatementType { return Ack }
 
@@ -270,8 +249,6 @@ func (*ReleaseSavepoint) StatementType() StatementType { return Ack }
 func (*ReleaseSavepoint) StatementTag() string { return "RELEASE" }
 
 func (*ReleaseSavepoint) hiddenFromStats() {}
-
-func (*ReleaseSavepoint) validAfterSchemaUpdateStatement() {}
 
 // StatementType implements the Statement interface.
 func (*RenameColumn) StatementType() StatementType { return DDL }
@@ -322,8 +299,6 @@ func (*Revoke) StatementTag() string { return "REVOKE" }
 
 func (*Revoke) hiddenFromStats() {}
 
-func (*Revoke) validAfterSchemaUpdateStatement() {}
-
 // StatementType implements the Statement interface.
 func (*RollbackToSavepoint) StatementType() StatementType { return Ack }
 
@@ -332,8 +307,6 @@ func (*RollbackToSavepoint) StatementTag() string { return "ROLLBACK" }
 
 func (*RollbackToSavepoint) hiddenFromStats() {}
 
-func (*RollbackToSavepoint) validAfterSchemaUpdateStatement() {}
-
 // StatementType implements the Statement interface.
 func (*RollbackTransaction) StatementType() StatementType { return Ack }
 
@@ -341,8 +314,6 @@ func (*RollbackTransaction) StatementType() StatementType { return Ack }
 func (*RollbackTransaction) StatementTag() string { return "ROLLBACK" }
 
 func (*RollbackTransaction) hiddenFromStats() {}
-
-func (*RollbackTransaction) validAfterSchemaUpdateStatement() {}
 
 // StatementType implements the Statement interface.
 func (*Savepoint) StatementType() StatementType { return Ack }
@@ -376,8 +347,6 @@ func (*Set) StatementTag() string { return "SET" }
 
 func (*Set) hiddenFromStats() {}
 
-func (*Set) validAfterSchemaUpdateStatement() {}
-
 // StatementType implements the Statement interface.
 func (*SetTransaction) StatementType() StatementType { return Ack }
 
@@ -394,8 +363,6 @@ func (*SetTimeZone) StatementTag() string { return "SET TIME ZONE" }
 
 func (*SetTimeZone) hiddenFromStats() {}
 
-func (*SetTimeZone) validAfterSchemaUpdateStatement() {}
-
 // StatementType implements the Statement interface.
 func (*SetDefaultIsolation) StatementType() StatementType { return Ack }
 
@@ -403,8 +370,6 @@ func (*SetDefaultIsolation) StatementType() StatementType { return Ack }
 func (*SetDefaultIsolation) StatementTag() string { return "SET" }
 
 func (*SetDefaultIsolation) hiddenFromStats() {}
-
-func (*SetDefaultIsolation) validAfterSchemaUpdateStatement() {}
 
 // StatementType implements the Statement interface.
 func (*Show) StatementType() StatementType { return Rows }
@@ -414,8 +379,6 @@ func (*Show) StatementTag() string { return "SHOW" }
 
 func (*Show) hiddenFromStats()                   {}
 func (*Show) independentFromParallelizedPriors() {}
-
-func (*Show) validAfterSchemaUpdateStatement() {}
 
 // StatementType implements the Statement interface.
 func (*ShowColumns) StatementType() StatementType { return Rows }
@@ -462,8 +425,6 @@ func (*ShowGrants) StatementTag() string { return "SHOW GRANTS" }
 func (*ShowGrants) hiddenFromStats()                   {}
 func (*ShowGrants) independentFromParallelizedPriors() {}
 
-func (*ShowGrants) validAfterSchemaUpdateStatement() {}
-
 // StatementType implements the Statement interface.
 func (*ShowIndex) StatementType() StatementType { return Rows }
 
@@ -482,8 +443,6 @@ func (*ShowTransactionStatus) StatementTag() string { return "SHOW TRANSACTION S
 func (*ShowTransactionStatus) hiddenFromStats()                   {}
 func (*ShowTransactionStatus) independentFromParallelizedPriors() {}
 
-func (*ShowTransactionStatus) validAfterSchemaUpdateStatement() {}
-
 // StatementType implements the Statement interface.
 func (*ShowUsers) StatementType() StatementType { return Rows }
 
@@ -492,8 +451,6 @@ func (*ShowUsers) StatementTag() string { return "SHOW USERS" }
 
 func (*ShowUsers) hiddenFromStats()                   {}
 func (*ShowUsers) independentFromParallelizedPriors() {}
-
-func (*ShowUsers) validAfterSchemaUpdateStatement() {}
 
 // StatementType implements the Statement interface.
 func (*ShowRanges) StatementType() StatementType { return Rows }
@@ -511,8 +468,6 @@ func (*Help) StatementTag() string { return "HELP" }
 
 func (*Help) hiddenFromStats()                   {}
 func (*Help) independentFromParallelizedPriors() {}
-
-func (*Help) validAfterSchemaUpdateStatement() {}
 
 // StatementType implements the Statement interface.
 func (*ShowConstraints) StatementType() StatementType { return Rows }

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -450,59 +450,76 @@ func TestPGPrepareWithCreateDropInTxn(t *testing.T) {
 	}
 	defer db.Close()
 
-	tx, err := db.Begin()
-	if err != nil {
-		t.Fatal(err)
-	}
+	{
+		tx, err := db.Begin()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if _, err := tx.Exec(`
+		if _, err := tx.Exec(`
 	CREATE DATABASE d;
 	CREATE TABLE d.kv (k CHAR PRIMARY KEY, v CHAR);
 `); err != nil {
-		t.Fatal(err)
+			t.Fatal(err)
+		}
+
+		stmt, err := tx.Prepare(`INSERT INTO d.kv (k,v) VALUES ($1, $2);`)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		res, err := stmt.Exec('a', 'b')
+		if err != nil {
+			t.Fatal(err)
+		}
+		stmt.Close()
+		affected, err := res.RowsAffected()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if affected != 1 {
+			t.Fatalf("unexpected number of rows affected: %d", affected)
+		}
+
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
 	}
 
-	stmt, err := tx.Prepare(`INSERT INTO d.kv (k,v) VALUES ($1, $2);`)
-	if err != nil {
-		t.Fatal(err)
-	}
+	{
+		tx, err := db.Begin()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	res, err := stmt.Exec('a', 'b')
-	if err != nil {
-		t.Fatal(err)
-	}
-	stmt.Close()
-	affected, err := res.RowsAffected()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if affected != 1 {
-		t.Fatalf("unexpected number of rows affected: %d", affected)
-	}
-
-	if err := tx.Commit(); err != nil {
-		t.Fatal(err)
-	}
-
-	tx, err = db.Begin()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := tx.Exec(`
+		if _, err := tx.Exec(`
 	DROP TABLE d.kv;
 `); err != nil {
-		t.Fatal(err)
-	}
+			t.Fatal(err)
+		}
 
-	if _, err := tx.Prepare(`
-	INSERT INTO d.kv (k,v) VALUES ($1, $2);
-`); !testutils.IsError(err, "statement cannot follow a schema change in a transaction") {
-		t.Fatalf("got err: %s", err)
-	}
+		stmt, err := tx.Prepare(`INSERT INTO d.kv (k,v) VALUES ($1, $2);`)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if err := tx.Rollback(); err != nil {
-		t.Fatal(err)
+		// INSERT works because it is using a cached descriptor that is leased.
+		res, err := stmt.Exec('c', 'd')
+		if err != nil {
+			t.Fatal(err)
+		}
+		stmt.Close()
+		affected, err := res.RowsAffected()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if affected != 1 {
+			t.Fatalf("unexpected number of rows affected: %d", affected)
+		}
+
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -1915,6 +1915,12 @@ INSERT INTO t.kv VALUES ('a', 'b');
 		// CREATE TABLE followed by INSERT works.
 		{`createtable-insert`, `CREATE TABLE t.origin (k CHAR PRIMARY KEY, v CHAR);`,
 			`INSERT INTO t.origin VALUES ('c', 'd')`, ``},
+		// Support multiple schema changes for ORMs: #15269
+		// Support insert into another table after schema changes: #15297
+		{`multiple-schema-change`,
+			`CREATE TABLE t.orm1 (k CHAR PRIMARY KEY, v CHAR); CREATE TABLE t.orm2 (k CHAR PRIMARY KEY, v CHAR);`,
+			`CREATE INDEX foo ON t.orm1 (v); CREATE INDEX foo ON t.orm2 (v); INSERT INTO t.origin VALUES ('e', 'f')`,
+			``},
 		// schema change at the end of a transaction that has written.
 		{`insert-create`, `INSERT INTO t.kv VALUES ('e', 'f')`, `CREATE INDEX foo ON t.kv (v)`,
 			`schema change statement cannot follow a statement that has written in the same transaction`},

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -1908,18 +1908,18 @@ INSERT INTO t.kv VALUES ('a', 'b');
 	}{
 		// DROP TABLE followed by CREATE TABLE case.
 		{`drop-create`, `DROP TABLE t.kv`, `CREATE TABLE t.kv (k CHAR PRIMARY KEY, v CHAR)`,
-			`statement cannot follow a schema change in a transaction`},
-		// schema change followed by another statement.
+			`relation "kv" already exists`},
+		// schema change followed by another statement works.
 		{`createindex-insert`, `CREATE INDEX foo ON t.kv (v)`, `INSERT INTO t.kv VALUES ('c', 'd')`,
-			`statement cannot follow a schema change in a transaction`},
+			``},
 		// CREATE TABLE followed by INSERT works.
 		{`createtable-insert`, `CREATE TABLE t.origin (k CHAR PRIMARY KEY, v CHAR);`,
 			`INSERT INTO t.origin VALUES ('c', 'd')`, ``},
 		// schema change at the end of a transaction that has written.
-		{`insert-create`, `INSERT INTO t.kv VALUES ('c', 'd')`, `CREATE INDEX foo ON t.kv (v)`,
+		{`insert-create`, `INSERT INTO t.kv VALUES ('e', 'f')`, `CREATE INDEX foo ON t.kv (v)`,
 			`schema change statement cannot follow a statement that has written in the same transaction`},
 		// schema change at the end of a read only transaction.
-		{`select-create`, `SELECT * FROM t.kv`, `CREATE INDEX foo ON t.kv (v)`, ``},
+		{`select-create`, `SELECT * FROM t.kv`, `CREATE INDEX bar ON t.kv (v)`, ``},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
rolls back #15339 #14368 for the most part and #14619 partially.

We used a very big hammer to prevent some statements from
following a schema change. This was done to reduce surprises
but it ended up introducing more surprises. ORMs and schema
migration tools depends on multiple schema changes executing
in the same transaction.

fixes #15269