### PR TITLE
check: add a new linter that checks that quoted URLs are live.

### DIFF
--- a/build/style_test.go
+++ b/build/style_test.go
@@ -803,4 +803,6 @@ func TestStyle(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("TestURLLiveness", func(t *testing.T) { testURLLiveness(t, pkg) })
 }

--- a/build/url_disabled_test.go
+++ b/build/url_disabled_test.go
@@ -1,0 +1,24 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build !urlcheck
+
+package build_test
+
+import (
+	"go/build"
+	"testing"
+)
+
+func testURLLiveness(*testing.T, *build.Package) {}

--- a/build/url_test.go
+++ b/build/url_test.go
@@ -1,0 +1,185 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build check,urlcheck
+
+package build_test
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"go/build"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ghemawat/stream"
+)
+
+// Number of concurrent HTTP requests during the test
+const concurrentRequests = 20
+
+// Source: https://mathiasbynens.be/demo/url-regex
+const urlRE = `https?://[^ \t\n/$.?#].[^ \t\n)]*(\)\.aspx)?`
+
+var re = regexp.MustCompile(urlRE)
+
+var ignored = []string{
+	// Invalid URLs
+	"http://%s",
+	"http://127.0.0.1",
+	"http://HOST:PORT/",
+	"http://\"",
+	"https://localhost",
+	"https://myroach:8080",
+	"http://localhost",
+	"https://127.0.0.1",
+	"https://\"",
+	"https://edge-binaries.cockroachdb.com/cockroach/cockroach.linux-gnu-amd64.${var.cockroach_sha}",
+	"https://edge-binaries.cockroachdb.com/examples-go/block_writer.${var.block_writer_sha}",
+	"https://edge-binaries.cockroachdb.com/examples-go/photos.${var.photos_sha}",
+	"https://github.com/cockroachdb/cockroach/commits/%s",
+	"https://github.com/cockroachdb/cockroach/issues/%d",
+	// These are cloud provider metadata endpoints.
+	"http://metadata/",
+	"http://instance-data/latest/meta-data/public-ipv4",
+	// All these are auto-generated and thus valid by definition.
+	"https://registry.yarnpkg.com/",
+	// XML namespace identifiers, these are not really HTTP endpoints.
+	"https://www.w3.org/",
+	"http://www.bohemiancoding.com/sketch/ns",
+	"http://www.w3.org/",
+	// These report 404 for non-API GETs.
+	"http://ignored:ignored@errors.cockroachdb.com/",
+	"https://cockroachdb.github.io/distsqlplan/",
+	"https://ignored:ignored@errors.cockroachdb.com/",
+	"https://register.cockroachdb.com",
+	"https://www.googleapis.com/auth",
+	// GitHub reports 404 for private repos without auth
+	"https://github.com/cockroachlabs/registration/",
+	// Regexp not too smart about HTML...
+	`http://www.cockroachlabs.com">http://www.cockroachlabs.com</a></span`,
+}
+
+func testURLLiveness(t *testing.T, pkg *build.Package) {
+	t.Parallel()
+
+	cmd, stderr, filter, err := dirCmd(pkg.Dir, "git", "grep", "-nE", urlRE)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	uniqueURLs := map[string][]string{}
+
+	if err := stream.ForEach(filter, func(s string) {
+		for _, match := range re.FindAllString(s, -1) {
+			// Remove punctuation after the URL
+			match = strings.TrimRight(match, ".,;\\\">`]")
+			// Remove the HTML target
+			n := strings.LastIndex(match, "#")
+			if n != -1 {
+				match = match[:n]
+			}
+			// Add the source reference to the list
+			l, _ := uniqueURLs[match]
+			l = append(l, s)
+			uniqueURLs[match] = l
+		}
+	}); err != nil {
+		t.Error(err)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		if out := stderr.String(); len(out) > 0 {
+			t.Fatalf("err=%s, stderr=%s", err, out)
+		}
+	}
+
+	var wg sync.WaitGroup
+	var sem = make(chan struct{}, concurrentRequests)
+
+	// This test doesn't care that https certificates are invalid.
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{
+		Transport: tr,
+		Timeout:   3 * time.Second,
+	}
+
+	for url, locs := range uniqueURLs {
+		ignore := false
+		for _, i := range ignored {
+			if strings.HasPrefix(url, i) {
+				ignore = true
+				break
+			}
+		}
+		if ignore {
+			continue
+		}
+
+		sem <- struct{}{}
+		wg.Add(1)
+		go func(url string, locs []string) {
+			defer func() { wg.Done(); <-sem }()
+
+			fmt.Fprintf(os.Stderr, "Checking %s...\n", url)
+			var buf bytes.Buffer
+			fmt.Fprintln(&buf, "Found in:")
+			for _, loc := range locs {
+				fmt.Fprintln(&buf, loc)
+			}
+
+			resp, err := client.Head(url)
+			if err != nil {
+				t.Errorf("while accessing %s: %v\n%s", url, err, buf.String())
+				return
+			}
+			io.Copy(ioutil.Discard, resp.Body)
+			resp.Body.Close()
+
+			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+				if resp.StatusCode == 405 {
+					// The server doesn't like HEAD. Try GET.
+					resp, err = client.Get(url)
+					if err != nil {
+						t.Errorf("while accessing %s: %v\n%s", url, err, buf.String())
+						return
+					}
+					io.Copy(ioutil.Discard, resp.Body)
+					resp.Body.Close()
+					if resp.StatusCode >= 200 || resp.StatusCode < 300 {
+						return
+					}
+				}
+
+				t.Errorf("while accessing %s: %s\n%s", url, resp.Status, buf.String())
+			}
+		}(url, locs)
+	}
+
+	wg.Wait()
+}

