### PR TITLE
cherrypick: sql: fix a latent panic in the handling of UNION

### DIFF
--- a/pkg/sql/testdata/logic_test/union
+++ b/pkg/sql/testdata/logic_test/union
@@ -183,3 +183,16 @@ SELECT 1 EXCEPT SELECT '3'
 
 query error column z does not exist
 SELECT 1 UNION SELECT 3 ORDER BY z
+
+# Check that EXPLAIN properly releases memory for virtual tables.
+query ITTT
+EXPLAIN SELECT node_id FROM crdb_internal.node_build_info UNION VALUES(123)
+----
+0  union
+1  render
+2  virtual table
+2                 source  crdb_internal.node_build_info
+3  values
+3                 size    3 columns, 9 rows
+1  values
+1                 size    1 column, 1 row

--- a/pkg/sql/union.go
+++ b/pkg/sql/union.go
@@ -85,13 +85,11 @@ func (p *planner) UnionClause(
 	}
 
 	node := &unionNode{
-		right:     right,
-		left:      left,
-		rightDone: false,
-		leftDone:  false,
-		emitAll:   emitAll,
-		emit:      emit,
-		scratch:   make([]byte, 0),
+		right:   right,
+		left:    left,
+		emitAll: emitAll,
+		emit:    emit,
+		scratch: make([]byte, 0),
 	}
 	return node, nil
 }
@@ -132,8 +130,6 @@ func (p *planner) UnionClause(
 //    already emitted as many as were on the right, don't emit.
 type unionNode struct {
 	right, left planNode
-	rightDone   bool
-	leftDone    bool
 	emitAll     bool // emitAll is a performance optimization for UNION ALL.
 	emit        unionNodeEmit
 	scratch     []byte
@@ -157,14 +153,13 @@ func (n *unionNode) Spans(ctx context.Context) (reads, writes roachpb.Spans, err
 }
 
 func (n *unionNode) Values() parser.Datums {
-	switch {
-	case !n.rightDone:
+	if n.right != nil {
 		return n.right.Values()
-	case !n.leftDone:
-		return n.left.Values()
-	default:
-		return nil
 	}
+	if n.left != nil {
+		return n.left.Values()
+	}
+	return nil
 }
 
 func (n *unionNode) MarkDebug(mode explainMode) {
@@ -214,8 +209,8 @@ func (n *unionNode) readRight(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
-	n.rightDone = true
 	n.right.Close(ctx)
+	n.right = nil
 	return n.readLeft(ctx)
 }
 
@@ -249,8 +244,8 @@ func (n *unionNode) readLeft(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	n.leftDone = true
 	n.left.Close(ctx)
+	n.left = nil
 	return false, nil
 }
 
@@ -262,22 +257,23 @@ func (n *unionNode) Start(ctx context.Context) error {
 }
 
 func (n *unionNode) Next(ctx context.Context) (bool, error) {
-	switch {
-	case !n.rightDone:
+	if n.right != nil {
 		return n.readRight(ctx)
-	case !n.leftDone:
-		return n.readLeft(ctx)
-	default:
-		return false, nil
 	}
+	if n.left != nil {
+		return n.readLeft(ctx)
+	}
+	return false, nil
 }
 
 func (n *unionNode) Close(ctx context.Context) {
-	switch {
-	case !n.rightDone:
+	if n.right != nil {
 		n.right.Close(ctx)
-	case !n.leftDone:
+		n.right = nil
+	}
+	if n.left != nil {
 		n.left.Close(ctx)
+		n.left = nil
 	}
 }
 


### PR DESCRIPTION
If a unionNode was Close()d before it had exhausted its source operands
(in particular when EXPLAIN is applied on a UNION), the source operands
would not be both Close()d properly.

This would in turn cause a memory reporting leak, and subsequently an
assertion panic that the memory was not de-registered properly.

cc @cockroachdb/release 