### PR TITLE
cmd/benchmark: log the package name

### DIFF
--- a/pkg/cmd/benchmark/main.go
+++ b/pkg/cmd/benchmark/main.go
@@ -145,7 +145,7 @@ func do(ctx context.Context) error {
 
 			cmd := exec.CommandContext(ctx, binaryPath, "-test.timeout", "0", "-test.run", "-", "-test.bench", ".", "-test.benchmem")
 			cmd.Dir = filepath.Dir(binaryPath)
-			cmd.Stdout = io.MultiWriter(buffer, os.Stdout)
+			cmd.Stdout = buffer
 			cmd.Stderr = os.Stderr
 
 			log.Printf("exec: %s", cmd.Args)


### PR DESCRIPTION
This emulates the behaviour of `go test`, which we don't see because we
pre-build the test binaries.