### PR TITLE
build: update snappy to 1.1.5 and use its new CMake build system

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,10 +11,8 @@
   - Git 1.8+
   - Bash (4+ is preferred)
   - GNU Make (3.81+ is known to work)
-  - CMake 2.8.12+
+  - CMake 3.1+
   - Autoconf 2.68+
-  - Automake (1.15 is known to work)
-  - Libtool (2.4.6 is known to work)
   - Optional: NodeJS 6.x and Yarn 0.22.0+. Required when compiling protocol
     buffers.
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial-20170214
+FROM ubuntu:xenial-20170619
 
 MAINTAINER Tamir Duberstein <tamird@gmail.com>
 
@@ -17,8 +17,7 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key ad
  && curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
  && echo 'deb https://dl.yarnpkg.com/debian/ stable main' | tee /etc/apt/sources.list.d/yarn.list
 
-# autoconf - crosstool-ng/bootstrap / c-deps: jemalloc/snappy
-# automake - c-deps: snappy
+# autoconf - crosstool-ng/bootstrap / c-deps: jemalloc
 # bison - crosstool-ng/configure
 # bzip2 - crosstool-ng/configure
 # clang - msan: -fsanitize
@@ -33,7 +32,6 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key ad
 # help2man - crosstool-ng/configure
 # iptables - acceptance tests' partition nemesis
 # libncurses-dev - crosstool-ng/configure
-# libtool - c-deps: snappy
 # make - crosstool-ng boostrap / CRDB build system
 # nodejs - ui: all
 # openssh-client - terraform / jepsen
@@ -45,7 +43,6 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key ad
 # yarn - ui: all
 RUN apt-get update && apt-get install -y --no-install-recommends \
     autoconf \
-    automake \
     bison \
     bzip2 \
     clang \
@@ -60,7 +57,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     help2man \
     iptables \
     libncurses-dev \
-    libtool \
     make \
     nodejs \
     openssh-client \

--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -7,7 +7,7 @@ set -euxo pipefail
 
 sudo apt-get update
 sudo apt-get dist-upgrade -y
-sudo apt-get install -y --no-install-recommends docker.io git autoconf automake cmake libtool
+sudo apt-get install -y --no-install-recommends docker.io git autoconf cmake
 
 sudo adduser "${USER}" docker
 

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20170705-161720
+version=20170706-162700
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")"

--- a/build/common.mk
+++ b/build/common.mk
@@ -351,7 +351,7 @@ $(CGO_FLAGS_FILES): $(REPO_ROOT)/build/common.mk
 # past, when the tarballs were packaged), and so the build artifacts always look
 # up-to-date.
 
-$(JEMALLOC_SRC_DIR)/configure:
+$(JEMALLOC_SRC_DIR)/configure: $(JEMALLOC_SRC_DIR)/configure.ac
 	cd $(JEMALLOC_SRC_DIR) && autoconf
 
 $(JEMALLOC_DIR)/Makefile: $(C_DEPS_DIR)/jemalloc-rebuild $(JEMALLOC_SRC_DIR)/configure

--- a/build/common.mk
+++ b/build/common.mk
@@ -430,7 +430,7 @@ librocksdb: $(ROCKSDB_DIR)/Makefile $(BOOTSTRAP_TARGET)
 
 .PHONY: clean-c-deps
 clean-c-deps:
-	rm -rf $(JEMALLOC_DIR) && cd $(JEMALLOC_SRC_DIR) && git clean -dxf
-	rm -rf $(PROTOBUF_DIR) && cd $(PROTOBUF_SRC_DIR) && git clean -dxf
-	rm -rf $(ROCKSDB_DIR) && cd $(ROCKSDB_SRC_DIR) && git clean -dxf
-	rm -rf $(SNAPPY_DIR) && cd $(SNAPPY_SRC_DIR) && git clean -dxf
+	rm -rf $(JEMALLOC_DIR) && git -C $(JEMALLOC_SRC_DIR) clean -dxf
+	rm -rf $(PROTOBUF_DIR) && git -C $(PROTOBUF_SRC_DIR) clean -dxf
+	rm -rf $(ROCKSDB_DIR)  && git -C $(ROCKSDB_SRC_DIR)  clean -dxf
+	rm -rf $(SNAPPY_DIR)   && git -C $(SNAPPY_SRC_DIR)   clean -dxf

--- a/build/common.mk
+++ b/build/common.mk
@@ -327,7 +327,7 @@ $(CGO_FLAGS_FILES): $(REPO_ROOT)/build/common.mk
 	@echo 'package $(notdir $(@D))' >> $@
 	@echo >> $@
 	@echo '// #cgo CPPFLAGS: -I$(JEMALLOC_DIR)/include' >> $@
