### PR TITLE
cherrypick: sql: fix panic on creation of views with arrays

### DIFF
--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -1173,7 +1173,10 @@ func (n *createViewNode) makeViewTableDesc(
 	}
 	desc.Name = viewName.Table()
 	for i, colRes := range resultColumns {
-		colType, _ := parser.DatumTypeToColumnType(colRes.Typ)
+		colType, err := parser.DatumTypeToColumnType(colRes.Typ)
+		if err != nil {
+			return desc, err
+		}
 		columnTableDef := parser.ColumnTableDef{Name: parser.Name(colRes.Name), Type: colType}
 		if len(p.ColumnNames) > i {
 			columnTableDef.Name = p.ColumnNames[i]

--- a/pkg/sql/testdata/logic_test/views
+++ b/pkg/sql/testdata/logic_test/views
@@ -356,3 +356,6 @@ CREATE TABLE t2 AS SELECT d, t FROM t AS OF SYSTEM TIME '2017-02-13 21:30:00'
 
 statement ok
 DROP TABLE t CASCADE
+
+statement error value type int\[\] cannot be used for table columns
+CREATE VIEW fail AS SELECT ARRAY[2]


### PR DESCRIPTION
Previously, the view creation code couldn't cleanly handle unsupported
column types.