### PR TITLE
sql: truncate sql strings unicode-safely

### DIFF
--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -655,7 +655,6 @@ func MassagePrettyPrintedSpanForTest(span string, dirs []encoding.Direction) str
 // TestPrettyPrintRange for some examples.
 func PrettyPrintRange(start, end roachpb.Key, maxChars int) string {
 	var b bytes.Buffer
-	const ellipsis = '\u2026'
 	if maxChars < 8 {
 		maxChars = 8
 	}
@@ -672,7 +671,7 @@ func PrettyPrintRange(start, end roachpb.Key, maxChars int) string {
 			i = maxChars - 1
 		}
 		b.WriteString(prettyStart[:i])
-		b.WriteRune(ellipsis)
+		b.WriteRune('…')
 		return b.String()
 	}
 	b.WriteString(prettyStart[:i])
@@ -683,7 +682,7 @@ func PrettyPrintRange(start, end roachpb.Key, maxChars int) string {
 			b.WriteString(what)
 		} else {
 			b.WriteString(what[:maxChars-1])
-			b.WriteRune(ellipsis)
+			b.WriteRune('…')
 		}
 	}
 

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -668,6 +669,10 @@ func (s *Session) setQueryExecutionMode(query queryHandle, isDistributed bool) {
 	s.mu.Unlock()
 }
 
