### PR TITLE
storage: various `storePool.getStoreList`-related improvements

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -431,11 +431,6 @@ func (s *Server) InitialBoot() bool {
 	return s.node.initialBoot
 }
 
-// ClusterStores returns a list of known stores in the cluster.
-func (s *Server) ClusterStores() []roachpb.ReplicationTarget {
-	return s.storePool.GetStores()
-}
-
 // grpcGatewayServer represents a grpc service with HTTP endpoints through GRPC
 // gateway.
 type grpcGatewayServer interface {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -459,27 +459,6 @@ func TestOfficializeAddr(t *testing.T) {
 	}
 }
 
-func TestClusterStores(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	tc := serverutils.StartTestCluster(t, 2, base.TestClusterArgs{})
-	defer tc.Stopper().Stop(context.TODO())
-
-	testutils.SucceedsSoon(t, func() error {
-		stores := tc.Server(0).(*TestServer).ClusterStores()
-		if len(stores) != 2 {
-			return errors.Errorf("expected 2 stores, got %v", stores)
-		}
-		n1 := tc.Server(0).NodeID()
-		n2 := tc.Server(1).NodeID()
-		s1 := stores[0].NodeID
-		s2 := stores[1].NodeID
-		if !(n1 == s1 && n2 == s2) && !(n1 == s2 && n2 == s1) {
-			return errors.Errorf("expected stores for nodes %d, %d, got %v", n1, n2, stores)
-		}
-		return nil
-	})
-}
-
 func TestListenURLFileCreation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 

