### PR TITLE
kv: handle RangeNotFound same as RangeKeyMismatch in DistSender

### DIFF
--- a/pkg/kv/send_test.go
+++ b/pkg/kv/send_test.go
@@ -290,7 +290,7 @@ func TestSendNext_RetryableApplicationErrorThenSuccess(t *testing.T) {
 	doneChans[1] <- BatchCall{
 		Reply: &roachpb.BatchResponse{
 			BatchResponse_Header: roachpb.BatchResponse_Header{
-				Error: roachpb.NewError(roachpb.NewRangeNotFoundError(1)),
+				Error: roachpb.NewError(roachpb.NewStoreNotFoundError(1)),
 			},
 		},
 	}
@@ -321,7 +321,7 @@ func TestSendNext_AllRetryableApplicationErrors(t *testing.T) {
 		ch <- BatchCall{
 			Reply: &roachpb.BatchResponse{
 				BatchResponse_Header: roachpb.BatchResponse_Header{
-					Error: roachpb.NewError(roachpb.NewRangeNotFoundError(1)),
+					Error: roachpb.NewError(roachpb.NewStoreNotFoundError(1)),
 				},
 			},
 		}
@@ -333,7 +333,7 @@ func TestSendNext_AllRetryableApplicationErrors(t *testing.T) {
 		t.Fatalf("expected SendError, got err=nil and reply=%s", bc.Reply)
 	} else if _, ok := bc.Err.(*roachpb.SendError); !ok {
 		t.Fatalf("expected SendError, got err=%s", bc.Err)
-	} else if exp := "r1 was not found"; !testutils.IsError(bc.Err, exp) {
+	} else if exp := "store 1 was not found"; !testutils.IsError(bc.Err, exp) {
 		t.Errorf("expected SendError to contain %q, but got %v", exp, bc.Err)
 	}
 }


### PR DESCRIPTION
`RangeNotFoundError` was previously being treated the same as a node
or store being temporarily or permanently unavailable. We now treat
it the same as `RangeKeyMismatchError`, exiting immediately with the
assumption that the `RangeDescriptor` used to collate a slice of
replicas as distributed send targets is stale and must be re-queried.

Further, we now deduce that the same is true in the event that we
get a `NotLeaseHolderError` that implicates a replica which is not
present in the replicas slice.

Fixes #15543