### PR TITLE
kubernetes: Use explicit image tag

### DIFF
--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -135,12 +135,7 @@ spec:
     spec:
       containers:
       - name: cockroachdb
-        # Runs the master branch. Not recommended for production, but since
-        # CockroachDB is in Beta, you don't want to run it in production
-        # anyway. See
-        # https://hub.docker.com/r/cockroachdb/cockroach/tags/
-        # if you prefer to run a beta release.
-        image: cockroachdb/cockroach
+        image: cockroachdb/cockroach:v1.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 26257


### PR DESCRIPTION
It might be slightly annoying to keep up-to-date as releases happen,
but this is widely considered a best practice to avoid accidentally
ending up with different versions in different pods.

I'll also be updating our upstream configs in the Kubernetes and Helm repos.