-	@echo '// #cgo LDFLAGS: $(addprefix -L,$(PROTOBUF_DIR) $(JEMALLOC_DIR)/lib $(SNAPPY_DIR)/.libs $(ROCKSDB_DIR))' >> $@
+	@echo '// #cgo LDFLAGS: $(addprefix -L,$(PROTOBUF_DIR) $(JEMALLOC_DIR)/lib $(SNAPPY_DIR) $(ROCKSDB_DIR))' >> $@
 	@echo 'import "C"' >> $@
 
 # BUILD ARTIFACT CACHING
@@ -387,21 +387,18 @@ $(ROCKSDB_DIR)/Makefile: $(C_DEPS_DIR)/rocksdb-rebuild | libsnappy $(if $(USE_ST
 	@# $(C_DEPS_DIR)/rocksdb-rebuild. See above for rationale.
 	cd $(ROCKSDB_DIR) && cmake $(CMAKE_FLAGS) $(ROCKSDB_SRC_DIR) \
 	  $(if $(findstring release,$(TYPE)),,-DWITH_$(if $(findstring mingw,$(TARGET_TRIPLE)),AVX2,SSE42)=OFF) \
-	  -DSNAPPY_LIBRARIES=$(SNAPPY_DIR)/.libs/libsnappy.a -DSNAPPY_INCLUDE_DIR="$(SNAPPY_SRC_DIR);$(SNAPPY_DIR)" -DWITH_SNAPPY=ON \
+	  -DSNAPPY_LIBRARIES=$(SNAPPY_DIR)/libsnappy.a -DSNAPPY_INCLUDE_DIR="$(SNAPPY_SRC_DIR);$(SNAPPY_DIR)" -DWITH_SNAPPY=ON \
 	  $(if $(USE_STDMALLOC),,-DJEMALLOC_LIBRARIES=$(JEMALLOC_DIR)/lib/libjemalloc.a -DJEMALLOC_INCLUDE_DIR=$(JEMALLOC_DIR)/include -DWITH_JEMALLOC=ON) \
 	  $(if $(ENABLE_ROCKSDB_ASSERTIONS),,-DCMAKE_CXX_FLAGS=-DNDEBUG)
 	@# TODO(benesch): Tweak how we pass -DNDEBUG above when we upgrade to a
 	@# RocksDB release that includes https://github.com/facebook/rocksdb/pull/2300.
 
-$(SNAPPY_SRC_DIR)/configure:
-	cd $(SNAPPY_SRC_DIR) && autoreconf -i
-
-$(SNAPPY_DIR)/Makefile: $(C_DEPS_DIR)/snappy-rebuild $(SNAPPY_SRC_DIR)/configure
+$(SNAPPY_DIR)/Makefile: $(C_DEPS_DIR)/snappy-rebuild
 	rm -rf $(SNAPPY_DIR)
 	mkdir -p $(SNAPPY_DIR)
-	@# NOTE: If you change the configure flags below, bump the version in
+	@# NOTE: If you change the CMake flags below, bump the version in
 	@# $(C_DEPS_DIR)/snappy-rebuild. See above for rationale.
-	cd $(SNAPPY_DIR) && $(SNAPPY_SRC_DIR)/configure $(CONFIGURE_FLAGS) --disable-shared --disable-gtest
+	cd $(SNAPPY_DIR) && cmake $(CMAKE_FLAGS) $(SNAPPY_SRC_DIR)
 
 # We mark C and C++ dependencies as .PHONY (or .ALWAYS_REBUILD) to avoid
 # having to name the artifact (for .PHONY), which can vary by platform, and so

--- a/build/teamcity-verify-archive.sh
+++ b/build/teamcity-verify-archive.sh
@@ -10,4 +10,4 @@ docker run \
   --rm \
   --volume="$(cd "$(dirname "$0")" && pwd):/work" \
   --workdir="/work" \
-  golang:1.8.1 ./verify-archive.sh
+  golang:stretch ./verify-archive.sh

--- a/build/verify-archive.sh
+++ b/build/verify-archive.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 apt-get update
-apt-get install -y autoconf automake cmake libtool
+apt-get install -y autoconf cmake
 
 workdir=$(mktemp -d)
 tar xzf cockroach.src.tgz -C "$workdir"

--- a/c-deps/rocksdb-rebuild
+++ b/c-deps/rocksdb-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing rocksdb CMake flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-3
+4

--- a/c-deps/snappy-rebuild
+++ b/c-deps/snappy-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing snappy configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-3
+4


### PR DESCRIPTION
This updates to upstream's 1.1.5 plus one manual change: https://github.com/cockroachdb/snappy/commit/41e12f946060fa2d8fd105a85be81393ea4c6627.