### PR TITLE
sql: miscellaneous SHOW improvements (part 2)

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -17,6 +17,7 @@
 package sql
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 	"strings"
@@ -51,6 +52,8 @@ var crdbInternal = virtualSchema{
 		crdbInternalSessionVariablesTable,
 		crdbInternalLocalQueriesTable,
 		crdbInternalClusterQueriesTable,
+		crdbInternalLocalSessionsTable,
+		crdbInternalClusterSessionsTable,
 	},
 }
 
@@ -637,5 +640,111 @@ func populateQueriesTable(
 			}
 		}
 	}
+	return nil
+}
+
+const sessionsSchemaPattern = `
+CREATE TABLE crdb_internal.%s (
+  node_id            INT NOT NULL,   -- the node on which the query is running
+  username           STRING,         -- the user running the query
+  client_address     STRING,         -- the address of the client that issued the query
+  application_name   STRING,         -- the name of the application as per SET application_name
+  active_queries     STRING,         -- the currently running queries as SQL
+  session_start      TIMESTAMP,      -- the time when the session was opened
+  oldest_query_start TIMESTAMP,      -- the time when the oldest query in the session was started
+  kv_txn             STRING          -- the ID of the current KV transaction
+);
+`
+
+// crdbInternalLocalSessionsTable exposes the list of running sessions
+// on the current node. The results are dependent on the current user.
+var crdbInternalLocalSessionsTable = virtualSchemaTable{
+	schema: fmt.Sprintf(sessionsSchemaPattern, "node_sessions"),
+	populate: func(ctx context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
+		req := serverpb.ListSessionsRequest{Username: p.session.User}
+		response, err := p.session.execCfg.StatusServer.ListLocalSessions(ctx, &req)
+		if err != nil {
+			return err
+		}
+		return populateSessionsTable(ctx, addRow, response)
+	},
+}
+
+// crdbInternalClusterSessionsTable exposes the list of running sessions
+// on the entire cluster. The result is dependent on the current user.
+var crdbInternalClusterSessionsTable = virtualSchemaTable{
+	schema: fmt.Sprintf(sessionsSchemaPattern, "cluster_sessions"),
+	populate: func(ctx context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
+		req := serverpb.ListSessionsRequest{Username: p.session.User}
+		response, err := p.session.execCfg.StatusServer.ListSessions(ctx, &req)
+		if err != nil {
+			return err
+		}
+		return populateSessionsTable(ctx, addRow, response)
+	},
+}
+
+func populateSessionsTable(
+	ctx context.Context, addRow func(...parser.Datum) error, response *serverpb.ListSessionsResponse,
+) error {
+	for _, session := range response.Sessions {
+		// Generate active_queries and oldest_query_start
+		var activeQueries bytes.Buffer
+		var oldestStart time.Time
+		var oldestStartDatum parser.Datum
+
+		for _, query := range session.ActiveQueries {
+			activeQueries.WriteString(query.Sql)
+			activeQueries.WriteString("; ")
+
+			if oldestStart.IsZero() || query.Start.Before(oldestStart) {
+				oldestStart = query.Start
+			}
+		}
+
+		if oldestStart.IsZero() {
+			oldestStartDatum = parser.DNull
+		} else {
+			oldestStartDatum = parser.MakeDTimestamp(oldestStart, time.Microsecond)
+		}
+
+		kvTxnIDDatum := parser.DNull
+		if session.KvTxnID != nil {
+			kvTxnIDDatum = parser.NewDString(session.KvTxnID.String())
+		}
+
+		if err := addRow(
+			parser.NewDInt(parser.DInt(session.NodeID)),
+			parser.NewDString(session.Username),
+			parser.NewDString(session.ClientAddress),
+			parser.NewDString(session.ApplicationName),
+			parser.NewDString(activeQueries.String()),
+			parser.MakeDTimestamp(session.Start, time.Microsecond),
+			oldestStartDatum,
+			kvTxnIDDatum,
+		); err != nil {
+			return err
+		}
+	}
+
+	for _, rpcErr := range response.Errors {
+		log.Warning(ctx, rpcErr.Message)
+		if rpcErr.NodeID != 0 {
+			// Add a row with this node ID, and nulls for all other columns
+			if err := addRow(
+				parser.NewDInt(parser.DInt(rpcErr.NodeID)),
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+			); err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -17,7 +17,9 @@
 package sql
 
 import (
+	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -25,10 +27,12 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/jobs"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 const crdbInternalName = "crdb_internal"
@@ -45,6 +49,8 @@ var crdbInternal = virtualSchema{
 		crdbInternalSessionTraceTable,
 		crdbInternalClusterSettingsTable,
 		crdbInternalSessionVariablesTable,
+		crdbInternalLocalQueriesTable,
+		crdbInternalClusterQueriesTable,
 	},
 }
 
@@ -542,4 +548,94 @@ CREATE TABLE crdb_internal.session_variables (
 		}
 		return nil
 	},
+}
+
+const queriesSchemaPattern = `
+CREATE TABLE crdb_internal.%s (
+  node_id          INT NOT NULL,   -- the node on which the query is running
+  username         STRING,         -- the user running the query
+  start            TIMESTAMP,      -- the start time of the query
+  query            STRING,         -- the SQL code of the query
+  client_address   STRING,         -- the address of the client that issued the query
+  application_name STRING,         -- the name of the application as per SET application_name
+  distributed      BOOL,           -- whether the query is running distributed
+  phase            STRING          -- the current execution phase
+);
+`
+
+// crdbInternalLocalQueriesTable exposes the list of running queries
+// on the current node. The results are dependent on the current user.
+var crdbInternalLocalQueriesTable = virtualSchemaTable{
+	schema: fmt.Sprintf(queriesSchemaPattern, "node_queries"),
+	populate: func(ctx context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
+		req := serverpb.ListSessionsRequest{Username: p.session.User}
+		response, err := p.session.execCfg.StatusServer.ListLocalSessions(ctx, &req)
+		if err != nil {
+			return err
+		}
+		return populateQueriesTable(ctx, addRow, response)
+	},
+}
+
+// crdbInternalClusterQueriesTable exposes the list of running queries
+// on the entire cluster. The result is dependent on the current user.
+var crdbInternalClusterQueriesTable = virtualSchemaTable{
+	schema: fmt.Sprintf(queriesSchemaPattern, "cluster_queries"),
+	populate: func(ctx context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
+		req := serverpb.ListSessionsRequest{Username: p.session.User}
+		response, err := p.session.execCfg.StatusServer.ListSessions(ctx, &req)
+		if err != nil {
+			return err
+		}
+		return populateQueriesTable(ctx, addRow, response)
+	},
+}
+
+func populateQueriesTable(
+	ctx context.Context, addRow func(...parser.Datum) error, response *serverpb.ListSessionsResponse,
+) error {
+	for _, session := range response.Sessions {
+		for _, query := range session.ActiveQueries {
+			isDistributedDatum := parser.DNull
+			phase := strings.ToLower(query.Phase.String())
+			if phase == "executing" {
+				isDistributedDatum = parser.DBoolFalse
+				if query.IsDistributed {
+					isDistributedDatum = parser.DBoolTrue
+				}
+			}
+			if err := addRow(
+				parser.NewDInt(parser.DInt(session.NodeID)),
+				parser.NewDString(session.Username),
+				parser.MakeDTimestamp(query.Start, time.Microsecond),
+				parser.NewDString(query.Sql),
+				parser.NewDString(session.ClientAddress),
+				parser.NewDString(session.ApplicationName),
+				isDistributedDatum,
+				parser.NewDString(phase),
+			); err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, rpcErr := range response.Errors {
+		log.Warning(ctx, rpcErr.Message)
+		if rpcErr.NodeID != 0 {
+			// Add a row with this node ID, and nulls for all other columns
+			if err := addRow(
+				parser.NewDInt(parser.DInt(rpcErr.NodeID)),
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+			); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -136,7 +136,7 @@ EXPLAIN SHOW TABLES
 1  render
 2  filter
 3  values
-3          size   5 columns, 56 rows
+3          size   5 columns, 58 rows
 
 query ITTT
 EXPLAIN SHOW DATABASE
@@ -192,7 +192,7 @@ EXPLAIN SHOW COLUMNS FROM foo
 5  render
 6  filter
 7  values
-7          size      13 columns, 481 rows
+7          size      13 columns, 497 rows
 5  render
 6  filter
 7  values

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -136,7 +136,7 @@ EXPLAIN SHOW TABLES
 1  render
 2  filter
 3  values
-3          size   5 columns, 58 rows
+3          size   5 columns, 59 rows
 
 query ITTT
 EXPLAIN SHOW DATABASE
@@ -192,7 +192,7 @@ EXPLAIN SHOW COLUMNS FROM foo
 5  render
 6  filter
 7  values
-7          size      13 columns, 497 rows
+7          size      13 columns, 501 rows
 5  render
 6  filter
 7  values

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -136,37 +136,47 @@ EXPLAIN SHOW TABLES
 1  render
 2  filter
 3  values
-3          size   5 columns, 53 rows
+3          size   5 columns, 54 rows
 
 query ITTT
 EXPLAIN SHOW DATABASE
 ----
-0  values
-0          size  1 column, 1 row
+0  render
+1  filter
+2  values
+2          size  2 columns, 19 rows
 
 query ITTT
 EXPLAIN SHOW TIME ZONE
 ----
-0  values
-0          size  1 column, 1 row
+0  render
+1  filter
+2  values
+2          size  2 columns, 19 rows
 
 query ITTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
 ----
-0  values
-0          size  1 column, 1 row
+0  render
+1  filter
+2  values
+2          size  2 columns, 19 rows
 
 query ITTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
 ----
-0  values
-0          size  1 column, 1 row
+0  render
+1  filter
+2  values
+2          size  2 columns, 19 rows
 
 query ITTT
 EXPLAIN SHOW TRANSACTION PRIORITY
 ----
-0  values
-0          size  1 column, 1 row
+0  render
+1  filter
+2  values
+2          size  2 columns, 19 rows
 
 query ITTT
 EXPLAIN SHOW COLUMNS FROM foo
@@ -182,7 +192,7 @@ EXPLAIN SHOW COLUMNS FROM foo
 5  render
 6  filter
 7  values
-7          size      13 columns, 463 rows
+7          size      13 columns, 465 rows
 5  render
 6  filter
 7  values

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -136,7 +136,7 @@ EXPLAIN SHOW TABLES
 1  render
 2  filter
 3  values
-3          size   5 columns, 54 rows
+3          size   5 columns, 56 rows
 
 query ITTT
 EXPLAIN SHOW DATABASE
@@ -192,7 +192,7 @@ EXPLAIN SHOW COLUMNS FROM foo
 5  render
 6  filter
 7  values
-7          size      13 columns, 465 rows
+7          size      13 columns, 481 rows
 5  render
 6  filter
 7  values

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -136,7 +136,7 @@ EXPLAIN SHOW TABLES
 1  render
 2  filter
 3  values
-3          size   5 columns, 52 rows
+3          size   5 columns, 53 rows
 
 query ITTT
 EXPLAIN SHOW DATABASE
@@ -182,7 +182,7 @@ EXPLAIN SHOW COLUMNS FROM foo
 5  render
 6  filter
 7  values
-7          size      13 columns, 459 rows
+7          size      13 columns, 463 rows
 5  render
 6  filter
 7  values

--- a/pkg/sql/logictest/testdata/logic_test/help
+++ b/pkg/sql/logictest/testdata/logic_test/help
@@ -3,16 +3,16 @@
 query TTTT colnames
 HELP replace
 ----
-Function  Signature                                            		Category         Details
+function  signature                                                 category         details
 replace   (input: string, find: string, replace: string) -> string  String and Byte  Replaces all occurrences of `find` with `replace` in `input`
 
 query TTTT colnames
 HELP missing
 ----
-Function    Signature                           Category            Details
+function  signature  category  details
 
 query TTTT colnames
 HELP LEAST
 ----
-Function    Signature                           Category            Details
-least       (anyelement...) -> anyelement       Comparison			Returns the element with the lowest value.
+function  signature                      category    details
+least     (anyelement...) -> anyelement  Comparison  Returns the element with the lowest value.

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -204,10 +204,12 @@ DROP DATABASE other_db
 query TT
 select table_schema, table_name FROM information_schema.tables ORDER BY 1, 2
 ----
+crdb_internal       cluster_queries
 crdb_internal       cluster_settings
 crdb_internal       jobs
 crdb_internal       leases
 crdb_internal       node_build_info
+crdb_internal       node_queries
 crdb_internal       node_statement_statistics
 crdb_internal       schema_changes
 crdb_internal       session_trace
@@ -338,10 +340,12 @@ query TTTTI colnames
 SELECT * FROM information_schema.tables
 ----
 table_catalog  table_schema        table_name                 table_type   version
+def            crdb_internal       cluster_queries            SYSTEM VIEW  1
 def            crdb_internal       cluster_settings           SYSTEM VIEW  1
 def            crdb_internal       jobs                       SYSTEM VIEW  1
 def            crdb_internal       leases                     SYSTEM VIEW  1
 def            crdb_internal       node_build_info            SYSTEM VIEW  1
+def            crdb_internal       node_queries               SYSTEM VIEW  1
 def            crdb_internal       node_statement_statistics  SYSTEM VIEW  1
 def            crdb_internal       schema_changes             SYSTEM VIEW  1
 def            crdb_internal       session_trace              SYSTEM VIEW  1

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -205,11 +205,13 @@ query TT
 select table_schema, table_name FROM information_schema.tables ORDER BY 1, 2
 ----
 crdb_internal       cluster_queries
+crdb_internal       cluster_sessions
 crdb_internal       cluster_settings
 crdb_internal       jobs
 crdb_internal       leases
 crdb_internal       node_build_info
 crdb_internal       node_queries
+crdb_internal       node_sessions
 crdb_internal       node_statement_statistics
 crdb_internal       schema_changes
 crdb_internal       session_trace
@@ -341,11 +343,13 @@ SELECT * FROM information_schema.tables
 ----
 table_catalog  table_schema        table_name                 table_type   version
 def            crdb_internal       cluster_queries            SYSTEM VIEW  1
+def            crdb_internal       cluster_sessions           SYSTEM VIEW  1
 def            crdb_internal       cluster_settings           SYSTEM VIEW  1
 def            crdb_internal       jobs                       SYSTEM VIEW  1
 def            crdb_internal       leases                     SYSTEM VIEW  1
 def            crdb_internal       node_build_info            SYSTEM VIEW  1
 def            crdb_internal       node_queries               SYSTEM VIEW  1
+def            crdb_internal       node_sessions              SYSTEM VIEW  1
 def            crdb_internal       node_statement_statistics  SYSTEM VIEW  1
 def            crdb_internal       schema_changes             SYSTEM VIEW  1
 def            crdb_internal       session_trace              SYSTEM VIEW  1

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -204,6 +204,7 @@ DROP DATABASE other_db
 query TT
 select table_schema, table_name FROM information_schema.tables ORDER BY 1, 2
 ----
+crdb_internal       cluster_settings
 crdb_internal       jobs
 crdb_internal       leases
 crdb_internal       node_build_info
@@ -336,6 +337,7 @@ query TTTTI colnames
 SELECT * FROM information_schema.tables
 ----
 table_catalog  table_schema        table_name                 table_type   version
+def            crdb_internal       cluster_settings           SYSTEM VIEW  1
 def            crdb_internal       jobs                       SYSTEM VIEW  1
 def            crdb_internal       leases                     SYSTEM VIEW  1
 def            crdb_internal       node_build_info            SYSTEM VIEW  1

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -211,6 +211,7 @@ crdb_internal       node_build_info
 crdb_internal       node_statement_statistics
 crdb_internal       schema_changes
 crdb_internal       session_trace
+crdb_internal       session_variables
 crdb_internal       tables
 information_schema  columns
 information_schema  key_column_usage
@@ -344,6 +345,7 @@ def            crdb_internal       node_build_info            SYSTEM VIEW  1
 def            crdb_internal       node_statement_statistics  SYSTEM VIEW  1
 def            crdb_internal       schema_changes             SYSTEM VIEW  1
 def            crdb_internal       session_trace              SYSTEM VIEW  1
+def            crdb_internal       session_variables          SYSTEM VIEW  1
 def            crdb_internal       tables                     SYSTEM VIEW  1
 def            information_schema  columns                    SYSTEM VIEW  1
 def            information_schema  key_column_usage           SYSTEM VIEW  1

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -204,6 +204,7 @@ DROP DATABASE other_db
 query TT
 select table_schema, table_name FROM information_schema.tables ORDER BY 1, 2
 ----
+crdb_internal       builtin_functions
 crdb_internal       cluster_queries
 crdb_internal       cluster_sessions
 crdb_internal       cluster_settings
@@ -342,6 +343,7 @@ query TTTTI colnames
 SELECT * FROM information_schema.tables
 ----
 table_catalog  table_schema        table_name                 table_type   version
+def            crdb_internal       builtin_functions          SYSTEM VIEW  1
 def            crdb_internal       cluster_queries            SYSTEM VIEW  1
 def            crdb_internal       cluster_sessions           SYSTEM VIEW  1
 def            crdb_internal       cluster_settings           SYSTEM VIEW  1

--- a/pkg/sql/logictest/testdata/logic_test/parallel_stmts
+++ b/pkg/sql/logictest/testdata/logic_test/parallel_stmts
@@ -385,8 +385,8 @@ Open
 query TTTT colnames
 HELP LEAST
 ----
-Function    Signature                           Category            Details
-least       (anyelement...) -> anyelement       Comparison			Returns the element with the lowest value.
+function  signature                      category    details
+least     (anyelement...) -> anyelement  Comparison  Returns the element with the lowest value.
 
 statement error duplicate key value \(k\)=\(4\) violates unique constraint "primary"
 COMMIT

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -19,7 +19,7 @@ UTF8                1
 query TT colnames
 SELECT * FROM [SHOW ALL]
 ----
-Variable                       Value
+variable                       value
 application_name
 client_encoding                UTF8
 client_min_messages

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -221,22 +221,27 @@ func (b Builtin) Signature() string {
 	return fmt.Sprintf("(%s) -> %s", b.Types.String(), b.FixedReturnType())
 }
 
+// AllBuiltinNames is an array containing all the built-in function
+// names, sorted in alphabetical order. This can be used for a
+// deterministic walk through the Builtins map.
+var AllBuiltinNames []string
+
 func init() {
 	initAggregateBuiltins()
 	initWindowBuiltins()
 	initGeneratorBuiltins()
 	initPGBuiltins()
 
-	names := make([]string, 0, len(Builtins))
+	AllBuiltinNames = make([]string, 0, len(Builtins))
 	funDefs = make(map[string]*FunctionDefinition)
 	for name, def := range Builtins {
 		funDefs[name] = newFunctionDefinition(name, def)
-		names = append(names, name)
+		AllBuiltinNames = append(AllBuiltinNames, name)
 	}
 
 	// We alias the builtins to uppercase to hasten the lookup in the
 	// common case.
-	for _, name := range names {
+	for _, name := range AllBuiltinNames {
 		uname := strings.ToUpper(name)
 		def := Builtins[name]
 		Builtins[uname] = def

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -385,7 +385,7 @@ func (p *planner) newPlan(
 	case *parser.SetDefaultIsolation:
 		return p.SetDefaultIsolation(n)
 	case *parser.Show:
-		return p.Show(n)
+		return p.Show(ctx, n)
 	case *parser.ShowColumns:
 		return p.ShowColumns(ctx, n)
 	case *parser.ShowConstraints:
@@ -411,7 +411,7 @@ func (p *planner) newPlan(
 	case *parser.ShowTrace:
 		return p.ShowTrace(ctx, n)
 	case *parser.ShowTransactionStatus:
-		return p.ShowTransactionStatus()
+		return p.ShowTransactionStatus(ctx)
 	case *parser.ShowUsers:
 		return p.ShowUsers(ctx, n)
 	case *parser.ShowRanges:
@@ -456,7 +456,7 @@ func (p *planner) prepare(ctx context.Context, stmt parser.Statement) (planNode,
 	case *parser.SelectClause:
 		return p.SelectClause(ctx, n, nil, nil, nil, publicColumns)
 	case *parser.Show:
-		return p.Show(n)
+		return p.Show(ctx, n)
 	case *parser.ShowCreateTable:
 		return p.ShowCreateTable(ctx, n)
 	case *parser.ShowCreateView:
@@ -484,7 +484,7 @@ func (p *planner) prepare(ctx context.Context, stmt parser.Statement) (planNode,
 	case *parser.ShowUsers:
 		return p.ShowUsers(ctx, n)
 	case *parser.ShowTransactionStatus:
-		return p.ShowTransactionStatus()
+		return p.ShowTransactionStatus(ctx)
 	case *parser.ShowRanges:
 		return p.ShowRanges(ctx, n)
 	case *parser.Split:

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -804,88 +804,11 @@ func (p *planner) ShowConstraints(
 }
 
 func (p *planner) ShowQueries(ctx context.Context, n *parser.ShowQueries) (planNode, error) {
-	columns := sqlbase.ResultColumns{
-		{Name: "node_id", Typ: parser.TypeInt},
-		{Name: "username", Typ: parser.TypeString},
-		{Name: "start", Typ: parser.TypeTimestamp},
-		{Name: "query", Typ: parser.TypeString},
-		{Name: "client_address", Typ: parser.TypeString},
-		{Name: "application_name", Typ: parser.TypeString},
-		{Name: "distributed", Typ: parser.TypeBool},
-		{Name: "phase", Typ: parser.TypeString},
+	query := `TABLE crdb_internal.node_queries`
+	if n.Cluster {
+		query = `TABLE crdb_internal.cluster_queries`
 	}
-
-	return &delayedNode{
-		name:    n.String(),
-		columns: columns,
-		constructor: func(ctx context.Context, p *planner) (planNode, error) {
-			statusServer := p.session.execCfg.StatusServer
-
-			var response *serverpb.ListSessionsResponse
-			var err error
-			sessionsRequest := &serverpb.ListSessionsRequest{Username: p.session.User}
-			if n.Cluster {
-				response, err = statusServer.ListSessions(ctx, sessionsRequest)
-			} else {
-				response, err = statusServer.ListLocalSessions(ctx, sessionsRequest)
-			}
-
-			if err != nil {
-				return nil, err
-			}
-
-			v := p.newContainerValuesNode(columns, 0)
-			for _, session := range response.Sessions {
-				for _, query := range session.ActiveQueries {
-					isDistributedDatum := parser.DNull
-					if query.Phase.String() == "EXECUTING" {
-						isDistributedDatum = parser.DBoolFalse
-						if query.IsDistributed {
-							isDistributedDatum = parser.DBoolTrue
-						}
-					}
-					row := parser.Datums{
-						parser.NewDInt(parser.DInt(session.NodeID)),
-						parser.NewDString(session.Username),
-						parser.MakeDTimestamp(query.Start, time.Microsecond),
-						parser.NewDString(query.Sql),
-						parser.NewDString(session.ClientAddress),
-						parser.NewDString(session.ApplicationName),
-						isDistributedDatum,
-						parser.NewDString(strings.ToLower(query.Phase.String())),
-					}
-					if _, err := v.rows.AddRow(ctx, row); err != nil {
-						v.Close(ctx)
-						return nil, err
-					}
-				}
-			}
-
-			for _, rpcErr := range response.Errors {
-				if rpcErr.NodeID != 0 {
-					// Add a row with this node ID, and nulls for all other columns
-					_, err := v.rows.AddRow(ctx, parser.Datums{
-						parser.NewDInt(parser.DInt(rpcErr.NodeID)),
-						parser.DNull,
-						parser.DNull,
-						parser.DNull,
-						parser.DNull,
-						parser.DNull,
-						parser.DNull,
-						parser.DNull,
-					})
-					if err != nil {
-						v.Close(ctx)
-						return nil, err
-					}
-				}
-				log.Warning(ctx, rpcErr.Message)
-			}
-
-			return v, nil
-		},
-	}, nil
-
+	return p.delegateQuery(ctx, "SHOW QUERIES", query, nil, nil)
 }
 
 // ShowJobs returns all the jobs.

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -20,19 +20,16 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
-	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 const (
@@ -818,103 +815,11 @@ func (p *planner) ShowJobs(ctx context.Context, n *parser.ShowJobs) (planNode, e
 }
 
 func (p *planner) ShowSessions(ctx context.Context, n *parser.ShowSessions) (planNode, error) {
-	columns := sqlbase.ResultColumns{
-		{Name: "node_id", Typ: parser.TypeInt},
-		{Name: "username", Typ: parser.TypeString},
-		{Name: "client_address", Typ: parser.TypeString},
-		{Name: "application_name", Typ: parser.TypeString},
-		{Name: "active_queries", Typ: parser.TypeString},
-		{Name: "session_start", Typ: parser.TypeTimestamp},
-		{Name: "oldest_query_start", Typ: parser.TypeTimestamp},
-		{Name: "kv_txn", Typ: parser.TypeString},
+	query := `TABLE crdb_internal.node_sessions`
+	if n.Cluster {
+		query = `TABLE crdb_internal.cluster_sessions`
 	}
-	return &delayedNode{
-		name:    n.String(),
-		columns: columns,
-		constructor: func(ctx context.Context, p *planner) (planNode, error) {
-			statusServer := p.session.execCfg.StatusServer
-
-			var response *serverpb.ListSessionsResponse
-			var err error
-			sessionsRequest := &serverpb.ListSessionsRequest{Username: p.session.User}
-			if n.Cluster {
-				response, err = statusServer.ListSessions(ctx, sessionsRequest)
-			} else {
-				response, err = statusServer.ListLocalSessions(ctx, sessionsRequest)
-			}
-
-			if err != nil {
-				return nil, err
-			}
-
-			v := p.newContainerValuesNode(columns, len(response.Sessions))
-			for _, session := range response.Sessions {
-
-				// Generate active_queries and oldest_query_start
-				var activeQueries bytes.Buffer
-				var oldestStart time.Time
-				var oldestStartDatum parser.Datum
-
-				for _, query := range session.ActiveQueries {
-					activeQueries.WriteString(query.Sql)
-					activeQueries.WriteString("; ")
-
-					if oldestStart.IsZero() || query.Start.Before(oldestStart) {
-						oldestStart = query.Start
-					}
-				}
-
-				if oldestStart.IsZero() {
-					oldestStartDatum = parser.DNull
-				} else {
-					oldestStartDatum = parser.MakeDTimestamp(oldestStart, time.Microsecond)
-				}
-
-				kvTxnIDDatum := parser.DNull
-				if session.KvTxnID != nil {
-					kvTxnIDDatum = parser.NewDString(session.KvTxnID.String())
-				}
-
-				row := parser.Datums{
-					parser.NewDInt(parser.DInt(session.NodeID)),
-					parser.NewDString(session.Username),
-					parser.NewDString(session.ClientAddress),
-					parser.NewDString(session.ApplicationName),
-					parser.NewDString(activeQueries.String()),
-					parser.MakeDTimestamp(session.Start, time.Microsecond),
-					oldestStartDatum,
-					kvTxnIDDatum,
-				}
-				if _, err := v.rows.AddRow(ctx, row); err != nil {
-					v.Close(ctx)
-					return nil, err
-				}
-			}
-
-			for _, rpcErr := range response.Errors {
-				if rpcErr.NodeID != 0 {
-					// Add a row with this node ID, and nulls for all other columns
-					_, err := v.rows.AddRow(ctx, parser.Datums{
-						parser.NewDInt(parser.DInt(rpcErr.NodeID)),
-						parser.DNull,
-						parser.DNull,
-						parser.DNull,
-						parser.DNull,
-						parser.DNull,
-						parser.DNull,
-						parser.DNull,
-					})
-					if err != nil {
-						v.Close(ctx)
-						return nil, err
-					}
-				}
-				log.Warning(ctx, rpcErr.Message)
-			}
-
-			return v, nil
-		},
-	}, nil
+	return p.delegateQuery(ctx, "SHOW SESSIONS", query, nil, nil)
 }
 
 // ShowTables returns all the tables.

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -171,53 +171,22 @@ func (p *planner) Show(ctx context.Context, n *parser.Show) (planNode, error) {
 		return p.showClusterSetting(ctx, name)
 	}
 
-	var columns sqlbase.ResultColumns
-
-	switch name {
-	case `all`:
-		columns = sqlbase.ResultColumns{
-			{Name: "Variable", Typ: parser.TypeString},
-			{Name: "Value", Typ: parser.TypeString},
-		}
-	default:
-		if _, ok := varGen[name]; !ok {
-			return nil, fmt.Errorf("unknown variable: %q", origName)
-		}
-		columns = sqlbase.ResultColumns{{Name: name, Typ: parser.TypeString}}
+	if name == "all" {
+		return p.delegateQuery(ctx, "SHOW SESSION ALL", "TABLE crdb_internal.session_variables",
+			nil, nil)
 	}
 
-	return &delayedNode{
-		name:    "SHOW " + origName,
-		columns: columns,
-		constructor: func(ctx context.Context, p *planner) (planNode, error) {
-			v := p.newContainerValuesNode(columns, 0)
+	if _, ok := varGen[name]; !ok {
+		return nil, fmt.Errorf("unknown variable: %q", origName)
+	}
 
-			switch name {
-			case `all`:
-				for _, vName := range varNames {
-					gen := varGen[vName]
-					value := gen.Get(p.session)
-					if _, err := v.rows.AddRow(
-						ctx, parser.Datums{parser.NewDString(vName), parser.NewDString(value)},
-					); err != nil {
-						v.rows.Close(ctx)
-						return nil, err
-					}
-				}
-			default:
-				// The key in varGen is guaranteed to exist thanks to the
-				// check above.
-				gen := varGen[name]
-				value := gen.Get(p.session)
-				if _, err := v.rows.AddRow(ctx, parser.Datums{parser.NewDString(value)}); err != nil {
-					v.rows.Close(ctx)
-					return nil, err
-				}
-			}
-
-			return v, nil
-		},
-	}, nil
+	varName := parser.EscapeSQLString(name)
+	return p.delegateQuery(ctx, "SHOW "+varName,
+		fmt.Sprintf(
+			`SELECT value AS %[1]s FROM crdb_internal.session_variables `+
+				`WHERE variable = %[2]s`,
+			parser.Name(name).String(), varName),
+		nil, nil)
 }
 
 // ShowColumns of a table.

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -863,41 +863,10 @@ func (p *planner) ShowUsers(ctx context.Context, n *parser.ShowUsers) (planNode,
 		`SELECT username FROM system.users ORDER BY 1`, nil, nil)
 }
 
-// Help returns usage information for the builtin functions
+// Help returns usage information for the given builtin function.
 // Privileges: None
 func (p *planner) Help(ctx context.Context, n *parser.Help) (planNode, error) {
-	name := strings.ToLower(string(n.Name))
-	columns := sqlbase.ResultColumns{
-		{Name: "Function", Typ: parser.TypeString},
-		{Name: "Signature", Typ: parser.TypeString},
-		{Name: "Category", Typ: parser.TypeString},
-		{Name: "Details", Typ: parser.TypeString},
-	}
-	return &delayedNode{
-		name:    "HELP " + name,
-		columns: columns,
-		constructor: func(ctx context.Context, p *planner) (planNode, error) {
-			v := p.newContainerValuesNode(columns, 0)
-
-			matches, ok := parser.Builtins[name]
-			// TODO(dt): support fuzzy matching.
-			if !ok {
-				return v, nil
-			}
-
-			for _, f := range matches {
-				row := parser.Datums{
-					parser.NewDString(name),
-					parser.NewDString(f.Signature()),
-					parser.NewDString(f.Category()),
-					parser.NewDString(f.Info),
-				}
-				if _, err := v.rows.AddRow(ctx, row); err != nil {
-					v.Close(ctx)
-					return nil, err
-				}
-			}
-			return v, nil
-		},
-	}, nil
+	return p.delegateQuery(ctx, "HELP", fmt.Sprintf(
+		`SELECT * FROM crdb_internal.builtin_functions WHERE function ILIKE %s`,
+		parser.EscapeSQLString(string(n.Name))), nil, nil)
 }


### PR DESCRIPTION
These are the remaining patches split away from #16760.

The rationale for this change is as follows:

- reduced data copying in memory.
- we'll soon do filter propagation down to the vtable generators, to avoid instantiating in memory those rows that are filtered out by the surrounding query. This patch set ensures that this optimization will apply to the various SHOW statements directly.