### PR TITLE
sql: support set client_encoding='unicode'

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -140,6 +140,9 @@ SET STANDARD_CONFORMING_STRINGS = 'off'
 statement ok
 SET CLIENT_ENCODING = 'UTF8'
 
+statement ok
+SET CLIENT_ENCODING = 'unicode'
+
 statement error non-UTF8 encoding other not supported
 SET CLIENT_ENCODING = 'other'
 

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -270,7 +270,8 @@ var varGen = map[string]sessionVar{
 			if err != nil {
 				return err
 			}
-			if strings.ToUpper(s) != "UTF8" {
+			upper := strings.ToUpper(s)
+			if upper != "UTF8" && upper != "UNICODE" {
 				return fmt.Errorf("non-UTF8 encoding %s not supported", s)
 			}
 			return nil


### PR DESCRIPTION
PostgreSQL treats this as a synonym to utf8 - we should too.

Fixes #16497.