### PR TITLE
sql: fix two problems with groupNode optimization for MIN/MAX 

### DIFF
--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -248,7 +248,7 @@ func (p *planner) groupBy(
 		group.filterToRenderIdxs[i] = colIdxs[0]
 	}
 
-	group.desiredOrdering = desiredAggregateOrdering(group.funcs, &p.evalCtx)
+	group.desiredOrdering = group.desiredAggregateOrdering()
 	return group, nil
 }
 
@@ -461,13 +461,20 @@ func (n *groupNode) Close(ctx context.Context) {
 	n.buckets = nil
 }
 
+// requiresIsNotNullFilter returns whether a "col IS NOT NULL" constraint must
+// be added. This is the case when we have a single MIN/MAX aggregation
+// function.
+func (n *groupNode) requiresIsNotNullFilter() bool {
+	return len(n.desiredOrdering) == 1
+}
+
 // isNotNullFilter adds as a "col IS NOT NULL" constraint to the expression if
 // the groupNode has a desired ordering on col (see
 // desiredAggregateOrdering). A desired ordering will only be present if there
 // is a single MIN/MAX aggregation function.
 func (n *groupNode) isNotNullFilter(expr parser.TypedExpr) parser.TypedExpr {
-	if len(n.desiredOrdering) != 1 {
-		return expr
+	if !n.requiresIsNotNullFilter() {
+		panic("IS NOT NULL filter not required")
 	}
 	i := n.desiredOrdering[0].ColIdx
 	f := n.funcs[i]
@@ -486,40 +493,35 @@ func (n *groupNode) isNotNullFilter(expr parser.TypedExpr) parser.TypedExpr {
 }
 
 // desiredAggregateOrdering computes the desired output ordering from the
-// scan. It looks for an output column index containing a simple MIN/MAX
-// aggregation. If zero or multiple MIN/MAX aggregations are requested then no
-// ordering will be requested. A negative index indicates a MAX aggregation was
-// requested for the output column.
-func desiredAggregateOrdering(
-	funcs []*aggregateFuncHolder, evalCtx *parser.EvalContext,
-) sqlbase.ColumnOrdering {
-	limit := -1
-	direction := encoding.Ascending
-	for i, f := range funcs {
-		impl := f.create(evalCtx)
-		switch impl.(type) {
-		case *parser.MaxAggregate, *parser.MinAggregate:
-			if limit != -1 || f.arg == nil {
-				return nil
-			}
-			switch f.arg.(type) {
-			case *parser.IndexedVar:
-				limit = i
-				if _, ok := impl.(*parser.MaxAggregate); ok {
-					direction = encoding.Descending
-				}
-			default:
-				return nil
-			}
-
-		default:
-			return nil
-		}
-	}
-	if limit == -1 {
+// scan.
+//
+// We only have a desired ordering if we have a single MIN or MAX aggregation
+// with a simple column argument and there is no GROUP BY.
+func (n *groupNode) desiredAggregateOrdering() sqlbase.ColumnOrdering {
+	if len(n.groupByIdx) > 0 {
 		return nil
 	}
-	return sqlbase.ColumnOrdering{{ColIdx: limit, Direction: direction}}
+
+	if len(n.funcs) != 1 {
+		return nil
+	}
+	f := n.funcs[0]
+	impl := f.create(&n.planner.evalCtx)
+	switch impl.(type) {
+	case *parser.MaxAggregate, *parser.MinAggregate:
+		if f.arg == nil {
+			return nil
+		}
+		direction := encoding.Ascending
+		switch f.arg.(type) {
+		case *parser.IndexedVar:
+			if _, ok := impl.(*parser.MaxAggregate); ok {
+				direction = encoding.Descending
+			}
+			return sqlbase.ColumnOrdering{{ColIdx: 0, Direction: direction}}
+		}
+	}
+	return nil
 }
 
 type extractAggregatesVisitor struct {

--- a/pkg/sql/testdata/logic_test/aggregate
+++ b/pkg/sql/testdata/logic_test/aggregate
@@ -533,7 +533,6 @@ CREATE TABLE abc (
 statement ok
 INSERT INTO abc VALUES ('one', 1.5, true, 5::decimal), ('two', 2.0, false, 1.1::decimal)
 
-# Verify we don't try to apply the single-key optimization to the primary index.
 query ITTT
 EXPLAIN (EXPRS) SELECT MIN(a) FROM abc
 ----
@@ -1140,3 +1139,86 @@ SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
 6.1
 6.1
 6.1
+
+# opt_test is used for tests around the single-row optimization for MIN/MAX.
+statement ok
+CREATE TABLE opt_test (k INT PRIMARY KEY, v INT, INDEX v(v))
+
+statement ok
+INSERT INTO opt_test VALUES (1, NULL), (2, 10), (3, NULL), (4, 5)
+
+# Verify that we correctly add the v IS NOT NULL constraint.
+# TODO(#15725): this is an incorrect result
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test
+----
+0  group                                      ("min(v)")
+0          aggregate 0  min(test.opt_test.v)
+0          render 0     min(test.opt_test.v)
+1  render                                     (v)              +v
+1          render 0     test.opt_test.v
+2  scan                                       (k[omitted], v)  +v
+2          table        opt_test@v
+2          spans        ALL
+2          limit        1
+
+# WWithout the v IS NOT NULL constraint, this result would incorrectly be NULL.
+# TODO(#15725): this is an incorrect result
+query I
+SELECT MIN(v) FROM opt_test
+----
+NULL
+
+# Cross-check against a query without this optimization.
+query I
+SELECT MIN(v) FROM opt_test@primary
+----
+5
+
+# Repeat test when there is an existing filter.
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test WHERE k <> 4
+----
+0  group                                      ("min(v)")
+0          aggregate 0  min(test.opt_test.v)
+0          render 0     min(test.opt_test.v)
+1  render                                     (v)         +v
+1          render 0     test.opt_test.v
+2  scan                                       (k, v)      +v
+2          table        opt_test@v
+2          spans        /#-
+2          filter       k != 4
+
+query I
+SELECT MIN(v) FROM opt_test WHERE k <> 4
+----
+10
+
+# Verify that we don't use the optimization if there is a GROUP BY.
+# TODO(#15725): this is an incorrect result
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test GROUP BY k
+----
+0  group                                      ("min(v)")
+0          aggregate 0  min(test.opt_test.v)
+0          render 0     min(test.opt_test.v)
+1  render                                     (v, k)      +v
+1          render 0     test.opt_test.v
+1          render 1     test.opt_test.k
+2  scan                                       (k, v)      +v
+2          table        opt_test@v
+2          spans        ALL
+2          limit        1
+
+
+# TODO(#15725): this is an incorrect result
+query I rowsort
+SELECT MIN(v) FROM opt_test GROUP BY k
+----
+NULL
+
+# TODO(#15725): this is an incorrect result
+query I rowsort
+SELECT MAX(v) FROM opt_test GROUP BY k
+----
+10

--- a/pkg/sql/testdata/logic_test/aggregate
+++ b/pkg/sql/testdata/logic_test/aggregate
@@ -537,14 +537,14 @@ query ITTT
 EXPLAIN (EXPRS) SELECT MIN(a) FROM abc
 ----
 0  group
-0                 aggregate 0  min(a)
-0                 render 0     min(a)
+0          aggregate 0  min(a)
+0          render 0     min(a)
 1  render
-1                 render 0     a
+1          render 0     a
 2  scan
-2                 table        abc@primary
-2                 spans        ALL
-2                 limit        1
+2          table        abc@primary
+2          spans        /#-
+2          limit        1
 
 query TRBR
 SELECT MIN(a), MIN(b), MIN(c), MIN(d) FROM abc
@@ -618,14 +618,14 @@ query ITTT
 EXPLAIN (EXPRS) SELECT MIN(x) FROM xyz
 ----
 0  group
-0                 aggregate 0  min(x)
-0                 render 0     min(x)
+0          aggregate 0  min(x)
+0          render 0     min(x)
 1  render
-1                 render 0     x
+1          render 0     x
 2  scan
-2                 table        xyz@xy
-2                 spans        ALL
-2                 limit        1
+2          table        xyz@xy
+2          spans        /#-
+2          limit        1
 
 query I
 SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
@@ -654,14 +654,14 @@ query ITTT
 EXPLAIN (EXPRS) SELECT MAX(x) FROM xyz
 ----
 0  group
-0                 aggregate 0  max(x)
-0                 render 0     max(x)
+0           aggregate 0  max(x)
+0           render 0     max(x)
 1  render
-1                 render 0     x
+1           render 0     x
 2  revscan
-2                 table        xyz@xy
-2                 spans        ALL
-2                 limit        1
+2           table        xyz@xy
+2           spans        /#-
+2           limit        1
 
 query I
 SELECT MIN(y) FROM xyz WHERE x = 1
@@ -923,14 +923,14 @@ query ITTT
 EXPLAIN (EXPRS) SELECT MIN(a) FROM abc
 ----
 0  group
-0                 aggregate 0  min(a)
-0                 render 0     min(a)
+0          aggregate 0  min(a)
+0          render 0     min(a)
 1  render
-1                 render 0     a
+1          render 0     a
 2  scan
-2                 table        abc@primary
-2                 spans        ALL
-2                 limit        1
+2          table        abc@primary
+2          spans        /#-
+2          limit        1
 
 # Verify we only buffer one row.
 query ITTT
@@ -944,14 +944,14 @@ query ITTT
 EXPLAIN (EXPRS) SELECT MAX(a) FROM abc
 ----
 0  group
-0                 aggregate 0  max(a)
-0                 render 0     max(a)
+0           aggregate 0  max(a)
+0           render 0     max(a)
 1  render
-1                 render 0     a
+1           render 0     a
 2  revscan
-2                 table        abc@primary
-2                 spans        ALL
-2                 limit        1
+2           table        abc@primary
+2           spans        /#-
+2           limit        1
 
 # Verify we only buffer one row.
 query ITTT
@@ -1147,8 +1147,7 @@ CREATE TABLE opt_test (k INT PRIMARY KEY, v INT, INDEX v(v))
 statement ok
 INSERT INTO opt_test VALUES (1, NULL), (2, 10), (3, NULL), (4, 5)
 
-# Verify that we correctly add the v IS NOT NULL constraint.
-# TODO(#15725): this is an incorrect result
+# Verify that we correctly add the v IS NOT NULL constraint (which restricts the span).
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test
 ----
@@ -1159,15 +1158,14 @@ EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test
 1          render 0     test.opt_test.v
 2  scan                                       (k[omitted], v)  +v
 2          table        opt_test@v
-2          spans        ALL
+2          spans        /#-
 2          limit        1
 
-# WWithout the v IS NOT NULL constraint, this result would incorrectly be NULL.
-# TODO(#15725): this is an incorrect result
+# Without the "v IS NOT NULL" constraint, this result would incorrectly be NULL.
 query I
 SELECT MIN(v) FROM opt_test
 ----
-NULL
+5
 
 # Cross-check against a query without this optimization.
 query I
@@ -1195,30 +1193,32 @@ SELECT MIN(v) FROM opt_test WHERE k <> 4
 10
 
 # Verify that we don't use the optimization if there is a GROUP BY.
-# TODO(#15725): this is an incorrect result
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test GROUP BY k
 ----
 0  group                                      ("min(v)")
 0          aggregate 0  min(test.opt_test.v)
 0          render 0     min(test.opt_test.v)
-1  render                                     (v, k)      +v
+1  render                                     (v, k)
 1          render 0     test.opt_test.v
 1          render 1     test.opt_test.k
-2  scan                                       (k, v)      +v
-2          table        opt_test@v
+2  scan                                       (k, v)
+2          table        opt_test@primary
 2          spans        ALL
-2          limit        1
 
 
-# TODO(#15725): this is an incorrect result
 query I rowsort
 SELECT MIN(v) FROM opt_test GROUP BY k
 ----
 NULL
+NULL
+5
+10
 
-# TODO(#15725): this is an incorrect result
 query I rowsort
 SELECT MAX(v) FROM opt_test GROUP BY k
 ----
+NULL
+NULL
+5
 10


### PR DESCRIPTION
This PR fixes the two problems described in #15725:
 - we don't always apply the IS NOT NULL constraint when we use the single-row
   optimization.
 - we incorrectly use the optimization when there is a GROUP BY.

Fixes #15725.