### PR TITLE
storage/engine: Limit batch size in MVCC GC

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -54,6 +54,7 @@ diagnostics.reporting.report_metrics               true           b     enable c
 diagnostics.reporting.send_crash_reports           true           b     send crash and panic reports
 kv.allocator.lease_rebalancing_aggressiveness      1E+00          f     set greater than 1.0 to rebalance leases toward load more aggressively, or between 0 and 1.0 to be more conservative about rebalancing leases
 kv.allocator.load_based_lease_rebalancing.enabled  true           b     set to enable rebalancing of range leases based on load and latency
+kv.gc.batch_size                                   100000         i     maximum number of keys in a batch for MVCC garbage collection
 kv.raft.command.max_size                           64 MiB         z     maximum size of a raft command
 kv.raft_log.synchronize                            true           b     set to true to synchronize on Raft log writes to persistent storage
 kv.snapshot_rebalance.max_rate                     2.0 MiB        z     the rate limit (bytes/sec) to use for rebalance snapshots

--- a/pkg/storage/engine/bench_test.go
+++ b/pkg/storage/engine/bench_test.go
@@ -766,7 +766,9 @@ func BenchmarkMVCCGarbageCollect(b *testing.B) {
 			gcKeys := setup(engine, keySize, valSize, numKeys, numVersions, deleteVersions)
 
 			b.StartTimer()
-			if err := MVCCGarbageCollect(ctx, engine, &enginepb.MVCCStats{}, gcKeys, now); err != nil {
+			if err := MVCCGarbageCollect(
+				ctx, engine, &enginepb.MVCCStats{}, gcKeys, now, math.MaxInt64,
+			); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -3704,7 +3704,9 @@ func TestMVCCGarbageCollect(t *testing.T) {
 		{Key: roachpb.Key("a-bad"), Timestamp: ts2},
 		{Key: roachpb.Key("inline-bad"), Timestamp: hlc.Timestamp{}},
 	}
-	if err := MVCCGarbageCollect(context.Background(), engine, ms, keys, ts3); err != nil {
+	if err := MVCCGarbageCollect(
+		context.Background(), engine, ms, keys, ts3, math.MaxInt64,
+	); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3792,7 +3794,7 @@ func TestMVCCGarbageCollectNonDeleted(t *testing.T) {
 		keys := []roachpb.GCRequest_GCKey{
 			{Key: test.key, Timestamp: ts2},
 		}
-		err := MVCCGarbageCollect(context.Background(), engine, nil, keys, ts2)
+		err := MVCCGarbageCollect(context.Background(), engine, nil, keys, ts2, math.MaxInt64)
 		if !testutils.IsError(err, test.expError) {
 			t.Fatalf("expected error %q when garbage collecting a non-deleted live value, found %v", test.expError, err)
 		}
@@ -3824,7 +3826,9 @@ func TestMVCCGarbageCollectIntent(t *testing.T) {
 	keys := []roachpb.GCRequest_GCKey{
 		{Key: key, Timestamp: ts2},
 	}
-	if err := MVCCGarbageCollect(context.Background(), engine, nil, keys, ts2); err == nil {
+	if err := MVCCGarbageCollect(
+		context.Background(), engine, nil, keys, ts2, math.MaxInt64,
+	); err == nil {
 		t.Fatal("expected error garbage collecting an intent")
 	}
 }


### PR DESCRIPTION
When there is a lot of garbage to collect, a single run of
MVCCGarbageCollect on the node liveness range can last long enough
that leases expire, leading to cascading unavailability.

Fixes #16565