### PR TITLE
sql: fix panic in generators with null arguments

### DIFF
--- a/pkg/sql/generator.go
+++ b/pkg/sql/generator.go
@@ -95,8 +95,13 @@ func (n *valueGenerator) Start(context.Context) error {
 	if err != nil {
 		return err
 	}
+	var tb *parser.DTable
+	if expr == parser.DNull {
+		tb = parser.EmptyDTable()
+	} else {
+		tb = expr.(*parser.DTable)
+	}
 
-	tb := expr.(*parser.DTable)
 	gen := tb.ValueGenerator
 	if err := gen.Start(); err != nil {
 		return err

--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -2077,6 +2077,11 @@ type DTable struct {
 	ValueGenerator
 }
 
+// EmptyDTable returns a new, empty DTable.
+func EmptyDTable() *DTable {
+	return &DTable{&arrayValueGenerator{array: NewDArray(TypeAny)}}
+}
+
 // AmbiguousFormat implements the Datum interface.
 func (*DTable) AmbiguousFormat() bool { return false }
 

--- a/pkg/sql/testdata/logic_test/generators
+++ b/pkg/sql/testdata/logic_test/generators
@@ -170,3 +170,16 @@ SELECT generate_series(1, 3) + generate_series(1, 3)
 
 query error pq: column name "generate_series" not found
 SELECT generate_series(1, 3) FROM t WHERE generate_series > 3
+
+# Regressions for #15900: ensure that null parameters to generate_series don't
+# cause issues.
+
+query T
+SELECT * from generate_series(1, (select * from generate_series(1, 0)))
+----
+
+# The following query is designed to produce a null array argument to unnest
+# in a way that the type system can't detect before evaluation.
+query T
+SELECT unnest((select current_schemas((select isnan((select round(3.4, (select generate_series(1, 0)))))))));
+----


### PR DESCRIPTION
Previously, null arguments to `generate_series` or `unnest` could produce
panics.

Fixes #15900.