### PR TITLE
debug: add blank row between CA certificates.

### DIFF
--- a/pkg/server/debug_certificates.go
+++ b/pkg/server/debug_certificates.go
@@ -227,6 +227,12 @@ const debugCertificatesTemplate = `
           </DIV>
         {{- else}}
           {{- range $i, $cert := .CertFields}}
+            {{- if gt $i 0}}
+              <DIV CLASS="row">
+                <DIV CLASS="header cell"></DIV>
+                <DIV CLASS="cell"></DIV>
+              </DIV>
+            {{- end}}
             <DIV CLASS="row">
               <DIV CLASS="header cell">Cert ID</DIV>
               <DIV CLASS="cell">{{$i}}</DIV>


### PR DESCRIPTION
When we have more than one certificate in the CA cert file, insert a
blank row between each cert to make things clearer.