### PR TITLE
ui: Palette Cleansing

### DIFF
--- a/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
+++ b/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
@@ -25,7 +25,7 @@ $viz-sides = 62px
 .visualization
   position relative
   background-color white
-  color $dark-blue
+  color $headings-color
   border-radius 5px
   border 1px solid rgba(0, 0, 0, .1)
   // prevents borders from doubling up
@@ -48,11 +48,11 @@ $viz-sides = 62px
   &__title
     font-size 14px
     font-family Lato-Bold
-    color $light-blue
+    color $body-color
     display inline
 
   &__subtitle
-    color $light-gray
+    color $tooltip-color
     margin-left 5px
     font-size 12px
     font-family Lato-Regular
@@ -72,17 +72,17 @@ $viz-sides = 62px
     width 12px
     height 12px
     border-radius 50%
-    border 1px solid $light-gray
+    border 1px solid $tooltip-color
     font-size 10px
-    color $light-gray
+    color $tooltip-color
     line-height 10px
 
   .hover-tooltip--hovered &__info-icon
-    border-color $light-blue
-    color $light-blue
+    border-color $body-color
+    color $body-color
 
   .icon-warning
-    color $secondary-gold
+    color $warning-color
 
 .linegraph
   height 100%
@@ -94,4 +94,4 @@ $viz-sides = 62px
     opacity .2
 
 .linked-guideline__line
-  stroke $glow-blue
+  stroke $link-color

--- a/pkg/ui/src/views/cluster/containers/events/events.styl
+++ b/pkg/ui/src/views/cluster/containers/events/events.styl
@@ -7,7 +7,7 @@
     border-collapse collapse
     tr
       height 39px
-      border-bottom 1px solid $lighter-gray
+      border-bottom 1px solid $table-border-color
       &:last-child
         border 0
     td
@@ -21,7 +21,7 @@
 
 .events__message
   font-size 14
-  color $secondary-gray-11
+  color $body-color
   text-overflow ellipsis
   display block
   white-space nowrap
@@ -30,13 +30,13 @@
 
 .events__timestamp
   font-size 12
-  color $light-gray
+  color $tooltip-color
   margin-left 20px
   text-align right
 
 .events__more-link
   text-align center
-  color $secondary-blue
+  color $link-color
   font-family Lato-Bold
   text-transform uppercase
   font-size 12px
@@ -44,7 +44,7 @@
   cursor pointer
 
   a
-    color $secondary-blue
+    color $link-color
     text-decoration none
 
 .events-table .sort-table__cell

--- a/pkg/ui/src/views/cluster/containers/timescale/timescale.styl
+++ b/pkg/ui/src/views/cluster/containers/timescale/timescale.styl
@@ -2,8 +2,8 @@
 
 .time-range
   margin-left 15px
-  color $lighter-blue
+  color $button-border-color
   font-size 12px
   font-family Lato-Regular
   &__time, &__date
-    color $dark-gray-blue
+    color $body-color

--- a/pkg/ui/src/views/databases/containers/tableDetails/sqlhighlight.styl
+++ b/pkg/ui/src/views/databases/containers/tableDetails/sqlhighlight.styl
@@ -2,19 +2,18 @@
 
 .sql-highlight
   font-family Inconsolata-Regular
-  background-color $secondary-gray-3
   padding 20px
   display inline-block
   width 100%
 
 .sql-highlight.hljs
-    background-color $main-dark-gray
-    color $secondary-gray-12
+    background-color $headings-color
+    color white
     overflow-x auto
 
     .hljs-string
-        color $syntax-orange
+        color $syntax-string-color
 
     .hljs-keyword
     .hljs-literal
-        color $syntax-blue
+        color $syntax-keyword-color

--- a/pkg/ui/src/views/shared/components/alertBox/alertbox.styl
+++ b/pkg/ui/src/views/shared/components/alertBox/alertbox.styl
@@ -7,7 +7,7 @@
   float left
   margin 0 6px 10px
   padding 20px
