### PR TITLE
build: don't build release binary in teamcity-build-test-binary.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,8 @@ override LDFLAGS += $(MSAN_LDFLAGS)
 export CFLAGS
 export CXXFLAGS
 export LDFLAGS
+else ifeq ($(TYPE),portable)
+override LINKFLAGS += -s -w -extldflags "-static-libgcc -static-libstdc++"
 else ifeq ($(TYPE),release-linux-gnu)
 # We use a custom toolchain to target old Linux and glibc versions. However,
 # this toolchain's libstdc++ version is quite recent and must be statically

--- a/build/teamcity-build-test-binary.sh
+++ b/build/teamcity-build-test-binary.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
+# This file builds a cockroach binary that's used by integration tests external
+# to this repository.
+
 set -euxo pipefail
 
-build/builder.sh make build TYPE=release-linux-gnu
+# We don't want to build a proper release binary here, because we don't want
+# this binary to operate in release mode and e.g. report errors.
+build/builder.sh make build TYPE=portable
 mkdir -p artifacts
-mv cockroach-linux-2.6.32-gnu-amd64 artifacts/cockroach
+mv cockroach artifacts/


### PR DESCRIPTION
`teamcity-build-test-binary.sh` builds a binary that's used by integration tests in external repositories, like the examples-orms repository.  Previously, it called `build/builder.sh make TYPE=release-linux-gnu` to ensure the produced binary was portable enough to run on the TeamCity agent. This, however, has the unwanted consequence of producing a binary that reports errors to Sentry.

This commit introduces a new build type, `PORTABLE`, that builds a binary portable enough to run on TeamCity agents without enabling release mode, and adjusts `teamcity-build-test-binary.sh` to use `TYPE=portable`.