### PR TITLE
[wip] cli/sql: display the node ID in the prompt

### DIFF
--- a/pkg/cli/interactive_tests/test_reconnect.tcl
+++ b/pkg/cli/interactive_tests/test_reconnect.tcl
@@ -7,11 +7,17 @@ start_server $argv
 spawn $argv sql
 eexpect root@
 
+start_test "Test initialization"
+send "create database t; set database = t;\r"
+eexpect root@
+eexpect "/t>"
+
 send "select 1;\r"
 eexpect "1 row"
 eexpect root@
+end_test
 
-# Check that the client properly detects the server went down.
+start_test "Check that the client properly detects the server went down"
 # We need to force since the open connection may prevent a quick
 # graceful shutdown.
 force_stop_server $argv
@@ -19,7 +25,10 @@ force_stop_server $argv
 send "select 1;\r"
 eexpect "bad connection"
 eexpect root@
+eexpect " ?>"
+end_test
 
+start_test "Check that the client gracefully fails to reconnect"
 send "select 1;\r"
 eexpect "opening new connection"
 expect {
@@ -28,16 +37,21 @@ expect {
     timeout { handle_timeout "connection error" }
 }
 eexpect root@
+eexpect " ?>"
+end_test
 
-# Check that the client automatically reconnects when the server goes up again.
+start_test "Check that the client automatically reconnects when the server goes up again"
 start_server $argv
 
 send "select 1;\r"
 eexpect "opening new connection"
 eexpect "1 row"
 eexpect root@
+# also check that the current db is restored
+eexpect "/t>"
+end_test
 
-# Check that the client picks up when the server was restarted.
+start_test "Check that the client picks up when the server was restarted"
 stop_server $argv
 start_server $argv
 
@@ -48,6 +62,8 @@ eexpect root@
 send "select 1;\r"
 eexpect "1 row"
 eexpect root@
+eexpect "/t>"
+end_test
 
 send "\\q\r"
 eexpect eof

--- a/pkg/cli/interactive_tests/test_txn_prompt.tcl
+++ b/pkg/cli/interactive_tests/test_txn_prompt.tcl
@@ -11,6 +11,11 @@ eexpect ":/# "
 send "$argv sql\r"
 eexpect root@
 
+start_test "Check node ID."
+eexpect "(node 1)"
+eexpect "/>"
+end_test
+
 start_test "Check database prompt."
 send "CREATE DATABASE IF NOT EXISTS testdb;\r"
 eexpect "\nCREATE DATABASE\r\n"

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -473,6 +473,10 @@ func (c *cliState) refreshDatabaseName(txnStatus string, nextState cliStateEnum)
 	}
 
 	dbName := formatVal(dbVals[0].(string), false /* showPrintableUnicode */, false /* shownewLinesAndTabs */)
+
+	// Preserve the current database name in case of reconnects.
+	c.conn.dbName = dbName
+
 	return c.refreshPrompts("/"+dbName+txnStatus, nextState)
 }
 

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -55,7 +55,7 @@ type sqlConn struct {
 func (c *sqlConn) ensureConn() error {
 	if c.conn == nil {
 		if c.reconnecting && isInteractive {
-			fmt.Fprintf(stderr, "connection lost; opening new connection and resetting session parameters...\n")
+			fmt.Fprintf(stderr, "connection lost; opening new connection: all session settings will be lost\n")
 		}
 		conn, err := pq.Open(c.url)
 		if err != nil {

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -122,6 +122,10 @@ func (c *sqlConn) Exec(query string, args []driver.Value) error {
 		return err
 	}
 	_, err := c.conn.Exec(query, args)
+	if err == driver.ErrBadConn {
+		c.reconnecting = true
+		c.Close()
+	}
 	return err
 }
 


### PR DESCRIPTION
Forked off #16589 for further iterations.

This patch causes the CLI shell to display the ID of the node the
client is connected to. This is displayed in the prompt and refreshed
at every line (when interactive), as opposed to just once upon
start-up, because the shell will reconnect automatically if the
connection drop and that may target a different node when connecting
via a load-balancer.

Fixes #14310.