### PR TITLE
storage/engine: log RocksDB compaction stats

### DIFF
--- a/pkg/storage/engine/db.h
+++ b/pkg/storage/engine/db.h
@@ -237,6 +237,7 @@ typedef struct {
 } DBStatsResult;
 
 DBStatus DBGetStats(DBEngine* db, DBStatsResult* stats);
+DBString DBGetCompactionStats(DBEngine* db);
 
 typedef struct {
   int level;

--- a/pkg/storage/engine/eventlistener.cc
+++ b/pkg/storage/engine/eventlistener.cc
@@ -29,10 +29,11 @@ void DBEventListener::OnFlushCompleted(rocksdb::DB* db, const rocksdb::FlushJobI
 
   if (kDebug) {
     const rocksdb::TableProperties &p = flush_job_info.table_properties;
-    fprintf(stderr, "OnFlushCompleted:\n  %40s:  index=%.1f  filter=%.1f\n",
-            flush_job_info.file_path.c_str(),
-            p.index_size / float(p.num_entries),
-            p.filter_size / float(p.num_entries));
+    fprintf(stderr, "OnFlushCompleted:\n  %40s:  entries=%d  data=%.1fMB  index=%.1fMB  filter=%.1fMB\n",
+            flush_job_info.file_path.c_str(), (int)p.num_entries,
+            float(p.data_size) / (1024.0 * 1024.0),
+            float(p.index_size) / (1024.0 * 1024.0),
+            float(p.filter_size) / (1024.0 * 1024.0));
   }
 }
 
@@ -40,13 +41,15 @@ void DBEventListener::OnCompactionCompleted(rocksdb::DB* db, const rocksdb::Comp
   ++compactions_;
 
   if (kDebug) {
-    fprintf(stderr, "OnCompactionCompleted:\n");
+    fprintf(stderr, "OnCompactionCompleted: input=%d output=%d\n",
+            ci.base_input_level, ci.output_level);
     for (auto iter = ci.table_properties.begin(); iter != ci.table_properties.end(); ++iter) {
       const rocksdb::TableProperties &p = *iter->second;
-      fprintf(stderr, "  %40s: index=%.1f  filter=%.1f\n",
-              iter->first.c_str(),
-              p.index_size / float(p.num_entries),
-              p.filter_size / float(p.num_entries));
+      fprintf(stderr, "  %40s: entries=%d  data=%.1fMB  index=%.1fMB  filter=%.1fMB\n",
+              iter->first.c_str(), (int)p.num_entries,
+              float(p.data_size) / (1024.0 * 1024.0),
+              float(p.index_size) / (1024.0 * 1024.0),
+              float(p.filter_size) / (1024.0 * 1024.0));
     }
   }
 }

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -829,6 +829,12 @@ func (r *RocksDB) GetStats() (*Stats, error) {
 	}, nil
 }
 
+// GetCompactionStats returns the internal RocksDB compaction stats. See
+// https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide#rocksdb-statistics.
+func (r *RocksDB) GetCompactionStats() string {
+	return cStringToGoString(C.DBGetCompactionStats(r.rdb))
+}
+
 type rocksDBSnapshot struct {
 	parent *RocksDB
 	handle *C.DBEngine

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -4142,8 +4142,9 @@ func (s *Store) ComputeMetrics(ctx context.Context, tick int) error {
 		readAmp := sstables.ReadAmplification()
 		s.metrics.RdbReadAmplification.Update(int64(readAmp))
 		// Log this metric infrequently.
-		if tick%100 == 0 {
+		if tick%60 == 0 /* every 10m */ {
 			log.Infof(ctx, "sstables (read amplification = %d):\n%s", readAmp, sstables)
+			log.Info(ctx, rocksdb.GetCompactionStats())
 		}
 	}
 	return nil


### PR DESCRIPTION
Periodically log RocksDB compaction stats which include details such as
write amplification per level.