### PR TITLE
sql/parser: permit untyped string constant coercion to numeric types

### DIFF
--- a/pkg/server/settingsworker_test.go
+++ b/pkg/server/settingsworker_test.go
@@ -268,7 +268,7 @@ func TestSettingsSetAndShow(t *testing.T) {
 	})
 
 	if _, err := db.DB.Exec(fmt.Sprintf(setQ, intKey, "'a-str'")); !testutils.IsError(
-		err, fmt.Sprintf(`argument of %s must be type int, not type string`, intKey),
+		err, "could not parse 'a-str' as type int",
 	) {
 		t.Fatal(err)
 	}

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -449,7 +449,7 @@ ALTER TABLE add_default ALTER COLUMN b SET DEFAULT 10
 statement ok
 INSERT INTO add_default (a) VALUES (3)
 
-statement error incompatible type for DEFAULT expression
+statement error could not parse 'foo' as type int
 ALTER TABLE add_default ALTER COLUMN b SET DEFAULT 'foo'
 
 statement error DEFAULT expression .* may not contain variable sub-expressions

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -137,7 +137,7 @@ SELECT ARRAY['a', 'b', 'c'][4][2]
 query error incompatible ARRAY subscript type: decimal
 SELECT ARRAY['a', 'b', 'c'][3.5]
 
-query error incompatible ARRAY subscript type: string
+query error could not parse 'abc' as type int
 SELECT ARRAY['a', 'b', 'c']['abc']
 
 query error cannot subscript type int because it is not an array
@@ -353,10 +353,10 @@ a  CREATE TABLE a (
      FAMILY "primary" (b, rowid)
    )
 
-statement error type of array contents string doesn't match column type INT
+statement error could not parse 'foo' as type int
 INSERT INTO a VALUES (ARRAY['foo'])
 
-statement error expected 'foo' to be of type int, found type string
+statement error could not parse 'foo' as type int
 INSERT INTO a VALUES (ARRAY[1, 'foo'])
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1083,11 +1083,15 @@ SELECT LEAST(NULL, NULL, NULL)
 ----
 NULL
 
-query error greatest\(\): expected '4' to be of type int, found type string
+query I
 SELECT GREATEST(2, '4')
+----
+4
 
-query error least\(\): expected '4' to be of type int, found type string
+query I
 SELECT LEAST(2, '4')
+----
+2
 
 query T
 SELECT GREATEST('foo', 'bar', 'foobar')

--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -5,7 +5,10 @@
 statement ok
 CREATE TABLE t1 (a INT CHECK (a > 0), to_delete INT, b INT CHECK (b < 0) CHECK (b > -100))
 
-statement error string value does not match CHECK expr type int
+statement error could not parse '3.3' as type int
+INSERT INTO t1 VALUES ('3.3', 0, -1)
+
+statement ok
 INSERT INTO t1 VALUES ('3', 0, -1)
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -323,13 +323,13 @@ CREATE TABLE kv4 (
   float FLOAT
 )
 
-statement error value type string doesn't match type INT of column "int"
+statement error could not parse 'a' as type int
 INSERT INTO kv4 (int) VALUES ('a')
 
 statement ok
 INSERT INTO kv4 (int) VALUES (1)
 
-statement error value type string doesn't match type INT of column "bit"
+statement error could not parse 'a' as type int
 INSERT INTO kv4 (int, bit) VALUES (2, 'a')
 
 statement ok
@@ -614,7 +614,7 @@ SELECT * FROM insert_t
 1  2
 
 query ITTT
-EXPLAIN (PLAN) INSERT INTO insert_t VALUES(1,'AAA'),(2,'BBB') LIMIT 1
+EXPLAIN (PLAN) INSERT INTO insert_t VALUES(1,1),(2,2) LIMIT 1
 ----
 0  insert  ·     ·
 0  ·       into  insert_t(x, v)
@@ -623,7 +623,7 @@ EXPLAIN (PLAN) INSERT INTO insert_t VALUES(1,'AAA'),(2,'BBB') LIMIT 1
 2  ·       size  2 columns, 2 rows
 
 query ITTT
