### PR TITLE
build: per convention, change default make goal to `build`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,9 +112,13 @@ executable will be in your current directory and can be run as shown in the
   not point to a specific package; those commits may begin with "*:" or "all:"
   to indicate their reach.
 
-+ Run the test suite locally:
++ Run the linters, code generators, and unit test suites locally:
 
-  `make generate lint test testrace`
+  ```
+  make pre-push
+  ````
+
+  This will take several minutes.
 
 + When you’re ready for review, groom your work: each commit should pass tests
   and contain a substantial (but not overwhelming) unit of work. You may also

--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,13 @@ clean: clean-c-deps
 protobuf:
 	$(MAKE) -C $(ORG_ROOT) -f cockroach/build/protobuf.mk
 
+# pre-push locally runs most of the checks CI will run. Notably, it doesn't run
+# the acceptance tests.
+.PHONY: pre-push
+pre-push: generate lint test
+	$(MAKE) -C $(REPO_ROOT)/pkg/ui lint test
+	! git status --porcelain | read || (git status; git --no-pager diff -a 1>&2; exit 1)
+
 # archive builds a source tarball out of this repository. Files in the special
 # directory build/archive/contents are inserted directly into $(ARCHIVE_BASE).
 # All other files in the repository are inserted into the archive with prefix

--- a/Makefile
+++ b/Makefile
@@ -129,11 +129,7 @@ endif
 XGO := $(strip $(if $(XGOOS),GOOS=$(XGOOS)) $(if $(XGOARCH),GOARCH=$(XGOARCH)) $(if $(XHOST_TRIPLE),CC=$(CC_PATH) CXX=$(CXX_PATH)) $(GO))
 
 .DEFAULT_GOAL := all
-.PHONY: all
-all: build test lint
-
-.PHONY: short
-short: build testshort lintshort
+all: build
 
 buildoss: BUILDTARGET = ./pkg/cmd/cockroach-oss
 


### PR DESCRIPTION
To adhere to Make convention, change the default Make goal from `build
test lint` to just `build`.

This is another step in addressing #15862.

---

I could have sworn that somewhere we mention that a bare `make` will build, run the tests, and lint, but now that I'm looking for it I can't find it.