### PR TITLE
Revert "pkg/cli: Refactor CLI to support streaming formatted results"

### DIFF
--- a/pkg/cli/format_table.go
+++ b/pkg/cli/format_table.go
@@ -29,82 +29,15 @@ import (
 	"github.com/olekukonko/tablewriter"
 )
 
-// rowStrIter is an iterator interface for the printQueryOutput function. It is
-// used so that results can be streamed to the row formatters as they arrive
-// to the CLI.
-type rowStrIter interface {
-	Next() (row []string, err error)
-	ToSlice() (allRows [][]string, err error)
-}
-
-// rowSliceIter is an implementation of the rowStrIter interface and it is used
-// to wrap a slice of rows that have already been completely buffered into
-// memory.
-type rowSliceIter struct {
-	allRows [][]string
-	index   int
-}
-
-func (iter *rowSliceIter) Next() (row []string, err error) {
-	if iter.index >= len(iter.allRows) {
-		return nil, io.EOF
-	}
-	row = iter.allRows[iter.index]
-	iter.index = iter.index + 1
-	return row, nil
-}
-
-func (iter *rowSliceIter) ToSlice() ([][]string, error) {
-	return iter.allRows, nil
-}
-
-// newRowSliceIter is an implementation of the rowStrIter interface and it is
-// used when the rows have not been buffered into memory yet and we want to
-// stream them to the row formatters as they arrive over the network.
-func newRowSliceIter(allRows [][]string) *rowSliceIter {
-	return &rowSliceIter{
-		allRows: allRows,
-		index:   0,
-	}
-}
-
-type rowIter struct {
-	rows          *sqlRows
-	showMoreChars bool
-}
-
-func (iter *rowIter) Next() (row []string, err error) {
-	nextRowString, err := getNextRowStrings(iter.rows, iter.showMoreChars)
-	if nextRowString == nil {
-		return nil, io.EOF
-	}
-	if err != nil {
-		return nil, err
-	}
-	return nextRowString, nil
-}
-
-func (iter *rowIter) ToSlice() ([][]string, error) {
-	return getAllRowStrings(iter.rows, iter.showMoreChars)
-}
-
-func newRowIter(rows *sqlRows, showMoreChars bool) *rowIter {
-	return &rowIter{
-		rows:          rows,
-		showMoreChars: showMoreChars,
-	}
-}
-
 // printQueryOutput takes a list of column names and a list of row contents
