### PR TITLE
cherrypick: storage: adjust {declined,failed} reservation timeouts

### DIFF
--- a/pkg/storage/store_pool.go
+++ b/pkg/storage/store_pool.go
@@ -44,16 +44,18 @@ const (
 	TestTimeUntilStoreDeadOff = 24 * time.Hour
 )
 
+// declinedReservationsTimeout needs to be non-zero to prevent useless retries
+// in the replicateQueue.process() retry loop.
 var declinedReservationsTimeout = settings.RegisterPositiveDurationSetting(
 	"server.declined_reservation_timeout",
 	"the amount of time to consider the store throttled for up-replication after a reservation was declined",
-	5*time.Second,
+	1*time.Second,
 )
 
 var failedReservationsTimeout = settings.RegisterPositiveDurationSetting(
 	"server.failed_reservation_timeout",
 	"the amount of time to consider the store throttled for up-replication after a failed reservation call",
-	0,
+	5*time.Second,
 )
 
 type nodeStatus int


### PR DESCRIPTION
The declined and failed reservation timeouts were unintentionally
flipped in #15619 which accidentally fixed #15370. The fix was due to
using a non-zero timeout for declined reservations. Revert #15619 but
provide a 1s timeout for declined reservations.

Fixes #15370