### PR TITLE
security: persist certificate loading errors

### DIFF
--- a/pkg/base/config_test.go
+++ b/pkg/base/config_test.go
@@ -28,7 +28,7 @@ import (
 func TestClientSSLSettings(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	const clientCertNotFound = "no client certificate found for user .*"
+	const clientCertNotFound = "problem with client cert for user .*: not found"
 	const certDirNotFound = "problem loading certs directory"
 
 	testCases := []struct {

--- a/pkg/cli/cert.go
+++ b/pkg/cli/cert.go
@@ -170,20 +170,48 @@ func runListCerts(cmd *cobra.Command, args []string) error {
 
 	fmt.Fprintf(os.Stdout, "Certificate directory: %s\n", baseCfg.SSLCertsDir)
 
-	certTableHeaders := []string{"Usage", "Certificate File", "Key File", "Notes"}
+	certTableHeaders := []string{"Usage", "Certificate File", "Key File", "Notes", "Error"}
 	var rows [][]string
 
 	if ca := cm.CACert(); ca != nil {
-		rows = append(rows, []string{ca.FileUsage.String(), ca.Filename, ca.KeyFilename, ""})
+		var errString string
+		if ca.Error != nil {
+			errString = ca.Error.Error()
+		}
+		rows = append(rows, []string{
+			ca.FileUsage.String(),
+			ca.Filename,
+			ca.KeyFilename,
+			"",
+			errString,
+		})
 	}
 
 	if node := cm.NodeCert(); node != nil {
-		rows = append(rows, []string{node.FileUsage.String(), node.Filename, node.KeyFilename, ""})
+		var errString string
+		if node.Error != nil {
+			errString = node.Error.Error()
+		}
+		rows = append(rows, []string{
+			node.FileUsage.String(),
+			node.Filename,
+			node.KeyFilename,
+			"",
+			errString,
+		})
 	}
 
 	for name, cert := range cm.ClientCerts() {
-		rows = append(rows, []string{cert.FileUsage.String(), cert.Filename, cert.KeyFilename,
-			fmt.Sprintf("user=%s", name)})
+		var errString string
+		if cert.Error != nil {
+			errString = cert.Error.Error()
+		}
+		rows = append(rows, []string{cert.FileUsage.String(),
+			cert.Filename,
+			cert.KeyFilename,
+			fmt.Sprintf("user=%s", name),
+			errString,
+		})
 	}
 
 	return printQueryOutput(os.Stdout, certTableHeaders, newRowSliceIter(rows), "", cliCtx.tableDisplayFormat)


### PR DESCRIPTION
We used to skip over bad certs/keys and only log to stderr.
Instead, keep the CertInfo but store the error in it.

This means that those errors are now surfaced all the way back to the
log.Shout calls.

eg: starting the server with wrong permissions on a key now logs the
following to stdout:
```
$ cockroach start*
* ERROR: failed to start server: problem using security settings, did
you mean to use --insecure?: problem with node certificate: key file
/home/marc/.cockroach-certs/node.key has permissions -rwxrwxrwx, exceeds
-rwx------
*
Failed running "start"
```