### PR TITLE
build: don't build snappy's gtest

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -378,7 +378,7 @@ $(SNAPPY_DIR)/Makefile: $(C_DEPS_DIR)/snappy-rebuild $(SNAPPY_SRC_DIR)/.extracte
 	mkdir -p $(SNAPPY_DIR)
 	@# NOTE: If you change the configure flags below, bump the version in
 	@# $(C_DEPS_DIR)/snappy-rebuild. See above for rationale.
-	cd $(SNAPPY_DIR) && $(SNAPPY_SRC_DIR)/configure $(CONFIGURE_FLAGS) --disable-shared
+	cd $(SNAPPY_DIR) && $(SNAPPY_SRC_DIR)/configure $(CONFIGURE_FLAGS) --disable-shared --disable-gtest
 
 # We mark C and C++ dependencies as .PHONY (or .ALWAYS_REBUILD) to avoid
 # having to name the artifact (for .PHONY), which can vary by platform, and so

--- a/c-deps/snappy-rebuild
+++ b/c-deps/snappy-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing snappy configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-1
+2


### PR DESCRIPTION
The gtest that our version of snappy ships doesn't compile on OpenBSD.
Since we don't run snappy's test suite, there's no harm in disabling
gtest completely.