### PR TITLE
distsql: basic memory accounting in aggregator

### DIFF
--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -19,6 +19,7 @@ package distsqlrun
 import (
 	"strings"
 	"sync"
+	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/mon"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -73,7 +74,8 @@ type aggregator struct {
 	funcs       []*aggregateFuncHolder
 	outputTypes []sqlbase.ColumnType
 	datumAlloc  sqlbase.DatumAlloc
-	acc         *mon.MemoryAccount
+
+	bucketsAcc mon.BoundAccount
 
 	groupCols columns
 	inputCols columns
@@ -99,9 +101,8 @@ func newAggregator(
 		funcs:       make([]*aggregateFuncHolder, len(spec.Aggregations)),
 		outputTypes: make([]sqlbase.ColumnType, len(spec.Aggregations)),
 		groupCols:   make(columns, len(spec.GroupCols)),
-		acc:         &mon.MemoryAccount{},
+		bucketsAcc:  flowCtx.evalCtx.Mon.MakeBoundAccount(),
 	}
-	flowCtx.evalCtx.Mon.OpenAccount(ag.acc)
 
 	for i, aggInfo := range spec.Aggregations {
 		ag.inputCols[i] = aggInfo.ColIdx
@@ -139,6 +140,7 @@ func (ag *aggregator) Run(ctx context.Context, wg *sync.WaitGroup) {
 	if wg != nil {
 		defer wg.Done()
 	}
+	defer ag.bucketsAcc.Close(ctx)
 
 	ctx = log.WithLogTag(ctx, "Agg", nil)
 	ctx, span := tracing.ChildSpan(ctx, "aggregator")
@@ -238,6 +240,10 @@ func (ag *aggregator) accumulateRows(ctx context.Context) (err error) {
 			return err
 		}
 
+		if err := ag.bucketsAcc.Grow(ctx, int64(len(encoded))); err != nil {
+			return err
+		}
+
 		ag.buckets[string(encoded)] = struct{}{}
 		// Feed the func holders for this bucket the non-grouping datums.
 		for i, colIdx := range ag.inputCols {
@@ -253,19 +259,23 @@ func (ag *aggregator) accumulateRows(ctx context.Context) (err error) {
 }
 
 type aggregateFuncHolder struct {
-	create  func(*parser.EvalContext) parser.AggregateFunc
-	group   *aggregator
-	buckets map[string]parser.AggregateFunc
-	seen    map[string]struct{}
+	create        func(*parser.EvalContext) parser.AggregateFunc
+	group         *aggregator
+	buckets       map[string]parser.AggregateFunc
+	seen          map[string]struct{}
+	bucketsMemAcc *mon.BoundAccount
 }
+
+const sizeOfAggregateFunc = int64(unsafe.Sizeof(parser.AggregateFunc(nil)))
 
 func (ag *aggregator) newAggregateFuncHolder(
 	create func(*parser.EvalContext) parser.AggregateFunc,
 ) *aggregateFuncHolder {
 	return &aggregateFuncHolder{
-		create:  create,
-		group:   ag,
-		buckets: make(map[string]parser.AggregateFunc),
+		create:        create,
+		group:         ag,
+		buckets:       make(map[string]parser.AggregateFunc),
+		bucketsMemAcc: &ag.bucketsAcc,
 	}
 }
 
@@ -279,12 +289,25 @@ func (a *aggregateFuncHolder) add(ctx context.Context, bucket []byte, d parser.D
 			// skip
 			return nil
 		}
+		if err := a.bucketsMemAcc.Grow(ctx, int64(len(encoded))); err != nil {
+			return err
+		}
 		a.seen[string(encoded)] = struct{}{}
 	}
 
 	impl, ok := a.buckets[string(bucket)]
 	if !ok {
+		// TODO(radu): we should account for the size of impl (this needs to be done
+		// in each aggregate constructor).
 		impl = a.create(&a.group.flowCtx.evalCtx)
+		usage := int64(len(bucket))
+		usage += sizeOfAggregateFunc
+		// TODO(radu): this model of each func having a map of buckets (one per
+		// group) for each func plus a global map is very wasteful. We should have a
+		// single map that stores all the AggregateFuncs.
+		if err := a.bucketsMemAcc.Grow(ctx, usage); err != nil {
+			return err
+		}
 		a.buckets[string(bucket)] = impl
 	}
 

--- a/pkg/sql/testdata/logic_test/distsql_agg
+++ b/pkg/sql/testdata/logic_test/distsql_agg
@@ -393,3 +393,6 @@ query I
 SELECT COUNT(*) FROM one AS a, one AS b, two AS c
 ----
 1000
+
+statement error memory budget exceeded
+SELECT SUM(d1.a), MAX(d1.a), MIN(d1.a) FROM data as d1, data as d2 GROUP BY (d1.b, d1.c, d1.d, d2.a, d2.b, d2.c, d2.d)


### PR DESCRIPTION
Accounting for memory used by the aggregator structures. We don't account for
the AggregateFunc implementations themselves (it needs to be plumbed to them,
the classic SQL path doesn't account for them either).