### PR TITLE
storage: Switch replica stats from counts to QPS

### DIFF
--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -48,6 +48,11 @@ const (
 	// that store.
 	baseRebalanceThreshold = 0.05
 
+	// minReplicaWeight sets a floor for how low a replica weight can be. This is
+	// needed because a weight of zero doesn't work in the current lease scoring
+	// algorithm.
+	minReplicaWeight = 0.001
+
 	// priorities for various repair operations.
 	addMissingReplicaPriority  float64 = 10000
 	removeDeadReplicaPriority  float64 = 1000
@@ -594,13 +599,13 @@ func (a Allocator) shouldTransferLeaseUsingStats(
 			replicaWeights[nodeID] += (1 - replicaLocality.DiversityScore(requestLocality)) * qps
 		}
 	}
-	sourceWeight := math.Max(1.0, replicaWeights[source.Node.NodeID])
 
 	if log.V(1) {
 		log.Infof(ctx,
 			"shouldTransferLease qpsStats: %+v, replicaLocalities: %+v, replicaWeights: %+v",
 			qpsStats, replicaLocalities, replicaWeights)
 	}
+	sourceWeight := math.Max(minReplicaWeight, replicaWeights[source.Node.NodeID])
 
 	// TODO(a-robinson): This may not have enough protection against all leases
 	// ending up on a single node in extreme cases. Continue testing against
@@ -625,7 +630,7 @@ func (a Allocator) shouldTransferLeaseUsingStats(
 			continue
 		}
 
