### PR TITLE
server: make the --insecure warning more explicit.

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -263,8 +263,11 @@ production usage.`,
 	ServerInsecure = FlagInfo{
 		Name: "insecure",
 		Description: `
-Start an insecure node, using unencrypted (non-TLS) connections. This is strongly discouraged for
-production usage.`,
+Start an insecure node, using unencrypted (non-TLS) connections,
+listening on all IP addresses (unless --host is provided) and
+disabling password authentication for all database users. This is
+strongly discouraged for production usage and should never be used on
+a public network without combining it with --host.`,
 	}
 
 	// KeySize, CertificateLifetime, AllowKeyReuse, and OverwriteFiles are used for

--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -5,6 +5,21 @@ source [file join [file dirname $argv0] common.tcl]
 set certs_dir "/certs"
 set ::env(COCKROACH_INSECURE) "false"
 
+spawn /bin/bash
+send "PS1=':''/# '\r"
+
+set prompt ":/# "
+eexpect $prompt
+
+start_test "Check that --insecure reports that the server is really insecure"
+send "$argv start --insecure\r"
+eexpect "WARNING: RUNNING IN INSECURE MODE"
+eexpect "node starting"
+interrupt
+eexpect $prompt
+end_test
+
+
 proc start_secure_server {argv certs_dir} {
     report "BEGIN START SECURE SERVER"
     system "mkfifo pid_fifo || true; $argv start --certs-dir=$certs_dir --pid-file=pid_fifo -s=path=logs/db >>expect-cmd.log 2>&1 & cat pid_fifo > server_pid"
@@ -18,12 +33,6 @@ proc stop_secure_server {argv certs_dir} {
 }
 
 start_secure_server $argv $certs_dir
-
-spawn /bin/bash
-send "PS1=':''/# '\r"
-
-set prompt ":/# "
-eexpect $prompt
 
 start_test "Check 'node ls' works with certificates."
 send "$argv node ls --certs-dir=$certs_dir\r"

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -569,6 +569,22 @@ func setupAndInitializeLoggingAndProfiling(startCtx context.Context) (*stop.Stop
 			" and --log-dir not specified, you may want to specify --log-dir to disambiguate.")
 	}
 
+	if serverInsecure {
+		// Use a non-annotated context here since the annotation just looks funny,
+		// particularly to new users (made worse by it always printing as [n?]).
+		addr := serverConnHost
+		if addr == "" {
+			addr = "<all your IP addresses>"
+		}
+		log.Shout(context.Background(), log.Severity_WARNING,
+			"RUNNING IN INSECURE MODE!\n\n"+
+				"- Your cluster is open for any client that can access "+addr+".\n"+
+				"- Any user, even root, can log in without providing a password.\n"+
+				"- Any user, connecting as root, can read or write any data in your cluster.\n"+
+				"- There is no network encryption nor authentication, and thus no confidentiality.\n\n"+
+				"Check out how to secure your cluster: https://www.cockroachlabs.com/docs/secure-a-cluster.html")
+	}
+
 	// We log build information to stdout (for the short summary), but also
 	// to stderr to coincide with the full logs.
 	info := build.GetInfo()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -155,12 +155,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	s.cfg.AmbientCtx.AddLogTag("n", &s.nodeIDContainer)
 
 	ctx := s.AnnotateCtx(context.Background())
-	if s.cfg.Insecure {
-		// Use a non-annotated context here since the annotation just looks funny,
-		// particularly to new users (made worse by it always printing as [n?]).
-		log.Shout(context.Background(), log.Severity_WARNING,
-			"running in insecure mode, this is strongly discouraged. See --insecure.")
-	}
 
 	s.rpcContext = rpc.NewContext(s.cfg.AmbientCtx, s.cfg.Config, s.clock, s.stopper)
 	s.rpcContext.HeartbeatCB = func() {


### PR DESCRIPTION
Example output:
```
*
* WARNING: RUNNING IN INSECURE MODE!
*
* - Your cluster is open for any client that can access localhost.
* - Any user, even root, can log in without providing a password.
* - Any user, connecting as root, can read or write any data in your cluster.
* - There is no network encryption nor authentication, and thus no confidentiality.
*
* Check out how to secure your cluster: https://www.cockroachlabs.com/docs/secure-a-cluster.html
*
CockroachDB node starting at 2017-05-15 14:07:53.1116454 +0000 UTC
build:      CCL 12ec77f-dirty @ 2017/05/15 14:05:14 (go1.8)
admin:      http://localhost:8080
sql:        postgresql://root@localhost:26257?sslmode=disable
logs:       /home/kena/cockroach/cockroach-data/logs
store[0]:   path=/home/kena/cockroach/cockroach-data
status:     restarted pre-existing node
clusterID:  fe26b6f3-3153-4c75-a7fb-3027c327e5ab
nodeID:     1

```

cc @mberhault 