-  border 1px solid $dark-blue
+  border 1px solid $headings-color
   border-radius 5px
   font-family Lato-Regular
   
@@ -31,16 +31,16 @@
     cursor pointer
 
   &--notification
-    color $light-blue
-    border-color $alert-blue-dark
-    background-color $alert-blue-light
+    color $body-color
+    border-color $notification-info-border-color
+    background-color $notification-info-fill-color
 
   &--warning
-    color $light-blue
-    border-color $alert-yellow-dark
-    background-color $alert-yellow-light
+    color $body-color
+    border-color $notification-warning-border-color
+    background-color $notification-warning-fill-color
 
   &--critical
-    color $light-blue
-    border-color $alert-red-dark
-    background-color $alert-red-light
+    color $body-color
+    border-color $notification-alert-border-color
+    background-color $notification-alert-fill-color

--- a/pkg/ui/src/views/shared/components/dropdown/dropdown.styl
+++ b/pkg/ui/src/views/shared/components/dropdown/dropdown.styl
@@ -1,21 +1,23 @@
 @require nib
 @require "~styl/base/palette.styl"
 
+$dropdown-hover-color = darken($background-color, 2.5%)
+
 .dropdown
   text-transform uppercase
   letter-spacing 2px
   line-height 17px
   padding 1rem 2rem
   vertical-align middle
-  border 1px solid $gray-blue
+  border 1px solid $button-border-color
   border-radius 4px
   display inline-flex
   white-space nowrap
   padding-right 10px
-  color $light-blue
+  color $body-color
 
   &:hover
-    background-color $hover-gray
+    background-color $dropdown-hover-color
 
   &__title
     vertical-align middle
@@ -26,32 +28,32 @@
     vertical-align middle
 
     &:hover
-      background-color $hover-gray
+      background-color $dropdown-hover-color
 
   &__side-arrow
     font-family Lato-Bold
     display none
-    color $secondary-blue-3
+    color $link-color
     cursor pointer
 
     &:first-child
-      border-right 1px solid $gray-blue
+      border-right 1px solid $button-border-color
       padding 1rem 20px
       border-top-left-radius 4px
       border-bottom-left-radius 4px
 
     &:last-child
-      border-left 1px solid $gray-blue
+      border-left 1px solid $button-border-color
       padding 1rem 20px
       border-top-right-radius 4px
       border-bottom-right-radius 4px
 
     &[disabled]
-      background-color $lighter-gray
+      background-color $table-border-color
       cursor auto
 
       polyline
-        stroke $light-gray
+        stroke $button-border-color
 
   &--side-arrows
     padding 0
@@ -63,6 +65,6 @@
       display inline
 
       &:hover
-        background-color $hover-gray
+        background-color $dropdown-hover-color
 
 // NOTE: react-select styles can be found in styl/shame.styl

--- a/pkg/ui/src/views/shared/components/sortabletable/sortabletable.styl
+++ b/pkg/ui/src/views/shared/components/sortabletable/sortabletable.styl
@@ -8,7 +8,7 @@
       // Display the sort direction arrow in header cells.
       .sort-table__cell
         padding 18px 20px
-        color $lighter-blue
+        color $tooltip-color
 
         &--sortable:after
           display inline-block
@@ -20,13 +20,13 @@
           content "▼"
 
         &--descending
-          color $light-blue
+          color $body-color
 
         &--ascending
-          color $light-blue
+          color $body-color
           &:after
             content "▲"
 
   &__unbounded-column
-    whitespace normal
+    white-space normal
     word-break break-all

--- a/pkg/ui/src/views/shared/components/summaryBar/summarybar.styl
+++ b/pkg/ui/src/views/shared/components/summaryBar/summarybar.styl
@@ -20,16 +20,16 @@
     font-weight 500
     text-transform uppercase
     letter-spacing 2px
-    color $light-gray
+    color $tooltip-color
 
   &__value
     font-weight 200
     font-size 30px
