### PR TITLE
storage: provided locking for RaftMessageResponseStream

### DIFF
--- a/pkg/storage/raft_transport.go
+++ b/pkg/storage/raft_transport.go
@@ -64,6 +64,21 @@ type RaftMessageResponseStream interface {
 	Send(*RaftMessageResponse) error
 }
 
+// lockedRaftMessageResponseStream is an implementation of
+// RaftMessageResponseStream which provides support for concurrent calls to
+// Send. Note that the default implementation of grpc.Stream for server
+// responses (grpc.serverStream) is not safe for concurrent calls to Send.
+type lockedRaftMessageResponseStream struct {
+	MultiRaft_RaftMessageBatchServer
+	sendMu syncutil.Mutex
+}
+
+func (s *lockedRaftMessageResponseStream) Send(resp *RaftMessageResponse) error {
+	s.sendMu.Lock()
+	defer s.sendMu.Unlock()
+	return s.MultiRaft_RaftMessageBatchServer.Send(resp)
+}
+
 // SnapshotResponseStream is the subset of the
 // MultiRaft_RaftSnapshotServer interface that is needed for sending responses.
 type SnapshotResponseStream interface {
@@ -296,6 +311,7 @@ func (t *RaftTransport) RaftMessageBatch(stream MultiRaft_RaftMessageBatchServer
 		t.rpcContext.Stopper.RunWorker(ctx, func(ctx context.Context) {
 			errCh <- func() error {
 				var stats *raftTransportStats
+				stream := &lockedRaftMessageResponseStream{MultiRaft_RaftMessageBatchServer: stream}
 				for {
 					batch, err := stream.Recv()
 					if err != nil {


### PR DESCRIPTION
grpc.Stream.Send() is not goroutine-safe, but we call it from 2
goroutines during RaftMessageBatch error handling. Add
lockedRaftMessageResponseStream which provides support for concurrent
calls to Send.

Fixes #16435