### PR TITLE
sql: construct proper index spans in the presence of tuples with NULL

### DIFF
--- a/pkg/sql/parser/datum_test.go
+++ b/pkg/sql/parser/datum_test.go
@@ -121,7 +121,7 @@ func TestDatumOrdering(t *testing.T) {
 
 		{`row(true, false, false)`, `(false, true, true)`, `(true, false, true)`,
 			`(false, false, false)`, `(true, true, true)`},
-		{`row(false, true, true)`, `(false, true, false)`, `(true, false, false)`,
+		{`row(false, true, true)`, `(false, true, false)`, `(true, NULL, NULL)`,
 			`(false, false, false)`, `(true, true, true)`},
 
 		{`row(0, 0)`, `(0, -1)`, `(0, 1)`,
@@ -129,7 +129,7 @@ func TestDatumOrdering(t *testing.T) {
 			`(9223372036854775807, 9223372036854775807)`},
 
 		{`row(0, 9223372036854775807)`,
-			`(0, 9223372036854775806)`, `(1, -9223372036854775808)`,
+			`(0, 9223372036854775806)`, `(1, NULL)`,
 			`(-9223372036854775808, -9223372036854775808)`,
 			`(9223372036854775807, 9223372036854775807)`},
 		{`row(9223372036854775807, 9223372036854775807)`,
@@ -154,12 +154,12 @@ func TestDatumOrdering(t *testing.T) {
 
 		{`row(true, NULL, false)`, `(false, NULL, true)`, `(true, NULL, true)`,
 			`(false, NULL, false)`, `(true, NULL, true)`},
-		{`row(false, NULL, true)`, `(false, NULL, false)`, `(true, NULL, false)`,
+		{`row(false, NULL, true)`, `(false, NULL, false)`, `(true, NULL, NULL)`,
 			`(false, NULL, false)`, `(true, NULL, true)`},
 
 		{`row(row(true), row(false))`, `((false), (true))`, `((true), (true))`,
 			`((false), (false))`, `((true), (true))`},
-		{`row(row(false), row(true))`, `((false), (false))`, `((true), (false))`,
+		{`row(row(false), row(true))`, `((false), (false))`, `((true), NULL)`,
 			`((false), (false))`, `((true), (true))`},
 
 		// Arrays
@@ -172,7 +172,7 @@ func TestDatumOrdering(t *testing.T) {
 		{`array[true]`, noPrev, `ARRAY[true,NULL]`, `ARRAY[]`, noMax},
 
 		// Mixed tuple/array datums.
-		{`row(ARRAY[true], row(true))`, `(ARRAY[true], (false))`, `(ARRAY[true,NULL], (false))`,
+		{`row(ARRAY[true], row(true))`, `(ARRAY[true], (false))`, `(ARRAY[true,NULL], NULL)`,
 			`(ARRAY[], (false))`, noMax},
 		{`row(row(false), ARRAY[true])`, noPrev, `((false), ARRAY[true,NULL])`,
 			`((false), ARRAY[])`, noMax},

--- a/pkg/sql/testdata/logic_test/select_index
+++ b/pkg/sql/testdata/logic_test/select_index
@@ -464,3 +464,61 @@ EXPLAIN (VERBOSE) SELECT k FROM tab0 WHERE (a IN (6) AND a > 6) OR b >= 4
 query I
 SELECT k FROM tab0 WHERE (a IN (6) AND a > 6) OR b >= 4
 ----
+
+# Regression tests for #12022
+
+statement ok
+CREATE TABLE t12022 (
+  c1 INT,
+  c2 BOOL,
+  UNIQUE INDEX i (c1, c2)
+);
+
+statement ok
+INSERT INTO t12022 VALUES
+  (1, NULL), (1, false), (1, true),
+  (2, NULL), (2, false), (2, true);
+
+query IB
+SELECT * FROM t12022@i WHERE (c1, c2) > (1, NULL) ORDER BY (c1, c2);
+----
+2  NULL
+2  false
+2  true
+
+query IB
+SELECT * FROM t12022@i WHERE (c1, c2) > (1, false) ORDER BY (c1, c2);
+----
+1  true
+2  NULL
+2  false
+2  true
+
+query IB
+SELECT * FROM t12022@i WHERE (c1, c2) > (1, true) ORDER BY (c1, c2);
+----
+2  NULL
+2  false
+2  true
+
+query IB
+SELECT * FROM t12022@i WHERE (c1, c2) < (2, NULL) ORDER BY (c1, c2);
+----
+1  NULL
+1  false
+1  true
+
+query IB
+SELECT * FROM t12022@i WHERE (c1, c2) < (2, false) ORDER BY (c1, c2);
+----
+1  NULL
+1  false
+1  true
+
+query IB
+SELECT * FROM t12022@i WHERE (c1, c2) < (2, true) ORDER BY (c1, c2);
+----
+1  NULL
+1  false
+1  true
+2  false


### PR DESCRIPTION
This is a temporary solution to #12022. The permanent fix should wait
for a SQL intermediate representation and the attendant rewrite of the
index selection code.