### PR TITLE
build: fix broken COCKROACH variable used as target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ endif
 
 XGO := $(strip $(if $(XGOOS),GOOS=$(XGOOS)) $(if $(XGOARCH),GOARCH=$(XGOARCH)) $(if $(XHOST_TRIPLE),CC=$(CC_PATH) CXX=$(CXX_PATH)) $(GO))
 
-COCKROACH := ./cockroach$(SUFFIX)$$($(XGO) env GOEXE)
+COCKROACH := ./cockroach$(SUFFIX)$(shell $(XGO) env GOEXE)
 
 .DEFAULT_GOAL := all
 all: $(COCKROACH)


### PR DESCRIPTION
This variable's definition includes a shell command substitution `$$(...)`, but it's now used in contexts that don't get run through the shell, like target definitions. This commit changes the variable definition to instead use Make's shell function (`$(shell ...)`) , which is supported in all contexts.

This means Make will run `go env GOEXE` on every invocation--even ones that don't need it--but at least it's correct.