--- a/pkg/ccl/acceptanceccl/backup_test.go
+++ b/pkg/ccl/acceptanceccl/backup_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package acceptanceccl
 

--- a/pkg/ccl/acceptanceccl/main_test.go
+++ b/pkg/ccl/acceptanceccl/main_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package acceptanceccl
 

--- a/pkg/ccl/sqlccl/backup.go
+++ b/pkg/ccl/sqlccl/backup.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package sqlccl
 

--- a/pkg/ccl/sqlccl/backup.proto
+++ b/pkg/ccl/sqlccl/backup.proto
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 syntax = "proto3";
 package cockroach.ccl.sqlccl;

--- a/pkg/ccl/sqlccl/backup_cloud_test.go
+++ b/pkg/ccl/sqlccl/backup_cloud_test.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package sqlccl
 

--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package sqlccl
 

--- a/pkg/ccl/sqlccl/bench_test.go
+++ b/pkg/ccl/sqlccl/bench_test.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package sqlccl
 

--- a/pkg/ccl/sqlccl/kv_test.go
+++ b/pkg/ccl/sqlccl/kv_test.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package sqlccl
 

--- a/pkg/ccl/sqlccl/load.go
+++ b/pkg/ccl/sqlccl/load.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package sqlccl
 

--- a/pkg/ccl/sqlccl/load_test.go
+++ b/pkg/ccl/sqlccl/load_test.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package sqlccl
 

--- a/pkg/ccl/sqlccl/main_test.go
+++ b/pkg/ccl/sqlccl/main_test.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package sqlccl
 

--- a/pkg/ccl/sqlccl/progress.go
+++ b/pkg/ccl/sqlccl/progress.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package sqlccl
 

--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package sqlccl
 

--- a/pkg/ccl/sqlccl/targets.go
+++ b/pkg/ccl/sqlccl/targets.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package sqlccl
 

--- a/pkg/ccl/sqlccl/targets_test.go
+++ b/pkg/ccl/sqlccl/targets_test.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package sqlccl
 

--- a/pkg/ccl/storageccl/engineccl/main_test.go
+++ b/pkg/ccl/storageccl/engineccl/main_test.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package engineccl
 

