### PR TITLE
1.0rc2 cherrypick: sql, distsql: don't create unnecessary ident aggre…

### DIFF
--- a/pkg/sql/testdata/logic_test/aggregate
+++ b/pkg/sql/testdata/logic_test/aggregate
@@ -44,34 +44,30 @@ SELECT ARRAY_AGG(1)
 
 # Check that COALESCE using aggregate results over an empty table
 # work properly.
-# Disabled until #12525 is fixed (it crashes distsql).
-# query I
-# SELECT COALESCE(MAX(1), 0) FROM generate_series(1,0)
-# ----
-# 0
+query I
+SELECT COALESCE(MAX(1), 0) FROM generate_series(1,0)
+----
+0
 
 # Same, using arithmetic on COUNT.
-# Disabled until #12525 is fixed (it crashes distsql).
-# query I
-# SELECT 1 + COUNT(*) FROM generate_series(1,0)
-# ----
-# 1
+query I
+SELECT 1 + COUNT(*) FROM generate_series(1,0)
+----
+1
 
 # Same, using an empty table.
 # The following test *must* occur before the first INSERT to the tables,
 # so that it can observe an empty table.
-# Disabled until #12525 is fixed (it crashes distsql).
-# query II
-# SELECT COUNT(*), COALESCE(MAX(k), 1) FROM kv
-# ----
-# 0 1
+query II
+SELECT COUNT(*), COALESCE(MAX(k), 1) FROM kv
+----
+0 1
 
 # Same, using a subquery. (#12705)
-# Disabled until #12525 is fixed (it crashes distsql).
-# query I
-# SELECT (SELECT COALESCE(MAX(1), 0) FROM generate_series(1,0))
-# ----
-# 0
+query I
+SELECT (SELECT COALESCE(MAX(1), 0) FROM generate_series(1,0))
+----
+0
 
 statement OK
 INSERT INTO kv VALUES
@@ -1083,17 +1079,10 @@ query ITTT
 EXPLAIN (EXPRS) SELECT 1 FROM kv GROUP BY kv.*;
 ----
 0  group
-0          aggregate 0  1
 0          render 0     1
-1  render
-1          render 0     1
-1          render 1     k
-1          render 2     v
-1          render 3     w
-1          render 4     s
-2  scan
-2          table        kv@primary
-2          spans        ALL
+1  scan
+1          table        kv@primary
+1          spans        ALL
 
 query I
 SELECT 1 FROM kv GROUP BY kv.*;

--- a/pkg/sql/testdata/logic_test/distsql_agg
+++ b/pkg/sql/testdata/logic_test/distsql_agg
@@ -120,7 +120,7 @@ SELECT SUM(a), MIN(b), MAX(c), COUNT(d), AVG(a+b+c+d) FROM data
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT SUM(a), round(STDDEV(b), 1) FROM data]
 ----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzEkjFr8zAQhvfvV5h3cuCGyE6-wZMKyZChaUnSLsWDah3GkEhGkqEl-L8X25TWIQ2UQDqe7p57XsQdYazmtTqwR_YCAUICQgrCDIQ5ckLtbMHeW9eNDMBKvyGbEipTN6F7zgmFdYzsiFCFPSPDTr3uecNKswNBc1DVvpfUrjoo9y61CgqEDRvNLoukiGQSCeQtwTbhc3FLPyi_TI2xTrNjPfLk7ZlQd2XpuFTBnmTaPt3HUkxA2O4Wi-VzLJOuWC2W610s08k4p7ON0bFMKOpalwKL2_9Rcntlenvl7G-P74xyw762xvPJEY735QTWJQ_3623jCn50tuiXD-VDP90_aPZh6IqhWJm-JbpY32FxEf4_gqencHKNOb0Gnl0Dz38F5-2_jwAAAP__E4Saug==
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzEkkFr8kAQhu_fr5D3pDAHN-p32FMK9uChWtT2UnLYZocQ0N0wu4EWyX8vSSitYoUi2OPszDPPyzIHOG95afYcoF-gQEhAmIAwBWGGjFCJzzkEL-1IDyzsG_SYULqqju1zRsi9MPQBsYw7hsbWvO54zcaygGA5mnLXSSop90beU2uiAWFVRz1IFaUJsobg6_i5s6EfbF-S2nmxLGyPFFlzJs9dUQgXJvqTOJunh2GqRiBstvP5_fMwTdpizc6ytMkG4mtnh2lCA6W1Xiy3o4tJ1U3_JbmpbXJT2_TPLuyMbc2h8i7wyaUd78sIbAvujzT4WnJ-FJ93y_ty1U13D5ZD7LuqLxaua6k21ndYXYT_H8HjUzi5xjy5Bp5eA89-BWfNv48AAAD__2Tbkkg=
 
 query RR
 SELECT SUM(a), round(STDDEV(b), 1) FROM data
