### PR TITLE
sql: set the parse phase times in ExecuteParsedStatement

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -534,6 +534,15 @@ func (e *Executor) ExecutePreparedStatement(
 
 	defer logIfPanicking(session.Ctx(), stmts.String())
 
+	{
+		// No parsing is taking place, but we need to set the parsing phase time
+		// because the service latency is measured from
+		// phaseTimes[sessionStartParse].
+		now := timeutil.Now()
+		session.phaseTimes[sessionStartParse] = now
+		session.phaseTimes[sessionEndParse] = now
+	}
+
 	// Send the Request for SQL execution and set the application-level error
 	// for each result in the reply.
 	return e.execParsed(session, stmts, pinfo, copyMsgNone)


### PR DESCRIPTION
This fixes a bug where the computed parse time for executing a prepared
statement was set to the parse time for the previously parsed
statement. Additionally, the service time was inaccurate as it is
measured from sessionStartParse phase time.