### PR TITLE
sql: propagate view names to dataSourceInfo

### DIFF
--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -328,7 +328,7 @@ func (p *planner) getDataSource(
 		return p.getGeneratorPlan(ctx, t)
 
 	case *parser.Subquery:
-		return p.getSubqueryPlan(ctx, t.Select, nil)
+		return p.getSubqueryPlan(ctx, anonymousTable, t.Select, nil)
 
 	case *parser.JoinTableExpr:
 		// Joins: two sources.
@@ -571,7 +571,7 @@ func (p *planner) getViewPlan(
 	// TODO(a-robinson): Support ORDER BY and LIMIT in views. Is it as simple as
 	// just passing the entire select here or will inserting an ORDER BY in the
 	// middle of a query plan break things?
-	plan, err := p.getSubqueryPlan(ctx, sel.Select, sqlbase.ResultColumnsFromColDescs(desc.Columns))
+	plan, err := p.getSubqueryPlan(ctx, *tn, sel.Select, sqlbase.ResultColumnsFromColDescs(desc.Columns))
 	if err != nil {
 		return plan, err
 	}
@@ -582,7 +582,7 @@ func (p *planner) getViewPlan(
 // getSubqueryPlan builds a planDataSource for a select statement, including
 // for simple VALUES statements.
 func (p *planner) getSubqueryPlan(
-	ctx context.Context, sel parser.SelectStatement, cols sqlbase.ResultColumns,
+	ctx context.Context, tn parser.TableName, sel parser.SelectStatement, cols sqlbase.ResultColumns,
 ) (planDataSource, error) {
 	plan, err := p.newPlan(ctx, sel, nil)
 	if err != nil {
@@ -592,7 +592,7 @@ func (p *planner) getSubqueryPlan(
 		cols = plan.Columns()
 	}
 	return planDataSource{
-		info: newSourceInfoForSingleTable(anonymousTable, cols),
+		info: newSourceInfoForSingleTable(tn, cols),
 		plan: plan,
 	}, nil
 }

--- a/pkg/sql/testdata/logic_test/views
+++ b/pkg/sql/testdata/logic_test/views
@@ -370,3 +370,38 @@ query TI
 SELECT *, a[1] FROM arr
 ----
 {3}  3
+
+# Regression for #15951
+
+statement ok
+CREATE TABLE t15951 (a int, b int)
+
+statement ok
+CREATE VIEW Caps15951 AS SELECT a, b FROM t15951
+
+statement ok
+INSERT INTO t15951 VALUES (1, 1), (1, 2), (1, 3), (2, 2), (2, 3), (3, 3)
+
+query R
+SELECT sum (Caps15951. a) FROM Caps15951 GROUP BY b ORDER BY b
+----
+1
+3
+6
+
+query R
+SELECT sum ("Caps15951". a) FROM "Caps15951" GROUP BY b ORDER BY b
+----
+1
+3
+6
+
+statement ok
+CREATE VIEW "QuotedCaps15951" AS SELECT a, b FROM t15951
+
+query R
+SELECT sum ("QuotedCaps15951". a) FROM "QuotedCaps15951" GROUP BY b ORDER BY b
+----
+1
+3
+6


### PR DESCRIPTION
It is currently impossible to fully qualify a column that comes from a
view, e.g.,

    root@:26257/test> CREATE TABLE test (a int, b int);
    CREATE TABLE
    root@:26257/test> CREATE VIEW Caps AS SELECT a, b FROM test;
    CREATE VIEW
    root@:26257/test> SELECT sum(Caps.a) FROM Caps GROUP BY b;
    pq: source name "caps" not found in FROM clause

This is because the view gets replaced by an anonymous subquery. Give
the dataSourceInfo corresponding to that subquery its proper name.

Fixes #15951.
