### PR TITLE
storage: make RelocateRanges robust

### DIFF
--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -223,7 +223,7 @@ func doExpandPlan(
 	case *splitNode:
 		n.rows, err = doExpandPlan(ctx, p, noParams, n.rows)
 
-	case *relocateNode:
+	case *testingRelocateNode:
 		n.rows, err = doExpandPlan(ctx, p, noParams, n.rows)
 
 	case *valuesNode:
@@ -535,7 +535,7 @@ func simplifyOrderings(plan planNode, usefulOrdering sqlbase.ColumnOrdering) pla
 	case *splitNode:
 		n.rows = simplifyOrderings(n.rows, nil)
 
-	case *relocateNode:
+	case *testingRelocateNode:
 		n.rows = simplifyOrderings(n.rows, nil)
 
 	case *valuesNode:

--- a/pkg/sql/filter_opt.go
+++ b/pkg/sql/filter_opt.go
@@ -314,7 +314,7 @@ func (p *planner) propagateFilters(
 			return plan, extraFilter, err
 		}
 
-	case *relocateNode:
+	case *testingRelocateNode:
 		if n.rows, err = p.triggerFilterPropagation(ctx, n.rows); err != nil {
 			return plan, extraFilter, err
 		}

--- a/pkg/sql/limit_opt.go
+++ b/pkg/sql/limit_opt.go
@@ -163,7 +163,7 @@ func applyLimit(plan planNode, numRows int64, soft bool) {
 	case *splitNode:
 		setUnlimited(n.rows)
 
-	case *relocateNode:
+	case *testingRelocateNode:
 		setUnlimited(n.rows)
 
 	case *valuesNode:

--- a/pkg/sql/needed_columns.go
+++ b/pkg/sql/needed_columns.go
@@ -185,7 +185,7 @@ func setNeededColumns(plan planNode, needed []bool) {
 	case *splitNode:
 		setNeededColumns(n.rows, allColumns(n.rows))
 
-	case *relocateNode:
+	case *testingRelocateNode:
 		setNeededColumns(n.rows, allColumns(n.rows))
 
 	case *alterTableNode:

--- a/pkg/sql/parser/split.go
+++ b/pkg/sql/parser/split.go
@@ -42,9 +42,9 @@ func (node *Split) Format(buf *bytes.Buffer, f FmtFlags) {
 	FormatNode(buf, f, node.Rows)
 }
 
-// Relocate represents an `ALTER TABLE/INDEX .. TESTING_RELOCATE ..`
+// TestingRelocate represents an `ALTER TABLE/INDEX .. TESTING_RELOCATE ..`
 // statement.
-type Relocate struct {
+type TestingRelocate struct {
 	// Only one of Table and Index can be set.
 	Table *NormalizableTableName
 	Index *TableNameWithIndex
@@ -55,7 +55,7 @@ type Relocate struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *Relocate) Format(buf *bytes.Buffer, f FmtFlags) {
+func (node *TestingRelocate) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString("ALTER ")
 	if node.Index != nil {
 		buf.WriteString("INDEX ")

--- a/pkg/sql/parser/sql.go
+++ b/pkg/sql/parser/sql.go
@@ -7392,14 +7392,14 @@ sqldefault:
 		//line sql.y:1847
 		{
 			/* SKIP DOC */
-			sqlVAL.union.val = &Relocate{Table: sqlDollar[3].union.newNormalizableTableName(), Rows: sqlDollar[5].union.slct()}
+			sqlVAL.union.val = &TestingRelocate{Table: sqlDollar[3].union.newNormalizableTableName(), Rows: sqlDollar[5].union.slct()}
 		}
 	case 263:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
 		//line sql.y:1851
 		{
 			/* SKIP DOC */
-			sqlVAL.union.val = &Relocate{Index: sqlDollar[3].union.tableWithIdx(), Rows: sqlDollar[5].union.slct()}
+			sqlVAL.union.val = &TestingRelocate{Index: sqlDollar[3].union.tableWithIdx(), Rows: sqlDollar[5].union.slct()}
 		}
 	case 264:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1867,12 +1867,12 @@ testing_relocate_stmt:
   ALTER TABLE qualified_name TESTING_RELOCATE select_stmt
   {
     /* SKIP DOC */
-    $$.val = &Relocate{Table: $3.newNormalizableTableName(), Rows: $5.slct()}
+    $$.val = &TestingRelocate{Table: $3.newNormalizableTableName(), Rows: $5.slct()}
   }
 | ALTER INDEX table_name_with_index TESTING_RELOCATE select_stmt
   {
     /* SKIP DOC */
-    $$.val = &Relocate{Index: $3.tableWithIdx(), Rows: $5.slct()}
+    $$.val = &TestingRelocate{Index: $3.tableWithIdx(), Rows: $5.slct()}
   }
 
 scatter_stmt:

--- a/pkg/sql/parser/stmt.go
+++ b/pkg/sql/parser/stmt.go
@@ -310,10 +310,10 @@ func (n *RenameTable) StatementTag() string {
 }
 
 // StatementType implements the Statement interface.
-func (*Relocate) StatementType() StatementType { return Rows }
+func (*TestingRelocate) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*Relocate) StatementTag() string { return "TESTING_RELOCATE" }
+func (*TestingRelocate) StatementTag() string { return "TESTING_RELOCATE" }
 
 // StatementType implements the Statement interface.
 func (*Restore) StatementType() StatementType { return Rows }
@@ -632,7 +632,7 @@ func (n *ParenSelect) String() string              { return AsString(n) }
 func (n *PauseJob) String() string                 { return AsString(n) }
 func (n *Prepare) String() string                  { return AsString(n) }
 func (n *ReleaseSavepoint) String() string         { return AsString(n) }
-func (n *Relocate) String() string                 { return AsString(n) }
+func (n *TestingRelocate) String() string          { return AsString(n) }
 func (n *RenameColumn) String() string             { return AsString(n) }
 func (n *RenameDatabase) String() string           { return AsString(n) }
 func (n *RenameIndex) String() string              { return AsString(n) }

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -154,7 +154,7 @@ var _ planNode = &insertNode{}
 var _ planNode = &joinNode{}
 var _ planNode = &limitNode{}
 var _ planNode = &ordinalityNode{}
-var _ planNode = &relocateNode{}
+var _ planNode = &testingRelocateNode{}
 var _ planNode = &renderNode{}
 var _ planNode = &scanNode{}
 var _ planNode = &scatterNode{}
@@ -358,8 +358,8 @@ func (p *planner) newPlan(
 		return p.newPlan(ctx, n.Select, desiredTypes)
 	case *parser.PauseJob:
 		return p.PauseJob(ctx, n)
-	case *parser.Relocate:
-		return p.Relocate(ctx, n)
+	case *parser.TestingRelocate:
+		return p.TestingRelocate(ctx, n)
 	case *parser.RenameColumn:
 		return p.RenameColumn(ctx, n)
 	case *parser.RenameDatabase:
@@ -489,8 +489,8 @@ func (p *planner) prepare(ctx context.Context, stmt parser.Statement) (planNode,
 		return p.ShowRanges(ctx, n)
 	case *parser.Split:
 		return p.Split(ctx, n)
-	case *parser.Relocate:
-		return p.Relocate(ctx, n)
+	case *parser.TestingRelocate:
+		return p.TestingRelocate(ctx, n)
 	case *parser.Scatter:
 		return p.Scatter(ctx, n)
 	case *parser.Update:

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -82,7 +82,7 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		// Nodes with a fixed schema.
 	case *explainDistSQLNode:
 		return n.getColumns(mut, explainDistSQLColumns)
-	case *relocateNode:
+	case *testingRelocateNode:
 		return n.getColumns(mut, relocateNodeColumns)
 	case *scatterNode:
 		return n.getColumns(mut, scatterNodeColumns)

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -273,7 +273,7 @@ func (v *planVisitor) visit(plan planNode) {
 	case *splitNode:
 		v.visit(n.rows)
 
-	case *relocateNode:
+	case *testingRelocateNode:
 		v.visit(n.rows)
 
 	case *insertNode:
@@ -512,7 +512,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&joinNode{}):             "join",
 	reflect.TypeOf(&limitNode{}):            "limit",
 	reflect.TypeOf(&ordinalityNode{}):       "ordinality",
-	reflect.TypeOf(&relocateNode{}):         "relocate",
+	reflect.TypeOf(&testingRelocateNode{}):  "testingRelocate",
 	reflect.TypeOf(&renderNode{}):           "render",
 	reflect.TypeOf(&scanNode{}):             "scan",
 	reflect.TypeOf(&scatterNode{}):          "scatter",


### PR DESCRIPTION
... by retrying aggressively. I don't know how test-only this is, so I did not
go overboard. As is, it may retry forever on permanent errors (barring context
cancellation). Perhaps this is enough? Let the review decide.

Fixes #16729.
Fixes #15646.
Fixes #16010.
Fixes #16400.