### PR TITLE
vendor: bump grpc to 1.4.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -524,7 +524,7 @@
 
 [[projects]]
   name = "golang.org/x/perf"
-  packages = ["benchstat","cmd/benchstat","internal/stats","storage/benchfmt"]
+  packages = ["benchstat","cmd/benchstat","internal/stats","storage","storage/benchfmt"]
   revision = "844f0140c89c0be84e3d3143f075ccff10819462"
 
 [[projects]]
@@ -570,7 +570,8 @@
 [[projects]]
   name = "google.golang.org/grpc"
   packages = [".","codes","credentials","credentials/oauth","grpclb/grpc_lb_v1","grpclog","internal","keepalive","metadata","naming","peer","stats","status","tap","transport"]
-  revision = "3419b42955675df23457629c75f58eb8dcd56954"
+  revision = "d8960bd63c6743defa6d54926e5edfa8e4a28e43"
+  version = "v1.4.0"
 
 [[projects]]
   name = "gopkg.in/yaml.v2"
@@ -585,6 +586,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "321c06350f151bb665ef35759ae1fc19afd6e0abba33aba47173c07f6bbe57ec"
+  inputs-digest = "562093f8ce91cd0353b3752147c62d3d3a32add8c2df0dba5145caedafbae699"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
**TL;DR: bump gRPC to latest tagged release with `dep ensure -update google.golang.org/grpc`**

Trying out the `dep` bump workflow for the first time, to verify it works as expected and provide an example to point to later. I've included all the submodule handling steps as well for completeness, even though they haven't changed.

Create new feature branches in both our working copy and the submodule:
```
$ git checkout -b bump-grpc
Switched to a new branch 'bump-grpc'

$ git -C vendor checkout -b bump-grpc
Switched to a new branch 'bump-grpc'
```

Ask `dep` to update `grpc` to the latest allowed version. We don't constrain it in our manifest, so this means latest (according to semvar) tagged release upstream:
```
$ dep ensure -update google.golang.org/grpc
```

Inspect changes
```
$ git diff Gopkg.lock
...
$ git -C vendor diff --stat
...
```
Currently 1.4.0 is the latest tagged release upstream, and is pretty recent.
Optionally, we can grab the old and new revisions from the lock file diff and look at the changelog on GitHub (ideally including this link in our commit message and PR text later), e.g https://github.com/grpc/grpc-go/compare/3419b42955675df23457629c75f58eb8dcd56954...d8960bd63c6743defa6d54926e5edfa8e4a28e43

This looks good, so we'll commit and push the changes in `vendor` and then the updated submodule ref in our working copy:
```
$ git -C vendor add . && git -C vendor commit -m "bump grpc to 1.4.0"
[bump-grpc 5d75d5d0] bump grpc to 1.4.0
 30 files changed, 2386 insertions(+), 464 deletions(-)

$ git -C vendor push origin bump-grpc
...
 * [new branch]        bump-grpc -> bump-grpc

$ git commit -a -m "vendor: bump grpc to 1.4.0"
[bump-grpc bfadbf090] vendor: bump grpc to 1.4.0
 2 files changed, 5 insertions(+), 4 deletions(-)

$ git push dt bump-grpc
...
 * [new branch]          bump-grpc -> bump-grpc
```

After the PR merges, we'll update the submodule's `master` pointer to ensure our ref that remains reachable and is thus never GCed, and cleanup our feature branch:
```
$ git -C vendor push bump-grpc:master :bump-grpc
```