### PR TITLE
ui: remove @types/node when running yarn from Make, too

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -154,6 +154,9 @@ YARN_INSTALLED_TARGET := $(UI_ROOT)/yarn.installed
 
 $(YARN_INSTALLED_TARGET): $(BOOTSTRAP_TARGET) $(UI_ROOT)/package.json $(UI_ROOT)/yarn.lock
 	cd $(UI_ROOT) && yarn install
+	@# We remove this broken dependency again in pkg/ui/webpack.config.js.
+	@# See the comment there for details.
+	rm -rf $(UI_ROOT)/node_modules/@types/node
 	touch $@
 
 # We store the bootstrap marker file in the bin directory so that remapping bin,

--- a/pkg/ui/webpack.config.js
+++ b/pkg/ui/webpack.config.js
@@ -7,10 +7,11 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const title = 'Cockroach Console';
 
-// Remove a broken dependency that yarn insists upon installing before every
-// Webpack compile. We used to do this in the Makefile, but it was common while
-// developing the UI to run e.g. `yarn add` manually, which would reinstall the
-// broken dependency, causing Webpack to fail with cryptic errors.
+// Remove a broken dependency that Yarn insists upon installing before every
+// Webpack compile. We also do this when installing dependencies via Make, but
+// it's common to run e.g. `yarn add` manually without re-running Make, which
+// will reinstall the broken dependency. The error this dependency causes is
+// horribly cryptic, so it's important to remove it aggressively.
 //
 // See: https://github.com/yarnpkg/yarn/issues/2987
 class RemoveBrokenDependenciesPlugin {


### PR DESCRIPTION
c42fa42 moved the removal of this broken dependency from Make to
Webpack, but really we need to remove it in both pipelines. Generating
protobufs will go through only the Makefile pipeline, while running
./proxy.js and `yarn` manually will go through only the Webpack
pipeline.