### PR TITLE
tracing: thread-safety fixes

### DIFF
--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -220,9 +220,9 @@ func (t *Tracer) StartSpan(
 
 	// Copy Baggage from parent context.
 	if hasParent && len(parentCtx.Baggage) > 0 {
-		s.Baggage = make(map[string]string, len(parentCtx.Baggage))
+		s.mu.Baggage = make(map[string]string, len(parentCtx.Baggage))
 		for k, v := range parentCtx.Baggage {
-			s.Baggage[k] = v
+			s.mu.Baggage[k] = v
 		}
 	}
 
@@ -239,9 +239,9 @@ func (t *Tracer) StartSpan(
 	if hasParent {
 		s.parentSpanID = parentCtx.SpanID
 		if l := len(parentCtx.Baggage); l > 0 {
-			s.Baggage = make(map[string]string, l)
+			s.mu.Baggage = make(map[string]string, l)
 			for k, v := range parentCtx.Baggage {
-				s.Baggage[k] = v
+				s.mu.Baggage[k] = v
 			}
 		}
 	}
@@ -252,7 +252,7 @@ func (t *Tracer) StartSpan(
 			s.SetTag(k, v)
 		}
 		// Copy baggage items to tags so they show up in the Lightstep UI or x/net/trace.
-		for k, v := range s.Baggage {
+		for k, v := range s.mu.Baggage {
 			s.SetTag(k, v)
 		}
 	}
@@ -319,8 +319,8 @@ func (t *Tracer) Extract(format interface{}, carrier interface{}) (opentracing.S
 		spanMeta: spanMeta{
 			TraceID: bc.TraceID,
 			SpanID:  bc.SpanID,
-			Baggage: bc.Baggage,
 		},
+		Baggage: bc.Baggage,
 	}, nil
 }
 


### PR DESCRIPTION
1. Copy the Baggage map from a Span to a SpanContext, so that the Span's
baggage can be written to after a context is created.
2. Serialize access to a Span's Baggage map, so that concurrent readers
and writers are supported. Besides this not being disallowed by the
opentracing API, we actually have a random writer in TxnCoordSender that
races with rando readers.

Fixes #16107