### PR TITLE
tracing: improve shadow tracer infrastructure

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -358,9 +358,10 @@
   revision = "472a0745531a17dbac346e828b4c60e73ddff30c"
 
 [[projects]]
+  branch = "master"
   name = "github.com/lightstep/lightstep-tracer-go"
   packages = [".","basictracer","collectorpb","lightstep_thrift","lightsteppb","thrift_0_9_2/lib/go/thrift","thrift_rpc"]
-  revision = "d9d2a958da1b2b4dd282e7685261942e20abd49c"
+  revision = "7a9b172199f2df79def78707aaba049a191e74f2"
 
 [[projects]]
   name = "github.com/mattn/go-isatty"

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -254,6 +254,7 @@ func TestTracerInjectExtract(t *testing.T) {
 }
 
 func TestLightstepContext(t *testing.T) {
+	tr := NewTracer()
 	lsTr := lightstep.NewTracer(lightstep.Options{
 		AccessToken: "invalid",
 		Collector: lightstep.Endpoint{
@@ -264,8 +265,7 @@ func TestLightstepContext(t *testing.T) {
 		MaxLogsPerSpan: maxLogsPerSpan,
 		UseGRPC:        true,
 	})
-	setShadowTracer(lightStepManager{}, lsTr)
-	tr := NewTracer()
+	tr.(*Tracer).setShadowTracer(lightStepManager{}, lsTr)
 	s := tr.StartSpan("test")
 
 	const testBaggageKey = "test-baggage"
@@ -277,8 +277,7 @@ func TestLightstepContext(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Extract also extracts the context in lightstep; this will fail if the
-	// contexts are not compatible.
+	// Extract also extracts the embedded lightstep context.
 	wireContext, err := tr.Extract(opentracing.HTTPHeaders, carrier)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
We switch from using a global shadowTracer to using one per Tracer. This allows
us to Close the Tracer when a server exits.

To implement this we need a tracer registry so we can update all outstanding
shadow tracers.

Updating the LightStep dependency to get the new close code.