### PR TITLE
sql: wrap session trace messages at 80 chars

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -475,7 +475,8 @@ CREATE TABLE crdb_internal.session_trace(
                                    -- the trace has been collected.
   OPERATION STRING NULL,           -- The span's operation. Set only on
                                    -- the first (dummy) message in a span.
-  MESSAGE STRING NOT NULL          -- The logged message.
+  CONTEXT STRING,                  -- The context of the logged message, if any.
+  MESSAGE STRING NOT NULL          -- The logged message without its context.
 );
 `,
 	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -60,7 +60,7 @@ EXPLAIN (METADATA) SHOW TRACE FOR SELECT 1
 2  render                               ("timestamp", "timestamp", message, context, operation, span)
 3  window                               ("timestamp", message, context, operation, span)
 4  render                               ("timestamp", message, context, operation, span, txn_idx, span_idx, message_idx)
-5  show trace for                       (txn_idx, span_idx, message_idx, "timestamp", duration, operation, message)
+5  show trace for                       (txn_idx, span_idx, message_idx, "timestamp", duration, operation, context, message)
 6  render                               ("1")                                                                             ="1"
 7  nullrow                              ()
 

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -582,8 +582,8 @@ SELECT timestamp,
        operation,
        span
   FROM (SELECT timestamp,
-               regexp_replace(message, e'^.*\\[[^]]*\\] ', '') AS message,
-               regexp_extract(message, e'^.*\\[[^]]*\\]') AS context,
+               message,
+               context,
                first_value(operation) OVER (PARTITION BY txn_idx, span_idx ORDER BY message_idx) as operation,
                (txn_idx, span_idx) AS span
           FROM crdb_internal.session_trace)


### PR DESCRIPTION
Looking at a session trace with `SHOW SESSION TRACE` can be difficult
because the log messages can be very long and cause the output table to
display in an ugly way unless one's terminal window is very wide.

Now, the log messages are wrapped at 80 characters to prevent this
issue.

Additionally, the context field of a log message is now represented in
its own column in `crdb_internal.session_trace`. This simplifies the
query that `SHOW [SESSION] TRACE` has to run, and makes the
implementation of the wrapping a little bit easier.