### PR TITLE
acceptance: fix a bug in TestDockerCLI and deflake some tests

### DIFF
--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -85,12 +85,15 @@ proc start_server {argv} {
 }
 proc stop_server {argv} {
     report "BEGIN STOP SERVER"
+    # Trigger a normal shutdown.
     system "$argv quit"
+    # If after 5 seconds the server hasn't shut down, trigger an error.
+    system "for i in `seq 1 5`; do kill -CONT `cat server_pid` 2>/dev/null || exit 0; echo still waiting; sleep 1; done; echo 'server still running?'; exit 1"
     report "END STOP SERVER"
 }
 
 proc force_stop_server {argv} {
     report "BEGIN FORCE STOP SERVER"
-    system "set -x; $argv quit & sleep 1; if kill -CONT `cat server_pid`; then kill -TERM `cat server pid`; sleep 1; if kill -CONT `cat server_pid`; then kill -KILL `cat server_pid`; fi; fi"
+    system "$argv quit & sleep 1; if kill -CONT `cat server_pid` 2>/dev/null; then kill -TERM `cat server pid`; sleep 1; if kill -CONT `cat server_pid` 2>/dev/null; then kill -KILL `cat server_pid`; fi; fi"
     report "END FORCE STOP SERVER"
 }


### PR DESCRIPTION
Fixes #15532.

See https://github.com/cockroachdb/cockroach/issues/15532#issuecomment-298329050 for the backstory. I needed to add a check loop in `stop_server` until the server process really terminated (to ensure when the rocksdb files are closed), but that didn't work at first, leading me to discover that `kill -CONT` never failed, even on properly dead servers, as I had expected -- because those server processes were remaining in zombie state. This patch ensures that the top-level bash process cleans up dead servers.