@@ -130,7 +130,7 @@ SELECT SUM(a), round(STDDEV(b), 1) FROM data
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT SUM(a), round(VARIANCE(b), 1) FROM data]
 ----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzEkjFr8zAQhvfvV5h3cuCGyE6-wZNDm8FD0-KmXYoH1TqMIZGMJENL8H8vtimtQxoogXQ83T33vIg7QBvFG7lnh-QFAoQIhBiEBQhLFITGmpKdM7YfGYFMvSGZE2rdtL5_LgilsYzkAF_7HSPBVr7uOGep2IKg2Mt6N0gaW--lfU-V9BKEnLVimwSpCNIoECg6gmn95-KOflB-mVptrGLLauIpuhOhVlVluZLeHGV6fLoLUzED4XmVZ6vNzTpMo77MbtebbZjGs2lSa1qtwjSioG-diyyu_0vR9ZXx9ZWLvz2_E8qcXWO046MznO4rCKwqHi_YmdaW_GBNOSwfy_thenhQ7PzYFWOR6aEl-ljfYXEW_j-B58dwdIk5vgReXAIvfwUX3b-PAAAA__-rZJs5
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzEksFKw0AQhu8-RflPLcyhm7Ye9pQiHnKwlVi9SA5rdgiBNhtmN6CUvLskQbSlFqRQj7Mz33w_y-xROcsrs2MP_QoFQgTCDIQ5CAtkhFpczt476UYGILHv0FNCWdVN6J4zQu6EofcIZdgyNDbmbcspG8sCguVgym0vqaXcGfmIrQkGhHUT9ChWFEfIWoJrwtfOln6xfUuayollYXugyNoTeZZFIVyY4I7iPD0_jGM1AeFlmSbL1d39OI66MuXKsnTZRuKayo7jiEZKa52sNpOzWdVVfya6qm12Vdv8327shC1lX7vK89GtHe7LCGwLHs7Uu0ZyfhSX98uHct1P9w-WfRi6aiiSqm-pLtZPWJ2Fbw_g6TEcXWKeXQLPL4EXf4Kz9uYzAAD__-x8ksc=
 
 query RR
 SELECT SUM(a), round(VARIANCE(b), 1) FROM data

--- a/pkg/sql/testdata/logic_test/explain_types
+++ b/pkg/sql/testdata/logic_test/explain_types
@@ -86,18 +86,16 @@ query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2
 ----
 0  group                                                          (z int, v int)
-0          aggregate 0  (2)[int]
-0          aggregate 1  (count((k)[int]))[int]
+0          aggregate 0  (count((k)[int]))[int]
+0          aggregate 1  (v)[int]
 0          aggregate 2  (v)[int]
-0          aggregate 3  ((v)[int] < (2)[int])[bool]
 0          render 0     ((2)[int] * (count((k)[int]))[int])[int]
 0          render 1     (v)[int]
 0          having       ((v)[int] < (2)[int])[bool]