-    color $light-blue
+    color $body-color
 
 .summary-label
   font-family Lato-Bold
-  color $light-blue
+  color $body-color
   padding-bottom 12px
   text-align center
 
@@ -42,61 +42,61 @@
     clearfix()
 
   &__title
-    color $light-blue
+    color $body-color
     float left
 
     // A link is present on at least one summary stat.
     a
       text-decoration none
-      color $glow-blue
+      color $link-color
       padding-left 6px
 
   &__value
     float right
-    color $light-blue
+    color $body-color
     font-family Lato-Bold
 
   &__tooltip
     display block
     clear both
     font-size 12px
-    color $light-gray
+    color $tooltip-color
 
   & + &
     border-top 1px solid rgb(242, 242, 242)
 
   &--number &__value
-    color $light-green
+    color $healthy-color
 
   &--dead &__value
-    color $secondary-red
+    color $alert-color
     text-transform capitalize
 
   &--suspect &__value
-    color $secondary-gold
+    color $warning-color
     text-transform capitalize
 
   &--healthy &__value
-    color $main-green
+    color $healthy-color
     text-transform capitalize
 
   &--link &__value
     a
       text-decoration none
       font-family Lato-Regular
-      color $glow-blue
+      color $link-color
 
 .summary-stat-breakdown
   padding 2px 0
 
   &--dead
-    color $secondary-red
+    color $alert-color
 
   &--suspect
-    color $secondary-gold
+    color $warning-color
 
   &--healthy
-    color $main-green
+    color $healthy-color
 
   &__body
     clearfix()

--- a/pkg/ui/src/views/shared/components/toolTip/tooltip.styl
+++ b/pkg/ui/src/views/shared/components/toolTip/tooltip.styl
@@ -1,12 +1,11 @@
 @require "~styl/base/palette.styl"
 @require "~styl/base/layout-vars.styl"
 
-.tooltip, .timescale-selector
+.tooltip
   position absolute
   z-index $z-index-tooltip
   padding 35px
-  border 1px solid $secondary-gray-1
-  box-shadow 2px 2px 0 $secondary-gray-15
+  box-shadow 2px 2px 0 $tooltip-shadow
   border-radius 4px
   opacity 0
   visibility hidden
@@ -16,26 +15,6 @@
   left 95%
   right auto
   white-space normal
-
-  .content, .warning
-    font-size 11px
-    color $secondary-gray-16
-    font-family Lato-Regular
-  .title, .warning-title
-    font-size 13px
-    color $main-navy
-    font-family Lato-Heavy
-    text-align center
-    width 100%
-    padding-bottom 5px
-
-  .warning .icon-warning
-    color $secondary-gold
-    font-size 50px
-    width 50px
-    line-height 50px
-    margin auto
-    margin-top 5px
 
   dt
     margin-top 10px
@@ -66,7 +45,7 @@
     background rgba(255, 255, 255, .98)
     font-family Lato-Regular
     text-align left
-    color $light-blue
+    color $body-color
 
   &--hovered &__text
     visibility visible

--- a/pkg/ui/src/views/shared/util/table.styl
+++ b/pkg/ui/src/views/shared/util/table.styl
@@ -1,17 +1,16 @@
 @require '~styl/base/palette.styl'
 
-$stats-table-cell--border = 1px solid $secondary-gray-12
+$table-cell-border = 1px solid $table-border-color
 
-$stats-table-th--fg = $secondary-light-gray
-$stats-table-td--fg = $table-gray
+$stats-table-td--fg = $body-color
 
 $stats-table-th--bg     = white
 $stats-table-tr--bg     = white
-$stats-table-tr--bg-alt = $secondary-gray-7
+$stats-table-tr--bg-alt = $background-color
 
 $table-base
   width 100%
-  border $stats-table-cell--border
+  border $table-cell-border
   border-collapse collapse
   font-family Lato-Regular
   font-weight 300
@@ -39,11 +38,11 @@ $table-base
 
   &__cell
     padding 10px 20px
