### PR TITLE
sql: move some descriptor mutation state related functions to sqlbase

### DIFF
--- a/pkg/ccl/sqlccl/load.go
+++ b/pkg/ccl/sqlccl/load.go
@@ -163,7 +163,8 @@ func Load(
 			if err != nil {
 				return BackupDescriptor{}, errors.Wrap(err, "make row inserter")
 			}
-			cols, defaultExprs, err = sql.ProcessDefaultColumns(tableDesc.Columns, tableDesc, &parse, &evalCtx)
+			cols, defaultExprs, err =
+				sqlbase.ProcessDefaultColumns(tableDesc.Columns, tableDesc, &parse, &evalCtx)
 			if err != nil {
 				return BackupDescriptor{}, errors.Wrap(err, "process default columns")
 			}

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1503,6 +1503,21 @@ func (desc *TableDescriptor) FindIndexByID(id IndexID) (*IndexDescriptor, error)
 	return nil, fmt.Errorf("index-id \"%d\" does not exist", id)
 }
 
+// GetIndexMutationCapabilities returns:
+// 1. Whether the index is a mutation
+// 2. if so, is it in state WRITE_ONLY
+func (desc *TableDescriptor) GetIndexMutationCapabilities(id IndexID) (bool, bool) {
+	for _, mutation := range desc.Mutations {
+		if mutationIndex := mutation.GetIndex(); mutationIndex != nil {
+			if mutationIndex.ID == id {
+				return true,
+					mutation.State == DescriptorMutation_WRITE_ONLY
+			}
+		}
+	}
+	return false, false
+}
+
 // IsInterleaved returns true if any part of this this table is interleaved with
 // another table's data.
 func (desc *TableDescriptor) IsInterleaved() bool {


### PR DESCRIPTION
After this change descriptor mutation state is only referenced
within sqlbase methods and the schema change state machine in
sql.