### PR TITLE
stop: add task names to Stopper tasks

### DIFF
--- a/pkg/acceptance/partition_test.go
+++ b/pkg/acceptance/partition_test.go
@@ -200,7 +200,7 @@ func runTransactionsAndNemeses(
 	}
 	for i := 0; i < concurrency; i++ {
 		localI := i
-		if err := stopper.RunAsyncTask(ctx, func(_ context.Context) {
+		if err := stopper.RunAsyncTask(ctx, "test", func(_ context.Context) {
 			for timeutil.Now().Before(deadline) {
 				select {
 				case <-stopper.ShouldQuiesce():

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -611,7 +611,7 @@ func setupAndInitializeLoggingAndProfiling(startCtx context.Context) (*stop.Stop
 	// Disable Stopper task tracking as performing that call site tracking is
 	// moderately expensive (certainly outweighing the infrequent benefit it
 	// provides).
-	stopper := initBacktrace(outputDirectory, stop.TrackTasks(false))
+	stopper := initBacktrace(outputDirectory)
 	log.Event(startCtx, "initialized profiles")
 
 	return stopper, nil

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1024,7 +1024,7 @@ func (g *Gossip) bootstrap() {
 		var bootstrapTimer timeutil.Timer
 		defer bootstrapTimer.Stop()
 		for {
-			if g.server.stopper.RunTask(ctx, func(ctx context.Context) {
+			if g.server.stopper.RunTask(ctx, "gossip.Gossip: bootstrap ", func(ctx context.Context) {
 				g.mu.Lock()
 				defer g.mu.Unlock()
 				haveClients := g.outgoing.len() > 0

--- a/pkg/gossip/server.go
+++ b/pkg/gossip/server.go
@@ -158,7 +158,7 @@ func (s *server) Gossip(stream Gossip_GossipServer) error {
 	errCh := make(chan error, 1)
 
 	// Starting workers in a task prevents data races during shutdown.
-	if err := s.stopper.RunTask(ctx, func(ctx context.Context) {
+	if err := s.stopper.RunTask(ctx, "gossip.server: receiver", func(ctx context.Context) {
 		s.stopper.RunWorker(ctx, func(ctx context.Context) {
 			errCh <- s.gossipReceiver(ctx, &args, send, stream.Recv)
 		})

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -111,7 +111,7 @@ func (s *DBServer) Batch(
 	}
 
 	taskCtx := context.TODO()
-	err = s.stopper.RunTask(taskCtx, func(taskCtx context.Context) {
+	err = s.stopper.RunTask(taskCtx, "kv.DBServer: batch", func(taskCtx context.Context) {
 		var pErr *roachpb.Error
 		// TODO(wiz): This is required to be a different context from the one
 		// provided by grpc since it has to last for the entire transaction and not

--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -866,7 +866,9 @@ func (ds *DistSender) sendPartialBatchAsync(
 	responseCh chan response,
 ) bool {
 	if err := ds.rpcContext.Stopper.RunLimitedAsyncTask(
-		ctx, ds.asyncSenderSem, false /* !wait */, func(ctx context.Context) {
+		ctx, "kv.DistSEnder: sending partial batch",
+		ds.asyncSenderSem, false, /* !wait */
+		func(ctx context.Context) {
 			atomic.AddInt32(&ds.asyncSenderCount, 1)
 			responseCh <- ds.sendPartialBatch(ctx, ba, rs, desc, evictToken, batchIdx)
 		},

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -708,7 +708,7 @@ func (tc *TxnCoordSender) tryAsyncAbort(txnID uuid.UUID) {
 	// NB: use context.Background() here because we may be called when the
 	// caller's context has been cancelled.
 	ctx := tc.AnnotateCtx(context.Background())
-	if err := tc.stopper.RunAsyncTask(ctx, func(ctx context.Context) {
+	if err := tc.stopper.RunAsyncTask(ctx, "kv.TxnCoordSender: aborting txn", func(ctx context.Context) {
 		// Use the wrapped sender since the normal Sender does not allow
 		// clients to specify intents.
 		if _, pErr := tc.wrapped.Send(ctx, ba); pErr != nil {
@@ -943,9 +943,10 @@ func (tc *TxnCoordSender) updateState(
 				}
 				tc.txnMu.txns[txnID] = txnMeta
 
-				if err := tc.stopper.RunAsyncTask(ctx, func(ctx context.Context) {
-					tc.heartbeatLoop(ctx, txnID)
-				}); err != nil {
+				if err := tc.stopper.RunAsyncTask(
+					ctx, "kv.TxnCoordSender: heartbeat loop", func(ctx context.Context) {
+						tc.heartbeatLoop(ctx, txnID)
+					}); err != nil {
 					// The system is already draining and we can't start the
 					// heartbeat. We refuse new transactions for now because
 					// they're likely not going to have all intents committed.

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -316,15 +316,16 @@ func (ctx *Context) GRPCDial(target string, opts ...grpc.DialOption) (*grpc.Clie
 		}
 		meta.conn, meta.dialErr = grpc.DialContext(ctx.masterCtx, target, dialOpts...)
 		if meta.dialErr == nil {
-			if err := ctx.Stopper.RunTask(ctx.masterCtx, func(masterCtx context.Context) {
-				ctx.Stopper.RunWorker(masterCtx, func(masterCtx context.Context) {
-					err := ctx.runHeartbeat(meta, target)
-					if err != nil && !grpcutil.IsClosedConnection(err) {
-						log.Errorf(masterCtx, "removing connection to %s due to error: %s", target, err)
-					}
-					ctx.removeConn(target, meta)
-				})
-			}); err != nil {
+			if err := ctx.Stopper.RunTask(
+				ctx.masterCtx, "rpc.Context: grpc heartbeat", func(masterCtx context.Context) {
+					ctx.Stopper.RunWorker(masterCtx, func(masterCtx context.Context) {
+						err := ctx.runHeartbeat(meta, target)
+						if err != nil && !grpcutil.IsClosedConnection(err) {
+							log.Errorf(masterCtx, "removing connection to %s due to error: %s", target, err)
+						}
+						ctx.removeConn(target, meta)
+					})
+				}); err != nil {
 				meta.dialErr = err
 				// removeConn and ctx's cleanup worker both lock ctx.conns. However,
 				// to avoid racing with meta's initialization, the cleanup worker

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -598,30 +598,32 @@ func (s *adminServer) TableStats(
 	defer cancel()
 	for nodeID := range nodeIDs {
 		nodeID := nodeID
-		if err := s.server.stopper.RunAsyncTask(nodeCtx, func(ctx context.Context) {
-			var spanResponse *serverpb.SpanStatsResponse
-			client, err := s.server.status.dialNode(nodeID)
-			if err == nil {
-				req := serverpb.SpanStatsRequest{
-					StartKey: startKey,
-					EndKey:   endKey,
-					NodeID:   nodeID.String(),
+		if err := s.server.stopper.RunAsyncTask(
+			nodeCtx, "server.adminServer: requesting remote stats",
+			func(ctx context.Context) {
+				var spanResponse *serverpb.SpanStatsResponse
+				client, err := s.server.status.dialNode(nodeID)
+				if err == nil {
+					req := serverpb.SpanStatsRequest{
+						StartKey: startKey,
+						EndKey:   endKey,
+						NodeID:   nodeID.String(),
+					}
+					spanResponse, err = client.SpanStats(ctx, &req)
 				}
-				spanResponse, err = client.SpanStats(ctx, &req)
-			}
 
-			response := nodeResponse{
-				nodeID: nodeID,
-				resp:   spanResponse,
-				err:    err,
-			}
-			select {
-			case responses <- response:
-				// Response processed.
-			case <-ctx.Done():
-				// Context completed, response no longer needed.
-			}
-		}); err != nil {
+				response := nodeResponse{
+					nodeID: nodeID,
+					resp:   spanResponse,
+					err:    err,
+				}
+				select {
+				case responses <- response:
+					// Response processed.
+				case <-ctx.Done():
+					// Context completed, response no longer needed.
+				}
+			}); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/server/debug_range.go
+++ b/pkg/server/debug_range.go
@@ -153,28 +153,30 @@ func (s *statusServer) handleDebugRange(w http.ResponseWriter, r *http.Request) 
 			continue
 		}
 		nodeID := nodeID
-		if err := s.stopper.RunAsyncTask(nodeCtx, func(ctx context.Context) {
-			status, err := s.dialNode(nodeID)
-			var rangesResponse *serverpb.RangesResponse
-			if err == nil {
-				req := &serverpb.RangesRequest{
-					RangeIDs: []roachpb.RangeID{roachpb.RangeID(rangeID)},
+		if err := s.stopper.RunAsyncTask(
+			nodeCtx, "server.statusServer: requesting remote ranges",
+			func(ctx context.Context) {
+				status, err := s.dialNode(nodeID)
+				var rangesResponse *serverpb.RangesResponse
+				if err == nil {
+					req := &serverpb.RangesRequest{
+						RangeIDs: []roachpb.RangeID{roachpb.RangeID(rangeID)},
+					}
+					rangesResponse, err = status.Ranges(ctx, req)
 				}
-				rangesResponse, err = status.Ranges(ctx, req)
-			}
-			response := nodeResponse{
-				nodeID: nodeID,
-				resp:   rangesResponse,
-				err:    err,
-			}
+				response := nodeResponse{
+					nodeID: nodeID,
+					resp:   rangesResponse,
+					err:    err,
+				}
 
-			select {
-			case responses <- response:
-				// Response processed.
-			case <-ctx.Done():
-				// Context completed, response no longer needed.
-			}
-		}); err != nil {
+				select {
+				case responses <- response:
+					// Response processed.
+				case <-ctx.Done():
+					// Context completed, response no longer needed.
+				}
+			}); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -522,7 +522,7 @@ func (n *Node) initStores(
 
 	// Bootstrap any uninitialized stores asynchronously.
 	if len(bootstraps) > 0 {
-		if err := stopper.RunAsyncTask(ctx, func(ctx context.Context) {
+		if err := stopper.RunAsyncTask(ctx, "node.Node: bootstrapping stores", func(ctx context.Context) {
 			n.bootstrapStores(ctx, bootstraps, stopper)
 		}); err != nil {
 			return err
@@ -753,7 +753,7 @@ func (n *Node) startWriteSummaries(frequency time.Duration) {
 // NodeStatusRecorder and persists them to the cockroach data store.
 func (n *Node) writeSummaries(ctx context.Context) error {
 	var err error
-	if runErr := n.stopper.RunTask(ctx, func(ctx context.Context) {
+	if runErr := n.stopper.RunTask(ctx, "node.Node: writing summary", func(ctx context.Context) {
 		err = n.recorder.WriteStatusSummary(ctx, n.storeCfg.DB)
 	}); runErr != nil {
 		err = runErr
@@ -828,7 +828,7 @@ func (n *Node) batchInternal(
 
 	var br *roachpb.BatchResponse
 
-	if err := n.stopper.RunTaskWithErr(ctx, func(ctx context.Context) error {
+	if err := n.stopper.RunTaskWithErr(ctx, "node.Node: batch", func(ctx context.Context) error {
 		var finishSpan func(*roachpb.BatchResponse)
 		// Shadow ctx from the outer function. Written like this to pass the linter.
 		ctx, finishSpan = n.setupSpanForIncomingRPC(ctx)

--- a/pkg/server/problem_ranges.go
+++ b/pkg/server/problem_ranges.go
@@ -73,26 +73,28 @@ func (s *statusServer) ProblemRanges(
 			continue
 		}
 		nodeID := nodeID
-		if err := s.stopper.RunAsyncTask(nodeCtx, func(ctx context.Context) {
-			status, err := s.dialNode(nodeID)
-			var rangesResponse *serverpb.RangesResponse
-			if err == nil {
-				req := &serverpb.RangesRequest{}
-				rangesResponse, err = status.Ranges(ctx, req)
-			}
-			response := nodeResponse{
-				nodeID: nodeID,
-				resp:   rangesResponse,
-				err:    err,
-			}
+		if err := s.stopper.RunAsyncTask(
+			nodeCtx, "server.statusServer: requesting remote ranges",
+			func(ctx context.Context) {
+				status, err := s.dialNode(nodeID)
+				var rangesResponse *serverpb.RangesResponse
+				if err == nil {
+					req := &serverpb.RangesRequest{}
+					rangesResponse, err = status.Ranges(ctx, req)
+				}
+				response := nodeResponse{
+					nodeID: nodeID,
+					resp:   rangesResponse,
+					err:    err,
+				}
 
-			select {
-			case responses <- response:
-				// Response processed.
-			case <-ctx.Done():
-				// Context completed, response no longer needed.
-			}
-		}); err != nil {
+				select {
+				case responses <- response:
+					// Response processed.
+				case <-ctx.Done():
+					// Context completed, response no longer needed.
+				}
+			}); err != nil {
 			return nil, grpc.Errorf(codes.Internal, err.Error())
 		}
 	}

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -876,8 +876,9 @@ func (s *statusServer) ListSessions(
 		getNodeSessionsTask := func(ctx context.Context) {
 			getNodeSessions(ctx, nodeID)
 		}
-		err := s.stopper.RunLimitedAsyncTask(ctx, sem, true /* wait */, getNodeSessionsTask)
-		if err != nil {
+		if err := s.stopper.RunLimitedAsyncTask(
+			ctx, "server.statusServe: requesting remote sessions", sem, true /* wait */, getNodeSessionsTask,
+		); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/sql/distsqlrun/flow_scheduler.go
+++ b/pkg/sql/distsqlrun/flow_scheduler.go
@@ -83,7 +83,7 @@ func (fs *flowScheduler) runFlowNow(ctx context.Context, f *Flow) {
 // ScheduleFlow is the main interface of the flow scheduler: it runs or enqueues
 // the given flow.
 func (fs *flowScheduler) ScheduleFlow(ctx context.Context, f *Flow) error {
-	return fs.stopper.RunTask(ctx, func(ctx context.Context) {
+	return fs.stopper.RunTask(ctx, "distsqlrun.flowScheduler: scheduling flow", func(ctx context.Context) {
 		fs.mu.Lock()
 		defer fs.mu.Unlock()
 

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -244,7 +244,7 @@ func (ds *ServerImpl) RunSyncFlow(stream DistSQL_RunSyncFlowServer) error {
 	}
 	mbox.setFlowCtx(&f.FlowCtx)
 
-	if err := ds.Stopper.RunTask(ctx, func(ctx context.Context) {
+	if err := ds.Stopper.RunTask(ctx, "distsqlrun.ServerImpl: sync flow", func(ctx context.Context) {
 		f.waitGroup.Add(1)
 		mbox.start(ctx, &f.waitGroup)
 		f.Start(ctx, func() {})

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -774,9 +774,11 @@ func (t *tableState) removeLease(lease *LeaseState, m *LeaseManager) {
 	}
 
 	// Release to the store asynchronously, without the tableState lock.
-	if err := t.stopper.RunAsyncTask(ctx, func(ctx context.Context) {
-		m.LeaseStore.Release(ctx, t.stopper, lease)
-	}); err != nil {
+	if err := t.stopper.RunAsyncTask(
+		ctx, "sql.tableState: releasing descriptor lease",
+		func(ctx context.Context) {
+			m.LeaseStore.Release(ctx, t.stopper, lease)
+		}); err != nil {
 		log.Warningf(ctx, "error: %s, not releasing lease: %q", err, lease)
 	}
 }

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -470,7 +470,7 @@ func (t *multiTestContextKVTransport) SendNext(ctx context.Context, done chan<- 
 	t.mtc.mu.RLock()
 	s := t.mtc.stoppers[nodeIndex]
 	t.mtc.mu.RUnlock()
-	if s == nil || s.RunAsyncTask(ctx, func(ctx context.Context) {
+	if s == nil || s.RunAsyncTask(ctx, "storage.multiTestContextKVTransport: calling next replica", func(ctx context.Context) {
 		t.mtc.mu.RLock()
 		sender := t.mtc.senders[nodeIndex]
 		t.mtc.mu.RUnlock()

--- a/pkg/storage/id_alloc.go
+++ b/pkg/storage/id_alloc.go
@@ -103,7 +103,7 @@ func (ia *idAllocator) start() {
 				var res client.KeyValue
 				for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
 					idKey := ia.idKey.Load().(roachpb.Key)
-					if err := ia.stopper.RunTask(ctx, func(ctx context.Context) {
+					if err := ia.stopper.RunTask(ctx, "storage.idAllocator: allocating block", func(ctx context.Context) {
 						res, err = ia.db.Inc(ctx, idKey, int64(ia.blockSize))
 					}); err != nil {
 						log.Warning(ctx, err)

--- a/pkg/storage/intent_resolver.go
+++ b/pkg/storage/intent_resolver.go
@@ -254,7 +254,8 @@ func (ir *intentResolver) processIntentsAsync(r *Replica, intents []intentsWithA
 
 	for _, item := range intents {
 		err := stopper.RunLimitedAsyncTask(
-			ctx, ir.sem, false /* wait */, func(ctx context.Context) {
+			ctx, "storage.intentResolver: processing intents", ir.sem, false, /* wait */
+			func(ctx context.Context) {
 				ir.processIntents(ctx, r, item, now)
 			})
 		if err != nil {
@@ -431,7 +432,8 @@ func (ir *intentResolver) resolveIntents(
 			return ir.store.DB().Run(ctx, b)
 		}
 		if wait || ir.store.Stopper().RunLimitedAsyncTask(
-			ctx, ir.sem, true /* wait */, func(ctx context.Context) {
+			ctx, "storage.intentResolve: resolving intents", ir.sem, true, /* wait */
+			func(ctx context.Context) {
 				if err := action(); err != nil {
 					log.Warningf(ctx, "unable to resolve external intents: %s", err)
 				}

--- a/pkg/storage/push_txn_queue.go
+++ b/pkg/storage/push_txn_queue.go
@@ -643,53 +643,55 @@ func (ptq *pushTxnQueue) startQueryPusherTxn(
 	pusher := push.req.PusherTxn.Clone()
 	push.mu.Unlock()
 
-	if err := ptq.store.Stopper().RunAsyncTask(ctx, func(ctx context.Context) {
-		// We use a backoff/retry here in case the pusher transaction
-		// doesn't yet exist.
-		for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
-			var pErr *roachpb.Error
-			var updatedPusher *roachpb.Transaction
-			updatedPusher, waitingTxns, pErr = ptq.queryTxnStatus(
-				ctx, pusher.TxnMeta, true, waitingTxns, ptq.store.Clock().Now(),
-			)
-			if pErr != nil {
-				errCh <- pErr
-				return
-			} else if updatedPusher == nil {
-				// No pusher to query; the BeginTransaction hasn't yet created the
-				// pusher's record. Continue in order to backoff and retry.
-				continue
-			}
+	if err := ptq.store.Stopper().RunAsyncTask(
+		ctx, "storage.pushTxnQueue: monitoring pusher txn",
+		func(ctx context.Context) {
+			// We use a backoff/retry here in case the pusher transaction
+			// doesn't yet exist.
+			for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
+				var pErr *roachpb.Error
+				var updatedPusher *roachpb.Transaction
+				updatedPusher, waitingTxns, pErr = ptq.queryTxnStatus(
+					ctx, pusher.TxnMeta, true, waitingTxns, ptq.store.Clock().Now(),
+				)
+				if pErr != nil {
+					errCh <- pErr
+					return
+				} else if updatedPusher == nil {
+					// No pusher to query; the BeginTransaction hasn't yet created the
+					// pusher's record. Continue in order to backoff and retry.
+					continue
+				}
 
-			// Update the pending pusher's set of dependents. These accumulate
-			// and are used to propagate the transitive set of dependencies for
-			// distributed deadlock detection.
-			push.mu.Lock()
-			if push.mu.dependents == nil {
-				push.mu.dependents = map[uuid.UUID]struct{}{}
-			}
-			for _, txnID := range waitingTxns {
-				push.mu.dependents[txnID] = struct{}{}
-			}
-			push.mu.Unlock()
+				// Update the pending pusher's set of dependents. These accumulate
+				// and are used to propagate the transitive set of dependencies for
+				// distributed deadlock detection.
+				push.mu.Lock()
+				if push.mu.dependents == nil {
+					push.mu.dependents = map[uuid.UUID]struct{}{}
+				}
+				for _, txnID := range waitingTxns {
+					push.mu.dependents[txnID] = struct{}{}
+				}
+				push.mu.Unlock()
 
-			// Send an update of the pusher txn.
-			pusher.Update(updatedPusher)
-			ch <- &pusher
+				// Send an update of the pusher txn.
+				pusher.Update(updatedPusher)
+				ch <- &pusher
 
-			// Wait for context cancellation or indication on readyCh that the
-			// push waiter requires another query of the pusher txn.
-			select {
-			case <-ctx.Done():
-				errCh <- roachpb.NewError(ctx.Err())
-				return
-			case <-readyCh:
+				// Wait for context cancellation or indication on readyCh that the
+				// push waiter requires another query of the pusher txn.
+				select {
+				case <-ctx.Done():
+					errCh <- roachpb.NewError(ctx.Err())
+					return
+				case <-readyCh:
+				}
+				// Reset the retry to query again immediately.
+				r.Reset()
 			}
-			// Reset the retry to query again immediately.
-			r.Reset()
-		}
-		errCh <- roachpb.NewError(ctx.Err())
-	}); err != nil {
+			errCh <- roachpb.NewError(ctx.Err())
+		}); err != nil {
 		errCh <- roachpb.NewError(err)
 	}
 	return ch, errCh

--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -18,6 +18,7 @@ package storage
 
 import (
 	"container/heap"
+	"fmt"
 	"sync"
 	"time"
 
@@ -523,18 +524,20 @@ func (bq *baseQueue) processLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 				var duration time.Duration
 				if repl != nil {
 					annotatedCtx := repl.AnnotateCtx(ctx)
-					if stopper.RunTask(annotatedCtx, func(annotatedCtx context.Context) {
-						start := timeutil.Now()
-						if err := bq.processReplica(annotatedCtx, repl, clock); err != nil {
-							// Maybe add failing replica to purgatory if the queue supports it.
-							bq.maybeAddToPurgatory(annotatedCtx, repl, err, clock, stopper)
-						}
-						duration = timeutil.Since(start)
-						if log.V(2) {
-							log.Infof(annotatedCtx, "done %s", duration)
-						}
-						bq.processingNanos.Inc(duration.Nanoseconds())
-					}) != nil {
+					if stopper.RunTask(
+						annotatedCtx, fmt.Sprintf("storage.%s: processing replica", bq.name),
+						func(annotatedCtx context.Context) {
+							start := timeutil.Now()
+							if err := bq.processReplica(annotatedCtx, repl, clock); err != nil {
+								// Maybe add failing replica to purgatory if the queue supports it.
+								bq.maybeAddToPurgatory(annotatedCtx, repl, err, clock, stopper)
+							}
+							duration = timeutil.Since(start)
+							if log.V(2) {
+								log.Infof(annotatedCtx, "done %s", duration)
+							}
+							bq.processingNanos.Inc(duration.Nanoseconds())
+						}) != nil {
 						return
 					}
 				}
@@ -706,11 +709,13 @@ func (bq *baseQueue) maybeAddToPurgatory(
 						return
 					}
 					annotatedCtx := repl.AnnotateCtx(ctx)
-					if stopper.RunTask(annotatedCtx, func(annotatedCtx context.Context) {
-						if err := bq.processReplica(annotatedCtx, repl, clock); err != nil {
-							bq.maybeAddToPurgatory(annotatedCtx, repl, err, clock, stopper)
-						}
-					}) != nil {
+					if stopper.RunTask(
+						annotatedCtx, fmt.Sprintf("storage.%s: purgatory processing replica", bq.name),
+						func(annotatedCtx context.Context) {
+							if err := bq.processReplica(annotatedCtx, repl, clock); err != nil {
+								bq.maybeAddToPurgatory(annotatedCtx, repl, err, clock, stopper)
+							}
+						}) != nil {
 						return
 					}
 				}

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4677,24 +4677,26 @@ func (r *Replica) getLeaseForGossip(ctx context.Context) (bool, *roachpb.Error) 
 	}
 	var hasLease bool
 	var pErr *roachpb.Error
-	if err := r.store.Stopper().RunTask(ctx, func(ctx context.Context) {
-		// Check for or obtain the lease, if none active.
-		_, pErr = r.redirectOnOrAcquireLease(ctx)
-		hasLease = pErr == nil
-		if pErr != nil {
-			switch e := pErr.GetDetail().(type) {
-			case *roachpb.NotLeaseHolderError:
-				// NotLeaseHolderError means there is an active lease, but only if
-				// the lease holder is set; otherwise, it's likely a timeout.
-				if e.LeaseHolder != nil {
-					pErr = nil
+	if err := r.store.Stopper().RunTask(
+		ctx, "storage.Replica: acquiring lease to gossip",
+		func(ctx context.Context) {
+			// Check for or obtain the lease, if none active.
+			_, pErr = r.redirectOnOrAcquireLease(ctx)
+			hasLease = pErr == nil
+			if pErr != nil {
+				switch e := pErr.GetDetail().(type) {
+				case *roachpb.NotLeaseHolderError:
+					// NotLeaseHolderError means there is an active lease, but only if
+					// the lease holder is set; otherwise, it's likely a timeout.
+					if e.LeaseHolder != nil {
+						pErr = nil
+					}
+				default:
+					// Any other error is worth being logged visibly.
+					log.Warningf(ctx, "could not acquire lease for range gossip: %s", e)
 				}
-			default:
-				// Any other error is worth being logged visibly.
-				log.Warningf(ctx, "could not acquire lease for range gossip: %s", e)
 			}
-		}
-	}); err != nil {
+		}); err != nil {
 		pErr = roachpb.NewError(err)
 	}
 	return hasLease, pErr

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -362,7 +362,7 @@ func (r *Replica) computeChecksumPostApply(
 	snap := r.store.NewSnapshot()
 
 	// Compute SHA asynchronously and store it in a map by UUID.
-	if err := stopper.RunAsyncTask(ctx, func(ctx context.Context) {
+	if err := stopper.RunAsyncTask(ctx, "storage.Replica: computing checksum", func(ctx context.Context) {
 		defer snap.Close()
 		var snapshot *roachpb.RaftSnapshotData
 		if args.Snapshot {
@@ -789,16 +789,18 @@ func (r *Replica) handleLocalEvalResult(
 		// blocks waiting for the lease acquisition to finish but it can't finish
 		// because we're not processing raft messages due to holding
 		// processRaftMu (and running on the processRaft goroutine).
-		if err := r.store.Stopper().RunAsyncTask(ctx, func(ctx context.Context) {
-			hasLease, pErr := r.getLeaseForGossip(ctx)
+		if err := r.store.Stopper().RunAsyncTask(
+			ctx, "storage.Replica: gossipping first range",
+			func(ctx context.Context) {
+				hasLease, pErr := r.getLeaseForGossip(ctx)
 
-			if pErr != nil {
-				log.Infof(ctx, "unable to gossip first range; hasLease=%t, err=%s", hasLease, pErr)
-			} else if !hasLease {
-				return
-			}
-			r.gossipFirstRange(ctx)
-		}); err != nil {
+				if pErr != nil {
+					log.Infof(ctx, "unable to gossip first range; hasLease=%t, err=%s", hasLease, pErr)
+				} else if !hasLease {
+					return
+				}
+				r.gossipFirstRange(ctx)
+			}); err != nil {
 			log.Infof(ctx, "unable to gossip first range: %s", err)
 		}
 		lResult.gossipFirstRange = false

--- a/pkg/storage/replica_range_lease.go
+++ b/pkg/storage/replica_range_lease.go
@@ -175,72 +175,74 @@ func (p *pendingLeaseRequest) requestLeaseAsync(
 	status LeaseStatus,
 	leaseReq roachpb.Request,
 ) error {
-	return repl.store.Stopper().RunAsyncTask(ctx, func(ctx context.Context) {
-		var pErr *roachpb.Error
+	return repl.store.Stopper().RunAsyncTask(
+		ctx, "storage.pendingLeaseRequest: requesting lease",
+		func(ctx context.Context) {
+			var pErr *roachpb.Error
 
-		// If requesting an epoch-based lease & current state is expired,
-		// potentially heartbeat our own liveness or increment epoch of
-		// prior owner. Note we only do this if the previous lease was
-		// epoch-based.
-		if reqLease.Type() == roachpb.LeaseEpoch && status.state == leaseExpired &&
-			status.lease.Type() == roachpb.LeaseEpoch {
-			var err error
-			// If this replica is previous & next lease holder, manually heartbeat to become live.
-			if status.lease.OwnedBy(nextLeaseHolder.StoreID) &&
-				repl.store.StoreID() == nextLeaseHolder.StoreID {
-				if err = repl.store.cfg.NodeLiveness.Heartbeat(ctx, status.liveness); err != nil {
-					log.Error(ctx, err)
+			// If requesting an epoch-based lease & current state is expired,
+			// potentially heartbeat our own liveness or increment epoch of
+			// prior owner. Note we only do this if the previous lease was
+			// epoch-based.
+			if reqLease.Type() == roachpb.LeaseEpoch && status.state == leaseExpired &&
+				status.lease.Type() == roachpb.LeaseEpoch {
+				var err error
+				// If this replica is previous & next lease holder, manually heartbeat to become live.
+				if status.lease.OwnedBy(nextLeaseHolder.StoreID) &&
+					repl.store.StoreID() == nextLeaseHolder.StoreID {
+					if err = repl.store.cfg.NodeLiveness.Heartbeat(ctx, status.liveness); err != nil {
+						log.Error(ctx, err)
+					}
+				} else if status.liveness.Epoch == *status.lease.Epoch {
+					// If not owner, increment epoch if necessary to invalidate lease.
+					if err = repl.store.cfg.NodeLiveness.IncrementEpoch(ctx, status.liveness); err != nil {
+						log.Error(ctx, err)
+					}
 				}
-			} else if status.liveness.Epoch == *status.lease.Epoch {
-				// If not owner, increment epoch if necessary to invalidate lease.
-				if err = repl.store.cfg.NodeLiveness.IncrementEpoch(ctx, status.liveness); err != nil {
-					log.Error(ctx, err)
+				// Set error for propagation to all waiters below.
+				if err != nil {
+					pErr = roachpb.NewError(newNotLeaseHolderError(&status.lease, repl.store.StoreID(), repl.Desc()))
 				}
 			}
-			// Set error for propagation to all waiters below.
-			if err != nil {
-				pErr = roachpb.NewError(newNotLeaseHolderError(&status.lease, repl.store.StoreID(), repl.Desc()))
-			}
-		}
 
-		// Send the RequestLeaseRequest or TransferLeaseRequest and wait for the new
-		// lease to be applied.
-		if pErr == nil {
-			ba := roachpb.BatchRequest{}
-			ba.Timestamp = repl.store.Clock().Now()
-			ba.RangeID = repl.RangeID
-			ba.Add(leaseReq)
-			_, pErr = repl.Send(ctx, ba)
-			// TODO(a-robinson): Remove this check after it's gotten some mileage in
-			// on test clusters or we gain an understanding of #10940.
-			if txn := pErr.GetTxn(); txn != nil {
-				log.Fatalf(ctx, "unexpected non-nil transaction %v in error from LeaseRequest %+v: %+v", txn, leaseReq, pErr)
+			// Send the RequestLeaseRequest or TransferLeaseRequest and wait for the new
+			// lease to be applied.
+			if pErr == nil {
+				ba := roachpb.BatchRequest{}
+				ba.Timestamp = repl.store.Clock().Now()
+				ba.RangeID = repl.RangeID
+				ba.Add(leaseReq)
+				_, pErr = repl.Send(ctx, ba)
+				// TODO(a-robinson): Remove this check after it's gotten some mileage in
+				// on test clusters or we gain an understanding of #10940.
+				if txn := pErr.GetTxn(); txn != nil {
+					log.Fatalf(ctx, "unexpected non-nil transaction %v in error from LeaseRequest %+v: %+v", txn, leaseReq, pErr)
+				}
 			}
-		}
-		// We reset our state below regardless of whether we've gotten an error or
-		// not, but note that an error is ambiguous - there's no guarantee that the
-		// transfer will not still apply. That's OK, however, as the "in transfer"
-		// state maintained by the pendingLeaseRequest is not relied on for
-		// correctness (see repl.mu.minLeaseProposedTS), and resetting the state
-		// is beneficial as it'll allow the replica to attempt to transfer again or
-		// extend the existing lease in the future.
+			// We reset our state below regardless of whether we've gotten an error or
+			// not, but note that an error is ambiguous - there's no guarantee that the
+			// transfer will not still apply. That's OK, however, as the "in transfer"
+			// state maintained by the pendingLeaseRequest is not relied on for
+			// correctness (see repl.mu.minLeaseProposedTS), and resetting the state
+			// is beneficial as it'll allow the replica to attempt to transfer again or
+			// extend the existing lease in the future.
 
-		// Send result of lease to all waiter channels.
-		repl.mu.Lock()
-		defer repl.mu.Unlock()
-		for _, llChan := range p.llChans {
-			// Don't send the same transaction object twice; this can lead to races.
-			if pErr != nil {
-				pErrClone := *pErr
-				pErrClone.SetTxn(pErr.GetTxn())
-				llChan <- &pErrClone
-			} else {
-				llChan <- nil
+			// Send result of lease to all waiter channels.
+			repl.mu.Lock()
+			defer repl.mu.Unlock()
+			for _, llChan := range p.llChans {
+				// Don't send the same transaction object twice; this can lead to races.
+				if pErr != nil {
+					pErrClone := *pErr
+					pErrClone.SetTxn(pErr.GetTxn())
+					llChan <- &pErrClone
+				} else {
+					llChan <- nil
+				}
 			}
-		}
-		p.llChans = p.llChans[:0]
-		p.nextLease = roachpb.Lease{}
-	})
+			p.llChans = p.llChans[:0]
+			p.nextLease = roachpb.Lease{}
+		})
 }
 
 // JoinRequest adds one more waiter to the currently pending request.

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -1872,7 +1872,7 @@ func TestLeaseConcurrent(t *testing.T) {
 			ts := tc.Clock().Now()
 			pErrCh := make(chan *roachpb.Error, num)
 			for i := 0; i < num; i++ {
-				if err := stopper.RunAsyncTask(context.Background(), func(ctx context.Context) {
+				if err := stopper.RunAsyncTask(context.Background(), "test", func(ctx context.Context) {
 					tc.repl.mu.Lock()
 					status := tc.repl.leaseStatus(*tc.repl.mu.state.Lease, ts, hlc.Timestamp{})
 					leaseCh := tc.repl.requestLeaseLocked(ctx, status)
@@ -2086,7 +2086,7 @@ func TestReplicaCommandQueue(t *testing.T) {
 
 						// Asynchronously put a value to the range with blocking enabled.
 						cmd1Done := make(chan *roachpb.Error, 1)
-						if err := stopper.RunAsyncTask(context.Background(), func(_ context.Context) {
+						if err := stopper.RunAsyncTask(context.Background(), "test", func(_ context.Context) {
 							args := readOrWriteArgs(key1, test.cmd1Read)
 							cmd1Done <- sendWithHeader(roachpb.Header{
 								UserPriority: blockingPriority,
@@ -2103,7 +2103,7 @@ func TestReplicaCommandQueue(t *testing.T) {
 
 						// First, try a command for same key as cmd1 to verify whether it blocks.
 						cmd2Done := make(chan *roachpb.Error, 1)
-						if err := stopper.RunAsyncTask(context.Background(), func(_ context.Context) {
+						if err := stopper.RunAsyncTask(context.Background(), "", func(_ context.Context) {
 							args := readOrWriteArgs(key1, test.cmd2Read)
 							cmd2Done <- sendWithHeader(roachpb.Header{}, args)
 						}); err != nil {
@@ -2112,7 +2112,7 @@ func TestReplicaCommandQueue(t *testing.T) {
 
 						// Next, try read for a non-impacted key--should go through immediately.
 						cmd3Done := make(chan *roachpb.Error, 1)
-						if err := stopper.RunAsyncTask(context.Background(), func(_ context.Context) {
+						if err := stopper.RunAsyncTask(context.Background(), "", func(_ context.Context) {
 							args := readOrWriteArgs(key2, true)
 							cmd3Done <- sendWithHeader(roachpb.Header{}, args)
 						}); err != nil {
@@ -2286,7 +2286,7 @@ func TestReplicaCommandQueueCancellation(t *testing.T) {
 	startBlockingCmd := func(ctx context.Context, keys ...roachpb.Key) <-chan *roachpb.Error {
 		done := make(chan *roachpb.Error)
 
-		if err := stopper.RunAsyncTask(context.Background(), func(_ context.Context) {
+		if err := stopper.RunAsyncTask(context.Background(), "test", func(_ context.Context) {
 			ba := roachpb.BatchRequest{
 				Header: roachpb.Header{
 					UserPriority: 42,

--- a/pkg/storage/scanner.go
+++ b/pkg/storage/scanner.go
@@ -277,19 +277,21 @@ func (rs *replicaScanner) scanLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 				shouldStop = rs.waitAndProcess(ctx, start, clock, stopper, nil)
 			}
 
-			shouldStop = shouldStop || nil != stopper.RunTask(ctx, func(ctx context.Context) {
-				// Increment iteration count.
-				rs.mu.Lock()
-				defer rs.mu.Unlock()
-				rs.mu.scanCount++
-				rs.mu.total += timeutil.Since(start)
-				if log.V(6) {
-					log.Infof(ctx, "reset replica scan iteration")
-				}
+			shouldStop = shouldStop || nil != stopper.RunTask(
+				ctx, "storage.replicaScanner: scan loop",
+				func(ctx context.Context) {
+					// Increment iteration count.
+					rs.mu.Lock()
+					defer rs.mu.Unlock()
+					rs.mu.scanCount++
+					rs.mu.total += timeutil.Since(start)
+					if log.V(6) {
+						log.Infof(ctx, "reset replica scan iteration")
+					}
 
-				// Reset iteration and start time.
-				start = timeutil.Now()
-			})
+					// Reset iteration and start time.
+					start = timeutil.Now()
+				})
 			if shouldStop {
 				return
 			}

--- a/pkg/ts/db.go
+++ b/pkg/ts/db.go
@@ -101,7 +101,7 @@ func (p *poller) start() {
 // returned time series data on the server.
 func (p *poller) poll() {
 	bgCtx := p.AnnotateCtx(context.Background())
-	if err := p.stopper.RunTask(bgCtx, func(bgCtx context.Context) {
+	if err := p.stopper.RunTask(bgCtx, "ts.poller: poll", func(bgCtx context.Context) {
 		data := p.source.GetTimeSeriesData()
 		if len(data) == 0 {
 			return

--- a/pkg/ts/server.go
+++ b/pkg/ts/server.go
@@ -119,12 +119,13 @@ func (s *Server) Query(
 	// a deadlock would occur because queries cannot complete until
 	// they have written their result to the "output" channel, which is
 	// processed later in the main function.
-	if err := s.stopper.RunAsyncTask(ctx, func(ctx context.Context) {
+	if err := s.stopper.RunAsyncTask(ctx, "ts.Server: queries", func(ctx context.Context) {
 		for queryIdx, query := range request.Queries {
 			queryIdx := queryIdx
 			query := query
 			if err := s.stopper.RunLimitedAsyncTask(
 				ctx,
+				"ts.Server: query",
 				s.workerSem,
 				true, /* wait */
 				func(ctx context.Context) {

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -34,6 +34,8 @@ import (
 	"github.com/opentracing/opentracing-go"
 )
 
+const asyncTaskNamePrefix = "[async] "
+
 // ErrThrottled is returned from RunLimitedAsyncTask in the event that there
 // is no more capacity for async tasks, as limited by the semaphore.
 var ErrThrottled = errors.New("throttled on async limiting semaphore")
@@ -93,15 +95,6 @@ func (f CloserFn) Close() {
 	f()
 }
 
-type taskKey struct {
-	file string
-	line int
-}
-
-func (k taskKey) String() string {
-	return fmt.Sprintf("%s:%d", k.file, k.line)
-}
-
 // A Stopper provides a channel-based mechanism to stop an arbitrary
 // array of workers. Each worker is registered with the stopper via
 // the RunWorker() method. The system further allows execution of functions
@@ -118,18 +111,17 @@ func (k taskKey) String() string {
 // be added to the stopper via AddCloser(), to be closed after the
 // stopper has stopped.
 type Stopper struct {
-	quiescer   chan struct{}     // Closed when quiescing
-	stopper    chan struct{}     // Closed when stopping
-	stopped    chan struct{}     // Closed when stopped completely
-	onPanic    func(interface{}) // called with recover() on panic on any goroutine
-	trackTasks bool              // Should task call sites be tracked
-	stop       sync.WaitGroup    // Incremented for outstanding workers
-	mu         struct {
+	quiescer chan struct{}     // Closed when quiescing
+	stopper  chan struct{}     // Closed when stopping
+	stopped  chan struct{}     // Closed when stopped completely
+	onPanic  func(interface{}) // called with recover() on panic on any goroutine
+	stop     sync.WaitGroup    // Incremented for outstanding workers
+	mu       struct {
 		syncutil.Mutex
 		quiesce   *sync.Cond // Conditional variable to wait for outstanding tasks
 		quiescing bool       // true when Stop() has been called
 		numTasks  int        // number of outstanding tasks
-		tasks     map[taskKey]int
+		tasks     TaskMap
 		closers   []Closer
 		cancels   []func()
 	}
@@ -155,27 +147,15 @@ func OnPanic(handler func(interface{})) Option {
 	return optionPanicHandler(handler)
 }
 
-type optionTrackTasks bool
-
-func (ott optionTrackTasks) apply(stopper *Stopper) {
-	stopper.trackTasks = bool(ott)
-}
-
-// TrackTasks is an option which allows tracking of tasks to be disabled.
-func TrackTasks(enabled bool) Option {
-	return optionTrackTasks(enabled)
-}
-
 // NewStopper returns an instance of Stopper.
 func NewStopper(options ...Option) *Stopper {
 	s := &Stopper{
-		quiescer:   make(chan struct{}),
-		stopper:    make(chan struct{}),
-		stopped:    make(chan struct{}),
-		trackTasks: true,
+		quiescer: make(chan struct{}),
+		stopper:  make(chan struct{}),
+		stopped:  make(chan struct{}),
 	}
 
-	s.mu.tasks = map[taskKey]int{}
+	s.mu.tasks = TaskMap{}
 
 	for _, opt := range options {
 		opt.apply(s)
@@ -223,77 +203,70 @@ func (s *Stopper) AddCloser(c Closer) {
 	s.mu.closers = append(s.mu.closers, c)
 }
 
-// RunTask adds one to the count of tasks left to quiesce in the system. Any
-// worker which is a "first mover" when starting tasks must call this method
-// before starting work on a new task. First movers include
-// goroutines launched to do periodic work and the kv/db.go gateway which
-// accepts external client requests.
-//
-// Returns an error to indicate that the system is currently quiescing and
-// function f was not called.
-func (s *Stopper) RunTask(ctx context.Context, f func(context.Context)) error {
-	key := taskKey{"???", 1}
-	if s.trackTasks {
-		key.file, key.line, _ = caller.Lookup(1)
-	}
-	if !s.runPrelude(key) {
-		return errUnavailable
-	}
-
-	// Call f.
-	defer s.Recover(ctx)
-	defer s.runPostlude(key)
-
-	f(ctx)
-	return nil
-}
-
-// RunTaskWithErr adds one to the count of tasks left to quiesce in the system.
+// RunTask adds one to the count of tasks left to quiesce in the system.
 // Any worker which is a "first mover" when starting tasks must call this method
 // before starting work on a new task. First movers include goroutines launched
 // to do periodic work and the kv/db.go gateway which accepts external client
 // requests.
 //
-// If the system is currently quiescing and function f was not called, returns
-// an error indicating this condition. Otherwise, returns whatever f returns.
-func (s *Stopper) RunTaskWithErr(ctx context.Context, f func(context.Context) error) error {
-	key := taskKey{"???", 1}
-	if s.trackTasks {
-		key.file, key.line, _ = caller.Lookup(1)
-	}
-	if !s.runPrelude(key) {
+// taskName is used as the "operation" field of the span opened for this task
+// and is visible in traces. It's also part of reports printed by stoppers
+// waiting to stop. The convention is
+// <package name>.<struct name>: <succinct description of the task's action>
+//
+// Returns an error to indicate that the system is currently quiescing and
+// function f was not called.
+func (s *Stopper) RunTask(ctx context.Context, taskName string, f func(context.Context)) error {
+	if !s.runPrelude(taskName) {
 		return errUnavailable
 	}
 
 	// Call f.
 	defer s.Recover(ctx)
-	defer s.runPostlude(key)
+	defer s.runPostlude(taskName)
+
+	f(ctx)
+	return nil
+}
+
+// RunTaskWithErr is like RunTask(), but takes in a callback that can return an
+// error. The error is returned to the caller.
+func (s *Stopper) RunTaskWithErr(
+	ctx context.Context, taskName string, f func(context.Context) error,
+) error {
+	if !s.runPrelude(taskName) {
+		return errUnavailable
+	}
+
+	// Call f.
+	defer s.Recover(ctx)
+	defer s.runPostlude(taskName)
 
 	return f(ctx)
 }
 
-// RunAsyncTask runs function f in a goroutine. It returns an error when the
-// Stopper is quiescing, in which case the function is not executed.
-func (s *Stopper) RunAsyncTask(ctx context.Context, f func(context.Context)) error {
-	key := taskKey{"???", 1}
-	if s.trackTasks {
-		key.file, key.line, _ = caller.Lookup(1)
-	}
-	if !s.runPrelude(key) {
+// RunAsyncTask is like RunTask, except the callback is run in a goroutine. The
+// method doesn't block for the callback to finish execution.
+func (s *Stopper) RunAsyncTask(
+	ctx context.Context, taskName string, f func(context.Context),
+) error {
+	taskName = asyncTaskNamePrefix + taskName
+	if !s.runPrelude(taskName) {
 		return errUnavailable
 	}
 
-	ctx, span := tracing.ForkCtxSpan(ctx, key.String())
+	ctx, span := tracing.ForkCtxSpan(ctx, taskName)
 
 	// Call f.
 	go func() {
 		defer s.Recover(ctx)
-		defer s.runPostlude(key)
+		defer s.runPostlude(taskName)
 		defer tracing.FinishSpan(span)
 
 		f(ctx)
 	}()
 	return nil
+
 }
 
 // RunLimitedAsyncTask runs function f in a goroutine, using the given
@@ -305,13 +278,8 @@ func (s *Stopper) RunAsyncTask(ctx context.Context, f func(context.Context)) err
 // available. Returns an error if the Stopper is quiescing, in which
 // case the function is not executed.
 func (s *Stopper) RunLimitedAsyncTask(
-	ctx context.Context, sem chan struct{}, wait bool, f func(context.Context),
+	ctx context.Context, taskName string, sem chan struct{}, wait bool, f func(context.Context),
 ) error {
-	key := taskKey{"???", 1}
-	if s.trackTasks {
-		key.file, key.line, _ = caller.Lookup(1)
-	}
-
 	// Wait for permission to run from the semaphore.
 	select {
 	case sem <- struct{}{}:
@@ -323,7 +291,7 @@ func (s *Stopper) RunLimitedAsyncTask(
 		if !wait {
 			return ErrThrottled
 		}
-		log.Infof(ctx, "stopper throttling task from %s due to semaphore", key)
+		log.Infof(ctx, "stopper throttling task from %s due to semaphore", taskName)
 		// Retry the select without the default.
 		select {
 		case sem <- struct{}{}:
@@ -343,16 +311,16 @@ func (s *Stopper) RunLimitedAsyncTask(
 	default:
 	}
 
-	if !s.runPrelude(key) {
+	if !s.runPrelude(taskName) {
 		<-sem
 		return errUnavailable
 	}
 
-	ctx, span := tracing.ForkCtxSpan(ctx, key.String())
+	ctx, span := tracing.ForkCtxSpan(ctx, taskName)
 
 	go func() {
 		defer s.Recover(ctx)
-		defer s.runPostlude(key)
+		defer s.runPostlude(taskName)
 		defer func() { <-sem }()
 		defer tracing.FinishSpan(span)
 
@@ -361,22 +329,22 @@ func (s *Stopper) RunLimitedAsyncTask(
 	return nil
 }
 
-func (s *Stopper) runPrelude(key taskKey) bool {
+func (s *Stopper) runPrelude(taskName string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.mu.quiescing {
 		return false
 	}
 	s.mu.numTasks++
-	s.mu.tasks[key]++
+	s.mu.tasks[taskName]++
 	return true
 }
 
-func (s *Stopper) runPostlude(key taskKey) {
+func (s *Stopper) runPostlude(taskName string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.mu.numTasks--
-	s.mu.tasks[key]--
+	s.mu.tasks[taskName]--
 	s.mu.quiesce.Broadcast()
 }
 
@@ -410,12 +378,12 @@ func (s *Stopper) RunningTasks() TaskMap {
 }
 
 func (s *Stopper) runningTasksLocked() TaskMap {
-	m := map[string]int{}
+	m := TaskMap{}
 	for k := range s.mu.tasks {
 		if s.mu.tasks[k] == 0 {
 			continue
 		}
-		m[k.String()] = s.mu.tasks[k]
+		m[k] = s.mu.tasks[k]
 	}
 	return m
 }


### PR DESCRIPTION
Before this patch, tasks were identified by the file:line of the caller
into Stopper.Run{Async}Task. This was expensive, and it was controlled
by a Stopper option. This identifier is also used as the "operation
name" of an opentracing span opened for the task.
Instead, now all callers need to pass in a task name. Since span names
are becoming more prominent as out tracing support advances, this
improves the traces (as well as the existing reports about tasks running
under a stopper). And also, this gives stable span names that we can use
in tracing tests.

cc @petermattis 