### PR TITLE
storage: fix transaction expiration test

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -818,8 +818,10 @@ func MakePriority(userPriority UserPriority) int32 {
 	// For userPriority=MaxUserPriority, the probability of overflow is 0.7%.
 	// For userPriority=(MaxUserPriority/2), the probability of overflow is 0.005%.
 	val = (val / (5 * MaxUserPriority)) * math.MaxInt32
-	if val >= MaxTxnPriority {
-		return MaxTxnPriority
+	if val <= MinTxnPriority {
+		return MinTxnPriority + 1
+	} else if val >= MaxTxnPriority {
+		return MaxTxnPriority - 1
 	}
 	return int32(val)
 }


### PR DESCRIPTION
The problem was we were allowing random priorities to occasionally
generate `MinTxnPriority` or `MaxTxnPriority` on a probabilistic basis.
Sometimes this took 30m in stress. I've adjusted the priority generation
code in `data.go` to avoid ever returning `MinTxnPriority` or
`MaxTxnPriority`.

Fixes #14362