### PR TITLE
storage: Add test for setting zone configs on system ranges

### DIFF
--- a/pkg/storage/replica_gc_queue.go
+++ b/pkg/storage/replica_gc_queue.go
@@ -123,6 +123,10 @@ func (rgcq *replicaGCQueue) shouldQueue(
 		return false, 0
 	}
 
+	if _, currentMember := repl.Desc().GetReplicaDescriptor(repl.store.StoreID()); !currentMember {
+		return true, replicaGCPriorityRemoved
+	}
+
 	lastActivity := hlc.Timestamp{
 		WallTime: repl.store.startedAt,
 	}


### PR DESCRIPTION
**storage: GC replicas that aren't members of their own range descriptor**

Fixes #16691

**storage: Add test for setting zone configs on system ranges**

This also stresses our replication/replicaGC logic pretty hard, as a
side benefit. It shouldn't be run as part of testshort since it takes
nearly 2 seconds in a typical run.

Fixes #14807