### PR TITLE
cmd/benchmark: don't upload "name"

### DIFF
--- a/pkg/cmd/benchmark/main.go
+++ b/pkg/cmd/benchmark/main.go
@@ -135,11 +135,10 @@ func do(ctx context.Context) error {
 
 		if _, err := fmt.Fprintf(
 			buffer,
-			"commit: %s\ncommit-time: %s\nbranch: %s\nname: %s\niteration: %d\nstart-time: %s\n",
+			"commit: %s\ncommit-time: %s\nbranch: %s\niteration: %d\nstart-time: %s\n",
 			commit,
 			commitTime,
 			"master",
-			"nightly",
 			i,
 			timeutil.Now().UTC().Format(time.RFC3339),
 		); err != nil {


### PR DESCRIPTION
This seems to be the actual benchmark name which is parsed out by the
server; setting it manually results in a uniqueness violation.