### PR TITLE
internal/rsg/yacc: more lenient parser

### DIFF
--- a/pkg/internal/rsg/yacc/parse.go
+++ b/pkg/internal/rsg/yacc/parse.go
@@ -137,7 +137,9 @@ func (t *Tree) parse() {
 func (t *Tree) parseProduction(p *ProductionNode) {
 	const context = "production"
 	t.expect(itemColon, context)
-	t.expect(itemNL, context)
+	if t.peek().typ == itemNL {
+		t.next()
+	}
 	expectExpr := true
 	for {
 		token := t.next()
@@ -177,7 +179,9 @@ func (t *Tree) parseExpression(e *ExpressionNode) {
 			e.Items = append(e.Items, Item{token.val, TypLiteral})
 		case itemExpr:
 			e.Command = token.val
-			t.expect(itemNL, context)
+			if t.peek().typ == itemNL {
+				t.next()
+			}
 			return
 		case itemPct, itemComment:
 			// ignore

--- a/pkg/internal/rsg/yacc/parse_test.go
+++ b/pkg/internal/rsg/yacc/parse_test.go
@@ -24,13 +24,9 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
-// TODO(mjibson): unskip these tests when we move to TeamCity (they fail on CircleCI)
-
 const sqlYPath = "../../../sql/parser/sql.y"
 
 func TestLex(t *testing.T) {
-	t.Skip("broken on CircleCI")
-
 	b, err := ioutil.ReadFile(sqlYPath)
 	if err != nil {
 		t.Fatal(err)
@@ -49,8 +45,6 @@ Loop:
 }
 
 func TestParse(t *testing.T) {
-	t.Skip("broken on CircleCI")
-
 	b, err := ioutil.ReadFile(sqlYPath)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This allows one line productions, which previously caused errors. It's
still not perfect (it shouldn't care about newlines) but it's good
enough for now.

Re-enable the tests since we've long since moved to teamcity. This
should prevent merges that break parsing of this in the future.

Fixes recent RSG and docs failures.