### PR TITLE
cmd/urlcheck: refer to correct variable in retry branch

### DIFF
--- a/pkg/cmd/urlcheck/main.go
+++ b/pkg/cmd/urlcheck/main.go
@@ -130,7 +130,7 @@ func checkURL(client *http.Client, url string) error {
 			return err
 		}
 
-		if retryResp.StatusCode >= 200 && resp.StatusCode < 300 {
+		if retryResp.StatusCode >= 200 && retryResp.StatusCode < 300 {
 			return nil
 		}
 


### PR DESCRIPTION
Self-inflicted refactor skew. 🤦