### PR TITLE
sql: row fetcher optimizations

### DIFF
--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
@@ -61,9 +62,8 @@ type RowFetcher struct {
 	// schema changes.
 	cols []ColumnDescriptor
 
-	// For each column in cols, indicates if the value is needed (used as an
-	// optimization when the upper layer doesn't need all values).
-	valNeededForCol []bool
+	// The set of ColumnIDs that are required.
+	neededCols util.FastIntSet
 
 	// Map used to get the index for columns in cols.
 	colIdxMap map[ColumnID]int
@@ -117,11 +117,23 @@ func (rf *RowFetcher) Init(
 	rf.reverse = reverse
 	rf.isSecondaryIndex = isSecondaryIndex
 	rf.cols = cols
-	// rf.valNeededForCol is modified below.
-	rf.valNeededForCol = append([]bool(nil), valNeededForCol...)
 	rf.returnRangeInfo = returnRangeInfo
 	rf.row = make([]EncDatum, len(rf.cols))
 	rf.decodedRow = make([]parser.Datum, len(rf.cols))
+
+	for i, v := range valNeededForCol {
+		if !v {
+			continue
+		}
+		// The i-th column is required. Search the colIdxMap to find the
+		// corresponding ColumnID.
+		for col, idx := range colIdxMap {
+			if idx == i {
+				rf.neededCols.Add(uint32(col))
+				break
+			}
+		}
+	}
 
 	var indexColumnIDs []ColumnID
 	indexColumnIDs, rf.indexColumnDirs = index.FullColumnIDs()
@@ -130,18 +142,18 @@ func (rf *RowFetcher) Init(
 	for i, id := range indexColumnIDs {
 		rf.indexColIdx[i] = rf.colIdxMap[id]
 	}
-	// Add composite key columns to valNeededForCol so that, like other key
+	// Add composite key columns to neededCols so that, like other key
 	// columns, their values are decoded.
 	for _, id := range index.CompositeColumnIDs {
-		if idx, ok := colIdxMap[id]; ok {
-			rf.valNeededForCol[idx] = true
+		if _, ok := colIdxMap[id]; ok {
+			rf.neededCols.Add(uint32(id))
 		}
 	}
 
 	if isSecondaryIndex {
-		for i, needed := range valNeededForCol {
-			if needed && !index.ContainsColumnID(rf.cols[i].ID) {
-				return errors.Errorf("requested column %s not in index", rf.cols[i].Name)
+		for i := range rf.cols {
+			if rf.neededCols.Contains(uint32(rf.cols[i].ID)) && !index.ContainsColumnID(rf.cols[i].ID) {
+				return fmt.Errorf("requested column %s not in index", rf.cols[i].Name)
 			}
 		}
 	}
@@ -347,8 +359,8 @@ func (rf *RowFetcher) ProcessKV(
 				return "", "", err
 			}
 			for i, id := range rf.index.ExtraColumnIDs {
-				if idx, ok := rf.colIdxMap[id]; ok && rf.valNeededForCol[idx] {
-					rf.row[idx] = rf.extraVals[i]
+				if rf.neededCols.Contains(uint32(id)) {
+					rf.row[rf.colIdxMap[id]] = rf.extraVals[i]
 				}
 			}
 			if debugStrings {
@@ -403,39 +415,40 @@ func (rf *RowFetcher) processValueSingle(
 		return "", "", errors.Errorf("single entry value with no default column id")
 	}
 
-	idx, ok := rf.colIdxMap[colID]
-	if ok && (debugStrings || rf.valNeededForCol[idx]) {
-		if debugStrings {
-			prettyKey = fmt.Sprintf("%s/%s", prettyKey, rf.desc.Columns[idx].Name)
-		}
-		typ := rf.cols[idx].Type
-		// TODO(arjun): The value is a directly marshaled single value, so we
-		// unmarshal it eagerly here. This can potentially be optimized out,
-		// although that would require changing UnmarshalColumnValue to operate
-		// on bytes, and for Encode/DecodeTableValue to operate on marshaled
-		// single values.
-		value, err := UnmarshalColumnValue(&rf.alloc, typ, kv.Value)
-		if err != nil {
-			return "", "", err
-		}
-		if debugStrings {
-			prettyValue = value.String()
-		}
-		if !rf.row[idx].IsUnset() {
-			panic(fmt.Sprintf("duplicate value for column %d", idx))
-		}
-		rf.row[idx] = DatumToEncDatum(typ, value)
-		if log.V(3) {
-			log.Infof(context.TODO(), "Scan %s -> %v", kv.Key, value)
-		}
-	} else {
-		// No need to unmarshal the column value. Either the column was part of
-		// the index key or it isn't needed.
-		if log.V(3) {
-			log.Infof(context.TODO(), "Scan %s -> [%d] (skipped)", kv.Key, colID)
+	if debugStrings || rf.neededCols.Contains(uint32(colID)) {
+		if idx, ok := rf.colIdxMap[colID]; ok {
+			if debugStrings {
+				prettyKey = fmt.Sprintf("%s/%s", prettyKey, rf.desc.Columns[idx].Name)
+			}
+			typ := rf.cols[idx].Type
+			// TODO(arjun): The value is a directly marshaled single value, so we
+			// unmarshal it eagerly here. This can potentially be optimized out,
+			// although that would require changing UnmarshalColumnValue to operate
+			// on bytes, and for Encode/DecodeTableValue to operate on marshaled
+			// single values.
+			value, err := UnmarshalColumnValue(&rf.alloc, typ, kv.Value)
+			if err != nil {
+				return "", "", err
+			}
+			if debugStrings {
+				prettyValue = value.String()
+			}
+			if !rf.row[idx].IsUnset() {
+				panic(fmt.Sprintf("duplicate value for column %d", idx))
+			}
+			rf.row[idx] = DatumToEncDatum(typ, value)
+			if log.V(3) {
+				log.Infof(context.TODO(), "Scan %s -> %v", kv.Key, value)
+			}
+			return prettyKey, prettyValue, nil
 		}
 	}
 
+	// No need to unmarshal the column value. Either the column was part of
+	// the index key or it isn't needed.
+	if log.V(3) {
+		log.Infof(context.TODO(), "Scan %s -> [%d] (skipped)", kv.Key, colID)
+	}
 	return prettyKey, prettyValue, nil
 }
 
@@ -456,8 +469,7 @@ func (rf *RowFetcher) processValueBytes(
 		}
 		colID := lastColID + ColumnID(colIDDiff)
 		lastColID = colID
-		idx, ok := rf.colIdxMap[colID]
-		if !ok || !rf.valNeededForCol[idx] {
+		if !rf.neededCols.Contains(uint32(colID)) {
 			// This column wasn't requested, so read its length and skip it.
 			_, len, err := encoding.PeekValueLength(bytes)
 			if err != nil {
@@ -469,6 +481,7 @@ func (rf *RowFetcher) processValueBytes(
 			}
 			continue
 		}
+		idx := rf.colIdxMap[colID]
 
 		if debugStrings {
 			prettyKey = fmt.Sprintf("%s/%s", prettyKey, rf.desc.Columns[idx].Name)
@@ -589,13 +602,13 @@ func (rf *RowFetcher) NextKeyDebug(
 
 func (rf *RowFetcher) finalizeRow() {
 	// Fill in any missing values with NULLs
-	for i, col := range rf.cols {
-		if rf.valNeededForCol[i] && rf.row[i].IsUnset() {
-			if !col.Nullable {
+	for i := range rf.cols {
+		if rf.neededCols.Contains(uint32(rf.cols[i].ID)) && rf.row[i].IsUnset() {
+			if !rf.cols[i].Nullable {
 				panic("Non-nullable column with no value!")
 			}
 			rf.row[i] = EncDatum{
-				Type:  col.Type,
+				Type:  rf.cols[i].Type,
 				Datum: parser.DNull,
 			}
 		}

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -99,6 +99,10 @@ type RowFetcher struct {
 	alloc DatumAlloc
 }
 
+// debugRowFetch can be used to turn on some low-level debugging logs. We use
+// this to avoid using log.V in the hot path.
+const debugRowFetch = false
+
 // Init sets up a RowFetcher for a given table and index. If we are using a
 // non-primary index, valNeededForCol can only be true for the columns in the
 // index.
@@ -368,7 +372,7 @@ func (rf *RowFetcher) ProcessKV(
 			}
 		}
 
-		if log.V(2) {
+		if debugRowFetch {
 			if rf.extraVals != nil {
 				log.Infof(context.TODO(), "Scan %s -> %s", kv.Key, prettyEncDatums(rf.extraVals))
 			} else {
@@ -437,7 +441,7 @@ func (rf *RowFetcher) processValueSingle(
 				panic(fmt.Sprintf("duplicate value for column %d", idx))
 			}
 			rf.row[idx] = DatumToEncDatum(typ, value)
-			if log.V(3) {
+			if debugRowFetch {
 				log.Infof(context.TODO(), "Scan %s -> %v", kv.Key, value)
 			}
 			return prettyKey, prettyValue, nil
@@ -446,7 +450,7 @@ func (rf *RowFetcher) processValueSingle(
 
 	// No need to unmarshal the column value. Either the column was part of
 	// the index key or it isn't needed.
-	if log.V(3) {
+	if debugRowFetch {
 		log.Infof(context.TODO(), "Scan %s -> [%d] (skipped)", kv.Key, colID)
 	}
 	return prettyKey, prettyValue, nil
@@ -476,7 +480,7 @@ func (rf *RowFetcher) processValueBytes(
 				return "", "", err
 			}
 			bytes = bytes[len:]
-			if log.V(3) {
+			if debugRowFetch {
 				log.Infof(context.TODO(), "Scan %s -> [%d] (skipped)", kv.Key, colID)
 			}
 			continue
@@ -504,7 +508,7 @@ func (rf *RowFetcher) processValueBytes(
 			panic(fmt.Sprintf("duplicate value for column %d", idx))
 		}
 		rf.row[idx] = encValue
-		if log.V(3) {
+		if debugRowFetch {
 			log.Infof(context.TODO(), "Scan %d -> %v", idx, encValue)
 		}
 	}

--- a/pkg/util/fast_int_set.go
+++ b/pkg/util/fast_int_set.go
@@ -1,0 +1,102 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package util
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// FastIntSet keeps track of a set of integers. It is very fast when the values
+// are small. It is not thread-safe.
+type FastIntSet struct {
+	smallVals uint64
+	largeVals map[uint32]struct{}
+}
+
+// We store bits for values smaller than this cutoff.
+const smallValCutoff = 64
+
+// Add adds a value to the set. No-op if the value is already in the set.
+func (s *FastIntSet) Add(i uint32) {
+	if i < smallValCutoff {
+		s.smallVals |= (1 << uint64(i))
+	} else {
+		if s.largeVals == nil {
+			s.largeVals = make(map[uint32]struct{})
+		}
+		s.largeVals[i] = struct{}{}
+	}
+}
+
+// Remove removes a value from the set. No-op if the value is not in the set.
+func (s *FastIntSet) Remove(i uint32) {
+	if i < smallValCutoff {
+		s.smallVals &= ^(1 << uint64(i))
+	} else {
+		delete(s.largeVals, i)
+	}
+}
+
+// Contains returns true if the set contains the value.
+func (s *FastIntSet) Contains(i uint32) bool {
+	if i < smallValCutoff {
+		return (s.smallVals & (1 << uint64(i))) != 0
+	}
+	_, ok := s.largeVals[i]
+	return ok
+}
+
+// Empty returns true if the set is empty.
+func (s *FastIntSet) Empty() bool {
+	return s.smallVals == 0 && len(s.largeVals) == 0
+}
+
+// ForEach calls a function for each value in the set (in arbitrary order).
+func (s *FastIntSet) ForEach(f func(i uint32)) {
+	if s.smallVals != 0 {
+		for i := uint32(0); i < smallValCutoff; i++ {
+			if (s.smallVals & (1 << uint64(i))) != 0 {
+				f(i)
+			} else {
+				// See if we can skip 8 bytes at a time
+				if (s.smallVals & (0xFF << uint64(i))) == 0 {
+					i += 7
+				}
+			}
+		}
+	}
+	for v := range s.largeVals {
+		f(v)
+	}
+}
+
+func (s *FastIntSet) String() string {
+	var buf bytes.Buffer
+	buf.WriteByte('(')
+	first := true
+	s.ForEach(func(i uint32) {
+		if first {
+			first = false
+		} else {
+			buf.WriteByte(',')
+		}
+		fmt.Fprintf(&buf, "%d", i)
+	})
+	buf.WriteByte(')')
+	return buf.String()
+}

--- a/pkg/util/fast_int_set_test.go
+++ b/pkg/util/fast_int_set_test.go
@@ -1,0 +1,49 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package util
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestFastIntSet(t *testing.T) {
+	const m = 2 * smallValCutoff
+	in := make([]bool, m)
+
+	var s FastIntSet
+	for i := 0; i < 1000; i++ {
+		v := uint32(rand.Intn(m))
+		if rand.Intn(2) == 0 {
+			in[v] = true
+			s.Add(v)
+		} else {
+			in[v] = false
+			s.Remove(v)
+		}
+		empty := true
+		for j := uint32(0); j < m; j++ {
+			empty = empty && !in[j]
+			if in[j] != s.Contains(j) {
+				t.Fatalf("incorrect result for Contains(%d), expected %t", j, in[j])
+			}
+		}
+		if empty != s.Empty() {
+			t.Fatalf("incorrect result for Empty(), expected %t", empty)
+		}
+	}
+}


### PR DESCRIPTION
### sql: optimize the rowfetcher per-column overhead for unneeded columns

In a profile of a TPC-H `COUNT(*)` (single node), 7-9% was the map lookup of
column IDs. This lookup happens even for columns that are not needed.

Optimizing this by implementing a `FastIntSet` primitive which uses bits for
small IDs. We now store the needed column IDs in a `FastIntSet` which we can
consult first.

This shaved a couple of seconds from the query (21-22s to 18-19s).

### sql: remove row fetcher overhead due to log.V

In the profile of a large `COUNT(*)` query, the `log.V` calls in `RowFetcher`
add up to about 4%. Changing these to depend on a constant flag so they are left
out of normal builds.