### PR TITLE
ui: Use BaseURL to reduce relative imports

### DIFF
--- a/pkg/ui/src/components/alertBox.tsx
+++ b/pkg/ui/src/components/alertBox.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import classNames from "classnames";
 
-import { AlertInfo, AlertLevel } from "../redux/alerts";
-import { warningIcon, notificationIcon, criticalIcon } from "../components/icons";
-import { trustIcon } from "../util/trust";
+import { AlertInfo, AlertLevel } from "src/redux/alerts";
+import { warningIcon, notificationIcon, criticalIcon } from "src/components/icons";
+import { trustIcon } from "src/util/trust";
 
 function alertIcon (level: AlertLevel) {
   switch (level) {

--- a/pkg/ui/src/components/dropdown.tsx
+++ b/pkg/ui/src/components/dropdown.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import _ from "lodash";
 
 import {leftArrow, rightArrow} from "./icons";
-import { trustIcon } from "../util/trust";
+import { trustIcon } from "src/util/trust";
 
 export interface DropdownOption {
   value: string;

--- a/pkg/ui/src/components/graphGroup.tsx
+++ b/pkg/ui/src/components/graphGroup.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { MetricsDataProvider } from "../containers/metricsDataProvider";
+import { MetricsDataProvider } from "src/containers/metricsDataProvider";
 
 /**
  * GraphGroup is a stateless react component that wraps a group of graphs (the

--- a/pkg/ui/src/components/graphs.tsx
+++ b/pkg/ui/src/components/graphs.tsx
@@ -2,13 +2,13 @@ import React from "react";
 import _ from "lodash";
 import * as nvd3 from "nvd3";
 import * as d3 from "d3";
-import * as protos from "../js/protos";
 import Long from "long";
 import moment from "moment";
 
-import { NanoToMilli } from "../util/convert";
-import { Bytes, ComputePrefixExponent, Duration, kibi } from "../util/format";
-import { QueryTimeInfo } from "../containers/metricsDataProvider";
+import * as protos from "src/js/protos";
+import { NanoToMilli } from "src/util/convert";
+import { Bytes, ComputePrefixExponent, Duration, kibi } from "src/util/format";
+import { QueryTimeInfo } from "src/containers/metricsDataProvider";
 
 import { MetricProps } from "./metric";
 

--- a/pkg/ui/src/components/layoutSidebar.tsx
+++ b/pkg/ui/src/components/layoutSidebar.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ListLink, LinkProps } from "./listLink";
 import * as Icons from "./icons";
-import { trustIcon } from "../util/trust";
+import { trustIcon } from "src/util/trust";
 
 interface IconLinkProps extends LinkProps {
   icon?: string;

--- a/pkg/ui/src/components/linegraph.tsx
+++ b/pkg/ui/src/components/linegraph.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import * as nvd3 from "nvd3";
 import { createSelector } from "reselect";
 
-import { findChildrenOfType } from "../util/find";
+import { findChildrenOfType } from "src/util/find";
 import {
   MetricsDataComponentProps, Axis, AxisProps, ConfigureLineChart, InitLineChart,
   updateLinkedGuidelines,

--- a/pkg/ui/src/components/sortedtable.tsx
+++ b/pkg/ui/src/components/sortedtable.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import _ from "lodash";
 import { createSelector } from "reselect";
 
-import { SortableTable, SortableColumn, SortSetting } from "../components/sortabletable";
+import { SortableTable, SortableColumn, SortSetting } from "./sortabletable";
 
 /**
  * ColumnDescriptor is used to describe metadata about an individual column

--- a/pkg/ui/src/components/summaryBar.tsx
+++ b/pkg/ui/src/components/summaryBar.tsx
@@ -2,8 +2,8 @@ import _ from "lodash";
 import React from "react";
 import classNames from "classnames";
 
-import { MetricsDataProvider } from "../containers/metricsDataProvider";
-import { MetricsDataComponentProps } from "../components/graphs";
+import { MetricsDataProvider } from "src/containers/metricsDataProvider";
+import { MetricsDataComponentProps } from "./graphs";
 
 interface SummaryValueProps {
   title: React.ReactNode;

--- a/pkg/ui/src/components/visualization.tsx
+++ b/pkg/ui/src/components/visualization.tsx
@@ -1,5 +1,5 @@
 // tslint:disable-next-line:no-var-requires
-const spinner = require<string>("../../assets/spinner.gif");
+const spinner = require<string>("assets/spinner.gif");
 
 import React from "react";
 import classNames from "classnames";

--- a/pkg/ui/src/containers/alertBanner.tsx
+++ b/pkg/ui/src/containers/alertBanner.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import { Dispatch, bindActionCreators } from "redux";
 import { connect } from "react-redux";
 
-import { AlertBox } from "../components/alertBox";
-import { Alert, bannerAlertsSelector } from "../redux/alerts";
-import { AdminUIState } from "../redux/state";
+import { AlertBox } from "src/components/alertBox";
+import { Alert, bannerAlertsSelector } from "src/redux/alerts";
+import { AdminUIState } from "src/redux/state";
 
 interface AlertBannerProps {
   /**

--- a/pkg/ui/src/containers/alerts.tsx
+++ b/pkg/ui/src/containers/alerts.tsx
@@ -3,9 +3,9 @@ import _ from "lodash";
 import { Dispatch, bindActionCreators } from "redux";
 import { connect } from "react-redux";
 
-import { AlertBox } from "../components/alertBox";
-import { AdminUIState } from "../redux/state";
-import { Alert, panelAlertsSelector } from "../redux/alerts";
+import { AlertBox } from "src/components/alertBox";
+import { AdminUIState } from "src/redux/state";
+import { Alert, panelAlertsSelector } from "src/redux/alerts";
 
 interface AlertSectionProps {
   /**

--- a/pkg/ui/src/containers/clusterViz.tsx
+++ b/pkg/ui/src/containers/clusterViz.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {runVisualization, viewWidth, viewHeight} from "../js/sim/index";
+import {runVisualization, viewWidth, viewHeight} from "src/js/sim/index";
 
 /**
  * Renders the layout of the ClusterViz page. "ClusterViz" is an experimental

--- a/pkg/ui/src/containers/databases/data.tsx
+++ b/pkg/ui/src/containers/databases/data.tsx
@@ -1,4 +1,4 @@
-import * as protos from "../../js/protos";
+import * as protos from "src/js/protos";
 
 type TableDetailsResponse = protos.cockroach.server.serverpb.TableDetailsResponse;
 type TableStatsResponse = protos.cockroach.server.serverpb.TableStatsResponse;

--- a/pkg/ui/src/containers/databases/databaseGrants.tsx
+++ b/pkg/ui/src/containers/databases/databaseGrants.tsx
@@ -1,17 +1,17 @@
 import React from "react";
 import { connect } from "react-redux";
 
-import * as protos from  "../../js/protos";
+import * as protos from  "src/js/protos";
 
-import { SummaryBar, SummaryHeadlineStat } from "../../components/summaryBar";
-import { SortSetting } from "../../components/sortabletable";
-import { SortedTable } from "../../components/sortedtable";
+import { SummaryBar, SummaryHeadlineStat } from "src/components/summaryBar";
+import { SortSetting } from "src/components/sortabletable";
+import { SortedTable } from "src/components/sortedtable";
 
-import { AdminUIState } from "../../redux/state";
-import { LocalSetting } from "../../redux/localsettings";
+import { AdminUIState } from "src/redux/state";
+import { LocalSetting } from "src/redux/localsettings";
 import {
     refreshDatabaseDetails, refreshTableDetails, refreshTableStats,
-} from "../../redux/apiReducers";
+} from "src/redux/apiReducers";
 
 import {
     DatabaseSummaryBase, DatabaseSummaryExplicitData, databaseDetails, tableInfos, grants,

--- a/pkg/ui/src/containers/databases/databaseSummary.tsx
+++ b/pkg/ui/src/containers/databases/databaseSummary.tsx
@@ -1,12 +1,12 @@
 import _ from "lodash";
 import React from "react";
 
-import * as protos from "../../js/protos";
+import * as protos from "src/js/protos";
 
-import { AdminUIState } from "../../redux/state";
-import { refreshDatabaseDetails, refreshTableDetails, refreshTableStats, generateTableID} from "../../redux/apiReducers";
+import { AdminUIState } from "src/redux/state";
+import { refreshDatabaseDetails, refreshTableDetails, refreshTableStats, generateTableID} from "src/redux/apiReducers";
 
-import { SortSetting } from "../../components/sortabletable";
+import { SortSetting } from "src/components/sortabletable";
 
 import { TableInfo } from "./data";
 

--- a/pkg/ui/src/containers/databases/databaseTables.tsx
+++ b/pkg/ui/src/containers/databases/databaseTables.tsx
@@ -3,17 +3,17 @@ import React from "react";
 import { connect } from "react-redux";
 import { Link } from "react-router";
 
-import { SummaryBar, SummaryHeadlineStat } from "../../components/summaryBar";
-import { SortSetting } from "../../components/sortabletable";
-import { SortedTable } from "../../components/sortedtable";
+import { SummaryBar, SummaryHeadlineStat } from "src/components/summaryBar";
+import { SortSetting } from "src/components/sortabletable";
+import { SortedTable } from "src/components/sortedtable";
 
-import { AdminUIState } from "../../redux/state";
-import { LocalSetting } from "../../redux/localsettings";
+import { AdminUIState } from "src/redux/state";
+import { LocalSetting } from "src/redux/localsettings";
 import {
     refreshDatabaseDetails, refreshTableDetails, refreshTableStats,
-} from "../../redux/apiReducers";
+} from "src/redux/apiReducers";
 
-import { Bytes } from "../../util/format";
+import { Bytes } from "src/util/format";
 
 import { TableInfo } from "./data";
 

--- a/pkg/ui/src/containers/databases/databases.tsx
+++ b/pkg/ui/src/containers/databases/databases.tsx
@@ -4,11 +4,11 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { InjectedRouter, RouterState } from "react-router";
 
-import Dropdown, { DropdownOption } from "../../components/dropdown";
-import { PageConfig, PageConfigItem } from "../../components/pageconfig";
+import Dropdown, { DropdownOption } from "src/components/dropdown";
+import { PageConfig, PageConfigItem } from "src/components/pageconfig";
 
-import { AdminUIState } from "../../redux/state";
-import { refreshDatabases } from "../../redux/apiReducers";
+import { AdminUIState } from "src/redux/state";
+import { refreshDatabases } from "src/redux/apiReducers";
 
 import DatabaseSummaryTables from "./databaseTables";
 import DatabaseSummaryGrants from "./databaseGrants";

--- a/pkg/ui/src/containers/databases/tableDetails.tsx
+++ b/pkg/ui/src/containers/databases/tableDetails.tsx
@@ -2,17 +2,17 @@ import React from "react";
 import { RouterState, Link } from "react-router";
 import { connect } from "react-redux";
 
-import * as protos from "../../js/protos";
-import { databaseNameAttr, tableNameAttr } from "../../util/constants";
-import { Bytes } from "../../util/format";
-import { AdminUIState } from "../../redux/state";
-import { LocalSetting } from "../../redux/localsettings";
-import { refreshTableDetails, refreshTableStats, generateTableID } from "../../redux/apiReducers";
-import { SummaryBar, SummaryHeadlineStat } from "../../components/summaryBar";
+import * as protos from "src/js/protos";
+import { databaseNameAttr, tableNameAttr } from "src/util/constants";
+import { Bytes } from "src/util/format";
+import { AdminUIState } from "src/redux/state";
+import { LocalSetting } from "src/redux/localsettings";
+import { refreshTableDetails, refreshTableStats, generateTableID } from "src/redux/apiReducers";
+import { SummaryBar, SummaryHeadlineStat } from "src/components/summaryBar";
 
 import { TableInfo } from "./data";
-import { SortSetting } from "../../components/sortabletable";
-import { SortedTable } from "../../components/sortedtable";
+import { SortSetting } from "src/components/sortabletable";
+import { SortedTable } from "src/components/sortedtable";
 import * as hljs from "highlight.js";
 
 // Specialization of generic SortedTable component:

--- a/pkg/ui/src/containers/events.spec.tsx
+++ b/pkg/ui/src/containers/events.spec.tsx
@@ -5,10 +5,10 @@ import _ from "lodash";
 import Long from "long";
 import * as sinon from "sinon";
 
-import * as protos from  "../js/protos";
+import * as protos from  "src/js/protos";
 import { EventBoxUnconnected as EventBox, EventRow, getEventInfo } from "./events";
-import { refreshEvents } from "../redux/apiReducers";
-import { allEvents } from "../util/eventTypes";
+import { refreshEvents } from "src/redux/apiReducers";
+import { allEvents } from "src/util/eventTypes";
 
 type Event = protos.cockroach.server.serverpb.EventsResponse.Event;
 

--- a/pkg/ui/src/containers/events.tsx
+++ b/pkg/ui/src/containers/events.tsx
@@ -5,15 +5,15 @@ import { connect } from "react-redux";
 import moment from "moment";
 import * as protobuf from "protobufjs/minimal";
 
-import * as protos from "../js/protos";
+import * as protos from "src/js/protos";
 
-import { AdminUIState } from "../redux/state";
-import { refreshEvents } from "../redux/apiReducers";
-import { LocalSetting } from "../redux/localsettings";
-import { TimestampToMoment } from "../util/convert";
-import * as eventTypes from "../util/eventTypes";
-import { SortSetting } from "../components/sortabletable";
-import { SortedTable } from "../components/sortedtable";
+import { AdminUIState } from "src/redux/state";
+import { refreshEvents } from "src/redux/apiReducers";
+import { LocalSetting } from "src/redux/localsettings";
+import { TimestampToMoment } from "src/util/convert";
+import * as eventTypes from "src/util/eventTypes";
+import { SortSetting } from "src/components/sortabletable";
+import { SortedTable } from "src/components/sortedtable";
 
 type Event$Properties = protos.cockroach.server.serverpb.EventsResponse.Event$Properties;
 

--- a/pkg/ui/src/containers/layout.tsx
+++ b/pkg/ui/src/containers/layout.tsx
@@ -3,9 +3,9 @@ import _ from "lodash";
 import { RouterState } from "react-router";
 import { StickyContainer } from "react-sticky";
 
-import { TitledComponent } from "../interfaces/layout";
-import NavigationBar from "../components/layoutSidebar";
-import TimeWindowManager from "../containers/timewindow";
+import { TitledComponent } from "src/interfaces/layout";
+import NavigationBar from "src/components/layoutSidebar";
+import TimeWindowManager from "src/containers/timewindow";
 import AlertBanner from "./alertBanner";
 
 function isTitledComponent(obj: Object | TitledComponent): obj is TitledComponent {

--- a/pkg/ui/src/containers/metricsDataProvider.spec.tsx
+++ b/pkg/ui/src/containers/metricsDataProvider.spec.tsx
@@ -5,14 +5,14 @@ import _ from "lodash";
 import Long from "long";
 import * as sinon from "sinon";
 
-import * as protos from  "../js/protos";
-import { TextGraph, Axis } from "../components/graphs";
-import { Metric } from "../components/metric";
+import * as protos from  "src/js/protos";
+import { TextGraph, Axis } from "src/components/graphs";
+import { Metric } from "src/components/metric";
 import {
   MetricsDataProviderUnconnected as MetricsDataProvider,
   QueryTimeInfo,
 } from "./metricsDataProvider";
-import { queryMetrics, MetricsQuery } from "../redux/metrics";
+import { queryMetrics, MetricsQuery } from "src/redux/metrics";
 
 function makeDataProvider(
   id: string,

--- a/pkg/ui/src/containers/metricsDataProvider.tsx
+++ b/pkg/ui/src/containers/metricsDataProvider.tsx
@@ -5,13 +5,13 @@ import _ from "lodash";
 import Long from "long";
 import moment from "moment";
 
-import * as protos from  "../js/protos";
-import { AdminUIState } from "../redux/state";
-import { queryMetrics, MetricsQuery } from "../redux/metrics";
-import { MetricsDataComponentProps } from "../components/graphs";
-import { Metric, MetricProps } from "../components/metric";
-import { findChildrenOfType } from "../util/find";
-import { MilliToNano } from "../util/convert";
+import * as protos from  "src/js/protos";
+import { AdminUIState } from "src/redux/state";
+import { queryMetrics, MetricsQuery } from "src/redux/metrics";
+import { MetricsDataComponentProps } from "src/components/graphs";
+import { Metric, MetricProps } from "src/components/metric";
+import { findChildrenOfType } from "src/util/find";
+import { MilliToNano } from "src/util/convert";
 
 /**
  * queryFromProps is a helper method which generates a TimeSeries Query data

--- a/pkg/ui/src/containers/nodeGraphs.tsx
+++ b/pkg/ui/src/containers/nodeGraphs.tsx
@@ -6,22 +6,22 @@ import { connect } from "react-redux";
 
 import {
   nodeIDAttr, dashboardNameAttr,
-} from "../util/constants";
+} from "src/util/constants";
 
-import { AdminUIState } from "../redux/state";
-import { refreshNodes, refreshLiveness } from "../redux/apiReducers";
-import { nodesSummarySelector, NodesSummary } from "../redux/nodes";
-import GraphGroup from "../components/graphGroup";
+import { AdminUIState } from "src/redux/state";
+import { refreshNodes, refreshLiveness } from "src/redux/apiReducers";
+import { nodesSummarySelector, NodesSummary } from "src/redux/nodes";
+import GraphGroup from "src/components/graphGroup";
 import {
   SummaryBar, SummaryLabel, SummaryStat, SummaryStatMessage, SummaryStatBreakdown, SummaryMetricStat,
-} from "../components/summaryBar";
+} from "src/components/summaryBar";
 import Alerts from "./alerts";
-import { Axis, AxisUnits } from "../components/graphs";
-import { LineGraph } from "../components/linegraph";
-import { Metric } from "../components/metric";
-import { EventBox } from "../containers/events";
-import { Bytes } from "../util/format";
-import { NanoToMilli } from "../util/convert";
+import { Axis, AxisUnits } from "src/components/graphs";
+import { LineGraph } from "src/components/linegraph";
+import { Metric } from "src/components/metric";
+import { EventBox } from "src/containers/events";
+import { Bytes } from "src/util/format";
+import { NanoToMilli } from "src/util/convert";
 
 // The properties required by the NodeTotalsSummary component.
 interface NodeTotalsSummaryProps {

--- a/pkg/ui/src/containers/nodeLogs.tsx
+++ b/pkg/ui/src/containers/nodeLogs.tsx
@@ -1,16 +1,16 @@
 import _ from "lodash";
 import React from "react";
 import { RouterState, Link } from "react-router";
-import { AdminUIState } from "../redux/state";
-import { refreshLogs, refreshNodes } from "../redux/apiReducers";
 import { connect } from "react-redux";
 
-import * as protos from "../js/protos";
-import { NodeStatus$Properties } from "../util/proto";
-import { nodeIDAttr } from "../util/constants";
-import { LogEntriesResponseMessage } from "../util/api";
-import { LongToMoment } from "../util/convert";
-import { SortableTable } from "../components/sortabletable";
+import * as protos from "src/js/protos";
+import { NodeStatus$Properties } from "src/util/proto";
+import { nodeIDAttr } from "src/util/constants";
+import { LogEntriesResponseMessage } from "src/util/api";
+import { LongToMoment } from "src/util/convert";
+import { SortableTable } from "src/components/sortabletable";
+import { AdminUIState } from "src/redux/state";
+import { refreshLogs, refreshNodes } from "src/redux/apiReducers";
 
 import { currentNode } from "./nodeOverview";
 

--- a/pkg/ui/src/containers/nodeOverview.tsx
+++ b/pkg/ui/src/containers/nodeOverview.tsx
@@ -6,16 +6,16 @@ import _ from "lodash";
 
 import {
   NodesSummary, nodesSummarySelector, LivenessStatus,
-} from "../redux/nodes";
-import { nodeIDAttr } from "./../util/constants";
-import { AdminUIState } from "../redux/state";
-import { refreshNodes } from "../redux/apiReducers";
-import { NodeStatus$Properties, MetricConstants, StatusMetrics } from  "../util/proto";
-import { Bytes, Percentage } from "../util/format";
-import { LongToMoment } from "../util/convert";
+} from "src/redux/nodes";
+import { nodeIDAttr } from "src/util/constants";
+import { AdminUIState } from "src/redux/state";
+import { refreshNodes } from "src/redux/apiReducers";
+import { NodeStatus$Properties, MetricConstants, StatusMetrics } from  "src/util/proto";
+import { Bytes, Percentage } from "src/util/format";
+import { LongToMoment } from "src/util/convert";
 import {
   SummaryBar, SummaryLabel, SummaryValue,
-} from "../components/summaryBar";
+} from "src/components/summaryBar";
 
 interface NodeOverviewProps extends RouterState {
   node: NodeStatus$Properties;

--- a/pkg/ui/src/containers/nodes.tsx
+++ b/pkg/ui/src/containers/nodes.tsx
@@ -4,17 +4,17 @@ import PropTypes from "prop-types";
 import { InjectedRouter, RouterState } from "react-router";
 import { connect } from "react-redux";
 
-import * as protos from "../js/protos";
+import * as protos from "src/js/protos";
 
-import Dropdown, { DropdownOption } from "../components/dropdown";
-import { PageConfig, PageConfigItem } from "../components/pageconfig";
+import Dropdown, { DropdownOption } from "src/components/dropdown";
+import { PageConfig, PageConfigItem } from "src/components/pageconfig";
 
-import { refreshNodes } from "../redux/apiReducers";
-import { AdminUIState } from "../redux/state";
+import { refreshNodes } from "src/redux/apiReducers";
+import { AdminUIState } from "src/redux/state";
 
 import {
   nodeIDAttr, dashboardNameAttr,
-} from "../util/constants";
+} from "src/util/constants";
 
 import TimeScaleDropdown from "./timescale";
 

--- a/pkg/ui/src/containers/nodesOverview.tsx
+++ b/pkg/ui/src/containers/nodesOverview.tsx
@@ -7,16 +7,16 @@ import _ from "lodash";
 
 import {
   NodesSummary, nodesSummarySelector, LivenessStatus, deadTimeout,
-} from "../redux/nodes";
-import { SummaryBar, SummaryHeadlineStat } from "../components/summaryBar";
-import { AdminUIState } from "../redux/state";
-import { refreshNodes, refreshLiveness } from "../redux/apiReducers";
-import { LocalSetting } from "../redux/localsettings";
-import { SortSetting } from "../components/sortabletable";
-import { SortedTable } from "../components/sortedtable";
-import { NanoToMilli, LongToMoment } from "../util/convert";
-import { Bytes } from "../util/format";
-import { NodeStatus$Properties, MetricConstants, BytesUsed } from  "../util/proto";
+} from "src/redux/nodes";
+import { SummaryBar, SummaryHeadlineStat } from "src/components/summaryBar";
+import { AdminUIState } from "src/redux/state";
+import { refreshNodes, refreshLiveness } from "src/redux/apiReducers";
+import { LocalSetting } from "src/redux/localsettings";
+import { SortSetting } from "src/components/sortabletable";
+import { SortedTable } from "src/components/sortedtable";
+import { NanoToMilli, LongToMoment } from "src/util/convert";
+import { Bytes } from "src/util/format";
+import { NodeStatus$Properties, MetricConstants, BytesUsed } from  "src/util/proto";
 
 const liveNodesSortSetting = new LocalSetting<AdminUIState, SortSetting>(
   "nodes/live_sort_setting", (s) => s.localSettings,

--- a/pkg/ui/src/containers/queryPlan.tsx
+++ b/pkg/ui/src/containers/queryPlan.tsx
@@ -8,11 +8,11 @@ import CodeMirror from "react-codemirror";
 // This import makes SQL highlighting info available to CodeMirror.
 import "codemirror/mode/sql/sql";
 
-import * as protos from "../js/protos";
-import { AdminUIState } from "../redux/state";
-import { refreshQueryPlan } from "../redux/apiReducers";
+import * as protos from "src/js/protos";
+import { AdminUIState } from "src/redux/state";
+import { refreshQueryPlan } from "src/redux/apiReducers";
 
-import { QueryPlanGraph } from "../components/queryPlanGraph";
+import { QueryPlanGraph } from "src/components/queryPlanGraph";
 
 // Constants used to store per-page sort settings in the redux UI store.
 export const UI_QUERY_PLAN_SOURCE_STRING_KEY = "queryPlan/query";

--- a/pkg/ui/src/containers/raft.tsx
+++ b/pkg/ui/src/containers/raft.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ListLink } from "../components/listLink";
+import { ListLink } from "src/components/listLink";
 
 /**
  * Renders the layout of the nodes page.

--- a/pkg/ui/src/containers/raftRanges.tsx
+++ b/pkg/ui/src/containers/raftRanges.tsx
@@ -4,12 +4,12 @@ import ReactPaginate from "react-paginate";
 import { Link } from "react-router";
 import { connect } from "react-redux";
 
-import * as protos from "../js/protos";
+import * as protos from "src/js/protos";
 
-import { AdminUIState } from "../redux/state";
-import { refreshRaft } from "../redux/apiReducers";
-import { CachedDataReducerState } from "../redux/cachedDataReducer";
-import { ToolTipWrapper } from "../components/toolTip";
+import { AdminUIState } from "src/redux/state";
+import { refreshRaft } from "src/redux/apiReducers";
+import { CachedDataReducerState } from "src/redux/cachedDataReducer";
+import { ToolTipWrapper } from "src/components/toolTip";
 
 /******************************
  *   RAFT RANGES MAIN COMPONENT

--- a/pkg/ui/src/containers/timescale.tsx
+++ b/pkg/ui/src/containers/timescale.tsx
@@ -3,15 +3,15 @@ import { connect } from "react-redux";
 import _ from "lodash";
 import moment from "moment";
 
-import Dropdown, { DropdownOption, ArrowDirection } from "../components/dropdown";
+import Dropdown, { DropdownOption, ArrowDirection } from "src/components/dropdown";
 
-import { AdminUIState } from "../redux/state";
-import { refreshNodes } from "../redux/apiReducers";
-import * as timewindow from "../redux/timewindow";
-import { LocalSetting } from "../redux/localsettings";
+import { AdminUIState } from "src/redux/state";
+import { refreshNodes } from "src/redux/apiReducers";
+import * as timewindow from "src/redux/timewindow";
+import { LocalSetting } from "src/redux/localsettings";
 
-import { NodeStatus$Properties } from "../util/proto";
-import { LongToMoment } from "../util/convert";
+import { NodeStatus$Properties } from "src/util/proto";
+import { LongToMoment } from "src/util/convert";
 
 // Tracks whether the default timescale been set once in the app. Tracked across
 // the entire app so that changing pages doesn't cause it to reset.

--- a/pkg/ui/src/containers/timewindow.spec.tsx
+++ b/pkg/ui/src/containers/timewindow.spec.tsx
@@ -6,7 +6,7 @@ import moment from "moment";
 import _ from "lodash";
 
 import { TimeWindowManagerUnconnected as TimeWindowManager } from "./timewindow";
-import * as timewindow from "../redux/timewindow";
+import * as timewindow from "src/redux/timewindow";
 
 describe("<TimeWindowManager>", function() {
   let spy: sinon.SinonSpy;

--- a/pkg/ui/src/containers/timewindow.tsx
+++ b/pkg/ui/src/containers/timewindow.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { connect } from "react-redux";
 import moment from "moment";
 
-import { AdminUIState } from "../redux/state";
-import * as timewindow from "../redux/timewindow";
+import { AdminUIState } from "src/redux/state";
+import * as timewindow from "src/redux/timewindow";
 
 interface TimeWindowManagerProps {
   // The current timewindow redux state.

--- a/pkg/ui/src/index.tsx
+++ b/pkg/ui/src/index.tsx
@@ -1,71 +1,11 @@
 /// <reference path="../node_modules/protobufjs/stub-node.d.ts" />
 
-/**
- * UI/NEXT TODO LIST
- *
- * ! = Potentially difficult to implement
- *
- * - All Pages / Shared Components
- *    - "Last Updated"
- *    - Dropdowns
- *      - Fix 1px offset bug
- *    - Tables
- *      - CSS Match to design
- *      - Management of column widths
- * - Cluster Page
- *    - Alert notifications
- *      - Mismatched/Out-of-date Version
- *      - Help us
- *    - Right-side Summary Section
- *      - Link to Nodes page
- *      - Events?
- *    - Graphs
- *      - Tooltip when hover over title
- *    - Code block syntax highlighting
- *      - Choose keywords correctly
- *      - Fix bug on direct page load
- * - Databases Page
- *    - Last Updated Column
- *      - Retrieve/Filter events
- *    - Single database page
- *       - Table component row limit
- *       - Route to single database
- *    - Schema Change
- *      - Retrieve information from backend
- *      - Display in table list column
- *      - Display alert on table details page
- *    - Table details page
- *      - Schema Change notification
- *      - Fill out summary stats
- *      - Back Button
- *      - Column widths for grants table
- * - Nodes page
- *  - Table Style
- *  - Add Summary Section
- *  - Remove Link from Navigation Bar
- * - Helpus Page
- *  - New Navigation Bar Icon
- *  - Header links
- *  - New form field Appearance
- *
- * NICE TO HAVE:
- *  - Create a "NodeStatusProvider" similar to "MetricsDataProvider", allowing
- *  different components to access nodes data.
- *
- *  - Commonize code between different graph types (LineGraph and
- *  StackedAreaGraph). This can likely be done by converting them into stateless
- *  functions, that return an underlying "Common" graph component. The props of
- *  the Common graph component would include the part of `initGraph` and
- *  `drawGraph` that are different for these two chart types.
- *
- */
-
 import "codemirror/lib/codemirror.css";
 import "codemirror/theme/neat.css";
 import "nvd3/build/nv.d3.min.css";
 import "react-select/dist/react-select.css";
-import "../styl/app.styl";
-import "./js/sim/style.css";
+import "styl/app.styl";
+import "src/js/sim/style.css";
 
 import * as protobuf from "protobufjs/minimal";
 import Long from "long";
@@ -80,23 +20,23 @@ import { Router, Route, IndexRoute, IndexRedirect } from "react-router";
 
 import {
   tableNameAttr, databaseNameAttr, nodeIDAttr, dashboardNameAttr,
-} from "./util/constants";
+} from "src/util/constants";
 
-import { store, history } from "./redux/state";
-import Layout from "./containers/layout";
-import { DatabaseTablesList, DatabaseGrantsList } from "./containers/databases/databases";
-import TableDetails from "./containers/databases/tableDetails";
-import Nodes from "./containers/nodes";
-import NodesOverview from "./containers/nodesOverview";
-import NodeOverview from "./containers/nodeOverview";
-import NodeGraphs from "./containers/nodeGraphs";
-import NodeLogs from "./containers/nodeLogs";
-import { EventPage } from "./containers/events";
-import QueryPlan from "./containers/queryPlan";
-import Raft from "./containers/raft";
-import RaftRanges from "./containers/raftRanges";
-import ClusterViz from "./containers/clusterViz";
-import { alertDataSync } from "./redux/alerts";
+import { store, history } from "src/redux/state";
+import Layout from "src/containers/layout";
+import { DatabaseTablesList, DatabaseGrantsList } from "src/containers/databases/databases";
+import TableDetails from "src/containers/databases/tableDetails";
+import Nodes from "src/containers/nodes";
+import NodesOverview from "src/containers/nodesOverview";
+import NodeOverview from "src/containers/nodeOverview";
+import NodeGraphs from "src/containers/nodeGraphs";
+import NodeLogs from "src/containers/nodeLogs";
+import { EventPage } from "src/containers/events";
+import QueryPlan from "src/containers/queryPlan";
+import Raft from "src/containers/raft";
+import RaftRanges from "src/containers/raftRanges";
+import ClusterViz from "src/containers/clusterViz";
+import { alertDataSync } from "src/redux/alerts";
 
 ReactDOM.render(
   <Provider store={store}>

--- a/pkg/ui/src/redux/alerts.spec.ts
+++ b/pkg/ui/src/redux/alerts.spec.ts
@@ -1,10 +1,10 @@
 import { assert } from "chai";
-import fetchMock from "../util/fetch-mock";
+import fetchMock from "src/util/fetch-mock";
 import { Store } from "redux";
 import moment from "moment";
 
-import * as protos from "../js/protos";
-import { API_PREFIX } from "../util/api";
+import * as protos from "src/js/protos";
+import { API_PREFIX } from "src/util/api";
 import { AdminUIState, createAdminUIStore } from "./state";
 import {
   AlertLevel,

--- a/pkg/ui/src/redux/apiReducers.spec.ts
+++ b/pkg/ui/src/redux/apiReducers.spec.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 import { generateTableID, databaseRequestToID, tableRequestToID } from "./apiReducers";
-import * as protos from "../js/protos";
+import * as protos from "src/js/protos";
 
 describe("table id generator", function () {
   it("generates encoded db/table id", function () {

--- a/pkg/ui/src/redux/apiReducers.ts
+++ b/pkg/ui/src/redux/apiReducers.ts
@@ -3,10 +3,10 @@ import { combineReducers } from "redux";
 import moment from "moment";
 
 import { CachedDataReducer, CachedDataReducerState, KeyedCachedDataReducer, KeyedCachedDataReducerState } from "./cachedDataReducer";
-import * as api from "../util/api";
-import { VersionList } from "../interfaces/cockroachlabs";
-import { versionCheck } from "../util/cockroachlabsAPI";
-import { NodeStatus$Properties, RollupStoreMetrics } from "../util/proto";
+import * as api from "src/util/api";
+import { VersionList } from "src/interfaces/cockroachlabs";
+import { versionCheck } from "src/util/cockroachlabsAPI";
+import { NodeStatus$Properties, RollupStoreMetrics } from "src/util/proto";
 
 // The primary export of this file are the "refresh" functions of the various
 // reducers, which are used by many react components to request fresh data.

--- a/pkg/ui/src/redux/cachedDataReducer.ts
+++ b/pkg/ui/src/redux/cachedDataReducer.ts
@@ -9,9 +9,9 @@ import { Action, Dispatch } from "redux";
 import { assert } from "chai";
 import moment from "moment";
 
-import { APIRequestFn } from "../util/api";
+import { APIRequestFn } from "src/util/api";
 
-import { PayloadAction, WithRequest } from "../interfaces/action";
+import { PayloadAction, WithRequest } from "src/interfaces/action";
 
 // CachedDataReducerState is used to track the state of the cached data.
 export class CachedDataReducerState<TResponseMessage> {

--- a/pkg/ui/src/redux/localsettings.ts
+++ b/pkg/ui/src/redux/localsettings.ts
@@ -12,7 +12,7 @@
 import _ from "lodash";
 import { createSelector, Selector } from "reselect";
 import { Action } from "redux";
-import { PayloadAction } from "../interfaces/action";
+import { PayloadAction } from "src/interfaces/action";
 
 const SET_UI_VALUE = "cockroachui/ui/SET_UI_VALUE";
 

--- a/pkg/ui/src/redux/metrics.spec.ts
+++ b/pkg/ui/src/redux/metrics.spec.ts
@@ -2,10 +2,10 @@ import { assert } from "chai";
 import _ from "lodash";
 import Long from "long";
 import { Action } from "redux";
-import fetchMock from "../util/fetch-mock";
+import fetchMock from "src/util/fetch-mock";
 
-import * as protos from "../js/protos";
-import * as api from "../util/api";
+import * as protos from "src/js/protos";
+import * as api from "src/util/api";
 import * as metrics from "./metrics";
 import reducer from "./metrics";
 

--- a/pkg/ui/src/redux/metrics.ts
+++ b/pkg/ui/src/redux/metrics.ts
@@ -8,9 +8,9 @@
 import _ from "lodash";
 import { Action, Dispatch } from "redux";
 
-import * as protos from  "../js/protos";
-import { PayloadAction } from "../interfaces/action";
-import { queryTimeSeries } from "../util/api";
+import * as protos from  "src/js/protos";
+import { PayloadAction } from "src/interfaces/action";
+import { queryTimeSeries } from "src/util/api";
 
 type TSRequest = protos.cockroach.ts.tspb.TimeSeriesQueryRequest;
 type TSResponse = protos.cockroach.ts.tspb.TimeSeriesQueryResponse;

--- a/pkg/ui/src/redux/nodes.ts
+++ b/pkg/ui/src/redux/nodes.ts
@@ -3,9 +3,9 @@ import _ from "lodash";
 import { createSelector } from "reselect";
 
 import { AdminUIState } from "./state";
-import { NanoToMilli } from "../util/convert";
-import { NodeStatus$Properties, MetricConstants, BytesUsed } from "../util/proto";
-import { nullOfReturnType } from "../util/types";
+import { NanoToMilli } from "src/util/convert";
+import { NodeStatus$Properties, MetricConstants, BytesUsed } from "src/util/proto";
+import { nullOfReturnType } from "src/util/types";
 
 /**
  * deadTimeout indicates a grace-period duration where nodes are still

--- a/pkg/ui/src/redux/timewindow.ts
+++ b/pkg/ui/src/redux/timewindow.ts
@@ -4,7 +4,7 @@
  */
 
 import { Action } from "redux";
-import { PayloadAction } from "../interfaces/action";
+import { PayloadAction } from "src/interfaces/action";
 import _ from "lodash";
 import moment from "moment";
 

--- a/pkg/ui/src/redux/uiData.spec.ts
+++ b/pkg/ui/src/redux/uiData.spec.ts
@@ -2,10 +2,10 @@ import { assert } from "chai";
 import _ from "lodash";
 import { Action } from "redux";
 import * as protobuf from "protobufjs/minimal";
-import fetchMock from "../util/fetch-mock";
+import fetchMock from "src/util/fetch-mock";
 
-import * as protos from "../js/protos";
-import * as api from "../util/api";
+import * as protos from "src/js/protos";
+import * as api from "src/util/api";
 import reducer from "./uiData";
 import * as uidata from "./uiData";
 

--- a/pkg/ui/src/redux/uiData.ts
+++ b/pkg/ui/src/redux/uiData.ts
@@ -2,9 +2,9 @@ import _ from "lodash";
 import { Action, Dispatch } from "redux";
 import * as protobuf from "protobufjs/minimal";
 
-import * as protos from  "../js/protos";
-import { PayloadAction } from "../interfaces/action";
-import { getUIData, setUIData } from "../util/api";
+import * as protos from  "src/js/protos";
+import { PayloadAction } from "src/interfaces/action";
+import { getUIData, setUIData } from "src/util/api";
 import { AdminUIState } from "./state";
 
 export const SET = "cockroachui/uidata/SET_OPTIN";

--- a/pkg/ui/src/util/api.spec.ts
+++ b/pkg/ui/src/util/api.spec.ts
@@ -3,9 +3,9 @@ import _ from "lodash";
 import moment from "moment";
 import Long from "long";
 
-import fetchMock from "../util/fetch-mock";
+import fetchMock from "./fetch-mock";
 
-import * as protos from "../js/protos";
+import * as protos from "src/js/protos";
 import * as api from "./api";
 
 describe("rest api", function() {

--- a/pkg/ui/src/util/api.ts
+++ b/pkg/ui/src/util/api.ts
@@ -6,7 +6,7 @@ import _ from "lodash";
 import "whatwg-fetch"; // needed for jsdom?
 import moment from "moment";
 
-import * as protos from "../js/protos";
+import * as protos from "src/js/protos";
 
 export type DatabasesRequestMessage = protos.cockroach.server.serverpb.DatabasesRequest;
 export type DatabasesResponseMessage = protos.cockroach.server.serverpb.DatabasesResponse;

--- a/pkg/ui/src/util/cockroachlabsAPI.ts
+++ b/pkg/ui/src/util/cockroachlabsAPI.ts
@@ -5,7 +5,9 @@
 import "whatwg-fetch"; // needed for jsdom?
 import moment from "moment";
 
-import { VersionList, VersionCheckRequest, RegistrationRequest, UnregistrationRequest } from "../interfaces/cockroachlabs";
+import {
+  VersionList, VersionCheckRequest, RegistrationRequest, UnregistrationRequest,
+} from "src/interfaces/cockroachlabs";
 import { withTimeout } from "./api";
 
 export const COCKROACHLABS_ADDR = "https://register.cockroachdb.com";

--- a/pkg/ui/src/util/convert.ts
+++ b/pkg/ui/src/util/convert.ts
@@ -1,6 +1,6 @@
 import moment from "moment";
 
-import * as protos from "../js/protos";
+import * as protos from "src/js/protos";
 
 /**
  * NanoToMilli converts a nanoseconds value into milliseconds.

--- a/pkg/ui/src/util/eventTypes.ts
+++ b/pkg/ui/src/util/eventTypes.ts
@@ -2,7 +2,7 @@
 
 import _ from "lodash";
 
-import * as protos from "../js/protos";
+import * as protos from "src/js/protos";
 
 type Event = protos.cockroach.server.serverpb.EventsResponse.Event;
 

--- a/pkg/ui/src/util/fetch-mock.ts
+++ b/pkg/ui/src/util/fetch-mock.ts
@@ -1,4 +1,4 @@
-import "../js/object-assign";
+import "src/js/object-assign";
 import fetchMock from "fetch-mock";
 
 fetchMock.configure({

--- a/pkg/ui/src/util/proto.ts
+++ b/pkg/ui/src/util/proto.ts
@@ -1,6 +1,6 @@
 import _ from "lodash";
 
-import * as protos from "../js/protos";
+import * as protos from "src/js/protos";
 
 export type NodeStatus$Properties = protos.cockroach.server.status.NodeStatus$Properties;
 const nodeStatus: NodeStatus$Properties = null;

--- a/pkg/ui/tsconfig.json
+++ b/pkg/ui/tsconfig.json
@@ -15,6 +15,13 @@
     "outDir": "./dist/",
     "sourceMap": true,
     "strictNullChecks": false,
-    "target": "es6"
+    "target": "es6",
+    "baseUrl": ".",
+    "paths": {
+      "*": [
+        "*",
+        "node_modules/*"
+      ]
+    }
   }
 }

--- a/pkg/ui/webpack.config.js
+++ b/pkg/ui/webpack.config.js
@@ -1,5 +1,6 @@
 'use strict;'
 
+const path = require('path');
 const rimraf = require('rimraf');
 
 const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
@@ -28,8 +29,15 @@ module.exports = {
   },
 
   resolve: {
-    // Add '.ts' and '.tsx' as resolvable extensions.
-    extensions: ['.ts', '.tsx', '.js', '.json'],
+    // Add resolvable extensions.
+    extensions: ['.ts', '.tsx', '.js', '.json', '.styl', '.css'],
+    // Resolve modules from src directory or node_modules.
+    // The 'path.resolve' is used to make these into absolute paths, meaning
+    // that only the exact directory is checked. A relative path would follow
+    // the resolution behavior used by node.js for "node_modules", which checks
+    // for a "node_modules" child directory located in either the current
+    // directory *or in any parent directory*.
+    modules: [path.resolve(__dirname), path.resolve(__dirname, "node_modules")]
   },
 
   module: {


### PR DESCRIPTION
This commit uses typescript's `baseUrl` setting, in combination with
webpack's `resolver` settings, in order to eliminate nearly all
cross-directory relative imports (i.e. uses of "../").

In this configuration, typescript and webpack look for non-relative
imports in two locations: the '/src' directory and the '/node_modules'
directory, in that order.  This allows all cross-folder imports within
the cockroach code to be expressed with non-relative notation, which
will make upcoming code refactoring much easier.

Relative imports are still used to reference files in the same folder
(i.e. using "./" with a single dot).

There are a few uses of "../" imports remaining in the project, but they
are not importing code - they are importing non-code cockroachDB assets
which are located outside of the "/src" directory. Those asset
directories could be added to the resolution order in webpack, but since
they are so few in number I would like to continue with upcoming code
refactors to see how the directory structure is changed.