### PR TITLE
key: pretty-print SystemConfigSpan key

### DIFF
--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -429,6 +429,9 @@ func print(key roachpb.Key) string {
 }
 
 func decodeKeyPrint(key roachpb.Key) string {
+	if key.Equal(SystemConfigSpan.Key) {
+		return "/SystemConfigSpan/Start"
+	}
 	return encoding.PrettyPrintValue(key, "/")
 }
 

--- a/pkg/keys/printer_test.go
+++ b/pkg/keys/printer_test.go
@@ -89,6 +89,7 @@ func TestPrettyPrint(t *testing.T) {
 		{RangeMetaKey(roachpb.RKey(makeKey(Meta2Prefix, roachpb.Key("foo")))), `/Meta1/"foo"`},
 
 		// table
+		{SystemConfigSpan.Key, "/Table/SystemConfigSpan/Start"},
 		{UserTableDataMin, "/Table/50"},
 		{MakeTablePrefix(111), "/Table/111"},
 		{makeKey(MakeTablePrefix(42), roachpb.RKey("foo")), `/Table/42/"foo"`},

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -62,7 +62,7 @@ SELECT span, operation, message FROM [SHOW SESSION KV TRACE] WHERE message NOT L
 (1,0)  sql txn implicit  querying next range at /Table/3/1/1/2/1
 (1,0)  sql txn implicit  r1: sending batch 1 Get to (n1,s1):1
 (1,0)  sql txn implicit  r1: sending batch 5 CPut to (n1,s1):1
-(1,0)  sql txn implicit  querying next range at /Table/0/0
+(1,0)  sql txn implicit  querying next range at /Table/SystemConfigSpan/Start
 (1,0)  sql txn implicit  r1: sending batch 1 EndTxn to (n1,s1):1
 
 
@@ -107,7 +107,7 @@ SELECT span, operation, regexp_replace(regexp_replace(message, 'mutationJobs:<[^
 (0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
 (0,1)  starting plan  querying next range at /Table/3/1/1/2/1
 (0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/0/0
+(0,1)  starting plan  querying next range at /Table/SystemConfigSpan/Start
 (0,1)  starting plan  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
 (0,1)  starting plan  Put /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:1 up_version:true modification_time:<wall_time:... logical:0 > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 > interleave:<> > next_index_id:3 privileges:<users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 > interleave:<> > state:DELETE_ONLY direction:ADD mutation_id:1 resume_spans:<key:"\274\211" end_key:"\274\212" > > next_mutation_id:2 format_version:InterleavedFormatVersion state:PUBLIC view_query:"" mutationJobs:<...> >
 (0,1)  starting plan  querying next range at /Table/3/1/52/2/1
@@ -236,7 +236,7 @@ SELECT span, operation, regexp_replace(message, '\d\d\d\d\d+', '...PK...') as me
 (0,1)  starting plan  CPut /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/2
 (0,1)  starting plan  fetched: /kv/primary/2/v -> /3
 (0,1)  starting plan  CPut /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/2/1:2:Int/3
-(0,1)  starting plan  querying next range at /Table/0/0
+(0,1)  starting plan  querying next range at /Table/SystemConfigSpan/Start
 (0,1)  starting plan  r1: sending batch 2 CPut, 1 EndTxn to (n1,s1):1
 
 query TTT
@@ -268,7 +268,7 @@ query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR DROP TABLE t.kv2] WHERE message NOT LIKE '%Z/%'
 ----
 (0,1)  starting plan  Put /Table/3/1/53/2/1 -> table:<name:"kv2" id:53 parent_id:51 version:1 up_version:true modification_time:<wall_time:0 logical:0 > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 > interleave:<> > next_index_id:2 privileges:<users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:InterleavedFormatVersion state:DROP view_query:"" >
-(0,1)  starting plan  querying next range at /Table/0/0
+(0,1)  starting plan  querying next range at /Table/SystemConfigSpan/Start
 (0,1)  starting plan  r1: sending batch 1 Put, 1 BeginTxn to (n1,s1):1
 (0,1)  starting plan  querying next range at /Table/2/1/0/"system"/3/1
 (0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
@@ -324,7 +324,7 @@ SELECT span, operation, regexp_replace(regexp_replace(message, 'mutationJobs:<[^
 (0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
 (0,1)  starting plan  querying next range at /Table/3/1/1/2/1
 (0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/0/0
+(0,1)  starting plan  querying next range at /Table/SystemConfigSpan/Start
 (0,1)  starting plan  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
 (0,1)  starting plan  Put /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:4 up_version:true modification_time:<wall_time:... logical:0 > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 > interleave:<> > next_index_id:3 privileges:<users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 > interleave:<> > state:DELETE_AND_WRITE_ONLY direction:DROP mutation_id:2 resume_spans:<key:"\274\211" end_key:"\274\212" > > next_mutation_id:3 format_version:InterleavedFormatVersion state:PUBLIC view_query:"" mutationJobs:<...> >
 (0,1)  starting plan  querying next range at /Table/3/1/52/2/1
@@ -346,7 +346,7 @@ SELECT span, operation, regexp_replace(regexp_replace(message, 'mutationJobs:<[^
   FROM [SHOW KV TRACE FOR DROP TABLE t.kv] WHERE message NOT LIKE '%Z/%'
 ----
 (0,1)  starting plan  Put /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:7 up_version:true modification_time:<wall_time:... logical:0 > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 > interleave:<> > next_index_id:3 privileges:<users:<user:"root" privileges:2 > > next_mutation_id:3 format_version:InterleavedFormatVersion state:DROP view_query:"" >
-(0,1)  starting plan  querying next range at /Table/0/0
+(0,1)  starting plan  querying next range at /Table/SystemConfigSpan/Start
 (0,1)  starting plan  r1: sending batch 1 Put, 1 BeginTxn to (n1,s1):1
 (0,1)  starting plan  querying next range at /Table/2/1/0/"system"/3/1
 (0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1


### PR DESCRIPTION
The SystemConfigSpan is a span of the key space that comprises different
system tables that are gossiped.  It's start key is important because it
is used to "anchor" DDL transaction and so it shows up in various place.
That key used to be printed as /Table/0/0, which was very confusing
(there is no table 0 and, even if it were, this key does not refer to a
particular table). Now it's printed as /Table/SystemConfigSpan/Start.