### PR TITLE
server: tweak problem ranges row

### DIFF
--- a/pkg/server/debug.go
+++ b/pkg/server/debug.go
@@ -155,8 +155,7 @@ func init() {
       </tr>
       <tr>
         <td>problem ranges</td>
-        <td><a href="/debug/problemranges">on the cluster</a></td>
-        <td><a href="/debug/problemranges?node_id=1">on a specific node</a></td>
+        <td><a href="/debug/problemranges">on the cluster</a>, <a href="/debug/problemranges?node_id=1">on a specific node</a></td>
       </tr>
       <tr>
         <td>network status</td>


### PR DESCRIPTION
Using a separate column for "on a specific node" placed it very distant
from "on the cluster". Using a single column and separate the links with
a comma.