### PR TITLE
distsql: fix outer join problems

### DIFF
--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -191,7 +191,7 @@ func TestHashJoiner(t *testing.T) {
 				LeftEqColumns:  []uint32{0},
 				RightEqColumns: []uint32{0},
 				Type:           JoinType_RIGHT_OUTER,
-				// Implicit @1 = @3 constraint.
+				// Implicit @1 = @4 constraint.
 			},
 			outCols: []uint32{3, 1, 2},
 			inputs: []sqlbase.EncDatumRows{
@@ -283,25 +283,44 @@ func TestHashJoiner(t *testing.T) {
 				LeftEqColumns:  []uint32{0},
 				RightEqColumns: []uint32{0},
 				Type:           JoinType_LEFT_OUTER,
-				OnExpr:         Expression{Expr: "@2 > 1"},
+				OnExpr:         Expression{Expr: "@3 = 9"},
 			},
 			outCols: []uint32{0, 1},
 			inputs: []sqlbase.EncDatumRows{
 				{
-					{v[0]},
-					{v[1]},
-					{v[2]},
-				},
-				{
 					{v[1]},
 					{v[2]},
 					{v[3]},
+					{v[5]},
+					{v[6]},
+					{v[7]},
+				},
+				{
+					{v[2], v[8]},
+					{v[3], v[9]},
+					{v[4], v[9]},
+
+					// Rows that match v[5].
+					{v[5], v[9]},
+					{v[5], v[9]},
+
+					// Rows that match v[6] but the ON condition fails.
+					{v[6], v[8]},
+					{v[6], v[8]},
+
+					// Rows that match v[7], ON condition fails for one.
+					{v[7], v[8]},
+					{v[7], v[9]},
 				},
 			},
 			expected: sqlbase.EncDatumRows{
-				{v[0], null},
 				{v[1], null},
-				{v[2], v[2]},
+				{v[2], null},
+				{v[3], v[3]},
+				{v[5], v[5]},
+				{v[5], v[5]},
+				{v[6], null},
+				{v[7], v[7]},
 			},
 		},
 		// Test that right outer joins work with filters as expected.

