### PR TITLE
cherry-pick: sql/parser: regclass casts must normalize input

### DIFF
--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -1680,7 +1680,7 @@ type EvalPlanner interface {
 	QueryRow(ctx context.Context, sql string, args ...interface{}) (Datums, error)
 
 	// QualifyWithDatabase resolves a possibly unqualified table name into a
-	// table name that is qualified by database.
+	// normalized table name that is qualified by database.
 	QualifyWithDatabase(ctx context.Context, t *NormalizableTableName) (*TableName, error)
 }
 
@@ -2414,7 +2414,7 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 				// table because we only have the database name, not its OID, which is
 				// what is stored in pg_class. This extra join means we can't use
 				// queryOid like everyone else.
-				return queryOidWithJoin(ctx, typ, NewDString(s),
+				return queryOidWithJoin(ctx, typ, NewDString(tn.Table()),
 					"JOIN pg_catalog.pg_namespace ON relnamespace = pg_namespace.oid",
 					fmt.Sprintf("AND nspname = '%s'", tn.Database()))
 			default:

--- a/pkg/sql/testdata/logic_test/pgoidtype
+++ b/pkg/sql/testdata/logic_test/pgoidtype
@@ -173,6 +173,16 @@ SELECT relname from pg_class where oid='a'::regclass
 ----
 a
 
+## Regression for #16767 - ensure regclass casts use normalized table names
+
+statement ok
+CREATE TABLE hasCase (id INT PRIMARY KEY)
+
+query T
+SELECT relname from pg_class where oid='a'::regclass
+----
+a
+
 # a non-root user with sufficient permissions can get the OID of a table from
 # the current database
 


### PR DESCRIPTION
Previously, table name inputs to regclass casts were not properly
normalized, leading to improper behavior. Table names that were not all
lowercase were not selectable via regclass casts unless they were
manually lowercased.

cc @cockroachdb/release 