### PR TITLE
sql: set atttypmod default as -1

### DIFF
--- a/pkg/acceptance/java_test.go
+++ b/pkg/acceptance/java_test.go
@@ -136,6 +136,17 @@ public class main {
 		if (nCols != 0) {
 		    throw new Exception("unexpected: SELECT returns " + nCols + " columns, expected 0");
 		}
+
+		stmt = conn.prepareStatement("SELECT 1.0::DECIMAL");
+		rs = stmt.executeQuery();
+		rs.next();
+		// The JDBC Postgres driver's getObject has different behavior than both
+		// its getString and getBigDecimal with respect to how it handles the type modifier:
+		// https://github.com/pgjdbc/pgjdbc/blob/REL42.1.1/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java#L188
+		Object dec = rs.getObject(1);
+		if (!dec.toString().equals("1.0")) {
+			throw new Exception("unexpected: expected 1.0 to be \"1.0\", got \"" + dec.toString() + "\"");
+		}
 	}
 }
 EOF

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -1057,7 +1057,16 @@ func (c *v3Conn) sendRowDescription(
 		c.writeBuf.putInt16(0) // Column attribute ID (optional).
 		c.writeBuf.putInt32(int32(typ.oid))
 		c.writeBuf.putInt16(int16(typ.size))
-		c.writeBuf.putInt32(0) // Type modifier (none of our supported types have modifiers).
+		// The type modifier (atttypmod) is used to include various extra information
+		// about the type being sent. -1 is used for values which don't make use of
+		// atttypmod and is generally an acceptable catch-all for those that do.
+		// See https://www.postgresql.org/docs/9.6/static/catalog-pg-attribute.html
+		// for information on atttypmod. In theory we differ from Postgres by never
+		// giving the scale/precision, and by not including the length of a VARCHAR,
+		// but it's not clear if any drivers/ORMs depend on this.
+		//
+		// TODO(justin): It would be good to include this information when possible.
+		c.writeBuf.putInt32(-1)
 		if formatCodes == nil {
 			c.writeBuf.putInt16(int16(formatText))
 		} else {


### PR DESCRIPTION
Fixes #15748.

Previously, we set the type modifier (`atttypmod`) of every message to
0. In most cases, this was fine, since most types don't use atttypmod
at all.

In the case of `DECIMAL`, atttypmod is used to specify the scale and
precision of the number, with a value of -1 signifying not specifying a
scale or precision, so for some Postgres drivers (notably jdbc), our use
of 0 was getting interpreted as a large scale (see
https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java#L188).
From what I can tell, always specifying -1 is fine, and is in line with
how we expected 0 to work before (as a default, generic catch-all).

Types which don't use atttypmod also generally use -1 as the default
value (source:
https://www.postgresql.org/docs/9.6/static/catalog-pg-attribute.html).

I'm not aware of any other issues caused by our lack of implementation
of atttypmod, but I'm going to keep investigating. Two obvious cases
where Postgres sets it and we don't are the length of VARCHAR types and
the scale/precision of NUMERICs.

I wrote a program to compare the results of querying Postgres and
Cockroach using some tricks @mjibson showed me, I made a gist comparing
the atttypmod values for a handful of different values before and after
this patch:

https://gist.github.com/justinj/9f494863d5f75b376045cecc936f2b1c

I wasn't sure of an appropriate place to test this, but since it seems
it wasn't tested in the first place I think this is fine for now.