### PR TITLE
sql: error on result type changes in prepared statements

### DIFF
--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -1601,3 +1601,40 @@ func TestPGWireAuth(t *testing.T) {
 		}
 	})
 }
+
+func TestPGWireNumResultsChanged(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.TODO())
+
+	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), t.Name(), url.User(security.RootUser))
+	defer cleanupFn()
+
+	db, err := gosql.Open("postgres", pgURL.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`CREATE DATABASE testing`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE testing.f (v INT)`); err != nil {
+		t.Fatal(err)
+	}
+	stmt, err := db.Prepare(`SELECT * FROM testing.f`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`ALTER TABLE testing.f ADD COLUMN u int`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO testing.f VALUES (1, 2)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stmt.Exec(); !testutils.IsError(err, "number of results changed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := stmt.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -978,6 +978,9 @@ func (c *v3Conn) sendResponse(
 				for i, col := range row {
 					fmtCode := formatText
 					if formatCodes != nil {
+						if i >= len(formatCodes) {
+							return c.sendError(errors.New("number of results changed"))
+						}
 						fmtCode = formatCodes[i]
 					}
 					switch fmtCode {


### PR DESCRIPTION
Fix a panic when the number of results change in a pgwire prepared
statement. This is not the full fix for this bug, but it is the most
we have decided to do for the 1.0 branch. This adds a few known bugs,
all of which are fixed in the master branch:

1. Prepared statements of the form `INSERT ... RETURNING *` where a
schema change is done after the prepare act inconsistently. They will
succeed to write the data, but also return an error if the number of
columns has increased. If the number of columns is the same but the
types have changed, they will write the data and not return an error.
2. PREPARE/EXECUTE statements (that is, statements where PREPARE
and EXECUTE appear in the text of the statement) incorrectly allow
changes in result types due to schema changes between executions.

Fixes #16062
See #16089 for the full fix

cc @cockroachdb/release 

@jseldess I think this needs to be documented in the 1.0 known limitations?