### PR TITLE
cmd/github-post: increase the number of context lines

### DIFF
--- a/pkg/cmd/github-post/main.go
+++ b/pkg/cmd/github-post/main.go
@@ -79,7 +79,7 @@ func trimIssueRequestBody(message string, usedCharacters int) string {
 		// We want the top stack traces plus a few lines before.
 		{
 			startIdx := m[0]
-			for i := 0; i < 10; i++ {
+			for i := 0; i < 100; i++ {
 				if idx := strings.LastIndexByte(message[:startIdx], '\n'); idx != -1 {
 					startIdx = idx
 				}


### PR DESCRIPTION
Runtime panics (e.g. https://github.com/golang/go/issues/19305) produce
a stack trace that doesn't begin with a "goroutine" line, resulting in
an issue report that omits the important first bit of the failure. This
increases the constant number of context lines in an attempt to include
this information.

See https://github.com/cockroachdb/cockroach/issues/16054.