### PR TITLE
cmd/release-upload: never cache `.LATEST` keys

### DIFF
--- a/pkg/cmd/release-upload/main.go
+++ b/pkg/cmd/release-upload/main.go
@@ -271,9 +271,11 @@ func main() {
 					log.Fatalf("s3 upload %s: %s", absolutePath, err)
 				}
 				latestKey := fmt.Sprintf("%s/%s.%s", repoName, remoteName, "LATEST")
+				noCache := "no-cache"
 				if _, err := svc.PutObject(&s3.PutObjectInput{
-					Bucket: &bucketName,
-					Key:    &latestKey,
+					Bucket:       &bucketName,
+					CacheControl: &noCache,
+					Key:          &latestKey,
 					WebsiteRedirectLocation: &versionKey,
 				}); err != nil {
 					log.Fatalf("s3 redirect to %s: %s", versionKey, err)


### PR DESCRIPTION
This problem should also be affecting the "-latest" artifacts on the release side, but since we haven't observed that, I'm guessing there are some global TTLs on binaries.cockroachdb.com.