### PR TITLE
sampledataccl: add an abstraction for ccl testdata

### DIFF
--- a/pkg/ccl/acceptanceccl/backup_test.go
+++ b/pkg/ccl/acceptanceccl/backup_test.go
@@ -140,14 +140,14 @@ const (
 	backupRestoreRowPayloadSize = 100
 
 	// TODO(mjibson): attempt to unify these with the identical ones in sqlccl.
-	bankCreateDatabase = `CREATE DATABASE bench`
-	bankCreateTable    = `CREATE TABLE bench.bank (
+	bankCreateDatabase = `CREATE DATABASE data`
+	bankCreateTable    = `CREATE TABLE data.bank (
 		id INT PRIMARY KEY,
 		balance INT,
 		payload STRING,
 		FAMILY (id, balance, payload)
 	)`
-	bankInsert = `INSERT INTO bench.bank VALUES (%d, %d, '%s')`
+	bankInsert = `INSERT INTO data.bank VALUES (%d, %d, '%s')`
 )
 
 func getAzureURI(t testing.TB) url.URL {
@@ -212,7 +212,7 @@ func BenchmarkRestoreBig(b *testing.B) {
 
 		ts := hlc.Timestamp{WallTime: hlc.UnixNano()}
 		restoreURI := restoreBaseURI.String()
-		desc, err := sqlccl.Load(ctx, sqlDB, &buf, "bench", restoreURI, ts, 0, os.TempDir())
+		desc, err := sqlccl.Load(ctx, sqlDB, &buf, "data", restoreURI, ts, 0, os.TempDir())
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -222,7 +222,7 @@ func BenchmarkRestoreBig(b *testing.B) {
 
 		b.ResetTimer()
 		log.Infof(ctx, "starting restore to %s", dbName)
-		r.Exec(fmt.Sprintf(`RESTORE TABLE bench.* FROM $1 WITH OPTIONS ('into_db'='%s')`, dbName), restoreURI)
+		r.Exec(fmt.Sprintf(`RESTORE TABLE data.* FROM $1 WITH OPTIONS ('into_db'='%s')`, dbName), restoreURI)
 		b.SetBytes(desc.DataSize / int64(b.N))
 		log.Infof(ctx, "restored %s", humanizeutil.IBytes(desc.DataSize))
 		b.StopTimer()

--- a/pkg/ccl/sqlccl/backup_cloud_test.go
+++ b/pkg/ccl/sqlccl/backup_cloud_test.go
@@ -6,7 +6,7 @@
 //
 //     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
-package sqlccl
+package sqlccl_test
 
 import (
 	"fmt"

--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -6,7 +6,7 @@
 //
 //     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
-package sqlccl
+package sqlccl_test
 
 import (
 	"bytes"
@@ -32,7 +32,9 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/sqlccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl/sampledataccl"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -56,55 +58,7 @@ const (
 	multiNode                   = 3
 	backupRestoreDefaultRanges  = 10
 	backupRestoreRowPayloadSize = 100
-
-	bankCreateDatabase = `CREATE DATABASE bench`
-	bankCreateTable    = `CREATE TABLE bench.bank (
-		id INT PRIMARY KEY,
-		balance INT,
-		payload STRING,
-		FAMILY (id, balance, payload)
-	)`
-	bankDataInsertRows = 1000
 )
-
-func bankDataInsertStmts(count int) []string {
-	rng, _ := randutil.NewPseudoRand()
-
-	var statements []string
-	var insert bytes.Buffer
-	for i := 0; i < count; i += bankDataInsertRows {
-		insert.Reset()
-		insert.WriteString(`INSERT INTO bench.bank VALUES `)
-		for j := i; j < i+bankDataInsertRows && j < count; j++ {
-			if j != i {
-				insert.WriteRune(',')
-			}
-			payload := randutil.RandBytes(rng, backupRestoreRowPayloadSize)
-			fmt.Fprintf(&insert, `(%d, %d, 'initial-%s')`, j, 0, payload)
-		}
-		statements = append(statements, insert.String())
-	}
-	return statements
-}
-
-func bankSplitStmt(numAccounts int, numRanges int) string {
-	// Asking for more splits than ranges doesn't make any sense. Because of the
-	// way go benchmarks work, split each row into a range instead of erroring.
-	if numRanges > numAccounts {
-		numRanges = numAccounts
-	}
-
-	var stmt bytes.Buffer
-	stmt.WriteString("ALTER TABLE bench.bank SPLIT AT VALUES ")
-
-	for i, incr := 1, numAccounts/numRanges; i < numRanges; i++ {
-		if i > 1 {
-			stmt.WriteString(", ")
-		}
-		fmt.Fprintf(&stmt, "(%d)", i*incr)
-	}
-	return stmt.String()
-}
 
 func backupRestoreTestSetupWithParams(
 	t testing.TB, clusterSize int, numAccounts int, params base.TestClusterArgs,
@@ -130,18 +84,16 @@ func backupRestoreTestSetupWithParams(
 		}
 	}
 
-	sqlDB = sqlutils.MakeSQLRunner(t, tc.Conns[0])
-
-	sqlDB.Exec(bankCreateDatabase)
-	sqlDB.Exec(bankCreateTable)
-	for _, insert := range bankDataInsertStmts(numAccounts) {
-		sqlDB.Exec(insert)
+	const payloadSize = 100
+	splits := 10
+	if numAccounts == 0 {
+		splits = 0
 	}
+	bankData := sampledataccl.Bank(numAccounts, payloadSize, splits)
 
-	if numAccounts > 0 {
-		split := bankSplitStmt(numAccounts, backupRestoreDefaultRanges)
-		// This occasionally flakes, so ignore errors.
-		_, _ = sqlDB.DB.Exec(split)
+	sqlDB = sqlutils.MakeSQLRunner(t, tc.Conns[0])
+	if err := sampledataccl.Setup(sqlDB.DB, bankData); err != nil {
+		t.Fatalf("%+v", err)
 	}
 
 	if err := tc.WaitForFullReplication(); err != nil {
@@ -235,15 +187,15 @@ func TestBackupRestoreStatementResult(t *testing.T) {
 	defer cleanupFn()
 
 	if err := verifyBackupRestoreStatementResult(
-		sqlDB, "BACKUP DATABASE bench TO $1", dir,
+		sqlDB, "BACKUP DATABASE data TO $1", dir,
 	); err != nil {
 		t.Fatal(err)
 	}
 
-	sqlDB.Exec("CREATE DATABASE bench2")
+	sqlDB.Exec("CREATE DATABASE data2")
 
 	if err := verifyBackupRestoreStatementResult(
-		sqlDB, "RESTORE bench.* FROM $1 WITH OPTIONS ('into_db'='bench2')", dir,
+		sqlDB, "RESTORE data.* FROM $1 WITH OPTIONS ('into_db'='data2')", dir,
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -293,11 +245,11 @@ func TestBackupRestoreNegativePrimaryKey(t *testing.T) {
 	defer cleanupFn()
 
 	// Give half the accounts negative primary keys.
-	sqlDB.Exec(`UPDATE bench.bank SET id = $1 - id WHERE id > $1`, numAccounts/2)
+	sqlDB.Exec(`UPDATE data.bank SET id = $1 - id WHERE id > $1`, numAccounts/2)
 
 	// Resplit that half of the table space.
 	sqlDB.Exec(
-		`ALTER TABLE bench.bank SPLIT AT SELECT generate_series($1, 0, $2)`,
+		`ALTER TABLE data.bank SPLIT AT SELECT generate_series($1, 0, $2)`,
 		-numAccounts/2, numAccounts/backupRestoreDefaultRanges/2,
 	)
 
@@ -308,11 +260,11 @@ func backupAndRestore(
 	ctx context.Context, t *testing.T, sqlDB *sqlutils.SQLRunner, dest string, numAccounts int,
 ) {
 	{
-		sqlDB.Exec(`CREATE INDEX balance_idx ON bench.bank (balance)`)
+		sqlDB.Exec(`CREATE INDEX balance_idx ON data.bank (balance)`)
 		testutils.SucceedsSoon(t, func() error {
 			var unused string
 			var createTable string
-			sqlDB.QueryRow(`SHOW CREATE TABLE bench.bank`).Scan(&unused, &createTable)
+			sqlDB.QueryRow(`SHOW CREATE TABLE data.bank`).Scan(&unused, &createTable)
 			if !strings.Contains(createTable, "balance_idx") {
 				return errors.New("expected a balance_idx index")
 			}
@@ -321,7 +273,7 @@ func backupAndRestore(
 
 		var unused string
 		var bytes int64
-		sqlDB.QueryRow(`BACKUP DATABASE bench TO $1`, dest).Scan(
+		sqlDB.QueryRow(`BACKUP DATABASE data TO $1`, dest).Scan(
 			&unused, &unused, &unused, &bytes,
 		)
 		// When numAccounts == 0, our approxBytes formula breaks down because
@@ -329,11 +281,11 @@ func backupAndRestore(
 		// tables. Just skip the check in this case.
 		if numAccounts > 0 {
 			approxBytes := int64(backupRestoreRowPayloadSize * numAccounts)
-			if max := approxBytes * 2; bytes < approxBytes || bytes > max {
+			if max := approxBytes * 3; bytes < approxBytes || bytes > max {
 				t.Errorf("expected data size in [%d,%d] but was %d", approxBytes, max, bytes)
 			}
 		}
-		if _, err := sqlDB.DB.Exec(`BACKUP DATABASE bench TO $1`, dest); !testutils.IsError(err,
+		if _, err := sqlDB.DB.Exec(`BACKUP DATABASE data TO $1`, dest); !testutils.IsError(err,
 			"already appears to exist",
 		) {
 			t.Fatalf("expeted to refused to overwrite, got %v", err)
@@ -348,31 +300,32 @@ func backupAndRestore(
 
 		// Create some other descriptors to change up IDs
 		sqlDBRestore.Exec(`CREATE DATABASE other`)
+		// Force the ID of the restored bank table to be different.
 		sqlDBRestore.Exec(`CREATE TABLE other.empty (a INT PRIMARY KEY)`)
 
 		// Restore assumes the database exists.
-		sqlDBRestore.Exec(bankCreateDatabase)
+		sqlDBRestore.Exec(`CREATE DATABASE data`)
 
 		// Force the ID of the restored bank table to be different.
-		sqlDBRestore.Exec(`CREATE TABLE bench.empty (a INT PRIMARY KEY)`)
+		sqlDBRestore.Exec(`CREATE TABLE data.empty (a INT PRIMARY KEY)`)
 
 		var unused string
 		var bytes int64
-		sqlDBRestore.QueryRow(`RESTORE bench.* FROM $1`, dest).Scan(
+		sqlDBRestore.QueryRow(`RESTORE data.* FROM $1`, dest).Scan(
 			&unused, &unused, &unused, &bytes,
 		)
 		approxBytes := int64(backupRestoreRowPayloadSize * numAccounts)
-		if max := approxBytes * 2; bytes < approxBytes || bytes > max {
+		if max := approxBytes * 3; bytes < approxBytes || bytes > max {
 			t.Errorf("expected data size in [%d,%d] but was %d", approxBytes, max, bytes)
 		}
 
 		var rowCount int64
-		sqlDBRestore.QueryRow(`SELECT COUNT(*) FROM bench.bank`).Scan(&rowCount)
+		sqlDBRestore.QueryRow(`SELECT COUNT(*) FROM data.bank`).Scan(&rowCount)
 		if rowCount != int64(numAccounts) {
 			t.Fatalf("expected %d rows but found %d", numAccounts, rowCount)
 		}
 
-		sqlDBRestore.QueryRow(`SELECT COUNT(*) FROM bench.bank@balance_idx`).Scan(&rowCount)
+		sqlDBRestore.QueryRow(`SELECT COUNT(*) FROM data.bank@balance_idx`).Scan(&rowCount)
 		if rowCount != int64(numAccounts) {
 			t.Fatalf("expected %d rows but found %d", numAccounts, rowCount)
 		}
@@ -451,6 +404,7 @@ func verifySystemJobProgress(
 
 func TestBackupRestoreSystemJobs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("TODO(dan): BEFORE MERGE")
 
 	const expectedProgressUpdateCount = backupRestoreDefaultRanges
 
@@ -500,14 +454,14 @@ func TestBackupRestoreSystemJobs(t *testing.T) {
 	allowResponse = make(chan struct{})
 	// Closing the channel allows export responses to proceed immediately.
 	close(allowResponse)
-	sqlDB.Exec(`BACKUP DATABASE bench TO $1`, fullDir)
+	sqlDB.Exec(`BACKUP DATABASE data TO $1`, fullDir)
 
 	jobDone := make(chan error)
 
 	{
 		allowResponse = make(chan struct{})
 		go func() {
-			_, err := sqlDB.DB.Exec(`BACKUP DATABASE bench TO $1 INCREMENTAL FROM $2`, incDir, fullDir)
+			_, err := sqlDB.DB.Exec(`BACKUP DATABASE data TO $1 INCREMENTAL FROM $2`, incDir, fullDir)
 			jobDone <- err
 		}()
 
@@ -521,14 +475,14 @@ func TestBackupRestoreSystemJobs(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		tableID, err := sqlutils.QueryTableID(sqlDB.DB, "bench", "bank")
+		tableID, err := sqlutils.QueryTableID(sqlDB.DB, "data", "bank")
 		if err != nil {
 			t.Fatal(err)
 		}
 		if err := verifySystemJob(sqlDB, 1, jobs.JobTypeBackup, jobs.JobRecord{
 			Username: security.RootUser,
 			Description: fmt.Sprintf(
-				`BACKUP DATABASE bench TO '%s' INCREMENTAL FROM '%s'`,
+				`BACKUP DATABASE data TO '%s' INCREMENTAL FROM '%s'`,
 				sanitizedIncDir, sanitizedFullDir,
 			),
 			DescriptorIDs: sqlbase.IDs{
@@ -542,11 +496,11 @@ func TestBackupRestoreSystemJobs(t *testing.T) {
 	}
 
 	{
-		sqlDB.Exec(`CREATE DATABASE bench2`)
+		sqlDB.Exec(`CREATE DATABASE data2`)
 
 		allowResponse = make(chan struct{})
 		go func() {
-			_, err := sqlDB.DB.Exec(`RESTORE bench.* FROM $1, $2 WITH OPTIONS ('into_db'='bench2')`, fullDir, incDir)
+			_, err := sqlDB.DB.Exec(`RESTORE data.* FROM $1, $2 WITH OPTIONS ('into_db'='data2')`, fullDir, incDir)
 			jobDone <- err
 		}()
 
@@ -560,14 +514,14 @@ func TestBackupRestoreSystemJobs(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		databaseID, err := sqlutils.QueryDatabaseID(sqlDB.DB, "bench2")
+		databaseID, err := sqlutils.QueryDatabaseID(sqlDB.DB, "data2")
 		if err != nil {
 			t.Fatal(err)
 		}
 		if err := verifySystemJob(sqlDB, 2, jobs.JobTypeRestore, jobs.JobRecord{
 			Username: security.RootUser,
 			Description: fmt.Sprintf(
-				`RESTORE bench.* FROM '%s', '%s' WITH OPTIONS ('into_db'='bench2')`,
+				`RESTORE data.* FROM '%s', '%s' WITH OPTIONS ('into_db'='data2')`,
 				sanitizedFullDir, sanitizedIncDir,
 			),
 			DescriptorIDs: sqlbase.IDs{
@@ -588,7 +542,7 @@ func TestBackupRestoreInterleaved(t *testing.T) {
 
 	// TODO(dan): The INTERLEAVE IN PARENT clause currently doesn't allow the
 	// `db.table` syntax. Fix that and use it here instead of `SET DATABASE`.
-	_ = sqlDB.Exec(`SET DATABASE = bench`)
+	_ = sqlDB.Exec(`SET DATABASE = data`)
 	_ = sqlDB.Exec(`CREATE TABLE i0 (a INT, b INT, PRIMARY KEY (a, b)) INTERLEAVE IN PARENT bank (a)`)
 	_ = sqlDB.Exec(`CREATE TABLE i0_0 (a INT, b INT, c INT, PRIMARY KEY (a, b, c)) INTERLEAVE IN PARENT i0 (a, b)`)
 	_ = sqlDB.Exec(`CREATE TABLE i1 (a INT, b INT, PRIMARY KEY (a, b)) INTERLEAVE IN PARENT bank (a)`)
@@ -604,7 +558,7 @@ func TestBackupRestoreInterleaved(t *testing.T) {
 	_ = sqlDB.Exec(`ALTER TABLE i0 SPLIT AT SELECT * from i0 LIMIT $1`, numAccounts)
 	_ = sqlDB.Exec(`ALTER TABLE i0_0 SPLIT AT SELECT * from i0 LIMIT $1`, numAccounts)
 	_ = sqlDB.Exec(`ALTER TABLE i1 SPLIT AT SELECT * from i0 LIMIT $1`, numAccounts)
-	_ = sqlDB.Exec(`BACKUP DATABASE bench TO $1`, dir)
+	_ = sqlDB.Exec(`BACKUP DATABASE data TO $1`, dir)
 
 	t.Run("all tables in interleave hierarchy", func(t *testing.T) {
 		tcRestore := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{})
@@ -612,24 +566,24 @@ func TestBackupRestoreInterleaved(t *testing.T) {
 		sqlDBRestore := sqlutils.MakeSQLRunner(t, tcRestore.Conns[0])
 		// Create a dummy database to verify rekeying is correctly performed.
 		sqlDBRestore.Exec(`CREATE DATABASE ignored`)
-		sqlDBRestore.Exec(bankCreateDatabase)
+		sqlDBRestore.Exec(`CREATE DATABASE data`)
 
-		sqlDBRestore.Exec(`RESTORE bench.* FROM $1`, dir)
+		sqlDBRestore.Exec(`RESTORE data.* FROM $1`, dir)
 
 		var rowCount int64
-		sqlDBRestore.QueryRow(`SELECT COUNT(*) FROM bench.bank`).Scan(&rowCount)
+		sqlDBRestore.QueryRow(`SELECT COUNT(*) FROM data.bank`).Scan(&rowCount)
 		if rowCount != numAccounts {
 			t.Errorf("expected %d rows but found %d", numAccounts, rowCount)
 		}
-		sqlDBRestore.QueryRow(`SELECT COUNT(*) FROM bench.i0`).Scan(&rowCount)
+		sqlDBRestore.QueryRow(`SELECT COUNT(*) FROM data.i0`).Scan(&rowCount)
 		if rowCount != 2*numAccounts {
 			t.Errorf("expected %d rows but found %d", 2*numAccounts, rowCount)
 		}
-		sqlDBRestore.QueryRow(`SELECT COUNT(*) FROM bench.i0_0`).Scan(&rowCount)
+		sqlDBRestore.QueryRow(`SELECT COUNT(*) FROM data.i0_0`).Scan(&rowCount)
 		if rowCount != 3*numAccounts {
 			t.Errorf("expected %d rows but found %d", 3*numAccounts, rowCount)
 		}
-		sqlDBRestore.QueryRow(`SELECT COUNT(*) FROM bench.i1`).Scan(&rowCount)
+		sqlDBRestore.QueryRow(`SELECT COUNT(*) FROM data.i1`).Scan(&rowCount)
 		if rowCount != 4*numAccounts {
 			t.Errorf("expected %d rows but found %d", 4*numAccounts, rowCount)
 		}
@@ -639,9 +593,9 @@ func TestBackupRestoreInterleaved(t *testing.T) {
 		tcRestore := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{})
 		defer tcRestore.Stopper().Stop(context.TODO())
 		sqlDBRestore := sqlutils.MakeSQLRunner(t, tcRestore.Conns[0])
-		sqlDBRestore.Exec(bankCreateDatabase)
+		sqlDBRestore.Exec(`CREATE DATABASE data`)
 
-		_, err := sqlDBRestore.DB.Exec(`RESTORE TABLE bench.i0 FROM $1`, dir)
+		_, err := sqlDBRestore.DB.Exec(`RESTORE TABLE data.i0 FROM $1`, dir)
 		if !testutils.IsError(err, "without interleave parent") {
 			t.Fatalf("expected 'without interleave parent' error but got: %+v", err)
 		}
@@ -651,9 +605,9 @@ func TestBackupRestoreInterleaved(t *testing.T) {
 		tcRestore := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{})
 		defer tcRestore.Stopper().Stop(context.TODO())
 		sqlDBRestore := sqlutils.MakeSQLRunner(t, tcRestore.Conns[0])
-		sqlDBRestore.Exec(bankCreateDatabase)
+		sqlDBRestore.Exec(`CREATE DATABASE data`)
 
-		_, err := sqlDBRestore.DB.Exec(`RESTORE TABLE bench.bank FROM $1`, dir)
+		_, err := sqlDBRestore.DB.Exec(`RESTORE TABLE data.bank FROM $1`, dir)
 		if !testutils.IsError(err, "without interleave child") {
 			t.Fatalf("expected 'without interleave child' error but got: %+v", err)
 		}
@@ -691,7 +645,7 @@ func TestBackupRestoreCrossTableReferences(t *testing.T) {
 		)`)
 
 		// unused makes our table IDs non-contiguous.
