### PR TITLE
sql: fix limit + index-join bug

### DIFF
--- a/pkg/sql/limit_opt.go
+++ b/pkg/sql/limit_opt.go
@@ -102,7 +102,9 @@ func applyLimit(plan planNode, numRows int64, soft bool) {
 		}
 
 	case *indexJoinNode:
-		applyLimit(n.index, numRows, soft)
+		// If we have a limit in the table node (i.e. post-index-join), the
+		// limit in the index is soft.
+		applyLimit(n.index, numRows, soft || !isFilterTrue(n.table.filter))
 		setUnlimited(n.table)
 
 	case *unionNode:

--- a/pkg/sql/testdata/logic_test/limit
+++ b/pkg/sql/testdata/logic_test/limit
@@ -42,3 +42,31 @@ SELECT generate_series FROM GENERATE_SERIES(1, 100) ORDER BY generate_series FET
 ----
 1
 2
+
+statement ok
+CREATE TABLE t (k INT PRIMARY KEY, v INT, w INT, INDEX(v))
+
+statement ok
+INSERT INTO t VALUES (1, 1, 1), (2, 4, 8), (3, 9, 27), (4, 16, 94), (5, 25, 125), (6, 36, 216)
+
+# Verify we don't incorrectly impose a hard limit at the index scan level.
+query III
+SELECT * FROM t WHERE v > 4 AND w > 30 ORDER BY v LIMIT 2
+----
+4 16 94
+5 25 125
+
+# There must be no limit at the index scan level.
+query ITTTTT colnames
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE v > 4 AND w > 30 ORDER BY v LIMIT 2
+----
+Level  Type        Field   Description  Columns                      Ordering
+0      limit                            (k, v, w)                    +v
+0                  count   2
+1      index-join                       (k, v, w)                    +v
+2      scan                             (k, v[omitted], w[omitted])  +v
+2                  table   t@t_v_idx
+2                  spans   /5-
+2      scan                             (k, v, w)
+2                  table   t@primary
+2                  filter  w > 30


### PR DESCRIPTION
If we have a limit that needs to be applied *after* the index join, it is
incorrect to set a hard limit on the index scan. This change fixes this by
checking the filter in the table node. Note that this bug existed for a while
but it only had functional consequences since #15925.

Fixes #16313.