### PR TITLE
cherry-pick: storage: disable key access assertions in non-race builds #16131

### DIFF
--- a/pkg/storage/build_default.go
+++ b/pkg/storage/build_default.go
@@ -1,0 +1,20 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+// +build !race
+
+package storage
+
+const raceEnabled = false

--- a/pkg/storage/build_race.go
+++ b/pkg/storage/build_race.go
@@ -1,0 +1,20 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+// +build race
+
+package storage
+
+const raceEnabled = true

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2313,9 +2313,6 @@ func (r *Replica) requestToProposal(
 	}
 	var pErr *roachpb.Error
 	var result *EvalResult
-	// TODO(bdarnell): provide an option to disable spanSet validation
-	// (i.e. pass nil instead of `spans` here) once we're confident our coverage
-	// is good.
 	result, pErr = r.evaluateProposal(ctx, idKey, ba, spans)
 	// Fill out the local results even if pErr != nil; we'll return the error below.
 	proposal.Local = &result.Local
@@ -4084,7 +4081,7 @@ func (r *Replica) evaluateTxnWriteBatch(
 
 		// If all writes occurred at the intended timestamp, we've succeeded on the fast path.
 		batch := r.store.Engine().NewBatch()
-		if spans != nil {
+		if raceEnabled && spans != nil {
 			batch = makeSpanSetBatch(batch, spans)
 		}
 		rec := ReplicaEvalContext{r, spans}
@@ -4136,7 +4133,7 @@ func (r *Replica) evaluateTxnWriteBatch(
 	}
 
 	batch := r.store.Engine().NewBatch()
-	if spans != nil {
+	if raceEnabled && spans != nil {
 		batch = makeSpanSetBatch(batch, spans)
 	}
 	rec := ReplicaEvalContext{r, spans}


### PR DESCRIPTION
Discovered in #16068. Using a SpanSetBatch incurs a `O(#spans)` overhead for
each engine operation, which quickly results in quadratic runtime for Raft
command evaluation.

Benchmark:

```
make bench PKG=./pkg/sql/ BENCHES='BenchmarkSQL/^Cockroach/Insert$$/count=100' TESTFLAGS='-count 10 -cpuprofile cpu.out -benchmem' 2>/dev/null | tee $(git rev-parse HEAD)
```

```
benchstat 61d1ee4a3b7eef3aff4d6bf25649aef15dad806f ad1116d51f2c4928857af45478d12d4511d13615
name                               old time/op    new time/op    delta
SQL/Cockroach/Insert/count=100-4     2.50ms ±14%    2.28ms ±31%   -8.53%  (p=0.013 n=10+9)
SQL/Cockroach/Insert/count=1000-4    33.5ms ± 7%    18.4ms ±17%  -45.19%  (p=0.000 n=10+10)

name                               old alloc/op   new alloc/op   delta
SQL/Cockroach/Insert/count=100-4     1.13MB ± 1%    1.13MB ± 1%     ~     (p=0.190 n=10+10)
SQL/Cockroach/Insert/count=1000-4    10.7MB ± 2%    10.5MB ± 0%   -1.89%  (p=0.000 n=10+10)

name                               old allocs/op  new allocs/op  delta
SQL/Cockroach/Insert/count=100-4      2.91k ±37%     2.91k ±34%     ~     (p=0.670 n=10+10)
SQL/Cockroach/Insert/count=1000-4     30.4k ±34%     20.7k ± 0%  -31.94%  (p=0.000 n=10+7)
```
questing a pull to cockroachdb:release-1.0 from cockroachdb:cp-disable-assertions