### PR TITLE
cmd: Add tool for parsing contents of gossip debug page

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -458,4 +458,19 @@ is the prefix for range local keys.`}
 		Name:        "replicated",
 		Description: "Restrict scan to replicated data.",
 	}
+
+	GossipInputFile = FlagInfo{
+		Name:      "file",
+		Shorthand: "f",
+		Description: `
+File containing the JSON output from a node's /_status/gossip/ endpoint.
+If specified, takes priority over host/port flags.`,
+	}
+
+	PrintSystemConfig = FlagInfo{
+		Name: "print-system-config",
+		Description: `
+If specified, print the system config contents. Beware that the output will be
+long and not particularly human-readable.`,
+	}
 )

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -261,8 +261,10 @@ func (k *mvccKey) Type() string {
 }
 
 type debugContext struct {
-	startKey, endKey engine.MVCCKey
-	values           bool
-	sizes            bool
-	replicated       bool
+	startKey, endKey  engine.MVCCKey
+	values            bool
+	sizes             bool
+	replicated        bool
+	inputFile         string
+	printSystemConfig bool
 }

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -304,6 +304,7 @@ func init() {
 	boolFlag(setUserCmd.Flags(), &password, cliflags.Password, false)
 
 	clientCmds := []*cobra.Command{
+		debugGossipValuesCmd,
 		debugZipCmd,
 		dumpCmd,
 		genHAProxyCmd,
@@ -375,9 +376,15 @@ func init() {
 		varFlag(f, (*mvccKey)(&debugCtx.endKey), cliflags.To)
 		boolFlag(f, &debugCtx.values, cliflags.Values, false)
 		boolFlag(f, &debugCtx.sizes, cliflags.Sizes, false)
-
-		f = debugRangeDataCmd.Flags()
+	}
+	{
+		f := debugRangeDataCmd.Flags()
 		boolFlag(f, &debugCtx.replicated, cliflags.Replicated, false)
+	}
+	{
+		f := debugGossipValuesCmd.Flags()
+		stringFlag(f, &debugCtx.inputFile, cliflags.GossipInputFile, "")
+		boolFlag(f, &debugCtx.printSystemConfig, cliflags.PrintSystemConfig, false)
 	}
 }
 


### PR DESCRIPTION
Fixes #13023 

The output looks like:
```
"cluster-id": a8995f48-5029-4705-b6d4-a01fdae347f3
"first-range": r1:/{Min-System/} [(n5,s5):3, (n3,s3):5, (n6,s6):7, next=8]
"liveness:1": {NodeID:1 Epoch:1 Expiration:1495137268.487952962,0 Draining:false}
"liveness:2": {NodeID:2 Epoch:3 Expiration:1495137265.687548343,0 Draining:false}
"liveness:3": {NodeID:3 Epoch:1 Expiration:1495137268.406753859,0 Draining:false}
"liveness:4": {NodeID:4 Epoch:1 Expiration:1495137267.467871337,0 Draining:false}
"liveness:5": {NodeID:5 Epoch:1 Expiration:1495137266.657675362,0 Draining:false}
"liveness:6": {NodeID:6 Epoch:3 Expiration:1495137266.872734133,0 Draining:false}
"node:1": {NodeID:1 Address:{NetworkField:tcp AddressField:10.197.64.1:26257} Attrs: Locality:}
"node:2": {NodeID:2 Address:{NetworkField:tcp AddressField:10.197.64.2:26257} Attrs: Locality:}
"node:3": {NodeID:3 Address:{NetworkField:tcp AddressField:10.197.64.4:26257} Attrs: Locality:}
"node:4": {NodeID:4 Address:{NetworkField:tcp AddressField:10.197.64.5:26257} Attrs: Locality:}
"node:5": {NodeID:5 Address:{NetworkField:tcp AddressField:10.197.64.6:26257} Attrs: Locality:}
"node:6": {NodeID:6 Address:{NetworkField:tcp AddressField:10.197.64.3:26257} Attrs: Locality:}
"sentinel": a8995f48-5029-4705-b6d4-a01fdae347f3
"store:1": {StoreID:1 Attrs: Node:{NodeID:1 Address:{NetworkField:tcp AddressField:10.197.64.1:26257} Attrs: Locality:} Capacity:{Capacity:984171765760 Available:933880942592 RangeCount:23 LeaseCount:9}}
"store:2": {StoreID:2 Attrs: Node:{NodeID:2 Address:{NetworkField:tcp AddressField:10.197.64.2:26257} Attrs: Locality:} Capacity:{Capacity:984171765760 Available:933824831488 RangeCount:23 LeaseCount:5}}
"store:3": {StoreID:3 Attrs: Node:{NodeID:3 Address:{NetworkField:tcp AddressField:10.197.64.4:26257} Attrs: Locality:} Capacity:{Capacity:984171765760 Available:934008590336 RangeCount:21 LeaseCount:3}}
"store:4": {StoreID:4 Attrs: Node:{NodeID:4 Address:{NetworkField:tcp AddressField:10.197.64.5:26257} Attrs: Locality:} Capacity:{Capacity:984171765760 Available:933885083648 RangeCount:23 LeaseCount:12}}
"store:5": {StoreID:5 Attrs: Node:{NodeID:5 Address:{NetworkField:tcp AddressField:10.197.64.6:26257} Attrs: Locality:} Capacity:{Capacity:984171765760 Available:934027681792 RangeCount:22 LeaseCount:8}}
"store:6": {StoreID:6 Attrs: Node:{NodeID:6 Address:{NetworkField:tcp AddressField:10.197.64.3:26257} Attrs: Locality:} Capacity:{Capacity:984171765760 Available:933934059520 RangeCount:20 LeaseCount:5}}
"system-db": omitted
```