-    border-right $stats-table-cell--border
+    border-right $table-cell-border
 
     a
       font-weight 400
-      color $link-blue
+      color $link-color
       text-decoration none
       width 100%
       height 100%

--- a/pkg/ui/styl/base/palette.styl
+++ b/pkg/ui/styl/base/palette.styl
@@ -16,90 +16,27 @@ permissions and limitations under the License.
 Author: Matt Tracy (matt@cockroachlabs.com)
 */
 
-// These colors are specified by the Cockroach UI-Kit designs.
-
-// Main colors
-$main-green = #7DBC42 // Main Highlight color, Status: Active
-$main-navy  = #151F34 // Main Highlight color, Main Headers
-
-// Main navigation colors
-$main-dark-gray = #595F6C // Main Navigation Rollover
-$main-gray      = #9F9F9F // Main Navigation
-
-// Secondary colors
-$secondary-gold   = #F2BE2C // Status: Idle, Chart Color
-$secondary-salmon = #F16969 // Status: Inactive, Chart Color
-$secondary-blue   = #4E9FD1 // Text Link, Chart Color
-$secondary-teal   = #47E2AA // Chart Color
-$secondary-purple = #D77FBF // Chart Color
-
-$secondary-red    = #ED7785 // Status: Missing/Error
-
-// Secondary nav colors
-$secondary-slate-gray = #7C8495 // Secondary Navigation
-$secondary-light-gray = #A6A6B2 // Secondary Headers
-
-// These colors weren't specified in the original UI-kit,
-// but were present in the design.
-
-// TODO: Discuss with designer to see if any can/should
-// be replaced by the primary/secondary palette colors.
-
-$secondary-gray-1  = #D1D1D1 // navbar/topbar borders
-$secondary-gray-2  = #C7C7D0 // last updated color
-$secondary-gray-3  = #E7EBF1 // subnav background
-$secondary-gray-4  = #F7F7F7 // main background, help-us header bg
-$secondary-gray-5  = #DDDDDD // viz info icon
-$secondary-gray-6  = #5F6C87 // table headers
-$secondary-gray-7  = #F5F6F7 // table alt color
-$secondary-gray-8  = #E3E3E3 // table border, hr
-$secondary-gray-9  = #BEBECC // banner/modal close icon
-$secondary-gray-10 = #A7A7B3 // table timestamp color
-$secondary-gray-11 = #5D5D5D // skull icon background
-$secondary-gray-12 = #ECECEC // cancel button background
-$secondary-gray-13 = #8D8D8D // cancel button foreground
-$secondary-gray-14 = #D6D6D6 // cancel button hover
-$secondary-gray-15 = rgba(67, 84, 109, .22) // tooltip shadow
-$secondary-gray-16 = #6D6F74 // tooltip text
-$secondary-gray-17 = #959797 // main nav inactive
-
-$secondary-green-1 = #66AA26 // subnav active
-
-$secondary-red-2  = #AA3737 // invalid form element border
-$secondary-red-3  = #D0021B // invalid form element text
-$secondary-red-4  = #BC2424 // invalid form element warning
-
-$secondary-blue-2 = #317DAB // submit button hover
-$secondary-blue-3 = #51BBFC // new main nav hover/active, selectors
-
-$secondary-gold-2 = #ECB51A // banner opt-in button hover
-
-// Syntax colors
-$syntax-orange = #EE833B
-$syntax-blue = #6DC0CE
-
-// NEW PALETTE
-
-$dark-blue = #152849
-$light-green = #66AA26
-$light-blue = #5F6C87
-$link-blue = #4E9FD1
-$glow-blue = #51BBFD
-$lighter-blue = #BEBECD
-$light-gray = #B8BBBC
-$light-gray-2 = #DCDCDC
-$lighter-gray = #F2F2F2
-$gray-blue = #C8CBD4
-$dark-gray-blue = #728099
-$hover-gray = #F0F0F0 // dropdown hover
-$table-gray = #5D5D5D
-$banner-red = #F4D9D9
+// Primary Palette
+$headings-color = #152849
+$healthy-color = #66AA26
+$warning-color   = #F2BE2C
+$alert-color    = #ED7785
+$body-color = #5F6C87
+$link-color = #51BBFD
+$tooltip-color = #B8BBBC
+$tooltip-shadow = rgba(0, 0, 0, .20)
+$table-border-color = #EDEDED
+$button-border-color = #C8CBD4
+$background-color  = #F6F6F6
 
 // Alert colors
