### PR TITLE
cli: Fix handling of unset system range zone config fields

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -462,6 +462,7 @@ func Example_zone() {
 	c.Run("zone ls")
 	c.Run("zone set system --file=./testdata/zone_attrs.yaml")
 	c.Run("zone ls")
+	c.Run("zone get .meta")
 	c.Run("zone get system.nonexistent")
 	c.Run("zone get system.lease")
 	c.Run("zone set system.lease --file=./testdata/zone_attrs.yaml")
@@ -503,6 +504,14 @@ func Example_zone() {
 	// zone ls
 	// .default
 	// system
+	// zone get .meta
+	// .default
+	// range_min_bytes: 1048576
+	// range_max_bytes: 67108864
+	// gc:
+	//   ttlseconds: 86400
+	// num_replicas: 1
+	// constraints: []
 	// zone get system.nonexistent
 	// system.nonexistent not found
 	// zone get system.lease
@@ -541,32 +550,32 @@ func Example_zone() {
 	// zone rm .default
 	// unable to remove special zone .default
 	// zone set .meta --file=./testdata/zone_range_max_bytes.yaml
-	// range_min_bytes: 0
+	// range_min_bytes: 1048576
 	// range_max_bytes: 134217728
 	// gc:
-	//   ttlseconds: 0
+	//   ttlseconds: 86400
 	// num_replicas: 3
 	// constraints: []
 	// zone set .system --file=./testdata/zone_range_max_bytes.yaml
-	// range_min_bytes: 0
+	// range_min_bytes: 1048576
 	// range_max_bytes: 134217728
 	// gc:
-	//   ttlseconds: 0
+	//   ttlseconds: 86400
 	// num_replicas: 3
 	// constraints: []
 	// zone set .timeseries --file=./testdata/zone_range_max_bytes.yaml
-	// range_min_bytes: 0
+	// range_min_bytes: 1048576
 	// range_max_bytes: 134217728
 	// gc:
-	//   ttlseconds: 0
+	//   ttlseconds: 86400
 	// num_replicas: 3
 	// constraints: []
 	// zone get .system
 	// .system
-	// range_min_bytes: 0
+	// range_min_bytes: 1048576
 	// range_max_bytes: 134217728
 	// gc:
-	//   ttlseconds: 0
+	//   ttlseconds: 86400
 	// num_replicas: 3
 	// constraints: []
 	// zone ls

--- a/pkg/cli/zone.go
+++ b/pkg/cli/zone.go
@@ -184,11 +184,11 @@ func queryDescriptorIDPath(conn *sqlConn, names []string) ([]sqlbase.ID, error) 
 	case defaultZoneName:
 		return path, nil
 	case metaZoneName:
-		return []sqlbase.ID{keys.MetaRangesID}, nil
+		return append(path, keys.MetaRangesID), nil
 	case systemZoneName:
-		return []sqlbase.ID{keys.SystemRangesID}, nil
+		return append(path, keys.SystemRangesID), nil
 	case timeseriesZoneName:
-		return []sqlbase.ID{keys.TimeseriesRangesID}, nil
+		return append(path, keys.TimeseriesRangesID), nil
 	}
 	for _, name := range names {
 		id, err := queryNamespace(conn, path[len(path)-1], name)


### PR DESCRIPTION
We need to fall back to the default zone config if they aren't fully
specified.

I guess this is an example of why writing the docs sooner is better, since it's what caused me to notice this.