### PR TITLE
storage: do not remove a replica which is a necessary part of quorum

### DIFF
--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -326,10 +326,11 @@ func (rq *replicateQueue) processOneChange(
 		if log.V(1) {
 			log.Infof(ctx, "removing a replica")
 		}
+		candidates := filterUnremovableReplicas(repl.RaftStatus(), desc.Replicas)
 		removeReplica, err := rq.allocator.RemoveTarget(
 			ctx,
 			zone.Constraints,
-			desc.Replicas,
+			candidates,
 		)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
After choosing a replica to remove, check to see that it is not a
necessary part of quorum. We allow moving behind replicas or an
up-to-date replica where the removal of the up-to-date replica leaves at
least a quorum of up-to-date replicas remaining.

Fixes #10506