### PR TITLE
client: don't rollback transactions that haven't sent any requests

### DIFF
--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -461,6 +461,37 @@ func (txn *Txn) CleanupOnError(ctx context.Context, err error) {
 	// we're just trying to clean up and will happily log the failed Rollback error
 	// if someone beat us.
 	if txn.status() == roachpb.PENDING {
+
+		// If the proto is uninitialized, we don't need to do anything; no requests
+		// have been set so there's nothing to cleanup. We'll avoid performing the
+		// rollback, because the rollback itself would send a request which would
+		// initialize the proto, which proves to be a problem for retryable errors
+		// that would look like they've been received for the wrong txn (they were
+		// produced for an uninitialized proto and they'll later be checked against
+		// an initialized one. How would a txn that hasn't sent anything get a
+		// retryable error, you may ask? By calling the SQL function
+		// crdb_iternal.force_retry().
+		//
+		// This here is a hack; the transaction protos should be initialized early
+		// so that we don't have this kind of problem. But even if they were
+		// initialized, we still should have some check here to not send an
+		// unnecessary rollback (which would probably fail, leading to potential
+		// confusing messages).
+		rollbackUnnecessary := false
+		txn.mu.Lock()
+		if !txn.mu.Proto.IsInitialized() {
+			rollbackUnnecessary = true
+			// Simulate the effect of sending a rollback.
+			txn.mu.finalized = true
+			// Let's set the status to ABORTED; unclear what that means given that our
+			// proto is not "initialized", but can't hurt.
+			txn.mu.Proto.Status = roachpb.ABORTED
+		}
+		txn.mu.Unlock()
+		if rollbackUnnecessary {
+			return
+		}
+
 		if replyErr := txn.rollback(ctx); replyErr != nil {
 			if _, ok := replyErr.GetDetail().(*roachpb.TransactionStatusError); ok || txn.status() == roachpb.ABORTED {
 				log.Eventf(ctx, "failure aborting transaction: %s; abort caused by: %s", replyErr, err)

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -530,7 +530,7 @@ COMMIT
 statement ok
 BEGIN TRANSACTION; SAVEPOINT cockroach_restart
 
-query error restart transaction: HandledRetryableTxnError: forced by crdb_internal.force_retry()
+query error pgcode 40001 restart transaction: HandledRetryableTxnError: forced by crdb_internal.force_retry()
 SELECT CRDB_INTERNAL.FORCE_RETRY('1s':::INTERVAL)
 
 query T
@@ -631,6 +631,15 @@ BEGIN READ WRITE; COMMIT
 statement error read only not supported
 BEGIN READ ONLY
 
+# TODO(andrei): Something might be fishy here. The statement above leaves the
+# transaction in an error state, and so we need this rollback. But all the
+# errors below are parse errors, and so they don't mess with the transaction
+# state. Perhaps it'd be better if the statement above also left the session in
+# the NoTxn state. I couldn't do an analogous test with Postgres since I can't
+# trigger a BEGIN error that's not a parse error.
+statement ok
+ROLLBACK
+
 statement error read mode specified multiple times
 BEGIN READ WRITE, READ ONLY
 
@@ -639,3 +648,14 @@ BEGIN PRIORITY LOW, PRIORITY HIGH
 
 statement error isolation level specified multiple times
 BEGIN ISOLATION LEVEL SERIALIZABLE, ISOLATION LEVEL SERIALIZABLE
+
+# Retryable error in a txn that hasn't performed any KV operations. It used to
+# not work.
+statement ok
+BEGIN
+
+query error pgcode 40001 restart transaction: HandledRetryableTxnError: forced by crdb_internal.force_retry()
+SELECT CRDB_INTERNAL.FORCE_RETRY('1s':::INTERVAL)
+
+statement ok
+ROLLBACK


### PR DESCRIPTION
Before this patch, the following would happen:

BEGIN;
SELECT crdb_internal.force_retry('1s')
pq: retryable error from another txn. Current txn ID:
ac5789e9-04d0-4ac8-aa72-73edabf9929c: HandledRetryableTxnError: forced
by crdb_internal.force_retry()

That's not the expected error. The "another txn" happens because the
rollback was initializing the previously unitialized txn proto, and then
the error that had been constructed for an unitialized proto looked
wrong.
Besides this annoying thing, it generally seems like a good idea to not
send unnecessary rollbacks.