### PR TITLE
build: stop creating files as root in verify-archive.sh

### DIFF
--- a/build/teamcity-verify-archive.sh
+++ b/build/teamcity-verify-archive.sh
@@ -7,6 +7,7 @@ build/builder.sh make archive ARCHIVE=build/cockroach.src.tgz
 # We use test the source archive in a minimal image; the builder image bundles
 # too much developer configuration to simulate a build on a fresh user machine.
 docker run \
+  --rm \
   --volume="$(cd "$(dirname "$0")" && pwd):/work" \
   --workdir="/work" \
   golang:1.8.1 ./verify-archive.sh

--- a/build/verify-archive.sh
+++ b/build/verify-archive.sh
@@ -10,8 +10,9 @@ set -euo pipefail
 apt-get update
 apt-get install -y cmake xz-utils
 
-tar xzf cockroach.src.tgz
-(cd cockroach-* && make install)
+workdir=$(mktemp -d)
+tar xzf cockroach.src.tgz -C "$workdir"
+(cd "$workdir"/cockroach-* && make install)
 
 cockroach start --insecure --store type=mem,size=1GiB --background
 cockroach sql --insecure <<EOF | diff <(echo $'1 row\nid	balance\n1	1000.50') -


### PR DESCRIPTION
If we build in a folder shared with the host, Go creates files in that
are owned by root. Use a temporary directory instead.