+// MaxSQLBytes is the maximum length in bytes of SQL statements serialized
+// into a serverpb.Session. Exported for testing.
+const MaxSQLBytes = 1000
+
 // serialize serializes a Session into a serverpb.Session
 // that can be served over RPC.
 func (s *Session) serialize() serverpb.Session {
@@ -686,16 +691,16 @@ func (s *Session) serialize() serverpb.Session {
 
 	for query := range s.mu.ActiveQueries {
 		sql := query.stmt.String()
-		if len(sql) > 1000 {
-			// Truncate just after the first ASCII character.
-			i := 996
-			for i = 996; i > 0; i-- {
-				if (sql[i] & 0x80) == 0 {
-					// ASCII character found.
+		if len(sql) > MaxSQLBytes {
+			sql = sql[:MaxSQLBytes-utf8.RuneLen('…')]
+			// Ensure the resulting string is valid utf8.
+			for {
+				if r, _ := utf8.DecodeLastRuneInString(sql); r != utf8.RuneError {
 					break
 				}
+				sql = sql[:len(sql)-1]
 			}
-			sql = sql[:(i+1)] + "..."
+			sql += "…"
 		}
 		activeQueries = append(activeQueries, serverpb.ActiveQuery{
 			Start:         query.start.UTC(),

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"golang.org/x/net/context"
 
@@ -290,20 +291,33 @@ func TestShowCreateView(t *testing.T) {
 
 func TestShowQueries(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	const multiByte = "💩"
+	const selectBase = "SELECT * FROM "
+
+	maxLen := sql.MaxSQLBytes - utf8.RuneLen('…')
+
+	// Craft a statement that would naively be truncated mid-rune.
+	tableName := strings.Repeat("a", maxLen-len(selectBase)-(len(multiByte)-1)) + multiByte
+	// Push the total length over the truncation threshold.
+	tableName += strings.Repeat("a", sql.MaxSQLBytes-len(tableName)+1)
+	selectStmt := selectBase + tableName
+
+	if r, _ := utf8.DecodeLastRuneInString(selectStmt[:maxLen]); r != utf8.RuneError {
+		t.Fatalf("expected naive truncation to produce invalid utf8, got %c", r)
+	}
+	expectedSelectStmt := selectStmt
+	for i := range expectedSelectStmt {
+		if i > maxLen {
+			_, prevLen := utf8.DecodeLastRuneInString(expectedSelectStmt[:i])
+			expectedSelectStmt = expectedSelectStmt[:i-prevLen]
+			break
+		}
+	}
+	expectedSelectStmt = expectedSelectStmt + "…"
+
 	var conn1 *gosql.DB
 	var conn2 *gosql.DB
-
-	insertStmt := "INSERT INTO t VALUES (1, '"
-	for i := 0; i < 996; i++ {
-		insertStmt = insertStmt + "a"
-	}
-	insertStmt = insertStmt + "\U0001F4A9aaa')"
-
-	expectedInsertStmt := "INSERT INTO t VALUES (1, e'"
-	for i := 0; i < (996 - 26); i++ {
-		expectedInsertStmt = expectedInsertStmt + "a"
-	}
-	expectedInsertStmt = expectedInsertStmt + "..."
 
 	tc := serverutils.StartTestCluster(t, 2, /* numNodes */
 		base.TestClusterArgs{
@@ -313,40 +327,43 @@ func TestShowQueries(t *testing.T) {
 				Knobs: base.TestingKnobs{
 					SQLExecutor: &sql.ExecutorTestingKnobs{
 						StatementFilter: func(ctx context.Context, stmt string, res *sql.Result) {
-							if strings.Contains(stmt, "INSERT INTO t") {
-								rows, _ := conn1.Query("SELECT node_id,query FROM [SHOW CLUSTER QUERIES]")
+							if stmt == selectStmt {
+								const showQuery = "SELECT node_id, query FROM [SHOW CLUSTER QUERIES]"
+
+								rows, err := conn1.Query(showQuery)
+								if err != nil {
+									t.Fatal(err)
+								}
 								defer rows.Close()
 
+								count := 0
 								for rows.Next() {
+									count++
+
 									var nodeID int
 									var sql string
 									if err := rows.Scan(&nodeID, &sql); err != nil {
 										t.Fatal(err)
 									}
-									if strings.Contains(sql, "INSERT INTO t") && sql != expectedInsertStmt {
-										t.Fatalf("Unexpected query in SHOW QUERIES: %s, expected: %s",
+									switch sql {
+									case showQuery, expectedSelectStmt:
+									default:
+										t.Fatalf(
+											"unexpected query in SHOW QUERIES: %+q, expected: %+q",
 											sql,
-											expectedInsertStmt)
+											expectedSelectStmt,
+										)
 									}
 									if nodeID < 1 || nodeID > 2 {
-										t.Fatalf("Invalid node ID: %d", nodeID)
+										t.Fatalf("invalid node ID: %d", nodeID)
 									}
 								}
-
-								countRow, _ := conn1.Query("SELECT COUNT(*) FROM [SHOW CLUSTER QUERIES]")
-								defer countRow.Close()
-
-								if !countRow.Next() {
-									t.Fatalf("Could not get countRow for SHOW CLUSTER QUERIES")
-								}
-
-								var count int
-								if err := countRow.Scan(&count); err != nil {
+								if err := rows.Err(); err != nil {
 									t.Fatal(err)
 								}
 
-								if count != 2 {
-									t.Fatalf("Unexpected number of running queries: %d. Expected 2", count)
+								if expectedCount := 2; count != expectedCount {
+									t.Fatalf("unexpected number of running queries: %d, expected %d", count, expectedCount)
 								}
 							}
 						},
@@ -358,11 +375,9 @@ func TestShowQueries(t *testing.T) {
 
 	conn1 = tc.ServerConn(0)
 	conn2 = tc.ServerConn(1)
-	sqlutils.CreateTable(t, conn1, "t",
-		"num INT, text TEXT",
-		0, nil)
+	sqlutils.CreateTable(t, conn1, tableName, "num INT", 0, nil)
 
-	if _, err := conn2.Exec(insertStmt); err != nil {
+	if _, err := conn2.Exec(selectStmt); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
This improves the implementation from #16602 by truncating to unicode
code points and rewrites the test to actually exercise this condition;
the previous test did not do so since SQL string pretty-printing
escapes multi-byte runes, but SQL identifier pretty-printing does not.

The test was also riddled with unchecked errors and generally exhibited
poor hygiene.