### PR TITLE
sql/parser: regclass casts must normalize input

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -173,6 +173,27 @@ SELECT relname from pg_class where oid='a'::regclass
 ----
 a
 
+## Regression for #16767 - ensure regclass casts use normalized table names
+
+statement ok
+CREATE TABLE hasCase (id INT PRIMARY KEY)
+
+query T
+SELECT relname from pg_class where oid='hasCase'::regclass
+----
+hascase
+
+statement ok
+CREATE TABLE "quotedCase" (id INT PRIMARY KEY)
+
+query error relation 'quotedcase' does not exist
+SELECT relname from pg_class where oid='quotedCase'::regclass
+
+query T
+SELECT relname from pg_class where oid='"quotedCase"'::regclass
+----
+quotedCase
+
 # a non-root user with sufficient permissions can get the OID of a table from
 # the current database
 

--- a/pkg/sql/parser/constant.go
+++ b/pkg/sql/parser/constant.go
@@ -268,7 +268,7 @@ func (expr *NumVal) ResolveAsType(ctx *SemaContext, typ Type) (Datum, error) {
 			return nil, err
 		}
 		oid := NewDOid(*d.(*DInt))
-		oid.symanticType = oidTypeToColType(typ)
+		oid.semanticType = oidTypeToColType(typ)
 		return oid, nil
 	default:
 		return nil, fmt.Errorf("could not resolve %T %v into a %T", expr, expr, typ)

--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -2241,16 +2241,16 @@ func (*DTable) Size() uintptr { return unsafe.Sizeof(DTable{}) }
 type DOid struct {
 	// A DOid embeds a DInt, the underlying integer OID for this OID datum.
 	DInt
-	// symanticType indicates the particular variety of OID this datum is, whether raw
+	// semanticType indicates the particular variety of OID this datum is, whether raw
 	// oid or a reg* type.
-	symanticType *OidColType
+	semanticType *OidColType
 	// name is set to the resolved name of this OID, if available.
 	name string
 }
 
 // MakeDOid is a helper routine to create a DOid initialized from a DInt.
 func MakeDOid(d DInt) DOid {
-	return DOid{DInt: d, symanticType: oidColTypeOid, name: ""}
+	return DOid{DInt: d, semanticType: oidColTypeOid, name: ""}
 }
 
 // NewDOid is a helper routine to create a *DOid initialized from a DInt.
