### PR TITLE
cli: really separate CA vs other lifetimes

### DIFF
--- a/pkg/cli/cert.go
+++ b/pkg/cli/cert.go
@@ -36,6 +36,7 @@ const defaultCALifetime = 10 * 366 * 24 * time.Hour  // ten years
 const defaultCertLifetime = 5 * 366 * 24 * time.Hour // five years
 
 var keySize int
+var caCertificateLifetime time.Duration
 var certificateLifetime time.Duration
 var allowCAKeyReuse bool
 var overwriteFiles bool
@@ -63,7 +64,7 @@ func runCreateCACert(cmd *cobra.Command, args []string) error {
 			baseCfg.SSLCertsDir,
 			baseCfg.SSLCAKey,
 			keySize,
-			certificateLifetime,
+			caCertificateLifetime,
 			allowCAKeyReuse,
 			overwriteFiles),
 		"failed to generate CA cert and key")

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -283,7 +283,7 @@ func init() {
 	for _, cmd := range []*cobra.Command{createCACertCmd} {
 		f := cmd.Flags()
 		// CA certificates have a longer expiration time.
-		durationFlag(f, &certificateLifetime, cliflags.CertificateLifetime, defaultCALifetime)
+		durationFlag(f, &caCertificateLifetime, cliflags.CertificateLifetime, defaultCALifetime)
 		// The CA key can be re-used if it exists.
 		boolFlag(f, &allowCAKeyReuse, cliflags.AllowCAKeyReuse, false)
 	}


### PR DESCRIPTION
This worked fine for the help message, but not to actually set the values as the flag would just get overwritten.

I think it's really time I got to #14662