### PR TITLE
sql: don't allocate apd.Decimals unnecessarily

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -533,9 +533,9 @@ func (v Value) GetDuration() (duration.Duration, error) {
 
 // GetDecimal decodes a decimal value from the bytes of the receiver. If the
 // tag is not DECIMAL an error will be returned.
-func (v Value) GetDecimal() (*apd.Decimal, error) {
+func (v Value) GetDecimal() (apd.Decimal, error) {
 	if tag := v.GetTag(); tag != ValueType_DECIMAL {
-		return nil, fmt.Errorf("value type is not %s: %s", ValueType_DECIMAL, tag)
+		return apd.Decimal{}, fmt.Errorf("value type is not %s: %s", ValueType_DECIMAL, tag)
 	}
 	return encoding.DecodeNonsortingDecimal(v.dataBytes(), nil)
 }
@@ -643,7 +643,7 @@ func (v Value) PrettyPrint() string {
 		t, err = v.GetTime()
 		buf.WriteString(t.UTC().Format(time.RFC3339Nano))
 	case ValueType_DECIMAL:
-		var d *apd.Decimal
+		var d apd.Decimal
 		d, err = v.GetDecimal()
 		buf.WriteString(d.String())
 	case ValueType_DURATION:

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -290,8 +290,8 @@ func TestSetGetChecked(t *testing.T) {
 	}
 	if r, err := v.GetDecimal(); err != nil {
 		t.Fatal(err)
-	} else if dec.Cmp(r) != 0 {
-		t.Errorf("set %s on a value and extracted it, expected %s back, but got %s", dec, dec, r)
+	} else if dec.Cmp(&r) != 0 {
+		t.Errorf("set %s on a value and extracted it, expected %s back, but got %s", dec, dec, &r)
 	}
 
 	if err := v.SetProto(&Value{}); err != nil {

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -1050,14 +1050,13 @@ func DecodeTableKey(
 		}
 		return a.NewDFloat(parser.DFloat(f)), rkey, err
 	case parser.TypeDecimal:
-		var d *apd.Decimal
+		var d apd.Decimal
 		if dir == encoding.Ascending {
 			rkey, d, err = encoding.DecodeDecimalAscending(key, nil)
 		} else {
 			rkey, d, err = encoding.DecodeDecimalDescending(key, nil)
 		}
-		dd := a.NewDDecimal(parser.DDecimal{})
-		dd.Set(d)
+		dd := a.NewDDecimal(parser.DDecimal{Decimal: d})
 		return dd, rkey, err
 	case parser.TypeString:
 		var r string
@@ -1161,10 +1160,9 @@ func DecodeTableValue(a *DatumAlloc, valType parser.Type, b []byte) (parser.Datu
 		b, f, err = encoding.DecodeFloatValue(b)
 		return a.NewDFloat(parser.DFloat(f)), b, err
 	case parser.TypeDecimal:
-		var d *apd.Decimal
+		var d apd.Decimal
 		b, d, err = encoding.DecodeDecimalValue(b)
-		dd := a.NewDDecimal(parser.DDecimal{})
-		dd.Set(d)
+		dd := a.NewDDecimal(parser.DDecimal{Decimal: d})
 		return dd, b, err
 	case parser.TypeString:
 		var data []byte
@@ -1473,8 +1471,7 @@ func UnmarshalColumnValue(
 		if err != nil {
 			return nil, err
 		}
-		dd := a.NewDDecimal(parser.DDecimal{})
-		dd.Set(v)
+		dd := a.NewDDecimal(parser.DDecimal{Decimal: v})
 		return dd, nil
 	case ColumnType_STRING:
 		v, err := value.GetBytes()

--- a/pkg/util/encoding/decimal_test.go
+++ b/pkg/util/encoding/decimal_test.go
@@ -101,10 +101,10 @@ func encodeDecimalWithDir(dir Direction, buf []byte, d *apd.Decimal) []byte {
 
 func decodeDecimalWithDir(
 	t *testing.T, dir Direction, buf []byte, tmp []byte,
-) ([]byte, *apd.Decimal) {
+) ([]byte, apd.Decimal) {
 	var err error
 	var resBuf []byte
-	var res *apd.Decimal
+	var res apd.Decimal
 	if dir == Ascending {
 		resBuf, res, err = DecodeDecimalAscending(buf, tmp)
 	} else {
@@ -257,7 +257,7 @@ func TestEncodeDecimalRand(t *testing.T) {
 				tmp = randBuf(rng, 100)
 			}
 			var enc []byte
-			var res *apd.Decimal
+			var res apd.Decimal
 			var err error
 			if dir == Ascending {
 				enc = EncodeDecimalAscending(appendTo, cur)
@@ -275,7 +275,7 @@ func TestEncodeDecimalRand(t *testing.T) {
 			testPeekLength(t, enc)
 
 			// Make sure we decode the same value we encoded.
-			if cur.Cmp(res) != 0 {
+			if cur.Cmp(&res) != 0 {
 				t.Fatalf("unexpected mismatch for %v, got %v", cur, res)
 			}
 
@@ -421,7 +421,7 @@ func TestNonsortingEncodeDecimalRand(t *testing.T) {
 		}
 
 		// Make sure we decode the same value we encoded.
-		if cur.Cmp(res) != 0 {
+		if cur.Cmp(&res) != 0 {
 			t.Fatalf("unexpected mismatch for %v, got %v", cur, res)
 		}
 

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -993,7 +993,7 @@ func prettyPrintFirstValue(b []byte) ([]byte, string, error) {
 		}
 		return b, strconv.FormatFloat(f, 'g', -1, 64), nil
 	case Decimal:
-		var d *apd.Decimal
+		var d apd.Decimal
 		b, d, err = DecodeDecimalAscending(b, nil)
 		if err != nil {
 			return b, "", err
@@ -1345,15 +1345,15 @@ func DecodeTimeValue(b []byte) (remaining []byte, t time.Time, err error) {
 }
 
 // DecodeDecimalValue decodes a value encoded by EncodeDecimalValue.
-func DecodeDecimalValue(b []byte) (remaining []byte, d *apd.Decimal, err error) {
+func DecodeDecimalValue(b []byte) (remaining []byte, d apd.Decimal, err error) {
 	b, err = decodeValueTypeAssert(b, Decimal)
 	if err != nil {
-		return b, nil, err
+		return b, apd.Decimal{}, err
 	}
 	var i uint64
 	b, _, i, err = DecodeNonsortingUvarint(b)
 	if err != nil {
-		return b, nil, err
+		return b, apd.Decimal{}, err
 	}
 	d, err = DecodeNonsortingDecimal(b[:int(i)], nil)
 	return b[int(i):], d, err
@@ -1503,7 +1503,7 @@ func PrettyPrintValueEncoded(b []byte) ([]byte, string, error) {
 		}
 		return b, strconv.FormatFloat(f, 'g', -1, 64), nil
 	case Decimal:
-		var d *apd.Decimal
+		var d apd.Decimal
 		b, d, err = DecodeDecimalValue(b)
 		if err != nil {
 			return b, "", err

--- a/pkg/util/encoding/encoding_test.go
+++ b/pkg/util/encoding/encoding_test.go
@@ -1552,7 +1552,7 @@ func randValueEncode(rd randData, buf []byte, colID uint32, typ Type) ([]byte, i
 		return EncodeFloatValue(buf, colID, x), x, true
 	case Decimal:
 		x := rd.decimal()
-		return EncodeDecimalValue(buf, colID, x), x, true
+		return EncodeDecimalValue(buf, colID, x), *x, true
 	case Bytes:
 		x := randutil.RandBytes(rd.Rand, 100)
 		return EncodeBytesValue(buf, colID, x), x, true
@@ -1724,7 +1724,9 @@ func TestValueEncodingRand(t *testing.T) {
 				t.Fatalf("seed %d: %s got %x expected %x", seed, typ, decoded.([]byte), value.([]byte))
 			}
 		case Decimal:
-			if decoded.(*apd.Decimal).Cmp(value.(*apd.Decimal)) != 0 {
+			d := decoded.(apd.Decimal)
+			val := value.(apd.Decimal)
+			if d.Cmp(&val) != 0 {
 				t.Fatalf("seed %d: %s got %v expected %v", seed, typ, decoded, value)
 			}
 		default:


### PR DESCRIPTION
The functions that decode decimals allocate a `*apd.Decimal`; many times this is
just a temporary variable. This is costly and unnecessary (the type is just a
slice plus a few integers). Switching to returning `apd.Decimal` directly.

We were also doing `Set` (which makes a copy) in a couple of places even though 
the source was a throw-away variable. Changed to just initialize 
`DDecimal.Decimal` with the value.
