### PR TITLE
debug: remove escaper html in template

### DIFF
--- a/pkg/server/debug_range.go
+++ b/pkg/server/debug_range.go
@@ -872,7 +872,7 @@ const debugRangeTemplate = `
             {{- $data := index $.Results $headerName}}
             {{- $datum := index $data $.HeaderFakeStoreID}}
             <DIV CLASS="row">
-              <DIV CLASS="header cell {{$datum.Class}}" TITLE="{{html $datum.Title}}">{{$datum.Value}}</DIV>
+              <DIV CLASS="header cell {{$datum.Class}}" TITLE="{{$datum.Title}}">{{$datum.Value}}</DIV>
               {{- range $_, $storeID := $.StoreIDs}}
                 {{- $datum := index $data $storeID}}
                 <DIV CLASS="cell {{$datum.Class}}" TITLE="{{$datum.Title}}">{{$datum.Value}}</DIV>


### PR DESCRIPTION
For security issues, 'html' is disallowed in html template.

See Also https://go-review.googlesource.com/c/37880

Signed-off-by: Peng Gao <peng.gao.dut@gmail.com>