### PR TITLE
cherry-pick: storage: declare fewer spans during GC

### DIFF
--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -199,7 +199,10 @@ func RangeStatsKey(rangeID roachpb.RangeID) roachpb.Key {
 	return MakeRangeIDPrefixBuf(rangeID).RangeStatsKey()
 }
 
-// RangeLastGCKey returns a system-local key for the last GC.
+// RangeLastGCKey returns a system-local key for last used GC threshold on the
+// user keyspace. Reads and writes <= this timestamp will not be served.
+//
+// TODO(tschottdorf): should be renamed to RangeGCThresholdKey.
 func RangeLastGCKey(rangeID roachpb.RangeID) roachpb.Key {
 	return MakeRangeIDPrefixBuf(rangeID).RangeLastGCKey()
 }

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -7184,6 +7184,55 @@ func TestAmbiguousResultErrorOnRetry(t *testing.T) {
 	}
 }
 
+// TestGCWithoutThreshold validates that GCRequest only declares the threshold
+// keys which are subject to change, and that it does not access these keys if
+// it does not declare them.
+func TestGCWithoutThreshold(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	desc := roachpb.RangeDescriptor{StartKey: roachpb.RKey("a"), EndKey: roachpb.RKey("z")}
+	ctx := context.Background()
+
+	options := []hlc.Timestamp{{}, hlc.Timestamp{}.Add(1, 0)}
+
+	for i, keyThresh := range options {
+		for j, txnThresh := range options {
+			func() {
+				var gc roachpb.GCRequest
+				var spans SpanSet
+
+				gc.Threshold = keyThresh
+				gc.TxnSpanGCThreshold = txnThresh
+				declareKeysGC(desc, roachpb.Header{}, &gc, &spans)
+
+				if num, exp := spans.len(), i+j+1; num != exp {
+					t.Fatalf("(%s,%s): expected %d declared keys, found %d",
+						keyThresh, txnThresh, exp, num)
+				}
+
+				eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+				defer eng.Close()
+
+				batch := eng.NewBatch()
+				defer batch.Close()
+				rw := makeSpanSetBatch(batch, &spans)
+
+				var resp roachpb.GCResponse
+
+				if _, err := evalGC(ctx, rw, CommandArgs{
+					Args: &gc,
+					EvalCtx: ReplicaEvalContext{
+						repl: &Replica{},
+						ss:   &spans,
+					},
+				}, &resp); err != nil {
+					t.Fatalf("at (%s,%s): %s", keyThresh, txnThresh, err)
+				}
+			}()
+		}
+	}
+}
+
 // TestCommandTimeThreshold verifies that commands outside the replica GC
 // threshold fail.
 func TestCommandTimeThreshold(t *testing.T) {

--- a/pkg/storage/span_set.go
+++ b/pkg/storage/span_set.go
@@ -52,6 +52,16 @@ type SpanSet struct {
 	spans [numSpanAccess][numSpanScope][]roachpb.Span
 }
 
+func (ss *SpanSet) len() int {
+	var count int
+	for i := SpanAccess(0); i < numSpanAccess; i++ {
+		for j := spanScope(0); j < numSpanScope; j++ {
+			count += len(ss.getSpans(i, j))
+		}
+	}
+	return count
+}
+
 // reserve space for N additional keys.
 func (ss *SpanSet) reserve(access SpanAccess, scope spanScope, n int) {
 	existing := ss.spans[access][scope]


### PR DESCRIPTION
If a GCRequest does not modify the GC threshold timestamps, it does
not need to declare their keys. This is useful because it allows the
GC queue to send a very small request with the threshold adjustments
first, and then a larger request that does not need to declare the
threshold keys and does less harm if it's slow.

We should additionally limit the size of each "big" `GCRequest`, but
that fits well in a follow-up PR.

cc @cockroachdb/release