### PR TITLE
build: add a new linter that checks that quoted URLs are live

### DIFF
--- a/build/teamcity-urlcheck.sh
+++ b/build/teamcity-urlcheck.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+export BUILDER_HIDE_GOPATH_SRC=1
+
+build/builder.sh go install ./pkg/cmd/urlcheck
+build/builder.sh urlcheck

--- a/docs/RFCS/drain_modes.md
+++ b/docs/RFCS/drain_modes.md
@@ -130,10 +130,10 @@ from `system.lease`. If sessions are still ongoing after this point, a log
 message would warn of this fact.
 
 ### Note on closing SQL connections
-The load balancing solutions for Postgres that seem to be the most popular are [PGPool](http://www.pgpool.net/docs/latest/pgpool-en.html) and
+The load balancing solutions for Postgres that seem to be the most popular are [PGPool](http://www.pgpool.net/docs/latest/en/html/) and
 [HAProxy](https://www.haproxy.com/). Both systems have health check mechanisms
 that try to establish a SQL
-connection[[1]](http://www.pgpool.net/docs/latest/pgpool-en.html#HEALTH_CHECK_USER)
+connection[[1]](http://www.pgpool.net/docs/latest/en/html/#HEALTH_CHECK_USER)
 [[2]](https://www.haproxy.com/doc/aloha/7.0/haproxy/healthchecks.html#checking-a-pgsql-service).
 HAProxy also supports doing only generic TCP checks. Because of how these health
 checks are performed, sending back a SQL error during the establishment of a

--- a/docs/RFCS/online_schema_change.md
+++ b/docs/RFCS/online_schema_change.md
@@ -25,7 +25,7 @@ from accessing the table and yet never leave table or index data in an
 invalid state.
 
 Online schema change will be built on top of [table descriptor
-leases](https://github.com/cockroachdb/cockroach/docs/RFCS/table_descriptor_lease.md)
+leases](https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/table_descriptor_lease.md)
 which describes the mechanism for asynchronously distributing
 modifications to table descriptors. This RFC is concerned with the
 actual steps of performing a schema change.

--- a/docs/RFCS/typing.md
+++ b/docs/RFCS/typing.md
@@ -1670,8 +1670,8 @@ The details:
    (numbers). This is performed for all expressions involving only
    untyped literals and functions applications applied only to such
    expressions.  For number literals, the imlementation type from the
-   [exact](<https://godoc.org/golang.org/x/tools/go/exact>)
-   arithmetic library can be used.
+   [go/constant](https://golang.org/pkg/go/constant/) arithmetic library
+   can be used.
 
    While the constant expressions are folded, the results must be typed
    using either the known type if any operands had one; or the unknown
@@ -2005,7 +2005,7 @@ quadratic time).
 
 To implement untyped numeric literals which will enable exact
 arithmetic, we will use
-https://godoc.org/golang.org/x/tools/go/exact. This will require a
+https://golang.org/pkg/go/constant/. This will require a
 change to our Yacc parser and lexical scanner, which will parser all
 numeric looking values (`ICONST` and `FCONST`) as `NumVal`.
 
@@ -2013,14 +2013,14 @@ We will then introduce a constant folding pass before type checking is
 initially performed (ideally using a folding visitor instead of the
 current interface approach).  While constant folding these untyped
 literals, we can use
-[BinaryOp](https://godoc.org/golang.org/x/tools/go/exact#BinaryOp) and
-[UnaryOp](https://godoc.org/golang.org/x/tools/go/exact#UnaryOp) to
+[BinaryOp](https://golang.org/pkg/go/constant/#BinaryOp) and
+[UnaryOp](https://golang.org/pkg/go/constant/#UnaryOp) to
 retain exact precision.
 
 Next, during type checking, ``NumVals`` will be evalutated as their
 logical `Datum` types. Here, they will be converted `int`, `float` or
 `decimal`, based on their `Value.Kind()` (e.g.  using
-[Int64Val](https://godoc.org/golang.org/x/tools/go/exact#Int64Val>) or
+[Int64Val](https://golang.org/pkg/go/constant/#Int64Val) or
 `decimal.SetString(Value.String())`.  Some Kinds will result in a
 panic because they should not be possible based on our
 parser. However, we could eventually introduce Complex literals using

--- a/docs/RFCS/version_upgrades.md
+++ b/docs/RFCS/version_upgrades.md
@@ -83,7 +83,7 @@ downgrading is more involved (there's no clear path except through a data dump
 and starting from scratch with the old version). They also have it easier than
 us.
 
-http://docs.datastax.com/en/latest-upgrade/upgrade/cassandra/upgradeChangesC_c.html
+http://docs.datastax.com/en/archived/cassandra/1.2/cassandra/upgrade/upgradeChangesC_c.html
 
 # High level design
 

--- a/docs/RFCS/views.md
+++ b/docs/RFCS/views.md
@@ -91,15 +91,14 @@ not too many.
 
 ## Storing view descriptors
 
-We can reuse the
-[`TableDescriptor`](https://github.com/cockroachdb/cockroach/blob/develop/sql/sqlbase/structured.proto#L244)
-protocol buffer type to represent views. Only a small amount of
-modification will be needed to support the needs of views, and reusing
-the same descriptor will remove the need to duplicate most of the fields
-in the proto and much of the code that processes the proto. Tables and
-views are typically used in the same ways, so it isn't much of a stretch
-to share the underlying descriptor, which is also what we do to support
-the information_schema tables.
+We can reuse the `TableDescriptor` protocol buffer type to represent
+views. Only a small amount of modification will be needed to support
+the needs of views, and reusing the same descriptor will remove the
+need to duplicate most of the fields in the proto and much of the code
+that processes the proto. Tables and views are typically used in the
+same ways, so it isn't much of a stretch to share the underlying
+descriptor, which is also what we do to support the information_schema
+tables.
 
 ## Storing view queries
 

--- a/docs/tech-notes/encoding.md
+++ b/docs/tech-notes/encoding.md
@@ -552,7 +552,7 @@ Example dump:
   [column families RFC]: https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/sql_column_families.md
   [interleaving RFC]: https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/sql_interleaved_tables.md
   [pkg/sql/sqlbase/structured.proto]: https://github.com/cockroachdb/cockroach/blob/master/pkg/sql/sqlbase/structured.proto
-  [pkg/sql/rowwriter.go]: https://github.com/cockroachdb/cockroach/blob/master/pkg/sql/rowwriter.go
+  [pkg/sql/rowwriter.go]: https://github.com/cockroachdb/cockroach/blob/master/pkg/sql/sqlbase/rowwriter.go
   [pkg/sql/sqlbase/rowfetcher.go]: https://github.com/cockroachdb/cockroach/blob/master/pkg/sql/sqlbase/rowfetcher.go
   [prefix-free]: https://en.wikipedia.org/wiki/Prefix_code
   [new `DECIMAL` encoding]: https://github.com/cockroachdb/cockroach/issues/13384#issuecomment-277120394

--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -4,7 +4,7 @@
 // License (the "License"); you may not use this file except in compliance with
 // the License. You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/ccl/LICENSE
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
 package engineccl
 

--- a/pkg/cmd/urlcheck/main.go
+++ b/pkg/cmd/urlcheck/main.go
@@ -1,0 +1,248 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/ghemawat/stream"
+)
+
+// maxConcurrentRequests specifies the maximum number of concurrent HTTP
+// requests during the test.
+const maxConcurrentRequests = 20
+
+// timeoutRetries specifies the number of times that requests which time out
+// will be retried.
+const timeoutRetries = 3
+
+// Source: https://mathiasbynens.be/demo/url-regex
+const urlRE = `https?://[^ \t\n/$.?#].[^ \t\n"<]*`
+
+var re = regexp.MustCompile(urlRE)
+
+var ignored = []string{
+	// These are invalid URLs.
+	"http://%s",
+	"http://127.0.0.1",
+	"http://HOST:PORT/",
+	"http://\"",
+	"https://localhost",
+	"https://myroach:8080",
+	"http://localhost",
+	"https://127.0.0.1",
+	"https://\"",
+	"https://storage.googleapis.com/golang/go${GOVERSION}",
+	"http://s3.amazonaws.com/cockroach/cockroach/cockroach.$(",
+	"https://binaries.cockroachdb.com/cockroach-${BETA_TAG}",
+	"https://edge-binaries.cockroachdb.com/cockroach/cockroach.linux-gnu-amd64.${var.cockroach_sha}",
+	"https://edge-binaries.cockroachdb.com/examples-go/block_writer.${var.block_writer_sha}",
+	"https://edge-binaries.cockroachdb.com/examples-go/photos.${var.photos_sha}",
+	"https://github.com/cockroachdb/cockroach/commits/%s",
+	"https://github.com/cockroachdb/cockroach/issues/%d",
+	// These are cloud provider metadata endpoints.
+	"http://metadata/",
+	"http://instance-data/latest/meta-data/public-ipv4",
+	// These are auto-generated and thus valid by definition.
+	"https://registry.yarnpkg.com/",
+	// XML namespace identifiers, these are not really HTTP endpoints.
+	"https://www.w3.org/",
+	"http://www.bohemiancoding.com/sketch/ns",
+	"http://www.w3.org/",
+	// These report 404 for non-API GETs.
+	"http://ignored:ignored@errors.cockroachdb.com/",
+	"https://cockroachdb.github.io/distsqlplan/",
+	"https://ignored:ignored@errors.cockroachdb.com/",
+	"https://register.cockroachdb.com",
+	"https://www.googleapis.com/auth",
+	// These require authentication.
+	"https://console.aws.amazon.com/",
+	"https://github.com/cockroachlabs/registration/",
+	"https://index.docker.io/v1/",
+}
+
+// chompUnbalanced truncates s before the first right rune to appear without an
+// earlier left rune.
+// Example: chompUnbalanced('(', ')', '(real) cool) garbage') -> '(real) cool'
+func chompUnbalanced(left, right rune, s string) string {
+	depth := 0
+	for i, c := range s {
+		switch c {
+		case left:
+			depth++
+		case right:
+			if depth == 0 {
+				return s[:i]
+			}
+			depth--
+		}
+	}
+	return s
+}
+
+func checkURL(client *http.Client, url string) error {
+	resp, err := client.Head(url)
+	if err != nil {
+		return err
+	}
+	if err := resp.Body.Close(); err != nil {
+		return err
+	}
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+
+	if resp.StatusCode == 403 || resp.StatusCode == 405 {
+		// The server doesn't like HEAD. Try GET. This is obviously the
+		// correct strategy for 405 Method Not ALlowed responses. This is a
+		// less-correct strategy for 403 Forbidden responses, but we link to
+		// several misconfigured S3 buckets that return 403 Forbidden for HEAD
+		// requests but not for GET requests.
+		retryResp, err := client.Get(url)
+		if err != nil {
+			return err
+		}
+		if err := retryResp.Body.Close(); err != nil {
+			return err
+		}
+
+		if retryResp.StatusCode >= 200 && resp.StatusCode < 300 {
+			return nil
+		}
+
+		return errors.New(retryResp.Status)
+	}
+
+	return errors.New(resp.Status)
+}
+
+func checkURLWithRetries(client *http.Client, url string) error {
+	for i := 0; i < timeoutRetries; i++ {
+		err := checkURL(client, url)
+		if err, ok := err.(net.Error); ok && err.Timeout() {
+			// Back off exponentially if we hit a timeout.
+			time.Sleep((1 << uint(i)) * time.Second)
+			continue
+		}
+		return err
+	}
+	return fmt.Errorf("timed out on %d separate tries, giving up", timeoutRetries)
+}
+
+func main() {
+	cmd := exec.Command("git", "grep", "-nE", urlRE)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		log.Fatal(err)
+	}
+	filter := stream.ReadLines(stdout)
+	stderr := new(bytes.Buffer)
+	cmd.Stderr = stderr
+
+	if err := cmd.Start(); err != nil {
+		log.Fatal(err)
+	}
+
+	uniqueURLs := map[string][]string{}
+
+	if err := stream.ForEach(filter, func(s string) {
+	outer:
+		for _, match := range re.FindAllString(s, -1) {
+			// Discard any characters after the first unbalanced ')' or ']'.
+			match = chompUnbalanced('(', ')', match)
+			match = chompUnbalanced('[', ']', match)
+			// Remove punctuation after the URL.
+			match = strings.TrimRight(match, ".,;\\\">`]")
+			// Remove the HTML target.
+			n := strings.LastIndex(match, "#")
+			if n != -1 {
+				match = match[:n]
+			}
+			// Add the source reference to the list.
+			if len(s) > 150 {
+				s = s[:150] + "..."
+			}
+			for _, ig := range ignored {
+				if strings.HasPrefix(match, ig) {
+					continue outer
+				}
+			}
+			uniqueURLs[match] = append(uniqueURLs[match], s)
+		}
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		log.Fatalf("err=%s, stderr=%s", err, stderr.String())
+	}
+
+	sem := make(chan struct{}, maxConcurrentRequests)
+	errChan := make(chan error, len(uniqueURLs))
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			// This test doesn't care that https certificates are invalid.
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+		Timeout: 5 * time.Second,
+	}
+
+	for url, locs := range uniqueURLs {
+		sem <- struct{}{}
+		go func(url string, locs []string) {
+			defer func() { <-sem }()
+			log.Printf("Checking %s...", url)
+			if err := checkURLWithRetries(client, url); err != nil {
+				var buf bytes.Buffer
+				fmt.Fprintf(&buf, "%s: %s\n", url, err)
+				for _, loc := range locs {
+					fmt.Fprintln(&buf, "    ", loc)
+				}
+				errChan <- errors.New(buf.String())
+			} else {
+				errChan <- nil
+			}
+		}(url, locs)
+	}
+
+	var errs []error
+	for i := 0; i < len(uniqueURLs); i++ {
+		if err := <-errChan; err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		for _, err := range errs {
+			fmt.Print(err)
+		}
+		fmt.Printf("%d errors\n", len(errs))
+		fmt.Println("FAIL")
+		os.Exit(1)
+	}
+	fmt.Println("PASS")
+}

--- a/pkg/util/log/file.go
+++ b/pkg/util/log/file.go
@@ -243,9 +243,8 @@ func create(
 		}
 		if err := os.Symlink(filepath.Base(fname), symlink); err != nil {
 			// On Windows, this will be the common case, as symlink creation
-			// requires special privileges. See https://docs.microsoft.com/en-
-			// us/windows/device-security/security-policy-settings/create-
-			// symbolic-links.
+			// requires special privileges.
+			// See: https://docs.microsoft.com/en-us/windows/device-security/security-policy-settings/create-symbolic-links
 			if runtime.GOOS != "windows" {
 				fmt.Fprintf(OrigStderr, "log: failed to create symlink %s: %s", symlink, err)
 			}


### PR DESCRIPTION
This extracts @knz's lovely URL checker from #15751 into a standalone `urlcheck` command and an associated TC script.