### PR TITLE
settings: add change callbacks

### DIFF
--- a/pkg/ccl/storageccl/engineccl/mvcc.go
+++ b/pkg/ccl/storageccl/engineccl/mvcc.go
@@ -53,7 +53,7 @@ type MVCCIncrementalIterator struct {
 var TimeBoundIteratorsEnabled = func() *settings.BoolSetting {
 	name := "enterprise.kv.timebound_iterator.enabled"
 	s := settings.RegisterBoolSetting(name, "speed up incremental backups by efficiently skipping over old SSTs", false)
-	settings.Hide(name)
+	s.Hide()
 	return s
 }()
 

--- a/pkg/ccl/utilccl/license_check.go
+++ b/pkg/ccl/utilccl/license_check.go
@@ -15,9 +15,8 @@ import (
 
 // EnterpriseEnabled is temporary, until #14114 is implemented.
 var EnterpriseEnabled = func() *settings.BoolSetting {
-	name := "enterprise.enabled"
-	s := settings.RegisterBoolSetting(name, "set to true to enable Enterprise features", false)
-	settings.Hide(name)
+	s := settings.RegisterBoolSetting("enterprise.enabled", "set to true to enable Enterprise features", false)
+	s.Hide()
 	return s
 }()
 

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -955,14 +955,14 @@ func (s *adminServer) Settings(
 
 	resp := serverpb.SettingsResponse{KeyValues: make(map[string]serverpb.SettingsResponse_Value)}
 	for _, k := range keys {
-		v, desc, ok := settings.Lookup(k)
+		v, ok := settings.Lookup(k)
 		if !ok {
 			continue
 		}
 		resp.KeyValues[k] = serverpb.SettingsResponse_Value{
 			Type:        v.Typ(),
 			Value:       v.String(),
-			Description: desc,
+			Description: v.Description(),
 		}
 	}
 

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -836,7 +836,7 @@ func TestAdminAPISettings(t *testing.T) {
 	allKeys := settings.Keys()
 
 	checkSetting := func(t *testing.T, k string, v serverpb.SettingsResponse_Value) {
-		ref, desc, ok := settings.Lookup(k)
+		ref, ok := settings.Lookup(k)
 		if !ok {
 			t.Fatalf("%s: not found after initial lookup", k)
 		}
@@ -846,7 +846,7 @@ func TestAdminAPISettings(t *testing.T) {
 			t.Errorf("%s: expected value %s, got %s", k, ref, v.Value)
 		}
 
-		if desc != v.Description {
+		if desc := ref.Description(); desc != v.Description {
 			t.Errorf("%s: expected description %s, got %s", k, desc, v.Description)
 		}
 		if typ != v.Type {

--- a/pkg/settings/bool.go
+++ b/pkg/settings/bool.go
@@ -24,6 +24,7 @@ import (
 type BoolSetting struct {
 	defaultValue bool
 	v            int32
+	common
 }
 
 var _ Setting = &BoolSetting{}

--- a/pkg/settings/bool.go
+++ b/pkg/settings/bool.go
@@ -22,9 +22,9 @@ import (
 // updated automatically when the corresponding cluster-wide setting
 // of type "bool" is updated.
 type BoolSetting struct {
-	defaultValue bool
-	v            int32
 	common
+	v            int32
+	defaultValue bool
 }
 
 var _ Setting = &BoolSetting{}
@@ -44,10 +44,12 @@ func (*BoolSetting) Typ() string {
 }
 
 func (b *BoolSetting) set(v bool) {
+	vInt := int32(0)
 	if v {
-		atomic.StoreInt32(&b.v, 1)
-	} else {
-		atomic.StoreInt32(&b.v, 0)
+		vInt = 1
+	}
+	if atomic.SwapInt32(&b.v, vInt) != vInt {
+		b.changed()
 	}
 }
 
@@ -79,4 +81,10 @@ func TestingSetBool(s **BoolSetting, v bool) func() {
 	return func() {
 		*s = saved
 	}
+}
+
+// OnChange registers a callback to be called when the setting changes.
+func (b *BoolSetting) OnChange(fn func()) *BoolSetting {
+	b.setOnChange(fn)
+	return b
 }

--- a/pkg/settings/byte_size.go
+++ b/pkg/settings/byte_size.go
@@ -70,3 +70,9 @@ func TestingSetByteSize(s **ByteSizeSetting, v int64) func() {
 		*s = saved
 	}
 }
+
+// OnChange registers a callback to be called when the setting changes.
+func (b *ByteSizeSetting) OnChange(fn func()) *ByteSizeSetting {
+	b.setOnChange(fn)
+	return b
+}

--- a/pkg/settings/doc.go
+++ b/pkg/settings/doc.go
@@ -45,5 +45,15 @@ like respecting an opt-*out* setting, we can default to `false` (opted out) and
 then use a migration to write an explicit `true`: in practice you'd still expect
 to read `true` unless a preference is expressed, but in the rare cases where you
 read a default, you don't risk ignoring an expressed opt-out.
+
+Ideally, when passing configuration into some structure or subsystem, e.g.
+a rate limit into a client or something, passing a `*FooSetting rather than a
+`Foo` and waiting to call `.Get()` until the value is actually used ensures
+observing the latest value.
+
+Existing/off-the-shelf systems generally will not be defined in terms of our
+settings, but if they can either be swapped at runtime or expose some `setFoo`
+method, that can be used in conjunction with an change callback registered via
+OnChange.
 */
 package settings

--- a/pkg/settings/duration.go
+++ b/pkg/settings/duration.go
@@ -28,6 +28,7 @@ type DurationSetting struct {
 	defaultValue time.Duration
 	v            int64
 	validateFn   func(time.Duration) error
+	common
 }
 
 var _ Setting = &DurationSetting{}

--- a/pkg/settings/enum.go
+++ b/pkg/settings/enum.go
@@ -119,3 +119,9 @@ func TestingSetEnum(s **EnumSetting, i int64) func() {
 		*s = saved
 	}
 }
+
+// OnChange registers a callback to be called when the setting changes.
+func (e *EnumSetting) OnChange(fn func()) *EnumSetting {
+	e.setOnChange(fn)
+	return e
+}

--- a/pkg/settings/float.go
+++ b/pkg/settings/float.go
@@ -28,6 +28,7 @@ type FloatSetting struct {
 	defaultValue float64
 	v            uint64
 	validateFn   func(float64) error
+	common
 }
 
 var _ Setting = &FloatSetting{}

--- a/pkg/settings/float.go
+++ b/pkg/settings/float.go
@@ -25,10 +25,10 @@ import (
 // updated automatically when the corresponding cluster-wide setting
 // of type "float" is updated.
 type FloatSetting struct {
+	common
 	defaultValue float64
 	v            uint64
 	validateFn   func(float64) error
-	common
 }
 
 var _ Setting = &FloatSetting{}
@@ -61,7 +61,9 @@ func (f *FloatSetting) set(v float64) error {
 	if err := f.Validate(v); err != nil {
 		return err
 	}
-	atomic.StoreUint64(&f.v, math.Float64bits(v))
+	if bits := math.Float64bits(v); atomic.SwapUint64(&f.v, bits) != bits {
+		f.changed()
+	}
 	return nil
 }
 
@@ -115,4 +117,10 @@ func TestingSetFloat(s **FloatSetting, v float64) func() {
 	return func() {
 		*s = saved
 	}
+}
+
+// OnChange registers a callback to be called when the setting changes.
+func (f *FloatSetting) OnChange(fn func()) *FloatSetting {
+	f.common.setOnChange(fn)
+	return f
 }

--- a/pkg/settings/int.go
+++ b/pkg/settings/int.go
@@ -27,6 +27,7 @@ type IntSetting struct {
 	defaultValue int64
 	v            int64
 	validateFn   func(int64) error
+	common
 }
 
 var _ Setting = &IntSetting{}

--- a/pkg/settings/int.go
+++ b/pkg/settings/int.go
@@ -24,10 +24,10 @@ import (
 // updated automatically when the corresponding cluster-wide setting
 // of type "int" is updated.
 type IntSetting struct {
+	common
 	defaultValue int64
 	v            int64
 	validateFn   func(int64) error
-	common
 }
 
 var _ Setting = &IntSetting{}
@@ -60,7 +60,9 @@ func (i *IntSetting) set(v int64) error {
 	if err := i.Validate(v); err != nil {
 		return err
 	}
-	atomic.StoreInt64(&i.v, v)
+	if atomic.SwapInt64(&i.v, v) != v {
+		i.changed()
+	}
 	return nil
 }
 
@@ -101,4 +103,10 @@ func TestingSetInt(s **IntSetting, v int64) func() {
 	return func() {
 		*s = saved
 	}
+}
+
+// OnChange registers a callback to be called when the setting changes.
+func (i *IntSetting) OnChange(fn func()) *IntSetting {
+	i.setOnChange(fn)
+	return i
 }

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -52,6 +52,7 @@ func register(key, desc string, s Setting) {
 		panic(fmt.Sprintf("setting already defined: %s", key))
 	}
 	s.setToDefault()
+	s.setDescription(desc)
 	registry[key] = s
 }
 

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -22,12 +22,18 @@ type Setting interface {
 	String() string
 
 	Description() string
+	setDescription(desc string)
 	Hidden() bool
 }
 
 type common struct {
 	description string
 	hidden      bool
+	onChange    func()
+}
+
+func (i *common) setDescription(s string) {
+	i.description = s
 }
 
 func (i common) Description() string {
@@ -37,6 +43,12 @@ func (i common) Hidden() bool {
 	return i.hidden
 }
 
+func (i common) changed() {
+	if i.onChange != nil {
+		i.onChange()
+	}
+}
+
 // Hide prevents a setting from showing up in SHOW ALL CLUSTER SETTINGS. It can
 // still be used with SET and SHOW if the exact setting name is known. Use Hide
 // for in-development features and other settings that should not be
@@ -44,6 +56,12 @@ func (i common) Hidden() bool {
 func (i *common) Hide() {
 	i.hidden = true
 }
+
+// setOnChange installs a callback to be called when a setting's value changes.
+// `fn` should avoid doing long-running or blocking work as it is called on the
+// goroutine which handles all settings updates.
+func (i *common) setOnChange(fn func()) {
+	i.onChange = fn
 }
 
 type numericSetting interface {

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -20,6 +20,30 @@ type Setting interface {
 	// Typ returns the short (1 char) string denoting the type of setting.
 	Typ() string
 	String() string
+
+	Description() string
+	Hidden() bool
+}
+
+type common struct {
+	description string
+	hidden      bool
+}
+
+func (i common) Description() string {
+	return i.description
+}
+func (i common) Hidden() bool {
+	return i.hidden
+}
+
+// Hide prevents a setting from showing up in SHOW ALL CLUSTER SETTINGS. It can
+// still be used with SET and SHOW if the exact setting name is known. Use Hide
+// for in-development features and other settings that should not be
+// user-visible.
+func (i *common) Hide() {
+	i.hidden = true
+}
 }
 
 type numericSetting interface {

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -36,7 +36,10 @@ var fA = settings.RegisterFloatSetting("f", "", 5.4)
 var dA = settings.RegisterDurationSetting("d", "", time.Second)
 var eA = settings.RegisterEnumSetting("e", "", "foo", map[int64]string{1: "foo", 2: "bar", 3: "baz"})
 var byteSize = settings.RegisterByteSizeSetting("zzz", "", mb)
-var _ = settings.RegisterBoolSetting("sekretz", "", false)
+var _ = func() {
+	settings.RegisterBoolSetting("sekretz", "", false).Hide()
+}
+
 var strVal = settings.RegisterValidatedStringSetting(
 	"str.val", "", "", func(v string) error {
 		for _, c := range v {
@@ -62,10 +65,6 @@ var iVal = settings.RegisterValidatedIntSetting(
 		}
 		return nil
 	})
-
-func init() {
-	settings.Hide("sekretz")
-}
 
 func TestCache(t *testing.T) {
 	t.Run("defaults", func(t *testing.T) {
@@ -117,28 +116,28 @@ func TestCache(t *testing.T) {
 	})
 
 	t.Run("lookup", func(t *testing.T) {
-		if actual, _, ok := settings.Lookup("i.1"); !ok || i1A != actual {
+		if actual, ok := settings.Lookup("i.1"); !ok || i1A != actual {
 			t.Fatalf("expected %v, got %v (exists: %v)", i1A, actual, ok)
 		}
-		if actual, _, ok := settings.Lookup("i.Val"); !ok || iVal != actual {
+		if actual, ok := settings.Lookup("i.Val"); !ok || iVal != actual {
 			t.Fatalf("expected %v, got %v (exists: %v)", iVal, actual, ok)
 		}
-		if actual, _, ok := settings.Lookup("f"); !ok || fA != actual {
+		if actual, ok := settings.Lookup("f"); !ok || fA != actual {
 			t.Fatalf("expected %v, got %v (exists: %v)", fA, actual, ok)
 		}
-		if actual, _, ok := settings.Lookup("fVal"); !ok || fVal != actual {
+		if actual, ok := settings.Lookup("fVal"); !ok || fVal != actual {
 			t.Fatalf("expected %v, got %v (exists: %v)", fVal, actual, ok)
 		}
-		if actual, _, ok := settings.Lookup("d"); !ok || dA != actual {
+		if actual, ok := settings.Lookup("d"); !ok || dA != actual {
 			t.Fatalf("expected %v, got %v (exists: %v)", dA, actual, ok)
 		}
-		if actual, _, ok := settings.Lookup("dVal"); !ok || dVal != actual {
+		if actual, ok := settings.Lookup("dVal"); !ok || dVal != actual {
 			t.Fatalf("expected %v, got %v (exists: %v)", dVal, actual, ok)
 		}
-		if actual, _, ok := settings.Lookup("e"); !ok || eA != actual {
+		if actual, ok := settings.Lookup("e"); !ok || eA != actual {
 			t.Fatalf("expected %v, got %v (exists: %v)", eA, actual, ok)
 		}
-		if actual, _, ok := settings.Lookup("dne"); ok {
+		if actual, ok := settings.Lookup("dne"); ok {
 			t.Fatalf("expected nothing, got %v", actual)
 		}
 	})

--- a/pkg/settings/string.go
+++ b/pkg/settings/string.go
@@ -27,6 +27,7 @@ type StringSetting struct {
 	defaultValue string
 	v            atomic.Value
 	validateFn   func(string) error
+	common
 }
 
 var _ Setting = &StringSetting{}

--- a/pkg/settings/string.go
+++ b/pkg/settings/string.go
@@ -43,7 +43,11 @@ func (*StringSetting) Typ() string {
 
 // Get retrieves the string value in the setting.
 func (s *StringSetting) Get() string {
-	return s.v.Load().(string)
+	loaded := s.v.Load()
+	if loaded == nil {
+		return ""
+	}
+	return loaded.(string)
 }
 
 // Validate that a value conforms with the validation function.
@@ -60,7 +64,11 @@ func (s *StringSetting) set(v string) error {
 	if err := s.Validate(v); err != nil {
 		return err
 	}
+	if s.Get() == v {
+		return nil
+	}
 	s.v.Store(v)
+	s.changed()
 	return nil
 }
 
@@ -105,4 +113,11 @@ func TestingSetString(s **StringSetting, v string) func() {
 	return func() {
 		*s = saved
 	}
+}
+
+// OnChange registers a callback to be called when the setting changes.
+// This overrides the `common`` impl to return the concrete impl type.
+func (s *StringSetting) OnChange(fn func()) *StringSetting {
+	s.setOnChange(fn)
+	return s
 }

--- a/pkg/settings/updater.go
+++ b/pkg/settings/updater.go
@@ -63,11 +63,11 @@ func (u Updater) Set(key, rawValue, vt string) error {
 	}
 	u[key] = struct{}{}
 
-	if expected := d.setting.Typ(); vt != expected {
+	if expected := d.Typ(); vt != expected {
 		return errors.Errorf("setting '%s' defined as type %s, not %s", key, expected, vt)
 	}
 
-	switch setting := d.setting.(type) {
+	switch setting := d.(type) {
 	case *StringSetting:
 		return setting.set(rawValue)
 	case *BoolSetting:
@@ -109,7 +109,7 @@ func (u Updater) Set(key, rawValue, vt string) error {
 func (u Updater) Done() {
 	for k, v := range registry {
 		if _, ok := u[k]; !ok {
-			v.setting.setToDefault()
+			v.setToDefault()
 		}
 	}
 }

--- a/pkg/sql/set.go
+++ b/pkg/sql/set.go
@@ -96,7 +96,7 @@ func (p *planner) setClusterSetting(
 	if err := p.RequireSuperUser("SET CLUSTER SETTING"); err != nil {
 		return nil, err
 	}
-	typ, _, ok := settings.Lookup(name)
+	typ, ok := settings.Lookup(name)
 	if !ok {
 		return nil, errors.Errorf("unknown cluster setting '%s'", name)
 	}

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -153,12 +153,12 @@ func (p *planner) showClusterSetting(name string) (planNode, error) {
 		}
 		populate = func(ctx context.Context, v *valuesNode) error {
 			for _, k := range settings.Keys() {
-				setting, desc, _ := settings.Lookup(k)
+				setting, _ := settings.Lookup(k)
 				if _, err := v.rows.AddRow(ctx, parser.Datums{
 					parser.NewDString(k),
 					parser.NewDString(setting.String()),
 					parser.NewDString(setting.Typ()),
-					parser.NewDString(desc),
+					parser.NewDString(setting.Description()),
 				}); err != nil {
 					return err
 				}
@@ -167,7 +167,7 @@ func (p *planner) showClusterSetting(name string) (planNode, error) {
 		}
 
 	default:
-		val, _, ok := settings.Lookup(name)
+		val, ok := settings.Lookup(name)
 		if !ok {
 			return nil, errors.Errorf("unknown setting: %q", name)
 		}


### PR DESCRIPTION
First commit is a refactor to the settings registry to invert wrapping/embedding of the common helpers (previously `wrappedSetting`) and the individual concrete impls.

My kingdom for generics in the second commit -- having to override the common helper just to return the concrete impl type is kinda gross.