### PR TITLE
kubernetes: Update peer-finder image to support custom DNS domains

### DIFF
--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -104,10 +104,13 @@ spec:
         # has to decide what command-line flags to use when starting CockroachDB.
         # This only matters when a pod's persistent volume is empty - if it has
         # data from a previous execution, that data will always be used.
+        #
+        # If your Kubernetes cluster uses a custom DNS domain, you will have
+        # to add an additional arg to this pod: "-domain=<your-custom-domain>"
         pod.alpha.kubernetes.io/init-containers: '[
             {
                 "name": "bootstrap",
-                "image": "cockroachdb/cockroach-k8s-init:0.1",
+                "image": "cockroachdb/cockroach-k8s-init:0.2",
                 "imagePullPolicy": "IfNotPresent",
                 "args": [
                   "-on-start=/on-start.sh",

--- a/cloud/kubernetes/init/Dockerfile
+++ b/cloud/kubernetes/init/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/google_containers/peer-finder:0.1
+FROM gcr.io/google_containers/peer-finder:0.2
 
 ADD on-start.sh /
 RUN chmod -c 755 /on-start.sh


### PR DESCRIPTION
The old peer-finder image couldn't be made to work in Kubernetes
clusters that set custom DNS domains. Now anyone whose cluster has a
non-standard domain can set the -domain flag on the init container to
get it to work.

Fixes #16223 

@rumyantseva this works in my testing, but if you want to try it out and let me know how it works for you, I'd appreciate it!