### PR TITLE
storage: overhaul GCQueue.shouldQueue

### DIFF
--- a/pkg/storage/engine/enginepb/mvcc.go
+++ b/pkg/storage/engine/enginepb/mvcc.go
@@ -67,7 +67,10 @@ func (ms *MVCCStats) AgeTo(nowNanos int64) {
 	if ms.LastUpdateNanos >= nowNanos {
 		return
 	}
-	diffSeconds := nowNanos/1E9 - ms.LastUpdateNanos/1E9 // not (...)/1E9!
+	// Seconds are counted every time each individual nanosecond timestamp
+	// crosses a whole second boundary (i.e. is zero mod 1E9). Thus it would
+	// be a mistake to use the (nonequivalent) expression (a-b)/1E9.
+	diffSeconds := nowNanos/1E9 - ms.LastUpdateNanos/1E9
 
 	ms.GCBytesAge += ms.GCBytes() * diffSeconds
 	ms.IntentAge += ms.IntentCount * diffSeconds

--- a/pkg/storage/engine/enginepb/mvcc.pb.go
+++ b/pkg/storage/engine/enginepb/mvcc.pb.go
@@ -175,11 +175,11 @@ type MVCCStats struct {
 	// See the comment on MVCCStats.
 	GCBytesAge int64 `protobuf:"fixed64,3,opt,name=gc_bytes_age,json=gcBytesAge" json:"gc_bytes_age"`
 	// live_bytes is the number of bytes stored in keys and values which can in
-	// principle be read by means of a Scan or Get, including intents but not
-	// deletion tombstones (or their intents). Note that the size of the meta kv
-	// pair (which could be explicit or implicit) is included in this.
-	// Only the meta kv pair counts for the actual length of the encoded key
-	// (regular pairs only count the timestamp suffix).
+	// principle be read by means of a Scan or Get in the far future, including
+	// intents but not deletion tombstones (or their intents). Note that the
+	// size of the meta kv pair (which could be explicit or implicit) is
+	// included in this. Only the meta kv pair counts for the actual length of
+	// the encoded key (regular pairs only count the timestamp suffix).
 	LiveBytes int64 `protobuf:"fixed64,4,opt,name=live_bytes,json=liveBytes" json:"live_bytes"`
 	// live_count is the number of meta keys tracked under live_bytes.
 	LiveCount int64 `protobuf:"fixed64,5,opt,name=live_count,json=liveCount" json:"live_count"`

--- a/pkg/storage/engine/enginepb/mvcc.proto
+++ b/pkg/storage/engine/enginepb/mvcc.proto
@@ -129,13 +129,12 @@ message MVCCStats {
   // data included in key_bytes and val_bytes, but not live_bytes).
   // See the comment on MVCCStats.
   optional sfixed64 gc_bytes_age = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "GCBytesAge"];
-
   // live_bytes is the number of bytes stored in keys and values which can in
-  // principle be read by means of a Scan or Get, including intents but not
-  // deletion tombstones (or their intents). Note that the size of the meta kv
-  // pair (which could be explicit or implicit) is included in this.
-  // Only the meta kv pair counts for the actual length of the encoded key
-  // (regular pairs only count the timestamp suffix).
+  // principle be read by means of a Scan or Get in the far future, including
+  // intents but not deletion tombstones (or their intents). Note that the
+  // size of the meta kv pair (which could be explicit or implicit) is
+  // included in this. Only the meta kv pair counts for the actual length of
+  // the encoded key (regular pairs only count the timestamp suffix).
   optional sfixed64 live_bytes = 4 [(gogoproto.nullable) = false];
   // live_count is the number of meta keys tracked under live_bytes.
   optional sfixed64 live_count = 5 [(gogoproto.nullable) = false];

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"fmt"
 	"math"
+	"math/rand"
 	"sync"
 	"time"
 
@@ -35,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -43,9 +45,6 @@ import (
 const (
 	// gcQueueTimerDuration is the duration between GCs of queued replicas.
 	gcQueueTimerDuration = 1 * time.Second
-	// gcByteCountNormalization is the count of GC'able bytes which
-	// amount to a score of "1" added to total replica priority.
-	gcByteCountNormalization = 1 << 20 // 1 MB
 	// intentAgeNormalization is the average age of outstanding intents
 	// which amount to a score of "1" added to total replica priority.
 	intentAgeNormalization = 24 * time.Hour // 1 day
@@ -67,9 +66,10 @@ const (
 	// aborted and whose abort cache entry is being deleted.
 	abortCacheAgeThreshold = 5 * base.DefaultHeartbeatInterval
 
-	// considerThreshold is used in shouldQueue. Only an a normalized GC bytes
-	// or intent byte age larger than the threshold queues the replica for GC.
-	considerThreshold = 10
+	// thresholds used by shouldQueue to decide whether to queue for GC based
+	// on keys and intents.
+	gcKeyScoreThreshold    = 2
+	gcIntentScoreThreshold = 10
 
 	// gcTaskLimit is the maximum number of concurrent goroutines
 	// that will be created by GC.
@@ -114,40 +114,229 @@ func newGCQueue(store *Store, gossip *gossip.Gossip) *gcQueue {
 type pushFunc func(hlc.Timestamp, *roachpb.Transaction, roachpb.PushTxnType)
 type resolveFunc func([]roachpb.Intent, bool, bool) error
 
+// gcQueueScore holds details about the score returned by makeGCQueueScoreImpl for
+// testing and logging. The fields in this struct are documented in
+// makeGCQueueScoreImpl.
+type gcQueueScore struct {
+	TTL                 time.Duration
+	LikelyLastGC        time.Duration
+	DeadFraction        float64
+	ValuesScalableScore float64
+	IntentScore         float64
+	FuzzFactor          float64
+	FinalScore          float64
+	ShouldQueue         bool
+
+	GCBytes                  int64
+	GCByteAge                int64
+	ExpMinGCByteAgeReduction int64
+}
+
+func (r gcQueueScore) String() string {
+	if (r == gcQueueScore{}) {
+		return "(empty)"
+	}
+	if r.ExpMinGCByteAgeReduction < 0 {
+		r.ExpMinGCByteAgeReduction = 0
+	}
+	return fmt.Sprintf("queue=%t with %.2f/fuzz(%.2f)=%.2f=valScaleScore(%.2f)*deadFrac(%.2f)+intentScore(%.2f)\n"+
+		"likely last GC: %s ago, %s non-live, curr. age %s*s, min exp. reduction: %s*s",
+		r.ShouldQueue, r.FinalScore, r.FuzzFactor, r.FinalScore/r.FuzzFactor, r.ValuesScalableScore,
+		r.DeadFraction, r.IntentScore, r.LikelyLastGC, humanizeutil.IBytes(r.GCBytes),
+		humanizeutil.IBytes(r.GCByteAge), humanizeutil.IBytes(r.ExpMinGCByteAgeReduction))
+}
+
 // shouldQueue determines whether a replica should be queued for garbage
 // collection, and if so, at what priority. Returns true for shouldQ
 // in the event that the cumulative ages of GC'able bytes or extant
 // intents exceed thresholds.
 func (gcq *gcQueue) shouldQueue(
 	ctx context.Context, now hlc.Timestamp, repl *Replica, sysCfg config.SystemConfig,
-) (shouldQ bool, priority float64) {
+) (bool, float64) {
+	r := makeGCQueueScore(ctx, repl, now, sysCfg)
+	return r.ShouldQueue, r.FinalScore
+}
+
+func makeGCQueueScore(
+	ctx context.Context, repl *Replica, now hlc.Timestamp, sysCfg config.SystemConfig,
+) gcQueueScore {
+	repl.mu.Lock()
+	ms := repl.mu.state.Stats
+	gcThreshold := repl.mu.state.GCThreshold
+	repl.mu.Unlock()
+
 	desc := repl.Desc()
 	zone, err := sysCfg.GetZoneConfigForKey(desc.StartKey)
 	if err != nil {
 		log.Errorf(ctx, "could not find zone config for range %s: %s", repl, err)
-		return
+		return gcQueueScore{}
+	}
+	// Use desc.RangeID for fuzzing the final score, so that different ranges
+	// have slightly different priorities and even symmetrical workloads don't
+	// trigger GC at the same time.
+	r := makeGCQueueScoreImpl(
+		ctx, int64(desc.RangeID), now, ms, zone.GC.TTLSeconds,
+	)
+	r.LikelyLastGC = time.Duration(now.WallTime - gcThreshold.Add(r.TTL.Nanoseconds(), 0).WallTime)
+	return r
+}
+
+// makeGCQueueScoreImpl is used to compute when to trigger the GC Queue. It's
+// important that we don't queue a replica before a relevant amount of data is
+// actually deletable, or the queue might run in a tight loop. To this end, we
+// use a base score with the right interplay between GCByteAge and TTL and
+// additionally weigh it so that GC is delayed when a large proportion of the
+// data in the replica is live. Additionally, returned scores are slightly
+// perturbed to avoid groups of replicas becoming eligible for GC at the same
+// time repeatedly.
+//
+// More details below.
+//
+// When a key of size `B` is deleted at timestamp `T` or superseded by a newer
+// version, it henceforth is accounted for in the range's `GCBytesAge`. At time
+// `S`, its contribution to age will be `B*seconds(S-T)`. The aggregate
+// `GCBytesAge` of all deleted versions in the cluster is what the GC queue at
+// the time of writing bases its `shouldQueue` method on.
+//
+// If a replica is queued to have its old values garbage collected, its contents
+// are scanned. However, the values which are deleted follow a criterion that
+// isn't immediately connected to `GCBytesAge`: We (basically) delete everything
+// that's older than the Replica's `TTLSeconds`.
+//
+// Thus, it's not obvious that garbage collection has the effect of reducing the
+// metric that we use to consider the replica for the next GC cycle, and it
+// seems that we messed it up.
+//
+// The previous metric used for queueing: `GCBytesAge/(1<<20 * ttl)` does not
+// have the right scaling. For example, consider that a value of size `1mb` is
+// overwritten with a newer version. After `ttl` seconds, it contributes `1mb`
+// to `GCBytesAge`, and so the replica has a score of `1`, i.e. (roughly) the
+// range becomes interesting to the GC queue. When GC runs, it will delete value
+// that are `ttl` old, which our value is. But a Replica is ~64mb, so picture
+// that you have 64mb of key-value data all at the same timestamp, and they
+// become superseded. Already after `ttl/64`, the metric becomes 1, but they
+// keys won't be GC'able for another (63*ttl)/64. Thus, GC will run "all the
+// time" long before it can actually have an effect.
+//
+// The metric with correct scaling must thus take into account the size of the
+// range. What size exactly? Any data that isn't live (i.e. isn't readable by a
+// scan from the far future). That's `KeyBytes + ms.ValBytes - ms.LiveBytes`,
+// which is also known as `GCBytes` in the code. Hence, the better metric is
+// `GCBytesAge/(ttl*GCBytes)`.
+//
+// Using this metric guarantees that after truncation, `GCBytesAge` is at most
+// `ttl*GCBytes` (where `GCBytes` has been updated), i.e. the new metric is at
+// most 1.
+//
+// To visualize this, picture a rectangular frame of width `ttl` and height
+// `GCBytes` (i.e. the horizontal dimension is time, the vertical one bytes),
+// where the right boundary of the frame corresponds to age zero. Each non-live
+// key is a domino aligned with the right side of the frame, its width equal to
+// its size, and its height given by the duration (in seconds) it's been
+// non-live.
+//
+// The combined surface of the dominos is then `GCBytesAge`, and the claim is
+// that if the total sum of domino heights (i.e. sizes) is `GCBytes`, and the
+// surface is larger than `ttl*GCBytes` by some positive `X`, then after
+// removing the dominos that cross the line `x=-ttl` (i.e. `ttl` to the left
+// from the right side of the frame), at least a surface area of `X` has been
+// removed.
+//
+//               x=-ttl                 GCBytes=1+4
+//                 |           3 (age)
+//                 |          +-------+
+//                 |          | keep  | 1 (bytes)
+//                 |          +-------+
+//            +-----------------------+
+//            |                       |
+//            |        remove         | 3 (bytes)
+//            |                       |
+//            +-----------------------+
+//                 |   7 (age)
+//
+// This is true because
+//
+// deletable area  = total area       - nondeletable area
+//                 = X + ttl*GCBytes  - nondeletable area
+//                >= X + ttl*GCBytes  - ttl*(bytes in nondeletable area)
+//                 = X + ttl*(GCBytes - bytes in nondeletable area)
+//                >= X.
+//
+// Or, in other words, you can only hope to put `ttl*GCBytes` of area in the
+// "safe" rectangle. Once you've done that, everything else you put is going to
+// be deleted.
+//
+// This means that running GC will always result in a `GCBytesAge` of `<=
+// ttl*GCBytes`, and that a decent trigger for GC is a multiple of
+// `ttl*GCBytes`.
+func makeGCQueueScoreImpl(
+	ctx context.Context, fuzzSeed int64, now hlc.Timestamp, ms enginepb.MVCCStats, ttlSeconds int32,
+) gcQueueScore {
+	ms.AgeTo(now.WallTime)
+	var r gcQueueScore
+	r.TTL = time.Duration(ttlSeconds) * time.Second
+
+	// Treat a zero TTL as a one-second TTL, which avoids a priority of infinity
+	// and otherwise behaves indistinguishable given that we can't possibly hope
+	// to GC values faster than that.
+	if r.TTL == 0 {
+		r.TTL = time.Second
 	}
 
-	ms := repl.GetMVCCStats()
-	// GC score is the total GC'able bytes age normalized by 1 MB * the replica's TTL in seconds.
-	gcScore := float64(ms.GCByteAge(now.WallTime)) / float64(zone.GC.TTLSeconds) / float64(gcByteCountNormalization)
+	r.GCByteAge = ms.GCByteAge(now.WallTime)
+	r.GCBytes = ms.GCBytes()
 
-	// Intent score. This computes the average age of outstanding intents
-	// and normalizes.
-	intentScore := ms.AvgIntentAge(now.WallTime) / float64(intentAgeNormalization.Nanoseconds()/1E9)
+	// If we GC'ed now, we can expect to delete at least this much GCByteAge.
+	// GCByteAge - TTL*GCBytes = ExpMinGCByteAgeReduction & algebra.
+	//
+	// Note that for ranges with ContainsEstimates=true, the value here may not
+	// reflect reality, and may even be nonsensical (though that's unlikely).
+	r.ExpMinGCByteAgeReduction = r.GCByteAge - r.GCBytes*int64(r.TTL.Seconds())
+
+	// DeadFraction is close to 1 when most values are dead, and close to zero
+	// when most of the replica is live. For example, for a replica with no
+	// superseded values, this should be (almost) zero. For one just hit
+	// completely by a DeleteRange, it should be (almost) one.
+	//
+	// The algebra below is complicated by the fact that ranges may contain
+	// stats that aren't exact (ContainsEstimates=true).
+	clamp := func(n int64) float64 {
+		if n < 0 {
+			return 0.0
+		}
+		return float64(n)
+	}
+	r.DeadFraction = math.Max(1-clamp(ms.LiveBytes)/(1+clamp(ms.ValBytes)+clamp(ms.KeyBytes)), 0)
+
+	// The "raw" GC score is the total GC'able bytes age normalized by (non-live
+	// size * the replica's TTL in seconds). This is a scale-invariant factor by
+	// (at least) which GCByteAge reduces when deleting values older than the
+	// TTL. The risk of an inaccurate GCBytes in the presence of estimated stats
+	// is neglected as GCByteAge and GCBytes undercount in the same way and
+	// estimation only happens for timeseries writes.
+	denominator := r.TTL.Seconds() * (1.0 + clamp(r.GCBytes)) // +1 avoids NaN
+	r.ValuesScalableScore = clamp(r.GCByteAge) / denominator
+	// However, it doesn't take into account the size of the live data, which
+	// also needs to be scanned in order to GC. We don't want to run this costly
+	// scan unless we get a corresponding expected reduction in GCByteAge, so we
+	// weighs by fraction of non-live data below.
+
+	// Intent score. This computes the average age of outstanding intents and
+	// normalizes. Note that at the time of writing this criterion hasn't
+	// undergone a reality check yet.
+	r.IntentScore = ms.AvgIntentAge(now.WallTime) / float64(intentAgeNormalization.Nanoseconds()/1E9)
+
+	// Random factor in [0.75, 1.25] to cause decoherence of replicas with
+	// similar load. This isn't 100% symmetric due to rounding issues near zero,
+	// but not an issue in practice.
+	r.FuzzFactor = 0.75 + rand.New(rand.NewSource(fuzzSeed)).Float64()/2.0
 
 	// Compute priority.
-	if gcScore >= considerThreshold {
-		priority += gcScore
-	}
-	if intentScore >= considerThreshold {
-		priority += intentScore
-	}
-	shouldQ = priority > 0
-	if shouldQ {
-		log.Infof(ctx, "gcScore = %f, intentScore = %f, ms=%+v", gcScore, intentScore, ms)
-	}
-	return
+	valScore := r.DeadFraction * r.ValuesScalableScore
+	r.ShouldQueue = r.FuzzFactor*valScore > gcKeyScoreThreshold || r.FuzzFactor*r.IntentScore > gcIntentScoreThreshold
+	r.FinalScore = r.FuzzFactor * (valScore + r.IntentScore)
+
+	return r
 }
 
 // processLocalKeyRange scans the local range key entries, consisting of
@@ -339,6 +528,13 @@ func (gcq *gcQueue) process(ctx context.Context, repl *Replica, sysCfg config.Sy
 	}
 
 	now := repl.store.Clock().Now()
+	r := makeGCQueueScore(ctx, repl, now, sysCfg)
+	// Yes, comparing floats to 0 is bad. However, FinalScore is either exactly zero or
+	// far away from zero.
+	if r.FinalScore == 0 {
+		log.Eventf(ctx, "skipping replica; low score %s", r)
+	}
+	log.Eventf(ctx, "processing replica with score %s", r)
 	gcKeys, info, err := RunGC(ctx, desc, snap, now, zone.GC,
 		func(now hlc.Timestamp, txn *roachpb.Transaction, typ roachpb.PushTxnType) {
 			pushTxn(ctx, gcq.store.DB(), now, txn, typ)
@@ -351,9 +547,11 @@ func (gcq *gcQueue) process(ctx context.Context, repl *Replica, sysCfg config.Sy
 		return err
 	}
 
-	log.Eventf(ctx, "assembled GC keys, now proceeding to GC; stats %+v", info)
-
-	info.updateMetrics(gcq.store.metrics)
+	log.Eventf(ctx, "MVCC stats: %+v", repl.GetMVCCStats())
+	log.Eventf(ctx, "assembled GC keys, now proceeding to GC; stats so far %+v", info)
+	defer func() {
+		info.updateMetrics(gcq.store.metrics)
+	}()
 
 	var ba roachpb.BatchRequest
 	var gcArgs roachpb.GCRequest
@@ -375,6 +573,8 @@ func (gcq *gcQueue) process(ctx context.Context, repl *Replica, sysCfg config.Sy
 		log.ErrEvent(ctx, pErr.String())
 		return pErr.GoError()
 	}
+
+	log.Eventf(ctx, "done GC'ing, new score is %s", makeGCQueueScore(ctx, repl, repl.store.Clock().Now(), sysCfg))
 	return nil
 }
 

--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -18,9 +18,10 @@ package storage
 
 import (
 	"fmt"
-	"math"
+	"math/rand"
 	"reflect"
 	"testing"
+	"testing/quick"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -34,10 +35,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/kr/pretty"
 )
 
 // makeTS creates a new hybrid logical timestamp.
@@ -48,115 +52,312 @@ func makeTS(nanos int64, logical int32) hlc.Timestamp {
 	}
 }
 
-// TestGCQueueShouldQueue verifies conditions which inform priority
-// and whether or not the range should be queued into the GC queue.
-// Ranges are queued for GC based on two conditions. The age of bytes
-// available to be GC'd, and the age of unresolved intents.
-func TestGCQueueShouldQueue(t *testing.T) {
+func TestGCQueueScoreString(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	tc := testContext{}
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
-	tc.Start(t, stopper)
-
-	cfg, ok := tc.gossip.GetSystemConfig()
-	if !ok {
-		t.Fatal("config not set")
-	}
-	desc := tc.repl.Desc()
-	zone, err := cfg.GetZoneConfigForKey(desc.StartKey)
-	if err != nil {
-		log.Errorf(context.Background(), "could not find GC policy for range %s: %s, got zone %+v",
-			tc.repl, err, zone)
-		return
-	}
-	policy := zone.GC
-
-	iaN := intentAgeNormalization.Nanoseconds()
-	ia := iaN / 1E9
-	bc := int64(gcByteCountNormalization)
-	ttl := int64(policy.TTLSeconds)
-
-	now := makeTS(considerThreshold*iaN, 0) // at time of stats object
-
-	testCases := []struct {
-		gcBytes     int64
-		gcBytesAge  int64
-		intentCount int64
-		intentAge   int64
-		now         hlc.Timestamp // at time of shouldQueue
-		shouldQ     bool
-		priority    float64
+	for i, c := range []struct {
+		r   gcQueueScore
+		exp string
 	}{
-		// First, test cases where shouldQueue is called with the same
-		// timestamp that the stats are at.
-
-		// No GC'able bytes, no time elapsed.
-		{0, 0, 0, 0, now, false, 0},
-		// No GC'able bytes, with intent age, 1/2 intent normalization period elapsed.
-		{0, 0, 1, ia / 2, now, false, 0},
-		// No GC'able bytes, with intent age=1/2 period, and other 1/2 period elapsed.
-		{0, 0, 1, ia / 2, now, false, 0},
-		// No GC'able bytes, with (abs and avg) intent age=1.5*normalization.
-		{0, 0, 1, 3 * ia / 2, now, true, 1.5},
-		// No GC'able bytes, 2 intents, with avg intent age=3.5*normalization.
-		{0, 0, 2, 7 * ia, now, true, 3.5},
-		// GC'able bytes, no time elapsed.
-		{bc, 0, 0, 0, now, false, 0},
-		// GC'able bytes, avg age = just below TTLSeconds.
-		{bc, bc*ttl - 1, 0, 0, now, false, 0},
-		// GC'able bytes, avg age = 2*TTLSeconds.
-		{bc, 2 * bc * ttl, 0, 0, now, true, 2},
-		// x2 GC'able bytes, avg age = TTLSeconds.
-		{2 * bc, 2 * bc * ttl, 0, 0, now, true, 2},
-		// GC'able bytes, intent bytes, and intent normalization * 2 elapsed.
-		// Queues solely because of gc'able bytes.
-		{bc, 5 * bc * ttl, 10 * ia, 0, now, true, 5},
-		// A contribution of 1 from gc, 10/5 from intents.
-		{bc, bc * ttl, 5, 10 * ia, now, true, (1 + 2)},
-
-		// Some tests where the ages increase since we call shouldNow with
-		// a later timestamp.
-
-		// One normalized unit of unaged gc'able bytes at time zero.
-		{ttl * bc, 0, 0, 0, hlc.Timestamp{}, true, float64(now.WallTime) / (1E9 * considerThreshold)},
-
-		// 2 intents aging from zero to now (which is exactly the intent age
-		// normalization).
-		{0, 0, 2, 0, hlc.Timestamp{}, true, 1},
-	}
-
-	gcQ := newGCQueue(tc.store, tc.gossip)
-
-	for i, test := range testCases {
-		// Write gc'able bytes as key bytes; since "live" bytes will be
-		// zero, this will translate into non live bytes.  Also write
-		// intent count. Note: the actual accounting on bytes is fictional
-		// in this test.
-		ms := enginepb.MVCCStats{
-			KeyBytes:        test.gcBytes,
-			IntentCount:     test.intentCount,
-			IntentAge:       test.intentAge * considerThreshold,
-			GCBytesAge:      test.gcBytesAge * considerThreshold,
-			LastUpdateNanos: test.now.WallTime,
+		{gcQueueScore{}, "(empty)"},
+		{gcQueueScore{
+			ShouldQueue:              true,
+			FuzzFactor:               1.25,
+			FinalScore:               3.45 * 1.25,
+			ValuesScalableScore:      4,
+			DeadFraction:             0.25,
+			IntentScore:              0.45,
+			ExpMinGCByteAgeReduction: 256 * 1024,
+			GCByteAge:                512 * 1024,
+			GCBytes:                  1024 * 3,
+			LikelyLastGC:             5 * time.Second,
+		},
+			`queue=true with 4.31/fuzz(1.25)=3.45=valScaleScore(4.00)*deadFrac(0.25)+intentScore(0.45)
+likely last GC: 5s ago, 3.0 KiB non-live, curr. age 512 KiB*s, min exp. reduction: 256 KiB*s`},
+	} {
+		if act := c.r.String(); act != c.exp {
+			t.Errorf("%d: wanted:\n'%s'\ngot:\n'%s'", i, c.exp, act)
 		}
-		func() {
-			// Hold lock throughout to reduce chance of random commands
-			// leading to inconsistent state.
-			tc.repl.mu.Lock()
-			defer tc.repl.mu.Unlock()
-			if err := tc.repl.mu.stateLoader.setMVCCStats(context.Background(), tc.repl.store.Engine(), &ms); err != nil {
+	}
+}
+
+func TestGCQueueMakeGCScoreInvariantQuick(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	rnd, seed := randutil.NewPseudoRand()
+	cfg := quick.Config{
+		MaxCount: 50000,
+		Rand:     rnd,
+	}
+	initialNow := hlc.Timestamp{}.Add(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC).UnixNano(), 0)
+	ctx := context.Background()
+
+	// Verify that the basic assumption always holds: We won't queue based on
+	// GCByte{s,Age} unless TTL-based deletion would actually delete something.
+	if err := quick.Check(func(
+		seed uint16, uTTLSec uint32, uTimePassed time.Duration, uGCBytes uint32, uGCByteAge uint32,
+	) bool {
+		ttlSec, timePassed := int32(uTTLSec), time.Duration(uTimePassed)
+		gcBytes, gcByteAge := int64(uGCBytes), int64(uGCByteAge)
+
+		ms := enginepb.MVCCStats{
+			LastUpdateNanos: initialNow.WallTime,
+			ValBytes:        gcBytes,
+			GCBytesAge:      gcByteAge,
+		}
+		now := initialNow.Add(timePassed.Nanoseconds(), 0)
+		r := makeGCQueueScoreImpl(ctx, int64(seed), now, ms, ttlSec)
+		wouldHaveToDeleteSomething := gcBytes*int64(ttlSec) < ms.GCByteAge(now.WallTime)
+		result := !r.ShouldQueue || wouldHaveToDeleteSomething
+		if !result {
+			log.Warningf(ctx, "failing on ttl=%d, timePassed=%s, gcBytes=%d, gcByteAge=%d:\n%s",
+				ttlSec, timePassed, gcBytes, gcByteAge, r)
+		}
+		return result
+	}, &cfg); err != nil {
+		t.Fatal(errors.Wrapf(err, "with seed %d", seed))
+	}
+}
+
+func TestGCQueueMakeGCScoreAnomalousStats(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	if err := quick.Check(func(keyBytes, valBytes, liveBytes int32, containsEstimates bool) bool {
+		r := makeGCQueueScoreImpl(context.Background(), 0, hlc.Timestamp{}, enginepb.MVCCStats{
+			ContainsEstimates: containsEstimates,
+			LiveBytes:         int64(liveBytes),
+			ValBytes:          int64(valBytes),
+			KeyBytes:          int64(keyBytes),
+		}, 60)
+		return r.DeadFraction >= 0 && r.DeadFraction <= 1
+	}, &quick.Config{MaxCount: 1000}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const cacheFirstLen = 3
+
+type gcTestCacheKey struct {
+	enginepb.MVCCStats
+	string
+}
+type gcTestCacheVal struct {
+	first [cacheFirstLen]enginepb.MVCCStats
+	last  enginepb.MVCCStats
+}
+
+type cachedWriteSimulator struct {
+	cache map[gcTestCacheKey]gcTestCacheVal
+	t     *testing.T
+}
+
+func newCachedWriteSimulator(t *testing.T) *cachedWriteSimulator {
+	var cws cachedWriteSimulator
+	cws.t = t
+	cws.cache = map[gcTestCacheKey]gcTestCacheVal{
+		{enginepb.MVCCStats{LastUpdateNanos: 946684800000000000}, "1-1m0s-1.0 MiB"}: {
+			first: [cacheFirstLen]enginepb.MVCCStats{
+				{ContainsEstimates: false, LastUpdateNanos: 946684800000000000, IntentAge: 0, GCBytesAge: 0, LiveBytes: 1048604, LiveCount: 1, KeyBytes: 23, KeyCount: 1, ValBytes: 1048581, ValCount: 1, IntentBytes: 0, IntentCount: 0, SysBytes: 0, SysCount: 0},
+				{ContainsEstimates: false, LastUpdateNanos: 946684801000000000, IntentAge: 0, GCBytesAge: 1048593, LiveBytes: 1048604, LiveCount: 1, KeyBytes: 35, KeyCount: 1, ValBytes: 2097162, ValCount: 2, IntentBytes: 0, IntentCount: 0, SysBytes: 0, SysCount: 0},
+				{ContainsEstimates: false, LastUpdateNanos: 946684802000000000, IntentAge: 0, GCBytesAge: 3145779, LiveBytes: 1048604, LiveCount: 1, KeyBytes: 47, KeyCount: 1, ValBytes: 3145743, ValCount: 3, IntentBytes: 0, IntentCount: 0, SysBytes: 0, SysCount: 0},
+			},
+			last: enginepb.MVCCStats{ContainsEstimates: false, LastUpdateNanos: 946684860000000000, IntentAge: 0, GCBytesAge: 1918925190, LiveBytes: 1048604, LiveCount: 1, KeyBytes: 743, KeyCount: 1, ValBytes: 63963441, ValCount: 61, IntentBytes: 0, IntentCount: 0, SysBytes: 0, SysCount: 0},
+		},
+	}
+	return &cws
+}
+
+func (cws *cachedWriteSimulator) value(size int) roachpb.Value {
+	var value roachpb.Value
+	kb := make([]byte, size)
+	if n, err := rand.New(rand.NewSource(int64(size))).Read(kb); err != nil {
+		cws.t.Fatal(err)
+	} else if n != size {
+		cws.t.Fatalf("wrote only %d < %d", n, size)
+	}
+	value.SetBytes(kb)
+	return value
+}
+
+func (cws *cachedWriteSimulator) multiKey(
+	numOps int, size int, txn *roachpb.Transaction, ms *enginepb.MVCCStats,
+) {
+	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	defer eng.Close()
+	t, ctx := cws.t, context.Background()
+
+	ts := hlc.Timestamp{}.Add(ms.LastUpdateNanos, 0)
+	key, value := []byte("multikey"), cws.value(size)
+	var eachMS enginepb.MVCCStats
+	if err := engine.MVCCPut(ctx, eng, &eachMS, key, ts, value, txn); err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i < numOps; i++ {
+		ms.Add(eachMS)
+	}
+}
+
+func (cws *cachedWriteSimulator) singleKeySteady(
+	qps int, duration time.Duration, size int, ms *enginepb.MVCCStats,
+) {
+	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	defer eng.Close()
+	t, ctx := cws.t, context.Background()
+	cacheKey := fmt.Sprintf("%d-%s-%s", qps, duration, humanizeutil.IBytes(int64(size)))
+	cached, ok := cws.cache[gcTestCacheKey{*ms, cacheKey}]
+	if !ok && duration > 0 {
+		t.Fatalf("cache key missing: %s with %s", cacheKey, pretty.Sprint(*ms))
+	}
+	firstSl := make([]enginepb.MVCCStats, 0, cacheFirstLen)
+	// Pick random bytes once; they don't matter for stats but we want reproducability.
+	key, value := []byte("0123456789"), cws.value(size)
+
+	initialNow := hlc.Timestamp{}.Add(ms.LastUpdateNanos, 0)
+
+	for elapsed := time.Duration(0); elapsed <= duration; elapsed += time.Second {
+		for i := 0; i < qps; i++ {
+			now := initialNow.Add(elapsed.Nanoseconds(), int32(i))
+
+			if err := engine.MVCCPut(ctx, eng, ms, key, now, value, nil /* txn */); err != nil {
 				t.Fatal(err)
 			}
-			tc.repl.mu.state.Stats = ms
-		}()
-		shouldQ, priority := gcQ.shouldQueue(context.TODO(), now, tc.repl, cfg)
-		if shouldQ != test.shouldQ {
-			t.Errorf("%d: should queue expected %t; got %t", i, test.shouldQ, shouldQ)
+			if len(firstSl) < cacheFirstLen {
+				firstSl = append(firstSl, *ms)
+			} else if len(firstSl) == cacheFirstLen {
+				if ok && reflect.DeepEqual(firstSl, cached.first[:cacheFirstLen]) {
+					*ms = cached.last
+					// Exit both loops.
+					elapsed += duration
+					break
+				} else {
+					ok = false
+				}
+			}
 		}
-		if scaledExpPri := test.priority * considerThreshold; math.Abs(priority-scaledExpPri) > 0.00001 {
-			t.Errorf("%d: priority expected %f; got %f", i, scaledExpPri, priority)
-		}
+	}
+
+	if !ok && duration > 0 {
+		copy(cached.first[:3], firstSl)
+		cached.last = *ms
+		t.Fatalf("missing or incorrect cache entry for %s, should be \n%s", cacheKey, pretty.Sprint(cached))
+	}
+}
+
+func (cws *cachedWriteSimulator) shouldQueue(
+	b bool, prio float64, after time.Duration, ttl time.Duration, ms enginepb.MVCCStats,
+) {
+	ts := hlc.Timestamp{}.Add(ms.LastUpdateNanos+after.Nanoseconds(), 0)
+	r := makeGCQueueScoreImpl(context.Background(), 0 /* seed */, ts, ms, int32(ttl.Seconds()))
+	if fmt.Sprintf("%.2f", r.FinalScore) != fmt.Sprintf("%.2f", prio) || b != r.ShouldQueue {
+		cws.t.Errorf("expected queued=%t (is %t), prio=%.2f, got %.2f: after=%s, ttl=%s:\nms: %+v\nscore: %s",
+			b, r.ShouldQueue, prio, r.FinalScore, after, ttl, ms, r)
+	}
+}
+
+// TestGCQueueMakeGCScoreRealistic verifies conditions which inform priority and
+// whether or not the range should be queued into the GC queue. Ranges are
+// queued for GC based on two conditions. The age of bytes available to be GC'd,
+// and the age of unresolved intents.
+func TestGCQueueMakeGCScoreRealistic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	cws := newCachedWriteSimulator(t)
+
+	initialMS := func() enginepb.MVCCStats {
+		var zeroMS enginepb.MVCCStats
+		zeroMS.AgeTo(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC).UnixNano())
+		return zeroMS
+	}
+
+	minuteTTL, hourTTL := time.Minute, time.Hour
+
+	{
+		// Hammer a key with 1MB blobs for a (simulated) minute. Logically, at
+		// the end of that you have around 60MB that are non-live, but cannot
+		// immediately be deleted. Deletion is only possible for keys that are
+		// (more or less) past TTL, and shouldQueue should respect that.
+		ms := initialMS()
+		cws.singleKeySteady(1, time.Minute, 1<<20, &ms)
+
+		// First, check that a zero second TTL behaves like a one second one.
+		// This is a special case without which the priority would be +Inf.
+		//
+		// Since at the time of this check the data is already 30s old on
+		// average (i.e. ~30x the TTL), we expect to *really* want GC.
+		cws.shouldQueue(true, 36.68, time.Duration(0), 0, ms)
+		cws.shouldQueue(true, 36.68, time.Duration(0), 0, ms)
+
+		// Right after we finished writing, we don't want to GC yet with a one-minute TTL.
+		cws.shouldQueue(false, 0.61, time.Duration(0), minuteTTL, ms)
+
+		// Neither after a minute. The first values are about to become GC'able, though.
+		cws.shouldQueue(false, 1.81, time.Minute, minuteTTL, ms)
+		// 90 seconds in it's really close, but still just shy of GC. Half of the
+		// values could be deleted now (remember that we wrote them over a one
+		// minute period).
+		cws.shouldQueue(true, 2.42, 3*time.Minute/2, minuteTTL, ms)
+		// Advancing another 1/4 minute does the trick.
+		cws.shouldQueue(true, 2.72, 7*time.Minute/4, minuteTTL, ms)
+		// After an hour, that's (of course) still true with a very high priority.
+		cws.shouldQueue(true, 72.76, time.Hour, minuteTTL, ms)
+
+		// Let's see what the same would look like with a 1h TTL.
+		// Can't delete anything until 59min have passed, and indeed the score is low.
+		cws.shouldQueue(false, 0.01, time.Duration(0), hourTTL, ms)
+		cws.shouldQueue(false, 0.03, time.Minute, hourTTL, ms)
+		cws.shouldQueue(false, 1.21, time.Hour, hourTTL, ms)
+		// After 90 minutes, we're getting closer. After two hours, definitely ripe for
+		// GC (and this would delete all the values).
+		cws.shouldQueue(false, 1.81, 3*time.Hour/2, hourTTL, ms)
+		cws.shouldQueue(true, 2.42, 2*time.Hour, hourTTL, ms)
+	}
+
+	{
+		ms, valSize := initialMS(), 1<<10
+
+		// Write 999 distinct 1kb keys at the initial timestamp without transaction.
+		cws.multiKey(999, valSize, nil /* no txn */, &ms)
+
+		// GC shouldn't move at all, even after a long time and short TTL.
+		cws.shouldQueue(false, 0, 24*time.Hour, minuteTTL, ms)
+
+		// Write a single key twice.
+		cws.singleKeySteady(2, 0, valSize, &ms)
+
+		// Now we have the situation in which the replica is pretty large
+		// compared to the amount of (ever) GC'able data it has. Consequently,
+		// the GC score should rise very slowly.
+
+		// If the fact that 99.9% of the replica is live were not taken into
+		// account, this would get us at least close to GC.
+		cws.shouldQueue(false, 0.01, 5*time.Minute, minuteTTL, ms)
+
+		// 12 hours in the score becomes relevant, but not yet large enough.
+		// The key is of course GC'able and has been for a long time, but
+		// to find it we'd have to scan all the other kv pairs as well.
+		cws.shouldQueue(false, 0.87, 12*time.Hour, minuteTTL, ms)
+
+		// Two days in we're more than ready to go, would queue for GC, and
+		// delete.
+		cws.shouldQueue(true, 3.49, 48*time.Hour, minuteTTL, ms)
+	}
+
+	{
+		irrelevantTTL := 24 * time.Hour * 365
+		ms, valSize := initialMS(), 1<<10
+		txn := newTransaction(
+			"txn", roachpb.Key("key"), roachpb.NormalUserPriority, enginepb.SERIALIZABLE,
+			hlc.NewClock(func() int64 { return ms.LastUpdateNanos }, time.Millisecond))
+
+		// Write 1000 distinct 1kb intents at the initial timestamp. This means that
+		// the average intent age is just the time elapsed from now, and this is roughly
+		// normalized by one day at the time of writing. Note that the size of the writes
+		// doesn't matter. In reality, the value-based GC score will often strike first.
+		cws.multiKey(100, valSize, txn, &ms)
+
+		cws.shouldQueue(false, 1.22, 24*time.Hour, irrelevantTTL, ms)
+		cws.shouldQueue(false, 2.45, 2*24*time.Hour, irrelevantTTL, ms)
+		cws.shouldQueue(false, 4.89, 4*24*time.Hour, irrelevantTTL, ms)
+		cws.shouldQueue(false, 8.56, 7*24*time.Hour, irrelevantTTL, ms)
+		cws.shouldQueue(true, 11, 9*24*time.Hour, irrelevantTTL, ms)
 	}
 }
 

--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -596,8 +596,10 @@ func (bq *baseQueue) processReplica(
 				if log.V(3) {
 					log.Infof(queueCtx, "%s; skipping", v)
 				}
+				log.Eventf(ctx, "%s; skipping", v)
 				return nil
 			default:
+				log.ErrEventf(ctx, "could not obtain lease: %s", pErr)
 				return errors.Wrapf(pErr.GoError(), "%s: could not obtain lease", repl)
 			}
 		}

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1268,10 +1268,7 @@ func containsKeyRange(desc roachpb.RangeDescriptor, start, end roachpb.Key) bool
 }
 
 // getLastReplicaGCTimestamp reads the timestamp at which the replica was
-// last checked for garbage collection.
-//
-// TODO(tschottdorf): we may want to phase this out in favor of using
-// gcThreshold.
+// last checked for removal by the replica gc queue.
 func (r *Replica) getLastReplicaGCTimestamp(ctx context.Context) (hlc.Timestamp, error) {
 	key := keys.RangeLastReplicaGCTimestampKey(r.RangeID)
 	var timestamp hlc.Timestamp
@@ -2493,7 +2490,7 @@ func (r *Replica) propose(
 
 	if proposal.command.Size() > int(maxCommandSize.Get()) {
 		// Once a command is written to the raft log, it must be loaded
-		// into memory and repliayed on all replicas. If a command is
+		// into memory and replayed on all replicas. If a command is
 		// too big, stop it here.
 		return nil, nil, errors.Errorf("command is too large: %d bytes (max: %d)",
 			proposal.command.Size(), maxCommandSize.Get())

--- a/pkg/storage/replica_state.go
+++ b/pkg/storage/replica_state.go
@@ -110,7 +110,7 @@ func (rsl replicaStateLoader) load(
 // its RangeID.
 //
 // TODO(tschottdorf): test and assert that none of the optional values are
-// missing when- ever saveState is called. Optional values should be reserved
+// missing whenever save is called. Optional values should be reserved
 // strictly for use in EvalResult. Do before merge.
 func (rsl replicaStateLoader) save(
 	ctx context.Context, eng engine.ReadWriter, state storagebase.ReplicaState,


### PR DESCRIPTION
For early review. Haven't updated tests yet and want to test drive this on adriatic.

TL;DR: use a scale-invariant `shouldQueue` for the GC Queue to avoid it running
in a tight loop without actually deleting anything. Furthermore don't queue for
GC if the replica has been processed within the TTL to mitigate a similar blow-
up due to the intent GC score.

See #15756

--

When a key of size `B` is deleted at timestamp `T` or superseded by a newer
version, it henceforth is accounted for in the range's `GCBytesAge`. At time
`S`, its contribution to age will be `B*seconds(S-T)`. The aggregate
`GCBytesAge` of all deleted versions in the cluster is what the GC queue at
the time of writing bases its `shouldQueue` method on.

If a replica is queued to have its old values garbage collected, its contents
are scanned. However, the values which are deleted follow a criterion that
isn't immediately connected to `GCBytesAge`: We (basically) delete everything
that's older than the Replica's `TTLSeconds`.

Thus, it's not obvious that garbage collection has the effect of reducing the
metric that we use to consider the replica for the next GC cycle, and it seems
that we messed it up.

The current metric used for queueing: `GCBytesAge/(1<<20 * ttl)` does not
have the right scaling. For example, consider that a value of size `1mb` is
overwritten with a newer version. After `ttl` seconds, it contributes `1mb` to
`GCBytesAge`, and so the replica has a score of `1`, i.e. (roughly) the range
becomes interesting to the GC queue. When GC runs, it will delete value that
are `ttl` old, which our value is. But a Replica is ~64mb, so picture that
you have 64mb of key-value data all at the same timestamp, and they become
superseded. Already after `ttl/64`, the metric becomes 1, but they keys won't
be GC'able for another (63*ttl)/64. Thus, GC will run "all the time" long
before it can actually have an effect.

The metric with correct scaling must thus take into account the size of the
range. What size exactly? Any data that isn't live (i.e. isn't readable by
a scan from the far future). That's `KeyBytes + ms.ValBytes - ms.LiveBytes`,
which is also known as `GCBytes` in the code. Hence, the better metric is
`GCBytesAge/(ttl*GCBytes)`.

Using this metric guarantees that after truncation, `GCBytesAge` is at most
`ttl*GCBytes` (where `GCBytes` has been updated), i.e. the new metric is at
most 1.

To visualize this, picture a rectangular frame of width `ttl` and height
`GCBytes` (i.e. the horizontal dimension is time, the vertical one bytes),
where the right boundary of the frame corresponds to age zero.
Each non-live key is a domino aligned with the right side of the frame, its
width equal to its size, and its height given by the duration (in seconds) it's
been non-live.

The combined surface of the dominos is then `GCBytesAge`, and the claim is that
if the total sum of domino heights (i.e. sizes) is `GCBytes`, and the surface
is larger than `ttl*GCBytes` by some positive `X`, then after removing the
dominos that cross the line `x=-ttl` (i.e. `ttl` to the left from the right
side of the frame), at least a surface area of `X` has been removed.

```           x=-ttl                 GCBytes=1+4
                |           3 (age)
                |          +-------+
                |          | keep  | 1 (bytes)
                |          +-------+
           +-----------------------+
           |                       |
           |        remove         | 3 (bytes)
           |                       |
           +-----------------------+
                |   7 (age)
```

This is true because

```
deletable area  = total area       - nondeletable area
                = X + ttl*GCBytes  - nondeletable area
               >= X + ttl*GCBytes  - ttl*(bytes in nondeletable area)
                = X + ttl*(GCBytes - bytes in nondeletable area)
               >= X.
```

Or, in other words, you can only hope to put `ttl*GCBytes` of area in the
"safe" rectangle. Once you've done that, everything else you put is going to be
deleted.

This means that running GC will always result in a `GCBytesAge` of `<=
ttl*GCBytes`, and that a decent trigger for GC is a multiple of `ttl*GCBytes`.

Limitations:

- Queueing for GC is nevertheless expensive due to the full scan involved, even
  if it gets to delete data. Small TTLs pose an obvious problem, and those
  should be throttled (i.e. bump a small TTL to a reasonable one implicitly).
- Replicas with heavy continuous deletion workloads could also pose a problem
  since the amount of data amassed on the Replica before GC kicks in could be
  prohibitive. There are likely scenarios in which it is more reasonable to
  perform garbage collection as the keys are accessed, though not even that can
  cover the scenario in which keys are never overwritten repeatedly. If it
  should come to that, the only reasonable path forward is excluding
  sufficiently outdated data from the consistent part of the replica, which
  excludes it from further replication (snapshots) and allows ad-hoc cleanup.
- `ttl=0` is particularly interesting in this regard since historical versions
  can always be deleted instantly and so GC runs can be driven directly by the
  number of non-live bytes.
- The intent portion of `shouldQueue` could be another time bomb if it fires
  continuously for some reason.