### PR TITLE
ui: more robustly nuke auto-installed broken dependency

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -154,7 +154,6 @@ YARN_INSTALLED_TARGET := $(UI_ROOT)/yarn.installed
 
 $(YARN_INSTALLED_TARGET): $(BOOTSTRAP_TARGET) $(UI_ROOT)/package.json $(UI_ROOT)/yarn.lock
 	cd $(UI_ROOT) && yarn install
-	rm -rf $(UI_ROOT)/node_modules/@types/node # https://github.com/yarnpkg/yarn/issues/2987
 	touch $@
 
 # We store the bootstrap marker file in the bin directory so that remapping bin,

--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -72,6 +72,7 @@
     "redux": "^3.6.0",
     "redux-thunk": "^2.2.0",
     "reselect": "^3.0.0",
+    "rimraf": "^2.6.1",
     "sinon": "^2.1.0",
     "source-map-loader": "^0.2.0",
     "style-loader": "^0.16.0",

--- a/pkg/ui/webpack.config.js
+++ b/pkg/ui/webpack.config.js
@@ -1,9 +1,23 @@
 'use strict;'
 
+const rimraf = require('rimraf');
+
 const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const title = 'Cockroach Console';
+
+// Remove a broken dependency that yarn insists upon installing before every
+// Webpack compile. We used to do this in the Makefile, but it was common while
+// developing the UI to run e.g. `yarn add` manually, which would reinstall the
+// broken dependency, causing Webpack to fail with cryptic errors.
+//
+// See: https://github.com/yarnpkg/yarn/issues/2987
+class RemoveBrokenDependenciesPlugin {
+  apply(compiler) {
+    compiler.plugin("compile", () => rimraf.sync("./node_modules/@types/node"));
+  }
+}
 
 module.exports = {
   entry: './src/index.tsx',
@@ -58,6 +72,7 @@ module.exports = {
   },
 
   plugins: [
+    new RemoveBrokenDependenciesPlugin(),
     new FaviconsWebpackPlugin({
       logo: './logo.png',
       persistentCache: false,


### PR DESCRIPTION
More robustly remove a broken dependency that yarn insists upon
installing by nuking it before every Webpack compile. We used to do this
in the Makefile, but it was common while developing the UI to run e.g.
`yarn add` manually, which would reinstall the broken dependency,
causing Webpack to fail with cryptic errors.