### PR TITLE
distsql, storage: add RocksDB engine for DistSQL

### DIFF
--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -51,11 +51,8 @@ func loadTestData(
 	}
 
 	eng, err := engine.NewRocksDB(
-		roachpb.Attributes{},
-		dir,
+		engine.RocksDBConfig{Dir: dir},
 		engine.RocksDBCache{},
-		0,
-		engine.DefaultMaxOpenFiles,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/ccl/storageccl/engineccl/mvcc_test.go
+++ b/pkg/ccl/storageccl/engineccl/mvcc_test.go
@@ -87,11 +87,8 @@ func TestMVCCIterateIncremental(t *testing.T) {
 
 	ctx := context.Background()
 	e, err := engine.NewRocksDB(
-		roachpb.Attributes{},
-		dir,
+		engine.RocksDBConfig{Dir: dir},
 		engine.RocksDBCache{},
-		0,
-		engine.DefaultMaxOpenFiles,
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -79,11 +79,11 @@ func openStore(cmd *cobra.Command, dir string, stopper *stop.Stopper) (*engine.R
 		return nil, err
 	}
 	db, err := engine.NewRocksDB(
-		roachpb.Attributes{},
-		dir,
+		engine.RocksDBConfig{
+			Dir:          dir,
+			MaxOpenFiles: maxOpenFiles,
+		},
 		cache,
-		0,
-		maxOpenFiles,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -298,6 +298,12 @@ func runStart(cmd *cobra.Command, args []string) error {
 	serverCfg.SSLCertsDir = serverSSLCertsDir
 	serverCfg.User = security.NodeUser
 
+	var err error
+	serverCfg.TempStore, err = server.MakeTempStoreSpecFromStoreSpec(serverCfg.Stores.Specs[0])
+	if err != nil {
+		return err
+	}
+
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -64,6 +64,9 @@ func makeTestConfig() Config {
 	// Test servers start in secure mode by default.
 	cfg.Insecure = false
 
+	// Override the DistSQL local store with an in-memory store.
+	cfg.TempStore = base.DefaultTestStoreSpec
+
 	// Load test certs. In addition, the tests requiring certs
 	// need to call security.SetAssetLoader(securitytest.EmbeddedAssets)
 	// in their init to mock out the file system calls for calls to AssetFS,

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -71,6 +72,13 @@ type FlowCtx struct {
 	// run.
 	nodeID       roachpb.NodeID
 	testingKnobs TestingKnobs
+
+	// tempStorage is used by some DistSQL processors to store Rows when the
+	// working set is larger than can be stored in memory.
+	tempStorage engine.Engine
+	// tempStorageIDGenerator is used to generate unique prefixes for each processor,
+	// so they use non-overlapping parts of the local store's keyspace.
+	tempStorageIDGenerator *TempStorageIDGenerator
 }
 
 func (flowCtx *FlowCtx) setupTxn() *client.Txn {

--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
@@ -43,6 +44,12 @@ type sorter struct {
 	// procOutputHelper. 0 if the sorter should sort and push all the rows from
 	// the input.
 	count int64
+	// tempStorage is used to store rows when the working set is larger than can
+	// be stored in memory.
+	tempStorage engine.Engine
+	// tempStorageID is a unique (to this node) ID prefixed before every row, to
+	// ensure that this processor's rows do not overlap with any other processors.
+	tempStorageID uint64
 }
 
 var _ processor = &sorter{}
@@ -56,13 +63,19 @@ func newSorter(
 		// will discard the first Offset ones.
 		count = int64(post.Limit) + int64(post.Offset)
 	}
+	var tempStorageID uint64
+	if flowCtx.tempStorage != nil {
+		tempStorageID = flowCtx.tempStorageIDGenerator.NewID()
+	}
 	s := &sorter{
-		flowCtx:  flowCtx,
-		input:    MakeNoMetadataRowSource(input, output),
-		rawInput: input,
-		ordering: convertToColumnOrdering(spec.OutputOrdering),
-		matchLen: spec.OrderingMatchLen,
-		count:    count,
+		flowCtx:       flowCtx,
+		input:         MakeNoMetadataRowSource(input, output),
+		rawInput:      input,
+		ordering:      convertToColumnOrdering(spec.OutputOrdering),
+		matchLen:      spec.OrderingMatchLen,
+		count:         count,
+		tempStorage:   flowCtx.tempStorage,
+		tempStorageID: tempStorageID,
 	}
 	if err := s.out.init(post, input.Types(), &flowCtx.evalCtx, output); err != nil {
 		return nil, err

--- a/pkg/sql/distsqlrun/sorter_test.go
+++ b/pkg/sql/distsqlrun/sorter_test.go
@@ -306,6 +306,7 @@ func BenchmarkSortLimit(b *testing.B) {
 					rowSource.Reset()
 				}
 			})
+
 		}
 	})
 }

--- a/pkg/storage/engine/bench_rocksdb_test.go
+++ b/pkg/storage/engine/bench_rocksdb_test.go
@@ -25,16 +25,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
-func setupMVCCRocksDB(b testing.TB, loc string) Engine {
+func setupMVCCRocksDB(b testing.TB, dir string) Engine {
 	rocksdb, err := NewRocksDB(
-		roachpb.Attributes{},
-		loc,
+		RocksDBConfig{Dir: dir},
 		RocksDBCache{},
-		0,
-		DefaultMaxOpenFiles,
 	)
 	if err != nil {
-		b.Fatalf("could not create new rocksdb db instance at %s: %v", loc, err)
+		b.Fatalf("could not create new rocksdb db instance at %s: %v", dir, err)
 	}
 	return rocksdb
 }

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -89,7 +89,10 @@ func prettyPrintKey(cKey C.DBKey) *C.char {
 }
 
 const (
-	defaultBlockSize = 32 << 10 // 32KB (rocksdb default is 4KB)
+	// defaultBlockSize configures the size of a black. When reading a key-value
+	// pair from a table file, RocksDB loads an entire block into memory. The
+	// RocksDB default is 4KB. This sets it to 32KB.
+	defaultBlockSize = 32 << 10
 
 	// DefaultMaxOpenFiles is the default value for rocksDB's max_open_files
 	// option.
@@ -243,9 +246,9 @@ func (s SSTableInfos) String() string {
 	return buf.String()
 }
 
-// ReadAmplification returns RocksDB's read amplification, which is the number
-// of level-0 sstables plus the number of levels, other than level 0, with at
-// least one sstable.
+// ReadAmplification returns RocksDB's worst case read amplification, which is
+// the number of level-0 sstables plus the number of levels, other than level 0,
+// with at least one sstable.
 //
 // This definition comes from here:
 // https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide#level-style-compaction
@@ -291,15 +294,31 @@ func (c RocksDBCache) Release() {
 	}
 }
 
+// RocksDBConfig holds all configuration parameters and knobs used in setting
+// up a new RocksDB instance.
+type RocksDBConfig struct {
+	Attrs roachpb.Attributes
+	// Dir is the data directory for this store.
+	Dir string
+	// MaxSizeBytes is used for calculating free space and making rebalancing
+	// decisions. Zero indicates that there is no maximum size.
+	MaxSizeBytes int64
+	// MaxOpenFiles controls the maximum number of file descriptors RocksDB
+	// creates. If MaxOpenFiles is zero, this is set to DefaultMaxOpenFiles.
+	MaxOpenFiles int
+	// WarnLargeBatchThreshold controls if a log message is printed when a
+	// WriteBatch takes longer than WarnLargeBatchThreshold. If it is set to
+	// zero, no log messages are ever printed.
+	WarnLargeBatchThreshold time.Duration
+}
+
 // RocksDB is a wrapper around a RocksDB database instance.
 type RocksDB struct {
-	rdb          *C.DBEngine
-	attrs        roachpb.Attributes // Attributes for this engine
-	dir          string             // The data directory
-	auxDir       string             // A path for storing auxiliary files (ideally under dir).
-	cache        RocksDBCache       // Shared cache.
-	maxSize      int64              // Used for calculating rebalancing and free space.
-	maxOpenFiles int                // The maximum number of open files this instance will use.
+	cfg   RocksDBConfig
+	rdb   *C.DBEngine
+	cache RocksDBCache // Shared cache.
+	// auxDir is used for storing auxiliary files. Ideally it is a subdirectory of Dir.
+	auxDir string
 
 	commit struct {
 		syncutil.Mutex
@@ -324,22 +343,17 @@ var _ Engine = &RocksDB{}
 // from scratch.
 // The caller must call the engine's Close method when the engine is no longer
 // needed.
-func NewRocksDB(
-	attrs roachpb.Attributes, dir string, cache RocksDBCache, maxSize int64, maxOpenFiles int,
-) (*RocksDB, error) {
-	if dir == "" {
+func NewRocksDB(cfg RocksDBConfig, cache RocksDBCache) (*RocksDB, error) {
+	if cfg.Dir == "" {
 		panic("dir must be non-empty")
 	}
 
 	r := &RocksDB{
-		attrs:        attrs,
-		dir:          dir,
-		cache:        cache.ref(),
-		maxSize:      maxSize,
-		maxOpenFiles: maxOpenFiles,
+		cfg:   cfg,
+		cache: cache.ref(),
 	}
 
-	auxDir := filepath.Join(dir, "auxiliary")
+	auxDir := filepath.Join(cfg.Dir, "auxiliary")
 	if err := r.SetAuxiliaryDir(auxDir); err != nil {
 		return nil, err
 	}
@@ -350,12 +364,16 @@ func NewRocksDB(
 	return r, nil
 }
 
-func newMemRocksDB(attrs roachpb.Attributes, cache RocksDBCache, maxSize int64) (*RocksDB, error) {
+func newMemRocksDB(
+	attrs roachpb.Attributes, cache RocksDBCache, MaxSizeBytes int64,
+) (*RocksDB, error) {
 	r := &RocksDB{
-		attrs: attrs,
+		cfg: RocksDBConfig{
+			Attrs:        attrs,
+			MaxSizeBytes: MaxSizeBytes,
+		},
 		// dir: empty dir == "mem" RocksDB instance.
-		cache:   cache.ref(),
-		maxSize: maxSize,
+		cache: cache.ref(),
 	}
 
 	if err := r.SetAuxiliaryDir(os.TempDir()); err != nil {
@@ -371,17 +389,17 @@ func newMemRocksDB(attrs roachpb.Attributes, cache RocksDBCache, maxSize int64) 
 
 // String formatter.
 func (r *RocksDB) String() string {
-	return fmt.Sprintf("%s=%s", r.attrs.Attrs, r.dir)
+	return fmt.Sprintf("%s=%s", r.Attrs(), r.cfg.Dir)
 }
 
 func (r *RocksDB) open() error {
 	var ver storageVersion
-	if len(r.dir) != 0 {
-		log.Infof(context.TODO(), "opening rocksdb instance at %q", r.dir)
+	if len(r.cfg.Dir) != 0 {
+		log.Infof(context.TODO(), "opening rocksdb instance at %q", r.cfg.Dir)
 
 		// Check the version number.
 		var err error
-		if ver, err = getVersion(r.dir); err != nil {
+		if ver, err = getVersion(r.cfg.Dir); err != nil {
 			return err
 		}
 		if ver < versionMinimum || ver > versionCurrent {
@@ -401,15 +419,19 @@ func (r *RocksDB) open() error {
 
 	blockSize := envutil.EnvOrDefaultBytes("COCKROACH_ROCKSDB_BLOCK_SIZE", defaultBlockSize)
 	walTTL := envutil.EnvOrDefaultDuration("COCKROACH_ROCKSDB_WAL_TTL", 0).Seconds()
+	maxOpenFiles := DefaultMaxOpenFiles
+	if r.cfg.MaxOpenFiles != 0 {
+		maxOpenFiles = r.cfg.MaxOpenFiles
+	}
 
-	status := C.DBOpen(&r.rdb, goToCSlice([]byte(r.dir)),
+	status := C.DBOpen(&r.rdb, goToCSlice([]byte(r.cfg.Dir)),
 		C.DBOptions{
 			cache:           r.cache.cache,
 			block_size:      C.uint64_t(blockSize),
 			wal_ttl_seconds: C.uint64_t(walTTL),
 			logging_enabled: C.bool(log.V(3)),
 			num_cpu:         C.int(runtime.NumCPU()),
-			max_open_files:  C.int(r.maxOpenFiles),
+			max_open_files:  C.int(maxOpenFiles),
 		})
 	if err := statusToError(status); err != nil {
 		return errors.Errorf("could not open rocksdb instance: %s", err)
@@ -417,7 +439,7 @@ func (r *RocksDB) open() error {
 
 	// Update or add the version file if needed.
 	if ver < versionCurrent {
-		if err := writeVersionFile(r.dir); err != nil {
+		if err := writeVersionFile(r.cfg.Dir); err != nil {
 			return err
 		}
 	}
@@ -467,7 +489,7 @@ func (r *RocksDB) syncLoop() {
 		s.Unlock()
 
 		var err error
-		if r.dir != "" {
+		if r.cfg.Dir != "" {
 			err = statusToError(C.DBSyncWAL(r.rdb))
 			lastSync = timeutil.Now()
 		}
@@ -487,12 +509,12 @@ func (r *RocksDB) Close() {
 		log.Errorf(context.TODO(), "closing unopened rocksdb instance")
 		return
 	}
-	if len(r.dir) == 0 {
+	if len(r.cfg.Dir) == 0 {
 		if log.V(1) {
 			log.Infof(context.TODO(), "closing in-memory rocksdb instance")
 		}
 	} else {
-		log.Infof(context.TODO(), "closing rocksdb instance at %q", r.dir)
+		log.Infof(context.TODO(), "closing rocksdb instance at %q", r.cfg.Dir)
 	}
 	if r.rdb != nil {
 		C.DBClose(r.rdb)
@@ -515,7 +537,7 @@ func (r *RocksDB) Closed() bool {
 // and potentially other labels to identify important attributes of
 // the engine.
 func (r *RocksDB) Attrs() roachpb.Attributes {
-	return r.attrs
+	return r.cfg.Attrs
 }
 
 // Put sets the given key to the value provided.
@@ -583,15 +605,15 @@ func (r *RocksDB) Iterate(start, end MVCCKey, f func(MVCCKeyValue) (bool, error)
 // Capacity queries the underlying file system for disk capacity information.
 func (r *RocksDB) Capacity() (roachpb.StoreCapacity, error) {
 	fileSystemUsage := gosigar.FileSystemUsage{}
-	dir := r.dir
+	dir := r.cfg.Dir
 	if dir == "" {
 		// This is an in-memory instance. Pretend we're empty since we
 		// don't know better and only use this for testing. Using any
 		// part of the actual file system here can throw off allocator
 		// rebalancing in a hard-to-trace manner. See #7050.
 		return roachpb.StoreCapacity{
-			Capacity:  r.maxSize,
-			Available: r.maxSize,
+			Capacity:  r.cfg.MaxSizeBytes,
+			Available: r.cfg.MaxSizeBytes,
 		}, nil
 	}
 	if err := fileSystemUsage.Get(dir); err != nil {
@@ -612,7 +634,7 @@ func (r *RocksDB) Capacity() (roachpb.StoreCapacity, error) {
 	// If no size limitation have been placed on the store size or if the
 	// limitation is greater than what's available, just return the actual
 	// totals.
-	if r.maxSize == 0 || r.maxSize >= fsuTotal || r.dir == "" {
+	if r.cfg.MaxSizeBytes == 0 || r.cfg.MaxSizeBytes >= fsuTotal || r.cfg.Dir == "" {
 		return roachpb.StoreCapacity{
 			Capacity:  fsuTotal,
 			Available: fsuAvail,
@@ -622,7 +644,7 @@ func (r *RocksDB) Capacity() (roachpb.StoreCapacity, error) {
 	// Find the total size of all the files in the r.dir and all its
 	// subdirectories.
 	var totalUsedBytes int64
-	if errOuter := filepath.Walk(r.dir, func(path string, info os.FileInfo, err error) error {
+	if errOuter := filepath.Walk(r.cfg.Dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil
 		}
@@ -634,7 +656,7 @@ func (r *RocksDB) Capacity() (roachpb.StoreCapacity, error) {
 		return roachpb.StoreCapacity{}, errOuter
 	}
 
-	available := r.maxSize - totalUsedBytes
+	available := r.cfg.MaxSizeBytes - totalUsedBytes
 	if available > fsuAvail {
 		available = fsuAvail
 	}
@@ -643,7 +665,7 @@ func (r *RocksDB) Capacity() (roachpb.StoreCapacity, error) {
 	}
 
 	return roachpb.StoreCapacity{
-		Capacity:  r.maxSize,
+		Capacity:  r.cfg.MaxSizeBytes,
 		Available: available,
 	}, nil
 }
@@ -655,7 +677,7 @@ func (r *RocksDB) Compact() error {
 
 // Destroy destroys the underlying filesystem data associated with the database.
 func (r *RocksDB) Destroy() error {
-	return statusToError(C.DBDestroy(goToCSlice([]byte(r.dir))))
+	return statusToError(C.DBDestroy(goToCSlice([]byte(r.cfg.Dir))))
 }
 
 // Flush causes RocksDB to write all in-memory data to disk immediately.
@@ -1422,10 +1444,10 @@ func (r *rocksDBBatch) commitInternal(sync bool) error {
 		r.batch = nil
 	}
 
-	const batchCommitWarnThreshold = 500 * time.Millisecond
-	if elapsed := timeutil.Since(start); elapsed >= batchCommitWarnThreshold {
+	warnLargeBatches := r.parent.cfg.WarnLargeBatchThreshold > 0
+	if elapsed := timeutil.Since(start); warnLargeBatches && (elapsed >= r.parent.cfg.WarnLargeBatchThreshold) {
 		log.Warningf(context.TODO(), "batch [%d/%d/%d] commit took %s (>%s):\n%s",
-			count, size, r.flushes, elapsed, batchCommitWarnThreshold, debug.Stack())
+			count, size, r.flushes, elapsed, r.parent.cfg.WarnLargeBatchThreshold, debug.Stack())
 	}
 
 	return nil

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -260,11 +260,8 @@ func openRocksDBWithVersion(t *testing.T, hasVersionFile bool, ver Version) erro
 	}
 
 	rocksdb, err := NewRocksDB(
-		roachpb.Attributes{},
-		dir,
+		RocksDBConfig{Dir: dir},
 		RocksDBCache{},
-		0,
-		DefaultMaxOpenFiles,
 	)
 	if err == nil {
 		rocksdb.Close()
@@ -386,8 +383,10 @@ func TestConcurrentBatch(t *testing.T) {
 		}
 	}()
 
-	db, err := NewRocksDB(roachpb.Attributes{}, dir, RocksDBCache{},
-		0, DefaultMaxOpenFiles)
+	db, err := NewRocksDB(
+		RocksDBConfig{Dir: dir},
+		RocksDBCache{},
+	)
 	if err != nil {
 		t.Fatalf("could not create new rocksdb db instance at %s: %v", dir, err)
 	}
@@ -570,7 +569,10 @@ func TestRocksDBTimeBound(t *testing.T) {
 	dir, dirCleanup := testutils.TempDir(t)
 	defer dirCleanup()
 
-	rocksdb, err := NewRocksDB(roachpb.Attributes{}, dir, RocksDBCache{}, 0, DefaultMaxOpenFiles)
+	rocksdb, err := NewRocksDB(
+		RocksDBConfig{Dir: dir},
+		RocksDBCache{},
+	)
 	if err != nil {
 		t.Fatalf("could not create new rocksdb db instance at %s: %v", dir, err)
 	}

--- a/pkg/storage/engine/temp_engine.go
+++ b/pkg/storage/engine/temp_engine.go
@@ -1,0 +1,95 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Arjun Narayan (arjun@cockroachlabs.com)
+
+package engine
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"golang.org/x/net/context"
+)
+
+// NewTempEngine creates a new engine for DistSQL processors to use when the
+// working set is larger than can be stored in memory. It returns nil if it
+// could not set up a temporary Engine.
+func NewTempEngine(ctx context.Context, storeCfg base.StoreSpec) (Engine, error) {
+	if storeCfg.InMemory {
+		// TODO(arjun): Copy the size in a principled fashion from the main store
+		// after #16750 is addressed.
+		return NewInMem(roachpb.Attributes{}, 0 /*cacheSize */), nil
+	}
+
+	if err := cleanupTempStorageDirs(ctx, storeCfg.Path, nil /* *WaitGroup */); err != nil {
+		return nil, err
+	}
+
+	rocksDBCfg := RocksDBConfig{
+		Attrs:        roachpb.Attributes{},
+		Dir:          storeCfg.Path,
+		MaxSizeBytes: 0,   // TODO(arjun): Revisit this.
+		MaxOpenFiles: 128, // TODO(arjun): Revisit this.
+	}
+	rocksDBCache := NewRocksDBCache(0)
+	return NewRocksDB(rocksDBCfg, rocksDBCache)
+}
+
+// wg is allowed to be nil, if the caller does not want to wait on the cleanup.
+func cleanupTempStorageDirs(ctx context.Context, path string, wg *sync.WaitGroup) error {
+	// Removing existing contents might be slow. Instead we rename it to a new
+	// name, and spawn a goroutine to clean it up asynchronously.
+	if err := os.MkdirAll(path, 0755); err != nil {
+		return err
+	}
+	deletionDir, err := ioutil.TempDir(path, "TO-DELETE-")
+	if err != nil {
+		return err
+	}
+
+	filesToDelete, err := ioutil.ReadDir(path)
+	if err != nil {
+		return err
+	}
+
+	for _, fileToDelete := range filesToDelete {
+		toDeleteFull := filepath.Join(path, fileToDelete.Name())
+		if toDeleteFull != deletionDir {
+			if err := os.Rename(toDeleteFull, filepath.Join(deletionDir, fileToDelete.Name())); err != nil {
+				return err
+			}
+		}
+	}
+	if wg != nil {
+		wg.Add(1)
+	}
+	go func() {
+		if wg != nil {
+			defer wg.Done()
+		}
+		if err := os.RemoveAll(deletionDir); err != nil {
+			log.Warningf(ctx, "could not clear old TempEngine files: %v", err.Error())
+			// Even if this errors, this is safe since it's in the marked-for-deletion subdirectory.
+			return
+		}
+	}()
+
+	return nil
+}

--- a/pkg/storage/engine/temp_engine_test.go
+++ b/pkg/storage/engine/temp_engine_test.go
@@ -1,0 +1,61 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Arjun Narayan (arjun@cockroachlabs.com)
+
+package engine
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"golang.org/x/net/context"
+)
+
+func TestCleanupTempStorageDirs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	dir, dirCleanup := testutils.TempDir(t)
+	defer dirCleanup()
+
+	tempBytes := []byte{byte(1), byte(2), byte(3)}
+	if err := ioutil.WriteFile(filepath.Join(dir, "FOO"), tempBytes, 0777); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(dir, "BAR"), tempBytes, 0777); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(dir, "BAZ"), tempBytes, 0777); err != nil {
+		t.Fatal(err)
+	}
+
+	wg := sync.WaitGroup{}
+	if err := cleanupTempStorageDirs(context.TODO(), dir, &wg); err != nil {
+		t.Fatal(fmt.Sprintf("error encountered in cleanupTempStorageDirs: %v", err))
+	}
+	wg.Wait()
+
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		t.Fatal(fmt.Sprintf("error reading temporary directory: %v", err))
+	}
+	if len(files) != 0 {
+		t.Fatalf("directory not cleaned up after calling cleanupTempStorageDirs, still have %d files", len(files))
+	}
+}


### PR DESCRIPTION
Add a separate RocksDB engine for DistSQL processors to use as scratch
space for queries that are too large to fit in memory. Also refactor
the engine.NewRocksDB to use a new struct RocksDBConfig, which holds
all the configuration knobs. The tuning of the knobs for the local
storage RocksDB engine is left to a later commit; for now it just
cargo-cults the durable storage RocksDB configurations.

FYI, this PR is separated from the subsequent PR that uses this external storage in the sorter processor, and that PR is rebased on top of this. The PRs should be separably reviewable.

cc @asubiotto 