### PR TITLE
cmd/publish-artifacts: properly seek to start of file

### DIFF
--- a/pkg/cmd/publish-artifacts/main.go
+++ b/pkg/cmd/publish-artifacts/main.go
@@ -347,9 +347,6 @@ func main() {
 						}); err != nil {
 							log.Fatal(err)
 						}
-						if _, err := binary.Seek(0, 0); err != nil {
-							log.Fatal(err)
-						}
 						if _, err := io.Copy(tw, binary); err != nil {
 							log.Fatal(err)
 						}
@@ -359,6 +356,9 @@ func main() {
 						if err := gzw.Close(); err != nil {
 							log.Fatal(err)
 						}
+					}
+					if _, err := binary.Seek(0, 0); err != nil {
+						log.Fatal(err)
 					}
 					putObjectInput := s3.PutObjectInput{
 						Bucket: &bucketName,


### PR DESCRIPTION
Fixes an issue where the Windows "latest" archive was empty because the
binary file wasn't being correctly rewound after the versioned archived
was written on Windows.