### PR TITLE
cli/sql: only trigger multi-line txn entry when there is no txn

### DIFF
--- a/pkg/cli/interactive_tests/test_multiline_statements.tcl
+++ b/pkg/cli/interactive_tests/test_multiline_statements.tcl
@@ -7,7 +7,7 @@ start_server $argv
 spawn $argv sql
 eexpect root@
 
-# Test that a multi-line entry can be recalled escaped.
+start_test "Test that a multi-line entry can be recalled escaped."
 send "select 'foo\r"
 eexpect " ->"
 send "bar';\r"
@@ -24,12 +24,14 @@ send "select 1,\r"
 eexpect " ->"
 send "2, 3\r"
 eexpect " ->"
+end_test
 
-# Test that \show does what it says.
+start_test "Test that \show does what it says."
 send "\\show\r"
 eexpect "select 1,\r\n2, 3\r\n*->"
+end_test
 
-# Test finishing the multi-line statement.
+start_test "Test finishing the multi-line statement."
 send ";\r"
 eexpect "1 row"
 eexpect "root@"
@@ -37,30 +39,52 @@ eexpect "root@"
 # Send up-arrow.
 send "\033\[A"
 eexpect "SELECT 1, 2, 3;"
+end_test
 
-# Test that Ctrl+C after the first line merely cancels the statement and presents the prompt.
+start_test "Test that Ctrl+C after the first line merely cancels the statement and presents the prompt."
 send "\r"
 eexpect root@
 send "SELECT\r"
 eexpect " ->"
 interrupt
 eexpect root@
+end_test
 
-# Test that BEGIN .. without COMMIT begins a multi-line statement.
+start_test "Test that BEGIN .. without COMMIT begins a multi-line statement."
 send "BEGIN; SELECT 1;\r"
 eexpect " ->"
+end_test
 
-# Test that \show does what it says.
+start_test "Test that \show does what it says."
 send "\\show\r"
 eexpect "BEGIN*;\r\nSELECT 1;\r\n*->"
+end_test
 
-# Test that a COMMIT is detected properly.
+start_test "Test that a COMMIT is detected properly."
 send "COMMIT;\r"
 eexpect "1 row"
 eexpect "root@"
+end_test
 
-# Test that an invalid statement inside a multi-line txn doesn't go to the
-# server.
+start_test "Test that BEGIN .. without COMMIT does not begin a multi-line statement in open txns. #16833"
+
+# trigger the error state
+send "BEGIN; SELECT nonexistent;\r\r"
+eexpect "not found"
+eexpect ERROR
+
+# Try to send a txn prefix, expect no multiline entry
+send "BEGIN; SELECT 1;\r"
+eexpect "commands ignored"
+eexpect "root@"
+
+# clear status for next test
+send "COMMIT;\r"
+eexpect ROLLBACK
+eexpect "root@"
+end_test
+
+start_test "Test that an invalid statement inside a multi-line txn does not go to the server."
 send "BEGIN;\r"
 eexpect " ->"
 send "SELEC T1;\r"
@@ -69,9 +93,9 @@ eexpect " ->"
 send "SELECT 1; COMMIT;\r"
 eexpect "1 row"
 eexpect root@
+end_test
 
-# Test that a dangling table creation can be committed, and that other
-# non-DDL, non-DML statements can be issued in the same txn. (#15283)
+start_test "Test that a dangling table creation can be committed, and that other non-DDL, non-DML statements can be issued in the same txn. (#15283)"
 send "create database if not exists t;"
 send "drop table if exists t.blih;"
 send "create table if not exists t.kv(k int primary key, v int);\r"
@@ -90,6 +114,7 @@ eexpect OPEN
 send "commit;\r"
 eexpect COMMIT
 eexpect root@
+end_test
 
 interrupt
 eexpect eof


### PR DESCRIPTION
Prior to this patch, the shell would detect whether the current entry
was "starting a transaction" by looking only at the statement in the
entry and trigger multi-line txn entry if it saw a BEGIN without a
COMMIT/ROLLBACK. This yields semi-surprising behavior when the current
txn state is not-empty (either open, retry or error).

This patch ensures that multi-line entry is only enabled when the txn
state is known to be empty.

Fixes #16833.