### PR TITLE
cherrypick: storage: overhaul GCQueue.shouldQueue

### DIFF
--- a/pkg/storage/engine/enginepb/mvcc.go
+++ b/pkg/storage/engine/enginepb/mvcc.go
@@ -67,7 +67,10 @@ func (ms *MVCCStats) AgeTo(nowNanos int64) {
 	if ms.LastUpdateNanos >= nowNanos {
 		return
 	}
-	diffSeconds := nowNanos/1E9 - ms.LastUpdateNanos/1E9 // not (...)/1E9!
+	// Seconds are counted every time each individual nanosecond timestamp
+	// crosses a whole second boundary (i.e. is zero mod 1E9). Thus it would
+	// be a mistake to use the (nonequivalent) expression (a-b)/1E9.
+	diffSeconds := nowNanos/1E9 - ms.LastUpdateNanos/1E9
 
 	ms.GCBytesAge += ms.GCBytes() * diffSeconds
 	ms.IntentAge += ms.IntentCount * diffSeconds

--- a/pkg/storage/engine/enginepb/mvcc.pb.go
+++ b/pkg/storage/engine/enginepb/mvcc.pb.go
@@ -175,11 +175,11 @@ type MVCCStats struct {
 	// See the comment on MVCCStats.
 	GCBytesAge int64 `protobuf:"fixed64,3,opt,name=gc_bytes_age,json=gcBytesAge" json:"gc_bytes_age"`
 	// live_bytes is the number of bytes stored in keys and values which can in
-	// principle be read by means of a Scan or Get, including intents but not
-	// deletion tombstones (or their intents). Note that the size of the meta kv
-	// pair (which could be explicit or implicit) is included in this.
-	// Only the meta kv pair counts for the actual length of the encoded key
-	// (regular pairs only count the timestamp suffix).
+	// principle be read by means of a Scan or Get in the far future, including
+	// intents but not deletion tombstones (or their intents). Note that the
+	// size of the meta kv pair (which could be explicit or implicit) is
+	// included in this. Only the meta kv pair counts for the actual length of
+	// the encoded key (regular pairs only count the timestamp suffix).
 	LiveBytes int64 `protobuf:"fixed64,4,opt,name=live_bytes,json=liveBytes" json:"live_bytes"`
 	// live_count is the number of meta keys tracked under live_bytes.
 	LiveCount int64 `protobuf:"fixed64,5,opt,name=live_count,json=liveCount" json:"live_count"`

--- a/pkg/storage/engine/enginepb/mvcc.proto
+++ b/pkg/storage/engine/enginepb/mvcc.proto
@@ -129,13 +129,12 @@ message MVCCStats {
   // data included in key_bytes and val_bytes, but not live_bytes).
   // See the comment on MVCCStats.
   optional sfixed64 gc_bytes_age = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "GCBytesAge"];
-
   // live_bytes is the number of bytes stored in keys and values which can in
-  // principle be read by means of a Scan or Get, including intents but not
-  // deletion tombstones (or their intents). Note that the size of the meta kv
-  // pair (which could be explicit or implicit) is included in this.
-  // Only the meta kv pair counts for the actual length of the encoded key
-  // (regular pairs only count the timestamp suffix).
+  // principle be read by means of a Scan or Get in the far future, including
+  // intents but not deletion tombstones (or their intents). Note that the
+  // size of the meta kv pair (which could be explicit or implicit) is
+  // included in this. Only the meta kv pair counts for the actual length of
+  // the encoded key (regular pairs only count the timestamp suffix).
   optional sfixed64 live_bytes = 4 [(gogoproto.nullable) = false];
   // live_count is the number of meta keys tracked under live_bytes.
   optional sfixed64 live_count = 5 [(gogoproto.nullable) = false];

--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -596,8 +596,10 @@ func (bq *baseQueue) processReplica(
 				if log.V(3) {
 					log.Infof(queueCtx, "%s; skipping", v)
 				}
+				log.Eventf(ctx, "%s; skipping", v)
 				return nil
 			default:
+				log.ErrEventf(ctx, "could not obtain lease: %s", pErr)
 				return errors.Wrapf(pErr.GoError(), "%s: could not obtain lease", repl)
 			}
 		}

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1258,10 +1258,7 @@ func containsKeyRange(desc roachpb.RangeDescriptor, start, end roachpb.Key) bool
 }
 
 // getLastReplicaGCTimestamp reads the timestamp at which the replica was
