### PR TITLE
storage: declare fewer spans during GC

### DIFF
--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -199,7 +199,10 @@ func RangeStatsKey(rangeID roachpb.RangeID) roachpb.Key {
 	return MakeRangeIDPrefixBuf(rangeID).RangeStatsKey()
 }
 
-// RangeLastGCKey returns a system-local key for the last GC.
+// RangeLastGCKey returns a system-local key for last used GC threshold on the
+// user keyspace. Reads and writes <= this timestamp will not be served.
+//
+// TODO(tschottdorf): should be renamed to RangeGCThresholdKey.
 func RangeLastGCKey(rangeID roachpb.RangeID) roachpb.Key {
 	return MakeRangeIDPrefixBuf(rangeID).RangeLastGCKey()
 }

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -559,25 +559,38 @@ func (gcq *gcQueue) processImpl(
 		info.updateMetrics(gcq.store.metrics)
 	}()
 
-	var ba roachpb.BatchRequest
-	var gcArgs roachpb.GCRequest
-	// TODO(tschottdorf): This is one of these instances in which we want
-	// to be more careful that the request ends up on the correct Replica,
-	// and we might have to worry about mixing range-local and global keys
-	// in a batch which might end up spanning Ranges by the time it executes.
-	gcArgs.Key = desc.StartKey.AsRawKey()
-	gcArgs.EndKey = desc.EndKey.AsRawKey()
-	gcArgs.Keys = gcKeys
-	gcArgs.Threshold = info.Threshold
-	gcArgs.TxnSpanGCThreshold = info.TxnSpanGCThreshold
+	batches := func() []roachpb.GCRequest {
+		var template roachpb.GCRequest
+		template.Key = desc.StartKey.AsRawKey()
+		template.EndKey = desc.EndKey.AsRawKey()
 
-	// Technically not needed since we're talking directly to the Range.
-	ba.RangeID = desc.RangeID
-	ba.Timestamp = now
-	ba.Add(&gcArgs)
-	if _, pErr := repl.Send(ctx, ba); pErr != nil {
-		log.ErrEvent(ctx, pErr.String())
-		return pErr.GoError()
+		gc1 := template
+		gc1.Threshold = info.Threshold
+		gc1.TxnSpanGCThreshold = info.TxnSpanGCThreshold
+
+		gc2 := template
+		gc2.Keys = gcKeys
+
+		return []roachpb.GCRequest{gc1, gc2}
+	}()
+
+	for i, gcArgs := range batches {
+		var ba roachpb.BatchRequest
+
+		// Technically not needed since we're talking directly to the Range.
+		ba.RangeID = desc.RangeID
+		ba.Timestamp = now
+
+		// TODO(tschottdorf): This is one of these instances in which we want
+		// to be more careful that the request ends up on the correct Replica,
+		// and we might have to worry about mixing range-local and global keys
+		// in a batch which might end up spanning Ranges by the time it executes.
+		ba.Add(&gcArgs)
+		log.Eventf(ctx, "sending batch %d of %d", i, len(batches))
+		if _, pErr := repl.Send(ctx, ba); pErr != nil {
+			log.ErrEvent(ctx, pErr.String())
+			return pErr.GoError()
+		}
 	}
 
 	log.Eventf(ctx, "done GC'ing, new score is %s", makeGCQueueScore(ctx, repl, repl.store.Clock().Now(), sysCfg))

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1371,20 +1371,29 @@ func evalHeartbeatTxn(
 func declareKeysGC(
 	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *SpanSet,
 ) {
+	// Intentionally don't call DefaultDeclareKeys: the key range in the header
+	// is usually the whole range (pending resolution of #7880).
 	gcr := req.(*roachpb.GCRequest)
 	for _, key := range gcr.Keys {
 		spans.Add(SpanReadWrite, roachpb.Span{Key: key.Key})
 	}
-	spans.Add(SpanReadWrite, roachpb.Span{Key: keys.RangeLastGCKey(header.RangeID)})
-	spans.Add(SpanReadWrite, roachpb.Span{
-		// TODO(bdarnell): since this must be checked by all
-		// reads, this should be factored out into a separate
-		// waiter which blocks only those reads far enough in the
-		// past to be affected by the in-flight GCRequest (i.e.
-		// normally none). This means this key would be special
-		// cased and not tracked by the command queue.
-		Key: keys.RangeTxnSpanGCThresholdKey(header.RangeID),
-	})
+	// Be smart here about blocking on the threshold keys. The GC queue can send an empty
+	// request first to bump the thresholds, and then another one that actually does work
+	// but can avoid declaring these keys below.
+	if gcr.Threshold != (hlc.Timestamp{}) {
+		spans.Add(SpanReadWrite, roachpb.Span{Key: keys.RangeLastGCKey(header.RangeID)})
+	}
+	if gcr.TxnSpanGCThreshold != (hlc.Timestamp{}) {
+		spans.Add(SpanReadWrite, roachpb.Span{
+			// TODO(bdarnell): since this must be checked by all
+			// reads, this should be factored out into a separate
+			// waiter which blocks only those reads far enough in the
+			// past to be affected by the in-flight GCRequest (i.e.
+			// normally none). This means this key would be special
+			// cased and not tracked by the command queue.
+			Key: keys.RangeTxnSpanGCThresholdKey(header.RangeID),
+		})
+	}
 	spans.Add(SpanReadOnly, roachpb.Span{Key: keys.RangeDescriptorKey(desc.StartKey)})
 }
 
@@ -1418,30 +1427,48 @@ func evalGC(
 		return EvalResult{}, err
 	}
 
-	newThreshold, err := cArgs.EvalCtx.GCThreshold()
-	if err != nil {
-		return EvalResult{}, err
-	}
-	newTxnSpanGCThreshold, err := cArgs.EvalCtx.TxnSpanGCThreshold()
-	if err != nil {
-		return EvalResult{}, err
-	}
 	// Protect against multiple GC requests arriving out of order; we track
 	// the maximum timestamps.
-	newThreshold.Forward(args.Threshold)
-	newTxnSpanGCThreshold.Forward(args.TxnSpanGCThreshold)
 
-	var pd EvalResult
-	pd.Replicated.State.GCThreshold = newThreshold
-	pd.Replicated.State.TxnSpanGCThreshold = newTxnSpanGCThreshold
-
-	stateLoader := makeReplicaStateLoader(cArgs.EvalCtx.RangeID())
-	if err := stateLoader.setGCThreshold(ctx, batch, cArgs.Stats, &newThreshold); err != nil {
-		return EvalResult{}, err
+	var newThreshold hlc.Timestamp
+	if args.Threshold != (hlc.Timestamp{}) {
+		oldThreshold, err := cArgs.EvalCtx.GCThreshold()
+		if err != nil {
+			return EvalResult{}, err
+		}
+		newThreshold = oldThreshold
+		newThreshold.Forward(args.Threshold)
 	}
 
-	if err := stateLoader.setTxnSpanGCThreshold(ctx, batch, cArgs.Stats, &newTxnSpanGCThreshold); err != nil {
-		return EvalResult{}, err
+	var newTxnSpanGCThreshold hlc.Timestamp
+	if args.TxnSpanGCThreshold != (hlc.Timestamp{}) {
+		oldTxnSpanGCThreshold, err := cArgs.EvalCtx.TxnSpanGCThreshold()
+		if err != nil {
+			return EvalResult{}, err
+		}
+		newTxnSpanGCThreshold = oldTxnSpanGCThreshold
+		newTxnSpanGCThreshold.Forward(args.TxnSpanGCThreshold)
+	}
+
+	var pd EvalResult
+	stateLoader := makeReplicaStateLoader(cArgs.EvalCtx.RangeID())
+
+	// Don't write these keys unless we have to. We also don't declare these
+	// keys unless we have to (to allow the GC queue to batch requests more
+	// efficiently), and we must honor what we declare.
+
+	if newThreshold != (hlc.Timestamp{}) {
+		pd.Replicated.State.GCThreshold = newThreshold
+		if err := stateLoader.setGCThreshold(ctx, batch, cArgs.Stats, &newThreshold); err != nil {
+			return EvalResult{}, err
+		}
+	}
+
+	if newTxnSpanGCThreshold != (hlc.Timestamp{}) {
+		pd.Replicated.State.TxnSpanGCThreshold = newTxnSpanGCThreshold
+		if err := stateLoader.setTxnSpanGCThreshold(ctx, batch, cArgs.Stats, &newTxnSpanGCThreshold); err != nil {
+			return EvalResult{}, err
+		}
 	}
 
 	return pd, nil

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -7220,6 +7220,55 @@ func TestAmbiguousResultErrorOnRetry(t *testing.T) {
 	}
 }
 
+// TestGCWithoutThreshold validates that GCRequest only declares the threshold
+// keys which are subject to change, and that it does not access these keys if
+// it does not declare them.
+func TestGCWithoutThreshold(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	desc := roachpb.RangeDescriptor{StartKey: roachpb.RKey("a"), EndKey: roachpb.RKey("z")}
+	ctx := context.Background()
+
+	options := []hlc.Timestamp{{}, hlc.Timestamp{}.Add(1, 0)}
+
+	for i, keyThresh := range options {
+		for j, txnThresh := range options {
+			func() {
+				var gc roachpb.GCRequest
+				var spans SpanSet
+
+				gc.Threshold = keyThresh
+				gc.TxnSpanGCThreshold = txnThresh
+				declareKeysGC(desc, roachpb.Header{}, &gc, &spans)
+
+				if num, exp := spans.len(), i+j+1; num != exp {
+					t.Fatalf("(%s,%s): expected %d declared keys, found %d",
+						keyThresh, txnThresh, exp, num)
+				}
+
+				eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+				defer eng.Close()
+
+				batch := eng.NewBatch()
+				defer batch.Close()
+				rw := makeSpanSetBatch(batch, &spans)
+
+				var resp roachpb.GCResponse
+
+				if _, err := evalGC(ctx, rw, CommandArgs{
+					Args: &gc,
+					EvalCtx: ReplicaEvalContext{
+						repl: &Replica{},
+						ss:   &spans,
+					},
+				}, &resp); err != nil {
+					t.Fatalf("at (%s,%s): %s", keyThresh, txnThresh, err)
+				}
+			}()
+		}
+	}
+}
+
 // TestCommandTimeThreshold verifies that commands outside the replica GC
 // threshold fail.
 func TestCommandTimeThreshold(t *testing.T) {

--- a/pkg/storage/span_set.go
+++ b/pkg/storage/span_set.go
@@ -53,6 +53,16 @@ type SpanSet struct {
 	spans [numSpanAccess][numSpanScope][]roachpb.Span
 }
 
+func (ss *SpanSet) len() int {
+	var count int
+	for i := SpanAccess(0); i < numSpanAccess; i++ {
+		for j := spanScope(0); j < numSpanScope; j++ {
+			count += len(ss.getSpans(i, j))
+		}
+	}
+	return count
+}
+
 // reserve space for N additional keys.
 func (ss *SpanSet) reserve(access SpanAccess, scope spanScope, n int) {
 	existing := ss.spans[access][scope]


### PR DESCRIPTION
If a GCRequest does not modify the GC threshold timestamps, it does
not need to declare their keys. This is useful because it allows the
GC queue to send a very small request with the threshold adjustments
first, and then a larger request that does not need to declare the
threshold keys and does less harm if it's slow.

We should additionally limit the size of each "big" `GCRequest`, but
that fits well in a follow-up PR.