### PR TITLE
storage: extract error from assertReplicaState

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1348,7 +1348,15 @@ func (r *Replica) assertStateLocked(ctx context.Context, reader engine.Reader) {
 		log.Fatal(ctx, err)
 	}
 	if !reflect.DeepEqual(diskState, r.mu.state) {
-		log.Fatalf(ctx, "on-disk and in-memory state diverged:\n%s", pretty.Diff(diskState, r.mu.state))
+		// The roundabout way of printing here is to expose this information in sentry.io.
+		//
+		// TODO(dt): expose properly once #15892 is addressed.
+		log.Errorf(ctx, "on-disk and in-memory state diverged:\n%s", pretty.Diff(diskState, r.mu.state))
+		r.mu.state.Desc, diskState.Desc = nil, nil
+		log.Fatal(
+			ctx, log.Safe{
+				V: fmt.Sprintf("on-disk and in-memory state diverged:\n%s", pretty.Diff(diskState, r.mu.state)),
+			})
 	}
 }
 

--- a/pkg/util/log/crash_reporting_test.go
+++ b/pkg/util/log/crash_reporting_test.go
@@ -1,0 +1,35 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package log
+
+import "testing"
+
+func TestCrashReportingFormatSave(t *testing.T) {
+	r1 := "i am hidden"
+	r2 := Safe{V: "i am public"}
+	r3 := Safe{V: &r2}
+	f1, f2, f3 := format(r1), format(r2), format(r3)
+	exp1, exp2 := "string", r2.V.(string)
+	exp3 := "&{V:i am public}"
+	if f1 != exp1 {
+		t.Errorf("wanted %s, got %s", exp1, f1)
+	}
+	if f2 != exp2 {
+		t.Errorf("wanted %s, got %s", exp2, f2)
+	}
+	if f3 != exp3 {
+		t.Errorf("wanted %s, got %s", exp3, f3)
+	}
+}


### PR DESCRIPTION
The 1.0.1 ship may already have sailed, but if it has not,
then let us consider whether we want to get this in to get
more information on #16004 in the wild.