### PR TITLE
k8s: update configs and docs for secure mode

### DIFF
--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -117,17 +117,21 @@ spec:
       # In addition to the node certificate and key, the init-certs entrypoint will symlink
       # the cluster CA to the certs directory.
       - name: init-certs
-        image: cockroachdb/cockroach-k8s-request-cert:0.1
+        image: cockroachdb/cockroach-k8s-request-cert:0.2
         imagePullPolicy: IfNotPresent
         command:
         - "/bin/ash"
         - "-ecx"
-        - "/request-cert -certs-dir=/cockroach-certs -type=node -addresses=localhost,127.0.0.1,${POD_IP},$(hostname -f),cockroachdb-public -symlink-ca-from=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+        - "/request-cert -namespace=${POD_NAMESPACE} -certs-dir=/cockroach-certs -type=node -addresses=localhost,127.0.0.1,${POD_IP},$(hostname -f),cockroachdb-public -symlink-ca-from=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
         env:
         - name: POD_IP
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         volumeMounts:
         - name: certs
           mountPath: /cockroach-certs

--- a/cloud/kubernetes/example_app.yaml
+++ b/cloud/kubernetes/example_app.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: example
 spec:
-  replicas: 2
+  replicas: 1
   template:
     metadata:
       labels:

--- a/cloud/kubernetes/example_app_secure.yaml
+++ b/cloud/kubernetes/example_app_secure.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: example-secure
 spec:
-  replicas: 2
+  replicas: 1
   template:
     metadata:
       labels:
@@ -22,13 +22,17 @@ spec:
       # In addition to the client certificate and key, the init-certs entrypoint will symlink
       # the cluster CA to the certs directory.
       - name: init-certs
-        image: cockroachdb/cockroach-k8s-request-cert:0.1
+        image: cockroachdb/cockroach-k8s-request-cert:0.2
         imagePullPolicy: IfNotPresent
-        args:
-        - "-certs-dir=/cockroach-certs"
-        - "-type=client"
-        - "-user=root"
-        - "-symlink-ca-from=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+        command:
+        - "/bin/ash"
+        - "-ecx"
+        - "/request-cert -namespace=${POD_NAMESPACE} -certs-dir=/cockroach-certs -type=client -user=root -symlink-ca-from=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         volumeMounts:
         - name: client-certs
           mountPath: /cockroach-certs


### PR DESCRIPTION
* use request-certs docker image v0.2 (pending in https://github.com/cockroachdb/k8s/pull/2)
* pass `namespace` to request-certs
* use only 1 pod for the example app
* improve docs on cert approval process (once per pod for nodes, one for
each deployment for example app)