### PR TITLE
sql: regtype casts now use the full type parser

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/orms
+++ b/pkg/sql/logictest/testdata/logic_test/orms
@@ -101,3 +101,14 @@ AND t3.nspname = ANY (current_schemas(false))
 ORDER BY c.conname
 ----
 a  a_id  id  fk_a_id_ref_a  a  a
+
+# Default value columns in Rails produce these kinds of queries:
+query O
+SELECT 'decimal(18,2)'::regtype::oid
+----
+1700
+
+query O
+SELECT 'character varying'::regtype::oid
+----
+25

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -125,7 +125,7 @@ system  2939540337
 query OO
 SELECT 'bool'::REGTYPE, 'bool'::REGTYPE::OID
 ----
-bool  16
+boolean  16
 
 query OO
 SELECT 'numeric(10,3)'::REGTYPE, 'numeric( 10, 3 )'::REGTYPE

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -185,3 +185,18 @@ func ParseExpr(sql string) (Expr, error) {
 	}
 	return exprs[0], nil
 }
+
+// ParseType parses a column type.
+func ParseType(sql string) (CastTargetType, error) {
+	expr, err := ParseExpr(fmt.Sprintf("1::%s", sql))
+	if err != nil {
+		return nil, err
+	}
+
+	cast, ok := expr.(*CastExpr)
+	if !ok {
+		return nil, errors.Errorf("expected a CastExpr, but found %T", expr)
+	}
+
+	return cast.Type, nil
+}


### PR DESCRIPTION
Previously, string casts to `regtype` such as `'foo'::regtype` used a custom
parser to match the string with the correct type OID. This led to a few
problems, such as missing the mapping for longer type names such as
`character varying` as well as improperly parsing parameterized types
such as `decimal(10,2)`.

Rather than fix our separate parser, we now just delegate this type
parsing to the full SQL parser and interpret the results.

If our standard type parser fails, we fall back to the previous method
of searching `pg_type`. That's required since we don't provide syntax for
every type whose OID we understand - such as `float4`.

Fixes #13993.
Fixes https://github.com/cockroachdb/activerecord-cockroachdb-adapter/issues/3.