### PR TITLE
cherrypick: storage/engine: Limit batch size in MVCC GC

### DIFF
--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -2102,18 +2102,23 @@ func MVCCResolveWriteIntentRangeUsingIter(
 // MVCCGarbageCollect creates an iterator on the engine. In parallel
 // it iterates through the keys listed for garbage collection by the
 // keys slice. The engine iterator is seeked in turn to each listed
-// key, clearing all values with timestamps <= to expiration.
-// The timestamp parameter is used to compute the intent age on GC.
+// key, clearing all values with timestamps <= to expiration. The
+// timestamp parameter is used to compute the intent age on GC.
+// Garbage collection stops after clearing maxClears values
+// (to limit the size of the WriteBatch produced).
 func MVCCGarbageCollect(
 	ctx context.Context,
 	engine ReadWriter,
 	ms *enginepb.MVCCStats,
 	keys []roachpb.GCRequest_GCKey,
 	timestamp hlc.Timestamp,
+	maxClears int64,
 ) error {
 	iter := engine.NewIterator(false)
 	defer iter.Close()
+
 	// Iterate through specified GC keys.
+	var count int64
 	meta := &enginepb.MVCCMetadata{}
 	for _, gcKey := range keys {
 		encKey := MakeMVCCMetadataKey(gcKey.Key)
@@ -2151,6 +2156,10 @@ func MVCCGarbageCollect(
 				if err := engine.Clear(iter.UnsafeKey()); err != nil {
 					return err
 				}
+				count++
+				if count >= maxClears {
+					return nil
+				}
 			}
 		}
 
@@ -2181,6 +2190,10 @@ func MVCCGarbageCollect(
 				}
 				if err := engine.Clear(unsafeIterKey); err != nil {
 					return err
+				}
+				count++
+				if count >= maxClears {
+					return nil
 				}
 			}
 		}

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -3704,7 +3704,9 @@ func TestMVCCGarbageCollect(t *testing.T) {
 		{Key: roachpb.Key("a-bad"), Timestamp: ts2},
 		{Key: roachpb.Key("inline-bad"), Timestamp: hlc.Timestamp{}},
 	}
-	if err := MVCCGarbageCollect(context.Background(), engine, ms, keys, ts3); err != nil {
+	if err := MVCCGarbageCollect(
+		context.Background(), engine, ms, keys, ts3, math.MaxInt64,
+	); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3792,7 +3794,7 @@ func TestMVCCGarbageCollectNonDeleted(t *testing.T) {
 		keys := []roachpb.GCRequest_GCKey{
 			{Key: test.key, Timestamp: ts2},
 		}
-		err := MVCCGarbageCollect(context.Background(), engine, nil, keys, ts2)
+		err := MVCCGarbageCollect(context.Background(), engine, nil, keys, ts2, math.MaxInt64)
 		if !testutils.IsError(err, test.expError) {
 			t.Fatalf("expected error %q when garbage collecting a non-deleted live value, found %v", test.expError, err)
 		}
@@ -3824,7 +3826,9 @@ func TestMVCCGarbageCollectIntent(t *testing.T) {
 	keys := []roachpb.GCRequest_GCKey{
 		{Key: key, Timestamp: ts2},
 	}
-	if err := MVCCGarbageCollect(context.Background(), engine, nil, keys, ts2); err == nil {
+	if err := MVCCGarbageCollect(
+		context.Background(), engine, nil, keys, ts2, math.MaxInt64,
+	); err == nil {
 		t.Fatal("expected error garbage collecting an intent")
 	}
 }

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
@@ -61,6 +62,15 @@ const (
 	// operation.
 	collectChecksumTimeout = 5 * time.Second
 )
+
+// gcBatchSize controls the amount of work done in a single pass of
+// MVCC GC. Setting this too high may block the range for too long
+// (especially a risk in the system ranges), while setting it too low
+// may allow ranges to grow too large if we are unable to keep up with
+// the amount of garbage generated.
+var gcBatchSize = settings.RegisterIntSetting("kv.gc.batch_size",
+	"maximum number of keys in a batch for MVCC garbage collection",
+	100000)
 
 // CommandArgs contains all the arguments to a command.
 // TODO(bdarnell): consider merging with storagebase.FilterArgs (which
@@ -1422,7 +1432,7 @@ func evalGC(
 	}
 
 	// Garbage collect the specified keys by expiration timestamps.
-	err := engine.MVCCGarbageCollect(ctx, batch, cArgs.Stats, keys, h.Timestamp)
+	err := engine.MVCCGarbageCollect(ctx, batch, cArgs.Stats, keys, h.Timestamp, gcBatchSize.Get())
 	if err != nil {
 		return EvalResult{}, err
 	}


### PR DESCRIPTION
When there is a lot of garbage to collect, a single run of
MVCCGarbageCollect on the node liveness range can last long enough
that leases expire, leading to cascading unavailability.

Fixes #16565 

@cockroachdb/release 