### PR TITLE
sql/parser: add fnv and crc hash builtins

### DIFF
--- a/pkg/sql/testdata/logic_test/builtin_function
+++ b/pkg/sql/testdata/logic_test/builtin_function
@@ -231,6 +231,16 @@ SELECT sha256('abc')
 ----
 ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
 
+query IIII
+SELECT fnv32('abc'), fnv32a('abc'), fnv64('abc'), fnv64a('abc')
+----
+1134309195  440920331  -2820157060406071861  -1792535898324117685
+
+query II
+SELECT crc32ieee('abc'), crc32c('abc')
+----
+891568578  910901175
+
 query T
 SELECT to_hex(2147483647)
 ----


### PR DESCRIPTION
fnv is expected to be useful for general purpose, fast non-crypto hashes.
crc is expected to be useful to those who already have crc32s from other applications.