### PR TITLE
storage: don't perform intent resolution after a failed Raft application

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -372,6 +372,11 @@ func (ts *TestServer) Stores() *storage.Stores {
 	return ts.node.stores
 }
 
+// GetStores is part of TestServerInterface.
+func (ts *TestServer) GetStores() interface{} {
+	return ts.node.stores
+}
+
 // Engines returns the TestServer's engines.
 func (ts *TestServer) Engines() []engine.Engine {
 	return ts.engines

--- a/pkg/storage/main_test.go
+++ b/pkg/storage/main_test.go
@@ -87,5 +87,7 @@ func TestMain(m *testing.M) {
 		}
 	}
 
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+
 	os.Exit(code)
 }

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -77,7 +77,9 @@ type ProposalData struct {
 	endCmds *endCmds
 
 	// doneCh is used to signal the waiting RPC handler (the contents of
-	// proposalResult come from LocalEvalResult)
+	// proposalResult come from LocalEvalResult).
+	// Attention: this channel is not to be signaled directly downstream of Raft.
+	// Always use ProposalData.finishRaftApplication().
 	doneCh chan proposalResult
 
 	// Local contains the results of evaluating the request
@@ -96,12 +98,35 @@ type ProposalData struct {
 	Request *roachpb.BatchRequest
 }
 
-// finish first invokes the endCmds function and then sends the
-// specified proposalResult on the proposal's done channel. endCmds is
-// invoked here in order to allow the original client to be cancelled
-// and possibly no longer listening to this done channel, and so can't
-// be counted on to invoke endCmds itself.
-func (proposal *ProposalData) finish(pr proposalResult) {
+// finishRaftApplication is called downstream of Raft when a command application
+// has finished. proposal.doneCh is signaled with pr so that the proposer is
+// unblocked.
+//
+// It first invokes the endCmds function and then sends the specified
+// proposalResult on the proposal's done channel. endCmds is invoked here in
+// order to allow the original client to be cancelled and possibly no longer
+// listening to this done channel, and so can't be counted on to invoke endCmds
+// itself.
+//
+// Note: this should not be called upstream of Raft because, in case pr.Err is
+// set, it clears the intents from pr before sending it on the channel. This
+// clearing should not be done upstream of Raft because, in cases of errors
+// encountered upstream of Raft, we might still want to resolve intents:
+// upstream of Raft, pr.intents represent intents encountered by a request, not
+// the current txn's intents.
+func (proposal *ProposalData) finishRaftApplication(pr proposalResult) {
+	if pr.Err != nil {
+		// Clear the intents so that the intent resolution process does not take
+		// place: if an EndTransaction fails, we don't want to commit the txn's
+		// writes. In principle we'd still want to resolve any intents ancountered
+		// by the EndTransaction's batch of requests, other than the current txn's
+		// intents, but we don't make an attempt to separate the two categories of
+		// intents.
+		// TODO(tschottdorf,bdarnell): refactor this so there are two Intents
+		// fields, one for intents to be resolved if the command applies
+		// successfully, and one for intents to be resolved no matter what.
+		pr.Intents = nil
+	}
 	if proposal.endCmds != nil {
 		proposal.endCmds.done(pr.Reply, pr.Err, pr.ProposalRetry)
 		proposal.endCmds = nil

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -1857,7 +1858,7 @@ func TestLeaseConcurrent(t *testing.T) {
 						// otherwise its context (and tracing span) may be used after the
 						// client cleaned up.
 						delete(tc.repl.mu.proposals, proposal.idKey)
-						proposal.finish(proposalResult{Err: roachpb.NewErrorf(origMsg)})
+						proposal.finishRaftApplication(proposalResult{Err: roachpb.NewErrorf(origMsg)})
 						return
 					}
 					if err := defaultSubmitProposalLocked(tc.repl, proposal); err != nil {
@@ -7846,5 +7847,90 @@ func TestCommandTooLarge(t *testing.T) {
 		[]byte(strings.Repeat("a", int(maxCommandSize.Get()))))
 	if _, pErr := tc.SendWrapped(&args); !testutils.IsPError(pErr, "command is too large") {
 		t.Fatalf("did not get expected error: %v", pErr)
+	}
+}
+
+// Test that, if the application of a Raft command fails, intents are not
+// resolved. This is because we don't want intent resolution to take place if an
+// EndTransaction fails.
+func TestErrorInRaftApplicationClearsIntents(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var storeKnobs StoreTestingKnobs
+	var filterActive int32
+	key := roachpb.Key("a")
+	rkey, err := keys.Addr(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	storeKnobs.TestingApplyFilter = func(filterArgs storagebase.ApplyFilterArgs) *roachpb.Error {
+		if atomic.LoadInt32(&filterActive) == 1 && filterArgs.StartKey.Equal(rkey) {
+			return roachpb.NewErrorf("boom")
+		}
+		return nil
+	}
+	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{Store: &storeKnobs}})
+	defer s.Stopper().Stop(context.TODO())
+
+	splitKey := roachpb.Key("b")
+	if err := kvDB.AdminSplit(context.TODO(), splitKey, splitKey); err != nil {
+		t.Fatal(err)
+	}
+
+	txn := newTransaction("test", key, roachpb.NormalUserPriority,
+		enginepb.SERIALIZABLE, s.Clock(),
+	)
+	btArgs, _ := beginTxnArgs(key, txn)
+	var ba roachpb.BatchRequest
+	ba.Header.Txn = txn
+	ba.Add(&btArgs)
+	if _, pErr := s.DistSender().Send(context.TODO(), ba); pErr != nil {
+		t.Fatal(pErr.GoError())
+	}
+
+	// Fail future command applications.
+	atomic.StoreInt32(&filterActive, 1)
+
+	// Propose an EndTransaction with a remote intent. The _remote_ part is
+	// important because intents local to the txn's range are resolved inline with
+	// the EndTransaction execution.
+	// We do this by using replica.propose() directly, as opposed to going through
+	// the DistSender, because we want to inspect the proposal's result after the
+	// injected error.
+	etArgs, _ := endTxnArgs(txn, true /* commit */)
+	etArgs.IntentSpans = []roachpb.Span{{Key: roachpb.Key("bb")}}
+	ba = roachpb.BatchRequest{}
+	ba.Timestamp = s.Clock().Now()
+	ba.Header.Txn = txn
+	ba.Add(&etArgs)
+	// Get a reference to the txn's replica.
+	stores := s.GetStores().(*Stores)
+	rangeID, _, err := stores.LookupReplica(rkey, nil /* end */)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := stores.GetStore(s.GetFirstStoreID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	repl, err := store.GetReplica(rangeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exLease, _ := repl.getLease()
+	ch, _, _, err := repl.propose(
+		context.Background(), exLease, ba, nil /* endCmds */, nil, /* spans */
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	propRes := <-ch
+	if !testutils.IsPError(propRes.Err, "boom") {
+		t.Fatalf("expected injected error, got: %v", propRes.Err)
+	}
+	if len(propRes.Intents) != 0 {
+		t.Fatal("expected intents to have been cleared")
 	}
 }

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -990,8 +990,9 @@ func TestStoreSendBadRange(t *testing.T) {
 }
 
 // splitTestRange splits a range. This does *not* fully emulate a real split
-// and should not be used in new tests. Tests that need splits should live in
-// client_split_test.go and use AdminSplit instead of this function.
+// and should not be used in new tests. Tests that need splits should either live in
+// client_split_test.go and use AdminSplit instead of this function or use the
+// TestServerInterface.
 // See #702
 // TODO(bdarnell): convert tests that use this function to use AdminSplit instead.
 func splitTestRange(store *Store, key, splitKey roachpb.RKey, t *testing.T) *Replica {

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -117,6 +117,10 @@ type TestServerInterface interface {
 	// store on this node.
 	GetFirstStoreID() roachpb.StoreID
 
+	// GetStores returns the collection of stores from this TestServer's node.
+	// The return value is of type *storage.Stores.
+	GetStores() interface{}
+
 	// SplitRange splits the range containing splitKey.
 	SplitRange(
 		splitKey roachpb.Key,


### PR DESCRIPTION
This patch fixes a bug causing us to erroneously resolve intents when
the application of a Raft command returned an error. This meant that we
could have an erroring EndTransaction application, and still commit the
transaction's data.

Sending early to get it cherry-picked in 1.0.3 while I work on a test.

Fixes #16724