### PR TITLE
sql: improve ctx hygene in planHook

### DIFF
--- a/pkg/ccl/sqlccl/backup.go
+++ b/pkg/ccl/sqlccl/backup.go
@@ -463,8 +463,8 @@ func Backup(
 }
 
 func backupPlanHook(
-	baseCtx context.Context, stmt parser.Statement, p sql.PlanHookState,
-) (func() ([]parser.Datums, error), sqlbase.ResultColumns, error) {
+	stmt parser.Statement, p sql.PlanHookState,
+) (func(context.Context) ([]parser.Datums, error), sqlbase.ResultColumns, error) {
 	backup, ok := stmt.(*parser.Backup)
 	if !ok {
 		return nil, nil, nil
@@ -496,9 +496,9 @@ func backupPlanHook(
 		{Name: "system_records", Typ: parser.TypeInt},
 		{Name: "bytes", Typ: parser.TypeInt},
 	}
-	fn := func() ([]parser.Datums, error) {
+	fn := func(ctx context.Context) ([]parser.Datums, error) {
 		// TODO(dan): Move this span into sql.
-		ctx, span := tracing.ChildSpan(baseCtx, stmt.StatementTag())
+		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer tracing.FinishSpan(span)
 
 		to, err := toFn()
@@ -569,8 +569,8 @@ func backupPlanHook(
 }
 
 func showBackupPlanHook(
-	baseCtx context.Context, stmt parser.Statement, p sql.PlanHookState,
-) (func() ([]parser.Datums, error), sqlbase.ResultColumns, error) {
+	stmt parser.Statement, p sql.PlanHookState,
+) (func(context.Context) ([]parser.Datums, error), sqlbase.ResultColumns, error) {
 	backup, ok := stmt.(*parser.ShowBackup)
 	if !ok {
 		return nil, nil, nil
@@ -594,9 +594,9 @@ func showBackupPlanHook(
 		{Name: "start_time", Typ: parser.TypeTimestamp},
 		{Name: "end_time", Typ: parser.TypeTimestamp},
 	}
-	fn := func() ([]parser.Datums, error) {
+	fn := func(ctx context.Context) ([]parser.Datums, error) {
 		// TODO(dan): Move this span into sql.
-		ctx, span := tracing.ChildSpan(baseCtx, stmt.StatementTag())
+		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer tracing.FinishSpan(span)
 
 		str, err := toFn()

--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -820,8 +820,8 @@ func Restore(
 }
 
 func restorePlanHook(
-	baseCtx context.Context, stmt parser.Statement, p sql.PlanHookState,
-) (func() ([]parser.Datums, error), sqlbase.ResultColumns, error) {
+	stmt parser.Statement, p sql.PlanHookState,
+) (func(context.Context) ([]parser.Datums, error), sqlbase.ResultColumns, error) {
 	restore, ok := stmt.(*parser.Restore)
 	if !ok {
 		return nil, nil, nil
@@ -848,9 +848,9 @@ func restorePlanHook(
 		{Name: "system_records", Typ: parser.TypeInt},
 		{Name: "bytes", Typ: parser.TypeInt},
 	}
-	fn := func() ([]parser.Datums, error) {
+	fn := func(ctx context.Context) ([]parser.Datums, error) {
 		// TODO(dan): Move this span into sql.
-		ctx, span := tracing.ChildSpan(baseCtx, stmt.StatementTag())
+		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer tracing.FinishSpan(span)
 
 		from, err := fromFn()

--- a/pkg/sql/logictest/main_test.go
+++ b/pkg/sql/logictest/main_test.go
@@ -40,8 +40,8 @@ import (
 // 'planhook'.
 func init() {
 	testingPlanHook := func(
-		ctx context.Context, stmt parser.Statement, state sql.PlanHookState,
-	) (func() ([]parser.Datums, error), sqlbase.ResultColumns, error) {
+		stmt parser.Statement, state sql.PlanHookState,
+	) (func(context.Context) ([]parser.Datums, error), sqlbase.ResultColumns, error) {
 		show, ok := stmt.(*parser.Show)
 		if !ok || show.Name != "planhook" {
 			return nil, nil, nil
@@ -49,7 +49,7 @@ func init() {
 		header := sqlbase.ResultColumns{
 			{Name: "value", Typ: parser.TypeString},
 		}
-		return func() ([]parser.Datums, error) {
+		return func(_ context.Context) ([]parser.Datums, error) {
 			return []parser.Datums{
 				{parser.NewDString(show.Name)},
 			}, nil

--- a/pkg/sql/main_test.go
+++ b/pkg/sql/main_test.go
@@ -202,8 +202,8 @@ func createTestServerParams() (base.TestServerArgs, *CommandFilters) {
 // 'planhook'.
 func init() {
 	testingPlanHook := func(
-		ctx context.Context, stmt parser.Statement, state sql.PlanHookState,
-	) (func() ([]parser.Datums, error), sqlbase.ResultColumns, error) {
+		stmt parser.Statement, state sql.PlanHookState,
+	) (func(context.Context) ([]parser.Datums, error), sqlbase.ResultColumns, error) {
 		show, ok := stmt.(*parser.Show)
 		if !ok || show.Name != "planhook" {
 			return nil, nil, nil
@@ -211,7 +211,7 @@ func init() {
 		header := sqlbase.ResultColumns{
 			{Name: "value", Typ: parser.TypeString},
 		}
-		return func() ([]parser.Datums, error) {
+		return func(_ context.Context) ([]parser.Datums, error) {
 			return []parser.Datums{
 				{parser.NewDString(show.Name)},
 			}, nil

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -239,7 +239,7 @@ func (p *planner) maybePlanHook(ctx context.Context, stmt parser.Statement) (pla
 	// upcoming IR work will provide unique numeric type tags, which will
 	// elegantly solve this.
 	for _, planHook := range planHooks {
-		if fn, header, err := planHook(ctx, stmt, p); err != nil {
+		if fn, header, err := planHook(stmt, p); err != nil {
 			return nil, err
 		} else if fn != nil {
 			return &hookFnNode{f: fn, header: header}, nil


### PR DESCRIPTION
PlanHook was written before planNode (the interface it implements) had
context.Contexts. This commit corrects the context used to be the
execution one instead of the prepare one (which it was saving and using
in the hook function).