### PR TITLE
Default GOPATH to $HOMEDIR/go

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -32,6 +32,7 @@ if [ "${1-}" = "version" ]; then
   exit 0
 fi
 
+GOPATH=$(go env GOPATH)
 gopath0=${GOPATH%%:*}
 gocache=${GOCACHEPATH-$gopath0}
 


### PR DESCRIPTION
Default GOPATH to the user's home directory if unset in builder.sh to
mimic go's default behavior (https://golang.org/doc/code.html#GOPATH).

reviewer: @bdarnell 