### PR TITLE
security: don't exceed CA expiration for server/client certs.

### DIFF
--- a/pkg/acceptance/cluster/localcluster.go
+++ b/pkg/acceptance/cluster/localcluster.go
@@ -477,7 +477,7 @@ func (l *LocalCluster) createRoach(
 func (l *LocalCluster) createCACert() {
 	maybePanic(security.CreateCAPair(
 		l.CertsDir, filepath.Join(l.CertsDir, security.EmbeddedCAKey),
-		keyLen, 48*time.Hour, false, false))
+		keyLen, 96*time.Hour, false, false))
 }
 
 func (l *LocalCluster) createNodeCerts() {

--- a/pkg/cli/cert.go
+++ b/pkg/cli/cert.go
@@ -31,8 +31,8 @@ const defaultKeySize = 2048
 
 // We use 366 days on certificate lifetimes to at least match X years,
 // otherwise leap years risk putting us just under.
-const defaultCALifetime = 10 * 366 * 24 * time.Hour   // ten years
-const defaultCertLifetime = 10 * 366 * 24 * time.Hour // ten years
+const defaultCALifetime = 10 * 366 * 24 * time.Hour  // ten years
+const defaultCertLifetime = 5 * 366 * 24 * time.Hour // five years
 
 var keySize int
 var certificateLifetime time.Duration
@@ -82,6 +82,7 @@ At least one host should be passed in (either IP address or dns name).
 
 Requires a CA cert in "<certs-dir>/ca.crt" and matching key in "--ca-key".
 If "ca.crt" contains more than one certificate, the first is used.
+Creation fails if the CA expiration time is before the desired certificate expiration.
 `,
 	RunE: MaybeDecorateGRPCError(runCreateNodeCert),
 }
@@ -116,6 +117,7 @@ If --overwrite is true, any existing files are overwritten.
 
 Requires a CA cert in "<certs-dir>/ca.crt" and matching key in "--ca-key".
 If "ca.crt" contains more than one certificate, the first is used.
+Creation fails if the CA expiration time is before the desired certificate expiration.
 `,
 	RunE: MaybeDecorateGRPCError(runCreateClientCert),
 }

--- a/pkg/security/certs.go
+++ b/pkg/security/certs.go
@@ -266,23 +266,23 @@ func CreateClientPair(
 	// Generate certificates and keys.
 	clientKey, err := rsa.GenerateKey(rand.Reader, keySize)
 	if err != nil {
-		return errors.Errorf("could not generate new node key: %v", err)
+		return errors.Errorf("could not generate new client key: %v", err)
 	}
 
 	clientCert, err := GenerateClientCert(caCert, caPrivateKey, clientKey.Public(), lifetime, user)
 	if err != nil {
-		return errors.Errorf("error creating node server certificate and key: %s", err)
+		return errors.Errorf("error creating client certificate and key: %s", err)
 	}
 
 	certPath := cm.ClientCertPath(user)
 	if err := writeCertificateToFile(certPath, clientCert, overwrite); err != nil {
-		return errors.Errorf("error writing node server certificate to %s: %v", certPath, err)
+		return errors.Errorf("error writing client certificate to %s: %v", certPath, err)
 	}
 	log.Infof(context.Background(), "Generated client certificate: %s", certPath)
 
 	keyPath := cm.ClientKeyPath(user)
 	if err := writeKeyToFile(keyPath, clientKey, overwrite); err != nil {
-		return errors.Errorf("error writing node server key to %s: %v", keyPath, err)
+		return errors.Errorf("error writing client key to %s: %v", keyPath, err)
 	}
 	log.Infof(context.Background(), "Generated client key: %s", keyPath)
 

--- a/pkg/security/certs_test.go
+++ b/pkg/security/certs_test.go
@@ -137,7 +137,7 @@ func TestGenerateNodeCerts(t *testing.T) {
 
 	// Now try in the proper order.
 	if err := security.CreateCAPair(
-		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey), 512, time.Hour*48, false, false,
+		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey), 512, time.Hour*96, false, false,
 	); err != nil {
 		t.Fatalf("Expected success, got %v", err)
 	}
@@ -153,7 +153,7 @@ func TestGenerateNodeCerts(t *testing.T) {
 func generateAllCerts(certsDir string) error {
 	if err := security.CreateCAPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		512, time.Hour*48, true, true,
+		512, time.Hour*96, true, true,
 	); err != nil {
 		return errors.Errorf("could not generate CA pair: %v", err)
 	}

--- a/pkg/security/x509_test.go
+++ b/pkg/security/x509_test.go
@@ -1,0 +1,114 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package security_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+const wiggle = time.Minute * 5
+
+// Returns true if "|a-b| <= wiggle".
+func timesFuzzyEqual(a, b time.Time) bool {
+	diff := a.Sub(b)
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff <= wiggle
+}
+
+func TestGenerateCertLifetime(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testKey, err := rsa.GenerateKey(rand.Reader, 512)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a CA that expires in 2 days.
+	caDuration := time.Hour * 48
+	now := timeutil.Now()
+	caBytes, err := security.GenerateCA(testKey, caDuration)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	caCert, err := x509.ParseCertificate(caBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if a, e := caCert.NotAfter, now.Add(caDuration); !timesFuzzyEqual(a, e) {
+		t.Fatalf("CA expiration differs from requested: %s vs %s", a, e)
+	}
+
+	// Create a Node certificate expiring in 4 days. Fails on shorter CA lifetime.
+	nodeDuration := time.Hour * 96
+	_, err = security.GenerateServerCert(caCert, testKey, testKey.Public(), nodeDuration, []string{"localhost"})
+	if !testutils.IsError(err, "CA lifetime is .*, shorter than the requested .*") {
+		t.Fatal(err)
+	}
+
+	// Try again, but expiring before the CA cert.
+	nodeDuration = time.Hour * 24
+	nodeBytes, err := security.GenerateServerCert(caCert, testKey, testKey.Public(), nodeDuration, []string{"localhost"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nodeCert, err := x509.ParseCertificate(nodeBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if a, e := nodeCert.NotAfter, now.Add(nodeDuration); !timesFuzzyEqual(a, e) {
+		t.Fatalf("node expiration differs from requested: %s vs %s", a, e)
+	}
+
+	// Create a Client certificate expiring in 4 days. Should get reduced to the CA lifetime.
+	clientDuration := time.Hour * 96
+	_, err = security.GenerateClientCert(caCert, testKey, testKey.Public(), clientDuration, "testuser")
+	if !testutils.IsError(err, "CA lifetime is .*, shorter than the requested .*") {
+		t.Fatal(err)
+	}
+
+	// Try again, but expiring before the CA cert.
+	clientDuration = time.Hour * 24
+	clientBytes, err := security.GenerateClientCert(caCert, testKey, testKey.Public(), clientDuration, "testuser")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clientCert, err := x509.ParseCertificate(clientBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if a, e := clientCert.NotAfter, now.Add(clientDuration); !timesFuzzyEqual(a, e) {
+		t.Fatalf("client expiration differs from requested: %s vs %s", a, e)
+	}
+
+}


### PR DESCRIPTION
It's generally not a good idea to have the server/client certs exceed
the CA lifetime.
This will also make monitoring more accurate, avoiding the need to
monitor certificate chains (although people could still craft their
own).