+$notification-alert-fill-color = #F4D9D9
+$notification-alert-border-color = #F2B7B7
+$notification-info-fill-color = #F2F8EC
+$notification-info-border-color = #C8E0AF
+$notification-warning-fill-color = #FDF8E9
+$notification-warning-border-color = #F9E6AF
 
-$alert-red-light = #F6DBDB
-$alert-red-dark = #F5B9B9
-$alert-blue-light = #D5EAF8
-$alert-blue-dark = #ADDCFA
-$alert-yellow-light = #F7ECCE
-$alert-yellow-dark = #F5DF9E
+// Syntax highlight colors
+$syntax-string-color = #E4843C
+$syntax-keyword-color = #91C8F2

--- a/pkg/ui/styl/base/reset.styl
+++ b/pkg/ui/styl/base/reset.styl
@@ -6,5 +6,5 @@
 html
 body
   height 100%
-  background-color $secondary-gray-4
+  background-color $background-color
   min-width 700px

--- a/pkg/ui/styl/layout/layout.styl
+++ b/pkg/ui/styl/layout/layout.styl
@@ -16,9 +16,7 @@ permissions and limitations under the License.
 Author: Matt Tracy (matt@cockroachlabs.com)
 */
 
-$topbar-border      = $secondary-gray-1
-$last-updated-color = $secondary-gray-2
-$subnav-background  = $secondary-gray-4
+$subnav-background  = $background-color
 
 .page
   position relative
@@ -41,8 +39,8 @@ $subnav-background  = $secondary-gray-4
   position relative
 
   &--fixed
-    background-color $secondary-gray-4
-    border-bottom 1px solid $lighter-gray
+    background-color $background-color
+    border-bottom 1px solid $table-border-color
 
   &__list
     clearfix()
@@ -54,7 +52,7 @@ $subnav-background  = $secondary-gray-4
 
 .header
   flex 0 0 auto
-  color $dark-blue
+  color $headings-color
   font-size 24px
   padding 24px 24px 12px
   text-transform uppercase
@@ -87,310 +85,21 @@ $subnav-background  = $secondary-gray-4
   max-width 1350px
   clearfix()
 
-  .form
-    padding 40px 10px
-    width 600px
-    font-size 13px
-
-    hr
-      border 1px solid $secondary-gray-8
-      margin 40px 0
-
-.section
-  input
-    border-radius 5px
-    border 1px solid $secondary-gray-1
-    padding 15px
-    font-size 12px
-    font-family Lato-Medium
-    margin-bottom 25px
-
-    &:not([type=checkbox])
-      width 47%
-      margin-right 3%
-      height 40px
-
-    &[type=checkbox]
-      display inline
-      margin-right 15px
-      padding-bottom 0
-      margin-bottom 25px
-
-    &.show-required
-      &:invalid
-        border-color $secondary-red-2
-      &:invalid + span.status:after
-          content "Required"
-      &:invalid + * + span.icon:after
-        content "\26A0"
-
 .parent-link a
-  color $glow-blue
+  color $link-color
   font-size 13px
   font-family Lato-Regular
   text-transform uppercase
   text-decoration none
   letter-spacing 2px
 
