### PR TITLE
build: excise disabled Homebrew formula

### DIFF
--- a/build/cockroach.rb
+++ b/build/cockroach.rb
@@ -1,8 +1,0 @@
-onoe <<-EOS.undent
-  The CockroachDB formula has moved into a dedicated tap.
-  Please instead run:
-
-      $ brew install cockroachdb/cockroach/cockroach
-
-EOS
-exit 1


### PR DESCRIPTION
Since March 10, the Homebrew formula has lived in a dedicated tap
(cockroachdb/homebrew-cockroach); since 1.0, CockroachDB has lived
Homebrew proper. Since our docs haven't been suggesting this Homebrew
formula for several months, seems like it's safe to remove it.