### PR TITLE
storage: panic instead of Fatal to surface assertion

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1350,10 +1350,7 @@ func (r *Replica) assertStateRLocked(reader engine.Reader) {
 		// TODO(dt): expose properly once #15892 is addressed.
 		log.Errorf(ctx, "on-disk and in-memory state diverged:\n%s", pretty.Diff(diskState, r.mu.state))
 		r.mu.state.Desc, diskState.Desc = nil, nil
-		log.Fatal(
-			ctx, log.Safe{
-				V: fmt.Sprintf("on-disk and in-memory state diverged:\n%s", pretty.Diff(diskState, r.mu.state)),
-			})
+		panic(log.Safe{V: fmt.Sprintf("on-disk and in-memory state diverged: %s", pretty.Diff(diskState, r.mu.state))})
 	}
 }
 


### PR DESCRIPTION
I messed this up in #16013 and changed the handler for `panic`, not
the one for `Fatal`. Instead of trying to fumble another set of edits,
I think it is acceptable to panic on this particular error for 1.0.1,
which should properly get us what we want sent to sentry.io.