### PR TITLE
sql: fix errors in DISTINCT and column orderings

### DIFF
--- a/pkg/sql/needed_columns.go
+++ b/pkg/sql/needed_columns.go
@@ -98,13 +98,8 @@ func setNeededColumns(plan planNode, needed []bool) {
 		markOmitted(n.resultColumns, n.valNeededForCol)
 
 	case *distinctNode:
-		sourceNeeded := make([]bool, len(n.plan.Columns()))
-		copy(sourceNeeded, needed)
-		// All the sorting columns are also needed.
-		for i, o := range n.columnsInOrder {
-			sourceNeeded[i] = sourceNeeded[i] || o
-		}
-		setNeededColumns(n.plan, sourceNeeded)
+		// Distinct needs values for every input column.
+		setNeededColumns(n.plan, allColumns(n.plan))
 
 	case *filterNode:
 		// Detect which columns from the source are needed in addition to

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -621,7 +621,7 @@ func (r *renderNode) computeOrdering(fromOrder orderingInfo) {
 			// or invalid indexed var; ignore.
 			continue
 		}
-		if !hasRowDependentValues {
+		if !hasRowDependentValues && !r.columns[col].Omitted {
 			r.ordering.addExactMatchColumn(col)
 		}
 	}

--- a/pkg/sql/select_name_resolution.go
+++ b/pkg/sql/select_name_resolution.go
@@ -60,6 +60,10 @@ func (v *nameResolutionVisitor) VisitPre(expr parser.Expr) (recurse bool, newNod
 		v.foundDependentVars = true
 	case *parser.AllColumnsSelector:
 		v.foundDependentVars = true
+	case *parser.StarDatum:
+		// StarDatum is inserted into expressions by count(*).
+		// When it is present, the "value" changes every row.
+		v.foundDependentVars = true
 
 	case *parser.IndexedVar:
 		// If the indexed var is a standalone ordinal reference, ensure it

--- a/pkg/sql/testdata/logic_test/aggregate
+++ b/pkg/sql/testdata/logic_test/aggregate
@@ -251,7 +251,7 @@ EXPLAIN (VERBOSE) SELECT COUNT(*), k+v FROM kv GROUP BY k+v
 0  group                                       ("count(*)", "k + v")
 0          aggregate 0  count(*)
 0          aggregate 1  test.kv.k + test.kv.v
-1  render                                      ("k + v", "*")                  ="*"
+1  render                                      ("k + v", "*")
 1          render 0     test.kv.k + test.kv.v
 1          render 1     *
 2  scan                                        (k, v, w[omitted], s[omitted])
@@ -280,7 +280,7 @@ EXPLAIN (VERBOSE) SELECT COUNT(*), k+v FROM kv GROUP BY k, v
 1          aggregate 0  count(*)
 1          aggregate 1  test.kv.k
 1          aggregate 2  test.kv.v
-2  render                           (k, v, "*")                     ="*"
+2  render                           (k, v, "*")
 2          render 0     test.kv.k
 2          render 1     test.kv.v
 2          render 2     *
@@ -1101,7 +1101,7 @@ EXPLAIN (TYPES) SELECT COUNT(*) FILTER (WHERE k > 5) FROM filter_test GROUP BY v
 ----
 0  group                                                                                   ("count(*) FILTER (WHERE k > 5)" int)
 0          aggregate 0  (count((*)[int]) FILTER (WHERE ((k)[int] > (5)[int])[bool]))[int]
-1  render                                                                                  (v int, "*" int, "k > 5" bool)                                 ="*"
+1  render                                                                                  (v int, "*" int, "k > 5" bool)
 1          render 0     (v)[int]
 1          render 1     (*)[int]
 1          render 2     ((k)[int] > (5)[int])[bool]

--- a/pkg/sql/testdata/logic_test/distinct
+++ b/pkg/sql/testdata/logic_test/distinct
@@ -31,6 +31,15 @@ SELECT DISTINCT y, z FROM xyz
 3 5
 2 9
 
+query I rowsort
+SELECT y FROM (SELECT DISTINCT y, z FROM xyz)
+----
+2
+5
+2
+3
+2
+
 # TODO(vivek): Use the secondary index. Use distinct in index selection.
 query ITTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz
@@ -181,3 +190,8 @@ SELECT DISTINCT (y,z) FROM xyz
 (3,5)
 (2,9)
 (2,)
+
+query I
+SELECT COUNT(*) FROM (SELECT DISTINCT y FROM xyz)
+----
+3

--- a/pkg/sql/testdata/logic_test/needed_columns
+++ b/pkg/sql/testdata/logic_test/needed_columns
@@ -12,7 +12,7 @@ query ITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM (SELECT 2 AS s)
 ----
 0  render       ("1")         ="1"
-1  render       (s[omitted])  =s
+1  render       (s[omitted])
 2  nullrow      ()
 
 # Propagation through CREATE TABLE.
@@ -21,7 +21,7 @@ EXPLAIN (METADATA) CREATE TABLE t AS SELECT 1 FROM (SELECT 2 AS s)
 ----
 0  create table      ()
 1  render            ("1")         ="1"
-2  render            (s[omitted])  =s
+2  render            (s[omitted])
 3  nullrow           ()
 
 # Propagation through LIMIT.
@@ -30,15 +30,15 @@ EXPLAIN (METADATA) SELECT 1 FROM (SELECT 2 AS s) LIMIT 1
 ----
 0  limit        ("1")         ="1"
 1  render       ("1")         ="1"
-2  render       (s[omitted])  =s
+2  render       (s[omitted])
 3  nullrow      ()
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM (SELECT 2 AS s LIMIT 1)
 ----
 0  render       ("1")         ="1"
-1  limit        (s[omitted])  =s
-2  render       (s[omitted])  =s
+1  limit        (s[omitted])
+2  render       (s[omitted])
 3  nullrow      ()
 
 # Propagation through UNION.
@@ -57,9 +57,9 @@ EXPLAIN (METADATA) SELECT 1 FROM (SELECT 1 AS s UNION ALL SELECT 2 AS s)
 ----
 0  render       ("1")         ="1"
 1  append       (s[omitted])
-2  render       (s[omitted])  =s
+2  render       (s[omitted])
 3  nullrow      ()
-2  render       (s[omitted])  =s
+2  render       (s[omitted])
 3  nullrow      ()
 
 # Propagation through WITH ORDINALITY.
@@ -67,8 +67,8 @@ query ITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM (SELECT 1 AS s) WITH ORDINALITY
 ----
 0  render          ("1")                       ="1"
-1  ordinality      (s[omitted], "ordinality")  =s,+"ordinality",unique
-2  render          (s[omitted])                =s
+1  ordinality      (s[omitted], "ordinality")  +"ordinality",unique
+2  render          (s[omitted])
 3  nullrow         ()
 
 # Propagation through sort, when the sorting column is in the results.
@@ -76,7 +76,7 @@ query ITTTTT
 EXPLAIN (METADATA) SELECT x FROM (SELECT 1 AS x, 2 AS y) ORDER BY x
 ----
 0  render       (x)              =x
-1  render       (x, y[omitted])  =x,=y
+1  render       (x, y[omitted])  =x
 2  nullrow      ()
 
 # Propagation through sort, when the sorting column is not in the results.
@@ -86,7 +86,7 @@ EXPLAIN (METADATA) SELECT x FROM (SELECT 1 AS x, 2 AS y, 3 AS z) ORDER BY y
 0  nosort              (x)                 =x
 0           order  +y
 1  render              (x, y)              =x,=y
-2  render              (x, y, z[omitted])  =x,=y,=z
+2  render              (x, y, z[omitted])  =x,=y
 3  nullrow             ()
 
 # Propagation to sub-queries.
@@ -97,7 +97,7 @@ EXPLAIN (METADATA) SELECT 1 = (SELECT 2 AS x FROM (SELECT 3 AS s)) AS y
 0           subqueries  1
 1  limit                   (x)           =x
 2  render                  (x)           =x
-3  render                  (s[omitted])  =s
+3  render                  (s[omitted])
 4  nullrow                 ()
 1  nullrow                 ()
 
@@ -130,7 +130,7 @@ EXPLAIN (METADATA) INSERT INTO kv(k, v) SELECT 1, 2 FROM (SELECT 3 AS x, 4 AS y)
 0  insert                   ()
 0           into  kv(k, v)
 1  render                   ("1", "2")                ="1",="2"
-2  render                   (x[omitted], y[omitted])  =x,=y
+2  render                   (x[omitted], y[omitted])
 3  nullrow                  ()
 
 # Propagation through DELETE.
@@ -151,10 +151,10 @@ EXPLAIN (VERBOSE) SELECT x FROM (SELECT 1 AS x, y FROM (SELECT 2 AS y))
 ----
 0  render                   (x)              =x
 0           render 0  x
-1  render                   (x, y[omitted])  =x,=y
+1  render                   (x, y[omitted])  =x
 1           render 0  1
 1           render 1  NULL
-2  render                   (y[omitted])     =y
+2  render                   (y[omitted])
 2           render 0  NULL
 3  nullrow                  ()
 
@@ -166,3 +166,20 @@ EXPLAIN (VERBOSE) SELECT 1 FROM (SELECT k+1 AS x, v-2 AS y FROM kv)
 1  scan                          (k[omitted], v[omitted])
 1          table     kv@primary
 1          spans     ALL
+
+statement ok
+CREATE TABLE a ("name" string, age int);
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT count(*) FROM (SELECT "name", age FROM a);
+----
+0  group                             ("count(*)")
+0          aggregate 0  count(*)
+1  render                            ("*")
+1          render 0     *
+2  render                            ("name"[omitted], age[omitted])
+2          render 0     NULL
+2          render 1     NULL
+3  scan                              ("name"[omitted], age[omitted], rowid[hidden,omitted])
+3          table        a@primary
+3          spans        ALL


### PR DESCRIPTION
Fixes  #16304.
Special thanks to Radu for pointing to the source of the problem.

###  	sql: fix the behavior of DISTINCT

Prior to this patch, distinctNode would incorrectly propagate the flag
that indicates whether data was needed for columns from its consumer
to its source. This is incorrect because distinctNode itself needs
data for *all* columns to bucket the unique values.

This patch addresses the issue by ensuring all columns of the source
are marked as "needed".

### sql: fix the ordering hints for omitted columns and StarDatum

Prior to this patch, columns that were omitted because they were not
needed in the result, and StarDatum instances placed in renderNode by
count(*), were incorrectly marked as "exact match" columns because
they appeared as constants to `(*renderNode).computeOrdering()`.

It is not known whether this error would yield invalid query results,
but it would certainly make the output of EXPLAIN harder to interpret.

This patch fixes the issue by skipping over omitted columns in
`computeOrdering()` and ensuring that `StarDatum` is considered "row
dependent" (not constant).