### PR TITLE
sql: restore sanity in the handling of special column names

### DIFF
--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -861,5 +861,5 @@ func (src *dataSourceInfo) FormatVar(buf *bytes.Buffer, f parser.FmtFlags, colId
 			buf.WriteString("_.")
 		}
 	}
-	buf.WriteString(src.sourceColumns[colIdx].Name)
+	parser.Name(src.sourceColumns[colIdx].Name).Format(buf, f)
 }

--- a/pkg/sql/distsqlrun/expr.go
+++ b/pkg/sql/distsqlrun/expr.go
@@ -39,10 +39,12 @@ func (v *ivarBinder) VisitPre(expr parser.Expr) (recurse bool, newExpr parser.Ex
 		return false, expr
 	}
 	if ivar, ok := expr.(*parser.IndexedVar); ok {
-		if err := v.h.BindIfUnbound(ivar); err != nil {
+		newVar, err := v.h.BindIfUnbound(ivar)
+		if err != nil {
 			v.err = err
+			return false, expr
 		}
-		return false, expr
+		return false, newVar
 	}
 	return true, expr
 }
@@ -62,7 +64,7 @@ func processExpression(exprSpec Expression, h *parser.IndexedVarHelper) (parser.
 
 	// Bind IndexedVars to our eh.vars.
 	v := ivarBinder{h: h, err: nil}
-	parser.WalkExprConst(&v, expr)
+	expr, _ = parser.WalkExpr(&v, expr)
 	if v.err != nil {
 		return nil, v.err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -278,7 +278,7 @@ query ITTTTT
 EXPLAIN (VERBOSE) SELECT COUNT(*), k+v FROM kv GROUP BY k, v
 ----
 0  render                             ("count(*)", "k + v")
-0          render 0     count(*)
+0          render 0     "count(*)"
 0          render 1     k + v
 1  group                              ("count(*)", k, v)
 1          aggregate 0  count_rows()

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -51,7 +51,7 @@ EXPLAIN (METADATA) SHOW TRACE FOR SELECT 1
 0  sort                                 ("timestamp", age, message, context, operation, span)                             +"timestamp"
 0                  order  +"timestamp"
 1  window                               ("timestamp", age, message, context, operation, span)
-2  render                               ("timestamp", "timestamp", message, context, operation, span)
+2  render                               ("timestamp", """timestamp""", message, context, operation, span)
 3  window                               ("timestamp", message, context, operation, span)
 4  render                               ("timestamp", message, context, operation, span, txn_idx, span_idx, message_idx)
 5  show trace for                       (txn_idx, span_idx, message_idx, "timestamp", duration, operation, message)

--- a/pkg/sql/logictest/testdata/logic_test/explain_types
+++ b/pkg/sql/logictest/testdata/logic_test/explain_types
@@ -86,10 +86,10 @@ query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2 AND COUNT(k)>1
 ----
 0  render                                                                                          (z int, v int)
-0          render 0     ((2)[int] * (count(k))[int])[int]
+0          render 0     ((2)[int] * ("count(k)")[int])[int]
 0          render 1     (v)[int]
 1  filter                                                                                          (v int, "count(k)" int, "count(k)" int, v int)
-1          filter       ((count(k))[int] > (1)[int])[bool]
+1          filter       (("count(k)")[int] > (1)[int])[bool]
 2  group                                                                                           (v int, "count(k)" int, "count(k)" int, v int)
 2          aggregate 0  (v)[int]
 2          aggregate 1  (count((k)[int]))[int]
@@ -106,20 +106,20 @@ EXPLAIN (TYPES,NOEXPAND) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v
 query ITTTTT
 EXPLAIN (TYPES) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2 AND COUNT(k)>1
 ----
-0  render                                                   (z int, v int)
-0          render 0     ((2)[int] * (count(k))[int])[int]
+0  render                                                     (z int, v int)
+0          render 0     ((2)[int] * ("count(k)")[int])[int]
 0          render 1     (v)[int]
-1  filter                                                   (v int, "count(k)" int, "count(k)" int, v int)
-1          filter       ((count(k))[int] > (1)[int])[bool]
-2  group                                                    (v int, "count(k)" int, "count(k)" int, v int)
+1  filter                                                     (v int, "count(k)" int, "count(k)" int, v int)
+1          filter       (("count(k)")[int] > (1)[int])[bool]
+2  group                                                      (v int, "count(k)" int, "count(k)" int, v int)
 2          aggregate 0  (v)[int]
 2          aggregate 1  (count((k)[int]))[int]
 2          aggregate 2  (count((k)[int]))[int]
 2          aggregate 3  (v)[int]
-3  render                                                   (v int, k int)
+3  render                                                     (v int, k int)
 3          render 0     (v)[int]
 3          render 1     (k)[int]
-4  empty                                                    ()
+4  empty                                                      ()
 
 query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) DELETE FROM t WHERE v > 1

--- a/pkg/sql/logictest/testdata/logic_test/name_escapes
+++ b/pkg/sql/logictest/testdata/logic_test/name_escapes
@@ -46,6 +46,18 @@ CREATE VIEW ";--alsoconcerning" AS SELECT @1, @2, @3 FROM ";--notbetter"
 query TT
 SHOW CREATE VIEW ";--alsoconcerning"
 ----
-";--alsoconcerning"  CREATE VIEW ";--alsoconcerning" ("@1", "@2", "@3") AS SELECT x, y, "welp INT); -- concerning much
-DROP USER dumpty;
-CREATE TABLE unused (x " FROM test.";--notbetter"
+";--alsoconcerning"  CREATE VIEW ";--alsoconcerning" AS SELECT @1, @2, @3 FROM test.";--notbetter"
+
+# Check that "create table as" handles strange things properly.
+statement ok
+CREATE TABLE ";--dontask" AS SELECT @1, @2, @3 FROM ";--notbetter"
+
+query TT
+SHOW CREATE TABLE ";--dontask"
+----
+";--dontask"  CREATE TABLE ";--dontask" (
+              "@1" INT NULL,
+              "@2" INT NULL,
+              "@3" INT NULL,
+              FAMILY "primary" ("@1", "@2", "@3", rowid)
+)

--- a/pkg/sql/logictest/testdata/logic_test/name_escapes
+++ b/pkg/sql/logictest/testdata/logic_test/name_escapes
@@ -38,3 +38,14 @@ CREATE TABLE unused3(x INT, y INT, FAMILY woo " (x, y, "welp INT); -- concerning
 DROP USER dumpty;
 CREATE TABLE unused (x ")
 ) INTERLEAVE IN PARENT "woo; DROP USER humpty;" (x)
+
+# Check that view creates handle strange things properly.
+statement ok
+CREATE VIEW ";--alsoconcerning" AS SELECT @1, @2, @3 FROM ";--notbetter"
+
+query TT
+SHOW CREATE VIEW ";--alsoconcerning"
+----
+";--alsoconcerning"  CREATE VIEW ";--alsoconcerning" ("@1", "@2", "@3") AS SELECT x, y, "welp INT); -- concerning much
+DROP USER dumpty;
+CREATE TABLE unused (x " FROM test.";--notbetter"

--- a/pkg/sql/logictest/testdata/logic_test/name_escapes
+++ b/pkg/sql/logictest/testdata/logic_test/name_escapes
@@ -1,0 +1,40 @@
+# Check that the various things in a table definition are properly escaped when
+# printed out.
+statement ok
+CREATE table "woo; DROP USER humpty;" (x INT PRIMARY KEY); CREATE TABLE ";--notbetter" (
+  x INT, y INT,
+  "welp INT); -- concerning much
+DROP USER dumpty;
+CREATE TABLE unused (x " INT,
+  INDEX "helpme ON (x)); -- this must stop!
+DROP USER alice;
+CREATE TABLE unused2(x INT, INDEX woo ON " (x ASC),
+  FAMILY "nonotagain (x)); -- welp!
+DROP USER queenofhearts;
+CREATE TABLE unused3(x INT, y INT, FAMILY woo " (x, y),
+  CONSTRAINT "getmeoutofhere PRIMARY KEY (x ASC)); -- saveme!
+DROP USER madhatter;
+CREATE TABLE unused4(x INT, CONSTRAINT woo " PRIMARY KEY (x)
+) INTERLEAVE IN PARENT "woo; DROP USER humpty;" (x);
+
+query TT
+SHOW CREATE TABLE ";--notbetter"
+----
+";--notbetter"  CREATE TABLE ";--notbetter" (
+                x INT NOT NULL,
+                y INT NULL,
+                "welp INT); -- concerning much
+DROP USER dumpty;
+CREATE TABLE unused (x " INT NULL,
+  CONSTRAINT "getmeoutofhere PRIMARY KEY (x ASC)); -- saveme!
+DROP USER madhatter;
+CREATE TABLE unused4(x INT, CONSTRAINT woo " PRIMARY KEY (x ASC),
+  INDEX "helpme ON (x)); -- this must stop!
+DROP USER alice;
+CREATE TABLE unused2(x INT, INDEX woo ON " (x ASC),
+  FAMILY "nonotagain (x)); -- welp!
+DROP USER queenofhearts;
+CREATE TABLE unused3(x INT, y INT, FAMILY woo " (x, y, "welp INT); -- concerning much
+DROP USER dumpty;
+CREATE TABLE unused (x ")
+) INTERLEAVE IN PARENT "woo; DROP USER humpty;" (x)

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -601,7 +601,7 @@ EXPLAIN (TYPES) SELECT max(k), max(k) + stddev(d) OVER (PARTITION BY v, 'a') FRO
 1          render 1     ((max((k)[int]))[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]
 1          render 2     (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]
 2  render                                                                                                                              ("max(k)" int, d decimal, d decimal, v int, "'a'" string, "100" int)                                                       ="'a'",="100"
-2          render 0     (max(k))[int]
+2          render 0     ("max(k)")[int]
 2          render 1     (d)[decimal]
 2          render 2     (d)[decimal]
 2          render 3     (v)[int]
@@ -629,7 +629,7 @@ EXPLAIN (TYPES) SELECT MAX(k), stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROU
 1          window 0     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
 1          render 1     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
 2  render                                                                                            ("max(k)" int, d decimal, v int, "'a'" string)                                                   ="'a'"
-2          render 0     (max(k))[int]
+2          render 0     ("max(k)")[int]
 2          render 1     (d)[decimal]
 2          render 2     (v)[int]
 2          render 3     ('a')[string]

--- a/pkg/sql/parser/indexed_vars.go
+++ b/pkg/sql/parser/indexed_vars.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/pkg/errors"
 )
 
@@ -55,21 +56,21 @@ func (v *IndexedVar) Walk(_ Visitor) Expr {
 
 // TypeCheck is part of the Expr interface.
 func (v *IndexedVar) TypeCheck(_ *SemaContext, desired Type) (TypedExpr, error) {
-	if v.container == nil {
+	if v.container == nil || v.container == unboundContainer {
 		// A more technically correct message would be to say that the
 		// reference is unbound and thus cannot be typed. However this is
 		// a tad bit too technical for the average SQL use case and
 		// instead we acknowledge that we only get here if someone has
 		// used a column reference in a place where it's not allowed by
 		// the docs, so just say that instead.
-		return nil, errors.Errorf("column reference %s not allowed in this context", v)
+		return nil, errors.Errorf("column reference @%d not allowed in this context", v.Idx+1)
 	}
 	return v, nil
 }
 
 // Eval is part of the TypedExpr interface.
 func (v *IndexedVar) Eval(ctx *EvalContext) (Datum, error) {
-	if v.container == nil {
+	if v.container == nil || v.container == unboundContainer {
 		panic("indexed var must be bound to a container before evaluation")
 	}
 	return v.container.IndexedVarEval(v.Idx, ctx)
@@ -77,7 +78,7 @@ func (v *IndexedVar) Eval(ctx *EvalContext) (Datum, error) {
 
 // ResolvedType is part of the TypedExpr interface.
 func (v *IndexedVar) ResolvedType() Type {
-	if v.container == nil {
+	if v.container == nil || v.container == unboundContainer {
 		panic("indexed var must be bound to a container before type resolution")
 	}
 	return v.container.IndexedVarResolvedType(v.Idx)
@@ -87,7 +88,7 @@ func (v *IndexedVar) ResolvedType() Type {
 func (v *IndexedVar) Format(buf *bytes.Buffer, f FmtFlags) {
 	if f.indexedVarFormat != nil {
 		f.indexedVarFormat(buf, f, v.container, v.Idx)
-	} else if f.symbolicVars || v.container == nil {
+	} else if f.symbolicVars || v.container == nil || v.container == unboundContainer {
 		fmt.Fprintf(buf, "@%d", v.Idx+1)
 	} else {
 		v.container.IndexedVarFormat(buf, f, v.Idx)
@@ -98,6 +99,18 @@ func (v *IndexedVar) Format(buf *bytes.Buffer, f FmtFlags) {
 // IndexedVar with the given index value. This needs to undergo
 // BindIfUnbound() below before it can be fully used.
 func NewOrdinalReference(r int) *IndexedVar {
+	return &IndexedVar{Idx: r, container: unboundContainer}
+}
+
+// NewIndexedVar is a helper routine to create a standalone Indexedvar
+// with the given index value. This needs to undergo BindIfUnbound()
+// below before it can be fully used. The difference with ordinal
+// references is that vars returned by this constructor are modified
+// in-place by BindIfUnbound.
+//
+// Do not use NewIndexedVar for AST nodes that can undergo binding two
+// or more times.
+func NewIndexedVar(r int) *IndexedVar {
 	return &IndexedVar{Idx: r, container: nil}
 }
 
@@ -111,33 +124,40 @@ type IndexedVarHelper struct {
 	container IndexedVarContainer
 }
 
-// BindIfUnbound attaches an IndexedVar to an existing container.
-// This is needed for standalone column ordinals created during parsing.
-func (h *IndexedVarHelper) BindIfUnbound(ivar *IndexedVar) error {
-	if ivar.container != nil {
-		return nil
-	}
+// BindIfUnbound ensures the IndexedVar is attached to this helper's container.
+// - for freshly created IndexedVars (with a nil container) this will bind in-place.
+// - for already bound IndexedVar, bound to this container, this will return the same ivar unchanged.
+// - for ordinal references (with an explicit unboundContainer) this will return a new var.
+// - for already bound IndexedVars, bound to another container, this will error out.
+func (h *IndexedVarHelper) BindIfUnbound(ivar *IndexedVar) (*IndexedVar, error) {
+	// We perform the range check always, even if the ivar is already
+	// bound, as a form of safety assertion against misreuse of ivars
+	// across containers.
 	if ivar.Idx < 0 || ivar.Idx >= len(h.vars) {
-		return errors.Errorf("invalid column ordinal: @%d", ivar.Idx+1)
+		return ivar, errors.Errorf("invalid column ordinal: @%d", ivar.Idx+1)
 	}
-	// This container must also remember it has "seen" the variable
-	// so that IndexedVarUsed() below returns the right results.
-	// The IndexedVar() method ensures this.
-	*ivar = *h.IndexedVar(ivar.Idx)
-	return nil
+
+	if ivar.container == nil {
+		// This container must also remember it has "seen" the variable
+		// so that IndexedVarUsed() below returns the right results.
+		// The IndexedVar() method ensures this.
+		*ivar = *h.IndexedVar(ivar.Idx)
+		return ivar, nil
+	}
+	if ivar.container == unboundContainer {
+		return h.IndexedVar(ivar.Idx), nil
+	}
+	if ivar.container == h.container {
+		return ivar, nil
+	}
+	return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
+		"indexed var linked to different container (%T) %+v, expected (%T) %+v",
+		ivar.container, ivar.container, h.container, h.container)
 }
 
 // MakeIndexedVarHelper initializes an IndexedVarHelper structure.
 func MakeIndexedVarHelper(container IndexedVarContainer, numVars int) IndexedVarHelper {
 	return IndexedVarHelper{vars: make([]IndexedVar, numVars), container: container}
-}
-
-// AssertSameContainer checks that the indexed var refers to the same container.
-func (h *IndexedVarHelper) AssertSameContainer(ivar *IndexedVar) {
-	if ivar.container != h.container {
-		panic(fmt.Sprintf("indexed var linked to different container (%T) %+v, expected (%T) %+v",
-			ivar.container, ivar.container, h.container, h.container))
-	}
 }
 
 // AppendSlot expands the capacity of this IndexedVarHelper by one and returns
@@ -164,10 +184,8 @@ func (h *IndexedVarHelper) NumVars() int {
 func (h *IndexedVarHelper) IndexedVar(idx int) *IndexedVar {
 	h.checkIndex(idx)
 	v := &h.vars[idx]
-	if v.container == nil {
-		v.Idx = idx
-		v.container = h.container
-	}
+	v.Idx = idx
+	v.container = h.container
 	return v
 }
 
@@ -238,3 +256,25 @@ func (h *IndexedVarHelper) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 
 // VisitPost implements the Visitor interface.
 func (*IndexedVarHelper) VisitPost(expr Expr) Expr { return expr }
+
+type unboundContainerType struct{}
+
+// unboundContainer is the marker used by ordinal references (@N) in
+// the input syntax. It differs from `nil` in that calling
+// BindIfUnbound on an indexed var that uses unboundContainer will
+// cause a new IndexedVar object to be returned, to ensure that the
+// original is left unchanged (to preserve the invariant that the AST
+// is constant after parse).
+var unboundContainer = &unboundContainerType{}
+
+func (*unboundContainerType) IndexedVarEval(idx int, _ *EvalContext) (Datum, error) {
+	panic(fmt.Sprintf("unbound ordinal reference @%d", idx+1))
+}
+
+func (*unboundContainerType) IndexedVarResolvedType(idx int) Type {
+	panic(fmt.Sprintf("unbound ordinal reference @%d", idx+1))
+}
+
+func (*unboundContainerType) IndexedVarFormat(_ *bytes.Buffer, _ FmtFlags, idx int) {
+	panic(fmt.Sprintf("unbound ordinal reference @%d", idx+1))
+}

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -378,8 +378,8 @@ func (n *scanNode) IndexedVarResolvedType(idx int) parser.Type {
 	return n.resultColumns[idx].Typ
 }
 
-func (n *scanNode) IndexedVarFormat(buf *bytes.Buffer, _ parser.FmtFlags, idx int) {
-	buf.WriteString(n.resultColumns[idx].Name)
+func (n *scanNode) IndexedVarFormat(buf *bytes.Buffer, f parser.FmtFlags, idx int) {
+	parser.Name(n.resultColumns[idx].Name).Format(buf, f)
 }
 
 // scanVisibility represents which table columns should be included in a scan.

--- a/pkg/sql/select_name_resolution.go
+++ b/pkg/sql/select_name_resolution.go
@@ -64,17 +64,13 @@ func (v *nameResolutionVisitor) VisitPre(expr parser.Expr) (recurse bool, newNod
 	case *parser.IndexedVar:
 		// If the indexed var is a standalone ordinal reference, ensure it
 		// becomes a fully bound indexed var.
-		if err := v.iVarHelper.BindIfUnbound(t); err != nil {
-			v.err = err
+		t, v.err = v.iVarHelper.BindIfUnbound(t)
+		if v.err != nil {
 			return false, expr
 		}
 
-		// We allow resolving IndexedVars on expressions that have already been resolved by this
-		// resolver. This is used in some cases when adding render targets for grouping or sorting.
-		v.iVarHelper.AssertSameContainer(t)
-
 		v.foundDependentVars = true
-		return true, expr
+		return false, t
 
 	case parser.UnresolvedName:
 		vn, err := t.NormalizeVarName()

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -509,11 +509,14 @@ func (p *planner) ShowCreateView(ctx context.Context, n *parser.ShowCreateView) 
 				}
 			}
 			if customColNames {
-				colNames := make([]string, 0, len(desc.Columns))
-				for _, col := range desc.Columns {
-					colNames = append(colNames, col.Name)
+				buf.WriteByte('(')
+				for i, col := range desc.Columns {
+					if i > 0 {
+						buf.WriteString(", ")
+					}
+					parser.Name(col.Name).Format(&buf, parser.FmtSimple)
 				}
-				fmt.Fprintf(&buf, "(%s) ", strings.Join(colNames, ", "))
+				buf.WriteString(") ")
 			}
 
 			fmt.Fprintf(&buf, "AS %s", desc.ViewQuery)


### PR DESCRIPTION
Fixes  #16813.
Fixes  #16814.

This should make it into the next 1.0.x, do you agree?