### PR TITLE
engine: use an in-memory rocksdb for RocksDBSstFileReader

### DIFF
--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -163,6 +163,14 @@ func evalExport(
 	return storage.EvalResult{}, nil
 }
 
+func sha512ChecksumData(data []byte) ([]byte, error) {
+	h := sha512.New()
+	if _, err := h.Write(data); err != nil {
+		panic(errors.Wrap(err, `"It never returns an error." -- https://golang.org/pkg/hash`))
+	}
+	return h.Sum(nil), nil
+}
+
 func sha512ChecksumFile(path string) ([]byte, error) {
 	h := sha512.New()
 	f, err := os.Open(path)

--- a/pkg/storage/engine/db.h
+++ b/pkg/storage/engine/db.h
@@ -256,8 +256,9 @@ DBSSTable* DBGetSSTables(DBEngine* db, int* n);
 DBString DBGetUserProperties(DBEngine* db);
 
 // Bulk adds the file at the given path to a database. See the RocksDB
-// documentation on `AddFile` for the various restrictions on what can be added.
-DBStatus DBEngineAddFile(DBEngine* db, DBSlice path);
+// documentation on `IngestExternalFile` for the various restrictions on what
+// can be added.
+DBStatus DBIngestExternalFile(DBEngine* db, DBSlice path);
 
 typedef struct DBSstFileWriter DBSstFileWriter;
 
@@ -278,6 +279,9 @@ DBStatus DBSstFileWriterAdd(DBSstFileWriter* fw, DBKey key, DBSlice val);
 DBStatus DBSstFileWriterClose(DBSstFileWriter* fw);
 
 void DBRunLDB(int argc, char** argv);
+
+// DBEnvWriteFile writes the given data as a new "file" in the given engine.
+DBStatus DBEnvWriteFile(DBEngine* db, DBSlice path, DBSlice contents);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1716,34 +1716,34 @@ func dbIterate(
 // RocksDBSstFileReader allows iteration over a number of non-overlapping
 // sstables exported by `RocksDBSstFileWriter`.
 type RocksDBSstFileReader struct {
-	// TODO(dan): This currently works by creating a RocksDB instance in a
-	// temporary directory that's cleaned up on `Close`. It doesn't appear that
-	// we can use an in-memory RocksDB with this, because AddFile doesn't then
-	// work with files on disk. This should also work with overlapping files.
-
-	rocksDB *RocksDB
+	rocksDB         InMem
+	filenameCounter int
 }
 
-// MakeRocksDBSstFileReader creates a RocksDBSstFileReader that uses a scratch
-// directory which is cleaned up by `Close`.
-func MakeRocksDBSstFileReader(tempdir string) (RocksDBSstFileReader, error) {
-	// TODO(dan): I pulled all these magic numbers out of nowhere. Make them
-	// less magic.
-	cache := NewRocksDBCache(1 << 20)
-	rocksDB, err := NewRocksDB(roachpb.Attributes{}, tempdir, cache, 512<<20, DefaultMaxOpenFiles)
-	if err != nil {
-		return RocksDBSstFileReader{}, err
-	}
-	return RocksDBSstFileReader{rocksDB}, nil
+// MakeRocksDBSstFileReader creates a RocksDBSstFileReader backed by an
+// in-memory RocksDB instance.
+func MakeRocksDBSstFileReader() RocksDBSstFileReader {
+	// cacheSize was selected because it's used for almost all other NewInMem
+	// calls. It's seemed to work well so far, but there's probably more tuning
+	// to be done here.
+	const cacheSize = 1 << 20
+	return RocksDBSstFileReader{rocksDB: NewInMem(roachpb.Attributes{}, cacheSize)}
 }
 
-// AddFile links the file at the given path into a database. See the RocksDB
-// documentation on `AddFile` for the various restrictions on what can be added.
-func (fr *RocksDBSstFileReader) AddFile(path string) error {
-	if fr.rocksDB == nil {
-		return errors.New("cannot call AddFile on a closed reader")
+// IngestExternalFile links a file with the given contents into a database. See
+// the RocksDB documentation on `IngestExternalFile` for the various
+// restrictions on what can be added.
+func (fr *RocksDBSstFileReader) IngestExternalFile(data []byte) error {
+	if fr.rocksDB.RocksDB == nil {
+		return errors.New("cannot call IngestExternalFile on a closed reader")
 	}
-	return statusToError(C.DBEngineAddFile(fr.rocksDB.rdb, goToCSlice([]byte(path))))
+
+	filename := fmt.Sprintf("ingest-%d", fr.filenameCounter)
+	fr.filenameCounter++
+	if err := fr.rocksDB.WriteFile(filename, data); err != nil {
+		return err
+	}
+	return statusToError(C.DBIngestExternalFile(fr.rocksDB.rdb, goToCSlice([]byte(filename))))
 }
 
 // Iterate iterates over the keys between start inclusive and end
@@ -1751,7 +1751,7 @@ func (fr *RocksDBSstFileReader) AddFile(path string) error {
 func (fr *RocksDBSstFileReader) Iterate(
 	start, end MVCCKey, f func(MVCCKeyValue) (bool, error),
 ) error {
-	if fr.rocksDB == nil {
+	if fr.rocksDB.RocksDB == nil {
 		return errors.New("cannot call Iterate on a closed reader")
 	}
 	return fr.rocksDB.Iterate(start, end, f)
@@ -1764,11 +1764,11 @@ func (fr *RocksDBSstFileReader) NewIterator(prefix bool) Iterator {
 
 // Close finishes the reader.
 func (fr *RocksDBSstFileReader) Close() {
-	if fr.rocksDB == nil {
+	if fr.rocksDB.RocksDB == nil {
 		return
 	}
-	fr.rocksDB.Close()
-	fr.rocksDB = nil
+	fr.rocksDB.RocksDB.Close()
+	fr.rocksDB.RocksDB = nil
 }
 
 // RocksDBSstFileWriter creates a file suitable for importing with
@@ -1846,4 +1846,9 @@ func (r *RocksDB) SetTempDir(d string) error {
 	}
 	r.tempDir = d
 	return nil
+}
+
+// WriteFile writes data to a file in this RocksDB's env.
+func (r *RocksDB) WriteFile(filename string, data []byte) error {
+	return statusToError(C.DBEnvWriteFile(r.rdb, goToCSlice([]byte(filename)), goToCSlice(data)))
 }

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -515,22 +515,14 @@ func BenchmarkRocksDBSstFileReader(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	readerTempDir, err := ioutil.TempDir(dir, "RocksDBSstFileReader")
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer func() {
-		if err := os.RemoveAll(readerTempDir); err != nil {
-			b.Fatal(err)
-		}
-	}()
-
-	sst, err := MakeRocksDBSstFileReader(readerTempDir)
-	if err != nil {
-		b.Fatal(err)
-	}
+	sst := MakeRocksDBSstFileReader()
 	defer sst.Close()
-	if err := sst.AddFile(sstPath); err != nil {
+
+	sstContents, err := ioutil.ReadFile(sstPath)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := sst.IngestExternalFile(sstContents); err != nil {
 		b.Fatal(err)
 	}
 	count := 0


### PR DESCRIPTION
This is accomplished by adding a new method to write files to the in-memory env
used by the SstFileReader's RocksDB instance. In addition to being way more
convenient, this allows us to avoid writing the pre-rekey sstables to disk in
Import, reducing disk usage.