-EXPLAIN (PLAN) INSERT INTO insert_t (VALUES(1,'AAA'),(2,'BBB')) LIMIT 1
+EXPLAIN (PLAN) INSERT INTO insert_t (VALUES(1,1),(2,2)) LIMIT 1
 ----
 0  insert  ·     ·
 0  ·       into  insert_t(x, v)
@@ -632,7 +632,7 @@ EXPLAIN (PLAN) INSERT INTO insert_t (VALUES(1,'AAA'),(2,'BBB')) LIMIT 1
 2  ·       size  2 columns, 2 rows
 
 query ITTT
-EXPLAIN (PLAN) INSERT INTO insert_t (VALUES(1,'AAA'),(2,'BBB') LIMIT 1)
+EXPLAIN (PLAN) INSERT INTO insert_t (VALUES(1,1),(2,2) LIMIT 1)
 ----
 0  insert  ·     ·
 0  ·       into  insert_t(x, v)
@@ -641,7 +641,7 @@ EXPLAIN (PLAN) INSERT INTO insert_t (VALUES(1,'AAA'),(2,'BBB') LIMIT 1)
 2  ·       size  2 columns, 2 rows
 
 statement error pq: multiple LIMIT clauses not allowed
-EXPLAIN (PLAN) INSERT INTO insert_t (VALUES(1,'AAA'),(2,'BBB') LIMIT 1) LIMIT 1
+EXPLAIN (PLAN) INSERT INTO insert_t (VALUES(1,1),(2,2) LIMIT 1) LIMIT 1
 
 statement error DEFAULT can only appear in a VALUES list within INSERT or on the right side of a SET within UPDATE
 INSERT INTO insert_t (VALUES(1, DEFAULT),(2,'BBB') LIMIT 1)

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -77,7 +77,7 @@ EXECUTE a(3, 1)
 ----
 4
 
-query error incompatible type for EXECUTE parameter expression: int vs string
+query error could not parse 'foo' as type int
 EXECUTE a('foo', 1)
 
 query error incompatible type for EXECUTE parameter expression: int vs decimal
@@ -108,7 +108,7 @@ EXECUTE b(3)
 ----
 3
 
-query error incompatible type for EXECUTE parameter expression: int vs string
+query error could not parse 'foo' as type int
 EXECUTE b('foo')
 
 statement
@@ -149,7 +149,7 @@ EXECUTE i(2)
 ----
 3
 
-query error incompatible type for EXECUTE parameter expression: int vs string
+query error could not parse 'foo' as type int
 EXECUTE i('foo')
 
 query error incompatible type for EXECUTE parameter expression: int vs decimal

--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -224,13 +224,13 @@ NULL           /1             {1}       1
 statement error too many columns in SPLIT AT data
 ALTER TABLE t SPLIT AT VALUES (1, 2, 3)
 
-statement error SPLIT AT data column 1 \(k1\) must be of type int, not type string
+statement error could not parse 'foo' as type int
 ALTER TABLE t SPLIT AT VALUES ('foo')
 
 statement error too many columns in TESTING_RELOCATE data
 ALTER TABLE t TESTING_RELOCATE VALUES (ARRAY[1], 1, 2, 3)
 
-statement error TESTING_RELOCATE data column 2 \(k1\) must be of type int, not type string
+statement error could not parse 'foo' as type int
 ALTER TABLE t TESTING_RELOCATE VALUES (ARRAY[4], 'foo')
 
 statement error TESTING_RELOCATE data column 1 \(relocation array\) must be of type int\[\], not type string

--- a/pkg/sql/logictest/testdata/logic_test/run_control
+++ b/pkg/sql/logictest/testdata/logic_test/run_control
@@ -3,7 +3,7 @@
 query error job with ID 1 does not exist
 PAUSE JOB 1
 
-query error argument of PAUSE JOB must be type int, not type string
+query error could not parse 'foo' as type int
 PAUSE JOB 'foo'
 
 query error NULL is not a valid job ID
@@ -12,7 +12,7 @@ PAUSE JOB (SELECT id FROM system.jobs LIMIT 1)
 query error job with ID 1 does not exist
 RESUME JOB 1
 
-query error argument of RESUME JOB must be type int, not type string
+query error could not parse 'foo' as type int
 RESUME JOB 'foo'
 
 query error NULL is not a valid job ID
