### PR TITLE
gossip: Reduce thrashing caused by process restarts

### DIFF
--- a/pkg/ccl/sqlccl/backup.go
+++ b/pkg/ccl/sqlccl/backup.go
@@ -12,7 +12,6 @@ import (
 	"bytes"
 	"io/ioutil"
 	"sort"
-	"strings"
 
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -231,11 +230,9 @@ func backupJobDescription(
 
 // clusterNodeCount returns the approximate number of nodes in the cluster.
 func clusterNodeCount(g *gossip.Gossip) int {
-	const nodePrefix = gossip.KeyNodeIDPrefix + ":"
-
 	var nodes int
 	for k := range g.GetInfoStatus().Infos {
-		if strings.HasPrefix(k, nodePrefix) {
+		if gossip.IsNodeIDKey(k) {
 			nodes++
 		}
 	}

--- a/pkg/gossip/infostore.go
+++ b/pkg/gossip/infostore.go
@@ -383,7 +383,12 @@ func (is *infoStore) mostDistant(
 	var nodeID roachpb.NodeID
 	var maxHops uint32
 	if err := is.visitInfos(func(key string, i *Info) error {
-		if i.Hops > maxHops && !hasOutgoingConn(i.NodeID) {
+		// Only consider NodeID keys here because they're re-gossiped every time a
+		// node restarts and periodically after that, so their Hops values are more
+		// likely to be accurate than keys which are rarely re-gossiped, which can
+		// acquire unreliably high Hops values in some pathological cases such as
+		// those described in #9819.
+		if i.Hops > maxHops && IsNodeIDKey(key) && !hasOutgoingConn(i.NodeID) {
 			maxHops = i.Hops
 			nodeID = i.NodeID
 		}

--- a/pkg/gossip/infostore_test.go
+++ b/pkg/gossip/infostore_test.go
@@ -269,12 +269,22 @@ func TestInfoStoreMostDistant(t *testing.T) {
 	}
 	is, stopper := newTestInfoStore()
 	defer stopper.Stop(context.TODO())
+
+	// Start with one very distant info that shouldn't affect mostDistant
+	// calculations because it isn't a node ID key.
+	scInfo := is.newInfo(nil, time.Second)
+	scInfo.Hops = 100
+	scInfo.NodeID = nodes[0]
+	if err := is.addInfo(KeySystemConfig, scInfo); err != nil {
+		t.Fatal(err)
+	}
+
 	// Add info from each address, with hop count equal to index+1.
 	for i := 0; i < len(nodes); i++ {
 		inf := is.newInfo(nil, time.Second)
 		inf.Hops = uint32(i + 1)
 		inf.NodeID = nodes[i]
-		if err := is.addInfo(fmt.Sprintf("b.%d", i), inf); err != nil {
+		if err := is.addInfo(MakeNodeIDKey(inf.NodeID), inf); err != nil {
 			t.Fatal(err)
 		}
 		nodeID, hops := is.mostDistant(func(roachpb.NodeID) bool { return false })

--- a/pkg/gossip/keys.go
+++ b/pkg/gossip/keys.go
@@ -96,6 +96,11 @@ func MakeNodeIDKey(nodeID roachpb.NodeID) string {
 	return MakeKey(KeyNodeIDPrefix, nodeID.String())
 }
 
+// IsNodeIDKey returns true iff the provided key is a valid node ID key.
+func IsNodeIDKey(key string) bool {
+	return strings.HasPrefix(key, KeyNodeIDPrefix+separator)
+}
+
 // NodeIDFromKey attempts to extract a NodeID from the provided key.
 // The key should have been constructed by MakeNodeIDKey.
 // Returns an error if the key is not of the correct type or is not parsable.

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -57,6 +57,9 @@ const (
 	// gossipStatusInterval is the interval for logging gossip status.
 	gossipStatusInterval = 1 * time.Minute
 	// gossipNodeDescriptorInterval is the interval for gossiping the node descriptor.
+	// Note that increasing this duration may increase the likelihood of gossip
+	// thrashing, since node descriptors are used to determine the number of gossip
+	// hops between nodes (see #9819 for context).
 	gossipNodeDescriptorInterval = 1 * time.Hour
 
 	// FirstNodeID is the node ID of the first node in a new cluster.

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4501,11 +4501,21 @@ func (r *Replica) shouldGossip() bool {
 // maybeGossipSystemConfig must only be called from Raft commands
 // (which provide the necessary serialization to avoid data races).
 func (r *Replica) maybeGossipSystemConfig(ctx context.Context) error {
-	if r.store.Gossip() == nil || !r.IsInitialized() {
+	if r.store.Gossip() == nil {
+		log.VEventf(ctx, 2, "not gossiping system config because gossip isn't initialized")
 		return nil
 	}
-
-	if !r.ContainsKey(keys.SystemConfigSpan.Key) || !r.shouldGossip() {
+	if !r.IsInitialized() {
+		log.VEventf(ctx, 2, "not gossiping system config because the replica isn't initialized")
+		return nil
+	}
+	if !r.ContainsKey(keys.SystemConfigSpan.Key) {
+		log.VEventf(ctx, 2,
+			"not gossiping system config because the replica doesn't contain the system config's start key")
+		return nil
+	}
+	if !r.shouldGossip() {
+		log.VEventf(ctx, 2, "not gossiping system config because the replica doesn't hold the lease")
 		return nil
 	}
 
@@ -4516,6 +4526,7 @@ func (r *Replica) maybeGossipSystemConfig(ctx context.Context) error {
 	}
 
 	if gossipedCfg, ok := r.store.Gossip().GetSystemConfig(); ok && gossipedCfg.Equal(loadedCfg) {
+		log.VEventf(ctx, 2, "not gossiping unchanged system config")
 		return nil
 	}
 


### PR DESCRIPTION
**storage: Add extra logging in maybeGossipSystemConfig**

**gossip: Reduce thrashing by only using NodeID keys in mostDistant**

NodeID infos are reliably re-gossiped periodically and on restart,
making it much less likely that process restarts can lead to large
Hops values, which has shown itself to be a problem for the system
config info.

Fixes #9819