### PR TITLE
rpc: Enable snappy compression by default

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -82,7 +82,7 @@ var SourceAddr = func() net.Addr {
 	return nil
 }()
 
-var enableRPCCompression = envutil.EnvOrDefaultBool("COCKROACH_ENABLE_RPC_COMPRESSION", false)
+var enableRPCCompression = envutil.EnvOrDefaultBool("COCKROACH_ENABLE_RPC_COMPRESSION", true)
 
 // NewServer is a thin wrapper around grpc.NewServer that registers a heartbeat
 // service.

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -235,7 +235,8 @@ func TestHeartbeatHealthTransport(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s := grpc.NewServer(grpc.Creds(credentials.NewTLS(tlsConfig)))
+	s := grpc.NewServer(
+		grpc.RPCDecompressor(snappyDecompressor{}), grpc.Creds(credentials.NewTLS(tlsConfig)))
 	ln, err := net.Listen("tcp", util.TestAddr.String())
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This will be safe during rolling upgrades because the snappy
decompressor was included in v1.0.

#14721