### PR TITLE
cherrypick: sql: don't try to drop views twice

### DIFF
--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -842,6 +842,10 @@ func (p *planner) dropTableImpl(
 		if err != nil {
 			return droppedViews, err
 		}
+		// This view is already getting dropped. Don't do it twice.
+		if viewDesc.Dropped() {
+			continue
+		}
 		cascadedViews, err := p.dropViewImpl(ctx, viewDesc, parser.DropCascade)
 		if err != nil {
 			return droppedViews, err

--- a/pkg/sql/testdata/logic_test/drop_view
+++ b/pkg/sql/testdata/logic_test/drop_view
@@ -169,3 +169,26 @@ DROP VIEW x
 
 statement ok
 DROP VIEW y, x
+
+# Ensure that dropping a database works even when views get referred to more=
+# than once. See #15953 for more details.
+statement ok
+CREATE DATABASE a
+
+statement ok
+SET DATABASE=a
+
+statement ok
+CREATE TABLE a (a int);
+
+statement ok
+CREATE TABLE b (b int);
+
+statement ok
+CREATE VIEW v AS SELECT a.a, b.b FROM a CROSS JOIN b
+
+statement ok
+CREATE VIEW u AS SELECT a FROM a UNION SELECT a FROM a
+
+statement ok
+DROP DATABASE a


### PR DESCRIPTION
Previously, if a single view depended on the same table twice via a
union, or if a single view depended on multiple tables, dropping the
database that contained them would fail because the drop routine would
try to drop the view more than once.