-span.status
-  position absolute
-  margin-left -65px
-  margin-top 10px
-  color $secondary-red-3
-
-span.icon
-  margin-top 10px
-  color $secondary-red-4
-  position absolute
-  margin-left -15px
-
-.topbar
-  padding 0 3rem 1rem
-  background-color white
-  border-bottom 1px solid $topbar-border
-  height $top-bar-height
-  width 100%
-  position absolute
-  top 0
-  right 0
-  z-index $z-index-page-config
-
-  h2
-    font-size 3rem
-    font-family Lato-Medium
-    color $main-navy
-    line-height $top-bar-height
-    padding-top 0
-    margin-top 0
-    display inline-block
-
-    a
-      text-decoration none
-      color $main-gray
-
-  img
-    position relative
-    top 8px
-
-  .health
-    text-transform uppercase
-    display block
-    font-size 11px
-    letter-spacing 1px
-    color $main-dark-gray
-
-    span.health-icon
-      display inline-block
-      padding 0 3px
-      height 21px
-      border-radius 100%
-
-    .icon-check-circle
-      color $main-green
-    .icon-x, .icon-stop-sign
-      color $secondary-red
-    .icon-skull
-      background-color $secondary-gray-11
-      color white
-
-    *
-      display inline
-
-    .unreachable-text, .good
-      position relative
-      top -1.5px
-      font-variant normal
-      font-family Lato-Heavy
-      color $secondary-red
-    .good
-      color $main-green
-
-  .info-container
-    display inline-block
-    margin-left 25px
-
-    .last-updated
-      font-size 1rem
-      font-family Lato-Regular
-      color $last-updated-color
-      letter-spacing .2px
-    .health
-      font-family Lato-Heavy
-      div
-        margin-left 5px
-        position relative
-        top 1px
-        span.refreshing-text
-          color $secondary-gray-2
-          font-variant none
-
-    strong
-      font-family Lato-Bold
-
-a.toggle
-  font-family Lato-Bold
-  font-size 1rem
-  color $secondary-light-gray
-
-.status
-  font-size 9px
-  &.missing
-    color $secondary-red
-  &.stale
-    color $secondary-gold
-  &.healthy
-    color $main-green
-
-.modal-container
-  z-index 10
-
-  &.close
-    .screen, .modal
-      transition opacity .2s ease-in
-      opacity 0
-
-  .screen
-    position fixed
-    top 0
-    left 0
-    bottom 0
-    right 0
-    background-color rgba(21, 31, 52, .8)
-    z-index 10
-
-  .modal
-    position absolute
-    width 700px
-    height 620px
-    background-color white
-    top 20px
-    z-index 20
-    left 50%
-    margin-left -350px
-    border 8px solid rgba(21, 31, 52, .4)
-    box-shadow 0 2px 4px rgba(0, 0, 0, .5)
-    border-radius 4px
-    background-clip padding-box
-    padding 35px
-    opacity 1
-    transition height .4s ease-in, width .4s ease-in, opacity .2s ease-in, margin .4s ease-in
-
-    &.hide-modal
-      opacity 0
-
-    &.thanks, &.thanks-pre
-      width 500px
-      height 375px
-      margin-left -250px
-
-    &.thanks
-      button
-        margin-left 52px
-
-    h1, .intro, .thanks, button, form
-      transition opacity .2s ease-in
-
-    &.hide, &.thanks-pre
-      h1, .intro, .thanks, button, form
-        opacity 0
-        transition opacity .2s ease-in
-
-
-    h1
-      color $main-green
-      margin-bottom 5px
-      margin-top 0
-      width 100%
-      text-align left
-      font-size 33px
-      font-family Lato-Regular
-
-    .intro
-      color $main-navy
-      margin 15px 0 30px
-      line-height 18px
-      font-family Lato-Regular
-      font-size 14px
-      line-height 2.25rem
-
-    .optin-text
-      margin -17px 20px 20px 28px
-
-    .thanks
-      margin 35px 52px
-
-      a
-        color $main-navy
-
-    .inputs
-      background-color $secondary-gray-3
-      margin 0 -35px
-      padding 30px 30px 10px
-      border-top 1px solid $secondary-gray-1
-      border-bottom 1px solid $secondary-gray-1
-
-    .close
-      position absolute
-      top 30px
-      right 30px
-      color $secondary-gray-9
-
-    button
-      margin 20px 0 35px 20px
-      width auto
-      padding 10px 25px
-
 #content
   position relative
