### PR TITLE
storage: allow acquisition from closed quota pools

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2115,11 +2115,7 @@ func TestRaftAfterRemoveRange(t *testing.T) {
 // reproduce a race (see #1911 and #9037).
 func TestRaftRemoveRace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sc := storage.TestStoreConfig(nil)
-	// Suppress timeout-based elections to avoid leadership changes in ways
-	// this test doesn't expect.
-	sc.RaftElectionTimeoutTicks = 100000
-	mtc := &multiTestContext{storeConfig: &sc}
+	mtc := &multiTestContext{}
 	defer mtc.Stop()
 	mtc.Start(t, 10)
 

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -890,6 +890,9 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 			r.mu.commandSizes = make(map[storagebase.CmdIDKey]int)
 		} else if r.mu.proposalQuota != nil {
 			// We're becoming a follower.
+
+			// We unblock all ongoing and subsequent quota acquisition
+			// goroutines (if any).
 			r.mu.proposalQuota.close()
 			r.mu.proposalQuota = nil
 			r.mu.quotaReleaseQueue = nil
@@ -906,8 +909,8 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 
 	// We're still the leader.
 
-	// We need to check if the replica is being destroyed and if so, close the
-	// quota pool and unblock ongoing quota acquisition goroutines (if any).
+	// We need to check if the replica is being destroyed and if so, unblock
+	// all ongoing and subsequent quota acquisition goroutines (if any).
 	//
 	// TODO(irfansharif): There is still a potential problem here that leaves
 	// clients hanging if the replica gets destroyed but this code path is


### PR DESCRIPTION
(actually) Fixes #16376, reverts #16399.

`TestRaftRemoveRace` touched the short window of time where it was
possible that the lease holder and the raft leader were not the same
replica (raft leadership could change from under us, but the lease 
holder stayed steady).

Consider the following sequence of events:
- the lease holder and the raft leader are co-located
- 'add replica' commands get queued up on the replicate queue
- leader replica steps down as leader thus closing the quota pool on
  the leaseholder, because they're one and the same
- commands get out of the queue, cannot acquire quota because the quota pool is
  closed (on the lease holder) and fail with an error indicating so

We make two observations:
- `quotaPool.close()` only takes place when a raft leader is becoming a
follower and thus causing all ongoing acquisitions to fail
- Ongoing acquisitions are _only_ taking place on the lease holder replica

The quota pool was implemented in a manner such that it is _effectively
disabled_ when the lease holder and the range leader are not co-located.
Failing with an error here (now that the raft leader has changed, the
lease holder and raft leader are no longer co-located) runs contrary to this.
What we really want is to "fail open" in this case instead, i.e. allow the
acquisition to proceed as if the quota pool is _effectively disabled_.
