### PR TITLE
storage: Add fatal log to help understand txns in lease request errors

### DIFF
--- a/pkg/storage/replica_range_lease.go
+++ b/pkg/storage/replica_range_lease.go
@@ -211,6 +211,11 @@ func (p *pendingLeaseRequest) requestLeaseAsync(
 			ba.RangeID = repl.RangeID
 			ba.Add(leaseReq)
 			_, pErr = repl.Send(ctx, ba)
+			// TODO(a-robinson): Remove this check after it's gotten some mileage in
+			// on test clusters or we gain an understanding of #10940.
+			if txn := pErr.GetTxn(); txn != nil {
+				log.Fatalf(ctx, "unexpected non-nil transaction %v in error from LeaseRequest %+v: %+v", txn, leaseReq, pErr)
+			}
 		}
 		// We reset our state below regardless of whether we've gotten an error or
 		// not, but note that an error is ambiguous - there's no guarantee that the


### PR DESCRIPTION
To begin addressing #10940

Since so many of our clusters are currently occupied and some local testing couldn't repro anything, let's just commit this and see what happens during the normal rollout processes.

@tschottdorf 