### PR TITLE
pkg/sql: group by mutation bugfix

### DIFF
--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -139,7 +139,6 @@ func (p *planner) groupBy(
 		if err != nil {
 			return nil, nil, err
 		}
-		n.Having.Expr = typedHaving
 	}
 
 	group := &groupNode{

--- a/pkg/sql/testdata/logic_test/prepare
+++ b/pkg/sql/testdata/logic_test/prepare
@@ -234,3 +234,14 @@ SELECT * FROM f
 
 statement
 PREPARE z AS SELECT UPPER('a')
+
+# Ensure that GROUP BY HAVING doesn't mutate the parsed AST (#16388)
+statement
+CREATE TABLE foo (a int)
+
+statement
+PREPARE groupbyhaving AS SELECT min(1) FROM foo WHERE a = $1 GROUP BY a HAVING count(a) = 0
+
+query I
+EXECUTE groupbyhaving(1)
+----


### PR DESCRIPTION
Previously, the `GROUP BY` planner would erroneously store the typed
version of its `HAVING` clause back on its original parsed AST. It's
invalid to mutate the original parsed AST.

Updates #16388.