### PR TITLE
sql: miscellaneous SHOW improvements

### DIFF
--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -143,7 +143,7 @@ func getDumpMetadata(
 func getTableNames(conn *sqlConn, dbName string, ts string) (tableNames []string, err error) {
 	rows, err := conn.Query(fmt.Sprintf(`
 		SELECT TABLE_NAME
-		FROM information_schema.tables
+		FROM "".information_schema.tables
 		AS OF SYSTEM TIME '%s'
 		WHERE TABLE_SCHEMA = $1
 		`, ts), []driver.Value{dbName})
@@ -179,7 +179,7 @@ func getMetadataForTable(
 	// Fetch column types.
 	rows, err := conn.Query(fmt.Sprintf(`
 		SELECT COLUMN_NAME, DATA_TYPE
-		FROM information_schema.columns
+		FROM "".information_schema.columns
 		AS OF SYSTEM TIME '%s'
 		WHERE TABLE_SCHEMA = $1
 			AND TABLE_NAME = $2
@@ -218,7 +218,7 @@ func getMetadataForTable(
 	// Fetch the primary index name.
 	vals, err = conn.QueryRow(fmt.Sprintf(`
 		SELECT CONSTRAINT_NAME
-		FROM information_schema.table_constraints
+		FROM "".information_schema.table_constraints
 		AS OF SYSTEM TIME '%s'
 		WHERE TABLE_SCHEMA = $1
 			AND TABLE_NAME = $2
@@ -239,7 +239,7 @@ func getMetadataForTable(
 
 	rows, err = conn.Query(fmt.Sprintf(`
 		SELECT COLUMN_NAME
-		FROM information_schema.key_column_usage
+		FROM "".information_schema.key_column_usage
 		AS OF SYSTEM TIME '%s'
 		WHERE TABLE_SCHEMA = $1
 			AND TABLE_NAME = $2
@@ -275,7 +275,7 @@ func getMetadataForTable(
 
 	vals, err = conn.QueryRow(fmt.Sprintf(`
 		SELECT CREATE_TABLE
-		FROM crdb_internal.tables
+		FROM "".crdb_internal.tables
 		AS OF SYSTEM TIME '%s'
 		WHERE NAME = $1
 			AND DATABASE_NAME = $2

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -53,7 +53,7 @@ CREATE TABLE crdb_internal.node_build_info (
   value   STRING NOT NULL
 );
 `,
-	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
 		node := p.ExecCfg().NodeInfo
 
 		nodeID := parser.NewDInt(parser.DInt(int64(node.NodeID.Get())))
@@ -95,7 +95,7 @@ CREATE TABLE crdb_internal.tables (
   create_table             STRING NOT NULL
 );
 `,
-	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
 		descs, err := getAllDescriptors(ctx, p.txn)
 		if err != nil {
 			return err
@@ -165,7 +165,7 @@ CREATE TABLE crdb_internal.schema_changes (
   direction     STRING NOT NULL
 );
 `,
-	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
 		descs, err := getAllDescriptors(ctx, p.txn)
 		if err != nil {
 			return err
@@ -223,7 +223,7 @@ CREATE TABLE crdb_internal.leases (
   deleted     BOOL NOT NULL
 );
 `,
-	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
 		leaseMgr := p.LeaseMgr()
 		nodeID := parser.NewDInt(parser.DInt(int64(leaseMgr.nodeID.Get())))
 
@@ -287,7 +287,7 @@ CREATE TABLE crdb_internal.jobs (
 	error              STRING
 );
 `,
-	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
 		rows, err := p.queryRows(ctx, `SELECT id, status, created, payload FROM system.jobs`)
 		if err != nil {
 			return err
@@ -372,7 +372,7 @@ CREATE TABLE crdb_internal.node_statement_statistics (
   overhead_lat_var    FLOAT NOT NULL
 );
 `,
-	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
 		if p.session.User != security.RootUser {
 			return errors.New("only root can access application statistics")
 		}
@@ -477,7 +477,7 @@ CREATE TABLE crdb_internal.session_trace(
   message     STRING NOT NULL      -- The logged message.
 );
 `,
-	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
 		rows, err := p.session.Tracing.generateSessionTraceVTable()
 		if err != nil {
 			return err

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -30,8 +30,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
+const crdbInternalName = "crdb_internal"
+
 var crdbInternal = virtualSchema{
-	name: "crdb_internal",
+	name: crdbInternalName,
 	tables: []virtualSchemaTable{
 		crdbInternalBuildInfoTable,
 		crdbInternalTablesTable,

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -628,6 +628,7 @@ func isSystemDatabaseName(name string) bool {
 	case informationSchemaName:
 	case pgCatalogName:
 	case sqlbase.SystemDB.Name:
+	case crdbInternalName:
 	default:
 		return false
 	}

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -85,6 +85,14 @@ EXPLAIN DROP DATABASE foo
 ----
 0 drop database
 
+# explain SHOW JOBS - beware to test this before the CREATE INDEX
+# below, otherwise the result becomes non-deterministic.
+query ITTT
+EXPLAIN SHOW JOBS
+----
+0  values
+0          size  12 columns, 0 rows
+
 statement ok
 CREATE INDEX a ON foo(x)
 
@@ -123,8 +131,12 @@ EXPLAIN SHOW DATABASES
 query ITTT
 EXPLAIN SHOW TABLES
 ----
-0  values
-0          size  1 column, 1 row
+0  sort
+0          order  +"Table"
+1  render
+2  filter
+3  values
+3          size   5 columns, 52 rows
 
 query ITTT
 EXPLAIN SHOW DATABASE
@@ -159,22 +171,40 @@ EXPLAIN SHOW TRANSACTION PRIORITY
 query ITTT
 EXPLAIN SHOW COLUMNS FROM foo
 ----
-0  values
-0          size  5 columns, 1 row
+0  sort
+0          order     +ordinal_position
+1  render
+2  group
+3  render
+4  join
+4          type      left outer
+4          equality  (column_name) = (column_name)
+5  render
+6  filter
+7  values
+7          size      13 columns, 459 rows
+5  render
+6  filter
+7  values
+7          size      13 columns, 22 rows
 
 query ITTT
 EXPLAIN SHOW GRANTS ON foo
 ----
 0  sort
 0          order  +"Table",+"User",+"Privileges"
-1  values
-1          size   3 columns, 1 row
+1  render
+2  filter
+3  values
+3          size   8 columns, 45 rows
 
 query ITTT
 EXPLAIN SHOW INDEX FROM foo
 ----
-0  values
-0          size  8 columns, 3 rows
+0  render
+1  filter
+2  values
+2          size  13 columns, 22 rows
 
 query ITTT
 EXPLAIN SHOW CONSTRAINTS FROM foo

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -386,41 +386,48 @@ user testuser
 query TTTTI colnames
 SELECT * FROM information_schema.tables
 ----
-table_catalog  table_schema        table_name         table_type   version
-def            information_schema  columns            SYSTEM VIEW  1
-def            information_schema  key_column_usage   SYSTEM VIEW  1
-def            information_schema  schema_privileges  SYSTEM VIEW  1
-def            information_schema  schemata           SYSTEM VIEW  1
-def            information_schema  statistics         SYSTEM VIEW  1
-def            information_schema  table_constraints  SYSTEM VIEW  1
-def            information_schema  table_privileges   SYSTEM VIEW  1
-def            information_schema  tables             SYSTEM VIEW  1
-def            information_schema  user_privileges    SYSTEM VIEW  1
-def            information_schema  views              SYSTEM VIEW  1
-def            pg_catalog          pg_am              SYSTEM VIEW  1
-def            pg_catalog          pg_attrdef         SYSTEM VIEW  1
-def            pg_catalog          pg_attribute       SYSTEM VIEW  1
-def            pg_catalog          pg_class           SYSTEM VIEW  1
-def            pg_catalog          pg_collation       SYSTEM VIEW  1
-def            pg_catalog          pg_constraint      SYSTEM VIEW  1
-def            pg_catalog          pg_database        SYSTEM VIEW  1
-def            pg_catalog          pg_depend          SYSTEM VIEW  1
-def            pg_catalog          pg_description     SYSTEM VIEW  1
-def            pg_catalog          pg_enum            SYSTEM VIEW  1
-def            pg_catalog          pg_extension       SYSTEM VIEW  1
-def            pg_catalog          pg_foreign_server  SYSTEM VIEW  1
-def            pg_catalog          pg_foreign_table   SYSTEM VIEW  1
-def            pg_catalog          pg_index           SYSTEM VIEW  1
-def            pg_catalog          pg_indexes         SYSTEM VIEW  1
-def            pg_catalog          pg_inherits        SYSTEM VIEW  1
-def            pg_catalog          pg_namespace       SYSTEM VIEW  1
-def            pg_catalog          pg_proc            SYSTEM VIEW  1
-def            pg_catalog          pg_range           SYSTEM VIEW  1
-def            pg_catalog          pg_roles           SYSTEM VIEW  1
-def            pg_catalog          pg_settings        SYSTEM VIEW  1
-def            pg_catalog          pg_tables          SYSTEM VIEW  1
-def            pg_catalog          pg_type            SYSTEM VIEW  1
-def            pg_catalog          pg_views           SYSTEM VIEW  1
+table_catalog  table_schema        table_name                 table_type   version
+def            crdb_internal       jobs                       SYSTEM VIEW  1
+def            crdb_internal       leases                     SYSTEM VIEW  1
+def            crdb_internal       node_build_info            SYSTEM VIEW  1
+def            crdb_internal       node_statement_statistics  SYSTEM VIEW  1
+def            crdb_internal       schema_changes             SYSTEM VIEW  1
+def            crdb_internal       session_trace              SYSTEM VIEW  1
+def            crdb_internal       tables                     SYSTEM VIEW  1
+def            information_schema  columns                    SYSTEM VIEW  1
+def            information_schema  key_column_usage           SYSTEM VIEW  1
+def            information_schema  schema_privileges          SYSTEM VIEW  1
+def            information_schema  schemata                   SYSTEM VIEW  1
+def            information_schema  statistics                 SYSTEM VIEW  1
+def            information_schema  table_constraints          SYSTEM VIEW  1
+def            information_schema  table_privileges           SYSTEM VIEW  1
+def            information_schema  tables                     SYSTEM VIEW  1
+def            information_schema  user_privileges            SYSTEM VIEW  1
+def            information_schema  views                      SYSTEM VIEW  1
+def            pg_catalog          pg_am                      SYSTEM VIEW  1
+def            pg_catalog          pg_attrdef                 SYSTEM VIEW  1
+def            pg_catalog          pg_attribute               SYSTEM VIEW  1
+def            pg_catalog          pg_class                   SYSTEM VIEW  1
+def            pg_catalog          pg_collation               SYSTEM VIEW  1
+def            pg_catalog          pg_constraint              SYSTEM VIEW  1
+def            pg_catalog          pg_database                SYSTEM VIEW  1
+def            pg_catalog          pg_depend                  SYSTEM VIEW  1
+def            pg_catalog          pg_description             SYSTEM VIEW  1
+def            pg_catalog          pg_enum                    SYSTEM VIEW  1
+def            pg_catalog          pg_extension               SYSTEM VIEW  1
+def            pg_catalog          pg_foreign_server          SYSTEM VIEW  1
+def            pg_catalog          pg_foreign_table           SYSTEM VIEW  1
+def            pg_catalog          pg_index                   SYSTEM VIEW  1
+def            pg_catalog          pg_indexes                 SYSTEM VIEW  1
+def            pg_catalog          pg_inherits                SYSTEM VIEW  1
+def            pg_catalog          pg_namespace               SYSTEM VIEW  1
+def            pg_catalog          pg_proc                    SYSTEM VIEW  1
+def            pg_catalog          pg_range                   SYSTEM VIEW  1
+def            pg_catalog          pg_roles                   SYSTEM VIEW  1
+def            pg_catalog          pg_settings                SYSTEM VIEW  1
+def            pg_catalog          pg_tables                  SYSTEM VIEW  1
+def            pg_catalog          pg_type                    SYSTEM VIEW  1
+def            pg_catalog          pg_views                   SYSTEM VIEW  1
 
 user root
 
@@ -435,42 +442,49 @@ SET DATABASE = other_db
 query TTTTI colnames
 SELECT * FROM information_schema.tables
 ----
-table_catalog  table_schema        table_name         table_type   version
-def            information_schema  columns            SYSTEM VIEW  1
-def            information_schema  key_column_usage   SYSTEM VIEW  1
-def            information_schema  schema_privileges  SYSTEM VIEW  1
-def            information_schema  schemata           SYSTEM VIEW  1
-def            information_schema  statistics         SYSTEM VIEW  1
-def            information_schema  table_constraints  SYSTEM VIEW  1
-def            information_schema  table_privileges   SYSTEM VIEW  1
-def            information_schema  tables             SYSTEM VIEW  1
-def            information_schema  user_privileges    SYSTEM VIEW  1
-def            information_schema  views              SYSTEM VIEW  1
-def            other_db            xyz                BASE TABLE   6
-def            pg_catalog          pg_am              SYSTEM VIEW  1
-def            pg_catalog          pg_attrdef         SYSTEM VIEW  1
-def            pg_catalog          pg_attribute       SYSTEM VIEW  1
-def            pg_catalog          pg_class           SYSTEM VIEW  1
-def            pg_catalog          pg_collation       SYSTEM VIEW  1
-def            pg_catalog          pg_constraint      SYSTEM VIEW  1
-def            pg_catalog          pg_database        SYSTEM VIEW  1
-def            pg_catalog          pg_depend          SYSTEM VIEW  1
-def            pg_catalog          pg_description     SYSTEM VIEW  1
-def            pg_catalog          pg_enum            SYSTEM VIEW  1
-def            pg_catalog          pg_extension       SYSTEM VIEW  1
-def            pg_catalog          pg_foreign_server  SYSTEM VIEW  1
-def            pg_catalog          pg_foreign_table   SYSTEM VIEW  1
-def            pg_catalog          pg_index           SYSTEM VIEW  1
-def            pg_catalog          pg_indexes         SYSTEM VIEW  1
-def            pg_catalog          pg_inherits        SYSTEM VIEW  1
-def            pg_catalog          pg_namespace       SYSTEM VIEW  1
-def            pg_catalog          pg_proc            SYSTEM VIEW  1
-def            pg_catalog          pg_range           SYSTEM VIEW  1
-def            pg_catalog          pg_roles           SYSTEM VIEW  1
-def            pg_catalog          pg_settings        SYSTEM VIEW  1
-def            pg_catalog          pg_tables          SYSTEM VIEW  1
-def            pg_catalog          pg_type            SYSTEM VIEW  1
-def            pg_catalog          pg_views           SYSTEM VIEW  1
+table_catalog  table_schema        table_name                 table_type   version
+def            crdb_internal       jobs                       SYSTEM VIEW  1
+def            crdb_internal       leases                     SYSTEM VIEW  1
+def            crdb_internal       node_build_info            SYSTEM VIEW  1
+def            crdb_internal       node_statement_statistics  SYSTEM VIEW  1
+def            crdb_internal       schema_changes             SYSTEM VIEW  1
+def            crdb_internal       session_trace              SYSTEM VIEW  1
+def            crdb_internal       tables                     SYSTEM VIEW  1
+def            information_schema  columns                    SYSTEM VIEW  1
+def            information_schema  key_column_usage           SYSTEM VIEW  1
+def            information_schema  schema_privileges          SYSTEM VIEW  1
+def            information_schema  schemata                   SYSTEM VIEW  1
+def            information_schema  statistics                 SYSTEM VIEW  1
+def            information_schema  table_constraints          SYSTEM VIEW  1
+def            information_schema  table_privileges           SYSTEM VIEW  1
+def            information_schema  tables                     SYSTEM VIEW  1
+def            information_schema  user_privileges            SYSTEM VIEW  1
+def            information_schema  views                      SYSTEM VIEW  1
+def            other_db            xyz                        BASE TABLE   6
+def            pg_catalog          pg_am                      SYSTEM VIEW  1
+def            pg_catalog          pg_attrdef                 SYSTEM VIEW  1
+def            pg_catalog          pg_attribute               SYSTEM VIEW  1
+def            pg_catalog          pg_class                   SYSTEM VIEW  1
+def            pg_catalog          pg_collation               SYSTEM VIEW  1
+def            pg_catalog          pg_constraint              SYSTEM VIEW  1
+def            pg_catalog          pg_database                SYSTEM VIEW  1
+def            pg_catalog          pg_depend                  SYSTEM VIEW  1
+def            pg_catalog          pg_description             SYSTEM VIEW  1
+def            pg_catalog          pg_enum                    SYSTEM VIEW  1
+def            pg_catalog          pg_extension               SYSTEM VIEW  1
+def            pg_catalog          pg_foreign_server          SYSTEM VIEW  1
+def            pg_catalog          pg_foreign_table           SYSTEM VIEW  1
+def            pg_catalog          pg_index                   SYSTEM VIEW  1
+def            pg_catalog          pg_indexes                 SYSTEM VIEW  1
+def            pg_catalog          pg_inherits                SYSTEM VIEW  1
+def            pg_catalog          pg_namespace               SYSTEM VIEW  1
+def            pg_catalog          pg_proc                    SYSTEM VIEW  1
+def            pg_catalog          pg_range                   SYSTEM VIEW  1
+def            pg_catalog          pg_roles                   SYSTEM VIEW  1
+def            pg_catalog          pg_settings                SYSTEM VIEW  1
+def            pg_catalog          pg_tables                  SYSTEM VIEW  1
+def            pg_catalog          pg_type                    SYSTEM VIEW  1
+def            pg_catalog          pg_views                   SYSTEM VIEW  1
 
 user root
 

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -199,6 +199,63 @@ DROP DATABASE other_db
 
 ## information_schema.tables
 
+# Check the default contents of information_schema.tables (incl. the
+# special system tables)
+query TT
+select table_schema, table_name FROM information_schema.tables ORDER BY 1, 2
+----
+crdb_internal       jobs
+crdb_internal       leases
+crdb_internal       node_build_info
+crdb_internal       node_statement_statistics
+crdb_internal       schema_changes
+crdb_internal       session_trace
+crdb_internal       tables
+information_schema  columns
+information_schema  key_column_usage
+information_schema  schema_privileges
+information_schema  schemata
+information_schema  statistics
+information_schema  table_constraints
+information_schema  table_privileges
+information_schema  tables
+information_schema  user_privileges
+information_schema  views
+pg_catalog          pg_am
+pg_catalog          pg_attrdef
+pg_catalog          pg_attribute
+pg_catalog          pg_class
+pg_catalog          pg_collation
+pg_catalog          pg_constraint
+pg_catalog          pg_database
+pg_catalog          pg_depend
+pg_catalog          pg_description
+pg_catalog          pg_enum
+pg_catalog          pg_extension
+pg_catalog          pg_foreign_server
+pg_catalog          pg_foreign_table
+pg_catalog          pg_index
+pg_catalog          pg_indexes
+pg_catalog          pg_inherits
+pg_catalog          pg_namespace
+pg_catalog          pg_proc
+pg_catalog          pg_range
+pg_catalog          pg_roles
+pg_catalog          pg_settings
+pg_catalog          pg_tables
+pg_catalog          pg_type
+pg_catalog          pg_views
+system              descriptor
+system              eventlog
+system              jobs
+system              lease
+system              namespace
+system              rangelog
+system              settings
+system              ui
+system              users
+system              zones
+
 statement ok
 CREATE DATABASE other_db
 
@@ -208,65 +265,60 @@ CREATE TABLE other_db.xyz (i INT)
 statement ok
 CREATE VIEW other_db.abc AS SELECT i from other_db.xyz
 
+statement ok
+GRANT UPDATE ON other_db.xyz TO testuser
+
+user testuser
+
+# Check the output with the current database set to 'test' (the
+# defaults in tests). This will make the tables in other_db invisible to
+# a non-root user.
 query T
-SELECT table_name FROM information_schema.tables
+SELECT table_name FROM information_schema.tables WHERE table_schema = 'other_db'
 ----
-jobs
-leases
-node_build_info
-node_statement_statistics
-schema_changes
-session_trace
-tables
-columns
-key_column_usage
-schema_privileges
-schemata
-statistics
-table_constraints
-table_privileges
-tables
-user_privileges
-views
+
+# Check that the other_db tables become visible when a prefix is specified
+query T
+SELECT table_name FROM other_db.information_schema.tables WHERE table_schema = 'other_db'
+----
+xyz
+
+# Check that the non-root user can also query all databases with an explicit empty prefix
+query T
+SELECT table_name FROM "".information_schema.tables WHERE table_schema = 'other_db'
+----
+xyz
+
+# Check that the other_db tables become visible to non-root when the current database is changed.
+query T
+SET DATABASE = other_db; SELECT table_name FROM information_schema.tables WHERE table_schema = 'other_db'
+----
+xyz
+
+user root
+
+# Check that root sees everything when there is no current database
+query T
+SET DATABASE = ''; SELECT table_name FROM information_schema.tables WHERE table_schema = 'other_db'
+----
 abc
 xyz
-pg_am
-pg_attrdef
-pg_attribute
-pg_class
-pg_collation
-pg_constraint
-pg_database
-pg_depend
-pg_description
-pg_enum
-pg_extension
-pg_foreign_server
-pg_foreign_table
-pg_index
-pg_indexes
-pg_inherits
-pg_namespace
-pg_proc
-pg_range
-pg_roles
-pg_settings
-pg_tables
-pg_type
-pg_views
-descriptor
-eventlog
-jobs
-lease
-namespace
-rangelog
-settings
-ui
-users
-zones
 
+# Check that root doesn't see other things when there is a current database
 query T
-SELECT table_name FROM information_schema.tables WHERE table_name > 'n' ORDER BY 1 DESC
+SET DATABASE = test; SELECT table_name FROM information_schema.tables WHERE table_schema = 'other_db'
+----
+
+# Check that a query cannot use prefixes for regular tables
+query error invalid table name
+SELECT * FROM other_db.other_db.xyz
+
+statement ok
+SET DATABASE = other_db
+
+# Check that filtering works.
+query T
+SELECT table_name FROM information_schema.tables WHERE table_name > 't'  ORDER BY 1 DESC
 ----
 zones
 xyz
@@ -278,41 +330,8 @@ tables
 tables
 table_privileges
 table_constraints
-statistics
-settings
-session_trace
-schemata
-schema_privileges
-schema_changes
-rangelog
-pg_views
-pg_type
-pg_tables
-pg_settings
-pg_roles
-pg_range
-pg_proc
-pg_namespace
-pg_inherits
-pg_indexes
-pg_index
-pg_foreign_table
-pg_foreign_server
-pg_extension
-pg_enum
-pg_description
-pg_depend
-pg_database
-pg_constraint
-pg_collation
-pg_class
-pg_attribute
-pg_attrdef
-pg_am
-node_statement_statistics
-node_build_info
-namespace
 
+# Check that the metadata is reported properly.
 query TTTTI colnames
 SELECT * FROM information_schema.tables
 ----
@@ -335,7 +354,7 @@ def            information_schema  tables                     SYSTEM VIEW  1
 def            information_schema  user_privileges            SYSTEM VIEW  1
 def            information_schema  views                      SYSTEM VIEW  1
 def            other_db            abc                        VIEW         1
-def            other_db            xyz                        BASE TABLE   2
+def            other_db            xyz                        BASE TABLE   3
 def            pg_catalog          pg_am                      SYSTEM VIEW  1
 def            pg_catalog          pg_attrdef                 SYSTEM VIEW  1
 def            pg_catalog          pg_attribute               SYSTEM VIEW  1
@@ -378,113 +397,33 @@ query TTI colnames
 SELECT TABLE_SCHEMA, TABLE_NAME, VERSION FROM information_schema.tables WHERE version > 1
 ----
 table_schema  table_name  version
-other_db      xyz         5
+other_db      xyz         6
 system        eventlog    2
 
 user testuser
 
+# Check that another user cannot see other_db.adbc any more because they
+# don't have privileges on it.
 query TTTTI colnames
-SELECT * FROM information_schema.tables
+SELECT * FROM information_schema.tables WHERE table_schema = 'other_db'
 ----
-table_catalog  table_schema        table_name                 table_type   version
-def            crdb_internal       jobs                       SYSTEM VIEW  1
-def            crdb_internal       leases                     SYSTEM VIEW  1
-def            crdb_internal       node_build_info            SYSTEM VIEW  1
-def            crdb_internal       node_statement_statistics  SYSTEM VIEW  1
-def            crdb_internal       schema_changes             SYSTEM VIEW  1
-def            crdb_internal       session_trace              SYSTEM VIEW  1
-def            crdb_internal       tables                     SYSTEM VIEW  1
-def            information_schema  columns                    SYSTEM VIEW  1
-def            information_schema  key_column_usage           SYSTEM VIEW  1
-def            information_schema  schema_privileges          SYSTEM VIEW  1
-def            information_schema  schemata                   SYSTEM VIEW  1
-def            information_schema  statistics                 SYSTEM VIEW  1
-def            information_schema  table_constraints          SYSTEM VIEW  1
-def            information_schema  table_privileges           SYSTEM VIEW  1
-def            information_schema  tables                     SYSTEM VIEW  1
-def            information_schema  user_privileges            SYSTEM VIEW  1
-def            information_schema  views                      SYSTEM VIEW  1
-def            pg_catalog          pg_am                      SYSTEM VIEW  1
-def            pg_catalog          pg_attrdef                 SYSTEM VIEW  1
-def            pg_catalog          pg_attribute               SYSTEM VIEW  1
-def            pg_catalog          pg_class                   SYSTEM VIEW  1
-def            pg_catalog          pg_collation               SYSTEM VIEW  1
-def            pg_catalog          pg_constraint              SYSTEM VIEW  1
-def            pg_catalog          pg_database                SYSTEM VIEW  1
-def            pg_catalog          pg_depend                  SYSTEM VIEW  1
-def            pg_catalog          pg_description             SYSTEM VIEW  1
-def            pg_catalog          pg_enum                    SYSTEM VIEW  1
-def            pg_catalog          pg_extension               SYSTEM VIEW  1
-def            pg_catalog          pg_foreign_server          SYSTEM VIEW  1
-def            pg_catalog          pg_foreign_table           SYSTEM VIEW  1
-def            pg_catalog          pg_index                   SYSTEM VIEW  1
-def            pg_catalog          pg_indexes                 SYSTEM VIEW  1
-def            pg_catalog          pg_inherits                SYSTEM VIEW  1
-def            pg_catalog          pg_namespace               SYSTEM VIEW  1
-def            pg_catalog          pg_proc                    SYSTEM VIEW  1
-def            pg_catalog          pg_range                   SYSTEM VIEW  1
-def            pg_catalog          pg_roles                   SYSTEM VIEW  1
-def            pg_catalog          pg_settings                SYSTEM VIEW  1
-def            pg_catalog          pg_tables                  SYSTEM VIEW  1
-def            pg_catalog          pg_type                    SYSTEM VIEW  1
-def            pg_catalog          pg_views                   SYSTEM VIEW  1
+table_catalog  table_schema  table_name  table_type  version
+def            other_db      xyz         BASE TABLE  6
 
 user root
 
 statement ok
-GRANT SELECT ON other_db.xyz TO testuser
+GRANT SELECT ON other_db.abc TO testuser
 
 user testuser
 
-statement ok
-SET DATABASE = other_db
-
+# Check the user can see the tables now that they have privilege.
 query TTTTI colnames
-SELECT * FROM information_schema.tables
+SELECT * FROM information_schema.tables WHERE table_schema = 'other_db'
 ----
-table_catalog  table_schema        table_name                 table_type   version
-def            crdb_internal       jobs                       SYSTEM VIEW  1
-def            crdb_internal       leases                     SYSTEM VIEW  1
-def            crdb_internal       node_build_info            SYSTEM VIEW  1
-def            crdb_internal       node_statement_statistics  SYSTEM VIEW  1
-def            crdb_internal       schema_changes             SYSTEM VIEW  1
-def            crdb_internal       session_trace              SYSTEM VIEW  1
-def            crdb_internal       tables                     SYSTEM VIEW  1
-def            information_schema  columns                    SYSTEM VIEW  1
-def            information_schema  key_column_usage           SYSTEM VIEW  1
-def            information_schema  schema_privileges          SYSTEM VIEW  1
-def            information_schema  schemata                   SYSTEM VIEW  1
-def            information_schema  statistics                 SYSTEM VIEW  1
-def            information_schema  table_constraints          SYSTEM VIEW  1
-def            information_schema  table_privileges           SYSTEM VIEW  1
-def            information_schema  tables                     SYSTEM VIEW  1
-def            information_schema  user_privileges            SYSTEM VIEW  1
-def            information_schema  views                      SYSTEM VIEW  1
-def            other_db            xyz                        BASE TABLE   6
-def            pg_catalog          pg_am                      SYSTEM VIEW  1
-def            pg_catalog          pg_attrdef                 SYSTEM VIEW  1
-def            pg_catalog          pg_attribute               SYSTEM VIEW  1
-def            pg_catalog          pg_class                   SYSTEM VIEW  1
-def            pg_catalog          pg_collation               SYSTEM VIEW  1
-def            pg_catalog          pg_constraint              SYSTEM VIEW  1
-def            pg_catalog          pg_database                SYSTEM VIEW  1
-def            pg_catalog          pg_depend                  SYSTEM VIEW  1
-def            pg_catalog          pg_description             SYSTEM VIEW  1
-def            pg_catalog          pg_enum                    SYSTEM VIEW  1
-def            pg_catalog          pg_extension               SYSTEM VIEW  1
-def            pg_catalog          pg_foreign_server          SYSTEM VIEW  1
-def            pg_catalog          pg_foreign_table           SYSTEM VIEW  1
-def            pg_catalog          pg_index                   SYSTEM VIEW  1
-def            pg_catalog          pg_indexes                 SYSTEM VIEW  1
-def            pg_catalog          pg_inherits                SYSTEM VIEW  1
-def            pg_catalog          pg_namespace               SYSTEM VIEW  1
-def            pg_catalog          pg_proc                    SYSTEM VIEW  1
-def            pg_catalog          pg_range                   SYSTEM VIEW  1
-def            pg_catalog          pg_roles                   SYSTEM VIEW  1
-def            pg_catalog          pg_settings                SYSTEM VIEW  1
-def            pg_catalog          pg_tables                  SYSTEM VIEW  1
-def            pg_catalog          pg_type                    SYSTEM VIEW  1
-def            pg_catalog          pg_views                   SYSTEM VIEW  1
+table_catalog  table_schema  table_name  table_type  version
+def            other_db      abc         VIEW        2
+def            other_db      xyz         BASE TABLE  6
 
 user root
 
@@ -529,6 +468,9 @@ CREATE TABLE constraint_db.t2 (
     CONSTRAINT fk FOREIGN KEY (t1_ID) REFERENCES constraint_db.t1(a),
     INDEX (t1_ID)
 )
+
+statement ok
+SET DATABASE = constraint_db
 
 query TTTTTT colnames
 SELECT *
@@ -591,6 +533,9 @@ def            system        users       username        1
 def            system        users       hashedPassword  2
 def            system        zones       id              1
 def            system        zones       config          2
+
+statement ok
+SET DATABASE = test
 
 statement ok
 CREATE TABLE with_defaults (a INT DEFAULT 9, b STRING DEFAULT 'default', c INT, d STRING)
@@ -713,6 +658,9 @@ CREATE TABLE constraint_column.t3 (
     INDEX (a, b)
 )
 
+statement ok
+SET DATABASE = constraint_column
+
 query TTTTTTTII colnames
 SELECT * FROM information_schema.key_column_usage WHERE constraint_schema = 'constraint_column' ORDER BY TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION
 ----
@@ -732,7 +680,7 @@ DROP DATABASE constraint_column
 ## information_schema.schema_privileges
 
 statement ok
-CREATE DATABASE other_db
+CREATE DATABASE other_db; SET DATABASE = other_db
 
 query TTTTT colnames
 SELECT * FROM information_schema.schema_privileges

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -183,6 +183,9 @@ oid         datname             datconnlimit  datlastsysoid  datfrozenxid  datmi
 
 ## pg_catalog.pg_tables
 
+statement ok
+SET DATABASE = constraint_db
+
 query TTTTBBBB colnames
 SELECT * FROM pg_catalog.pg_tables WHERE schemaname = 'constraint_db'
 ----
@@ -404,9 +407,9 @@ JOIN pg_catalog.pg_class c ON ad.adrelid = c.oid
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'constraint_db'
 ----
-oid         relname  adrelid     adnum  adbin          adsrc
-2737381215  t1       2876473678  4      12:::INT       12:::INT
-2989572986  t3       3211628798  3      'FOO':::STRING 'FOO':::STRING
+oid         relname  adrelid     adnum  adbin           adsrc
+2737381215  t1       2876473678  4      12:::INT        12:::INT
+2989572986  t3       3211628798  3      'FOO':::STRING  'FOO':::STRING
 
 ## pg_catalog.pg_indexes
 
@@ -937,6 +940,9 @@ extname  extowner  extnamespace  extrelocatable  extversion  extconfig  extcondi
 
 ## pg_catalog.pg_settings
 
+statement ok
+SET DATABASE = test
+
 query TTTTTT colnames
 SELECT name, setting, category, short_desc, extra_desc, vartype FROM pg_catalog.pg_settings
 ----
@@ -1021,6 +1027,9 @@ query T
 SELECT pg_catalog.pg_get_expr('1', 0, true)
 ----
 1
+
+statement ok
+SET DATABASE = constraint_db
 
 query OTT
 SELECT def.oid, c.relname, pg_catalog.pg_get_expr(def.adbin, def.adrelid)

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -256,19 +256,9 @@ CREATE DATABASE thirddb
 statement ok
 SET DATABASE = thirddb
 
-# Ensure that if there's no such table in the search path, but it still exists
-# in another database, the query fails.
+# Ensure that if the table is not in the current database, but it
+# still exists in another database, the query does fail (regclass
+# does not automatically search in other dbs, even for the root user).
 
 query error table "a" does not exist
 SELECT relname, relnatts FROM pg_class WHERE oid='a'::regclass
-
-statement ok
-SET SEARCH_PATH = otherdb,test
-
-# Ensure that the search path is respected properly: the table named "a" from
-# otherdb should be selected.
-
-query OI
-SELECT relname, relnatts FROM pg_class WHERE oid='a'::regclass
-----
-a  2

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -235,3 +235,8 @@ query TTTTTT colnames
 SELECT * FROM [SHOW TRACE FOR SELECT 1] LIMIT 0
 ----
 timestamp age message context operation span
+
+query ITTTTTTTTTRT colnames
+SELECT * FROM [SHOW JOBS] LIMIT 0
+----
+id  type  description  username  descriptor_ids  status  created  started  finished  modified  fraction_completed  error

--- a/pkg/sql/parser/encode.go
+++ b/pkg/sql/parser/encode.go
@@ -52,6 +52,15 @@ func encodeSQLString(buf *bytes.Buffer, in string) {
 	encodeSQLStringWithFlags(buf, in, FmtSimple)
 }
 
+// EscapeSQLString returns an escaped SQL representation of the given
+// string. This is suitable for safely producing a SQL string valid
+// for input to the parser.
+func EscapeSQLString(in string) string {
+	var buf bytes.Buffer
+	encodeSQLString(&buf, in)
+	return buf.String()
+}
+
 // encodeSQLStringWithFlags writes a string literal to buf. All unicode and
 // non-printable characters are escaped. FmtFlags controls the output format:
 // if f.bareStrings is true, the output string will not be wrapped in quotes

--- a/pkg/sql/parser/table_name_test.go
+++ b/pkg/sql/parser/table_name_test.go
@@ -35,12 +35,13 @@ func TestNormalizeTableName(t *testing.T) {
 		{`foo`, `test.foo`, `test`, ``},
 		{`test.foo`, `test.foo`, ``, ``},
 		{`bar.foo`, `bar.foo`, `test`, ``},
+		{`p.foo.bar`, `p.foo.bar`, ``, ``},
 
 		{`""`, ``, ``, `empty table name`},
 		{`foo`, ``, ``, `no database specified`},
 		{`foo@bar`, ``, ``, `syntax error`},
-		{`test.foo.bar`, ``, ``, `invalid table name: "test.foo.bar"`},
-		{`test.*`, ``, ``, `invalid table name: "test.*"`},
+		{`test.*`, ``, ``, `invalid table name: "test\.\*"`},
+		{`p."".bar`, ``, ``, `empty database name: "p.\\"\\".bar"`},
 	}
 
 	for _, tc := range testCases {
@@ -50,7 +51,7 @@ func TestNormalizeTableName(t *testing.T) {
 		}
 		if tc.err != "" {
 			if !testutils.IsError(err, tc.err) {
-				t.Fatalf("%s: expected %s, but found %v", tc.in, tc.err, err)
+				t.Fatalf("%s: expected %s, but found %s", tc.in, tc.err, err.Error())
 			}
 			continue
 		}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -90,7 +90,7 @@ CREATE TABLE pg_catalog.pg_am (
 	amtype CHAR
 );
 `,
-	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
 		h.writeStr(cockroachIndexEncoding)
 		return addRow(
@@ -113,9 +113,9 @@ CREATE TABLE pg_catalog.pg_attrdef (
 	adsrc STRING
 );
 `,
-	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
-		return forEachTableDesc(ctx, p, func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
+		return forEachTableDesc(ctx, p, prefix, func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
 			colNum := 0
 			return forEachColumnInTable(table, func(column *sqlbase.ColumnDescriptor) error {
 				colNum++
@@ -163,9 +163,9 @@ CREATE TABLE pg_catalog.pg_attribute (
 	attfdwoptions STRING
 );
 `,
-	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
-		return forEachTableDesc(ctx, p, func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
+		return forEachTableDesc(ctx, p, prefix, func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
 			// addColumn adds adds either a table or a index column to the pg_attribute table.
 			addColumn := func(column *sqlbase.ColumnDescriptor, attRelID parser.Datum, colNum int) error {
 				colTyp := column.Type.ToDatumType()
@@ -257,9 +257,9 @@ CREATE TABLE pg_catalog.pg_class (
 	reloptions STRING
 );
 `,
-	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
-		return forEachTableDesc(ctx, p, func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
+		return forEachTableDesc(ctx, p, prefix, func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
 			// Table.
 			relKind := relKindTable
 			if table.IsView() {
@@ -345,7 +345,7 @@ CREATE TABLE pg_catalog.pg_collation (
   collctype STRING
 );
 `,
-	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
 		for _, tag := range collate.Supported() {
 			collName := tag.String()
@@ -431,9 +431,9 @@ CREATE TABLE pg_catalog.pg_constraint (
 	consrc STRING
 );
 `,
-	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
-		return forEachTableDescWithTableLookup(ctx, p, func(
+		return forEachTableDescWithTableLookup(ctx, p, prefix, func(
 			db *sqlbase.DatabaseDescriptor,
 			table *sqlbase.TableDescriptor,
 			tableLookup tableLookupFn,
@@ -599,7 +599,7 @@ CREATE TABLE pg_catalog.pg_database (
 	datacl STRING
 );
 `,
-	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
 		return forEachDatabaseDesc(ctx, p, func(db *sqlbase.DatabaseDescriptor) error {
 			return addRow(
@@ -659,7 +659,7 @@ CREATE TABLE pg_catalog.pg_depend (
   deptype CHAR
 );
 `,
-	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
 		db, err := getDatabaseDesc(ctx, p.txn, p.getVirtualTabler(), pgCatalogName)
 		if err != nil {
@@ -691,7 +691,7 @@ CREATE TABLE pg_catalog.pg_depend (
 		}
 		pgClassTableOid := h.TableOid(db, pgClassDesc)
 
-		return forEachTableDescWithTableLookup(ctx, p, func(
+		return forEachTableDescWithTableLookup(ctx, p, prefix, func(
 			db *sqlbase.DatabaseDescriptor,
 			table *sqlbase.TableDescriptor,
 			tableLookup tableLookupFn,
@@ -739,7 +739,7 @@ CREATE TABLE pg_catalog.pg_description (
 	description STRING
 );
 `,
-	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
 		// Comments on database objects are not currently supported.
 		return nil
 	},
@@ -755,7 +755,7 @@ CREATE TABLE pg_catalog.pg_enum (
   enumlabel STRING
 );
 `,
-	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
 		// Enum types are not currently supported.
 		return nil
 	},
@@ -774,7 +774,7 @@ CREATE TABLE pg_catalog.pg_extension (
   extcondition STRING
 );
 `,
-	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
 		// Extensions are not supported.
 		return nil
 	},
@@ -794,7 +794,7 @@ CREATE TABLE pg_catalog.pg_foreign_server (
   srvoptions STRING
 );
 `,
-	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
 		// Foreign servers are not supported.
 		return nil
 	},
@@ -809,7 +809,7 @@ CREATE TABLE pg_catalog.pg_foreign_table (
   ftoptions STRING
 );
 `,
-	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
 		// Foreign tables are not supported.
 		return nil
 	},
@@ -840,9 +840,9 @@ CREATE TABLE pg_catalog.pg_index (
     indpred STRING
 );
 `,
-	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
-		return forEachTableDesc(ctx, p, func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
+		return forEachTableDesc(ctx, p, prefix, func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
 			tableOid := h.TableOid(db, table)
 			return forEachIndexInTable(table, func(index *sqlbase.IndexDescriptor) error {
 				isMutation, isWriteOnly :=
@@ -893,9 +893,9 @@ CREATE TABLE pg_catalog.pg_indexes (
 	indexdef STRING
 );
 `,
-	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
-		return forEachTableDesc(ctx, p, func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
+		return forEachTableDesc(ctx, p, prefix, func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
 			return forEachIndexInTable(table, func(index *sqlbase.IndexDescriptor) error {
 				def, err := indexDefFromDescriptor(ctx, p, db, table, index)
 				if err != nil {
@@ -985,7 +985,7 @@ CREATE TABLE pg_catalog.pg_inherits (
 	inhseqno INT
 );
 `,
-	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
 		// Table inheritance is not supported.
 		return nil
 	},
@@ -1001,7 +1001,7 @@ CREATE TABLE pg_catalog.pg_namespace (
 	aclitem STRING
 );
 `,
-	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
 		return forEachDatabaseDesc(ctx, p, func(db *sqlbase.DatabaseDescriptor) error {
 			return addRow(
@@ -1064,7 +1064,7 @@ CREATE TABLE pg_catalog.pg_proc (
 	proacl STRING
 );
 `,
-	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
 		dbDesc, err := getDatabaseDesc(ctx, p.txn, p.getVirtualTabler(), pgCatalogName)
 		if err != nil {
@@ -1188,7 +1188,7 @@ CREATE TABLE pg_catalog.pg_range (
 	rngsubdiff INT
 );
 `,
-	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
 		// We currently do not support any range types, so this table is empty.
 		// This table should be populated when any range types are added to
 		// oidToDatum (and therefore pg_type).
@@ -1214,7 +1214,7 @@ CREATE TABLE pg_catalog.pg_roles (
 	rolconfig STRING
 );
 `,
-	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
 		// We intentionally do not check if the user has access to system.user.
 		// Because Postgres allows access to pg_roles by non-privileged users, we
 		// need to do the same. This shouldn't be an issue, because pg_roles doesn't
@@ -1269,7 +1269,7 @@ CREATE TABLE pg_catalog.pg_settings (
     pending_restart BOOL
 );
 `,
-	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
 		for _, vName := range varNames {
 			gen := varGen[vName]
 			value := gen.Get(p)
@@ -1314,8 +1314,8 @@ CREATE TABLE pg_catalog.pg_tables (
 	rowsecurity BOOL
 );
 `,
-	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {
-		return forEachTableDesc(ctx, p, func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
+	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...parser.Datum) error) error {
+		return forEachTableDesc(ctx, p, prefix, func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
 			if table.IsView() {
 				return nil
 			}
@@ -1416,7 +1416,7 @@ CREATE TABLE pg_catalog.pg_type (
 	typacl STRING
 );
 `,
-	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
+	populate: func(_ context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
 		h := makeOidHasher()
 		for o, typ := range parser.OidToType {
 			cat := typCategory(typ)
@@ -1549,8 +1549,8 @@ CREATE TABLE pg_catalog.pg_views (
 	definition STRING
 );
 `,
-	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {
-		return forEachTableDesc(ctx, p, func(db *sqlbase.DatabaseDescriptor, desc *sqlbase.TableDescriptor) error {
+	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...parser.Datum) error) error {
+		return forEachTableDesc(ctx, p, prefix, func(db *sqlbase.DatabaseDescriptor, desc *sqlbase.TableDescriptor) error {
 			if !desc.IsView() {
 				return nil
 			}

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
@@ -227,6 +228,60 @@ func (p *planner) maybePlanHook(ctx context.Context, stmt parser.Statement) (pla
 		}
 	}
 	return nil, nil
+}
+
+// delegateQuery creates a plan for a given SQL query.
+// In addition, the caller can specify an additional validation
+// function (initialCheck) that will be ran and checked for errors
+// during plan optimization. This is meant for checks that cannot be
+// run during a SQL prepare operation.
+func (p *planner) delegateQuery(
+	ctx context.Context,
+	name string,
+	sql string,
+	initialCheck func(ctx context.Context) error,
+	desiredTypes []parser.Type,
+) (planNode, error) {
+	// Prepare the sub-plan.
+	stmt, err := parser.ParseOne(sql)
+	if err != nil {
+		return nil, err
+	}
+	plan, err := p.newPlan(ctx, stmt, desiredTypes)
+	if err != nil {
+		return nil, err
+	}
+
+	if initialCheck == nil {
+		return plan, nil
+	}
+
+	// To enable late calling into initialCheck, we use a delayedNode.
+	return &delayedNode{
+		name: name,
+
+		// The columns attribute cannot be a straight-up reference to the sub-plan's
+		// own columns, because they can be modified in-place by setNeededColumns().
+		columns: append(sqlbase.ResultColumns(nil), planColumns(plan)...),
+
+		// The delayed constructor's only responsibility is to call
+		// initialCheck() - the plan is already constructed.
+		constructor: func(ctx context.Context, _ *planner) (planNode, error) {
+			if err := initialCheck(ctx); err != nil {
+				return nil, err
+			}
+			return plan, nil
+		},
+
+		// Breaking with the common usage pattern of delayedNode, where
+		// the plan attribute is initially nil (the constructor creates
+		// it), here we prepopulate the field with the sub-plan created
+		// above. We do this instead of simply returning the newly created
+		// sub-plan in a constructor closure, to ensure the sub-plan is
+		// properly Close()d if the delayedNode is discarded before its
+		// constructor is called.
+		plan: plan,
+	}, nil
 }
 
 // newPlan constructs a planNode from a statement. This is used

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -274,15 +274,17 @@ func (p *planner) fillFKTableMap(ctx context.Context, m sqlbase.TableLookupsByID
 	return nil
 }
 
-// isDatabaseVisible returns true if the given database is visible to the
-// current user. Only the current database and system databases are available
-// to ordinary users; everything is available to root.
-func (p *planner) isDatabaseVisible(dbName string) bool {
-	if p.session.User == security.RootUser {
+// isDatabaseVisible returns true if the given database is visible
+// given the provided prefix.
+// An empty prefix makes all databases visible.
+// System databases are always visible.
+// Otherwise only the database with the same name as the prefix is available.
+func isDatabaseVisible(dbName, prefix, user string) bool {
+	if isSystemDatabaseName(dbName) {
 		return true
-	} else if dbName == p.evalCtx.Database {
+	} else if dbName == prefix {
 		return true
-	} else if isSystemDatabaseName(dbName) {
+	} else if prefix == "" {
 		return true
 	}
 	return false

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -167,6 +167,9 @@ func (p *planner) setTxn(txn *client.Txn) {
 
 // query initializes a planNode from a SQL statement string. Close() must be
 // called on the returned planNode after use.
+// This function is not suitable for use in the planNode constructors directly:
+// the returned planNode has already been optimized.
+// Consider also (*planner).delegateQuery(...).
 func (p *planner) query(ctx context.Context, sql string, args ...interface{}) (planNode, error) {
 	if log.V(2) {
 		log.Infof(ctx, "internal query: %s", sql)

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -38,19 +38,19 @@ import (
 const (
 	checkSchemaQuery = `
 		SELECT SCHEMA_NAME
-		FROM information_schema.schemata
+		FROM "".information_schema.schemata
 		WHERE SCHEMA_NAME=$1
 		LIMIT 1`
 	checkTableQuery = `
 		SELECT TABLE_SCHEMA
-		FROM information_schema.tables
+		FROM "".information_schema.tables
 		WHERE
 			TABLE_SCHEMA=$1 AND
 			TABLE_NAME=$2
 		LIMIT 1`
 	checkTablePrivilegesQuery = `
 		SELECT TABLE_NAME
-		FROM information_schema.table_privileges
+		FROM "".information_schema.table_privileges
 		WHERE
 			TABLE_SCHEMA=$1 AND
 			TABLE_NAME=$2 AND
@@ -101,46 +101,6 @@ func checkTablePrivileges(ctx context.Context, p *planner, tn *parser.TableName)
 		return fmt.Errorf("user %s has no privileges on table %s", p.session.User, tn.String())
 	}
 	return nil
-}
-
-// runInDB runs the closure with the provided database set to the session's current
-// database, and resets the session's database afterwards. This is necessary to get
-// visibility into information_schema if the current user isn't root.
-func runInDB(p *planner, tempDB string, f func() error) error {
-	origDatabase := p.evalCtx.Database
-	p.evalCtx.Database = tempDB
-	err := f()
-	p.evalCtx.Database = origDatabase
-	return err
-}
-
-// queryInfoSchema queries the information_schema with the provided SQL query and
-// uses the results to populate a valuesNode.
-func queryInfoSchema(
-	ctx context.Context,
-	p *planner,
-	columns sqlbase.ResultColumns,
-	db string,
-	sql string,
-	args ...interface{},
-) (*valuesNode, error) {
-	v := p.newContainerValuesNode(columns, 0)
-	if err := runInDB(p, db, func() error {
-		rows, err := p.queryRows(ctx, sql, args...)
-		if err != nil {
-			return err
-		}
-		for _, r := range rows {
-			if _, err := v.rows.AddRow(ctx, r); err != nil {
-				return err
-			}
-		}
-		return nil
-	}); err != nil {
-		v.rows.Close(ctx)
-		return nil, err
-	}
-	return v, nil
 }
 
 func (p *planner) showClusterSetting(name string) (planNode, error) {
@@ -279,23 +239,7 @@ func (p *planner) Show(n *parser.Show) (planNode, error) {
 //   Notes: postgres does not have a SHOW COLUMNS statement.
 //          mysql only returns columns you have privileges on.
 func (p *planner) ShowColumns(ctx context.Context, n *parser.ShowColumns) (planNode, error) {
-	tn, err := n.Table.NormalizeWithDatabaseName(p.session.Database)
-	if err != nil {
-		return nil, err
-	}
-
-	columns := sqlbase.ResultColumns{
-		{Name: "Field", Typ: parser.TypeString},
-		{Name: "Type", Typ: parser.TypeString},
-		{Name: "Null", Typ: parser.TypeBool},
-		{Name: "Default", Typ: parser.TypeString},
-		{Name: "Indices", Typ: parser.TypeString},
-	}
-	return &delayedNode{
-		name:    "SHOW COLUMNS FROM " + tn.String(),
-		columns: columns,
-		constructor: func(ctx context.Context, p *planner) (planNode, error) {
-			const getColumnsQuery = `
+	const getColumnsQuery = `
 				SELECT
 					COLUMN_NAME AS "Field",
 					DATA_TYPE AS "Type",
@@ -307,33 +251,47 @@ func (p *planner) ShowColumns(ctx context.Context, n *parser.ShowColumns) (planN
 									ARRAY_AGG(INDEX_NAME) AS inames
 						 FROM
 								 (SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT, ORDINAL_POSITION
-										FROM information_schema.columns
-									 WHERE TABLE_SCHEMA=$1 AND TABLE_NAME=$2)
+										FROM "".information_schema.columns
+									 WHERE TABLE_SCHEMA=%[1]s AND TABLE_NAME=%[2]s)
 								 LEFT OUTER JOIN
 								 (SELECT COLUMN_NAME, INDEX_NAME
-										FROM information_schema.statistics
-									 WHERE TABLE_SCHEMA=$1 AND TABLE_NAME=$2)
+										FROM "".information_schema.statistics
+									 WHERE TABLE_SCHEMA=%[1]s AND TABLE_NAME=%[2]s)
 								 USING(COLUMN_NAME)
 						GROUP BY COLUMN_NAME, DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT, ORDINAL_POSITION
 					 )
 				ORDER BY ORDINAL_POSITION`
+	return p.showTableDetails(ctx, "SHOW COLUMNS", n.Table, getColumnsQuery)
+}
 
-			db := tn.Database()
-			if err := checkDBExists(ctx, p, db); err != nil {
-				return nil, err
-			}
+// showTableDetails extracts information about the given table using
+// the given query patterns in SQL. The query pattern must accept two
+// formatting parameters: the database and the table name, in that
+// order. They will be pre-formatted as SQL string literals.
+func (p *planner) showTableDetails(
+	ctx context.Context, showType string, t parser.NormalizableTableName, query string,
+) (planNode, error) {
+	tn, err := t.NormalizeWithDatabaseName(p.session.Database)
+	if err != nil {
+		return nil, err
+	}
+	db := tn.Database()
 
-			if err := checkTableExists(ctx, p, tn); err != nil {
-				return nil, err
-			}
+	initialCheck := func(ctx context.Context) error {
+		if err := checkDBExists(ctx, p, db); err != nil {
+			return err
+		}
+		if err := checkTableExists(ctx, p, tn); err != nil {
+			return err
+		}
+		return checkTablePrivileges(ctx, p, tn)
+	}
 
-			if err := checkTablePrivileges(ctx, p, tn); err != nil {
-				return nil, err
-			}
-
-			return queryInfoSchema(ctx, p, columns, db, getColumnsQuery, tn.Database(), tn.Table())
-		},
-	}, nil
+	return p.delegateQuery(ctx, showType,
+		fmt.Sprintf(query,
+			parser.EscapeSQLString(tn.Database()),
+			parser.EscapeSQLString(tn.Table())),
+		initialCheck, nil)
 }
 
 // showCreateInterleave returns an INTERLEAVE IN PARENT clause for the specified
@@ -609,12 +567,8 @@ WHERE message LIKE 'fetched: %'
 `
 	}
 
-	stmt, err := parser.ParseOne(fmt.Sprintf(traceClause, whereClause))
-	if err != nil {
-		return nil, err
-	}
-
-	plan, err := p.newPlan(ctx, stmt, nil)
+	plan, err := p.delegateQuery(ctx, "SHOW TRACE",
+		fmt.Sprintf(traceClause, whereClause), nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -689,13 +643,9 @@ WHERE message LIKE 'fetched: %'
 //   Notes: postgres does not have a "show databases"
 //          mysql has a "SHOW DATABASES" permission, but we have no system-level permissions.
 func (p *planner) ShowDatabases(ctx context.Context, n *parser.ShowDatabases) (planNode, error) {
-	const getDatabases = `SELECT SCHEMA_NAME AS "Database" FROM information_schema.schemata
-							ORDER BY "Database"`
-	stmt, err := parser.ParseOne(getDatabases)
-	if err != nil {
-		return nil, err
-	}
-	return p.newPlan(ctx, stmt, nil)
+	return p.delegateQuery(ctx, "SHOW DATABASES",
+		`SELECT SCHEMA_NAME AS "Database" FROM information_schema.schemata ORDER BY "Database"`,
+		nil, nil)
 }
 
 // ShowGrants returns grant details for the specified objects and users.
@@ -709,135 +659,92 @@ func (p *planner) ShowGrants(ctx context.Context, n *parser.ShowGrants) (planNod
 			"cannot use SHOW GRANTS without a target")
 	}
 
-	objectType := "Database"
-	if n.Targets.Tables != nil {
-		objectType = "Table"
-	}
+	var grantQuery bytes.Buffer
+	var params []string
+	var initCheck func(context.Context) error
 
-	columns := sqlbase.ResultColumns{
-		{Name: objectType, Typ: parser.TypeString},
-		{Name: "User", Typ: parser.TypeString},
-		{Name: "Privileges", Typ: parser.TypeString},
-	}
+	if n.Targets.Databases != nil {
+		// Get grants of database from information_schema.schema_privileges
+		// if the type of target is database.
+		dbNames := n.Targets.Databases.ToStrings()
 
-	return &delayedNode{
-		name:    "SHOW GRANTS",
-		columns: columns,
-		constructor: func(ctx context.Context, p *planner) (planNode, error) {
-			v := p.newContainerValuesNode(columns, 0)
-
-			queryFn := func(sql string, args ...interface{}) error {
-				rows, err := p.queryRows(ctx, sql, args...)
-				if err != nil {
+		initCheck = func(ctx context.Context) error {
+			for _, db := range dbNames {
+				if err := checkDBExists(ctx, p, db); err != nil {
 					return err
 				}
-				for _, r := range rows {
-					if _, err := v.rows.AddRow(ctx, r); err != nil {
-						return err
-					}
-				}
-				return nil
 			}
+			return nil
+		}
 
-			// Get grants of database from information_schema.schema_privileges
-			// if the type of target is database.
-			if n.Targets.Databases != nil {
-				// TODO(nvanbenschoten): Clean up parameter assignment throughout.
-				var params []interface{}
-				var paramHolders []string
-				paramSeq := 1
-				for _, db := range n.Targets.Databases.ToStrings() {
-					if err := checkDBExists(ctx, p, db); err != nil {
-						v.rows.Close(ctx)
-						return nil, err
-					}
+		for _, db := range dbNames {
+			params = append(params, parser.EscapeSQLString(db))
+		}
 
-					paramHolders = append(paramHolders, fmt.Sprintf("$%d", paramSeq))
-					paramSeq++
-					params = append(params, db)
-				}
-				schemaGrants := fmt.Sprintf(`SELECT TABLE_SCHEMA AS "Database", GRANTEE AS "User",
-									PRIVILEGE_TYPE AS "Privileges" FROM information_schema.schema_privileges
-									WHERE TABLE_SCHEMA IN (%s)`, strings.Join(paramHolders, ","))
-				if n.Grantees != nil {
-					paramHolders = paramHolders[:0]
-					for _, grantee := range n.Grantees.ToStrings() {
-						paramHolders = append(paramHolders, fmt.Sprintf("$%d", paramSeq))
-						params = append(params, grantee)
-						paramSeq++
-					}
-					schemaGrants = fmt.Sprintf(`%s AND GRANTEE IN(%s)`, schemaGrants, strings.Join(paramHolders, ","))
-				}
-				if err := queryFn(schemaGrants, params...); err != nil {
-					v.rows.Close(ctx)
-					return nil, err
-				}
+		fmt.Fprint(&grantQuery,
+			`SELECT TABLE_SCHEMA AS "Database", GRANTEE AS "User", PRIVILEGE_TYPE AS "Privileges" `+
+				`FROM "".information_schema.schema_privileges`)
+		if len(params) == 0 {
+			// There are no rows, but we can't simply return emptyNode{} because
+			// the result columns must still be defined.
+			grantQuery.WriteString(` WHERE false`)
+		} else {
+			fmt.Fprintf(&grantQuery, ` WHERE TABLE_SCHEMA IN (%s)`, strings.Join(params, ","))
+		}
+	} else {
+		// Get grants of table from information_schema.table_privileges
+		// if the type of target is table.
+		var allTables parser.TableNames
+
+		for _, tableTarget := range n.Targets.Tables {
+			tableGlob, err := tableTarget.NormalizeTablePattern()
+			if err != nil {
+				return nil, err
 			}
+			tables, err := expandTableGlob(ctx, p.txn, p.getVirtualTabler(),
+				p.session.Database, tableGlob)
+			if err != nil {
+				return nil, err
+			}
+			allTables = append(allTables, tables...)
+		}
 
-			// Get grants of table from information_schema.table_privileges
-			// if the type of target is table.
-			if n.Targets.Tables != nil {
-				// TODO(nvanbenschoten): Clean up parameter assignment throughout.
-				var params []interface{}
-				var paramHolders []string
-				paramSeq := 1
-				for _, tableTarget := range n.Targets.Tables {
-					tableGlob, err := tableTarget.NormalizeTablePattern()
-					if err != nil {
-						v.rows.Close(ctx)
-						return nil, err
-					}
-					tables, err := expandTableGlob(ctx, p.txn, p.getVirtualTabler(), p.session.Database, tableGlob)
-					if err != nil {
-						v.rows.Close(ctx)
-						return nil, err
-					}
-					for i := range tables {
-						if err := checkTableExists(ctx, p, &tables[i]); err != nil {
-							v.rows.Close(ctx)
-							return nil, err
-						}
-
-						paramHolders = append(paramHolders, fmt.Sprintf("($%d,$%d)",
-							paramSeq, paramSeq+1))
-						params = append(params, tables[i].Database(), tables[i].Table())
-						paramSeq += 2
-
-					}
-				}
-				if len(paramHolders) == 0 {
-					return v, nil
-				}
-				tableGrants := fmt.Sprintf(`SELECT TABLE_NAME, GRANTEE, PRIVILEGE_TYPE FROM information_schema.table_privileges
-									WHERE (TABLE_SCHEMA, TABLE_NAME) IN (%s)`, strings.Join(paramHolders, ","))
-				if n.Grantees != nil {
-					paramHolders = paramHolders[:0]
-					for _, grantee := range n.Grantees.ToStrings() {
-						paramHolders = append(paramHolders, fmt.Sprintf("$%d", paramSeq))
-						params = append(params, grantee)
-						paramSeq++
-					}
-					tableGrants = fmt.Sprintf(`%s AND GRANTEE IN(%s)`, tableGrants, strings.Join(paramHolders, ","))
-				}
-				if err := queryFn(tableGrants, params...); err != nil {
-					v.rows.Close(ctx)
-					return nil, err
+		initCheck = func(ctx context.Context) error {
+			for i := range allTables {
+				if err := checkTableExists(ctx, p, &allTables[i]); err != nil {
+					return err
 				}
 			}
+			return nil
+		}
 
-			// Sort the result by target name, user name and privileges.
-			return &sortNode{
-				p:    p,
-				plan: v,
-				ordering: sqlbase.ColumnOrdering{
-					{ColIdx: 0, Direction: encoding.Ascending},
-					{ColIdx: 1, Direction: encoding.Ascending},
-					{ColIdx: 2, Direction: encoding.Ascending},
-				},
-				columns: v.columns,
-			}, nil
-		},
-	}, nil
+		for i := range allTables {
+			params = append(params, fmt.Sprintf("(%s,%s)",
+				parser.EscapeSQLString(allTables[i].Database()),
+				parser.EscapeSQLString(allTables[i].Table())))
+		}
+
+		fmt.Fprint(&grantQuery,
+			`SELECT TABLE_NAME AS "Table", GRANTEE AS "User", PRIVILEGE_TYPE AS "Privileges" `+
+				`FROM "".information_schema.table_privileges`)
+		if len(params) == 0 {
+			// There are no rows, but we can't simply return emptyNode{} because
+			// the result columns must still be defined.
+			grantQuery.WriteString(` WHERE false`)
+		} else {
+			fmt.Fprintf(&grantQuery, ` WHERE (TABLE_SCHEMA, TABLE_NAME) IN (%s)`, strings.Join(params, ","))
+		}
+	}
+
+	if n.Grantees != nil {
+		params = params[:0]
+		for _, grantee := range n.Grantees.ToStrings() {
+			params = append(params, parser.EscapeSQLString(grantee))
+		}
+		fmt.Fprintf(&grantQuery, ` AND GRANTEE IN (%s)`, strings.Join(params, ","))
+	}
+	fmt.Fprint(&grantQuery, " ORDER BY 1,2,3")
+	return p.delegateQuery(ctx, "SHOW GRANTS", grantQuery.String(), initCheck, nil)
 }
 
 // ShowIndex returns all the indexes for a table.
@@ -845,26 +752,7 @@ func (p *planner) ShowGrants(ctx context.Context, n *parser.ShowGrants) (planNod
 //   Notes: postgres does not have a SHOW INDEXES statement.
 //          mysql requires some privilege for any column.
 func (p *planner) ShowIndex(ctx context.Context, n *parser.ShowIndex) (planNode, error) {
-	tn, err := n.Table.NormalizeWithDatabaseName(p.session.Database)
-	if err != nil {
-		return nil, err
-	}
-
-	columns := sqlbase.ResultColumns{
-		{Name: "Table", Typ: parser.TypeString},
-		{Name: "Name", Typ: parser.TypeString},
-		{Name: "Unique", Typ: parser.TypeBool},
-		{Name: "Seq", Typ: parser.TypeInt},
-		{Name: "Column", Typ: parser.TypeString},
-		{Name: "Direction", Typ: parser.TypeString},
-		{Name: "Storing", Typ: parser.TypeBool},
-		{Name: "Implicit", Typ: parser.TypeBool},
-	}
-	return &delayedNode{
-		name:    "SHOW INDEXES FROM " + tn.String(),
-		columns: columns,
-		constructor: func(ctx context.Context, p *planner) (planNode, error) {
-			const getIndexes = `
+	const getIndexes = `
 				SELECT
 					TABLE_NAME AS "Table",
 					INDEX_NAME AS "Name",
@@ -874,27 +762,9 @@ func (p *planner) ShowIndex(ctx context.Context, n *parser.ShowIndex) (planNode,
 					DIRECTION AS "Direction",
 					STORING AS "Storing",
 					IMPLICIT AS "Implicit"
-				FROM information_schema.statistics
-				WHERE
-					TABLE_SCHEMA=$1 AND
-					TABLE_NAME=$2`
-
-			db := tn.Database()
-			if err := checkDBExists(ctx, p, db); err != nil {
-				return nil, err
-			}
-
-			if err := checkTableExists(ctx, p, tn); err != nil {
-				return nil, err
-			}
-
-			if err := checkTablePrivileges(ctx, p, tn); err != nil {
-				return nil, err
-			}
-
-			return queryInfoSchema(ctx, p, columns, db, getIndexes, tn.Database(), tn.Table())
-		},
-	}, nil
+				FROM "".information_schema.statistics
+				WHERE TABLE_SCHEMA=%[1]s AND TABLE_NAME=%[2]s`
+	return p.showTableDetails(ctx, "SHOW INDEX", n.Table, getIndexes)
 }
 
 // ShowConstraints returns all the constraints for a table.
@@ -1063,12 +933,7 @@ func (p *planner) ShowQueries(ctx context.Context, n *parser.ShowQueries) (planN
 // ShowJobs returns all the jobs.
 // Privileges: None.
 func (p *planner) ShowJobs(ctx context.Context, n *parser.ShowJobs) (planNode, error) {
-	const getJobs = `TABLE crdb_internal.jobs`
-	stmt, err := parser.ParseOne(getJobs)
-	if err != nil {
-		return nil, err
-	}
-	return p.newPlan(ctx, stmt, nil)
+	return p.delegateQuery(ctx, "SHOW JOBS", "TABLE crdb_internal.jobs", nil, nil)
 }
 
 func (p *planner) ShowSessions(ctx context.Context, n *parser.ShowSessions) (planNode, error) {
@@ -1183,25 +1048,19 @@ func (p *planner) ShowTables(ctx context.Context, n *parser.ShowTables) (planNod
 	if name == "" {
 		return nil, errNoDatabase
 	}
+	initialCheck := func(ctx context.Context) error {
+		return checkDBExists(ctx, p, name)
+	}
 
-	columns := sqlbase.ResultColumns{{Name: "Table", Typ: parser.TypeString}}
-	return &delayedNode{
-		name:    "SHOW TABLES FROM " + name,
-		columns: columns,
-		constructor: func(ctx context.Context, p *planner) (planNode, error) {
-			const getTablesQuery = `
-				SELECT TABLE_NAME
-				FROM information_schema.tables
-				WHERE tables.TABLE_SCHEMA=$1
+	const getTablesQuery = `
+				SELECT TABLE_NAME AS "Table"
+				FROM "".information_schema.tables
+				WHERE tables.TABLE_SCHEMA=%[1]s
 				ORDER BY tables.TABLE_NAME`
 
-			if err := checkDBExists(ctx, p, name); err != nil {
-				return nil, err
-			}
-
-			return queryInfoSchema(ctx, p, columns, name, getTablesQuery, name)
-		},
-	}, nil
+	return p.delegateQuery(ctx, "SHOW TABLES",
+		fmt.Sprintf(getTablesQuery, parser.EscapeSQLString(name)),
+		initialCheck, nil)
 }
 
 // ShowTransactionStatus implements the plan for SHOW TRANSACTION STATUS.
@@ -1214,11 +1073,8 @@ func (p *planner) ShowTransactionStatus() (planNode, error) {
 // ShowUsers returns all the users.
 // Privileges: SELECT on system.users.
 func (p *planner) ShowUsers(ctx context.Context, n *parser.ShowUsers) (planNode, error) {
-	stmt, err := parser.ParseOne(`SELECT username FROM system.users ORDER BY 1`)
-	if err != nil {
-		return nil, err
-	}
-	return p.newPlan(ctx, stmt, nil)
+	return p.delegateQuery(ctx, "SHOW USERS",
+		`SELECT username FROM system.users ORDER BY 1`, nil, nil)
 }
 
 // Help returns usage information for the builtin functions


### PR DESCRIPTION
Summary:
- a new method `(*planner).delegateQuery` for all your future SHOW needs, you should use this instead of `(*planner).query()` or `queryRows()`
- much code in SHOW is factored/simplified

Motivations:
- the previous code was using `p.query` /  `containerValuesNode` all over the place, causing mandatory duplication of the rows in memory

