### PR TITLE
storage: fix two store pool setting defaults

### DIFF
--- a/pkg/storage/store_pool.go
+++ b/pkg/storage/store_pool.go
@@ -47,13 +47,13 @@ const (
 var declinedReservationsTimeout = settings.RegisterNonNegativeDurationSetting(
 	"server.declined_reservation_timeout",
 	"the amount of time to consider the store throttled for up-replication after a reservation was declined",
-	5*time.Second,
+	0,
 )
 
 var failedReservationsTimeout = settings.RegisterNonNegativeDurationSetting(
 	"server.failed_reservation_timeout",
 	"the amount of time to consider the store throttled for up-replication after a failed reservation call",
-	0,
+	5*time.Second,
 )
 
 type nodeStatus int


### PR DESCRIPTION
These settings were accidentally reversed in #15619.

Fixes #15370.