### PR TITLE
storage: Avoid up-replicating to even replica states

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -271,6 +271,9 @@ func (ts *TestServer) Start(params base.TestServerArgs) error {
 		params.Stopper = stop.NewStopper()
 	}
 
+	// TODO(andrei): Running two TestServers concurrently with
+	// PartOfCluster==false can result in the default zone config not be reset
+	// properly. It would be nice if this were more robust.
 	if !params.PartOfCluster {
 		// Change the replication requirements so we don't get log spam about ranges
 		// not being replicated enough.

--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -650,7 +650,7 @@ func (bq *baseQueue) maybeAddToPurgatory(
 	bq.failures.Inc(1)
 
 	// Check whether the failure is a purgatory error and whether the queue supports it.
-	if _, ok := triggeringErr.(purgatoryError); !ok || bq.impl.purgatoryChan() == nil {
+	if _, ok := errors.Cause(triggeringErr).(purgatoryError); !ok || bq.impl.purgatoryChan() == nil {
 		log.Error(ctx, triggeringErr)
 		return
 	}

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -152,7 +152,6 @@ func StartTestCluster(t testing.TB, nodes int, args base.TestClusterArgs) *TestC
 		} else {
 			serverArgs = args.ServerArgs
 		}
-		serverArgs.PartOfCluster = true
 		if i > 0 {
 			serverArgs.JoinAddr = tc.Servers[0].ServingAddr()
 		}
@@ -222,6 +221,7 @@ func (tc *TestCluster) AddServer(t testing.TB, serverArgs base.TestServerArgs) e
 }
 
 func (tc *TestCluster) doAddServer(t testing.TB, serverArgs base.TestServerArgs) error {
+	serverArgs.PartOfCluster = true
 	// Check args even though they might have been checked in StartTestCluster;
 	// this method might be called for servers being added after the cluster was
 	// started, in which case the check has not been performed.


### PR DESCRIPTION
Avoid up-replicating to an even replica state if it is not possible to
go to an odd replica state beyond it, unless the even replica state is
the configured number of replicas.