### PR TITLE
sql/parser: Format omits space after unary operators

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -102,7 +102,7 @@ INSERT INTO test VALUES (_, _, _)
 SELECT ROW(_, _, _, _, _) FROM test WHERE _
 SELECT key FROM crdb_internal.node_statement_statistics
 SELECT sin(_)
-SELECT sqrt(- _)                                         !
+SELECT sqrt(-_)                                          !
 SELECT x FROM (VALUES (_, _, _)) AS t (x)
 SELECT x FROM test WHERE y = (_ / z)                     !+
 SELECT x FROM test WHERE y IN (_, _)
@@ -120,7 +120,7 @@ INSERT INTO _ VALUES (_, _, _)
 SELECT ROW(_, _, _, _, _) FROM _ WHERE _
 SELECT _ FROM crdb_internal.node_statement_statistics
 SELECT sin(_)
-SELECT sqrt(- _)
+SELECT sqrt(-_)
 SELECT _ FROM (VALUES (_, _, _)) AS _ (_)
 SELECT _ FROM _ WHERE _ = (_ / _)
 SELECT _ FROM _ WHERE _ IN (_, _)

--- a/pkg/sql/parser/constant_test.go
+++ b/pkg/sql/parser/constant_test.go
@@ -381,7 +381,7 @@ func TestFoldNumericConstants(t *testing.T) {
 		{`-1.2`, `-1.2`},
 		// Unary ops (int only).
 		{`~1`, `-2`},
-		{`~1.2`, `~ 1.2`},
+		{`~1.2`, `~1.2`},
 		// Binary ops.
 		{`1 + 1`, `2`},
 		{`1.2 + 2.3`, `3.5`},

--- a/pkg/sql/parser/expr.go
+++ b/pkg/sql/parser/expr.go
@@ -869,7 +869,6 @@ func (*UnaryExpr) operatorExpr() {}
 // Format implements the NodeFormatter interface.
 func (node *UnaryExpr) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString(node.Operator.String())
-	buf.WriteByte(' ')
 	exprFmtWithParen(buf, f, node.Expr)
 }
 

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -343,8 +343,8 @@ func TestParse(t *testing.T) {
 		{`INSERT INTO a VALUES (1) ON CONFLICT (a) DO UPDATE SET (a, b) = (SELECT 1, 2) RETURNING NOTHING`},
 
 		{`SELECT 1 + 1`},
-		{`SELECT - 1`},
-		{`SELECT + 1`},
+		{`SELECT -1`},
+		{`SELECT +1`},
 		{`SELECT .1`},
 		{`SELECT 1.2e1`},
 		{`SELECT 1.2e+1`},
@@ -744,8 +744,8 @@ func TestParse2(t *testing.T) {
 		{`SELECT a FROM t WHERE a IS UNKNOWN`, `SELECT a FROM t WHERE a IS NULL`},
 		{`SELECT a FROM t WHERE a IS NOT UNKNOWN`, `SELECT a FROM t WHERE a IS NOT NULL`},
 
-		{`SELECT - - 5`, `SELECT - (- 5)`},
-		{`SELECT a FROM t WHERE b = - 2`, `SELECT a FROM t WHERE b = (- 2)`},
+		{`SELECT - - 5`, `SELECT -(-5)`},
+		{`SELECT a FROM t WHERE b = - 2`, `SELECT a FROM t WHERE b = (-2)`},
 		{`SELECT a FROM t WHERE a = b AND a = c`, `SELECT a FROM t WHERE (a = b) AND (a = c)`},
 		{`SELECT a FROM t WHERE a = b OR a = c`, `SELECT a FROM t WHERE (a = b) OR (a = c)`},
 		{`SELECT a FROM t WHERE NOT a = b`, `SELECT a FROM t WHERE NOT (a = b)`},
@@ -760,9 +760,9 @@ func TestParse2(t *testing.T) {
 		{`SELECT a FROM t WHERE a = b / c`, `SELECT a FROM t WHERE a = (b / c)`},
 		{`SELECT a FROM t WHERE a = b % c`, `SELECT a FROM t WHERE a = (b % c)`},
 		{`SELECT a FROM t WHERE a = b || c`, `SELECT a FROM t WHERE a = (b || c)`},
-		{`SELECT a FROM t WHERE a = + b`, `SELECT a FROM t WHERE a = (+ b)`},
-		{`SELECT a FROM t WHERE a = - b`, `SELECT a FROM t WHERE a = (- b)`},
-		{`SELECT a FROM t WHERE a = ~ b`, `SELECT a FROM t WHERE a = (~ b)`},
+		{`SELECT a FROM t WHERE a = + b`, `SELECT a FROM t WHERE a = (+b)`},
+		{`SELECT a FROM t WHERE a = - b`, `SELECT a FROM t WHERE a = (-b)`},
+		{`SELECT a FROM t WHERE a = ~ b`, `SELECT a FROM t WHERE a = (~b)`},
 
 		// Escaped string literals are not always escaped the same because
 		// '''' and e'\'' scan to the same token. It's more convenient to
@@ -840,18 +840,18 @@ func TestParse2(t *testing.T) {
 			`SELECT a FROM t LIMIT 2 * a OFFSET b`},
 		// Double negation. See #1800.
 		{`SELECT *,-/* comment */-5`,
-			`SELECT *, - (- 5)`},
+			`SELECT *, -(-5)`},
 		{"SELECT -\n-5",
-			`SELECT - (- 5)`},
+			`SELECT -(-5)`},
 		{`SELECT -0.-/*test*/-1`,
-			`SELECT (- 0.) - (- 1)`,
+			`SELECT (-0.) - (-1)`,
 		},
 		// See #1948.
 		{`SELECT~~+~++~bd(*)`,
-			`SELECT ~ (~ (+ (~ (+ (+ (~ bd(*)))))))`},
+			`SELECT ~(~(+(~(+(+(~bd(*)))))))`},
 		// See #1957.
 		{`SELECT+y[array[]]`,
-			`SELECT + y[ARRAY[]]`},
+			`SELECT +y[ARRAY[]]`},
 		{`SELECT a FROM t UNION DISTINCT SELECT 1 FROM t`,
 			`SELECT a FROM t UNION SELECT 1 FROM t`},
 		{`SELECT a FROM t EXCEPT DISTINCT SELECT 1 FROM t`,


### PR DESCRIPTION
This is the traditional format, since most people write (e.g.) `-42`
instead of `- 42`, though our proximate motivation is #16226.

The possible danger here is that two consecutive unary operators turn
into another token. With our current grammar, however, that cannot
happen. There are three unary operators: `+`, `-`, and `~`. Comments
start with `--` but `Format` emits parentheses for `- - x`. Expressions
cannot start with `*`, so the operator `~` cannot turn into the
different operator `~*`. The only other use of `+` and `-` is inside
floating-point literals.

The random syntax generator will give assurance over time that this
safety property continues to hold.

Closes #16226.