--- a/pkg/sql/distsqlrun/joinerbase.go
+++ b/pkg/sql/distsqlrun/joinerbase.go
@@ -17,6 +17,8 @@
 package distsqlrun
 
 import (
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
@@ -57,6 +59,8 @@ func (jb *joinerBase) init(
 		jb.emptyRight[i].Datum = parser.DNull
 	}
 
+	jb.combinedRow = make(sqlbase.EncDatumRow, 0, len(leftTypes)+len(rightTypes))
+
 	types := make([]sqlbase.ColumnType, 0, len(leftTypes)+len(rightTypes))
 	types = append(types, leftTypes...)
 	types = append(types, rightTypes...)
@@ -67,55 +71,56 @@ func (jb *joinerBase) init(
 	return jb.out.init(post, types, &flowCtx.evalCtx, output)
 }
 
-// render evaluates the provided on-condition and constructs a row with columns
-// from both rows as specified by the provided output columns. We expect left or
-// right to be nil if there was no explicit "join" match, the on condition is
-// then evaluated on a combinedRow with null values for the columns of the nil
-// row. render returns a nil row if no row is to be emitted (eg. if join type is
-// inner join and one of the given rows is nil). The returned boolean indicates
-// whether or not the returned row failed the on condition.
-func (jb *joinerBase) render(
-	lrow, rrow sqlbase.EncDatumRow,
-) (ret sqlbase.EncDatumRow, failedOnCond bool, err error) {
-	lnil := lrow == nil
-	rnil := rrow == nil
-	if lnil {
-		if jb.joinType == innerJoin || jb.joinType == leftOuter {
-			return nil, false, nil
-		}
-		lrow = jb.emptyLeft
-	}
-	if rnil {
-		if jb.joinType == innerJoin || jb.joinType == rightOuter {
-			return nil, false, nil
-		}
-		rrow = jb.emptyRight
-	}
-	if jb.combinedRow == nil {
-		// In the corner case where lrow, rrow are empty rows, we want a non-nil
-		// combined row (even if it is empty).
-		jb.combinedRow = make(sqlbase.EncDatumRow, len(lrow)+len(rrow))
+// renderUnmatchedRow creates a result row given an unmatched row on either
+// side. Only used for outer joins.
+func (jb *joinerBase) renderUnmatchedRow(
+	row sqlbase.EncDatumRow, leftSide bool,
+) sqlbase.EncDatumRow {
+	lrow, rrow := jb.emptyLeft, jb.emptyRight
+	if leftSide {
+		lrow = row
+	} else {
+		rrow = row
 	}
 	jb.combinedRow = append(jb.combinedRow[:0], lrow...)
 	jb.combinedRow = append(jb.combinedRow, rrow...)
-	res, err := jb.onCond.evalFilter(jb.combinedRow)
-	if err != nil {
-		return nil, false, err
-	}
-	if !res && !rnil && !lnil {
-		// The on condition failed and we're trying to render a row that's been
-		// successfully equality joined already. In this case, we need to
-		// output a failed match row that contains just the left side, if we're
-		// required to by the join style.
-		if jb.joinType == innerJoin || jb.joinType == rightOuter {
-			// If we're doing an inner or right outer join, we shouldn't return
-			// a row: we don't want to output rows with NULL right sides. We
-			// still need to notify the caller that the on condition failed,
-			// though, because they'll want to render the corresponding right
-			// side row by itself later.
-			return nil, true, nil
+	return jb.combinedRow
+}
+
+// maybeEmitUnmatchedRow is used for rows that don't match anything in the other
+// table; we emit them if it's called for given the type of join, otherwise we
+// discard them.
+//
+// Returns false if no more rows are needed (in which case the inputs and the
+// output has been properly closed).
+func (jb *joinerBase) maybeEmitUnmatchedRow(
+	ctx context.Context, row sqlbase.EncDatumRow, leftSide bool,
+) bool {
+	switch jb.joinType {
+	case innerJoin:
+		return true
+	case rightOuter:
+		if leftSide {
+			return true
 		}
-		jb.combinedRow = append(jb.combinedRow[:len(lrow)], jb.emptyRight...)
+	case leftOuter:
+		if !leftSide {
+			return true
+		}
 	}
-	return jb.combinedRow, !res, nil
+
+	renderedRow := jb.renderUnmatchedRow(row, leftSide)
+	return emitHelper(ctx, &jb.out, renderedRow, ProducerMetadata{}, jb.leftSource, jb.rightSource)
+}
+
+// render constructs a row with columns from both sides. The ON condition is
+// evaluated; if it fails, returns nil.
+func (jb *joinerBase) render(lrow, rrow sqlbase.EncDatumRow) (sqlbase.EncDatumRow, error) {
+	jb.combinedRow = append(jb.combinedRow[:0], lrow...)
+	jb.combinedRow = append(jb.combinedRow, rrow...)
+	res, err := jb.onCond.evalFilter(jb.combinedRow)
+	if !res || err != nil {
+		return nil, err
+	}
+	return jb.combinedRow, nil
 }


### PR DESCRIPTION
### distsql: minor cleanup in hashjoiner

Clarifying and simplifying the return cases of the two phases.

### distsql: fix outer join problems
I was working on the hashjoiner and noticed that we incorrectly handle outer
joins if there are multiple rows with the same value on the equality columns.
Here is an example:

```
Left       Right
----------------
1 1        1 2
           1 3
           1 4
Equality columns:   Left(1) = Right(1)
Extra ON condition: Left(2) + Right(2) = 4
```

If we are doing a left outer join, the correct output is:
```
1 1 1 3
```
The current code makes the decision to emit an "outer" result for every pair of
rows we try to render; this incorrectly results in multiple "outer" results for
the same row:
```
1 1 NULL NULL
1 1 1    3
1 1 NULL NULL
```

Moving the decision at a higher level: keep track of whether there was any
"match" for a given left row, and only output the "outer" result if there
wasn't.

A similar fix is made for merge joins. The stream merger code is changed to
return sets of left and right rows for each group, rather than returning a
group cross-product.