### PR TITLE
sql/pgwire: clean up doNotSendReadyForQuery logic

### DIFF
--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -413,9 +413,7 @@ func (c *v3Conn) serve(ctx context.Context, draining func() bool, reserved mon.B
 				return err
 			}
 		}
-		if c.doNotSendReadyForQuery {
-			c.doNotSendReadyForQuery = false
-		}
+		c.doNotSendReadyForQuery = false
 		typ, n, err := c.readBuf.readTypedMsg(c.rd)
 		c.metrics.BytesInCount.Inc(int64(n))
 		if err != nil {


### PR DESCRIPTION
Addressing a post-review comment - it's more clear to unconditionally
reset the `doNotSendReadyForQuery` flag after sending (or not) the ready
for query message.