### PR TITLE
sql: keep query separate when agumenting sql panics

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -495,7 +495,7 @@ func (e *Executor) ExecuteStatements(
 	defer func() {
 		if r := recover(); r != nil {
 			// On a panic, prepend the executed SQL.
-			panic(fmt.Errorf("%s: %s", stmts, r))
+			panic(log.WrappedPanic{ExtraInfo: stmts, Err: r})
 		}
 	}()
 

--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -52,16 +52,26 @@ var DiagnosticsReportingEnabled = settings.RegisterBoolSetting(
 // real stderr a panic has occurred.
 func RecoverAndReportPanic(ctx context.Context) {
 	if r := recover(); r != nil {
-		ReportPanic(ctx, r)
+		r = ReportPanic(ctx, r)
 		panic(r)
 	}
 }
 
 // ReportPanic reports a panic has occurred on the real stderr.
-func ReportPanic(ctx context.Context, r interface{}) {
+//
+// The passed value is returned unless it is a WrappedPanic, in which case a new
+// error is created, combining the original error plus the contextural info,
+// thus making the returned value suitable for passing back to a final panic().
+func ReportPanic(ctx context.Context, r interface{}) interface{} {
 	Shout(ctx, Severity_ERROR, "a panic has occurred!")
 
-	maybeSendCrashReport(ctx, r)
+	reportable := r
+	if e, ok := r.(WrappedPanic); ok {
+		reportable = e.Err
+		r = errors.Errorf("%s: %v", e.ExtraInfo, e.Err)
+	}
+
+	maybeSendCrashReport(ctx, reportable)
 
 	// Ensure that the logs are flushed before letting a panic
 	// terminate the server.
@@ -77,6 +87,7 @@ func ReportPanic(ctx context.Context, r interface{}) {
 	if stderrRedirected {
 		fmt.Fprintf(OrigStderr, "%v\n\n%s\n", r, debug.Stack())
 	}
+	return r
 }
 
 var crashReports = settings.RegisterBoolSetting(
@@ -113,6 +124,14 @@ func SetupCrashReporter(ctx context.Context, cmd string) {
 		"rev":          info.Revision,
 		"goversion":    info.GoVersion,
 	})
+}
+
+// WrappedPanic represents a panic plus extra contextual info, which is stripped
+// if/when the panic is handled by crash reporting (e.g. if that info contains a
+// raw query, which we do not want to include in collected crash reports.
+type WrappedPanic struct {
+	ExtraInfo string
+	Err       interface{}
 }
 
 func sendCrashReport(ctx context.Context, r interface{}) {

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -196,7 +196,7 @@ func (s *Stopper) Recover(ctx context.Context) {
 			s.onPanic(r)
 			return
 		}
-		log.ReportPanic(ctx, r)
+		r = log.ReportPanic(ctx, r)
 		panic(r)
 	}
 }


### PR DESCRIPTION
this allows ommiting it when passing the panic to crash reporting, as we don't want to include the raw query.