### PR TITLE
keys: Clean up `MakeRowSentinelKey` and `EnsureSafeSplitKey`

### DIFF
--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -533,15 +533,7 @@ func PresplitRanges(baseCtx context.Context, db client.DB, input []roachpb.Key) 
 
 		// Pick the index such that it's 0 if len(splitPoints) == 1.
 		splitIdx := len(splitPoints) / 2
-		// AdminSplit requires that the key be a valid table key, which means
-		// the last byte is a uvarint indicating how much of the end of the key
-		// needs to be stripped off to get the key's row prefix. The start keys
-		// input to restore don't have this suffix, so make them row sentinels,
-		// which means nothing should be stripped (aka appends 0). See
-		// EnsureSafeSplitKey for more context.
-		splitKey := append([]byte(nil), splitPoints[splitIdx]...)
-		splitKey = keys.MakeRowSentinelKey(splitKey)
-		if err := db.AdminSplit(ctx, splitPoints[splitIdx], splitKey); err != nil {
+		if err := db.AdminSplit(ctx, splitPoints[splitIdx], splitPoints[splitIdx]); err != nil {
 			return err
 		}
 

--- a/pkg/ccl/storageccl/key_rewriter_test.go
+++ b/pkg/ccl/storageccl/key_rewriter_test.go
@@ -12,7 +12,6 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -73,7 +72,7 @@ func TestKeyRewriter(t *testing.T) {
 	}
 
 	t.Run("normal", func(t *testing.T) {
-		key := keys.MakeRowSentinelKey(sqlbase.MakeIndexKeyPrefix(&sqlbase.NamespaceTable, desc.PrimaryIndex.ID))
+		key := sqlbase.MakeIndexKeyPrefix(&sqlbase.NamespaceTable, desc.PrimaryIndex.ID)
 		newKey, ok, err := kr.RewriteKey(key)
 		if err != nil {
 			t.Fatal(err)
@@ -126,7 +125,7 @@ func TestKeyRewriter(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		key := keys.MakeRowSentinelKey(sqlbase.MakeIndexKeyPrefix(&sqlbase.NamespaceTable, desc.PrimaryIndex.ID))
+		key := sqlbase.MakeIndexKeyPrefix(&sqlbase.NamespaceTable, desc.PrimaryIndex.ID)
 		newKey, ok, err := kr.RewriteKey(key)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -402,9 +402,9 @@ func Example_ranges() {
 	// 	0: node-id=1 store-id=1
 	// /System/"tse"-"ranges3" [4]
 	// 	0: node-id=1 store-id=1
-	// "ranges3"-/Table/0 [11]
+	// "ranges3"-/Table/SystemConfigSpan/Start [11]
 	// 	0: node-id=1 store-id=1
-	// /Table/0-/Table/11 [5]
+	// /Table/SystemConfigSpan/Start-/Table/11 [5]
 	// 	0: node-id=1 store-id=1
 	// /Table/11-/Table/12 [6]
 	// 	0: node-id=1 store-id=1

--- a/pkg/cmd/zerosum/main.go
+++ b/pkg/cmd/zerosum/main.go
@@ -221,7 +221,6 @@ func (z *zeroSum) monkey(tableID uint32, d time.Duration) {
 
 		key := keys.MakeTablePrefix(tableID)
 		key = encoding.EncodeVarintAscending(key, int64(zipf.Uint64()))
-		key = keys.MakeRowSentinelKey(key)
 
 		switch r.Intn(2) {
 		case 0:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -464,7 +464,7 @@ func (s SystemConfig) ComputeSplitKey(startKey, endKey roachpb.RKey) roachpb.RKe
 	findSplitKey := func(startID, endID uint32) roachpb.RKey {
 		// endID could be smaller than startID if we don't have user tables.
 		for id := startID; id <= endID; id++ {
-			key := roachpb.RKey(keys.MakeRowSentinelKey(keys.MakeTablePrefix(id)))
+			key := roachpb.RKey(keys.MakeTablePrefix(id))
 			// Skip if this ID matches the provided startKey.
 			if !startKey.Less(key) {
 				continue

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -358,7 +358,7 @@ func TestComputeSplitKeyTableIDs(t *testing.T) {
 		}
 		var expected roachpb.RKey
 		if tc.split != -1 {
-			expected = keys.MakeRowSentinelKey(keys.MakeTablePrefix(uint32(tc.split)))
+			expected = keys.MakeTablePrefix(uint32(tc.split))
 		}
 		if !splitKey.Equal(expected) {
 			t.Errorf("#%d: bad split:\ngot: %v\nexpected: %v", tcNum, splitKey, expected)

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -244,7 +244,8 @@ var (
 
 	// SystemConfigSplitKey is the key to split at immediately prior to the
 	// system config span. NB: Split keys need to be valid column keys.
-	SystemConfigSplitKey = MakeRowSentinelKey(TableDataMin)
+	// TODO(bdarnell): this should be either roachpb.Key or RKey, not []byte.
+	SystemConfigSplitKey = []byte(TableDataMin)
 	// SystemConfigTableDataMax is the end key of system config span.
 	SystemConfigTableDataMax = roachpb.Key(MakeTablePrefix(MaxSystemConfigDescID + 1))
 

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -586,6 +586,7 @@ func MakeFamilyKey(key []byte, famID uint32) []byte {
 }
 
 // MakeRowSentinelKey creates the first key in a sql table row.
+// TODO(bdarnell): should use roachpb.Key or roachpb.RKey, not []byte.
 func MakeRowSentinelKey(key []byte) []byte {
 	return MakeFamilyKey(key, SentinelFamilyID)
 }

--- a/pkg/sql/ambiguous_commit_test.go
+++ b/pkg/sql/ambiguous_commit_test.go
@@ -109,7 +109,7 @@ func TestAmbiguousCommitDueToLeadershipChange(t *testing.T) {
 			}
 
 			// Lookup the lease.
-			tableRangeDesc, err := tc.LookupRange(keys.MakeRowSentinelKey(tableStartKey.Load().([]byte)))
+			tableRangeDesc, err := tc.LookupRange(tableStartKey.Load().([]byte))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -73,8 +72,7 @@ func SplitTable(
 		t.Fatal(err)
 	}
 
-	splitKey := keys.MakeRowSentinelKey(pik)
-	_, rightRange, err := tc.Server(0).SplitRange(splitKey)
+	_, rightRange, err := tc.Server(0).SplitRange(pik)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,8 +128,7 @@ func TestPlanningDuringSplits(t *testing.T) {
 					panic(err)
 				}
 
-				splitKey := keys.MakeRowSentinelKey(pik)
-				if _, _, err := tc.Server(0).SplitRange(splitKey); err != nil {
+				if _, _, err := tc.Server(0).SplitRange(pik); err != nil {
 					panic(err)
 				}
 			}

--- a/pkg/sql/distsqlplan/span_resolver_test.go
+++ b/pkg/sql/distsqlplan/span_resolver_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -183,8 +182,7 @@ func splitRangeAtVal(
 		return roachpb.RangeDescriptor{}, roachpb.RangeDescriptor{}, err
 	}
 
-	startKey := keys.MakeRowSentinelKey(pik)
-	leftRange, rightRange, err := ts.SplitRange(startKey)
+	leftRange, rightRange, err := ts.SplitRange(pik)
 	if err != nil {
 		return roachpb.RangeDescriptor{}, roachpb.RangeDescriptor{},
 			errors.Wrapf(err, "failed to split at row: %d", pk)

--- a/pkg/sql/main_test.go
+++ b/pkg/sql/main_test.go
@@ -155,12 +155,8 @@ func checkEndTransactionTrigger(args storagebase.FilterArgs) *roachpb.Error {
 
 	var hasSystemKey bool
 	for _, span := range req.IntentSpans {
-		keyAddr, err := keys.Addr(span.Key)
-		if err != nil {
-			return roachpb.NewError(err)
-		}
-		if bytes.Compare(keyAddr, keys.SystemConfigSpan.Key) >= 0 &&
-			bytes.Compare(keyAddr, keys.SystemConfigSpan.EndKey) < 0 {
+		if bytes.Compare(span.Key, keys.SystemConfigSpan.Key) >= 0 &&
+			bytes.Compare(span.Key, keys.SystemConfigSpan.EndKey) < 0 {
 			hasSystemKey = true
 			break
 		}

--- a/pkg/sql/split_at.go
+++ b/pkg/sql/split_at.go
@@ -305,7 +305,7 @@ func (n *testingRelocateNode) Next(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	rowKey = keys.MakeRowSentinelKey(rowKey)
+	rowKey = keys.MakeFamilyKey(rowKey, 0)
 
 	rangeDesc, err := lookupRangeDescriptor(ctx, n.p.session.execCfg.DB, rowKey)
 	if err != nil {

--- a/pkg/sql/split_at.go
+++ b/pkg/sql/split_at.go
@@ -47,7 +47,7 @@ func getRowKey(
 	if err != nil {
 		return nil, err
 	}
-	return keys.MakeRowSentinelKey(key), nil
+	return key, nil
 }
 
 // Split executes a KV split.

--- a/pkg/sql/split_at_test.go
+++ b/pkg/sql/split_at_test.go
@@ -23,7 +23,6 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -135,9 +134,9 @@ func TestSplitAt(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			expect := roachpb.Key(keys.MakeRowSentinelKey(rng.StartKey))
+			expect := roachpb.Key(rng.StartKey)
 			if !expect.Equal(key) {
-				t.Fatalf("%s: expected range start %s, got %s", tt.in, pretty, expect)
+				t.Fatalf("%s: expected range start %s, got %s", tt.in, expect, pretty)
 			}
 		}
 	}

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -25,7 +25,6 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -397,8 +396,9 @@ func (rf *RowFetcher) processValueSingle(
 ) (prettyKey string, prettyValue string, err error) {
 	prettyKey = prettyKeyPrefix
 
-	// If this is the sentinel family, a value is not expected, so we're done.
-	if family.ID == keys.SentinelFamilyID {
+	// If this is the row sentinel (in the legacy pre-family format),
+	// a value is not expected, so we're done.
+	if family.ID == 0 {
 		return "", "", nil
 	}
 

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -1350,7 +1350,7 @@ func EncodeSecondaryIndex(
 
 	// Index keys are considered "sentinel" keys in that they do not have a
 	// column ID suffix.
-	entry.Key = keys.MakeRowSentinelKey(entry.Key)
+	entry.Key = keys.MakeFamilyKey(entry.Key, 0)
 
 	var entryValue []byte
 	if secondaryIndex.Unique {

--- a/pkg/sql/table_split_test.go
+++ b/pkg/sql/table_split_test.go
@@ -55,7 +55,7 @@ SELECT tables.id FROM system.namespace tables
 
 	// Wait for new table to split.
 	testutils.SucceedsSoon(t, func() error {
-		desc, err := tc.LookupRange(keys.MakeRowSentinelKey(tableStartKey))
+		desc, err := tc.LookupRange(tableStartKey)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2815,7 +2815,7 @@ func TestReplicaLazyLoad(t *testing.T) {
 	// Split so we can rely on RHS range being quiescent after a restart.
 	// We use UserTableDataMin to avoid having the range activated to
 	// gossip system table data.
-	splitKey := keys.MakeRowSentinelKey(keys.UserTableDataMin)
+	splitKey := keys.UserTableDataMin
 	splitArgs := adminSplitArgs(roachpb.KeyMin, splitKey)
 	if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), splitArgs); err != nil {
 		t.Fatal(err)
@@ -2830,7 +2830,12 @@ func TestReplicaLazyLoad(t *testing.T) {
 		time.Sleep(time.Millisecond)
 	}
 
-	replica := mtc.stores[0].LookupReplica(splitKey, nil)
+	splitKeyAddr, err := keys.Addr(splitKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replica := mtc.stores[0].LookupReplica(splitKeyAddr, nil)
 	if replica == nil {
 		t.Fatalf("lookup replica at key %q returned nil", splitKey)
 	}
@@ -3433,7 +3438,7 @@ func TestInitRaftGroupOnRequest(t *testing.T) {
 	// Split so we can rely on RHS range being quiescent after a restart.
 	// We use UserTableDataMin to avoid having the range activated to
 	// gossip system table data.
-	splitKey := keys.MakeRowSentinelKey(keys.UserTableDataMin)
+	splitKey := keys.UserTableDataMin
 	splitArgs := adminSplitArgs(roachpb.KeyMin, splitKey)
 	if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), splitArgs); err != nil {
 		t.Fatal(err)

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -1528,8 +1528,7 @@ func TestSystemZoneConfigs(t *testing.T) {
 		keys.MakeTablePrefix(keys.SystemRangesID),
 	}
 	for _, key := range splitKeys {
-		splitKey := keys.MakeRowSentinelKey(key)
-		if _, _, err := tc.SplitRange(splitKey); err != nil {
+		if _, _, err := tc.SplitRange(key); err != nil {
 			t.Fatalf("failed to split at key %s: %s", key, err)
 		}
 	}

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -1322,7 +1322,7 @@ func TestRangeInfo(t *testing.T) {
 func TestCampaignOnLazyRaftGroupInitialization(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	t.Skip("this test is flaky on the 5m initial stress due to errant Raft messages initializing the Raft group")
-	splitKey := keys.MakeRowSentinelKey(keys.UserTableDataMin)
+	splitKey := keys.UserTableDataMin
 	testState := struct {
 		syncutil.Mutex
 		blockingCh chan struct{}

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -2221,7 +2221,7 @@ func IsValidSplitKey(key roachpb.Key) bool {
 		return false
 	}
 	for _, span := range keys.NoSplitSpans {
-		if bytes.Compare(key, span.Key) >= 0 && bytes.Compare(key, span.EndKey) < 0 {
+		if bytes.Compare(key, span.Key) > 0 && bytes.Compare(key, span.EndKey) < 0 {
 			return false
 		}
 	}
@@ -2317,9 +2317,8 @@ func MVCCFindSplitKey(
 		return nil, nil
 	}
 
-	// The key is an MVCC (versioned) key, so to avoid corrupting MVCC we only
-	// return the base portion, which is fine to split in front of.
-	return bestSplitKey.Key, nil
+	// The family ID has been removed from this key, making it a valid split point.
+	return keys.EnsureSafeSplitKey(bestSplitKey.Key)
 }
 
 // willOverflow returns true iff adding both inputs would under- or overflow

--- a/pkg/storage/replica_raftstorage_test.go
+++ b/pkg/storage/replica_raftstorage_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -40,7 +39,7 @@ const valSize = 1 << 10 // 1 KiB
 func fillTestRange(rep *Replica, size int64) error {
 	src := rand.New(rand.NewSource(0))
 	for i := int64(0); i < size/int64(keySize+valSize); i++ {
-		key := keys.MakeRowSentinelKey(randutil.RandBytes(src, keySize))
+		key := randutil.RandBytes(src, keySize)
 		val := randutil.RandBytes(src, valSize)
 		pArgs := putArgs(key, val)
 		if _, pErr := client.SendWrappedWith(context.Background(), rep, roachpb.Header{

--- a/pkg/storage/replicate_queue_test.go
+++ b/pkg/storage/replicate_queue_test.go
@@ -60,7 +60,7 @@ func TestReplicateQueueRebalance(t *testing.T) {
 	const newRanges = 5
 	for i := 0; i < newRanges; i++ {
 		tableID := keys.MaxReservedDescID + i + 1
-		splitKey := keys.MakeRowSentinelKey(keys.MakeTablePrefix(uint32(tableID)))
+		splitKey := keys.MakeTablePrefix(uint32(tableID))
 		if _, _, err := tc.SplitRange(splitKey); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/testutils/testcluster/testcluster_test.go
+++ b/pkg/testutils/testcluster/testcluster_test.go
@@ -69,7 +69,7 @@ func TestManualReplication(t *testing.T) {
 	kvDB := tc.Servers[0].DB()
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
 
-	tableStartKey := keys.MakeRowSentinelKey(keys.MakeTablePrefix(uint32(tableDesc.ID)))
+	tableStartKey := keys.MakeTablePrefix(uint32(tableDesc.ID))
 	leftRangeDesc, tableRangeDesc, err := tc.SplitRange(tableStartKey)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Fixes #16344. @bdarnell 