### PR TITLE
storage: only down-replicate if a replacement is available

### DIFF
--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -225,12 +225,24 @@ func (a *Allocator) ComputeAction(
 		// Adjust the priority by the number of dead replicas the range has.
 		quorum := computeQuorum(len(desc.Replicas))
 		if lr := len(liveReplicas); lr >= quorum {
-			priority := removeDeadReplicaPriority + float64(quorum-lr)
-			if log.V(3) {
-				log.Infof(ctx, "AllocatorRemoveDead - dead=%d, live=%d, quorum=%d, priority=%.2f",
-					len(deadReplicas), liveReplicas, quorum, priority)
+			// Only allow removal of a dead replica if we have a suitable allocation
+			// target that we can up-replicate to. This isn't necessarily the target
+			// we'll up-replicate to, just an indication that such a target exists.
+			_, err := a.AllocateTarget(
+				ctx,
+				zone.Constraints,
+				liveReplicas,
+				desc.RangeID,
+				true, /* relaxConstraints */
+			)
+			if err == nil {
+				priority := removeDeadReplicaPriority + float64(quorum-lr)
+				if log.V(3) {
+					log.Infof(ctx, "AllocatorRemoveDead - dead=%d, live=%d, quorum=%d, priority=%.2f",
+						len(deadReplicas), liveReplicas, quorum, priority)
+				}
+				return AllocatorRemoveDead, priority
 			}
-			return AllocatorRemoveDead, priority
 		}
 	}
 	if have > need {

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -1856,6 +1856,91 @@ func TestAllocatorComputeAction(t *testing.T) {
 	}
 }
 
+func TestAllocatorComputeActionRemoveDead(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Each test case should describe a repair situation which has a lower
+	// priority than the previous test case.
+	testCases := []struct {
+		zone           config.ZoneConfig
+		desc           roachpb.RangeDescriptor
+		expectedAction AllocatorAction
+		live           []roachpb.StoreID
+		dead           []roachpb.StoreID
+	}{
+		// Needs three replicas, one is dead, but there is no replacement.
+		{
+			zone: config.ZoneConfig{
+				NumReplicas: 3,
+			},
+			desc: roachpb.RangeDescriptor{
+				Replicas: []roachpb.ReplicaDescriptor{
+					{
+						StoreID:   1,
+						NodeID:    1,
+						ReplicaID: 1,
+					},
+					{
+						StoreID:   2,
+						NodeID:    2,
+						ReplicaID: 2,
+					},
+					{
+						StoreID:   3,
+						NodeID:    3,
+						ReplicaID: 3,
+					},
+				},
+			},
+			expectedAction: AllocatorNoop,
+			live:           []roachpb.StoreID{1, 2},
+			dead:           []roachpb.StoreID{3},
+		},
+		// Needs three replicas, one is dead, but there is a replacement.
+		{
+			zone: config.ZoneConfig{
+				NumReplicas: 3,
+			},
+			desc: roachpb.RangeDescriptor{
+				Replicas: []roachpb.ReplicaDescriptor{
+					{
+						StoreID:   1,
+						NodeID:    1,
+						ReplicaID: 1,
+					},
+					{
+						StoreID:   2,
+						NodeID:    2,
+						ReplicaID: 2,
+					},
+					{
+						StoreID:   3,
+						NodeID:    3,
+						ReplicaID: 3,
+					},
+				},
+			},
+			expectedAction: AllocatorRemoveDead,
+			live:           []roachpb.StoreID{1, 2, 4},
+			dead:           []roachpb.StoreID{3},
+		},
+	}
+
+	stopper, _, sp, a, _ := createTestAllocator( /* deterministic */ false)
+	ctx := context.Background()
+	defer stopper.Stop(ctx)
+
+	for i, tcase := range testCases {
+		mockStorePool(sp, tcase.live, tcase.dead, nil)
+
+		action, _ := a.ComputeAction(ctx, tcase.zone, &tcase.desc)
+		if tcase.expectedAction != action {
+			t.Errorf("Test case %d expected action %d, got action %d", i, tcase.expectedAction, action)
+			continue
+		}
+	}
+}
+
 // TestAllocatorComputeActionNoStorePool verifies that
 // ComputeAction returns AllocatorNoop when storePool is nil.
 func TestAllocatorComputeActionNoStorePool(t *testing.T) {


### PR DESCRIPTION
Only down-replicate for removal of a replica on a dead node if a
suitable replacement target exists.

Fixes #16097