### PR TITLE
sql: fix SHOW GRANTS * on empty database

### DIFF
--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -715,6 +715,9 @@ func (p *planner) ShowGrants(ctx context.Context, n *parser.ShowGrants) (planNod
 
 					}
 				}
+				if len(paramHolders) == 0 {
+					return v, nil
+				}
 				tableGrants := fmt.Sprintf(`SELECT TABLE_NAME, GRANTEE, PRIVILEGE_TYPE FROM information_schema.table_privileges
 									WHERE (TABLE_SCHEMA, TABLE_NAME) IN (%s)`, strings.Join(paramHolders, ","))
 				if n.Grantees != nil {

--- a/pkg/sql/testdata/logic_test/grant_table
+++ b/pkg/sql/testdata/logic_test/grant_table
@@ -334,3 +334,19 @@ Table  User    Privileges
 t      millie  ALL
 t      root    ALL
 t2     root    ALL
+
+statement ok
+CREATE DATABASE empty
+
+query TTT colnames
+SHOW GRANTS ON empty.*
+----
+Table  User    Privileges
+
+query TTT colnames
+SHOW GRANTS ON empty.*, b.*
+----
+Table  User    Privileges
+t      millie  ALL
+t      root    ALL
+t2     root    ALL


### PR DESCRIPTION
Avoid generating a malformed internal query when performing
`SHOW GRANTS ON empty_database.*` by returning an empty result set when
there are no tables that match the given table glob.

Resolves #15308 