@@ -21,7 +21,7 @@ RESUME JOB (SELECT id FROM system.jobs LIMIT 1)
 query error job with ID 1 does not exist
 CANCEL JOB 1
 
-query error argument of CANCEL JOB must be type int, not type string
+query error could not parse 'foo' as type int
 CANCEL JOB 'foo'
 
 query error NULL is not a valid job ID

--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -206,8 +206,13 @@ SELECT * FROM xyzw LIMIT x
 query error name \"y\" is not defined
 SELECT * FROM xyzw OFFSET 1 + y
 
-query error argument of LIMIT must be type int, not type string
-SELECT * FROM xyzw LIMIT '1'
+query error argument of LIMIT must be type int, not type decimal
+SELECT * FROM xyzw LIMIT 3.3
+
+query IIII
+SELECT * FROM xyzw ORDER BY 1 LIMIT '1'
+----
+1 2 3 4
 
 query error argument of OFFSET must be type int, not type decimal
 SELECT * FROM xyzw OFFSET 1.5

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -98,7 +98,7 @@ SELECT
 ----
 true NULL false NULL
 
-statement error pq: tuples \(1, 2\), \(1, 'hi'\) are not comparable at index 2: unsupported comparison operator: <int> > <string>
+statement error pq: tuples \(1, 2\), \(1, 'hi'\) are not comparable at index 2: unsupported comparison operator
 SELECT (1, 2) > (1, 'hi')
 
 statement error pq: expected tuple \(1, 2, 3\) to have a length of 2
@@ -143,7 +143,7 @@ SELECT (ROW(SQRT(100.0)), 'ab') = (ROW(POW(1, 10.0) + 9), 'a' || 'b')
 ----
 true
 
-query error pq: tuples \(\(1, 2\), 'equal'\), \(\(1, 'huh'\), 'equal'\) are not comparable at index 1: tuples \(1, 2\), \(1, 'huh'\) are not comparable at index 2: unsupported comparison operator: <int> = <string>
+query error pq: tuples \(\(1, 2\), 'equal'\), \(\(1, 'huh'\), 'equal'\) are not comparable at index 1: tuples \(1, 2\), \(1, 'huh'\) are not comparable at index 2: unsupported comparison operator
 SELECT ((1, 2), 'equal') = ((1, 'huh'), 'equal')
 
 # Issue #3568

--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -74,16 +74,16 @@ SELECT * from s
 qwe
 startend
 
-statement error incompatible COALESCE expressions: expected 1 to be of type string, found type int
+statement error incompatible COALESCE expressions: could not parse 'foo' as type int
 INSERT INTO s VALUES (COALESCE(1, 'foo'))
 
-statement error incompatible COALESCE expressions: expected 'foo' to be of type int, found type string
+statement error incompatible COALESCE expressions: could not parse 'foo' as type int
 INSERT INTO i VALUES (COALESCE(1, 'foo'))
 
-query error incompatible COALESCE expressions: expected 'foo' to be of type int, found type string
+query error incompatible COALESCE expressions: could not parse 'foo' as type int
 SELECT COALESCE(1, 'foo')
 
-query error incompatible COALESCE expressions: expected 'foo' to be of type int, found type string
+query error incompatible COALESCE expressions: could not parse 'foo' as type int
 SELECT COALESCE(1::INT, 'foo')
 
 query R
@@ -117,15 +117,15 @@ SELECT GREATEST(-1, 1, 2.3, 123456789, 3 + 5, -(-4), ABS(-9.0))
 123456789
 
 statement ok
-CREATE TABLE untyped (b bool, d DATE, ts TIMESTAMP, tz TIMESTAMPTZ, i INTERVAL)
+CREATE TABLE untyped (b bool, n INT, f FLOAT, e DECIMAL, d DATE, ts TIMESTAMP, tz TIMESTAMPTZ, i INTERVAL)
 
 statement ok
-INSERT INTO untyped VALUES ('f', '2010-09-28', '2010-09-28 12:00:00.1', '2010-09-29 12:00:00.1', 'PT12H2M')
+INSERT INTO untyped VALUES ('f', '42', '4.2', '4.20', '2010-09-28', '2010-09-28 12:00:00.1', '2010-09-29 12:00:00.1', 'PT12H2M')
 
