### PR TITLE
ccl/sqlccl,sql: cleanup in TypeAsString

### DIFF
--- a/pkg/ccl/sqlccl/backup.go
+++ b/pkg/ccl/sqlccl/backup.go
@@ -475,11 +475,11 @@ func backupPlanHook(
 		return nil, nil, err
 	}
 
-	toFn, err := p.TypeAsString(&backup.To)
+	toFn, err := p.TypeAsString(backup.To, "BACKUP")
 	if err != nil {
 		return nil, nil, err
 	}
-	incrementalFromFn, err := p.TypeAsStringArray(&backup.IncrementalFrom)
+	incrementalFromFn, err := p.TypeAsStringArray(backup.IncrementalFrom, "BACKUP")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -495,8 +495,14 @@ func backupPlanHook(
 		ctx, span := tracing.ChildSpan(baseCtx, stmt.StatementTag())
 		defer tracing.FinishSpan(span)
 
-		to := toFn()
-		incrementalFrom := incrementalFromFn()
+		to, err := toFn()
+		if err != nil {
+			return nil, err
+		}
+		incrementalFrom, err := incrementalFromFn()
+		if err != nil {
+			return nil, err
+		}
 
 		var startTime hlc.Timestamp
 		if backup.IncrementalFrom != nil {

--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -831,7 +831,7 @@ func restorePlanHook(
 		return nil, nil, err
 	}
 
-	fromFn, err := p.TypeAsStringArray(&restore.From)
+	fromFn, err := p.TypeAsStringArray(restore.From, "RESTORE")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -847,7 +847,10 @@ func restorePlanHook(
 		ctx, span := tracing.ChildSpan(baseCtx, stmt.StatementTag())
 		defer tracing.FinishSpan(span)
 
-		from := fromFn()
+		from, err := fromFn()
+		if err != nil {
+			return nil, err
+		}
 		description, err := restoreJobDescription(restore, from)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -45,8 +45,8 @@ var planHooks []planHookFn
 type PlanHookState interface {
 	ExecCfg() *ExecutorConfig
 	LeaseMgr() *LeaseManager
-	TypeAsString(e *parser.Expr) (func() string, error)
-	TypeAsStringArray(e *parser.Exprs) (func() []string, error)
+	TypeAsString(e parser.Expr, op string) (func() (string, error), error)
+	TypeAsStringArray(e parser.Exprs, op string) (func() ([]string, error), error)
 	User() string
 	AuthorizationAccessor
 }

--- a/pkg/sql/planner_test.go
+++ b/pkg/sql/planner_test.go
@@ -1,0 +1,87 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Jordan Lewis (jordan@cockroachlabs.com)
+
+package sql
+
+import (
+	"testing"
+
+	"reflect"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestTypeAsString(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	p := planner{}
+	testData := []struct {
+		expr        parser.Expr
+		expected    string
+		expectedErr bool
+	}{
+		{expr: parser.NewDString("foo"), expected: "foo"},
+		{
+			expr: &parser.BinaryExpr{
+				Operator: parser.Concat, Left: parser.NewDString("foo"), Right: parser.NewDString("bar")},
+			expected: "foobar",
+		},
+		{expr: parser.NewDInt(3), expectedErr: true},
+	}
+
+	t.Run("TypeAsString", func(t *testing.T) {
+		for _, td := range testData {
+			fn, err := p.TypeAsString(td.expr, "test")
+			if err != nil {
+				if !td.expectedErr {
+					t.Fatalf("expected no error; got %v", err)
+				}
+				continue
+			} else if td.expectedErr {
+				t.Fatal("expected error; got none")
+			}
+			s, err := fn()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if s != td.expected {
+				t.Fatalf("expected %s; got %s", td.expected, s)
+			}
+		}
+	})
+
+	t.Run("TypeAsStringArray", func(t *testing.T) {
+		for _, td := range testData {
+			fn, err := p.TypeAsStringArray([]parser.Expr{td.expr, td.expr}, "test")
+			if err != nil {
+				if !td.expectedErr {
+					t.Fatalf("expected no error; got %v", err)
+				}
+				continue
+			} else if td.expectedErr {
+				t.Fatal("expected error; got none")
+			}
+			a, err := fn()
+			if err != nil {
+				t.Fatal(err)
+			}
+			expected := []string{td.expected, td.expected}
+			if !reflect.DeepEqual(a, expected) {
+				t.Fatalf("expected %s; got %s", expected, a)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Previously, `TypeAsString` was duplicating some logic that already
exists in `TypeCheckAndRequire`. Running `expr.TypeCheck` will no longer
replace placeholders automatically, so code needs to switch to using
`parser.TypeCheck{AndRequire}` going forward.