### PR TITLE
roachpb: make Export update the timestamp cache

### DIFF
--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -921,7 +921,7 @@ func (*ComputeChecksumRequest) flags() int          { return isWrite | isRange }
 func (*DeprecatedVerifyChecksumRequest) flags() int { return isWrite }
 func (*CheckConsistencyRequest) flags() int         { return isAdmin | isRange }
 func (*WriteBatchRequest) flags() int               { return isWrite | isRange }
-func (*ExportRequest) flags() int                   { return isRead | isRange }
+func (*ExportRequest) flags() int                   { return isRead | isRange | updatesTSCache }
 func (*ImportRequest) flags() int                   { return isAdmin | isAlone }
 func (*AdminScatterRequest) flags() int             { return isAdmin | isAlone | isRange }
 


### PR DESCRIPTION
I thought this was being done for me, but it's actually controlled by a
flag. Export is a read and needs to update the timestamp cache. Before
this change, Export could see stale reads which may have actually
happened in #15618.

For #15618.