### PR TITLE
sql: unify implicitTxn refs and unify Get interface

### DIFF
--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1272,7 +1272,7 @@ CREATE TABLE pg_catalog.pg_settings (
 	populate: func(_ context.Context, p *planner, addRow func(...parser.Datum) error) error {
 		for _, vName := range varNames {
 			gen := varGen[vName]
-			value := gen.Get(p)
+			value := gen.Get(p.session)
 			valueDatum := parser.NewDString(value)
 			if err := addRow(
 				parser.NewDString(strings.ToLower(vName)), // name

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -250,7 +250,7 @@ func (p *planner) Show(n *parser.Show) (planNode, error) {
 			case `all`:
 				for _, vName := range varNames {
 					gen := varGen[vName]
-					value := gen.Get(p)
+					value := gen.Get(p.session)
 					if _, err := v.rows.AddRow(
 						ctx, parser.Datums{parser.NewDString(vName), parser.NewDString(value)},
 					); err != nil {
@@ -262,7 +262,7 @@ func (p *planner) Show(n *parser.Show) (planNode, error) {
 				// The key in varGen is guaranteed to exist thanks to the
 				// check above.
 				gen := varGen[name]
-				value := gen.Get(p)
+				value := gen.Get(p.session)
 				if _, err := v.rows.AddRow(ctx, parser.Datums{parser.NewDString(value)}); err != nil {
 					v.rows.Close(ctx)
 					return nil, err

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -120,6 +120,8 @@ var varGen = map[string]sessionVar{
 
 			if len(dbName) != 0 {
 				// Verify database descriptor exists.
+				session.TxnState.mu.RLock()
+				defer session.TxnState.mu.RUnlock()
 				if _, err := MustGetDatabaseDesc(ctx, session.TxnState.mu.txn, &session.virtualSchemas, dbName); err != nil {
 					return err
 				}
@@ -309,13 +311,19 @@ var varGen = map[string]sessionVar{
 	},
 
 	`transaction isolation level`: {
-		// TODO(couchand): determine if we need to lock here (is this the session's main goroutine?)
-		Get: func(session *Session) string { return session.TxnState.mu.txn.Isolation().String() },
+		Get: func(session *Session) string {
+			session.TxnState.mu.RLock()
+			defer session.TxnState.mu.RUnlock()
+			return session.TxnState.mu.txn.Isolation().String()
+		},
 	},
 
 	`transaction priority`: {
-		// TODO(couchand): determine if we need to lock here (is this the session's main goroutine?)
-		Get: func(session *Session) string { return session.TxnState.mu.txn.UserPriority().String() },
+		Get: func(session *Session) string {
+			session.TxnState.mu.RLock()
+			defer session.TxnState.mu.RUnlock()
+			return session.TxnState.mu.txn.UserPriority().String()
+		},
 	},
 
 	`transaction status`: {

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -317,7 +317,7 @@ var varGen = map[string]sessionVar{
 	},
 
 	`transaction status`: {
-		Get: func(p *planner) string { return getTransactionState(&p.session.TxnState, p.autoCommit) },
+		Get: func(p *planner) string { return getTransactionState(&p.session.TxnState) },
 	},
 
 	`trace`: {


### PR DESCRIPTION
This PR finishes up the last items that were identified during development of #16746 but left off of that.  The first commit unifies all references to `implicitTxn` to use the flag from `txnState` rather than passing it around separately.  The second commit updates `Get` for session vars to use just the session and not a whole planner.