### PR TITLE
ui: Font and Margin Refactoring

### DIFF
--- a/pkg/ui/src/views/app/containers/layout/index.tsx
+++ b/pkg/ui/src/views/app/containers/layout/index.tsx
@@ -43,8 +43,9 @@ export default class extends React.Component<RouterState, {}> {
           // TODO(mrtracy): The title can be moved down to individual pages,
           // it is not always the top element on the page (for example, on
           // pages with a back button).
-          !!title ? <section className="header">{ title }</section>
-                  : null
+          !!title
+            ? <section className="section"><h1>{ title }</h1></section>
+            : null
         }
         { children }
       </StickyContainer>

--- a/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
+++ b/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
@@ -28,7 +28,6 @@ $viz-sides = 62px
   border 1px solid rgba(0, 0, 0, .1)
   // prevents borders from doubling up
   margin-bottom 10px
-  width 925px
 
   &__content
     padding 0 10px 15px

--- a/pkg/ui/src/views/cluster/containers/events/events.styl
+++ b/pkg/ui/src/views/cluster/containers/events/events.styl
@@ -46,8 +46,3 @@
   a
     color $link-color
     text-decoration none
-
-.events-table .sort-table__cell
-  font-family Lato-Regular
-  font-weight normal
-  letter-spacing normal

--- a/pkg/ui/src/views/cluster/containers/events/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/events/index.tsx
@@ -207,8 +207,8 @@ export class EventPageUnconnected extends React.Component<EventPageProps, {}> {
       <section className="section parent-link">
         <Link to="/cluster">&lt; Back to Cluster</Link>
       </section>
-      <section className="header header--subsection">
-        Events
+      <section className="section section--heading">
+        <h2>Events</h2>
       </section>
       <section className="section l-columns">
         <div className="l-columns__left events-table">

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -208,15 +208,17 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
           <TimeScaleDropdown />
         </PageConfigItem>
       </PageConfig>
-      <div className="section l-columns">
-        <div className="chart-group l-columns__left">
-          { graphComponents }
+      <section className="section">
+        <div className="l-columns">
+          <div className="chart-group l-columns__left">
+            { graphComponents }
+          </div>
+          <div className="l-columns__right">
+            <Alerts />
+            <ClusterSummaryBar nodesSummary={this.props.nodesSummary} nodeSources={nodeSources} />
+          </div>
         </div>
-        <div className="l-columns__right">
-          <Alerts />
-          <ClusterSummaryBar nodesSummary={this.props.nodesSummary} nodeSources={nodeSources} />
-        </div>
-      </div>
+      </section>
     </div>;
   }
 }

