### PR TITLE
cmd/benchmark: use files instead of buffers

### DIFF
--- a/pkg/cmd/benchmark/main.go
+++ b/pkg/cmd/benchmark/main.go
@@ -34,6 +34,7 @@ import (
 	"golang.org/x/oauth2/google"
 	"golang.org/x/perf/storage"
 
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -179,6 +180,14 @@ func do(ctx context.Context) error {
 
 	if err := func() error {
 		for i, file := range files {
+			{
+				info, err := file.Stat()
+				if err != nil {
+					return errors.Wrapf(err, "could not stat temporary file %s", file.Name())
+				}
+				log.Printf("uploading file %s: %s", file.Name(), humanizeutil.IBytes(info.Size()))
+			}
+
 			w, err := u.CreateFile(fmt.Sprintf("bench%02d.txt", i))
 			if err != nil {
 				return errors.Wrap(err, "could not create upload file")


### PR DESCRIPTION
Looks like we're running into the OOM killer here; using files should
alleviate that, though I'm surprised the amount of data produced by
benchmarks on stdout is enough to cause OOM. Perhaps the benchmarks
themselves get the machine quite close, and these buffers are enough to
break the camel's back.