### PR TITLE
internal/client: separate AdminSplit span key and split key

### DIFF
--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -541,7 +541,7 @@ func presplitRanges(baseCtx context.Context, db client.DB, input []roachpb.Key) 
 		// EnsureSafeSplitKey for more context.
 		splitKey := append([]byte(nil), splitPoints[splitIdx]...)
 		splitKey = keys.MakeRowSentinelKey(splitKey)
-		if err := db.AdminSplit(ctx, splitKey); err != nil {
+		if err := db.AdminSplit(ctx, splitPoints[splitIdx], splitKey); err != nil {
 			return err
 		}
 

--- a/pkg/cli/range.go
+++ b/pkg/cli/range.go
@@ -118,7 +118,7 @@ func runSplitRange(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer stopper.Stop(stopperContext(stopper))
-	return errors.Wrap(kvDB.AdminSplit(context.Background(), key), "split failed")
+	return errors.Wrap(kvDB.AdminSplit(context.Background(), key, key), "split failed")
 }
 
 var rangeCmds = []*cobra.Command{

--- a/pkg/cmd/internal/localcluster/localcluster.go
+++ b/pkg/cmd/internal/localcluster/localcluster.go
@@ -297,7 +297,7 @@ func (c *Cluster) UpdateZoneConfig(rangeMinBytes, rangeMaxBytes int64) {
 
 // Split splits the range containing the split key at the specified split key.
 func (c *Cluster) Split(nodeIdx int, splitKey roachpb.Key) error {
-	return c.Clients[nodeIdx].AdminSplit(context.Background(), splitKey)
+	return c.Clients[nodeIdx].AdminSplit(context.Background(), splitKey, splitKey)
 }
 
 // TransferLease transfers the lease for the range containing key to a random

--- a/pkg/internal/client/batch.go
+++ b/pkg/internal/client/batch.go
@@ -577,18 +577,23 @@ func (b *Batch) adminMerge(key interface{}) {
 
 // adminSplit is only exported on DB. It is here for symmetry with the
 // other operations.
-func (b *Batch) adminSplit(splitKey interface{}) {
-	k, err := marshalKey(splitKey)
+func (b *Batch) adminSplit(spanKeyIn, splitKeyIn interface{}) {
+	spanKey, err := marshalKey(spanKeyIn)
+	if err != nil {
+		b.initResult(0, 0, notRaw, err)
+		return
+	}
+	splitKey, err := marshalKey(splitKeyIn)
 	if err != nil {
 		b.initResult(0, 0, notRaw, err)
 		return
 	}
 	req := &roachpb.AdminSplitRequest{
 		Span: roachpb.Span{
-			Key: k,
+			Key: spanKey,
 		},
 	}
-	req.SplitKey = k
+	req.SplitKey = splitKey
 	b.appendReqs(req)
 	b.initResult(1, 0, notRaw, nil)
 }

--- a/pkg/internal/client/db.go
+++ b/pkg/internal/client/db.go
@@ -366,10 +366,18 @@ func (db *DB) AdminMerge(ctx context.Context, key interface{}) error {
 
 // AdminSplit splits the range at splitkey.
 //
-// key can be either a byte slice or a string.
-func (db *DB) AdminSplit(ctx context.Context, splitKey interface{}) error {
+// spanKey is a key within the range that should be split, and splitKey is the
+// key at which that range should be split. splitKey is not used exactly as
+// provided--it is first mutated by keys.EnsureSafeSplitKey. Accounting for
+// this mutation sometimes requires constructing a key that falls in a
+// different range, hence the separation between spanKey and splitKey. See
+// #16008 for details, and #16344 for the tracking issue to clean this mess up
+// properly.
+//
+// keys can be either a byte slice or a string.
+func (db *DB) AdminSplit(ctx context.Context, spanKey, splitKey interface{}) error {
 	b := &Batch{}
-	b.adminSplit(splitKey)
+	b.adminSplit(spanKey, splitKey)
 	return getOneErr(db.Run(ctx, b), b)
 }
 

--- a/pkg/kv/dist_sender_server_test.go
+++ b/pkg/kv/dist_sender_server_test.go
@@ -90,7 +90,7 @@ func setupMultipleRanges(
 
 	// Split the keyspace at the given keys.
 	for _, key := range splitAt {
-		if err := db.AdminSplit(context.TODO(), key); err != nil {
+		if err := db.AdminSplit(context.TODO(), key, key); err != nil {
 			// Don't leak server goroutines.
 			t.Fatal(err)
 		}
@@ -807,7 +807,7 @@ func TestParallelSender(t *testing.T) {
 	// Split into multiple ranges.
 	splitKeys := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}
 	for _, key := range splitKeys {
-		if err := db.AdminSplit(context.TODO(), key); err != nil {
+		if err := db.AdminSplit(context.TODO(), key, key); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -849,7 +849,7 @@ func initReverseScanTestEnv(s serverutils.TestServerInterface, t *testing.T) *cl
 	// ["", "b"),["b", "e") ,["e", "g") and ["g", "\xff\xff").
 	for _, key := range []string{"b", "e", "g"} {
 		// Split the keyspace at the given key.
-		if err := db.AdminSplit(context.TODO(), key); err != nil {
+		if err := db.AdminSplit(context.TODO(), key, key); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -949,7 +949,7 @@ func TestBatchPutWithConcurrentSplit(t *testing.T) {
 	// Split first using the default client and scan to make sure that
 	// the range descriptor cache reflects the split.
 	for _, key := range []string{"b", "f"} {
-		if err := db.AdminSplit(context.TODO(), key); err != nil {
+		if err := db.AdminSplit(context.TODO(), key, key); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -998,7 +998,7 @@ func TestReverseScanWithSplitAndMerge(t *testing.T) {
 
 	// Case 1: An encounter with a range split.
 	// Split the range ["b", "e") at "c".
-	if err := db.AdminSplit(context.TODO(), "c"); err != nil {
+	if err := db.AdminSplit(context.TODO(), "c", "c"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/kv/split_test.go
+++ b/pkg/kv/split_test.go
@@ -111,9 +111,10 @@ func TestRangeSplitMeta(t *testing.T) {
 		mustMeta(roachpb.RKey("K")), mustMeta(roachpb.RKey("H"))}
 
 	// Execute the consecutive splits.
-	for _, splitKey := range splitKeys {
+	for _, splitRKey := range splitKeys {
+		splitKey := roachpb.Key(splitRKey)
 		log.Infof(ctx, "starting split at key %q...", splitKey)
-		if err := s.DB.AdminSplit(ctx, roachpb.Key(splitKey)); err != nil {
+		if err := s.DB.AdminSplit(ctx, splitKey, splitKey); err != nil {
 			t.Fatal(err)
 		}
 		log.Infof(ctx, "split at key %q complete", splitKey)
@@ -159,7 +160,7 @@ func TestRangeSplitsWithConcurrentTxns(t *testing.T) {
 			<-txnChannel
 		}
 		log.Infof(ctx, "starting split at key %q...", splitKey)
-		if pErr := s.DB.AdminSplit(context.TODO(), splitKey); pErr != nil {
+		if pErr := s.DB.AdminSplit(context.TODO(), splitKey, splitKey); pErr != nil {
 			t.Error(pErr)
 		}
 		log.Infof(ctx, "split at key %q complete", splitKey)
@@ -246,11 +247,11 @@ func TestRangeSplitsWithSameKeyTwice(t *testing.T) {
 
 	splitKey := roachpb.Key("aa")
 	log.Infof(ctx, "starting split at key %q...", splitKey)
-	if err := s.DB.AdminSplit(ctx, splitKey); err != nil {
+	if err := s.DB.AdminSplit(ctx, splitKey, splitKey); err != nil {
 		t.Fatal(err)
 	}
 	log.Infof(ctx, "split at key %q first time complete", splitKey)
-	if err := s.DB.AdminSplit(ctx, splitKey); err != nil {
+	if err := s.DB.AdminSplit(ctx, splitKey, splitKey); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -674,7 +674,7 @@ func TestTxnRepeatGetWithRangeSplit(t *testing.T) {
 		}
 		s.Manual.Increment(time.Second.Nanoseconds())
 		// Split range by keyB.
-		if err := s.DB.AdminSplit(context.TODO(), splitKey); err != nil {
+		if err := s.DB.AdminSplit(context.TODO(), splitKey, splitKey); err != nil {
 			t.Fatal(err)
 		}
 		// Wait till split complete.

--- a/pkg/server/intent_test.go
+++ b/pkg/server/intent_test.go
@@ -119,7 +119,7 @@ func TestIntentResolution(t *testing.T) {
 				Knobs: base.TestingKnobs{Store: &storeKnobs}})
 			defer s.Stopper().Stop(context.TODO())
 			// Split the Range. This should not have any asynchronous intents.
-			if err := kvDB.AdminSplit(context.TODO(), splitKey); err != nil {
+			if err := kvDB.AdminSplit(context.TODO(), splitKey, splitKey); err != nil {
 				t.Fatal(err)
 			}
 

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -653,7 +653,7 @@ func TestStatusSummaries(t *testing.T) {
 	// ========================================
 
 	// Split the range.
-	if err := ts.db.AdminSplit(context.TODO(), splitKey); err != nil {
+	if err := ts.db.AdminSplit(context.TODO(), splitKey, splitKey); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -237,7 +237,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	ts := s.(*TestServer)
 	tds := db.GetSender()
 
-	if err := ts.node.storeCfg.DB.AdminSplit(context.TODO(), "m"); err != nil {
+	if err := ts.node.storeCfg.DB.AdminSplit(context.TODO(), "m", "m"); err != nil {
 		t.Fatal(err)
 	}
 	writes := []roachpb.Key{roachpb.Key("a"), roachpb.Key("z")}
@@ -326,7 +326,7 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 		tds := db.GetSender()
 
 		for _, sk := range tc.splitKeys {
-			if err := ts.node.storeCfg.DB.AdminSplit(context.TODO(), sk); err != nil {
+			if err := ts.node.storeCfg.DB.AdminSplit(context.TODO(), sk, sk); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/pkg/sql/split_at.go
+++ b/pkg/sql/split_at.go
@@ -124,7 +124,7 @@ func (n *splitNode) Next(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
-	if err := n.p.session.execCfg.DB.AdminSplit(ctx, rowKey); err != nil {
+	if err := n.p.session.execCfg.DB.AdminSplit(ctx, rowKey, rowKey); err != nil {
 		return false, err
 	}
 
@@ -308,6 +308,7 @@ func (n *relocateNode) Next(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	rowKey = keys.MakeRowSentinelKey(rowKey)
 
 	rangeDesc, err := lookupRangeDescriptor(ctx, n.p.session.execCfg.DB, rowKey)
 	if err != nil {

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -375,7 +375,7 @@ func TestStoreRangeSplitConcurrent(t *testing.T) {
 			// The only expected error from concurrent splits is the split key being
 			// outside the bounds for the range. Note that conflicting range
 			// descriptor errors are retried internally.
-			if !testutils.IsError(pErr.GoError(), "key range .* outside of bounds of range") {
+			if !testutils.IsError(pErr.GoError(), "requested split key .* out of bounds of") {
 				t.Fatalf("unexpected error: %v", pErr)
 			}
 			failureCount++
@@ -1860,6 +1860,9 @@ func TestStoreRangeGossipOnSplits(t *testing.T) {
 		_, pErr := store.LookupReplica(roachpb.RKey(splitKey), nil).AdminSplit(
 			context.TODO(),
 			roachpb.AdminSplitRequest{
+				Span: roachpb.Span{
+					Key: splitKey,
+				},
 				SplitKey: splitKey,
 			},
 		)

--- a/pkg/storage/log_test.go
+++ b/pkg/storage/log_test.go
@@ -65,7 +65,7 @@ func TestLogSplits(t *testing.T) {
 	}
 
 	// Generate an explicit split event.
-	if err := kvDB.AdminSplit(context.TODO(), "splitkey"); err != nil {
+	if err := kvDB.AdminSplit(context.TODO(), "splitkey", "splitkey"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -2628,12 +2628,12 @@ func (r *Replica) adminSplitWithDescriptor(
 				return reply, false, nil
 			}
 		} else {
-			// Split at requested key. If it's out of this range's bounds,
-			// return an error for the client to try again on the correct
-			// range.
-			if !containsKey(*desc, args.SplitKey) {
+			// If the key that routed this request to this range is now out of this
+			// range's bounds, return an error for the client to try again on the
+			// correct range.
+			if !containsKey(*desc, args.Span.Key) {
 				return reply, false,
-					roachpb.NewError(roachpb.NewRangeKeyMismatchError(args.SplitKey, args.SplitKey, desc))
+					roachpb.NewError(roachpb.NewRangeKeyMismatchError(args.Span.Key, args.Span.Key, desc))
 			}
 			foundSplitKey = args.SplitKey
 		}

--- a/pkg/storage/split_queue.go
+++ b/pkg/storage/split_queue.go
@@ -92,6 +92,9 @@ func (sq *splitQueue) process(ctx context.Context, r *Replica, sysCfg config.Sys
 		if _, _, pErr := r.adminSplitWithDescriptor(
 			ctx,
 			roachpb.AdminSplitRequest{
+				Span: roachpb.Span{
+					Key: splitKey.AsRawKey(),
+				},
 				SplitKey: splitKey.AsRawKey(),
 			},
 			desc,

--- a/pkg/storage/ts_maintenance_queue_test.go
+++ b/pkg/storage/ts_maintenance_queue_test.go
@@ -271,7 +271,7 @@ func TestTimeSeriesMaintenanceQueueServer(t *testing.T) {
 
 	// Force a range split in between near past and far past. This guarantees
 	// that the pruning operation will issue a DeleteRange which spans ranges.
-	if err := db.AdminSplit(context.TODO(), splitKey); err != nil {
+	if err := db.AdminSplit(context.TODO(), splitKey, splitKey); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
This is a quick fix for #16008; #16344 is tracking the longer-term fix.

In short, `AdminSplit` does not actually split at the requested key, but rather runs the key through `keys.EnsureSafeSplitKey` first. This means that whoever calls `AdminSplit` with a table key needs to adjust the split key to account for `EnsureSafeSplitKey`'s modification by running the key through `keys.MakeRowSentinelKey`. When using row keys like `/Table/51/` or `/Table/51/1`, this is perfectly safe. In RESTORE, though, we call `MakeRowSentinelKey` on longer keys, like `/Table/51/1/0`. This can create a key in a *different* range (see #16008 for details), so the request gets routed to the wrong range even though `EnsureSafeSplitKey` would have selected the right key had the request been routed to the right range.

This commit solves the issue by adjusting `AdminSplit` to take both a "span key" and a "split key". The span key is used to route the request to the right range, while the split key contains the `MakeRowSentinelKey` modifications that will be undone by `MakeRowSentinelKey` on the receiver.

---

It's unfortunate this causes so much fallout in our tests, but wanted to get this first attempt out for review. Another option would be to set the span key to `keys.EnsureSafeSplitKey(splitKey)`  in the client-side `AdminSplit` function, but that felt like layering yet another hack onto this already messy system.

Any suggestions on writing a targeted test for this? I'll run a restore on Lapis before merging at the very least.