### PR TITLE
Use correct user for ssh in azworker

### DIFF
--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -7,7 +7,7 @@ set -euxo pipefail
 
 sudo apt-get update
 sudo apt-get dist-upgrade -y
-sudo apt-get install -y --no-install-recommends docker.io git
+sudo apt-get install -y --no-install-recommends docker.io git cmake
 
 sudo adduser "${USER}" docker
 

--- a/scripts/azworker.sh
+++ b/scripts/azworker.sh
@@ -48,18 +48,18 @@ case ${1-} in
     # Clear any cached host keys for this hostname and accept the new one.
     ssh-keygen -R "${FQDN}"
     # Retry while vm and sshd to start up.
-    "$(dirname "${0}")/travis_retry.sh" ssh -o StrictHostKeyChecking=no "${FQDN}" true
+    "$(dirname "${0}")/travis_retry.sh" ssh -o StrictHostKeyChecking=no "${USER}@${FQDN}" true
 
-    rsync -az "$(dirname "${0}")/../build/bootstrap/" "${FQDN}:bootstrap/"
-    rsync -az "$(dirname "${0}")/../build/parallelbuilds-"* "${FQDN}:bootstrap/"
-    ssh -A "${FQDN}" ./bootstrap/bootstrap-debian.sh
+    rsync -az "$(dirname "${0}")/../build/bootstrap/" "${USER}@${FQDN}:bootstrap/"
+    rsync -az "$(dirname "${0}")/../build/parallelbuilds-"* "${USER}@${FQDN}:bootstrap/"
+    ssh -A "${USER}@${FQDN}" ./bootstrap/bootstrap-debian.sh
 
     # TODO(bdarnell): autoshutdown.cron.sh does not work on azure. It
     # halts the VM, but halting the VM doesn't stop billing. The VM
     # must instead be "deallocated" with the azure API.
     # Install automatic shutdown after ten minutes of operation without a
     # logged in user. To disable this, `sudo touch /.active`.
-    #ssh "${FQDN}" "sudo cp bootstrap/autoshutdown.cron.sh /root/; echo '* * * * * /root/autoshutdown.cron.sh 10' | sudo crontab -i -"
+    #ssh "${USER}@${FQDN}" "sudo cp bootstrap/autoshutdown.cron.sh /root/; echo '* * * * * /root/autoshutdown.cron.sh 10' | sudo crontab -i -"
 
     echo "VM now running at ${FQDN}"
     ;;
@@ -75,7 +75,7 @@ case ${1-} in
     ssh)
     shift
     # shellcheck disable=SC2029
-    ssh -A "${FQDN}" -- "$@"
+    ssh -A "${USER}@${FQDN}" -- "$@"
     ;;
     *)
     echo "$0: unknown command: ${1-}, use one of create, start, stop, delete, or ssh"


### PR DESCRIPTION
Not sure how this worked for others previously; perhaps some global ssh
settings? Also added missing `cmake` installation in bootstrap script.