-
-.saving
-  display inline
-  font-family Lato-Medium
-  color $secondary-gray-2
-  transition opacity 2s ease-in
-  opacity 0
-  &.no-animate
-    transition opacity 0s
-  &.failed
-    opacity 1
 
 .optin-text
   font-size 10px
   margin -17px 28px 20px
   line-height 1.8rem
-
-.event-table-container
-    background-color white
-  .table-header
-    padding 15px
-    button, h1
-      margin 0
-      padding 0
-      display inline
-      margin-right 20px
-    button.toggled, button.untoggled
-      border 2px solid $secondary-blue
-      height auto
-      width auto
-      padding 5px
-      font-size 12px
-    button.untoggled
-      background-color white
-      color $secondary-blue
-
-  // TODO: if we want the green border from the mock, we should inline the svg
-  .icon-info-filled
-    color $main-green
-    width 18px
-    height 18px
-    padding 0
-    margin 0
-    line-height 0
-
-  .timestamp
-    font-family Lato-Bold
-    font-size 11px
-    color $secondary-gray-10
 
 .page.events
   .section
@@ -422,20 +131,6 @@ a.toggle
     font-size 16px
     margin-bottom 2rem
 
-#footer
-  height $footer-height
-  padding-left 80px
-  border-top 1px solid $secondary-gray-1
-
-  .links
-    width 600px
-    margin auto
-    a
-      line-height $footer-height
-      margin 20px
-      text-decoration none
-      color $main-gray
-
 div.raft-filters
   label, b
     margin 5px
@@ -445,10 +140,6 @@ div.raft-filters
 
     input[type="checkbox"]
       margin 5px
-
-.database-events
-  width 918px
-  border 1px solid $secondary-gray-1
 
 .table-stats
   margin-bottom 50px

--- a/pkg/ui/styl/layout/navigation-bar.styl
+++ b/pkg/ui/styl/layout/navigation-bar.styl
@@ -18,15 +18,11 @@ Author: Matt Tracy (matt@cockroachlabs.com)
 
 // ---- Navigation ----
 $navbar-bg            = white
-$navbar-border        = $secondary-gray-1
-$main-nav-inactive    = $secondary-gray-17
-$main-nav-active-bg   = $secondary-gray-4
-$main-nav-active-font = $secondary-blue-3
-$main-nav-active-icon = $secondary-blue-3
-$main-nav-hover       = $secondary-blue-3
-$subnav-active-color  = $secondary-green-1
-$subnav-text-color    = $secondary-slate-gray
-$subnav-hover-color   = $main-dark-gray
+$main-nav-active-bg   = $background-color
+$main-nav-active-font = $link-color
+$main-nav-active-icon = $link-color
+$main-nav-hover       = $link-color
+$subnav-active-color  = $healthy-color
 
 $subnav-underline-height = 3px
 
@@ -40,7 +36,7 @@ $subnav-underline-height = 3px
   width $nav-width
   modular-font-size '1'
   background-color $navbar-bg
-  border-right 1px solid $light-gray-2
+  border-right 1px solid $table-border-color
   margin 0
   padding 0
   display block
@@ -60,23 +56,22 @@ $subnav-underline-height = 3px
     font-size 8px
     text-transform uppercase
     float left
-    color $light-blue
+    color $body-color
     list-style-type none
     line-height 1.8rem
 
     &.normal
       path
-        fill $light-blue
+        fill $body-color
 
       &.active, &.active:hover, &:hover
-        color $glow-blue
+        color $link-color
 
         path
-          fill $glow-blue
+          fill $link-color
 
     &.cockroach
       padding-top 10px
-      border-bottom 1px solid $navbar-border
 
     &.active
       background-color $navbar-bg
