### PR TITLE
[DO NOT MERGE] storage: shard the raft entry cache to reduce lock contention

### DIFF
--- a/pkg/storage/entry_cache_test.go
+++ b/pkg/storage/entry_cache_test.go
@@ -60,7 +60,7 @@ func verifyGet(
 
 func TestEntryCache(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	rec := newRaftEntryCache(100)
+	rec := newRaftEntryCache(400, 4)
 	rangeID := roachpb.RangeID(2)
 	// Add entries for range 1, indexes (1-10).
 	ents := addEntries(rec, rangeID, 1, 11)
@@ -97,7 +97,7 @@ func TestEntryCache(t *testing.T) {
 func TestEntryCacheClearTo(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	rangeID := roachpb.RangeID(1)
-	rec := newRaftEntryCache(100)
+	rec := newRaftEntryCache(100, 4)
 	rec.addEntries(rangeID, []raftpb.Entry{newEntry(2, 1)})
 	rec.addEntries(rangeID, []raftpb.Entry{newEntry(20, 1), newEntry(21, 1)})
 	rec.clearTo(rangeID, 21)
@@ -112,7 +112,7 @@ func TestEntryCacheClearTo(t *testing.T) {
 func TestEntryCacheEviction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	rangeID := roachpb.RangeID(1)
-	rec := newRaftEntryCache(100)
+	rec := newRaftEntryCache(100, 1)
 	rec.addEntries(rangeID, []raftpb.Entry{newEntry(1, 40), newEntry(2, 40)})
 	ents, _, hi := rec.getEntries(nil, rangeID, 1, 3, 0)
 	if len(ents) != 2 || hi != 3 {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -74,7 +74,8 @@ const (
 
 	// defaultRaftEntryCacheSize is the default size in bytes for a
 	// store's Raft log entry cache.
-	defaultRaftEntryCacheSize = 1 << 24 // 16M
+	defaultRaftEntryCacheSize   = 16 << 20 // 16M
+	defaultRaftEntryCacheShards = 16
 
 	// rangeLeaseRaftElectionTimeoutMultiplier specifies what multiple the leader
 	// lease active duration should be of the raft election timeout.
@@ -665,10 +666,6 @@ type StoreConfig struct {
 	// the range event log.
 	LogRangeEvents bool
 
-	// RaftEntryCacheSize is the size in bytes of the Raft log entry cache
-	// shared by all Raft groups managed by the store.
-	RaftEntryCacheSize uint64
-
 	TestingKnobs StoreTestingKnobs
 
 	// concurrentSnapshotApplyLimit specifies the maximum number of empty
@@ -860,9 +857,6 @@ func (sc *StoreConfig) SetDefaults() {
 	if sc.RaftElectionTimeoutTicks == 0 {
 		sc.RaftElectionTimeoutTicks = defaultRaftElectionTimeoutTicks
 	}
-	if sc.RaftEntryCacheSize == 0 {
-		sc.RaftEntryCacheSize = defaultRaftEntryCacheSize
-	}
 	if sc.concurrentSnapshotApplyLimit == 0 {
 		// NB: setting this value higher than 1 is likely to degrade client
 		// throughput.
@@ -916,7 +910,7 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 		})
 	}
 	s.intentResolver = newIntentResolver(s)
-	s.raftEntryCache = newRaftEntryCache(cfg.RaftEntryCacheSize)
+	s.raftEntryCache = newRaftEntryCache(defaultRaftEntryCacheSize, defaultRaftEntryCacheShards)
 	s.draining.Store(false)
 	s.scheduler = newRaftScheduler(s.cfg.AmbientCtx, s.metrics, s, storeSchedulerConcurrency)
 


### PR DESCRIPTION
Split raft entry cache into 16 shards to reduce lock contention in
raftEntryCache.addEntries. Switch the shards to use a RWMutex to reduce
contention in raftEntryCache.getEntries.

Remove the unused StoreConfig.RaftEntryCacheSize knob.