### PR TITLE
cli: list number of CA certificates in the file.

### DIFF
--- a/pkg/cli/cert.go
+++ b/pkg/cli/cert.go
@@ -192,7 +192,11 @@ func runListCerts(cmd *cobra.Command, args []string) error {
 	}
 
 	if cert := cm.CACert(); cert != nil {
-		addRow(cert, "")
+		var notes string
+		if cert.Error == nil && len(cert.ParsedCertificates) > 0 {
+			notes = fmt.Sprintf("num certs: %d", len(cert.ParsedCertificates))
+		}
+		addRow(cert, notes)
 	}
 
 	if cert := cm.NodeCert(); cert != nil {


### PR DESCRIPTION
This is useful when examining certificates before/after rotation.

eg:
```
$ cockroach cert list
Certificate directory: ~/.cockroach-certs
+-----------------------+------------------+----------+------------+--------------+-------+
|         Usage         | Certificate File | Key File |  Expires   |
Notes     | Error |
+-----------------------+------------------+----------+------------+--------------+-------+
| Certificate Authority | ca.crt           |          | 2017/10/19 | num
certs: 1 |       |
+-----------------------+------------------+----------+------------+--------------+-------+
(1 row)

$ rm ca.key
$ cockroach cert create-ca --overwrite --ca-key=ca.key

$ cockroach cert list
Certificate directory: ~/.cockroach-certs
+-----------------------+------------------+----------+------------+--------------+-------+
|         Usage         | Certificate File | Key File |  Expires   |
Notes     | Error |
+-----------------------+------------------+----------+------------+--------------+-------+
| Certificate Authority | ca.crt           |          | 2022/05/28 | num
certs: 2 |       |
+-----------------------+------------------+----------+------------+--------------+-------+
(1 row)
```

That way, we can examine the output and see at a glance that my new
ca.crt has two certificates with the latest expiration date pushed
appropriately.