### PR TITLE
log: collect crash reports at correct stack depth

### DIFF
--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -1550,6 +1551,22 @@ var Builtins = map[string][]Builtin{
 			fn: func(ctx *EvalContext, args Datums) (Datum, error) {
 				msg := string(*args[0].(*DString))
 				panic(msg)
+			},
+			category: categorySystemInfo,
+			Info:     "This function is used only by CockroachDB's developers for testing purposes.",
+		},
+	},
+
+	"crdb_internal.force_log_fatal": {
+		Builtin{
+			Types:      ArgTypes{{"msg", TypeString}},
+			ReturnType: fixedReturnType(TypeInt),
+			impure:     true,
+			privileged: true,
+			fn: func(ctx *EvalContext, args Datums) (Datum, error) {
+				msg := string(*args[0].(*DString))
+				log.Fatal(ctx.Ctx(), msg)
+				return nil, nil
 			},
 			category: categorySystemInfo,
 			Info:     "This function is used only by CockroachDB's developers for testing purposes.",

--- a/pkg/sql/rsg_test.go
+++ b/pkg/sql/rsg_test.go
@@ -112,7 +112,7 @@ func TestRandomSyntaxFunctions(t *testing.T) {
 		for {
 			for name, variations := range parser.Builtins {
 				switch strings.ToLower(name) {
-				case "crdb_internal.force_panic":
+				case "crdb_internal.force_panic", "crdb_internal.force_log_fatal":
 					continue
 				}
 				for _, builtin := range variations {

--- a/pkg/sql/testdata/logic_test/crdb_internal
+++ b/pkg/sql/testdata/logic_test/crdb_internal
@@ -102,3 +102,6 @@ select crdb_internal.force_internal_error('foo')
 
 query error pq: insufficient privilege
 select crdb_internal.force_panic('foo')
+
+query error pq: insufficient privilege
+select crdb_internal.force_log_fatal('foo')

--- a/pkg/util/log/structured.go
+++ b/pkg/util/log/structured.go
@@ -142,7 +142,7 @@ func addStructured(ctx context.Context, s Severity, depth int, format string, ar
 	msg := MakeMessage(ctx, format, args)
 
 	if s == Severity_FATAL {
-		maybeSendCrashReport(ctx, msg)
+		sendCrashReport(ctx, msg, depth+1)
 	}
 	// MakeMessage already added the tags when forming msg, we don't want
 	// eventInternal to prepend them again.


### PR DESCRIPTION
Also always include a stacktrace (raven’s CaptureMessage does not).
