### PR TITLE
build: use absolute paths to `vendor`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,8 +233,8 @@ stress stressrace: $(C_LIBS) $(CGO_FLAGS_FILES) $(BOOTSTRAP_TARGET)
 
 .PHONY: upload-coverage
 upload-coverage: $(BOOTSTRAP_TARGET)
-	$(GO) install ./vendor/github.com/wadey/gocovmerge
-	$(GO) install ./vendor/github.com/mattn/goveralls
+	$(GO) install $(REPO_ROOT)/vendor/github.com/wadey/gocovmerge
+	$(GO) install $(REPO_ROOT)/vendor/github.com/mattn/goveralls
 	@build/upload-coverage.sh
 
 .PHONY: acceptance

--- a/build/README.md
+++ b/build/README.md
@@ -36,62 +36,80 @@ usual fashion.
 
 #  Dependencies
 
-A snapshot of CockroachDB's dependencies is maintained at https://github.com/cockroachdb/vendored
-and checked out as a submodule at `./vendor`.
+A snapshot of CockroachDB's dependencies is maintained at
+https://github.com/cockroachdb/vendored and checked out as a submodule at
+`./vendor`.
 
 ## Updating Dependencies
 
-This snapshot was built and is managed using `dep` and we manage `vendor` as a submodule.
+This snapshot was built and is managed using `dep` and we manage `vendor` as a
+submodule.
 
-Install `dep` using the vendored sources: `go install ./vendor/github.com/golang/dep/cmd/dep`
+Install `dep` using the vendored sources: `go install
+./vendor/github.com/golang/dep/cmd/dep`
 
 ### Working with Submodules
 