@@ -116,7 +111,7 @@ $subnav-underline-height = 3px
     flex-flow row nowrap
     justify-content flex-start
     modular-font-size '1'
-    color $subnav-text-color
+    color $tooltip-color
     list-style-type none
     line-height $subnav-height - $subnav-underline-height
 
@@ -179,7 +174,7 @@ ul.pagination
   text-transform uppercase
   font-family Lato-Heavy
   font-size 1.1rem
-  color $main-nav-inactive
+  color $tooltip-color
   list-style-type none
   text-align center
 

--- a/pkg/ui/styl/pages/debug.styl
+++ b/pkg/ui/styl/pages/debug.styl
@@ -5,7 +5,7 @@ $debug-table
 
   &__row
     display table-row
-    background-color $light-gray-2
+    background-color $table-border-color
 
     &--header
       font-weight 900
@@ -31,10 +31,10 @@ $debug-table
   @extend $debug-table
 
   &__row
-    alternating-background $light-gray-2 $lighter-gray
+    alternating-background white $table-border-color
 
     &&--header
-      background-color $secondary-red-3
+      background-color $alert-color
 
   &__cell
     white-space normal

--- a/pkg/ui/styl/pages/nodes.styl
+++ b/pkg/ui/styl/pages/nodes.styl
@@ -6,8 +6,8 @@
   vertical-align middle
   
   &--dead
-    color $secondary-red
+    color $alert-color
   &--suspect
-    color $secondary-gold
+    color $warning-color
   &--healthy
-    color $main-green
+    color $healthy-color

--- a/pkg/ui/styl/pages/queryplan.styl
+++ b/pkg/ui/styl/pages/queryplan.styl
@@ -34,4 +34,4 @@
   top 50%
   left 50%
   transform translate(-50%, -50%)
-  color $secondary-red
+  color $alert-color

--- a/pkg/ui/styl/shame.styl
+++ b/pkg/ui/styl/shame.styl
@@ -4,12 +4,12 @@
 // @stylint off
 .has-value.Select--single > .Select-control .Select-value .Select-value-label,
 .has-value.is-pseudo-focused.Select--single > .Select-control .Select-value .Select-value-label
-  color $secondary-blue-3 !important
+  color $link-color !important
 
 .Select-option
   padding 10px 25px !important
   &.is-selected
-    color $secondary-blue-3 !important
+    color $link-color !important
 
 .Select-value
   line-height inherit !important
@@ -55,7 +55,7 @@
   display block !important
 
 .Select-arrow
-  border-top-color $secondary-blue-3 !important
+  border-top-color $link-color !important
 
 .Select
   display inline-block
@@ -70,7 +70,7 @@
 // NVD3 Style overrides.
 .nvtooltip
   font-family Lato-Regular !important
-  color $light-blue !important
+  color $body-color !important
   padding 15px 20px !important
   background rgba(255, 255, 255, .98) !important
   border-radius 5px !important
@@ -97,22 +97,22 @@
   font-weight 400 !important
 
 .legend-subtext
-  color $light-gray !important
+  color $tooltip-color !important
   font-weight 300
 
 .nvd3 .nv-axis
   .tick line
-    stroke $lighter-gray
+    stroke $table-border-color
 
   text
-    fill $dark-blue
+    fill $headings-color
     font-family Lato-Regular
     font-size 11px
 
   .nv-axislabel
     text-transform lowercase
     font-family Lato-Regular
-    fill $lighter-blue
+    fill $button-border-color
 
 .nv-y .nv-axis .domain
   opacity 0


### PR DESCRIPTION
Cuts down our stylus color palette to a small fraction of the colors
defined previously; early in UI development we were rampantly defining
colors with little thought given to any sort of common palette, and
there was a lot of cleanup debt remaining. As of this commit, we are
using only 21 colors in the UI, and each one of them has a consistent
semantic meaning.

Special thanks to @kuanluo for sitting with me for two hours while we
tediously went through this.