--- a/pkg/ccl/storageccl/engineccl/multi_iterator.go
+++ b/pkg/ccl/storageccl/engineccl/multi_iterator.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package engineccl
 

--- a/pkg/ccl/storageccl/engineccl/multi_iterator_test.go
+++ b/pkg/ccl/storageccl/engineccl/multi_iterator_test.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package engineccl
 

--- a/pkg/ccl/storageccl/engineccl/rocksdb.go
+++ b/pkg/ccl/storageccl/engineccl/rocksdb.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package engineccl
 

--- a/pkg/ccl/storageccl/engineccl/rocksdb_test.go
+++ b/pkg/ccl/storageccl/engineccl/rocksdb_test.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package engineccl
 

--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package storageccl
 

--- a/pkg/ccl/storageccl/export_storage.go
+++ b/pkg/ccl/storageccl/export_storage.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package storageccl
 

--- a/pkg/ccl/storageccl/export_storage_test.go
+++ b/pkg/ccl/storageccl/export_storage_test.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package storageccl
 

--- a/pkg/ccl/storageccl/export_test.go
+++ b/pkg/ccl/storageccl/export_test.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package storageccl
 

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package storageccl
 

--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package storageccl
 

--- a/pkg/ccl/storageccl/limiter.go
+++ b/pkg/ccl/storageccl/limiter.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package storageccl
 

--- a/pkg/ccl/storageccl/main_test.go
+++ b/pkg/ccl/storageccl/main_test.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package storageccl
 

--- a/pkg/ccl/storageccl/writebatch.go
+++ b/pkg/ccl/storageccl/writebatch.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package storageccl
 

--- a/pkg/ccl/storageccl/writebatch_test.go
+++ b/pkg/ccl/storageccl/writebatch_test.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package storageccl
 

--- a/pkg/ccl/utilccl/intervalccl/main_test.go
+++ b/pkg/ccl/utilccl/intervalccl/main_test.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package intervalccl
 

--- a/pkg/ccl/utilccl/intervalccl/overlap_merge.go
+++ b/pkg/ccl/utilccl/intervalccl/overlap_merge.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package intervalccl
 

--- a/pkg/ccl/utilccl/intervalccl/overlap_merge_test.go
+++ b/pkg/ccl/utilccl/intervalccl/overlap_merge_test.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/pkg/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package intervalccl
 

--- a/pkg/util/tracing/span_context_carrier.pb.go
+++ b/pkg/util/tracing/span_context_carrier.pb.go
@@ -34,7 +34,7 @@ const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 
 // A SpanContextCarrier message holds metadata of a (potentially ongoing) span
 // of a distributed trace as per the OpenTracing specification. See
-// http://opentracing.io/spec/ for details.
+// http://opentracing.io/documentation/pages/spec for details.
 type SpanContextCarrier struct {
 	TraceID uint64            `protobuf:"varint,1,opt,name=trace_id,json=traceId,proto3" json:"trace_id,omitempty"`
 	SpanID  uint64            `protobuf:"varint,2,opt,name=span_id,json=spanId,proto3" json:"span_id,omitempty"`

--- a/pkg/util/tracing/span_context_carrier.proto
+++ b/pkg/util/tracing/span_context_carrier.proto
@@ -22,7 +22,7 @@ import "gogoproto/gogo.proto";
 
 // A SpanContextCarrier message holds metadata of a (potentially ongoing) span
 // of a distributed trace as per the OpenTracing specification. See
-// http://opentracing.io/spec/ for details.
+// http://opentracing.io/documentation/pages/spec for details.
 message SpanContextCarrier {
   uint64 trace_id = 1 [(gogoproto.customname) = "TraceID"];
   uint64 span_id = 2 [(gogoproto.customname) = "SpanID"];


### PR DESCRIPTION
This was requested by @sploiselle in https://github.com/cockroachdb/cockroach/pull/13540#issuecomment-279493990

Fixes #15752.
Fixes  #15844.