### PR TITLE
ui: README addition about troubleshooting cryptic typescript compile failures

### DIFF
--- a/pkg/ui/README.md
+++ b/pkg/ui/README.md
@@ -49,6 +49,10 @@ do this will result in wasted time waiting for CI. We commit this generated file
 so that CockroachDB can be compiled with minimal [non-go
 dependencies](#dependencies).
 
+If you get cryptic TypeScript compile/lint failures upon running `make` that seem
+completely unrelated to your changes, try removing `yarn.installed` and
+`node_modules` before re-running `make` (do NOT run `yarn install` directly).
+
 Be sure to also commit modifications resulting from dependency changes, like
 updates to `package.json` and `yarn.lock`.
 


### PR DESCRIPTION
Anecdotally it seems like this gotcha has caught a bunch of us, so it would be good to mention it in the README.