### PR TITLE
sql: add a --rewrite-results-in-testfiles mode to logic test

### DIFF
--- a/pkg/sql/testdata/logic_test/check_constraints
+++ b/pkg/sql/testdata/logic_test/check_constraints
@@ -192,5 +192,3 @@ CREATE TABLE t6 (x INT CHECK (x = $1))
 
 statement error CHECK expression .* may not contain variable sub-expressions
 CREATE TABLE t6 (x INT CHECK (x = (SELECT 1)))
-
-

--- a/pkg/sql/testdata/logic_test/explain_types
+++ b/pkg/sql/testdata/logic_test/explain_types
@@ -297,4 +297,3 @@ EXPLAIN (TYPES) SELECT x[1] FROM (SELECT ARRAY[1,2,3] AS x)
 1  render                                                         (x int[])
 1           render 0  (ARRAY[(1)[int],(2)[int],(3)[int]])[int[]]
 2  nullrow                                                        ()
-

--- a/pkg/sql/testdata/logic_test/select_search_path
+++ b/pkg/sql/testdata/logic_test/select_search_path
@@ -118,4 +118,3 @@ query I
 SELECT COUNT(DISTINCT(1)) FROM pg_tables
 ----
 1
-


### PR DESCRIPTION
Adding a special mode to logic tests which rewrites the tests, replacing the
results if there are any mismatches. This is useful when a change produces many
changes (most commonly for `EXPLAIN` statements). However, it should be used
with care: the diffs must always be inspected manually to confirm there are no
unexpected changes.