### PR TITLE
sql,distsql: close distsql memory monitor and aggregate accounts

### DIFF
--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -141,6 +141,13 @@ func (ag *aggregator) Run(ctx context.Context, wg *sync.WaitGroup) {
 		defer wg.Done()
 	}
 	defer ag.bucketsAcc.Close(ctx)
+	defer func() {
+		for _, f := range ag.funcs {
+			for _, aggFunc := range f.buckets {
+				aggFunc.Close(ctx)
+			}
+		}
+	}()
 
 	ctx = log.WithLogTag(ctx, "Agg", nil)
 	ctx, span := tracing.ChildSpan(ctx, "aggregator")

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -333,6 +333,8 @@ func (f *Flow) Cleanup(ctx context.Context) {
 	if f.status == FlowFinished {
 		panic("flow cleanup called twice")
 	}
+	// This closes the account and monitor opened in ServerImpl.setupFlow
+	f.evalCtx.Mon.Stop(ctx)
 	if log.V(1) {
 		log.Infof(ctx, "cleaning up")
 	}


### PR DESCRIPTION
Subset of the changes in #15402, closes the memory monitor used by
distsql and also makes sure that the accounts used for aggregations are
closed properly.

Creating the `EvalContext` was losing the reference to the MemoryMonitor,
I asked @jordanlewis and he thinks using the existing one is fine.