### PR TITLE
sql: move txn from RestartWait to Aborted on unexpected stmt

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1070,8 +1070,18 @@ func (e *Executor) execStmtInAbortedTxn(session *Session, stmt parser.Statement)
 			parser.RestartSavepointName))
 		return Result{}, err
 	default:
-		err := sqlbase.NewTransactionAbortedError("")
-		return Result{}, err
+		if txnState.State == RestartWait {
+			err := sqlbase.NewTransactionAbortedError(
+				"Expected \"ROLLBACK TO SAVEPOINT COCKROACH_RESTART\"" /* customMsg */)
+			// If we were waiting for a restart, but the client failed to perform it,
+			// we'll cleanup the txn. The client is not respecting the protocol, so
+			// there seems to be little point in staying in RestartWait (plus,
+			// higher-level code asserts that we're only in RestartWait when returning
+			// retryable errors to the client).
+			txnState.updateStateAndCleanupOnErr(err, e)
+			return Result{}, err
+		}
+		return Result{}, sqlbase.NewTransactionAbortedError("" /* customMsg */)
 	}
 }
 


### PR DESCRIPTION
In the RestartWait state, we only expect ROLLBACK [TO SAVEPOINT]. On any
other statement, before this patch, we'd leave the state to be
RestartWait and we'd crash because the Executor asserts that we're in
that state only on retryable errors (i.e. we were supposed to get into
that state on a retryable error, and exit it upon the next statement).
This patch makes us move from RestartWait to Aborted (and thus rollback
the kv-level txn, if any).

Fixes #15412