### PR TITLE
sql: accept ROLLBACK TO SAVEPOINT after any error

### DIFF
--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -55,7 +55,8 @@ type Txn struct {
 	mu struct {
 		syncutil.Mutex
 		Proto roachpb.Transaction
-		// UserPriority is the transaction's priority.
+		// UserPriority is the transaction's priority. Is not set,
+		// NormalUserPriority will be used.
 		UserPriority roachpb.UserPriority
 		// txnAnchorKey is the key at which to anchor the transaction record. If
 		// unset, the first key written in the transaction will be used.

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -55,7 +55,7 @@ type Txn struct {
 	mu struct {
 		syncutil.Mutex
 		Proto roachpb.Transaction
-		// UserPriority is the transaction's priority. Is not set,
+		// UserPriority is the transaction's priority. If not set,
 		// NormalUserPriority will be used.
 		UserPriority roachpb.UserPriority
 		// txnAnchorKey is the key at which to anchor the transaction record. If

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -742,16 +742,17 @@ func (t *Transaction) IsInitialized() bool {
 	return t.ID != nil
 }
 
-// MakePriority generates a random priority value, biased by the
-// specified userPriority. If userPriority=100, the random priority
-// will be 100x more likely to be greater than if userPriority=1. If
-// userPriority = 0.1, the random priority will be 1/10th as likely to
-// be greater than if userPriority=1. Balance is achieved when
-// userPriority=1, in which case the priority chosen is unbiased.
+// MakePriority generates a random priority value, biased by the specified
+// userPriority. If userPriority=100, the random priority will be 100x more
+// likely to be greater than if userPriority=1. If userPriority = 0.1, the
+// random priority will be 1/10th as likely to be greater than if
+// userPriority=NormalUserPriority ( = 1). Balance is achieved when
+// userPriority=NormalUserPriority, in which case the priority chosen is
+// unbiased.
 //
 // If userPriority is less than or equal to MinUserPriority, returns
-// MinTxnPriority; if greater than or equal to MaxUserPriority,
-// returns MaxTxnPriority.
+// MinTxnPriority; if greater than or equal to MaxUserPriority, returns
+// MaxTxnPriority. If userPriority is 0, returns NormalUserPriority.
 func MakePriority(userPriority UserPriority) int32 {
 	// A currently undocumented feature allows an explicit priority to
 	// be set by specifying priority < 1. The explicit priority is
@@ -763,7 +764,7 @@ func MakePriority(userPriority UserPriority) int32 {
 		}
 		return int32(-userPriority)
 	} else if userPriority == 0 {
-		userPriority = 1
+		userPriority = NormalUserPriority
 	} else if userPriority >= MaxUserPriority {
 		return MaxTxnPriority
 	} else if userPriority <= MinUserPriority {

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -291,7 +291,7 @@ statement ok
 UPDATE kv SET v = 'b' WHERE k in ('a')
 
 statement error cannot change the user priority of a running transaction
-SET TRANSACTION PRIORITY NORMAL
+SET TRANSACTION PRIORITY HIGH
 
 statement ok
 ROLLBACK
@@ -621,7 +621,7 @@ ROLLBACK TO SAVEPOINT cockroach_restart
 statement ok
 ROLLBACK TO SAVEPOINT cockroach_restart
 
-# Can rollback after a transactional write, even if not in a retryable state.
+# Can rollback after a transactional write, even from a non-error state.
 statement ok
 UPSERT INTO kv VALUES('savepoint', 'true')
 
@@ -636,6 +636,56 @@ query I
 SELECT COUNT(*) FROM kv WHERE k = 'savepoint'
 ----
 0
+
+
+# Can ROLLBACK TO SAVEPOINT even from a non-retryable error.
+statement ok
+BEGIN TRANSACTION; SAVEPOINT cockroach_restart
+
+statement error pq: table "bogus_name" does not exist
+SELECT * from bogus_name
+
+query T
+SHOW TRANSACTION STATUS
+----
+Aborted
+
+statement ok
+ROLLBACK TO SAVEPOINT cockroach_restart
+
+query T
+SHOW TRANSACTION STATUS
+----
+Open
+
+statement ok
+ROLLBACK
+
+
+# ROLLBACK TO SAVEPOINT in a txn without a SAVEPOINT.
+statement ok
+BEGIN
+
+statement error SAVEPOINT COCKROACH_RESTART has not been used
+ROLLBACK TO SAVEPOINT cockroach_restart
+
+statement ok
+ROLLBACK
+
+
+# ROLLBACK TO SAVEPOINT in an aborted txn without a SAVEPOINT.
+statement ok
+BEGIN
+
+statement error pq: table "bogus_name" does not exist
+SELECT * from bogus_name
+
+statement error SAVEPOINT COCKROACH_RESTART has not been used
+ROLLBACK TO SAVEPOINT cockroach_restart
+
+statement ok
+ROLLBACK
+
 
 # Test READ ONLY/WRITE syntax.
 

--- a/pkg/sql/txn.go
+++ b/pkg/sql/txn.go
@@ -50,33 +50,41 @@ func (p *planner) setTransactionModes(modes parser.TransactionModes) error {
 }
 
 func (p *planner) setIsolationLevel(level parser.IsolationLevel) error {
+	var iso enginepb.IsolationType
 	switch level {
 	case parser.UnspecifiedIsolation:
 		return nil
 	case parser.SnapshotIsolation:
-		return p.txn.SetIsolation(enginepb.SNAPSHOT)
+		iso = enginepb.SNAPSHOT
 	case parser.SerializableIsolation:
-		return p.txn.SetIsolation(enginepb.SERIALIZABLE)
+		iso = enginepb.SERIALIZABLE
 	default:
 		return errors.Errorf("unknown isolation level: %s", level)
 	}
+
+	return p.session.TxnState.setIsolationLevel(iso)
 }
 
 func (p *planner) setUserPriority(userPriority parser.UserPriority) error {
+	var up roachpb.UserPriority
 	switch userPriority {
 	case parser.UnspecifiedUserPriority:
 		return nil
 	case parser.Low:
-		return p.txn.SetUserPriority(roachpb.MinUserPriority)
+		up = roachpb.MinUserPriority
 	case parser.Normal:
-		return p.txn.SetUserPriority(roachpb.NormalUserPriority)
+		up = roachpb.NormalUserPriority
 	case parser.High:
-		return p.txn.SetUserPriority(roachpb.MaxUserPriority)
+		up = roachpb.MaxUserPriority
 	default:
 		return errors.Errorf("unknown user priority: %s", userPriority)
 	}
+	return p.session.TxnState.setPriority(up)
 }
 
+// Note: This setting currently doesn't have any effect and therefor is not
+// persisted anywhere. If this changes, care needs to be taken to restore it
+// when ROLLBACK TO SAVEPOINT starts a new sql transaction.
 func (p *planner) setReadWriteMode(readWriteMode parser.ReadWriteMode) error {
 	switch readWriteMode {
 	case parser.UnspecifiedReadWriteMode:


### PR DESCRIPTION
Before this patch, we accepted ROLLBACK TO SAVEPOINT after a retryable
error, or when the transaction was not in an error state. We did not
accept it if the sql txn was in the Aborted state (so, after a
non-retryable error). This was likely an oversight in #14538. Besides
consistency, this change is motivated by the desire of some client
libraries (the python one?) to always issue a ROLLBACK TO SAVEPOINT on
any error, and possibly follow it with a ROLLBACK on non-retryable
errors.

Touches https://github.com/cockroachdb/cockroachdb-python/issues/26