### PR TITLE
storage: expose experimental clockless reads mode

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -335,6 +335,13 @@ disabled by setting the environment variable COCKROACH_SKIP_KEY_PERMISSION_CHECK
 		Description: `Path to the CA key.`,
 	}
 
+	// TODO(tschottdorf): once clockless mode becomes non-experimental, explain it here:
+	// <PRE>
+	//
+	// </PRE>
+	// Specifying the string value 'experimental-clockless' instead of a duration runs the cluster
+	// in clockless reads mode. In that mode, reads are routed through Raft and subsequently
+	// performance is reduced, but clock synchronization is not relied upon for correctness.
 	MaxOffset = FlagInfo{
 		Name: "max-offset",
 		Description: `
@@ -346,8 +353,8 @@ failures as well as the frequency of uncertainty-based read restarts.
 
 </PRE>
 Note that this value must be the same on all nodes in the cluster. In order to
-change it, every node in the cluster must be stopped and restarted with the new
-value.`,
+change it, all nodes in the cluster must be stopped simultaneously and restarted
+with the new value.`,
 	}
 
 	Store = FlagInfo{

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -241,7 +241,7 @@ func init() {
 		varFlag(f, &serverCfg.Locality, cliflags.Locality)
 
 		varFlag(f, &serverCfg.Stores, cliflags.Store)
-		durationFlag(f, &serverCfg.MaxOffset, cliflags.MaxOffset, base.DefaultMaxClockOffset)
+		varFlag(f, &serverCfg.MaxOffset, cliflags.MaxOffset)
 
 		// Usage for the unix socket is odd as we use a real file, whereas
 		// postgresql and clients consider it a directory and build a filename

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -103,7 +103,7 @@ func TestClockOffsetFlagValue(t *testing.T) {
 		if err := f.Parse(td.args); err != nil {
 			t.Fatal(err)
 		}
-		if td.expected != serverCfg.MaxOffset {
+		if td.expected != time.Duration(serverCfg.MaxOffset) {
 			t.Errorf("%d. MaxOffset expected %v, but got %v", i, td.expected, serverCfg.RaftTickInterval)
 		}
 	}

--- a/pkg/internal/client/lease.go
+++ b/pkg/internal/client/lease.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
@@ -121,7 +122,13 @@ func (m *LeaseManager) TimeRemaining(l *Lease) time.Duration {
 }
 
 func (m *LeaseManager) timeRemaining(val *LeaseVal) time.Duration {
-	return val.Expiration.GoTime().Sub(m.clock.Now().GoTime()) - m.clock.MaxOffset()
+	maxOffset := m.clock.MaxOffset()
+	if maxOffset == timeutil.ClocklessMaxOffset {
+		// Clockless reads are active, so we don't need to stop using the lease
+		// early.
+		maxOffset = 0
+	}
+	return val.Expiration.GoTime().Sub(m.clock.Now().GoTime()) - maxOffset
 }
 
 // ExtendLease attempts to push the expiration time of the lease farther out

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -461,20 +461,23 @@ func (tc *TxnCoordSender) Send(
 	if _, ok := ba.GetArg(roachpb.EndTransaction); !ok {
 		return br, nil
 	}
-	// If the --linearizable flag is set, we want to make sure that
-	// all the clocks in the system are past the commit timestamp
-	// of the transaction. This is guaranteed if either
-	// - the commit timestamp is MaxOffset behind startNS
-	// - MaxOffset ns were spent in this function
-	// when returning to the client. Below we choose the option
-	// that involves less waiting, which is likely the first one
-	// unless a transaction commits with an odd timestamp.
+	// If the --linearizable flag is set, we want to make sure that all the
+	// clocks in the system are past the commit timestamp of the transaction.
+	// This is guaranteed if either - the commit timestamp is MaxOffset behind
+	// startNS - MaxOffset ns were spent in this function when returning to the
+	// client. Below we choose the option that involves less waiting, which is
+	// likely the first one unless a transaction commits with an odd timestamp.
+	//
+	// Can't use --linearizable mode with clockless reads since in that case we
+	// don't know how long to sleep - could be forever!
 	if tsNS := br.Txn.Timestamp.WallTime; startNS > tsNS {
 		startNS = tsNS
 	}
-	sleepNS := tc.clock.MaxOffset() -
+	maxOffset := tc.clock.MaxOffset()
+	sleepNS := maxOffset -
 		time.Duration(tc.clock.PhysicalNow()-startNS)
-	if tc.linearizable && sleepNS > 0 {
+
+	if maxOffset != timeutil.ClocklessMaxOffset && tc.linearizable && sleepNS > 0 {
 		defer func() {
 			if log.V(1) {
 				log.Infof(ctx, "%v: waiting %s on EndTransaction for linearizability", br.Txn.Short(), util.TruncateDuration(sleepNS, time.Millisecond))

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -423,7 +423,10 @@ func (ctx *Context) runHeartbeat(meta *connMeta, remoteAddr string) error {
 			// Only update the clock offset measurement if we actually got a
 			// successful response from the server.
 			pingDuration := receiveTime.Sub(sendTime)
-			if pingDuration > maximumPingDurationMult*ctx.LocalClock.MaxOffset() {
+			maxOffset := ctx.LocalClock.MaxOffset()
+			if maxOffset != timeutil.ClocklessMaxOffset &&
+				pingDuration > maximumPingDurationMult*maxOffset {
+
 				request.Offset.Reset()
 			} else {
 				// Offset and error are measured using the remote clock reading

--- a/pkg/rpc/heartbeat.go
+++ b/pkg/rpc/heartbeat.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 var _ security.RequestWithUser = &PingRequest{}
@@ -65,7 +66,10 @@ func (hs *HeartbeatService) Ping(ctx context.Context, args *PingRequest) (*PingR
 	// Commit suicide in the event that this is ever untrue.
 	// This check is ignored if either offset is set to 0 (for unittests).
 	mo, amo := hs.clock.MaxOffset(), time.Duration(args.MaxOffsetNanos)
-	if mo != 0 && amo != 0 && mo != amo {
+	if mo != 0 && amo != 0 &&
+		mo != timeutil.ClocklessMaxOffset && amo != timeutil.ClocklessMaxOffset &&
+		mo != amo {
+
 		panic(fmt.Sprintf("locally configured maximum clock offset (%s) "+
 			"does not match that of node %s (%s)", mo, args.Addr, amo))
 	}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -106,7 +106,7 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	}
 	if knobs := params.Knobs.Store; knobs != nil {
 		if mo := knobs.(*storage.StoreTestingKnobs).MaxOffset; mo != 0 {
-			cfg.MaxOffset = mo
+			cfg.MaxOffset = MaxOffsetType(mo)
 		}
 	}
 	if params.ScanInterval != 0 {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1670,12 +1670,20 @@ func (r *Replica) Send(
 	// If the internal Raft group is not initialized, create it and wake the leader.
 	r.maybeInitializeRaftGroup(ctx)
 
+	useRaft := ba.IsWrite()
+	isReadOnly := ba.IsReadOnly()
+
+	if isReadOnly && r.store.Clock().MaxOffset() == timeutil.ClocklessMaxOffset {
+		// Clockless reads mode: reads go through Raft.
+		useRaft = true
+	}
+
 	// Differentiate between admin, read-only and write.
 	var pErr *roachpb.Error
-	if ba.IsWrite() {
+	if useRaft {
 		log.Event(ctx, "read-write path")
 		br, pErr = r.executeWriteBatch(ctx, ba)
-	} else if ba.IsReadOnly() {
+	} else if isReadOnly {
 		log.Event(ctx, "read-only path")
 		br, pErr = r.executeReadOnlyBatch(ctx, ba)
 	} else if ba.IsAdmin() {
@@ -1791,6 +1799,11 @@ func (ec *endCmds) done(br *roachpb.BatchResponse, pErr *roachpb.Error, retry pr
 			log.Fatal(context.Background(), err)
 		}
 		creq := makeCacheRequest(&ec.ba, br, span)
+
+		if ec.repl.store.Clock().MaxOffset() == timeutil.ClocklessMaxOffset {
+			// Clockless mode: all reads count as writes.
+			creq.writes, creq.reads = append(creq.writes, creq.reads...), nil
+		}
 		ec.repl.store.tsCacheMu.Lock()
 		ec.repl.store.tsCacheMu.cache.AddRequest(creq)
 		ec.repl.store.tsCacheMu.Unlock()
@@ -1929,6 +1942,7 @@ func (r *Replica) beginCmds(
 	var cmds [numSpanAccess]struct {
 		global, local *cmd
 	}
+	clocklessReads := r.store.Clock().MaxOffset() == timeutil.ClocklessMaxOffset
 	// Don't use the command queue for inconsistent reads.
 	if ba.ReadConsistency != roachpb.INCONSISTENT {
 
@@ -1962,12 +1976,13 @@ func (r *Replica) beginCmds(
 		// Collect all the channels to wait on before adding this batch to the
 		// command queue.
 		for i := SpanAccess(0); i < numSpanAccess; i++ {
-			readOnly := i == SpanReadOnly
+			// With clockless reads, everything is treated as writing.
+			readOnly := i == SpanReadOnly && !clocklessReads
 			chans = append(chans, r.cmdQMu.global.getWait(readOnly, reqGlobalTS, spans.getSpans(i, spanGlobal))...)
 			chans = append(chans, r.cmdQMu.local.getWait(readOnly, reqLocalTS, spans.getSpans(i, spanLocal))...)
 		}
 		for i := SpanAccess(0); i < numSpanAccess; i++ {
-			readOnly := i == SpanReadOnly
+			readOnly := i == SpanReadOnly && !clocklessReads // ditto above
 			cmds[i].global = r.cmdQMu.global.add(readOnly, reqGlobalTS, spans.getSpans(i, spanGlobal))
 			cmds[i].local = r.cmdQMu.local.add(readOnly, reqLocalTS, spans.getSpans(i, spanLocal))
 		}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -893,7 +893,12 @@ func (sc *StoreConfig) LeaseExpiration() int64 {
 	// Due to lease extensions, the remaining interval can be longer than just
 	// the sum of the offset (=length of stasis period) and the active
 	// duration, but definitely not by 2x.
-	return 2 * int64(sc.RangeLeaseActiveDuration+sc.Clock.MaxOffset())
+	maxOffset := sc.Clock.MaxOffset()
+	if maxOffset == timeutil.ClocklessMaxOffset {
+		// Don't do shady math on clockless reads.
+		maxOffset = 0
+	}
+	return 2 * int64(sc.RangeLeaseActiveDuration+maxOffset)
 }
 
 // NewStore returns a new instance of a store.
@@ -2452,13 +2457,13 @@ func (s *Store) Send(
 		s.cfg.TestingKnobs.ClockBeforeSend(s.cfg.Clock, ba)
 	}
 
-	if s.Clock().MaxOffset() > 0 {
+	if maxOffset := s.Clock().MaxOffset(); maxOffset > 0 && maxOffset != timeutil.ClocklessMaxOffset {
 		// Once a command is submitted to raft, all replicas' logical
 		// clocks will be ratcheted forward to match. If the command
 		// appears to come from a node with a bad clock, reject it now
 		// before we reach that point.
 		offset := time.Duration(ba.Timestamp.WallTime - s.Clock().PhysicalNow())
-		if offset > s.Clock().MaxOffset() && !s.cfg.TestingKnobs.DisableMaxOffsetCheck {
+		if offset > maxOffset && !s.cfg.TestingKnobs.DisableMaxOffsetCheck {
 			return nil, roachpb.NewErrorf("rejecting command with timestamp in the future: %d (%s ahead)",
 				ba.Timestamp.WallTime, offset)
 		}

--- a/pkg/util/timeutil/time.go
+++ b/pkg/util/timeutil/time.go
@@ -17,10 +17,16 @@
 package timeutil
 
 import (
+	"math"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 )
+
+// ClocklessMaxOffset is a special-cased value that is used when the cluster
+// runs in "clockless" mode. In that (experimental) mode, we operate without
+// assuming any bound on the clock drift.
+const ClocklessMaxOffset = math.MaxInt64
 
 var nowFunc = now
 


### PR DESCRIPTION
See #14093. Add the `--max-offset=experimental-clockless` mode in which the
cluster sends an empty request through Raft for each read and always restarts
on uncertainty errors.

Not for production use.
Not tested (#15738 will help).