### PR TITLE
sql: changed LeaseManager API to return/use table descriptors

### DIFF
--- a/pkg/internal/client/db_test.go
+++ b/pkg/internal/client/db_test.go
@@ -389,7 +389,6 @@ func TestCommonMethods(t *testing.T) {
 		{txnType, "IsFinalized"}:                     {},
 		{txnType, "NewBatch"}:                        {},
 		{txnType, "Exec"}:                            {},
-		{txnType, "GetDeadline"}:                     {},
 		{txnType, "ResetDeadline"}:                   {},
 		{txnType, "Run"}:                             {},
 		{txnType, "SetDebugName"}:                    {},

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -523,11 +523,6 @@ func (txn *Txn) ResetDeadline() {
 	txn.deadline = nil
 }
 
-// GetDeadline returns the deadline. For testing.
-func (txn *Txn) GetDeadline() *hlc.Timestamp {
-	return txn.deadline
-}
-
 // Rollback sends an EndTransactionRequest with Commit=false.
 // txn is considered finalized and cannot be used to send any more commands.
 func (txn *Txn) Rollback(ctx context.Context) error {

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -448,7 +448,7 @@ func (p *planner) getTableScanByRef(
 	scanVisibility scanVisibility,
 ) (planDataSource, error) {
 	tableID := sqlbase.ID(tref.TableID)
-	descFunc := p.session.leases.getTableLeaseByID
+	descFunc := p.session.tables.getTableVersionByID
 	if p.avoidCachedDescriptors {
 		descFunc = sqlbase.GetTableDescFromID
 	}
@@ -492,7 +492,7 @@ func (p *planner) getTableScanOrViewPlan(
 		desc, err = mustGetTableOrViewDesc(
 			ctx, p.txn, p.getVirtualTabler(), tn, false /*allowAdding*/)
 	} else {
-		desc, err = p.session.leases.getTableLease(ctx, p.txn, p.getVirtualTabler(), tn)
+		desc, err = p.session.tables.getTableVersion(ctx, p.txn, p.getVirtualTabler(), tn)
 	}
 	if err != nil {
 		return planDataSource{}, err

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -894,7 +894,7 @@ func (e *Executor) execParsed(
 			// Exec the schema changers (if the txn rolled back, the schema changers
 			// will short-circuit because the corresponding descriptor mutation is not
 			// found).
-			session.leases.releaseLeases(session.Ctx())
+			session.tables.releaseTables(session.Ctx())
 			txnState.schemaChangers.execSchemaChanges(session.Ctx(), e, session, res.ResultList)
 		}
 

--- a/pkg/sql/executor_test.go
+++ b/pkg/sql/executor_test.go
@@ -77,7 +77,7 @@ func TestPrepareCanAcquireLeases(t *testing.T) {
 
 				// Acquire a lease and assert that the store did in fact create a
 				// new lease.
-				_, err := s.LeaseManager().(*LeaseManager).Acquire(
+				_, _, err := s.LeaseManager().(*LeaseManager).Acquire(
 					ctx, planner.txn, sqlbase.ID(dummyTableID), 0 /* version */)
 				if err != nil {
 					return nil, err

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -45,7 +45,7 @@ func (ie InternalExecutor) ExecuteStatementInTransaction(
 ) (int, error) {
 	p := makeInternalPlanner(opName, txn, security.RootUser, ie.LeaseManager.memMetrics)
 	defer finishInternalPlanner(p)
-	p.session.leases.leaseMgr = ie.LeaseManager
+	p.session.tables.leaseMgr = ie.LeaseManager
 	return p.exec(ctx, statement, qargs...)
 }
 
@@ -57,7 +57,7 @@ func (ie InternalExecutor) QueryRowInTransaction(
 ) (parser.Datums, error) {
 	p := makeInternalPlanner(opName, txn, security.RootUser, ie.LeaseManager.memMetrics)
 	defer finishInternalPlanner(p)
-	p.session.leases.leaseMgr = ie.LeaseManager
+	p.session.tables.leaseMgr = ie.LeaseManager
 	return p.QueryRow(ctx, statement, qargs...)
 }
 
@@ -68,7 +68,7 @@ func (ie InternalExecutor) GetTableSpan(
 	// Lookup the table ID.
 	p := makeInternalPlanner("get-table-span", txn, user, ie.LeaseManager.memMetrics)
 	defer finishInternalPlanner(p)
-	p.session.leases.leaseMgr = ie.LeaseManager
+	p.session.tables.leaseMgr = ie.LeaseManager
 
 	tn := parser.TableName{DatabaseName: parser.Name(dbName), TableName: parser.Name(tableName)}
 	tableID, err := getTableID(ctx, p, &tn)
@@ -97,7 +97,7 @@ func getTableID(ctx context.Context, p *planner, tn *parser.TableName) (sqlbase.
 		return virtual.GetID(), nil
 	}
 
-	dbID, err := p.session.leases.databaseCache.getDatabaseID(ctx, p.txn, p.getVirtualTabler(), tn.Database())
+	dbID, err := p.session.tables.databaseCache.getDatabaseID(ctx, p.txn, p.getVirtualTabler(), tn.Database())
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -1298,20 +1298,3 @@ func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *client.DB, gossip *gos
 		}
 	})
 }
-
-// TableCollection is a collection of tables held by a single session that
-// serves SQL requests, or a background job using a table descriptor.
-type TableCollection struct {
-	timestamp hlc.Timestamp
-	// A collection of table descriptor valid for the timestamp.
-	// They are released once the transaction using them is complete.
-	// If the transaction gets pushed and the timestamp changes,
-	// the tables are released.
-	tables []sqlbase.TableDescriptor
-	// leaseMgr manages acquiring and releasing per-table leases.
-	leaseMgr *LeaseManager
-	// databaseCache is used as a cache for database names.
-	// TODO(andrei): get rid of it and replace it with a leasing system for
-	// database descriptors.
-	databaseCache *databaseCache
-}

--- a/pkg/sql/parallel_stmts_test.go
+++ b/pkg/sql/parallel_stmts_test.go
@@ -313,7 +313,7 @@ func planNodeForQuery(
 	txn := client.NewTxn(kvDB)
 	txn.Proto().OrigTimestamp = s.Clock().Now()
 	p := makeInternalPlanner("plan", txn, security.RootUser, &MemoryMetrics{})
-	p.session.leases.leaseMgr = s.LeaseManager().(*LeaseManager)
+	p.session.tables.leaseMgr = s.LeaseManager().(*LeaseManager)
 	p.session.Database = "test"
 
 	stmts, err := p.parser.Parse(sql)

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -437,6 +437,7 @@ func TestPGPrepareFail(t *testing.T) {
 // transaction.
 func TestPGPrepareWithCreateDropInTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.TODO())
 

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -98,7 +98,7 @@ func makeInternalPlanner(
 		User:     user,
 		TxnState: txnState{Ctx: ctx},
 		context:  ctx,
-		leases:   LeaseCollection{databaseCache: newDatabaseCache(config.SystemConfig{})},
+		tables:   TableCollection{databaseCache: newDatabaseCache(config.SystemConfig{})},
 	}
 
 	s.mon = mon.MakeUnlimitedMonitor(ctx,
@@ -144,7 +144,7 @@ func (p *planner) ExecCfg() *ExecutorConfig {
 }
 
 func (p *planner) LeaseMgr() *LeaseManager {
-	return p.session.leases.leaseMgr
+	return p.session.tables.leaseMgr
 }
 
 func (p *planner) User() string {
@@ -261,7 +261,7 @@ func (p *planner) exec(ctx context.Context, sql string, args ...interface{}) (in
 
 func (p *planner) fillFKTableMap(ctx context.Context, m sqlbase.TableLookupsByID) error {
 	for tableID := range m {
-		table, err := p.session.leases.getTableLeaseByID(ctx, p.txn, tableID)
+		table, err := p.session.tables.getTableVersionByID(ctx, p.txn, tableID)
 		if err == errTableAdding {
 			m[tableID] = sqlbase.TableLookup{IsAdding: true}
 			continue

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -1272,11 +1272,11 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 		// Grab a lease at the latest version so that we are confident
 		// that all future leases will be taken at the latest version.
 		if err := kvDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-			lease, err := leaseMgr.Acquire(ctx, txn, id, version+1)
+			table, _, err := leaseMgr.Acquire(ctx, txn, id, version+1)
 			if err != nil {
 				return err
 			}
-			return leaseMgr.Release(lease)
+			return leaseMgr.Release(table)
 		}); err != nil {
 			t.Error(err)
 		}

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -625,19 +625,6 @@ func (s *Session) resetForBatch(e *Executor) {
 	s.TxnState.schemaChangers.curGroupNum++
 }
 
-// releaseTables releases all tables currently held by the Session.
-func (tc *TableCollection) releaseTables(ctx context.Context) {
-	if tc.tables != nil {
-		log.VEventf(ctx, 2, "releasing %d tables", len(tc.tables))
-		for _, table := range tc.tables {
-			if err := tc.leaseMgr.Release(table); err != nil {
-				log.Warning(ctx, err)
-			}
-		}
-		tc.tables = nil
-	}
-}
-
 // setTestingVerifyMetadata sets a callback to be called after the Session
 // is done executing the current SQL statement. It can be used to verify
 // assumptions about how metadata will be asynchronously updated.

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -285,7 +285,7 @@ type Session struct {
 
 	Tracing SessionTracing
 
-	leases LeaseCollection
+	tables TableCollection
 
 	// If set, contains the in progress COPY FROM columns.
 	copyFrom *copyNode
@@ -422,7 +422,7 @@ func NewSession(
 			applicationName: args.ApplicationName,
 			database:        args.Database,
 		},
-		leases: LeaseCollection{
+		tables: TableCollection{
 			leaseMgr:      e.cfg.LeaseManager,
 			databaseCache: e.getDatabaseCache(),
 		},
@@ -494,10 +494,10 @@ func (s *Session) Finish(e *Executor) {
 		s.TxnState.finishSQLTxn(s)
 	}
 
-	// Cleanup leases. We might have unreleased leases if we're finishing the
+	// We might have unreleased tables if we're finishing the
 	// session abruptly in the middle of a transaction, or, until #7648 is
 	// addressed, there might be leases accumulated by preparing statements.
-	s.leases.releaseLeases(s.context)
+	s.tables.releaseTables(s.context)
 
 	s.ClearStatementsAndPortals(s.context)
 	s.sessionMon.Stop(s.context)
@@ -535,7 +535,7 @@ func (s *Session) EmergencyClose() {
 	_ = s.parallelizeQueue.Wait()
 
 	// Release the leases - to ensure other sessions don't get stuck.
-	s.leases.releaseLeases(s.context)
+	s.tables.releaseTables(s.context)
 
 	// The KV txn may be unusable - just leave it dead. Simply
 	// shut down its memory monitor.
@@ -621,22 +621,20 @@ func (s *Session) evalCtx() parser.EvalContext {
 func (s *Session) resetForBatch(e *Executor) {
 	// Update the database cache to a more recent copy, so that we can use tables
 	// that we created in previous batches of the same transaction.
-	s.leases.databaseCache = e.getDatabaseCache()
+	s.tables.databaseCache = e.getDatabaseCache()
 	s.TxnState.schemaChangers.curGroupNum++
 }
 
-// releaseLeases releases all leases currently held by the Session.
-func (lc *LeaseCollection) releaseLeases(ctx context.Context) {
-	if lc.leases != nil {
-		if log.V(2) {
-			log.VEventf(ctx, 2, "releasing %d leases", len(lc.leases))
-		}
-		for _, lease := range lc.leases {
-			if err := lc.leaseMgr.Release(lease); err != nil {
+// releaseTables releases all tables currently held by the Session.
+func (tc *TableCollection) releaseTables(ctx context.Context) {
+	if tc.tables != nil {
+		log.VEventf(ctx, 2, "releasing %d tables", len(tc.tables))
+		for _, table := range tc.tables {
+			if err := tc.leaseMgr.Release(table); err != nil {
 				log.Warning(ctx, err)
 			}
 		}
-		lc.leases = nil
+		tc.tables = nil
 	}
 }
 
@@ -1013,7 +1011,7 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 	ctx context.Context, e *Executor, session *Session, results ResultList,
 ) {
 	// Release the leases once a transaction is complete.
-	session.leases.releaseLeases(ctx)
+	session.tables.releaseTables(ctx)
 	if e.cfg.SchemaChangerTestingKnobs.SyncFilter != nil {
 		e.cfg.SchemaChangerTestingKnobs.SyncFilter(TestingSchemaChangerCollection{scc})
 	}

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -427,7 +427,7 @@ func (p *planner) showCreateTable(
 	buf.WriteString(primary)
 	for _, idx := range desc.Indexes {
 		if fk := idx.ForeignKey; fk.IsSet() {
-			fkTable, err := p.session.leases.getTableLeaseByID(ctx, p.txn, fk.Table)
+			fkTable, err := p.session.tables.getTableVersionByID(ctx, p.txn, fk.Table)
 			if err != nil {
 				return "", err
 			}

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -176,7 +176,7 @@ func (n *showFingerprintsNode) Next(ctx context.Context) (bool, error) {
 		// need to set `avoidCachedDescriptors`.
 		p := makeInternalPlanner("SELECT", txn, security.RootUser, n.p.LeaseMgr().memMetrics)
 		defer finishInternalPlanner(p)
-		p.session.leases.leaseMgr = n.p.LeaseMgr()
+		p.session.tables.leaseMgr = n.p.LeaseMgr()
 		p.avoidCachedDescriptors = true
 
 		var err error

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -71,6 +71,12 @@ func GetKeysForTableDescriptor(
 	return
 }
 
+// A unique id for a particular table descriptor version.
+type tableVersionID struct {
+	id      sqlbase.ID
+	version sqlbase.DescriptorVersion
+}
+
 // SchemaAccessor provides helper methods for using the SQL schema.
 type SchemaAccessor interface {
 	// NB: one can use GetTableDescFromID() to retrieve a descriptor for
@@ -233,9 +239,27 @@ func filterTableState(tableDesc *sqlbase.TableDescriptor) error {
 	return nil
 }
 
-// getTableLease acquires a lease for the specified table. The lease must
-// be released by calling lc.releaseLeases().
-func (lc *LeaseCollection) getTableLease(
+func (tc *TableCollection) maybeChangeTimestamp(ctx context.Context, txn *client.Txn) {
+	if tc.timestamp != (hlc.Timestamp{}) && tc.timestamp != txn.OrigTimestamp() {
+		txn.ResetDeadline()
+		tc.releaseTables(ctx)
+	}
+}
+
+// getTableVersion returns a table descriptor with a version suitable for
+// the transaction. The table must be released by calling tc.releaseTables().
+//
+// TODO(vivek): The suitability of the table version returned is only partial
+// checked. The expiration time for the table descriptor is added as a deadline
+// for the transaction. The ModificationTime of the table is not compared to the
+// timestamp of the transaction. Fix this to be such that:
+// table.ModificationTime <= txn.Timestamp < expirationTime
+//
+// TODO(vivek): Rollback most of #6418. #6418 introduced a transaction deadline
+// that is enforced at the KV layer, and was introduced to manager the validity
+// window of a table descriptor. Since we will be checking for the valid use
+// of a table descriptor here, we do not need the extra check at the KV layer.
+func (tc *TableCollection) getTableVersion(
 	ctx context.Context, txn *client.Txn, vt VirtualTabler, tn *parser.TableName,
 ) (*sqlbase.TableDescriptor, error) {
 	if log.V(2) {
@@ -260,56 +284,55 @@ func (lc *LeaseCollection) getTableLease(
 		return tbl, nil
 	}
 
-	dbID, err := lc.databaseCache.getDatabaseID(ctx, txn, vt, tn.Database())
+	dbID, err := tc.databaseCache.getDatabaseID(ctx, txn, vt, tn.Database())
 	if err != nil {
 		return nil, err
 	}
 
-	// First, look to see if we already have a lease for this table.
+	// If the txn has been pushed the table collection is released and
+	// txn deadline is reset.
+	tc.maybeChangeTimestamp(ctx, txn)
+
+	// First, look to see if we already have the table.
 	// This ensures that, once a SQL transaction resolved name N to id X, it will
 	// continue to use N to refer to X even if N is renamed during the
 	// transaction.
-	var lease *LeaseState
-	for _, l := range lc.leases {
-		if parser.ReNormalizeName(l.Name) == tn.TableName.Normalize() &&
-			l.ParentID == dbID {
-			lease = l
+	for _, table := range tc.tables {
+		if parser.ReNormalizeName(table.Name) == tn.TableName.Normalize() &&
+			table.ParentID == dbID {
 			if log.V(2) {
-				log.Infof(ctx, "found lease in planner cache for table '%s'", tn)
+				log.Infof(ctx, "found table in table collection for table '%s'", tn)
 			}
-			break
+			return &table, nil
 		}
 	}
 
-	// If we didn't find a lease or the lease is about to expire, acquire one.
-	if lease == nil || lc.removeLeaseIfExpiring(ctx, txn, lease) {
-		var err error
-		lease, err = lc.leaseMgr.AcquireByName(ctx, txn, dbID, tn.Table())
-		if err != nil {
-			if err == sqlbase.ErrDescriptorNotFound {
-				// Transform the descriptor error into an error that references the
-				// table's name.
-				return nil, sqlbase.NewUndefinedTableError(tn.String())
-			}
-			return nil, err
+	table, expiration, err := tc.leaseMgr.AcquireByName(ctx, txn, dbID, tn.Table())
+	if err != nil {
+		if err == sqlbase.ErrDescriptorNotFound {
+			// Transform the descriptor error into an error that references the
+			// table's name.
+			return nil, sqlbase.NewUndefinedTableError(tn.String())
 		}
-		lc.leases = append(lc.leases, lease)
-		if log.V(2) {
-			log.Infof(ctx, "added lease on table '%s' to planner cache", tn)
-		}
-		// If the lease we just acquired expires before the txn's deadline, reduce
-		// the deadline.
-		txn.UpdateDeadlineMaybe(hlc.Timestamp{WallTime: lease.Expiration().UnixNano()})
+		return nil, err
 	}
-	return &lease.TableDescriptor, nil
+	tc.timestamp = txn.OrigTimestamp()
+	tc.tables = append(tc.tables, table)
+	if log.V(2) {
+		log.Infof(ctx, "added table '%s' to table collection", tn)
+	}
+	// If the table we just acquired expires before the txn's deadline, reduce
+	// the deadline.
+	txn.UpdateDeadlineMaybe(expiration)
+	return &table, nil
 }
 
-// getTableLeaseByID is a by-ID variant of getTableLease (i.e. uses same cache).
-func (lc *LeaseCollection) getTableLeaseByID(
+// getTableVersionByID is a by-ID variant of getTableVersion (i.e. uses same cache).
+func (tc *TableCollection) getTableVersionByID(
 	ctx context.Context, txn *client.Txn, tableID sqlbase.ID,
 ) (*sqlbase.TableDescriptor, error) {
 	if log.V(2) {
-		log.Infof(ctx, "planner acquiring lease on table ID %d", tableID)
+		log.Infof(ctx, "planner getting table on table ID %d", tableID)
 	}
 
 	if testDisableTableLeases {
@@ -323,74 +346,39 @@ func (lc *LeaseCollection) getTableLeaseByID(
 		return table, nil
 	}
 
-	// First, look to see if we already have a lease for this table -- including
-	// leases acquired via `getTableLease`.
-	var lease *LeaseState
-	for _, l := range lc.leases {
-		if l.ID == tableID {
-			lease = l
+	// If the txn has been pushed the table collection is released and
+	// txn deadline is reset.
+	tc.maybeChangeTimestamp(ctx, txn)
+
+	// First, look to see if we already have the table -- including those
+	// via `getTableVersion`.
+	for _, table := range tc.tables {
+		if table.ID == tableID {
 			if log.V(2) {
-				log.Infof(ctx, "found lease in planner cache for table %d", tableID)
+				log.Infof(ctx, "found table %d in table cache", tableID)
 			}
-			break
+			return &table, nil
 		}
 	}
 
-	// If we didn't find a lease or the lease is about to expire, acquire one.
-	if lease == nil || lc.removeLeaseIfExpiring(ctx, txn, lease) {
-		var err error
-		lease, err = lc.leaseMgr.Acquire(ctx, txn, tableID, 0)
-		if err != nil {
-			if err == sqlbase.ErrDescriptorNotFound {
-				// Transform the descriptor error into an error that references the
-				// table's ID.
-				return nil, sqlbase.NewUndefinedTableError(fmt.Sprintf("<id=%d>", tableID))
-			}
-			return nil, err
+	table, expiration, err := tc.leaseMgr.Acquire(ctx, txn, tableID, 0)
+	if err != nil {
+		if err == sqlbase.ErrDescriptorNotFound {
+			// Transform the descriptor error into an error that references the
+			// table's ID.
+			return nil, sqlbase.NewUndefinedTableError(fmt.Sprintf("<id=%d>", tableID))
 		}
-		lc.leases = append(lc.leases, lease)
-		// If the lease we just acquired expires before the txn's deadline, reduce
-		// the deadline.
-		txn.UpdateDeadlineMaybe(hlc.Timestamp{WallTime: lease.Expiration().UnixNano()})
+		return nil, err
 	}
-	return &lease.TableDescriptor, nil
-}
-
-// removeLeaseIfExpiring removes a lease and returns true if it is about to expire.
-// The method also resets the transaction deadline.
-func (lc *LeaseCollection) removeLeaseIfExpiring(
-	ctx context.Context, txn *client.Txn, lease *LeaseState,
-) bool {
-	if lease == nil || lease.hasSomeLifeLeft(lc.leaseMgr.clock) {
-		return false
+	tc.timestamp = txn.OrigTimestamp()
+	tc.tables = append(tc.tables, table)
+	if log.V(2) {
+		log.Infof(ctx, "added table '%s' to table collection", table.Name)
 	}
-
-	// Remove the lease from session.leases.
-	idx := -1
-	for i, l := range lc.leases {
-		if l == lease {
-			idx = i
-			break
-		}
-	}
-	if idx == -1 {
-		log.Warningf(ctx, "lease (%s) not found", lease)
-		return false
-	}
-	lc.leases[idx] = lc.leases[len(lc.leases)-1]
-	lc.leases[len(lc.leases)-1] = nil
-	lc.leases = lc.leases[:len(lc.leases)-1]
-
-	if err := lc.leaseMgr.Release(lease); err != nil {
-		log.Warning(ctx, err)
-	}
-
-	// Reset the deadline so that a new deadline will be set after the lease is acquired.
-	txn.ResetDeadline()
-	for _, l := range lc.leases {
-		txn.UpdateDeadlineMaybe(hlc.Timestamp{WallTime: l.Expiration().UnixNano()})
-	}
-	return true
+	// If the table we just acquired expires before the txn's deadline, reduce
+	// the deadline.
+	txn.UpdateDeadlineMaybe(expiration)
+	return &table, nil
 }
 
 // getTableNames retrieves the list of qualified names of tables
@@ -452,7 +440,7 @@ func (p *planner) createSchemaChangeJob(
 		DescriptorIDs: sqlbase.IDs{tableDesc.GetID()},
 		Details:       jobs.SchemaChangeJobDetails{},
 	}
-	jobLogger := jobs.NewJobLogger(p.ExecCfg().DB, InternalExecutor{LeaseManager: p.session.leases.leaseMgr}, jobRecord)
+	jobLogger := jobs.NewJobLogger(p.ExecCfg().DB, InternalExecutor{LeaseManager: p.session.tables.leaseMgr}, jobRecord)
 	if err := jobLogger.WithTxn(p.txn).Created(ctx); err != nil {
 		return sqlbase.InvalidMutationID, nil
 	}
@@ -533,7 +521,7 @@ func expandTableGlob(
 func (p *planner) searchAndQualifyDatabase(ctx context.Context, tn *parser.TableName) error {
 	t := *tn
 
-	descFunc := p.session.leases.getTableLease
+	descFunc := p.session.tables.getTableVersion
 	if p.avoidCachedDescriptors {
 		// AS OF SYSTEM TIME queries need to fetch the table descriptor at the
 		// specified time, and never lease anything. The proto transaction already

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -52,7 +52,7 @@ func (p *planner) Truncate(ctx context.Context, n *parser.Truncate) (planNode, e
 			return nil, err
 		}
 
-		tableDesc, err := p.session.leases.getTableLease(ctx, p.txn, p.getVirtualTabler(), tn)
+		tableDesc, err := p.session.tables.getTableVersion(ctx, p.txn, p.getVirtualTabler(), tn)
 		if err != nil {
 			return nil, err
 		}
@@ -77,7 +77,7 @@ func (p *planner) Truncate(ctx context.Context, n *parser.Truncate) (planNode, e
 					continue
 				}
 
-				other, err := p.session.leases.getTableLeaseByID(ctx, p.txn, ref.Table)
+				other, err := p.session.tables.getTableVersionByID(ctx, p.txn, ref.Table)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -43,7 +43,7 @@ type editNodeBase struct {
 func (p *planner) makeEditNode(
 	ctx context.Context, tn *parser.TableName, priv privilege.Kind,
 ) (editNodeBase, error) {
-	tableDesc, err := p.session.leases.getTableLease(ctx, p.txn, p.getVirtualTabler(), tn)
+	tableDesc, err := p.session.tables.getTableVersion(ctx, p.txn, p.getVirtualTabler(), tn)
 	if err != nil {
 		return editNodeBase{}, err
 	}


### PR DESCRIPTION
The Acquire/AcquireByName and Release() methods no longer
return/use a LeaseState and instead return/use a
sqlbase.TableDescriptor with an expiration time.

the LeaseManager is moving towards a model where it returns
a table descriptor with an expiration time for the use of the
table descriptor. For now this table descriptor is associated
with a lease, but in the future it might be an older version of
the table descriptor, in which case it will not have a lease.

With this change, leases on the same table descriptor version
are renewed under the covers without needing the API to issue
an explicit release on a table descriptor version. The refcount
on the old lease is simply transferred to the new one. The new
lease is guaranteed to have a higher expiration time and thus a
prior returned expiration time returned by the API is guaranteed
to be contained within the new lease expiration time.

A Release() on the table descriptor will reduce the refcount on the
current lease. In the future, this will reduce the refcount on a table
version which might not be associated with a lease.

Removed the need to use removeLeaseIfExpiring since once a transaction
has picked a timestamp and a valid table descriptor for the timestamp
the table descriptor need not be reacquired through the API.

related to #2948