### PR TITLE
storage: use in-memory env for sstable construction

### DIFF
--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -116,11 +116,11 @@ func TestImport(t *testing.T) {
 	writeSST := func(keys ...[]byte) string {
 		path := strconv.FormatInt(hlc.UnixNano(), 10)
 
-		sst := engine.MakeRocksDBSstFileWriter()
-		if err := sst.Open(filepath.Join(dir, path)); err != nil {
-			_ = sst.Close()
+		sst, err := engine.MakeRocksDBSstFileWriter()
+		if err != nil {
 			t.Fatalf("%+v", err)
 		}
+		defer sst.Close()
 		ts := hlc.NewClock(hlc.UnixNano, time.Nanosecond).Now()
 		value := roachpb.MakeValueFromString("bar")
 		for _, key := range keys {
@@ -131,7 +131,11 @@ func TestImport(t *testing.T) {
 				t.Fatalf("%+v", err)
 			}
 		}
-		if err := sst.Close(); err != nil {
+		sstContents, err := sst.Finish()
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+		if err := ioutil.WriteFile(filepath.Join(dir, path), sstContents, 0644); err != nil {
 			t.Fatalf("%+v", err)
 		}
 		return path

--- a/pkg/storage/engine/db.cc
+++ b/pkg/storage/engine/db.cc
@@ -2341,10 +2341,12 @@ DBStatus DBIngestExternalFile(DBEngine* db, DBSlice path) {
 
 struct DBSstFileWriter {
   std::unique_ptr<rocksdb::Options> options;
+  std::unique_ptr<rocksdb::Env> memenv;
   rocksdb::SstFileWriter rep;
 
-  DBSstFileWriter(rocksdb::Options* o)
+  DBSstFileWriter(rocksdb::Options* o, rocksdb::Env* m)
       : options(o),
+        memenv(m),
         rep(rocksdb::EnvOptions(), *o, o->comparator) {
   }
   virtual ~DBSstFileWriter() { }
@@ -2369,11 +2371,15 @@ DBSstFileWriter* DBSstFileWriterNew() {
   options->comparator = &kComparator;
   options->table_factory.reset(rocksdb::NewBlockBasedTableFactory(table_options));
 
-  return new DBSstFileWriter(options);
+  std::unique_ptr<rocksdb::Env> memenv;
+  memenv.reset(rocksdb::NewMemEnv(rocksdb::Env::Default()));
+  options->env = memenv.get();
+
+  return new DBSstFileWriter(options, memenv.release());
 }
 
-DBStatus DBSstFileWriterOpen(DBSstFileWriter* fw, DBSlice path) {
-  rocksdb::Status status = fw->rep.Open(ToString(path));
+DBStatus DBSstFileWriterOpen(DBSstFileWriter* fw) {
+  rocksdb::Status status = fw->rep.Open("sst");
   if (!status.ok()) {
     return ToDBStatus(status);
   }
@@ -2388,13 +2394,55 @@ DBStatus DBSstFileWriterAdd(DBSstFileWriter* fw, DBKey key, DBSlice val) {
   return kSuccess;
 }
 
-DBStatus DBSstFileWriterClose(DBSstFileWriter* fw) {
+DBStatus DBSstFileWriterFinish(DBSstFileWriter* fw, DBString* data) {
   rocksdb::Status status = fw->rep.Finish();
-  delete fw;
   if (!status.ok()) {
     return ToDBStatus(status);
   }
+
+  uint64_t file_size;
+  status = fw->memenv->GetFileSize("sst", &file_size);
+  if (!status.ok()) {
+    return ToDBStatus(status);
+  }
+
+  const rocksdb::EnvOptions soptions;
+  rocksdb::unique_ptr<rocksdb::SequentialFile> sst;
+  status = fw->memenv->NewSequentialFile("sst", &sst, soptions);
+  if (!status.ok()) {
+    return ToDBStatus(status);
+  }
+
+  // scratch is eventually returned as the array part of data and freed by the
+  // caller.
+  char* scratch = static_cast<char*>(malloc(file_size));
+
+  rocksdb::Slice sst_contents;
+  status = sst->Read(file_size, &sst_contents, scratch);
+  if (!status.ok()) {
+    return ToDBStatus(status);
+  }
+  if (sst_contents.size() != file_size) {
+    return FmtStatus("expected to read %d bytes but got %d", file_size, sst_contents.size());
+  }
+
+  // The contract of the SequentialFile.Read call above is that it _might_ use
+  // scratch as the backing data for sst_contents, but it also _might not_. If
+  // it didn't, copy sst_contents into scratch, so we can unconditionally return
+  // a DBString backed by scratch (which can then always be freed by the
+  // caller). Note that this means the data is always copied exactly once,
+  // either by Read or here.
+  if (sst_contents.data() != scratch) {
+    memcpy(scratch, sst_contents.data(), sst_contents.size());
+  }
+  data->data = scratch;
+  data->len = sst_contents.size();
+
   return kSuccess;
+}
+
+void DBSstFileWriterClose(DBSstFileWriter* fw) {
+  delete fw;
 }
 
 namespace {

--- a/pkg/storage/engine/db.h
+++ b/pkg/storage/engine/db.h
@@ -265,8 +265,8 @@ typedef struct DBSstFileWriter DBSstFileWriter;
 // Creates a new SstFileWriter with the default configuration.
 DBSstFileWriter* DBSstFileWriterNew();
 
-// Opens a file at the given path for output of an sstable.
-DBStatus DBSstFileWriterOpen(DBSstFileWriter* fw, DBSlice path);
+// Opens an in-memory file for output of an sstable.
+DBStatus DBSstFileWriterOpen(DBSstFileWriter* fw);
 
 // Adds a kv entry to the sstable being built. An error is returned if it is
 // not greater than any previously added entry (according to the comparator
@@ -274,9 +274,13 @@ DBStatus DBSstFileWriterOpen(DBSstFileWriter* fw, DBSlice path);
 // cannot have been called.
 DBStatus DBSstFileWriterAdd(DBSstFileWriter* fw, DBKey key, DBSlice val);
 
-// Closes the writer, flushing any remaining writes to disk and freeing
-// memory and other resources. At least one kv entry must have been added.
-DBStatus DBSstFileWriterClose(DBSstFileWriter* fw);
+// Finalizes the writer and stores the constructed file's contents in *data. At
+// least one kv entry must have been added. May only be called once.
+DBStatus DBSstFileWriterFinish(DBSstFileWriter* fw, DBString* data);
+
+// Closes the writer and frees memory and other resources. May only be called
+// once.
+void DBSstFileWriterClose(DBSstFileWriter* fw);
 
 void DBRunLDB(int argc, char** argv);
 

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1781,22 +1781,15 @@ type RocksDBSstFileWriter struct {
 
 // MakeRocksDBSstFileWriter creates a new RocksDBSstFileWriter with the default
 // configuration.
-func MakeRocksDBSstFileWriter() RocksDBSstFileWriter {
-	return RocksDBSstFileWriter{C.DBSstFileWriterNew(), 0}
-}
-
-// Open creates a file at the given path for output of an sstable.
-func (fw *RocksDBSstFileWriter) Open(path string) error {
-	if fw == nil {
-		return errors.New("cannot call Open on a closed writer")
-	}
-	return statusToError(C.DBSstFileWriterOpen(fw.fw, goToCSlice([]byte(path))))
+func MakeRocksDBSstFileWriter() (RocksDBSstFileWriter, error) {
+	fw := C.DBSstFileWriterNew()
+	err := statusToError(C.DBSstFileWriterOpen(fw))
+	return RocksDBSstFileWriter{fw: fw}, err
 }
 
 // Add puts a kv entry into the sstable being built. An error is returned if it
 // is not greater than any previously added entry (according to the comparator
-// configured during writer creation). `Open` must have been called. `Close`
-// cannot have been called.
+// configured during writer creation). `Close` cannot have been called.
 func (fw *RocksDBSstFileWriter) Add(kv MVCCKeyValue) error {
 	if fw == nil {
 		return errors.New("cannot call Open on a closed writer")
@@ -1805,15 +1798,23 @@ func (fw *RocksDBSstFileWriter) Add(kv MVCCKeyValue) error {
 	return statusToError(C.DBSstFileWriterAdd(fw.fw, goToCKey(kv.Key), goToCSlice(kv.Value)))
 }
 
-// Close finishes the writer, flushing any remaining writes to disk. At least
-// one kv entry must have been added. Close is idempotent.
-func (fw *RocksDBSstFileWriter) Close() error {
-	if fw.fw == nil {
-		return nil
+// Finish finalizes the writer and returns the constructed file's contents. At
+// least one kv entry must have been added.
+func (fw *RocksDBSstFileWriter) Finish() ([]byte, error) {
+	var contents C.DBString
+	if err := statusToError(C.DBSstFileWriterFinish(fw.fw, &contents)); err != nil {
+		return nil, err
 	}
-	err := statusToError(C.DBSstFileWriterClose(fw.fw))
+	return cStringToGoBytes(contents), nil
+}
+
+// Close finishes and frees memory and other resources. Close is idempotent.
+func (fw *RocksDBSstFileWriter) Close() {
+	if fw.fw == nil {
+		return
+	}
+	C.DBSstFileWriterClose(fw.fw)
 	fw.fw = nil
-	return err
 }
 
 // RunLDB runs RocksDB's ldb command-line tool. The passed

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -5141,6 +5141,11 @@ func (r *Replica) GetTempPrefix() string {
 	return r.store.GetTempPrefix()
 }
 
+// TODO(dan): This is likely to be used by upcoming projects (IngestExternalFile
+// and/or DistSQL external storage). Delete it if that doesn't happen and delete
+// this line if it does.
+var _ = (*Replica).GetTempPrefix
+
 // GetLeaseHistory returns the lease history stored on this replica.
 func (r *Replica) GetLeaseHistory() []roachpb.Lease {
 	if r.leaseHistory == nil {

--- a/pkg/storage/replica_state.go
+++ b/pkg/storage/replica_state.go
@@ -735,3 +735,8 @@ func (rec ReplicaEvalContext) GetLease() (roachpb.Lease, *roachpb.Lease, error) 
 func (rec ReplicaEvalContext) GetTempPrefix() string {
 	return rec.repl.GetTempPrefix()
 }
+
+// TODO(dan): This is likely to be used by upcoming projects (IngestExternalFile
+// and/or DistSQL external storage). Delete it if that doesn't happen and delete
+// this line if it does.
+var _ = (ReplicaEvalContext).GetTempPrefix

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -4034,6 +4034,11 @@ func (s *Store) GetTempPrefix() string {
 	return s.engine.GetTempDir()
 }
 
+// TODO(dan): This is likely to be used by upcoming projects (IngestExternalFile
+// and/or DistSQL external storage). Delete it if that doesn't happen and delete
+// this line if it does.
+var _ = (*Store).GetTempPrefix
+
 // The methods below can be used to control a store's queues. Stopping a queue
 // is only meant to happen in tests.
 


### PR DESCRIPTION
Similar to #16077, this guarantees that we don't hit the disk and
greatly simplifies the temp dir story in backup/restore.

This also means the ExportFileWriter is now unused (and I suspect it's
no longer needed at all) so remove it. Leave the GetTempDir stuff since
it might be used by IngestExternalFile and/or DistSQL external storage.

@petermattis could you look at the bit of c++ in this?