### PR TITLE
cherrypick: tracing: fix snowball tracing when tracing disabled

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -944,7 +944,8 @@ func (n *Node) setupSpanForIncomingRPC(
 				if err == nil {
 					br.CollectedSpans = append(br.CollectedSpans, encSp)
 				} else {
-					log.Warning(ctx, err)
+					// We can't log to the finished span; strip the span from the context.
+					log.Warning(opentracing.ContextWithSpan(ctx, nil), err)
 				}
 			}
 		}

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -26,8 +26,10 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
 func rowsToStrings(rows *gosql.Rows) [][]string {
@@ -84,43 +86,65 @@ func prettyPrint(m [][]string) string {
 
 func TestExplainTrace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	params, _ := createTestServerParams()
-	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop(context.TODO())
 
-	if _, err := sqlDB.Exec(`CREATE DATABASE test; CREATE TABLE test.foo (id INT PRIMARY KEY)`); err != nil {
-		t.Fatal(err)
-	}
-	rows, err := sqlDB.Query(`EXPLAIN (TRACE) SELECT * FROM test.foo`)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer rows.Close()
-	expParts := []string{"explain trace", "grpcTransport SendNext", "node.Batch"}
-	var parts []string
-
-	pretty := rowsToStrings(rows)
-	for _, row := range pretty[1:] {
-		part := row[3] // Operation
-		if ind := sort.SearchStrings(parts, part); ind == len(parts) || parts[ind] != part {
-			parts = append(parts, part)
-			sort.Strings(parts)
+	// EXPLAIN (TRACE) needs to work regardless of whether tracing is enabled. Test both cases.
+	for _, enableTr := range []bool{false, true} {
+		name := "TracingOff"
+		if enableTr {
+			name = "TracingOn"
 		}
-	}
-	sort.Strings(expParts)
-	if err := rows.Err(); err != nil {
-		t.Fatal(err)
-	}
-	for _, exp := range expParts {
-		found := false
-		for _, part := range parts {
-			if part == exp {
-				found = true
-				break
+		t.Run(name, func(t *testing.T) {
+			defer tracing.SetEnabled(enableTr)()
+
+			const numNodes = 4
+			cluster := serverutils.StartTestCluster(t, numNodes, base.TestClusterArgs{})
+			defer cluster.Stopper().Stop(context.TODO())
+
+			if _, err := cluster.ServerConn(0).Exec(`
+				CREATE DATABASE test;
+				CREATE TABLE test.foo (id INT PRIMARY KEY);
+				SET DISTSQL = OFF;
+			`); err != nil {
+				t.Fatal(err)
 			}
-		}
-		if !found {
-			t.Fatalf("expected at least %v, got %v\n\nResults:\n%v", expParts, parts, prettyPrint(pretty))
-		}
+			// Check EXPLAIN (TRACE) from all nodes. The point is to test from a node
+			// that is different than the leaseholder for the range.
+			for n := 0; n < numNodes; n++ {
+				rows, err := cluster.ServerConn(n).Query(`EXPLAIN (TRACE) SELECT * FROM test.foo`)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer rows.Close()
+				expParts := []string{"explain trace", "grpcTransport SendNext", "node.Batch"}
+				var parts []string
+
+				pretty := rowsToStrings(rows)
+				for _, row := range pretty[1:] {
+					part := row[3] // Operation
+					if ind := sort.SearchStrings(parts, part); ind == len(parts) || parts[ind] != part {
+						parts = append(parts, part)
+						sort.Strings(parts)
+					}
+				}
+				sort.Strings(expParts)
+				if err := rows.Err(); err != nil {
+					t.Fatal(err)
+				}
+				for _, exp := range expParts {
+					found := false
+					for _, part := range parts {
+						if part == exp {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Fatalf(
+							"expected at least %v, got %v\n\nResults:\n%v", expParts, parts, prettyPrint(pretty),
+						)
+					}
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Snowball tracing is used for `EXPLAIN (TRACE)` and
`sql.trace.txn.enable_threshold` and it does not work when tracing is disabled
(which is the default).

The problem is in `JoinRemoteTrace`: when tracing is disabled, the `Tracer` we
get is a `NoopTracer` which can't `Extract` the context. Fix this by using a
separate basictracer just for extraction.

Also improve `TestExplainTrace` to use a cluster and to test with tracing both
enabled and disabled. Verified the test fails without the rest of the change.

Verified that lightstep traces still work.

Fixes #16035.

CC @cockroachdb/release