### PR TITLE
sql: remove log.Scope from TestLogic

### DIFF
--- a/pkg/sql/logic_test.go
+++ b/pkg/sql/logic_test.go
@@ -1514,12 +1514,6 @@ func TestLogic(t *testing.T) {
 		}
 	}
 
-	// The tests below are likely to run concurrently; `log` is shared
-	// between all the goroutines and thus all tests, so it doesn't make
-	// sense to try to use separate `log.Scope` instances for each test.
-	logScope := log.Scope(t)
-	defer logScope.Close(t)
-
 	verbose := testing.Verbose() || log.V(1)
 	for idx, cfg := range logicTestConfigs {
 		paths := configPaths[idx]


### PR DESCRIPTION
This does more harm than good. Ostensibly, the goal here was to remove
interleaved log output from the main test output (the output is
interleaved because this test runs in parallel), but the reality is
that these logs are still interleaved; they just live in another file,
making understanding test failures require trips to the Teamcity UI
for additional log retrieval.

It's also the case that the size of these logs isn't meaningful enough
to improve the Teamcity log viewing experience; the diverted logs are
around 900KiB, while the remaining logs exceed 4MiB; they are unusably
large either way.