### PR TITLE
sql/parser: encodeSQLIdent double quotes lookahead keywords

### DIFF
--- a/pkg/sql/parser/encode.go
+++ b/pkg/sql/parser/encode.go
@@ -116,9 +116,7 @@ func encodeSQLStringWithFlags(buf *bytes.Buffer, in string, f FmtFlags) {
 }
 
 func encodeSQLIdent(buf *bytes.Buffer, s string) {
-	// To round trip without quotes, the string must match the identifier format
-	// and be normalized.
-	if isIdent(s) && Name(s).Normalize() == s {
+	if isNonKeywordBareIdentifier(s) {
 		buf.WriteString(s)
 		return
 	}

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -372,6 +372,7 @@ func TestParse(t *testing.T) {
 		{`SELECT 'a' FROM t@bar`},
 		{`SELECT 'a' FROM t@{NO_INDEX_JOIN}`},
 		{`SELECT 'a' FROM t@{FORCE_INDEX=bar,NO_INDEX_JOIN}`},
+		{`SELECT * FROM t AS "of" AS OF SYSTEM TIME '2016-01-01'`},
 
 		{`SELECT '1':::INT`},
 

--- a/pkg/sql/testdata/logic_test/information_schema
+++ b/pkg/sql/testdata/logic_test/information_schema
@@ -892,4 +892,3 @@ root     def            INSERT          NULL
 root     def            SELECT          NULL
 root     def            UPDATE          NULL
 
-

--- a/pkg/sql/testdata/logic_test/needed_columns
+++ b/pkg/sql/testdata/logic_test/needed_columns
@@ -66,10 +66,10 @@ EXPLAIN (METADATA) SELECT 1 FROM (SELECT 1 AS s UNION ALL SELECT 2 AS s)
 query ITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM (SELECT 1 AS s) WITH ORDINALITY
 ----
-0   render                             ("1")
-1   ordinality                         (s[omitted], ordinality)   +ordinality,unique
-2   render                             (s[omitted])
-3   nullrow                            ()
+0  render          ("1")
+1  ordinality      (s[omitted], "ordinality")  +"ordinality",unique
+2  render          (s[omitted])
+3  nullrow         ()
 
 # Propagation through sort, when the sorting column is in the results.
 query ITTTTT

--- a/pkg/sql/testdata/logic_test/order_by
+++ b/pkg/sql/testdata/logic_test/order_by
@@ -627,7 +627,7 @@ query ITTT
 EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality DESC
 ----
 0  sort
-0              order  -ordinality
+0              order  -"ordinality"
 1  ordinality
 2  values
 2              size   1 column, 3 rows
@@ -635,7 +635,7 @@ EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordi
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY
 ----
-0  ordinality                          (x, ordinality)  +ordinality,unique
+0  ordinality                          (x, "ordinality")  +"ordinality",unique
 1  render                              (x)
 2  values                              (column1)
 2              size  1 column, 3 rows
@@ -643,8 +643,8 @@ EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS 
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY
 ----
-0  ordinality                           (x, ordinality)  +x
-1  sort                                 (x)              +x
+0  ordinality                           (x, "ordinality")  +x
+1  sort                                 (x)                +x
 1              order  +x
 2  render                               (x)
 3  values                               (column1)

--- a/pkg/sql/testdata/logic_test/ordinality
+++ b/pkg/sql/testdata/logic_test/ordinality
@@ -85,8 +85,8 @@ true
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM foo WHERE x > 'a') WITH ORDINALITY
 ----
-0  ordinality                      (x, ordinality)  +x,unique
-1  scan                            (x)              +x,unique
+0  ordinality                      (x, "ordinality")  +x,unique
+1  scan                            (x)                +x,unique
 1              table  foo@primary
 1              spans  /"a\x00"-
 
@@ -95,8 +95,8 @@ EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM foo WHERE x > 'a') WITH ORDINALI
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM foo WITH ORDINALITY WHERE x > 'a'
 ----
-0  filter                          (x, ordinality)  +x,unique
-1  ordinality                      (x, ordinality)  +x,unique
-2  scan                            (x)              +x,unique
+0  filter                          (x, "ordinality")  +x,unique
+1  ordinality                      (x, "ordinality")  +x,unique
+2  scan                            (x)                +x,unique
 2              table  foo@primary
 2              spans  ALL


### PR DESCRIPTION
encodeSQLIdent currently does not quote non-reserved keywords, which
causes statements like
`SELECT * FROM t AS "of" AS OF SYSTEM TIME '2016-01-01'` to be formatted
improperly.

Since encodeSQLIdent is the only user of reservedKeywords, delete it and
its generating script.