### PR TITLE
tracing: control net/trace and lightstep via cluster settings

### DIFF
--- a/pkg/ccl/sqlccl/bench_test.go
+++ b/pkg/ccl/sqlccl/bench_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
 func bankStatementBuf(numAccounts int) *bytes.Buffer {
@@ -37,7 +36,6 @@ func BenchmarkClusterBackup(b *testing.B) {
 	// NB: This benchmark takes liberties in how b.N is used compared to the go
 	// documentation's description. We're getting useful information out of it,
 	// but this is not a pattern to cargo-cult.
-	defer tracing.Disable()()
 
 	ctx, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(b, multiNode, 0)
 	defer cleanupFn()
@@ -71,7 +69,6 @@ func BenchmarkClusterRestore(b *testing.B) {
 	// NB: This benchmark takes liberties in how b.N is used compared to the go
 	// documentation's description. We're getting useful information out of it,
 	// but this is not a pattern to cargo-cult.
-	defer tracing.Disable()()
 
 	ctx, dir, _, sqlDB, cleanup := backupRestoreTestSetup(b, multiNode, 0)
 	defer cleanup()
@@ -92,7 +89,6 @@ func BenchmarkLoadRestore(b *testing.B) {
 	// NB: This benchmark takes liberties in how b.N is used compared to the go
 	// documentation's description. We're getting useful information out of it,
 	// but this is not a pattern to cargo-cult.
-	defer tracing.Disable()()
 
 	ctx, dir, _, sqlDB, cleanup := backupRestoreTestSetup(b, multiNode, 0)
 	defer cleanup()
@@ -138,8 +134,6 @@ func BenchmarkLoadSQL(b *testing.B) {
 }
 
 func runEmptyIncrementalBackup(b *testing.B) {
-	defer tracing.Disable()()
-
 	const numStatements = 100000
 
 	ctx, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(b, multiNode, 0)

--- a/pkg/ccl/sqlccl/kv_test.go
+++ b/pkg/ccl/sqlccl/kv_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
 type kvInterface interface {
@@ -41,7 +40,6 @@ type kvWriteBatch struct {
 }
 
 func newKVWriteBatch(b *testing.B) kvInterface {
-	enableTracing := tracing.Disable()
 	s, _, _ := serverutils.StartServer(b, base.TestServerArgs{})
 
 	// TestServer.KVClient() returns the TxnCoordSender wrapped client. But that
@@ -58,7 +56,6 @@ func newKVWriteBatch(b *testing.B) kvInterface {
 		db: client.NewDB(client.NewSender(conn), rpcContext.LocalClock),
 		doneFn: func() {
 			s.Stopper().Stop(context.TODO())
-			enableTracing()
 		},
 	}
 }

--- a/pkg/ccl/sqlccl/load_test.go
+++ b/pkg/ccl/sqlccl/load_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
 func TestImportChunking(t *testing.T) {
@@ -61,7 +60,6 @@ func BenchmarkImport(b *testing.B) {
 	// NB: This benchmark takes liberties in how b.N is used compared to the go
 	// documentation's description. We're getting useful information out of it,
 	// but this is not a pattern to cargo-cult.
-	defer tracing.Disable()()
 	ctx, dir, _, sqlDB, cleanup := backupRestoreTestSetup(b, multiNode, 0)
 	defer cleanup()
 

--- a/pkg/sql/bench_test.go
+++ b/pkg/sql/bench_test.go
@@ -37,11 +37,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
 func benchmarkCockroach(b *testing.B, f func(b *testing.B, db *gosql.DB)) {
-	defer tracing.Disable()()
 	s, db, _ := serverutils.StartServer(
 		b, base.TestServerArgs{UseDatabase: "bench"})
 	defer s.Stopper().Stop(context.TODO())
@@ -54,7 +52,6 @@ func benchmarkCockroach(b *testing.B, f func(b *testing.B, db *gosql.DB)) {
 }
 
 func benchmarkMultinodeCockroach(b *testing.B, f func(b *testing.B, db *gosql.DB)) {
-	defer tracing.Disable()()
 	tc := testcluster.StartTestCluster(b, 3,
 		base.TestClusterArgs{
 			ReplicationMode: base.ReplicationAuto,

--- a/pkg/sql/kv_test.go
+++ b/pkg/sql/kv_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
 type kvInterface interface {
@@ -54,7 +53,6 @@ type kvNative struct {
 }
 
 func newKVNative(b *testing.B) kvInterface {
-	enableTracing := tracing.Disable()
 	s, _, _ := serverutils.StartServer(b, base.TestServerArgs{})
 
 	// TestServer.KVClient() returns the TxnCoordSender wrapped client. But that
@@ -71,7 +69,6 @@ func newKVNative(b *testing.B) kvInterface {
 		db: client.NewDB(client.NewSender(conn), rpcContext.LocalClock),
 		doneFn: func() {
 			s.Stopper().Stop(context.TODO())
-			enableTracing()
 		},
 	}
 }
@@ -164,9 +161,7 @@ type kvSQL struct {
 }
 
 func newKVSQL(b *testing.B) kvInterface {
-	enableTracing := tracing.Disable()
-	s, db, _ := serverutils.StartServer(
-		b, base.TestServerArgs{UseDatabase: "bench"})
+	s, db, _ := serverutils.StartServer(b, base.TestServerArgs{UseDatabase: "bench"})
 
 	if _, err := db.Exec(`CREATE DATABASE IF NOT EXISTS bench`); err != nil {
 		b.Fatal(err)
@@ -176,7 +171,6 @@ func newKVSQL(b *testing.B) kvInterface {
 	kv.db = db
 	kv.doneFn = func() {
 		s.Stopper().Stop(context.TODO())
-		enableTracing()
 	}
 	return kv
 }

--- a/pkg/sql/pgbench_test.go
+++ b/pkg/sql/pgbench_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
 // Tests a batch of queries very similar to those that that PGBench runs
@@ -113,7 +112,6 @@ func execPgbench(b *testing.B, pgURL url.URL) {
 
 func BenchmarkPgbenchExec(b *testing.B) {
 	b.Run("Cockroach", func(b *testing.B) {
-		defer tracing.Disable()()
 		s, _, _ := serverutils.StartServer(b, base.TestServerArgs{Insecure: true})
 		defer s.Stopper().Stop(context.TODO())
 

--- a/pkg/sql/testdata/logic_test/show_source
+++ b/pkg/sql/testdata/logic_test/show_source
@@ -69,6 +69,8 @@ sql.trace.log_statement_execute                    false          b     set to t
 sql.trace.session_eventlog.enabled                 false          b     set to true to enable session tracing
 sql.trace.txn.enable_threshold                     0s             d     duration beyond which all transactions are traced (set to 0 to disable)
 trace.debug.enable                                 false          b     if set, traces for recent requests can be seen in the /debug page
+trace.lightstep.token                                             s     if set, traces go to Lightstep using this token
+
 
 
 query T colnames

--- a/pkg/sql/testdata/logic_test/show_source
+++ b/pkg/sql/testdata/logic_test/show_source
@@ -68,6 +68,8 @@ sql.metrics.statement_details.threshold            0s             d     minmum e
 sql.trace.log_statement_execute                    false          b     set to true to enable logging of executed statements
 sql.trace.session_eventlog.enabled                 false          b     set to true to enable session tracing
 sql.trace.txn.enable_threshold                     0s             d     duration beyond which all transactions are traced (set to 0 to disable)
+trace.debug.enable                                 false          b     if set, traces for recent requests can be seen in the /debug page
+
 
 query T colnames
 SELECT * FROM [SHOW SESSION_USER]

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
 func rowsToStrings(rows *gosql.Rows) [][]string {
@@ -94,11 +93,15 @@ func TestExplainTrace(t *testing.T) {
 			name = "TracingOn"
 		}
 		t.Run(name, func(t *testing.T) {
-			defer tracing.SetEnabled(enableTr)()
-
 			const numNodes = 4
 			cluster := serverutils.StartTestCluster(t, numNodes, base.TestClusterArgs{})
 			defer cluster.Stopper().Stop(context.TODO())
+
+			if _, err := cluster.ServerConn(0).Exec(
+				fmt.Sprintf(`SET CLUSTER SETTING trace.debug.enable = %t`, enableTr),
+			); err != nil {
+				t.Fatal(err)
+			}
 
 			if _, err := cluster.ServerConn(0).Exec(`
 				CREATE DATABASE test;

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
 func adminMergeArgs(key roachpb.Key) *roachpb.AdminMergeRequest {
@@ -436,7 +435,6 @@ func TestStoreRangeMergeStats(t *testing.T) {
 }
 
 func BenchmarkStoreRangeMerge(b *testing.B) {
-	defer tracing.Disable()()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -54,7 +54,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
 func adminSplitArgs(key, splitKey roachpb.Key) *roachpb.AdminSplitRequest {
@@ -1526,7 +1525,6 @@ func TestLeaderAfterSplit(t *testing.T) {
 }
 
 func BenchmarkStoreRangeSplit(b *testing.B) {
-	defer tracing.Disable()()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
 	stopper := stop.NewStopper()

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -23,14 +23,15 @@ import (
 	"math/rand"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
+	"unsafe"
 
 	"golang.org/x/net/context"
 	"golang.org/x/net/trace"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/util/envutil"
-	"github.com/lightstep/lightstep-tracer-go"
+	lightstep "github.com/lightstep/lightstep-tracer-go"
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
@@ -60,6 +61,43 @@ var enableNetTrace = settings.RegisterBoolSetting(
 	false,
 )
 
+var lightstepToken = settings.RegisterStringSetting(
+	"trace.lightstep.token",
+	"if set, traces go to Lightstep using this token",
+	"",
+)
+
+// We don't call OnChange inline above because it causes an "initialization
+// loop" compile error.
+var _ = lightstepToken.OnChange(updateLightstep)
+
+// Atomic pointer of type *opentracing.Tracer which itself points to a lightstep
+// tracer. We don't use sync.Value because we can't set it to nil.
+var lightstepPtr unsafe.Pointer
+
+func updateLightstep() {
+	if token := lightstepToken.Get(); token == "" {
+		// TODO(radu): if we had a lightstep tracer allocated, its background task
+		// will live on.
+		// Filed https://github.com/lightstep/lightstep-tracer-go/issues/82.
+		atomic.StorePointer(&lightstepPtr, nil)
+	} else {
+		lsTr := lightstep.NewTracer(lightstep.Options{
+			AccessToken:    token,
+			MaxLogsPerSpan: maxLogsPerSpan,
+			UseGRPC:        true,
+		})
+		atomic.StorePointer(&lightstepPtr, unsafe.Pointer(&lsTr))
+	}
+}
+
+func getLightstep() opentracing.Tracer {
+	if ptr := atomic.LoadPointer(&lightstepPtr); ptr != nil {
+		return *(*opentracing.Tracer)(ptr)
+	}
+	return nil
+}
+
 // Tracer is our own custom implementation of opentracing.Tracer. It supports:
 //
 //  - forwarding events to x/net/trace instances
@@ -74,10 +112,11 @@ var enableNetTrace = settings.RegisterBoolSetting(
 // Even when tracing is disabled, we still use this Tracer (with x/net/trace and
 // lightstep disabled) because of its recording capability (snowball
 // tracing needs to work in all cases).
+//
+// Tracer is currently stateless so we could have a single instance; however,
+// this won't be the case if the cluster settings move away from using global
+// state.
 type Tracer struct {
-	// If set, we are using a lightstep tracer for most operations.
-	lightstep opentracing.Tracer
-
 	// Preallocated noopSpan, used to avoid creating spans when we are not using
 	// x/net/trace or lightstep and we are not recording.
 	noopSpan noopSpan
@@ -85,10 +124,10 @@ type Tracer struct {
 
 var _ opentracing.Tracer = &Tracer{}
 
-func newTracer(lightstep opentracing.Tracer) *Tracer {
-	t := &Tracer{
-		lightstep: lightstep,
-	}
+// NewTracer creates a Tracer. The cluster settings control whether
+// we trace to net/trace and/or lightstep.
+func NewTracer() opentracing.Tracer {
+	t := &Tracer{}
 	t.noopSpan.tracer = t
 	return t
 }
@@ -118,12 +157,12 @@ func (l *lightstepExtractIDsCarrier) Set(key, val string) {
 }
 
 // getLightstepSpanIDs extracts the TraceID and SpanID from a lightstep context.
-func (t *Tracer) getLightstepSpanIDs(
-	spanCtx opentracing.SpanContext,
+func getLightstepSpanIDs(
+	lightstep opentracing.Tracer, spanCtx opentracing.SpanContext,
 ) (traceID uint64, spanID uint64) {
 	// Retrieve the trace metadata from lightstep.
 	var carrier lightstepExtractIDsCarrier
-	if err := t.lightstep.Inject(spanCtx, opentracing.TextMap, &carrier); err != nil {
+	if err := lightstep.Inject(spanCtx, opentracing.TextMap, &carrier); err != nil {
 		panic(fmt.Sprintf("error injecting lightstep context %s", err))
 	}
 	if carrier.traceID == 0 || carrier.spanID == 0 {
@@ -150,7 +189,7 @@ func (t *Tracer) StartSpan(
 	// Fast paths to avoid the allocation of StartSpanOptions below when tracing
 	// is disabled: if we have no options or a single SpanReference (the common
 	// case) with a noop context, return a noop span now.
-	if len(opts) == 1 && t.lightstep == nil {
+	if len(opts) == 1 {
 		if o, ok := opts[0].(opentracing.SpanReference); ok {
 			if _, noopCtx := o.ReferencedContext.(noopSpanContext); noopCtx {
 				return &t.noopSpan
@@ -159,8 +198,9 @@ func (t *Tracer) StartSpan(
 	}
 
 	netTrace := enableNetTrace.Get()
+	lsTr := getLightstep()
 
-	if len(opts) == 0 && !netTrace && t.lightstep == nil {
+	if len(opts) == 0 && !netTrace && lsTr == nil {
 		return &t.noopSpan
 	}
 
@@ -200,11 +240,16 @@ func (t *Tracer) StartSpan(
 		// TODO(radu): can we do something for multiple references?
 		break
 	}
+	if hasParent && parentCtx.lightstep == nil {
+		// If a lightstep tracer was configured, don't use it if the parent span
+		// isn't using it.
+		lsTr = nil
+	}
 
 	// If tracing is disabled, the Recordable option wasn't passed, and we're not
 	// part of a recording or snowball trace, avoid overhead and return a noop
 	// span.
-	if !recordable && recordingGroup == nil && t.lightstep == nil && !netTrace {
+	if !recordable && recordingGroup == nil && lsTr == nil && !netTrace {
 		return &t.noopSpan
 	}
 
@@ -221,7 +266,7 @@ func (t *Tracer) StartSpan(
 	// If we are using lightstep, we create a new lightstep span and use the
 	// metadata (TraceID, SpanID, Baggage) from that span. Otherwise, we generate
 	// our own IDs.
-	if t.lightstep != nil {
+	if lsTr != nil {
 		// Create the shadow lightstep span.
 		var lsOpts []opentracing.StartSpanOption
 		// Replicate the options, using the lightstep context in the reference.
@@ -240,8 +285,8 @@ func (t *Tracer) StartSpan(
 				ReferencedContext: parentCtx.lightstep,
 			})
 		}
-		s.lightstep = t.lightstep.StartSpan(operationName, lsOpts...)
-		s.TraceID, s.SpanID = t.getLightstepSpanIDs(s.lightstep.Context())
+		s.lightstep = lsTr.StartSpan(operationName, lsOpts...)
+		s.TraceID, s.SpanID = getLightstepSpanIDs(lsTr, s.lightstep.Context())
 		if hasParent && s.TraceID != parentCtx.TraceID {
 			panic(fmt.Sprintf(
 				"TraceID doesn't match between parent (%d) and child (%d) spans",
@@ -291,7 +336,7 @@ func (t *Tracer) StartSpan(
 		s.SetTag(k, v)
 	}
 
-	if netTrace || t.lightstep != nil {
+	if netTrace || lsTr != nil {
 		// Copy baggage items to tags so they show up in the Lightstep UI or x/net/trace.
 		for k, v := range s.mu.Baggage {
 			s.SetTag(k, v)
@@ -384,10 +429,10 @@ func (t *Tracer) Extract(format interface{}, carrier interface{}) (opentracing.S
 		return noopSpanContext{}, nil
 	}
 
-	if t.lightstep != nil {
+	if lightstep := getLightstep(); lightstep != nil {
 		// Extract the lightstep context. For this to work, our key-value "schema"
-		// must match lighstep's exactly (otherwise we get an error here).
-		sc.lightstep, err = t.lightstep.Extract(format, carrier)
+		// must match lightstep's exactly (otherwise we get an error here).
+		sc.lightstep, err = lightstep.Extract(format, carrier)
 		if err != nil {
 			return noopSpanContext{}, err
 		}
@@ -438,22 +483,6 @@ func ChildSpan(ctx context.Context, opName string) (context.Context, opentracing
 	}
 	newSpan := span.Tracer().StartSpan(opName, opentracing.ChildOf(span.Context()))
 	return opentracing.ContextWithSpan(ctx, newSpan), newSpan
-}
-
-var lightstepToken = envutil.EnvOrDefaultString("COCKROACH_LIGHTSTEP_TOKEN", "")
-
-// NewTracer creates a Tracer which records to the net/trace
-// endpoint.
-func NewTracer() opentracing.Tracer {
-	var lsTr opentracing.Tracer
-	if lightstepToken != "" {
-		lsTr = lightstep.NewTracer(lightstep.Options{
-			AccessToken:    lightstepToken,
-			MaxLogsPerSpan: maxLogsPerSpan,
-			UseGRPC:        true,
-		})
-	}
-	return newTracer(lsTr)
 }
 
 // EnsureContext checks whether the given context.Context contains a Span. If

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/net/trace"
 
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/lightstep/lightstep-tracer-go"
 	opentracing "github.com/opentracing/opentracing-go"
@@ -53,6 +54,12 @@ const (
 	fieldNameSampled = prefixTracerState + "sampled"
 )
 
+var enableNetTrace = settings.RegisterBoolSetting(
+	"trace.debug.enable",
+	"if set, traces for recent requests can be seen in the /debug page",
+	false,
+)
+
 // Tracer is our own custom implementation of opentracing.Tracer. It supports:
 //
 //  - forwarding events to x/net/trace instances
@@ -68,8 +75,6 @@ const (
 // lightstep disabled) because of its recording capability (snowball
 // tracing needs to work in all cases).
 type Tracer struct {
-	// If set, we set up an x/net/trace for each span.
-	netTrace bool
 	// If set, we are using a lightstep tracer for most operations.
 	lightstep opentracing.Tracer
 
@@ -80,20 +85,12 @@ type Tracer struct {
 
 var _ opentracing.Tracer = &Tracer{}
 
-func newTracer(netTrace bool, lightstep opentracing.Tracer) *Tracer {
+func newTracer(lightstep opentracing.Tracer) *Tracer {
 	t := &Tracer{
-		netTrace:  netTrace,
 		lightstep: lightstep,
 	}
 	t.noopSpan.tracer = t
 	return t
-}
-
-// isNoop returns if this is a noop tracer, which means that span events don't
-// go anywhere, unless they are being recorded. Such a tracer is still capable
-// of snowball tracing.
-func (t *Tracer) isNoop() bool {
-	return !t.netTrace && t.lightstep == nil
 }
 
 // lightstepExtractIDsCarrier is used as a carrier for getLightstepSpanIDs.
@@ -150,20 +147,21 @@ func (recordableOption) Apply(*opentracing.StartSpanOptions) {}
 func (t *Tracer) StartSpan(
 	operationName string, opts ...opentracing.StartSpanOption,
 ) opentracing.Span {
-	if t.isNoop() {
-		// Fast paths to avoid the allocation of StartSpanOptions below when tracing
-		// is disabled: if we have no options or a single SpanReference (the common
-		// case) with a noop context, return a noop span now.
-		switch len(opts) {
-		case 0:
-			return &t.noopSpan
-		case 1:
-			if o, ok := opts[0].(opentracing.SpanReference); ok {
-				if _, noopCtx := o.ReferencedContext.(noopSpanContext); noopCtx {
-					return &t.noopSpan
-				}
+	// Fast paths to avoid the allocation of StartSpanOptions below when tracing
+	// is disabled: if we have no options or a single SpanReference (the common
+	// case) with a noop context, return a noop span now.
+	if len(opts) == 1 && t.lightstep == nil {
+		if o, ok := opts[0].(opentracing.SpanReference); ok {
+			if _, noopCtx := o.ReferencedContext.(noopSpanContext); noopCtx {
+				return &t.noopSpan
 			}
 		}
+	}
+
+	netTrace := enableNetTrace.Get()
+
+	if len(opts) == 0 && !netTrace && t.lightstep == nil {
+		return &t.noopSpan
 	}
 
 	var sso opentracing.StartSpanOptions
@@ -206,7 +204,7 @@ func (t *Tracer) StartSpan(
 	// If tracing is disabled, the Recordable option wasn't passed, and we're not
 	// part of a recording or snowball trace, avoid overhead and return a noop
 	// span.
-	if !recordable && recordingGroup == nil && t.isNoop() {
+	if !recordable && recordingGroup == nil && t.lightstep == nil && !netTrace {
 		return &t.noopSpan
 	}
 
@@ -274,7 +272,7 @@ func (t *Tracer) StartSpan(
 		s.enableRecording(recordingGroup)
 	}
 
-	if t.netTrace {
+	if netTrace {
 		s.netTr = trace.New("tracing", operationName)
 		s.netTr.SetMaxEvents(maxLogsPerSpan)
 	}
@@ -293,7 +291,7 @@ func (t *Tracer) StartSpan(
 		s.SetTag(k, v)
 	}
 
-	if t.netTrace || t.lightstep != nil {
+	if netTrace || t.lightstep != nil {
 		// Copy baggage items to tags so they show up in the Lightstep UI or x/net/trace.
 		for k, v := range s.mu.Baggage {
 			s.SetTag(k, v)
@@ -443,16 +441,10 @@ func ChildSpan(ctx context.Context, opName string) (context.Context, opentracing
 }
 
 var lightstepToken = envutil.EnvOrDefaultString("COCKROACH_LIGHTSTEP_TOKEN", "")
-var enableTracing = envutil.EnvOrDefaultBool("COCKROACH_ENABLE_TRACING", false)
 
 // NewTracer creates a Tracer which records to the net/trace
 // endpoint.
 func NewTracer() opentracing.Tracer {
-	if !enableTracing {
-		// Create a tracer that drops all events unless we enable
-		// recording on a span.
-		return newTracer(false /* netTrace */, nil /* lightstep */)
-	}
 	var lsTr opentracing.Tracer
 	if lightstepToken != "" {
 		lsTr = lightstep.NewTracer(lightstep.Options{
@@ -461,7 +453,7 @@ func NewTracer() opentracing.Tracer {
 			UseGRPC:        true,
 		})
 	}
-	return newTracer(true /* netTrace */, lsTr)
+	return newTracer(lsTr)
 }
 
 // EnsureContext checks whether the given context.Context contains a Span. If
@@ -476,24 +468,6 @@ func EnsureContext(
 		return opentracing.ContextWithSpan(ctx, sp), sp.Finish
 	}
 	return ctx, func() {}
-}
-
-// Disable is for benchmarking use and causes all future tracers to deal in
-// no-ops. Calling the returned closure undoes this effect. There is no
-// synchronization, so no moving parts are allowed while Disable and the
-// closure are called.
-func Disable() func() {
-	return SetEnabled(false)
-}
-
-// SetEnabled enables or disables tracing. Returns a function that restores
-// the previous setting.
-func SetEnabled(enabled bool) func() {
-	orig := enableTracing
-	enableTracing = enabled
-	return func() {
-		enableTracing = orig
-	}
 }
 
 // StartSnowballTrace takes in a context and returns a derived one with a

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -75,7 +75,7 @@ func checkRecordedSpans(t *testing.T, recSpans []RecordedSpan, expected string) 
 }
 
 func TestTracerRecording(t *testing.T) {
-	tr := newTracer(false /* netTrace */, nil /* lightstep */)
+	tr := newTracer(nil /* lightstep */)
 
 	noop1 := tr.StartSpan("noop")
 	if !IsNoopSpan(noop1) {
@@ -169,8 +169,8 @@ func TestTracerRecording(t *testing.T) {
 }
 
 func TestTracerInjectExtract(t *testing.T) {
-	tr := newTracer(false /* netTrace */, nil /* lightstep */)
-	tr2 := newTracer(false /* netTrace */, nil /* lightstep */)
+	tr := newTracer(nil /* lightstep */)
+	tr2 := newTracer(nil /* lightstep */)
 
 	// Verify that noop spans become noop spans on the remote side.
 

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
 	lightstep "github.com/lightstep/lightstep-tracer-go"
@@ -75,7 +77,7 @@ func checkRecordedSpans(t *testing.T, recSpans []RecordedSpan, expected string) 
 }
 
 func TestTracerRecording(t *testing.T) {
-	tr := newTracer(nil /* lightstep */)
+	tr := NewTracer()
 
 	noop1 := tr.StartSpan("noop")
 	if !IsNoopSpan(noop1) {
@@ -169,8 +171,8 @@ func TestTracerRecording(t *testing.T) {
 }
 
 func TestTracerInjectExtract(t *testing.T) {
-	tr := newTracer(nil /* lightstep */)
-	tr2 := newTracer(nil /* lightstep */)
+	tr := NewTracer()
+	tr2 := NewTracer()
 
 	// Verify that noop spans become noop spans on the remote side.
 
@@ -261,7 +263,8 @@ func TestLightstepContext(t *testing.T) {
 		MaxLogsPerSpan: maxLogsPerSpan,
 		UseGRPC:        true,
 	})
-	tr := newTracer(false /* netTrace */, lsTr)
+	atomic.StorePointer(&lightstepPtr, unsafe.Pointer(&lsTr))
+	tr := NewTracer()
 	s := tr.StartSpan("test")
 
 	const testBaggageKey = "test-baggage"
@@ -272,7 +275,7 @@ func TestLightstepContext(t *testing.T) {
 	if err := tr.Inject(s.Context(), opentracing.HTTPHeaders, carrier); err != nil {
 		t.Fatal(err)
 	}
-	traceID, spanID := tr.getLightstepSpanIDs(s.(*span).lightstep.Context())
+	traceID, spanID := getLightstepSpanIDs(lsTr, s.(*span).lightstep.Context())
 	if traceID == 0 || spanID == 0 {
 		t.Errorf("invalid trace/span IDs: %d %d", traceID, spanID)
 	}
@@ -287,7 +290,7 @@ func TestLightstepContext(t *testing.T) {
 	s2 := tr.StartSpan("child", opentracing.FollowsFrom(wireContext))
 	s2Ctx := s2.(*span).lightstep.Context()
 
-	traceID2, spanID2 := tr.getLightstepSpanIDs(s2Ctx)
+	traceID2, spanID2 := getLightstepSpanIDs(lsTr, s2Ctx)
 
 	if traceID2 != traceID || spanID2 == 0 {
 		t.Errorf("invalid child trace/span IDs: %d %d", traceID2, spanID2)


### PR DESCRIPTION
See individual commits. The TL;DR is that we now have two cluster settings that control net/trace and the lightstep token. The default is for them to be off in which case no tracing happens (other than snowball tracing when requested).

I plan to run some more manual tests but it seems to work so far.
CC @dt for the naming of the settings (is there a doc somewhere with guidelines?). Note that we may add more lightstep settings like `trace.lightstep.address` and whatnot.