### PR TITLE
kv: fix racy access to a Transaction proto

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -530,12 +530,7 @@ func (ds *DistSender) initAndVerifyBatch(
 				//
 				// We already have a clone of our txn (see above), so we can
 				// modify it freely.
-				//
-				// Zero the existing data. That makes sure that if we had
-				// something of size zero but with capacity, we don't re-use the
-				// existing space (which others may also use). This is just to
-				// satisfy paranoia/OCD and not expected to matter in practice.
-				ba.Txn.ResetObservedTimestamps()
+
 				// OrigTimestamp is the HLC timestamp at which the Txn started, so
 				// this effectively means no more uncertainty on this node.
 				ba.Txn.UpdateObservedTimestamp(nDesc.NodeID, ba.Txn.OrigTimestamp)

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -715,7 +715,7 @@ func (t Transaction) LastActive() hlc.Timestamp {
 // keys with the intent spans.
 func (t Transaction) Clone() Transaction {
 	mt := t.ObservedTimestamps
-	if len(mt) != 0 {
+	if mt != nil {
 		t.ObservedTimestamps = make([]ObservedTimestamp, len(mt))
 		copy(t.ObservedTimestamps, mt)
 	}

--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -75,6 +75,8 @@ func NewError(err error) *Error {
 }
 
 // NewErrorWithTxn creates an Error from the given error and a transaction.
+//
+// txn is cloned before being stored in Error.
 func NewErrorWithTxn(err error, txn *Transaction) *Error {
 	e := NewError(err)
 	e.SetTxn(txn)


### PR DESCRIPTION
Fixes #15565

There was a race on accesses to Transaction.ObservedTimestamps because
we ended up sharing the ObservedTimestamps between a Transaction proto
stored in TxnCoordSender's map and the proto stored in the client.Txn.
The sharing happened because the call to
TxnCoordSender.cleanupTxnLocked() from TxnCoordSender.send() made a
shallow copy of the proto.
