### PR TITLE
testcluster: Fix AddReplicas to wait until replica is part of range

### DIFF
--- a/pkg/storage/gossip_test.go
+++ b/pkg/storage/gossip_test.go
@@ -137,7 +137,6 @@ func TestGossipFirstRange(t *testing.T) {
 // restarted after losing its data) without the cluster breaking.
 func TestGossipHandlesReplacedNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#15585")
 	ctx := context.Background()
 
 	// Shorten the raft tick interval and election timeout to make range leases
@@ -179,6 +178,7 @@ func TestGossipHandlesReplacedNode(t *testing.T) {
 	newServerArgs.Addr = tc.Servers[oldNodeIdx].ServingAddr()
 	newServerArgs.PartOfCluster = true
 	newServerArgs.JoinAddr = tc.Servers[1].ServingAddr()
+	log.Infof(ctx, "stopping server %d", oldNodeIdx)
 	tc.StopServer(oldNodeIdx)
 	if err := tc.AddServer(t, newServerArgs); err != nil {
 		t.Fatal(err)

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -361,8 +361,13 @@ func (tc *TestCluster) AddReplicas(
 				log.Errorf(context.TODO(), "unexpected error: %s", err)
 				return err
 			}
-			if store.LookupReplica(rKey, nil) == nil {
+			repl := store.LookupReplica(rKey, nil)
+			if repl == nil {
 				return errors.Errorf("range not found on store %d", target)
+			}
+			desc := repl.Desc()
+			if _, ok := desc.GetReplicaDescriptor(target.StoreID); !ok {
+				return errors.Errorf("target store %d not yet in range descriptor %v", target.StoreID, desc)
 			}
 		}
 		return nil


### PR DESCRIPTION
And unskip TestGossipHandlesReplacedNode which is fixed by the change.

Fixes #15585 (and possibly other tests that call AddReplicas, but I'm
not sure which others may have been broken by this).