### PR TITLE
build: remove duplicate "cockroach" and ".exe" from release archives

### DIFF
--- a/pkg/cmd/release-upload/main.go
+++ b/pkg/cmd/release-upload/main.go
@@ -281,7 +281,7 @@ func main() {
 					log.Fatalf("s3 redirect to %s: %s", versionKey, err)
 				}
 			} else {
-				targetSuffix := base
+				targetSuffix := strings.TrimSuffix(target.baseSuffix, ".exe")
 				// TODO(tamird): remove this weirdness. Requires updating
 				// "users" e.g. docs, cockroachdb/cockroach-go, maybe others.
 				if strings.Contains(target.buildType, "linux") {


### PR DESCRIPTION
@tamird I need to run so you'll have to push this through. This *should* give us

> https://binaries.cockroachdb.com/cockroach-latest.windows-6.2-amd64.zip

instead of 

> https://binaries.cockroachdb.com/cockroach-latest.cockroach-windows-6.2-amd64.exe.zip

but you should double check my logic.