### PR TITLE
sql: untagged versions of encoding functions

### DIFF
--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -1182,42 +1182,72 @@ func EncodeBoolValue(appendTo []byte, colID uint32, b bool) []byte {
 	return encodeValueTag(appendTo, colID, False)
 }
 
-// EncodeIntValue encodes an int value, appends it to the supplied buffer, and
-// returns the final buffer.
+// EncodeIntValue encodes an int value with its value tag, appends it to the
+// supplied buffer, and returns the final buffer.
 func EncodeIntValue(appendTo []byte, colID uint32, i int64) []byte {
 	appendTo = encodeValueTag(appendTo, colID, Int)
+	return EncodeUntaggedIntValue(appendTo, i)
+}
+
+// EncodeUntaggedIntValue encodes an int value, appends it to the supplied buffer, and
+// returns the final buffer.
+func EncodeUntaggedIntValue(appendTo []byte, i int64) []byte {
 	return EncodeNonsortingStdlibVarint(appendTo, i)
 }
 
 const floatValueEncodedLength = uint64AscendingEncodedLength
 
-// EncodeFloatValue encodes a float value, appends it to the supplied buffer,
-// and returns the final buffer.
+// EncodeFloatValue encodes a float value with its value tag, appends it to the
+// supplied buffer, and returns the final buffer.
 func EncodeFloatValue(appendTo []byte, colID uint32, f float64) []byte {
 	appendTo = encodeValueTag(appendTo, colID, Float)
+	return EncodeUntaggedFloatValue(appendTo, f)
+}
+
+// EncodeUntaggedFloatValue encodes a float value, appends it to the supplied buffer,
+// and returns the final buffer.
+func EncodeUntaggedFloatValue(appendTo []byte, f float64) []byte {
 	return EncodeUint64Ascending(appendTo, math.Float64bits(f))
 }
 
-// EncodeBytesValue encodes a byte array value, appends it to the supplied
-// buffer, and returns the final buffer.
+// EncodeBytesValue encodes a byte array value with its value tag, appends it to
+// the supplied buffer, and returns the final buffer.
 func EncodeBytesValue(appendTo []byte, colID uint32, data []byte) []byte {
 	appendTo = encodeValueTag(appendTo, colID, Bytes)
+	return EncodeUntaggedBytesValue(appendTo, data)
+}
+
+// EncodeUntaggedBytesValue encodes a byte array value, appends it to the supplied
+// buffer, and returns the final buffer.
+func EncodeUntaggedBytesValue(appendTo []byte, data []byte) []byte {
 	appendTo = EncodeNonsortingUvarint(appendTo, uint64(len(data)))
 	return append(appendTo, data...)
 }
 
-// EncodeTimeValue encodes a time.Time value, appends it to the supplied buffer,
-// and returns the final buffer.
+// EncodeTimeValue encodes a time.Time value with its value tag, appends it to
+// the supplied buffer, and returns the final buffer.
 func EncodeTimeValue(appendTo []byte, colID uint32, t time.Time) []byte {
 	appendTo = encodeValueTag(appendTo, colID, Time)
+	return EncodeUntaggedTimeValue(appendTo, t)
+}
+
+// EncodeUntaggedTimeValue encodes a time.Time value, appends it to the supplied buffer,
+// and returns the final buffer.
+func EncodeUntaggedTimeValue(appendTo []byte, t time.Time) []byte {
 	appendTo = EncodeNonsortingStdlibVarint(appendTo, t.Unix())
 	return EncodeNonsortingStdlibVarint(appendTo, int64(t.Nanosecond()))
 }
 
