### PR TITLE
sql: allow imprecise pgwire type hints

### DIFF
--- a/pkg/acceptance/java_test.go
+++ b/pkg/acceptance/java_test.go
@@ -180,6 +180,30 @@ public class main {
 		if (!returnedUuid.equals(uuid)) {
 			throw new Exception("expected " + uuid + " but got " + returnedUuid);
 		}
+
+		// Check that imprecise placeholder typing works correctly. See issues
+		// #14245 and #14311 for more detail.
+		stmt = conn.prepareStatement("CREATE TABLE t (price decimal(5,2) NOT NULL)");
+		res = stmt.executeUpdate();
+		if (res != 0) {
+		    throw new Exception("unexpected: CREATE TABLE t " + res + " rows changed, expecting 0");
+		}
+
+		stmt = conn.prepareStatement("INSERT INTO test.t VALUES (?)");
+		stmt.setFloat(1, 3.3f);
+		res = stmt.executeUpdate();
+		if (res != 1) {
+		    throw new Exception("unexpected: INSERT INTO t " + res + " rows changed, expecting 0");
+		}
+
+		stmt = conn.prepareStatement("SELECT nspname FROM pg_catalog.pg_namespace WHERE oid=?");
+		stmt.setLong(1, 1782195457);
+		rs = stmt.executeQuery();
+		rs.next();
+		String nspName = rs.getString(1);
+		if (!"pg_catalog".equals(nspName)) {
+		    throw new Exception("unexpected: SELECT can't find pg_catalog database: found " + nspName);
+		}
 	}
 }
 EOF

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -246,7 +246,19 @@ query I
 EXECUTE groupbyhaving(1)
 ----
 
-# Mismatch between expected and hinted types
+# Mismatch between expected and hinted types should prepare, but potentially
+# fail to execute if the cast is not possible.
+statement
+PREPARE wrongTypePossibleCast(float) AS INSERT INTO foo VALUES ($1)
 
-statement error expected \$1 to be of type int, found type float
-PREPARE wrongType(float) AS INSERT INTO foo VALUES ($1)
+statement
+EXECUTE wrongTypePossibleCast(2.3)
+
+statement
+PREPARE wrongTypeImpossibleCast(string) AS INSERT INTO foo VALUES ($1)
+
+statement
+EXECUTE wrongTypeImpossibleCast('3')
+
+statement error could not parse 'crabgas' as type int
+EXECUTE wrongTypeImpossibleCast('crabgas')

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -245,3 +245,8 @@ PREPARE groupbyhaving AS SELECT min(1) FROM foo WHERE a = $1 GROUP BY a HAVING c
 query I
 EXECUTE groupbyhaving(1)
 ----
+
+# Mismatch between expected and hinted types
+
+statement error expected \$1 to be of type int, found type float
+PREPARE wrongType(float) AS INSERT INTO foo VALUES ($1)

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -81,9 +81,12 @@ func TypeCheck(expr Expr, ctx *SemaContext, desired Type) (TypedExpr, error) {
 		panic("the desired type for parser.TypeCheck cannot be nil, use TypeAny instead")
 	}
 
-	expr = replacePlaceholders(expr, ctx)
+	expr, err := replacePlaceholders(expr, ctx)
+	if err != nil {
+		return nil, err
+	}
 