-// writes a formatted table to 'w', or simply the tag if empty. Note that
-// printQueryOutput expects the tag to already be properly formatted.
+// writes a formatted table to 'w', or simply the tag if empty.
 func printQueryOutput(
-	w io.Writer, cols []string, allRows rowStrIter, tag string, displayFormat tableDisplayFormat,
-) error {
+	w io.Writer, cols []string, allRows [][]string, tag string, displayFormat tableDisplayFormat,
+) {
 	if len(cols) == 0 {
 		// This operation did not return rows, just show the tag.
 		fmt.Fprintln(w, tag)
-		return nil
+		return
 	}
 
 	switch displayFormat {
@@ -114,40 +47,28 @@ func printQueryOutput(
 		table.SetAutoFormatHeaders(false)
 		table.SetAutoWrapText(false)
 		table.SetHeader(cols)
-		nRows := 0
-		for {
-			row, err := allRows.Next()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return err
-			}
+		for _, row := range allRows {
 			for i, r := range row {
 				row[i] = expandTabsAndNewLines(r)
 			}
 			table.Append(row)
-			nRows++
 		}
 		table.Render()
+		nRows := len(allRows)
 		fmt.Fprintf(w, "(%d row%s)\n", nRows, util.Pluralize(int64(nRows)))
 
 	case tableDisplayTSV:
 		fallthrough
 	case tableDisplayCSV:
-		allRowsSlice, err := allRows.ToSlice()
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(w, "%d row%s\n", len(allRowsSlice),
-			util.Pluralize(int64(len(allRowsSlice))))
+		fmt.Fprintf(w, "%d row%s\n", len(allRows),
+			util.Pluralize(int64(len(allRows))))
 
 		csvWriter := csv.NewWriter(w)
 		if displayFormat == tableDisplayTSV {
 			csvWriter.Comma = '\t'
 		}
 		_ = csvWriter.Write(cols)
-		_ = csvWriter.WriteAll(allRowsSlice)
+		_ = csvWriter.WriteAll(allRows)
 
 	case tableDisplayHTML:
 		fmt.Fprint(w, "<table>\n<thead><tr>")
@@ -155,14 +76,7 @@ func printQueryOutput(
 			fmt.Fprintf(w, "<th>%s</th>", html.EscapeString(col))
 		}
 		fmt.Fprint(w, "</tr></head>\n<tbody>\n")
-		for {
-			row, err := allRows.Next()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return err
-			}
+		for _, row := range allRows {
 			fmt.Fprint(w, "<tr>")
 			for _, r := range row {
 				fmt.Fprintf(w, "<td>%s</td>", strings.Replace(html.EscapeString(r), "\n", "<br/>", -1))
@@ -180,14 +94,7 @@ func printQueryOutput(
 			}
 		}
 
-		for i := 0; ; i++ {
-			row, err := allRows.Next()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return err
-			}
+		for i, row := range allRows {
 			fmt.Fprintf(w, "-[ RECORD %d ]\n", i+1)
 			for j, r := range row {
 				lines := strings.Split(r, "\n")
@@ -215,14 +122,7 @@ func printQueryOutput(
 			fmt.Fprint(w, "\n")
 		}
 		fmt.Fprint(w, ");\n\n")
-		for {
-			row, err := allRows.Next()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return err
-			}
+		for _, row := range allRows {
 			fmt.Fprint(w, "INSERT INTO results VALUES (")
 			for i, r := range row {
 				s := parser.DString(r)
@@ -234,5 +134,4 @@ func printQueryOutput(
 			fmt.Fprint(w, ");\n")
 		}
 	}
-	return nil
 }

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -71,7 +71,8 @@ func runLsNodes(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	return printQueryOutput(os.Stdout, lsNodesColumnHeaders, newRowSliceIter(rows), "", cliCtx.tableDisplayFormat)
+	printQueryOutput(os.Stdout, lsNodesColumnHeaders, rows, "", cliCtx.tableDisplayFormat)
+	return nil
 }
 
 var nodesColumnHeaders = []string{
@@ -140,8 +141,9 @@ func runStatusNode(cmd *cobra.Command, args []string) error {
 		return errors.Errorf("expected no arguments or a single node ID")
 	}
 
-	return printQueryOutput(os.Stdout, nodesColumnHeaders, newRowSliceIter(nodeStatusesToRows(nodeStatuses)), "",
+	printQueryOutput(os.Stdout, nodesColumnHeaders, nodeStatusesToRows(nodeStatuses), "",
 		cliCtx.tableDisplayFormat)
+	return nil
 }
 
 // nodeStatusesToRows converts NodeStatuses to SQL-like result rows, so that we can pretty-print

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -263,19 +263,15 @@ var options = map[string]struct {
 // handleSet supports the \set client-side command.
 func (c *cliState) handleSet(args []string, nextState, errState cliStateEnum) cliStateEnum {
 	if len(args) == 0 {
-		err := printQueryOutput(os.Stdout,
+		printQueryOutput(os.Stdout,
 			[]string{"Option", "Value"},
-			newRowSliceIter([][]string{
+			[][]string{
 				{"display_format", cliCtx.tableDisplayFormat.String()},
 				{"errexit", strconv.FormatBool(c.errExit)},
 				{"check_syntax", strconv.FormatBool(c.checkSyntax)},
 				{"normalize_history", strconv.FormatBool(c.normalizeHistory)},
-			}),
+			},
 			"set", cliCtx.tableDisplayFormat)
-		if err != nil {
-			panic(err)
-		}
-
 		return nextState
 	}
 	opt, ok := options[args[0]]

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -308,45 +308,18 @@ func runQueryAndFormatResults(
 	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = rows.Close()
-	}()
+	defer func() { _ = rows.Close() }()
 	for {
-		cols := getColumnStrings(rows)
-		if len(cols) == 0 {
-			// When no columns are returned, we want to render a summary of the
-			// number of rows that were returned or affected. To do this this, the
-			// driver needs to "consume" all the rows so that the RowsAffected()
-			// method returns the correct number of rows (it only reports the number
-			// of rows that the driver consumes).
-			if err := consumeAllRows(rows); err != nil {
-				return err
-			}
-		}
-		formattedTag := getFormattedTag(rows.Tag(), rows.Result())
-		if err := printQueryOutput(w, cols, newRowIter(rows, true), formattedTag, displayFormat); err != nil {
+		cols, allRows, result, err := sqlRowsToStrings(rows, true)
+		if err != nil {
 			return err
 		}
+		printQueryOutput(w, cols, allRows, result, displayFormat)
 
 		if more, err := rows.NextResultSet(); err != nil {
 			return err
 		} else if !more {
 			return nil
-		}
-	}
-}
-
-// consumeAllRows consumes all of the rows from the network. Used this method
-// when the driver needs to consume all the rows, but you don't care about the
-// rows themselves.
-func consumeAllRows(rows *sqlRows) error {
-	for {
-		err := rows.Next(nil)
-		if err == io.EOF {
-			return nil
-		}
-		if err != nil {
-			return err
 		}
 	}
 }
@@ -359,65 +332,35 @@ func consumeAllRows(rows *sqlRows) error {
 // information was returned (eg: statement was not a query).
 // If showMoreChars is true, then more characters are not escaped.
 func sqlRowsToStrings(rows *sqlRows, showMoreChars bool) ([]string, [][]string, string, error) {
-	cols := getColumnStrings(rows)
-	allRows, err := getAllRowStrings(rows, showMoreChars)
-	if err != nil {
-		return nil, nil, "", err
-	}
-	tag := getFormattedTag(rows.Tag(), rows.Result())
-
-	return cols, allRows, tag, nil
-}
-
-func getColumnStrings(rows *sqlRows) []string {
 	srcCols := rows.Columns()
 	cols := make([]string, len(srcCols))
 	for i, c := range srcCols {
-		cols[i] = formatVal(c, true, false)
+		cols[i] = formatVal(c, showMoreChars, false)
 	}
-	return cols
-}
 
-func getAllRowStrings(rows *sqlRows, showMoreChars bool) ([][]string, error) {
 	var allRows [][]string
-
-	for {
-		rowStrings, err := getNextRowStrings(rows, showMoreChars)
-		if err != nil {
-			return nil, err
-		}
-		if rowStrings == nil {
-			break
-		}
-		allRows = append(allRows, rowStrings)
-	}
-
-	return allRows, nil
-}
-
-func getNextRowStrings(rows *sqlRows, showMoreChars bool) ([]string, error) {
-	cols := rows.Columns()
 	var vals []driver.Value
 	if len(cols) > 0 {
 		vals = make([]driver.Value, len(cols))
 	}
 
-	err := rows.Next(vals)
-	if err == io.EOF {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
+	for {
+		err := rows.Next(vals)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, nil, "", err
+		}
+		rowStrings := make([]string, len(cols))
+		for i, v := range vals {
+			rowStrings[i] = formatVal(v, showMoreChars, showMoreChars)
+		}
+		allRows = append(allRows, rowStrings)
 	}
 
-	rowStrings := make([]string, len(cols))
-	for i, v := range vals {
-		rowStrings[i] = formatVal(v, showMoreChars, showMoreChars)
-	}
-	return rowStrings, nil
-}
-
-func getFormattedTag(tag string, result driver.Result) string {
+	result := rows.Result()
+	tag := rows.Tag()
 	switch tag {
 	case "":
 		tag = "OK"
@@ -426,7 +369,8 @@ func getFormattedTag(tag string, result driver.Result) string {
 			tag = fmt.Sprintf("%s %d", tag, n)
 		}
 	}
-	return tag
+
+	return cols, allRows, tag, nil
 }
 
 // expandTabsAndNewLines ensures that multi-line row strings that may


### PR DESCRIPTION
Reverts cockroachdb/cockroach#15277

This broke the master build:

```
pkg/cli/cert.go:189: cannot use rows (type [][]string) as type rowStrIter in argument to printQueryOutput:
	[][]string does not implement rowStrIter (missing Next method)
make: *** [build] Error 2
```