### PR TITLE
sql: have a memory account for prepared statements

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -474,6 +474,14 @@ func (e *Executor) Prepare(
 	planner.semaCtx.Placeholders.SetTypes(pinfo)
 	planner.evalCtx.PrepareOnly = true
 
+	// We need a memory account available in order to prepare a statement, since we
+	// might need to allocate memory for constant-folded values in the process of
+	// planning it. We close the account while still storing the statement though,
+	// so we undercount memory here.
+	constantMemAcc := planner.evalCtx.Mon.MakeBoundAccount()
+	planner.evalCtx.ActiveMemAcc = &constantMemAcc
+	defer constantMemAcc.Close(session.Ctx())
+
 	if protoTS != nil {
 		planner.avoidCachedDescriptors = true
 		txn.SetFixedTimestamp(*protoTS)

--- a/pkg/sql/testdata/logic_test/prepare
+++ b/pkg/sql/testdata/logic_test/prepare
@@ -229,3 +229,8 @@ SELECT * FROM f
 ----
 1 2 NULL
 2 3 NULL
+
+# Ensure that we have a memory monitor for preparing statements
+
+statement
+PREPARE z AS SELECT UPPER('a')


### PR DESCRIPTION
It's not ideal that we have to construct the account for folded values
in two different places (the one that was added here and in
execStmtInOpenTxn) but I can't think of a common place to put the
creation/assignment of this account such that it would still have the
appropriate lifetime for the non-prepared case.