### PR TITLE
distsql: use custom not supported error

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -127,12 +127,12 @@ func (v *distSQLExprCheckVisitor) VisitPre(expr parser.Expr) (recurse bool, newE
 	}
 	switch t := expr.(type) {
 	case *subquery, *parser.Subquery:
-		v.err = errors.Errorf("subqueries not supported yet")
+		v.err = newQueryNotSupportedError("subqueries not supported yet")
 		return false, expr
 
 	case *parser.FuncExpr:
 		if t.IsDistSQLBlacklist() {
-			v.err = errors.Errorf("function %s cannot be executed with distsql", t)
+			v.err = newQueryNotSupportedErrorf("function %s cannot be executed with distsql", t)
 			return false, expr
 		}
 	}
@@ -193,6 +193,24 @@ func (a distRecommendation) compose(b distRecommendation) distRecommendation {
 	return canDistribute
 }
 
+type queryNotSupportedError struct {
+	msg string
+}
+
+func (e *queryNotSupportedError) Error() string {
+	return e.msg
+}
+
+func newQueryNotSupportedError(msg string) error {
+	return &queryNotSupportedError{msg: msg}
+}
+
+func newQueryNotSupportedErrorf(format string, args ...interface{}) error {
+	return &queryNotSupportedError{msg: fmt.Sprintf(format, args...)}
+}
+
+var mutationsNotSupportedError = newQueryNotSupportedError("mutations not supported")
+
 // checkSupportForNode returns a distRecommendation (as described above) or an
 // error if the plan subtree is not supported by DistSQL.
 // TODO(radu): add tests for this.
@@ -209,7 +227,7 @@ func (dsp *distSQLPlanner) checkSupportForNode(node planNode) (distRecommendatio
 			if typ := n.columns[i].Typ; typ.FamilyEqual(parser.TypeTuple) ||
 				typ.FamilyEqual(parser.TypeStringArray) ||
 				typ.FamilyEqual(parser.TypeIntArray) {
-				return 0, errors.Errorf("unsupported render type %s", typ)
+				return 0, newQueryNotSupportedErrorf("unsupported render type %s", typ)
 			}
 			if err := dsp.checkExpr(e); err != nil {
 				return 0, err
@@ -230,7 +248,7 @@ func (dsp *distSQLPlanner) checkSupportForNode(node planNode) (distRecommendatio
 
 	case *joinNode:
 		if n.joinType != joinTypeInner {
-			return 0, errors.Errorf("only inner join supported")
+			return 0, newQueryNotSupportedError("only inner join supported")
 		}
 		if err := dsp.checkExpr(n.pred.onCond); err != nil {
 			return 0, err
@@ -286,7 +304,7 @@ func (dsp *distSQLPlanner) checkSupportForNode(node planNode) (distRecommendatio
 		for _, fholder := range n.funcs {
 			if f, ok := fholder.expr.(*parser.FuncExpr); ok {
 				if strings.ToUpper(f.Func.FunctionReference.String()) == "ARRAY_AGG" {
-					return 0, errors.Errorf("ARRAY_AGG aggregation not supported yet")
+					return 0, newQueryNotSupportedError("ARRAY_AGG aggregation not supported yet")
 				}
 			}
 		}
@@ -309,8 +327,12 @@ func (dsp *distSQLPlanner) checkSupportForNode(node planNode) (distRecommendatio
 	case *distinctNode:
 		return dsp.checkSupportForNode(n.plan)
 
+	case *insertNode, *updateNode, *deleteNode:
+		// This is a potential hot path.
+		return 0, mutationsNotSupportedError
+
 	default:
-		return 0, errors.Errorf("unsupported node %T", node)
+		return 0, newQueryNotSupportedErrorf("unsupported node %T", node)
 	}
 }
 


### PR DESCRIPTION
Avoid the use of `errors.Errorf` in the hot path for queries not supported by
DistSQL.

Fixes #16549.