--- a/pkg/ui/src/views/cluster/containers/nodeLogs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeLogs/index.tsx
@@ -67,8 +67,8 @@ class Logs extends React.Component<LogProps & RouterState, {}> {
         <section className="section parent-link">
           <Link to="/cluster/nodes">&lt; Back to Node List</Link>
         </section>
-        <div className="header header--subsection">
-          Logs Node { this.props.params[nodeIDAttr] } / { nodeAddress }
+        <div className="section section--heading">
+          <h2>Logs Node { this.props.params[nodeIDAttr] } / { nodeAddress }</h2>
         </div>
         <section className="section">
           { content }

--- a/pkg/ui/src/views/cluster/containers/nodeOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeOverview/index.tsx
@@ -58,8 +58,8 @@ class NodeOverview extends React.Component<NodeOverviewProps, {}> {
         <section className="section parent-link">
           <Link to="/cluster/nodes">&lt; Back to Node List</Link>
         </section>
-        <div className="header header--subsection">
-          {`Node ${node.desc.node_id} / ${node.desc.address.address_field}`}
+        <div className="section section--heading">
+          <h2>{`Node ${node.desc.node_id} / ${node.desc.address.address_field}`}</h2>
         </div>
         <section className="section l-columns">
           <div className="l-columns__left">

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -61,9 +61,9 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
     }
 
     return <div>
-      <div className="header header--subsection">
-        Live Nodes
-      </div>
+      <section className="section section--heading">
+        <h2>Live Nodes</h2>
+      </section>
       <section className="section">
         <NodeSortedTable
           data={statuses}
@@ -165,8 +165,8 @@ class NotLiveNodeList extends React.Component<NotLiveNodeListProps, {}> {
     }
 
     return <div>
-      <section className="header header--subsection">
-        {title}
+      <section className="section section--heading">
+        <h2>{title}</h2>
       </section>
       <section className="section">
         <NodeSortedTable

--- a/pkg/ui/src/views/databases/containers/databaseGrants/index.tsx
+++ b/pkg/ui/src/views/databases/containers/databaseGrants/index.tsx
@@ -43,41 +43,45 @@ class DatabaseSummaryGrants extends DatabaseSummaryBase {
 
     const numTables = tableInfos && tableInfos.length || 0;
 
-    return <div className="database-summary l-columns">
-      <div className="database-summary-title">
-        { dbID }
-      </div>
-      <div className="l-columns__left">
-        <div className="database-summary-table sql-table">
-        {
-          (numTables === 0) ? "" :
-          <DatabaseGrantsSortedTable
-              data={grants}
-              sortSetting={sortSetting}
-              onChangeSortSetting={(setting) => this.props.setSort(setting) }
-              columns={[
-                {
-                    title: "User",
-                    cell: (grant) => grant.user,
-                    sort: (grant) => grant.user,
-                },
-                {
-                    title: "Grants",
-                    cell: (grant) => grant.privileges.join(", "),
-                },
-              ]}/>
-        }
+    return (
+      <div className="database-summary">
+        <div className="database-summary-title">
+          <h2>{dbID}</h2>
+        </div>
+        <div className="l-columns">
+          <div className="l-columns__left">
+            <div className="database-summary-table sql-table">
+              {
+                (numTables === 0) ? "" :
+                  <DatabaseGrantsSortedTable
+                    data={grants}
+                    sortSetting={sortSetting}
+                    onChangeSortSetting={(setting) => this.props.setSort(setting)}
+                    columns={[
+                      {
+                        title: "User",
+                        cell: (grant) => grant.user,
+                        sort: (grant) => grant.user,
+                      },
+                      {
+                        title: "Grants",
+                        cell: (grant) => grant.privileges.join(", "),
+                      },
+                    ]} />
+              }
+            </div>
+          </div>
+          <div className="l-columns__right">
+            <SummaryBar>
+              <SummaryHeadlineStat
+                title="Total Users"
+                tooltip="Total users that have been granted permissions on this table."
+                value={this.totalUsers()} />
+            </SummaryBar>
+          </div>
         </div>
       </div>
-      <div className="l-columns__right">
-        <SummaryBar>
-          <SummaryHeadlineStat
-            title="Total Users"
-            tooltip="Total users that have been granted permissions on this table."
-            value={ this.totalUsers() }/>
-        </SummaryBar>
-      </div>
-    </div>;
+    );
   }
 }
 

