### PR TITLE
[WIP] storage: retry 1PC transactions on WriteTooOld errors

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -3487,6 +3487,7 @@ func TestRaftRetryProtectionInTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer setTxnAutoGC(true)()
 	cfg := TestStoreConfig(nil)
+	cfg.TestingKnobs.DisableOnePhaseCommits = true
 	tc := testContext{}
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -1166,6 +1166,7 @@ func TestStoreLongTxnStarvation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	storeCfg := TestStoreConfig(nil)
 	storeCfg.DontRetryPushTxnFailures = true
+	storeCfg.TestingKnobs.DisableOnePhaseCommits = true
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, &storeCfg)


### PR DESCRIPTION
As @tschottdorf points out, this likely isn't safe. Seems like we'd want
to retry the 1PC at a higher level so that we go through the timestamp
cache again.

Fixes #15797