### PR TITLE
storage: buffer reads in command queue

### DIFF
--- a/pkg/storage/command_queue.go
+++ b/pkg/storage/command_queue.go
@@ -53,12 +53,13 @@ import (
 //
 // CommandQueue is not thread safe.
 type CommandQueue struct {
-	reads     interval.Tree
-	writes    interval.Tree
-	idAlloc   int64
-	wRg, rwRg interval.RangeGroup // avoids allocating in getWait
-	oHeap     overlapHeap         // avoids allocating in getWait
-	overlaps  []*cmd              // avoids allocating in getOverlaps
+	readsBuffer map[*cmd]struct{}
+	reads       interval.Tree
+	writes      interval.Tree
+	idAlloc     int64
+	wRg, rwRg   interval.RangeGroup // avoids allocating in getWait
+	oHeap       overlapHeap         // avoids allocating in getWait
+	overlaps    []*cmd              // avoids allocating in getOverlaps
 
 	coveringOptimization bool // if true, use covering span optimization
 
@@ -77,6 +78,7 @@ type cmd struct {
 	readOnly  bool
 	timestamp hlc.Timestamp
 	expanded  bool          // have the children been added
+	buffered  bool          // is this cmd buffered in readsBuffer
 	pending   chan struct{} // closed when complete
 	children  []cmd
 }
@@ -139,6 +141,7 @@ func (c *cmd) String() string {
 // typically contain many spans, but are spatially disjoint.
 func NewCommandQueue(coveringOptimization bool) *CommandQueue {
 	cq := &CommandQueue{
+		readsBuffer:          make(map[*cmd]struct{}),
 		reads:                interval.NewTree(interval.ExclusiveOverlapper),
 		writes:               interval.NewTree(interval.ExclusiveOverlapper),
 		wRg:                  interval.NewRangeTree(),
@@ -212,8 +215,7 @@ func (cq *CommandQueue) expand(c *cmd, isInserted bool) bool {
 }
 
 // getWait returns a slice of the pending channels of executing
-// commands which overlap the specified key ranges. The caller should
-// call wg.Wait() to fetch the required wait channels. The caller
+// commands which overlap the specified key ranges. The caller
 // should then invoke add() to add the keys to the command queue and
 // then wait for confirmation that all gating commands have completed
 // or failed. readOnly is true if the requester is a read-only
@@ -415,6 +417,17 @@ func (cq *CommandQueue) getOverlaps(
 	readOnly bool, timestamp hlc.Timestamp, rng interval.Range,
 ) []*cmd {
 	if !readOnly {
+		// Upon a write cmd, flush out cmds from readsBuffer to the read interval
+		// tree.
+		for cmd := range cq.readsBuffer {
+			cmd.buffered = false
+			cq.insertIntoTree(cmd)
+		}
+		if len(cq.readsBuffer) > 0 {
+			// Allocate a new map, thereby deleting all previous entries.
+			cq.readsBuffer = make(map[*cmd]struct{})
+		}
+
 		cq.reads.DoMatching(func(i interval.Interface) bool {
 			c := i.(*cmd)
 			// Writes only wait on equal or later reads (we always wait
@@ -553,7 +566,20 @@ func (cq *CommandQueue) add(readOnly bool, timestamp hlc.Timestamp, spans []roac
 		cq.localMetrics.writeCommands += int64(cmd.cmdCount())
 	}
 
-	if cq.coveringOptimization || len(spans) == 1 {
+	// Insert a readOnly command into the readsBuffer instead of mutating the
+	// interval tree.
+	if cmd.readOnly {
+		cmd.buffered = true
+		cq.readsBuffer[cmd] = struct{}{}
+		return cmd
+	}
+
+	cq.insertIntoTree(cmd)
+	return cmd
+}
+
+func (cq *CommandQueue) insertIntoTree(cmd *cmd) {
+	if cq.coveringOptimization || len(cmd.children) == 0 {
 		tree := cq.tree(cmd)
 		if err := tree.Insert(cmd, false /* !fast */); err != nil {
 			panic(err)
@@ -561,7 +587,6 @@ func (cq *CommandQueue) add(readOnly bool, timestamp hlc.Timestamp, spans []roac
 	} else {
 		cq.expand(cmd, false /* !isInserted */)
 	}
-	return cmd
 }
 
 // remove is invoked to signal that the command associated with the
@@ -579,6 +604,19 @@ func (cq *CommandQueue) remove(cmd *cmd) {
 		cq.localMetrics.readCommands -= int64(cmd.cmdCount())
 	} else {
 		cq.localMetrics.writeCommands -= int64(cmd.cmdCount())
+	}
+
+	// If cmd is buffered, just remove it from readsBuffer and be done.
+	if cmd.buffered {
+		if _, ok := cq.readsBuffer[cmd]; !ok {
+			panic(fmt.Sprintf("buffered cmd %d not found in readsBuffer", cmd.id))
+		}
+		delete(cq.readsBuffer, cmd)
+		// Nobody can be waiting on a buffered read, assert that its channel is nil
+		if cmd.pending != nil {
+			panic(fmt.Sprintf("buffered cmd %d has non-nil pending chan", cmd.id))
+		}
+		return
 	}
 
 	tree := cq.tree(cmd)

--- a/pkg/storage/command_queue_test.go
+++ b/pkg/storage/command_queue_test.go
@@ -17,7 +17,9 @@
 package storage
 
 import (
+	"bytes"
 	"fmt"
+	"math/rand"
 	"reflect"
 	"testing"
 	"time"
@@ -330,6 +332,15 @@ func mkSpan(start, end string) roachpb.Span {
 	return roachpb.Span{Key: roachpb.Key(start), EndKey: roachpb.Key(end)}
 }
 
+func randBytes(n int) []byte {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
 // Reconstruct a set of commands that tickled a bug in interval.Tree. See
 // https://github.com/cockroachdb/cockroach/issues/6495 for details.
 func TestCommandQueueIssue6495(t *testing.T) {
@@ -555,7 +566,7 @@ func TestCommandQueueTimestampsEmpty(t *testing.T) {
 	}
 }
 
-func BenchmarkCommandQueueGetWait(b *testing.B) {
+func BenchmarkCommandQueueGetWaitAllReadOnly(b *testing.B) {
 	// Test read-only getWait performance for various number of command queue
 	// entries. See #13627 where a previous implementation of
 	// CommandQueue.getOverlaps had O(n) performance in this setup. Since reads
@@ -574,6 +585,41 @@ func BenchmarkCommandQueueGetWait(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				_ = cq.getWait(true, zeroTS, spans)
+			}
+		})
+	}
+}
+
+func BenchmarkCommandQueueReadWriteMix(b *testing.B) {
+	// Test performance with a mixture of reads and writes with a high number
+	// of reads per write.
+	// See #15544.
+	for _, readsPerWrite := range []int{1, 4, 16, 64, 128, 256} {
+		b.Run(fmt.Sprintf("%d", readsPerWrite), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				totalCmds := 1 << 10
+				liveCmdQueue := make(chan *cmd, 16)
+				cq := NewCommandQueue(true /* coveringOptimization */)
+				for j := 0; j < totalCmds; j++ {
+					a, b := randBytes(100), randBytes(100)
+					// Overwrite first byte so that we do not mix local and global ranges
+					a[0], b[0] = 'a', 'a'
+					if bytes.Compare(a, b) > 0 {
+						a, b = b, a
+					}
+					spans := []roachpb.Span{{
+						Key:    roachpb.Key(a),
+						EndKey: roachpb.Key(b),
+					}}
+					var cmd *cmd
+					readOnly := j%(readsPerWrite+1) != 0
+					_ = cq.getWait(readOnly, zeroTS, spans)
+					cmd = cq.add(readOnly, zeroTS, spans)
+					if len(liveCmdQueue) == cap(liveCmdQueue) {
+						cq.remove(<-liveCmdQueue)
+					}
+					liveCmdQueue <- cmd
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Buffer readOnly commands in a map until getWait is called for a write,
at which point the buffered reads are inserted in the interval tree.
This is ok because reads do not depend on other reads. For read-heavy
workloads, this avoids inserting reads into the interval tree (which
does substantial compute per insert,) until it is necessary to do so.

Add a fresh benchmark for various reads skews. Performance of getWait
improves for workloads with high #reads per write, and worsens a tad
bit for workloads with low #reads per write.

Without reads buffer:
```
BenchmarkCommandQueueReadWriteMix/1-8        200   7455438 ns/op
BenchmarkCommandQueueReadWriteMix/4-8        300   4226602 ns/op
BenchmarkCommandQueueReadWriteMix/16-8               500   2642431 ns/op
BenchmarkCommandQueueReadWriteMix/64-8              1000   2180990 ns/op
BenchmarkCommandQueueReadWriteMix/128-8             1000   2150545 ns/op
BenchmarkCommandQueueReadWriteMix/256-8             1000   2035172 ns/op
```

With reads buffer:
```
BenchmarkCommandQueueReadWriteMix/1-8        200   7462599 ns/op
BenchmarkCommandQueueReadWriteMix/4-8        300   4375028 ns/op
BenchmarkCommandQueueReadWriteMix/16-8               500   2476118 ns/op
BenchmarkCommandQueueReadWriteMix/64-8              1000   1439204 ns/op
BenchmarkCommandQueueReadWriteMix/128-8             1000   1234747 ns/op
BenchmarkCommandQueueReadWriteMix/256-8             2000   1130114 ns/op
```