### PR TITLE
Revert "storage: Add fatal log to help understand txns in lease request errors"

### DIFF
--- a/pkg/storage/replica_range_lease.go
+++ b/pkg/storage/replica_range_lease.go
@@ -213,11 +213,6 @@ func (p *pendingLeaseRequest) requestLeaseAsync(
 				ba.RangeID = repl.RangeID
 				ba.Add(leaseReq)
 				_, pErr = repl.Send(ctx, ba)
-				// TODO(a-robinson): Remove this check after it's gotten some mileage in
-				// on test clusters or we gain an understanding of #10940.
-				if txn := pErr.GetTxn(); txn != nil {
-					log.Fatalf(ctx, "unexpected non-nil transaction %v in error from LeaseRequest %+v: %+v", txn, leaseReq, pErr)
-				}
 			}
 			// We reset our state below regardless of whether we've gotten an error or
 			// not, but note that an error is ambiguous - there's no guarantee that the


### PR DESCRIPTION
This reverts commit 966673316177a045aa2aed82f4afa9cd40ab7225.

Closes #10940