### PR TITLE
storage, settings, server: move 3 env variables to settings

### DIFF
--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -151,10 +151,6 @@ func TestReadEnvironmentVariables(t *testing.T) {
 		t.Fatal(err)
 	}
 	cfgExpected.ConsistencyCheckPanicOnFailure = true
-	if err := os.Setenv("COCKROACH_TIME_UNTIL_STORE_DEAD", "10ms"); err != nil {
-		t.Fatal(err)
-	}
-	cfgExpected.TimeUntilStoreDead = time.Millisecond * 10
 
 	envutil.ClearEnvCache()
 	cfg.readEnvironmentVariables()

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
@@ -111,7 +112,7 @@ func createTestNode(
 		cfg.Gossip,
 		cfg.Clock,
 		storage.MakeStorePoolNodeLivenessFunc(cfg.NodeLiveness),
-		storage.TestTimeUntilStoreDead,
+		settings.TestingDuration(time.Millisecond*10),
 		/* deterministic */ false,
 	)
 	node := NewNode(cfg, status.NewMetricsRecorder(cfg.Clock), metric.NewRegistry(), stopper,

--- a/pkg/settings/duration.go
+++ b/pkg/settings/duration.go
@@ -75,6 +75,18 @@ func RegisterDurationSetting(key, desc string, defaultValue time.Duration) *Dura
 	return RegisterValidatedDurationSetting(key, desc, defaultValue, nil)
 }
 
+// RegisterPositiveDurationSetting defines a new setting with type duration.
+func RegisterPositiveDurationSetting(
+	key, desc string, defaultValue time.Duration,
+) *DurationSetting {
+	return RegisterValidatedDurationSetting(key, desc, defaultValue, func(v time.Duration) error {
+		if v < 0 {
+			return errors.Errorf("cannot set %s to a negative duration: %s", key, v)
+		}
+		return nil
+	})
+}
+
 // RegisterValidatedDurationSetting defines a new setting with type duration.
 func RegisterValidatedDurationSetting(
 	key, desc string, defaultValue time.Duration, validateFn func(time.Duration) error,

--- a/pkg/settings/duration.go
+++ b/pkg/settings/duration.go
@@ -113,3 +113,9 @@ func TestingSetDuration(s **DurationSetting, v time.Duration) func() {
 		*s = saved
 	}
 }
+
+// TestingDuration returns a one off, unregistered duration setting for test use
+// only.
+func TestingDuration(v time.Duration) *DurationSetting {
+	return &DurationSetting{v: int64(v)}
+}

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -46,13 +46,7 @@ var strVal = settings.RegisterValidatedStringSetting(
 		}
 		return nil
 	})
