### PR TITLE
acceptance: enhance the Docker tests.

### DIFF
--- a/pkg/acceptance/cluster/localcluster.go
+++ b/pkg/acceptance/cluster/localcluster.go
@@ -151,11 +151,12 @@ type LocalCluster struct {
 	stopper              *stop.Stopper
 	monitorCtx           context.Context
 	monitorCtxCancelFunc func()
-	logDir               string // no logging if empty
 	clusterID            string
 	networkID            string
 	networkName          string
-	privileged           bool // whether to run containers in privileged mode
+	privileged           bool   // whether to run containers in privileged mode
+	logDir               string // no logging if empty
+	logDirRemovable      bool   // if true, the log directory can be removed after use
 }
 
 // CreateLocal creates a new local cockroach cluster. The stopper is used to
@@ -190,8 +191,17 @@ func CreateLocal(
 	// Only pass a nonzero logDir down to LocalCluster when instructed to keep
 	// logs.
 	var uniqueLogDir string
+	logDirRemovable := false
 	if logDir != "" {
+		pwd, err := os.Getwd()
+		maybePanic(err)
+
 		uniqueLogDir = fmt.Sprintf("%s-%s", logDir, clusterIDS)
+		if !filepath.IsAbs(uniqueLogDir) {
+			uniqueLogDir = filepath.Join(pwd, uniqueLogDir)
+		}
+		ensureLogDirExists(uniqueLogDir)
+		logDirRemovable = true
 		log.Infof(ctx, "local cluster log directory: %s", uniqueLogDir)
 	}
 	return &LocalCluster{
@@ -200,10 +210,11 @@ func CreateLocal(
 		config:    cfg,
 		stopper:   stopper,
 		// TODO(tschottdorf): deadlocks will occur if these channels fill up.
-		events:         make(chan Event, 1000),
-		expectedEvents: make(chan Event, 1000),
-		logDir:         uniqueLogDir,
-		privileged:     privileged,
+		events:          make(chan Event, 1000),
+		expectedEvents:  make(chan Event, 1000),
+		logDir:          uniqueLogDir,
+		logDirRemovable: logDirRemovable,
+		privileged:      privileged,
 	}
 }
 
@@ -348,14 +359,7 @@ func (l *LocalCluster) initCluster(ctx context.Context) {
 	}
 
 	if l.logDir != "" {
-		if !filepath.IsAbs(l.logDir) {
-			l.logDir = filepath.Join(pwd, l.logDir)
-		}
 		binds = append(binds, l.logDir+":/logs")
-		// If we don't make sure the directory exists, Docker will and then we
-		// may run into ownership issues (think Docker running as root, but us
-		// running as a regular Joe as it happens on CircleCI).
-		maybePanic(os.MkdirAll(l.logDir, 0777))
 	}
 	if *cockroachImage == builderImageFull {
 		path, err := filepath.Abs(*cockroachBinary)
@@ -517,15 +521,15 @@ func (l *LocalCluster) startNode(ctx context.Context, node *testNode) {
 		cmd = append(cmd, "--join="+net.JoinHostPort(l.Nodes[0].nodeStr, base.DefaultPort))
 	}
 
-	var locallogDir string
+	var localLogDir string
 	if len(l.logDir) > 0 {
-		dockerlogDir := "/logs/" + node.nodeStr
-		locallogDir = filepath.Join(l.logDir, node.nodeStr)
-		maybePanic(os.MkdirAll(locallogDir, 0777))
+		dockerLogDir := "/logs/" + node.nodeStr
+		localLogDir = filepath.Join(l.logDir, node.nodeStr)
+		ensureLogDirExists(localLogDir)
 		cmd = append(
 			cmd,
 			"--logtostderr=ERROR",
-			"--log-dir="+dockerlogDir)
+			"--log-dir="+dockerLogDir)
 	} else {
 		cmd = append(cmd, "--logtostderr=INFO")
 	}
@@ -546,7 +550,7 @@ func (l *LocalCluster) startNode(ctx context.Context, node *testNode) {
   cockroach: %[6]s
 
   cli-env:   COCKROACH_INSECURE=false COCKROACH_CERTS_DIR=%[7]s COCKROACH_HOST=%s COCKROACH_PORT=%d`,
-		node.Name(), "https://"+httpAddr.String(), locallogDir, node.Container.id[:5],
+		node.Name(), "https://"+httpAddr.String(), localLogDir, node.Container.id[:5],
 		base.DefaultHTTPPort, cmd, l.CertsDir, httpAddr.IP, httpAddr.Port)
 }
 
@@ -909,4 +913,26 @@ func (l *LocalCluster) ExecRoot(ctx context.Context, i int, cmd []string) error 
 
 	return retry(ctx, 3, 10*time.Second, "ExecRoot",
 		matchNone, execRoot)
+}
+
+func ensureLogDirExists(logDir string) {
+	// Ensure that the path exists, with all its parents.
+	// If we don't make sure the directory exists, Docker will and then we
+	// may run into ownership issues (think Docker running as root, but us
+	// running as a regular Joe as it happens on CircleCI).
+	maybePanic(os.MkdirAll(logDir, 0755))
+	// Now make the last component, and just the last one, writable by
+	// anyone, and set the gid and uid bit so that the owner is
+	// propagated to sub-directories.
+	maybePanic(os.Chmod(logDir, 0777|os.ModeSetuid|os.ModeSetgid))
+}
+
+// Cleanup removes the log directory if it was initially created
+// by this LocalCluster.
+func (l *LocalCluster) Cleanup(ctx context.Context) {
+	if l.logDir != "" && l.logDirRemovable {
+		if err := os.RemoveAll(l.logDir); err != nil {
+			log.Warning(ctx, err)
+		}
+	}
 }

--- a/pkg/acceptance/cluster/localcluster.go
+++ b/pkg/acceptance/cluster/localcluster.go
@@ -192,6 +192,7 @@ func CreateLocal(
 	var uniqueLogDir string
 	if logDir != "" {
 		uniqueLogDir = fmt.Sprintf("%s-%s", logDir, clusterIDS)
+		log.Infof(ctx, "local cluster log directory: %s", uniqueLogDir)
 	}
 	return &LocalCluster{
 		clusterID: clusterIDS,

--- a/pkg/acceptance/terrafarm/ssh.go
+++ b/pkg/acceptance/terrafarm/ssh.go
@@ -17,17 +17,18 @@
 package terrafarm
 
 import (
-	"os/user"
 	"path/filepath"
+
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 )
 
 const sshUser = "ubuntu"
 
 func (f *Farmer) defaultKeyFile() string {
 	base := "."
-	me, err := user.Current()
+	me, err := envutil.HomeDir()
 	if err == nil {
-		base = me.HomeDir
+		base = me
 	}
 	return filepath.Join(base, ".ssh/"+f.KeyName)
 }

--- a/pkg/acceptance/util.go
+++ b/pkg/acceptance/util.go
@@ -569,7 +569,14 @@ func testDocker(
 		containerConfig.Env = append(containerConfig.Env, "PGHOST="+l.Hostname(0))
 	}
 	hostConfig := container.HostConfig{NetworkMode: "host"}
-	return l.OneShot(ctx, postgresTestImage, types.ImagePullOptions{}, containerConfig, hostConfig, "docker-"+name)
+	if err := l.OneShot(
+		ctx, postgresTestImage, types.ImagePullOptions{}, containerConfig, hostConfig, "docker-"+name,
+	); err != nil {
+		return err
+	}
+	// Clean up the log files if the run was successful.
+	l.Cleanup(ctx)
+	return nil
 }
 
 func testDockerSingleNode(

--- a/pkg/acceptance/util.go
+++ b/pkg/acceptance/util.go
@@ -49,7 +49,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/cockroachdb/cockroach/pkg/util/caller"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -126,8 +125,6 @@ var flagCLTWriters = flag.Int("clt.writers", -1,
 	"# of load generators to spawn (defaults to # of nodes)")
 var flagCLTMinQPS = flag.Float64("clt.min-qps", 5.0,
 	"fail load tests when queries per second drops below this during a health check interval")
-
-var testFuncRE = regexp.MustCompile("^(Test|Benchmark)")
 
 var stopper = stop.NewStopper()
 
@@ -413,15 +410,7 @@ func StartCluster(ctx context.Context, t *testing.T, cfg cluster.TestConfig) (c 
 	} else {
 		logDir := *flagLogDir
 		if logDir != "" {
-			logDir = func(d string) string {
-				for i := 1; i < 100; i++ {
-					_, _, fun := caller.Lookup(i)
-					if testFuncRE.MatchString(fun) {
-						return filepath.Join(d, fun)
-					}
-				}
-				panic("no caller matching Test(.*) in stack trace")
-			}(logDir)
+			logDir = filepath.Join(logDir, filepath.Clean(t.Name()))
 		}
 		l := cluster.CreateLocal(ctx, cfg, logDir, *flagPrivileged, stopper)
 		l.Start(ctx)

--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -2,9 +2,14 @@
 # accordingly.
 set env(TERM) vt100
 
+# If running inside docker, change the home dir to the output log dir
+# so that any HOME-derived artifacts land there.
+set ::env(HOME) "logs"
+
 # Keep the history in a test location, so as to not override the
-# developer's own history file.
-set histfile ".cockroachdb_history_test"
+# developer's own history file when running out of Docker.
+set histfile "cockroach_sql_history"
+
 set ::env(COCKROACH_SQL_CLI_HISTORY) $histfile
 # Set client commands as insecure. The server uses --insecure.
 set ::env(COCKROACH_INSECURE) "true"

--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -20,18 +20,12 @@ set stty_init "cols 80 rows 25"
 
 # Convenience function to tag what's going on in log files.
 proc report {text} {
-    system "echo; echo \$(date '+.%y%m%d %H:%M:%S.%N') EXPECT TEST: '$text' | tee -a cmd.log"
-}
-
-# Upon termination
-proc report_log_files {} {
-    system "(echo '==COMMAND OUTPUT=='; cat cmd.log; echo '==DB LOG=='; cat cockroach-data/logs/cockroach.log; echo '==END==') || true"
+    system "echo; echo \$(date '+.%y%m%d %H:%M:%S.%N') EXPECT TEST: '$text' | tee -a logs/expect-cmd.log"
 }
 
 # Catch signals
 proc mysig {} {
     report "EXPECT KILLED BY SIGNAL"
-    report_log_files
     exit 130
 }
 trap mysig SIGINT
@@ -50,7 +44,6 @@ proc end_test {} {
 # show up fast).
 proc handle_timeout {text} {
     report "TIMEOUT WAITING FOR \"$text\""
-    report_log_files
     exit 1
 }
 proc eexpect {text} {
@@ -72,7 +65,7 @@ proc interrupt {} {
 # in `server_pid`.
 proc start_server {argv} {
     report "BEGIN START SERVER"
-    system "mkfifo pid_fifo || true; $argv start --insecure --pid-file=pid_fifo --background >>cmd.log 2>&1 & cat pid_fifo > server_pid"
+    system "mkfifo pid_fifo || true; $argv start --insecure --pid-file=pid_fifo --background -s=path=logs/db >>logs/expect-cmd.log 2>&1 & cat pid_fifo > server_pid"
     report "START SERVER DONE"
 }
 proc stop_server {argv} {

--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -84,3 +84,9 @@ proc stop_server {argv} {
     system "$argv quit"
     report "END STOP SERVER"
 }
+
+proc force_stop_server {argv} {
+    report "BEGIN FORCE STOP SERVER"
+    system "set -x; $argv quit & sleep 1; if kill -CONT `cat server_pid`; then kill -TERM `cat server pid`; sleep 1; if kill -CONT `cat server_pid`; then kill -KILL `cat server_pid`; fi; fi"
+    report "END FORCE STOP SERVER"
+}

--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -26,6 +26,12 @@ set stty_init "cols 80 rows 25"
 # Convenience function to tag what's going on in log files.
 proc report {text} {
     system "echo; echo \$(date '+.%y%m%d %H:%M:%S.%N') EXPECT TEST: '$text' | tee -a logs/expect-cmd.log"
+    # We really want to have all files erasable outside of the container
+    # even though the commands here run with uid 0.
+    # Docker is obnoxious in that it doesn't support setting `umask`.
+    # Also CockroachDB doesn't honor umask anyway.
+    # So we simply come after the fact and adjust the permissions.
+    system "find logs -exec chmod a+rw '{}' \\;"
 }
 
 # Catch signals

--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -4,7 +4,11 @@ set env(TERM) vt100
 
 # If running inside docker, change the home dir to the output log dir
 # so that any HOME-derived artifacts land there.
-set ::env(HOME) "logs"
+if {[pwd] == "/"} {
+  set ::env(HOME) "/logs"
+} else {
+  system "mkdir logs"
+}
 
 # Keep the history in a test location, so as to not override the
 # developer's own history file when running out of Docker.

--- a/pkg/cli/interactive_tests/test_high_verbosity.tcl
+++ b/pkg/cli/interactive_tests/test_high_verbosity.tcl
@@ -2,7 +2,7 @@
 
 source [file join [file dirname $argv0] common.tcl]
 
-system "mkfifo pid_fifo || true; $argv start --insecure --verbosity 3 --pid-file=pid_fifo & cat pid_fifo > server_pid"
+system "mkfifo pid_fifo || true; $argv start --insecure --verbosity 3 --pid-file=pid_fifo -s=path=logs/db & cat pid_fifo > server_pid"
 
 spawn /bin/bash
 send "PS1=':''/# '\r"

--- a/pkg/cli/interactive_tests/test_log_flags.tcl
+++ b/pkg/cli/interactive_tests/test_log_flags.tcl
@@ -13,48 +13,48 @@ eexpect ":/# "
 # to exit entirely (it has errorHandling set to ExitOnError).
 
 # Check that log files are created by default in the store directory.
-send "$argv start --insecure --store=path=mystore\r"
+send "$argv start --insecure --store=path=logs/mystore\r"
 eexpect "node starting"
-send "\003"
+interrupt
 eexpect ":/# "
-send "ls mystore/logs\r"
+send "ls logs/mystore/logs\r"
 eexpect "cockroach.log"
 eexpect ":/# "
 
 # Check that an empty `-log-dir` disables file logging.
-send "$argv start --insecure --store=path=mystore2 --log-dir=\r"
+send "$argv start --insecure --store=path=logs/mystore2 --log-dir=\r"
 eexpect "node starting"
-send "\003"
+interrupt
 eexpect ":/# "
-send "ls mystore2/logs 2>/dev/null | wc -l\r"
+send "ls logs/mystore2/logs 2>/dev/null | wc -l\r"
 eexpect "0"
 eexpect ":/# "
 
 # Check that leading tildes are properly rejected.
-send "$argv start --insecure --log-dir=\~/blah\r"
+send "$argv start --insecure -s=path=logs/db --log-dir=\~/blah\r"
 eexpect "log directory cannot start with '~'"
 eexpect ":/# "
 
 # Check that the user can override.
-send "$argv start --insecure --log-dir=blah/\~/blah\r"
+send "$argv start --insecure -s=path=logs/db --log-dir=logs/blah/\~/blah\r"
 eexpect "logs: *blah/~/blah"
-send "\003"
+interrupt
 eexpect ":/# "
 
 # Check that TRUE and FALSE are valid values for the severity flags.
-send "$argv start --insecure --logtostderr=false\r"
+send "$argv start --insecure -s=path=logs/db --logtostderr=false\r"
 eexpect "node starting"
-send "\003"
+interrupt
 eexpect ":/# "
-send "$argv start --insecure --logtostderr=true\r"
+send "$argv start --insecure -s=path=logs/db --logtostderr=true\r"
 eexpect "node starting"
-send "\003"
+interrupt
 eexpect ":/# "
-send "$argv start --insecure --logtostderr=2\r"
+send "$argv start --insecure -s=path=logs/db --logtostderr=2\r"
 eexpect "node starting"
-send "\003"
+interrupt
 eexpect ":/# "
-send "$argv start --insecure --logtostderr=cantparse\r"
+send "$argv start --insecure -s=path=logs/db --logtostderr=cantparse\r"
 eexpect "parsing \"cantparse\": invalid syntax"
 eexpect ":/# "
 

--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -6,7 +6,7 @@ spawn /bin/bash
 send "PS1=':''/# '\r"
 eexpect ":/# "
 
-start_test "Check that a server started with only in-memory stores automatically logs to stderr."
+start_test "Check that a server started with only in-memory stores and no --log-dir automatically logs to stderr."
 send "$argv start --insecure --store=type=mem,size=1GiB\r"
 eexpect "CockroachDB"
 eexpect "starting cockroach node"
@@ -24,7 +24,7 @@ eexpect ":/# "
 stop_server $argv
 
 start_test "Check that a server started with --logtostderr logs even info messages to stderr."
-send "$argv start --insecure --logtostderr\r"
+send "$argv start -s=path=logs/db --insecure --logtostderr\r"
 eexpect "CockroachDB"
 eexpect "starting cockroach node"
 end_test
@@ -34,7 +34,7 @@ interrupt
 eexpect ":/# "
 
 start_test "Check that --logtostderr can override the threshold but no error is printed on startup"
-send "echo marker; $argv start --insecure --logtostderr=ERROR 2>&1 | grep -v '^\\*'\r"
+send "echo marker; $argv start -s=path=logs/db --insecure --logtostderr=ERROR 2>&1 | grep -v '^\\*'\r"
 eexpect "marker\r\nCockroachDB node starting"
 end_test
 

--- a/pkg/cli/interactive_tests/test_reconnect.tcl
+++ b/pkg/cli/interactive_tests/test_reconnect.tcl
@@ -12,7 +12,9 @@ eexpect "1 row"
 eexpect root@
 
 # Check that the client properly detects the server went down.
-stop_server $argv
+# We need to force since the open connection may prevent a quick
+# graceful shutdown.
+force_stop_server $argv
 
 send "select 1;\r"
 eexpect "bad connection"

--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -7,13 +7,13 @@ set ::env(COCKROACH_INSECURE) "false"
 
 proc start_secure_server {argv certs_dir} {
     report "BEGIN START SECURE SERVER"
-    system "mkfifo pid_fifo || true; $argv start --certs-dir=$certs_dir --pid-file=pid_fifo >>cmd.log 2>&1 & cat pid_fifo > server_pid"
+    system "mkfifo pid_fifo || true; $argv start --certs-dir=$certs_dir --pid-file=pid_fifo -s=path=logs/db >>expect-cmd.log 2>&1 & cat pid_fifo > server_pid"
     report "END START SECURE SERVER"
 }
 
 proc stop_secure_server {argv certs_dir} {
     report "BEGIN STOP SECURE SERVER"
-    system "set -e; if kill -CONT `cat server_pid`; then $argv quit --certs-dir=$certs_dir || true & sleep 1; kill -9 `cat server_pid` || true; else $argv quit --certs-dir=$certs_dir || true; fi"
+    system "$argv quit --certs-dir=$certs_dir"
     report "END STOP SECURE SERVER"
 }
 

--- a/pkg/cli/interactive_tests/test_server_sig.tcl
+++ b/pkg/cli/interactive_tests/test_server_sig.tcl
@@ -9,7 +9,7 @@ send "PS1='\\h:''/# '\r"
 eexpect ":/# "
 
 start_test "Check that the server shuts down upon receiving SIGTERM"
-send "$argv start --insecure --pid-file=server_pid\r"
+send "$argv start --insecure --pid-file=server_pid --log-dir=logs \r"
 eexpect "initialized"
 
 system "kill `cat server_pid`"
@@ -25,7 +25,7 @@ eexpect ":/# "
 end_test
 
 start_test "Check that the server shuts down upon receiving Ctrl+C."
-send "$argv start --insecure --pid-file=server_pid\r"
+send "$argv start --insecure --pid-file=server_pid --log-dir=logs \r"
 eexpect "restarted"
 
 interrupt
@@ -43,7 +43,7 @@ end_test
 start_test "Check that the server shuts down fast upon receiving Ctrl+C twice."
 
 # Start a server via the shell
-send "$argv start --insecure --pid-file=server_pid\r"
+send "$argv start --insecure --pid-file=server_pid --log-dir=logs \r"
 eexpect "restarted"
 
 # Make a client open a connection and keep using it with an open txn.

--- a/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
+++ b/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
@@ -44,7 +44,7 @@ send "ulimit -v [ expr {2*$vmem+400} ]\r"
 eexpect ":/# "
 
 # Start a server with this limit set. The server will now run in the foreground.
-send "$argv start --insecure --no-redirect-stderr\r"
+send "$argv start --insecure --no-redirect-stderr -s=path=logs/db \r"
 eexpect "restarted pre-existing node"
 sleep 1
 
@@ -84,7 +84,7 @@ eexpect root@
 
 # Re-launch a server with relatively lower limit for SQL memory
 set spawn_id $shell_spawn_id
-send "$argv start --insecure --max-sql-memory=150K --no-redirect-stderr\r"
+send "$argv start --insecure --max-sql-memory=150K --no-redirect-stderr -s=path=logs/db \r"
 eexpect "restarted pre-existing node"
 sleep 2
 

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -26,7 +26,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -534,14 +533,14 @@ func (c *cliState) doStart(nextState cliStateEnum) cliStateEnum {
 		// We only enable history management when the terminal is actually
 		// interactive. This saves on memory when e.g. piping a large SQL
 		// script through the command-line client.
-		userAcct, err := user.Current()
+		homeDir, err := envutil.HomeDir()
 		if err != nil {
 			if log.V(2) {
-				log.Warningf(context.TODO(), "cannot retrieve user information: %s", err)
+				log.Warningf(context.TODO(), "cannot retrieve user information: %v", err)
 				log.Info(context.TODO(), "cannot load or save the command-line history")
 			}
 		} else {
-			histFile := filepath.Join(userAcct.HomeDir, cmdHistFile)
+			histFile := filepath.Join(homeDir, cmdHistFile)
 			cfg := c.ins.Config.Clone()
 			cfg.HistoryFile = histFile
 			cfg.HistorySearchFold = true

--- a/pkg/util/envutil/env.go
+++ b/pkg/util/envutil/env.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"os/user"
 	"runtime"
 	"strconv"
 	"strings"
@@ -143,6 +144,20 @@ func GetShellCommand(cmd string) []string {
 	}
 
 	return []string{"/bin/sh", "-c", cmd}
+}
+
+// HomeDir returns the user's home directory, as determined by the env
+// var HOME, if it exists, and otherwise the system's idea of the user
+// configuration (e.g. on non-UNIX systems).
+func HomeDir() (string, error) {
+	if homeDir := os.Getenv("HOME"); len(homeDir) > 0 {
+		return homeDir, nil
+	}
+	userAcct, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	return userAcct.HomeDir, nil
 }
 
 // EnvString returns the value set by the specified environment variable. The


### PR DESCRIPTION
Needed to investigate  #15510.

Two patches:

###  	acceptance: enhance the collection of docker logs upon Wait()

**tl;dr** output of command inside container now copied to `console-output.log`

###  	cli/interactive_tests: place test output details in the artifacts directory

**tl;dr** tests now place output directly in artifacts.