### PR TITLE
cli/sql: report the cluster ID and server version upon new connections

### DIFF
--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -21,6 +21,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 )
 
 // const char* compilerVersion() {
@@ -54,6 +56,14 @@ var (
 // IsRelease returns true if the binary was produced by a "release" build.
 func IsRelease() bool {
 	return strings.HasPrefix(typ, "release")
+}
+
+func init() {
+	// Allow tests to override the tag.
+	if tagOverride := envutil.EnvOrDefaultString(
+		"COCKROACH_TESTING_VERSION_TAG", ""); tagOverride != "" {
+		tag = tagOverride
+	}
 }
 
 // Short returns a pretty printed build and version summary.

--- a/pkg/cli/interactive_tests/test_version_reporting.tcl
+++ b/pkg/cli/interactive_tests/test_version_reporting.tcl
@@ -1,0 +1,79 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_server $argv
+
+spawn $argv sql
+
+start_test "Check that the client starts with the welcome message."
+eexpect "# Welcome to the cockroach SQL interface."
+end_test
+
+start_test "Check that the client reports the server version, and correctly detects the version is the same as the client."
+eexpect "# Server version: CockroachDB"
+eexpect "(same version as client)"
+end_test
+
+start_test "Check that cluster ID is reported as well."
+eexpect "# Cluster ID: "
+end_test
+
+start_test "Check that the help part of the introductory message is at the end."
+eexpect "for a brief introduction"
+end_test
+
+eexpect root@
+
+start_test "Check that a reconnect without version change is quiet."
+# We need to force since the open connection may prevent a quick
+# graceful shutdown.
+force_stop_server $argv
+start_server $argv
+send "select 1;\r"
+eexpect "driver: bad connection"
+# Check that the prompt immediately succeeds the error message
+eexpect "connection lost; opening new connection: all session settings will be lost"
+expect {
+    "\r\n# " {
+	report "unexpected server message"
+	exit 1
+    }
+    "root@" {}
+}
+
+# Check the reconnect did succeed - this also resets the connection state to good.
+send "select 1;\r"
+eexpect "1 row"
+eexpect root@
+end_test
+
+start_test "Check that the client picks up a new cluster ID."
+force_stop_server $argv
+system "mv logs/db logs/db-bak"
+start_server $argv
+send "select 1;\r"
+eexpect "opening new connection"
+eexpect "error"
+eexpect "the cluster ID has changed!"
+eexpect "Previous ID:"
+eexpect "New ID:"
+eexpect root@
+end_test
+
+start_test "Check that the client picks up a new server version."
+force_stop_server $argv
+set env(COCKROACH_TESTING_VERSION_TAG) "fakever"
+start_server $argv
+send "select 1;\r"
+eexpect "opening new connection"
+eexpect "# Client version: CockroachDB"
+eexpect "# Server version: CockroachDB"
+eexpect "fakever"
+eexpect root@
+end_test
+
+interrupt
+eexpect eof
+
+stop_server $argv

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -43,6 +43,7 @@ const (
 	infoMessage = `# Welcome to the cockroach SQL interface.
 # All statements must be terminated by a semicolon.
 # To exit: CTRL + D.
+#
 `
 )
 
@@ -169,7 +170,8 @@ const (
 // printCliHelp prints a short inline help about the CLI.
 func printCliHelp() {
 	fmt.Print(`You are using 'cockroach sql', CockroachDB's lightweight SQL client.
-Type: \q to exit (Ctrl+C/Ctrl+D also supported)
+Type:
+  \q to exit        (Ctrl+C/Ctrl+D also supported)
   \! CMD            run an external command and print its results on standard output.
   \| CMD            run an external command and run its output as SQL statements.
   \set [NAME]       set a client-side flag or (without argument) print the current settings.
@@ -522,8 +524,7 @@ func (c *cliState) doStart(nextState cliStateEnum) cliStateEnum {
 			c.ins.SetConfig(cfg)
 		}
 
-		// The user only gets to see the info screen on interactive session.
-		fmt.Print(infoMessage)
+		fmt.Println("#\n# Enter \\? for a brief introduction.\n#")
 
 		c.checkSyntax = true
 		c.normalizeHistory = true
@@ -953,6 +954,11 @@ func runStatements(conn *sqlConn, stmts []string, displayFormat tableDisplayForm
 func runTerm(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		return usageAndError(cmd)
+	}
+
+	if isInteractive && len(sqlCtx.execStmts) == 0 {
+		// The user only gets to see the info screen on interactive sessions.
+		fmt.Print(infoMessage)
 	}
 
 	conn, err := getPasswordAndMakeSQLClient()

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"reflect"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -29,8 +30,10 @@ import (
 	"unicode/utf8"
 
 	"github.com/lib/pq"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -50,6 +53,12 @@ type sqlConn struct {
 	// dbName is the last known current database, to be reconfigured in
 	// case of automatic reconnects.
 	dbName string
+
+	// clusterID and serverBuildInfo are the last known corresponding
+	// values from the server, used to report any changes upon
+	// (re)connects.
+	clusterID       string
+	serverBuildInfo build.Info
 }
 
 func (c *sqlConn) ensureConn() error {
@@ -69,9 +78,131 @@ func (c *sqlConn) ensureConn() error {
 				fmt.Fprintf(stderr, "unable to restore current database: %v\n", err)
 			}
 		}
-		c.reconnecting = false
 		c.conn = conn.(sqlConnI)
+		if err := c.checkServerMetadata(); err != nil {
+			c.Close()
+			return err
+		}
+		c.reconnecting = false
 	}
+	return nil
+}
+
+// clientVersionIdent identifies the client version.
+var clientVersionIdent = computeVersionFromInfo(build.GetInfo())
+
+// clientVersion describes the client version.
+var clientVersion = build.GetInfo().Short()
+
+// computeVersionFromInfo returns a value that identifies a particular
+// version number.
+// We use both Revision and tag here because:
+// - Revision is insufficient to determine whether the source code was modified
+//   since the last commit, whereas tag contains `-dirty` in that case;
+// - Tag only has few bits from the revision, and will thus
+//   become more sensitive to silent version mismatches over time.
+func computeVersionFromInfo(info build.Info) string {
+	return info.Revision + info.Tag
+}
+
+var unknownServerBuild = build.Info{
+	GoVersion:    "?",
+	Tag:          "?",
+	Time:         "?",
+	Revision:     "?",
+	CgoCompiler:  "?",
+	Platform:     "?",
+	Distribution: "?",
+	Type:         "?",
+	Dependencies: nil,
+}
+
+// checkServerMetadata reports the server version and cluster ID
+// upon the initial connection or if either has changed since
+// the last connection, based on the last known values in the sqlConn
+// struct.
+func (c *sqlConn) checkServerMetadata() error {
+	if !isInteractive {
+		// Version reporting is just noise in non-interactive sessions.
+		return nil
+	}
+
+	newServerBuildInfo := unknownServerBuild
+	newClusterID := ""
+
+	// Retrieve the node ID and server build info.
+	rows, err := c.Query("SELECT * FROM crdb_internal.node_build_info", nil)
+	if err == driver.ErrBadConn {
+		return err
+	}
+	if err != nil {
+		fmt.Fprintln(stderr, "unable to retrieve the server's version")
+	} else {
+		defer func() { _ = rows.Close() }()
+
+		// Read the node_build_info table as an array of strings.
+		rowVals, err := getAllRowStrings(rows, true /* showMoreChars */)
+		if err != nil || len(rowVals) == 0 || len(rowVals[0]) != 3 {
+			fmt.Fprintln(stderr, "error while retrieving the server's version")
+			// It is not an error that the server version cannot be retrieved.
+			return nil
+		}
+
+		// Extract the build.Info fields from the query results.
+		var zeroValue reflect.Value
+		infoStruct := reflect.ValueOf(&newServerBuildInfo).Elem()
+		for _, row := range rowVals {
+			if vField := infoStruct.FieldByName(row[1]); vField != zeroValue {
+				vField.Set(reflect.ValueOf(row[2]))
+			}
+		}
+	}
+
+	// Report the server version only if it the revision has been
+	// fetched successfully, and the revision has changed since the last
+	// connection.
+	if newServerBuildInfo != c.serverBuildInfo && newServerBuildInfo.Revision != "?" {
+		c.serverBuildInfo = newServerBuildInfo
+
+		serverVersionIdent := computeVersionFromInfo(newServerBuildInfo)
+		isSame := ""
+		// We compare the version numbers only using revision+tag, whereas
+		// we *display* the version using the full version string
+		// (computed by Short() below).
+		// This is because we don't care if they're different
+		// platforms/build tools/timestamps. The important bit exposed by
+		// a version mismatch is the wire protocol and SQL dialect.
+		if serverVersionIdent == clientVersionIdent {
+			isSame = " (same version as client)"
+		}
+
+		if isSame == "" {
+			fmt.Println("# Client version:", clientVersion)
+		}
+		fmt.Printf("# Server version: %s%s\n", newServerBuildInfo.Short(), isSame)
+	}
+
+	// Retrieve the cluster ID.
+	clusterVal, _ := c.getServerValue("cluster ID", "SELECT crdb_internal.cluster_id()::STRING")
+	if s, ok := clusterVal.(string); ok {
+		newClusterID = s
+	}
+
+	// Report the cluster ID only if it it could be fetched
+	// successfully, and it has changed since the last connection.
+	if newClusterID != c.clusterID && newClusterID != "" {
+		defer func() { c.clusterID = newClusterID }()
+
+		// As a special case, we complain loudly if the cluster ID
+		// actually changes. This is sign of a potentially very bad load
+		// balancer configuration.
+		if c.clusterID != "" {
+			return errors.Errorf("the cluster ID has changed!\nPrevious ID: %s\nNew ID: %s",
+				c.clusterID, newClusterID)
+		}
+		fmt.Println("# Cluster ID:", newClusterID)
+	}
+
 	return nil
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -950,6 +950,7 @@ default_transaction_isolation  SERIALIZABLE  NULL      NULL        NULL        s
 distsql                        off           NULL      NULL        NULL        string
 extra_float_digits                           NULL      NULL        NULL        string
 max_index_keys                 32            NULL      NULL        NULL        string
+node_id                        1             NULL      NULL        NULL        string
 search_path                    pg_catalog    NULL      NULL        NULL        string
 server_version                 9.5.0         NULL      NULL        NULL        string
 session_user                   root          NULL      NULL        NULL        string
@@ -973,6 +974,7 @@ default_transaction_isolation  SERIALIZABLE  NULL  user     NULL      SERIALIZAB
 distsql                        off           NULL  user     NULL      off           off
 extra_float_digits                           NULL  user     NULL
 max_index_keys                 32            NULL  user     NULL      32            32
+node_id                        1             NULL  user     NULL      1             1
 search_path                    pg_catalog    NULL  user     NULL      pg_catalog    pg_catalog
 server_version                 9.5.0         NULL  user     NULL      9.5.0         9.5.0
 session_user                   root          NULL  user     NULL      root          root
@@ -996,6 +998,7 @@ default_transaction_isolation  NULL    NULL     NULL     NULL        NULL
 distsql                        NULL    NULL     NULL     NULL        NULL
 extra_float_digits             NULL    NULL     NULL     NULL        NULL
 max_index_keys                 NULL    NULL     NULL     NULL        NULL
+node_id                        NULL    NULL     NULL     NULL        NULL
 search_path                    NULL    NULL     NULL     NULL        NULL
 server_version                 NULL    NULL     NULL     NULL        NULL
 session_user                   NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -85,6 +85,7 @@ default_transaction_isolation  SERIALIZABLE
 distsql                        off
 extra_float_digits
 max_index_keys                 32
+node_id                        1
 search_path                    pg_catalog
 server_version                 9.5.0
 session_user                   root
@@ -177,6 +178,9 @@ server_version
 # Test read-only variables
 statement error variable "max_index_keys" cannot be changed
 SET max_index_keys = 32
+
+statement error variable "node_id" cannot be changed
+SET node_id = 123
 
 query TT
 SELECT name, value FROM system.settings WHERE name = 'testing.str'

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -29,6 +29,7 @@ default_transaction_isolation  SERIALIZABLE
 distsql                        off
 extra_float_digits
 max_index_keys                 32
+node_id                        1
 search_path                    pg_catalog
 server_version                 9.5.0
 session_user                   root

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -226,6 +226,10 @@ var varGen = map[string]sessionVar{
 		Get: func(*planner) string { return "32" },
 	},
 
+	`node_id`: {
+		Get: func(p *planner) string { return fmt.Sprintf("%d", p.LeaseMgr().nodeID.Get()) },
+	},
+
 	`search_path`: {
 		Set: func(_ context.Context, p *planner, values []parser.TypedExpr) error {
 			// https://www.postgresql.org/docs/9.6/static/runtime-config-client.html

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -59,7 +59,58 @@ var nopVar = sessionVar{
 	Reset: func(*planner) error { return nil },
 }
 
+// varGen is the main definition array for all session variables.
+// Note to maintainers: try to keep this sorted in the source code.
 var varGen = map[string]sessionVar{
+	`application_name`: {
+		Set: func(_ context.Context, p *planner, values []parser.TypedExpr) error {
+			// Set by clients to improve query logging.
+			// See https://www.postgresql.org/docs/9.6/static/runtime-config-logging.html#GUC-APPLICATION-NAME
+			s, err := p.getStringVal(`application_name`, values)
+			if err != nil {
+				return err
+			}
+			p.session.resetApplicationName(s)
+
+			return nil
+		},
+		Get: func(p *planner) string {
+			p.session.mu.RLock()
+			defer p.session.mu.RUnlock()
+			return p.session.mu.ApplicationName
+		},
+		Reset: func(p *planner) error {
+			p.session.resetApplicationName(p.session.defaults.applicationName)
+			return nil
+		},
+	},
+
+	// Supported for PG compatibility only.
+	// Controls returned message verbosity. We don't support this.
+	// See https://www.postgresql.org/docs/9.6/static/runtime-config-compatible.html
+	`client_min_messages`: nopVar,
+
+	// Supported for PG compatibility only.
+	// See https://www.postgresql.org/docs/9.6/static/multibyte.html
+	// Also aliased to SET NAMES.
+	`client_encoding`: {
+		Get: func(*planner) string {
+			return "UTF8"
+		},
+		Set: func(_ context.Context, p *planner, values []parser.TypedExpr) error {
+			s, err := p.getStringVal(`client_encoding`, values)
+			if err != nil {
+				return err
+			}
+			upper := strings.ToUpper(s)
+			if upper != "UTF8" && upper != "UNICODE" {
+				return fmt.Errorf("non-UTF8 encoding %s not supported", s)
+			}
+			return nil
+		},
+		Reset: func(*planner) error { return nil },
+	},
+
 	`database`: {
 		Set: func(ctx context.Context, p *planner, values []parser.TypedExpr) error {
 			dbName, err := p.getStringVal(`database`, values)
@@ -84,6 +135,25 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 	},
+
+	`datestyle`: {
+		// Supported for PG compatibility only.
+		Get: func(*planner) string {
+			return "ISO"
+		},
+		Set: func(_ context.Context, p *planner, values []parser.TypedExpr) error {
+			s, err := p.getStringVal(`datestyle`, values)
+			if err != nil {
+				return err
+			}
+			if strings.ToUpper(s) != "ISO" {
+				return fmt.Errorf("non-ISO date style %s not supported", s)
+			}
+			return nil
+		},
+		Reset: func(*planner) error { return nil },
+	},
+
 	`default_transaction_isolation`: {
 		Set: func(_ context.Context, p *planner, values []parser.TypedExpr) error {
 			// It's unfortunate that clients want us to support both SET
@@ -113,6 +183,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 	},
+
 	`distsql`: {
 		Set: func(_ context.Context, p *planner, values []parser.TypedExpr) error {
 			s, err := p.getStringVal(`distsql`, values)
@@ -145,6 +216,16 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 	},
+
+	// Supported for PG compatibility only.
+	// See https://www.postgresql.org/docs/9.6/static/runtime-config-client.html
+	`extra_float_digits`: nopVar,
+
+	`max_index_keys`: {
+		// Supported for PG compatibility only.
+		Get: func(*planner) string { return "32" },
+	},
+
 	`search_path`: {
 		Set: func(_ context.Context, p *planner, values []parser.TypedExpr) error {
 			// https://www.postgresql.org/docs/9.6/static/runtime-config-client.html
@@ -177,7 +258,16 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 	},
+
+	`server_version`: {
+		Get: func(*planner) string { return PgServerVersion },
+	},
+	`session_user`: {
+		Get: func(p *planner) string { return p.session.User },
+	},
+
 	`standard_conforming_strings`: {
+		// Supported for PG compatibility only.
 		Set: func(_ context.Context, p *planner, values []parser.TypedExpr) error {
 			// If true, escape backslash literals in strings. We do this by default,
 			// and we do not support the opposite behavior.
@@ -195,28 +285,7 @@ var varGen = map[string]sessionVar{
 		Get:   func(*planner) string { return "on" },
 		Reset: func(*planner) error { return nil },
 	},
-	`application_name`: {
-		Set: func(_ context.Context, p *planner, values []parser.TypedExpr) error {
-			// Set by clients to improve query logging.
-			// See https://www.postgresql.org/docs/9.6/static/runtime-config-logging.html#GUC-APPLICATION-NAME
-			s, err := p.getStringVal(`application_name`, values)
-			if err != nil {
-				return err
-			}
-			p.session.resetApplicationName(s)
 
-			return nil
-		},
-		Get: func(p *planner) string {
-			p.session.mu.RLock()
-			defer p.session.mu.RUnlock()
-			return p.session.mu.ApplicationName
-		},
-		Reset: func(p *planner) error {
-			p.session.resetApplicationName(p.session.defaults.applicationName)
-			return nil
-		},
-	},
 	`time zone`: {
 		Get: func(p *planner) string {
 			// If the time zone is a "fixed offset" one, initialized from an offset
@@ -235,66 +304,17 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 	},
+
 	`transaction isolation level`: {
 		Get: func(p *planner) string { return p.txn.Isolation().String() },
 	},
+
 	`transaction priority`: {
 		Get: func(p *planner) string { return p.txn.UserPriority().String() },
 	},
+
 	`transaction status`: {
 		Get: func(p *planner) string { return getTransactionState(&p.session.TxnState, p.autoCommit) },
-	},
-	`max_index_keys`: {
-		Get: func(*planner) string { return "32" },
-	},
-	`server_version`: {
-		Get: func(*planner) string { return PgServerVersion },
-	},
-	`session_user`: {
-		Get: func(p *planner) string { return p.session.User },
-	},
-
-	// See https://www.postgresql.org/docs/9.6/static/runtime-config-client.html
-	`extra_float_digits`: nopVar,
-
-	// Controls returned message verbosity. We don't support this.
-	// See https://www.postgresql.org/docs/9.6/static/runtime-config-compatible.html
-	`client_min_messages`: nopVar,
-
-	// See https://www.postgresql.org/docs/9.6/static/multibyte.html
-	`client_encoding`: {
-		Get: func(*planner) string {
-			return "UTF8"
-		},
-		Set: func(_ context.Context, p *planner, values []parser.TypedExpr) error {
-			s, err := p.getStringVal(`client_encoding`, values)
-			if err != nil {
-				return err
-			}
-			upper := strings.ToUpper(s)
-			if upper != "UTF8" && upper != "UNICODE" {
-				return fmt.Errorf("non-UTF8 encoding %s not supported", s)
-			}
-			return nil
-		},
-		Reset: func(*planner) error { return nil },
-	},
-
-	`datestyle`: {
-		Get: func(*planner) string {
-			return "ISO"
-		},
-		Set: func(_ context.Context, p *planner, values []parser.TypedExpr) error {
-			s, err := p.getStringVal(`datestyle`, values)
-			if err != nil {
-				return err
-			}
-			if strings.ToUpper(s) != "ISO" {
-				return fmt.Errorf("non-ISO date style %s not supported", s)
-			}
-			return nil
-		},
-		Reset: func(*planner) error { return nil },
 	},
 
 	`trace`: {


### PR DESCRIPTION
### sql: expose the node ID of the gateway node as a read-only session variable

The new variable is called `node_id`.

This makes it more convenient than `SELECT node_id FROM
crdb_internal.node_build_info LIMIT 1`.

Requested/suggested by @jseldess.

Fixes #14310.

### cli/sql: report the cluster ID and server version upon new connections

This patch ensures the client prints out the cluster ID and
server version, and if different from the server version, also the
client version, both upon the initial connection and upon reconnects
*if they change*.

For example:

    $ ./cockroach sql
    # Welcome to the cockroach SQL interface.
    # All statements must be terminated by a semicolon.
    # To exit: CTRL + D.
    #
    # Server version: CockroachDB CCL 0da9d8f-dirty (linux amd64, built 2017/06/23 19:50:15, go1.8) (same version as client)
    # Cluster ID: fe26b6f3-3153-4c75-a7fb-3027c327e5ab
    #
    # Enter \? for a brief introduction.
    #
    root@localhost:26257/>

Then upon a reconnect, if the node ID changes:

    root@localhost:26257/> SELECT 1;
    driver: bad connection
    connection lost; opening new connection: all session settings will be lost
    root@localhost:26257/>

If the server version has changed:

    root@localhost:26257/> select 1;
    driver: bad connection
    connection lost; opening new connection: all session settings will be lost
    # Client version: CockroachDB CCL a1b6734-dirty (linux amd64, built 2017/06/23 19:14:15, go1.8)
    # Server version: CockroachDB CCL a1b6734-dirty (linux amd64, built 2017/06/23 19:15:00, go1.8)
    root@localhost:26257/>

If the cluster ID has changed:

        root@localhost:26257/> SELECT 1;
        driver: bad connection
        connection lost; opening new connection: all session settings will be lost
        error retrieving the transaction status: the cluster ID has changed!
        Previous ID: b8d0cc65-3a71-4db8-bcda-6fa86206ebb0
        New ID: fe26b6f3-3153-4c75-a7fb-3027c327e5ab
        root@localhost:26257/ ?>

Supersedes #16615.


cc @mberhault 