### PR TITLE
sql: more RowFetcher optimizations

### DIFF
--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -301,11 +301,6 @@ func (rf *RowFetcher) ProcessKV(
 		}
 	}
 
-	// Composite columns that are not present use the key in the index. Record
-	// those values here for use later on if the datums are not present in
-	// the value.
-	unsetCols := map[int]EncDatum{}
-
 	if !rf.isSecondaryIndex && len(rf.keyRemainingBytes) > 0 {
 		_, familyID, err := encoding.DecodeUvarintAscending(rf.keyRemainingBytes)
 		if err != nil {
@@ -317,17 +312,15 @@ func (rf *RowFetcher) ProcessKV(
 			return "", "", err
 		}
 
-		if familyID == 0 {
-			// This value contains values for the composite columns. Clear the
-			// undecodable bytes that came from the key so that there is no panic for
-			// a duplicate value.
-			for _, colID := range rf.index.CompositeColumnIDs {
-				if idx, ok := rf.colIdxMap[colID]; ok {
-					unsetCols[idx] = rf.row[idx]
-					rf.row[idx].UnsetDatum()
-				}
-			}
-		}
+		// If familyID is 0, kv.Value contains values for composite key columns.
+		// These columns already have a rf.row value assigned above, but that value
+		// (obtained from the key encoding) might not be correct (e.g. for decimals,
+		// it might not contain the right number of trailing 0s; for collated
+		// strings, it is one of potentially many strings with the same collation
+		// key).
+		//
+		// In these cases, the correct value will be present in family 0 and the
+		// rf.row value gets overwritten.
 
 		switch kv.Value.GetTag() {
 		case roachpb.ValueType_TUPLE:
@@ -339,13 +332,6 @@ func (rf *RowFetcher) ProcessKV(
 			return "", "", err
 		}
 	} else {
-		for _, colID := range rf.index.CompositeColumnIDs {
-			if idx, ok := rf.colIdxMap[colID]; ok {
-				unsetCols[idx] = rf.row[idx]
-				rf.row[idx].UnsetDatum()
-			}
-		}
-
 		valueBytes := kv.ValueBytes()
 		if rf.extraVals != nil {
 			// This is a unique index; decode the extra column values from
@@ -378,12 +364,6 @@ func (rf *RowFetcher) ProcessKV(
 			if err != nil {
 				return "", "", err
 			}
-		}
-	}
-
-	for idx, ed := range unsetCols {
-		if rf.row[idx].IsUnset() {
-			rf.row[idx] = ed
 		}
 	}
 
@@ -429,9 +409,6 @@ func (rf *RowFetcher) processValueSingle(
 			}
 			if debugStrings {
 				prettyValue = value.String()
-			}
-			if !rf.row[idx].IsUnset() {
-				panic(fmt.Sprintf("duplicate value for column %d", idx))
 			}
 			rf.row[idx] = DatumToEncDatum(typ, value)
 			if debugRowFetch {
@@ -496,9 +473,6 @@ func (rf *RowFetcher) processValueBytes(
 				return "", "", err
 			}
 			fmt.Fprintf(&rf.prettyValueBuf, "/%v", encValue.Datum)
-		}
-		if !rf.row[idx].IsUnset() {
-			panic(fmt.Sprintf("duplicate value for column %d", idx))
 		}
 		rf.row[idx] = encValue
 		if debugRowFetch {

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -146,13 +146,6 @@ func (rf *RowFetcher) Init(
 	for i, id := range indexColumnIDs {
 		rf.indexColIdx[i] = rf.colIdxMap[id]
 	}
-	// Add composite key columns to neededCols so that, like other key
-	// columns, their values are decoded.
-	for _, id := range index.CompositeColumnIDs {
-		if _, ok := colIdxMap[id]; ok {
-			rf.neededCols.Add(uint32(id))
-		}
-	}
 
 	if isSecondaryIndex {
 		for i := range rf.cols {

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -301,6 +301,15 @@ func (rf *RowFetcher) ProcessKV(
 		}
 	}
 
+	if rf.neededCols.Empty() {
+		// We don't need to decode any values.
+		if debugStrings {
+			prettyValue = parser.DNull.String()
+		}
+
+		return prettyKey, prettyValue, nil
+	}
+
 	if !rf.isSecondaryIndex && len(rf.keyRemainingBytes) > 0 {
 		_, familyID, err := encoding.DecodeUvarintAscending(rf.keyRemainingBytes)
 		if err != nil {


### PR DESCRIPTION
### sql: don't set composite columns as needed in row fetcher
We don't need to fully decode all key columns if they are not needed.

### sql: remove unsetCols map
Removing the unsetCols map which is only used to avoid some assertions. Creating
this map was about 3.7% in a profile of a large scan where we don't need column
values.

### sql: avoid KV decoding altogether if no values are required
Special optimization when no columns are needed in the row fetcher. This is only
useful for `COUNT(*)` but the speedup for that is significant (20%).