### PR TITLE
sqlccl: adjust the restore presplit rate down

### DIFF
--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -490,11 +490,11 @@ func presplitRanges(baseCtx context.Context, db client.DB, input []roachpb.Key) 
 		return nil
 	}
 
-	// 100 was picked because it's small enough to work with on a 3-node cluster
-	// on my laptop and large enough that it only takes a couple minutes to
-	// presplit for a ~16000 range dataset.
+	// 20 was picked because it's small enough that the 2tb restore acceptance
+	// test finishes smoothly on GCE and large enough that it only takes ~8
+	// minutes to presplit for a ~16000 range dataset.
 	// TODO(dan): See if there's some better solution #14798.
-	const splitsPerSecond, splitsBurst = 100, 1
+	const splitsPerSecond, splitsBurst = 20, 1
 	limiter := rate.NewLimiter(splitsPerSecond, splitsBurst)
 
 	g, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
When syncing after every raft commit is on (the default recently
switched to true in 801f3a0) then presplits on sufficiently large
restores were behaving badly.

I suspect this was overloading the disk, slowing down rocksdb commits
(similar to the underlying cause addressed by our recent Import rate
limiting changes). Unfortunately, this is not entirely confirmed by our
metrics. Disk iops and usage were slightly elevated during the bad
periods, but not really beyond what happens in a healthy cluster with
block_writer traffic.

However, reducing this constant from 100 to 20 clearly fixes the split
badness in the 2tb restore acceptance test (while making the splits take
8 minutes, up from ~3). This is unfortunate, as it's possible to go
faster in other circumstances, but there's already an issue to revisit
this rate limiting post 1.0 (#14798).