### PR TITLE
sql: automatically retry the first batches of uncommitable SERIALIZABLE txns

### DIFF
--- a/pkg/internal/client/db_test.go
+++ b/pkg/internal/client/db_test.go
@@ -387,6 +387,7 @@ func TestCommonMethods(t *testing.T) {
 		{txnType, "EnsureProto"}:                     {},
 		{txnType, "InternalSetPriority"}:             {},
 		{txnType, "IsFinalized"}:                     {},
+		{txnType, "IsSerializableRestart"}:           {},
 		{txnType, "NewBatch"}:                        {},
 		{txnType, "Exec"}:                            {},
 		{txnType, "ResetDeadline"}:                   {},

--- a/pkg/sql/parallel_stmts.go
+++ b/pkg/sql/parallel_stmts.go
@@ -122,6 +122,15 @@ func (pq *ParallelizeQueue) Add(ctx context.Context, plan planNode, exec func(pl
 	}()
 }
 
+// Empty returns true if there's currently no statements being executed or
+// queued.
+func (pq *ParallelizeQueue) Empty() bool {
+	pq.mu.Lock()
+	empty := len(pq.plans) == 0
+	pq.mu.Unlock()
+	return empty
+}
+
 // insertInQueue inserts the planNode in the queue. It returns a list of the "done"
 // channels of prerequisite blocking the new plan from executing. It also returns a
 // function to call when the new plan has finished executing. This function must be

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -1065,6 +1065,25 @@ func (ts *txnState) setPriority(userPriority roachpb.UserPriority) error {
 	return nil
 }
 
+// isSerializableRestart returns true if the KV transaction is serializable and
+// its timestamp has been pushed. Used to detect whether the SQL txn will be
+// allowed to commit.
+//
+// Note that this method allows for false negatives: sometimes the client only
+// figures out that it's been pushed when it sends an EndTransaction - i.e. it's
+// possible for the txn to have been pushed asynchoronously by some other
+// operation (usually, but not exclusively, by a high-priority txn with
+// conflicting writes).
+func (ts *txnState) isSerializableRestart() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	txn := ts.mu.txn
+	if txn == nil {
+		return false
+	}
+	return txn.IsSerializableRestart()
+}
+
 type schemaChangerCollection struct {
 	// A schemaChangerCollection accumulates schemaChangers from potentially
 	// multiple user requests, part of the same SQL transaction. We need to


### PR DESCRIPTION
Before this patch, a write-read conflict (a txn attempting to write
"under" a previous read) would be handled by pushing the commit
timestamp of the writer, but otherwise letting it continue. Even though
it will not be allowed to commit, the writer is allowed to continue
laying down intents in the hope that they'll keep other conflicting txns
away.
Since this push is only detected at COMMIT time, that's too late to do
automatic retries. Therefore, the desire to let the txn go forward and
lay down intents is at odds with the desire to sometimes retry
automatically.
This commit puts a finger on this tradeof scale and makes it so that we
detect pushes after statements executed in the FirstBatch state (so,
while we can still retry automatically). When a push is detected, the
txn is (auto-)retried. Note that the write will still have laid down at
least one intent on the key that caused the push.

This change hopes to make it possible for some transactions to
all-but-never see retryable errors (e.g. Jepsen's BEGIN; CREATE TABLE;
COMMIT).

Touches #16450

cc @tschottdorf @knz 