### PR TITLE
sql: edit correct table when dropping self-ref FKs

### DIFF
--- a/pkg/sql/testdata/logic_test/fk
+++ b/pkg/sql/testdata/logic_test/fk
@@ -749,3 +749,24 @@ ALTER TABLE a ADD CONSTRAINT fk_self_id FOREIGN KEY (self_id) REFERENCES a(b_id)
 
 statement ok
 DROP TABLE a;
+
+# Check that removing self-ref FK correctly removed backref too, #16070.
+statement ok
+CREATE TABLE employee (
+   id INT PRIMARY KEY,
+   manager INT,
+   UNIQUE (manager)
+);
+
+statement ok
+ALTER TABLE employee
+   ADD CONSTRAINT emp_emp
+   FOREIGN KEY (manager)
+   REFERENCES employee;
+
+statement ok
+ALTER TABLE employee
+   DROP CONSTRAINT emp_emp;
+
+statement ok
+SHOW CREATE TABLE employee;


### PR DESCRIPTION
When dropping a self-ref FK, we want to make sure that we do the back-reference removal on the same copy of the table descriptor that we'll edit to remove the outbound reference, rather than looking up/editing another copy (and then clobbering one of our edits when we save).

Fixes #16070