### PR TITLE
acceptance: disable hyper-v time sync for nightlies

### DIFF
--- a/pkg/acceptance/terraform/azure/disable-hyperv
+++ b/pkg/acceptance/terraform/azure/disable-hyperv
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# Disabling hyper-v time synchronization means unbinding the device.
+# To find the device, one can use:
+# $ curl -O https://raw.githubusercontent.com/torvalds/linux/master/tools/hv/lsvmbus
+# $ python lsvmbus -vv | grep -w "Time Synchronization" -A 3
+#   VMBUS ID 11: Class_ID = {9527e630-d0ae-497b-adce-e80ab0175caf} - [Time Synchronization]
+#     Device_ID = {2dd1ce17-079e-403c-b352-a1921ee207ee}
+#     Sysfs path: /sys/bus/vmbus/devices/2dd1ce17-079e-403c-b352-a1921ee207ee
+#     Rel_ID=11, target_cpu=0
+# echo 2dd1ce17-079e-403c-b352-a1921ee207ee | sudo tee /sys/bus/vmbus/drivers/hv_util/unbind
+
+# According to lsvmbus, the time sync class ID is:
+TIME_SYNC_CLASS_ID='{9527e630-d0ae-497b-adce-e80ab0175caf}'
+
+# hv bus devices are all listed under:
+VMBUS_DIR=/sys/bus/vmbus/devices
+
+# Each device folder contains many plaintext files, including:
+CLASS_ID_FILE=class_id
+
+# The device can be unbound by writing its ID to:
+UNBIND_PATH=/sys/bus/vmbus/drivers/hv_util/unbind
+
+if ! full_path=$(grep ${TIME_SYNC_CLASS_ID} ${VMBUS_DIR}/*/${CLASS_ID_FILE}); then
+  echo 'Time sync device not found'
+  exit 1
+fi
+dev_id=$(echo "${full_path}" | cut -d/ -f6)
+
+if ! echo -n "${dev_id}" | sudo tee ${UNBIND_PATH} > /dev/null; then
+  echo 'Time sync device already unbound, or error encountered.'
+fi
+
+# Install ntpdate.
+sudo apt-get -qqy install ntpdate
+# Stop ntp, force ntp sync, restart ntp.
+sudo service ntp stop
+sudo ntpdate -b ntp.ubuntu.com
+sudo service ntp start

--- a/pkg/acceptance/terraform/azure/main.tf
+++ b/pkg/acceptance/terraform/azure/main.tf
@@ -206,6 +206,11 @@ resource "null_resource" "cockroach-runner" {
     destination = "/home/ubuntu/nodectl"
   }
 
+  provisioner "file" {
+    source = "disable-hyperv"
+    destination = "/home/ubuntu/disable-hyperv"
+  }
+
   # This writes the filled-in supervisor template. It would be nice if we could
   # use rendered templates in the file provisioner.
   provisioner "remote-exec" {
@@ -225,6 +230,7 @@ FILE
   # Launch CockroachDB.
   provisioner "remote-exec" {
     inline = [
+      "chmod 755 cockroach nodectl disable-hyperv",
       # For consistency with other Terraform configs, we create the store in
       # /mnt/data0.
       "sudo mkdir /mnt/data0",
@@ -232,28 +238,26 @@ FILE
       # This sleep is needed to avoid apt-get errors below. It appears that when
       # the VM first launches, something is interfering with launches of apt-get.
       "sleep 30",
-      # Install test dependencies. NTP synchronization is especially needed for
-      # Azure VMs.
-      "sudo apt-get -qqy update >/dev/null",
-      "sudo apt-get -qqy install supervisor ntpdate >/dev/null",
-      "sudo ntpdate -b pool.ntp.org",
-      "sudo apt-get -qqy install ntp >/dev/null",
-      "sudo sed -i  's/^#statsdir/statsdir/' /etc/ntp.conf",
-      "sudo service supervisor stop",
+      # Install test dependencies.
       # TODO(cuongdo): Remove this dependency on Google Cloud SDK after we move
       # the test data to Azure Storage.
       "export CLOUD_SDK_REPO=\"cloud-sdk-$(lsb_release -c -s)\"",
       "echo \"deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main\" | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list",
       "curl -sS https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -",
       "sudo apt-get -qqy update >/dev/null",
-      "sudo apt-get -qqy install google-cloud-sdk >/dev/null",
+      "sudo apt-get -qqy install google-cloud-sdk ntp supervisor ntpdate >/dev/null",
       # Install CockroachDB.
       "mkdir /mnt/data0/logs",
       "ln -sf /mnt/data0/logs logs",
-      "chmod 755 cockroach nodectl",
       "[ $(stat --format=%s cockroach) -ne 0 ] || curl -sfSL https://edge-binaries.cockroachdb.com/cockroach/cockroach.linux-gnu-amd64.${var.cockroach_sha} -o cockroach",
       "chmod +x cockroach",
+      # Restart supervisord with the custom config.
+      "sudo service supervisor stop",
       "if [ ! -e supervisor.pid ]; then supervisord -c supervisor.conf; fi",
+      # Disable hypervisor clock sync, because it can cause an unrecoverable
+      # amount of clock skew. This also forces an NTP sync.
+      "./disable-hyperv",
+      # Start CockroachDB.
       "supervisorctl -c supervisor.conf start cockroach",
       # Install load generators.
       "curl -sfSL https://edge-binaries.cockroachdb.com/examples-go/block_writer.${var.block_writer_sha} -o block_writer",


### PR DESCRIPTION
hyper-v time synchronization appears to be the cause of various issues,
including some recent failures of TestRebalance_3To5Small and the
requirement that the max clock offset be set to the rather high 1 second
for our nightlies. This change disables the faulty time sync by using
the same approach the prod scripts use.