### PR TITLE
cherry-pick: storage: don't perform intent resolution after a failed Raft application

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -364,6 +364,11 @@ func (ts *TestServer) Stores() *storage.Stores {
 	return ts.node.stores
 }
 
+// GetStores is part of TestServerInterface.
+func (ts *TestServer) GetStores() interface{} {
+	return ts.node.stores
+}
+
 // Engines returns the TestServer's engines.
 func (ts *TestServer) Engines() []engine.Engine {
 	return ts.engines

--- a/pkg/storage/main_test.go
+++ b/pkg/storage/main_test.go
@@ -87,5 +87,7 @@ func TestMain(m *testing.M) {
 		}
 	}
 
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+
 	os.Exit(code)
 }

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -682,7 +682,7 @@ func (r *Replica) cancelPendingCommandsLocked() {
 			Err:           roachpb.NewError(roachpb.NewAmbiguousResultError("removing replica")),
 			ProposalRetry: proposalRangeNoLongerExists,
 		}
-		p.finish(resp)
+		p.finishRaftApplication(resp)
 	}
 	r.mu.proposals = map[storagebase.CmdIDKey]*ProposalData{}
 }
@@ -3233,7 +3233,7 @@ func (r *Replica) refreshProposalsLocked(refreshAtDelta int, reason refreshRaftR
 			delete(r.mu.proposals, idKey)
 			log.VEventf(p.ctx, 2, "refresh (reason: %s) returning AmbiguousResultError for command "+
 				"without MaxLeaseIndex: %v", reason, p.command)
-			p.finish(proposalResult{Err: roachpb.NewError(
+			p.finishRaftApplication(proposalResult{Err: roachpb.NewError(
 				roachpb.NewAmbiguousResultError(
 					fmt.Sprintf("unknown status for command without MaxLeaseIndex "+
 						"at refreshProposalsLocked time (refresh reason: %s)", reason)))})
@@ -3265,9 +3265,9 @@ func (r *Replica) refreshProposalsLocked(refreshAtDelta int, reason refreshRaftR
 			delete(r.mu.proposals, idKey)
 			log.Eventf(p.ctx, "retry proposal %x: %s", p.idKey, reason)
 			if reason == reasonSnapshotApplied {
-				p.finish(proposalResult{ProposalRetry: proposalAmbiguousShouldBeReevaluated})
+				p.finishRaftApplication(proposalResult{ProposalRetry: proposalAmbiguousShouldBeReevaluated})
 			} else {
-				p.finish(proposalResult{ProposalRetry: proposalIllegalLeaseIndex})
+				p.finishRaftApplication(proposalResult{ProposalRetry: proposalIllegalLeaseIndex})
 			}
 			numShouldRetry++
 		} else if reason == reasonTicks && p.proposedAtTicks > r.mu.ticks-refreshAtDelta {
@@ -3315,7 +3315,7 @@ func (r *Replica) refreshProposalsLocked(refreshAtDelta int, reason refreshRaftR
 		log.Eventf(p.ctx, "re-submitting command %x to Raft: %s", p.idKey, reason)
 		if err := r.submitProposalLocked(p); err != nil {
 			delete(r.mu.proposals, p.idKey)
-			p.finish(proposalResult{Err: roachpb.NewError(err), ProposalRetry: proposalErrorReproposing})
+			p.finishRaftApplication(proposalResult{Err: roachpb.NewError(err), ProposalRetry: proposalErrorReproposing})
 		}
 	}
 }
@@ -3648,7 +3648,7 @@ func (r *Replica) processRaftCommand(
 				// Assert against another defer trying to use the context after
 				// the client has been signaled.
 				ctx = nil
-				copyProposal.finish(proposalResult{ProposalRetry: proposalIllegalLeaseIndex})
+				copyProposal.finishRaftApplication(proposalResult{ProposalRetry: proposalIllegalLeaseIndex})
 			}()
 		}
 	}
@@ -3755,7 +3755,7 @@ func (r *Replica) processRaftCommand(
 	}
 
 	if proposedLocally {
-		proposal.finish(response)
+		proposal.finishRaftApplication(response)
 	} else if response.Err != nil {
 		log.VEventf(ctx, 1, "error executing raft command %s: %s", raftCmd.BatchRequest, response.Err)
 	}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -1821,7 +1822,7 @@ func TestLeaseConcurrent(t *testing.T) {
 						// otherwise its context (and tracing span) may be used after the
 						// client cleaned up.
 						delete(tc.repl.mu.proposals, proposal.idKey)
-						proposal.finish(proposalResult{Err: roachpb.NewErrorf(origMsg)})
+						proposal.finishRaftApplication(proposalResult{Err: roachpb.NewErrorf(origMsg)})
 						return
 					}
 					if err := defaultSubmitProposalLocked(tc.repl, proposal); err != nil {
@@ -7809,5 +7810,90 @@ func TestCommandTooLarge(t *testing.T) {
 		[]byte(strings.Repeat("a", int(maxCommandSize.Get()))))
 	if _, pErr := tc.SendWrapped(&args); !testutils.IsPError(pErr, "command is too large") {
 		t.Fatalf("did not get expected error: %v", pErr)
+	}
+}
+
+// Test that, if the application of a Raft command fails, intents are not
+// resolved. This is because we don't want intent resolution to take place if an
+// EndTransaction fails.
+func TestErrorInRaftApplicationClearsIntents(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var storeKnobs StoreTestingKnobs
+	var filterActive int32
+	key := roachpb.Key("a")
+	rkey, err := keys.Addr(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	storeKnobs.TestingApplyFilter = func(filterArgs storagebase.ApplyFilterArgs) *roachpb.Error {
+		if atomic.LoadInt32(&filterActive) == 1 && filterArgs.StartKey.Equal(rkey) {
+			return roachpb.NewErrorf("boom")
+		}
+		return nil
+	}
+	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{Store: &storeKnobs}})
+	defer s.Stopper().Stop(context.TODO())
+
+	splitKey := roachpb.Key("b")
+	if err := kvDB.AdminSplit(context.TODO(), splitKey); err != nil {
+		t.Fatal(err)
+	}
+
+	txn := newTransaction("test", key, roachpb.NormalUserPriority,
+		enginepb.SERIALIZABLE, s.Clock(),
+	)
+	btArgs, _ := beginTxnArgs(key, txn)
+	var ba roachpb.BatchRequest
+	ba.Header.Txn = txn
+	ba.Add(&btArgs)
+	if _, pErr := s.DistSender().Send(context.TODO(), ba); pErr != nil {
+		t.Fatal(pErr.GoError())
+	}
+
+	// Fail future command applications.
+	atomic.StoreInt32(&filterActive, 1)
+
+	// Propose an EndTransaction with a remote intent. The _remote_ part is
+	// important because intents local to the txn's range are resolved inline with
+	// the EndTransaction execution.
+	// We do this by using replica.propose() directly, as opposed to going through
+	// the DistSender, because we want to inspect the proposal's result after the
+	// injected error.
+	etArgs, _ := endTxnArgs(txn, true /* commit */)
+	etArgs.IntentSpans = []roachpb.Span{{Key: roachpb.Key("bb")}}
+	ba = roachpb.BatchRequest{}
+	ba.Timestamp = s.Clock().Now()
+	ba.Header.Txn = txn
+	ba.Add(&etArgs)
+	// Get a reference to the txn's replica.
+	stores := s.GetStores().(*Stores)
+	rangeID, _, err := stores.LookupReplica(rkey, nil /* end */)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := stores.GetStore(s.GetFirstStoreID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	repl, err := store.GetReplica(rangeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exLease, _ := repl.getLease()
+	ch, _, err := repl.propose(
+		context.Background(), exLease, ba, nil /* endCmds */, nil, /* spans */
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	propRes := <-ch
+	if !testutils.IsPError(propRes.Err, "boom") {
+		t.Fatalf("expected injected error, got: %v", propRes.Err)
+	}
+	if len(propRes.Intents) != 0 {
+		t.Fatal("expected intents to have been cleared")
 	}
 }

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -991,8 +991,9 @@ func TestStoreSendBadRange(t *testing.T) {
 }
 
 // splitTestRange splits a range. This does *not* fully emulate a real split
-// and should not be used in new tests. Tests that need splits should live in
-// client_split_test.go and use AdminSplit instead of this function.
+// and should not be used in new tests. Tests that need splits should either live in
+// client_split_test.go and use AdminSplit instead of this function or use the
+// TestServerInterface.
 // See #702
 // TODO(bdarnell): convert tests that use this function to use AdminSplit instead.
 func splitTestRange(store *Store, key, splitKey roachpb.RKey, t *testing.T) *Replica {

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -117,6 +117,10 @@ type TestServerInterface interface {
 	// store on this node.
 	GetFirstStoreID() roachpb.StoreID
 
+	// GetStores returns the collection of stores from this TestServer's node.
+	// The return value is of type *storage.Stores.
+	GetStores() interface{}
+
 	// SplitRange splits the range containing splitKey.
 	SplitRange(
 		splitKey roachpb.Key,


### PR DESCRIPTION
This patch fixes a bug causing us to erroneously resolve intents when
the application of a Raft command returned an error. This meant that we
could have an erroring EndTransaction application, and still commit the
transaction's data.

Fixes #16724 

cc @cockroachdb/release 