### PR TITLE
storage: prevent removed replica from getting lease

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1082,7 +1082,7 @@ func (l Lease) Type() LeaseType {
 // Ignore proposed timestamps for lease verification; for epoch-
 // based leases, the start time of the lease is sufficient to
 // avoid using an older lease with same epoch.
-func (l Lease) Equivalent(ol Lease) error {
+func (l Lease) Equivalent(ol Lease) bool {
 	// Ignore proposed timestamp & deprecated start stasis.
 	l.ProposedTS, ol.ProposedTS = nil, nil
 	l.DeprecatedStartStasis = ol.DeprecatedStartStasis
@@ -1096,10 +1096,7 @@ func (l Lease) Equivalent(ol Lease) error {
 		l.Expiration.Less(ol.Expiration) {
 		l.Expiration = ol.Expiration
 	}
-	if l == ol {
-		return nil
-	}
-	return errors.Errorf("leases %+v and %+v are not equivalent", l, ol)
+	return l == ol
 }
 
 // AsIntents takes a slice of spans and returns it as a slice of intents for

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -629,8 +629,8 @@ func TestLeaseEquivalence(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		if err := tc.l.Equivalent(tc.ol); tc.expSuccess != (err == nil) {
-			t.Errorf("%d: expected success? %t; got %s", i, tc.expSuccess, err)
+		if ok := tc.l.Equivalent(tc.ol); tc.expSuccess != ok {
+			t.Errorf("%d: expected success? %t; got %t", i, tc.expSuccess, ok)
 		}
 	}
 }

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -588,8 +588,8 @@ func TestRangeTransferLease(t *testing.T) {
 				t.Fatal(err)
 			}
 			newLease, _ := replica0.GetLease()
-			if err := origLease.Equivalent(newLease); err != nil {
-				t.Fatal(err)
+			if !origLease.Equivalent(newLease) {
+				t.Fatalf("original lease %v and new lease %v not equivalent", origLease, newLease)
 			}
 		}
 


### PR DESCRIPTION
Out for early review since the fix seems easier than what has been proposed
in #15385 so far. Will add tests in this PR.

Only review my commits, those of @andreimatei are from #15711 (which is
waiting for @bdarnell as well).

---

Make sure that a lease with an intended lease holder that has since been
removed catches a forcedError.

See #15385.