### PR TITLE
acceptance: don't use the builder image

### DIFF
--- a/pkg/acceptance/cluster/localcluster.go
+++ b/pkg/acceptance/cluster/localcluster.go
@@ -57,10 +57,8 @@ import (
 )
 
 const (
-	builderImage     = "docker.io/cockroachdb/builder"
-	builderTag       = "20170422-212842"
-	builderImageFull = builderImage + ":" + builderTag
-	networkPrefix    = "cockroachdb_acceptance"
+	defaultImage  = "docker.io/library/ubuntu:xenial-20170214"
+	networkPrefix = "cockroachdb_acceptance"
 )
 
 // DefaultTCP is the default SQL/RPC port specification.
@@ -71,8 +69,8 @@ const defaultHTTP nat.Port = base.DefaultHTTPPort + "/tcp"
 // binary.
 const CockroachBinaryInContainer = "/cockroach/cockroach"
 
-var cockroachImage = flag.String("i", builderImageFull, "the docker image to run")
-var cockroachBinary = flag.String("b", defaultBinary(), "the host-side binary to run (if image == "+builderImage+")")
+var cockroachImage = flag.String("i", defaultImage, "the docker image to run")
+var cockroachBinary = flag.String("b", defaultBinary(), "the host-side binary to run (if image == "+defaultImage+")")
 var cockroachEntry = flag.String("e", "", "the entry point for the image")
 var waitOnStop = flag.Bool("w", false, "wait for the user to interrupt before tearing down the cluster")
 var maxRangeBytes = config.DefaultZoneConfig().RangeMaxBytes
@@ -173,7 +171,7 @@ func CreateLocal(
 	default:
 	}
 
-	if *cockroachImage == builderImageFull && !exists(*cockroachBinary) {
+	if *cockroachImage == defaultImage && !exists(*cockroachBinary) {
 		log.Fatalf(ctx, "\"%s\": does not exist", *cockroachBinary)
 	}
 
@@ -361,7 +359,7 @@ func (l *LocalCluster) initCluster(ctx context.Context) {
 	if l.logDir != "" {
 		binds = append(binds, l.logDir+":/logs")
 	}
-	if *cockroachImage == builderImageFull {
+	if *cockroachImage == defaultImage {
 		path, err := filepath.Abs(*cockroachBinary)
 		maybePanic(err)
 		binds = append(binds, path+":"+CockroachBinaryInContainer)
@@ -396,8 +394,8 @@ func (l *LocalCluster) initCluster(ctx context.Context) {
 		}
 	}
 
-	if *cockroachImage == builderImageFull {
-		maybePanic(pullImage(ctx, l, builderImageFull, types.ImagePullOptions{}))
+	if *cockroachImage == defaultImage {
+		maybePanic(pullImage(ctx, l, defaultImage, types.ImagePullOptions{}))
 	}
 	c, err := createContainer(
 		ctx,
@@ -444,7 +442,7 @@ func (l *LocalCluster) createRoach(
 	}
 	log.Infof(ctx, "creating docker container with name: %s", hostname)
 	var entrypoint []string
-	if *cockroachImage == builderImageFull {
+	if *cockroachImage == defaultImage {
 		entrypoint = append(entrypoint, CockroachBinaryInContainer)
 	} else if *cockroachEntry != "" {
 		entrypoint = append(entrypoint, *cockroachEntry)


### PR DESCRIPTION
This disentangles the acceptance tests from our builder image, which
isn't needed for running the tests (only for building the binary).

This has the benefit of making build/builder.sh self-contained so it
can be shared with other repositories that require it for their builds.