### PR TITLE
1.0.1 cherrypick: cli: don't prompt for password twice when using it.

### DIFF
--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -55,8 +55,6 @@ start_test "Check a password is requested by the client."
 send "$argv sql --certs-dir=$certs_dir --user=carl\r"
 eexpect "Enter password:"
 send "woof\r"
-eexpect "Confirm password:"
-send "woof\r"
 eexpect "carl@"
 end_test
 

--- a/pkg/security/password.go
+++ b/pkg/security/password.go
@@ -47,9 +47,24 @@ func HashPassword(password string) ([]byte, error) {
 	return bcrypt.GenerateFromPassword(h.Sum([]byte(password)), bcryptCost)
 }
 
-// PromptForPassword prompts for a password twice, returning the read string if
-// they match, or an error.
+// PromptForPassword prompts for a password.
+// This is meant to be used when using a password.
 func PromptForPassword() (string, error) {
+	fmt.Print("Enter password: ")
+	password, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+	if err != nil {
+		return "", err
+	}
+	// Make sure stdout moves on to the next line.
+	fmt.Print("\n")
+
+	return string(password), nil
+}
+
+// PromptForPasswordTwice prompts for a password twice, returning the read string if
+// they match, or an error.
+// This is meant to be used when setting a password.
+func PromptForPasswordTwice() (string, error) {
 	fmt.Print("Enter password: ")
 	one, err := terminal.ReadPassword(int(os.Stdin.Fd()))
 	if err != nil {
@@ -75,7 +90,7 @@ func PromptForPassword() (string, error) {
 // PromptForPasswordAndHash prompts for a password twice and returns the bcrypt
 // hash.
 func PromptForPasswordAndHash() ([]byte, error) {
-	password, err := PromptForPassword()
+	password, err := PromptForPasswordTwice()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Cherrypick #15690 for 1.0.1

Fixes #15656

We used the same function to prompt for a password when setting it and
when using it.
This resulted in password prompts to setup a connection to ask for it
twice which is just plain silly.

Instead, split the function into two, only prompting twice when setting
a password.

We really need a test for all this stuff. The stdin behavior means that
we'll want to use the interactive tests. I'll try to add it to this PR,
this will ideally go into 1.0.