### PR TITLE
build: instruct rocksdb to build a portable library

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -399,7 +399,7 @@ $(ROCKSDB_DIR)/Makefile: $(C_DEPS_DIR)/rocksdb-rebuild $(ROCKSDB_SRC_DIR)/.extra
 	@# NOTE: If you change the CMake flags below, bump the version in
 	@# $(C_DEPS_DIR)/rocksdb-rebuild. See above for rationale.
 	cd $(ROCKSDB_DIR) && cmake $(CMAKE_FLAGS) $(ROCKSDB_SRC_DIR) \
-	  $(if $(findstring release,$(TYPE)),,-DWITH_$(if $(findstring mingw,$(TARGET_TRIPLE)),AVX2,SSE42)=OFF) \
+	  $(if $(findstring release,$(TYPE)),-DPORTABLE=ON -DFORCE_SSE42=ON) \
 	  -DSNAPPY_LIBRARIES=$(SNAPPY_DIR)/.libs/libsnappy.a -DSNAPPY_INCLUDE_DIR=$(SNAPPY_SRC_DIR) -DWITH_SNAPPY=ON \
 	  $(if $(USE_STDMALLOC),,-DJEMALLOC_LIBRARIES=$(JEMALLOC_DIR)/lib/libjemalloc.a -DJEMALLOC_INCLUDE_DIR=$(JEMALLOC_DIR)/include -DWITH_JEMALLOC=ON) \
 	  $(if $(ENABLE_ROCKSDB_ASSERTIONS),,-DCMAKE_CXX_FLAGS=-DNDEBUG)

--- a/c-deps/rocksdb-rebuild
+++ b/c-deps/rocksdb-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing rocksdb CMake flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-2
+3


### PR DESCRIPTION
RocksDB 5.5.1, which a7d51cc upgraded us to, builds with `-march=native` (or its approximate equivalent, `/arch:AVX2`, on Windows) unless a "portable" build is requested. This is obviously undesirable for our release builds, which should run on a wide variety of hardware.

This commit restore the old behavior of not building release binaries with any uncommon x86 instructions except for SSE v4.2 (i.e., `-march=generic -msse4.2`) by specifying the right CMake flags, `-DPORTABLE=ON -DFORCE_SSE42=ON`.

Fixes #16843.