### PR TITLE
cli: add --advertise-port flag to start command

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -199,9 +199,11 @@ hostname if advertise-host is not specified.`,
 	}
 
 	ServerPort = FlagInfo{
-		Name:        "port",
-		Shorthand:   "p",
-		Description: `The port to bind to.`,
+		Name:      "port",
+		Shorthand: "p",
+		Description: `
+The port to bind to. The node will also advertise itself
+using this port if advertise-port is not specified.`,
 	}
 
 	AdvertiseHost = FlagInfo{
@@ -209,6 +211,13 @@ hostname if advertise-host is not specified.`,
 		Description: `
 The hostname to advertise to other CockroachDB nodes for intra-cluster
 communication; it must resolve from other nodes in the cluster.`,
+	}
+
+	AdvertisePort = FlagInfo{
+		Name: "advertise-port",
+		Description: `
+The port to advertise to other CockroachDB nodes for intra-cluster
+communication.`,
 	}
 
 	ServerHTTPHost = FlagInfo{

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -42,7 +42,7 @@ import (
 var maxResults int64
 
 var sqlConnURL, sqlConnUser, sqlConnDBName string
-var serverConnHost, serverConnPort, serverAdvertiseHost string
+var serverConnHost, serverConnPort, serverAdvertiseHost, serverAdvertisePort string
 var serverHTTPHost, serverHTTPPort string
 var clientConnHost, clientConnPort string
 var zoneConfig string
@@ -232,6 +232,7 @@ func init() {
 		stringFlag(f, &serverConnHost, cliflags.ServerHost, "")
 		stringFlag(f, &serverConnPort, cliflags.ServerPort, base.DefaultPort)
 		stringFlag(f, &serverAdvertiseHost, cliflags.AdvertiseHost, "")
+		stringFlag(f, &serverAdvertisePort, cliflags.AdvertisePort, "")
 		stringFlag(f, &serverHTTPHost, cliflags.ServerHTTPHost, "")
 		stringFlag(f, &serverHTTPPort, cliflags.ServerHTTPPort, base.DefaultHTTPPort)
 		stringFlag(f, &serverCfg.Attrs, cliflags.Attrs, serverCfg.Attrs)
@@ -383,7 +384,10 @@ func extraServerFlagInit() {
 	if serverAdvertiseHost == "" {
 		serverAdvertiseHost = serverConnHost
 	}
-	serverCfg.AdvertiseAddr = net.JoinHostPort(serverAdvertiseHost, serverConnPort)
+	if serverAdvertisePort == "" {
+		serverAdvertisePort = serverConnPort
+	}
+	serverCfg.AdvertiseAddr = net.JoinHostPort(serverAdvertiseHost, serverAdvertisePort)
 	if serverHTTPHost == "" {
 		serverHTTPHost = serverConnHost
 	}

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -120,6 +120,7 @@ func TestServerConnSettings(t *testing.T) {
 		// an empty port.
 		serverConnHost = ""
 		serverAdvertiseHost = ""
+		serverAdvertisePort = ""
 		serverConnPort = ""
 	}
 	defer resetGlobals()
@@ -136,9 +137,14 @@ func TestServerConnSettings(t *testing.T) {
 		{[]string{"start", "--port", "12345"}, ":12345", ":12345"},
 		{[]string{"start", "--host", "127.0.0.1", "--port", "12345"}, "127.0.0.1:12345", "127.0.0.1:12345"},
 		{[]string{"start", "--advertise-host", "192.168.0.111"}, ":", "192.168.0.111:"},
+		{[]string{"start", "--advertise-host", "192.168.0.111", "--advertise-port", "12345"}, ":", "192.168.0.111:12345"},
 		{[]string{"start", "--host", "127.0.0.1", "--advertise-host", "192.168.0.111"}, "127.0.0.1:", "192.168.0.111:"},
 		{[]string{"start", "--host", "127.0.0.1", "--advertise-host", "192.168.0.111", "--port", "12345"}, "127.0.0.1:12345", "192.168.0.111:12345"},
+		{[]string{"start", "--host", "127.0.0.1", "--advertise-host", "192.168.0.111", "--advertise-port", "12345"}, "127.0.0.1:", "192.168.0.111:12345"},
+		{[]string{"start", "--host", "127.0.0.1", "--advertise-host", "192.168.0.111", "--port", "54321", "--advertise-port", "12345"}, "127.0.0.1:54321", "192.168.0.111:12345"},
 		{[]string{"start", "--advertise-host", "192.168.0.111", "--port", "12345"}, ":12345", "192.168.0.111:12345"},
+		{[]string{"start", "--advertise-host", "192.168.0.111", "--advertise-port", "12345"}, ":", "192.168.0.111:12345"},
+		{[]string{"start", "--advertise-host", "192.168.0.111", "--port", "54321", "--advertise-port", "12345"}, ":54321", "192.168.0.111:12345"},
 		// confirm hostnames will work
 		{[]string{"start", "--host", "my.host.name"}, "my.host.name:", "my.host.name:"},
 		{[]string{"start", "--host", "myhostname"}, "myhostname:", "myhostname:"},

--- a/pkg/cli/start_test.go
+++ b/pkg/cli/start_test.go
@@ -52,11 +52,15 @@ func TestInitInsecure(t *testing.T) {
 		{[]string{"--insecure", "--host", "192.168.1.1"}, true, ""},
 		{[]string{"--host", "localhost", "--advertise-host", "192.168.1.1"}, false, ""},
 		{[]string{"--host", "127.0.0.1", "--advertise-host", "192.168.1.1"}, false, ""},
+		{[]string{"--host", "127.0.0.1", "--advertise-host", "192.168.1.1", "--advertise-port", "36259"}, false, ""},
 		{[]string{"--host", "::1", "--advertise-host", "192.168.1.1"}, false, ""},
+		{[]string{"--host", "::1", "--advertise-host", "192.168.1.1", "--advertise-port", "36259"}, false, ""},
 		{[]string{"--insecure", "--host", "192.168.1.1", "--advertise-host", "192.168.1.1"}, true, ""},
 		{[]string{"--insecure", "--host", "192.168.1.1", "--advertise-host", "192.168.2.2"}, true, ""},
+		{[]string{"--insecure", "--host", "192.168.1.1", "--advertise-host", "192.168.2.2", "--advertise-port", "36259"}, true, ""},
 		// Clear out the flags when done to avoid affecting other tests that rely on the flag state.
 		{[]string{"--host", "", "--advertise-host", ""}, false, ""},
+		{[]string{"--host", "", "--advertise-host", "", "--advertise-port", ""}, false, ""},
 	}
 	for i, c := range testCases {
 		// Reset the context and for every test case.


### PR DESCRIPTION
Related to #1008, extending #9503. Also see #6862.
The flag enables any given node to advertise it's listening port. We
have a similar mechanism for just the hostname, this would enable us to
use this in conjunction with `--advertise-host` to construct an
advertised address. Necessary when running behind a proxy or equivalent
where internal and external ports differ.