--- a/pkg/ui/src/views/databases/containers/databaseTables/index.tsx
+++ b/pkg/ui/src/views/databases/containers/databaseTables/index.tsx
@@ -52,77 +52,81 @@ class DatabaseSummaryTables extends DatabaseSummaryBase {
 
     const numTables = tableInfos && tableInfos.length || 0;
 
-    return <div className="database-summary l-columns">
-      <div className="database-summary-title">
-        { dbID }
-      </div>
-      <div className="l-columns__left">
-        <div className="database-summary-table sql-table">
-        {
-          (numTables === 0) ? "" :
-          <DatabaseTableListSortedTable
-              data={tableInfos}
-              sortSetting={sortSetting}
-              onChangeSortSetting={(setting) => this.props.setSort(setting) }
-              columns={[
+    return (
+      <div className="database-summary">
+        <div className="database-summary-title">
+          <h2>{dbID}</h2>
+        </div>
+        <div className="l-columns">
+          <div className="l-columns__left">
+            <div className="database-summary-table sql-table">
               {
-                title: "Table Name",
-                cell: (tableInfo) => {
-                  return (
-                    <div className="sort-table__unbounded-column">
-                      <Link to={`/databases/database/${dbID}/table/${tableInfo.name}`}>{tableInfo.name}</Link>
-                    </div>
-                  );
-                },
-                sort: (tableInfo) => tableInfo.name,
-                className: "expand-link", // don't pad the td element to allow the link to expand
-              },
-              {
-                title: "Size",
-                cell: (tableInfo) => Bytes(tableInfo.size),
-                sort: (tableInfo) => tableInfo.size,
-              },
-              {
-                title: "Ranges",
-                cell: (tableInfo) => tableInfo.rangeCount,
-                sort: (tableInfo) => tableInfo.rangeCount,
-              },
-              {
-                title: "# of Columns",
-                cell: (tableInfo) => tableInfo.numColumns,
-                sort: (tableInfo) => tableInfo.numColumns,
-              },
-              {
-                title: "# of Indices",
-                cell: (tableInfo) => tableInfo.numIndices,
-                sort: (tableInfo) => tableInfo.numIndices,
-              },
-              {
-                title: "Schema Change",
-                cell: (_tableInfo) => "",
-              },
-              ]}/>
-        }
+                (numTables === 0) ? "" :
+                  <DatabaseTableListSortedTable
+                    data={tableInfos}
+                    sortSetting={sortSetting}
+                    onChangeSortSetting={(setting) => this.props.setSort(setting)}
+                    columns={[
+                      {
+                        title: "Table Name",
+                        cell: (tableInfo) => {
+                          return (
+                            <div className="sort-table__unbounded-column">
+                              <Link to={`/databases/database/${dbID}/table/${tableInfo.name}`}>{tableInfo.name}</Link>
+                            </div>
+                          );
+                        },
+                        sort: (tableInfo) => tableInfo.name,
+                        className: "expand-link", // don't pad the td element to allow the link to expand
+                      },
+                      {
+                        title: "Size",
+                        cell: (tableInfo) => Bytes(tableInfo.size),
+                        sort: (tableInfo) => tableInfo.size,
+                      },
+                      {
+                        title: "Ranges",
+                        cell: (tableInfo) => tableInfo.rangeCount,
+                        sort: (tableInfo) => tableInfo.rangeCount,
+                      },
+                      {
+                        title: "# of Columns",
+                        cell: (tableInfo) => tableInfo.numColumns,
+                        sort: (tableInfo) => tableInfo.numColumns,
+                      },
+                      {
+                        title: "# of Indices",
+                        cell: (tableInfo) => tableInfo.numIndices,
+                        sort: (tableInfo) => tableInfo.numIndices,
+                      },
+                      {
+                        title: "Schema Change",
+                        cell: (_tableInfo) => "",
+                      },
+                    ]} />
+              }
+            </div>
+          </div>
+          <div className="l-columns__right">
+            <SummaryBar>
+              <SummaryHeadlineStat
+                title="Database Size"
+                tooltip="Total disk size of this database."
+                value={this.totalSize()}
+                format={Bytes} />
+              <SummaryHeadlineStat
+                title={(numTables === 1) ? "Table" : "Tables"}
+                tooltip="The total number of tables in this database."
+                value={numTables} />
+              <SummaryHeadlineStat
+                title="Total Range Count"
+                tooltip="The total ranges across all tables in this database."
+                value={this.totalRangeCount()} />
+            </SummaryBar>
+          </div>
         </div>
       </div>
-      <div className="l-columns__right">
-        <SummaryBar>
-          <SummaryHeadlineStat
-            title="Database Size"
-            tooltip="Total disk size of this database."
-            value={ this.totalSize() }
-            format={ Bytes }/>
-          <SummaryHeadlineStat
-            title={ (numTables === 1) ? "Table" : "Tables" }
-            tooltip="The total number of tables in this database."
-            value={ numTables }/>
-          <SummaryHeadlineStat
-            title="Total Range Count"
-            tooltip="The total ranges across all tables in this database."
-            value={ this.totalRangeCount() }/>
-        </SummaryBar>
-      </div>
-    </div>;
+    );
   }
 }
 

