### PR TITLE
storage: Add env var for configuring raft election timeout ticks

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -63,9 +63,8 @@ import (
 
 const (
 	// rangeIDAllocCount is the number of Range IDs to allocate per allocation.
-	rangeIDAllocCount               = 10
-	defaultHeartbeatIntervalTicks   = 5
-	defaultRaftElectionTimeoutTicks = 15
+	rangeIDAllocCount             = 10
+	defaultHeartbeatIntervalTicks = 5
 	// ttlStoreGossip is time-to-live for store-related info.
 	ttlStoreGossip = 2 * time.Minute
 
@@ -118,6 +117,9 @@ var changeTypeInternalToRaft = map[roachpb.ReplicaChangeType]raftpb.ConfChangeTy
 	roachpb.ADD_REPLICA:    raftpb.ConfChangeAddNode,
 	roachpb.REMOVE_REPLICA: raftpb.ConfChangeRemoveNode,
 }
+
+var defaultRaftElectionTimeoutTicks = envutil.EnvOrDefaultInt(
+	"COCKROACH_RAFT_ELECTION_TIMEOUT_TICKS", 15)
 
 var storeSchedulerConcurrency = envutil.EnvOrDefaultInt(
 	"COCKROACH_SCHEDULER_CONCURRENCY", 8*runtime.NumCPU())


### PR DESCRIPTION
To ensure that anyone who hits #15702 can at least get themselves out of the situation.

We'll also probably want to recommend that anyone who hits it decrease the `kv.raft.command.max_size` setting, but luckily that option already exists. Some more testing is needed before we can really recommend whether that's needed preemptively.