### PR TITLE
build: version control teamcity-build-test-binary.sh

### DIFF
--- a/build/teamcity-build-test-binary.sh
+++ b/build/teamcity-build-test-binary.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+build/builder.sh make build TYPE=release-linux-gnu
+mkdir -p artifacts
+mv cockroach-linux-2.6.32-gnu-amd64 artifacts/cockroach


### PR DESCRIPTION
"Build test binary" is a new build step on TeamCity that creates a release binary for use in later build steps. Move the script into the repository so that we can atomically update the invocation to create a release build.

Necessary for #15337.