### PR TITLE
sqlccl: add RESTORE benchmarks for AddSSTable vs WriteBatch

### DIFF
--- a/pkg/ccl/sqlccl/bench_test.go
+++ b/pkg/ccl/sqlccl/bench_test.go
@@ -17,9 +17,11 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlccl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl/sampledataccl"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
@@ -71,6 +73,18 @@ func BenchmarkClusterBackup(b *testing.B) {
 }
 
 func BenchmarkClusterRestore(b *testing.B) {
+	b.Run("AddSSTable", func(b *testing.B) {
+		defer settings.TestingSetBool(&storageccl.AddSSTableEnabled, true)()
+		defer storage.TestingSetDisableSnapshotClearRange(true)()
+		runBenchmarkClusterRestore(b)
+	})
+	b.Run("WriteBatch", func(b *testing.B) {
+		defer settings.TestingSetBool(&storageccl.AddSSTableEnabled, false)()
+		runBenchmarkClusterRestore(b)
+	})
+}
+
+func runBenchmarkClusterRestore(b *testing.B) {
 	// NB: This benchmark takes liberties in how b.N is used compared to the go
 	// documentation's description. We're getting useful information out of it,
 	// but this is not a pattern to cargo-cult.

--- a/pkg/ccl/storageccl/bench_test.go
+++ b/pkg/ccl/storageccl/bench_test.go
@@ -142,7 +142,10 @@ func BenchmarkImport(b *testing.B) {
 		defer storage.TestingSetDisableSnapshotClearRange(true)()
 		runBenchmarkImport(b)
 	})
-	b.Run("WriteBatch", runBenchmarkImport)
+	b.Run("WriteBatch", func(b *testing.B) {
+		defer settings.TestingSetBool(&storageccl.AddSSTableEnabled, false)()
+		runBenchmarkImport(b)
+	})
 }
 
 func runBenchmarkImport(b *testing.B) {


### PR DESCRIPTION
name                         time/op
ClusterRestore/WriteBatch-8   13.3µs ±107%
ClusterRestore/AddSSTable-8    6.47µs ± 3%

name                         speed
ClusterRestore/WriteBatch-8  19.4MB/s ±58%
ClusterRestore/AddSSTable-8  34.7MB/s ± 3%

name                         alloc/op
ClusterRestore/WriteBatch-8    13.1kB ±35%
ClusterRestore/AddSSTable-8    7.05kB ± 5%

name                         allocs/op
ClusterRestore/WriteBatch-8     0.27 ±275%
ClusterRestore/AddSSTable-8      0.00