### PR TITLE
storage: Avoid holding raftMu during evaluation

### DIFF
--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -145,7 +145,7 @@ func TestGCQueueShouldQueue(t *testing.T) {
 			// leading to inconsistent state.
 			tc.repl.mu.Lock()
 			defer tc.repl.mu.Unlock()
-			if err := tc.repl.stateLoader.setMVCCStats(context.Background(), tc.repl.store.Engine(), &ms); err != nil {
+			if err := tc.repl.mu.stateLoader.setMVCCStats(context.Background(), tc.repl.store.Engine(), &ms); err != nil {
 				t.Fatal(err)
 			}
 			tc.repl.mu.state.Stats = ms

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -561,7 +561,7 @@ func (r *Replica) handleReplicatedEvalResult(
 			r.mu.state.Stats.ContainsEstimates = false
 			stats := r.mu.state.Stats
 			r.mu.Unlock()
-			if err := r.stateLoader.setMVCCStats(ctx, r.store.Engine(), &stats); err != nil {
+			if err := r.raftMu.stateLoader.setMVCCStats(ctx, r.store.Engine(), &stats); err != nil {
 				log.Fatal(ctx, errors.Wrap(err, "unable to write MVCC stats"))
 			}
 		}

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -51,10 +51,10 @@ var _ raft.Storage = (*Replica)(nil)
 // to Replica.store.Engine().
 
 // InitialState implements the raft.Storage interface.
-// InitialState requires that the replica lock be held.
+// InitialState requires that r.mu is held.
 func (r *Replica) InitialState() (raftpb.HardState, raftpb.ConfState, error) {
 	ctx := r.AnnotateCtx(context.TODO())
-	hs, err := r.stateLoader.loadHardState(ctx, r.store.Engine())
+	hs, err := r.mu.stateLoader.loadHardState(ctx, r.store.Engine())
 	// For uninitialized ranges, membership is unknown at this point.
 	if raft.IsEmptyHardState(hs) || err != nil {
 		return raftpb.HardState{}, raftpb.ConfState{}, err
@@ -240,7 +240,7 @@ func (r *Replica) raftTruncatedStateLocked(
 	if r.mu.state.TruncatedState != nil {
 		return *r.mu.state.TruncatedState, nil
 	}
-	ts, err := r.stateLoader.loadTruncatedState(ctx, r.store.Engine())
+	ts, err := r.mu.stateLoader.loadTruncatedState(ctx, r.store.Engine())
 	if err != nil {
 		return ts, err
 	}
@@ -264,8 +264,8 @@ func (r *Replica) FirstIndex() (uint64, error) {
 // GetFirstIndex is the same function as FirstIndex but it does not
 // require that the replica lock is held.
 func (r *Replica) GetFirstIndex() (uint64, error) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.FirstIndex()
 }
 
@@ -447,7 +447,7 @@ func (r *Replica) append(
 	var value roachpb.Value
 	for i := range entries {
 		ent := &entries[i]
-		key := r.stateLoader.RaftLogKey(ent.Index)
+		key := r.raftMu.stateLoader.RaftLogKey(ent.Index)
 		if err := value.SetProto(ent); err != nil {
 			return 0, 0, err
 		}
@@ -466,14 +466,14 @@ func (r *Replica) append(
 	// Delete any previously appended log entries which never committed.
 	lastIndex := entries[len(entries)-1].Index
 	for i := lastIndex + 1; i <= prevLastIndex; i++ {
-		err := engine.MVCCDelete(ctx, batch, &diff, r.stateLoader.RaftLogKey(i),
+		err := engine.MVCCDelete(ctx, batch, &diff, r.raftMu.stateLoader.RaftLogKey(i),
 			hlc.Timestamp{}, nil /* txn */)
 		if err != nil {
 			return 0, 0, err
 		}
 	}
 
-	if err := r.stateLoader.setLastIndex(ctx, batch, lastIndex); err != nil {
+	if err := r.raftMu.stateLoader.setLastIndex(ctx, batch, lastIndex); err != nil {
 		return 0, 0, err
 	}
 
@@ -648,7 +648,7 @@ func (r *Replica) applySnapshot(
 	// say it isn't going to accept a snapshot which is identical to the current
 	// state?
 	if !raft.IsEmptyHardState(hs) {
-		if err := r.stateLoader.setHardState(ctx, distinctBatch, hs); err != nil {
+		if err := r.raftMu.stateLoader.setHardState(ctx, distinctBatch, hs); err != nil {
 			return errors.Wrapf(err, "unable to persist HardState %+v", &hs)
 		}
 	}
@@ -684,7 +684,7 @@ func (r *Replica) applySnapshot(
 	r.store.metrics.subtractMVCCStats(r.mu.state.Stats)
 	r.store.metrics.addMVCCStats(s.Stats)
 	r.mu.state = s
-	r.assertStateRLocked(ctx, r.store.Engine())
+	r.assertStateLocked(ctx, r.store.Engine())
 	r.mu.Unlock()
 
 	// As the last deferred action after committing the batch, update other

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -5336,7 +5336,7 @@ func TestReplicaCorruption(t *testing.T) {
 	}
 
 	// Verify destroyed error was persisted.
-	pErr, err = r.stateLoader.loadReplicaDestroyedError(context.Background(), r.store.Engine())
+	pErr, err = r.mu.stateLoader.loadReplicaDestroyedError(context.Background(), r.store.Engine())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3036,7 +3036,7 @@ func (s *Store) processRaftRequest(
 		needTombstone := r.mu.state.Desc.NextReplicaID != 0
 		r.mu.Unlock()
 
-		appliedIndex, _, err := r.stateLoader.loadAppliedIndex(ctx, r.store.Engine())
+		appliedIndex, _, err := r.raftMu.stateLoader.loadAppliedIndex(ctx, r.store.Engine())
 		if err != nil {
 			return roachpb.NewError(err)
 		}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -636,10 +636,9 @@ func TestProcessRangeDescriptorUpdate(t *testing.T) {
 	}
 
 	r := &Replica{
-		RangeID:     desc.RangeID,
-		stateLoader: makeReplicaStateLoader(desc.RangeID),
-		store:       store,
-		abortCache:  NewAbortCache(desc.RangeID),
+		RangeID:    desc.RangeID,
+		store:      store,
+		abortCache: NewAbortCache(desc.RangeID),
 	}
 	if err := r.init(desc, store.Clock(), 0); err != nil {
 		t.Fatal(err)
@@ -2036,8 +2035,8 @@ func TestStoreGCThreshold(t *testing.T) {
 		}
 		repl.mu.Lock()
 		gcThreshold := repl.mu.state.GCThreshold
+		pgcThreshold, err := repl.mu.stateLoader.loadGCThreshold(context.Background(), store.Engine())
 		repl.mu.Unlock()
-		pgcThreshold, err := repl.stateLoader.loadGCThreshold(context.Background(), store.Engine())
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Now that the command-queue issues in #10084 have been fixed, the only
reason to hold raftMu during evaluation was because it controlled
access to the replicaStateLoader (and lock-ordering requirements
forced us to give the lock a broad scope). By forking the
replicaStateLoader into several copies (one protected by Replica.mu
and one by Replica.raftMu, plus a few temporary loaders created off
the critical path), we can reduce the scope of this coarse-grained
lock (which in turn facilitates #15802).