### PR TITLE
1.0rc2 cherrypick: build: disable jemalloc profiling in musl builds

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -346,7 +346,10 @@ $(JEMALLOC_DIR)/Makefile: $(C_DEPS_DIR)/jemalloc-rebuild $(JEMALLOC_SRC_DIR)/.ex
 	mkdir -p $(JEMALLOC_DIR)
 	@# NOTE: If you change the configure flags below, bump the version in
 	@# $(C_DEPS_DIR)/jemalloc-rebuild. See above for rationale.
-	cd $(JEMALLOC_DIR) && $(JEMALLOC_SRC_DIR)/configure $(CONFIGURE_FLAGS) --enable-prof
+	@#
+	@# jemalloc profiling deadlocks when built against musl. See
+	@# https://github.com/jemalloc/jemalloc/issues/585.
+	cd $(JEMALLOC_DIR) && $(JEMALLOC_SRC_DIR)/configure $(CONFIGURE_FLAGS) $(if $(findstring musl,$(TARGET_TRIPLE)),,--enable-prof)
 
 $(PROTOBUF_DIR)/Makefile: $(C_DEPS_DIR)/protobuf-rebuild $(PROTOBUF_SRC_DIR)/.extracted
 	rm -rf $(PROTOBUF_DIR)

--- a/c-deps/jemalloc-rebuild
+++ b/c-deps/jemalloc-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing jemalloc configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-1
+2

--- a/pkg/cmd/release-upload/main.go
+++ b/pkg/cmd/release-upload/main.go
@@ -215,7 +215,7 @@ func main() {
 			}
 
 			if strings.Contains(target.buildType, "linux") {
-				binaryName := fmt.Sprintf("./cockroach%s-linux-2.6.32-gnu-amd64", extraArgs.suffix)
+				binaryName := fmt.Sprintf("./cockroach%s-%s", extraArgs.suffix, target.baseSuffix)
 
 				cmd := exec.Command(binaryName, "version")
 				cmd.Dir = pkg.Dir


### PR DESCRIPTION
Cherrypick #15675 for #15660.

Seems like a reasonable fix, and we're also picking other release-upload
changes.