### PR TITLE
engineccl: fix horribly broken TestMVCCIterateTimeBound

### DIFF
--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -77,7 +77,7 @@ func loadTestData(
 
 	sstTimestamps := make([]int64, numBatches)
 	for i := 0; i < len(sstTimestamps); i++ {
-		sstTimestamps[i] = int64(i * batchTimeSpan)
+		sstTimestamps[i] = int64((i + 1) * batchTimeSpan)
 	}
 
 	var batch engine.Batch

--- a/pkg/ccl/storageccl/engineccl/mvcc_test.go
+++ b/pkg/ccl/storageccl/engineccl/mvcc_test.go
@@ -218,7 +218,7 @@ func TestMVCCIterateTimeBound(t *testing.T) {
 	dir, cleanupFn := testutils.TempDir(t)
 	defer cleanupFn()
 
-	const numKeys = 100
+	const numKeys = 1000
 	const numBatches = 10
 	const batchTimeSpan = 10
 	const valueSize = 8
@@ -235,7 +235,7 @@ func TestMVCCIterateTimeBound(t *testing.T) {
 		end   hlc.Timestamp
 	}{
 		// entire time range
-		{hlc.Timestamp{WallTime: 0, Logical: 0}, hlc.Timestamp{WallTime: 100, Logical: 0}},
+		{hlc.Timestamp{WallTime: 0, Logical: 0}, hlc.Timestamp{WallTime: 110, Logical: 0}},
 		// one SST
 		{hlc.Timestamp{WallTime: 10, Logical: 0}, hlc.Timestamp{WallTime: 19, Logical: 0}},
 		// one SST, plus the min of the following SST
@@ -264,9 +264,15 @@ func TestMVCCIterateTimeBound(t *testing.T) {
 			for iter.Reset(keys.MinKey, keys.MaxKey); iter.Valid(); iter.Next() {
 				expectedKVs = append(expectedKVs, engine.MVCCKeyValue{Key: iter.Key(), Value: iter.Value()})
 			}
+			if err := iter.Error(); err != nil {
+				t.Fatal(err)
+			}
+			if len(expectedKVs) < 1 {
+				t.Fatalf("source of truth had no expected KVs; likely a bug in the test itself")
+			}
 
 			settings.TestingSetBool(&TimeBoundIteratorsEnabled, true)
-			assertEqualKVs(eng, keys.MinKey, keys.MaxKey, testCase.start, testCase.end, expectedKVs)
+			assertEqualKVs(eng, keys.MinKey, keys.MaxKey, testCase.start, testCase.end, expectedKVs)(t)
 		})
 	}
 }


### PR DESCRIPTION
This test wasn't actually testing anything, because `assertEqualKVs` *returns* a function that must be invoked to actually run the assertions. Actually invoking that function revealed that the test was broken because `loadTestData` was generating data with empty `hlc.Timestamp{}`s, which secretely create "inline values" that the MVCCIncrementalIterator doesn't support. Fixing *that* required bumping the minimum wall time from 0 to 10 to avoid creating empty `hlc.Timestamp`s, which in turn required updating some of the test cases.

For good measure, this commit adds some sanity checks and bumps the number of generated keys from 100 to 1000 to guarantee that the keyspace contains at least one value at each timestamp from 10 to 110.