### PR TITLE
storage: Balance based on ranges-per-GB of disk, not raw range count

### DIFF
--- a/pkg/storage/rule_solver_test.go
+++ b/pkg/storage/rule_solver_test.go
@@ -76,8 +76,8 @@ func TestCandidateSelection(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	type scoreTuple struct {
-		constraint int
-		rangeCount int
+		constraint   int
+		rangesPerGiB float64
 	}
 	genCandidates := func(scores []scoreTuple, idShift int) candidateList {
 		var cl candidateList
@@ -87,7 +87,7 @@ func TestCandidateSelection(t *testing.T) {
 					StoreID: roachpb.StoreID(i + idShift),
 				},
 				constraintScore: float64(score.constraint),
-				rangeCount:      score.rangeCount,
+				rangesPerGiB:    score.rangesPerGiB,
 				valid:           true,
 			})
 		}
@@ -101,7 +101,7 @@ func TestCandidateSelection(t *testing.T) {
 			if i != 0 {
 				buffer.WriteRune(',')
 			}
-			buffer.WriteString(fmt.Sprintf("%d:%d", int(c.constraintScore), c.rangeCount))
+			buffer.WriteString(fmt.Sprintf("%d:%.2f", int(c.constraintScore), c.rangesPerGiB))
 		}
 		return buffer.String()
 	}
@@ -199,7 +199,7 @@ func TestCandidateSelection(t *testing.T) {
 			if good == nil {
 				t.Fatalf("candidate for store %d not found in candidate list: %s", goodStore.StoreID, cl)
 			}
-			actual := scoreTuple{int(good.constraintScore), good.rangeCount}
+			actual := scoreTuple{int(good.constraintScore), good.rangesPerGiB}
 			if actual != tc.good {
 				t.Errorf("expected:%v actual:%v", tc.good, actual)
 			}
@@ -213,7 +213,7 @@ func TestCandidateSelection(t *testing.T) {
 			if bad == nil {
 				t.Fatalf("candidate for store %d not found in candidate list: %s", badStore.StoreID, cl)
 			}
-			actual := scoreTuple{int(bad.constraintScore), bad.rangeCount}
+			actual := scoreTuple{int(bad.constraintScore), bad.rangesPerGiB}
 			if actual != tc.bad {
 				t.Errorf("expected:%v actual:%v", tc.bad, actual)
 			}
@@ -228,57 +228,57 @@ func TestBetterThan(t *testing.T) {
 		{
 			valid:           true,
 			constraintScore: 1,
-			rangeCount:      0,
+			rangesPerGiB:    0,
 		},
 		{
 			valid:           true,
 			constraintScore: 1,
-			rangeCount:      0,
+			rangesPerGiB:    0,
 		},
 		{
 			valid:           true,
 			constraintScore: 1,
-			rangeCount:      1,
+			rangesPerGiB:    1,
 		},
 		{
 			valid:           true,
 			constraintScore: 1,
-			rangeCount:      1,
+			rangesPerGiB:    1,
 		},
 		{
 			valid:           true,
 			constraintScore: 0,
-			rangeCount:      0,
+			rangesPerGiB:    0,
 		},
 		{
 			valid:           true,
 			constraintScore: 0,
-			rangeCount:      0,
+			rangesPerGiB:    0,
 		},
 		{
 			valid:           true,
 			constraintScore: 0,
-			rangeCount:      1,
+			rangesPerGiB:    1,
 		},
 		{
 			valid:           true,
 			constraintScore: 0,
-			rangeCount:      1,
+			rangesPerGiB:    1,
 		},
 		{
 			valid:           false,
 			constraintScore: 1,
-			rangeCount:      0,
+			rangesPerGiB:    0,
 		},
 		{
 			valid:           false,
 			constraintScore: 0,
-			rangeCount:      0,
+			rangesPerGiB:    0,
 		},
 		{
 			valid:           false,
 			constraintScore: 0,
-			rangeCount:      1,
+			rangesPerGiB:    1,
 		},
 	}
 

--- a/pkg/storage/store_pool.go
+++ b/pkg/storage/store_pool.go
@@ -408,10 +408,10 @@ func (s *stat) update(x float64) {
 type StoreList struct {
 	stores []roachpb.StoreDescriptor
 
-	// candidateCount tracks range count stats for stores that are eligible to
-	// be rebalance targets (their used capacity percentage must be lower than
-	// maxFractionUsedThreshold).
-	candidateCount stat
+	// candidateRangesPerGiB tracks ranges-per-GiB of disk capacity stats for
+	// stores that are eligible to be rebalance targets (their used capacity
+	// percentage must be lower than maxFractionUsedThreshold).
+	candidateRangesPerGiB stat
 
 	// candidateLeases tracks range lease stats for stores that are eligible to
 	// be rebalance targets.
@@ -424,7 +424,7 @@ func makeStoreList(descriptors []roachpb.StoreDescriptor) StoreList {
 	sl := StoreList{stores: descriptors}
 	for _, desc := range descriptors {
 		if desc.Capacity.FractionUsed() <= maxFractionUsedThreshold {
-			sl.candidateCount.update(float64(desc.Capacity.RangeCount))
+			sl.candidateRangesPerGiB.update(rangesPerGiB(desc.Capacity))
 		}
 		sl.candidateLeases.update(float64(desc.Capacity.LeaseCount))
 	}
@@ -434,7 +434,7 @@ func makeStoreList(descriptors []roachpb.StoreDescriptor) StoreList {
 func (sl StoreList) String() string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "  candidate: avg-ranges=%v avg-leases=%v\n",
-		sl.candidateCount.mean, sl.candidateLeases.mean)
+		sl.candidateRangesPerGiB.mean, sl.candidateLeases.mean)
 	for _, desc := range sl.stores {
 		fmt.Fprintf(&buf, "  %d: ranges=%d leases=%d fraction-used=%.2f\n",
 			desc.StoreID, desc.Capacity.RangeCount,


### PR DESCRIPTION
This should work approximately the same as today for clusters where all
nodes have the same disk size, but better in clusters where some nodes
have different size disks.

As proposed in https://github.com/cockroachdb/cockroach/pull/16296