### PR TITLE
distsql: implement external storage for the sortAllStrategy

### DIFF
--- a/pkg/sql/distsqlrun/disk_map.go
+++ b/pkg/sql/distsqlrun/disk_map.go
@@ -1,0 +1,287 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Alfonso Subiotto Marqués (alfonso@cockroachlabs.com)
+
+package distsqlrun
+
+import (
+	"bytes"
+	"math"
+
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// SortedDiskMapIterator is a simple iterator used to iterate over keys and/or
+// values.
+// Example use of iterating over all keys:
+// 	var i SortedDiskMapIterator
+// 	for i.Rewind(); ; i.Next() {
+// 		if ok, err := i.Valid(); err != nil {
+//			// Handle error.
+// 		} else if !ok {
+//			break
+// 		}
+// 		key := i.Key()
+//		// Do something.
+// 	}
+type SortedDiskMapIterator interface {
+	// Seek sets the iterator's position to the first key greater than or equal
+	// to the provided key.
+	Seek(key []byte)
+	// Rewind seeks to the start key.
+	Rewind()
+	// Valid must be called after any call to Seek(), Rewind(), or Next(). It
+	// returns (true, nil) if the iterator points to a valid key and
+	// (false, nil) if the iterator has moved past the end of the valid range.
+	// If an error has occurred, the returned bool is invalid.
+	Valid() (bool, error)
+	// Next advances the iterator to the next key in the iteration.
+	Next()
+	// Key returns the current key. The resulting byte slice is still valid
+	// after the next call to Seek(), Rewind(), or Next().
+	Key() []byte
+	// Value returns the current value. The resulting byte slice is still valid
+	// after the next call to Seek(), Rewind(), or Next().
+	Value() []byte
+
+	// Close frees up resources held by the iterator.
+	Close()
+}
+
+// SortedDiskMapBatchWriter batches writes to a SortedDiskMap.
+type SortedDiskMapBatchWriter interface {
+	// Put writes the given key/value pair to the batch. The write to the
+	// underlying store happens on Flush(), Close(), or when the batch writer
+	// reaches its capacity.
+	Put(k []byte, v []byte) error
+	// Flush flushes all writes to the underlying store. The batch can be reused
+	// after a call to Flush().
+	Flush() error
+
+	// Close flushes all writes to the underlying store and frees up resources
+	// held by the batch writer.
+	Close(context.Context)
+}
+
+// SortedDiskMap is an on-disk map. Keys are iterated over in sorted order.
+type SortedDiskMap interface {
+	// Put writes the given key/value pair.
+	Put(k []byte, v []byte) error
+	// Get reads the value for the given key.
+	Get(k []byte) ([]byte, error)
+
+	// NewIterator returns a SortedDiskMapIterator that can be used to iterate
+	// over key/value pairs in sorted order.
+	NewIterator() SortedDiskMapIterator
+	// NewBatchWriter returns a SortedDiskMapBatchWriter that can be used to
+	// batch writes to this map for performance improvements.
+	NewBatchWriter() SortedDiskMapBatchWriter
+	// NewBatchWriterCapacity is identical to NewBatchWriter, but overrides the
+	// SortedDiskMapBatchWriter's default capacity with capacityBytes.
+	NewBatchWriterCapacity(capacityBytes int) SortedDiskMapBatchWriter
+
+	// Close frees up resources held by the map.
+	Close(context.Context)
+}
+
+// defaultBatchCapacityBytes is the default capacity for a
+// SortedDiskMapBatchWriter.
+const defaultBatchCapacityBytes = 4096
+
+// RocksDBMapBatchWriter batches writes to a RocksDBMap.
+type RocksDBMapBatchWriter struct {
+	// capacity is the number of bytes to write before a Flush() is triggered.
+	capacity int
+
+	// makeKey is a function that transforms a key into an MVCCKey with a prefix
+	// to be written to the underlying store.
+	makeKey func(k []byte) engine.MVCCKey
+	batch   engine.Batch
+	store   engine.Engine
+}
+
+// RocksDBMapIterator iterates over the keys of a RocksDBMap in sorted order.
+type RocksDBMapIterator struct {
+	iter engine.Iterator
+	// makeKey is a function that transforms a key into an MVCCKey with a prefix
+	// used to Seek() the underlying iterator.
+	makeKey func(k []byte) engine.MVCCKey
+	// prefix is the prefix of keys that this iterator iterates over.
+	prefix []byte
+}
+
+// RocksDBMap is a SortedDiskMap that uses RocksDB as its underlying storage
+// engine.
+type RocksDBMap struct {
+	// TODO(asubiotto): Add memory accounting.
+	prefix []byte
+	store  engine.Engine
+}
+
+var _ SortedDiskMapBatchWriter = &RocksDBMapBatchWriter{}
+var _ SortedDiskMapIterator = &RocksDBMapIterator{}
+var _ SortedDiskMap = &RocksDBMap{}
+
+// NewRocksDBMap creates a new RocksDBMap with the passed in engine.Engine as
+// the underlying store. The RocksDBMap instance will have a keyspace prefixed
+// by prefix.
+func NewRocksDBMap(prefix uint64, e engine.Engine) (*RocksDBMap, error) {
+	// When we close this instance, we also delete the associated keyspace. If
+	// we accepted math.MaxUint64 as a prefix, our prefixBytes would be
+	// []byte{0xff, ..., 0xff} for which there is no end key, thus deleting
+	// nothing.
+	if prefix == math.MaxUint64 {
+		return nil, errors.New("invalid prefix")
+	}
+
+	return &RocksDBMap{prefix: encoding.EncodeUvarintAscending([]byte(nil), prefix), store: e}, nil
+}
+
+// makeKey appends k to the RocksDBMap's prefix to keep the key local to this
+// instance and creates an MVCCKey, which is what the underlying storage engine
+// expects. The returned key is only valid until the next call to makeKey().
+func (r *RocksDBMap) makeKey(k []byte) engine.MVCCKey {
+	// TODO(asubiotto): We can make this more performant by bypassing MVCCKey
+	// creation (have to generalize storage API). See
+	// https://github.com/cockroachdb/cockroach/issues/16718#issuecomment-311493414
+	prefixLen := len(r.prefix)
+	r.prefix = append(r.prefix, k...)
+	mvccKey := engine.MVCCKey{Key: r.prefix}
+	r.prefix = r.prefix[:prefixLen]
+	return mvccKey
+}
+
+// Put implements the SortedDiskMap interface.
+func (r *RocksDBMap) Put(k []byte, v []byte) error {
+	return r.store.Put(r.makeKey(k), v)
+}
+
+// Get implements the SortedDiskMap interface.
+func (r *RocksDBMap) Get(k []byte) ([]byte, error) {
+	return r.store.Get(r.makeKey(k))
+}
+
+// NewIterator implements the SortedDiskMap interface.
+func (r *RocksDBMap) NewIterator() SortedDiskMapIterator {
+	// NOTE: prefix is only false because we can't use the normal prefix
+	// extractor. This iterator still only does prefix iteration. See
+	// RocksDBMapIterator.Valid().
+	return &RocksDBMapIterator{iter: r.store.NewIterator(false /* prefix */), makeKey: r.makeKey, prefix: r.prefix}
+}
+
+// NewBatchWriter implements the SortedDiskMap interface.
+func (r *RocksDBMap) NewBatchWriter() SortedDiskMapBatchWriter {
+	return r.NewBatchWriterCapacity(defaultBatchCapacityBytes)
+}
+
+// NewBatchWriterCapacity implements the SortedDiskMap interface.
+func (r *RocksDBMap) NewBatchWriterCapacity(capacityBytes int) SortedDiskMapBatchWriter {
+	return &RocksDBMapBatchWriter{
+		capacity: capacityBytes,
+		makeKey:  r.makeKey,
+		batch:    r.store.NewWriteOnlyBatch(),
+		store:    r.store,
+	}
+}
+
+// Close implements the SortedDiskMap interface.
+func (r *RocksDBMap) Close(ctx context.Context) {
+	if err := r.store.ClearRange(
+		engine.MVCCKey{Key: r.prefix},
+		engine.MVCCKey{Key: roachpb.Key(r.prefix).PrefixEnd()},
+	); err != nil {
+		log.Error(ctx, errors.Wrapf(err, "unable to clear range with prefix %v", r.prefix))
+	}
+}
+
+// Seek implements the SortedDiskMapIterator interface.
+func (i *RocksDBMapIterator) Seek(k []byte) {
+	i.iter.Seek(i.makeKey(k))
+}
+
+// Rewind implements the SortedDiskMapIterator interface.
+func (i *RocksDBMapIterator) Rewind() {
+	i.iter.Seek(i.makeKey(nil))
+}
+
+// Valid implements the SortedDiskMapIterator interface.
+func (i *RocksDBMapIterator) Valid() (bool, error) {
+	ok, err := i.iter.Valid()
+	if err != nil {
+		return false, err
+	}
+	if ok && !bytes.HasPrefix(i.iter.UnsafeKey().Key, i.prefix) {
+		return false, nil
+	}
+
+	return ok, nil
+}
+
+// Next implements the SortedDiskMapIterator interface.
+func (i *RocksDBMapIterator) Next() {
+	i.iter.Next()
+}
+
+// Key implements the SortedDiskMapIterator interface.
+func (i *RocksDBMapIterator) Key() []byte {
+	return i.iter.Key().Key[len(i.prefix):]
+}
+
+// Value implements the SortedDiskMapIterator interface.
+func (i *RocksDBMapIterator) Value() []byte {
+	return i.iter.Value()
+}
+
+// Close implements the SortedDiskMapIterator interface.
+func (i *RocksDBMapIterator) Close() {
+	i.iter.Close()
+}
+
+// Put implements the SortedDiskMapBatchWriter interface.
+func (b *RocksDBMapBatchWriter) Put(k []byte, v []byte) error {
+	if err := b.batch.Put(b.makeKey(k), v); err != nil {
+		return err
+	}
+	if len(b.batch.Repr()) >= b.capacity {
+		return b.Flush()
+	}
+	return nil
+}
+
+// Flush implements the SortedDiskMapBatchWriter interface.
+func (b *RocksDBMapBatchWriter) Flush() error {
+	if len(b.batch.Repr()) < 1 {
+		return nil
+	}
+	if err := b.batch.Commit(false /* syncCommit */); err != nil {
+		return err
+	}
+	b.batch = b.store.NewWriteOnlyBatch()
+	return nil
+}
+
+// Close implements the SortedDiskMapBatchWriter interface.
+func (b *RocksDBMapBatchWriter) Close(ctx context.Context) {
+	if err := b.Flush(); err != nil {
+		log.Warning(ctx, errors.Wrapf(err, "batch writer could not be flushed on close"))
+	}
+	b.batch.Close()
+}

--- a/pkg/sql/distsqlrun/disk_map_test.go
+++ b/pkg/sql/distsqlrun/disk_map_test.go
@@ -1,0 +1,325 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Alfonso Subiotto Marqués (alfonso@cockroachlabs.com)
+
+package distsqlrun
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"math/rand"
+	"os"
+	"sort"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+func TestRocksDBMap(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	tempEngine, err := engine.NewTempEngine(ctx, base.DefaultTestStoreSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tempEngine.Close()
+
+	diskMap, err := NewRocksDBMap(0 /* prefix */, tempEngine)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer diskMap.Close(ctx)
+
+	batchWriter := diskMap.NewBatchWriterCapacity(64)
+	defer batchWriter.Close(ctx)
+
+	rng := rand.New(rand.NewSource(int64(timeutil.Now().UnixNano())))
+
+	numKeysToWrite := 1 << 12
+	keys := make([]string, numKeysToWrite)
+	for i := 0; i < numKeysToWrite; i++ {
+		k := []byte(fmt.Sprintf("%d", rng.Int()))
+		v := []byte(fmt.Sprintf("%d", rng.Int()))
+
+		keys[i] = string(k)
+		// Use batch on every other write.
+		if i%2 == 0 {
+			if err := diskMap.Put(k, v); err != nil {
+				t.Fatal(err)
+			}
+			// Check key was inserted properly.
+			if b, err := diskMap.Get(k); err != nil {
+				t.Fatal(err)
+			} else if !bytes.Equal(b, v) {
+				t.Fatalf("expected %v for value of key %v but got %v", v, k, b)
+			}
+		} else {
+			if err := batchWriter.Put(k, v); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	sort.StringSlice(keys).Sort()
+
+	if err := batchWriter.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	i := diskMap.NewIterator()
+	defer i.Close()
+
+	checkKeyAndPopFirst := func(k []byte) error {
+		if !bytes.Equal([]byte(keys[0]), k) {
+			return fmt.Errorf("expected %v but got %v", []byte(keys[0]), k)
+		}
+		keys = keys[1:]
+		return nil
+	}
+
+	i.Rewind()
+	if ok, err := i.Valid(); err != nil {
+		t.Fatal(err)
+	} else if !ok {
+		t.Fatal("unexpectedly invalid")
+	}
+	lastKey := i.Key()
+	if err := checkKeyAndPopFirst(lastKey); err != nil {
+		t.Fatal(err)
+	}
+	i.Next()
+
+	numKeysRead := 1
+	for ; ; i.Next() {
+		if ok, err := i.Valid(); err != nil {
+			t.Fatal(err)
+		} else if !ok {
+			break
+		}
+		curKey := i.Key()
+		if err := checkKeyAndPopFirst(curKey); err != nil {
+			t.Fatal(err)
+		}
+		if bytes.Compare(curKey, lastKey) < 0 {
+			t.Fatalf("expected keys in sorted order but %v is larger than %v", curKey, lastKey)
+		}
+		lastKey = curKey
+		numKeysRead++
+	}
+	if numKeysRead != numKeysToWrite {
+		t.Fatalf("expected to read %d keys but only read %d", numKeysToWrite, numKeysRead)
+	}
+}
+
+// TestRocksDBMapSandbox verifies that multiple instances of a RocksDBMap
+// initialized with the same RocksDB storage engine cannot read or write
+// another instance's data.
+func TestRocksDBMapSandbox(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	tempEngine, err := engine.NewTempEngine(ctx, base.DefaultTestStoreSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tempEngine.Close()
+
+	if _, err := NewRocksDBMap(math.MaxUint64, tempEngine); err == nil {
+		t.Fatal("expected error when creating map with prefix math.MaxUint64")
+	}
+
+	diskMaps := make([]*RocksDBMap, 3)
+	for i := 0; i < len(diskMaps); i++ {
+		if diskMaps[i], err = NewRocksDBMap(uint64(i) /* prefix */, tempEngine); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Put [0,10) as a key into each diskMap with the value specifying which
+	// diskMap inserted this value.
+	numKeys := 10
+	for i := 0; i < numKeys; i++ {
+		for j := 0; j < len(diskMaps); j++ {
+			if err := diskMaps[j].Put([]byte{byte(i)}, []byte{byte(j)}); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// Verify that an iterator created from a diskMap is constrained to the
+	// diskMap's keyspace and that the keys in the keyspace were all written
+	// by the expected diskMap.
+	t.Run("KeyspaceSandbox", func(t *testing.T) {
+		for j := 0; j < len(diskMaps); j++ {
+			func() {
+				i := diskMaps[j].NewIterator()
+				defer i.Close()
+				numRead := 0
+				for i.Rewind(); ; i.Next() {
+					if ok, err := i.Valid(); err != nil {
+						t.Fatal(err)
+					} else if !ok {
+						break
+					}
+					numRead++
+					if numRead > numKeys {
+						t.Fatal("read too many keys")
+					}
+					if int(i.Value()[0]) != j {
+						t.Fatalf(
+							"key %s in %d's keyspace was clobbered by %d", i.Key(), j, i.Value()[0],
+						)
+					}
+				}
+				if numRead < numKeys {
+					t.Fatalf("only read %d keys in %d's keyspace", numRead, j)
+				}
+			}()
+		}
+	})
+
+	// Verify that a diskMap cleans up its keyspace when closed.
+	t.Run("KeyspaceDelete", func(t *testing.T) {
+		for j := 0; j < len(diskMaps); j++ {
+			diskMaps[j].Close(ctx)
+			numKeysRemaining := 0
+			func() {
+				i := tempEngine.NewIterator(false)
+				defer i.Close()
+				for i.Seek(engine.NilKey); ; i.Next() {
+					if ok, err := i.Valid(); err != nil {
+						t.Fatal(err)
+					} else if !ok {
+						break
+					}
+					if int(i.Value()[0]) == j {
+						t.Fatalf("key %s belonging to %d was not deleted", i.Key(), j)
+					}
+					numKeysRemaining++
+				}
+				expectedKeysRemaining := (len(diskMaps) - 1 - j) * numKeys
+				if numKeysRemaining != expectedKeysRemaining {
+					t.Fatalf(
+						"expected %d keys to remain but counted %d",
+						expectedKeysRemaining,
+						numKeysRemaining,
+					)
+				}
+			}()
+		}
+	})
+}
+
+func BenchmarkRocksDBMapWrite(b *testing.B) {
+	dir, err := ioutil.TempDir("", "BenchmarkRocksDBMapWrite")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			b.Fatal(err)
+		}
+	}()
+	ctx := context.Background()
+	tempEngine, err := engine.NewTempEngine(ctx, base.StoreSpec{Path: dir})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer tempEngine.Close()
+
+	rng := rand.New(rand.NewSource(int64(timeutil.Now().UnixNano())))
+
+	for _, inputSize := range []int{1 << 12, 1 << 14, 1 << 16, 1 << 18, 1 << 20} {
+		b.Run(fmt.Sprintf("InputSize%d", inputSize), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				func() {
+					diskMap, err := NewRocksDBMap(uint64(i) /* prefix */, tempEngine)
+					if err != nil {
+						b.Fatal(err)
+					}
+					defer diskMap.Close(ctx)
+					batchWriter := diskMap.NewBatchWriter()
+					// This Close() flushes writes.
+					defer batchWriter.Close(ctx)
+					for j := 0; j < inputSize; j++ {
+						k := fmt.Sprintf("%d", rng.Int())
+						v := fmt.Sprintf("%d", rng.Int())
+						if err := batchWriter.Put([]byte(k), []byte(v)); err != nil {
+							b.Fatal(err)
+						}
+					}
+				}()
+			}
+		})
+	}
+}
+
+func BenchmarkRocksDBMapIteration(b *testing.B) {
+	dir, err := ioutil.TempDir("", "BenchmarkRocksDBMapIteration")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			b.Fatal(err)
+		}
+	}()
+	ctx := context.Background()
+	tempEngine, err := engine.NewTempEngine(ctx, base.StoreSpec{Path: dir})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer tempEngine.Close()
+
+	diskMap, err := NewRocksDBMap(0 /* prefix */, tempEngine)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer diskMap.Close(context.Background())
+
+	rng := rand.New(rand.NewSource(int64(timeutil.Now().UnixNano())))
+
+	for _, inputSize := range []int{1 << 12, 1 << 14, 1 << 16, 1 << 18, 1 << 20} {
+		for i := 0; i < inputSize; i++ {
+			k := fmt.Sprintf("%d", rng.Int())
+			v := fmt.Sprintf("%d", rng.Int())
+			if err := diskMap.Put([]byte(k), []byte(v)); err != nil {
+				b.Fatal(err)
+			}
+		}
+
+		b.Run(fmt.Sprintf("InputSize%d", inputSize), func(b *testing.B) {
+			for j := 0; j < b.N; j++ {
+				i := diskMap.NewIterator()
+				for i.Rewind(); ; i.Next() {
+					if ok, err := i.Valid(); err != nil {
+						b.Fatal(err)
+					} else if !ok {
+						break
+					}
+					i.Key()
+					i.Value()
+				}
+				i.Close()
+			}
+		})
+	}
+}

--- a/pkg/sql/distsqlrun/disk_row_container.go
+++ b/pkg/sql/distsqlrun/disk_row_container.go
@@ -1,0 +1,244 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Alfonso Subiotto Marqués (alfonso@cockroachlabs.com)
+
+package distsqlrun
+
+import (
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// diskRowContainer is a sortableRowContainer that stores rows on disk according
+// to the ordering specified in diskRowContainer.ordering. The underlying store
+// is a SortedDiskMap so the sorting itself is delegated. Use an iterator
+// created through NewIterator() to read the rows in sorted order.
+type diskRowContainer struct {
+	diskMap SortedDiskMap
+	// bufferedRows buffers writes to the diskMap.
+	bufferedRows  SortedDiskMapBatchWriter
+	scratchKey    []byte
+	scratchVal    []byte
+	scratchEncRow sqlbase.EncDatumRow
+
+	// rowID is used as a key suffix to prevent duplicate rows from overwriting
+	// each other.
+	rowID uint64
+
+	// types is the schema of rows in the container.
+	types []sqlbase.ColumnType
+	// ordering is the order in which rows should be sorted.
+	ordering sqlbase.ColumnOrdering
+	// encodings keeps around the DatumEncoding equivalents of the encoding
+	// directions in ordering to avoid conversions in hot paths.
+	encodings []sqlbase.DatumEncoding
+	// valueIdxs holds the indexes of the columns that we encode as values. The
+	// columns described by ordering will be encoded as keys. See
+	// makeDiskRowContainer() for more encoding specifics.
+	valueIdxs []int
+
+	datumAlloc sqlbase.DatumAlloc
+}
+
+var _ sortableRowContainer = &diskRowContainer{}
+
+// makeDiskRowContainer creates a diskRowContainer with the rows from the passed
+// in rowContainer. Note that makeDiskRowContainer consumes the rows from
+// rowContainer and deletes them so rowContainer cannot be used after creating
+// a diskRowContainer. The caller must still Close() the rowContainer.
+// Arguments:
+// 	- tempStorageID is the ID of the processor that is calling
+// 	  makeDiskRowContainer. It is used as a prefix in the underlying
+// 	  SortedDiskMap to have a private keyspace.
+// 	- types is the schema of rows that will be added to this container.
+// 	- ordering is the output ordering; the order in which rows should be sorted.
+// 	- rowContainer contains the initial set of rows that this diskRowContainer
+// 	  is created with.
+// 	- e is the underlying store that rows are stored on.
+func makeDiskRowContainer(
+	ctx context.Context,
+	tempStorageID uint64,
+	types []sqlbase.ColumnType,
+	ordering sqlbase.ColumnOrdering,
+	rowContainer memRowContainer,
+	e engine.Engine,
+) (diskRowContainer, error) {
+	// Use the tempStorageID as the prefix.
+	diskMap, err := NewRocksDBMap(tempStorageID, e)
+	if err != nil {
+		return diskRowContainer{}, err
+	}
+	d := diskRowContainer{
+		diskMap:       diskMap,
+		types:         types,
+		ordering:      ordering,
+		scratchEncRow: make(sqlbase.EncDatumRow, len(types)),
+	}
+	d.bufferedRows = d.diskMap.NewBatchWriter()
+
+	// The ordering is specified for a subset of the columns. These will be
+	// encoded as a key in the given order according to the given direction so
+	// that the sorting can be delegated to the underlying SortedDiskMap. To
+	// avoid converting encoding.Direction to sqlbase.DatumEncoding we do this
+	// once at initialization and store the conversions in d.encodings.
+	// We encode the other columns as values. The indexes of these columns are
+	// kept around in d.valueIdxs to have them ready in hot paths.
+	// For composite columns that are specified in d.ordering, the Datum is
+	// encoded both in the key for comparison and in the value for decoding.
+	orderingIdxs := make(map[int]struct{})
+	for _, orderInfo := range d.ordering {
+		orderingIdxs[orderInfo.ColIdx] = struct{}{}
+	}
+	d.valueIdxs = make([]int, 0, len(d.types))
+	for i := range d.types {
+		// TODO(asubiotto): A datum of a type for with HasCompositeKeyEncoding
+		// returns true may not necessarily need to be encoded in the value, so
+		// make this more fine-grained. See IsComposite() methods in
+		// pkg/sql/parser/datum.go.
+		if _, ok := orderingIdxs[i]; !ok || sqlbase.HasCompositeKeyEncoding(d.types[i].SemanticType) {
+			d.valueIdxs = append(d.valueIdxs, i)
+		}
+	}
+
+	d.encodings = make([]sqlbase.DatumEncoding, len(d.ordering))
+	for i, orderInfo := range ordering {
+		d.encodings[i] = sqlbase.EncodingDirToDatumEncoding(orderInfo.Direction)
+	}
+
+	i := rowContainer.NewIterator(ctx)
+	defer i.Close()
+
+	for i.Rewind(); ; i.Next() {
+		if ok, err := i.Valid(); err != nil {
+			return diskRowContainer{}, err
+		} else if !ok {
+			break
+		}
+		row, err := i.Row()
+		if err != nil {
+			return diskRowContainer{}, err
+		}
+		if err := d.AddRow(ctx, row); err != nil {
+			return diskRowContainer{}, errors.Wrap(err, "could not add row")
+		}
+	}
+	return d, nil
+}
+
+func (d *diskRowContainer) AddRow(ctx context.Context, row sqlbase.EncDatumRow) error {
+	if len(row) != len(d.types) {
+		log.Fatalf(ctx, "invalid row length %d, expected %d", len(row), len(d.types))
+	}
+
+	for i, orderInfo := range d.ordering {
+		var err error
+		d.scratchKey, err = row[orderInfo.ColIdx].Encode(&d.datumAlloc, d.encodings[i], d.scratchKey)
+		if err != nil {
+			return err
+		}
+	}
+	for _, i := range d.valueIdxs {
+		var err error
+		d.scratchVal, err = row[i].Encode(&d.datumAlloc, sqlbase.DatumEncoding_VALUE, d.scratchVal)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Put a unique row to keep track of duplicates. Note that this will not
+	// mess with key decoding.
+	if err := d.bufferedRows.Put(
+		encoding.EncodeUvarintAscending(d.scratchKey, d.rowID),
+		d.scratchVal,
+	); err != nil {
+		return err
+	}
+	d.scratchKey = d.scratchKey[:0]
+	d.scratchVal = d.scratchVal[:0]
+	d.rowID++
+	return nil
+}
+
+// Sort is a noop because the use of a SortedDiskMap as the underlying store
+// keeps the rows in sorted order.
+func (d *diskRowContainer) Sort() {}
+
+func (d *diskRowContainer) Close(ctx context.Context) {
+	d.bufferedRows.Close(ctx)
+	d.diskMap.Close(ctx)
+}
+
+// keyValToRow decodes a key and a value byte slice stored with AddRow() into
+// a sqlbase.EncDatumRow. The returned EncDatumRow is only valid until the next
+// call to keyValToRow().
+func (d *diskRowContainer) keyValToRow(k []byte, v []byte) (sqlbase.EncDatumRow, error) {
+	for i, orderInfo := range d.ordering {
+		// Types with composite key encodings are decoded from the value.
+		if sqlbase.HasCompositeKeyEncoding(d.types[orderInfo.ColIdx].SemanticType) {
+			// Skip over the encoded key.
+			encLen, err := encoding.PeekLength(k)
+			if err != nil {
+				return nil, err
+			}
+			k = k[encLen:]
+			continue
+		}
+		var err error
+		d.scratchEncRow[orderInfo.ColIdx], k, err = sqlbase.EncDatumFromBuffer(d.types[orderInfo.ColIdx], d.encodings[i], k)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to decode row")
+		}
+	}
+	for _, i := range d.valueIdxs {
+		var err error
+		d.scratchEncRow[i], v, err = sqlbase.EncDatumFromBuffer(d.types[i], sqlbase.DatumEncoding_VALUE, v)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to decode row")
+		}
+	}
+	return d.scratchEncRow, nil
+}
+
+// diskRowIterator iterates over the rows in a diskRowContainer.
+type diskRowIterator struct {
+	rowContainer *diskRowContainer
+	SortedDiskMapIterator
+}
+
+var _ rowIterator = diskRowIterator{}
+
+func (d *diskRowContainer) NewIterator(ctx context.Context) rowIterator {
+	if err := d.bufferedRows.Flush(); err != nil {
+		log.Fatal(ctx, err)
+	}
+	return diskRowIterator{rowContainer: d, SortedDiskMapIterator: d.diskMap.NewIterator()}
+}
+
+// Row returns the current row. The returned sqlbase.EncDatumRow is only valid
+// until the next call to Row().
+func (r diskRowIterator) Row() (sqlbase.EncDatumRow, error) {
+	if ok, err := r.Valid(); err != nil {
+		return nil, errors.Wrap(err, "unable to check row validity")
+	} else if !ok {
+		return nil, errors.New("invalid row")
+	}
+
+	return r.rowContainer.keyValToRow(r.Key(), r.Value())
+}

--- a/pkg/sql/distsqlrun/disk_row_container_test.go
+++ b/pkg/sql/distsqlrun/disk_row_container_test.go
@@ -1,0 +1,255 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Alfonso Subiotto Marques (alfonso@cockroachlabs.com)
+
+package distsqlrun
+
+import (
+	"math/rand"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// compareRows compares l and r according to a column ordering. Returns -1 if
+// l < r, 0 if l == r, and 1 if l > r. If an error is returned the int returned
+// is invalid. Note that the comparison is only performed on the ordering
+// columns.
+func compareRows(
+	l, r sqlbase.EncDatumRow,
+	e *parser.EvalContext,
+	d *sqlbase.DatumAlloc,
+	ordering sqlbase.ColumnOrdering,
+) (int, error) {
+	for _, orderInfo := range ordering {
+		cmp, err := l[orderInfo.ColIdx].Compare(d, e, &r[orderInfo.ColIdx])
+		if err != nil {
+			return 0, err
+		}
+		if cmp != 0 {
+			if orderInfo.Direction == encoding.Descending {
+				cmp = -cmp
+			}
+			return cmp, nil
+		}
+	}
+	return 0, nil
+}
+
+func TestDiskRowContainer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	tempEngine, err := engine.NewTempEngine(ctx, base.DefaultTestStoreSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tempEngine.Close()
+
+	// These orderings assume at least 4 columns.
+	numCols := 4
+	orderings := []sqlbase.ColumnOrdering{
+		{
+			sqlbase.ColumnOrderInfo{
+				ColIdx:    0,
+				Direction: encoding.Ascending,
+			},
+		},
+		{
+			sqlbase.ColumnOrderInfo{
+				ColIdx:    0,
+				Direction: encoding.Descending,
+			},
+		},
+		{
+			sqlbase.ColumnOrderInfo{
+				ColIdx:    3,
+				Direction: encoding.Ascending,
+			},
+			sqlbase.ColumnOrderInfo{
+				ColIdx:    1,
+				Direction: encoding.Descending,
+			},
+			sqlbase.ColumnOrderInfo{
+				ColIdx:    2,
+				Direction: encoding.Ascending,
+			},
+		},
+	}
+
+	rng := rand.New(rand.NewSource(int64(timeutil.Now().UnixNano())))
+
+	evalCtx := parser.MakeTestingEvalContext()
+	t.Run("EncodeDecode", func(t *testing.T) {
+		for i := 0; i < 100; i++ {
+			// Test with different orderings so that we have a mix of key and
+			// value encodings.
+			for _, ordering := range orderings {
+				types := make([]sqlbase.ColumnType, numCols)
+				for i := range types {
+					types[i] = sqlbase.RandColumnType(rng)
+				}
+				row := sqlbase.EncDatumRow(sqlbase.RandEncDatumSliceOfTypes(rng, types))
+				func() {
+					d, err := makeDiskRowContainer(
+						ctx, 0 /* tempStorageID */, types, ordering, memRowContainer{}, tempEngine,
+					)
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer d.Close(ctx)
+					if err := d.AddRow(ctx, row); err != nil {
+						t.Fatal(err)
+					}
+
+					i := d.NewIterator(ctx)
+					defer i.Close()
+					i.Rewind()
+					if ok, err := i.Valid(); err != nil {
+						t.Fatal(err)
+					} else if !ok {
+						t.Fatal("unexpectedly invalid")
+					}
+					readRow := make(sqlbase.EncDatumRow, len(row))
+
+					temp, err := i.Row()
+					if err != nil {
+						t.Fatal(err)
+					}
+					copy(readRow, temp)
+
+					// Ensure the datum fields are set and no errors occur when
+					// decoding.
+					for _, encDatum := range readRow {
+						if err := encDatum.EnsureDecoded(&d.datumAlloc); err != nil {
+							t.Fatal(err)
+						}
+					}
+
+					// Check equality of the row we wrote and the row we read.
+					for i := range row {
+						if cmp, err := readRow[i].Compare(&d.datumAlloc, &evalCtx, &row[i]); err != nil {
+							t.Fatal(err)
+						} else if cmp != 0 {
+							t.Fatalf("encoded %s but decoded %s", row, readRow)
+						}
+					}
+				}()
+			}
+		}
+	})
+
+	t.Run("SortedOrder", func(t *testing.T) {
+		numRows := 1024
+		for _, ordering := range orderings {
+			// numRows rows with numCols columns of the same random type.
+			rows := sqlbase.RandEncDatumRows(rng, numRows, numCols)
+			types := make([]sqlbase.ColumnType, len(rows[0]))
+			for i := range types {
+				types[i] = rows[0][i].Type
+			}
+			func() {
+				// Make the diskRowContainer with half of these rows and insert
+				// the other half normally.
+				memoryContainer := makeRowContainer(ordering, types, &evalCtx)
+				defer memoryContainer.Close(ctx)
+				midIdx := len(rows) / 2
+				for i := 0; i < midIdx; i++ {
+					if err := memoryContainer.AddRow(ctx, rows[i]); err != nil {
+						t.Fatal(err)
+					}
+				}
+
+				d, err := makeDiskRowContainer(
+					ctx,
+					0, /* tempStorageID */
+					types,
+					ordering,
+					memoryContainer,
+					tempEngine,
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer d.Close(ctx)
+				for i := midIdx; i < len(rows); i++ {
+					if err := d.AddRow(ctx, rows[i]); err != nil {
+						t.Fatal(err)
+					}
+				}
+
+				// Make another row container that stores all the rows then sort
+				// it to compare equality.
+				sortedRows := makeRowContainer(ordering, types, &evalCtx)
+				defer sortedRows.Close(ctx)
+				for _, row := range rows {
+					if err := sortedRows.AddRow(ctx, row); err != nil {
+						t.Fatal(err)
+					}
+				}
+				sortedRows.Sort()
+
+				i := d.NewIterator(ctx)
+				defer i.Close()
+
+				numKeysRead := 0
+				for i.Rewind(); ; i.Next() {
+					if ok, err := i.Valid(); err != nil {
+						t.Fatal(err)
+					} else if !ok {
+						break
+					}
+					row, err := i.Row()
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					// Ensure datum fields are set and no errors occur when
+					// decoding.
+					for _, encDatum := range row {
+						if err := encDatum.EnsureDecoded(&d.datumAlloc); err != nil {
+							t.Fatal(err)
+						}
+					}
+
+					// Check sorted order.
+					if cmp, err := compareRows(
+						sortedRows.EncRow(numKeysRead), row, &evalCtx, &d.datumAlloc, ordering,
+					); err != nil {
+						t.Fatal(err)
+					} else if cmp != 0 {
+						t.Fatalf(
+							"expected %s to be equal to %s",
+							row,
+							sortedRows.EncRow(numKeysRead),
+						)
+					}
+					numKeysRead++
+				}
+				if numKeysRead != numRows {
+					t.Fatalf("expected to read %d keys but only read %d", numRows, numKeysRead)
+				}
+			}()
+		}
+	})
+}

--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -79,7 +79,7 @@ type hashJoiner struct {
 	// We read a portion of both streams, in the hope that one is small. One of
 	// the containers will contain the entire "stored" stream, the other just the
 	// start of the other stream.
-	rows [2]rowContainer
+	rows [2]memRowContainer
 
 	// storedSide is set by the initial buffering phase and indicates which stream
 	// we store fully and build the hashtable from.

--- a/pkg/sql/distsqlrun/row_container.go
+++ b/pkg/sql/distsqlrun/row_container.go
@@ -27,10 +27,58 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
-// rowContainer is the wrapper around sqlbase.RowContainer that provides more
+// sortableRowContainer is a container used to store rows and optionally sort
+// these.
+type sortableRowContainer interface {
+	AddRow(context.Context, sqlbase.EncDatumRow) error
+	// Sort sorts the rows according to an ordering specified at initialization.
+	Sort()
+	// NewIterator returns a rowIterator that can be used to iterate over
+	// the rows.
+	NewIterator(context.Context) rowIterator
+
+	// Close frees up resources held by the sortableRowContainer.
+	Close(context.Context)
+}
+
+// rowIterator is a simple iterator used to iterate over sqlbase.EncDatumRows.
+// Example use:
+// 	var i rowIterator
+// 	for i.Rewind(); ; i.Next() {
+// 		if ok, err := i.Valid(); err != nil {
+// 			// Handle error.
+// 		} else if !ok {
+//			break
+// 		}
+//		row, err := i.Row()
+//		if err != nil {
+//			// Handle error.
+//		}
+//		// Do something.
+// 	}
+//
+type rowIterator interface {
+	// Rewind seeks to the first row.
+	Rewind()
+	// Valid must be called after any call to Rewind() or Next(). It returns
+	// (true, nil) if the iterator points to a valid row and (false, nil) if the
+	// iterator has moved past the last row.
+	// If an error has occurred, the returned bool is invalid.
+	Valid() (bool, error)
+	// Next advances the iterator to the next row in the iteration.
+	Next()
+	// Row returns the current row. The returned row is only valid until the
+	// next call to Rewind() or Next().
+	Row() (sqlbase.EncDatumRow, error)
+
+	// Close frees up resources held by the iterator.
+	Close()
+}
+
+// memRowContainer is the wrapper around sqlbase.RowContainer that provides more
 // functionality, especially around converting to/from EncDatumRows and
 // facilitating sorting.
-type rowContainer struct {
+type memRowContainer struct {
 	sqlbase.RowContainer
 	types         []sqlbase.ColumnType
 	invertSorting bool // Inverts the sorting predicate.
@@ -43,13 +91,14 @@ type rowContainer struct {
 	datumAlloc sqlbase.DatumAlloc
 }
 
-var _ heap.Interface = &rowContainer{}
+var _ heap.Interface = &memRowContainer{}
+var _ sortableRowContainer = &memRowContainer{}
 
 func makeRowContainer(
 	ordering sqlbase.ColumnOrdering, types []sqlbase.ColumnType, evalCtx *parser.EvalContext,
-) rowContainer {
+) memRowContainer {
 	acc := evalCtx.Mon.MakeBoundAccount()
-	return rowContainer{
+	return memRowContainer{
 		RowContainer:  sqlbase.MakeRowContainer(acc, sqlbase.ColTypeInfoFromColTypes(types), 0),
 		types:         types,
 		ordering:      ordering,
@@ -60,7 +109,7 @@ func makeRowContainer(
 }
 
 // Less is part of heap.Interface and is only meant to be used internally.
-func (sv *rowContainer) Less(i, j int) bool {
+func (sv *memRowContainer) Less(i, j int) bool {
 	cmp := sqlbase.CompareDatums(sv.ordering, sv.evalCtx, sv.At(i), sv.At(j))
 	if sv.invertSorting {
 		cmp = -cmp
@@ -70,7 +119,7 @@ func (sv *rowContainer) Less(i, j int) bool {
 
 // EncRow returns the idx-th row as an EncDatumRow. The slice itself is reused
 // so it is only valid until the next call to EncRow.
-func (sv *rowContainer) EncRow(idx int) sqlbase.EncDatumRow {
+func (sv *memRowContainer) EncRow(idx int) sqlbase.EncDatumRow {
 	datums := sv.At(idx)
 	for i, d := range datums {
 		sv.scratchEncRow[i] = sqlbase.DatumToEncDatum(sv.types[i], d)
@@ -79,7 +128,7 @@ func (sv *rowContainer) EncRow(idx int) sqlbase.EncDatumRow {
 }
 
 // AddRow adds a row to the container.
-func (sv *rowContainer) AddRow(ctx context.Context, row sqlbase.EncDatumRow) error {
+func (sv *memRowContainer) AddRow(ctx context.Context, row sqlbase.EncDatumRow) error {
 	if len(row) != len(sv.types) {
 		log.Fatalf(ctx, "invalid row length %d, expected %d", len(row), len(sv.types))
 	}
@@ -94,20 +143,20 @@ func (sv *rowContainer) AddRow(ctx context.Context, row sqlbase.EncDatumRow) err
 	return err
 }
 
-func (sv *rowContainer) Sort() {
+func (sv *memRowContainer) Sort() {
 	sv.invertSorting = false
 	sort.Sort(sv)
 }
 
 // Push is part of heap.Interface.
-func (sv *rowContainer) Push(_ interface{}) { panic("unimplemented") }
+func (sv *memRowContainer) Push(_ interface{}) { panic("unimplemented") }
 
 // Pop is part of heap.Interface.
-func (sv *rowContainer) Pop() interface{} { panic("unimplemented") }
+func (sv *memRowContainer) Pop() interface{} { panic("unimplemented") }
 
 // MaybeReplaceMax replaces the maximum element with the given row, if it is smaller.
 // Assumes InitMaxHeap was called.
-func (sv *rowContainer) MaybeReplaceMax(row sqlbase.EncDatumRow) error {
+func (sv *memRowContainer) MaybeReplaceMax(row sqlbase.EncDatumRow) error {
 	max := sv.At(0)
 	cmp, err := row.CompareToDatums(&sv.datumAlloc, sv.ordering, sv.evalCtx, max)
 	if err != nil {
@@ -127,7 +176,45 @@ func (sv *rowContainer) MaybeReplaceMax(row sqlbase.EncDatumRow) error {
 }
 
 // InitMaxHeap rearranges the rows in the rowContainer into a Max-Heap.
-func (sv *rowContainer) InitMaxHeap() {
+func (sv *memRowContainer) InitMaxHeap() {
 	sv.invertSorting = true
 	heap.Init(sv)
 }
+
+// memRowIterator is a rowIterator that iterates over a memRowContainer. This
+// iterator doesn't iterate over a snapshot of memRowContainer and deletes rows
+// as soon as they are iterated over to free up memory eagerly.
+type memRowIterator struct {
+	*memRowContainer
+}
+
+var _ rowIterator = memRowIterator{}
+
+// NewIterator returns an iterator that can be used to iterate over a
+// memRowContainer. Note that this iterator doesn't iterate over a snapshot
+// of memRowContainer and that it deletes rows as soon as they are iterated
+// over.
+func (sv *memRowContainer) NewIterator(_ context.Context) rowIterator {
+	return memRowIterator{memRowContainer: sv}
+}
+
+// Rewind implements the rowIterator interface.
+func (i memRowIterator) Rewind() {}
+
+// Valid implements the rowIterator interface.
+func (i memRowIterator) Valid() (bool, error) {
+	return i.Len() > 0, nil
+}
+
+// Next implements the rowIterator interface.
+func (i memRowIterator) Next() {
+	i.PopFirst()
+}
+
+// Row implements the rowIterator interface.
+func (i memRowIterator) Row() (sqlbase.EncDatumRow, error) {
+	return i.EncRow(0), nil
+}
+
+// Close implements the rowIterator interface.
+func (i memRowIterator) Close() {}

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/mon"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -70,6 +71,12 @@ const Version = 4
 // MinAcceptedVersion is the oldest version that the server is
 // compatible with; see above.
 const MinAcceptedVersion = 4
+
+var distSQLUseTempStorage = settings.RegisterBoolSetting(
+	"sql.defaults.distsql.tempstorage",
+	"set to true to enable use of disk for larger distributed sql queries",
+	false,
+)
 
 var noteworthyMemoryUsageBytes = envutil.EnvOrDefaultInt64("COCKROACH_NOTEWORTHY_DISTSQL_MEMORY_USAGE", 10*1024)
 
@@ -127,7 +134,7 @@ type ServerImpl struct {
 	// gracefully OOM if the working set gets too large.
 	tempStorage engine.Engine
 	// tempStorageIDGenerator is used to generate unique prefixes per processor so that
-	// each processor uses a nonoverlapping part of the localStorage keyspace.
+	// each processor uses a nonoverlapping part of the temp keyspace.
 	tempStorageIDGenerator TempStorageIDGenerator
 }
 

--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -21,8 +21,10 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/mon"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
@@ -44,6 +46,9 @@ type sorter struct {
 	// procOutputHelper. 0 if the sorter should sort and push all the rows from
 	// the input.
 	count int64
+	// testingKnobMemLimit is used in testing to set a limit on the memory that
+	// should be used by the sortAllStrategy. Minimum value to enable is 1.
+	testingKnobMemLimit int64
 	// tempStorage is used to store rows when the working set is larger than can
 	// be stored in memory.
 	tempStorage engine.Engine
@@ -83,6 +88,8 @@ func newSorter(
 	return s, nil
 }
 
+var workMem = envutil.EnvOrDefaultInt64("COCKROACH_WORK_MEM", 64*1024*1024 /* 64MB */)
+
 // Run is part of the processor interface.
 func (s *sorter) Run(ctx context.Context, wg *sync.WaitGroup) {
 	if wg != nil {
@@ -98,7 +105,31 @@ func (s *sorter) Run(ctx context.Context, wg *sync.WaitGroup) {
 		defer log.Infof(ctx, "exiting sorter run")
 	}
 
-	sv := makeRowContainer(s.ordering, s.rawInput.Types(), &s.flowCtx.evalCtx)
+	var sv memRowContainer
+	// Enable fall back to disk if the cluster setting is set or a memory limit
+	// has been set through testing.
+	useTempStorage := distSQLUseTempStorage.Get() || s.testingKnobMemLimit > 0
+	if s.matchLen == 0 && s.count == 0 && useTempStorage {
+		// We will use the sortAllStrategy in this case and potentially fall
+		// back to disk.
+		// Limit the memory use by creating a child monitor with a hard limit.
+		// The strategy will overflow to disk if this limit is not enough.
+		limit := s.testingKnobMemLimit
+		if limit <= 0 {
+			limit = workMem
+		}
+		limitedMon := mon.MakeMonitorInheritWithLimit(
+			"sortall-limited", limit, s.flowCtx.evalCtx.Mon,
+		)
+		limitedMon.Start(ctx, s.flowCtx.evalCtx.Mon, mon.BoundAccount{})
+		defer limitedMon.Stop(ctx)
+
+		evalCtx := s.flowCtx.evalCtx
+		evalCtx.Mon = &limitedMon
+		sv = makeRowContainer(s.ordering, s.rawInput.Types(), &evalCtx)
+	} else {
+		sv = makeRowContainer(s.ordering, s.rawInput.Types(), &s.flowCtx.evalCtx)
+	}
 	// Construct the optimal sorterStrategy.
 	var ss sorterStrategy
 	if s.matchLen == 0 {
@@ -107,7 +138,7 @@ func (s *sorter) Run(ctx context.Context, wg *sync.WaitGroup) {
 			// optimizations are possible so we simply load all rows into memory and
 			// sort all values in-place. It has a worst-case time complexity of
 			// O(n*log(n)) and a worst-case space complexity of O(n).
-			ss = newSortAllStrategy(sv)
+			ss = newSortAllStrategy(sv, useTempStorage)
 		} else {
 			// No specified ordering match length but specified limit; we can optimize
 			// our sort procedure by maintaining a max-heap populated with only the

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -68,6 +68,7 @@ server.failed_reservation_timeout                  5s             d     the amou
 server.remote_debugging.mode                       local          s     set to enable remote debugging, localhost-only or disable (any, local, off)
 server.time_until_store_dead                       5m0s           d     the time after which if there is no new gossiped information about a store, it is considered dead
 sql.defaults.distsql                               1              e     Default distributed SQL execution mode [off = 0, auto = 1, on = 2]
+sql.defaults.distsql.tempstorage                   false          b     set to true to enable use of disk for larger distributed sql queries
 sql.metrics.statement_details.dump_to_logs         false          b     dump collected statement statistics to node logs when periodically cleared
 sql.metrics.statement_details.enabled              true           b     collect per-statement query statistics
 sql.metrics.statement_details.threshold            0s             d     minmum execution time to cause statics to be collected

--- a/pkg/sql/mon/mem_usage_test.go
+++ b/pkg/sql/mon/mem_usage_test.go
@@ -299,5 +299,17 @@ func TestMemoryMonitor(t *testing.T) {
 		t.Fatalf("incorrect current allocation: got %d, expected %d", m.mu.curAllocated, 0)
 	}
 
+	limitedMonitor := MakeMonitorWithLimit("testlimit", 10, nil, nil, 1, 1000)
+	limitedMonitor.Start(ctx, &m, BoundAccount{})
+
+	if err := limitedMonitor.reserveMemory(ctx, 10); err != nil {
+		t.Fatalf("limited monitor refused small allocation: %v", err)
+	}
+	if err := limitedMonitor.reserveMemory(ctx, 1); err == nil {
+		t.Fatal("limited monitor allowed allocation over limit")
+	}
+	limitedMonitor.releaseMemory(ctx, 10)
+
+	limitedMonitor.Stop(ctx)
 	m.Stop(ctx)
 }

--- a/pkg/sql/sqlbase/encoded_datum.go
+++ b/pkg/sql/sqlbase/encoded_datum.go
@@ -25,6 +25,19 @@ import (
 	"github.com/pkg/errors"
 )
 
+// EncodingDirToDatumEncoding returns an equivalent DatumEncoding for the given
+// encoding direction.
+func EncodingDirToDatumEncoding(dir encoding.Direction) DatumEncoding {
+	switch dir {
+	case encoding.Ascending:
+		return DatumEncoding_ASCENDING_KEY
+	case encoding.Descending:
+		return DatumEncoding_DESCENDING_KEY
+	default:
+		panic(fmt.Sprintf("invalid encoding direction: %d", dir))
+	}
+}
+
 // EncDatum represents a datum that is "backed" by an encoding and/or by a
 // parser.Datum. It allows "passing through" a Datum without decoding and
 // reencoding.

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -190,8 +190,18 @@ func RandEncDatum(rng *rand.Rand) EncDatum {
 // type.
 func RandEncDatumSlice(rng *rand.Rand, numVals int) []EncDatum {
 	typ := RandColumnType(rng)
-	vals := make([]EncDatum, numVals)
-	for i := range vals {
+	types := make([]ColumnType, numVals)
+	for i := range types {
+		types[i] = typ
+	}
+	return RandEncDatumSliceOfTypes(rng, types)
+}
+
+// RandEncDatumSliceOfTypes generates a slice of random EncDatum values for the
+// corresponding type in types.
+func RandEncDatumSliceOfTypes(rng *rand.Rand, types []ColumnType) []EncDatum {
+	vals := make([]EncDatum, len(types))
+	for i, typ := range types {
 		vals[i] = DatumToEncDatum(typ, RandDatum(rng, typ, true))
 	}
 	return vals
@@ -203,6 +213,26 @@ func RandEncDatumSlices(rng *rand.Rand, numSets, numValsPerSet int) [][]EncDatum
 	vals := make([][]EncDatum, numSets)
 	for i := range vals {
 		vals[i] = RandEncDatumSlice(rng, numValsPerSet)
+	}
+	return vals
+}
+
+// RandEncDatumRows generates EncDatumRows where all rows follow the same random
+// []ColumnType structure.
+func RandEncDatumRows(rng *rand.Rand, numSets, numValsPerSet int) EncDatumRows {
+	types := make([]ColumnType, numValsPerSet)
+	for i := range types {
+		types[i] = RandColumnType(rng)
+	}
+	return RandEncDatumRowsOfTypes(rng, numSets, types)
+}
+
+// RandEncDatumRowsOfTypes generates EncDatumRows, each row with values of the
+// corresponding type in types.
+func RandEncDatumRowsOfTypes(rng *rand.Rand, numSets int, types []ColumnType) EncDatumRows {
+	vals := make(EncDatumRows, numSets)
+	for i := range vals {
+		vals[i] = RandEncDatumSliceOfTypes(rng, types)
 	}
 	return vals
 }


### PR DESCRIPTION
This PR consists of three commits of which only the last two should be reviewed on this PR. Adding a RocksDB instance for DistSQL that can be reviewed here: #16716.

This is a first step in tackling the issue raised in #15206. The next steps to be taken are outlined in #16718.

There are some changes and additions that I am working on: reusing the rocksDB instance creation code in tests and setting a constant limit on the memory used by the sortAllStrategy in the sorter processor.

cc @arjunravinarayan 