-		origDB.Exec(`CREATE TABLE bench.unused (id INT PRIMARY KEY)`)
+		origDB.Exec(`CREATE TABLE data.unused (id INT PRIMARY KEY)`)
 
 		// receipts is has a self-referential FK.
 		origDB.Exec(`CREATE TABLE store.receipts (
@@ -946,7 +900,7 @@ func TestBackupRestoreCrossTableReferences(t *testing.T) {
 
 func checksumBankPayload(t *testing.T, sqlDB *sqlutils.SQLRunner) uint32 {
 	crc := crc32.New(crc32.MakeTable(crc32.Castagnoli))
-	rows := sqlDB.Query(`SELECT id, balance, payload FROM bench.bank`)
+	rows := sqlDB.Query(`SELECT id, balance, payload FROM data.bank`)
 	defer rows.Close()
 	var id, balance int
 	var payload []byte
@@ -985,8 +939,8 @@ func TestBackupRestoreIncremental(t *testing.T) {
 			// mutates [o+w,o+2w), and inserts [o+2w,o+3w).
 			offset := windowSize * backupNum
 			var buf bytes.Buffer
-			fmt.Fprintf(&buf, `DELETE FROM bench.bank WHERE id < %d; `, offset)
-			buf.WriteString(`UPSERT INTO bench.bank VALUES `)
+			fmt.Fprintf(&buf, `DELETE FROM data.bank WHERE id < %d; `, offset)
+			buf.WriteString(`UPSERT INTO data.bank VALUES `)
 			for j := 0; j < windowSize*2; j++ {
 				if j != 0 {
 					buf.WriteRune(',')
@@ -1004,7 +958,7 @@ func TestBackupRestoreIncremental(t *testing.T) {
 			if backupNum > 0 {
 				from = fmt.Sprintf(` INCREMENTAL FROM %s`, strings.Join(backupDirs, `,`))
 			}
-			sqlDB.Exec(fmt.Sprintf(`BACKUP TABLE bench.bank TO '%s' %s`, backupDir, from))
+			sqlDB.Exec(fmt.Sprintf(`BACKUP TABLE data.bank TO '%s' %s`, backupDir, from))
 
 			backupDirs = append(backupDirs, fmt.Sprintf(`'%s'`, backupDir))
 		}
@@ -1012,10 +966,10 @@ func TestBackupRestoreIncremental(t *testing.T) {
 		// Test a regression in RESTORE where the WriteBatch end key was not
 		// being set correctly in Import: make an incremental backup such that
 		// the greatest key in the diff is less than the previous backups.
-		sqlDB.Exec(`INSERT INTO bench.bank VALUES (0, -1, 'final')`)
+		sqlDB.Exec(`INSERT INTO data.bank VALUES (0, -1, 'final')`)
 		checksums = append(checksums, checksumBankPayload(t, sqlDB))
 		finalBackupDir := filepath.Join(dir, "final")
-		sqlDB.Exec(fmt.Sprintf(`BACKUP TABLE bench.bank TO '%s' %s`,
+		sqlDB.Exec(fmt.Sprintf(`BACKUP TABLE data.bank TO '%s' %s`,
 			finalBackupDir, fmt.Sprintf(` INCREMENTAL FROM %s`, strings.Join(backupDirs, `,`)),
 		))
 		backupDirs = append(backupDirs, fmt.Sprintf(`'%s'`, finalBackupDir))
@@ -1027,12 +981,12 @@ func TestBackupRestoreIncremental(t *testing.T) {
 		defer tc.Stopper().Stop(context.TODO())
 		sqlDBRestore := sqlutils.MakeSQLRunner(t, tc.Conns[0])
 
-		sqlDBRestore.Exec(`CREATE DATABASE bench`)
+		sqlDBRestore.Exec(`CREATE DATABASE data`)
 
 		for i := len(backupDirs); i > 0; i-- {
-			sqlDBRestore.Exec(`DROP TABLE IF EXISTS bench.bank`)
+			sqlDBRestore.Exec(`DROP TABLE IF EXISTS data.bank`)
 			from := strings.Join(backupDirs[:i], `,`)
-			sqlDBRestore.Exec(fmt.Sprintf(`RESTORE bench.bank FROM %s`, from))
+			sqlDBRestore.Exec(fmt.Sprintf(`RESTORE data.bank FROM %s`, from))
 
 			testutils.SucceedsSoon(t, func() error {
 				checksum := checksumBankPayload(t, sqlDBRestore)
@@ -1075,7 +1029,7 @@ func startBackgroundWrites(
 			default:
 				// Keep going.
 			}
-			_, err := sqlDB.Exec(`UPDATE bench.bank SET payload = $1 WHERE id = $2`, payload, id)
+			_, err := sqlDB.Exec(`UPDATE data.bank SET payload = $1 WHERE id = $2`, payload, id)
 			if atomic.LoadInt32(allowErrors) == 1 {
 				return nil
 			}
@@ -1115,30 +1069,30 @@ func TestBackupRestoreWithConcurrentWrites(t *testing.T) {
 		})
 	}
 
-	// Use the bench.bank table as a key (id), value (balance) table with a
+	// Use the data.bank table as a key (id), value (balance) table with a
 	// payload.The background tasks are mutating the table concurrently while we
 	// backup and restore.
 	<-bgActivity
 
 	// Set, break, then reset the id=balance invariant -- while doing concurrent
 	// writes -- to get multiple MVCC revisions as well as txn conflicts.
-	sqlDB.Exec(`UPDATE bench.bank SET balance = id`)
+	sqlDB.Exec(`UPDATE data.bank SET balance = id`)
 	<-bgActivity
-	sqlDB.Exec(`UPDATE bench.bank SET balance = -1`)
+	sqlDB.Exec(`UPDATE data.bank SET balance = -1`)
 	<-bgActivity
-	sqlDB.Exec(`UPDATE bench.bank SET balance = id`)
+	sqlDB.Exec(`UPDATE data.bank SET balance = id`)
 	<-bgActivity
 
 	// Backup DB while concurrent writes continue.
-	sqlDB.Exec(`BACKUP DATABASE bench TO $1`, baseDir)
+	sqlDB.Exec(`BACKUP DATABASE data TO $1`, baseDir)
 
 	// Drop the table and restore from backup and check our invariant.
 	atomic.StoreInt32(&allowErrors, 1)
-	sqlDB.Exec(`DROP TABLE bench.bank`)
-	sqlDB.Exec(`RESTORE bench.* FROM $1`, baseDir)
+	sqlDB.Exec(`DROP TABLE data.bank`)
+	sqlDB.Exec(`RESTORE data.* FROM $1`, baseDir)
 	atomic.StoreInt32(&allowErrors, 0)
 
-	bad := sqlDB.QueryStr(`SELECT id, balance, payload FROM bench.bank WHERE id != balance`)
+	bad := sqlDB.QueryStr(`SELECT id, balance, payload FROM data.bank WHERE id != balance`)
 	for _, r := range bad {
 		t.Errorf("bad row ID %s = bal %s (payload: %q)", r[0], r[1], r[2])
 	}
@@ -1156,20 +1110,20 @@ func TestBackupAsOfSystemTime(t *testing.T) {
 	var rowCount int64
 
 	sqlDB.QueryRow(`SELECT cluster_logical_timestamp()`).Scan(&ts)
-	sqlDB.Exec(`TRUNCATE bench.bank`)
+	sqlDB.Exec(`TRUNCATE data.bank`)
 
-	sqlDB.QueryRow(`SELECT COUNT(*) FROM bench.bank`).Scan(&rowCount)
+	sqlDB.QueryRow(`SELECT COUNT(*) FROM data.bank`).Scan(&rowCount)
 	if rowCount != 0 {
 		t.Fatalf("expected 0 rows but found %d", rowCount)
 	}
 
-	sqlDB.Exec(fmt.Sprintf(`BACKUP DATABASE bench TO '%s' AS OF SYSTEM TIME %s`, dir, ts))
+	sqlDB.Exec(fmt.Sprintf(`BACKUP DATABASE data TO '%s' AS OF SYSTEM TIME %s`, dir, ts))
 
-	sqlDB.Exec(`DROP TABLE bench.bank`)
+	sqlDB.Exec(`DROP TABLE data.bank`)
 
-	sqlDB.Exec(`RESTORE bench.* FROM $1`, dir)
+	sqlDB.Exec(`RESTORE data.* FROM $1`, dir)
 
-	sqlDB.QueryRow(`SELECT COUNT(*) FROM bench.bank`).Scan(&rowCount)
+	sqlDB.QueryRow(`SELECT COUNT(*) FROM data.bank`).Scan(&rowCount)
 	if rowCount != numAccounts {
 		t.Fatalf("expected %d rows but found %d", numAccounts, rowCount)
 	}
@@ -1185,11 +1139,11 @@ func TestBackupRestoreChecksum(t *testing.T) {
 	// The helper helpfully prefixes it, but we're going to do direct file IO.
 	rawDir := strings.TrimPrefix(dir, "nodelocal://")
 
-	sqlDB.Exec(`BACKUP DATABASE bench TO $1`, dir)
+	sqlDB.Exec(`BACKUP DATABASE data TO $1`, dir)
 
-	var backupDesc BackupDescriptor
+	var backupDesc sqlccl.BackupDescriptor
 	{
-		backupDescBytes, err := ioutil.ReadFile(filepath.Join(rawDir, BackupDescriptorName))
+		backupDescBytes, err := ioutil.ReadFile(filepath.Join(rawDir, sqlccl.BackupDescriptorName))
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
@@ -1216,8 +1170,8 @@ func TestBackupRestoreChecksum(t *testing.T) {
 		t.Fatalf("%+v", err)
 	}
 
-	sqlDB.Exec(`DROP TABLE bench.bank`)
-	_, err = sqlDB.DB.Exec(`RESTORE bench.* FROM $1`, dir)
+	sqlDB.Exec(`DROP TABLE data.bank`)
+	_, err = sqlDB.DB.Exec(`RESTORE data.* FROM $1`, dir)
 	if !testutils.IsError(err, "checksum mismatch") {
 		t.Fatalf("expected 'checksum mismatch' error got: %+v", err)
 	}
@@ -1229,79 +1183,79 @@ func TestTimestampMismatch(t *testing.T) {
 
 	_, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts)
 	defer cleanupFn()
-	sqlDB.Exec(`CREATE TABLE bench.t2 (a INT PRIMARY KEY)`)
-	sqlDB.Exec(`INSERT INTO bench.t2 VALUES (1)`)
+	sqlDB.Exec(`CREATE TABLE data.t2 (a INT PRIMARY KEY)`)
+	sqlDB.Exec(`INSERT INTO data.t2 VALUES (1)`)
 
 	fullBackup := filepath.Join(dir, "0")
 	incrementalT1FromFull := filepath.Join(dir, "1")
 	incrementalT2FromT1 := filepath.Join(dir, "2")
 	incrementalT3FromT1OneTable := filepath.Join(dir, "3")
 
-	sqlDB.Exec(`BACKUP DATABASE bench TO $1`,
+	sqlDB.Exec(`BACKUP DATABASE data TO $1`,
 		fullBackup)
-	sqlDB.Exec(`BACKUP DATABASE bench TO $1 INCREMENTAL FROM $2`,
+	sqlDB.Exec(`BACKUP DATABASE data TO $1 INCREMENTAL FROM $2`,
 		incrementalT1FromFull, fullBackup)
-	sqlDB.Exec(`BACKUP TABLE bench.bank TO $1 INCREMENTAL FROM $2`,
+	sqlDB.Exec(`BACKUP TABLE data.bank TO $1 INCREMENTAL FROM $2`,
 		incrementalT3FromT1OneTable, fullBackup)
-	sqlDB.Exec(`BACKUP DATABASE bench TO $1 INCREMENTAL FROM $2, $3`,
+	sqlDB.Exec(`BACKUP DATABASE data TO $1 INCREMENTAL FROM $2, $3`,
 		incrementalT2FromT1, fullBackup, incrementalT1FromFull)
 
 	t.Run("Backup", func(t *testing.T) {
 		// Missing the initial full backup.
-		_, err := sqlDB.DB.Exec(`BACKUP DATABASE bench TO $1 INCREMENTAL FROM $2`,
+		_, err := sqlDB.DB.Exec(`BACKUP DATABASE data TO $1 INCREMENTAL FROM $2`,
 			dir, incrementalT1FromFull)
 		if !testutils.IsError(err, "no backup covers time") {
 			t.Errorf("expected 'no backup covers time' error got: %+v", err)
 		}
 
 		// Missing an intermediate incremental backup.
-		_, err = sqlDB.DB.Exec(`BACKUP DATABASE bench TO $1 INCREMENTAL FROM $2, $3`,
+		_, err = sqlDB.DB.Exec(`BACKUP DATABASE data TO $1 INCREMENTAL FROM $2, $3`,
 			dir, fullBackup, incrementalT2FromT1)
 		if !testutils.IsError(err, "no backup covers time") {
 			t.Errorf("expected 'no backup covers time' error got: %+v", err)
 		}
 
 		// Backups specified out of order.
-		_, err = sqlDB.DB.Exec(`BACKUP DATABASE bench TO $1 INCREMENTAL FROM $2, $3`,
+		_, err = sqlDB.DB.Exec(`BACKUP DATABASE data TO $1 INCREMENTAL FROM $2, $3`,
 			dir, incrementalT1FromFull, fullBackup)
 		if !testutils.IsError(err, "out of order") {
 			t.Errorf("expected 'out of order' error got: %+v", err)
 		}
 
 		// Missing data for one table in the most recent backup.
-		_, err = sqlDB.DB.Exec(`BACKUP DATABASE bench TO $1 INCREMENTAL FROM $2, $3`,
+		_, err = sqlDB.DB.Exec(`BACKUP DATABASE data TO $1 INCREMENTAL FROM $2, $3`,
 			dir, fullBackup, incrementalT3FromT1OneTable)
 		if !testutils.IsError(err, "no backup covers time") {
 			t.Errorf("expected 'no backup covers time' error got: %+v", err)
 		}
 	})
 
-	sqlDB.Exec(`DROP TABLE bench.bank`)
-	sqlDB.Exec(`DROP TABLE bench.t2`)
+	sqlDB.Exec(`DROP TABLE data.bank`)
+	sqlDB.Exec(`DROP TABLE data.t2`)
 	t.Run("Restore", func(t *testing.T) {
 		// Missing the initial full backup.
-		_, err := sqlDB.DB.Exec(`RESTORE bench.* FROM $1`,
+		_, err := sqlDB.DB.Exec(`RESTORE data.* FROM $1`,
 			incrementalT1FromFull)
 		if !testutils.IsError(err, "no backup covers time") {
 			t.Errorf("expected 'no backup covers time' error got: %+v", err)
 		}
 
 		// Missing an intermediate incremental backup.
-		_, err = sqlDB.DB.Exec(`RESTORE bench.* FROM $1, $2`,
+		_, err = sqlDB.DB.Exec(`RESTORE data.* FROM $1, $2`,
 			fullBackup, incrementalT2FromT1)
 		if !testutils.IsError(err, "no backup covers time") {
 			t.Errorf("expected 'no backup covers time' error got: %+v", err)
 		}
 
 		// Backups specified out of order.
-		_, err = sqlDB.DB.Exec(`RESTORE bench.* FROM $1, $2`,
+		_, err = sqlDB.DB.Exec(`RESTORE data.* FROM $1, $2`,
 			incrementalT1FromFull, fullBackup)
 		if !testutils.IsError(err, "out of order") {
 			t.Errorf("expected 'out of order' error got: %+v", err)
 		}
 
 		// Missing data for one table in the most recent backup.
-		_, err = sqlDB.DB.Exec(`RESTORE bench.* FROM $1, $2`,
+		_, err = sqlDB.DB.Exec(`RESTORE data.* FROM $1, $2`,
 			fullBackup, incrementalT3FromT1OneTable)
 		if !testutils.IsError(err, "no backup covers time") {
 			t.Errorf("expected 'no backup covers time' error got: %+v", err)
@@ -1325,12 +1279,12 @@ func TestPresplitRanges(t *testing.T) {
 				key := encoding.EncodeUvarintAscending(append([]byte(nil), baseKey...), uint64(i))
 				splitPoints = append(splitPoints, key)
 			}
-			if err := presplitRanges(ctx, *kvDB, splitPoints); err != nil {
+			if err := sqlccl.PresplitRanges(ctx, *kvDB, splitPoints); err != nil {
 				t.Error(err)
 			}
 
 			// Verify that the splits exist.
-			// Note that presplitRanges adds the row sentinel to make a valid table
+			// Note that PresplitRanges adds the row sentinel to make a valid table
 			// key, but AdminSplit internally removes it (via EnsureSafeSplitKey). So
 			// we expect splits that match the splitPoints exactly.
 			for _, splitKey := range splitPoints {
@@ -1373,7 +1327,7 @@ func TestBackupLevelDB(t *testing.T) {
 	_, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, singleNode, 0)
 	defer cleanupFn()
 
-	_ = sqlDB.Exec(`BACKUP DATABASE bench TO $1`, dir)
+	_ = sqlDB.Exec(`BACKUP DATABASE data TO $1`, dir)
 	rawDir := strings.TrimPrefix(dir, "nodelocal://")
 	// Verify that the sstables are in LevelDB format by checking the trailer
 	// magic.
@@ -1406,34 +1360,34 @@ func TestRestoredPrivileges(t *testing.T) {
 	_, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts)
 	defer cleanupFn()
 
-	rootOnly := sqlDB.QueryStr(`SHOW GRANTS ON bench.bank`)
+	rootOnly := sqlDB.QueryStr(`SHOW GRANTS ON data.bank`)
 
 	sqlDB.Exec(`CREATE USER someone`)
-	sqlDB.Exec(`GRANT SELECT, INSERT, UPDATE, DELETE ON bench.bank TO someone`)
+	sqlDB.Exec(`GRANT SELECT, INSERT, UPDATE, DELETE ON data.bank TO someone`)
 
-	withGrants := sqlDB.QueryStr(`SHOW GRANTS ON bench.bank`)
+	withGrants := sqlDB.QueryStr(`SHOW GRANTS ON data.bank`)
 
-	sqlDB.Exec(`BACKUP DATABASE bench TO $1`, dir)
-	sqlDB.Exec(`DROP TABLE bench.bank`)
+	sqlDB.Exec(`BACKUP DATABASE data TO $1`, dir)
+	sqlDB.Exec(`DROP TABLE data.bank`)
 
 	t.Run("into fresh db", func(t *testing.T) {
 		tc := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{})
 		defer tc.Stopper().Stop(context.TODO())
 		sqlDBRestore := sqlutils.MakeSQLRunner(t, tc.Conns[0])
-		sqlDBRestore.Exec(`CREATE DATABASE bench`)
-		sqlDBRestore.Exec(`RESTORE bench.bank FROM $1`, dir)
-		sqlDBRestore.CheckQueryResults(`SHOW GRANTS ON bench.bank`, rootOnly)
+		sqlDBRestore.Exec(`CREATE DATABASE data`)
+		sqlDBRestore.Exec(`RESTORE data.bank FROM $1`, dir)
+		sqlDBRestore.CheckQueryResults(`SHOW GRANTS ON data.bank`, rootOnly)
 	})
 
 	t.Run("into db with added grants", func(t *testing.T) {
 		tc := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{})
 		defer tc.Stopper().Stop(context.TODO())
 		sqlDBRestore := sqlutils.MakeSQLRunner(t, tc.Conns[0])
-		sqlDBRestore.Exec(`CREATE DATABASE bench`)
+		sqlDBRestore.Exec(`CREATE DATABASE data`)
 		sqlDBRestore.Exec(`CREATE USER someone`)
-		sqlDBRestore.Exec(`GRANT SELECT, INSERT, UPDATE, DELETE ON DATABASE bench TO someone`)
-		sqlDBRestore.Exec(`RESTORE bench.bank FROM $1`, dir)
-		sqlDBRestore.CheckQueryResults(`SHOW GRANTS ON bench.bank`, withGrants)
+		sqlDBRestore.Exec(`GRANT SELECT, INSERT, UPDATE, DELETE ON DATABASE data TO someone`)
+		sqlDBRestore.Exec(`RESTORE data.bank FROM $1`, dir)
+		sqlDBRestore.CheckQueryResults(`SHOW GRANTS ON data.bank`, withGrants)
 	})
 }
 
@@ -1444,20 +1398,20 @@ func TestRestoreInto(t *testing.T) {
 	_, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts)
 	defer cleanupFn()
 
-	sqlDB.Exec(`BACKUP DATABASE bench TO $1`, dir)
+	sqlDB.Exec(`BACKUP DATABASE data TO $1`, dir)
 
-	restoreStmt := fmt.Sprintf(`RESTORE bench.bank FROM '%s' WITH OPTIONS ('into_db'='bench2')`, dir)
+	restoreStmt := fmt.Sprintf(`RESTORE data.bank FROM '%s' WITH OPTIONS ('into_db'='data2')`, dir)
 
 	_, err := sqlDB.DB.Exec(restoreStmt)
-	if !testutils.IsError(err, "a database named \"bench2\" needs to exist") {
+	if !testutils.IsError(err, "a database named \"data2\" needs to exist") {
 		t.Fatal(err)
 	}
 
-	sqlDB.Exec(`CREATE DATABASE bench2`)
+	sqlDB.Exec(`CREATE DATABASE data2`)
 	sqlDB.Exec(restoreStmt)
 
-	expected := sqlDB.QueryStr(`SELECT * FROM bench.bank`)
-	sqlDB.CheckQueryResults(`SELECT * FROM bench2.bank`, expected)
+	expected := sqlDB.QueryStr(`SELECT * FROM data.bank`)
+	sqlDB.CheckQueryResults(`SELECT * FROM data2.bank`, expected)
 }
 
 func TestBackupRestorePermissions(t *testing.T) {
@@ -1478,7 +1432,7 @@ func TestBackupRestorePermissions(t *testing.T) {
 	}
 	defer testuser.Close()
 
-	backupStmt := fmt.Sprintf(`BACKUP DATABASE bench TO '%s'`, dir)
+	backupStmt := fmt.Sprintf(`BACKUP DATABASE data TO '%s'`, dir)
 
 	t.Run("root-only", func(t *testing.T) {
 		if _, err := testuser.Exec(backupStmt); !testutils.IsError(
@@ -1498,7 +1452,7 @@ func TestBackupRestorePermissions(t *testing.T) {
 		// Root doesn't have CREATE on `system` DB, so that should fail. Still need
 		// a valid `dir` though, since descriptors are always loaded first.
 		if _, err := sqlDB.DB.Exec(
-			`RESTORE bench.bank FROM $1 WITH OPTIONS ('into_db'='system')`, dir,
+			`RESTORE data.bank FROM $1 WITH OPTIONS ('into_db'='system')`, dir,
 		); !testutils.IsError(err, "user root does not have CREATE privilege") {
 			t.Fatal(err)
 		}

--- a/pkg/ccl/sqlccl/load.go
+++ b/pkg/ccl/sqlccl/load.go
@@ -326,6 +326,10 @@ func writeSST(
 	kvs []engine.MVCCKeyValue,
 	ts hlc.Timestamp,
 ) error {
+	if len(kvs) == 0 {
+		return nil
+	}
+
 	filename := fmt.Sprintf("load-%d.sst", rand.Int63())
 	log.Info(ctx, "writesst ", filename)
 

--- a/pkg/ccl/sqlccl/load_test.go
+++ b/pkg/ccl/sqlccl/load_test.go
@@ -6,12 +6,16 @@
 //
 //     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
 
-package sqlccl
+package sqlccl_test
 
 import (
 	"bytes"
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/sqlccl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl/sampledataccl"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -28,7 +32,7 @@ func TestImportChunking(t *testing.T) {
 	defer cleanupFn()
 
 	ts := hlc.Timestamp{WallTime: hlc.UnixNano()}
-	desc, err := Load(ctx, sqlDB.DB, bankStatementBuf(numAccounts), "bench", dir, ts, chunkSize, dir)
+	desc, err := sqlccl.Load(ctx, sqlDB.DB, bankBuf(numAccounts), "data", dir, ts, chunkSize, dir)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
@@ -43,14 +47,24 @@ func TestImportOutOfOrder(t *testing.T) {
 	ctx, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, singleNode, 0)
 	defer cleanupFn()
 
+	bankData := sampledataccl.Bank(2, 0, 0)
+	row1, ok := bankData.NextRow()
+	if !ok {
+		t.Fatalf("expected 2 rows")
+	}
+	row2, ok := bankData.NextRow()
+	if !ok {
+		t.Fatalf("expected 2 rows")
+	}
+
 	var buf bytes.Buffer
-	buf.WriteString(bankCreateTable + ";\n")
-	stmts := bankDataInsertStmts(2 * bankDataInsertRows)
-	buf.WriteString(stmts[1] + ";\n")
-	buf.WriteString(stmts[0] + ";\n")
+	fmt.Fprintf(&buf, "CREATE TABLE %s %s;\n", bankData.Name(), bankData.Schema())
+	// Intentionally write the rows out of order.
+	fmt.Fprintf(&buf, "INSERT INTO %s VALUES (%s);\n", bankData.Name(), strings.Join(row2, `,`))
+	fmt.Fprintf(&buf, "INSERT INTO %s VALUES (%s);\n", bankData.Name(), strings.Join(row1, `,`))
 
 	ts := hlc.Timestamp{WallTime: hlc.UnixNano()}
-	_, err := Load(ctx, sqlDB.DB, &buf, "bench", dir, ts, 0, dir)
+	_, err := sqlccl.Load(ctx, sqlDB.DB, &buf, "data", dir, ts, 0, dir)
 	if !testutils.IsError(err, "out of order row") {
 		t.Fatalf("expected out of order row, got: %+v", err)
 	}
@@ -63,11 +77,11 @@ func BenchmarkImport(b *testing.B) {
 	ctx, dir, _, sqlDB, cleanup := backupRestoreTestSetup(b, multiNode, 0)
 	defer cleanup()
 
-	buf := bankStatementBuf(b.N)
 	ts := hlc.Timestamp{WallTime: hlc.UnixNano()}
+	buf := bankBuf(b.N)
 	b.SetBytes(int64(buf.Len() / b.N))
 	b.ResetTimer()
-	if _, err := Load(ctx, sqlDB.DB, buf, "bench", dir, ts, 0, dir); err != nil {
+	if _, err := sqlccl.Load(ctx, sqlDB.DB, buf, "data", dir, ts, 0, dir); err != nil {
 		b.Fatalf("%+v", err)
 	}
 }

--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -498,19 +498,19 @@ func makeImportRequests(
 	return requestEntries, maxEndTime, nil
 }
 
-// presplitRanges concurrently creates the splits described by `input`. It does
+// PresplitRanges concurrently creates the splits described by `input`. It does
 // this by finding the middle key, splitting and recursively presplitting the
 // resulting left and right hand ranges. NB: The split code assumes that the LHS
 // of the resulting ranges is the smaller, so normally you'd split from the
 // left, but this method should only be called on empty keyranges, so it's okay.
 //
 // The `input` parameter expected to be sorted.
-func presplitRanges(baseCtx context.Context, db client.DB, input []roachpb.Key) error {
+func PresplitRanges(baseCtx context.Context, db client.DB, input []roachpb.Key) error {
 	// TODO(dan): This implementation does nothing to control the maximum
 	// parallelization or number of goroutines spawned. Revisit (possibly via a
 	// semaphore) if this becomes a problem in practice.
 
-	ctx, span := tracing.ChildSpan(baseCtx, "presplitRanges")
+	ctx, span := tracing.ChildSpan(baseCtx, "PresplitRanges")
 	defer tracing.FinishSpan(span)
 	log.Infof(ctx, "presplitting %d ranges", len(input))
 
@@ -714,7 +714,7 @@ func Restore(
 			return 0, errors.Errorf("failed to rewrite key: %s", r.Key)
 		}
 	}
-	if err := presplitRanges(ctx, db, splitKeys); err != nil {
+	if err := PresplitRanges(ctx, db, splitKeys); err != nil {
 		return 0, errors.Wrapf(err, "presplitting %d ranges", len(importRequests))
 	}
 	{

--- a/pkg/ccl/storageccl/add_sstable_test.go
+++ b/pkg/ccl/storageccl/add_sstable_test.go
@@ -11,26 +11,19 @@ package storageccl
 import (
 	"bytes"
 	"reflect"
-	"strconv"
 	"testing"
-	"time"
 
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/internal/client"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
-	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
 func singleKVSSTable(key engine.MVCCKey, value []byte) ([]byte, error) {
@@ -185,67 +178,4 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 	// but AddSSTable requires the ReplicatedEvalResult to be resolved before
 	// this will work. Rewrite this test to use TestServer and add the
 	// idempotence test back.
-}
-
-func BenchmarkAddSSTable(b *testing.B) {
-	defer storage.TestingSetDisableSnapshotClearRange(true)()
-
-	rng, _ := randutil.NewPseudoRand()
-	const payloadSize = 100
-	v := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, payloadSize))
-
-	ts := hlc.NewClock(hlc.UnixNano, time.Nanosecond).Now()
-	for _, numEntries := range []int{100, 1000, 10000, 100000} {
-		b.Run(strconv.Itoa(numEntries), func(b *testing.B) {
-			ctx := context.Background()
-			tc := testcluster.StartTestCluster(b, 3, base.TestClusterArgs{})
-			defer tc.Stopper().Stop(ctx)
-			kvDB := tc.Server(0).KVClient().(*client.DB)
-
-			id := keys.MaxReservedDescID + 1
-			sst, err := engine.MakeRocksDBSstFileWriter()
-			if err != nil {
-				b.Fatalf("%+v", err)
-			}
-			defer sst.Close()
-
-			var totalLen int64
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				b.StopTimer()
-				prefix := roachpb.Key(keys.MakeTablePrefix(uint32(id)))
-				id++
-				for j := 0; j < numEntries; j++ {
-					key := encoding.EncodeUvarintAscending(prefix, uint64(j))
-					v.ClearChecksum()
-					v.InitChecksum(key)
-					kv := engine.MVCCKeyValue{
-						Key:   engine.MVCCKey{Key: key, Timestamp: ts},
-						Value: v.RawBytes,
-					}
-					if err := sst.Add(kv); err != nil {
-						b.Fatalf("%+v", err)
-					}
-				}
-				end := prefix.PrefixEnd()
-				data, err := sst.Finish()
-				if err != nil {
-					b.Fatalf("%+v", err)
-				}
-				sst.Close()
-				sst, err = engine.MakeRocksDBSstFileWriter()
-				if err != nil {
-					b.Fatalf("%+v", err)
-				}
-				totalLen += int64(len(data))
-				b.StartTimer()
-
-				if err := kvDB.ExperimentalAddSSTable(ctx, prefix, end, data); err != nil {
-					b.Fatalf("%+v", err)
-				}
-			}
-			b.StopTimer()
-			b.SetBytes(totalLen / int64(b.N))
-		})
-	}
 }

--- a/pkg/ccl/storageccl/bench_test.go
+++ b/pkg/ccl/storageccl/bench_test.go
@@ -1,0 +1,133 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
+
+package storageccl_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func BenchmarkAddSSTable(b *testing.B) {
+	defer storage.TestingSetDisableSnapshotClearRange(true)()
+
+	rng, _ := randutil.NewPseudoRand()
+	const payloadSize = 100
+	v := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, payloadSize))
+
+	ts := hlc.NewClock(hlc.UnixNano, time.Nanosecond).Now()
+	for _, numEntries := range []int{100, 1000, 10000, 100000} {
+		b.Run(strconv.Itoa(numEntries), func(b *testing.B) {
+			ctx := context.Background()
+			tc := testcluster.StartTestCluster(b, 3, base.TestClusterArgs{})
+			defer tc.Stopper().Stop(ctx)
+			kvDB := tc.Server(0).KVClient().(*client.DB)
+
+			id := keys.MaxReservedDescID + 1
+			sst, err := engine.MakeRocksDBSstFileWriter()
+			if err != nil {
+				b.Fatalf("%+v", err)
+			}
+			defer sst.Close()
+
+			var totalLen int64
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				prefix := roachpb.Key(keys.MakeTablePrefix(uint32(id)))
+				id++
+				for j := 0; j < numEntries; j++ {
+					key := encoding.EncodeUvarintAscending(prefix, uint64(j))
+					v.ClearChecksum()
+					v.InitChecksum(key)
+					kv := engine.MVCCKeyValue{
+						Key:   engine.MVCCKey{Key: key, Timestamp: ts},
+						Value: v.RawBytes,
+					}
+					if err := sst.Add(kv); err != nil {
+						b.Fatalf("%+v", err)
+					}
+				}
+				end := prefix.PrefixEnd()
+				data, err := sst.Finish()
+				if err != nil {
+					b.Fatalf("%+v", err)
+				}
+				sst.Close()
+				sst, err = engine.MakeRocksDBSstFileWriter()
+				if err != nil {
+					b.Fatalf("%+v", err)
+				}
+				totalLen += int64(len(data))
+				b.StartTimer()
+
+				if err := kvDB.ExperimentalAddSSTable(ctx, prefix, end, data); err != nil {
+					b.Fatalf("%+v", err)
+				}
+			}
+			b.StopTimer()
+			b.SetBytes(totalLen / int64(b.N))
+		})
+	}
+}
+
+func BenchmarkWriteBatch(b *testing.B) {
+	rng, _ := randutil.NewPseudoRand()
+	const payloadSize = 100
+	v := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, payloadSize))
+
+	ts := hlc.NewClock(hlc.UnixNano, time.Nanosecond).Now()
+	for _, numEntries := range []int{100, 1000, 10000, 100000} {
+		b.Run(strconv.Itoa(numEntries), func(b *testing.B) {
+			ctx := context.Background()
+			tc := testcluster.StartTestCluster(b, 3, base.TestClusterArgs{})
+			defer tc.Stopper().Stop(ctx)
+			kvDB := tc.Server(0).KVClient().(*client.DB)
+
+			id := keys.MaxReservedDescID + 1
+			var batch engine.RocksDBBatchBuilder
+
+			var totalLen int64
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				prefix := roachpb.Key(keys.MakeTablePrefix(uint32(id)))
+				id++
+				for j := 0; j < numEntries; j++ {
+					key := encoding.EncodeUvarintAscending(prefix, uint64(j))
+					v.ClearChecksum()
+					v.InitChecksum(key)
+					batch.Put(engine.MVCCKey{Key: key, Timestamp: ts}, v.RawBytes)
+				}
+				end := prefix.PrefixEnd()
+				repr := batch.Finish()
+				totalLen += int64(len(repr))
+				b.StartTimer()
+
+				if err := kvDB.WriteBatch(ctx, prefix, end, repr); err != nil {
+					b.Fatalf("%+v", err)
+				}
+			}
+			b.StopTimer()
+			b.SetBytes(totalLen / int64(b.N))
+		})
+	}
+}

--- a/pkg/ccl/storageccl/bench_test.go
+++ b/pkg/ccl/storageccl/bench_test.go
@@ -9,77 +9,73 @@
 package storageccl_test
 
 import (
-	"context"
+	"path/filepath"
 	"strconv"
 	"testing"
-	"time"
+
+	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl/sampledataccl"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
-	"github.com/cockroachdb/cockroach/pkg/util/encoding"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
 func BenchmarkAddSSTable(b *testing.B) {
 	defer storage.TestingSetDisableSnapshotClearRange(true)()
+	tempDir, dirCleanupFn := testutils.TempDir(b)
+	defer dirCleanupFn()
 
-	rng, _ := randutil.NewPseudoRand()
-	const payloadSize = 100
-	v := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, payloadSize))
-
-	ts := hlc.NewClock(hlc.UnixNano, time.Nanosecond).Now()
 	for _, numEntries := range []int{100, 1000, 10000, 100000} {
+		bankData := sampledataccl.BankRows(numEntries)
+		backupDir := filepath.Join(tempDir, strconv.Itoa(numEntries))
+		backup, err := sampledataccl.ToBackup(b, bankData, backupDir)
+		if err != nil {
+			b.Fatalf("%+v", err)
+		}
+
 		b.Run(strconv.Itoa(numEntries), func(b *testing.B) {
 			ctx := context.Background()
 			tc := testcluster.StartTestCluster(b, 3, base.TestClusterArgs{})
 			defer tc.Stopper().Stop(ctx)
 			kvDB := tc.Server(0).KVClient().(*client.DB)
 
-			id := keys.MaxReservedDescID + 1
-			sst, err := engine.MakeRocksDBSstFileWriter()
-			if err != nil {
-				b.Fatalf("%+v", err)
-			}
-			defer sst.Close()
+			id := sqlbase.ID(keys.MaxReservedDescID + 1)
 
 			var totalLen int64
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
-				prefix := roachpb.Key(keys.MakeTablePrefix(uint32(id)))
+				sst, err := engine.MakeRocksDBSstFileWriter()
+				if err != nil {
+					b.Fatalf("%+v", err)
+				}
+
 				id++
-				for j := 0; j < numEntries; j++ {
-					key := encoding.EncodeUvarintAscending(prefix, uint64(j))
-					v.ClearChecksum()
-					v.InitChecksum(key)
-					kv := engine.MVCCKeyValue{
-						Key:   engine.MVCCKey{Key: key, Timestamp: ts},
-						Value: v.RawBytes,
-					}
+				backup.ResetKeyValueIteration()
+				kvs, span, err := backup.NextKeyValues(numEntries, id)
+				if err != nil {
+					b.Fatalf("%+v", err)
+				}
+				for _, kv := range kvs {
 					if err := sst.Add(kv); err != nil {
 						b.Fatalf("%+v", err)
 					}
 				}
-				end := prefix.PrefixEnd()
 				data, err := sst.Finish()
 				if err != nil {
 					b.Fatalf("%+v", err)
 				}
 				sst.Close()
-				sst, err = engine.MakeRocksDBSstFileWriter()
-				if err != nil {
-					b.Fatalf("%+v", err)
-				}
 				totalLen += int64(len(data))
 				b.StartTimer()
 
-				if err := kvDB.ExperimentalAddSSTable(ctx, prefix, end, data); err != nil {
+				if err := kvDB.ExperimentalAddSSTable(ctx, span.Key, span.EndKey, data); err != nil {
 					b.Fatalf("%+v", err)
 				}
 			}
@@ -90,39 +86,44 @@ func BenchmarkAddSSTable(b *testing.B) {
 }
 
 func BenchmarkWriteBatch(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
-	const payloadSize = 100
-	v := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, payloadSize))
+	tempDir, dirCleanupFn := testutils.TempDir(b)
+	defer dirCleanupFn()
 
-	ts := hlc.NewClock(hlc.UnixNano, time.Nanosecond).Now()
 	for _, numEntries := range []int{100, 1000, 10000, 100000} {
+		bankData := sampledataccl.BankRows(numEntries)
+		backupDir := filepath.Join(tempDir, strconv.Itoa(numEntries))
+		backup, err := sampledataccl.ToBackup(b, bankData, backupDir)
+		if err != nil {
+			b.Fatalf("%+v", err)
+		}
+
 		b.Run(strconv.Itoa(numEntries), func(b *testing.B) {
 			ctx := context.Background()
 			tc := testcluster.StartTestCluster(b, 3, base.TestClusterArgs{})
 			defer tc.Stopper().Stop(ctx)
 			kvDB := tc.Server(0).KVClient().(*client.DB)
 
-			id := keys.MaxReservedDescID + 1
+			id := sqlbase.ID(keys.MaxReservedDescID + 1)
 			var batch engine.RocksDBBatchBuilder
 
 			var totalLen int64
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
-				prefix := roachpb.Key(keys.MakeTablePrefix(uint32(id)))
 				id++
-				for j := 0; j < numEntries; j++ {
-					key := encoding.EncodeUvarintAscending(prefix, uint64(j))
-					v.ClearChecksum()
-					v.InitChecksum(key)
-					batch.Put(engine.MVCCKey{Key: key, Timestamp: ts}, v.RawBytes)
+				backup.ResetKeyValueIteration()
+				kvs, span, err := backup.NextKeyValues(numEntries, id)
+				if err != nil {
+					b.Fatalf("%+v", err)
 				}
-				end := prefix.PrefixEnd()
+				for _, kv := range kvs {
+					batch.Put(kv.Key, kv.Value)
+				}
 				repr := batch.Finish()
 				totalLen += int64(len(repr))
 				b.StartTimer()
 
-				if err := kvDB.WriteBatch(ctx, prefix, end, repr); err != nil {
+				if err := kvDB.WriteBatch(ctx, span.Key, span.EndKey, repr); err != nil {
 					b.Fatalf("%+v", err)
 				}
 			}

--- a/pkg/ccl/storageccl/writebatch_test.go
+++ b/pkg/ccl/storageccl/writebatch_test.go
@@ -11,14 +11,11 @@ package storageccl
 import (
 	"bytes"
 	"reflect"
-	"strconv"
 	"testing"
-	"time"
 
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -26,11 +23,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
-	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
 func TestDBWriteBatch(t *testing.T) {
@@ -178,48 +172,5 @@ func TestWriteBatchMVCCStats(t *testing.T) {
 	}
 	if !reflect.DeepEqual(expectedStats, cArgs.Stats) {
 		t.Errorf("mvcc stats mismatch %+v != %+v", expectedStats, cArgs.Stats)
-	}
-}
-
-func BenchmarkWriteBatch(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
-	const payloadSize = 100
-	v := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, payloadSize))
-
-	ts := hlc.NewClock(hlc.UnixNano, time.Nanosecond).Now()
-	for _, numEntries := range []int{100, 1000, 10000, 100000} {
-		b.Run(strconv.Itoa(numEntries), func(b *testing.B) {
-			ctx := context.Background()
-			tc := testcluster.StartTestCluster(b, 3, base.TestClusterArgs{})
-			defer tc.Stopper().Stop(ctx)
-			kvDB := tc.Server(0).KVClient().(*client.DB)
-
-			id := keys.MaxReservedDescID + 1
-			var batch engine.RocksDBBatchBuilder
-
-			var totalLen int64
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				b.StopTimer()
-				prefix := roachpb.Key(keys.MakeTablePrefix(uint32(id)))
-				id++
-				for j := 0; j < numEntries; j++ {
-					key := encoding.EncodeUvarintAscending(prefix, uint64(j))
-					v.ClearChecksum()
-					v.InitChecksum(key)
-					batch.Put(engine.MVCCKey{Key: key, Timestamp: ts}, v.RawBytes)
-				}
-				end := prefix.PrefixEnd()
-				repr := batch.Finish()
-				totalLen += int64(len(repr))
-				b.StartTimer()
-
-				if err := kvDB.WriteBatch(ctx, prefix, end, repr); err != nil {
-					b.Fatalf("%+v", err)
-				}
-			}
-			b.StopTimer()
-			b.SetBytes(totalLen / int64(b.N))
-		})
 	}
 }

--- a/pkg/ccl/utilccl/sampledataccl/bankdata.go
+++ b/pkg/ccl/utilccl/sampledataccl/bankdata.go
@@ -1,0 +1,389 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
+
+package sampledataccl
+
+import (
+	"bytes"
+	gosql "database/sql"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/sqlccl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+// TODO(dan): Once the interface for this has settled a bit, move it out of ccl.
+
+// Data is a representation of a sql table, used for creating test data in
+// various forms (sql rows, kvs, enterprise backup). All data tables live in the
+// `data` database.
+type Data interface {
+	// Name returns the fully-qualified name of the represented table.
+	Name() string
+
+	// Schema returns the schema for the represented table, such that it can be
+	// used in fmt.Sprintf(`CREATE TABLE %s %s`, data.Name(), data.Schema`())`.
+	Schema() string
+
+	// NextRow iterates through the rows in the represented table, returning one
+	// per call. The row is represented as a slice of strings, each string one
+	// of the columns in the row. When no more rows are available, the bool
+	// returned is false.
+	NextRow() ([]string, bool)
+
+	// NextRow iterates through the split points in the represented table,
+	// returning one per call. The split is represented as a slice of strings,
+	// each string one of the columns in the split. When no more splits are
+	// available, the bool returned is false.
+	NextSplit() ([]string, bool)
+}
+
+// InsertBatched inserts all rows represented by `data` into `db` in batches of
+// `batchSize` rows. The table must exist.
+func InsertBatched(db *gosql.DB, data Data, batchSize int) error {
+	var stmt bytes.Buffer
+	for {
+		stmt.Reset()
+		fmt.Fprintf(&stmt, `INSERT INTO %s VALUES `, data.Name())
+		i := 0
+		done := false
+		for ; i < batchSize; i++ {
+			row, ok := data.NextRow()
+			if !ok {
+				done = true
+				break
+			}
+			if i != 0 {
+				stmt.WriteRune(',')
+			}
+			fmt.Fprintf(&stmt, `(%s)`, strings.Join(row, `,`))
+		}
+		if i > 0 {
+			if _, err := db.Exec(stmt.String()); err != nil {
+				return err
+			}
+		}
+		if done {
+			return nil
+		}
+		continue
+	}
+}
+
+// Split creates the configured number of ranges in an already created created
+// version of the table represented by `data`.
+func Split(db *gosql.DB, data Data) error {
+	var stmt bytes.Buffer
+	fmt.Fprintf(&stmt, `ALTER TABLE %s SPLIT AT VALUES `, data.Name())
+	i := 0
+	for ; ; i++ {
+		split, ok := data.NextSplit()
+		if !ok {
+			break
+		}
+		if i != 0 {
+			stmt.WriteRune(',')
+		}
+		fmt.Fprintf(&stmt, `(%s)`, strings.Join(split, `,`))
+	}
+	if i > 0 {
+		if _, err := db.Exec(stmt.String()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Setup creates a table in `db` with all the rows and splits of `data`.
+func Setup(db *gosql.DB, data Data) error {
+	if _, err := db.Exec(`CREATE DATABASE IF NOT EXISTS data`); err != nil {
+		return err
+	}
+	if _, err := db.Exec(fmt.Sprintf(`CREATE TABLE %s %s`, data.Name(), data.Schema())); err != nil {
+		return err
+	}
+	const batchSize = 1000
+	if err := InsertBatched(db, data, batchSize); err != nil {
+		return err
+	}
+	// This occasionally flakes, so ignore errors.
+	_ = Split(db, data)
+	return nil
+}
+
+// ToBackup creates an enterprise backup in `dir`.
+func ToBackup(t testing.TB, data Data, dir string) (*Backup, error) {
+	return toBackup(t, data, dir, 0)
+}
+
+func toBackup(t testing.TB, data Data, dir string, chunkBytes int64) (*Backup, error) {
+	tempDir, dirCleanupFn := testutils.TempDir(t)
+	defer dirCleanupFn()
+
+	// TODO(dan): Get rid of the `t testing.TB` parameter and this `TestServer`.
+	ctx := context.Background()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	if _, err := db.Exec(`CREATE DATABASE data`); err != nil {
+		return nil, err
+	}
+
+	var stmts bytes.Buffer
+	fmt.Fprintf(&stmts, "CREATE TABLE %s %s;\n", data.Name(), data.Schema())
+	for {
+		row, ok := data.NextRow()
+		if !ok {
+			break
+		}
+		fmt.Fprintf(&stmts, "INSERT INTO %s VALUES (%s);\n", data.Name(), strings.Join(row, `,`))
+	}
+
+	// TODO(dan): The csv load will be less overhead, use it when we have it.
+	ts := hlc.Timestamp{WallTime: hlc.UnixNano()}
+	desc, err := sqlccl.Load(ctx, db, &stmts, `data`, `nodelocal://`+dir, ts, chunkBytes, tempDir)
+	if err != nil {
+		return nil, err
+	}
+	return &Backup{BaseDir: dir, Desc: desc}, nil
+}
+
+// Backup is a representation of an enterprise BACKUP.
+type Backup struct {
+	// BaseDir can be used for a RESTORE. All paths in the descriptor are
+	// relative to this.
+	BaseDir string
+	Desc    sqlccl.BackupDescriptor
+
+	fileIdx int
+	iterIdx int
+}
+
+// ResetKeyValueIteration resets the NextKeyValues iteration to the first kv.
+func (b *Backup) ResetKeyValueIteration() {
+	b.fileIdx = 0
+	b.iterIdx = 0
+}
+
+// NextKeyValues iterates and returns every *user table data* key-value in the
+// backup. At least `count` kvs will be returned, but rows are not broken up, so
+// slightly more than `count` may come back. If fewer than `count` are
+// available, err will be `io.EOF` and kvs may be partially filled with the
+// remainer.
+func (b *Backup) NextKeyValues(
+	count int, newTableID sqlbase.ID,
+) ([]engine.MVCCKeyValue, roachpb.Span, error) {
+	var userTables []*sqlbase.TableDescriptor
+	for _, d := range b.Desc.Descriptors {
+		if t := d.GetTable(); t != nil && t.ParentID != keys.SystemDatabaseID {
+			userTables = append(userTables, t)
+		}
+	}
+	if len(userTables) != 1 {
+		return nil, roachpb.Span{}, errors.Errorf(
+			"only backups of one table are currently supported, got %d", len(userTables))
+	}
+	tableDesc := userTables[0]
+
+	newDesc := *tableDesc
+	newDesc.ID = newTableID
+	newDescBytes, err := sqlbase.WrapDescriptor(&newDesc).Marshal()
+	if err != nil {
+		return nil, roachpb.Span{}, err
+	}
+	kr, err := storageccl.MakeKeyRewriter([]roachpb.ImportRequest_TableRekey{{
+		OldID: uint32(tableDesc.ID), NewDesc: newDescBytes,
+	}})
+	if err != nil {
+		return nil, roachpb.Span{}, err
+	}
+
+	var kvs []engine.MVCCKeyValue
+	span := roachpb.Span{Key: keys.MaxKey}
+	for ; b.fileIdx < len(b.Desc.Files); b.fileIdx++ {
+		file := b.Desc.Files[b.fileIdx]
+
+		sst := engine.MakeRocksDBSstFileReader()
+		defer sst.Close()
+		fileContents, err := ioutil.ReadFile(filepath.Join(b.BaseDir, file.Path))
+		if err != nil {
+			return nil, roachpb.Span{}, err
+		}
+		if err := sst.IngestExternalFile(fileContents); err != nil {
+			return nil, roachpb.Span{}, err
+		}
+
+		it := sst.NewIterator(false)
+		defer it.Close()
+		it.Seek(engine.MVCCKey{Key: file.Span.Key})
+
+		iterIdx := 0
+		for ; ; it.Next() {
+			if len(kvs) >= count {
+				break
+			}
+			if iterIdx < b.iterIdx {
+				iterIdx++
+				continue
+			}
+
+			ok, err := it.Valid()
+			if err != nil {
+				return nil, roachpb.Span{}, err
+			}
+			if !ok || it.UnsafeKey().Key.Compare(file.Span.EndKey) >= 0 {
+				break
+			}
+
+			if iterIdx < b.iterIdx {
+				break
+			}
+			b.iterIdx = iterIdx
+
+			key := it.Key()
+			key.Key, ok, err = kr.RewriteKey(key.Key)
+			if err != nil {
+				return nil, roachpb.Span{}, err
+			}
+			if !ok {
+				return nil, roachpb.Span{}, errors.Errorf("rewriter did not match key: %s", key.Key)
+			}
+			v := roachpb.Value{RawBytes: it.Value()}
+			v.ClearChecksum()
+			v.InitChecksum(key.Key)
+			kvs = append(kvs, engine.MVCCKeyValue{Key: key, Value: v.RawBytes})
+
+			if key.Key.Compare(span.Key) < 0 {
+				span.Key = append(span.Key[:0], key.Key...)
+			}
+			if key.Key.Compare(span.EndKey) > 0 {
+				span.EndKey = append(span.EndKey[:0], key.Key...)
+			}
+			iterIdx++
+		}
+		b.iterIdx = iterIdx
+
+		if len(kvs) >= count {
+			break
+		}
+		if ok, _ := it.Valid(); !ok {
+			b.iterIdx = 0
+		}
+	}
+
+	span.EndKey = span.EndKey.Next()
+	if len(kvs) < count {
+		return kvs, span, io.EOF
+	}
+	return kvs, span, nil
+}
+
+type bankData struct {
+	Rows         int
+	PayloadBytes int
+	Ranges       int
+	Rng          *rand.Rand
+
+	rowIdx   int
+	splitIdx int
+}
+
+var _ Data = &bankData{}
+
+// bankConfigDefault will trigger the default for any of the parameters for
+// `Bank`.
+const bankConfigDefault = -1
+
+// BankRows returns Bank testdata with the given number of rows and default
+// payload size and range count.
+func BankRows(rows int) Data {
+	return Bank(rows, bankConfigDefault, bankConfigDefault)
+}
+
+// Bank returns a bank table with three columns: an `id INT PRIMARY KEY`
+// representing an account number, a `balance` INT, and a `payload` BYTES to pad
+// the size of the rows for various tests.
+func Bank(rows int, payloadBytes int, ranges int) Data {
+	// TODO(dan): This interface is a little wonky, but it's a bit annoying to
+	// replace it with a struct because that would make most of the callsites
+	// wrap. Complicating things is that there needs to be a distinction between
+	// the default value and an explicit 0 for ranges and payloadBytes.
+	if rows == bankConfigDefault {
+		rows = 1000
+	}
+	if payloadBytes == bankConfigDefault {
+		payloadBytes = 100
+	}
+	if ranges == bankConfigDefault {
+		ranges = 10
+	}
+	if ranges > rows {
+		ranges = rows
+	}
+	rng, _ := randutil.NewPseudoRand()
+	return &bankData{Rows: rows, PayloadBytes: payloadBytes, Ranges: ranges, Rng: rng}
+}
+
+// Name implements the Data interface.
+func (d *bankData) Name() string {
+	return `data.bank`
+}
+
+// Schema implements the Data interface.
+func (d *bankData) Schema() string {
+	return `(
+		id INT PRIMARY KEY,
+		balance INT,
+		payload STRING,
+		FAMILY (id, balance, payload)
+	)`
+}
+
+// NextRow implements the Data interface.
+func (d *bankData) NextRow() ([]string, bool) {
+	if d.rowIdx >= d.Rows {
+		return nil, false
+	}
+	payload := fmt.Sprintf(`'initial-%x'`, randutil.RandBytes(d.Rng, d.PayloadBytes))
+	row := []string{
+		strconv.Itoa(d.rowIdx), // id
+		`0`,     // balance
+		payload, // payload
+	}
+	d.rowIdx++
+	return row, true
+}
+
+// NextSplit implements the Data interface.
+func (d *bankData) NextSplit() ([]string, bool) {
+	if d.splitIdx+1 >= d.Ranges {
+		return nil, false
+	}
+	// TODO(dan): This doesn't make evenly sized splits.
+	split := []string{strconv.Itoa(d.splitIdx)}
+	d.splitIdx++
+	return split, true
+}

