### PR TITLE
sql: limit non-table decimal types in casts

### DIFF
--- a/pkg/sql/parser/col_types.go
+++ b/pkg/sql/parser/col_types.go
@@ -19,7 +19,10 @@ package parser
 import (
 	"bytes"
 	"fmt"
+	"math"
 
+	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/pkg/errors"
 )
 
@@ -187,6 +190,44 @@ func (node *DecimalColType) Format(buf *bytes.Buffer, f FmtFlags) {
 		}
 		buf.WriteByte(')')
 	}
+}
+
+// LimitDecimalWidth limits d's precision (total number of digits) and scale
+// (number of digits after the decimal point).
+func LimitDecimalWidth(d *apd.Decimal, precision, scale int) error {
+	if d.Form != apd.Finite || precision <= 0 {
+		return nil
+	}
+	// Use +1 here because it is inverted later.
+	if scale < math.MinInt32+1 || scale > math.MaxInt32 {
+		return errors.New("scale out of range")
+	}
+	if scale > precision {
+		return pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError, "scale (%d) must be between 0 and precision (%d)", scale, precision)
+	}
+
+	// http://www.postgresql.org/docs/9.5/static/datatype-numeric.html
+	// "If the scale of a value to be stored is greater than
+	// the declared scale of the column, the system will round the
+	// value to the specified number of fractional digits. Then,
+	// if the number of digits to the left of the decimal point
+	// exceeds the declared precision minus the declared scale, an
+	// error is raised."
+
+	c := DecimalCtx.WithPrecision(uint32(precision))
+	c.Traps = apd.InvalidOperation
+
+	if _, err := c.Quantize(d, d, -int32(scale)); err != nil {
+		var lt string
+		switch v := precision - scale; v {
+		case 0:
+			lt = "1"
+		default:
+			lt = fmt.Sprintf("10^%d", v)
+		}
+		return pgerror.NewErrorf(pgerror.CodeNumericValueOutOfRangeError, "value with precision %d, scale %d must round to an absolute value less than %s", precision, scale, lt)
+	}
+	return nil
 }
 
 // Pre-allocated immutable date column type.

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -1581,23 +1581,8 @@ func CheckValueWidth(col ColumnDescriptor, val parser.Datum) error {
 		}
 	case ColumnType_DECIMAL:
 		if v, ok := val.(*parser.DDecimal); ok {
-			if v.Decimal.Form == apd.Finite && col.Type.Precision > 0 {
-				// http://www.postgresql.org/docs/9.5/static/datatype-numeric.html
-				// "If the scale of a value to be stored is greater than
-				// the declared scale of the column, the system will round the
-				// value to the specified number of fractional digits. Then,
-				// if the number of digits to the left of the decimal point
-				// exceeds the declared precision minus the declared scale, an
-				// error is raised."
-
-				c := parser.DecimalCtx.WithPrecision(uint32(col.Type.Precision))
-				c.Traps = apd.InvalidOperation
-
-				_, err := c.Quantize(&v.Decimal, &v.Decimal, -col.Type.Width)
-				if err != nil {
-					return errors.Errorf("too many digits for type %s (column %q), ",
-						col.Type.SQLString(), col.Name)
-				}
+			if err := parser.LimitDecimalWidth(&v.Decimal, int(col.Type.Precision), int(col.Type.Width)); err != nil {
+				return errors.Wrapf(err, "type %s (column %q)", col.Type.SQLString(), col.Name)
 			}
 		}
 	}

--- a/pkg/sql/testdata/logic_test/decimal
+++ b/pkg/sql/testdata/logic_test/decimal
@@ -231,3 +231,17 @@ SELECT * FROM s@idx WHERE d = 10
 10.0000
 10.00000
 10.000000
+
+query R
+SELECT 1.00::decimal(6,4)
+----
+1.0000
+
+statement error value with precision 6, scale 4 must round to an absolute value less than 10\^2
+SELECT 101.00::decimal(6,4)
+
+statement error scale \(6\) must be between 0 and precision \(4\)
+SELECT 101.00::decimal(4,6)
+
+statement error value with precision 2, scale 2 must round to an absolute value less than 1
+SELECT 1::decimal(2, 2)

--- a/pkg/sql/testdata/logic_test/scale
+++ b/pkg/sql/testdata/logic_test/scale
@@ -69,7 +69,7 @@ INSERT INTO td VALUES (DECIMAL '3.14')
 statement error duplicate
 INSERT INTO td VALUES (DECIMAL '3.1415')
 
-statement error too many digits for type DECIMAL\(3,2\) \(column "d"\)
+statement error type DECIMAL\(3,2\) \(column "d"\): value with precision 3, scale 2 must round to an absolute value less than 10\^1
 INSERT INTO td VALUES (DECIMAL '13.1415')
 
 query R rowsort
@@ -78,7 +78,7 @@ SELECT d FROM td
 3.10
 3.14
 
-statement error too many digits
+statement error must round
 UPDATE td SET d = DECIMAL '101.414' WHERE d = DECIMAL '3.14'
 
 statement ok
@@ -118,5 +118,5 @@ select * from td3
 ----
 123456789012.123456789012 12.3 1234567890.1234567890
 
-statement error too many digits
+statement error must round
 INSERT INTO td3 (c) VALUES (12345678901)


### PR DESCRIPTION
While here change the error message to be more similar to postgres.

Fixes #15833