### PR TITLE
base: restore default retry options settings

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -297,8 +297,8 @@ func DefaultRetryOptions() retry.Options {
 	// Derive the retry options from a configured or measured
 	// estimate of latency.
 	return retry.Options{
-		InitialBackoff: 10 * time.Millisecond,
+		InitialBackoff: 50 * time.Millisecond,
 		MaxBackoff:     1 * time.Second,
-		Multiplier:     1.5,
+		Multiplier:     2,
 	}
 }


### PR DESCRIPTION
They were set to lower values as part of the high contention change in
the system. Notably: export_storage, the dist sender, sql leases, node
liveness, etc.