### PR TITLE
kv: always wait on error if there are pending requests in DistSender

### DIFF
--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -513,7 +513,10 @@ func (t *multiTestContextKVTransport) SendNext(ctx context.Context, done chan<- 
 }
 
 func (t *multiTestContextKVTransport) NextReplica() roachpb.ReplicaDescriptor {
-	return roachpb.ReplicaDescriptor{}
+	if t.IsExhausted() {
+		return roachpb.ReplicaDescriptor{}
+	}
+	return t.replicas[t.idx].ReplicaDescriptor
 }
 
 func (t *multiTestContextKVTransport) MoveToFront(replica roachpb.ReplicaDescriptor) {


### PR DESCRIPTION
Previously, we'd immediately propagate an error from DistSender in the
event of a non replica-specific error, even if there were pending
requests which might succeed, in the case of a non-committing batch.

This causes some problems due to a combination of unittests using
`Increment` and the recent change in #15573 to return `RangeNotFound`
errors immediately. In those cases, we saw a not-yet returned, but
ultimately successful `Increment` being run twice and double-counting.

Fixes #15596