### PR TITLE
tracing: flush lightstep tracer

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -139,6 +139,10 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		registry: metric.NewRegistry(),
 	}
 
+	stopper.AddCloser(stop.CloserFn(func() {
+		tracing.FlushTracer()
+	}))
+
 	// Attempt to load TLS configs right away, failures are permanent.
 	if certMgr, err := cfg.InitializeNodeTLSConfigs(stopper); err != nil {
 		return nil, err


### PR DESCRIPTION
Call `FlushLigtstepTracer` when a server exits. This is particularly useful in
tests that may exit quickly (before the tracer got a chance to send the traces).

Backup tests are especially sensitive to this because they generate a lot of
spans, and some of the spans have a lot of logs. Also increasing
MaxBufferedSpans from 1000 to 10000 to avoid dropping spans in the client. Note
that the number of dropped spans recently can be seen in LightStep under
"Reporting Status".

This helps but unfortunately still not reliably because of
https://github.com/lightstep/lightstep-tracer-go/issues/89. Hopefully that will
get fixed.

Also fixing an issue when hardcoding a lightstep token.