### PR TITLE
engine: adjust time-bound iterators to use half-open intervals

### DIFF
--- a/pkg/storage/engine/db.cc
+++ b/pkg/storage/engine/db.cc
@@ -2088,8 +2088,10 @@ DBIterator* DBNewTimeBoundIter(DBEngine* db, DBTimestamp min_ts, DBTimestamp max
       return true;
     }
     // If the timestamp range of the table overlaps with the timestamp range we
-    // want to iterate, the table might contain timestamps we care about.
-    return max.compare(tbl_min->second) >= 0 && min.compare(tbl_max->second) <= 0;
+    // want to iterate, the table might contain timestamps we care about. For
+    // consistency with engineccl.MVCCIncrementalIterator, the min_ts bound is
+    // exclusive, but the max_ts bound is inclusive.
+    return max.compare(tbl_min->second) >= 0 && min.compare(tbl_max->second) < 0;
   };
   return db->NewIter(&opts);
 }

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -134,7 +134,7 @@ type Reader interface {
 	NewIterator(prefix bool) Iterator
 	// NewTimeBoundIterator is like NewIterator, but the underlying iterator will
 	// efficiently skip over SSTs that contain no MVCC keys in the time range
-	// [start, end].
+	// (start, end].
 	NewTimeBoundIterator(start, end hlc.Timestamp) Iterator
 }
 


### PR DESCRIPTION
The only client of time-bound iterators is
`engineccl.MVCCIncrementalIterator`, which uses half-open intervals
[start, end) instead of inclusive intervals [start, end]. The prior
behavior wasn't wrong, since the MVCCIncrementalIterator used a more
restrictive interval and could filter out the extra keys, but we might
as well make them consistent.

---

Submitted as a separate PR because I want to make triple-sure this is valid.