### PR TITLE
sql: fix two OFFSET bugs in distsql

### DIFF
--- a/pkg/sql/distsqlrun/processors.pb.go
+++ b/pkg/sql/distsqlrun/processors.pb.go
@@ -270,7 +270,8 @@ type PostProcessSpec struct {
 	RenderExprs []Expression `protobuf:"bytes,4,rep,name=render_exprs,json=renderExprs" json:"render_exprs"`
 	// If nonzero, the first <offset> rows will be suppressed.
 	Offset uint64 `protobuf:"varint,5,opt,name=offset" json:"offset"`
-	// If nonzero, the processor will stop after emitting this many rows.
+	// If nonzero, the processor will stop after emitting this many rows. The rows
+	// suppressed by <offset>, if any, do not count towards this limit.
 	Limit uint64 `protobuf:"varint,6,opt,name=limit" json:"limit"`
 }
 

--- a/pkg/sql/distsqlrun/processors.proto
+++ b/pkg/sql/distsqlrun/processors.proto
@@ -101,7 +101,8 @@ message PostProcessSpec {
   // If nonzero, the first <offset> rows will be suppressed.
   optional uint64 offset = 5 [(gogoproto.nullable) = false];
 
-  // If nonzero, the processor will stop after emitting this many rows.
+  // If nonzero, the processor will stop after emitting this many rows. The rows
+  // suppressed by <offset>, if any, do not count towards this limit.
   optional uint64 limit = 6 [(gogoproto.nullable) = false];
 }
 

--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -39,10 +39,10 @@ type sorter struct {
 	out      procOutputHelper
 	ordering sqlbase.ColumnOrdering
 	matchLen uint32
-	// limit is the maximum number of rows that the sorter will push to the
+	// count is the maximum number of rows that the sorter will push to the
 	// procOutputHelper. 0 if the sorter should sort and push all the rows from
 	// the input.
-	limit int64
+	count int64
 }
 
 var _ processor = &sorter{}
@@ -50,11 +50,11 @@ var _ processor = &sorter{}
 func newSorter(
 	flowCtx *FlowCtx, spec *SorterSpec, input RowSource, post *PostProcessSpec, output RowReceiver,
 ) (*sorter, error) {
-	limit := int64(0)
+	count := int64(0)
 	if post.Limit != 0 {
 		// The sorter needs to produce Offset + Limit rows. The procOutputHelper
 		// will discard the first Offset ones.
-		limit = int64(post.Limit) + int64(post.Offset)
+		count = int64(post.Limit) + int64(post.Offset)
 	}
 	s := &sorter{
 		flowCtx:  flowCtx,
@@ -62,7 +62,7 @@ func newSorter(
 		rawInput: input,
 		ordering: convertToColumnOrdering(spec.OutputOrdering),
 		matchLen: spec.OrderingMatchLen,
-		limit:    limit,
+		count:    count,
 	}
 	if err := s.out.init(post, input.Types(), &flowCtx.evalCtx, output); err != nil {
 		return nil, err
@@ -89,7 +89,7 @@ func (s *sorter) Run(ctx context.Context, wg *sync.WaitGroup) {
 	// Construct the optimal sorterStrategy.
 	var ss sorterStrategy
 	if s.matchLen == 0 {
-		if s.limit == 0 {
+		if s.count == 0 {
 			// No specified ordering match length and unspecified limit; no
 			// optimizations are possible so we simply load all rows into memory and
 			// sort all values in-place. It has a worst-case time complexity of
@@ -100,7 +100,7 @@ func (s *sorter) Run(ctx context.Context, wg *sync.WaitGroup) {
 			// our sort procedure by maintaining a max-heap populated with only the
 			// smallest k rows seen. It has a worst-case time complexity of
 			// O(n*log(k)) and a worst-case space complexity of O(k).
-			ss = newSortTopKStrategy(sv, s.limit)
+			ss = newSortTopKStrategy(sv, s.count)
 		}
 	} else {
 		// Ordering match length is specified. We will be able to use existing

--- a/pkg/sql/testdata/logic_test/select
+++ b/pkg/sql/testdata/logic_test/select
@@ -243,6 +243,16 @@ SELECT * FROM xyzw ORDER BY x LIMIT 1 OFFSET 1
 ----
 4 5 6 7
 
+query IIII
+SELECT * FROM xyzw ORDER BY y OFFSET 1
+----
+4 5 6 7
+
+query IIII
+SELECT * FROM xyzw ORDER BY y OFFSET 1 LIMIT 1
+----
+4 5 6 7
+
 # Multiplying by zero so the result is deterministic.
 query IIII
 SELECT * FROM xyzw LIMIT (RANDOM() * 0.0)::int OFFSET (RANDOM() * 0.0)::int


### PR DESCRIPTION
1. In distsql physical planning for a limit, we were erroneously
adjusting the limit when there was an OFFSET, in one case.
2. At runtime, the sorter processor was not correctly accounting for an
OFFSET when configuring a limit on the top-K sorting strategy.

Fixes #16090


cc @RaduBerinde 