### PR TITLE
parser: standardize handling of parentheses in table expressions

### DIFF
--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -679,6 +679,9 @@ func TestParse(t *testing.T) {
 		{`BACKUP foo TO 'bar' WITH OPTIONS ('key1', 'key2'='value')`},
 		{`RESTORE foo FROM 'bar' WITH OPTIONS ('key1', 'key2'='value')`},
 		{`SET ROW (1, true, NULL)`},
+
+		// Regression for #15926
+		{`SELECT * FROM ((t1 NATURAL JOIN t2 WITH ORDINALITY AS o1)) WITH ORDINALITY AS o2`},
 	}
 	for _, d := range testData {
 		stmts, err := Parse(d.sql)

--- a/pkg/sql/parser/select.go
+++ b/pkg/sql/parser/select.go
@@ -270,14 +270,7 @@ type AliasedTableExpr struct {
 
 // Format implements the NodeFormatter interface.
 func (node *AliasedTableExpr) Format(buf *bytes.Buffer, f FmtFlags) {
-	_, exprIsJoin := node.Expr.(*JoinTableExpr)
-	if exprIsJoin {
-		buf.WriteByte('(')
-	}
 	FormatNode(buf, f, node.Expr)
-	if exprIsJoin {
-		buf.WriteByte(')')
-	}
 	if node.Hints != nil {
 		FormatNode(buf, f, node.Hints)
 	}

--- a/pkg/sql/parser/sql.go
+++ b/pkg/sql/parser/sql.go
@@ -8394,7 +8394,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
 		//line sql.y:3072
 		{
-			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[2].union.tblExpr(), Ordinality: sqlDollar[4].union.bool(), As: sqlDollar[5].union.aliasClause()}
+			sqlVAL.union.val = &AliasedTableExpr{Expr: &ParenTableExpr{sqlDollar[2].union.tblExpr()}, Ordinality: sqlDollar[4].union.bool(), As: sqlDollar[5].union.aliasClause()}
 		}
 	case 481:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3089,7 +3089,7 @@ table_ref:
   }
 | '(' joined_table ')' opt_ordinality alias_clause
   {
-    $$.val = &AliasedTableExpr{Expr: $2.tblExpr(), Ordinality: $4.bool(), As: $5.aliasClause() }
+    $$.val = &AliasedTableExpr{Expr: &ParenTableExpr{$2.tblExpr()}, Ordinality: $4.bool(), As: $5.aliasClause()}
   }
 
 // The following syntax is a CockroachDB extension: SELECT ... FROM [ EXPLAIN .... ] WHERE ...


### PR DESCRIPTION
Abstract syntax trees for table expression use `ParenTableExpr` to
represent parentheses except for join expressions. Remove this special
case and the corresponding special case in the formatting logic for
`AliasedTableExpr`, which sometimes cause a failure to round trip.

Fixes #15926