### PR TITLE
settings: Add validation to LeaseRebalancingAggressiveness

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -62,7 +62,7 @@ const (
 	productionSettingsWebpage = "please see https://www.cockroachlabs.com/docs/recommended-production-settings.html for more details"
 )
 
-var timeUntilStoreDead = settings.RegisterPositiveDurationSetting(
+var timeUntilStoreDead = settings.RegisterNonNegativeDurationSetting(
 	"server.time_until_store_dead",
 	"the time after which if there is no new gossiped information about a store, it is considered dead",
 	5*time.Minute)

--- a/pkg/settings/duration.go
+++ b/pkg/settings/duration.go
@@ -75,8 +75,8 @@ func RegisterDurationSetting(key, desc string, defaultValue time.Duration) *Dura
 	return RegisterValidatedDurationSetting(key, desc, defaultValue, nil)
 }
 
-// RegisterPositiveDurationSetting defines a new setting with type duration.
-func RegisterPositiveDurationSetting(
+// RegisterNonNegativeDurationSetting defines a new setting with type duration.
+func RegisterNonNegativeDurationSetting(
 	key, desc string, defaultValue time.Duration,
 ) *DurationSetting {
 	return RegisterValidatedDurationSetting(key, desc, defaultValue, func(v time.Duration) error {

--- a/pkg/settings/float.go
+++ b/pkg/settings/float.go
@@ -92,6 +92,16 @@ func RegisterValidatedFloatSetting(
 	return setting
 }
 
+// RegisterNonNegativeFloatSetting defines a new setting with type float.
+func RegisterNonNegativeFloatSetting(key, desc string, defaultValue float64) *FloatSetting {
+	return RegisterValidatedFloatSetting(key, desc, defaultValue, func(v float64) error {
+		if v < 0 {
+			return errors.Errorf("cannot set %s to a negative value: %f", key, v)
+		}
+		return nil
+	})
+}
+
 // TestingSetFloat returns a mock, unregistered float setting for testing. See
 // TestingSetBool for more details.
 func TestingSetFloat(s **FloatSetting, v float64) func() {

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -46,7 +46,7 @@ var strVal = settings.RegisterValidatedStringSetting(
 		}
 		return nil
 	})
-var dVal = settings.RegisterPositiveDurationSetting("dVal", "", time.Second)
+var dVal = settings.RegisterNonNegativeDurationSetting("dVal", "", time.Second)
 var byteSizeVal = settings.RegisterValidatedByteSizeSetting(
 	"byteSize.Val", "", mb, func(v int64) error {
 		if v < 0 {

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -47,17 +47,11 @@ var strVal = settings.RegisterValidatedStringSetting(
 		return nil
 	})
 var dVal = settings.RegisterNonNegativeDurationSetting("dVal", "", time.Second)
+var fVal = settings.RegisterNonNegativeFloatSetting("fVal", "", 5.4)
 var byteSizeVal = settings.RegisterValidatedByteSizeSetting(
 	"byteSize.Val", "", mb, func(v int64) error {
 		if v < 0 {
 			return errors.Errorf("bytesize cannot be negative")
-		}
-		return nil
-	})
-var fVal = settings.RegisterValidatedFloatSetting(
-	"fVal", "", 5.4, func(v float64) error {
-		if v < 0 {
-			return errors.Errorf("float cannot be negative")
 		}
 		return nil
 	})
@@ -360,7 +354,7 @@ func TestCache(t *testing.T) {
 		{
 			u := settings.MakeUpdater()
 			if err := u.Set("fVal", settings.EncodeFloat(-1.1), "f"); !testutils.IsError(err,
-				"float cannot be negative",
+				"cannot set fVal to a negative value: -1.1",
 			) {
 				t.Fatal(err)
 			}

--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -78,9 +78,7 @@ var (
 	//
 	// Setting this to 0 effectively disables load-based lease rebalancing, and
 	// settings less than 0 are disallowed.
-	//
-	// TODO(a-robinson): How can we enforce this isn't set to less than 0?
-	LeaseRebalancingAggressiveness = settings.RegisterFloatSetting(
+	LeaseRebalancingAggressiveness = settings.RegisterNonNegativeFloatSetting(
 		"kv.allocator.lease_rebalancing_aggressiveness",
 		"set greater than 1.0 to rebalance leases toward load more aggressively, "+
 			"or between 0 and 1.0 to be more conservative about rebalancing leases",

--- a/pkg/storage/store_pool.go
+++ b/pkg/storage/store_pool.go
@@ -44,13 +44,13 @@ const (
 	TestTimeUntilStoreDeadOff = 24 * time.Hour
 )
 
-var declinedReservationsTimeout = settings.RegisterPositiveDurationSetting(
+var declinedReservationsTimeout = settings.RegisterNonNegativeDurationSetting(
 	"server.declined_reservation_timeout",
 	"the amount of time to consider the store throttled for up-replication after a reservation was declined",
 	5*time.Second,
 )
 
-var failedReservationsTimeout = settings.RegisterPositiveDurationSetting(
+var failedReservationsTimeout = settings.RegisterNonNegativeDurationSetting(
 	"server.failed_reservation_timeout",
 	"the amount of time to consider the store throttled for up-replication after a failed reservation call",
 	0,


### PR DESCRIPTION
Also rename from `RegisterPositiveDurationSetting` to `RegisterNonNegativeDurationSetting`, since the validation function isn't requiring positive values, it's requiring non-negative values.

It'd be nice to put the validation from the second commit into 1.0, but it's obviously not a huge deal if we don't want to cherry pick it.