### PR TITLE
storage: De-flake TestRemovePlaceholderRace

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -860,6 +860,12 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	if r.mu.replicaID == 0 {
+		// The replica was created from preemptive snapshot and has not been
+		// added to the Raft group.
+		return
+	}
+
 	if r.mu.leaderID != lastLeaderID {
 		if r.mu.replicaID == r.mu.leaderID {
 			// We're becoming the leader.


### PR DESCRIPTION
Fixes #16227.

Account for replicas that have been created from preemptive snapshots
but have not been added to their corresponding Raft groups.

cc @tschottdorf.