### PR TITLE
log: disable crash reports from non-release binaries

### DIFF
--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -100,8 +100,6 @@ var crashReportURL = func() string {
 	var defaultURL string
 	if build.IsRelease() {
 		defaultURL = "https://ignored:ignored@errors.cockroachdb.com/sentry"
-	} else {
-		defaultURL = "https://ignored:ignored@errors.cockroachdb.com/sentrydev"
 	}
 	return envutil.EnvOrDefaultString("COCKROACH_CRASH_REPORTS", defaultURL)
 }()


### PR DESCRIPTION
developers add placeholder panics during local development all the time,
and might be surprised that they get reported.

Requested by @danhhz