### PR TITLE
storage: quota status only on leaseholder replica

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1551,7 +1551,9 @@ func (r *Replica) State() storagebase.RangeInfo {
 	ri.NumPending = uint64(len(r.mu.proposals))
 	ri.RaftLogSize = r.mu.raftLogSize
 	ri.NumDropped = uint64(r.mu.droppedMessages)
-	ri.ApproximateProposalQuota = r.mu.proposalQuota.approximateQuota()
+	if r.mu.proposalQuota != nil {
+		ri.ApproximateProposalQuota = r.mu.proposalQuota.approximateQuota()
+	}
 
 	return ri
 }


### PR DESCRIPTION
Fixes #16192.

`Replica.State` can be called on a non-leaseholder replica, in which case
`Replica.mu.proposalQuota` is set to nil.

cc @BramGruneir.