### PR TITLE
kv: increase the pending rpc timeout from 500ms to 1s

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -45,7 +45,7 @@ import (
 // Default constants for timeouts.
 const (
 	defaultClientTimeout     = 10 * time.Second
-	defaultPendingRPCTimeout = 500 * time.Millisecond
+	defaultPendingRPCTimeout = 1 * time.Second
 
 	// The default maximum number of ranges to return from a range
 	// lookup.


### PR DESCRIPTION
This is meant to decrease unnecessary incidences of `AmbiguousResultError`.