### PR TITLE
engineccl: only emit tombstones in incremental export

### DIFF
--- a/pkg/ccl/storageccl/engineccl/mvcc.go
+++ b/pkg/ccl/storageccl/engineccl/mvcc.go
@@ -162,6 +162,12 @@ func (i *MVCCIncrementalIterator) Next() {
 			continue
 		}
 
+		// Skip tombstone (len=0) records when startTime is zero (non-incremental).
+		if (i.startTime == hlc.Timestamp{}) && len(i.iter.UnsafeValue()) == 0 {
+			i.iter.NextKey()
+			continue
+		}
+
 		i.nextkey = true
 		break
 	}

--- a/pkg/ccl/storageccl/engineccl/mvcc_test.go
+++ b/pkg/ccl/storageccl/engineccl/mvcc_test.go
@@ -151,7 +151,8 @@ func runMVCCIterateIncremental(t *testing.T) {
 		t.Fatal(err)
 	}
 	mustFlush()
-	t.Run("del", assertEqualKVs(e, keyMin, keyMax, ts0, tsMax, kvs(kv1_3Deleted, kv2_2_2)))
+	t.Run("del", assertEqualKVs(e, keyMin, keyMax, ts1, tsMax, kvs(kv1_3Deleted, kv2_2_2)))
+	t.Run("no-tombstone", assertEqualKVs(e, keyMin, keyMax, hlc.Timestamp{}, tsMax, kvs(kv2_2_2)))
 
 	// Exercise intent handling.
 	txn1ID := uuid.MakeV4()

--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -151,11 +151,8 @@ func evalExport(
 			log.Infof(ctx, "Export %s %s", iter.UnsafeKey(), v.PrettyPrint())
 		}
 
-		// Pass only non-tombstone KVs to the row counter.
-		if len(iter.UnsafeValue()) != 0 {
-			if err := rows.count(iter.UnsafeKey().Key); err != nil {
-				return storage.EvalResult{}, errors.Wrapf(err, "decoding %s", iter.UnsafeKey())
-			}
+		if err := rows.count(iter.UnsafeKey().Key); err != nil {
+			return storage.EvalResult{}, errors.Wrapf(err, "decoding %s", iter.UnsafeKey())
 		}
 		if err := sst.Add(engine.MVCCKeyValue{Key: iter.UnsafeKey(), Value: iter.UnsafeValue()}); err != nil {
 			return storage.EvalResult{}, errors.Wrapf(err, "adding key %s", iter.UnsafeKey())

--- a/pkg/ccl/storageccl/export_test.go
+++ b/pkg/ccl/storageccl/export_test.go
@@ -120,7 +120,7 @@ func TestExport(t *testing.T) {
 	if expected := 2; len(paths5) != expected {
 		t.Fatalf("expected %d files in export got %d", expected, len(paths5))
 	}
-	if expected := 3; len(kvs5) != expected {
+	if expected := 2; len(kvs5) != expected {
 		t.Fatalf("expected %d kvs in export got %d", expected, len(kvs5))
 	}
 }


### PR DESCRIPTION
while the import correctly handles them either way, they are just dead weight in non-incrmental export.
eliding them should make backups smaller and faster.

Semantics for row counts on incremental backups are now number of rows changed, which makes sense.