### PR TITLE
sql: migrate the autoCommit flag into the planner.

### DIFF
--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -76,9 +76,7 @@ func (*copyNode) DebugValues() debugValues {
 
 // CopyFrom begins a COPY.
 // Privileges: INSERT on table.
-func (p *planner) CopyFrom(
-	ctx context.Context, n *parser.CopyFrom, autoCommit bool,
-) (planNode, error) {
+func (p *planner) CopyFrom(ctx context.Context, n *parser.CopyFrom) (planNode, error) {
 	cn := &copyNode{
 		table:   &n.Table,
 		columns: n.Columns,
@@ -88,7 +86,7 @@ func (p *planner) CopyFrom(
 	if err != nil {
 		return nil, err
 	}
-	en, err := p.makeEditNode(ctx, tn, autoCommit, privilege.INSERT)
+	en, err := p.makeEditNode(ctx, tn, privilege.INSERT)
 	if err != nil {
 		return nil, err
 	}
@@ -359,9 +357,7 @@ var decodeMap = map[byte]byte{
 // CopyData is the statement type after a block of COPY data has been
 // received. There may be additional rows ready to insert. If so, return an
 // insertNode, otherwise emptyNode.
-func (p *planner) CopyData(
-	ctx context.Context, n CopyDataBlock, autoCommit bool,
-) (planNode, error) {
+func (p *planner) CopyData(ctx context.Context, n CopyDataBlock) (planNode, error) {
 	// When this many rows are in the copy buffer, they are inserted.
 	const copyRowSize = 100
 
@@ -385,7 +381,7 @@ func (p *planner) CopyData(
 		},
 		Returning: parser.AbsentReturningClause,
 	}
-	return p.Insert(ctx, &in, nil, autoCommit)
+	return p.Insert(ctx, &in, nil)
 }
 
 // Format implements the NodeFormatter interface.

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -385,7 +385,7 @@ func (p *planner) CreateView(ctx context.Context, n *parser.CreateView) (planNod
 	// depends on, make sure we use the most recent versions of table
 	// descriptors rather than the copies in the lease cache.
 	p.avoidCachedDescriptors = true
-	sourcePlan, err := p.Select(ctx, n.AsSource, []parser.Type{}, false)
+	sourcePlan, err := p.Select(ctx, n.AsSource, []parser.Type{})
 	if err != nil {
 		p.avoidCachedDescriptors = false
 		return nil, err
@@ -575,7 +575,7 @@ func (p *planner) CreateTable(ctx context.Context, n *parser.CreateTable) (planN
 		// to populate the new table descriptor in Start() below. We
 		// instantiate the sourcePlan as early as here so that EXPLAIN has
 		// something useful to show about CREATE TABLE .. AS ...
-		sourcePlan, err = p.Select(ctx, n.AsSource, []parser.Type{}, false)
+		sourcePlan, err = p.Select(ctx, n.AsSource, []parser.Type{})
 		if err != nil {
 			return nil, err
 		}
@@ -725,7 +725,7 @@ func (n *createTableNode) Start(ctx context.Context) error {
 			Rows:      n.n.AsSource,
 			Returning: parser.AbsentReturningClause,
 		}
-		insertPlan, err := n.p.Insert(ctx, insert, nil /* desiredTypes */, false /* autoCommit */)
+		insertPlan, err := n.p.Insert(ctx, insert, nil /* desiredTypes */)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -343,7 +343,7 @@ func (p *planner) getDataSource(
 		return p.makeJoin(ctx, t.Join, left, right, t.Cond)
 
 	case *parser.Explain:
-		plan, err := p.Explain(ctx, t, false)
+		plan, err := p.Explain(ctx, t)
 		if err != nil {
 			return planDataSource{}, err
 		}
@@ -574,7 +574,7 @@ func (p *planner) getViewPlan(
 func (p *planner) getSubqueryPlan(
 	ctx context.Context, sel parser.SelectStatement, cols sqlbase.ResultColumns,
 ) (planDataSource, error) {
-	plan, err := p.newPlan(ctx, sel, nil, false)
+	plan, err := p.newPlan(ctx, sel, nil)
 	if err != nil {
 		return planDataSource{}, err
 	}

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -47,14 +47,14 @@ type deleteNode struct {
 //   Notes: postgres requires DELETE. Also requires SELECT for "USING" and "WHERE" with tables.
 //          mysql requires DELETE. Also requires SELECT if a table is used in the "WHERE" clause.
 func (p *planner) Delete(
-	ctx context.Context, n *parser.Delete, desiredTypes []parser.Type, autoCommit bool,
+	ctx context.Context, n *parser.Delete, desiredTypes []parser.Type,
 ) (planNode, error) {
 	tn, err := p.getAliasedTableName(n.Table)
 	if err != nil {
 		return nil, err
 	}
 
-	en, err := p.makeEditNode(ctx, tn, autoCommit, privilege.DELETE)
+	en, err := p.makeEditNode(ctx, tn, privilege.DELETE)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (p *planner) Delete(
 	if err != nil {
 		return nil, err
 	}
-	tw := tableDeleter{rd: rd, autoCommit: autoCommit}
+	tw := tableDeleter{rd: rd, autoCommit: p.autoCommit}
 
 	// TODO(knz): Until we split the creation of the node from Start()
 	// for the SelectClause too, we cannot cache this. This is because

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -53,9 +53,7 @@ var explainStrings = map[explainMode]string{
 // info about the wrapped statement.
 //
 // Privileges: the same privileges as the statement being explained.
-func (p *planner) Explain(
-	ctx context.Context, n *parser.Explain, autoCommit bool,
-) (planNode, error) {
+func (p *planner) Explain(ctx context.Context, n *parser.Explain) (planNode, error) {
 	mode := explainNone
 
 	optimized := true
@@ -136,7 +134,7 @@ func (p *planner) Explain(
 
 	p.evalCtx.SkipNormalize = !normalizeExprs
 
-	plan, err := p.newPlan(ctx, n.Statement, nil, autoCommit)
+	plan, err := p.newPlan(ctx, n.Statement, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/parallel_stmts_test.go
+++ b/pkg/sql/parallel_stmts_test.go
@@ -324,7 +324,7 @@ func planNodeForQuery(
 		t.Fatalf("expected to parse 1 statement, got: %d", len(stmts))
 	}
 	stmt := stmts[0]
-	plan, err := p.makePlan(context.TODO(), stmt, false /* autoCommit */)
+	plan, err := p.makePlan(context.TODO(), stmt)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1282,7 +1282,7 @@ CREATE TABLE pg_catalog.pg_settings (
 	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		for _, vName := range varNames {
 			gen := varGen[vName]
-			value := gen.Get(p, false)
+			value := gen.Get(p)
 			valueDatum := parser.NewDString(value)
 			if err := addRow(
 				parser.NewDString(strings.ToLower(vName)), // name

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -61,6 +61,13 @@ type planner struct {
 	// initializing plans to read from a table. This should be used with care.
 	skipSelectPrivilegeChecks bool
 
+	// autoCommit indicates whether we're planning for a spontaneous transaction.
+	// If autoCommit is true, the plan is allowed (but not required) to
+	// commit the transaction along with other KV operations.
+	// Note: The autoCommit parameter enables operations to enable the
+	// 1PC optimization. This is a bit hackish/preliminary at present.
+	autoCommit bool
+
 	// phaseTimes helps measure the time spent in each phase of SQL execution.
 	// See executor_statement_metrics.go for details.
 	phaseTimes phaseTimes
@@ -172,7 +179,7 @@ func (p *planner) query(ctx context.Context, sql string, args ...interface{}) (p
 		return nil, err
 	}
 	golangFillQueryArguments(&p.semaCtx.Placeholders, args)
-	return p.makePlan(ctx, stmt, false)
+	return p.makePlan(ctx, stmt)
 }
 
 // QueryRow implements the parser.EvalPlanner interface.

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -167,7 +167,7 @@ func (s *renderNode) IndexedVarFormat(buf *bytes.Buffer, f parser.FmtFlags, idx 
 
 // Select selects rows from a SELECT/UNION/VALUES, ordering and/or limiting them.
 func (p *planner) Select(
-	ctx context.Context, n *parser.Select, desiredTypes []parser.Type, autoCommit bool,
+	ctx context.Context, n *parser.Select, desiredTypes []parser.Type,
 ) (planNode, error) {
 	wrapped := n.Select
 	limit := n.Limit
@@ -201,7 +201,7 @@ func (p *planner) Select(
 	// investigating a general mechanism for passing some context down during
 	// plan node construction.
 	default:
-		plan, err := p.newPlan(ctx, s, desiredTypes, autoCommit)
+		plan, err := p.newPlan(ctx, s, desiredTypes)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -213,7 +213,7 @@ func (p *planner) showClusterSetting(name string) (planNode, error) {
 }
 
 // Show a session-local variable name.
-func (p *planner) Show(n *parser.Show, autoCommit bool) (planNode, error) {
+func (p *planner) Show(n *parser.Show) (planNode, error) {
 	origName := n.Name
 	name := strings.ToLower(n.Name)
 
@@ -246,7 +246,7 @@ func (p *planner) Show(n *parser.Show, autoCommit bool) (planNode, error) {
 			case `all`:
 				for _, vName := range varNames {
 					gen := varGen[vName]
-					value := gen.Get(p, autoCommit)
+					value := gen.Get(p)
 					if _, err := v.rows.AddRow(
 						ctx, parser.Datums{parser.NewDString(vName), parser.NewDString(value)},
 					); err != nil {
@@ -258,7 +258,7 @@ func (p *planner) Show(n *parser.Show, autoCommit bool) (planNode, error) {
 				// The key in varGen is guaranteed to exist thanks to the
 				// check above.
 				gen := varGen[name]
-				value := gen.Get(p, autoCommit)
+				value := gen.Get(p)
 				if _, err := v.rows.AddRow(ctx, parser.Datums{parser.NewDString(value)}); err != nil {
 					v.rows.Close(ctx)
 					return nil, err
@@ -564,7 +564,7 @@ func (p *planner) ShowCreateView(ctx context.Context, n *parser.ShowCreateView) 
 			p.skipSelectPrivilegeChecks = true
 			defer func() { p.skipSelectPrivilegeChecks = false }()
 
-			sourcePlan, err := p.Select(ctx, sel, []parser.Type{}, false)
+			sourcePlan, err := p.Select(ctx, sel, []parser.Type{})
 			if err != nil {
 				return nil, err
 			}
@@ -606,7 +606,7 @@ func (p *planner) ShowDatabases(ctx context.Context, n *parser.ShowDatabases) (p
 	if err != nil {
 		return nil, err
 	}
-	return p.newPlan(ctx, stmt, nil, true)
+	return p.newPlan(ctx, stmt, nil)
 }
 
 // ShowGrants returns grant details for the specified objects and users.
@@ -922,7 +922,7 @@ func (p *planner) ShowUsers(ctx context.Context, n *parser.ShowUsers) (planNode,
 	if err != nil {
 		return nil, err
 	}
-	return p.newPlan(ctx, stmt, nil, true)
+	return p.newPlan(ctx, stmt, nil)
 }
 
 // Help returns usage information for the builtin functions

--- a/pkg/sql/split_at.go
+++ b/pkg/sql/split_at.go
@@ -69,7 +69,7 @@ func (p *planner) Split(ctx context.Context, n *parser.Split) (planNode, error) 
 	}
 
 	// Create the plan for the split rows source.
-	rows, err := p.newPlan(ctx, n.Rows, desiredTypes, false /* auto commit */)
+	rows, err := p.newPlan(ctx, n.Rows, desiredTypes)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func (p *planner) Relocate(ctx context.Context, n *parser.Relocate) (planNode, e
 	}
 
 	// Create the plan for the split rows source.
-	rows, err := p.newPlan(ctx, n.Rows, desiredTypes, false /* auto commit */)
+	rows, err := p.newPlan(ctx, n.Rows, desiredTypes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -349,7 +349,7 @@ func (v *subqueryVisitor) VisitPre(expr parser.Expr) (recurse bool, newExpr pars
 	// Calling newPlan() might recursively invoke expandSubqueries, so we need to preserve
 	// the state of the visitor across the call to newPlan().
 	visitorCopy := v.planner.subqueryVisitor
-	plan, err := v.planner.newPlan(v.ctx, sq.Select, nil, false)
+	plan, err := v.planner.newPlan(v.ctx, sq.Select, nil)
 	v.planner.subqueryVisitor = visitorCopy
 	if err != nil {
 		v.err = err

--- a/pkg/sql/subquery_test.go
+++ b/pkg/sql/subquery_test.go
@@ -39,7 +39,7 @@ func TestStartSubqueriesReturnsError(t *testing.T) {
 		t.Fatalf("expected to parse 1 statement, got: %d", len(stmts))
 	}
 	stmt := stmts[0]
-	plan, err := p.makePlan(context.TODO(), stmt, false /* autoCommit */)
+	plan, err := p.makePlan(context.TODO(), stmt)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/testdata/logic_test/pg_catalog
+++ b/pkg/sql/testdata/logic_test/pg_catalog
@@ -951,7 +951,7 @@ standard_conforming_strings    on            NULL      NULL        NULL        s
 time zone                      UTC           NULL      NULL        NULL        string
 transaction isolation level    SERIALIZABLE  NULL      NULL        NULL        string
 transaction priority           NORMAL        NULL      NULL        NULL        string
-transaction status             Open          NULL      NULL        NULL        string
+transaction status             NoTxn         NULL      NULL        NULL        string
 
 query TTTTTTT colnames
 SELECT name, setting, unit, context, enumvals, boot_val, reset_val FROM pg_catalog.pg_settings
@@ -972,7 +972,7 @@ standard_conforming_strings    on            NULL  user     NULL      on        
 time zone                      UTC           NULL  user     NULL      UTC           UTC
 transaction isolation level    SERIALIZABLE  NULL  user     NULL      SERIALIZABLE  SERIALIZABLE
 transaction priority           NORMAL        NULL  user     NULL      NORMAL        NORMAL
-transaction status             Open          NULL  user     NULL      Open          Open
+transaction status             NoTxn         NULL  user     NULL      NoTxn         NoTxn
 
 query TTTTTT colnames
 SELECT name, source, min_val, max_val, sourcefile, sourceline FROM pg_catalog.pg_settings

--- a/pkg/sql/union.go
+++ b/pkg/sql/union.go
@@ -29,7 +29,7 @@ import (
 
 // UnionClause constructs a planNode from a UNION/INTERSECT/EXCEPT expression.
 func (p *planner) UnionClause(
-	ctx context.Context, n *parser.UnionClause, desiredTypes []parser.Type, autoCommit bool,
+	ctx context.Context, n *parser.UnionClause, desiredTypes []parser.Type,
 ) (planNode, error) {
 	var emitAll = false
 	var emit unionNodeEmit
@@ -56,11 +56,11 @@ func (p *planner) UnionClause(
 		return nil, errors.Errorf("%v is not supported", n.Type)
 	}
 
-	left, err := p.newPlan(ctx, n.Left, desiredTypes, autoCommit)
+	left, err := p.newPlan(ctx, n.Left, desiredTypes)
 	if err != nil {
 		return nil, err
 	}
-	right, err := p.newPlan(ctx, n.Right, desiredTypes, autoCommit)
+	right, err := p.newPlan(ctx, n.Right, desiredTypes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -35,14 +35,13 @@ import (
 // editNodeBase holds the common (prepare+execute) state needed to run
 // row-modifying statements.
 type editNodeBase struct {
-	p          *planner
-	rh         *returningHelper
-	tableDesc  *sqlbase.TableDescriptor
-	autoCommit bool
+	p         *planner
+	rh        *returningHelper
+	tableDesc *sqlbase.TableDescriptor
 }
 
 func (p *planner) makeEditNode(
-	ctx context.Context, tn *parser.TableName, autoCommit bool, priv privilege.Kind,
+	ctx context.Context, tn *parser.TableName, priv privilege.Kind,
 ) (editNodeBase, error) {
 	tableDesc, err := p.session.leases.getTableLease(ctx, p.txn, p.getVirtualTabler(), tn)
 	if err != nil {
@@ -59,9 +58,8 @@ func (p *planner) makeEditNode(
 	}
 
 	return editNodeBase{
-		p:          p,
-		tableDesc:  tableDesc,
-		autoCommit: autoCommit,
+		p:         p,
+		tableDesc: tableDesc,
 	}, nil
 }
 
@@ -223,7 +221,7 @@ func addOrMergeExpr(
 //          mysql requires UPDATE. Also requires SELECT with WHERE clause with table.
 // TODO(guanqun): need to support CHECK in UPDATE
 func (p *planner) Update(
-	ctx context.Context, n *parser.Update, desiredTypes []parser.Type, autoCommit bool,
+	ctx context.Context, n *parser.Update, desiredTypes []parser.Type,
 ) (planNode, error) {
 	tracing.AnnotateTrace()
 
@@ -232,7 +230,7 @@ func (p *planner) Update(
 		return nil, err
 	}
 
-	en, err := p.makeEditNode(ctx, tn, autoCommit, privilege.UPDATE)
+	en, err := p.makeEditNode(ctx, tn, privilege.UPDATE)
 	if err != nil {
 		return nil, err
 	}
@@ -278,7 +276,7 @@ func (p *planner) Update(
 	if err != nil {
 		return nil, err
 	}
-	tw := tableUpdater{ru: ru, autoCommit: autoCommit}
+	tw := tableUpdater{ru: ru, autoCommit: p.autoCommit}
 
 	tracing.AnnotateTrace()
 

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -39,7 +39,7 @@ type sessionVar struct {
 
 	// Get returns a string representation of a given variable to be used
 	// either by SHOW or in the pg_catalog table.
-	Get func(p *planner, ac bool) string
+	Get func(p *planner) string
 
 	// Reset performs mutations (usually on p.session) to effect the change
 	// desired by RESET commands.
@@ -51,7 +51,7 @@ type sessionVar struct {
 // throwing an error when trying to SET or SHOW them.
 var nopVar = sessionVar{
 	Set:   func(context.Context, *planner, []parser.TypedExpr) error { return nil },
-	Get:   func(*planner, bool) string { return "" },
+	Get:   func(*planner) string { return "" },
 	Reset: func(*planner) error { return nil },
 }
 
@@ -74,7 +74,7 @@ var varGen = map[string]sessionVar{
 
 			return nil
 		},
-		Get: func(p *planner, ac bool) string { return p.session.Database },
+		Get: func(p *planner) string { return p.session.Database },
 		Reset: func(p *planner) error {
 			p.session.Database = p.session.defaults.database
 			return nil
@@ -103,7 +103,7 @@ var varGen = map[string]sessionVar{
 
 			return nil
 		},
-		Get: func(p *planner, ac bool) string { return p.session.DefaultIsolationLevel.String() },
+		Get: func(p *planner) string { return p.session.DefaultIsolationLevel.String() },
 		Reset: func(p *planner) error {
 			p.session.DefaultIsolationLevel = enginepb.IsolationType(0)
 			return nil
@@ -130,7 +130,7 @@ var varGen = map[string]sessionVar{
 
 			return nil
 		},
-		Get: func(p *planner, ac bool) string {
+		Get: func(p *planner) string {
 			return p.session.DistSQLMode.String()
 		},
 		Reset: func(p *planner) error {
@@ -172,7 +172,7 @@ var varGen = map[string]sessionVar{
 			p.session.SearchPath = newSearchPath
 			return nil
 		},
-		Get: func(p *planner, ac bool) string { return strings.Join(p.session.SearchPath, ", ") },
+		Get: func(p *planner) string { return strings.Join(p.session.SearchPath, ", ") },
 		Reset: func(p *planner) error {
 			p.session.SearchPath = parser.SearchPath{"pg_catalog"}
 			return nil
@@ -193,7 +193,7 @@ var varGen = map[string]sessionVar{
 
 			return nil
 		},
-		Get:   func(*planner, bool) string { return "on" },
+		Get:   func(*planner) string { return "on" },
 		Reset: func(*planner) error { return nil },
 	},
 	`application_name`: {
@@ -208,32 +208,32 @@ var varGen = map[string]sessionVar{
 
 			return nil
 		},
-		Get: func(p *planner, ac bool) string { return p.session.ApplicationName },
+		Get: func(p *planner) string { return p.session.ApplicationName },
 		Reset: func(p *planner) error {
 			p.session.resetApplicationName(p.session.defaults.applicationName)
 			return nil
 		},
 	},
 	`time zone`: {
-		Get: func(p *planner, ac bool) string { return p.session.Location.String() },
+		Get: func(p *planner) string { return p.session.Location.String() },
 	},
 	`transaction isolation level`: {
-		Get: func(p *planner, ac bool) string { return p.txn.Isolation().String() },
+		Get: func(p *planner) string { return p.txn.Isolation().String() },
 	},
 	`transaction priority`: {
-		Get: func(p *planner, ac bool) string { return p.txn.UserPriority().String() },
+		Get: func(p *planner) string { return p.txn.UserPriority().String() },
 	},
 	`transaction status`: {
-		Get: func(p *planner, ac bool) string { return getTransactionState(&p.session.TxnState, ac) },
+		Get: func(p *planner) string { return getTransactionState(&p.session.TxnState, p.autoCommit) },
 	},
 	`max_index_keys`: {
-		Get: func(*planner, bool) string { return "32" },
+		Get: func(*planner) string { return "32" },
 	},
 	`server_version`: {
-		Get: func(*planner, bool) string { return PgServerVersion },
+		Get: func(*planner) string { return PgServerVersion },
 	},
 	`session_user`: {
-		Get: func(p *planner, ac bool) string { return p.session.User },
+		Get: func(p *planner) string { return p.session.User },
 	},
 
 	// See https://www.postgresql.org/docs/9.6/static/runtime-config-client.html
@@ -245,7 +245,7 @@ var varGen = map[string]sessionVar{
 
 	// See https://www.postgresql.org/docs/9.6/static/multibyte.html
 	`client_encoding`: {
-		Get: func(*planner, bool) string {
+		Get: func(*planner) string {
 			return "UTF8"
 		},
 		Set: func(_ context.Context, p *planner, values []parser.TypedExpr) error {


### PR DESCRIPTION
This incidentally ensures that queries that indirectly access the
transaction status via session variables (e.g. via `pg_catalog`) see
the proper transaction status.

cc @andreimatei 