@@ -2263,7 +2263,7 @@ func NewDOid(d DInt) *DOid {
 // returns it.
 func (d *DOid) AsRegProc(name string) *DOid {
 	d.name = name
-	d.symanticType = oidColTypeRegProc
+	d.semanticType = oidColTypeRegProc
 	return d
 }
 
@@ -2291,7 +2291,7 @@ func (d *DOid) Compare(ctx *EvalContext, other Datum) int {
 
 // Format implements the Datum interface.
 func (d *DOid) Format(buf *bytes.Buffer, f FmtFlags) {
-	if d.symanticType == oidColTypeOid || d.name == "" {
+	if d.semanticType == oidColTypeOid || d.name == "" {
 		FormatNode(buf, f, &d.DInt)
 	} else {
 		encodeSQLStringWithFlags(buf, d.name, FmtBareStrings)
@@ -2307,18 +2307,18 @@ func (d *DOid) IsMin() bool { return d.DInt.IsMin() }
 // Next implements the Datum interface.
 func (d *DOid) Next() (Datum, bool) {
 	next, ok := d.DInt.Next()
-	return &DOid{*next.(*DInt), d.symanticType, ""}, ok
+	return &DOid{*next.(*DInt), d.semanticType, ""}, ok
 }
 
 // Prev implements the Datum interface.
 func (d *DOid) Prev() (Datum, bool) {
 	prev, ok := d.DInt.Prev()
-	return &DOid{*prev.(*DInt), d.symanticType, ""}, ok
+	return &DOid{*prev.(*DInt), d.semanticType, ""}, ok
 }
 
 // ResolvedType implements the Datum interface.
 func (d *DOid) ResolvedType() Type {
-	return oidColTypeToType(d.symanticType)
+	return oidColTypeToType(d.semanticType)
 }
 
 // Size implements the Datum interface.
@@ -2327,13 +2327,13 @@ func (d *DOid) Size() uintptr { return unsafe.Sizeof(*d) }
 // max implements the Datum interface.
 func (d *DOid) max() (Datum, bool) {
 	max, ok := d.DInt.max()
-	return &DOid{*max.(*DInt), d.symanticType, ""}, ok
+	return &DOid{*max.(*DInt), d.semanticType, ""}, ok
 }
 
 // min implements the Datum interface.
 func (d *DOid) min() (Datum, bool) {
 	min, ok := d.DInt.min()
-	return &DOid{*min.(*DInt), d.symanticType, ""}, ok
+	return &DOid{*min.(*DInt), d.semanticType, ""}, ok
 }
 
 // DOidWrapper is a Datum implementation which is a wrapper around a Datum, allowing

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -1702,7 +1702,7 @@ type EvalPlanner interface {
 	QueryRow(ctx context.Context, sql string, args ...interface{}) (Datums, error)
 
 	// QualifyWithDatabase resolves a possibly unqualified table name into a
-	// table name that is qualified by database.
+	// normalized table name that is qualified by database.
 	QualifyWithDatabase(ctx context.Context, t *NormalizableTableName) (*TableName, error)
 }
 
@@ -2418,7 +2418,9 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 			// Trim whitespace and unwrap outer quotes if necessary.
 			// This is required to mimic postgres.
 			s = strings.TrimSpace(s)
+			var hadQuotes bool
 			if len(s) > 1 && s[0] == '"' && s[len(s)-1] == '"' {
+				hadQuotes = true
 				s = s[1 : len(s)-1]
 			}
 
@@ -2462,6 +2464,12 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 			case oidColTypeRegClass:
 				// Resolving a table name requires looking at the search path to
 				// determine the database that owns it.
+				// If the table wasn't quoted, normalize it. This matches the behavior
+				// when creating tables - table names are normalized (downcased) unless
+				// they're double quoted.
+				if !hadQuotes {
+					s = ReNormalizeName(s)
+				}
 				t := &NormalizableTableName{
 					TableNameReference: UnresolvedName{
 						Name(s),
@@ -2474,7 +2482,7 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 				// table because we only have the database name, not its OID, which is
 				// what is stored in pg_class. This extra join means we can't use
 				// queryOid like everyone else.
-				return queryOidWithJoin(ctx, typ, NewDString(s),
+				return queryOidWithJoin(ctx, typ, NewDString(tn.Table()),
 					"JOIN pg_catalog.pg_namespace ON relnamespace = pg_namespace.oid",
 					fmt.Sprintf("AND nspname = '%s'", tn.Database()))
 			default:

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -2041,7 +2041,7 @@ var regTypeInfos = map[*OidColType]regTypeInfo{
 func queryOidWithJoin(
 	ctx *EvalContext, typ *OidColType, d Datum, joinClause string, additionalWhere string,
 ) (*DOid, error) {
-	ret := &DOid{symanticType: typ}
+	ret := &DOid{semanticType: typ}
 	info := regTypeInfos[typ]
 	var queryCol string
 	switch d.(type) {
@@ -2391,25 +2391,25 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 		case *DOid:
 			switch typ {
 			case oidColTypeOid:
-				return &DOid{symanticType: typ, DInt: v.DInt}, nil
+				return &DOid{semanticType: typ, DInt: v.DInt}, nil
 			default:
 				oid, err := queryOid(ctx, typ, v)
 				if err != nil {
 					oid = NewDOid(v.DInt)
-					oid.symanticType = typ
+					oid.semanticType = typ
 				}
 				return oid, nil
 			}
 		case *DInt:
 			switch typ {
 			case oidColTypeOid:
-				return &DOid{symanticType: typ, DInt: *v}, nil
+				return &DOid{semanticType: typ, DInt: *v}, nil
 			default:
 				tmpOid := NewDOid(*v)
 				oid, err := queryOid(ctx, typ, tmpOid)
 				if err != nil {
 					oid = tmpOid
-					oid.symanticType = typ
+					oid.semanticType = typ
 				}
 				return oid, nil
 			}
@@ -2428,7 +2428,7 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 				if err != nil {
 					return nil, err
 				}
-				return &DOid{symanticType: typ, DInt: *i}, nil
+				return &DOid{semanticType: typ, DInt: *i}, nil
 			case oidColTypeRegProc, oidColTypeRegProcedure:
 				// Trim procedure type parameters, e.g. `max(int)` becomes `max`.
 				// Postgres only does this when the cast is ::regprocedure, but we're
@@ -2451,7 +2451,7 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 				colType, err := ParseType(s)
 				if err == nil {
 					datumType := CastTargetToDatumType(colType)
-					return &DOid{symanticType: typ, DInt: DInt(datumType.Oid()), name: datumType.SQLName()}, nil
+					return &DOid{semanticType: typ, DInt: DInt(datumType.Oid()), name: datumType.SQLName()}, nil
 				}
 				// Fall back to searching pg_type, since we don't provide syntax for
 				// every postgres type that we understand OIDs for.


### PR DESCRIPTION
Previously, table name inputs to regclass casts were not properly
normalized, leading to improper behavior. Table names that were not all
lowercase were not selectable via regclass casts unless they were
manually lowercased.

Also, correct variable name typo: s/symantic/semantic/ in `DOid`.

Fixes #16767.