### PR TITLE
storage: give Storage.replicaQueues its own mutex

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4130,8 +4130,10 @@ func (r *Replica) acquireSplitLock(
 			rightRng.mu.Unlock()
 			r.store.mu.Lock()
 			delete(r.store.mu.replicas, rightRng.RangeID)
-			delete(r.store.mu.replicaQueues, rightRng.RangeID)
 			delete(r.store.mu.uninitReplicas, rightRng.RangeID)
+			r.store.replicaQueues.Lock()
+			delete(r.store.replicaQueues.m, rightRng.RangeID)
+			r.store.replicaQueues.Unlock()
 			r.store.mu.Unlock()
 		}
 		rightRng.raftMu.Unlock()


### PR DESCRIPTION
This reduces usage of Store.mu in attempt to alleviate contention on
that mutex. No performance benefit was measured, but this seems
reasoanble regardless.