### PR TITLE
sql: execute queued up schema change through synchronous path

### DIFF
--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -670,6 +670,7 @@ func TestSchemaChangeCommandsWithPendingMutations(t *testing.T) {
 	// Disable external processing of mutations.
 	params, _ := createTestServerParams()
 	params.Knobs.SQLSchemaChanger = &sql.SchemaChangerTestingKnobs{
+		SyncFilter:            sql.TestingSchemaChangerCollection.ClearSchemaChangers,
 		AsyncExecNotification: asyncSchemaChangerDisabled,
 	}
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -802,7 +802,7 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 		for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
 			evalCtx := createSchemaChangeEvalCtx(e.cfg.Clock.Now())
 			if err := sc.exec(ctx, evalCtx); err != nil {
-				if err != errExistingSchemaChangeLease {
+				if shouldLogSchemaChangeError(err) {
 					log.Warningf(ctx, "Error executing schema change: %s", err)
 				}
 				if err == sqlbase.ErrDescriptorNotFound {


### PR DESCRIPTION
prior to this fix a queued up schema change would always execute
through the asynchronous path.

fixes #15038