### PR TITLE
cherrypick: sql: allow CREATE USER WITH PASSWORD from CLI trans…

### DIFF
--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -56,6 +56,42 @@ send "$argv sql --certs-dir=$certs_dir --user=carl\r"
 eexpect "Enter password:"
 send "woof\r"
 eexpect "carl@"
+send "\\q\r"
+eexpect $prompt
+end_test
+
+start_test "Check that CREATE USER WITH PASSWORD can be used from transactions."
+# Create a user from a transaction.
+send "$argv sql --certs-dir=$certs_dir\r"
+eexpect "root@"
+send "BEGIN TRANSACTION;\r"
+eexpect " ->"
+send "CREATE USER eisen WITH PASSWORD 'hunter2';\r"
+eexpect " ->"
+send "COMMIT TRANSACTION;\r"
+eexpect "root@"
+send "\\q\r"
+# Log in with the correct password.
+eexpect $prompt
+send "$argv sql --certs-dir=$certs_dir --user=eisen\r"
+eexpect "Enter password:"
+send "hunter2\r"
+eexpect "eisen@"
+send "\\q\r"
+# Try to log in with an incorrect password.
+eexpect $prompt
+send "$argv sql --certs-dir=$certs_dir --user=eisen\r"
+eexpect "Enter password:"
+send "*****\r"
+eexpect "Error: pq: invalid password"
+eexpect "Failed running \"sql\""
+# Check that history is scrubbed.
+send "$argv sql --certs-dir=$certs_dir\r"
+eexpect "root@"
+# Ctrl+R eisen
+send "\022eisen"
+eexpect "CREATE USER eisen WITH PASSWORD \\*\\*\\*\\*\\*;"
+interrupt
 end_test
 
 # Terminate with Ctrl+C.

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -849,7 +849,8 @@ func (c *cliState) doCheckStatement(startState, contState, execState cliStateEnu
 	// Replace the last entered lines by the last entered statements.
 	c.partialLines = c.partialLines[:c.partialStmtsLen]
 	for i := c.partialStmtsLen; i < len(parsedStmts); i++ {
-		c.partialLines = append(c.partialLines, parsedStmts[i].String()+";")
+		c.partialLines = append(c.partialLines,
+			parser.AsStringWithFlags(parsedStmts[i], parser.FmtSimpleWithPasswords)+";")
 	}
 
 	nextState := execState

--- a/pkg/sql/parser/create.go
+++ b/pkg/sql/parser/create.go
@@ -671,7 +671,12 @@ func (node *CreateUser) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString("CREATE USER ")
 	FormatNode(buf, f, node.Name)
 	if node.HasPassword() {
-		buf.WriteString(" WITH PASSWORD *****")
+		buf.WriteString(" WITH PASSWORD ")
+		if f.showPasswords {
+			encodeSQLString(buf, *node.Password)
+		} else {
+			buf.WriteString("*****")
+		}
 	}
 }
 

--- a/pkg/sql/parser/format.go
+++ b/pkg/sql/parser/format.go
@@ -44,6 +44,8 @@ type fmtFlags struct {
 	// :::interval) as necessary to disambiguate between possible type
 	// resolutions.
 	disambiguateDatumTypes bool
+	// If false, passwords are replaced by *****.
+	showPasswords bool
 }
 
 // FmtFlags enables conditional formatting in the pretty-printer.
@@ -52,6 +54,10 @@ type FmtFlags *fmtFlags
 // FmtSimple instructs the pretty-printer to produce
 // a straightforward representation.
 var FmtSimple FmtFlags = &fmtFlags{}
+
+// FmtSimpleWithPasswords instructs the pretty-printer to produce a
+// straightforward representation that does not suppress passwords.
+var FmtSimpleWithPasswords FmtFlags = &fmtFlags{showPasswords: true}
 
 // FmtShowTypes instructs the pretty-printer to
 // annotate expressions with their resolved types.


### PR DESCRIPTION
…action

The CLI parses and serializes the CREATE USER statement before sending
it to the server, which previously caused the password string to be
redacted by stars.

This commit is part of a push to ensure that Serialize is a right
inverse for Parse.