### PR TITLE
sql: re-prevent panic in CREATE VIEW

### DIFF
--- a/pkg/sql/testdata/logic_test/views
+++ b/pkg/sql/testdata/logic_test/views
@@ -357,5 +357,16 @@ CREATE TABLE t2 AS SELECT d, t FROM t AS OF SYSTEM TIME '2017-02-13 21:30:00'
 statement ok
 DROP TABLE t CASCADE
 
-statement error value type int\[\] cannot be used for table columns
-CREATE VIEW fail AS SELECT ARRAY[2]
+statement error cannot make array for column type BOOL
+CREATE VIEW fail AS SELECT ARRAY[true]
+
+statement error arrays of type STRING are unsupported
+CREATE VIEW fail AS SELECT ARRAY['foo']
+
+statement ok
+CREATE VIEW arr(a) AS SELECT ARRAY[3]
+
+query TI
+SELECT *, a[1] FROM arr
+----
+{3}  3


### PR DESCRIPTION
Some merge skew with #15639 caused the original fix to not really work.
Array types are now permitted in `CastTargetToDatumType`, so we need to
validate the result of its output in `CREATE VIEW` before passing it
onward. This validation code was already there, but unfortunately
occurred slightly too late to prevent issues. The validation now occurs
soon enough to prevent trouble.

Fixes #15810.
Fixes #15809.