### PR TITLE
engine: remove TempDir, introduce AuxiliaryDir

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -78,7 +78,7 @@ func backupRestoreTestSetupWithParams(
 	tc = testcluster.StartTestCluster(t, clusterSize, params)
 	for _, s := range tc.Servers {
 		for _, e := range s.Engines() {
-			if err := e.SetTempDir(temp); err != nil {
+			if err := e.SetAuxiliaryDir(temp); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -188,8 +188,15 @@ type Engine interface {
 	Flush() error
 	// GetStats retrieves stats from the engine.
 	GetStats() (*Stats, error)
-	// GetTempDir returns a path under which tempdirs or tempfiles can be created.
-	GetTempDir() string
+	// GetAuxiliaryDir returns a path under which files can be stored
+	// persistently, and from which data can be ingested by the engine.
+	//
+	// Not thread safe.
+	GetAuxiliaryDir() string
+	// SetAuxiliaryDir changes the path returned by GetAuxiliaryDir.
+	//
+	// Not thread safe.
+	SetAuxiliaryDir(string) error
 	// NewBatch returns a new instance of a batched engine which wraps
 	// this engine. Batched engines accumulate all mutations and apply
 	// them atomically on a call to Commit().
@@ -214,8 +221,6 @@ type Engine interface {
 	// by invoking Close(). Note that snapshots must not be used after the
 	// original engine has been stopped.
 	NewSnapshot() Reader
-	// SetTempDir overrides the tempdir path returned by GetTempDir.
-	SetTempDir(dir string) error
 	// IngestExternalFile links a file into the RocksDB log-structured
 	// merge-tree.
 	IngestExternalFile(ctx context.Context, path string, move bool) error

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -5165,16 +5165,6 @@ func calcGoodReplicas(
 	return goodReplicas, behindCount
 }
 
-// GetTempPrefix proxies Store.GetTempPrefix.
-func (r *Replica) GetTempPrefix() string {
-	return r.store.GetTempPrefix()
-}
-
-// TODO(dan): This is likely to be used by upcoming projects (IngestExternalFile
-// and/or DistSQL external storage). Delete it if that doesn't happen and delete
-// this line if it does.
-var _ = (*Replica).GetTempPrefix
-
 // GetLeaseHistory returns the lease history stored on this replica.
 func (r *Replica) GetLeaseHistory() []roachpb.Lease {
 	if r.leaseHistory == nil {

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -503,7 +503,7 @@ func (r *Replica) addSSTablePostApply(ctx context.Context, data []byte) {
 			panic(err)
 		}
 	} else {
-		path = filepath.Join(r.store.engine.GetTempDir(), fmt.Sprintf("addsstable-%x", checksum))
+		path = filepath.Join(r.store.engine.GetAuxiliaryDir(), fmt.Sprintf("addsstable-%x", checksum))
 		move = true
 		if err := ioutil.WriteFile(path, data, 0600); err != nil {
 			panic(err)

--- a/pkg/storage/replica_state.go
+++ b/pkg/storage/replica_state.go
@@ -730,13 +730,3 @@ func (rec ReplicaEvalContext) GetLease() (roachpb.Lease, *roachpb.Lease, error) 
 	lease, nextLease := rec.repl.getLease()
 	return lease, nextLease, nil
 }
-
-// GetTempPrefix proxies Replica.GetTempDir
-func (rec ReplicaEvalContext) GetTempPrefix() string {
-	return rec.repl.GetTempPrefix()
-}
-
-// TODO(dan): This is likely to be used by upcoming projects (IngestExternalFile
-// and/or DistSQL external storage). Delete it if that doesn't happen and delete
-// this line if it does.
-var _ = (ReplicaEvalContext).GetTempPrefix

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -4069,17 +4069,6 @@ func (s *Store) ComputeStatsForKeySpan(startKey, endKey roachpb.RKey) (enginepb.
 	return output, count
 }
 
-// GetTempPrefix returns a path where temporary files and directories can be
-// allocated.
-func (s *Store) GetTempPrefix() string {
-	return s.engine.GetTempDir()
-}
-
-// TODO(dan): This is likely to be used by upcoming projects (IngestExternalFile
-// and/or DistSQL external storage). Delete it if that doesn't happen and delete
-// this line if it does.
-var _ = (*Store).GetTempPrefix
-
 // The methods below can be used to control a store's queues. Stopping a queue
 // is only meant to happen in tests.
 


### PR DESCRIPTION
This is in preparation for Raft sideloading (#16263). We need a permanent
location to link files into RocksDB from. For temporary files, we can simply
use a subdirectory that we wipe on node start.