### PR TITLE
util/log: preserve stderr in tests w/ log.Scope

### DIFF
--- a/pkg/util/log/test_log_scope.go
+++ b/pkg/util/log/test_log_scope.go
@@ -87,6 +87,7 @@ func enableLogFileOutput(dir string, stderrSeverity Severity) error {
 	logging.mu.Lock()
 	defer logging.mu.Unlock()
 	logging.stderrThreshold = stderrSeverity
+	logging.noStderrRedirect = true
 	return logDir.Set(dir)
 }
 


### PR DESCRIPTION
Previously, stderr was directed to the test log file when log.Scope was
active. This was frustrating because it meant that test panics would not
get output to stdout/stderr- they'd only show up in the log.Scope's
test log file. This behavior is deleterious for both local development
and TeamCity test runs, since it means that panics must be dug out of
the separate log file.

Now, log.Scope's behavior is preserved for all log statements, but
writes to stderr itself (including panic reports) are never redirected
to the log file.