### PR TITLE
acceptance: De-flake and unskip TestClusterRecovery

### DIFF
--- a/pkg/acceptance/zchaos_test.go
+++ b/pkg/acceptance/zchaos_test.go
@@ -134,6 +134,11 @@ func transferMoney(client *testClient, numAccounts, maxTransfer int) error {
 	client.RLock()
 	defer client.RUnlock()
 	_, err := client.db.Exec(update, from, to, amount)
+	if err == nil {
+		// Do all increments under the read lock so that grabbing a write lock in
+		// chaosMonkey below guarantees no more increments could be incoming.
+		atomic.AddUint64(&client.count, 1)
+	}
 	return err
 }
 
@@ -170,9 +175,6 @@ func transferMoneyLoop(
 				state.errChan <- err
 				break
 			}
-		} else {
-			// Only advance the counts on a successful update.
-			atomic.AddUint64(&client.count, 1)
 		}
 	}
 	log.Infof(ctx, "client %d shutting down", idx)
@@ -239,10 +241,13 @@ func chaosMonkey(
 
 		preCount := state.counts()
 
+		progressIdx := 0
 		madeProgress := func() bool {
 			newCounts := state.counts()
 			for i := range newCounts {
 				if newCounts[i] > preCount[i] {
+					log.Infof(ctx, "progress made by client %d", i)
+					progressIdx = i
 					return true
 				}
 			}
@@ -254,9 +259,20 @@ func chaosMonkey(
 		for !state.done() && !madeProgress() {
 			time.Sleep(time.Second)
 		}
+		if state.done() {
+			log.Infof(ctx, "round %d: not waiting for recovery due to signal that we're done", curRound)
+			return
+		}
 		c.Assert(ctx, state.t)
 
-		if err := cluster.Consistent(ctx, c, consistentIdx); err != nil {
+		// If a particular node index wasn't specified, use the index that informed
+		// us about progress having been made.
+		idx := consistentIdx
+		if idx < 0 {
+			idx = progressIdx
+		}
+		if err := cluster.Consistent(ctx, c, idx); err != nil {
+			log.Errorf(ctx, "round %d: failed to do consistency check against node %d", curRound, idx)
 			state.t.Error(err)
 		}
 		log.Warningf(ctx, "round %d: cluster recovered", curRound)
@@ -319,8 +335,6 @@ func waitClientsStop(ctx context.Context, num int, state *testState, stallDurati
 // being killed and restarted continuously. The test doesn't measure write
 // performance, but cluster recovery.
 func TestClusterRecovery(t *testing.T) {
-	t.Skip("#15620")
-
 	s := log.Scope(t)
 	defer s.Close(t)
 
@@ -361,7 +375,7 @@ func testClusterRecoveryInner(
 	pickNodes := func() []int {
 		return rnd.Perm(num)[:rnd.Intn(num)+1]
 	}
-	go chaosMonkey(ctx, &state, c, true, pickNodes, 0)
+	go chaosMonkey(ctx, &state, c, true, pickNodes, -1)
 
 	waitClientsStop(ctx, num, &state, stall)
 


### PR DESCRIPTION
Because TestClusterRecovery picks a random subset of nodes (including
possibly all the nodes), attempting to pick a safe index to rely on
being running is bound to fail once in a while. Get around this by
always doing the follow-up consistency check against a node that is
responsive.

Also, there's a very small chance that an increment could be coming
in to the count variable after the clients are supposed to have been
shut down, so make sure that it only gets incremented under lock.

Finally, there was a chance that the test could fail simply due to it
deciding it had run for long enough at an inopportune time, causing the
subsequent consistency check to not be able to connect to a node.

Fixes #15620 (I think)