### PR TITLE
storage: Remove obsolete comment

### DIFF
--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -186,9 +186,6 @@ func (rq *replicateQueue) shouldQueue(
 		}
 	}
 
-	// Check for a rebalancing opportunity. Note that leaseStoreID will be 0 if
-	// the range doesn't currently have a lease which will allow the current
-	// replica to be considered a rebalancing source.
 	target, err := rq.allocator.RebalanceTarget(
 		ctx,
 		zone.Constraints,


### PR DESCRIPTION
The variable/logic it was referring to got removed in
f787e1eba566cebb8c87c80861e42ddebacc6ad4