### PR TITLE
sql/parser: update issue numbers related to collated strings

### DIFF
--- a/pkg/sql/parser/sql.go
+++ b/pkg/sql/parser/sql.go
@@ -6212,7 +6212,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
 		//line sql.y:995
 		{
-			return unimplementedWithIssue(sqllex, 2473)
+			return unimplementedWithIssue(sqllex, 9851)
 		}
 	case 60:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
@@ -7777,7 +7777,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
 		//line sql.y:2258
 		{
-			return unimplementedWithIssue(sqllex, 2473)
+			return unimplementedWithIssue(sqllex, 16619)
 		}
 	case 337:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -992,7 +992,7 @@ opt_validate_behavior:
   }
 
 opt_collate_clause:
-  COLLATE unrestricted_name { return unimplementedWithIssue(sqllex, 2473) }
+  COLLATE unrestricted_name { return unimplementedWithIssue(sqllex, 9851) }
 | /* EMPTY */ {}
 
 alter_using:
@@ -2281,7 +2281,7 @@ index_elem:
 | '(' a_expr ')' opt_collate opt_asc_desc { return unimplemented(sqllex, "index_elem a_expr") }
 
 opt_collate:
-  COLLATE unrestricted_name { return unimplementedWithIssue(sqllex, 2473) }
+  COLLATE unrestricted_name { return unimplementedWithIssue(sqllex, 16619) }
 | /* EMPTY */ {}
 
 opt_asc_desc:


### PR DESCRIPTION
The old issue was #2473. The issues tracking support for collated
strings are now #16618 (database-level collation), #16619 (indexing with
a different collation), and #9851 (general support for altering column
types).