-// last checked for garbage collection.
-//
-// TODO(tschottdorf): we may want to phase this out in favor of using
-// gcThreshold.
+// last checked for removal by the replica gc queue.
 func (r *Replica) getLastReplicaGCTimestamp(ctx context.Context) (hlc.Timestamp, error) {
 	key := keys.RangeLastReplicaGCTimestampKey(r.RangeID)
 	var timestamp hlc.Timestamp
@@ -2504,7 +2501,7 @@ func (r *Replica) propose(
 
 	if proposal.command.Size() > int(maxCommandSize.Get()) {
 		// Once a command is written to the raft log, it must be loaded
-		// into memory and repliayed on all replicas. If a command is
+		// into memory and replayed on all replicas. If a command is
 		// too big, stop it here.
 		return nil, nil, errors.Errorf("command is too large: %d bytes (max: %d)",
 			proposal.command.Size(), maxCommandSize.Get())

--- a/pkg/storage/replica_state.go
+++ b/pkg/storage/replica_state.go
@@ -103,7 +103,7 @@ func (rsl replicaStateLoader) load(
 // its RangeID.
 //
 // TODO(tschottdorf): test and assert that none of the optional values are
-// missing when- ever saveState is called. Optional values should be reserved
+// missing whenever save is called. Optional values should be reserved
 // strictly for use in EvalResult. Do before merge.
 func (rsl replicaStateLoader) save(
 	ctx context.Context, eng engine.ReadWriter, state storagebase.ReplicaState,


### PR DESCRIPTION
TL;DR: use a scale-invariant `shouldQueue` for the GC Queue to avoid it running
in a tight loop without actually deleting anything. Adjust this scalable score
so that GC is delayed when a large proportion of the data in the replica is
live. Slightly perturb returned scores to avoid groups of replicas becoming
eligible for GC at the same time repeatedly.

Closes #15897.

--

When a key of size `B` is deleted at timestamp `T` or superseded by a newer
version, it henceforth is accounted for in the range's `GCBytesAge`. At time
`S`, its contribution to age will be `B*seconds(S-T)`. The aggregate
`GCBytesAge` of all deleted versions in the cluster is what the GC queue at
the time of writing bases its `shouldQueue` method on.

If a replica is queued to have its old values garbage collected, its contents
are scanned. However, the values which are deleted follow a criterion that
isn't immediately connected to `GCBytesAge`: We (basically) delete everything
that's older than the Replica's `TTLSeconds`.

Thus, it's not obvious that garbage collection has the effect of reducing the
metric that we use to consider the replica for the next GC cycle, and it seems
that we messed it up.

The previous metric used for queueing: `GCBytesAge/(1<<20 * ttl)` does not
have the right scaling. For example, consider that a value of size `1mb` is
overwritten with a newer version. After `ttl` seconds, it contributes `1mb` to
`GCBytesAge`, and so the replica has a score of `1`, i.e. (roughly) the range
becomes interesting to the GC queue. When GC runs, it will delete value that
are `ttl` old, which our value is. But a Replica is ~64mb, so picture that
you have 64mb of key-value data all at the same timestamp, and they become
superseded. Already after `ttl/64`, the metric becomes 1, but they keys won't
be GC'able for another (63*ttl)/64. Thus, GC will run "all the time" long
before it can actually have an effect.

The metric with correct scaling must thus take into account the size of the
range. What size exactly? Any data that isn't live (i.e. isn't readable by
a scan from the far future). That's `KeyBytes + ms.ValBytes - ms.LiveBytes`,
which is also known as `GCBytes` in the code. Hence, the better metric is
`GCBytesAge/(ttl*GCBytes)`.

Using this metric guarantees that after truncation, `GCBytesAge` is at most
`ttl*GCBytes` (where `GCBytes` has been updated), i.e. the new metric is at
most 1.

To visualize this, picture a rectangular frame of width `ttl` and height
`GCBytes` (i.e. the horizontal dimension is time, the vertical one bytes),
where the right boundary of the frame corresponds to age zero.
Each non-live key is a domino aligned with the right side of the frame, its
width equal to its size, and its height given by the duration (in seconds) it's
been non-live.

The combined surface of the dominos is then `GCBytesAge`, and the claim is that
if the total sum of domino heights (i.e. sizes) is `GCBytes`, and the surface
is larger than `ttl*GCBytes` by some positive `X`, then after removing the
dominos that cross the line `x=-ttl` (i.e. `ttl` to the left from the right
side of the frame), at least a surface area of `X` has been removed.

```           x=-ttl                 GCBytes=1+4
                |           3 (age)
                |          +-------+
                |          | keep  | 1 (bytes)
                |          +-------+
           +-----------------------+
           |                       |
           |        remove         | 3 (bytes)
           |                       |
           +-----------------------+
                |   7 (age)
```

This is true because

```
deletable area  = total area       - nondeletable area
                = X + ttl*GCBytes  - nondeletable area
               >= X + ttl*GCBytes  - ttl*(bytes in nondeletable area)
                = X + ttl*(GCBytes - bytes in nondeletable area)
               >= X.
```

Or, in other words, you can only hope to put `ttl*GCBytes` of area in the
"safe" rectangle. Once you've done that, everything else you put is going to be
deleted.

This means that running GC will always result in a `GCBytesAge` of `<=
ttl*GCBytes`, and that a decent trigger for GC is a multiple of `ttl*GCBytes`.

Limitations:

- The intent portion of `shouldQueue` could be another time bomb if it fires
  continuously for some reason.