### PR TITLE
vendor: bump gRPC

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: fc0b1a51280176d84e80717f73ef0128e61e0f35608a90364ddc81dbb87e52c9
-updated: 2017-05-17T10:06:48.687769178-04:00
+hash: 1761d84fe439a296fab45493e0a64156f42349b8c4e0e9ba7c42d1854cac2e77
+updated: 2017-05-17T10:42:39.575779187-04:00
 imports:
 - name: cloud.google.com/go
   version: ed63fb27efcf32e25fe7837e4662457d3da4c4f2
@@ -203,6 +203,7 @@ imports:
   - protoc-gen-go/descriptor
   - protoc-gen-go/generator
   - protoc-gen-go/plugin
+  - ptypes/any
   - ptypes/timestamp
 - name: github.com/golang/snappy
   version: 553a641470496b2327abcac10b36396bd98e45c9
@@ -507,13 +508,14 @@ imports:
   subpackages:
   - googleapis/api/annotations
   - googleapis/iam/v1
+  - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: ded79a3531af2dd320eed5b2fd138f23fb2e3f59
-  repo: https://github.com/andreimatei/grpc-go
+  version: 3419b42955675df23457629c75f58eb8dcd56954
   subpackages:
   - codes
   - credentials
   - credentials/oauth
+  - grpclb/grpc_lb_v1
   - grpclog
   - internal
   - keepalive
@@ -521,6 +523,7 @@ imports:
   - naming
   - peer
   - stats
+  - status
   - tap
   - transport
 - name: gopkg.in/yaml.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,16 +7,6 @@ import:
 # https://github.com/docker/docker/issues/29362
 - package: github.com/docker/docker
   version: 7248742ae7127347a52ab9d215451c213b7b59da
-# We use a fork of grpc to adjust the hardcoded RPC/conn window
-# sizes. The defaults are too low for high latency links and do not
-# adjust dynamically. Remove when upstream addresses the issue, either
-# making the window sizes configurable or dynamically adjust them.
-#
-# https://github.com/grpc/grpc-go/issues/760
-# https://github.com/grpc/grpc-go/issues/1043
-- package: google.golang.org/grpc
-  version: ded79a3531af2dd320eed5b2fd138f23fb2e3f59
-  repo: https://github.com/andreimatei/grpc-go
 # https://github.com/lightstep/lightstep-tracer-go/pull/73 removed support for
 # basictracer.Delegator. Revisit when
 # https://github.com/cockroachdb/cockroach/issues/9806 is fixed.
@@ -73,3 +63,5 @@ import:
   version: a6577fac2d73be281a500b310739095313165611
 - package: golang.org/x/sys
   version: 1e4778a9a153163315e71a39674fbe87fe8f30a5
+- package: google.golang.org/grpc
+  version: 3419b42955675df23457629c75f58eb8dcd56954

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -58,6 +58,12 @@ const (
 	maximumPingDurationMult = 2
 )
 
+const (
+	defaultWindowSize     = 65535
+	initialWindowSize     = defaultWindowSize * 32 // for an RPC
+	initialConnWindowSize = initialWindowSize * 16 // for a connection
+)
+
 // SourceAddr provides a way to specify a source/local address for outgoing
 // connections. It should only ever be set by testing code, and is not thread
 // safe (so it must be initialized before the server starts).
@@ -86,6 +92,10 @@ func NewServer(ctx *Context) *grpc.Server {
 		// Our maximum kv size is unlimited, so we need this to be very large.
 		// TODO(peter,tamird): need tests before lowering
 		grpc.MaxMsgSize(math.MaxInt32),
+		// Adjust the stream and connection window sizes. The gRPC defaults are too
+		// low for high latency connections.
+		grpc.InitialWindowSize(initialWindowSize),
+		grpc.InitialConnWindowSize(initialConnWindowSize),
 		// The default number of concurrent streams/requests on a client connection
 		// is 100, while the server is unlimited. The client setting can only be
 		// controlled by adjusting the server value. Set a very large value for the


### PR DESCRIPTION
Move off our custom fork of gRPC and use the InitialWindowSize and
InitialConnWindowSize configurables instead.