### PR TITLE
build: shard testrace for faster CI builds

### DIFF
--- a/build/teamcity-testlogicrace.sh
+++ b/build/teamcity-testlogicrace.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+export BUILDER_HIDE_GOPATH_SRC=1
+
+mkdir -p artifacts
+
+build/builder.sh env \
+	make testrace \
+	PKG=./pkg/sql/logictest \
+	TESTFLAGS='-v' \
+	2>&1 \
+	| tee artifacts/testrace.log \
+	| go-test-teamcity

--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -12,8 +12,9 @@ build/builder.sh env \
 	TARGET=stressrace \
 	github-pull-request-make
 
-build/builder.sh env \
+build/builder.sh \
 	make testrace \
+	PKG="$(go list ./pkg/... | grep -Fv github.com/cockroachdb/cockroach/pkg/sql/logictest | tr '\n' ' ')" \
 	TESTFLAGS='-v' \
 	2>&1 \
 	| tee artifacts/testrace.log \


### PR DESCRIPTION
Split out SQL logic tests from the main testrace build; they're by far
the slowest part.

---

Just an experiment for now.