### PR TITLE
server: Minor debuggability improvements

### DIFF
--- a/pkg/storage/replica_range_lease.go
+++ b/pkg/storage/replica_range_lease.go
@@ -352,6 +352,9 @@ func (r *Replica) leaseStatus(
 			// If lease validity can't be determined (e.g. gossip is down
 			// and liveness info isn't available for owner), we can neither
 			// use the lease nor do we want to attempt to acquire it.
+			if err != nil {
+				log.Warningf(context.TODO(), "can't determine lease status due to node liveness error: %s", err)
+			}
 			status.state = leaseError
 			return status
 		}


### PR DESCRIPTION
**storage: Log if we can't get lease status due to node liveness error**

**server: Don't break debug pages when system config isn't available**

This fixes the following pages to work even when the system config isn't
available yet:
/_status/raft
/_status/ranges/<node>
/debug/range
/debug/problemranges

These changes helped while debugging #16268