### PR TITLE
allocsim: Disable raft log syncing to avoid massive perf hit

### DIFF
--- a/pkg/cmd/allocsim/main.go
+++ b/pkg/cmd/allocsim/main.go
@@ -513,6 +513,10 @@ func main() {
 	allNodeArgs := append(flag.Args(), "--vmodule=allocator=1")
 	c.Start("allocsim", *workers, os.Args[0], allNodeArgs, perNodeArgs, perNodeEnv)
 	c.UpdateZoneConfig(1, 1<<20)
+	_, err := c.DB[0].Exec("SET CLUSTER SETTING kv.raft_log.synchronize = false;")
+	if err != nil {
+		log.Fatal(context.Background(), err)
+	}
 	if len(config.Localities) != 0 {
 		a.runWithConfig(config)
 	} else {


### PR DESCRIPTION
Fixes #16463 

This gets perf back down to approximately where it was before on the same config as mentioned in the issue:

```
_elapsed__ops/sec__average__latency___errors_replicas_______________1:1_______________2:2_______________3:3
    1m0s    531.5    388.8   82.2ms        0      129           43/9/13           43/25/0            43/2/0
    2m0s    489.9    446.7   71.6ms        0      225          75/12/14           75/49/5            75/8/0
    3m0s    480.6    445.6   71.8ms        0      411         137/24/14         137/89/12          137/19/0
    4m0s    497.1    452.0   70.8ms        0      423         141/22/15         141/91/13          141/22/0
    5m0s    487.6    455.1   70.3ms        0      669         223/41/15        223/134/16          223/36/0
```