-To keep the bloat of all the changes in all our dependencies out of our main repository, we embed
-`vendor` as a git submodule, storing its content and history in [`vendored`](https://github.com/cockroachdb/vendored) instead.
+To keep the bloat of all the changes in all our dependencies out of our main
+repository, we embed `vendor` as a git submodule, storing its content and
+history in [`vendored`](https://github.com/cockroachdb/vendored) instead.
 
-This split across two repositories however means that changes involving changed dependencies require
-a two step process.
+This split across two repositories however means that changes involving
+changed dependencies require a two step process.
 
-- After using dep to add or update dependencies and making related code changes,
-`git status` in `cockroachdb/cockroach` checkout will report that the `vendor` submodule has
-`modified/untracked content`
-- Switch into `vendor` and commit all changes (or use `git -C vendor`), on a new named branch.
-  - At this point the `git status` in your `cockroachdb/cockroach` checkout will report
-  `new commits` for `vendor` instead of `modified content`.
+- After using dep to add or update dependencies and making related code
+changes, `git status` in `cockroachdb/cockroach` checkout will report that the
+`vendor` submodule has `modified/untracked content`.
+
+- Switch into `vendor` and commit all changes (or use `git -C vendor`), on a
+new named branch.
+
+   + At this point the `git status` in your `cockroachdb/cockroach` checkout
+will report `new commits` for `vendor` instead of `modified content`.
+
 - Commit your code changes and new `vendor` submodule ref.
-- Before this commit can be submitted in a pull request to `cockroachdb/cockroach`, the submodule
-commit it references must be available on `github.com/cockroachdb/vendored`.
+
+- Before this commit can be submitted in a pull request to
+`cockroachdb/cockroach`, the submodule commit it references must be available
+on `github.com/cockroachdb/vendored`.
+
 * Organization members can push their named branches there directly.
-* Non-members should fork the `vendored` repo and submit a pull request to `cockroachdb/vendored`,
-  and need wait for it to merge before they will be able to use it in a `cockroachdb/cockroach` PR.
+
+* Non-members should fork the `vendored` repo and submit a pull request to
+`cockroachdb/vendored`, and need wait for it to merge before they will be able
+to use it in a `cockroachdb/cockroach` PR.
 
 #### `master` Branch Pointer in Vendored Repo
 
-Since the `cockroachdb/cockroach` submodule references individual commit hashes in `vendored`, there
-is little significance to the `master` branch in `vendored` -- as outlined above, new commits are
-always authored with the previously referenced commit as their parent, regardless of what `master`
+Since the `cockroachdb/cockroach` submodule references individual commit
+hashes in `vendored`, there is little significance to the `master` branch in
+`vendored` -- as outlined above, new commits are always authored with the
+previously referenced commit as their parent, regardless of what `master`
 happens to be.
 
-That said, it is critical that any ref in `vendored` that is referenced from `cockroachdb/cockroach`
-remain available in `vendored` in perpetuity: after a PR referencing a ref merges, the `vendored`
-`master` branch should be updated to point to it before the named feature branch can be deleted, to
-ensure the ref remains reachable and thus is never garbage collected.
+That said, it is critical that any ref in `vendored` that is referenced from
+`cockroachdb/cockroach` remain available in `vendored` in perpetuity: after a
+PR referencing a ref merges, the `vendored` `master` branch should be updated
+to point to it before the named feature branch can be deleted, to ensure the
+ref remains reachable and thus is never garbage collected.
 
 #### Conflicting Submodule Changes
 
-The canonical linearization of history is always the main repo. In the event of concurrent
-changes to `vendor`, the first should cause the second to see a conflict on the `vendor` submodule
-pointer. When resolving that conflict, it is important to re-run dep against the fetched, updated
-`vendor` ref, thus generating a new commit in the submodule that has as its parent the one from the
-earlier change.
+The canonical linearization of history is always the main repo. In the event
+of concurrent changes to `vendor`, the first should cause the second to see a
+conflict on the `vendor` submodule pointer. When resolving that conflict, it
+is important to re-run dep against the fetched, updated `vendor` ref, thus
+generating a new commit in the submodule that has as its parent the one from
+the earlier change.
 
 ## Repository Name
 
-We only want the vendor directory used by builds when it is explicitly checked out *and managed* as a
-submodule at `./vendor`.
+We only want the vendor directory used by builds when it is explicitly checked
+out *and managed* as a submodule at `./vendor`.
 
-If a go build fails to find a dependency in `./vendor`, it will continue searching anything named
-"vendor" in parent directories. Thus the vendor repository is _not_ named "vendor", to minimize the risk
-of it ending up somewhere in `GOPATH` with the name `vendor` (e.g. if it is manually cloned), where
-it could end up being unintentionally used by builds and causing confusion.
+If a go build fails to find a dependency in `./vendor`, it will continue
+searching anything named "vendor" in parent directories. Thus the vendor
+repository is _not_ named "vendor", to minimize the risk of it ending up
+somewhere in `GOPATH` with the name `vendor` (e.g. if it is manually cloned),
+where it could end up being unintentionally used by builds and causing
+confusion.

--- a/build/common.mk
+++ b/build/common.mk
@@ -172,23 +172,23 @@ ifneq ($(GIT_DIR),)
 	git submodule update --init
 endif
 	@$(GO_INSTALL) -v $(PKG_ROOT)/cmd/{metacheck,ncpus,returncheck} \
-		"./vendor/github.com/golang/dep/cmd/dep" \
-		"./vendor/github.com/client9/misspell/cmd/misspell" \
-		"./vendor/github.com/cockroachdb/crlfmt" \
-		"./vendor/github.com/cockroachdb/stress" \
-		"./vendor/github.com/golang/lint/golint" \
-		"./vendor/github.com/google/pprof" \
-		"./vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway" \
-		"./vendor/github.com/jteeuwen/go-bindata/go-bindata" \
-		"./vendor/github.com/kisielk/errcheck" \
-		"./vendor/github.com/mattn/goveralls" \
-		"./vendor/github.com/mdempsky/unconvert" \
-		"./vendor/github.com/mibk/dupl" \
-		"./vendor/github.com/wadey/gocovmerge" \
-		"./vendor/golang.org/x/perf/cmd/benchstat" \
-		"./vendor/golang.org/x/tools/cmd/goimports" \
-		"./vendor/golang.org/x/tools/cmd/goyacc" \
-		"./vendor/golang.org/x/tools/cmd/stringer"
+		$(REPO_ROOT)/vendor/github.com/golang/dep/cmd/dep \
+		$(REPO_ROOT)/vendor/github.com/client9/misspell/cmd/misspell \
+		$(REPO_ROOT)/vendor/github.com/cockroachdb/crlfmt \
+		$(REPO_ROOT)/vendor/github.com/cockroachdb/stress \
+		$(REPO_ROOT)/vendor/github.com/golang/lint/golint \
+		$(REPO_ROOT)/vendor/github.com/google/pprof \
+		$(REPO_ROOT)/vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway \
+		$(REPO_ROOT)/vendor/github.com/jteeuwen/go-bindata/go-bindata \
+		$(REPO_ROOT)/vendor/github.com/kisielk/errcheck \
+		$(REPO_ROOT)/vendor/github.com/mattn/goveralls \
+		$(REPO_ROOT)/vendor/github.com/mdempsky/unconvert \
+		$(REPO_ROOT)/vendor/github.com/mibk/dupl \
+		$(REPO_ROOT)/vendor/github.com/wadey/gocovmerge \
+		$(REPO_ROOT)/vendor/golang.org/x/perf/cmd/benchstat \
+		$(REPO_ROOT)/vendor/golang.org/x/tools/cmd/goimports \
+		$(REPO_ROOT)/vendor/golang.org/x/tools/cmd/goyacc \
+		$(REPO_ROOT)/vendor/golang.org/x/tools/cmd/stringer
 	touch $@
 
 # Make doesn't expose a list of the variables declared in a given file, so we


### PR DESCRIPTION
This makes the behaviour of BOOTSTRAP_TARGET independent of CWD.

Also re-wrap build/README.md while I'm here.

cc @dt @BramGruneir 