### PR TITLE
ccl/sqlccl: add a load csv command

### DIFF
--- a/pkg/ccl/ccl_init.go
+++ b/pkg/ccl/ccl_init.go
@@ -14,6 +14,7 @@ package ccl
 import (
 	// ccl init hooks
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/buildccl"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/cliccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/sqlccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl"

--- a/pkg/ccl/cliccl/load.go
+++ b/pkg/ccl/cliccl/load.go
@@ -1,0 +1,151 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
+
+package cliccl
+
+import (
+	"unicode/utf8"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/sqlccl"
+	"github.com/cockroachdb/cockroach/pkg/cli"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func init() {
+	loadCSVCmd := &cobra.Command{
+		Use:   "csv --table=name --dest=directory [--data=file [...]] [flags]",
+		Short: "convert CSV files into enterprise backup format",
+		Long: `
+Convert CSV files into enterprise backup format.
+
+The file at table must contain a single CREATE TABLE statement. The
+files at the various data options (or table.dat if unspecified) must be
+CSV files with data matching the table. A comma is used as a delimiter,
+but can be changed with the delimiter option. Lines beginning with
+comment are ignored. Fields are considered null if equal to nullif
+(may be the empty string).
+
+The backup's tables are created in the "csv" database.
+
+It requires approximately 2x the size of the data files of free disk
+space. An intermediate copy will be stored in the OS temp directory,
+and the final copy in the dest directory.
+
+For example, if there were a file at /data/names containing:
+
+	CREATE TABLE names (first string, last string)
+
+And a file at /data/names.dat containing:
+
+	James,Kirk
+	Leonard,McCoy
+	Spock,
+
+Then the file could be converted and saved to /data/backup with:
+
+	cockroach load csv --table '/data/names' --nullif '' --dest '/data/backup'
+`,
+		RunE: cli.MaybeDecorateGRPCError(runLoadCSV),
+	}
+	flags := loadCSVCmd.PersistentFlags()
+	flags.StringVar(&csvTableName, "table", "", "location of a file containing a single CREATE TABLE statement")
+	flags.StringSliceVar(&csvDataNames, "data", nil, "filenames of CSV data; uses <table>.dat if empty")
+	flags.StringVar(&csvDest, "dest", "", "destination directory for backup files")
+	flags.StringVar(&csvNullIf, "nullif", "", "if specified, the value of NULL; can specify the empty string")
+	flags.StringVar(&csvComma, "delimiter", "", "if specified, the CSV delimiter instead of a comma")
+	flags.StringVar(&csvComment, "comment", "", "if specified, allows comment lines starting with this character")
+
+	loadCmds := &cobra.Command{
+		Use:   "load [command]",
+		Short: "loading commands",
+		Long:  `Commands for bulk loading external files.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Usage()
+		},
+	}
+	cli.AddCmd(loadCmds)
+	loadCmds.AddCommand(loadCSVCmd)
+}
+
+var (
+	csvComma     string
+	csvComment   string
+	csvDataNames []string
+	csvDest      string
+	csvNullIf    string
+	csvTableName string
+)
+
+func runLoadCSV(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	getRune := func(s string) (rune, error) {
+		if s == "" {
+			return 0, nil
+		}
+		r, sz := utf8.DecodeRuneInString(s)
+		if r == utf8.RuneError {
+			return r, errors.Errorf("invalid character: %s", s)
+		}
+		if sz != len(s) {
+			return r, errors.New("must be only one character")
+		}
+		return r, nil
+	}
+
+	// The Go CSV package by default uses a comma and doesn't allow comments. We
+	// use getRune to check if there is a valid and single Unicode rune
+	// specified. If not, getRune returns 0. If the 0 rune is passed to LoadCSV,
+	// it leaves the Go defaults for those options. Otherwise, it uses that rune
+	// as the delimiter or comment char.
+	comma, err := getRune(csvComma)
+	if err != nil {
+		return errors.Wrap(err, "delimiter flag")
+	}
+	comment, err := getRune(csvComment)
+	if err != nil {
+		return errors.Wrap(err, "comment flag")
+	}
+	var nullIf *string
+	// pflags doesn't have an option to have a flag without a default value
+	// (which would leave it as nil). Instead, we must iterate through all set
+	// flags and detect its presence ourselves.
+	cmd.Flags().Visit(func(f *pflag.Flag) {
+		if f.Name != "nullif" {
+			return
+		}
+		s := f.Value.String()
+		nullIf = &s
+	})
+
+	const sstMaxSize = 1024 * 1024 * 50
+
+	csv, kv, sst, err := sqlccl.LoadCSV(
+		ctx,
+		csvTableName,
+		csvDataNames,
+		csvDest,
+		comma,
+		comment,
+		nullIf,
+		sstMaxSize,
+	)
+	if err != nil {
+		return err
+	}
+	log.Infof(ctx, "CSV rows read: %d", csv)
+	log.Infof(ctx, "KVs pairs created: %d", kv)
+	log.Infof(ctx, "SST files written: %d", sst)
+
+	return nil
+}

--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -1,0 +1,505 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
+
+package sqlccl
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"time"
+
+	"golang.org/x/net/context"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/pkg/errors"
+)
+
+// LoadCSV converts CSV files into enterprise backup format.
+func LoadCSV(
+	ctx context.Context,
+	table string,
+	dataFiles []string,
+	dest string,
+	comma, comment rune,
+	nullif *string,
+	sstMaxSize int64,
+) (csvCount, kvCount, sstCount int64, err error) {
+	if table == "" {
+		return 0, 0, 0, errors.New("no table specified")
+	}
+	if dest == "" {
+		return 0, 0, 0, errors.New("no destination specified")
+	}
+	if comma == 0 {
+		comma = ','
+	}
+	if len(dataFiles) == 0 {
+		dataFiles = []string{fmt.Sprintf("%s.dat", table)}
+	}
+	tableDefStr, err := ioutil.ReadFile(table)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	stmt, err := parser.ParseOne(string(tableDefStr))
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	create, ok := stmt.(*parser.CreateTable)
+	if !ok {
+		return 0, 0, 0, errors.New("expected CREATE TABLE statement in table file")
+	}
+	if create.IfNotExists {
+		return 0, 0, 0, errors.New("unsupported IF NOT EXISTS")
+	}
+	if create.Interleave != nil {
+		return 0, 0, 0, errors.New("interleaved not supported")
+	}
+	if create.AsSource != nil {
+		return 0, 0, 0, errors.New("CREATE AS not supported")
+	}
+	// TODO(mjibson): error on FKs
+
+	const (
+		// We need to choose arbitrary database and table IDs. These aren't important,
+		// but they do match what would happen when creating a new database and
+		// table on an empty cluster.
+		parentID = keys.MaxReservedDescID + 1
+		id       = parentID + 1
+	)
+	tableDesc, err := sql.MakeTableDesc(
+		ctx,
+		nil, /* txn */
+		sql.NilVirtualTabler,
+		nil, /* SearchPath */
+		create,
+		parentID,
+		id,
+		sqlbase.NewDefaultPrivilegeDescriptor(),
+		nil, /* affected */
+		"",  /* sessionDB */
+		nil, /* EvalContext */
+	)
+	if err != nil {
+		return 0, 0, 0, errors.Wrap(err, "creating table descriptor")
+	}
+
+	rocksdbDest, err := ioutil.TempDir("", "cockroach-csv-rocksdb")
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	defer func() {
+		if err := os.RemoveAll(rocksdbDest); err != nil {
+			log.Infof(ctx, "could not remove temp directory %s: %s", rocksdbDest, err)
+		}
+	}()
+
+	// Some channels are buffered because reads happen in bursts, so having lots
+	// of pre-computed data improves overall performance.
+	const chanSize = 10000
+
+	group, gCtx := errgroup.WithContext(ctx)
+	recordCh := make(chan csvRecord, chanSize)
+	kvCh := make(chan roachpb.KeyValue, chanSize)
+	contentCh := make(chan sstContent)
+	group.Go(func() error {
+		defer close(recordCh)
+		var err error
+		csvCount, err = readCSV(gCtx, comma, comment, len(tableDesc.VisibleColumns()), dataFiles, recordCh)
+		return err
+	})
+	group.Go(func() error {
+		defer close(kvCh)
+		return groupWorkers(gCtx, runtime.NumCPU(), func(ctx context.Context) error {
+			return convertRecord(ctx, recordCh, kvCh, nullif, &tableDesc)
+		})
+	})
+	group.Go(func() error {
+		defer close(contentCh)
+		var err error
+		kvCount, err = writeRocksDB(gCtx, kvCh, rocksdbDest, sstMaxSize, contentCh)
+		return err
+	})
+	group.Go(func() error {
+		var err error
+		sstCount, err = makeBackup(gCtx, parentID, &tableDesc, dest, contentCh)
+		return err
+	})
+	return csvCount, kvCount, sstCount, group.Wait()
+}
+
+// groupWorkers creates num worker go routines in an error group.
+func groupWorkers(ctx context.Context, num int, f func(context.Context) error) error {
+	group, ctx := errgroup.WithContext(ctx)
+	for i := 0; i < num; i++ {
+		group.Go(func() error {
+			return f(ctx)
+		})
+	}
+	return group.Wait()
+}
+
+// readCSV sends records on ch from CSV listed by dataFiles. comma, if
+// non-zero, specifies the field separator. comment, if non-zero, specifies
+// the comment character. It returns the number of rows read.
+func readCSV(
+	ctx context.Context,
+	comma, comment rune,
+	expectedCols int,
+	dataFiles []string,
+	recordCh chan<- csvRecord,
+) (int64, error) {
+	expectedColsExtra := expectedCols + 1
+	done := ctx.Done()
+	var count int64
+	for _, dataFile := range dataFiles {
+		select {
+		case <-done:
+			return 0, ctx.Err()
+		default:
+		}
+		err := func() error {
+			f, err := os.Open(dataFile)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			cr := csv.NewReader(f)
+			cr.Comma = comma
+			cr.FieldsPerRecord = -1
+			cr.LazyQuotes = true
+			cr.Comment = comment
+			for i := 1; ; i++ {
+				record, err := cr.Read()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					return errors.Wrapf(err, "row %d: reading CSV record", i)
+				}
+				if len(record) == expectedCols {
+					// Expected number of columns.
+				} else if len(record) == expectedColsExtra && record[expectedCols] == "" {
+					// Line has the optional trailing comma, ignore the empty field.
+					record = record[:expectedCols]
+				} else {
+					return errors.Errorf("row %d: expected %d fields, got %d", i, expectedCols, len(record))
+				}
+				cr := csvRecord{
+					r:    record,
+					file: dataFile,
+					row:  i,
+				}
+				select {
+				case <-done:
+					return ctx.Err()
+				case recordCh <- cr:
+					count++
+				}
+			}
+			return nil
+		}()
+		if err != nil {
+			return 0, errors.Wrapf(err, dataFile)
+		}
+	}
+	return count, nil
+}
+
+type csvRecord struct {
+	r    []string
+	file string
+	row  int
+}
+
+// convertRecord converts CSV records KV pairs and sends them on the kvCh chan.
+func convertRecord(
+	ctx context.Context,
+	recordCh <-chan csvRecord,
+	kvCh chan<- roachpb.KeyValue,
+	nullif *string,
+	tableDesc *sqlbase.TableDescriptor,
+) error {
+	done := ctx.Done()
+
+	visibleCols := tableDesc.VisibleColumns()
+	for _, col := range visibleCols {
+		if col.DefaultExpr != nil {
+			return errors.Errorf("column %q: DEFAULT expression unsupported", col.Name)
+		}
+	}
+	keyDatums := make(sqlbase.EncDatumRow, len(tableDesc.PrimaryIndex.ColumnIDs))
+	// keyDatumIdx maps ColumnIDs to indexes in keyDatums.
+	keyDatumIdx := make(map[sqlbase.ColumnID]int)
+	for _, id := range tableDesc.PrimaryIndex.ColumnIDs {
+		for _, col := range visibleCols {
+			if col.ID == id {
+				keyDatumIdx[id] = len(keyDatumIdx)
+				break
+			}
+		}
+	}
+
+	ri, err := sqlbase.MakeRowInserter(nil /* txn */, tableDesc, nil /* fkTables */, tableDesc.Columns, false /* checkFKs */)
+	if err != nil {
+		return errors.Wrap(err, "make row inserter")
+	}
+
+	parse := parser.Parser{}
+	evalCtx := parser.EvalContext{}
+	// Although we don't yet support DEFAULT expressions on visible columns,
+	// we do on hidden columns (which is only the default _rowid one). This
+	// allows those expressions to run.
+	cols, defaultExprs, err := sqlbase.ProcessDefaultColumns(tableDesc.Columns, tableDesc, &parse, &evalCtx)
+	if err != nil {
+		return errors.Wrap(err, "process default columns")
+	}
+
+	datums := make([]parser.Datum, len(visibleCols))
+	var insertErr error
+	for record := range recordCh {
+		for i, r := range record.r {
+			if nullif != nil && r == *nullif {
+				datums[i] = parser.DNull
+			} else {
+				datums[i], err = parser.ParseStringAs(visibleCols[i].Type.ToDatumType(), r, time.UTC)
+				if err != nil {
+					return errors.Wrapf(err, "%s: row %d: parse %q as %s", record.file, record.row, visibleCols[i].Name, visibleCols[i].Type.SQLString())
+				}
+			}
+			if idx, ok := keyDatumIdx[visibleCols[i].ID]; ok {
+				keyDatums[idx] = sqlbase.DatumToEncDatum(visibleCols[i].Type, datums[i])
+			}
+		}
+
+		row, err := sql.GenerateInsertRow(defaultExprs, ri.InsertColIDtoRowIndex, cols, evalCtx, tableDesc, datums)
+		if err != nil {
+			return errors.Wrapf(err, "generate insert row: %s: row %d", record.file, record.row)
+		}
+		insertErr = nil
+		if err := ri.InsertRow(ctx, inserter(func(kv roachpb.KeyValue) {
+			select {
+			case kvCh <- kv:
+			case <-done:
+				insertErr = ctx.Err()
+			}
+		}), row, true /* ignoreConflicts */, false /* traceKV */); err != nil {
+			return errors.Wrapf(err, "insert row: %s: row %d", record.file, record.row)
+		}
+		if insertErr != nil {
+			return insertErr
+		}
+	}
+	return nil
+}
+
+type sstContent struct {
+	data []byte
+	size int64
+	span roachpb.Span
+}
+
+// writeRocksDB writes kvs to a RocksDB instance that is created at
+// rocksdbDir. After kvs is closed, sst files are created of size maxSize
+// and sent on contents. It returns the number of KV pairs created.
+func writeRocksDB(
+	ctx context.Context,
+	kvCh <-chan roachpb.KeyValue,
+	rocksdbDir string,
+	sstMaxSize int64,
+	contentCh chan<- sstContent,
+) (int64, error) {
+	const batchMaxSize = 1024 * 50
+
+	cache := engine.NewRocksDBCache(0)
+	defer cache.Release()
+	r, err := engine.NewRocksDB(roachpb.Attributes{}, rocksdbDir, cache, 0 /* maxSize */, 1024 /* maxOpenFiles */)
+	if err != nil {
+		return 0, errors.Wrap(err, "create rocksdb instance")
+	}
+	defer r.Close()
+	b := r.NewBatch()
+	var mk engine.MVCCKey
+	for kv := range kvCh {
+		mk.Key = kv.Key
+
+		// We need to detect duplicate primary/unique keys. This means we can't
+		// call .Put with the same keys, because it will overwrite a previous
+		// key. Calling .Get before each .Put is very slow. Instead, give each key
+		// a unique timestamp. When we iterate in order, this timestamp will be set
+		// to a static value, which will cause duplicate keys to error during sst.Add.
+		mk.Timestamp.WallTime++
+
+		if err := b.Put(mk, kv.Value.RawBytes); err != nil {
+			return 0, err
+		}
+		if len(b.Repr()) > batchMaxSize {
+			if err := b.Commit(false /* sync */); err != nil {
+				return 0, err
+			}
+			b = r.NewBatch()
+		}
+	}
+	if len(b.Repr()) > 0 {
+		if err := b.Commit(false /* sync */); err != nil {
+			return 0, err
+		}
+	}
+	it := r.NewIterator(false /* prefix */)
+	defer it.Close()
+	sst, err := engine.MakeRocksDBSstFileWriter()
+	if err != nil {
+		return 0, err
+	}
+	defer sst.Close()
+
+	writeSST := func(key, endKey roachpb.Key) error {
+		data, err := sst.Finish()
+		if err != nil {
+			return err
+		}
+		sc := sstContent{
+			data: data,
+			size: sst.DataSize,
+			span: roachpb.Span{
+				Key:    key,
+				EndKey: endKey,
+			},
+		}
+		select {
+		case contentCh <- sc:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		sst.Close()
+		return nil
+	}
+
+	var kv engine.MVCCKeyValue
+	var firstKey, lastKey roachpb.Key
+	ts := timeutil.Now().UnixNano()
+	var count int64
+	for it.Seek(engine.MVCCKey{}); ; it.Next() {
+		if ok, err := it.Valid(); err != nil {
+			return 0, err
+		} else if !ok {
+			break
+		}
+		count++
+
+		// Save the first key for the span.
+		if firstKey == nil {
+			firstKey = append([]byte(nil), it.UnsafeKey().Key...)
+
+			// Ensure the first key doesn't match the last key of the previous SST.
+			if firstKey.Equal(lastKey) {
+				return 0, errors.Errorf("duplicate key: %s", firstKey)
+			}
+		}
+
+		kv.Key = it.UnsafeKey()
+		kv.Key.Timestamp.WallTime = ts
+		kv.Value = it.UnsafeValue()
+
+		if err := sst.Add(kv); err != nil {
+			return 0, errors.Wrapf(err, "SST creation error at %s; this can happen when a primary or unique index has duplicate keys", kv.Key.Key)
+		}
+		if sst.DataSize > sstMaxSize {
+			if err := writeSST(firstKey, kv.Key.Key.Next()); err != nil {
+				return 0, err
+			}
+			firstKey = nil
+			lastKey = append([]byte(nil), kv.Key.Key...)
+
+			sst, err = engine.MakeRocksDBSstFileWriter()
+			if err != nil {
+				return 0, err
+			}
+			defer sst.Close()
+		}
+	}
+	if sst.DataSize > 0 {
+		if err := writeSST(firstKey, kv.Key.Key.Next()); err != nil {
+			return 0, err
+		}
+	}
+	return count, nil
+}
+
+// makeBackup writes sst files from contents to destDir and creates a backup
+// descriptor. It returns the number of SST files written.
+func makeBackup(
+	ctx context.Context,
+	parentID sqlbase.ID,
+	tableDesc *sqlbase.TableDescriptor,
+	destDir string,
+	contentCh <-chan sstContent,
+) (int64, error) {
+	backupDesc := BackupDescriptor{
+		FormatVersion: BackupFormatInitialVersion,
+	}
+
+	i := 0
+	for sst := range contentCh {
+		backupDesc.EntryCounts.DataSize += sst.size
+		checksum, err := storageccl.SHA512ChecksumData(sst.data)
+		if err != nil {
+			return 0, err
+		}
+		i++
+		name := fmt.Sprintf("%d.sst", i)
+		path := filepath.Join(destDir, name)
+		if err := ioutil.WriteFile(path, sst.data, 0666); err != nil {
+			return 0, err
+		}
+
+		backupDesc.Files = append(backupDesc.Files, BackupDescriptor_File{
+			Path:   name,
+			Span:   sst.span,
+			Sha512: checksum,
+		})
+	}
+	if len(backupDesc.Files) == 0 {
+		return 0, errors.New("no files in backup")
+	}
+
+	sort.Sort(backupFileDescriptors(backupDesc.Files))
+	backupDesc.Spans = []roachpb.Span{
+		{
+			Key:    backupDesc.Files[0].Span.Key,
+			EndKey: backupDesc.Files[len(backupDesc.Files)-1].Span.EndKey,
+		},
+	}
+	backupDesc.Descriptors = []sqlbase.Descriptor{
+		*sqlbase.WrapDescriptor(&sqlbase.DatabaseDescriptor{
+			Name: "csv",
+			ID:   parentID,
+		}),
+		*sqlbase.WrapDescriptor(tableDesc),
+	}
+	descBuf, err := backupDesc.Marshal()
+	if err != nil {
+		return 0, err
+	}
+	err = ioutil.WriteFile(filepath.Join(destDir, BackupDescriptorName), descBuf, 0666)
+	return int64(len(backupDesc.Files)), err
+}

--- a/pkg/ccl/sqlccl/csv_test.go
+++ b/pkg/ccl/sqlccl/csv_test.go
@@ -1,0 +1,286 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
+
+package sqlccl
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+const testSSTMaxSize = 1024 * 1024 * 50
+
+func TestLoadCSV(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	ctx := context.Background()
+	defer s.Stopper().Stop(ctx)
+
+	tmp, tmpCleanup := testutils.TempDir(t)
+	defer tmpCleanup()
+
+	const (
+		tableName   = "t"
+		csvName     = tableName + ".dat"
+		tableCreate = `
+			CREATE TABLE ` + tableName + ` (
+				i int,
+				s string,
+				f float,
+				d decimal,
+				primary key (d, s),
+				index idx_f (f)
+			)
+		`
+		tableCSV = `1,1,1,1
+2,two,2.0,2.00
+1234,a string,12.34e56,123456.78e90
+0,0,,0
+`
+	)
+
+	tablePath := filepath.Join(tmp, tableName)
+	dataPath := filepath.Join(tmp, csvName)
+
+	if err := ioutil.WriteFile(tablePath, []byte(tableCreate), 0666); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(dataPath, []byte(tableCSV), 0666); err != nil {
+		t.Fatal(err)
+	}
+
+	null := ""
+	if _, _, _, err := LoadCSV(ctx, tablePath, []string{dataPath}, tmp, 0 /* comma */, 0 /* comment */, &null, testSSTMaxSize); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := db.Exec("SET CLUSTER SETTING enterprise.enabled = true"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec("CREATE DATABASE csv"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`RESTORE csv.* FROM $1`, fmt.Sprintf("nodelocal://%s", tmp)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test the primary key.
+	var i int
+	if err := db.QueryRow("SELECT count(*) FROM csv. " + tableName + "@primary WHERE f = 2").Scan(&i); err != nil {
+		t.Fatal(err)
+	} else if i != 1 {
+		t.Fatalf("expected 1 row, got %v", i)
+	}
+	// Test the secondary index.
+	if err := db.QueryRow("SELECT count(*) FROM csv. " + tableName + "@idx_f WHERE f = 2").Scan(&i); err != nil {
+		t.Fatal(err)
+	} else if i != 1 {
+		t.Fatalf("expected 1 row, got %v", i)
+	}
+	// Test the NULL was created correctly in row 4.
+	if err := db.QueryRow("SELECT count(f) FROM csv. " + tableName).Scan(&i); err != nil {
+		t.Fatal(err)
+	} else if i != 3 {
+		t.Fatalf("expected 3, got %v", i)
+	}
+}
+
+func TestLoadCSVUniqueDuplicate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tmp, tmpCleanup := testutils.TempDir(t)
+	defer tmpCleanup()
+	ctx := context.Background()
+
+	const (
+		tableName   = "t"
+		csvName     = tableName + ".dat"
+		tableCreate = `
+			CREATE TABLE ` + tableName + ` (
+				i int,
+				unique index idx_f (i)
+			)
+		`
+		tableCSV = `1
+2
+3
+3
+4
+`
+	)
+
+	tablePath := filepath.Join(tmp, tableName)
+	dataPath := filepath.Join(tmp, csvName)
+
+	if err := ioutil.WriteFile(tablePath, []byte(tableCreate), 0666); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(dataPath, []byte(tableCSV), 0666); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, _, err := LoadCSV(ctx, tablePath, []string{dataPath}, tmp, 0 /* comma */, 0 /* comment */, nil /* nullif */, testSSTMaxSize)
+	if !testutils.IsError(err, "duplicate key") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadCSVPrimaryDuplicate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tmp, tmpCleanup := testutils.TempDir(t)
+	defer tmpCleanup()
+	ctx := context.Background()
+
+	const (
+		tableName   = "t"
+		csvName     = tableName + ".dat"
+		tableCreate = `
+			CREATE TABLE ` + tableName + ` (
+				i int primary key
+			)
+		`
+		tableCSV = `1
+2
+3
+3
+4
+`
+	)
+
+	tablePath := filepath.Join(tmp, tableName)
+	dataPath := filepath.Join(tmp, csvName)
+
+	if err := ioutil.WriteFile(tablePath, []byte(tableCreate), 0666); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(dataPath, []byte(tableCSV), 0666); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, _, err := LoadCSV(ctx, tablePath, []string{dataPath}, tmp, 0 /* comma */, 0 /* comment */, nil /* nullif */, testSSTMaxSize)
+	if !testutils.IsError(err, "duplicate key") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestLoadCSVPrimaryDuplicateSSTBoundary tests that duplicate keys at
+// SST boundaries are detected.
+func TestLoadCSVPrimaryDuplicateSSTBoundary(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tmp, tmpCleanup := testutils.TempDir(t)
+	defer tmpCleanup()
+	ctx := context.Background()
+
+	const (
+		tableName   = "t"
+		csvName     = tableName + ".dat"
+		tableCreate = `
+			CREATE TABLE ` + tableName + ` (
+				i int primary key,
+				s string
+			)
+		`
+	)
+
+	const sstMaxSize = 10
+
+	tablePath := filepath.Join(tmp, tableName)
+	dataPath := filepath.Join(tmp, csvName)
+
+	s := strings.Repeat("0", sstMaxSize)
+	tableCSV := fmt.Sprintf("1,%s\n1,%s\n", s, s)
+
+	if err := ioutil.WriteFile(tablePath, []byte(tableCreate), 0666); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(dataPath, []byte(tableCSV), 0666); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, _, err := LoadCSV(ctx, tablePath, []string{dataPath}, tmp, 0 /* comma */, 0 /* comment */, nil /* nullif */, sstMaxSize)
+	if !testutils.IsError(err, "duplicate key") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestLoadCSVOptions tests LoadCSV with the comma, comment, and nullif
+// options set.
+func TestLoadCSVOptions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tmp, tmpCleanup := testutils.TempDir(t)
+	defer tmpCleanup()
+	ctx := context.Background()
+
+	const (
+		tableName   = "t"
+		csvName     = tableName + ".dat"
+		tableCreate = `
+			CREATE TABLE ` + tableName + ` (
+				i int,
+				s string,
+				index (s)
+			)
+		`
+		tableCSV = `1|2
+# second value should be null
+2|N
+# delimiter at EOL is allowed
+3|blah|
+4|"quoted "" line"
+5|"quoted "" line
+"
+6|"quoted "" line
+"|
+7|"quoted "" line
+# with comment
+"
+8|lazy " quotes|
+9|"lazy "quotes"|
+N|N
+10|"|"|
+`
+	)
+
+	tablePath := filepath.Join(tmp, tableName)
+	dataPath := filepath.Join(tmp, csvName)
+
+	if err := ioutil.WriteFile(tablePath, []byte(tableCreate), 0666); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(dataPath, []byte(tableCSV), 0666); err != nil {
+		t.Fatal(err)
+	}
+	null := "N"
+	csv, kv, sst, err := LoadCSV(ctx, tablePath, []string{dataPath}, tmp, '|' /* comma */, '#' /* comment */, &null /* nullif */, 500)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if csv != 11 {
+		t.Fatalf("read %d rows, expected %d", csv, 11)
+	}
+	if kv != 22 {
+		t.Fatalf("created %d KVs, expected %d", kv, 22)
+	}
+	if sst != 2 {
+		t.Fatalf("created %d SSTs, expected %d", sst, 2)
+	}
+}

--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -182,7 +182,7 @@ func evalExport(
 	}
 
 	// Compute the checksum before we upload and remove the local file.
-	checksum, err := sha512ChecksumData(sstContents)
+	checksum, err := SHA512ChecksumData(sstContents)
 	if err != nil {
 		return storage.EvalResult{}, err
 	}
@@ -202,7 +202,8 @@ func evalExport(
 	return storage.EvalResult{}, nil
 }
 
-func sha512ChecksumData(data []byte) ([]byte, error) {
+// SHA512ChecksumData returns the SHA512 checksum of data.
+func SHA512ChecksumData(data []byte) ([]byte, error) {
 	h := sha512.New()
 	if _, err := h.Write(data); err != nil {
 		panic(errors.Wrap(err, `"It never returns an error." -- https://golang.org/pkg/hash`))

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -239,7 +239,7 @@ func evalImport(ctx context.Context, cArgs storage.CommandArgs) (*roachpb.Import
 		rows.BulkOpSummary.DataSize += dataSize
 
 		if len(file.Sha512) > 0 {
-			checksum, err := sha512ChecksumData(fileContents)
+			checksum, err := SHA512ChecksumData(fileContents)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -130,6 +130,11 @@ func init() {
 	)
 }
 
+// AddCmd adds a command to the cli.
+func AddCmd(c *cobra.Command) {
+	cockroachCmd.AddCommand(c)
+}
+
 // Run ...
 func Run(args []string) error {
 	cockroachCmd.SetArgs(args)

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"time"
 	"unsafe"
 
 	"golang.org/x/net/context"
@@ -184,55 +183,20 @@ func (n *copyNode) addRow(ctx context.Context, line []byte) error {
 			exprs[i] = parser.DNull
 			continue
 		}
-		var d parser.Datum
 		switch t := n.resultColumns[i].Typ; t {
-		case parser.TypeBool:
-			d, err = parser.ParseDBool(s)
-		case parser.TypeBytes:
-			s, err = decodeCopy(s)
-			d = parser.NewDBytes(parser.DBytes(s))
-		case parser.TypeDate:
-			s, err = decodeCopy(s)
-			if err != nil {
-				break
-			}
-			d, err = parser.ParseDDate(s, n.p.session.Location)
-		case parser.TypeDecimal:
-			d, err = parser.ParseDDecimal(s)
-		case parser.TypeFloat:
-			d, err = parser.ParseDFloat(s)
-		case parser.TypeInt:
-			d, err = parser.ParseDInt(s)
-		case parser.TypeInterval:
+		case parser.TypeBytes,
+			parser.TypeDate,
+			parser.TypeInterval,
+			parser.TypeString,
+			parser.TypeTimestamp,
+			parser.TypeTimestampTZ,
+			parser.TypeUUID:
 			s, err = decodeCopy(s)
 			if err != nil {
-				break
+				return err
 			}
-			d, err = parser.ParseDInterval(s)
-		case parser.TypeString:
-			s, err = decodeCopy(s)
-			d = parser.NewDString(s)
-		case parser.TypeTimestamp:
-			s, err = decodeCopy(s)
-			if err != nil {
-				break
-			}
-			d, err = parser.ParseDTimestamp(s, time.Microsecond)
-		case parser.TypeTimestampTZ:
-			s, err = decodeCopy(s)
-			if err != nil {
-				break
-			}
-			d, err = parser.ParseDTimestampTZ(s, n.p.session.Location, time.Microsecond)
-		case parser.TypeUUID:
-			s, err = decodeCopy(s)
-			if err != nil {
-				break
-			}
-			d, err = parser.ParseDUuidFromString(s)
-		default:
-			return fmt.Errorf("unknown type %s", t)
 		}
+		d, err := parser.ParseStringAs(n.resultColumns[i].Typ, s, n.p.session.Location)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -26,6 +26,7 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/pkg/errors"
@@ -199,4 +200,37 @@ func ParseType(sql string) (CastTargetType, error) {
 	}
 
 	return cast.Type, nil
+}
+
+// ParseStringAs parses s as type t.
+func ParseStringAs(t Type, s string, location *time.Location) (Datum, error) {
+	var d Datum
+	var err error
+	switch t {
+	case TypeBool:
+		d, err = ParseDBool(s)
+	case TypeBytes:
+		d = NewDBytes(DBytes(s))
+	case TypeDate:
+		d, err = ParseDDate(s, location)
+	case TypeDecimal:
+		d, err = ParseDDecimal(s)
+	case TypeFloat:
+		d, err = ParseDFloat(s)
+	case TypeInt:
+		d, err = ParseDInt(s)
+	case TypeInterval:
+		d, err = ParseDInterval(s)
+	case TypeString:
+		d = NewDString(s)
+	case TypeTimestamp:
+		d, err = ParseDTimestamp(s, time.Microsecond)
+	case TypeTimestampTZ:
+		d, err = ParseDTimestampTZ(s, location, time.Microsecond)
+	case TypeUUID:
+		d, err = ParseDUuidFromString(s)
+	default:
+		return nil, errors.Errorf("unknown type %s", t)
+	}
+	return d, err
 }


### PR DESCRIPTION
This adds the ability to convert a CSV file to enterprise BACKUP
format using only the CLI (without connecting to any server). This
is a good-enough solution for most of our current needs. A more
complicated, distributed CSV processing and sorting algorithm could
be used in the future for very large (> many hundred GB) files.

It works by creating a pipeline of channels with worker go routines
at each stage. The stages are: read the CSV into records per line,
convert the records into KV pairs, sort all KV pairs and split into
SST files, write SST files and create the backup descriptor. Only
the second stage (conversion) can be parallelized with multpile go
routines because all others require reading or writing in order.

Although we would like CSV importing (including the RESTORE step)
to not require an enterprise license, for now this code is CCL. When
we figure out exactly how we want to do that we may move it to Apache.

Closes #15933