### PR TITLE
engine: benchmark MVCCGarbageCollect

### DIFF
--- a/pkg/storage/engine/bench_test.go
+++ b/pkg/storage/engine/bench_test.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -33,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -684,4 +686,98 @@ func BenchmarkClearIterRange_RocksDB(b *testing.B) {
 		defer iter.Close()
 		return batch.ClearIterRange(iter, start, end)
 	})
+}
+
+func BenchmarkMVCCGarbageCollect(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	ctx := context.Background()
+	ts := hlc.Timestamp{}.Add(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC).UnixNano(), 0)
+
+	// Write 'numKeys' of the given 'keySize' and 'valSize' to the given engine.
+	// For each key, write 'numVersions' versions, and add a GCRequest_GCKey to
+	// the returned slice that affects the oldest 'deleteVersions' versions. The
+	// first write for each key will be at `ts`, the second one at `ts+(0,1)`,
+	// etc.
+	//
+	// NB: a real invocation of MVCCGarbageCollect typically has most of the keys
+	// in sorted order. Here they will be ordered randomly.
+	setup := func(
+		engine Engine, keySize, valSize, numKeys, numVersions, deleteVersions int,
+	) []roachpb.GCRequest_GCKey {
+		var ms enginepb.MVCCStats
+		var gcKeys []roachpb.GCRequest_GCKey
+
+		mkKey := func() []byte {
+			k := make([]byte, keySize)
+			if n, err := rand.Read(k); err != nil || n != keySize {
+				b.Fatalf("error or read too little: n=%d err=%v", n, err)
+			}
+			return k
+		}
+		valBytes := make([]byte, valSize)
+		if n, err := rand.Read(valBytes); err != nil || n != valSize {
+			b.Fatalf("error or read too little: n=%d err=%v", n, err)
+		}
+		v := roachpb.MakeValueFromBytesAndTimestamp(valBytes, hlc.Timestamp{})
+
+		for j := 0; j < numKeys; j++ {
+			curKey := mkKey()
+			if deleteVersions > 0 {
+				gcKeys = append(gcKeys, roachpb.GCRequest_GCKey{
+					Timestamp: ts.Add(0, int32(deleteVersions-1)),
+					Key:       curKey,
+				})
+			}
+
+			for i := 0; i < numVersions; i++ {
+				if err := MVCCPut(
+					ctx, engine, &ms, curKey, ts.Add(0, int32(i)), v, nil); err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+		return gcKeys
+	}
+
+	// We write values at ts+(0,i), set now=ts+(1,0) so that we're ahead of all
+	// the writes. This value doesn't matter in practice, it's used only for
+	// stats updates.
+	now := ts.Add(1, 0)
+
+	run := func(
+		b *testing.B, keySize, valSize, numKeys, numVersions, deleteVersions int,
+	) {
+		engine := createTestEngine()
+		defer engine.Close()
+
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			gcKeys := setup(engine, keySize, valSize, numKeys, numVersions, deleteVersions)
+
+			b.StartTimer()
+			if err := MVCCGarbageCollect(ctx, engine, &enginepb.MVCCStats{}, gcKeys, now); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+
+	// NB: To debug #16068, test only 128-128-15000-6.
+	for _, keySize := range []int{128} {
+		b.Run(fmt.Sprintf("keySize=%d", keySize), func(b *testing.B) {
+			for _, valSize := range []int{128} {
+				b.Run(fmt.Sprintf("valSize=%d", valSize), func(b *testing.B) {
+					for _, numKeys := range []int{1, 1024} {
+						b.Run(fmt.Sprintf("numKeys=%d", numKeys), func(b *testing.B) {
+							for _, numVersions := range []int{2, 1024} {
+								b.Run(fmt.Sprintf("numVersions=%d", numVersions), func(b *testing.B) {
+									deleteVersions := numVersions - 1
+									run(b, keySize, valSize, numKeys, numVersions, deleteVersions)
+								})
+							}
+						})
+					}
+				})
+			}
+		})
+	}
 }


### PR DESCRIPTION
Motivated by #16068, though unfortunately not revealing a
smoking gun so far.

Run with:

    make bench PKG=./pkg/storage/engine/ BENCHES=MVCCGarbage TESTFLAGS='-cpuprofile cpu.out -benchmem'

Investigate profile with:

    go tool pprof engine.test cpu.out

Results (single run on laptop):

    BenchmarkMVCCGarbageCollect/keySize=128/valSize=128/numKeys=1/numVersions=2-4         	  200000     22617 ns/op	      80 B/op	       1 allocs/op
    BenchmarkMVCCGarbageCollect/keySize=128/valSize=128/numKeys=1/numVersions=1024-4      	     500	   3321554 ns/op	      82 B/op	       1 allocs/op
    BenchmarkMVCCGarbageCollect/keySize=128/valSize=128/numKeys=1024/numVersions=2-4      	     100	  34494030 ns/op	      91 B/op	       1 allocs/op
    BenchmarkMVCCGarbageCollect/keySize=128/valSize=128/numKeys=1024/numVersions=1024-4   	       1	3772347996 ns/op	     768 B/op	       9 allocs/op