### PR TITLE
utilccl: allow cluster-independant license

### DIFF
--- a/pkg/ccl/utilccl/license_check.go
+++ b/pkg/ccl/utilccl/license_check.go
@@ -108,6 +108,9 @@ func checkEnterpriseEnabledAt(cluster uuid.UUID, at time.Time, feature string) e
 }
 
 func (l License) checkCluster(cluster uuid.UUID) error {
+	if l.ClusterID == nil {
+		return nil
+	}
 	for _, c := range l.ClusterID {
 		if cluster == c {
 			return nil


### PR DESCRIPTION
In testing it has proved tedious to regenerate a new license for every recreated testing cluster.

While the licenses we usually hand out are intended to be scoped to specific cluster ID(s),
in some cases, like testing and development, we may want the ability to represent licenses
with no cluster IDs.

The specifics here may change though before 1.1, as we exercise this and further develop
what our license offerings will be -- e.g. some form of "Site License" that would eg. check
a cluster's "site" or whatever.