### PR TITLE
1.0x cherrypick: build: separate S3 binary upload from docker.

### DIFF
--- a/build/teamcity-publish-artifacts.sh
+++ b/build/teamcity-publish-artifacts.sh
@@ -1,34 +1,13 @@
 #!/usr/bin/env bash
 
 # Any arguments to this script are passed through unmodified to
-# ./pkg/cmd/publish-artifacts.
+# ./build/teamcity-publish-s3-binaries.
 
 set -euxo pipefail
 
 export BUILDER_HIDE_GOPATH_SRC=1
 
-echo 'starting release build'
-cat .buildinfo/tag || true
-cat .buildinfo/rev || true
-build/builder.sh git status
-
-build/builder.sh go install ./pkg/cmd/publish-artifacts
-
-echo 'installed release builder'
-cat .buildinfo/tag || true
-cat .buildinfo/rev || true
-build/builder.sh git status
-
-build/builder.sh env \
-	AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
-	AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
-	TC_BUILD_BRANCH="$TC_BUILD_BRANCH" \
-	publish-artifacts "$@"
-
-echo 'built and uploaded artifacts'
-cat .buildinfo/tag || true
-cat .buildinfo/rev || true
-build/builder.sh git status
+build/teamcity-publish-s3-binaries "$@"
 
 if [ "$TC_BUILD_BRANCH" != master ]; then
 	image=docker.io/cockroachdb/cockroach

--- a/build/teamcity-publish-s3-binaries.sh
+++ b/build/teamcity-publish-s3-binaries.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Any arguments to this script are passed through unmodified to
+# ./pkg/cmd/publish-artifacts.
+
+set -euxo pipefail
+
+export BUILDER_HIDE_GOPATH_SRC=1
+
+echo 'starting release build'
+cat .buildinfo/tag || true
+cat .buildinfo/rev || true
+build/builder.sh git status
+
+build/builder.sh go install ./pkg/cmd/publish-artifacts
+
+echo 'installed release builder'
+cat .buildinfo/tag || true
+cat .buildinfo/rev || true
+build/builder.sh git status
+
+build/builder.sh env \
+	AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+	AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+	TC_BUILD_BRANCH="$TC_BUILD_BRANCH" \
+	publish-artifacts "$@"
+
+echo 'built and uploaded artifacts'
+cat .buildinfo/tag || true
+cat .buildinfo/rev || true
+build/builder.sh git status

--- a/pkg/cmd/publish-artifacts/main.go
+++ b/pkg/cmd/publish-artifacts/main.go
@@ -114,6 +114,7 @@ func main() {
 	} else {
 		bucketName = "cockroach"
 	}
+	log.Printf("Using S3 bucket: %s", bucketName)
 
 	// TODO(tamird,benesch,bdarnell): make "latest" a website-redirect
 	// rather than a full key. This means that the actual artifact will no


### PR DESCRIPTION
Cherrypicking #15768

This is to be able to call just the S3 upload from the test release
pipeline.