### PR TITLE
engineccl: fix inclusivity of MVCCIncrementalIterator time bounds

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -1140,26 +1140,37 @@ func TestBackupAsOfSystemTime(t *testing.T) {
 	_, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, multiNode, numAccounts)
 	defer cleanupFn()
 
-	var ts string
-	var rowCount int64
+	var beforeTs, equalTs string
+	var rowCount int
 
-	sqlDB.QueryRow(`SELECT cluster_logical_timestamp()`).Scan(&ts)
-	sqlDB.Exec(`TRUNCATE data.bank`)
+	sqlDB.QueryRow(`SELECT cluster_logical_timestamp()`).Scan(&beforeTs)
+	sqlDB.Exec(`BEGIN`)
+	sqlDB.Exec(`DELETE FROM data.bank`)
+	sqlDB.QueryRow(`SELECT cluster_logical_timestamp()`).Scan(&equalTs)
+	sqlDB.Exec(`COMMIT`)
 
 	sqlDB.QueryRow(`SELECT COUNT(*) FROM data.bank`).Scan(&rowCount)
-	if rowCount != 0 {
-		t.Fatalf("expected 0 rows but found %d", rowCount)
+	if expected := 0; rowCount != expected {
+		t.Fatalf("expected %d rows but found %d", expected, rowCount)
 	}
 
-	sqlDB.Exec(fmt.Sprintf(`BACKUP DATABASE data TO '%s' AS OF SYSTEM TIME %s`, dir, ts))
+	beforeDir := filepath.Join(dir, `beforeTs`)
+	sqlDB.Exec(fmt.Sprintf(`BACKUP DATABASE data TO '%s' AS OF SYSTEM TIME %s`, beforeDir, beforeTs))
+	equalDir := filepath.Join(dir, `equalTs`)
+	sqlDB.Exec(fmt.Sprintf(`BACKUP DATABASE data TO '%s' AS OF SYSTEM TIME %s`, equalDir, equalTs))
 
 	sqlDB.Exec(`DROP TABLE data.bank`)
-
-	sqlDB.Exec(`RESTORE data.* FROM $1`, dir)
-
+	sqlDB.Exec(`RESTORE data.* FROM $1`, beforeDir)
 	sqlDB.QueryRow(`SELECT COUNT(*) FROM data.bank`).Scan(&rowCount)
-	if rowCount != numAccounts {
-		t.Fatalf("expected %d rows but found %d", numAccounts, rowCount)
+	if expected := numAccounts; rowCount != expected {
+		t.Fatalf("expected %d rows but found %d", expected, rowCount)
+	}
+
+	sqlDB.Exec(`DROP TABLE data.bank`)
+	sqlDB.Exec(`RESTORE data.* FROM $1`, equalDir)
+	sqlDB.QueryRow(`SELECT COUNT(*) FROM data.bank`).Scan(&rowCount)
+	if expected := 0; rowCount != expected {
+		t.Fatalf("expected %d rows but found %d", expected, rowCount)
 	}
 }
 

--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -28,7 +28,8 @@ import (
 
 // loadTestData writes numKeys keys in numBatches separate batches. Keys are
 // written in order. Every key in a given batch has the same MVCC timestamp;
-// batch timestamps start at 0 and increase in intervals of batchTimeSpan.
+// batch timestamps start at batchTimeSpan and increase in intervals of
+// batchTimeSpan.
 //
 // Importantly, writing keys in order convinces RocksDB to output one SST per
 // batch, where each SST contains keys of only one timestamp. E.g., writing A,B

--- a/pkg/ccl/storageccl/engineccl/mvcc.go
+++ b/pkg/ccl/storageccl/engineccl/mvcc.go
@@ -17,15 +17,24 @@ import (
 )
 
 // MVCCIncrementalIterator iterates over the diff of the key range
-// [startKey,endKey) and time range [startTime,endTime). If a key was added or
+// [startKey,endKey) and time range (startTime,endTime]. If a key was added or
 // modified between startTime and endTime, the iterator will position at the
-// most recent version (before endTime) of that key. If the key was most
+// most recent version (before or at endTime) of that key. If the key was most
 // recently deleted, this is signalled with an empty value.
 //
+// Note: The endTime is inclusive to be consistent with the non-incremental
+// iterator, where reads at a given timestamp return writes at that
+// timestamp. The startTime is then made exclusive so that iterating time 1 to
+// 2 and then 2 to 3 will only return values with time 2 once. An exclusive
+// start time would normally make it difficult to scan timestamp 0, but
+// CockroachDB uses that as a sentinel for key metadata anyway.
+//
 // Expected usage:
-//    iter := NewMVCCIncrementalIterator(e)
+//    iter := NewMVCCIncrementalIterator(e, startTime, endTime)
 //    defer iter.Close()
-//    for iter.Reset(startKey, endKey, ...); iter.Valid(); iter.Next() {
+//    for iter.Seek(startKey); ; iter.Next() {
+//        ok, err := iter.Valid()
+//        if !ok { ... }
 //        [code using iter.Key() and iter.Value()]
 //    }
 //    if err := iter.Error(); err != nil {
@@ -36,7 +45,6 @@ type MVCCIncrementalIterator struct {
 
 	iter engine.Iterator
 
-	endKey    engine.MVCCKey
 	startTime hlc.Timestamp
 	endTime   hlc.Timestamp
 	err       error
@@ -46,6 +54,8 @@ type MVCCIncrementalIterator struct {
 	// For allocation avoidance.
 	meta enginepb.MVCCMetadata
 }
+
+var _ engine.SimpleIterator = &MVCCIncrementalIterator{}
 
 // NewMVCCIncrementalIterator creates an MVCCIncrementalIterator with the
 // specified engine and time range.
@@ -59,14 +69,14 @@ func NewMVCCIncrementalIterator(
 	}
 }
 
-// Reset begins a new iteration with the specified key range.
-func (i *MVCCIncrementalIterator) Reset(startKey, endKey roachpb.Key) {
-	i.iter.Seek(engine.MakeMVCCMetadataKey(startKey))
-	i.endKey = engine.MakeMVCCMetadataKey(endKey)
+// Seek advances the iterator to the first key in the engine which is >= the
+// provided key.
+func (i *MVCCIncrementalIterator) Seek(startKey engine.MVCCKey) {
+	i.iter.Seek(startKey)
 	i.err = nil
 	i.valid = true
 	i.nextkey = false
-	i.Next()
+	i.NextKey()
 }
 
 // Close frees up resources held by the iterator.
@@ -74,8 +84,20 @@ func (i *MVCCIncrementalIterator) Close() {
 	i.iter.Close()
 }
 
-// Next advances the iterator to the next key/value in the iteration.
+// Next advances the iterator to the next key/value in the iteration. After this
+// call, Valid() will be true if the iterator was not positioned at the last
+// key.
 func (i *MVCCIncrementalIterator) Next() {
+	// TODO(dan): Implement Next. We'll need this for `RESTORE ... AS OF SYSTEM
+	// TIME`.
+	panic("unimplemented")
+}
+
+// NextKey advances the iterator to the next MVCC key. This operation is
+// distinct from Next which advances to the next version of the current key or
+// the next key if the iterator is currently located at the last version for a
+// key.
+func (i *MVCCIncrementalIterator) NextKey() {
 	for {
 		if !i.valid {
 			return
@@ -93,10 +115,6 @@ func (i *MVCCIncrementalIterator) Next() {
 		}
 
 		unsafeMetaKey := i.iter.UnsafeKey()
-		if !unsafeMetaKey.Less(i.endKey) {
-			i.valid = false
-			return
-		}
 		if unsafeMetaKey.IsValue() {
 			i.meta.Reset()
 			i.meta.Timestamp = unsafeMetaKey.Timestamp
@@ -115,10 +133,6 @@ func (i *MVCCIncrementalIterator) Next() {
 				unsafeMetaKey.Key)
 			return
 		}
-		if unsafeMetaKey.Key == nil {
-			// iter was pointed after i.endKey.
-			break
-		}
 
 		if i.meta.Txn != nil {
 			if !i.endTime.Less(i.meta.Timestamp) {
@@ -136,11 +150,11 @@ func (i *MVCCIncrementalIterator) Next() {
 			continue
 		}
 
-		if !i.meta.Timestamp.Less(i.endTime) {
+		if i.endTime.Less(i.meta.Timestamp) {
 			i.iter.Next()
 			continue
 		}
-		if i.meta.Timestamp.Less(i.startTime) {
+		if !i.startTime.Less(i.meta.Timestamp) {
 			i.iter.NextKey()
 			continue
 		}
@@ -156,16 +170,14 @@ func (i *MVCCIncrementalIterator) Next() {
 	}
 }
 
-// Valid returns true if the iterator is currently valid. An iterator that
-// hasn't had Reset called on it or has gone past the end of the key range is
-// invalid.
-func (i *MVCCIncrementalIterator) Valid() bool {
-	return i.valid
-}
-
-// Error returns the error, if any, which the iterator encountered.
-func (i *MVCCIncrementalIterator) Error() error {
-	return i.err
+// Valid must be called after any call to Reset(), Next(), or similar methods.
+// It returns (true, nil) if the iterator points to a valid key (it is undefined
+// to call Key(), Value(), or similar methods unless Valid() has returned (true,
+// nil)). It returns (false, nil) if the iterator has moved past the end of the
+// valid range, or (false, err) if an error has occurred. Valid() will never
+// return true with a non-nil error.
+func (i *MVCCIncrementalIterator) Valid() (bool, error) {
+	return i.valid, i.err
 }
 
 // Key returns the current key.

--- a/pkg/ccl/storageccl/engineccl/mvcc_test.go
+++ b/pkg/ccl/storageccl/engineccl/mvcc_test.go
@@ -33,12 +33,16 @@ func iterateExpectErr(
 	return func(t *testing.T) {
 		iter := NewMVCCIncrementalIterator(e, startTime, endTime)
 		defer iter.Close()
-		for iter.Reset(startKey, endKey); iter.Valid(); iter.Next() {
+		for iter.Seek(engine.MakeMVCCMetadataKey(startKey)); ; iter.NextKey() {
+			if ok, _ := iter.Valid(); !ok || iter.UnsafeKey().Key.Compare(endKey) >= 0 {
+				break
+			}
 			// pass
 		}
-		if err := iter.Error(); !testutils.IsError(err, errString) {
+		if _, err := iter.Valid(); !testutils.IsError(err, errString) {
 			t.Fatalf("expected error %q but got %v", errString, err)
 		}
+
 	}
 }
 
@@ -52,7 +56,12 @@ func assertEqualKVs(
 		iter := NewMVCCIncrementalIterator(e, startTime, endTime)
 		defer iter.Close()
 		var kvs []engine.MVCCKeyValue
-		for iter.Reset(startKey, endKey); iter.Valid(); iter.Next() {
+		for iter.Seek(engine.MakeMVCCMetadataKey(startKey)); ; iter.NextKey() {
+			if ok, err := iter.Valid(); err != nil {
+				t.Fatalf("unexpected error: %+v", err)
+			} else if !ok || iter.UnsafeKey().Key.Compare(endKey) >= 0 {
+				break
+			}
 			kvs = append(kvs, engine.MVCCKeyValue{Key: iter.Key(), Value: iter.Value()})
 		}
 
@@ -106,7 +115,7 @@ func TestMVCCIterateIncremental(t *testing.T) {
 		testValue3 = []byte("val3")
 		testValue4 = []byte("val4")
 
-		ts0   = hlc.Timestamp{WallTime: 0, Logical: 0}
+		tsMin = hlc.Timestamp{WallTime: 0, Logical: 0}
 		ts1   = hlc.Timestamp{WallTime: 1, Logical: 0}
 		ts2   = hlc.Timestamp{WallTime: 2, Logical: 0}
 		ts3   = hlc.Timestamp{WallTime: 3, Logical: 0}
@@ -125,7 +134,7 @@ func TestMVCCIterateIncremental(t *testing.T) {
 	kv1_3Deleted := makeKVT(testKey1, nil, ts3)
 	kvs := func(kvs ...engine.MVCCKeyValue) []engine.MVCCKeyValue { return kvs }
 
-	t.Run("empty", assertEqualKVs(e, keyMin, keyMax, ts0, ts3, nil))
+	t.Run("empty", assertEqualKVs(e, keyMin, keyMax, tsMin, ts3, nil))
 
 	for _, kv := range kvs(kv1_1_1, kv1_2_2, kv2_2_2) {
 		v := roachpb.Value{RawBytes: kv.Value}
@@ -136,16 +145,16 @@ func TestMVCCIterateIncremental(t *testing.T) {
 	}
 
 	// Exercise time ranges.
-	t.Run("ts 1-1", assertEqualKVs(e, keyMin, keyMax, ts1, ts1, nil))
-	t.Run("ts 1-2", assertEqualKVs(e, keyMin, keyMax, ts1, ts2, kvs(kv1_1_1)))
-	t.Run("ts 1-∞", assertEqualKVs(e, keyMin, keyMax, ts1, tsMax, kvs(kv1_2_2, kv2_2_2)))
-	t.Run("ts 2-2", assertEqualKVs(e, keyMin, keyMax, ts2, ts2, nil))
-	t.Run("ts 2-3", assertEqualKVs(e, keyMin, keyMax, ts2, ts3, kvs(kv1_2_2, kv2_2_2)))
-	t.Run("ts 3-3", assertEqualKVs(e, keyMin, keyMax, ts3, ts3, nil))
+	t.Run("ts (0-0]", assertEqualKVs(e, keyMin, keyMax, tsMin, tsMin, nil))
+	t.Run("ts (0-1]", assertEqualKVs(e, keyMin, keyMax, tsMin, ts1, kvs(kv1_1_1)))
+	t.Run("ts (0-∞]", assertEqualKVs(e, keyMin, keyMax, tsMin, tsMax, kvs(kv1_2_2, kv2_2_2)))
+	t.Run("ts (1-1]", assertEqualKVs(e, keyMin, keyMax, ts1, ts1, nil))
+	t.Run("ts (1-2]", assertEqualKVs(e, keyMin, keyMax, ts1, ts2, kvs(kv1_2_2, kv2_2_2)))
+	t.Run("ts (2-2]", assertEqualKVs(e, keyMin, keyMax, ts2, ts2, nil))
 
 	// Exercise key ranges.
-	t.Run("kv 1-1", assertEqualKVs(e, testKey1, testKey1, ts0, tsMax, nil))
-	t.Run("kv 1-2", assertEqualKVs(e, testKey1, testKey2, ts0, tsMax, kvs(kv1_2_2)))
+	t.Run("kv [1-1)", assertEqualKVs(e, testKey1, testKey1, tsMin, tsMax, nil))
+	t.Run("kv [1-2)", assertEqualKVs(e, testKey1, testKey2, tsMin, tsMax, kvs(kv1_2_2)))
 
 	// Exercise deletion.
 	if err := engine.MVCCDelete(ctx, e, nil, testKey1, ts3, nil); err != nil {
@@ -181,10 +190,10 @@ func TestMVCCIterateIncremental(t *testing.T) {
 	}
 	mustFlush()
 	t.Run("intents1",
-		iterateExpectErr(e, testKey1, testKey1.PrefixEnd(), ts0, tsMax, "conflicting intents"))
+		iterateExpectErr(e, testKey1, testKey1.PrefixEnd(), tsMin, tsMax, "conflicting intents"))
 	t.Run("intents2",
-		iterateExpectErr(e, testKey2, testKey2.PrefixEnd(), ts0, tsMax, "conflicting intents"))
-	t.Run("intents3", assertEqualKVs(e, keyMin, keyMax, ts0, ts4, nil))
+		iterateExpectErr(e, testKey2, testKey2.PrefixEnd(), tsMin, tsMax, "conflicting intents"))
+	t.Run("intents3", assertEqualKVs(e, keyMin, keyMax, tsMin, ts3, kvs(kv2_2_2)))
 
 	intent1 := roachpb.Intent{Span: roachpb.Span{Key: testKey1}, Txn: txn1.TxnMeta, Status: roachpb.COMMITTED}
 	if err := engine.MVCCResolveWriteIntent(ctx, e, nil, intent1); err != nil {
@@ -196,7 +205,7 @@ func TestMVCCIterateIncremental(t *testing.T) {
 		t.Fatal(err)
 	}
 	mustFlush()
-	t.Run("intents4", assertEqualKVs(e, keyMin, keyMax, ts0, tsMax, kvs(kv1_4_4, kv2_2_2)))
+	t.Run("intents4", assertEqualKVs(e, keyMin, keyMax, tsMin, tsMax, kvs(kv1_4_4, kv2_2_2)))
 }
 
 func TestMVCCIterateTimeBound(t *testing.T) {
@@ -232,11 +241,11 @@ func TestMVCCIterateTimeBound(t *testing.T) {
 		// one SST, plus the min of the following and the max of the preceding SST
 		{hlc.Timestamp{WallTime: 9, Logical: 0}, hlc.Timestamp{WallTime: 21, Logical: 0}},
 		// one SST, not min or max
-		{hlc.Timestamp{WallTime: 18, Logical: 0}, hlc.Timestamp{WallTime: 18, Logical: 1}},
+		{hlc.Timestamp{WallTime: 17, Logical: 0}, hlc.Timestamp{WallTime: 18, Logical: 0}},
 		// one SST's max
-		{hlc.Timestamp{WallTime: 19, Logical: 0}, hlc.Timestamp{WallTime: 19, Logical: 1}},
+		{hlc.Timestamp{WallTime: 18, Logical: 0}, hlc.Timestamp{WallTime: 19, Logical: 0}},
 		// one SST's min
-		{hlc.Timestamp{WallTime: 20, Logical: 0}, hlc.Timestamp{WallTime: 20, Logical: 1}},
+		{hlc.Timestamp{WallTime: 19, Logical: 0}, hlc.Timestamp{WallTime: 20, Logical: 0}},
 		// random endpoints
 		{hlc.Timestamp{WallTime: 32, Logical: 0}, hlc.Timestamp{WallTime: 78, Logical: 0}},
 	} {
@@ -255,7 +264,7 @@ func TestMVCCIterateTimeBound(t *testing.T) {
 					break
 				}
 				ts := iter.Key().Timestamp
-				if ts.Less(testCase.end) && (testCase.start.Less(ts) || testCase.start == ts) {
+				if (ts.Less(testCase.end) || testCase.end == ts) && testCase.start.Less(ts) {
 					expectedKVs = append(expectedKVs, engine.MVCCKeyValue{Key: iter.Key(), Value: iter.Value()})
 				}
 				iter.Next()


### PR DESCRIPTION
Originally, the endTime was exclusive, but this is a bug. Reads are
expected to see writes at the same timestamp but BACKUP would not do
this. Luckily, it's unlikely anyone would have hit this. (They would
have had to get extraordinarily unlucky or used the
cluster_logical_timestamp function which is marked as internal only).

The startTime is then made exclusive so that iterating time 1 to 2 and
then 2 to 3 will only return values with time 2 once. (An exclusive
start time would normally make it difficult to scan timestamp 0, but
CockroachDB uses that as a sentinel for key metadata anyway.)

While I'm in here, made MVCCIncrementalIterator implement the
SimpleIterator interface. It was already very close and now it matches
the usage of our other iterators.

Adds one of two new tests described in #16768.