### PR TITLE
build: improve source archives

### DIFF
--- a/build/archive/contents/Makefile
+++ b/build/archive/contents/Makefile
@@ -1,2 +1,12 @@
-all build buildoss install test:
+prefix := /usr/local
+bindir := $(prefix)/bin
+INSTALL := install
+
+.PHONY: all build buildoss test
+all build buildoss test:
 	$(MAKE) -C src/github.com/cockroachdb/cockroach $@
+
+.PHONY: install
+install: build
+	$(INSTALL) -d -m 755 $(DESTDIR)$(bindir)
+	$(INSTALL) -m 755 src/github.com/cockroachdb/cockroach/cockroach $(DESTDIR)$(bindir)

--- a/build/archive/contents/Makefile
+++ b/build/archive/contents/Makefile
@@ -1,2 +1,2 @@
-all build buildoss install:
+all build buildoss install test:
 	$(MAKE) -C src/github.com/cockroachdb/cockroach $@

--- a/build/archive/contents/Makefile
+++ b/build/archive/contents/Makefile
@@ -1,4 +1,2 @@
-GOPATH := $(CURDIR)
-
 all build buildoss install:
 	$(MAKE) -C src/github.com/cockroachdb/cockroach $@

--- a/build/archive/contents/README
+++ b/build/archive/contents/README
@@ -22,8 +22,9 @@ To install CockroachDB onto your PATH:
 
 To interact with a one-node SQL cluster:
 
-     $ ./cockroach start --background
-     $ ./cockroach sql
+     $ cockroach start --background --insecure
+     $ cockroach sql --insecure
+     $ cockroach quit --insecure
 
 Next steps:
 

--- a/build/archive/contents/README
+++ b/build/archive/contents/README
@@ -11,14 +11,9 @@ To build CockroachDB from this source archive:
 See src/github.com/cockroachdb/cockroach/CONTRIBUTING.md for a complete list of
 build requirements.
 
-To install CockroachDB to ./bin/cockroach:
+To install CockroachDB as /usr/local/bin/cockroach:
 
      $ make install
-
-To install CockroachDB onto your PATH:
-
-     $ make install
-     $ sudo cp -i ./bin/cockroach /usr/local/bin/cockroach
 
 To interact with a one-node SQL cluster:
 

--- a/build/teamcity-verify-archive.sh
+++ b/build/teamcity-verify-archive.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+build/builder.sh make archive ARCHIVE=build/cockroach.src.tgz
+
+# We use test the source archive in a minimal image; the builder image bundles
+# too much developer configuration to simulate a build on a fresh user machine.
+docker run \
+  --volume="$(cd "$(dirname "$0")" && pwd):/work" \
+  --workdir="/work" \
+  golang:1.8.1 ./verify-archive.sh

--- a/build/verify-archive.sh
+++ b/build/verify-archive.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# This script sanity-checks a source tarball, assuming a Debian-based Linux
+# environment with a Go version capable of building CockroachDB. Source tarballs
+# are expected to build and install a functional cockroach binary into the PATH,
+# even when the tarball is extracted outside of GOPATH.
+
+set -euo pipefail
+
+apt-get update
+apt-get install -y cmake xz-utils
+
+tar xzf cockroach.src.tgz
+(cd cockroach-* && make install)
+
+cockroach start --insecure --store type=mem,size=1GiB --background
+cockroach sql --insecure <<EOF | diff <(echo $'1 row\nid	balance\n1	1000.50') -
+  CREATE DATABASE bank; \
+  CREATE TABLE bank.accounts (id INT PRIMARY KEY, balance DECIMAL); \
+  INSERT INTO bank.accounts VALUES (1, 1000.50); \
+  SELECT * FROM bank.accounts;" \
+EOF
+cockroach quit --insecure


### PR DESCRIPTION
Teach source archives to install into `/usr/local/bin/cockroach` and (finally) add a basic test to catch future breakage.

@bdarnell: I feel like you might have thoughts on installing into `/usr/local/bin` instead of `$GOPATH/bin`.