### PR TITLE
sql: handle BEGIN error

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1293,6 +1293,12 @@ func (e *Executor) execStmtInOpenTxn(
 				panic(fmt.Sprintf("unexpected txnState when cleaning up: %v", txnState.State()))
 			}
 			txnState.updateStateAndCleanupOnErr(err, e)
+
+			if firstInTxn && isBegin(stmt) {
+				// A failed BEGIN statement that was starting a txn doesn't leave the
+				// txn in the Aborted state; we transition back to NoTxn.
+				txnState.resetStateAndTxn(NoTxn)
+			}
 		} else if txnState.State() == FirstBatch &&
 			!canStayInFirstBatchState(stmt) {
 			// Transition from FirstBatch to Open except in the case of special

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -790,14 +790,10 @@ BEGIN READ WRITE; COMMIT
 statement error read only not supported
 BEGIN READ ONLY
 
-# TODO(andrei): Something might be fishy here. The statement above leaves the
-# transaction in an error state, and so we need this rollback. But all the
-# errors below are parse errors, and so they don't mess with the transaction
-# state. Perhaps it'd be better if the statement above also left the session in
-# the NoTxn state. I couldn't do an analogous test with Postgres since I can't
-# trigger a BEGIN error that's not a parse error.
-statement ok
-ROLLBACK
+query T
+SHOW TRANSACTION STATUS
+----
+NoTxn
 
 statement error read mode specified multiple times
 BEGIN READ WRITE, READ ONLY


### PR DESCRIPTION
Before this patch, a failing BEGIN would leave the session's txn in the
Aborted state. This is surprising; this patches makes the transition
back to NoTxn.

Fixes #16712