### PR TITLE
sql: cleanups, bug fixes & optimizations

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -462,20 +462,20 @@ CREATE TABLE crdb_internal.node_statement_statistics (
 var crdbInternalSessionTraceTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE crdb_internal.session_trace(
-  TXN_IDX INT NOT NULL,            -- The transaction's 0-based index, among all
+  txn_idx     INT NOT NULL,        -- The transaction's 0-based index, among all
                                    -- transactions that have been traced.
-																   -- Only filled for the first log message in a
-																   -- transaction's top-level span.
-  SPAN_IDX INT NOT NULL,           -- The span's index.
-  MESSAGE_IDX INT NOT NULL,        -- The message's index within its span.
-  TIMESTAMP TIMESTAMPTZ NOT NULL,  -- The message's timestamp.
-  DURATION INTERVAL,               -- The span's duration. Set only on the first
+                                   -- Only filled for the first log message in a
+                                   -- transaction's top-level span.
+  span_idx    INT NOT NULL,        -- The span's index.
+  message_idx INT NOT NULL,        -- The message's index within its span.
+  timestamp   TIMESTAMPTZ NOT NULL,-- The message's timestamp.
+  duration    INTERVAL,            -- The span's duration. Set only on the first
                                    -- (dummy) message on a span.
                                    -- NULL if the span was not finished at the time
                                    -- the trace has been collected.
-  OPERATION STRING NULL,           -- The span's operation. Set only on
+  operation   STRING NULL,         -- The span's operation. Set only on
                                    -- the first (dummy) message in a span.
-  MESSAGE STRING NOT NULL          -- The logged message.
+  message     STRING NOT NULL      -- The logged message.
 );
 `,
 	populate: func(ctx context.Context, p *planner, addRow func(...parser.Datum) error) error {

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -209,10 +209,16 @@ func doExpandPlan(
 		plan, err = expandRenderNode(ctx, p, params, n)
 
 	case *delayedNode:
-		n.plan, err = n.constructor(ctx, p)
-		if err == nil {
-			n.plan, err = doExpandPlan(ctx, p, params, n.plan)
+		var newPlan planNode
+		newPlan, err = n.constructor(ctx, p)
+		if err != nil {
+			return plan, err
 		}
+		newPlan, err = doExpandPlan(ctx, p, params, newPlan)
+		if err != nil {
+			return plan, err
+		}
+		plan = newPlan
 
 	case *splitNode:
 		n.rows, err = doExpandPlan(ctx, p, noParams, n.rows)

--- a/pkg/sql/filter_opt.go
+++ b/pkg/sql/filter_opt.go
@@ -302,6 +302,13 @@ func (p *planner) propagateFilters(
 			return plan, extraFilter, err
 		}
 
+	case *delayedNode:
+		if n.plan != nil {
+			if n.plan, err = p.triggerFilterPropagation(ctx, n.plan); err != nil {
+				return plan, extraFilter, err
+			}
+		}
+
 	case *splitNode:
 		if n.rows, err = p.triggerFilterPropagation(ctx, n.rows); err != nil {
 			return plan, extraFilter, err
@@ -317,7 +324,6 @@ func (p *planner) propagateFilters(
 	case *createDatabaseNode:
 	case *createIndexNode:
 	case *createUserNode:
-	case *delayedNode:
 	case *dropDatabaseNode:
 	case *dropIndexNode:
 	case *dropTableNode:

--- a/pkg/sql/limit_opt.go
+++ b/pkg/sql/limit_opt.go
@@ -130,6 +130,11 @@ func applyLimit(plan planNode, numRows int64, soft bool) {
 	case *ordinalityNode:
 		applyLimit(n.source, numRows, soft)
 
+	case *delayedNode:
+		if n.plan != nil {
+			applyLimit(n.plan, numRows, soft)
+		}
+
 	case *deleteNode:
 		setUnlimited(n.run.rows)
 	case *updateNode:
@@ -148,11 +153,6 @@ func applyLimit(plan planNode, numRows int64, soft bool) {
 		setUnlimited(n.plan)
 	case *explainPlanNode:
 		if n.expanded {
-			setUnlimited(n.plan)
-		}
-
-	case *delayedNode:
-		if n.plan != nil {
 			setUnlimited(n.plan)
 		}
 

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -115,96 +115,74 @@ query ITTT
 EXPLAIN SHOW DATABASES
 ----
 0  sort
-0                 order   +"Database"
+0          order  +"Database"
 1  render
-2  virtual table
-2                 source  information_schema.schemata
-3  values
-3                 size    4 columns, 6 rows
+2  values
+2          size   4 columns, 6 rows
 
 query ITTT
 EXPLAIN SHOW TABLES
 ----
-0  virtual table
-0                 source  SHOW TABLES FROM test
-1  values
-1                 size    1 column, 1 row
+0  values
+0          size  1 column, 1 row
 
 query ITTT
 EXPLAIN SHOW DATABASE
 ----
-0  virtual table
-0                 source  SHOW database
-1  values
-1                 size    1 column, 1 row
+0  values
+0          size  1 column, 1 row
 
 query ITTT
 EXPLAIN SHOW TIME ZONE
 ----
-0 virtual table
-0                 source  SHOW TIME ZONE
-1 values
-1                 size    1 column, 1 row
+0  values
+0          size  1 column, 1 row
 
 query ITTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
 ----
-0  virtual table
-0                 source  SHOW default_transaction_isolation
-1  values
-1                 size    1 column, 1 row
+0  values
+0          size  1 column, 1 row
 
 query ITTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
 ----
-0 virtual table
-0                 source  SHOW TRANSACTION ISOLATION LEVEL
-1 values
-1                 size    1 column, 1 row
+0  values
+0          size  1 column, 1 row
 
 query ITTT
 EXPLAIN SHOW TRANSACTION PRIORITY
 ----
-0 virtual table
-0                 source  SHOW TRANSACTION PRIORITY
-1 values
-1                 size    1 column, 1 row
+0  values
+0          size  1 column, 1 row
 
 query ITTT
 EXPLAIN SHOW COLUMNS FROM foo
 ----
-0  virtual table
-0                 source  SHOW COLUMNS FROM foo
-1  values
-1                 size    5 columns, 1 row
+0  values
+0          size  5 columns, 1 row
 
 query ITTT
 EXPLAIN SHOW GRANTS ON foo
 ----
-0  virtual table
-0                 source  SHOW GRANTS
-1  sort
-1                 order   +"Table",+"User",+"Privileges"
-2  values
-2                 size    3 columns, 1 row
+0  sort
+0          order  +"Table",+"User",+"Privileges"
+1  values
+1          size   3 columns, 1 row
 
 query ITTT
 EXPLAIN SHOW INDEX FROM foo
 ----
-0  virtual table
-0                 source  SHOW INDEXES FROM foo
-1  values
-1                 size    8 columns, 3 rows
+0  values
+0          size  8 columns, 3 rows
 
 query ITTT
 EXPLAIN SHOW CONSTRAINTS FROM foo
 ----
-0  virtual table
-0                 source  SHOW CONSTRAINTS FROM foo
-1  sort
-1                 order   +"Table",+"Name"
-2  values
-2                 size    5 columns, 0 rows
+0  sort
+0          order  +"Table",+"Name"
+1  values
+1          size   5 columns, 0 rows
 
 query ITTT
 EXPLAIN SHOW USERS

--- a/pkg/sql/logictest/testdata/logic_test/grant_database
+++ b/pkg/sql/logictest/testdata/logic_test/grant_database
@@ -9,7 +9,7 @@ SHOW GRANTS ON DATABASE a
 Database User Privileges
 a        root ALL
 
-statement error TODO\(marc\): implement SHOW GRANT with no targets
+statement error cannot use SHOW GRANTS without a target
 SHOW GRANTS
 
 statement error user root does not have ALL privileges

--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -764,56 +764,38 @@ SELECT * FROM [EXPLAIN SELECT
   ] WHERE type <> 'values' AND field <> 'size'
 ----
 0   sort
-0                  order     +pktable_schem,+pktable_name,+fk_name,+key_seq
+0              order     +pktable_schem,+pktable_name,+fk_name,+key_seq
 1   render
 2   join
-2                  type      inner
-2                  equality  (oid) = (relnamespace)
-3   virtual table
-3                  source    pg_catalog.pg_namespace
+2              type      inner
+2              equality  (oid) = (relnamespace)
 3   join
-3                  type      inner
-3                  equality  (oid, oid) = (attrelid, confrelid)
-4   virtual table
-4                  source    pg_catalog.pg_class
+3              type      inner
+3              equality  (oid, oid) = (attrelid, confrelid)
 4   join
-4                  type      inner
-5   virtual table
-5                  source    pg_catalog.pg_attribute
+4              type      inner
 5   join
-5                  type      inner
-5                  equality  (oid) = (relnamespace)
+5              type      inner
+5              equality  (oid) = (relnamespace)
 6   filter
-7   virtual table
-7                  source    pg_catalog.pg_namespace
 6   join
-6                  type      inner
-6                  equality  (oid, oid) = (attrelid, conrelid)
+6              type      inner
+6              equality  (oid, oid) = (attrelid, conrelid)
 7   filter
-8   virtual table
-8                  source    pg_catalog.pg_class
 7   join
-7                  type      inner
-8   virtual table
-8                  source    pg_catalog.pg_attribute
+7              type      inner
 8   join
-8                  type      inner
-8                  equality  (oid) = (objid)
+8              type      inner
+8              equality  (oid) = (objid)
 9   filter
-10  virtual table
-10                 source    pg_catalog.pg_constraint
 9   join
-9                  type      cross
+9              type      cross
 10  generator
 10  join
-10                 type      inner
-10                 equality  (refobjid) = (oid)
+10             type      inner
+10             equality  (refobjid) = (oid)
 11  filter
-12  virtual table
-12                 source    pg_catalog.pg_depend
 11  filter
-12  virtual table
-12                 source    pg_catalog.pg_class
 
 query TTTTTTTTIIITTI
 SELECT     NULL::text  AS pktable_cat,

--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -197,9 +197,7 @@ EXPLAIN SELECT node_id FROM crdb_internal.node_build_info UNION VALUES(123)
 ----
 0  union
 1  render
-2  virtual table
-2                 source  crdb_internal.node_build_info
-3  values
-3                 size    3 columns, 9 rows
+2  values
+2          size  3 columns, 9 rows
 1  values
-1                 size    1 column, 1 row
+1          size  1 column, 1 row

--- a/pkg/sql/needed_columns.go
+++ b/pkg/sql/needed_columns.go
@@ -84,6 +84,12 @@ func setNeededColumns(plan planNode, needed []bool) {
 	case *valuesNode:
 		markOmitted(n.columns, needed)
 
+	case *delayedNode:
+		if n.plan != nil {
+			setNeededColumns(n.plan, needed)
+		}
+		markOmitted(n.columns, needed)
+
 	case *scanNode:
 		copy(n.valNeededForCol, needed)
 		for i := range needed {
@@ -187,7 +193,6 @@ func setNeededColumns(plan planNode, needed []bool) {
 	case *createDatabaseNode:
 	case *createIndexNode:
 	case *createUserNode:
-	case *delayedNode:
 	case *dropDatabaseNode:
 	case *dropIndexNode:
 	case *dropTableNode:

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -354,7 +354,7 @@ func (p *planner) showCreateInterleave(
 		sharedPrefixLen += int(ancestor.SharedPrefixLen)
 	}
 	interleavedColumnNames := quoteNames(idx.ColumnNames[:sharedPrefixLen]...)
-	s := fmt.Sprintf(" INTERLEAVE IN PARENT %s (%s)", parentTable.Name, interleavedColumnNames)
+	s := fmt.Sprintf(" INTERLEAVE IN PARENT %s (%s)", parser.Name(parentTable.Name), interleavedColumnNames)
 	return s, nil
 }
 

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -701,7 +701,8 @@ func (p *planner) ShowDatabases(ctx context.Context, n *parser.ShowDatabases) (p
 //          mysql only returns the user's privileges.
 func (p *planner) ShowGrants(ctx context.Context, n *parser.ShowGrants) (planNode, error) {
 	if n.Targets == nil {
-		return nil, errors.Errorf("TODO(marc): implement SHOW GRANT with no targets")
+		return nil, pgerror.Unimplemented("SHOW GRANTS <no target>",
+			"cannot use SHOW GRANTS without a target")
 	}
 
 	objectType := "Database"

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -674,10 +674,14 @@ WHERE message LIKE 'fetched: %'
 	}
 
 	// We failed to substitute; this is an internal error.
+	err = pgerror.NewErrorf(pgerror.CodeInternalError,
+		"invalid logical plan structure:\n%s\nwhile inserting:\n%s",
+		planToString(ctx, plan),
+		planToString(ctx, tracePlan))
 	plan.Close(ctx)
 	stmtPlan.Close(ctx)
 	tracePlan.Close(ctx)
-	return nil, pgerror.NewError(pgerror.CodeInternalError, "invalid logical plan structure")
+	return nil, err
 }
 
 // ShowDatabases returns all the databases.


### PR DESCRIPTION
These are the base commits from  #16760, split so that the review of that other PR becomes simpler.

Visible changes:
- a bug in the printing of SHOW CREATE with interleaved tables has been fixed
- the unsupported form of SHOW GRANTS now properly reports the unsupported pg error code
- everything that uses a delayedNode (most significantly, most SHOW forms) will now benefit more from query optimization - the various optimization layers will now properly recurse into the delayedNode's subplan
- the delayedNode itself is elided during plan optimization. This is possible because it doesn't compute anything. This can yield a slight performance speed-up in SHOW (when there's a lot of data to show).