### PR TITLE
storage: fix liveness error string

### DIFF
--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -467,7 +467,7 @@ func (nl *NodeLiveness) IncrementEpoch(ctx context.Context, liveness *Liveness) 
 		} else if actual.Epoch < liveness.Epoch {
 			return errors.Errorf("unexpected liveness epoch %d; expected >= %d", actual.Epoch, liveness.Epoch)
 		}
-		return errors.Errorf("mismatch incrementing epoch for %+v; actual is %+v", liveness, actual)
+		return errors.Errorf("mismatch incrementing epoch for %+v; actual is %+v", *liveness, actual)
 	}); err != nil {
 		if err == errEpochAlreadyIncremented {
 			return nil


### PR DESCRIPTION
The old code would print

```
node_id:3 epoch:122 expiration:<wall_time:1497621451659892498 logical:0 > ; actual is {NodeID:3 Epoch:122 Expiration:1497621455.938854596,0 Draining
:false}
```

and the new code would use the `{NodeID: 3}` format for both.