### PR TITLE
storage: check whether a replica is destroyed before proposing

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2513,6 +2513,14 @@ func (r *Replica) propose(
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	// NB: We need to check Replica.mu.destroyed again in case the Replica has
+	// been destroyed between the initial check at the beginning of this method
+	// and the acquisition of Replica.mu. Failure to do so will leave pending
+	// proposals that never get cleared.
+	if err := r.mu.destroyed; err != nil {
+		return nil, nil, err
+	}
+
 	repDesc, err := r.getReplicaDescriptorRLocked()
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Fix a race where a proposal could be submitted after a replica was
destroyed. We need to check Replica.mu.destroyed and propose while
holding Replica.mu.lock.

Fixes #15551