### PR TITLE
storage: Hold raftMu when calling handleEvalResult

### DIFF
--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -552,7 +552,11 @@ func TestGCQueueTransactionTable(t *testing.T) {
 
 	batch := tc.engine.NewSnapshot()
 	defer batch.Close()
-	tc.repl.assertState(context.TODO(), batch) // check that in-mem and on-disk state were updated
+	tc.repl.raftMu.Lock()
+	tc.repl.mu.Lock()
+	tc.repl.assertStateLocked(context.TODO(), batch) // check that in-mem and on-disk state were updated
+	tc.repl.mu.Unlock()
+	tc.repl.raftMu.Unlock()
 
 	tc.repl.mu.Lock()
 	txnSpanThreshold := tc.repl.mu.state.TxnSpanGCThreshold

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -788,7 +788,7 @@ func (r *Replica) handleLocalEvalResult(
 	return shouldAssert
 }
 
-func (r *Replica) handleEvalResult(
+func (r *Replica) handleEvalResultRaftMuLocked(
 	ctx context.Context, lResult *LocalEvalResult, rResult storagebase.ReplicatedEvalResult,
 ) {
 	shouldAssert := r.handleReplicatedEvalResult(ctx, rResult)
@@ -799,6 +799,8 @@ func (r *Replica) handleEvalResult(
 	if shouldAssert {
 		// Assert that the on-disk state doesn't diverge from the in-memory
 		// state as a result of the side effects.
-		r.assertState(ctx, r.store.Engine())
+		r.mu.Lock()
+		r.assertStateLocked(ctx, r.store.Engine())
+		r.mu.Unlock()
 	}
 }

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -304,7 +304,11 @@ func (tc *testContext) addBogusReplicaToRangeDesc(
 	}
 
 	tc.repl.setDescWithoutProcessUpdate(&newDesc)
-	tc.repl.assertState(ctx, tc.engine)
+	tc.repl.raftMu.Lock()
+	tc.repl.mu.Lock()
+	tc.repl.assertStateLocked(ctx, tc.engine)
+	tc.repl.mu.Unlock()
+	tc.repl.raftMu.Unlock()
 	return secondReplica, nil
 }
 


### PR DESCRIPTION
The call to assertStateLocked may fail if called without the raft lock
as the on-disk state may be changed concurrently. This fixes a
regression introduced in #15935.

Fixes #15975
Fixes #15979