### PR TITLE
cherrypick: sql: fix the behavior of DISTINCT

### DIFF
--- a/pkg/sql/needed_columns.go
+++ b/pkg/sql/needed_columns.go
@@ -98,13 +98,8 @@ func setNeededColumns(plan planNode, needed []bool) {
 		markOmitted(n.resultColumns, n.valNeededForCol)
 
 	case *distinctNode:
-		sourceNeeded := make([]bool, len(n.plan.Columns()))
-		copy(sourceNeeded, needed)
-		// All the sorting columns are also needed.
-		for i, o := range n.columnsInOrder {
-			sourceNeeded[i] = sourceNeeded[i] || o
-		}
-		setNeededColumns(n.plan, sourceNeeded)
+		// Distinct needs values for every input column.
+		setNeededColumns(n.plan, allColumns(n.plan))
 
 	case *filterNode:
 		// Detect which columns from the source are needed in addition to

--- a/pkg/sql/testdata/logic_test/distinct
+++ b/pkg/sql/testdata/logic_test/distinct
@@ -31,6 +31,15 @@ SELECT DISTINCT y, z FROM xyz
 3 5
 2 9
 
+query I rowsort
+SELECT y FROM (SELECT DISTINCT y, z FROM xyz)
+----
+2
+5
+2
+3
+2
+
 # TODO(vivek): Use the secondary index. Use distinct in index selection.
 query ITTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz
@@ -181,3 +190,8 @@ SELECT DISTINCT (y,z) FROM xyz
 (3,5)
 (2,9)
 (2,)
+
+query I
+SELECT COUNT(*) FROM (SELECT DISTINCT y FROM xyz)
+----
+3


### PR DESCRIPTION
Prior to this patch, distinctNode would incorrectly propagate the flag
that indicates whether data was needed for columns from its consumer
to its source. This is incorrect because distinctNode itself needs
data for *all* columns to bucket the unique values.

This patch addresses the issue by ensuring all columns of the source
are marked as "needed".

NB: the other commit from #16307 (ccb0202cd0e69c6e0689a856f8a4e03ec096848f) needs not be merged, because it fixes a bug introduced by a feature not present in 1.0.x.

cc @cockroachdb/release 