### PR TITLE
build: rename `make check` to `make lint` to follow convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,12 +114,12 @@ executable will be in your current directory and can be run as shown in the
 
 + Run the test suite locally:
 
-  `make generate check test testrace`
+  `make generate lint test testrace`
 
 + When you’re ready for review, groom your work: each commit should pass tests
   and contain a substantial (but not overwhelming) unit of work. You may also
   want to `git fetch origin` and run
-  `git rebase -i --exec "make check test" origin/master` to make sure you're
+  `git rebase -i --exec "make lint test" origin/master` to make sure you're
   submitting your changes on top of the newest version of our code. Next, push
   to your fork:
 

--- a/Makefile
+++ b/Makefile
@@ -130,10 +130,10 @@ XGO := $(strip $(if $(XGOOS),GOOS=$(XGOOS)) $(if $(XGOARCH),GOARCH=$(XGOARCH)) $
 
 .DEFAULT_GOAL := all
 .PHONY: all
-all: build test check
+all: build test lint
 
 .PHONY: short
-short: build testshort checkshort
+short: build testshort lintshort
 
 buildoss: BUILDTARGET = ./pkg/cmd/cockroach-oss
 
@@ -257,15 +257,22 @@ generate: gotestdashi
 
 # The style checks depend on `go vet` and so must depend on gotestdashi per the
 # above comment. See https://github.com/golang/go/issues/16086 for details.
-.PHONY: check
-check: override TAGS += check
-check: gotestdashi
+.PHONY: lint
+lint: override TAGS += lint
+lint: gotestdashi
 	$(XGO) test ./build -v $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -run 'TestStyle/$(TESTS)'
 
-.PHONY: checkshort
-checkshort: override TAGS += check
-checkshort: gotestdashi
+.PHONY: lintshort
+lintshort: override TAGS += lint
+lintshort: gotestdashi
 	$(XGO) test ./build -v $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -short -run 'TestStyle/$(TESTS)'
+
+.PHONY: check checkshort
+check checkshort:
+	@# TODO(benesch): make this target an alias for the `test` target.
+	@echo 'To adhere to convention, `make check` will soon be an alias for `make test`.' >&2
+	@echo 'The linters have moved to `make lint` and `make lintshort`.' >&2
+	@false
 
 .PHONY: clean
 clean: clean-c-deps

--- a/build/style_test.go
+++ b/build/style_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// +build check
+// +build lint
 
 package build_test
 

--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -13,7 +13,7 @@ build/builder.sh env \
 	TARGET=checkdeps \
 	github-pull-request-make
 
-build/builder.sh make check 2>&1 | tee artifacts/check.log | go-test-teamcity
+build/builder.sh make lint 2>&1 | tee artifacts/lint.log | go-test-teamcity
 
 build/builder.sh make generate
 build/builder.sh /bin/bash -c '! git status --porcelain | read || (git status; git diff -a 1>&2; exit 1)'

--- a/pkg/util/protoutil/clone.go
+++ b/pkg/util/protoutil/clone.go
@@ -46,11 +46,12 @@ func init() {
 // recursively contains any instances of types which are known to be
 // unsupported by proto.Clone.
 //
-// This function and its associated lint (see `make check`) exist to ensure we
-// do not attempt to proto.Clone types which are not supported by proto.Clone.
-// This hackery is necessary because proto.Clone gives no direct indication
-// that it has incompletely cloned a type; it merely logs to standard output
-// (see https://github.com/golang/protobuf/blob/89238a3/proto/clone.go#L204).
+// This function and its associated lint (see build/style_test.go) exist to
+// ensure we do not attempt to proto.Clone types which are not supported by
+// proto.Clone. This hackery is necessary because proto.Clone gives no direct
+// indication that it has incompletely cloned a type; it merely logs to standard
+// output (see
+// https://github.com/golang/protobuf/blob/89238a3/proto/clone.go#L204).
 //
 // The concrete case against which this is currently guarding may be resolved
 // upstream, see https://github.com/gogo/protobuf/issues/147.


### PR DESCRIPTION
Per convention, rename `make check` to `make lint`, since `make check`
usually means run the tests. To avoid confusing everyone, this commit
tweaks `make check` to print a deprecation warning. We can change it to
be an alias for `make test` (or not) at some later date.

This partially addresses #15862.