### PR TITLE
log: send crash reports from dev build to separate collector

### DIFF
--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -19,6 +19,7 @@ package build
 import (
 	"fmt"
 	"runtime"
+	"strings"
 	"time"
 )
 
@@ -49,6 +50,11 @@ var (
 	Distribution = "OSS"
 	typ          string // Type of this build; <empty>, "release", or "musl"
 )
+
+// IsRelease returns true if the binary was produced by a "release" build.
+func IsRelease() bool {
+	return strings.HasPrefix(typ, "release")
+}
 
 // Short returns a pretty printed build and version summary.
 func (b Info) Short() string {


### PR DESCRIPTION
we technically can sort them by the enviornment after collection, but a separate collector
can allow us to send to a different (or no) project to make it easier to manage.