-1  render                                                         ("2" int, k int, v int, "v < 2" bool)
-1          render 0     (2)[int]
-1          render 1     (k)[int]
+1  render                                                         (k int, v int, v int)
+1          render 0     (k)[int]
+1          render 1     (v)[int]
 1          render 2     (v)[int]
-1          render 3     ((v)[int] < (2)[int])[bool]
 2  scan                                                           (k int, v int)
 2          table        t@primary
 2          filter       ((v)[int] > (123)[int])[bool]
@@ -106,18 +104,16 @@ query ITTTTT
 EXPLAIN (TYPES) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2
 ----
 0  group                                                          (z int, v int)
-0          aggregate 0  (2)[int]
-0          aggregate 1  (count((k)[int]))[int]
+0          aggregate 0  (count((k)[int]))[int]
+0          aggregate 1  (v)[int]
 0          aggregate 2  (v)[int]
-0          aggregate 3  ((v)[int] < (2)[int])[bool]
 0          render 0     ((2)[int] * (count((k)[int]))[int])[int]
 0          render 1     (v)[int]
 0          having       ((v)[int] < (2)[int])[bool]
-1  render                                                         ("2" int, k int, v int, "v < 2" bool)
-1          render 0     (2)[int]
-1          render 1     (k)[int]
+1  render                                                         (k int, v int, v int)
+1          render 0     (k)[int]
+1          render 1     (v)[int]
 1          render 2     (v)[int]
-1          render 3     ((v)[int] < (2)[int])[bool]
 2  scan                                                           (k int, v int)
 2          table        t@primary
 2          spans        ALL

--- a/pkg/sql/testdata/logic_test/window
+++ b/pkg/sql/testdata/logic_test/window
@@ -610,21 +610,17 @@ EXPLAIN (TYPES) SELECT max(k), max(k) + stddev(d) OVER (PARTITION BY v, 'a') FRO
 2          aggregate 1  (d)[decimal]
 2          aggregate 2  (d)[decimal]
 2          aggregate 3  (v)[int]
-2          aggregate 4  ('a')[string]
-2          aggregate 5  (100)[int]
 2          render 0     (max((k)[int]))[int]
 2          render 1     (d)[decimal]
 2          render 2     (d)[decimal]
 2          render 3     (v)[int]
 2          render 4     ('a')[string]
 2          render 5     (100)[int]
-3  render                                                                                                                              (k int, d decimal, d decimal, v int, "'a'" string, "100" int)
+3  render                                                                                                                              (k int, d decimal, d decimal, v int)
 3          render 0     (k)[int]
 3          render 1     (d)[decimal]
 3          render 2     (d)[decimal]
 3          render 3     (v)[int]
-3          render 4     ('a')[string]
-3          render 5     (100)[int]
 4  scan                                                                                                                                (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)
 4          table        kv@primary
 4          spans        ALL
@@ -641,16 +637,14 @@ EXPLAIN (TYPES) SELECT MAX(k), stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROU
 2          aggregate 0  (max((k)[int]))[int]
 2          aggregate 1  (d)[decimal]
 2          aggregate 2  (v)[int]
-2          aggregate 3  ('a')[string]
 2          render 0     (max((k)[int]))[int]
 2          render 1     (d)[decimal]
 2          render 2     (v)[int]
 2          render 3     ('a')[string]
-3  render                                                                                            (k int, d decimal, v int, "'a'" string)
+3  render                                                                                            (k int, d decimal, v int)
 3          render 0     (k)[int]
 3          render 1     (d)[decimal]
 3          render 2     (v)[int]
-3          render 3     ('a')[string]
 4  scan                                                                                              (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)
 4          table        kv@primary
 4          spans        ALL


### PR DESCRIPTION
…gators

Cherrypicking #15688 for #15660

The groupNode code was creating unnecessary `IdentAggregators`, even for
constant values. This is not only inefficient, but it doesn't work
correctly in the case where there are no rows to be processed.

Fixes #15686.
Updates #12525.