### PR TITLE
engineccl: check errors while testing MVCCIncrementalIterator

### DIFF
--- a/pkg/ccl/storageccl/engineccl/mvcc_test.go
+++ b/pkg/ccl/storageccl/engineccl/mvcc_test.go
@@ -56,6 +56,9 @@ func assertEqualKVs(
 		for iter.Reset(startKey, endKey); iter.Valid(); iter.Next() {
 			kvs = append(kvs, engine.MVCCKeyValue{Key: iter.Key(), Value: iter.Value()})
 		}
+		if err := iter.Error(); err != nil {
+			t.Fatal(err)
+		}
 
 		if len(kvs) != len(expected) {
 			t.Fatalf("got %d kvs but expected %d: %v", len(kvs), len(expected), kvs)


### PR DESCRIPTION
This is going to fail with

```
-- FAIL: TestMVCCIterateIncremental (0.03s)
    --- FAIL: TestMVCCIterateIncremental/NormalIterators (0.02s)
        --- FAIL: TestMVCCIterateIncremental/NormalIterators/intents3 (0.00s)
        	mvcc_test.go:60: conflicting intents on "/db1"
    --- FAIL: TestMVCCIterateIncremental/TimeBoundIterators (0.01s)
        --- FAIL: TestMVCCIterateIncremental/TimeBoundIterators/intents3 (0.00s)
        	mvcc_test.go:60: conflicting intents on "/db1"
```

which doesn't seem right, but maybe I'm crazy.