### PR TITLE
cherrypick: ui: include favicons

### DIFF
--- a/pkg/ui/Makefile
+++ b/pkg/ui/Makefile
@@ -48,7 +48,7 @@ test-debug: $(YARN_INSTALLED_TARGET) | protos
 $(GOBINDATA_TARGET): $(YARN_INSTALLED_TARGET) $(shell git ls-files | grep -vF $(GOBINDATA_TARGET)) | protos
 	rm -rf dist
 	webpack -p
-	go-bindata -nometadata -pkg ui -o $@ -prefix dist dist
+	go-bindata -nometadata -pkg ui -o $@ -prefix dist dist/...
 	# Add comment recognized by reviewable.
 	echo '// GENERATED FILE DO NOT EDIT' >> $@
 	gofmt -s -w $@

--- a/pkg/ui/webpack.config.js
+++ b/pkg/ui/webpack.config.js
@@ -60,8 +60,9 @@ module.exports = {
   plugins: [
     new FaviconsWebpackPlugin({
       logo: './logo.png',
-      title: title,
+      persistentCache: false,
       inject: true,
+      title: title,
       icons: {
         // Must explicitly override defaults. Sigh.
         android: false,


### PR DESCRIPTION
Our favicons are generated into a subdirectory in pkg/ui/dist, which
our go-bindata invocation was not previously including, resulting in
missing favicons for our users! Fixed by adding the elipsis postfix as
described in the go-bindata readme.

Fixes #15891.