-	expr, err := foldConstantLiterals(expr)
+	expr, err = foldConstantLiterals(expr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/parser/placeholders.go
+++ b/pkg/sql/parser/placeholders.go
@@ -182,7 +182,7 @@ func (*placeholdersVisitor) VisitPost(expr Expr) Expr { return expr }
 // available value for a placeholder, it is left alone. A nil ctx makes
 // this a no-op and is supported for tests only.
 func replacePlaceholders(expr Expr, ctx *SemaContext) Expr {
-	if ctx == nil {
+	if ctx == nil || len(ctx.Placeholders.Values) == 0 {
 		return expr
 	}
 	v := &placeholdersVisitor{placeholders: ctx.Placeholders}

--- a/pkg/sql/parser/placeholders.go
+++ b/pkg/sql/parser/placeholders.go
@@ -32,7 +32,15 @@ type QueryArguments map[string]TypedExpr
 // PlaceholderInfo defines the interface to SQL placeholders.
 type PlaceholderInfo struct {
 	Values QueryArguments
-	Types  PlaceholderTypes
+	// TypeHints contains the initially set type hints for each placeholder if
+	// present, and will be filled in completely by the end of type checking
+	// Hints that were present before type checking will not change, and hints
+	// that were not present before type checking will be set to their
+	// placeholder's inferred type.
+	TypeHints PlaceholderTypes
+	// Types contains the final types set for each placeholder after type
+	// checking.
+	Types PlaceholderTypes
 }
 
 // MakePlaceholderInfo constructs an empty PlaceholderInfo.
@@ -44,6 +52,7 @@ func MakePlaceholderInfo() PlaceholderInfo {
 
 // Clear resets the placeholder info map.
 func (p *PlaceholderInfo) Clear() {
+	p.TypeHints = PlaceholderTypes{}
 	p.Types = PlaceholderTypes{}
 	p.Values = QueryArguments{}
 }
@@ -87,10 +96,13 @@ func (p *PlaceholderInfo) AssertAllAssigned() error {
 	return nil
 }
 
-// Type returns the known type of a placeholder.
+// Type returns the known type of a placeholder. If allowHints is true, will
+// return a type hint if there's no known type yet but there is a type hint.
 // Returns false in the 2nd value if the placeholder is not typed.
-func (p *PlaceholderInfo) Type(name string) (Type, bool) {
+func (p *PlaceholderInfo) Type(name string, allowHints bool) (Type, bool) {
 	if t, ok := p.Types[name]; ok {
+		return t, true
+	} else if t, ok := p.TypeHints[name]; ok {
 		return t, true
 	}
 	return nil, false
@@ -118,25 +130,31 @@ func (p *PlaceholderInfo) SetValue(name string, val Datum) {
 	}
 }
 
-// SetType assignes a known type to a placeholder.
+// SetType assigns a known type to a placeholder.
 // Reports an error if another type was previously assigned.
 func (p *PlaceholderInfo) SetType(name string, typ Type) error {
-	if t, ok := p.Types[name]; ok && !typ.Equivalent(t) {
-		return pgerror.NewErrorf(
-			pgerror.CodeInternalError, "placeholder %s already has type %s, cannot assign %s", name, t, typ)
+	t, ok := p.Types[name]
+	if ok && !typ.Equivalent(t) {
+		return pgerror.NewErrorf(pgerror.CodeDatatypeMismatchError, "placeholder %s already has type %s, cannot assign %s", name, t, typ)
 	}
 	p.Types[name] = typ
+	if _, ok := p.TypeHints[name]; !ok {
+		// If the client didn't give us a type hint, we must communicate our
+		// inferred type to pgwire so it can know how to parse incoming data.
+		p.TypeHints[name] = typ
+	}
 	return nil
 }
 
-// SetTypes resets the type and values in the map and replaces the
-// types map by an alias to src. If src is nil, the map is cleared.
-// The types map is aliased because the invoking code from
+// SetTypeHints resets the type and values in the map and replaces the
+// type hints map by an alias to src. If src is nil, the map is cleared.
+// The type hints map is aliased because the invoking code from
 // pgwire/v3.go for sql.Prepare needs to receive the updated type
 // assignments after Prepare completes.
-func (p *PlaceholderInfo) SetTypes(src PlaceholderTypes) {
+func (p *PlaceholderInfo) SetTypeHints(src PlaceholderTypes) {
 	if src != nil {
-		p.Types = src
+		p.TypeHints = src
+		p.Types = PlaceholderTypes{}
 		p.Values = QueryArguments{}
 	} else {
 		p.Clear()
@@ -149,7 +167,7 @@ func (p *PlaceholderInfo) SetTypes(src PlaceholderTypes) {
 // whether the placeholder's type remains unset in the PlaceholderInfo.
 func (p *PlaceholderInfo) IsUnresolvedPlaceholder(expr Expr) bool {
 	if t, ok := StripParens(expr).(*Placeholder); ok {
-		_, res := p.Types[t.Name]
+		_, res := p.TypeHints[t.Name]
 		return !res
 	}
 	return false
@@ -159,6 +177,7 @@ func (p *PlaceholderInfo) IsUnresolvedPlaceholder(expr Expr) bool {
 // replace placeholders with their supplied values.
 type placeholdersVisitor struct {
 	placeholders PlaceholderInfo
+	err          error
 }
 
 var _ Visitor = &placeholdersVisitor{}
@@ -169,6 +188,25 @@ func (v *placeholdersVisitor) VisitPre(expr Expr) (recurse bool, newNode Expr) {
 		if e, ok := v.placeholders.Value(t.Name); ok {
 			// Placeholder expressions cannot contain other placeholders, so we do
 			// not need to recurse.
+			typ, typed := v.placeholders.Type(t.Name, false)
+			if !typed {
+				// All placeholders should be typed at this point.
+				v.err = pgerror.NewErrorf(pgerror.CodeInternalError, "missing type for placeholder %s", t.Name)
+				return false, e
+			}
+			if !e.ResolvedType().Equivalent(typ) {
+				// This happens when we overrode the placeholder's type during type
+				// checking, since the placeholder's type hint didn't match the desired
+				// type for the placeholder. In this case, we cast the expression to
+				// the desired type.
+				// TODO(jordan): introduce a restriction on what casts are allowed here.
+				colType, err := DatumTypeToColumnType(typ)
+				if err != nil {
+					v.err = err
+					return false, e
+				}
+				return false, &CastExpr{Expr: e, Type: colType}
+			}
 			return false, e
 		}
 	}
@@ -181,12 +219,16 @@ func (*placeholdersVisitor) VisitPost(expr Expr) Expr { return expr }
 // their supplied values in the SemaContext's Placeholders map. If there is no
 // available value for a placeholder, it is left alone. A nil ctx makes
 // this a no-op and is supported for tests only.
-func replacePlaceholders(expr Expr, ctx *SemaContext) Expr {
+func replacePlaceholders(expr Expr, ctx *SemaContext) (Expr, error) {
+	// We don't need to recurse through the input if there are no values to
+	// replace, since the walk above will do no work in that case. This happens
+	// during typechecking during the prepare phase. Missing placeholder values
+	// during execute are detected before this step.
 	if ctx == nil || len(ctx.Placeholders.Values) == 0 {
-		return expr
+		return expr, nil
 	}
 	v := &placeholdersVisitor{placeholders: ctx.Placeholders}
 
 	expr, _ = WalkExpr(v, expr)
-	return expr
+	return expr, v.err
 }

--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -802,6 +802,13 @@ func (expr *Placeholder) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, e
 	// during Execute all placeholders are replaced from the AST before type
 	// checking.
 	if typ, ok := ctx.Placeholders.Type(expr.Name); ok {
+		if !desired.Equivalent(typ) {
+			// This indicates there's a conflict between what the type system thinks
+			// the type for this position should be, and the actual type of the
+			// placeholder. This actual placeholder type could be either a type hint
+			// (from pgwire or from a SQL PREPARE), or the actual value type.
+			return nil, unexpectedTypeError{expr, desired, typ}
+		}
 		expr.typ = typ
 		return expr, nil
 	}

--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -801,13 +801,24 @@ func (expr *Placeholder) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, e
 	// when there are no available values for the placeholders yet, because
 	// during Execute all placeholders are replaced from the AST before type
 	// checking.
-	if typ, ok := ctx.Placeholders.Type(expr.Name); ok {
+	if typ, ok := ctx.Placeholders.Type(expr.Name, true); ok {
 		if !desired.Equivalent(typ) {
 			// This indicates there's a conflict between what the type system thinks
 			// the type for this position should be, and the actual type of the
 			// placeholder. This actual placeholder type could be either a type hint
 			// (from pgwire or from a SQL PREPARE), or the actual value type.
-			return nil, unexpectedTypeError{expr, desired, typ}
+			//
+			// To resolve this situation, we *override* the placeholder type with what
+			// the type system expects. Then, when the value is actually sent to us
+			// later, we cast the input value (whose type is the expected type) to the
+			// desired type here.
+			typ = desired
+		}
+		// We call SetType regardless of the above condition to inform the
+		// placeholder struct that this placeholder is locked to its type and cannot
+		// be overridden again.
+		if err := ctx.Placeholders.SetType(expr.Name, typ); err != nil {
+			return nil, err
 		}
 		expr.typ = typ
 		return expr, nil

--- a/pkg/sql/parser/type_check_test.go
+++ b/pkg/sql/parser/type_check_test.go
@@ -315,7 +315,7 @@ func attemptTypeCheckSameTypedExprs(t *testing.T, idx int, test sameTypedExprsTe
 	}
 	forEachPerm(test.exprs, 0, func(exprs []copyableExpr) {
 		ctx := MakeSemaContext(false)
-		ctx.Placeholders.SetTypes(clonePlaceholderTypes(test.ptypes))
+		ctx.Placeholders.SetTypeHints(clonePlaceholderTypes(test.ptypes))
 		desired := TypeAny
 		if test.desired != nil {
 			desired = test.desired
@@ -444,9 +444,7 @@ func TestTypeCheckSameTypedExprsError(t *testing.T) {
 		// Single type mismatches.
 		{nil, nil, exprs(dint(1), decConst("1.1")), decimalIntMismatchErr},
 		{nil, nil, exprs(dint(1), ddecimal(1)), decimalIntMismatchErr},
-		{mapPTypesInt, nil, exprs(ddecimal(1.1), placeholder("a")), decimalIntMismatchErr},
 		{mapPTypesInt, nil, exprs(decConst("1.1"), placeholder("a")), decimalIntMismatchErr},
-		{mapPTypesIntAndDecimal, nil, exprs(placeholder("b"), placeholder("a")), decimalIntMismatchErr},
 		// Tuple type mismatches.
 		{nil, nil, exprs(tuple(dint(1)), tuple(ddecimal(1))), tupleFloatIntMismatchErr},
 		{nil, nil, exprs(tuple(dint(1)), dint(1), dint(1)), tupleIntMismatchErr},
@@ -456,7 +454,7 @@ func TestTypeCheckSameTypedExprsError(t *testing.T) {
 	}
 	for i, d := range testData {
 		ctx := MakeSemaContext(false)
-		ctx.Placeholders.SetTypes(d.ptypes)
+		ctx.Placeholders.SetTypeHints(d.ptypes)
 		desired := TypeAny
 		if d.desired != nil {
 			desired = d.desired

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -432,7 +432,7 @@ func TestPGPrepareFail(t *testing.T) {
 		"SELECT $1 + $1":                            "pq: could not determine data type of placeholder $1",
 		"SELECT CASE WHEN TRUE THEN $1 END":         "pq: could not determine data type of placeholder $1",
 		"SELECT CASE WHEN TRUE THEN $1 ELSE $2 END": "pq: could not determine data type of placeholder $1",
-		"SELECT $1 > 0 AND NOT $1":                  "pq: incompatible NOT argument type: int",
+		"SELECT $1 > 0 AND NOT $1":                  "pq: placeholder 1 already has type int, cannot assign bool",
 		"CREATE TABLE $1 (id INT)":                  "pq: syntax error at or near \"1\"\nCREATE TABLE $1 (id INT)\n             ^\n",
 		"UPDATE d.t SET s = i + $1":                 "pq: unsupported binary operator: <int> + <placeholder{1}> (desired <string>)",
 		"SELECT $0 > 0":                             "pq: invalid placeholder name: $0",

--- a/pkg/sql/values_test.go
+++ b/pkg/sql/values_test.go
@@ -212,7 +212,7 @@ func TestGolangQueryArgs(t *testing.T) {
 	pinfo := &parser.PlaceholderInfo{}
 	for i, tcase := range testCases {
 		golangFillQueryArguments(pinfo, []interface{}{tcase.value})
-		output, valid := pinfo.Type("1")
+		output, valid := pinfo.Type("1", false)
 		if !valid {
 			t.Errorf("case %d failed: argument was invalid", i)
 			continue


### PR DESCRIPTION

    This commit permits the use of imprecise pgwire or sql type hints by
    recording any mismatch between the client-provided type hint and the
    type-system inferred type, and inserting a runtime cast from the
    placeholder's original type to its inferred type.

    Before this patch, type hints that were sent via pgwire or SQL (e.g. in
    `PREPARE x(int) as ...` the `int` is the type hint) were taken perfectly
    literally. Placeholder type hints were required to match the type
    system's inferred type for that placeholder. This simple behavior
    unfortunately leaves us with compatibility issues with some drivers,
    such as JDBC, which send "imprecise type hints" - type hints that don't
    exactly match the correct type for the placeholder.

    The main motivating example is the following query:

    ```
    PREPARE x(INT) AS SELECT * FROM pg_type WHERE oid=$1
    ```

    In this query, the type hint is `INT` but the inferred type is `OID`,
    since we don't support heterogeneous comparisons between integer and
    oid. Previously, this would not type check - but JDBC expects it to.

    After this patch, if the type hint does not match the inferred type, we
    insert a runtime cast from the original type to the inferred type. This
    produces the query `SELECT * FROM pg_type WHERE oid=$1::oid` for our
    example.

    We accomplish this by separately storing the type hints from the
    inferred types. Now, type hints inform the typing of the placeholder
    during prepare, if present. As soon as a placeholder is typed, the final
    placeholder type is set and cannot be changed. If the type hint was
    missing for that placeholder, it is set to the final placeholder type -
    this is required by pgwire so that the values passed to execute can be
    parsed properly.


Previously #14387.
Resolves #14311.
Resolves #14245.
Resolves #14554.
Resolves #17140.
