### PR TITLE
interval: Remove extremely verbose logging from btree interval test

### DIFF
--- a/pkg/util/interval/btree_based_interval_test.go
+++ b/pkg/util/interval/btree_based_interval_test.go
@@ -119,6 +119,8 @@ func (tree *btree) describe() string {
 	return tree.root.String()
 }
 
+var _ = (*btree).describe
+
 func (n node) String() string {
 	var buf bytes.Buffer
 	n.describe(&buf)
@@ -146,10 +148,8 @@ func (n *node) describe(buf *bytes.Buffer) {
 }
 
 func (n *node) isKeyInRange(t *testing.T, min, max Comparable) bool {
-	t.Logf("%v, min: %v, max: %v", n, min, max)
 	for _, i := range n.items {
 		start := i.Range().Start
-		t.Log(i.Range())
 		if min != nil && start.Compare(min) < 0 {
 			return false
 		}
@@ -279,7 +279,6 @@ func checkWithLen(t *testing.T, tree *btree, l int) {
 }
 
 func check(t *testing.T, tree *btree) {
-	t.Logf("tree: %s", tree.describe())
 	if !tree.isLeafSameDepth(t) {
 		t.Error("Not all the leaves have the same depth as the tree height")
 	}
@@ -476,8 +475,7 @@ func TestBTree(t *testing.T) {
 			t.Fatalf("expected intervals %v, got %v", expected, halfSlice)
 		}
 
-		for i, item := range perm(treeSize) {
-			t.Logf("i: %d", i)
+		for _, item := range perm(treeSize) {
 			if err := tree.Delete(item, false); err != nil {
 				t.Fatalf("delete error: %s", err)
 			}


### PR DESCRIPTION
This logging produced 72MB of output in `make test
TESTFLAGS=-v` (which is how we run tests in CI). For comparison, the
entire rest of the test suite produces 4MB of output.