### PR TITLE
sql: generate descriptor IDs non-transactionally

### DIFF
--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -425,7 +425,7 @@ func (n *createViewNode) Start(ctx context.Context) error {
 		return err
 	}
 
-	id, err := GenerateUniqueDescID(ctx, n.p.txn)
+	id, err := GenerateUniqueDescID(ctx, n.p.session.execCfg.DB)
 	if err != nil {
 		return nil
 	}
@@ -593,7 +593,7 @@ func (n *createTableNode) Start(ctx context.Context) error {
 		return err
 	}
 
-	id, err := GenerateUniqueDescID(ctx, n.p.txn)
+	id, err := GenerateUniqueDescID(ctx, n.p.session.execCfg.DB)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -290,4 +290,4 @@ EXPLAIN SELECT * FROM orders WHERE customer = 1 AND id = 1000
 ----
 0  scan
 0        table  orders@primary
-0        spans  /1/#/57/1/1000-/1/#/57/1/1001
+0        spans  /1/#/64/1/1000-/1/#/64/1/1001

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -46,11 +46,11 @@ SELECT span, operation, message FROM [SHOW SESSION KV TRACE] WHERE message NOT L
 (1,0)  sql txn implicit  querying next range at /Table/2/1/0/"t"/3/1
 (1,0)  sql txn implicit  r1: sending batch 1 Get to (n1,s1):1
 (1,0)  sql txn implicit  querying next range at /System/"desc-idgen"
-(1,0)  sql txn implicit  r1: sending batch 1 Inc, 1 BeginTxn to (n1,s1):1
+(1,0)  sql txn implicit  r1: sending batch 1 Inc to (n1,s1):1
 (1,0)  sql txn implicit  CPut /Table/2/1/0/"t"/3/1 -> 51
 (1,0)  sql txn implicit  CPut /Table/3/1/51/2/1 -> database:<name:"t" id:51 privileges:<users:<user:"root" privileges:2 > > >
-(1,0)  sql txn implicit  querying next range at /Table/2/1/0/"t"/3/1
-(1,0)  sql txn implicit  r1: sending batch 2 CPut to (n1,s1):1
+(1,0)  sql txn implicit  querying next range at /Table/SystemConfigSpan/Start
+(1,0)  sql txn implicit  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
 (1,0)  sql txn implicit  querying next range at /Table/2/1/0/"system"/3/1
 (1,0)  sql txn implicit  r1: sending batch 1 Get to (n1,s1):1
 (1,0)  sql txn implicit  querying next range at /Table/3/1/1/2/1
@@ -74,11 +74,11 @@ SELECT span, operation, message FROM [SHOW KV TRACE FOR CREATE TABLE t.kv(k INT 
 (0,1)  starting plan  querying next range at /Table/2/1/51/"kv"/3/1
 (0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
 (0,1)  starting plan  querying next range at /System/"desc-idgen"
-(0,1)  starting plan  r1: sending batch 1 Inc, 1 BeginTxn to (n1,s1):1
+(0,1)  starting plan  r1: sending batch 1 Inc to (n1,s1):1
 (0,1)  starting plan  CPut /Table/2/1/51/"kv"/3/1 -> 52
 (0,1)  starting plan  CPut /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:1 up_version:false modification_time:<wall_time:0 logical:0 > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 > interleave:<> > next_index_id:2 privileges:<users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:InterleavedFormatVersion state:PUBLIC view_query:"" >
-(0,1)  starting plan  querying next range at /Table/2/1/51/"kv"/3/1
-(0,1)  starting plan  r1: sending batch 2 CPut to (n1,s1):1
+(0,1)  starting plan  querying next range at /Table/SystemConfigSpan/Start
+(0,1)  starting plan  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
 (0,1)  starting plan  querying next range at /Table/3/1/51/2/1
 (0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
 (0,1)  starting plan  querying next range at /Table/2/1/0/"system"/3/1
@@ -196,11 +196,11 @@ SELECT span, operation, regexp_replace(message, '\d\d\d\d\d+', '...PK...') as me
 (0,1)  starting plan  querying next range at /Table/2/1/51/"kv2"/3/1
 (0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
 (0,1)  starting plan  querying next range at /System/"desc-idgen"
-(0,1)  starting plan  r1: sending batch 1 Inc, 1 BeginTxn to (n1,s1):1
+(0,1)  starting plan  r1: sending batch 1 Inc to (n1,s1):1
 (0,1)  starting plan  CPut /Table/2/1/51/"kv2"/3/1 -> 53
 (0,1)  starting plan  CPut /Table/3/1/53/2/1 -> table:<name:"kv2" id:53 parent_id:51 version:1 up_version:false modification_time:<wall_time:0 logical:0 > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 > interleave:<> > next_index_id:2 privileges:<users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:InterleavedFormatVersion state:PUBLIC view_query:"" >
-(0,1)  starting plan  querying next range at /Table/2/1/51/"kv2"/3/1
-(0,1)  starting plan  r1: sending batch 2 CPut to (n1,s1):1
+(0,1)  starting plan  querying next range at /Table/SystemConfigSpan/Start
+(0,1)  starting plan  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
 (0,1)  starting plan  querying next range at /Table/3/1/51/2/1
 (0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
 (0,1)  starting plan  querying next range at /Table/2/1/0/"system"/3/1

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
@@ -59,8 +60,8 @@ func GetTableDescriptor(kvDB *client.DB, database string, table string) *TableDe
 
 	descKey := MakeDescMetadataKey(ID(gr.ValueInt()))
 	desc := &Descriptor{}
-	if err := kvDB.GetProto(context.TODO(), descKey, desc); err != nil {
-		panic("proto missing")
+	if err := kvDB.GetProto(context.TODO(), descKey, desc); err != nil || (*desc == Descriptor{}) {
+		log.Fatalf(context.TODO(), "proto with id %d missing. err: %v", gr.ValueInt(), err)
 	}
 	return desc.GetTable()
 }

--- a/pkg/storage/id_alloc.go
+++ b/pkg/storage/id_alloc.go
@@ -34,6 +34,9 @@ import (
 
 // An idAllocator is used to increment a key in allocation blocks
 // of arbitrary size starting at a minimum ID.
+//
+// Note: if all you want is to increment a key and retry on retryable errors,
+// see client.IncrementValRetryable().
 type idAllocator struct {
 	log.AmbientContext
 


### PR DESCRIPTION
Before this patch, ids for new table of database descriptors were
created in the same transaction as the SQL statement performing the
creation. This meant that if they encountered a retryable error, the
statement failed. This is a problem for CREATEs performed by an ORM,
which like to perform such statements in explicit transactions (so we
can't automatically retry the statement).
This patch makes the id creation non-transactional, and retryable on
errors.

Fixes #13180.
Touches #16450