--- a/pkg/ui/src/views/databases/containers/tableDetails/index.tsx
+++ b/pkg/ui/src/views/databases/containers/tableDetails/index.tsx
@@ -87,7 +87,7 @@ class TableMain extends React.Component<TableMainProps, {}> {
         </section>
         <section className="section">
           <div className="database-summary-title">
-            { this.props.params[tableNameAttr] }
+            <h2>{ this.props.params[tableNameAttr] }</h2>
           </div>
           <div className="content l-columns">
             <div className="l-columns__left">

--- a/pkg/ui/src/views/databases/containers/tableDetails/sqlhighlight.styl
+++ b/pkg/ui/src/views/databases/containers/tableDetails/sqlhighlight.styl
@@ -3,8 +3,8 @@
 .sql-highlight
   font-family Inconsolata-Regular
   padding 20px
-  display inline-block
   width 100%
+  margin-bottom 10px
 
 .sql-highlight.hljs
     background-color $headings-color

--- a/pkg/ui/src/views/shared/components/dropdown/dropdown.styl
+++ b/pkg/ui/src/views/shared/components/dropdown/dropdown.styl
@@ -7,7 +7,7 @@ $dropdown-hover-color = darken($background-color, 2.5%)
   text-transform uppercase
   letter-spacing 2px
   line-height 17px
-  padding 1rem 2rem
+  padding 12px 24px
   vertical-align middle
   border 1px solid $button-border-color
   border-radius 4px
@@ -38,13 +38,13 @@ $dropdown-hover-color = darken($background-color, 2.5%)
 
     &:first-child
       border-right 1px solid $button-border-color
-      padding 1rem 20px
+      padding 12px 24px
       border-top-left-radius 4px
       border-bottom-left-radius 4px
 
     &:last-child
       border-left 1px solid $button-border-color
-      padding 1rem 20px
+      padding 12px 24px
       border-top-right-radius 4px
       border-bottom-right-radius 4px
 

--- a/pkg/ui/src/views/shared/components/summaryBar/summarybar.styl
+++ b/pkg/ui/src/views/shared/components/summaryBar/summarybar.styl
@@ -2,10 +2,10 @@
 @require '~styl/base/palette.styl'
 
 .summary-section
-  width calc(100% - 48px)
+  width 100%
   float left
   background-color white
-  margin 0 6px 10px
+  margin-bottom 10px
   padding 15px 24px 12px
   border-radius 5px
   border 1px solid rgba(0, 0, 0, .1)

--- a/pkg/ui/src/views/shared/util/table.styl
+++ b/pkg/ui/src/views/shared/util/table.styl
@@ -29,7 +29,7 @@ $table-base
     &--header
       padding 20px
       font-size 12px
-      font-weight normal
+      font-weight bold
       letter-spacing 2px
       text-transform uppercase
       text-align left
@@ -39,6 +39,7 @@ $table-base
   &__cell
     padding 10px 20px
     border-right $table-cell-border
+    font-weight inherit
 
     a
       font-weight 400

--- a/pkg/ui/styl/base/typography.styl
+++ b/pkg/ui/styl/base/typography.styl
@@ -14,55 +14,28 @@ implied. See the License for the specific language governing
 permissions and limitations under the License.
 */
 
-$font-base-size = 14px
-$font-line-height = $font-base-size * 1.5
-$root-size = $font-line-height / 2
-
-// A really simple implementation of a Modular Scale.
-// For an example, see http://www.modularscale.com/
-$font-ratio = 1.2
-$font-size-table = {
-  '5': $font-base-size * ($font-ratio**5),
-  '4': $font-base-size * ($font-ratio**4),
-  '3': $font-base-size * ($font-ratio**3),
-  '2': $font-base-size * ($font-ratio**2),
-  '1': $font-base-size * ($font-ratio),
-  '0': $font-base-size,
-  '-1': $font-base-size * (1 / $font-ratio),
-  '-2': $font-base-size * (1 / $font-ratio**2),
-  '-3': $font-base-size * (1 / $font-ratio**3),
-}
-
-// Select a modular font size from the table.
-modular-font-size($font-size)
-  font-size: remove-unit($font-size-table[$font-size]/$root-size) rem
-
 // Using the same strategy as sassline: establish the root size (rems) as 1/2
 // of our chosen baseline height. This allows easy, integer math for baseline units
 // using rems.
 html
-  font-size $root-size
+  font-size 14px
 
 body
-  line-height 2rem
+  line-height 20px
   font-size $font-base-size
-  font-family Lato-Medium
+  font-family Lato-Regular
   font-weight 400
 
 h1
-  modular-font-size '3'
-  line-height 4rem
-  font-weight 600
+  font-size 24px
+  font-weight bold
+  letter-spacing 5px
+  text-transform uppercase
 
 h2
-  modular-font-size '3'
-  line-height 4rem
-  font-weight 500
-
-h3
-  modular-font-size '1'
-  line-height 2rem
-  font-weight 600
+  padding 12px 0
+  font-size 20px
+  font-weight bold
 
 font-face('Lato-Heavy')
 font-face('Lato-Bold')

--- a/pkg/ui/styl/layout/layout.styl
+++ b/pkg/ui/styl/layout/layout.styl
@@ -23,6 +23,7 @@ $subnav-background  = $background-color
   height 100vh
   min-width 100%
   padding-left $nav-width
+  padding-top 20px
 
   &:after
     content ""
@@ -46,47 +47,39 @@ $subnav-background  = $background-color
   &__item
     float left
     list-style none
-    margin-right 2rem
-
-.header
-  flex 0 0 auto
-  color $headings-color
-  font-size 24px
-  padding 24px 24px 12px
-  text-transform uppercase
-  font-family Lato-Bold
-  letter-spacing 5px
-
-.header--subsection
-  text-transform none
-  letter-spacing 0
+    margin-right 24px
 
 .l-columns
-  clearfix()
-  min-width 1360px
+  display flex
+  margin 0 -5px
 
 .l-columns__left
-  float left
-  width 930px
+  flex 3
+  padding 0 5px
 
 .l-columns__right
-  float left
-  width 380px
+  flex 1
+  padding 0 5px
 
 .page.help-us
   height 100%
   background-color white
 
 .section
-  flex 1 1 auto
+  flex 0 0 auto
   padding 12px 24px
   max-width 1350px
   clearfix()
 
+  &--heading
+    padding-top 0
+    padding-bottom 0
+
 .parent-link a
   color $link-color
-  font-size 13px
+  font-size 14px
   font-family Lato-Regular
+  font-weight bold
   text-transform uppercase
   text-decoration none
   letter-spacing 2px

--- a/pkg/ui/styl/layout/navigation-bar.styl
+++ b/pkg/ui/styl/layout/navigation-bar.styl
@@ -32,7 +32,6 @@ $subnav-underline-height = 3px
   min-height 350px
   z-index $z-index-navigation
   width $nav-width
-  modular-font-size '1'
   background-color $navbar-bg
   border-right 1px solid $table-border-color
   margin 0
@@ -56,7 +55,7 @@ $subnav-underline-height = 3px
     float left
     color $body-color
     list-style-type none
-    line-height 1.8rem
+    line-height 18px
 
     &.normal
       path
@@ -112,13 +111,12 @@ $subnav-underline-height = 3px
     display flex
     flex-flow row nowrap
     justify-content flex-start
-    modular-font-size '1'
     color $tooltip-color
     list-style-type none
     line-height $subnav-height - $subnav-underline-height
 
     font-family Lato-Bold
-    font-size 1.1rem
+    font-size 9px
     max-width calc(100vw - 80px)
     @media (min-width: 1300px)
       max-width 1300px

--- a/pkg/ui/styl/pages/databases.styl
+++ b/pkg/ui/styl/pages/databases.styl
@@ -1,10 +1,5 @@
 .database-summary
-  clearfix()
+  margin-bottom 24px
 
 .database-summary-title
-  font-size 24px
-  margin 0 0 1em
   text-align left
-
-.database-summary-table table
-  width 100%

--- a/pkg/ui/styl/shame.styl
+++ b/pkg/ui/styl/shame.styl
@@ -63,7 +63,7 @@
 
 .dropdown--side-arrows
   .Select
-    padding 1rem 20px !important
+    padding 12px 24px !important
   .Select-arrow-zone
     display none
 


### PR DESCRIPTION
A number of refactors to improve font sizes and layout margins
throughout the project; done in a pair-programming session with
@kuanluo.

+ Adjusted "l-columns" style, used on several pages to divide the main
layout into two columns, to use flex layout. Column spacing and gutters
is now much more consistent between all pages, and there are no longer
any column-related spacing styles applied to specific elements on any
pages.
+ Started using h1 and h2 tags to represent titles across all pages.
Removed "header" and "header--subsection" classes.
+ Removed several usages of "rem", instead preferring px units
in all places.
+ Adjusted margins in several places to match Kuan's current style guide.