### PR TITLE
sql: some performance optimizations in the makePlan path

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1344,26 +1344,38 @@ func (e *Executor) execStmtInOpenTxn(
 		return Result{PGTag: s.StatementTag()}, nil
 	}
 
-	// Create a new planner from the Session to execute the statement.
-	planner := session.newPlanner(e, txnState.txn)
-	planner.evalCtx.SetTxnTimestamp(txnState.sqlTimestamp)
-	planner.evalCtx.SetStmtTimestamp(e.cfg.Clock.PhysicalTime())
-	planner.semaCtx.Placeholders.Assign(pinfo)
-	planner.avoidCachedDescriptors = avoidCachedDescriptors
-	planner.phaseTimes[plannerStartExecStmt] = timeutil.Now()
+	var p *planner
+	runInParallel := parallelize && !implicitTxn
+	if runInParallel {
+		// Create a new planner from the Session to execute the statement, since
+		// we're executing in parallel.
+		p = session.newPlanner(e, txnState.txn)
+	} else {
+		// We're not executing in parallel. We can use the cached planner on the
+		// session.
+		p = &session.planner
+		session.resetPlanner(p, e, txnState.txn)
+	}
+	p.evalCtx.SetTxnTimestamp(txnState.sqlTimestamp)
+	p.evalCtx.SetStmtTimestamp(e.cfg.Clock.PhysicalTime())
+	p.semaCtx.Placeholders.Assign(pinfo)
+	p.avoidCachedDescriptors = avoidCachedDescriptors
+	p.phaseTimes[plannerStartExecStmt] = timeutil.Now()
 
 	var result Result
