### PR TITLE
scripts: update stale azure-cli installation URL

### DIFF
--- a/scripts/azworker.sh
+++ b/scripts/azworker.sh
@@ -2,7 +2,7 @@
 #
 # Prerequisites:
 # - Cockroach Labs employees: ask an admin to create an Azure account for you.
-# - Install the Azure CLI: https://docs.microsoft.com/en-us/azure/xplat-cli-install
+# - Install the Azure XPlat CLI: https://github.com/Azure/azure-xplat-cli
 # - Run "azure login" and sign in to your Azure account.
 
 set -euo pipefail


### PR DESCRIPTION
`https://docs.microsoft.com/en-us/azure/xplat-cli-install` redirects to `https://docs.microsoft.com/en-gb/cli/azure/install-azure-cli`, installing `azure-cli` (binary: `az`). Updated installation instructions to point to `azure-xplat-cli` instead.