### PR TITLE
sql: error instead of panic on duplicate span when tracing

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -478,7 +478,10 @@ CREATE TABLE crdb_internal.session_trace(
 );
 `,
 	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {
-		rows := p.session.Tracing.generateSessionTraceVTable()
+		rows, err := p.session.Tracing.generateSessionTraceVTable()
+		if err != nil {
+			return err
+		}
 		for _, r := range rows {
 			if err := addRow(r[:]...); err != nil {
 				return err

--- a/pkg/sql/trace.go
+++ b/pkg/sql/trace.go
@@ -116,7 +116,11 @@ func (n *traceNode) Next(ctx context.Context) (bool, error) {
 			return false, err
 		}
 
-		n.traceRows = n.p.session.Tracing.generateSessionTraceVTable()
+		var err error
+		n.traceRows, err = n.p.session.Tracing.generateSessionTraceVTable()
+		if err != nil {
+			return false, err
+		}
 		n.execDone = true
 	}
 


### PR DESCRIPTION
I ran into this while working on a change, it was caused by duplicate spans in
the recording. This is indicative of a bug in the tracing logic, but even so an
error is preferable.