### PR TITLE
sql: introduce a session-based tracing mechanism

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -39,6 +39,7 @@ var crdbInternal = virtualSchema{
 		crdbInternalSchemaChangesTable,
 		crdbInternalStmtStatsTable,
 		crdbInternalJobsTable,
+		crdbInternalSessionTraceTable,
 	},
 }
 
@@ -448,6 +449,38 @@ CREATE TABLE crdb_internal.node_statement_statistics (
 				if err != nil {
 					return err
 				}
+			}
+		}
+		return nil
+	},
+}
+
+// crdbInternalSessionTraceTable exposes the latest trace collected on this
+// session (via SET TRACE={ON/OFF})
+var crdbInternalSessionTraceTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE crdb_internal.session_trace(
+  TXN_IDX INT NOT NULL,            -- The transaction's 0-based index, among all
+                                   -- transactions that have been traced.
+																   -- Only filled for the first log message in a
+																   -- transaction's top-level span.
+  SPAN_IDX INT NOT NULL,           -- The span's index.
+  MESSAGE_IDX INT NOT NULL,        -- The message's index within its span.
+  TIMESTAMP TIMESTAMPTZ NOT NULL,  -- The message's timestamp.
+  DURATION INTERVAL,               -- The span's duration. Set only on the first
+                                   -- (dummy) message on a span.
+                                   -- NULL if the span was not finished at the time
+                                   -- the trace has been collected.
+  OPERATION STRING NULL,           -- The span's operation. Set only on
+                                   -- the first (dummy) message in a span.
+  MESSAGE STRING NOT NULL          -- The logged message.
+);
+`,
+	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {
+		rows := p.session.Tracing.GenerateSessionTraceVTable()
+		for _, r := range rows {
+			if err := addRow(r[:]...); err != nil {
+				return err
 			}
 		}
 		return nil

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -128,7 +128,7 @@ func (r *traceResult) String() string {
 	if r.count < 0 {
 		return r.tag
 	}
-	return fmt.Sprintf("%s %d", r.tag, r.count)
+	return fmt.Sprintf("%s (%d results)", r.tag, r.count)
 }
 
 // ResultList represents a list of results for a list of SQL statements.
@@ -719,10 +719,10 @@ func (e *Executor) execParsed(
 					avoidCachedDescriptors = true
 				}
 			}
-			txnState.resetForNewSQLTxn(e, session)
+			txnState.resetForNewSQLTxn(e, session, execOpt.AutoCommit /* implicitTxn */)
 			txnState.autoRetry = true
 			txnState.sqlTimestamp = e.cfg.Clock.PhysicalTime()
-			if execOpt.AutoCommit {
+			if txnState.implicitTxn {
 				txnState.mu.txn.SetDebugName(sqlImplicitTxnName)
 			} else {
 				txnState.mu.txn.SetDebugName(sqlTxnName)
@@ -853,7 +853,7 @@ func (e *Executor) execParsed(
 
 		// If we're no longer in a transaction, finish the trace.
 		if txnState.State == NoTxn {
-			txnState.finishSQLTxn(session.context)
+			txnState.finishSQLTxn(session)
 		}
 
 		// Verify that the metadata callback fails, if one was set. This is

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -216,6 +216,7 @@ leases
 node_build_info
 node_statement_statistics
 schema_changes
+session_trace
 tables
 columns
 key_column_usage
@@ -279,6 +280,7 @@ table_privileges
 table_constraints
 statistics
 settings
+session_trace
 schemata
 schema_privileges
 schema_changes
@@ -320,6 +322,7 @@ def            crdb_internal       leases                     SYSTEM VIEW  1
 def            crdb_internal       node_build_info            SYSTEM VIEW  1
 def            crdb_internal       node_statement_statistics  SYSTEM VIEW  1
 def            crdb_internal       schema_changes             SYSTEM VIEW  1
+def            crdb_internal       session_trace              SYSTEM VIEW  1
 def            crdb_internal       tables                     SYSTEM VIEW  1
 def            information_schema  columns                    SYSTEM VIEW  1
 def            information_schema  key_column_usage           SYSTEM VIEW  1

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -954,6 +954,7 @@ server_version                 9.5.0         NULL      NULL        NULL        s
 session_user                   root          NULL      NULL        NULL        string
 standard_conforming_strings    on            NULL      NULL        NULL        string
 time zone                      UTC           NULL      NULL        NULL        string
+trace                          OFF           NULL      NULL        NULL        string
 transaction isolation level    SERIALIZABLE  NULL      NULL        NULL        string
 transaction priority           NORMAL        NULL      NULL        NULL        string
 transaction status             NoTxn         NULL      NULL        NULL        string
@@ -975,6 +976,7 @@ server_version                 9.5.0         NULL  user     NULL      9.5.0     
 session_user                   root          NULL  user     NULL      root          root
 standard_conforming_strings    on            NULL  user     NULL      on            on
 time zone                      UTC           NULL  user     NULL      UTC           UTC
+trace                          OFF           NULL  user     NULL      OFF           OFF
 transaction isolation level    SERIALIZABLE  NULL  user     NULL      SERIALIZABLE  SERIALIZABLE
 transaction priority           NORMAL        NULL  user     NULL      NORMAL        NORMAL
 transaction status             NoTxn         NULL  user     NULL      NoTxn         NoTxn
@@ -996,6 +998,7 @@ server_version                 NULL    NULL     NULL     NULL        NULL
 session_user                   NULL    NULL     NULL     NULL        NULL
 standard_conforming_strings    NULL    NULL     NULL     NULL        NULL
 time zone                      NULL    NULL     NULL     NULL        NULL
+trace                          NULL    NULL     NULL     NULL        NULL
 transaction isolation level    NULL    NULL     NULL     NULL        NULL
 transaction priority           NULL    NULL     NULL     NULL        NULL
 transaction status             NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -89,6 +89,7 @@ server_version                 9.5.0
 session_user                   root
 standard_conforming_strings    on
 time zone                      UTC
+trace                          OFF
 transaction isolation level    SERIALIZABLE
 transaction priority           NORMAL
 transaction status             NoTxn

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -33,6 +33,7 @@ server_version                 9.5.0
 session_user                   root
 standard_conforming_strings    on
 time zone                      UTC
+trace                          OFF
 transaction isolation level    SERIALIZABLE
 transaction priority           NORMAL
 transaction status             NoTxn

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -151,3 +151,120 @@ func TestExplainTrace(t *testing.T) {
 		})
 	}
 }
+
+func TestSessionTrace(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Session tracing needs to work regardless of whether tracing is enabled, so
+	// we're goint to test both cases.
+	//
+	// We'll also check traces from all nodes. The point is to be sure that we
+	// test a node that is different than the leaseholder for the range, so that
+	// the trace contains remote spans.
+	for _, enableTr := range []bool{false, true} {
+		name := "TracingOff"
+		if enableTr {
+			name = "TracingOn"
+		}
+		t.Run(name, func(t *testing.T) {
+			// Create a cluster. We'll run sub-tests using each node of this cluster.
+			const numNodes = 3
+			cluster := serverutils.StartTestCluster(t, numNodes, base.TestClusterArgs{})
+			defer cluster.Stopper().Stop(context.TODO())
+
+			clusterDB := cluster.ServerConn(0)
+			if _, err := clusterDB.Exec(`
+				CREATE DATABASE test;
+				CREATE TABLE test.foo (id INT PRIMARY KEY);
+			`); err != nil {
+				t.Fatal(err)
+			}
+			for i := 0; i < numNodes; i++ {
+				t.Run(fmt.Sprintf("node-%d", i), func(t *testing.T) {
+					sqlDB := cluster.ServerConn(i)
+					sqlDB.SetMaxOpenConns(1)
+
+					// Run a non-traced read to acquire a lease on the table, so that the
+					// traced read below doesn't need to take a lease. Tracing a lease
+					// acquisition incurs some spans that are too fragile to test here.
+					if _, err := sqlDB.Exec(`SELECT * FROM test.foo LIMIT 1`); err != nil {
+						t.Fatal(err)
+					}
+
+					if _, err := cluster.ServerConn(0).Exec(
+						fmt.Sprintf(`SET CLUSTER SETTING trace.debug.enable = %t`, enableTr),
+					); err != nil {
+						t.Fatal(err)
+					}
+
+					// DistSQL doesn't support snowball tracing at the moment.
+					if _, err := sqlDB.Exec("SET DISTSQL = OFF"); err != nil {
+						t.Fatal(err)
+					}
+
+					// Sanity check that new sessions don't have trace info on them.
+					if !enableTr {
+						row := sqlDB.QueryRow("SELECT COUNT(1) FROM crdb_internal.session_trace")
+						var count int
+						if err := row.Scan(&count); err != nil {
+							t.Fatal(err)
+						}
+						if count != 0 {
+							t.Fatalf("expected crdb_internal.session_trace to be empty "+
+								"at the beginning of a session, but it wasn't. Count: %d.", count)
+						}
+					}
+
+					// Start session tracing.
+					if _, err := sqlDB.Exec("SET TRACE = ON"); err != nil {
+						t.Fatal(err)
+					}
+
+					rows, err := sqlDB.Query(`SELECT * FROM test.foo`)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if err := rows.Close(); err != nil {
+						t.Fatal(err)
+					}
+
+					if _, err := sqlDB.Exec("SET TRACE = OFF"); err != nil {
+						t.Fatal(err)
+					}
+
+					rows, err = sqlDB.Query(
+						"SELECT DISTINCT(operation) op FROM crdb_internal.session_trace " +
+							"WHERE operation IS NOT NULL ORDER BY op")
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer rows.Close()
+					expSpans := []string{
+						"sql txn implicit",
+						"grpcTransport SendNext",
+						"/cockroach.roachpb.Internal/Batch",
+					}
+					sort.Strings(expSpans)
+					r := 0
+					for rows.Next() {
+						var op string
+						if err := rows.Scan(&op); err != nil {
+							t.Fatal(err)
+						}
+						if r >= len(expSpans) {
+							t.Fatalf("extra span: %s", op)
+						}
+						if op != expSpans[r] {
+							t.Fatalf("expected span: %q, got: %q", expSpans[r], op)
+						}
+						r++
+					}
+					if r < len(expSpans) {
+						t.Fatalf("missing expected spans: %s", expSpans[r:])
+					}
+				})
+			}
+
+		})
+	}
+}

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -24,6 +24,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -275,6 +277,50 @@ var varGen = map[string]sessionVar{
 		},
 		Reset: func(*planner) error { return nil },
 	},
+
+	`trace`: {
+		Get: func(p *planner) string {
+			if p.session.Tracing.Enabled() {
+				return "ON"
+			}
+			return "OFF"
+		},
+		Reset: func(p *planner) error {
+			if !p.session.Tracing.Enabled() {
+				// Tracing is not active. Nothing to do.
+				return nil
+			}
+			return stopTracing(p.session)
+		},
+		Set: func(_ context.Context, p *planner, values []parser.TypedExpr) error {
+			s, err := p.getStringVal("trace", values)
+			if err != nil {
+				return err
+			}
+			switch parser.Name(s).Normalize() {
+			case parser.ReNormalizeName("on"), parser.ReNormalizeName("local"):
+				recordingType := tracing.SnowballRecording
+				if parser.Name(s).Normalize() == parser.ReNormalizeName("local") {
+					recordingType = tracing.SingleNodeRecording
+				}
+				if err := p.session.Tracing.StartTracing(recordingType); err != nil {
+					return err
+				}
+				return nil
+			case parser.ReNormalizeName("off"):
+				return stopTracing(p.session)
+			default:
+				return fmt.Errorf("set trace: \"%s\" not supported", s)
+			}
+		},
+	},
+}
+
+func stopTracing(s *Session) error {
+	if err := s.Tracing.StopTracing(); err != nil {
+		return errors.Wrapf(err, "error stopping tracing")
+	}
+	return nil
 }
 
 var varNames = func() []string {

--- a/pkg/util/tracing/format.go
+++ b/pkg/util/tracing/format.go
@@ -49,6 +49,9 @@ func (l traceLogs) Swap(i, j int) {
 // FormatRecordedSpans formats the given spans for human consumption, showing the
 // relationship using nesting and times as both relative to the previous event
 // and cumulative.
+//
+// TODO(andrei): this should be unified with
+// SessionTracing.GenerateSessionTraceVTable.
 func FormatRecordedSpans(spans []RecordedSpan) string {
 	m := make(map[uint64]*RecordedSpan)
 	for i, sp := range spans {

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -217,6 +217,7 @@ func (t *Tracer) StartSpan(
 	var parentType opentracing.SpanReferenceType
 	var parentCtx *spanContext
 	var recordingGroup *spanGroup
+	var recordingType RecordingType
 
 	for _, r := range sso.References {
 		if r.Type != opentracing.ChildOfRef && r.Type != opentracing.FollowsFromRef {
@@ -233,9 +234,11 @@ func (t *Tracer) StartSpan(
 		parentCtx = r.ReferencedContext.(*spanContext)
 		if parentCtx.recordingGroup != nil {
 			recordingGroup = parentCtx.recordingGroup
+			recordingType = parentCtx.recordingType
 		} else if parentCtx.Baggage[Snowball] != "" {
 			// Automatically enable recording if we have the Snowball baggage item.
 			recordingGroup = new(spanGroup)
+			recordingType = SnowballRecording
 		}
 		// TODO(radu): can we do something for multiple references?
 		break
@@ -314,7 +317,7 @@ func (t *Tracer) StartSpan(
 
 	// Start recording if necessary.
 	if recordingGroup != nil {
-		s.enableRecording(recordingGroup)
+		s.enableRecording(recordingGroup, recordingType)
 	}
 
 	if netTrace {
@@ -503,6 +506,8 @@ func EnsureContext(
 // "snowball span" in it. The caller takes ownership of this span from the
 // returned context and is in charge of Finish()ing it. The span has recording
 // enabled.
+//
+// TODO(andrei): remove this method once EXPLAIN(TRACE) is gone.
 func StartSnowballTrace(
 	ctx context.Context, tracer opentracing.Tracer, opName string,
 ) (context.Context, opentracing.Span, error) {
@@ -514,7 +519,6 @@ func StartSnowballTrace(
 	} else {
 		span = tracer.StartSpan(opName, Recordable)
 	}
-	StartRecording(span)
-	span.SetBaggageItem(Snowball, "1")
+	StartRecording(span, SnowballRecording)
 	return opentracing.ContextWithSpan(ctx, span), span, nil
 }

--- a/pkg/util/tracing/tracer_span.go
+++ b/pkg/util/tracing/tracer_span.go
@@ -47,6 +47,7 @@ type spanContext struct {
 
 	// If set, all spans derived from this context are being recorded as a group.
 	recordingGroup *spanGroup
+	recordingType  RecordingType
 
 	// The span's associated baggage.
 	Baggage map[string]string
@@ -62,6 +63,17 @@ func (sc *spanContext) ForeachBaggageItem(handler func(k, v string) bool) {
 		}
 	}
 }
+
+// RecordingType is the type of recording that a span might be performing.
+type RecordingType bool
+
+const (
+	// SnowballRecording means that remote child spans (generally opened through
+	// RPCs) are also recorded.
+	SnowballRecording RecordingType = true
+	// SingleNodeRecording means that only spans on the current node are recorded.
+	SingleNodeRecording RecordingType = false
+)
 
 type span struct {
 	spanMeta
@@ -87,6 +99,7 @@ type span struct {
 		duration time.Duration
 
 		recordingGroup *spanGroup
+		recordingType  RecordingType
 		recordedLogs   []opentracing.LogRecord
 		// tags are only set when recording.
 		// TODO(radu): perhaps we want a recording to capture all the tags (even
@@ -104,13 +117,17 @@ func (s *span) isRecording() bool {
 	return atomic.LoadInt32(&s.recording) != 0
 }
 
-func (s *span) enableRecording(group *spanGroup) {
+func (s *span) enableRecording(group *spanGroup, recType RecordingType) {
 	if group == nil {
 		panic("no spanGroup")
 	}
 	s.mu.Lock()
 	atomic.StoreInt32(&s.recording, 1)
 	s.mu.recordingGroup = group
+	s.mu.recordingType = recType
+	if recType == SnowballRecording {
+		s.setBaggageItemLocked(Snowball, "1")
+	}
 	// Clear any previously recorded logs.
 	s.mu.recordedLogs = nil
 	s.mu.Unlock()
@@ -138,18 +155,11 @@ func GetSpanTag(os opentracing.Span, key string) interface{} {
 //
 // If recording was already started on this span (either directly or because a
 // parent span is recording), the old recording is lost.
-func StartRecording(os opentracing.Span) {
+func StartRecording(os opentracing.Span, recType RecordingType) {
 	if IsNoopSpan(os) {
 		panic("StartRecording called on NoopSpan; use the Force option for StartSpan")
 	}
-	os.(*span).enableRecording(new(spanGroup))
-}
-
-func (s *span) disableRecording() {
-	s.mu.Lock()
-	atomic.StoreInt32(&s.recording, 0)
-	s.mu.recordingGroup = nil
-	s.mu.Unlock()
+	os.(*span).enableRecording(new(spanGroup), recType)
 }
 
 // StopRecording disables recording on this span. Child spans that were created
@@ -159,6 +169,28 @@ func (s *span) disableRecording() {
 // when all the spans finish.
 func StopRecording(os opentracing.Span) {
 	os.(*span).disableRecording()
+}
+
+func (s *span) disableRecording() {
+	s.mu.Lock()
+	atomic.StoreInt32(&s.recording, 0)
+	s.mu.recordingGroup = nil
+	if s.mu.recordingType == SnowballRecording {
+		// Clear the Snowball baggage item, assuming that it was set by
+		// enableRecording().
+		s.setBaggageItemLocked(Snowball, "")
+	}
+	s.mu.Unlock()
+}
+
+// IsRecordable returns true if {Start,Stop}Recording() can be called on this
+// span.
+//
+// In other words, this tests if the span is our custom type, and not a noopSpan
+// or anything else.
+func IsRecordable(os opentracing.Span) bool {
+	_, isCockroachSpan := os.(*span)
+	return isCockroachSpan
 }
 
 // GetRecording retrieves the current recording, if the span has
@@ -267,6 +299,7 @@ func (s *span) Context() opentracing.SpanContext {
 
 	if s.isRecording() {
 		sc.recordingGroup = s.mu.recordingGroup
+		sc.recordingType = s.mu.recordingType
 	}
 	return sc
 }
@@ -282,6 +315,10 @@ func (s *span) SetOperationName(operationName string) opentracing.Span {
 
 // SetTag is part of the opentracing.Span interface.
 func (s *span) SetTag(key string, value interface{}) opentracing.Span {
+	return s.setTagInner(key, value, false /* locked */)
+}
+
+func (s *span) setTagInner(key string, value interface{}, locked bool) opentracing.Span {
 	if s.lightstep != nil {
 		s.lightstep.SetTag(key, value)
 	}
@@ -289,12 +326,16 @@ func (s *span) SetTag(key string, value interface{}) opentracing.Span {
 		s.netTr.LazyPrintf("%s:%v", key, value)
 	}
 	if s.isRecording() {
-		s.mu.Lock()
+		if !locked {
+			s.mu.Lock()
+		}
 		if s.mu.tags == nil {
 			s.mu.tags = make(opentracing.Tags)
 		}
 		s.mu.tags[key] = value
-		s.mu.Unlock()
+		if !locked {
+			s.mu.Unlock()
+		}
 	}
 	return s
 }
@@ -347,17 +388,21 @@ func (s *span) LogKV(alternatingKeyValues ...interface{}) {
 // SetBaggageItem is part of the opentracing.Span interface.
 func (s *span) SetBaggageItem(restrictedKey, value string) opentracing.Span {
 	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.setBaggageItemLocked(restrictedKey, value)
+}
+
+func (s *span) setBaggageItemLocked(restrictedKey, value string) opentracing.Span {
 	if s.mu.Baggage == nil {
 		s.mu.Baggage = make(map[string]string)
 	}
 	s.mu.Baggage[restrictedKey] = value
-	s.mu.Unlock()
 
 	if s.lightstep != nil {
 		s.lightstep.SetBaggageItem(restrictedKey, value)
 	}
 	// Also set a tag so it shows up in the Lightstep UI or x/net/trace.
-	s.SetTag(restrictedKey, value)
+	s.setTagInner(restrictedKey, value, true /* locked */)
 	return s
 }
 
@@ -393,6 +438,9 @@ func (s *span) Log(data opentracing.LogData) {
 // spans since then).
 type spanGroup struct {
 	syncutil.Mutex
+	// spans keeps track of all the local spans. A span is inserted in this slice
+	// as soon as it is opened; the first element is the span passed to
+	// StartRecording().
 	spans []*span
 	// remoteSpans stores spans obtained from another host that we want to associate
 	// with the record for this group.
@@ -405,6 +453,9 @@ func (ss *spanGroup) addSpan(s *span) {
 	ss.Unlock()
 }
 
+// getSpans returns all the local and remote spans accumulated in this group.
+// The first result is the first local span - i.e. the span originally passed to
+// StartRecording().
 func (ss *spanGroup) getSpans() []RecordedSpan {
 	ss.Lock()
 	spans := ss.spans


### PR DESCRIPTION
This patch allows one to say "SET TRACE=ON", then run whatever SQL
commands, and then do "SET TRACE=OFF". While tracing is on, spans are
accumulated and, when tracing is done, they're accessible through a
session-local virtual table called crdb_internal.session_trace.

This mechanism is more flexible than the existing EXPLAIN(TRACE), as it
supports tracing an arbitrary set of queries (from a single session),
including multiple transactions, retries, etc. It supports all queries,
notably INSERT/UPDATE/DELETE, which were not supported previously.

The implementation is flexible enough to let one start tracing in the
middle of a transaction and end tracing in the middle of a different
transaction.
The plan is to now delete EXPLAIN(TRACE) and EXPLAIN(DEBUG).

The implementation is based on a new SessionTracing object that
coordinates tracing activities for a particular Session. Once tracing
has been enabled, the span corresponding to the current sql txn is
instructed to start recording. Future transactions will also start
recording on their spans as soon as they are created. As each such span
is finished, the SessionTracing accumulates the span information (mostly
log messages). All the information is presented through a
crdb_internal.session_trace virtual table.
Underneath, this all takes advantage of our new Tracer that's capable of
natively "recording" spans, and under that it's the snowball tracing
infrastructure.

At the moment, tracing due to txn_threshold is disabled while a session
tracing is active.

The supported options for SET TRACE are ON/OFF/Local. "Local" only
enables recording for spans on the current node (no snowballing).

Future related work:
- get snowball tracing working with DistSQL
- build a library of "trace matchers", allowing one to write flexible
tests verifying the execution of a request in a non-intrusive way. E.g.
want to assert that a transaction has or hasn't run into an intent on
its way? Programatically inspect its trace.
- figure out ways to exclude queries generated by the cli (SHOW
TRANSACTION STATUS, SHOW database, etc) from session traces
- work on dynamically enabling tracing on a slow query, to help answer
the "why isn't this query returning" recurring question.

The output table looks something like:

+---------+----------+-------------+----------------------------------+-----------------+-----------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| txn_idx | span_idx | message_idx |            timestamp             |    duration     |             operation             |                                                                                                        message                                                                                                        |
+---------+----------+-------------+----------------------------------+-----------------+-----------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|       0 |        0 |           0 | 2017-06-08 18:41:25.507496+00:00 | 156µs835ns      | sql txn implicit                  | === SPAN START: sql txn implicit ===                                                                                                                                                                                  |
| NULL    |        0 |           1 | 2017-06-08 18:41:25.507649+00:00 | NULL            | NULL                              | [client=[::1]:49587,user=root,n1] client.Txn did AutoCommit. err: <nil>␤                                                                                                                                              |
|         |          |             |                                  |                 |                                   | txn: "sql txn implicit" id=c6d359cf key=/Min rw=false pri=0.07098010 iso=SERIALIZABLE stat=COMMITTED epo=0 ts=1496947285.507506144,0 orig=1496947285.507506144,0 max=1496947286.007506144,0 wto=false rop=false seq=1 |
|       1 |        0 |           0 | 2017-06-08 18:41:25.507854+00:00 | 59µs877ns       | sql txn implicit                  | === SPAN START: sql txn implicit ===                                                                                                                                                                                  |
| NULL    |        0 |           1 | 2017-06-08 18:41:25.507873+00:00 | NULL            | NULL                              | [client=[::1]:49587,user=root,n1] executing 1/1: SHOW TRANSACTION STATUS                                                                                                                                              |
| NULL    |        0 |           2 | 2017-06-08 18:41:25.507912+00:00 | NULL            | NULL                              | [client=[::1]:49587,user=root,n1] client.Txn did AutoCommit. err: <nil>␤                                                                                                                                              |
|         |          |             |                                  |                 |                                   | txn: "sql txn implicit" id=c186c788 key=/Min rw=false pri=0.01765545 iso=SERIALIZABLE stat=COMMITTED epo=0 ts=1496947285.507863724,0 orig=1496947285.507863724,0 max=1496947286.007863724,0 wto=false rop=false seq=1 |
|       2 |        0 |           0 | 2017-06-08 18:41:25.50807+00:00  | 101µs879ns      | sql txn implicit                  | === SPAN START: sql txn implicit ===                                                                                                                                                                                  |
| NULL    |        0 |           1 | 2017-06-08 18:41:25.508082+00:00 | NULL            | NULL                              | [client=[::1]:49587,user=root,n1] executing 1/1: SHOW database                                                                                                                                                        |
| NULL    |        0 |           2 | 2017-06-08 18:41:25.508133+00:00 | NULL            | NULL                              | [client=[::1]:49587,user=root,n1] query not supported for distSQL: unsupported node *sql.delayedNode                                                                                                                  |
| NULL    |        0 |           3 | 2017-06-08 18:41:25.508168+00:00 | NULL            | NULL                              | [client=[::1]:49587,user=root,n1] client.Txn did AutoCommit. err: <nil>␤                                                                                                                                              |
|         |          |             |                                  |                 |                                   | txn: "sql txn implicit" id=96bda68e key=/Min rw=false pri=0.02932083 iso=SERIALIZABLE stat=COMMITTED epo=0 ts=1496947285.508075390,0 orig=1496947285.508075390,0 max=1496947286.008075390,0 wto=false rop=false seq=1 |
|       3 |        0 |           0 | 2017-06-08 18:41:27.427481+00:00 | 248µs471ns      | sql txn implicit                  | === SPAN START: sql txn implicit ===                                                                                                                                                                                  |
| NULL    |        0 |           1 | 2017-06-08 18:41:27.427521+00:00 | NULL            | NULL                              | [client=[::1]:49587,user=root,n1] executing 1/1: SELECT * FROM crdb_internal.session_trace                                                                                                                            |
| NULL    |        0 |           2 | 2017-06-08 18:41:27.427649+00:00 | NULL            | NULL                              | [client=[::1]:49587,user=root,n1] query not supported for distSQL: unsupported node *sql.delayedNode                                                                                                                  |
| NULL    |        0 |           3 | 2017-06-08 18:41:27.427725+00:00 | NULL            | NULL                              | [client=[::1]:49587,user=root,n1] client.Txn did AutoCommit. err: <nil>␤                                                                                                                                              |
|         |          |             |                                  |                 |                                   | txn: "sql txn implicit" id=fc2e7365 key=/Min rw=false pri=0.00305688 iso=SERIALIZABLE stat=COMMITTED epo=0 ts=1496947287.427498111,0 orig=1496947287.427498111,0 max=1496947287.927498111,0 wto=false rop=false seq=1 |
|       4 |        0 |           0 | 2017-06-08 18:41:27.429527+00:00 | 105µs217ns      | sql txn implicit                  | === SPAN START: sql txn implicit ===                                                                                                                                                                                  |
| NULL    |        0 |           1 | 2017-06-08 18:41:27.429565+00:00 | NULL            | NULL                              | [client=[::1]:49587,user=root,n1] executing 1/1: SHOW TRANSACTION STATUS                                                                                                                                              |
| NULL    |        0 |           2 | 2017-06-08 18:41:27.429629+00:00 | NULL            | NULL                              | [client=[::1]:49587,user=root,n1] client.Txn did AutoCommit. err: <nil>␤                                                                                                                                              |
|         |          |             |                                  |                 |                                   | txn: "sql txn implicit" id=6d21e8ac key=/Min rw=false pri=0.02571805 iso=SERIALIZABLE stat=COMMITTED epo=0 ts=1496947287.429544362,0 orig=1496947287.429544362,0 max=1496947287.929544362,0 wto=false rop=false seq=1 |
|       5 |        0 |           0 | 2017-06-08 18:41:27.429774+00:00 | 153µs184ns      | sql txn implicit                  | === SPAN START: sql txn implicit ===                                                                                                                                                                                  |
| NULL    |        0 |           1 | 2017-06-08 18:41:27.429793+00:00 | NULL            | NULL                              | [client=[::1]:49587,user=root,n1] executing 1/1: SHOW database                                                                                                                                                        |
| NULL    |        0 |           2 | 2017-06-08 18:41:27.429871+00:00 | NULL            | NULL                              | [client=[::1]:49587,user=root,n1] query not supported for distSQL: unsupported node *sql.delayedNode                                                                                                                  |
| NULL    |        0 |           3 | 2017-06-08 18:41:27.429921+00:00 | NULL            | NULL                              | [client=[::1]:49587,user=root,n1] client.Txn did AutoCommit. err: <nil>␤                                                                                                                                              |
|         |          |             |                                  |                 |                                   | txn: "sql txn implicit" id=a5eae9e8 key=/Min rw=false pri=0.01186179 iso=SERIALIZABLE stat=COMMITTED epo=0 ts=1496947287.429784392,0 orig=1496947287.429784392,0 max=1496947287.929784392,0 wto=false rop=false seq=1 |
|       6 |        0 |           0 | 2017-06-08 18:41:33.884562+00:00 | 450ms831µs626ns | sql txn implicit                  | === SPAN START: sql txn implicit ===                                                                                                                                                                                  |
| NULL    |        0 |           1 | 2017-06-08 18:41:33.884609+00:00 | NULL            | NULL                              | [client=[::1]:49587,user=root,n1] executing 1/1: SELECT count(*) FROM series                                                                                                                                          |
| NULL    |        0 |           2 | 2017-06-08 18:41:33.884874+00:00 | NULL            | NULL                              | [client=[::1]:49587,user=root,n1] creating DistSQL plan                                                                                                                                                               |
| NULL    |        0 |           3 | 2017-06-08 18:41:33.88491+00:00  | NULL            | NULL                              | [client=[::1]:49587,user=root,n1] querying next range at /Table/54/1                                                                                                                                                  |
| NULL    |        0 |           4 | 2017-06-08 18:41:33.884963+00:00 | NULL            | NULL                              | [client=[::1]:49587,user=root,n1] running DistSQL plan                                                                                                                                                                |
| NULL    |        1 |           0 | 2017-06-08 18:41:33.884976+00:00 | 450ms330µs747ns | flow                              | === SPAN START: flow ===                                                                                                                                                                                              |
| NULL    |        1 |           1 | 2017-06-08 18:41:33.885226+00:00 | NULL            | NULL                              | [client=[::1]:49587,user=root,n1] starting (0 processors, 2 outboxes)                                                                                                                                                 |
| NULL    |        2 |           0 | 2017-06-08 18:41:33.885259+00:00 | 450ms20µs461ns  | aggregator                        | === SPAN START: aggregator ===                                                                                                                                                                                        |
| NULL    |        2 |           1 | 2017-06-08 18:41:34.335272+00:00 | NULL            | NULL                              | [client=[::1]:49587,user=root,n1,Agg] accumulation complete                                                                                                                                                           |
| NULL    |        3 |           0 | 2017-06-08 18:41:33.885272+00:00 | 449ms991µs997ns | table reader                      | === SPAN START: table reader ===                                                                                                                                                                                      |
| NULL    |        3 |           1 | 2017-06-08 18:41:33.885279+00:00 | NULL            | NULL                              | [client=[::1]:49587,user=root,n1,TableReader=54] starting                                                                                                                                                             |
| NULL    |        3 |           2 | 2017-06-08 18:41:33.885378+00:00 | NULL            | NULL                              | [client=[::1]:49587,user=root,TableReader=54,n1] querying next range at /Table/54/1                                                                                                                                   |
| NULL    |        3 |           3 | 2017-06-08 18:41:33.885413+00:00 | NULL            | NULL                              | [client=[::1]:49587,user=root,TableReader=54,n1] r33: sending batch 1 Scan to (n1,s1):1                                                                                                                               |
| NULL    |        4 |           0 | 2017-06-08 18:41:33.885422+00:00 | 16ms696µs939ns  | grpcTransport SendNext            | === SPAN START: grpcTransport SendNext ===                                                                                                                                                                            |
| NULL    |        4 |           1 | 2017-06-08 18:41:33.885442+00:00 | NULL            | NULL                              | [client=[::1]:49587,user=root,TableReader=54,n1] sending request to local server                                                                                                                                      |
| NULL    |        5 |           0 | 2017-06-08 18:41:33.885461+00:00 | 16ms652µs78ns   | /cockroach.roachpb.Internal/Batch | === SPAN START: /cockroach.roachpb.Internal/Batch ===                                                                                                                                                                 |
| NULL    |        5 |           1 | 2017-06-08 18:41:33.885466+00:00 | NULL            | NULL                              | [n1] 1 Scan                                                                                                                                                                                                           |
| NULL    |        5 |           2 | 2017-06-08 18:41:33.88547+00:00  | NULL            | NULL                              | [n1] read has no clock uncertainty                                                                                                                                                                                    |
| NULL    |        5 |           3 | 2017-06-08 18:41:33.885476+00:00 | NULL            | NULL                              | [n1,s1] executing 1 requests                                                                                                                                                                                          |
| NULL    |        5 |           4 | 2017-06-08 18:41:33.885487+00:00 | NULL            | NULL                              | [n1,s1,r33/1:/Table/5{4-5}] read-only path |