### PR TITLE
rpc: remove grpc max message size limits

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -91,8 +91,10 @@ func NewServer(ctx *Context) *grpc.Server {
 		// The limiting factor for lowering the max message size is the fact
 		// that a single large kv can be sent over the network in one message.
 		// Our maximum kv size is unlimited, so we need this to be very large.
-		// TODO(peter,tamird): need tests before lowering
-		grpc.MaxMsgSize(math.MaxInt32),
+		//
+		// TODO(peter,tamird): need tests before lowering.
+		grpc.MaxRecvMsgSize(math.MaxInt32),
+		grpc.MaxSendMsgSize(math.MaxInt32),
 		// Adjust the stream and connection window sizes. The gRPC defaults are too
 		// low for high latency connections.
 		grpc.InitialWindowSize(initialWindowSize),
@@ -273,6 +275,15 @@ func (ctx *Context) GRPCDial(target string, opts ...grpc.DialOption) (*grpc.Clie
 
 		var dialOpts []grpc.DialOption
 		dialOpts = append(dialOpts, dialOpt)
+		// The limiting factor for lowering the max message size is the fact
+		// that a single large kv can be sent over the network in one message.
+		// Our maximum kv size is unlimited, so we need this to be very large.
+		//
+		// TODO(peter,tamird): need tests before lowering.
+		dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(math.MaxInt32),
+			grpc.MaxCallSendMsgSize(math.MaxInt32),
+		))
 		dialOpts = append(dialOpts, grpc.WithBackoffMaxDelay(maxBackoff))
 		dialOpts = append(dialOpts, grpc.WithDecompressor(snappyDecompressor{}))
 		// Compression is enabled separately from decompression to allow staged


### PR DESCRIPTION
This fixes sql.BenchmarkWideTable which previously failed with:

	--- FAIL: BenchmarkWideTable/MultinodeCockroach/count=10/bigColumnBytes=1000000
		bench_test.go:879: pq: result is ambiguous (error=rpc error: code = ResourceExhausted desc = grpc: trying to send message larger than max (4596569 vs. 4194304) pending=0)

Seems like we're gonna want some chunking here sooner than later.