-// EncodeDecimalValue encodes an apd.Decimal value, appends it to the supplied
-// buffer, and returns the final buffer.
+// EncodeDecimalValue encodes an apd.Decimal value with its value tag, appends
+// it to the supplied buffer, and returns the final buffer.
 func EncodeDecimalValue(appendTo []byte, colID uint32, d *apd.Decimal) []byte {
 	appendTo = encodeValueTag(appendTo, colID, Decimal)
+	return EncodeUntaggedDecimalValue(appendTo, d)
+}
+
+// EncodeUntaggedDecimalValue encodes an apd.Decimal value, appends it to the supplied
+// buffer, and returns the final buffer.
+func EncodeUntaggedDecimalValue(appendTo []byte, d *apd.Decimal) []byte {
 	// To avoid the allocation, leave space for the varint, encode the decimal,
 	// encode the varint, and shift the encoded decimal to the end of the
 	// varint.
@@ -1232,19 +1262,31 @@ func EncodeDecimalValue(appendTo []byte, colID uint32, d *apd.Decimal) []byte {
 	return appendTo[:varintPos+varintLen+decLen]
 }
 
-// EncodeDurationValue encodes a duration.Duration value, appends it to the
-// supplied buffer, and returns the final buffer.
+// EncodeDurationValue encodes a duration.Duration value with its value tag,
+// appends it to the supplied buffer, and returns the final buffer.
 func EncodeDurationValue(appendTo []byte, colID uint32, d duration.Duration) []byte {
 	appendTo = encodeValueTag(appendTo, colID, Duration)
+	return EncodeUntaggedDurationValue(appendTo, d)
+}
+
+// EncodeUntaggedDurationValue encodes a duration.Duration value, appends it to the
+// supplied buffer, and returns the final buffer.
+func EncodeUntaggedDurationValue(appendTo []byte, d duration.Duration) []byte {
 	appendTo = EncodeNonsortingStdlibVarint(appendTo, d.Months)
 	appendTo = EncodeNonsortingStdlibVarint(appendTo, d.Days)
 	return EncodeNonsortingStdlibVarint(appendTo, d.Nanos)
 }
 
-// EncodeUUIDValue encodes a uuid.UUID value, appends it to the supplied buffer,
-// and returns the final buffer.
+// EncodeUUIDValue encodes a uuid.UUID value with its value tag, appends it to
+// the supplied buffer, and returns the final buffer.
 func EncodeUUIDValue(appendTo []byte, colID uint32, u uuid.UUID) []byte {
 	appendTo = encodeValueTag(appendTo, colID, UUID)
+	return EncodeUntaggedUUIDValue(appendTo, u)
+}
+
+// EncodeUntaggedUUIDValue encodes a uuid.UUID value, appends it to the supplied buffer,
+// and returns the final buffer.
+func EncodeUntaggedUUIDValue(appendTo []byte, u uuid.UUID) []byte {
 	return append(appendTo, u.GetBytes()...)
 }
 
@@ -1317,6 +1359,11 @@ func DecodeIntValue(b []byte) (remaining []byte, i int64, err error) {
 	if err != nil {
 		return b, 0, err
 	}
+	return DecodeUntaggedIntValue(b)
+}
+
+// DecodeUntaggedIntValue decodes a value encoded by EncodeUntaggedIntValue.
+func DecodeUntaggedIntValue(b []byte) (remaining []byte, i int64, err error) {
 	b, _, i, err = DecodeNonsortingStdlibVarint(b)
 	return b, i, err
 }
@@ -1327,6 +1374,11 @@ func DecodeFloatValue(b []byte) (remaining []byte, f float64, err error) {
 	if err != nil {
 		return b, 0, err
 	}
+	return DecodeUntaggedFloatValue(b)
+}
+
+// DecodeUntaggedFloatValue decodes a value encoded by EncodeUntaggedFloatValue.
+func DecodeUntaggedFloatValue(b []byte) (remaining []byte, f float64, err error) {
 	if len(b) < 8 {
 		return b, 0, fmt.Errorf("float64 value should be exactly 8 bytes: %d", len(b))
 	}
@@ -1341,6 +1393,11 @@ func DecodeBytesValue(b []byte) (remaining []byte, data []byte, err error) {
 	if err != nil {
 		return b, nil, err
 	}
+	return DecodeUntaggedBytesValue(b)
+}
+
+// DecodeUntaggedBytesValue decodes a value encoded by EncodeUntaggedBytesValue.
+func DecodeUntaggedBytesValue(b []byte) (remaining, data []byte, err error) {
 	var i uint64
 	b, _, i, err = DecodeNonsortingUvarint(b)
 	if err != nil {
@@ -1355,6 +1412,11 @@ func DecodeTimeValue(b []byte) (remaining []byte, t time.Time, err error) {
 	if err != nil {
 		return b, time.Time{}, err
 	}
+	return DecodeUntaggedTimeValue(b)
+}
+
+// DecodeUntaggedTimeValue decodes a value encoded by EncodeUntaggedTimeValue.
+func DecodeUntaggedTimeValue(b []byte) (remaining []byte, t time.Time, err error) {
 	var sec, nsec int64
 	b, _, sec, err = DecodeNonsortingStdlibVarint(b)
 	if err != nil {
@@ -1373,6 +1435,11 @@ func DecodeDecimalValue(b []byte) (remaining []byte, d apd.Decimal, err error) {
 	if err != nil {
 		return b, apd.Decimal{}, err
 	}
+	return DecodeUntaggedDecimalValue(b)
+}
+
+// DecodeUntaggedDecimalValue decodes a value encoded by EncodeUntaggedDecimalValue.
+func DecodeUntaggedDecimalValue(b []byte) (remaining []byte, d apd.Decimal, err error) {
 	var i uint64
 	b, _, i, err = DecodeNonsortingStdlibUvarint(b)
 	if err != nil {
@@ -1388,6 +1455,11 @@ func DecodeDurationValue(b []byte) (remaining []byte, d duration.Duration, err e
 	if err != nil {
 		return b, duration.Duration{}, err
 	}
+	return DecodeUntaggedDurationValue(b)
+}
+
+// DecodeUntaggedDurationValue decodes a value encoded by EncodeUntaggedDurationValue.
+func DecodeUntaggedDurationValue(b []byte) (remaining []byte, d duration.Duration, err error) {
 	var months, days, nanos int64
 	b, _, months, err = DecodeNonsortingStdlibVarint(b)
 	if err != nil {
@@ -1414,6 +1486,11 @@ func DecodeUUIDValue(b []byte) (remaining []byte, u uuid.UUID, err error) {
 	if err != nil {
 		return b, u, err
 	}
+	return DecodeUntaggedUUIDValue(b)
+}
+
+// DecodeUntaggedUUIDValue decodes a value encoded by EncodeUntaggedUUIDValue.
+func DecodeUntaggedUUIDValue(b []byte) (remaining []byte, u uuid.UUID, err error) {
 	u, err = uuid.FromBytes(b[:uuidValueEncodedLength])
 	if err != nil {
 		return b, uuid.UUID{}, err
@@ -1579,6 +1656,13 @@ func PrettyPrintValueEncoded(b []byte) ([]byte, string, error) {
 			return b, "", err
 		}
 		return b, d.String(), nil
+	case UUID:
+		var u uuid.UUID
+		b, u, err = DecodeUUIDValue(b)
+		if err != nil {
+			return b, "", err
+		}
+		return b, u.String(), nil
 	default:
 		return b, "", errors.Errorf("unknown type %s", typ)
 	}

--- a/pkg/util/encoding/encoding_test.go
+++ b/pkg/util/encoding/encoding_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
 func testBasicEncodeDecode32(
@@ -1777,6 +1778,8 @@ func TestUpperBoundValueEncodingSize(t *testing.T) {
 }
 
 func TestPrettyPrintValueEncoded(t *testing.T) {
+	uuidStr := "63616665-6630-3064-6465-616462656562"
+	u, _ := uuid.FromString(uuidStr)
 	tests := []struct {
 		buf      []byte
 		expected string
@@ -1793,6 +1796,7 @@ func TestPrettyPrintValueEncoded(t *testing.T) {
 			duration.Duration{Months: 1, Days: 2, Nanos: 3}), "1mon2d3ns"},
 		{EncodeBytesValue(nil, NoColumnID, []byte{0x1, 0x2, 0xF, 0xFF}), "01020fff"},
 		{EncodeBytesValue(nil, NoColumnID, []byte("foo")), "foo"},
+		{EncodeUUIDValue(nil, NoColumnID, u), uuidStr},
 	}
 	for i, test := range tests {
 		remaining, str, err := PrettyPrintValueEncoded(test.buf)


### PR DESCRIPTION
Needed for array encoding/decoding, since we don't want to include value tags in array data.
Also pull out a decodeUntaggedDatum function in table.go to help with
that.

I've lost the value tag assertion here which I'm unhappy about, I've been thinking
about how to do this properly for a while now and I'm going in circles so I figured
I'd just PR it and get opinions.

If we want to re-add the value tag assertions and keep the untagged functionality, I
see three options:

1. Keep the original big switch in `DecodeTableValue` and introduce `decodeUntaggedValue` separately
  * I'd rather not add an additional switch of types, just one more thing to add to for any new types
2. Introduce a function from parser.Type -> encoding.Type to get the expected tag,
and check that in `DecodeTableValue`
  * Same as above, adding a new switch seems unfortunate
  * Is this a hot code path? Would the switch for this have performance penalties (I haven't tested anything, just wondering)
3. Instead of having these additional functions, give the encode/decode functions a flag argument that determines if they should include the tag.
  * I don't like flag arguments, seems kind of nasty and less readable