### PR TITLE
sql: automatically retry the first batch after a BEGIN

### DIFF
--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -432,6 +432,8 @@ func (c *cliState) refreshTransactionStatus() {
 	case sql.RestartWait.String():
 		c.lastKnownTxnStatus = " RETRY"
 	case sql.Open.String():
+		// The state FirstBatch is reported by the server as Open, so no need to
+		// handle it here.
 		c.lastKnownTxnStatus = "  OPEN"
 	}
 }

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -689,7 +689,7 @@ func (e *Executor) execParsed(
 	for len(stmts) > 0 {
 		// Each iteration consumes a transaction's worth of statements.
 
-		inTxn := txnState.State != NoTxn
+		inTxn := txnState.State() != NoTxn
 		execOpt := client.TxnExecOptions{
 			AssignTimestampImmediately: true,
 		}
@@ -736,19 +736,19 @@ func (e *Executor) execParsed(
 			txnState.autoRetry = false
 		}
 		execOpt.AutoRetry = txnState.autoRetry
-		if txnState.State == NoTxn {
+		if txnState.State() == NoTxn {
 			panic("we failed to initialize a txn")
 		}
 		// Now actually run some statements.
 		var remainingStmts StatementList
 		var results []Result
-		origState := txnState.State
+		origState := txnState.State()
 
 		// Track if we are retrying this query, so that we do not double count.
 		automaticRetryCount := 0
 		txnClosure := func(ctx context.Context, txn *client.Txn, opt *client.TxnExecOptions) error {
 			defer func() { automaticRetryCount++ }()
-			if txnState.State == Open && txnState.mu.txn != txn {
+			if txnState.State() == Open && txnState.mu.txn != txn {
 				panic(fmt.Sprintf("closure wasn't called in the txn we set up for it."+
 					"\ntxnState.mu.txn:%+v\ntxn:%+v\ntxnState:%+v", txnState.mu.txn, txn, txnState))
 			}
@@ -771,7 +771,7 @@ func (e *Executor) execParsed(
 				avoidCachedDescriptors, automaticRetryCount)
 
 			// TODO(andrei): Until #7881 fixed.
-			if err == nil && txnState.State == Aborted {
+			if err == nil && txnState.State() == Aborted {
 				doWarn := true
 				if len(stmtsToExec) > 0 {
 					if _, ok := stmtsToExec[0].AST.(*parser.ShowTransactionStatus); ok {
@@ -835,13 +835,13 @@ func (e *Executor) execParsed(
 			if _, retryable := err.(*roachpb.HandledRetryableTxnError); !retryable {
 				log.Fatalf(session.Ctx(), "got a non-retryable error but the KV "+
 					"transaction is not finalized. TxnState: %s, err: %s\n"+
-					"err:%+v\n\ntxn: %s", txnState.State, err, err, txnState.mu.txn.Proto())
+					"err:%+v\n\ntxn: %s", txnState.State(), err, err, txnState.mu.txn.Proto())
 			}
 		}
 
 		res.ResultList = append(res.ResultList, results...)
 		// Now make sense of the state we got into and update txnState.
-		if (txnState.State == RestartWait || txnState.State == Aborted) &&
+		if (txnState.State() == RestartWait || txnState.State() == Aborted) &&
 			txnState.commitSeen {
 			// A COMMIT got an error (retryable or not). Too bad, this txn is toast.
 			// After we return a result for COMMIT (with the COMMIT pgwire tag), the
@@ -857,7 +857,7 @@ func (e *Executor) execParsed(
 		}
 
 		// If we're no longer in a transaction, finish the trace.
-		if txnState.State == NoTxn {
+		if txnState.State() == NoTxn {
 			txnState.finishSQLTxn(session)
 		}
 
@@ -880,7 +880,7 @@ func (e *Executor) execParsed(
 		// If the txn is in any state but Open, exec the schema changes. They'll
 		// short-circuit themselves if the mutation that queued them has been
 		// rolled back from the table descriptor.
-		if txnState.State != Open {
+		if txnState.State() != Open {
 			// Verify that metadata callback eventually succeeds, if one was
 			// set.
 			if e.cfg.TestingKnobs.WaitForGossipUpdate {
@@ -953,7 +953,7 @@ func runTxnAttempt(
 	// statements are still executing and reading from the state. This
 	// means that no synchronization is necessary to prevent data races.
 	if automaticRetryCount > 0 {
-		session.TxnState.State = origState
+		session.TxnState.SetState(origState)
 		session.TxnState.commitSeen = false
 	}
 
@@ -1011,7 +1011,7 @@ func (e *Executor) execStmtsInCurrentTxn(
 	var results []Result
 
 	txnState := &session.TxnState
-	if txnState.State == NoTxn {
+	if txnState.State() == NoTxn {
 		panic("execStmtsInCurrentTransaction called outside of a txn")
 	}
 
@@ -1044,7 +1044,7 @@ func (e *Executor) execStmtsInCurrentTxn(
 		if _, ok := stmt.AST.(*parser.ShowTransactionStatus); ok {
 			res, err = runShowTransactionState(session)
 		} else {
-			switch txnState.State {
+			switch txnState.State() {
 			case Open:
 				res, err = e.execStmtInOpenTxn(
 					session, stmt, pinfo, txnBeginning && (i == 0), /* firstInTxn */
@@ -1054,7 +1054,7 @@ func (e *Executor) execStmtsInCurrentTxn(
 			case CommitWait:
 				res, err = e.execStmtInCommitWaitTxn(session, stmt)
 			default:
-				panic(fmt.Sprintf("unexpected txn state: %s", txnState.State))
+				panic(fmt.Sprintf("unexpected txn state: %s", txnState.State()))
 			}
 			if (e.cfg.TestingKnobs.CheckStmtStringChange && false) ||
 				(e.cfg.TestingKnobs.StatementFilter != nil) {
@@ -1074,7 +1074,7 @@ func (e *Executor) execStmtsInCurrentTxn(
 			// protocol doesn't let you return results after an error.
 			return results, nil, err
 		}
-		if txnState.State == NoTxn {
+		if txnState.State() == NoTxn {
 			// If the transaction is done, return the remaining statements to
 			// be executed as a different group.
 			return results, stmts[i+1:], nil
@@ -1086,7 +1086,7 @@ func (e *Executor) execStmtsInCurrentTxn(
 
 // getTransactionState retrieves a text representation of the given state.
 func getTransactionState(txnState *txnState) string {
-	state := txnState.State
+	state := txnState.State()
 	if txnState.implicitTxn {
 		state = NoTxn
 	}
@@ -1119,13 +1119,13 @@ func runShowTransactionState(session *Session) (Result, error) {
 //   allowing it to be retried.
 func (e *Executor) execStmtInAbortedTxn(session *Session, stmt Statement) (Result, error) {
 	txnState := &session.TxnState
-	if txnState.State != Aborted && txnState.State != RestartWait {
+	if txnState.State() != Aborted && txnState.State() != RestartWait {
 		panic("execStmtInAbortedTxn called outside of an aborted txn")
 	}
 	// TODO(andrei/cuongdo): Figure out what statements to count here.
 	switch s := stmt.AST.(type) {
 	case *parser.CommitTransaction, *parser.RollbackTransaction:
-		if txnState.State == RestartWait {
+		if txnState.State() == RestartWait {
 			return rollbackSQLTransaction(txnState), nil
 		}
 		// Reset the state to allow new transactions to start.
@@ -1148,22 +1148,22 @@ func (e *Executor) execStmtInAbortedTxn(session *Session, stmt Statement) (Resul
 			panic("unreachable")
 		}
 		if err := parser.ValidateRestartCheckpoint(spName); err != nil {
-			if txnState.State == RestartWait {
+			if txnState.State() == RestartWait {
 				txnState.updateStateAndCleanupOnErr(err, e)
 			}
 			return Result{}, err
 		}
 		if !txnState.retryIntent {
 			err := fmt.Errorf("SAVEPOINT %s has not been used", parser.RestartSavepointName)
-			if txnState.State == RestartWait {
+			if txnState.State() == RestartWait {
 				txnState.updateStateAndCleanupOnErr(err, e)
 			}
 			return Result{}, err
 		}
 
-		if txnState.State == RestartWait {
+		if txnState.State() == RestartWait {
 			// Reset the state. Txn is Open again.
-			txnState.State = Open
+			txnState.SetState(Open)
 		} else {
 			// We accept ROLLBACK TO SAVEPOINT even after non-retryable errors to make
 			// it easy for client libraries that want to indiscriminately issue
@@ -1182,7 +1182,7 @@ func (e *Executor) execStmtInAbortedTxn(session *Session, stmt Statement) (Resul
 		// TODO(andrei/cdo): add a counter for user-directed retries.
 		return Result{}, nil
 	default:
-		if txnState.State == RestartWait {
+		if txnState.State() == RestartWait {
 			err := sqlbase.NewTransactionAbortedError(
 				"Expected \"ROLLBACK TO SAVEPOINT COCKROACH_RESTART\"" /* customMsg */)
 			// If we were waiting for a restart, but the client failed to perform it,
@@ -1202,7 +1202,7 @@ func (e *Executor) execStmtInAbortedTxn(session *Session, stmt Statement) (Resul
 // Everything but COMMIT/ROLLBACK causes errors. ROLLBACK is treated like COMMIT.
 func (e *Executor) execStmtInCommitWaitTxn(session *Session, stmt Statement) (Result, error) {
 	txnState := &session.TxnState
-	if txnState.State != CommitWait {
+	if txnState.State() != CommitWait {
 		panic("execStmtInCommitWaitTxn called outside of an aborted txn")
 	}
 	e.updateStmtCounts(stmt)
@@ -1261,7 +1261,7 @@ func (e *Executor) execStmtInOpenTxn(
 	automaticRetryCount int,
 ) (_ Result, err error) {
 	txnState := &session.TxnState
-	if txnState.State != Open {
+	if txnState.State() != Open {
 		panic("execStmtInOpenTxn called outside of an open txn")
 	}
 
@@ -1274,8 +1274,8 @@ func (e *Executor) execStmtInOpenTxn(
 
 	defer func() {
 		if err != nil {
-			if txnState.State != Open {
-				panic(fmt.Sprintf("unexpected txnState when cleaning up: %v", txnState.State))
+			if txnState.State() != Open {
+				panic(fmt.Sprintf("unexpected txnState when cleaning up: %v", txnState.State()))
 			}
 			txnState.updateStateAndCleanupOnErr(err, e)
 		}
@@ -1455,9 +1455,9 @@ func stmtAllowedInImplicitTxn(stmt Statement) bool {
 
 // rollbackSQLTransaction rolls back a transaction. All errors are swallowed.
 func rollbackSQLTransaction(txnState *txnState) Result {
-	if txnState.State != Open && txnState.State != RestartWait {
+	if txnState.State() != Open && txnState.State() != RestartWait {
 		panic(fmt.Sprintf("rollbackSQLTransaction called on txn in wrong state: %s (txn: %s)",
-			txnState.State, txnState.mu.txn.Proto()))
+			txnState.State(), txnState.mu.txn.Proto()))
 	}
 	err := txnState.mu.txn.Rollback(txnState.Ctx)
 	result := Result{PGTag: (*parser.RollbackTransaction)(nil).StatementTag()}
@@ -1479,7 +1479,7 @@ const (
 
 // commitSqlTransaction commits a transaction.
 func commitSQLTransaction(txnState *txnState, commitType commitType) (Result, error) {
-	if txnState.State != Open {
+	if txnState.State() != Open {
 		panic(fmt.Sprintf("commitSqlTransaction called on non-open txn: %+v", txnState.mu.txn))
 	}
 	if commitType == commit {

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -687,7 +687,8 @@ func (e *Executor) execParsed(
 	}
 
 	for len(stmts) > 0 {
-		// Each iteration consumes a transaction's worth of statements.
+		// Each iteration consumes a transaction's worth of statements. Any error
+		// that is encountered resets stmts.
 
 		inTxn := txnState.State() != NoTxn
 		execOpt := client.TxnExecOptions{
@@ -704,7 +705,7 @@ func (e *Executor) execParsed(
 		// (i.e. the next statements we're going to see are the first statements in
 		// a transaction).
 		if !inTxn {
-			// Detect implicit transactions.
+			// Detect implicit transactions - they need to be autocommitted.
 			if _, isBegin := stmts[0].AST.(*parser.BeginTransaction); !isBegin {
 				execOpt.AutoCommit = true
 				stmtsToExec = stmtsToExec[:1]
@@ -733,7 +734,8 @@ func (e *Executor) execParsed(
 				roachpb.NormalUserPriority,
 			)
 		} else {
-			txnState.autoRetry = false
+			// If we are in a txn, the first batch get auto-retried.
+			txnState.autoRetry = txnState.State() == FirstBatch
 		}
 		execOpt.AutoRetry = txnState.autoRetry
 		if txnState.State() == NoTxn {
@@ -748,7 +750,7 @@ func (e *Executor) execParsed(
 		automaticRetryCount := 0
 		txnClosure := func(ctx context.Context, txn *client.Txn, opt *client.TxnExecOptions) error {
 			defer func() { automaticRetryCount++ }()
-			if txnState.State() == Open && txnState.mu.txn != txn {
+			if txnState.TxnIsOpen() && txnState.mu.txn != txn {
 				panic(fmt.Sprintf("closure wasn't called in the txn we set up for it."+
 					"\ntxnState.mu.txn:%+v\ntxn:%+v\ntxnState:%+v", txnState.mu.txn, txn, txnState))
 			}
@@ -768,7 +770,7 @@ func (e *Executor) execParsed(
 
 			results, remainingStmts, err = runTxnAttempt(
 				e, session, stmtsToExec, pinfo, origState, opt,
-				avoidCachedDescriptors, automaticRetryCount)
+				!inTxn /* txnPrefix */, avoidCachedDescriptors, automaticRetryCount)
 
 			// TODO(andrei): Until #7881 fixed.
 			if err == nil && txnState.State() == Aborted {
@@ -877,10 +879,10 @@ func (e *Executor) execParsed(
 			}
 		}
 
-		// If the txn is in any state but Open, exec the schema changes. They'll
-		// short-circuit themselves if the mutation that queued them has been
-		// rolled back from the table descriptor.
-		if txnState.State() != Open {
+		// If the txn is not in an "open" state any more, exec the schema changes.
+		// They'll short-circuit themselves if the mutation that queued them has
+		// been rolled back from the table descriptor.
+		if !txnState.TxnIsOpen() {
 			// Verify that metadata callback eventually succeeds, if one was
 			// set.
 			if e.cfg.TestingKnobs.WaitForGossipUpdate {
@@ -936,6 +938,9 @@ func countRowsAffected(ctx context.Context, p planNode) (int, error) {
 
 // runTxnAttempt is used in the closure we pass to txn.Exec(). It
 // will be called possibly multiple times (if opt.AutoRetry is set).
+//
+// txnPrefix: set if the statements represent the first batch of statements in a
+// 	txn. Used to trap nested BEGINs.
 func runTxnAttempt(
 	e *Executor,
 	session *Session,
@@ -943,6 +948,7 @@ func runTxnAttempt(
 	pinfo *parser.PlaceholderInfo,
 	origState TxnStateEnum,
 	opt *client.TxnExecOptions,
+	txnPrefix bool,
 	avoidCachedDescriptors bool,
 	automaticRetryCount int,
 ) ([]Result, StatementList, error) {
@@ -959,7 +965,7 @@ func runTxnAttempt(
 
 	results, remainingStmts, err := e.execStmtsInCurrentTxn(
 		session, stmts, pinfo,
-		opt.AutoRetry /* txnBeginning */, avoidCachedDescriptors, automaticRetryCount)
+		txnPrefix, avoidCachedDescriptors, automaticRetryCount)
 
 	if opt.AutoCommit && len(remainingStmts) > 0 {
 		panic("implicit txn failed to execute all stmts")
@@ -987,6 +993,8 @@ func runTxnAttempt(
 // session: the session to execute the statement in.
 // stmts: the semicolon-separated list of statements to execute.
 // pinfo: the placeholders to use in the statements.
+// txnPrefix: set if the statements represent the first batch of statements in a
+// 	txn. Used to trap nested BEGINs.
 // avoidCachedDescriptors: set if the statement execution should avoid
 //  using cached descriptors.
 // automaticRetryCount: increases with each retry; 0 for the first attempt.
@@ -1004,7 +1012,7 @@ func (e *Executor) execStmtsInCurrentTxn(
 	session *Session,
 	stmts StatementList,
 	pinfo *parser.PlaceholderInfo,
-	txnBeginning bool,
+	txnPrefix bool,
 	avoidCachedDescriptors bool,
 	automaticRetryCount int,
 ) ([]Result, StatementList, error) {
@@ -1045,9 +1053,9 @@ func (e *Executor) execStmtsInCurrentTxn(
 			res, err = runShowTransactionState(session)
 		} else {
 			switch txnState.State() {
-			case Open:
+			case Open, FirstBatch:
 				res, err = e.execStmtInOpenTxn(
-					session, stmt, pinfo, txnBeginning && (i == 0), /* firstInTxn */
+					session, stmt, pinfo, txnPrefix && (i == 0), /* firstInTxn */
 					avoidCachedDescriptors, automaticRetryCount)
 			case Aborted, RestartWait:
 				res, err = e.execStmtInAbortedTxn(session, stmt)
@@ -1089,6 +1097,11 @@ func getTransactionState(txnState *txnState) string {
 	state := txnState.State()
 	if txnState.implicitTxn {
 		state = NoTxn
+	}
+	// For the purposes of representing the states to client, make the FirstBatch
+	// state look like Open.
+	if state == FirstBatch {
+		state = Open
 	}
 	return state.String()
 }
@@ -1162,8 +1175,8 @@ func (e *Executor) execStmtInAbortedTxn(session *Session, stmt Statement) (Resul
 		}
 
 		if txnState.State() == RestartWait {
-			// Reset the state. Txn is Open again.
-			txnState.SetState(Open)
+			// Reset the state to FirstBatch. We're in an "open" txn again.
+			txnState.SetState(FirstBatch)
 		} else {
 			// We accept ROLLBACK TO SAVEPOINT even after non-retryable errors to make
 			// it easy for client libraries that want to indiscriminately issue
@@ -1237,7 +1250,8 @@ func sessionEventf(session *Session, format string, args ...interface{}) {
 // It binds placeholders.
 //
 // The current transaction might be committed/rolled back when this returns.
-// It might also have transitioned to the aborted or RestartWait state.
+// It might also transition to the aborted or RestartWait state, and it
+// might transition from FirstBatch to Open.
 //
 // Args:
 // session: the session to execute the statement in.
@@ -1261,7 +1275,7 @@ func (e *Executor) execStmtInOpenTxn(
 	automaticRetryCount int,
 ) (_ Result, err error) {
 	txnState := &session.TxnState
-	if txnState.State() != Open {
+	if !txnState.TxnIsOpen() {
 		panic("execStmtInOpenTxn called outside of an open txn")
 	}
 
@@ -1272,12 +1286,18 @@ func (e *Executor) execStmtInOpenTxn(
 		e.updateStmtCounts(stmt)
 	}
 
+	// After the statement is executed, we might have to do state transitions.
 	defer func() {
 		if err != nil {
-			if txnState.State() != Open {
+			if !txnState.TxnIsOpen() {
 				panic(fmt.Sprintf("unexpected txnState when cleaning up: %v", txnState.State()))
 			}
 			txnState.updateStateAndCleanupOnErr(err, e)
+		} else if txnState.State() == FirstBatch &&
+			!canStayInFirstBatchState(stmt) {
+			// Transition from FirstBatch to Open except in the case of special
+			// statements that don't return results to the client.
+			txnState.SetState(Open)
 		}
 	}()
 
@@ -1455,7 +1475,7 @@ func stmtAllowedInImplicitTxn(stmt Statement) bool {
 
 // rollbackSQLTransaction rolls back a transaction. All errors are swallowed.
 func rollbackSQLTransaction(txnState *txnState) Result {
-	if txnState.State() != Open && txnState.State() != RestartWait {
+	if !txnState.TxnIsOpen() && txnState.State() != RestartWait {
 		panic(fmt.Sprintf("rollbackSQLTransaction called on txn in wrong state: %s (txn: %s)",
 			txnState.State(), txnState.mu.txn.Proto()))
 	}
@@ -1479,7 +1499,7 @@ const (
 
 // commitSqlTransaction commits a transaction.
 func commitSQLTransaction(txnState *txnState, commitType commitType) (Result, error) {
-	if txnState.State() != Open {
+	if !txnState.TxnIsOpen() {
 		panic(fmt.Sprintf("commitSqlTransaction called on non-open txn: %+v", txnState.mu.txn))
 	}
 	if commitType == commit {
@@ -1978,6 +1998,48 @@ func isAsOf(session *Session, stmt parser.Statement, max hlc.Timestamp) (*hlc.Ti
 	evalCtx := session.evalCtx()
 	ts, err := EvalAsOfTimestamp(&evalCtx, sc.From.AsOf, max)
 	return &ts, err
+}
+
+// isSavepoint returns true if stmt is a SAVEPOINT statement.
+func isSavepoint(stmt Statement) bool {
+	_, isSavepoint := stmt.AST.(*parser.Savepoint)
+	return isSavepoint
+}
+
+// isBegin returns true if stmt is a BEGIN statement.
+func isBegin(stmt Statement) bool {
+	_, isBegin := stmt.AST.(*parser.BeginTransaction)
+	return isBegin
+}
+
+// isSetTransaction returns true if stmt is a "SET TRANSACTION ..." statement.
+func isSetTransaction(stmt Statement) bool {
+	_, isSet := stmt.AST.(*parser.SetTransaction)
+	return isSet
+}
+
+// isRollbackToSavepoint returns true if stmt is a "ROLLBACK TO SAVEPOINT"
+// statement.
+func isRollbackToSavepoint(stmt Statement) bool {
+	_, isSet := stmt.AST.(*parser.RollbackToSavepoint)
+	return isSet
+}
+
+// canStayInFirstBatchState returns true if the statement can leave the
+// transaction in the FirstBatch state (as opposed to transitioning it to Open).
+//
+// Only statements that affect the transaction state in such a way such that a
+// restart would not destroy the state can currently be added here; we don't
+// replay past batches in case of a restart. So, for example, RETURNING NOTHING
+// statements can't be put here without adding some replay capability.
+// TODO(andrei): support RETURNING NOTHING statements.
+func canStayInFirstBatchState(stmt Statement) bool {
+	return isBegin(stmt) ||
+		isSavepoint(stmt) ||
+		isSetTransaction(stmt) ||
+		// ROLLBACK TO SAVEPOINT does its own state transitions; if it leaves the
+		// transaction in the FirstBatch state, don't mess with it.
+		isRollbackToSavepoint(stmt)
 }
 
 // convertToErrWithPGCode recognizes errs that should have SQL error codes to be

--- a/pkg/sql/logictest/testdata/logic_test/manual_retry
+++ b/pkg/sql/logictest/testdata/logic_test/manual_retry
@@ -10,6 +10,11 @@ SELECT CRDB_INTERNAL.FORCE_RETRY('50ms':::INTERVAL)
 statement ok
 BEGIN TRANSACTION; SAVEPOINT cockroach_restart
 
+# The SELECT 1 is necessary to take the session out of the FirstBatch state,
+# otherwise the statement below would be retries automatically.
+statement ok
+SELECT 1
+
 query error restart transaction: HandledRetryableTxnError: forced by crdb_internal.force_retry()
 SELECT CRDB_INTERNAL.FORCE_RETRY('500ms':::INTERVAL)
 

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -139,6 +139,17 @@ SELECT * FROM kv
 a c
 x y
 
+# Two BEGINs in a row.
+
+statement ok
+BEGIN TRANSACTION
+
+statement error there is already a transaction in progress
+BEGIN TRANSACTION
+
+statement ok
+ROLLBACK TRANSACTION
+
 # BEGIN in the middle of a transaction is an error.
 
 statement ok
@@ -527,8 +538,10 @@ statement ok
 COMMIT
 
 # RestartWait state
+# The SELECT 1 is necessary to move the txn out of the FirstBatch state,
+# otherwise the next statement is automatically retried on the server.
 statement ok
-BEGIN TRANSACTION; SAVEPOINT cockroach_restart
+BEGIN TRANSACTION; SAVEPOINT cockroach_restart; SELECT 1
 
 query error pgcode 40001 restart transaction: HandledRetryableTxnError: forced by crdb_internal.force_retry()
 SELECT CRDB_INTERNAL.FORCE_RETRY('1s':::INTERVAL)
@@ -549,9 +562,82 @@ Open
 statement ok
 COMMIT
 
+
+# Automatic retries for the first batch.
+statement ok
+BEGIN TRANSACTION; SELECT CRDB_INTERNAL.FORCE_RETRY('100ms':::INTERVAL)
+
+statement ok
+ROLLBACK
+
+# Automatic retries for the first batch even when that first batch comes after
+# the BEGIN.
+statement ok
+BEGIN TRANSACTION;
+
+statement ok
+SELECT 1; SELECT CRDB_INTERNAL.FORCE_RETRY('100ms':::INTERVAL)
+
+statement ok
+ROLLBACK
+
+# Automatic retries for the first batch even when that first batch comes after
+# the BEGIN and the BEGIN also has special statements that don't move the txn
+# state out of the "FirstBatch" state.
+statement ok
+BEGIN TRANSACTION; SAVEPOINT cockroach_restart; SET TRANSACTION PRIORITY HIGH; SET TRANSACTION ISOLATION LEVEL SNAPSHOT;
+
+statement ok
+SELECT CRDB_INTERNAL.FORCE_RETRY('100ms':::INTERVAL)
+
+query T
+SHOW TRANSACTION ISOLATION LEVEL
+----
+SNAPSHOT
+
+query T
+SHOW TRANSACTION PRIORITY
+----
+HIGH
+
+statement ok
+ROLLBACK
+
+# Like above, but the SAVEPOINT is its own batch.
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+SAVEPOINT cockroach_restart;
+
+statement ok
+SELECT CRDB_INTERNAL.FORCE_RETRY('100ms':::INTERVAL)
+
+statement ok
+ROLLBACK
+
+
+# Automatic retries for the first batch after an explicit restart.
+statement ok
+BEGIN TRANSACTION; SAVEPOINT cockroach_restart; SELECT 1;
+
+query error pgcode 40001 restart transaction: HandledRetryableTxnError: forced by crdb_internal.force_retry()
+SELECT CRDB_INTERNAL.FORCE_RETRY('50ms':::INTERVAL)
+
+statement ok
+ROLLBACK TO SAVEPOINT COCKROACH_RESTART;
+
+# This is the automatic retry we care about.
+statement ok
+SELECT CRDB_INTERNAL.FORCE_RETRY('100ms':::INTERVAL)
+
+statement ok
+ROLLBACK
+
+
 # Wrong savepoint name moves the txn state from RestartWait to Aborted.
 statement ok
-BEGIN TRANSACTION; SAVEPOINT cockroach_restart
+BEGIN TRANSACTION; SAVEPOINT cockroach_restart; SELECT 1;
 
 query error pgcode 40001 restart transaction: HandledRetryableTxnError: forced by crdb_internal.force_retry()
 SELECT CRDB_INTERNAL.FORCE_RETRY('1s':::INTERVAL)
@@ -724,8 +810,10 @@ BEGIN ISOLATION LEVEL SERIALIZABLE, ISOLATION LEVEL SERIALIZABLE
 
 # Retryable error in a txn that hasn't performed any KV operations. It used to
 # not work.
+# The SELECT 1 is necessary to take the session out of the FirstBatch state,
+# otherwise the statement below would be retries automatically.
 statement ok
-BEGIN
+BEGIN; SELECT 1
 
 query error pgcode 40001 restart transaction: HandledRetryableTxnError: forced by crdb_internal.force_retry()
 SELECT CRDB_INTERNAL.FORCE_RETRY('1s':::INTERVAL)

--- a/pkg/sql/metric_test.go
+++ b/pkg/sql/metric_test.go
@@ -161,9 +161,15 @@ func TestAbortCountConflictingWrites(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Run a batch of statements to move the txn out of the FirstBatch state,
+	// otherwise the INSERT below would be automatically retried.
+	if _, err := txn.Exec("SELECT 1"); err != nil {
+		t.Fatal(err)
+	}
+
 	_, err = txn.Exec("INSERT INTO db.t VALUES ('key', 'marker')")
 	if !testutils.IsError(err, "aborted") {
-		t.Fatal(err)
+		t.Fatalf("expected aborted error, got: %v", err)
 	}
 
 	if err = txn.Rollback(); err != nil {

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -387,7 +387,7 @@ func (c *v3Conn) serve(ctx context.Context, draining func() bool, reserved mon.B
 				// We send status "InFailedTransaction" also for state RestartWait
 				// because GO's lib/pq freaks out if we invent a new status.
 				txnStatus = 'E'
-			case sql.Open:
+			case sql.Open, sql.FirstBatch:
 				txnStatus = 'T'
 			case sql.NoTxn:
 				// We're not in a txn (i.e. the last txn was committed).

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -367,7 +367,7 @@ func (c *v3Conn) serve(ctx context.Context, draining func() bool, reserved mon.B
 	// is draining and the session does not have an ongoing transaction.
 	c.conn = newReadTimeoutConn(c.conn, func() error {
 		if err := func() error {
-			if draining() && c.session.TxnState.State == sql.NoTxn {
+			if draining() && c.session.TxnState.State() == sql.NoTxn {
 				return errors.New(ErrDraining)
 			}
 			return c.session.Ctx().Err()
@@ -382,7 +382,7 @@ func (c *v3Conn) serve(ctx context.Context, draining func() bool, reserved mon.B
 		if !c.doingExtendedQueryMessage && !c.doNotSendReadyForQuery {
 			c.writeBuf.initMsg(serverMsgReady)
 			var txnStatus byte
-			switch c.session.TxnState.State {
+			switch c.session.TxnState.State() {
 			case sql.Aborted, sql.RestartWait:
 				// We send status "InFailedTransaction" also for state RestartWait
 				// because GO's lib/pq freaks out if we invent a new status.

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -487,11 +488,11 @@ func (s *Session) Finish(e *Executor) {
 	_ = s.parallelizeQueue.Wait()
 
 	// If we're inside a txn, roll it back.
-	if s.TxnState.State.kvTxnIsOpen() {
+	if s.TxnState.State().kvTxnIsOpen() {
 		s.TxnState.updateStateAndCleanupOnErr(
 			errors.Errorf("session closing"), e)
 	}
-	if s.TxnState.State != NoTxn {
+	if s.TxnState.State() != NoTxn {
 		s.TxnState.finishSQLTxn(s)
 	}
 
@@ -565,7 +566,7 @@ func (s *Session) EmergencyClose() {
 // active transaction (an example is when we want to log an event to the session
 // event log); in that case s.context should be used directly.
 func (s *Session) Ctx() context.Context {
-	if s.TxnState.State != NoTxn {
+	if s.TxnState.State() != NoTxn {
 		return s.TxnState.Ctx
 	}
 	return s.context
@@ -721,7 +722,7 @@ func (s *Session) serialize() serverpb.Session {
 }
 
 // TxnStateEnum represents the state of a SQL txn.
-type TxnStateEnum int
+type TxnStateEnum int64
 
 //go:generate stringer -type=TxnStateEnum
 const (
@@ -754,7 +755,14 @@ func (s TxnStateEnum) kvTxnIsOpen() bool {
 // For interactive transactions (open across batches of SQL commands sent by a
 // user), txnState is intended to be stored as part of a user Session.
 type txnState struct {
-	State TxnStateEnum
+	// state is read and written to atomically because it can be updated
+	// concurrently with the execution of statements in the parallelizeQueue.
+	// Access with State() / SetState().
+	//
+	// NOTE: Only state updates that are inconsequential to statement execution
+	// are allowed concurrently with the execution of the parallizeQueue (e.g.
+	// Open->FirstBatch).
+	state TxnStateEnum
 
 	// Mutable fields accessed from goroutines not synchronized by this txn's session,
 	// such as when a SHOW SESSIONS statement is executed on another session.
@@ -808,6 +816,16 @@ type txnState struct {
 	// host this here instead of TxnState because TxnState is
 	// fully reset upon each call to resetForNewSQLTxn().
 	mon mon.MemoryMonitor
+}
+
+// State returns the current state of the session.
+func (ts *txnState) State() TxnStateEnum {
+	return TxnStateEnum(atomic.LoadInt64((*int64)(&ts.state)))
+}
+
+// SetState updates the state of the session.
+func (ts *txnState) SetState(val TxnStateEnum) {
+	atomic.StoreInt64((*int64)(&ts.state), int64(val))
 }
 
 // resetForNewSQLTxn (re)initializes the txnState for a new transaction.
@@ -893,7 +911,7 @@ func (ts *txnState) resetForNewSQLTxn(
 
 	ts.sp = sp
 	ts.Ctx = ctx
-	ts.State = Open
+	ts.SetState(Open)
 	s.Tracing.onNewSQLTxn(ts.sp)
 
 	ts.mon.Start(ctx, &s.mon, mon.BoundAccount{})
@@ -934,7 +952,7 @@ func (ts *txnState) resetStateAndTxn(state TxnStateEnum) {
 			"attempting to move SQL txn to state %v inconsistent with KV txn state: %s "+
 				"(finalized: false)", state, ts.mu.txn.Proto().Status))
 	}
-	ts.State = state
+	ts.SetState(state)
 	ts.mu.Lock()
 	ts.mu.txn = nil
 	ts.mu.Unlock()
@@ -993,7 +1011,7 @@ func (ts *txnState) updateStateAndCleanupOnErr(err error, e *Executor) {
 		// If we got a retriable error, move the SQL txn to the RestartWait state.
 		// Note that TransactionAborted is also a retriable error, handled here;
 		// in this case cleanup for the txn has been done for us under the hood.
-		ts.State = RestartWait
+		ts.SetState(RestartWait)
 	}
 }
 

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -732,8 +732,27 @@ const (
 	// Executor opens implicit transactions before executing non-transactional
 	// queries.
 	NoTxn TxnStateEnum = iota
+
+	// A txn is in scope, and we're currently executing statements from the first
+	// batch of statements using the transaction. If BEGIN was the last (or the
+	// only) statement in a batch, that batch doesn't count (the next batch will
+	// be considered the first one). The first batch of statements can be
+	// automatically retried in case of retryable errors since there's been no
+	// client logic relying on reads performed in the transaction.
+	//
+	// A BEGIN statement makes the transaction enter this state (from a previous
+	// NoTxn state). The end of the first batch of statements, if executed
+	// successfully, will move the state to Open.
+	//
+	// TODO(andrei): It'd be cool if exiting this state would be based not on
+	// batches sent by the client, but results being sent by the server to the
+	// client (i.e. the client can send 100 batches but, if we haven't sent it any
+	// results yet, we know that we can still retry them all).
+	FirstBatch
+
 	// A txn is in scope.
 	Open
+
 	// The txn has encountered a (non-retriable) error.
 	// Statements will be rejected until a COMMIT/ROLLBACK is seen.
 	Aborted
@@ -747,7 +766,7 @@ const (
 
 // Some states mean that a client.Txn is open, others don't.
 func (s TxnStateEnum) kvTxnIsOpen() bool {
-	return s == Open || s == RestartWait
+	return s == Open || s == FirstBatch || s == RestartWait
 }
 
 // txnState contains state associated with an ongoing SQL txn.
@@ -826,6 +845,12 @@ func (ts *txnState) State() TxnStateEnum {
 // SetState updates the state of the session.
 func (ts *txnState) SetState(val TxnStateEnum) {
 	atomic.StoreInt64((*int64)(&ts.state), int64(val))
+}
+
+// TxnIsOpen returns true if we are presently inside a SQL txn, and the txn is
+// not in an error state.
+func (ts *txnState) TxnIsOpen() bool {
+	return ts.State() == Open || ts.State() == FirstBatch
 }
 
 // resetForNewSQLTxn (re)initializes the txnState for a new transaction.
@@ -911,7 +936,7 @@ func (ts *txnState) resetForNewSQLTxn(
 
 	ts.sp = sp
 	ts.Ctx = ctx
-	ts.SetState(Open)
+	ts.SetState(FirstBatch)
 	s.Tracing.onNewSQLTxn(ts.sp)
 
 	ts.mon.Start(ctx, &s.mon, mon.BoundAccount{})

--- a/pkg/sql/txn.go
+++ b/pkg/sql/txn.go
@@ -28,7 +28,14 @@ func (p *planner) BeginTransaction(n *parser.BeginTransaction) (planNode, error)
 	if p.txn == nil {
 		return nil, errors.Errorf("the server should have already created a transaction")
 	}
-	return &emptyNode{}, p.setTransactionModes(n.Modes)
+	if err := p.setTransactionModes(n.Modes); err != nil {
+		return nil, err
+	}
+
+	// Enter the FirstBatch state.
+	p.session.TxnState.SetState(FirstBatch)
+
+	return &emptyNode{}, nil
 }
 
 // SetTransaction sets a transaction's isolation level

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -569,6 +569,12 @@ BEGIN;
 		t.Fatal(err)
 	}
 
+	// Run a batch of statements to move the txn out of the FirstBatch state,
+	// otherwise the INSERT below would be automatically retried.
+	if _, err := sqlDB.Exec("SELECT 1"); err != nil {
+		t.Fatal(err)
+	}
+
 	// Continue the txn in a new request, which is not retriable.
 	_, err := sqlDB.Exec("INSERT INTO t.test(k, v, t) VALUES (4, 'hooly', cluster_logical_timestamp())")
 	if !testutils.IsError(
@@ -685,6 +691,12 @@ func runTestTxn(
 	tx *gosql.Tx,
 	sentinelInsert string,
 ) bool {
+	// Run a bogus statement to disable the automatic server retries of subsequent
+	// statements.
+	if _, err := tx.Exec("SELECT 1"); err != nil {
+		t.Fatal(err)
+	}
+
 	retriesNeeded :=
 		(magicVals.restartCounts["boulanger"] + magicVals.abortCounts["boulanger"]) > 0
 	if retriesNeeded {
@@ -966,6 +978,12 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
 	if _, err := tx.Exec("SAVEPOINT cockroach_restart"); err != nil {
 		t.Fatal(err)
 	}
+	// Run a batch of statements to move the txn out of the FirstBatch state,
+	// otherwise the INSERT below would be automatically retried.
+	if _, err := tx.Exec("SELECT 1"); err != nil {
+		t.Fatal(err)
+	}
+
 	if _, err := tx.Exec(insertStmt); err != nil {
 		t.Fatal(err)
 	}
@@ -998,6 +1016,12 @@ func TestUnexpectedStatementInRestartWait(t *testing.T) {
 	if _, err := tx.Exec("SAVEPOINT cockroach_restart"); err != nil {
 		t.Fatal(err)
 	}
+	// Run a batch of statements to move the txn out of the FirstBatch state,
+	// otherwise the SELECT below would be automatically retried.
+	if _, err := tx.Exec("SELECT 1"); err != nil {
+		t.Fatal(err)
+	}
+
 	if _, err := tx.Exec(
 		"SELECT CRDB_INTERNAL.FORCE_RETRY('1s':::INTERVAL)"); !testutils.IsError(
 		err, `forced by crdb_internal\.force_retry\(\)`) {
@@ -1287,7 +1311,7 @@ func TestDistSQLRetryableError(t *testing.T) {
 
 	db.SetMaxOpenConns(1)
 
-	if _, err := db.Exec("SET DISTSQL = ALWAYS"); err != nil {
+	if _, err := db.Exec("SET DISTSQL = ON"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1306,6 +1330,20 @@ func TestDistSQLRetryableError(t *testing.T) {
 	txn, err := db.Begin()
 	if err != nil {
 		t.Fatal(err)
+	}
+	// Run a batch of statements to move the txn out of the "FirstBatch" state.
+	if _, err := txn.Exec("SELECT 1"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Let's make sure that DISTSQL will actually be used.
+	row := txn.QueryRow("SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT COUNT(1) FROM t]")
+	var automatic bool
+	if err := row.Scan(&automatic); err != nil {
+		t.Fatal(err)
+	}
+	if !automatic {
+		t.Fatal("DISTSQL not used for test's query")
 	}
 
 	_, err = txn.Exec("SELECT COUNT(1) FROM t")

--- a/pkg/sql/txnstateenum_string.go
+++ b/pkg/sql/txnstateenum_string.go
@@ -4,9 +4,9 @@ package sql
 
 import "fmt"
 
-const _TxnStateEnum_name = "NoTxnOpenAbortedRestartWaitCommitWait"
+const _TxnStateEnum_name = "NoTxnFirstBatchOpenAbortedRestartWaitCommitWait"
 
-var _TxnStateEnum_index = [...]uint8{0, 5, 9, 16, 27, 37}
+var _TxnStateEnum_index = [...]uint8{0, 5, 15, 19, 26, 37, 47}
 
 func (i TxnStateEnum) String() string {
 	if i < 0 || i >= TxnStateEnum(len(_TxnStateEnum_index)-1) {


### PR DESCRIPTION
Before this patch, in case of retryable errors, the server (i.e. the
Executor) would automatically retry a batch of statements if the batch
was the prefix of a transaction (or if the batch contained the whole
txn). For example, if the following SELECT would get an error, it'd be
retried if all of the following statements arrived to the server in one
batch: BEGIN; ...; SELECT foo; [... COMMIT]. The rationale in retrying
these prefixes, but not otherwise, was that, in the case of a prefix
batch, we know that the client had no conditional logic based on reads
performed in the current txn.

This patch extends this reasoning to statements executed in the first
batch arriving after the batch with the BEGIN if the BEGIN had been
trailing a previous batch (more realistically, if the BEGIN is sent
alone as a batch). As a further optimization, the SAVEPOINT statement
doesn't change the retryable character of the next range). So, if you do
something like (different lines are different batches):
BEGIN
SELECT foo;

or

BEGIN; SAVEPOINT cockroach_restart;
SELECT foo

or

BEGIN
SAVEPOINT cockroach_restart
[...;] SELECT FOO

the SELECTs will be retried automatically.

Besides being generally a good idea to hide retryable errors more, this
change was motivated by ORMs getting retryable errors from a BEGIN;
CREATE TABLE ...; COMMIT; sequence (with the BEGIN being a separate
batch). This ORM code is not under our control and we can't teach it
about user-directed retries.

This is implemented by creating a new txnState.State - FirstBatch.
Auto-retry is enabled for batches executed in this state.

Fixes #16450
Fixes #16200
See also forum discussion about it:
https://forum.cockroachlabs.com/t/automatically-retrying-the-first-batch-of-statements-after-a-begin/759

cc @tristan-ohlson 