-query BTTTT
+query BIRRTTTT
 SELECT * FROM untyped
 ----
-false   2010-09-28 00:00:00 +0000 +0000   2010-09-28 12:00:00.1 +0000 +0000   2010-09-29 12:00:00.1 +0000 +0000   12h2m
+false   42   4.2    4.20    2010-09-28 00:00:00 +0000 +0000   2010-09-28 12:00:00.1 +0000 +0000   2010-09-29 12:00:00.1 +0000 +0000   12h2m
 
 # Issue #14527: support string literal coercion during overload resolution
 query T

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -1250,10 +1250,10 @@ SELECT k, lead(k, w) OVER (PARTITION BY v ORDER BY w) FROM kv ORDER BY 1
 10  NULL
 11  NULL
 
-query error unknown signature: lag\(int, int, string\)
+query error could not parse 'FOO' as type int
 SELECT k, lag(k, 1, 'FOO') OVER () FROM kv ORDER BY 1
 
-query error unknown signature: lead\(int, int, string\)
+query error could not parse 'FOO' as type int
 SELECT k, lead(k, 1, 'FOO') OVER () FROM kv ORDER BY 1
 
 query error unknown signature: lag\(int, int, string\)
@@ -1483,7 +1483,7 @@ SELECT k, v, w, last_value(w) OVER (PARTITION BY v ORDER BY w DESC) FROM kv ORDE
 10  4     9  9
 11  NULL  9  9
 
-query error unknown signature: nth_value\(int, string\)
+query error could not parse 'FOO' as type int
 SELECT k, nth_value(v, 'FOO') OVER () FROM kv ORDER BY 1
 
 query error argument of nth_value\(\) must be greater than zero