-		remoteWeight := math.Max(1.0, replicaWeights[repl.NodeID])
+		remoteWeight := math.Max(minReplicaWeight, replicaWeights[repl.NodeID])
 		score := loadBasedLeaseRebalanceScore(
 			ctx, remoteWeight, remoteLatency, storeDesc, sourceWeight, source, sl.candidateLeases.mean)
 		if score > bestReplScore {

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -1156,7 +1156,7 @@ func TestAllocatorTransferLeaseTargetLoadBased(t *testing.T) {
 	imbalanced1 := newReplicaStats(clock, localityFn)
 	imbalanced2 := newReplicaStats(clock, localityFn)
 	imbalanced3 := newReplicaStats(clock, localityFn)
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 100*int(MinLeaseTransferStatsDuration.Seconds()); i++ {
 		evenlyBalanced.record(99)
 		imbalanced1.record(1)
 		imbalanced2.record(2)

--- a/pkg/storage/replica_stats_test.go
+++ b/pkg/storage/replica_stats_test.go
@@ -278,6 +278,8 @@ func TestReplicaStatsDecay(t *testing.T) {
 		}
 		durationDivisor := time.Duration(float64(replStatsRotateInterval) * decayFactor).Seconds()
 		expected := perLocalityCounts{
+			// We expect the first loop's requests to be decreased by decayFactor,
+			// but not the second loop's.
 			awsLocalities[1]: 2 * decayFactor / durationDivisor,
 			awsLocalities[2]: (2*decayFactor + 2) / durationDivisor,
 			awsLocalities[3]: (1*decayFactor + 3) / durationDivisor,

--- a/pkg/storage/replica_stats_test.go
+++ b/pkg/storage/replica_stats_test.go
@@ -173,12 +173,21 @@ func TestReplicaStats(t *testing.T) {
 		for _, req := range tc.reqs {
 			rs.record(req)
 		}
-		if actual, _ := rs.getRequestCounts(); !reflect.DeepEqual(tc.expected, actual) {
-			t.Errorf("%d: incorrect per-locality request counts: %s", i, pretty.Diff(tc.expected, actual))
+		manual.Increment(int64(time.Second))
+		if actual, _ := rs.perLocalityDecayingQPS(); !floatMapsEqual(tc.expected, actual) {
+			t.Errorf("%d: incorrect per-locality QPS averages: %s", i, pretty.Diff(tc.expected, actual))
+		}
+		// Verify that QPS numbers get cut in half after another second.
+		manual.Increment(int64(time.Second))
+		for k, v := range tc.expected {
+			tc.expected[k] = v / 2
+		}
+		if actual, _ := rs.perLocalityDecayingQPS(); !floatMapsEqual(tc.expected, actual) {
+			t.Errorf("%d: incorrect per-locality QPS averages: %s", i, pretty.Diff(tc.expected, actual))
 		}
 		rs.resetRequestCounts()
-		if actual, _ := rs.getRequestCounts(); len(actual) != 0 {
-			t.Errorf("%d: unexpected no request counts after resetting: %+v", i, actual)
+		if actual, _ := rs.perLocalityDecayingQPS(); len(actual) != 0 {
+			t.Errorf("%d: unexpected non-empty QPS averages after resetting: %+v", i, actual)
 		}
 	}
 }
@@ -200,7 +209,7 @@ func TestReplicaStatsDecay(t *testing.T) {
 	})
 
 	{
-		counts, dur := rs.getRequestCounts()
+		counts, dur := rs.perLocalityDecayingQPS()
 		if len(counts) != 0 {
 			t.Errorf("expected empty request counts, got %+v", counts)
 		}
@@ -208,7 +217,7 @@ func TestReplicaStatsDecay(t *testing.T) {
 			t.Errorf("expected duration = 0, got %v", dur)
 		}
 		manual.Increment(1)
-		if _, dur := rs.getRequestCounts(); dur != 1 {
+		if _, dur := rs.perLocalityDecayingQPS(); dur != 1 {
 			t.Errorf("expected duration = 1, got %v", dur)
 		}
 		rs.resetRequestCounts()
@@ -218,38 +227,42 @@ func TestReplicaStatsDecay(t *testing.T) {
 		for _, req := range []roachpb.NodeID{1, 1, 2, 2, 3} {
 			rs.record(req)
 		}
-		expected := perLocalityCounts{
+		counts := perLocalityCounts{
 			awsLocalities[1]: 2,
 			awsLocalities[2]: 2,
 			awsLocalities[3]: 1,
 		}
-		actual, dur := rs.getRequestCounts()
+		actual, dur := rs.perLocalityDecayingQPS()
 		if dur != 0 {
 			t.Errorf("expected duration = 0, got %v", dur)
 		}
-		if !reflect.DeepEqual(expected, actual) {
-			t.Errorf("incorrect per-locality request counts: %s", pretty.Diff(expected, actual))
+		if !reflect.DeepEqual(counts, actual) {
+			t.Errorf("incorrect per-locality request counts: %s", pretty.Diff(counts, actual))
 		}
 
+		var totalDuration time.Duration
 		for i := 0; i < len(rs.mu.requests)-1; i++ {
 			manual.Increment(int64(replStatsRotateInterval))
-			for k, v := range expected {
-				expected[k] = v * decayFactor
+			totalDuration = time.Duration(float64(replStatsRotateInterval+totalDuration) * decayFactor)
+			expected := make(perLocalityCounts)
+			for k, v := range counts {
+				counts[k] = v * decayFactor
+				expected[k] = counts[k] / totalDuration.Seconds()
 			}
-			actual, dur = rs.getRequestCounts()
+			actual, dur = rs.perLocalityDecayingQPS()
 			if expectedDur := replStatsRotateInterval * time.Duration(i+1); dur != expectedDur {
 				t.Errorf("expected duration = %v, got %v", expectedDur, dur)
 			}
 			// We can't just use DeepEqual to compare these due to the float
 			// multiplication inaccuracies.
 			if !floatMapsEqual(expected, actual) {
-				t.Errorf("incorrect per-locality request counts: %s", pretty.Diff(expected, actual))
+				t.Errorf("%d: incorrect per-locality request counts: %s", i, pretty.Diff(expected, actual))
 			}
 		}
 
 		manual.Increment(int64(replStatsRotateInterval))
-		expected = make(perLocalityCounts)
-		if actual, _ := rs.getRequestCounts(); !reflect.DeepEqual(expected, actual) {
+		expected := make(perLocalityCounts)
+		if actual, _ := rs.perLocalityDecayingQPS(); !reflect.DeepEqual(expected, actual) {
 			t.Errorf("incorrect per-locality request counts: %s", pretty.Diff(expected, actual))
 		}
 		rs.resetRequestCounts()
@@ -263,12 +276,13 @@ func TestReplicaStatsDecay(t *testing.T) {
 		for _, req := range []roachpb.NodeID{2, 2, 3, 3, 3} {
 			rs.record(req)
 		}
+		durationDivisor := time.Duration(float64(replStatsRotateInterval) * decayFactor).Seconds()
 		expected := perLocalityCounts{
-			awsLocalities[1]: 2 * decayFactor,
-			awsLocalities[2]: 2*decayFactor + 2,
-			awsLocalities[3]: 1*decayFactor + 3,
+			awsLocalities[1]: 2 * decayFactor / durationDivisor,
+			awsLocalities[2]: (2*decayFactor + 2) / durationDivisor,
+			awsLocalities[3]: (1*decayFactor + 3) / durationDivisor,
 		}
-		if actual, _ := rs.getRequestCounts(); !reflect.DeepEqual(expected, actual) {
+		if actual, _ := rs.perLocalityDecayingQPS(); !reflect.DeepEqual(expected, actual) {
 			t.Errorf("incorrect per-locality request counts: %s", pretty.Diff(expected, actual))
 		}
 	}
@@ -300,18 +314,18 @@ func TestReplicaStatsDecaySmoothing(t *testing.T) {
 		awsLocalities[2]: 2,
 		awsLocalities[3]: 1,
 	}
-	if actual, _ := rs.getRequestCounts(); !reflect.DeepEqual(expected, actual) {
+	if actual, _ := rs.perLocalityDecayingQPS(); !reflect.DeepEqual(expected, actual) {
 		t.Errorf("incorrect per-locality request counts: %s", pretty.Diff(expected, actual))
 	}
 
 	increment := replStatsRotateInterval / 2
 	manual.Increment(int64(increment))
-	actual1, dur := rs.getRequestCounts()
+	actual1, dur := rs.perLocalityDecayingQPS()
 	if dur != increment {
 		t.Errorf("expected duration = %v; got %v", increment, dur)
 	}
 	for k := range expected {
-		expected[k] *= math.Pow(decayFactor, 0.5)
+		expected[k] /= increment.Seconds()
 	}
 	if !floatMapsEqual(expected, actual1) {
 		t.Errorf("incorrect per-locality request counts: %s", pretty.Diff(expected, actual1))
@@ -319,7 +333,7 @@ func TestReplicaStatsDecaySmoothing(t *testing.T) {
 
 	// Verify that all values decrease as time advances if no requests come in.
 	manual.Increment(1)
-	actual2, _ := rs.getRequestCounts()
+	actual2, _ := rs.perLocalityDecayingQPS()
 	if len(actual1) != len(actual2) {
 		t.Fatalf("unexpected different results sizes (expected %d, got %d)", len(actual1), len(actual2))
 	}
@@ -331,7 +345,7 @@ func TestReplicaStatsDecaySmoothing(t *testing.T) {
 
 	// Ditto for passing a window boundary.
 	manual.Increment(int64(increment))
-	actual3, _ := rs.getRequestCounts()
+	actual3, _ := rs.perLocalityDecayingQPS()
 	if len(actual2) != len(actual3) {
 		t.Fatalf("unexpected different results sizes (expected %d, got %d)", len(actual2), len(actual3))
 	}


### PR DESCRIPTION
This was discussed prior to 1.0 but pushed off to minimize scope. This
makes stats more comparable across time (i.e. it's now more fair to
compare stats collected after 5 minutes to stats collected after 20
minutes), which should make for a reduced likelihood of thrashing.

I still have to rerun a couple of the allocsim workloads before merging this to see if the constants in the allocator code need to be tweaked at all, since this will make some of the replica weights there considerably smaller in imbalanced situations. That's tough to do without understanding #16463, though.

(edit) some relevant allocsim results, all of which look good without needing to adjust anything

`node-per-locality-high-latency-imbalanced-load.json`:
```
_elapsed__ops/sec__average__latency___errors_replicas_______________1:1_______________2:2_______________3:3
    1m0s    585.9    436.0   73.3ms        0      129           43/8/14           43/31/3            43/4/0
    2m0s    522.2    507.0   63.1ms        0      261          87/10/14           87/63/3            87/4/0
    3m0s    578.8    529.6   60.4ms        0      420         140/11/15         140/124/3           140/4/0
    4m0s    581.8    541.3   59.1ms        0      598         199/15/15         200/166/3           199/5/0
    5m0s    550.8    546.3   58.6ms        0      795         265/17/15         265/238/4           265/5/0
    6m0s    555.9    551.1   58.1ms        0      807         269/16/15         269/246/5           269/6/0
    7m0s    558.9    554.1   57.7ms        0      954         318/20/15         318/278/6           318/6/0
```

`node-per-locality-uneven-latency-imbalanced-load2.json`:
```
_elapsed__ops/sec__average__latency___errors_replicas_______________1:1_______________2:2_______________3:3
    1m0s   1269.8   1106.3   28.9ms        0      311         104/35/28          104/36/5           103/7/0
    2m0s   1289.8   1172.2   27.3ms        0      721         240/97/34          241/95/8           240/8/0
    3m0s   1269.8   1195.9   26.8ms        0      810        270/113/34         270/145/8           270/9/0
    4m0s   1272.7   1207.0   26.5ms        0     1449        483/214/35         483/231/8           483/9/0
    5m0s   1239.6   1211.3   26.4ms        0     1575        525/226/35        525/288/12          525/10/0
    6m0s   1296.4   1219.0   26.2ms        0     1632        544/232/35        544/289/12          544/10/0
```

`multiple-nodes-per-locality-imbalanced-load.json`:
```
_elapsed__ops/sec__average__latency___errors_replicas_______________1:1_______________2:1_______________3:1_______________4:2_______________5:2_______________6:2_______________7:3_______________8:3_______________9:3
    1m0s    505.3    394.4   81.0ms        0      132           15/4/16            15/6/6            15/4/5           14/10/7            14/6/1            14/7/3            15/3/6            15/0/3            15/4/1
    2m0s    487.9    440.5   72.6ms        0      234           25/6/19            26/7/9            25/6/6          26/14/13           27/14/4           26/16/3            25/6/8            27/3/4            27/4/3
    3m0s    524.4    454.8   70.3ms        0      427           48/9/22          49/11/12           45/11/6          49/27/16           48/30/6           46/29/7            48/8/9            48/8/5            46/8/3
    4m0s    438.9    465.1   68.8ms        0      442           51/9/22          50/11/12           48/12/7          49/28/16           49/30/6           48/29/7            50/8/9            51/9/5            46/7/3
    5m0s    482.1    469.5   68.1ms        0      749          87/18/23          83/18/15          79/16/11          86/49/16           83/52/6          84/47/10          81/11/12           82/16/5           84/12/3
    6m0s    531.9    473.2   67.6ms        0      820          89/17/27          91/18/16          86/16/11          95/57/18           94/61/8          90/57/10          93/14/12           91/19/5           91/13/4
```