### PR TITLE
distsql: add SortAll and SortLimit benchmarks to Sorter

### DIFF
--- a/pkg/sql/distsqlrun/testutils.go
+++ b/pkg/sql/distsqlrun/testutils.go
@@ -1,0 +1,81 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Alfonso Subiotto Marqués (alfonso@cockroachlabs.com)
+
+package distsqlrun
+
+import "github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+
+// RepeatableRowSource is a RowSource used in benchmarks to avoid having to
+// reinitialize a new RowSource every time during multiple passes of the input.
+// It is intended to be initialized with all rows.
+type RepeatableRowSource struct {
+	// The index of the next row to emit.
+	nextRowIdx int
+	rows       sqlbase.EncDatumRows
+	// Schema of rows.
+	types []sqlbase.ColumnType
+}
+
+var _ RowSource = &RepeatableRowSource{}
+
+// NewRepeatableRowSource creates a RepeatableRowSource with the given schema
+// and rows.
+func NewRepeatableRowSource(
+	types []sqlbase.ColumnType, rows sqlbase.EncDatumRows,
+) *RepeatableRowSource {
+	return &RepeatableRowSource{rows: rows, types: types}
+}
+
+// Types is part of the RowSource interface.
+func (r *RepeatableRowSource) Types() []sqlbase.ColumnType {
+	return r.types
+}
+
+// Next is part of the RowSource interface.
+func (r *RepeatableRowSource) Next() (sqlbase.EncDatumRow, ProducerMetadata) {
+	// If we've emitted all rows, signal that we have reached the end.
+	if r.nextRowIdx >= len(r.rows) {
+		return nil, ProducerMetadata{}
+	}
+	nextRow := r.rows[r.nextRowIdx]
+	r.nextRowIdx++
+	return nextRow, ProducerMetadata{}
+}
+
+// Reset resets the RepeatableRowSource such that a subsequent call to Next()
+// returns the first row.
+func (r *RepeatableRowSource) Reset() {
+	r.nextRowIdx = 0
+}
+
+// ConsumerDone is part of the RowSource interface.
+func (r *RepeatableRowSource) ConsumerDone() {}
+
+// ConsumerClosed is part of the RowSource interface.
+func (r *RepeatableRowSource) ConsumerClosed() {}
+
+// RowDisposer is a RowReceiver that discards any rows Push()ed.
+type RowDisposer struct{}
+
+var _ RowReceiver = &RowDisposer{}
+
+// Push is part of the RowReceiver interface.
+func (r *RowDisposer) Push(row sqlbase.EncDatumRow, meta ProducerMetadata) ConsumerStatus {
+	return NeedMoreRows
+}
+
+// ProducerDone is part of the RowReceiver interface.
+func (r *RowDisposer) ProducerDone() {}


### PR DESCRIPTION
I think it's a good idea to start tracking the running times of processor implementations so here are some initial benchmarks for the Sorter (only SortAll and Limit for now) that show what this would look like. All processors should have these in the long term.

The other commit introduces a `RowReceiver/RowSource` that is useful for benchmarks because once all its rows are consumed, it starts again from the beginning. It also acts as a sink that throws away any input.

```
$ make bench PKG=./pkg/sql/distsqlrun BENCHES=BenchmarkSort
BenchmarkSortAll/InputSize0-8         	  300000	      4070 ns/op
BenchmarkSortAll/InputSize1-8         	  300000	      5426 ns/op
BenchmarkSortAll/InputSize2-8         	  200000	      5902 ns/op
BenchmarkSortAll/InputSize4-8         	  200000	      6837 ns/op
BenchmarkSortAll/InputSize8-8         	  200000	      8087 ns/op
BenchmarkSortAll/InputSize16-8        	  100000	     12839 ns/op
BenchmarkSortAll/InputSize32-8        	  100000	     22252 ns/op
BenchmarkSortAll/InputSize64-8        	   30000	     43094 ns/op
BenchmarkSortAll/InputSize128-8       	   20000	     88813 ns/op
BenchmarkSortLimit/Limit0-8           	   20000	     87563 ns/op
BenchmarkSortLimit/Limit1-8           	  100000	     12964 ns/op
BenchmarkSortLimit/Limit2-8           	  100000	     13390 ns/op
BenchmarkSortLimit/Limit4-8           	  100000	     15098 ns/op
BenchmarkSortLimit/Limit8-8           	  100000	     19218 ns/op
BenchmarkSortLimit/Limit16-8          	   50000	     26267 ns/op
BenchmarkSortLimit/Limit32-8          	   30000	     43182 ns/op
BenchmarkSortLimit/Limit64-8          	   20000	     63152 ns/op
BenchmarkSortLimit/Limit128-8         	   20000	     70387 ns/op
```

Note some potential weirdness that this has uncovered: sorting a 128-row input with no limit takes `17000 ns` longer than sorting a 128-row input with a limit of 128. I haven't found anything at first glance (nothing should be different in the implementations since we never construct a max-heap in the latter case)

@cuongdo 