### PR TITLE
migrations: Don't crash for an old lease if we're already done

### DIFF
--- a/pkg/sql/distsqlplan/span_resolver_test.go
+++ b/pkg/sql/distsqlplan/span_resolver_test.go
@@ -194,7 +194,6 @@ func splitRangeAtVal(
 
 func TestSpanResolver(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#13237")
 	s, db, cdb := serverutils.StartServer(t, base.TestServerArgs{
 		UseDatabase: "t",
 	})


### PR DESCRIPTION
@asubiotto found a flake where an ExtendLease call would return with an
"unexpected value: <nil>" error and then the server would crash because
the lease was too close to expiring. That error implies that the lease
got released before ExtendLease was able to execute, which means that
checking the `done` channel before exiting would have safely prevented
the crash.

Fixes #13237 (assuming this was the only problem with it)