### PR TITLE
cherrypick: ui: Fix js time formatting - print seconds, not fractional seconds

### DIFF
--- a/pkg/ui/src/containers/nodeLogs.tsx
+++ b/pkg/ui/src/containers/nodeLogs.tsx
@@ -41,7 +41,7 @@ class Logs extends React.Component<LogProps & RouterState, {}> {
       const columns = [
         {
           title: "Time",
-          cell: (index: number) => LongToMoment(logEntries[index].time).format("YYYY-MM-DD HH:mm:SS"),
+          cell: (index: number) => LongToMoment(logEntries[index].time).format("YYYY-MM-DD HH:mm:ss"),
         },
         {
           title: "Severity",

--- a/pkg/ui/src/containers/timescale.tsx
+++ b/pkg/ui/src/containers/timescale.tsx
@@ -29,8 +29,8 @@ class TimeRange extends React.Component<TimeRangeProps, {}> {
   render() {
     let s = this.props.start.clone().utc();
     let e = this.props.end.clone().utc();
-    let startTimeSpan = <span className="time-range__time">{s.format("HH:mm:SS")}</span>;
-    let endTimeSpan = <span className="time-range__time">{e.format("HH:mm:SS")}</span>;
+    let startTimeSpan = <span className="time-range__time">{s.format("HH:mm:ss")}</span>;
+    let endTimeSpan = <span className="time-range__time">{e.format("HH:mm:ss")}</span>;
     let startDateSpan = <span className="time-range__date">{s.format("MMM DD, YYYY")}</span>;
     let endDateSpan = <span className="time-range__date">{e.format("MMM DD, YYYY")}</span>;
 


### PR DESCRIPTION
Documented at https://momentjs.com/docs/#/parsing/string-format/

Fixes #16002