### PR TITLE
storageccl: add a cgo-free sstable iterator and use it in Import & AddSSTable

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -240,6 +240,12 @@
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/golang/leveldb"
+  packages = ["crc","db","memfs","table"]
+  revision = "259d9253d71996b7778a3efb4144fe4892342b18"
+
+[[projects]]
   name = "github.com/golang/lint"
   packages = [".","golint"]
   revision = "cb00e5669539f047b2f4c53a421a01b0c8e172c6"
@@ -583,6 +589,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "52f52f1230e1e90e0a8fd8fa240787b0b7948f9a35beea191580796fb1c1938d"
+  inputs-digest = "6f78b7ab3c44287d1bcb1fc379ad6583d0492c9a5b43841d0c373de6a1d7c7dc"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/ccl/storageccl/add_sstable.go
+++ b/pkg/ccl/storageccl/add_sstable.go
@@ -13,6 +13,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -75,37 +76,46 @@ func evalAddSSTable(
 func verifySSTable(
 	data []byte, start, end engine.MVCCKey, nowNanos int64,
 ) (enginepb.MVCCStats, error) {
-	sstReader := engine.MakeRocksDBSstFileReader()
-	if err := sstReader.IngestExternalFile(data); err != nil {
-		return enginepb.MVCCStats{}, err
-	}
-	defer sstReader.Close()
-	iter := sstReader.NewIterator(false)
-	defer iter.Close()
-
-	iter.Seek(engine.MVCCKey{Key: keys.MinKey})
-	ok, err := iter.Valid()
-	for ; ok; ok, err = iter.Valid() {
-		unsafeKey := iter.UnsafeKey()
-		if unsafeKey.Less(start) || !unsafeKey.Less(end) {
-			// TODO(dan): Add a new field in roachpb.Error, so the client can
-			// catch this and retry. It can happen if the range splits between
-			// when the client constructs the file and sends the request.
-			return enginepb.MVCCStats{}, errors.Errorf("key %s not in request range [%s,%s)",
-				unsafeKey.Key, start.Key, end.Key)
-		}
-
-		v := roachpb.Value{RawBytes: iter.UnsafeValue()}
-		if err := v.Verify(unsafeKey.Key); err != nil {
+	{
+		iter, err := engineccl.NewMemSSTIterator(data)
+		if err != nil {
 			return enginepb.MVCCStats{}, err
 		}
-		iter.Next()
-	}
-	if err != nil {
-		return enginepb.MVCCStats{}, err
+		defer iter.Close()
+
+		iter.Seek(engine.MVCCKey{Key: keys.MinKey})
+		ok, err := iter.Valid()
+		for ; ok; ok, err = iter.Valid() {
+			unsafeKey := iter.UnsafeKey()
+			if unsafeKey.Less(start) || !unsafeKey.Less(end) {
+				// TODO(dan): Add a new field in roachpb.Error, so the client can
+				// catch this and retry. It can happen if the range splits between
+				// when the client constructs the file and sends the request.
+				return enginepb.MVCCStats{}, errors.Errorf("key %s not in request range [%s,%s)",
+					unsafeKey.Key, start.Key, end.Key)
+			}
+
+			v := roachpb.Value{RawBytes: iter.UnsafeValue()}
+			if err := v.Verify(unsafeKey.Key); err != nil {
+				return enginepb.MVCCStats{}, err
+			}
+			iter.Next()
+		}
+		if err != nil {
+			return enginepb.MVCCStats{}, err
+		}
 	}
 
-	return iter.ComputeStats(start, end, nowNanos)
+	{
+		// TODO(dan): Switch this to the cgo-free sst iterator, too.
+		sstReader := engine.MakeRocksDBSstFileReader()
+		if err := sstReader.IngestExternalFile(data); err != nil {
+			return enginepb.MVCCStats{}, err
+		}
+		defer sstReader.Close()
+		iter := sstReader.NewIterator(false)
+		return iter.ComputeStats(start, end, nowNanos)
+	}
 }
 
 func clearExistingData(

--- a/pkg/ccl/storageccl/engineccl/multi_iterator_test.go
+++ b/pkg/ccl/storageccl/engineccl/multi_iterator_test.go
@@ -67,7 +67,7 @@ func TestMultiIterator(t *testing.T) {
 	for _, test := range tests {
 		name := fmt.Sprintf("%q", test.inputs)
 		t.Run(name, func(t *testing.T) {
-			var iters []engine.Iterator
+			var iters []engine.SimpleIterator
 			for _, input := range test.inputs {
 				batch := rocksDB.NewBatch()
 				defer batch.Close()
@@ -97,28 +97,28 @@ func TestMultiIterator(t *testing.T) {
 			subtests := []struct {
 				name     string
 				expected string
-				fn       func(*MultiIterator)
+				fn       func(engine.SimpleIterator)
 			}{
-				{"NextKey", test.expectedNextKey, (*MultiIterator).NextKey},
-				{"Next", test.expectedNext, (*MultiIterator).Next},
+				{"NextKey", test.expectedNextKey, (engine.SimpleIterator).NextKey},
+				{"Next", test.expectedNext, (engine.SimpleIterator).Next},
 			}
 			for _, subtest := range subtests {
 				t.Run(subtest.name, func(t *testing.T) {
 					var output bytes.Buffer
 					it := MakeMultiIterator(iters)
-					for it.Seek(engine.MVCCKey{Key: keys.MinKey}); it.Valid(); subtest.fn(it) {
+					for it.Seek(engine.MVCCKey{Key: keys.MinKey}); ; subtest.fn(it) {
+						ok, err := it.Valid()
+						if !testutils.IsError(err, test.errRE) {
+							t.Fatalf("expected '%s' error got: %+v", test.errRE, err)
+						}
+						if !ok {
+							break
+						}
 						output.Write(it.UnsafeKey().Key)
 						output.WriteByte(byte(it.UnsafeKey().Timestamp.WallTime))
 						if len(it.UnsafeValue()) == 0 {
 							output.WriteRune('X')
 						}
-					}
-					if err := it.Error(); len(test.errRE) > 0 {
-						if !testutils.IsError(err, test.errRE) {
-							t.Fatalf("expected '%s' error got: %+v", test.errRE, err)
-						}
-					} else if err != nil {
-						t.Fatalf("unexpected error: %+v", err)
 					}
 					if actual := output.String(); actual != subtest.expected {
 						t.Errorf("got %q expected %q", actual, subtest.expected)

--- a/pkg/ccl/storageccl/engineccl/sst_iterator.go
+++ b/pkg/ccl/storageccl/engineccl/sst_iterator.go
@@ -1,0 +1,191 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
+
+package engineccl
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	"github.com/golang/leveldb/db"
+	"github.com/golang/leveldb/memfs"
+	"github.com/golang/leveldb/table"
+	"github.com/pkg/errors"
+
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+)
+
+var readerOpts = &db.Options{
+	Comparer: cockroachComparer{},
+}
+
+type sstIterator struct {
+	sst  *table.Reader
+	iter db.Iterator
+
+	valid   bool
+	err     error
+	mvccKey engine.MVCCKey
+
+	// For allocation avoidance in NextKey.
+	nextKeyStart []byte
+
+	// fs is used to hold the in-memory filesystem for an in-memory reader. I
+	// don't think there's a concrete reason that we need to hold a pointer to
+	// it, but may as well.
+	fs db.FileSystem
+}
+
+var _ engine.SimpleIterator = &sstIterator{}
+
+// NewSSTIterator returns a SimpleIterator for a leveldb formatted sstable on
+// disk. It's compatible with sstables output by engine.RocksDBSstFileWriter,
+// which means the keys are CockroachDB mvcc keys and they each have the RocksDB
+// trailer (of seqno & value type).
+func NewSSTIterator(path string) (engine.SimpleIterator, error) {
+	file, err := db.DefaultFileSystem.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	return &sstIterator{sst: table.NewReader(file, readerOpts)}, nil
+}
+
+// NewMemSSTIterator returns a SimpleIterator for a leveldb format sstable in
+// memory. It's compatible with sstables output by engine.RocksDBSstFileWriter,
+// which means the keys are CockroachDB mvcc keys and they each have the RocksDB
+// trailer (of seqno & value type).
+func NewMemSSTIterator(data []byte) (engine.SimpleIterator, error) {
+	fs := memfs.New()
+	const filename = "data.sst"
+	f, err := fs.Create(filename)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := f.Write(data); err != nil {
+		return nil, err
+	}
+	if err := f.Close(); err != nil {
+		return nil, err
+	}
+
+	file, err := fs.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	return &sstIterator{fs: fs, sst: table.NewReader(file, readerOpts)}, nil
+}
+
+// Close implements the engine.SimpleIterator interface.
+func (r *sstIterator) Close() {
+	if r.iter != nil {
+		r.err = errors.Wrap(r.iter.Close(), "closing sstable iterator")
+	}
+	if err := r.sst.Close(); err != nil && r.err == nil {
+		r.err = errors.Wrap(err, "closing sstable")
+	}
+}
+
+// Seek implements the engine.SimpleIterator interface.
+func (r *sstIterator) Seek(key engine.MVCCKey) {
+	if r.iter != nil {
+		if r.err = errors.Wrap(r.sst.Close(), "resetting sstable iterator"); r.err != nil {
+			return
+		}
+	}
+	r.iter = r.sst.Find(engine.EncodeKey(key), nil)
+	r.Next()
+}
+
+// Valid implements the engine.SimpleIterator interface.
+func (r *sstIterator) Valid() (bool, error) {
+	return r.valid && r.err == nil, r.err
+}
+
+// Next implements the engine.SimpleIterator interface.
+func (r *sstIterator) Next() {
+	if r.valid = r.iter.Next(); !r.valid {
+		return
+	}
+
+	// RocksDB uses the last 8 bytes to pack the sequence number and value type
+	// into a little-endian encoded uint64. The value type is stored in the
+	// low byte and the sequence number is in the high 7 bytes. See dbformat.h.
+	rocksdbInternalKey := r.iter.Key()
+	if len(rocksdbInternalKey) < 8 {
+		r.err = errors.Errorf("invalid rocksdb InternalKey: %x", rocksdbInternalKey)
+		return
+	}
+	seqAndValueType := binary.LittleEndian.Uint64(rocksdbInternalKey[len(rocksdbInternalKey)-8:])
+	if valueType := engine.BatchType(seqAndValueType & 0xff); valueType != engine.BatchTypeValue {
+		r.err = errors.Errorf("value type not supported: %d", valueType)
+		return
+	}
+
+	key := rocksdbInternalKey[:len(rocksdbInternalKey)-8]
+	if r.mvccKey, r.err = engine.DecodeKey(key); r.err != nil {
+		r.err = errors.Wrapf(r.err, "decoding key: %s", key)
+	}
+}
+
+// NextKey implements the engine.SimpleIterator interface.
+func (r *sstIterator) NextKey() {
+	if !r.valid {
+		return
+	}
+	r.nextKeyStart = append(r.nextKeyStart[:0], r.mvccKey.Key...)
+	for r.Next(); r.valid && r.err != nil && bytes.Equal(r.nextKeyStart, r.mvccKey.Key); r.Next() {
+	}
+}
+
+// UnsafeKey implements the engine.SimpleIterator interface.
+func (r *sstIterator) UnsafeKey() engine.MVCCKey {
+	return r.mvccKey
+}
+
+// UnsafeValue implements the engine.SimpleIterator interface.
+func (r *sstIterator) UnsafeValue() []byte {
+	return r.iter.Value()
+}
+
+type cockroachComparer struct{}
+
+var _ db.Comparer = cockroachComparer{}
+
+// Compare implements the db.Comparer interface.
+func (cockroachComparer) Compare(a, b []byte) int {
+	keyA, tsA, okA := engine.SplitMVCCKey(a)
+	keyB, tsB, okB := engine.SplitMVCCKey(b)
+	if !okA || !okB {
+		// This should never happen unless there is some sort of corruption of
+		// the keys. This is a little bizarre, but the behavior exactly matches
+		// engine/db.cc:DBComparator.
+		return bytes.Compare(a, b)
+	}
+
+	if c := bytes.Compare(keyA, keyB); c != 0 {
+		return c
+	}
+	if len(tsA) == 0 {
+		if len(tsB) == 0 {
+			return 0
+		}
+		return -1
+	} else if len(tsB) == 0 {
+		return 1
+	}
+	return bytes.Compare(tsB, tsA)
+}
+
+func (cockroachComparer) Name() string {
+	// This must match the name in engine/db.cc:DBComparator::Name.
+	return "cockroach_comparator"
+}
+
+func (cockroachComparer) AppendSeparator(dst, a, b []byte) []byte {
+	panic("unimplemented")
+}

--- a/pkg/ccl/storageccl/engineccl/sst_iterator_test.go
+++ b/pkg/ccl/storageccl/engineccl/sst_iterator_test.go
@@ -1,0 +1,137 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
+
+package engineccl
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func runTestSSTIterator(t *testing.T, iter engine.SimpleIterator, allKVs []engine.MVCCKeyValue) {
+	// Drop the first kv so we can test Seek.
+	expected := allKVs[1:]
+
+	var kvs []engine.MVCCKeyValue
+	for iter.Seek(expected[0].Key); ; iter.Next() {
+		ok, err := iter.Valid()
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+		if !ok {
+			break
+		}
+		kv := engine.MVCCKeyValue{
+			Key: engine.MVCCKey{
+				Key:       append([]byte(nil), iter.UnsafeKey().Key...),
+				Timestamp: iter.UnsafeKey().Timestamp,
+			},
+			Value: append([]byte(nil), iter.UnsafeValue()...),
+		}
+		kvs = append(kvs, kv)
+	}
+	iter.Close()
+	if ok, err := iter.Valid(); err != nil {
+		t.Fatalf("%+v", err)
+	} else if ok {
+		t.Fatalf("expected !ok")
+	}
+
+	if !reflect.DeepEqual(kvs, expected) {
+		t.Fatalf("got %+v but expected %+v", kvs, expected)
+	}
+}
+
+func TestSSTIterator(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	sst, err := engine.MakeRocksDBSstFileWriter()
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	defer sst.Close()
+	var allKVs []engine.MVCCKeyValue
+	for i := byte(0); i < 10; i++ {
+		kv := engine.MVCCKeyValue{
+			Key: engine.MVCCKey{
+				Key:       []byte{i},
+				Timestamp: hlc.Timestamp{WallTime: int64(i)},
+			},
+			Value: []byte{i},
+		}
+		if err := sst.Add(kv); err != nil {
+			t.Fatalf("%+v", err)
+		}
+		allKVs = append(allKVs, kv)
+	}
+	data, err := sst.Finish()
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	t.Run("Disk", func(t *testing.T) {
+		tempDir, cleanup := testutils.TempDir(t)
+		defer cleanup()
+
+		path := filepath.Join(tempDir, "data.sst")
+		if err := ioutil.WriteFile(path, data, 0600); err != nil {
+			t.Fatalf("%+v", err)
+		}
+
+		iter, err := NewSSTIterator(path)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+		runTestSSTIterator(t, iter, allKVs)
+	})
+	t.Run("Mem", func(t *testing.T) {
+		iter, err := NewMemSSTIterator(data)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+		runTestSSTIterator(t, iter, allKVs)
+	})
+}
+
+func TestCockroachComparer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	keyAMetadata := engine.EncodeKey(engine.MVCCKey{
+		Key: []byte("a"),
+	})
+	keyA2 := engine.EncodeKey(engine.MVCCKey{
+		Key:       []byte("a"),
+		Timestamp: hlc.Timestamp{WallTime: 2},
+	})
+	keyA1 := engine.EncodeKey(engine.MVCCKey{
+		Key:       []byte("a"),
+		Timestamp: hlc.Timestamp{WallTime: 1},
+	})
+	keyB2 := engine.EncodeKey(engine.MVCCKey{
+		Key:       []byte("b"),
+		Timestamp: hlc.Timestamp{WallTime: 2},
+	})
+
+	c := cockroachComparer{}
+	if x := c.Compare(keyAMetadata, keyA1); x != -1 {
+		t.Errorf("expected key metadata to sort first got: %d", x)
+	}
+	if x := c.Compare(keyA2, keyA1); x != -1 {
+		t.Errorf("expected higher timestamp to sort first got: %d", x)
+	}
+	if x := c.Compare(keyA2, keyB2); x != -1 {
+		t.Errorf("expected lower key to sort first got: %d", x)
+	}
+}

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -252,17 +252,10 @@ func evalImport(ctx context.Context, cArgs storage.CommandArgs) (*roachpb.Import
 			}
 		}
 
-		sst := engine.MakeRocksDBSstFileReader()
-		defer sst.Close()
-
-		// Add each file in its own sst reader because IngestExternalFile
-		// requires the affected keyrange be empty and the keys in these files
-		// might overlap.
-		if err := sst.IngestExternalFile(fileContents); err != nil {
+		iter, err := engineccl.NewMemSSTIterator(fileContents)
+		if err != nil {
 			return nil, err
 		}
-
-		iter := sst.NewIterator(false)
 		defer iter.Close()
 		iters = append(iters, iter)
 	}

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -210,7 +210,7 @@ func evalImport(ctx context.Context, cArgs storage.CommandArgs) (*roachpb.Import
 	log.Infof(ctx, "import [%s,%s)", importStart, importEnd)
 
 	var rows rowCounter
-	var iters []engine.Iterator
+	var iters []engine.SimpleIterator
 	for _, file := range args.Files {
 		if log.V(2) {
 			log.Infof(ctx, "import file [%s,%s) %s", importStart, importEnd, file.Path)
@@ -291,9 +291,16 @@ func evalImport(ctx context.Context, cArgs storage.CommandArgs) (*roachpb.Import
 	g, gCtx := errgroup.WithContext(ctx)
 	startKeyMVCC, endKeyMVCC := engine.MVCCKey{Key: args.DataSpan.Key}, engine.MVCCKey{Key: args.DataSpan.EndKey}
 	iter := engineccl.MakeMultiIterator(iters)
+	defer iter.Close()
 	var keyScratch, valueScratch []byte
-
-	for iter.Seek(startKeyMVCC); iter.Valid() && iter.UnsafeKey().Less(endKeyMVCC); iter.NextKey() {
+	for iter.Seek(startKeyMVCC); ; iter.NextKey() {
+		ok, err := iter.Valid()
+		if err != nil {
+			return nil, err
+		}
+		if !ok || !iter.UnsafeKey().Less(endKeyMVCC) {
+			break
+		}
 		if len(iter.UnsafeValue()) == 0 {
 			// Value is deleted.
 			continue
@@ -304,8 +311,6 @@ func evalImport(ctx context.Context, cArgs storage.CommandArgs) (*roachpb.Import
 		key := engine.MVCCKey{Key: keyScratch, Timestamp: iter.UnsafeKey().Timestamp}
 		value := roachpb.Value{RawBytes: valueScratch}
 
-		var ok bool
-		var err error
 		key.Key, ok, err = kr.RewriteKey(key.Key)
 		if err != nil {
 			return nil, err
@@ -346,9 +351,6 @@ func evalImport(ctx context.Context, cArgs storage.CommandArgs) (*roachpb.Import
 				return nil, err
 			}
 		}
-	}
-	if err := iter.Error(); err != nil {
-		return nil, err
 	}
 	// Flush out the last batch.
 	if batcher.Size() > 0 {


### PR DESCRIPTION
The cgo calls involved in iterating an sstable to rekey it and validate
it in AddSSTable are now showing up as significant in pprof (especially
when run with the in-progress sideloading work). This drastically
improves our benchmarks, see next commit.

This uses the github.com/golang/leveldb package, which has a big
"work-in-progress" warning, but the sstable parsing part seems finished.
At very worst, we can always fork it if we need any fixes.

We still need the old one for now to compute mvcc stats. I'm quite
surprised at how much of a difference computing the stats makes,
commenting it out changes the AddSSTable benchmark radically
(100/1000/10000 are ~15/30/46 MB/s).

```
name                         old time/op    new time/op    delta
AddSSTable/100-8               2.14ms ± 2%    2.17ms ± 2%     ~     (p=0.200 n=4+4)
AddSSTable/1000-8              6.68ms ± 9%    6.91ms ±14%     ~     (p=0.690 n=5+5)
AddSSTable/10000-8             52.8ms ± 3%    50.1ms ± 3%   -5.02%  (p=0.016 n=5+5)
Import/AddSSTable/1-8          2.51ms ± 1%    1.80ms ± 1%  -28.39%  (p=0.008 n=5+5)
Import/AddSSTable/100-8        3.72ms ± 1%    2.84ms ± 2%  -23.78%  (p=0.016 n=4+5)
Import/AddSSTable/10000-8      93.4ms ± 6%    81.3ms ± 4%  -13.05%  (p=0.008 n=5+5)
Import/AddSSTable/100000-8      540ms ± 6%     430ms ± 9%  -20.35%  (p=0.008 n=5+5)
ClusterRestore/AddSSTable-8    6.25µs ± 3%    5.51µs ± 6%  -11.84%  (p=0.008 n=5+5)

name                         old speed      new speed      delta
AddSSTable/100-8             8.71MB/s ± 2%  8.55MB/s ± 2%     ~     (p=0.200 n=4+4)
AddSSTable/1000-8            25.8MB/s ± 8%  25.1MB/s ±13%     ~     (p=0.690 n=5+5)
AddSSTable/10000-8           32.4MB/s ± 3%  34.1MB/s ± 3%   +5.24%  (p=0.016 n=5+5)
Import/AddSSTable/1-8         450kB/s ± 0%   626kB/s ± 1%  +39.11%  (p=0.016 n=4+5)
Import/AddSSTable/100-8      4.66MB/s ±10%  6.29MB/s ± 2%  +34.92%  (p=0.008 n=5+5)
Import/AddSSTable/10000-8    17.5MB/s ± 6%  20.1MB/s ± 4%  +14.96%  (p=0.008 n=5+5)
Import/AddSSTable/100000-8   30.2MB/s ± 6%  38.0MB/s ± 8%  +25.61%  (p=0.008 n=5+5)
ClusterRestore/AddSSTable-8  35.8MB/s ± 3%  40.7MB/s ± 6%  +13.62%  (p=0.008 n=5+5)
```

cc @petermattis in case you want to look at the storage/engine changes