### PR TITLE
server: "secure" all of the debug endpoint

### DIFF
--- a/pkg/acceptance/debug_remote_test.go
+++ b/pkg/acceptance/debug_remote_test.go
@@ -68,14 +68,16 @@ func TestDebugRemote(t *testing.T) {
 				t.Fatalf("expected \"%s\", but found %v", c.expectedErr, err)
 			}
 
-			resp, err := cluster.HTTPClient.Get(l.URL(ctx, 0) + "/debug/")
-			if err != nil {
-				t.Fatal(err)
-			}
-			resp.Body.Close()
+			for i, url := range []string{"/debug/", "/debug/pprof", "/debug/requests"} {
+				resp, err := cluster.HTTPClient.Get(l.URL(ctx, 0) + url)
+				if err != nil {
+					t.Fatalf("%d: %v", i, err)
+				}
+				resp.Body.Close()
 
-			if c.status != resp.StatusCode {
-				t.Fatalf("expected %d, but got %d", c.status, resp.StatusCode)
+				if c.status != resp.StatusCode {
+					t.Fatalf("%d: expected %d, but got %d", i, c.status, resp.StatusCode)
+				}
 			}
 		})
 	}

--- a/pkg/server/debug.go
+++ b/pkg/server/debug.go
@@ -66,38 +66,45 @@ var debugRemote = settings.RegisterValidatedStringSetting(
 // serve mux, which is preconfigured (by import of net/http/pprof and registration
 // of go-metrics) to serve endpoints which access exported variables and pprof tools.
 func handleDebug(w http.ResponseWriter, r *http.Request) {
+
+	if any, _ := authRequest(r); !any {
+		http.Error(w, "not allowed (due to the 'server.remote_debugging.mode' setting)",
+			http.StatusForbidden)
+		return
+	}
 	handler, _ := debugServeMux.Handler(r)
+
 	handler.ServeHTTP(w, r)
 }
 
+// traceAuthRequest is the original trace.AuthRequest, populated in init().
+var traceAuthRequest func(*http.Request) (bool, bool)
+
+// authRequest restricts access to /debug/*.
+func authRequest(r *http.Request) (allow, sensitive bool) {
+	allow, sensitive = traceAuthRequest(r)
+	switch strings.ToLower(debugRemote.Get()) {
+	case debugRemoteAny:
+		allow = true
+	case debugRemoteLocal:
+		break
+	default:
+		allow = false
+	}
+	return allow, sensitive
+}
+
 func init() {
+	traceAuthRequest = trace.AuthRequest
+
 	// Tweak the authentication logic for the tracing endpoint. By default it's
-	// open for localhost only, but with Docker we want to get there from
-	// anywhere. We maintain the default behavior of only allowing access to
-	// sensitive logs from localhost.
+	// open for localhost only, but we want it to behave according to our
+	// settings.
 	//
 	// TODO(mberhault): properly secure this once we require client certs.
-	origAuthRequest := trace.AuthRequest
-	trace.AuthRequest = func(req *http.Request) (bool, bool) {
-		allow, sensitive := origAuthRequest(req)
-		switch strings.ToLower(debugRemote.Get()) {
-		case debugRemoteAny:
-			allow = true
-		case debugRemoteLocal:
-			break
-		default:
-			allow = false
-		}
-		return allow, sensitive
-	}
+	trace.AuthRequest = authRequest
 
 	debugServeMux.HandleFunc(debugEndpoint, func(w http.ResponseWriter, r *http.Request) {
-		if any, _ := trace.AuthRequest(r); !any {
-			http.Error(w, "not allowed (due to the 'server.remote_debugging.mode' setting)",
-				http.StatusForbidden)
-			return
-		}
-
 		if r.URL.Path != debugEndpoint {
 			http.Redirect(w, r, debugEndpoint, http.StatusMovedPermanently)
 			return


### PR DESCRIPTION
Previously, while `/debug/` was inaccessible for external requests by default,
`/debug/pprof/*` enjoyed no such protection. Cleaned this up by putting the
authentication handler in the top-level `HandlerFunc`, where it affects
everything equally.

```
$ curl http://127.0.0.1:8080/debug/pprof/profile
[works]
$ curl http://macts-2:8080/debug/pprof/profile
not allowed (due to the 'server.remote_debugging.mode' setting)
$ ./cockroach sql --insecure -e "set cluster setting server.remote_debugging.mode = 'any';"
SET
$ curl http://macts-2:8080/debug/pprof/profile
[works]
```