### PR TITLE
storage: set node liveness TTL

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4596,7 +4596,7 @@ func (r *Replica) maybeGossipNodeLiveness(ctx context.Context, span roachpb.Span
 				continue
 			}
 		}
-		if err := r.store.Gossip().AddInfoProto(key, &liveness, 0); err != nil {
+		if err := r.store.Gossip().AddInfoProto(key, &liveness, 50*r.store.cfg.NodeLiveness.heartbeatInterval); err != nil {
 			return errors.Wrapf(err, "failed to gossip node liveness (%+v)", liveness)
 		}
 	}


### PR DESCRIPTION
Prior to this change, nodes which had been permanently removed from the
cluster would continue to appear in certain operator-facing locations
(e.g. admin UI, range debug page) indefinitely, complicating debugging.

This sets the TTL conservatively at 50 times the liveness heartbeat
interval.

Closes #15609.