### PR TITLE
sql: add missing IN tuple op for OIDs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/orms
+++ b/pkg/sql/logictest/testdata/logic_test/orms
@@ -112,3 +112,20 @@ query O
 SELECT 'character varying'::regtype::oid
 ----
 25
+
+statement ok
+CREATE INDEX b_idx ON b(a_id);
+
+# ActiveRecord 4.2.x query for checking if an index exists
+# Relies on OID IN tuple support
+query I
+SELECT COUNT(*)
+FROM pg_class t
+INNER JOIN pg_index d ON t.oid = d.indrelid
+INNER JOIN pg_class i ON d.indexrelid = i.oid
+WHERE i.relkind = 'i'
+AND i.relname = 'b_idx'
+AND t.relname = 'b'
+AND i.relnamespace IN (SELECT oid FROM pg_namespace WHERE nspname = ANY (current_schemas(false)))
+----
+1

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -1428,6 +1428,7 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		makeEvalTupleIn(TypeInterval),
 		makeEvalTupleIn(TypeUUID),
 		makeEvalTupleIn(TypeTuple),
+		makeEvalTupleIn(TypeOid),
 	},
 
 	Like: {


### PR DESCRIPTION
Previously, users couldn't evaluate expressions that checked if an OID
value was inside of an OID tuple. This omission was an accident and is
now corrected.