### PR TITLE
sql/cli: restore the current database after a reconnect

### DIFF
--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -269,7 +269,7 @@ func TestDumpBytes(t *testing.T) {
 	c := newCLITest(cliTestParams{t: t})
 	defer c.cleanup()
 
-	url, cleanup := sqlutils.PGUrl(t, c.ServingAddr(), "TestDumpBytes", url.User(security.RootUser))
+	url, cleanup := sqlutils.PGUrl(t, c.ServingAddr(), t.Name(), url.User(security.RootUser))
 	defer cleanup()
 
 	conn := makeSQLConn(url.String())
@@ -333,7 +333,7 @@ func TestDumpRandom(t *testing.T) {
 	c := newCLITest(cliTestParams{t: t})
 	defer c.cleanup()
 
-	url, cleanup := sqlutils.PGUrl(t, c.ServingAddr(), "TestDumpRandom", url.User(security.RootUser))
+	url, cleanup := sqlutils.PGUrl(t, c.ServingAddr(), t.Name(), url.User(security.RootUser))
 	defer cleanup()
 
 	conn := makeSQLConn(url.String())

--- a/pkg/cli/interactive_tests/test_reconnect.tcl
+++ b/pkg/cli/interactive_tests/test_reconnect.tcl
@@ -7,11 +7,17 @@ start_server $argv
 spawn $argv sql
 eexpect root@
 
+start_test "Test initialization"
+send "create database t; set database = t;\r"
+eexpect root@
+eexpect "/t>"
+
 send "select 1;\r"
 eexpect "1 row"
 eexpect root@
+end_test
 
-# Check that the client properly detects the server went down.
+start_test "Check that the client properly detects the server went down"
 # We need to force since the open connection may prevent a quick
 # graceful shutdown.
 force_stop_server $argv
@@ -19,7 +25,10 @@ force_stop_server $argv
 send "select 1;\r"
 eexpect "bad connection"
 eexpect root@
+eexpect " ?>"
+end_test
 
+start_test "Check that the client gracefully fails to reconnect"
 send "select 1;\r"
 eexpect "opening new connection"
 expect {
@@ -28,16 +37,21 @@ expect {
     timeout { handle_timeout "connection error" }
 }
 eexpect root@
+eexpect " ?>"
+end_test
 
-# Check that the client automatically reconnects when the server goes up again.
+start_test "Check that the client automatically reconnects when the server goes up again"
 start_server $argv
 
 send "select 1;\r"
 eexpect "opening new connection"
 eexpect "1 row"
 eexpect root@
+# also check that the current db is restored
+eexpect "/t>"
+end_test
 
-# Check that the client picks up when the server was restarted.
+start_test "Check that the client picks up when the server was restarted"
 stop_server $argv
 start_server $argv
 
@@ -48,6 +62,8 @@ eexpect root@
 send "select 1;\r"
 eexpect "1 row"
 eexpect root@
+eexpect "/t>"
+end_test
 
 send "\\q\r"
 eexpect eof

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -473,6 +473,10 @@ func (c *cliState) refreshDatabaseName(txnStatus string, nextState cliStateEnum)
 	}
 
 	dbName := formatVal(dbVals[0].(string), false /* showPrintableUnicode */, false /* shownewLinesAndTabs */)
+
+	// Preserve the current database name in case of reconnects.
+	c.conn.dbName = dbName
+
 	return c.refreshPrompts("/"+dbName+txnStatus, nextState)
 }
 

--- a/pkg/cli/sql_test.go
+++ b/pkg/cli/sql_test.go
@@ -21,13 +21,9 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
-
 	"github.com/chzyer/readline"
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
-	"github.com/cockroachdb/cockroach/pkg/server"
-	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -35,13 +31,12 @@ import (
 func TestSQLLex(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
-	defer s.Stopper().Stop(context.TODO())
+	c := newCLITest(cliTestParams{t: t})
+	defer c.cleanup()
 
-	pgurl, err := s.(*server.TestServer).Cfg.PGURL(url.User(security.RootUser))
-	if err != nil {
-		t.Fatal(err)
-	}
+	pgurl, cleanup := sqlutils.PGUrl(t, c.ServingAddr(), t.Name(), url.User(security.RootUser))
+	defer cleanup()
+
 	conn := makeSQLConn(pgurl.String())
 	defer conn.Close()
 

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -55,7 +55,7 @@ type sqlConn struct {
 func (c *sqlConn) ensureConn() error {
 	if c.conn == nil {
 		if c.reconnecting && isInteractive {
-			fmt.Fprintf(stderr, "connection lost; opening new connection and resetting session parameters...\n")
+			fmt.Fprintf(stderr, "connection lost; opening new connection: all session settings will be lost\n")
 		}
 		conn, err := pq.Open(c.url)
 		if err != nil {

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -122,6 +122,10 @@ func (c *sqlConn) Exec(query string, args []driver.Value) error {
 		return err
 	}
 	_, err := c.conn.Exec(query, args)
+	if err == driver.ErrBadConn {
+		c.reconnecting = true
+		c.Close()
+	}
 	return err
 }
 
@@ -192,6 +196,7 @@ func (r *sqlRows) Tag() string {
 func (r *sqlRows) Close() error {
 	err := r.rows.Close()
 	if err == driver.ErrBadConn {
+		r.conn.reconnecting = true
 		r.conn.Close()
 	}
 	return err


### PR DESCRIPTION
Before:
```
root@26257/> set database=t;

<server restart happens here>

root@26257/t> select * from kv;
connection lost; opening new connection and resetting session parameters...

root@26257/> select * from kv;
pq: table "kv" does not exist
```

After:
```
root@26257/> set database=t;

<server restart happens here>

root@26257/t> select * from kv;
connection lost; opening new connection: all session settings will be lost
root@26257/t> select * from kv;
...
(10 rows)
```
