### PR TITLE
storage/engine: cache iterators within read-only batches

### DIFF
--- a/pkg/storage/engine/batch_test.go
+++ b/pkg/storage/engine/batch_test.go
@@ -136,6 +136,107 @@ func TestBatchBasics(t *testing.T) {
 	})
 }
 
+func shouldPanic(t *testing.T, f func(), funcName string, expectedPanicStr string) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("%v: test did not panic", funcName)
+		} else if r != expectedPanicStr {
+			t.Fatalf("%v: unexpected panic: %v", funcName, r)
+		}
+	}()
+	f()
+}
+
+func shouldNotPanic(t *testing.T, f func(), funcName string) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("%v: unexpected panic: %v", funcName, r)
+		}
+	}()
+	f()
+}
+
+// TestReadOnlyBasics verifies that for a read-only ReadWriter (obtained via engine.NewReadOnly()) all Reader methods
+// work except NewTimeBoundIterator, and all Writer methods panic as "not implemented". Also basic iterating
+// functionality is verified.
+func TestReadOnlyBasics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.TODO())
+	e := NewInMem(roachpb.Attributes{}, 1<<20)
+	stopper.AddCloser(e)
+
+	b := e.NewReadOnly()
+	if b.Closed() {
+		t.Fatal("read-only is expectedly found to be closed")
+	}
+	a := mvccKey("a")
+	getVal := &roachpb.Value{}
+	successTestCases := []func(){
+		func() { _, _ = b.Get(a) },
+		func() { _, _, _, _ = b.GetProto(a, getVal) },
+		func() { _ = b.Iterate(a, a, func(MVCCKeyValue) (bool, error) { return true, nil }) },
+		func() { _ = b.NewIterator(false) },
+	}
+	defer func() {
+		b.Close()
+		if !b.Closed() {
+			t.Fatal("even after calling Close, a read-only should not be closed")
+		}
+		shouldPanic(t, func() { b.Close() }, "Close", "closing an already-closed rocksDBReadOnly")
+		for i, f := range successTestCases {
+			shouldPanic(t, f, string(i), "using a closed rocksDBReadOnly")
+		}
+	}()
+
+	for i, f := range successTestCases {
+		shouldNotPanic(t, f, string(i))
+	}
+
+	// For a read-only ReadWriter, all Writer methods should panic, as well as NewTimeBoundIterator
+	failureTestCases := []func(){
+		func() { _ = b.NewTimeBoundIterator(hlc.Timestamp{}, hlc.Timestamp{}) },
+		func() { _ = b.ApplyBatchRepr(nil, false) },
+		func() { _ = b.Clear(a) },
+		func() { _ = b.ClearRange(a, a) },
+		func() { _ = b.Merge(a, nil) },
+		func() { _ = b.Put(a, nil) },
+	}
+	for i, f := range failureTestCases {
+		shouldPanic(t, f, string(i), "not implemented")
+	}
+
+	if err := e.Put(mvccKey("a"), []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.Put(mvccKey("b"), []byte("value")); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.Clear(mvccKey("b")); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.Put(mvccKey("c"), appender("foo")); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.Merge(mvccKey("c"), appender("bar")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now, merged values should be:
+	expValues := []MVCCKeyValue{
+		{Key: mvccKey("a"), Value: []byte("value")},
+		{Key: mvccKey("c"), Value: appender("foobar")},
+	}
+
+	kvs, err := Scan(e, mvccKey(roachpb.RKeyMin), mvccKey(roachpb.RKeyMax), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(expValues, kvs) {
+		t.Errorf("%v != %v", kvs, expValues)
+	}
+}
+
 func TestBatchRepr(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	testBatchBasics(t, false /* writeOnly */, func(e Engine, b Batch) error {

--- a/pkg/storage/engine/bench_rocksdb_test.go
+++ b/pkg/storage/engine/bench_rocksdb_test.go
@@ -83,6 +83,30 @@ func BenchmarkIterOnBatch_RocksDB(b *testing.B) {
 	}
 }
 
+// BenchmarkIterOnReadOnly_RocksDB is a microbenchmark that measures the performance of creating an iterator
+// and seeking to a key if a read-only ReadWriter that caches the RocksDB iterator is used
+func BenchmarkIterOnReadOnly_RocksDB(b *testing.B) {
+	for _, writes := range []int{10, 100, 1000, 10000} {
+		b.Run(fmt.Sprintf("%d", writes), func(b *testing.B) {
+			benchmarkIterOnReadWriter(b, writes,
+				func(engine Engine) ReadWriter { return engine.NewReadOnly() },
+				true)
+		})
+	}
+}
+
+// BenchmarkIterOnEngine_RocksDB is a microbenchmark that measures the performance of creating an iterator
+// and seeking to a key without caching is used (see BenchmarkIterOnReadOnly_RocksDB)
+func BenchmarkIterOnEngine_RocksDB(b *testing.B) {
+	for _, writes := range []int{10, 100, 1000, 10000} {
+		b.Run(fmt.Sprintf("%d", writes), func(b *testing.B) {
+			benchmarkIterOnReadWriter(b, writes,
+				func(engine Engine) ReadWriter { return engine },
+				false)
+		})
+	}
+}
+
 // Write benchmarks. Most of them run in-memory except for DeleteRange benchs,
 // which make more sense when data is present.
 

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -194,6 +194,11 @@ type Engine interface {
 	// this engine. Batched engines accumulate all mutations and apply
 	// them atomically on a call to Commit().
 	NewBatch() Batch
+	// NewReadOnly returns a new instance of a ReadWriter that wraps
+	// this engine. This wrapper panics when unexpected operations (e.g., write
+	// operations) are executed on it and caches iterators to avoid the overhead
+	// of creating multiple iterators for batched reads.
+	NewReadOnly() ReadWriter
 	// NewWriteOnlyBatch returns a new instance of a batched engine which wraps
 	// this engine. A write-only batch accumulates all mutations and applies them
 	// atomically on a call to Commit(). Read operations return an error.

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -183,6 +183,34 @@ func benchmarkIterOnBatch(b *testing.B, writes int) {
 	}
 }
 
+func benchmarkIterOnReadWriter(
+	b *testing.B, writes int, f func(Engine) ReadWriter, closeReadWriter bool,
+) {
+	engine := createTestEngine()
+	defer engine.Close()
+
+	for i := 0; i < writes; i++ {
+		if err := engine.Put(makeKey(i), []byte(strconv.Itoa(i))); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	readWriter := f(engine)
+	if closeReadWriter {
+		defer readWriter.Close()
+	}
+
+	r := rand.New(rand.NewSource(5))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		key := makeKey(r.Intn(writes))
+		iter := readWriter.NewIterator(true)
+		iter.Seek(key)
+		iter.Close()
+	}
+}
+
 // TestRocksDBOpenWithVersions verifies the version checking in Open()
 // functions correctly.
 func TestRocksDBOpenWithVersions(t *testing.T) {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2282,7 +2282,9 @@ func (r *Replica) executeReadOnlyBatch(
 	// "wrong" key range being served after the range has been split.
 	var result EvalResult
 	rec := ReplicaEvalContext{r, spans}
-	br, result, pErr = evaluateBatch(ctx, storagebase.CmdIDKey(""), r.store.Engine(), rec, nil, ba)
+	readOnly := r.store.Engine().NewReadOnly()
+	defer readOnly.Close()
+	br, result, pErr = evaluateBatch(ctx, storagebase.CmdIDKey(""), readOnly, rec, nil, ba)
 
 	if intents := result.Local.detachIntents(); len(intents) > 0 {
 		log.Eventf(ctx, "submitting %d intents to asynchronous processing", len(intents))


### PR DESCRIPTION
Read-only batches currently execute on a RocksDB which bypasses the
optimization to reuse iterators across execution of a command that
occurs when using a *rocksDBBatch. We create a minimalist wrapper for
RocksDB called rocksDBReadOnly that caches iterators and does not
have the overhead of state for supporting writes. Here are the results
of microbenchmarks that test the relative performance of iterating over
one key using the underlying engine, versus the read-write batch versus
the read only wrapper:

```
Engine vs. ReadOnly
name            old time/op  new time/op  delta
IterOn/10-8     1.15us       0.52us        -55.03%  (p=0.000 n=10+10)
IterOn/100-8    1.25us       0.67us        -46.61%  (p=0.000 n=9+10)
IterOn/1000-8   1.42us       0.81us        -43.41%  (p=0.000 n=9+10)
IterOn/10000-8  1.63us       0.96us        -40.83%  (p=0.000 n=10+10)

Batch vs. ReadOnly
name            old time/op  new time/op  delta
IterOn/10-8     568ns        517ns      -9.13%  (p=0.000 n=10+10)
IterOn/100-8    705ns        669ns      -5.04%  (p=0.005 n=10+10)
IterOn/1000-8   855ns        805ns      -5.88%  (p=0.000 n=10+10)
IterOn/10000-8  1.02us       0.96us     -5.60%  (p=0.000 n=9+10)
```