### PR TITLE
storage: fix Replica.mu.commandSizes blow up

### DIFF
--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -280,6 +280,18 @@ func (r *Replica) QuotaAvailable() int64 {
 	return r.mu.proposalQuota.approximateQuota()
 }
 
+func (r *Replica) QuotaReleaseQueueLen() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.mu.quotaReleaseQueue)
+}
+
+func (r *Replica) CommandSizesLen() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.mu.commandSizes)
+}
+
 // GetTimestampCacheLowWater returns the timestamp cache low water mark.
 func (r *Replica) GetTimestampCacheLowWater() hlc.Timestamp {
 	r.store.tsCacheMu.Lock()


### PR DESCRIPTION
Fixes the issue seen [here](https://github.com/cockroachdb/cockroach/issues/14108#issuecomment-305659813).

Not deleting the command size after queuing it to
`Replica.mu.quotaReleaseQueue` causes `Replica.mu.commandSizes` 
to grow indefinitely.

Following a 10m `hotspot` run, before:
```
.          .   2784:   // Add size of proposal to commandSizes map.
.          .   2785:   if r.mu.commandSizes != nil {
.     3.75MB   2786:           r.mu.commandSizes[proposal.idKey] = proposal.command.Size()
.          .   2787:   }
```
With `--inuse_objects`:
```
.          .   2784:   // Add size of proposal to commandSizes map.
.          .   2785:   if r.mu.commandSizes != nil {
.       2522   2786:           r.mu.commandSizes[proposal.idKey] = proposal.command.Size()
.          .   2787:   }
```
![image](https://cloud.githubusercontent.com/assets/10536690/26712083/e616de44-4732-11e7-9453-2613bdd95dc4.png)



After (same for `--inuse_objects`):
```
.          .   2784:   // Add size of proposal to commandSizes map.
.          .   2785:   if r.mu.commandSizes != nil {
.          .   2786:           r.mu.commandSizes[proposal.idKey] = proposal.command.Size()
.          .   2787:   }
```