### PR TITLE
sql: fix panic when using the wrong savepoint name in RestartWait

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1154,6 +1154,9 @@ func (e *Executor) execStmtInAbortedTxn(session *Session, stmt Statement) (Resul
 			panic("unreachable")
 		}
 		if err := parser.ValidateRestartCheckpoint(spName); err != nil {
+			if txnState.State == RestartWait {
+				txnState.updateStateAndCleanupOnErr(err, e)
+			}
 			return Result{}, err
 		}
 		if txnState.State == RestartWait {

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -549,6 +549,29 @@ Open
 statement ok
 COMMIT
 
+# Wrong savepoint name moves the txn state from RestartWait to Aborted.
+statement ok
+BEGIN TRANSACTION; SAVEPOINT cockroach_restart
+
+query error pgcode 40001 restart transaction: HandledRetryableTxnError: forced by crdb_internal.force_retry()
+SELECT CRDB_INTERNAL.FORCE_RETRY('1s':::INTERVAL)
+
+query T
+SHOW TRANSACTION STATUS
+----
+RestartWait
+
+statement error SAVEPOINT not supported except for COCKROACH_RESTART
+ROLLBACK TO SAVEPOINT bogus_name
+
+query T
+SHOW TRANSACTION STATUS
+----
+Aborted
+
+statement ok
+ROLLBACK
+
 # General savepoints
 statement ok
 BEGIN TRANSACTION


### PR DESCRIPTION
Before this patch, an error about using a wrong savepoint name
encountered in the RestartWait state would cause a panic because we
didn't rollback the transaction. Rolling back is asserted for
non-retryable errors.

So, this would panic:
BEGIN TRANSACTION; SAVEPOINT cockroach_restart
SELECT CRDB_INTERNAL.FORCE_RETRY('1s':::INTERVAL)
ROLLBACK TO SAVEPOINT bogus_name

This patch adds the rollback.