--- a/pkg/ccl/utilccl/sampledataccl/bankdata_test.go
+++ b/pkg/ccl/utilccl/sampledataccl/bankdata_test.go
@@ -1,0 +1,198 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
+
+package sampledataccl
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestInsertBatched(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tests := []struct {
+		rows      int
+		batchSize int
+	}{
+		{10, 1},
+		{10, 9},
+		{10, 10},
+		{10, 100},
+	}
+
+	ctx := context.Background()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("rows=%d/batch=%d", test.rows, test.batchSize), func(t *testing.T) {
+			sqlDB := sqlutils.MakeSQLRunner(t, db)
+
+			data := Bank(test.rows, 0, bankConfigDefault)
+			sqlDB.Exec(`CREATE DATABASE IF NOT EXISTS data`)
+			sqlDB.Exec(fmt.Sprintf(`DROP TABLE IF EXISTS %s`, data.Name()))
+			sqlDB.Exec(fmt.Sprintf(`CREATE TABLE %s %s`, data.Name(), data.Schema()))
+
+			if err := InsertBatched(sqlDB.DB, data, test.batchSize); err != nil {
+				t.Fatalf("%+v", err)
+			}
+
+			var rowCount int
+			sqlDB.QueryRow(fmt.Sprintf(`SELECT COUNT(*) FROM %s`, data.Name())).Scan(&rowCount)
+			if rowCount != test.rows {
+				t.Errorf("got %d rows expected %d", rowCount, test.rows)
+			}
+		})
+	}
+}
+
+func TestSplit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tests := []struct {
+		rows           int
+		ranges         int
+		expectedRanges int
+	}{
+		{10, 0, 1}, // We always have at least one range.
+		{10, 1, 1},
+		{10, 9, 9},
+		{10, 10, 10},
+		{10, 100, 10}, // Don't make more ranges than rows.
+	}
+
+	ctx := context.Background()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("rows=%d/ranges=%d", test.rows, test.ranges), func(t *testing.T) {
+			sqlDB := sqlutils.MakeSQLRunner(t, db)
+
+			data := Bank(test.rows, bankConfigDefault, test.ranges)
+			sqlDB.Exec(`CREATE DATABASE IF NOT EXISTS data`)
+			sqlDB.Exec(fmt.Sprintf(`DROP TABLE IF EXISTS %s`, data.Name()))
+			sqlDB.Exec(fmt.Sprintf(`CREATE TABLE %s %s`, data.Name(), data.Schema()))
+
+			if err := Split(sqlDB.DB, data); err != nil {
+				t.Fatalf("%+v", err)
+			}
+
+			var rangeCount int
+			sqlDB.QueryRow(
+				fmt.Sprintf(`SELECT COUNT(*) FROM [SHOW TESTING_RANGES FROM TABLE %s]`, data.Name()),
+			).Scan(&rangeCount)
+			if rangeCount != test.expectedRanges {
+				t.Errorf("got %d ranges expected %d", rangeCount, test.expectedRanges)
+			}
+		})
+	}
+}
+
+func TestToBackup(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	const payloadBytes = 100
+	chunkBytesSizes := []int64{
+		0,                // 0 means default ~32MB
+		3 * payloadBytes, // a number that will not evently divide the number of rows
+	}
+
+	for _, rows := range []int{1, 10} {
+		for _, chunkBytes := range chunkBytesSizes {
+			t.Run(fmt.Sprintf("rows=%d/chunk=%d", rows, chunkBytes), func(t *testing.T) {
+				dir, dirCleanupFn := testutils.TempDir(t)
+				defer dirCleanupFn()
+
+				data := Bank(rows, payloadBytes, bankConfigDefault)
+				backup, err := toBackup(t, data, dir, chunkBytes)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+
+				t.Run("Restore", func(t *testing.T) {
+					sqlDB := sqlutils.MakeSQLRunner(t, db)
+					sqlDB.Exec(`DROP DATABASE IF EXISTS data`)
+					sqlDB.Exec(`CREATE DATABASE data`)
+					sqlDB.Exec(`RESTORE data.* FROM $1`, `nodelocal://`+dir)
+
+					var rowCount int
+					sqlDB.QueryRow(fmt.Sprintf(`SELECT COUNT(*) FROM %s`, data.Name())).Scan(&rowCount)
+					if rowCount != rows {
+						t.Errorf("got %d rows expected %d", rowCount, rows)
+					}
+				})
+
+				t.Run("NextKeyValues", func(t *testing.T) {
+					for _, requestedKVs := range []int{2, 3} {
+						newTableID := sqlbase.ID(keys.MaxReservedDescID + requestedKVs)
+						newTablePrefix := roachpb.Key(keys.MakeTablePrefix(uint32(newTableID)))
+
+						keys := make(map[string]struct{}, rows)
+						for {
+							kvs, span, err := backup.NextKeyValues(requestedKVs, newTableID)
+							if err != nil && err != io.EOF {
+								t.Fatalf("%+v", err)
+							}
+							if len(kvs) < requestedKVs && err != io.EOF {
+								t.Errorf("got %d kvs requested at least %d", len(kvs), requestedKVs)
+							}
+							for k := range keys {
+								key := roachpb.Key(k)
+								if key.Compare(span.Key) >= 0 && key.Compare(span.EndKey) < 0 {
+									t.Errorf("previous key %s overlaps this span %s", key, span)
+								}
+							}
+							for _, kv := range kvs {
+								key := kv.Key.Key
+								if key.Compare(span.Key) < 0 || key.Compare(span.EndKey) >= 0 {
+									t.Errorf("key %s is not in %s", kv.Key, span)
+								}
+								if _, ok := keys[string(key)]; ok {
+									t.Errorf("key %s was output twice", key)
+								}
+								keys[string(key)] = struct{}{}
+								if !bytes.HasPrefix(key, newTablePrefix) {
+									t.Errorf("key %s is not for table %d", key, newTableID)
+								}
+							}
+							if err == io.EOF {
+								break
+							}
+						}
+
+						if len(keys) != rows {
+							t.Errorf("got %d kvs expected %d", len(keys), rows)
+						}
+						// Don't reconstruct the backup between runs so we can
+						// test the reset.
+						backup.ResetKeyValueIteration()
+					}
+				})
+			})
+		}
+	}
+}

--- a/pkg/ccl/utilccl/sampledataccl/main_test.go
+++ b/pkg/ccl/utilccl/sampledataccl/main_test.go
@@ -1,0 +1,34 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
+
+package sampledataccl
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestMain(m *testing.M) {
+	defer settings.TestingSetBool(&utilccl.EnterpriseEnabled, true)()
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}
+
+//go:generate ../../../util/leaktest/add-leaktest.sh *_test.go


### PR DESCRIPTION
Data is a representation of a sql table, used for creating test data in
various forms (sql rows, kvs, enterprise backup).

We only have one for the moment (a bank table with an id, balance, and
payload for padding row-size), but the indirection of the interface
didn't really add any complexity.

This also moves over a number of our existing tests & benchmarks and adds a new benchmark for the Import command.