### PR TITLE
1.0rc2 cherrypick: build: switch release-upload on whether a tag is p…

### DIFF
--- a/build/teamcity-publish-artifacts.sh
+++ b/build/teamcity-publish-artifacts.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Any arguments to this script are passed through unmodified to
+# ./pkg/cmd/publish-artifacts.
+
 set -euxo pipefail
 
 export BUILDER_HIDE_GOPATH_SRC=1
@@ -8,7 +12,7 @@ cat .buildinfo/tag || true
 cat .buildinfo/rev || true
 build/builder.sh git status
 
-build/builder.sh go install ./pkg/cmd/release-upload
+build/builder.sh go install ./pkg/cmd/publish-artifacts
 
 echo 'installed release builder'
 cat .buildinfo/tag || true
@@ -19,7 +23,7 @@ build/builder.sh env \
 	AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
 	AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
 	TC_BUILD_BRANCH="$TC_BUILD_BRANCH" \
-	release-upload
+	publish-artifacts "$@"
 
 echo 'built and uploaded artifacts'
 cat .buildinfo/tag || true


### PR DESCRIPTION
…resent

Cherrypick #15694 for #15660.

Release builds currently operate in two modes: the bleeding-edge mode
where the latest binary on master is built, and the actual release mode
where binaries for a tagged SHA are built. To allow for multiple release
branches, check for the presence of a tag instead of hardcoding that
"master" means bleeding-edge mode. Now, the presence of a tag means
actual release mode, and the lack of a tag means bleeding-edge mode.

Additionally upload non-master bleeding-edge binaries to a subfolder of
the "cockroach" bucket.

Since these scripts build and upload bleeding-edge binaries, not just
release binaries, also update their names to "publish-artifacts" to
better reflect their purpose.