### PR TITLE
sql: fix panic in max(true), min(true)

### DIFF
--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -474,7 +474,7 @@ func (n *groupNode) addIsNotNullFilter(where *filterNode, render *renderNode) {
 		where.ivarHelper.Rebind(
 			render.render[n.desiredOrdering[0].ColIdx],
 			false, // alsoReset
-			false, // normalizeToNonNil
+			true,  // normalizeToNonNil
 		),
 		parser.DNull,
 	)

--- a/pkg/sql/testdata/logic_test/aggregate
+++ b/pkg/sql/testdata/logic_test/aggregate
@@ -1263,3 +1263,9 @@ SELECT TO_HEX(XOR_AGG(a)), b, XOR_AGG(c) FROM xor_bytes GROUP BY b ORDER BY b
 
 statement error arguments to xor must all be the same length
 SELECT XOR_AGG(i) FROM (VALUES (b'\x01'), (b'\x01\x01')) AS a(i)
+
+query BB
+SELECT MAX(true), MIN(true)
+----
+true
+true


### PR DESCRIPTION
Since 9b14155, single-argument aggregate functions would panic the server
in certain circumstances due to a misuse of `IndexedVarHelper.Rebind`
when creating the implicit `NOT NULL` constraint on the argument.

Fixes #15800.