### PR TITLE
sql: bugfix in FuncExpr.CopyNode

### DIFF
--- a/pkg/sql/parser/walk.go
+++ b/pkg/sql/parser/walk.go
@@ -199,6 +199,10 @@ func (expr *ExistsExpr) Walk(v Visitor) Expr {
 // CopyNode makes a copy of this Expr without recursing in any child Exprs.
 func (expr *FuncExpr) CopyNode() *FuncExpr {
 	exprCopy := *expr
+	if expr.WindowDef != nil {
+		windowDefCopy := *expr.WindowDef
+		exprCopy.WindowDef = &windowDefCopy
+	}
 	exprCopy.Exprs = append(Exprs(nil), exprCopy.Exprs...)
 	if windowDef := exprCopy.WindowDef; windowDef != nil {
 		windowDef.Partitions = append(Exprs(nil), windowDef.Partitions...)

--- a/pkg/sql/testdata/logic_test/prepare
+++ b/pkg/sql/testdata/logic_test/prepare
@@ -169,3 +169,23 @@ EXECUTE s
 
 statement
 DEALLOCATE ALL
+
+# Regression test for #15970
+
+statement
+PREPARE x AS SELECT avg(column1) OVER (PARTITION BY column2) FROM (VALUES (1, 2), (3, 4))
+
+query R
+EXECUTE x
+----
+1
+3
+
+statement
+PREPARE y AS SELECT avg(a.column1) OVER (PARTITION BY a.column2) FROM (VALUES (1, 2), (3, 4)) a
+
+query R
+EXECUTE y
+----
+1
+3


### PR DESCRIPTION
Previously, `FuncExpr.CopyNode` contained a bug that caused the copy to
share the `WindowDef` of the original expression, which caused
`FuncExprs` to no longer be immutable if they were copied and their
`WindowDef` modified.

Fixes #15970.