--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -262,7 +262,7 @@ func (a *Allocator) AllocateTarget(
 	rangeID roachpb.RangeID,
 	relaxConstraints bool,
 ) (*roachpb.StoreDescriptor, error) {
-	sl, _, throttledStoreCount := a.storePool.getStoreList(rangeID)
+	sl, _, throttledStoreCount := a.storePool.getStoreList(rangeID, storeFilterThrottled)
 
 	candidates := allocateCandidates(
 		sl,
@@ -308,7 +308,7 @@ func (a Allocator) RemoveTarget(
 	for i, exist := range existing {
 		existingStoreIDs[i] = exist.StoreID
 	}
-	sl, _, _ := a.storePool.getStoreListFromIDs(existingStoreIDs, roachpb.RangeID(0))
+	sl, _, _ := a.storePool.getStoreListFromIDs(existingStoreIDs, roachpb.RangeID(0), storeFilterNone)
 
 	candidates := removeCandidates(
 		sl,
@@ -358,7 +358,7 @@ func (a Allocator) RebalanceTarget(
 	existing []roachpb.ReplicaDescriptor,
 	rangeID roachpb.RangeID,
 ) (*roachpb.StoreDescriptor, error) {
-	sl, _, _ := a.storePool.getStoreList(rangeID)
+	sl, _, _ := a.storePool.getStoreList(rangeID, storeFilterThrottled)
 
 	existingCandidates, candidates := rebalanceCandidates(
 		ctx,
@@ -416,7 +416,7 @@ func (a *Allocator) TransferLeaseTarget(
 	checkTransferLeaseSource bool,
 	checkCandidateFullness bool,
 ) roachpb.ReplicaDescriptor {
-	sl, _, _ := a.storePool.getStoreList(rangeID)
+	sl, _, _ := a.storePool.getStoreList(rangeID, storeFilterNone)
 	sl = sl.filter(constraints)
 
 	// Filter stores that are on nodes containing existing replicas, but leave
@@ -507,7 +507,7 @@ func (a *Allocator) ShouldTransferLease(
 	if !ok {
 		return false
 	}
-	sl, _, _ := a.storePool.getStoreList(rangeID)
+	sl, _, _ := a.storePool.getStoreList(rangeID, storeFilterNone)
 	sl = sl.filter(constraints)
 	if log.V(3) {
 		log.Infof(ctx, "ShouldTransferLease (lease-holder=%d):\n%s", leaseStoreID, sl)

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -654,7 +654,7 @@ func TestAllocatorRebalance(t *testing.T) {
 		if !ok {
 			t.Fatalf("%d: unable to get store %d descriptor", i, store.StoreID)
 		}
-		sl, _, _ := a.storePool.getStoreList(firstRange)
+		sl, _, _ := a.storePool.getStoreList(firstRange, storeFilterThrottled)
 		result := shouldRebalance(ctx, desc, sl)
 		if expResult := (i >= 2); expResult != result {
 			t.Errorf("%d: expected rebalance %t; got %t", i, expResult, result)
@@ -842,7 +842,7 @@ func TestAllocatorRebalanceThrashing(t *testing.T) {
 
 			// Ensure gossiped store descriptor changes have propagated.
 			testutils.SucceedsSoon(t, func() error {
-				sl, _, _ := a.storePool.getStoreList(firstRange)
+				sl, _, _ := a.storePool.getStoreList(firstRange, storeFilterThrottled)
 				for j, s := range sl.stores {
 					if a, e := s.Capacity.RangeCount, tc.cluster[j].rangeCount; a != e {
 						return errors.Errorf("range count for %d = %d != expected %d", j, a, e)
@@ -850,7 +850,7 @@ func TestAllocatorRebalanceThrashing(t *testing.T) {
 				}
 				return nil
 			})
-			sl, _, _ := a.storePool.getStoreList(firstRange)
+			sl, _, _ := a.storePool.getStoreList(firstRange, storeFilterThrottled)
 
 			// Verify shouldRebalance returns the expected value.
 			for j, store := range stores {
@@ -924,7 +924,7 @@ func TestAllocatorRebalanceByCount(t *testing.T) {
 		if !ok {
 			t.Fatalf("%d: unable to get store %d descriptor", i, store.StoreID)
 		}
-		sl, _, _ := a.storePool.getStoreList(firstRange)
+		sl, _, _ := a.storePool.getStoreList(firstRange, storeFilterThrottled)
 		result := shouldRebalance(ctx, desc, sl)
 		if expResult := (i < 3); expResult != result {
 			t.Errorf("%d: expected rebalance %t; got %t", i, expResult, result)

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -293,9 +293,10 @@ func (r *Replica) HasQuorum() bool {
 	return len(liveReplicas) >= quorum
 }
 
-// GetStoreList is the same function as GetStoreList exposed for tests only.
+// GetStoreList exposes getStoreList for testing only, but with a hardcoded
+// storeFilter of storeFilterNone.
 func (sp *StorePool) GetStoreList(rangeID roachpb.RangeID) (StoreList, int, int) {
-	return sp.getStoreList(rangeID)
+	return sp.getStoreList(rangeID, storeFilterNone)
 }
 
 // Stores returns a copy of sl.stores.

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -3841,7 +3841,13 @@ func (r *Replica) adminScatter(
 	rangeDesc := *r.Desc()
 
 	rng := rand.New(rand.NewSource(rand.Int63()))
-	stores := r.store.cfg.StorePool.GetStores()
+
+	sl, _, _ := r.store.cfg.StorePool.getStoreList(roachpb.RangeID(0))
+	stores := make([]roachpb.ReplicationTarget, len(sl.stores))
+	for i, sd := range sl.stores {
+		stores[i].StoreID = sd.StoreID
+		stores[i].NodeID = sd.Node.NodeID
+	}
 
 	// Choose three random stores.
 	// TODO(radu): this is a toy implementation; we need to get a real

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -3842,7 +3842,7 @@ func (r *Replica) adminScatter(
 
 	rng := rand.New(rand.NewSource(rand.Int63()))
 
-	sl, _, _ := r.store.cfg.StorePool.getStoreList(roachpb.RangeID(0))
+	sl, _, _ := r.store.cfg.StorePool.getStoreList(roachpb.RangeID(0), storeFilterNone)
 	stores := make([]roachpb.ReplicationTarget, len(sl.stores))
 	for i, sd := range sl.stores {
 		stores[i].StoreID = sd.StoreID

--- a/pkg/storage/store_pool.go
+++ b/pkg/storage/store_pool.go
@@ -465,17 +465,6 @@ storeLoop:
 	return makeStoreList(filteredDescs)
 }
 
-// GetStores returns a list of known stores in the cluster.
-func (sp *StorePool) GetStores() []roachpb.ReplicationTarget {
-	sl, _, _ := sp.getStoreList(roachpb.RangeID(0))
-	result := make([]roachpb.ReplicationTarget, len(sl.stores))
-	for i, sd := range sl.stores {
-		result[i].StoreID = sd.StoreID
-		result[i].NodeID = sd.Node.NodeID
-	}
-	return result
-}
-
 // getStoreList returns a storeList that contains all active stores that
 // contain the required attributes and their associated stats. It also returns
 // the total number of alive and throttled stores. The passed in rangeID is used

--- a/pkg/storage/store_pool.go
+++ b/pkg/storage/store_pool.go
@@ -465,11 +465,29 @@ storeLoop:
 	return makeStoreList(filteredDescs)
 }
 
-// getStoreList returns a storeList that contains all active stores that
-// contain the required attributes and their associated stats. It also returns
-// the total number of alive and throttled stores. The passed in rangeID is used
-// to check for corrupted replicas.
-func (sp *StorePool) getStoreList(rangeID roachpb.RangeID) (StoreList, int, int) {
+type storeFilter int
+
+const (
+	_ storeFilter = iota
+	// storeFilterNone requests that the storeList include all live stores. Dead,
+	// unknown, and corrupted stores are always excluded from the storeList.
+	storeFilterNone
+	// storeFilterThrottled requests that the returned store list additionally
+	// exclude stores that have been throttled for declining a snapshot. (See
+	// storePool.throttle for details.) Throttled stores should not be considered
+	// for replica rebalancing, for example, but can still be considered for lease
+	// rebalancing.
+	storeFilterThrottled
+)
+
+// getStoreList returns a storeList that contains all active stores that contain
+// the required attributes and their associated stats. The storeList is filtered
+// according to the provided storeFilter. It also returns the total number of
+// alive and throttled stores. The passed in rangeID is used to check for
+// corrupted replicas.
+func (sp *StorePool) getStoreList(
+	rangeID roachpb.RangeID, filter storeFilter,
+) (StoreList, int, int) {
 	sp.detailsMu.RLock()
 	defer sp.detailsMu.RUnlock()
 
@@ -477,23 +495,23 @@ func (sp *StorePool) getStoreList(rangeID roachpb.RangeID) (StoreList, int, int)
 	for storeID := range sp.detailsMu.storeDetails {
 		storeIDs = append(storeIDs, storeID)
 	}
-	return sp.getStoreListFromIDsRLocked(storeIDs, rangeID)
+	return sp.getStoreListFromIDsRLocked(storeIDs, rangeID, filter)
 }
 
 // getStoreListFromIDs is the same function as getStoreList but only returns stores
 // from the subset of passed in store IDs.
 func (sp *StorePool) getStoreListFromIDs(
-	storeIDs roachpb.StoreIDSlice, rangeID roachpb.RangeID,
+	storeIDs roachpb.StoreIDSlice, rangeID roachpb.RangeID, filter storeFilter,
 ) (StoreList, int, int) {
 	sp.detailsMu.RLock()
 	defer sp.detailsMu.RUnlock()
-	return sp.getStoreListFromIDsRLocked(storeIDs, rangeID)
+	return sp.getStoreListFromIDsRLocked(storeIDs, rangeID, filter)
 }
 
 // getStoreListFromIDsRLocked is the same function as getStoreList but requires
 // that the detailsMU read lock is held.
 func (sp *StorePool) getStoreListFromIDsRLocked(
-	storeIDs roachpb.StoreIDSlice, rangeID roachpb.RangeID,
+	storeIDs roachpb.StoreIDSlice, rangeID roachpb.RangeID, filter storeFilter,
 ) (StoreList, int, int) {
 	if sp.deterministic {
 		sort.Sort(storeIDs)
@@ -512,6 +530,9 @@ func (sp *StorePool) getStoreListFromIDsRLocked(
 		case storeStatusThrottled:
 			aliveStoreCount++
 			throttledStoreCount++
+			if filter != storeFilterThrottled {
+				storeDescriptors = append(storeDescriptors, *detail.desc)
+			}
 		case storeStatusReplicaCorrupted:
 			aliveStoreCount++
 		case storeStatusAvailable:


### PR DESCRIPTION
This is some preliminary refactoring necessary for a real implementation of scatter that I'm working on. The most important changes here are allowing scatter and lease transferring to get a list of stores that *includes* stores that have been throttled because of a declined snapshot.

@a-robinson, anyone else I should ask to review?