-	if parallelize && !implicitTxn {
+	if runInParallel {
 		// Only run statements asynchronously through the parallelize queue if the
 		// statements are parallelized and we're in a transaction. Parallelized
 		// statements outside of a transaction are run synchronously with mocked
 		// results, which has the same effect as running asynchronously but
 		// immediately blocking.
-		result, err = e.execStmtInParallel(stmt, planner)
+		result, err = e.execStmtInParallel(stmt, p)
 	} else {
-		planner.autoCommit = implicitTxn && !e.cfg.TestingKnobs.DisableAutoCommit
-		result, err = e.execStmt(stmt, planner,
+		p.autoCommit = implicitTxn && !e.cfg.TestingKnobs.DisableAutoCommit
+		result, err = e.execStmt(stmt, p,
 			automaticRetryCount, parallelize /* mockResults */)
+		// Zeroing the cached planner allows the GC to clean up any memory hanging
+		// off the planner, which we're finished using at this point.
 	}
 
 	if err != nil {

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -75,15 +75,16 @@ func (UnaryOp) preferred() bool {
 func init() {
 	for op, overload := range UnaryOps {
 		for i, impl := range overload {
-			impl.types = ArgTypes{{"arg", impl.Typ}}
-			impl.retType = fixedReturnType(impl.ReturnType)
-			UnaryOps[op][i] = impl
+			casted := impl.(UnaryOp)
+			casted.types = ArgTypes{{"arg", casted.Typ}}
+			casted.retType = fixedReturnType(casted.ReturnType)
+			UnaryOps[op][i] = casted
 		}
 	}
 }
 
 // unaryOpOverload is an overloaded set of unary operator implementations.
-type unaryOpOverload []UnaryOp
+type unaryOpOverload []overloadImpl
 
 // UnaryOps contains the unary operations indexed by operation type.
 var UnaryOps = map[UnaryOperator]unaryOpOverload{
@@ -194,20 +195,22 @@ func (BinOp) preferred() bool {
 func init() {
 	for op, overload := range BinOps {
 		for i, impl := range overload {
-			impl.types = ArgTypes{{"left", impl.LeftType}, {"right", impl.RightType}}
-			impl.retType = fixedReturnType(impl.ReturnType)
-			BinOps[op][i] = impl
+			casted := impl.(BinOp)
+			casted.types = ArgTypes{{"left", casted.LeftType}, {"right", casted.RightType}}
+			casted.retType = fixedReturnType(casted.ReturnType)
+			BinOps[op][i] = casted
 		}
 	}
 }
 
 // binOpOverload is an overloaded set of binary operator implementations.
-type binOpOverload []BinOp
+type binOpOverload []overloadImpl
 
 func (o binOpOverload) lookupImpl(left, right Type) (BinOp, bool) {
 	for _, fn := range o {
-		if fn.matchParams(left, right) {
-			return fn, true
+		casted := fn.(BinOp)
+		if casted.matchParams(left, right) {
+			return casted, true
 		}
 	}
 	return BinOp{}, false
@@ -993,19 +996,21 @@ func (CmpOp) preferred() bool {
 func init() {
 	for op, overload := range CmpOps {
 		for i, impl := range overload {
-			impl.types = ArgTypes{{"left", impl.LeftType}, {"right", impl.RightType}}
-			CmpOps[op][i] = impl
+			casted := impl.(CmpOp)
+			casted.types = ArgTypes{{"left", casted.LeftType}, {"right", casted.RightType}}
+			CmpOps[op][i] = casted
 		}
 	}
 }
 
 // cmpOpOverload is an overloaded set of comparison operator implementations.
-type cmpOpOverload []CmpOp
+type cmpOpOverload []overloadImpl
 
 func (o cmpOpOverload) lookupImpl(left, right Type) (CmpOp, bool) {
 	for _, fn := range o {
-		if fn.matchParams(left, right) {
-			return fn, true
+		casted := fn.(CmpOp)
+		if casted.matchParams(left, right) {
+			return casted, true
 		}
 	}
 	return CmpOp{}, false

--- a/pkg/sql/parser/function_definition.go
+++ b/pkg/sql/parser/function_definition.go
@@ -32,21 +32,22 @@ type FunctionDefinition struct {
 	// Set e.g. for aggregate functions.
 	HasOverloadsNeedingRepeatedEvaluation bool
 	// Definition is the set of overloads for this function name.
-	Definition []Builtin
+	Definition []overloadImpl
 }
 
 func newFunctionDefinition(name string, def []Builtin) *FunctionDefinition {
 	hasRowDependentOverloads := false
-	for _, d := range def {
+	overloads := make([]overloadImpl, len(def))
+	for i, d := range def {
+		overloads[i] = d
 		if d.needsRepeatedEvaluation {
 			hasRowDependentOverloads = true
-			break
 		}
 	}
 	return &FunctionDefinition{
 		Name: name,
 		HasOverloadsNeedingRepeatedEvaluation: hasRowDependentOverloads,
-		Definition:                            def,
+		Definition:                            overloads,
 	}
 }
 

--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -118,12 +118,8 @@ func (expr *AndExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, error
 // TypeCheck implements the Expr interface.
 func (expr *BinaryExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, error) {
 	ops := BinOps[expr.Operator]
-	overloads := make([]overloadImpl, len(ops))
-	for i := range ops {
-		overloads[i] = ops[i]
-	}
 
-	typedSubExprs, fn, err := typeCheckOverloadedExprs(ctx, desired, overloads, expr.Left, expr.Right)
+	typedSubExprs, fn, err := typeCheckOverloadedExprs(ctx, desired, ops, expr.Left, expr.Right)
 	if err != nil {
 		return nil, err
 	}
@@ -377,11 +373,7 @@ func (expr *FuncExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, erro
 		return nil, err
 	}
 
-	overloads := make([]overloadImpl, len(def.Definition))
-	for i, d := range def.Definition {
-		overloads[i] = d
-	}
-	typedSubExprs, fn, err := typeCheckOverloadedExprs(ctx, desired, overloads, expr.Exprs...)
+	typedSubExprs, fn, err := typeCheckOverloadedExprs(ctx, desired, def.Definition, expr.Exprs...)
 	if err != nil {
 		return nil, fmt.Errorf("%s(): %v", def.Name, err)
 	} else if fn == nil {
@@ -612,12 +604,8 @@ func (expr *Subquery) TypeCheck(_ *SemaContext, desired Type) (TypedExpr, error)
 // TypeCheck implements the Expr interface.
 func (expr *UnaryExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, error) {
 	ops := UnaryOps[expr.Operator]
-	overloads := make([]overloadImpl, len(ops))
-	for i := range ops {
-		overloads[i] = ops[i]
-	}
 
-	typedSubExprs, fn, err := typeCheckOverloadedExprs(ctx, desired, overloads, expr.Expr)
+	typedSubExprs, fn, err := typeCheckOverloadedExprs(ctx, desired, ops, expr.Expr)
 	if err != nil {
 		return nil, err
 	}
@@ -979,11 +967,7 @@ func typeCheckComparisonOp(
 		return typedLeft, typedRight, fn, nil
 	}
 
-	overloads := make([]overloadImpl, len(ops))
-	for i := range ops {
-		overloads[i] = ops[i]
-	}
-	typedSubExprs, fn, err := typeCheckOverloadedExprs(ctx, TypeAny, overloads, foldedLeft, foldedRight)
+	typedSubExprs, fn, err := typeCheckOverloadedExprs(ctx, TypeAny, ops, foldedLeft, foldedRight)
 	if err != nil {
 		return nil, nil, CmpOp{}, err
 	}

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -832,7 +832,10 @@ func (c *v3Conn) finishExecute(
 	results sql.StatementResults, formatCodes []formatCode, sendDescription bool, limit int,
 ) error {
 	// Delay evaluation of c.session.Ctx().
-	defer func() { results.Close(c.session.Ctx()) }()
+	defer func() {
+		results.Close(c.session.Ctx())
+		c.session.FinishPlan()
+	}()
 
 	tracing.AnnotateTrace()
 	if results.Empty {

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -78,6 +78,8 @@ type planner struct {
 	srfExtractionVisitor  srfExtractionVisitor
 }
 
+var emptyPlanner planner
+
 // noteworthyInternalMemoryUsageBytes is the minimum size tracked by each
 // internal SQL pool before the pool starts explicitly logging overall usage
 // growth in the log.

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -193,6 +193,12 @@ type Session struct {
 	// structure.
 	virtualSchemas virtualSchemaHolder
 
+	// planner is the "default planner" on a session, to save planner allocations
+	// during serial execution. Since planners are not threadsafe, this is only
+	// safe to use when a statement is not being parallelized. It must be reset
+	// before using.
+	planner planner
+
 	//
 	// Run-time state.
 	//
@@ -420,15 +426,10 @@ func (s *Session) hijackCtx(ctx context.Context) func() {
 	return s.TxnState.hijackCtx(ctx)
 }
 
-// newPlanner creates a planner inside the scope of the given Session. The
-// statement executed by the planner will be executed in txn. The planner
-// should only be used to execute one statement.
-func (s *Session) newPlanner(e *Executor, txn *client.Txn) *planner {
-	p := &planner{
-		session: s,
-		// phaseTimes is an array, not a slice, so this performs a copy-by-value.
-		phaseTimes: s.phaseTimes,
-	}
+func (s *Session) resetPlanner(p *planner, e *Executor, txn *client.Txn) {
+	p.session = s
+	// phaseTimes is an array, not a slice, so this performs a copy-by-value.
+	p.phaseTimes = s.phaseTimes
 
 	p.semaCtx = parser.MakeSemaContext(s.User == security.RootUser)
 	p.semaCtx.Location = &s.Location
@@ -442,7 +443,22 @@ func (s *Session) newPlanner(e *Executor, txn *client.Txn) *planner {
 	}
 
 	p.setTxn(txn)
+}
 
+// FinishPlan releases the resources that were consumed by the currently active
+// default planner. It does not check to see whether any other resources are
+// still pointing to the planner, so it should only be called when a connection
+// is entirely finished executing a statement.
+func (s *Session) FinishPlan() {
+	s.planner = emptyPlanner
+}
+
+// newPlanner creates a planner inside the scope of the given Session. The
+// statement executed by the planner will be executed in txn. The planner
+// should only be used to execute one statement.
+func (s *Session) newPlanner(e *Executor, txn *client.Txn) *planner {
+	p := &planner{}
+	s.resetPlanner(p, e, txn)
 	return p
 }
 


### PR DESCRIPTION
Two optimizations along the `makePlan` codepath. I observed a ~5% improvement  vs master to read-only query throughput against a single-node local cluster via `kv --read-percent 100`, from 13798 to 14623 ops/s.

- avoid planner allocation in executor
A planner is quite expensive, weighing in at 6200 bytes. Allocating one
per query is wasteful during serial execution, since planners are
session-scoped and sessions do not execute more than one query at once
unless the query is parallelizeable and running within a transaction.

- don't copy overloadImpls around
Previously, `typeCheckOverloadedExprs` modified its input slice of
`overloadImpls`, requiring that callers make a copy. This copy was very
expensive, representing a large proportion of the typechecking time for
a simple equality comparison.
Now, the input slice is not modified, and callers don't have to make a
copy.

Updates #14927.