### PR TITLE
sql: fix panic in constant typechecking

### DIFF
--- a/pkg/sql/testdata/logic_test/typing
+++ b/pkg/sql/testdata/logic_test/typing
@@ -140,3 +140,21 @@ CREATE TABLE t15050a (c DECIMAL DEFAULT CASE WHEN NOW() < '2017-04-18 18:00' THE
 
 statement error error type checking constant value: could not parse '2017-04-18 18:00' as type timestamp
 CREATE TABLE t15050b (c DECIMAL DEFAULT IF(NOW() < '2017-04-18 18:00', 2, 2));
+
+# Regression tests for #15632
+
+statement error incompatible IFNULL expressions: could not parse 'foo' as type bool: strconv.ParseBool: parsing "foo": invalid syntax
+SELECT IFNULL('foo', false)
+
+statement error incompatible IFNULL expressions: could not parse 'foo' as type bool: strconv.ParseBool: parsing "foo": invalid syntax
+SELECT IFNULL(true, 'foo')
+
+query B
+SELECT IFNULL(false, 'true')
+----
+false
+
+query B
+SELECT IFNULL('true', false)
+----
+true


### PR DESCRIPTION
Previously, when typechecking a list of same-typed expressions that were
all constants that could resolve to a desired type `T`, a failure to
parse one of the constants as `T` would produce a server panic. This is
invalid behavior - just because a constant can become a type does not
mean that it can *always* become a type. For instance, strings can
become booleans, but they can only be parsed as booleans when they're a
valid boolean string (e.g. `'true'`, `'t'`).

Now, instead of panicking, the parsing error is properly bubbled up.

Fixes #15632.