### PR TITLE
sql: don't try to add index in ALTER...ADD FK

### DIFF
--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -912,7 +912,11 @@ func resolveFK(
 			}
 		}
 		if !found {
-			return fmt.Errorf("foreign key requires table %q have a unique index on %s", targetTable.String(), colNames(targetCols))
+			return pgerror.NewErrorf(
+				pgerror.CodeInvalidForeignKeyError,
+				"there is no unique constraint matching given keys for referenced table %s",
+				targetTable.String(),
+			)
 		}
 	}
 
@@ -929,7 +933,8 @@ func resolveFK(
 
 	if matchesIndex(srcCols, tbl.PrimaryIndex, matchPrefix) {
 		if tbl.PrimaryIndex.ForeignKey.IsSet() {
-			return fmt.Errorf("columns cannot be used by multiple foreign key constraints")
+			return pgerror.NewErrorf(pgerror.CodeInvalidForeignKeyError,
+				"columns cannot be used by multiple foreign key constraints")
 		}
 		tbl.PrimaryIndex.ForeignKey = ref
 		backref.Index = tbl.PrimaryIndex.ID
@@ -938,7 +943,8 @@ func resolveFK(
 		for i := range tbl.Indexes {
 			if matchesIndex(srcCols, tbl.Indexes[i], matchPrefix) {
 				if tbl.Indexes[i].ForeignKey.IsSet() {
-					return fmt.Errorf("columns cannot be used by multiple foreign key constraints")
+					return pgerror.NewErrorf(pgerror.CodeInvalidForeignKeyError,
+						"columns cannot be used by multiple foreign key constraints")
 				}
 				tbl.Indexes[i].ForeignKey = ref
 				backref.Index = tbl.Indexes[i].ID
@@ -947,6 +953,11 @@ func resolveFK(
 			}
 		}
 		if !found {
+			// Avoid unexpected index builds from ALTER TABLE ADD CONSTRAINT.
+			if mode == sqlbase.ConstraintValidity_Unvalidated {
+				return pgerror.NewErrorf(pgerror.CodeInvalidForeignKeyError,
+					"foreign key requires an existing index on columns %s", colNames(srcCols))
+			}
 			added, err := addIndexForFK(tbl, srcCols, constraintName, ref)
 			if err != nil {
 				return err

--- a/pkg/sql/testdata/logic_test/fk
+++ b/pkg/sql/testdata/logic_test/fk
@@ -32,7 +32,7 @@ unindexed  primary                                         true    1    rowid   
 unindexed  unindexed_auto_index_fk_customer_ref_customers  false   1    customer  ASC        false    false
 unindexed  unindexed_auto_index_fk_customer_ref_customers  false   2    rowid     ASC        false    true
 
-statement error foreign key requires table "products" have a unique index on \("vendor"\)
+statement error there is no unique constraint matching given keys for referenced table products
 CREATE TABLE non_unique (product STRING REFERENCES products (vendor))
 
 statement error type of "customer" \(INT\) does not match foreign key "customers"."email" \(STRING\)
@@ -628,8 +628,20 @@ statement ok
 CREATE TABLE b (id SERIAL NOT NULL, PRIMARY KEY (id))
 
 # Adding a self-ref FK to an _existing_ table also works.
+statement error foreign key requires an existing index on columns \("self_id"\)
+ALTER TABLE a ADD CONSTRAINT fk_self_id FOREIGN KEY (self_id) REFERENCES a;
+
+statement ok
+CREATE INDEX ON a (self_id);
+
 statement ok
 ALTER TABLE a ADD CONSTRAINT fk_self_id FOREIGN KEY (self_id) REFERENCES a;
+
+statement error foreign key requires an existing index on columns \("b_id"\)
+ALTER TABLE a ADD CONSTRAINT fk_b FOREIGN KEY (b_id) REFERENCES b;
+
+statement ok
+CREATE INDEX ON a (b_id);
 
 statement ok
 ALTER TABLE a ADD CONSTRAINT fk_b FOREIGN KEY (b_id) REFERENCES b;
@@ -718,3 +730,22 @@ DROP TABLE refers1
 
 statement ok
 COMMIT
+
+
+statement ok
+CREATE TABLE a (id BIGSERIAL NOT NULL, self_id INT, b_id INT UNIQUE NOT NULL, PRIMARY KEY (id));
+
+statement error foreign key requires an existing index on columns \("self_id"\)
+ALTER TABLE a ADD CONSTRAINT fk_self_id FOREIGN KEY (self_id) REFERENCES a(b_id);
+
+statement ok
+DROP TABLE a;
+
+statement ok
+CREATE TABLE a (id BIGSERIAL NOT NULL, self_id INT, b_id INT UNIQUE NOT NULL, PRIMARY KEY (id));
+
+statement error foreign key requires an existing index on columns \("self_id"\)
+ALTER TABLE a ADD CONSTRAINT fk_self_id FOREIGN KEY (self_id) REFERENCES a(b_id);
+
+statement ok
+DROP TABLE a;


### PR DESCRIPTION
ALTER...ADD FOREIGN KEY reuses the index resolution and modification logic used in CREATE TABLE...FOREIGN KEY.

However, as of 668f3c74, that logic included *adding* the required source index to the table if it didn't exist. This is fine during CREATE TABLE, but is *not* fine for an existing table, when index additions need to go though the schema change process to be staged, backfilled, etc correctly.