### PR TITLE
sql: allow schema changes on tables in state: TableDescriptor_ADD

### DIFF
--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -144,7 +144,7 @@ func (p *planner) CreateIndex(ctx context.Context, n *parser.CreateIndex) (planN
 		return nil, err
 	}
 
-	tableDesc, err := mustGetTableDesc(ctx, p.txn, p.getVirtualTabler(), tn)
+	tableDesc, err := mustGetTableDesc(ctx, p.txn, p.getVirtualTabler(), tn, true /*allowAdding*/)
 	if err != nil {
 		return nil, err
 	}
@@ -1053,7 +1053,7 @@ func addInterleave(
 		return err
 	}
 
-	parentTable, err := mustGetTableDesc(ctx, txn, vt, tn)
+	parentTable, err := mustGetTableDesc(ctx, txn, vt, tn, true /*allowAdding*/)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -268,7 +268,8 @@ func getDescriptorsFromTargetList(
 			return nil, err
 		}
 		for i := range tables {
-			descriptor, err := mustGetTableOrViewDesc(ctx, txn, vt, &tables[i])
+			descriptor, err := mustGetTableOrViewDesc(
+				ctx, txn, vt, &tables[i], true /*allowAdding*/)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -243,7 +243,7 @@ func (p *planner) DropIndex(ctx context.Context, n *parser.DropIndex) (planNode,
 			return nil, err
 		}
 
-		tableDesc, err := mustGetTableDesc(ctx, p.txn, p.getVirtualTabler(), tn)
+		tableDesc, err := mustGetTableDesc(ctx, p.txn, p.getVirtualTabler(), tn, true /*allowAdding*/)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/rename.go
+++ b/pkg/sql/rename.go
@@ -258,7 +258,7 @@ func (p *planner) RenameIndex(ctx context.Context, n *parser.RenameIndex) (planN
 		return nil, err
 	}
 
-	tableDesc, err := mustGetTableDesc(ctx, p.txn, p.getVirtualTabler(), tn)
+	tableDesc, err := mustGetTableDesc(ctx, p.txn, p.getVirtualTabler(), tn, true /*allowAdding*/)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -364,7 +364,7 @@ func (p *planner) ShowCreateTable(
 		return nil, err
 	}
 
-	desc, err := mustGetTableDesc(ctx, p.txn, p.getVirtualTabler(), tn)
+	desc, err := mustGetTableDesc(ctx, p.txn, p.getVirtualTabler(), tn, true /*allowAdding*/)
 	if err != nil {
 		return nil, err
 	}
@@ -819,7 +819,7 @@ func (p *planner) ShowConstraints(
 		return nil, err
 	}
 
-	desc, err := mustGetTableDesc(ctx, p.txn, p.getVirtualTabler(), tn)
+	desc, err := mustGetTableDesc(ctx, p.txn, p.getVirtualTabler(), tn, true /*allowAdding*/)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -68,7 +68,8 @@ func (p *planner) ShowFingerprints(
 		txn.SetFixedTimestamp(ts)
 
 		var err error
-		tableDesc, err = mustGetTableDesc(ctx, txn, p.getVirtualTabler(), tn)
+		tableDesc, err = mustGetTableDesc(
+			ctx, txn, p.getVirtualTabler(), tn, false /*allowAdding*/)
 		return err
 	}); err != nil {
 		return nil, err

--- a/pkg/sql/testdata/logic_test/fk
+++ b/pkg/sql/testdata/logic_test/fk
@@ -675,7 +675,46 @@ statement ok
 BEGIN TRANSACTION
 
 statement ok
-CREATE TABLE refers (a INT REFERENCES referee);
+CREATE TABLE refers (
+  a INT REFERENCES referee,
+  b INT,
+  INDEX b_idx (b)
+)
+
+# Add some schema changes within the same transaction to verify that a
+# table that isn't yet public can be modified.
+statement ok
+CREATE INDEX foo ON refers (a)
+
+statement ok
+ALTER INDEX refers@b_idx RENAME TO another_idx
+
+query TT
+SHOW CREATE TABLE refers
+----
+refers  CREATE TABLE refers (
+a INT NULL,
+b INT NULL,
+INDEX another_idx (b ASC),
+CONSTRAINT fk_a_ref_referee FOREIGN KEY (a) REFERENCES referee (id),
+FAMILY "primary" (a, b, rowid)
+)
+
+statement ok
+DROP INDEX refers@another_idx
+
+statement ok
+COMMIT
+
+# CREATE AND DROP a table with a fk in the same transaction.
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+CREATE TABLE refers1 (a INT REFERENCES referee);
+
+statement ok
+DROP TABLE refers1
 
 statement ok
 COMMIT


### PR DESCRIPTION
A new table descriptor is placed in the non-public TableDescriptor_ADD state
when it refers to another table through an FK or interleaved reference,
and can only be made public once the other tables back reference is
visible across the cluster.

This change allows schema change operations on such non-public tables,
while preserving the non-public behavior for table leases.

fixes #13505