--- a/pkg/sql/parser/constant.go
+++ b/pkg/sql/parser/constant.go
@@ -34,6 +34,17 @@ type Constant interface {
 	// be resolved into. The order of the type slice provides a notion of precedence,
 	// with the first element in the ordering being the Constant's "natural type".
 	AvailableTypes() []Type
+	// DesirableTypes returns the ordered set of types that the constant would
+	// prefer to be resolved into. As in AvailableTypes, the order of the returned
+	// type slice provides a notion of precedence, with the first element in the
+	// ordering being the Constant's "natural type." The function is meant to be
+	// differentiated from AvailableTypes in that it will exclude certain types
+	// that are possible, but not desirable.
+	//
+	// An example of this is a floating point numeric constant without a value
+	// past the decimal point. It is possible to resolve this constant as a
+	// decimal, but it is not desirable.
+	DesirableTypes() []Type
 	// ResolveAsType resolves the Constant as the Datum type specified, or returns an
 	// error if the Constant could not be resolved as that type. The method should only
 	// be passed a type returned from AvailableTypes and should never be called more than
@@ -95,22 +106,6 @@ func canConstantBecome(c Constant, typ Type) bool {
 	return false
 }
 
-// shouldConstantBecome returns whether the provided Constant should or
-// should not become the provided type. The function is meant to be differentiated
-// from canConstantBecome in that it will exclude certain (Constant, Type) resolution
-// pairs that are possible, but not desirable.
-//
-// An example of this is resolving a floating point numeric constant without a value
-// past the decimal point as an DInt. This is possible, but it is not desirable.
-func shouldConstantBecome(c Constant, typ Type) bool {
-	if num, ok := c.(*NumVal); ok {
-		if UnwrapType(typ) == TypeInt && num.Kind() == constant.Float {
-			return false
-		}
-	}
-	return canConstantBecome(c, typ)
-}
-
 // NumVal represents a constant numeric value.
 type NumVal struct {
 	constant.Value
@@ -148,9 +143,6 @@ func (expr *NumVal) canBeInt64() bool {
 //  1.0 = no
 //  1.1 = no
 //  123...overflow...456 = no
-//
-// Currently unused so commented out, but useful even just for
-// its documentation value.
 func (expr *NumVal) ShouldBeInt64() bool {
 	return expr.Kind() == constant.Int && expr.canBeInt64()
 }
@@ -206,6 +198,14 @@ func (expr *NumVal) AvailableTypes() []Type {
 	default:
 		return numValAvailDecimalWithFraction
 	}
+}
+
+// DesirableTypes implements the Constant interface.
+func (expr *NumVal) DesirableTypes() []Type {
+	if expr.ShouldBeInt64() {
+		return numValAvailInteger
+	}
+	return numValAvailDecimalWithFraction
 }
 
 // ResolveAsType implements the Constant interface.
@@ -275,66 +275,39 @@ func (expr *NumVal) ResolveAsType(ctx *SemaContext, typ Type) (Datum, error) {
 	}
 }
 
+func intersectTypeSlices(xs, ys []Type) (out []Type) {
+	for _, x := range xs {
+		for _, y := range ys {
+			if x == y {
+				out = append(out, x)
+			}
+		}
+	}
+	return out
+}
+
 // commonConstantType returns the most constrained type which is mutually
-// resolvable between a set of provided constants. It returns false if constants
-// are not all of the same kind, and therefore share no common type.
+// resolvable between a set of provided constants.
 //
 // The function takes a slice of Exprs and indexes, but expects all the indexed
 // Exprs to wrap a Constant. The reason it does no take a slice of Constants
 // instead is to avoid forcing callers to allocate separate slices of Constant.
 func commonConstantType(vals []Expr, idxs []int) (Type, bool) {
-	switch vals[idxs[0]].(Constant).(type) {
-	case *NumVal:
-		for _, i := range idxs[1:] {
-			if _, ok := vals[i].(Constant).(*NumVal); !ok {
-				return nil, false
-			}
-		}
-		return commonNumericConstantType(vals, idxs), true
-	case *StrVal:
-		for _, i := range idxs[1:] {
-			if _, ok := vals[i].(Constant).(*StrVal); !ok {
-				return nil, false
-			}
-		}
-		return commonStringConstantType(vals, idxs), true
-	default:
-		panic(fmt.Sprintf("unexpected Constant type %T", vals[idxs[0]]))
-	}
-}
+	var candidates []Type
 
-// commonNumericConstantType returns the best type which is mutually
-// resolvable between a set of provided numeric constants. Here, "best"
-// is defined as the smallest numeric data type that all constants can
-// become without losing information.
-//
-// The function takes a slice of Exprs and indexes, but expects all the indexed
-// Exprs to wrap a *NumVal. The reason it does no take a slice of *NumVals
-// instead is to avoid forcing callers to allocate separate slices of *NumVals.
-func commonNumericConstantType(vals []Expr, idxs []int) Type {
 	for _, i := range idxs {
-		if !shouldConstantBecome(vals[i].(*NumVal), TypeInt) {
-			return TypeDecimal
+		availableTypes := vals[i].(Constant).DesirableTypes()
+		if candidates == nil {
+			candidates = availableTypes
+		} else {
+			candidates = intersectTypeSlices(candidates, availableTypes)
 		}
 	}
-	return TypeInt
-}
 
-// commonStringConstantType returns the best type which is shared
-// between a set of provided string constants. Here, "best" is defined as
-// the most specific string-like type that applies to all constants. This
-// suffers from the same limitation as StrVal.AvailableTypes.
-//
-// The function takes a slice of Exprs and indexes, but expects all the indexed
-// Exprs to wrap a *StrVal. The reason it does no take a slice of *StrVals
-// instead is to avoid forcing callers to allocate separate slices of *StrVals.
-func commonStringConstantType(vals []Expr, idxs []int) Type {
-	for _, i := range idxs {
-		if vals[i].(*StrVal).bytesEsc {
-			return TypeBytes
-		}
+	if len(candidates) > 0 {
+		return candidates[0], true
 	}
-	return TypeString
+	return nil, false
 }
 
 // StrVal represents a constant string value.
@@ -364,6 +337,9 @@ var (
 		TypeString,
 		TypeBytes,
 		TypeBool,
+		TypeInt,
+		TypeFloat,
+		TypeDecimal,
 		TypeDate,
 		TypeTimestamp,
 		TypeTimestampTZ,
@@ -413,6 +389,11 @@ func (expr *StrVal) AvailableTypes() []Type {
 	return strValAvailBytes
 }
 
+// DesirableTypes implements the Constant interface.
+func (expr *StrVal) DesirableTypes() []Type {
+	return expr.AvailableTypes()
+}
+
 // ResolveAsType implements the Constant interface.
 func (expr *StrVal) ResolveAsType(ctx *SemaContext, typ Type) (Datum, error) {
 	switch typ {
@@ -428,6 +409,12 @@ func (expr *StrVal) ResolveAsType(ctx *SemaContext, typ Type) (Datum, error) {
 		return &expr.resBytes, err
 	case TypeBool:
 		return ParseDBool(expr.s)
+	case TypeInt:
+		return ParseDInt(expr.s)
+	case TypeFloat:
+		return ParseDFloat(expr.s)
+	case TypeDecimal:
+		return ParseDDecimal(expr.s)
 	case TypeDate:
 		return ParseDDate(expr.s, ctx.getLocation())
 	case TypeTimestamp:

--- a/pkg/sql/parser/eval_test.go
+++ b/pkg/sql/parser/eval_test.go
@@ -548,8 +548,11 @@ func TestEval(t *testing.T) {
 		{`1::boolean`, `true`},
 		{`0::boolean`, `false`},
 		{`1::int`, `1`},
+		{`'1'::int`, `1`},
 		{`1::float`, `1.0`},
+		{`'1'::float`, `1.0`},
 		{`1::decimal`, `1`},
+		{`'1'::decimal`, `1`},
 		{`length(123::text)`, `3`},
 		{`1.1::boolean`, `true`},
 		{`0.0::boolean`, `false`},
@@ -571,6 +574,7 @@ func TestEval(t *testing.T) {
 		{`-1.5::int`, `-2`},
 		{`-2.5::int`, `-3`},
 		{`1.1::float`, `1.1`},
+		{`'1.1'::float`, `1.1`},
 		{`-1e+06::float`, `-1e+06`},
 		{`-9.99999e+05`, `-999999`},
 		{`999999.0`, `999999.0`},
@@ -578,6 +582,7 @@ func TestEval(t *testing.T) {
 		{`-1e+06`, `-1E+6`},
 		{`-9.99999e+05::decimal`, `-999999`},
 		{`999999.0::decimal`, `999999.0`},
+		{`'999999.0'::decimal`, `999999.0`},
 		{`1000000.0::decimal`, `1000000.0`},
 		{`length(1.23::text)`, `4`},
 		{`'t'::boolean`, `true`},
@@ -1090,6 +1095,7 @@ func TestEvalError(t *testing.T) {
 		{`'NaN'::decimal::int`, `integer out of range`},
 		{`'Inf'::float::int`, `integer out of range`},
 		{`'NaN'::float::int`, `integer out of range`},
+		{`'1.1'::int`, `could not parse '1.1' as type int`},
 	}
 	for _, d := range testData {
 		expr, err := ParseExpr(d.expr)

--- a/pkg/sql/parser/overload_test.go
+++ b/pkg/sql/parser/overload_test.go
@@ -110,7 +110,7 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 		{nil, []Expr{intConst("1")}, []overloadImpl{unaryStringFn, binaryIntFn}, unsupported, false},
 		{nil, []Expr{strConst("PT12H2M")}, []overloadImpl{unaryIntervalFn}, unaryIntervalFn, false},
 		{nil, []Expr{strConst("PT12H2M")}, []overloadImpl{unaryIntervalFn, unaryStringFn}, unaryStringFn, false},
-		{nil, []Expr{strConst("PT12H2M")}, []overloadImpl{unaryIntervalFn, unaryTimestampFn}, unsupported, false}, // Limitation.
+		{nil, []Expr{strConst("PT12H2M")}, []overloadImpl{unaryIntervalFn, unaryTimestampFn}, unaryIntervalFn, false},
 		{nil, []Expr{}, []overloadImpl{unaryIntFn, unaryIntFnPref}, unaryIntFnPref, false},
 		{nil, []Expr{}, []overloadImpl{unaryIntFnPref, unaryIntFnPref}, ambiguous, false},
 		{nil, []Expr{strConst("PT12H2M")}, []overloadImpl{unaryIntervalFn, unaryIntFn}, unaryIntervalFn, false},

--- a/pkg/sql/parser/type_check_test.go
+++ b/pkg/sql/parser/type_check_test.go
@@ -92,7 +92,7 @@ func TestTypeCheck(t *testing.T) {
 		{`NULL = ALL CURRENT_SCHEMAS(true)`, `NULL`},
 
 		{`INTERVAL '1'`, `'1s':::INTERVAL`},
-		{`DECIMAL '1.0'`, `'1.0':::STRING::DECIMAL`},
+		{`DECIMAL '1.0'`, `1.0:::DECIMAL::DECIMAL`},
 
 		{`1 + 2`, `3:::INT`},
 		{`1:::decimal + 2`, `1:::DECIMAL + 2:::DECIMAL`},
@@ -104,10 +104,15 @@ func TestTypeCheck(t *testing.T) {
 		{`1:::DECIMAL + $1`, `1:::DECIMAL + $1:::DECIMAL`},
 		{`$1:::INT`, `$1:::INT`},
 
-		{`'NaN'::decimal`, `'NaN':::STRING::DECIMAL`},
-		{`'-NaN'::decimal`, `'-NaN':::STRING::DECIMAL`},
-		{`'Inf'::decimal`, `'Inf':::STRING::DECIMAL`},
-		{`'-Inf'::decimal`, `'-Inf':::STRING::DECIMAL`},
+		// These outputs, while bizarre looking, are correct and expected.
+		// The first cast is caused by ReType in normalize.go. The type annotation
+		// is caused by the call to Serialize, which formats the output using the
+		// Parseable formatter which inserts type annotations at the end of all
+		// well-typed atums. And the final cast is caused by the test itself.
+		{`'NaN'::decimal`, `'NaN'::DECIMAL:::DECIMAL::DECIMAL`},
+		{`'-NaN'::decimal`, `'NaN'::DECIMAL:::DECIMAL::DECIMAL`},
+		{`'Inf'::decimal`, `'Infinity'::DECIMAL:::DECIMAL::DECIMAL`},
+		{`'-Inf'::decimal`, `'-Infinity'::DECIMAL:::DECIMAL::DECIMAL`},
 	}
 	for _, d := range testData {
 		expr, err := ParseExpr(d.expr)
@@ -165,12 +170,10 @@ func TestTypeCheckError(t *testing.T) {
 		expected string
 	}{
 		{`'1' + '2'`, `unsupported binary operator:`},
-		// This strange error is a result of the <date> + <int> overload and because
-		// of the limitation described on StrVal.AvailableTypes.
-		{`'a' + 0`, `could not parse 'a' as type date`},
+		{`'a' + 0`, `unsupported binary operator:`},
 		{`1.1 # 3.1`, `unsupported binary operator:`},
 		{`~0.1`, `unsupported unary operator:`},
-		{`'10' > 2`, `unsupported comparison operator:`},
+		{`'a' > 2`, `unsupported comparison operator:`},
 		{`a`, `name "a" is not defined`},
 		{`COS(*)`, `cannot use "*" in this context`},
 		{`a.*`, `cannot use "a.*" in this context`},
@@ -188,21 +191,21 @@ func TestTypeCheckError(t *testing.T) {
 		{`CASE 1 WHEN 1 THEN 'one' WHEN 2 THEN 2 END`, `incompatible value type`},
 		{`CASE 1 WHEN 1 THEN 'one' ELSE 2 END`, `incompatible value type`},
 		{`(1, 2, 3) = (1, 2)`, `expected tuple (1, 2) to have a length of 3`},
-		{`(1, 2) = (1, 'a')`, `tuples (1, 2), (1, 'a') are not comparable at index 2: unsupported comparison operator: <int> = <string>`},
-		{`1 IN ('a', 'b')`, `unsupported comparison operator: 1 IN ('a', 'b'): expected 'a' to be of type int, found type string`},
-		{`1 IN (1, 'a')`, `unsupported comparison operator: 1 IN (1, 'a'): expected 'a' to be of type int, found type string`},
+		{`(1, 2) = (1, 'a')`, `tuples (1, 2), (1, 'a') are not comparable at index 2: unsupported comparison operator:`},
+		{`1 IN ('a', 'b')`, `unsupported comparison operator: 1 IN ('a', 'b'): could not parse 'a' as type int`},
+		{`1 IN (1, 'a')`, `unsupported comparison operator: 1 IN (1, 'a'): could not parse 'a' as type int`},
 		{`1 = ANY 2`, `unsupported comparison operator: 1 = ANY 2: op ANY array requires array on right side`},
-		{`1 = ANY ARRAY[2, '3']`, `unsupported comparison operator: 1 ANY = ARRAY[2, '3']: expected '3' to be of type int, found type string`},
+		{`1 = ANY ARRAY[2, 'a']`, `unsupported comparison operator: 1 ANY = ARRAY[2, 'a']: could not parse 'a' as type int`},
 		{`1 = ALL CURRENT_SCHEMAS(true)`, `unsupported comparison operator: <int> = ALL <string[]>`},
-		{`1.0 BETWEEN 2 AND '5'`, `unsupported comparison operator: <decimal> < <string>`},
+		{`1.0 BETWEEN 2 AND 'a'`, `unsupported comparison operator: <decimal> < <string>`},
 		{`IF(1, 2, 3)`, `incompatible IF condition type: int`},
-		{`IF(true, '5', 2)`, `incompatible IF expressions: expected 2 to be of type string, found type int`},
-		{`IF(true, 2, '5')`, `incompatible IF expressions: expected '5' to be of type int, found type string`},
-		{`IFNULL(1, '5')`, `incompatible IFNULL expressions: expected '5' to be of type int, found type string`},
-		{`NULLIF(1, '5')`, `incompatible NULLIF expressions: expected '5' to be of type int, found type string`},
-		{`COALESCE(1, 2, 3, 4, '5')`, `incompatible COALESCE expressions: expected '5' to be of type int, found type string`},
+		{`IF(true, 'a', 2)`, `incompatible IF expressions: could not parse 'a' as type int`},
+		{`IF(true, 2, 'a')`, `incompatible IF expressions: could not parse 'a' as type int`},
+		{`IFNULL(1, 'a')`, `incompatible IFNULL expressions: could not parse 'a' as type int`},
+		{`NULLIF(1, 'a')`, `incompatible NULLIF expressions: could not parse 'a' as type int`},
+		{`COALESCE(1, 2, 3, 4, 'a')`, `incompatible COALESCE expressions: could not parse 'a' as type int`},
 		{`ARRAY[]`, `cannot determine type of empty array`},
-		{`ANNOTATE_TYPE('a', int)`, `incompatible type annotation for 'a' as int, found type: string`},
+		{`ANNOTATE_TYPE('a', int)`, `could not parse 'a' as type int`},
 		{`ANNOTATE_TYPE(ANNOTATE_TYPE(1, int), decimal)`, `incompatible type annotation for ANNOTATE_TYPE(1, INT) as decimal, found type: int`},
 		{`3:::int[]`, `incompatible type annotation for 3 as int[], found type: int`},
 	}

--- a/pkg/sql/split_at_test.go
+++ b/pkg/sql/split_at_test.go
@@ -74,7 +74,7 @@ func TestSplitAt(t *testing.T) {
 		},
 		{
 			in:    "ALTER TABLE d.t SPLIT AT VALUES ('c', 3)",
-			error: "SPLIT AT data column 1 (i) must be of type int, not type string",
+			error: "could not parse 'c' as type int",
 		},
 		{
 			in:    "ALTER TABLE d.t SPLIT AT VALUES (i, s)",


### PR DESCRIPTION
It seems that @nvanbenschoten would be the obvious choice as reviewer, but @knz, since he's on vacation, could you triage and/or review?

@cuongdo, now that I've drawn this up, it seems to me that it's a better solution than cockroachdb/sequelize-cockroachdb#2.

---

Allow untyped string literals to coerce to `INT`, `DECIMAL`, and `FLOAT`. (For
prior art, see #13685, which allowed string literals to coerce into
booleans.)

Essentially, anywhere an `INT`, `DECIMAL`, or `FLOAT` is required, a string
constant encoding the appropriate type can be used instead. The
following query now works, for example:

    CREATE TABLE t (a INT DEFAULT '1');

As does:

    SELECT * FROM foo LIMIT '1';

This brings us closer in line with Postgres's semantics. Importantly,
it solves a problem with Sequelize (see cockroachdb/sequelize-cockroachdb#2),
where Sequelize expects to be able to store a string literal
representing an integer (instead of an integer literal) into an INT
column.