### PR TITLE
storage: separately throttle empty snapshots

### DIFF
--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -207,7 +207,7 @@ func (s *Store) ManualReplicaGC(repl *Replica) error {
 }
 
 func (s *Store) ReservationCount() int {
-	return len(s.snapshotApplySem)
+	return len(s.emptySnapshotApplySem) + len(s.nonEmptySnapshotApplySem)
 }
 
 func NewTestStorePool(cfg StoreConfig) *StorePool {


### PR DESCRIPTION
~WARNING: This is proof of concept, not ready to merge.~

This is one possible fix for #15861. Essentially, when presplitting ranges for a `RESTORE` in an empty four-node cluster, the replicate queue is able to keep pace with the splits, rebalancing replicas to the unlucky fourth node as necessary, since ranges are empty and the snapshots complete in ~1ms. In a cluster with existing data, on the other hand, one of the node's replicate queues will select a replica with existing data to send to the unlucky fourth node, blocking that node from receiving additional snapshots for nearly 20s, since the snapshots are throttled at 2MB/s. Since the entire pre-splitting process takes on the order of minutes, a few large snapshots can completely leave the unlucky fourth node in the dust. (See the discussion on #15861 for a more detailed explanation.)

This commit applies a very simple fix: it separates empty snapshots from non-empty snapshots. Empty snapshots are thus no longer blocked on large snapshots, and the replicate queues can keep even clusters with existing data balanced during a `RESTORE` presplit. Making this work required also prioritizing these empty ranges in the replicate queue. Have not thought through the implications of all this, especially the latter prioritization. Will need to discuss with someone on Core tomorrow.

Here's a screenshot of the with-existing-data experiment from #15861 with this patch applied:

![screenshot 2017-05-16 01 22 26](https://cloud.githubusercontent.com/assets/882976/26091158/79143f16-39d7-11e7-9606-4601209bcf91.png)

Leaseholders per store is still a disaster, but replicas per store is pretty darn even.

/cc @a-robinson @danhhz