### PR TITLE
distsql: fix hashjoiner mem accounting leak

### DIFF
--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -113,6 +113,7 @@ func (h *hashJoiner) Run(ctx context.Context, wg *sync.WaitGroup) {
 	}
 
 	defer h.bucketsAcc.Close(ctx)
+	defer h.rows.Close(ctx)
 
 	moreRows, err := h.buildPhase(ctx)
 	if err != nil {

--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -486,6 +486,7 @@ func TestHashJoiner(t *testing.T) {
 	}
 
 	monitor := mon.MakeUnlimitedMonitor(context.Background(), "test", nil, nil, math.MaxInt64)
+	defer monitor.Stop(context.Background())
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
 			hs := c.spec
@@ -599,6 +600,7 @@ func TestHashJoinerDrain(t *testing.T) {
 		nil /* types */, nil, /* rows */
 		RowBufferArgs{AccumulateRowsWhileDraining: true})
 	monitor := mon.MakeUnlimitedMonitor(context.Background(), "test", nil, nil, math.MaxInt64)
+	defer monitor.Stop(context.Background())
 	flowCtx := FlowCtx{evalCtx: parser.EvalContext{Mon: &monitor}}
 
 	post := PostProcessSpec{Projection: true, OutputColumns: outCols}
@@ -707,6 +709,7 @@ func TestHashJoinerDrainAfterBuildPhaseError(t *testing.T) {
 		nil /* types */, nil, /* rows */
 		RowBufferArgs{})
 	monitor := mon.MakeUnlimitedMonitor(context.Background(), "test", nil, nil, math.MaxInt64)
+	defer monitor.Stop(context.Background())
 	flowCtx := FlowCtx{evalCtx: parser.EvalContext{Mon: &monitor}}
 
 	post := PostProcessSpec{Projection: true, OutputColumns: outCols}

--- a/pkg/sql/distsqlrun/sorter_test.go
+++ b/pkg/sql/distsqlrun/sorter_test.go
@@ -171,6 +171,7 @@ func TestSorter(t *testing.T) {
 	}
 
 	monitor := mon.MakeUnlimitedMonitor(context.Background(), "test", nil, nil, math.MaxInt64)
+	defer monitor.Stop(context.Background())
 	for _, c := range testCases {
 		ss := c.spec
 		types := make([]sqlbase.ColumnType, len(c.input[0]))


### PR DESCRIPTION
Fix mem accounting leak in hash joiner and fix the tests to stop the monitor (which panics if there are leaks).