### PR TITLE
storageccl: clean up batching in Import command and resurrect TestImport

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -169,10 +169,12 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 			if storeSpec.SizePercent > 0 {
 				panic(fmt.Sprintf("test server does not yet support in memory stores based on percentage of total memory: %s", storeSpec))
 			}
-		} else {
-			// TODO(bram): This will require some cleanup of on disk files.
-			panic(fmt.Sprintf("test server does not yet support on disk stores: %s", storeSpec))
 		}
+		// The default store spec is in-memory, so if this one is on-disk then
+		// one specific test must have requested it. A failure is returned if
+		// the Path field is empty, which means the test is then forced to pick
+		// the dir (and the test is then responsible for cleaning it up, not
+		// TestServer).
 	}
 	// Copy over the store specs.
 	cfg.Stores = base.StoreSpecList{Specs: params.StoreSpecs}

--- a/pkg/storage/engine/db.cc
+++ b/pkg/storage/engine/db.cc
@@ -2326,15 +2326,29 @@ DBString DBGetUserProperties(DBEngine* db) {
 DBStatus DBIngestExternalFile(DBEngine* db, DBSlice path, bool move_file) {
   const std::vector<std::string> paths = { ToString(path) };
   rocksdb::IngestExternalFileOptions ingest_options;
+  // If move_files is true and the env supports it, RocksDB will hard link.
+  // Otherwise, it will copy.
   ingest_options.move_files = move_file;
+  // If snapshot_consistency is true and there is an outstanding RocksDB
+  // snapshot, a global sequence number is forced (see the allow_global_seqno
+  // option).
+  //
   // TODO(dan): Switch snapshot_consistency back to true. The RocksDB in-memory
   // env doesn't support NewRandomRWFile, which is used when a file is ingested
   // while a snapshot is outstanding (it rewrites the sequence number in the
   // ingested file to be greated than the snapshot's sequence number). Setting
   // the option to false avoids this codepath during development. #16345.
   ingest_options.snapshot_consistency = false;
+  // If a file is ingested over existing data (including the range tombstones
+  // used by range snapshots) or if a RocksDB snapshot is outstanding when this
+  // ingest runs, then after moving/copying the file, RocksDB will edit it
+  // (overwrite some of the bytes) to have a global sequence number. If this is
+  // false, it will error in these cases instead.
   ingest_options.allow_global_seqno = true;
-  ingest_options.allow_blocking_flush = false;
+  // If there are mutations in the memtable for the keyrange covered by the file
+  // being ingested, this option is checked. If true, the memtable is flushed
+  // and the ingest run. If false, an error is returned.
+  ingest_options.allow_blocking_flush = true;
   rocksdb::Status status = db->rep->IngestExternalFile(paths, ingest_options);
   if (!status.ok()) {
     return ToDBStatus(status);

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1791,7 +1791,7 @@ func MakeRocksDBSstFileWriter() (RocksDBSstFileWriter, error) {
 // is not greater than any previously added entry (according to the comparator
 // configured during writer creation). `Close` cannot have been called.
 func (fw *RocksDBSstFileWriter) Add(kv MVCCKeyValue) error {
-	if fw == nil {
+	if fw.fw == nil {
 		return errors.New("cannot call Open on a closed writer")
 	}
 	fw.DataSize += int64(len(kv.Key.Key)) + int64(len(kv.Value))
@@ -1801,6 +1801,9 @@ func (fw *RocksDBSstFileWriter) Add(kv MVCCKeyValue) error {
 // Finish finalizes the writer and returns the constructed file's contents. At
 // least one kv entry must have been added.
 func (fw *RocksDBSstFileWriter) Finish() ([]byte, error) {
+	if fw.fw == nil {
+		return nil, errors.New("cannot call Finish on a closed writer")
+	}
 	var contents C.DBString
 	if err := statusToError(C.DBSstFileWriterFinish(fw.fw, &contents)); err != nil {
 		return nil, err


### PR DESCRIPTION
The semantics of Close, Finish, and resetBatcher were a little muddy and caused
an actual bug (Close was being called before Finish sometimes). This
changes resetBatcher to require that the batcher was Close'd and nil'd
beforehand (and fixes the bug).

----

TestImport was skipped during some last minute bug fixing in the runup to 1.0.
I can't remember why, but it works now when unskipped, so do that.

Also extend TestImport to check batching (which would have caught
found that we weren't retrying AmbiguousResultError for the latter. This
also found that allow_blocking_flush wasn't being set to true on the
IngestExternalFile call, but it should be.

Finally, improve the errors being returned from RocksDBSstFileWriter,
which helped me debug what all was going on here.
