### PR TITLE
build: standardize `make check` and `make install` too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,8 +193,8 @@ bench: BENCHES := .
 bench: TESTS := -
 bench: TESTTIMEOUT := $(BENCHTIMEOUT)
 
-.PHONY: test testshort testrace testlogic bench
-test testshort testrace bench: gotestdashi
+.PHONY: check test testshort testrace testlogic bench
+check test testshort testrace bench: gotestdashi
 	$(XGO) test $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -run "$(TESTS)" $(if $(BENCHES),-bench "$(BENCHES)") -timeout $(TESTTIMEOUT) $(PKG) $(TESTFLAGS)
 
 # Run make testlogic to run all of the logic tests. Specify test files to run
@@ -271,13 +271,6 @@ lint: gotestdashi
 lintshort: override TAGS += lint
 lintshort: gotestdashi
 	$(XGO) test ./build -v $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -short -run 'TestStyle/$(TESTS)'
-
-.PHONY: check checkshort
-check checkshort:
-	@# TODO(benesch): make this target an alias for the `test` target.
-	@echo 'To adhere to convention, `make check` will soon be an alias for `make test`.' >&2
-	@echo 'The linters have moved to `make lint` and `make lintshort`.' >&2
-	@false
 
 .PHONY: clean
 clean: clean-c-deps

--- a/build/archive/contents/Makefile
+++ b/build/archive/contents/Makefile
@@ -1,3 +1,3 @@
-.PHONY: all build buildoss install test
-all build buildoss install test:
+.PHONY: all build buildoss check install test
+all build buildoss check install test:
 	$(MAKE) -C src/github.com/cockroachdb/cockroach $@

--- a/build/archive/contents/Makefile
+++ b/build/archive/contents/Makefile
@@ -1,12 +1,3 @@
-prefix := /usr/local
-bindir := $(prefix)/bin
-INSTALL := install
-
-.PHONY: all build buildoss test
-all build buildoss test:
+.PHONY: all build buildoss install test
+all build buildoss install test:
 	$(MAKE) -C src/github.com/cockroachdb/cockroach $@
-
-.PHONY: install
-install: build
-	$(INSTALL) -d -m 755 $(DESTDIR)$(bindir)
-	$(INSTALL) -m 755 src/github.com/cockroachdb/cockroach/cockroach $(DESTDIR)$(bindir)


### PR DESCRIPTION
See commit messages for details. This (finally) addresses everything from #15862, I believe!

@bdarnell, this will break your workflow just a bit; you'll need `make go-install` instead of `make install` with this patch.