### PR TITLE
storage: wait long enough in resolveIntents

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -3981,7 +3981,8 @@ func TestEndTransactionDirectGCFailure(t *testing.T) {
 				atomic.AddInt64(&count, 1)
 				return roachpb.NewErrorWithTxn(errors.Errorf("boom"), filterArgs.Hdr.Txn)
 			} else if filterArgs.Req.Method() == roachpb.GC {
-				t.Fatalf("unexpected GCRequest: %+v", filterArgs.Req)
+				// Can't fatal since we're on a goroutine. This'll do it.
+				t.Error(errors.Errorf("unexpected GCRequest: %+v", filterArgs.Req))
 			}
 			return nil
 		}


### PR DESCRIPTION
The previous code would release the WaitGroup before passing the error to
the channel, which means that the caller would be very likely to never
receive it. Luckily, this was caught in #16684 and is fixed in this commit.
The bug was introduced in #16632.

`make stressrace PKG=./pkg/storage TESTS=TestEndTransactionDirectGCFailure`
would fail within the first 30 iters quickly before this change. Passes
now.

Fixes #16684.