### PR TITLE
distsql: add initial buffering phase to hash joiner

### DIFF
--- a/pkg/sql/distsqlrun/mergejoiner.go
+++ b/pkg/sql/distsqlrun/mergejoiner.go
@@ -126,12 +126,12 @@ func (m *mergeJoiner) outputBatch(ctx context.Context) (bool, error) {
 				if matchedRight != nil {
 					matchedRight[rIdx] = true
 				}
-				if !emitHelper(ctx, &m.out, renderedRow, ProducerMetadata{}, m.leftSource, m.rightSource) {
+				if !emitHelper(ctx, &m.out, renderedRow, ProducerMetadata{}) {
 					return false, nil
 				}
 			}
 		}
-		if !matched && !m.maybeEmitUnmatchedRow(ctx, lrow, true /* leftSide */) {
+		if !matched && !m.maybeEmitUnmatchedRow(ctx, lrow, leftSide) {
 			return false, nil
 		}
 	}
@@ -139,7 +139,7 @@ func (m *mergeJoiner) outputBatch(ctx context.Context) (bool, error) {
 	if matchedRight != nil {
 		// Produce results for unmatched right rows (for RIGHT OUTER or FULL OUTER).
 		for rIdx, rrow := range rightRows {
-			if !matchedRight[rIdx] && !m.maybeEmitUnmatchedRow(ctx, rrow, false /* !leftSide */) {
+			if !matchedRight[rIdx] && !m.maybeEmitUnmatchedRow(ctx, rrow, rightSide) {
 				return false, nil
 			}
 		}

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -163,9 +163,9 @@ func (h *procOutputHelper) neededColumns() []bool {
 // If the consumer signals the producer to drain, the message is relayed and all
 // the draining metadata is consumed and forwarded.
 //
-// inputs can be nil.
+// inputs are optional.
 //
-// Returns true if more rows are needed, false otherwise. If false is returned,
+// Returns true if more rows are needed, false otherwise. If false is returned
 // both the inputs and the output have been properly closed.
 func emitHelper(
 	ctx context.Context,
@@ -186,10 +186,10 @@ func emitHelper(
 		var err error
 		consumerStatus, err = output.emitRow(ctx, row)
 		if err != nil {
+			output.output.Push(nil /* row */, ProducerMetadata{Err: err})
 			for _, input := range inputs {
 				input.ConsumerClosed()
 			}
-			output.output.Push(nil /* row */, ProducerMetadata{Err: err})
 			output.close()
 			return false
 		}

--- a/pkg/sql/distsqlrun/values.go
+++ b/pkg/sql/distsqlrun/values.go
@@ -101,7 +101,8 @@ func (v *valuesProcessor) Run(ctx context.Context, wg *sync.WaitGroup) {
 				break
 			}
 
-			if !emitHelper(ctx, &v.out, row, meta, nil /* inputs */) {
+			if !emitHelper(ctx, &v.out, row, meta) {
+				v.out.close()
 				return
 			}
 		}

--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -619,10 +619,6 @@ SELECT * FROM (onecolumn AS a JOIN onecolumn AS b ON a.y > y)
 statement ok
 CREATE TABLE s(x INT); INSERT INTO s(x) VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10)
 
-# The following query demands at least 100GB of RAM if unoptimized.
-query error memory budget exceeded
-SELECT COUNT(a.x+b.x+c.x+d.x+e.x+f.x+g.x+h.x+i.x+j.x+k.x) FROM s AS a, s AS b, s AS c, s AS d, s AS e, s AS f, s AS g, s AS h, s AS i, s AS j, s AS k
-
 # THe following queries verify that only the necessary columns are scanned.
 query ITTTTT
 EXPLAIN (METADATA) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b

--- a/pkg/sql/mon/mem_usage.go
+++ b/pkg/sql/mon/mem_usage.go
@@ -379,6 +379,12 @@ type MemoryAccount struct {
 	curAllocated int64
 }
 
+// CurrentlyAllocated returns the number of bytes currently allocated through
+// this account.
+func (acc MemoryAccount) CurrentlyAllocated() int64 {
+	return acc.curAllocated
+}
+
 // OpenAccount creates a new empty account.
 func (mm *MemoryMonitor) OpenAccount(_ *MemoryAccount) {
 	// TODO(knz): conditionally track accounts in the memory monitor

--- a/pkg/sql/sqlbase/row_container.go
+++ b/pkg/sql/sqlbase/row_container.go
@@ -296,6 +296,8 @@ func (c *RowContainer) PopFirst() {
 		c.deletedRows++
 		if c.deletedRows == c.rowsPerChunk {
 			c.deletedRows = 0
+			// Reset the pointer so the slice can be garbage collected.
+			c.chunks[0] = nil
 			c.chunks = c.chunks[1:]
 		}
 	}
@@ -315,4 +317,9 @@ func (c *RowContainer) Replace(ctx context.Context, i int, newRow parser.Datums)
 	}
 	copy(row, newRow)
 	return nil
+}
+
+// MemUsage returns the current accounted memory usage.
+func (c *RowContainer) MemUsage() int64 {
+	return c.memAcc.CurrentlyAllocated()
 }


### PR DESCRIPTION
The hash joiner stores the entire right stream in a map. Given that currently we
don't have enough data to estimate at planning time the size of each stream, the
choice of left vs right is arbitrary. This can lead to cases where the left
stream is very small and the right stream is very large. We want to detect these
cases and store the left stream in the map. This would reduce memory usage and
should make the queries faster (it's faster to query a small map than to insert
in a large map).

We do this by adding an initial buffering phase. In this phase we read and store
rows from both streams up to a certain number of bytes (in terms of memory
usage). If we find the end of a stream in this phase, we choose that stream for
storing. If not, we use the right stream as before. In the worst case, we might
use more memory than before - up to double what we were using, and up to 4MB.

The change is conceptually straightforward but fairly tedious unfortunately.

I ran TPC-H query 8 manually (single node, scale factor 1). Before this change,
this query failed because 1.5GB of budget wasn't enough (I'm not sure how much
memory it actually needed). With this change it uses about 500MB.

Fixes #16380.

CC @petermattis