### PR TITLE
distsql: blacklist REPEAT for distsql

### DIFF
--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -428,8 +428,9 @@ var Builtins = map[string][]Builtin{
 
 	"repeat": {
 		Builtin{
-			Types:      ArgTypes{{"input", TypeString}, {"repeat_counter", TypeInt}},
-			ReturnType: fixedReturnType(TypeString),
+			Types:            ArgTypes{{"input", TypeString}, {"repeat_counter", TypeInt}},
+			distsqlBlacklist: true,
+			ReturnType:       fixedReturnType(TypeString),
 			fn: func(_ *EvalContext, args Datums) (_ Datum, err error) {
 				s := string(MustBeDString(args[0]))
 				count := int(MustBeDInt(args[1]))


### PR DESCRIPTION
Stopgap fix until #15402, REPEAT has the potential to allocate a large
amount of memory, and if such a query is run over DistSQL it can crash
some or all of the nodes in a cluster.