### PR TITLE
sql: fix missing indexes in SHOW CREATE TABLE

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -182,7 +182,9 @@ delivery  CREATE TABLE delivery (
               shipment INT NULL,
               item STRING NULL,
               CONSTRAINT fk_item_ref_products FOREIGN KEY (item) REFERENCES products (upc),
+              INDEX delivery_item_idx (item ASC),
               CONSTRAINT fk_order_ref_orders FOREIGN KEY ("order", shipment) REFERENCES orders (id, shipment),
+              INDEX delivery_auto_index_fk_order_ref_orders ("order" ASC, shipment ASC),
               FAMILY "primary" (ts, "order", shipment, item, rowid)
 )
 
@@ -705,11 +707,12 @@ query TT
 SHOW CREATE TABLE refers
 ----
 refers  CREATE TABLE refers (
-a INT NULL,
-b INT NULL,
-INDEX another_idx (b ASC),
-CONSTRAINT fk_a_ref_referee FOREIGN KEY (a) REFERENCES referee (id),
-FAMILY "primary" (a, b, rowid)
+    a INT NULL,
+    b INT NULL,
+    INDEX another_idx (b ASC),
+    CONSTRAINT fk_a_ref_referee FOREIGN KEY (a) REFERENCES referee (id),
+    INDEX refers_auto_index_fk_a_ref_referee (a ASC),
+    FAMILY "primary" (a, b, rowid)
 )
 
 statement ok

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -442,16 +442,16 @@ func (p *planner) showCreateTable(
 				parser.Name(fkTable.Name),
 				quoteNames(fkIdx.ColumnNames...),
 			)
-		} else {
-			interleave, err := p.showCreateInterleave(ctx, &idx)
-			if err != nil {
-				return "", err
-			}
-			fmt.Fprintf(&buf, ",\n\t%s%s",
-				idx.SQLString(""),
-				interleave,
-			)
 		}
+		interleave, err := p.showCreateInterleave(ctx, &idx)
+		if err != nil {
+			return "", err
+		}
+		fmt.Fprintf(&buf, ",\n\t%s%s",
+			idx.SQLString(""),
+			interleave,
+		)
+
 	}
 	for _, fam := range desc.Families {
 		activeColumnNames := make([]string, 0, len(fam.ColumnNames))

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -172,7 +172,9 @@ func TestShowCreateTable(t *testing.T) {
 	j INT NULL,
 	k INT NULL,
 	CONSTRAINT fk_i_ref_items FOREIGN KEY (i, j) REFERENCES items (a, b),
+	INDEX t7_auto_index_fk_i_ref_items (i ASC, j ASC),
 	CONSTRAINT fk_k_ref_items FOREIGN KEY (k) REFERENCES items (c),
+	INDEX t7_auto_index_fk_k_ref_items (k ASC),
 	FAMILY "primary" (i, j, k, rowid)
 )`,
 		},


### PR DESCRIPTION
previously, if an index was used by a foreign key, it was ommitted by SHOW CREATE TABLE, with only
the foriegn key printed.

Fixes #16653.