### PR TITLE
build: require tagged version in IsRelease

### DIFF
--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -18,6 +18,7 @@ package build
 
 import (
 	"fmt"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -51,9 +52,11 @@ var (
 	typ          string // Type of this build; <empty>, "release", or "musl"
 )
 
+var developmentVersionRegex = regexp.MustCompile(`^[a-f0-9]{9}(-dirty)?`)
+
 // IsRelease returns true if the binary was produced by a "release" build.
 func IsRelease() bool {
-	return strings.HasPrefix(typ, "release")
+	return strings.HasPrefix(typ, "release") && developmentVersionRegex.MatchString(tag)
 }
 
 // Short returns a pretty printed build and version summary.


### PR DESCRIPTION
IsRelease is used to disable crash reporting in development builds. since even our non-master CI builds
are 'release' builds, to disable crash reports in them, we also check if the git revision is a tagged
release rather than an arbitrary sha.

I'm not entirely sure I like cluttering up this logic though -- a (cleaner?) alternative would be to just *not* pass buildType=release in non-master CIs?