### PR TITLE
migrations: Handle CPut unexpected value errors gracefully

### DIFF
--- a/pkg/migrations/main_test.go
+++ b/pkg/migrations/main_test.go
@@ -12,15 +12,22 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package migrations
+package migrations_test
 
 import (
+	"os"
+	"testing"
+
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 )
 
-func init() {
+func TestMain(m *testing.M) {
 	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	os.Exit(m.Run())
 }
 
 //go:generate ../util/leaktest/add-leaktest.sh *_test.go

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -340,37 +340,20 @@ func eventlogUniqueIDDefault(ctx context.Context, r runner) error {
 	return err
 }
 
-// TODO(a-robinson): Write unit test for this.
 func createJobsTable(ctx context.Context, r runner) error {
-	// We install the table at the KV layer so that we can choose a known ID in
-	// the reserved ID space. (The SQL layer doesn't allow this.)
-	err := r.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		b := txn.NewBatch()
-		desc := sqlbase.JobsTable
-		b.CPut(sqlbase.MakeNameMetadataKey(desc.GetParentID(), desc.GetName()), desc.GetID(), nil)
-		b.CPut(sqlbase.MakeDescMetadataKey(desc.GetID()), sqlbase.WrapDescriptor(&desc), nil)
-		if err := txn.SetSystemConfigTrigger(); err != nil {
-			return err
-		}
-		return txn.Run(ctx, b)
-	})
-	if err != nil {
-		// CPuts only provide idempotent inserts if we ignore the errors that arise
-		// when the condition isn't met.
-		if _, ok := err.(*roachpb.ConditionFailedError); ok {
-			return nil
-		}
-	}
-	return err
+	return createSystemTable(ctx, r, sqlbase.JobsTable)
+}
+
+func createSettingsTable(ctx context.Context, r runner) error {
+	return createSystemTable(ctx, r, sqlbase.SettingsTable)
 }
 
 // TODO(a-robinson): Write unit test for this.
-func createSettingsTable(ctx context.Context, r runner) error {
+func createSystemTable(ctx context.Context, r runner, desc sqlbase.TableDescriptor) error {
 	// We install the table at the KV layer so that we can choose a known ID in
 	// the reserved ID space. (The SQL layer doesn't allow this.)
 	err := r.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		b := txn.NewBatch()
-		desc := sqlbase.SettingsTable
 		b.CPut(sqlbase.MakeNameMetadataKey(desc.GetParentID(), desc.GetName()), desc.GetID(), nil)
 		b.CPut(sqlbase.MakeDescMetadataKey(desc.GetID()), sqlbase.WrapDescriptor(&desc), nil)
 		if err := txn.SetSystemConfigTrigger(); err != nil {


### PR DESCRIPTION
Fixes #16206

While I'm here, add a test that covers these migrations that we should have written when (or at least shortly after) we added them.