### PR TITLE
sql: massage tests to allow passing on arm64

### DIFF
--- a/pkg/sql/testdata/logic_test/builtin_function
+++ b/pkg/sql/testdata/logic_test/builtin_function
@@ -502,10 +502,13 @@ SELECT div(1.0::decimal, 0.0::decimal)
 query error div\(\): division by zero
 SELECT div(1::int, 0::int)
 
+# math.Exp(1.0) returns different results on amd64 vs arm64.
+# Round to make this test consistent across archs.
+# See https://github.com/golang/go/issues/20319.
 query RRR
-SELECT exp(-1.0::float), exp(1.0::float), exp(2.0::decimal)
+SELECT exp(-1.0::float), round(exp(1.0::float), 13), exp(2.0::decimal)
 ----
-0.36787944117144233 2.718281828459045 7.3890560989306502272
+0.36787944117144233 2.718281828459 7.3890560989306502272
 
 query error exp\(\): overflow
 SELECT exp(1e2000::decimal)


### PR DESCRIPTION
math.Exp(1.0) returns 2.7182818284590455 on arm64, which rounds to
2.718281828459046 with 15 digits, and 2.71828182845905 with 14 digits.
Compare this to amd64 which returns 2.718281828459045, rounding to
2.71828182845904 with 14 digits. Therefore, we must round all the way
to 13 digits to get a consistent result.

Updates #14405.