### PR TITLE
storage: stop returning always-nil error from allocator.RebalanceTarget

### DIFF
--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -357,7 +357,7 @@ func (a Allocator) RebalanceTarget(
 	constraints config.Constraints,
 	existing []roachpb.ReplicaDescriptor,
 	rangeID roachpb.RangeID,
-) (*roachpb.StoreDescriptor, error) {
+) *roachpb.StoreDescriptor {
 	sl, _, _ := a.storePool.getStoreList(rangeID, storeFilterThrottled)
 
 	existingCandidates, candidates := rebalanceCandidates(
@@ -385,12 +385,12 @@ func (a Allocator) RebalanceTarget(
 	if len(existing) > 1 && len(existingCandidates) < newQuorum {
 		// Don't rebalance as we won't be able to make quorum after the rebalance
 		// until the new replica has been caught up.
-		return nil, nil
+		return nil
 	}
 
 	// No need to rebalance.
 	if len(existingCandidates) == 0 {
-		return nil, nil
+		return nil
 	}
 
 	// Find all candidates that are better than the worst existing replica.
@@ -400,7 +400,7 @@ func (a Allocator) RebalanceTarget(
 		log.Infof(ctx, "rebalance candidates: %s\nexisting replicas: %s\ntarget: %s",
 			candidates, existingCandidates, target)
 	}
-	return target, nil
+	return target
 }
 
 // TransferLeaseTarget returns a suitable replica to transfer the range lease

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -628,15 +628,12 @@ func TestAllocatorRebalance(t *testing.T) {
 
 	// Every rebalance target must be either store 1 or 2.
 	for i := 0; i < 10; i++ {
-		result, err := a.RebalanceTarget(
+		result := a.RebalanceTarget(
 			ctx,
 			config.Constraints{},
 			[]roachpb.ReplicaDescriptor{{StoreID: 3}},
 			firstRange,
 		)
-		if err != nil {
-			t.Fatal(err)
-		}
 		if result == nil {
 			i-- // loop until we find 10 candidates
 			continue
@@ -726,11 +723,8 @@ func TestAllocatorRebalanceDeadNodes(t *testing.T) {
 
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
-			result, err := a.RebalanceTarget(
+			result := a.RebalanceTarget(
 				ctx, config.Constraints{}, c.existing, firstRange)
-			if err != nil {
-				t.Fatal(err)
-			}
 			if c.expected > 0 {
 				if result == nil {
 					t.Fatalf("expected %d, but found nil", c.expected)
@@ -904,15 +898,12 @@ func TestAllocatorRebalanceByCount(t *testing.T) {
 
 	// Every rebalance target must be store 4 (or nil for case of missing the only option).
 	for i := 0; i < 10; i++ {
-		result, err := a.RebalanceTarget(
+		result := a.RebalanceTarget(
 			ctx,
 			config.Constraints{},
 			[]roachpb.ReplicaDescriptor{{StoreID: stores[0].StoreID}},
 			firstRange,
 		)
-		if err != nil {
-			t.Fatal(err)
-		}
 		if result != nil && result.StoreID != 4 {
 			t.Errorf("expected store 4; got %d", result.StoreID)
 		}
@@ -2146,15 +2137,12 @@ func TestAllocatorRebalanceAway(t *testing.T) {
 				},
 			}
 
-			actual, err := a.RebalanceTarget(
+			actual := a.RebalanceTarget(
 				ctx,
 				constraints,
 				existingReplicas,
 				firstRange,
 			)
-			if err != nil {
-				t.Fatal(err)
-			}
 
 			if tc.expected == nil && actual != nil {
 				t.Errorf("rebalancing to the incorrect store, expected nil, got %d", actual.StoreID)
@@ -2261,15 +2249,12 @@ func Example_rebalancing() {
 		// Next loop through test stores and maybe rebalance.
 		for j := 0; j < len(testStores); j++ {
 			ts := &testStores[j]
-			target, err := alloc.RebalanceTarget(
+			target := alloc.RebalanceTarget(
 				context.Background(),
 				config.Constraints{},
 				[]roachpb.ReplicaDescriptor{{NodeID: ts.Node.NodeID, StoreID: ts.StoreID}},
 				firstRange,
 			)
-			if err != nil {
-				panic(err)
-			}
 			if target != nil {
 				testStores[j].rebalance(&testStores[int(target.StoreID)], alloc.randGen.Int63n(1<<20))
 			}

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -186,16 +186,12 @@ func (rq *replicateQueue) shouldQueue(
 		}
 	}
 
-	target, err := rq.allocator.RebalanceTarget(
+	target := rq.allocator.RebalanceTarget(
 		ctx,
 		zone.Constraints,
 		desc.Replicas,
 		desc.RangeID,
 	)
-	if err != nil {
-		log.ErrEventf(ctx, "rebalance target failed: %s", err)
-		return false, 0
-	}
 	if log.V(2) {
 		if target != nil {
 			log.Infof(ctx, "rebalance target found, enqueuing")
@@ -392,16 +388,12 @@ func (rq *replicateQueue) processOneChange(
 			}
 		}
 
-		rebalanceStore, err := rq.allocator.RebalanceTarget(
+		rebalanceStore := rq.allocator.RebalanceTarget(
 			ctx,
 			zone.Constraints,
 			desc.Replicas,
 			desc.RangeID,
 		)
-		if err != nil {
-			log.ErrEventf(ctx, "rebalance target failed %s", err)
-			return false, nil
-		}
 		if rebalanceStore == nil {
 			if log.V(1) {
 				log.Infof(ctx, "no suitable rebalance target")


### PR DESCRIPTION
`allocator.RebalanceTarget` was adjusted to return an error in a1f49a when the rule solver was introduced and the allocator needed to propogate any errors from the rule solver. Since 5a4a926a, however, the rule solver no longer returns errors. The returned `error` in `allocator.RebalanceTarget` is thus once again unnecessary; this commit removes it.

@BramGruneir, thoughts? This makes my scatter implementation just a tad cleaner.