### PR TITLE
scripts: Reintroduce scripts/pprof

### DIFF
--- a/scripts/pprof
+++ b/scripts/pprof
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# This script wraps "go tool pprof" (and stunnel) to work better with
+# HTTPS servers using untrusted certificates (like cockroachdb).
+#
+# Go 1.8 introduced the "https+insecure" option to ignore certificate
+# validation errors, but it did not extend to the symbolizer
+# (https://github.com/google/pprof/issues/94). In go 1.9, this script
+# should be obsolete.
+
+set -euo pipefail
+
+server=$1
+if [ -z "${server}" ]; then
+  echo "host:port not specified, run with: $0 host:port [profile_type]"
+  exit 1
+fi
+
+profile_type=${2-profile}
+
+port=8089
+
+pidfile=$(mktemp /tmp/pprof.XXXXXX)
+stunnel -fd 0 <<EOF
+pid=${pidfile}
+[http]
+client = yes
+accept = 127.0.0.1:${port}
+connect = $1
+EOF
+
+cleanup() {
+    kill "$(cat ${pidfile})"
+    # stunnel cleans up its own pidfile on exit
+}
+
+trap cleanup EXIT
+
+go tool pprof "http://127.0.0.1:${port}/debug/pprof/${profile_type}"


### PR DESCRIPTION
This script was removed in #14130 because it was believed to be
redundant with the Go 1.8 https+insecure option, but this mode does
not correctly support symbolization. Other than comments, the script
is the same as the previous version.