-var dVal = settings.RegisterValidatedDurationSetting(
-	"dVal", "", time.Second, func(v time.Duration) error {
-		if v < 0 {
-			return errors.Errorf("duration cannot be negative")
-		}
-		return nil
-	})
+var dVal = settings.RegisterPositiveDurationSetting("dVal", "", time.Second)
 var byteSizeVal = settings.RegisterValidatedByteSizeSetting(
 	"byteSize.Val", "", mb, func(v int64) error {
 		if v < 0 {
@@ -338,7 +332,7 @@ func TestCache(t *testing.T) {
 		{
 			u := settings.MakeUpdater()
 			if err := u.Set("dVal", settings.EncodeDuration(-time.Hour), "d"); !testutils.IsError(err,
-				"duration cannot be negative",
+				"cannot set dVal to a negative duration: -1h0m0s",
 			) {
 				t.Fatal(err)
 			}

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/gossiputil"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -2208,7 +2209,7 @@ func Example_rebalancing() {
 		g,
 		clock,
 		newMockNodeLiveness(nodeStatusLive).nodeLivenessFunc,
-		TestTimeUntilStoreDeadOff,
+		settings.TestingDuration(TestTimeUntilStoreDeadOff),
 		/* deterministic */ true,
 	)
 	alloc := MakeAllocator(sp, func(string) (time.Duration, bool) {

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
@@ -666,7 +667,7 @@ func (m *multiTestContext) populateStorePool(idx int, nodeLiveness *storage.Node
 		m.gossips[idx],
 		m.clock,
 		storage.MakeStorePoolNodeLivenessFunc(nodeLiveness),
-		m.timeUntilStoreDead,
+		settings.TestingDuration(m.timeUntilStoreDead),
 		/* deterministic */ false,
 	)
 }
@@ -1002,7 +1003,7 @@ func (m *multiTestContext) changeReplicasLocked(
 		}
 
 		if _, ok := errors.Cause(err).(*roachpb.AmbiguousResultError); ok {
-			// Try again after an AmbigousResultError. If the operation
+			// Try again after an AmbiguousResultError. If the operation
 			// succeeded, then the next attempt will return alreadyDoneErr;
 			// if it failed then the next attempt should succeed.
 			continue

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
@@ -217,7 +218,7 @@ func NewTestStorePool(cfg StoreConfig) *StorePool {
 		func(roachpb.NodeID, time.Time, time.Duration) nodeStatus {
 			return nodeStatusLive
 		},
-		TestTimeUntilStoreDeadOff,
+		settings.TestingDuration(TestTimeUntilStoreDeadOff),
 		/* deterministic */ false,
 	)
 }

--- a/pkg/storage/store_pool_test.go
+++ b/pkg/storage/store_pool_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/testutils/gossiputil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -88,7 +89,7 @@ func (m *mockNodeLiveness) nodeLivenessFunc(
 // createTestStorePool creates a stopper, gossip and storePool for use in
 // tests. Stopper must be stopped by the caller.
 func createTestStorePool(
-	timeUntilStoreDead time.Duration, deterministic bool, defaultNodeStatus nodeStatus,
+	timeUntilStoreDeadValue time.Duration, deterministic bool, defaultNodeStatus nodeStatus,
 ) (*stop.Stopper, *gossip.Gossip, *hlc.ManualClock, *StorePool, *mockNodeLiveness) {
 	stopper := stop.NewStopper()
 	mc := hlc.NewManualClock(123)
@@ -102,7 +103,7 @@ func createTestStorePool(
 		g,
 		clock,
 		mnl.nodeLivenessFunc,
-		timeUntilStoreDead,
+		settings.TestingDuration(timeUntilStoreDeadValue),
 		deterministic,
 	)
 	return stopper, g, mc, storePool, mnl

--- a/pkg/storage/store_pool_test.go
+++ b/pkg/storage/store_pool_test.go
@@ -449,7 +449,7 @@ func TestStorePoolThrottle(t *testing.T) {
 	sg.GossipStores(uniqueStore, t)
 
 	{
-		expected := sp.clock.Now().GoTime().Add(sp.declinedReservationsTimeout)
+		expected := sp.clock.Now().GoTime().Add(declinedReservationsTimeout.Get())
 		sp.throttle(throttleDeclined, 1)
 
 		sp.detailsMu.Lock()
@@ -462,7 +462,7 @@ func TestStorePoolThrottle(t *testing.T) {
 	}
 
 	{
-		expected := sp.clock.Now().GoTime().Add(sp.failedReservationsTimeout)
+		expected := sp.clock.Now().GoTime().Add(failedReservationsTimeout.Get())
 		sp.throttle(throttleFailed, 1)
 
 		sp.detailsMu.Lock()

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -2242,7 +2242,7 @@ func TestStoreRemovePlaceholderOnError(t *testing.T) {
 
 // Test that we remove snapshot placeholders when raft ignores the
 // snapshot. This is testing the removal of placeholder after handleRaftReady
-// processing for an unitialized Replica.
+// processing for an uninitialized Replica.
 func TestStoreRemovePlaceholderOnRaftIgnored(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
@@ -2507,7 +2507,7 @@ func TestSendSnapshotThrottling(t *testing.T) {
 	}
 	newBatch := e.NewBatch
 
-	// Test that a failed Recv() fauses a fail throttle
+	// Test that a failed Recv() causes a fail throttle
 	{
 		sp := &fakeStorePool{}
 		expectedErr := errors.New("")

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -143,7 +144,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initSende
 		cfg.Gossip,
 		cfg.Clock,
 		storage.MakeStorePoolNodeLivenessFunc(cfg.NodeLiveness),
-		storage.TestTimeUntilStoreDead,
+		settings.TestingDuration(storage.TestTimeUntilStoreDead),
 		/* deterministic */ false,
 	)
 	cfg.Transport = transport


### PR DESCRIPTION
Only look at the 3rd and 4th commit.  The other two are in #15581.  Do not merge this until after that has been merged. 

- storage, settings: convert 2 env variables to settings
Converted declinedReservationsTimeout and failedReservationsTimeout to env variables.
Added a RegisterPositiveDurationSetting to settings, since this will be the most common use case for validated durations.

- storage, server: convert time_until_store_dead to a setting
Fixes #13602.