### PR TITLE
build: restore stdmalloc builds

### DIFF
--- a/pkg/ccl/storageccl/engineccl/jemalloc.go
+++ b/pkg/ccl/storageccl/engineccl/jemalloc.go
@@ -1,0 +1,24 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nikhil Benesch (nikhil.benesch@gmail.com)
+
+// +build !stdmalloc
+
+package engineccl
+
+// #cgo LDFLAGS: -ljemalloc
+// #cgo dragonfly freebsd LDFLAGS: -lm
+// #cgo linux LDFLAGS: -lrt -lm -lpthread
+import "C"

--- a/pkg/ccl/storageccl/engineccl/rocksdb.go
+++ b/pkg/ccl/storageccl/engineccl/rocksdb.go
@@ -22,10 +22,9 @@ import (
 // #cgo CPPFLAGS: -I../../../../c-deps/rocksdb.src/include
 // #cgo LDFLAGS: -lprotobuf
 // #cgo LDFLAGS: -lrocksdb
-// #cgo LDFLAGS: -ljemalloc
 // #cgo LDFLAGS: -lsnappy
 // #cgo CXXFLAGS: -std=c++11 -Werror -Wall -Wno-sign-compare
-// #cgo linux LDFLAGS: -lrt -lm -lpthread
+// #cgo linux LDFLAGS: -lrt -lpthread
 // #cgo windows LDFLAGS: -lrpcrt4
 //
 // // Building this package will trigger "unresolved symbol" errors

--- a/pkg/storage/engine/jemalloc.go
+++ b/pkg/storage/engine/jemalloc.go
@@ -1,0 +1,24 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nikhil Benesch (nikhil.benesch@gmail.com)
+
+// +build !stdmalloc
+
+package engine
+
+// #cgo LDFLAGS: -ljemalloc
+// #cgo dragonfly freebsd LDFLAGS: -lm
+// #cgo linux LDFLAGS: -lrt -lm -lpthread
+import "C"

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -54,10 +54,9 @@ import (
 // #cgo CPPFLAGS: -I../../../c-deps/protobuf.src/src
 // #cgo LDFLAGS: -lprotobuf
 // #cgo LDFLAGS: -lrocksdb
-// #cgo LDFLAGS: -ljemalloc
 // #cgo LDFLAGS: -lsnappy
 // #cgo CXXFLAGS: -std=c++11 -Werror -Wall -Wno-sign-compare
-// #cgo linux LDFLAGS: -lrt -lm -lpthread
+// #cgo linux LDFLAGS: -lrt -lpthread
 // #cgo windows LDFLAGS: -lrpcrt4
 //
 // #include <stdlib.h>


### PR DESCRIPTION
stdmalloc builds were broken in the transition to using the C/C++ dependencies'
native build systems.