### PR TITLE
build: fix paths in teamcity-release-upload.sh

### DIFF
--- a/build/teamcity-release-upload.sh
+++ b/build/teamcity-release-upload.sh
@@ -17,8 +17,7 @@ if [ "$TC_BUILD_BRANCH" != master ]; then
 	docker build --tag=$image:{latest,"$TC_BUILD_BRANCH"} build/deploy
 
 	build/builder.sh make TYPE=release-linux-gnu testbuild TAGS=acceptance PKG=./pkg/acceptance
-	cd pkg/acceptance
-	time ./acceptance.test -i $image -b /cockroach/cockroach -nodes 3 -test.v -test.timeout -5m
+	(cd pkg/acceptance && ./acceptance.test -i $image -b /cockroach/cockroach -nodes 3 -test.v -test.timeout -5m)
 
 	sed "s/<EMAIL>/$DOCKER_EMAIL/;s/<AUTH>/$DOCKER_AUTH/" < build/.dockercfg.in > ~/.dockercfg
 	docker push $image:{latest,"$TC_BUILD_BRANCH"}


### PR DESCRIPTION
@bdarnell, @tamird tells me this should fix the release build error. Should I merge this and let you backport onto the release branch?