### PR TITLE
security: parse certificates at load time and export expiration time.

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -212,24 +212,27 @@ func (cfg *Config) GetCertificateManager() (*security.CertificateManager, error)
 // It also enables the reload-on-SIGHUP functionality on the certificate manager.
 // This should be called early in the life of the server to make sure there are no
 // issues with TLS configs.
-func (cfg *Config) InitializeNodeTLSConfigs(stopper *stop.Stopper) error {
+// Returns the certificate manager if successfully created and in secure mode.
+func (cfg *Config) InitializeNodeTLSConfigs(
+	stopper *stop.Stopper,
+) (*security.CertificateManager, error) {
 	if cfg.Insecure {
-		return nil
+		return nil, nil
 	}
 
 	if _, err := cfg.GetServerTLSConfig(); err != nil {
-		return err
+		return nil, err
 	}
 	if _, err := cfg.GetClientTLSConfig(); err != nil {
-		return err
+		return nil, err
 	}
 
 	cm, err := cfg.GetCertificateManager()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	cm.RegisterSignalHandler(stopper)
-	return nil
+	return cm, nil
 }
 
 // GetClientTLSConfig returns the client TLS config, initializing it if needed.

--- a/pkg/security/certificate_loader.go
+++ b/pkg/security/certificate_loader.go
@@ -127,7 +127,7 @@ type CertInfo struct {
 	// Name is the blob in the middle of the filename. eg: username for client certs.
 	Name string
 
-	// Parsed certificates. This is used to debugging/printing/monitoring only,
+	// Parsed certificates. This is used by debugging/printing/monitoring only,
 	// TLS config objects are passed raw certificate file contents.
 	// CA certs may contain (and use) more than one certificate.
 	// Client/Server certs may contain more than one, but only the first certificate will be used.

--- a/pkg/security/certificate_loader_test.go
+++ b/pkg/security/certificate_loader_test.go
@@ -17,12 +17,18 @@
 package security_test
 
 import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
@@ -68,8 +74,37 @@ func countLoadedCertificates(certsDir string) (int, error) {
 	return len(cl.Certificates()), nil
 }
 
+// Generate a valid x509 CA certificate. Returns the x509 certificate and the
+// PEM-encoded contents (suitable to write to a .crt file).
+func makeTestCACert() (*x509.Certificate, []byte, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 512)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certBytes, err := security.GenerateCA(key, time.Hour*48)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	x509Cert, err := x509.ParseCertificate(certBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certBlock := &pem.Block{Type: "CERTIFICATE", Bytes: certBytes}
+	return x509Cert, pem.EncodeToMemory(certBlock), nil
+}
+
 func TestNamingScheme(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	// Make a valid x509 certificate. We don't use it here, but we do need something that
+	// parses as a valid pem-encoded x509 certificate.
+	x509Cert, certContents, err := makeTestCACert()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Do not use embedded certs.
 	security.ResetAssetLoader()
@@ -99,8 +134,9 @@ func TestNamingScheme(t *testing.T) {
 	}()
 
 	type testFile struct {
-		name string
-		mode os.FileMode
+		name     string
+		mode     os.FileMode
+		contents []byte
 	}
 
 	testData := []struct {
@@ -122,24 +158,24 @@ func TestNamingScheme(t *testing.T) {
 			// Test bad names, including ca/node certs with blobs in the middle, wrong separator.
 			// We only need to test certs, if they're not loaded, neither will keys.
 			files: []testFile{
-				{"ca.foo.crt", 0777},
-				{"cr..crt", 0777},
-				{"node.foo.crt", 0777},
-				{"node..crt", 0777},
-				{"client.crt", 0777},
-				{"client..crt", 0777},
+				{"ca.foo.crt", 0777, []byte{}},
+				{"cr..crt", 0777, []byte{}},
+				{"node.foo.crt", 0777, []byte{}},
+				{"node..crt", 0777, []byte{}},
+				{"client.crt", 0777, []byte{}},
+				{"client..crt", 0777, []byte{}},
 			},
 			certs: []security.CertInfo{},
 		},
 		{
 			// Test proper names, but no key files, only the CA cert should be loaded without error.
 			files: []testFile{
-				{"ca.crt", 0777},
-				{"node.crt", 0777},
-				{"client.root.crt", 0777},
+				{"ca.crt", 0777, certContents},
+				{"node.crt", 0777, certContents},
+				{"client.root.crt", 0777, certContents},
 			},
 			certs: []security.CertInfo{
-				{FileUsage: security.CAPem, Filename: "ca.crt"},
+				{FileUsage: security.CAPem, Filename: "ca.crt", FileContents: certContents},
 				{FileUsage: security.ClientPem, Filename: "client.root.crt", Name: "root",
 					Error: errors.New(".* no such file or directory")},
 				{FileUsage: security.NodePem, Filename: "node.crt",
@@ -150,15 +186,15 @@ func TestNamingScheme(t *testing.T) {
 			// Key files, but wrong permissions.
 			// We don't load CA keys here, so permissions for them don't matter.
 			files: []testFile{
-				{"ca.crt", 0777},
-				{"ca.key", 0777},
-				{"node.crt", 0777},
-				{"node.key", 0704},
-				{"client.root.crt", 0777},
-				{"client.root.key", 0740},
+				{"ca.crt", 0777, certContents},
+				{"ca.key", 0777, []byte{}},
+				{"node.crt", 0777, certContents},
+				{"node.key", 0704, []byte{}},
+				{"client.root.crt", 0777, certContents},
+				{"client.root.key", 0740, []byte{}},
 			},
 			certs: []security.CertInfo{
-				{FileUsage: security.CAPem, Filename: "ca.crt"},
+				{FileUsage: security.CAPem, Filename: "ca.crt", FileContents: certContents},
 				{FileUsage: security.ClientPem, Filename: "client.root.crt", Name: "root",
 					Error: errors.New(".* exceeds -rwx------")},
 				{FileUsage: security.NodePem, Filename: "node.crt",
@@ -167,35 +203,58 @@ func TestNamingScheme(t *testing.T) {
 			skipWindows: true,
 		},
 		{
-			// Everything loads.
+			// Bad cert files.
 			files: []testFile{
-				{"ca.crt", 0777},
-				{"ca.key", 0700},
-				{"node.crt", 0777},
-				{"node.key", 0700},
-				{"client.root.crt", 0777},
-				{"client.root.key", 0700},
+				{"ca.crt", 0777, []byte{}},
+				{"ca.key", 0777, []byte{}},
+				{"node.crt", 0777, []byte("foo")},
+				{"node.key", 0700, []byte{}},
+				{"client.root.crt", 0777, append(certContents, []byte("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----")...)},
+				{"client.root.key", 0700, []byte{}},
 			},
 			certs: []security.CertInfo{
-				{FileUsage: security.CAPem, Filename: "ca.crt"},
-				{FileUsage: security.ClientPem, Filename: "client.root.crt", KeyFilename: "client.root.key", Name: "root"},
-				{FileUsage: security.NodePem, Filename: "node.crt", KeyFilename: "node.key"},
+				{FileUsage: security.CAPem, Filename: "ca.crt",
+					Error: errors.New("empty certificate file: ca.crt")},
+				{FileUsage: security.ClientPem, Filename: "client.root.crt", Name: "root",
+					Error: errors.New("failed to parse certificate at position 1 in file client.root.crt")},
+				{FileUsage: security.NodePem, Filename: "node.crt",
+					Error: errors.New("no certificates found in node.crt")},
+			},
+		},
+		{
+			// Everything loads.
+			files: []testFile{
+				{"ca.crt", 0777, certContents},
+				{"ca.key", 0700, []byte("ca.key")},
+				{"node.crt", 0777, certContents},
+				{"node.key", 0700, []byte("node.key")},
+				{"client.root.crt", 0777, certContents},
+				{"client.root.key", 0700, []byte("client.root.key")},
+			},
+			certs: []security.CertInfo{
+				{FileUsage: security.CAPem, Filename: "ca.crt", FileContents: certContents},
+				{FileUsage: security.ClientPem, Filename: "client.root.crt", KeyFilename: "client.root.key",
+					Name: "root", FileContents: certContents, KeyFileContents: []byte("client.root.key")},
+				{FileUsage: security.NodePem, Filename: "node.crt", KeyFilename: "node.key",
+					FileContents: certContents, KeyFileContents: []byte("node.key")},
 			},
 		},
 		{
 			// Bad key permissions, but skip permissions checks.
 			files: []testFile{
-				{"ca.crt", 0777},
-				{"ca.key", 0777},
-				{"node.crt", 0777},
-				{"node.key", 0777},
-				{"client.root.crt", 0777},
-				{"client.root.key", 0777},
+				{"ca.crt", 0777, certContents},
+				{"ca.key", 0777, []byte("ca.key")},
+				{"node.crt", 0777, certContents},
+				{"node.key", 0777, []byte("node.key")},
+				{"client.root.crt", 0777, certContents},
+				{"client.root.key", 0777, []byte("client.root.key")},
 			},
 			certs: []security.CertInfo{
-				{FileUsage: security.CAPem, Filename: "ca.crt"},
-				{FileUsage: security.ClientPem, Filename: "client.root.crt", KeyFilename: "client.root.key", Name: "root"},
-				{FileUsage: security.NodePem, Filename: "node.crt", KeyFilename: "node.key"},
+				{FileUsage: security.CAPem, Filename: "ca.crt", FileContents: certContents},
+				{FileUsage: security.ClientPem, Filename: "client.root.crt", KeyFilename: "client.root.key",
+					Name: "root", FileContents: certContents, KeyFileContents: []byte("client.root.key")},
+				{FileUsage: security.NodePem, Filename: "node.crt", KeyFilename: "node.key",
+					FileContents: certContents, KeyFileContents: []byte("node.key")},
 			},
 			skipChecks: true,
 		},
@@ -209,7 +268,7 @@ func TestNamingScheme(t *testing.T) {
 		// Write all files.
 		for _, f := range data.files {
 			n := f.name
-			if err := ioutil.WriteFile(filepath.Join(certsDir, n), []byte(n), f.mode); err != nil {
+			if err := ioutil.WriteFile(filepath.Join(certsDir, n), f.contents, f.mode); err != nil {
 				t.Fatalf("#%d: could not write file %s: %v", testNum, n, err)
 			}
 		}
@@ -235,9 +294,13 @@ func TestNamingScheme(t *testing.T) {
 			if expected.Error == nil {
 				if actual.Error != nil {
 					t.Errorf("#%d: expected success, got error: %+v", testNum, actual.Error)
+					continue
 				}
-			} else if !testutils.IsError(actual.Error, expected.Error.Error()) {
-				t.Errorf("#%d: mismatched error, expected: %+v, got %+v", testNum, expected, actual)
+			} else {
+				if !testutils.IsError(actual.Error, expected.Error.Error()) {
+					t.Errorf("#%d: mismatched error, expected: %+v, got %+v", testNum, expected, actual)
+				}
+				continue
 			}
 
 			// Compare some fields.
@@ -246,12 +309,29 @@ func TestNamingScheme(t *testing.T) {
 				actual.KeyFilename != expected.KeyFilename ||
 				actual.Name != expected.Name {
 				t.Errorf("#%d: mismatching CertInfo, expected: %+v, got %+v", testNum, expected, actual)
+				continue
 			}
-			if actual.Filename != "" && string(actual.FileContents) != actual.Filename {
-				t.Errorf("#%d: bad file contents: expected %s, got %s", testNum, actual.Filename, actual.FileContents)
+			if actual.Filename != "" {
+				if !bytes.Equal(actual.FileContents, expected.FileContents) {
+					t.Errorf("#%d: bad file contents: expected %s, got %s", testNum, expected.FileContents, actual.FileContents)
+					continue
+				}
+				if a, e := len(actual.ParsedCertificates), 1; a != e {
+					t.Errorf("#%d: expected %d certificates, found: %d", testNum, e, a)
+					continue
+				}
+				if a, e := actual.ParsedCertificates[0], x509Cert; !bytes.Equal(a.Raw, e.Raw) {
+					t.Errorf("#%d: mismatched certificate: %+v vs %+v", testNum, a, e)
+					continue
+				}
+				if a, e := actual.ExpirationTime, x509Cert.NotAfter; a != e {
+					t.Errorf("#%d: mismatched expiration: %s vs %s", testNum, a, e)
+					continue
+				}
 			}
-			if actual.KeyFilename != "" && string(actual.KeyFileContents) != actual.KeyFilename {
-				t.Errorf("#%d: bad file contents: expected %s, got %s", testNum, actual.KeyFilename, actual.KeyFileContents)
+			if actual.KeyFilename != "" && !bytes.Equal(actual.KeyFileContents, expected.KeyFileContents) {
+				t.Errorf("#%d: bad file contents: expected %s, got %s", testNum, expected.KeyFileContents, actual.KeyFileContents)
+				continue
 			}
 		}
 

--- a/pkg/security/certificate_manager.go
+++ b/pkg/security/certificate_manager.go
@@ -24,11 +24,21 @@ import (
 	"syscall"
 
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"golang.org/x/net/context"
 
 	"github.com/pkg/errors"
+)
+
+var (
+	metaCAExpiration = metric.Metadata{
+		Name: "security.certificate.expiration.ca",
+		Help: "Expiration timestamp for the CA certificate. 0 means no certificate or error."}
+	metaNodeExpiration = metric.Metadata{
+		Name: "security.certificate.expiration.node",
+		Help: "Expiration timestamp for the node certificate. 0 means no certificate or error."}
 )
 
 // CertificateManager lives for the duration of the process and manages certificates and keys.
@@ -39,8 +49,11 @@ import (
 // but these are by no means complete. Completeness is not required as nodes restarting have
 // no fallback if invalid certs/keys are present.
 type CertificateManager struct {
-	// Immutable fields after object construction.
+	// Certificate directory is not modified after initialization.
 	certsDir string
+	// The metrics struct is initialized at init time and metrics do their
+	// own locking.
+	certMetrics CertificateMetrics
 
 	// mu protects all remaining fields.
 	mu syncutil.RWMutex
@@ -61,9 +74,27 @@ type CertificateManager struct {
 	clientConfig *tls.Config
 }
 
+// CertificateMetrics holds metrics about the various certificates.
+// These are initialized when the certificate manager is created and updated
+// on reload.
+type CertificateMetrics struct {
+	CAExpiration   *metric.Gauge
+	NodeExpiration *metric.Gauge
+}
+
+func makeCertificateManager(certsDir string) *CertificateManager {
+	cm := &CertificateManager{certsDir: os.ExpandEnv(certsDir)}
+	// Initialize metrics:
+	cm.certMetrics = CertificateMetrics{
+		CAExpiration:   metric.NewGauge(metaCAExpiration),
+		NodeExpiration: metric.NewGauge(metaNodeExpiration),
+	}
+	return cm
+}
+
 // NewCertificateManager creates a new certificate manager.
 func NewCertificateManager(certsDir string) (*CertificateManager, error) {
-	cm := &CertificateManager{certsDir: os.ExpandEnv(certsDir)}
+	cm := makeCertificateManager(certsDir)
 	return cm, cm.LoadCertificates()
 }
 
@@ -72,12 +103,17 @@ func NewCertificateManager(certsDir string) (*CertificateManager, error) {
 // This should only be called when generating certificates, the server has
 // no business creating the certs directory.
 func NewCertificateManagerFirstRun(certsDir string) (*CertificateManager, error) {
-	cm := &CertificateManager{certsDir: os.ExpandEnv(certsDir)}
+	cm := makeCertificateManager(certsDir)
 	if err := NewCertificateLoader(cm.certsDir).MaybeCreateCertsDir(); err != nil {
 		return nil, err
 	}
 
 	return cm, cm.LoadCertificates()
+}
+
+// Metrics returns the metrics struct.
+func (cm *CertificateManager) Metrics() CertificateMetrics {
+	return cm.certMetrics
 }
 
 // RegisterSignalHandler registers a signal handler for SIGHUP, triggering a
@@ -203,7 +239,33 @@ func (cm *CertificateManager) LoadCertificates() error {
 	cm.serverConfig = nil
 	cm.clientConfig = nil
 
+	cm.updateMetricsLocked()
 	return nil
+}
+
+// updateMetricsLocked updates the values on the certificate metrics.
+// The metrics may not exist (eg: in tests that build their own CertificateManager).
+// If the corresponding certificate is missing or invalid (Error != nil), we reset the
+// metric to zero.
+// cm.mu must be held to protect the certificates. Metrics do their own atomicity.
+func (cm *CertificateManager) updateMetricsLocked() {
+	// CA certificate expiration.
+	if cm.certMetrics.CAExpiration != nil {
+		if cm.caCert != nil && cm.caCert.Error == nil {
+			cm.certMetrics.CAExpiration.Update(cm.caCert.ExpirationTime.Unix())
+		} else {
+			cm.certMetrics.CAExpiration.Update(0)
+		}
+	}
+
+	// Node certificate expiration.
+	if cm.certMetrics.NodeExpiration != nil {
+		if cm.nodeCert != nil && cm.nodeCert.Error == nil {
+			cm.certMetrics.NodeExpiration.Update(cm.nodeCert.ExpirationTime.Unix())
+		} else {
+			cm.certMetrics.NodeExpiration.Update(0)
+		}
+	}
 }
 
 // GetServerTLSConfig returns a server TLS config with a callback to fetch the

--- a/pkg/security/certificate_manager.go
+++ b/pkg/security/certificate_manager.go
@@ -259,6 +259,8 @@ func (cm *CertificateManager) updateMetricsLocked() {
 	}
 
 	// Node certificate expiration.
+	// TODO(marc): we need to examine the entire certificate chain here, if the CA cert
+	// used to sign the node cert expires sooner, then that is the expiration time to report.
 	if cm.certMetrics.NodeExpiration != nil {
 		if cm.nodeCert != nil && cm.nodeCert.Error == nil {
 			cm.certMetrics.NodeExpiration.Update(cm.nodeCert.ExpirationTime.Unix())


### PR DESCRIPTION
Work towards #15027

Parse certificates at load time. Any failures are persisted for clarity.
For now, only the expiration time is used (in `cockroach cert list` and metrics) but debug pages will make use of the parsed certificates.