### PR TITLE
sql: error on result type changes in prepared statements

### DIFF
--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -82,7 +82,7 @@ func (s stmtKey) flags() string {
 }
 
 func (a *appStats) recordStatement(
-	stmt parser.Statement,
+	stmt Statement,
 	distSQLUsed bool,
 	automaticRetryCount int,
 	numRows int,
@@ -99,7 +99,7 @@ func (a *appStats) recordStatement(
 
 	// Some statements like SET, SHOW etc are not useful to collect
 	// stats about. Ignore them.
-	if _, ok := stmt.(parser.HiddenFromStats); ok {
+	if _, ok := stmt.AST.(parser.HiddenFromStats); ok {
 		return
 	}
 
@@ -108,7 +108,7 @@ func (a *appStats) recordStatement(
 	// that we use separate buckets for the different situations.
 	var buf bytes.Buffer
 
-	parser.FormatNode(&buf, parser.FmtHideConstants, stmt)
+	parser.FormatNode(&buf, parser.FmtHideConstants, stmt.AST)
 
 	// Get the statistics object.
 	s := a.getStatsForStmt(stmtKey{stmt: buf.String(), failed: err != nil, distSQLUsed: distSQLUsed})

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -141,7 +141,7 @@ var (
 // to the internal state after this call.
 func (s *Session) ProcessCopyData(
 	ctx context.Context, data string, msg copyMsg,
-) (parser.StatementList, error) {
+) (StatementList, error) {
 	cf := s.copyFrom
 	buf := cf.buf
 
@@ -154,7 +154,7 @@ func (s *Session) ProcessCopyData(
 		if buf.Len() > 0 {
 			err = cf.addRow(ctx, buf.Bytes())
 		}
-		return parser.StatementList{CopyDataBlock{Done: true}}, err
+		return StatementList{{AST: CopyDataBlock{Done: true}}}, err
 	default:
 		return nil, fmt.Errorf("expected copy command")
 	}
@@ -181,7 +181,7 @@ func (s *Session) ProcessCopyData(
 			return nil, err
 		}
 	}
-	return parser.StatementList{CopyDataBlock{}}, nil
+	return StatementList{{AST: CopyDataBlock{}}}, nil
 }
 
 func (n *copyNode) addRow(ctx context.Context, line []byte) error {

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -425,7 +425,7 @@ func (e *Executor) getDatabaseCache() *databaseCache {
 // nil if there are no results). An error is returned if there is more than
 // one statement in the statement list.
 func (e *Executor) Prepare(
-	stmts parser.StatementList, session *Session, pinfo parser.PlaceholderTypes,
+	stmts StatementList, session *Session, pinfo parser.PlaceholderTypes,
 ) (*PreparedStatement, error) {
 	session.resetForBatch(e)
 	sessionEventf(session, "preparing: %s", stmts)
@@ -442,7 +442,7 @@ func (e *Executor) Prepare(
 	default:
 		return nil, errWrongNumberOfPreparedStatements(len(stmts))
 	}
-	stmt := stmts[0]
+	stmt := stmts[0].AST
 	prepared.Statement = stmt
 	if err := pinfo.ProcessPlaceholderAnnotations(stmt); err != nil {
 		return nil, err
@@ -551,11 +551,11 @@ func (e *Executor) ExecuteStatements(
 // ExecutePreparedStatement executes the given statement and returns a response.
 func (e *Executor) ExecutePreparedStatement(
 	session *Session, stmt *PreparedStatement, pinfo *parser.PlaceholderInfo,
-) StatementResults {
+) (StatementResults, error) {
 
-	var stmts parser.StatementList
+	var stmts StatementList
 	if stmt.Statement != nil {
-		stmts = parser.StatementList{stmt.Statement}
+		stmts = StatementList{{AST: stmt.Statement}}
 	}
 
 	defer logIfPanicking(session.Ctx(), stmts.String())
@@ -576,9 +576,32 @@ func (e *Executor) ExecutePreparedStatement(
 		session.phaseTimes[sessionEndParse] = now
 	}
 
+	return e.execPrepared(session, stmt, pinfo)
+}
+
+// execPrepared executes a prepared statement. It returns an error if there
+// is more than 1 result or the returned types differ from the prepared
+// return types.
+func (e *Executor) execPrepared(
+	session *Session, stmt *PreparedStatement, pinfo *parser.PlaceholderInfo,
+) (StatementResults, error) {
+	var stmts StatementList
+	if stmt.Statement != nil {
+		stmts = StatementList{{
+			AST:           stmt.Statement,
+			ExpectedTypes: stmt.Columns,
+		}}
+	}
 	// Send the Request for SQL execution and set the application-level error
 	// for each result in the reply.
-	return e.execParsed(session, stmts, pinfo, copyMsgNone)
+	results := e.execParsed(session, stmts, pinfo, copyMsgNone)
+	// This shouldn't ever happen since prepared statements are limited during
+	// creation to one statement, but just in case it does, throw an error.
+	if len(results.ResultList) > 1 {
+		results.Close(session.Ctx())
+		return StatementResults{}, pgerror.NewError(pgerror.CodeInternalError, "unexpected number of results")
+	}
+	return results, nil
 }
 
 // CopyData adds data to the COPY buffer and executes if there are enough rows.
@@ -613,7 +636,7 @@ func (session *Session) CopyEnd(ctx context.Context) {
 func (e *Executor) execRequest(
 	session *Session, sql string, pinfo *parser.PlaceholderInfo, copymsg copyMsg,
 ) StatementResults {
-	var stmts parser.StatementList
+	var stmts StatementList
 	var err error
 	txnState := &session.TxnState
 
@@ -627,7 +650,9 @@ func (e *Executor) execRequest(
 	} else if copymsg != copyMsgNone {
 		err = fmt.Errorf("unexpected copy command")
 	} else {
-		stmts, err = parser.Parse(sql)
+		var sl parser.StatementList
+		sl, err = parser.Parse(sql)
+		stmts = NewStatementList(sl)
 	}
 	session.phaseTimes[sessionEndParse] = timeutil.Now()
 
@@ -654,7 +679,7 @@ func (e *Executor) execRequest(
 }
 
 func (e *Executor) execParsed(
-	session *Session, stmts parser.StatementList, pinfo *parser.PlaceholderInfo, copymsg copyMsg,
+	session *Session, stmts StatementList, pinfo *parser.PlaceholderInfo, copymsg copyMsg,
 ) StatementResults {
 	var res StatementResults
 	var avoidCachedDescriptors bool
@@ -684,13 +709,13 @@ func (e *Executor) execParsed(
 		// a transaction).
 		if !inTxn {
 			// Detect implicit transactions.
-			if _, isBegin := stmts[0].(*parser.BeginTransaction); !isBegin {
+			if _, isBegin := stmts[0].AST.(*parser.BeginTransaction); !isBegin {
 				execOpt.AutoCommit = true
 				stmtsToExec = stmtsToExec[:1]
 				// Check for AS OF SYSTEM TIME. If it is present but not detected here,
 				// it will raise an error later on.
 				var err error
-				protoTS, err = isAsOf(session, stmtsToExec[0], e.cfg.Clock.Now())
+				protoTS, err = isAsOf(session, stmtsToExec[0].AST, e.cfg.Clock.Now())
 				if err != nil {
 					res.ResultList = append(res.ResultList, Result{Err: err})
 					return res
@@ -719,7 +744,7 @@ func (e *Executor) execParsed(
 			panic("we failed to initialize a txn")
 		}
 		// Now actually run some statements.
-		var remainingStmts parser.StatementList
+		var remainingStmts StatementList
 		var results []Result
 		origState := txnState.State
 
@@ -742,6 +767,7 @@ func (e *Executor) execParsed(
 				// Some results were produced by a previous attempt. Discard them.
 				ResultList(results).Close(ctx)
 			}
+
 			results, remainingStmts, err = runTxnAttempt(
 				e, session, stmtsToExec, pinfo, origState, opt,
 				avoidCachedDescriptors, automaticRetryCount)
@@ -750,7 +776,7 @@ func (e *Executor) execParsed(
 			if err == nil && txnState.State == Aborted {
 				doWarn := true
 				if len(stmtsToExec) > 0 {
-					if _, ok := stmtsToExec[0].(*parser.ShowTransactionStatus); ok {
+					if _, ok := stmtsToExec[0].AST.(*parser.ShowTransactionStatus); ok {
 						doWarn = false
 					}
 				}
@@ -915,13 +941,13 @@ func countRowsAffected(ctx context.Context, p planNode) (int, error) {
 func runTxnAttempt(
 	e *Executor,
 	session *Session,
-	stmts parser.StatementList,
+	stmts StatementList,
 	pinfo *parser.PlaceholderInfo,
 	origState TxnStateEnum,
 	opt *client.TxnExecOptions,
 	avoidCachedDescriptors bool,
 	automaticRetryCount int,
-) ([]Result, parser.StatementList, error) {
+) ([]Result, StatementList, error) {
 
 	// Ignore the state that might have been set by a previous try of this
 	// closure. By putting these modifications to txnState behind the
@@ -983,13 +1009,13 @@ func runTxnAttempt(
 //    after converting it adequately.
 func (e *Executor) execStmtsInCurrentTxn(
 	session *Session,
-	stmts parser.StatementList,
+	stmts StatementList,
 	pinfo *parser.PlaceholderInfo,
 	implicitTxn bool,
 	txnBeginning bool,
 	avoidCachedDescriptors bool,
 	automaticRetryCount int,
-) ([]Result, parser.StatementList, error) {
+) ([]Result, StatementList, error) {
 	var results []Result
 
 	txnState := &session.TxnState
@@ -1020,7 +1046,7 @@ func (e *Executor) execStmtsInCurrentTxn(
 		var err error
 		// Run SHOW TRANSACTION STATUS in a separate code path so it is
 		// always guaranteed to execute regardless of the current transaction state.
-		if _, ok := stmt.(*parser.ShowTransactionStatus); ok {
+		if _, ok := stmt.AST.(*parser.ShowTransactionStatus); ok {
 			res, err = runShowTransactionState(session, implicitTxn)
 		} else {
 			switch txnState.State {
@@ -1096,13 +1122,13 @@ func runShowTransactionState(session *Session, implicitTxn bool) (Result, error)
 // - COMMIT / ROLLBACK: aborts the current transaction.
 // - ROLLBACK TO SAVEPOINT / SAVEPOINT: reopens the current transaction,
 //   allowing it to be retried.
-func (e *Executor) execStmtInAbortedTxn(session *Session, stmt parser.Statement) (Result, error) {
+func (e *Executor) execStmtInAbortedTxn(session *Session, stmt Statement) (Result, error) {
 	txnState := &session.TxnState
 	if txnState.State != Aborted && txnState.State != RestartWait {
 		panic("execStmtInAbortedTxn called outside of an aborted txn")
 	}
 	// TODO(andrei/cuongdo): Figure out what statements to count here.
-	switch s := stmt.(type) {
+	switch s := stmt.AST.(type) {
 	case *parser.CommitTransaction, *parser.RollbackTransaction:
 		if txnState.State == RestartWait {
 			return rollbackSQLTransaction(txnState), nil
@@ -1158,15 +1184,13 @@ func (e *Executor) execStmtInAbortedTxn(session *Session, stmt parser.Statement)
 // execStmtInCommitWaitTxn executes a statement in a txn that's in state
 // CommitWait.
 // Everything but COMMIT/ROLLBACK causes errors. ROLLBACK is treated like COMMIT.
-func (e *Executor) execStmtInCommitWaitTxn(
-	session *Session, stmt parser.Statement,
-) (Result, error) {
+func (e *Executor) execStmtInCommitWaitTxn(session *Session, stmt Statement) (Result, error) {
 	txnState := &session.TxnState
 	if txnState.State != CommitWait {
 		panic("execStmtInCommitWaitTxn called outside of an aborted txn")
 	}
 	e.updateStmtCounts(stmt)
-	switch stmt.(type) {
+	switch stmt.AST.(type) {
 	case *parser.CommitTransaction, *parser.RollbackTransaction:
 		// Reset the state to allow new transactions to start.
 		result := Result{PGTag: (*parser.CommitTransaction)(nil).StatementTag()}
@@ -1219,7 +1243,7 @@ func sessionEventf(session *Session, format string, args ...interface{}) {
 // - an error, if any. In case of error, the result returned also reflects this error.
 func (e *Executor) execStmtInOpenTxn(
 	session *Session,
-	stmt parser.Statement,
+	stmt Statement,
 	pinfo *parser.PlaceholderInfo,
 	implicitTxn bool,
 	firstInTxn bool,
@@ -1251,7 +1275,7 @@ func (e *Executor) execStmtInOpenTxn(
 	// execution. If neither of these cases are true, we need to synchronize
 	// parallel execution by letting it drain before we can begin executing ourselves.
 	parallelize := IsStmtParallelized(stmt)
-	_, independentFromParallelStmts := stmt.(parser.IndependentFromParallelizedPriors)
+	_, independentFromParallelStmts := stmt.AST.(parser.IndependentFromParallelizedPriors)
 	if !(parallelize || independentFromParallelStmts) {
 		if err := session.parallelizeQueue.Wait(); err != nil {
 			return Result{}, err
@@ -1262,7 +1286,7 @@ func (e *Executor) execStmtInOpenTxn(
 		return Result{}, errNoTransactionInProgress
 	}
 
-	switch s := stmt.(type) {
+	switch s := stmt.AST.(type) {
 	case *parser.BeginTransaction:
 		if !firstInTxn {
 			return Result{}, errTransactionInProgress
@@ -1317,7 +1341,7 @@ func (e *Executor) execStmtInOpenTxn(
 		for i, t := range s.Types {
 			typeHints[strconv.Itoa(i+1)] = parser.CastTargetToDatumType(t)
 		}
-		_, err := session.PreparedStatements.New(e, name, parser.StatementList{s.Statement}, len(s.Statement.String()), typeHints)
+		_, err := session.PreparedStatements.New(e, name, StatementList{{AST: s.Statement}}, len(s.Statement.String()), typeHints)
 		return Result{}, err
 	case *parser.Execute:
 		name := s.Name.String()
@@ -1344,14 +1368,15 @@ func (e *Executor) execStmtInOpenTxn(
 			}
 			qArgs[idx] = typedExpr
 		}
-		results := e.execParsed(session, parser.StatementList{prepared.Statement},
-			&parser.PlaceholderInfo{Values: qArgs, Types: prepared.SQLTypes},
-			copyMsgNone)
-		if results.Empty {
-			return Result{}, nil
+		results, err := e.execPrepared(session, prepared,
+			&parser.PlaceholderInfo{Values: qArgs, Types: prepared.SQLTypes})
+		if err != nil {
+			return Result{}, err
 		}
-		if len(results.ResultList) > 1 {
-			return Result{}, errWrongNumberOfPreparedStatements(len(results.ResultList))
+		// No need to check if len(results.ResultList) > 1 because execPrepared
+		// returns an error in that case.
+		if len(results.ResultList) == 0 {
+			return Result{}, nil
 		}
 		return results.ResultList[0], nil
 
@@ -1428,8 +1453,8 @@ func (e *Executor) execStmtInOpenTxn(
 
 // stmtAllowedInImplicitTxn returns whether the statement is allowed in an
 // implicit transaction or not.
-func stmtAllowedInImplicitTxn(stmt parser.Statement) bool {
-	switch stmt.(type) {
+func stmtAllowedInImplicitTxn(stmt Statement) bool {
+	switch stmt.AST.(type) {
 	case *parser.CommitTransaction:
 	case *parser.ReleaseSavepoint:
 	case *parser.RollbackTransaction:
@@ -1612,10 +1637,10 @@ func (e *Executor) shouldUseDistSQL(planner *planner, plan planNode) (bool, erro
 }
 
 // makeRes creates an empty result set for the given statement and plan.
-func makeRes(stmt parser.Statement, planner *planner, plan planNode) (Result, error) {
+func makeRes(stmt Statement, planner *planner, plan planNode) (Result, error) {
 	result := Result{
-		PGTag: stmt.StatementTag(),
-		Type:  stmt.StatementType(),
+		PGTag: stmt.AST.StatementTag(),
+		Type:  stmt.AST.StatementType(),
 	}
 	if result.Type == parser.Rows {
 		result.Columns = plan.Columns()
@@ -1635,7 +1660,7 @@ func makeRes(stmt parser.Statement, planner *planner, plan planNode) (Result, er
 // If mockResults is set, these results will be replaced by the "zero value" of the
 // statement's result type, identical to the mock results returned by execStmtInParallel.
 func (e *Executor) execStmt(
-	stmt parser.Statement, planner *planner, automaticRetryCount int, mockResults bool,
+	stmt Statement, planner *planner, automaticRetryCount int, mockResults bool,
 ) (Result, error) {
 	session := planner.session
 
@@ -1689,7 +1714,7 @@ func (e *Executor) execStmt(
 //
 // TODO(nvanbenschoten): We do not currently support parallelizing distributed SQL
 // queries, so this method can only be used with classical SQL.
-func (e *Executor) execStmtInParallel(stmt parser.Statement, planner *planner) (Result, error) {
+func (e *Executor) execStmtInParallel(stmt Statement, planner *planner) (Result, error) {
 	session := planner.session
 	ctx := session.Ctx()
 
@@ -1723,9 +1748,9 @@ func (e *Executor) execStmtInParallel(stmt parser.Statement, planner *planner) (
 
 // updateStmtCounts updates metrics for the number of times the different types of SQL
 // statements have been received by this node.
-func (e *Executor) updateStmtCounts(stmt parser.Statement) {
+func (e *Executor) updateStmtCounts(stmt Statement) {
 	e.QueryCount.Inc(1)
-	switch stmt.(type) {
+	switch stmt.AST.(type) {
 	case *parser.BeginTransaction:
 		e.TxnBeginCount.Inc(1)
 	case *parser.Select:
@@ -1741,7 +1766,7 @@ func (e *Executor) updateStmtCounts(stmt parser.Statement) {
 	case *parser.RollbackTransaction:
 		e.TxnRollbackCount.Inc(1)
 	default:
-		if stmt.StatementType() == parser.DDL {
+		if stmt.AST.StatementType() == parser.DDL {
 			e.DdlCount.Inc(1)
 		} else {
 			e.MiscCount.Inc(1)

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -71,7 +71,7 @@ type phaseTimes [sessionNumPhases]time.Time
 // - err is the error encountered, if any.
 func (e *Executor) recordStatementSummary(
 	planner *planner,
-	stmt parser.Statement,
+	stmt Statement,
 	distSQLUsed bool,
 	automaticRetryCount int,
 	result Result,
@@ -107,7 +107,7 @@ func (e *Executor) recordStatementSummary(
 
 	if automaticRetryCount == 0 {
 		if distSQLUsed {
-			if _, ok := stmt.(*parser.Select); ok {
+			if _, ok := stmt.AST.(*parser.Select); ok {
 				e.DistSQLSelectCount.Inc(1)
 			}
 			e.DistSQLExecLatency.RecordValue(runLatRaw.Nanoseconds())

--- a/pkg/sql/parallel_stmts.go
+++ b/pkg/sql/parallel_stmts.go
@@ -341,12 +341,12 @@ func (a *spanBasedDependencyAnalyzer) Clear(p planNode) {
 // parallelized. This means that its results should be mocked out, and that
 // it should be run asynchronously and in parallel with other statements that
 // are independent.
-func IsStmtParallelized(stmt parser.Statement) bool {
+func IsStmtParallelized(stmt Statement) bool {
 	parallelizedRetClause := func(ret parser.ReturningClause) bool {
 		_, ok := ret.(*parser.ReturningNothing)
 		return ok
 	}
-	switch s := stmt.(type) {
+	switch s := stmt.AST.(type) {
 	case *parser.Delete:
 		return parallelizedRetClause(s.Returning)
 	case *parser.Insert:

--- a/pkg/sql/parallel_stmts_test.go
+++ b/pkg/sql/parallel_stmts_test.go
@@ -324,7 +324,7 @@ func planNodeForQuery(
 		t.Fatalf("expected to parse 1 statement, got: %d", len(stmts))
 	}
 	stmt := stmts[0]
-	plan, err := p.makePlan(context.TODO(), stmt)
+	plan, err := p.makePlan(context.TODO(), Statement{AST: stmt})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -1604,3 +1604,66 @@ func TestPGWireAuth(t *testing.T) {
 		}
 	})
 }
+
+func TestPGWireResultChange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.TODO())
+
+	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), t.Name(), url.User(security.RootUser))
+	defer cleanupFn()
+
+	db, err := gosql.Open("postgres", pgURL.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`CREATE DATABASE testing`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE testing.f (v INT)`); err != nil {
+		t.Fatal(err)
+	}
+	stmt, err := db.Prepare(`SELECT * FROM testing.f`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`ALTER TABLE testing.f ADD COLUMN u int`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO testing.f VALUES (1, 2)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stmt.Exec(); !testutils.IsError(err, "must not change result type") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := stmt.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test that an INSERT RETURNING will not commit data.
+	stmt, err = db.Prepare(`INSERT INTO testing.f VALUES ($1, $2) RETURNING *`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`ALTER TABLE testing.f ADD COLUMN t int`); err != nil {
+		t.Fatal(err)
+	}
+	var count int
+	if err := db.QueryRow(`SELECT count(*) FROM testing.f`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stmt.Exec(3, 4); !testutils.IsError(err, "must not change result type") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := stmt.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var countAfter int
+	if err := db.QueryRow(`SELECT count(*) FROM testing.f`).Scan(&countAfter); err != nil {
+		t.Fatal(err)
+	}
+	if count != countAfter {
+		t.Fatalf("expected %d rows, got %d", count, countAfter)
+	}
+}

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -824,7 +824,10 @@ func (c *v3Conn) handleExecute(buf *readBuffer) error {
 
 	tracing.AnnotateTrace()
 
-	results := c.executor.ExecutePreparedStatement(c.session, stmt, pinfo)
+	results, err := c.executor.ExecutePreparedStatement(c.session, stmt, pinfo)
+	if err != nil {
+		return c.sendError(err)
+	}
 	return c.finishExecute(results, portalMeta.outFormats, false, int(limit))
 }
 

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -179,7 +179,7 @@ func (p *planner) query(ctx context.Context, sql string, args ...interface{}) (p
 		return nil, err
 	}
 	golangFillQueryArguments(&p.semaCtx.Placeholders, args)
-	return p.makePlan(ctx, stmt)
+	return p.makePlan(ctx, Statement{AST: stmt})
 }
 
 // QueryRow implements the parser.EvalPlanner interface.

--- a/pkg/sql/sqlbase/result_columns.go
+++ b/pkg/sql/sqlbase/result_columns.go
@@ -54,3 +54,23 @@ func ResultColumnsFromColDescs(colDescs []ColumnDescriptor) ResultColumns {
 	}
 	return cols
 }
+
+// TypesEqual returns whether the length and types of r matches other. If
+// a type in other is NULL, it is considered equal.
+func (r ResultColumns) TypesEqual(other ResultColumns) bool {
+	if len(r) != len(other) {
+		return false
+	}
+	for i, c := range r {
+		// NULLs are considered equal because some types of queries (SELECT CASE,
+		// for example) can change their output types between a type and NULL based
+		// on input.
+		if other[i].Typ == parser.TypeNull {
+			continue
+		}
+		if !c.Typ.Equivalent(other[i].Typ) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/sql/sqlbase/result_columns_test.go
+++ b/pkg/sql/sqlbase/result_columns_test.go
@@ -1,0 +1,73 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqlbase
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+)
+
+func TestResultColumnsTypesEqual(t *testing.T) {
+	tests := []struct {
+		r, o  ResultColumns
+		equal bool
+	}{
+		{
+			r:     ResultColumns{{Typ: parser.TypeInt}},
+			o:     ResultColumns{{Typ: parser.TypeInt}},
+			equal: true,
+		},
+		{
+			r:     ResultColumns{{Typ: parser.TypeInt}},
+			o:     ResultColumns{{Typ: parser.TypeString}},
+			equal: false,
+		},
+		{
+			r:     ResultColumns{{Typ: parser.TypeNull}},
+			o:     ResultColumns{{Typ: parser.TypeInt}},
+			equal: false,
+		},
+		{
+			r:     ResultColumns{{Typ: parser.TypeInt}},
+			o:     ResultColumns{{Typ: parser.TypeNull}},
+			equal: true,
+		},
+		{
+			r:     ResultColumns{{Typ: parser.TypeNull}},
+			o:     ResultColumns{{Typ: parser.TypeNull}},
+			equal: true,
+		},
+		{
+			r:     ResultColumns{{Typ: parser.TypeInt}, {Typ: parser.TypeInt}},
+			o:     ResultColumns{{Typ: parser.TypeInt}},
+			equal: false,
+		},
+		{
+			r:     ResultColumns{},
+			o:     ResultColumns{{Typ: parser.TypeNull}},
+			equal: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%v-%v", tc.r, tc.o), func(t *testing.T) {
+			eq := tc.r.TypesEqual(tc.o)
+			if eq != tc.equal {
+				t.Fatalf("expected %v, got %v", tc.equal, eq)
+			}
+		})
+	}
+}

--- a/pkg/sql/subquery_test.go
+++ b/pkg/sql/subquery_test.go
@@ -39,7 +39,7 @@ func TestStartSubqueriesReturnsError(t *testing.T) {
 		t.Fatalf("expected to parse 1 statement, got: %d", len(stmts))
 	}
 	stmt := stmts[0]
-	plan, err := p.makePlan(context.TODO(), stmt)
+	plan, err := p.makePlan(context.TODO(), Statement{AST: stmt})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/testdata/logic_test/prepare
+++ b/pkg/sql/testdata/logic_test/prepare
@@ -189,3 +189,43 @@ EXECUTE y
 ----
 1
 3
+
+statement
+DEALLOCATE ALL
+
+# Regression test for #16062
+
+statement
+CREATE TABLE IF NOT EXISTS f (v INT)
+
+statement
+PREPARE x AS SELECT * FROM f
+
+statement
+ALTER TABLE f ADD COLUMN u int
+
+statement
+INSERT INTO f VALUES (1, 2)
+
+statement error cached plan must not change result type
+EXECUTE x
+
+# Ensure that plan changes prevent INSERTs from succeeding.
+
+statement
+PREPARE y AS INSERT INTO f VALUES ($1, $2) RETURNING *
+
+statement
+EXECUTE y (2, 3)
+
+statement
+ALTER TABLE f ADD COLUMN t int
+
+statement error cached plan must not change result type
+EXECUTE y (3, 4)
+
+query III
+SELECT * FROM f
+----
+1 2 NULL
+2 3 NULL


### PR DESCRIPTION
Check the result types (excluding empty results and NULLs) against
what the initial prepared statement expected. This also moves all
error handling in prepared statements to a common place, unifying
more details of the pgwire and executor prepare paths.

Fixes #16062