### PR TITLE
Makefile: gotestdashi the testlogic target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,8 +189,10 @@ testrace: TESTTIMEOUT := $(RACETIMEOUT)
 # guaranteed to be irrelevant to save nearly 10s on every Make invocation.
 FIND_RELEVANT := find pkg -name node_modules -prune -o
 
+bin/logictest.test: PKG := ./pkg/sql/logictest
 bin/logictest.test: main.go $(shell $(FIND_RELEVANT) ! -name 'zcgo_flags.go' -name '*.go')
-	$(XGO) test $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -c -o bin/logictest.test ./pkg/sql/logictest
+	$(MAKE) gotestdashi GOFLAGS='$(GOFLAGS)' TAGS='$(TAGS)' LINKFLAGS='$(LINKFLAGS)' PKG='$(PKG)'
+	$(XGO) test $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -c -o bin/logictest.test $(PKG)
 
 bench: BENCHES := .
 bench: TESTS := -


### PR DESCRIPTION
This is a bit gross because we don't want to invoke gotestdashi at all
unless we need to rebuild the binary, but it'll do.
This is all @tamird.