### PR TITLE
sql: prepared statements cache parsed query

### DIFF
--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -793,8 +793,7 @@ func (c *cliState) doPrepareStatementLine(
 
 func (c *cliState) doCheckStatement(startState, contState, execState cliStateEnum) cliStateEnum {
 	// From here on, client-side syntax checking is enabled.
-	var p parser.Parser
-	parsedStmts, err := p.Parse(c.concatLines)
+	parsedStmts, err := parser.Parse(c.concatLines)
 	if err != nil {
 		_ = c.invalidSyntax(0, "statement ignored: %v", err)
 

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -247,9 +247,9 @@ func TestReportUsage(t *testing.T) {
 		"": {
 			`CREATE DATABASE _`,
 			`CREATE TABLE _ (_ INT, CONSTRAINT _ CHECK (_ > _))`,
-			`INSERT INTO _ VALUES (length(_::STRING))`,
+			`INSERT INTO _ VALUES (length($1::STRING))`,
 			`INSERT INTO _ VALUES (_)`,
-			`SELECT * FROM _ WHERE (_ = length(_::STRING)) OR (_ = $2)`,
+			`SELECT * FROM _ WHERE (_ = length($1::STRING)) OR (_ = $2)`,
 			`SELECT * FROM _ WHERE (_ = _) AND (_ = _)`,
 		},
 		elemName: {

--- a/pkg/sql/analyze.go
+++ b/pkg/sql/analyze.go
@@ -1621,6 +1621,7 @@ func makeIsNotNull(left parser.TypedExpr) parser.TypedExpr {
 // analyzeExpr performs semantic analysis of an expression, including:
 // - replacing sub-queries by a sql.subquery node;
 // - resolving names (optional);
+// - replacing placeholders by their value;
 // - type checking (with optional type enforcement);
 // - normalization.
 // The parameters sources and IndexedVars, if both are non-nil, indicate

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -588,7 +588,6 @@ func (e *Executor) execRequest(
 	} else if copymsg != copyMsgNone {
 		err = fmt.Errorf("unexpected copy command")
 	} else {
-		var parser parser.Parser
 		stmts, err = parser.Parse(sql)
 	}
 	session.phaseTimes[sessionEndParse] = timeutil.Now()

--- a/pkg/sql/parser/col_types.go
+++ b/pkg/sql/parser/col_types.go
@@ -466,6 +466,13 @@ func DatumTypeToColumnType(t Type) (ColumnType, error) {
 		if typ, ok := t.(TCollatedString); ok {
 			return &CollatedStringColType{Name: "STRING", Locale: typ.Locale}, nil
 		}
+		if typ, ok := t.(TArray); ok {
+			elemTyp, err := DatumTypeToColumnType(typ.Typ)
+			if err != nil {
+				return nil, err
+			}
+			return arrayOf(elemTyp, Exprs(nil))
+		}
 	}
 	return nil, errors.Errorf("value type %s cannot be used for table columns", t)
 }

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -78,6 +78,9 @@ func TypeCheck(expr Expr, ctx *SemaContext, desired Type) (TypedExpr, error) {
 	if desired == nil {
 		panic("the desired type for parser.TypeCheck cannot be nil, use TypeAny instead")
 	}
+
+	expr = replacePlaceholders(expr, ctx)
+
 	expr, err := foldConstantLiterals(expr)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -117,15 +117,16 @@ func (p *Parser) NormalizeExpr(ctx *EvalContext, typedExpr TypedExpr) (TypedExpr
 	return expr.(TypedExpr), nil
 }
 
-// parse parses the sql and returns a list of statements.
-func parse(sql string) (StatementList, error) {
+// Parse parses a sql statement string and returns a list of Statements.
+func Parse(sql string) (StatementList, error) {
 	var p Parser
 	return p.Parse(sql)
 }
 
-// ParseOne parses a sql statement.
+// ParseOne parses a sql statement string, ensuring that it contains only a
+// single statement, and returns that Statement.
 func ParseOne(sql string) (Statement, error) {
-	stmts, err := parse(sql)
+	stmts, err := Parse(sql)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +149,7 @@ func ParseTableName(sql string) (*TableName, error) {
 	return rename.Name.Normalize()
 }
 
-// parseExprs parses one or more sql expression.
+// parseExprs parses one or more sql expressions.
 func parseExprs(exprs []string) (Exprs, error) {
 	stmt, err := ParseOne(fmt.Sprintf("SET ROW (%s)", strings.Join(exprs, ",")))
 	if err != nil {

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -676,7 +676,7 @@ func TestParse(t *testing.T) {
 		{`SET ROW (1, true, NULL)`},
 	}
 	for _, d := range testData {
-		stmts, err := parse(d.sql)
+		stmts, err := Parse(d.sql)
 		if err != nil {
 			t.Fatalf("%s: expected success, but found %s", d.sql, err)
 		}
@@ -920,7 +920,7 @@ func TestParse2(t *testing.T) {
 		{`SHOW ALL CLUSTER SETTINGS`, `SHOW CLUSTER SETTING all`},
 	}
 	for _, d := range testData {
-		stmts, err := parse(d.sql)
+		stmts, err := Parse(d.sql)
 		if err != nil {
 			t.Errorf("%s: expected success, but found %s", d.sql, err)
 			continue
@@ -929,7 +929,7 @@ func TestParse2(t *testing.T) {
 		if d.expected != s {
 			t.Errorf("%s: expected %s, but found (%d statements): %s", d.sql, d.expected, len(stmts), s)
 		}
-		if _, err := parse(s); err != nil {
+		if _, err := Parse(s); err != nil {
 			t.Errorf("expected string found, but not parsable: %s:\n%s", err, s)
 		}
 	}
@@ -948,7 +948,7 @@ func TestParseSyntax(t *testing.T) {
 		{`SELECT '\x' FROM t`},
 	}
 	for _, d := range testData {
-		if _, err := parse(d.sql); err != nil {
+		if _, err := Parse(d.sql); err != nil {
 			t.Fatalf("%s: expected success, but not parsable %s", d.sql, err)
 		}
 	}
@@ -1271,7 +1271,7 @@ SELECT 1 + ANY ARRAY[1, 2, 3]
 		},
 	}
 	for _, d := range testData {
-		_, err := parse(d.sql)
+		_, err := Parse(d.sql)
 		if err == nil || err.Error() != d.expected {
 			t.Errorf("%s: expected\n%s, but found\n%v", d.sql, d.expected, err)
 		}
@@ -1296,7 +1296,7 @@ func TestParsePanic(t *testing.T) {
 		"(F(F(F(F(F(F(F(F(F(F" +
 		"(F(F(F(F(F(F(F(F(F((" +
 		"F(0"
-	_, err := parse(s)
+	_, err := Parse(s)
 	expected := `syntax error at or near "EOF"`
 	if !testutils.IsError(err, expected) {
 		t.Fatalf("expected %s, but found %v", expected, err)
@@ -1491,7 +1491,7 @@ func TestParsePrecedence(t *testing.T) {
 
 func BenchmarkParse(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		st, err := parse(`
+		st, err := Parse(`
 			BEGIN;
 			UPDATE pgbench_accounts SET abalance = abalance + 77 WHERE aid = 5;
 			SELECT abalance FROM pgbench_accounts WHERE aid = 5;
@@ -1556,7 +1556,7 @@ func testEncodeString(t *testing.T, input []byte, encode func(*bytes.Buffer, str
 			t.Fatalf("unprintable character: %v (%v): %s %v", ch, input, sql, []byte(sql))
 		}
 	}
-	stmts, err := parse(sql)
+	stmts, err := Parse(sql)
 	if err != nil {
 		t.Fatalf("%s: expected success, but found %s", sql, err)
 	}

--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -733,12 +733,8 @@ func (expr *ArrayFlatten) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, 
 
 // TypeCheck implements the Expr interface.
 func (expr *Placeholder) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, error) {
-	// If there is a value known already, immediately substitute with it.
-	if v, ok := ctx.Placeholders.Value(expr.Name); ok {
-		return v, nil
-	}
-
-	// Otherwise, perform placeholder typing.
+	// Perform placeholder typing. This only happens during Prepare, when there
+	// are no available values for the placeholders yet.
 	if typ, ok := ctx.Placeholders.Type(expr.Name); ok {
 		expr.typ = typ
 		return expr, nil

--- a/pkg/sql/prepare.go
+++ b/pkg/sql/prepare.go
@@ -28,8 +28,9 @@ import (
 // PreparedStatement is a SQL statement that has been parsed and the types
 // of arguments and results have been determined.
 type PreparedStatement struct {
-	Query       string
-	Type        parser.StatementType
+	// Statement is the parsed, prepared SQL statement. It may be nil if the
+	// prepared statement is empty.
+	Statement   parser.Statement
 	SQLTypes    parser.PlaceholderTypes
 	Columns     sqlbase.ResultColumns
 	portalNames map[string]struct{}
@@ -65,16 +66,37 @@ func (ps PreparedStatements) Exists(name string) bool {
 	return ok
 }
 
+// NewFromString creates a new PreparedStatement with the provided name and
+// corresponding query string, using the given PlaceholderTypes hints to assist
+// in inferring placeholder types.
+//
+// ps.session.Ctx() is used as the logging context for the prepare operation.
+func (ps PreparedStatements) NewFromString(
+	e *Executor, name, query string, placeholderHints parser.PlaceholderTypes,
+) (*PreparedStatement, error) {
+	sessionEventf(ps.session, "parsing: %s", query)
+
+	stmts, err := parser.Parse(query)
+	if err != nil {
+		return nil, err
+	}
+	return ps.New(e, name, stmts, len(query), placeholderHints)
+}
+
 // New creates a new PreparedStatement with the provided name and corresponding
-// query string, using the given PlaceholderTypes hints to assist in inferring
-// placeholder types.
+// query statements, using the given PlaceholderTypes hints to assist in
+// inferring placeholder types.
 //
 // ps.session.Ctx() is used as the logging context for the prepare operation.
 func (ps PreparedStatements) New(
-	e *Executor, name, query string, placeholderHints parser.PlaceholderTypes,
+	e *Executor,
+	name string,
+	stmts parser.StatementList,
+	queryLen int,
+	placeholderHints parser.PlaceholderTypes,
 ) (*PreparedStatement, error) {
 	// Prepare the query. This completes the typing of placeholders.
-	stmt, err := e.Prepare(query, ps.session, placeholderHints)
+	stmt, err := e.Prepare(stmts, ps.session, placeholderHints)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +104,7 @@ func (ps PreparedStatements) New(
 	// For now we are just counting the size of the query string and
 	// statement name. When we start storing the prepared query plan
 	// during prepare, this should be tallied up to the monitor as well.
-	sz := int64(uintptr(len(query)+len(name)) + unsafe.Sizeof(*stmt))
+	sz := int64(uintptr(len(name)+queryLen) + unsafe.Sizeof(*stmt))
 	if err := stmt.memAcc.Wsession(ps.session).OpenAndInit(ps.session.Ctx(), sz); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Previously, prepared statements contained only the text of their query, causing them to be re-parsed at execution time.

Now, they contain a parsed query.

This improves throughput of `kv -read-percent=100 -concurrency=1` by about 15% on a local single-node cluster.

Updates #14927.